### PR TITLE
builtins: fix json_build_object for tsvector/tsquery

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/json_builtins
+++ b/pkg/sql/logictest/testdata/logic_test/json_builtins
@@ -594,6 +594,11 @@ query error pq: json_build_object\(\): key value must be scalar, not array, tupl
 SELECT json_build_object('{1,2,3}'::int[], 3)
 
 query T
+SELECT json_build_object('a'::tsvector, 1, 'b'::tsquery, 2)
+----
+{"'a'": 1, "'b'": 2}
+
+query T
 SELECT json_extract_path('{"a": 1}', 'a')
 ----
 1

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -10118,7 +10118,7 @@ func asJSONBuildObjectKey(
 		*tree.DDecimal, *tree.DEnum, *tree.DFloat, *tree.DGeography,
 		*tree.DGeometry, *tree.DIPAddr, *tree.DInt, *tree.DInterval, *tree.DOid,
 		*tree.DOidWrapper, *tree.DTime, *tree.DTimeTZ, *tree.DTimestamp,
-		*tree.DUuid, *tree.DVoid:
+		*tree.DTSQuery, *tree.DTSVector, *tree.DUuid, *tree.DVoid:
 		return tree.AsStringWithFlags(d, tree.FmtBareStrings), nil
 	default:
 		return "", errors.AssertionFailedf("unexpected type %T for key value", d)


### PR DESCRIPTION
Previously, json_build_object would return an internal error when encountering tsvector/tsquery types. This is now corrected.

Updates #87322

Epic: CRDB-22357
Release note: None (no released version with this issue)