### PR TITLE
kvserver,server: add more load stats to hot ranges v2 api

### DIFF
--- a/docs/generated/http/full.md
+++ b/docs/generated/http/full.md
@@ -1329,6 +1329,7 @@ only.
 | reads_per_second | [double](#cockroach.server.serverpb.RaftDebugResponse-double) |  | Reads per second served is the number of keys read from this range per second, averaged over the last 30 minute period. | [reserved](#support-status) |
 | write_bytes_per_second | [double](#cockroach.server.serverpb.RaftDebugResponse-double) |  | Writes (bytes) per second is the number of bytes written to this range per second, averaged over the last 30 minute period. | [reserved](#support-status) |
 | read_bytes_per_second | [double](#cockroach.server.serverpb.RaftDebugResponse-double) |  | Reads (bytes) per second is the number of bytes read from this range per second, averaged over the last 30 minute period. | [reserved](#support-status) |
+| cpu_time_per_second | [double](#cockroach.server.serverpb.RaftDebugResponse-double) |  | CPU time (ns) per second is the cpu usage of this range per second, averaged over the last 30 minute period. | [reserved](#support-status) |
 
 
 
@@ -1575,6 +1576,7 @@ only.
 | reads_per_second | [double](#cockroach.server.serverpb.RangesResponse-double) |  | Reads per second served is the number of keys read from this range per second, averaged over the last 30 minute period. | [reserved](#support-status) |
 | write_bytes_per_second | [double](#cockroach.server.serverpb.RangesResponse-double) |  | Writes (bytes) per second is the number of bytes written to this range per second, averaged over the last 30 minute period. | [reserved](#support-status) |
 | read_bytes_per_second | [double](#cockroach.server.serverpb.RangesResponse-double) |  | Reads (bytes) per second is the number of bytes read from this range per second, averaged over the last 30 minute period. | [reserved](#support-status) |
+| cpu_time_per_second | [double](#cockroach.server.serverpb.RangesResponse-double) |  | CPU time (ns) per second is the cpu usage of this range per second, averaged over the last 30 minute period. | [reserved](#support-status) |
 
 
 
@@ -1784,6 +1786,7 @@ only.
 | reads_per_second | [double](#cockroach.server.serverpb.TenantRangesResponse-double) |  | Reads per second served is the number of keys read from this range per second, averaged over the last 30 minute period. | [reserved](#support-status) |
 | write_bytes_per_second | [double](#cockroach.server.serverpb.TenantRangesResponse-double) |  | Writes (bytes) per second is the number of bytes written to this range per second, averaged over the last 30 minute period. | [reserved](#support-status) |
 | read_bytes_per_second | [double](#cockroach.server.serverpb.TenantRangesResponse-double) |  | Reads (bytes) per second is the number of bytes read from this range per second, averaged over the last 30 minute period. | [reserved](#support-status) |
+| cpu_time_per_second | [double](#cockroach.server.serverpb.TenantRangesResponse-double) |  | CPU time (ns) per second is the cpu usage of this range per second, averaged over the last 30 minute period. | [reserved](#support-status) |
 
 
 
@@ -3495,6 +3498,7 @@ target node(s) selected in a HotRangesRequest.
 | reads_per_second | [double](#cockroach.server.serverpb.HotRangesResponse-double) |  | Reads per second is the recent number of keys read per second on this range. | [reserved](#support-status) |
 | write_bytes_per_second | [double](#cockroach.server.serverpb.HotRangesResponse-double) |  | Write bytes per second is the recent number of bytes written per second on this range. | [reserved](#support-status) |
 | read_bytes_per_second | [double](#cockroach.server.serverpb.HotRangesResponse-double) |  | Read bytes per second is the recent number of bytes read per second on this range. | [reserved](#support-status) |
+| cpu_time_per_second | [double](#cockroach.server.serverpb.HotRangesResponse-double) |  | CPU time per second is the recent cpu usage in nanoseconds of this range. | [reserved](#support-status) |
 
 
 
@@ -3795,6 +3799,7 @@ only.
 | reads_per_second | [double](#cockroach.server.serverpb.RangeResponse-double) |  | Reads per second served is the number of keys read from this range per second, averaged over the last 30 minute period. | [reserved](#support-status) |
 | write_bytes_per_second | [double](#cockroach.server.serverpb.RangeResponse-double) |  | Writes (bytes) per second is the number of bytes written to this range per second, averaged over the last 30 minute period. | [reserved](#support-status) |
 | read_bytes_per_second | [double](#cockroach.server.serverpb.RangeResponse-double) |  | Reads (bytes) per second is the number of bytes read from this range per second, averaged over the last 30 minute period. | [reserved](#support-status) |
+| cpu_time_per_second | [double](#cockroach.server.serverpb.RangeResponse-double) |  | CPU time (ns) per second is the cpu usage of this range per second, averaged over the last 30 minute period. | [reserved](#support-status) |
 
 
 

--- a/docs/generated/http/full.md
+++ b/docs/generated/http/full.md
@@ -3571,6 +3571,11 @@ HotRange message describes a single hot range, ie its QPS, node ID it belongs to
 | leaseholder_node_id | [int32](#cockroach.server.serverpb.HotRangesResponseV2-int32) |  | leaseholder_node_id indicates the Node ID that is the current leaseholder for the given range. | [reserved](#support-status) |
 | schema_name | [string](#cockroach.server.serverpb.HotRangesResponseV2-string) |  | schema_name provides the name of schema (if exists) for table in current range. | [reserved](#support-status) |
 | store_id | [int32](#cockroach.server.serverpb.HotRangesResponseV2-int32) |  | store_id indicates the Store ID where range is stored. | [reserved](#support-status) |
+| writes_per_second | [double](#cockroach.server.serverpb.HotRangesResponseV2-double) |  | writes_per_second is the recent number of keys written per second on this range. | [reserved](#support-status) |
+| reads_per_second | [double](#cockroach.server.serverpb.HotRangesResponseV2-double) |  | reads_per_second is the recent number of keys read per second on this range. | [reserved](#support-status) |
+| write_bytes_per_second | [double](#cockroach.server.serverpb.HotRangesResponseV2-double) |  | write_bytes_per_second is the recent number of bytes written per second on this range. | [reserved](#support-status) |
+| read_bytes_per_second | [double](#cockroach.server.serverpb.HotRangesResponseV2-double) |  | read_bytes_per_second is the recent number of bytes read per second on this range. | [reserved](#support-status) |
+| cpu_time_per_second | [double](#cockroach.server.serverpb.HotRangesResponseV2-double) |  | CPU time (ns) per second is the recent cpu usage per second on this range. | [reserved](#support-status) |
 
 
 

--- a/docs/generated/http/hotranges-other.md
+++ b/docs/generated/http/hotranges-other.md
@@ -68,5 +68,6 @@ Support status: [alpha](#support-status)
 | reads_per_second | [double](#double) |  | Reads per second is the recent number of keys read per second on this range. | [reserved](#support-status) |
 | write_bytes_per_second | [double](#double) |  | Write bytes per second is the recent number of bytes written per second on this range. | [reserved](#support-status) |
 | read_bytes_per_second | [double](#double) |  | Read bytes per second is the recent number of bytes read per second on this range. | [reserved](#support-status) |
+| cpu_time_per_second | [double](#double) |  | CPU time per second is the recent cpu usage in nanoseconds of this range. | [reserved](#support-status) |
 
 

--- a/docs/generated/swagger/spec.json
+++ b/docs/generated/swagger/spec.json
@@ -2104,6 +2104,31 @@
           "format": "double",
           "x-go-name": "QPS"
         },
+        "writes_per_second": {
+          "type": "number",
+          "format": "double",
+          "x-go-name": "WritesPerSecond"
+        },
+        "reads_per_second": {
+          "type": "number",
+          "format": "double",
+          "x-go-name": "ReadsPerSecond"
+        },
+        "write_bytes_per_second": {
+          "type": "number",
+          "format": "double",
+          "x-go-name": "WriteBytesPerSecond"
+        },
+        "read_bytes_per_second": {
+          "type": "number",
+          "format": "double",
+          "x-go-name": "ReadBytesPerSecond"
+        },
+        "cpu_time_per_second": {
+          "type": "number",
+          "format": "double",
+          "x-go-name": "CPUTimePerSecond"
+        },
         "range_id": {
           "$ref": "#/definitions/RangeID"
         },

--- a/pkg/kv/kvserver/store.go
+++ b/pkg/kv/kvserver/store.go
@@ -3032,7 +3032,7 @@ type HotReplicaInfo struct {
 	WriteKeysPerSecond  float64
 	WriteBytesPerSecond float64
 	ReadBytesPerSecond  float64
-	CPUNanosPerSecond   float64
+	CPUTimePerSecond    float64
 }
 
 // HottestReplicas returns the hottest replicas on a store, sorted by their
@@ -3064,6 +3064,7 @@ func mapToHotReplicasInfo(repls []CandidateReplica) []HotReplicaInfo {
 		hotRepls[i].ReadKeysPerSecond = loadStats.ReadKeysPerSecond
 		hotRepls[i].WriteBytesPerSecond = loadStats.WriteBytesPerSecond
 		hotRepls[i].ReadBytesPerSecond = loadStats.ReadBytesPerSecond
+		hotRepls[i].CPUTimePerSecond = loadStats.RaftCPUNanosPerSecond + loadStats.RequestCPUNanosPerSecond
 	}
 	return hotRepls
 }

--- a/pkg/server/api_v2_ranges.go
+++ b/pkg/server/api_v2_ranges.go
@@ -440,16 +440,21 @@ type hotRangesResponse struct {
 //
 // swagger:model hotRangeInfo
 type hotRangeInfo struct {
-	RangeID           roachpb.RangeID  `json:"range_id"`
-	NodeID            roachpb.NodeID   `json:"node_id"`
-	QPS               float64          `json:"qps"`
-	LeaseholderNodeID roachpb.NodeID   `json:"leaseholder_node_id"`
-	TableName         string           `json:"table_name"`
-	DatabaseName      string           `json:"database_name"`
-	IndexName         string           `json:"index_name"`
-	SchemaName        string           `json:"schema_name"`
-	ReplicaNodeIDs    []roachpb.NodeID `json:"replica_node_ids"`
-	StoreID           roachpb.StoreID  `json:"store_id"`
+	RangeID             roachpb.RangeID  `json:"range_id"`
+	NodeID              roachpb.NodeID   `json:"node_id"`
+	QPS                 float64          `json:"qps"`
+	WritesPerSecond     float64          `json:"writes_per_second"`
+	ReadsPerSecond      float64          `json:"reads_per_second"`
+	WriteBytesPerSecond float64          `json:"write_bytes_per_second"`
+	ReadBytesPerSecond  float64          `json:"read_bytes_per_second"`
+	CPUTimePerSecond    float64          `json:"cpu_time_per_second"`
+	LeaseholderNodeID   roachpb.NodeID   `json:"leaseholder_node_id"`
+	TableName           string           `json:"table_name"`
+	DatabaseName        string           `json:"database_name"`
+	IndexName           string           `json:"index_name"`
+	SchemaName          string           `json:"schema_name"`
+	ReplicaNodeIDs      []roachpb.NodeID `json:"replica_node_ids"`
+	StoreID             roachpb.StoreID  `json:"store_id"`
 }
 
 // swagger:operation GET /ranges/hot/ listHotRanges
@@ -522,16 +527,21 @@ func (a *apiV2Server) listHotRanges(w http.ResponseWriter, r *http.Request) {
 		var hotRangeInfos = make([]hotRangeInfo, len(resp.Ranges))
 		for i, r := range resp.Ranges {
 			hotRangeInfos[i] = hotRangeInfo{
-				RangeID:           r.RangeID,
-				NodeID:            r.NodeID,
-				QPS:               r.QPS,
-				LeaseholderNodeID: r.LeaseholderNodeID,
-				TableName:         r.TableName,
-				DatabaseName:      r.DatabaseName,
-				IndexName:         r.IndexName,
-				ReplicaNodeIDs:    r.ReplicaNodeIds,
-				SchemaName:        r.SchemaName,
-				StoreID:           r.StoreID,
+				RangeID:             r.RangeID,
+				NodeID:              r.NodeID,
+				QPS:                 r.QPS,
+				WritesPerSecond:     r.WritesPerSecond,
+				ReadsPerSecond:      r.ReadsPerSecond,
+				WriteBytesPerSecond: r.WriteBytesPerSecond,
+				ReadBytesPerSecond:  r.ReadBytesPerSecond,
+				CPUTimePerSecond:    r.CPUTimePerSecond,
+				LeaseholderNodeID:   r.LeaseholderNodeID,
+				TableName:           r.TableName,
+				DatabaseName:        r.DatabaseName,
+				IndexName:           r.IndexName,
+				ReplicaNodeIDs:      r.ReplicaNodeIds,
+				SchemaName:          r.SchemaName,
+				StoreID:             r.StoreID,
 			}
 		}
 		return hotRangeInfos, nil

--- a/pkg/server/serverpb/status.proto
+++ b/pkg/server/serverpb/status.proto
@@ -1437,6 +1437,21 @@ message HotRangesResponseV2 {
       (gogoproto.casttype) =
         "github.com/cockroachdb/cockroach/pkg/roachpb.StoreID"
     ];
+    // writes_per_second is the recent number of keys written per second on
+    // this range.
+    double writes_per_second = 11;
+    // reads_per_second is the recent number of keys read per second on
+    // this range.
+    double reads_per_second = 12;
+    // write_bytes_per_second is the recent number of bytes written per second
+    // on this range.
+    double write_bytes_per_second = 13;
+    // read_bytes_per_second is the recent number of bytes read per second on
+    // this range.
+    double read_bytes_per_second = 14;
+    // CPU time (ns) per second is the recent cpu usage per second on this
+    // range.
+    double cpu_time_per_second = 15 [(gogoproto.customname) = "CPUTimePerSecond"];
   }
   // Ranges contain list of hot ranges info that has highest number of QPS.
   repeated HotRange ranges = 1;

--- a/pkg/server/serverpb/status.proto
+++ b/pkg/server/serverpb/status.proto
@@ -414,6 +414,9 @@ message RangeStatistics {
   // Reads (bytes) per second is the number of bytes read from this range per
   // second, averaged over the last 30 minute period.
   double read_bytes_per_second = 6;
+  // CPU time (ns) per second is the cpu usage of this range per second,
+  // averaged over the last 30 minute period.
+  double cpu_time_per_second = 7 [(gogoproto.customname) = "CPUTimePerSecond"];
 }
 
 message PrettySpan {
@@ -1340,6 +1343,8 @@ message HotRangesResponse {
     // Read bytes per second is the recent number of bytes read per second on
     // this range.
     double read_bytes_per_second = 8;
+    // CPU time per second is the recent cpu usage in nanoseconds of this range.
+    double cpu_time_per_second = 9 [(gogoproto.customname) = "CPUTimePerSecond"];
   }
 
   // StoreResponse contains the part of a hot ranges report that

--- a/pkg/server/status.go
+++ b/pkg/server/status.go
@@ -2585,16 +2585,21 @@ func (s *systemStatusServer) HotRangesV2(
 					}
 
 					ranges = append(ranges, &serverpb.HotRangesResponseV2_HotRange{
-						RangeID:           r.Desc.RangeID,
-						NodeID:            requestedNodeID,
-						QPS:               r.QueriesPerSecond,
-						TableName:         tableName,
-						SchemaName:        schemaName,
-						DatabaseName:      dbName,
-						IndexName:         indexName,
-						ReplicaNodeIds:    replicaNodeIDs,
-						LeaseholderNodeID: r.LeaseholderNodeID,
-						StoreID:           store.StoreID,
+						RangeID:             r.Desc.RangeID,
+						NodeID:              requestedNodeID,
+						QPS:                 r.QueriesPerSecond,
+						WritesPerSecond:     r.WritesPerSecond,
+						ReadsPerSecond:      r.ReadsPerSecond,
+						WriteBytesPerSecond: r.WriteBytesPerSecond,
+						ReadBytesPerSecond:  r.ReadBytesPerSecond,
+						CPUTimePerSecond:    r.CPUTimePerSecond,
+						TableName:           tableName,
+						SchemaName:          schemaName,
+						DatabaseName:        dbName,
+						IndexName:           indexName,
+						ReplicaNodeIds:      replicaNodeIDs,
+						LeaseholderNodeID:   r.LeaseholderNodeID,
+						StoreID:             store.StoreID,
 					})
 				}
 			}

--- a/pkg/server/status.go
+++ b/pkg/server/status.go
@@ -2143,6 +2143,7 @@ func (s *systemStatusServer) rangesHelper(
 				ReadsPerSecond:      loadStats.ReadKeysPerSecond,
 				WriteBytesPerSecond: loadStats.WriteKeysPerSecond,
 				ReadBytesPerSecond:  loadStats.ReadBytesPerSecond,
+				CPUTimePerSecond:    loadStats.RaftCPUNanosPerSecond + loadStats.RequestCPUNanosPerSecond,
 			},
 			Problems: serverpb.RangeProblems{
 				Unavailable:            metrics.Unavailable,
@@ -2687,6 +2688,7 @@ func (s *systemStatusServer) localHotRanges(
 			storeResp.HotRanges[i].ReadsPerSecond = r.ReadKeysPerSecond
 			storeResp.HotRanges[i].WriteBytesPerSecond = r.WriteBytesPerSecond
 			storeResp.HotRanges[i].ReadBytesPerSecond = r.ReadBytesPerSecond
+			storeResp.HotRanges[i].CPUTimePerSecond = r.CPUTimePerSecond
 		}
 		resp.Stores = append(resp.Stores, storeResp)
 		return nil

--- a/pkg/server/status_test.go
+++ b/pkg/server/status_test.go
@@ -1054,6 +1054,16 @@ func TestHotRangesResponse(t *testing.T) {
 				if r.Desc.RangeID == 0 || (len(r.Desc.StartKey) == 0 && len(r.Desc.EndKey) == 0) {
 					t.Errorf("unexpected empty/unpopulated range descriptor: %+v", r.Desc)
 				}
+				if r.QueriesPerSecond > 0 {
+					if r.ReadsPerSecond == 0 && r.WritesPerSecond == 0 {
+						t.Errorf("qps %.2f > 0, expected either reads=%.2f or writes=%.2f to be non-zero",
+							r.QueriesPerSecond, r.ReadsPerSecond, r.WritesPerSecond)
+					}
+					if r.CPUTimePerSecond == 0 {
+						t.Errorf("qps %.2f > 0, expected cpu=%.2f to be non-zero",
+							r.QueriesPerSecond, r.CPUTimePerSecond)
+					}
+				}
 				if r.QueriesPerSecond > lastQPS {
 					t.Errorf("unexpected increase in qps between ranges; prev=%.2f, current=%.2f, desc=%v",
 						lastQPS, r.QueriesPerSecond, r.Desc)

--- a/pkg/server/status_test.go
+++ b/pkg/server/status_test.go
@@ -1093,6 +1093,15 @@ func TestHotRanges2Response(t *testing.T) {
 		if r.RangeID == 0 {
 			t.Errorf("unexpected empty range id: %d", r.RangeID)
 		}
+		if r.QPS > 0 {
+			if r.ReadsPerSecond == 0 && r.WritesPerSecond == 0 {
+				t.Errorf("qps %.2f > 0, expected either reads=%.2f or writes=%.2f to be non-zero",
+					r.QPS, r.ReadsPerSecond, r.WritesPerSecond)
+			}
+			if r.CPUTimePerSecond == 0 {
+				t.Errorf("qps %.2f > 0, expected cpu=%.2f to be non-zero", r.QPS, r.CPUTimePerSecond)
+			}
+		}
 		if r.QPS > lastQPS {
 			t.Errorf("unexpected increase in qps between ranges; prev=%.2f, current=%.2f", lastQPS, r.QPS)
 		}


### PR DESCRIPTION
This PR adds CPU as a hotranges v1 and range statistic field. Then the stats that are included in the v1 hot ranges (including cpu) but not v2 are added to the hot ranges v2 api.

```
WritesPerSecond
ReadsPerSecond
WriteBytesPerSecond
ReadBytesPerSecond
CPUTimePerSecond
```

See the associated comments in `status.proto` for a description of each
load statistic.

These may be used to determine the hottest ranges. Note however that
these are sorted by default by QPS. The ordering of ranges w.r.t the new
load statistics has no guarantees. Likewise, ranges may be omitted which
have high relative values for the new load statistics but relatively low
QPS. In practice however, there usually exists a strong correlation that
ensures that such ranges would not be omitted entirely.

resolves: https://github.com/cockroachdb/cockroach/issues/95383
resolves: https://github.com/cockroachdb/cockroach/issues/95384

Release note: None