### PR TITLE
bench: add separate-process tenant benchmarks

### DIFF
--- a/pkg/bench/BUILD.bazel
+++ b/pkg/bench/BUILD.bazel
@@ -13,6 +13,7 @@ go_library(
     deps = [
         "//pkg/base",
         "//pkg/ccl",
+        "//pkg/roachpb",
         "//pkg/server",
         "//pkg/testutils/serverutils",
         "//pkg/testutils/skip",

--- a/pkg/bench/foreachdb.go
+++ b/pkg/bench/foreachdb.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	_ "github.com/cockroachdb/cockroach/pkg/ccl"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/server"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
@@ -51,9 +52,10 @@ func benchmarkCockroach(b *testing.B, f BenchmarkFn) {
 	f(b, sqlutils.MakeSQLRunner(db))
 }
 
-// benchmarkTenantCockroach runs the benchmark against an in-memory tenant in a
-// single-node cluster.
-func benchmarkTenantCockroach(b *testing.B, f BenchmarkFn) {
+// benchmarkInProcessTenantCockroach runs the benchmark against an in-memory
+// tenant in a single-node cluster. The tenant runs in the same process as the
+// KV host.
+func benchmarkInProcessTenantCockroach(b *testing.B, f BenchmarkFn) {
 	ctx := context.Background()
 	s, db, _ := serverutils.StartServer(
 		b, base.TestServerArgs{
@@ -74,6 +76,36 @@ func benchmarkTenantCockroach(b *testing.B, f BenchmarkFn) {
 	// NOTE(andrei): Benchmarks drop the tables they're creating, so I'm not sure
 	// if hitting this limit is expected.
 	_, err = db.Exec(`ALTER TENANT ALL SET CLUSTER SETTING "spanconfig.tenant_limit" = 10000000`)
+	require.NoError(b, err)
+
+	_, err = tenantDB.Exec(`CREATE DATABASE bench`)
+	require.NoError(b, err)
+
+	f(b, sqlutils.MakeSQLRunner(tenantDB))
+}
+
+// benchmarkSepProcessTenantCockroach runs the benchmark against a tenant with a
+// single SQL pod and a single-node KV host cluster. The tenant runs in a
+// separate process from the KV host.
+func benchmarkSepProcessTenantCockroach(b *testing.B, f BenchmarkFn) {
+	ctx := context.Background()
+	s, db, _ := serverutils.StartServer(
+		b, base.TestServerArgs{
+			DisableDefaultTestTenant: true,
+		})
+	defer s.Stopper().Stop(ctx)
+
+	// Create our own test tenant with a known name.
+	_, tenantDB := serverutils.StartTenant(b, s, base.TestTenantArgs{
+		TenantName:  "benchtenant",
+		TenantID:    roachpb.MustMakeTenantID(10),
+		UseDatabase: "bench",
+	})
+
+	// The benchmarks sometime hit the default span limit, so we increase it.
+	// NOTE(andrei): Benchmarks drop the tables they're creating, so I'm not sure
+	// if hitting this limit is expected.
+	_, err := db.Exec(`ALTER TENANT ALL SET CLUSTER SETTING "spanconfig.tenant_limit" = 10000000`)
 	require.NoError(b, err)
 
 	_, err = tenantDB.Exec(`CREATE DATABASE bench`)
@@ -171,7 +203,8 @@ func benchmarkMySQL(b *testing.B, f BenchmarkFn) {
 func ForEachDB(b *testing.B, fn BenchmarkFn) {
 	for _, dbFn := range []func(*testing.B, BenchmarkFn){
 		benchmarkCockroach,
-		benchmarkTenantCockroach,
+		benchmarkInProcessTenantCockroach,
+		benchmarkSepProcessTenantCockroach,
 		benchmarkMultinodeCockroach,
 		benchmarkPostgres,
 		benchmarkMySQL,


### PR DESCRIPTION
Some time ago we merged a change to run all benchmarks in `pkg/bench` against an in-memory tenant. Recently we introduced a local fastpath for in-process in-memory tenants which will resemble how things will look once we get to UA for single-tenant clusters. However, it is also interesting to measure how we perform with separate-process tenants (which is how we run serverless), so this commit introduces that additional config.

Epic: CRDB-14837

Release note: None