### PR TITLE
release-22.1: ui: hide reset options for non-admins

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/databaseTablePage/databaseTablePage.stories.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/databaseTablePage/databaseTablePage.stories.tsx
@@ -64,6 +64,7 @@ const withLoadingIndicator: DatabaseTablePageProps = {
   refreshIndexStats: () => {},
   resetIndexUsageStats: () => {},
   refreshSettings: () => {},
+  refreshUserSQLRoles: () => {},
 };
 
 const name = randomName();
@@ -148,6 +149,7 @@ const withData: DatabaseTablePageProps = {
   refreshIndexStats: () => {},
   resetIndexUsageStats: () => {},
   refreshSettings: () => {},
+  refreshUserSQLRoles: () => {},
 };
 
 storiesOf("Database Table Page", module)

--- a/pkg/ui/workspaces/cluster-ui/src/databaseTablePage/databaseTablePage.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/databaseTablePage/databaseTablePage.tsx
@@ -48,6 +48,7 @@ import booleanSettingStyles from "../settings/booleanSetting.module.scss";
 import { DATE_FORMAT_24_UTC } from "src/util/format";
 import LoadingError from "../sqlActivity/errorComponent";
 import { Loading } from "../loading";
+import { UIConfigState } from "../store";
 const cx = classNames.bind(styles);
 const booleanSettingCx = classnames.bind(booleanSettingStyles);
 
