### PR TITLE
sql: make pg_description aware of builtin function descriptions

### DIFF
--- a/pkg/cli/clisqlshell/testdata/complete/composite_names
+++ b/pkg/cli/clisqlshell/testdata/complete/composite_names
@@ -10,7 +10,7 @@ complete 0 32
 msg: ""
 completions:
 - "functions":
-  "crdb_internal.force_error(" (This function is used only by CockroachDB's developers for testing purposes.) -> "crdb_internal.force_error(" (0, 25)
+  "crdb_internal.force_error(" (This function is used only by CockroachDB's developers for testing purposes) -> "crdb_internal.force_error(" (0, 25)
 
 sql
 create schema my_schema
@@ -34,7 +34,7 @@ complete 0 9
 msg: ""
 completions:
 - "functions":
-  "my_func(" () -> "my_func(" (0, 2)
+  "my_func(" ((from schema public) ) -> "my_func(" (0, 2)
 - "schema":
   "my_schema" () -> "my_schema" (0, 2)
 
@@ -54,8 +54,8 @@ complete 0 25
 msg: ""
 completions:
 - "functions":
-  "pg_catalog.array_length(" (Calculates the length of `input` on the provided `array_dimension`. However, bec) -> "pg_catalog.array_length(" (0, 18)
-  "pg_catalog.array_lower(" (Calculates the minimum value of `input` on the provided `array_dimension`. Howev) -> "pg_catalog.array_lower(" (0, 18)
+  "pg_catalog.array_length(" (Calculates the length of `input` on the provided `array_dimension`) -> "pg_catalog.array_length(" (0, 18)
+  "pg_catalog.array_lower(" (Calculates the minimum value of `input` on the provided `array_dimension`) -> "pg_catalog.array_lower(" (0, 18)
 
 complete
 select "PG_CATALOG".@

--- a/pkg/cli/clisqlshell/testdata/complete/functions
+++ b/pkg/cli/clisqlshell/testdata/complete/functions
@@ -1,0 +1,35 @@
+sql
+CREATE FUNCTION lalala(val INT) RETURNS INT LANGUAGE SQL AS $$ SELECT val $$;
+CREATE FUNCTION lastval(val INT) RETURNS INT LANGUAGE SQL AS $$ SELECT val $$;
+----
+ok
+
+complete
+SELECT la@
+----
+complete 0 9
+msg: ""
+completions:
+- "functions":
+  "lag(" ((from schema pg_catalog) Returns `val` evaluated at the previous row within current row's partition; if t) -> "lag(" (0, 2)
+  "lalala(" ((from schema public) ) -> "lalala(" (0, 2)
+  "last_value(" ((from schema pg_catalog) Returns `val` evaluated at the row that is the last row of the window frame) -> "last_value(" (0, 2)
+  "lastval(" ((from schema pg_catalog) Return value most recently obtained with nextval in this session) -> "lastval(" (0, 2)
+  "lastval(" ((from schema public) ) -> "lastval(" (0, 2)
+- "keyword":
+  "LABEL" (unreserved) -> "LABEL" (0, 2)
+  "LANGUAGE" (unreserved) -> "LANGUAGE" (0, 2)
+  "LAST" (unreserved) -> "LAST" (0, 2)
+  "LATERAL" (reserved) -> "LATERAL" (0, 2)
+  "LATEST" (unreserved) -> "LATEST" (0, 2)
+
+complete
+SELECT pg_catalog.la@
+----
+complete 0 20
+msg: ""
+completions:
+- "functions":
+  "pg_catalog.lag(" (Returns `val` evaluated at the previous row within current row's partition; if t) -> "pg_catalog.lag(" (0, 13)
+  "pg_catalog.last_value(" (Returns `val` evaluated at the row that is the last row of the window frame) -> "pg_catalog.last_value(" (0, 13)
+  "pg_catalog.lastval(" (Return value most recently obtained with nextval in this session) -> "pg_catalog.lastval(" (0, 13)

--- a/pkg/cli/clisqlshell/testdata/complete/sql
+++ b/pkg/cli/clisqlshell/testdata/complete/sql
@@ -10,16 +10,16 @@ completions:
   "postgres" () -> "postgres" (0, 0)
   "system" () -> "system" (0, 0)
 - "functions":
-  "_st_contains(" (Returns true if no points of geometry_b lie in the exterior of geometry_a, and t) -> "_st_contains(" (0, 0)
-  "_st_containsproperly(" (Returns true if geometry_b intersects the interior of geometry_a but not the bou) -> "_st_containsproperly(" (0, 0)
-  "_st_coveredby(" (Returns true if no point in geometry_a is outside geometry_b.) -> "_st_coveredby(" (0, 0)
-  "_st_covers(" (Returns true if no point in geometry_b is outside geometry_a.) -> "_st_covers(" (0, 0)
-  "_st_crosses(" (Returns true if geometry_a has some - but not all - interior points in common wi) -> "_st_crosses(" (0, 0)
-  "_st_dfullywithin(" (Returns true if every pair of points comprising geometry_a and geometry_b are wi) -> "_st_dfullywithin(" (0, 0)
-  "_st_dfullywithinexclusive(" (Returns true if every pair of points comprising geometry_a and geometry_b are wi) -> "_st_dfullywithinexclusive(" (0, 0)
-  "_st_dwithin(" (Returns true if any of geometry_a is within distance units of geometry_b, inclus) -> "_st_dwithin(" (0, 0)
-  "_st_dwithinexclusive(" (Returns true if any of geometry_a is within distance units of geometry_b, exclus) -> "_st_dwithinexclusive(" (0, 0)
-  "_st_equals(" (Returns true if geometry_a is spatially equal to geometry_b, i.e. ST_Within(geom) -> "_st_equals(" (0, 0)
+  "\"current_date\"(" ((from schema pg_catalog) Returns the date of the current transaction) -> "\"current_date\"(" (0, 0)
+  "\"current_schema\"(" ((from schema pg_catalog) Returns the current schema) -> "\"current_schema\"(" (0, 0)
+  "\"current_time\"(" ((from schema pg_catalog) Returns the current transaction's time with time zone) -> "\"current_time\"(" (0, 0)
+  "\"current_timestamp\"(" ((from schema pg_catalog) Returns the time of the current transaction) -> "\"current_timestamp\"(" (0, 0)
+  "\"current_user\"(" ((from schema pg_catalog) Returns the current user) -> "\"current_user\"(" (0, 0)
+  "\"extract\"(" ((from schema pg_catalog) Extracts `element` from `input`) -> "\"extract\"(" (0, 0)
+  "\"extract_duration\"(" ((from schema pg_catalog) Extracts `element` from `input`) -> "\"extract_duration\"(" (0, 0)
+  "\"family\"(" ((from schema pg_catalog) Extracts the IP family of the value; 4 for IPv4, 6 for IPv6) -> "\"family\"(" (0, 0)
+  "\"greatest\"(" ((from schema pg_catalog) Returns the element with the greatest value) -> "\"greatest\"(" (0, 0)
+  "\"information_schema._pg_char_max_length\"(" ((from schema pg_catalog) Not usable; exposed only for compatibility with PostgreSQL) -> "\"information_schema._pg_char_max_length\"(" (0, 0)
   ... entries omitted ...
 - "keyword":
   "ABORT" (unreserved) -> "ABORT" (0, 0)
@@ -50,7 +50,7 @@ completions:
 - "database":
   "defaultdb" () -> "defaultdb" (0, 6)
 - "functions":
-  "default_to_database_primary_region(" (Returns the given region if the region has been added to the current database.) -> "default_to_database_primary_region(" (0, 6)
+  "default_to_database_primary_region(" ((from schema pg_catalog) Returns the given region if the region has been added to the current database) -> "default_to_database_primary_region(" (0, 6)
 - "keyword":
   "DEFAULT" (reserved) -> "DEFAULT" (0, 6)
   "DEFAULTS" (unreserved) -> "DEFAULTS" (0, 6)
@@ -110,5 +110,5 @@ complete 0 14
 msg: ""
 completions:
 - "functions":
-  "array_length(" (Calculates the length of `input` on the provided `array_dimension`. However, bec) -> "array_length(" (0, 7)
-  "array_lower(" (Calculates the minimum value of `input` on the provided `array_dimension`. Howev) -> "array_lower(" (0, 7)
+  "array_length(" ((from schema pg_catalog) Calculates the length of `input` on the provided `array_dimension`) -> "array_length(" (0, 7)
+  "array_lower(" ((from schema pg_catalog) Calculates the minimum value of `input` on the provided `array_dimension`) -> "array_lower(" (0, 7)

--- a/pkg/sql/comment_on_table_test.go
+++ b/pkg/sql/comment_on_table_test.go
@@ -39,17 +39,17 @@ func TestCommentOnTable(t *testing.T) {
 		}{
 			{
 				`COMMENT ON TABLE t IS 'foo'`,
-				`SELECT obj_description('t'::regclass)`,
+				`SELECT obj_description('t'::regclass, 'pg_class')`,
 				gosql.NullString{String: `foo`, Valid: true},
 			},
 			{
 				`TRUNCATE t`,
-				`SELECT obj_description('t'::regclass)`,
+				`SELECT obj_description('t'::regclass, 'pg_class')`,
 				gosql.NullString{String: `foo`, Valid: true},
 			},
 			{
 				`COMMENT ON TABLE t IS NULL`,
-				`SELECT obj_description('t'::regclass)`,
+				`SELECT obj_description('t'::regclass, 'pg_class')`,
 				gosql.NullString{Valid: false},
 			},
 		}

--- a/pkg/sql/comprules/testdata/completion_patterns/builtins
+++ b/pkg/sql/comprules/testdata/completion_patterns/builtins
@@ -13,24 +13,24 @@ ii'
 functions: completing for "xor" (7,10) with schema ""
 --sql:
 WITH p AS (
+SELECT min(p.oid) AS oid, p.proname, n.nspname
+  FROM pg_catalog.pg_proc p
+  JOIN pg_catalog.pg_namespace n ON n.oid = p.pronamespace
+ WHERE left(p.proname, length($1:::STRING)) = $1:::STRING
+ AND ((length($4) > 0 AND $4 = n.nspname)
+   OR (length($4) = 0 AND n.nspname = ANY current_schemas(true)))
+GROUP BY p.proname, n.nspname
+)
 SELECT DISTINCT
-       proname, nspname
-  FROM pg_catalog.pg_proc
-  JOIN pg_catalog.pg_namespace n ON n.oid = pronamespace)
-SELECT IF(length($4) > 0, pg_catalog.quote_ident($4:::STRING) || '.', '') ||
+       IF(length($4) > 0, pg_catalog.quote_ident($4:::STRING) || '.', '') ||
        pg_catalog.quote_ident(proname) || '(' AS completion,
        'functions' AS category,
-       substr(COALESCE((
-         SELECT details
-          FROM "".crdb_internal.builtin_functions f2
-         WHERE f2.function = p.proname AND f2.schema = p.nspname
-         LIMIT 1), ''), e'[^\n]{0,80}') AS description,
+       IF(length($4) = 0, '(from schema '||nspname||') ', '') ||
+       substr(COALESCE(pg_catalog.obj_description(oid, 'pg_proc'),''), e'[^.\n]{0,80}') AS description,
        $2:::INT AS start,
        $3:::INT AS end
   FROM p
- WHERE left(proname, length($1:::STRING)) = $1:::STRING
- AND ((length($4) > 0 AND $4 = nspname)
-   OR (length($4) = 0 AND nspname = ANY current_schemas(true)))
+ORDER BY 1,2,3,4,5
 --placeholders: []interface {}{"xor", 7, 10, ""}
 
 comp at=12
@@ -42,24 +42,24 @@ ii_
 functions: completing for "" (12,12) with schema ""
 --sql:
 WITH p AS (
+SELECT min(p.oid) AS oid, p.proname, n.nspname
+  FROM pg_catalog.pg_proc p
+  JOIN pg_catalog.pg_namespace n ON n.oid = p.pronamespace
+ WHERE left(p.proname, length($1:::STRING)) = $1:::STRING
+ AND ((length($4) > 0 AND $4 = n.nspname)
+   OR (length($4) = 0 AND n.nspname = ANY current_schemas(true)))
+GROUP BY p.proname, n.nspname
+)
 SELECT DISTINCT
-       proname, nspname
-  FROM pg_catalog.pg_proc
-  JOIN pg_catalog.pg_namespace n ON n.oid = pronamespace)
-SELECT IF(length($4) > 0, pg_catalog.quote_ident($4:::STRING) || '.', '') ||
+       IF(length($4) > 0, pg_catalog.quote_ident($4:::STRING) || '.', '') ||
        pg_catalog.quote_ident(proname) || '(' AS completion,
        'functions' AS category,
-       substr(COALESCE((
-         SELECT details
-          FROM "".crdb_internal.builtin_functions f2
-         WHERE f2.function = p.proname AND f2.schema = p.nspname
-         LIMIT 1), ''), e'[^\n]{0,80}') AS description,
+       IF(length($4) = 0, '(from schema '||nspname||') ', '') ||
+       substr(COALESCE(pg_catalog.obj_description(oid, 'pg_proc'),''), e'[^.\n]{0,80}') AS description,
        $2:::INT AS start,
        $3:::INT AS end
   FROM p
- WHERE left(proname, length($1:::STRING)) = $1:::STRING
- AND ((length($4) > 0 AND $4 = nspname)
-   OR (length($4) = 0 AND nspname = ANY current_schemas(true)))
+ORDER BY 1,2,3,4,5
 --placeholders: []interface {}{"", 12, 12, ""}
 
 subtest end
@@ -75,24 +75,24 @@ ii.i'
 functions: completing for "xor" (7,12) with schema "a"
 --sql:
 WITH p AS (
+SELECT min(p.oid) AS oid, p.proname, n.nspname
+  FROM pg_catalog.pg_proc p
+  JOIN pg_catalog.pg_namespace n ON n.oid = p.pronamespace
+ WHERE left(p.proname, length($1:::STRING)) = $1:::STRING
+ AND ((length($4) > 0 AND $4 = n.nspname)
+   OR (length($4) = 0 AND n.nspname = ANY current_schemas(true)))
+GROUP BY p.proname, n.nspname
+)
 SELECT DISTINCT
-       proname, nspname
-  FROM pg_catalog.pg_proc
-  JOIN pg_catalog.pg_namespace n ON n.oid = pronamespace)
-SELECT IF(length($4) > 0, pg_catalog.quote_ident($4:::STRING) || '.', '') ||
+       IF(length($4) > 0, pg_catalog.quote_ident($4:::STRING) || '.', '') ||
        pg_catalog.quote_ident(proname) || '(' AS completion,
        'functions' AS category,
-       substr(COALESCE((
-         SELECT details
-          FROM "".crdb_internal.builtin_functions f2
-         WHERE f2.function = p.proname AND f2.schema = p.nspname
-         LIMIT 1), ''), e'[^\n]{0,80}') AS description,
+       IF(length($4) = 0, '(from schema '||nspname||') ', '') ||
+       substr(COALESCE(pg_catalog.obj_description(oid, 'pg_proc'),''), e'[^.\n]{0,80}') AS description,
        $2:::INT AS start,
        $3:::INT AS end
   FROM p
- WHERE left(proname, length($1:::STRING)) = $1:::STRING
- AND ((length($4) > 0 AND $4 = nspname)
-   OR (length($4) = 0 AND nspname = ANY current_schemas(true)))
+ORDER BY 1,2,3,4,5
 --placeholders: []interface {}{"xor", 7, 12, "a"}
 
 comp at=10
@@ -104,24 +104,24 @@ ii._
 functions: completing for "" (7,9) with schema "a"
 --sql:
 WITH p AS (
+SELECT min(p.oid) AS oid, p.proname, n.nspname
+  FROM pg_catalog.pg_proc p
+  JOIN pg_catalog.pg_namespace n ON n.oid = p.pronamespace
+ WHERE left(p.proname, length($1:::STRING)) = $1:::STRING
+ AND ((length($4) > 0 AND $4 = n.nspname)
+   OR (length($4) = 0 AND n.nspname = ANY current_schemas(true)))
+GROUP BY p.proname, n.nspname
+)
 SELECT DISTINCT
-       proname, nspname
-  FROM pg_catalog.pg_proc
-  JOIN pg_catalog.pg_namespace n ON n.oid = pronamespace)
-SELECT IF(length($4) > 0, pg_catalog.quote_ident($4:::STRING) || '.', '') ||
+       IF(length($4) > 0, pg_catalog.quote_ident($4:::STRING) || '.', '') ||
        pg_catalog.quote_ident(proname) || '(' AS completion,
        'functions' AS category,
-       substr(COALESCE((
-         SELECT details
-          FROM "".crdb_internal.builtin_functions f2
-         WHERE f2.function = p.proname AND f2.schema = p.nspname
-         LIMIT 1), ''), e'[^\n]{0,80}') AS description,
+       IF(length($4) = 0, '(from schema '||nspname||') ', '') ||
+       substr(COALESCE(pg_catalog.obj_description(oid, 'pg_proc'),''), e'[^.\n]{0,80}') AS description,
        $2:::INT AS start,
        $3:::INT AS end
   FROM p
- WHERE left(proname, length($1:::STRING)) = $1:::STRING
- AND ((length($4) > 0 AND $4 = nspname)
-   OR (length($4) = 0 AND nspname = ANY current_schemas(true)))
+ORDER BY 1,2,3,4,5
 --placeholders: []interface {}{"", 7, 9, "a"}
 
 subtest end
@@ -137,24 +137,24 @@ ii.i'
 functions: completing for "xor" (7,24) with schema "crdb_internal"
 --sql:
 WITH p AS (
+SELECT min(p.oid) AS oid, p.proname, n.nspname
+  FROM pg_catalog.pg_proc p
+  JOIN pg_catalog.pg_namespace n ON n.oid = p.pronamespace
+ WHERE left(p.proname, length($1:::STRING)) = $1:::STRING
+ AND ((length($4) > 0 AND $4 = n.nspname)
+   OR (length($4) = 0 AND n.nspname = ANY current_schemas(true)))
+GROUP BY p.proname, n.nspname
+)
 SELECT DISTINCT
-       proname, nspname
-  FROM pg_catalog.pg_proc
-  JOIN pg_catalog.pg_namespace n ON n.oid = pronamespace)
-SELECT IF(length($4) > 0, pg_catalog.quote_ident($4:::STRING) || '.', '') ||
+       IF(length($4) > 0, pg_catalog.quote_ident($4:::STRING) || '.', '') ||
        pg_catalog.quote_ident(proname) || '(' AS completion,
        'functions' AS category,
-       substr(COALESCE((
-         SELECT details
-          FROM "".crdb_internal.builtin_functions f2
-         WHERE f2.function = p.proname AND f2.schema = p.nspname
-         LIMIT 1), ''), e'[^\n]{0,80}') AS description,
+       IF(length($4) = 0, '(from schema '||nspname||') ', '') ||
+       substr(COALESCE(pg_catalog.obj_description(oid, 'pg_proc'),''), e'[^.\n]{0,80}') AS description,
        $2:::INT AS start,
        $3:::INT AS end
   FROM p
- WHERE left(proname, length($1:::STRING)) = $1:::STRING
- AND ((length($4) > 0 AND $4 = nspname)
-   OR (length($4) = 0 AND nspname = ANY current_schemas(true)))
+ORDER BY 1,2,3,4,5
 --placeholders: []interface {}{"xor", 7, 24, "crdb_internal"}
 
 comp at=21
@@ -166,24 +166,24 @@ ii.'
 functions: completing for "" (7,21) with schema "crdb_internal"
 --sql:
 WITH p AS (
+SELECT min(p.oid) AS oid, p.proname, n.nspname
+  FROM pg_catalog.pg_proc p
+  JOIN pg_catalog.pg_namespace n ON n.oid = p.pronamespace
+ WHERE left(p.proname, length($1:::STRING)) = $1:::STRING
+ AND ((length($4) > 0 AND $4 = n.nspname)
+   OR (length($4) = 0 AND n.nspname = ANY current_schemas(true)))
+GROUP BY p.proname, n.nspname
+)
 SELECT DISTINCT
-       proname, nspname
-  FROM pg_catalog.pg_proc
-  JOIN pg_catalog.pg_namespace n ON n.oid = pronamespace)
-SELECT IF(length($4) > 0, pg_catalog.quote_ident($4:::STRING) || '.', '') ||
+       IF(length($4) > 0, pg_catalog.quote_ident($4:::STRING) || '.', '') ||
        pg_catalog.quote_ident(proname) || '(' AS completion,
        'functions' AS category,
