### PR TITLE
server: add NetworkConnectivity endpoint to get network connection statuses between nodes

### DIFF
--- a/docs/generated/http/full.md
+++ b/docs/generated/http/full.md
@@ -5078,6 +5078,123 @@ Support status: [reserved](#support-status)
 
 
 
+## NetworkConnectivity
+
+`GET /_status/connectivity`
+
+
+
+Support status: [reserved](#support-status)
+
+#### Request Parameters
+
+
+
+
+
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| node_id | [string](#cockroach.server.serverpb.NetworkConnectivityRequest-string) |  |  | [reserved](#support-status) |
+
+
+
+
+
+
+
+#### Response Parameters
+
+
+
+
+
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| connections | [NetworkConnectivityResponse.ConnectionsEntry](#cockroach.server.serverpb.NetworkConnectivityResponse-cockroach.server.serverpb.NetworkConnectivityResponse.ConnectionsEntry) | repeated |  | [reserved](#support-status) |
+| errors_by_node_id | [NetworkConnectivityResponse.ErrorsByNodeIdEntry](#cockroach.server.serverpb.NetworkConnectivityResponse-cockroach.server.serverpb.NetworkConnectivityResponse.ErrorsByNodeIdEntry) | repeated | errors contains any errors that occurred during fan-out calls to other nodes. | [reserved](#support-status) |
+
+
+
+
+
+
+<a name="cockroach.server.serverpb.NetworkConnectivityResponse-cockroach.server.serverpb.NetworkConnectivityResponse.ConnectionsEntry"></a>
+#### NetworkConnectivityResponse.ConnectionsEntry
+
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| key | [int32](#cockroach.server.serverpb.NetworkConnectivityResponse-int32) |  |  |  |
+| value | [NetworkConnectivityResponse.Connectivity](#cockroach.server.serverpb.NetworkConnectivityResponse-cockroach.server.serverpb.NetworkConnectivityResponse.Connectivity) |  |  |  |
+
+
+
+
+
+<a name="cockroach.server.serverpb.NetworkConnectivityResponse-cockroach.server.serverpb.NetworkConnectivityResponse.Connectivity"></a>
+#### NetworkConnectivityResponse.Connectivity
+
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| peers | [NetworkConnectivityResponse.Connectivity.PeersEntry](#cockroach.server.serverpb.NetworkConnectivityResponse-cockroach.server.serverpb.NetworkConnectivityResponse.Connectivity.PeersEntry) | repeated |  | [reserved](#support-status) |
+
+
+
+
+
+<a name="cockroach.server.serverpb.NetworkConnectivityResponse-cockroach.server.serverpb.NetworkConnectivityResponse.Connectivity.PeersEntry"></a>
+#### NetworkConnectivityResponse.Connectivity.PeersEntry
+
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| key | [int32](#cockroach.server.serverpb.NetworkConnectivityResponse-int32) |  |  |  |
+| value | [NetworkConnectivityResponse.Peer](#cockroach.server.serverpb.NetworkConnectivityResponse-cockroach.server.serverpb.NetworkConnectivityResponse.Peer) |  |  |  |
+
+
+
+
+
+<a name="cockroach.server.serverpb.NetworkConnectivityResponse-cockroach.server.serverpb.NetworkConnectivityResponse.Peer"></a>
+#### NetworkConnectivityResponse.Peer
+
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| latency | [google.protobuf.Duration](#cockroach.server.serverpb.NetworkConnectivityResponse-google.protobuf.Duration) |  |  | [reserved](#support-status) |
+| status | [NetworkConnectivityResponse.ConnectionStatus](#cockroach.server.serverpb.NetworkConnectivityResponse-cockroach.server.serverpb.NetworkConnectivityResponse.ConnectionStatus) |  |  | [reserved](#support-status) |
+| address | [string](#cockroach.server.serverpb.NetworkConnectivityResponse-string) |  |  | [reserved](#support-status) |
+| locality | [cockroach.roachpb.Locality](#cockroach.server.serverpb.NetworkConnectivityResponse-cockroach.roachpb.Locality) |  |  | [reserved](#support-status) |
+| error | [string](#cockroach.server.serverpb.NetworkConnectivityResponse-string) |  |  | [reserved](#support-status) |
+
+
+
+
+
+<a name="cockroach.server.serverpb.NetworkConnectivityResponse-cockroach.server.serverpb.NetworkConnectivityResponse.ErrorsByNodeIdEntry"></a>
+#### NetworkConnectivityResponse.ErrorsByNodeIdEntry
+
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| key | [int32](#cockroach.server.serverpb.NetworkConnectivityResponse-int32) |  |  |  |
+| value | [string](#cockroach.server.serverpb.NetworkConnectivityResponse-string) |  |  |  |
+
+
+
+
+
+
 ## RequestCA
 
 `GET /_join/v1/ca`

--- a/pkg/server/serverpb/status.proto
+++ b/pkg/server/serverpb/status.proto
@@ -1995,6 +1995,55 @@ message CriticalNodesResponse {
   roachpb.SpanConfigConformanceReport report = 2 [(gogoproto.nullable) = false];
 }
 
+message NetworkConnectivityRequest {
+  string node_id = 1 [
+    (gogoproto.customname) = "NodeID"
+  ];
+}
+
+message NetworkConnectivityResponse {
+  enum ConnectionStatus {
+    // Indicates that system couldn't get information about nodes connection.
+    UNKNOWN = 0;
+    // Source node established connection to target node.
+    ESTABLISHED = 1;
+    // Indicates that node is attempting to establish connection to target node for the first time.
+    ESTABLISHING = 2;
+    // Indicates that connection state is unhealthy.
+    ERROR = 3;
+  }
+
+  message Peer {
+    google.protobuf.Duration latency = 1 [
+      (gogoproto.nullable) = false,
+      (gogoproto.stdduration) = true
+    ];
+    ConnectionStatus status = 2;
+    string address = 4;
+    roachpb.Locality locality = 5;
+    string error = 6;
+  }
+
+  message Connectivity {
+    map<int32, Peer> peers = 1 [
+      (gogoproto.nullable) = false,
+      (gogoproto.castkey) = "github.com/cockroachdb/cockroach/pkg/roachpb.NodeID"
+    ];
+  }
+
+  map<int32, Connectivity> connections = 1 [
+    (gogoproto.nullable) = false,
+    (gogoproto.castkey) = "github.com/cockroachdb/cockroach/pkg/roachpb.NodeID"
+  ];
+
+  // errors contains any errors that occurred during fan-out calls to other nodes.
+  map<int32, string> errors_by_node_id = 2 [
+    (gogoproto.castkey) = "github.com/cockroachdb/cockroach/pkg/roachpb.NodeID",
+    (gogoproto.customname) = "ErrorsByNodeID",
+    (gogoproto.nullable) = false
+  ];
+}
+
 service Status {
   // Certificates retrieves a copy of the TLS certificates.
   rpc Certificates(CertificatesRequest) returns (CertificatesResponse) {
@@ -2457,4 +2506,10 @@ service Status {
   // ListExecutionInsights returns potentially problematic statements cluster-wide,
   // along with actions we suggest the application developer might take to remedy them.
   rpc ListExecutionInsights(ListExecutionInsightsRequest) returns (ListExecutionInsightsResponse) {}
+
+  rpc NetworkConnectivity(NetworkConnectivityRequest) returns (NetworkConnectivityResponse) {
+    option (google.api.http) = {
+      get: "/_status/connectivity"
+    };
+  }
 }

--- a/pkg/server/status.go
+++ b/pkg/server/status.go
@@ -1989,6 +1989,104 @@ func (s *statusServer) NodeUI(
 	return &resp, nil
 }
 
+// NetworkConnectivity collects information about connections statuses across all nodes.
+func (s *systemStatusServer) NetworkConnectivity(
+	ctx context.Context, req *serverpb.NetworkConnectivityRequest,
+) (*serverpb.NetworkConnectivityResponse, error) {
+	ctx = forwardSQLIdentityThroughRPCCalls(ctx)
+	ctx = s.AnnotateCtx(ctx)
+
+	response := &serverpb.NetworkConnectivityResponse{
+		Connections:    map[roachpb.NodeID]serverpb.NetworkConnectivityResponse_Connectivity{},
+		ErrorsByNodeID: map[roachpb.NodeID]string{},
+	}
+
+	if len(req.NodeID) > 0 {
+		sourceNodeID, local, err := s.parseNodeID(req.NodeID)
+		if err != nil {
+			return nil, serverError(ctx, err)
+		}
+
+		if !local {
+			statusClient, err := s.dialNode(ctx, sourceNodeID)
+			if err != nil {
+				return nil, serverError(ctx, err)
+			}
+			return statusClient.NetworkConnectivity(ctx, req)
+		}
+
+		// "local" specified, so collect the local results and return them back.
+		peers := map[roachpb.NodeID]serverpb.NetworkConnectivityResponse_Peer{}
+		var nodeIDs []roachpb.NodeID
+		err = s.gossip.IterateInfos(gossip.KeyNodeDescPrefix, func(k string, info gossip.Info) error {
+			nodeIDs = append(nodeIDs, info.NodeID)
+			return nil
+		})
+		if err != nil {
+			return nil, serverError(ctx, err)
+		}
+
+		latencies := s.rpcCtx.RemoteClocks.AllLatencies()
+
+		for _, targetNodeId := range nodeIDs {
+			if sourceNodeID == targetNodeId {
+				continue
+			}
+			peer := serverpb.NetworkConnectivityResponse_Peer{}
+			peer.Latency = latencies[targetNodeId]
+
+			node, err := s.gossip.GetNodeDescriptor(targetNodeId)
+			if err != nil {
+				peer.Status = serverpb.NetworkConnectivityResponse_UNKNOWN
+				peer.Error = errors.UnwrapAll(err).Error()
+				continue
+			}
+			if err = s.rpcCtx.ConnHealth(node.Address.AddressField, node.NodeID, rpc.SystemClass); err != nil {
+				if errors.Is(rpc.ErrNotHeartbeated, err) {
+					peer.Status = serverpb.NetworkConnectivityResponse_ESTABLISHING
+				} else {
+					peer.Status = serverpb.NetworkConnectivityResponse_ERROR
+				}
+				peer.Error = errors.UnwrapAll(err).Error()
+			} else {
+				peer.Status = serverpb.NetworkConnectivityResponse_ESTABLISHED
+			}
+			peer.Address = node.Address.AddressField
+			peer.Locality = &node.Locality
+
+			peers[targetNodeId] = peer
+		}
+
+		response.Connections[sourceNodeID] = serverpb.NetworkConnectivityResponse_Connectivity{
+			Peers: peers,
+		}
+		return response, nil
+	}
+
+	// No NodeID parameter specified, so fan-out to all nodes and collect results.
+	dialFn := func(ctx context.Context, nodeID roachpb.NodeID) (interface{}, error) {
+		return s.dialNode(ctx, nodeID)
+	}
+	remoteRequest := serverpb.NetworkConnectivityRequest{NodeID: "local"}
+	nodeFn := func(ctx context.Context, client interface{}, _ roachpb.NodeID) (interface{}, error) {
+		statusClient := client.(serverpb.StatusClient)
+		return statusClient.NetworkConnectivity(ctx, &remoteRequest)
+	}
+	responseFn := func(nodeID roachpb.NodeID, resp interface{}) {
+		r := resp.(*serverpb.NetworkConnectivityResponse)
+		response.Connections[nodeID] = r.Connections[nodeID]
+	}
+	errorFn := func(nodeID roachpb.NodeID, err error) {
+		response.ErrorsByNodeID[nodeID] = err.Error()
+	}
+
+	if err := s.iterateNodes(ctx, "network connectivity", dialFn, nodeFn, responseFn, errorFn); err != nil {
+		return nil, serverError(ctx, err)
+	}
+
+	return response, nil
+}
+
 // Metrics return metrics information for the server specified.
 func (s *statusServer) Metrics(
 	ctx context.Context, req *serverpb.MetricsRequest,

--- a/pkg/server/status_test.go
+++ b/pkg/server/status_test.go
@@ -1127,6 +1127,51 @@ func TestHotRanges2Response(t *testing.T) {
 	}
 }
 
+func TestNetworkConnectivity(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	numNodes := 3
+	testCluster := serverutils.StartNewTestCluster(t, numNodes, base.TestClusterArgs{
+		ReplicationMode: base.ReplicationManual,
+	})
+	ctx := context.Background()
+	defer testCluster.Stopper().Stop(ctx)
+	ts := testCluster.Server(0)
+
+	var resp serverpb.NetworkConnectivityResponse
+	// Should wait because endpoint relies on Gossip.
+	testutils.SucceedsSoon(t, func() error {
+		if err := getStatusJSONProto(ts, "connectivity", &resp); err != nil {
+			return err
+		}
+		if len(resp.ErrorsByNodeID) > 0 {
+			return errors.Errorf("expected no errors but got: %d", len(resp.ErrorsByNodeID))
+		}
+		if len(resp.Connections) < numNodes {
+			return errors.Errorf("expected results from %d nodes but got: %d", numNodes, len(resp.ErrorsByNodeID))
+		}
+		return nil
+	})
+	// Test when one node is stopped.
+	stoppedNodeID := testCluster.Server(1).NodeID()
+	testCluster.Server(1).Stopper().Stop(ctx)
+
+	testutils.SucceedsSoon(t, func() error {
+		if err := getStatusJSONProto(ts, "connectivity", &resp); err != nil {
+			return err
+		}
+		require.Equal(t, len(resp.Connections), numNodes-1)
+		fmt.Printf("got status: %s", resp.Connections[ts.NodeID()].Peers[stoppedNodeID].Status.String())
+		if resp.Connections[ts.NodeID()].Peers[stoppedNodeID].Status != serverpb.NetworkConnectivityResponse_ERROR {
+			return errors.New("waiting for connection state to be changed.")
+		}
+		if latency := resp.Connections[ts.NodeID()].Peers[stoppedNodeID].Latency; latency > 0 {
+			return errors.Errorf("expected latency to be 0 but got %s", latency.String())
+		}
+		return nil
+	})
+}
+
 func TestHotRanges2ResponseWithViewActivityOptions(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)


### PR DESCRIPTION
This patch introduces new endpoint which aimed to provide information
about network connection status between nodes rather than nodes statuses
(that is done with node liveness api).

`NetworkConnectivity` endpoint relies on gossip client to get all known
nodes in the cluster and then checks `rpcCtx.ConnHealth` for every peer.
It can tell us following:
- connection is live if no error returned;
- `ErrNoConnection` returned if nodes don't have connection;
- other errors indicate that network connection is unhealthy;

This functionality should not care about whether node is decommissioned,
shutdown or whatever.

Later on, it'll be used in conjunction with node liveness statuses to
distinguish more specific reasons why network connection is broken.
For instance,
- if node liveness status is DEAD and connection is failed,
then it should not be considered as network issue.
- if node liveness status is LIVE/DECOMMISSIONING and network
connection is failed, then it is network partitioning;

Release note: None

Part of #58033
Part of #96101

Epic: https://cockroachlabs.atlassian.net/browse/CRDB-21710