### PR TITLE
backupccl: add include_all_secondary_tenants option

### DIFF
--- a/docs/generated/sql/bnf/stmt_block.bnf
+++ b/docs/generated/sql/bnf/stmt_block.bnf
@@ -1149,6 +1149,7 @@ unreserved_keyword ::=
 	| 'IMPORT'
 	| 'INCLUDE'
 	| 'INCLUDING'
+	| 'INCLUDE_ALL_SECONDARY_TENANTS'
 	| 'INCREMENT'
 	| 'INCREMENTAL'
 	| 'INCREMENTAL_LOCATION'
@@ -2263,6 +2264,8 @@ backup_options ::=
 	| 'KMS' '=' string_or_placeholder_opt_list
 	| 'INCREMENTAL_LOCATION' '=' string_or_placeholder_opt_list
 	| 'COORDINATOR_LOCALITY' '=' string_or_placeholder
+	| 'INCLUDE_ALL_SECONDARY_TENANTS'
+	| 'INCLUDE_ALL_SECONDARY_TENANTS' '=' a_expr
 
 c_expr ::=
 	d_expr
@@ -2621,6 +2624,8 @@ restore_options ::=
 	| 'SKIP_LOCALITIES_CHECK'
 	| 'DEBUG_PAUSE_ON' '=' string_or_placeholder
 	| 'NEW_DB_NAME' '=' string_or_placeholder
+	| 'INCLUDE_ALL_SECONDARY_TENANTS'
+	| 'INCLUDE_ALL_SECONDARY_TENANTS' '=' a_expr
 	| 'INCREMENTAL_LOCATION' '=' string_or_placeholder_opt_list
 	| 'TENANT_NAME' '=' string_or_placeholder
 	| 'TENANT' '=' string_or_placeholder

--- a/pkg/ccl/backupccl/alter_backup_schedule.go
+++ b/pkg/ccl/backupccl/alter_backup_schedule.go
@@ -328,6 +328,10 @@ func processOptionsForArgs(inOpts tree.BackupOptions, outOpts *tree.BackupOption
 		outOpts.CaptureRevisionHistory = inOpts.CaptureRevisionHistory
 	}
 
+	if inOpts.IncludeAllSecondaryTenants != nil {
+		outOpts.IncludeAllSecondaryTenants = inOpts.IncludeAllSecondaryTenants
+	}
+
 	// If a string-y option is set to empty, interpret this as "unset."
 	if inOpts.EncryptionPassphrase != nil {
 		if tree.AsStringWithFlags(inOpts.EncryptionPassphrase, tree.FmtBareStrings) == "" {

--- a/pkg/ccl/backupccl/backup_planning.go
+++ b/pkg/ccl/backupccl/backup_planning.go
@@ -529,6 +529,7 @@ func backupTypeCheck(
 		},
 		exprutil.Bools{
 			backupStmt.Options.CaptureRevisionHistory,
+			backupStmt.Options.IncludeAllSecondaryTenants,
 		}); err != nil {
 		return false, nil, err
 	}
@@ -614,6 +615,16 @@ func backupPlanHook(
 		}
 	}
 
+	var includeAllSecondaryTenants bool
+	if backupStmt.Options.IncludeAllSecondaryTenants != nil {
+		includeAllSecondaryTenants, err = exprEval.Bool(
+			ctx, backupStmt.Options.IncludeAllSecondaryTenants,
+		)
+		if err != nil {
+			return nil, nil, nil, false, err
+		}
+	}
+
 	encryptionParams := jobspb.BackupEncryptionOptions{
 		Mode: jobspb.EncryptionMode_None,
 	}
