### PR TITLE
upgrades_test: speed up TestRoleMembersIDMigration1500Users test

### DIFF
--- a/pkg/upgrade/upgrades/role_members_ids_migration_test.go
+++ b/pkg/upgrade/upgrades/role_members_ids_migration_test.go
@@ -94,25 +94,38 @@ func runTestRoleMembersIDMigration(t *testing.T, numUsers int) {
 
 	// Create test users.
 	expectedNumRoleMembersRows := 1
+	tx, err := db.BeginTx(ctx, nil /* opts */)
+	require.NoError(t, err)
+	txRunner := sqlutils.MakeSQLRunner(tx)
 	for i := 0; i < numUsers; i++ {
-		tdb.Exec(t, fmt.Sprintf("CREATE USER testuser%d", i))
+		// Group statements into transactions of 100 users to speed up creation.
+		if i != 0 && i%100 == 0 {
+			err := tx.Commit()
+			require.NoError(t, err)
+			tx, err = db.BeginTx(ctx, nil /* opts */)
+			require.NoError(t, err)
+			txRunner = sqlutils.MakeSQLRunner(tx)
+		}
+		txRunner.Exec(t, fmt.Sprintf("CREATE USER testuser%d", i))
 		if i == 0 {
 			continue
 		}
-		// Randomly choose an earlier testuser to grant to the current testuser.
+		// Randomly choose an earlier test user to grant to the current test user.
 		grantStmt := fmt.Sprintf("GRANT testuser%d to testuser%d", rand.Intn(i), i)
 		if rand.Intn(2) == 1 {
 			grantStmt += " WITH ADMIN OPTION"
 		}
-		tdb.Exec(t, grantStmt)
+		txRunner.Exec(t, grantStmt)
 		expectedNumRoleMembersRows += 1
 	}
+	err = tx.Commit()
+	require.NoError(t, err)
 	tdb.CheckQueryResults(t, "SELECT count(*) FROM system.role_members", [][]string{
 		{fmt.Sprintf("%d", expectedNumRoleMembersRows)},
 	})
 
 	// Run migrations.
-	_, err := tc.Conns[0].ExecContext(ctx, `SET CLUSTER SETTING version = $1`,
+	_, err = tc.Conns[0].ExecContext(ctx, `SET CLUSTER SETTING version = $1`,
 		clusterversion.ByKey(clusterversion.V23_1RoleMembersTableHasIDColumns).String())
 	require.NoError(t, err)
 	_, err = tc.Conns[0].ExecContext(ctx, `SET CLUSTER SETTING version = $1`,


### PR DESCRIPTION
This patch speeds up the TestRoleMembersIDMigration1500Users test by
moving the creation of test users into transactions. On my Mac, this
change reduced the running time from ~55s to ~15s (a 4x speedup).

Fixes #95268

Release note: None