-       substr(COALESCE((
-         SELECT details
-          FROM "".crdb_internal.builtin_functions f2
-         WHERE f2.function = p.proname AND f2.schema = p.nspname
-         LIMIT 1), ''), e'[^\n]{0,80}') AS description,
+       IF(length($4) = 0, '(from schema '||nspname||') ', '') ||
+       substr(COALESCE(pg_catalog.obj_description(oid, 'pg_proc'),''), e'[^.\n]{0,80}') AS description,
        $2:::INT AS start,
        $3:::INT AS end
   FROM p
- WHERE left(proname, length($1:::STRING)) = $1:::STRING
- AND ((length($4) > 0 AND $4 = nspname)
-   OR (length($4) = 0 AND nspname = ANY current_schemas(true)))
+ORDER BY 1,2,3,4,5
 --placeholders: []interface {}{"", 7, 21, "crdb_internal"}
 
 
@@ -196,24 +196,24 @@ ii.i'
 functions: completing for "xor" (7,21) with schema "pg_catalog"
 --sql:
 WITH p AS (
+SELECT min(p.oid) AS oid, p.proname, n.nspname
+  FROM pg_catalog.pg_proc p
+  JOIN pg_catalog.pg_namespace n ON n.oid = p.pronamespace
+ WHERE left(p.proname, length($1:::STRING)) = $1:::STRING
+ AND ((length($4) > 0 AND $4 = n.nspname)
+   OR (length($4) = 0 AND n.nspname = ANY current_schemas(true)))
+GROUP BY p.proname, n.nspname
+)
 SELECT DISTINCT
