### PR TITLE
kv: Fix typo in log line

### DIFF
--- a/pkg/kv/kvprober/planner.go
+++ b/pkg/kv/kvprober/planner.go
@@ -156,7 +156,7 @@ func (p *meta2Planner) next(ctx context.Context) (Step, error) {
 		happyInterval := p.happyInterval()
 		if limit := p.getRateLimit(happyInterval, p.settings); timeSinceLastPlan < limit {
 			return Step{}, errors.Newf("planner rate limit hit: "+
-				"timSinceLastPlan=%v, happyInterval=%v, limit=%v", timeSinceLastPlan, happyInterval, limit)
+				"timeSinceLastPlan=%v, happyInterval=%v, limit=%v", timeSinceLastPlan, happyInterval, limit)
 		}
 		p.lastPlanTime = p.now()
 


### PR DESCRIPTION
  This commit fixes a very small typo in the KV Prober rate limit logic.

Epic: None