### PR TITLE
release-22.1: backupccl: restore role options during RESTORE SYSTEM USERS

### DIFF
--- a/pkg/ccl/backupccl/backup_test.go
+++ b/pkg/ccl/backupccl/backup_test.go
@@ -9372,10 +9372,10 @@ func TestBackupRestoreSystemUsers(t *testing.T) {
 		sqlDBRestore.CheckQueryResults(t, "SHOW USERS", [][]string{
 			{"admin", "", "{}"},
 			{"app", "", "{admin,app_role}"},
-			{"app_role", "", "{}"},
+			{"app_role", "NOLOGIN", "{}"},
 			{"root", "", "{admin}"},
 			{"test", "", "{}"},
-			{"test_role", "", "{app_role}"},
+			{"test_role", "NOLOGIN", "{app_role}"},
 		})
 	})
 

--- a/pkg/ccl/backupccl/targets.go
+++ b/pkg/ccl/backupccl/targets.go
@@ -415,7 +415,7 @@ func checkMissingIntroducedSpans(
 				table.Name, mainBackupManifests[i].StartTime.GoTime().String(), table.Name)
 			return errors.WithIssueLink(tableError, errors.IssueLink{
 				IssueURL: "https://www.cockroachlabs.com/docs/advisories/a88042",
-				Detail: `An incremental database backup with revision history can incorrectly backup data for a table 
+				Detail: `An incremental database backup with revision history can incorrectly backup data for a table
 that was running an IMPORT at the time of the previous incremental in this chain of backups.`,
 			})
 		}
@@ -488,7 +488,8 @@ func selectTargets(
 					systemTables = append(systemTables, desc)
 				case systemschema.RoleMembersTable.GetName():
 					systemTables = append(systemTables, desc)
-					// TODO(casper): should we handle role_options table?
+				case systemschema.RoleOptionsTable.GetName():
+					systemTables = append(systemTables, desc)
 				}
 			}
 		}

--- a/pkg/ccl/backupccl/testdata/backup-restore/system-users
+++ b/pkg/ccl/backupccl/testdata/backup-restore/system-users
@@ -1,0 +1,53 @@
+new-server name=s1
+----
+
+exec-sql
+CREATE ROLE testuser NOLOGIN;
+CREATE ROLE testuser2 WITH CONTROLJOB CREATEDB;
+CREATE ROLE developer WITH CREATEDB;
+CREATE USER abbey WITH PASSWORD 'lincoln';
+GRANT developer TO abbey;
+----
+
+query-sql
+SHOW ROLES
+----
+abbey  {developer}
+admin  {}
+developer CREATEDB, NOLOGIN {}
+root  {admin}
+testuser NOLOGIN {}
+testuser2 CONTROLJOB, CREATEDB, NOLOGIN {}
+
+query-sql
+SHOW GRANTS ON ROLE developer
+----
+developer abbey false
+
+exec-sql
+BACKUP DATABASE system INTO 'nodelocal://0/test/'
+----
+
+# Start a new cluster with the same IO dir.
+new-server name=s2 share-io-dir=s1
+----
+
+# Restore into the new cluster.
+exec-sql cluster=s2
+RESTORE SYSTEM USERS FROM LATEST IN 'nodelocal://0/test/'
+----
+
+query-sql cluster=s2
+SHOW ROLES
+----
+abbey  {developer}
+admin  {}
+developer CREATEDB, NOLOGIN {}
+root  {admin}
+testuser NOLOGIN {}
+testuser2 CONTROLJOB, CREATEDB, NOLOGIN {}
+
+query-sql cluster=s2
+SHOW GRANTS ON ROLE developer
+----
+developer abbey false


### PR DESCRIPTION
Backport 1/1 commits from #94134.

/cc @cockroachdb/release

Release justification: bug fix

---

Previously, we did not restore the system.role_options table when executing RESTORE SYSTEM USERS. As a result, a user's role options would not be restored.

For example, a user create with

   CREATE USER foo WITH NOLOGIN

would lose the NOLOGIN option.

Now, we restore these options.

Fixes: #94107

Release note (bug fix): Fixed a bug in which RESTORE SYSTEM USERS would fail to restore role options.
