### PR TITLE
sql/catalog/schemaexpr: fix default expression assignment casts

### DIFF
--- a/pkg/sql/catalog/schemaexpr/BUILD.bazel
+++ b/pkg/sql/catalog/schemaexpr/BUILD.bazel
@@ -28,6 +28,7 @@ go_library(
         "//pkg/sql/parser",
         "//pkg/sql/pgwire/pgcode",
         "//pkg/sql/pgwire/pgerror",
+        "//pkg/sql/sem/builtins/builtinsregistry",
         "//pkg/sql/sem/cast",
         "//pkg/sql/sem/catid",
         "//pkg/sql/sem/eval",

--- a/pkg/sql/logictest/testdata/logic_test/alter_table
+++ b/pkg/sql/logictest/testdata/logic_test/alter_table
@@ -2770,3 +2770,14 @@ query IT
 SELECT * FROM t_93398;
 ----
 0  3.141592653589793
+
+statement error pgcode 22001 value too long for type CHAR
+ALTER TABLE t_93398 ADD COLUMN c3 CHAR(1) DEFAULT 'foo'::TEXT;
+
+statement ok
+ALTER TABLE t_93398 ADD COLUMN c3 "char" DEFAULT 'foo'::TEXT;
+
+query IT
+SELECT c1, c3 FROM t_93398;
+----
+0  f


### PR DESCRIPTION
In #95398, casts were added to default expressions during backfills when
the default expression's type was not equivalent to the target column's
type. This commit fixes two minor bugs with the previous fix:

  1. Casts were only added when types were not equivalent, i.e., when
     they had different families. Assignment casts must be added for
     non-identical types with the same family. For example, a `TEXT`
     default expression must be assignment cast to a `CHAR(1)` column,
     even though they are both in the string family.
  2. Explicit casts were added instead of assignment casts, which have
     different behavior. For example, an assignment cast will error when
     casting `TEXT` to `CHAR(1)` if the string has a length greater than
     one.

Some tests were added to show that default column backfills behave
consistently with Postgres.

Informs #93398

Epic: None

Release note: None
