### PR TITLE
release-22.1: fix unstable sort in SSTSink

### DIFF
--- a/pkg/ccl/backupccl/backup_processor.go
+++ b/pkg/ccl/backupccl/backup_processor.go
@@ -251,6 +251,7 @@ type returnedSST struct {
 	f              BackupManifest_File
 	sst            []byte
 	revStart       hlc.Timestamp
+	endKeyTS       hlc.Timestamp
 	completedSpans int32
 	atKeyBoundary  bool
 }
@@ -536,7 +537,7 @@ func runBackupProcessor(
 							f.StartTime = span.start
 							f.EndTime = span.end
 						}
-						ret := returnedSST{f: f, sst: file.SST, revStart: res.StartTime, atKeyBoundary: file.EndKeyTS.IsEmpty()}
+						ret := returnedSST{f: f, endKeyTS: file.EndKeyTS, sst: file.SST, revStart: res.StartTime, atKeyBoundary: file.EndKeyTS.IsEmpty()}
 						// If multiple files were returned for this span, only one -- the
 						// last -- should count as completing the requested span.
 						if i == len(res.Files)-1 {
@@ -603,6 +604,50 @@ func runBackupProcessor(
 	return grp.Wait()
 }
 
+type sstQueue []returnedSST
+
+// Len implements the sort.Interface.
+func (s sstQueue) Len() int {
+	return len(s)
+}
+
+// Less implements the sort.Interface.
+func (s sstQueue) Less(i, j int) bool {
+	cmp := s[i].f.Span.Key.Compare(s[j].f.Span.Key)
+	// If two backup files have the same start key, it implies we have
+	// paginated in the middle of a key's revisions and those revisions
+	// straddle the file boundary. We must ensure that these files are sorted
+	// in decreasing order of the key's revision timestamps so that they are
+	// added in-order to the underlying SSTWriter.
+	if cmp == 0 {
+		// Since the start key of the files are equal we compare the EndKeys.
+		endKeyCmp := s[i].f.Span.EndKey.Compare(s[j].f.Span.EndKey)
+		// If the end keys are also equal, we know that both files only contain
+		// revisions of the same key, and so it is safe to sort in descending
+		// order of the timestamp of the last revision in each file.
+		if endKeyCmp == 0 {
+			return s[j].endKeyTS.Less(s[i].endKeyTS)
+		}
+		// Otherwise, we want to sort the files in increasing order of their
+		// EndKeys.
+		// This ensures that a queue such as
+		// `{[a@3, a@2, b@6] , [a@6, a@5, a@4]}`
+		// will have its files in an order that will write to the underlying
+		// SSTWriter in-order.
+		// `{[a@6, a@5, a@4], [a@3, a@2, b@6]}`
+		return endKeyCmp < 0
+	}
+
+	return cmp < 0
+}
+
+// Swap implements the sort.Interface.
+func (s sstQueue) Swap(i, j int) {
+	s[i], s[j] = s[j], s[i]
+}
+
+var _ sort.Interface = &sstQueue{}
+
 type sstSinkConf struct {
 	progCh   chan execinfrapb.RemoteProducerMetadata_BulkProcessorProgress
 	enc      *roachpb.FileEncryptionOptions
@@ -614,7 +659,7 @@ type sstSink struct {
 	dest cloud.ExternalStorage
 	conf sstSinkConf
 
-	queue []returnedSST
+	queue sstQueue
 	// queueCap is the maximum byte size that the queue can grow to.
 	queueCap int64
 	// queueSize is the current byte size of the queue.
@@ -709,7 +754,7 @@ func (s *sstSink) push(ctx context.Context, resp returnedSST) error {
 	s.queueSize += len(resp.sst)
 
 	if s.queueSize >= int(s.queueCap) {
-		sort.Slice(s.queue, func(i, j int) bool { return s.queue[i].f.Span.Key.Compare(s.queue[j].f.Span.Key) < 0 })
+		sort.Sort(s.queue)
 
 		// Drain the first half.
 		drain := len(s.queue) / 2

--- a/pkg/kv/kvserver/batcheval/cmd_export.go
+++ b/pkg/kv/kvserver/batcheval/cmd_export.go
@@ -209,11 +209,21 @@ func evalExport(
 		}
 		data := destFile.Data()
 
-		// NB: This should only happen on the first page of results. If there were
-		// more data to be read that lead to pagination then we'd see it in this
-		// page. Break out of the loop because there must be no data to export.
+		// NB: This should only happen in two cases:
+		//
+		// 1. There was nothing to export for this span.
+		//
+		// 2. We hit a resource constraint that led to an
+		//    early exit and thus have a resume key despite
+		//    not having data.
 		if summary.DataSize == 0 {
-			break
+			if resume != nil {
+				start = resume
+				resumeKeyTS = resumeTS
+				continue
+			} else {
+				break
+			}
 		}
 
 		span := roachpb.Span{Key: start}


### PR DESCRIPTION
This patch includes a backport of
https://github.com/cockroachdb/cockroach/pull/83102.

The focus of this patch is fixing the unstable sort described in #95445. Previously, we would sort only on the basis of the start key of two backup files returned as part of an ExportResponse. This could result in older revisions of a key getting sorted and flushed to the underlying SSTWriter before new revisions, resulting in out-of-order writes, causing the backup to fail. We saw this in the support issue https://github.com/cockroachlabs/support/issues/1998 and have a test TestExportRevisionsWithTimestampPagination that failed under stress.

To fix this unstable sort we now use the following algorithm:

1. Sort on start key of the backup files.
2. If start key is the same, sort on end key of the backup files.
3. If end key is the same, sort in descending order on the end key timestamp of the files as both files are guaranteed to only contain revisions of the same key.

Fixes: #95445

Release note (bug fix): Fixes a bug where a backup of keys with many revisions would fail with "pebble: keys must be added in order".

Release justification: high impact bug fix to prevent failing backups