### PR TITLE
release-22.1: ingesting: fixup privileges granted during database restore

### DIFF
--- a/pkg/ccl/backupccl/testdata/backup-restore/restore-grants
+++ b/pkg/ccl/backupccl/testdata/backup-restore/restore-grants
@@ -446,6 +446,8 @@ query-sql
 SHOW GRANTS ON SCHEMA testdb.public
 ----
 testdb public admin ALL true
+testdb public public CREATE false
+testdb public public USAGE false
 testdb public root ALL true
 
 query-sql
@@ -536,8 +538,9 @@ query-sql
 SHOW GRANTS ON SCHEMA testdb.public
 ----
 testdb public admin ALL true
+testdb public public CREATE false
+testdb public public USAGE false
 testdb public root ALL true
-testdb public testuser ALL true
 
 query-sql
 SHOW GRANTS ON testdb.sc.othertable
@@ -585,10 +588,13 @@ SELECT owner FROM [SHOW SCHEMAS] WHERE schema_name = 'sc'
 ----
 testuser
 
+# In postgres, the user "postgres" is the owner of the public schema in a
+# newly created db. In CockroachDB, admin is our substitute for the postgres
+# user.
 query-sql
 SELECT owner FROM [SHOW SCHEMAS] WHERE schema_name = 'public'
 ----
-testuser
+admin
 
 # Ensure that testuser is the owner of the type.
 query-sql


### PR DESCRIPTION
Backport 1/1 commits from #95531.

/cc @cockroachdb/release

---

Backport 1/1 commits from #95466.

/cc @cockroachdb/release

---

Previously, all schemas and tables that were ingested as part of a database restore would "inherit" the privileges of the database. The database would be granted `CONNECT` for the `public` role and `ALL` to `admin` and `root`, and so all ingested schemas would have `ALL` for `admin` and `root`. Since 21.2 we have moved away from tables/schemas inheriting privileges from the parent database and so this logic is stale and partly incorrect. It is incorrect because the restored `public` schema does not have `CREATE` and `USAGE` granted to the `public` role. These privileges are always granted to `public` schemas of a database and so there is a discrepancy in restore's behaviour.

This change simplifies the logic to grant schemas and tables their default set of privileges if ingested via a database restore. It leaves the logic for cluster and table restores unchanged.

Release note (bug fix): fixes a bug where a database restore would not grant `CREATE` and `USAGE` on the public schema to the public role

Release justification: low risk bug fix

Fixes: #95456

