### PR TITLE
schemachangerccl: rename generated tests

### DIFF
--- a/pkg/ccl/schemachangerccl/BUILD.bazel
+++ b/pkg/ccl/schemachangerccl/BUILD.bazel
@@ -51,7 +51,7 @@ sctest_gen(
     ccl = True,
     new_cluster_func = "newCluster",
     package = "schemachangerccl",
-    suffix = "base",
+    suffix = "_base",
     test_data = [
         "//pkg/sql/schemachanger:end_to_end_testdata",
     ],
@@ -68,7 +68,7 @@ sctest_gen(
     ccl = True,
     new_cluster_func = "newCluster",
     package = "schemachangerccl",
-    suffix = "ccl",
+    suffix = "_ccl",
     test_data = glob(["testdata/end_to_end/**"]),
     tests = [
         "Backup",

--- a/pkg/ccl/schemachangerccl/backup_base_generated_test.go
+++ b/pkg/ccl/schemachangerccl/backup_base_generated_test.go
@@ -18,122 +18,122 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 )
 
-func TestBackupbase_add_column(t *testing.T) {
+func TestBackup_base_add_column(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	sctest.Backup(t, "pkg/sql/schemachanger/testdata/end_to_end/add_column", newCluster)
 }
-func TestBackupbase_add_column_default_seq(t *testing.T) {
+func TestBackup_base_add_column_default_seq(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	sctest.Backup(t, "pkg/sql/schemachanger/testdata/end_to_end/add_column_default_seq", newCluster)
 }
-func TestBackupbase_add_column_default_unique(t *testing.T) {
+func TestBackup_base_add_column_default_unique(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	sctest.Backup(t, "pkg/sql/schemachanger/testdata/end_to_end/add_column_default_unique", newCluster)
 }
-func TestBackupbase_add_column_no_default(t *testing.T) {
+func TestBackup_base_add_column_no_default(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	sctest.Backup(t, "pkg/sql/schemachanger/testdata/end_to_end/add_column_no_default", newCluster)
 }
-func TestBackupbase_alter_table_add_check_vanilla(t *testing.T) {
+func TestBackup_base_alter_table_add_check_vanilla(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	sctest.Backup(t, "pkg/sql/schemachanger/testdata/end_to_end/alter_table_add_check_vanilla", newCluster)
 }
-func TestBackupbase_alter_table_add_check_with_seq_and_udt(t *testing.T) {
+func TestBackup_base_alter_table_add_check_with_seq_and_udt(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	sctest.Backup(t, "pkg/sql/schemachanger/testdata/end_to_end/alter_table_add_check_with_seq_and_udt", newCluster)
 }
-func TestBackupbase_alter_table_add_foreign_key(t *testing.T) {
+func TestBackup_base_alter_table_add_foreign_key(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	sctest.Backup(t, "pkg/sql/schemachanger/testdata/end_to_end/alter_table_add_foreign_key", newCluster)
 }
-func TestBackupbase_alter_table_add_primary_key_drop_rowid(t *testing.T) {
+func TestBackup_base_alter_table_add_primary_key_drop_rowid(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	sctest.Backup(t, "pkg/sql/schemachanger/testdata/end_to_end/alter_table_add_primary_key_drop_rowid", newCluster)
 }
-func TestBackupbase_alter_table_add_unique_without_index(t *testing.T) {
+func TestBackup_base_alter_table_add_unique_without_index(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	sctest.Backup(t, "pkg/sql/schemachanger/testdata/end_to_end/alter_table_add_unique_without_index", newCluster)
 }
-func TestBackupbase_alter_table_alter_primary_key_drop_rowid(t *testing.T) {
+func TestBackup_base_alter_table_alter_primary_key_drop_rowid(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	sctest.Backup(t, "pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_drop_rowid", newCluster)
 }
-func TestBackupbase_alter_table_alter_primary_key_vanilla(t *testing.T) {
+func TestBackup_base_alter_table_alter_primary_key_vanilla(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	sctest.Backup(t, "pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_vanilla", newCluster)
 }
-func TestBackupbase_create_index(t *testing.T) {
+func TestBackup_base_create_index(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	sctest.Backup(t, "pkg/sql/schemachanger/testdata/end_to_end/create_index", newCluster)
 }
-func TestBackupbase_drop_column_basic(t *testing.T) {
+func TestBackup_base_drop_column_basic(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	sctest.Backup(t, "pkg/sql/schemachanger/testdata/end_to_end/drop_column_basic", newCluster)
 }
-func TestBackupbase_drop_column_computed_index(t *testing.T) {
+func TestBackup_base_drop_column_computed_index(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	sctest.Backup(t, "pkg/sql/schemachanger/testdata/end_to_end/drop_column_computed_index", newCluster)
 }
-func TestBackupbase_drop_column_create_index_separate_statements(t *testing.T) {
+func TestBackup_base_drop_column_create_index_separate_statements(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	sctest.Backup(t, "pkg/sql/schemachanger/testdata/end_to_end/drop_column_create_index_separate_statements", newCluster)
 }
-func TestBackupbase_drop_column_unique_index(t *testing.T) {
+func TestBackup_base_drop_column_unique_index(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	sctest.Backup(t, "pkg/sql/schemachanger/testdata/end_to_end/drop_column_unique_index", newCluster)
 }
-func TestBackupbase_drop_column_with_index(t *testing.T) {
+func TestBackup_base_drop_column_with_index(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	sctest.Backup(t, "pkg/sql/schemachanger/testdata/end_to_end/drop_column_with_index", newCluster)
 }
-func TestBackupbase_drop_index_hash_sharded_index(t *testing.T) {
+func TestBackup_base_drop_index_hash_sharded_index(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	sctest.Backup(t, "pkg/sql/schemachanger/testdata/end_to_end/drop_index_hash_sharded_index", newCluster)
 }
-func TestBackupbase_drop_index_partial_expression_index(t *testing.T) {
+func TestBackup_base_drop_index_partial_expression_index(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	sctest.Backup(t, "pkg/sql/schemachanger/testdata/end_to_end/drop_index_partial_expression_index", newCluster)
 }
-func TestBackupbase_drop_index_vanilla_index(t *testing.T) {
+func TestBackup_base_drop_index_vanilla_index(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	sctest.Backup(t, "pkg/sql/schemachanger/testdata/end_to_end/drop_index_vanilla_index", newCluster)
 }
-func TestBackupbase_drop_index_with_materialized_view_dep(t *testing.T) {
+func TestBackup_base_drop_index_with_materialized_view_dep(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	sctest.Backup(t, "pkg/sql/schemachanger/testdata/end_to_end/drop_index_with_materialized_view_dep", newCluster)
 }
-func TestBackupbase_drop_multiple_columns_separate_statements(t *testing.T) {
+func TestBackup_base_drop_multiple_columns_separate_statements(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	sctest.Backup(t, "pkg/sql/schemachanger/testdata/end_to_end/drop_multiple_columns_separate_statements", newCluster)
 }
-func TestBackupbase_drop_schema(t *testing.T) {
+func TestBackup_base_drop_schema(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	sctest.Backup(t, "pkg/sql/schemachanger/testdata/end_to_end/drop_schema", newCluster)
 }
-func TestBackupbase_drop_table(t *testing.T) {
+func TestBackup_base_drop_table(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	sctest.Backup(t, "pkg/sql/schemachanger/testdata/end_to_end/drop_table", newCluster)

--- a/pkg/ccl/schemachangerccl/ccl_generated_test.go
+++ b/pkg/ccl/schemachangerccl/ccl_generated_test.go
@@ -18,102 +18,102 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 )
 
-func TestBackupccl_create_index(t *testing.T) {
+func TestBackup_ccl_create_index(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	sctest.Backup(t, "pkg/ccl/schemachangerccl/testdata/end_to_end/create_index", newCluster)
 }
-func TestEndToEndSideEffectsccl_create_index(t *testing.T) {
+func TestEndToEndSideEffects_ccl_create_index(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	sctest.EndToEndSideEffects(t, "pkg/ccl/schemachangerccl/testdata/end_to_end/create_index", newCluster)
 }
-func TestGenerateSchemaChangeCorpusccl_create_index(t *testing.T) {
+func TestGenerateSchemaChangeCorpus_ccl_create_index(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	sctest.GenerateSchemaChangeCorpus(t, "pkg/ccl/schemachangerccl/testdata/end_to_end/create_index", newCluster)
 }
-func TestPauseccl_create_index(t *testing.T) {
+func TestPause_ccl_create_index(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	sctest.Pause(t, "pkg/ccl/schemachangerccl/testdata/end_to_end/create_index", newCluster)
 }
-func TestRollbackccl_create_index(t *testing.T) {
+func TestRollback_ccl_create_index(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	sctest.Rollback(t, "pkg/ccl/schemachangerccl/testdata/end_to_end/create_index", newCluster)
 }
-func TestBackupccl_drop_database_multiregion_primary_region(t *testing.T) {
+func TestBackup_ccl_drop_database_multiregion_primary_region(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	sctest.Backup(t, "pkg/ccl/schemachangerccl/testdata/end_to_end/drop_database_multiregion_primary_region", newCluster)
 }
-func TestEndToEndSideEffectsccl_drop_database_multiregion_primary_region(t *testing.T) {
+func TestEndToEndSideEffects_ccl_drop_database_multiregion_primary_region(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	sctest.EndToEndSideEffects(t, "pkg/ccl/schemachangerccl/testdata/end_to_end/drop_database_multiregion_primary_region", newCluster)
 }
-func TestGenerateSchemaChangeCorpusccl_drop_database_multiregion_primary_region(t *testing.T) {
+func TestGenerateSchemaChangeCorpus_ccl_drop_database_multiregion_primary_region(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	sctest.GenerateSchemaChangeCorpus(t, "pkg/ccl/schemachangerccl/testdata/end_to_end/drop_database_multiregion_primary_region", newCluster)
 }
-func TestPauseccl_drop_database_multiregion_primary_region(t *testing.T) {
+func TestPause_ccl_drop_database_multiregion_primary_region(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	sctest.Pause(t, "pkg/ccl/schemachangerccl/testdata/end_to_end/drop_database_multiregion_primary_region", newCluster)
 }
-func TestRollbackccl_drop_database_multiregion_primary_region(t *testing.T) {
+func TestRollback_ccl_drop_database_multiregion_primary_region(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	sctest.Rollback(t, "pkg/ccl/schemachangerccl/testdata/end_to_end/drop_database_multiregion_primary_region", newCluster)
 }
-func TestBackupccl_drop_table_multiregion(t *testing.T) {
+func TestBackup_ccl_drop_table_multiregion(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	sctest.Backup(t, "pkg/ccl/schemachangerccl/testdata/end_to_end/drop_table_multiregion", newCluster)
 }
-func TestEndToEndSideEffectsccl_drop_table_multiregion(t *testing.T) {
+func TestEndToEndSideEffects_ccl_drop_table_multiregion(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	sctest.EndToEndSideEffects(t, "pkg/ccl/schemachangerccl/testdata/end_to_end/drop_table_multiregion", newCluster)
 }
-func TestGenerateSchemaChangeCorpusccl_drop_table_multiregion(t *testing.T) {
+func TestGenerateSchemaChangeCorpus_ccl_drop_table_multiregion(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	sctest.GenerateSchemaChangeCorpus(t, "pkg/ccl/schemachangerccl/testdata/end_to_end/drop_table_multiregion", newCluster)
 }
-func TestPauseccl_drop_table_multiregion(t *testing.T) {
+func TestPause_ccl_drop_table_multiregion(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	sctest.Pause(t, "pkg/ccl/schemachangerccl/testdata/end_to_end/drop_table_multiregion", newCluster)
 }
-func TestRollbackccl_drop_table_multiregion(t *testing.T) {
+func TestRollback_ccl_drop_table_multiregion(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	sctest.Rollback(t, "pkg/ccl/schemachangerccl/testdata/end_to_end/drop_table_multiregion", newCluster)
 }
-func TestBackupccl_drop_table_multiregion_primary_region(t *testing.T) {
+func TestBackup_ccl_drop_table_multiregion_primary_region(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	sctest.Backup(t, "pkg/ccl/schemachangerccl/testdata/end_to_end/drop_table_multiregion_primary_region", newCluster)
 }
-func TestEndToEndSideEffectsccl_drop_table_multiregion_primary_region(t *testing.T) {
+func TestEndToEndSideEffects_ccl_drop_table_multiregion_primary_region(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	sctest.EndToEndSideEffects(t, "pkg/ccl/schemachangerccl/testdata/end_to_end/drop_table_multiregion_primary_region", newCluster)
 }
-func TestGenerateSchemaChangeCorpusccl_drop_table_multiregion_primary_region(t *testing.T) {
+func TestGenerateSchemaChangeCorpus_ccl_drop_table_multiregion_primary_region(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	sctest.GenerateSchemaChangeCorpus(t, "pkg/ccl/schemachangerccl/testdata/end_to_end/drop_table_multiregion_primary_region", newCluster)
 }
-func TestPauseccl_drop_table_multiregion_primary_region(t *testing.T) {
+func TestPause_ccl_drop_table_multiregion_primary_region(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	sctest.Pause(t, "pkg/ccl/schemachangerccl/testdata/end_to_end/drop_table_multiregion_primary_region", newCluster)
 }
-func TestRollbackccl_drop_table_multiregion_primary_region(t *testing.T) {
+func TestRollback_ccl_drop_table_multiregion_primary_region(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	sctest.Rollback(t, "pkg/ccl/schemachangerccl/testdata/end_to_end/drop_table_multiregion_primary_region", newCluster)


### PR DESCRIPTION
This commit adds an underscore in the generated tests' name where there previously was one missing.

Informs #88294.

Release note: None