### PR TITLE
ui: ux improvements

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/api/insightsApi.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/api/insightsApi.ts
@@ -827,7 +827,7 @@ export async function getClusterInsightsApi(
       },
     ],
     execute: true,
-    // max_result_size: LARGE_RESULT_SIZE,
+    max_result_size: LARGE_RESULT_SIZE,
     timeout: LONG_TIMEOUT,
   };
 

--- a/pkg/ui/workspaces/cluster-ui/src/sessions/sessionDetails.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/sessions/sessionDetails.tsx
@@ -382,7 +382,7 @@ export class SessionDetails extends React.Component<SessionDetailsProps> {
                 <SummaryCardItem
                   label={"Gateway Node"}
                   value={
-                    this.props.uiConfig.showGatewayNodeLink ? (
+                    this.props.uiConfig?.showGatewayNodeLink ? (
                       <div className={cx("session-details-link")}>
                         <NodeLink
                           nodeId={session.node_id.toString()}

--- a/pkg/ui/workspaces/cluster-ui/src/sessions/sessionsTable.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/sessions/sessionsTable.tsx
@@ -16,7 +16,7 @@ import {
   DurationToNumber,
   TimestampToMoment,
 } from "src/util/convert";
-import { BytesWithPrecision } from "src/util/format";
+import { BytesWithPrecision, Count } from "src/util/format";
 import { Link } from "react-router-dom";
 import React from "react";
 
@@ -224,7 +224,7 @@ export function makeSessionsColumns(
       name: "sessionTxnCount",
       title: statisticsTableTitles.sessionTxnCount(statType),
       className: cx("cl-table__col-session"),
-      cell: session => session.session?.num_txns_executed,
+      cell: session => Count(session.session?.num_txns_executed),
       sort: session => session.session?.num_txns_executed,
     },
     {

--- a/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetails.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetails.tsx
@@ -8,7 +8,7 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
-import React, { ReactNode } from "react";
+import React, { ReactNode, useContext } from "react";
 import { Col, Row, Tabs } from "antd";
 import "antd/lib/col/style";
 import "antd/lib/row/style";
@@ -16,7 +16,7 @@ import "antd/lib/tabs/style";
 import { cockroach } from "@cockroachlabs/crdb-protobuf-client";
 import { InlineAlert, Text } from "@cockroachlabs/ui-components";
 import { ArrowLeft } from "@cockroachlabs/icons";
-import _, { isNil } from "lodash";
+import { isNil } from "lodash";
 import Long from "long";
 import { Helmet } from "react-helmet";
 import { Link, RouteComponentProps } from "react-router-dom";
@@ -75,6 +75,7 @@ import {
   InsertStmtDiagnosticRequest,
   StatementDiagnosticsReport,
 } from "../api";
+import { CockroachCloudContext } from "src";
 
 type StatementDetailsResponse =
   cockroach.server.serverpb.StatementDetailsResponse;
@@ -797,7 +798,7 @@ export class StatementDetails extends React.Component<
     if (!hasData && !this.state.query) {
       return this.renderNoDataTabContent();
     }
-
+    const showDiagnosticsLink = !useContext(CockroachCloudContext);
     return (
       <DiagnosticsView
         activateDiagnosticsRef={this.activateDiagnosticsRef}
@@ -811,9 +812,7 @@ export class StatementDetails extends React.Component<
         onDiagnosticCancelRequestClick={report =>
           this.props.onDiagnosticCancelRequest(report)
         }
-        showDiagnosticsViewLink={
-          this.props.uiConfig?.showStatementDiagnosticsLink
-        }
+        showDiagnosticsViewLink={showDiagnosticsLink}
         onSortingChange={this.props.onSortingChange}
       />
     );

--- a/pkg/ui/workspaces/cluster-ui/src/store/uiConfig/uiConfig.selector.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/store/uiConfig/uiConfig.selector.ts
@@ -12,7 +12,7 @@ import { createSelector } from "reselect";
 import { AppState } from "../reducers";
 
 export const selectUIConfig = createSelector(
-  (state: AppState) => state.adminUI.uiConfig,
+  (state: AppState) => state.adminUI?.uiConfig,
   uiConfig => uiConfig,
 );
 


### PR DESCRIPTION
We want to show the link to "all diagnistics" only on
DB Console, but it wasn't properly being displayed.
Uodated to use cloud context instead.

Remove comment added by mistake on the api result size.

Use Count format funcion on transactions count on session
table.

Epic: None
Release note: None