-       proname, nspname
-  FROM pg_catalog.pg_proc
-  JOIN pg_catalog.pg_namespace n ON n.oid = pronamespace)
-SELECT IF(length($4) > 0, pg_catalog.quote_ident($4:::STRING) || '.', '') ||
+       IF(length($4) > 0, pg_catalog.quote_ident($4:::STRING) || '.', '') ||
        pg_catalog.quote_ident(proname) || '(' AS completion,
        'functions' AS category,
-       substr(COALESCE((
-         SELECT details
-          FROM "".crdb_internal.builtin_functions f2
-         WHERE f2.function = p.proname AND f2.schema = p.nspname
-         LIMIT 1), ''), e'[^\n]{0,80}') AS description,
+       IF(length($4) = 0, '(from schema '||nspname||') ', '') ||
+       substr(COALESCE(pg_catalog.obj_description(oid, 'pg_proc'),''), e'[^.\n]{0,80}') AS description,
        $2:::INT AS start,
        $3:::INT AS end
   FROM p
- WHERE left(proname, length($1:::STRING)) = $1:::STRING
- AND ((length($4) > 0 AND $4 = nspname)
-   OR (length($4) = 0 AND nspname = ANY current_schemas(true)))
+ORDER BY 1,2,3,4,5
 --placeholders: []interface {}{"xor", 7, 21, "pg_catalog"}
 
 comp at=18
@@ -225,24 +225,24 @@ ii.'
 functions: completing for "" (7,18) with schema "pg_catalog"
 --sql:
 WITH p AS (
+SELECT min(p.oid) AS oid, p.proname, n.nspname
+  FROM pg_catalog.pg_proc p
+  JOIN pg_catalog.pg_namespace n ON n.oid = p.pronamespace
+ WHERE left(p.proname, length($1:::STRING)) = $1:::STRING
+ AND ((length($4) > 0 AND $4 = n.nspname)
+   OR (length($4) = 0 AND n.nspname = ANY current_schemas(true)))
+GROUP BY p.proname, n.nspname
+)
 SELECT DISTINCT
-       proname, nspname
-  FROM pg_catalog.pg_proc
-  JOIN pg_catalog.pg_namespace n ON n.oid = pronamespace)
-SELECT IF(length($4) > 0, pg_catalog.quote_ident($4:::STRING) || '.', '') ||
+       IF(length($4) > 0, pg_catalog.quote_ident($4:::STRING) || '.', '') ||
        pg_catalog.quote_ident(proname) || '(' AS completion,
        'functions' AS category,
-       substr(COALESCE((
-         SELECT details
-          FROM "".crdb_internal.builtin_functions f2
-         WHERE f2.function = p.proname AND f2.schema = p.nspname
-         LIMIT 1), ''), e'[^\n]{0,80}') AS description,
+       IF(length($4) = 0, '(from schema '||nspname||') ', '') ||
+       substr(COALESCE(pg_catalog.obj_description(oid, 'pg_proc'),''), e'[^.\n]{0,80}') AS description,
        $2:::INT AS start,
        $3:::INT AS end
   FROM p
- WHERE left(proname, length($1:::STRING)) = $1:::STRING
- AND ((length($4) > 0 AND $4 = nspname)
-   OR (length($4) = 0 AND nspname = ANY current_schemas(true)))
+ORDER BY 1,2,3,4,5
 --placeholders: []interface {}{"", 7, 18, "pg_catalog"}
 
 
@@ -255,24 +255,24 @@ ii.i'
 functions: completing for "xor" (7,29) with schema "information_schema"
 --sql:
 WITH p AS (
+SELECT min(p.oid) AS oid, p.proname, n.nspname
+  FROM pg_catalog.pg_proc p
+  JOIN pg_catalog.pg_namespace n ON n.oid = p.pronamespace
+ WHERE left(p.proname, length($1:::STRING)) = $1:::STRING
+ AND ((length($4) > 0 AND $4 = n.nspname)
+   OR (length($4) = 0 AND n.nspname = ANY current_schemas(true)))
+GROUP BY p.proname, n.nspname
+)
 SELECT DISTINCT
-       proname, nspname
-  FROM pg_catalog.pg_proc
-  JOIN pg_catalog.pg_namespace n ON n.oid = pronamespace)
-SELECT IF(length($4) > 0, pg_catalog.quote_ident($4:::STRING) || '.', '') ||
+       IF(length($4) > 0, pg_catalog.quote_ident($4:::STRING) || '.', '') ||
        pg_catalog.quote_ident(proname) || '(' AS completion,
        'functions' AS category,
