### PR TITLE
release-22.1: ui: fix polling for statement and transaction details pages

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetails.fixture.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetails.fixture.ts
@@ -17,6 +17,8 @@ import { StatementDetailsResponse } from "../api";
 
 const history = createMemoryHistory({ initialEntries: ["/statements"] });
 
+const lastUpdated = moment("Nov 28 2022 01:30:00 GMT");
+
 const statementDetailsNoData: StatementDetailsResponse = {
   statement: {
     metadata: {
@@ -777,6 +779,7 @@ export const getStatementDetailsPropsFixture = (
     },
   },
   isLoading: false,
+  lastUpdated: lastUpdated,
   timeScale: {
     windowSize: moment.duration(5, "day"),
     sampleSize: moment.duration(5, "minutes"),

--- a/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetails.selectors.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetails.selectors.ts
@@ -22,7 +22,10 @@ import {
 import { cockroach } from "@cockroachlabs/crdb-protobuf-client";
 import { TimeScale, toRoundedDateRange } from "../timeScaleDropdown";
 import { selectTimeScale } from "../statementsPage/statementsPage.selectors";
-type StatementDetailsResponseMessage = cockroach.server.serverpb.StatementDetailsResponse;
+import moment from "moment";
+
+type StatementDetailsResponseMessage =
+  cockroach.server.serverpb.StatementDetailsResponse;
 
 export const selectStatementDetails = createSelector(
   (_state: AppState, props: RouteComponentProps): string =>
@@ -40,6 +43,7 @@ export const selectStatementDetails = createSelector(
     statementDetails: StatementDetailsResponseMessage;
     isLoading: boolean;
     lastError: Error;
+    lastUpdated: moment.Moment | null;
   } => {
     // Since the aggregation interval is 1h, we want to round the selected timeScale to include
     // the full hour. If a timeScale is between 14:32 - 15:17 we want to search for values
@@ -58,13 +62,19 @@ export const selectStatementDetails = createSelector(
         statementDetails: statementDetailsStatsData[key].data,
         isLoading: statementDetailsStatsData[key].inFlight,
         lastError: statementDetailsStatsData[key].lastError,
+        lastUpdated: statementDetailsStatsData[key].lastUpdated,
       };
     }
-    return { statementDetails: null, isLoading: true, lastError: null };
+    return {
+      statementDetails: null,
+      isLoading: true,
+      lastError: null,
+      lastUpdated: null,
+    };
   },
 );
 
 export const selectStatementDetailsUiConfig = createSelector(
   (state: AppState) => state.adminUI.uiConfig.pages.statementDetails,
-  statementDetailsUiConfig => statementDetailsUiConfig,
+  (statementDetailsUiConfig) => statementDetailsUiConfig,
 );

--- a/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetailsConnected.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetailsConnected.ts
@@ -45,7 +45,8 @@ import { StatementDetailsRequest } from "../api";
 import { TimeScale } from "../timeScaleDropdown";
 import { getMatchParamByName, statementAttr } from "../util";
 type IDuration = google.protobuf.IDuration;
-type IStatementDiagnosticsReport = cockroach.server.serverpb.IStatementDiagnosticsReport;
+type IStatementDiagnosticsReport =
+  cockroach.server.serverpb.IStatementDiagnosticsReport;
 
 const CreateStatementDiagnosticsReportRequest =
   cockroach.server.serverpb.CreateStatementDiagnosticsReportRequest;
@@ -56,10 +57,8 @@ const CancelStatementDiagnosticsReportRequest =
 // For tenant cases, we don't show information about node, regions and
 // diagnostics.
 const mapStateToProps = (state: AppState, props: RouteComponentProps) => {
-  const { statementDetails, isLoading, lastError } = selectStatementDetails(
-    state,
-    props,
-  );
+  const { statementDetails, isLoading, lastError, lastUpdated } =
+    selectStatementDetails(state, props);
   return {
     statementFingerprintID: getMatchParamByName(props.match, statementAttr),
     statementDetails,
@@ -67,6 +66,7 @@ const mapStateToProps = (state: AppState, props: RouteComponentProps) => {
     latestQuery: state.adminUI.sqlDetailsStats.latestQuery,
     latestFormattedQuery: state.adminUI.sqlDetailsStats.latestFormattedQuery,
     statementsError: lastError,
+    lastUpdated: lastUpdated,
     timeScale: selectTimeScale(state),
     nodeNames: selectIsTenant(state) ? {} : nodeDisplayNameByIDSelector(state),
     nodeRegions: selectIsTenant(state) ? {} : nodeRegionsByIDSelector(state),
@@ -129,7 +129,7 @@ const mapDispatchToProps = (
       }),
     );
   },
-  onTabChanged: tabName =>
+  onTabChanged: (tabName) =>
     dispatch(
       analyticsActions.track({
         name: "Tab Changed",

--- a/pkg/ui/workspaces/cluster-ui/src/store/statementDetails/statementDetails.reducer.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/store/statementDetails/statementDetails.reducer.ts
@@ -17,12 +17,14 @@ import {
   StatementDetailsResponseWithKey,
 } from "src/api/statementsApi";
 import { generateStmtDetailsToID } from "../../util";
+import moment from "moment";
 
 export type SQLDetailsStatsState = {
   data: StatementDetailsResponse;
   lastError: Error;
   valid: boolean;
   inFlight: boolean;
+  lastUpdated: moment.Moment | null;
 };
 
 export type SQLDetailsStatsReducerState = {
@@ -52,6 +54,7 @@ const sqlDetailsStatsSlice = createSlice({
         valid: true,
         lastError: null,
         inFlight: false,
+        lastUpdated: moment.utc(),
       };
     },
     failed: (state, action: PayloadAction<ErrorWithKey>) => {
@@ -60,6 +63,7 @@ const sqlDetailsStatsSlice = createSlice({
         valid: false,
         lastError: action.payload.err,
         inFlight: false,
+        lastUpdated: moment.utc(),
       };
     },
     invalidated: (state, action: PayloadAction<{ key: string }>) => {
@@ -85,6 +89,7 @@ const sqlDetailsStatsSlice = createSlice({
         valid: false,
         lastError: null,
         inFlight: true,
+        lastUpdated: null,
       };
     },
     request: (state, action: PayloadAction<StatementDetailsRequest>) => {
@@ -101,6 +106,7 @@ const sqlDetailsStatsSlice = createSlice({
         valid: false,
         lastError: null,
         inFlight: true,
+        lastUpdated: null,
       };
     },
     setLatestQuery: (state, action: PayloadAction<string>) => {

--- a/pkg/ui/workspaces/cluster-ui/src/store/statementDetails/statementDetails.sagas.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/store/statementDetails/statementDetails.sagas.ts
@@ -9,7 +9,7 @@
 // licenses/APL.txt.
 
 import { PayloadAction } from "@reduxjs/toolkit";
-import { all, call, put, delay, takeLatest } from "redux-saga/effects";
+import { all, call, put, takeLatest } from "redux-saga/effects";
 import {
   ErrorWithKey,
   getStatementDetails,
@@ -17,7 +17,6 @@ import {
   StatementDetailsResponseWithKey,
 } from "src/api/statementsApi";
 import { actions as sqlDetailsStatsActions } from "./statementDetails.reducer";
-import { CACHE_INVALIDATION_PERIOD } from "src/store/utils";
 import { generateStmtDetailsToID } from "../../util";
 
 export function* refreshSQLDetailsStatsSaga(
@@ -53,28 +52,9 @@ export function* requestSQLDetailsStatsSaga(
   }
 }
 
-export function receivedSQLDetailsStatsSagaFactory(delayMs: number) {
-  return function* receivedSQLDetailsStatsSaga(
-    action: PayloadAction<StatementDetailsResponseWithKey>,
-  ) {
-    yield delay(delayMs);
-    yield put(
-      sqlDetailsStatsActions.invalidated({
-        key: action?.payload.key,
-      }),
-    );
-  };
-}
-
-export function* sqlDetailsStatsSaga(
-  cacheInvalidationPeriod: number = CACHE_INVALIDATION_PERIOD,
-) {
+export function* sqlDetailsStatsSaga() {
   yield all([
     takeLatest(sqlDetailsStatsActions.refresh, refreshSQLDetailsStatsSaga),
     takeLatest(sqlDetailsStatsActions.request, requestSQLDetailsStatsSaga),
-    takeLatest(
-      sqlDetailsStatsActions.received,
-      receivedSQLDetailsStatsSagaFactory(cacheInvalidationPeriod),
-    ),
   ]);
 }

--- a/pkg/ui/workspaces/cluster-ui/src/transactionDetails/transactionDetailsConnected.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionDetails/transactionDetailsConnected.tsx
@@ -60,6 +60,7 @@ export const selectTransaction = createSelector(
     return {
       isLoading: false,
       transaction: transaction,
+      lastUpdated: transactionState.lastUpdated,
     };
   },
 );
@@ -68,7 +69,10 @@ const mapStateToProps = (
   state: AppState,
   props: TransactionDetailsProps,
 ): TransactionDetailsStateProps => {
-  const { isLoading, transaction } = selectTransaction(state, props);
+  const { isLoading, transaction, lastUpdated } = selectTransaction(
+    state,
+    props,
+  );
   return {
     timeScale: selectTimeScale(state),
     error: selectTransactionsLastError(state),
@@ -81,6 +85,7 @@ const mapStateToProps = (
       txnFingerprintIdAttr,
     ),
     isLoading: isLoading,
+    lastUpdated: lastUpdated,
     hasViewActivityRedactedRole: selectHasViewActivityRedactedRole(state),
   };
 };

--- a/pkg/ui/workspaces/cluster-ui/src/transactionsPage/transactionsPage.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionsPage/transactionsPage.tsx
@@ -185,6 +185,24 @@ export class TransactionsPage extends React.Component<
     };
   };
 
+  clearRefreshDataTimeout(): void {
+    if (this.refreshDataTimeout != null) {
+      clearTimeout(this.refreshDataTimeout);
+    }
+  }
+
+  // Schedule the next data request depending on the time
+  // range key.
+  resetPolling(key: string): void {
+    this.clearRefreshDataTimeout();
+    if (key !== "Custom") {
+      this.refreshDataTimeout = setTimeout(
+        this.refreshData,
+        300000, // 5 minutes
+      );
+    }
+  }
+
   refreshData = (): void => {
     const req = statementsRequestFromProps(this.props);
     this.props.refreshData(req);
@@ -367,27 +385,25 @@ export class TransactionsPage extends React.Component<
     const nodes = isTenant
       ? []
       : Object.keys(nodeRegions)
-          .map(n => Number(n))
+          .map((n) => Number(n))
           .sort();
     const regions = isTenant
       ? []
-      : unique(nodes.map(node => nodeRegions[node.toString()])).sort();
+      : unique(nodes.map((node) => nodeRegions[node.toString()])).sort();
     // We apply the search filters and app name filters prior to aggregating across Node IDs
     // in order to match what's done on the Statements Page.
     //
     // TODO(davidh): Once the redux layer for TransactionsPage is added to this repo,
     // extract this work into the selector
-    const {
-      transactions: filteredTransactions,
-      activeFilters,
-    } = filterTransactions(
-      searchTransactionsData(search, data?.transactions || [], statements),
-      filters,
-      internal_app_name_prefix,
-      statements,
-      nodeRegions,
-      isTenant,
-    );
+    const { transactions: filteredTransactions, activeFilters } =
+      filterTransactions(
+        searchTransactionsData(search, data?.transactions || [], statements),
+        filters,
+        internal_app_name_prefix,
+        statements,
+        nodeRegions,
+        isTenant,
+      );
 
     const appNames = getTrxAppFilterOptions(
       data?.transactions || [],
@@ -419,7 +435,7 @@ export class TransactionsPage extends React.Component<
               appNames={appNames}
               regions={regions}
               timeLabel={"Transaction fingerprint"}
-              nodes={nodes.map(n => "n" + n)}
+              nodes={nodes.map((n) => "n" + n)}
               activeFilters={activeFilters}
               filters={filters}
               showRegions={regions.length > 1}
@@ -447,16 +463,16 @@ export class TransactionsPage extends React.Component<
             error={this.props?.error}
             render={() => {
               const { pagination } = this.state;
-              const transactionsToDisplay: TransactionInfo[] = aggregateAcrossNodeIDs(
-                filteredTransactions,
-                statements,
-              ).map(t => ({
-                stats_data: t.stats_data,
-                node_id: t.node_id,
-                regionNodes: isTenant
-                  ? []
-                  : generateRegionNode(t, statements, nodeRegions),
-              }));
+              const transactionsToDisplay: TransactionInfo[] =
+                aggregateAcrossNodeIDs(filteredTransactions, statements).map(
+                  (t) => ({
+                    stats_data: t.stats_data,
+                    node_id: t.node_id,
+                    regionNodes: isTenant
+                      ? []
+                      : generateRegionNode(t, statements, nodeRegions),
+                  }),
+                );
               const { current, pageSize } = pagination;
               const hasData = data.transactions?.length > 0;
               const isUsedFilter = search?.length > 0;
@@ -470,8 +486,10 @@ export class TransactionsPage extends React.Component<
                 isTenant,
                 search,
               )
-                .filter(c => !(c.name === "regionNodes" && regions.length < 2))
-                .filter(c => !(isTenant && c.hideIfTenant));
+                .filter(
+                  (c) => !(c.name === "regionNodes" && regions.length < 2),
+                )
+                .filter((c) => !(isTenant && c.hideIfTenant));
 
               const isColumnSelected = (
                 c: ColumnDescriptor<TransactionInfo>,
@@ -490,7 +508,7 @@ export class TransactionsPage extends React.Component<
               // values based on stored user selections in local storage and default column configs.
               // Columns that are set to alwaysShow are filtered from the list.
               const tableColumns = columns
-                .filter(c => !c.alwaysShow)
+                .filter((c) => !c.alwaysShow)
                 .map(
                   (c): SelectOption => ({
                     label: getLabel(
@@ -503,7 +521,7 @@ export class TransactionsPage extends React.Component<
                 );
 
               // List of all columns that will be displayed based on the column selection.
-              const displayColumns = columns.filter(c => isColumnSelected(c));
+              const displayColumns = columns.filter((c) => isColumnSelected(c));
 
               const period = timeScaleToString(this.props.timeScale);
 

--- a/pkg/ui/workspaces/db-console/src/redux/apiReducers.ts
+++ b/pkg/ui/workspaces/db-console/src/redux/apiReducers.ts
@@ -340,7 +340,7 @@ export const statementDetailsReducerObj = new KeyedCachedDataReducer(
   api.getStatementDetails,
   statementDetailsActionNamespace,
   statementDetailsRequestToID,
-  moment.duration(5, "m"),
+  null,
   moment.duration(30, "m"),
 );
 

--- a/pkg/ui/workspaces/db-console/src/views/statements/statementDetails.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/statements/statementDetails.tsx
@@ -55,9 +55,10 @@ import {
   statementDetailsLatestFormattedQueryAction,
 } from "src/redux/sqlActivity";
 import { selectTimeScale } from "src/redux/timeScale";
+import moment from "moment";
 
-type IStatementDiagnosticsReport = protos.cockroach.server.serverpb.IStatementDiagnosticsReport;
-
+type IStatementDiagnosticsReport =
+  protos.cockroach.server.serverpb.IStatementDiagnosticsReport;
 const { generateStmtDetailsToID } = util;
 
 export const selectStatementDetails = createSelector(
@@ -76,6 +77,7 @@ export const selectStatementDetails = createSelector(
     statementDetails: StatementDetailsResponseMessage;
     isLoading: boolean;
     lastError: Error;
+    lastUpdated: moment.Moment | null;
   } => {
     // Since the aggregation interval is 1h, we want to round the selected timeScale to include
     // the full hour. If a timeScale is between 14:32 - 15:17 we want to search for values
@@ -94,9 +96,15 @@ export const selectStatementDetails = createSelector(
         statementDetails: statementDetailsStats[key].data,
         isLoading: statementDetailsStats[key].inFlight,
         lastError: statementDetailsStats[key].lastError,
+        lastUpdated: statementDetailsStats[key]?.setAt?.utc(),
       };
     }
-    return { statementDetails: null, isLoading: true, lastError: null };
+    return {
+      statementDetails: null,
+      isLoading: true,
+      lastError: null,
+      lastUpdated: null,
+    };
   },
 );
 
@@ -104,10 +112,8 @@ const mapStateToProps = (
   state: AdminUIState,
   props: RouteComponentProps,
 ): StatementDetailsStateProps => {
-  const { statementDetails, isLoading, lastError } = selectStatementDetails(
-    state,
-    props,
-  );
+  const { statementDetails, isLoading, lastError, lastUpdated } =
+    selectStatementDetails(state, props);
   return {
     statementFingerprintID: getMatchParamByName(props.match, statementAttr),
     statementDetails,
@@ -116,6 +122,7 @@ const mapStateToProps = (
     latestFormattedQuery:
       state.sqlActivity.statementDetailsLatestFormattedQuery,
     statementsError: lastError,
+    lastUpdated: lastUpdated,
     timeScale: selectTimeScale(state),
     nodeNames: nodeDisplayNameByIDSelector(state),
     nodeRegions: nodeRegionsByIDSelector(state),
@@ -145,7 +152,8 @@ const mapDispatchToProps: StatementDetailsDispatchProps = {
     };
   },
   onStatementDetailsQueryChange: statementDetailsLatestQueryAction,
-  onStatementDetailsFormattedQueryChange: statementDetailsLatestFormattedQueryAction,
+  onStatementDetailsFormattedQueryChange:
+    statementDetailsLatestFormattedQueryAction,
   refreshNodes: refreshNodes,
   refreshNodesLiveness: refreshLiveness,
   refreshUserSQLRoles: refreshUserSQLRoles,

--- a/pkg/ui/workspaces/db-console/src/views/transactions/transactionDetails.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/transactions/transactionDetails.tsx
@@ -42,6 +42,7 @@ export const selectTransaction = createSelector(
       return {
         isLoading: true,
         transaction: null,
+        lastUpdated: null,
       };
     }
     const txnFingerprintId = getMatchParamByName(
@@ -57,6 +58,7 @@ export const selectTransaction = createSelector(
     return {
       isLoading: false,
       transaction: transaction,
+      lastUpdated: transactionState?.setAt?.utc(),
     };
   },
 );
@@ -67,7 +69,10 @@ export default withRouter(
       state: AdminUIState,
       props: TransactionDetailsProps,
     ): TransactionDetailsStateProps => {
-      const { isLoading, transaction } = selectTransaction(state, props);
+      const { isLoading, transaction, lastUpdated } = selectTransaction(
+        state,
+        props,
+      );
       return {
         timeScale: selectTimeScale(state),
         error: selectLastError(state),
@@ -80,6 +85,7 @@ export default withRouter(
           txnFingerprintIdAttr,
         ),
         isLoading: isLoading,
+        lastUpdated: lastUpdated,
       };
     },
     {


### PR DESCRIPTION
Backport 1/1 commits from #92596.

/cc @cockroachdb/release

---

This commit moves polling to the statement and transaction details page components from the cached data reducer and sagas, using the same approach as #85772.

Fixes #91297.

Loom (DB Console and CC Console): https://www.loom.com/share/d3002ad54463448aaa3b8c9d74e31d10

Release note (ui change): The statement fingerprint details page in the Console no longer infinitely loads after 5 minutes.
Release justification: bug fix