### PR TITLE
roachtest: use unified mode in c2c roach tests

### DIFF
--- a/pkg/cmd/roachprod/flags.go
+++ b/pkg/cmd/roachprod/flags.go
@@ -47,6 +47,7 @@ var (
 	listMine              bool
 	listPattern           string
 	secure                = false
+	tenantName            string
 	extraSSHOptions       = ""
 	nodeEnv               []string
 	tag                   string
@@ -198,7 +199,7 @@ func initFlags() {
 		"create a cluster backup schedule once the cluster has started (by default, "+
 			"full backup hourly and incremental every 15 minutes)")
 	startCmd.Flags().StringVar(&startOpts.ScheduleBackupArgs, "schedule-backup-args", "",
-		`Recurrence and scheduled backup options specification. 
+		`Recurrence and scheduled backup options specification.
 Default is "RECURRING '*/15 * * * *' FULL BACKUP '@hourly' WITH SCHEDULE OPTIONS first_run = 'now'"`)
 
 	startTenantCmd.Flags().StringVarP(&hostCluster,
@@ -330,4 +331,9 @@ Default is "RECURRING '*/15 * * * *' FULL BACKUP '@hourly' WITH SCHEDULE OPTIONS
 		cmd.Flags().BoolVar(&secure,
 			"secure", false, "use a secure cluster")
 	}
+	for _, cmd := range []*cobra.Command{pgurlCmd, sqlCmd} {
+		cmd.Flags().StringVar(&tenantName,
+			"tenant-name", "", "specific tenant to connect to")
+	}
+
 }

--- a/pkg/cmd/roachprod/main.go
+++ b/pkg/cmd/roachprod/main.go
@@ -794,7 +794,7 @@ var sqlCmd = &cobra.Command{
 	Long:  "Run `cockroach sql` on a remote cluster.\n",
 	Args:  cobra.MinimumNArgs(1),
 	Run: wrap(func(cmd *cobra.Command, args []string) error {
-		return roachprod.SQL(context.Background(), roachprodLibraryLogger, args[0], secure, args[1:])
+		return roachprod.SQL(context.Background(), roachprodLibraryLogger, args[0], secure, tenantName, args[1:])
 	}),
 }
 
@@ -805,7 +805,11 @@ var pgurlCmd = &cobra.Command{
 `,
 	Args: cobra.ExactArgs(1),
 	Run: wrap(func(cmd *cobra.Command, args []string) error {
-		urls, err := roachprod.PgURL(context.Background(), roachprodLibraryLogger, args[0], pgurlCertsDir, external, secure)
+		urls, err := roachprod.PgURL(context.Background(), roachprodLibraryLogger, args[0], pgurlCertsDir, roachprod.PGURLOptions{
+			External:   external,
+			Secure:     secure,
+			TenantName: tenantName,
+		})
 		if err != nil {
 			return err
 		}

--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -2103,7 +2103,9 @@ func (c *clusterImpl) loggerForCmd(
 func (c *clusterImpl) pgURLErr(
 	ctx context.Context, l *logger.Logger, node option.NodeListOption, external bool,
 ) ([]string, error) {
-	urls, err := roachprod.PgURL(ctx, l, c.MakeNodes(node), c.localCertsDir, external, c.localCertsDir != "" /* secure */)
+	urls, err := roachprod.PgURL(ctx, l, c.MakeNodes(node), c.localCertsDir, roachprod.PGURLOptions{
+		External: external,
+		Secure:   c.localCertsDir != ""})
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -267,8 +267,10 @@ func initBinariesAndLibraries() {
 }
 
 // execCmd is like execCmdEx, but doesn't return the command's output.
-func execCmd(ctx context.Context, l *logger.Logger, clusterName string, args ...string) error {
-	return execCmdEx(ctx, l, clusterName, args...).err
+func execCmd(
+	ctx context.Context, l *logger.Logger, clusterName string, secure bool, args ...string,
+) error {
+	return execCmdEx(ctx, l, clusterName, secure, args...).err
 }
 
 type cmdRes struct {
@@ -283,7 +285,9 @@ type cmdRes struct {
 // Note that the output is truncated; only a tail is returned.
 // Also note that if the command exits with an error code, its output is also
 // included in cmdRes.err.
-func execCmdEx(ctx context.Context, l *logger.Logger, clusterName string, args ...string) cmdRes {
+func execCmdEx(
+	ctx context.Context, l *logger.Logger, clusterName string, secure bool, args ...string,
+) cmdRes {
 	var cancel func()
 	ctx, cancel = context.WithCancel(ctx)
 	defer cancel()
@@ -380,7 +384,7 @@ func execCmdEx(ctx context.Context, l *logger.Logger, clusterName string, args .
 		}
 	}
 
-	err := roachprod.Run(ctx, l, clusterName, "" /* SSHOptions */, "" /* processTag */, false /* secure */, roachprodRunStdout, roachprodRunStderr, args)
+	err := roachprod.Run(ctx, l, clusterName, "" /* SSHOptions */, "" /* processTag */, secure, roachprodRunStdout, roachprodRunStderr, args)
 	closePipes(ctx)
 	wg.Wait()
 
@@ -1950,7 +1954,7 @@ func (c *clusterImpl) RunE(ctx context.Context, node option.NodeListOption, args
 	if err := errors.Wrap(ctx.Err(), "cluster.RunE"); err != nil {
 		return err
 	}
-	err = execCmd(ctx, l, c.MakeNodes(node), args...)
+	err = execCmd(ctx, l, c.MakeNodes(node), c.IsSecure(), args...)
 
 	l.Printf("> result: %+v", err)
 	if err := ctx.Err(); err != nil {

--- a/pkg/cmd/roachtest/tests/BUILD.bazel
+++ b/pkg/cmd/roachtest/tests/BUILD.bazel
@@ -198,7 +198,6 @@ go_library(
         "//pkg/roachprod/install",
         "//pkg/roachprod/logger",
         "//pkg/roachprod/prometheus",
-        "//pkg/roachprod/vm/local",
         "//pkg/security/username",
         "//pkg/server",
         "//pkg/server/serverpb",

--- a/pkg/cmd/roachtest/tests/cluster_to_cluster.go
+++ b/pkg/cmd/roachtest/tests/cluster_to_cluster.go
@@ -29,7 +29,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/install"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/logger"
-	"github.com/cockroachdb/cockroach/pkg/roachprod/vm/local"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
@@ -48,29 +47,24 @@ type clusterInfo struct {
 	// ID is the id of the tenant
 	ID int
 
-	// pgurl is a connection string to the host cluster
+	// pgurl is a connection string to the system tenant
 	pgURL string
 
-	// tenant provides a handler to the tenant
-	tenant *tenantNode
-
-	// db provides a connection to the host cluster
+	// db provides a connection to the system tenant
 	db *gosql.DB
 
 	// sql provides a sql connection to the host cluster
 	sql *sqlutils.SQLRunner
 
-	// sqlNode indicates the roachprod node running a single sql server
-	sqlNode int
-
-	// kvNodes indicates the roachprod nodes running the cluster's kv nodes
-	kvNodes option.NodeListOption
+	// nodes indicates the roachprod nodes running the cluster's nodes
+	nodes option.NodeListOption
 }
 
 type c2cSetup struct {
-	src     clusterInfo
-	dst     clusterInfo
-	metrics c2cMetrics
+	src          clusterInfo
+	dst          clusterInfo
+	workloadNode option.NodeListOption
+	metrics      c2cMetrics
 }
 
 // DiskUsageTracker can grab the disk usage of the provided cluster.
@@ -194,12 +188,12 @@ func (m c2cMetrics) export() map[string]exportedMetric {
 func setupC2C(
 	ctx context.Context, t test.Test, c cluster.Cluster, srcKVNodes,
 	dstKVNodes int,
-) (*c2cSetup, func()) {
+) *c2cSetup {
 	c.Put(ctx, t.Cockroach(), "./cockroach")
 	srcCluster := c.Range(1, srcKVNodes)
 	dstCluster := c.Range(srcKVNodes+1, srcKVNodes+dstKVNodes)
-	srcTenantNode := srcKVNodes + dstKVNodes + 1
-	c.Put(ctx, t.DeprecatedWorkload(), "./workload", c.Node(srcTenantNode))
+	workloadNode := c.Node(srcKVNodes + dstKVNodes + 1)
+	c.Put(ctx, t.DeprecatedWorkload(), "./workload", workloadNode)
 
 	srcStartOps := option.DefaultStartOpts()
 	srcStartOps.RoachprodOpts.InitTarget = 1
@@ -230,36 +224,22 @@ func setupC2C(
 	destTenantName := "destination-tenant"
 	srcSQL.Exec(t, fmt.Sprintf(`CREATE TENANT %q`, srcTenantName))
 
-	pgURL, pgCleanup, err := copyPGCertsAndMakeURL(ctx, t, c, srcNode, dstCluster,
-		srcClusterSetting.PGUrlCertsDir, addr[0])
+	pgURL, err := copyPGCertsAndMakeURL(ctx, t, c, srcNode, srcClusterSetting.PGUrlCertsDir, addr[0])
 	require.NoError(t, err)
 
-	const (
-		tenantHTTPPort = 8081
-		tenantSQLPort  = 30258
-	)
-	t.Status("creating tenant node")
-	srcTenant := createTenantNode(ctx, t, c, srcCluster, srcTenantID, srcTenantNode, tenantHTTPPort, tenantSQLPort)
-	srcTenant.start(ctx, t, c, "./cockroach")
-	cleanup := func() {
-		srcTenant.stop(ctx, t, c)
-		pgCleanup()
-	}
 	srcTenantInfo := clusterInfo{
-		name:    srcTenantName,
-		ID:      srcTenantID,
-		pgURL:   pgURL,
-		tenant:  srcTenant,
-		sql:     srcSQL,
-		db:      srcDB,
-		sqlNode: srcTenantNode,
-		kvNodes: srcCluster}
+		name:  srcTenantName,
+		ID:    srcTenantID,
+		pgURL: pgURL,
+		sql:   srcSQL,
+		db:    srcDB,
+		nodes: srcCluster}
 	destTenantInfo := clusterInfo{
-		name:    destTenantName,
-		ID:      destTenantID,
-		sql:     destSQL,
-		db:      destDB,
-		kvNodes: dstCluster}
+		name:  destTenantName,
+		ID:    destTenantID,
+		sql:   destSQL,
+		db:    destDB,
+		nodes: dstCluster}
 
 	// Currently, a tenant has by default a 10m RU burst limit, which can be
 	// reached during these tests. To prevent RU limit throttling, add 10B RUs to
@@ -270,20 +250,11 @@ func setupC2C(
 	createSystemRole(t, srcTenantInfo.name+" system tenant", srcTenantInfo.sql)
 	createSystemRole(t, destTenantInfo.name+" system tenant", destTenantInfo.sql)
 
-	tenantConn, err := srcTenant.conn()
-	require.NoError(t, err)
-	createSystemRole(t, srcTenantInfo.name+" app tenant", sqlutils.MakeSQLRunner(tenantConn))
-	t.L().Printf(`To open a sql session on the app tenant, ssh to the tenant node and run:
-  ./cockroach sql url="%s"`, srcTenant.secureURL())
-	t.L().Printf(`To open the app tenant's db console, run:
-  1. roachprod adminui $CLUSTER:%d
-  2. change the port in the url to %d
-`, srcTenantNode, tenantHTTPPort)
-
 	return &c2cSetup{
-		src:     srcTenantInfo,
-		dst:     destTenantInfo,
-		metrics: c2cMetrics{}}, cleanup
+		src:          srcTenantInfo,
+		dst:          destTenantInfo,
+		workloadNode: workloadNode,
+		metrics:      c2cMetrics{}}
 }
 
 // createSystemRole creates a role that can be used to log into the cluster's db console
@@ -299,51 +270,52 @@ func createSystemRole(t test.Test, name string, sql *sqlutils.SQLRunner) {
 type streamingWorkload interface {
 	// sourceInitCmd returns a command that will populate the src cluster with data before the
 	// replication stream begins
-	sourceInitCmd(pgURL string) string
+	sourceInitCmd(tenantName string, nodes option.NodeListOption) string
 
 	// sourceRunCmd returns a command that will run a workload
-	sourceRunCmd(pgURL string) string
+	sourceRunCmd(tenantName string, nodes option.NodeListOption) string
 }
 
 type replicateTPCC struct {
 	warehouses int
 }
 
-func (tpcc replicateTPCC) sourceInitCmd(pgURL string) string {
-	return fmt.Sprintf(`./workload init tpcc --data-loader import --warehouses %d '%s'`,
-		tpcc.warehouses, pgURL)
+func (tpcc replicateTPCC) sourceInitCmd(tenantName string, nodes option.NodeListOption) string {
+	return fmt.Sprintf(`./workload init tpcc --data-loader import --warehouses %d {pgurl%s:%s}`,
+		tpcc.warehouses, nodes, tenantName)
 }
 
-func (tpcc replicateTPCC) sourceRunCmd(pgURL string) string {
+func (tpcc replicateTPCC) sourceRunCmd(tenantName string, nodes option.NodeListOption) string {
 	// added --tolerate-errors flags to prevent test from flaking due to a transaction retry error
-	return fmt.Sprintf(`./workload run tpcc --warehouses %d --tolerate-errors '%s'`,
-		tpcc.warehouses, pgURL)
+	return fmt.Sprintf(`./workload run tpcc --warehouses %d --tolerate-errors {pgurl%s:%s}`,
+		tpcc.warehouses, nodes, tenantName)
 }
 
 type replicateKV struct {
 	readPercent int
 }
 
-func (kv replicateKV) sourceInitCmd(pgURL string) string {
+func (kv replicateKV) sourceInitCmd(tenantName string, nodes option.NodeListOption) string {
 	return ""
 }
 
-func (kv replicateKV) sourceRunCmd(pgURL string) string {
+func (kv replicateKV) sourceRunCmd(tenantName string, nodes option.NodeListOption) string {
 	// added --tolerate-errors flags to prevent test from flaking due to a transaction retry error
-	return fmt.Sprintf(`./workload run kv --tolerate-errors --init --read-percent %d '%s'`,
+	return fmt.Sprintf(`./workload run kv --tolerate-errors --init --read-percent %d {pgurl%s:%s}`,
 		kv.readPercent,
-		pgURL)
+		nodes,
+		tenantName)
 }
 
 type replicationTestSpec struct {
 	// name specifies the name of the roachtest
 	name string
 
-	// srcKVNodes is the number of kv nodes on the source cluster.
-	srcKVNodes int
+	// srcodes is the number of nodes on the source cluster.
+	srcNodes int
 
-	// dstKVNodes is the number of kv nodes on the destination cluster.
-	dstKVNodes int
+	// dstNodes is the number of nodes on the destination cluster.
+	dstNodes int
 
 	// cpus is the per node cpu count.
 	cpus int
@@ -367,11 +339,11 @@ type replicationTestSpec struct {
 func registerClusterToCluster(r registry.Registry) {
 	for _, sp := range []replicationTestSpec{
 		{
-			name:       "c2c/tpcc/warehouses=500/duration=10/cutover=5",
-			srcKVNodes: 4,
-			dstKVNodes: 4,
-			cpus:       8,
-			pdSize:     1000,
+			name:     "c2c/tpcc/warehouses=500/duration=10/cutover=5",
+			srcNodes: 4,
+			dstNodes: 4,
+			cpus:     8,
+			pdSize:   1000,
 			// 500 warehouses adds 30 GB to source
 			//
 			// TODO(msbutler): increase default test to 1000 warehouses once fingerprinting
@@ -383,8 +355,8 @@ func registerClusterToCluster(r registry.Registry) {
 		},
 		{
 			name:               "c2c/kv0",
-			srcKVNodes:         3,
-			dstKVNodes:         3,
+			srcNodes:           3,
+			dstNodes:           3,
 			cpus:               8,
 			pdSize:             100,
 			workload:           replicateKV{readPercent: 0},
@@ -403,26 +375,20 @@ func registerClusterToCluster(r registry.Registry) {
 		r.Add(registry.TestSpec{
 			Name:            sp.name,
 			Owner:           registry.OwnerDisasterRecovery,
-			Cluster:         r.MakeClusterSpec(sp.dstKVNodes+sp.srcKVNodes+1, clusterOps...),
+			Cluster:         r.MakeClusterSpec(sp.dstNodes+sp.srcNodes+1, clusterOps...),
 			Timeout:         sp.timeout,
 			RequiresLicense: true,
 			Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
-
-				setup, cleanup := setupC2C(ctx, t, c, sp.srcKVNodes, sp.dstKVNodes)
-				defer cleanup()
-
-				t.L().Printf("tenant secureURL: %s; http port: %s; sql port: %s",
-					setup.src.tenant.secureURL(), setup.src.tenant.httpPort, setup.src.tenant.sqlPort)
-
-				m := c.NewMonitor(ctx, setup.src.kvNodes.Merge(setup.dst.kvNodes))
+				setup := setupC2C(ctx, t, c, sp.srcNodes, sp.dstNodes)
+				m := c.NewMonitor(ctx, setup.src.nodes.Merge(setup.dst.nodes))
 				du, err := NewDiskUsageTracker(c, t.L())
 				require.NoError(t, err)
 				var initDuration time.Duration
-				if initCmd := sp.workload.sourceInitCmd(setup.src.tenant.secureURL()); initCmd != "" {
+				if initCmd := sp.workload.sourceInitCmd(setup.src.name, setup.src.nodes); initCmd != "" {
 					t.Status("populating source cluster before replication")
-					setup.metrics.start = newSizeTime(ctx, du, setup.src.kvNodes)
-					c.Run(ctx, c.Node(setup.src.sqlNode), initCmd)
-					setup.metrics.initialScanEnd = newSizeTime(ctx, du, setup.src.kvNodes)
+					setup.metrics.start = newSizeTime(ctx, du, setup.src.nodes)
+					c.Run(ctx, setup.workloadNode, initCmd)
+					setup.metrics.initialScanEnd = newSizeTime(ctx, du, setup.src.nodes)
 
 					initDuration = setup.metrics.initialScanEnd.time.Sub(setup.metrics.start.time)
 					t.L().Printf("src cluster workload initialization took %s minutes", initDuration)
@@ -434,8 +400,8 @@ func registerClusterToCluster(r registry.Registry) {
 
 				workloadDoneCh := make(chan struct{})
 				m.Go(func(ctx context.Context) error {
-					err := c.RunE(workloadCtx, c.Node(setup.src.sqlNode),
-						sp.workload.sourceRunCmd(setup.src.tenant.secureURL()))
+					err := c.RunE(workloadCtx, setup.workloadNode,
+						sp.workload.sourceRunCmd(setup.src.name, setup.src.nodes))
 					// The workload should only stop if the workloadCtx is cancelled once
 					// sp.additionalDuration has elapsed after the initial scan completes.
 					if workloadCtx.Err() == nil {
@@ -484,9 +450,9 @@ func registerClusterToCluster(r registry.Registry) {
 				}
 				t.Status(fmt.Sprintf("waiting for replication stream to cutover to %s", cutoverTime.String()))
 				retainedTime := getReplicationRetainedTime(t, setup.dst.sql, roachpb.TenantName(setup.dst.name))
-				setup.metrics.cutoverStart = newSizeTime(ctx, du, setup.dst.kvNodes)
+				setup.metrics.cutoverStart = newSizeTime(ctx, du, setup.dst.nodes)
 				stopReplicationStream(t, setup.dst.sql, ingestionJobID, cutoverTime)
-				setup.metrics.cutoverEnd = newSizeTime(ctx, du, setup.dst.kvNodes)
+				setup.metrics.cutoverEnd = newSizeTime(ctx, du, setup.dst.nodes)
 
 				t.Status("comparing fingerprints")
 				compareTenantFingerprintsAtTimestamp(
@@ -668,40 +634,43 @@ func copyPGCertsAndMakeURL(
 	t test.Test,
 	c cluster.Cluster,
 	srcNode option.NodeListOption,
-	destNode option.NodeListOption,
 	pgURLDir string,
 	urlString string,
-) (string, func(), error) {
-	cleanup := func() {}
+) (string, error) {
 	pgURL, err := url.Parse(urlString)
 	if err != nil {
-		return "", cleanup, err
+		return "", err
 	}
 
 	tmpDir, err := os.MkdirTemp("", "certs")
 	if err != nil {
-		return "", cleanup, err
+		return "", err
 	}
-	cleanup = func() { _ = os.RemoveAll(tmpDir) }
+	func() { _ = os.RemoveAll(tmpDir) }()
 
 	if err := c.Get(ctx, t.L(), pgURLDir, tmpDir, srcNode); err != nil {
-		return "", cleanup, err
-	}
-	if err := c.PutE(ctx, t.L(), tmpDir, "./src-cluster-certs", destNode); err != nil {
-		return "", cleanup, err
+		return "", err
 	}
 
-	dir := "."
-	if c.IsLocal() {
-		dir = filepath.Join(local.VMDir(c.Name(), destNode[0]), "src-cluster-certs")
-	} else {
-		dir = "./src-cluster-certs/certs"
+	sslRootCert, err := os.ReadFile(filepath.Join(tmpDir, "ca.crt"))
+	if err != nil {
+		return "", err
 	}
+	sslClientCert, err := os.ReadFile(filepath.Join(tmpDir, "client.root.crt"))
+	if err != nil {
+		return "", err
+	}
+	sslClientKey, err := os.ReadFile(filepath.Join(tmpDir, "client.root.key"))
+	if err != nil {
+		return "", err
+	}
+
 	options := pgURL.Query()
 	options.Set("sslmode", "verify-full")
-	options.Set("sslrootcert", filepath.Join(dir, "ca.crt"))
-	options.Set("sslcert", filepath.Join(dir, "client.root.crt"))
-	options.Set("sslkey", filepath.Join(dir, "client.root.key"))
+	options.Set("sslinline", "true")
+	options.Set("sslrootcert", string(sslRootCert))
+	options.Set("sslcert", string(sslClientCert))
+	options.Set("sslkey", string(sslClientKey))
 	pgURL.RawQuery = options.Encode()
-	return pgURL.String(), cleanup, err
+	return pgURL.String(), nil
 }

--- a/pkg/cmd/roachtest/tests/multitenant_utils.go
+++ b/pkg/cmd/roachtest/tests/multitenant_utils.go
@@ -253,11 +253,6 @@ func (tn *tenantNode) start(ctx context.Context, t test.Test, c cluster.Cluster,
 	t.L().Printf("sql server for tenant %d (instance %d) now running", tn.tenantID, tn.instanceID)
 }
 
-// conn returns a sql connection to the tenant
-func (tn *tenantNode) conn() (*gosql.DB, error) {
-	return gosql.Open("postgres", tn.pgURL)
-}
-
 func startTenantServer(
 	tenantCtx context.Context,
 	c cluster.Cluster,

--- a/pkg/cmd/roachtest/tests/multitenant_utils.go
+++ b/pkg/cmd/roachtest/tests/multitenant_utils.go
@@ -217,7 +217,9 @@ func (tn *tenantNode) start(ctx context.Context, t test.Test, c cluster.Cluster,
 	// pgURL has full paths to local certs embedded, i.e.
 	// /tmp/roachtest-certs3630333874/certs, on the cluster we want just certs
 	// (i.e. to run workload on the tenant).
-	secureUrls, err := roachprod.PgURL(ctx, t.L(), c.MakeNodes(c.Node(tn.node)), "certs", false /*external*/, true /* secure */)
+	secureUrls, err := roachprod.PgURL(ctx, t.L(), c.MakeNodes(c.Node(tn.node)), "certs", roachprod.PGURLOptions{
+		External: false,
+		Secure:   true})
 	require.NoError(t, err)
 	u, err = url.Parse(strings.Trim(secureUrls[0], "'"))
 	require.NoError(t, err)

--- a/pkg/roachprod/install/cluster_synced.go
+++ b/pkg/roachprod/install/cluster_synced.go
@@ -1190,13 +1190,20 @@ func (c *SyncedCluster) DistributeCerts(ctx context.Context, l *logger.Logger) e
 		if c.IsLocal() {
 			cmd = fmt.Sprintf(`cd %s ; `, c.localVMDir(1))
 		}
+		// TODO(ssd): Pre-populating the certs for tenants 1
+		// through 4 helps facilitate UA testing. But we
+		// should do something better here.
 		cmd += fmt.Sprintf(`
 rm -fr certs
 mkdir -p certs
 %[1]s cert create-ca --certs-dir=certs --ca-key=certs/ca.key
-%[1]s cert create-client root --certs-dir=certs --ca-key=certs/ca.key
-%[1]s cert create-client testuser --certs-dir=certs --ca-key=certs/ca.key
+%[1]s cert create-client root --certs-dir=certs --ca-key=certs/ca.key --tenant-scope 1,2,3,4
+%[1]s cert create-client testuser --certs-dir=certs --ca-key=certs/ca.key --tenant-scope 1,2,3,4
 %[1]s cert create-node %[2]s --certs-dir=certs --ca-key=certs/ca.key
+# Pre-create a few tenant-client
+%[1]s cert create-tenant-client 2 %[2]s --certs-dir=certs --ca-key=certs/ca.key
+%[1]s cert create-tenant-client 3 %[2]s --certs-dir=certs --ca-key=certs/ca.key
+%[1]s cert create-tenant-client 4 %[2]s --certs-dir=certs --ca-key=certs/ca.key
 tar cvf %[3]s certs
 `, cockroachNodeBinary(c, 1), strings.Join(nodeNames, " "), certsTarName)
 
@@ -2137,7 +2144,7 @@ func (c *SyncedCluster) Get(l *logger.Logger, nodes Nodes, src, dest string) err
 
 // pgurls returns a map of PG URLs for the given nodes.
 func (c *SyncedCluster) pgurls(
-	ctx context.Context, l *logger.Logger, nodes Nodes,
+	ctx context.Context, l *logger.Logger, nodes Nodes, tenantName string,
 ) (map[Node]string, error) {
 	hosts, err := c.pghosts(ctx, l, nodes)
 	if err != nil {
@@ -2145,7 +2152,7 @@ func (c *SyncedCluster) pgurls(
 	}
 	m := make(map[Node]string, len(hosts))
 	for node, host := range hosts {
-		m[node] = c.NodeURL(host, c.NodePort(node))
+		m[node] = c.NodeURL(host, c.NodePort(node), tenantName)
 	}
 	return m, nil
 }

--- a/pkg/roachprod/install/cockroach.go
+++ b/pkg/roachprod/install/cockroach.go
@@ -255,7 +255,7 @@ func (c *SyncedCluster) CertsDir(node Node) string {
 }
 
 // NodeURL constructs a postgres URL.
-func (c *SyncedCluster) NodeURL(host string, port int) string {
+func (c *SyncedCluster) NodeURL(host string, port int, tenantName string) string {
 	var u url.URL
 	u.User = url.User("root")
 	u.Scheme = "postgres"
@@ -268,6 +268,9 @@ func (c *SyncedCluster) NodeURL(host string, port int) string {
 		v.Add("sslmode", "verify-full")
 	} else {
 		v.Add("sslmode", "disable")
+	}
+	if tenantName != "" {
+		v.Add("options", fmt.Sprintf("-ccluster=%s", tenantName))
 	}
 	u.RawQuery = v.Encode()
 	return "'" + u.String() + "'"
@@ -290,14 +293,16 @@ func (c *SyncedCluster) NodeUIPort(node Node) int {
 //
 // In non-interactive mode, a command specified via the `-e` flag is run against
 // all nodes.
-func (c *SyncedCluster) SQL(ctx context.Context, l *logger.Logger, args []string) error {
+func (c *SyncedCluster) SQL(
+	ctx context.Context, l *logger.Logger, tenantName string, args []string,
+) error {
 	if len(args) == 0 || len(c.Nodes) == 1 {
 		// If no arguments, we're going to get an interactive SQL shell. Require
 		// exactly one target and ask SSH to provide a pseudoterminal.
 		if len(args) == 0 && len(c.Nodes) != 1 {
 			return fmt.Errorf("invalid number of nodes for interactive sql: %d", len(c.Nodes))
 		}
-		url := c.NodeURL("localhost", c.NodePort(c.Nodes[0]))
+		url := c.NodeURL("localhost", c.NodePort(c.Nodes[0]), tenantName)
 		binary := cockroachNodeBinary(c, c.Nodes[0])
 		allArgs := []string{binary, "sql", "--url", url}
 		allArgs = append(allArgs, ssh.Escape(args))
@@ -327,7 +332,7 @@ func (c *SyncedCluster) RunSQL(ctx context.Context, l *logger.Logger, args []str
 			cmd = fmt.Sprintf(`cd %s ; `, c.localVMDir(node))
 		}
 		cmd += cockroachNodeBinary(c, node) + " sql --url " +
-			c.NodeURL("localhost", c.NodePort(node)) + " " +
+			c.NodeURL("localhost", c.NodePort(node), "" /* tenantName */) + " " +
 			ssh.Escape(args)
 
 		sess := c.newSession(l, node, cmd, "run-sql")
@@ -670,7 +675,7 @@ func (c *SyncedCluster) generateClusterSettingCmd(l *logger.Logger, node Node) s
 
 	binary := cockroachNodeBinary(c, node)
 	path := fmt.Sprintf("%s/%s", c.NodeDir(node, 1 /* storeIndex */), "settings-initialized")
-	url := c.NodeURL("localhost", c.NodePort(node))
+	url := c.NodeURL("localhost", c.NodePort(node), "" /* tenantName */)
 
 	// We ignore failures to set remote_debugging.mode, which was
 	// removed in v21.2.
@@ -692,7 +697,7 @@ func (c *SyncedCluster) generateInitCmd(node Node) string {
 	}
 
 	path := fmt.Sprintf("%s/%s", c.NodeDir(node, 1 /* storeIndex */), "cluster-bootstrapped")
-	url := c.NodeURL("localhost", c.NodePort(node))
+	url := c.NodeURL("localhost", c.NodePort(node), "" /* tenantName */)
 	binary := cockroachNodeBinary(c, node)
 	initCmd += fmt.Sprintf(`
 		if ! test -e %[1]s ; then
@@ -786,18 +791,18 @@ func (c *SyncedCluster) createFixedBackupSchedule(
 
 	// Default scheduled backup runs a full backup every hour and an incremental
 	// every 15 minutes.
-	scheduleArgs := `RECURRING '*/15 * * * *' 
-FULL BACKUP '@hourly' 
+	scheduleArgs := `RECURRING '*/15 * * * *'
+FULL BACKUP '@hourly'
 WITH SCHEDULE OPTIONS first_run = 'now'`
 
 	if scheduledBackupArgs != "" {
 		scheduleArgs = scheduledBackupArgs
 	}
 
-	createScheduleCmd := fmt.Sprintf(`-e 
+	createScheduleCmd := fmt.Sprintf(`-e
 CREATE SCHEDULE IF NOT EXISTS test_only_backup FOR BACKUP INTO '%s' %s`,
 		collectionPath, scheduleArgs)
-	return c.SQL(ctx, l, []string{createScheduleCmd})
+	return c.SQL(ctx, l, "" /* tenantName */, []string{createScheduleCmd})
 }
 
 // getEnvVars returns all COCKROACH_* environment variables, in the form


### PR DESCRIPTION
The first two commits modify roachprod and roactest to make it 
a bit easier to use CRDB's new ability to serve multiple tenants from
a single process:

- Adds a --tenant-name flag to the sql and pgurl commands
- Adds the ability to specify a tenant name when using roachprods command templating
- Adds the first 3 secondary tenants (2, 3, 4) to the default certificate setup

Together this allows us to fairly easily rewrite the c2c roachtests to avoid starting a separate 
SQL pod.

Epic: None

Release note: None