### PR TITLE
ui: hide reset options for non-admins

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/databaseTablePage/databaseTablePage.stories.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/databaseTablePage/databaseTablePage.stories.tsx
@@ -67,6 +67,7 @@ const withLoadingIndicator: DatabaseTablePageProps = {
   refreshIndexStats: () => {},
   resetIndexUsageStats: () => {},
   refreshSettings: () => {},
+  refreshUserSQLRoles: () => {},
 };
 
 const name = randomName();
@@ -170,6 +171,7 @@ const withData: DatabaseTablePageProps = {
   refreshIndexStats: () => {},
   resetIndexUsageStats: () => {},
   refreshSettings: () => {},
+  refreshUserSQLRoles: () => {},
 };
 
 storiesOf("Database Table Page", module)

--- a/pkg/ui/workspaces/cluster-ui/src/databaseTablePage/databaseTablePage.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/databaseTablePage/databaseTablePage.tsx
@@ -53,6 +53,7 @@ import IdxRecAction from "../insights/indexActionBtn";
 import { RecommendationType } from "../indexDetailsPage";
 import LoadingError from "../sqlActivity/errorComponent";
 import { Loading } from "../loading";
+import { UIConfigState } from "../store";
 
 const cx = classNames.bind(styles);
 const booleanSettingCx = classnames.bind(booleanSettingStyles);
