### PR TITLE
opt: do not hoist correlated, non-leakproof subqueries in COALESCE

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/conditional
+++ b/pkg/sql/logictest/testdata/logic_test/conditional
@@ -107,3 +107,15 @@ SELECT
     END
 ----
 one  one  three  four  two
+
+subtest regression_95560
+
+# Regression test for #95560. COALESCE should only evaluate arguments to the
+# right of the first non-NULL argument, and an error (in this case a "division
+# by zero" error) should not occur from a branch that should never be evaluated.
+statement ok
+CREATE TABLE t95560a (a INT);
+INSERT INTO t95560a VALUES (1);
+CREATE TABLE t95560b (b INT);
+INSERT INTO t95560b VALUES (0);
+SELECT coalesce(a, (SELECT (a/b)::INT FROM t95560b)) FROM t95560a;

--- a/pkg/sql/opt/norm/testdata/rules/decorrelate
+++ b/pkg/sql/opt/norm/testdata/rules/decorrelate
@@ -4252,6 +4252,121 @@ project
       └── filters
            └── ((0, length(count_rows:12::STRING)) > (0, 1)) OR (i:2 = 1) [outer=(2,12), immutable]
 
+# CREATE TABLE a (k INT PRIMARY KEY, i INT, f FLOAT, s STRING, j JSON)
+# CREATE TABLE xy (x INT PRIMARY KEY, y INT)
+
+# Hoist a leakproof subquery within a COALESCE.
+norm expect=HoistSelectSubquery
+SELECT * FROM a WHERE k = COALESCE(i, (SELECT y FROM xy WHERE x = i))
+----
+project
+ ├── columns: k:1!null i:2 f:3 s:4 j:5
+ ├── key: (1)
+ ├── fd: (1)-->(2-5)
+ └── select
+      ├── columns: k:1!null i:2 f:3 s:4 j:5 x:8 y:9
+      ├── key: (1)
+      ├── fd: (1)-->(2-5,8,9), (8)-->(9), (2,9)-->(1)
+      ├── left-join (hash)
+      │    ├── columns: k:1!null i:2 f:3 s:4 j:5 x:8 y:9
+      │    ├── multiplicity: left-rows(exactly-one), right-rows(zero-or-more)
+      │    ├── key: (1)
+      │    ├── fd: (1)-->(2-5,8,9), (8)-->(9)
+      │    ├── scan a
+      │    │    ├── columns: k:1!null i:2 f:3 s:4 j:5
+      │    │    ├── key: (1)
+      │    │    └── fd: (1)-->(2-5)
+      │    ├── scan xy
+      │    │    ├── columns: x:8!null y:9
+      │    │    ├── key: (8)
+      │    │    └── fd: (8)-->(9)
+      │    └── filters
+      │         └── x:8 = i:2 [outer=(2,8), constraints=(/2: (/NULL - ]; /8: (/NULL - ]), fd=(2)==(8), (8)==(2)]
+      └── filters
+           └── k:1 = COALESCE(i:2, y:9) [outer=(1,2,9), constraints=(/1: (/NULL - ]), fd=(2,9)-->(1)]
+
+# Hoist a non-leakproof subquery within a COALESCE if it is the first argument.
+norm expect=HoistSelectSubquery
+SELECT * FROM a WHERE k = COALESCE((SELECT (1/y)::INT FROM xy WHERE x = i), i)
+----
+project
+ ├── columns: k:1!null i:2 f:3 s:4 j:5
+ ├── immutable
+ ├── key: (1)
+ ├── fd: (1)-->(2-5)
+ └── select
+      ├── columns: k:1!null i:2 f:3 s:4 j:5 x:8 int8:12
+      ├── immutable
+      ├── key: (1)
+      ├── fd: (1)-->(2-5,8,12), (8)-->(12), (2,12)-->(1)
+      ├── left-join (hash)
+      │    ├── columns: k:1!null i:2 f:3 s:4 j:5 x:8 int8:12
+      │    ├── multiplicity: left-rows(exactly-one), right-rows(zero-or-more)
+      │    ├── immutable
+      │    ├── key: (1)
+      │    ├── fd: (1)-->(2-5,8,12), (8)-->(12)
+      │    ├── scan a
+      │    │    ├── columns: k:1!null i:2 f:3 s:4 j:5
+      │    │    ├── key: (1)
+      │    │    └── fd: (1)-->(2-5)
+      │    ├── project
+      │    │    ├── columns: int8:12 x:8!null
+      │    │    ├── immutable
+      │    │    ├── key: (8)
+      │    │    ├── fd: (8)-->(12)
+      │    │    ├── scan xy
+      │    │    │    ├── columns: x:8!null y:9
+      │    │    │    ├── key: (8)
+      │    │    │    └── fd: (8)-->(9)
+      │    │    └── projections
+      │    │         └── (1 / y:9)::INT8 [as=int8:12, outer=(9), immutable]
+      │    └── filters
+      │         └── x:8 = i:2 [outer=(2,8), constraints=(/2: (/NULL - ]; /8: (/NULL - ]), fd=(2)==(8), (8)==(2)]
+      └── filters
+           └── k:1 = COALESCE(int8:12, i:2) [outer=(1,2,12), constraints=(/1: (/NULL - ]), fd=(2,12)-->(1)]
+
+# Do not hoist a non-leakproof subquery within a COALESCE if it is not the first
+# argument.
+norm expect-not=HoistSelectSubquery
+SELECT * FROM a WHERE k = COALESCE(i, (SELECT (1/y)::INT FROM xy WHERE x = i))
+----
+select
+ ├── columns: k:1!null i:2 f:3 s:4 j:5
+ ├── immutable
+ ├── key: (1)
+ ├── fd: (1)-->(2-5)
+ ├── scan a
+ │    ├── columns: k:1!null i:2 f:3 s:4 j:5
+ │    ├── key: (1)
+ │    └── fd: (1)-->(2-5)
+ └── filters
+      └── eq [outer=(1,2), immutable, correlated-subquery, constraints=(/1: (/NULL - ])]
+           ├── k:1
+           └── coalesce
+                ├── i:2
+                └── subquery
+                     └── project
+                          ├── columns: int8:12
+                          ├── outer: (2)
+                          ├── cardinality: [0 - 1]
+                          ├── immutable
+                          ├── key: ()
+                          ├── fd: ()-->(12)
+                          ├── select
+                          │    ├── columns: x:8!null y:9
+                          │    ├── outer: (2)
+                          │    ├── cardinality: [0 - 1]
+                          │    ├── key: ()
+                          │    ├── fd: ()-->(8,9)
+                          │    ├── scan xy
+                          │    │    ├── columns: x:8!null y:9
+                          │    │    ├── key: (8)
+                          │    │    └── fd: (8)-->(9)
+                          │    └── filters
+                          │         └── x:8 = i:2 [outer=(2,8), constraints=(/2: (/NULL - ]; /8: (/NULL - ]), fd=(2)==(8), (8)==(2)]
+                          └── projections
+                               └── (1 / y:9)::INT8 [as=int8:12, outer=(9), immutable]
+
 # Exists within a disjunction.
 norm expect=HoistSelectSubquery
 SELECT * FROM a WHERE i=1 OR EXISTS(SELECT * FROM xy WHERE y=i)
