### PR TITLE
release: do not use custom field for SRE issues

### DIFF
--- a/pkg/cmd/release/jira.go
+++ b/pkg/cmd/release/jira.go
@@ -24,9 +24,6 @@ const jiraBaseURL = "https://cockroachlabs.atlassian.net/"
 const dryRunProject = "REL"
 const sreDryRunProject = "RE"
 
-// for DeployToClusterIssue
-const customFieldHasSLAKey = "customfield_10073"
-
 // Jira uses Wiki syntax, see https://jira.atlassian.com/secure/WikiRendererHelpAction.jspa?section=all
 const trackingIssueTemplate = `
 * Version: *{{ .Version }}*
@@ -209,18 +206,14 @@ func createSREIssue(client *jiraClient, release releaseInfo, dryRun bool) (jiraI
 	}
 	projectKey := "SREOPS"
 	summary := fmt.Sprintf("Deploy %s to release qualification cluster", release.nextReleaseVersion)
-	customFields := make(jira.CustomFields)
-	customFields[customFieldHasSLAKey] = "Yes"
 	if dryRun {
 		projectKey = sreDryRunProject
-		customFields = nil
 	}
 	issue := newIssue(&jiraIssue{
-		ProjectKey:   projectKey,
-		TypeName:     "Task",
-		Summary:      summary,
-		Description:  description,
-		CustomFields: customFields,
+		ProjectKey:  projectKey,
+		TypeName:    "Task",
+		Summary:     summary,
+		Description: description,
 	})
 	return createJiraIssue(client, issue)
 }


### PR DESCRIPTION
Previously, we submitted Jira issues for the SRE team. Recently they changed the project settings and there is no more "Has SLA" field.

This PR removes the custom field from the submissions. NExt step will be adding the "Due date" field.

Epic: none
Part of: RE-361
Release note: None