### PR TITLE
catalog: add and adopt TypeDescriptor subtypes

### DIFF
--- a/pkg/ccl/backupccl/BUILD.bazel
+++ b/pkg/ccl/backupccl/BUILD.bazel
@@ -127,6 +127,7 @@ go_library(
         "//pkg/util/ctxgroup",
         "//pkg/util/hlc",
         "//pkg/util/interval",
+        "//pkg/util/iterutil",
         "//pkg/util/json",
         "//pkg/util/log",
         "//pkg/util/log/eventpb",

--- a/pkg/ccl/backupccl/show.go
+++ b/pkg/ccl/backupccl/show.go
@@ -33,6 +33,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/server/telemetry"
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/colinfo"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descs"
@@ -1064,30 +1065,27 @@ func showRegions(typeDesc catalog.TypeDescriptor, dbname string) (string, error)
 	if typeDesc == nil {
 		return "", fmt.Errorf("type descriptor for %s is nil", dbname)
 	}
-
-	primaryRegionName, err := typeDesc.PrimaryRegionName()
-	if err != nil {
-		return "", err
+	r := typeDesc.AsRegionEnumTypeDescriptor()
+	if r == nil {
+		return "", fmt.Errorf("type descriptor for %s is of kind %s", dbname, typeDesc.GetKind())
 	}
+
 	regionsStringBuilder.WriteString("ALTER DATABASE ")
 	regionsStringBuilder.WriteString(dbname)
 	regionsStringBuilder.WriteString(" SET PRIMARY REGION ")
-	regionsStringBuilder.WriteString("\"" + primaryRegionName.String() + "\"")
+	regionsStringBuilder.WriteString("\"" + r.PrimaryRegion().String() + "\"")
 	regionsStringBuilder.WriteString(";")
 
-	regionNames, err := typeDesc.RegionNames()
-	if err != nil {
-		return "", err
-	}
-	for _, regionName := range regionNames {
-		if regionName != primaryRegionName {
+	_ = r.ForEachPublicRegion(func(regionName catpb.RegionName) error {
+		if regionName != r.PrimaryRegion() {
 			regionsStringBuilder.WriteString(" ALTER DATABASE ")
 			regionsStringBuilder.WriteString(dbname)
 			regionsStringBuilder.WriteString(" ADD REGION ")
 			regionsStringBuilder.WriteString("\"" + regionName.String() + "\"")
 			regionsStringBuilder.WriteString(";")
 		}
-	}
+		return nil
+	})
 	return regionsStringBuilder.String(), nil
 }
 

--- a/pkg/ccl/multiregionccl/region_util_test.go
+++ b/pkg/ccl/multiregionccl/region_util_test.go
@@ -129,8 +129,10 @@ func getEnumMembers(
 		require.NoError(t, err)
 		regionEnumID, err := dbDesc.MultiRegionEnumID()
 		require.NoError(t, err)
-		regionEnumDesc, err := descsCol.ByIDWithLeased(txn.KV()).WithoutNonPublic().Get().Type(ctx, regionEnumID)
+		typeDesc, err := descsCol.ByIDWithLeased(txn.KV()).WithoutNonPublic().Get().Type(ctx, regionEnumID)
 		require.NoError(t, err)
+		regionEnumDesc := typeDesc.AsRegionEnumTypeDescriptor()
+		require.NotNil(t, regionEnumDesc)
 		for ord := 0; ord < regionEnumDesc.NumEnumMembers(); ord++ {
 			enumMembers[regionEnumDesc.GetMemberLogicalRepresentation(ord)] = regionEnumDesc.GetMemberPhysicalRepresentation(ord)
 		}

--- a/pkg/sql/catalog/descriptor.go
+++ b/pkg/sql/catalog/descriptor.go
@@ -714,8 +714,7 @@ type MutableTableDescriptor interface {
 	MutableDescriptor
 }
 
-// TypeDescriptor will eventually be called typedesc.Descriptor.
-// It is implemented by (Imm|M)utableTypeDescriptor.
+// TypeDescriptor is an interface around the type descriptor types.
 type TypeDescriptor interface {
 	Descriptor
 	// TypeDesc returns the backing descriptor for this type, if one exists.
@@ -730,10 +729,6 @@ type TypeDescriptor interface {
 	// As of now "compatibility" entails that disk encoded data of "desc" can be
 	// interpreted and used by "other".
 	IsCompatibleWith(other TypeDescriptor) error
-	// GetArrayTypeID returns the globally unique ID for the implicitly created
-	// array type for this type. It is only set when the type descriptor points to
-	// a non-array type.
-	GetArrayTypeID() descpb.ID
 	// AsTypesT returns a reference to a types.T corresponding to this type
 	// descriptor. No guarantees are provided as to whether this object is a
 	// singleton or not, or whether it's hydrated or not.
@@ -741,36 +736,54 @@ type TypeDescriptor interface {
 	// GetKind returns the kind of this type.
 	GetKind() descpb.TypeDescriptor_Kind
 
-	// The following fields are only valid for multi-region enum types.
+	// NumReferencingDescriptors returns the number of descriptors referencing this
+	// type, directly or indirectly.
+	NumReferencingDescriptors() int
+	// GetReferencingDescriptorID returns the ID of the referencing descriptor at
+	// ordinal refOrdinal.
+	GetReferencingDescriptorID(refOrdinal int) descpb.ID
+	// GetReferencingDescriptorIDs returns IDs of descriptors referencing this
+	// type.
+	GetReferencingDescriptorIDs() []descpb.ID
 
-	// PrimaryRegionName returns the primary region for a multi-region enum.
-	PrimaryRegionName() (catpb.RegionName, error)
-	// RegionNames returns all `PUBLIC` regions on the multi-region enum. Regions
-	// that are in the process of being added/removed (`READ_ONLY`) are omitted.
-	RegionNames() (catpb.RegionNames, error)
-	// RegionNamesIncludingTransitioning returns all the regions on a multi-region
-	// enum, including `READ ONLY` regions which are in the process of transitioning.
-	RegionNamesIncludingTransitioning() (catpb.RegionNames, error)
-	// RegionNamesForValidation returns all regions on the multi-region
-	// enum to make validation with the public zone configs and partitons
-	// possible.
-	// Since the partitions and zone configs are only updated when a transaction
-	// commits, this must ignore all regions being added (since they will not be
-	// reflected in the zone configuration yet), but it must include all region
-	// being dropped (since they will not be dropped from the zone configuration
-	// until they are fully removed from the type descriptor, again, at the end
-	// of the transaction).
-	RegionNamesForValidation() (catpb.RegionNames, error)
-	// TransitioningRegionNames returns regions which are transitioning to PUBLIC
-	// or are being removed.
-	TransitioningRegionNames() (catpb.RegionNames, error)
-	// SuperRegions returns the list of super regions.
-	SuperRegions() ([]descpb.SuperRegion, error)
-	// ZoneConfigExtensions returns the zone configuration extensions on the
-	// multi-region enum.
-	ZoneConfigExtensions() (descpb.ZoneConfigExtensions, error)
+	// AsEnumTypeDescriptor returns this instance cast to EnumTypeDescriptor
+	// if this type is an enum type, nil otherwise.
+	AsEnumTypeDescriptor() EnumTypeDescriptor
 
-	// The following fields are set if the type is an enum or a multi-region enum.
+	// AsRegionEnumTypeDescriptor returns this instance cast to
+	// RegionEnumTypeDescriptor if this type is a multi-region enum type,
+	// nil otherwise.
+	AsRegionEnumTypeDescriptor() RegionEnumTypeDescriptor
+
+	// AsAliasTypeDescriptor returns this instance cast to
+	// AliasTypeDescriptor if this type is an alias type,
+	// nil otherwise.
+	AsAliasTypeDescriptor() AliasTypeDescriptor
+
+	// AsCompositeTypeDescriptor returns this instance cast to
+	// CompositeTypeDescriptor if this type is a composite type,
+	// nil otherwise.
+	AsCompositeTypeDescriptor() CompositeTypeDescriptor
+
+	// AsTableImplicitRecordTypeDescriptor returns this instance cast to
+	// TableImplicitRecordTypeDescriptor if this type is an implicit table record
+	// type, nil otherwise.
+	AsTableImplicitRecordTypeDescriptor() TableImplicitRecordTypeDescriptor
+}
+
+// NonAliasTypeDescriptor is the TypeDescriptor subtype for concrete user-defined
+// types.
+type NonAliasTypeDescriptor interface {
+	TypeDescriptor
+
+	// GetArrayTypeID returns the globally unique ID for the implicitly created
+	// array type for this type.
+	GetArrayTypeID() descpb.ID
+}
+
+// EnumTypeDescriptor is the TypeDescriptor subtype for enums (incl. regions).
+type EnumTypeDescriptor interface {
+	NonAliasTypeDescriptor
 
 	// NumEnumMembers returns the number of enum members if the type is an
 	// enumeration type, 0 otherwise.
@@ -784,16 +797,69 @@ type TypeDescriptor interface {
 	// IsMemberReadOnly returns true iff the enum member at ordinal
 	// enumMemberOrdinal is read-only.
 	IsMemberReadOnly(enumMemberOrdinal int) bool
+}
 
-	// NumReferencingDescriptors returns the number of descriptors referencing this
-	// type, directly or indirectly.
-	NumReferencingDescriptors() int
-	// GetReferencingDescriptorID returns the ID of the referencing descriptor at
-	// ordinal refOrdinal.
-	GetReferencingDescriptorID(refOrdinal int) descpb.ID
-	// GetReferencingDescriptorIDs returns IDs of descriptors referencing this
-	// type.
-	GetReferencingDescriptorIDs() []descpb.ID
+// RegionEnumTypeDescriptor is the TypeDescriptor subtype for multi-region enums.
+type RegionEnumTypeDescriptor interface {
+	EnumTypeDescriptor
+
+	// PrimaryRegion returns the primary region name.
+	PrimaryRegion() catpb.RegionName
+
+	// ForEachPublicRegion is like ForEachRegion but limited to regions
+	// which are public, i.e. not in the process of being added or removed.
+	ForEachPublicRegion(f func(regionName catpb.RegionName) error) error
+
+	// ForEachRegion applies f on each region name,
+	// Supports iterutil.StopIteration().
+	ForEachRegion(f func(regionName catpb.RegionName, transition descpb.TypeDescriptor_EnumMember_Direction) error) error
+
+	// ForEachSuperRegion applies f on each super-region name.
+	// Supports iterutil.StopIteration().
+	ForEachSuperRegion(f func(superRegionName string) error) error
+
+	// ForEachRegionInSuperRegion applies f on each region in the super region.
+	// Supports iterutil.StopIteration().
+	ForEachRegionInSuperRegion(
+		superRegion string,
+		f func(region catpb.RegionName) error,
+	) error
+}
+
+// AliasTypeDescriptor is the TypeDescriptor subtype for alias types.
+// This is used for array subtypes.
+type AliasTypeDescriptor interface {
+	TypeDescriptor
+
+	// Aliased returns the types.T which is being aliased.
+	Aliased() *types.T
+}
+
+// CompositeTypeDescriptor is the TypeDescriptor subtype for composite types,
+// which are union types.
+type CompositeTypeDescriptor interface {
+	NonAliasTypeDescriptor
+
+	// NumElements returns the number of elements forming the composite type.
+	NumElements() int
+
+	// GetElementLabel returns the label of the composite type element at the
+	// given ordinal.
+	GetElementLabel(ordinal int) string
+
+	// GetElementType returns the type of the composite type element at the
+	// given ordinal.
+	GetElementType(ordinal int) *types.T
+}
+
+// TableImplicitRecordTypeDescriptor is the TypeDescriptor subtype for the
+// record type implicitly defined by a table.
+type TableImplicitRecordTypeDescriptor interface {
+	NonAliasTypeDescriptor
+
+	// UnderlyingTableDescriptor returns the table descriptor underlying this
+	// implicit type.
+	UnderlyingTableDescriptor() TableDescriptor
 }
 
 // TypeDescriptorResolver is an interface used during hydration of type

--- a/pkg/sql/catalog/resolver/resolver.go
+++ b/pkg/sql/catalog/resolver/resolver.go
@@ -163,7 +163,7 @@ func ResolveMutableType(
 	switch t := desc.(type) {
 	case *typedesc.Mutable:
 		return prefix, t, nil
-	case *typedesc.TableImplicitRecordType:
+	case catalog.TableImplicitRecordTypeDescriptor:
 		return catalog.ResolvedObjectPrefix{}, nil, pgerror.Newf(pgcode.DependentObjectsStillExist,
 			"cannot modify table record type %q", desc.GetName())
 	default:

--- a/pkg/sql/catalog/typedesc/table_implicit_record_type.go
+++ b/pkg/sql/catalog/typedesc/table_implicit_record_type.go
@@ -21,10 +21,10 @@ import (
 	"github.com/cockroachdb/errors"
 )
 
-// TableImplicitRecordType is an implementation of catalog.TypeDescriptor that
+// tableImplicitRecordType is an implementation of catalog.TypeDescriptor that
 // represents a record type for a particular table: meaning, the composite type
 // that contains, in order, all of the visible columns for the table.
-type TableImplicitRecordType struct {
+type tableImplicitRecordType struct {
 	// desc is the TableDescriptor that this implicit record type is created from.
 	desc catalog.TableDescriptor
 	// privs holds the privileges for this implicit record type. It's calculated
@@ -34,7 +34,7 @@ type TableImplicitRecordType struct {
 	privs *catpb.PrivilegeDescriptor
 }
 
-var _ catalog.TypeDescriptor = (*TableImplicitRecordType)(nil)
+var _ catalog.TableImplicitRecordTypeDescriptor = (*tableImplicitRecordType)(nil)
 
 // CreateImplicitRecordTypeFromTableDesc creates a TypeDescriptor that represents
 // the implicit record type for a table, which has 1 field for every visible
@@ -59,7 +59,7 @@ func CreateImplicitRecordTypeFromTableDesc(
 		}
 	}
 
-	return &TableImplicitRecordType{
+	return &tableImplicitRecordType{
 		desc: descriptor,
 		privs: &catpb.PrivilegeDescriptor{
 			Users:      newPrivs,
@@ -69,78 +69,78 @@ func CreateImplicitRecordTypeFromTableDesc(
 	}, nil
 }
 
-// GetName implements the Namespace interface.
-func (v TableImplicitRecordType) GetName() string { return v.desc.GetName() }
+// GetName implements the catalog.NameKey interface.
+func (v *tableImplicitRecordType) GetName() string { return v.desc.GetName() }
 
-// GetParentID implements the Namespace interface.
-func (v TableImplicitRecordType) GetParentID() descpb.ID { return v.desc.GetParentID() }
+// GetParentID implements the catalog.NameKey interface.
+func (v *tableImplicitRecordType) GetParentID() descpb.ID { return v.desc.GetParentID() }
 
-// GetParentSchemaID implements the Namespace interface.
-func (v TableImplicitRecordType) GetParentSchemaID() descpb.ID { return v.desc.GetParentSchemaID() }
+// GetParentSchemaID implements the catalog.NameKey interface.
+func (v *tableImplicitRecordType) GetParentSchemaID() descpb.ID { return v.desc.GetParentSchemaID() }
 
 // GetID implements the NameEntry interface.
-func (v TableImplicitRecordType) GetID() descpb.ID { return v.desc.GetID() }
+func (v *tableImplicitRecordType) GetID() descpb.ID { return v.desc.GetID() }
 
-// IsUncommittedVersion implements the Descriptor interface.
-func (v TableImplicitRecordType) IsUncommittedVersion() bool { return v.desc.IsUncommittedVersion() }
+// IsUncommittedVersion implements the catalog.Descriptor interface.
+func (v *tableImplicitRecordType) IsUncommittedVersion() bool { return v.desc.IsUncommittedVersion() }
 
-// GetVersion implements the Descriptor interface.
-func (v TableImplicitRecordType) GetVersion() descpb.DescriptorVersion { return v.desc.GetVersion() }
+// GetVersion implements the catalog.Descriptor interface.
+func (v *tableImplicitRecordType) GetVersion() descpb.DescriptorVersion { return v.desc.GetVersion() }
 
-// GetModificationTime implements the Descriptor interface.
-func (v TableImplicitRecordType) GetModificationTime() hlc.Timestamp {
+// GetModificationTime implements the catalog.Descriptor interface.
+func (v *tableImplicitRecordType) GetModificationTime() hlc.Timestamp {
 	return v.desc.GetModificationTime()
 }
 
-// GetPrivileges implements the Descriptor interface.
-func (v TableImplicitRecordType) GetPrivileges() *catpb.PrivilegeDescriptor {
+// GetPrivileges implements the catalog.Descriptor interface.
+func (v *tableImplicitRecordType) GetPrivileges() *catpb.PrivilegeDescriptor {
 	return v.privs
 }
 
-// DescriptorType implements the Descriptor interface.
-func (v TableImplicitRecordType) DescriptorType() catalog.DescriptorType {
+// DescriptorType implements the catalog.Descriptor interface.
+func (v *tableImplicitRecordType) DescriptorType() catalog.DescriptorType {
 	return catalog.Type
 }
 
-// GetAuditMode implements the Descriptor interface.
-func (v TableImplicitRecordType) GetAuditMode() descpb.TableDescriptor_AuditMode {
+// GetAuditMode implements the catalog.Descriptor interface.
+func (v *tableImplicitRecordType) GetAuditMode() descpb.TableDescriptor_AuditMode {
 	return descpb.TableDescriptor_DISABLED
 }
 
-// Public implements the Descriptor interface.
-func (v TableImplicitRecordType) Public() bool { return v.desc.Public() }
+// Public implements the catalog.Descriptor interface.
+func (v *tableImplicitRecordType) Public() bool { return v.desc.Public() }
 
-// Adding implements the Descriptor interface.
-func (v TableImplicitRecordType) Adding() bool {
+// Adding implements the catalog.Descriptor interface.
+func (v *tableImplicitRecordType) Adding() bool {
 	v.panicNotSupported("Adding")
 	return false
 }
 
-// Dropped implements the Descriptor interface.
-func (v TableImplicitRecordType) Dropped() bool {
+// Dropped implements the catalog.Descriptor interface.
+func (v *tableImplicitRecordType) Dropped() bool {
 	return v.desc.Dropped()
 }
 
-// Offline implements the Descriptor interface.
-func (v TableImplicitRecordType) Offline() bool {
+// Offline implements the catalog.Descriptor interface.
+func (v *tableImplicitRecordType) Offline() bool {
 	v.panicNotSupported("Offline")
 	return false
 }
 
-// GetOfflineReason implements the Descriptor interface.
-func (v TableImplicitRecordType) GetOfflineReason() string {
+// GetOfflineReason implements the catalog.Descriptor interface.
+func (v *tableImplicitRecordType) GetOfflineReason() string {
 	v.panicNotSupported("GetOfflineReason")
 	return ""
 }
 
-// DescriptorProto implements the Descriptor interface.
-func (v TableImplicitRecordType) DescriptorProto() *descpb.Descriptor {
+// DescriptorProto implements the catalog.Descriptor interface.
+func (v *tableImplicitRecordType) DescriptorProto() *descpb.Descriptor {
 	v.panicNotSupported("DescriptorProto")
 	return nil
 }
 
-// ByteSize implements the Descriptor interface.
-func (v TableImplicitRecordType) ByteSize() int64 {
+// ByteSize implements the catalog.Descriptor interface.
+func (v *tableImplicitRecordType) ByteSize() int64 {
 	mem := v.desc.ByteSize()
 	if v.privs != nil {
 		mem += int64(v.privs.Size())
@@ -148,58 +148,58 @@ func (v TableImplicitRecordType) ByteSize() int64 {
 	return mem
 }
 
-// NewBuilder implements the Descriptor interface.
-func (v TableImplicitRecordType) NewBuilder() catalog.DescriptorBuilder {
+// NewBuilder implements the catalog.Descriptor interface.
+func (v *tableImplicitRecordType) NewBuilder() catalog.DescriptorBuilder {
 	v.panicNotSupported("NewBuilder")
 	return nil
 }
 
-// GetReferencedDescIDs implements the Descriptor interface.
-func (v TableImplicitRecordType) GetReferencedDescIDs() (catalog.DescriptorIDSet, error) {
+// GetReferencedDescIDs implements the catalog.Descriptor interface.
+func (v *tableImplicitRecordType) GetReferencedDescIDs() (catalog.DescriptorIDSet, error) {
 	return catalog.DescriptorIDSet{}, errors.AssertionFailedf(
 		"GetReferencedDescIDs are unsupported for implicit table record types")
 }
 
-// ValidateSelf implements the Descriptor interface.
-func (v TableImplicitRecordType) ValidateSelf(_ catalog.ValidationErrorAccumulator) {
+// ValidateSelf implements the catalog.Descriptor interface.
+func (v *tableImplicitRecordType) ValidateSelf(_ catalog.ValidationErrorAccumulator) {
 }
 
-// ValidateForwardReferences implements the Descriptor interface.
-func (v TableImplicitRecordType) ValidateForwardReferences(
+// ValidateForwardReferences implements the catalog.Descriptor interface.
+func (v *tableImplicitRecordType) ValidateForwardReferences(
 	_ catalog.ValidationErrorAccumulator, _ catalog.ValidationDescGetter,
 ) {
 }
 
-// ValidateBackReferences implements the Descriptor interface.
-func (v TableImplicitRecordType) ValidateBackReferences(
+// ValidateBackReferences implements the catalog.Descriptor interface.
+func (v *tableImplicitRecordType) ValidateBackReferences(
 	_ catalog.ValidationErrorAccumulator, _ catalog.ValidationDescGetter,
 ) {
 }
 
-// ValidateTxnCommit implements the Descriptor interface.
-func (v TableImplicitRecordType) ValidateTxnCommit(
+// ValidateTxnCommit implements the catalog.Descriptor interface.
+func (v *tableImplicitRecordType) ValidateTxnCommit(
 	_ catalog.ValidationErrorAccumulator, _ catalog.ValidationDescGetter,
 ) {
 }
 
 // GetRawBytesInStorage implements the catalog.Descriptor interface.
-func (v TableImplicitRecordType) GetRawBytesInStorage() []byte {
+func (v *tableImplicitRecordType) GetRawBytesInStorage() []byte {
 	return nil
 }
 
 // ForEachUDTDependentForHydration implements the catalog.Descriptor interface.
-func (v TableImplicitRecordType) ForEachUDTDependentForHydration(_ func(t *types.T) error) error {
+func (v *tableImplicitRecordType) ForEachUDTDependentForHydration(_ func(t *types.T) error) error {
 	return nil
 }
 
-// TypeDesc implements the TypeDescriptor interface.
-func (v TableImplicitRecordType) TypeDesc() *descpb.TypeDescriptor {
+// TypeDesc implements the catalog.TypeDescriptor interface.
+func (v *tableImplicitRecordType) TypeDesc() *descpb.TypeDescriptor {
 	v.panicNotSupported("TypeDesc")
 	return nil
 }
 
-// AsTypesT implements the TypeDescriptor interface.
-func (v TableImplicitRecordType) AsTypesT() *types.T {
+// AsTypesT implements the catalog.TypeDescriptor interface.
+func (v *tableImplicitRecordType) AsTypesT() *types.T {
 	cols := v.desc.VisibleColumns()
 	typs := make([]*types.T, len(cols))
 	names := make([]string, len(cols))
@@ -207,7 +207,7 @@ func (v TableImplicitRecordType) AsTypesT() *types.T {
 		typs[i] = col.GetType()
 		names[i] = col.GetName()
 	}
-	// The TypeDescriptor will be an alias to this Tuple type, which contains
+	// the catalog.TypeDescriptor will be an alias to this Tuple type, which contains
 	// all of the table's visible columns in order, labeled by the table's column
 	// names.
 	typ := types.MakeLabeledTuple(typs, names)
@@ -229,122 +229,111 @@ func (v TableImplicitRecordType) AsTypesT() *types.T {
 	return typ
 }
 
-// HasPendingSchemaChanges implements the TypeDescriptor interface.
-func (v TableImplicitRecordType) HasPendingSchemaChanges() bool { return false }
+// HasPendingSchemaChanges implements the catalog.TypeDescriptor interface.
+func (v *tableImplicitRecordType) HasPendingSchemaChanges() bool { return false }
 
 // GetIDClosure implements the TypeDescriptor interface.
-func (v TableImplicitRecordType) GetIDClosure() catalog.DescriptorIDSet {
+func (v *tableImplicitRecordType) GetIDClosure() catalog.DescriptorIDSet {
 	v.panicNotSupported("GetIDClosure")
 	return catalog.DescriptorIDSet{}
 }
 
-// IsCompatibleWith implements the TypeDescriptorInterface.
-func (v TableImplicitRecordType) IsCompatibleWith(_ catalog.TypeDescriptor) error {
+// IsCompatibleWith implements the catalog.TypeDescriptor interface.
+func (v *tableImplicitRecordType) IsCompatibleWith(_ catalog.TypeDescriptor) error {
 	return errors.AssertionFailedf("compatibility comparison unsupported for implicit table record types")
 }
 
-// PrimaryRegionName implements the TypeDescriptorInterface.
-func (v TableImplicitRecordType) PrimaryRegionName() (catpb.RegionName, error) {
-	return "", errors.AssertionFailedf(
-		"can not get primary region of a implicit table record type")
-}
-
-// RegionNames implements the TypeDescriptorInterface.
-func (v TableImplicitRecordType) RegionNames() (catpb.RegionNames, error) {
-	return nil, errors.AssertionFailedf(
-		"can not get region names of a implicit table record type")
-}
-
-// RegionNamesIncludingTransitioning implements the TypeDescriptorInterface.
-func (v TableImplicitRecordType) RegionNamesIncludingTransitioning() (catpb.RegionNames, error) {
-	return nil, errors.AssertionFailedf(
-		"can not get region names of a implicit table record type")
-}
-
-// RegionNamesForValidation implements the TypeDescriptorInterface.
-func (v TableImplicitRecordType) RegionNamesForValidation() (catpb.RegionNames, error) {
-	return nil, errors.AssertionFailedf(
-		"can not get region names of a implicit table record type")
-}
-
-// TransitioningRegionNames implements the TypeDescriptorInterface.
-func (v TableImplicitRecordType) TransitioningRegionNames() (catpb.RegionNames, error) {
-	return nil, errors.AssertionFailedf(
-		"can not get region names of a implicit table record type")
-}
-
-// SuperRegions implements the TypeDescriptor interface.
-func (v TableImplicitRecordType) SuperRegions() ([]descpb.SuperRegion, error) {
-	return nil, errors.AssertionFailedf(
-		"can not get super regions of a implicit table record type",
-	)
-}
-
-// ZoneConfigExtensions implements the TypeDescriptorInterface.
-func (v TableImplicitRecordType) ZoneConfigExtensions() (descpb.ZoneConfigExtensions, error) {
-	return descpb.ZoneConfigExtensions{}, errors.AssertionFailedf(
-		"can not get the zone config extensions of a implicit table record type")
-}
-
-// GetArrayTypeID implements the TypeDescriptorInterface.
-func (v TableImplicitRecordType) GetArrayTypeID() descpb.ID {
+// GetArrayTypeID implements the catalog.TypeDescriptor interface.
+func (v *tableImplicitRecordType) GetArrayTypeID() descpb.ID {
 	return 0
 }
 
-// GetKind implements the TypeDescriptorInterface.
-func (v TableImplicitRecordType) GetKind() descpb.TypeDescriptor_Kind {
+// GetKind implements the catalog.TypeDescriptor interface.
+func (v *tableImplicitRecordType) GetKind() descpb.TypeDescriptor_Kind {
 	return descpb.TypeDescriptor_TABLE_IMPLICIT_RECORD_TYPE
 }
 
-// NumEnumMembers implements the TypeDescriptorInterface.
-func (v TableImplicitRecordType) NumEnumMembers() int { return 0 }
+// NumEnumMembers implements the catalog.TypeDescriptor interface.
+func (v *tableImplicitRecordType) NumEnumMembers() int { return 0 }
 
-// GetMemberPhysicalRepresentation implements the TypeDescriptorInterface.
-func (v TableImplicitRecordType) GetMemberPhysicalRepresentation(_ int) []byte { return nil }
+// GetMemberPhysicalRepresentation implements the catalog.TypeDescriptor interface.
+func (v *tableImplicitRecordType) GetMemberPhysicalRepresentation(_ int) []byte { return nil }
 
-// GetMemberLogicalRepresentation implements the TypeDescriptorInterface.
-func (v TableImplicitRecordType) GetMemberLogicalRepresentation(_ int) string { return "" }
+// GetMemberLogicalRepresentation implements the catalog.TypeDescriptor interface.
+func (v *tableImplicitRecordType) GetMemberLogicalRepresentation(_ int) string { return "" }
 
-// IsMemberReadOnly implements the TypeDescriptorInterface.
-func (v TableImplicitRecordType) IsMemberReadOnly(_ int) bool { return false }
+// IsMemberReadOnly implements the catalog.TypeDescriptor interface.
+func (v *tableImplicitRecordType) IsMemberReadOnly(_ int) bool { return false }
 
-// NumReferencingDescriptors implements the TypeDescriptorInterface.
-func (v TableImplicitRecordType) NumReferencingDescriptors() int { return 0 }
+// NumReferencingDescriptors implements the catalog.TypeDescriptor interface.
+func (v *tableImplicitRecordType) NumReferencingDescriptors() int { return 0 }
 
-// GetReferencingDescriptorID implements the TypeDescriptorInterface.
-func (v TableImplicitRecordType) GetReferencingDescriptorID(_ int) descpb.ID { return 0 }
+// GetReferencingDescriptorID implements the catalog.TypeDescriptor interface.
+func (v *tableImplicitRecordType) GetReferencingDescriptorID(_ int) descpb.ID { return 0 }
 
-// GetReferencingDescriptorIDs implements the TypeDescriptorInterface.
-func (v TableImplicitRecordType) GetReferencingDescriptorIDs() []descpb.ID { return nil }
+// GetReferencingDescriptorIDs implements the catalog.TypeDescriptor interface.
+func (v *tableImplicitRecordType) GetReferencingDescriptorIDs() []descpb.ID { return nil }
 
-// GetPostDeserializationChanges implements the Descriptor interface.
-func (v TableImplicitRecordType) GetPostDeserializationChanges() catalog.PostDeserializationChanges {
+// GetPostDeserializationChanges implements the catalog.Descriptor interface.
+func (v *tableImplicitRecordType) GetPostDeserializationChanges() catalog.PostDeserializationChanges {
 	return catalog.PostDeserializationChanges{}
 }
 
 // HasConcurrentSchemaChanges implements catalog.Descriptor.
-func (v TableImplicitRecordType) HasConcurrentSchemaChanges() bool {
+func (v *tableImplicitRecordType) HasConcurrentSchemaChanges() bool {
 	return false
 }
 
 // SkipNamespace implements catalog.Descriptor. We never store table implicit
 // record type which is always constructed in memory.
-func (v TableImplicitRecordType) SkipNamespace() bool {
+func (v *tableImplicitRecordType) SkipNamespace() bool {
 	return true
 }
 
-func (v TableImplicitRecordType) panicNotSupported(message string) {
+func (v *tableImplicitRecordType) panicNotSupported(message string) {
 	panic(errors.AssertionFailedf("implicit table record type for table %q: not supported: %s", v.GetName(), message))
 }
 
-// GetDeclarativeSchemaChangerState implements the Descriptor interface.
-func (v TableImplicitRecordType) GetDeclarativeSchemaChangerState() *scpb.DescriptorState {
+// GetDeclarativeSchemaChangerState implements the catalog.Descriptor interface.
+func (v *tableImplicitRecordType) GetDeclarativeSchemaChangerState() *scpb.DescriptorState {
 	v.panicNotSupported("GetDeclarativeSchemaChangeState")
 	return nil
 }
 
 // GetObjectType implements the Object interface.
-func (v TableImplicitRecordType) GetObjectType() privilege.ObjectType {
+func (v *tableImplicitRecordType) GetObjectType() privilege.ObjectType {
 	v.panicNotSupported("GetObjectType")
 	return ""
+}
+
+// AsEnumTypeDescriptor implements the catalog.TypeDescriptor interface.
+func (v *tableImplicitRecordType) AsEnumTypeDescriptor() catalog.EnumTypeDescriptor {
+	return nil
+}
+
+// AsRegionEnumTypeDescriptor implements the catalog.TypeDescriptor interface.
+func (v *tableImplicitRecordType) AsRegionEnumTypeDescriptor() catalog.RegionEnumTypeDescriptor {
+	return nil
+}
+
+// AsAliasTypeDescriptor implements the catalog.TypeDescriptor interface.
+func (v *tableImplicitRecordType) AsAliasTypeDescriptor() catalog.AliasTypeDescriptor {
+	return nil
+}
+
+// AsCompositeTypeDescriptor implements the catalog.TypeDescriptor interface.
+func (v *tableImplicitRecordType) AsCompositeTypeDescriptor() catalog.CompositeTypeDescriptor {
+	return nil
+}
+
+// AsTableImplicitRecordTypeDescriptor implements the catalog.TypeDescriptor
+// interface.
+func (v *tableImplicitRecordType) AsTableImplicitRecordTypeDescriptor() catalog.TableImplicitRecordTypeDescriptor {
+	return v
+}
+
+// UnderlyingTableDescriptor implements the
+// catalog.TableImplicitRecordTypeDescriptor interface.
+func (v *tableImplicitRecordType) UnderlyingTableDescriptor() catalog.TableDescriptor {
+	return v.desc
 }

--- a/pkg/sql/catalog/typedesc/type_desc.go
+++ b/pkg/sql/catalog/typedesc/type_desc.go
@@ -39,6 +39,10 @@ import (
 )
 
 var _ catalog.TypeDescriptor = (*immutable)(nil)
+var _ catalog.EnumTypeDescriptor = (*immutable)(nil)
+var _ catalog.RegionEnumTypeDescriptor = (*immutable)(nil)
+var _ catalog.AliasTypeDescriptor = (*immutable)(nil)
+var _ catalog.CompositeTypeDescriptor = (*immutable)(nil)
 var _ catalog.TypeDescriptor = (*Mutable)(nil)
 var _ catalog.MutableDescriptor = (*Mutable)(nil)
 
@@ -218,99 +222,34 @@ func (desc *immutable) NewBuilder() catalog.DescriptorBuilder {
 	return b
 }
 
-// PrimaryRegionName implements the TypeDescriptor interface.
-func (desc *immutable) PrimaryRegionName() (catpb.RegionName, error) {
-	if desc.Kind != descpb.TypeDescriptor_MULTIREGION_ENUM {
-		return "", errors.AssertionFailedf(
-			"can not get primary region of a non multi-region enum %q (%d)", desc.GetName(), desc.GetID())
-	}
-	return desc.RegionConfig.PrimaryRegion, nil
+// PrimaryRegion implements the catalog.RegionEnumTypeDescriptor interface.
+func (desc *immutable) PrimaryRegion() catpb.RegionName {
+	return desc.RegionConfig.PrimaryRegion
 }
 
-// RegionNames implements the TypeDescriptor interface.
-func (desc *immutable) RegionNames() (catpb.RegionNames, error) {
-	if desc.Kind != descpb.TypeDescriptor_MULTIREGION_ENUM {
-		return nil, errors.AssertionFailedf(
-			"can not get regions of a non multi-region enum %q (%d)", desc.GetName(), desc.GetID(),
-		)
+// ForEachRegion implements the catalog.RegionEnumTypeDescriptor interface.
+func (desc *immutable) ForEachRegion(
+	f func(name catpb.RegionName, transition descpb.TypeDescriptor_EnumMember_Direction) error,
+) error {
+	for _, member := range desc.EnumMembers {
+		if err := f(catpb.RegionName(member.LogicalRepresentation), member.Direction); err != nil {
+			return iterutil.Map(err)
+		}
 	}
-	var regions catpb.RegionNames
+	return nil
+}
+
+// ForEachPublicRegion implements the catalog.RegionEnumTypeDescriptor interface.
+func (desc *immutable) ForEachPublicRegion(f func(name catpb.RegionName) error) error {
 	for _, member := range desc.EnumMembers {
 		if member.Capability == descpb.TypeDescriptor_EnumMember_READ_ONLY {
 			continue
 		}
-		regions = append(regions, catpb.RegionName(member.LogicalRepresentation))
-	}
-	return regions, nil
-}
-
-// TransitioningRegionNames implements the TypeDescriptor interface.
-func (desc *immutable) TransitioningRegionNames() (catpb.RegionNames, error) {
-	if desc.Kind != descpb.TypeDescriptor_MULTIREGION_ENUM {
-		return nil, errors.AssertionFailedf(
-			"can not get regions of a non multi-region enum %q (%d)", desc.GetName(), desc.GetID(),
-		)
-	}
-	var regions catpb.RegionNames
-	for _, member := range desc.EnumMembers {
-		if member.Direction != descpb.TypeDescriptor_EnumMember_NONE {
-			regions = append(regions, catpb.RegionName(member.LogicalRepresentation))
+		if err := f(catpb.RegionName(member.LogicalRepresentation)); err != nil {
+			return iterutil.Map(err)
 		}
 	}
-	return regions, nil
-}
-
-// RegionNamesForValidation implements the TypeDescriptor interface.
-func (desc *immutable) RegionNamesForValidation() (catpb.RegionNames, error) {
-	if desc.Kind != descpb.TypeDescriptor_MULTIREGION_ENUM {
-		return nil, errors.AssertionFailedf(
-			"can not get regions of a non multi-region enum %q (%d)", desc.GetName(), desc.GetID(),
-		)
-	}
-	var regions catpb.RegionNames
-	for _, member := range desc.EnumMembers {
-		if member.Capability == descpb.TypeDescriptor_EnumMember_READ_ONLY &&
-			member.Direction == descpb.TypeDescriptor_EnumMember_ADD {
-			continue
-		}
-		regions = append(regions, catpb.RegionName(member.LogicalRepresentation))
-	}
-	return regions, nil
-}
-
-// SuperRegions implements the TypeDescriptor interface.
-func (desc *immutable) SuperRegions() ([]descpb.SuperRegion, error) {
-	if desc.Kind != descpb.TypeDescriptor_MULTIREGION_ENUM {
-		return nil, errors.AssertionFailedf(
-			"can not get regions of a non multi-region enum %q (%d)", desc.GetName(), desc.GetID(),
-		)
-	}
-
-	return desc.RegionConfig.SuperRegions, nil
-}
-
-// RegionNamesIncludingTransitioning implements the TypeDescriptor interface.
-func (desc *immutable) RegionNamesIncludingTransitioning() (catpb.RegionNames, error) {
-	if desc.Kind != descpb.TypeDescriptor_MULTIREGION_ENUM {
-		return nil, errors.AssertionFailedf(
-			"can not get regions of a non multi-region enum %q (%d)", desc.GetName(), desc.GetID(),
-		)
-	}
-	var regions catpb.RegionNames
-	for _, member := range desc.EnumMembers {
-		regions = append(regions, catpb.RegionName(member.LogicalRepresentation))
-	}
-	return regions, nil
-}
-
-// ZoneConfigExtensions implements the TypeDescriptorInterface.
-func (desc *immutable) ZoneConfigExtensions() (descpb.ZoneConfigExtensions, error) {
-	if desc.Kind != descpb.TypeDescriptor_MULTIREGION_ENUM {
-		return descpb.ZoneConfigExtensions{}, errors.AssertionFailedf(
-			"can not get the zone config extensions of a non multi-region enum %q (%d)", desc.GetName(), desc.GetID(),
-		)
-	}
-	return desc.RegionConfig.ZoneConfigExtensions, nil
+	return nil
 }
 
 // GetAuditMode implements the DescriptorProto interface.
@@ -481,7 +420,7 @@ func (desc *Mutable) AddReferencingDescriptorID(new descpb.ID) {
 }
 
 // RemoveReferencingDescriptorID removes the desired referencing descriptor ID
-// from the TypeDescriptor. It has no effect if the requested ID is not present.
+// from the catalog.TypeDescriptor. It has no effect if the requested ID is not present.
 func (desc *Mutable) RemoveReferencingDescriptorID(remove descpb.ID) {
 	for i, id := range desc.ReferencingDescriptorIDs {
 		if id == remove {
@@ -496,7 +435,7 @@ func (desc *Mutable) SetParentSchemaID(schemaID descpb.ID) {
 	desc.ParentSchemaID = schemaID
 }
 
-// SetName sets the TypeDescriptor's name.
+// SetName sets the catalog.TypeDescriptor's name.
 func (desc *Mutable) SetName(name string) {
 	desc.Name = name
 }
@@ -511,7 +450,7 @@ func (e EnumMembers) Less(i, j int) bool {
 }
 func (e EnumMembers) Swap(i, j int) { e[i], e[j] = e[j], e[i] }
 
-// ValidateSelf performs validation on the TypeDescriptor.
+// ValidateSelf performs validation on the catalog.TypeDescriptor.
 func (desc *immutable) ValidateSelf(vea catalog.ValidationErrorAccumulator) {
 	// Validate local properties of the descriptor.
 	vea.Report(catalog.ValidateName(desc))
@@ -562,8 +501,8 @@ func (desc *immutable) ValidateSelf(vea catalog.ValidationErrorAccumulator) {
 		if desc.Alias == nil {
 			vea.Report(errors.AssertionFailedf("ALIAS type desc has nil alias type"))
 		}
-		if desc.GetArrayTypeID() != descpb.InvalidID {
-			vea.Report(errors.AssertionFailedf("ALIAS type desc has array type ID %d", desc.GetArrayTypeID()))
+		if desc.ArrayTypeID != descpb.InvalidID {
+			vea.Report(errors.AssertionFailedf("ALIAS type desc has array type ID %d", desc.ArrayTypeID))
 		}
 	case descpb.TypeDescriptor_COMPOSITE:
 		if desc.Composite == nil {
@@ -659,13 +598,13 @@ func (desc *immutable) ValidateForwardReferences(
 		}
 	}
 
-	if desc.GetKind() == descpb.TypeDescriptor_MULTIREGION_ENUM && dbDesc != nil {
-		desc.validateMultiRegion(dbDesc, vea)
+	if r := desc.AsRegionEnumTypeDescriptor(); r != nil && dbDesc != nil {
+		validateMultiRegion(r, dbDesc, vea)
 	}
 
 	// Validate that the forward-referenced types exist.
-	if desc.GetKind() == descpb.TypeDescriptor_ALIAS && desc.GetAlias().UserDefined() {
-		aliasedID := UserDefinedTypeOIDToID(desc.GetAlias().Oid())
+	if a := desc.AsAliasTypeDescriptor(); a != nil && a.Aliased().UserDefined() {
+		aliasedID := UserDefinedTypeOIDToID(a.Aliased().Oid())
 		if typ, err := vdg.GetTypeDescriptor(aliasedID); err != nil {
 			vea.Report(errors.Wrapf(err, "aliased type %d does not exist", aliasedID))
 		} else if typ.Dropped() {
@@ -673,9 +612,9 @@ func (desc *immutable) ValidateForwardReferences(
 		}
 	}
 
-	if desc.GetKind() == descpb.TypeDescriptor_COMPOSITE {
-		for _, e := range desc.Composite.Elements {
-			t := e.ElementType
+	if c := desc.AsCompositeTypeDescriptor(); c != nil {
+		for i := 0; i < c.NumElements(); i++ {
+			t := c.GetElementType(i)
 			if t.UserDefined() {
 				// User-defined type references within user-defined types are currently
 				// not supported, but this should be validated elsewhere.
@@ -694,14 +633,13 @@ func (desc *immutable) ValidateBackReferences(
 ) {
 
 	// Validate that the backward-referenced types exist.
-	switch desc.GetKind() {
-	case descpb.TypeDescriptor_ENUM, descpb.TypeDescriptor_MULTIREGION_ENUM:
+	if e := desc.AsEnumTypeDescriptor(); e != nil {
 		// Ensure that the array type exists.
 		// This is considered to be a backward reference, not a forward reference,
 		// as the element type doesn't need the array type to exist, but the
 		// converse is not true.
-		if typ, err := vdg.GetTypeDescriptor(desc.GetArrayTypeID()); err != nil {
-			vea.Report(errors.Wrapf(err, "arrayTypeID %d does not exist for %q", desc.GetArrayTypeID(), desc.GetKind()))
+		if typ, err := vdg.GetTypeDescriptor(e.GetArrayTypeID()); err != nil {
+			vea.Report(errors.Wrapf(err, "arrayTypeID %d does not exist for %q", e.GetArrayTypeID(), e.GetKind()))
 		} else if typ.Dropped() {
 			vea.Report(errors.AssertionFailedf("array type %q (%d) is dropped", typ.GetName(), typ.GetID()))
 		}
@@ -727,8 +665,10 @@ func (desc *immutable) ValidateBackReferences(
 	}
 }
 
-func (desc *immutable) validateMultiRegion(
-	dbDesc catalog.DatabaseDescriptor, vea catalog.ValidationErrorAccumulator,
+func validateMultiRegion(
+	desc catalog.RegionEnumTypeDescriptor,
+	dbDesc catalog.DatabaseDescriptor,
+	vea catalog.ValidationErrorAccumulator,
 ) {
 	// Parent database must be a multi-region database if it includes a
 	// multi-region enum.
@@ -737,15 +677,12 @@ func (desc *immutable) validateMultiRegion(
 		return
 	}
 
-	primaryRegion, err := desc.PrimaryRegionName()
-	if err != nil {
-		vea.Report(err)
-	}
+	primaryRegion := desc.PrimaryRegion()
 
 	{
 		found := false
-		for _, member := range desc.EnumMembers {
-			if catpb.RegionName(member.LogicalRepresentation) == primaryRegion {
+		for i := 0; i < desc.NumEnumMembers(); i++ {
+			if catpb.RegionName(desc.GetMemberLogicalRepresentation(i)) == primaryRegion {
 				found = true
 			}
 		}
@@ -766,10 +703,11 @@ func (desc *immutable) validateMultiRegion(
 			dbPrimaryRegion, primaryRegion))
 	}
 
-	regionNames, err := desc.RegionNames()
-	if err != nil {
-		vea.Report(err)
-	}
+	var regionNames catpb.RegionNames
+	_ = desc.ForEachPublicRegion(func(name catpb.RegionName) error {
+		regionNames = append(regionNames, name)
+		return nil
+	})
 	if dbDesc.GetRegionConfig().SurvivalGoal == descpb.SurvivalGoal_REGION_FAILURE {
 		if len(regionNames) < 3 {
 			vea.Report(
@@ -782,18 +720,12 @@ func (desc *immutable) validateMultiRegion(
 		}
 	}
 
-	superRegions, err := desc.SuperRegions()
-	if err != nil {
-		vea.Report(err)
-	}
+	superRegions := desc.TypeDesc().RegionConfig.SuperRegions
 	multiregion.ValidateSuperRegions(superRegions, dbDesc.GetRegionConfig().SurvivalGoal, regionNames, func(err error) {
 		vea.Report(err)
 	})
 
-	zoneCfgExtensions, err := desc.ZoneConfigExtensions()
-	if err != nil {
-		vea.Report(err)
-	}
+	zoneCfgExtensions := desc.TypeDesc().RegionConfig.ZoneConfigExtensions
 	multiregion.ValidateZoneConfigExtensions(regionNames, zoneCfgExtensions, func(err error) {
 		vea.Report(err)
 	})
@@ -809,14 +741,14 @@ func (desc *immutable) ValidateTxnCommit(
 // TypeLookupFunc is a type alias for a function that looks up a type by ID.
 type TypeLookupFunc func(ctx context.Context, id descpb.ID) (tree.TypeName, catalog.TypeDescriptor, error)
 
-// GetTypeDescriptor implements the TypeDescriptorResolver interface.
+// GetTypeDescriptor implements the catalog.TypeDescriptorResolver interface.
 func (t TypeLookupFunc) GetTypeDescriptor(
 	ctx context.Context, id descpb.ID,
 ) (tree.TypeName, catalog.TypeDescriptor, error) {
 	return t(ctx, id)
 }
 
-// AsTypesT implements the TypeDescriptor interface.
+// AsTypesT implements the catalog.TypeDescriptor interface.
 func (desc *immutable) AsTypesT() *types.T {
 	switch desc.Kind {
 	case descpb.TypeDescriptor_ENUM, descpb.TypeDescriptor_MULTIREGION_ENUM:
@@ -840,75 +772,73 @@ func (desc *immutable) AsTypesT() *types.T {
 	panic(errors.AssertionFailedf("unsupported descriptor kind %s", desc.Kind.String()))
 }
 
-// NumEnumMembers implements the TypeDescriptor interface.
+// NumEnumMembers implements the catalog.EnumTypeDescriptor interface.
 func (desc *immutable) NumEnumMembers() int {
 	return len(desc.EnumMembers)
 }
 
-// GetMemberPhysicalRepresentation implements the TypeDescriptor interface.
+// GetMemberPhysicalRepresentation implements the catalog.EnumTypeDescriptor interface.
 func (desc *immutable) GetMemberPhysicalRepresentation(enumMemberOrdinal int) []byte {
 	return desc.physicalReps[enumMemberOrdinal]
 }
 
-// GetMemberLogicalRepresentation implements the TypeDescriptor interface.
+// GetMemberLogicalRepresentation implements the catalog.EnumTypeDescriptor interface.
 func (desc *immutable) GetMemberLogicalRepresentation(enumMemberOrdinal int) string {
 	return desc.logicalReps[enumMemberOrdinal]
 }
 
-// IsMemberReadOnly implements the TypeDescriptor interface.
+// IsMemberReadOnly implements the catalog.EnumTypeDescriptor interface.
 func (desc *immutable) IsMemberReadOnly(enumMemberOrdinal int) bool {
 	return desc.readOnlyMembers[enumMemberOrdinal]
 }
 
-// NumReferencingDescriptors implements the TypeDescriptor interface.
+// NumReferencingDescriptors implements the catalog.TypeDescriptor interface.
 func (desc *immutable) NumReferencingDescriptors() int {
 	return len(desc.ReferencingDescriptorIDs)
 }
 
-// GetReferencingDescriptorID implements the TypeDescriptor interface.
+// GetReferencingDescriptorID implements the catalog.TypeDescriptor interface.
 func (desc *immutable) GetReferencingDescriptorID(refOrdinal int) descpb.ID {
 	return desc.ReferencingDescriptorIDs[refOrdinal]
 }
 
-// IsCompatibleWith implements the TypeDescriptor interface.
+// IsCompatibleWith implements the catalog.TypeDescriptor interface.
 func (desc *immutable) IsCompatibleWith(other catalog.TypeDescriptor) error {
-
-	switch desc.Kind {
-	case descpb.TypeDescriptor_ENUM, descpb.TypeDescriptor_MULTIREGION_ENUM:
-		if other.GetKind() != desc.Kind {
-			return errors.Newf("%q of type %q is not compatible with type %q",
-				other.GetName(), other.GetKind(), desc.Kind)
-		}
-		// Every enum value in desc must be present in other, and all of the
-		// physical representations must be the same.
-		for _, thisMember := range desc.EnumMembers {
-			found := false
-			for i := 0; i < other.NumEnumMembers(); i++ {
-				if thisMember.LogicalRepresentation == other.GetMemberLogicalRepresentation(i) {
-					// We've found a match. Now the physical representations must be
-					// the same, otherwise the enums are incompatible.
-					if !bytes.Equal(thisMember.PhysicalRepresentation, other.GetMemberPhysicalRepresentation(i)) {
-						return errors.Newf(
-							"%q has differing physical representation for value %q",
-							other.GetName(),
-							thisMember.LogicalRepresentation,
-						)
-					}
-					found = true
-				}
-			}
-			if !found {
-				return errors.Newf(
-					"could not find enum value %q in %q", thisMember.LogicalRepresentation, other.GetName())
-			}
-		}
-		return nil
-	default:
-		return errors.Newf("compatibility comparison unsupported for type kind %s", desc.Kind.String())
+	if desc.AsEnumTypeDescriptor() == nil {
+		return errors.Newf("compatibility comparison unsupported for type kind %s", desc.GetKind())
 	}
+	if other.GetKind() != desc.GetKind() {
+		return errors.Newf("%q of type %q is not compatible with type %q",
+			other.GetName(), other.GetKind(), desc.GetKind())
+	}
+	e := other.AsEnumTypeDescriptor()
+	// Every enum value in desc must be present in other, and all of the
+	// physical representations must be the same.
+	for _, thisMember := range desc.EnumMembers {
+		var found bool
+		for i := 0; i < e.NumEnumMembers(); i++ {
+			if thisMember.LogicalRepresentation == e.GetMemberLogicalRepresentation(i) {
+				// We've found a match. Now the physical representations must be
+				// the same, otherwise the enums are incompatible.
+				if !bytes.Equal(thisMember.PhysicalRepresentation, e.GetMemberPhysicalRepresentation(i)) {
+					return errors.Newf(
+						"%q has differing physical representation for value %q",
+						e.GetName(),
+						thisMember.LogicalRepresentation,
+					)
+				}
+				found = true
+			}
+		}
+		if !found {
+			return errors.Newf(
+				"could not find enum value %q in %q", thisMember.LogicalRepresentation, e.GetName())
+		}
+	}
+	return nil
 }
 
-// HasPendingSchemaChanges implements the TypeDescriptor interface.
+// HasPendingSchemaChanges implements the catalog.TypeDescriptor interface.
 func (desc *immutable) HasPendingSchemaChanges() bool {
 	switch desc.Kind {
 	case descpb.TypeDescriptor_ENUM, descpb.TypeDescriptor_MULTIREGION_ENUM:
@@ -1020,6 +950,94 @@ func GetTypeDescriptorClosure(typ *types.T) (ret catalog.DescriptorIDSet) {
 		ret.Add(GetUserDefinedArrayTypeDescID(typ))
 	}
 	return ret
+}
+
+// AsEnumTypeDescriptor implements the catalog.TypeDescriptor interface.
+func (desc *immutable) AsEnumTypeDescriptor() catalog.EnumTypeDescriptor {
+	if desc.Kind == descpb.TypeDescriptor_ENUM ||
+		desc.Kind == descpb.TypeDescriptor_MULTIREGION_ENUM {
+		return desc
+	}
+	return nil
+}
+
+// AsRegionEnumTypeDescriptor implements the catalog.TypeDescriptor interface.
+func (desc *immutable) AsRegionEnumTypeDescriptor() catalog.RegionEnumTypeDescriptor {
+	if desc.Kind == descpb.TypeDescriptor_MULTIREGION_ENUM {
+		return desc
+	}
+	return nil
+}
+
+// AsAliasTypeDescriptor implements the catalog.TypeDescriptor interface.
+func (desc *immutable) AsAliasTypeDescriptor() catalog.AliasTypeDescriptor {
+	if desc.Kind == descpb.TypeDescriptor_ALIAS {
+		return desc
+	}
+	return nil
+}
+
+// AsCompositeTypeDescriptor implements the catalog.TypeDescriptor interface.
+func (desc *immutable) AsCompositeTypeDescriptor() catalog.CompositeTypeDescriptor {
+	if desc.Kind == descpb.TypeDescriptor_COMPOSITE {
+		return desc
+	}
+	return nil
+}
+
+// AsTableImplicitRecordTypeDescriptor implements the catalog.TypeDescriptor
+// interface.
+func (desc *immutable) AsTableImplicitRecordTypeDescriptor() catalog.TableImplicitRecordTypeDescriptor {
+	return nil
+}
+
+// Aliased implements the catalog.AliasTypeDescriptor interface.
+func (desc *immutable) Aliased() *types.T {
+	return desc.Alias
+}
+
+// NumElements implements the catalog.CompositeTypeDescriptor interface.
+func (desc *immutable) NumElements() int {
+	return len(desc.Composite.Elements)
+}
+
+// GetElementLabel implements the catalog.CompositeTypeDescriptor interface.
+func (desc *immutable) GetElementLabel(ordinal int) string {
+	return desc.Composite.Elements[ordinal].ElementLabel
+}
+
+// GetElementType implements the catalog.CompositeTypeDescriptor interface.
+func (desc *immutable) GetElementType(ordinal int) *types.T {
+	return desc.Composite.Elements[ordinal].ElementType
+}
+
+// ForEachRegionInSuperRegion implements the catalog.RegionEnumTypeDescriptor
+// interface.
+func (desc *immutable) ForEachRegionInSuperRegion(
+	superRegionName string, f func(region catpb.RegionName) error,
+) error {
+	for _, s := range desc.RegionConfig.SuperRegions {
+		if superRegionName == s.SuperRegionName {
+			for _, r := range s.Regions {
+				if err := f(r); err != nil {
+					return iterutil.Map(err)
+				}
+			}
+			break
+		}
+	}
+	return nil
+}
+
+// ForEachSuperRegion implements the catalog.RegionEnumTypeDescriptor
+// interface.
+func (desc *immutable) ForEachSuperRegion(f func(superRegionName string) error) error {
+	for _, s := range desc.RegionConfig.SuperRegions {
+		if err := f(s.SuperRegionName); err != nil {
+			return iterutil.Map(err)
+		}
+	}
+	return nil
 }
 
 // SetDeclarativeSchemaChangerState is part of the catalog.MutableDescriptor

--- a/pkg/sql/reassign_owned_by.go
+++ b/pkg/sql/reassign_owned_by.go
@@ -177,8 +177,8 @@ func (n *reassignOwnedByNode) startExec(params runParams) error {
 			if err != nil {
 				return err
 			}
-			if isOwner && (lCtx.typDescs[typID].GetKind() != descpb.TypeDescriptor_ALIAS) {
-				if err := n.reassignTypeOwner(lCtx.typDescs[typID], params); err != nil {
+			if isOwner && (lCtx.typDescs[typID].AsAliasTypeDescriptor() == nil) {
+				if err := n.reassignTypeOwner(lCtx.typDescs[typID].(catalog.NonAliasTypeDescriptor), params); err != nil {
 					return err
 				}
 			}
@@ -290,7 +290,7 @@ func (n *reassignOwnedByNode) reassignTableOwner(
 }
 
 func (n *reassignOwnedByNode) reassignTypeOwner(
-	typDesc catalog.TypeDescriptor, params runParams,
+	typDesc catalog.NonAliasTypeDescriptor, params runParams,
 ) error {
 	mutableTypDesc, err := params.p.Descriptors().MutableByID(params.p.txn).Desc(params.ctx, typDesc.GetID())
 	if err != nil {


### PR DESCRIPTION
This refactor introduces dedicated interfaces for each TypeDescriptor subtype. This allows simplifying some method signatures.

Informs #91924.

Release note: None