### PR TITLE
release-22.2: sql/catalog/schemaexpr: fix bug when new column default has different…

### DIFF
--- a/pkg/sql/catalog/schemaexpr/default_exprs.go
+++ b/pkg/sql/catalog/schemaexpr/default_exprs.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/eval"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/transform"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/errors"
 )
 
 // MakeDefaultExprs returns a slice of the default expressions for the slice
@@ -70,6 +71,20 @@ func MakeDefaultExprs(
 		typedExpr, err := tree.TypeCheck(ctx, expr, semaCtx, col.GetType())
 		if err != nil {
 			return nil, err
+		}
+		// For "reasons" the CastExpr type check ignores the desired type. That
+		// means that we can get a result here that is not the right type, and
+		// we'd need to wrap that in an explicit cast. This is the equivalent of
+		// an assignment cast we'd insert when writing to the table directly.
+		if !typedExpr.ResolvedType().Equivalent(col.GetType()) {
+			if typedExpr, err = tree.TypeCheck(ctx, &tree.CastExpr{
+				Expr:       typedExpr,
+				Type:       col.GetType(),
+				SyntaxMode: tree.CastExplicit,
+			}, semaCtx, col.GetType()); err != nil {
+				return nil, errors.NewAssertionErrorWithWrappedErrf(err,
+					"failed to type check the cast of %v to %v", expr, col.GetType())
+			}
 		}
 		if typedExpr, err = txCtx.NormalizeExpr(evalCtx, typedExpr); err != nil {
 			return nil, err

--- a/pkg/sql/logictest/testdata/logic_test/alter_table
+++ b/pkg/sql/logictest/testdata/logic_test/alter_table
@@ -2718,3 +2718,22 @@ SELECT count(*) from t_with_dropped_index_expr;
 
 statement ok
 RESUME JOB (SELECT job_id FROM crdb_internal.jobs WHERE description LIKE 'ALTER TABLE %t_with_dropped_index_expr DROP COLUMN j CASCADE%' AND status='paused' FETCH FIRST 1 ROWS ONLY);
+
+
+# In 23.1 we added support for default expressions which can be assignment cast
+# to the column type. This work introduced a bug whereby the backfill logic
+# would not apply the appropriate cast. This test ensures that such tables can
+# be backfilled.
+subtest add_column_with_default_expression_with_different_type
+
+statement ok
+CREATE TABLE t_93398 (c1 INT);
+INSERT INTO t_93398 VALUES (0);
+
+statement ok
+ALTER TABLE t_93398 ADD COLUMN c2 DECIMAL DEFAULT pi();
+
+query IT
+SELECT * FROM t_93398;
+----
+0  3.141592653589793


### PR DESCRIPTION
Backport 1/1 commits from #95398.

/cc @cockroachdb/release

---

… type

Since 22.2 we permit default expressions to contain types which are not exactly the same as the column type; it is valid to have an expression which can be cast to the column type in an assignment context. Generally, the optimizer handles inserting the assignment cast into the execution of the relevant mutations. Unfortunately, the cast was not present for backfills.

This PR detects the situation where a cast is needed and insert it directly into the plan of the backfill (or import).

Epic: None

Fixes: #93398

Release note (bug fix): Since 22.2, default expressions can have a type which differs from the type of the column so long as the expression's type can be cast in an assignment context. Unfortunately, this code had a bug when adding new columns. The code in the backfill logic was not sophisticated enough to know to add the cast; when such a default expression was added to a new column it would result in a panic during the backfill. This bug has now been fixed.

Release justification: Fixes a bug with newly introduced feature.
