### PR TITLE
release-22.1: sql: reduce contention on `SessionRegistry` mutex

### DIFF
--- a/pkg/server/status.go
+++ b/pkg/server/status.go
@@ -216,7 +216,6 @@ func (b *baseStatusServer) getLocalSessions(
 			}
 			session.LastActiveQuery = ""
 		}
-
 		userSessions = append(userSessions, session)
 	}
 	return userSessions, nil

--- a/pkg/sql/conn_executor_test.go
+++ b/pkg/sql/conn_executor_test.go
@@ -651,7 +651,7 @@ func TestQueryProgress(t *testing.T) {
 		// stalled ch as expected.
 		defer func() {
 			select {
-			case <-stalled: //stalled was closed as expected.
+			case <-stalled: // stalled was closed as expected.
 			default:
 				panic("expected stalled to have been closed during execution")
 			}


### PR DESCRIPTION
Backport 1/1 commits from #95553.

/cc @cockroachdb/release

---

Fixes #95535

This reduces `SessionRegistry` contention in 2 ways:
1) Change `SessionRegistry` `syncutil.Mutex` to `syncutil.RWMutex` and use `RLock()` in place of `Lock()` when not modifying the registry.
2) Only lock reading/writing `SessionRegistry` maps with mutex instead of including the session operations in the lock.

Release note (bug fix): Reduce register session, deregister session, and session cancel query contention.

Release justification: Session registry performance improvement.