### PR TITLE
sql,multitenant: simplify the cap pb package name

### DIFF
--- a/pkg/multitenant/tenantcapabilities/tenantcapabilitiespb/capabilities.proto
+++ b/pkg/multitenant/tenantcapabilities/tenantcapabilitiespb/capabilities.proto
@@ -9,7 +9,7 @@
 // licenses/APL.txt.
 
 syntax = "proto3";
-package cockroach.multitenant.tenantcapabilities.tenantcapabilitiespb;
+package cockroach.multitenant.tenantcapabilitiespb;
 option go_package = "tenantcapabilitiespb";
 
 import "gogoproto/gogo.proto";
@@ -29,4 +29,3 @@ message TenantCapabilities {
   // successfully perform `AdminSplit` requests.
   bool can_admin_split = 1;
 };
-

--- a/pkg/sql/catalog/descpb/tenant.proto
+++ b/pkg/sql/catalog/descpb/tenant.proto
@@ -55,7 +55,7 @@ message TenantInfo {
 
   // Capabilities encapsulate a set of capabilities that a specific tenant
   // possesses.
-  optional multitenant.tenantcapabilities.tenantcapabilitiespb.TenantCapabilities capabilities = 6 [
+  optional cockroach.multitenant.tenantcapabilitiespb.TenantCapabilities capabilities = 6 [
     (gogoproto.nullable) = false
   ];
 }


### PR DESCRIPTION
Fixes  #95572

proto packages don't need to have a relationship with the filesystem path.

Release note: None