### PR TITLE
sql: fix a possible race between Flow.Cleanup and Flow.Cancel

### DIFF
--- a/pkg/sql/colflow/vectorized_flow.go
+++ b/pkg/sql/colflow/vectorized_flow.go
@@ -369,6 +369,10 @@ func (f *vectorizedFlow) MemUsage() int64 {
 
 // Cleanup is part of the flowinfra.Flow interface.
 func (f *vectorizedFlow) Cleanup(ctx context.Context) {
+	startCleanup, endCleanup := f.FlowBase.GetOnCleanupFns()
+	startCleanup()
+	defer endCleanup()
+
 	// This cleans up all the memory and disk monitoring of the vectorized flow
 	// as well as closes all the closers.
 	f.creator.cleanup(ctx)

--- a/pkg/sql/distsql/server.go
+++ b/pkg/sql/distsql/server.go
@@ -216,7 +216,7 @@ func (ds *ServerImpl) setupFlow(
 ) (retCtx context.Context, _ flowinfra.Flow, _ execopnode.OpChains, retErr error) {
 	var sp *tracing.Span          // will be Finish()ed by Flow.Cleanup()
 	var monitor *mon.BytesMonitor // will be closed in Flow.Cleanup()
-	var onFlowCleanup func()
+	var onFlowCleanupEnd func()   // will be called at the very end of Flow.Cleanup()
 	// Make sure that we clean up all resources (which in the happy case are
 	// cleaned up in Flow.Cleanup()) if an error is encountered.
 	defer func() {
@@ -224,8 +224,8 @@ func (ds *ServerImpl) setupFlow(
 			if monitor != nil {
 				monitor.Stop(ctx)
 			}
-			if onFlowCleanup != nil {
-				onFlowCleanup()
+			if onFlowCleanupEnd != nil {
+				onFlowCleanupEnd()
 			} else {
 				reserved.Close(ctx)
 			}
@@ -307,7 +307,7 @@ func (ds *ServerImpl) setupFlow(
 		// the whole evalContext, but that isn't free, so we choose to restore
 		// the original state in order to avoid performance regressions.
 		origTxn := evalCtx.Txn
-		onFlowCleanup = func() {
+		onFlowCleanupEnd = func() {
 			evalCtx.Txn = origTxn
 			reserved.Close(ctx)
 		}
@@ -322,7 +322,7 @@ func (ds *ServerImpl) setupFlow(
 			evalCtx.Txn = leafTxn
 		}
 	} else {
-		onFlowCleanup = func() {
+		onFlowCleanupEnd = func() {
 			reserved.Close(ctx)
 		}
 		if localState.IsLocal {
@@ -388,7 +388,7 @@ func (ds *ServerImpl) setupFlow(
 	isVectorized := req.EvalContext.SessionData.VectorizeMode != sessiondatapb.VectorizeOff
 	f := newFlow(
 		flowCtx, sp, ds.flowRegistry, rowSyncFlowConsumer, batchSyncFlowConsumer,
-		localState.LocalProcs, isVectorized, onFlowCleanup, req.StatementSQL,
+		localState.LocalProcs, isVectorized, onFlowCleanupEnd, req.StatementSQL,
 	)
 	opt := flowinfra.FuseNormally
 	if !localState.MustUseLeafTxn() {
@@ -521,10 +521,10 @@ func newFlow(
 	batchSyncFlowConsumer execinfra.BatchReceiver,
 	localProcessors []execinfra.LocalProcessor,
 	isVectorized bool,
-	onFlowCleanup func(),
+	onFlowCleanupEnd func(),
 	statementSQL string,
 ) flowinfra.Flow {
-	base := flowinfra.NewFlowBase(flowCtx, sp, flowReg, rowSyncFlowConsumer, batchSyncFlowConsumer, localProcessors, onFlowCleanup, statementSQL)
+	base := flowinfra.NewFlowBase(flowCtx, sp, flowReg, rowSyncFlowConsumer, batchSyncFlowConsumer, localProcessors, onFlowCleanupEnd, statementSQL)
 	if isVectorized {
 		return colflow.NewVectorizedFlow(base)
 	}

--- a/pkg/sql/rowflow/row_based_flow.go
+++ b/pkg/sql/rowflow/row_based_flow.go
@@ -439,6 +439,9 @@ func (f *rowBasedFlow) Release() {
 
 // Cleanup is part of the flowinfra.Flow interface.
 func (f *rowBasedFlow) Cleanup(ctx context.Context) {
+	startCleanup, endCleanup := f.FlowBase.GetOnCleanupFns()
+	startCleanup()
+	defer endCleanup()
 	f.FlowBase.Cleanup(ctx)
 	f.Release()
 }


### PR DESCRIPTION
This commit fixes a possible race that could occur when `Flow.Cleanup`
is called by the main goroutine concurrently with `Flow.Cancel` by the
listener goroutine (which is not allowed). We already had
synchronization in place, but it was insufficient. In particular, the
following scenario could lead to a nil pointer crash:
- the listener checks whether `Cleanup` has been called, it hasn't, and
the mutex is unlocked;
- the listener is preemptied;
- the main goroutine proceeds to perform the `Cleanup`. At the very end
the flow object is unset (including `ctxCancel` overwritten to `nil`);
- the listener resumes its execution, proceeds to call `Cancel` on the
already-unset `Flow` object, leading to a nil pointer on `ctxCancel`
call.

This is now fixed by holding the mutex through the call to `Cancel` in
the listener goroutine, ensuring that the `Flow` object is not unset
from under the listener. Additionally, this commit clarifies the
callbacks that are performed at the very beginning and very end of
`Cleanup` method.

Fixes: #95527.

Release note: None