### PR TITLE
ui: hide filter for databases and database details page

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/databaseDetailsPage/databaseDetailsPage.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/databaseDetailsPage/databaseDetailsPage.tsx
@@ -772,9 +772,13 @@ export class DatabaseDetailsPage extends React.Component<
         ? this.props.sortSettingTables
         : this.props.sortSettingGrants;
 
-    // Only show the filter component when the viewMode is Tables.
+    const showNodes = !isTenant && nodes.length > 1;
+    const showRegions = regions.length > 1;
+
+    // Only show the filter component when the viewMode is Tables and if at
+    // least one of drop-down is shown.
     const filterComponent =
-      this.props.viewMode == ViewMode.Tables ? (
+      this.props.viewMode == ViewMode.Tables && (showNodes || showRegions) ? (
         <PageConfigItem>
           <Filter
             hideAppNames={true}
@@ -784,8 +788,8 @@ export class DatabaseDetailsPage extends React.Component<
             activeFilters={activeFilters}
             filters={defaultFilters}
             onSubmitFilters={this.onSubmitFilters}
-            showNodes={!isTenant && nodes.length > 1}
-            showRegions={regions.length > 1}
+            showNodes={showNodes}
+            showRegions={showRegions}
           />
         </PageConfigItem>
       ) : (

--- a/pkg/ui/workspaces/cluster-ui/src/databasesPage/databasesPage.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/databasesPage/databasesPage.tsx
@@ -603,6 +603,27 @@ export class DatabasesPage extends React.Component<
 
     const regions = unique(Object.values(nodeRegions));
     const showNodes = !isTenant && nodes.length > 1;
+    const showRegions = regions.length > 1;
+
+    // Only show the databases filter if at least one drop-down is shown.
+    const databasesFilter =
+      showNodes || showRegions ? (
+        <PageConfigItem>
+          <Filter
+            hideAppNames={true}
+            regions={regions}
+            hideTimeLabel={true}
+            nodes={nodes.map(n => "n" + n.toString())}
+            activeFilters={activeFilters}
+            filters={defaultFilters}
+            onSubmitFilters={this.onSubmitFilters}
+            showNodes={showNodes}
+            showRegions={showRegions}
+          />
+        </PageConfigItem>
+      ) : (
+        <></>
+      );
 
     return (
       <div>
@@ -640,19 +661,7 @@ export class DatabasesPage extends React.Component<
                 placeholder={"Search Databases"}
               />
             </PageConfigItem>
-            <PageConfigItem>
-              <Filter
-                hideAppNames={true}
-                regions={regions}
-                hideTimeLabel={true}
-                nodes={nodes.map(n => "n" + n.toString())}
-                activeFilters={activeFilters}
-                filters={defaultFilters}
-                onSubmitFilters={this.onSubmitFilters}
-                showNodes={showNodes}
-                showRegions={regions.length > 1}
-              />
-            </PageConfigItem>
+            {databasesFilter}
           </PageConfig>
           <TableStatistics
             pagination={pagination}


### PR DESCRIPTION
Epic: None

Previously, in the databases and database filters page, when the node
and the regions drop-downs were hidden, the filter dropdown was empty
with only the "Apply" button displayed. This was not only misleading,
but was also visually awkward. This commit hides the filter from both
pages entirely if both drop-downs are hidden.

- [Demo](https://www.loom.com/share/6b600fd4a64f4d039946643db07cd5d3) for multi-region, multi-node
- [Demo](https://www.loom.com/share/f028f1831ec74ded9d62b1867cb7970c) for single-region, single-node

Release note (ui change): hide filter for databases and database details
page if both node and regions drop-downs and also hidden.