### PR TITLE
build: update ci tests bench script to use iterations

### DIFF
--- a/build/teamcity/cockroach/ci/tests/bench_impl.sh
+++ b/build/teamcity/cockroach/ci/tests/bench_impl.sh
@@ -28,6 +28,6 @@ do
     # We need the `test_sharding_strategy` flag or else the benchmarks will
     # fail to run sharded tests like //pkg/sql/importer:importer_test.
     bazel run --config=test --config=$CROSSLINUX_CONFIG --config=ci --test_sharding_strategy=disabled $target -- \
-          -test.bench=. -test.benchtime=1ns -test.short -test.run=-
+          -test.bench=. -test.benchtime=1x -test.short -test.run=-
     tc_end_block "Bench $target"
 done


### PR DESCRIPTION
The goal of the `bench_impl.sh` script is to confirm microbenchmarks can run for at least 1 iteration successfully. Hence we can change the `test.benchtime` flag from a duration of `1ns` to rather use the iteration notation `1x` and run for 1 iteration.

Epic: CRDB-20903

Release note: None