### PR TITLE
streamingest,bulk,roachpb: add a metric for bytes streamed, compressed

### DIFF
--- a/pkg/ccl/streamingccl/streamingest/metrics.go
+++ b/pkg/ccl/streamingccl/streamingest/metrics.go
@@ -34,6 +34,12 @@ var (
 		Measurement: "Bytes",
 		Unit:        metric.Unit_BYTES,
 	}
+	metaStreamingSSTBytes = metric.Metadata{
+		Name:        "streaming.sst_bytes",
+		Help:        "SST bytes (compressed) sent to KV by all ingestion jobs",
+		Measurement: "Bytes",
+		Unit:        metric.Unit_BYTES,
+	}
 	metaStreamingFlushes = metric.Metadata{
 		Name:        "streaming.flushes",
 		Help:        "Total flushes across all ingestion jobs",
@@ -110,6 +116,7 @@ var (
 type Metrics struct {
 	IngestedEvents              *metric.Counter
 	IngestedBytes               *metric.Counter
+	SSTBytes                    *metric.Counter
 	Flushes                     *metric.Counter
 	JobProgressUpdates          *metric.Counter
 	ResolvedEvents              *metric.Counter
@@ -132,6 +139,7 @@ func MakeMetrics(histogramWindow time.Duration) metric.Struct {
 	m := &Metrics{
 		IngestedEvents:     metric.NewCounter(metaStreamingEventsIngested),
 		IngestedBytes:      metric.NewCounter(metaStreamingIngestedBytes),
+		SSTBytes:           metric.NewCounter(metaStreamingSSTBytes),
 		Flushes:            metric.NewCounter(metaStreamingFlushes),
 		ResolvedEvents:     metric.NewCounter(metaStreamingResolvedEventsIngested),
 		JobProgressUpdates: metric.NewCounter(metaJobProgressUpdates),

--- a/pkg/ccl/streamingccl/streamingest/stream_ingestion_processor.go
+++ b/pkg/ccl/streamingccl/streamingest/stream_ingestion_processor.go
@@ -825,6 +825,7 @@ func (sip *streamIngestionProcessor) flush() (*jobspb.ResolvedSpans, error) {
 			sip.metrics.CommitLatency.RecordValue(timeutil.Since(minBatchMVCCTimestamp.GoTime()).Nanoseconds())
 			sip.metrics.Flushes.Inc(1)
 			sip.metrics.IngestedBytes.Inc(int64(totalSize))
+			sip.metrics.SSTBytes.Inc(sip.batcher.GetSummary().SSTDataSize)
 			sip.metrics.IngestedEvents.Inc(int64(len(sip.curKVBatch)))
 			sip.metrics.IngestedEvents.Inc(int64(sip.rangeBatcher.size()))
 		}()

--- a/pkg/kv/bulk/sst_batcher.go
+++ b/pkg/kv/bulk/sst_batcher.go
@@ -624,6 +624,7 @@ func (b *SSTBatcher) doFlush(ctx context.Context, reason int) error {
 		b.mu.Lock()
 		defer b.mu.Unlock()
 		summary.DataSize += int64(size)
+		summary.SSTDataSize += int64(len(data))
 		currentBatchStatsCopy.DataSize += int64(size)
 		b.mu.totalRows.Add(summary)
 

--- a/pkg/roachpb/api.go
+++ b/pkg/roachpb/api.go
@@ -1470,6 +1470,7 @@ func BulkOpSummaryID(tableID, indexID uint64) uint64 {
 // Add combines the values from other, for use on an accumulator BulkOpSummary.
 func (b *BulkOpSummary) Add(other BulkOpSummary) {
 	b.DataSize += other.DataSize
+	b.SSTDataSize += other.SSTDataSize
 	b.DeprecatedRows += other.DeprecatedRows
 	b.DeprecatedIndexEntries += other.DeprecatedIndexEntries
 

--- a/pkg/roachpb/api.proto
+++ b/pkg/roachpb/api.proto
@@ -1641,6 +1641,8 @@ message ExportRequest {
 message BulkOpSummary {
   // DataSize is the sum of key and value lengths.
   int64 data_size = 1;
+  // SSTDataSize is the size of the SST, post compression, sent to KV.
+  int64 sst_data_size = 6 [(gogoproto.customname) = "SSTDataSize"];
   // DeprecatedRows contained the row count when "rows" were always defined as
   // entries in the index with ID 1, however since 20.1 and the introduction of
   // PK changes, the low-level counters that produce BulkOpSummaries are unable

--- a/pkg/ts/catalog/chart_catalog.go
+++ b/pkg/ts/catalog/chart_catalog.go
@@ -1620,6 +1620,12 @@ var charts = []sectionDescription{
 				},
 			},
 			{
+				Title: "SST Bytes",
+				Metrics: []string{
+					"streaming.sst_bytes",
+				},
+			},
+			{
 				Title:   "Earliest Data Processor Checkpoint Span",
 				Metrics: []string{"streaming.earliest_data_checkpoint_span"},
 			},


### PR DESCRIPTION
We currently have a mteric for the logical bytes written to SSTs, pre-compression, and this PR adds a metric for the "physical" bytes sent to KV in SSTs, post compression.

Epic: CRDB-18752

Fixes: #92959

Release note: None

For example:
<img width="1012" alt="Screenshot 2023-01-20 at 2 15 31 PM" src="https://user-images.githubusercontent.com/51982110/213814907-13ebdde1-82c4-4597-b9f9-d02a8bc1a112.png">
