### PR TITLE
release-22.2: ui: add proper checks and message for insights

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/api/sqlApi.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/api/sqlApi.ts
@@ -119,3 +119,25 @@ export function sqlResultsAreEmpty(
     )
   );
 }
+
+/**
+ * errorMessage cleans the error message returned by the sqlApi,
+ * removing information not useful for the user.
+ * e.g. the error message
+ * "$executing stmt 1: run-query-via-api: only users with either MODIFYCLUSTERSETTING
+ * or VIEWCLUSTERSETTING privileges are allowed to show cluster settings"
+ * became
+ * "only users with either MODIFYCLUSTERSETTING or VIEWCLUSTERSETTING privileges are allowed to show cluster settings"
+ * and the error message
+ * "executing stmt 1: max result size exceeded"
+ * became
+ * "max result size exceeded"
+ * @param message
+ */
+export function sqlApiErrorMessage(message: string): string {
+  message = message.replace("run-query-via-api: ", "");
+  if (message.includes(":")) {
+    return message.split(":")[1];
+  }
+  return message;
+}

--- a/pkg/ui/workspaces/cluster-ui/src/insights/insightsErrorComponent.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/insightsErrorComponent.tsx
@@ -11,20 +11,29 @@
 import React from "react";
 import classNames from "classnames/bind";
 import styles from "./workloadInsights/util/workloadInsights.module.scss";
+import { sqlApiErrorMessage } from "../api";
 
 const cx = classNames.bind(styles);
 
-export const InsightsError = (): React.ReactElement => (
-  <div className={cx("row")}>
-    <span>This page had an unexpected error while loading insights.</span>
-    &nbsp;
-    <a
-      className={cx("action")}
-      onClick={() => {
-        window.location.reload();
-      }}
-    >
-      Reload this page
-    </a>
-  </div>
-);
+export const InsightsError = (errMsg?: string): React.ReactElement => {
+  const message = errMsg
+    ? errMsg
+    : "This page had an unexpected error while loading insights.";
+  const showReload = !message.toLowerCase().includes("size exceeded");
+  return (
+    <div className={cx("row")}>
+      <span>{message}</span>
+      &nbsp;
+      {showReload && (
+        <a
+          className={cx("action")}
+          onClick={() => {
+            window.location.reload();
+          }}
+        >
+          Reload this page
+        </a>
+      )}
+    </div>
+  );
+};

--- a/pkg/ui/workspaces/cluster-ui/src/insights/schemaInsights/schemaInsights.fixture.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/schemaInsights/schemaInsights.fixture.ts
@@ -70,7 +70,9 @@ export const SchemaInsightsPropsFixture: SchemaInsightsViewProps = {
     database: "",
     schemaInsightType: "",
   },
+  hasAdminRole: true,
   refreshSchemaInsights: () => {},
   onSortChange: () => {},
   onFiltersChange: () => {},
+  refreshUserSQLRoles: () => {},
 };

--- a/pkg/ui/workspaces/cluster-ui/src/insights/schemaInsights/schemaInsightsPageConnected.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/schemaInsights/schemaInsightsPageConnected.tsx
@@ -19,7 +19,7 @@ import {
   selectFilters,
   selectSortSetting,
 } from "src/store/schemaInsights";
