### PR TITLE
sql: add retries on COPY under certain conditions

### DIFF
--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -2549,9 +2549,10 @@ func (ex *connExecutor) execCopyIn(
 	if copyErr = ex.execWithProfiling(ctx, cmd.Stmt, nil, func(ctx context.Context) error {
 		return cm.run(ctx)
 	}); copyErr != nil {
-		// TODO(andrei): We don't have a retriable error story for the copy machine.
+		// TODO(andrei): We don't have a full retriable error story for the copy machine.
 		// When running outside of a txn, the copyMachine should probably do retries
-		// internally. When not, it's unclear what we should do. For now, we abort
+		// internally - this is partially done, see `copyMachine.insertRows`.
+		// When not, it's unclear what we should do. For now, we abort
 		// the txn (if any).
 		// We also don't have a story for distinguishing communication errors (which
 		// should terminate the connection) from query errors. For now, we treat all

--- a/pkg/sql/copy.go
+++ b/pkg/sql/copy.go
@@ -20,6 +20,7 @@ import (
 	"time"
 	"unicode/utf8"
 
+	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/colinfo"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/resolver"
@@ -37,6 +38,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/encoding/csv"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/mon"
+	"github.com/cockroachdb/cockroach/pkg/util/retry"
 	"github.com/cockroachdb/errors"
 )
 
@@ -81,6 +83,7 @@ type copyMachineInterface interface {
 // See: https://www.postgresql.org/docs/current/static/sql-copy.html
 // and: https://www.postgresql.org/docs/current/static/protocol-flow.html#PROTOCOL-COPY
 type copyMachine struct {
+	copyFromAST              *tree.CopyFrom
 	table                    tree.TableExpr
 	columns                  tree.NameList
 	resultColumns            colinfo.ResultColumns
@@ -155,7 +158,8 @@ func newCopyMachine(
 	execInsertPlan func(ctx context.Context, p *planner, res RestrictedCommandResult) error,
 ) (_ *copyMachine, retErr error) {
 	c := &copyMachine{
-		conn: conn,
+		conn:        conn,
+		copyFromAST: n,
 		// TODO(georgiah): Currently, insertRows depends on Table and Columns,
 		//  but that dependency can be removed by refactoring it.
 		table:           &n.Table,
@@ -822,8 +826,35 @@ func (p *planner) preparePlannerForCopy(
 	}
 }
 
-// insertRows transforms the buffered rows into an insertNode and executes it.
-func (c *copyMachine) insertRows(ctx context.Context, finalBatch bool) (retErr error) {
+// insertRows inserts rows, retrying if necessary.
+func (c *copyMachine) insertRows(ctx context.Context, finalBatch bool) error {
+	var err error
+
+	rOpts := base.DefaultRetryOptions()
+	rOpts.MaxRetries = 5
+	r := retry.StartWithCtx(ctx, rOpts)
+	for r.Next() {
+		if err = c.insertRowsInternal(ctx, finalBatch); err == nil {
+			return nil
+		} else {
+			// It is currently only safe to retry if we are not in atomic copy mode &
+			// we are in an implicit transaction.
+			// NOTE: we cannot re-use the connExecutor retry scheme here as COPY
+			// consumes directly from the read buffer, and the data would no longer
+			// be available during the retry.
+			// NOTE: in theory we can also retry if c.insertRows == 0.
+			if c.implicitTxn && !c.p.SessionData().CopyFromAtomicEnabled && c.p.SessionData().CopyFromRetriesEnabled && errIsRetriable(err) {
+				log.SqlExec.Infof(ctx, "%s failed on attempt %d and is retrying, error %+v", c.copyFromAST.String(), r.CurrentAttempt(), err)
+				continue
+			}
+			return err
+		}
+	}
+	return err
+}
+
+// insertRowsInternal transforms the buffered rows into an insertNode and executes it.
+func (c *copyMachine) insertRowsInternal(ctx context.Context, finalBatch bool) (retErr error) {
 	cleanup := c.p.preparePlannerForCopy(ctx, &c.txnOpt, finalBatch, c.implicitTxn)
 	defer func() {
 		retErr = cleanup(ctx, retErr)
@@ -832,6 +863,12 @@ func (c *copyMachine) insertRows(ctx context.Context, finalBatch bool) (retErr e
 		return nil
 	}
 	numRows := c.rows.Len()
+
+	if c.p.ExecCfg().TestingKnobs.BeforeCopyFromInsert != nil {
+		if err := c.p.ExecCfg().TestingKnobs.BeforeCopyFromInsert(); err != nil {
+			return err
+		}
+	}
 
 	copyFastPath := c.p.SessionData().CopyFastPathEnabled
 	var vc tree.SelectStatement

--- a/pkg/sql/copy_in_test.go
+++ b/pkg/sql/copy_in_test.go
@@ -22,7 +22,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/security/username"
+	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/randgen"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/tests"
@@ -36,6 +38,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/timetz"
 	"github.com/jackc/pgx/v4"
 	"github.com/lib/pq"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -485,6 +488,152 @@ func TestCopyTrace(t *testing.T) {
 				}
 				require.NoError(t, txn.Rollback())
 			})
+		})
+	}
+}
+
+// TestCopyFromRetries tests copy from works as expected for certain retry
+// states.
+func TestCopyFromRetries(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	const numRows = sql.CopyBatchRowSizeDefault * 5
+
+	testCases := []struct {
+		desc           string
+		hook           func(attemptNum int) error
+		atomicEnabled  bool
+		retriesEnabled bool
+		inTxn          bool
+		expectedRows   int
+		expectedErr    bool
+	}{
+		{
+			desc:           "failure in atomic transaction does not retry",
+			atomicEnabled:  true,
+			retriesEnabled: true,
+			hook: func(attemptNum int) error {
+				if attemptNum == 1 {
+					return &roachpb.TransactionRetryWithProtoRefreshError{}
+				}
+				return nil
+			},
+			expectedErr: true,
+		},
+		{
+			desc:           "does not attempt to retry if disabled",
+			atomicEnabled:  false,
+			retriesEnabled: false,
+			hook: func(attemptNum int) error {
+				if attemptNum == 1 {
+					return &roachpb.TransactionRetryWithProtoRefreshError{}
+				}
+				return nil
+			},
+			expectedErr: true,
+		},
+		{
+			desc:           "does not retry inside a txn",
+			atomicEnabled:  true,
+			retriesEnabled: true,
+			inTxn:          true,
+			hook: func(attemptNum int) error {
+				if attemptNum == 1 {
+					return &roachpb.TransactionRetryWithProtoRefreshError{}
+				}
+				return nil
+			},
+			expectedErr: true,
+		},
+		{
+			desc:           "retries successfully on every batch",
+			atomicEnabled:  false,
+			retriesEnabled: true,
+			hook: func(attemptNum int) error {
+				if attemptNum%2 == 1 {
+					return &roachpb.TransactionRetryWithProtoRefreshError{}
+				}
+				return nil
+			},
+			expectedRows: numRows,
+		},
+		{
+			desc:           "eventually dies on too many restarts",
+			atomicEnabled:  false,
+			retriesEnabled: true,
+			hook: func(attemptNum int) error {
+				return &roachpb.TransactionRetryWithProtoRefreshError{}
+			},
+			expectedErr: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			params, _ := tests.CreateTestServerParams()
+			var attemptNumber int
+			params.Knobs.SQLExecutor = &sql.ExecutorTestingKnobs{
+				BeforeCopyFromInsert: func() error {
+					attemptNumber++
+					return tc.hook(attemptNumber)
+				},
+			}
+			s, db, _ := serverutils.StartServer(t, params)
+			defer s.Stopper().Stop(context.Background())
+
+			_, err := db.Exec(
+				`CREATE TABLE t (
+					i INT PRIMARY KEY
+				);`,
+			)
+			require.NoError(t, err)
+
+			ctx := context.Background()
+
+			// Use pgx instead of lib/pq as pgx doesn't require copy to be in a txn.
+			pgURL, cleanupGoDB := sqlutils.PGUrl(
+				t, s.ServingSQLAddr(), "StartServer" /* prefix */, url.User(username.RootUser))
+			defer cleanupGoDB()
+			pgxConn, err := pgx.Connect(ctx, pgURL.String())
+			require.NoError(t, err)
+			_, err = pgxConn.Exec(ctx, "SET copy_from_atomic_enabled = $1", fmt.Sprintf("%t", tc.atomicEnabled))
+			require.NoError(t, err)
+			_, err = pgxConn.Exec(ctx, "SET copy_from_retries_enabled = $1", fmt.Sprintf("%t", tc.retriesEnabled))
+			require.NoError(t, err)
+
+			if err := func() error {
+				var rows [][]interface{}
+				for i := 0; i < numRows; i++ {
+					rows = append(rows, []interface{}{i})
+				}
+				if !tc.inTxn {
+					_, err := pgxConn.CopyFrom(ctx, pgx.Identifier{"t"}, []string{"i"}, pgx.CopyFromRows(rows))
+					return err
+				}
+
+				txn, err := pgxConn.Begin(ctx)
+				if err != nil {
+					return err
+				}
+				defer func() {
+					_ = txn.Rollback(ctx)
+				}()
+				_, err = txn.CopyFrom(ctx, pgx.Identifier{"t"}, []string{"i"}, pgx.CopyFromRows(rows))
+				if err != nil {
+					return err
+				}
+				return txn.Commit(ctx)
+			}(); err != nil {
+				assert.True(t, tc.expectedErr, "got error %+v", err)
+			} else {
+				assert.False(t, tc.expectedErr, "expected error but got none")
+			}
+
+			var actualRows int
+			err = db.QueryRow("SELECT count(1) FROM t").Scan(&actualRows)
+			require.NoError(t, err)
+			require.Equal(t, tc.expectedRows, actualRows)
 		})
 	}
 }

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -1537,6 +1537,9 @@ type ExecutorTestingKnobs struct {
 	// to use a transaction, and, in doing so, more deterministically allocate
 	// descriptor IDs at the cost of decreased parallelism.
 	UseTransactionalDescIDGenerator bool
+
+	// BeforeCopyFromInsert, if set, will be called during a COPY FROM insert statement.
+	BeforeCopyFromInsert func() error
 }
 
 // PGWireTestingKnobs contains knobs for the pgwire module.
@@ -3387,6 +3390,10 @@ func (m *sessionDataMutator) SetCopyFastPathEnabled(val bool) {
 
 func (m *sessionDataMutator) SetCopyFromAtomicEnabled(val bool) {
 	m.data.CopyFromAtomicEnabled = val
+}
+
+func (m *sessionDataMutator) SetCopyFromRetriesEnabled(val bool) {
+	m.data.CopyFromRetriesEnabled = val
 }
 
 func (m *sessionDataMutator) SetEnforceHomeRegion(val bool) {

--- a/pkg/sql/logictest/testdata/logic_test/information_schema
+++ b/pkg/sql/logictest/testdata/logic_test/information_schema
@@ -4770,6 +4770,7 @@ check_function_bodies                                 on
 client_encoding                                       UTF8
 client_min_messages                                   notice
 copy_from_atomic_enabled                              on
+copy_from_retries_enabled                             off
 cost_scans_with_default_col_size                      off
 database                                              test
 datestyle                                             ISO, MDY

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -2778,6 +2778,7 @@ check_function_bodies                                 on                  NULL  
 client_encoding                                       UTF8                NULL      NULL        NULL        string
 client_min_messages                                   notice              NULL      NULL        NULL        string
 copy_from_atomic_enabled                              on                  NULL      NULL        NULL        string
+copy_from_retries_enabled                             off                 NULL      NULL        NULL        string
 cost_scans_with_default_col_size                      off                 NULL      NULL        NULL        string
 database                                              test                NULL      NULL        NULL        string
 datestyle                                             ISO, MDY            NULL      NULL        NULL        string
@@ -2921,6 +2922,7 @@ check_function_bodies                                 on                  NULL  
 client_encoding                                       UTF8                NULL  user     NULL      UTF8                UTF8
 client_min_messages                                   notice              NULL  user     NULL      notice              notice
 copy_from_atomic_enabled                              on                  NULL  user     NULL      on                  on
+copy_from_retries_enabled                             off                 NULL  user     NULL      off                 off
 cost_scans_with_default_col_size                      off                 NULL  user     NULL      off                 off
 database                                              test                NULL  user     NULL      ·                   test
 datestyle                                             ISO, MDY            NULL  user     NULL      ISO, MDY            ISO, MDY
@@ -3059,6 +3061,7 @@ client_encoding                                       NULL    NULL     NULL     
 client_min_messages                                   NULL    NULL     NULL     NULL        NULL
 copy_fast_path_enabled                                NULL    NULL     NULL     NULL        NULL
 copy_from_atomic_enabled                              NULL    NULL     NULL     NULL        NULL
+copy_from_retries_enabled                             NULL    NULL     NULL     NULL        NULL
 cost_scans_with_default_col_size                      NULL    NULL     NULL     NULL        NULL
 crdb_version                                          NULL    NULL     NULL     NULL        NULL
 database                                              NULL    NULL     NULL     NULL        NULL

--- a/pkg/sql/logictest/testdata/logic_test/show_source
+++ b/pkg/sql/logictest/testdata/logic_test/show_source
@@ -36,6 +36,7 @@ check_function_bodies                                 on
 client_encoding                                       UTF8
 client_min_messages                                   notice
 copy_from_atomic_enabled                              on
+copy_from_retries_enabled                             off
 cost_scans_with_default_col_size                      off
 database                                              test
 datestyle                                             ISO, MDY

--- a/pkg/sql/sessiondatapb/local_only_session_data.proto
+++ b/pkg/sql/sessiondatapb/local_only_session_data.proto
@@ -323,6 +323,9 @@ message LocalOnlySessionData {
   // interesting ordering to require from the input to the group-by expression.
   // This can potentially eliminate a top-k operation.
   bool optimizer_use_limit_ordering_for_streaming_group_by = 88;
+  // CopyFromRetriesEnabled controls whether retries should be internally
+  // attempted for retriable errors.
+  bool copy_from_retries_enabled = 89;
 
   ///////////////////////////////////////////////////////////////////////////
   // WARNING: consider whether a session parameter you're adding needs to  //

--- a/pkg/sql/vars.go
+++ b/pkg/sql/vars.go
@@ -2323,6 +2323,23 @@ var varGen = map[string]sessionVar{
 	},
 
 	// CockroachDB extension.
+	`copy_from_retries_enabled`: {
+		GetStringVal: makePostgresBoolGetStringValFn(`copy_from_retries_enabled`),
+		Set: func(_ context.Context, m sessionDataMutator, s string) error {
+			b, err := paramparse.ParseBoolVar("copy_from_retries_enabled", s)
+			if err != nil {
+				return err
+			}
+			m.SetCopyFromRetriesEnabled(b)
+			return nil
+		},
+		Get: func(evalCtx *extendedEvalContext, _ *kv.Txn) (string, error) {
+			return formatBoolAsPostgresSetting(evalCtx.SessionData().CopyFromRetriesEnabled), nil
+		},
+		GlobalDefault: globalFalse,
+	},
+
+	// CockroachDB extension.
 	`enforce_home_region`: {
 		GetStringVal: makePostgresBoolGetStringValFn(`enforce_home_region`),
 		Set: func(_ context.Context, m sessionDataMutator, s string) error {


### PR DESCRIPTION
Release note (sql change): If `copy_from_retries_enabled` is set, COPY is now able to retry certain safe circumstances - namely when `copy_from_atomic_enabled` is false, there is no transaction running COPY and the error returned is retriable. This prevents users who keep running into `TransactionProtoWithRefreshError` from having issues.

Informs #90656

Release justification: feature gated new feature critical for unblocking DMS