### PR TITLE
kvserver: separate loadstats cpu nanos to raft/req

### DIFF
--- a/pkg/kv/kvserver/allocator/range_usage_info.go
+++ b/pkg/kv/kvserver/allocator/range_usage_info.go
@@ -19,10 +19,12 @@ import (
 // RangeUsageInfo contains usage information (sizes and traffic) needed by the
 // allocator to make rebalancing decisions for a given range.
 type RangeUsageInfo struct {
-	LogicalBytes     int64
-	QueriesPerSecond float64
-	WritesPerSecond  float64
-	RequestLocality  *RangeRequestLocalityInfo
+	LogicalBytes             int64
+	QueriesPerSecond         float64
+	WritesPerSecond          float64
+	RequestCPUNanosPerSecond float64
+	RaftCPUNanosPerSecond    float64
+	RequestLocality          *RangeRequestLocalityInfo
 }
 
 // RangeRequestLocalityInfo is the same as PerLocalityCounts and is used for

--- a/pkg/kv/kvserver/load/replica_load.go
+++ b/pkg/kv/kvserver/load/replica_load.go
@@ -75,8 +75,12 @@ type ReplicaLoadStats struct {
 	// ReadBytesPerSecond is the replica's average bytes read per second. A "Read" is as
 	// described in ReadsPerSecond.
 	ReadBytesPerSecond float64
-	// CPUNanosPerSecond is the range's time spent on-processor averaged per second.
-	CPUNanosPerSecond float64
+	// RaftCPUNanos is the replica's time spent on-processor for raft averaged
+	// per second.
+	RaftCPUNanosPerSecond float64
+	// RequestCPUNanos is the replica's time spent on-processor for requests
+	// averaged per second.
+	RequestCPUNanosPerSecond float64
 }
 
 // ReplicaLoad tracks a sliding window of throughput on a replica.
@@ -188,13 +192,14 @@ func (rl *ReplicaLoad) Stats() ReplicaLoadStats {
 	defer rl.mu.Unlock()
 
 	return ReplicaLoadStats{
-		QueriesPerSecond:    rl.getLocked(Queries),
-		RequestsPerSecond:   rl.getLocked(Requests),
-		WriteKeysPerSecond:  rl.getLocked(WriteKeys),
-		ReadKeysPerSecond:   rl.getLocked(ReadKeys),
-		WriteBytesPerSecond: rl.getLocked(WriteBytes),
-		ReadBytesPerSecond:  rl.getLocked(ReadBytes),
-		CPUNanosPerSecond:   rl.getLocked(RaftCPUNanos) + rl.getLocked(ReqCPUNanos),
+		QueriesPerSecond:         rl.getLocked(Queries),
+		RequestsPerSecond:        rl.getLocked(Requests),
+		WriteKeysPerSecond:       rl.getLocked(WriteKeys),
+		ReadKeysPerSecond:        rl.getLocked(ReadKeys),
+		WriteBytesPerSecond:      rl.getLocked(WriteBytes),
+		ReadBytesPerSecond:       rl.getLocked(ReadBytes),
+		RequestCPUNanosPerSecond: rl.getLocked(ReqCPUNanos),
+		RaftCPUNanosPerSecond:    rl.getLocked(RaftCPUNanos),
 	}
 }
 

--- a/pkg/kv/kvserver/replicate_queue.go
+++ b/pkg/kv/kvserver/replicate_queue.go
@@ -2105,9 +2105,11 @@ func RangeUsageInfoForRepl(repl *Replica) allocator.RangeUsageInfo {
 	loadStats := repl.LoadStats()
 	localityInfo := repl.loadStats.RequestLocalityInfo()
 	return allocator.RangeUsageInfo{
-		LogicalBytes:     repl.GetMVCCStats().Total(),
-		QueriesPerSecond: loadStats.QueriesPerSecond,
-		WritesPerSecond:  loadStats.WriteKeysPerSecond,
+		LogicalBytes:             repl.GetMVCCStats().Total(),
+		QueriesPerSecond:         loadStats.QueriesPerSecond,
+		WritesPerSecond:          loadStats.WriteKeysPerSecond,
+		RaftCPUNanosPerSecond:    loadStats.RaftCPUNanosPerSecond,
+		RequestCPUNanosPerSecond: loadStats.RequestCPUNanosPerSecond,
 		RequestLocality: &allocator.RangeRequestLocalityInfo{
 			Counts:   localityInfo.LocalityCounts,
 			Duration: localityInfo.Duration,

--- a/pkg/kv/kvserver/store.go
+++ b/pkg/kv/kvserver/store.go
@@ -3155,7 +3155,7 @@ func (s *Store) updateReplicationGauges(ctx context.Context) error {
 		averageReadsPerSecond += loadStats.ReadKeysPerSecond
 		averageReadBytesPerSecond += loadStats.ReadBytesPerSecond
 		averageWriteBytesPerSecond += loadStats.WriteBytesPerSecond
-		averageCPUNanosPerSecond += loadStats.CPUNanosPerSecond
+		averageCPUNanosPerSecond += loadStats.RaftCPUNanosPerSecond + loadStats.RequestCPUNanosPerSecond
 
 		locks += metrics.LockTableMetrics.Locks
 		totalLockHoldDurationNanos += metrics.LockTableMetrics.TotalLockHoldDurationNanos


### PR DESCRIPTION
Previously, loadstats tracked replica raft/request cpu nanos per second separately but returned both summed together in `load.ReplicaLoadStats`. This patch separates `RaftCPUNanosPerSecond` and
`RequestCPUNanosPerSecond` in the returned `load.ReplicaLoadStats` so that they may be used independently.

Informs #95380

Release note: None