### PR TITLE
sqlsmith: use more varied random identifiers

### DIFF
--- a/pkg/internal/sqlsmith/BUILD.bazel
+++ b/pkg/internal/sqlsmith/BUILD.bazel
@@ -33,6 +33,8 @@ go_library(
         "//pkg/sql/sem/tree/treewindow",
         "//pkg/sql/sem/volatility",
         "//pkg/sql/types",
+        "//pkg/util/randident",
+        "//pkg/util/randident/randidentcfg",
         "//pkg/util/syncutil",
         "//pkg/util/timeutil",
         "@com_github_cockroachdb_errors//:errors",


### PR DESCRIPTION
To complement #95239.

This makes the generated identifiers more "interesting" and exercises more code paths for quoting identifiers in TestRandomSyntax.

Release note: None
Epic: None