@@ -4632,6 +4747,93 @@ scalar-group-by
  └── aggregations
       └── max [as=max:13, outer=(12)]
            └── column12:12
+
+# Hoist a leakproof subquery within a COALESCE.
+norm expect=HoistProjectSubquery
+SELECT COALESCE(i, (SELECT y FROM xy WHERE x = i)) FROM a
+----
+project
+ ├── columns: coalesce:12
+ ├── left-join (hash)
+ │    ├── columns: i:2 x:8 y:9
+ │    ├── multiplicity: left-rows(exactly-one), right-rows(zero-or-more)
+ │    ├── fd: (8)-->(9)
+ │    ├── scan a
+ │    │    └── columns: i:2
+ │    ├── scan xy
+ │    │    ├── columns: x:8!null y:9
+ │    │    ├── key: (8)
+ │    │    └── fd: (8)-->(9)
+ │    └── filters
+ │         └── x:8 = i:2 [outer=(2,8), constraints=(/2: (/NULL - ]; /8: (/NULL - ]), fd=(2)==(8), (8)==(2)]
+ └── projections
+      └── COALESCE(i:2, y:9) [as=coalesce:12, outer=(2,9)]
+
+# Hoist a non-leakproof subquery within a COALESCE if it is the first argument.
+norm expect=HoistProjectSubquery
+SELECT COALESCE((SELECT (1/y)::INT FROM xy WHERE x = i), i) FROM a
+----
+project
+ ├── columns: coalesce:13
+ ├── immutable
+ ├── left-join (hash)
+ │    ├── columns: i:2 x:8 int8:12
+ │    ├── multiplicity: left-rows(exactly-one), right-rows(zero-or-more)
+ │    ├── immutable
+ │    ├── fd: (8)-->(12)
+ │    ├── scan a
+ │    │    └── columns: i:2
+ │    ├── project
+ │    │    ├── columns: int8:12 x:8!null
+ │    │    ├── immutable
+ │    │    ├── key: (8)
+ │    │    ├── fd: (8)-->(12)
+ │    │    ├── scan xy
+ │    │    │    ├── columns: x:8!null y:9
+ │    │    │    ├── key: (8)
+ │    │    │    └── fd: (8)-->(9)
+ │    │    └── projections
+ │    │         └── (1 / y:9)::INT8 [as=int8:12, outer=(9), immutable]
+ │    └── filters
+ │         └── x:8 = i:2 [outer=(2,8), constraints=(/2: (/NULL - ]; /8: (/NULL - ]), fd=(2)==(8), (8)==(2)]
+ └── projections
+      └── COALESCE(int8:12, i:2) [as=coalesce:13, outer=(2,12)]
+
+# Do not hoist a non-leakproof subquery within a COALESCE if it is not the first
+# argument.
+norm expect-not=HoistProjectSubquery
+SELECT COALESCE(i, (SELECT (1/y)::INT FROM xy WHERE x = i)) FROM a
+----
+project
+ ├── columns: coalesce:13
+ ├── immutable
+ ├── scan a
+ │    └── columns: i:2
+ └── projections
+      └── coalesce [as=coalesce:13, outer=(2), immutable, correlated-subquery]
+           ├── i:2
+           └── subquery
+                └── project
+                     ├── columns: int8:12
+                     ├── outer: (2)
+                     ├── cardinality: [0 - 1]
+                     ├── immutable
+                     ├── key: ()
+                     ├── fd: ()-->(12)
+                     ├── select
+                     │    ├── columns: x:8!null y:9
+                     │    ├── outer: (2)
+                     │    ├── cardinality: [0 - 1]
+                     │    ├── key: ()
+                     │    ├── fd: ()-->(8,9)
+                     │    ├── scan xy
+                     │    │    ├── columns: x:8!null y:9
+                     │    │    ├── key: (8)
+                     │    │    └── fd: (8)-->(9)
+                     │    └── filters
+                     │         └── x:8 = i:2 [outer=(2,8), constraints=(/2: (/NULL - ]; /8: (/NULL - ]), fd=(2)==(8), (8)==(2)]
+                     └── projections
+                          └── (1 / y:9)::INT8 [as=int8:12, outer=(9), immutable]
 
 # Exists in projection list.
 norm expect=HoistProjectSubquery

