### PR TITLE
streamingest,catalog: rename metrics from `streaming` to `replication`

### DIFF
--- a/pkg/ccl/streamingccl/streamingest/metrics.go
+++ b/pkg/ccl/streamingccl/streamingest/metrics.go
@@ -16,96 +16,96 @@ import (
 )
 
 var (
-	metaStreamingEventsIngested = metric.Metadata{
-		Name:        "streaming.events_ingested",
+	metaReplicationEventsIngested = metric.Metadata{
+		Name:        "replication.events_ingested",
 		Help:        "Events ingested by all ingestion jobs",
 		Measurement: "Events",
 		Unit:        metric.Unit_COUNT,
 	}
-	metaStreamingResolvedEventsIngested = metric.Metadata{
-		Name:        "streaming.resolved_events_ingested",
+	metaReplicationResolvedEventsIngested = metric.Metadata{
+		Name:        "replication.resolved_events_ingested",
 		Help:        "Resolved events ingested by all ingestion jobs",
 		Measurement: "Events",
 		Unit:        metric.Unit_COUNT,
 	}
-	metaStreamingIngestedBytes = metric.Metadata{
-		Name:        "streaming.ingested_bytes",
+	metaReplicationIngestedBytes = metric.Metadata{
+		Name:        "replication.ingested_bytes",
 		Help:        "Bytes ingested by all ingestion jobs",
 		Measurement: "Bytes",
 		Unit:        metric.Unit_BYTES,
 	}
-	metaStreamingSSTBytes = metric.Metadata{
-		Name:        "streaming.sst_bytes",
+	metaReplicationSSTBytes = metric.Metadata{
+		Name:        "replication.sst_bytes",
 		Help:        "SST bytes (compressed) sent to KV by all ingestion jobs",
 		Measurement: "Bytes",
 		Unit:        metric.Unit_BYTES,
 	}
-	metaStreamingFlushes = metric.Metadata{
-		Name:        "streaming.flushes",
+	metaReplicationFlushes = metric.Metadata{
+		Name:        "replication.flushes",
 		Help:        "Total flushes across all ingestion jobs",
 		Measurement: "Flushes",
 		Unit:        metric.Unit_COUNT,
 	}
 
-	metaStreamingFlushHistNanos = metric.Metadata{
-		Name:        "streaming.flush_hist_nanos",
+	metaReplicationFlushHistNanos = metric.Metadata{
+		Name:        "replication.flush_hist_nanos",
 		Help:        "Time spent flushing messages across all replication streams",
 		Measurement: "Nanoseconds",
 		Unit:        metric.Unit_NANOSECONDS,
 	}
-	metaStreamingCommitLatency = metric.Metadata{
-		Name: "streaming.commit_latency",
+	metaReplicationCommitLatency = metric.Metadata{
+		Name: "replication.commit_latency",
 		Help: "Event commit latency: a difference between event MVCC timestamp " +
 			"and the time it was flushed into disk. If we batch events, then the difference " +
 			"between the oldest event in the batch and flush is recorded",
 		Measurement: "Nanoseconds",
 		Unit:        metric.Unit_NANOSECONDS,
 	}
-	metaStreamingAdmitLatency = metric.Metadata{
-		Name: "streaming.admit_latency",
+	metaReplicationAdmitLatency = metric.Metadata{
+		Name: "replication.admit_latency",
 		Help: "Event admission latency: a difference between event MVCC timestamp " +
 			"and the time it was admitted into ingestion processor",
 		Measurement: "Nanoseconds",
 		Unit:        metric.Unit_NANOSECONDS,
 	}
 	metaStreamsRunning = metric.Metadata{
-		Name:        "streaming.running",
+		Name:        "replication.running",
 		Help:        "Number of currently running replication streams",
 		Measurement: "Replication Streams",
 		Unit:        metric.Unit_COUNT,
 	}
 	metaEarliestDataCheckpointSpan = metric.Metadata{
-		Name:        "streaming.earliest_data_checkpoint_span",
+		Name:        "replication.earliest_data_checkpoint_span",
 		Help:        "The earliest timestamp of the last checkpoint forwarded by an ingestion data processor",
 		Measurement: "Timestamp",
 		Unit:        metric.Unit_TIMESTAMP_NS,
 	}
 	metaLatestDataCheckpointSpan = metric.Metadata{
-		Name:        "streaming.latest_data_checkpoint_span",
+		Name:        "replication.latest_data_checkpoint_span",
 		Help:        "The latest timestamp of the last checkpoint forwarded by an ingestion data processor",
 		Measurement: "Timestamp",
 		Unit:        metric.Unit_TIMESTAMP_NS,
 	}
 	metaDataCheckpointSpanCount = metric.Metadata{
-		Name:        "streaming.data_checkpoint_span_count",
+		Name:        "replication.data_checkpoint_span_count",
 		Help:        "The number of resolved spans in the last checkpoint forwarded by an ingestion data processor",
 		Measurement: "Resolved Spans",
 		Unit:        metric.Unit_COUNT,
 	}
 	metaFrontierCheckpointSpanCount = metric.Metadata{
-		Name:        "streaming.frontier_checkpoint_span_count",
+		Name:        "replication.frontier_checkpoint_span_count",
 		Help:        "The number of resolved spans last persisted to the ingestion job's checkpoint record",
 		Measurement: "Resolved Spans",
 		Unit:        metric.Unit_COUNT,
 	}
 	metaFrontierLagSeconds = metric.Metadata{
-		Name:        "streaming.frontier_lag_seconds",
+		Name:        "replication.frontier_lag_seconds",
 		Help:        "Time the replication frontier lags",
 		Measurement: "Seconds",
 		Unit:        metric.Unit_SECONDS,
 	}
 	metaJobProgressUpdates = metric.Metadata{
-		Name:        "streaming.job_progress_updates",
+		Name:        "replication.job_progress_updates",
 		Help:        "Total number of updates to the ingestion job progress",
 		Measurement: "Job Updates",
 		Unit:        metric.Unit_COUNT,
@@ -137,17 +137,17 @@ func (*Metrics) MetricStruct() {}
 // MakeMetrics makes the metrics for stream ingestion job monitoring.
 func MakeMetrics(histogramWindow time.Duration) metric.Struct {
 	m := &Metrics{
-		IngestedEvents:     metric.NewCounter(metaStreamingEventsIngested),
-		IngestedBytes:      metric.NewCounter(metaStreamingIngestedBytes),
-		SSTBytes:           metric.NewCounter(metaStreamingSSTBytes),
-		Flushes:            metric.NewCounter(metaStreamingFlushes),
-		ResolvedEvents:     metric.NewCounter(metaStreamingResolvedEventsIngested),
+		IngestedEvents:     metric.NewCounter(metaReplicationEventsIngested),
+		IngestedBytes:      metric.NewCounter(metaReplicationIngestedBytes),
+		SSTBytes:           metric.NewCounter(metaReplicationSSTBytes),
+		Flushes:            metric.NewCounter(metaReplicationFlushes),
+		ResolvedEvents:     metric.NewCounter(metaReplicationResolvedEventsIngested),
 		JobProgressUpdates: metric.NewCounter(metaJobProgressUpdates),
-		FlushHistNanos: metric.NewHistogram(metaStreamingFlushHistNanos,
+		FlushHistNanos: metric.NewHistogram(metaReplicationFlushHistNanos,
 			histogramWindow, metric.BatchProcessLatencyBuckets),
-		CommitLatency: metric.NewHistogram(metaStreamingCommitLatency,
+		CommitLatency: metric.NewHistogram(metaReplicationCommitLatency,
 			histogramWindow, metric.BatchProcessLatencyBuckets),
-		AdmitLatency: metric.NewHistogram(metaStreamingAdmitLatency,
+		AdmitLatency: metric.NewHistogram(metaReplicationAdmitLatency,
 			histogramWindow, metric.BatchProcessLatencyBuckets),
 		RunningCount:                metric.NewGauge(metaStreamsRunning),
 		EarliestDataCheckpointSpan:  metric.NewGauge(metaEarliestDataCheckpointSpan),

--- a/pkg/ts/catalog/chart_catalog.go
+++ b/pkg/ts/catalog/chart_catalog.go
@@ -1580,74 +1580,74 @@ var charts = []sectionDescription{
 		Charts: []chartDescription{
 			{
 				Title:   "Currently Running",
-				Metrics: []string{"streaming.running"},
+				Metrics: []string{"replication.running"},
 			},
 			{
 				Title: "Event admission latency",
 				Metrics: []string{
-					"streaming.admit_latency",
+					"replication.admit_latency",
 				},
 			},
 			{
 				Title: "Commits Latency",
 				Metrics: []string{
-					"streaming.commit_latency",
+					"replication.commit_latency",
 				},
 			},
 			{
 				Title: "Time spent",
 				Metrics: []string{
-					"streaming.flush_hist_nanos",
+					"replication.flush_hist_nanos",
 				},
 			},
 			{
 				Title: "Ingested Events",
 				Metrics: []string{
-					"streaming.events_ingested",
-					"streaming.resolved_events_ingested",
+					"replication.events_ingested",
+					"replication.resolved_events_ingested",
 				},
 			},
 			{
 				Title: "Flushes",
 				Metrics: []string{
-					"streaming.flushes",
+					"replication.flushes",
 				},
 			},
 			{
 				Title: "Ingested Bytes",
 				Metrics: []string{
-					"streaming.ingested_bytes",
+					"replication.ingested_bytes",
 				},
 			},
 			{
 				Title: "SST Bytes",
 				Metrics: []string{
-					"streaming.sst_bytes",
+					"replication.sst_bytes",
 				},
 			},
 			{
 				Title:   "Earliest Data Processor Checkpoint Span",
-				Metrics: []string{"streaming.earliest_data_checkpoint_span"},
+				Metrics: []string{"replication.earliest_data_checkpoint_span"},
 			},
 			{
 				Title:   "Latest Data Processor Checkpoint Span",
-				Metrics: []string{"streaming.latest_data_checkpoint_span"},
+				Metrics: []string{"replication.latest_data_checkpoint_span"},
 			},
 			{
 				Title:   "Data Checkpoint Span Count",
-				Metrics: []string{"streaming.data_checkpoint_span_count"},
+				Metrics: []string{"replication.data_checkpoint_span_count"},
 			},
 			{
 				Title:   "Frontier Checkpoint Span Count",
-				Metrics: []string{"streaming.frontier_checkpoint_span_count"},
+				Metrics: []string{"replication.frontier_checkpoint_span_count"},
 			},
 			{
 				Title:   "Frontier Lag",
-				Metrics: []string{"streaming.frontier_lag_seconds"},
+				Metrics: []string{"replication.frontier_lag_seconds"},
 			},
 			{
 				Title:   "Job Progress Updates",
-				Metrics: []string{"streaming.job_progress_updates"},
+				Metrics: []string{"replication.job_progress_updates"},
 			},
 		},
 	},

--- a/pkg/ts/catalog/metrics.go
+++ b/pkg/ts/catalog/metrics.go
@@ -97,9 +97,9 @@ var histogramMetricsNames = map[string]struct{}{
 	"changefeed.message_size_hist":              {},
 	"changefeed.commit_latency":                 {},
 	"changefeed.sink_batch_hist_nanos":          {},
-	"streaming.admit_latency":                   {},
-	"streaming.commit_latency":                  {},
-	"streaming.flush_hist_nanos":                {},
+	"replication.admit_latency":                 {},
+	"replication.commit_latency":                {},
+	"replication.flush_hist_nanos":              {},
 	"kv.replica_read_batch_evaluate.latency":    {},
 	"kv.replica_write_batch_evaluate.latency":   {},
 }


### PR DESCRIPTION
At some point, all of cluster to cluster replication should be `replication` instead of `streaming`. This is a small rename, just for c2c metrics.

Epic: none

Release note: None