### PR TITLE
release-22.2: ui: hide reset options for non-admins

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/databaseTablePage/databaseTablePage.stories.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/databaseTablePage/databaseTablePage.stories.tsx
@@ -66,6 +66,7 @@ const withLoadingIndicator: DatabaseTablePageProps = {
   refreshIndexStats: () => {},
   resetIndexUsageStats: () => {},
   refreshSettings: () => {},
+  refreshUserSQLRoles: () => {},
 };
 
 const name = randomName();
@@ -167,6 +168,7 @@ const withData: DatabaseTablePageProps = {
   refreshIndexStats: () => {},
   resetIndexUsageStats: () => {},
   refreshSettings: () => {},
+  refreshUserSQLRoles: () => {},
 };
 
 storiesOf("Database Table Page", module)

--- a/pkg/ui/workspaces/cluster-ui/src/databaseTablePage/databaseTablePage.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/databaseTablePage/databaseTablePage.tsx
@@ -53,6 +53,7 @@ import { Loading } from "../loading";
 import { CockroachCloudContext } from "../contexts";
 import IdxRecAction from "../insights/indexActionBtn";
 import { RecommendationType } from "../indexDetailsPage";
+import { UIConfigState } from "../store";
 
 const cx = classNames.bind(styles);
 const booleanSettingCx = classnames.bind(booleanSettingStyles);
