### PR TITLE
release-22.2: builtins: make pg_get_indexdef handle expression indexes

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/builtin_function
+++ b/pkg/sql/logictest/testdata/logic_test/builtin_function
@@ -2256,10 +2256,13 @@ SELECT pg_catalog.pg_get_indexdef((SELECT oid from pg_class WHERE relname='pg_in
 ----
 b
 
+# The empty string should be returned for index 3. Previously, there was a bug
+# where this would return the primary key column name, since the primary key
+# is stored in the index.
 query T
 SELECT pg_catalog.pg_get_indexdef((SELECT oid from pg_class WHERE relname='pg_indexdef_cols_idx'), 3, false)
 ----
-rowid
+·
 
 query I
 SELECT length(pg_catalog.pg_get_indexdef((SELECT oid from pg_class WHERE relname='pg_indexdef_cols_idx'), 4, false))

--- a/pkg/sql/logictest/testdata/logic_test/pg_builtins
+++ b/pkg/sql/logictest/testdata/logic_test/pg_builtins
@@ -809,3 +809,24 @@ query T
 SELECT to_regtype('test_type')
 ----
 test_type
+
+# Test that pg_get_indexdef works for expression indexes.
+statement ok
+CREATE TABLE expr_idx_tbl (id string PRIMARY key, json JSON)
+
+statement ok
+CREATE INDEX expr_idx ON expr_idx_tbl (id, (json->>'bar'), (length(id)))
+
+query T
+SELECT pg_get_indexdef((SELECT oid FROM pg_class WHERE relname = 'expr_idx' LIMIT 1))
+----
+CREATE INDEX expr_idx ON test.public.expr_idx_tbl USING btree (id ASC, (json->>'bar'::STRING) ASC, length(id) ASC)
+
+query IT
+SELECT k, pg_get_indexdef((SELECT oid FROM pg_class WHERE relname = 'expr_idx' LIMIT 1), k, true) FROM generate_series(0,4) k ORDER BY k
+----
+0  CREATE INDEX expr_idx ON test.public.expr_idx_tbl USING btree (id ASC, (json->>'bar'::STRING) ASC, length(id) ASC)
+1  id
+2  (json->>'bar'::STRING)
+3  (length(id))
+4  ·

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -1077,10 +1077,10 @@ SELECT indexrelid, indrelid, indislive, indisreplident, indkey, indcollation, in
 FROM pg_catalog.pg_index
 WHERE indnkeyatts = 2
 ----
-indexrelid  indrelid  indislive  indisreplident  indkey  indcollation  indclass  indoption  indexprs            indpred
-3687884464  110       true       false           3 4     0 0           0 0       2 2        NULL                NULL
-2695335053  114       true       false           1 2 3   0 0           0 0       2 1        NULL                NULL
-2129466854  120       true       false           0 0     3403232968 0  0 0       2 2        (lower(c)) (a + b)  NULL
+indexrelid  indrelid  indislive  indisreplident  indkey  indcollation  indclass  indoption  indexprs                indpred
+3687884464  110       true       false           3 4     0 0           0 0       2 2        NULL                    NULL
+2695335053  114       true       false           1 2 3   0 0           0 0       2 1        NULL                    NULL
+2129466854  120       true       false           0 0     3403232968 0  0 0       2 2        {(lower(c)),"(a + b)"}  NULL
 
 # Index expression elements should have an indkey of 0 and be included in
 # indexprs.
@@ -1093,12 +1093,12 @@ JOIN pg_catalog.pg_class c ON i.indexrelid = c.oid
 WHERE c.relname LIKE 't6_%'
 ORDER BY 1
 ----
-relname            indkey  indexprs                                  indpred
-t6_expr_expr1_idx  0 0     (lower(c)) (a + b)                        NULL
-t6_expr_idx        0       (a + b)                                   NULL
-t6_expr_idx1       0       (m = 'foo'::constraint_db.public.mytype)  m = 'foo'::constraint_db.public.mytype
-t6_expr_key        0       (lower(c))                                NULL
-t6_pkey            6       NULL                                      NULL
+relname            indkey  indexprs                                      indpred
+t6_expr_expr1_idx  0 0     {(lower(c)),"(a + b)"}                        NULL
+t6_expr_idx        0       {"(a + b)"}                                   NULL
+t6_expr_idx1       0       {"(m = 'foo'::constraint_db.public.mytype)"}  m = 'foo'::constraint_db.public.mytype
+t6_expr_key        0       {(lower(c))}                                  NULL
+t6_pkey            6       NULL                                          NULL
 
 statement ok
 SET DATABASE = system

--- a/pkg/sql/sem/builtins/pg_builtins.go
+++ b/pkg/sql/sem/builtins/pg_builtins.go
@@ -210,41 +210,29 @@ func makePGGetIndexDef(argTypes tree.ArgTypes) tree.Overload {
 		Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
 			colNumber := *tree.NewDInt(0)
 			if len(args) == 3 {
+				// The 1 argument and 3 argument variants are equivalent when column number 0 is passed.
 				colNumber = *args[1].(*tree.DInt)
 			}
+			// The 3 argument variant for column number other than 0 returns the column name.
 			r, err := ctx.Planner.QueryRowEx(
 				ctx.Ctx(), "pg_get_indexdef",
 				sessiondata.NoSessionDataOverride,
-				"SELECT indexdef FROM pg_catalog.pg_indexes WHERE crdb_oid = $1", args[0])
+				`SELECT CASE
+    				WHEN $2 = 0 THEN defs.indexdef
+						-- If the column number does not exist in the index we return an empty string.
+						WHEN $2 < 0 OR $2 > array_length(i.indkey, 1) THEN ''
+						WHEN i.indkey[$2-1] = 0 THEN (indexprs::STRING[])[array_position(array_positions(i.indkey, 0), $2)]
+						ELSE a.attname
+					END as pg_get_indexdef
+					FROM pg_catalog.pg_index i
+					LEFT JOIN pg_attribute a ON (a.attrelid = i.indexrelid AND a.attnum = $2)
+					LEFT JOIN pg_indexes defs ON ($2 = 0 AND defs.crdb_oid = i.indexrelid)
+					WHERE i.indexrelid = $1`, args[0], colNumber)
 			if err != nil {
 				return nil, err
 			}
-			// If the index does not exist we return null.
 			if len(r) == 0 {
 				return tree.DNull, nil
-			}
-			// The 1 argument and 3 argument variants are equivalent when column number 0 is passed.
-			if colNumber == 0 {
-				return r[0], nil
-			}
-			// The 3 argument variant for column number other than 0 returns the column name.
-			r, err = ctx.Planner.QueryRowEx(
-				ctx.Ctx(), "pg_get_indexdef",
-				sessiondata.NoSessionDataOverride,
-				`SELECT ischema.column_name as pg_get_indexdef 
-		               FROM information_schema.statistics AS ischema 
-											INNER JOIN pg_catalog.pg_indexes AS pgindex 
-													ON ischema.table_schema = pgindex.schemaname 
-													AND ischema.table_name = pgindex.tablename 
-													AND ischema.index_name = pgindex.indexname 
-													AND pgindex.crdb_oid = $1 
-													AND ischema.seq_in_index = $2`, args[0], args[1])
-			if err != nil {
-				return nil, err
-			}
-			// If the column number does not exist in the index we return an empty string.
-			if len(r) == 0 {
-				return tree.NewDString(""), nil
 			}
 			if len(r) > 1 {
 				return nil, errors.AssertionFailedf("pg_get_indexdef query has more than 1 result row: %+v", r)


### PR DESCRIPTION
Backport 1/3 commits from #95413.

/cc @cockroachdb/release

Release justification: bug fix

---

fixes https://github.com/cockroachdb/cockroach/issues/94690

Release note (bug fix): The pg_get_indexdef was fixed so that it shows
the expression used to define an expression-based index.  In addition,
the function was previously including columns stored by the index,
which was incorrect and has now been fixed.
