### PR TITLE
sql: rationalize the handling of comments

### DIFF
--- a/pkg/sql/catalog/catalogkeys/keys.go
+++ b/pkg/sql/catalog/catalogkeys/keys.go
@@ -45,6 +45,8 @@ type CommentType int
 //go:generate stringer --type CommentType
 
 // Note: please add the new comment types to AllCommentTypes as well.
+// Note: do not change the numeric values of this enum -- they correspond
+// to stored values in system.comments.
 const (
 	// DatabaseCommentType comment on a database.
 	DatabaseCommentType CommentType = 0

--- a/pkg/sql/comprules/BUILD.bazel
+++ b/pkg/sql/comprules/BUILD.bazel
@@ -13,6 +13,7 @@ go_library(
         "//pkg/sql/compengine",
         "//pkg/sql/lexbase",
         "//pkg/sql/scanner",
+        "//pkg/sql/sem/catconstants",
     ],
 )
 

--- a/pkg/sql/comprules/rules.go
+++ b/pkg/sql/comprules/rules.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/compengine"
 	"github.com/cockroachdb/cockroach/pkg/sql/lexbase"
 	"github.com/cockroachdb/cockroach/pkg/sql/scanner"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/catconstants"
 )
 
 // GetCompMethods exposes the completion heuristics defined in this
@@ -257,19 +258,20 @@ func completeObjectInCurrentDatabase(
 
 	c.Trace("completing for %q (%d,%d), schema: %s", prefix, start, end, schema)
 	const queryT = `
-WITH n AS (SELECT oid FROM pg_catalog.pg_namespace WHERE nspname %s),
-     t AS (SELECT oid, relname FROM pg_catalog.pg_class WHERE reltype != 0 AND relnamespace IN (TABLE n))
-SELECT relname AS completion,
-       'relation' AS category,
-       substr(COALESCE(cc.comment, ''), e'[^\n]{0,80}') as description,
-       $2:::INT AS start,
-       $3:::INT AS end
-  FROM t
-LEFT OUTER JOIN "".crdb_internal.kv_catalog_comments cc
-    ON t.oid = cc.object_id AND cc.type = 'TableCommentType'
- WHERE left(relname, length($1:::STRING)) = $1::STRING
+         SELECT c.relname AS completion,
+                'relation' AS category,
+                substr(d.description, ''), e'[^\n]{0,80}') as description,
+                $2:::INT AS start,
+                $3:::INT AS end
+           FROM pg_catalog.pg_class c
+           JOIN pg_catalog.pg_namespace n
+                ON c.relnamespace = n.oid AND n.nspname %s
+LEFT OUTER JOIN crdb_internal.kv_catalog_comments d
+                ON t.oid = d.objoid AND d.classoid = %d
+          WHERE c.reltype != 0
+            AND left(relname, length($1:::STRING)) = $1::STRING
 `
-	query := fmt.Sprintf(queryT, schema)
+	query := fmt.Sprintf(queryT, schema, catconstants.PgCatalogClassTableID)
 	iter, err := c.Query(ctx, query, prefix, start, end)
 	return iter, err
 }
@@ -298,17 +300,18 @@ func completeSchemaInCurrentDatabase(
 	}
 
 	c.Trace("completing for %q (%d,%d)", prefix, start, end)
-	const query = `
-SELECT nspname AS completion,
-       'schema' AS category,
-       substr(COALESCE(cc.comment, ''), e'[^\n]{0,80}') as description,
-       $2:::INT AS start,
-       $3:::INT AS end
-  FROM pg_catalog.pg_namespace t
-LEFT OUTER JOIN "".crdb_internal.kv_catalog_comments cc
-    ON t.oid = cc.object_id AND cc.type = 'SchemaCommentType'
+	const queryT = `
+         SELECT n.nspname AS completion,
+                'schema' AS category,
+                substr(COALESCE(d.description, ''), e'[^\n]{0,80}') as description,
+                $2:::INT AS start,
+                $3:::INT AS end
+           FROM pg_catalog.pg_namespace n
+LEFT OUTER JOIN crdb_internal.kv_catalog_comments d
+                ON n.oid = d.objoid AND d.classoid = %d
  WHERE left(nspname, length($1:::STRING)) = $1::STRING
 `
+	query := fmt.Sprintf(queryT, catconstants.PgCatalogNamespaceTableID)
 	iter, err := c.Query(ctx, query, prefix, start, end)
 	return iter, err
 }
@@ -418,7 +421,7 @@ func completeObjectInOtherDatabase(
 	}
 
 	c.Trace("completing for %q (%d,%d), schema: %q, db: %q", prefix, start, end, schema, dbname)
-	const query = `
+	const queryT = `
 WITH t AS (
 SELECT name, table_id
   FROM "".crdb_internal.tables
@@ -433,8 +436,9 @@ SELECT name AS completion,
        $3:::INT AS end
   FROM t
 LEFT OUTER JOIN "".crdb_internal.kv_catalog_comments cc
-    ON t.table_id = cc.object_id AND cc.type = 'TableCommentType'
+    ON t.table_id = cc.objoid AND cc.classoid = %d
 `
+	query := fmt.Sprintf(queryT, catconstants.PgCatalogClassTableID)
 	iter, err := c.Query(ctx, query, prefix, start, end, dbname, schema)
 	return iter, err
 }

--- a/pkg/sql/sem/catconstants/constants.go
+++ b/pkg/sql/sem/catconstants/constants.go
@@ -96,6 +96,7 @@ const (
 	CrdbInternalBackwardDependenciesTableID
 	CrdbInternalBuildInfoTableID
 	CrdbInternalBuiltinFunctionsTableID
+	CrdbInternalBuiltinFunctionCommentsTableID
 	CrdbInternalCatalogCommentsTableID
 	CrdbInternalCatalogDescriptorTableID
 	CrdbInternalCatalogNamespaceTableID


### PR DESCRIPTION
Found while working on #88061 .

Prior to this patch, we had a weird translation going in `kv_catalog_comments`, which was causing the tree of objects to be traversed 6 times (one per comment type), and then the rows to be mapped one by one again in `pg_description` / `pg_shdescription`.

This made no sense - it should be possible to push a predicate on `pg_description` down to a virtual index on `kv_catalog_comments`, and this requires the column types to align and no computation to happen in-between.

This commit simplifies all this by having `kv_catalog_comments` responsible for preparing the data in the format expected by the `pg_` tables.

Release note: None
Epic: None