### PR TITLE
opt: remove unnecessary filter after inverted zigzag join

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/testdata/distsql_inverted_index
+++ b/pkg/sql/opt/exec/execbuilder/testdata/distsql_inverted_index
@@ -203,7 +203,6 @@ vectorized: true
     │ table: array_tab@array_tab_pkey
     │ equality: (a) = (a)
     │ equality cols are key
-    │ pred: b @> ARRAY[1,2]
     │
     └── • zigzag join
           estimated row count: 0
@@ -214,4 +213,4 @@ vectorized: true
           right columns: (a, b_inverted_key)
           right fixed values: 1 column
 ·
-Diagram: https://cockroachdb.github.io/distsqlplan/decode.html#eJyUkk9v00AQxe98itFcCmKleJ0L2pNDa4RRiIsdCUqxok08RKbpjtldI4rl745so6ahStTe5t_v-T1rW3Q_d6gw_nI5nyULeHmR5Mv80_wV5PE8Pl-ChndZ-hG0tfpu5fU6-s68qswv-Pw-zmJYQ_StCYIpwVkrBYTdGaTZRZzB2yvQKNBwSQt9Sw7VNUosBNaWN-Qc237UDgdJ-RtVILAydeP7cSFww5ZQtegrvyNU-LXa_tHbD1wZspMABZbkdbUbdPOqJAjUY5Mo8Jx3za1xCrSANYrxVj7tNm28gmiKRSeQG78357zeEirZiacH6K1npEuyE3lof2_lvlrVN3SHAufMN00NP7gywEZB1KPpAqLw_r_Psmx2dS2VUsli-UaE_4riYZ59GHk0TPicMDlbT3YSHgaJ5Ouj8tPnyGfkajaODuSPKQddIZDKLY0PynFjN3RpeTN8ZmzTgRsGJTk_buXYJGZc9QYfwvIkHJ6Gw5Pw9D-46F78DQAA__9VuCLV
+Diagram: https://cockroachdb.github.io/distsqlplan/decode.html#eJyUkl1v0zAUhu_5FUfnZiAsNU7vfBXYgigq60gm8RlVbnKIzDKfYDuIEeW_oyQSXZlabXc-H8_rx5J79D8bVJh-ulq_Wl3C84tVfp1_WL-APF2n59eg4U22eQ_aOX23DXqXfGfeGvsLPr5NsxR2kHzromhJcNZLAfFwBpvsIs3g9WfQKNByRZf6ljyqryixENg6Lsl7dmOrnxZW1W9UkUBj2y6M7UJgyY5Q9RhMaAgVfjH1H12_Y2PJLSIUWFHQpplyc1MRROqhJAo856a7tV6BFrBDMe_Kx-1uuqAgWWIxCOQu7OV80DWhkoN4_ANG9Yx0RW4hD_X3Kv9O2_aG7lDgmvmma-EHGwtsFSTyvubeUR51jJ_imLML5BbxoV8iXx6NXz4lPiPfsvV0EH8sORoKgVTVNP8Tz50r6cpxOV0zl5uJmxoV-TBP5Vys7DwaBe_D8iQcn4bjk_DyP7gYnv0NAAD___D1GIU=

--- a/pkg/sql/opt/exec/execbuilder/testdata/inverted_index
+++ b/pkg/sql/opt/exec/execbuilder/testdata/inverted_index
@@ -945,7 +945,6 @@ vectorized: true
 │ table: d@d_pkey
 │ equality: (a) = (a)
 │ equality cols are key
-│ pred: b @> '{"a": {"b": "c"}, "f": "g"}'
 │
 └── • project
     │ columns: (a)
@@ -999,7 +998,6 @@ vectorized: true
 │ table: d@d_pkey
 │ equality: (a) = (a)
 │ equality cols are key
-│ pred: b @> '[{"a": {"b": [[2]]}}, "d"]'
 │
 └── • project
     │ columns: (a)
