### PR TITLE
sql/schemachanger: fix backup/restore test

### DIFF
--- a/pkg/sql/schemachanger/testdata/end_to_end/drop_table
+++ b/pkg/sql/schemachanger/testdata/end_to_end/drop_table
@@ -3,6 +3,7 @@ CREATE DATABASE db;
 CREATE SCHEMA db.sc;
 CREATE TABLE db.sc.t (k INT, v STRING);
 CREATE TYPE db.sc.e AS ENUM('a', 'b', 'c');
+CREATE VIEW db.sc.v AS SELECT 1;
 ----
 ...
 +database {0 0 db} -> 104


### PR DESCRIPTION
Previously, we have a test flavor where only tables are restored. So if there is any other non-table objects, they won't be restored. However, the descriptor state query always query everything, so there could be a mis-match when there is non-table objects which are not restored for some reason. For example, UDT that is not used by any table restored.

Epic: None
Release note: None