### PR TITLE
sql: remove extra type hint from `SHOW CREATE VIEW`

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/views
+++ b/pkg/sql/logictest/testdata/logic_test/views
@@ -140,6 +140,27 @@ CREATE DATABASE test2
 statement ok
 SET DATABASE = test2
 
+statement ok
+CREATE VIEW t1 AS SELECT ARRAY[]:::STRING[];
+CREATE VIEW t2 AS SELECT ARRAY[1,2,3]:::INT[];
+
+
+query TT colnames
+SHOW CREATE VIEW t1
+----
+table_name  create_statement
+t1          CREATE VIEW public.t1 (
+              "array"
+            ) AS SELECT ARRAY[]:::STRING[]
+
+query TT colnames
+SHOW CREATE VIEW t2
+----
+table_name  create_statement
+t2          CREATE VIEW public.t2 (
+              "array"
+            ) AS SELECT ARRAY[1:::INT8, 2:::INT8, 3:::INT8]:::INT8[]
+
 query II colnames,rowsort
 SELECT * FROM test.v1
 ----

--- a/pkg/sql/sem/tree/expr.go
+++ b/pkg/sql/sem/tree/expr.go
@@ -1595,6 +1595,13 @@ func (node *AnnotateTypeExpr) Format(ctx *FmtCtx) {
 	switch node.SyntaxMode {
 	case AnnotateShort:
 		exprFmtWithParen(ctx, node.Expr)
+		// The Array format function handles adding type annotations for this case.
+		// We short circuit here to prevent double type annotation.
+		if arrayExpr, ok := node.Expr.(*Array); ok {
+			if ctx.HasFlags(FmtParsable) && arrayExpr.typ != nil {
+				return
+			}
+		}
 		ctx.WriteString(":::")
 		ctx.FormatTypeReference(node.Type)
 


### PR DESCRIPTION
Resolves: #87886

Views created with user provided type hints were given
extra type annotations. The format functions for `AnnotateTypeExpr`
and `Array` were both annotating the expression. This commit alters
the format function of `AnnotateTypeExpr` so it doesnt duplicate
annotations for arrays.


Release note: None