### PR TITLE
server: add viewactivityredacted permission

### DIFF
--- a/pkg/server/index_usage_stats.go
+++ b/pkg/server/index_usage_stats.go
@@ -209,7 +209,7 @@ func (s *statusServer) TableIndexStats(
 	ctx = propagateGatewayMetadata(ctx)
 	ctx = s.AnnotateCtx(ctx)
 
-	if err := s.privilegeChecker.requireViewActivityPermission(ctx); err != nil {
+	if err := s.privilegeChecker.requireViewActivityOrViewActivityRedactedPermission(ctx); err != nil {
 		return nil, err
 	}
 	return getTableIndexUsageStats(ctx, req, s.sqlServer.pgServer.SQLServer.GetLocalIndexStatistics(),


### PR DESCRIPTION
This commit updates the code so now user with role VIEWACTIVITYREDACTED can also view table index stats.

Epic: None

Release note: None