### PR TITLE
kvserver: decrease log verbosity when no rebalance

### DIFF
--- a/pkg/kv/kvserver/replicate_queue.go
+++ b/pkg/kv/kvserver/replicate_queue.go
@@ -1673,7 +1673,7 @@ func (rq *replicateQueue) considerRebalance(
 	if !ok {
 		// If there was nothing to do for the set of voting replicas on this
 		// range, attempt to rebalance non-voters.
-		log.KvDistribution.Infof(ctx, "no suitable rebalance target for voters")
+		log.KvDistribution.VInfof(ctx, 2, "no suitable rebalance target for voters")
 		addTarget, removeTarget, details, ok = rq.allocator.RebalanceNonVoter(
 			ctx,
 			rq.storePool,
@@ -1693,7 +1693,7 @@ func (rq *replicateQueue) considerRebalance(
 	lhRemovalAllowed := addTarget != (roachpb.ReplicationTarget{})
 
 	if !ok {
-		log.KvDistribution.Infof(ctx, "no suitable rebalance target for non-voters")
+		log.KvDistribution.VInfof(ctx, 2, "no suitable rebalance target for non-voters")
 	} else if !lhRemovalAllowed {
 		if transferOp, err := rq.maybeTransferLeaseAwayTarget(
 			ctx, repl, removeTarget.StoreID, canTransferLeaseFrom,


### PR DESCRIPTION
Previously, the replicate queue would log every time it could not find a rebalance target for a voter or non-voter. This can spam the logs on startup with messages. This commit reduces the logging verbosity of these lines to 2, from default on.

resolves: #95681

Release note: None