### PR TITLE
sql: cache result of nullary UDFs and uncorrelated subqueries

### DIFF
--- a/pkg/sql/logictest/logic.go
+++ b/pkg/sql/logictest/logic.go
@@ -1091,7 +1091,7 @@ func (t *logicTest) substituteVars(line string) string {
 		if replace, ok := t.varMap[varName]; ok {
 			return replace
 		}
-		return line
+		return varName
 	})
 }
 

--- a/pkg/sql/logictest/testdata/logic_test/udf
+++ b/pkg/sql/logictest/testdata/logic_test/udf
@@ -2653,7 +2653,7 @@ statement error pgcode 42883 unknown function: other_udf()
 CREATE FUNCTION err() RETURNS INT LANGUAGE SQL AS 'SELECT other_udf()'
 
 
-subtest subqueries
+subtest subquery
 
 statement ok
 CREATE TABLE sub_all (a INT);

--- a/pkg/sql/logictest/testdata/logic_test/udf
+++ b/pkg/sql/logictest/testdata/logic_test/udf
@@ -2359,6 +2359,41 @@ l1  l2  i1  i2  s1  s2  v1  v2
 2   2   2   2   2   2   12  12
 3   3   3   3   3   3   13  13
 
+statement ok
+CREATE SEQUENCE sq2;
+CREATE FUNCTION rand_i() RETURNS INT IMMUTABLE LANGUAGE SQL AS $$SELECT nextval('sq2')$$;
+CREATE FUNCTION rand_s() RETURNS INT STABLE    LANGUAGE SQL AS $$SELECT nextval('sq2')$$;
+CREATE FUNCTION rand_v() RETURNS INT VOLATILE  LANGUAGE SQL AS $$SELECT nextval('sq2')$$;
+
+# UDFs with mislabeled volatilities. The volatile functions incorrectly marked
+# immutable and stable are evaluated just once, either during optimization or
+# execution.
+#
+# Note: This particular example does not match the behavior of Postgres 14.6
+# exactly, where rand_s() returns a different value in each row. However,
+# Postgres can fold these stable functions in some situations. Specifically,
+# Postgres will fold a stable function if doing so allows it to plan a
+# constrained index scan. For example:
+#
+#   CREATE TABLE t (i INT PRIMARY KEY);
+#   INSERT INTO t SELECT * FROM generate_series(1, 1000000);
+#   ANALYZE t;
+#   CREATE FUNCTION rand_s() RETURNS INT STABLE LANGUAGE SQL AS 'SELECT (10*random())::INT';
+#   SELECT i FROM t WHERE i = rand_s();
+#
+# The query plan of the SELECT is a contrained index scan, with rand_s() only
+# being evalauated once. With this query plan, the SELECT always returns a
+# single row.
+#
+# So, our behavior is more aggressive in folding table functions, but this is
+# perfectly valid.
+query IIIIII rowsort
+SELECT rand_i(), rand_i(), rand_s(), rand_s(), rand_v(), rand_v() FROM generate_series(1, 3)
+----
+1  2  3  4  5  6
+1  2  3  4  7  8
+1  2  3  4  9  10
+
 
 subtest implicit_record_types
 
@@ -2840,10 +2875,10 @@ SELECT oid, proname, pronamespace, proowner, prolang, proleakproof, proisstrict,
 FROM pg_catalog.pg_proc WHERE proname IN ('f_93314', 'f_93314_alias', 'f_93314_comp', 'f_93314_comp_t')
 ORDER BY oid;
 ----
-100259  f_93314         105  1546506610  14  false  false  false  v  0  100258  ·  {}  NULL  SELECT i, e FROM test.public.t_93314 ORDER BY i LIMIT 1;
-100261  f_93314_alias   105  1546506610  14  false  false  false  v  0  100260  ·  {}  NULL  SELECT i, e FROM test.public.t_93314_alias ORDER BY i LIMIT 1;
-100265  f_93314_comp    105  1546506610  14  false  false  false  v  0  100262  ·  {}  NULL  SELECT (1, 2);
-100266  f_93314_comp_t  105  1546506610  14  false  false  false  v  0  100264  ·  {}  NULL  SELECT a, c FROM test.public.t_93314_comp LIMIT 1;
+100263  f_93314         105  1546506610  14  false  false  false  v  0  100262  ·  {}  NULL  SELECT i, e FROM test.public.t_93314 ORDER BY i LIMIT 1;
+100265  f_93314_alias   105  1546506610  14  false  false  false  v  0  100264  ·  {}  NULL  SELECT i, e FROM test.public.t_93314_alias ORDER BY i LIMIT 1;
+100269  f_93314_comp    105  1546506610  14  false  false  false  v  0  100266  ·  {}  NULL  SELECT (1, 2);
+100270  f_93314_comp_t  105  1546506610  14  false  false  false  v  0  100268  ·  {}  NULL  SELECT a, c FROM test.public.t_93314_comp LIMIT 1;
 
 # Regression test for #95240. Strict UDFs that are inlined should result in NULL
 # when presented with NULL arguments.

--- a/pkg/sql/opt/exec/execbuilder/testdata/udf
+++ b/pkg/sql/opt/exec/execbuilder/testdata/udf
@@ -147,33 +147,39 @@ vectorized: true
               spans: LIMITED SCAN
               limit: 1
 
-# TODO(mgartner): The uncorrelated subquery in the UDF body should be executed
-# only once.
+# The uncorrelated subquery in the UDF body is executed only once.
 query T kvtrace
 SELECT sub_fn()
 ----
 Scan /Table/112/{1-2}
 Scan /Table/113/{1-2}