@@ -1029,7 +1027,6 @@ vectorized: true
 │ table: d@d_pkey
 │ equality: (a) = (a)
 │ equality cols are key
-│ pred: b @> '{"a": {"b": "c"}, "f": "g"}'
 │
 └── • project
     │ columns: (a)
@@ -1083,7 +1080,6 @@ vectorized: true
 │ table: d@d_pkey
 │ equality: (a) = (a)
 │ equality cols are key
-│ pred: b @> '[{"a": {"b": [[2]]}}, "d"]'
 │
 └── • project
     │ columns: (a)
@@ -1235,7 +1231,6 @@ vectorized: true
     │ table: d@d_pkey
     │ equality: (a) = (a)
     │ equality cols are key
-    │ pred: b @> '[1, 2]'
     │
     └── • zigzag join
           estimated row count: 1,247
@@ -1263,7 +1258,6 @@ vectorized: true
     │ table: d@d_pkey
     │ equality: (a) = (a)
     │ equality cols are key
-    │ pred: (b @> '[1]') AND (b @> '[2]')
     │
     └── • zigzag join
           estimated row count: 1,247
@@ -1392,7 +1386,6 @@ vectorized: true
 │ table: e@e_pkey
 │ equality: (a) = (a)
 │ equality cols are key
-│ pred: b @> ARRAY[1,2]
 │
 └── • project
     │ columns: (a)
@@ -1419,7 +1412,6 @@ vectorized: true
 │ table: e@e_pkey
 │ equality: (a) = (a)
 │ equality cols are key
-│ pred: (b @> ARRAY[1]) AND (b @> ARRAY[2])
 │
 └── • project
     │ columns: (a)

--- a/pkg/sql/opt/exec/execbuilder/testdata/select_for_update
+++ b/pkg/sql/opt/exec/execbuilder/testdata/select_for_update
@@ -1805,7 +1805,6 @@ vectorized: true
 │ table: inverted@inverted_pkey
 │ equality: (a) = (a)
 │ equality cols are key
-│ pred: b @> ARRAY[1,2]
 │ locking strength: for update
 │
 └── • project
@@ -1941,7 +1940,6 @@ vectorized: true
 │ table: zigzag@zigzag_pkey
 │ equality: (a) = (a)
 │ equality cols are key
-│ pred: d @> '{"a": {"b": "c"}, "f": "g"}'
 │ locking strength: for update
 │
 └── • project

--- a/pkg/sql/opt/exec/execbuilder/testdata/tsvector_index
+++ b/pkg/sql/opt/exec/execbuilder/testdata/tsvector_index
@@ -101,7 +101,6 @@ vectorized: true
 │ table: a@a_pkey
 │ equality: (a) = (a)
 │ equality cols are key
-│ pred: b @@ '''foo'' & ''bar'''
 │
 └── • zigzag join
       left table: a@a_b_idx

--- a/pkg/sql/opt/exec/explain/testdata/gists
+++ b/pkg/sql/opt/exec/explain/testdata/gists
@@ -453,7 +453,6 @@ explain(shape):
     │ table: foo@foo_pkey
     │ equality: (a) = (a)
     │ equality cols are key
-    │ pred: b @> _
     │
     └── • zigzag join
           left table: foo@b_inverted_index

--- a/pkg/sql/opt/indexrec/testdata/index
+++ b/pkg/sql/opt/indexrec/testdata/index
@@ -1222,7 +1222,7 @@ inner-join (lookup t4)
  ├── key columns: [6] = [6]
  ├── lookup columns are key
  ├── immutable
- ├── cost: 238.247531
+ ├── cost: 237.980741
  ├── inner-join (zigzag t4@_hyp_1 t4@_hyp_1)
  │    ├── columns: rowid:6!null
  │    ├── eq columns: [6] = [6]
@@ -1230,8 +1230,7 @@ inner-join (lookup t4)
  │    ├── right fixed columns: [9] = ['\x37666f6f000112310001']
  │    ├── cost: 159.155802
  │    └── filters (true)
