### PR TITLE
release-22.1: roachtest: update import-cancellation ownership

### DIFF
--- a/pkg/cmd/roachtest/tests/import_cancellation.go
+++ b/pkg/cmd/roachtest/tests/import_cancellation.go
@@ -31,7 +31,7 @@ import (
 func registerImportCancellation(r registry.Registry) {
 	r.Add(registry.TestSpec{
 		Name:    `import-cancellation`,
-		Owner:   registry.OwnerStorage,
+		Owner:   registry.OwnerDisasterRecovery,
 		Timeout: 4 * time.Hour,
 		Cluster: r.MakeClusterSpec(6, spec.CPU(32)),
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {


### PR DESCRIPTION
Backport of #95368 for 22.1.

---

Update the ownership of the `import-cancellation` roachtest to better reflect CRL team boundaries. Import cancellation resides with the Disaster Recovery team.

Release note: None.

Epic: CRDB-20293

----

Release justification: Test only.