### PR TITLE
sql: remove redundant session iteration

### DIFF
--- a/pkg/ccl/serverccl/statusccl/tenant_status_test.go
+++ b/pkg/ccl/serverccl/statusccl/tenant_status_test.go
@@ -943,30 +943,22 @@ func testTenantStatusCancelSessionErrorMessages(t *testing.T, helper serverccl.T
 	testCases := []struct {
 		sessionID     string
 		expectedError string
-
-		// This is a temporary assertion. We should always show the following "not found" error messages,
-		// regardless of admin status, but our current behavior is slightly broken and will be fixed in #77676.
-		nonAdminSeesError bool
 	}{
 		{
-			sessionID:         "",
-			expectedError:     "session ID 00000000000000000000000000000000 not found",
-			nonAdminSeesError: true,
+			sessionID:     "",
+			expectedError: "session ID 00000000000000000000000000000000 not found",
 		},
 		{
-			sessionID:         "01", // This query ID claims to have SQL instance ID 1, different from the one we're talking to.
-			expectedError:     "session ID 00000000000000000000000000000001 not found",
-			nonAdminSeesError: false,
+			sessionID:     "01", // This query ID claims to have SQL instance ID 1, different from the one we're talking to.
+			expectedError: "session ID 00000000000000000000000000000001 not found",
 		},
 		{
-			sessionID:         "02", // This query ID claims to have SQL instance ID 2, the instance we're talking to.
-			expectedError:     "session ID 00000000000000000000000000000002 not found",
-			nonAdminSeesError: false,
+			sessionID:     "02", // This query ID claims to have SQL instance ID 2, the instance we're talking to.
+			expectedError: "session ID 00000000000000000000000000000002 not found",
 		},
 		{
-			sessionID:         "42", // This query ID claims to have SQL instance ID 42, which does not exist.
-			expectedError:     "session ID 00000000000000000000000000000042 not found",
-			nonAdminSeesError: true,
+			sessionID:     "42", // This query ID claims to have SQL instance ID 42, which does not exist.
+			expectedError: "session ID 00000000000000000000000000000042 not found",
 		},
 	}
 
@@ -982,12 +974,8 @@ func testTenantStatusCancelSessionErrorMessages(t *testing.T, helper serverccl.T
 				err = client.PostJSONChecked("/_status/cancel_session/0", &serverpb.CancelSessionRequest{
 					SessionID: sessionID.GetBytes(),
 				}, &resp)
-				if isAdmin || testCase.nonAdminSeesError {
-					require.NoError(t, err)
-					require.Equal(t, testCase.expectedError, resp.Error)
-				} else {
-					require.Error(t, err)
-				}
+				require.NoError(t, err)
+				require.Equal(t, testCase.expectedError, resp.Error)
 			})
 		}
 	})
@@ -1072,36 +1060,27 @@ func testTenantStatusCancelQueryErrorMessages(t *testing.T, helper serverccl.Ten
 	testCases := []struct {
 		queryID       string
 		expectedError string
-
-		// This is a temporary assertion. We should always show the following "not found" error messages,
-		// regardless of admin status, but our current behavior is slightly broken and will be fixed in #77676.
-		nonAdminSeesError bool
 	}{
 		{
 			queryID: "BOGUS_QUERY_ID",
 			expectedError: "query ID 00000000000000000000000000000000 malformed: " +
 				"could not decode BOGUS_QUERY_ID as hex: encoding/hex: invalid byte: U+004F 'O'",
-			nonAdminSeesError: true,
 		},
 		{
-			queryID:           "",
-			expectedError:     "query ID 00000000000000000000000000000000 not found",
-			nonAdminSeesError: true,
+			queryID:       "",
+			expectedError: "query ID 00000000000000000000000000000000 not found",
 		},
 		{
-			queryID:           "01", // This query ID claims to have SQL instance ID 1, different from the one we're talking to.
-			expectedError:     "query ID 00000000000000000000000000000001 not found",
-			nonAdminSeesError: false,
+			queryID:       "01", // This query ID claims to have SQL instance ID 1, different from the one we're talking to.
+			expectedError: "query ID 00000000000000000000000000000001 not found",
 		},
 		{
-			queryID:           "02", // This query ID claims to have SQL instance ID 2, the instance we're talking to.
-			expectedError:     "query ID 00000000000000000000000000000002 not found",
-			nonAdminSeesError: false,
+			queryID:       "02", // This query ID claims to have SQL instance ID 2, the instance we're talking to.
+			expectedError: "query ID 00000000000000000000000000000002 not found",
 		},
 		{
-			queryID:           "42", // This query ID claims to have SQL instance ID 42, which does not exist.
-			expectedError:     "query ID 00000000000000000000000000000042 not found",
-			nonAdminSeesError: true,
+			queryID:       "42", // This query ID claims to have SQL instance ID 42, which does not exist.
+			expectedError: "query ID 00000000000000000000000000000042 not found",
 		},
 	}
 
@@ -1115,12 +1094,8 @@ func testTenantStatusCancelQueryErrorMessages(t *testing.T, helper serverccl.Ten
 				err := client.PostJSONChecked("/_status/cancel_query/0", &serverpb.CancelQueryRequest{
 					QueryID: testCase.queryID,
 				}, &resp)
-				if isAdmin || testCase.nonAdminSeesError {
-					require.NoError(t, err)
-					require.Equal(t, testCase.expectedError, resp.Error)
-				} else {
-					require.Error(t, err)
-				}
+				require.NoError(t, err)
+				require.Equal(t, testCase.expectedError, resp.Error)
 			})
 		}
 	})