- └── filters
-      └── j:4 @> '{"bar": "2", "foo": "1"}' [outer=(4), immutable, constraints=(/4: (/NULL - ])]
+ └── filters (true)
 
 index-candidates
 SELECT k, f FROM t4 WHERE j <@ '{"foo": "1"}' AND k = 1

--- a/pkg/sql/opt/memo/testdata/stats/select
+++ b/pkg/sql/opt/memo/testdata/stats/select
@@ -883,10 +883,9 @@ inner-join (lookup t_json_arr)
  │    ├── eq columns: [1] = [1]
  │    ├── left fixed columns: [7] = ['\x3761000112620001']
  │    ├── right fixed columns: [7] = ['\x3763000112640001']
- │    ├── stats: [rows=61.7284, distinct(1)=61.7284, null(1)=0]
+ │    ├── stats: [rows=61.7284]
  │    └── filters (true)
- └── filters
-      └── b:2 @> '{"a": "b", "c": "d"}' [type=bool, outer=(2), immutable, constraints=(/2: (/NULL - ])]
+ └── filters (true)
 
 # Should generate a select on the table with a JSON filter, since c does not
 # have an inverted index.

--- a/pkg/sql/opt/xform/testdata/rules/select
+++ b/pkg/sql/opt/xform/testdata/rules/select
@@ -3569,9 +3569,7 @@ inner-join (lookup c)
  │    ├── left fixed columns: [6] = ['\x89']
  │    ├── right fixed columns: [6] = ['\x8a']
  │    └── filters (true)
- └── filters
-      ├── a:2 && ARRAY[1] [outer=(2), immutable]
-      └── a:2 && ARRAY[2] [outer=(2), immutable]
+ └── filters (true)
 
 # TODO: Add normalization rule to convert to no-op since predicate
 # is a contradiction
@@ -6653,8 +6651,7 @@ project
       │    ├── left fixed columns: [9] = ['\x3761000112620001']
       │    ├── right fixed columns: [9] = ['\x3763000112640001']
       │    └── filters (true)
-      └── filters
-           └── j:4 @> '{"a": "b", "c": "d"}' [outer=(4), immutable, constraints=(/4: (/NULL - ])]
+      └── filters (true)
 
 # Query requiring a zigzag join with a remaining filter.
 # TODO(itsbilal): remove filter from index join if zigzag join covers it.
@@ -6674,8 +6671,7 @@ inner-join (lookup b)
  │    ├── left fixed columns: [9] = ['\x3761000112620001']
  │    ├── right fixed columns: [9] = ['\x3763000112640001']
  │    └── filters (true)
- └── filters
-      └── j:4 @> '{"a": "b", "c": "d"}' [outer=(4), immutable, constraints=(/4: (/NULL - ])]
+ └── filters (true)
 
 opt expect=GenerateInvertedIndexZigzagJoins
 SELECT * FROM b WHERE j @> '{"a": {"b": "c", "d": "e"}, "f": "g"}'
@@ -6772,6 +6768,8 @@ ALTER TABLE c INJECT STATISTICS '[
 ]';
 ----
 
+# We need a remaining filter since only two of the three values
+# are covered by the zigzag join.
 opt expect=GenerateInvertedIndexZigzagJoins
 SELECT k FROM c WHERE a @> ARRAY[1,3,1,5]
 ----
@@ -6794,6 +6792,29 @@ project
       │    └── filters (true)
       └── filters
            └── a:2 @> ARRAY[1,3,1,5] [outer=(2), immutable, constraints=(/2: (/NULL - ])]