-       substr(COALESCE((
-         SELECT details
-          FROM "".crdb_internal.builtin_functions f2
-         WHERE f2.function = p.proname AND f2.schema = p.nspname
-         LIMIT 1), ''), e'[^\n]{0,80}') AS description,
+       IF(length($4) = 0, '(from schema '||nspname||') ', '') ||
+       substr(COALESCE(pg_catalog.obj_description(oid, 'pg_proc'),''), e'[^.\n]{0,80}') AS description,
        $2:::INT AS start,
        $3:::INT AS end
   FROM p
- WHERE left(proname, length($1:::STRING)) = $1:::STRING
- AND ((length($4) > 0 AND $4 = nspname)
-   OR (length($4) = 0 AND nspname = ANY current_schemas(true)))
+ORDER BY 1,2,3,4,5
 --placeholders: []interface {}{"xor", 7, 29, "information_schema"}
 
 comp at=26
@@ -284,24 +284,24 @@ ii.'
 functions: completing for "" (7,26) with schema "information_schema"
 --sql:
 WITH p AS (
+SELECT min(p.oid) AS oid, p.proname, n.nspname
+  FROM pg_catalog.pg_proc p
+  JOIN pg_catalog.pg_namespace n ON n.oid = p.pronamespace
+ WHERE left(p.proname, length($1:::STRING)) = $1:::STRING
+ AND ((length($4) > 0 AND $4 = n.nspname)
+   OR (length($4) = 0 AND n.nspname = ANY current_schemas(true)))
+GROUP BY p.proname, n.nspname
+)
 SELECT DISTINCT
-       proname, nspname
-  FROM pg_catalog.pg_proc
-  JOIN pg_catalog.pg_namespace n ON n.oid = pronamespace)
-SELECT IF(length($4) > 0, pg_catalog.quote_ident($4:::STRING) || '.', '') ||
+       IF(length($4) > 0, pg_catalog.quote_ident($4:::STRING) || '.', '') ||
        pg_catalog.quote_ident(proname) || '(' AS completion,
        'functions' AS category,
-       substr(COALESCE((
-         SELECT details
-          FROM "".crdb_internal.builtin_functions f2
-         WHERE f2.function = p.proname AND f2.schema = p.nspname
-         LIMIT 1), ''), e'[^\n]{0,80}') AS description,
+       IF(length($4) = 0, '(from schema '||nspname||') ', '') ||
+       substr(COALESCE(pg_catalog.obj_description(oid, 'pg_proc'),''), e'[^.\n]{0,80}') AS description,
        $2:::INT AS start,
        $3:::INT AS end
   FROM p
- WHERE left(proname, length($1:::STRING)) = $1:::STRING
- AND ((length($4) > 0 AND $4 = nspname)
-   OR (length($4) = 0 AND nspname = ANY current_schemas(true)))
+ORDER BY 1,2,3,4,5
 --placeholders: []interface {}{"", 7, 26, "information_schema"}
 
 subtest end
@@ -317,24 +317,24 @@ ii.i'
 functions: completing for "xor" (7,23) with schema "pg_catalog"
 --sql:
 WITH p AS (
+SELECT min(p.oid) AS oid, p.proname, n.nspname
+  FROM pg_catalog.pg_proc p
+  JOIN pg_catalog.pg_namespace n ON n.oid = p.pronamespace
+ WHERE left(p.proname, length($1:::STRING)) = $1:::STRING
+ AND ((length($4) > 0 AND $4 = n.nspname)
+   OR (length($4) = 0 AND n.nspname = ANY current_schemas(true)))
+GROUP BY p.proname, n.nspname
+)
 SELECT DISTINCT
-       proname, nspname
-  FROM pg_catalog.pg_proc
-  JOIN pg_catalog.pg_namespace n ON n.oid = pronamespace)
-SELECT IF(length($4) > 0, pg_catalog.quote_ident($4:::STRING) || '.', '') ||
+       IF(length($4) > 0, pg_catalog.quote_ident($4:::STRING) || '.', '') ||
        pg_catalog.quote_ident(proname) || '(' AS completion,
        'functions' AS category,
-       substr(COALESCE((
-         SELECT details
-          FROM "".crdb_internal.builtin_functions f2
-         WHERE f2.function = p.proname AND f2.schema = p.nspname
-         LIMIT 1), ''), e'[^\n]{0,80}') AS description,
+       IF(length($4) = 0, '(from schema '||nspname||') ', '') ||
+       substr(COALESCE(pg_catalog.obj_description(oid, 'pg_proc'),''), e'[^.\n]{0,80}') AS description,
        $2:::INT AS start,
        $3:::INT AS end
   FROM p
- WHERE left(proname, length($1:::STRING)) = $1:::STRING
- AND ((length($4) > 0 AND $4 = nspname)
-   OR (length($4) = 0 AND nspname = ANY current_schemas(true)))
+ORDER BY 1,2,3,4,5
 --placeholders: []interface {}{"xor", 7, 23, "pg_catalog"}
 
 # Quoted uppercase is an entire schema entirely.
@@ -347,24 +347,24 @@ ii.i'
 functions: completing for "xor" (7,23) with schema "PG_CATALOG"
 --sql:
 WITH p AS (
+SELECT min(p.oid) AS oid, p.proname, n.nspname
+  FROM pg_catalog.pg_proc p
+  JOIN pg_catalog.pg_namespace n ON n.oid = p.pronamespace
+ WHERE left(p.proname, length($1:::STRING)) = $1:::STRING
+ AND ((length($4) > 0 AND $4 = n.nspname)
+   OR (length($4) = 0 AND n.nspname = ANY current_schemas(true)))
+GROUP BY p.proname, n.nspname
+)
 SELECT DISTINCT
-       proname, nspname
-  FROM pg_catalog.pg_proc
-  JOIN pg_catalog.pg_namespace n ON n.oid = pronamespace)
-SELECT IF(length($4) > 0, pg_catalog.quote_ident($4:::STRING) || '.', '') ||
+       IF(length($4) > 0, pg_catalog.quote_ident($4:::STRING) || '.', '') ||
        pg_catalog.quote_ident(proname) || '(' AS completion,
        'functions' AS category,
-       substr(COALESCE((
-         SELECT details
-          FROM "".crdb_internal.builtin_functions f2
-         WHERE f2.function = p.proname AND f2.schema = p.nspname
-         LIMIT 1), ''), e'[^\n]{0,80}') AS description,
+       IF(length($4) = 0, '(from schema '||nspname||') ', '') ||
+       substr(COALESCE(pg_catalog.obj_description(oid, 'pg_proc'),''), e'[^.\n]{0,80}') AS description,
        $2:::INT AS start,
        $3:::INT AS end
   FROM p
- WHERE left(proname, length($1:::STRING)) = $1:::STRING
- AND ((length($4) > 0 AND $4 = nspname)
-   OR (length($4) = 0 AND nspname = ANY current_schemas(true)))
+ORDER BY 1,2,3,4,5
 --placeholders: []interface {}{"xor", 7, 23, "PG_CATALOG"}
 
 

--- a/pkg/sql/delegate/show_tables.go
+++ b/pkg/sql/delegate/show_tables.go
@@ -96,8 +96,8 @@ ORDER BY schema_name, table_name
 	var comment string
 	if n.WithComment {
 		descJoin = fmt.Sprintf(
-			`LEFT JOIN %s.pg_catalog.pg_description AS pd ON (pc.oid = pd.objoid AND pd.objsubid = 0)`,
-			&name.CatalogName,
+			`LEFT JOIN %[1]s.pg_catalog.pg_description AS pd ON (pc.oid = pd.objoid AND pd.objsubid = 0 AND pd.classoid = %[2]d)`,
+			&name.CatalogName, catconstants.PgCatalogClassTableID,
 		)
 		comment = `, COALESCE(pd.description, '') AS comment`
 	}

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -2367,6 +2367,15 @@ json_extract_path  25           2         3802        3802 25      {i,v}
 
 user root
 
+query TT rowsort
+SELECT DISTINCT proname, prokind FROM pg_catalog.pg_proc
+WHERE proname IN ('lag', 'abs', 'max')
+----
+abs  f
+lag  w
+max  a
+
+
 ## pg_catalog.pg_range
 query IIIIII colnames
 SELECT * from pg_catalog.pg_range

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -2426,305 +2426,44 @@ testuser  2264919399  false        false     false    false         ********  NU
 
 ## pg_catalog.pg_description
 
