### PR TITLE
release-22.2: backupccl: restore role options during RESTORE SYSTEM USERS

### DIFF
--- a/pkg/ccl/backupccl/backup_test.go
+++ b/pkg/ccl/backupccl/backup_test.go
@@ -9387,10 +9387,10 @@ func TestBackupRestoreSystemUsers(t *testing.T) {
 		sqlDBRestore.CheckQueryResults(t, "SHOW USERS", [][]string{
 			{"admin", "", "{}"},
 			{"app", "", "{admin,app_role}"},
-			{"app_role", "", "{}"},
+			{"app_role", "NOLOGIN", "{}"},
 			{"root", "", "{admin}"},
 			{"test", "", "{}"},
-			{"test_role", "", "{app_role}"},
+			{"test_role", "NOLOGIN", "{app_role}"},
 		})
 	})
 

--- a/pkg/ccl/backupccl/restore_job.go
+++ b/pkg/ccl/backupccl/restore_job.go
@@ -46,10 +46,12 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/nstree"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/rewrite"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/schemadesc"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/systemschema"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/tabledesc"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/typedesc"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scbackup"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/catid"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlutil"
@@ -2664,51 +2666,99 @@ func (r *restoreResumer) restoreSystemUsers(
 		if r.execCfg.Settings.Version.IsActive(ctx, clusterversion.AddSystemUserIDColumn) {
 			insertUser = `INSERT INTO system.users ("username", "hashedPassword", "isRole", "user_id") VALUES ($1, $2, $3, $4)`
 		}
-		newUsernames := make(map[string]bool)
+		newUsernames := make(map[string]catid.RoleID)
+
 		args := make([]interface{}, 4)
 		for _, user := range users {
-			newUsernames[user[0].String()] = true
 			args[0] = user[0]
 			args[1] = user[1]
 			args[2] = user[2]
+			var id catid.RoleID
 			if r.execCfg.Settings.Version.IsActive(ctx, clusterversion.AddSystemUserIDColumn) {
-				id, err := descidgen.GenerateUniqueRoleID(ctx, r.execCfg.DB, r.execCfg.Codec)
+				var err error
+				id, err = descidgen.GenerateUniqueRoleID(ctx, r.execCfg.DB, r.execCfg.Codec)
 				if err != nil {
 					return err
 				}
 				args[3] = id
 			}
-			if _, err = executor.Exec(ctx, "insert-non-existent-users", txn, insertUser,
+			if _, err := executor.Exec(ctx, "insert-non-existent-users", txn, insertUser,
 				args...); err != nil {
 				return err
 			}
+			newUsernames[user[0].String()] = id
 		}
 
 		// We skip granting roles if the backup does not contain system.role_members.
-		if len(systemTables) == 1 {
-			return nil
-		}
+		if hasSystemRoleMembersTable(systemTables) {
+			selectNonExistentRoleMembers := "SELECT * FROM crdb_temp_system.role_members temp_rm WHERE " +
+				"NOT EXISTS (SELECT * FROM system.role_members rm WHERE temp_rm.role = rm.role AND temp_rm.member = rm.member)"
+			roleMembers, err := executor.QueryBuffered(ctx, "get-role-members",
+				txn, selectNonExistentRoleMembers)
+			if err != nil {
+				return err
+			}
 
-		selectNonExistentRoleMembers := "SELECT * FROM crdb_temp_system.role_members temp_rm WHERE " +
-			"NOT EXISTS (SELECT * FROM system.role_members rm WHERE temp_rm.role = rm.role AND temp_rm.member = rm.member)"
-		roleMembers, err := executor.QueryBuffered(ctx, "get-role-members",
-			txn, selectNonExistentRoleMembers)
-		if err != nil {
-			return err
-		}
-
-		insertRoleMember := `INSERT INTO system.role_members ("role", "member", "isAdmin") VALUES ($1, $2, $3)`
-		for _, roleMember := range roleMembers {
-			// Only grant roles to users that don't currently exist, i.e., new users we just added
-			if _, ok := newUsernames[roleMember[1].String()]; ok {
-				if _, err = executor.Exec(ctx, "insert-non-existent-role-members", txn, insertRoleMember,
-					roleMember[0], roleMember[1], roleMember[2]); err != nil {
-					return err
+			insertRoleMember := `INSERT INTO system.role_members ("role", "member", "isAdmin") VALUES ($1, $2, $3)`
+			for _, roleMember := range roleMembers {
+				// Only grant roles to users that don't currently exist, i.e., new users we just added
+				if _, ok := newUsernames[roleMember[1].String()]; ok {
+					if _, err = executor.Exec(ctx, "insert-non-existent-role-members", txn, insertRoleMember,
+						roleMember[0], roleMember[1], roleMember[2]); err != nil {
+						return err
+					}
 				}
 			}
 		}
+
+		if hasSystemRoleOptionsTable(systemTables) {
+			selectNonExistentRoleOptions := "SELECT * FROM crdb_temp_system.role_options temp_ro WHERE " +
+				"NOT EXISTS (SELECT * FROM system.role_options ro WHERE temp_ro.username = ro.username AND temp_ro.option = ro.option)"
+			roleOptions, err := executor.QueryBuffered(ctx, "get-role-options", txn, selectNonExistentRoleOptions)
+			if err != nil {
+				return err
+			}
+
+			// RoleOptionsHasIDColumn comes after AddSystemUserIDColumn, so we don't need to chekc both.
+			roleOptionsHasIDColumn := r.execCfg.Settings.Version.IsActive(ctx, clusterversion.RoleOptionsTableHasIDColumn)
+			insertRoleOption := `INSERT INTO system.role_options ("username", "option", "value", "user_id") VALUES ($1, $2, $3, $4)`
+			if !roleOptionsHasIDColumn {
+				insertRoleOption = `INSERT INTO system.role_options ("username", "option", "value") VALUES ($1, $2, $3)`
+			}
+
+			for _, roleOption := range roleOptions {
+				if roleID, ok := newUsernames[roleOption[0].String()]; ok {
+					args := []interface{}{roleOption[0], roleOption[1], roleOption[2]}
+					if roleOptionsHasIDColumn {
+						args = append(args, roleID)
+					}
+					if _, err = executor.Exec(ctx, "insert-non-existent-role-options", txn,
+						insertRoleOption, args...); err != nil {
+						return err
+					}
+				}
+			}
+		}
+
 		return nil
 	})
+}
+
+func hasSystemRoleMembersTable(systemTables []catalog.TableDescriptor) bool {
+	return hasSystemTableByName(systemschema.RoleMembersTable.GetName(), systemTables)
+}
+
+func hasSystemRoleOptionsTable(systemTables []catalog.TableDescriptor) bool {
+	return hasSystemTableByName(systemschema.RoleOptionsTable.GetName(), systemTables)
+}
+
+func hasSystemTableByName(name string, systemTables []catalog.TableDescriptor) bool {
+	for _, t := range systemTables {
+		if t.GetName() == name {
+			return true
+		}
+	}
+	return false
 }
 
 // restoreSystemTables atomically replaces the contents of the system tables

--- a/pkg/ccl/backupccl/targets.go
+++ b/pkg/ccl/backupccl/targets.go
@@ -425,7 +425,7 @@ func checkMissingIntroducedSpans(
 				table.Name, mainBackupManifests[i].StartTime.GoTime().String(), table.Name)
 			return errors.WithIssueLink(tableError, errors.IssueLink{
 				IssueURL: "https://www.cockroachlabs.com/docs/advisories/a88042",
-				Detail: `An incremental database backup with revision history can incorrectly backup data for a table 
+				Detail: `An incremental database backup with revision history can incorrectly backup data for a table
 that was running an IMPORT at the time of the previous incremental in this chain of backups.`,
 			})
 		}
@@ -502,7 +502,8 @@ func selectTargets(
 					systemTables = append(systemTables, desc)
 				case systemschema.RoleMembersTable.GetName():
 					systemTables = append(systemTables, desc)
-					// TODO(casper): should we handle role_options table?
+				case systemschema.RoleOptionsTable.GetName():
+					systemTables = append(systemTables, desc)
 				}
 			}
 		}

--- a/pkg/ccl/backupccl/testdata/backup-restore/system-users
+++ b/pkg/ccl/backupccl/testdata/backup-restore/system-users
@@ -1,0 +1,53 @@
+new-server name=s1
+----
+
+exec-sql
+CREATE ROLE testuser NOLOGIN;
+CREATE ROLE testuser2 WITH CONTROLJOB CREATEDB;
+CREATE ROLE developer WITH CREATEDB;
+CREATE USER abbey WITH PASSWORD 'lincoln';
+GRANT developer TO abbey;
+----
+
+query-sql
+SHOW ROLES
+----
+abbey  {developer}
+admin  {}
+developer CREATEDB, NOLOGIN {}
+root  {admin}
+testuser NOLOGIN {}
+testuser2 CONTROLJOB, CREATEDB, NOLOGIN {}
+
+query-sql
+SHOW GRANTS ON ROLE developer
+----
+developer abbey false
+
+exec-sql
+BACKUP DATABASE system INTO 'nodelocal://0/test/'
+----
+
+# Start a new cluster with the same IO dir.
+new-server name=s2 share-io-dir=s1
+----
+
+# Restore into the new cluster.
+exec-sql cluster=s2
+RESTORE SYSTEM USERS FROM LATEST IN 'nodelocal://0/test/'
+----
+
+query-sql cluster=s2
+SHOW ROLES
+----
+abbey  {developer}
+admin  {}
+developer CREATEDB, NOLOGIN {}
+root  {admin}
+testuser NOLOGIN {}
+testuser2 CONTROLJOB, CREATEDB, NOLOGIN {}
+
+query-sql cluster=s2
+SHOW GRANTS ON ROLE developer
+----
+developer abbey false


### PR DESCRIPTION
Backport 1/1 commits from #94134.

/cc @cockroachdb/release

Release justification: bug fix

---

Previously, we did not restore the system.role_options table when executing RESTORE SYSTEM USERS. As a result, a user's role options would not be restored.

For example, a user create with

   CREATE USER foo WITH NOLOGIN

would lose the NOLOGIN option.

Now, we restore these options.

Fixes: #94107

Release note (bug fix): Fixed a bug in which RESTORE SYSTEM USERS failed to restore role options.
