### PR TITLE
release-22.1: ui: proper call of sql user for CC

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/api/userApi.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/api/userApi.ts
@@ -1,0 +1,27 @@
+// Copyright 2023 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import { cockroach } from "@cockroachlabs/crdb-protobuf-client";
+import { fetchData } from "src/api";
+
+export type UserSQLRolesRequestMessage = cockroach.server.serverpb.UserSQLRolesRequest;
+export type UserSQLRolesResponseMessage = cockroach.server.serverpb.UserSQLRolesResponse;
+
+export function getUserSQLRoles(
+  req: UserSQLRolesRequestMessage,
+): Promise<UserSQLRolesResponseMessage> {
+  return fetchData(
+    cockroach.server.serverpb.UserSQLRolesResponse,
+    `/_status/sqlroles`,
+    null,
+    null,
+    "30M",
+  );
+}

--- a/pkg/ui/workspaces/cluster-ui/src/store/sagas.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/store/sagas.ts
@@ -20,6 +20,7 @@ import { terminateSaga } from "./terminateQuery";
 import { notifificationsSaga } from "./notifications";
 import { sqlStatsSaga } from "./sqlStats";
 import { sqlDetailsStatsSaga } from "./statementDetails";
+import { uiConfigSaga } from "./uiConfig";
 
 export function* sagas(cacheInvalidationPeriod?: number): SagaIterator {
   yield all([
@@ -32,5 +33,6 @@ export function* sagas(cacheInvalidationPeriod?: number): SagaIterator {
     fork(notifificationsSaga),
     fork(sqlStatsSaga),
     fork(sqlDetailsStatsSaga),
+    fork(uiConfigSaga),
   ]);
 }

--- a/pkg/ui/workspaces/cluster-ui/src/store/uiConfig/index.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/store/uiConfig/index.ts
@@ -9,3 +9,5 @@
 // licenses/APL.txt.
 
 export * from "./uiConfig.reducer";
+export * from "./uiConfig.selector";
+export * from "./uiConfig.sagas";

--- a/pkg/ui/workspaces/cluster-ui/src/store/uiConfig/uiConfig.reducer.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/store/uiConfig/uiConfig.reducer.ts
@@ -11,8 +11,6 @@
 import { createSlice, PayloadAction } from "@reduxjs/toolkit";
 import { merge } from "lodash";
 import { DOMAIN_NAME } from "../utils";
-import { createSelector } from "reselect";
-import { AppState } from "../reducers";
 import { cockroach } from "@cockroachlabs/crdb-protobuf-client";
 export type UserSQLRolesRequest = cockroach.server.serverpb.UserSQLRolesRequest;
 
@@ -57,23 +55,16 @@ const uiConfigSlice = createSlice({
     update: (state, action: PayloadAction<Partial<UIConfigState>>) => {
       merge(state, action.payload);
     },
-    refreshUserSQLRoles: (_, action?: PayloadAction<UserSQLRolesRequest>) => {},
+    refreshUserSQLRoles: (
+      state,
+      action?: PayloadAction<UserSQLRolesRequest>,
+    ) => {
+      if (action?.payload) {
+        const resp = action.payload.toJSON();
+        state.userSQLRoles = resp["roles"];
+      }
+    },
   },
 });
-
-export const selectUIConfig = createSelector(
-  (state: AppState) => state.adminUI.uiConfig,
-  uiConfig => uiConfig,
-);
-
-export const selectIsTenant = createSelector(
-  selectUIConfig,
-  uiConfig => uiConfig.isTenant,
-);
-
-export const selectHasViewActivityRedactedRole = createSelector(
-  selectUIConfig,
-  uiConfig => uiConfig.userSQLRoles.includes("VIEWACTIVITYREDACTED"),
-);
 
 export const { actions, reducer } = uiConfigSlice;

--- a/pkg/ui/workspaces/cluster-ui/src/store/uiConfig/uiConfig.sagas.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/store/uiConfig/uiConfig.sagas.ts
@@ -1,0 +1,29 @@
+// Copyright 2023 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import { all, call, put, takeLatest } from "redux-saga/effects";
+import { actions, UserSQLRolesRequest } from "./uiConfig.reducer";
+import { PayloadAction } from "@reduxjs/toolkit";
+import { getUserSQLRoles } from "../../api/userApi";
+
+export function* refreshUserSQLRoles(
+  action: PayloadAction<UserSQLRolesRequest>,
+): any {
+  try {
+    const result = yield call(getUserSQLRoles, action?.payload);
+    yield put(actions.refreshUserSQLRoles(result));
+  } catch (e) {
+    console.warn(e.message);
+  }
+}
+
+export function* uiConfigSaga() {
+  yield all([takeLatest(actions.refreshUserSQLRoles, refreshUserSQLRoles)]);
+}

--- a/pkg/ui/workspaces/cluster-ui/src/store/uiConfig/uiConfig.selector.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/store/uiConfig/uiConfig.selector.ts
@@ -1,0 +1,27 @@
+// Copyright 2023 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import { createSelector } from "reselect";
+import { AppState } from "../reducers";
+
+export const selectUIConfig = createSelector(
+  (state: AppState) => state.adminUI.uiConfig,
+  uiConfig => uiConfig,
+);
+
+export const selectIsTenant = createSelector(
+  selectUIConfig,
+  uiConfig => uiConfig.isTenant,
+);
+
+export const selectHasViewActivityRedactedRole = createSelector(
+  selectUIConfig,
+  uiConfig => uiConfig.userSQLRoles.includes("VIEWACTIVITYREDACTED"),
+);


### PR DESCRIPTION
Backport 1/1 commits from #95271.

/cc @cockroachdb/release

---

Previously, the sql user used on CC Console was always admin, not making it necessary to do calls to get the list of sql roles. Now with new sql user roles being introduced, the call needs to be made and the proper value set on redux.

Epic: None

Release note: None

---

Release justification: bug fix