### PR TITLE
sem/tree: fix the formatting of backup options

### DIFF
--- a/pkg/sql/parser/testdata/backup_restore
+++ b/pkg/sql/parser/testdata/backup_restore
@@ -346,6 +346,16 @@ BACKUP TABLE (foo) TO ('bar') WITH revision_history = (true), detached, kms = ((
 BACKUP TABLE foo TO '_' WITH revision_history = _, detached, kms = ('_', '_') -- literals removed
 BACKUP TABLE _ TO 'bar' WITH revision_history = true, detached, kms = ('foo', 'bar') -- identifiers removed
 
+
+# Regression test for #95235.
+parse
+BACKUP foo TO 'bar' WITH OPTIONS (detached = false)
+----
+BACKUP TABLE foo TO 'bar' WITH detached = FALSE -- normalized!
+BACKUP TABLE (foo) TO ('bar') WITH detached = FALSE -- fully parenthesized
+BACKUP TABLE foo TO '_' WITH detached = FALSE -- literals removed
+BACKUP TABLE _ TO 'bar' WITH detached = FALSE -- identifiers removed
+
 parse
 BACKUP TENANT 36 TO 'bar'
 ----

--- a/pkg/sql/sem/tree/backup.go
+++ b/pkg/sql/sem/tree/backup.go
@@ -272,9 +272,12 @@ func (o *BackupOptions) Format(ctx *FmtCtx) {
 		}
 	}
 
-	if o.Detached == DBoolTrue {
+	if o.Detached != nil {
 		maybeAddSep()
 		ctx.WriteString("detached")
+		if o.Detached != DBoolTrue {
+			ctx.WriteString(" = FALSE")
+		}
 	}
 
 	if o.EncryptionKMSURI != nil {
@@ -334,7 +337,8 @@ func (o *BackupOptions) CombineWith(other *BackupOptions) error {
 func (o BackupOptions) IsDefault() bool {
 	options := BackupOptions{}
 	return o.CaptureRevisionHistory == options.CaptureRevisionHistory &&
-		o.Detached == options.Detached && cmp.Equal(o.EncryptionKMSURI, options.EncryptionKMSURI) &&
+		o.Detached == options.Detached &&
+		cmp.Equal(o.EncryptionKMSURI, options.EncryptionKMSURI) &&
 		o.EncryptionPassphrase == options.EncryptionPassphrase &&
 		cmp.Equal(o.IncrementalStorage, options.IncrementalStorage)
 }


### PR DESCRIPTION
Fixes #89054.
Fixes #95235.

Found using TestRandomSyntax.

Release note: None