### PR TITLE
release-22.1: kv: campaign on rejected lease request when leader not live in node liveness

### DIFF
--- a/pkg/kv/kvserver/replica_application_state_machine.go
+++ b/pkg/kv/kvserver/replica_application_state_machine.go
@@ -1474,7 +1474,7 @@ func (s *closedTimestampSetterInfo) record(cmd *replicatedCmd, lease *roachpb.Le
 				s.merge = true
 			}
 		}
-	} else if req.IsLeaseRequest() {
+	} else if req.IsSingleRequestLeaseRequest() {
 		// Make a deep copy since we're not allowed to hold on to request
 		// memory.
 		lr, _ := req.GetArg(roachpb.RequestLease)

--- a/pkg/kv/kvserver/replica_proposal.go
+++ b/pkg/kv/kvserver/replica_proposal.go
@@ -731,7 +731,7 @@ func (r *Replica) evaluateProposal(
 
 		// Set the proposal's replicated result, which contains metadata and
 		// side-effects that are to be replicated to all replicas.
-		res.Replicated.IsLeaseRequest = ba.IsLeaseRequest()
+		res.Replicated.IsLeaseRequest = ba.IsSingleRequestLeaseRequest()
 		if ba.AppliesTimestampCache() {
 			res.Replicated.WriteTimestamp = ba.WriteTimestamp()
 		} else {

--- a/pkg/kv/kvserver/replica_proposal_buf.go
+++ b/pkg/kv/kvserver/replica_proposal_buf.go
@@ -451,7 +451,7 @@ func (b *propBuf) FlushLockedWithRaftGroup(
 		// Lease extensions for a currently held lease always go through, to
 		// keep the lease alive until the normal lease transfer mechanism can
 		// colocate it with the leader.
-		if !leaderInfo.iAmTheLeader && p.Request.IsLeaseRequest() {
+		if !leaderInfo.iAmTheLeader && p.Request.IsSingleRequestLeaseRequest() {
 			leaderKnownAndEligible := leaderInfo.leaderKnown && leaderInfo.leaderEligibleForLease
 			ownsCurrentLease := b.p.ownsValidLeaseRLocked(ctx, b.clock.NowAsClockTimestamp())
 			if leaderKnownAndEligible && !ownsCurrentLease && !b.testing.allowLeaseProposalWhenNotLeader {
@@ -619,7 +619,7 @@ func (b *propBuf) allocateLAIAndClosedTimestampLocked(
 	// replays (though they could in principle also be handled like lease
 	// requests).
 	var lai uint64
-	if !p.Request.IsLeaseRequest() {
+	if !p.Request.IsSingleRequestLeaseRequest() {
 		b.assignedLAI++
 		lai = b.assignedLAI
 	}
@@ -674,7 +674,7 @@ func (b *propBuf) allocateLAIAndClosedTimestampLocked(
 	// timestamps carried by lease requests, make sure to resurrect the old
 	// TestRejectedLeaseDoesntDictateClosedTimestamp and protect against that
 	// scenario.
-	if p.Request.IsLeaseRequest() {
+	if p.Request.IsSingleRequestLeaseRequest() {
 		return lai, hlc.Timestamp{}, nil
 	}
 

--- a/pkg/kv/kvserver/replica_proposal_buf.go
+++ b/pkg/kv/kvserver/replica_proposal_buf.go
@@ -141,12 +141,12 @@ type proposer interface {
 	leaseAppliedIndex() uint64
 	enqueueUpdateCheck()
 	closedTimestampTarget() hlc.Timestamp
+	leaderStatus(ctx context.Context, raftGroup proposerRaft) rangeLeaderInfo
+	ownsValidLease(ctx context.Context, now hlc.ClockTimestamp) bool
 
 	// The following require the proposer to hold an exclusive lock.
 	withGroupLocked(func(proposerRaft) error) error
 	registerProposalLocked(*ProposalData)
-	leaderStatusRLocked(ctx context.Context, raftGroup proposerRaft) rangeLeaderInfo
-	ownsValidLeaseRLocked(ctx context.Context, now hlc.ClockTimestamp) bool
 	// rejectProposalWithRedirectLocked rejects a proposal and redirects the
 	// proposer to try it on another node. This is used to sometimes reject lease
 	// acquisitions when another replica is the leader; the intended consequence
@@ -591,7 +591,7 @@ func (b *propBuf) maybeRejectUnsafeProposalLocked(
 			return false
 		}
 		leaderKnownAndEligible := li.leaderKnown && li.leaderEligibleForLease
-		ownsCurrentLease := b.p.ownsValidLeaseRLocked(ctx, b.clock.NowAsClockTimestamp())
+		ownsCurrentLease := b.p.ownsValidLease(ctx, b.clock.NowAsClockTimestamp())
 		if leaderKnownAndEligible && !ownsCurrentLease && !b.testing.allowLeaseProposalWhenNotLeader {
 			log.VEventf(ctx, 2, "not proposing lease acquisition because we're not the leader; replica %d is",
 				li.leader)
@@ -618,7 +618,7 @@ func (b *propBuf) maybeRejectUnsafeProposalLocked(
 // leaderStatusRLocked returns the rangeLeaderInfo for the provided raft group,
 // or an empty rangeLeaderInfo if the raftGroup is nil.
 func (b *propBuf) leaderStatusRLocked(ctx context.Context, raftGroup proposerRaft) rangeLeaderInfo {
-	leaderInfo := b.p.leaderStatusRLocked(ctx, raftGroup)
+	leaderInfo := b.p.leaderStatus(ctx, raftGroup)
 	// Sanity check.
 	if leaderInfo.leaderKnown && leaderInfo.leader == b.p.getReplicaID() &&
 		!leaderInfo.iAmTheLeader {
@@ -1086,7 +1086,7 @@ func (rp *replicaProposer) registerProposalLocked(p *ProposalData) {
 	rp.mu.proposals[p.idKey] = p
 }
 
-func (rp *replicaProposer) leaderStatusRLocked(
+func (rp *replicaProposer) leaderStatus(
 	ctx context.Context, raftGroup proposerRaft,
 ) rangeLeaderInfo {
 	r := (*Replica)(rp)
@@ -1132,7 +1132,7 @@ func (rp *replicaProposer) leaderStatusRLocked(
 	}
 }
 
-func (rp *replicaProposer) ownsValidLeaseRLocked(ctx context.Context, now hlc.ClockTimestamp) bool {
+func (rp *replicaProposer) ownsValidLease(ctx context.Context, now hlc.ClockTimestamp) bool {
 	return (*Replica)(rp).ownsValidLeaseRLocked(ctx, now)
 }
 

--- a/pkg/kv/kvserver/replica_proposal_buf_test.go
+++ b/pkg/kv/kvserver/replica_proposal_buf_test.go
@@ -52,6 +52,8 @@ type testProposer struct {
 	onRejectProposalWithRedirectLocked func(prop *ProposalData, redirectTo roachpb.ReplicaID)
 	// validLease is returned by ownsValidLease()
 	validLease bool
+	// leaderNotLive is returned from shouldCampaignOnRedirect().
+	leaderNotLive bool
 
 	// leaderReplicaInDescriptor is set if the leader (as indicated by raftGroup)
 	// is known, and that leader is part of the range's descriptor (as seen by the
@@ -73,7 +75,8 @@ type testProposerRaft struct {
 	status raft.BasicStatus
 	// proposals are the commands that the propBuf flushed (i.e. passed to the
 	// Raft group) and have not yet been consumed with consumeProposals().
-	proposals []kvserverpb.RaftCommand
+	proposals  []kvserverpb.RaftCommand
+	campaigned bool
 }
 
 var _ proposerRaft = &testProposerRaft{}
@@ -106,6 +109,11 @@ func (t testProposerRaft) BasicStatus() raft.BasicStatus {
 
 func (t testProposerRaft) ProposeConfChange(i raftpb.ConfChangeI) error {
 	// TODO(andrei, nvanbenschoten): Capture the message and test against it.
+	return nil
+}
+
+func (t *testProposerRaft) Campaign() error {
+	t.campaigned = true
 	return nil
 }
 
@@ -161,7 +169,8 @@ func (t *testProposer) registerProposalLocked(p *ProposalData) {
 }
 
 func (t *testProposer) leaderStatus(ctx context.Context, raftGroup proposerRaft) rangeLeaderInfo {
-	leaderKnown := raftGroup.BasicStatus().Lead != raft.None
+	lead := raftGroup.BasicStatus().Lead
+	leaderKnown := lead != raft.None
 	var leaderRep roachpb.ReplicaID
 	var iAmTheLeader, leaderEligibleForLease bool
 	if leaderKnown {
@@ -186,15 +195,19 @@ func (t *testProposer) leaderStatus(ctx context.Context, raftGroup proposerRaft)
 		}
 	}
 	return rangeLeaderInfo{
+		iAmTheLeader:           iAmTheLeader,
 		leaderKnown:            leaderKnown,
 		leader:                 leaderRep,
-		iAmTheLeader:           iAmTheLeader,
 		leaderEligibleForLease: leaderEligibleForLease,
 	}
 }
 
 func (t *testProposer) ownsValidLease(ctx context.Context, now hlc.ClockTimestamp) bool {
 	return t.validLease
+}
+
+func (t *testProposer) shouldCampaignOnRedirect(raftGroup proposerRaft) bool {
+	return t.leaderNotLive
 }
 
 func (t *testProposer) rejectProposalWithRedirectLocked(
@@ -458,10 +471,14 @@ func TestProposalBufferRejectLeaseAcqOnFollower(t *testing.T) {
 		// Set to simulate situations where the local replica is so behind that the
 		// leader is not even part of the range descriptor.
 		leaderNotInRngDesc bool
+		// Set to simulate situations where the Raft leader is not live in the node
+		// liveness map.
+		leaderNotLive bool
 		// If true, the follower has a valid lease.
 		ownsValidLease bool
 
 		expRejection bool
+		expCampaign  bool
 	}{
 		{
 			name:   "leader",
@@ -517,6 +534,17 @@ func TestProposalBufferRejectLeaseAcqOnFollower(t *testing.T) {
 			// FlushLockedWithRaftGroup().
 			expRejection: false,
 		},
+		{
+			name:  "follower, known eligible non-live leader",
+			state: raft.StateFollower,
+			// Someone else is leader.
+			leader:        self + 1,
+			leaderNotLive: true,
+			// Rejection - a follower can't request a lease.
+			expRejection: true,
+			// The leader is non-live, so we should campaign.
+			expCampaign: true,
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			var p testProposer
@@ -553,6 +581,7 @@ func TestProposalBufferRejectLeaseAcqOnFollower(t *testing.T) {
 			p.leaderReplicaInDescriptor = !tc.leaderNotInRngDesc
 			p.leaderReplicaType = tc.leaderRepType
 			p.validLease = tc.ownsValidLease
+			p.leaderNotLive = tc.leaderNotLive
 
 			var b propBuf
 			clock := hlc.NewClock(hlc.UnixNano, time.Nanosecond)
@@ -569,6 +598,7 @@ func TestProposalBufferRejectLeaseAcqOnFollower(t *testing.T) {
 			} else {
 				require.Equal(t, roachpb.ReplicaID(0), rejected)
 			}
+			require.Equal(t, tc.expCampaign, r.campaigned)
 			require.Zero(t, tracker.Count())
 		})
 	}

--- a/pkg/kv/kvserver/replica_rangefeed_test.go
+++ b/pkg/kv/kvserver/replica_rangefeed_test.go
@@ -1210,7 +1210,7 @@ func TestRangefeedCheckpointsRecoverFromLeaseExpiration(t *testing.T) {
 						return nil
 					}
 					nudged := atomic.LoadInt64(&nudgeSeen)
-					if ba.IsLeaseRequest() && (nudged == 1) {
+					if ba.IsSingleRequestLeaseRequest() && (nudged == 1) {
 						return nil
 					}
 					log.Infof(ctx, "test rejecting request: %s", ba)
@@ -1376,7 +1376,7 @@ func TestNewRangefeedForceLeaseRetry(t *testing.T) {
 						return nil
 					}
 					nudged := atomic.LoadInt64(&nudgeSeen)
-					if ba.IsLeaseRequest() && (nudged == 1) {
+					if ba.IsSingleRequestLeaseRequest() && (nudged == 1) {
 						return nil
 					}
 					log.Infof(ctx, "test rejecting request: %s", ba)

--- a/pkg/kv/kvserver/replica_test.go
+++ b/pkg/kv/kvserver/replica_test.go
@@ -11445,6 +11445,117 @@ func TestReplicaShouldCampaignOnWake(t *testing.T) {
 	}
 }
 
+func TestReplicaShouldCampaignOnLeaseRequestRedirect(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	desc := roachpb.RangeDescriptor{
+		RangeID:  1,
+		StartKey: roachpb.RKeyMin,
+		EndKey:   roachpb.RKeyMax,
+		InternalReplicas: []roachpb.ReplicaDescriptor{
+			{
+				ReplicaID: 1,
+				NodeID:    1,
+				StoreID:   1,
+			},
+			{
+				ReplicaID: 2,
+				NodeID:    2,
+				StoreID:   2,
+			},
+			{
+				ReplicaID: 3,
+				NodeID:    3,
+				StoreID:   3,
+			},
+		},
+		NextReplicaID: 4,
+	}
+
+	now := hlc.Timestamp{WallTime: 100}
+	livenessMap := liveness.IsLiveMap{
+		1: liveness.IsLiveMapEntry{
+			IsLive:   true,
+			Liveness: livenesspb.Liveness{Expiration: now.Add(1, 0).ToLegacyTimestamp()},
+		},
+		2: liveness.IsLiveMapEntry{
+			// NOTE: we purposefully set IsLive to true in disagreement with the
+			// Liveness expiration to ensure that we're only looking at node liveness
+			// in shouldCampaignOnLeaseRequestRedirect and not at whether this node is
+			// reachable from the local node.
+			IsLive:   true,
+			Liveness: livenesspb.Liveness{Expiration: now.Add(-1, 0).ToLegacyTimestamp()},
+		},
+	}
+
+	followerWithoutLeader := raft.BasicStatus{
+		SoftState: raft.SoftState{
+			RaftState: raft.StateFollower,
+			Lead:      0,
+		},
+	}
+	followerWithLeader := raft.BasicStatus{
+		SoftState: raft.SoftState{
+			RaftState: raft.StateFollower,
+			Lead:      1,
+		},
+	}
+	candidate := raft.BasicStatus{
+		SoftState: raft.SoftState{
+			RaftState: raft.StateCandidate,
+			Lead:      0,
+		},
+	}
+	leader := raft.BasicStatus{
+		SoftState: raft.SoftState{
+			RaftState: raft.StateLeader,
+			Lead:      1,
+		},
+	}
+	followerDeadLeader := raft.BasicStatus{
+		SoftState: raft.SoftState{
+			RaftState: raft.StateFollower,
+			Lead:      2,
+		},
+	}
+	followerMissingLiveness := raft.BasicStatus{
+		SoftState: raft.SoftState{
+			RaftState: raft.StateFollower,
+			Lead:      3,
+		},
+	}
+	followerMissingDesc := raft.BasicStatus{
+		SoftState: raft.SoftState{
+			RaftState: raft.StateFollower,
+			Lead:      4,
+		},
+	}
+
+	tests := []struct {
+		name                  string
+		raftStatus            raft.BasicStatus
+		requiresExpiringLease bool
+		exp                   bool
+	}{
+		{"candidate", candidate, false, false},
+		{"leader", leader, false, false},
+		{"follower without leader", followerWithoutLeader, false, true},
+		{"follower unknown leader", followerMissingDesc, false, false},
+		{"follower expiration-based lease", followerDeadLeader, true, false},
+		{"follower unknown liveness leader", followerMissingLiveness, false, false},
+		{"follower live leader", followerWithLeader, false, false},
+		{"follower dead leader", followerDeadLeader, false, true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			v := shouldCampaignOnLeaseRequestRedirect(tc.raftStatus, livenessMap, &desc, tc.requiresExpiringLease, now)
+			require.Equal(t, tc.exp, v)
+		})
+	}
+}
+
 func TestRangeStatsRequest(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)

--- a/pkg/roachpb/batch.go
+++ b/pkg/roachpb/batch.go
@@ -147,18 +147,6 @@ func (ba *BatchRequest) UpdateTxn(o *Transaction) {
 	ba.Txn = clonedTxn
 }
 
-// IsLeaseRequest returns whether the batch consists of a single RequestLease
-// request. Note that TransferLease requests return false.
-// RequestLease requests are special because they're the only type of requests a
-// non-lease-holder can propose.
-func (ba *BatchRequest) IsLeaseRequest() bool {
-	if !ba.IsSingleRequest() {
-		return false
-	}
-	_, ok := ba.GetArg(RequestLease)
-	return ok
-}
-
 // AppliesTimestampCache returns whether the command is a write that applies the
 // timestamp cache (and closed timestamp), possibly pushing its write timestamp
 // into the future to avoid re-writing history.
@@ -226,6 +214,15 @@ func (ba *BatchRequest) IsSingleSkipsLeaseCheckRequest() bool {
 
 func (ba *BatchRequest) isSingleRequestWithMethod(m Method) bool {
 	return ba.IsSingleRequest() && ba.Requests[0].GetInner().Method() == m
+}
+
+// IsSingleRequestLeaseRequest returns true iff the batch contains a single
+// request, and that request is a RequestLease. Note that TransferLease requests
+// return false.
+// RequestLease requests are special because they're the only type of requests a
+// non-lease-holder can propose.
+func (ba *BatchRequest) IsSingleRequestLeaseRequest() bool {
+	return ba.isSingleRequestWithMethod(RequestLease)
 }
 
 // IsSingleTransferLeaseRequest returns true iff the batch contains a single

--- a/pkg/testutils/serverutils/test_cluster_shim.go
+++ b/pkg/testutils/serverutils/test_cluster_shim.go
@@ -106,6 +106,17 @@ type TestClusterInterface interface {
 		t testing.TB, startKey roachpb.Key, targets ...roachpb.ReplicationTarget,
 	) roachpb.RangeDescriptor
 
+	// RebalanceVoter rebalances a voting replica from src to dest.
+	RebalanceVoter(
+		ctx context.Context, startKey roachpb.Key, src, dest roachpb.ReplicationTarget,
+	) (*roachpb.RangeDescriptor, error)
+
+	// RebalanceVoterOrFatal rebalances a voting replica from src to dest but wil
+	// fatal if it fails.
+	RebalanceVoterOrFatal(
+		ctx context.Context, t *testing.T, startKey roachpb.Key, src, dest roachpb.ReplicationTarget,
+	) *roachpb.RangeDescriptor
+
 	// SwapVoterWithNonVoter atomically "swaps" the voting replica located on
 	// `voterTarget` with the non-voting replica located on `nonVoterTarget`. A
 	// sequence of ReplicationChanges is considered to have "swapped" a voter on


### PR DESCRIPTION
Backport:
  * 1/1 commits from "kv: clean up BatchRequest.IsLeaseRequest" (#82798)
  * 1/2 commits from "kv: don't allow lease transfers to replicas in need of snapshot" (#82758)
  * 1/1 commits from "kv: don't try to reject lease transfer when flushing proposal buffer" (#83520)
  * 2/2 commits from "kv: campaign on rejected lease request when leader not live in node liveness" (#87244)

Please see individual PRs for details.

/cc @cockroachdb/release

---

Fixes #84655.
Related to #49220.

This commit extends the logic introduced in 8aa1c14 to simultaneously campaign for Raft leadership when rejecting a lease request on a Raft follower that observes that the current Raft leader is not live according to node liveness. These kinds of cases are often associated with asymmetric network partitions. 

In such cases, the Raft leader will be unable to acquire an epoch-based lease until it heartbeats its liveness record. As a result, the range can only regain availability if a different replica acquires the lease. However, the protection added in 8aa1c14 prevents followers from acquiring leases to protect against a different form of unavailability.

After this commit, the followers will attempt to acquire Raft leadership when detecting such cases by campaigning. This allows these ranges to recover availability once Raft leadership moves off the partitioned Raft leader to one of the followers that can reach node liveness and can subsequently acquire the lease.

Campaigning for Raft leadership is safer than blindly allowing the lease request to be proposed (through a redirected proposal). This is because the follower may be arbitrarily far behind on its Raft log and acquiring the lease in such cases could cause unavailability (the kind we saw in #37906). By instead calling a Raft pre-vote election, the follower can determine whether it is behind on its log without risking disruption. If so, we don't want it to acquire the lease — one of the other followers that is caught up on its log can. If not, it will eventually become leader and can proceed with a future attempt to acquire the lease.

The commit adds a test that reproduces the failure mode described in #84655. It creates an asymmetric network partition scenario that looks like:
```
        [0]       raft leader / leaseholder
         ^
        / \
       /   \
      v     v
    [1]<--->[2]   raft followers
      ^     ^
       \   /
        \ /
         v
        [3]       liveness range
```
It then waits for the raft leader's lease to expire and demonstrates that one of the raft followers will now call a Raft election, which allows it to safely grab Raft leadership, acquire the lease, and recover availability. Without the change, the test failed.

----

Release justification: None. Too risky for the stability period. Potential backport candidate after sufficient baking on master.

Release note (bug fix): A bug causing ranges to remain without a leaseholder in cases of asymmetric network partitions has been resolved.
