### PR TITLE
sem/builtins: fix population of generator builtins

### DIFF
--- a/pkg/sql/sem/builtins/all_builtins.go
+++ b/pkg/sql/sem/builtins/all_builtins.go
@@ -98,7 +98,8 @@ func addResolvedFuncDef(
 }
 
 func registerBuiltin(name string, def builtinDefinition) {
-	for _, overload := range def.overloads {
+	for i := range def.overloads {
+		overload := &def.overloads[i]
 		fnCount := 0
 		if overload.Fn != nil {
 			fnCount++

--- a/pkg/sql/sem/builtins/geo_builtins.go
+++ b/pkg/sql/sem/builtins/geo_builtins.go
@@ -7416,7 +7416,7 @@ func appendStrArgOverloadForGeometryArgOverloads(def builtinDefinition) builtinD
 	copy(newOverloads, def.overloads)
 
 	for i := range def.overloads {
-		// Define independntly as it is used by a closure below.
+		// Define independently as it is used by a closure below.
 		ov := def.overloads[i]
 
 		paramTypes, ok := ov.Types.(tree.ParamTypes)


### PR DESCRIPTION
Generator builtins are such that they should not evaluated as scalars (i.e. `Fn` and `FnWithExprs` evaluation functions should not be called on them). In order to highlight this as an assertion failure we initialize generator builtins with special functions in those two fields. However, previously the initialization was broken since we were modifying a copy of the builtin struct, and this is now fixed. There isn't much of a production impact though (if we ever tried to evaluate the generator as a scalar, it'd result in a nil pointer which would be caught by the vectorized engine panic-catcher; also, it seems very hard if possible to trigger this without the testing randomizations), so there is no release note.

Informs: #94890.
Epic: None

Release note: None