### PR TITLE
logictest: fix "box2d comparison operator is experimental" flakes

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/geospatial_bbox
+++ b/pkg/sql/logictest/testdata/logic_test/geospatial_bbox
@@ -81,6 +81,10 @@ SELECT 'box(0 0,1 1)'::box2d && 'box(1 1,2 2)'::box2d
 statement ok
 SET CLUSTER SETTING sql.spatial.experimental_box2d_comparison_operators.enabled = on
 
+# Ensure the cluster setting has time to propagate to all nodes so distributed
+# execution does not see the old setting on non-gateway nodes.
+sleep 10ms
+
 query TTBBBB
 SELECT
   a.dsc,

--- a/pkg/sql/logictest/testdata/logic_test/inverted_filter_geospatial
+++ b/pkg/sql/logictest/testdata/logic_test/inverted_filter_geospatial
@@ -49,6 +49,10 @@ SELECT k FROM geo_table WHERE ST_DWithin('POINT(2.5 2.5)'::geometry, geom, 1) OR
 statement ok
 SET CLUSTER SETTING sql.spatial.experimental_box2d_comparison_operators.enabled = on
 
+# Ensure the cluster setting has time to propagate to all nodes so distributed
+# execution does not see the old setting on non-gateway nodes.
+sleep 10ms
+
 query I retry
 SELECT k FROM geo_table WHERE 'POINT(3.0 3.0)'::geometry && geom ORDER BY k
 ----

--- a/pkg/sql/logictest/testdata/logic_test/inverted_join_geospatial_bbox
+++ b/pkg/sql/logictest/testdata/logic_test/inverted_join_geospatial_bbox
@@ -37,6 +37,10 @@ INSERT INTO rtable VALUES
 statement ok
 SET CLUSTER SETTING sql.spatial.experimental_box2d_comparison_operators.enabled = on
 
+# Ensure the cluster setting has time to propagate to all nodes so distributed
+# execution does not see the old setting on non-gateway nodes.
+sleep 10ms
+
 query II
 SELECT lk, rk FROM ltable JOIN rtable@geom_index ON ltable.geom1 ~ rtable.geom
 ORDER BY lk, rk


### PR DESCRIPTION
Fixes #95700

Logic tests with a fakedist configuration, which set the
`sql.spatial.experimental_box2d_comparison_operators.enabled` cluster
setting may flake with the error:
```
   expected success, but found
   (0A000) this box2d comparison operator is experimental
   settings.go:33: in checkExperimentalBox2DComparisonOperatorEnabled()
```
This is likely due to a fully distributed physical plan being selected
for the problem query, and the cluster setting not propagating to
non-gateway nodes before query execution starts on those nodes.

The solution is to add a 10ms sleep to give the setting time to
propagate.

Release note: None