### PR TITLE
kvstorage: complete RaftReplicaID migration

### DIFF
--- a/pkg/kv/kvserver/kvstorage/BUILD.bazel
+++ b/pkg/kv/kvserver/kvstorage/BUILD.bazel
@@ -27,16 +27,29 @@ go_library(
 
 go_test(
     name = "kvstorage_test",
-    srcs = ["cluster_version_test.go"],
+    srcs = [
+        "cluster_version_test.go",
+        "datadriven_test.go",
+    ],
     args = ["-test.timeout=295s"],
+    data = glob(["testdata/**"]),
     embed = [":kvstorage"],
     deps = [
         "//pkg/clusterversion",
+        "//pkg/keys",
+        "//pkg/kv/kvserver/logstore",
         "//pkg/roachpb",
         "//pkg/storage",
         "//pkg/testutils",
+        "//pkg/testutils/datapathutils",
+        "//pkg/util/hlc",
         "//pkg/util/leaktest",
         "//pkg/util/log",
+        "//pkg/util/tracing",
+        "//pkg/util/uuid",
+        "@com_github_cockroachdb_datadriven//:datadriven",
+        "@com_github_stretchr_testify//require",
+        "@io_etcd_go_raft_v3//raftpb",
     ],
 )
 

--- a/pkg/kv/kvserver/kvstorage/BUILD.bazel
+++ b/pkg/kv/kvserver/kvstorage/BUILD.bazel
@@ -16,12 +16,13 @@ go_library(
         "//pkg/kv/kvserver/logstore",
         "//pkg/roachpb",
         "//pkg/storage",
-        "//pkg/util/buildutil",
         "//pkg/util/hlc",
         "//pkg/util/iterutil",
         "//pkg/util/log",
         "//pkg/util/protoutil",
         "@com_github_cockroachdb_errors//:errors",
+        "@com_github_cockroachdb_redact//:redact",
+        "@io_etcd_go_raft_v3//raftpb",
     ],
 )
 

