### PR TITLE
grunning: add grunning.Elapsed()

### DIFF
--- a/pkg/kv/kvserver/replica.go
+++ b/pkg/kv/kvserver/replica.go
@@ -2108,7 +2108,7 @@ func (r *Replica) MeasureRaftCPUNanos(start time.Duration) {
 // is recorded against the replica's cpu time attribution.
 func (r *Replica) measureNanosRunning(start time.Duration, f func(float64)) {
 	end := grunning.Time()
-	dur := grunning.Difference(start, end).Nanoseconds()
+	dur := grunning.Elapsed(start, end).Nanoseconds()
 	f(float64(dur))
 }
 

--- a/pkg/util/admission/elastic_cpu_work_handle.go
+++ b/pkg/util/admission/elastic_cpu_work_handle.go
@@ -60,7 +60,7 @@ func (h *ElasticCPUWorkHandle) runningTime() time.Duration {
 	if override := h.testingOverrideRunningTime; override != nil {
 		return override()
 	}
-	return grunning.Difference(grunning.Time(), h.cpuStart)
+	return grunning.Elapsed(h.cpuStart, grunning.Time())
 }
 
 // OverLimit is used to check whether we're over the allotted elastic CPU

--- a/pkg/util/grunning/disabled_test.go
+++ b/pkg/util/grunning/disabled_test.go
@@ -26,4 +26,5 @@ func TestDisabled(t *testing.T) {
 	require.False(t, grunning.Supported())
 	require.Zero(t, grunning.Time())
 	require.Zero(t, grunning.Difference(grunning.Time(), grunning.Time()))
+	require.Zero(t, grunning.Elapsed(grunning.Time(), grunning.Time()))
 }

--- a/pkg/util/grunning/grunning.go
+++ b/pkg/util/grunning/grunning.go
@@ -22,12 +22,28 @@ func Time() time.Duration {
 }
 
 // Difference is a helper function to compute the absolute difference between
-// two durations. It's commonly used to measure how much running time is spent
-// doing some piece of work.
+// two durations.
 func Difference(a, b time.Duration) time.Duration {
 	diff := a.Nanoseconds() - b.Nanoseconds()
 	if diff < 0 {
 		diff = -diff
+	}
+	return time.Duration(diff)
+}
+
+// Elapsed returns the running time spent doing some piece of work, with
+// grunning.Time() measurements from the start and end.
+//
+// NB: This only exists due to grunning.Time()'s non-monotonicity, a bug in our
+// runtime patch: https://github.com/cockroachdb/cockroach/issues/95529. We can
+// get rid of this, keeping just grunning.Difference(), if that bug is fixed.
+// The bug results in slight {over,under}-estimation of the running time (the
+// latter breaking monotonicity), but is livable with our current uses of this
+// library.
+func Elapsed(start, end time.Duration) time.Duration {
+	diff := end.Nanoseconds() - start.Nanoseconds()
+	if diff < 0 {
+		diff = 0
 	}
 	return time.Duration(diff)
 }


### PR DESCRIPTION
Elapsed returns the running time spent doing some piece of work, with grunning.Time() measurements from the start and end. This only exists due to grunning.Time()'s non-monotonicity, a bug in our runtime patch: #95529. We can get rid of this, keeping just grunning.Difference(), if that bug is fixed. The bug results in slight {over,under}-estimation of the running time (the latter breaking monotonicity), but is livable with our current uses of this library.

Release note: None