### PR TITLE
workflow: finalizing cluster-ui release workflow

### DIFF
--- a/.github/workflows/cluster-ui-release.yml
+++ b/.github/workflows/cluster-ui-release.yml
@@ -64,6 +64,13 @@ jobs:
         cp ../../../../_bazel/bin/pkg/ui/workspaces/db-console/src/js/protos.* ../db-console/src/js/
         yarn build
 
+    - name: Create version tag and push
+      if: steps.version-check.outputs.published == 'no'
+      run: |
+        TAGNAME="@cockroachlabs/cluster-ui@$(cat ./package.json | jq -r '.version')"
+        git tag $TAGNAME
+        git push origin $TAGNAME
+
     - name: Publish patch version
       if: steps.version-check.outputs.published == 'no'
-      run: npm publish --access public --tag ${{ steps.branch_name.outputs.branch }} --dry-run
+      run: yarn publish --access public --tag ${{ steps.branch-name.outputs.branch }}


### PR DESCRIPTION
Made some final changes to the cluster-ui-release workflow. This
workflow shouldn't do anything on the master branch, but is being
adjusted to facilitate auto-publishing when release branches are cut
from master.

- Corrected "branch-name" step in distribution tag when publishing
- Added a step to tag commit being published
- Removed "--dry-run" flag from publishing step

Part of: https://cockroachlabs.atlassian.net/browse/CC-7959
Epic: CC-7999

Release note: None