### PR TITLE
upgrades: modify InjectLegacyTable to handle dynamically assigned IDs

### DIFF
--- a/pkg/upgrade/upgrades/BUILD.bazel
+++ b/pkg/upgrade/upgrades/BUILD.bazel
@@ -130,6 +130,7 @@ go_test(
         "//pkg/sql/catalog/descbuilder",
         "//pkg/sql/catalog/descpb",
         "//pkg/sql/catalog/descs",
+        "//pkg/sql/catalog/schemadesc",
         "//pkg/sql/catalog/schematelemetry/schematelemetrycontroller",
         "//pkg/sql/catalog/systemschema",
         "//pkg/sql/catalog/tabledesc",


### PR DESCRIPTION
This patch modifies the `InjectLegacyTable` function, which is used by
upgrade tests to inject an old version of a table descriptor, to handle
the case where the table has a dynamically assigned ID.

Epic: None

Release note: None