### PR TITLE
multiregionccl: deflake TestColdStartLatency

### DIFF
--- a/pkg/ccl/multiregionccl/cold_start_latency_test.go
+++ b/pkg/ccl/multiregionccl/cold_start_latency_test.go
@@ -159,6 +159,9 @@ func TestColdStartLatency(t *testing.T) {
 		if !isTenant {
 			stmts = append(stmts,
 				"ALTER TENANT ALL SET CLUSTER SETTING sql.zone_configs.allow_for_secondary_tenant.enabled = true",
+				// Disable automatic stats because it gets upset about the way we change the column
+				// structure.
+				"ALTER TENANT ALL SET CLUSTER SETTING sql.stats.automatic_collection.enabled = false",
 				"ALTER TENANT ALL SET CLUSTER SETTING sql.multi_region.allow_abstractions_for_secondary_tenants.enabled = true",
 				`alter range meta configure zone using constraints = '{"+region=us-east1": 1, "+region=us-west1": 1, "+region=europe-west1": 1}';`)
 		} else {


### PR DESCRIPTION
The way we hackily upgrade the system database causes problems with stats on the system tables we're updating in place. As a band-aid, let's turn off auto-stats.

<what was there before: Previously, ...>
<why it needed to change: This was inadequate because ...>
<what you did about it: To address this, this patch ...>

Epic: none

Fixes: #95763

Release note: None