### PR TITLE
cdc: add continuous telemetry logging for emitted bytes

### DIFF
--- a/docs/generated/eventlog.md
+++ b/docs/generated/eventlog.md
@@ -2724,6 +2724,30 @@ An event of type `captured_index_usage_stats`
 | `Timestamp` | The timestamp of the event. Expressed as nanoseconds since the Unix epoch. | no |
 | `EventType` | The type of the event. | no |
 
+### `changefeed_emitted_bytes`
+
+An event of type `changefeed_emitted_bytes` is an event representing the bytes emitted by a changefeed over an interval.
+
+
+| Field | Description | Sensitive |
+|--|--|--|
+| `JobId` | The job id for enterprise changefeeds. | no |
+| `EmittedBytes` | The number of bytes emitted. | no |
+| `LoggingInterval` | The time period in nanoseconds between emitting telemetry events of this type (per-aggregator). | no |
+| `Closing` | Flag to indicate that the changefeed is closing. | no |
+
+
+#### Common fields
+
+| Field | Description | Sensitive |
+|--|--|--|
+| `Description` | The description of that would show up in the job's description field, redacted | yes |
+| `SinkType` | The type of sink being emitted to (ex: kafka, nodelocal, webhook-https). | no |
+| `NumTables` | The number of tables listed in the query that the changefeed is to run on. | no |
+| `Resolved` | The behavior of emitted resolved spans (ex: yes, no, 10s) | no |
+| `InitialScan` | The desired behavior of initial scans (ex: yes, no, only) | no |
+| `Format` | The data format being emitted (ex: JSON, Avro). | no |
+
 ### `changefeed_failed`
 
 An event of type `changefeed_failed` is an event for any Changefeed failure since the plan hook

