### PR TITLE
cluster-ui: use absolute path in node selector import

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/store/nodes/nodes.selectors.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/store/nodes/nodes.selectors.ts
@@ -13,7 +13,7 @@ import _ from "lodash";
 import { AppState } from "../reducers";
 import { getDisplayName } from "../../nodes";
 import { livenessStatusByNodeIDSelector } from "../liveness";
-import { accumulateMetrics } from "../../util";
+import { accumulateMetrics } from "src/util/proto";
 import { cockroach } from "@cockroachlabs/crdb-protobuf-client";
 type ILocality = cockroach.roachpb.ILocality;
 


### PR DESCRIPTION
Previously, the import path for accumulateMetrics in `nodes.selector.ts` was using a relative path. This for some reason broke the session details page on CC for 23.1.

Epic: none

Release note: None


https://www.loom.com/share/d315f2a605254701b91fc189213b0e41