### PR TITLE
kvserver: add cause metrics to split queue

### DIFF
--- a/pkg/ts/catalog/chart_catalog.go
+++ b/pkg/ts/catalog/chart_catalog.go
@@ -787,6 +787,18 @@ var charts = []sectionDescription{
 				Title:   "Time Spent",
 				Metrics: []string{"queue.split.processingnanos"},
 			},
+			{
+				Title:   "Sized Based Splits",
+				Metrics: []string{"queue.split.size_based"},
+			},
+			{
+				Title:   "Load Based Splits",
+				Metrics: []string{"queue.split.load_based"},
+			},
+			{
+				Title:   "Span Configuration Based Splits",
+				Metrics: []string{"queue.split.span_config_based"},
+			},
 		},
 	},
 	{


### PR DESCRIPTION
Previously, there was no insight into the breakdown by cause of range
splits. Only `range.splits` existed as a metric. This commit adds three
additional metrics for range splits triggered by the split queue.

`queue.split.size_based`: when the range exceeds the range bytes
threshsold.
`queue.split.load_based`: when the range exceeds the load based split
threshold
`queue.split.span_config_based`: when the range should be split for
configuration reasons e.g. tenant or table boundaries.

Resolves: https://github.com/cockroachdb/cockroach/issues/95381

Release note (ops change): Add `queue.split.size_based`,
`queue.split.load_based`, `queue.split.span_config_based` metrics which
track the number range splits successfully made by the split queue due to
the range exceeding the configured range size threshold, exceeding the
load based split threshold and table or tenant boundaries respectively.