@@ -108,6 +109,7 @@ export interface DatabaseTablePageData {
   indexStats: DatabaseTablePageIndexStats;
   showNodeRegionsSection?: boolean;
   automaticStatsCollectionEnabled?: boolean;
+  hasAdminRole?: UIConfigState["hasAdminRole"];
 }
 
 export interface DatabaseTablePageDataDetails {
@@ -166,6 +168,7 @@ export interface DatabaseTablePageActions {
   refreshIndexStats?: (database: string, table: string) => void;
   resetIndexUsageStats?: (database: string, table: string) => void;
   refreshNodes?: () => void;
+  refreshUserSQLRoles: () => void;
 }
 
 export type DatabaseTablePageProps = DatabaseTablePageData &
@@ -247,6 +250,7 @@ export class DatabaseTablePage extends React.Component<
   }
 
   private refresh() {
+    this.props.refreshUserSQLRoles();
     if (this.props.refreshNodes != null) {
       this.props.refreshNodes();
     }
@@ -493,6 +497,7 @@ export class DatabaseTablePage extends React.Component<
   };
 
   render(): React.ReactElement {
+    const { hasAdminRole } = this.props;
     return (
       <div className="root table-area">
         <section className={baseHeadingClasses.wrapper}>
@@ -644,23 +649,25 @@ export class DatabaseTablePage extends React.Component<
                                 {this.getLastResetString()}
                               </div>
                             </Tooltip>
-                            <div>
-                              <a
-                                className={cx(
-                                  "action",
-                                  "separator",
-                                  "index-stats__reset-btn",
-                                )}
-                                onClick={() =>
-                                  this.props.resetIndexUsageStats(
-                                    this.props.databaseName,
-                                    this.props.name,
-                                  )
-                                }
-                              >
-                                Reset all index stats
-                              </a>
-                            </div>
+                            {hasAdminRole && (
+                              <div>
+                                <a
+                                  className={cx(
+                                    "action",
+                                    "separator",
+                                    "index-stats__reset-btn",
+                                  )}
+                                  onClick={() =>
+                                    this.props.resetIndexUsageStats(
+                                      this.props.databaseName,
+                                      this.props.name,
+                                    )
+                                  }
+                                >
+                                  Reset all index stats
+                                </a>
+                              </div>
+                            )}
                           </div>
                         </div>
                         <IndexUsageStatsTable

--- a/pkg/ui/workspaces/cluster-ui/src/indexDetailsPage/indexDetails.selectors.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/indexDetailsPage/indexDetails.selectors.ts
@@ -23,7 +23,7 @@ import {
 } from "../util";
 import { cockroach } from "@cockroachlabs/crdb-protobuf-client";
 import { IndexDetailsPageData } from "./indexDetailsPage";
-import { selectIsTenant } from "../store/uiConfig";
+import { selectHasAdminRole, selectIsTenant } from "../store/uiConfig";
 import { BreadcrumbItem } from "../breadcrumbs";
 import { RecommendationType as RecType } from "./indexDetailsPage";
 const { RecommendationType } = cockroach.sql.IndexRecommendation;
@@ -39,7 +39,16 @@ export const selectIndexDetails = createSelector(
     getMatchParamByName(props.match, indexNameAttr),
   (state: AppState) => state.adminUI.indexStats.cachedData,
   (state: AppState) => selectIsTenant(state),
-  (database, schema, table, index, indexStats): IndexDetailsPageData => {
+  (state: AppState) => selectHasAdminRole(state),
+  (
+    database,
+    schema,
+    table,
+    index,
+    indexStats,
+    isTenant,
+    hasAdminRole,
+  ): IndexDetailsPageData => {
     const stats = indexStats[generateTableID(database, table)];
     const details = stats?.data?.statistics.filter(
       stat => stat.index_name === index, // index names must be unique for a table
@@ -70,6 +79,7 @@ export const selectIndexDetails = createSelector(
         table,
         index,
       ),
+      hasAdminRole: hasAdminRole,
       details: {
         loading: !!stats?.inFlight,
         loaded: !!stats?.valid,

--- a/pkg/ui/workspaces/cluster-ui/src/indexDetailsPage/indexDetailsConnected.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/indexDetailsPage/indexDetailsConnected.ts
@@ -8,7 +8,7 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
-import { AppState } from "../store";
+import { AppState, uiConfigActions } from "../store";
 import { RouteComponentProps, withRouter } from "react-router-dom";
 import { selectIndexDetails } from "./indexDetails.selectors";
 import { Dispatch } from "redux";
@@ -42,6 +42,7 @@ const mapDispatchToProps = (dispatch: Dispatch): IndexDetailPageActions => ({
     );
   },
   refreshNodes: () => dispatch(nodesActions.refresh()),
+  refreshUserSQLRoles: () => dispatch(uiConfigActions.refreshUserSQLRoles()),
 });
 
 export const ConnectedIndexDetailsPage = withRouter<any, any>(

--- a/pkg/ui/workspaces/cluster-ui/src/indexDetailsPage/indexDetailsPage.stories.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/indexDetailsPage/indexDetailsPage.stories.tsx
@@ -55,6 +55,7 @@ const withData: IndexDetailsPageProps = {
   refreshIndexStats: () => {},
   resetIndexUsageStats: () => {},
   refreshNodes: () => {},
+  refreshUserSQLRoles: () => {},
 };
 
 storiesOf("Index Details Page", module)

--- a/pkg/ui/workspaces/cluster-ui/src/indexDetailsPage/indexDetailsPage.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/indexDetailsPage/indexDetailsPage.tsx
@@ -11,7 +11,7 @@
 import React from "react";
 import classNames from "classnames/bind";
 import { SortSetting } from "src/sortedtable";
-
+import { UIConfigState } from "../store";
 import styles from "./indexDetailsPage.module.scss";
 import { baseHeadingClasses } from "src/transactionsPage/transactionsPageClasses";
 import { CaretRight } from "../icon/caretRight";
@@ -58,6 +58,7 @@ export interface IndexDetailsPageData {
   indexName: string;
   details: IndexDetails;
   breadcrumbItems: BreadcrumbItem[];
+  hasAdminRole?: UIConfigState["hasAdminRole"];
 }
 
 interface IndexDetails {
@@ -81,6 +82,7 @@ export interface IndexDetailPageActions {
   refreshIndexStats?: (database: string, table: string) => void;
   resetIndexUsageStats?: (database: string, table: string) => void;
   refreshNodes?: () => void;
+  refreshUserSQLRoles: () => void;
 }
 
 export type IndexDetailsPageProps = IndexDetailsPageData &
@@ -113,6 +115,7 @@ export class IndexDetailsPage extends React.Component<
   }
 
   private refresh() {
+    this.props.refreshUserSQLRoles();
     if (this.props.refreshNodes != null) {
       this.props.refreshNodes();
     }
@@ -210,6 +213,8 @@ export class IndexDetailsPage extends React.Component<
   }
 
   render(): React.ReactElement {
+    const { hasAdminRole } = this.props;
+
     return (
       <div className={cx("page-container")}>
         <div className="root table-area">
@@ -235,23 +240,25 @@ export class IndexDetailsPage extends React.Component<
                   {this.getTimestampString(this.props.details.lastReset)}
                 </div>
               </Tooltip>
-              <div>
-                <a
-                  className={cx(
-                    "action",
-                    "separator",
-                    "index-stats__reset-btn",
-                  )}
-                  onClick={() =>
-                    this.props.resetIndexUsageStats(
-                      this.props.databaseName,
-                      this.props.tableName,
-                    )
-                  }
-                >
-                  Reset all index stats
-                </a>
-              </div>
+              {hasAdminRole && (
+                <div>
+                  <a
+                    className={cx(
+                      "action",
+                      "separator",
+                      "index-stats__reset-btn",
+                    )}
+                    onClick={() =>
+                      this.props.resetIndexUsageStats(
+                        this.props.databaseName,
+                        this.props.tableName,
+                      )
+                    }
+                  >
+                    Reset all index stats
+                  </a>
+                </div>
+              )}
             </div>
           </div>
           <section className={baseHeadingClasses.wrapper}>

--- a/pkg/ui/workspaces/cluster-ui/src/sessions/sessionDetails.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/sessions/sessionDetails.tsx
@@ -100,10 +100,6 @@ export const MemoryUsageItem: React.FC<{
 export class SessionDetails extends React.Component<SessionDetailsProps> {
   terminateSessionRef: React.RefObject<TerminateSessionModalRef>;
   terminateQueryRef: React.RefObject<TerminateQueryModalRef>;
-  static defaultProps = {
-    uiConfig: { showGatewayNodeLink: true },
-    isTenant: false,
-  };
 
   componentDidMount(): void {
     if (!this.props.isTenant) {

--- a/pkg/ui/workspaces/cluster-ui/src/statementDetails/diagnostics/diagnosticsView.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementDetails/diagnostics/diagnosticsView.tsx
@@ -117,9 +117,6 @@ export class DiagnosticsView extends React.Component<
   DiagnosticsViewProps,
   DiagnosticsViewState
 > {
-  static defaultProps: Partial<DiagnosticsViewProps> = {
-    showDiagnosticsViewLink: true,
-  };
   columns: ColumnsConfig<IStatementDiagnosticsReport> = [
     {
       key: "activatedOn",

--- a/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetails.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetails.tsx
@@ -210,15 +210,6 @@ export class StatementDetails extends React.Component<
     }
   }
 
-  static defaultProps: Partial<StatementDetailsProps> = {
-    onDiagnosticBundleDownload: _.noop,
-    uiConfig: {
-      showStatementDiagnosticsLink: true,
-    },
-    isTenant: false,
-    hasViewActivityRedactedRole: false,
-  };
-
   hasDiagnosticReports = (): boolean =>
     this.props.diagnosticsReports.length > 0;
 

--- a/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.fixture.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.fixture.ts
@@ -925,6 +925,7 @@ const statementsPagePropsFixture: StatementsPageProps = {
   columns: null,
   isTenant: false,
   hasViewActivityRedactedRole: false,
+  hasAdminRole: true,
   dismissAlertMessage: noop,
   refreshStatementDiagnosticsRequests: noop,
   refreshStatements: noop,

--- a/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.tsx
@@ -137,6 +137,7 @@ export interface StatementsPageStateProps {
   search: string;
   isTenant?: UIConfigState["isTenant"];
   hasViewActivityRedactedRole?: UIConfigState["hasViewActivityRedactedRole"];
+  hasAdminRole?: UIConfigState["hasAdminRole"];
 }
 
 export interface StatementsPageState {
@@ -212,11 +213,6 @@ export class StatementsPage extends React.Component<
       this.changeTimeScale(ts);
     }
   }
-
-  static defaultProps: Partial<StatementsPageProps> = {
-    isTenant: false,
-    hasViewActivityRedactedRole: false,
-  };
 
   getStateFromHistory = (): Partial<StatementsPageState> => {
     const {
@@ -673,6 +669,7 @@ export class StatementsPage extends React.Component<
       search,
       isTenant,
       nodeRegions,
+      hasAdminRole,
     } = this.props;
 
     const nodes = isTenant
@@ -728,14 +725,18 @@ export class StatementsPage extends React.Component<
               setTimeScale={this.changeTimeScale}
             />
           </PageConfigItem>
-          <PageConfigItem
-            className={`${commonStyles("separator")} ${cx("reset-btn-area")} `}
-          >
-            <ClearStats
-              resetSQLStats={this.resetSQLStats}
-              tooltipType="statement"
-            />
-          </PageConfigItem>
+          {hasAdminRole && (
+            <PageConfigItem
+              className={`${commonStyles("separator")} ${cx(
+                "reset-btn-area",
+              )} `}
+            >
+              <ClearStats
+                resetSQLStats={this.resetSQLStats}
+                tooltipType="statement"
+              />
+            </PageConfigItem>
+          )}
         </PageConfig>
         <div className={cx("table-area")}>
           <Loading

--- a/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPageConnected.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPageConnected.tsx
@@ -39,6 +39,7 @@ import {
 import {
   selectIsTenant,
   selectHasViewActivityRedactedRole,
+  selectHasAdminRole,
 } from "../store/uiConfig";
 import { nodeRegionsByIDSelector } from "../store/nodes";
 import { StatementsRequest } from "src/api/statementsApi";
@@ -94,6 +95,7 @@ export const ConnectedStatementsPage = withRouter(
         filters: selectFilters(state),
         isTenant: selectIsTenant(state),
         hasViewActivityRedactedRole: selectHasViewActivityRedactedRole(state),
+        hasAdminRole: selectHasAdminRole(state),
         lastReset: selectLastReset(state),
         nodeRegions: selectIsTenant(state)
           ? {}

--- a/pkg/ui/workspaces/cluster-ui/src/store/uiConfig/uiConfig.reducer.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/store/uiConfig/uiConfig.reducer.ts
@@ -18,6 +18,7 @@ export type UIConfigState = {
   isTenant: boolean;
   userSQLRoles: string[];
   hasViewActivityRedactedRole: boolean;
+  hasAdminRole: boolean;
   pages: {
     statementDetails: {
       showStatementDiagnosticsLink: boolean;
@@ -32,6 +33,7 @@ const initialState: UIConfigState = {
   isTenant: false,
   userSQLRoles: [],
   hasViewActivityRedactedRole: false,
+  hasAdminRole: false,
   pages: {
     statementDetails: {
       showStatementDiagnosticsLink: true,

--- a/pkg/ui/workspaces/cluster-ui/src/store/uiConfig/uiConfig.selector.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/store/uiConfig/uiConfig.selector.ts
@@ -25,3 +25,7 @@ export const selectHasViewActivityRedactedRole = createSelector(
   selectUIConfig,
   uiConfig => uiConfig.userSQLRoles.includes("VIEWACTIVITYREDACTED"),
 );
+
+export const selectHasAdminRole = createSelector(selectUIConfig, uiConfig =>
+  uiConfig.userSQLRoles.includes("ADMIN"),
+);

--- a/pkg/ui/workspaces/cluster-ui/src/transactionDetails/transactionDetails.stories.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionDetails/transactionDetails.stories.tsx
@@ -23,6 +23,7 @@ import {
 } from "./transactionDetails.fixture";
 
 import { TransactionDetails } from ".";
+import moment from "moment";
 
 storiesOf("Transactions Details", module)
   .addDecorator(storyFn => <MemoryRouter>{storyFn()}</MemoryRouter>)
@@ -43,6 +44,8 @@ storiesOf("Transactions Details", module)
       refreshData={noop}
       refreshUserSQLRoles={noop}
       onTimeScaleChange={noop}
+      refreshNodes={noop}
+      lastUpdated={moment("0001-01-01T00:00:00Z")}
     />
   ))
   .add("with loading indicator", () => (
@@ -59,6 +62,8 @@ storiesOf("Transactions Details", module)
       refreshData={noop}
       refreshUserSQLRoles={noop}
       onTimeScaleChange={noop}
+      refreshNodes={noop}
+      lastUpdated={moment("0001-01-01T00:00:00Z")}
     />
   ))
   .add("with error alert", () => (
@@ -76,6 +81,8 @@ storiesOf("Transactions Details", module)
       refreshData={noop}
       refreshUserSQLRoles={noop}
       onTimeScaleChange={noop}
+      refreshNodes={noop}
+      lastUpdated={moment("0001-01-01T00:00:00Z")}
     />
   ))
   .add("No data for this time frame; no cached transaction text", () => {
@@ -93,6 +100,8 @@ storiesOf("Transactions Details", module)
         refreshData={noop}
         refreshUserSQLRoles={noop}
         onTimeScaleChange={noop}
+        refreshNodes={noop}
+        lastUpdated={moment("0001-01-01T00:00:00Z")}
       />
     );
   });

--- a/pkg/ui/workspaces/cluster-ui/src/transactionDetails/transactionDetails.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionDetails/transactionDetails.tsx
@@ -150,11 +150,6 @@ export class TransactionDetails extends React.Component<
     }
   }
 
-  static defaultProps: Partial<TransactionDetailsProps> = {
-    isTenant: false,
-    hasViewActivityRedactedRole: false,
-  };
-
   getTransactionStateInfo = (prevTransactionFingerprintId: string): void => {
     const { transaction, transactionFingerprintId } = this.props;
 

--- a/pkg/ui/workspaces/db-console/src/redux/user/userSagas.ts
+++ b/pkg/ui/workspaces/db-console/src/redux/user/userSagas.ts
@@ -16,3 +16,8 @@ export const selectHasViewActivityRedactedRole = createSelector(
   cachedData =>
     cachedData.userSQLRoles.data?.roles?.includes("VIEWACTIVITYREDACTED"),
 );
+
+export const selectHasAdminRole = createSelector(
+  (state: AdminUIState) => state.cachedData,
+  cachedData => cachedData.userSQLRoles.data?.roles?.includes("ADMIN"),
+);

--- a/pkg/ui/workspaces/db-console/src/views/databases/databaseTablePage/redux.ts
+++ b/pkg/ui/workspaces/db-console/src/views/databases/databaseTablePage/redux.ts
@@ -25,7 +25,9 @@ import {
   refreshNodes,
   refreshIndexStats,
   refreshSettings,
+  refreshUserSQLRoles,
 } from "src/redux/apiReducers";
+import { selectHasAdminRole } from "src/redux/user";
 import { AdminUIState } from "src/redux/state";
 import { databaseNameAttr, tableNameAttr } from "src/util/constants";
 import { FixLong, longToInt } from "src/util/fixLong";
@@ -55,7 +57,7 @@ export const mapStateToProps = createSelector(
   state => nodeRegionsByIDSelector(state),
   state => selectIsMoreThanOneNode(state),
   state => selectAutomaticStatsCollectionEnabled(state),
-
+  state => selectHasAdminRole(state),
   (
     database,
     table,
@@ -65,6 +67,7 @@ export const mapStateToProps = createSelector(
     nodeRegions,
     showNodeRegionsSection,
     automaticStatsCollectionEnabled,
+    hasAdminRole,
   ): DatabaseTablePageData => {
     const details = tableDetails[generateTableID(database, table)];
     const stats = tableStats[generateTableID(database, table)];
@@ -147,6 +150,7 @@ export const mapStateToProps = createSelector(
       },
       showNodeRegionsSection,
       automaticStatsCollectionEnabled,
+      hasAdminRole,
       stats: {
         loading: !!stats?.inFlight,
         loaded: !!stats?.valid,
@@ -176,14 +180,11 @@ export const mapDispatchToProps = {
   refreshTableStats: (database: string, table: string) => {
     return refreshTableStats(new TableStatsRequest({ database, table }));
   },
-
   refreshIndexStats: (database: string, table: string) => {
     return refreshIndexStats(new TableIndexStatsRequest({ database, table }));
   },
-
   resetIndexUsageStats: resetIndexUsageStatsAction,
-
   refreshNodes,
-
   refreshSettings,
+  refreshUserSQLRoles,
 };

--- a/pkg/ui/workspaces/db-console/src/views/databases/indexDetailsPage/redux.ts
+++ b/pkg/ui/workspaces/db-console/src/views/databases/indexDetailsPage/redux.ts
@@ -26,11 +26,13 @@ import {
   generateTableID,
   refreshIndexStats,
   refreshNodes,
+  refreshUserSQLRoles,
 } from "src/redux/apiReducers";
 import { resetIndexUsageStatsAction } from "src/redux/indexUsageStats";
 import { longToInt } from "src/util/fixLong";
 import { cockroach } from "src/js/protos";
 import TableIndexStatsRequest = cockroach.server.serverpb.TableIndexStatsRequest;
+import { selectHasAdminRole } from "src/redux/user";
 const { RecommendationType } = cockroach.sql.IndexRecommendation;
 
 export const mapStateToProps = createSelector(
@@ -41,7 +43,8 @@ export const mapStateToProps = createSelector(
   (_state: AdminUIState, props: RouteComponentProps): string =>
     getMatchParamByName(props.match, indexNameAttr),
   state => state.cachedData.indexStats,
-  (database, table, index, indexStats): IndexDetailsPageData => {
+  state => selectHasAdminRole(state),
+  (database, table, index, indexStats, hasAdminRole): IndexDetailsPageData => {
     const stats = indexStats[generateTableID(database, table)];
     const details = stats?.data?.statistics.filter(
       stat => stat.index_name === index, // index names must be unique for a table
@@ -67,6 +70,7 @@ export const mapStateToProps = createSelector(
       databaseName: database,
       tableName: table,
       indexName: index,
+      hasAdminRole: hasAdminRole,
       details: {
         loading: !!stats?.inFlight,
         loaded: !!stats?.valid,
@@ -88,4 +92,5 @@ export const mapDispatchToProps = {
   },
   resetIndexUsageStats: resetIndexUsageStatsAction,
   refreshNodes,
+  refreshUserSQLRoles,
 };

--- a/pkg/ui/workspaces/db-console/src/views/statements/statementsPage.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/statements/statementsPage.tsx
@@ -29,7 +29,10 @@ import {
   createStatementDiagnosticsAlertLocalSetting,
   cancelStatementDiagnosticsAlertLocalSetting,
 } from "src/redux/alerts";
-import { selectHasViewActivityRedactedRole } from "src/redux/user";
+import {
+  selectHasViewActivityRedactedRole,
+  selectHasAdminRole,
+} from "src/redux/user";
 import { queryByName } from "src/util/query";
 
 import {
@@ -376,6 +379,7 @@ export default withRouter(
         statementsError: state.cachedData.statements.lastError,
         totalFingerprints: selectTotalFingerprints(state),
         hasViewActivityRedactedRole: selectHasViewActivityRedactedRole(state),
+        hasAdminRole: selectHasAdminRole(state),
       },
       activePageProps: mapStateToActiveStatementViewProps(state),
     }),


### PR DESCRIPTION
Backport 1/1 commits from #95303.

/cc @cockroachdb/release

---

Previously, we were showing reset sql stats and reset index stats options for all users. If a non-admin user tried to reset, it wasn't doing the reset as expected, but no message was being displayed.
This commit now hides these options for non-admin so it's no longer confusing to see the options but not being able to use it.

Fixes #95213

https://www.loom.com/share/d82672e9ec994a6e9200fd9094ee9b55

Release note (ui change): Remove `reset sql stats` and `reset index stats` from the Console when the user is a non-admin.

---

Release justification: small change, high benefit
