### PR TITLE
sql: use better identifiers in the rnd schema test

### DIFF
--- a/pkg/ccl/backupccl/backuprand/BUILD.bazel
+++ b/pkg/ccl/backupccl/backuprand/BUILD.bazel
@@ -19,6 +19,7 @@ go_test(
         "//pkg/security/securitytest",
         "//pkg/server",
         "//pkg/sql/randgen",
+        "//pkg/sql/sem/tree",
         "//pkg/testutils",
         "//pkg/testutils/serverutils",
         "//pkg/testutils/skip",

--- a/pkg/sql/randgen/BUILD.bazel
+++ b/pkg/sql/randgen/BUILD.bazel
@@ -44,6 +44,8 @@ go_library(
         "//pkg/util/encoding",
         "//pkg/util/ipaddr",
         "//pkg/util/json",
+        "//pkg/util/randident",
+        "//pkg/util/randident/randidentcfg",
         "//pkg/util/randutil",
         "//pkg/util/timeofday",
         "//pkg/util/timeutil",

--- a/pkg/sql/randgen/schema_test.go
+++ b/pkg/sql/randgen/schema_test.go
@@ -63,12 +63,12 @@ func TestPopulateTableWithRandData(t *testing.T) {
 	// To prevent the test from being flaky, pass the test if PopulateTableWithRandomData
 	// inserts at least one row in at least one table.
 	success := false
-	for i := 1; i <= numTables; i++ {
-		tableName := tablePrefix + fmt.Sprint(i)
+	for i := 0; i < numTables; i++ {
+		tableName := string(stmts[i].(*tree.CreateTable).Table.ObjectName)
 		numRows := 30
 		numRowsInserted, err := randgen.PopulateTableWithRandData(rng, dbConn, tableName, numRows)
 		require.NoError(t, err)
-		res := sqlDB.QueryStr(t, fmt.Sprintf("SELECT count(*) FROM %s", tableName))
+		res := sqlDB.QueryStr(t, fmt.Sprintf("SELECT count(*) FROM %s", tree.NameString(tableName)))
 		require.Equal(t, fmt.Sprint(numRowsInserted), res[0][0])
 		if numRowsInserted > 0 {
 			success = true

--- a/pkg/sql/tests/random_schema_test.go
+++ b/pkg/sql/tests/random_schema_test.go
@@ -62,14 +62,14 @@ func TestCreateRandomSchema(t *testing.T) {
 			t.Fatal(createTable, err)
 		}
 
-		var tabName, tabStmt, secondTabStmt string
+		var quotedTabName, tabStmt, secondTabStmt string
 		if err := db.QueryRow(fmt.Sprintf("SHOW CREATE TABLE %s",
-			createTable.Table.String())).Scan(&tabName, &tabStmt); err != nil {
+			createTable.Table.String())).Scan(&quotedTabName, &tabStmt); err != nil {
 			t.Fatal(err)
 		}
 
-		if tabName != createTable.Table.String() {
-			t.Fatalf("found table name %s, expected %s", tabName, createTable.Table.String())
+		if quotedTabName != createTable.Table.String() {
+			t.Fatalf("found table name %s, expected %s", quotedTabName, createTable.Table.String())
 		}
 
 		// Reparse the show create table statement that's stored in the database.
@@ -88,12 +88,12 @@ func TestCreateRandomSchema(t *testing.T) {
 		}
 
 		if err := db.QueryRow(fmt.Sprintf("SHOW CREATE TABLE %s",
-			tabName)).Scan(&tabName, &secondTabStmt); err != nil {
+			quotedTabName)).Scan(&quotedTabName, &secondTabStmt); err != nil {
 			t.Fatal(err)
 		}
 
-		if tabName != createTable.Table.String() {
-			t.Fatalf("found table name %s, expected %s", tabName, createTable.Table.String())
+		if quotedTabName != createTable.Table.String() {
+			t.Fatalf("found table name %s, expected %s", quotedTabName, createTable.Table.String())
 		}
 		// Reparse the show create table statement that's stored in the database.
 		secondParsed, err := parser.ParseOne(secondTabStmt)

--- a/pkg/workload/insights/BUILD.bazel
+++ b/pkg/workload/insights/BUILD.bazel
@@ -8,6 +8,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/col/coldata",
+        "//pkg/sql/sem/tree",
         "//pkg/sql/types",
         "//pkg/util/bufalloc",
         "//pkg/util/timeutil",
@@ -33,6 +34,7 @@ go_test(
         "//pkg/security/securityassets",
         "//pkg/security/securitytest",
         "//pkg/server",
+        "//pkg/sql/sem/tree",
         "//pkg/testutils/serverutils",
         "//pkg/testutils/sqlutils",
         "//pkg/testutils/testcluster",

--- a/pkg/workload/insights/insights_test.go
+++ b/pkg/workload/insights/insights_test.go
@@ -16,6 +16,7 @@ import (
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
@@ -48,8 +49,8 @@ func TestInsightsWorkload(t *testing.T) {
 
 			insights := FromConfig(test.rows, test.rows, defaultPayloadBytes, test.ranges)
 			insightsTableA := insights.Tables()[0]
-			sqlDB.Exec(t, fmt.Sprintf(`DROP TABLE IF EXISTS %s`, insightsTableA.Name))
-			sqlDB.Exec(t, fmt.Sprintf(`CREATE TABLE %s %s`, insightsTableA.Name, insightsTableA.Schema))
+			sqlDB.Exec(t, fmt.Sprintf(`DROP TABLE IF EXISTS %s`, tree.NameString(insightsTableA.Name)))
+			sqlDB.Exec(t, fmt.Sprintf(`CREATE TABLE %s %s`, tree.NameString(insightsTableA.Name), insightsTableA.Schema))
 
 			if err := workloadsql.Split(ctx, db, insightsTableA, 1 /* concurrency */); err != nil {
 				t.Fatalf("%+v", err)
@@ -57,7 +58,7 @@ func TestInsightsWorkload(t *testing.T) {
 
 			var rangeCount int
 			sqlDB.QueryRow(t,
-				fmt.Sprintf(`SELECT count(*) FROM [SHOW RANGES FROM TABLE %s]`, insightsTableA.Name),
+				fmt.Sprintf(`SELECT count(*) FROM [SHOW RANGES FROM TABLE %s]`, tree.NameString(insightsTableA.Name)),
 			).Scan(&rangeCount)
 			if rangeCount != test.expectedRanges {
 				t.Errorf("got %d ranges expected %d", rangeCount, test.expectedRanges)

--- a/pkg/workload/rand/rand_test.go
+++ b/pkg/workload/rand/rand_test.go
@@ -51,7 +51,7 @@ func TestRandRun(t *testing.T) {
 	s, db, _ := serverutils.StartServer(t, base.TestServerArgs{UseDatabase: dbName})
 	defer s.Stopper().Stop(ctx)
 	sqlDB := sqlutils.MakeSQLRunner(db)
-	sqlDB.Exec(t, "CREATE DATABASE "+dbName)
+	sqlDB.Exec(t, "CREATE DATABASE "+tree.NameString(dbName))
 
 	rng, seed := randutil.NewTestRand()
 	t.Logf("rand workload random seed: %v", seed)
@@ -71,12 +71,13 @@ func TestRandRun(t *testing.T) {
 		unwrapped := tree.UnwrapDOidWrapper(datum)
 
 		t.Run(fmt.Sprintf("%s-%T", sqlName, unwrapped), func(t *testing.T) {
-			sqlDB.Exec(t, fmt.Sprintf("DROP TABLE IF EXISTS %s.%s", dbName, tblName))
+			sqlDB.Exec(t, fmt.Sprintf("DROP TABLE IF EXISTS %s.%s", tree.NameString(dbName), tree.NameString(tblName)))
 			createTableStmt := fmt.Sprintf("CREATE TABLE %s.%s (%s %s)",
-				dbName, tblName, colName, sqlName)
+				tree.NameString(dbName), tree.NameString(tblName), tree.NameString(colName), sqlName)
 			sqlDB.Exec(t, createTableStmt)
 
-			stmt := fmt.Sprintf("INSERT INTO %s.%s (%s) VALUES ($1)", dbName, tblName, colName)
+			stmt := fmt.Sprintf("INSERT INTO %s.%s (%s) VALUES ($1)",
+				tree.NameString(dbName), tree.NameString(tblName), tree.NameString(colName))
 			writeStmt, err := db.Prepare(stmt)
 			require.NoError(t, err)
 

--- a/pkg/workload/schemachange/operation_generator.go
+++ b/pkg/workload/schemachange/operation_generator.go
@@ -3488,7 +3488,7 @@ func (og *operationGenerator) selectStmt(ctx context.Context, tx pgx.Tx) (stmt *
 			selectColumns.WriteString(",")
 		}
 		selectColumns.WriteString(fmt.Sprintf("t%d.", tableIdx))
-		selectColumns.WriteString(col.name)
+		selectColumns.WriteString(tree.NameString(col.name))
 		selectColumns.WriteString(" AS ")
 		selectColumns.WriteString(fmt.Sprintf("col%d", colIdx))
 	}

--- a/pkg/workload/sqlsmith/sqlsmith.go
+++ b/pkg/workload/sqlsmith/sqlsmith.go
@@ -82,7 +82,7 @@ func (g *sqlSmith) Tables() []workload.Table {
 	for idx := 0; idx < g.tables; idx++ {
 		schema := randgen.RandCreateTable(rng, "table", idx, false /* isMultiRegion */)
 		table := workload.Table{
-			Name:   schema.Table.String(),
+			Name:   string(schema.Table.ObjectName),
 			Schema: tree.Serialize(schema),
 		}
 		// workload expects the schema to be missing the CREATE TABLE "name", so

--- a/pkg/workload/workloadsql/BUILD.bazel
+++ b/pkg/workload/workloadsql/BUILD.bazel
@@ -11,6 +11,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/sql/lexbase",
+        "//pkg/sql/sem/tree",
         "//pkg/util/ctxgroup",
         "//pkg/util/errorutil",
         "//pkg/util/log",
@@ -38,6 +39,7 @@ go_test(
         "//pkg/security/securityassets",
         "//pkg/security/securitytest",
         "//pkg/server",
+        "//pkg/sql/sem/tree",
         "//pkg/testutils/serverutils",
         "//pkg/testutils/sqlutils",
         "//pkg/testutils/testcluster",

--- a/pkg/workload/workloadsql/workloadsql.go
+++ b/pkg/workload/workloadsql/workloadsql.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/lexbase"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/util/ctxgroup"
 	"github.com/cockroachdb/cockroach/pkg/util/errorutil"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -164,7 +165,7 @@ func Split(ctx context.Context, db *gosql.DB, table workload.Table, concurrency 
 					split := strings.Join(StringTuple(splitPoints[m]), `,`)
 
 					buf.Reset()
-					fmt.Fprintf(&buf, `ALTER TABLE %s SPLIT AT VALUES (%s)`, table.Name, split)
+					fmt.Fprintf(&buf, `ALTER TABLE %s SPLIT AT VALUES (%s)`, tree.NameString(table.Name), split)
 					// If you're investigating an error coming out of this Exec, see the
 					// HACK comment in ColBatchToRows for some context that may (or may
 					// not) help you.
@@ -180,7 +181,7 @@ func Split(ctx context.Context, db *gosql.DB, table workload.Table, concurrency 
 
 					buf.Reset()
 					fmt.Fprintf(&buf, `ALTER TABLE %s SCATTER FROM (%s) TO (%s)`,
-						table.Name, split, split)
+						tree.NameString(table.Name), split, split)
 					stmt = buf.String()
 					if _, err := db.Exec(stmt); err != nil {
 						// SCATTER can collide with normal replicate queue


### PR DESCRIPTION
This extends TestRandomSchema to use the new random identifier generator.

Release note: None
Epic: None