### PR TITLE
storage: rely on pebble for log message in case of write stall

### DIFF
--- a/pkg/storage/pebble.go
+++ b/pkg/storage/pebble.go
@@ -54,7 +54,6 @@ import (
 	"github.com/cockroachdb/pebble/replay"
 	"github.com/cockroachdb/pebble/sstable"
 	"github.com/cockroachdb/pebble/vfs"
-	"github.com/cockroachdb/redact"
 	humanize "github.com/dustin/go-humanize"
 )
 
@@ -1067,11 +1066,9 @@ func (p *Pebble) makeMetricEtcEventListener(ctx context.Context) pebble.EventLis
 				// Note that the below log messages go to the main cockroach log, not
 				// the pebble-specific log.
 				if fatalOnExceeded {
-					log.Fatalf(ctx, "disk stall detected: pebble unable to write to %s in %.2f seconds",
-						info.Path, redact.Safe(info.Duration.Seconds()))
+					log.Fatalf(ctx, "file write stall detected: %s", info)
 				} else {
-					log.Errorf(ctx, "disk stall detected: pebble unable to write to %s in %.2f seconds",
-						info.Path, redact.Safe(info.Duration.Seconds()))
+					log.Errorf(ctx, "file write stall detected: %s", info)
 				}
 				return
 			}


### PR DESCRIPTION
Part of https://github.com/cockroachdb/cockroach/issues/67856. Haven't added additional context re: op type & size of write to `pebble.DiskSlowInfo` but will do that shortly. With this change, if we make changes to how much context is included in `pebble.DiskSlowInfo`, we will not need to make a CRDB change to have the context in the CRDB logs. Note also that I will adjust the pebble String method to be less accusatory to disks ("disk slow" -> "write slow").

See below for log message with this commit in.

```
$ ./dev test pkg/storage -v --filter='TestPebbleMetricEventListener' --show-logs
$ bazel test pkg/storage:all --test_env=GOTRACEBACK=all --test_filter=TestPebbleMetricEventListener --test_arg -test.v --test_arg -show-logs --test_sharding_strategy=disabled --test_output all
Starting local Bazel server and connecting to it...
INFO: Invocation ID: a4365f4b-9190-4ef3-8a54-de3b4c0c46b7
INFO: Analyzed 3 targets (626 packages loaded, 16556 targets configured).
INFO: Found 2 targets and 1 test target...
INFO: From Testing //pkg/storage:storage_test:
==================== Test output for //pkg/storage:storage_test:
initialized metamorphic constant "span-reuse-rate" with value 58
initialized metamorphic constant "mvcc-value-disable-simple-encoding" with value true
initialized metamorphic constant "mvcc-max-iters-before-seek" with value 2
initialized metamorphic constant "span-reuse-rate" with value 39
initialized metamorphic constant "mvcc-value-disable-simple-encoding" with value true
initialized metamorphic constant "mvcc-max-iters-before-seek" with value 0
=== RUN   TestPebbleMetricEventListener
    test_log_scope.go:76: test logs captured to: /private/var/tmp/_bazel_joshimhoff/69f147d3e5e8d9a9bc7bc343361a1a94/sandbox/darwin-sandbox/6/execroot/com_github_cockroachdb_cockroach/_tmp/88d640957a51906868fc787a6e8a38b4/logTestPebbleMetricEventListener440509452
E230118 21:01:15.941881 28 storage/pebble.go:1001  [-] 1  write stall detected: disk slowness detected: write to file  has been ongoing for 70.0s
    pebble_test.go:356: -- test log scope end --
--- PASS: TestPebbleMetricEventListener (0.05s)
PASS
================================================================================
INFO: Elapsed time: 29.194s, Critical Path: 8.66s
INFO: 7 processes: 1 internal, 6 darwin-sandbox.
INFO: Build completed successfully, 7 total actions
//pkg/storage:storage_test                                               PASSED in 0.6s

Executed 1 out of 1 test: 1 test passes.
INFO: Build completed successfully, 7 total actions
```

**storage: rely on pebble for log message in case of write stall**

In case of a write stall, CRDB logs out details re: the write stall. By
default, CRDB logs at fatal level & then crashes. Before this commit, tho the
pebble event had a String method, it was not used in the CRDB log message.
This means adding additional context to the pebble event will not add the
context to the CRDB logs, unless a CRDB change is made in addition to a pebble
change. With this commit, the log message calls the pebble event's String
method.

Release note (ops change): CRDB log message in case of write stall has been
adjusted slightly.