--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -3137,8 +3137,16 @@ func (ex *connExecutor) initStatementResult(
 	return nil
 }
 
-// cancelQuery is part of the registrySession interface.
-func (ex *connExecutor) cancelQuery(queryID clusterunique.ID) bool {
+// hasQuery is part of the RegistrySession interface.
+func (ex *connExecutor) hasQuery(queryID clusterunique.ID) bool {
+	ex.mu.RLock()
+	defer ex.mu.RUnlock()
+	_, exists := ex.mu.ActiveQueries[queryID]
+	return exists
+}
+
+// CancelQuery is part of the RegistrySession interface.
+func (ex *connExecutor) CancelQuery(queryID clusterunique.ID) bool {
 	ex.mu.Lock()
 	defer ex.mu.Unlock()
 	if queryMeta, exists := ex.mu.ActiveQueries[queryID]; exists {
@@ -3148,8 +3156,8 @@ func (ex *connExecutor) cancelQuery(queryID clusterunique.ID) bool {
 	return false
 }
 
-// cancelCurrentQueries is part of the registrySession interface.
-func (ex *connExecutor) cancelCurrentQueries() bool {
+// CancelActiveQueries is part of the RegistrySession interface.
+func (ex *connExecutor) CancelActiveQueries() bool {
 	ex.mu.Lock()
 	defer ex.mu.Unlock()
 	canceled := false
@@ -3160,8 +3168,8 @@ func (ex *connExecutor) cancelCurrentQueries() bool {
 	return canceled
 }
 
-// cancelSession is part of the registrySession interface.
-func (ex *connExecutor) cancelSession() {
+// CancelSession is part of the RegistrySession interface.
+func (ex *connExecutor) CancelSession() {
 	if ex.onCancelSession == nil {
 		return
 	}
@@ -3169,12 +3177,17 @@ func (ex *connExecutor) cancelSession() {
 	ex.onCancelSession()
 }
 
-// user is part of the registrySession interface.
+// user is part of the RegistrySession interface.
 func (ex *connExecutor) user() username.SQLUsername {
 	return ex.sessionData().User()
 }
 
-// serialize is part of the registrySession interface.
+// BaseSessionUser is part of the RegistrySession interface.
+func (ex *connExecutor) BaseSessionUser() username.SQLUsername {
+	return ex.sessionDataStack.Base().SessionUser()
+}
+
+// serialize is part of the RegistrySession interface.
 func (ex *connExecutor) serialize() serverpb.Session {
 	ex.mu.RLock()
 	defer ex.mu.RUnlock()

--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -149,7 +149,7 @@ func (ex *connExecutor) execStmt(
 		// Cancel the session if the idle time exceeds the idle in session timeout.
 		ex.mu.IdleInSessionTimeout = timeout{time.AfterFunc(
 			ex.sessionData().IdleInSessionTimeout,
-			ex.cancelSession,
+			ex.CancelSession,
 		)}
 	}
 
@@ -162,7 +162,7 @@ func (ex *connExecutor) execStmt(
 			default:
 				ex.mu.IdleInTransactionSessionTimeout = timeout{time.AfterFunc(
 					ex.sessionData().IdleInTransactionSessionTimeout,
-					ex.cancelSession,
+					ex.CancelSession,
 				)}
 			}
 		}

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -2068,8 +2068,8 @@ type SessionArgs struct {
 type SessionRegistry struct {
 	mu struct {
 		syncutil.RWMutex
-		sessionsByID        map[clusterunique.ID]registrySession
-		sessionsByCancelKey map[pgwirecancel.BackendKeyData]registrySession
+		sessionsByID        map[clusterunique.ID]RegistrySession
+		sessionsByCancelKey map[pgwirecancel.BackendKeyData]RegistrySession
 	}
 }
 
@@ -2077,31 +2077,40 @@ type SessionRegistry struct {
 // of sessions.
 func NewSessionRegistry() *SessionRegistry {
 	r := SessionRegistry{}
-	r.mu.sessionsByID = make(map[clusterunique.ID]registrySession)
-	r.mu.sessionsByCancelKey = make(map[pgwirecancel.BackendKeyData]registrySession)
+	r.mu.sessionsByID = make(map[clusterunique.ID]RegistrySession)
+	r.mu.sessionsByCancelKey = make(map[pgwirecancel.BackendKeyData]RegistrySession)
 	return &r
 }
 
-func (r *SessionRegistry) getSessionByID(id clusterunique.ID) (registrySession, bool) {
+func (r *SessionRegistry) GetSessionByID(sessionID clusterunique.ID) (RegistrySession, bool) {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
-	session, ok := r.mu.sessionsByID[id]
+	session, ok := r.mu.sessionsByID[sessionID]
 	return session, ok
 }
 
-func (r *SessionRegistry) getSessionByCancelKey(
+func (r *SessionRegistry) GetSessionByQueryID(queryID clusterunique.ID) (RegistrySession, bool) {
+	for _, session := range r.getSessions() {
+		if session.hasQuery(queryID) {
+			return session, true
+		}
+	}
+	return nil, false
+}
+
+func (r *SessionRegistry) GetSessionByCancelKey(
 	cancelKey pgwirecancel.BackendKeyData,
-) (registrySession, bool) {
+) (RegistrySession, bool) {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 	session, ok := r.mu.sessionsByCancelKey[cancelKey]
 	return session, ok
 }
 
-func (r *SessionRegistry) getSessions() []registrySession {
+func (r *SessionRegistry) getSessions() []RegistrySession {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
-	sessions := make([]registrySession, 0, len(r.mu.sessionsByID))
+	sessions := make([]RegistrySession, 0, len(r.mu.sessionsByID))
 	for _, session := range r.mu.sessionsByID {
 		sessions = append(sessions, session)
 	}
@@ -2109,7 +2118,7 @@ func (r *SessionRegistry) getSessions() []registrySession {
 }
 
 func (r *SessionRegistry) register(
-	id clusterunique.ID, queryCancelKey pgwirecancel.BackendKeyData, s registrySession,
+	id clusterunique.ID, queryCancelKey pgwirecancel.BackendKeyData, s RegistrySession,
 ) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
@@ -2126,63 +2135,20 @@ func (r *SessionRegistry) deregister(
 	delete(r.mu.sessionsByCancelKey, queryCancelKey)
 }
 
-type registrySession interface {
+type RegistrySession interface {
 	user() username.SQLUsername
-	cancelQuery(queryID clusterunique.ID) bool
-	cancelCurrentQueries() bool
-	cancelSession()
+	// BaseSessionUser returns the base session's username.
+	BaseSessionUser() username.SQLUsername
+	hasQuery(queryID clusterunique.ID) bool
+	// CancelQuery cancels the query specified by queryID if it exists.
+	CancelQuery(queryID clusterunique.ID) bool
+	// CancelActiveQueries cancels all currently active queries.
+	CancelActiveQueries() bool
+	// CancelSession cancels the session.
+	CancelSession()
 	// serialize serializes a Session into a serverpb.Session
 	// that can be served over RPC.
 	serialize() serverpb.Session
-}
-
-// CancelQuery looks up the associated query in the session registry and cancels
-// it. The caller is responsible for all permission checks.
-func (r *SessionRegistry) CancelQuery(queryIDStr string) (bool, error) {
-	queryID, err := clusterunique.IDFromString(queryIDStr)
-	if err != nil {
-		return false, errors.Wrapf(err, "query ID %s malformed", queryID)
-	}
-
-	for _, session := range r.getSessions() {
-		if session.cancelQuery(queryID) {
-			return true, nil
-		}
-	}
-
-	return false, fmt.Errorf("query ID %s not found", queryID)
-}
-
-// CancelQueryByKey looks up the associated query in the session registry and
-// cancels it.
-func (r *SessionRegistry) CancelQueryByKey(
-	queryCancelKey pgwirecancel.BackendKeyData,
-) (canceled bool, err error) {
-	session, ok := r.getSessionByCancelKey(queryCancelKey)
-	if !ok {
-		return false, fmt.Errorf("session for cancel key %d not found", queryCancelKey)
-	}
-	return session.cancelCurrentQueries(), nil
-}
-
-// CancelSession looks up the specified session in the session registry and
-// cancels it. The caller is responsible for all permission checks.
-func (r *SessionRegistry) CancelSession(
-	sessionIDBytes []byte,
-) (*serverpb.CancelSessionResponse, error) {
-	if len(sessionIDBytes) != 16 {
-		return nil, errors.Errorf("invalid non-16-byte UUID %v", sessionIDBytes)
-	}
-	sessionID := clusterunique.IDFromBytes(sessionIDBytes)
-
-	session, ok := r.getSessionByID(sessionID)
-	if !ok {
-		return &serverpb.CancelSessionResponse{
-			Error: fmt.Sprintf("session ID %s not found", sessionID),
-		}, nil
-	}
-	session.cancelSession()
-	return &serverpb.CancelSessionResponse{Canceled: true}, nil
 }
 
 // SerializeAll returns a slice of all sessions in the registry converted to


### PR DESCRIPTION
Fixes #95743

Improves session/query cancelation with the following
1) Replaces session scanning by session ID with map lookup.
2) Replaces active query scanning by query ID with map lookup
   (session containing query to cancel is still scanned for).
3) Does not serialize entire session to get session username or id.

Informs #77676

77676 was closed but some test cases incorrectly mentioned that addressing
77676 fixed them. This PR correctly fixes these test cases.

Release note: None