--- a/pkg/kv/kvserver/kvstorage/datadriven_test.go
+++ b/pkg/kv/kvserver/kvstorage/datadriven_test.go
@@ -1,0 +1,208 @@
+// Copyright 2023 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package kvstorage
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/clusterversion"
+	"github.com/cockroachdb/cockroach/pkg/keys"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/logstore"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/storage"
+	"github.com/cockroachdb/cockroach/pkg/testutils/datapathutils"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/tracing"
+	"github.com/cockroachdb/cockroach/pkg/util/uuid"
+	"github.com/cockroachdb/datadriven"
+	"github.com/stretchr/testify/require"
+	"go.etcd.io/raft/v3/raftpb"
+)
+
+type env struct {
+	eng storage.Engine
+	tr  *tracing.Tracer
+}
+
+func newEnv(t *testing.T) *env {
+	ctx := context.Background()
+	eng := storage.NewDefaultInMemForTesting()
+	// TODO(tbg): ideally this would do full bootstrap, which requires
+	// moving a lot more code from kvserver. But then we could unit test
+	// all of it with the datadriven harness!
+	require.NoError(t, WriteClusterVersion(ctx, eng, clusterversion.TestingClusterVersion))
+	require.NoError(t, InitEngine(ctx, eng, roachpb.StoreIdent{
+		ClusterID: uuid.FastMakeV4(),
+		NodeID:    1,
+		StoreID:   1,
+	}))
+	tr := tracing.NewTracer()
+	tr.SetRedactable(true)
+	return &env{
+		eng: eng,
+		tr:  tr,
+	}
+}
+
+func (e *env) close() {
+	e.eng.Close()
+	e.tr.Close()
+}
+
+func (e *env) handleNewReplica(
+	t *testing.T,
+	ctx context.Context,
+	id storage.FullReplicaID,
+	skipRaftReplicaID bool,
+	k, ek roachpb.RKey,
+) *roachpb.RangeDescriptor {
+	sl := logstore.NewStateLoader(id.RangeID)
+	require.NoError(t, sl.SetHardState(ctx, e.eng, raftpb.HardState{}))
+	if !skipRaftReplicaID && id.ReplicaID != 0 {
+		require.NoError(t, sl.SetRaftReplicaID(ctx, e.eng, id.ReplicaID))
+	}
+	if len(ek) == 0 {
+		return nil
+	}
+	desc := &roachpb.RangeDescriptor{
+		RangeID:  id.RangeID,
+		StartKey: keys.MustAddr(roachpb.Key(k)),
+		EndKey:   keys.MustAddr(roachpb.Key(ek)),
+		InternalReplicas: []roachpb.ReplicaDescriptor{{
+			NodeID:    1,
+			StoreID:   1,
+			ReplicaID: id.ReplicaID,
+		}},
+		NextReplicaID: id.ReplicaID + 1,
+	}
+	var v roachpb.Value
+	require.NoError(t, v.SetProto(desc))
+	ts := hlc.Timestamp{WallTime: 123}
+	require.NoError(t, e.eng.PutMVCC(storage.MVCCKey{
+		Key:       keys.RangeDescriptorKey(desc.StartKey),
+		Timestamp: ts,
+	}, storage.MVCCValue{Value: v}))
+	return desc
+}
+
+func TestDataDriven(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	reStripFileLinePrefix := regexp.MustCompile(`^[^ ]+ `)
+
+	datadriven.Walk(t, datapathutils.TestDataPath(t), func(t *testing.T, path string) {
+		e := newEnv(t)
+		defer e.close()
+		datadriven.RunTest(t, path, func(t *testing.T, d *datadriven.TestData) (output string) {
+			ctx, finishAndGet := tracing.ContextWithRecordingSpan(context.Background(), e.tr, path)
+			// This method prints all output to `buf`.
+			var buf strings.Builder
+			var printTrace bool // if true, trace printed to buf on return
+			if d.HasArg("trace") {
+				d.ScanArgs(t, "trace", &printTrace)
+			}
+
+			defer func() {
+				if r := recover(); r != nil {
+					fmt.Fprintln(&buf, r)
+				}
+				rec := finishAndGet()[0]
+				for _, l := range rec.Logs {
+					if !printTrace || !strings.Contains(string(l.Message), "kvstorage") {
+						continue
+					}
+
+					fmt.Fprintln(&buf, reStripFileLinePrefix.ReplaceAllString(string(l.Message), ``))
+				}
+				if buf.Len() == 0 {
+					fmt.Fprintln(&buf, "ok")
+				}
+				output = buf.String()
+			}()
+
+			switch d.Cmd {
+			case "new-replica":
+				var rangeID int
+				d.ScanArgs(t, "range-id", &rangeID)
+				var replicaID int
+				if d.HasArg("replica-id") { // optional to allow making incomplete state
+					d.ScanArgs(t, "replica-id", &replicaID)
+				}
+				var k string
+				if d.HasArg("k") {
+					d.ScanArgs(t, "k", &k)
+				}
+				var ek string
+				if d.HasArg("ek") {
+					d.ScanArgs(t, "ek", &ek)
+				}
+				var skipRaftReplicaID bool
+				if d.HasArg("skip-raft-replica-id") {
+					d.ScanArgs(t, "skip-raft-replica-id", &skipRaftReplicaID)
+				}
+				if desc := e.handleNewReplica(t, ctx,
+					storage.FullReplicaID{RangeID: roachpb.RangeID(rangeID), ReplicaID: roachpb.ReplicaID(replicaID)},
+					skipRaftReplicaID, keys.MustAddr(roachpb.Key(k)), keys.MustAddr(roachpb.Key(ek)),
+				); desc != nil {
+					fmt.Fprintln(&buf, desc)
+				}
+			case "list-range-ids":
+				m, err := loadFullReplicaIDsFromDisk(ctx, e.eng)
+				require.NoError(t, err)
+				var sl []storage.FullReplicaID
+				for id := range m {
+					sl = append(sl, id)
+				}
+				sort.Slice(sl, func(i, j int) bool {
+					return sl[i].RangeID < sl[j].RangeID
+				})
+				for _, id := range sl {
+					fmt.Fprintf(&buf, "r%d/%d\n", id.RangeID, id.ReplicaID)
+				}
+			case "load-and-reconcile":
+				rs, err := LoadAndReconcileReplicas(ctx, e.eng)
+				if err != nil {
+					fmt.Fprintln(&buf, err)
+					break
+				}
+				var merged []storage.FullReplicaID
+				for id := range rs.Initialized {
+					merged = append(merged, id)
+				}
+				for id := range rs.Uninitialized {
+					merged = append(merged, id)
+				}
+				sort.Slice(merged, func(i, j int) bool {
+					return merged[i].RangeID < merged[j].RangeID
+				})
+				for _, id := range merged {
+					fmt.Fprintf(&buf, "r%d/%d: ", id.RangeID, id.ReplicaID)
+					if desc := rs.Initialized[id]; desc != nil {
+						fmt.Fprint(&buf, desc)
+					} else {
+						fmt.Fprintf(&buf, "uninitialized")
+					}
+					fmt.Fprintln(&buf)
+				}
+			default:
+				t.Fatalf("unknown command %s", d.Cmd)
+			}
+			return "" // defer will do it
+		})
+	})
+
+}

