### PR TITLE
sql/catalog/schemaexpr: fix bug when new column default has different…

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/alter_table
+++ b/pkg/sql/logictest/testdata/logic_test/alter_table
@@ -2751,3 +2751,22 @@ SELECT count(*) from t_with_dropped_index_expr;
 
 statement ok
 RESUME JOB (SELECT job_id FROM crdb_internal.jobs WHERE description LIKE 'ALTER TABLE %t_with_dropped_index_expr DROP COLUMN j CASCADE%' AND status='paused' FETCH FIRST 1 ROWS ONLY);
+
+
+# In 23.1 we added support for default expressions which can be assignment cast
+# to the column type. This work introduced a bug whereby the backfill logic
+# would not apply the appropriate cast. This test ensures that such tables can
+# be backfilled.
+subtest add_column_with_default_expression_with_different_type
+
+statement ok
+CREATE TABLE t_93398 (c1 INT);
+INSERT INTO t_93398 VALUES (0);
+
+statement ok
+ALTER TABLE t_93398 ADD COLUMN c2 DECIMAL DEFAULT pi();
+
+query IT
+SELECT * FROM t_93398;
+----
+0  3.141592653589793


### PR DESCRIPTION
… type

Since 22.2 we permit default expressions to contain types which are not exactly the same as the column type; it is valid to have an expression which can be cast to the column type in an assignment context. Generally, the optimizer handles inserting the assignment cast into the execution of the relevant mutations. Unfortunately, the cast was not present for backfills.

This PR detects the situation where a cast is needed and insert it directly into the plan of the backfill (or import).

Epic: None

Fixes: #93398

Release note (bug fix): Since 22.2, default expressions can have a type which differs from the type of the column so long as the expression's type can be cast in an assignment context. Unfortunately, this code had a bug when adding new columns. The code in the backfill logic was not sophisticated enough to know to add the cast; when such a default expression was added to a new column it would result in a panic during the backfill. This bug has now been fixed.