--- a/pkg/sql/opt/xform/testdata/external/liquibase
+++ b/pkg/sql/opt/xform/testdata/external/liquibase
@@ -378,35 +378,40 @@ project
       │    │    ├── c.relowner:5 IS NULL
       │    │    └── CAST(NULL AS STRING)
       │    └── subquery
-      │         └── project
+      │         └── values
       │              ├── columns: column172:172
       │              ├── outer: (5)
       │              ├── cardinality: [1 - 1]
       │              ├── immutable
       │              ├── key: ()
       │              ├── fd: ()-->(172)
-      │              ├── limit
-      │              │    ├── columns: pg_catalog.pg_roles.oid:157 rolname:158
-      │              │    ├── outer: (5)
-      │              │    ├── cardinality: [1 - 1]
-      │              │    ├── key: ()
-      │              │    ├── fd: ()-->(157,158)
-      │              │    ├── right-join (cross)
-      │              │    │    ├── columns: pg_catalog.pg_roles.oid:157 rolname:158
-      │              │    │    ├── outer: (5)
-      │              │    │    ├── cardinality: [1 - ]
-      │              │    │    ├── limit hint: 1.00
-      │              │    │    ├── scan pg_roles
-      │              │    │    │    └── columns: pg_catalog.pg_roles.oid:157 rolname:158
-      │              │    │    ├── values
-      │              │    │    │    ├── cardinality: [1 - 1]
-      │              │    │    │    ├── key: ()
-      │              │    │    │    └── ()
-      │              │    │    └── filters
-      │              │    │         └── pg_catalog.pg_roles.oid:157 = c.relowner:5 [outer=(5,157), constraints=(/5: (/NULL - ]; /157: (/NULL - ]), fd=(5)==(157), (157)==(5)]
-      │              │    └── 1
-      │              └── projections
-      │                   └── assignment-cast: STRING [as=column172:172, outer=(5,158), immutable]
-      │                        └── COALESCE(rolname:158, (('unknown (OID=' || c.relowner:5) || ')')::NAME)
+      │              └── tuple
+      │                   └── assignment-cast: STRING
+      │                        └── coalesce
+      │                             ├── subquery
+      │                             │    └── project
+      │                             │         ├── columns: rolname:158
+      │                             │         ├── outer: (5)
+      │                             │         ├── cardinality: [0 - 1]
+      │                             │         ├── key: ()
+      │                             │         ├── fd: ()-->(158)
+      │                             │         └── limit
+      │                             │              ├── columns: pg_catalog.pg_roles.oid:157!null rolname:158
+      │                             │              ├── outer: (5)
+      │                             │              ├── cardinality: [0 - 1]
+      │                             │              ├── key: ()
+      │                             │              ├── fd: ()-->(157,158)
+      │                             │              ├── select
+      │                             │              │    ├── columns: pg_catalog.pg_roles.oid:157!null rolname:158
+      │                             │              │    ├── outer: (5)
+      │                             │              │    ├── fd: ()-->(157)
+      │                             │              │    ├── limit hint: 1.00
+      │                             │              │    ├── scan pg_roles
+      │                             │              │    │    ├── columns: pg_catalog.pg_roles.oid:157 rolname:158
+      │                             │              │    │    └── limit hint: 1.01
+      │                             │              │    └── filters
+      │                             │              │         └── pg_catalog.pg_roles.oid:157 = c.relowner:5 [outer=(5,157), constraints=(/5: (/NULL - ]; /157: (/NULL - ]), fd=(5)==(157), (157)==(5)]
+      │                             │              └── 1
+      │                             └── (('unknown (OID=' || c.relowner:5) || ')')::NAME
       ├── CASE WHEN c.oid:1 IS NULL THEN CAST(NULL AS STRING) ELSE pg_catalog.pg_description.description:179 END [as=description:180, outer=(1,179)]
       └── count_rows:154 > 0 [as=inhtable:181, outer=(154)]

