### PR TITLE
sql: standardize column names in SHOW GRANTS

### DIFF
--- a/pkg/sql/delegate/show_grants.go
+++ b/pkg/sql/delegate/show_grants.go
@@ -66,7 +66,7 @@ SELECT type_catalog AS database_name,
 FROM "".information_schema.type_privileges`
 	const systemPrivilegeQuery = `
 SELECT a.username AS grantee,
-       privilege,
+       privilege AS privilege_type,
        a.privilege
        IN (
           SELECT unnest(grant_options)
@@ -81,15 +81,15 @@ SELECT a.username AS grantee,
 	const externalConnectionPrivilegeQuery = `
 SELECT *
   FROM (
-        SELECT name,
+        SELECT name AS connection_name,
                a.username AS grantee,
-               privilege,
+               privilege AS privilege_type,
                a.privilege
                IN (
                   SELECT unnest(grant_options)
                     FROM system.privileges
                    WHERE username = a.username
-                ) AS grantable
+                ) AS is_grantable
           FROM (
                 SELECT regexp_extract(
                         path,

--- a/pkg/sql/logictest/testdata/logic_test/external_connection_privileges
+++ b/pkg/sql/logictest/testdata/logic_test/external_connection_privileges
@@ -84,20 +84,20 @@ GRANT DROP, USAGE ON EXTERNAL CONNECTION foo TO testuser2 WITH GRANT OPTION
 query TTTB colnames
 SHOW GRANTS ON EXTERNAL CONNECTION foo
 ----
-name  grantee    privilege  grantable
-foo   bar        DROP       false
-foo   bar        USAGE      false
-foo   root       ALL        false
-foo   testuser   DROP       true
-foo   testuser   USAGE      true
-foo   testuser2  DROP       true
-foo   testuser2  USAGE      true
+connection_name  grantee    privilege_type  is_grantable
+foo              bar        DROP            false
+foo              bar        USAGE           false
+foo              root       ALL             false
+foo              testuser   DROP            true
+foo              testuser   USAGE           true
+foo              testuser2  DROP            true
+foo              testuser2  USAGE           true
 
 query TTTB colnames
 SHOW GRANTS ON EXTERNAL CONNECTION foo FOR testuser, testuser2
 ----
-name  grantee    privilege  grantable
-foo   testuser   DROP       true
-foo   testuser   USAGE      true
-foo   testuser2  DROP       true
-foo   testuser2  USAGE      true
+connection_name  grantee    privilege_type  is_grantable
+foo              testuser   DROP            true
+foo              testuser   USAGE           true
+foo              testuser2  DROP            true
+foo              testuser2  USAGE           true

--- a/pkg/sql/logictest/testdata/logic_test/show_grants_synthetic
+++ b/pkg/sql/logictest/testdata/logic_test/show_grants_synthetic
@@ -10,7 +10,7 @@ GRANT SYSTEM EXTERNALCONNECTION TO testuser WITH GRANT OPTION
 query TTB colnames
 SHOW SYSTEM GRANTS
 ----
-grantee   privilege             is_grantable
+grantee   privilege_type        is_grantable
 testuser  EXTERNALCONNECTION    true
 testuser  MODIFYCLUSTERSETTING  false
 testuser  VIEWACTIVITY          false
@@ -18,7 +18,7 @@ testuser  VIEWACTIVITY          false
 query TTB colnames
 SHOW SYSTEM GRANTS FOR testuser
 ----
-grantee   privilege             is_grantable
+grantee   privilege_type        is_grantable
 testuser  EXTERNALCONNECTION    true
 testuser  MODIFYCLUSTERSETTING  false
 testuser  VIEWACTIVITY          false
@@ -29,7 +29,7 @@ REVOKE SYSTEM VIEWACTIVITY FROM testuser
 query TTB colnames
 SHOW SYSTEM GRANTS
 ----
-grantee   privilege             is_grantable
+grantee   privilege_type        is_grantable
 testuser  EXTERNALCONNECTION    true
 testuser  MODIFYCLUSTERSETTING  false
 
@@ -45,7 +45,7 @@ GRANT SYSTEM EXTERNALCONNECTION TO testuser2
 query TTB colnames
 SHOW SYSTEM GRANTS
 ----
-grantee    privilege             is_grantable
+grantee    privilege_type        is_grantable
 testuser   EXTERNALCONNECTION    true
 testuser   MODIFYCLUSTERSETTING  false
 testuser2  EXTERNALCONNECTION    false
@@ -54,14 +54,14 @@ testuser2  VIEWACTIVITY          true
 query TTB colnames
 SHOW SYSTEM GRANTS FOR testuser2
 ----
-grantee    privilege           is_grantable
+grantee    privilege_type      is_grantable
 testuser2  EXTERNALCONNECTION  false
 testuser2  VIEWACTIVITY        true
 
 query TTB colnames
 SHOW SYSTEM GRANTS FOR testuser, testuser2
 ----
-grantee    privilege             is_grantable
+grantee    privilege_type        is_grantable
 testuser   EXTERNALCONNECTION    true
 testuser   MODIFYCLUSTERSETTING  false
 testuser2  EXTERNALCONNECTION    false


### PR DESCRIPTION
fixes https://github.com/cockroachdb/cockroach/issues/92768

cc @andf-crl when this is backported, the docs page may need another update.

Release note (sql change): The SHOW GRANTS ON EXTERNAL CONNECTION and SHOW SYSTEM GRANTS commands 
now use a column name of `privilege_type` rather than `privilege`. For external connections, the `name` column was changed to `connection_name`. This makes the commands consistent with other SHOW GRANTS commands.