### PR TITLE
release-22.2: cloud/amazon: reuse aws kms clients

### DIFF
--- a/pkg/cloud/amazon/BUILD.bazel
+++ b/pkg/cloud/amazon/BUILD.bazel
@@ -23,6 +23,7 @@ go_library(
         "//pkg/server/telemetry",
         "//pkg/settings",
         "//pkg/settings/cluster",
+        "//pkg/util",
         "//pkg/util/contextutil",
         "//pkg/util/envutil",
         "//pkg/util/ioctx",


### PR DESCRIPTION
Backport 1/1 commits from #95026.

/cc @cockroachdb/release

---

This patch adds a setting to cache the last AWS KMS client and then reuse it if subsequent KMS client initializations use the same arguments. This should fix issues where backups with a long incremental chain fail with `NoCredentialProviders: no valid providers in chain` because we are initializing too many KMS clients and overwhelming the EC2 metadata service.

Release note (bug fix): Operations like BACKUP can now reuse a previously created AWS KMS client if the client was created with the same parameters. This addresses the NoCredentialProviders errors on EC2 with for backups with long incremental chains.

Release justification: bug fix to address overwhelming the EC2 metadata service by caching the most recent KMS client.
