### PR TITLE
backupccl: explicitly parse SHOW BACKUP options

### DIFF
--- a/docs/generated/sql/bnf/show_backup.bnf
+++ b/docs/generated/sql/bnf/show_backup.bnf
@@ -1,23 +1,9 @@
 show_backup_stmt ::=
 	'SHOW' 'BACKUPS' 'IN' location_opt_list
-	| 'SHOW' 'BACKUP' show_backup_details 'FROM' string_or_placeholder 'IN' string_or_placeholder_opt_list 'WITH' kv_option_list
-	| 'SHOW' 'BACKUP' show_backup_details 'FROM' string_or_placeholder 'IN' string_or_placeholder_opt_list 'WITH' 'OPTIONS' '(' kv_option_list ')'
-	| 'SHOW' 'BACKUP' show_backup_details 'FROM' string_or_placeholder 'IN' string_or_placeholder_opt_list 
-	| 'SHOW' 'BACKUP' subdirectory 'IN' location_opt_list 'WITH' kv_option_list
-	| 'SHOW' 'BACKUP' subdirectory 'IN' location_opt_list 'WITH' 'OPTIONS' '(' kv_option_list ')'
-	| 'SHOW' 'BACKUP' subdirectory 'IN' location_opt_list 
-	| 'SHOW' 'BACKUP' string_or_placeholder 'WITH' kv_option_list
-	| 'SHOW' 'BACKUP' string_or_placeholder 'WITH' 'OPTIONS' '(' kv_option_list ')'
-	| 'SHOW' 'BACKUP' string_or_placeholder 
-	| 'SHOW' 'BACKUP' 'SCHEMAS' location 'WITH' kv_option_list
-	| 'SHOW' 'BACKUP' 'SCHEMAS' location 'WITH' 'OPTIONS' '(' kv_option_list ')'
-	| 'SHOW' 'BACKUP' 'SCHEMAS' location 
-	| 'SHOW' 'BACKUP' 'FILES' string_or_placeholder 'WITH' kv_option_list
-	| 'SHOW' 'BACKUP' 'FILES' string_or_placeholder 'WITH' 'OPTIONS' '(' kv_option_list ')'
-	| 'SHOW' 'BACKUP' 'FILES' string_or_placeholder 
-	| 'SHOW' 'BACKUP' 'RANGES' string_or_placeholder 'WITH' kv_option_list
-	| 'SHOW' 'BACKUP' 'RANGES' string_or_placeholder 'WITH' 'OPTIONS' '(' kv_option_list ')'
-	| 'SHOW' 'BACKUP' 'RANGES' string_or_placeholder 
-	| 'SHOW' 'BACKUP' 'VALIDATE' string_or_placeholder 'WITH' kv_option_list
-	| 'SHOW' 'BACKUP' 'VALIDATE' string_or_placeholder 'WITH' 'OPTIONS' '(' kv_option_list ')'
-	| 'SHOW' 'BACKUP' 'VALIDATE' string_or_placeholder 
+	| 'SHOW' 'BACKUP' show_backup_details 'FROM' string_or_placeholder 'IN' string_or_placeholder_opt_list opt_with_show_backup_options
+	| 'SHOW' 'BACKUP' subdirectory 'IN' location_opt_list opt_with_show_backup_options
+	| 'SHOW' 'BACKUP' string_or_placeholder opt_with_show_backup_options
+	| 'SHOW' 'BACKUP' 'SCHEMAS' location opt_with_show_backup_options
+	| 'SHOW' 'BACKUP' 'FILES' string_or_placeholder opt_with_show_backup_options
+	| 'SHOW' 'BACKUP' 'RANGES' string_or_placeholder opt_with_show_backup_options
+	| 'SHOW' 'BACKUP' 'VALIDATE' string_or_placeholder opt_with_show_backup_options

--- a/docs/generated/sql/bnf/stmt_block.bnf
+++ b/docs/generated/sql/bnf/stmt_block.bnf
@@ -771,13 +771,13 @@ use_stmt ::=
 
 show_backup_stmt ::=
 	'SHOW' 'BACKUPS' 'IN' string_or_placeholder_opt_list
-	| 'SHOW' 'BACKUP' show_backup_details 'FROM' string_or_placeholder 'IN' string_or_placeholder_opt_list opt_with_options
-	| 'SHOW' 'BACKUP' string_or_placeholder 'IN' string_or_placeholder_opt_list opt_with_options
-	| 'SHOW' 'BACKUP' string_or_placeholder opt_with_options
-	| 'SHOW' 'BACKUP' 'SCHEMAS' string_or_placeholder opt_with_options
-	| 'SHOW' 'BACKUP' 'FILES' string_or_placeholder opt_with_options
-	| 'SHOW' 'BACKUP' 'RANGES' string_or_placeholder opt_with_options
-	| 'SHOW' 'BACKUP' 'VALIDATE' string_or_placeholder opt_with_options
+	| 'SHOW' 'BACKUP' show_backup_details 'FROM' string_or_placeholder 'IN' string_or_placeholder_opt_list opt_with_show_backup_options
+	| 'SHOW' 'BACKUP' string_or_placeholder 'IN' string_or_placeholder_opt_list opt_with_show_backup_options
+	| 'SHOW' 'BACKUP' string_or_placeholder opt_with_show_backup_options
+	| 'SHOW' 'BACKUP' 'SCHEMAS' string_or_placeholder opt_with_show_backup_options
+	| 'SHOW' 'BACKUP' 'FILES' string_or_placeholder opt_with_show_backup_options
+	| 'SHOW' 'BACKUP' 'RANGES' string_or_placeholder opt_with_show_backup_options
+	| 'SHOW' 'BACKUP' 'VALIDATE' string_or_placeholder opt_with_show_backup_options
 
 show_columns_stmt ::=
 	'SHOW' 'COLUMNS' 'FROM' table_name with_comment
@@ -1010,6 +1010,7 @@ unreserved_keyword ::=
 	| 'ALTER'
 	| 'ALWAYS'
 	| 'ASENSITIVE'
+	| 'AS_JSON'
 	| 'AT'
 	| 'ATOMIC'
 	| 'ATTRIBUTE'
@@ -1032,6 +1033,7 @@ unreserved_keyword ::=
 	| 'CAPABILITY'
 	| 'CASCADE'
 	| 'CHANGEFEED'
+	| 'CHECK_FILES'
 	| 'CLOSE'
 	| 'CLUSTER'
 	| 'COLUMNS'
@@ -1069,7 +1071,9 @@ unreserved_keyword ::=
 	| 'DATABASES'
 	| 'DAY'
 	| 'DEALLOCATE'
+	| 'DEBUG_IDS'
 	| 'DEBUG_PAUSE_ON'
+	| 'DEBUG_DUMP_METADATA_SST'
 	| 'DECLARE'
 	| 'DELETE'
 	| 'DEFAULTS'
@@ -1087,6 +1091,7 @@ unreserved_keyword ::=
 	| 'ENCODING'
 	| 'ENCRYPTED'
 	| 'ENCRYPTION_PASSPHRASE'