--- a/pkg/kv/kvserver/kvstorage/init.go
+++ b/pkg/kv/kvserver/kvstorage/init.go
@@ -13,17 +13,19 @@ package kvstorage
 import (
 	"bytes"
 	"context"
+	"sort"
 
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/logstore"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/storage"
-	"github.com/cockroachdb/cockroach/pkg/util/buildutil"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/iterutil"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/redact"
+	"go.etcd.io/raft/v3/raftpb"
 )
 
 // FirstNodeID is the NodeID assigned to the node bootstrapping a new cluster.
@@ -249,7 +251,7 @@ func IterateRangeDescriptorsFromDisk(
 
 	allCount := 0
 	matchCount := 0
-	bySuffix := make(map[string]int)
+	bySuffix := make(map[redact.RedactableString]int)
 	kvToDesc := func(kv roachpb.KeyValue) error {
 		allCount++
 		// Only consider range metadata entries; ignore others.
@@ -257,7 +259,7 @@ func IterateRangeDescriptorsFromDisk(
 		if err != nil {
 			return err
 		}
-		bySuffix[string(suffix)]++
+		bySuffix[redact.RedactableString(suffix)]++
 		if !bytes.Equal(suffix, keys.LocalRangeDescriptorSuffix) {
 			return nil
 		}
@@ -291,103 +293,202 @@ func IterateRangeDescriptorsFromDisk(
 	return err
 }
 
-type EngineReplicas struct {
-	Uninitialized map[storage.FullReplicaID]struct{}
-	Initialized   map[storage.FullReplicaID]*roachpb.RangeDescriptor
+// A Replica references a CockroachDB Replica. The data in this struct does not
+// represent the data of the Replica but is sufficient to access all of its
+// contents via additional calls to the storage engine.
+type Replica struct {
+	RangeID   roachpb.RangeID
+	ReplicaID roachpb.ReplicaID
+	Desc      *roachpb.RangeDescriptor // nil for uninitialized Replica
+
+	hardState raftpb.HardState // internal to kvstorage, see migration in LoadAndReconcileReplicas
 }
 
-// loadFullReplicaIDsFromDisk discovers all Replicas on this Store.
-// There will only be one entry in the map for a given RangeID.
-//
-// TODO(sep-raft-log): the reader here is for the log engine.
-func loadFullReplicaIDsFromDisk(
-	ctx context.Context, reader storage.Reader,
-) (map[storage.FullReplicaID]struct{}, error) {
-	m := map[storage.FullReplicaID]struct{}{}
-	var msg roachpb.RaftReplicaID
-	if err := IterateIDPrefixKeys(ctx, reader, func(rangeID roachpb.RangeID) roachpb.Key {
-		return keys.RaftReplicaIDKey(rangeID)
-	}, &msg, func(rangeID roachpb.RangeID) error {
-		m[storage.FullReplicaID{RangeID: rangeID, ReplicaID: msg.ReplicaID}] = struct{}{}
-		return nil
-	}); err != nil {
-		return nil, err
+// ID returns the FullReplicaID.
+func (r Replica) ID() storage.FullReplicaID {
+	return storage.FullReplicaID{
+		RangeID:   r.RangeID,
+		ReplicaID: r.ReplicaID,
 	}
-
-	// TODO(sep-raft-log): if there is any other data that we mandate is present here
-	// (like a HardState), validate that here.
-
-	return m, nil
 }
 
-// LoadAndReconcileReplicas loads the Replicas present on this
-// store. It reconciles inconsistent state and runs validation checks.
-//
-// TOOD(sep-raft-log): consider a callback-visitor pattern here.
-func LoadAndReconcileReplicas(ctx context.Context, eng storage.Engine) (*EngineReplicas, error) {
-	ident, err := ReadStoreIdent(ctx, eng)
-	if err != nil {
-		return nil, err
-	}
+// A replicaMap organizes a set of Replicas with unique RangeIDs.
+type replicaMap map[roachpb.RangeID]Replica
 
-	initM := map[storage.FullReplicaID]*roachpb.RangeDescriptor{}
+func (m replicaMap) getOrMake(rangeID roachpb.RangeID) Replica {
+	ent := m[rangeID]
+	ent.RangeID = rangeID
+	return ent
+}
+
+func (m replicaMap) setReplicaID(rangeID roachpb.RangeID, replicaID roachpb.ReplicaID) {
+	ent := m.getOrMake(rangeID)
+	ent.ReplicaID = replicaID
+	m[rangeID] = ent
+}
+
+func (m replicaMap) setHardState(rangeID roachpb.RangeID, hs raftpb.HardState) {
+	ent := m.getOrMake(rangeID)
+	ent.hardState = hs
+	m[rangeID] = ent
+}
+
+func (m replicaMap) setDesc(rangeID roachpb.RangeID, desc roachpb.RangeDescriptor) error {
+	ent := m.getOrMake(rangeID)
+	if ent.Desc != nil {
+		return errors.AssertionFailedf("overlapping descriptors %v and %v", ent.Desc, &desc)
+	}
+	ent.Desc = &desc
+	m[rangeID] = ent
+	return nil
+}
+
+func loadReplicas(ctx context.Context, eng storage.Engine) ([]Replica, error) {
+	s := replicaMap{}
+
 	// INVARIANT: the latest visible committed version of the RangeDescriptor
 	// (which is what IterateRangeDescriptorsFromDisk returns) is the one reflecting
 	// the state of the Replica.
 	// INVARIANT: the descriptor for range [a,z) is located at RangeDescriptorKey(a).
 	// This is checked in IterateRangeDescriptorsFromDisk.
-	if err := IterateRangeDescriptorsFromDisk(
-		ctx, eng, func(desc roachpb.RangeDescriptor) error {
-			// INVARIANT: a Replica's RangeDescriptor always contains the local Store,
-			// i.e. a Store is a member of all of its local Replicas.
-			repDesc, found := desc.GetReplicaDescriptor(ident.StoreID)
-			if !found {
-				return errors.AssertionFailedf(
-					"RangeDescriptor does not contain local s%d: %s",
-					ident.StoreID, desc)
-			}
-
-			initM[storage.FullReplicaID{
-				RangeID:   desc.RangeID,
-				ReplicaID: repDesc.ReplicaID,
-			}] = &desc
-			return nil
-		}); err != nil {
-		return nil, err
+	{
+		var lastDesc roachpb.RangeDescriptor
+		if err := IterateRangeDescriptorsFromDisk(
+			ctx, eng, func(desc roachpb.RangeDescriptor) error {
+				if lastDesc.RangeID != 0 && desc.StartKey.Less(lastDesc.EndKey) {
+					return errors.AssertionFailedf("overlapping descriptors %s and %s", lastDesc, desc)
+				}
+				lastDesc = desc
+				return s.setDesc(desc.RangeID, desc)
+			},
+		); err != nil {
+			return nil, err
+		}
 	}
 
-	allM, err := loadFullReplicaIDsFromDisk(ctx, eng)
+	// INVARIANT: all replicas have a persisted full ReplicaID (i.e. a "ReplicaID from disk").
+	//
+	// This invariant is true for replicas created in 22.1. Without further action, it
+	// would be violated for clusters that originated before 22.1. In this method, we
+	// backfill the ReplicaID (for initialized replicas) and we remove uninitialized
+	// replicas lacking a ReplicaID (see below for rationale).
+	//
+	// The migration can be removed when the KV host cluster MinSupportedVersion
+	// matches or exceeds 23.1 (i.e. once we know that a store has definitely
+	// started up on >=23.1 at least once).
+
+	// Collect all the RangeIDs that either have a RaftReplicaID or HardState. For
+	// unmigrated replicas we see only the HardState - that is how we detect
+	// replicas that still need to be migrated.
+	//
+	// TODO(tbg): tighten up the case where we see a RaftReplicaID but no HardState.
+	// This leads to the general desire to validate the internal consistency of the
+	// entire raft state (i.e. HardState, TruncatedState, Log).
+	{
+		var msg roachpb.RaftReplicaID
+		if err := IterateIDPrefixKeys(ctx, eng, func(rangeID roachpb.RangeID) roachpb.Key {
+			return keys.RaftReplicaIDKey(rangeID)
+		}, &msg, func(rangeID roachpb.RangeID) error {
+			s.setReplicaID(rangeID, msg.ReplicaID)
+			return nil
+		}); err != nil {
+			return nil, err
+		}
+
+		var hs raftpb.HardState
+		if err := IterateIDPrefixKeys(ctx, eng, func(rangeID roachpb.RangeID) roachpb.Key {
+			return keys.RaftHardStateKey(rangeID)
+		}, &hs, func(rangeID roachpb.RangeID) error {
+			s.setHardState(rangeID, hs)
+			return nil
+		}); err != nil {
+			return nil, err
+		}
+	}
+	sl := make([]Replica, 0, len(s))
+	for _, repl := range s {
+		sl = append(sl, repl)
+	}
+	sort.Slice(sl, func(i, j int) bool {
+		return sl[i].RangeID < sl[j].RangeID
+	})
+	return sl, nil
+}
+
+// LoadAndReconcileReplicas loads the Replicas present on this
+// store. It reconciles inconsistent state and runs validation checks.
+// The returned slice is sorted by ReplicaID.
+//
+// TODO(sep-raft-log): consider a callback-visitor pattern here.
+func LoadAndReconcileReplicas(ctx context.Context, eng storage.Engine) ([]Replica, error) {
+	ident, err := ReadStoreIdent(ctx, eng)
 	if err != nil {
 		return nil, err
 	}
 
-	for id := range initM {
-		if _, ok := allM[id]; !ok {
-			// INVARIANT: all replicas have a persisted full replicaID (i.e. a "replicaID from disk").
-			//
-			// This invariant is true for replicas created in 22.2, but no migration
-			// was ever written. So we backfill the replicaID here (as of 23.1) and
-			// remove this code in the future (the follow-up release, assuming it is
-			// forced to migrate through 23.1, otherwise later).
-			if buildutil.CrdbTestBuild {
-				return nil, errors.AssertionFailedf("%s has no persisted replicaID", initM[id])
-			}
-			if err := logstore.NewStateLoader(id.RangeID).SetRaftReplicaID(ctx, eng, id.ReplicaID); err != nil {
-				return nil, errors.Wrapf(err, "backfilling replicaID for r%d", id.RangeID)
-			}
-			log.Eventf(ctx, "backfilled replicaID for %s", id)
-		}
-		// `allM` will be our map of uninitialized replicas.
-		//
-		// A replica is "uninitialized" if it's not in initM (i.e. is at log position
-		// zero and has no visible RangeDescriptor).
-		delete(allM, id)
+	sl, err := loadReplicas(ctx, eng)
+	if err != nil {
+		return nil, err
 	}
 
-	return &EngineReplicas{
-		Initialized:   initM,
-		Uninitialized: allM, // NB: init'ed ones were deleted earlier
-	}, nil
+	// Check invariants.
+	//
+	// Migrate into RaftReplicaID for all replicas that need it.
+	var newIdx int
+	for _, repl := range sl {
+		var descReplicaID roachpb.ReplicaID
+		if repl.Desc != nil {
+			// INVARIANT: a Replica's RangeDescriptor always contains the local Store,
+			// i.e. a Store is a member of all of its local initialized Replicas.
+			replDesc, found := repl.Desc.GetReplicaDescriptor(ident.StoreID)
+			if !found {
+				return nil, errors.AssertionFailedf("s%d not found in %s", ident.StoreID, repl.Desc)
+			}
+			if repl.ReplicaID != 0 && replDesc.ReplicaID != repl.ReplicaID {
+				return nil, errors.AssertionFailedf("conflicting RaftReplicaID %d for %s", repl.ReplicaID, repl.Desc)
+			}
+			descReplicaID = replDesc.ReplicaID
+		}
+
+		if repl.ReplicaID != 0 {
+			sl[newIdx] = repl
+			newIdx++
+			// RaftReplicaID present, no need to migrate.
+			continue
+		}
+
+		// Migrate into RaftReplicaID. This migration can be removed once the
+		// BinaryMinSupportedVersion is >= 23.1, and we can assert that
+		// repl.ReplicaID != 0 always holds.
+
+		if descReplicaID != 0 {
+			// Backfill RaftReplicaID for an initialized Replica.
+			if err := logstore.NewStateLoader(repl.RangeID).SetRaftReplicaID(ctx, eng, descReplicaID); err != nil {
+				return nil, errors.Wrapf(err, "backfilling ReplicaID for r%d", repl.RangeID)
+			}
+			repl.ReplicaID = descReplicaID
+			sl[newIdx] = repl
+			newIdx++
+			log.Eventf(ctx, "backfilled replicaID for initialized replica %s", repl.ID())
+		} else {
+			// We found an uninitialized replica that did not have a persisted
+			// ReplicaID. We can't determine the ReplicaID now, so we migrate by
+			// removing this uninitialized replica. This technically violates raft
+			// invariants if this replica has cast a vote, but the conditions under
+			// which this matters are extremely unlikely.
+			//
+			// TODO(tbg): if clearRangeData were in this package we could destroy more
+			// effectively even if for some reason we had in the past written state
+			// other than the HardState here (not supposed to happen, but still).
+			if err := eng.ClearUnversioned(logstore.NewStateLoader(repl.RangeID).RaftHardStateKey()); err != nil {
+				return nil, errors.Wrapf(err, "removing HardState for r%d", repl.RangeID)
+			}
+			log.Eventf(ctx, "removed legacy uninitialized replica for r%s", repl.RangeID)
+			// NB: removed from `sl` since we're not incrementing `newIdx`.
+		}
+	}
+
+	return sl[:newIdx], nil
 }
 
 // A NotBootstrappedError indicates that an engine has not yet been

--- a/pkg/kv/kvserver/kvstorage/testdata/assert_duplicate_replica
+++ b/pkg/kv/kvserver/kvstorage/testdata/assert_duplicate_replica
@@ -1,0 +1,14 @@
+new-replica range-id=1 replica-id=10 k=a ek=c
+----
+r1:{a-c} [(n1,s1):10, next=11, gen=0]
+
+new-replica range-id=1 replica-id=20 k=c ek=d
+----
+r1:{c-d} [(n1,s1):20, next=21, gen=0]
+
+# When we created replica-id=20, it clobbered replica-id=10
+# and so we see the descriptor but cannot match it up to a
+# raft state.
+load-and-reconcile
+----
+r1:{a-c} [(n1,s1):10, next=11, gen=0] has no persisted replicaID

--- a/pkg/kv/kvserver/kvstorage/testdata/assert_duplicate_replica
+++ b/pkg/kv/kvserver/kvstorage/testdata/assert_duplicate_replica
@@ -11,4 +11,4 @@ r1:{c-d} [(n1,s1):20, next=21, gen=0]
 # raft state.
 load-and-reconcile
 ----
-r1:{a-c} [(n1,s1):10, next=11, gen=0] has no persisted replicaID
+overlapping descriptors r1:{a-c} [(n1,s1):10, next=11, gen=0] and r1:{c-d} [(n1,s1):20, next=21, gen=0]

--- a/pkg/kv/kvserver/kvstorage/testdata/assert_duplicate_replica_2
+++ b/pkg/kv/kvserver/kvstorage/testdata/assert_duplicate_replica_2
@@ -1,0 +1,14 @@
+# Variant of the original test but there's overlap between an
+# initialized and uninitialized copy. The result is exactly
+# the same.
+new-replica range-id=1 replica-id=10 k=a ek=c
+----
+r1:{a-c} [(n1,s1):10, next=11, gen=0]
+
+new-replica range-id=1 replica-id=20
+----
+ok
+
+load-and-reconcile
+----
+r1:{a-c} [(n1,s1):10, next=11, gen=0] has no persisted replicaID

--- a/pkg/kv/kvserver/kvstorage/testdata/assert_duplicate_replica_2
+++ b/pkg/kv/kvserver/kvstorage/testdata/assert_duplicate_replica_2
@@ -11,4 +11,4 @@ ok
 
 load-and-reconcile
 ----
-r1:{a-c} [(n1,s1):10, next=11, gen=0] has no persisted replicaID
+conflicting RaftReplicaID 20 for r1:{a-c} [(n1,s1):10, next=11, gen=0]

--- a/pkg/kv/kvserver/kvstorage/testdata/assert_overlapping_replica
+++ b/pkg/kv/kvserver/kvstorage/testdata/assert_overlapping_replica
@@ -1,3 +1,5 @@
+# TODO(tbg): actually assert against the overlap and make the output of this
+# test a failed assertion.
 new-replica range-id=1 replica-id=10 k=a ek=c
 ----
 r1:{a-c} [(n1,s1):10, next=11, gen=0]
@@ -8,5 +10,4 @@ r2:{b-d} [(n1,s1):20, next=21, gen=0]
 
 load-and-reconcile
 ----
-r1/10: r1:{a-c} [(n1,s1):10, next=11, gen=0]
-r2/20: r2:{b-d} [(n1,s1):20, next=21, gen=0]
+overlapping descriptors r1:{a-c} [(n1,s1):10, next=11, gen=0] and r2:{b-d} [(n1,s1):20, next=21, gen=0]

--- a/pkg/kv/kvserver/kvstorage/testdata/assert_overlapping_replica
+++ b/pkg/kv/kvserver/kvstorage/testdata/assert_overlapping_replica
@@ -1,0 +1,12 @@
+new-replica range-id=1 replica-id=10 k=a ek=c
+----
+r1:{a-c} [(n1,s1):10, next=11, gen=0]
+
+new-replica range-id=2 replica-id=20 k=b ek=d
+----
+r2:{b-d} [(n1,s1):20, next=21, gen=0]
+
+load-and-reconcile
+----
+r1/10: r1:{a-c} [(n1,s1):10, next=11, gen=0]
+r2/20: r2:{b-d} [(n1,s1):20, next=21, gen=0]

--- a/pkg/kv/kvserver/kvstorage/testdata/init
+++ b/pkg/kv/kvserver/kvstorage/testdata/init
@@ -19,21 +19,23 @@ new-replica range-id=8 replica-id=80 k=c ek=f
 ----
 r8:{c-f} [(n1,s1):80, next=81, gen=0]
 
-list-range-ids
-----
-r6/60
-r8/80
-
 # Loading the replicas returns only the ones that
 # had a ReplicaID.
 load-and-reconcile trace=true
 ----
-r7:{a-c} [(n1,s1):70, next=71, gen=0] has no persisted replicaID
+r6/60: uninitialized
+r7/70: r7:{a-c} [(n1,s1):70, next=71, gen=0]
+r8/80: r8:{c-f} [(n1,s1):80, next=81, gen=0]
 beginning range descriptor iteration
-iterated over 2 keys to find 2 range descriptors (by suffix: map[‹rdsc›:2])
+iterated over 2 keys to find 2 range descriptors (by suffix: map[rdsc:2])
+removed legacy uninitialized replica for r5
+backfilled replicaID for initialized replica r7/70
 
-# r5 was removed, and r7 had its RaftReplicaID backfilled.
-list-range-ids
+# Idempotency.
+load-and-reconcile trace=true
 ----
-r6/60
-r8/80
+r6/60: uninitialized
+r7/70: r7:{a-c} [(n1,s1):70, next=71, gen=0]
+r8/80: r8:{c-f} [(n1,s1):80, next=81, gen=0]
+beginning range descriptor iteration
+iterated over 2 keys to find 2 range descriptors (by suffix: map[rdsc:2])

--- a/pkg/kv/kvserver/kvstorage/testdata/init
+++ b/pkg/kv/kvserver/kvstorage/testdata/init
@@ -1,0 +1,39 @@
+# Uninitialized deprecated replica: doesn't have a RaftReplicaID, it's just a
+# HardState. We expect this to be removed by load-and-reconcile.
+new-replica range-id=5
+----
+ok
+
+# Uninitialized replica. Expect this to stay around and be returned as such.
+new-replica range-id=6 replica-id=60
+----
+ok
+
+# Initialized deprecated replica: no RaftReplicaID. Expect ID to be backfilled.
+new-replica range-id=7 replica-id=70 k=a ek=c skip-raft-replica-id=true
+----
+r7:{a-c} [(n1,s1):70, next=71, gen=0]
+
+# Initialized replica without a need for a backfill.
+new-replica range-id=8 replica-id=80 k=c ek=f
+----
+r8:{c-f} [(n1,s1):80, next=81, gen=0]
+
+list-range-ids
+----
+r6/60
+r8/80
+
+# Loading the replicas returns only the ones that
+# had a ReplicaID.
+load-and-reconcile trace=true
+----
+r7:{a-c} [(n1,s1):70, next=71, gen=0] has no persisted replicaID
+beginning range descriptor iteration
+iterated over 2 keys to find 2 range descriptors (by suffix: map[‹rdsc›:2])
+
+# r5 was removed, and r7 had its RaftReplicaID backfilled.
+list-range-ids
+----
+r6/60
+r8/80


### PR DESCRIPTION
As of v22.1[^1], we always write the RaftReplicaID when creating a
Replica or updating a snapshot. However, since this is
persisted state that could've originated in older versions and not
updated yet, we couldn't rely on a persisted ReplicaID yet.

This commit adds code to the `(*Store).Start` boot sequence that

- persists a RaftReplicaID for all initialized replicas (using the
  ReplicaID from the descriptor)
- deletes all uninitialized replicas lacking RaftReplicaID (since we don't know their
  ReplicaID at this point).

The second item in theory violates Raft invariants, as uninitialized
Replicas are allowed to vote (though they then cannot accept log
entries). So in theory:

- an uninitialized replica casts a decisive vote for a leader
- it restarts
- code in this commit removes the uninited replica (and its vote)
- delayed MsgVote from another leader arrives
- it casts another vote for the same term for a dueling leader
- now there are two leaders in the same term.

The above in addition presupposes that the two leaders cannot
communicate with each other. Also, even if that is the case, since the
two leaders cannot append to the uninitialized replica (it doesn't
accept entries), we also need additional voters to return at the exact
right time.

Since an uninitialized replica without RaftReplicaID in is necessarily
at least one release old, this is exceedingly unlikely and we will
live with this theoretical risk.

This PR also adds a first stab at a datadriven test harness for
`kvstorage` which is likely to be of use for #93247.

[^1]: https://github.com/cockroachdb/cockroach/pull/75761

Epic: [CRDB-220](https://cockroachlabs.atlassian.net/browse/CRDB-220)
Release note: None