+
+# Regression test for #95270. We should not need any remaining filter.
+opt expect=GenerateInvertedIndexZigzagJoins
+SELECT k FROM c WHERE a @> ARRAY[1,2]
+----
+project
+ ├── columns: k:1!null
+ ├── immutable
+ ├── key: (1)
+ └── inner-join (lookup c)
+      ├── columns: k:1!null a:2!null
+      ├── key columns: [1] = [1]
+      ├── lookup columns are key
+      ├── immutable
+      ├── key: (1)
+      ├── fd: (1)-->(2)
+      ├── inner-join (zigzag c@a_inv_idx c@a_inv_idx)
+      │    ├── columns: k:1!null
+      │    ├── eq columns: [1] = [1]
+      │    ├── left fixed columns: [8] = ['\x89']
+      │    ├── right fixed columns: [8] = ['\x8a']
+      │    └── filters (true)
+      └── filters (true)
 
 # The first path can't be used for a zigzag join, but the second two can.
 opt expect=GenerateInvertedIndexZigzagJoins
@@ -6873,8 +6894,7 @@ inner-join (lookup b)
  │    ├── left locking: for-update
  │    ├── right locking: for-update
  │    └── filters (true)
- └── filters
-      └── j:4 @> '{"a": 1, "c": 2}' [outer=(4), immutable, constraints=(/4: (/NULL - ])]
+ └── filters (true)
 
 # Zigzag join should not be produced when there is a NO_ZIGZAG_JOIN hint.
 opt expect-not=GenerateInvertedIndexZigzagJoins
@@ -6972,7 +6992,6 @@ project
       │    ├── right fixed columns: [7] = ['\x376200012a0400']
       │    └── filters (true)
       └── filters
-           ├── j:2 @> '{"a": 1, "b": 2}' [outer=(2), immutable, constraints=(/2: (/NULL - ])]
            └── s:4 = 'foo' [outer=(4), constraints=(/4: [/'foo' - /'foo']; tight), fd=()-->(4)]
 
 # Don't generate a zigzag join when the predicate is not implied.
@@ -7010,7 +7029,6 @@ project
       │    ├── right fixed columns: [7] = ['\x376200012a0400']
       │    └── filters (true)
       └── filters
-           ├── j:2 @> '{"a": 1, "b": 2}' [outer=(2), immutable, constraints=(/2: (/NULL - ])]
            └── s:4 = 'foo' [outer=(4), constraints=(/4: [/'foo' - /'foo']; tight), fd=()-->(4)]
 
 # Generate an inverted zigzag join with a hint.
@@ -7035,7 +7053,6 @@ project
       │    ├── right fixed columns: [7] = ['\x376200012a0400']
       │    └── filters (true)
       └── filters
-           ├── j:2 @> '{"a": 1, "b": 2}' [outer=(2), immutable, constraints=(/2: (/NULL - ])]
            └── s:4 = 'foo' [outer=(4), constraints=(/4: [/'foo' - /'foo']; tight), fd=()-->(4)]
 
 exec-ddl

--- a/pkg/sql/opt/xform/testdata/rules/select_for_update
+++ b/pkg/sql/opt/xform/testdata/rules/select_for_update
@@ -172,8 +172,7 @@ inner-join (lookup inverted)
  │    ├── left locking: for-update
  │    ├── right locking: for-update
  │    └── filters (true)
- └── filters
-      └── b:2 @> ARRAY[1,2] [outer=(2), immutable, constraints=(/2: (/NULL - ])]
+ └── filters (true)
 
 opt expect=GenerateInvertedIndexScans
 SELECT * FROM inverted WHERE b <@ '{1, 2}' FOR UPDATE
@@ -292,5 +291,4 @@ inner-join (lookup zigzag)
  │    ├── left locking: for-update
  │    ├── right locking: for-update
  │    └── filters (true)
- └── filters
-      └── d:4 @> '{"a": {"b": "c"}, "f": "g"}' [outer=(4), immutable, constraints=(/4: (/NULL - ])]
+ └── filters (true)


### PR DESCRIPTION
This commit identifies when an inverted zigzag join fully represents a filter and produces no false positives. In this case, we can avoid re-applying the filter after the zigzag join.

Fixes #95270

Release note (performance improvement): In some cases, when planning an inverted zigzag join, the optimizer can now detect whether it is necessary to re-apply the filter after the zigzag join. If it's not necessary, the optimizer can produce a more efficient plan.