### PR TITLE
logictest: add a skip_on_retry directive to the sequences test

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/sequences
+++ b/pkg/sql/logictest/testdata/logic_test/sequences
@@ -2085,6 +2085,10 @@ CREATE SEQUENCE seqas_error
 
 subtest sequence_in_transaction
 
+# We're using explicit transactions, so we might hit retries.
+
+skip_on_retry
+
 # create a sequence and nextval in the same transaction
 statement ok
 BEGIN


### PR DESCRIPTION
See [this bors run](https://teamcity.cockroachdb.com/buildConfiguration/Cockroach_BazelEssentialCi/8344646?showRootCauses=false&expandBuildChangesSection=true&expandBuildProblemsSection=true&expandBuildTestsSection=true)

In the long run, this directive is not great, but it's better than flakes.

Epic: none

Release note: None