### PR TITLE
roachprod: add tenant param to cluster.Conn* methods

### DIFF
--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -2104,7 +2104,9 @@ func (c *clusterImpl) loggerForCmd(
 // external IP address. In general, inter-cluster communication and should use
 // internal IPs and communication from a test driver to nodes in a cluster
 // should use external IPs.
-func (c *clusterImpl) pgURLErr(ctx context.Context, l *logger.Logger, node option.NodeListOption, external bool, tenant string) ([]string, error) {
+func (c *clusterImpl) pgURLErr(
+	ctx context.Context, l *logger.Logger, node option.NodeListOption, external bool, tenant string,
+) ([]string, error) {
 	urls, err := roachprod.PgURL(ctx, l, c.MakeNodes(node), c.localCertsDir, roachprod.PGURLOptions{
 		External:   external,
 		Secure:     c.localCertsDir != "",
@@ -2119,7 +2121,9 @@ func (c *clusterImpl) pgURLErr(ctx context.Context, l *logger.Logger, node optio
 }
 
 // InternalPGUrl returns the internal Postgres endpoint for the specified nodes.
-func (c *clusterImpl) InternalPGUrl(ctx context.Context, l *logger.Logger, node option.NodeListOption, tenant string) ([]string, error) {
+func (c *clusterImpl) InternalPGUrl(
+	ctx context.Context, l *logger.Logger, node option.NodeListOption, tenant string,
+) ([]string, error) {
 	return c.pgURLErr(ctx, l, node, false, tenant)
 }
 
@@ -2127,7 +2131,9 @@ func (c *clusterImpl) InternalPGUrl(ctx context.Context, l *logger.Logger, node 
 var _ = (&clusterImpl{}).InternalPGUrl
 
 // ExternalPGUrl returns the external Postgres endpoint for the specified nodes.
-func (c *clusterImpl) ExternalPGUrl(ctx context.Context, l *logger.Logger, node option.NodeListOption, tenant string) ([]string, error) {
+func (c *clusterImpl) ExternalPGUrl(
+	ctx context.Context, l *logger.Logger, node option.NodeListOption, tenant string,
+) ([]string, error) {
 	return c.pgURLErr(ctx, l, node, true, tenant)
 }
 
@@ -2294,12 +2300,10 @@ func (c *clusterImpl) ExternalIP(
 var _ = (&clusterImpl{}).ExternalIP
 
 // Conn returns a SQL connection to the specified node.
-func (c *clusterImpl) Conn(ctx context.Context, l *logger.Logger, node int) *gosql.DB {
-	urls, err := c.ExternalPGUrl(ctx, l, c.Node(node), "")
-	if err != nil {
-		c.t.Fatal(err)
-	}
-	db, err := gosql.Open("postgres", urls[0])
+func (c *clusterImpl) Conn(
+	ctx context.Context, l *logger.Logger, node int, opts ...func(*option.ConnOption),
+) *gosql.DB {
+	db, err := c.ConnE(ctx, l, node, opts...)
 	if err != nil {
 		c.t.Fatal(err)
 	}
@@ -2307,33 +2311,28 @@ func (c *clusterImpl) Conn(ctx context.Context, l *logger.Logger, node int) *gos
 }
 
 // ConnE returns a SQL connection to the specified node.
-func (c *clusterImpl) ConnE(ctx context.Context, l *logger.Logger, node int) (*gosql.DB, error) {
-	urls, err := c.ExternalPGUrl(ctx, l, c.Node(node), "")
-	if err != nil {
-		return nil, err
-	}
-	db, err := gosql.Open("postgres", urls[0])
-	if err != nil {
-		return nil, err
-	}
-	return db, nil
-}
-
-// ConnEAsUser returns a SQL connection to the specified node as a specific user
-func (c *clusterImpl) ConnEAsUser(
-	ctx context.Context, l *logger.Logger, node int, user string,
+func (c *clusterImpl) ConnE(
+	ctx context.Context, l *logger.Logger, node int, opts ...func(*option.ConnOption),
 ) (*gosql.DB, error) {
-	urls, err := c.ExternalPGUrl(ctx, l, c.Node(node), "")
+
+	connOptions := &option.ConnOption{}
+	for _, opt := range opts {
+		opt(connOptions)
+	}
+	urls, err := c.ExternalPGUrl(ctx, l, c.Node(node), connOptions.TenantName)
 	if err != nil {
 		return nil, err
 	}
 
-	u, err := url.Parse(urls[0])
-	if err != nil {
-		return nil, err
+	dataSourceName := urls[0]
+	if connOptions.User != "" {
+		u, err := url.Parse(urls[0])
+		if err != nil {
+			return nil, err
+		}
+		u.User = url.User(connOptions.User)
+		dataSourceName = u.String()
 	}
-	u.User = url.User(user)
-	dataSourceName := u.String()
 	db, err := gosql.Open("postgres", dataSourceName)
 	if err != nil {
 		return nil, err

--- a/pkg/cmd/roachtest/cluster/cluster_interface.go
+++ b/pkg/cmd/roachtest/cluster/cluster_interface.go
@@ -66,8 +66,8 @@ type Cluster interface {
 
 	// SQL connection strings.
 
-	InternalPGUrl(ctx context.Context, l *logger.Logger, node option.NodeListOption) ([]string, error)
-	ExternalPGUrl(ctx context.Context, l *logger.Logger, node option.NodeListOption) ([]string, error)
+	InternalPGUrl(ctx context.Context, l *logger.Logger, node option.NodeListOption, tenant string) ([]string, error)
+	ExternalPGUrl(ctx context.Context, l *logger.Logger, node option.NodeListOption, tenant string) ([]string, error)
 
 	// SQL clients to nodes.
 

--- a/pkg/cmd/roachtest/cluster/cluster_interface.go
+++ b/pkg/cmd/roachtest/cluster/cluster_interface.go
@@ -70,10 +70,8 @@ type Cluster interface {
 	ExternalPGUrl(ctx context.Context, l *logger.Logger, node option.NodeListOption, tenant string) ([]string, error)
 
 	// SQL clients to nodes.
-
-	Conn(ctx context.Context, l *logger.Logger, node int) *gosql.DB
-	ConnE(ctx context.Context, l *logger.Logger, node int) (*gosql.DB, error)
-	ConnEAsUser(ctx context.Context, l *logger.Logger, node int, user string) (*gosql.DB, error)
+	Conn(ctx context.Context, l *logger.Logger, node int, opts ...func(*option.ConnOption)) *gosql.DB
+	ConnE(ctx context.Context, l *logger.Logger, node int, opts ...func(*option.ConnOption)) (*gosql.DB, error)
 
 	// URLs for the Admin UI.
 

--- a/pkg/cmd/roachtest/option/BUILD.bazel
+++ b/pkg/cmd/roachtest/option/BUILD.bazel
@@ -4,6 +4,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 go_library(
     name = "option",
     srcs = [
+        "connection_options.go",
         "node_list_option.go",
         "node_lister.go",
         "option_interface.go",

--- a/pkg/cmd/roachtest/option/connection_options.go
+++ b/pkg/cmd/roachtest/option/connection_options.go
@@ -1,0 +1,28 @@
+// Copyright 2023 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package option
+
+type ConnOption struct {
+	User       string
+	TenantName string
+}
+
+func User(user string) func(*ConnOption) {
+	return func(option *ConnOption) {
+		option.User = user
+	}
+}
+
+func TenantName(tenantName string) func(*ConnOption) {
+	return func(option *ConnOption) {
+		option.TenantName = tenantName
+	}
+}

--- a/pkg/cmd/roachtest/tests/cluster_to_cluster.go
+++ b/pkg/cmd/roachtest/tests/cluster_to_cluster.go
@@ -208,7 +208,7 @@ func setupC2C(
 	srcNode := srcCluster.RandNode()
 	destNode := dstCluster.RandNode()
 
-	addr, err := c.ExternalPGUrl(ctx, t.L(), srcNode)
+	addr, err := c.ExternalPGUrl(ctx, t.L(), srcNode, "")
 	require.NoError(t, err)
 
 	srcDB := c.Conn(ctx, t.L(), srcNode[0])

--- a/pkg/cmd/roachtest/tests/cluster_to_cluster.go
+++ b/pkg/cmd/roachtest/tests/cluster_to_cluster.go
@@ -248,8 +248,11 @@ func setupC2C(
 10000000000, now(), 0);`, srcTenantInfo.ID)
 
 	createSystemRole(t, srcTenantInfo.name+" system tenant", srcTenantInfo.sql)
-	createSystemRole(t, destTenantInfo.name+" system tenant", destTenantInfo.sql)
+	createSystemRole(t, srcTenantInfo.name+" system tenant", destTenantInfo.sql)
 
+	srcTenantDB := c.Conn(ctx, t.L(), srcNode[0], option.TenantName(srcTenantName))
+	srcTenantSQL := sqlutils.MakeSQLRunner(srcTenantDB)
+	createSystemRole(t, destTenantInfo.name+" app tenant", srcTenantSQL)
 	return &c2cSetup{
 		src:          srcTenantInfo,
 		dst:          destTenantInfo,

--- a/pkg/cmd/roachtest/tests/copyfrom.go
+++ b/pkg/cmd/roachtest/tests/copyfrom.go
@@ -130,7 +130,7 @@ func runCopyFromCRDB(ctx context.Context, t test.Test, c cluster.Cluster, sf int
 	stmt := fmt.Sprintf("ALTER ROLE ALL SET copy_from_atomic_enabled = %t", atomic)
 	_, err = db.ExecContext(ctx, stmt)
 	require.NoError(t, err)
-	urls, err := c.InternalPGUrl(ctx, t.L(), c.Node(1))
+	urls, err := c.InternalPGUrl(ctx, t.L(), c.Node(1), "")
 	require.NoError(t, err)
 	m := c.NewMonitor(ctx, c.All())
 	m.Go(func(ctx context.Context) error {

--- a/pkg/cmd/roachtest/tests/gossip.go
+++ b/pkg/cmd/roachtest/tests/gossip.go
@@ -153,7 +153,7 @@ SELECT node_id
 type gossipUtil struct {
 	waitTime time.Duration
 	urlMap   map[int]string
-	conn     func(ctx context.Context, l *logger.Logger, i int) *gosql.DB
+	conn     func(ctx context.Context, l *logger.Logger, i int, opts ...func(*option.ConnOption)) *gosql.DB
 }
 
 func newGossipUtil(ctx context.Context, t test.Test, c cluster.Cluster) *gossipUtil {
@@ -451,7 +451,7 @@ SELECT count(replicas)
 	// current infrastructure which doesn't know about cockroach nodes started on
 	// non-standard ports.
 	g := newGossipUtil(ctx, t, c)
-	g.conn = func(ctx context.Context, l *logger.Logger, i int) *gosql.DB {
+	g.conn = func(ctx context.Context, l *logger.Logger, i int, opts ...func(*option.ConnOption)) *gosql.DB {
 		if i != 1 {
 			return c.Conn(ctx, l, i)
 		}

--- a/pkg/cmd/roachtest/tests/gossip.go
+++ b/pkg/cmd/roachtest/tests/gossip.go
@@ -455,7 +455,7 @@ SELECT count(replicas)
 		if i != 1 {
 			return c.Conn(ctx, l, i)
 		}
-		urls, err := c.ExternalPGUrl(ctx, l, c.Node(1))
+		urls, err := c.ExternalPGUrl(ctx, l, c.Node(1), "")
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/pkg/cmd/roachtest/tests/multitenant_utils.go
+++ b/pkg/cmd/roachtest/tests/multitenant_utils.go
@@ -204,7 +204,7 @@ func (tn *tenantNode) start(ctx context.Context, t test.Test, c cluster.Cluster,
 		extraArgs...,
 	)
 
-	externalUrls, err := c.ExternalPGUrl(ctx, t.L(), c.Node(tn.node))
+	externalUrls, err := c.ExternalPGUrl(ctx, t.L(), c.Node(tn.node), "")
 	require.NoError(t, err)
 	u, err := url.Parse(externalUrls[0])
 	require.NoError(t, err)

--- a/pkg/cmd/roachtest/tests/tpcdsvec.go
+++ b/pkg/cmd/roachtest/tests/tpcdsvec.go
@@ -91,7 +91,7 @@ func registerTPCDSVec(r registry.Registry) {
 		// We additionally open fresh connections for each query.
 		setStmtTimeout := fmt.Sprintf("SET statement_timeout='%s';", timeout)
 		firstNode := c.Node(1)
-		urls, err := c.ExternalPGUrl(ctx, t.L(), firstNode)
+		urls, err := c.ExternalPGUrl(ctx, t.L(), firstNode, "")
 		if err != nil {
 			t.Fatal(err)
 		}


### PR DESCRIPTION
This patch allows the roachtest writer to easily open a sql connection with an
in-process tenant.

Release note: None

Epic: None.