+	| 'ENCRYPTION_INFO_DIR'
 	| 'ENUM'
 	| 'ENUMS'
 	| 'ESCAPE'
@@ -1901,6 +1906,11 @@ show_backup_details ::=
 	| 'RANGES'
 	| 'VALIDATE'
 
+opt_with_show_backup_options ::=
+	'WITH' show_backup_options_list
+	| 'WITH' 'OPTIONS' '(' show_backup_options_list ')'
+	| 
+
 with_comment ::=
 	'WITH' 'COMMENT'
 	| 
@@ -2642,6 +2652,9 @@ extra_var_value ::=
 	'ON'
 	| cockroachdb_extra_reserved_keyword
 
+show_backup_options_list ::=
+	( show_backup_options ) ( ( ',' show_backup_options ) )*
+
 targets_roles ::=
 	'ROLE' role_spec_list
 	| 'SCHEMA' schema_name_list
@@ -3181,6 +3194,17 @@ for_locking_item ::=
 var_list ::=
 	( var_value ) ( ( ',' var_value ) )*
 
+show_backup_options ::=
+	'AS_JSON'
+	| 'CHECK_FILES'
+	| 'DEBUG_IDS'
+	| 'INCREMENTAL_LOCATION' '=' string_or_placeholder_opt_list
+	| 'KMS' '=' string_or_placeholder_opt_list
+	| 'ENCRYPTION_PASSPHRASE' '=' string_or_placeholder
+	| 'PRIVILEGES'
+	| 'ENCRYPTION_INFO_DIR' '=' string_or_placeholder
+	| 'DEBUG_DUMP_METADATA_SST'
+
 schema_wildcard ::=
 	wildcard_pattern
 
@@ -3382,11 +3406,16 @@ family_name ::=
 	name
 
 bare_label_keywords ::=
-	'ATOMIC'
+	'AS_JSON'
+	| 'ATOMIC'
 	| 'CALLED'
 	| 'COST'
+	| 'CHECK_FILES'
+	| 'DEBUG_IDS'
+	| 'DEBUG_DUMP_METADATA_SST'
 	| 'DEFINER'
 	| 'DEPENDS'
+	| 'ENCRYPTION_INFO_DIR'
 	| 'EXTERNAL'
 	| 'IMMUTABLE'
 	| 'INPUT'

