### PR TITLE
cluster-ui: populate database list filter on sql activity page

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/store/databasesList/databasesList.reducers.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/store/databasesList/databasesList.reducers.ts
@@ -39,8 +39,8 @@ const databasesListSlice = createSlice({
       state.valid = false;
       state.lastError = action.payload;
     },
-    refresh: (_, action: PayloadAction<SqlExecutionRequest>) => {},
-    request: (_, action: PayloadAction<SqlExecutionRequest>) => {},
+    refresh: (_, _action: PayloadAction<SqlExecutionRequest>) => {},
+    request: (_, _action: PayloadAction<SqlExecutionRequest>) => {},
   },
 });
 

--- a/pkg/ui/workspaces/cluster-ui/src/store/databasesList/databasesList.saga.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/store/databasesList/databasesList.saga.ts
@@ -12,6 +12,7 @@ import { all, call, put, takeLatest } from "redux-saga/effects";
 
 import { actions } from "./databasesList.reducers";
 import { getDatabasesList } from "src/api";
+import moment from "moment";
 
 export function* refreshDatabasesListSaga() {
   yield put(actions.request());
@@ -19,7 +20,7 @@ export function* refreshDatabasesListSaga() {
 
 export function* requestDatabasesListSaga(): any {
   try {
-    const result = yield call(getDatabasesList);
+    const result = yield call(getDatabasesList, moment.duration(10, "m"));
     yield put(actions.received(result));
   } catch (e) {
     yield put(actions.failed(e));

--- a/pkg/ui/workspaces/cluster-ui/src/store/sagas.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/store/sagas.ts
@@ -17,6 +17,7 @@ import { nodesSaga } from "./nodes";
 import { jobsSaga } from "./jobs";
 import { jobSaga } from "./jobDetails";
 import { livenessSaga } from "./liveness";
+import { databasesListSaga } from "./databasesList";
 import { sessionsSaga } from "./sessions";
 import { terminateSaga } from "./terminateQuery";
 import { notifificationsSaga } from "./notifications";
@@ -41,6 +42,7 @@ export function* sagas(cacheInvalidationPeriod?: number): SagaIterator {
     fork(statementInsightsSaga),
     fork(jobsSaga),
     fork(jobSaga),
+    fork(databasesListSaga),
     fork(sessionsSaga),
     fork(terminateSaga),
     fork(notifificationsSaga),


### PR DESCRIPTION
Epic: none

Previously, the database list filter on the SQL Activity page was not
being populated on CC Console. This patch fixes that bug by populating
the dropdown using sql-over-http.

- [Demo](https://www.loom.com/share/49c370f9f6d442e6a4c27295c7a45767) video on CC console.

Release note (ui change): database list filter now shows all databases
in the cluster on CC console.