### PR TITLE
ui: add CPU time to statement and transaction tables

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/api/statementsApi.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/api/statementsApi.ts
@@ -111,6 +111,7 @@ type ExecStats = {
   maxMemUsage: NumericStat;
   networkBytes: NumericStat;
   networkMsgs: NumericStat;
+  cpuNanos: NumericStat;
 };
 
 type StatementStatistics = {
@@ -155,6 +156,7 @@ export function convertStatementRawFormatToAggregatedStatistics(
         max_mem_usage: s.statistics.execution_statistics.maxMemUsage,
         network_bytes: s.statistics.execution_statistics.networkBytes,
         network_messages: s.statistics.execution_statistics.networkMsgs,
+        cpu_nanos: s.statistics.execution_statistics.cpuNanos,
       },
       bytes_read: s.statistics.statistics.bytesRead,
       count: s.statistics.statistics.cnt,

--- a/pkg/ui/workspaces/cluster-ui/src/barCharts/barCharts.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/barCharts/barCharts.module.scss
@@ -74,6 +74,7 @@
   .bytes-read-dev,
   .rows-written-dev,
   .contention-dev,
+  .cpu-dev,
   .max-mem-usage-dev,
   .network-bytes-dev {
     background-color: $colors--primary-blue-3;

--- a/pkg/ui/workspaces/cluster-ui/src/barCharts/barCharts.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/barCharts/barCharts.tsx
@@ -48,6 +48,10 @@ const contentionBars = [
   ),
 ];
 
+const cpuBars = [
+  bar("cpu", (d: StatementStatistics) => d.stats.exec_stats.cpu_nanos?.mean),
+];
+
 const maxMemUsageBars = [
   bar(
     "max-mem-usage",
@@ -80,6 +84,9 @@ const latencyStdDev = bar(
 const contentionStdDev = bar(cx("contention-dev"), (d: StatementStatistics) =>
   stdDevLong(d.stats.exec_stats.contention_time, d.stats.exec_stats.count),
 );
+const cpuStdDev = bar(cx("cpu-dev"), (d: StatementStatistics) =>
+  stdDevLong(d.stats.exec_stats.cpu_nanos, d.stats.exec_stats.count),
+);
 const maxMemUsageStdDev = bar(
   cx("max-mem-usage-dev"),
   (d: StatementStatistics) =>
@@ -109,6 +116,12 @@ export const contentionBarChart = barChartFactory(
   contentionBars,
   v => Duration(v * 1e9),
   contentionStdDev,
+);
+export const cpuBarChart = barChartFactory(
+  "grey",
+  cpuBars,
+  v => Duration(v * 1e9),
+  cpuStdDev,
 );
 export const maxMemUsageBarChart = barChartFactory(
   "grey",

--- a/pkg/ui/workspaces/cluster-ui/src/statementsTable/statementsTable.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsTable/statementsTable.tsx
@@ -27,6 +27,7 @@ import {
   bytesReadBarChart,
   latencyBarChart,
   contentionBarChart,
+  cpuBarChart,
   maxMemUsageBarChart,
   networkBytesBarChart,
   retryBarChart,
@@ -135,6 +136,7 @@ export function makeStatementsColumns(
     statements,
     sampledExecStatsBarChartOptions,
   );
+  const cpuBar = cpuBarChart(statements, sampledExecStatsBarChartOptions);
   const maxMemUsageBar = maxMemUsageBarChart(
     statements,
     sampledExecStatsBarChartOptions,
@@ -216,6 +218,13 @@ export function makeStatementsColumns(
       cell: contentionBar,
       sort: (stmt: AggregateStatistics) =>
         FixLong(Number(stmt.stats.exec_stats.contention_time.mean)),
+    },
+    {
+      name: "cpu",
+      title: statisticsTableTitles.cpu(statType),
+      cell: cpuBar,
+      sort: (stmt: AggregateStatistics) =>
+        FixLong(Number(stmt.stats.exec_stats.cpu_nanos.mean)),
     },
     {
       name: "maxMemUsage",

--- a/pkg/ui/workspaces/cluster-ui/src/statsTableUtil/statsTableUtil.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statsTableUtil/statsTableUtil.tsx
@@ -46,6 +46,7 @@ export const statisticsColumnLabels = {
   applicationName: "Application Name",
   bytesRead: "Bytes Read",
   contention: "Contention Time",
+  cpu: "CPU Time",
   database: "Database",
   diagnostics: "Diagnostics",
   executionCount: "Execution Count",
@@ -629,6 +630,25 @@ export const statisticsTableTitles: StatisticTableTitleType = {
         }
       >
         {getLabel("contention")}
+      </Tooltip>
+    );
+  },
+  cpu: (_: StatisticType) => {
+    return (
+      <Tooltip
+        placement="bottom"
+        style="tableTitle"
+        content={
+          <>
+            <p>
+              Average CPU time spent executing within the specified time
+              interval. The gray bar indicates mean CPU time. The blue bar
+              indicates one standard deviation from the mean.
+            </p>
+          </>
+        }
+      >
+        {getLabel("cpu")}
       </Tooltip>
     );
   },

--- a/pkg/ui/workspaces/cluster-ui/src/transactionsTable/transactionsBarCharts.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionsTable/transactionsBarCharts.ts
@@ -53,6 +53,15 @@ const contentionStdDev = bar(cx("contention-dev"), (d: Transaction) =>
     d.stats_data.stats.exec_stats.count,
   ),
 );
+const cpuBar = [
+  bar("cpu", (d: Transaction) => d.stats_data.stats.exec_stats.cpu_nanos?.mean),
+];
+const cpuStdDev = bar(cx("cpu-dev"), (d: Transaction) =>
+  stdDevLong(
+    d.stats_data.stats.exec_stats.cpu_nanos,
+    d.stats_data.stats.exec_stats.count,
+  ),
+);
 const maxMemUsageBar = [
   bar("max-mem-usage", (d: Transaction) =>
     longToInt(d.stats_data.stats.exec_stats.max_mem_usage?.mean),
@@ -103,6 +112,12 @@ export const transactionsContentionBarChart = barChartFactory(
   contentionBar,
   v => Duration(v * 1e9),
   contentionStdDev,
+);
+export const transactionsCPUBarChart = barChartFactory(
+  "grey",
+  cpuBar,
+  v => Duration(v * 1e9),
+  cpuStdDev,
 );
 export const transactionsMaxMemUsageBarChart = barChartFactory(
   "grey",

--- a/pkg/ui/workspaces/cluster-ui/src/transactionsTable/transactionsTable.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionsTable/transactionsTable.tsx
@@ -21,6 +21,7 @@ import {
   transactionsBytesReadBarChart,
   transactionsLatencyBarChart,
   transactionsContentionBarChart,
+  transactionsCPUBarChart,
   transactionsMaxMemUsageBarChart,
   transactionsNetworkBytesBarChart,
   transactionsRetryBarChart,
@@ -111,6 +112,10 @@ export function makeTransactionsColumns(
     latencyClasses.barChart,
   );
   const contentionBar = transactionsContentionBarChart(
+    transactions,
+    sampledExecStatsBarChartOptions,
+  );
+  const cpuBar = transactionsCPUBarChart(
     transactions,
     sampledExecStatsBarChartOptions,
   );
@@ -205,6 +210,14 @@ export function makeTransactionsColumns(
       className: cx("statements-table__col-contention"),
       sort: (item: TransactionInfo) =>
         FixLong(Number(item.stats_data.stats.exec_stats.contention_time?.mean)),
+    },
+    {
+      name: "cpu",
+      title: statisticsTableTitles.cpu(statType),
+      cell: cpuBar,
+      className: cx("statements-table__col-cpu"),
+      sort: (item: TransactionInfo) =>
+        FixLong(Number(item.stats_data.stats.exec_stats.cpu_nanos?.mean)),
     },
     {
       name: "maxMemUsage",


### PR DESCRIPTION
Adds CPU time as a column on Statement and Transaction tables under SQL Activity and List of fingerprints on Index Details.

Part Of #87213

Statements Page
<img width="1300" alt="Screen Shot 2023-01-24 at 5 38 32 PM" src="https://user-images.githubusercontent.com/1017486/214437590-70fb8b08-93ab-4588-b7ea-ac564c75c13d.png">


Transactions Page
<img width="1424" alt="Screen Shot 2023-01-24 at 5 38 09 PM" src="https://user-images.githubusercontent.com/1017486/214437573-aaadc388-8886-419c-ba5b-75389aa5481e.png">


Transaction Details Page
<img width="1535" alt="Screen Shot 2023-01-24 at 5 22 27 PM" src="https://user-images.githubusercontent.com/1017486/214437551-b14d5d3a-3629-46a5-90ae-c57aabd1f5f5.png">

Table on Index Stats Details
<img width="1534" alt="Screen Shot 2023-01-24 at 5 21 55 PM" src="https://user-images.githubusercontent.com/1017486/214437371-1940294b-3433-40bb-af74-2086ae190f94.png">



Release note (ui change): Add CPU time as a column on Statement and Transaction tables.