--- a/pkg/sql/opt/xform/testdata/external/navicat
+++ b/pkg/sql/opt/xform/testdata/external/navicat
@@ -382,35 +382,40 @@ sort
            │    │    ├── c.relowner:5 IS NULL
            │    │    └── CAST(NULL AS STRING)
            │    └── subquery
-           │         └── project
+           │         └── values
            │              ├── columns: column172:172
            │              ├── outer: (5)
            │              ├── cardinality: [1 - 1]
            │              ├── immutable
            │              ├── key: ()
            │              ├── fd: ()-->(172)
-           │              ├── limit
-           │              │    ├── columns: pg_catalog.pg_roles.oid:157 rolname:158
-           │              │    ├── outer: (5)
-           │              │    ├── cardinality: [1 - 1]
-           │              │    ├── key: ()
-           │              │    ├── fd: ()-->(157,158)
-           │              │    ├── right-join (cross)
-           │              │    │    ├── columns: pg_catalog.pg_roles.oid:157 rolname:158
-           │              │    │    ├── outer: (5)
-           │              │    │    ├── cardinality: [1 - ]
-           │              │    │    ├── limit hint: 1.00
-           │              │    │    ├── scan pg_roles
-           │              │    │    │    └── columns: pg_catalog.pg_roles.oid:157 rolname:158
-           │              │    │    ├── values
-           │              │    │    │    ├── cardinality: [1 - 1]
-           │              │    │    │    ├── key: ()
-           │              │    │    │    └── ()
-           │              │    │    └── filters
-           │              │    │         └── pg_catalog.pg_roles.oid:157 = c.relowner:5 [outer=(5,157), constraints=(/5: (/NULL - ]; /157: (/NULL - ]), fd=(5)==(157), (157)==(5)]
-           │              │    └── 1
-           │              └── projections
-           │                   └── assignment-cast: STRING [as=column172:172, outer=(5,158), immutable]
-           │                        └── COALESCE(rolname:158, (('unknown (OID=' || c.relowner:5) || ')')::NAME)
+           │              └── tuple
+           │                   └── assignment-cast: STRING
+           │                        └── coalesce
+           │                             ├── subquery
+           │                             │    └── project
+           │                             │         ├── columns: rolname:158
+           │                             │         ├── outer: (5)
+           │                             │         ├── cardinality: [0 - 1]
+           │                             │         ├── key: ()
+           │                             │         ├── fd: ()-->(158)
+           │                             │         └── limit
+           │                             │              ├── columns: pg_catalog.pg_roles.oid:157!null rolname:158
+           │                             │              ├── outer: (5)
+           │                             │              ├── cardinality: [0 - 1]
+           │                             │              ├── key: ()
+           │                             │              ├── fd: ()-->(157,158)
+           │                             │              ├── select
+           │                             │              │    ├── columns: pg_catalog.pg_roles.oid:157!null rolname:158
+           │                             │              │    ├── outer: (5)
+           │                             │              │    ├── fd: ()-->(157)
+           │                             │              │    ├── limit hint: 1.00
+           │                             │              │    ├── scan pg_roles
+           │                             │              │    │    ├── columns: pg_catalog.pg_roles.oid:157 rolname:158
+           │                             │              │    │    └── limit hint: 1.01
+           │                             │              │    └── filters
+           │                             │              │         └── pg_catalog.pg_roles.oid:157 = c.relowner:5 [outer=(5,157), constraints=(/5: (/NULL - ]; /157: (/NULL - ]), fd=(5)==(157), (157)==(5)]
+           │                             │              └── 1
+           │                             └── (('unknown (OID=' || c.relowner:5) || ')')::NAME
            ├── CASE WHEN c.oid:1 IS NULL THEN CAST(NULL AS STRING) ELSE pg_catalog.pg_description.description:179 END [as=description:180, outer=(1,179)]
            └── count_rows:154 > 0 [as=inhtable:181, outer=(154)]


### PR DESCRIPTION
Previously, correlated, non-leakproof subqueries within a `COALESCE`
expression would be hoisted into an apply-join. This caused those
arguments to be evaluated when they shouldn't have been, i.e., when
previous arguments always evaluated to non-NULL values. This could cause
errors to propagate from arguments that should have never been
evaluated, and it was inconsistent with Postgres:

> Like a CASE expression, COALESCE only evaluates the arguments that are
needed to determine the result; that is, arguments to the right of the
first non-null argument are not evaluated[^1].

Now, non-leakproof subqueries are only hoisted from within a `COALESCE`
expression if they are not in the first argument. It is safe to hoist a
non-leakproof subquery in the first argument because it is always
evaluated.

Fixes #95560

Release note (bug fix): A bug has been fixed that could arguments of a
`COALESCE` to be evaluated when previous arguments always evaluated to
non-NULL values. This bug could cause query errors to originate from
arguments of a `COALESCE` that should have never been evaluated.

[^1]: https://www.postgresql.org/docs/15/functions-conditional.html#FUNCTIONS-COALESCE-NVL-IFNULL
