### PR TITLE
cpustopwatch: s/grunning.Difference/grunning.Elapsed

### DIFF
--- a/pkg/util/timeutil/cpustopwatch.go
+++ b/pkg/util/timeutil/cpustopwatch.go
@@ -95,7 +95,7 @@ func (w *cpuStopWatch) stop() {
 	if w == nil {
 		return
 	}
-	w.totalCPU += grunning.Difference(w.startCPU, grunning.Time())
+	w.totalCPU += grunning.Elapsed(w.startCPU, grunning.Time())
 }
 
 func (w *cpuStopWatch) elapsed() time.Duration {


### PR DESCRIPTION
`grunning.Elapsed()` is the API to use when measuring the running time spent doing some piece of work, with measurements from the start and end. This only exists due to `grunning.Time()`'s non-monotonicity, a bug in our runtime patch: #95529. The bug results in slight {over,under}-estimation of the running time (the latter breaking monotonicity), but is livable with our current uses of this library, including the one here in cpustopwatch. `grunning.Elapsed()` papers over this bug by 0-ing out when `grunning.Time()`stamps regress. This is unlike `grunning.Difference()` which would return the absolute value of the regression -- not what we want here.

Release note: None