### PR TITLE
insights: record insights when txn contention meets threshold

### DIFF
--- a/pkg/sql/sqlstats/insights/registry_test.go
+++ b/pkg/sql/sqlstats/insights/registry_test.go
@@ -254,4 +254,46 @@ func TestRegistry(t *testing.T) {
 		registry := newRegistry(st, &latencyThresholdDetector{st: st}, newStore(st))
 		require.NotPanics(t, func() { registry.ObserveTransaction(session.ID, transaction) })
 	})
+
+	t.Run("txn with high accumulated contention without high single stmt contention", func(t *testing.T) {
+		st := cluster.MakeTestingClusterSettings()
+		store := newStore(st)
+		registry := newRegistry(st, &latencyThresholdDetector{st: st}, store)
+		contentionDuration := 10 * time.Second
+		statement := &Statement{
+			Status:           Statement_Completed,
+			ID:               clusterunique.IDFromBytes([]byte("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb")),
+			FingerprintID:    roachpb.StmtFingerprintID(100),
+			LatencyInSeconds: 0.00001,
+		}
+		txnHighContention := &Transaction{ID: uuid.FastMakeV4(), Contention: &contentionDuration}
+
+		registry.ObserveStatement(session.ID, statement)
+		registry.ObserveTransaction(session.ID, txnHighContention)
+
+		expected := []*Insight{
+			{
+				Session: session,
+				Transaction: &Transaction{
+					ID:               txnHighContention.ID,
+					Contention:       &contentionDuration,
+					StmtExecutionIDs: txnHighContention.StmtExecutionIDs,
+					Problems:         []Problem{Problem_SlowExecution},
+					Causes:           []Cause{Cause_HighContention}},
+				Statements: []*Statement{
+					newStmtWithProblemAndCauses(statement, Problem_None, nil),
+				},
+			},
+		}
+
+		var actual []*Insight
+		store.IterateInsights(
+			context.Background(),
+			func(ctx context.Context, o *Insight) {
+				actual = append(actual, o)
+			},
+		)
+
+		require.Equal(t, expected, actual)
+	})
 }


### PR DESCRIPTION
Part of #90393

Previously, we only write a transaction and its statements to the insights system when there is an issue detected for one of the statements in the transaction. However, a transaction should still report high contention when the total amount of contention time is high, even if the contention experienced by each of its statements is not over the threshold.

This commit ensures that transactions which have a recorded contention time above the insights latency threshold get reported to the insights system.

Release note: None