### PR TITLE
grunning: exclude s390x

### DIFF
--- a/pkg/util/grunning/BUILD.bazel
+++ b/pkg/util/grunning/BUILD.bazel
@@ -184,8 +184,6 @@ go_test(
         ],
         "@io_bazel_rules_go//go/platform:linux_s390x": [
             ":grunning",
-            "//pkg/testutils/skip",
-            "//pkg/util/syncutil",
             "@com_github_stretchr_testify//require",
         ],
         "@io_bazel_rules_go//go/platform:netbsd_386": [

--- a/pkg/util/grunning/disabled.go
+++ b/pkg/util/grunning/disabled.go
@@ -10,8 +10,8 @@
 
 // See grunning.Supported() for an explanation behind this build tag.
 //
-//go:build (darwin && arm64) || freebsd || !bazel
-// +build darwin,arm64 freebsd !bazel
+//go:build (darwin && arm64) || freebsd || (linux && s390x) || !bazel
+// +build darwin,arm64 freebsd linux,s390x !bazel
 
 package grunning
 

--- a/pkg/util/grunning/disabled_test.go
+++ b/pkg/util/grunning/disabled_test.go
@@ -10,8 +10,8 @@
 
 // See grunning.Supported() for an explanation behind this build tag.
 //
-//go:build (darwin && arm64) || freebsd || !bazel
-// +build darwin,arm64 freebsd !bazel
+//go:build (darwin && arm64) || freebsd || (linux && s390x) || !bazel
+// +build darwin,arm64 freebsd linux,s390x !bazel
 
 package grunning_test
 

--- a/pkg/util/grunning/enabled.go
+++ b/pkg/util/grunning/enabled.go
@@ -10,9 +10,10 @@
 
 // See grunning.Supported() for an explanation behind this build tag.
 //
-//go:build !((darwin && arm64) || freebsd || !bazel)
+//go:build !((darwin && arm64) || freebsd || (linux && s390x) || !bazel)
 // +build !darwin !arm64
 // +build !freebsd
+// +build !linux !s390x
 // +build bazel
 
 package grunning

--- a/pkg/util/grunning/enabled_test.go
+++ b/pkg/util/grunning/enabled_test.go
@@ -10,9 +10,10 @@
 
 // See grunning.Supported() for an explanation behind this build tag.
 //
-//go:build !((darwin && arm64) || freebsd || !bazel)
+//go:build !((darwin && arm64) || freebsd || (linux && s390x) || !bazel)
 // +build !darwin !arm64
 // +build !freebsd
+// +build !linux !s390x
 // +build bazel
 
 package grunning_test


### PR DESCRIPTION
As the patched Go runtime is not available, disable grunning library on s390x.

When s390x artifacts are made available (https://github.com/cockroachdb/cockroach/issues/92393), we can re-enable the library.  

Thanks.

Release note: None
Epic: none