### PR TITLE
roachtest: attach stack when recovering from panic in monitor

### DIFF
--- a/pkg/cmd/roachtest/monitor.go
+++ b/pkg/cmd/roachtest/monitor.go
@@ -98,7 +98,7 @@ func (m *monitorImpl) Go(fn func(context.Context) error) {
 			// Note that `t.Fatal` calls `panic(err)`, so this mechanism primarily
 			// enables that use case. But it also offers protection against accidental
 			// panics (NPEs and such) which should not bubble up to the runtime.
-			err = rErr
+			err = errors.WithStack(rErr)
 		}()
 		// Automatically clear the worker status message when the goroutine exits.
 		defer m.t.WorkerStatus()


### PR DESCRIPTION
roachtest's `Monitor` wraps the function passed to `Go()` so that if the function panics, an error is generated which is ultimately reported. The problem with the previous implementation is that the error would lose its associated stack trace, leaving the user with just the error message to try and figure out where the panic happened.

This changes the `Go()` wrapper function to attach the stack trace in case the monitored function panics. As a result, the corresponding `failure_*.log` file will include a stack trace that points to the source of the panic.

Informs #95416.

Release note: None