@@ -666,6 +677,10 @@ func backupPlanHook(
 		if len(incrementalStorage) > 0 && (len(incrementalStorage) != len(to)) {
 			return errors.New("the incremental_location option must contain the same number of locality" +
 				" aware URIs as the full backup destination")
+		}
+
+		if includeAllSecondaryTenants && backupStmt.Coverage() != tree.AllDescriptors {
+			return errors.New("the include_all_secondary_tenants option is only supported for full cluster backups")
 		}
 
 		var asOfInterval int64
@@ -734,17 +749,18 @@ func backupPlanHook(
 		}
 
 		initialDetails := jobspb.BackupDetails{
-			Destination:         jobspb.BackupDetails_Destination{To: to, IncrementalStorage: incrementalStorage},
-			EndTime:             endTime,
-			RevisionHistory:     revisionHistory,
-			IncrementalFrom:     incrementalFrom,
-			FullCluster:         backupStmt.Coverage() == tree.AllDescriptors,
-			ResolvedCompleteDbs: completeDBs,
-			EncryptionOptions:   &encryptionParams,
-			AsOfInterval:        asOfInterval,
-			Detached:            detached,
-			ApplicationName:     p.SessionData().ApplicationName,
-			CoordinatorLocation: coordinatorLocality,
+			Destination:                jobspb.BackupDetails_Destination{To: to, IncrementalStorage: incrementalStorage},
+			EndTime:                    endTime,
+			RevisionHistory:            revisionHistory,
+			IncludeAllSecondaryTenants: includeAllSecondaryTenants,
+			IncrementalFrom:            incrementalFrom,
+			FullCluster:                backupStmt.Coverage() == tree.AllDescriptors,
+			ResolvedCompleteDbs:        completeDBs,
+			EncryptionOptions:          &encryptionParams,
+			AsOfInterval:               asOfInterval,
+			Detached:                   detached,
+			ApplicationName:            p.SessionData().ApplicationName,
+			CoordinatorLocation:        coordinatorLocality,
 		}
 		if backupStmt.CreatedByInfo != nil && backupStmt.CreatedByInfo.Name == jobs.CreatedByScheduledJobs {
 			initialDetails.ScheduleID = backupStmt.CreatedByInfo.ID
@@ -1367,7 +1383,7 @@ func getTenantInfo(
 	var spans []roachpb.Span
 	var tenants []mtinfopb.TenantInfoWithUsage
 	var err error
-	if jobDetails.FullCluster && codec.ForSystemTenant() {
+	if jobDetails.FullCluster && codec.ForSystemTenant() && jobDetails.IncludeAllSecondaryTenants {
 		// Include all tenants.
 		tenants, err = retrieveAllTenantsMetadata(
 			ctx, txn, settings,

--- a/pkg/ccl/backupccl/backup_test.go
+++ b/pkg/ccl/backupccl/backup_test.go
@@ -3513,7 +3513,7 @@ func TestBackupTenantsWithRevisionHistory(t *testing.T) {
 	_, err = sqlDB.DB.ExecContext(ctx, `BACKUP TENANT 10 TO 'nodelocal://0/foo' WITH revision_history`)
 	require.Contains(t, fmt.Sprint(err), msg)
 
-	_, err = sqlDB.DB.ExecContext(ctx, `BACKUP TO 'nodelocal://0/bar' WITH revision_history`)
+	_, err = sqlDB.DB.ExecContext(ctx, `BACKUP TO 'nodelocal://0/bar' WITH revision_history, include_all_secondary_tenants`)
 	require.Contains(t, fmt.Sprint(err), msg)
 }
 
@@ -6602,7 +6602,7 @@ func TestBackupRestoreInsideTenant(t *testing.T) {
 		httpAddr, httpServerCleanup := makeInsecureHTTPServer(t)
 		defer httpServerCleanup()
 
-		systemDB.Exec(t, `BACKUP TO $1`, httpAddr)
+		systemDB.Exec(t, `BACKUP TO $1 WITH include_all_secondary_tenants`, httpAddr)
 
 		tenant20C2, cleanupT20C2 := makeTenant(srv2, 20)
 		defer cleanupT20C2()
@@ -6612,7 +6612,7 @@ func TestBackupRestoreInsideTenant(t *testing.T) {
 				// This is disallowed because the cluster restore includes other
 				// tenants, which can't be restored inside a tenant.
 				tenant20C2.ExpectErr(t, `only the system tenant can restore other tenants`,
-					`RESTORE FROM $1`, httpAddr)
+					`RESTORE FROM $1 WITH include_all_secondary_tenants`, httpAddr)
 			})
 
 			t.Run("with-no-tenant", func(t *testing.T) {
@@ -6672,13 +6672,13 @@ func TestBackupRestoreTenantSettings(t *testing.T) {
 	systemDB.Exec(t, `BACKUP TO $1`, backup2HttpAddr)
 
 	t.Run("cluster-restore-into-tenant-with-tenant-settings-succeeds", func(t *testing.T) {
-		tenant2C2.Exec(t, `RESTORE FROM $1`, backup2HttpAddr)
+		tenant2C2.Exec(t, `RESTORE FROM $1 WITH include_all_secondary_tenants`, backup2HttpAddr)
 	})
 
 	_, systemDB2, cleanupDB2 := backupRestoreTestSetupEmpty(t, singleNode, dir, InitManualReplication, base.TestClusterArgs{})
 	defer cleanupDB2()
 	t.Run("cluster-restore-into-cluster-with-tenant-settings-succeeds", func(t *testing.T) {
-		systemDB2.Exec(t, `RESTORE FROM $1`, backup2HttpAddr)
+		systemDB2.Exec(t, `RESTORE FROM $1 WITH include_all_secondary_tenants`, backup2HttpAddr)
 		systemDB2.CheckQueryResults(t, `SELECT * FROM system.tenant_settings`, systemDB.QueryStr(t, `SELECT * FROM system.tenant_settings`))
 	})
 }
@@ -6781,7 +6781,7 @@ func TestBackupRestoreInsideMultiPodTenant(t *testing.T) {
 		httpAddr, httpServerCleanup := makeInsecureHTTPServer(t)
 		defer httpServerCleanup()
 
-		systemDB.Exec(t, `BACKUP TO $1`, httpAddr)
+		systemDB.Exec(t, `BACKUP TO $1 WITH include_all_secondary_tenants`, httpAddr)
 
 		tenant20C2, cleanupT20C2 := makeTenant(srv2, 20, false)
 		defer cleanupT20C2()
@@ -6791,7 +6791,7 @@ func TestBackupRestoreInsideMultiPodTenant(t *testing.T) {
 				// This is disallowed because the cluster restore includes other
 				// tenants, which can't be restored inside a tenant.
 				tenant20C2.ExpectErr(t, `only the system tenant can restore other tenants`,
-					`RESTORE FROM $1`, httpAddr)
+					`RESTORE FROM $1 WITH include_all_secondary_tenants`, httpAddr)
 			})
 
 			t.Run("with-no-tenant", func(t *testing.T) {
@@ -6886,12 +6886,12 @@ func TestBackupRestoreTenant(t *testing.T) {
 	// BACKUP tenant 10 at ts1, before they created bar2.
 	systemDB.Exec(t, `BACKUP TENANT 10 TO 'nodelocal://1/t10' AS OF SYSTEM TIME `+ts1)
 	// Also create a full cluster backup. It should contain the tenant.
-	systemDB.Exec(t, `BACKUP TO 'nodelocal://1/clusterwide' AS OF SYSTEM TIME `+ts1)
+	systemDB.Exec(t, fmt.Sprintf("BACKUP TO 'nodelocal://1/clusterwide' AS OF SYSTEM TIME %s WITH include_all_secondary_tenants", ts1))
 
 	// Incrementally backup tenant 10 again, capturing up to ts2.
 	systemDB.Exec(t, `BACKUP TENANT 10 TO 'nodelocal://1/t10' AS OF SYSTEM TIME `+ts2)
 	// Run full cluster backup incrementally to ts2 as well.
-	systemDB.Exec(t, `BACKUP TO 'nodelocal://1/clusterwide' AS OF SYSTEM TIME `+ts2)
+	systemDB.Exec(t, fmt.Sprintf("BACKUP TO 'nodelocal://1/clusterwide' AS OF SYSTEM TIME %s WITH include_all_secondary_tenants", ts2))
 
 	systemDB.Exec(t, `BACKUP TENANT 11 TO 'nodelocal://1/t11'`)
 	systemDB.Exec(t, `BACKUP TENANT 20 TO 'nodelocal://1/t20'`)
@@ -7152,7 +7152,7 @@ func TestBackupRestoreTenant(t *testing.T) {
 					`{"capabilities": {}, "deprecatedId": "1"}`,
 				},
 			})
-		restoreDB.Exec(t, `RESTORE FROM 'nodelocal://1/clusterwide'`)
+		restoreDB.Exec(t, `RESTORE FROM 'nodelocal://1/clusterwide' WITH include_all_secondary_tenants`)
 		restoreDB.CheckQueryResults(t,
 			`select id, active, name, data_state, service_mode, crdb_internal.pb_to_json('cockroach.multitenant.ProtoInfo', info) from system.tenants`,
 			[][]string{
@@ -9545,7 +9545,7 @@ func TestProtectRestoreTargets(t *testing.T) {
 			MustMakeTenantID(10)})
 		require.NoError(t, err)
 	}
-	sqlDB.Exec(t, `BACKUP INTO $1`, localFoo)
+	sqlDB.Exec(t, `BACKUP INTO $1 WITH include_all_secondary_tenants`, localFoo)
 
 	for _, subtest := range []struct {
 		name        string

--- a/pkg/ccl/backupccl/restore_planning.go
+++ b/pkg/ccl/backupccl/restore_planning.go
@@ -982,6 +982,9 @@ func restoreTypeCheck(
 			tree.Exprs(restoreStmt.Options.DecryptionKMSURI),
 			tree.Exprs(restoreStmt.Options.IncrementalStorage),
 		),
+		exprutil.Bools{
+			restoreStmt.Options.IncludeAllSecondaryTenants,
+		},
 		exprutil.Strings{
 			restoreStmt.Subdir,
 			restoreStmt.Options.EncryptionPassphrase,
@@ -1134,6 +1137,18 @@ func restorePlanHook(
 		}
 	}
 
+	var restoreAllTenants bool
+	if restoreStmt.Options.IncludeAllSecondaryTenants != nil {
+		if restoreStmt.DescriptorCoverage != tree.AllDescriptors {
+			return nil, nil, nil, false, errors.New("the include_all_secondary_tenants option is only supported for full cluster restores")
+		}
+		var err error
+		restoreAllTenants, err = exprEval.Bool(ctx, restoreStmt.Options.IncludeAllSecondaryTenants)
+		if err != nil {
+			return nil, nil, nil, false, err
+		}
+	}
+
 	var newTenantID *roachpb.TenantID
 	var newTenantName *roachpb.TenantName
 	if restoreStmt.Options.AsTenant != nil || restoreStmt.Options.ForceTenantID != nil {
@@ -1220,7 +1235,7 @@ func restorePlanHook(
 		// locality aware.
 
 		return doRestorePlan(
-			ctx, restoreStmt, &exprEval, p, from, incStorage, pw, kms, intoDB,
+			ctx, restoreStmt, &exprEval, p, from, incStorage, pw, kms, restoreAllTenants, intoDB,
 			newDBName, newTenantID, newTenantName, endTime, resultsCh, subdir,
 		)
 	}
@@ -1411,6 +1426,7 @@ func doRestorePlan(
 	incFrom []string,
 	passphrase string,
 	kms []string,
+	restoreAllTenants bool,
 	intoDB string,
 	newDBName string,
 	newTenantID *roachpb.TenantID,
@@ -1657,7 +1673,7 @@ func doRestorePlan(
 	}
 
 	sqlDescs, restoreDBs, descsByTablePattern, tenants, err := selectTargets(
-		ctx, p, mainBackupManifests, layerToIterFactory, restoreStmt.Targets, restoreStmt.DescriptorCoverage, endTime,
+		ctx, p, mainBackupManifests, layerToIterFactory, restoreStmt.Targets, restoreStmt.DescriptorCoverage, endTime, restoreAllTenants,
 	)
 	if err != nil {
 		return errors.Wrap(err,

--- a/pkg/ccl/backupccl/testdata/backup-restore/alter-schedule/backup-options
+++ b/pkg/ccl/backupccl/testdata/backup-restore/alter-schedule/backup-options
@@ -102,3 +102,38 @@ with schedules as (show schedules) select id, command->'backup_statement' from s
 ----
 $fullID "BACKUP INTO 'nodelocal://1/example-schedule' WITH revision_history = true, detached"
 $incID "BACKUP INTO LATEST IN 'nodelocal://1/example-schedule' WITH revision_history = true, detached"
+
+exec-sql
+alter backup schedule $incID set with include_all_secondary_tenants = true
+----
+
+query-sql
+with schedules as (show schedules) select id, command->'backup_statement' from schedules where label='datatest' order by command->>'backup_type' asc;
+----
+$fullID "BACKUP INTO 'nodelocal://1/example-schedule' WITH revision_history = true, detached, include_all_secondary_tenants = true"
+$incID "BACKUP INTO LATEST IN 'nodelocal://1/example-schedule' WITH revision_history = true, detached, include_all_secondary_tenants = true"
+
+
+exec-sql
+create schedule 'with-secondary' for backup into 'nodelocal://1/example-schedule-with-secondary' WITH include_all_secondary_tenants recurring '@daily' full backup '@weekly';
+----
+
+let $withSecondaryFullID $withSecondaryIncID
+with schedules as (show schedules) select id from schedules where label='with-secondary' order by command->>'backup_type' asc;
+----
+
+query-sql
+with schedules as (show schedules) select id, command->'backup_statement' from schedules where label='with-secondary' order by command->>'backup_type' asc;
+----
+$withSecondaryFullID "BACKUP INTO 'nodelocal://1/example-schedule-with-secondary' WITH detached, include_all_secondary_tenants = true"
+$withSecondaryIncID "BACKUP INTO LATEST IN 'nodelocal://1/example-schedule-with-secondary' WITH detached, include_all_secondary_tenants = true"
+
+exec-sql
+alter backup schedule $withSecondaryIncID set with Include_all_secondary_tenants = false
+----
+
+query-sql
+with schedules as (show schedules) select id, command->'backup_statement' from schedules where label='with-secondary' order by command->>'backup_type' asc;
+----
+$withSecondaryFullID "BACKUP INTO 'nodelocal://1/example-schedule-with-secondary' WITH detached, include_all_secondary_tenants = false"
+$withSecondaryIncID "BACKUP INTO LATEST IN 'nodelocal://1/example-schedule-with-secondary' WITH detached, include_all_secondary_tenants = false"

--- a/pkg/ccl/backupccl/testdata/backup-restore/restore-tenants
+++ b/pkg/ccl/backupccl/testdata/backup-restore/restore-tenants
@@ -18,6 +18,14 @@ exec-sql
 ALTER TENANT [5] STOP SERVICE; DROP TENANT [5]
 ----
 
+exec-sql
+CREATE TABLE tab1 (pk int primary key)
+----
+
+exec-sql
+CREATE DATABASE db1;
+----
+
 query-sql
 SELECT id,name,data_state,service_mode,active,crdb_internal.pb_to_json('cockroach.multitenant.ProtoInfo', info, true) FROM system.tenants;
 ----
@@ -26,8 +34,22 @@ SELECT id,name,data_state,service_mode,active,crdb_internal.pb_to_json('cockroac
 6 tenant-6 1 1 true {"capabilities": {"canAdminSplit": false, "canViewNodeInfo": false, "canViewTsdbMetrics": false}, "deprecatedDataState": "READY", "deprecatedId": "6", "droppedName": "", "tenantReplicationJobId": "0"}
 
 exec-sql
-BACKUP INTO 'nodelocal://1/cluster'
+BACKUP INTO 'nodelocal://1/cluster_without_tenants'
 ----
+
+exec-sql
+BACKUP INTO 'nodelocal://1/cluster_with_tenants' WITH include_all_secondary_tenants
+----
+
+exec-sql expect-error-regex=(the include_all_secondary_tenants option is only supported for full cluster backups)
+BACKUP TABLE tab1 INTO 'nodelocal://1/table_backup' WITH include_all_secondary_tenants
+----
+regex matches error
+
+exec-sql expect-error-regex=(the include_all_secondary_tenants option is only supported for full cluster backups)
+BACKUP DATABASE db1 INTO 'nodelocal://1/database_backup' WITH include_all_secondary_tenants
+----
+regex matches error
 
 exec-sql expect-error-regex=(tenant 5 is not active)
 BACKUP TENANT 5 INTO 'nodelocal://1/tenant5'
@@ -50,7 +72,7 @@ SET CLUSTER SETTING jobs.debug.pausepoints = 'restore.before_flow'
 ----
 
 restore expect-pausepoint tag=a
-RESTORE FROM LATEST IN 'nodelocal://1/cluster'
+RESTORE FROM LATEST IN 'nodelocal://1/cluster_with_tenants' WITH include_all_secondary_tenants
 ----
 job paused at pausepoint
 
@@ -82,6 +104,12 @@ SELECT id,name,data_state,service_mode,active,crdb_internal.pb_to_json('cockroac
 ----
 1 system 1 2 true {"capabilities": {"canAdminSplit": false, "canViewNodeInfo": false, "canViewTsdbMetrics": false}, "deprecatedDataState": "READY", "deprecatedId": "1", "droppedName": "", "tenantReplicationJobId": "0"}
 6 tenant-6 1 1 true {"capabilities": {"canAdminSplit": false, "canViewNodeInfo": false, "canViewTsdbMetrics": false}, "deprecatedDataState": "READY", "deprecatedId": "6", "droppedName": "", "tenantReplicationJobId": "0"}
+
+
+exec-sql expect-error-regex=(tenant 6 not in backup)
+RESTORE TENANT 6 FROM LATEST IN 'nodelocal://1/cluster_without_tenants'
+----
+regex matches error
 
 exec-sql expect-error-regex=(tenant 6 already exists)
 RESTORE TENANT 6 FROM LATEST IN 'nodelocal://1/tenant6';
@@ -131,3 +159,25 @@ query-sql
 SELECT id,name,service_mode FROM system.tenants WHERE name = 'another-name';
 ----
 3 another-name 2
+
+new-cluster name=s3 share-io-dir=s1 disable-tenant
+----
+
+exec-sql expect-error-regex=(the include_all_secondary_tenants option is only supported for full cluster restores)
+RESTORE DATABASE db1 FROM LATEST IN 'nodelocal://1/cluster_with_tenants' WITH include_all_secondary_tenants
+----
+regex matches error
+
+exec-sql expect-error-regex=(the include_all_secondary_tenants option is only supported for full cluster restores)
+RESTORE TABLE tab1 FROM LATEST IN 'nodelocal://1/cluster_with_tenants' WITH include_all_secondary_tenants
+----
+regex matches error
+
+exec-sql
+RESTORE FROM LATEST IN 'nodelocal://1/cluster_without_tenants'
+----
+
+query-sql
+SHOW TENANTS
+----
+1 system ready shared

--- a/pkg/jobs/jobspb/jobs.proto
+++ b/pkg/jobs/jobspb/jobs.proto
@@ -77,16 +77,16 @@ message StreamIngestionDetails {
   // StreamAddress locates the stream. It enables the client to find the
   // addresses of the stream's partitions.
   string stream_address = 1;
-  
+
   uint64 stream_id = 4 [(gogoproto.customname) = "StreamID"];
-  
+
   // Span is the keyspan into which this job will ingest KVs.
   //
   // The stream should emit all changes for a given span, and no changes outside
   // a span. Note that KVs received from the stream may need to be re-keyed into
   // this span.
   roachpb.Span span = 2 [(gogoproto.nullable) = false];
-  
+
   // Stream of tenant data will be ingested as a new tenant with 'new_tenant_id'.
   roachpb.TenantID destination_tenant_id = 7 [(gogoproto.customname) = "DestinationTenantID", (gogoproto.nullable) = false];
 
@@ -308,7 +308,12 @@ message BackupDetails {
 
   roachpb.Locality coordinator_location = 24 [(gogoproto.nullable) = false];
 
-  // NEXT ID: 25;
+  // IncldeAllSecondaryTenants indicates whether a full tenant backup
+  // should also include a tenant backup of all existing secondary
+  // tenants.
+  bool include_all_secondary_tenants = 25;
+
+  // NEXT ID: 26;
 }
 
 message BackupProgress {
@@ -316,7 +321,7 @@ message BackupProgress {
 }
 
 // DescriptorRewrite specifies a remapping from one descriptor ID to another for
-// use in rewritting descriptors themselves or things that reference them such 
+// use in rewritting descriptors themselves or things that reference them such
 // as is done during RESTORE or IMPORT.
 message DescriptorRewrite {
   uint32 id = 1 [

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -921,7 +921,7 @@ func (u *sqlSymUnion) showTenantOpts() tree.ShowTenantOptions {
 
 %token <str> IDENTITY
 %token <str> IF IFERROR IFNULL IGNORE_FOREIGN_KEYS ILIKE IMMEDIATE IMMUTABLE IMPORT IN INCLUDE
-%token <str> INCLUDING INCREMENT INCREMENTAL INCREMENTAL_LOCATION
+%token <str> INCLUDING INCLUDE_ALL_SECONDARY_TENANTS INCREMENT INCREMENTAL INCREMENTAL_LOCATION
 %token <str> INET INET_CONTAINED_BY_OR_EQUALS
 %token <str> INET_CONTAINS_OR_EQUALS INDEX INDEXES INHERITS INJECT INITIALLY
 %token <str> INDEX_BEFORE_PAREN INDEX_BEFORE_NAME_THEN_PAREN INDEX_AFTER_ORDER_BY_BEFORE_AT
@@ -3125,6 +3125,7 @@ opt_clear_data:
 //    kms="[kms_provider]://[kms_host]/[master_key_identifier]?[parameters]" : encrypt backups using KMS
 //    detached: execute backup job asynchronously, without waiting for its completion
 //    incremental_location: specify a different path to store the incremental backup
+//    include_all_secondary_tenants: enable backups of all secondary tenants during a cluster backup in the system tenant
 //
 // %SeeAlso: RESTORE, WEBDOCS/backup.html
 backup_stmt:
@@ -3249,6 +3250,14 @@ backup_options:
 | COORDINATOR_LOCALITY '=' string_or_placeholder
   {
     $$.val = &tree.BackupOptions{CoordinatorLocality: $3.expr()}
+  }
+| INCLUDE_ALL_SECONDARY_TENANTS
+  {
+    $$.val = &tree.BackupOptions{IncludeAllSecondaryTenants: tree.MakeDBool(true)}
+  }
+| INCLUDE_ALL_SECONDARY_TENANTS '=' a_expr
+  {
+    $$.val = &tree.BackupOptions{IncludeAllSecondaryTenants: $3.expr()}
   }
 
 // %Help: CREATE SCHEDULE FOR BACKUP - backup data periodically
@@ -3562,6 +3571,7 @@ drop_external_connection_stmt:
 //    skip_localities_check: ignore difference of zone configuration between restore cluster and backup cluster
 //    debug_pause_on: describes the events that the job should pause itself on for debugging purposes.
 //    new_db_name: renames the restored database. only applies to database restores
+//    include_all_secondary_tenants: enable backups of all secondary tenants during a cluster backup in the system tenant
 // %SeeAlso: BACKUP, WEBDOCS/restore.html
 restore_stmt:
   RESTORE FROM list_of_string_or_placeholder_opt_list opt_as_of_clause opt_with_restore_options
@@ -3720,6 +3730,14 @@ restore_options:
 | NEW_DB_NAME '=' string_or_placeholder
   {
     $$.val = &tree.RestoreOptions{NewDBName: $3.expr()}
+  }
+| INCLUDE_ALL_SECONDARY_TENANTS
+  {
+    $$.val = &tree.RestoreOptions{IncludeAllSecondaryTenants: tree.MakeDBool(true)}
+  }
+| INCLUDE_ALL_SECONDARY_TENANTS '=' a_expr
+  {
+    $$.val = &tree.RestoreOptions{IncludeAllSecondaryTenants: $3.expr()}
   }
 | INCREMENTAL_LOCATION '=' string_or_placeholder_opt_list
 	{
@@ -16116,6 +16134,7 @@ unreserved_keyword:
 | IMPORT
 | INCLUDE
 | INCLUDING
+| INCLUDE_ALL_SECONDARY_TENANTS
 | INCREMENT
 | INCREMENTAL
 | INCREMENTAL_LOCATION

--- a/pkg/sql/parser/testdata/backup_restore
+++ b/pkg/sql/parser/testdata/backup_restore
@@ -767,6 +767,38 @@ RESTORE TABLE (foo) FROM ('bar') WITH skip_missing_foreign_keys, skip_missing_se
 RESTORE TABLE foo FROM '_' WITH skip_missing_foreign_keys, skip_missing_sequences, detached -- literals removed
 RESTORE TABLE _ FROM 'bar' WITH skip_missing_foreign_keys, skip_missing_sequences, detached -- identifiers removed
 
+parse
+BACKUP INTO 'bar' WITH include_all_secondary_tenants = $1, detached
+----
+BACKUP INTO 'bar' WITH detached, include_all_secondary_tenants = $1 -- normalized!
+BACKUP INTO ('bar') WITH detached, include_all_secondary_tenants = ($1) -- fully parenthesized
+BACKUP INTO '_' WITH detached, include_all_secondary_tenants = $1 -- literals removed
+BACKUP INTO 'bar' WITH detached, include_all_secondary_tenants = $1 -- identifiers removed
+
+parse
+BACKUP INTO 'bar' WITH include_all_secondary_tenants, detached
+----
+BACKUP INTO 'bar' WITH detached, include_all_secondary_tenants = true -- normalized!
+BACKUP INTO ('bar') WITH detached, include_all_secondary_tenants = (true) -- fully parenthesized
+BACKUP INTO '_' WITH detached, include_all_secondary_tenants = _ -- literals removed
+BACKUP INTO 'bar' WITH detached, include_all_secondary_tenants = true -- identifiers removed
+
+parse
+RESTORE FROM LATEST IN 'bar' WITH include_all_secondary_tenants = $1, detached
+----
+RESTORE FROM 'latest' IN 'bar' WITH detached, include_all_secondary_tenants = $1 -- normalized!
+RESTORE FROM ('latest') IN ('bar') WITH detached, include_all_secondary_tenants = ($1) -- fully parenthesized
+RESTORE FROM '_' IN '_' WITH detached, include_all_secondary_tenants = $1 -- literals removed
+RESTORE FROM 'latest' IN 'bar' WITH detached, include_all_secondary_tenants = $1 -- identifiers removed
+
+parse
+RESTORE FROM LATEST IN 'bar' WITH include_all_secondary_tenants, detached
+----
+RESTORE FROM 'latest' IN 'bar' WITH detached, include_all_secondary_tenants = true -- normalized!
+RESTORE FROM ('latest') IN ('bar') WITH detached, include_all_secondary_tenants = (true) -- fully parenthesized
+RESTORE FROM '_' IN '_' WITH detached, include_all_secondary_tenants = _ -- literals removed
+RESTORE FROM 'latest' IN 'bar' WITH detached, include_all_secondary_tenants = true -- identifiers removed
+
 error
 BACKUP foo TO 'bar' WITH key1, key2 = 'value'
 ----
@@ -807,6 +839,14 @@ at or near "true": syntax error: detached option specified multiple times
 DETAIL: source SQL:
 BACKUP foo TO 'bar' WITH detached=true, revision_history, detached=true
                                                                    ^
+
+error
+BACKUP TO 'bar' WITH include_all_secondary_tenants=false, include_all_secondary_tenants
+----
+at or near "EOF": syntax error: include_all_secondary_tenants specified multiple times
+DETAIL: source SQL:
+BACKUP TO 'bar' WITH include_all_secondary_tenants=false, include_all_secondary_tenants
+                                                                                       ^
 
 error
 BACKUP foo TO 'bar' WITH detached=$1, revision_history
@@ -857,6 +897,14 @@ at or near "skip_missing_udfs": syntax error: skip_missing_udfs specified multip
 DETAIL: source SQL:
 RESTORE foo FROM 'bar' WITH skip_missing_udfs, skip_missing_views, skip_missing_udfs
                                                                    ^
+
+error
+RESTORE FROM 'bar' WITH include_all_secondary_tenants=false, include_all_secondary_tenants
+----
+at or near "EOF": syntax error: include_all_secondary_tenants specified multiple times
+DETAIL: source SQL:
+RESTORE FROM 'bar' WITH include_all_secondary_tenants=false, include_all_secondary_tenants
+                                                                                          ^
 
 error
 BACKUP ROLE foo, bar TO 'baz'

--- a/pkg/sql/sem/tree/walk.go
+++ b/pkg/sql/sem/tree/walk.go
@@ -1207,6 +1207,17 @@ func (stmt *Backup) walkStmt(v Visitor) Statement {
 			ret.Options.CaptureRevisionHistory = rh
 		}
 	}
+
+	if stmt.Options.IncludeAllSecondaryTenants != nil {
+		include, changed := WalkExpr(v, stmt.Options.IncludeAllSecondaryTenants)
+		if changed {
+			if ret == stmt {
+				ret = stmt.copyNode()
+			}
+			ret.Options.IncludeAllSecondaryTenants = include
+		}
+	}
+
 	return ret
 }
 
@@ -1474,6 +1485,17 @@ func (stmt *Restore) walkStmt(v Visitor) Statement {
 			ret.Options.IntoDB = intoDB
 		}
 	}
+
+	if stmt.Options.IncludeAllSecondaryTenants != nil {
+		include, changed := WalkExpr(v, stmt.Options.IncludeAllSecondaryTenants)
+		if changed {
+			if ret == stmt {
+				ret = stmt.copyNode()
+			}
+			ret.Options.IncludeAllSecondaryTenants = include
+		}
+	}
+
 	return ret
 }
 


### PR DESCRIPTION
Previously, full cluster backups from the system tenant would include tenant backups of all secondary tenants. A full cluster restore of a backup that included tenant backups would similarly restore all tenant backups.

Here, we change that behaviour by default. A full cluster backup only takes a backup of data inside that tenant, even if it is a system tenant. Similarly, a fully cluster restore of a backup that includes tenant backups does not restore those secondary tenant data (but will restore the secondary tenant records).

NB: We may want some more thought about how tenant settings work with respect to full cluster restores. At the moment, the tenant settings table is restored from the backup even when no tenants are restored.

Epic: CRDB-14582

Release note: None