### PR TITLE
sql: execution-time erroring of remote region access for enforce_home_region setting

### DIFF
--- a/pkg/ccl/backupccl/backup_processor_planning.go
+++ b/pkg/ccl/backupccl/backup_processor_planning.go
@@ -181,7 +181,7 @@ func distBackup(
 	p.AddNoInputStage(corePlacement, execinfrapb.PostProcessSpec{}, []*types.T{}, execinfrapb.Ordering{})
 	p.PlanToStreamColMap = []int{}
 
-	dsp.FinalizePlan(planCtx, p)
+	dsp.FinalizePlan(ctx, planCtx, p)
 
 	metaFn := func(_ context.Context, meta *execinfrapb.ProducerMetadata) error {
 		if meta.BulkProcessorProgress != nil {

--- a/pkg/ccl/backupccl/restore_processor_planning.go
+++ b/pkg/ccl/backupccl/restore_processor_planning.go
@@ -229,7 +229,7 @@ func distRestore(
 			}
 		}
 
-		dsp.FinalizePlan(planCtx, p)
+		dsp.FinalizePlan(ctx, planCtx, p)
 		return p, planCtx, nil
 	}
 

--- a/pkg/ccl/changefeedccl/changefeed_dist.go
+++ b/pkg/ccl/changefeedccl/changefeed_dist.go
@@ -432,6 +432,7 @@ func makePlan(
 		p := planCtx.NewPhysicalPlan()
 		p.AddNoInputStage(aggregatorCorePlacement, execinfrapb.PostProcessSpec{}, changefeedResultTypes, execinfrapb.Ordering{})
 		p.AddSingleGroupStage(
+			ctx,
 			dsp.GatewayID(),
 			execinfrapb.ProcessorCoreUnion{ChangeFrontier: &changeFrontierSpec},
 			execinfrapb.PostProcessSpec{},
@@ -439,7 +440,7 @@ func makePlan(
 		)
 
 		p.PlanToStreamColMap = []int{1, 2, 3}
-		dsp.FinalizePlan(planCtx, p)
+		dsp.FinalizePlan(ctx, planCtx, p)
 
 		return p, planCtx, nil
 	}

--- a/pkg/ccl/logictestccl/testdata/logic_test/multi_region_remote_access_error
+++ b/pkg/ccl/logictestccl/testdata/logic_test/multi_region_remote_access_error
@@ -1,5 +1,11 @@
 # tenant-cluster-setting-override-opt: allow-multi-region-abstractions-for-secondary-tenants
 # LogicTest: multiregion-9node-3region-3azs !metamorphic-batch-sizes
+# TODO(msirek): Make this test work with the multiregion-9node-3region-3azs-vec-off config
+# Currently this test and other multiregion tests may flake when run under
+# the multiregion-9node-3region-3azs-vec-off config, possibly due to zone
+# configs not propagating in a timely manner after table creation.
+# Other tests like regional_by_row_query_behavior should also enable this
+# test config to verify any fix which is applied.
 
 # Set the closed timestamp interval to be short to shorten the amount of time
 # we need to wait for the system config to propagate.
@@ -23,10 +29,20 @@ SELECT gateway_region();
 ap-southeast-2
 
 statement ok
+CREATE TABLE t1 (a INT, b INT, c INT, primary key(a)) LOCALITY REGIONAL BY ROW;
+
+statement ok
+INSERT INTO t1 (crdb_region, a, b, c) VALUES ('ap-southeast-2', 1, 1, 1);
+INSERT INTO t1 (crdb_region, a, b, c) VALUES ('ca-central-1', 2, 1, 1);
+
+statement ok
 CREATE TABLE parent (
   p_id INT PRIMARY KEY,
   FAMILY (p_id)
 ) LOCALITY REGIONAL BY ROW;
+
+statement ok
+INSERT INTO parent VALUES(1);
 
 statement ok
 CREATE TABLE child (
@@ -35,6 +51,9 @@ CREATE TABLE child (
   INDEX (c_p_id),
   FAMILY (c_id, c_p_id)
 ) LOCALITY REGIONAL BY ROW;
+
+statement ok
+INSERT INTO child VALUES(10, 1);
 
 statement ok
 CREATE TABLE messages_global (
@@ -63,6 +82,9 @@ CREATE TABLE messages_rbr (
     INDEX msg_idx(message)
 )
 LOCALITY REGIONAL BY ROW
+
+statement ok
+INSERT INTO messages_rbr (account_id, message) VALUES (1, 'Hello, Region!');
 
 statement ok
 CREATE TABLE messages_rbr_alt (
@@ -174,20 +196,21 @@ SET enforce_home_region = true
 ### Regression tests for issue #89875
 
 # Non-DML statements should not error out due to enforce_home_region.
-query T
+query T retry
 SELECT table_name FROM [SHOW CREATE messages_global]
 ----
 messages_global
 
 # Non-DML SHOW RANGES statement on RBR table should succeed.
-query I
+skipif config multiregion-9node-3region-3azs-vec-off
+query I retry
 SELECT DISTINCT range_id FROM [SHOW RANGES FROM TABLE messages_rbr]
 ----
 54
 
 # Update does not fail when accessing all rows in messages_rbr because lookup
 # join does not error out the lookup table in phase 1.
-statement ok
+statement ok retry
 UPDATE messages_rbt SET account_id = -account_id WHERE account_id NOT IN (SELECT account_id FROM messages_rbr)
 
 # Update should fail accessing all rows in messages_rbr.
@@ -242,9 +265,10 @@ statement error pq: Query has no home region\. Try adding a filter on messages_r
 SELECT * FROM messages_rbr UNION ALL SELECT * FROM messages_rbt
 
 # UNION ALL where one branch scans 1 row of an RBR table should succeed.
-query TTT
-SELECT * FROM (SELECT * FROM messages_rbr LIMIT 1) UNION ALL SELECT * FROM messages_rbt
+query T retry
+SELECT * FROM (SELECT message FROM messages_rbr LIMIT 1) UNION ALL SELECT message FROM messages_rbt
 ----
+Hello, Region!
 
 ### End regression tests for issue #89875
 
@@ -258,6 +282,7 @@ SELECT * FROM messages_rbr rbr INNER LOOKUP JOIN messages_global g2 ON rbr.accou
 query I retry
 SELECT c_id FROM child, (SELECT * FROM [VALUES (1)]) v WHERE crdb_region = 'ap-southeast-2'
 ----
+10
 
 # Joins which may access all regions should error out in phase 1.
 statement error pq: Query has no home region\. Try adding a filter on p\.crdb_region and/or on key column \(p\.p_id\)\. Try adding a filter on c\.crdb_region and/or on key column \(c\.c_id\)\.
@@ -267,11 +292,8 @@ p.crdb_region = c.crdb_region LIMIT 1
 # Locality-optimized search of locality-optimized join and lookup join is
 # treated as having a home region.
 query T retry
-EXPLAIN SELECT * FROM parent p, child c WHERE p_id = c_p_id LIMIT 1
+SELECT * FROM [EXPLAIN SELECT * FROM parent p, child c WHERE p_id = c_p_id LIMIT 1] OFFSET 3
 ----
-distribution: local
-vectorized: true
-·
 • limit
 │ count: 1
 │
@@ -306,67 +328,6 @@ query TT retry
 SELECT * FROM child WHERE NOT EXISTS (SELECT * FROM parent WHERE p_id = c_p_id) AND c_id = 10
 ----
 
-query T retry
-EXPLAIN(OPT,VERBOSE) SELECT * FROM child WHERE NOT EXISTS (SELECT * FROM parent WHERE p_id = c_p_id) AND c_id = 10
-----
-anti-join (lookup parent)
- ├── columns: c_id:1 c_p_id:2
- ├── lookup expression
- │    └── filters
- │         ├── parent.crdb_region:7 IN ('ca-central-1', 'us-east-1') [outer=(7), constraints=(/7: [/'ca-central-1' - /'ca-central-1'] [/'us-east-1' - /'us-east-1']; tight)]
- │         └── c_p_id:2 = p_id:6 [outer=(2,6), constraints=(/2: (/NULL - ]; /6: (/NULL - ]), fd=(2)==(6), (6)==(2)]
- ├── lookup columns are key
- ├── cardinality: [0 - 1]
- ├── stats: [rows=1e-10]
- ├── cost: 10.6184167
- ├── key: ()
- ├── fd: ()-->(1,2)
- ├── distribution: ap-southeast-2
- ├── anti-join (lookup parent)
- │    ├── columns: c_id:1 c_p_id:2
- │    ├── lookup expression
- │    │    └── filters
- │    │         ├── parent.crdb_region:7 = 'ap-southeast-2' [outer=(7), immutable, constraints=(/7: [/'ap-southeast-2' - /'ap-southeast-2']; tight), fd=()-->(7)]
- │    │         └── c_p_id:2 = p_id:6 [outer=(2,6), constraints=(/2: (/NULL - ]; /6: (/NULL - ]), fd=(2)==(6), (6)==(2)]
- │    ├── lookup columns are key
- │    ├── cardinality: [0 - 1]
- │    ├── stats: [rows=0.6666667, distinct(1)=0.666667, null(1)=0, distinct(2)=0.665314, null(2)=0.00666667]
- │    ├── cost: 7.91921667
- │    ├── key: ()
- │    ├── fd: ()-->(1,2)
- │    ├── distribution: ap-southeast-2
- │    ├── locality-optimized-search
- │    │    ├── columns: c_id:1 c_p_id:2
- │    │    ├── left columns: c_id:11 c_p_id:12
- │    │    ├── right columns: c_id:16 c_p_id:17
- │    │    ├── cardinality: [0 - 1]
- │    │    ├── stats: [rows=1, distinct(1)=1, null(1)=0, distinct(2)=0.995512, null(2)=0.01]
- │    │    ├── cost: 6.02541667
- │    │    ├── key: ()
- │    │    ├── fd: ()-->(1,2)
- │    │    ├── distribution: ap-southeast-2
- │    │    ├── prune: (2)
- │    │    ├── scan child
- │    │    │    ├── columns: c_id:11 c_p_id:12
- │    │    │    ├── constraint: /13/11: [/'ap-southeast-2'/10 - /'ap-southeast-2'/10]
- │    │    │    ├── cardinality: [0 - 1]
- │    │    │    ├── stats: [rows=0.9333333, distinct(11)=0.933333, null(11)=0, distinct(13)=0.933333, null(13)=0, distinct(11,13)=0.933333, null(11,13)=0]
- │    │    │    ├── cost: 5.09555556
- │    │    │    ├── key: ()
- │    │    │    └── fd: ()-->(11,12)
- │    │    └── scan child
- │    │         ├── columns: c_id:16 c_p_id:17
- │    │         ├── constraint: /18/16
- │    │         │    ├── [/'ca-central-1'/10 - /'ca-central-1'/10]
- │    │         │    └── [/'us-east-1'/10 - /'us-east-1'/10]
- │    │         ├── cardinality: [0 - 1]
- │    │         ├── stats: [rows=0.9666667, distinct(16)=0.966667, null(16)=0, distinct(18)=0.966667, null(18)=0, distinct(16,18)=0.966667, null(16,18)=0]
- │    │         ├── cost: 9.09861111
- │    │         ├── key: ()
- │    │         └── fd: ()-->(16,17)
- │    └── filters (true)
- └── filters (true)
-
 statement ok
 SET locality_optimized_partitioned_index_scan = false
 
@@ -378,9 +339,10 @@ statement ok
 RESET locality_optimized_partitioned_index_scan
 
 # Locality optimized search is allowed.
-query T retry
+query I retry
 SELECT * FROM parent LIMIT 1
 ----
+1
 
 query T retry
 EXPLAIN(OPT) SELECT * FROM parent LIMIT 1
@@ -405,11 +367,8 @@ SELECT * FROM messages_rbr rbr, messages_rbt rbt WHERE rbr.account_id = rbt.acco
 ----
 
 query T retry
-EXPLAIN SELECT * FROM messages_rbr rbr, messages_rbt rbt WHERE rbr.account_id = rbt.account_id LIMIT 1
+SELECT * FROM [EXPLAIN SELECT * FROM messages_rbr rbr, messages_rbt rbt WHERE rbr.account_id = rbt.account_id LIMIT 1] OFFSET 3
 ----
-distribution: local
-vectorized: true
-·
 • limit
 │ count: 1
 │
@@ -426,11 +385,9 @@ vectorized: true
 
 # Lookup into a local RBT table is allowed.
 query T retry
-EXPLAIN SELECT * FROM (SELECT * FROM messages_rbr LIMIT 1) rbr, messages_rbt rbt WHERE rbr.account_id = rbt.account_id
+SELECT * FROM [EXPLAIN SELECT * FROM (SELECT * FROM messages_rbr LIMIT 1) rbr,
+               messages_rbt rbt WHERE rbr.account_id = rbt.account_id] OFFSET 3
 ----
-distribution: local
-vectorized: true
-·
 • lookup join
 │ table: messages_rbt@messages_rbt_pkey
 │ equality: (account_id) = (account_id)
@@ -618,6 +575,7 @@ AND rbr.crdb_region = 'ap-southeast-2'
 query T retry
 SELECT message from messages_rbr@msg_idx WHERE crdb_region = 'ap-southeast-2'
 ----
+Hello, Region!
 
 query T retry
 EXPLAIN(OPT) SELECT message from messages_rbr@msg_idx WHERE crdb_region = 'ap-southeast-2'
@@ -634,6 +592,7 @@ PREPARE s AS SELECT message from messages_rbr@msg_idx WHERE crdb_region = $1
 query T retry
 EXECUTE s('ap-southeast-2')
 ----
+Hello, Region!
 
 # Prepared statement accessing a remote span is disallowed.
 statement error pq: Query is not running in its home region. Try running the query from region 'us-east-1'.
@@ -681,6 +640,9 @@ SELECT * FROM multi_region_test_db.messages_global mr INNER LOOKUP JOIN non_mult
 
 statement ok
 ALTER DATABASE multi_region_test_db SURVIVE REGION FAILURE
+
+# Give zone configs time to propagate.
+sleep 5s
 
 statement ok
 USE multi_region_test_db
@@ -816,3 +778,252 @@ project
 
 statement ok
 RESET enforce_home_region
+
+# ---------------------------
+# enforce_home_region phase 2
+# ---------------------------
+
+# See https://github.com/cockroachdb/cockroach/issues/83819#issuecomment-1178301614
+
+# Reset messages_rbt locality back to the local region.
+statement ok
+ALTER TABLE messages_rbt SET LOCALITY REGIONAL BY TABLE IN "ap-southeast-2";
+
+statement ok
+INSERT INTO messages_rbt (account_id, message) VALUES (1, 'Hello, Zone!');
+
+statement ok
+INSERT INTO messages_rbt (account_id, message) VALUES (2, 'Hello, Nest!');
+
+statement ok
+INSERT INTO parent (crdb_region, p_id) VALUES('ca-central-1', 2);
+
+statement ok
+INSERT INTO child (crdb_region, c_id, c_p_id) VALUES('ap-southeast-2', 11, 2);
+
+subtest enforce_home_region_phase_2_vectorized
+
+statement ok
+SET enforce_home_region = true;
+
+# Querying the row in the local region succeeds.
+query III retry
+SELECT * FROM t1 WHERE a=1;
+----
+1  1  1
+
+# Querying the row in the remote region errors out.
+statement error pq: Query has no home region\. Try using a lower LIMIT value or running the query from a different region\.
+SELECT * FROM t1 WHERE a=2;
+
+# Locality-optimized join in the local region succeeds.
+query III retry
+SELECT * FROM parent p, child c WHERE p_id = c_p_id AND c_id = 10 LIMIT 1
+----
+1  10  1
+
+# Locality-optimized join with a remote region errors out.
+statement error pq: Query has no home region\. Try using a lower LIMIT value or running the query from a different region\.
+SELECT * FROM parent p, child c WHERE p_id = c_p_id AND c_id = 11 LIMIT 1
+
+# A locality-optimized lookup join which can be satisfied in the local region
+# should succeed.
+query III retry
+SELECT * FROM parent p, child c WHERE p_id = c_p_id LIMIT 1
+----
+1  10  1
+
+# Locality-optimized lookup join with enough local rows to satisfy the LIMIT
+# succeeds.
+query T retry
+SELECT rbr.message FROM messages_rbr rbr, (SELECT * FROM messages_rbt ORDER BY account_id LIMIT 1) rbt
+       WHERE rbr.account_id = rbt.account_id LIMIT 1
+----
+Hello, Region!
+
+# Locality-optimized semijoin in the local region succeeds.
+query T retry
+SELECT message FROM (SELECT * FROM messages_rbt ORDER BY account_id LIMIT 1) rbt WHERE account_id IN
+                     (SELECT account_id FROM messages_rbr rbr) LIMIT 1;
+----
+Hello, Zone!
+
+# Locality-optimized semijoin reading into a remote region fails.
+# Prior to fixing a bug in `DistributeExpr.GetDistributions`, this query would
+# return a different error message.
+statement error pq: Query has no home region\. Try using a lower LIMIT value or running the query from a different region\.
+SELECT message FROM (SELECT * FROM messages_rbt ORDER BY account_id LIMIT 2) rbt WHERE account_id IN
+                     (SELECT account_id FROM messages_rbr rbr) ORDER BY 1 LIMIT 2;
+
+# Locality-optimized semijoin in the local region with an ordered join reader
+# succeeds.
+query I
+SELECT account_id FROM (SELECT * FROM messages_rbt ORDER BY account_id LIMIT 1) rbt WHERE account_id IN
+                     (SELECT account_id FROM messages_rbr rbr) ORDER BY 1 LIMIT 1;
+----
+1
+
+# Locality-optimized semijoin reading into a remote region with an ordered join
+# reader fails.
+statement error pq: Query has no home region\. Try using a lower LIMIT value or running the query from a different region\.
+SELECT account_id FROM (SELECT * FROM messages_rbt ORDER BY account_id LIMIT 2) rbt WHERE account_id IN
+                     (SELECT account_id FROM messages_rbr rbr) ORDER BY 1 LIMIT 2;
+
+# Locality-optimized left outer join in the local region succeeds.
+query TT retry
+SELECT rbt.message, rbr.message FROM (SELECT * FROM messages_rbt ORDER BY account_id LIMIT 1) rbt LEFT OUTER LOOKUP JOIN
+                    messages_rbr rbr ON rbr.account_id = rbt.account_id LIMIT 1;
+----
+Hello, Zone!  Hello, Region!
+
+# Locality-optimized left outer join reading into a remote region fails.
+statement error pq: Query has no home region\. Try using a lower LIMIT value or running the query from a different region\.
+SELECT rbt.message, rbr.message FROM (SELECT * FROM messages_rbt ORDER BY account_id LIMIT 2) rbt LEFT OUTER LOOKUP JOIN
+                    messages_rbr rbr ON rbr.account_id = rbt.account_id LIMIT 2;
+
+# Locality-optimized antijoin in the local region succeeds.
+query T retry
+SELECT message FROM (SELECT * FROM messages_rbt ORDER BY account_id LIMIT 1) rbt WHERE account_id NOT IN
+                     (SELECT account_id FROM messages_rbr rbr) LIMIT 1
+----
+
+# Locality-optimized antijoin reading into a remote region fails.
+statement error pq: Query has no home region\. Try using a lower LIMIT value or running the query from a different region\.
+SELECT message from (SELECT * FROM messages_rbt ORDER BY account_id LIMIT 2) rbt WHERE account_id NOT IN
+                     (SELECT account_id FROM messages_rbr rbr) LIMIT 2
+
+# Locality-optimized lookup join with less local rows than the LIMIT errors
+# out.
+statement error pq: Query has no home region\. Try using a lower LIMIT value or running the query from a different region\.
+SELECT rbr.message FROM messages_rbr rbr, messages_rbt rbt WHERE rbr.account_id = rbt.account_id LIMIT 4
+
+# A locality-optimized search of lookup joins reading local rows succeeds.
+query T retry
+SELECT rbr.message FROM messages_rbr rbr INNER LOOKUP JOIN messages_rbt rbt
+       ON rbr.account_id = rbt.account_id LIMIT 1
+----
+Hello, Region!
+
+# A locality-optimized search of lookup joins attempting a remote read fails.
+statement error pq: Query has no home region\. Try using a lower LIMIT value or running the query from a different region\.
+SELECT rbr.message FROM messages_rbr rbr INNER LOOKUP JOIN messages_rbt rbt
+       ON rbr.account_id = rbt.account_id LIMIT 2
+
+statement ok
+RESET enforce_home_region
+
+### Now repeat the tests using the row engine.
+subtest enforce_home_region_phase_2_non_vectorized
+
+statement ok
+SET enforce_home_region = true;
+
+statement ok
+SET vectorize = off;
+
+# Querying the row in the local region succeeds.
+query III retry
+SELECT * FROM t1 WHERE a=1;
+----
+1  1  1
+
+# Querying the row in the remote region errors out.
+statement error pq: Query has no home region\. Try using a lower LIMIT value or running the query from a different region\.
+SELECT * FROM t1 WHERE a=2;
+
+# Locality-optimized join in the local region succeeds.
+query III retry
+SELECT * FROM parent p, child c WHERE p_id = c_p_id AND c_id = 10 LIMIT 1
+----
+1  10  1
+
+# Locality-optimized join with a remote region errors out.
+statement error pq: Query has no home region\. Try using a lower LIMIT value or running the query from a different region\.
+SELECT * FROM parent p, child c WHERE p_id = c_p_id AND c_id = 11 LIMIT 1
+
+# A locality-optimized lookup join which can be satisfied in the local region
+# should succeed.
+query III retry
+SELECT * FROM parent p, child c WHERE p_id = c_p_id LIMIT 1
+----
+1  10  1
+
+# Locality-optimized lookup join with enough local rows to satisfy the LIMIT
+# succeeds.
+query T retry
+SELECT rbr.message FROM messages_rbr rbr, (SELECT * FROM messages_rbt ORDER BY account_id LIMIT 1) rbt
+       WHERE rbr.account_id = rbt.account_id LIMIT 1
+----
+Hello, Region!
+
+# Locality-optimized semijoin in the local region succeeds.
+query T retry
+SELECT message FROM (SELECT * FROM messages_rbt ORDER BY account_id LIMIT 1) rbt WHERE account_id IN
+                     (SELECT account_id FROM messages_rbr rbr) LIMIT 1;
+----
+Hello, Zone!
+
+# Locality-optimized semijoin reading into a remote region fails.
+statement error pq: Query has no home region\. Try using a lower LIMIT value or running the query from a different region\.
+SELECT message FROM (SELECT * FROM messages_rbt ORDER BY account_id LIMIT 2) rbt WHERE account_id IN
+                     (SELECT account_id FROM messages_rbr rbr) ORDER BY 1 LIMIT 2;
+
+# Locality-optimized semijoin in the local region with an ordered join reader
+# succeeds.
+query I
+SELECT account_id FROM (SELECT * FROM messages_rbt ORDER BY account_id LIMIT 1) rbt WHERE account_id IN
+                     (SELECT account_id FROM messages_rbr rbr) ORDER BY 1 LIMIT 1;
+----
+1
+
+# Locality-optimized semijoin reading into a remote region with an ordered join
+# reader fails.
+statement error pq: Query has no home region\. Try using a lower LIMIT value or running the query from a different region\.
+SELECT account_id FROM (SELECT * FROM messages_rbt ORDER BY account_id LIMIT 2) rbt WHERE account_id IN
+                     (SELECT account_id FROM messages_rbr rbr) ORDER BY 1 LIMIT 2;
+
+# Locality-optimized left outer join in the local region succeeds.
+query TT retry
+SELECT rbt.message, rbr.message FROM (SELECT * FROM messages_rbt ORDER BY account_id LIMIT 1) rbt LEFT OUTER LOOKUP JOIN
+                    messages_rbr rbr ON rbr.account_id = rbt.account_id LIMIT 1;
+----
+Hello, Zone!  Hello, Region!
+
+# Locality-optimized left outer join reading into a remote region fails.
+statement error pq: Query has no home region\. Try using a lower LIMIT value or running the query from a different region\.
+SELECT rbt.message, rbr.message FROM (SELECT * FROM messages_rbt ORDER BY account_id LIMIT 2) rbt LEFT OUTER LOOKUP JOIN
+                    messages_rbr rbr ON rbr.account_id = rbt.account_id LIMIT 2;
+
+# Locality-optimized antijoin in the local region succeeds.
+query T retry
+SELECT message FROM (SELECT * FROM messages_rbt ORDER BY account_id LIMIT 1) rbt WHERE account_id NOT IN
+                     (SELECT account_id FROM messages_rbr rbr) LIMIT 1
+----
+
+# Locality-optimized antijoin reading into a remote region fails.
+statement error pq: Query has no home region\. Try using a lower LIMIT value or running the query from a different region\.
+SELECT message from (SELECT * FROM messages_rbt ORDER BY account_id LIMIT 2) rbt WHERE account_id NOT IN
+                     (SELECT account_id FROM messages_rbr rbr) LIMIT 2
+
+# Locality-optimized lookup join with less local rows than the LIMIT errors
+# out.
+statement error pq: Query has no home region\. Try using a lower LIMIT value or running the query from a different region\.
+SELECT rbr.message FROM messages_rbr rbr, messages_rbt rbt WHERE rbr.account_id = rbt.account_id LIMIT 4
+
+# A locality-optimized search of lookup joins reading local rows succeeds.
+query T retry
+SELECT rbr.message FROM messages_rbr rbr INNER LOOKUP JOIN messages_rbt rbt
+       ON rbr.account_id = rbt.account_id LIMIT 1
+----
+Hello, Region!
+
+# A locality-optimized search of lookup joins attempting a remote read fails.
+statement error pq: Query has no home region\. Try using a lower LIMIT value or running the query from a different region\.
+SELECT rbr.message FROM messages_rbr rbr INNER LOOKUP JOIN messages_rbt rbt
+       ON rbr.account_id = rbt.account_id LIMIT 2
+
+statement ok
+RESET enforce_home_region
+
+statement ok
+RESET vectorize

--- a/pkg/ccl/streamingccl/streamingest/stream_ingestion_processor_planning.go
+++ b/pkg/ccl/streamingccl/streamingest/stream_ingestion_processor_planning.go
@@ -131,12 +131,12 @@ func distStreamIngest(
 
 	// The ResultRouters from the previous stage will feed in to the
 	// StreamIngestionFrontier processor.
-	p.AddSingleGroupStage(base.SQLInstanceID(gatewayNodeID),
+	p.AddSingleGroupStage(ctx, base.SQLInstanceID(gatewayNodeID),
 		execinfrapb.ProcessorCoreUnion{StreamIngestionFrontier: streamIngestionFrontierSpec},
 		execinfrapb.PostProcessSpec{}, streamIngestionResultTypes)
 
 	p.PlanToStreamColMap = []int{0}
-	dsp.FinalizePlan(planCtx, p)
+	dsp.FinalizePlan(ctx, planCtx, p)
 
 	rw := sql.NewRowResultWriter(nil /* rowContainer */)
 

--- a/pkg/sql/colexec/serial_unordered_synchronizer_test.go
+++ b/pkg/sql/colexec/serial_unordered_synchronizer_test.go
@@ -54,7 +54,10 @@ func TestSerialUnorderedSynchronizer(t *testing.T) {
 			},
 		}
 	}
-	s := NewSerialUnorderedSynchronizer(inputs)
+	s := NewSerialUnorderedSynchronizer(inputs,
+		0,   /* serialInputIdxExclusiveUpperBound */
+		nil, /* exceedsInputIdxExclusiveUpperBoundError */
+	)
 	s.Init(ctx)
 	resultBatches := 0
 	for {

--- a/pkg/sql/colflow/vectorized_flow.go
+++ b/pkg/sql/colflow/vectorized_flow.go
@@ -961,7 +961,11 @@ func (s *vectorizedFlowCreator) setupInput(
 			}
 			s.closers = append(s.closers, os)
 		} else if input.Type == execinfrapb.InputSyncSpec_SERIAL_UNORDERED || opt == flowinfra.FuseAggressively {
-			sync := colexec.NewSerialUnorderedSynchronizer(inputStreamOps)
+			var err error
+			if input.EnforceHomeRegionError != nil {
+				err = input.EnforceHomeRegionError.ErrorDetail(ctx)
+			}
+			sync := colexec.NewSerialUnorderedSynchronizer(inputStreamOps, input.EnforceHomeRegionStreamExclusiveUpperBound, err)
 			opWithMetaInfo = colexecargs.OpWithMetaInfo{
 				Root:            sync,
 				MetadataSources: colexecop.MetadataSources{sync},

--- a/pkg/sql/distsql_plan_backfill.go
+++ b/pkg/sql/distsql_plan_backfill.go
@@ -106,7 +106,7 @@ func (dsp *DistSQLPlanner) createBackfillerPhysicalPlan(
 		pIdx := p.AddProcessor(proc)
 		p.ResultRouters[i] = pIdx
 	}
-	dsp.FinalizePlan(planCtx, p)
+	dsp.FinalizePlan(ctx, planCtx, p)
 	return p, nil
 }
 
@@ -178,7 +178,7 @@ func (dsp *DistSQLPlanner) createIndexBackfillerMergePhysicalPlan(
 		pIdx := p.AddProcessor(proc)
 		p.ResultRouters[i] = pIdx
 	}
-	dsp.FinalizePlan(planCtx, p)
+	dsp.FinalizePlan(ctx, planCtx, p)
 	return p, nil
 }
 

--- a/pkg/sql/distsql_plan_ctas.go
+++ b/pkg/sql/distsql_plan_ctas.go
@@ -54,6 +54,6 @@ func PlanAndRunCTAS(
 
 	// Make copy of evalCtx as Run might modify it.
 	evalCtxCopy := planner.ExtendedEvalContextCopy()
-	dsp.FinalizePlan(planCtx, physPlan)
+	dsp.FinalizePlan(ctx, planCtx, physPlan)
 	dsp.Run(ctx, planCtx, txn, physPlan, recv, evalCtxCopy, nil /* finishedSetupFn */)
 }

--- a/pkg/sql/distsql_plan_stats.go
+++ b/pkg/sql/distsql_plan_stats.go
@@ -59,6 +59,7 @@ var maxTimestampAge = settings.RegisterDurationSetting(
 )
 
 func (dsp *DistSQLPlanner) createAndAttachSamplers(
+	ctx context.Context,
 	p *PhysicalPlan,
 	desc catalog.TableDescriptor,
 	tableStats []*stats.TableStatistic,
@@ -149,6 +150,7 @@ func (dsp *DistSQLPlanner) createAndAttachSamplers(
 		node = p.Processors[p.ResultRouters[0]].SQLInstanceID
 	}
 	p.AddSingleGroupStage(
+		ctx,
 		node,
 		execinfrapb.ProcessorCoreUnion{SampleAggregator: agg},
 		execinfrapb.PostProcessSpec{},
@@ -326,6 +328,7 @@ func (dsp *DistSQLPlanner) createPartialStatsPlan(
 		sketchSpec = append(sketchSpec, spec)
 	}
 	return dsp.createAndAttachSamplers(
+		ctx,
 		p,
 		desc,
 		tableStats,
@@ -447,6 +450,7 @@ func (dsp *DistSQLPlanner) createStatsPlan(
 	}
 
 	return dsp.createAndAttachSamplers(
+		ctx,
 		p,
 		desc,
 		tableStats,
@@ -507,7 +511,7 @@ func (dsp *DistSQLPlanner) planAndRunCreateStats(
 		return err
 	}
 
-	dsp.FinalizePlan(planCtx, physPlan)
+	dsp.FinalizePlan(ctx, planCtx, physPlan)
 
 	recv := MakeDistSQLReceiver(
 		ctx,

--- a/pkg/sql/distsql_running.go
+++ b/pkg/sql/distsql_running.go
@@ -1610,7 +1610,7 @@ func (dsp *DistSQLPlanner) planAndRunSubquery(
 	if err != nil {
 		return err
 	}
-	dsp.finalizePlanWithRowCount(subqueryPlanCtx, subqueryPhysPlan, subqueryPlan.rowCount)
+	dsp.finalizePlanWithRowCount(ctx, subqueryPlanCtx, subqueryPhysPlan, subqueryPlan.rowCount)
 
 	// TODO(arjun): #28264: We set up a row container, wrap it in a row
 	// receiver, and use it and serialize the results of the subquery. The type
@@ -1754,7 +1754,7 @@ func (dsp *DistSQLPlanner) PlanAndRun(
 		recv.SetError(err)
 		return
 	}
-	dsp.finalizePlanWithRowCount(planCtx, physPlan, planCtx.planner.curPlan.mainRowCount)
+	dsp.finalizePlanWithRowCount(ctx, planCtx, physPlan, planCtx.planner.curPlan.mainRowCount)
 	recv.expectedRowsRead = int64(physPlan.TotalEstimatedScannedRows)
 	dsp.Run(ctx, planCtx, txn, physPlan, recv, evalCtx, finishedSetupFn)
 }
@@ -1945,7 +1945,7 @@ func (dsp *DistSQLPlanner) planAndRunPostquery(
 	if err != nil {
 		return err
 	}
-	dsp.FinalizePlan(postqueryPlanCtx, postqueryPhysPlan)
+	dsp.FinalizePlan(ctx, postqueryPlanCtx, postqueryPhysPlan)
 
 	postqueryRecv := recv.clone()
 	defer postqueryRecv.Release()

--- a/pkg/sql/distsql_spec_exec_factory.go
+++ b/pkg/sql/distsql_spec_exec_factory.go
@@ -620,7 +620,7 @@ func (e *distSQLSpecExecFactory) ConstructStreamingSetOp(
 
 // ConstructUnionAll is part of the exec.Factory interface.
 func (e *distSQLSpecExecFactory) ConstructUnionAll(
-	left, right exec.Node, reqOrdering exec.OutputOrdering, hardLimit uint64,
+	left, right exec.Node, reqOrdering exec.OutputOrdering, hardLimit uint64, enforceHomeRegion bool,
 ) (exec.Node, error) {
 	return nil, unimplemented.NewWithIssue(47473, "experimental opt-driven distsql planning: union all")
 }
@@ -669,6 +669,7 @@ func (e *distSQLSpecExecFactory) ConstructLookupJoin(
 	reqOrdering exec.OutputOrdering,
 	locking opt.Locking,
 	limitHint int64,
+	remoteOnlyLookups bool,
 ) (exec.Node, error) {
 	// TODO (rohany): Implement production of system columns by the underlying scan here.
 	return nil, unimplemented.NewWithIssue(47473, "experimental opt-driven distsql planning: lookup join")

--- a/pkg/sql/distsql_spec_exec_factory.go
+++ b/pkg/sql/distsql_spec_exec_factory.go
@@ -293,6 +293,11 @@ func (e *distSQLSpecExecFactory) ConstructScan(
 	return makePlanMaybePhysical(p, nil /* planNodesToClose */), err
 }
 
+// Ctx implements the Factory interface.
+func (e *distSQLSpecExecFactory) Ctx() context.Context {
+	return e.ctx
+}
+
 // checkExprsAndMaybeMergeLastStage is a helper method that returns a
 // recommendation about exprs' distribution. If one of the expressions cannot
 // be distributed, then all expressions cannot be distributed either. In such
@@ -315,7 +320,7 @@ func (e *distSQLSpecExecFactory) checkExprsAndMaybeMergeLastStage(
 				// make sure that there is a single stream on a node. We could
 				// do so on one of the nodes that streams originate from, but
 				// for now we choose the gateway.
-				physPlan.EnsureSingleStreamOnGateway()
+				physPlan.EnsureSingleStreamOnGateway(e.ctx)
 			}
 			break
 		}
@@ -373,7 +378,7 @@ func (e *distSQLSpecExecFactory) ConstructSerializingProject(
 	n exec.Node, cols []exec.NodeColumnOrdinal, colNames []string,
 ) (exec.Node, error) {
 	physPlan, plan := getPhysPlan(n)
-	physPlan.EnsureSingleStreamOnGateway()
+	physPlan.EnsureSingleStreamOnGateway(e.ctx)
 	projection := make([]uint32, len(cols))
 	for i, col := range cols {
 		projection[i] = uint32(physPlan.PlanToStreamColMap[col])
@@ -594,7 +599,7 @@ func (e *distSQLSpecExecFactory) ConstructDistinct(
 		errorOnDup,
 		e.dsp.convertOrdering(ReqOrdering(reqOrdering), physPlan.PlanToStreamColMap),
 	)
-	e.dsp.addDistinctProcessors(physPlan, spec)
+	e.dsp.addDistinctProcessors(e.ctx, physPlan, spec)
 	// Since addition of distinct processors doesn't change any properties of
 	// the physical plan, we don't need to update any of those.
 	return plan, nil
@@ -629,7 +634,7 @@ func (e *distSQLSpecExecFactory) ConstructSort(
 	input exec.Node, ordering exec.OutputOrdering, alreadyOrderedPrefix int,
 ) (exec.Node, error) {
 	physPlan, plan := getPhysPlan(input)
-	e.dsp.addSorters(physPlan, colinfo.ColumnOrdering(ordering), alreadyOrderedPrefix, 0 /* limit */)
+	e.dsp.addSorters(e.ctx, physPlan, colinfo.ColumnOrdering(ordering), alreadyOrderedPrefix, 0 /* limit */)
 	// Since addition of sorters doesn't change any properties of the physical
 	// plan, we don't need to update any of those.
 	return plan, nil
@@ -811,7 +816,7 @@ func (e *distSQLSpecExecFactory) ConstructTopK(
 		return nil, errors.New("negative or zero value for LIMIT")
 	}
 	// No already ordered prefix.
-	e.dsp.addSorters(physPlan, colinfo.ColumnOrdering(ordering), alreadyOrderedPrefix, k)
+	e.dsp.addSorters(e.ctx, physPlan, colinfo.ColumnOrdering(ordering), alreadyOrderedPrefix, k)
 	// Since addition of topk doesn't change any properties of
 	// the physical plan, we don't need to update any of those.
 	return plan, nil
@@ -1235,7 +1240,7 @@ func (e *distSQLSpecExecFactory) constructHashOrMergeJoin(
 		rightPlanDistribution:    rightPhysPlan.Distribution,
 		allowPartialDistribution: e.planningMode != distSQLLocalOnlyPlanning,
 	}
-	p := e.dsp.planJoiners(planCtx, &info, ReqOrdering(reqOrdering))
+	p := e.dsp.planJoiners(e.ctx, planCtx, &info, ReqOrdering(reqOrdering))
 	p.ResultColumns = resultColumns
 	return makePlanMaybePhysical(p, append(leftPlan.physPlan.planNodesToClose, rightPlan.physPlan.planNodesToClose...)), nil
 }

--- a/pkg/sql/execinfrapb/data.proto
+++ b/pkg/sql/execinfrapb/data.proto
@@ -135,6 +135,18 @@ message InputSyncSpec {
 
   // Schema for the streams entering this synchronizer.
   repeated sql.sem.types.T column_types = 4;
+
+  // EnforceHomeRegionStreamExclusiveUpperBound is one greater than the maximum
+  // stream input index this synchronizer will read into. It is only used if
+  // non-zero. Attempts to read a stream input index greater than or equal to
+  // this value will cause the query to error out before the read attempt is
+  // made.
+  optional uint32 enforce_home_region_stream_exclusive_upper_bound = 5 [(gogoproto.nullable) = false];
+
+  // EnforceHomeRegionError is the error to return when
+  // EnforceHomeRegionStreamExclusiveUpperBound is exceeded. This error must be
+  // set when EnforceHomeRegionStreamExclusiveUpperBound is non-zero.
+  optional Error enforce_home_region_error = 6;
 }
 
 // OutputRouterSpec is the specification for the output router of a processor;

--- a/pkg/sql/execinfrapb/processors_sql.proto
+++ b/pkg/sql/execinfrapb/processors_sql.proto
@@ -397,6 +397,11 @@ message JoinReaderSpec {
   // a prefix of input columns followed by index (lookup) columns without
   // requiring a (buffered) sort.
   optional bool maintain_lookup_ordering = 22 [(gogoproto.nullable) = false];
+
+  // RemoteOnlyLookups is true when this join is defined with only lookups
+  // that read into remote regions, though the lookups are defined in
+  // LookupExpr, not RemoteLookupExpr.
+  optional bool remote_only_lookups = 23 [(gogoproto.nullable) = false];
 }
 
 // SorterSpec is the specification for a "sorting aggregator". A sorting

--- a/pkg/sql/explain_plan.go
+++ b/pkg/sql/explain_plan.go
@@ -90,7 +90,7 @@ func (e *explainPlanNode) startExec(params runParams) error {
 		} else {
 			// There might be an issue making the physical plan, but that should not
 			// cause an error or panic, so swallow the error. See #40677 for example.
-			distSQLPlanner.finalizePlanWithRowCount(planCtx, physicalPlan, plan.mainRowCount)
+			distSQLPlanner.finalizePlanWithRowCount(params.ctx, planCtx, physicalPlan, plan.mainRowCount)
 			ob.AddDistribution(physicalPlan.Distribution.String())
 			flows := physicalPlan.GenerateFlowSpecs()
 

--- a/pkg/sql/explain_vec.go
+++ b/pkg/sql/explain_vec.go
@@ -60,7 +60,7 @@ func (n *explainVecNode) startExec(params runParams) error {
 		return err
 	}
 
-	distSQLPlanner.finalizePlanWithRowCount(planCtx, physPlan, n.plan.mainRowCount)
+	distSQLPlanner.finalizePlanWithRowCount(params.ctx, planCtx, physPlan, n.plan.mainRowCount)
 	flows := physPlan.GenerateFlowSpecs()
 	flowCtx, cleanup := newFlowCtxForExplainPurposes(params.ctx, planCtx, params.p)
 	defer cleanup()

--- a/pkg/sql/importer/import_processor_planning.go
+++ b/pkg/sql/importer/import_processor_planning.go
@@ -111,7 +111,7 @@ func distImport(
 
 		p.PlanToStreamColMap = []int{0, 1}
 
-		dsp.FinalizePlan(planCtx, p)
+		dsp.FinalizePlan(ctx, planCtx, p)
 		return p, planCtx, nil
 	}
 

--- a/pkg/sql/lookup_join.go
+++ b/pkg/sql/lookup_join.go
@@ -72,6 +72,11 @@ type lookupJoinNode struct {
 	reqOrdering ReqOrdering
 
 	limitHint int64
+
+	// remoteOnlyLookups is true when this join is defined with only lookups
+	// that read into remote regions, though the lookups are defined in
+	// lookupExpr, not remoteLookupExpr.
+	remoteOnlyLookups bool
 }
 
 func (lj *lookupJoinNode) startExec(params runParams) error {

--- a/pkg/sql/opt/exec/execbuilder/relational.go
+++ b/pkg/sql/opt/exec/execbuilder/relational.go
@@ -1706,6 +1706,7 @@ func (b *Builder) buildSetOp(set memo.RelExpr) (execPlan, error) {
 	}
 
 	hardLimit := uint64(0)
+	enforceHomeRegion := false
 	if set.Op() == opt.LocalityOptimizedSearchOp {
 		if !b.disableTelemetry {
 			telemetry.Inc(sqltelemetry.LocalityOptimizedSearchUseCounter)
@@ -1720,6 +1721,7 @@ func (b *Builder) buildSetOp(set memo.RelExpr) (execPlan, error) {
 		if set.Relational().Cardinality.Max != math.MaxUint32 {
 			hardLimit = uint64(set.Relational().Cardinality.Max)
 		}
+		enforceHomeRegion = b.IsANSIDML && b.evalCtx.SessionData().EnforceHomeRegion
 	}
 
 	ep := execPlan{}
@@ -1732,7 +1734,7 @@ func (b *Builder) buildSetOp(set memo.RelExpr) (execPlan, error) {
 	reqOrdering := ep.reqOrdering(set)
 
 	if typ == tree.UnionOp && all {
-		ep.root, err = b.factory.ConstructUnionAll(left.root, right.root, reqOrdering, hardLimit)
+		ep.root, err = b.factory.ConstructUnionAll(left.root, right.root, reqOrdering, hardLimit, enforceHomeRegion)
 	} else if len(streamingOrdering) > 0 {
 		if typ != tree.UnionOp {
 			b.recordJoinAlgorithm(exec.MergeJoin)
@@ -2353,6 +2355,7 @@ func (b *Builder) buildLookupJoin(join *memo.LookupJoinExpr) (execPlan, error) {
 		res.reqOrdering(join),
 		locking,
 		join.RequiredPhysical().LimitHintInt64(),
+		join.RemoteOnlyLookups,
 	)
 	if err != nil {
 		return execPlan{}, err

--- a/pkg/sql/opt/exec/explain/explain_factory.go
+++ b/pkg/sql/opt/exec/explain/explain_factory.go
@@ -11,6 +11,8 @@
 package explain
 
 import (
+	"context"
+
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/colinfo"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/exec"
 )
@@ -25,6 +27,11 @@ type Factory struct {
 }
 
 var _ exec.ExplainFactory = &Factory{}
+
+// Ctx implements the Factory interface.
+func (f *Factory) Ctx() context.Context {
+	return f.wrappedFactory.Ctx()
+}
 
 // Node in a plan tree; records the operation and arguments passed to the
 // factory method and provides access to the corresponding exec.Node (produced

--- a/pkg/sql/opt/exec/explain/plan_gist_factory.go
+++ b/pkg/sql/opt/exec/explain/plan_gist_factory.go
@@ -112,6 +112,11 @@ type PlanGistFactory struct {
 
 var _ exec.Factory = &PlanGistFactory{}
 
+// Ctx implements the Factory interface.
+func (f *PlanGistFactory) Ctx() context.Context {
+	return f.wrappedFactory.Ctx()
+}
+
 // writeAndHash writes an arbitrary slice of bytes to the buffer and hashes each
 // byte.
 func (f *PlanGistFactory) writeAndHash(data []byte) int {

--- a/pkg/sql/opt/exec/factory.opt
+++ b/pkg/sql/opt/exec/factory.opt
@@ -215,11 +215,17 @@ define StreamingSetOp {
 # left node to completion and possibly short-circuit if the limit is reached
 # before executing the right node. The limit is guaranteed but the short-circuit
 # behavior is not.
+#
+# If true, EnforceHomeRegion specifies that the UNION ALL operation should
+# error out if it attempts to read rows beyond the leftmost branch. This
+# should only be set if performing the UNION ALL on behalf of a
+# locality-optimized search.
 define UnionAll {
     Left exec.Node
     Right exec.Node
     ReqOrdering exec.OutputOrdering
     HardLimit uint64
+    EnforceHomeRegion bool
 }
 
 # Sort performs a resorting of the rows produced by the input node.
@@ -266,7 +272,8 @@ define IndexJoin {
 # contains the lookup join conditions targeting ranges located on local nodes
 # (relative to the gateway region), and remoteLookupExpr contains the lookup
 # join conditions targeting remote nodes; lookupCols are ordinals for the table
-# columns we are retrieving.
+# columns we are retrieving. If RemoteOnlyLookups is true, all lookups target
+# rows in remote regions.
 #
 # The node produces the columns in the input and (unless join type is
 # LeftSemiJoin or LeftAntiJoin) the lookupCols, ordered by ordinal. The ON
@@ -287,6 +294,7 @@ define LookupJoin {
     ReqOrdering exec.OutputOrdering
     Locking opt.Locking
     LimitHint int64
+    RemoteOnlyLookups bool
 }
 
 # InvertedJoin performs a lookup join into an inverted index.

--- a/pkg/sql/opt/memo/expr.go
+++ b/pkg/sql/opt/memo/expr.go
@@ -296,7 +296,7 @@ func (e *DistributeExpr) GetDistributions() (target, source physical.Distributio
 	if distributionProvidedPhysical != nil && inputDistributionProvidedPhysical != nil {
 		target = distributionProvidedPhysical.Distribution
 		source = inputDistributionProvidedPhysical.Distribution
-		return target, source, ok
+		return target, source, true
 	}
 	return physical.Distribution{}, physical.Distribution{}, false
 }

--- a/pkg/sql/opt/ops/relational.opt
+++ b/pkg/sql/opt/ops/relational.opt
@@ -502,6 +502,11 @@ define LookupJoinPrivate {
     # different wait policies are used by SELECT .. FOR UPDATE/SHARE SKIP
     # LOCKED/NOWAIT statements to react differently to conflicting locks.
     Locking Locking
+
+    # RemoteOnlyLookups is true when this join is defined with only lookups
+    # that read into remote regions, though the lookups are defined in
+    # LookupExpr, not RemoteLookupExpr.
+    RemoteOnlyLookups bool
     _ JoinPrivate
 }
 

--- a/pkg/sql/opt/optgen/cmd/optgen/exec_factory_gen.go
+++ b/pkg/sql/opt/optgen/cmd/optgen/exec_factory_gen.go
@@ -29,6 +29,7 @@ func (g *execFactoryGen) generate(compiled *lang.CompiledExpr, w io.Writer) {
 	g.w.write("package exec\n\n")
 
 	g.w.nestIndent("import (\n")
+	g.w.writeIndent("\"context\"\n\n")
 	g.w.writeIndent("\"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb\"\n")
 	g.w.writeIndent("\"github.com/cockroachdb/cockroach/pkg/sql/catalog/colinfo\"\n")
 	g.w.writeIndent("\"github.com/cockroachdb/cockroach/pkg/sql/opt/cat\"\n")
@@ -84,6 +85,11 @@ func (g *execFactoryGen) genExecFactory() {
 	g.w.writeIndent("rootRowCount int64,\n")
 	g.w.unnest(") (Plan, error)\n")
 
+	g.w.write("\n")
+	g.w.nest("// Ctx returns the ctx of this execution.\n")
+	g.w.writeIndent("Ctx() context.Context\n")
+	g.w.unnest("\n")
+
 	for _, define := range g.compiled.Defines {
 		g.w.write("\n")
 		g.w.write("// Construct%s creates a node for a %s operation.\n", define.Name, define.Name)
@@ -117,6 +123,11 @@ func (g *execFactoryGen) genStubFactory() {
 	g.w.writeIndent("rootRowCount int64,\n")
 	g.w.unnest(") (Plan, error) {\n")
 	g.w.nestIndent("return struct{}{}, nil\n")
+	g.w.unnest("}\n")
+
+	g.w.write("\n")
+	g.w.nest("func (StubFactory) Ctx() context.Context {\n")
+	g.w.writeIndent("return context.Background()\n")
 	g.w.unnest("}\n")
 
 	for _, define := range g.compiled.Defines {

--- a/pkg/sql/opt/optgen/cmd/optgen/testdata/execfactory
+++ b/pkg/sql/opt/optgen/cmd/optgen/testdata/execfactory
@@ -22,6 +22,8 @@ define Values {
 package exec
 
 import (
+	"context"
+
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/colinfo"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/inverted"
@@ -71,6 +73,9 @@ type Factory interface {
 		rootRowCount int64,
 	) (Plan, error)
 
+	// Ctx returns the ctx of this execution.
+	Ctx() context.Context
+
 	// ConstructScan creates a node for a Scan operation.
 	//
 	// Scan runs a scan of a specified index of a table, possibly with an index
@@ -105,6 +110,10 @@ func (StubFactory) ConstructPlan(
 	rootRowCount int64,
 ) (Plan, error) {
 	return struct{}{}, nil
+}
+
+func (StubFactory) Ctx() context.Context {
+	return context.Background()
 }
 
 func (StubFactory) ConstructScan(

--- a/pkg/sql/opt/xform/join_funcs.go
+++ b/pkg/sql/opt/xform/join_funcs.go
@@ -1286,6 +1286,18 @@ func (c *CustomFuncs) EmptyFiltersExpr() memo.FiltersExpr {
 	return memo.EmptyFiltersExpr
 }
 
+// CreateRemoteOnlyLookupJoinPrivate creates a new lookup join private from the
+// given private and replaces the LookupExpr with the given filter. It also
+// marks the private as locality optimized and as a join which only does lookups
+// into remote regions.
+func (c *CustomFuncs) CreateRemoteOnlyLookupJoinPrivate(
+	remoteLookupExpr memo.FiltersExpr, private *memo.LookupJoinPrivate,
+) *memo.LookupJoinPrivate {
+	newPrivate := c.CreateLocalityOptimizedLookupJoinPrivate(remoteLookupExpr, c.e.funcs.EmptyFiltersExpr(), private)
+	newPrivate.RemoteOnlyLookups = true
+	return newPrivate
+}
+
 // CreateLocalityOptimizedLookupJoinPrivate creates a new lookup join private
 // from the given private and replaces the LookupExpr and RemoteLookupExpr with
 // the given filters. It also marks the private as locality optimized.
@@ -2148,5 +2160,6 @@ func (c *CustomFuncs) mapInputSideOfLookupJoin(
 	constFilters := c.e.f.RemapCols(&lookupJoinExpr.ConstFilters, colMap).(*memo.FiltersExpr)
 	mappedLookupJoinExpr.ConstFilters = *constFilters
 	mappedLookupJoinExpr.Locking = lookupJoinExpr.Locking
+	mappedLookupJoinExpr.RemoteOnlyLookups = lookupJoinExpr.RemoteOnlyLookups
 	return mappedLookupJoinExpr
 }

--- a/pkg/sql/opt/xform/rules/join.opt
+++ b/pkg/sql/opt/xform/rules/join.opt
@@ -590,7 +590,10 @@
 # one of the other regions, the first plan would be slightly faster.
 #
 # Note: we also apply a similar optimization for other lookup joins; see
-# GenerateLocalityOptimizedLookupJoin.
+# GenerateLocalityOptimizedLookupJoin. The `enforce_home_region` setting
+# behavior of erroring out before an attempt to access remote rows is made
+# is handled by marking the second anti-join as remote-only, which is
+# propagated to structures in the execution engine to trigger the error.
 [GenerateLocalityOptimizedAntiJoin, Explore]
 (LookupJoin
     $input:*
@@ -619,11 +622,7 @@
         )
     )
     $on
-    (CreateLocalityOptimizedLookupJoinPrivate
-        $remoteExpr
-        (EmptyFiltersExpr)
-        $private
-    )
+    (CreateRemoteOnlyLookupJoinPrivate $remoteExpr $private)
 )
 
 # GenerateLocalityOptimizedLookupJoin converts a semi, inner, or left lookup

--- a/pkg/sql/opt_exec_factory.go
+++ b/pkg/sql/opt_exec_factory.go
@@ -67,6 +67,11 @@ func newExecFactory(ctx context.Context, p *planner) *execFactory {
 	}
 }
 
+// Ctx implements the Factory interface.
+func (ef *execFactory) Ctx() context.Context {
+	return ef.ctx
+}
+
 func (ef *execFactory) getDatumAlloc() *tree.DatumAlloc {
 	if ef.alloc == nil {
 		ef.alloc = &tree.DatumAlloc{}

--- a/pkg/sql/opt_exec_factory.go
+++ b/pkg/sql/opt_exec_factory.go
@@ -557,6 +557,7 @@ func (ef *execFactory) ConstructHashSetOp(
 ) (exec.Node, error) {
 	return ef.planner.newUnionNode(
 		typ, all, left.(planNode), right.(planNode), nil, nil, 0, /* hardLimit */
+		false, /* enforceHomeRegion */
 	)
 }
 
@@ -575,13 +576,14 @@ func (ef *execFactory) ConstructStreamingSetOp(
 		right.(planNode),
 		streamingOrdering,
 		ReqOrdering(reqOrdering),
-		0, /* hardLimit */
+		0,     /* hardLimit */
+		false, /* enforceHomeRegion */
 	)
 }
 
 // ConstructUnionAll is part of the exec.Factory interface.
 func (ef *execFactory) ConstructUnionAll(
-	left, right exec.Node, reqOrdering exec.OutputOrdering, hardLimit uint64,
+	left, right exec.Node, reqOrdering exec.OutputOrdering, hardLimit uint64, enforceHomeRegion bool,
 ) (exec.Node, error) {
 	return ef.planner.newUnionNode(
 		tree.UnionOp,
@@ -591,6 +593,7 @@ func (ef *execFactory) ConstructUnionAll(
 		colinfo.ColumnOrdering(reqOrdering),
 		ReqOrdering(reqOrdering),
 		hardLimit,
+		enforceHomeRegion,
 	)
 }
 
@@ -689,6 +692,7 @@ func (ef *execFactory) ConstructLookupJoin(
 	reqOrdering exec.OutputOrdering,
 	locking opt.Locking,
 	limitHint int64,
+	remoteOnlyLookups bool,
 ) (exec.Node, error) {
 	if table.IsVirtualTable() {
 		return ef.constructVirtualTableLookupJoin(joinType, input, table, index, eqCols, lookupCols, onCond)
@@ -723,6 +727,7 @@ func (ef *execFactory) ConstructLookupJoin(
 		isSecondJoinInPairedJoiner: isSecondJoinInPairedJoiner,
 		reqOrdering:                ReqOrdering(reqOrdering),
 		limitHint:                  limitHint,
+		remoteOnlyLookups:          remoteOnlyLookups,
 	}
 	n.eqCols = make([]int, len(eqCols))
 	for i, c := range eqCols {

--- a/pkg/sql/physicalplan/physical_plan.go
+++ b/pkg/sql/physicalplan/physical_plan.go
@@ -168,9 +168,6 @@ type SerialStreamErrorSpec struct {
 	// `SerialInputIdxExclusiveUpperBound` - 1 streams have been executed to
 	// completion without satisfying the query.
 	ExceedsInputIdxExclusiveUpperBoundError error
-
-	// Ctx is the context for setting up the Error.
-	Ctx context.Context
 }
 
 // NewPhysicalInfrastructure initializes a PhysicalInfrastructure that can then
@@ -363,6 +360,7 @@ func (p *PhysicalPlan) AddNoGroupingStage(
 // forceSerialization determines whether the streams are forced to be serialized
 // (i.e. whether we don't want any parallelism).
 func (p *PhysicalPlan) MergeResultStreams(
+	ctx context.Context,
 	resultRouters []ProcessorIdx,
 	sourceRouterSlot int,
 	ordering execinfrapb.Ordering,
@@ -388,7 +386,7 @@ func (p *PhysicalPlan) MergeResultStreams(
 				proc.Spec.Input[destInput].EnforceHomeRegionStreamExclusiveUpperBound =
 					serialStreamErrorSpec.SerialInputIdxExclusiveUpperBound
 				proc.Spec.Input[destInput].EnforceHomeRegionError =
-					execinfrapb.NewError(serialStreamErrorSpec.Ctx, serialStreamErrorSpec.ExceedsInputIdxExclusiveUpperBoundError)
+					execinfrapb.NewError(ctx, serialStreamErrorSpec.ExceedsInputIdxExclusiveUpperBoundError)
 			}
 		} else {
 			proc.Spec.Input[destInput].Type = execinfrapb.InputSyncSpec_PARALLEL_UNORDERED
@@ -409,6 +407,7 @@ func (p *PhysicalPlan) MergeResultStreams(
 // parallelized) which consists of a single processor on the specified node. The
 // previous stage (ResultRouters) are all connected to this processor.
 func (p *PhysicalPlan) AddSingleGroupStage(
+	ctx context.Context,
 	sqlInstanceID base.SQLInstanceID,
 	core execinfrapb.ProcessorCoreUnion,
 	post execinfrapb.PostProcessSpec,
@@ -437,7 +436,7 @@ func (p *PhysicalPlan) AddSingleGroupStage(
 	pIdx := p.AddProcessor(proc)
 
 	// Connect the result routers to the processor.
-	p.MergeResultStreams(p.ResultRouters, 0, p.MergeOrdering, pIdx, 0, false, /* forceSerialization */
+	p.MergeResultStreams(ctx, p.ResultRouters, 0, p.MergeOrdering, pIdx, 0, false, /* forceSerialization */
 		SerialStreamErrorSpec{},
 	)
 
@@ -468,12 +467,13 @@ func (p *PhysicalPlan) ReplaceLastStage(
 // EnsureSingleStreamOnGateway ensures that there is only one stream on the
 // gateway node in the plan (meaning it possibly merges multiple streams or
 // brings a single stream from a remote node to the gateway).
-func (p *PhysicalPlan) EnsureSingleStreamOnGateway() {
+func (p *PhysicalPlan) EnsureSingleStreamOnGateway(ctx context.Context) {
 	// If we don't already have a single result router on the gateway, add a
 	// single grouping stage.
 	if len(p.ResultRouters) != 1 ||
 		p.Processors[p.ResultRouters[0]].SQLInstanceID != p.GatewaySQLInstanceID {
 		p.AddSingleGroupStage(
+			ctx,
 			p.GatewaySQLInstanceID,
 			execinfrapb.ProcessorCoreUnion{Noop: &execinfrapb.NoopCoreSpec{}},
 			execinfrapb.PostProcessSpec{},
@@ -877,6 +877,7 @@ func (p *PhysicalPlan) AddLimit(
 		post.Limit = uint64(count)
 	}
 	p.AddSingleGroupStage(
+		ctx,
 		p.GatewaySQLInstanceID,
 		execinfrapb.ProcessorCoreUnion{Noop: &execinfrapb.NoopCoreSpec{}},
 		post,
@@ -970,6 +971,7 @@ func MergePlans(
 // AddJoinStage adds join processors at each of the specified nodes, and wires
 // the left and right-side outputs to these processors.
 func (p *PhysicalPlan) AddJoinStage(
+	ctx context.Context,
 	sqlInstanceIDs []base.SQLInstanceID,
 	core execinfrapb.ProcessorCoreUnion,
 	post execinfrapb.PostProcessSpec,
@@ -1029,11 +1031,11 @@ func (p *PhysicalPlan) AddJoinStage(
 
 		// Connect left routers to the processor's first input. Currently the join
 		// node doesn't care about the orderings of the left and right results.
-		p.MergeResultStreams(leftRouters, bucket, leftMergeOrd, pIdx, 0, false, /* forceSerialization */
+		p.MergeResultStreams(ctx, leftRouters, bucket, leftMergeOrd, pIdx, 0, false, /* forceSerialization */
 			SerialStreamErrorSpec{},
 		)
 		// Connect right routers to the processor's second input if it has one.
-		p.MergeResultStreams(rightRouters, bucket, rightMergeOrd, pIdx, 1, false, /* forceSerialization */
+		p.MergeResultStreams(ctx, rightRouters, bucket, rightMergeOrd, pIdx, 1, false, /* forceSerialization */
 			SerialStreamErrorSpec{},
 		)
 
@@ -1045,6 +1047,7 @@ func (p *PhysicalPlan) AddJoinStage(
 // logical stream on the specified nodes and connects them to the previous
 // stage via a hash router.
 func (p *PhysicalPlan) AddStageOnNodes(
+	ctx context.Context,
 	sqlInstanceIDs []base.SQLInstanceID,
 	core execinfrapb.ProcessorCoreUnion,
 	post execinfrapb.PostProcessSpec,
@@ -1086,7 +1089,7 @@ func (p *PhysicalPlan) AddStageOnNodes(
 	// Connect the result streams to the processors.
 	for bucket := 0; bucket < len(sqlInstanceIDs); bucket++ {
 		pIdx := ProcessorIdx(pIdxStart + bucket)
-		p.MergeResultStreams(routers, bucket, mergeOrd, pIdx, 0, false, /* forceSerialization */
+		p.MergeResultStreams(ctx, routers, bucket, mergeOrd, pIdx, 0, false, /* forceSerialization */
 			SerialStreamErrorSpec{},
 		)
 	}
@@ -1104,6 +1107,7 @@ func (p *PhysicalPlan) AddStageOnNodes(
 // TODO(yuzefovich): If there's a strong key on the left or right side, we
 // can elide the distinct stage on that side.
 func (p *PhysicalPlan) AddDistinctSetOpStage(
+	ctx context.Context,
 	sqlInstanceIDs []base.SQLInstanceID,
 	joinCore execinfrapb.ProcessorCoreUnion,
 	distinctCores []execinfrapb.ProcessorCoreUnion,
@@ -1122,7 +1126,7 @@ func (p *PhysicalPlan) AddDistinctSetOpStage(
 	// before the EXCEPT ALL join).
 	distinctProcs := make(map[base.SQLInstanceID][]ProcessorIdx)
 	p.AddStageOnNodes(
-		sqlInstanceIDs, distinctCores[0], execinfrapb.PostProcessSpec{}, eqCols,
+		ctx, sqlInstanceIDs, distinctCores[0], execinfrapb.PostProcessSpec{}, eqCols,
 		leftTypes, leftTypes, leftMergeOrd, leftRouters,
 	)
 	for _, leftDistinctProcIdx := range p.ResultRouters {
@@ -1130,7 +1134,7 @@ func (p *PhysicalPlan) AddDistinctSetOpStage(
 		distinctProcs[node] = append(distinctProcs[node], leftDistinctProcIdx)
 	}
 	p.AddStageOnNodes(
-		sqlInstanceIDs, distinctCores[1], execinfrapb.PostProcessSpec{}, eqCols,
+		ctx, sqlInstanceIDs, distinctCores[1], execinfrapb.PostProcessSpec{}, eqCols,
 		rightTypes, rightTypes, rightMergeOrd, rightRouters,
 	)
 	for _, rightDistinctProcIdx := range p.ResultRouters {
@@ -1182,6 +1186,7 @@ func (p *PhysicalPlan) AddDistinctSetOpStage(
 // same node. A fix for that is much more complicated, requiring remembering
 // extra state in the PhysicalPlan.
 func (p *PhysicalPlan) EnsureSingleStreamPerNode(
+	ctx context.Context,
 	forceSerialization bool,
 	post execinfrapb.PostProcessSpec,
 	serialStreamErrorSpec SerialStreamErrorSpec,
@@ -1237,7 +1242,7 @@ func (p *PhysicalPlan) EnsureSingleStreamPerNode(
 			},
 		}
 		mergedProcIdx := p.AddProcessor(proc)
-		p.MergeResultStreams(streams, 0 /* sourceRouterSlot */, p.MergeOrdering, mergedProcIdx,
+		p.MergeResultStreams(ctx, streams, 0 /* sourceRouterSlot */, p.MergeOrdering, mergedProcIdx,
 			0 /* destInput */, forceSerialization, serialStreamErrorSpec,
 		)
 		p.ResultRouters[i] = mergedProcIdx

--- a/pkg/sql/rowexec/joinreader.go
+++ b/pkg/sql/rowexec/joinreader.go
@@ -28,6 +28,8 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/execstats"
 	"github.com/cockroachdb/cockroach/pkg/sql/memsize"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/row"
 	"github.com/cockroachdb/cockroach/pkg/sql/rowcontainer"
 	"github.com/cockroachdb/cockroach/pkg/sql/rowenc"
@@ -240,6 +242,12 @@ type joinReader struct {
 	// scanStats is collected from the trace after we finish doing work for this
 	// join.
 	scanStats execstats.ScanStats
+
+	// Set errorOnLookup to true to cause the join to error out just prior to
+	// performing a lookup. This is currently only set when the join contains
+	// only lookups to rows in remote regions and remote accesses are set to
+	// error out via a session setting.
+	errorOnLookup bool
 }
 
 var _ execinfra.Processor = &joinReader{}
@@ -333,6 +341,9 @@ func newJoinReader(
 		return nil, err
 	}
 
+	errorOnLookup := spec.RemoteOnlyLookups && flowCtx.EvalCtx.SessionData().EnforceHomeRegion &&
+		flowCtx.EvalCtx.Planner != nil && flowCtx.EvalCtx.Planner.IsANSIDML()
+
 	jr := &joinReader{
 		fetchSpec:                         spec.FetchSpec,
 		splitFamilyIDs:                    spec.SplitFamilyIDs,
@@ -346,6 +357,7 @@ func newJoinReader(
 		usesStreamer:                      useStreamer,
 		lookupBatchBytesLimit:             rowinfra.BytesLimit(spec.LookupBatchBytesLimit),
 		limitHintHelper:                   execinfra.MakeLimitHintHelper(spec.LimitHint, post),
+		errorOnLookup:                     errorOnLookup,
 	}
 	if readerType != indexJoinReaderType {
 		jr.groupingState = &inputBatchGroupingState{doGrouping: spec.LeftJoinWithPairedJoiner}
@@ -1008,8 +1020,15 @@ func (jr *joinReader) readInput() (
 	return jrPerformingLookup, outRow, nil
 }
 
+var noHomeRegionError = pgerror.Newf(pgcode.QueryHasNoHomeRegion,
+	"Query has no home region. Try using a lower LIMIT value or running the query from a different region.")
+
 // performLookup reads the next batch of index rows.
 func (jr *joinReader) performLookup() (joinReaderState, *execinfrapb.ProducerMetadata) {
+	if jr.errorOnLookup {
+		jr.MoveToDraining(noHomeRegionError)
+		return jrStateUnknown, jr.DrainHelper()
+	}
 	for {
 		// Fetch the next row and tell the strategy to process it.
 		lookedUpRow, spanID, err := jr.fetcher.NextRow(jr.Ctx())

--- a/pkg/sql/rowexec/joinreader_strategies.go
+++ b/pkg/sql/rowexec/joinreader_strategies.go
@@ -186,6 +186,10 @@ func (s *joinReaderNoOrderingStrategy) generateRemoteSpans() (roachpb.Spans, []i
 	if !ok {
 		return nil, nil, errors.AssertionFailedf("generateRemoteSpans can only be called for locality optimized lookup joins")
 	}
+
+	if s.EvalCtx.SessionData().EnforceHomeRegion && s.EvalCtx.Planner.IsANSIDML() {
+		return nil, nil, noHomeRegionError
+	}
 	s.remoteSpansGenerated = true
 	return gen.generateRemoteSpans(s.Ctx(), s.inputRows)
 }
@@ -590,6 +594,9 @@ func (s *joinReaderOrderingStrategy) generateRemoteSpans() (roachpb.Spans, []int
 	gen, ok := s.joinReaderSpanGenerator.(*localityOptimizedSpanGenerator)
 	if !ok {
 		return nil, nil, errors.AssertionFailedf("generateRemoteSpans can only be called for locality optimized lookup joins")
+	}
+	if s.EvalCtx.SessionData().EnforceHomeRegion && s.EvalCtx.Planner.IsANSIDML() {
+		return nil, nil, noHomeRegionError
 	}
 	s.remoteSpansGenerated = true
 	return gen.generateRemoteSpans(s.Ctx(), s.inputRows)

--- a/pkg/sql/rowflow/input_sync.go
+++ b/pkg/sql/rowflow/input_sync.go
@@ -379,6 +379,16 @@ type serialUnorderedSynchronizer struct {
 	serialSynchronizerBase
 
 	srcIndex int
+
+	// serialSrcIndexExclusiveUpperBound indicates the srcIndex to error out on
+	// should execution fail to halt prior to this input. This is only valid if
+	// non-zero.
+	serialSrcIndexExclusiveUpperBound uint32
+
+	// exceedsSrcIndexExclusiveUpperBoundErrorFunc produces the error to return to
+	// the receiver when srcIndex has incremented to match
+	// serialSrcIndexExclusiveUpperBound.
+	exceedsSrcIndexExclusiveUpperBoundErrorFunc func() error
 }
 
 var _ execinfra.RowSource = &serialUnorderedSynchronizer{}
@@ -395,6 +405,15 @@ func (u *serialUnorderedSynchronizer) Next() (rowenc.EncDatumRow, *execinfrapb.P
 		// If we see nil,nil go to next source.
 		if row == nil && metadata == nil {
 			u.srcIndex++
+			if u.serialSrcIndexExclusiveUpperBound > 0 && u.srcIndex >= int(u.serialSrcIndexExclusiveUpperBound) &&
+				(u.state == notInitialized || u.state == returningRows) {
+				// Do not return the error in the `draining` or `drainBuffered` states
+				// because we don't want to indicate that a drain operation has
+				// failed, and it is only necessary to return the error once.
+				meta := execinfrapb.GetProducerMeta()
+				meta.Err = u.exceedsSrcIndexExclusiveUpperBoundErrorFunc()
+				return nil, meta
+			}
 			continue
 		}
 
@@ -431,7 +450,11 @@ func (u *serialUnorderedSynchronizer) ConsumerClosed() {
 // sources should be consumed in index order (which is useful when you intend to
 // fuse the synchronizer and its inputs later; see FuseAggressively).
 func makeSerialSync(
-	ordering colinfo.ColumnOrdering, evalCtx *eval.Context, sources []execinfra.RowSource,
+	ordering colinfo.ColumnOrdering,
+	evalCtx *eval.Context,
+	sources []execinfra.RowSource,
+	serialSrcIndexExclusiveUpperBound uint32,
+	exceedsSrcIndexExclusiveUpperBoundErrorFunc func() error,
 ) (execinfra.RowSource, error) {
 	if len(sources) < 2 {
 		return nil, errors.Errorf("only %d sources for serial synchronizer", len(sources))
@@ -462,7 +485,9 @@ func makeSerialSync(
 		sync = os
 	} else {
 		sync = &serialUnorderedSynchronizer{
-			serialSynchronizerBase: base,
+			serialSynchronizerBase:                      base,
+			serialSrcIndexExclusiveUpperBound:           serialSrcIndexExclusiveUpperBound,
+			exceedsSrcIndexExclusiveUpperBoundErrorFunc: exceedsSrcIndexExclusiveUpperBoundErrorFunc,
 		}
 	}
 

--- a/pkg/sql/rowflow/input_sync_test.go
+++ b/pkg/sql/rowflow/input_sync_test.go
@@ -116,7 +116,10 @@ func TestOrderedSync(t *testing.T) {
 		}
 		evalCtx := eval.NewTestingEvalContext(cluster.MakeTestingClusterSettings())
 		defer evalCtx.Stop(context.Background())
-		src, err := makeSerialSync(c.ordering, evalCtx, sources)
+		src, err := makeSerialSync(c.ordering, evalCtx, sources,
+			0,   /* serialSrcIndexExclusiveUpperBound */
+			nil, /* exceedsSrcIndexExclusiveUpperBoundErrorFunc */
+		)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -156,7 +159,10 @@ func TestOrderedSyncDrainBeforeNext(t *testing.T) {
 	ctx := context.Background()
 	evalCtx := eval.NewTestingEvalContext(cluster.MakeTestingClusterSettings())
 	defer evalCtx.Stop(ctx)
-	o, err := makeSerialSync(colinfo.ColumnOrdering{}, evalCtx, sources)
+	o, err := makeSerialSync(colinfo.ColumnOrdering{}, evalCtx, sources,
+		0,   /* serialSrcIndexExclusiveUpperBound */
+		nil, /* exceedsSrcIndexExclusiveUpperBoundErrorFunc */
+	)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/sql/rowflow/row_based_flow.go
+++ b/pkg/sql/rowflow/row_based_flow.go
@@ -328,7 +328,16 @@ func (f *rowBasedFlow) setupInputSyncs(
 				if is.Type == execinfrapb.InputSyncSpec_ORDERED {
 					ordering = execinfrapb.ConvertToColumnOrdering(is.Ordering)
 				}
-				sync, err = makeSerialSync(ordering, f.EvalCtx, streams)
+				var returnErrorFunc func() error
+				if is.EnforceHomeRegionError != nil {
+					returnErrorFunc = func() error {
+						return is.EnforceHomeRegionError.ErrorDetail(ctx)
+					}
+				}
+				sync, err = makeSerialSync(ordering, f.EvalCtx, streams,
+					is.EnforceHomeRegionStreamExclusiveUpperBound,
+					returnErrorFunc,
+				)
 				if err != nil {
 					return nil, err
 				}

--- a/pkg/sql/ttl/ttljob/ttljob.go
+++ b/pkg/sql/ttl/ttljob/ttljob.go
@@ -290,7 +290,7 @@ func (t rowLevelTTLResumer) Resume(ctx context.Context, execCtx interface{}) err
 		)
 		physicalPlan.PlanToStreamColMap = []int{}
 
-		distSQLPlanner.FinalizePlan(planCtx, physicalPlan)
+		distSQLPlanner.FinalizePlan(ctx, planCtx, physicalPlan)
 
 		metadataCallbackWriter := sql.NewMetadataOnlyMetadataCallbackWriter()
 

--- a/pkg/sql/union.go
+++ b/pkg/sql/union.go
@@ -93,6 +93,14 @@ type unionNode struct {
 	// the limit is reached before executing the right node. The limit is
 	// guaranteed but the short-circuit behavior is not.
 	hardLimit uint64
+
+	// enforceHomeRegion is true if this UNION ALL is a locality-optimized search
+	// and the session setting `enforce_home_region` is true, indicating the
+	// operation should error out if the query cannot be satisfied by accessing
+	// only rows in the local region. The left branch of the UNION ALL is set up
+	// to only read rows in the local region when this flag is true, and the
+	// right branch reads rows in remote regions.
+	enforceHomeRegion bool
 }
 
 func (p *planner) newUnionNode(
@@ -102,6 +110,7 @@ func (p *planner) newUnionNode(
 	streamingOrdering colinfo.ColumnOrdering,
 	reqOrdering ReqOrdering,
 	hardLimit uint64,
+	enforceHomeRegion bool,
 ) (planNode, error) {
 	emitAll := false
 	switch typ {
@@ -162,6 +171,7 @@ func (p *planner) newUnionNode(
 		streamingOrdering: streamingOrdering,
 		reqOrdering:       reqOrdering,
 		hardLimit:         hardLimit,
+		enforceHomeRegion: enforceHomeRegion,
 	}
 	return node, nil
 }


### PR DESCRIPTION
Informs #83819

enforce_home_region phase 2
---------------------------
This adds dynamic checking of whether locality-optimized searches
and locality-optimized lookup joins must access rows in remote regions.
If the `enforce_home_region` session setting is true, and remote access is
required in these operations, the query errors out. Both vectorized and
non-vectorized execution is handled.

Locality-optimized search is handled by setting an exclusive upper bound
on the inputs to the `SerialUnorderedSynchronizer` built for this operation,
and erroring out if the synchronizer iterates to that input before the query
finishes execution due to a LimitOp consumer.

Locality-optimized joins besides antijoin are handled by erroring out if
`joinReader.performLookup` calls `jr.strategy.generateRemoteSpans` and
is about to issue a lookup to a remote region.

Locality-optimized antijoins come as a pair, first the local lookup join,
and then the output of that feeds into a remote lookup join. This PR adds
tagging of that 2nd lookup join as having only lookups of remote rows so
that any attempted lookup by that 2nd join errors out.

Release note: None

physicalplan: pass ctx in more execution code paths
----

This commit passes the `context.Context` in all code paths necessary to
make it accessible to `PhysicalPlan.MergeResultStreams` and adds a `Ctx`
method to `exec.Factory` to make the context accessible in more locations.

Release note: None