### PR TITLE
sql: evaluate correlated subqueries as routines

### DIFF
--- a/pkg/ccl/logictestccl/tests/3node-tenant/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/3node-tenant/generated_test.go
@@ -301,6 +301,13 @@ func TestTenantLogic_as_of(
 	runLogicTest(t, "as_of")
 }
 
+func TestTenantLogic_asyncpg(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "asyncpg")
+}
+
 func TestTenantLogic_auto_span_config_reconciliation_job(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/testdata/logic_test/asyncpg
+++ b/pkg/sql/logictest/testdata/logic_test/asyncpg
@@ -1,0 +1,229 @@
+# Tests for queries made by asyncpg.
+
+# Regression test for #71908 and #80169.
+query TTTTTTTTTTITTI rowsort
+----------------------------------------------------------------------------------------
+WITH RECURSIVE
+    typeinfo_tree
+        (
+            oid, ns, name, kind, basetype, elemtype, elemdelim, range_subtype, attrtypoids, attrnames, depth
+        )
+        AS (
+            SELECT
+                ti.oid,
+                ti.ns,
+                ti.name,
+                ti.kind,
+                ti.basetype,
+                ti.elemtype,
+                ti.elemdelim,
+                ti.range_subtype,
+                ti.attrtypoids,
+                ti.attrnames,
+                0
+            FROM
+                (
+                    SELECT
+                        t.oid AS oid,
+                        ns.nspname AS ns,
+                        t.typname AS name,
+                        t.typtype AS kind,
+                        CASE
+                        WHEN t.typtype = 'd'
+                        THEN (
+                            WITH RECURSIVE
+                                typebases (oid, depth)
+                                    AS (
+                                        SELECT
+                                            t2.typbasetype AS oid, 0 AS depth
+                                        FROM
+                                            pg_type AS t2
+                                        WHERE
+                                            t2.oid = t.oid
+                                        UNION ALL
+                                            SELECT
+                                                t2.typbasetype AS oid,
+                                                tb.depth + 1 AS depth
+                                            FROM
+                                                pg_type AS t2, typebases AS tb
+                                            WHERE
+                                                tb.oid = t2.oid AND t2.typbasetype != 0
+                                    )
+                            SELECT
+                                oid
+                            FROM
+                                typebases
+                            ORDER BY
+                                depth DESC
+                            LIMIT
+                                1
+                        )
+                        ELSE NULL
+                        END
+                            AS basetype,
+                        t.typelem AS elemtype,
+                        elem_t.typdelim AS elemdelim,
+                        range_t.rngsubtype AS range_subtype,
+                        CASE
+                        WHEN t.typtype = 'c'
+                        THEN (
+                            SELECT
+                                array_agg(ia.atttypid ORDER BY ia.attnum)
+                            FROM
+                                pg_attribute AS ia
+                                INNER JOIN pg_class AS c ON ia.attrelid = c.oid
+                            WHERE
+                                ia.attnum > 0
+                                AND NOT ia.attisdropped
+                                AND c.reltype = t.oid
+                        )
+                        ELSE NULL
+                        END
+                            AS attrtypoids,
+                        CASE
+                        WHEN t.typtype = 'c'
+                        THEN (
+                            SELECT
+                                array_agg(ia.attname::STRING ORDER BY ia.attnum)
+                            FROM
+                                pg_attribute AS ia
+                                INNER JOIN pg_class AS c ON ia.attrelid = c.oid
+                            WHERE
+                                ia.attnum > 0
+                                AND NOT ia.attisdropped
+                                AND c.reltype = t.oid
+                        )
+                        ELSE NULL
+                        END
+                            AS attrnames
+                    FROM
+                        pg_catalog.pg_type AS t
+                        INNER JOIN pg_catalog.pg_namespace AS ns ON
+                                ns.oid = t.typnamespace
+                        LEFT JOIN pg_type AS elem_t ON
+                                t.typlen = -1
+                                AND t.typelem != 0
+                                AND t.typelem = elem_t.oid
+                        LEFT JOIN pg_range AS range_t ON t.oid = range_t.rngtypid
+                )
+                    AS ti
+            WHERE
+                ti.oid = ANY ARRAY[21, 23]::OID[]
+            UNION ALL
+                SELECT
+                    ti.oid,
+                    ti.ns,
+                    ti.name,
+                    ti.kind,
+                    ti.basetype,
+                    ti.elemtype,
+                    ti.elemdelim,
+                    ti.range_subtype,
+                    ti.attrtypoids,
+                    ti.attrnames,
+                    tt.depth + 1
+                FROM
+                    (
+                        SELECT
+                            t.oid AS oid,
+                            ns.nspname AS ns,
+                            t.typname AS name,
+                            t.typtype AS kind,
+                            CASE
+                            WHEN t.typtype = 'd'
+                            THEN (
+                                WITH RECURSIVE
+                                    typebases (oid, depth)
+                                        AS (
+                                            SELECT
+                                                t2.typbasetype AS oid, 0 AS depth
+                                            FROM
+                                                pg_type AS t2
+                                            WHERE
+                                                t2.oid = t.oid
+                                            UNION ALL
+                                                SELECT
+                                                    t2.typbasetype AS oid,
+                                                    tb.depth + 1 AS depth
+                                                FROM
+                                                    pg_type AS t2, typebases AS tb
+                                                WHERE
+                                                    tb.oid = t2.oid
+                                                    AND t2.typbasetype != 0
+                                        )
+                                SELECT
+                                    oid
+                                FROM
+                                    typebases
+                                ORDER BY
+                                    depth DESC
+                                LIMIT
+                                    1
+                            )
+                            ELSE NULL
+                            END
+                                AS basetype,
+                            t.typelem AS elemtype,
+                            elem_t.typdelim AS elemdelim,
+                            range_t.rngsubtype AS range_subtype,
+                            CASE
+                            WHEN t.typtype = 'c'
+                            THEN (
+                                SELECT
+                                    array_agg(ia.atttypid ORDER BY ia.attnum)
+                                FROM
+                                    pg_attribute AS ia
+                                    INNER JOIN pg_class AS c ON ia.attrelid = c.oid
+                                WHERE
+                                    ia.attnum > 0
+                                    AND NOT ia.attisdropped
+                                    AND c.reltype = t.oid
+                            )
+                            ELSE NULL
+                            END
+                                AS attrtypoids,
+                            CASE
+                            WHEN t.typtype = 'c'
+                            THEN (
+                                SELECT
+                                    array_agg(ia.attname::STRING ORDER BY ia.attnum)
+                                FROM
+                                    pg_attribute AS ia
+                                    INNER JOIN pg_class AS c ON ia.attrelid = c.oid
+                                WHERE
+                                    ia.attnum > 0
+                                    AND NOT ia.attisdropped
+                                    AND c.reltype = t.oid
+                            )
+                            ELSE NULL
+                            END
+                                AS attrnames
+                        FROM
+                            pg_catalog.pg_type AS t
+                            INNER JOIN pg_catalog.pg_namespace AS ns ON
+                                    ns.oid = t.typnamespace
+                            LEFT JOIN pg_type AS elem_t ON
+                                    t.typlen = -1
+                                    AND t.typelem != 0
+                                    AND t.typelem = elem_t.oid
+                            LEFT JOIN pg_range AS range_t ON t.oid = range_t.rngtypid
+                    )
+                        AS ti,
+                    typeinfo_tree AS tt
+                WHERE
+                    (tt.elemtype IS NOT NULL AND ti.oid = tt.elemtype)
+                    OR (tt.attrtypoids IS NOT NULL AND ti.oid = ANY tt.attrtypoids)
+                    OR (tt.range_subtype IS NOT NULL AND ti.oid = tt.range_subtype)
+        )
+SELECT
+    DISTINCT *,
+    basetype::REGTYPE::STRING AS basetype_name,
+    elemtype::REGTYPE::STRING AS elemtype_name,
+    range_subtype::REGTYPE::STRING AS range_subtype_name
+FROM
+    typeinfo_tree
+ORDER BY
+    depth DESC
+----
+21  pg_catalog  int2  b  NULL  0  NULL  NULL  NULL  NULL  0  NULL  -  NULL
+23  pg_catalog  int4  b  NULL  0  NULL  NULL  NULL  NULL  0  NULL  -  NULL

--- a/pkg/sql/logictest/testdata/logic_test/subquery
+++ b/pkg/sql/logictest/testdata/logic_test/subquery
@@ -444,6 +444,174 @@ query I
 SELECT col0 FROM tab4 WHERE (col0 <= 0 AND col4 <= 5.38) OR (col4 IN (SELECT col1 FROM tab4 WHERE col1 > 8.27)) AND (col3 <= 5 AND (col3 BETWEEN 7 AND 9))
 ----
 
+subtest correlated
+
+statement ok
+CREATE TABLE corr (
+  k INT PRIMARY KEY,
+  i INT
+)
+
+statement ok
+INSERT INTO corr VALUES (1, 10), (2, 22), (3, 30), (4, 40), (5, 50)
+
+query II rowsort
+SELECT * FROM corr
+WHERE CASE WHEN k < 5 THEN k*10 = (SELECT i FROM corr tmp WHERE k = corr.k) END
+----
+1  10
+3  30
+4  40
+
+query III colnames,rowsort
+SELECT k, i, CASE WHEN k > 1 THEN (SELECT i FROM corr tmp WHERE k = corr.k-1) END AS prev_i
+FROM corr
+----
+k  i   prev_i
+1  10  NULL
+2  22  10
+3  30  22
+4  40  30
+5  50  40
+
+# A test similar to the previous showing that the physical ordering requested by
+# the ORDER BY is respected when re-optimizing the subquery.
+query IIR colnames,rowsort
+SELECT k, i,
+  CASE WHEN k > 1 THEN (SELECT i/1 FROM corr tmp WHERE i < corr.i ORDER BY i DESC LIMIT 1) END prev_i
+FROM corr
+----
+k  i   prev_i
+1  10  NULL
+2  22  10
+3  30  22
+4  40  30
+5  50  40
+
+# The same query as above, but as a prepared statement with placeholders in the
+# subquery.
+statement ok
+PREPARE corr_s1(INT) AS
+SELECT k, i,
+  CASE WHEN k > 1 THEN (SELECT i/$1 FROM corr tmp WHERE i < corr.i ORDER BY i DESC LIMIT $1) END prev_i
+FROM corr
+
+query IIR colnames,rowsort
+EXECUTE corr_s1(1)
+----
+k  i   prev_i
+1  10  NULL
+2  22  10
+3  30  22
+4  40  30
+5  50  40
+
+# A subquery with a star-expansion.
+query IIR colnames,rowsort
+SELECT k, i,
+  CASE WHEN k > 1 THEN (
+    SELECT * FROM (VALUES (33::DECIMAL)) v(i)
+    UNION ALL
+    SELECT i/1 FROM corr tmp WHERE i < corr.i
+    ORDER BY i DESC LIMIT 1
+  ) END prev_i
+FROM corr
+----
+k  i   prev_i
+1  10  NULL
+2  22  33
+3  30  33
+4  40  33
+5  50  40
+
+# TODO(mgartner): Execute correlated EXISTS subqueries.
+statement error could not decorrelate subquery
+SELECT * FROM corr
+WHERE CASE WHEN k < 5 THEN EXISTS (SELECT i FROM corr tmp WHERE i = corr.k*10) END
+
+# TODO(mgartner): Execute correlated <op> ANY subqueries.
+statement error could not decorrelate subquery
+SELECT * FROM corr
+WHERE CASE WHEN k < 5 THEN k*10 = ANY (SELECT i FROM corr tmp WHERE k <= corr.k) END
+
+# Correlated subqueries can reference outer with expressions.
+query III colnames,rowsort
+WITH w AS MATERIALIZED (
+  (VALUES (1))
+)
+SELECT k, i,
+  CASE WHEN k > 0 THEN (SELECT i+corr.i FROM corr tmp UNION ALL SELECT * FROM w LIMIT 1) END i_plus_first_i
+FROM corr
+----
+k  i   i_plus_first_i
+1  10  20
+2  22  32
+3  30  40
+4  40  50
+5  50  60
+
+# Uncorrelated subqueries within correlated subqueries can reference outer with
+# expressions.
+query III colnames,rowsort
+WITH w AS MATERIALIZED (
+  (VALUES (1))
+)
+SELECT k, i,
+  CASE WHEN k > 0 THEN (SELECT i+corr.i FROM corr tmp WHERE k = (SELECT * FROM w)) END i_plus_first_i
+FROM corr
+----
+k  i   i_plus_first_i
+1  10  20
+2  22  32
+3  30  40
+4  40  50
+5  50  60
+
+# WITH within subquery that is shadowing outer WITH.
+query III colnames,rowsort
+WITH w(i) AS MATERIALIZED (
+  (VALUES (1))
+)
+SELECT k, i,
+  CASE WHEN k > 0 THEN (
+    WITH w(i) AS MATERIALIZED (
+      (VALUES (2))
+    )
+    SELECT * FROM w UNION ALL SELECT i+corr.i FROM corr tmp LIMIT 1
+  ) END w
+FROM corr
+UNION ALL
+SELECT NULL, NULL, i FROM w
+----
+k     i     w
+1     10    2
+2     22    2
+3     30    2
+4     40    2
+5     50    2
+NULL  NULL  1
+
+statement ok
+CREATE TABLE corr2 (i INT);
+
+# A NOT MATERIALIZED CTE with a mutation.
+# TODO(mgartner): Lift this restriction.
+statement error could not decorrelate subquery
+WITH tmp AS NOT MATERIALIZED (INSERT INTO corr2 VALUES (1) RETURNING i)
+SELECT * FROM corr
+WHERE CASE WHEN k < 5 THEN k+1 = (SELECT i FROM tmp WHERE i = corr.k) END
+
+# The statement above should perform the INSERT only once.
+# TODO(mgartner): This should return 1 when the statement above can be executed
+# successfully.
+query I
+SELECT count(*) FROM corr2
+----
+0
+
+
+subtest regressions
+
 statement ok
 CREATE TABLE z (z INT PRIMARY KEY)
 

--- a/pkg/sql/logictest/tests/fakedist-disk/generated_test.go
+++ b/pkg/sql/logictest/tests/fakedist-disk/generated_test.go
@@ -261,6 +261,13 @@ func TestLogic_as_of(
 	runLogicTest(t, "as_of")
 }
 
+func TestLogic_asyncpg(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "asyncpg")
+}
+
 func TestLogic_auto_span_config_reconciliation_job(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/fakedist-vec-off/generated_test.go
+++ b/pkg/sql/logictest/tests/fakedist-vec-off/generated_test.go
@@ -261,6 +261,13 @@ func TestLogic_as_of(
 	runLogicTest(t, "as_of")
 }
 
+func TestLogic_asyncpg(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "asyncpg")
+}
+
 func TestLogic_auto_span_config_reconciliation_job(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/fakedist/generated_test.go
+++ b/pkg/sql/logictest/tests/fakedist/generated_test.go
@@ -261,6 +261,13 @@ func TestLogic_as_of(
 	runLogicTest(t, "as_of")
 }
 
+func TestLogic_asyncpg(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "asyncpg")
+}
+
 func TestLogic_auto_span_config_reconciliation_job(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/local-legacy-schema-changer/generated_test.go
+++ b/pkg/sql/logictest/tests/local-legacy-schema-changer/generated_test.go
@@ -261,6 +261,13 @@ func TestLogic_as_of(
 	runLogicTest(t, "as_of")
 }
 
+func TestLogic_asyncpg(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "asyncpg")
+}
+
 func TestLogic_auto_span_config_reconciliation_job(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/local-vec-off/generated_test.go
+++ b/pkg/sql/logictest/tests/local-vec-off/generated_test.go
@@ -261,6 +261,13 @@ func TestLogic_as_of(
 	runLogicTest(t, "as_of")
 }
 
+func TestLogic_asyncpg(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "asyncpg")
+}
+
 func TestLogic_auto_span_config_reconciliation_job(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/local/generated_test.go
+++ b/pkg/sql/logictest/tests/local/generated_test.go
@@ -261,6 +261,13 @@ func TestLogic_as_of(
 	runLogicTest(t, "as_of")
 }
 
+func TestLogic_asyncpg(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "asyncpg")
+}
+
 func TestLogic_auto_span_config_reconciliation_job(
 	t *testing.T,
 ) {

--- a/pkg/sql/opt/exec/execbuilder/testdata/subquery
+++ b/pkg/sql/opt/exec/execbuilder/testdata/subquery
@@ -451,3 +451,64 @@ vectorized: true
       estimated row count: 1,000 (missing stats)
       table: abc@abc_pkey
       spans: FULL SCAN
+
+statement ok
+CREATE TABLE corr (
+  k INT PRIMARY KEY,
+  i INT,
+  FAMILY (k, i)
+);
+INSERT INTO corr VALUES (1, 10), (2, 22), (3, 30), (4, 40), (5, 50)
+
+# Case where the subquery in a filter cannot be hoisted into an apply-join.
+query T
+EXPLAIN (VERBOSE)
+SELECT * FROM corr
+WHERE CASE WHEN k < 5 THEN k*10 = (SELECT i FROM corr tmp WHERE k = corr.k) END
+----
+distribution: local
+vectorized: true
+·
+• filter
+│ columns: (k, i)
+│ estimated row count: 333 (missing stats)
+│ filter: CASE WHEN k < 5 THEN (k * 10) = subquery(k) ELSE CAST(NULL AS BOOL) END
+│
+└── • scan
+      columns: (k, i)
+      estimated row count: 1,000 (missing stats)
+      table: corr@corr_pkey
+      spans: FULL SCAN
+
+# Case where the subquery in a projection cannot be hoisted into an apply-join.
+query T
+EXPLAIN (VERBOSE)
+SELECT k, i, CASE WHEN k > 1 THEN (SELECT i FROM corr tmp WHERE k = corr.k-1) ELSE 0 END AS prev_i
+FROM corr
+----
+distribution: local
+vectorized: true
+·
+• render
+│ columns: (k, i, prev_i)
+│ render prev_i: CASE WHEN k > 1 THEN subquery(k) ELSE 0 END
+│ render k: k
+│ render i: i
+│
+└── • scan
+      columns: (k, i)
+      estimated row count: 1,000 (missing stats)
+      table: corr@corr_pkey
+      spans: FULL SCAN
+
+# Each invocation of the subquery is re-optimized, so the scans are constrained
+# by constant values substituted for corr.k.
+query T kvtrace
+SELECT k, i, CASE WHEN k > 1 THEN (SELECT i FROM corr tmp WHERE k = corr.k-1) ELSE 0 END AS prev_i
+FROM corr
+----
+Scan /Table/110/{1-2}
+Scan /Table/110/1/1/0
+Scan /Table/110/1/2/0
+Scan /Table/110/1/3/0
+Scan /Table/110/1/4/0


### PR DESCRIPTION
#### opt: create tree.Routine planning closure in helper function

The logic for creating a planning closure for a `tree.Routine` has been
moved to a helper function so that it can be reused in future commits.

Release note: None

#### sql: evaluate correlated subqueries as routines

Previously, the optimizer would error in rare cases when it was unable
to hoist correlated subqueries into apply-joins. Now, scalar, correlated
subqueries that aren't hoisted are executed successfully. There is
remaining work to apply the same method in this commit to `EXISTS` and
`<op> ANY` subqueries.

Hoisting correlated subqueries is not possible when a conditional
expression, like a `CASE`, wraps a subquery that is not leak-proof. One
of the effects of hoisting a subquery is that the subquery will be
unconditionally evaluated. For leak-proof subqueries, the worst case is
that unnecessary computation is performed. For non-leak-proof
subqueries, errors could originate from the subquery when it should have
never been evaluated because the corresponding conditional expression
was never true. So, in order to support these cases, we must be able to
execute a correlated subquery.

A correlated subquery can be thought of as a relational expression with
parameters that need to be filled in with constant value arguments for
each invocation. It is essentially a user-defined function with a single
statement in the function body. So, the `tree.RoutineExpr` machinery
that powers UDFs is easily repurposed to facilitate evaluation of
correlated subqueries.

Fixes #71908
Fixes #73573
Fixes #80169

Release note (sql change): Some queries which previously resulted in the
error "could not decorrelate subquery" now succeed.
