### PR TITLE
cdc: add transformations to create changefeed telemetry

### DIFF
--- a/docs/generated/eventlog.md
+++ b/docs/generated/eventlog.md
@@ -2711,6 +2711,9 @@ successfully starts running.  Failed CREATE statements will show up as
 ChangefeedFailed events.
 
 
+| Field | Description | Sensitive |
+|--|--|--|
+| `Transformation` |  | no |
 
 
 #### Common fields

--- a/pkg/ccl/changefeedccl/changefeed_stmt.go
+++ b/pkg/ccl/changefeedccl/changefeed_stmt.go
@@ -222,7 +222,7 @@ func changefeedPlanHook(
 			p.ExtendedEvalContext().Descs.ReleaseAll(ctx)
 
 			telemetry.Count(`changefeed.create.core`)
-			logChangefeedCreateTelemetry(ctx, jr)
+			logChangefeedCreateTelemetry(ctx, jr, changefeedStmt.Select != nil)
 
 			var err error
 			for r := getRetry(ctx); r.Next(); {
@@ -325,7 +325,7 @@ func changefeedPlanHook(
 			return err
 		}
 
-		logChangefeedCreateTelemetry(ctx, jr)
+		logChangefeedCreateTelemetry(ctx, jr, changefeedStmt.Select != nil)
 
 		select {
 		case <-ctx.Done():
@@ -1261,7 +1261,7 @@ func getChangefeedTargetName(
 	return desc.GetName(), nil
 }
 
-func logChangefeedCreateTelemetry(ctx context.Context, jr *jobs.Record) {
+func logChangefeedCreateTelemetry(ctx context.Context, jr *jobs.Record, isTransformation bool) {
 	var changefeedEventDetails eventpb.CommonChangefeedEventDetails
 	if jr != nil {
 		changefeedDetails := jr.Details.(jobspb.ChangefeedDetails)
@@ -1270,6 +1270,7 @@ func logChangefeedCreateTelemetry(ctx context.Context, jr *jobs.Record) {
 
 	createChangefeedEvent := &eventpb.CreateChangefeed{
 		CommonChangefeedEventDetails: changefeedEventDetails,
+		Transformation:               isTransformation,
 	}
 
 	log.StructuredEvent(ctx, createChangefeedEvent)

--- a/pkg/util/log/eventpb/json_encode_generated.go
+++ b/pkg/util/log/eventpb/json_encode_generated.go
@@ -2140,6 +2140,14 @@ func (m *CreateChangefeed) AppendJSONFields(printComma bool, b redact.Redactable
 
 	printComma, b = m.CommonChangefeedEventDetails.AppendJSONFields(printComma, b)
 
+	if m.Transformation {
+		if printComma {
+			b = append(b, ',')
+		}
+		printComma = true
+		b = append(b, "\"Transformation\":true"...)
+	}
+
 	return printComma, b
 }
 

--- a/pkg/util/log/eventpb/telemetry.proto
+++ b/pkg/util/log/eventpb/telemetry.proto
@@ -239,6 +239,8 @@ message CapturedIndexUsageStats {
 // ChangefeedFailed events.
 message CreateChangefeed {
   CommonChangefeedEventDetails common = 1 [(gogoproto.nullable) = false, (gogoproto.jsontag) = "", (gogoproto.embed) = true];
+
+  bool transformation = 2 [(gogoproto.jsontag) = ",omitempty", (gogoproto.moretags) = "redact:\"nonsensitive\""];
 }
 
 // ChangefeedFailed is an event for any Changefeed failure since the plan hook


### PR DESCRIPTION
Previously, there were no telemetry events emitted to track the usage of changefeed transformations. This change adds the `transformation` field to the `CREATE CHANGEFEED` telemetry log event to track that. Example:
```
{
  "Timestamp": 1674574083953989000, "EventType": "create_changefeed",
  "Description": "CREATE CHANGEFEED INTO 'gcpubsub://testfeed?region=testfeedRegion' AS SELECT b FROM foo",
  "SinkType": "gcpubsub", "NumTables": 1, "Resolved": "no", "Transformation": true
}
```

Epic: CRDB-17161
Closes: https://github.com/cockroachdb/cockroach/issues/95126

Release note: None