### PR TITLE
gossip: don't resolve addresses while holding mutex

### DIFF
--- a/pkg/gossip/client.go
+++ b/pkg/gossip/client.go
@@ -259,13 +259,6 @@ func (c *client) handleResponse(ctx context.Context, g *Gossip, reply *Response)
 				"received forward from n%d to n%d (%s); already have active connection, skipping",
 				reply.NodeID, reply.AlternateNodeID, reply.AlternateAddr)
 		}
-		// We try to resolve the address, but don't actually use the result.
-		// The certificates (if any) may only be valid for the unresolved
-		// address.
-		if _, err := reply.AlternateAddr.Resolve(); err != nil {
-			return errors.Wrapf(err, "unable to resolve alternate address %s for n%d",
-				reply.AlternateAddr, reply.AlternateNodeID)
-		}
 		c.forwardAddr = reply.AlternateAddr
 		return errors.Errorf("received forward from n%d to n%d (%s)",
 			reply.NodeID, reply.AlternateNodeID, reply.AlternateAddr)


### PR DESCRIPTION
This patch removes a DNS resolution call performed while holding the gossip mutex. This can lead to severe process stalls if the DNS lookup is not immediate, since we need to acquire gossip read locks in several performance critical code paths, including Raft processing. However, the DNS lookup was only done when validating a remote forwarding address, which presumably happens fairly rarely. Removing it should not cause any problems, since the address will necessarily be validated later when attempting to connect to it.

Resolves #95349.

Epic: none
Release note (bug fix): Fixed a bug where a DNS lookup was performed during gossip remote forwarding while holding the gossip mutex. This could cause processing stalls if the DNS server was slow to respond.