### PR TITLE
loqrecovery,admin,cli: check staged plans, stage recovery plan on cluster

### DIFF
--- a/docs/generated/http/full.md
+++ b/docs/generated/http/full.md
@@ -7535,7 +7535,7 @@ Support status: [reserved](#support-status)
 | Field | Type | Label | Description | Support status |
 | ----- | ---- | ----- | ----------- | -------------- |
 | statuses | [cockroach.kv.kvserver.loqrecovery.loqrecoverypb.NodeRecoveryStatus](#cockroach.server.serverpb.RecoveryVerifyResponse-cockroach.kv.kvserver.loqrecovery.loqrecoverypb.NodeRecoveryStatus) | repeated | Statuses contain a list of recovery statuses of nodes updated during recovery. It also contains nodes that were expected to be live (not decommissioned by recovery) but failed to return status response. | [reserved](#support-status) |
-| unavailable_ranges | [cockroach.roachpb.RangeDescriptor](#cockroach.server.serverpb.RecoveryVerifyResponse-cockroach.roachpb.RangeDescriptor) | repeated | Unavailable ranges contains descriptors of ranges that failed health checks. | [reserved](#support-status) |
+| unavailable_ranges | [cockroach.roachpb.RangeDescriptor](#cockroach.server.serverpb.RecoveryVerifyResponse-cockroach.roachpb.RangeDescriptor) | repeated | UnavailableRanges contains descriptors of ranges that failed health checks. | [reserved](#support-status) |
 | decommissioned_node_ids | [int32](#cockroach.server.serverpb.RecoveryVerifyResponse-int32) | repeated | DecommissionedNodeIDs contains list of decommissioned node id's. Only nodes that were decommissioned by the plan would be listed here, not all historically decommissioned ones. | [reserved](#support-status) |
 
 

--- a/pkg/kv/kvserver/loqrecovery/BUILD.bazel
+++ b/pkg/kv/kvserver/loqrecovery/BUILD.bazel
@@ -69,6 +69,7 @@ go_test(
         "//pkg/kv/kvserver/raftlog",
         "//pkg/kv/kvserver/stateloader",
         "//pkg/roachpb",
+        "//pkg/rpc",
         "//pkg/security/securityassets",
         "//pkg/security/securitytest",
         "//pkg/server",

--- a/pkg/kv/kvserver/loqrecovery/BUILD.bazel
+++ b/pkg/kv/kvserver/loqrecovery/BUILD.bazel
@@ -90,7 +90,6 @@ go_test(
         "@com_github_cockroachdb_datadriven//:datadriven",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_cockroachdb_pebble//vfs",
-        "@com_github_google_uuid//:uuid",
         "@com_github_stretchr_testify//require",
         "@in_gopkg_yaml_v2//:yaml_v2",
         "@io_etcd_go_raft_v3//raftpb",

--- a/pkg/kv/kvserver/loqrecovery/loqrecoverypb/recovery.proto
+++ b/pkg/kv/kvserver/loqrecovery/loqrecoverypb/recovery.proto
@@ -147,20 +147,23 @@ message ReplicaRecoveryRecord {
 // NodeRecoveryStatus contains information about loss of quorum recovery
 // operations of a node.
 message NodeRecoveryStatus {
+  // NodeID contains id of the node that status belongs to.
+  int32 node_id = 1 [(gogoproto.customname) = "NodeID",
+    (gogoproto.casttype) = "github.com/cockroachdb/cockroach/pkg/roachpb.NodeID"];
   // PendingPlanID contains an ID or recovery plan that is staged on the node for
   // application on the next restart.
-  bytes pending_plan_id = 1 [
+  bytes pending_plan_id = 2 [
     (gogoproto.customname) = "PendingPlanID",
     (gogoproto.customtype) = "github.com/cockroachdb/cockroach/pkg/util/uuid.UUID"];
   // AppliedPlanID contains an ID of recovery plan that was processed last.
   // If plan application succeeded, then ApplyError will be nil, otherwise it will
   // contain an error message.
-  bytes applied_plan_id = 2 [
+  bytes applied_plan_id = 3 [
     (gogoproto.customname) = "AppliedPlanID",
     (gogoproto.customtype) = "github.com/cockroachdb/cockroach/pkg/util/uuid.UUID"];
   // LastProcessingTime is a node wall clock time when last recovery plan was applied.
-  google.protobuf.Timestamp apply_timestamp = 3 [(gogoproto.stdtime) = true];
+  google.protobuf.Timestamp apply_timestamp = 4 [(gogoproto.stdtime) = true];
   // If most recent recovery plan application failed, Error will contain
   // aggregated error messages containing all encountered errors.
-  string error = 4;
+  string error = 5;
 }

--- a/pkg/kv/kvserver/loqrecovery/server.go
+++ b/pkg/kv/kvserver/loqrecovery/server.go
@@ -12,6 +12,7 @@ package loqrecovery
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"time"
 
@@ -52,10 +53,13 @@ type visitNodesFn func(ctx context.Context, retryOpts retry.Options,
 ) error
 
 type Server struct {
-	nodeIDContainer      *base.NodeIDContainer
-	stores               *kvserver.Stores
-	visitNodes           visitNodesFn
-	planStore            PlanStore
+	nodeIDContainer    *base.NodeIDContainer
+	clusterIDContainer *base.ClusterIDContainer
+	stores             *kvserver.Stores
+	visitNodes         visitNodesFn
+	planStore          PlanStore
+	decommissionFn     func(context.Context, roachpb.NodeID) error
+
 	metadataQueryTimeout time.Duration
 	forwardReplicaFilter func(*serverpb.RecoveryCollectLocalReplicaInfoResponse) error
 }
@@ -68,6 +72,7 @@ func NewServer(
 	loc roachpb.Locality,
 	rpcCtx *rpc.Context,
 	knobs base.ModuleTestingKnobs,
+	decommission func(context.Context, roachpb.NodeID) error,
 ) *Server {
 	// Server side timeouts are necessary in recovery collector since we do best
 	// effort operations where cluster info collection as an operation succeeds
@@ -82,9 +87,11 @@ func NewServer(
 	}
 	return &Server{
 		nodeIDContainer:      nodeIDContainer,
+		clusterIDContainer:   rpcCtx.StorageClusterID,
 		stores:               stores,
 		visitNodes:           makeVisitAvailableNodes(g, loc, rpcCtx),
 		planStore:            planStore,
+		decommissionFn:       decommission,
 		metadataQueryTimeout: metadataQueryTimeout,
 		forwardReplicaFilter: forwardReplicaFilter,
 	}
@@ -209,6 +216,142 @@ func (s Server) ServeClusterReplicas(
 			nodes++
 			return nil
 		})
+}
+
+func (s Server) StagePlan(
+	ctx context.Context, req *serverpb.RecoveryStagePlanRequest,
+) (*serverpb.RecoveryStagePlanResponse, error) {
+	if !req.ForcePlan && req.Plan == nil {
+		return nil, errors.New("stage plan request can't be used with empty plan without force flag")
+	}
+	clusterID := s.clusterIDContainer.Get().String()
+	if req.Plan != nil && req.Plan.ClusterID != clusterID {
+		return nil, errors.Newf("attempting to stage plan from cluster %s on cluster %s",
+			req.Plan.ClusterID, clusterID)
+	}
+
+	localNodeID := s.nodeIDContainer.Get()
+	// Create a plan copy with all empty fields to shortcut all plan nil checks
+	// below to avoid unnecessary nil checks.
+	var plan loqrecoverypb.ReplicaUpdatePlan
+	if req.Plan != nil {
+		plan = *req.Plan
+	}
+	if req.AllNodes {
+		// Scan cluster for conflicting recovery plans and for stray nodes that are
+		// planned for forced decommission, but rejoined cluster.
+		foundNodes := make(map[roachpb.NodeID]struct{})
+		err := s.visitNodes(
+			ctx,
+			replicaInfoStreamRetryOptions,
+			func(nodeID roachpb.NodeID, client serverpb.AdminClient) error {
+				res, err := client.RecoveryNodeStatus(ctx, &serverpb.RecoveryNodeStatusRequest{})
+				if err != nil {
+					return errors.Mark(err, errMarkRetry)
+				}
+				// If operation fails here, we don't want to find all remaining
+				// violating nodes because cli must ensure that cluster is safe for
+				// staging.
+				if !req.ForcePlan && res.Status.PendingPlanID != nil && !res.Status.PendingPlanID.Equal(plan.PlanID) {
+					return errors.Newf("plan %s is already staged on node n%d", res.Status.PendingPlanID, nodeID)
+				}
+				foundNodes[nodeID] = struct{}{}
+				return nil
+			})
+		if err != nil {
+			return nil, err
+		}
+
+		// Check that no nodes that must be decommissioned are present.
+		for _, dID := range plan.DecommissionedNodeIDs {
+			if _, ok := foundNodes[dID]; ok {
+				return nil, errors.Newf("node n%d was planned for decommission, but is present in cluster", dID)
+			}
+		}
+
+		// Check out that all nodes that should save plan are present.
+		for _, u := range plan.Updates {
+			if _, ok := foundNodes[u.NodeID()]; !ok {
+				return nil, errors.Newf("node n%d has planned changed but is unreachable in the cluster", u.NodeID())
+			}
+		}
+
+		// Distribute plan - this should not use fan out to available, but use
+		// list from previous step.
+		var nodeErrors []string
+		err = s.visitNodes(
+			ctx,
+			replicaInfoStreamRetryOptions,
+			func(nodeID roachpb.NodeID, client serverpb.AdminClient) error {
+				delete(foundNodes, nodeID)
+				res, err := client.RecoveryStagePlan(ctx, &serverpb.RecoveryStagePlanRequest{
+					Plan:      req.Plan,
+					AllNodes:  false,
+					ForcePlan: req.ForcePlan,
+				})
+				if err != nil {
+					nodeErrors = append(nodeErrors,
+						errors.Wrapf(err, "failed staging the plan on node n%d", nodeID).Error())
+					return nil
+				}
+				nodeErrors = append(nodeErrors, res.Errors...)
+				return nil
+			})
+		if err != nil {
+			nodeErrors = append(nodeErrors,
+				errors.Wrapf(err, "failed to perform fan-out to cluster nodes from n%d",
+					localNodeID).Error())
+		}
+		if len(foundNodes) > 0 {
+			// We didn't talk to some of originally found nodes. Need to report
+			// disappeared nodes as we don't know what is happening with the cluster.
+			for n := range foundNodes {
+				nodeErrors = append(nodeErrors, fmt.Sprintf("node n%d disappeared while performing plan staging operation", n))
+			}
+		}
+		return &serverpb.RecoveryStagePlanResponse{Errors: nodeErrors}, nil
+	}
+
+	log.Infof(ctx, "attempting to stage loss of quorum recovery plan")
+
+	responseFromError := func(err error) (*serverpb.RecoveryStagePlanResponse, error) {
+		return &serverpb.RecoveryStagePlanResponse{
+			Errors: []string{
+				errors.Wrapf(err, "failed to stage plan on node n%d", localNodeID).Error(),
+			},
+		}, nil
+	}
+
+	existingPlan, exists, err := s.planStore.LoadPlan()
+	if err != nil {
+		return responseFromError(err)
+	}
+	if exists && !existingPlan.PlanID.Equal(plan.PlanID) && !req.ForcePlan {
+		return responseFromError(errors.Newf("conflicting plan %s is already staged", existingPlan.PlanID))
+	}
+
+	for _, node := range plan.DecommissionedNodeIDs {
+		if err := s.decommissionFn(ctx, node); err != nil {
+			return responseFromError(err)
+		}
+	}
+
+	if req.ForcePlan {
+		if err := s.planStore.RemovePlan(); err != nil {
+			return responseFromError(err)
+		}
+	}
+
+	for _, r := range plan.Updates {
+		if r.NodeID() == localNodeID {
+			if err := s.planStore.SavePlan(plan); err != nil {
+				return responseFromError(err)
+			}
+			break
+		}
+	}
+
+	return &serverpb.RecoveryStagePlanResponse{}, nil
 }
 
 func (s Server) NodeStatus(

--- a/pkg/kv/kvserver/loqrecovery/server.go
+++ b/pkg/kv/kvserver/loqrecovery/server.go
@@ -29,6 +29,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 	"github.com/cockroachdb/cockroach/pkg/util/retry"
+	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 	"github.com/cockroachdb/errors"
 )
 
@@ -51,6 +52,7 @@ type visitNodesFn func(ctx context.Context, retryOpts retry.Options,
 ) error
 
 type Server struct {
+	nodeIDContainer      *base.NodeIDContainer
 	stores               *kvserver.Stores
 	visitNodes           visitNodesFn
 	planStore            PlanStore
@@ -59,6 +61,7 @@ type Server struct {
 }
 
 func NewServer(
+	nodeIDContainer *base.NodeIDContainer,
 	stores *kvserver.Stores,
 	planStore PlanStore,
 	g *gossip.Gossip,
@@ -78,6 +81,7 @@ func NewServer(
 		forwardReplicaFilter = rk.ForwardReplicaFilter
 	}
 	return &Server{
+		nodeIDContainer:      nodeIDContainer,
 		stores:               stores,
 		visitNodes:           makeVisitAvailableNodes(g, loc, rpcCtx),
 		planStore:            planStore,
@@ -205,6 +209,50 @@ func (s Server) ServeClusterReplicas(
 			nodes++
 			return nil
 		})
+}
+
+func (s Server) NodeStatus(
+	_ context.Context, _ *serverpb.RecoveryNodeStatusRequest,
+) (*serverpb.RecoveryNodeStatusResponse, error) {
+	// TODO: report full status.
+	plan, exists, err := s.planStore.LoadPlan()
+	if err != nil {
+		return nil, err
+	}
+	var planID *uuid.UUID
+	if exists {
+		planID = &plan.PlanID
+	}
+	return &serverpb.RecoveryNodeStatusResponse{
+		Status: loqrecoverypb.NodeRecoveryStatus{
+			NodeID:        s.nodeIDContainer.Get(),
+			PendingPlanID: planID,
+		},
+	}, nil
+}
+
+func (s Server) Verify(
+	ctx context.Context, request *serverpb.RecoveryVerifyRequest,
+) (*serverpb.RecoveryVerifyResponse, error) {
+	var nss []loqrecoverypb.NodeRecoveryStatus
+	err := s.visitNodes(ctx, replicaInfoStreamRetryOptions,
+		func(nodeID roachpb.NodeID, client serverpb.AdminClient) error {
+			res, err := client.RecoveryNodeStatus(ctx, &serverpb.RecoveryNodeStatusRequest{})
+			if err != nil {
+				return errors.Mark(errors.Wrapf(err, "failed to retrieve status of n%d", nodeID), errMarkRetry)
+			}
+			nss = append(nss, res.Status)
+			return nil
+		})
+	if err != nil {
+		return nil, err
+	}
+
+	// TODO: retrieve status of requested nodes (for decommission check)
+	// TODO: retrieve unavailable ranges report
+	return &serverpb.RecoveryVerifyResponse{
+		Statuses: nss,
+	}, nil
 }
 
 func makeVisitAvailableNodes(

--- a/pkg/kv/kvserver/loqrecovery/server_test.go
+++ b/pkg/kv/kvserver/loqrecovery/server_test.go
@@ -12,6 +12,7 @@ package loqrecovery_test
 
 import (
 	"context"
+	"fmt"
 	"strconv"
 	"sync/atomic"
 	"testing"
@@ -21,6 +22,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/loqrecovery"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/loqrecovery/loqrecoverypb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/rpc"
 	"github.com/cockroachdb/cockroach/pkg/server"
 	"github.com/cockroachdb/cockroach/pkg/server/serverpb"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
@@ -96,8 +98,6 @@ func TestReplicaCollection(t *testing.T) {
 	assertReplicas(2, true)
 	tc.StopServer(1)
 	assertReplicas(1, false)
-
-	tc.Stopper().Stop(ctx)
 }
 
 // TestStreamRestart verifies that if connection is dropped mid way through
@@ -161,8 +161,6 @@ func TestStreamRestart(t *testing.T) {
 	}
 
 	assertReplicas(3)
-
-	tc.Stopper().Stop(ctx)
 }
 
 func getInfoCounters(info loqrecoverypb.ClusterReplicaInfo) clusterInfoCounters {
@@ -190,32 +188,9 @@ func TestGetRecoveryState(t *testing.T) {
 
 	ctx := context.Background()
 
-	reg := server.NewStickyInMemEnginesRegistry()
+	tc, reg, planStores := prepTestCluster(t)
 	defer reg.CloseAllStickyInMemEngines()
-
-	args := base.TestClusterArgs{
-		ServerArgsPerNode: make(map[int]base.TestServerArgs),
-	}
-	for i := 0; i < 3; i++ {
-		args.ServerArgsPerNode[i] = base.TestServerArgs{
-			Knobs: base.TestingKnobs{
-				Server: &server.TestingKnobs{
-					StickyEngineRegistry: reg,
-				},
-			},
-			StoreSpecs: []base.StoreSpec{
-				{
-					InMemory:               true,
-					StickyInMemoryEngineID: strconv.FormatInt(int64(i), 10),
-				},
-			},
-		}
-	}
-	tc := testcluster.NewTestCluster(t, 3, args)
-	tc.Start(t)
 	defer tc.Stopper().Stop(ctx)
-
-	planStores := prepInMemPlanStores(t, args.ServerArgsPerNode)
 
 	adm, err := tc.GetAdminClient(ctx, t, 0)
 	require.NoError(t, err, "failed to get admin client")
@@ -227,9 +202,7 @@ func TestGetRecoveryState(t *testing.T) {
 	}
 
 	// Injecting plan into 2 nodes out of 3.
-	plan := loqrecoverypb.ReplicaUpdatePlan{
-		PlanID: uuid.MakeV4(),
-	}
+	plan := makeTestRecoveryPlan(ctx, t, adm)
 	for i := 0; i < 2; i++ {
 		require.NoError(t, planStores[i].SavePlan(plan), "failed to save plan on node n%d", i)
 	}
@@ -238,9 +211,9 @@ func TestGetRecoveryState(t *testing.T) {
 	resp, err = adm.RecoveryVerify(ctx, &serverpb.RecoveryVerifyRequest{})
 	require.NoError(t, err)
 	statuses := aggregateStatusByNode(resp)
-	require.Equal(t, &plan.PlanID, statuses[1].PendingPlanID, "incorrect plan id on node 0")
-	require.Equal(t, &plan.PlanID, statuses[2].PendingPlanID, "incorrect plan id on node 1")
-	require.Nil(t, statuses[3].PendingPlanID, "unexpected plan id on node 2")
+	require.Equal(t, &plan.PlanID, statuses[1].PendingPlanID, "incorrect plan id on node 1")
+	require.Equal(t, &plan.PlanID, statuses[2].PendingPlanID, "incorrect plan id on node 2")
+	require.Nil(t, statuses[3].PendingPlanID, "unexpected plan id on node 3")
 
 	// Check we can collect partial results.
 	tc.StopServer(1)
@@ -271,6 +244,236 @@ func aggregateStatusByNode(
 	return statuses
 }
 
+func TestStageRecoveryPlans(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+
+	tc, reg, _ := prepTestCluster(t)
+	defer reg.CloseAllStickyInMemEngines()
+	defer tc.Stopper().Stop(ctx)
+
+	adm, err := tc.GetAdminClient(ctx, t, 0)
+	require.NoError(t, err, "failed to get admin client")
+
+	resp, err := adm.RecoveryVerify(ctx, &serverpb.RecoveryVerifyRequest{})
+	require.NoError(t, err)
+	for _, s := range resp.Statuses {
+		require.Nil(t, s.PendingPlanID, "no pending plan")
+	}
+
+	sk := tc.ScratchRange(t)
+
+	// Stage plan with update for node 3 using node 0 and check which nodes
+	// saved plan.
+	plan := makeTestRecoveryPlan(ctx, t, adm)
+	plan.Updates = []loqrecoverypb.ReplicaUpdate{
+		createRecoveryForRange(t, tc, sk, 3),
+	}
+	res, err := adm.RecoveryStagePlan(ctx, &serverpb.RecoveryStagePlanRequest{Plan: &plan, AllNodes: true})
+	require.NoError(t, err, "failed to stage plan")
+	require.Empty(t, res.Errors, "unexpected errors in stage response")
+
+	// First we test that plans are successfully picked up by status call.
+	resp, err = adm.RecoveryVerify(ctx, &serverpb.RecoveryVerifyRequest{})
+	require.NoError(t, err)
+	statuses := aggregateStatusByNode(resp)
+	require.Nil(t, statuses[1].PendingPlanID, "unexpected plan id on node 1")
+	require.Nil(t, statuses[2].PendingPlanID, "unexpected plan id on node 2")
+	require.Equal(t, &plan.PlanID, statuses[3].PendingPlanID, "incorrect plan id on node 3")
+}
+
+func TestStageConflictingPlans(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+
+	tc, reg, _ := prepTestCluster(t)
+	defer reg.CloseAllStickyInMemEngines()
+	defer tc.Stopper().Stop(ctx)
+
+	adm, err := tc.GetAdminClient(ctx, t, 0)
+	require.NoError(t, err, "failed to get admin client")
+
+	resp, err := adm.RecoveryVerify(ctx, &serverpb.RecoveryVerifyRequest{})
+	require.NoError(t, err)
+	for _, s := range resp.Statuses {
+		require.Nil(t, s.PendingPlanID, "no pending plan")
+	}
+
+	sk := tc.ScratchRange(t)
+
+	// Stage first plan.
+	plan := makeTestRecoveryPlan(ctx, t, adm)
+	plan.Updates = []loqrecoverypb.ReplicaUpdate{
+		createRecoveryForRange(t, tc, sk, 3),
+	}
+	res, err := adm.RecoveryStagePlan(ctx, &serverpb.RecoveryStagePlanRequest{Plan: &plan, AllNodes: true})
+	require.NoError(t, err, "failed to stage plan")
+	require.Empty(t, res.Errors, "unexpected errors in stage response")
+
+	plan2 := makeTestRecoveryPlan(ctx, t, adm)
+	plan2.Updates = []loqrecoverypb.ReplicaUpdate{
+		createRecoveryForRange(t, tc, sk, 2),
+	}
+	_, err = adm.RecoveryStagePlan(ctx, &serverpb.RecoveryStagePlanRequest{Plan: &plan2, AllNodes: true})
+	require.ErrorContains(t, err,
+		fmt.Sprintf("plan %s is already staged on node n3", plan.PlanID.String()),
+		"conflicting plans must not be allowed")
+}
+
+func TestForcePlanUpdate(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+
+	tc, reg, _ := prepTestCluster(t)
+	defer reg.CloseAllStickyInMemEngines()
+	defer tc.Stopper().Stop(ctx)
+
+	adm, err := tc.GetAdminClient(ctx, t, 0)
+	require.NoError(t, err, "failed to get admin client")
+
+	resV, err := adm.RecoveryVerify(ctx, &serverpb.RecoveryVerifyRequest{})
+	require.NoError(t, err)
+	for _, s := range resV.Statuses {
+		require.Nil(t, s.PendingPlanID, "no pending plan")
+	}
+
+	sk := tc.ScratchRange(t)
+
+	// Stage first plan.
+	plan := makeTestRecoveryPlan(ctx, t, adm)
+	plan.Updates = []loqrecoverypb.ReplicaUpdate{
+		createRecoveryForRange(t, tc, sk, 3),
+	}
+	resS, err := adm.RecoveryStagePlan(ctx, &serverpb.RecoveryStagePlanRequest{Plan: &plan, AllNodes: true})
+	require.NoError(t, err, "failed to stage plan")
+	require.Empty(t, resS.Errors, "unexpected errors in stage response")
+
+	_, err = adm.RecoveryStagePlan(ctx, &serverpb.RecoveryStagePlanRequest{AllNodes: true, ForcePlan: true})
+	require.NoError(t, err, "force plan should reset previous plans")
+
+	// Verify that plan was successfully replaced by an empty one.
+	resV, err = adm.RecoveryVerify(ctx, &serverpb.RecoveryVerifyRequest{})
+	require.NoError(t, err)
+	statuses := aggregateStatusByNode(resV)
+	require.Nil(t, statuses[1].PendingPlanID, "unexpected plan id on node 1")
+	require.Nil(t, statuses[2].PendingPlanID, "unexpected plan id on node 2")
+	require.Nil(t, statuses[3].PendingPlanID, "unexpected plan id on node 3")
+}
+
+func TestNodeDecommissioned(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+
+	tc, reg, _ := prepTestCluster(t)
+	defer reg.CloseAllStickyInMemEngines()
+	defer tc.Stopper().Stop(ctx)
+
+	adm, err := tc.GetAdminClient(ctx, t, 0)
+	require.NoError(t, err, "failed to get admin client")
+
+	tc.StopServer(2)
+
+	plan := makeTestRecoveryPlan(ctx, t, adm)
+	plan.DecommissionedNodeIDs = []roachpb.NodeID{roachpb.NodeID(3)}
+	res, err := adm.RecoveryStagePlan(ctx,
+		&serverpb.RecoveryStagePlanRequest{Plan: &plan, AllNodes: true})
+	require.NoError(t, err, "failed to stage plan")
+	require.Empty(t, res.Errors, "unexpected errors in stage response")
+
+	require.ErrorContains(t, tc.Server(0).RPCContext().OnOutgoingPing(ctx, &rpc.PingRequest{TargetNodeID: 3}),
+		"permanently removed from the cluster", "ping of decommissioned node should fail")
+}
+
+func TestRejectDecommissionReachableNode(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+
+	tc, reg, _ := prepTestCluster(t)
+	defer reg.CloseAllStickyInMemEngines()
+	defer tc.Stopper().Stop(ctx)
+
+	adm, err := tc.GetAdminClient(ctx, t, 0)
+	require.NoError(t, err, "failed to get admin client")
+
+	plan := makeTestRecoveryPlan(ctx, t, adm)
+	plan.DecommissionedNodeIDs = []roachpb.NodeID{roachpb.NodeID(3)}
+	_, err = adm.RecoveryStagePlan(ctx,
+		&serverpb.RecoveryStagePlanRequest{Plan: &plan, AllNodes: true})
+	require.ErrorContains(t, err, "was planned for decommission, but is present in cluster",
+		"staging plan decommissioning live nodes must not be allowed")
+}
+
+func TestStageRecoveryPlansToWrongCluster(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+
+	tc, reg, _ := prepTestCluster(t)
+	defer reg.CloseAllStickyInMemEngines()
+	defer tc.Stopper().Stop(ctx)
+
+	adm, err := tc.GetAdminClient(ctx, t, 0)
+	require.NoError(t, err, "failed to get admin client")
+
+	resp, err := adm.RecoveryVerify(ctx, &serverpb.RecoveryVerifyRequest{})
+	require.NoError(t, err)
+	for _, s := range resp.Statuses {
+		require.Nil(t, s.PendingPlanID, "no pending plan")
+	}
+
+	sk := tc.ScratchRange(t)
+
+	fakeClusterID, _ := uuid.NewV4()
+	// Stage plan with id of different cluster and see if error is raised.
+	plan := makeTestRecoveryPlan(ctx, t, adm)
+	plan.ClusterID = fakeClusterID.String()
+	plan.Updates = []loqrecoverypb.ReplicaUpdate{
+		createRecoveryForRange(t, tc, sk, 3),
+	}
+	_, err = adm.RecoveryStagePlan(ctx, &serverpb.RecoveryStagePlanRequest{Plan: &plan, AllNodes: true})
+	require.ErrorContains(t, err, "attempting to stage plan from cluster", "failed to stage plan")
+}
+
+func prepTestCluster(
+	t *testing.T,
+) (*testcluster.TestCluster, server.StickyInMemEnginesRegistry, map[int]loqrecovery.PlanStore) {
+	reg := server.NewStickyInMemEnginesRegistry()
+
+	const nodes = 3
+	args := base.TestClusterArgs{
+		ServerArgsPerNode: make(map[int]base.TestServerArgs),
+	}
+	for i := 0; i < nodes; i++ {
+		args.ServerArgsPerNode[i] = base.TestServerArgs{
+			Knobs: base.TestingKnobs{
+				Server: &server.TestingKnobs{
+					StickyEngineRegistry: reg,
+				},
+			},
+			StoreSpecs: []base.StoreSpec{
+				{
+					InMemory:               true,
+					StickyInMemoryEngineID: strconv.FormatInt(int64(i), 10),
+				},
+			},
+		}
+	}
+	tc := testcluster.NewTestCluster(t, nodes, args)
+	tc.Start(t)
+	return tc, reg, prepInMemPlanStores(t, args.ServerArgsPerNode)
+}
+
 func prepInMemPlanStores(
 	t *testing.T, serverArgs map[int]base.TestServerArgs,
 ) map[int]loqrecovery.PlanStore {
@@ -282,4 +485,33 @@ func prepInMemPlanStores(
 		pss[id] = loqrecovery.NewPlanStore(".", store)
 	}
 	return pss
+}
+
+func createRecoveryForRange(
+	t *testing.T, tc *testcluster.TestCluster, key roachpb.Key, storeID int,
+) loqrecoverypb.ReplicaUpdate {
+	rngD, err := tc.LookupRange(key)
+	require.NoError(t, err, "can't find range for key %s", key)
+	replD, ok := rngD.GetReplicaDescriptor(roachpb.StoreID(storeID))
+	require.True(t, ok, "expecting scratch replica on node 3")
+	replD.ReplicaID += 10
+	return loqrecoverypb.ReplicaUpdate{
+		RangeID:       rngD.RangeID,
+		StartKey:      loqrecoverypb.RecoveryKey(rngD.StartKey),
+		OldReplicaID:  replD.ReplicaID,
+		NewReplica:    replD,
+		NextReplicaID: replD.ReplicaID + 1,
+	}
+}
+
+func makeTestRecoveryPlan(
+	ctx context.Context, t *testing.T, ac serverpb.AdminClient,
+) loqrecoverypb.ReplicaUpdatePlan {
+	t.Helper()
+	cr, err := ac.Cluster(ctx, &serverpb.ClusterRequest{})
+	require.NoError(t, err, "failed to read cluster it")
+	return loqrecoverypb.ReplicaUpdatePlan{
+		PlanID:    uuid.MakeV4(),
+		ClusterID: cr.ClusterID,
+	}
 }

--- a/pkg/server/admin.go
+++ b/pkg/server/admin.go
@@ -3265,13 +3265,25 @@ func (s *systemAdminServer) RecoveryStagePlan(
 func (s *systemAdminServer) RecoveryNodeStatus(
 	ctx context.Context, request *serverpb.RecoveryNodeStatusRequest,
 ) (*serverpb.RecoveryNodeStatusResponse, error) {
-	return nil, errors.AssertionFailedf("To be implemented by #93043")
+	ctx = s.server.AnnotateCtx(ctx)
+	_, err := s.requireAdminUser(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.server.recoveryServer.NodeStatus(ctx, request)
 }
 
 func (s *systemAdminServer) RecoveryVerify(
 	ctx context.Context, request *serverpb.RecoveryVerifyRequest,
 ) (*serverpb.RecoveryVerifyResponse, error) {
-	return nil, errors.AssertionFailedf("To be implemented by #93043")
+	ctx = s.server.AnnotateCtx(ctx)
+	_, err := s.requireAdminUser(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.server.recoveryServer.Verify(ctx, request)
 }
 
 // sqlQuery allows you to incrementally build a SQL query that uses

--- a/pkg/server/admin.go
+++ b/pkg/server/admin.go
@@ -3259,7 +3259,14 @@ func (s *systemAdminServer) RecoveryCollectLocalReplicaInfo(
 func (s *systemAdminServer) RecoveryStagePlan(
 	ctx context.Context, request *serverpb.RecoveryStagePlanRequest,
 ) (*serverpb.RecoveryStagePlanResponse, error) {
-	return nil, errors.AssertionFailedf("To be implemented by #93044")
+	ctx = s.server.AnnotateCtx(ctx)
+	_, err := s.requireAdminUser(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	log.Ops.Info(ctx, "staging recovery plan")
+	return s.server.recoveryServer.StagePlan(ctx, request)
 }
 
 func (s *systemAdminServer) RecoveryNodeStatus(

--- a/pkg/server/loss_of_quorum.go
+++ b/pkg/server/loss_of_quorum.go
@@ -32,7 +32,7 @@ func newPlanStore(cfg Config) (loqrecovery.PlanStore, error) {
 	fs := vfs.Default
 	path := spec.Path
 	if spec.InMemory {
-		path = "."
+		path = ""
 		if spec.StickyInMemoryEngineID != "" {
 			if cfg.TestingKnobs.Server == nil {
 				return loqrecovery.PlanStore{}, errors.AssertionFailedf("Could not create a sticky " +

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -1038,7 +1038,15 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to create loss of quorum recovery server")
 	}
-	recoveryServer := loqrecovery.NewServer(stores, planStore, g, cfg.Locality, rpcContext, cfg.TestingKnobs.LOQRecovery)
+	recoveryServer := loqrecovery.NewServer(
+		nodeIDContainer,
+		stores,
+		planStore,
+		g,
+		cfg.Locality,
+		rpcContext,
+		cfg.TestingKnobs.LOQRecovery,
+	)
 
 	*lateBoundServer = Server{
 		nodeIDContainer:        nodeIDContainer,

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -1046,6 +1046,9 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 		cfg.Locality,
 		rpcContext,
 		cfg.TestingKnobs.LOQRecovery,
+		func(ctx context.Context, id roachpb.NodeID) error {
+			return nodeTombStorage.SetDecommissioned(ctx, id, timeutil.Now())
+		},
 	)
 
 	*lateBoundServer = Server{

--- a/pkg/server/serverpb/admin.proto
+++ b/pkg/server/serverpb/admin.proto
@@ -952,7 +952,8 @@ message RecoveryNodeStatusRequest {
 }
 
 message RecoveryNodeStatusResponse {
-  cockroach.kv.kvserver.loqrecovery.loqrecoverypb.NodeRecoveryStatus status = 1;
+  cockroach.kv.kvserver.loqrecovery.loqrecoverypb.NodeRecoveryStatus status = 1 [
+    (gogoproto.nullable) = false];
 }
 
 message RecoveryVerifyRequest {
@@ -970,10 +971,11 @@ message RecoveryVerifyResponse {
   // Statuses contain a list of recovery statuses of nodes updated during recovery. It
   // also contains nodes that were expected to be live (not decommissioned by recovery)
   // but failed to return status response.
-  repeated cockroach.kv.kvserver.loqrecovery.loqrecoverypb.NodeRecoveryStatus statuses = 1;
-  // Unavailable ranges contains descriptors of ranges that failed health checks.
+  repeated cockroach.kv.kvserver.loqrecovery.loqrecoverypb.NodeRecoveryStatus statuses = 1 [
+    (gogoproto.nullable) = false];
+  // UnavailableRanges contains descriptors of ranges that failed health checks.
   repeated roachpb.RangeDescriptor unavailable_ranges = 2 [
-    (gogoproto.customname) = "UnavailableRanges"];
+    (gogoproto.nullable) = false];
   // DecommissionedNodeIDs contains list of decommissioned node id's. Only nodes that
   // were decommissioned by the plan would be listed here, not all historically
   // decommissioned ones.


### PR DESCRIPTION
loqrecovery,admin,cli: stage recovery plan on cluster

This commit adds loss of quorum recovery plan staging on nodes.
RecoveryStagePlan admin call is distributing recovery plan to
relevant nodes of the cluster. To do so, it first verifies that
cluster state is unchanged from the state where plan was created
and there are no previously staged plans.
Then it distributes plan to all cluster nodes using fan-out mechanism.
Each node in turn markes dead nodes as decommissioned and if there
are planned changes for the node it saves plan in the local store.
Admin call is backed by debug recover apply-plan command when using
--host flag to work in half-online mode.

Release note: None

----

loqrecovery,admin: implement endpoint to check staged plans

This commit adds loss of quorum recovery verify call to admin
interface. Call allows querying loss of quorum recovery status
from all nodes of the cluster. It provides info about loss of
quorum recovery plans staged on each node.

Release note: None

----

State checkpoint is included in the PR as it only provide partial functionality of state needed for stage phase to work.

Fixes #93044
Fixes #74135
Touches #93043

When doing staging, cli would present following reports in happy case:
```
$ cockroach debug recover apply-plan  --host=127.0.0.1:26257 --insecure=true recover-plan.json
Proposed changes in plan 66200d2c-e0e1-4af4-b890-ef5bb6e9ccc4:
  range r93:/Table/106/1/"boston"/"333333D\x00\x80\x00\x00\x00\x00\x00\x00\n" updating replica 2 to 16.
  range r92:/Table/106/1/"los angeles"/"\x99\x99\x99\x99\x99\x99H\x00\x80\x00\x00\x00\x00\x00\x00\x1e" updating replica 2 to 16.
  range r91:/Table/106/1/"seattle"/"ffffffH\x00\x80\x00\x00\x00\x00\x00\x00\x14" updating replica 2 to 16.
  range r115:/Table/106/1/"washington dc"/"L\xcc\xcc\xcc\xcc\xccL\x00\x80\x00\x00\x00\x00\x00\x00\x0f" updating replica 2 to 15.
  range r80:/Table/107 updating replica 1 to 15.
  range r96:/Table/107/1/"san francisco"/"\x88\x88\x88\x88\x88\x88H\x00\x80\x00\x00\x00\x00\x00\x00\b" updating replica 1 to 15.
  range r102:/Table/107/1/"seattle"/"UUUUUUD\x00\x80\x00\x00\x00\x00\x00\x00\x05" updating replica 4 to 16.
  range r89:/Table/107/2 updating replica 1 to 15.
  range r126:/Table/108/1/"amsterdam"/"\xc5\x1e\xb8Q\xeb\x85@\x00\x80\x00\x00\x00\x00\x00\x01\x81" updating replica 2 to 16.
  range r104:/Table/108/1/"los angeles"/"\xa8\xf5\u008f\\(H\x00\x80\x00\x00\x00\x00\x00\x01J" updating replica 3 to 16.
  range r119:/Table/108/1/"san francisco"/"\x8c\xcc\xcc\xcc\xcc\xcc@\x00\x80\x00\x00\x00\x00\x00\x01\x13" updating replica 6 to 18.
  range r117:/Table/108/1/"seattle"/"p\xa3\xd7\n=pD\x00\x80\x00\x00\x00\x00\x00\x00\xdc" updating replica 4 to 17.
  range r155:/Table/108/1/"washington dc"/"Tz\xe1G\xae\x14L\x00\x80\x00\x00\x00\x00\x00\x00\xa5" updating replica 3 to 15.
  range r82:/Table/108/3 updating replica 1 to 15.

Nodes n4, n5 will be marked as decommissioned.


Proceed with staging plan [y/N] y

Plan staged. To complete recovery restart nodes n1, n2, n3.

To verify recovery status invoke

'cockroach debug recover verify  --host=127.0.0.1:26257 --insecure=true recover-plan.json'

```

And allow overwriting of currently stages plans if need be:

```
$ cockroach debug recover apply-plan  --host=127.0.0.1:26257 --insecure=true recover-plan-2.json
Proposed changes in plan 576f3d2e-518c-4dbc-9af4-b416629bbf1a:
  range r93:/Table/106/1/"boston"/"333333D\x00\x80\x00\x00\x00\x00\x00\x00\n" updating replica 2 to 16.
  range r92:/Table/106/1/"los angeles"/"\x99\x99\x99\x99\x99\x99H\x00\x80\x00\x00\x00\x00\x00\x00\x1e" updating replica 2 to 16.
  range r91:/Table/106/1/"seattle"/"ffffffH\x00\x80\x00\x00\x00\x00\x00\x00\x14" updating replica 2 to 16.
  range r115:/Table/106/1/"washington dc"/"L\xcc\xcc\xcc\xcc\xccL\x00\x80\x00\x00\x00\x00\x00\x00\x0f" updating replica 2 to 15.
  range r80:/Table/107 updating replica 1 to 15.
  range r96:/Table/107/1/"san francisco"/"\x88\x88\x88\x88\x88\x88H\x00\x80\x00\x00\x00\x00\x00\x00\b" updating replica 1 to 15.
  range r102:/Table/107/1/"seattle"/"UUUUUUD\x00\x80\x00\x00\x00\x00\x00\x00\x05" updating replica 4 to 16.
  range r89:/Table/107/2 updating replica 1 to 15.
  range r126:/Table/108/1/"amsterdam"/"\xc5\x1e\xb8Q\xeb\x85@\x00\x80\x00\x00\x00\x00\x00\x01\x81" updating replica 2 to 16.
  range r104:/Table/108/1/"los angeles"/"\xa8\xf5\u008f\\(H\x00\x80\x00\x00\x00\x00\x00\x01J" updating replica 3 to 16.
  range r119:/Table/108/1/"san francisco"/"\x8c\xcc\xcc\xcc\xcc\xcc@\x00\x80\x00\x00\x00\x00\x00\x01\x13" updating replica 6 to 18.
  range r117:/Table/108/1/"seattle"/"p\xa3\xd7\n=pD\x00\x80\x00\x00\x00\x00\x00\x00\xdc" updating replica 4 to 17.
  range r155:/Table/108/1/"washington dc"/"Tz\xe1G\xae\x14L\x00\x80\x00\x00\x00\x00\x00\x00\xa5" updating replica 3 to 15.
  range r82:/Table/108/3 updating replica 1 to 15.

Nodes n4, n5 will be marked as decommissioned.

Conflicting staged plans will be replaced:
  plan 66200d2c-e0e1-4af4-b890-ef5bb6e9ccc4 is staged on node n1.
  plan 66200d2c-e0e1-4af4-b890-ef5bb6e9ccc4 is staged on node n3.
  plan 66200d2c-e0e1-4af4-b890-ef5bb6e9ccc4 is staged on node n2.


Proceed with staging plan [y/N] y

Plan staged. To complete recovery restart nodes n1, n2, n3.

To verify recovery status invoke

'cockroach debug recover verify  --host=127.0.0.1:26257 --insecure=true recover-plan-2.json'

```
