### PR TITLE
sql/tests: disable generate_test_objects in RSG tests

### DIFF
--- a/pkg/sql/tests/rsg_test.go
+++ b/pkg/sql/tests/rsg_test.go
@@ -781,6 +781,12 @@ func testRandomSyntax(
 	err := db.exec(t, ctx, "SET CLUSTER SETTING schemachanger.job.max_retry_backoff='1s'")
 	require.NoError(t, err)
 
+	// Disable the test object generator. This merely causes the built-in function to report
+	// an error when called. This is OK -- we are testing syntax, so this will still ensure
+	// the function syntax is exercised.
+	err = db.exec(t, ctx, "SET CLUSTER SETTING sql.schema.test_object_generator.enabled = false")
+	require.NoError(t, err)
+
 	yBytes, err := os.ReadFile(datapathutils.TestDataPath(t, "rsg", "sql.y"))
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
Fixes #87322.
Requested by @jordanlewis in https://github.com/cockroachdb/cockroach/issues/87322#issuecomment-1398908570

Letting the test object generator actually run causes the RSG test to
struggle cleaning up extremely large schemas after the test completes.
This is not necessary - we are just checking syntax. So this commit
disables it.

Release note: None