### PR TITLE
sql: increase the online help for SHOW RANGES

### DIFF
--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -7918,10 +7918,11 @@ show_range_for_row_stmt:
 // SHOW RANGES FROM INDEX [ <tablename> @ ] <indexname> [ WITH <options...> ]
 //
 // Options:
-//   INDEXES
-//   TABLES
-//   DETAILS
-//   EXPLAIN
+//   INDEXES: list indexes contained per range
+//   TABLES:  list tables contained per range
+//   DETAILS: add range size, leaseholder and other details
+//   KEYS:    include binary start/end keys
+//   EXPLAIN: show the SQL queries that produces the result
 show_ranges_stmt:
   SHOW RANGES FROM INDEX table_index_name opt_show_ranges_options
   {


### PR DESCRIPTION
The output of `\h SHOW RANGES` wasn't mentioning the KEYS option. Now it does. Also this adds some additional details about the various options.

Release note: None
Epic: None