-query OOIT colnames
-SELECT objoid, classoid, objsubid, regexp_replace(description, e'\n.*', '') AS description
-  FROM pg_catalog.pg_description
+statement ok
+CREATE TABLE testtable(x INT, INDEX testtable_x_idx(x));
+COMMENT ON TABLE testtable IS 'mycomment1';
+COMMENT ON COLUMN testtable.x IS 'mycomment2';
+COMMENT ON INDEX testtable_x_idx IS 'mycomment3';
+CREATE SCHEMA testschema; COMMENT ON SCHEMA testschema IS 'mycomment4';
+
+query TOOIT colnames
+SELECT c.relname, d.objoid, d.classoid, d.objsubid, regexp_replace(description, e'\n.*', '') AS description
+  FROM pg_catalog.pg_description d
+JOIN pg_catalog.pg_class c ON d.classoid = c.oid
+JOIN pg_catalog.pg_namespace n ON c.relnamespace = n.oid AND n.nspname = 'pg_catalog'
+WHERE
+   (c.relname = 'pg_proc' AND d.objoid IN (SELECT oid FROM pg_catalog.pg_proc WHERE proname = 'abs'))
+OR (c.relname = 'pg_class' AND d.objoid IN (SELECT oid FROM pg_catalog.pg_class WHERE relname IN ('pg_user', 'testtable')))
+OR (c.relname = 'pg_class' AND d.objoid IN (SELECT oid FROM pg_catalog.pg_class WHERE relname IN ('pg_user', 'testtable', 'testtable_x_idx')))
+OR (c.relname = 'pg_namespace' AND d.objoid IN (SELECT oid FROM pg_catalog.pg_namespace WHERE nspname = 'testschema'))
 ----
