### PR TITLE
gossip: Remove creation time dependency on grpc

### DIFF
--- a/pkg/gossip/BUILD.bazel
+++ b/pkg/gossip/BUILD.bazel
@@ -42,7 +42,6 @@ go_library(
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_cockroachdb_logtags//:logtags",
         "@com_github_cockroachdb_redact//:redact",
-        "@org_golang_google_grpc//:go_default_library",
     ],
 )
 

--- a/pkg/gossip/client_test.go
+++ b/pkg/gossip/client_test.go
@@ -41,7 +41,7 @@ func startGossip(
 	stopper *stop.Stopper,
 	t *testing.T,
 	registry *metric.Registry,
-) *Gossip {
+) (*Gossip, *rpc.Context) {
 	return startGossipAtAddr(clusterID, nodeID, util.IsolatedTestAddr, stopper, t, registry)
 }
 
@@ -52,14 +52,15 @@ func startGossipAtAddr(
 	stopper *stop.Stopper,
 	t *testing.T,
 	registry *metric.Registry,
-) *Gossip {
+) (*Gossip, *rpc.Context) {
 	ctx := context.Background()
 	clock := hlc.NewClockWithSystemTimeSource(time.Nanosecond /* maxOffset */)
 	rpcContext := rpc.NewInsecureTestingContextWithClusterID(ctx, clock, stopper, clusterID)
 	rpcContext.NodeID.Set(ctx, nodeID)
 
 	server := rpc.NewServer(rpcContext)
-	g := NewTest(nodeID, rpcContext, server, stopper, registry, zonepb.DefaultZoneConfigRef())
+	g := NewTest(nodeID, stopper, registry, zonepb.DefaultZoneConfigRef())
+	RegisterGossipServer(server, g)
 	ln, err := netutil.ListenAndServeGRPC(stopper, server, addr)
 	if err != nil {
 		t.Fatal(err)
@@ -73,7 +74,7 @@ func startGossipAtAddr(
 	}
 	g.start(addr)
 	time.Sleep(time.Millisecond)
-	return g
+	return g, rpcContext
 }
 
 type fakeGossipServer struct {
@@ -121,7 +122,8 @@ func startFakeServerGossips(
 	lRPCContext := rpc.NewInsecureTestingContextWithClusterID(ctx, clock, stopper, clusterID)
 
 	lserver := rpc.NewServer(lRPCContext)
-	local := NewTest(localNodeID, lRPCContext, lserver, stopper, metric.NewRegistry(), zonepb.DefaultZoneConfigRef())
+	local := NewTest(localNodeID, stopper, metric.NewRegistry(), zonepb.DefaultZoneConfigRef())
+	RegisterGossipServer(lserver, local)
 	lln, err := netutil.ListenAndServeGRPC(stopper, lserver, util.IsolatedTestAddr)
 	if err != nil {
 		t.Fatal(err)
@@ -184,8 +186,8 @@ func TestClientGossip(t *testing.T) {
 
 	ctx := context.Background()
 
-	local := startGossip(clusterID, 1, stopper, t, metric.NewRegistry())
-	remote := startGossip(clusterID, 2, stopper, t, metric.NewRegistry())
+	local, _ := startGossip(clusterID, 1, stopper, t, metric.NewRegistry())
+	remote, _ := startGossip(clusterID, 2, stopper, t, metric.NewRegistry())
 	disconnected := make(chan *client, 1)
 	c := newClient(log.MakeTestingAmbientCtxWithNewTracer(), remote.GetNodeAddr(), makeMetrics())
 
@@ -226,8 +228,8 @@ func TestClientGossipMetrics(t *testing.T) {
 	// don't talk to servers from unrelated tests by accident).
 	clusterID := uuid.MakeV4()
 
-	local := startGossip(clusterID, 1, stopper, t, metric.NewRegistry())
-	remote := startGossip(clusterID, 2, stopper, t, metric.NewRegistry())
+	local, _ := startGossip(clusterID, 1, stopper, t, metric.NewRegistry())
+	remote, _ := startGossip(clusterID, 2, stopper, t, metric.NewRegistry())
 
 	if err := local.AddInfo("local-key", nil, time.Hour); err != nil {
 		t.Fatal(err)
@@ -341,12 +343,12 @@ func TestClientDisconnectLoopback(t *testing.T) {
 	ctx := context.Background()
 	stopper := stop.NewStopper()
 	defer stopper.Stop(ctx)
-	local := startGossip(uuid.Nil, 1, stopper, t, metric.NewRegistry())
+	local, localCtx := startGossip(uuid.Nil, 1, stopper, t, metric.NewRegistry())
 	local.mu.Lock()
 	lAddr := local.mu.is.NodeAddr
-	local.startClientLocked(lAddr)
+	local.startClientLocked(lAddr, localCtx)
 	local.mu.Unlock()
-	local.manage()
+	local.manage(localCtx)
 	testutils.SucceedsSoon(t, func() error {
 		ok := local.findClient(func(c *client) bool { return c.addr.String() == lAddr.String() }) != nil
 		if !ok && verifyServerMaps(local, 0) {
@@ -368,16 +370,16 @@ func TestClientDisconnectRedundant(t *testing.T) {
 	// don't talk to servers from unrelated tests by accident).
 	clusterID := uuid.MakeV4()
 
-	local := startGossip(clusterID, 1, stopper, t, metric.NewRegistry())
-	remote := startGossip(clusterID, 2, stopper, t, metric.NewRegistry())
+	local, localCtx := startGossip(clusterID, 1, stopper, t, metric.NewRegistry())
+	remote, remoteCtx := startGossip(clusterID, 2, stopper, t, metric.NewRegistry())
 	local.mu.Lock()
 	remote.mu.Lock()
 	rAddr := remote.mu.is.NodeAddr
 	lAddr := local.mu.is.NodeAddr
 	local.mu.Unlock()
 	remote.mu.Unlock()
-	local.manage()
-	remote.manage()
+	local.manage(localCtx)
+	remote.manage(remoteCtx)
 
 	// Gossip a key on local and wait for it to show up on remote. This
 	// guarantees we have an active local to remote client connection.
@@ -390,7 +392,7 @@ func TestClientDisconnectRedundant(t *testing.T) {
 			// Restart the client connection in the loop. It might have failed due to
 			// a heartbeat time.
 			local.mu.Lock()
-			local.startClientLocked(rAddr)
+			local.startClientLocked(rAddr, localCtx)
 			local.mu.Unlock()
 			return fmt.Errorf("unable to find local to remote client")
 		}
@@ -401,7 +403,7 @@ func TestClientDisconnectRedundant(t *testing.T) {
 	// Start a remote to local client. This client will get removed as being
 	// redundant as there is already a connection between the two nodes.
 	remote.mu.Lock()
-	remote.startClientLocked(lAddr)
+	remote.startClientLocked(lAddr, remoteCtx)
 	remote.mu.Unlock()
 
 	testutils.SucceedsSoon(t, func() error {
@@ -427,8 +429,8 @@ func TestClientDisallowMultipleConns(t *testing.T) {
 	// don't talk to servers from unrelated tests by accident).
 	clusterID := uuid.MakeV4()
 
-	local := startGossip(clusterID, 1, stopper, t, metric.NewRegistry())
-	remote := startGossip(clusterID, 2, stopper, t, metric.NewRegistry())
+	local, localCtx := startGossip(clusterID, 1, stopper, t, metric.NewRegistry())
+	remote, remoteCtx := startGossip(clusterID, 2, stopper, t, metric.NewRegistry())
 
 	local.mu.Lock()
 	remote.mu.Lock()
@@ -436,12 +438,12 @@ func TestClientDisallowMultipleConns(t *testing.T) {
 	// Start two clients from local to remote. RPC client cache is
 	// disabled via the context, so we'll start two different outgoing
 	// connections.
-	local.startClientLocked(rAddr)
-	local.startClientLocked(rAddr)
+	local.startClientLocked(rAddr, localCtx)
+	local.startClientLocked(rAddr, localCtx)
 	local.mu.Unlock()
 	remote.mu.Unlock()
-	local.manage()
-	remote.manage()
+	local.manage(localCtx)
+	remote.manage(remoteCtx)
 	testutils.SucceedsSoon(t, func() error {
 		// Verify that the remote server has only a single incoming
 		// connection and the local server has only a single outgoing
@@ -480,9 +482,8 @@ func TestClientRegisterWithInitNodeID(t *testing.T) {
 		rpcContext := rpc.NewInsecureTestingContextWithClusterID(ctx, clock, stopper, clusterID)
 		server := rpc.NewServer(rpcContext)
 		// node ID must be non-zero
-		gnode := NewTest(
-			nodeID, rpcContext, server, stopper, metric.NewRegistry(), zonepb.DefaultZoneConfigRef(),
-		)
+		gnode := NewTest(nodeID, stopper, metric.NewRegistry(), zonepb.DefaultZoneConfigRef())
+		RegisterGossipServer(server, gnode)
 		g = append(g, gnode)
 
 		ln, err := netutil.ListenAndServeGRPC(stopper, server, util.IsolatedTestAddr)
@@ -496,7 +497,7 @@ func TestClientRegisterWithInitNodeID(t *testing.T) {
 		}
 
 		addresses := []util.UnresolvedAddr{util.MakeUnresolvedAddr("tcp", gossipAddr)}
-		gnode.Start(ln.Addr(), addresses)
+		gnode.Start(ln.Addr(), addresses, rpcContext)
 	}
 
 	testutils.SucceedsSoon(t, func() error {
@@ -518,7 +519,7 @@ func TestClientForwardUnresolved(t *testing.T) {
 	stopper := stop.NewStopper()
 	defer stopper.Stop(context.Background())
 	const nodeID = 1
-	local := startGossip(uuid.Nil, nodeID, stopper, t, metric.NewRegistry())
+	local, _ := startGossip(uuid.Nil, nodeID, stopper, t, metric.NewRegistry())
 	addr := local.GetNodeAddr()
 
 	client := newClient(log.MakeTestingAmbientCtxWithNewTracer(), addr, makeMetrics()) // never started

--- a/pkg/gossip/gossip.go
+++ b/pkg/gossip/gossip.go
@@ -76,7 +76,6 @@ import (
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/logtags"
 	"github.com/cockroachdb/redact"
-	"google.golang.org/grpc"
 )
 
 const (
@@ -222,7 +221,6 @@ type Gossip struct {
 
 	Connected     chan struct{}       // Closed upon initial connection
 	hasConnected  bool                // Set first time network is connected
-	rpcContext    *rpc.Context        // The context required for RPC
 	outgoing      nodeSet             // Set of outgoing client node IDs
 	storage       Storage             // Persistent storage interface
 	bootstrapInfo BootstrapInfo       // BootstrapInfo proto for persistent storage
@@ -276,24 +274,12 @@ type Gossip struct {
 
 // New creates an instance of a gossip node.
 // The higher level manages the ClusterIDContainer and NodeIDContainer instances
-// (which can be shared by various server components). The ambient context is
-// expected to already contain the node ID.
-//
-// grpcServer: The server on which the new Gossip instance will register its RPC
-//
-//	service. Can be nil, in which case the Gossip will not register the
-//	service.
-//
-// rpcContext: The context used to connect to other nodes. Can be nil for tests
-//
-//	that also specify a nil grpcServer and that plan on using the Gossip in a
-//	restricted way by populating it with data manually.
+// (which can be shared by various server components).
+// The struct returned is started by calling Start and passing a rpc.Context.
 func New(
 	ambient log.AmbientContext,
 	clusterID *base.ClusterIDContainer,
 	nodeID *base.NodeIDContainer,
-	rpcContext *rpc.Context,
-	grpcServer *grpc.Server,
 	stopper *stop.Stopper,
 	registry *metric.Registry,
 	locality roachpb.Locality,
@@ -303,7 +289,6 @@ func New(
 	g := &Gossip{
 		server:            newServer(ambient, clusterID, nodeID, stopper, registry),
 		Connected:         make(chan struct{}),
-		rpcContext:        rpcContext,
 		outgoing:          makeNodeSet(minPeers, metric.NewGauge(MetaConnectionsOutgoingGauge)),
 		bootstrapping:     map[string]struct{}{},
 		disconnected:      make(chan *client, 10),
@@ -331,40 +316,23 @@ func New(
 	g.mu.is.registerCallback(MakePrefixPattern(KeyStoreDescPrefix), g.updateStoreMap)
 	g.mu.Unlock()
 
-	if grpcServer != nil {
-		RegisterGossipServer(grpcServer, g.server)
-	}
 	return g
 }
 
 // NewTest is a simplified wrapper around New that creates the
 // ClusterIDContainer and NodeIDContainer internally. Used for testing.
-//
-// grpcServer: The server on which the new Gossip instance will register its RPC
-//
-//	service. Can be nil, in which case the Gossip will not register the
-//	service.
-//
-// rpcContext: The context used to connect to other nodes. Can be nil for tests
-//
-//	that also specify a nil grpcServer and that plan on using the Gossip in a
-//	restricted way by populating it with data manually.
 func NewTest(
 	nodeID roachpb.NodeID,
-	rpcContext *rpc.Context,
-	grpcServer *grpc.Server,
 	stopper *stop.Stopper,
 	registry *metric.Registry,
 	defaultZoneConfig *zonepb.ZoneConfig,
 ) *Gossip {
-	return NewTestWithLocality(nodeID, rpcContext, grpcServer, stopper, registry, roachpb.Locality{}, defaultZoneConfig)
+	return NewTestWithLocality(nodeID, stopper, registry, roachpb.Locality{}, defaultZoneConfig)
 }
 
 // NewTestWithLocality calls NewTest with an explicit locality value.
 func NewTestWithLocality(
 	nodeID roachpb.NodeID,
-	rpcContext *rpc.Context,
-	grpcServer *grpc.Server,
 	stopper *stop.Stopper,
 	registry *metric.Registry,
 	locality roachpb.Locality,
@@ -374,7 +342,7 @@ func NewTestWithLocality(
 	n := &base.NodeIDContainer{}
 	var ac log.AmbientContext
 	ac.AddLogTag("n", n)
-	gossip := New(ac, c, n, rpcContext, grpcServer, stopper, registry, locality, defaultZoneConfig)
+	gossip := New(ac, c, n, stopper, registry, locality, defaultZoneConfig)
 	if nodeID != 0 {
 		n.Set(context.TODO(), nodeID)
 	}
@@ -1173,15 +1141,20 @@ func (g *Gossip) MaxHops() uint32 {
 // instance in the gossip network; it will be used by other instances
 // to connect to this instance.
 //
-// This method starts bootstrap loop, gossip server, and client
-// management in separate goroutines and returns.
-func (g *Gossip) Start(advertAddr net.Addr, addresses []util.UnresolvedAddr) {
+// This method starts bootstrap loop, gossip server, and client management in
+// separate goroutines and returns.
+//
+// The rpcContext is passed in here rather than at struct creation time to allow
+// a looser coupling between the objects at construction.
+func (g *Gossip) Start(
+	advertAddr net.Addr, addresses []util.UnresolvedAddr, rpcContext *rpc.Context,
+) {
 	g.AssertNotStarted(context.Background())
 	g.started = true
 	g.setAddresses(addresses)
 	g.server.start(advertAddr) // serve gossip protocol
-	g.bootstrap()              // bootstrap gossip client
-	g.manage()                 // manage gossip clients
+	g.bootstrap(rpcContext)    // bootstrap gossip client
+	g.manage(rpcContext)       // manage gossip clients
 }
 
 // hasIncomingLocked returns whether the server has an incoming gossip
@@ -1237,7 +1210,7 @@ func (g *Gossip) getNextBootstrapAddressLocked() util.UnresolvedAddr {
 // connection, this method will block on the stalled condvar, which
 // receives notifications that gossip network connectivity has been
 // lost and requires re-bootstrapping.
-func (g *Gossip) bootstrap() {
+func (g *Gossip) bootstrap(rpcContext *rpc.Context) {
 	ctx := g.AnnotateCtx(context.Background())
 	_ = g.server.stopper.RunAsyncTask(ctx, "gossip-bootstrap", func(ctx context.Context) {
 		ctx = logtags.AddTag(ctx, "bootstrap", nil)
@@ -1253,7 +1226,7 @@ func (g *Gossip) bootstrap() {
 				if !haveClients || !haveSentinel {
 					// Try to get another bootstrap address.
 					if addr := g.getNextBootstrapAddressLocked(); !addr.IsEmpty() {
-						g.startClientLocked(addr)
+						g.startClientLocked(addr, rpcContext)
 					} else {
 						bootstrapAddrs := make([]string, 0, len(g.bootstrapping))
 						for addr := range g.bootstrapping {
@@ -1300,7 +1273,7 @@ func (g *Gossip) bootstrap() {
 // the outgoing address set. If there are no longer any outgoing
 // connections or the sentinel gossip is unavailable, the bootstrapper
 // is notified via the stalled conditional variable.
-func (g *Gossip) manage() {
+func (g *Gossip) manage(rpcContext *rpc.Context) {
 	ctx := g.AnnotateCtx(context.Background())
 	_ = g.server.stopper.RunAsyncTask(ctx, "gossip-manage", func(ctx context.Context) {
 		cullTimer := timeutil.NewTimer()
@@ -1315,9 +1288,9 @@ func (g *Gossip) manage() {
 			case <-g.server.stopper.ShouldQuiesce():
 				return
 			case c := <-g.disconnected:
-				g.doDisconnected(c)
+				g.doDisconnected(c, rpcContext)
 			case <-g.tighten:
-				g.tightenNetwork(ctx)
+				g.tightenNetwork(ctx, rpcContext)
 			case <-cullTimer.C:
 				cullTimer.Read = true
 				cullTimer.Reset(jitteredInterval(g.cullInterval))
@@ -1335,7 +1308,7 @@ func (g *Gossip) manage() {
 
 							// After releasing the lock, block until the client disconnects.
 							defer func() {
-								g.doDisconnected(<-g.disconnected)
+								g.doDisconnected(<-g.disconnected, rpcContext)
 							}()
 						} else {
 							if log.V(1) {
@@ -1369,7 +1342,7 @@ func jitteredInterval(interval time.Duration) time.Duration {
 // client to the most distant node to which we don't already have an outgoing
 // connection. Does nothing if we don't have room for any more outgoing
 // connections.
-func (g *Gossip) tightenNetwork(ctx context.Context) {
+func (g *Gossip) tightenNetwork(ctx context.Context, rpcContext *rpc.Context) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
 
@@ -1395,19 +1368,19 @@ func (g *Gossip) tightenNetwork(ctx context.Context) {
 			log.Health.Infof(ctx, "starting client to n%d (%d > %d) to tighten network graph",
 				distantNodeID, distantHops, maxHops)
 			log.Eventf(ctx, "tightening network with new client to %s", nodeAddr)
-			g.startClientLocked(*nodeAddr)
+			g.startClientLocked(*nodeAddr, rpcContext)
 		}
 	}
 }
 
-func (g *Gossip) doDisconnected(c *client) {
+func (g *Gossip) doDisconnected(c *client, rpcContext *rpc.Context) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
 	g.removeClientLocked(c)
 
 	// If the client was disconnected with a forwarding address, connect now.
 	if c.forwardAddr != nil {
-		g.startClientLocked(*c.forwardAddr)
+		g.startClientLocked(*c.forwardAddr, rpcContext)
 	}
 	g.maybeSignalStatusChangeLocked()
 }
@@ -1479,20 +1452,20 @@ func (g *Gossip) signalConnectedLocked() {
 // startClientLocked launches a new client connected to remote address.
 // The client is added to the outgoing address set and launched in
 // a goroutine.
-func (g *Gossip) startClientLocked(addr util.UnresolvedAddr) {
+func (g *Gossip) startClientLocked(addr util.UnresolvedAddr, rpcContext *rpc.Context) {
 	g.clientsMu.Lock()
 	defer g.clientsMu.Unlock()
 	breaker, ok := g.clientsMu.breakers[addr.String()]
 	if !ok {
-		name := fmt.Sprintf("gossip %v->%v", g.rpcContext.Config.Addr, addr)
-		breaker = g.rpcContext.NewBreaker(name)
+		name := fmt.Sprintf("gossip %v->%v", rpcContext.Config.Addr, addr)
+		breaker = rpcContext.NewBreaker(name)
 		g.clientsMu.breakers[addr.String()] = breaker
 	}
 	ctx := g.AnnotateCtx(context.TODO())
 	log.VEventf(ctx, 1, "starting new client to %s", addr)
 	c := newClient(g.server.AmbientContext, &addr, g.serverMetrics)
 	g.clientsMu.clients = append(g.clientsMu.clients, c)
-	c.startLocked(g, g.disconnected, g.rpcContext, g.server.stopper, breaker)
+	c.startLocked(g, g.disconnected, rpcContext, g.server.stopper, breaker)
 }
 
 // removeClientLocked removes the specified client. Called when a client

--- a/pkg/gossip/gossip_test.go
+++ b/pkg/gossip/gossip_test.go
@@ -43,9 +43,7 @@ func TestGossipInfoStore(t *testing.T) {
 	ctx := context.Background()
 	stopper := stop.NewStopper()
 	defer stopper.Stop(ctx)
-	clock := hlc.NewClockWithSystemTimeSource(time.Nanosecond /* maxOffset */)
-	rpcContext := rpc.NewInsecureTestingContext(ctx, clock, stopper)
-	g := NewTest(1, rpcContext, rpc.NewServer(rpcContext), stopper, metric.NewRegistry(), zonepb.DefaultZoneConfigRef())
+	g := NewTest(1, stopper, metric.NewRegistry(), zonepb.DefaultZoneConfigRef())
 	slice := []byte("b")
 	if err := g.AddInfo("s", slice, time.Hour); err != nil {
 		t.Fatal(err)
@@ -65,9 +63,7 @@ func TestGossipMoveNode(t *testing.T) {
 	ctx := context.Background()
 	stopper := stop.NewStopper()
 	defer stopper.Stop(ctx)
-	clock := hlc.NewClockWithSystemTimeSource(time.Nanosecond /* maxOffset */)
-	rpcContext := rpc.NewInsecureTestingContext(ctx, clock, stopper)
-	g := NewTest(1, rpcContext, rpc.NewServer(rpcContext), stopper, metric.NewRegistry(), zonepb.DefaultZoneConfigRef())
+	g := NewTest(1, stopper, metric.NewRegistry(), zonepb.DefaultZoneConfigRef())
 	var nodes []*roachpb.NodeDescriptor
 	for i := 1; i <= 3; i++ {
 		node := &roachpb.NodeDescriptor{
@@ -117,10 +113,7 @@ func TestGossipGetNextBootstrapAddress(t *testing.T) {
 		util.MakeUnresolvedAddr("tcp", "localhost:9004"),
 	}
 
-	clock := hlc.NewClockWithSystemTimeSource(time.Nanosecond /* maxOffset */)
-	rpcContext := rpc.NewInsecureTestingContext(ctx, clock, stopper)
-	server := rpc.NewServer(rpcContext)
-	g := NewTest(0, nil, server, stopper, metric.NewRegistry(), zonepb.DefaultZoneConfigRef())
+	g := NewTest(0, stopper, metric.NewRegistry(), zonepb.DefaultZoneConfigRef())
 	g.setAddresses(addresses)
 
 	// Using specified addresses, fetch bootstrap addresses 3 times
@@ -145,8 +138,6 @@ func TestGossipLocalityResolver(t *testing.T) {
 	ctx := context.Background()
 	stopper := stop.NewStopper()
 	defer stopper.Stop(ctx)
-	clock := hlc.NewClockWithSystemTimeSource(time.Nanosecond /* maxOffset */)
-	rpcContext := rpc.NewInsecureTestingContext(ctx, clock, stopper)
 
 	gossipLocalityAdvertiseList := roachpb.Locality{}
 	tier := roachpb.Tier{}
@@ -181,7 +172,7 @@ func TestGossipLocalityResolver(t *testing.T) {
 	var node2LocalityList []roachpb.LocalityAddress
 	node2LocalityList = append(node2LocalityList, nodeLocalityAddress2)
 
-	g := NewTestWithLocality(1, rpcContext, rpc.NewServer(rpcContext), stopper, metric.NewRegistry(), gossipLocalityAdvertiseList, zonepb.DefaultZoneConfigRef())
+	g := NewTestWithLocality(1, stopper, metric.NewRegistry(), gossipLocalityAdvertiseList, zonepb.DefaultZoneConfigRef())
 	node1 := &roachpb.NodeDescriptor{
 		NodeID:          1,
 		Address:         node1PublicAddressRPC,
@@ -236,11 +227,11 @@ func TestGossipRaceLogStatus(t *testing.T) {
 	// Shared cluster ID by all gossipers (this ensures that the gossipers
 	// don't talk to servers from unrelated tests by accident).
 	clusterID := uuid.MakeV4()
-	local := startGossip(clusterID, 1, stopper, t, metric.NewRegistry())
+	local, localCtx := startGossip(clusterID, 1, stopper, t, metric.NewRegistry())
 
 	local.mu.Lock()
-	peer := startGossip(clusterID, 2, stopper, t, metric.NewRegistry())
-	local.startClientLocked(peer.mu.is.NodeAddr)
+	peer, _ := startGossip(clusterID, 2, stopper, t, metric.NewRegistry())
+	local.startClientLocked(peer.mu.is.NodeAddr, localCtx)
 	local.mu.Unlock()
 
 	// Race gossiping against LogStatus.
@@ -286,7 +277,7 @@ func TestGossipOutgoingLimitEnforced(t *testing.T) {
 	// don't talk to servers from unrelated tests by accident).
 	clusterID := uuid.MakeV4()
 
-	local := startGossip(clusterID, 1, stopper, t, metric.NewRegistry())
+	local, localCtx := startGossip(clusterID, 1, stopper, t, metric.NewRegistry())
 	local.mu.Lock()
 	localAddr := local.mu.is.NodeAddr
 	local.mu.Unlock()
@@ -295,9 +286,9 @@ func TestGossipOutgoingLimitEnforced(t *testing.T) {
 		// After creating a new node, join it to the first node to ensure that the
 		// network is connected (and thus all nodes know each other's addresses)
 		// before we start the actual test.
-		newPeer := startGossip(clusterID, roachpb.NodeID(i+2), stopper, t, metric.NewRegistry())
+		newPeer, peerCtx := startGossip(clusterID, roachpb.NodeID(i+2), stopper, t, metric.NewRegistry())
 		newPeer.mu.Lock()
-		newPeer.startClientLocked(localAddr)
+		newPeer.startClientLocked(localAddr, peerCtx)
 		newPeer.mu.Unlock()
 		peers = append(peers, newPeer)
 	}
@@ -327,7 +318,7 @@ func TestGossipOutgoingLimitEnforced(t *testing.T) {
 		t.Fatal(err)
 	}
 	for range peers {
-		local.tightenNetwork(context.Background())
+		local.tightenNetwork(context.Background(), localCtx)
 	}
 
 	if outgoing := local.outgoing.gauge.Value(); outgoing > int64(maxPeers) {
@@ -346,12 +337,12 @@ func TestGossipMostDistant(t *testing.T) {
 	stopper := stop.NewStopper()
 	defer stopper.Stop(context.Background())
 
-	connect := func(from, to *Gossip) {
+	connect := func(from, to *Gossip, fromCtx *rpc.Context) {
 		to.mu.Lock()
 		addr := to.mu.is.NodeAddr
 		to.mu.Unlock()
 		from.mu.Lock()
-		from.startClientLocked(addr)
+		from.startClientLocked(addr, fromCtx)
 		from.mu.Unlock()
 	}
 
@@ -382,12 +373,13 @@ func TestGossipMostDistant(t *testing.T) {
 			//
 			//   1 <- 2 <- 3 <- 4 <- 5 <- 6 <- 7 <- 8 <- 9 <- 10
 			nodes := make([]*Gossip, n)
+			nodesCtx := make([]*rpc.Context, n)
 			for i := range nodes {
-				nodes[i] = startGossip(clusterID, roachpb.NodeID(i+1), stopper, t, metric.NewRegistry())
+				nodes[i], nodesCtx[i] = startGossip(clusterID, roachpb.NodeID(i+1), stopper, t, metric.NewRegistry())
 				if i == 0 {
 					continue
 				}
-				connect(nodes[i], nodes[i-1])
+				connect(nodes[i], nodes[i-1], nodesCtx[i])
 			}
 
 			// Wait for n1 to determine that n10 is the most distant node.
@@ -418,7 +410,7 @@ func TestGossipMostDistant(t *testing.T) {
 			// Connect the network in a loop. This will cut the distance to the most
 			// distant node in half.
 			log.Infof(context.Background(), "connecting from n%d to n%d", c.from, c.to)
-			connect(nodes[c.from], nodes[c.to])
+			connect(nodes[c.from], nodes[c.to], nodesCtx[c.from])
 
 			// Wait for n1 to determine that n6 is now the most distant hops from 9
 			// to 5 and change the most distant node to n6.
@@ -470,7 +462,7 @@ func TestGossipNoForwardSelf(t *testing.T) {
 	// don't talk to servers from unrelated tests by accident).
 	clusterID := uuid.MakeV4()
 
-	local := startGossip(clusterID, 1, stopper, t, metric.NewRegistry())
+	local, localCtx := startGossip(clusterID, 1, stopper, t, metric.NewRegistry())
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -478,18 +470,22 @@ func TestGossipNoForwardSelf(t *testing.T) {
 	// Start one loopback client plus enough additional clients to fill the
 	// incoming clients.
 	peers := []*Gossip{local}
+	peerCtx := []*rpc.Context{localCtx}
+
 	local.server.mu.Lock()
 	maxSize := local.server.mu.incoming.maxSize
 	local.server.mu.Unlock()
 	for i := 0; i < maxSize; i++ {
-		peers = append(peers, startGossip(clusterID, roachpb.NodeID(i+2), stopper, t, metric.NewRegistry()))
+		g, gCtx := startGossip(clusterID, roachpb.NodeID(i+2), stopper, t, metric.NewRegistry())
+		peers = append(peers, g)
+		peerCtx = append(peerCtx, gCtx)
 	}
 
-	for _, peer := range peers {
+	for i, peer := range peers {
 		c := newClient(log.MakeTestingAmbientCtxWithNewTracer(), local.GetNodeAddr(), makeMetrics())
 
 		testutils.SucceedsSoon(t, func() error {
-			conn, err := peer.rpcContext.GRPCUnvalidatedDial(c.addr.String()).Connect(ctx)
+			conn, err := peerCtx[i].GRPCUnvalidatedDial(c.addr.String()).Connect(ctx)
 			if err != nil {
 				return err
 			}
@@ -518,13 +514,13 @@ func TestGossipNoForwardSelf(t *testing.T) {
 		local.server.mu.Lock()
 		maxSize := local.server.mu.incoming.maxSize
 		local.server.mu.Unlock()
-		peer := startGossip(clusterID, roachpb.NodeID(i+maxSize+2), stopper, t, metric.NewRegistry())
+		peer, peerCtx := startGossip(clusterID, roachpb.NodeID(i+maxSize+2), stopper, t, metric.NewRegistry())
 
 		for {
 			localAddr := local.GetNodeAddr()
 			c := newClient(log.MakeTestingAmbientCtxWithNewTracer(), localAddr, makeMetrics())
 			peer.mu.Lock()
-			c.startLocked(peer, disconnectedCh, peer.rpcContext, stopper, peer.rpcContext.NewBreaker(""))
+			c.startLocked(peer, disconnectedCh, peerCtx, stopper, peerCtx.NewBreaker(""))
 			peer.mu.Unlock()
 
 			disconnectedClient := <-disconnectedCh
@@ -555,13 +551,13 @@ func TestGossipCullNetwork(t *testing.T) {
 	// don't talk to servers from unrelated tests by accident).
 	clusterID := uuid.MakeV4()
 
-	local := startGossip(clusterID, 1, stopper, t, metric.NewRegistry())
+	local, localCtx := startGossip(clusterID, 1, stopper, t, metric.NewRegistry())
 	local.SetCullInterval(5 * time.Millisecond)
 
 	local.mu.Lock()
 	for i := 0; i < minPeers; i++ {
-		peer := startGossip(clusterID, roachpb.NodeID(i+2), stopper, t, metric.NewRegistry())
-		local.startClientLocked(*peer.GetNodeAddr())
+		peer, peerCtx := startGossip(clusterID, roachpb.NodeID(i+2), stopper, t, metric.NewRegistry())
+		local.startClientLocked(*peer.GetNodeAddr(), peerCtx)
 	}
 	local.mu.Unlock()
 
@@ -576,7 +572,7 @@ func TestGossipCullNetwork(t *testing.T) {
 		t.Fatalf("condition failed to evaluate within %s: %s", slowGossipDuration, err)
 	}
 
-	local.manage()
+	local.manage(localCtx)
 
 	if err := retry.ForDuration(slowGossipDuration, func() error {
 		// Verify that a client is closed within the cull interval.
@@ -599,7 +595,7 @@ func TestGossipOrphanedStallDetection(t *testing.T) {
 	// don't talk to servers from unrelated tests by accident).
 	clusterID := uuid.MakeV4()
 
-	local := startGossip(clusterID, 1, stopper, t, metric.NewRegistry())
+	local, localCtx := startGossip(clusterID, 1, stopper, t, metric.NewRegistry())
 	local.SetStallInterval(5 * time.Millisecond)
 
 	// Make sure we have the sentinel to ensure that its absence is not the
@@ -609,14 +605,14 @@ func TestGossipOrphanedStallDetection(t *testing.T) {
 	}
 
 	peerStopper := stop.NewStopper()
-	peer := startGossip(clusterID, 2, peerStopper, t, metric.NewRegistry())
+	peer, _ := startGossip(clusterID, 2, peerStopper, t, metric.NewRegistry())
 
 	peerNodeID := peer.NodeID.Get()
 	peerAddr := peer.GetNodeAddr()
 	peerAddrStr := peerAddr.String()
 
 	local.mu.Lock()
-	local.startClientLocked(*peerAddr)
+	local.startClientLocked(*peerAddr, localCtx)
 	local.mu.Unlock()
 
 	testutils.SucceedsSoon(t, func() error {
@@ -637,8 +633,8 @@ func TestGossipOrphanedStallDetection(t *testing.T) {
 		return errors.Errorf("n%d descriptor not yet available", peerNodeID)
 	})
 
-	local.bootstrap()
-	local.manage()
+	local.bootstrap(localCtx)
+	local.manage(localCtx)
 
 	peerStopper.Stop(context.Background())
 
@@ -713,8 +709,8 @@ func TestGossipJoinTwoClusters(t *testing.T) {
 		server := rpc.NewServer(rpcContext)
 
 		// node ID must be non-zero
-		gnode := NewTest(
-			roachpb.NodeID(i+1), rpcContext, server, stopper, metric.NewRegistry(), zonepb.DefaultZoneConfigRef())
+		gnode := NewTest(roachpb.NodeID(i+1), stopper, metric.NewRegistry(), zonepb.DefaultZoneConfigRef())
+		RegisterGossipServer(server, gnode)
 		g = append(g, gnode)
 		gnode.SetStallInterval(interval)
 		gnode.SetBootstrapInterval(interval)
@@ -734,7 +730,7 @@ func TestGossipJoinTwoClusters(t *testing.T) {
 				addresses = append(addresses, util.MakeUnresolvedAddr("tcp", addrs[j].String()))
 			}
 		}
-		gnode.Start(ln.Addr(), addresses)
+		gnode.Start(ln.Addr(), addresses, rpcContext)
 	}
 
 	// Wait for connections.
@@ -779,13 +775,13 @@ func TestGossipPropagation(t *testing.T) {
 	// don't talk to servers from unrelated tests by accident).
 	clusterID := uuid.MakeV4()
 
-	local := startGossip(clusterID, 1, stopper, t, metric.NewRegistry())
-	remote := startGossip(clusterID, 2, stopper, t, metric.NewRegistry())
+	local, localCtx := startGossip(clusterID, 1, stopper, t, metric.NewRegistry())
+	remote, remoteCtx := startGossip(clusterID, 2, stopper, t, metric.NewRegistry())
 	remote.mu.Lock()
 	rAddr := remote.mu.is.NodeAddr
 	remote.mu.Unlock()
-	local.manage()
-	remote.manage()
+	local.manage(localCtx)
+	remote.manage(remoteCtx)
 
 	mustAdd := func(g *Gossip, key string, val []byte, ttl time.Duration) {
 		if err := g.AddInfo(key, val, ttl); err != nil {
@@ -802,7 +798,7 @@ func TestGossipPropagation(t *testing.T) {
 			// Restart the client connection in the loop. It might have failed due to
 			// a heartbeat timeout.
 			local.mu.Lock()
-			local.startClientLocked(rAddr)
+			local.startClientLocked(rAddr, localCtx)
 			local.mu.Unlock()
 			return fmt.Errorf("unable to find local to remote client")
 		}
@@ -895,13 +891,13 @@ func TestGossipLoopbackInfoPropagation(t *testing.T) {
 	// don't talk to servers from unrelated tests by accident).
 	clusterID := uuid.MakeV4()
 
-	local := startGossip(clusterID, 1, stopper, t, metric.NewRegistry())
-	remote := startGossip(clusterID, 2, stopper, t, metric.NewRegistry())
+	local, localCtx := startGossip(clusterID, 1, stopper, t, metric.NewRegistry())
+	remote, remoteCtx := startGossip(clusterID, 2, stopper, t, metric.NewRegistry())
 	remote.mu.Lock()
 	rAddr := remote.mu.is.NodeAddr
 	remote.mu.Unlock()
-	local.manage()
-	remote.manage()
+	local.manage(localCtx)
+	remote.manage(remoteCtx)
 
 	// Add a gossip info for "foo" on remote, that was generated by local. This
 	// simulates what happens if local was to gossip an info, and later restart
@@ -927,7 +923,7 @@ func TestGossipLoopbackInfoPropagation(t *testing.T) {
 
 	// Start a client connection to the remote node.
 	local.mu.Lock()
-	local.startClientLocked(rAddr)
+	local.startClientLocked(rAddr, localCtx)
 	local.mu.Unlock()
 
 	getInfo := func(g *Gossip, key string) *Info {

--- a/pkg/kv/kvclient/kvcoord/dist_sender_test.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender_test.go
@@ -212,10 +212,8 @@ func (l *simpleTransportAdapter) MoveToFront(replica roachpb.ReplicaDescriptor) 
 func (l *simpleTransportAdapter) Release() {}
 
 func makeGossip(t *testing.T, stopper *stop.Stopper, rpcContext *rpc.Context) *gossip.Gossip {
-	server := rpc.NewServer(rpcContext)
-
 	const nodeID = 1
-	g := gossip.NewTest(nodeID, rpcContext, server, stopper, metric.NewRegistry(), zonepb.DefaultZoneConfigRef())
+	g := gossip.NewTest(nodeID, stopper, metric.NewRegistry(), zonepb.DefaultZoneConfigRef())
 	if err := g.SetNodeDescriptor(newNodeDesc(nodeID)); err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/kv/kvserver/allocator/allocatorimpl/BUILD.bazel
+++ b/pkg/kv/kvserver/allocator/allocatorimpl/BUILD.bazel
@@ -42,7 +42,6 @@ go_test(
     args = ["-test.timeout=295s"],
     embed = [":allocatorimpl"],
     deps = [
-        "//pkg/base",
         "//pkg/config/zonepb",
         "//pkg/gossip",
         "//pkg/keys",
@@ -53,7 +52,6 @@ go_test(
         "//pkg/kv/kvserver/liveness/livenesspb",
         "//pkg/kv/kvserver/replicastats",
         "//pkg/roachpb",
-        "//pkg/rpc",
         "//pkg/settings/cluster",
         "//pkg/testutils",
         "//pkg/testutils/gossiputil",

--- a/pkg/kv/kvserver/allocator/allocatorimpl/allocator_test.go
+++ b/pkg/kv/kvserver/allocator/allocatorimpl/allocator_test.go
@@ -22,7 +22,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/config/zonepb"
 	"github.com/cockroachdb/cockroach/pkg/gossip"
 	"github.com/cockroachdb/cockroach/pkg/keys"
@@ -33,7 +32,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/liveness/livenesspb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/replicastats"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
-	"github.com/cockroachdb/cockroach/pkg/rpc"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/gossiputil"
@@ -8205,18 +8203,7 @@ func TestAllocatorFullDisks(t *testing.T) {
 	tr := tracing.NewTracer()
 	clock := hlc.NewClockWithSystemTimeSource(time.Nanosecond /* maxOffset */)
 
-	// Model a set of stores in a cluster doing rebalancing, with ranges being
-	// randomly added occasionally.
-	rpcContext := rpc.NewContext(ctx, rpc.ContextOptions{
-		TenantID:  roachpb.SystemTenantID,
-		Config:    &base.Config{Insecure: true},
-		Clock:     clock.WallClock(),
-		MaxOffset: clock.MaxOffset(),
-		Stopper:   stopper,
-		Settings:  st,
-	})
-	server := rpc.NewServer(rpcContext) // never started
-	g := gossip.NewTest(1, rpcContext, server, stopper, metric.NewRegistry(), zonepb.DefaultZoneConfigRef())
+	g := gossip.NewTest(1, stopper, metric.NewRegistry(), zonepb.DefaultZoneConfigRef())
 
 	storepool.TimeUntilStoreDead.Override(ctx, &st.SV, storepool.TestTimeUntilStoreDeadOff)
 
@@ -8661,16 +8648,7 @@ func exampleRebalancing(
 
 	// Model a set of stores in a cluster,
 	// adding / rebalancing ranges of random sizes.
-	rpcContext := rpc.NewContext(ctx, rpc.ContextOptions{
-		TenantID:  roachpb.SystemTenantID,
-		Config:    &base.Config{Insecure: true},
-		Clock:     clock.WallClock(),
-		MaxOffset: clock.MaxOffset(),
-		Stopper:   stopper,
-		Settings:  st,
-	})
-	server := rpc.NewServer(rpcContext) // never started
-	g := gossip.NewTest(1, rpcContext, server, stopper, metric.NewRegistry(), zonepb.DefaultZoneConfigRef())
+	g := gossip.NewTest(1, stopper, metric.NewRegistry(), zonepb.DefaultZoneConfigRef())
 
 	storepool.TimeUntilStoreDead.Override(ctx, &st.SV, storepool.TestTimeUntilStoreDeadOff)
 

--- a/pkg/kv/kvserver/allocator/storepool/BUILD.bazel
+++ b/pkg/kv/kvserver/allocator/storepool/BUILD.bazel
@@ -11,7 +11,6 @@ go_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/kv/kvserver/allocator/storepool",
     visibility = ["//visibility:public"],
     deps = [
-        "//pkg/base",
         "//pkg/config/zonepb",
         "//pkg/gossip",
         "//pkg/kv/kvserver/allocator",
@@ -19,7 +18,6 @@ go_library(
         "//pkg/kv/kvserver/liveness",
         "//pkg/kv/kvserver/liveness/livenesspb",
         "//pkg/roachpb",
-        "//pkg/rpc",
         "//pkg/settings",
         "//pkg/settings/cluster",
         "//pkg/util",

--- a/pkg/kv/kvserver/allocator/storepool/test_helpers.go
+++ b/pkg/kv/kvserver/allocator/storepool/test_helpers.go
@@ -14,12 +14,10 @@ import (
 	"context"
 	"time"
 
-	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/config/zonepb"
 	"github.com/cockroachdb/cockroach/pkg/gossip"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/liveness/livenesspb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
-	"github.com/cockroachdb/cockroach/pkg/rpc"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -81,17 +79,7 @@ func CreateTestStorePool(
 	mc := timeutil.NewManualTime(timeutil.Unix(0, 123))
 	clock := hlc.NewClock(mc, time.Nanosecond /* maxOffset */)
 	ambientCtx := log.MakeTestingAmbientContext(stopper.Tracer())
-	rpcContext := rpc.NewContext(ctx,
-		rpc.ContextOptions{
-			TenantID:  roachpb.SystemTenantID,
-			Config:    &base.Config{Insecure: true},
-			Clock:     clock.WallClock(),
-			MaxOffset: clock.MaxOffset(),
-			Stopper:   stopper,
-			Settings:  st,
-		})
-	server := rpc.NewServer(rpcContext) // never started
-	g := gossip.NewTest(1, rpcContext, server, stopper, metric.NewRegistry(), zonepb.DefaultZoneConfigRef())
+	g := gossip.NewTest(1, stopper, metric.NewRegistry(), zonepb.DefaultZoneConfigRef())
 	mnl := NewMockNodeLiveness(defaultNodeStatus)
 
 	TimeUntilStoreDead.Override(ctx, &st.SV, timeUntilStoreDeadValue)

--- a/pkg/kv/kvserver/asim/state/helpers.go
+++ b/pkg/kv/kvserver/asim/state/helpers.go
@@ -73,7 +73,7 @@ func NewStorePool(
 	ambientCtx := log.MakeTestingAmbientContext(stopper.Tracer())
 
 	// Never gossip, pass in nil values.
-	g := gossip.NewTest(1, nil, nil, stopper, metric.NewRegistry(), zonepb.DefaultZoneConfigRef())
+	g := gossip.NewTest(1, stopper, metric.NewRegistry(), zonepb.DefaultZoneConfigRef())
 	sp := storepool.NewStorePool(
 		ambientCtx,
 		st,

--- a/pkg/kv/kvserver/raft_transport_test.go
+++ b/pkg/kv/kvserver/raft_transport_test.go
@@ -140,10 +140,7 @@ func newRaftTransportTestContext(t testing.TB) *raftTransportTestContext {
 	// we can't enforce some of the RPC check validation.
 	rttc.nodeRPCContext.TestingAllowNamedRPCToAnonymousServer = true
 
-	server := rpc.NewServer(rttc.nodeRPCContext) // never started
-	rttc.gossip = gossip.NewTest(
-		1, rttc.nodeRPCContext, server, rttc.stopper, metric.NewRegistry(), zonepb.DefaultZoneConfigRef(),
-	)
+	rttc.gossip = gossip.NewTest(1, rttc.stopper, metric.NewRegistry(), zonepb.DefaultZoneConfigRef())
 
 	return rttc
 }

--- a/pkg/kv/kvserver/store_test.go
+++ b/pkg/kv/kvserver/store_test.go
@@ -193,7 +193,7 @@ func createTestStoreWithoutStart(
 	// TestChooseLeaseToTransfer and TestNoLeaseTransferToBehindReplicas. This is
 	// generally considered bad and should eventually be refactored away.
 	if cfg.Gossip == nil {
-		cfg.Gossip = gossip.NewTest(1, rpcContext, server, stopper, metric.NewRegistry(), zonepb.DefaultZoneConfigRef())
+		cfg.Gossip = gossip.NewTest(1, stopper, metric.NewRegistry(), zonepb.DefaultZoneConfigRef())
 	}
 	if cfg.StorePool == nil {
 		cfg.StorePool = NewTestStorePool(*cfg)

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -259,6 +259,16 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 
 	nodeTombStorage, checkPingFor := getPingCheckDecommissionFn(engines)
 
+	g := gossip.New(
+		cfg.AmbientCtx,
+		cfg.ClusterIDContainer,
+		nodeIDContainer,
+		stopper,
+		registry,
+		cfg.Locality,
+		&cfg.DefaultZoneConfig,
+	)
+
 	rpcCtxOpts := rpc.ContextOptions{
 		TenantID:         roachpb.SystemTenantID,
 		NodeID:           cfg.IDContainer,
@@ -328,18 +338,7 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 	rpcContext.CheckCertificateAddrs(ctx)
 
 	grpcServer := newGRPCServer(rpcContext)
-
-	g := gossip.New(
-		cfg.AmbientCtx,
-		rpcContext.StorageClusterID,
-		nodeIDContainer,
-		rpcContext,
-		grpcServer.Server,
-		stopper,
-		registry,
-		cfg.Locality,
-		&cfg.DefaultZoneConfig,
-	)
+	gossip.RegisterGossipServer(grpcServer.Server, g)
 
 	var dialerKnobs nodedialer.DialerTestingKnobs
 	if dk := cfg.TestingKnobs.DialerKnobs; dk != nil {
@@ -1574,7 +1573,7 @@ func (s *Server) PreStart(ctx context.Context) error {
 	advAddrU := util.NewUnresolvedAddr("tcp", s.cfg.AdvertiseAddr)
 
 	// We're going to need to start gossip before we spin up Node below.
-	s.gossip.Start(advAddrU, filtered)
+	s.gossip.Start(advAddrU, filtered, s.rpcContext)
 	log.Event(ctx, "started gossip")
 
 	// Now that we have a monotonic HLC wrt previous incarnations of the process,

--- a/pkg/sql/distsql_physical_planner_test.go
+++ b/pkg/sql/distsql_physical_planner_test.go
@@ -791,8 +791,7 @@ func TestPartitionSpans(t *testing.T) {
 	// DistSQLPlanner will not plan flows on them.
 	testStopper := stop.NewStopper()
 	defer testStopper.Stop(context.Background())
-	mockGossip := gossip.NewTest(roachpb.NodeID(1), nil /* rpcContext */, nil, /* grpcServer */
-		testStopper, metric.NewRegistry(), zonepb.DefaultZoneConfigRef())
+	mockGossip := gossip.NewTest(roachpb.NodeID(1), testStopper, metric.NewRegistry(), zonepb.DefaultZoneConfigRef())
 	var nodeDescs []*roachpb.NodeDescriptor
 	for i := 1; i <= 10; i++ {
 		sqlInstanceID := base.SQLInstanceID(i)
@@ -987,8 +986,7 @@ func TestPartitionSpansSkipsIncompatibleNodes(t *testing.T) {
 			// reflect tc.nodesNotAdvertisingDistSQLVersion.
 			testStopper := stop.NewStopper()
 			defer testStopper.Stop(context.Background())
-			mockGossip := gossip.NewTest(roachpb.NodeID(1), nil /* rpcContext */, nil, /* grpcServer */
-				testStopper, metric.NewRegistry(), zonepb.DefaultZoneConfigRef())
+			mockGossip := gossip.NewTest(roachpb.NodeID(1), testStopper, metric.NewRegistry(), zonepb.DefaultZoneConfigRef())
 			var nodeDescs []*roachpb.NodeDescriptor
 			for i := 1; i <= 2; i++ {
 				sqlInstanceID := base.SQLInstanceID(i)
@@ -1082,8 +1080,7 @@ func TestPartitionSpansSkipsNodesNotInGossip(t *testing.T) {
 	stopper := stop.NewStopper()
 	defer stopper.Stop(context.Background())
 
-	mockGossip := gossip.NewTest(roachpb.NodeID(1), nil /* rpcContext */, nil, /* grpcServer */
-		stopper, metric.NewRegistry(), zonepb.DefaultZoneConfigRef())
+	mockGossip := gossip.NewTest(roachpb.NodeID(1), stopper, metric.NewRegistry(), zonepb.DefaultZoneConfigRef())
 	var nodeDescs []*roachpb.NodeDescriptor
 	for i := 1; i <= 2; i++ {
 		sqlInstanceID := base.SQLInstanceID(i)
@@ -1178,7 +1175,7 @@ func TestCheckNodeHealth(t *testing.T) {
 
 	const sqlInstanceID = base.SQLInstanceID(5)
 
-	mockGossip := gossip.NewTest(roachpb.NodeID(sqlInstanceID), nil /* rpcContext */, nil, /* grpcServer */
+	mockGossip := gossip.NewTest(roachpb.NodeID(sqlInstanceID),
 		stopper, metric.NewRegistry(), zonepb.DefaultZoneConfigRef())
 
 	desc := &roachpb.NodeDescriptor{

--- a/pkg/sql/physicalplan/replicaoracle/BUILD.bazel
+++ b/pkg/sql/physicalplan/replicaoracle/BUILD.bazel
@@ -29,7 +29,6 @@ go_test(
         "//pkg/config/zonepb",
         "//pkg/gossip",
         "//pkg/roachpb",
-        "//pkg/rpc",
         "//pkg/testutils",
         "//pkg/util",
         "//pkg/util/hlc",

--- a/pkg/sql/physicalplan/replicaoracle/oracle_test.go
+++ b/pkg/sql/physicalplan/replicaoracle/oracle_test.go
@@ -21,7 +21,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/config/zonepb"
 	"github.com/cockroachdb/cockroach/pkg/gossip"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
-	"github.com/cockroachdb/cockroach/pkg/rpc"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
@@ -85,12 +84,9 @@ func TestClosest(t *testing.T) {
 
 func makeGossip(t *testing.T, stopper *stop.Stopper) (*gossip.Gossip, *hlc.Clock) {
 	clock := hlc.NewClockWithSystemTimeSource(time.Nanosecond /* maxOffset */)
-	ctx := context.Background()
-	rpcContext := rpc.NewInsecureTestingContext(ctx, clock, stopper)
-	server := rpc.NewServer(rpcContext)
 
 	const nodeID = 1
-	g := gossip.NewTest(nodeID, rpcContext, server, stopper, metric.NewRegistry(), zonepb.DefaultZoneConfigRef())
+	g := gossip.NewTest(nodeID, stopper, metric.NewRegistry(), zonepb.DefaultZoneConfigRef())
 	if err := g.SetNodeDescriptor(newNodeDesc(nodeID)); err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/testutils/localtestcluster/local_test_cluster.go
+++ b/pkg/testutils/localtestcluster/local_test_cluster.go
@@ -145,8 +145,7 @@ func (ltc *LocalTestCluster) Start(t testing.TB, baseCtx *base.Config, initFacto
 	})
 	cfg.RPCContext.NodeID.Set(ctx, nodeID)
 	clusterID := cfg.RPCContext.StorageClusterID
-	server := rpc.NewServer(cfg.RPCContext) // never started
-	ltc.Gossip = gossip.New(ambient, clusterID, nc, cfg.RPCContext, server, ltc.stopper, metric.NewRegistry(), roachpb.Locality{}, zonepb.DefaultZoneConfigRef())
+	ltc.Gossip = gossip.New(ambient, clusterID, nc, ltc.stopper, metric.NewRegistry(), roachpb.Locality{}, zonepb.DefaultZoneConfigRef())
 	var err error
 	ltc.Eng, err = storage.Open(
 		ctx,


### PR DESCRIPTION
    Create gossip objects without a grpc depencency. The rpcContext is
    injected during Start instead. This removes some code tangles and
    simplifies the usage of gossip in tests.

    Epic: none
    Release note: None