### PR TITLE
changefeedccl: nilsafe kafkaSink.Close

### DIFF
--- a/pkg/ccl/changefeedccl/sink_kafka.go
+++ b/pkg/ccl/changefeedccl/sink_kafka.go
@@ -307,8 +307,10 @@ func (s *kafkaSink) newSyncProducer(client kafkaClient) (sarama.SyncProducer, er
 
 // Close implements the Sink interface.
 func (s *kafkaSink) Close() error {
-	close(s.stopWorkerCh)
-	s.worker.Wait()
+	if s.stopWorkerCh != nil {
+		close(s.stopWorkerCh)
+		s.worker.Wait()
+	}
 
 	if s.producer != nil {
 		// Ignore errors related to outstanding messages since we're either shutting


### PR DESCRIPTION
We were tolerating nils in other parts of Close, but not here, which can create a race condition if a sink gets closed before being fully initialized resulting in a panic.

Fixes #95278
Release note: None