-objoid      classoid    objsubid  description
-4294966996  4294967117  0         Shows all defined Spatial Reference Identifiers (SRIDs). Matches PostGIS' spatial_ref_sys table.
-4294966997  4294967117  0         Shows all defined geometry columns. Matches PostGIS' geometry_columns functionality.
-4294966998  4294967117  0         Shows all defined geography columns. Matches PostGIS' geography_columns functionality.
-4294967000  4294967117  0         view definitions (incomplete - see also information_schema.views)
-4294967001  4294967117  0         database users
-4294967002  4294967117  0         pg_user_mappings was created for compatibility and is currently unimplemented
-4294967003  4294967117  0         local to remote user mapping (empty - feature does not exist)
-4294967004  4294967117  0         scalar types (incomplete)
-4294967005  4294967117  0         pg_ts_template was created for compatibility and is currently unimplemented
-4294967006  4294967117  0         pg_ts_parser was created for compatibility and is currently unimplemented
-4294967007  4294967117  0         pg_ts_dict was created for compatibility and is currently unimplemented
-4294967008  4294967117  0         pg_ts_config was created for compatibility and is currently unimplemented
-4294967009  4294967117  0         pg_ts_config_map was created for compatibility and is currently unimplemented
-4294967010  4294967117  0         triggers (empty - feature does not exist)
-4294967011  4294967117  0         pg_transform was created for compatibility and is currently unimplemented
-4294967012  4294967117  0         pg_timezone_names lists all the timezones that are supported by SET timezone
-4294967013  4294967117  0         pg_timezone_abbrevs was created for compatibility and is currently unimplemented
-4294967014  4294967117  0         available tablespaces (incomplete; concept inapplicable to CockroachDB)
-4294967015  4294967117  0         tables summary (see also information_schema.tables, pg_catalog.pg_class)
-4294967016  4294967117  0         pg_subscription was created for compatibility and is currently unimplemented
-4294967017  4294967117  0         pg_subscription_rel was created for compatibility and is currently unimplemented
-4294967018  4294967117  0         pg_stats was created for compatibility and is currently unimplemented
-4294967019  4294967117  0         pg_stats_ext was created for compatibility and is currently unimplemented
-4294967020  4294967117  0         pg_statistic was created for compatibility and is currently unimplemented
-4294967021  4294967117  0         pg_statistic_ext has the statistics objects created with CREATE STATISTICS
-4294967022  4294967117  0         pg_statistic_ext_data was created for compatibility and is currently unimplemented
-4294967023  4294967117  0         pg_statio_user_tables was created for compatibility and is currently unimplemented
-4294967024  4294967117  0         pg_statio_user_sequences was created for compatibility and is currently unimplemented
-4294967025  4294967117  0         pg_statio_user_indexes was created for compatibility and is currently unimplemented
-4294967026  4294967117  0         pg_statio_sys_tables was created for compatibility and is currently unimplemented
-4294967027  4294967117  0         pg_statio_sys_sequences was created for compatibility and is currently unimplemented
-4294967028  4294967117  0         pg_statio_sys_indexes was created for compatibility and is currently unimplemented
-4294967029  4294967117  0         pg_statio_all_tables was created for compatibility and is currently unimplemented
-4294967030  4294967117  0         pg_statio_all_sequences was created for compatibility and is currently unimplemented
-4294967031  4294967117  0         pg_statio_all_indexes was created for compatibility and is currently unimplemented
-4294967032  4294967117  0         pg_stat_xact_user_tables was created for compatibility and is currently unimplemented
-4294967033  4294967117  0         pg_stat_xact_user_functions was created for compatibility and is currently unimplemented
-4294967034  4294967117  0         pg_stat_xact_sys_tables was created for compatibility and is currently unimplemented
-4294967035  4294967117  0         pg_stat_xact_all_tables was created for compatibility and is currently unimplemented
-4294967036  4294967117  0         pg_stat_wal_receiver was created for compatibility and is currently unimplemented
-4294967037  4294967117  0         pg_stat_user_tables was created for compatibility and is currently unimplemented
-4294967038  4294967117  0         pg_stat_user_indexes was created for compatibility and is currently unimplemented
-4294967039  4294967117  0         pg_stat_user_functions was created for compatibility and is currently unimplemented
-4294967040  4294967117  0         pg_stat_sys_tables was created for compatibility and is currently unimplemented
-4294967041  4294967117  0         pg_stat_sys_indexes was created for compatibility and is currently unimplemented
-4294967042  4294967117  0         pg_stat_subscription was created for compatibility and is currently unimplemented
-4294967043  4294967117  0         pg_stat_ssl was created for compatibility and is currently unimplemented
-4294967044  4294967117  0         pg_stat_slru was created for compatibility and is currently unimplemented
-4294967045  4294967117  0         pg_stat_replication was created for compatibility and is currently unimplemented
-4294967046  4294967117  0         pg_stat_progress_vacuum was created for compatibility and is currently unimplemented
-4294967047  4294967117  0         pg_stat_progress_create_index was created for compatibility and is currently unimplemented
-4294967048  4294967117  0         pg_stat_progress_cluster was created for compatibility and is currently unimplemented
-4294967049  4294967117  0         pg_stat_progress_basebackup was created for compatibility and is currently unimplemented
-4294967050  4294967117  0         pg_stat_progress_analyze was created for compatibility and is currently unimplemented
-4294967051  4294967117  0         pg_stat_gssapi was created for compatibility and is currently unimplemented
-4294967052  4294967117  0         pg_stat_database was created for compatibility and is currently unimplemented
-4294967053  4294967117  0         pg_stat_database_conflicts was created for compatibility and is currently unimplemented
-4294967054  4294967117  0         pg_stat_bgwriter was created for compatibility and is currently unimplemented
-4294967055  4294967117  0         pg_stat_archiver was created for compatibility and is currently unimplemented
-4294967056  4294967117  0         pg_stat_all_tables was created for compatibility and is currently unimplemented
-4294967057  4294967117  0         pg_stat_all_indexes was created for compatibility and is currently unimplemented
-4294967058  4294967117  0         backend access statistics (empty - monitoring works differently in CockroachDB)
-4294967059  4294967117  0         pg_shmem_allocations was created for compatibility and is currently unimplemented
-4294967060  4294967117  0         Shared Dependencies (Roles depending on objects).
-4294967061  4294967117  0         shared security labels (empty - feature not supported)
-4294967062  4294967117  0         shared object comments
-4294967063  4294967117  0         pg_shadow lists properties for roles that are marked as rolcanlogin in pg_authid
-4294967064  4294967117  0         session variables (incomplete)
-4294967065  4294967117  0         pg_sequences is very similar as pg_sequence.
-4294967066  4294967117  0         sequences (see also information_schema.sequences)
-4294967067  4294967117  0         security labels (empty - feature does not exist)
-4294967068  4294967117  0         security labels (empty)
-4294967069  4294967117  0         pg_rules was created for compatibility and is currently unimplemented
-4294967070  4294967117  0         database roles
-4294967071  4294967117  0         rewrite rules (only for referencing on pg_depend for table-view dependencies)
-4294967072  4294967117  0         pg_replication_slots was created for compatibility and is currently unimplemented
-4294967073  4294967117  0         pg_replication_origin was created for compatibility and is currently unimplemented
-4294967074  4294967117  0         pg_replication_origin_status was created for compatibility and is currently unimplemented
-4294967075  4294967117  0         range types (empty - feature does not exist)
-4294967076  4294967117  0         pg_publication_tables was created for compatibility and is currently unimplemented
-4294967077  4294967117  0         pg_publication was created for compatibility and is currently unimplemented
-4294967078  4294967117  0         pg_publication_rel was created for compatibility and is currently unimplemented
-4294967079  4294967117  0         built-in functions (incomplete)
-4294967080  4294967117  0         prepared transactions (empty - feature does not exist)
-4294967081  4294967117  0         prepared statements
-4294967082  4294967117  0         pg_policy was created for compatibility and is currently unimplemented
-4294967083  4294967117  0         pg_policies was created for compatibility and is currently unimplemented
-4294967084  4294967117  0         pg_partitioned_table was created for compatibility and is currently unimplemented
-4294967085  4294967117  0         pg_opfamily was created for compatibility and is currently unimplemented
-4294967086  4294967117  0         operators (incomplete)
-4294967087  4294967117  0         opclass (empty - Operator classes not supported yet)
-4294967088  4294967117  0         available namespaces
-4294967089  4294967117  0         available materialized views (empty - feature does not exist)
-4294967090  4294967117  0         locks held by active processes (empty - feature does not exist)
-4294967091  4294967117  0         pg_largeobject was created for compatibility and is currently unimplemented
-4294967092  4294967117  0         pg_largeobject_metadata was created for compatibility and is currently unimplemented
-4294967093  4294967117  0         available languages (empty - feature does not exist)
-4294967094  4294967117  0         pg_init_privs was created for compatibility and is currently unimplemented
-4294967095  4294967117  0         table inheritance hierarchy (empty - feature does not exist)
-4294967096  4294967117  0         index creation statements
-4294967097  4294967117  0         indexes (incomplete)
-4294967098  4294967117  0         pg_hba_file_rules was created for compatibility and is currently unimplemented
-4294967099  4294967117  0         pg_group was created for compatibility and is currently unimplemented
-4294967100  4294967117  0         foreign tables (empty  - feature does not exist)
-4294967101  4294967117  0         foreign servers (empty - feature does not exist)
-4294967102  4294967117  0         foreign data wrappers (empty - feature does not exist)
-4294967103  4294967117  0         pg_file_settings was created for compatibility and is currently unimplemented
-4294967104  4294967117  0         installed extensions (empty - feature does not exist)
-4294967105  4294967117  0         event triggers (empty - feature does not exist)
-4294967106  4294967117  0         enum types and labels (empty - feature does not exist)
-4294967107  4294967117  0         object comments
-4294967108  4294967117  0         dependency relationships (incomplete)
-4294967109  4294967117  0         default ACLs; these are the privileges that will be assigned to newly created objects
-4294967110  4294967117  0         contains the default values that have been configured for session variables
-4294967111  4294967117  0         available databases (incomplete)
-4294967112  4294967117  0         contains currently active SQL cursors created with DECLARE
-4294967113  4294967117  0         encoding conversions (empty - unimplemented)
-4294967114  4294967117  0         table constraints (incomplete - see also information_schema.table_constraints)
-4294967115  4294967117  0         pg_config was created for compatibility and is currently unimplemented
-4294967116  4294967117  0         available collations (incomplete)
-4294967117  4294967117  0         tables and relation-like objects (incomplete - see also information_schema.tables/sequences/views)
-4294967118  4294967117  0         casts (empty - needs filling out)
-4294967119  4294967117  0         available extensions
-4294967120  4294967117  0         pg_available_extension_versions was created for compatibility and is currently unimplemented
-4294967121  4294967117  0         role membership
-4294967122  4294967117  0         authorization identifiers - differs from postgres as we do not display passwords,
-4294967123  4294967117  0         table columns (incomplete - see also information_schema.columns)
-4294967124  4294967117  0         column default values
-4294967125  4294967117  0         pg_amproc was created for compatibility and is currently unimplemented
-4294967126  4294967117  0         pg_amop was created for compatibility and is currently unimplemented
-4294967127  4294967117  0         index access methods (incomplete)
-4294967128  4294967117  0         aggregated built-in functions (incomplete)
-4294967130  4294967117  0         views (incomplete)
-4294967131  4294967117  0         view_table_usage was created for compatibility and is currently unimplemented
-4294967132  4294967117  0         view_routine_usage was created for compatibility and is currently unimplemented
-4294967133  4294967117  0         view_column_usage was created for compatibility and is currently unimplemented
-4294967134  4294967117  0         grantable privileges (incomplete)
-4294967135  4294967117  0         user_mappings was created for compatibility and is currently unimplemented
-4294967136  4294967117  0         user_mapping_options was created for compatibility and is currently unimplemented
-4294967137  4294967117  0         user_defined_types was created for compatibility and is currently unimplemented
-4294967138  4294967117  0         user_attributes was created for compatibility and is currently unimplemented
-4294967139  4294967117  0         usage_privileges was created for compatibility and is currently unimplemented
-4294967140  4294967117  0         udt_privileges was created for compatibility and is currently unimplemented
-4294967141  4294967117  0         type privileges (incomplete; may contain excess users or roles)
-4294967142  4294967117  0         triggers was created for compatibility and is currently unimplemented
-4294967143  4294967117  0         triggered_update_columns was created for compatibility and is currently unimplemented
-4294967144  4294967117  0         transforms was created for compatibility and is currently unimplemented
-4294967145  4294967117  0         tablespaces was created for compatibility and is currently unimplemented
-4294967146  4294967117  0         tablespaces_extensions was created for compatibility and is currently unimplemented
-4294967147  4294967117  0         tables and views
-4294967148  4294967117  0         tables_extensions was created for compatibility and is currently unimplemented
-4294967149  4294967117  0         privileges granted on table or views (incomplete; may contain excess users or roles)
-4294967150  4294967117  0         table_constraints_extensions was created for compatibility and is currently unimplemented
-4294967151  4294967117  0         table constraints
-4294967152  4294967117  0         index metadata and statistics (incomplete)
-4294967153  4294967117  0         st_units_of_measure was created for compatibility and is currently unimplemented
-4294967154  4294967117  0         st_spatial_reference_systems was created for compatibility and is currently unimplemented
-4294967155  4294967117  0         st_geometry_columns was created for compatibility and is currently unimplemented
-4294967156  4294967117  0         exposes the session variables.
-4294967157  4294967117  0         sequences
-4294967158  4294967117  0         schema privileges (incomplete; may contain excess users or roles)
-4294967159  4294967117  0         database schemas (may contain schemata without permission)
-4294967160  4294967117  0         schemata_extensions was created for compatibility and is currently unimplemented
-4294967161  4294967117  0         sql_sizing was created for compatibility and is currently unimplemented
-4294967162  4294967117  0         sql_parts was created for compatibility and is currently unimplemented
-4294967163  4294967117  0         sql_implementation_info was created for compatibility and is currently unimplemented
-4294967164  4294967117  0         sql_features was created for compatibility and is currently unimplemented
-4294967165  4294967117  0         built-in functions (empty - introspection not yet supported)
-4294967166  4294967117  0         routine_privileges was created for compatibility and is currently unimplemented
-4294967167  4294967117  0         role_usage_grants was created for compatibility and is currently unimplemented
-4294967168  4294967117  0         role_udt_grants was created for compatibility and is currently unimplemented
-4294967169  4294967117  0         privileges granted on table or views (incomplete; see also information_schema.table_privileges; may contain excess users or roles)
-4294967170  4294967117  0         privileges granted on functions (incomplete; only contains privileges of user-defined functions)
-4294967171  4294967117  0         role_column_grants was created for compatibility and is currently unimplemented
-4294967172  4294967117  0         resource_groups was created for compatibility and is currently unimplemented
-4294967173  4294967117  0         foreign key constraints
-4294967174  4294967117  0         profiling was created for compatibility and is currently unimplemented
-4294967175  4294967117  0         processlist was created for compatibility and is currently unimplemented
-4294967176  4294967117  0         plugins was created for compatibility and is currently unimplemented
-4294967177  4294967117  0         partitions was created for compatibility and is currently unimplemented
-4294967178  4294967117  0         built-in function parameters (empty - introspection not yet supported)
-4294967179  4294967117  0         optimizer_trace was created for compatibility and is currently unimplemented
-4294967180  4294967117  0         keywords was created for compatibility and is currently unimplemented
-4294967181  4294967117  0         column usage by indexes and key constraints
-4294967182  4294967117  0         information_schema_catalog_name was created for compatibility and is currently unimplemented
-4294967183  4294967117  0         foreign_tables was created for compatibility and is currently unimplemented
-4294967184  4294967117  0         foreign_table_options was created for compatibility and is currently unimplemented
-4294967185  4294967117  0         foreign_servers was created for compatibility and is currently unimplemented
-4294967186  4294967117  0         foreign_server_options was created for compatibility and is currently unimplemented
-4294967187  4294967117  0         foreign_data_wrappers was created for compatibility and is currently unimplemented
-4294967188  4294967117  0         foreign_data_wrapper_options was created for compatibility and is currently unimplemented
-4294967189  4294967117  0         files was created for compatibility and is currently unimplemented
-4294967190  4294967117  0         events was created for compatibility and is currently unimplemented
-4294967191  4294967117  0         engines was created for compatibility and is currently unimplemented
-4294967192  4294967117  0         roles for the current user
-4294967193  4294967117  0         element_types was created for compatibility and is currently unimplemented
-4294967194  4294967117  0         domains was created for compatibility and is currently unimplemented
-4294967195  4294967117  0         domain_udt_usage was created for compatibility and is currently unimplemented
-4294967196  4294967117  0         domain_constraints was created for compatibility and is currently unimplemented
-4294967197  4294967117  0         data_type_privileges was created for compatibility and is currently unimplemented
-4294967198  4294967117  0         constraint_table_usage was created for compatibility and is currently unimplemented
-4294967199  4294967117  0         columns usage by constraints
-4294967200  4294967117  0         table and view columns (incomplete)
-4294967201  4294967117  0         columns_extensions was created for compatibility and is currently unimplemented
-4294967202  4294967117  0         columns with user defined types
-4294967203  4294967117  0         column_statistics was created for compatibility and is currently unimplemented
-4294967204  4294967117  0         column privilege grants (incomplete)
-4294967205  4294967117  0         column_options was created for compatibility and is currently unimplemented
-4294967206  4294967117  0         column_domain_usage was created for compatibility and is currently unimplemented
-4294967207  4294967117  0         column_column_usage was created for compatibility and is currently unimplemented
-4294967208  4294967117  0         shows the collations available in the current database
-4294967209  4294967117  0         identifies which character set the available collations are
-4294967210  4294967117  0         check constraints
-4294967211  4294967117  0         check_constraint_routine_usage was created for compatibility and is currently unimplemented
-4294967212  4294967117  0         character sets available in the current database
-4294967213  4294967117  0         attributes was created for compatibility and is currently unimplemented
-4294967214  4294967117  0         roles available to the current user
-4294967215  4294967117  0         roles for which the current user has admin option
-4294967217  4294967117  0         list super regions of databases visible to the current user
-4294967218  4294967117  0         which entries of pg_catalog are implemented in this version of CockroachDB
-4294967220  4294967117  0         node-level table listing all currently running range feeds
-4294967221  4294967117  0         virtual table with default privileges
-4294967222  4294967117  0         available regions for the cluster
-4294967223  4294967117  0         traces for in-flight spans across all nodes in the cluster (cluster RPC; expensive!)
-4294967224  4294967117  0         virtual table with table descriptors that still have data
-4294967225  4294967117  0         virtual table with cross db references
-4294967226  4294967117  0         virtual table with database privileges
-4294967227  4294967117  0         virtual table to validate descriptors
-4294967228  4294967117  0         decoded zone configurations from system.zones (KV scan)
-4294967230  4294967117  0         finer-grained transaction statistics. The contents of this table are flushed to the system.transaction_statistics table at the interval set by the cluster setting sql.stats.flush.interval (by default, 10m).
-4294967231  4294967117  0         stats for all tables accessible by current user in current database as of 10s ago
-4294967232  4294967117  0         table descriptors accessible by current user, including non-public and virtual (KV scan; expensive!)
-4294967233  4294967117  0         key spans per SQL object
-4294967234  4294967117  0         indexes accessible by current user in current database (KV scan)
-4294967235  4294967117  0         details for all columns accessible by current user in current database (KV scan)
-4294967237  4294967117  0         session variables (RAM)
-4294967238  4294967117  0         session trace accumulated so far (RAM)
-4294967239  4294967117  0         ongoing schema changes, across all descriptors accessible by current user (KV scan; expensive!)
-4294967240  4294967117  0         server parameters, useful to construct connection URLs (RAM, local node only)
-4294967242  4294967117  0         range metadata without leaseholder details (KV join; expensive!)
-4294967243  4294967117  0         defined partitions for all tables/indexes accessible by the current user in the current database (KV scan)
-4294967244  4294967117  0         per-application transaction statistics (in-memory, not durable; local node only). This table is wiped periodically (by default, at least every two hours)
-4294967245  4294967117  0         statement statistics. The contents of this table are flushed to the system.statement_statistics table at the interval set by the cluster setting sql.stats.flush.interval (by default, 10m).
-4294967246  4294967117  0         current values for metrics (RAM; local node only)
-4294967247  4294967117  0         running sessions visible by current user (RAM; local node only)
-4294967248  4294967117  0         running user transactions visible by the current user (RAM; local node only)
-4294967249  4294967117  0         running queries visible by current user (RAM; local node only)
-4294967251  4294967117  0         DistSQL remote flows information (RAM; local node only)
-4294967252  4294967117  0         contention information (RAM; local node only)
-4294967253  4294967117  0         acquired table leases (RAM; local node only)
-4294967254  4294967117  0         store details and status (cluster RPC; expensive!)
-4294967255  4294967117  0         node details across the entire cluster (cluster RPC; expensive!)
-4294967256  4294967117  0         wrapper over system.jobs with row access control (KV scan)
-4294967257  4294967117  0         decoded job metadata from crdb_internal.system_jobs (KV scan)
-4294967258  4294967117  0         in-flight spans (RAM; local node only)
-4294967259  4294967117  0         cluster-wide index usage statistics (in-memory, not durable).Querying this table is an expensive operation since it creates acluster-wide RPC fanout.
-4294967260  4294967117  0         key spans per table index
-4294967261  4294967117  0         index columns for all indexes accessible by current user in current database (KV scan)
-4294967262  4294967117  0         cluster-wide transaction contention events. Querying this table is an
-4294967263  4294967117  0         locally known edges in the gossip network (RAM; local node only)
-4294967264  4294967117  0         locally known gossiped node liveness (RAM; local node only)
-4294967265  4294967117  0         locally known gossiped health alerts (RAM; local node only)
-4294967266  4294967117  0         locally known gossiped node details (RAM; local node only)
-4294967267  4294967117  0         node liveness status, as seen by kv
-4294967268  4294967117  0         forward inter-descriptor dependencies starting from tables accessible by current user in current database (KV scan)
-4294967269  4294967117  0         telemetry counters (RAM; local node only)
-4294967270  4294967117  0         databases accessible by the current user (KV scan)
-4294967271  4294967117  0         CREATE statements for all user defined types accessible by the current user in current database (KV scan)
-4294967272  4294967117  0         CREATE and ALTER statements for all tables accessible by current user in current database (KV scan)
-4294967273  4294967117  0         CREATE statements for all user defined schemas accessible by the current user in current database (KV scan)
-4294967274  4294967117  0         CREATE statements for all user-defined functions
-4294967275  4294967117  0         cluster-wide transaction statistics that have not yet been flushed to system tables. Querying this table is a somewhat expensive operation since it creates a cluster-wide RPC-fanout.
-4294967276  4294967117  0         cluster-wide statement statistics that have not yet been flushed to system tables. Querying this table is a somewhat expensive operation since it creates a cluster-wide RPC-fanout.
-4294967277  4294967117  0         cluster settings (RAM)
-4294967278  4294967117  0         running sessions visible to current user (cluster RPC; expensive!)
-4294967279  4294967117  0         running user transactions visible by the current user (cluster RPC; expensive!)
-4294967280  4294967117  0         running queries visible by current user (cluster RPC; expensive!)
-4294967281  4294967117  0         cluster-wide locks held in lock tables. Querying this table is an
-4294967283  4294967117  0         DistSQL remote flows information (cluster RPC; expensive!)
-4294967284  4294967117  0         contention information (cluster RPC; expensive!)
-4294967288  4294967117  0         like system.zones but overlaid with in-txn in-memory changes
-4294967289  4294967117  0         like system.namespace but overlaid with in-txn in-memory changes
-4294967290  4294967117  0         like system.descriptor but overlaid with in-txn in-memory changes and including virtual objects
-4294967291  4294967117  0         like system.comments but overlaid with in-txn in-memory changes and including virtual objects
-4294967292  4294967117  0         built-in functions (RAM/static)
-4294967293  4294967117  0         detailed identification strings (RAM, local node only)
-4294967294  4294967117  0         backward inter-descriptor dependencies starting from tables accessible by current user in current database (KV scan)
+relname       objoid      classoid    objsubid  description
+pg_class      135         4294967117  0         mycomment1
+pg_class      4294967001  4294967117  0         database users
+pg_class      135         4294967117  1         mycomment2
+pg_class      125730312   4294967117  0         mycomment3
+pg_namespace  136         4294967088  0         mycomment4
+pg_proc       738         4294967079  0         Calculates the absolute value of `val`.
+pg_proc       739         4294967079  0         Calculates the absolute value of `val`.
+pg_proc       740         4294967079  0         Calculates the absolute value of `val`.
 
 ## pg_catalog.pg_shdescription