-import { AppState } from "src/store";
+import { AppState, uiConfigActions } from "src/store";
 import {
   SchemaInsightsView,
   SchemaInsightsViewDispatchProps,
@@ -29,6 +29,7 @@ import { SchemaInsightEventFilters } from "../types";
 import { SortSetting } from "src/sortedtable";
 import { actions as localStorageActions } from "../../store/localStorage";
 import { Dispatch } from "redux";
+import { selectHasAdminRole } from "../../store/uiConfig";
 
 const mapStateToProps = (
   state: AppState,
@@ -40,6 +41,7 @@ const mapStateToProps = (
   schemaInsightsError: selectSchemaInsightsError(state),
   filters: selectFilters(state),
   sortSetting: selectSortSetting(state),
+  hasAdminRole: selectHasAdminRole(state),
 });
 
 const mapDispatchToProps = (
@@ -64,6 +66,7 @@ const mapDispatchToProps = (
   refreshSchemaInsights: () => {
     dispatch(actions.refresh());
   },
+  refreshUserSQLRoles: () => dispatch(uiConfigActions.refreshUserSQLRoles()),
 });
 
 export const SchemaInsightsPageConnected = withRouter(

--- a/pkg/ui/workspaces/cluster-ui/src/insights/schemaInsights/schemaInsightsView.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/schemaInsights/schemaInsightsView.tsx
@@ -48,12 +48,14 @@ export type SchemaInsightsViewStateProps = {
   schemaInsightsError: Error | null;
   filters: SchemaInsightEventFilters;
   sortSetting: SortSetting;
+  hasAdminRole: boolean;
 };
 
 export type SchemaInsightsViewDispatchProps = {
   onFiltersChange: (filters: SchemaInsightEventFilters) => void;
   onSortChange: (ss: SortSetting) => void;
   refreshSchemaInsights: () => void;
+  refreshUserSQLRoles: () => void;
 };
 
 export type SchemaInsightsViewProps = SchemaInsightsViewStateProps &
@@ -68,7 +70,9 @@ export const SchemaInsightsView: React.FC<SchemaInsightsViewProps> = ({
   schemaInsightsTypes,
   schemaInsightsError,
   filters,
+  hasAdminRole,
   refreshSchemaInsights,
+  refreshUserSQLRoles,
   onFiltersChange,
   onSortChange,
 }: SchemaInsightsViewProps) => {
@@ -90,6 +94,15 @@ export const SchemaInsightsView: React.FC<SchemaInsightsViewProps> = ({
       clearInterval(interval);
     };
   }, [refreshSchemaInsights]);
+
+  useEffect(() => {
+    // Refresh every 5 minutes.
+    refreshUserSQLRoles();
+    const interval = setInterval(refreshUserSQLRoles, 60 * 5000);
+    return () => {
+      clearInterval(interval);
+    };
+  }, [refreshUserSQLRoles]);
 
   useEffect(() => {
     // We use this effect to sync settings defined on the URL (sort, filters),
@@ -205,7 +218,7 @@ export const SchemaInsightsView: React.FC<SchemaInsightsViewProps> = ({
           loading={schemaInsights === null}
           page="schema insights"
           error={schemaInsightsError}
-          renderError={() => InsightsError()}
+          renderError={() => InsightsError(schemaInsightsError?.message)}
         >
           <div>
             <section className={sortableTableCx("cl-table-container")}>
@@ -220,7 +233,7 @@ export const SchemaInsightsView: React.FC<SchemaInsightsViewProps> = ({
                 />
               </div>
               <InsightsSortedTable
-                columns={makeInsightsColumns(isCockroachCloud)}
+                columns={makeInsightsColumns(isCockroachCloud, hasAdminRole)}
                 data={filteredSchemaInsights}
                 sortSetting={sortSetting}
                 onChangeSortSetting={onChangeSortSetting}

--- a/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsightDetails/statementInsightDetails.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsightDetails/statementInsightDetails.tsx
@@ -42,11 +42,13 @@ export interface StatementInsightDetailsStateProps {
   insightEventDetails: StatementInsightEvent;
   insightError: Error | null;
   isTenant?: boolean;
+  hasAdminRole: boolean;
 }
 
 export interface StatementInsightDetailsDispatchProps {
   setTimeScale: (ts: TimeScale) => void;
   refreshStatementInsights: () => void;
+  refreshUserSQLRoles: () => void;
 }
 
 export type StatementInsightDetailsProps = StatementInsightDetailsStateProps &
@@ -67,8 +69,10 @@ export const StatementInsightDetails: React.FC<
   insightError,
   match,
   isTenant,
+  hasAdminRole,
   setTimeScale,
   refreshStatementInsights,
+  refreshUserSQLRoles,
 }) => {
   const [explainPlanState, setExplainPlanState] = useState<ExplainPlanState>({
     explainPlan: null,
@@ -101,10 +105,11 @@ export const StatementInsightDetails: React.FC<
   const executionID = getMatchParamByName(match, idAttr);
 
   useEffect(() => {
+    refreshUserSQLRoles();
     if (!insightEventDetails) {
       refreshStatementInsights();
     }
-  }, [insightEventDetails, refreshStatementInsights]);
+  }, [insightEventDetails, refreshStatementInsights, refreshUserSQLRoles]);
 
   return (
     <div>
@@ -148,6 +153,7 @@ export const StatementInsightDetails: React.FC<
               <StatementInsightDetailsOverviewTab
                 insightEventDetails={insightEventDetails}
                 setTimeScale={setTimeScale}
+                hasAdminRole={hasAdminRole}
               />
             </Tabs.TabPane>
             {!isTenant && (

--- a/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsightDetails/statementInsightDetailsConnected.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsightDetails/statementInsightDetailsConnected.tsx
@@ -15,13 +15,13 @@ import {
   StatementInsightDetailsDispatchProps,
   StatementInsightDetailsStateProps,
 } from "./statementInsightDetails";
-import { AppState } from "src/store";
+import { AppState, uiConfigActions } from "src/store";
 import {
   actions as statementInsights,
   selectStatementInsightDetails,
   selectStatementInsightsError,
 } from "src/store/insights/statementInsights";
-import { selectIsTenant } from "src/store/uiConfig";
+import { selectHasAdminRole, selectIsTenant } from "src/store/uiConfig";
 import { TimeScale } from "../../timeScaleDropdown";
 import { actions as sqlStatsActions } from "../../store/sqlStats";
 
@@ -35,6 +35,7 @@ const mapStateToProps = (
     insightEventDetails: insightStatements,
     insightError: insightError,
     isTenant: selectIsTenant(state),
+    hasAdminRole: selectHasAdminRole(state),
   };
 };
 
@@ -51,6 +52,7 @@ const mapDispatchToProps = (
       }),
     );
   },
+  refreshUserSQLRoles: () => dispatch(uiConfigActions.refreshUserSQLRoles()),
 });
 
 export const StatementInsightDetailsConnected = withRouter(

--- a/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsightDetails/statementInsightDetailsOverviewTab.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsightDetails/statementInsightDetailsOverviewTab.tsx
@@ -115,16 +115,17 @@ const insightsTableData = (
 export interface StatementInsightDetailsOverviewTabProps {
   insightEventDetails: StatementInsightEvent;
   setTimeScale: (ts: TimeScale) => void;
+  hasAdminRole: boolean;
 }
 
 export const StatementInsightDetailsOverviewTab: React.FC<
   StatementInsightDetailsOverviewTabProps
-> = ({ insightEventDetails, setTimeScale }) => {
+> = ({ insightEventDetails, setTimeScale, hasAdminRole }) => {
   const isCockroachCloud = useContext(CockroachCloudContext);
 
   const insightsColumns = useMemo(
-    () => makeInsightsColumns(isCockroachCloud),
-    [isCockroachCloud],
+    () => makeInsightsColumns(isCockroachCloud, hasAdminRole),
+    [isCockroachCloud, hasAdminRole],
   );
 
   const insightDetails = insightEventDetails;

--- a/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsightDetails/transactionInsightDetails.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsightDetails/transactionInsightDetails.tsx
@@ -73,6 +73,7 @@ function insightsTableData(
 export interface TransactionInsightDetailsStateProps {
   insightEventDetails: TransactionInsightEventDetailsResponse;
   insightError: Error | null;
+  hasAdminRole: boolean;
 }
 
 export interface TransactionInsightDetailsDispatchProps {
@@ -80,6 +81,7 @@ export interface TransactionInsightDetailsDispatchProps {
     req: TransactionInsightEventDetailsRequest,
   ) => void;
   setTimeScale: (ts: TimeScale) => void;
+  refreshUserSQLRoles: () => void;
 }
 
 export type TransactionInsightDetailsProps =
@@ -96,6 +98,8 @@ export const TransactionInsightDetails: React.FC<
   insightEventDetails,
   insightError,
   match,
+  hasAdminRole,
+  refreshUserSQLRoles,
 }) => {
   const [insightsSortSetting, setInsightsSortSetting] = useState<SortSetting>({
     ascending: false,
@@ -105,12 +109,18 @@ export const TransactionInsightDetails: React.FC<
   const executionID = getMatchParamByName(match, idAttr);
   const noInsights = !insightEventDetails;
   useEffect(() => {
+    refreshUserSQLRoles();
     if (noInsights) {
       refreshTransactionInsightDetails({
         id: executionID,
       });
     }
-  }, [executionID, refreshTransactionInsightDetails, noInsights]);
+  }, [
+    executionID,
+    refreshTransactionInsightDetails,
+    noInsights,
+    refreshUserSQLRoles,
+  ]);
 
   const prevPage = (): void => history.goBack();
 
@@ -119,7 +129,7 @@ export const TransactionInsightDetails: React.FC<
 
   const insightQueries =
     insightDetails?.queries.join("") || "Insight not found.";
-  const insightsColumns = makeInsightsColumns(isCockroachCloud);
+  const insightsColumns = makeInsightsColumns(isCockroachCloud, hasAdminRole);
 
   const blockingExecutions: EventExecution[] =
     insightDetails?.blockingContentionDetails.map(x => {

--- a/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsightDetails/transactionInsightDetailsConnected.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsightDetails/transactionInsightDetailsConnected.tsx
@@ -14,7 +14,7 @@ import {
 } from "./transactionInsightDetails";
 import { connect } from "react-redux";
 import { RouteComponentProps, withRouter } from "react-router-dom";
-import { AppState } from "src/store";
+import { AppState, uiConfigActions } from "src/store";
 import {
   selectTransactionInsightDetails,
   selectTransactionInsightDetailsError,
@@ -24,6 +24,7 @@ import { TimeScale } from "../../timeScaleDropdown";
 import { actions as sqlStatsActions } from "../../store/sqlStats";
 import { Dispatch } from "redux";
 import { TransactionInsightEventDetailsRequest } from "src/api";
+import { selectHasAdminRole } from "src/store/uiConfig";
 
 const mapStateToProps = (
   state: AppState,
@@ -34,6 +35,7 @@ const mapStateToProps = (
   return {
     insightEventDetails: insightDetails,
     insightError: insightError,
+    hasAdminRole: selectHasAdminRole(state),
   };
 };
 
@@ -52,6 +54,7 @@ const mapDispatchToProps = (
       }),
     );
   },
+  refreshUserSQLRoles: () => dispatch(uiConfigActions.refreshUserSQLRoles()),
 });
 
 export const TransactionInsightDetailsConnected = withRouter(

--- a/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsights/statementInsights/statementInsightsView.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsights/statementInsights/statementInsightsView.tsx
@@ -242,7 +242,7 @@ export const StatementInsightsView: React.FC<StatementInsightsViewProps> = (
           loading={statements === null}
           page="statement insights"
           error={statementsError}
-          renderError={() => InsightsError()}
+          renderError={() => InsightsError(statementsError?.message)}
         >
           <div>
             <section className={sortableTableCx("cl-table-container")}>

--- a/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsights/transactionInsights/transactionInsightsView.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsights/transactionInsights/transactionInsightsView.tsx
@@ -216,7 +216,7 @@ export const TransactionInsightsView: React.FC<TransactionInsightsViewProps> = (
           loading={transactions === null}
           page="transaction insights"
           error={transactionsError}
-          renderError={() => InsightsError()}
+          renderError={() => InsightsError(transactionsError?.message)}
         >
           <div>
             <section className={sortableTableCx("cl-table-container")}>

--- a/pkg/ui/workspaces/cluster-ui/src/insightsTable/insightsTable.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insightsTable/insightsTable.tsx
@@ -286,6 +286,7 @@ function actionCell(
 
 export function makeInsightsColumns(
   isCockroachCloud: boolean,
+  hasAdminRole: boolean,
   disableStmtLink?: boolean,
 ): ColumnDescriptor<InsightRecommendation>[] {
   return [
@@ -305,7 +306,8 @@ export function makeInsightsColumns(
     {
       name: "action",
       title: insightsTableTitles.actions(),
-      cell: (item: InsightRecommendation) => actionCell(item, isCockroachCloud),
+      cell: (item: InsightRecommendation) =>
+        actionCell(item, isCockroachCloud || !hasAdminRole),
     },
   ];
 }

--- a/pkg/ui/workspaces/cluster-ui/src/sessions/sessionDetails.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/sessions/sessionDetails.tsx
@@ -382,7 +382,7 @@ export class SessionDetails extends React.Component<SessionDetailsProps> {
                 <SummaryCardItem
                   label={"Gateway Node"}
                   value={
-                    this.props.uiConfig.showGatewayNodeLink ? (
+                    this.props.uiConfig?.showGatewayNodeLink ? (
                       <div className={cx("session-details-link")}>
                         <NodeLink
                           nodeId={session.node_id.toString()}

--- a/pkg/ui/workspaces/cluster-ui/src/statementDetails/planDetails/planDetails.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementDetails/planDetails/planDetails.tsx
@@ -35,11 +35,13 @@ const cx = classNames.bind(styles);
 interface PlanDetailsProps {
   plans: PlanHashStats[];
   statementFingerprintID: string;
+  hasAdminRole: boolean;
 }
 
 export function PlanDetails({
   plans,
   statementFingerprintID,
+  hasAdminRole,
 }: PlanDetailsProps): React.ReactElement {
   const [plan, setPlan] = useState<PlanHashStats | null>(null);
   const [plansSortSetting, setPlansSortSetting] = useState<SortSetting>({
@@ -65,6 +67,7 @@ export function PlanDetails({
         backToPlanTable={backToPlanTable}
         sortSetting={insightsSortSetting}
         onChangeSortSetting={setInsightsSortSetting}
+        hasAdminRole={hasAdminRole}
       />
     );
   } else {
@@ -112,6 +115,7 @@ interface ExplainPlanProps {
   backToPlanTable: () => void;
   sortSetting: SortSetting;
   onChangeSortSetting: (ss: SortSetting) => void;
+  hasAdminRole: boolean;
 }
 
 function ExplainPlan({
@@ -120,6 +124,7 @@ function ExplainPlan({
   backToPlanTable,
   sortSetting,
   onChangeSortSetting,
+  hasAdminRole,
 }: ExplainPlanProps): React.ReactElement {
   const explainPlan =
     `Plan Gist: ${plan.stats.plan_gists[0]} \n\n` +
@@ -146,6 +151,7 @@ function ExplainPlan({
           statementFingerprintID={statementFingerprintID}
           sortSetting={sortSetting}
           onChangeSortSetting={onChangeSortSetting}
+          hasAdminRole={hasAdminRole}
         />
       )}
     </div>
@@ -202,6 +208,7 @@ interface InsightsProps {
   statementFingerprintID: string;
   sortSetting: SortSetting;
   onChangeSortSetting: (ss: SortSetting) => void;
+  hasAdminRole: boolean;
 }
 
 function Insights({
@@ -210,9 +217,14 @@ function Insights({
   statementFingerprintID,
   sortSetting,
   onChangeSortSetting,
+  hasAdminRole,
 }: InsightsProps): React.ReactElement {
   const isCockroachCloud = useContext(CockroachCloudContext);
-  const insightsColumns = makeInsightsColumns(isCockroachCloud, true);
+  const insightsColumns = makeInsightsColumns(
+    isCockroachCloud,
+    hasAdminRole,
+    true,
+  );
   const data = formatIdxRecommendations(
     idxRecommendations,
     plan,

--- a/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetails.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetails.tsx
@@ -16,7 +16,6 @@ import "antd/lib/tabs/style";
 import { cockroach, google } from "@cockroachlabs/crdb-protobuf-client";
 import { InlineAlert, Text } from "@cockroachlabs/ui-components";
 import { ArrowLeft } from "@cockroachlabs/icons";
-import { Location } from "history";
 import _, { isNil } from "lodash";
 import Long from "long";
 import { Helmet } from "react-helmet";
@@ -131,6 +130,7 @@ export interface StatementDetailsStateProps {
   uiConfig?: UIConfigState["pages"]["statementDetails"];
   isTenant?: UIConfigState["isTenant"];
   hasViewActivityRedactedRole?: UIConfigState["hasViewActivityRedactedRole"];
+  hasAdminRole?: UIConfigState["hasAdminRole"];
 }
 
 export type StatementDetailsOwnProps = StatementDetailsDispatchProps &
@@ -779,6 +779,7 @@ export class StatementDetails extends React.Component<
           <PlanDetails
             statementFingerprintID={this.props.statementFingerprintID}
             plans={statement_statistics_per_plan_hash}
+            hasAdminRole={this.props.hasAdminRole}
           />
         </section>
       </>
@@ -800,7 +801,7 @@ export class StatementDetails extends React.Component<
         onDownloadDiagnosticBundleClick={this.props.onDiagnosticBundleDownload}
         onDiagnosticCancelRequestClick={this.props.onDiagnosticCancelRequest}
         showDiagnosticsViewLink={
-          this.props.uiConfig.showStatementDiagnosticsLink
+          this.props.uiConfig?.showStatementDiagnosticsLink
         }
         onSortingChange={this.props.onSortingChange}
       />

--- a/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetailsConnected.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetailsConnected.ts
@@ -24,6 +24,7 @@ import {
 import {
   selectIsTenant,
   selectHasViewActivityRedactedRole,
+  selectHasAdminRole,
 } from "../store/uiConfig";
 import {
   nodeDisplayNameByIDSelector,
@@ -80,6 +81,7 @@ const mapStateToProps = (state: AppState, props: RouteComponentProps) => {
     uiConfig: selectStatementDetailsUiConfig(state),
     isTenant: selectIsTenant(state),
     hasViewActivityRedactedRole: selectHasViewActivityRedactedRole(state),
+    hasAdminRole: selectHasAdminRole(state),
   };
 };
 

--- a/pkg/ui/workspaces/db-console/src/views/insights/schemaInsightsPage.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/insights/schemaInsightsPage.tsx
@@ -10,7 +10,10 @@
 
 import { connect } from "react-redux";
 import { RouteComponentProps, withRouter } from "react-router-dom";
-import { refreshSchemaInsights } from "src/redux/apiReducers";
+import {
+  refreshSchemaInsights,
+  refreshUserSQLRoles,
+} from "src/redux/apiReducers";
 import { AdminUIState } from "src/redux/state";
 import {
   SchemaInsightEventFilters,
@@ -26,6 +29,7 @@ import {
   selectSchemaInsightsDatabases,
   selectSchemaInsightsTypes,
 } from "src/views/insights/insightsSelectors";
+import { selectHasAdminRole } from "src/redux/user";
 
 const mapStateToProps = (
   state: AdminUIState,
@@ -37,6 +41,7 @@ const mapStateToProps = (
   schemaInsightsError: state.cachedData?.schemaInsights.lastError,
   filters: schemaInsightsFiltersLocalSetting.selector(state),
   sortSetting: schemaInsightsSortLocalSetting.selector(state),
+  hasAdminRole: selectHasAdminRole(state),
 });
 
 const mapDispatchToProps = {
@@ -44,6 +49,7 @@ const mapDispatchToProps = {
     schemaInsightsFiltersLocalSetting.set(filters),
   onSortChange: (ss: SortSetting) => schemaInsightsSortLocalSetting.set(ss),
   refreshSchemaInsights: refreshSchemaInsights,
+  refreshUserSQLRoles: refreshUserSQLRoles,
 };
 
 const SchemaInsightsPage = withRouter(

--- a/pkg/ui/workspaces/db-console/src/views/insights/statementInsightDetailsPage.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/insights/statementInsightDetailsPage.tsx
@@ -15,9 +15,13 @@ import {
 import { connect } from "react-redux";
 import { RouteComponentProps, withRouter } from "react-router-dom";
 import { AdminUIState } from "src/redux/state";
-import { refreshStatementInsights } from "src/redux/apiReducers";
+import {
+  refreshStatementInsights,
+  refreshUserSQLRoles,
+} from "src/redux/apiReducers";
 import { selectStatementInsightDetails } from "src/views/insights/insightsSelectors";
 import { setGlobalTimeScaleAction } from "src/redux/statements";
+import { selectHasAdminRole } from "src/redux/user";
 
 const mapStateToProps = (
   state: AdminUIState,
@@ -28,12 +32,14 @@ const mapStateToProps = (
   return {
     insightEventDetails: insightStatements,
     insightError: insightError,
+    hasAdminRole: selectHasAdminRole(state),
   };
 };
 
 const mapDispatchToProps: StatementInsightDetailsDispatchProps = {
   setTimeScale: setGlobalTimeScaleAction,
   refreshStatementInsights: refreshStatementInsights,
+  refreshUserSQLRoles: refreshUserSQLRoles,
 };
 
 const StatementInsightDetailsPage = withRouter(

--- a/pkg/ui/workspaces/db-console/src/views/insights/transactionInsightDetailsPage.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/insights/transactionInsightDetailsPage.tsx
@@ -14,13 +14,17 @@ import {
 } from "@cockroachlabs/cluster-ui";
 import { connect } from "react-redux";
 import { RouteComponentProps, withRouter } from "react-router-dom";
-import { refreshTransactionInsightDetails } from "src/redux/apiReducers";
+import {
+  refreshTransactionInsightDetails,
+  refreshUserSQLRoles,
+} from "src/redux/apiReducers";
 import { AdminUIState } from "src/redux/state";
 import {
   selectTransactionInsightDetails,
   selectTransactionInsightDetailsError,
 } from "src/views/insights/insightsSelectors";
 import { setGlobalTimeScaleAction } from "src/redux/statements";
+import { selectHasAdminRole } from "src/redux/user";
 
 const mapStateToProps = (
   state: AdminUIState,
@@ -29,12 +33,14 @@ const mapStateToProps = (
   return {
     insightEventDetails: selectTransactionInsightDetails(state, props),
     insightError: selectTransactionInsightDetailsError(state, props),
+    hasAdminRole: selectHasAdminRole(state),
   };
 };
 
 const mapDispatchToProps: TransactionInsightDetailsDispatchProps = {
   refreshTransactionInsightDetails,
   setTimeScale: setGlobalTimeScaleAction,
+  refreshUserSQLRoles: refreshUserSQLRoles,
 };
 
 const TransactionInsightDetailsPage = withRouter(

--- a/pkg/ui/workspaces/db-console/src/views/sessions/sessionDetails.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/sessions/sessionDetails.tsx
@@ -10,7 +10,6 @@
 
 import { getMatchParamByName } from "src/util/query";
 import { sessionAttr } from "src/util/constants";
-import _ from "lodash";
 import { RouteComponentProps, withRouter } from "react-router-dom";
 import { createSelector } from "reselect";
 import { Pick } from "src/util/pick";

--- a/pkg/ui/workspaces/db-console/src/views/statements/activeStatementDetailsConnected.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/statements/activeStatementDetailsConnected.tsx
@@ -21,6 +21,7 @@ import {
   selectActiveStatement,
   selectContentionDetailsForStatement,
 } from "src/selectors";
+import { selectHasAdminRole } from "src/redux/user";
 
 export default withRouter(
   connect<
@@ -32,6 +33,7 @@ export default withRouter(
       match: props.match,
       statement: selectActiveStatement(state, props),
       contentionDetails: selectContentionDetailsForStatement(state, props),
+      hasAdminRole: selectHasAdminRole(state),
     }),
     { refreshLiveWorkload },
   )(ActiveStatementDetails),

--- a/pkg/ui/workspaces/db-console/src/views/statements/statementDetails.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/statements/statementDetails.tsx
@@ -39,7 +39,10 @@ import {
   setGlobalTimeScaleAction,
 } from "src/redux/statements";
 import { createStatementDiagnosticsAlertLocalSetting } from "src/redux/alerts";
-import { selectHasViewActivityRedactedRole } from "src/redux/user";
+import {
+  selectHasAdminRole,
+  selectHasViewActivityRedactedRole,
+} from "src/redux/user";
 import {
   trackCancelDiagnosticsBundleAction,
   trackDownloadDiagnosticsBundleAction,
@@ -132,6 +135,7 @@ const mapStateToProps = (
       state.sqlActivity.statementDetailsLatestQuery,
     ),
     hasViewActivityRedactedRole: selectHasViewActivityRedactedRole(state),
+    hasAdminRole: selectHasAdminRole(state),
   };
 };
 


### PR DESCRIPTION
Backport 1/1 commits from #95516.

/cc @cockroachdb/release

---

Previously, no checks were done on insights when user was not admin, making the page show empty results, even when there was an error retrieving the data.
This commit passes on the proper error message when there is one. It also checks for admin privilege to show option to apply a recommendation.

https://www.loom.com/share/33d002cc9b704a4fad2f9851109b04ee

Epic: CRDB-20388

Release note (ui change): Hide apply option for index recommendation when user is not admin.

---

Release justification: improvement on error messages