--- a/pkg/ccl/backupccl/backup_planning.go
+++ b/pkg/ccl/backupccl/backup_planning.go
@@ -62,14 +62,6 @@ import (
 )
 
 const (
-	backupOptRevisionHistory  = "revision_history"
-	backupOptWithPrivileges   = "privileges"
-	backupOptAsJSON           = "as_json"
-	backupOptWithDebugIDs     = "debug_ids"
-	backupOptIncStorage       = "incremental_location"
-	backupOptDebugMetadataSST = "debug_dump_metadata_sst"
-	backupOptEncDir           = "encryption_info_dir"
-	backupOptCheckFiles       = "check_files"
 	// backupPartitionDescriptorPrefix is the file name prefix for serialized
 	// BackupPartitionDescriptor protos.
 	backupPartitionDescriptorPrefix = "BACKUP_PART"

--- a/pkg/ccl/backupccl/backup_test.go
+++ b/pkg/ccl/backupccl/backup_test.go
@@ -1226,19 +1226,16 @@ func TestEncryptedBackupRestoreSystemJobs(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			var encryptionOption string
-			var sanitizedEncryptionOption1 string
-			var sanitizedEncryptionOption2 string
+			var sanitizedEncryptionOption string
 			if tc.useKMS {
 				correctKMSURI, _ := getAWSKMSURI(t, regionEnvVariable, keyIDEnvVariable)
 				encryptionOption = fmt.Sprintf("kms = '%s'", correctKMSURI)
 				sanitizedURI, err := redactTestKMSURI(correctKMSURI)
 				require.NoError(t, err)
-				sanitizedEncryptionOption1 = fmt.Sprintf("kms = '%s'", sanitizedURI)
-				sanitizedEncryptionOption2 = sanitizedEncryptionOption1
+				sanitizedEncryptionOption = fmt.Sprintf("kms = '%s'", sanitizedURI)
 			} else {
 				encryptionOption = "encryption_passphrase = 'abcdefg'"
-				sanitizedEncryptionOption1 = "encryption_passphrase = '*****'"
-				sanitizedEncryptionOption2 = "encryption_passphrase = 'redacted'"
+				sanitizedEncryptionOption = "encryption_passphrase = '*****'"
 			}
 			_, sqlDB, _, cleanupFn := backupRestoreTestSetup(t, multiNode, 3, InitManualReplication)
 			conn := sqlDB.DB.(*gosql.DB)
@@ -1261,7 +1258,7 @@ func TestEncryptedBackupRestoreSystemJobs(t *testing.T) {
 					Username: username.RootUserName(),
 					Description: fmt.Sprintf(
 						`BACKUP DATABASE data TO '%s' WITH %s`,
-						backupLoc1, sanitizedEncryptionOption1),
+						backupLoc1, sanitizedEncryptionOption),
 					DescriptorIDs: descpb.IDs{
 						descpb.ID(backupDatabaseID),
 						descpb.ID(backupSchemaID),
@@ -1280,7 +1277,7 @@ into_db='restoredb', %s)`, encryptionOption), backupLoc1)
 				Username: username.RootUserName(),
 				Description: fmt.Sprintf(
 					`RESTORE TABLE data.bank FROM '%s' WITH %s, into_db = 'restoredb'`,
-					backupLoc1, sanitizedEncryptionOption2,
+					backupLoc1, sanitizedEncryptionOption,
 				),
 				DescriptorIDs: descpb.IDs{
 					descpb.ID(restoreDatabaseID + 1),

--- a/pkg/ccl/backupccl/show.go
+++ b/pkg/ccl/backupccl/show.go
@@ -187,11 +187,15 @@ func showBackupTypeCheck(
 	}
 	if err := exprutil.TypeCheck(
 		ctx, "SHOW BACKUP", p.SemaCtx(),
-		exprutil.Strings{backup.Path},
-		exprutil.StringArrays{tree.Exprs(backup.InCollection)},
-		exprutil.KVOptions{
-			KVOptions:  backup.Options,
-			Validation: showBackupOptions,
+		exprutil.Strings{
+			backup.Path,
+			backup.Options.EncryptionPassphrase,
+			backup.Options.EncryptionInfoDir,
+		},
+		exprutil.StringArrays{
+			tree.Exprs(backup.InCollection),
+			tree.Exprs(backup.Options.IncrementalStorage),
+			tree.Exprs(backup.Options.DecryptionKMSURI),
 		},
 	); err != nil {
 		return false, nil, err
@@ -200,52 +204,40 @@ func showBackupTypeCheck(
 	return true, infoReader.header(), nil
 }
 
-var showBackupOptions = exprutil.KVOptionValidationMap{
-	backupencryption.BackupOptEncPassphrase: exprutil.KVStringOptRequireValue,
-	backupencryption.BackupOptEncKMS:        exprutil.KVStringOptRequireValue,
-	backupOptWithPrivileges:                 exprutil.KVStringOptRequireNoValue,
-	backupOptAsJSON:                         exprutil.KVStringOptRequireNoValue,
-	backupOptWithDebugIDs:                   exprutil.KVStringOptRequireNoValue,
-	backupOptIncStorage:                     exprutil.KVStringOptRequireValue,
-	backupOptDebugMetadataSST:               exprutil.KVStringOptRequireNoValue,
-	backupOptEncDir:                         exprutil.KVStringOptRequireValue,
-	backupOptCheckFiles:                     exprutil.KVStringOptRequireNoValue,
-}
-
 // showBackupPlanHook implements PlanHookFn.
 func showBackupPlanHook(
 	ctx context.Context, stmt tree.Statement, p sql.PlanHookState,
 ) (sql.PlanHookRowFn, colinfo.ResultColumns, []sql.PlanNode, bool, error) {
-	backup, ok := stmt.(*tree.ShowBackup)
+	showStmt, ok := stmt.(*tree.ShowBackup)
 	if !ok {
 		return nil, nil, nil, false, nil
 	}
 	exprEval := p.ExprEvaluator("SHOW BACKUP")
-	if backup.Path == nil && backup.InCollection != nil {
+	if showStmt.Path == nil && showStmt.InCollection != nil {
 		collection, err := exprEval.StringArray(
-			ctx, tree.Exprs(backup.InCollection),
+			ctx, tree.Exprs(showStmt.InCollection),
 		)
 		if err != nil {
 			return nil, nil, nil, false, err
 		}
-		return showBackupsInCollectionPlanHook(ctx, collection, backup, p)
+		return showBackupsInCollectionPlanHook(ctx, collection, showStmt, p)
 	}
 
-	to, err := exprEval.String(ctx, backup.Path)
+	to, err := exprEval.String(ctx, showStmt.Path)
 	if err != nil {
 		return nil, nil, nil, false, err
 	}
 
 	var inCol []string
-	if backup.InCollection != nil {
-		inCol, err = exprEval.StringArray(ctx, tree.Exprs(backup.InCollection))
+	if showStmt.InCollection != nil {
+		inCol, err = exprEval.StringArray(ctx, tree.Exprs(showStmt.InCollection))
 		if err != nil {
 			return nil, nil, nil, false, err
 		}
 	}
 
-	infoReader := getBackupInfoReader(p, backup)
-	opts, err := exprEval.KVOptions(ctx, backup.Options, showBackupOptions)
+	infoReader := getBackupInfoReader(p, showStmt)
+
 	if err != nil {
 		return nil, nil, nil, false, err
 	}
@@ -305,12 +297,13 @@ func showBackupPlanHook(
 		}
 
 		// TODO(msbutler): put encryption resolution in helper function, hopefully shared with RESTORE
-		// A user that calls SHOW BACKUP <incremental_dir> on an encrypted incremental
-		// backup will need to pass their full backup's directory to the
-		// encryption_info_dir parameter because the `ENCRYPTION-INFO` file
-		// necessary to decode the incremental backup lives in the full backup dir.
+
 		encStore := baseStores[0]
-		if encDir, ok := opts[backupOptEncDir]; ok {
+		if showStmt.Options.EncryptionInfoDir != nil {
+			encDir, err := exprEval.String(ctx, showStmt.Options.EncryptionInfoDir)
+			if err != nil {
+				return err
+			}
 			encStore, err = p.ExecCfg().DistSQLSrv.ExternalStorageFromURI(ctx, encDir, p.User())
 			if err != nil {
 				return errors.Wrap(err, "make storage")
@@ -326,7 +319,11 @@ func showBackupPlanHook(
 		)
 		showEncErr := `If you are running SHOW BACKUP exclusively on an incremental backup, 
 you must pass the 'encryption_info_dir' parameter that points to the directory of your full backup`
-		if passphrase, ok := opts[backupencryption.BackupOptEncPassphrase]; ok {
+		if showStmt.Options.EncryptionPassphrase != nil {
+			passphrase, err := exprEval.String(ctx, showStmt.Options.EncryptionPassphrase)
+			if err != nil {
+				return err
+			}
 			opts, err := backupencryption.ReadEncryptionOptions(ctx, encStore)
 			if errors.Is(err, backupencryption.ErrEncryptionInfoRead) {
 				return errors.WithHint(err, showEncErr)
@@ -339,7 +336,11 @@ you must pass the 'encryption_info_dir' parameter that points to the directory o
 				Mode: jobspb.EncryptionMode_Passphrase,
 				Key:  encryptionKey,
 			}
-		} else if kms, ok := opts[backupencryption.BackupOptEncKMS]; ok {
+		} else if showStmt.Options.DecryptionKMSURI != nil {
+			kms, err := exprEval.StringArray(ctx, tree.Exprs(showStmt.Options.DecryptionKMSURI))
+			if err != nil {
+				return err
+			}
 			opts, err := backupencryption.ReadEncryptionOptions(ctx, encStore)
 			if errors.Is(err, backupencryption.ErrEncryptionInfoRead) {
 				return errors.WithHint(err, showEncErr)
@@ -347,12 +348,11 @@ you must pass the 'encryption_info_dir' parameter that points to the directory o
 			if err != nil {
 				return err
 			}
-
 			var defaultKMSInfo *jobspb.BackupEncryptionOptions_KMSInfo
 			for _, encFile := range opts {
 				defaultKMSInfo, err = backupencryption.ValidateKMSURIsAgainstFullBackup(
 					ctx,
-					[]string{kms},
+					kms,
 					backupencryption.NewEncryptedDataKeyMapFromProtoMap(encFile.EncryptedDataKeyByKMSMasterKeyID),
 					&kmsEnv,
 				)
@@ -368,16 +368,13 @@ you must pass the 'encryption_info_dir' parameter that points to the directory o
 				KMSInfo: defaultKMSInfo,
 			}
 		}
-		explicitIncPaths := make([]string, 0)
-		explicitIncPath := opts[backupOptIncStorage]
-		if len(explicitIncPath) > 0 {
-			explicitIncPaths = append(explicitIncPaths, explicitIncPath)
-			if len(dest) > 1 {
-				return errors.New("SHOW BACKUP on locality aware backups using incremental_location is" +
-					" not supported yet")
+		var explicitIncPaths []string
+		if showStmt.Options.IncrementalStorage != nil {
+			explicitIncPaths, err = exprEval.StringArray(ctx, tree.Exprs(showStmt.Options.IncrementalStorage))
+			if err != nil {
+				return err
 			}
 		}
-
 		collection, computedSubdir := backupdest.CollectionAndSubdir(dest[0], subdir)
 		fullyResolvedIncrementalsDirectory, err := backupdest.ResolveIncrementalsBackupLocation(
 			ctx,
@@ -465,7 +462,7 @@ you must pass the 'encryption_info_dir' parameter that points to the directory o
 						len(dest)))
 			}
 		}
-		if _, ok := opts[backupOptCheckFiles]; ok {
+		if showStmt.Options.CheckFiles {
 			fileSizes, err := checkBackupFiles(ctx, info, p.ExecCfg(), p.User(), encryption, &kmsEnv)
 			if err != nil {
 				return err
@@ -475,7 +472,7 @@ you must pass the 'encryption_info_dir' parameter that points to the directory o
 		if err := infoReader.showBackup(ctx, &mem, mkStore, info, p.User(), &kmsEnv, resultsCh); err != nil {
 			return err
 		}
-		if backup.InCollection == nil {
+		if showStmt.InCollection == nil {
 			telemetry.Count("show-backup.deprecated-subdir-syntax")
 		} else {
 			telemetry.Count("show-backup.collection")
@@ -486,26 +483,26 @@ you must pass the 'encryption_info_dir' parameter that points to the directory o
 	return fn, infoReader.header(), nil, false, nil
 }
 
-func getBackupInfoReader(p sql.PlanHookState, backup *tree.ShowBackup) backupInfoReader {
+func getBackupInfoReader(p sql.PlanHookState, showStmt *tree.ShowBackup) backupInfoReader {
 	var infoReader backupInfoReader
-	if dumpSST := backup.Options.HasKey(backupOptDebugMetadataSST); dumpSST {
+	if showStmt.Options.DebugMetadataSST {
 		infoReader = metadataSSTInfoReader{}
-	} else if asJSON := backup.Options.HasKey(backupOptAsJSON); asJSON {
+	} else if showStmt.Options.AsJson {
 		infoReader = manifestInfoReader{shower: jsonShower}
 	} else {
 		var shower backupShower
-		switch backup.Details {
+		switch showStmt.Details {
 		case tree.BackupRangeDetails:
 			shower = backupShowerRanges
 		case tree.BackupFileDetails:
-			shower = backupShowerFileSetup(p, backup.InCollection)
+			shower = backupShowerFileSetup(p, showStmt.InCollection)
 		case tree.BackupSchemaDetails:
-			shower = backupShowerDefault(p, true, backup.Options)
+			shower = backupShowerDefault(p, true, showStmt.Options)
 		case tree.BackupValidateDetails:
 			shower = backupShowerDoctor
 
 		default:
-			shower = backupShowerDefault(p, false, backup.Options)
+			shower = backupShowerDefault(p, false, showStmt.Options)
 		}
 		infoReader = manifestInfoReader{shower: shower}
 	}
@@ -659,7 +656,7 @@ type backupShower struct {
 }
 
 // backupShowerHeaders defines the schema for the table presented to the user.
-func backupShowerHeaders(showSchemas bool, opts tree.KVOptions) colinfo.ResultColumns {
+func backupShowerHeaders(showSchemas bool, opts tree.ShowBackupOptions) colinfo.ResultColumns {
 	baseHeaders := colinfo.ResultColumns{
 		{Name: "database_name", Typ: types.String},
 		{Name: "parent_schema_name", Typ: types.String},
@@ -676,14 +673,14 @@ func backupShowerHeaders(showSchemas bool, opts tree.KVOptions) colinfo.ResultCo
 	if showSchemas {
 		baseHeaders = append(baseHeaders, colinfo.ResultColumn{Name: "create_statement", Typ: types.String})
 	}
-	if shouldShowPrivleges := opts.HasKey(backupOptWithPrivileges); shouldShowPrivleges {
+	if opts.Privileges {
 		baseHeaders = append(baseHeaders, colinfo.ResultColumn{Name: "privileges", Typ: types.String})
 		baseHeaders = append(baseHeaders, colinfo.ResultColumn{Name: "owner", Typ: types.String})
 	}
-	if checkFiles := opts.HasKey(backupOptCheckFiles); checkFiles {
+	if opts.CheckFiles {
 		baseHeaders = append(baseHeaders, colinfo.ResultColumn{Name: "file_bytes", Typ: types.Int})
 	}
-	if shouldShowIDs := opts.HasKey(backupOptWithDebugIDs); shouldShowIDs {
+	if opts.DebugIDs {
 		baseHeaders = append(
 			colinfo.ResultColumns{
 				baseHeaders[0],
@@ -699,10 +696,9 @@ func backupShowerHeaders(showSchemas bool, opts tree.KVOptions) colinfo.ResultCo
 	return baseHeaders
 }
 
-func backupShowerDefault(p sql.PlanHookState, showSchemas bool, opts tree.KVOptions) backupShower {
-	shouldShowPrivileges := opts.HasKey(backupOptWithPrivileges)
-	checkFiles := opts.HasKey(backupOptCheckFiles)
-	shouldShowIDs := opts.HasKey(backupOptWithDebugIDs)
+func backupShowerDefault(
+	p sql.PlanHookState, showSchemas bool, opts tree.ShowBackupOptions,
+) backupShower {
 	return backupShower{
 		header: backupShowerHeaders(showSchemas, opts),
 		fn: func(ctx context.Context, info backupInfo) ([]tree.Datums, error) {
@@ -871,15 +867,15 @@ func backupShowerDefault(p sql.PlanHookState, showSchemas bool, opts tree.KVOpti
 					if showSchemas {
 						row = append(row, createStmtDatum)
 					}
-					if shouldShowPrivileges {
+					if opts.Privileges {
 						row = append(row, tree.NewDString(showPrivileges(ctx, desc)))
 						owner := desc.GetPrivileges().Owner().SQLIdentifier()
 						row = append(row, tree.NewDString(owner))
 					}
-					if checkFiles {
+					if opts.CheckFiles {
 						row = append(row, fileSizeDatum)
 					}
-					if shouldShowIDs {
+					if opts.DebugIDs {
 						// If showing debug IDs, interleave the IDs with the corresponding object names.
 						row = append(
 							tree.Datums{
@@ -912,13 +908,13 @@ func backupShowerDefault(p sql.PlanHookState, showSchemas bool, opts tree.KVOpti
 					if showSchemas {
 						row = append(row, tree.DNull)
 					}
-					if shouldShowPrivileges {
+					if opts.Privileges {
 						row = append(row, tree.DNull)
 					}
-					if checkFiles {
+					if opts.CheckFiles {
 						row = append(row, tree.DNull)
 					}
-					if shouldShowIDs {
+					if opts.DebugIDs {
 						// If showing debug IDs, interleave the IDs with the corresponding object names.
 						row = append(
 							tree.Datums{
@@ -1433,7 +1429,7 @@ var showBackupsInCollectionHeader = colinfo.ResultColumns{
 
 // showBackupPlanHook implements PlanHookFn.
 func showBackupsInCollectionPlanHook(
-	ctx context.Context, collection []string, backup *tree.ShowBackup, p sql.PlanHookState,
+	ctx context.Context, collection []string, showStmt *tree.ShowBackup, p sql.PlanHookState,
 ) (sql.PlanHookRowFn, colinfo.ResultColumns, []sql.PlanNode, bool, error) {
 
 	if err := cloudprivilege.CheckDestinationPrivileges(ctx, p, collection); err != nil {
@@ -1441,7 +1437,7 @@ func showBackupsInCollectionPlanHook(
 	}
 
 	fn := func(ctx context.Context, _ []sql.PlanNode, resultsCh chan<- tree.Datums) error {
-		ctx, span := tracing.ChildSpan(ctx, backup.StatementTag())
+		ctx, span := tracing.ChildSpan(ctx, showStmt.StatementTag())
 		defer span.Finish()
 
 		store, err := p.ExecCfg().DistSQLSrv.ExternalStorageFromURI(ctx, collection[0], p.User())

--- a/pkg/ccl/backupccl/show_test.go
+++ b/pkg/ccl/backupccl/show_test.go
@@ -523,7 +523,7 @@ func TestShowBackups(t *testing.T) {
 
 	// check that full and remote incremental backups appear
 	b3 := sqlDBRestore.QueryStr(t,
-		`SELECT * FROM [SHOW BACKUP LATEST IN $1 WITH incremental_location= 'nodelocal://0/foo/inc'] WHERE object_type='table'`, full)
+		`SELECT * FROM [SHOW BACKUP LATEST IN $1 WITH incremental_location = $2 ] WHERE object_type ='table'`, full, remoteInc)
 	require.Equal(t, 3, len(b3))
 
 }

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -704,6 +704,9 @@ func (u *sqlSymUnion) copyOptions() *tree.CopyOptions {
 func (u *sqlSymUnion) showBackupDetails() tree.ShowBackupDetails {
   return u.val.(tree.ShowBackupDetails)
 }
+func (u *sqlSymUnion) showBackupOptions() *tree.ShowBackupOptions {
+  return u.val.(*tree.ShowBackupOptions)
+}
 func (u *sqlSymUnion) restoreOptions() *tree.RestoreOptions {
   return u.val.(*tree.RestoreOptions)
 }
@@ -875,7 +878,7 @@ func (u *sqlSymUnion) showTenantOpts() tree.ShowTenantOptions {
 
 // Ordinary key words in alphabetical order.
 %token <str> ABORT ABSOLUTE ACCESS ACTION ADD ADMIN AFTER AGGREGATE
-%token <str> ALL ALTER ALWAYS ANALYSE ANALYZE AND AND_AND ANY ANNOTATE_TYPE ARRAY AS ASC AT_AT
+%token <str> ALL ALTER ALWAYS ANALYSE ANALYZE AND AND_AND ANY ANNOTATE_TYPE ARRAY AS ASC AS_JSON AT_AT
 %token <str> ASENSITIVE ASYMMETRIC AT ATOMIC ATTRIBUTE AUTHORIZATION AUTOMATIC AVAILABILITY
 
 %token <str> BACKUP BACKUPS BACKWARD BEFORE BEGIN BETWEEN BIGINT BIGSERIAL BINARY BIT
@@ -883,7 +886,7 @@ func (u *sqlSymUnion) showTenantOpts() tree.ShowTenantOptions {
 %token <str> BOOLEAN BOTH BOX2D BUNDLE BY
 
 %token <str> CACHE CALLED CANCEL CANCELQUERY CAPABILITIES CAPABILITY CASCADE CASE CAST CBRT CHANGEFEED CHAR
-%token <str> CHARACTER CHARACTERISTICS CHECK CLOSE
+%token <str> CHARACTER CHARACTERISTICS CHECK CHECK_FILES CLOSE
 %token <str> CLUSTER COALESCE COLLATE COLLATION COLUMN COLUMNS COMMENT COMMENTS COMMIT
 %token <str> COMMITTED COMPACT COMPLETE COMPLETIONS CONCAT CONCURRENTLY CONFIGURATION CONFIGURATIONS CONFIGURE
 %token <str> CONFLICT CONNECTION CONNECTIONS CONSTRAINT CONSTRAINTS CONTAINS CONTROLCHANGEFEED CONTROLJOB
@@ -892,11 +895,11 @@ func (u *sqlSymUnion) showTenantOpts() tree.ShowTenantOptions {
 %token <str> CURRENT_ROLE CURRENT_TIME CURRENT_TIMESTAMP
 %token <str> CURRENT_USER CURSOR CYCLE
 
-%token <str> DATA DATABASE DATABASES DATE DAY DEBUG_PAUSE_ON DEC DECIMAL DEFAULT DEFAULTS DEFINER
+%token <str> DATA DATABASE DATABASES DATE DAY DEBUG_IDS DEBUG_PAUSE_ON DEC DEBUG_DUMP_METADATA_SST DECIMAL DEFAULT DEFAULTS DEFINER
 %token <str> DEALLOCATE DECLARE DEFERRABLE DEFERRED DELETE DELIMITER DEPENDS DESC DESTINATION DETACHED DETAILS
 %token <str> DISCARD DISTINCT DO DOMAIN DOUBLE DROP
 
-%token <str> ELSE ENCODING ENCRYPTED ENCRYPTION_PASSPHRASE END ENUM ENUMS ESCAPE EXCEPT EXCLUDE EXCLUDING
+%token <str> ELSE ENCODING ENCRYPTED ENCRYPTION_INFO_DIR ENCRYPTION_PASSPHRASE END ENUM ENUMS ESCAPE EXCEPT EXCLUDE EXCLUDING
 %token <str> EXISTS EXECUTE EXECUTION EXPERIMENTAL
 %token <str> EXPERIMENTAL_FINGERPRINTS EXPERIMENTAL_REPLICA
 %token <str> EXPERIMENTAL_AUDIT EXPERIMENTAL_RELOCATE
@@ -1307,6 +1310,7 @@ func (u *sqlSymUnion) showTenantOpts() tree.ShowTenantOptions {
 %type <*tree.RestoreOptions> opt_with_restore_options restore_options restore_options_list
 %type <*tree.TenantReplicationOptions> opt_with_tenant_replication_options tenant_replication_options tenant_replication_options_list
 %type <tree.ShowBackupDetails> show_backup_details
+%type <*tree.ShowBackupOptions> opt_with_show_backup_options show_backup_options show_backup_options_list
 %type <*tree.CopyOptions> opt_with_copy_options copy_options copy_options_list
 %type <str> import_format
 %type <str> storage_parameter_key
@@ -7095,63 +7099,63 @@ show_backup_stmt:
       InCollection:    $4.stringOrPlaceholderOptList(),
     }
   }
-| SHOW BACKUP show_backup_details FROM string_or_placeholder IN string_or_placeholder_opt_list opt_with_options
+| SHOW BACKUP show_backup_details FROM string_or_placeholder IN string_or_placeholder_opt_list opt_with_show_backup_options
 	{
 		$$.val = &tree.ShowBackup{
 			From:    true,
 			Details:    $3.showBackupDetails(),
 			Path:    $5.expr(),
 			InCollection: $7.stringOrPlaceholderOptList(),
-			Options: $8.kvOptions(),
+			Options: *$8.showBackupOptions(),
 		}
 	}
-| SHOW BACKUP string_or_placeholder IN string_or_placeholder_opt_list opt_with_options
+| SHOW BACKUP string_or_placeholder IN string_or_placeholder_opt_list opt_with_show_backup_options
 	{
 		$$.val = &tree.ShowBackup{
 			Details:  tree.BackupDefaultDetails,
 			Path:    $3.expr(),
 			InCollection: $5.stringOrPlaceholderOptList(),
-			Options: $6.kvOptions(),
+			Options: *$6.showBackupOptions(),
 		}
 	}
-| SHOW BACKUP string_or_placeholder opt_with_options
+| SHOW BACKUP string_or_placeholder opt_with_show_backup_options
 	{
 		$$.val = &tree.ShowBackup{
 		  Details:  tree.BackupDefaultDetails,
 			Path:    $3.expr(),
-			Options: $4.kvOptions(),
+			Options: *$4.showBackupOptions(),
 		}
 	}
-| SHOW BACKUP SCHEMAS string_or_placeholder opt_with_options
+| SHOW BACKUP SCHEMAS string_or_placeholder opt_with_show_backup_options
 	{
 		$$.val = &tree.ShowBackup{
 		  Details:  tree.BackupSchemaDetails,
 			Path:    $4.expr(),
-			Options: $5.kvOptions(),
+			Options: *$5.showBackupOptions(),
 		}
 	}
-| SHOW BACKUP FILES string_or_placeholder opt_with_options
+| SHOW BACKUP FILES string_or_placeholder opt_with_show_backup_options
 	{
 		$$.val = &tree.ShowBackup{
 		  Details:  tree.BackupFileDetails,
 			Path:    $4.expr(),
-			Options: $5.kvOptions(),
+			Options: *$5.showBackupOptions(),
 		}
 	}
-| SHOW BACKUP RANGES string_or_placeholder opt_with_options
+| SHOW BACKUP RANGES string_or_placeholder opt_with_show_backup_options
 	{
 		$$.val = &tree.ShowBackup{
 		  Details:  tree.BackupRangeDetails,
 			Path:    $4.expr(),
-			Options: $5.kvOptions(),
+			Options: *$5.showBackupOptions(),
 		}
 	}
-| SHOW BACKUP VALIDATE string_or_placeholder opt_with_options
+| SHOW BACKUP VALIDATE string_or_placeholder opt_with_show_backup_options
   	{
   		$$.val = &tree.ShowBackup{
   		  Details:  tree.BackupValidateDetails,
   			Path:    $4.expr(),
-  			Options: $5.kvOptions(),
+  			Options: *$5.showBackupOptions(),
   		}
   	}
 | SHOW BACKUP error // SHOW HELP: SHOW BACKUP
@@ -7177,6 +7181,71 @@ show_backup_details:
 	{
 	$$.val = tree.BackupValidateDetails
 	}
+
+opt_with_show_backup_options:
+  WITH show_backup_options_list
+  {
+    $$.val = $2.showBackupOptions()
+  }
+| WITH OPTIONS '(' show_backup_options_list ')'
+  {
+    $$.val = $4.showBackupOptions()
+  }
+| /* EMPTY */
+  {
+    $$.val = &tree.ShowBackupOptions{}
+  }
+
+show_backup_options_list:
+  // Require at least one option
+  show_backup_options
+  {
+    $$.val = $1.showBackupOptions()
+  }
+| show_backup_options_list ',' show_backup_options
+  {
+    if err := $1.showBackupOptions().CombineWith($3.showBackupOptions()); err != nil {
+      return setErr(sqllex, err)
+    }
+  }
+
+show_backup_options:
+ AS_JSON
+ {
+ $$.val = &tree.ShowBackupOptions{AsJson: true}
+ }
+ | CHECK_FILES
+ {
+ $$.val = &tree.ShowBackupOptions{CheckFiles: true}
+ }
+ | DEBUG_IDS
+ {
+ $$.val = &tree.ShowBackupOptions{DebugIDs: true}
+ }
+ | INCREMENTAL_LOCATION '=' string_or_placeholder_opt_list
+ {
+ $$.val = &tree.ShowBackupOptions{IncrementalStorage: $3.stringOrPlaceholderOptList()}
+ }
+ | KMS '=' string_or_placeholder_opt_list
+ {
+ $$.val = &tree.ShowBackupOptions{DecryptionKMSURI: $3.stringOrPlaceholderOptList()}
+ }
+ | ENCRYPTION_PASSPHRASE '=' string_or_placeholder
+ {
+ $$.val = &tree.ShowBackupOptions{EncryptionPassphrase: $3.expr()}
+ }
+ | PRIVILEGES
+ {
+ $$.val = &tree.ShowBackupOptions{Privileges: true}
+ }
+ | ENCRYPTION_INFO_DIR '=' string_or_placeholder
+ {
+ $$.val = &tree.ShowBackupOptions{EncryptionInfoDir: $3.expr()}
+ }
+ | DEBUG_DUMP_METADATA_SST
+ {
+ $$.val = &tree.ShowBackupOptions{DebugMetadataSST: true}
+ }
 
 // %Help: SHOW CLUSTER SETTING - display cluster settings
 // %Category: Cfg
@@ -15853,6 +15922,7 @@ unreserved_keyword:
 | ALTER
 | ALWAYS
 | ASENSITIVE
+| AS_JSON
 | AT
 | ATOMIC
 | ATTRIBUTE
@@ -15875,6 +15945,7 @@ unreserved_keyword:
 | CAPABILITY
 | CASCADE
 | CHANGEFEED
+| CHECK_FILES
 | CLOSE
 | CLUSTER
 | COLUMNS
@@ -15912,7 +15983,9 @@ unreserved_keyword:
 | DATABASES
 | DAY
 | DEALLOCATE
+| DEBUG_IDS
 | DEBUG_PAUSE_ON
+| DEBUG_DUMP_METADATA_SST
 | DECLARE
 | DELETE
 | DEFAULTS
@@ -15930,6 +16003,7 @@ unreserved_keyword:
 | ENCODING
 | ENCRYPTED
 | ENCRYPTION_PASSPHRASE
+| ENCRYPTION_INFO_DIR
 | ENUM
 | ENUMS
 | ESCAPE
@@ -16279,11 +16353,16 @@ unreserved_keyword:
 // query like "SELECT col label FROM table" where "label" is a new keyword.
 // Any new keyword should be added to this list.
 bare_label_keywords:
-  ATOMIC
+  AS_JSON
+| ATOMIC
 | CALLED
 | COST
+| CHECK_FILES
+| DEBUG_IDS
+| DEBUG_DUMP_METADATA_SST
 | DEFINER
 | DEPENDS
+| ENCRYPTION_INFO_DIR
 | EXTERNAL
 | IMMUTABLE
 | INPUT

--- a/pkg/sql/parser/testdata/backup_restore
+++ b/pkg/sql/parser/testdata/backup_restore
@@ -692,20 +692,21 @@ parse
 RESTORE foo FROM 'bar' WITH OPTIONS (encryption_passphrase='secret', into_db='baz', debug_pause_on='error',
 skip_missing_foreign_keys, skip_missing_sequences, skip_missing_sequence_owners, skip_missing_views, detached, skip_localities_check)
 ----
-RESTORE TABLE foo FROM 'bar' WITH encryption_passphrase = 'secret', into_db = 'baz', debug_pause_on = 'error', skip_missing_foreign_keys, skip_missing_sequence_owners, skip_missing_sequences, skip_missing_views, detached, skip_localities_check -- normalized!
-RESTORE TABLE (foo) FROM ('bar') WITH encryption_passphrase = ('secret'), into_db = ('baz'), debug_pause_on = ('error'), skip_missing_foreign_keys, skip_missing_sequence_owners, skip_missing_sequences, skip_missing_views, detached, skip_localities_check -- fully parenthesized
-RESTORE TABLE foo FROM '_' WITH encryption_passphrase = '_', into_db = '_', debug_pause_on = '_', skip_missing_foreign_keys, skip_missing_sequence_owners, skip_missing_sequences, skip_missing_views, detached, skip_localities_check -- literals removed
-RESTORE TABLE _ FROM 'bar' WITH encryption_passphrase = 'secret', into_db = 'baz', debug_pause_on = 'error', skip_missing_foreign_keys, skip_missing_sequence_owners, skip_missing_sequences, skip_missing_views, detached, skip_localities_check -- identifiers removed
+RESTORE TABLE foo FROM 'bar' WITH encryption_passphrase = '*****', into_db = 'baz', debug_pause_on = 'error', skip_missing_foreign_keys, skip_missing_sequence_owners, skip_missing_sequences, skip_missing_views, detached, skip_localities_check -- normalized!
+RESTORE TABLE (foo) FROM ('bar') WITH encryption_passphrase = '*****', into_db = ('baz'), debug_pause_on = ('error'), skip_missing_foreign_keys, skip_missing_sequence_owners, skip_missing_sequences, skip_missing_views, detached, skip_localities_check -- fully parenthesized
+RESTORE TABLE foo FROM '_' WITH encryption_passphrase = '*****', into_db = '_', debug_pause_on = '_', skip_missing_foreign_keys, skip_missing_sequence_owners, skip_missing_sequences, skip_missing_views, detached, skip_localities_check -- literals removed
+RESTORE TABLE _ FROM 'bar' WITH encryption_passphrase = '*****', into_db = 'baz', debug_pause_on = 'error', skip_missing_foreign_keys, skip_missing_sequence_owners, skip_missing_sequences, skip_missing_views, detached, skip_localities_check -- identifiers removed
+RESTORE TABLE foo FROM 'bar' WITH encryption_passphrase = 'secret', into_db = 'baz', debug_pause_on = 'error', skip_missing_foreign_keys, skip_missing_sequence_owners, skip_missing_sequences, skip_missing_views, detached, skip_localities_check -- passwords exposed
 
 parse
 RESTORE foo FROM 'bar' WITH ENCRYPTION_PASSPHRASE = 'secret', INTO_DB=baz, DEBUG_PAUSE_ON='error',
 SKIP_MISSING_FOREIGN_KEYS, SKIP_MISSING_SEQUENCES, SKIP_MISSING_SEQUENCE_OWNERS, SKIP_MISSING_VIEWS, SKIP_LOCALITIES_CHECK
 ----
-RESTORE TABLE foo FROM 'bar' WITH encryption_passphrase = 'secret', into_db = 'baz', debug_pause_on = 'error', skip_missing_foreign_keys, skip_missing_sequence_owners, skip_missing_sequences, skip_missing_views, skip_localities_check -- normalized!
-RESTORE TABLE (foo) FROM ('bar') WITH encryption_passphrase = ('secret'), into_db = ('baz'), debug_pause_on = ('error'), skip_missing_foreign_keys, skip_missing_sequence_owners, skip_missing_sequences, skip_missing_views, skip_localities_check -- fully parenthesized
-RESTORE TABLE foo FROM '_' WITH encryption_passphrase = '_', into_db = '_', debug_pause_on = '_', skip_missing_foreign_keys, skip_missing_sequence_owners, skip_missing_sequences, skip_missing_views, skip_localities_check -- literals removed
-RESTORE TABLE _ FROM 'bar' WITH encryption_passphrase = 'secret', into_db = 'baz', debug_pause_on = 'error', skip_missing_foreign_keys, skip_missing_sequence_owners, skip_missing_sequences, skip_missing_views, skip_localities_check -- identifiers removed
-
+RESTORE TABLE foo FROM 'bar' WITH encryption_passphrase = '*****', into_db = 'baz', debug_pause_on = 'error', skip_missing_foreign_keys, skip_missing_sequence_owners, skip_missing_sequences, skip_missing_views, skip_localities_check -- normalized!
+RESTORE TABLE (foo) FROM ('bar') WITH encryption_passphrase = '*****', into_db = ('baz'), debug_pause_on = ('error'), skip_missing_foreign_keys, skip_missing_sequence_owners, skip_missing_sequences, skip_missing_views, skip_localities_check -- fully parenthesized
+RESTORE TABLE foo FROM '_' WITH encryption_passphrase = '*****', into_db = '_', debug_pause_on = '_', skip_missing_foreign_keys, skip_missing_sequence_owners, skip_missing_sequences, skip_missing_views, skip_localities_check -- literals removed
+RESTORE TABLE _ FROM 'bar' WITH encryption_passphrase = '*****', into_db = 'baz', debug_pause_on = 'error', skip_missing_foreign_keys, skip_missing_sequence_owners, skip_missing_sequences, skip_missing_views, skip_localities_check -- identifiers removed
+RESTORE TABLE foo FROM 'bar' WITH encryption_passphrase = 'secret', into_db = 'baz', debug_pause_on = 'error', skip_missing_foreign_keys, skip_missing_sequence_owners, skip_missing_sequences, skip_missing_views, skip_localities_check -- passwords exposed
 
 parse
 RESTORE TENANT 36 FROM ($1, $2) AS OF SYSTEM TIME '1'

--- a/pkg/sql/parser/testdata/backup_restore
+++ b/pkg/sql/parser/testdata/backup_restore
@@ -103,12 +103,30 @@ SHOW BACKUP '_' -- literals removed
 SHOW BACKUP 'bar' -- identifiers removed
 
 parse
-SHOW BACKUP 'bar' WITH foo = 'bar'
+SHOW BACKUP 'bar' WITH ENCRYPTION_PASSPHRASE = 'secret', CHECK_FILES
 ----
-SHOW BACKUP 'bar' WITH foo = 'bar'
-SHOW BACKUP ('bar') WITH foo = ('bar') -- fully parenthesized
-SHOW BACKUP '_' WITH foo = '_' -- literals removed
-SHOW BACKUP 'bar' WITH _ = 'bar' -- identifiers removed
+SHOW BACKUP 'bar' WITH check_files, encryption_passphrase = '*****' -- normalized!
+SHOW BACKUP ('bar') WITH check_files, encryption_passphrase = '*****' -- fully parenthesized
+SHOW BACKUP '_' WITH check_files, encryption_passphrase = '*****' -- literals removed
+SHOW BACKUP 'bar' WITH check_files, encryption_passphrase = '*****' -- identifiers removed
+SHOW BACKUP 'bar' WITH check_files, encryption_passphrase = 'secret' -- passwords exposed
+
+parse
+SHOW BACKUP FROM LATEST IN 'bar' WITH incremental_location = 'baz'
+----
+SHOW BACKUP FROM 'latest' IN 'bar' WITH incremental_location = 'baz' -- normalized!
+SHOW BACKUP FROM ('latest') IN ('bar') WITH incremental_location = ('baz') -- fully parenthesized
+SHOW BACKUP FROM '_' IN '_' WITH incremental_location = '_' -- literals removed
+SHOW BACKUP FROM 'latest' IN 'bar' WITH incremental_location = 'baz' -- identifiers removed
+
+parse
+SHOW BACKUP FROM LATEST IN ('bar','bar1') WITH KMS = ('foo', 'bar'), incremental_location=('hi','hello')
+----
+SHOW BACKUP FROM 'latest' IN ('bar', 'bar1') WITH incremental_location = ('hi', 'hello'), kms = ('foo', 'bar') -- normalized!
+SHOW BACKUP FROM ('latest') IN (('bar'), ('bar1')) WITH incremental_location = (('hi'), ('hello')), kms = (('foo'), ('bar')) -- fully parenthesized
+SHOW BACKUP FROM '_' IN ('_', '_') WITH incremental_location = ('_', '_'), kms = ('_', '_') -- literals removed
+SHOW BACKUP FROM 'latest' IN ('bar', 'bar1') WITH incremental_location = ('hi', 'hello'), kms = ('foo', 'bar') -- identifiers removed
+
 
 parse
 EXPLAIN SHOW BACKUP 'bar'
@@ -135,14 +153,6 @@ SHOW BACKUP FILES '_' -- literals removed
 SHOW BACKUP FILES 'bar' -- identifiers removed
 
 parse
-SHOW BACKUP FILES 'bar' WITH foo = 'bar'
-----
-SHOW BACKUP FILES 'bar' WITH foo = 'bar'
-SHOW BACKUP FILES ('bar') WITH foo = ('bar') -- fully parenthesized
-SHOW BACKUP FILES '_' WITH foo = '_' -- literals removed
-SHOW BACKUP FILES 'bar' WITH _ = 'bar' -- identifiers removed
-
-parse
 SHOW BACKUPS IN 'bar'
 ----
 SHOW BACKUPS IN 'bar'
@@ -167,12 +177,12 @@ SHOW BACKUP '_' IN '_' -- literals removed
 SHOW BACKUP 'foo' IN 'bar' -- identifiers removed
 
 parse
-SHOW BACKUP FROM $1 IN $2 WITH foo = 'bar'
+SHOW BACKUP FROM $1 IN $2 WITH privileges
 ----
-SHOW BACKUP FROM $1 IN $2 WITH foo = 'bar'
-SHOW BACKUP FROM ($1) IN ($2) WITH foo = ('bar') -- fully parenthesized
-SHOW BACKUP FROM $1 IN $1 WITH foo = '_' -- literals removed
-SHOW BACKUP FROM $1 IN $2 WITH _ = 'bar' -- identifiers removed
+SHOW BACKUP FROM $1 IN $2 WITH privileges
+SHOW BACKUP FROM ($1) IN ($2) WITH privileges -- fully parenthesized
+SHOW BACKUP FROM $1 IN $1 WITH privileges -- literals removed
+SHOW BACKUP FROM $1 IN $2 WITH privileges -- identifiers removed
 
 parse
 SHOW BACKUP FILES FROM 'foo' IN 'bar'
@@ -199,12 +209,13 @@ SHOW BACKUP SCHEMAS FROM '_' IN '_' -- literals removed
 SHOW BACKUP SCHEMAS FROM 'foo' IN 'bar' -- identifiers removed
 
 parse
-SHOW BACKUP $1 IN $2 WITH foo = 'bar'
+SHOW BACKUP $1 IN $2 WITH ENCRYPTION_PASSPHRASE = 'secret', ENCRYPTION_INFO_DIR = 'long_live_backupper'
 ----
-SHOW BACKUP $1 IN $2 WITH foo = 'bar'
-SHOW BACKUP ($1) IN ($2) WITH foo = ('bar') -- fully parenthesized
-SHOW BACKUP $1 IN $1 WITH foo = '_' -- literals removed
-SHOW BACKUP $1 IN $2 WITH _ = 'bar' -- identifiers removed
+SHOW BACKUP $1 IN $2 WITH encryption_passphrase = '*****', encryption_info_dir = 'long_live_backupper' -- normalized!
+SHOW BACKUP ($1) IN ($2) WITH encryption_passphrase = '*****', encryption_info_dir = ('long_live_backupper') -- fully parenthesized
+SHOW BACKUP $1 IN $1 WITH encryption_passphrase = '*****', encryption_info_dir = '_' -- literals removed
+SHOW BACKUP $1 IN $2 WITH encryption_passphrase = '*****', encryption_info_dir = 'long_live_backupper' -- identifiers removed
+SHOW BACKUP $1 IN $2 WITH encryption_passphrase = 'secret', encryption_info_dir = 'long_live_backupper' -- passwords exposed
 
 parse
 BACKUP TABLE foo TO 'bar' AS OF SYSTEM TIME '1' INCREMENTAL FROM 'baz'

--- a/pkg/sql/sem/tree/backup.go
+++ b/pkg/sql/sem/tree/backup.go
@@ -356,7 +356,11 @@ func (o *RestoreOptions) Format(ctx *FmtCtx) {
 	if o.EncryptionPassphrase != nil {
 		addSep = true
 		ctx.WriteString("encryption_passphrase = ")
-		ctx.FormatNode(o.EncryptionPassphrase)
+		if ctx.flags.HasFlags(FmtShowPasswords) {
+			ctx.FormatNode(o.EncryptionPassphrase)
+		} else {
+			ctx.WriteString(PasswordSubstitution)
+		}
 	}
 
 	if o.DecryptionKMSURI != nil {


### PR DESCRIPTION
Fixes: https://github.com/cockroachdb/cockroach/issues/82912

Release note (sql change): Previously, SHOW BACKUP options would get parsed as
`kv_options`, which meant that a user could not pass multiple values to a show
backup option, causing feature gaps in SHOW BACKUP relative to BACKUP and
RESTORE. This patch rewrites the show backup option parser, closing the
following feature gaps:
 1. A user can now pass and check multiple KMS URIs in
SHOW BACKUP 
2. A user can pass locality aware incremental_locations, allowing a
user to also pass the check_files parameter to a locality aware backup chain
that also specifies the backup incremental location.

Note that while this patch introduces a couple new words to the CRDB SQL
syntax, the same SHOW BACKUP options should remain documented, specifically:
- [public option] -> value
- AS_JSON -> N/A
- CHECK_FILES -> N/A
- INCREMENTAL_LOCATION -> string, with potentially multiple uris
- DEBUG_IDS -> N/A
- KMS -> string, with potentially multiple uris
- PRIVILEGES -> N/A
- ENCRYPTION_PASSPHRASE -> string