### PR TITLE
ui: add proper checks and message for insights

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/api/sqlApi.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/api/sqlApi.ts
@@ -119,3 +119,25 @@ export function sqlResultsAreEmpty(
     )
   );
 }
+
+/**
+ * errorMessage cleans the error message returned by the sqlApi,
+ * removing information not useful for the user.
+ * e.g. the error message
+ * "$executing stmt 1: run-query-via-api: only users with either MODIFYCLUSTERSETTING
+ * or VIEWCLUSTERSETTING privileges are allowed to show cluster settings"
+ * became
+ * "only users with either MODIFYCLUSTERSETTING or VIEWCLUSTERSETTING privileges are allowed to show cluster settings"
+ * and the error message
+ * "executing stmt 1: max result size exceeded"
+ * became
+ * "max result size exceeded"
+ * @param message
+ */
+export function sqlApiErrorMessage(message: string): string {
+  message = message.replace("run-query-via-api: ", "");
+  if (message.includes(":")) {
+    return message.split(":")[1];
+  }
+  return message;
+}

--- a/pkg/ui/workspaces/cluster-ui/src/insights/insightsErrorComponent.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/insightsErrorComponent.tsx
@@ -11,20 +11,29 @@
 import React from "react";
 import classNames from "classnames/bind";
 import styles from "./workloadInsights/util/workloadInsights.module.scss";
+import { sqlApiErrorMessage } from "../api";
 
 const cx = classNames.bind(styles);
 
-export const InsightsError = (): React.ReactElement => (
-  <div className={cx("row")}>
-    <span>This page had an unexpected error while loading insights.</span>
-    &nbsp;
-    <a
-      className={cx("action")}
-      onClick={() => {
-        window.location.reload();
-      }}
-    >
-      Reload this page
-    </a>
-  </div>
-);
+export const InsightsError = (errMsg?: string): React.ReactElement => {
+  const message = errMsg
+    ? errMsg
+    : "This page had an unexpected error while loading insights.";
+  const showReload = !message.toLowerCase().includes("size exceeded");
+  return (
+    <div className={cx("row")}>
+      <span>{message}</span>
+      &nbsp;
+      {showReload && (
+        <a
+          className={cx("action")}
+          onClick={() => {
+            window.location.reload();
+          }}
+        >
+          Reload this page
+        </a>
+      )}
+    </div>
+  );
+};

--- a/pkg/ui/workspaces/cluster-ui/src/insights/schemaInsights/schemaInsights.fixture.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/schemaInsights/schemaInsights.fixture.ts
@@ -70,7 +70,9 @@ export const SchemaInsightsPropsFixture: SchemaInsightsViewProps = {
     database: "",
     schemaInsightType: "",
   },
+  hasAdminRole: true,
   refreshSchemaInsights: () => {},
   onSortChange: () => {},
   onFiltersChange: () => {},
+  refreshUserSQLRoles: () => {},
 };

--- a/pkg/ui/workspaces/cluster-ui/src/insights/schemaInsights/schemaInsightsPageConnected.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/schemaInsights/schemaInsightsPageConnected.tsx
@@ -19,7 +19,7 @@ import {
   selectFilters,
   selectSortSetting,
 } from "src/store/schemaInsights";
