### PR TITLE
storage: disallow nil settings in StorageConfig

### DIFF
--- a/pkg/base/config.go
+++ b/pkg/base/config.go
@@ -721,7 +721,7 @@ type StorageConfig struct {
 	// BallastSize is the amount reserved by a ballast file for manual
 	// out-of-disk recovery.
 	BallastSize int64
-	// Settings instance for cluster-wide knobs.
+	// Settings instance for cluster-wide knobs. Must not be nil.
 	Settings *cluster.Settings
 	// UseFileRegistry is true if the file registry is needed (eg: encryption-at-rest).
 	// This may force the store version to versionFileRegistry if currently lower.

--- a/pkg/ccl/cliccl/BUILD.bazel
+++ b/pkg/ccl/cliccl/BUILD.bazel
@@ -62,6 +62,7 @@ go_test(
         "//pkg/ccl/storageccl/engineccl",
         "//pkg/cli",
         "//pkg/server",
+        "//pkg/settings/cluster",
         "//pkg/storage",
         "//pkg/testutils/serverutils",
         "//pkg/util/envutil",

--- a/pkg/ccl/cliccl/ear_test.go
+++ b/pkg/ccl/cliccl/ear_test.go
@@ -22,6 +22,7 @@ import (
 	// NewEncryptedEnvFunc in `pkg/storage`.
 	_ "github.com/cockroachdb/cockroach/pkg/ccl/storageccl/engineccl"
 	"github.com/cockroachdb/cockroach/pkg/cli"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/util/envutil"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
@@ -49,7 +50,7 @@ func TestDecrypt(t *testing.T) {
 	require.NoError(t, err)
 	encOpts, err := encSpec.ToEncryptionOptions()
 	require.NoError(t, err)
-	p, err := storage.Open(ctx, storage.Filesystem(dir), storage.EncryptionAtRest(encOpts))
+	p, err := storage.Open(ctx, storage.Filesystem(dir), cluster.MakeClusterSettings(), storage.EncryptionAtRest(encOpts))
 	require.NoError(t, err)
 
 	// Find a manifest file to check.
@@ -128,7 +129,7 @@ func TestList(t *testing.T) {
 	require.NoError(t, err)
 	encOpts, err := encSpec.ToEncryptionOptions()
 	require.NoError(t, err)
-	p, err := storage.Open(ctx, storage.Filesystem(dir), storage.EncryptionAtRest(encOpts))
+	p, err := storage.Open(ctx, storage.Filesystem(dir), cluster.MakeClusterSettings(), storage.EncryptionAtRest(encOpts))
 	require.NoError(t, err)
 
 	// Write a key and flush, to create a table in the store.

--- a/pkg/ccl/storageccl/engineccl/bench_test.go
+++ b/pkg/ccl/storageccl/engineccl/bench_test.go
@@ -55,7 +55,7 @@ func loadTestData(
 	eng, err := storage.Open(
 		ctx,
 		storage.Filesystem(dir),
-		storage.Settings(cluster.MakeTestingClusterSettings()))
+		cluster.MakeTestingClusterSettings())
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/ccl/storageccl/engineccl/encrypted_fs_test.go
+++ b/pkg/ccl/storageccl/engineccl/encrypted_fs_test.go
@@ -294,6 +294,7 @@ func TestPebbleEncryption(t *testing.T) {
 		context.Background(),
 		storage.PebbleConfig{
 			StorageConfig: base.StorageConfig{
+				Settings:          cluster.MakeTestingClusterSettings(),
 				Attrs:             roachpb.Attributes{},
 				MaxSize:           512 << 20,
 				UseFileRegistry:   true,
@@ -380,6 +381,7 @@ func TestPebbleEncryption2(t *testing.T) {
 			context.Background(),
 			storage.PebbleConfig{
 				StorageConfig: base.StorageConfig{
+					Settings:          cluster.MakeTestingClusterSettings(),
 					Attrs:             roachpb.Attributes{},
 					MaxSize:           512 << 20,
 					UseFileRegistry:   true,

--- a/pkg/cli/debug.go
+++ b/pkg/cli/debug.go
@@ -170,11 +170,12 @@ func OpenEngine(
 	if err != nil {
 		return nil, err
 	}
-	db, err := storage.Open(context.Background(),
+	db, err := storage.Open(
+		context.Background(),
 		storage.Filesystem(dir),
+		serverCfg.Settings,
 		storage.MaxOpenFiles(int(maxOpenFiles)),
 		storage.CacheSize(server.DefaultCacheSize),
-		storage.Settings(serverCfg.Settings),
 		storage.Hook(PopulateStorageConfigHook),
 		storage.CombineOptions(opts...))
 	if err != nil {

--- a/pkg/cli/debug_check_store_test.go
+++ b/pkg/cli/debug_check_store_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/stateloader"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
@@ -83,6 +84,7 @@ func TestDebugCheckStore(t *testing.T) {
 	func() {
 		eng, err := storage.Open(ctx,
 			storage.Filesystem(storePaths[0]),
+			cluster.MakeClusterSettings(),
 			storage.CacheSize(10<<20 /* 10 MiB */),
 			storage.MustExist)
 		require.NoError(t, err)

--- a/pkg/cli/debug_test.go
+++ b/pkg/cli/debug_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/gossip"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/server"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
@@ -37,6 +38,7 @@ func createStore(t *testing.T, path string) {
 	db, err := storage.Open(
 		context.Background(),
 		storage.Filesystem(path),
+		cluster.MakeClusterSettings(),
 		storage.CacheSize(server.DefaultCacheSize))
 	if err != nil {
 		t.Fatal(err)

--- a/pkg/cli/syncbench/syncbench.go
+++ b/pkg/cli/syncbench/syncbench.go
@@ -141,8 +141,8 @@ func Run(opts Options) error {
 	db, err := storage.Open(
 		context.Background(),
 		storage.Filesystem(opts.Dir),
-		storage.CacheSize(0),
-		storage.Settings(cluster.MakeTestingClusterSettings()))
+		cluster.MakeTestingClusterSettings(),
+		storage.CacheSize(0))
 	if err != nil {
 		return err
 	}

--- a/pkg/kv/kvserver/batcheval/cmd_export_test.go
+++ b/pkg/kv/kvserver/batcheval/cmd_export_test.go
@@ -686,7 +686,7 @@ func TestRandomKeyAndTimestampExport(t *testing.T) {
 	st := cluster.MakeTestingClusterSettings()
 	mkEngine := func(t *testing.T) (e storage.Engine, cleanup func()) {
 		dir, cleanupDir := testutils.TempDir(t)
-		e, err := storage.Open(ctx, storage.Filesystem(dir), storage.CacheSize(0), storage.Settings(st))
+		e, err := storage.Open(ctx, storage.Filesystem(dir), st, storage.CacheSize(0))
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/pkg/kv/kvserver/consistency_queue_test.go
+++ b/pkg/kv/kvserver/consistency_queue_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/stateloader"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/server"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
@@ -382,7 +383,7 @@ func TestCheckConsistencyInconsistent(t *testing.T) {
 		// VFS to verify its contents.
 		fs, err := stickyEngineRegistry.GetUnderlyingFS(base.StoreSpec{StickyInMemoryEngineID: strconv.FormatInt(int64(i), 10)})
 		assert.NoError(t, err)
-		cpEng := storage.InMemFromFS(context.Background(), fs, cps[0], storage.CacheSize(1<<20))
+		cpEng := storage.InMemFromFS(context.Background(), fs, cps[0], cluster.MakeClusterSettings(), storage.CacheSize(1<<20))
 		defer cpEng.Close()
 
 		// Find the problematic range in the storage.
@@ -520,6 +521,7 @@ func testConsistencyQueueRecomputeStatsImpl(t *testing.T, hadEstimates bool) {
 	func() {
 		eng, err := storage.Open(ctx,
 			storage.Filesystem(path),
+			cluster.MakeClusterSettings(),
 			storage.CacheSize(1<<20 /* 1 MiB */),
 			storage.MustExist)
 		require.NoError(t, err)

--- a/pkg/kv/kvserver/logstore/sideload_test.go
+++ b/pkg/kv/kvserver/logstore/sideload_test.go
@@ -566,6 +566,7 @@ func newOnDiskEngine(ctx context.Context, t *testing.T) (func(), storage.Engine)
 	eng, err := storage.Open(
 		ctx,
 		storage.Filesystem(dir),
+		cluster.MakeClusterSettings(),
 		storage.CacheSize(1<<20 /* 1 MiB */))
 	if err != nil {
 		t.Fatal(err)

--- a/pkg/kv/kvserver/loqrecovery/BUILD.bazel
+++ b/pkg/kv/kvserver/loqrecovery/BUILD.bazel
@@ -70,6 +70,7 @@ go_test(
         "//pkg/security/securitytest",
         "//pkg/server",
         "//pkg/server/serverpb",
+        "//pkg/settings/cluster",
         "//pkg/storage",
         "//pkg/storage/enginepb",
         "//pkg/testutils",

--- a/pkg/kv/kvserver/loqrecovery/recovery_env_test.go
+++ b/pkg/kv/kvserver/loqrecovery/recovery_env_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/raftlog"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/stateloader"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
@@ -495,6 +496,7 @@ func (e *quorumRecoveryEnv) getOrCreateStore(
 		var err error
 		eng, err := storage.Open(ctx,
 			storage.InMemory(),
+			cluster.MakeClusterSettings(),
 			storage.CacheSize(1<<20 /* 1 MiB */))
 		if err != nil {
 			t.Fatalf("failed to crate in mem store: %v", err)

--- a/pkg/kv/kvserver/rditer/replica_data_iter_test.go
+++ b/pkg/kv/kvserver/rditer/replica_data_iter_test.go
@@ -522,8 +522,8 @@ func benchReplicaEngineDataIterator(b *testing.B, numRanges, numKeysPerRange, va
 	// Write data for ranges.
 	eng, err := storage.Open(ctx,
 		storage.Filesystem(b.TempDir()),
-		storage.CacheSize(1e9),
-		storage.Settings(cluster.MakeTestingClusterSettings()))
+		cluster.MakeTestingClusterSettings(),
+		storage.CacheSize(1e9))
 	require.NoError(b, err)
 	defer eng.Close()
 

--- a/pkg/kv/kvserver/replica_sst_snapshot_storage_test.go
+++ b/pkg/kv/kvserver/replica_sst_snapshot_storage_test.go
@@ -332,6 +332,7 @@ func newOnDiskEngine(ctx context.Context, t *testing.T) (func(), storage.Engine)
 	eng, err := storage.Open(
 		ctx,
 		storage.Filesystem(dir),
+		cluster.MakeClusterSettings(),
 		storage.CacheSize(1<<20 /* 1 MiB */))
 	if err != nil {
 		t.Fatal(err)

--- a/pkg/kv/kvserver/store_snapshot.go
+++ b/pkg/kv/kvserver/store_snapshot.go
@@ -1340,6 +1340,7 @@ func SendEmptySnapshot(
 	eng, err := storage.Open(
 		context.Background(),
 		storage.InMemory(),
+		cluster.MakeClusterSettings(),
 		storage.CacheSize(1<<20 /* 1 MiB */),
 		storage.MaxSize(512<<20 /* 512 MiB */))
 	if err != nil {

--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -724,7 +724,6 @@ func (cfg *Config) CreateEngines(ctx context.Context) (Engines, error) {
 					storage.CacheSize(cfg.CacheSize),
 					storage.MaxSize(sizeInBytes),
 					storage.EncryptionAtRest(spec.EncryptionOptions),
-					storage.Settings(cfg.Settings),
 					storage.If(storeKnobs.SmallEngineBlocks, storage.BlockSize(1)),
 				}
 				if len(storeKnobs.EngineKnobs) > 0 {
@@ -732,6 +731,7 @@ func (cfg *Config) CreateEngines(ctx context.Context) (Engines, error) {
 				}
 				e, err := storage.Open(ctx,
 					storage.InMemory(),
+					cfg.Settings,
 					storageConfigs...,
 				)
 				if err != nil {

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -40,6 +40,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/server/serverpb"
 	"github.com/cockroachdb/cockroach/pkg/server/status/statuspb"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/storage"
@@ -1071,7 +1072,7 @@ func TestAssertEnginesEmpty(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	ctx := context.Background()
-	eng, err := storage.Open(ctx, storage.InMemory())
+	eng, err := storage.Open(ctx, storage.InMemory(), cluster.MakeClusterSettings())
 	require.NoError(t, err)
 	defer eng.Close()
 

--- a/pkg/server/settings_cache_test.go
+++ b/pkg/server/settings_cache_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/closedts"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
@@ -45,6 +46,7 @@ func TestCachedSettingsStoreAndLoad(t *testing.T) {
 
 	ctx := context.Background()
 	engine, err := storage.Open(ctx, storage.InMemory(),
+		cluster.MakeClusterSettings(),
 		storage.MaxSize(512<<20 /* 512 MiB */),
 		storage.ForTesting)
 	require.NoError(t, err)

--- a/pkg/server/sticky_engine.go
+++ b/pkg/server/sticky_engine.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
@@ -157,15 +158,11 @@ func (registry *stickyInMemEnginesRegistryImpl) GetOrCreateStickyInMemEngine(
 	}
 
 	log.Infof(ctx, "creating new sticky in-mem engine %s", spec.StickyInMemoryEngineID)
-	engine := storage.InMemFromFS(ctx, fs, "", options...)
+	engine := storage.InMemFromFS(ctx, fs, "", cluster.MakeClusterSettings(), options...)
 
 	engineEntry := &stickyInMemEngine{
 		id:     spec.StickyInMemoryEngineID,
 		closed: false,
-		// This engine will stay alive after the node dies, so we don't want the
-		// caller to pass in a *cluster.Settings from the current node. Just
-		// create a random one since that is what we like to do in tests (for
-		// better test coverage).
 		Engine: engine,
 		fs:     fs,
 	}

--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -281,6 +281,7 @@ func makeTestConfigFromParams(params base.TestServerArgs) Config {
 	cfg.Stores = base.StoreSpecList{Specs: params.StoreSpecs}
 	if params.TempStorageConfig.InMemory || params.TempStorageConfig.Path != "" {
 		cfg.TempStorageConfig = params.TempStorageConfig
+		cfg.TempStorageConfig.Settings = st
 	}
 
 	cfg.DisableDefaultTestTenant = params.DisableDefaultTestTenant

--- a/pkg/sql/colflow/vectorized_flow_test.go
+++ b/pkg/sql/colflow/vectorized_flow_test.go
@@ -269,7 +269,7 @@ func TestVectorizedFlowTempDirectory(t *testing.T) {
 	// We use an on-disk engine for this test since we're testing FS interactions
 	// and want to get the same behavior as a non-testing environment.
 	tempPath, dirCleanup := testutils.TempDir(t)
-	ngn, err := storage.Open(ctx, storage.Filesystem(tempPath), storage.CacheSize(0))
+	ngn, err := storage.Open(ctx, storage.Filesystem(tempPath), cluster.MakeClusterSettings(), storage.CacheSize(0))
 	require.NoError(t, err)
 	defer ngn.Close()
 	defer dirCleanup()

--- a/pkg/sql/rowcontainer/row_container_test.go
+++ b/pkg/sql/rowcontainer/row_container_test.go
@@ -195,7 +195,14 @@ func TestDiskBackedRowContainer(t *testing.T) {
 	ctx := context.Background()
 	st := cluster.MakeTestingClusterSettings()
 	evalCtx := eval.MakeTestingEvalContext(st)
-	tempEngine, _, err := storage.NewTempEngine(ctx, base.TempStorageConfig{InMemory: true}, base.DefaultTestStoreSpec)
+	tempEngine, _, err := storage.NewTempEngine(
+		ctx,
+		base.TempStorageConfig{
+			InMemory: true,
+			Settings: st,
+		},
+		base.DefaultTestStoreSpec,
+	)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -351,7 +358,14 @@ func TestDiskBackedRowContainerDeDuping(t *testing.T) {
 	ctx := context.Background()
 	st := cluster.MakeTestingClusterSettings()
 	evalCtx := eval.MakeTestingEvalContext(st)
-	tempEngine, _, err := storage.NewTempEngine(ctx, base.TempStorageConfig{InMemory: true}, base.DefaultTestStoreSpec)
+	tempEngine, _, err := storage.NewTempEngine(
+		ctx,
+		base.TempStorageConfig{
+			InMemory: true,
+			Settings: st,
+		},
+		base.DefaultTestStoreSpec,
+	)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -471,7 +485,14 @@ func TestDiskBackedIndexedRowContainer(t *testing.T) {
 	ctx := context.Background()
 	st := cluster.MakeTestingClusterSettings()
 	evalCtx := eval.MakeTestingEvalContext(st)
-	tempEngine, _, err := storage.NewTempEngine(ctx, base.TempStorageConfig{InMemory: true}, base.DefaultTestStoreSpec)
+	tempEngine, _, err := storage.NewTempEngine(
+		ctx,
+		base.TempStorageConfig{
+			InMemory: true,
+			Settings: st,
+		},
+		base.DefaultTestStoreSpec,
+	)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -935,7 +956,14 @@ func BenchmarkDiskBackedIndexedRowContainer(b *testing.B) {
 	ctx := context.Background()
 	st := cluster.MakeTestingClusterSettings()
 	evalCtx := eval.MakeTestingEvalContext(st)
-	tempEngine, _, err := storage.NewTempEngine(ctx, base.TempStorageConfig{InMemory: true}, base.DefaultTestStoreSpec)
+	tempEngine, _, err := storage.NewTempEngine(
+		ctx,
+		base.TempStorageConfig{
+			InMemory: true,
+			Settings: st,
+		},
+		base.DefaultTestStoreSpec,
+	)
 	if err != nil {
 		b.Fatal(err)
 	}

--- a/pkg/storage/batch_test.go
+++ b/pkg/storage/batch_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/iterutil"
@@ -856,7 +857,7 @@ func TestDecodeKey(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	e, err := Open(context.Background(), InMemory(), CacheSize(1<<20 /* 1 MiB */))
+	e, err := Open(context.Background(), InMemory(), cluster.MakeClusterSettings(), CacheSize(1<<20 /* 1 MiB */))
 	assert.NoError(t, err)
 	defer e.Close()
 

--- a/pkg/storage/bench_data_test.go
+++ b/pkg/storage/bench_data_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
@@ -103,7 +104,7 @@ func getInitialStateEngine(
 		testutils.ReadAllFiles(filepath.Join(testRunDir, "*"))
 
 		loc := Filesystem(testRunDir)
-		e, err := Open(ctx, loc, opts...)
+		e, err := Open(ctx, loc, cluster.MakeClusterSettings(), opts...)
 		require.NoError(b, err)
 		return engineWithLocation{Engine: e, Location: loc}
 	}
@@ -124,7 +125,7 @@ func getInitialStateEngine(
 	}
 
 	loc := Location{fs: fs}
-	e, err := Open(ctx, loc, opts...)
+	e, err := Open(ctx, loc, cluster.MakeClusterSettings(), opts...)
 	require.NoError(b, err)
 	return engineWithLocation{Engine: e, Location: loc}
 }
@@ -156,7 +157,8 @@ func buildInitialState(
 		buildFS = vfs.NewMem()
 
 		var err error
-		e, err := Open(ctx, Location{fs: buildFS}, opts...)
+		e, err := Open(ctx, Location{fs: buildFS}, cluster.MakeClusterSettings(), opts...)
+
 		require.NoError(b, err)
 
 		require.NoError(b, initial.Build(ctx, b, e))

--- a/pkg/storage/bench_pebble_test.go
+++ b/pkg/storage/bench_pebble_test.go
@@ -35,8 +35,8 @@ func setupMVCCPebble(b testing.TB, dir string) Engine {
 	peb, err := Open(
 		context.Background(),
 		Filesystem(dir),
-		CacheSize(testCacheSize),
-		Settings(cluster.MakeTestingClusterSettings()))
+		cluster.MakeTestingClusterSettings(),
+		CacheSize(testCacheSize))
 	if err != nil {
 		b.Fatalf("could not create new pebble instance at %s: %+v", dir, err)
 	}
@@ -51,6 +51,7 @@ func setupMVCCInMemPebbleWithSeparatedIntents(b testing.TB) Engine {
 	peb, err := Open(
 		context.Background(),
 		InMemory(),
+		cluster.MakeClusterSettings(),
 		CacheSize(testCacheSize))
 	if err != nil {
 		b.Fatalf("could not create new in-mem pebble instance: %+v", err)
@@ -66,7 +67,7 @@ func setupPebbleInMemPebbleForLatestRelease(b testing.TB, _ string) Engine {
 		b.Fatalf("failed to set current cluster version: %+v", err)
 	}
 
-	peb, err := Open(ctx, InMemory(), CacheSize(testCacheSize), Settings(s))
+	peb, err := Open(ctx, InMemory(), s, CacheSize(testCacheSize))
 	if err != nil {
 		b.Fatalf("could not create new in-mem pebble instance: %+v", err)
 	}

--- a/pkg/storage/bench_test.go
+++ b/pkg/storage/bench_test.go
@@ -663,7 +663,7 @@ func loadTestData(dir string, numKeys, numBatches, batchTimeSpan, valueBytes int
 	eng, err := Open(
 		context.Background(),
 		Filesystem(dir),
-		Settings(cluster.MakeTestingClusterSettings()))
+		cluster.MakeTestingClusterSettings())
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/storage/disk_map_test.go
+++ b/pkg/storage/disk_map_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/diskmap"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/datapathutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
@@ -173,7 +174,10 @@ func TestPebbleMap(t *testing.T) {
 	dir, cleanup := testutils.TempDir(t)
 	defer cleanup()
 
-	e, _, err := NewPebbleTempEngine(ctx, base.TempStorageConfig{Path: dir}, base.StoreSpec{})
+	e, _, err := NewPebbleTempEngine(ctx, base.TempStorageConfig{
+		Path:     dir,
+		Settings: cluster.MakeClusterSettings(),
+	}, base.StoreSpec{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -189,7 +193,10 @@ func TestPebbleMultiMap(t *testing.T) {
 	dir, cleanup := testutils.TempDir(t)
 	defer cleanup()
 
-	e, _, err := NewPebbleTempEngine(ctx, base.TempStorageConfig{Path: dir}, base.StoreSpec{})
+	e, _, err := NewPebbleTempEngine(ctx, base.TempStorageConfig{
+		Path:     dir,
+		Settings: cluster.MakeClusterSettings(),
+	}, base.StoreSpec{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -205,7 +212,10 @@ func TestPebbleMapClose(t *testing.T) {
 	ctx := context.Background()
 	dir, cleanup := testutils.TempDir(t)
 	defer cleanup()
-	e, _, err := newPebbleTempEngine(ctx, base.TempStorageConfig{Path: dir}, base.StoreSpec{})
+	e, _, err := newPebbleTempEngine(ctx, base.TempStorageConfig{
+		Path:     dir,
+		Settings: cluster.MakeClusterSettings(),
+	}, base.StoreSpec{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -309,7 +319,10 @@ func TestPebbleMapClose(t *testing.T) {
 func BenchmarkPebbleMapWrite(b *testing.B) {
 	dir := b.TempDir()
 	ctx := context.Background()
-	tempEngine, _, err := NewPebbleTempEngine(ctx, base.TempStorageConfig{Path: dir}, base.DefaultTestStoreSpec)
+	tempEngine, _, err := NewPebbleTempEngine(ctx, base.TempStorageConfig{
+		Path:     dir,
+		Settings: cluster.MakeClusterSettings(),
+	}, base.DefaultTestStoreSpec)
 	if err != nil {
 		b.Fatal(err)
 	}
@@ -347,7 +360,10 @@ func BenchmarkPebbleMapIteration(b *testing.B) {
 	skip.UnderShort(b)
 	dir := b.TempDir()
 	ctx := context.Background()
-	tempEngine, _, err := NewPebbleTempEngine(ctx, base.TempStorageConfig{Path: dir}, base.DefaultTestStoreSpec)
+	tempEngine, _, err := NewPebbleTempEngine(ctx, base.TempStorageConfig{
+		Path:     dir,
+		Settings: cluster.MakeClusterSettings(),
+	}, base.DefaultTestStoreSpec)
 	if err != nil {
 		b.Fatal(err)
 	}

--- a/pkg/storage/min_version_test.go
+++ b/pkg/storage/min_version_test.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/pebble"
@@ -91,7 +92,7 @@ func TestSetMinVersion(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	p, err := Open(context.Background(), InMemory(), CacheSize(0))
+	p, err := Open(context.Background(), InMemory(), cluster.MakeClusterSettings(), CacheSize(0))
 	require.NoError(t, err)
 	defer p.Close()
 	require.Equal(t, pebble.FormatMostCompatible, p.db.FormatMajorVersion())
@@ -119,6 +120,7 @@ func TestMinVersion_IsNotEncrypted(t *testing.T) {
 	p, err := Open(
 		context.Background(),
 		Location{dir: "", fs: fs},
+		cluster.MakeClusterSettings(),
 		EncryptionAtRest(nil))
 	require.NoError(t, err)
 	defer p.Close()

--- a/pkg/storage/mvcc_history_test.go
+++ b/pkg/storage/mvcc_history_test.go
@@ -184,9 +184,8 @@ func TestMVCCHistories(t *testing.T) {
 		disableSeparateEngineBlocks := strings.Contains(path, "_disable_separate_engine_blocks")
 
 		// We start from a clean slate in every test file.
-		engine, err := storage.Open(ctx, storage.InMemory(),
+		engine, err := storage.Open(ctx, storage.InMemory(), st,
 			storage.CacheSize(1<<20 /* 1 MiB */),
-			storage.Settings(st),
 			storage.If(separateEngineBlocks && !disableSeparateEngineBlocks, storage.BlockSize(1)),
 		)
 		require.NoError(t, err)

--- a/pkg/storage/mvcc_incremental_iterator_test.go
+++ b/pkg/storage/mvcc_incremental_iterator_test.go
@@ -1309,7 +1309,7 @@ func TestMVCCIncrementalIteratorIntentStraddlesSStables(t *testing.T) {
 	// regular MVCCPut operation to generate these keys, which we'll later be
 	// copying into manually created sstables.
 	ctx := context.Background()
-	db1, err := Open(ctx, InMemory(), ForTesting)
+	db1, err := Open(ctx, InMemory(), cluster.MakeClusterSettings(), ForTesting)
 	require.NoError(t, err)
 	defer db1.Close()
 
@@ -1342,7 +1342,7 @@ func TestMVCCIncrementalIteratorIntentStraddlesSStables(t *testing.T) {
 	//   SSTable 2:
 	//     a@2
 	//     b@1
-	db2, err := Open(ctx, InMemory(), ForTesting)
+	db2, err := Open(ctx, InMemory(), cluster.MakeTestingClusterSettings(), ForTesting)
 	require.NoError(t, err)
 	defer db2.Close()
 
@@ -1572,6 +1572,7 @@ func BenchmarkMVCCIncrementalIteratorForOldData(b *testing.B) {
 		eng, err := Open(
 			context.Background(),
 			InMemory(),
+			cluster.MakeClusterSettings(),
 			// Use a small cache size. Scanning large tables with mostly cold data
 			// will mostly miss the cache (especially since the block cache is meant
 			// to be scan resistant).

--- a/pkg/storage/mvcc_test.go
+++ b/pkg/storage/mvcc_test.go
@@ -3679,7 +3679,7 @@ func generateBytes(rng *rand.Rand, min int, max int) []byte {
 }
 
 func createEngWithSeparatedIntents(t *testing.T) Engine {
-	eng, err := Open(context.Background(), InMemory(), MaxSize(1<<20))
+	eng, err := Open(context.Background(), InMemory(), cluster.MakeClusterSettings(), MaxSize(1<<20))
 	require.NoError(t, err)
 	return eng
 }
@@ -3917,11 +3917,13 @@ func TestRandomizedSavepointRollbackAndIntentResolution(t *testing.T) {
 	fmt.Printf("seed: %d\n", seed)
 	rng := rand.New(rand.NewSource(seed))
 	ctx := context.Background()
-	eng, err := Open(context.Background(), InMemory(), func(cfg *engineConfig) error {
-		cfg.Opts.LBaseMaxBytes = int64(100 + rng.Intn(16384))
-		log.Infof(ctx, "lbase: %d", cfg.Opts.LBaseMaxBytes)
-		return nil
-	})
+	eng, err := Open(
+		context.Background(), InMemory(), cluster.MakeClusterSettings(),
+		func(cfg *engineConfig) error {
+			cfg.Opts.LBaseMaxBytes = int64(100 + rng.Intn(16384))
+			log.Infof(ctx, "lbase: %d", cfg.Opts.LBaseMaxBytes)
+			return nil
+		})
 	require.NoError(t, err)
 	defer eng.Close()
 

--- a/pkg/storage/open.go
+++ b/pkg/storage/open.go
@@ -248,6 +248,8 @@ func Open(ctx context.Context, loc Location, opts ...ConfigOption) (*Pebble, err
 		defer cfg.Opts.Cache.Unref()
 	}
 	if cfg.Settings == nil {
+		// TODO(radu): this seems error-prone; should we require the use of
+		// Settings() in all cases?
 		cfg.Settings = cluster.MakeClusterSettings()
 	}
 	p, err := NewPebble(ctx, cfg.PebbleConfig)

--- a/pkg/storage/pebble_iterator_test.go
+++ b/pkg/storage/pebble_iterator_test.go
@@ -37,7 +37,7 @@ func TestPebbleIterator_Corruption(t *testing.T) {
 	// Create a Pebble DB that can be used to back a pebbleIterator.
 	dir := t.TempDir()
 	dataDir := filepath.Join(dir, "data")
-	p, err := Open(context.Background(), Filesystem(dataDir))
+	p, err := Open(context.Background(), Filesystem(dataDir), cluster.MakeClusterSettings())
 	require.NoError(t, err)
 	defer p.Close()
 

--- a/pkg/storage/pebble_mvcc_scanner_test.go
+++ b/pkg/storage/pebble_mvcc_scanner_test.go
@@ -35,6 +35,7 @@ func TestMVCCScanWithManyVersionsAndSeparatedIntents(t *testing.T) {
 
 	// We default to separated intents enabled.
 	eng, err := Open(context.Background(), InMemory(),
+		cluster.MakeClusterSettings(),
 		CacheSize(1<<20))
 	require.NoError(t, err)
 	defer eng.Close()

--- a/pkg/storage/pebble_test.go
+++ b/pkg/storage/pebble_test.go
@@ -256,7 +256,7 @@ func TestPebbleMetricEventListener(t *testing.T) {
 
 	settings := cluster.MakeTestingClusterSettings()
 	MaxSyncDurationFatalOnExceeded.Override(ctx, &settings.SV, false)
-	p, err := Open(ctx, InMemory(), CacheSize(1<<20 /* 1 MiB */), Settings(settings))
+	p, err := Open(ctx, InMemory(), settings, CacheSize(1<<20 /* 1 MiB */))
 	require.NoError(t, err)
 	defer p.Close()
 
@@ -547,7 +547,7 @@ func TestPebbleBackgroundError(t *testing.T) {
 			errorCount: 3,
 		},
 	}
-	eng, err := Open(context.Background(), loc)
+	eng, err := Open(context.Background(), loc, cluster.MakeClusterSettings())
 	require.NoError(t, err)
 	defer eng.Close()
 
@@ -1206,7 +1206,8 @@ func TestFSOpenFd(t *testing.T) {
 	defer log.Scope(t).Close(t)
 	dir := t.TempDir()
 
-	eng, err := Open(context.Background(), Filesystem(dir), ForTesting, MaxSize(1<<20))
+	eng, err := Open(context.Background(), Filesystem(dir), cluster.MakeClusterSettings(),
+		ForTesting, MaxSize(1<<20))
 	require.NoError(t, err)
 	defer eng.Close()
 

--- a/pkg/storage/read_as_of_iterator_test.go
+++ b/pkg/storage/read_as_of_iterator_test.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -34,7 +35,7 @@ func TestReadAsOfIterator(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	pebble, err := Open(context.Background(), InMemory(), CacheSize(1<<20 /* 1 MiB */))
+	pebble, err := Open(context.Background(), InMemory(), cluster.MakeClusterSettings(), CacheSize(1<<20 /* 1 MiB */))
 	require.NoError(t, err)
 	defer pebble.Close()
 
@@ -108,7 +109,7 @@ func TestReadAsOfIteratorSeek(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	pebble, err := Open(context.Background(), InMemory(), CacheSize(1<<20 /* 1 MiB */))
+	pebble, err := Open(context.Background(), InMemory(), cluster.MakeClusterSettings(), CacheSize(1<<20 /* 1 MiB */))
 	require.NoError(t, err)
 	defer pebble.Close()
 

--- a/pkg/storage/sst_test.go
+++ b/pkg/storage/sst_test.go
@@ -63,7 +63,10 @@ func TestCheckSSTConflictsMaxIntents(t *testing.T) {
 	sstWriter.Close()
 
 	ctx := context.Background()
-	engine := NewDefaultInMemForTesting(Settings(cs))
+	engine, err := Open(context.Background(), InMemory(), cs, MaxSize(1<<20))
+	if err != nil {
+		t.Fatal(err)
+	}
 	defer engine.Close()
 
 	// Write some committed keys and intents at txn1TS.

--- a/pkg/storage/temp_engine.go
+++ b/pkg/storage/temp_engine.go
@@ -75,6 +75,7 @@ func newPebbleTempEngine(
 	}
 
 	p, err := Open(ctx, loc,
+		tempStorage.Settings,
 		CacheSize(cacheSize),
 		func(cfg *engineConfig) error {
 			cfg.UseFileRegistry = storeSpec.UseFileRegistry

--- a/pkg/storage/temp_engine_test.go
+++ b/pkg/storage/temp_engine_test.go
@@ -15,6 +15,7 @@ import (
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -28,7 +29,10 @@ func TestNewPebbleTempEngine(t *testing.T) {
 	tempDir, tempDirCleanup := testutils.TempDir(t)
 	defer tempDirCleanup()
 
-	db, fs, err := NewPebbleTempEngine(context.Background(), base.TempStorageConfig{Path: tempDir}, base.StoreSpec{Path: tempDir})
+	db, fs, err := NewPebbleTempEngine(context.Background(), base.TempStorageConfig{
+		Path:     tempDir,
+		Settings: cluster.MakeTestingClusterSettings(),
+	}, base.StoreSpec{Path: tempDir})
 	if err != nil {
 		t.Fatalf("error encountered when invoking NewRocksDBTempEngine: %+v", err)
 	}

--- a/pkg/testutils/colcontainerutils/BUILD.bazel
+++ b/pkg/testutils/colcontainerutils/BUILD.bazel
@@ -7,6 +7,7 @@ go_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/testutils/colcontainerutils",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/settings/cluster",
         "//pkg/sql/colcontainer",
         "//pkg/storage",
         "//pkg/testutils",

--- a/pkg/testutils/colcontainerutils/diskqueuecfg.go
+++ b/pkg/testutils/colcontainerutils/diskqueuecfg.go
@@ -14,6 +14,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/colcontainer"
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
@@ -45,6 +46,7 @@ func NewTestingDiskQueueCfg(t testing.TB, inMem bool) (colcontainer.DiskQueueCfg
 	ngn, err := storage.Open(
 		context.Background(),
 		loc,
+		cluster.MakeClusterSettings(),
 		storage.ForTesting,
 		storage.CacheSize(0))
 	if err != nil {

--- a/pkg/testutils/localtestcluster/local_test_cluster.go
+++ b/pkg/testutils/localtestcluster/local_test_cluster.go
@@ -151,6 +151,7 @@ func (ltc *LocalTestCluster) Start(t testing.TB, baseCtx *base.Config, initFacto
 	ltc.Eng, err = storage.Open(
 		ctx,
 		storage.InMemory(),
+		cfg.Settings,
 		storage.CacheSize(0),
 		storage.MaxSize(50<<20 /* 50 MiB */),
 	)


### PR DESCRIPTION
Tolerating nil settings is tedious and error-prone. We don't want these settings to be unset in production paths. This change makes it non-optional.

Release note: None