### PR TITLE
batcheval: modify MVCCStats CleanRange assertion under race

### DIFF
--- a/pkg/kv/kvserver/batcheval/cmd_clear_range.go
+++ b/pkg/kv/kvserver/batcheval/cmd_clear_range.go
@@ -189,10 +189,14 @@ func computeStatsDelta(
 		if err != nil {
 			return enginepb.MVCCStats{}, err
 		}
-		// If we took the fast path but race is enabled, assert stats were correctly computed.
+		// If we took the fast path but race is enabled, assert stats were correctly
+		// computed.
 		if entireRange {
-			computed.ContainsEstimates = delta.ContainsEstimates // retained for tests under race
-			if !delta.Equal(computed) {
+			// Retain the value of ContainsEstimates for tests under race.
+			computed.ContainsEstimates = delta.ContainsEstimates
+			// We only want to assert the correctness of stats that do not contain
+			// estimates.
+			if delta.ContainsEstimates == 0 && !delta.Equal(computed) {
 				log.Fatalf(ctx, "fast-path MVCCStats computation gave wrong result: diff(fast, computed) = %s",
 					pretty.Diff(delta, computed))
 			}


### PR DESCRIPTION
Previously, if ClearRange took a fast path and was being tested under race, then we would assert that the computed MVCCStats were the same as those of the fast path. This would not be true if the MVCCStats contained estimates which they do in operation such as cluster to cluster replication.

This change tweaks the assertion to only run if the MVCCStats do not contain estimates since if they do there is no guarantee they will match up with the computed MVCCStats.

Fixes: #95656
Fixes: #95677

Release note: None