### PR TITLE
release-22.2: ui: fix polling for statement and transaction details pages

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetails.fixture.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetails.fixture.ts
@@ -17,6 +17,8 @@ import { StatementDetailsResponse } from "../api";
 
 const history = createMemoryHistory({ initialEntries: ["/statements"] });
 
+const lastUpdated = moment("Nov 28 2022 01:30:00 GMT");
+
 const statementDetailsNoData: StatementDetailsResponse = {
   statement: {
     metadata: {
@@ -777,6 +779,7 @@ export const getStatementDetailsPropsFixture = (
     },
   },
   isLoading: false,
+  lastUpdated: lastUpdated,
   timeScale: {
     windowSize: moment.duration(5, "day"),
     sampleSize: moment.duration(5, "minutes"),

--- a/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetails.selectors.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetails.selectors.ts
@@ -22,6 +22,8 @@ import {
 import { cockroach } from "@cockroachlabs/crdb-protobuf-client";
 import { TimeScale, toRoundedDateRange } from "../timeScaleDropdown";
 import { selectTimeScale } from "../statementsPage/statementsPage.selectors";
+import moment from "moment";
+
 type StatementDetailsResponseMessage =
   cockroach.server.serverpb.StatementDetailsResponse;
 
@@ -41,6 +43,7 @@ export const selectStatementDetails = createSelector(
     statementDetails: StatementDetailsResponseMessage;
     isLoading: boolean;
     lastError: Error;
+    lastUpdated: moment.Moment | null;
   } => {
     // Since the aggregation interval is 1h, we want to round the selected timeScale to include
     // the full hour. If a timeScale is between 14:32 - 15:17 we want to search for values
@@ -59,9 +62,15 @@ export const selectStatementDetails = createSelector(
         statementDetails: statementDetailsStatsData[key].data,
         isLoading: statementDetailsStatsData[key].inFlight,
         lastError: statementDetailsStatsData[key].lastError,
+        lastUpdated: statementDetailsStatsData[key].lastUpdated,
       };
     }
-    return { statementDetails: null, isLoading: true, lastError: null };
+    return {
+      statementDetails: null,
+      isLoading: true,
+      lastError: null,
+      lastUpdated: null,
+    };
   },
 );
 

--- a/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetailsConnected.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetailsConnected.ts
@@ -57,10 +57,8 @@ const CancelStatementDiagnosticsReportRequest =
 // For tenant cases, we don't show information about node, regions and
 // diagnostics.
 const mapStateToProps = (state: AppState, props: RouteComponentProps) => {
-  const { statementDetails, isLoading, lastError } = selectStatementDetails(
-    state,
-    props,
-  );
+  const { statementDetails, isLoading, lastError, lastUpdated } =
+    selectStatementDetails(state, props);
   return {
     statementFingerprintID: getMatchParamByName(props.match, statementAttr),
     statementDetails,
@@ -68,6 +66,7 @@ const mapStateToProps = (state: AppState, props: RouteComponentProps) => {
     latestQuery: state.adminUI.sqlDetailsStats.latestQuery,
     latestFormattedQuery: state.adminUI.sqlDetailsStats.latestFormattedQuery,
     statementsError: lastError,
+    lastUpdated: lastUpdated,
     timeScale: selectTimeScale(state),
     nodeNames: selectIsTenant(state) ? {} : nodeDisplayNameByIDSelector(state),
     nodeRegions: selectIsTenant(state) ? {} : nodeRegionsByIDSelector(state),

--- a/pkg/ui/workspaces/cluster-ui/src/store/statementDetails/statementDetails.reducer.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/store/statementDetails/statementDetails.reducer.ts
@@ -17,12 +17,14 @@ import {
   StatementDetailsResponseWithKey,
 } from "src/api/statementsApi";
 import { generateStmtDetailsToID } from "../../util";
+import moment from "moment";
 
 export type SQLDetailsStatsState = {
   data: StatementDetailsResponse;
   lastError: Error;
   valid: boolean;
   inFlight: boolean;
+  lastUpdated: moment.Moment | null;
 };
 
 export type SQLDetailsStatsReducerState = {
@@ -52,6 +54,7 @@ const sqlDetailsStatsSlice = createSlice({
         valid: true,
         lastError: null,
         inFlight: false,
+        lastUpdated: moment.utc(),
       };
     },
     failed: (state, action: PayloadAction<ErrorWithKey>) => {
@@ -60,6 +63,7 @@ const sqlDetailsStatsSlice = createSlice({
         valid: false,
         lastError: action.payload.err,
         inFlight: false,
+        lastUpdated: moment.utc(),
       };
     },
     invalidated: (state, action: PayloadAction<{ key: string }>) => {
@@ -85,6 +89,7 @@ const sqlDetailsStatsSlice = createSlice({
         valid: false,
         lastError: null,
         inFlight: true,
+        lastUpdated: null,
       };
     },
     request: (state, action: PayloadAction<StatementDetailsRequest>) => {
@@ -101,6 +106,7 @@ const sqlDetailsStatsSlice = createSlice({
         valid: false,
         lastError: null,
         inFlight: true,
+        lastUpdated: null,
       };
     },
     setLatestQuery: (state, action: PayloadAction<string>) => {

--- a/pkg/ui/workspaces/cluster-ui/src/store/statementDetails/statementDetails.sagas.spec.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/store/statementDetails/statementDetails.sagas.spec.ts
@@ -28,10 +28,24 @@ import {
   reducer,
   SQLDetailsStatsReducerState,
 } from "./statementDetails.reducer";
+
+import moment from "moment";
+
+const lastUpdated = moment();
+
 export type StatementDetailsRequest =
   cockroach.server.serverpb.StatementDetailsRequest;
 
 describe("SQLDetailsStats sagas", () => {
+  let spy: jest.SpyInstance;
+  beforeAll(() => {
+    spy = jest.spyOn(moment, "utc").mockImplementation(() => lastUpdated);
+  });
+
+  afterAll(() => {
+    spy.mockRestore();
+  });
+
   const action: PayloadAction<StatementDetailsRequest> = {
     payload: cockroach.server.serverpb.StatementDetailsRequest.create({
       fingerprint_id: "SELECT * FROM crdb_internal.node_build_info",
@@ -665,6 +679,7 @@ describe("SQLDetailsStats sagas", () => {
                 lastError: null,
                 valid: true,
                 inFlight: false,
+                lastUpdated: lastUpdated,
               },
           },
           latestQuery: "",
@@ -692,6 +707,7 @@ describe("SQLDetailsStats sagas", () => {
                 lastError: error,
                 valid: false,
                 inFlight: false,
+                lastUpdated: lastUpdated,
               },
           },
           latestQuery: "",

--- a/pkg/ui/workspaces/cluster-ui/src/store/statementDetails/statementDetails.sagas.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/store/statementDetails/statementDetails.sagas.ts
@@ -9,7 +9,7 @@
 // licenses/APL.txt.
 
 import { PayloadAction } from "@reduxjs/toolkit";
-import { all, call, put, delay, takeLatest } from "redux-saga/effects";
+import { all, call, put, takeLatest } from "redux-saga/effects";
 import {
   ErrorWithKey,
   getStatementDetails,
@@ -17,7 +17,6 @@ import {
   StatementDetailsResponseWithKey,
 } from "src/api/statementsApi";
 import { actions as sqlDetailsStatsActions } from "./statementDetails.reducer";
-import { CACHE_INVALIDATION_PERIOD } from "src/store/utils";
 import { generateStmtDetailsToID } from "../../util";
 
 export function* refreshSQLDetailsStatsSaga(
@@ -53,28 +52,9 @@ export function* requestSQLDetailsStatsSaga(
   }
 }
 
-export function receivedSQLDetailsStatsSagaFactory(delayMs: number) {
-  return function* receivedSQLDetailsStatsSaga(
-    action: PayloadAction<StatementDetailsResponseWithKey>,
-  ) {
-    yield delay(delayMs);
-    yield put(
-      sqlDetailsStatsActions.invalidated({
-        key: action?.payload.key,
-      }),
-    );
-  };
-}
-
-export function* sqlDetailsStatsSaga(
-  cacheInvalidationPeriod: number = CACHE_INVALIDATION_PERIOD,
-) {
+export function* sqlDetailsStatsSaga() {
   yield all([
     takeLatest(sqlDetailsStatsActions.refresh, refreshSQLDetailsStatsSaga),
     takeLatest(sqlDetailsStatsActions.request, requestSQLDetailsStatsSaga),
-    takeLatest(
-      sqlDetailsStatsActions.received,
-      receivedSQLDetailsStatsSagaFactory(cacheInvalidationPeriod),
-    ),
   ]);
 }

--- a/pkg/ui/workspaces/cluster-ui/src/transactionDetails/transactionDetails.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionDetails/transactionDetails.tsx
@@ -70,8 +70,9 @@ import {
   timeScaleToString,
   toRoundedDateRange,
 } from "../timeScaleDropdown";
-import timeScaleStyles from "../timeScaleDropdown/timeScale.module.scss";
+import moment from "moment";
 
+import timeScaleStyles from "../timeScaleDropdown/timeScale.module.scss";
 const { containerClass } = tableClasses;
 const cx = classNames.bind(statementsStyles);
 const timeScaleStylesCx = classNames.bind(timeScaleStyles);
@@ -92,6 +93,7 @@ export interface TransactionDetailsStateProps {
   transaction: Transaction;
   transactionFingerprintId: string;
   isLoading: boolean;
+  lastUpdated: moment.Moment | null;
 }
 
 export interface TransactionDetailsDispatchProps {
@@ -126,6 +128,8 @@ export class TransactionDetails extends React.Component<
   TransactionDetailsProps,
   TState
 > {
+  refreshDataTimeout: NodeJS.Timeout;
+
   constructor(props: TransactionDetailsProps) {
     super(props);
     this.state = {
@@ -146,7 +150,7 @@ export class TransactionDetails extends React.Component<
     // where the value 10/30 min is selected on the Metrics page.
     const ts = getValidOption(this.props.timeScale, timeScale1hMinOptions);
     if (ts !== this.props.timeScale) {
-      this.props.onTimeScaleChange(ts);
+      this.changeTimeScale(ts);
     }
   }
 
@@ -188,18 +192,64 @@ export class TransactionDetails extends React.Component<
     }
   };
 
+  changeTimeScale = (ts: TimeScale): void => {
+    if (this.props.onTimeScaleChange) {
+      this.props.onTimeScaleChange(ts);
+    }
+    this.resetPolling(ts.key);
+  };
+
+  clearRefreshDataTimeout() {
+    if (this.refreshDataTimeout != null) {
+      clearTimeout(this.refreshDataTimeout);
+    }
+  }
+
+  // Schedule the next data request depending on the time
+  // range key.
+  resetPolling(key: string) {
+    this.clearRefreshDataTimeout();
+    if (key !== "Custom") {
+      this.refreshDataTimeout = setTimeout(
+        this.refreshData,
+        300000, // 5 minutes
+      );
+    }
+  }
+
   refreshData = (prevTransactionFingerprintId: string): void => {
     const req = statementsRequestFromProps(this.props);
     this.props.refreshData(req);
     this.getTransactionStateInfo(prevTransactionFingerprintId);
+    this.resetPolling(this.props.timeScale.key);
   };
 
   componentDidMount(): void {
     this.refreshData("");
+    // For the first data fetch for this page, we refresh if there are:
+    // - Last updated is null (no statements fetched previously)
+    // - The time interval is not custom, i.e. we have a moving window
+    // in which case we poll every 5 minutes. For the first fetch we will
+    // calculate the next time to refresh based on when the data was last
+    // updated.
+    if (this.props.timeScale.key !== "Custom" || !this.props.lastUpdated) {
+      const now = moment();
+      const nextRefresh =
+        this.props.lastUpdated?.clone().add(5, "minutes") || now;
+      setTimeout(
+        this.refreshData,
+        Math.max(0, nextRefresh.diff(now, "milliseconds")),
+        this.props.transactionFingerprintId,
+      );
+    }
     this.props.refreshUserSQLRoles();
     if (!this.props.isTenant) {
       this.props.refreshNodes();
     }
+  }
+
+  componentWillUnmount(): void {
+    this.clearRefreshDataTimeout();
   }
 
   componentDidUpdate(prevProps: TransactionDetailsProps): void {
@@ -274,7 +324,7 @@ export class TransactionDetails extends React.Component<
             <TimeScaleDropdown
               options={timeScale1hMinOptions}
               currentScale={this.props.timeScale}
-              setTimeScale={this.props.onTimeScaleChange}
+              setTimeScale={this.changeTimeScale}
             />
           </PageConfigItem>
         </PageConfig>

--- a/pkg/ui/workspaces/cluster-ui/src/transactionDetails/transactionDetailsConnected.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionDetails/transactionDetailsConnected.tsx
@@ -60,6 +60,7 @@ export const selectTransaction = createSelector(
     return {
       isLoading: false,
       transaction: transaction,
+      lastUpdated: transactionState.lastUpdated,
     };
   },
 );
@@ -68,7 +69,10 @@ const mapStateToProps = (
   state: AppState,
   props: TransactionDetailsProps,
 ): TransactionDetailsStateProps => {
-  const { isLoading, transaction } = selectTransaction(state, props);
+  const { isLoading, transaction, lastUpdated } = selectTransaction(
+    state,
+    props,
+  );
   return {
     timeScale: selectTimeScale(state),
     error: selectTransactionsLastError(state),
@@ -81,6 +85,7 @@ const mapStateToProps = (
       txnFingerprintIdAttr,
     ),
     isLoading: isLoading,
+    lastUpdated: lastUpdated,
     hasViewActivityRedactedRole: selectHasViewActivityRedactedRole(state),
   };
 };

--- a/pkg/ui/workspaces/cluster-ui/src/transactionsPage/transactionsPage.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionsPage/transactionsPage.tsx
@@ -195,7 +195,7 @@ export class TransactionsPage extends React.Component<
     }
   }
 
-  // Scheudle the next data request depending on the time
+  // Schedule the next data request depending on the time
   // range key.
   resetPolling(key: string): void {
     this.clearRefreshDataTimeout();

--- a/pkg/ui/workspaces/db-console/src/redux/apiReducers.ts
+++ b/pkg/ui/workspaces/db-console/src/redux/apiReducers.ts
@@ -344,7 +344,7 @@ export const statementDetailsReducerObj = new KeyedCachedDataReducer(
   api.getStatementDetails,
   statementDetailsActionNamespace,
   statementDetailsRequestToID,
-  moment.duration(5, "m"),
+  null,
   moment.duration(30, "m"),
 );
 

--- a/pkg/ui/workspaces/db-console/src/views/transactions/transactionDetails.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/transactions/transactionDetails.tsx
@@ -42,6 +42,7 @@ export const selectTransaction = createSelector(
       return {
         isLoading: true,
         transaction: null,
+        lastUpdated: null,
       };
     }
     const txnFingerprintId = getMatchParamByName(
@@ -57,6 +58,7 @@ export const selectTransaction = createSelector(
     return {
       isLoading: false,
       transaction: transaction,
+      lastUpdated: transactionState?.setAt?.utc(),
     };
   },
 );
@@ -67,7 +69,10 @@ export default withRouter(
       state: AdminUIState,
       props: TransactionDetailsProps,
     ): TransactionDetailsStateProps => {
-      const { isLoading, transaction } = selectTransaction(state, props);
+      const { isLoading, transaction, lastUpdated } = selectTransaction(
+        state,
+        props,
+      );
       return {
         timeScale: selectTimeScale(state),
         error: selectLastError(state),
@@ -80,6 +85,7 @@ export default withRouter(
           txnFingerprintIdAttr,
         ),
         isLoading: isLoading,
+        lastUpdated: lastUpdated,
       };
     },
     {


### PR DESCRIPTION
Backport 1/1 commits from #92596.

/cc @cockroachdb/release

---

This commit moves polling to the statement and transaction details page components from the cached data reducer and sagas, using the same approach as #85772.

Fixes #91297.

Loom (DB Console and CC Console): https://www.loom.com/share/d3002ad54463448aaa3b8c9d74e31d10

Release note (ui change): The statement fingerprint details page in the Console no longer infinitely loads after 5 minutes.
Release justification: bug fix