### PR TITLE
roachtest: fix env var passing in activerecord test

### DIFF
--- a/pkg/cmd/roachtest/tests/activerecord.go
+++ b/pkg/cmd/roachtest/tests/activerecord.go
@@ -159,7 +159,7 @@ func registerActiveRecord(r registry.Registry) {
 			"installing gems",
 			fmt.Sprintf(
 				`cd /mnt/data1/activerecord-cockroachdb-adapter/ && `+
-					`RAILS_VERSION=%s sudo bundle install`, supportedRailsVersion),
+					`sudo RAILS_VERSION=%s bundle install`, supportedRailsVersion),
 		); err != nil {
 			t.Fatal(err)
 		}
@@ -172,8 +172,9 @@ func registerActiveRecord(r registry.Registry) {
 		t.Status("running activerecord test suite")
 
 		result, err := c.RunWithDetailsSingleNode(ctx, t.L(), node,
-			`cd /mnt/data1/activerecord-cockroachdb-adapter/ && `+
-				`sudo RUBYOPT="-W0" TESTOPTS="-v" bundle exec rake test`,
+			fmt.Sprintf(
+				`cd /mnt/data1/activerecord-cockroachdb-adapter/ && `+
+					`sudo RAILS_VERSION=%s RUBYOPT="-W0" TESTOPTS="-v" bundle exec rake test`, supportedRailsVersion),
 		)
 
 		// Fatal for a roachprod or SSH error. A roachprod error is when result.Err==nil.


### PR DESCRIPTION
This patch fixes the rails version pinning in the activerecord
roachtest. The rails version is passed in via the env variable
`RAILS_VERSION` and was previously being set before the `sudo`
in the adapter install command and thus erroneously discarded.

Informs #94211

Release note: None