### PR TITLE
backupccl: handle placeholders for revision_history

### DIFF
--- a/pkg/sql/sem/tree/walk.go
+++ b/pkg/sql/sem/tree/walk.go
@@ -1153,6 +1153,15 @@ func (stmt *Backup) walkStmt(v Visitor) Statement {
 			ret.Options.EncryptionPassphrase = pw
 		}
 	}
+	if stmt.Options.CaptureRevisionHistory != nil {
+		rh, changed := WalkExpr(v, stmt.Options.CaptureRevisionHistory)
+		if changed {
+			if ret == stmt {
+				ret = stmt.copyNode()
+			}
+			ret.Options.CaptureRevisionHistory = rh
+		}
+	}
 	return ret
 }
 


### PR DESCRIPTION
With the addition of ALTER BACKUP SCHEDULE, the revision_history option was changed to take an expression. However, we didn't update a few locations where we need to evaluate that expression.

As a result, you could create a scheduled backup using a placeholder for the value of revision_history, but that scheduled backup would always fail because the placeholder value isn't available when the job is created.

Epic: none

Release note: Fix a bug in which CREATE SCHEDULE would not properly handle a placeholder for the revision_history option.