### PR TITLE
server,sql: add an interface for internal SQL sessions

### DIFF
--- a/pkg/server/BUILD.bazel
+++ b/pkg/server/BUILD.bazel
@@ -524,6 +524,7 @@ go_test(
         "@com_github_gogo_protobuf//jsonpb",
         "@com_github_gogo_protobuf//proto",
         "@com_github_grpc_ecosystem_grpc_gateway//runtime:go_default_library",
+        "@com_github_jackc_pgx_v4//:pgx",
         "@com_github_kr_pretty//:pretty",
         "@com_github_lib_pq//:pq",
         "@com_github_stretchr_testify//assert",

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -97,6 +97,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/metric"
 	"github.com/cockroachdb/cockroach/pkg/util/mon"
+	"github.com/cockroachdb/cockroach/pkg/util/netutil"
 	"github.com/cockroachdb/cockroach/pkg/util/rangedesc"
 	"github.com/cockroachdb/cockroach/pkg/util/retry"
 	"github.com/cockroachdb/cockroach/pkg/util/schedulerlatency"
@@ -106,6 +107,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/logtags"
 	"github.com/cockroachdb/redact"
 	sentry "github.com/getsentry/sentry-go"
 	"google.golang.org/grpc/codes"
@@ -172,6 +174,8 @@ type Server struct {
 
 	// pgL is the SQL listener.
 	pgL net.Listener
+	// loopbackPgL is the SQL listener for internal pgwire connections.
+	loopbackPgL *netutil.LoopbackListener
 
 	// pgPreServer handles SQL connections prior to routing them to a
 	// specific tenant.
@@ -1198,6 +1202,9 @@ func (s *Server) Start(ctx context.Context) error {
 	if err := s.PreStart(ctx); err != nil {
 		return err
 	}
+	if err := s.AcceptInternalClients(ctx); err != nil {
+		return err
+	}
 	return s.AcceptClients(ctx)
 }
 
@@ -1378,11 +1385,13 @@ func (s *Server) PreStart(ctx context.Context) error {
 	// and dispatches the server worker for the RPC.
 	// The SQL listener is returned, to start the SQL server later
 	// below when the server has initialized.
-	pgL, rpcLoopbackDialFn, startRPCServer, err := startListenRPCAndSQL(ctx, workersCtx, s.cfg.BaseConfig, s.stopper, s.grpc, true /* enableSQLListener */)
+	pgL, loopbackPgL, rpcLoopbackDialFn, startRPCServer, err := startListenRPCAndSQL(
+		ctx, workersCtx, s.cfg.BaseConfig, s.stopper, s.grpc, true /* enableSQLListener */)
 	if err != nil {
 		return err
 	}
 	s.pgL = pgL
+	s.loopbackPgL = loopbackPgL
 
 	// Tell the RPC context how to connect in-memory.
 	s.rpcContext.SetLoopbackDialer(rpcLoopbackDialFn)
@@ -1964,6 +1973,32 @@ func (s *Server) AcceptClients(ctx context.Context) error {
 
 	log.Event(ctx, "server ready")
 	return nil
+}
+
+// AcceptInternalClients starts listening for incoming SQL connections on the
+// internal loopback interface.
+func (s *Server) AcceptInternalClients(ctx context.Context) error {
+	connManager := netutil.MakeTCPServer(ctx, s.stopper)
+
+	return s.stopper.RunAsyncTaskEx(ctx,
+		stop.TaskOpts{TaskName: "sql-internal-listener", SpanOpt: stop.SterileRootSpan},
+		func(ctx context.Context) {
+			err := connManager.ServeWith(ctx, s.loopbackPgL, func(ctx context.Context, conn net.Conn) {
+				connCtx := s.pgPreServer.AnnotateCtxForIncomingConn(ctx, conn)
+				connCtx = logtags.AddTag(connCtx, "internal-conn", nil)
+
+				conn, status, err := s.pgPreServer.PreServe(connCtx, conn, pgwire.SocketInternalLoopback)
+				if err != nil {
+					log.Ops.Errorf(connCtx, "serving SQL client conn: %v", err)
+					return
+				}
+
+				if err := s.serverController.sqlMux(connCtx, conn, status); err != nil {
+					log.Ops.Errorf(connCtx, "serving internal SQL client conn: %s", err)
+				}
+			})
+			netutil.FatalIfUnexpected(err)
+		})
 }
 
 // Stop shuts down this server instance. Note that this method exists

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -17,6 +17,7 @@ import (
 	"fmt"
 	"io"
 	"math"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -59,6 +60,7 @@ import (
 	"github.com/gogo/protobuf/jsonpb"
 	"github.com/gogo/protobuf/proto"
 	"github.com/grpc-ecosystem/grpc-gateway/runtime"
+	"github.com/jackc/pgx/v4"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc/codes"
@@ -1207,4 +1209,27 @@ func TestSocketAutoNumbering(t *testing.T) {
 	if socketPath := s.(*TestServer).Cfg.SocketFile; !strings.HasSuffix(socketPath, "."+expectedPort) {
 		t.Errorf("expected unix socket ending with port %q, got %q", expectedPort, socketPath)
 	}
+}
+
+// Test that connections using the internal SQL loopback listener work.
+func TestInternalSQL(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	ctx := context.Background()
+	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	defer s.Stopper().Stop(ctx)
+
+	conf, err := pgx.ParseConfig("")
+	require.NoError(t, err)
+	conf.User = "root"
+	// Configure pgx to connect on the loopback listener.
+	conf.DialFunc = func(ctx context.Context, network, addr string) (net.Conn, error) {
+		return s.(*TestServer).Server.loopbackPgL.Connect(ctx)
+	}
+	conn, err := pgx.ConnectConfig(ctx, conf)
+	require.NoError(t, err)
+	// Run a random query to check that it all works.
+	r := conn.QueryRow(ctx, "SELECT count(*) FROM system.sqlliveness")
+	var count int
+	require.NoError(t, r.Scan(&count))
 }

--- a/pkg/server/tenant.go
+++ b/pkg/server/tenant.go
@@ -60,11 +60,13 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/metric"
+	"github.com/cockroachdb/cockroach/pkg/util/netutil"
 	"github.com/cockroachdb/cockroach/pkg/util/schedulerlatency"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/logtags"
 	"github.com/cockroachdb/redact"
 	sentry "github.com/getsentry/sentry-go"
 )
@@ -104,6 +106,8 @@ type SQLServerWrapper struct {
 
 	// pgL is the SQL listener.
 	pgL net.Listener
+	// loopbackPgL is the SQL listener for internal pgwire connections.
+	loopbackPgL *netutil.LoopbackListener
 
 	// pgPreServer handles SQL connections prior to routing them to a
 	// specific tenant.
@@ -444,13 +448,14 @@ func (s *SQLServerWrapper) PreStart(ctx context.Context) error {
 	// The SQL listener is returned, to start the SQL server later
 	// below when the server has initialized.
 	enableSQLListener := !s.sqlServer.cfg.DisableSQLListener
-	pgL, rpcLoopbackDialFn, startRPCServer, err := startListenRPCAndSQL(ctx, workersCtx, *s.sqlServer.cfg, s.stopper, s.grpc, enableSQLListener)
+	pgL, loopbackPgL, rpcLoopbackDialFn, startRPCServer, err := startListenRPCAndSQL(ctx, workersCtx, *s.sqlServer.cfg, s.stopper, s.grpc, enableSQLListener)
 	if err != nil {
 		return err
 	}
 	if enableSQLListener {
 		s.pgL = pgL
 	}
+	s.loopbackPgL = loopbackPgL
 
 	// Tell the RPC context how to connect in-memory.
 	s.rpcContext.SetLoopbackDialer(rpcLoopbackDialFn)
@@ -710,33 +715,33 @@ func (s *SQLServerWrapper) PreStart(ctx context.Context) error {
 	return nil
 }
 
+func (s *SQLServerWrapper) serveConn(
+	ctx context.Context, conn net.Conn, status pgwire.PreServeStatus,
+) error {
+	pgServer := s.PGServer()
+	switch status.State {
+	case pgwire.PreServeCancel:
+		if err := pgServer.HandleCancel(ctx, status.CancelKey); err != nil {
+			log.Sessions.Warningf(ctx, "unexpected while handling pgwire cancellation request: %v", err)
+		}
+		return nil
+	case pgwire.PreServeReady:
+		return pgServer.ServeConn(ctx, conn, status)
+	default:
+		return errors.AssertionFailedf("programming error: missing case %v", status.State)
+	}
+}
+
 // AcceptClients starts listening for incoming SQL clients over the network.
 // This mirrors the implementation of (*Server).AcceptClients.
 // TODO(knz): Find a way to implement this method only once for both.
 func (s *SQLServerWrapper) AcceptClients(ctx context.Context) error {
 	if !s.sqlServer.cfg.DisableSQLListener {
-		workersCtx := s.AnnotateCtx(context.Background())
-
-		pgServer := s.sqlServer.pgServer
-		serveConn := func(ctx context.Context, conn net.Conn, status pgwire.PreServeStatus) error {
-			switch status.State {
-			case pgwire.PreServeCancel:
-				if err := pgServer.HandleCancel(ctx, status.CancelKey); err != nil {
-					log.Sessions.Warningf(ctx, "unexpected while handling pgwire cancellation request: %v", err)
-				}
-				return nil
-			case pgwire.PreServeReady:
-				return pgServer.ServeConn(ctx, conn, status)
-			default:
-				return errors.AssertionFailedf("programming error: missing case %v", status.State)
-			}
-		}
-
 		if err := startServeSQL(
-			workersCtx,
+			s.AnnotateCtx(context.Background()),
 			s.stopper,
 			s.pgPreServer,
-			serveConn,
+			s.serveConn,
 			s.pgL,
 			&s.sqlServer.cfg.SocketFile,
 		); err != nil {
@@ -748,6 +753,32 @@ func (s *SQLServerWrapper) AcceptClients(ctx context.Context) error {
 
 	log.Event(ctx, "server ready")
 	return nil
+}
+
+// AcceptInternalClients starts listening for incoming SQL connections on the
+// internal loopback interface.
+func (s *SQLServerWrapper) AcceptInternalClients(ctx context.Context) error {
+	connManager := netutil.MakeTCPServer(ctx, s.stopper)
+
+	return s.stopper.RunAsyncTaskEx(ctx,
+		stop.TaskOpts{TaskName: "sql-internal-listener", SpanOpt: stop.SterileRootSpan},
+		func(ctx context.Context) {
+			err := connManager.ServeWith(ctx, s.loopbackPgL, func(ctx context.Context, conn net.Conn) {
+				connCtx := s.pgPreServer.AnnotateCtxForIncomingConn(ctx, conn)
+				connCtx = logtags.AddTag(connCtx, "internal-conn", nil)
+
+				conn, status, err := s.pgPreServer.PreServe(connCtx, conn, pgwire.SocketInternalLoopback)
+				if err != nil {
+					log.Ops.Errorf(connCtx, "serving SQL client conn: %v", err)
+					return
+				}
+
+				if err := s.serveConn(connCtx, conn, status); err != nil {
+					log.Ops.Errorf(connCtx, "serving internal SQL client conn: %s", err)
+				}
+			})
+			netutil.FatalIfUnexpected(err)
+		})
 }
 
 // Start calls PreStart() and AcceptClient() in sequence.

--- a/pkg/sql/pgwire/auth.go
+++ b/pkg/sql/pgwire/auth.go
@@ -305,7 +305,7 @@ func (c *conn) lookupAuthenticationMethodUsingRules(
 	connType hba.ConnType, auth *hba.Conf,
 ) (mi methodInfo, entry *hba.Entry, err error) {
 	var ip net.IP
-	if connType != hba.ConnLocal {
+	if connType != hba.ConnLocal && connType != hba.ConnInternalLoopback {
 		// Extract the IP address of the client.
 		tcpAddr, ok := c.sessionArgs.RemoteAddr.(*net.TCPAddr)
 		if !ok {

--- a/pkg/sql/pgwire/hba/hba.go
+++ b/pkg/sql/pgwire/hba/hba.go
@@ -74,9 +74,13 @@ const (
 	// ConnHostAny matches TCP connections with or without SSL/TLS.
 	ConnHostAny = ConnHostNoSSL | ConnHostSSL
 
+	// ConnInternalLoopback matches internal connections running over the loopback
+	// interface.
+	ConnInternalLoopback = 8
+
 	// ConnAny matches any connection type. Used when registering auth
 	// methods.
-	ConnAny = ConnHostAny | ConnLocal
+	ConnAny = ConnHostAny | ConnLocal | ConnInternalLoopback
 )
 
 // String implements the fmt.Stringer interface.
@@ -90,6 +94,8 @@ func (t ConnType) String() string {
 		return "hostssl"
 	case ConnHostAny:
 		return "host"
+	case ConnInternalLoopback:
+		return "loopback"
 	default:
 		panic(errors.Newf("unimplemented conn type: %v", int(t)))
 	}
@@ -188,6 +194,8 @@ func (h Entry) ConnTypeMatches(clientConn ConnType) bool {
 	case ConnHostNoSSL:
 		// A non-SSL connection matches both "hostnossl" and "host".
 		return h.ConnType&ConnHostNoSSL != 0
+	case ConnInternalLoopback:
+		return h.ConnType&ConnInternalLoopback != 0
 	default:
 		panic("unimplemented")
 	}

--- a/pkg/sql/pgwire/hba/parser.go
+++ b/pkg/sql/pgwire/hba/parser.go
@@ -231,6 +231,8 @@ func ParseConnType(s string) (ConnType, error) {
 		return ConnHostSSL, nil
 	case "hostnossl":
 		return ConnHostNoSSL, nil
+	case "loopback":
+		return ConnInternalLoopback, nil
 	}
 	return 0, errors.Newf("unknown connection type: %q", s)
 }

--- a/pkg/sql/pgwire/hba_conf.go
+++ b/pkg/sql/pgwire/hba_conf.go
@@ -217,6 +217,28 @@ func ParseAndNormalize(val string) (*hba.Conf, error) {
 		conf.Entries = entries
 	}
 
+	// If not rule for ConnInternalLoopback connections has been specified, add
+	// one similar to the default.
+	found := false
+	for _, e := range conf.Entries {
+		if e.ConnType == hba.ConnInternalLoopback {
+			found = true
+			break
+		}
+	}
+	if !found {
+		entries := make([]hba.Entry, 1, len(conf.Entries)+1)
+		entries[0] = hba.Entry{
+			ConnType: hba.ConnInternalLoopback,
+			User:     []hba.String{{Value: "all", Quoted: false}},
+			Address:  hba.AnyAddr{},
+			Method:   hba.String{Value: "trust"},
+			Input:    "loopback all all all trust       # built-in CockroachDB default",
+		}
+		entries = append(entries, conf.Entries...)
+		conf.Entries = entries
+	}
+
 	// Lookup and cache the auth methods.
 	for i := range conf.Entries {
 		method := conf.Entries[i].Method.Value
@@ -276,8 +298,9 @@ var rootLocalEntry = hba.Entry{
 var DefaultHBAConfig = func() *hba.Conf {
 	loadDefaultMethods()
 	conf, err := ParseAndNormalize(`
-host  all all  all cert-password # built-in CockroachDB default
-local all all      password      # built-in CockroachDB default
+loopback all all all trust       # built-in CockroachDB default
+host     all all all cert-password # built-in CockroachDB default
+local    all all     password      # built-in CockroachDB default
 `)
 	if err != nil {
 		panic(err)

--- a/pkg/sql/pgwire/server.go
+++ b/pkg/sql/pgwire/server.go
@@ -640,13 +640,17 @@ func (s *Server) drainImpl(
 
 // SocketType indicates the connection type. This is an optimization to
 // prevent a comparison against conn.LocalAddr().Network().
-type SocketType bool
+type SocketType int
 
 const (
+	SocketUnknown SocketType = iota
 	// SocketTCP is used for TCP sockets. The standard.
-	SocketTCP SocketType = true
+	SocketTCP
 	// SocketUnix is used for unix datagram sockets.
-	SocketUnix SocketType = false
+	SocketUnix
+	// SocketInternalLoopback is used for internal connections running over our
+	// loopback listener.
+	SocketInternalLoopback
 )
 
 func (s SocketType) asConnType() (hba.ConnType, error) {
@@ -655,6 +659,8 @@ func (s SocketType) asConnType() (hba.ConnType, error) {
 		return hba.ConnHostNoSSL, nil
 	case SocketUnix:
 		return hba.ConnLocal, nil
+	case SocketInternalLoopback:
+		return hba.ConnInternalLoopback, nil
 	default:
 		return 0, errors.AssertionFailedf("unimplemented socket type: %v", errors.Safe(s))
 	}

--- a/pkg/sql/pgwire/testdata/auth/conn_log
+++ b/pkg/sql/pgwire/testdata/auth/conn_log
@@ -30,6 +30,7 @@ local all all         password      # built-in CockroachDB default
 ----
 # Active authentication configuration on this node:
 # Original configuration:
+# loopback all all all trust       # built-in CockroachDB default
 # host  all root all cert-password # CockroachDB mandatory rule
 # host  all trusted all trust         # custom
 # host  all all     all cert-password # built-in CockroachDB default
@@ -37,12 +38,13 @@ local all all         password      # built-in CockroachDB default
 # local all all         password      # built-in CockroachDB default
 #
 # Interpreted configuration:
-# TYPE DATABASE USER    ADDRESS METHOD        OPTIONS
-host   all      root    all     cert-password
-host   all      trusted all     trust
-host   all      all     all     cert-password
-local  all      trusted         reject
-local  all      all             password
+# TYPE   DATABASE USER    ADDRESS METHOD        OPTIONS
+loopback all      all     all     trust
+host     all      root    all     cert-password
+host     all      trusted all     trust
+host     all      all     all     cert-password
+local    all      trusted         reject
+local    all      all             password
 
 subtest conn_tls
 

--- a/pkg/sql/pgwire/testdata/auth/empty_hba
+++ b/pkg/sql/pgwire/testdata/auth/empty_hba
@@ -22,14 +22,16 @@ set_hba
 # Active authentication configuration on this node:
 # Original configuration:
 # host  all root all cert-password # CockroachDB mandatory rule
-# host  all all  all cert-password # built-in CockroachDB default
-# local all all      password      # built-in CockroachDB default
+# loopback all all all trust       # built-in CockroachDB default
+# host     all all all cert-password # built-in CockroachDB default
+# local    all all     password      # built-in CockroachDB default
 #
 # Interpreted configuration:
-# TYPE DATABASE USER ADDRESS METHOD        OPTIONS
-host   all      root all     cert-password
-host   all      all  all     cert-password
-local  all      all          password
+# TYPE   DATABASE USER ADDRESS METHOD        OPTIONS
+host     all      root all     cert-password
+loopback all      all  all     trust
+host     all      all  all     cert-password
+local    all      all          password
 
 subtest root
 

--- a/pkg/sql/pgwire/testdata/auth/hba_alternative_root_rule
+++ b/pkg/sql/pgwire/testdata/auth/hba_alternative_root_rule
@@ -13,11 +13,13 @@ host  all root 127.0.0.1/32 cert-password
 ----
 # Active authentication configuration on this node:
 # Original configuration:
+# loopback all all all trust       # built-in CockroachDB default
 # host  all root 127.0.0.1/32 cert-password
 #
 # Interpreted configuration:
-# TYPE DATABASE USER ADDRESS      METHOD        OPTIONS
-host   all      root 127.0.0.1/32 cert-password
+# TYPE   DATABASE USER ADDRESS      METHOD        OPTIONS
+loopback all      all  all          trust
+host     all      root 127.0.0.1/32 cert-password
 
 subtest root_localhost
 
@@ -40,13 +42,15 @@ host all root 127.0.0.2/32 cert-password
 ----
 # Active authentication configuration on this node:
 # Original configuration:
+# loopback all all all trust       # built-in CockroachDB default
 # host  all root all cert-password # CockroachDB mandatory rule
 # host all root 127.0.0.2/32 cert-password
 #
 # Interpreted configuration:
-# TYPE DATABASE USER ADDRESS      METHOD        OPTIONS
-host   all      root all          cert-password
-host   all      root 127.0.0.2/32 cert-password
+# TYPE   DATABASE USER ADDRESS      METHOD        OPTIONS
+loopback all      all  all          trust
+host     all      root all          cert-password
+host     all      root 127.0.0.2/32 cert-password
 
 subtest root_default_rule
 

--- a/pkg/sql/pgwire/testdata/auth/hba_default_equivalence
+++ b/pkg/sql/pgwire/testdata/auth/hba_default_equivalence
@@ -16,15 +16,17 @@ local all all      password
 ----
 # Active authentication configuration on this node:
 # Original configuration:
+# loopback all all all trust       # built-in CockroachDB default
 # host  all root all cert-password
 # host  all all  all cert-password
 # local all all      password
 #
 # Interpreted configuration:
-# TYPE DATABASE USER ADDRESS METHOD        OPTIONS
-host   all      root all     cert-password
-host   all      all  all     cert-password
-local  all      all          password
+# TYPE   DATABASE USER ADDRESS METHOD        OPTIONS
+loopback all      all  all     trust
+host     all      root all     cert-password
+host     all      all  all     cert-password
+local    all      all          password
 
 subtest root
 

--- a/pkg/sql/pgwire/testdata/auth/hba_host_selection
+++ b/pkg/sql/pgwire/testdata/auth/hba_host_selection
@@ -12,13 +12,15 @@ host all all 0.0.0.0/32 cert
 ----
 # Active authentication configuration on this node:
 # Original configuration:
+# loopback all all all trust       # built-in CockroachDB default
 # host  all root all cert-password # CockroachDB mandatory rule
 # host all all 0.0.0.0/32 cert
 #
 # Interpreted configuration:
-# TYPE DATABASE USER ADDRESS    METHOD        OPTIONS
-host   all      root all        cert-password
-host   all      all  0.0.0.0/32 cert
+# TYPE   DATABASE USER ADDRESS    METHOD        OPTIONS
+loopback all      all  all        trust
+host     all      root all        cert-password
+host     all      all  0.0.0.0/32 cert
 
 connect user=testuser
 ----
@@ -47,13 +49,15 @@ host all all 127.0.0.0/8 cert
 ----
 # Active authentication configuration on this node:
 # Original configuration:
+# loopback all all all trust       # built-in CockroachDB default
 # host  all root all cert-password # CockroachDB mandatory rule
 # host all all 127.0.0.0/8 cert
 #
 # Interpreted configuration:
-# TYPE DATABASE USER ADDRESS     METHOD        OPTIONS
-host   all      root all         cert-password
-host   all      all  127.0.0.0/8 cert
+# TYPE   DATABASE USER ADDRESS     METHOD        OPTIONS
+loopback all      all  all         trust
+host     all      root all         cert-password
+host     all      all  127.0.0.0/8 cert
 
 connect user=testuser
 ----

--- a/pkg/sql/pgwire/testdata/auth/hba_user_selection
+++ b/pkg/sql/pgwire/testdata/auth/hba_user_selection
@@ -23,13 +23,15 @@ host all root 0.0.0.0/0 cert
 ----
 # Active authentication configuration on this node:
 # Original configuration:
+# loopback all all all trust       # built-in CockroachDB default
 # host  all root all cert-password # CockroachDB mandatory rule
 # host all root 0.0.0.0/0 cert
 #
 # Interpreted configuration:
-# TYPE DATABASE USER ADDRESS   METHOD        OPTIONS
-host   all      root all       cert-password
-host   all      root 0.0.0.0/0 cert
+# TYPE   DATABASE USER ADDRESS   METHOD        OPTIONS
+loopback all      all  all       trust
+host     all      root all       cert-password
+host     all      root 0.0.0.0/0 cert
 
 connect user=root
 ----
@@ -57,13 +59,15 @@ host all testuser 0.0.0.0/0 cert
 ----
 # Active authentication configuration on this node:
 # Original configuration:
+# loopback all all all trust       # built-in CockroachDB default
 # host  all root all cert-password # CockroachDB mandatory rule
 # host all testuser 0.0.0.0/0 cert
 #
 # Interpreted configuration:
-# TYPE DATABASE USER     ADDRESS   METHOD        OPTIONS
-host   all      root     all       cert-password
-host   all      testuser 0.0.0.0/0 cert
+# TYPE   DATABASE USER     ADDRESS   METHOD        OPTIONS
+loopback all      all      all       trust
+host     all      root     all       cert-password
+host     all      testuser 0.0.0.0/0 cert
 
 connect user=testuser
 ----
@@ -89,15 +93,17 @@ host all "a","b","testuser" 0.0.0.0/0 cert
 ----
 # Active authentication configuration on this node:
 # Original configuration:
+# loopback all all all trust       # built-in CockroachDB default
 # host  all root all cert-password # CockroachDB mandatory rule
 # host all "a","b","testuser" 0.0.0.0/0 cert
 #
 # Interpreted configuration:
-# TYPE DATABASE USER       ADDRESS   METHOD        OPTIONS
-host   all      root       all       cert-password
-host   all      "a"        0.0.0.0/0 cert
-host   all      "b"        0.0.0.0/0 cert
-host   all      "testuser" 0.0.0.0/0 cert
+# TYPE   DATABASE USER       ADDRESS   METHOD        OPTIONS
+loopback all      all        all       trust
+host     all      root       all       cert-password
+host     all      "a"        0.0.0.0/0 cert
+host     all      "b"        0.0.0.0/0 cert
+host     all      "testuser" 0.0.0.0/0 cert
 
 connect user=testuser
 ----
@@ -113,15 +119,17 @@ host all passworduser 0.0.0.0/0 cert-password
 ----
 # Active authentication configuration on this node:
 # Original configuration:
+# loopback all all all trust       # built-in CockroachDB default
 # host  all root all cert-password # CockroachDB mandatory rule
 # host all testuser 0.0.0.0/0 cert
 # host all passworduser 0.0.0.0/0 cert-password
 #
 # Interpreted configuration:
-# TYPE DATABASE USER         ADDRESS   METHOD        OPTIONS
-host   all      root         all       cert-password
-host   all      testuser     0.0.0.0/0 cert
-host   all      passworduser 0.0.0.0/0 cert-password
+# TYPE   DATABASE USER         ADDRESS   METHOD        OPTIONS
+loopback all      all          all       trust
+host     all      root         all       cert-password
+host     all      testuser     0.0.0.0/0 cert
+host     all      passworduser 0.0.0.0/0 cert-password
 
 connect user=testuser
 ----
@@ -147,14 +155,16 @@ host all testuser,passworduser 0.0.0.0/0 cert-password
 ----
 # Active authentication configuration on this node:
 # Original configuration:
+# loopback all all all trust       # built-in CockroachDB default
 # host  all root all cert-password # CockroachDB mandatory rule
 # host all testuser,passworduser 0.0.0.0/0 cert-password
 #
 # Interpreted configuration:
-# TYPE DATABASE USER         ADDRESS   METHOD        OPTIONS
-host   all      root         all       cert-password
-host   all      testuser     0.0.0.0/0 cert-password
-host   all      passworduser 0.0.0.0/0 cert-password
+# TYPE   DATABASE USER         ADDRESS   METHOD        OPTIONS
+loopback all      all          all       trust
+host     all      root         all       cert-password
+host     all      testuser     0.0.0.0/0 cert-password
+host     all      passworduser 0.0.0.0/0 cert-password
 
 connect user=testuser
 ----
@@ -188,15 +198,17 @@ host all passworduser 0.0.0.0/0 password
 ----
 # Active authentication configuration on this node:
 # Original configuration:
+# loopback all all all trust       # built-in CockroachDB default
 # host  all root all cert-password # CockroachDB mandatory rule
 # host all testuser,all 0.0.0.0/0 cert
 # host all passworduser 0.0.0.0/0 password
 #
 # Interpreted configuration:
-# TYPE DATABASE USER         ADDRESS   METHOD        OPTIONS
-host   all      root         all       cert-password
-host   all      all          0.0.0.0/0 cert
-host   all      passworduser 0.0.0.0/0 password
+# TYPE   DATABASE USER         ADDRESS   METHOD        OPTIONS
+loopback all      all          all       trust
+host     all      root         all       cert-password
+host     all      all          0.0.0.0/0 cert
+host     all      passworduser 0.0.0.0/0 password
 
 connect user=testuser
 ----
@@ -216,16 +228,18 @@ host all passworduser 0.0.0.0/0 password
 ----
 # Active authentication configuration on this node:
 # Original configuration:
+# loopback all all all trust       # built-in CockroachDB default
 # host  all root all cert-password # CockroachDB mandatory rule
 # host all testuser,"all" 0.0.0.0/0 cert
 # host all passworduser 0.0.0.0/0 password
 #
 # Interpreted configuration:
-# TYPE DATABASE USER         ADDRESS   METHOD        OPTIONS
-host   all      root         all       cert-password
-host   all      testuser     0.0.0.0/0 cert
-host   all      "all"        0.0.0.0/0 cert
-host   all      passworduser 0.0.0.0/0 password
+# TYPE   DATABASE USER         ADDRESS   METHOD        OPTIONS
+loopback all      all          all       trust
+host     all      root         all       cert-password
+host     all      testuser     0.0.0.0/0 cert
+host     all      "all"        0.0.0.0/0 cert
+host     all      passworduser 0.0.0.0/0 password
 
 connect user=testuser
 ----

--- a/pkg/sql/pgwire/testdata/auth/identity_map
+++ b/pkg/sql/pgwire/testdata/auth/identity_map
@@ -10,13 +10,15 @@ host  all all  all cert-password map=testing
 ----
 # Active authentication configuration on this node:
 # Original configuration:
+# loopback all all all trust       # built-in CockroachDB default
 # host  all root all cert-password # CockroachDB mandatory rule
 # host  all all  all cert-password map=testing
 #
 # Interpreted configuration:
-# TYPE DATABASE USER ADDRESS METHOD        OPTIONS
-host   all      root all     cert-password
-host   all      all  all     cert-password map=testing
+# TYPE   DATABASE USER ADDRESS METHOD        OPTIONS
+loopback all      all  all     trust
+host     all      root all     cert-password
+host     all      all  all     cert-password map=testing
 
 set_identity_map
 testing testuser carl               # Exact remapping
@@ -28,13 +30,15 @@ testing testuser@example.com carl   # Cert with a non-SQL principal baked in
 ----
 # Active authentication configuration on this node:
 # Original configuration:
+# loopback all all all trust       # built-in CockroachDB default
 # host  all root all cert-password # CockroachDB mandatory rule
 # host  all all  all cert-password map=testing
 #
 # Interpreted configuration:
-# TYPE DATABASE USER ADDRESS METHOD        OPTIONS
-host   all      root all     cert-password
-host   all      all  all     cert-password map=testing
+# TYPE   DATABASE USER ADDRESS METHOD        OPTIONS
+loopback all      all  all     trust
+host     all      root all     cert-password
+host     all      all  all     cert-password map=testing
 # Active identity mapping on this node:
 # Original configuration:
 # testing testuser carl               # Exact remapping
@@ -190,13 +194,15 @@ testing testuser root               # Exact remapping
 ----
 # Active authentication configuration on this node:
 # Original configuration:
+# loopback all all all trust       # built-in CockroachDB default
 # host  all root all cert-password # CockroachDB mandatory rule
 # host  all all  all cert-password map=testing
 #
 # Interpreted configuration:
-# TYPE DATABASE USER ADDRESS METHOD        OPTIONS
-host   all      root all     cert-password
-host   all      all  all     cert-password map=testing
+# TYPE   DATABASE USER ADDRESS METHOD        OPTIONS
+loopback all      all  all     trust
+host     all      root all     cert-password
+host     all      all  all     cert-password map=testing
 # Active identity mapping on this node:
 # Original configuration:
 # testing testuser root               # Exact remapping
@@ -217,13 +223,15 @@ testing testuser node               # Exact remapping
 ----
 # Active authentication configuration on this node:
 # Original configuration:
+# loopback all all all trust       # built-in CockroachDB default
 # host  all root all cert-password # CockroachDB mandatory rule
 # host  all all  all cert-password map=testing
 #
 # Interpreted configuration:
-# TYPE DATABASE USER ADDRESS METHOD        OPTIONS
-host   all      root all     cert-password
-host   all      all  all     cert-password map=testing
+# TYPE   DATABASE USER ADDRESS METHOD        OPTIONS
+loopback all      all  all     trust
+host     all      root all     cert-password
+host     all      all  all     cert-password map=testing
 # Active identity mapping on this node:
 # Original configuration:
 # testing testuser node               # Exact remapping
@@ -244,24 +252,28 @@ set_identity_map
 ----
 # Active authentication configuration on this node:
 # Original configuration:
+# loopback all all all trust       # built-in CockroachDB default
 # host  all root all cert-password # CockroachDB mandatory rule
 # host  all all  all cert-password map=testing
 #
 # Interpreted configuration:
-# TYPE DATABASE USER ADDRESS METHOD        OPTIONS
-host   all      root all     cert-password
-host   all      all  all     cert-password map=testing
+# TYPE   DATABASE USER ADDRESS METHOD        OPTIONS
+loopback all      all  all     trust
+host     all      root all     cert-password
+host     all      all  all     cert-password map=testing
 
 set_hba
 ----
 # Active authentication configuration on this node:
 # Original configuration:
 # host  all root all cert-password # CockroachDB mandatory rule
-# host  all all  all cert-password # built-in CockroachDB default
-# local all all      password      # built-in CockroachDB default
+# loopback all all all trust       # built-in CockroachDB default
+# host     all all all cert-password # built-in CockroachDB default
+# local    all all     password      # built-in CockroachDB default
 #
 # Interpreted configuration:
-# TYPE DATABASE USER ADDRESS METHOD        OPTIONS
-host   all      root all     cert-password
-host   all      all  all     cert-password
-local  all      all          password
+# TYPE   DATABASE USER ADDRESS METHOD        OPTIONS
+host     all      root all     cert-password
+loopback all      all  all     trust
+host     all      all  all     cert-password
+local    all      all          password

--- a/pkg/sql/pgwire/testdata/auth/insecure
+++ b/pkg/sql/pgwire/testdata/auth/insecure
@@ -20,13 +20,15 @@ host all root 0.0.0.0/0 cert
 ----
 # Active authentication configuration on this node:
 # Original configuration:
+# loopback all all all trust       # built-in CockroachDB default
 # host  all root all cert-password # CockroachDB mandatory rule
 # host all root 0.0.0.0/0 cert
 #
 # Interpreted configuration:
-# TYPE DATABASE USER ADDRESS   METHOD        OPTIONS
-host   all      root all       cert-password
-host   all      root 0.0.0.0/0 cert
+# TYPE   DATABASE USER ADDRESS   METHOD        OPTIONS
+loopback all      all  all       trust
+host     all      root all       cert-password
+host     all      root 0.0.0.0/0 cert
 
 connect user=root sslmode=disable
 ----

--- a/pkg/sql/pgwire/testdata/auth/scram
+++ b/pkg/sql/pgwire/testdata/auth/scram
@@ -46,15 +46,17 @@ host all abc2 all password
 ----
 # Active authentication configuration on this node:
 # Original configuration:
+# loopback all all all trust       # built-in CockroachDB default
 # host  all root all cert-password # CockroachDB mandatory rule
 # host all abc all password
 # host all abc2 all password
 #
 # Interpreted configuration:
-# TYPE DATABASE USER ADDRESS METHOD        OPTIONS
-host   all      root all     cert-password
-host   all      abc  all     password
-host   all      abc2 all     password
+# TYPE   DATABASE USER ADDRESS METHOD        OPTIONS
+loopback all      all  all     trust
+host     all      root all     cert-password
+host     all      abc  all     password
+host     all      abc2 all     password
 
 # User abc has SCRAM credentials, but 'mistake' is not its password.
 # Expect authn error.
@@ -108,17 +110,19 @@ host all abc2 all scram-sha-256
 ----
 # Active authentication configuration on this node:
 # Original configuration:
+# loopback all all all trust       # built-in CockroachDB default
 # host  all root all cert-password # CockroachDB mandatory rule
 # host all foo all scram-sha-256
 # host all abc all scram-sha-256
 # host all abc2 all scram-sha-256
 #
 # Interpreted configuration:
-# TYPE DATABASE USER ADDRESS METHOD        OPTIONS
-host   all      root all     cert-password
-host   all      foo  all     scram-sha-256
-host   all      abc  all     scram-sha-256
-host   all      abc2 all     scram-sha-256
+# TYPE   DATABASE USER ADDRESS METHOD        OPTIONS
+loopback all      all  all     trust
+host     all      root all     cert-password
+host     all      foo  all     scram-sha-256
+host     all      abc  all     scram-sha-256
+host     all      abc2 all     scram-sha-256
 
 subtest only_scram/conn_scram
 
@@ -193,13 +197,15 @@ host all all all cert-scram-sha-256
 ----
 # Active authentication configuration on this node:
 # Original configuration:
+# loopback all all all trust       # built-in CockroachDB default
 # host  all root all cert-password # CockroachDB mandatory rule
 # host all all all cert-scram-sha-256
 #
 # Interpreted configuration:
-# TYPE DATABASE USER ADDRESS METHOD             OPTIONS
-host   all      root all     cert-password
-host   all      all  all     cert-scram-sha-256
+# TYPE   DATABASE USER ADDRESS METHOD             OPTIONS
+loopback all      all  all     trust
+host     all      root all     cert-password
+host     all      all  all     cert-scram-sha-256
 
 subtest scram_cert/cert
 
@@ -238,15 +244,17 @@ host all abc all cert-password
 ----
 # Active authentication configuration on this node:
 # Original configuration:
+# loopback all all all trust       # built-in CockroachDB default
 # host  all root all cert-password # CockroachDB mandatory rule
 # host all foo all cert-password
 # host all abc all cert-password
 #
 # Interpreted configuration:
-# TYPE DATABASE USER ADDRESS METHOD        OPTIONS
-host   all      root all     cert-password
-host   all      foo  all     cert-password
-host   all      abc  all     cert-password
+# TYPE   DATABASE USER ADDRESS METHOD        OPTIONS
+loopback all      all  all     trust
+host     all      root all     cert-password
+host     all      foo  all     cert-password
+host     all      abc  all     cert-password
 
 # Foo uses a bcrypt hash.
 connect user=foo password=abc

--- a/pkg/sql/pgwire/testdata/auth/secure_non_tls
+++ b/pkg/sql/pgwire/testdata/auth/secure_non_tls
@@ -52,6 +52,7 @@ local     all all      password
 ----
 # Active authentication configuration on this node:
 # Original configuration:
+# loopback all all all trust       # built-in CockroachDB default
 # host  all root all cert-password # CockroachDB mandatory rule
 # hostnossl all all  all reject
 # host      all all  all cert-password
@@ -59,6 +60,7 @@ local     all all      password
 #
 # Interpreted configuration:
 # TYPE    DATABASE USER ADDRESS METHOD        OPTIONS
+loopback  all      all  all     trust
 host      all      root all     cert-password
 hostnossl all      all  all     reject
 host      all      all  all     cert-password

--- a/pkg/sql/pgwire/testdata/auth/special_cases
+++ b/pkg/sql/pgwire/testdata/auth/special_cases
@@ -19,13 +19,15 @@ host all root 0.0.0.0/0 password
 ----
 # Active authentication configuration on this node:
 # Original configuration:
+# loopback all all all trust       # built-in CockroachDB default
 # host  all root all cert-password # CockroachDB mandatory rule
 # host all root 0.0.0.0/0 password
 #
 # Interpreted configuration:
-# TYPE DATABASE USER ADDRESS   METHOD        OPTIONS
-host   all      root all       cert-password
-host   all      root 0.0.0.0/0 password
+# TYPE   DATABASE USER ADDRESS   METHOD        OPTIONS
+loopback all      all  all       trust
+host     all      root all       cert-password
+host     all      root 0.0.0.0/0 password
 
 connect user=root password=abc sslmode=verify-ca sslcert=
 ----
@@ -51,13 +53,15 @@ host all testuser 0.0.0.0/0 cert
 ----
 # Active authentication configuration on this node:
 # Original configuration:
+# loopback all all all trust       # built-in CockroachDB default
 # host  all root all cert-password # CockroachDB mandatory rule
 # host all testuser 0.0.0.0/0 cert
 #
 # Interpreted configuration:
-# TYPE DATABASE USER     ADDRESS   METHOD        OPTIONS
-host   all      root     all       cert-password
-host   all      testuser 0.0.0.0/0 cert
+# TYPE   DATABASE USER     ADDRESS   METHOD        OPTIONS
+loopback all      all      all       trust
+host     all      root     all       cert-password
+host     all      testuser 0.0.0.0/0 cert
 
 connect user=testuser password=pass sslmode=verify-ca sslcert=
 ----
@@ -72,13 +76,15 @@ host all testuser 0.0.0.0/0 password
 ----
 # Active authentication configuration on this node:
 # Original configuration:
+# loopback all all all trust       # built-in CockroachDB default
 # host  all root all cert-password # CockroachDB mandatory rule
 # host all testuser 0.0.0.0/0 password
 #
 # Interpreted configuration:
-# TYPE DATABASE USER     ADDRESS   METHOD        OPTIONS
-host   all      root     all       cert-password
-host   all      testuser 0.0.0.0/0 password
+# TYPE   DATABASE USER     ADDRESS   METHOD        OPTIONS
+loopback all      all      all       trust
+host     all      root     all       cert-password
+host     all      testuser 0.0.0.0/0 password
 
 connect user=testuser
 ----
@@ -111,13 +117,15 @@ host all nopassword 0.0.0.0/0 password
 ----
 # Active authentication configuration on this node:
 # Original configuration:
+# loopback all all all trust       # built-in CockroachDB default
 # host  all root all cert-password # CockroachDB mandatory rule
 # host all nopassword 0.0.0.0/0 password
 #
 # Interpreted configuration:
-# TYPE DATABASE USER       ADDRESS   METHOD        OPTIONS
-host   all      root       all       cert-password
-host   all      nopassword 0.0.0.0/0 password
+# TYPE   DATABASE USER       ADDRESS   METHOD        OPTIONS
+loopback all      all        all       trust
+host     all      root       all       cert-password
+host     all      nopassword 0.0.0.0/0 password
 
 connect user=nopassword
 ----

--- a/pkg/sql/pgwire/testdata/auth/trust_reject
+++ b/pkg/sql/pgwire/testdata/auth/trust_reject
@@ -16,15 +16,17 @@ host all all all cert-password
 ----
 # Active authentication configuration on this node:
 # Original configuration:
+# loopback all all all trust       # built-in CockroachDB default
 # host  all root all cert-password # CockroachDB mandatory rule
 # host all testuser all reject
 # host all all all cert-password
 #
 # Interpreted configuration:
-# TYPE DATABASE USER     ADDRESS METHOD        OPTIONS
-host   all      root     all     cert-password
-host   all      testuser all     reject
-host   all      all      all     cert-password
+# TYPE   DATABASE USER     ADDRESS METHOD        OPTIONS
+loopback all      all      all     trust
+host     all      root     all     cert-password
+host     all      testuser all     reject
+host     all      all      all     cert-password
 
 connect user=testuser
 ----
@@ -49,15 +51,17 @@ host all all all cert
 ----
 # Active authentication configuration on this node:
 # Original configuration:
+# loopback all all all trust       # built-in CockroachDB default
 # host  all root all cert-password # CockroachDB mandatory rule
 # host all nocert all trust
 # host all all all cert
 #
 # Interpreted configuration:
-# TYPE DATABASE USER   ADDRESS METHOD        OPTIONS
-host   all      root   all     cert-password
-host   all      nocert all     trust
-host   all      all    all     cert
+# TYPE   DATABASE USER   ADDRESS METHOD        OPTIONS
+loopback all      all    all     trust
+host     all      root   all     cert-password
+host     all      nocert all     trust
+host     all      all    all     cert
 
 
 connect user=nocert sslcert= sslmode=require


### PR DESCRIPTION
This patch adds a way for a CRDB node to open pgwire connections to itself. This is implemented through the use of net.Conn's implemented by in-memory pipes.

I want to use this in particular in order to embed the Obs Service into CRBD. The Obs Service is a library that wants to be given a handle to the backend database in the form of a pgx connection pool. Now such a connection pool can be created based on this new "network" interface, without any network actually being involved.  Beyond that, I think this is a generally useful feature that we should have had for a long time - frequently it's useful internally to have a SQL session against the cluster; so far we've been doing that with the InternalExecutor, except that guy doesn't actually support sessions (it mostly supports single statements).

Release note: None
Epic: None