+
+statement ok
+COMMENT ON DATABASE defaultdb IS 'mydbcomment'
 
 query OOT colnames
 SELECT objoid, classoid, description FROM pg_catalog.pg_shdescription
 ----
-objoid  classoid  description
+objoid  classoid    description
+100     4294967111  mydbcomment
 
 ## pg_catalog.pg_event_trigger
 
@@ -3227,8 +2966,8 @@ query OOIIIIIB colnames
 SELECT * FROM pg_catalog.pg_sequence
 ----
 seqrelid  seqtypid  seqstart  seqincrement  seqmax               seqmin  seqcache  seqcycle
-137       20        1         1             9223372036854775807  1       1         false
-138       20        6         2             10                   5       1         false
+139       20        1         1             9223372036854775807  1       1         false
+140       20        6         2             10                   5       1         false
 
 statement ok
 DROP DATABASE seq
@@ -3273,16 +3012,17 @@ JOIN pg_catalog.pg_class c ON def.adrelid = c.oid
 JOIN pg_catalog.pg_namespace n ON c.relnamespace = n.oid
 WHERE n.nspname = 'public'
 ----
-2306804694  t1   12
-2306804700  t1   nextval('public.t1_m_seq'::REGCLASS)
-2306804701  t1   nextval('public.t1_n_seq'::REGCLASS)
-4171354239  t2   unique_rowid()
-1221463949  t3   'FOO'::STRING
-1221463946  t3   unique_rowid()
-1740936492  t4   unique_rowid()
-3086013501  t5   unique_rowid()
-655595746   t6   unique_rowid()
-2000672759  mv1  unique_rowid()
+2306804694  t1         12
+2306804700  t1         nextval('public.t1_m_seq'::REGCLASS)
+2306804701  t1         nextval('public.t1_n_seq'::REGCLASS)
+4171354239  t2         unique_rowid()
+1221463949  t3         'FOO'::STRING
+1221463946  t3         unique_rowid()
+1740936492  t4         unique_rowid()
+3086013501  t5         unique_rowid()
+655595746   t6         unique_rowid()
+2000672759  mv1        unique_rowid()
+1249221897  testtable  unique_rowid()
 
 # Verify that a set database shows tables from that database for a non-root
 # user, when that user has permissions.
