### PR TITLE
sem/tree: avoid heap allocs during pretty-printing

### DIFF
--- a/pkg/sql/alter_function.go
+++ b/pkg/sql/alter_function.go
@@ -148,7 +148,7 @@ func (n *alterFunctionRenameNode) startExec(params runParams) error {
 	if existing != nil {
 		return pgerror.Newf(
 			pgcode.DuplicateFunction, "function %s already exists in schema %q",
-			tree.AsString(maybeExistingFuncObj), scDesc.GetName(),
+			tree.AsString(&maybeExistingFuncObj), scDesc.GetName(),
 		)
 	}
 
@@ -312,7 +312,7 @@ func (n *alterFunctionSetSchemaNode) startExec(params runParams) error {
 	if existing != nil {
 		return pgerror.Newf(
 			pgcode.DuplicateFunction, "function %s already exists in schema %q",
-			tree.AsString(maybeExistingFuncObj), targetSc.GetName(),
+			tree.AsString(&maybeExistingFuncObj), targetSc.GetName(),
 		)
 	}
 

--- a/pkg/sql/alter_function.go
+++ b/pkg/sql/alter_function.go
@@ -140,7 +140,7 @@ func (n *alterFunctionRenameNode) startExec(params runParams) error {
 
 	maybeExistingFuncObj := fnDesc.ToFuncObj()
 	maybeExistingFuncObj.FuncName.ObjectName = n.n.NewName
-	existing, err := params.p.matchUDF(params.ctx, &maybeExistingFuncObj, false /* required */)
+	existing, err := params.p.matchUDF(params.ctx, maybeExistingFuncObj, false /* required */)
 	if err != nil {
 		return err
 	}
@@ -148,7 +148,7 @@ func (n *alterFunctionRenameNode) startExec(params runParams) error {
 	if existing != nil {
 		return pgerror.Newf(
 			pgcode.DuplicateFunction, "function %s already exists in schema %q",
-			tree.AsString(&maybeExistingFuncObj), scDesc.GetName(),
+			tree.AsString(maybeExistingFuncObj), scDesc.GetName(),
 		)
 	}
 
@@ -305,14 +305,14 @@ func (n *alterFunctionSetSchemaNode) startExec(params runParams) error {
 	maybeExistingFuncObj := fnDesc.ToFuncObj()
 	maybeExistingFuncObj.FuncName.SchemaName = tree.Name(targetSc.GetName())
 	maybeExistingFuncObj.FuncName.ExplicitSchema = true
-	existing, err := params.p.matchUDF(params.ctx, &maybeExistingFuncObj, false /* required */)
+	existing, err := params.p.matchUDF(params.ctx, maybeExistingFuncObj, false /* required */)
 	if err != nil {
 		return err
 	}
 	if existing != nil {
 		return pgerror.Newf(
 			pgcode.DuplicateFunction, "function %s already exists in schema %q",
-			tree.AsString(&maybeExistingFuncObj), targetSc.GetName(),
+			tree.AsString(maybeExistingFuncObj), targetSc.GetName(),
 		)
 	}
 

--- a/pkg/sql/catalog/funcdesc/func_desc.go
+++ b/pkg/sql/catalog/funcdesc/func_desc.go
@@ -504,8 +504,8 @@ func (desc *Mutable) SetParentSchemaID(id descpb.ID) {
 }
 
 // ToFuncObj converts the descriptor to a tree.FuncObj.
-func (desc *immutable) ToFuncObj() tree.FuncObj {
-	ret := tree.FuncObj{
+func (desc *immutable) ToFuncObj() *tree.FuncObj {
+	ret := &tree.FuncObj{
 		FuncName: tree.MakeFunctionNameFromPrefix(tree.ObjectNamePrefix{}, tree.Name(desc.Name)),
 		Params:   make(tree.FuncParams, len(desc.Params)),
 	}

--- a/pkg/sql/sem/tree/alter_database.go
+++ b/pkg/sql/sem/tree/alter_database.go
@@ -131,11 +131,11 @@ func (node *AlterDatabaseAddSuperRegion) Format(ctx *FmtCtx) {
 	ctx.WriteString(" ADD SUPER REGION ")
 	ctx.FormatNode(&node.SuperRegionName)
 	ctx.WriteString(" VALUES ")
-	for i, region := range node.Regions {
+	for i := range node.Regions {
 		if i != 0 {
 			ctx.WriteString(",")
 		}
-		ctx.FormatNode(&region)
+		ctx.FormatNode(&node.Regions[i])
 	}
 }
 
@@ -173,11 +173,11 @@ func (node *AlterDatabaseAlterSuperRegion) Format(ctx *FmtCtx) {
 	ctx.WriteString(" ALTER SUPER REGION ")
 	ctx.FormatNode(&node.SuperRegionName)
 	ctx.WriteString(" VALUES ")
-	for i, region := range node.Regions {
+	for i := range node.Regions {
 		if i != 0 {
 			ctx.WriteString(",")
 		}
-		ctx.FormatNode(&region)
+		ctx.FormatNode(&node.Regions[i])
 	}
 }
 

--- a/pkg/sql/sem/tree/alter_default_privileges.go
+++ b/pkg/sql/sem/tree/alter_default_privileges.go
@@ -40,11 +40,11 @@ func (n *AlterDefaultPrivileges) Format(ctx *FmtCtx) {
 		ctx.WriteString("FOR ALL ROLES ")
 	} else if len(n.Roles) > 0 {
 		ctx.WriteString("FOR ROLE ")
-		for i, role := range n.Roles {
+		for i := range n.Roles {
 			if i > 0 {
 				ctx.WriteString(", ")
 			}
-			ctx.FormatNode(&role)
+			ctx.FormatNode(&n.Roles[i])
 		}
 		ctx.WriteString(" ")
 	}

--- a/pkg/sql/sem/tree/changefeed.go
+++ b/pkg/sql/sem/tree/changefeed.go
@@ -89,11 +89,11 @@ type ChangefeedTargets []ChangefeedTarget
 
 // Format implements the NodeFormatter interface.
 func (cts *ChangefeedTargets) Format(ctx *FmtCtx) {
-	for i, ct := range *cts {
+	for i := range *cts {
 		if i > 0 {
 			ctx.WriteString(", ")
 		}
-		ctx.FormatNode(&ct)
+		ctx.FormatNode(&(*cts)[i])
 	}
 }
 

--- a/pkg/sql/sem/tree/create.go
+++ b/pkg/sql/sem/tree/create.go
@@ -381,7 +381,8 @@ func (node *CreateType) Format(ctx *FmtCtx) {
 		ctx.WriteString(")")
 	case Composite:
 		ctx.WriteString("AS (")
-		for i, elem := range node.CompositeTypeList {
+		for i := range node.CompositeTypeList {
+			elem := &node.CompositeTypeList[i]
 			if i != 0 {
 				ctx.WriteString(", ")
 			}

--- a/pkg/sql/sem/tree/create.go
+++ b/pkg/sql/sem/tree/create.go
@@ -2228,10 +2228,10 @@ func (node *SuperRegion) Format(ctx *FmtCtx) {
 	ctx.WriteString(" SUPER REGION ")
 	ctx.FormatNode(&node.Name)
 	ctx.WriteString(" VALUES ")
-	for i, region := range node.Regions {
+	for i := range node.Regions {
 		if i != 0 {
 			ctx.WriteString(",")
 		}
-		ctx.FormatNode(&region)
+		ctx.FormatNode(&node.Regions[i])
 	}
 }

--- a/pkg/sql/sem/tree/pretty.go
+++ b/pkg/sql/sem/tree/pretty.go
@@ -1121,8 +1121,9 @@ func (node *Tuple) doc(p *PrettyCfg) pretty.Doc {
 	d := p.bracket("(", exprDoc, ")")
 	if len(node.Labels) > 0 {
 		labels := make([]pretty.Doc, len(node.Labels))
-		for i, n := range node.Labels {
-			labels[i] = p.Doc((*Name)(&n))
+		for i := range node.Labels {
+			n := &node.Labels[i]
+			labels[i] = p.Doc((*Name)(n))
 		}
 		d = p.bracket("(", pretty.Stack(
 			d,

--- a/pkg/sql/sem/tree/show.go
+++ b/pkg/sql/sem/tree/show.go
@@ -1231,11 +1231,11 @@ func (n *ShowDefaultPrivileges) Format(ctx *FmtCtx) {
 	ctx.WriteString("SHOW DEFAULT PRIVILEGES ")
 	if len(n.Roles) > 0 {
 		ctx.WriteString("FOR ROLE ")
-		for i, role := range n.Roles {
+		for i := range n.Roles {
 			if i > 0 {
 				ctx.WriteString(", ")
 			}
-			ctx.FormatNode(&role)
+			ctx.FormatNode(&n.Roles[i])
 		}
 		ctx.WriteString(" ")
 	} else if n.ForAllRoles {

--- a/pkg/sql/sem/tree/udf.go
+++ b/pkg/sql/sem/tree/udf.go
@@ -280,11 +280,11 @@ type FuncParams []FuncParam
 
 // Format implements the NodeFormatter interface.
 func (node FuncParams) Format(ctx *FmtCtx) {
-	for i, arg := range node {
+	for i := range node {
 		if i > 0 {
 			ctx.WriteString(", ")
 		}
-		ctx.FormatNode(&arg)
+		ctx.FormatNode(&node[i])
 	}
 }
 
@@ -367,11 +367,11 @@ type FuncObjs []FuncObj
 
 // Format implements the NodeFormatter interface.
 func (node FuncObjs) Format(ctx *FmtCtx) {
-	for i, f := range node {
+	for i := range node {
 		if i > 0 {
 			ctx.WriteString(", ")
 		}
-		ctx.FormatNode(f)
+		ctx.FormatNode(&node[i])
 	}
 }
 
@@ -382,7 +382,7 @@ type FuncObj struct {
 }
 
 // Format implements the NodeFormatter interface.
-func (node FuncObj) Format(ctx *FmtCtx) {
+func (node *FuncObj) Format(ctx *FmtCtx) {
 	ctx.FormatNode(&node.FuncName)
 	if node.Params != nil {
 		ctx.WriteString("(")
@@ -419,7 +419,7 @@ type AlterFunctionOptions struct {
 // Format implements the NodeFormatter interface.
 func (node *AlterFunctionOptions) Format(ctx *FmtCtx) {
 	ctx.WriteString("ALTER FUNCTION ")
-	ctx.FormatNode(node.Function)
+	ctx.FormatNode(&node.Function)
 	for _, option := range node.Options {
 		ctx.WriteString(" ")
 		ctx.FormatNode(option)
@@ -435,7 +435,7 @@ type AlterFunctionRename struct {
 // Format implements the NodeFormatter interface.
 func (node *AlterFunctionRename) Format(ctx *FmtCtx) {
 	ctx.WriteString("ALTER FUNCTION ")
-	ctx.FormatNode(node.Function)
+	ctx.FormatNode(&node.Function)
 	ctx.WriteString(" RENAME TO ")
 	ctx.WriteString(string(node.NewName))
 }
@@ -449,7 +449,7 @@ type AlterFunctionSetSchema struct {
 // Format implements the NodeFormatter interface.
 func (node *AlterFunctionSetSchema) Format(ctx *FmtCtx) {
 	ctx.WriteString("ALTER FUNCTION ")
-	ctx.FormatNode(node.Function)
+	ctx.FormatNode(&node.Function)
 	ctx.WriteString(" SET SCHEMA ")
 	ctx.WriteString(string(node.NewSchemaName))
 }
@@ -463,7 +463,7 @@ type AlterFunctionSetOwner struct {
 // Format implements the NodeFormatter interface.
 func (node *AlterFunctionSetOwner) Format(ctx *FmtCtx) {
 	ctx.WriteString("ALTER FUNCTION ")
-	ctx.FormatNode(node.Function)
+	ctx.FormatNode(&node.Function)
 	ctx.WriteString(" OWNER TO ")
 	ctx.FormatNode(&node.NewOwner)
 }
@@ -478,7 +478,7 @@ type AlterFunctionDepExtension struct {
 // Format implements the NodeFormatter interface.
 func (node *AlterFunctionDepExtension) Format(ctx *FmtCtx) {
 	ctx.WriteString("ALTER FUNCTION  ")
-	ctx.FormatNode(node.Function)
+	ctx.FormatNode(&node.Function)
 	if node.Remove {
 		ctx.WriteString(" NO")
 	}


### PR DESCRIPTION
Everywhere applicable, change
```go
  for i, xxx := range yyy {
      ctx.FormatNode(&xxx)
  }
```
to:
```go
  for i := range yyy {
      ctx.FormatNode(&yyy[i])
  }
```

Epic: None