### PR TITLE
base: require non-nil settings in TempStorageConfig

### DIFF
--- a/pkg/base/config.go
+++ b/pkg/base/config.go
@@ -763,7 +763,8 @@ type TempStorageConfig struct {
 	Mon *mon.BytesMonitor
 	// Spec stores the StoreSpec this TempStorageConfig will use.
 	Spec StoreSpec
-	// Settings stores the cluster.Settings this TempStoreConfig will use.
+	// Settings stores the cluster.Settings this TempStoreConfig will use. Must
+	// not be nil.
 	Settings *cluster.Settings
 }
 

--- a/pkg/sql/colflow/draining_test.go
+++ b/pkg/sql/colflow/draining_test.go
@@ -34,6 +34,7 @@ func TestDrainingAfterRemoteError(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	ctx := context.Background()
+	st := cluster.MakeTestingClusterSettings()
 
 	// Create a disk monitor for the temp storage only with 1 byte of space.
 	// This ensures that the query will run into "out of temporary storage"
@@ -45,12 +46,12 @@ func TestDrainingAfterRemoteError(t *testing.T) {
 		nil, /* maxHist */
 		-1,  /* increment: use default block size */
 		math.MaxInt64,
-		cluster.MakeTestingClusterSettings(),
+		st,
 	)
 	diskMonitor.Start(ctx, nil /* pool */, mon.NewStandaloneBudget(1))
 
 	// Set up a two node cluster.
-	tempStorageConfig := base.TempStorageConfig{InMemory: true, Mon: diskMonitor}
+	tempStorageConfig := base.TempStorageConfig{InMemory: true, Mon: diskMonitor, Settings: st}
 	args := base.TestClusterArgs{
 		ServerArgs:      base.TestServerArgs{TempStorageConfig: tempStorageConfig},
 		ReplicationMode: base.ReplicationManual,

--- a/pkg/sql/rowcontainer/numbered_row_container_test.go
+++ b/pkg/sql/rowcontainer/numbered_row_container_test.go
@@ -565,7 +565,7 @@ func BenchmarkNumberedContainerIteratorCaching(b *testing.B) {
 	ctx := context.Background()
 	st := cluster.MakeTestingClusterSettings()
 	evalCtx := eval.MakeTestingEvalContext(st)
-	tempEngine, _, err := storage.NewTempEngine(ctx, base.TempStorageConfig{InMemory: true}, base.DefaultTestStoreSpec)
+	tempEngine, _, err := storage.NewTempEngine(ctx, base.TempStorageConfig{InMemory: true, Settings: st}, base.DefaultTestStoreSpec)
 	if err != nil {
 		b.Fatal(err)
 	}

--- a/pkg/sql/rowexec/joinreader_test.go
+++ b/pkg/sql/rowexec/joinreader_test.go
@@ -1702,7 +1702,11 @@ func benchmarkJoinReader(b *testing.B, bc JRBenchConfig) {
 	defer cleanupTempDir()
 	tempStoreSpec, err := base.NewStoreSpec(fmt.Sprintf("path=%s", tempStoragePath))
 	require.NoError(b, err)
-	tempEngine, _, err := storage.NewTempEngine(ctx, base.TempStorageConfig{Path: tempStoragePath, Mon: diskMonitor}, tempStoreSpec)
+	tempEngine, _, err := storage.NewTempEngine(ctx, base.TempStorageConfig{
+		Path:     tempStoragePath,
+		Mon:      diskMonitor,
+		Settings: st,
+	}, tempStoreSpec)
 	require.NoError(b, err)
 	defer tempEngine.Close()
 	flowCtx.Cfg.TempStorage = tempEngine
@@ -1967,7 +1971,11 @@ func BenchmarkJoinReaderLookupStress(b *testing.B) {
 	defer cleanupTempDir()
 	tempStoreSpec, err := base.NewStoreSpec(fmt.Sprintf("path=%s", tempStoragePath))
 	require.NoError(b, err)
-	tempEngine, _, err := storage.NewTempEngine(ctx, base.TempStorageConfig{Path: tempStoragePath, Mon: diskMonitor}, tempStoreSpec)
+	tempEngine, _, err := storage.NewTempEngine(ctx, base.TempStorageConfig{
+		Path:     tempStoragePath,
+		Mon:      diskMonitor,
+		Settings: st,
+	}, tempStoreSpec)
 	require.NoError(b, err)
 	defer tempEngine.Close()
 	flowCtx.Cfg.TempStorage = tempEngine


### PR DESCRIPTION
We recently merged a change to require non-nil settings in `StorageConfig`. Sometimes that struct is populated based on the `TempStorageConfig` which we forgot to update accordingly in some test spots. This is now fixed (I only looked through the test spots though).

Epic: None

Release note: None