@@ -3298,7 +3038,7 @@ SET DATABASE = 'constraint_db'
 query I
 SELECT count(*) FROM pg_catalog.pg_tables WHERE schemaname='public'
 ----
-7
+8
 
 user root
 
@@ -3819,13 +3559,13 @@ CREATE TABLE jt (a INT PRIMARY KEY); INSERT INTO jt VALUES(1); INSERT INTO jt VA
 query ITT
 SELECT a, oid, relname FROM jt INNER LOOKUP JOIN pg_class ON a::oid=oid
 ----
-168  168  jt
+170  170  jt
 
 query ITT
 SELECT a, oid, relname FROM jt LEFT OUTER LOOKUP JOIN pg_class ON a::oid=oid
 ----
 1    NULL  NULL
-168  168   jt
+170  170   jt
 
 subtest regression_49207
 statement ok
@@ -4439,7 +4179,7 @@ JOIN pg_class ON pg_statistic_ext.stxrelid = pg_class.oid
 ----
 relname  stxname  stxnamespace  stxowner  stxstattarget  stxkeys  stxkind
 stxtbl   stxobj   105           NULL      -1             {2,3}    {d}
-stxtbl2  stxobj2  189           NULL      -1             {1,3}    {d}
+stxtbl2  stxobj2  191           NULL      -1             {1,3}    {d}
 stx      NULL     105           NULL      -1             {2}      {d}
 stx      NULL     105           NULL      -1             {1}      {d}
 

--- a/pkg/sql/logictest/testdata/logic_test/udf
+++ b/pkg/sql/logictest/testdata/logic_test/udf
@@ -166,13 +166,13 @@ CREATE SCHEMA sc;
 statement
 CREATE FUNCTION sc.proc_f_2(STRING) RETURNS STRING LANGUAGE SQL AS $$ SELECT 'hello' $$;
 
-query TTTTTBBBTITTTTT
-SELECT oid, proname, pronamespace, proowner, prolang, proleakproof, proisstrict, proretset, provolatile, pronargs, prorettype, proargtypes, proargmodes, proargnames, prosrc
+query TTTTTBBBTITTTTTT
+SELECT oid, proname, pronamespace, proowner, prolang, proleakproof, proisstrict, proretset, provolatile, pronargs, prorettype, proargtypes, proargmodes, proargnames, prokind, prosrc
 FROM pg_catalog.pg_proc WHERE proname IN ('proc_f', 'proc_f_2');
 ----
-100118  proc_f    105  1546506610  14  false  false  false  v  1  20  20     {i}    NULL    SELECT 1;
-100119  proc_f    105  1546506610  14  true   true   false  i  2  25  25 20  {i,i}  {"",b}  SELECT 'hello';
-100121  proc_f_2  120  1546506610  14  false  false  false  v  1  25  25     {i}    NULL    SELECT 'hello';
+100118  proc_f    105  1546506610  14  false  false  false  v  1  20  20     {i}    NULL    f  SELECT 1;
+100119  proc_f    105  1546506610  14  true   true   false  i  2  25  25 20  {i,i}  {"",b}  f  SELECT 'hello';
+100121  proc_f_2  120  1546506610  14  false  false  false  v  1  25  25     {i}    NULL    f  SELECT 'hello';
 
 # Ensure that the pg_proc virtual index works properly.
 

--- a/pkg/sql/opt/exec/execbuilder/testdata/explain
+++ b/pkg/sql/opt/exec/execbuilder/testdata/explain
@@ -427,20 +427,23 @@ vectorized: true
         │       │           │   └── • virtual table
         │       │           │         table: pg_namespace@primary
         │       │           │
-        │       │           └── • hash join (left outer)
+        │       │           └── • merge join (left outer)
         │       │               │ equality: (oid) = (objoid)
         │       │               │
         │       │               ├── • filter
         │       │               │   │ filter: relkind IN ('S', 'm', 'r', 'v')
         │       │               │   │
         │       │               │   └── • virtual table
-        │       │               │         table: pg_class@primary
+        │       │               │         table: pg_class@pg_class_oid_idx
         │       │               │
-        │       │               └── • filter
-        │       │                   │ filter: objsubid = 0
+        │       │               └── • sort
+        │       │                   │ order: +objoid
         │       │                   │
-        │       │                   └── • virtual table
-        │       │                         table: pg_description@primary
+        │       │                   └── • filter
+        │       │                       │ filter: (objsubid = 0) AND (classoid = 4294967117)
+        │       │                       │
+        │       │                       └── • virtual table
+        │       │                             table: pg_description@primary
         │       │
         │       └── • virtual table
         │             table: table_row_statistics@primary

--- a/pkg/sql/pg_catalog.go
+++ b/pkg/sql/pg_catalog.go
@@ -2339,6 +2339,16 @@ func addPgProcBuiltinRow(name string, addRow func(...tree.Datum) error) error {
 		name = name[len(crdbInternal):]
 	}
 
+	var kind tree.Datum
+	switch {
+	case isAggregate:
+		kind = tree.NewDString("a")
+	case isWindow:
+		kind = tree.NewDString("w")
+	default:
+		kind = tree.NewDString("f")
+	}
+
 	for _, builtin := range overloads {
 		dName := tree.NewDName(name)
 		dSrc := tree.NewDString(name)
@@ -2435,8 +2445,8 @@ func addPgProcBuiltinRow(name string, addRow func(...tree.Datum) error) error {
 			tree.DNull,                                      // probin
 			tree.DNull,                                      // proconfig
 			tree.DNull,                                      // proacl
+			kind,                                            // prokind
 			// These columns were automatically created by pg_catalog_test's missing column generator.
-			tree.DNull, // prokind
 			tree.DNull, // prosupport
 		)
 		if err != nil {
@@ -2511,8 +2521,8 @@ func addPgProcUDFRow(
 		tree.DNull,                                       // probin
 		tree.DNull,                                       // proconfig
 		tree.DNull,                                       // proacl
+		tree.NewDString("f"),                             // prokind
 		// These columns were automatically created by pg_catalog_test's missing column generator.
-		tree.DNull, // prokind
 		tree.DNull, // prosupport
 	)
 }

--- a/pkg/sql/pg_catalog.go
+++ b/pkg/sql/pg_catalog.go
@@ -1628,6 +1628,22 @@ https://www.postgresql.org/docs/9.5/catalog-pg-description.html`,
 				return err
 			}
 		}
+
+		// Also add all built-in comments.
+		for _, name := range builtins.AllBuiltinNames() {
+			_, overloads := builtinsregistry.GetBuiltinProperties(name)
+			for _, builtin := range overloads {
+				if err := addRow(
+					tree.NewDOid(builtin.Oid),
+					tree.NewDOid(catconstants.PgCatalogProcTableID),
+					tree.DZero,
+					tree.NewDString(builtin.Info),
+				); err != nil {
+					return err
+				}
+			}
+		}
+
 		return nil
 	},
 }


### PR DESCRIPTION
Epic: CRDB-23454
Fixes #95292.
Needed for #88061. 

First commit from #95289.

This also extends the completion rules to properly handle
functions in multiple namespaces.

Release note (bug fix): `pg_catalog.pg_description` and `pg_catalog.obj_description()` are now able to retrieve the descriptive help for built-in functions.