### PR TITLE
tenantcostclient: fix TestWaitingRU flake

### DIFF
--- a/pkg/ccl/multitenantccl/tenantcostclient/tenant_side_test.go
+++ b/pkg/ccl/multitenantccl/tenantcostclient/tenant_side_test.go
@@ -831,9 +831,10 @@ func TestWaitingRU(t *testing.T) {
 				timeSource.Now(), timesToString(timeSource.Timers()))
 		}, timeout)
 
+		const allowedDelta = 0.01
 		available := tenantcostclient.TestingAvailableRU(ctrl)
 		if succeeded {
-			require.Equal(t, tenantcostmodel.RU(0), available)
+			require.InDelta(t, 0, float64(available), allowedDelta)
 			return nil
 		}
 


### PR DESCRIPTION
This patch increases the allowed range of values in a test assertion for `TestWaitingRU` to avoid flakes due to precision errors.

Fixes #95547

Release note: None