-import { AppState } from "src/store";
+import { AppState, uiConfigActions } from "src/store";
 import {
   SchemaInsightsView,
   SchemaInsightsViewDispatchProps,
@@ -29,6 +29,7 @@ import { SchemaInsightEventFilters } from "../types";
 import { SortSetting } from "src/sortedtable";
 import { actions as localStorageActions } from "../../store/localStorage";
 import { Dispatch } from "redux";
+import { selectHasAdminRole } from "../../store/uiConfig";
 
 const mapStateToProps = (
   state: AppState,
@@ -40,6 +41,7 @@ const mapStateToProps = (
   schemaInsightsError: selectSchemaInsightsError(state),
   filters: selectFilters(state),
   sortSetting: selectSortSetting(state),
+  hasAdminRole: selectHasAdminRole(state),
 });
 
 const mapDispatchToProps = (
@@ -64,6 +66,7 @@ const mapDispatchToProps = (
   refreshSchemaInsights: () => {
     dispatch(actions.refresh());
   },
+  refreshUserSQLRoles: () => dispatch(uiConfigActions.refreshUserSQLRoles()),
 });
 
 export const SchemaInsightsPageConnected = withRouter(

--- a/pkg/ui/workspaces/cluster-ui/src/insights/schemaInsights/schemaInsightsView.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/schemaInsights/schemaInsightsView.tsx
@@ -48,12 +48,14 @@ export type SchemaInsightsViewStateProps = {
   schemaInsightsError: Error | null;
   filters: SchemaInsightEventFilters;
   sortSetting: SortSetting;
+  hasAdminRole: boolean;
 };
 
 export type SchemaInsightsViewDispatchProps = {
   onFiltersChange: (filters: SchemaInsightEventFilters) => void;
   onSortChange: (ss: SortSetting) => void;
   refreshSchemaInsights: () => void;
+  refreshUserSQLRoles: () => void;
 };
 
 export type SchemaInsightsViewProps = SchemaInsightsViewStateProps &
@@ -68,7 +70,9 @@ export const SchemaInsightsView: React.FC<SchemaInsightsViewProps> = ({
   schemaInsightsTypes,
   schemaInsightsError,
   filters,
+  hasAdminRole,
   refreshSchemaInsights,
+  refreshUserSQLRoles,
   onFiltersChange,
   onSortChange,
 }: SchemaInsightsViewProps) => {
@@ -90,6 +94,15 @@ export const SchemaInsightsView: React.FC<SchemaInsightsViewProps> = ({
       clearInterval(interval);
     };
   }, [refreshSchemaInsights]);
+
+  useEffect(() => {
+    // Refresh every 5 minutes.
+    refreshUserSQLRoles();
+    const interval = setInterval(refreshUserSQLRoles, 60 * 5000);
+    return () => {
+      clearInterval(interval);
+    };
+  }, [refreshUserSQLRoles]);
 
   useEffect(() => {
     // We use this effect to sync settings defined on the URL (sort, filters),
@@ -205,7 +218,7 @@ export const SchemaInsightsView: React.FC<SchemaInsightsViewProps> = ({
           loading={schemaInsights === null}
           page="schema insights"
           error={schemaInsightsError}
-          renderError={() => InsightsError()}
+          renderError={() => InsightsError(schemaInsightsError?.message)}
         >
           <div>
             <section className={sortableTableCx("cl-table-container")}>
@@ -220,7 +233,12 @@ export const SchemaInsightsView: React.FC<SchemaInsightsViewProps> = ({
                 />
               </div>
               <InsightsSortedTable
-                columns={makeInsightsColumns(isCockroachCloud)}
+                columns={makeInsightsColumns(
+                  isCockroachCloud,
+                  hasAdminRole,
+                  true,
+                  false,
+                )}
                 data={filteredSchemaInsights}
                 sortSetting={sortSetting}
                 onChangeSortSetting={onChangeSortSetting}

--- a/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsightDetails/statementInsightDetails.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsightDetails/statementInsightDetails.tsx
@@ -44,11 +44,13 @@ export interface StatementInsightDetailsStateProps {
   insightError: Error | null;
   isTenant?: boolean;
   timeScale?: TimeScale;
+  hasAdminRole: boolean;
 }
 
 export interface StatementInsightDetailsDispatchProps {
   refreshStatementInsights: (req: ExecutionInsightsRequest) => void;
   setTimeScale: (ts: TimeScale) => void;
+  refreshUserSQLRoles: () => void;
 }
 
 export type StatementInsightDetailsProps = StatementInsightDetailsStateProps &
@@ -70,8 +72,10 @@ export const StatementInsightDetails: React.FC<
   match,
   isTenant,
   timeScale,
+  hasAdminRole,
   setTimeScale,
   refreshStatementInsights,
+  refreshUserSQLRoles,
 }) => {
   const [explainPlanState, setExplainPlanState] = useState<ExplainPlanState>({
     explainPlan: null,
@@ -104,11 +108,17 @@ export const StatementInsightDetails: React.FC<
   const executionID = getMatchParamByName(match, idAttr);
 
   useEffect(() => {
+    refreshUserSQLRoles();
     if (!insightEventDetails || insightEventDetails === null) {
       const req = executionInsightsRequestFromTimeScale(timeScale);
       refreshStatementInsights(req);
     }
-  }, [insightEventDetails, timeScale, refreshStatementInsights]);
+  }, [
+    insightEventDetails,
+    timeScale,
+    refreshStatementInsights,
+    refreshUserSQLRoles,
+  ]);
 
   return (
     <div>
@@ -152,6 +162,7 @@ export const StatementInsightDetails: React.FC<
               <StatementInsightDetailsOverviewTab
                 insightEventDetails={insightEventDetails}
                 setTimeScale={setTimeScale}
+                hasAdminRole={hasAdminRole}
               />
             </Tabs.TabPane>
             {!isTenant && (

--- a/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsightDetails/statementInsightDetailsConnected.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsightDetails/statementInsightDetailsConnected.tsx
@@ -15,13 +15,13 @@ import {
   StatementInsightDetailsDispatchProps,
   StatementInsightDetailsStateProps,
 } from "./statementInsightDetails";
-import { AppState } from "src/store";
+import { AppState, uiConfigActions } from "src/store";
 import {
   actions as statementInsights,
   selectStatementInsightDetails,
   selectExecutionInsightsError,
 } from "src/store/insights/statementInsights";
-import { selectIsTenant } from "src/store/uiConfig";
+import { selectHasAdminRole, selectIsTenant } from "src/store/uiConfig";
 import { TimeScale } from "../../timeScaleDropdown";
 import { actions as sqlStatsActions } from "../../store/sqlStats";
 import { selectTimeScale } from "../../store/utils/selectors";
@@ -38,6 +38,7 @@ const mapStateToProps = (
     insightError: insightError,
     isTenant: selectIsTenant(state),
     timeScale: selectTimeScale(state),
+    hasAdminRole: selectHasAdminRole(state),
   };
 };
 
@@ -54,6 +55,7 @@ const mapDispatchToProps = (
       }),
     );
   },
+  refreshUserSQLRoles: () => dispatch(uiConfigActions.refreshUserSQLRoles()),
 });
 
 export const StatementInsightDetailsConnected = withRouter(

--- a/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsightDetails/statementInsightDetailsOverviewTab.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsightDetails/statementInsightDetailsOverviewTab.tsx
@@ -44,16 +44,17 @@ const summaryCardStylesCx = classNames.bind(summaryCardStyles);
 export interface StatementInsightDetailsOverviewTabProps {
   insightEventDetails: FlattenedStmtInsightEvent;
   setTimeScale: (ts: TimeScale) => void;
+  hasAdminRole: boolean;
 }
 
 export const StatementInsightDetailsOverviewTab: React.FC<
   StatementInsightDetailsOverviewTabProps
-> = ({ insightEventDetails, setTimeScale }) => {
+> = ({ insightEventDetails, setTimeScale, hasAdminRole }) => {
   const isCockroachCloud = useContext(CockroachCloudContext);
 
   const insightsColumns = useMemo(
-    () => makeInsightsColumns(isCockroachCloud),
-    [isCockroachCloud],
+    () => makeInsightsColumns(isCockroachCloud, hasAdminRole),
+    [isCockroachCloud, hasAdminRole],
   );
 
   const insightDetails = insightEventDetails;

--- a/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsightDetails/transactionInsightDetails.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsightDetails/transactionInsightDetails.tsx
@@ -33,6 +33,7 @@ export interface TransactionInsightDetailsStateProps {
   insightDetails: TxnInsightDetails;
   insightError: Error | null;
   timeScale?: TimeScale;
+  hasAdminRole: boolean;
 }
 
 export interface TransactionInsightDetailsDispatchProps {
@@ -40,6 +41,7 @@ export interface TransactionInsightDetailsDispatchProps {
     req: TxnContentionInsightDetailsRequest,
   ) => void;
   setTimeScale: (ts: TimeScale) => void;
+  refreshUserSQLRoles: () => void;
 }
 
 export type TransactionInsightDetailsProps =
@@ -62,10 +64,13 @@ export const TransactionInsightDetails: React.FC<
   insightError,
   timeScale,
   match,
+  hasAdminRole,
+  refreshUserSQLRoles,
 }) => {
   const executionID = getMatchParamByName(match, idAttr);
   const noInsights = !insightDetails;
   useEffect(() => {
+    refreshUserSQLRoles();
     const execReq = executionInsightsRequestFromTimeScale(timeScale);
     if (noInsights) {
       // Only refresh if we have no data (e.g. refresh the page)
@@ -75,7 +80,13 @@ export const TransactionInsightDetails: React.FC<
         end: execReq.end,
       });
     }
-  }, [executionID, refreshTransactionInsightDetails, noInsights, timeScale]);
+  }, [
+    executionID,
+    refreshTransactionInsightDetails,
+    noInsights,
+    timeScale,
+    refreshUserSQLRoles,
+  ]);
 
   const prevPage = (): void => history.goBack();
 
@@ -114,6 +125,7 @@ export const TransactionInsightDetails: React.FC<
               <TransactionInsightDetailsOverviewTab
                 insightDetails={insightDetails}
                 setTimeScale={setTimeScale}
+                hasAdminRole={hasAdminRole}
               />
             </Tabs.TabPane>
             {insightDetails?.statementInsights?.length && (

--- a/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsightDetails/transactionInsightDetailsConnected.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsightDetails/transactionInsightDetailsConnected.tsx
@@ -14,7 +14,7 @@ import {
 } from "./transactionInsightDetails";
 import { connect } from "react-redux";
 import { RouteComponentProps, withRouter } from "react-router-dom";
-import { AppState } from "src/store";
+import { AppState, uiConfigActions } from "src/store";
 import {
   selectTransactionInsightDetails,
   selectTransactionInsightDetailsError,
@@ -25,6 +25,7 @@ import { actions as sqlStatsActions } from "../../store/sqlStats";
 import { Dispatch } from "redux";
 import { TxnContentionInsightDetailsRequest } from "src/api";
 import { selectTimeScale } from "../../store/utils/selectors";
+import { selectHasAdminRole } from "../../store/uiConfig";
 
 const mapStateToProps = (
   state: AppState,
@@ -36,6 +37,7 @@ const mapStateToProps = (
     insightDetails: insightDetails,
     insightError: insightError,
     timeScale: selectTimeScale(state),
+    hasAdminRole: selectHasAdminRole(state),
   };
 };
 
@@ -54,6 +56,7 @@ const mapDispatchToProps = (
       }),
     );
   },
+  refreshUserSQLRoles: () => dispatch(uiConfigActions.refreshUserSQLRoles()),
 });
 
 export const TransactionInsightDetailsConnected = withRouter(

--- a/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsightDetails/transactionInsightDetailsOverviewTab.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsightDetails/transactionInsightDetailsOverviewTab.tsx
@@ -44,18 +44,16 @@ export interface TransactionInsightDetailsStateProps {
   insightError: Error | null;
 }
 
-export interface TransactionInsightDetailsDispatchProps {
-  setTimeScale: (ts: TimeScale) => void;
-}
-
 type Props = {
   insightDetails: TxnInsightDetails;
   setTimeScale: (ts: TimeScale) => void;
+  hasAdminRole: boolean;
 };
 
 export const TransactionInsightDetailsOverviewTab: React.FC<Props> = ({
   insightDetails,
   setTimeScale,
+  hasAdminRole,
 }) => {
   const [insightsSortSetting, setInsightsSortSetting] = useState<SortSetting>({
     ascending: false,
@@ -67,6 +65,7 @@ export const TransactionInsightDetailsOverviewTab: React.FC<Props> = ({
     insightDetails?.queries?.join("") || "Insight not found.";
   const insightsColumns = makeInsightsColumns(
     isCockroachCloud,
+    hasAdminRole,
     insightDetails.queries?.length > 1,
     true,
   );

--- a/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsights/statementInsights/statementInsightsView.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsights/statementInsights/statementInsightsView.tsx
@@ -268,7 +268,7 @@ export const StatementInsightsView: React.FC<StatementInsightsViewProps> = (
           loading={statements === null || isLoading}
           page="statement insights"
           error={statementsError}
-          renderError={() => InsightsError()}
+          renderError={() => InsightsError(statementsError?.message)}
         >
           <div>
             <section className={sortableTableCx("cl-table-container")}>

--- a/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsights/transactionInsights/transactionInsightsView.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsights/transactionInsights/transactionInsightsView.tsx
@@ -243,7 +243,7 @@ export const TransactionInsightsView: React.FC<TransactionInsightsViewProps> = (
           loading={transactions === null || isLoading}
           page="transaction insights"
           error={transactionsError}
-          renderError={() => InsightsError()}
+          renderError={() => InsightsError(transactionsError?.message)}
         >
           <div>
             <section className={sortableTableCx("cl-table-container")}>

--- a/pkg/ui/workspaces/cluster-ui/src/insightsTable/insightsTable.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insightsTable/insightsTable.tsx
@@ -316,6 +316,7 @@ const isIndexRec = (rec: InsightRecommendation) => {
 
 export function makeInsightsColumns(
   isCockroachCloud: boolean,
+  hasAdminRole: boolean,
   showQuery?: boolean,
   disableStmtLink?: boolean,
 ): ColumnDescriptor<InsightRecommendation>[] {
@@ -336,7 +337,8 @@ export function makeInsightsColumns(
     {
       name: "action",
       title: insightsTableTitles.actions(),
-      cell: (item: InsightRecommendation) => actionCell(item, isCockroachCloud),
+      cell: (item: InsightRecommendation) =>
+        actionCell(item, isCockroachCloud || !hasAdminRole),
     },
   ];
 }

--- a/pkg/ui/workspaces/cluster-ui/src/statementDetails/planDetails/planDetails.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementDetails/planDetails/planDetails.tsx
@@ -47,11 +47,13 @@ const cx = classNames.bind(styles);
 interface PlanDetailsProps {
   plans: PlanHashStats[];
   statementFingerprintID: string;
+  hasAdminRole: boolean;
 }
 
 export function PlanDetails({
   plans,
   statementFingerprintID,
+  hasAdminRole,
 }: PlanDetailsProps): React.ReactElement {
   const [plan, setPlan] = useState<PlanHashStats | null>(null);
   const [plansSortSetting, setPlansSortSetting] = useState<SortSetting>({
@@ -77,6 +79,7 @@ export function PlanDetails({
         backToPlanTable={backToPlanTable}
         sortSetting={insightsSortSetting}
         onChangeSortSetting={setInsightsSortSetting}
+        hasAdminRole={hasAdminRole}
       />
     );
   } else {
@@ -124,6 +127,7 @@ interface ExplainPlanProps {
   backToPlanTable: () => void;
   sortSetting: SortSetting;
   onChangeSortSetting: (ss: SortSetting) => void;
+  hasAdminRole: boolean;
 }
 
 function ExplainPlan({
@@ -132,6 +136,7 @@ function ExplainPlan({
   backToPlanTable,
   sortSetting,
   onChangeSortSetting,
+  hasAdminRole,
 }: ExplainPlanProps): React.ReactElement {
   const explainPlan =
     `Plan Gist: ${plan.stats.plan_gists[0]} \n\n` +
@@ -218,6 +223,7 @@ function ExplainPlan({
           statementFingerprintID={statementFingerprintID}
           sortSetting={sortSetting}
           onChangeSortSetting={onChangeSortSetting}
+          hasAdminRole={hasAdminRole}
         />
       )}
     </div>
@@ -275,6 +281,7 @@ interface InsightsProps {
   statementFingerprintID?: string;
   sortSetting?: SortSetting;
   onChangeSortSetting?: (ss: SortSetting) => void;
+  hasAdminRole: boolean;
 }
 
 export function Insights({
@@ -285,9 +292,15 @@ export function Insights({
   statementFingerprintID,
   sortSetting,
   onChangeSortSetting,
+  hasAdminRole,
 }: InsightsProps): React.ReactElement {
-  const hideAction = useContext(CockroachCloudContext) && database?.length == 0;
-  const insightsColumns = makeInsightsColumns(hideAction, false, true);
+  const hideAction = useContext(CockroachCloudContext) || database?.length == 0;
+  const insightsColumns = makeInsightsColumns(
+    hideAction,
+    hasAdminRole,
+    false,
+    true,
+  );
   const data = formatIdxRecommendations(
     idxRecommendations,
     database,

--- a/pkg/ui/workspaces/cluster-ui/src/statementDetails/recentStatementDetails.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementDetails/recentStatementDetails.tsx
@@ -42,6 +42,7 @@ export type RecentStatementDetailsStateProps = {
   contentionDetails?: ExecutionContentionDetails;
   statement: RecentStatement;
   match: match;
+  hasAdminRole: boolean;
 };
 
 export type RecentStatementDetailsDispatchProps = {
@@ -68,6 +69,7 @@ export const RecentStatementDetails: React.FC<RecentStatementDetailsProps> = ({
   statement,
   match,
   refreshLiveWorkload,
+  hasAdminRole,
 }) => {
   const history = useHistory();
   const executionID = getMatchParamByName(match, executionIdAttr);
@@ -189,6 +191,7 @@ export const RecentStatementDetails: React.FC<RecentStatementDetailsProps> = ({
                       database={statement.database}
                       sortSetting={insightsSortSetting}
                       onChangeSortSetting={setInsightsSortSetting}
+                      hasAdminRole={hasAdminRole}
                     />
                   )}
                 </Loading>

--- a/pkg/ui/workspaces/cluster-ui/src/statementDetails/recentStatementDetailsConnected.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementDetails/recentStatementDetailsConnected.tsx
@@ -22,7 +22,7 @@ import {
   selecteRecentStatement,
   selectContentionDetailsForStatement,
 } from "src/selectors/recentExecutions.selectors";
-import { selectIsTenant } from "src/store/uiConfig";
+import { selectHasAdminRole, selectIsTenant } from "src/store/uiConfig";
 
 // For tenant cases, we don't show information about node, regions and
 // diagnostics.
@@ -35,6 +35,7 @@ const mapStateToProps = (
     statement: selecteRecentStatement(state, props),
     match: props.match,
     isTenant: selectIsTenant(state),
+    hasAdminRole: selectHasAdminRole(state),
   };
 };
 

--- a/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetails.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetails.tsx
@@ -16,7 +16,6 @@ import "antd/lib/tabs/style";
 import { cockroach } from "@cockroachlabs/crdb-protobuf-client";
 import { InlineAlert, Text } from "@cockroachlabs/ui-components";
 import { ArrowLeft } from "@cockroachlabs/icons";
-import { Location } from "history";
 import _, { isNil } from "lodash";
 import Long from "long";
 import { Helmet } from "react-helmet";
@@ -139,6 +138,7 @@ export interface StatementDetailsStateProps {
   uiConfig?: UIConfigState["pages"]["statementDetails"];
   isTenant?: UIConfigState["isTenant"];
   hasViewActivityRedactedRole?: UIConfigState["hasViewActivityRedactedRole"];
+  hasAdminRole?: UIConfigState["hasAdminRole"];
 }
 
 export type StatementDetailsOwnProps = StatementDetailsDispatchProps &
@@ -786,6 +786,7 @@ export class StatementDetails extends React.Component<
           <PlanDetails
             statementFingerprintID={this.props.statementFingerprintID}
             plans={statement_statistics_per_plan_hash}
+            hasAdminRole={this.props.hasAdminRole}
           />
         </section>
       </>
@@ -811,7 +812,7 @@ export class StatementDetails extends React.Component<
           this.props.onDiagnosticCancelRequest(report)
         }
         showDiagnosticsViewLink={
-          this.props.uiConfig.showStatementDiagnosticsLink
+          this.props.uiConfig?.showStatementDiagnosticsLink
         }
         onSortingChange={this.props.onSortingChange}
       />

--- a/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetailsConnected.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetailsConnected.ts
@@ -24,6 +24,7 @@ import {
 import {
   selectIsTenant,
   selectHasViewActivityRedactedRole,
+  selectHasAdminRole,
 } from "../store/uiConfig";
 import { nodeRegionsByIDSelector } from "../store/nodes";
 import { actions as sqlDetailsStatsActions } from "src/store/statementDetails";
@@ -69,6 +70,7 @@ const mapStateToProps = (state: AppState, props: RouteComponentProps) => {
     uiConfig: selectStatementDetailsUiConfig(state),
     isTenant: selectIsTenant(state),
     hasViewActivityRedactedRole: selectHasViewActivityRedactedRole(state),
+    hasAdminRole: selectHasAdminRole(state),
   };
 };
 

--- a/pkg/ui/workspaces/db-console/src/views/insights/schemaInsightsPage.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/insights/schemaInsightsPage.tsx
@@ -10,7 +10,10 @@
 
 import { connect } from "react-redux";
 import { RouteComponentProps, withRouter } from "react-router-dom";
-import { refreshSchemaInsights } from "src/redux/apiReducers";
+import {
+  refreshSchemaInsights,
+  refreshUserSQLRoles,
+} from "src/redux/apiReducers";
 import { AdminUIState } from "src/redux/state";
 import {
   SchemaInsightEventFilters,
@@ -26,6 +29,7 @@ import {
   selectSchemaInsightsDatabases,
   selectSchemaInsightsTypes,
 } from "src/views/insights/insightsSelectors";
+import { selectHasAdminRole } from "src/redux/user";
 
 const mapStateToProps = (
   state: AdminUIState,
@@ -37,6 +41,7 @@ const mapStateToProps = (
   schemaInsightsError: state.cachedData?.schemaInsights.lastError,
   filters: schemaInsightsFiltersLocalSetting.selector(state),
   sortSetting: schemaInsightsSortLocalSetting.selector(state),
+  hasAdminRole: selectHasAdminRole(state),
 });
 
 const mapDispatchToProps = {
@@ -44,6 +49,7 @@ const mapDispatchToProps = {
     schemaInsightsFiltersLocalSetting.set(filters),
   onSortChange: (ss: SortSetting) => schemaInsightsSortLocalSetting.set(ss),
   refreshSchemaInsights: refreshSchemaInsights,
+  refreshUserSQLRoles: refreshUserSQLRoles,
 };
 
 const SchemaInsightsPage = withRouter(

--- a/pkg/ui/workspaces/db-console/src/views/insights/statementInsightDetailsPage.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/insights/statementInsightDetailsPage.tsx
@@ -15,10 +15,14 @@ import {
 import { connect } from "react-redux";
 import { RouteComponentProps, withRouter } from "react-router-dom";
 import { AdminUIState } from "src/redux/state";
-import { refreshExecutionInsights } from "src/redux/apiReducers";
+import {
+  refreshExecutionInsights,
+  refreshUserSQLRoles,
+} from "src/redux/apiReducers";
 import { selectStatementInsightDetails } from "src/views/insights/insightsSelectors";
 import { setGlobalTimeScaleAction } from "src/redux/statements";
 import { selectTimeScale } from "src/redux/timeScale";
+import { selectHasAdminRole } from "src/redux/user";
 
 const mapStateToProps = (
   state: AdminUIState,
@@ -28,12 +32,14 @@ const mapStateToProps = (
     insightEventDetails: selectStatementInsightDetails(state, props),
     insightError: state.cachedData?.executionInsights?.lastError,
     timeScale: selectTimeScale(state),
+    hasAdminRole: selectHasAdminRole(state),
   };
 };
 
 const mapDispatchToProps: StatementInsightDetailsDispatchProps = {
   refreshStatementInsights: refreshExecutionInsights,
   setTimeScale: setGlobalTimeScaleAction,
+  refreshUserSQLRoles: refreshUserSQLRoles,
 };
 
 const StatementInsightDetailsPage = withRouter(

--- a/pkg/ui/workspaces/db-console/src/views/insights/transactionInsightDetailsPage.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/insights/transactionInsightDetailsPage.tsx
@@ -14,7 +14,10 @@ import {
 } from "@cockroachlabs/cluster-ui";
 import { connect } from "react-redux";
 import { RouteComponentProps, withRouter } from "react-router-dom";
-import { refreshTransactionInsightDetails } from "src/redux/apiReducers";
+import {
+  refreshTransactionInsightDetails,
+  refreshUserSQLRoles,
+} from "src/redux/apiReducers";
 import { AdminUIState } from "src/redux/state";
 import {
   selectTxnInsightDetails,
@@ -22,6 +25,7 @@ import {
 } from "src/views/insights/insightsSelectors";
 import { setGlobalTimeScaleAction } from "src/redux/statements";
 import { selectTimeScale } from "src/redux/timeScale";
+import { selectHasAdminRole } from "src/redux/user";
 
 const mapStateToProps = (
   state: AdminUIState,
@@ -31,12 +35,14 @@ const mapStateToProps = (
     insightDetails: selectTxnInsightDetails(state, props),
     insightError: selectTransactionInsightDetailsError(state, props),
     timeScale: selectTimeScale(state),
+    hasAdminRole: selectHasAdminRole(state),
   };
 };
 
 const mapDispatchToProps: TransactionInsightDetailsDispatchProps = {
   refreshTransactionInsightDetails: refreshTransactionInsightDetails,
   setTimeScale: setGlobalTimeScaleAction,
+  refreshUserSQLRoles: refreshUserSQLRoles,
 };
 
 const TransactionInsightDetailsPage = withRouter(

--- a/pkg/ui/workspaces/db-console/src/views/sessions/sessionDetails.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/sessions/sessionDetails.tsx
@@ -10,7 +10,6 @@
 
 import { getMatchParamByName } from "src/util/query";
 import { sessionAttr } from "src/util/constants";
-import _ from "lodash";
 import { RouteComponentProps, withRouter } from "react-router-dom";
 import { createSelector } from "reselect";
 import { Pick } from "src/util/pick";

--- a/pkg/ui/workspaces/db-console/src/views/statements/recentStatementDetailsConnected.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/statements/recentStatementDetailsConnected.tsx
@@ -21,6 +21,7 @@ import {
   selectRecentStatement,
   selectContentionDetailsForStatement,
 } from "src/selectors";
+import { selectHasAdminRole } from "src/redux/user";
 
 export default withRouter(
   connect<
@@ -32,6 +33,7 @@ export default withRouter(
       match: props.match,
       statement: selectRecentStatement(state, props),
       contentionDetails: selectContentionDetailsForStatement(state, props),
+      hasAdminRole: selectHasAdminRole(state),
     }),
     { refreshLiveWorkload },
   )(RecentStatementDetails),

--- a/pkg/ui/workspaces/db-console/src/views/statements/statementDetails.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/statements/statementDetails.tsx
@@ -36,7 +36,10 @@ import {
   setGlobalTimeScaleAction,
 } from "src/redux/statements";
 import { createStatementDiagnosticsAlertLocalSetting } from "src/redux/alerts";
-import { selectHasViewActivityRedactedRole } from "src/redux/user";
+import {
+  selectHasAdminRole,
+  selectHasViewActivityRedactedRole,
+} from "src/redux/user";
 import {
   trackCancelDiagnosticsBundleAction,
   trackDownloadDiagnosticsBundleAction,
@@ -119,6 +122,7 @@ const mapStateToProps = (
       statementFingerprint,
     ),
     hasViewActivityRedactedRole: selectHasViewActivityRedactedRole(state),
+    hasAdminRole: selectHasAdminRole(state),
   };
 };
 


### PR DESCRIPTION
Previously, no checks were done on insights when user was not admin, making the page show empty results, even when there was an error retrieving the data.
This commit passes on the proper error message when there is one. It also checks for admin privilege to show option to apply a recommendation.

https://www.loom.com/share/33d002cc9b704a4fad2f9851109b04ee

Epic: CRDB-20388

Release note (ui change): Hide apply option for index recommendation when user is not admin.