### PR TITLE
sql: fix CLOSE ALL so it doesn't ignore the ALL flag

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/cursor
+++ b/pkg/sql/logictest/testdata/logic_test/cursor
@@ -1,4 +1,7 @@
 statement ok
+CLOSE ALL
+
+statement ok
 CREATE TABLE a (a INT PRIMARY KEY, b INT);
 INSERT INTO a VALUES (1, 2), (2, 3)
 
@@ -46,6 +49,38 @@ CLOSE foo
 
 statement ok
 COMMIT;
+BEGIN;
+DECLARE foo CURSOR FOR SELECT * FROM a ORDER BY a
+
+query II
+FETCH 1 foo
+----
+1  2
+
+statement ok
+CLOSE foo
+
+statement error cursor \"foo\" does not exist
+FETCH 2 foo
+
+statement ok
+ROLLBACK;
+BEGIN;
+DECLARE foo CURSOR FOR SELECT * FROM a ORDER BY a
+
+query II
+FETCH 1 foo
+----
+1  2
+
+statement ok
+CLOSE ALL
+
+statement error cursor \"foo\" does not exist
+FETCH 2 foo
+
+statement ok
+ROLLBACK;
 
 statement error cursor \"foo\" does not exist
 BEGIN;

--- a/pkg/sql/sql_cursor.go
+++ b/pkg/sql/sql_cursor.go
@@ -243,6 +243,9 @@ func (p *planner) CloseCursor(ctx context.Context, n *tree.CloseCursor) (planNod
 	return &delayedNode{
 		name: n.String(),
 		constructor: func(ctx context.Context, p *planner) (planNode, error) {
+			if n.All {
+				return newZeroNode(nil /* columns */), p.sqlCursors.closeAll(false /* errorOnWithHold */)
+			}
 			return newZeroNode(nil /* columns */), p.sqlCursors.closeCursor(n.Name)
 		},
 	}, nil


### PR DESCRIPTION
informs https://github.com/cockroachdb/cockroach/issues/83061

Release note (bug fix): Fixed a bug where CLOSE ALL would not respect the "ALL" flag and would instead attempt to close a cursor with no name.