--- a/pkg/ccl/changefeedccl/BUILD.bazel
+++ b/pkg/ccl/changefeedccl/BUILD.bazel
@@ -32,6 +32,7 @@ go_library(
         "sink_pubsub.go",
         "sink_sql.go",
         "sink_webhook.go",
+        "telemetry.go",
         "testing_knobs.go",
         "tls.go",
         "topic.go",

--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -5620,6 +5620,104 @@ func TestChangefeedTelemetry(t *testing.T) {
 	cdcTest(t, testFn, feedTestForceSink("enterprise"))
 }
 
+func TestChangefeedContinuousTelemetry(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	testFn := func(t *testing.T, s TestServer, f cdctest.TestFeedFactory) {
+		// Hack: since setting a zero value disabled, set a negative value to ensure we always log.
+		interval := -10 * time.Millisecond
+		ContinuousTelemetryInterval.Override(context.Background(), &s.Server.ClusterSettings().SV, interval)
+
+		sqlDB := sqlutils.MakeSQLRunner(s.DB)
+		sqlDB.Exec(t, `CREATE TABLE foo (id INT PRIMARY KEY)`)
+
+		foo := feed(t, f, `CREATE CHANGEFEED FOR foo`)
+		defer closeFeed(t, foo)
+		jobID := foo.(cdctest.EnterpriseTestFeed).JobID()
+
+		for i := 0; i < 5; i++ {
+			beforeCreate := timeutil.Now()
+			sqlDB.Exec(t, fmt.Sprintf(`INSERT INTO foo VALUES (%d) RETURNING cluster_logical_timestamp()`, i))
+			verifyLogsWithEmittedBytes(t, jobID, beforeCreate.UnixNano(), interval.Nanoseconds(), false)
+		}
+	}
+
+	// TODO(#89421): include pubsub once it supports metrics
+	cdcTest(t, testFn, feedTestOmitSinks("sinkless", "pubsub"))
+}
+
+func TestChangefeedContinuousTelemetryOnTermination(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	testFn := func(t *testing.T, s TestServer, f cdctest.TestFeedFactory) {
+		interval := 24 * time.Hour
+		ContinuousTelemetryInterval.Override(context.Background(), &s.Server.ClusterSettings().SV, interval)
+		beforeCreate := timeutil.Now()
+		sqlDB := sqlutils.MakeSQLRunner(s.DB)
+		sqlDB.Exec(t, `CREATE TABLE foo (id INT PRIMARY KEY)`)
+
+		// Insert a row and wait for logs to be created.
+		foo := feed(t, f, `CREATE CHANGEFEED FOR foo`)
+		jobID := foo.(cdctest.EnterpriseTestFeed).JobID()
+		sqlDB.Exec(t, `INSERT INTO foo VALUES (1)`)
+		verifyLogsWithEmittedBytes(t, jobID, beforeCreate.UnixNano(), interval.Nanoseconds(), false)
+
+		// Insert more rows. No logs should be created for these since we recently
+		// published them above and the interval is 24h.
+		sqlDB.Exec(t, `INSERT INTO foo VALUES (2)`)
+		sqlDB.Exec(t, `INSERT INTO foo VALUES (3)`)
+		assertPayloads(t, foo, []string{
+			`foo: [1]->{"after": {"id": 1}}`,
+			`foo: [2]->{"after": {"id": 2}}`,
+			`foo: [3]->{"after": {"id": 3}}`,
+		})
+
+		// Close the changefeed and ensure logs were created after closing.
+		beforeClose := timeutil.Now()
+		require.NoError(t, foo.Close())
+		verifyLogsWithEmittedBytes(t, jobID, beforeClose.UnixNano(), interval.Nanoseconds(), true)
+	}
+
+	// TODO(#89421): include pubsub once it supports metrics
+	cdcTest(t, testFn, feedTestOmitSinks("sinkless", "pubsub"))
+}
+
+func TestChangefeedContinuousTelemetryDifferentJobs(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	testFn := func(t *testing.T, s TestServer, f cdctest.TestFeedFactory) {
+		// Hack: since setting a zero value disabled, set a negative value to ensure we always log.
+		interval := -100 * time.Millisecond
+		ContinuousTelemetryInterval.Override(context.Background(), &s.Server.ClusterSettings().SV, interval)
+		sqlDB := sqlutils.MakeSQLRunner(s.DB)
+		sqlDB.Exec(t, `CREATE TABLE foo (id INT PRIMARY KEY)`)
+		sqlDB.Exec(t, `CREATE TABLE foo2 (id INT PRIMARY KEY)`)
+
+		foo := feed(t, f, `CREATE CHANGEFEED FOR foo`)
+		foo2 := feed(t, f, `CREATE CHANGEFEED FOR foo2`)
+		job1 := foo.(cdctest.EnterpriseTestFeed).JobID()
+		job2 := foo2.(cdctest.EnterpriseTestFeed).JobID()
+
+		beforeInsert := timeutil.Now()
+		sqlDB.Exec(t, `INSERT INTO foo VALUES (1)`)
+		sqlDB.Exec(t, `INSERT INTO foo2 VALUES (1)`)
+		verifyLogsWithEmittedBytes(t, job1, beforeInsert.UnixNano(), interval.Nanoseconds(), false)
+		verifyLogsWithEmittedBytes(t, job2, beforeInsert.UnixNano(), interval.Nanoseconds(), false)
+		require.NoError(t, foo.Close())
+
+		beforeInsert = timeutil.Now()
+		sqlDB.Exec(t, `INSERT INTO foo2 VALUES (2)`)
+		verifyLogsWithEmittedBytes(t, job2, beforeInsert.UnixNano(), interval.Nanoseconds(), false)
+		require.NoError(t, foo2.Close())
+	}
+
+	// TODO(#89421): include pubsub once it supports metrics
+	cdcTest(t, testFn, feedTestOmitSinks("sinkless", "pubsub"))
+}
+
 // Regression test for #41694.
 func TestChangefeedRestartDuringBackfill(t *testing.T) {
 	defer leaktest.AfterTest(t)()

--- a/pkg/ccl/changefeedccl/helpers_test.go
+++ b/pkg/ccl/changefeedccl/helpers_test.go
@@ -1063,6 +1063,55 @@ func checkStructuredLogs(t *testing.T, eventType string, startTime int64) []stri
 	return matchingEntries
 }
 
+func checkContinuousChangefeedLogs(t *testing.T, startTime int64) []eventpb.ChangefeedEmittedBytes {
+	logs := checkStructuredLogs(t, "changefeed_emitted_bytes", startTime)
+	matchingEntries := make([]eventpb.ChangefeedEmittedBytes, len(logs))
+
+	for i, m := range logs {
+		jsonPayload := []byte(m)
+		var event eventpb.ChangefeedEmittedBytes
+		if err := gojson.Unmarshal(jsonPayload, &event); err != nil {
+			t.Errorf("unmarshalling %q: %v", m, err)
+		}
+		matchingEntries[i] = event
+	}
+
+	return matchingEntries
+}
+
+// verifyLogsWithEmittedBytes fetches changefeed_emitted_bytes telemetry logs produced
+// after startTime for a particular job and asserts that at least one message has positive emitted bytes.
+// This function also asserts the LoggingInterval and Closing fields of
+// each message.
+func verifyLogsWithEmittedBytes(
+	t *testing.T, jobID jobspb.JobID, startTime int64, interval int64, closing bool,
+) {
+	testutils.SucceedsSoon(t, func() error {
+		emittedBytesLogs := checkContinuousChangefeedLogs(t, startTime)
+		if len(emittedBytesLogs) == 0 {
+			return errors.New("no logs found")
+		}
+		emittedBytes := false
+		for _, msg := range emittedBytesLogs {
+			if msg.JobId != int64(jobID) {
+				continue
+			}
+
+			if msg.EmittedBytes > 0 {
+				emittedBytes = true
+			}
+			require.Equal(t, interval, msg.LoggingInterval)
+			if closing {
+				require.Equal(t, true, msg.Closing)
+			}
+		}
+		if !emittedBytes {
+			return errors.New("expected emitted bytes in log messages, but found 0")
+		}
+		return nil
+	})
+}
+
 func checkCreateChangefeedLogs(t *testing.T, startTime int64) []eventpb.CreateChangefeed {
 	var matchingEntries []eventpb.CreateChangefeed
 

--- a/pkg/ccl/changefeedccl/telemetry.go
+++ b/pkg/ccl/changefeedccl/telemetry.go
@@ -1,0 +1,196 @@
+// Copyright 2023 The Cockroach Authors.
+//
+// Licensed as a CockroachDB Enterprise file under the Cockroach Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//     https://github.com/cockroachdb/cockroach/blob/master/licenses/CCL.txt
+
+package changefeedccl
+
+import (
+	"context"
+	"sync/atomic"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/jobs"
+	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
+	"github.com/cockroachdb/cockroach/pkg/settings"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/log/eventpb"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+)
+
+type sinkTelemetryData struct {
+	emittedBytes atomic.Int64
+}
+
+type periodicTelemetryLogger struct {
+	ctx               context.Context
+	sinkTelemetryData sinkTelemetryData
+	job               *jobs.Job
+	changefeedDetails eventpb.CommonChangefeedEventDetails
+	settings          *cluster.Settings
+
+	lastEmitTime atomic.Int64
+}
+
+type telemetryLogger interface {
+	// recordEmittedBytes records the number of emitted bytes without
+	// publishing logs.
+	recordEmittedBytes(numBytes int)
+
+	// maybeFlushLogs flushes buffered metrics to logs depending
+	// on the semantics of the implementation.
+	maybeFlushLogs()
+
+	// close flushes buffered metrics to logs.
+	close()
+}
+
+var _ telemetryLogger = (*periodicTelemetryLogger)(nil)
+
+func makePeriodicTelemetryLogger(
+	ctx context.Context, job *jobs.Job, s *cluster.Settings,
+) (*periodicTelemetryLogger, error) {
+	return &periodicTelemetryLogger{
+		ctx:               ctx,
+		job:               job,
+		changefeedDetails: getCommonChangefeedEventDetails(ctx, job.Details().(jobspb.ChangefeedDetails), job.Payload().Description),
+		sinkTelemetryData: sinkTelemetryData{},
+		settings:          s,
+	}, nil
+}
+
+// recordEmittedBytes implements the telemetryLogger interface.
+func (ptl *periodicTelemetryLogger) recordEmittedBytes(numBytes int) {
+	ptl.sinkTelemetryData.emittedBytes.Add(int64(numBytes))
+}
+
+func (ptl *periodicTelemetryLogger) resetEmittedBytes() int {
+	return int(ptl.sinkTelemetryData.emittedBytes.Swap(0))
+}
+
+// recordEmittedBytes implements the telemetryLogger interface.
+func (ptl *periodicTelemetryLogger) maybeFlushLogs() {
+	loggingInterval := ContinuousTelemetryInterval.Get(&ptl.settings.SV).Nanoseconds()
+	if loggingInterval == 0 {
+		return
+	}
+
+	currentTime := timeutil.Now().UnixNano()
+	// This is a barrier to ensure that only one goroutine writes logs in
+	// case multiple goroutines call this function at the same time.
+	// This prevents a burst of telemetry events from being needlessly
+	// logging the same data.
+	lastEmit := ptl.lastEmitTime.Load()
+	if currentTime < lastEmit+loggingInterval {
+		return
+	}
+	if !ptl.lastEmitTime.CompareAndSwap(lastEmit, currentTime) {
+		return
+	}
+
+	continuousTelemetryEvent := &eventpb.ChangefeedEmittedBytes{
+		CommonChangefeedEventDetails: ptl.changefeedDetails,
+		JobId:                        int64(ptl.job.ID()),
+		EmittedBytes:                 int32(ptl.resetEmittedBytes()),
+		LoggingInterval:              loggingInterval,
+	}
+	log.StructuredEvent(ptl.ctx, continuousTelemetryEvent)
+}
+
+func (ptl *periodicTelemetryLogger) close() {
+	loggingInterval := ContinuousTelemetryInterval.Get(&ptl.settings.SV).Nanoseconds()
+	if loggingInterval == 0 {
+		return
+	}
+
+	continuousTelemetryEvent := &eventpb.ChangefeedEmittedBytes{
+		CommonChangefeedEventDetails: ptl.changefeedDetails,
+		JobId:                        int64(ptl.job.ID()),
+		EmittedBytes:                 int32(ptl.resetEmittedBytes()),
+		LoggingInterval:              loggingInterval,
+		Closing:                      true,
+	}
+	log.StructuredEvent(ptl.ctx, continuousTelemetryEvent)
+}
+
+func wrapMetricsRecorderWithTelemetry(
+	ctx context.Context, job *jobs.Job, s *cluster.Settings, mb metricsRecorder,
+) (*telemetryMetricsRecorder, error) {
+	logger, err := makePeriodicTelemetryLogger(ctx, job, s)
+	if err != nil {
+		return &telemetryMetricsRecorder{}, err
+	}
+	return &telemetryMetricsRecorder{
+		telemetryLogger: logger,
+		inner:           mb,
+	}, nil
+}
+
+type telemetryMetricsRecorder struct {
+	telemetryLogger *periodicTelemetryLogger
+	inner           metricsRecorder
+}
+
+func (r *telemetryMetricsRecorder) close() {
+	r.telemetryLogger.close()
+}
+
+func (r *telemetryMetricsRecorder) recordMessageSize(sz int64) {
+	r.inner.recordMessageSize(sz)
+}
+
+func (r *telemetryMetricsRecorder) recordInternalRetry(numMessages int64, reducedBatchSize bool) {
+	r.inner.recordInternalRetry(numMessages, reducedBatchSize)
+}
+
+func (r *telemetryMetricsRecorder) recordOneMessage() recordOneMessageCallback {
+	return func(mvcc hlc.Timestamp, bytes int, compressedBytes int) {
+		r.inner.recordOneMessage()(mvcc, bytes, compressedBytes)
+		r.telemetryLogger.recordEmittedBytes(bytes)
+		r.telemetryLogger.maybeFlushLogs()
+	}
+}
+
+func (r *telemetryMetricsRecorder) recordEmittedBatch(
+	startTime time.Time, numMessages int, mvcc hlc.Timestamp, bytes int, compressedBytes int,
+) {
+	r.inner.recordEmittedBatch(startTime, numMessages, mvcc, bytes, compressedBytes)
+	r.telemetryLogger.recordEmittedBytes(bytes)
+	r.telemetryLogger.maybeFlushLogs()
+}
+
+func (r *telemetryMetricsRecorder) recordResolvedCallback() func() {
+	return r.inner.recordResolvedCallback()
+}
+
+func (r *telemetryMetricsRecorder) recordFlushRequestCallback() func() {
+	return r.inner.recordFlushRequestCallback()
+}
+
+func (r *telemetryMetricsRecorder) getBackfillCallback() func() func() {
+	return r.inner.getBackfillCallback()
+}
+
+func (r *telemetryMetricsRecorder) getBackfillRangeCallback() func(int64) (func(), func()) {
+	return r.inner.getBackfillRangeCallback()
+}
+
+func (r *telemetryMetricsRecorder) recordSizeBasedFlush() {
+	r.inner.recordSizeBasedFlush()
+}
+
+// ContinuousTelemetryInterval determines the interval at which each node emits telemetry events
+// during the lifespan of each enterprise changefeed.
+var ContinuousTelemetryInterval = settings.RegisterDurationSetting(
+	settings.TenantWritable,
+	"changefeed.telemetry.continuous_logging.interval",
+	"determines the interval at which each node emits continuous telemetry events"+
+		" during the lifespan of every enterprise changefeed; setting a zero value disables",
+	24*time.Hour,
+	settings.NonNegativeDuration,
+)

--- a/pkg/util/log/eventpb/eventlog_channels_generated.go
+++ b/pkg/util/log/eventpb/eventlog_channels_generated.go
@@ -317,6 +317,9 @@ func (m *StoreStats) LoggingChannel() logpb.Channel { return logpb.Channel_TELEM
 func (m *CapturedIndexUsageStats) LoggingChannel() logpb.Channel { return logpb.Channel_TELEMETRY }
 
 // LoggingChannel implements the EventPayload interface.
+func (m *ChangefeedEmittedBytes) LoggingChannel() logpb.Channel { return logpb.Channel_TELEMETRY }
+
+// LoggingChannel implements the EventPayload interface.
 func (m *ChangefeedFailed) LoggingChannel() logpb.Channel { return logpb.Channel_TELEMETRY }
 
 // LoggingChannel implements the EventPayload interface.

--- a/pkg/util/log/eventpb/json_encode_generated.go
+++ b/pkg/util/log/eventpb/json_encode_generated.go
@@ -962,6 +962,49 @@ func (m *ChangeTypePrivilege) AppendJSONFields(printComma bool, b redact.Redacta
 }
 
 // AppendJSONFields implements the EventPayload interface.
+func (m *ChangefeedEmittedBytes) AppendJSONFields(printComma bool, b redact.RedactableBytes) (bool, redact.RedactableBytes) {
+
+	printComma, b = m.CommonChangefeedEventDetails.AppendJSONFields(printComma, b)
+
+	if m.JobId != 0 {
+		if printComma {
+			b = append(b, ',')
+		}
+		printComma = true
+		b = append(b, "\"JobId\":"...)
+		b = strconv.AppendInt(b, int64(m.JobId), 10)
+	}
+
+	if m.EmittedBytes != 0 {
+		if printComma {
+			b = append(b, ',')
+		}
+		printComma = true
+		b = append(b, "\"EmittedBytes\":"...)
+		b = strconv.AppendInt(b, int64(m.EmittedBytes), 10)
+	}
+
+	if m.LoggingInterval != 0 {
+		if printComma {
+			b = append(b, ',')
+		}
+		printComma = true
+		b = append(b, "\"LoggingInterval\":"...)
+		b = strconv.AppendInt(b, int64(m.LoggingInterval), 10)
+	}
+
+	if m.Closing {
+		if printComma {
+			b = append(b, ',')
+		}
+		printComma = true
+		b = append(b, "\"Closing\":true"...)
+	}
+
+	return printComma, b
+}
+
+// AppendJSONFields implements the EventPayload interface.
 func (m *ChangefeedFailed) AppendJSONFields(printComma bool, b redact.RedactableBytes) (bool, redact.RedactableBytes) {
 
 	printComma, b = m.CommonChangefeedEventDetails.AppendJSONFields(printComma, b)

--- a/pkg/util/log/eventpb/telemetry.proto
+++ b/pkg/util/log/eventpb/telemetry.proto
@@ -253,6 +253,23 @@ message ChangefeedFailed {
   string failure_type = 2 [(gogoproto.jsontag) = ",omitempty", (gogoproto.moretags) = "redact:\"nonsensitive\""];
 }
 
+// ChangefeedEmittedBytes is an event representing the bytes emitted by a changefeed over an interval.
+message ChangefeedEmittedBytes {
+  CommonChangefeedEventDetails common = 1 [(gogoproto.nullable) = false, (gogoproto.jsontag) = "", (gogoproto.embed) = true];
+
+  // The job id for enterprise changefeeds.
+  int64 job_id = 2 [(gogoproto.jsontag) = ",omitempty", (gogoproto.moretags) =  "redact:\"nonsensitive\""];
+
+  // The number of bytes emitted.
+  int32 emitted_bytes = 3 [(gogoproto.jsontag) = ",omitempty", (gogoproto.moretags) = "redact:\"nonsensitive\""];
+
+  // The time period in nanoseconds between emitting telemetry events of this type (per-aggregator).
+  int64 logging_interval = 4 [(gogoproto.jsontag) = ",omitempty", (gogoproto.moretags) = "redact:\"nonsensitive\""];
+
+  // Flag to indicate that the changefeed is closing.
+  bool closing = 5 [(gogoproto.jsontag) = ",omitempty", (gogoproto.moretags) = "redact:\"nonsensitive\""];
+}
+
 // RecoveryEvent is an event that is logged on every invocation of BACKUP,
 // RESTORE, and on every BACKUP schedule creation, with the appropriate subset
 // of fields populated depending on the type of event. This event is is also


### PR DESCRIPTION
#### cdc: add continuous telemetry logging for emitted bytes

This change updates change aggregators to emit periodic telemetry events for all enterprise
sinks (with the exception of pubsub, which does not yet support metrics - see https://github.com/cockroachdb/cockroach/issues/89421).
A final event is emited by each aggregator upon closing.

These telemetry events contain:
- the job id of the changefeed
- the number of bytes emitted by the aggregator since the last event
- the time interval between events
- a flag to indicate if the event was emitted on closing

Additionally, these events contain common information such as the
timestamp of the emitted event, sink type, encoding scheme etc.

The default period for each aggregator is 24h. This can be changed via the cluster setting
`changefeed.telemetry.continuous_logging.interval`. Setting a negative value disables
continuous telemetry.

Epic: [CRDB-13935](https://cockroachlabs.atlassian.net/browse/CRDB-13935)
Closes: https://github.com/cockroachdb/cockroach/issues/93915

Release note: None