### PR TITLE
builtins: add non-null check to a recently merged builtin overload

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/crdb_internal
+++ b/pkg/sql/logictest/testdata/logic_test/crdb_internal
@@ -1156,9 +1156,14 @@ statement ok
 SELECT crdb_internal.probe_ranges(INTERVAL '1000ms', 'write')
 
 # Regression test for not handling NULL values correctly by an internal builtin
-# (#82056).
+# (#82056 and #95671).
 query I
 SELECT crdb_internal.num_inverted_index_entries(NULL::STRING, 0)
+----
+0
+
+query I
+SELECT crdb_internal.num_inverted_index_entries(NULL::TSVECTOR, NULL::INT8)
 ----
 0
 

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -5952,6 +5952,9 @@ value if you rely on the HLC for accuracy.`,
 			},
 			ReturnType: tree.FixedReturnType(types.Int),
 			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
+				if args[0] == tree.DNull {
+					return tree.DZero, nil
+				}
 				val := args[0].(*tree.DTSVector)
 				return tree.NewDInt(tree.DInt(len(val.TSVector))), nil
 			},


### PR DESCRIPTION
Fixes: #95671.

Release note: None