### PR TITLE
cli/sql: avoid an error upon connect to a different cluster

### DIFF
--- a/pkg/cli/clisqlclient/conn.go
+++ b/pkg/cli/clisqlclient/conn.go
@@ -430,13 +430,13 @@ func (c *sqlConn) checkServerMetadata(ctx context.Context) error {
 	// Report the cluster ID only if it it could be fetched
 	// successfully, and it has changed since the last connection.
 	if old := c.clusterID; newClusterID != c.clusterID {
-		c.clusterID = newClusterID
+		label := ""
 		if old != "" {
-			return errors.Errorf("the cluster ID has changed!\nPrevious ID: %s\nNew ID: %s",
-				old, newClusterID)
+			label = "New "
+			fmt.Fprintf(c.errw, "\nwarning: the cluster ID has changed!\n# Previous ID: %s\n", old)
 		}
 		c.clusterID = newClusterID
-		fmt.Fprintln(c.infow, "# Cluster ID:", c.clusterID)
+		fmt.Fprintf(c.infow, "# %sCluster ID: %v\n", label, c.clusterID)
 		if c.clusterOrganization != "" {
 			fmt.Fprintln(c.infow, "# Organization:", c.clusterOrganization)
 		}

--- a/pkg/cli/clisqlshell/sql.go
+++ b/pkg/cli/clisqlshell/sql.go
@@ -1679,7 +1679,7 @@ func (c *cliState) switchToURL(newURL *pgurl.URL) error {
 	}
 	c.conn.SetURL(newURL.ToPQ().String())
 	c.conn.SetMissingPassword(!usePw || !pwSet)
-	return nil
+	return c.conn.EnsureConn(context.Background())
 }
 
 const maxRecursionLevels = 10

--- a/pkg/cli/interactive_tests/test_connect_cmd.tcl
+++ b/pkg/cli/interactive_tests/test_connect_cmd.tcl
@@ -224,3 +224,26 @@ end_test
 
 stop_server $argv
 
+system "rm -rf logs/db"
+start_server $argv
+
+start_test "Check that the connect cmd does not generate an error when the cluster ID changes"
+send "\\c - root\r"
+eexpect "warning: the cluster ID has changed"
+eexpect "Previous ID"
+eexpect "New Cluster ID"
+eexpect "system>"
+
+send "\\q\r"
+expect {
+    "ERROR" {
+	report "reconnect generated an unexpected error"
+	exit 1
+    }
+    eof { }
+}
+
+end_test
+
+
+stop_server $argv

--- a/pkg/cli/interactive_tests/test_sql_version_reporting.tcl
+++ b/pkg/cli/interactive_tests/test_sql_version_reporting.tcl
@@ -55,10 +55,9 @@ system "mv logs/db logs/db-bak"
 start_server $argv
 send "select 1;\r"
 eexpect "opening new connection"
-eexpect "error"
 eexpect "the cluster ID has changed!"
 eexpect "Previous ID:"
-eexpect "New ID:"
+eexpect "New Cluster ID:"
 eexpect root@
 end_test
 


### PR DESCRIPTION
Fixes #95133.
This affects `cockroach demo` when switching between tenants.

Release note (bug fix): In the SQL shell (`cockroach sql` / `cockroach demo`), when using `\c`/`\connect` to connect to a different server, CockroachDB would previously report an error if the new server had a different cluster ID. This has been fixed: this situation is merely a warning.