### PR TITLE
release-22.2: kv: campaign on rejected lease request when leader not live in node liveness

### DIFF
--- a/pkg/kv/kvserver/replica_proposal_buf.go
+++ b/pkg/kv/kvserver/replica_proposal_buf.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/closedts/tracker"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverpb"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/liveness"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/raftutil"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
@@ -117,15 +118,14 @@ type propBuf struct {
 }
 
 type rangeLeaderInfo struct {
+	// iAmTheLeader is set if the local replica is the leader.
+	iAmTheLeader bool
 	// leaderKnown is set if the local Raft machinery knows who the leader is. If
 	// not set, all other fields are empty.
 	leaderKnown bool
-
 	// leader represents the Raft group's leader. Not set if leaderKnown is not
 	// set.
 	leader roachpb.ReplicaID
-	// iAmTheLeader is set if the local replica is the leader.
-	iAmTheLeader bool
 	// leaderEligibleForLease is set if the leader is known and its type of
 	// replica allows it to acquire a lease.
 	leaderEligibleForLease bool
@@ -144,6 +144,7 @@ type proposer interface {
 	closedTimestampTarget() hlc.Timestamp
 	leaderStatus(ctx context.Context, raftGroup proposerRaft) rangeLeaderInfo
 	ownsValidLease(ctx context.Context, now hlc.ClockTimestamp) bool
+	shouldCampaignOnRedirect(raftGroup proposerRaft) bool
 
 	// The following require the proposer to hold an exclusive lock.
 	withGroupLocked(func(proposerRaft) error) error
@@ -182,7 +183,9 @@ type proposer interface {
 type proposerRaft interface {
 	Step(raftpb.Message) error
 	Status() raft.Status
+	BasicStatus() raft.BasicStatus
 	ProposeConfChange(raftpb.ConfChangeI) error
+	Campaign() error
 }
 
 // Init initializes the proposal buffer and binds it to the provided proposer.
@@ -614,6 +617,12 @@ func (b *propBuf) maybeRejectUnsafeProposalLocked(
 			log.VEventf(ctx, 2, "not proposing lease acquisition because we're not the leader; replica %d is",
 				li.leader)
 			b.p.rejectProposalWithRedirectLocked(ctx, p, li.leader)
+			if b.p.shouldCampaignOnRedirect(raftGroup) {
+				log.VEventf(ctx, 2, "campaigning because Raft leader not live in node liveness map")
+				if err := raftGroup.Campaign(); err != nil {
+					log.VEventf(ctx, 1, "failed to campaign: %s", err)
+				}
+			}
 			return true
 		}
 		// If the leader is not known, or if it is known but it's ineligible
@@ -715,7 +724,7 @@ func (b *propBuf) leaderStatusRLocked(ctx context.Context, raftGroup proposerRaf
 		!leaderInfo.iAmTheLeader {
 		log.Fatalf(ctx,
 			"inconsistent Raft state: state %s while the current replica is also the lead: %d",
-			raftGroup.Status().RaftState, leaderInfo.leader)
+			raftGroup.BasicStatus().RaftState, leaderInfo.leader)
 	}
 	return leaderInfo
 }
@@ -1186,7 +1195,7 @@ func (rp *replicaProposer) leaderStatus(
 ) rangeLeaderInfo {
 	r := (*Replica)(rp)
 
-	status := raftGroup.Status()
+	status := raftGroup.BasicStatus()
 	iAmTheLeader := status.RaftState == raft.StateLeader
 	leader := status.Lead
 	leaderKnown := leader != raft.None
@@ -1217,15 +1226,27 @@ func (rp *replicaProposer) leaderStatus(
 		}
 	}
 	return rangeLeaderInfo{
+		iAmTheLeader:           iAmTheLeader,
 		leaderKnown:            leaderKnown,
 		leader:                 roachpb.ReplicaID(leader),
-		iAmTheLeader:           iAmTheLeader,
 		leaderEligibleForLease: leaderEligibleForLease,
 	}
 }
 
 func (rp *replicaProposer) ownsValidLease(ctx context.Context, now hlc.ClockTimestamp) bool {
 	return (*Replica)(rp).ownsValidLeaseRLocked(ctx, now)
+}
+
+func (rp *replicaProposer) shouldCampaignOnRedirect(raftGroup proposerRaft) bool {
+	r := (*Replica)(rp)
+	livenessMap, _ := r.store.livenessMap.Load().(liveness.IsLiveMap)
+	return shouldCampaignOnLeaseRequestRedirect(
+		raftGroup.BasicStatus(),
+		livenessMap,
+		r.descRLocked(),
+		r.requiresExpiringLeaseRLocked(),
+		r.store.Clock().Now(),
+	)
 }
 
 // rejectProposalWithRedirectLocked is part of the proposer interface.

--- a/pkg/kv/kvserver/replica_raft.go
+++ b/pkg/kv/kvserver/replica_raft.go
@@ -1878,7 +1878,7 @@ func shouldCampaignOnWake(
 	if raftStatus.RaftState != raft.StateFollower {
 		return false
 	}
-	// If we dont know who the leader is, then campaign.
+	// If we don't know who the leader is, then campaign.
 	if raftStatus.Lead == raft.None {
 		return true
 	}
@@ -1924,6 +1924,75 @@ func (r *Replica) maybeCampaignOnWakeLocked(ctx context.Context) {
 	if shouldCampaignOnWake(leaseStatus, r.store.StoreID(), raftStatus, livenessMap, r.descRLocked(), r.requiresExpiringLeaseRLocked()) {
 		r.campaignLocked(ctx)
 	}
+}
+
+// shouldCampaignOnLeaseRequestRedirect returns whether a replica that is
+// redirecting a lease request to its range's Raft leader should simultaneously
+// campaign to acquire Raft leadership itself. A follower replica may want to
+// campaign in such a case if it determines that the Raft leader is non-live
+// according to node liveness despite being able to retain Raft leadership
+// within the range. In such cases, the Raft leader will be unable to acquire an
+// epoch-based lease until it heartbeats its liveness record, so it would be
+// beneficial for one of the followers to step forward as leader/leaseholder.
+//
+// In these cases, campaigning for Raft leadership is safer than blindly
+// allowing the lease request to be proposed (through a redirected proposal).
+// This is because the follower may be arbitrarily far behind on its Raft log
+// and acquiring the lease in such cases could cause unavailability. By instead
+// calling a Raft pre-vote election, the follower can determine whether it is
+// behind on its log without risking disruption. If not, it will eventually
+// become leader and can proceed with a future attempt to acquire the lease.
+func shouldCampaignOnLeaseRequestRedirect(
+	raftStatus raft.BasicStatus,
+	livenessMap liveness.IsLiveMap,
+	desc *roachpb.RangeDescriptor,
+	requiresExpiringLease bool,
+	now hlc.Timestamp,
+) bool {
+	// If we're already campaigning don't start a new term.
+	if raftStatus.RaftState != raft.StateFollower {
+		return false
+	}
+	// If we don't know who the leader is, then campaign.
+	// NOTE: at the time of writing, we only reject lease requests and call this
+	// function when the leader is known, so this check is not needed. However, if
+	// that ever changes, and we do decide to reject a lease request when the
+	// leader is not known, we should immediately campaign.
+	if raftStatus.Lead == raft.None {
+		return true
+	}
+	// Avoid a circular dependency on liveness and skip the is leader alive check
+	// for ranges that always use expiration based leases. These ranges don't need
+	// to campaign based on liveness state because there can never be a case where
+	// a node can retain Raft leadership but still be unable to acquire the lease.
+	// This is possible on ranges that use epoch-based leases because the Raft
+	// leader may be partitioned from the liveness range.
+	// See TestRequestsOnFollowerWithNonLiveLeaseholder for an example of a test
+	// that demonstrates this case.
+	if requiresExpiringLease {
+		return false
+	}
+	// Determine if we think the leader is alive, if we don't have the leader in
+	// the descriptor we assume it is, since it could be an indication that this
+	// replica is behind.
+	replDesc, ok := desc.GetReplicaDescriptorByID(roachpb.ReplicaID(raftStatus.Lead))
+	if !ok {
+		return false
+	}
+	// If we don't know about the leader in our liveness map, then we err on the
+	// side of caution and don't campaign.
+	livenessEntry, ok := livenessMap[replDesc.NodeID]
+	if !ok {
+		return false
+	}
+	// Otherwise, we check if the leader is live according to node liveness and
+	// campaign if it is not.
+	// NOTE: we intentionally do not look at the IsLiveMapEntry.IsLive field,
+	// which accounts for whether the leader is reachable from this node (see
+	// Store.updateLivenessMap). We only care whether the leader is currently live
+	// according to node liveness because this determines whether it will be able
+	// to acquire an epoch-based lease.
+	return !livenessEntry.Liveness.IsLive(now.GoTime())
 }
 
 func (r *Replica) campaignLocked(ctx context.Context) {


### PR DESCRIPTION
Backport 2/2 commits from #87244.

/cc @cockroachdb/release

---

Fixes #84655.
Related to #49220.

This commit extends the logic introduced in 8aa1c14 to simultaneously campaign for Raft leadership when rejecting a lease request on a Raft follower that observes that the current Raft leader is not live according to node liveness. These kinds of cases are often associated with asymmetric network partitions. 

In such cases, the Raft leader will be unable to acquire an epoch-based lease until it heartbeats its liveness record. As a result, the range can only regain availability if a different replica acquires the lease. However, the protection added in 8aa1c14 prevents followers from acquiring leases to protect against a different form of unavailability.

After this commit, the followers will attempt to acquire Raft leadership when detecting such cases by campaigning. This allows these ranges to recover availability once Raft leadership moves off the partitioned Raft leader to one of the followers that can reach node liveness and can subsequently acquire the lease.

Campaigning for Raft leadership is safer than blindly allowing the lease request to be proposed (through a redirected proposal). This is because the follower may be arbitrarily far behind on its Raft log and acquiring the lease in such cases could cause unavailability (the kind we saw in #37906). By instead calling a Raft pre-vote election, the follower can determine whether it is behind on its log without risking disruption. If so, we don't want it to acquire the lease — one of the other followers that is caught up on its log can. If not, it will eventually become leader and can proceed with a future attempt to acquire the lease.

The commit adds a test that reproduces the failure mode described in #84655. It creates an asymmetric network partition scenario that looks like:
```
        [0]       raft leader / leaseholder
         ^
        / \
       /   \
      v     v
    [1]<--->[2]   raft followers
      ^     ^
       \   /
        \ /
         v
        [3]       liveness range
```
It then waits for the raft leader's lease to expire and demonstrates that one of the raft followers will now call a Raft election, which allows it to safely grab Raft leadership, acquire the lease, and recover availability. Without the change, the test failed.

----

Release justification: None. Too risky for the stability period. Potential backport candidate after sufficient baking on master.

Release note (bug fix): A bug causing ranges to remain without a leaseholder in cases of asymmetric network partitions has been resolved.
