### PR TITLE
sql: fix the implementation of system_jobs

### DIFF
--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -884,19 +884,19 @@ func getInternalSystemJobsQueryFromClusterVersion(
 var crdbInternalSystemJobsTable = virtualSchemaTable{
 	schema: `
 CREATE TABLE crdb_internal.system_jobs (
-	id                INT8      NOT NULL,      
-	status            STRING    NOT NULL,
-	created           TIMESTAMP NOT NULL,
-	payload           BYTES     NOT NULL,
-	progress          BYTES,
-	created_by_type   STRING,
-	created_by_id     INT,
-	claim_session_id  BYTES,
-	claim_instance_id INT8,
-	num_runs          INT8,
-	last_run          TIMESTAMP,
-	job_type          STRING,
-	INDEX (id),
+  id                INT8      NOT NULL,
+  status            STRING    NOT NULL,
+  created           TIMESTAMP NOT NULL,
+  payload           BYTES     NOT NULL,
+  progress          BYTES,
+  created_by_type   STRING,
+  created_by_id     INT,
+  claim_session_id  BYTES,
+  claim_instance_id INT8,
+  num_runs          INT8,
+  last_run          TIMESTAMP,
+  job_type          STRING,
+  INDEX (id),
   INDEX (job_type),
   INDEX (status)
 )`,
@@ -939,7 +939,7 @@ func populateSystemJobsTableRows(
 	addRow func(...tree.Datum) error,
 	query string,
 	params ...interface{},
-) (bool, error) {
+) (result bool, retErr error) {
 	const jobIdIdx = 0
 	const jobPayloadIdx = 3
 
@@ -969,14 +969,7 @@ func populateSystemJobsTableRows(
 
 	cleanup := func(ctx context.Context) {
 		if err := it.Close(); err != nil {
-			// TODO(yuzefovich): this error should be propagated further up
-			// and not simply being logged. Fix it (#61123).
-			//
-			// Doing that as a return parameter would require changes to
-			// `planNode.Close` signature which is a bit annoying. One other
-			// possible solution is to panic here and catch the error
-			// somewhere.
-			log.Warningf(ctx, "error closin3g an iterator: %v", err)
+			retErr = errors.CombineErrors(retErr, err)
 		}
 	}
 	defer cleanup(ctx)

--- a/pkg/sql/sem/builtins/fixed_oids.go
+++ b/pkg/sql/sem/builtins/fixed_oids.go
@@ -2037,7 +2037,6 @@ var builtinOidsArray = []string{
 	2060: `pg_get_function_arguments(func_oid: oid) -> string`,
 	2061: `crdb_internal.job_payload_type(data: bytes) -> string`,
 	2062: `crdb_internal.tenant_span(tenant_name: string) -> bytes[]`,
-	2063: `crdb_internal.system_jobs -> tuple{int AS id, string AS status, timestamp AS created, bytes AS payload, bytes AS progress, string AS created_by_type, int AS created_by_id, bytes AS claim_session_id, int AS claim_instance_id, int AS num_runs, timestamp AS last_run}`,
 	2064: `crdb_internal.generate_test_objects(names: string, number: int) -> jsonb`,
 	2065: `crdb_internal.generate_test_objects(names: string, counts: int[]) -> jsonb`,
 	2066: `crdb_internal.generate_test_objects(parameters: jsonb) -> jsonb`,


### PR DESCRIPTION
Fixup for #93643.
Informs #92261.

- No fixed OID necessary.
- Better error handling.
- Whitespace fixups.

Release note: None
Epic: CRDB-21508