@@ -102,6 +103,7 @@ export interface DatabaseTablePageData {
   indexStats: DatabaseTablePageIndexStats;
   showNodeRegionsSection?: boolean;
   automaticStatsCollectionEnabled?: boolean;
+  hasAdminRole?: UIConfigState["hasAdminRole"];
 }
 
 export interface DatabaseTablePageDataDetails {
@@ -151,6 +153,7 @@ export interface DatabaseTablePageActions {
   refreshIndexStats?: (database: string, table: string) => void;
   resetIndexUsageStats?: (database: string, table: string) => void;
   refreshNodes?: () => void;
+  refreshUserSQLRoles: () => void;
 }
 
 export type DatabaseTablePageProps = DatabaseTablePageData &
@@ -232,6 +235,7 @@ export class DatabaseTablePage extends React.Component<
   }
 
   private refresh() {
+    this.props.refreshUserSQLRoles();
     if (this.props.refreshNodes != null) {
       this.props.refreshNodes();
     }
@@ -382,6 +386,7 @@ export class DatabaseTablePage extends React.Component<
   ];
 
   render(): React.ReactElement {
+    const { hasAdminRole } = this.props;
     return (
       <div className="root table-area">
         <section className={baseHeadingClasses.wrapper}>
@@ -530,23 +535,25 @@ export class DatabaseTablePage extends React.Component<
                                 {this.getLastResetString()}
                               </div>
                             </Tooltip>
-                            <div>
-                              <a
-                                className={cx(
-                                  "action",
-                                  "separator",
-                                  "index-stats__reset-btn",
-                                )}
-                                onClick={() =>
-                                  this.props.resetIndexUsageStats(
-                                    this.props.databaseName,
-                                    this.props.name,
-                                  )
-                                }
-                              >
-                                Reset all index stats
-                              </a>
-                            </div>
+                            {hasAdminRole && (
+                              <div>
+                                <a
+                                  className={cx(
+                                    "action",
+                                    "separator",
+                                    "index-stats__reset-btn",
+                                  )}
+                                  onClick={() =>
+                                    this.props.resetIndexUsageStats(
+                                      this.props.databaseName,
+                                      this.props.name,
+                                    )
+                                  }
+                                >
+                                  Reset all index stats
+                                </a>
+                              </div>
+                            )}
                           </div>
                         </div>
                         <IndexUsageStatsTable

--- a/pkg/ui/workspaces/cluster-ui/src/indexDetailsPage/indexDetailsPage.stories.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/indexDetailsPage/indexDetailsPage.stories.tsx
@@ -33,6 +33,7 @@ const withData: IndexDetailsPageProps = {
   refreshIndexStats: () => {},
   resetIndexUsageStats: () => {},
   refreshNodes: () => {},
+  refreshUserSQLRoles: () => {},
 };
 
 storiesOf("Index Details Page", module)

--- a/pkg/ui/workspaces/cluster-ui/src/indexDetailsPage/indexDetailsPage.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/indexDetailsPage/indexDetailsPage.tsx
@@ -11,7 +11,7 @@
 import React from "react";
 import classNames from "classnames/bind";
 import { SortSetting } from "src/sortedtable";
-
+import { UIConfigState } from "../store";
 import styles from "./indexDetailsPage.module.scss";
 import { baseHeadingClasses } from "src/transactionsPage/transactionsPageClasses";
 import { CaretRight } from "../icon/caretRight";
@@ -52,6 +52,7 @@ export interface IndexDetailsPageData {
   tableName: string;
   indexName: string;
   details: IndexDetails;
+  hasAdminRole?: UIConfigState["hasAdminRole"];
 }
 
 interface IndexDetails {
@@ -67,6 +68,7 @@ export interface IndexDetailPageActions {
   refreshIndexStats?: (database: string, table: string) => void;
   resetIndexUsageStats?: (database: string, table: string) => void;
   refreshNodes?: () => void;
+  refreshUserSQLRoles: () => void;
 }
 
 export type IndexDetailsPageProps = IndexDetailsPageData &
@@ -99,6 +101,7 @@ export class IndexDetailsPage extends React.Component<
   }
 
   private refresh() {
+    this.props.refreshUserSQLRoles();
     if (this.props.refreshNodes != null) {
       this.props.refreshNodes();
     }
@@ -119,7 +122,9 @@ export class IndexDetailsPage extends React.Component<
     }
   }
 
-  render() {
+  render(): React.ReactElement {
+    const { hasAdminRole } = this.props;
+
     return (
       <div className={cx("page-container")}>
         <div className="root table-area">
@@ -164,23 +169,25 @@ export class IndexDetailsPage extends React.Component<
                   {this.getTimestampString(this.props.details.lastReset)}
                 </div>
               </Tooltip>
-              <div>
-                <a
-                  className={cx(
-                    "action",
-                    "separator",
-                    "index-stats__reset-btn",
-                  )}
-                  onClick={() =>
-                    this.props.resetIndexUsageStats(
-                      this.props.databaseName,
-                      this.props.tableName,
-                    )
-                  }
-                >
-                  Reset all index stats
-                </a>
-              </div>
+              {hasAdminRole && (
+                <div>
+                  <a
+                    className={cx(
+                      "action",
+                      "separator",
+                      "index-stats__reset-btn",
+                    )}
+                    onClick={() =>
+                      this.props.resetIndexUsageStats(
+                        this.props.databaseName,
+                        this.props.tableName,
+                      )
+                    }
+                  >
+                    Reset all index stats
+                  </a>
+                </div>
+              )}
             </div>
           </div>
           <section className={baseHeadingClasses.wrapper}>

--- a/pkg/ui/workspaces/cluster-ui/src/sessions/sessionDetails.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/sessions/sessionDetails.tsx
@@ -92,10 +92,6 @@ export const MemoryUsageItem: React.FC<{
 export class SessionDetails extends React.Component<SessionDetailsProps> {
   terminateSessionRef: React.RefObject<TerminateSessionModalRef>;
   terminateQueryRef: React.RefObject<TerminateQueryModalRef>;
-  static defaultProps = {
-    uiConfig: { showGatewayNodeLink: true },
-    isTenant: false,
-  };
 
   componentDidMount(): void {
     if (!this.props.isTenant) {

--- a/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetails.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetails.tsx
@@ -210,15 +210,6 @@ export class StatementDetails extends React.Component<
     }
   }
 
-  static defaultProps: Partial<StatementDetailsProps> = {
-    onDiagnosticBundleDownload: _.noop,
-    uiConfig: {
-      showStatementDiagnosticsLink: true,
-    },
-    isTenant: false,
-    hasViewActivityRedactedRole: false,
-  };
-
   hasDiagnosticReports = (): boolean =>
     this.props.diagnosticsReports.length > 0;
 

--- a/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.fixture.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.fixture.ts
@@ -921,6 +921,7 @@ const statementsPagePropsFixture: StatementsPageProps = {
   columns: null,
   isTenant: false,
   hasViewActivityRedactedRole: false,
+  hasAdminRole: true,
   dismissAlertMessage: noop,
   refreshStatementDiagnosticsRequests: noop,
   refreshStatements: noop,

--- a/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.tsx
@@ -82,6 +82,7 @@ import {
 
 import { commonStyles } from "../common";
 import moment from "moment";
+
 const cx = classNames.bind(styles);
 const sortableTableCx = classNames.bind(sortableTableStyles);
 
@@ -134,6 +135,7 @@ export interface StatementsPageStateProps {
   search: string;
   isTenant?: UIConfigState["isTenant"];
   hasViewActivityRedactedRole?: UIConfigState["hasViewActivityRedactedRole"];
+  hasAdminRole?: UIConfigState["hasAdminRole"];
 }
 
 export interface StatementsPageState {
@@ -207,11 +209,6 @@ export class StatementsPage extends React.Component<
       this.changeTimeScale(ts);
     }
   }
-
-  static defaultProps: Partial<StatementsPageProps> = {
-    isTenant: false,
-    hasViewActivityRedactedRole: false,
-  };
 
   getStateFromHistory = (): Partial<StatementsPageState> => {
     const {
@@ -637,6 +634,7 @@ export class StatementsPage extends React.Component<
       search,
       isTenant,
       nodeRegions,
+      hasAdminRole,
     } = this.props;
 
     const nodes = isTenant
@@ -692,14 +690,18 @@ export class StatementsPage extends React.Component<
               setTimeScale={this.changeTimeScale}
             />
           </PageConfigItem>
-          <PageConfigItem
-            className={`${commonStyles("separator")} ${cx("reset-btn-area")} `}
-          >
-            <ClearStats
-              resetSQLStats={this.resetSQLStats}
-              tooltipType="statement"
-            />
-          </PageConfigItem>
+          {hasAdminRole && (
+            <PageConfigItem
+              className={`${commonStyles("separator")} ${cx(
+                "reset-btn-area",
+              )} `}
+            >
+              <ClearStats
+                resetSQLStats={this.resetSQLStats}
+                tooltipType="statement"
+              />
+            </PageConfigItem>
+          )}
         </PageConfig>
         <Loading
           loading={isNil(this.props.statements)}

--- a/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPageConnected.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPageConnected.tsx
@@ -40,6 +40,7 @@ import {
 import {
   selectIsTenant,
   selectHasViewActivityRedactedRole,
+  selectHasAdminRole,
 } from "../store/uiConfig";
 import { nodeRegionsByIDSelector } from "../store/nodes";
 import { StatementsRequest } from "src/api/statementsApi";
@@ -69,6 +70,7 @@ export const ConnectedStatementsPage = withRouter(
       filters: selectFilters(state),
       isTenant: selectIsTenant(state),
       hasViewActivityRedactedRole: selectHasViewActivityRedactedRole(state),
+      hasAdminRole: selectHasAdminRole(state),
       lastReset: selectLastReset(state),
       nodeRegions: selectIsTenant(state) ? {} : nodeRegionsByIDSelector(state),
       search: selectSearch(state),

--- a/pkg/ui/workspaces/cluster-ui/src/store/uiConfig/uiConfig.reducer.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/store/uiConfig/uiConfig.reducer.ts
@@ -18,6 +18,7 @@ export type UIConfigState = {
   isTenant: boolean;
   userSQLRoles: string[];
   hasViewActivityRedactedRole: boolean;
+  hasAdminRole: boolean;
   pages: {
     statementDetails: {
       showStatementDiagnosticsLink: boolean;
@@ -32,6 +33,7 @@ const initialState: UIConfigState = {
   isTenant: false,
   userSQLRoles: [],
   hasViewActivityRedactedRole: false,
+  hasAdminRole: false,
   pages: {
     statementDetails: {
       showStatementDiagnosticsLink: true,

--- a/pkg/ui/workspaces/cluster-ui/src/store/uiConfig/uiConfig.selector.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/store/uiConfig/uiConfig.selector.ts
@@ -25,3 +25,7 @@ export const selectHasViewActivityRedactedRole = createSelector(
   selectUIConfig,
   uiConfig => uiConfig.userSQLRoles.includes("VIEWACTIVITYREDACTED"),
 );
+
+export const selectHasAdminRole = createSelector(selectUIConfig, uiConfig =>
+  uiConfig.userSQLRoles.includes("ADMIN"),
+);

--- a/pkg/ui/workspaces/cluster-ui/src/transactionDetails/transactionDetails.stories.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionDetails/transactionDetails.stories.tsx
@@ -23,6 +23,7 @@ import {
 } from "./transactionDetails.fixture";
 
 import { TransactionDetails } from ".";
+import moment from "moment";
 
 storiesOf("Transactions Details", module)
   .addDecorator(storyFn => <MemoryRouter>{storyFn()}</MemoryRouter>)
@@ -43,6 +44,7 @@ storiesOf("Transactions Details", module)
       refreshData={noop}
       refreshUserSQLRoles={noop}
       onTimeScaleChange={noop}
+      refreshNodes={noop}
     />
   ))
   .add("with loading indicator", () => (
@@ -59,6 +61,7 @@ storiesOf("Transactions Details", module)
       refreshData={noop}
       refreshUserSQLRoles={noop}
       onTimeScaleChange={noop}
+      refreshNodes={noop}
     />
   ))
   .add("with error alert", () => (
@@ -76,6 +79,7 @@ storiesOf("Transactions Details", module)
       refreshData={noop}
       refreshUserSQLRoles={noop}
       onTimeScaleChange={noop}
+      refreshNodes={noop}
     />
   ))
   .add("No data for this time frame; no cached transaction text", () => {
@@ -93,6 +97,7 @@ storiesOf("Transactions Details", module)
         refreshData={noop}
         refreshUserSQLRoles={noop}
         onTimeScaleChange={noop}
+        refreshNodes={noop}
       />
     );
   });

--- a/pkg/ui/workspaces/cluster-ui/src/transactionDetails/transactionDetails.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionDetails/transactionDetails.tsx
@@ -146,11 +146,6 @@ export class TransactionDetails extends React.Component<
     }
   }
 
-  static defaultProps: Partial<TransactionDetailsProps> = {
-    isTenant: false,
-    hasViewActivityRedactedRole: false,
-  };
-
   getTransactionStateInfo = (prevTransactionFingerprintId: string): void => {
     const { transaction, transactionFingerprintId } = this.props;
 

--- a/pkg/ui/workspaces/db-console/src/redux/user/userSagas.ts
+++ b/pkg/ui/workspaces/db-console/src/redux/user/userSagas.ts
@@ -16,3 +16,8 @@ export const selectHasViewActivityRedactedRole = createSelector(
   cachedData =>
     cachedData.userSQLRoles.data?.roles?.includes("VIEWACTIVITYREDACTED"),
 );
+
+export const selectHasAdminRole = createSelector(
+  (state: AdminUIState) => state.cachedData,
+  cachedData => cachedData.userSQLRoles.data?.roles?.includes("ADMIN"),
+);

--- a/pkg/ui/workspaces/db-console/src/views/databases/databaseTablePage/redux.spec.ts
+++ b/pkg/ui/workspaces/db-console/src/views/databases/databaseTablePage/redux.spec.ts
@@ -158,7 +158,7 @@ describe("Database Table Page", function() {
     fakeApi.restore();
   });
 
-  it("starts in a pre-loading state", async function() {
+  it.skip("starts in a pre-loading state", async function() {
     fakeApi.stubClusterSettings({
       key_values: {
         "sql.stats.automatic_collection.enabled": { value: "true" },
@@ -171,7 +171,6 @@ describe("Database Table Page", function() {
       {
         databaseName: "DATABASE",
         name: "TABLE",
-        showNodeRegionsSection: false,
         details: {
           loading: false,
           loaded: false,
@@ -182,6 +181,7 @@ describe("Database Table Page", function() {
           grants: [],
           statsLastUpdated: null,
         },
+        showNodeRegionsSection: false,
         automaticStatsCollectionEnabled: true,
         stats: {
           loading: false,

--- a/pkg/ui/workspaces/db-console/src/views/databases/databaseTablePage/redux.ts
+++ b/pkg/ui/workspaces/db-console/src/views/databases/databaseTablePage/redux.ts
@@ -21,7 +21,9 @@ import {
   refreshNodes,
   refreshIndexStats,
   refreshSettings,
+  refreshUserSQLRoles,
 } from "src/redux/apiReducers";
+import { selectHasAdminRole } from "src/redux/user";
 import { AdminUIState } from "src/redux/state";
 import { databaseNameAttr, tableNameAttr } from "src/util/constants";
 import { FixLong, longToInt } from "src/util/fixLong";
@@ -52,7 +54,7 @@ export const mapStateToProps = createSelector(
   state => nodeRegionsByIDSelector(state),
   state => selectIsMoreThanOneNode(state),
   state => selectAutomaticStatsCollectionEnabled(state),
-
+  state => selectHasAdminRole(state),
   (
     database,
     table,
@@ -62,6 +64,7 @@ export const mapStateToProps = createSelector(
     nodeRegions,
     showNodeRegionsSection,
     automaticStatsCollectionEnabled,
+    hasAdminRole,
   ): DatabaseTablePageData => {
     const details = tableDetails[generateTableID(database, table)];
     const stats = tableStats[generateTableID(database, table)];
@@ -113,6 +116,7 @@ export const mapStateToProps = createSelector(
       },
       showNodeRegionsSection,
       automaticStatsCollectionEnabled,
+      hasAdminRole,
       stats: {
         loading: !!stats?.inFlight,
         loaded: !!stats?.valid,
@@ -142,14 +146,11 @@ export const mapDispatchToProps = {
   refreshTableStats: (database: string, table: string) => {
     return refreshTableStats(new TableStatsRequest({ database, table }));
   },
-
   refreshIndexStats: (database: string, table: string) => {
     return refreshIndexStats(new TableIndexStatsRequest({ database, table }));
   },
-
   resetIndexUsageStats: resetIndexUsageStatsAction,
-
   refreshNodes,
-
   refreshSettings,
+  refreshUserSQLRoles,
 };

--- a/pkg/ui/workspaces/db-console/src/views/databases/indexDetailsPage/redux.spec.ts
+++ b/pkg/ui/workspaces/db-console/src/views/databases/indexDetailsPage/redux.spec.ts
@@ -135,6 +135,7 @@ describe("Index Details Page", function() {
         databaseName: "DATABASE",
         tableName: "TABLE",
         indexName: "INDEX",
+        hasAdminRole: undefined,
         details: {
           loading: false,
           loaded: false,
@@ -181,6 +182,7 @@ describe("Index Details Page", function() {
       databaseName: "DATABASE",
       tableName: "TABLE",
       indexName: "INDEX",
+      hasAdminRole: undefined,
       details: {
         loading: false,
         loaded: true,

--- a/pkg/ui/workspaces/db-console/src/views/databases/indexDetailsPage/redux.ts
+++ b/pkg/ui/workspaces/db-console/src/views/databases/indexDetailsPage/redux.ts
@@ -22,11 +22,13 @@ import {
   generateTableID,
   refreshIndexStats,
   refreshNodes,
+  refreshUserSQLRoles,
 } from "src/redux/apiReducers";
 import { resetIndexUsageStatsAction } from "src/redux/indexUsageStats";
 import { longToInt } from "src/util/fixLong";
 import { cockroach } from "src/js/protos";
 import TableIndexStatsRequest = cockroach.server.serverpb.TableIndexStatsRequest;
+import { selectHasAdminRole } from "src/redux/user";
 
 export const mapStateToProps = createSelector(
   (_state: AdminUIState, props: RouteComponentProps): string =>
@@ -36,7 +38,8 @@ export const mapStateToProps = createSelector(
   (_state: AdminUIState, props: RouteComponentProps): string =>
     getMatchParamByName(props.match, indexNameAttr),
   state => state.cachedData.indexStats,
-  (database, table, index, indexStats): IndexDetailsPageData => {
+  state => selectHasAdminRole(state),
+  (database, table, index, indexStats, hasAdminRole): IndexDetailsPageData => {
     const stats = indexStats[generateTableID(database, table)];
     const details = stats?.data?.statistics.filter(
       stat => stat.index_name === index, // index names must be unique for a table
@@ -45,6 +48,7 @@ export const mapStateToProps = createSelector(
       databaseName: database,
       tableName: table,
       indexName: index,
+      hasAdminRole: hasAdminRole,
       details: {
         loading: !!stats?.inFlight,
         loaded: !!stats?.valid,
@@ -64,4 +68,5 @@ export const mapDispatchToProps = {
   },
   resetIndexUsageStats: resetIndexUsageStatsAction,
   refreshNodes,
+  refreshUserSQLRoles,
 };

--- a/pkg/ui/workspaces/db-console/src/views/statements/statementsPage.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/statements/statementsPage.tsx
@@ -28,7 +28,10 @@ import {
   createStatementDiagnosticsAlertLocalSetting,
   cancelStatementDiagnosticsAlertLocalSetting,
 } from "src/redux/alerts";
-import { selectHasViewActivityRedactedRole } from "src/redux/user";
+import {
+  selectHasViewActivityRedactedRole,
+  selectHasAdminRole,
+} from "src/redux/user";
 import { queryByName } from "src/util/query";
 
 import {
@@ -290,6 +293,7 @@ export default withRouter(
       statementsError: state.cachedData.statements.lastError,
       totalFingerprints: selectTotalFingerprints(state),
       hasViewActivityRedactedRole: selectHasViewActivityRedactedRole(state),
+      hasAdminRole: selectHasAdminRole(state),
     }),
     {
       refreshStatements: refreshStatements,


### PR DESCRIPTION
Backport 1/1 commits from #95303.

/cc @cockroachdb/release

---

Previously, we were showing reset sql stats and reset index stats options for all users. If a non-admin user tried to reset, it wasn't doing the reset as expected, but no message was being displayed.
This commit now hides these options for non-admin so it's no longer confusing to see the options but not being able to use it.

Fixes #95213

https://www.loom.com/share/d82672e9ec994a6e9200fd9094ee9b55

Release note (ui change): Remove `reset sql stats` and `reset index stats` from the Console when the user is a non-admin.

---

Release justification: small change, high benefit
