### PR TITLE
ci: publish `latest-master-build` docker image

### DIFF
--- a/build/teamcity/internal/release/process/make-and-publish-build-tagging.sh
+++ b/build/teamcity/internal/release/process/make-and-publish-build-tagging.sh
@@ -55,6 +55,10 @@ if [[ -n "${release_branch}" ]] ; then
   log_into_gcloud
   gcloud container images add-tag "${gcr_repository}:${build_name}" "${gcr_repository}:latest-${release_branch}-build"
 fi
+if [[ "$TC_BUILD_BRANCH" == "master" ]]; then
+  log_into_gcloud
+  gcloud container images add-tag "${gcr_repository}:${build_name}" "${gcr_repository}:latest-master-build"
+fi
 tc_end_block "Tag docker image as latest-build"
 
 


### PR DESCRIPTION
Previously, our automation published latest docker images using `latest-v2x.x-build` tag. External automation that tracked the master branch would need to update the tag, when we change the version.

This PR adds an extra step to tag the master branch builds with `latest-master-build` docker tag.

Epic: none
Release note: None