### PR TITLE
*: stop swallowing errors from privilege checks

### DIFF
--- a/pkg/ccl/backupccl/backup_planning.go
+++ b/pkg/ccl/backupccl/backup_planning.go
@@ -423,8 +423,13 @@ func checkPrivilegesForBackup(
 		for _, desc := range targetDescs {
 			switch desc := desc.(type) {
 			case catalog.DatabaseDescriptor:
-				hasRequiredBackupPrivileges = hasRequiredBackupPrivileges &&
-					p.CheckPrivilegeForUser(ctx, desc, privilege.BACKUP, p.User()) == nil
+				if hasRequiredBackupPrivileges {
+					if ok, err := p.HasPrivilege(ctx, desc, privilege.BACKUP, p.User()); err != nil {
+						return err
+					} else {
+						hasRequiredBackupPrivileges = ok
+					}
+				}
 			}
 		}
 	} else if backupStmt.Targets.Tables.TablePatterns != nil {
@@ -437,8 +442,13 @@ func checkPrivilegesForBackup(
 		for _, desc := range targetDescs {
 			switch desc := desc.(type) {
 			case catalog.TableDescriptor:
-				hasRequiredBackupPrivileges = hasRequiredBackupPrivileges &&
-					p.CheckPrivilegeForUser(ctx, desc, privilege.BACKUP, p.User()) == nil
+				if hasRequiredBackupPrivileges {
+					if ok, err := p.HasPrivilege(ctx, desc, privilege.BACKUP, p.User()); err != nil {
+						return err
+					} else {
+						hasRequiredBackupPrivileges = ok
+					}
+				}
 			}
 		}
 	} else {

--- a/pkg/ccl/backupccl/restore_planning.go
+++ b/pkg/ccl/backupccl/restore_planning.go
@@ -1276,7 +1276,12 @@ func checkPrivilegesForRestore(
 	// error. In 22.2 we continue to check for old style privileges and role
 	// options.
 	if len(restoreStmt.Targets.Databases) > 0 {
-		hasRestoreSystemPrivilege := p.CheckPrivilegeForUser(ctx, syntheticprivilege.GlobalPrivilegeObject, privilege.RESTORE, p.User()) == nil
+		var hasRestoreSystemPrivilege bool
+		if ok, err := p.HasPrivilege(ctx, syntheticprivilege.GlobalPrivilegeObject, privilege.RESTORE, p.User()); err != nil {
+			return err
+		} else {
+			hasRestoreSystemPrivilege = ok
+		}
 		if hasRestoreSystemPrivilege {
 			return checkRestoreDestinationPrivileges(ctx, p, from)
 		}

--- a/pkg/ccl/backupccl/restore_planning.go
+++ b/pkg/ccl/backupccl/restore_planning.go
@@ -1216,7 +1216,9 @@ func checkRestoreDestinationPrivileges(
 func checkRestorePrivilegesOnDatabase(
 	ctx context.Context, p sql.PlanHookState, parentDB catalog.DatabaseDescriptor,
 ) (shouldBufferNotice bool, err error) {
-	if err := p.CheckPrivilege(ctx, parentDB, privilege.RESTORE); err == nil {
+	if ok, err := p.HasPrivilege(ctx, parentDB, privilege.RESTORE, p.User()); err != nil {
+		return false, err
+	} else if ok {
 		return false, nil
 	}
 

--- a/pkg/server/admin.go
+++ b/pkg/server/admin.go
@@ -3906,6 +3906,7 @@ func (c *adminPrivilegeChecker) checkHasGlobalPrivilege(
 	planner, cleanup := c.makePlanner("check-system-privilege")
 	defer cleanup()
 	aa := planner.(sql.AuthorizationAccessor)
+	// TODO(rafi): switch to HasPrivilege check, and propogate error.
 	err := aa.CheckPrivilegeForUser(ctx, syntheticprivilege.GlobalPrivilegeObject, privilege, user)
 	return err == nil
 }

--- a/pkg/server/admin.go
+++ b/pkg/server/admin.go
@@ -1946,7 +1946,7 @@ func (s *adminServer) Settings(
 		keys = settings.Keys(settings.ForSystemTenant)
 	}
 
-	user, isAdmin, err := s.getUserAndRole(ctx)
+	_, isAdmin, err := s.getUserAndRole(ctx)
 	if err != nil {
 		return nil, serverError(ctx, err)
 	}
@@ -1963,24 +1963,8 @@ func (s *adminServer) Settings(
 	} else {
 		// Non-root access cannot see the values in any case.
 		lookupPurpose = settings.LookupForReporting
-
-		hasView := s.checkHasGlobalPrivilege(ctx, user, privilege.VIEWCLUSTERSETTING)
-		hasModify := s.checkHasGlobalPrivilege(ctx, user, privilege.MODIFYCLUSTERSETTING)
-		if !hasModify && !hasView {
-			hasView, err := s.hasRoleOption(ctx, user, roleoption.VIEWCLUSTERSETTING)
-			if err != nil {
-				return nil, err
-			}
-
-			hasModify, err := s.hasRoleOption(ctx, user, roleoption.MODIFYCLUSTERSETTING)
-			if err != nil {
-				return nil, err
-			}
-			if !hasModify && !hasView {
-				return nil, grpcstatus.Errorf(
-					codes.PermissionDenied, "this operation requires either %s or %s system privileges",
-					privilege.VIEWCLUSTERSETTING, privilege.MODIFYCLUSTERSETTING)
-			}
+		if err := s.adminPrivilegeChecker.requireViewClusterSettingOrModifyClusterSettingPermission(ctx); err != nil {
+			return nil, err
 		}
 	}
 
@@ -3710,21 +3694,22 @@ func (c *adminPrivilegeChecker) requireViewActivityPermission(ctx context.Contex
 	if err != nil {
 		return serverError(ctx, err)
 	}
-	if !isAdmin {
-		hasView := c.checkHasGlobalPrivilege(ctx, userName, privilege.VIEWACTIVITY)
-		if !hasView {
-			hasView, err := c.hasRoleOption(ctx, userName, roleoption.VIEWACTIVITY)
-			if err != nil {
-				return serverError(ctx, err)
-			}
-			if !hasView {
-				return grpcstatus.Errorf(
-					codes.PermissionDenied, "this operation requires the %s system privilege",
-					roleoption.VIEWACTIVITY)
-			}
-		}
+	if isAdmin {
+		return nil
 	}
-	return nil
+	if hasView, err := c.hasGlobalPrivilege(ctx, userName, privilege.VIEWACTIVITY); err != nil {
+		return serverError(ctx, err)
+	} else if hasView {
+		return nil
+	}
+	if hasView, err := c.hasRoleOption(ctx, userName, roleoption.VIEWACTIVITY); err != nil {
+		return serverError(ctx, err)
+	} else if hasView {
+		return nil
+	}
+	return grpcstatus.Errorf(
+		codes.PermissionDenied, "this operation requires the %s system privilege",
+		roleoption.VIEWACTIVITY)
 }
 
 // requireViewActivityOrViewActivityRedactedPermission's error return is a gRPC error.
@@ -3735,26 +3720,68 @@ func (c *adminPrivilegeChecker) requireViewActivityOrViewActivityRedactedPermiss
 	if err != nil {
 		return serverError(ctx, err)
 	}
-	if !isAdmin {
-		hasView := c.checkHasGlobalPrivilege(ctx, userName, privilege.VIEWACTIVITY)
-		hasViewRedacted := c.checkHasGlobalPrivilege(ctx, userName, privilege.VIEWACTIVITYREDACTED)
-		if !hasView && !hasViewRedacted {
-			hasView, err := c.hasRoleOption(ctx, userName, roleoption.VIEWACTIVITY)
-			if err != nil {
-				return serverError(ctx, err)
-			}
-			hasViewRedacted, err := c.hasRoleOption(ctx, userName, roleoption.VIEWACTIVITYREDACTED)
-			if err != nil {
-				return serverError(ctx, err)
-			}
-			if !hasView && !hasViewRedacted {
-				return grpcstatus.Errorf(
-					codes.PermissionDenied, "this operation requires the %s or %s system privileges",
-					roleoption.VIEWACTIVITY, roleoption.VIEWACTIVITYREDACTED)
-			}
-		}
+	if isAdmin {
+		return nil
 	}
-	return nil
+	if hasView, err := c.hasGlobalPrivilege(ctx, userName, privilege.VIEWACTIVITY); err != nil {
+		return serverError(ctx, err)
+	} else if hasView {
+		return nil
+	}
+	if hasViewRedacted, err := c.hasGlobalPrivilege(ctx, userName, privilege.VIEWACTIVITYREDACTED); err != nil {
+		return serverError(ctx, err)
+	} else if hasViewRedacted {
+		return nil
+	}
+	if hasView, err := c.hasRoleOption(ctx, userName, roleoption.VIEWACTIVITY); err != nil {
+		return serverError(ctx, err)
+	} else if hasView {
+		return nil
+	}
+	if hasViewRedacted, err := c.hasRoleOption(ctx, userName, roleoption.VIEWACTIVITYREDACTED); err != nil {
+		return serverError(ctx, err)
+	} else if hasViewRedacted {
+		return nil
+	}
+	return grpcstatus.Errorf(
+		codes.PermissionDenied, "this operation requires the %s or %s system privileges",
+		roleoption.VIEWACTIVITY, roleoption.VIEWACTIVITYREDACTED)
+}
+
+// requireViewClusterSettingOrModifyClusterSettingPermission's error return is a gRPC error.
+func (c *adminPrivilegeChecker) requireViewClusterSettingOrModifyClusterSettingPermission(
+	ctx context.Context,
+) (err error) {
+	userName, isAdmin, err := c.getUserAndRole(ctx)
+	if err != nil {
+		return serverError(ctx, err)
+	}
+	if isAdmin {
+		return nil
+	}
+	if hasView, err := c.hasGlobalPrivilege(ctx, userName, privilege.VIEWCLUSTERSETTING); err != nil {
+		return serverError(ctx, err)
+	} else if hasView {
+		return nil
+	}
+	if hasModify, err := c.hasGlobalPrivilege(ctx, userName, privilege.MODIFYCLUSTERSETTING); err != nil {
+		return serverError(ctx, err)
+	} else if hasModify {
+		return nil
+	}
+	if hasView, err := c.hasRoleOption(ctx, userName, roleoption.VIEWCLUSTERSETTING); err != nil {
+		return serverError(ctx, err)
+	} else if hasView {
+		return nil
+	}
+	if hasModify, err := c.hasRoleOption(ctx, userName, roleoption.MODIFYCLUSTERSETTING); err != nil {
+		return serverError(ctx, err)
+	} else if hasModify {
+		return nil
+	}
+	return grpcstatus.Errorf(
+		codes.PermissionDenied, "this operation requires the %s or %s system privileges",
+		privilege.VIEWCLUSTERSETTING, privilege.MODIFYCLUSTERSETTING)
 }
 
 // This function requires that the user have the VIEWACTIVITY role, but does not
@@ -3769,7 +3796,10 @@ func (c *adminPrivilegeChecker) requireViewActivityAndNoViewActivityRedactedPerm
 	}
 
 	if !isAdmin {
-		hasViewRedacted := c.checkHasGlobalPrivilege(ctx, userName, privilege.VIEWACTIVITYREDACTED)
+		hasViewRedacted, err := c.hasGlobalPrivilege(ctx, userName, privilege.VIEWACTIVITYREDACTED)
+		if err != nil {
+			return serverError(ctx, err)
+		}
 		if !hasViewRedacted {
 			hasViewRedacted, err := c.hasRoleOption(ctx, userName, roleoption.VIEWACTIVITYREDACTED)
 			if err != nil {
@@ -3799,14 +3829,17 @@ func (c *adminPrivilegeChecker) requireViewClusterMetadataPermission(
 	if err != nil {
 		return serverError(ctx, err)
 	}
-	if !isAdmin {
-		if hasViewClusterMetadata := c.checkHasGlobalPrivilege(ctx, userName, privilege.VIEWCLUSTERMETADATA); !hasViewClusterMetadata {
-			return grpcstatus.Errorf(
-				codes.PermissionDenied, "this operation requires the %s system privilege",
-				privilege.VIEWCLUSTERMETADATA)
-		}
+	if isAdmin {
+		return nil
 	}
-	return nil
+	if hasViewClusterMetadata, err := c.hasGlobalPrivilege(ctx, userName, privilege.VIEWCLUSTERMETADATA); err != nil {
+		return serverError(ctx, err)
+	} else if hasViewClusterMetadata {
+		return nil
+	}
+	return grpcstatus.Errorf(
+		codes.PermissionDenied, "this operation requires the %s system privilege",
+		privilege.VIEWCLUSTERMETADATA)
 }
 
 // requireViewDebugPermission requires the user have admin or the VIEWDEBUG system privilege
@@ -3816,14 +3849,17 @@ func (c *adminPrivilegeChecker) requireViewDebugPermission(ctx context.Context) 
 	if err != nil {
 		return serverError(ctx, err)
 	}
-	if !isAdmin {
-		if hasViewDebug := c.checkHasGlobalPrivilege(ctx, userName, privilege.VIEWDEBUG); !hasViewDebug {
-			return grpcstatus.Errorf(
-				codes.PermissionDenied, "this operation requires the %s system privilege",
-				privilege.VIEWDEBUG)
-		}
+	if isAdmin {
+		return nil
 	}
-	return nil
+	if hasViewDebug, err := c.hasGlobalPrivilege(ctx, userName, privilege.VIEWDEBUG); err != nil {
+		return serverError(ctx, err)
+	} else if hasViewDebug {
+		return nil
+	}
+	return grpcstatus.Errorf(
+		codes.PermissionDenied, "this operation requires the %s system privilege",
+		privilege.VIEWDEBUG)
 }
 
 // Note that the function returns plain errors, and it is the caller's
@@ -3897,18 +3933,16 @@ func (c *adminPrivilegeChecker) hasRoleOption(
 	return bool(dbDatum), nil
 }
 
-// checkHasGlobalPrivilege is a helper function which calls
+// hasGlobalPrivilege is a helper function which calls
 // CheckPrivilege and returns a true/false based on the returned
 // result.
-func (c *adminPrivilegeChecker) checkHasGlobalPrivilege(
+func (c *adminPrivilegeChecker) hasGlobalPrivilege(
 	ctx context.Context, user username.SQLUsername, privilege privilege.Kind,
-) bool {
+) (bool, error) {
 	planner, cleanup := c.makePlanner("check-system-privilege")
 	defer cleanup()
 	aa := planner.(sql.AuthorizationAccessor)
-	// TODO(rafi): switch to HasPrivilege check, and propogate error.
-	err := aa.CheckPrivilegeForUser(ctx, syntheticprivilege.GlobalPrivilegeObject, privilege, user)
-	return err == nil
+	return aa.HasPrivilege(ctx, syntheticprivilege.GlobalPrivilegeObject, privilege, user)
 }
 
 var errRequiresAdmin = grpcstatus.Error(codes.PermissionDenied, "this operation requires admin privilege")

--- a/pkg/server/status.go
+++ b/pkg/server/status.go
@@ -336,7 +336,10 @@ func (b *baseStatusServer) checkCancelPrivilege(
 		if sessionUser != reqUser {
 			// Must have CANCELQUERY privilege to cancel other users'
 			// sessions/queries.
-			hasCancelQuery := b.privilegeChecker.checkHasGlobalPrivilege(ctx, reqUser, privilege.CANCELQUERY)
+			hasCancelQuery, err := b.privilegeChecker.hasGlobalPrivilege(ctx, reqUser, privilege.CANCELQUERY)
+			if err != nil {
+				return serverError(ctx, err)
+			}
 			if !hasCancelQuery {
 				ok, err := b.privilegeChecker.hasRoleOption(ctx, reqUser, roleoption.CANCELQUERY)
 				if err != nil {

--- a/pkg/sql/alter_table.go
+++ b/pkg/sql/alter_table.go
@@ -100,7 +100,7 @@ func (p *planner) AlterTable(ctx context.Context, n *tree.AlterTable) (planNode,
 
 	// This check for CREATE privilege is kept for backwards compatibility.
 	if err := p.CheckPrivilege(ctx, tableDesc, privilege.CREATE); err != nil {
-		return nil, pgerror.Newf(pgcode.InsufficientPrivilege,
+		return nil, pgerror.Wrapf(err, pgcode.InsufficientPrivilege,
 			"must be owner of table %s or have CREATE privilege on table %s",
 			tree.Name(tableDesc.GetName()), tree.Name(tableDesc.GetName()))
 	}
@@ -864,7 +864,10 @@ func (p *planner) setAuditMode(
 	}
 	if !hasAdmin {
 		// Check for system privilege first, otherwise fall back to role options.
-		hasModify := p.CheckPrivilege(ctx, syntheticprivilege.GlobalPrivilegeObject, privilege.MODIFYCLUSTERSETTING) == nil
+		hasModify, err := p.HasPrivilege(ctx, syntheticprivilege.GlobalPrivilegeObject, privilege.MODIFYCLUSTERSETTING, p.User())
+		if err != nil {
+			return false, err
+		}
 		if !hasModify {
 			hasModify, err = p.HasRoleOption(ctx, roleoption.MODIFYCLUSTERSETTING)
 			if err != nil {

--- a/pkg/sql/authorization.go
+++ b/pkg/sql/authorization.go
@@ -80,6 +80,12 @@ type AuthorizationAccessor interface {
 		ctx context.Context, tableID descpb.ID, privilege privilege.Kind,
 	) error
 
+	// HasPrivilege checks if the user has `privilege` on `descriptor`.
+	HasPrivilege(ctx context.Context, privilegeObject privilege.Object, privilege privilege.Kind, user username.SQLUsername) (bool, error)
+
+	// HasAnyPrivilege returns true if user has any privileges at all.
+	HasAnyPrivilege(ctx context.Context, privilegeObject privilege.Object) (bool, error)
+
 	// CheckPrivilege verifies that the user has `privilege` on `descriptor`.
 	CheckPrivilegeForUser(
 		ctx context.Context, privilegeObject privilege.Object, privilege privilege.Kind, user username.SQLUsername,
@@ -122,19 +128,18 @@ type AuthorizationAccessor interface {
 
 var _ AuthorizationAccessor = &planner{}
 
-// CheckPrivilegeForUser implements the AuthorizationAccessor interface.
-// Requires a valid transaction to be open.
-func (p *planner) CheckPrivilegeForUser(
+// HasPrivilege is part of the AuthorizationAccessor interface.
+func (p *planner) HasPrivilege(
 	ctx context.Context,
 	privilegeObject privilege.Object,
 	privilegeKind privilege.Kind,
 	user username.SQLUsername,
-) error {
+) (bool, error) {
 	// Verify that the txn is valid in any case, so that
 	// we don't get the risk to say "OK" to root requests
 	// with an invalid API usage.
 	if p.txn == nil {
-		return errors.AssertionFailedf("cannot use CheckPrivilege without a txn")
+		return false, errors.AssertionFailedf("cannot use CheckPrivilege without a txn")
 	}
 
 	// root, admin and node user should always have privileges.
@@ -149,9 +154,9 @@ func (p *planner) CheckPrivilegeForUser(
 		if privilege.GetValidPrivilegesForObject(
 			privilegeObject.GetObjectType(),
 		).Contains(privilegeKind) {
-			return nil
+			return true, nil
 		}
-		return insufficientPrivilegeError(user, privilegeKind, privilegeObject)
+		return false, nil
 	}
 
 	// Test whether the object is being audited, and if so, record an
@@ -163,12 +168,12 @@ func (p *planner) CheckPrivilegeForUser(
 
 	privs, err := p.getPrivilegeDescriptor(ctx, privilegeObject)
 	if err != nil {
-		return err
+		return false, err
 	}
 
 	// Check if the 'public' pseudo-role has privileges.
 	if privs.CheckPrivilege(username.PublicRoleName(), privilegeKind) {
-		return nil
+		return true, nil
 	}
 
 	hasPriv, err := p.checkRolePredicate(ctx, user, func(role username.SQLUsername) (bool, error) {
@@ -176,12 +181,78 @@ func (p *planner) CheckPrivilegeForUser(
 		return isOwner || privs.CheckPrivilege(role, privilegeKind), err
 	})
 	if err != nil {
-		return err
+		return false, err
 	}
 	if hasPriv {
-		return nil
+		return true, nil
 	}
-	return insufficientPrivilegeError(user, privilegeKind, privilegeObject)
+	return false, nil
+}
+
+// HasAnyPrivilege is part of the AuthorizationAccessor interface.
+func (p *planner) HasAnyPrivilege(
+	ctx context.Context, privilegeObject privilege.Object,
+) (bool, error) {
+	// Verify that the txn is valid in any case, so that
+	// we don't get the risk to say "OK" to root requests
+	// with an invalid API usage.
+	if p.txn == nil {
+		return false, errors.AssertionFailedf("cannot use CheckAnyPrivilege without a txn")
+	}
+
+	user := p.SessionData().User()
+	if user.IsNodeUser() {
+		// User "node" has all privileges.
+		return true, nil
+	}
+
+	privs, err := p.getPrivilegeDescriptor(ctx, privilegeObject)
+	if err != nil {
+		return false, err
+	}
+
+	// Check if 'user' itself has privileges.
+	if privs.AnyPrivilege(user) {
+		return true, nil
+	}
+
+	// Check if 'public' has privileges.
+	if privs.AnyPrivilege(username.PublicRoleName()) {
+		return true, nil
+	}
+
+	// Expand role memberships.
+	memberOf, err := p.MemberOfWithAdminOption(ctx, user)
+	if err != nil {
+		return false, err
+	}
+
+	// Iterate over the roles that 'user' is a member of. We don't care about the admin option.
+	for role := range memberOf {
+		if privs.AnyPrivilege(role) {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}
+
+// CheckPrivilegeForUser implements the AuthorizationAccessor interface.
+// Requires a valid transaction to be open.
+func (p *planner) CheckPrivilegeForUser(
+	ctx context.Context,
+	privilegeObject privilege.Object,
+	privilegeKind privilege.Kind,
+	user username.SQLUsername,
+) error {
+	ok, err := p.HasPrivilege(ctx, privilegeObject, privilegeKind, user)
+	if err != nil {
+		return err
+	}
+	if !ok {
+		return insufficientPrivilegeError(user, privilegeKind, privilegeObject)
+	}
+	return nil
 }
 
 // CheckPrivilege implements the AuthorizationAccessor interface.
@@ -336,49 +407,15 @@ func (p *planner) checkRolePredicate(
 // CheckAnyPrivilege implements the AuthorizationAccessor interface.
 // Requires a valid transaction to be open.
 func (p *planner) CheckAnyPrivilege(ctx context.Context, privilegeObject privilege.Object) error {
-	// Verify that the txn is valid in any case, so that
-	// we don't get the risk to say "OK" to root requests
-	// with an invalid API usage.
-	if p.txn == nil {
-		return errors.AssertionFailedf("cannot use CheckAnyPrivilege without a txn")
-	}
-
 	user := p.SessionData().User()
-
-	if user.IsNodeUser() {
-		// User "node" has all privileges.
-		return nil
-	}
-
-	privs, err := p.getPrivilegeDescriptor(ctx, privilegeObject)
+	ok, err := p.HasAnyPrivilege(ctx, privilegeObject)
 	if err != nil {
 		return err
 	}
-
-	// Check if 'user' itself has privileges.
-	if privs.AnyPrivilege(user) {
-		return nil
+	if !ok {
+		return insufficientPrivilegeError(user, 0 /* kind */, privilegeObject)
 	}
-
-	// Check if 'public' has privileges.
-	if privs.AnyPrivilege(username.PublicRoleName()) {
-		return nil
-	}
-
-	// Expand role memberships.
-	memberOf, err := p.MemberOfWithAdminOption(ctx, user)
-	if err != nil {
-		return err
-	}
-
-	// Iterate over the roles that 'user' is a member of. We don't care about the admin option.
-	for role := range memberOf {
-		if privs.AnyPrivilege(role) {
-			return nil
-		}
-	}
-
-	return insufficientPrivilegeError(user, 0 /* kind */, privilegeObject)
+	return nil
 }
 
 // UserHasAdminRole implements the AuthorizationAccessor interface.

--- a/pkg/sql/catalog/randgen/randgen.go
+++ b/pkg/sql/catalog/randgen/randgen.go
@@ -221,6 +221,7 @@ type genError struct {
 type Catalog interface {
 	HasAdminRole(context.Context) (bool, error)
 	CheckAnyPrivilege(context.Context, privilege.Object) error
+	HasAnyPrivilege(context.Context, privilege.Object) (bool, error)
 	CanCreateDatabase(context.Context) error
 	CheckPrivilegeForUser(context.Context, privilege.Object, privilege.Kind, username.SQLUsername) error
 	ExpandTableGlob(context.Context, tree.TablePattern) (tree.TableNames, descpb.IDs, error)

--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -1836,29 +1836,39 @@ CREATE TABLE crdb_internal.cluster_settings (
   description   STRING NOT NULL
 )`,
 	populate: func(ctx context.Context, p *planner, _ catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) error {
-		hasAdmin, err := p.HasAdminRole(ctx)
-		if err != nil {
-			return err
-		}
-		if !hasAdmin {
-			hasModify := p.CheckPrivilege(ctx, syntheticprivilege.GlobalPrivilegeObject, privilege.MODIFYCLUSTERSETTING) == nil
-			hasView := p.CheckPrivilege(ctx, syntheticprivilege.GlobalPrivilegeObject, privilege.VIEWCLUSTERSETTING) == nil
-
-			if !hasModify && !hasView {
-				hasModify, err := p.HasRoleOption(ctx, roleoption.MODIFYCLUSTERSETTING)
-				if err != nil {
-					return err
-				}
-				hasView, err := p.HasRoleOption(ctx, roleoption.VIEWCLUSTERSETTING)
-				if err != nil {
-					return err
-				}
-				if !hasModify && !hasView {
-					return pgerror.Newf(pgcode.InsufficientPrivilege,
-						"only users with either %s or %s system privileges are allowed to read "+
-							"crdb_internal.cluster_settings", privilege.MODIFYCLUSTERSETTING, privilege.VIEWCLUSTERSETTING)
-				}
+		if hasPriv, err := func() (bool, error) {
+			if hasAdmin, err := p.HasAdminRole(ctx); err != nil {
+				return false, err
+			} else if hasAdmin {
+				return true, nil
 			}
+			if hasModify, err := p.HasPrivilege(ctx, syntheticprivilege.GlobalPrivilegeObject, privilege.MODIFYCLUSTERSETTING, p.User()); err != nil {
+				return false, err
+			} else if hasModify {
+				return true, nil
+			}
+			if hasView, err := p.HasPrivilege(ctx, syntheticprivilege.GlobalPrivilegeObject, privilege.VIEWCLUSTERSETTING, p.User()); err != nil {
+				return false, err
+			} else if hasView {
+				return true, nil
+			}
+			if hasModify, err := p.HasRoleOption(ctx, roleoption.MODIFYCLUSTERSETTING); err != nil {
+				return false, err
+			} else if hasModify {
+				return true, nil
+			}
+			if hasView, err := p.HasRoleOption(ctx, roleoption.VIEWCLUSTERSETTING); err != nil {
+				return false, err
+			} else if hasView {
+				return true, nil
+			}
+			return false, nil
+		}(); err != nil {
+			return err
+		} else if !hasPriv {
+			return pgerror.Newf(pgcode.InsufficientPrivilege,
+				"only users with either %s or %s system privileges are allowed to read "+
+					"crdb_internal.cluster_settings", privilege.MODIFYCLUSTERSETTING, privilege.VIEWCLUSTERSETTING)
 		}
 		for _, k := range settings.Keys(p.ExecCfg().Codec.ForSystemTenant()) {
 			setting, _ := settings.Lookup(
@@ -3808,17 +3818,18 @@ CREATE TABLE crdb_internal.ranges_no_leases (
 		}
 		descs := all.OrderedDescriptors()
 
-		privCheckerFunc := func(desc catalog.Descriptor) bool {
+		privCheckerFunc := func(desc catalog.Descriptor) (bool, error) {
 			if hasAdmin {
-				return true
+				return true, nil
 			}
-
-			return p.CheckPrivilege(ctx, desc, privilege.ZONECONFIG) == nil
+			return p.HasPrivilege(ctx, desc, privilege.ZONECONFIG, p.User())
 		}
 
 		hasPermission := false
 		for _, desc := range descs {
-			if privCheckerFunc(desc) {
+			if ok, err := privCheckerFunc(desc); err != nil {
+				return nil, nil, err
+			} else if ok {
 				hasPermission = true
 				break
 			}
@@ -5026,7 +5037,9 @@ CREATE TABLE crdb_internal.kv_catalog_descriptor (
 		// Delegate privilege check to system table.
 		{
 			sysTable := all.LookupDescriptor(systemschema.DescriptorTable.GetID())
-			if p.CheckPrivilege(ctx, sysTable, privilege.SELECT) != nil {
+			if ok, err := p.HasPrivilege(ctx, sysTable, privilege.SELECT, p.User()); err != nil {
+				return err
+			} else if !ok {
 				return nil
 			}
 		}
@@ -5060,7 +5073,9 @@ CREATE TABLE crdb_internal.kv_catalog_zones (
 		// Delegate privilege check to system table.
 		{
 			sysTable := all.LookupDescriptor(systemschema.ZonesTable.GetID())
-			if p.CheckPrivilege(ctx, sysTable, privilege.SELECT) != nil {
+			if ok, err := p.HasPrivilege(ctx, sysTable, privilege.SELECT, p.User()); err != nil {
+				return err
+			} else if !ok {
 				return nil
 			}
 		}
@@ -5097,7 +5112,9 @@ CREATE TABLE crdb_internal.kv_catalog_namespace (
 		// Delegate privilege check to system table.
 		{
 			sysTable := all.LookupDescriptor(systemschema.NamespaceTable.GetID())
-			if p.CheckPrivilege(ctx, sysTable, privilege.SELECT) != nil {
+			if ok, err := p.HasPrivilege(ctx, sysTable, privilege.SELECT, p.User()); err != nil {
+				return err
+			} else if !ok {
 				return nil
 			}
 		}
@@ -5132,7 +5149,9 @@ CREATE TABLE crdb_internal.kv_catalog_comments (
 		// Delegate privilege check to system table.
 		{
 			sysTable := all.LookupDescriptor(systemschema.CommentsTable.GetID())
-			if p.CheckPrivilege(ctx, sysTable, privilege.SELECT) != nil {
+			if ok, err := p.HasPrivilege(ctx, sysTable, privilege.SELECT, p.User()); err != nil {
+				return err
+			} else if !ok {
 				return nil
 			}
 		}

--- a/pkg/sql/faketreeeval/evalctx.go
+++ b/pkg/sql/faketreeeval/evalctx.go
@@ -65,8 +65,8 @@ func (so *DummySequenceOperators) SchemaExists(
 	return false, errors.WithStack(errSequenceOperators)
 }
 
-// HasAnyPrivilege is part of the eval.DatabaseCatalog interface.
-func (so *DummySequenceOperators) HasAnyPrivilege(
+// HasAnyPrivilegeForSpecifier is part of the eval.DatabaseCatalog interface.
+func (so *DummySequenceOperators) HasAnyPrivilegeForSpecifier(
 	ctx context.Context,
 	specifier eval.HasPrivilegeSpecifier,
 	user username.SQLUsername,
@@ -355,8 +355,8 @@ func (ep *DummyEvalPlanner) SchemaExists(ctx context.Context, dbName, scName str
 	return false, errors.WithStack(errEvalPlanner)
 }
 
-// HasAnyPrivilege is part of the eval.DatabaseCatalog interface.
-func (ep *DummyEvalPlanner) HasAnyPrivilege(
+// HasAnyPrivilegeForSpecifier is part of the eval.DatabaseCatalog interface.
+func (ep *DummyEvalPlanner) HasAnyPrivilegeForSpecifier(
 	ctx context.Context,
 	specifier eval.HasPrivilegeSpecifier,
 	user username.SQLUsername,

--- a/pkg/sql/importer/import_table_creation.go
+++ b/pkg/sql/importer/import_table_creation.go
@@ -303,8 +303,8 @@ func (so *importSequenceOperators) SchemaExists(
 	return false, errSequenceOperators
 }
 
-// HasAnyPrivilege is part of the eval.DatabaseCatalog interface.
-func (so *importSequenceOperators) HasAnyPrivilege(
+// HasAnyPrivilegeForSpecifier is part of the eval.DatabaseCatalog interface.
+func (so *importSequenceOperators) HasAnyPrivilegeForSpecifier(
 	ctx context.Context,
 	specifier eval.HasPrivilegeSpecifier,
 	user username.SQLUsername,

--- a/pkg/sql/logictest/testdata/logic_test/gen_test_objects
+++ b/pkg/sql/logictest/testdata/logic_test/gen_test_objects
@@ -507,7 +507,7 @@ user testuser
 query error permission denied to create database
 SELECT crdb_internal.generate_test_objects('foo._._', ARRAY[1,0,0])
 
-query error user testuser has no privileges on relation foo
+query error user has no privileges on foo
 SELECT crdb_internal.generate_test_objects('{"table_templates":["rootonly.foo"]}'::jsonb)
 
 query error template name expansion did not find any usable tables

--- a/pkg/sql/pg_extension.go
+++ b/pkg/sql/pg_extension.go
@@ -50,7 +50,9 @@ func postgisColumnsTablePopulator(
 				if !table.IsPhysicalTable() {
 					return nil
 				}
-				if p.CheckAnyPrivilege(ctx, table) != nil {
+				if ok, err := p.HasAnyPrivilege(ctx, table); err != nil {
+					return err
+				} else if !ok {
 					return nil
 				}
 				for _, col := range table.PublicColumns() {

--- a/pkg/sql/privileged_accessor.go
+++ b/pkg/sql/privileged_accessor.go
@@ -89,7 +89,7 @@ func (p *planner) checkDescriptorPermissions(ctx context.Context, id descpb.ID) 
 		return err
 	}
 	if err := p.CheckAnyPrivilege(ctx, desc); err != nil {
-		return pgerror.New(pgcode.InsufficientPrivilege, "insufficient privilege")
+		return pgerror.Wrapf(err, pgcode.InsufficientPrivilege, "insufficient privilege")
 	}
 	return nil
 }

--- a/pkg/sql/resolver.go
+++ b/pkg/sql/resolver.go
@@ -134,8 +134,8 @@ func (p *planner) SchemaExists(ctx context.Context, dbName, scName string) (foun
 	return found, err
 }
 
-// HasAnyPrivilege is part of the eval.DatabaseCatalog interface.
-func (p *planner) HasAnyPrivilege(
+// HasAnyPrivilegeForSpecifier is part of the eval.DatabaseCatalog interface.
+func (p *planner) HasAnyPrivilegeForSpecifier(
 	ctx context.Context,
 	specifier eval.HasPrivilegeSpecifier,
 	user username.SQLUsername,

--- a/pkg/sql/resolver.go
+++ b/pkg/sql/resolver.go
@@ -161,11 +161,10 @@ func (p *planner) HasAnyPrivilegeForSpecifier(
 			continue
 		}
 
-		if err := p.CheckPrivilegeForUser(ctx, desc, priv.Kind, user); err != nil {
-			if pgerror.GetPGCode(err) == pgcode.InsufficientPrivilege {
-				continue
-			}
+		if ok, err := p.HasPrivilege(ctx, desc, priv.Kind, user); err != nil {
 			return eval.HasNoPrivilege, err
+		} else if !ok {
+			continue
 		}
 
 		if priv.GrantOption {

--- a/pkg/sql/schemachanger/scbuild/dependencies.go
+++ b/pkg/sql/schemachanger/scbuild/dependencies.go
@@ -174,6 +174,12 @@ type AuthorizationAccessor interface {
 	// MemberOfWithAdminOption looks up all the roles 'member' belongs to (direct
 	// and indirect) and returns a map of "role" -> "isAdmin".
 	MemberOfWithAdminOption(ctx context.Context, member username.SQLUsername) (map[username.SQLUsername]bool, error)
+
+	// HasPrivilege checks if the user has `privilege` on `descriptor`.
+	HasPrivilege(ctx context.Context, privilegeObject privilege.Object, privilege privilege.Kind, user username.SQLUsername) (bool, error)
+
+	// HasAnyPrivilege returns true if user has any privileges at all.
+	HasAnyPrivilege(ctx context.Context, privilegeObject privilege.Object) (bool, error)
 }
 
 // AstFormatter provides interfaces for formatting AST nodes.

--- a/pkg/sql/schemachanger/scdeps/sctestdeps/test_deps.go
+++ b/pkg/sql/schemachanger/scdeps/sctestdeps/test_deps.go
@@ -160,6 +160,23 @@ func (s *TestState) HasOwnership(
 	return true, nil
 }
 
+// HasPrivilege implements the scbuild.AuthorizationAccessor interface.
+func (s *TestState) HasPrivilege(
+	ctx context.Context,
+	privilegeObject privilege.Object,
+	privilege privilege.Kind,
+	user username.SQLUsername,
+) (bool, error) {
+	return true, nil
+}
+
+// HasAnyPrivilege implements the scbuild.AuthorizationAccessor interface.
+func (s *TestState) HasAnyPrivilege(
+	ctx context.Context, privilegeObject privilege.Object,
+) (bool, error) {
+	return true, nil
+}
+
 // CheckPrivilegeForUser implements the scbuild.AuthorizationAccessor interface.
 func (s *TestState) CheckPrivilegeForUser(
 	ctx context.Context,

--- a/pkg/sql/sem/builtins/pg_builtins.go
+++ b/pkg/sql/sem/builtins/pg_builtins.go
@@ -1250,7 +1250,7 @@ var pgBuiltins = map[string]builtinDefinition{
 			if err != nil {
 				return eval.HasNoPrivilege, err
 			}
-			return evalCtx.Planner.HasAnyPrivilege(ctx, specifier, user, privs)
+			return evalCtx.Planner.HasAnyPrivilegeForSpecifier(ctx, specifier, user, privs)
 		},
 	),
 
@@ -1278,7 +1278,7 @@ var pgBuiltins = map[string]builtinDefinition{
 			if err != nil {
 				return eval.HasNoPrivilege, err
 			}
-			return evalCtx.Planner.HasAnyPrivilege(ctx, specifier, user, privs)
+			return evalCtx.Planner.HasAnyPrivilegeForSpecifier(ctx, specifier, user, privs)
 		},
 	),
 
@@ -1307,7 +1307,7 @@ var pgBuiltins = map[string]builtinDefinition{
 				return eval.HasNoPrivilege, err
 			}
 
-			return evalCtx.Planner.HasAnyPrivilege(ctx, specifier, user, privs)
+			return evalCtx.Planner.HasAnyPrivilegeForSpecifier(ctx, specifier, user, privs)
 		},
 	),
 
@@ -1388,7 +1388,7 @@ var pgBuiltins = map[string]builtinDefinition{
 
 			// For user-defined function, utilize the descriptor based way.
 			if catid.IsOIDUserDefined(oid.(*tree.DOid).Oid) {
-				return evalCtx.Planner.HasAnyPrivilege(ctx, specifier, evalCtx.SessionData().User(), privs)
+				return evalCtx.Planner.HasAnyPrivilegeForSpecifier(ctx, specifier, evalCtx.SessionData().User(), privs)
 			}
 
 			// For builtin functions, all users should have `EXECUTE` privilege, but
@@ -1465,7 +1465,7 @@ var pgBuiltins = map[string]builtinDefinition{
 				return eval.ObjectNotFound, nil
 			}
 
-			return evalCtx.Planner.HasAnyPrivilege(ctx, specifier, user, privs)
+			return evalCtx.Planner.HasAnyPrivilegeForSpecifier(ctx, specifier, user, privs)
 		},
 	),
 
@@ -1491,7 +1491,7 @@ var pgBuiltins = map[string]builtinDefinition{
 			if err != nil {
 				return eval.HasPrivilege, err
 			}
-			return evalCtx.Planner.HasAnyPrivilege(ctx, specifier, user, privs)
+			return evalCtx.Planner.HasAnyPrivilegeForSpecifier(ctx, specifier, user, privs)
 		},
 	),
 
@@ -1564,7 +1564,7 @@ var pgBuiltins = map[string]builtinDefinition{
 			if err != nil {
 				return eval.HasNoPrivilege, err
 			}
-			return evalCtx.Planner.HasAnyPrivilege(ctx, specifier, user, privs)
+			return evalCtx.Planner.HasAnyPrivilegeForSpecifier(ctx, specifier, user, privs)
 		},
 	),
 

--- a/pkg/sql/sem/eval/deps.go
+++ b/pkg/sql/sem/eval/deps.go
@@ -65,9 +65,9 @@ type DatabaseCatalog interface {
 	// whether it exists.
 	SchemaExists(ctx context.Context, dbName, scName string) (found bool, err error)
 
-	// HasAnyPrivilege returns whether the current user has privilege to access
-	// the given object.
-	HasAnyPrivilege(ctx context.Context, specifier HasPrivilegeSpecifier, user username.SQLUsername, privs []privilege.Privilege) (HasAnyPrivilegeResult, error)
+	// HasAnyPrivilegeForSpecifier returns whether the current user has privilege
+	// to access the given object.
+	HasAnyPrivilegeForSpecifier(ctx context.Context, specifier HasPrivilegeSpecifier, user username.SQLUsername, privs []privilege.Privilege) (HasAnyPrivilegeResult, error)
 }
 
 // CastFunc is a function which cases a datum to a given type.

--- a/pkg/sql/user.go
+++ b/pkg/sql/user.go
@@ -321,7 +321,9 @@ func retrieveAuthInfo(
 		return aInfo, err
 	}
 	if !hasAdmin {
-		if noSQLLogin := aa.CheckPrivilegeForUser(ctx, syntheticprivilege.GlobalPrivilegeObject, privilege.NOSQLLOGIN, user) == nil; noSQLLogin {
+		if ok, err = aa.HasPrivilege(ctx, syntheticprivilege.GlobalPrivilegeObject, privilege.NOSQLLOGIN, user); err != nil {
+			return aInfo, err
+		} else if ok {
 			aInfo.CanLoginSQL = false
 		}
 	}


### PR DESCRIPTION
sql: add HasPrivilege and HasAnyPrivilege to AuthorizationAccessor
*: stop swallowing errors from CheckPrivilegeForUser
*: stop swallowing errors from CheckAnyPrivilege
*: stop swallowing errors from CheckPrivilege
server: don't swallow error in hasGlobalPrivilege

Instead of swallowing errors, we use the new Has*Privilege functions. If
there was an error that causes the transaction to abort, it's important
to propagate it.

Epic: None
Release note: None