-Scan /Table/113/{1-2}
-Scan /Table/113/{1-2}
 
-# TODO(mgartner): The uncorrelated subquery in the UDF body should be executed
-# only once per row produced by generate_series.
+# The uncorrelated subquery in the UDF body is executed only once per row
+# produced by generate_series.
 query T kvtrace
 SELECT sub_fn() FROM generate_series(1, 3)
 ----
 Scan /Table/112/{1-2}
 Scan /Table/113/{1-2}
-Scan /Table/113/{1-2}
+Scan /Table/112/{1-2}
 Scan /Table/113/{1-2}
 Scan /Table/112/{1-2}
 Scan /Table/113/{1-2}
-Scan /Table/113/{1-2}
-Scan /Table/113/{1-2}
+
+statement ok
+CREATE FUNCTION sub_fn2() RETURNS INT LANGUAGE SQL AS 'SELECT a FROM sub1 WHERE a = (SELECT a FROM sub2 WHERE a = 30)'
+
+# The uncorrelated subquery in the UDF body is fully optimized - it performs
+# a constrained scan of sub2.
+query T kvtrace
+SELECT sub_fn2() FROM generate_series(1, 3)
+----
 Scan /Table/112/{1-2}
-Scan /Table/113/{1-2}
-Scan /Table/113/{1-2}
-Scan /Table/113/{1-2}
+Scan /Table/113/1/30/0
+Scan /Table/112/{1-2}
+Scan /Table/113/1/30/0
+Scan /Table/112/{1-2}
+Scan /Table/113/1/30/0
 
 
 subtest regressions

--- a/pkg/sql/opt/exec/execbuilder/testdata/udf
+++ b/pkg/sql/opt/exec/execbuilder/testdata/udf
@@ -97,12 +97,14 @@ SELECT fetch_a_of_2_strict(1, NULL::INT)
 ----
 
 
-subtest subqueries
+subtest subquery
 
 statement ok
-CREATE TABLE sub1 (a INT);
-CREATE TABLE sub2 (a INT);
-CREATE TABLE sub3 (a INT);
+CREATE TABLE sub1 (a INT PRIMARY KEY);
+CREATE TABLE sub2 (a INT PRIMARY KEY);
+CREATE TABLE sub3 (a INT PRIMARY KEY);
+INSERT INTO sub1 VALUES (1), (2), (3);
+INSERT INTO sub2 VALUES (10), (20), (30);
 
 statement ok
 CREATE FUNCTION sub_fn() RETURNS INT LANGUAGE SQL AS 'SELECT a FROM sub1 WHERE a = (SELECT max(a) FROM sub2)'
@@ -119,7 +121,7 @@ vectorized: true
 │
 ├── • filter
 │   │ columns: (a)
-│   │ estimated row count: 110 (missing stats)
+│   │ estimated row count: 111 (missing stats)
 │   │ filter: (sub_fn() = 3) AND (a = @S1)
 │   │
 │   └── • scan
@@ -134,15 +136,44 @@ vectorized: true
     │ exec mode: one row
     │
     └── • group (scalar)
-        │ columns: (max)
+        │ columns: (any_not_null)
         │ estimated row count: 1 (missing stats)
-        │ aggregate 0: max(a)
+        │ aggregate 0: any_not_null(a)
         │
-        └── • scan
+        └── • revscan
               columns: (a)
-              estimated row count: 1,000 (missing stats)
+              estimated row count: 1 (missing stats)
               table: sub2@sub2_pkey
-              spans: FULL SCAN
+              spans: LIMITED SCAN
+              limit: 1
+
+# TODO(mgartner): The uncorrelated subquery in the UDF body should be executed
+# only once.
+query T kvtrace
+SELECT sub_fn()
+----
+Scan /Table/112/{1-2}
+Scan /Table/113/{1-2}
+Scan /Table/113/{1-2}
+Scan /Table/113/{1-2}
+
+# TODO(mgartner): The uncorrelated subquery in the UDF body should be executed
+# only once per row produced by generate_series.
+query T kvtrace
+SELECT sub_fn() FROM generate_series(1, 3)
+----
+Scan /Table/112/{1-2}
+Scan /Table/113/{1-2}
+Scan /Table/113/{1-2}
+Scan /Table/113/{1-2}
+Scan /Table/112/{1-2}
+Scan /Table/113/{1-2}
+Scan /Table/113/{1-2}
+Scan /Table/113/{1-2}
+Scan /Table/112/{1-2}
+Scan /Table/113/{1-2}
+Scan /Table/113/{1-2}
+Scan /Table/113/{1-2}
 
 
 subtest regressions


### PR DESCRIPTION
#### sql: add tests showing duplicate execution of uncorrelated subqueries

Release note: None

#### logictest: fix bug in let variable replacement

This commit fixes a bug in the implementation of the `let` command that
incorrectly matched and replaced parts of queries with dollar-quotes,
like `CREATE FUNCTION ... AS $$SELECT 1$$`.

Release note: None

#### sql: cache result of nullary UDFs and uncorrelated subqueries

Nullary (zero-argument), non-volatile UDFs and lazily-evaluated,
uncorrelated subqueries now cache the result of their first invocation.
On subsequent invocations, the cached result is returned rather than
evaluating the full UDF or subquery. This eliminates duplicate work, and
makes the behavior of lazily-evaluated, uncorrelated subqueries match
that of eagerly-evaluated, uncorrelated subqueries which are evaluated
once before the main query is evaluated.

Epic: CRDB-20370

Release note: None