@@ -108,6 +109,7 @@ export interface DatabaseTablePageData {
   indexStats: DatabaseTablePageIndexStats;
   showNodeRegionsSection?: boolean;
   automaticStatsCollectionEnabled?: boolean;
+  hasAdminRole?: UIConfigState["hasAdminRole"];
 }
 
 export interface DatabaseTablePageDataDetails {
@@ -166,6 +168,7 @@ export interface DatabaseTablePageActions {
   refreshIndexStats?: (database: string, table: string) => void;
   resetIndexUsageStats?: (database: string, table: string) => void;
   refreshNodes?: () => void;
+  refreshUserSQLRoles: () => void;
 }
 
 export type DatabaseTablePageProps = DatabaseTablePageData &
@@ -247,6 +250,7 @@ export class DatabaseTablePage extends React.Component<
   }
 
   private refresh() {
+    this.props.refreshUserSQLRoles();
     if (this.props.refreshNodes != null) {
       this.props.refreshNodes();
     }
@@ -493,6 +497,7 @@ export class DatabaseTablePage extends React.Component<
   };
 
   render(): React.ReactElement {
+    const { hasAdminRole } = this.props;
     return (
       <div className="root table-area">
         <section className={baseHeadingClasses.wrapper}>
@@ -644,23 +649,25 @@ export class DatabaseTablePage extends React.Component<
                                 {this.getLastResetString()}
                               </div>
                             </Tooltip>
-                            <div>
-                              <a
-                                className={cx(
-                                  "action",
-                                  "separator",
-                                  "index-stats__reset-btn",
-                                )}
-                                onClick={() =>
-                                  this.props.resetIndexUsageStats(
-                                    this.props.databaseName,
-                                    this.props.name,
-                                  )
-                                }
-                              >
-                                Reset all index stats
-                              </a>
-                            </div>
+                            {hasAdminRole && (
+                              <div>
+                                <a
+                                  className={cx(
+                                    "action",
+                                    "separator",
+                                    "index-stats__reset-btn",
+                                  )}
+                                  onClick={() =>
+                                    this.props.resetIndexUsageStats(
+                                      this.props.databaseName,
+                                      this.props.name,
+                                    )
+                                  }
+                                >
+                                  Reset all index stats
+                                </a>
+                              </div>
+                            )}
                           </div>
                         </div>
                         <IndexUsageStatsTable

--- a/pkg/ui/workspaces/cluster-ui/src/indexDetailsPage/indexDetails.selectors.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/indexDetailsPage/indexDetails.selectors.ts
@@ -25,6 +25,7 @@ import { cockroach } from "@cockroachlabs/crdb-protobuf-client";
 import { IndexDetailsPageData } from "./indexDetailsPage";
 import {
   selectHasViewActivityRedactedRole,
+  selectHasAdminRole,
   selectIsTenant,
 } from "../store/uiConfig";
 import { BreadcrumbItem } from "../breadcrumbs";
@@ -45,6 +46,7 @@ export const selectIndexDetails = createSelector(
   (state: AppState) => selectIsTenant(state),
   (state: AppState) => selectHasViewActivityRedactedRole(state),
   (state: AppState) => nodeRegionsByIDSelector(state),
+  (state: AppState) => selectHasAdminRole(state),
   (
     database,
     schema,
@@ -54,6 +56,7 @@ export const selectIndexDetails = createSelector(
     isTenant,
     hasViewActivityRedactedRole,
     nodeRegions,
+    hasAdminRole,
   ): IndexDetailsPageData => {
     const stats = indexStats[generateTableID(database, table)];
     const details = stats?.data?.statistics.filter(
@@ -87,6 +90,7 @@ export const selectIndexDetails = createSelector(
       ),
       isTenant: isTenant,
       hasViewActivityRedactedRole: hasViewActivityRedactedRole,
+      hasAdminRole: hasAdminRole,
       nodeRegions: nodeRegions,
       details: {
         loading: !!stats?.inFlight,

--- a/pkg/ui/workspaces/cluster-ui/src/indexDetailsPage/indexDetailsConnected.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/indexDetailsPage/indexDetailsConnected.ts
@@ -8,7 +8,7 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
-import { AppState } from "../store";
+import { AppState, uiConfigActions } from "../store";
 import { RouteComponentProps, withRouter } from "react-router-dom";
 import { selectIndexDetails } from "./indexDetails.selectors";
 import { Dispatch } from "redux";
@@ -42,6 +42,7 @@ const mapDispatchToProps = (dispatch: Dispatch): IndexDetailPageActions => ({
     );
   },
   refreshNodes: () => dispatch(nodesActions.refresh()),
+  refreshUserSQLRoles: () => dispatch(uiConfigActions.refreshUserSQLRoles()),
 });
 
 export const ConnectedIndexDetailsPage = withRouter<any, any>(

--- a/pkg/ui/workspaces/cluster-ui/src/indexDetailsPage/indexDetailsPage.stories.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/indexDetailsPage/indexDetailsPage.stories.tsx
@@ -59,6 +59,7 @@ const withData: IndexDetailsPageProps = {
   refreshIndexStats: () => {},
   resetIndexUsageStats: () => {},
   refreshNodes: () => {},
+  refreshUserSQLRoles: () => {},
 };
 
 storiesOf("Index Details Page", module)

--- a/pkg/ui/workspaces/cluster-ui/src/indexDetailsPage/indexDetailsPage.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/indexDetailsPage/indexDetailsPage.tsx
@@ -88,6 +88,7 @@ export interface IndexDetailsPageData {
   breadcrumbItems: BreadcrumbItem[];
   isTenant: UIConfigState["isTenant"];
   hasViewActivityRedactedRole?: UIConfigState["hasViewActivityRedactedRole"];
+  hasAdminRole?: UIConfigState["hasAdminRole"];
   nodeRegions: { [nodeId: string]: string };
 }
 
@@ -114,6 +115,7 @@ export interface IndexDetailPageActions {
   refreshIndexStats?: (database: string, table: string) => void;
   resetIndexUsageStats?: (database: string, table: string) => void;
   refreshNodes?: () => void;
+  refreshUserSQLRoles: () => void;
 }
 
 export type IndexDetailsPageProps = IndexDetailsPageData &
@@ -165,6 +167,7 @@ export class IndexDetailsPage extends React.Component<
   };
 
   private refresh() {
+    this.props.refreshUserSQLRoles();
     if (this.props.refreshNodes != null) {
       this.props.refreshNodes();
     }
@@ -274,7 +277,7 @@ export class IndexDetailsPage extends React.Component<
 
   render(): React.ReactElement {
     const { statements, stmtSortSetting, stmtPagination } = this.state;
-    const { isTenant, hasViewActivityRedactedRole } = this.props;
+    const { isTenant, hasViewActivityRedactedRole, hasAdminRole } = this.props;
     const isEmptySearchResults = statements?.length > 0;
 
     return (
@@ -302,23 +305,25 @@ export class IndexDetailsPage extends React.Component<
                   {this.getTimestampString(this.props.details.lastReset)}
                 </div>
               </Tooltip>
-              <div>
-                <a
-                  className={cx(
-                    "action",
-                    "separator",
-                    "index-stats__reset-btn",
-                  )}
-                  onClick={() =>
-                    this.props.resetIndexUsageStats(
-                      this.props.databaseName,
-                      this.props.tableName,
-                    )
-                  }
-                >
-                  Reset all index stats
-                </a>
-              </div>
+              {hasAdminRole && (
+                <div>
+                  <a
+                    className={cx(
+                      "action",
+                      "separator",
+                      "index-stats__reset-btn",
+                    )}
+                    onClick={() =>
+                      this.props.resetIndexUsageStats(
+                        this.props.databaseName,
+                        this.props.tableName,
+                      )
+                    }
+                  >
+                    Reset all index stats
+                  </a>
+                </div>
+              )}
             </div>
           </div>
           <section className={baseHeadingClasses.wrapper}>

--- a/pkg/ui/workspaces/cluster-ui/src/sessions/sessionDetails.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/sessions/sessionDetails.tsx
@@ -100,10 +100,6 @@ export const MemoryUsageItem: React.FC<{
 export class SessionDetails extends React.Component<SessionDetailsProps> {
   terminateSessionRef: React.RefObject<TerminateSessionModalRef>;
   terminateQueryRef: React.RefObject<TerminateQueryModalRef>;
-  static defaultProps = {
-    uiConfig: { showGatewayNodeLink: true },
-    isTenant: false,
-  };
 
   componentDidMount(): void {
     this.props.refreshNodes();

--- a/pkg/ui/workspaces/cluster-ui/src/statementDetails/diagnostics/diagnosticsView.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementDetails/diagnostics/diagnosticsView.tsx
@@ -112,9 +112,6 @@ export class DiagnosticsView extends React.Component<
   DiagnosticsViewProps,
   DiagnosticsViewState
 > {
-  static defaultProps: Partial<DiagnosticsViewProps> = {
-    showDiagnosticsViewLink: true,
-  };
   columns: ColumnsConfig<StatementDiagnosticsReport> = [
     {
       key: "activatedOn",

--- a/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetails.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetails.tsx
@@ -222,15 +222,6 @@ export class StatementDetails extends React.Component<
     }
   }
 
-  static defaultProps: Partial<StatementDetailsProps> = {
-    onDiagnosticBundleDownload: _.noop,
-    uiConfig: {
-      showStatementDiagnosticsLink: true,
-    },
-    isTenant: false,
-    hasViewActivityRedactedRole: false,
-  };
-
   hasDiagnosticReports = (): boolean =>
     this.props.diagnosticsReports.length > 0;
 

--- a/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.fixture.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.fixture.ts
@@ -928,6 +928,7 @@ const statementsPagePropsFixture: StatementsPageProps = {
   columns: null,
   isTenant: false,
   hasViewActivityRedactedRole: false,
+  hasAdminRole: true,
   dismissAlertMessage: noop,
   refreshDatabases: noop,
   refreshStatementDiagnosticsRequests: noop,

--- a/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.tsx
@@ -81,9 +81,7 @@ import { isSelectedColumn } from "src/columnsSelector/utils";
 import { StatementViewType } from "./statementPageTypes";
 import moment from "moment";
 import {
-  databasesRequest,
   InsertStmtDiagnosticRequest,
-  SqlExecutionRequest,
   StatementDiagnosticsReport,
 } from "../api";
 
@@ -139,6 +137,7 @@ export interface StatementsPageStateProps {
   search: string;
   isTenant?: UIConfigState["isTenant"];
   hasViewActivityRedactedRole?: UIConfigState["hasViewActivityRedactedRole"];
+  hasAdminRole?: UIConfigState["hasAdminRole"];
 }
 
 export interface StatementsPageState {
@@ -214,11 +213,6 @@ export class StatementsPage extends React.Component<
       this.changeTimeScale(ts);
     }
   }
-
-  static defaultProps: Partial<StatementsPageProps> = {
-    isTenant: false,
-    hasViewActivityRedactedRole: false,
-  };
 
   getStateFromHistory = (): Partial<StatementsPageState> => {
     const {
@@ -675,6 +669,7 @@ export class StatementsPage extends React.Component<
       search,
       isTenant,
       nodeRegions,
+      hasAdminRole,
     } = this.props;
 
     const nodes = Object.keys(nodeRegions)
@@ -730,14 +725,18 @@ export class StatementsPage extends React.Component<
               setTimeScale={this.changeTimeScale}
             />
           </PageConfigItem>
-          <PageConfigItem
-            className={`${commonStyles("separator")} ${cx("reset-btn-area")} `}
-          >
-            <ClearStats
-              resetSQLStats={this.resetSQLStats}
-              tooltipType="statement"
-            />
-          </PageConfigItem>
+          {hasAdminRole && (
+            <PageConfigItem
+              className={`${commonStyles("separator")} ${cx(
+                "reset-btn-area",
+              )} `}
+            >
+              <ClearStats
+                resetSQLStats={this.resetSQLStats}
+                tooltipType="statement"
+              />
+            </PageConfigItem>
+          )}
         </PageConfig>
         <div className={cx("table-area")}>
           <Loading

--- a/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPageConnected.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPageConnected.tsx
@@ -40,6 +40,7 @@ import { selectTimeScale } from "../store/utils/selectors";
 import {
   selectIsTenant,
   selectHasViewActivityRedactedRole,
+  selectHasAdminRole,
 } from "../store/uiConfig";
 import { nodeRegionsByIDSelector } from "../store/nodes";
 import { StatementsRequest } from "src/api/statementsApi";
@@ -58,7 +59,6 @@ import {
 } from "./recentStatementsPage.selectors";
 import {
   InsertStmtDiagnosticRequest,
-  SqlExecutionRequest,
   StatementDiagnosticsReport,
 } from "../api";
 
@@ -89,6 +89,7 @@ export const ConnectedStatementsPage = withRouter(
         filters: selectFilters(state),
         isTenant: selectIsTenant(state),
         hasViewActivityRedactedRole: selectHasViewActivityRedactedRole(state),
+        hasAdminRole: selectHasAdminRole(state),
         lastReset: selectLastReset(state),
         nodeRegions: nodeRegionsByIDSelector(state),
         search: selectSearch(state),

--- a/pkg/ui/workspaces/cluster-ui/src/store/uiConfig/uiConfig.reducer.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/store/uiConfig/uiConfig.reducer.ts
@@ -18,6 +18,7 @@ export type UIConfigState = {
   isTenant: boolean;
   userSQLRoles: string[];
   hasViewActivityRedactedRole: boolean;
+  hasAdminRole: boolean;
   pages: {
     statementDetails: {
       showStatementDiagnosticsLink: boolean;
@@ -32,6 +33,7 @@ const initialState: UIConfigState = {
   isTenant: false,
   userSQLRoles: [],
   hasViewActivityRedactedRole: false,
+  hasAdminRole: false,
   pages: {
     statementDetails: {
       showStatementDiagnosticsLink: true,

--- a/pkg/ui/workspaces/cluster-ui/src/store/uiConfig/uiConfig.selector.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/store/uiConfig/uiConfig.selector.ts
@@ -25,3 +25,7 @@ export const selectHasViewActivityRedactedRole = createSelector(
   selectUIConfig,
   uiConfig => uiConfig.userSQLRoles.includes("VIEWACTIVITYREDACTED"),
 );
+
+export const selectHasAdminRole = createSelector(selectUIConfig, uiConfig =>
+  uiConfig.userSQLRoles.includes("ADMIN"),
+);

--- a/pkg/ui/workspaces/cluster-ui/src/transactionDetails/transactionDetails.stories.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionDetails/transactionDetails.stories.tsx
@@ -23,6 +23,7 @@ import {
 } from "./transactionDetails.fixture";
 
 import { TransactionDetails } from ".";
+import moment from "moment";
 
 storiesOf("Transactions Details", module)
   .addDecorator(storyFn => <MemoryRouter>{storyFn()}</MemoryRouter>)
@@ -43,6 +44,8 @@ storiesOf("Transactions Details", module)
       refreshData={noop}
       refreshUserSQLRoles={noop}
       onTimeScaleChange={noop}
+      refreshNodes={noop}
+      lastUpdated={moment("0001-01-01T00:00:00Z")}
     />
   ))
   .add("with loading indicator", () => (
@@ -59,6 +62,8 @@ storiesOf("Transactions Details", module)
       refreshData={noop}
       refreshUserSQLRoles={noop}
       onTimeScaleChange={noop}
+      refreshNodes={noop}
+      lastUpdated={moment("0001-01-01T00:00:00Z")}
     />
   ))
   .add("with error alert", () => (
@@ -76,6 +81,8 @@ storiesOf("Transactions Details", module)
       refreshData={noop}
       refreshUserSQLRoles={noop}
       onTimeScaleChange={noop}
+      refreshNodes={noop}
+      lastUpdated={moment("0001-01-01T00:00:00Z")}
     />
   ))
   .add("No data for this time frame; no cached transaction text", () => {
@@ -93,6 +100,8 @@ storiesOf("Transactions Details", module)
         refreshData={noop}
         refreshUserSQLRoles={noop}
         onTimeScaleChange={noop}
+        refreshNodes={noop}
+        lastUpdated={moment("0001-01-01T00:00:00Z")}
       />
     );
   });

--- a/pkg/ui/workspaces/cluster-ui/src/transactionDetails/transactionDetails.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionDetails/transactionDetails.tsx
@@ -154,11 +154,6 @@ export class TransactionDetails extends React.Component<
     }
   }
 
-  static defaultProps: Partial<TransactionDetailsProps> = {
-    isTenant: false,
-    hasViewActivityRedactedRole: false,
-  };
-
   getTransactionStateInfo = (prevTransactionFingerprintId: string): void => {
     const { transaction, transactionFingerprintId } = this.props;
 

--- a/pkg/ui/workspaces/db-console/src/redux/user/userSagas.ts
+++ b/pkg/ui/workspaces/db-console/src/redux/user/userSagas.ts
@@ -16,3 +16,8 @@ export const selectHasViewActivityRedactedRole = createSelector(
   cachedData =>
     cachedData.userSQLRoles.data?.roles?.includes("VIEWACTIVITYREDACTED"),
 );
+
+export const selectHasAdminRole = createSelector(
+  (state: AdminUIState) => state.cachedData,
+  cachedData => cachedData.userSQLRoles.data?.roles?.includes("ADMIN"),
+);

--- a/pkg/ui/workspaces/db-console/src/views/databases/databaseTablePage/redux.ts
+++ b/pkg/ui/workspaces/db-console/src/views/databases/databaseTablePage/redux.ts
@@ -25,7 +25,9 @@ import {
   refreshNodes,
   refreshIndexStats,
   refreshSettings,
+  refreshUserSQLRoles,
 } from "src/redux/apiReducers";
+import { selectHasAdminRole } from "src/redux/user";
 import { AdminUIState } from "src/redux/state";
 import { databaseNameAttr, tableNameAttr } from "src/util/constants";
 import { FixLong, longToInt } from "src/util/fixLong";
@@ -60,6 +62,7 @@ export const mapStateToProps = createSelector(
   state => selectIsMoreThanOneNode(state),
   state => selectAutomaticStatsCollectionEnabled(state),
   _ => isTenant,
+  state => selectHasAdminRole(state),
   (
     database,
     table,
@@ -70,6 +73,7 @@ export const mapStateToProps = createSelector(
     showNodeRegionsSection,
     automaticStatsCollectionEnabled,
     isTenant,
+    hasAdminRole,
   ): DatabaseTablePageData => {
     const details = tableDetails[generateTableID(database, table)];
     const stats = tableStats[generateTableID(database, table)];
@@ -164,6 +168,7 @@ export const mapStateToProps = createSelector(
       },
       showNodeRegionsSection,
       automaticStatsCollectionEnabled,
+      hasAdminRole,
       stats: {
         loading: !!stats?.inFlight,
         loaded: !!stats?.valid,
@@ -197,14 +202,11 @@ export const mapDispatchToProps = {
   refreshTableStats: (database: string, table: string) => {
     return refreshTableStats(new TableStatsRequest({ database, table }));
   },
-
   refreshIndexStats: (database: string, table: string) => {
     return refreshIndexStats(new TableIndexStatsRequest({ database, table }));
   },
-
   resetIndexUsageStats: resetIndexUsageStatsAction,
-
   refreshNodes,
-
   refreshSettings,
+  refreshUserSQLRoles,
 };

--- a/pkg/ui/workspaces/db-console/src/views/databases/indexDetailsPage/redux.ts
+++ b/pkg/ui/workspaces/db-console/src/views/databases/indexDetailsPage/redux.ts
@@ -26,12 +26,16 @@ import {
   generateTableID,
   refreshIndexStats,
   refreshNodes,
+  refreshUserSQLRoles,
 } from "src/redux/apiReducers";
 import { resetIndexUsageStatsAction } from "src/redux/indexUsageStats";
 import { longToInt } from "src/util/fixLong";
 import { cockroach } from "src/js/protos";
 import TableIndexStatsRequest = cockroach.server.serverpb.TableIndexStatsRequest;
-import { selectHasViewActivityRedactedRole } from "src/redux/user";
+import {
+  selectHasViewActivityRedactedRole,
+  selectHasAdminRole,
+} from "src/redux/user";
 import { nodeRegionsByIDSelector } from "src/redux/nodes";
 const { RecommendationType } = cockroach.sql.IndexRecommendation;
 
@@ -45,6 +49,7 @@ export const mapStateToProps = createSelector(
   state => state.cachedData.indexStats,
   state => selectHasViewActivityRedactedRole(state),
   state => nodeRegionsByIDSelector(state),
+  state => selectHasAdminRole(state),
   (
     database,
     table,
@@ -52,6 +57,7 @@ export const mapStateToProps = createSelector(
     indexStats,
     hasViewActivityRedactedRole,
     nodeRegions,
+    hasAdminRole,
   ): IndexDetailsPageData => {
     const stats = indexStats[generateTableID(database, table)];
     const details = stats?.data?.statistics.filter(
@@ -80,6 +86,7 @@ export const mapStateToProps = createSelector(
       indexName: index,
       isTenant: false,
       hasViewActivityRedactedRole: hasViewActivityRedactedRole,
+      hasAdminRole: hasAdminRole,
       nodeRegions: nodeRegions,
       details: {
         loading: !!stats?.inFlight,
@@ -104,4 +111,5 @@ export const mapDispatchToProps = {
   },
   resetIndexUsageStats: resetIndexUsageStatsAction,
   refreshNodes,
+  refreshUserSQLRoles,
 };

--- a/pkg/ui/workspaces/db-console/src/views/statements/statementsPage.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/statements/statementsPage.tsx
@@ -30,7 +30,10 @@ import {
   createStatementDiagnosticsAlertLocalSetting,
   cancelStatementDiagnosticsAlertLocalSetting,
 } from "src/redux/alerts";
-import { selectHasViewActivityRedactedRole } from "src/redux/user";
+import {
+  selectHasViewActivityRedactedRole,
+  selectHasAdminRole,
+} from "src/redux/user";
 import { queryByName } from "src/util/query";
 
 import {
@@ -380,6 +383,7 @@ export default withRouter(
         statementsError: state.cachedData.statements.lastError,
         totalFingerprints: selectTotalFingerprints(state),
         hasViewActivityRedactedRole: selectHasViewActivityRedactedRole(state),
+        hasAdminRole: selectHasAdminRole(state),
       },
       activePageProps: mapStateToRecentStatementViewProps(state),
     }),


### PR DESCRIPTION
Previously, we were showing reset sql stats and reset index stats options for all users. If a non-admin user tried to reset, it wasn't doing the reset as expected, but no message was being displayed.
This commit now hides these options for non-admin so it's no longer confusing to see the options but not being able to use it.

Fixes #95213

https://www.loom.com/share/d82672e9ec994a6e9200fd9094ee9b55

Release note (ui change): Remove `reset sql stats` and `reset index stats` from the Console when the user is a non-admin.