### PR TITLE
sql: Fix testing_optimizer_disable_rule_probability usage with vtables

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/testdata/virtual
+++ b/pkg/sql/opt/exec/execbuilder/testdata/virtual
@@ -429,3 +429,27 @@ SELECT info FROM [EXPLAIN SELECT count(*) FROM crdb_internal.system_jobs WHERE i
     └── • virtual table
           table: system_jobs@system_jobs_id_idx
           spans: [/1 - /1]
+
+# Regression test for PruneCols fix (#94890)
+statement ok
+SET testing_optimizer_disable_rule_probability = 1.0;
+
+query T
+EXPLAIN SELECT
+  datname AS database_name
+FROM
+  pg_catalog.pg_database d
+ORDER BY
+	database_name
+----
+distribution: local
+vectorized: true
+·
+• sort
+│ order: +datname
+│
+└── • virtual table
+      table: pg_database@primary
+
+statement ok
+RESET testing_optimizer_disable_rule_probability

--- a/pkg/sql/opt/norm/prune_cols_funcs.go
+++ b/pkg/sql/opt/norm/prune_cols_funcs.go
@@ -513,14 +513,28 @@ func DerivePruneCols(e memo.RelExpr, disabledRules intsets.Fast) opt.ColSet {
 	relProps.SetAvailable(props.PruneCols)
 
 	switch e.Op() {
-	case opt.ScanOp, opt.ValuesOp, opt.WithScanOp:
-		if disabledRules.Contains(int(opt.PruneScanCols)) ||
-			disabledRules.Contains(int(opt.PruneValuesCols)) ||
-			disabledRules.Contains(int(opt.PruneWithScanCols)) {
+	case opt.ScanOp:
+		if disabledRules.Contains(int(opt.PruneScanCols)) {
 			// Avoid rule cycles.
 			break
 		}
-		// All columns can potentially be pruned from the Scan, Values, and WithScan
+		// All columns can potentially be pruned from the Scan
+		// operators.
+		relProps.Rule.PruneCols = relProps.OutputCols.Copy()
+	case opt.ValuesOp:
+		if disabledRules.Contains(int(opt.PruneValuesCols)) {
+			// Avoid rule cycles.
+			break
+		}
+		// All columns can potentially be pruned from the Values
+		// operators.
+		relProps.Rule.PruneCols = relProps.OutputCols.Copy()
+	case opt.WithScanOp:
+		if disabledRules.Contains(int(opt.PruneWithScanCols)) {
+			// Avoid rule cycles.
+			break
+		}
+		// All columns can potentially be pruned from the WithScan
 		// operators.
 		relProps.Rule.PruneCols = relProps.OutputCols.Copy()
 


### PR DESCRIPTION
If a vtable scan query tries to use the dummy "0" column the exec
builder errors out, this typically won't happen thanks to prune columns
normalization rules and those rules are marked as "essential" but the
logic allowing those rules to be applied was flawed.

Epic: CRDB-20535
Informs: #94890
Release note: None
