### PR TITLE
ui: add CPU Time chart do statement details

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetails.fixture.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetails.fixture.ts
@@ -60,6 +60,7 @@ const statementDetailsNoData: StatementDetailsResponse = {
         contention_time: { mean: 0, squared_diffs: 0 },
         network_messages: { mean: 0, squared_diffs: 0 },
         max_disk_usage: { mean: 0, squared_diffs: 0 },
+        cpu_nanos: { mean: 0, squared_diffs: 0 },
       },
       sql_type: "",
       last_exec_timestamp: { seconds: new Long(-62135596800) },
@@ -174,6 +175,10 @@ const statementDetailsData: StatementDetailsResponse = {
           mean: 0,
           squared_diffs: 0,
         },
+        cpu_nanos: {
+          mean: 0,
+          squared_diffs: 0,
+        },
       },
       sql_type: "TypeDML",
       last_exec_timestamp: {
@@ -268,6 +273,10 @@ const statementDetailsData: StatementDetailsResponse = {
             squared_diffs: 0,
           },
           max_disk_usage: {
+            mean: 0,
+            squared_diffs: 0,
+          },
+          cpu_nanos: {
             mean: 0,
             squared_diffs: 0,
           },
@@ -371,6 +380,10 @@ const statementDetailsData: StatementDetailsResponse = {
             mean: 0,
             squared_diffs: 0,
           },
+          cpu_nanos: {
+            mean: 0,
+            squared_diffs: 0,
+          },
         },
         sql_type: "TypeDML",
         last_exec_timestamp: {
@@ -471,6 +484,10 @@ const statementDetailsData: StatementDetailsResponse = {
             mean: 0,
             squared_diffs: 0,
           },
+          cpu_nanos: {
+            mean: 0,
+            squared_diffs: 0,
+          },
         },
         sql_type: "TypeDML",
         last_exec_timestamp: {
@@ -568,6 +585,10 @@ const statementDetailsData: StatementDetailsResponse = {
             squared_diffs: 0,
           },
           max_disk_usage: {
+            mean: 0,
+            squared_diffs: 0,
+          },
+          cpu_nanos: {
             mean: 0,
             squared_diffs: 0,
           },
@@ -673,6 +694,10 @@ const statementDetailsData: StatementDetailsResponse = {
             mean: 0,
             squared_diffs: 0,
           },
+          cpu_nanos: {
+            mean: 0,
+            squared_diffs: 0,
+          },
         },
         sql_type: "TypeDML",
         last_exec_timestamp: {
@@ -768,6 +793,10 @@ const statementDetailsData: StatementDetailsResponse = {
             squared_diffs: 0,
           },
           max_disk_usage: {
+            mean: 0,
+            squared_diffs: 0,
+          },
+          cpu_nanos: {
             mean: 0,
             squared_diffs: 0,
           },

--- a/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetails.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetails.tsx
@@ -16,7 +16,7 @@ import "antd/lib/tabs/style";
 import { cockroach } from "@cockroachlabs/crdb-protobuf-client";
 import { InlineAlert, Text } from "@cockroachlabs/ui-components";
 import { ArrowLeft } from "@cockroachlabs/icons";
-import _, { isNil } from "lodash";
+import { isNil } from "lodash";
 import Long from "long";
 import { Helmet } from "react-helmet";
 import { Link, RouteComponentProps } from "react-router-dom";
@@ -68,6 +68,7 @@ import {
   generateExecRetriesTimeseries,
   generateExecuteAndPlanningTimeseries,
   generateRowsProcessedTimeseries,
+  generateCPUTimeseries,
 } from "./timeseriesUtils";
 import { Delayed } from "../delayed";
 import moment from "moment";
@@ -622,6 +623,15 @@ export class StatementDetails extends React.Component<
       width: cardWidth,
     };
 
+    const cpuTimeseries: AlignedData =
+      generateCPUTimeseries(statsPerAggregatedTs);
+    const cpuOps: Partial<Options> = {
+      axes: [{}, { label: "CPU Time" }],
+      series: [{}, { label: "CPU Time" }],
+      legend: { show: false },
+      width: cardWidth,
+    };
+
     return (
       <>
         <PageConfig>
@@ -741,6 +751,15 @@ export class StatementDetails extends React.Component<
                 title={`Contention Time${noSamples}`}
                 alignedData={contentionTimeseries}
                 uPlotOptions={contentionOps}
+                tooltip={unavailableTooltip}
+                yAxisUnits={AxisUnits.Duration}
+              />
+            </Col>
+            <Col className="gutter-row" span={12}>
+              <BarGraphTimeSeries
+                title={`CPU Time${noSamples}`}
+                alignedData={cpuTimeseries}
+                uPlotOptions={cpuOps}
                 tooltip={unavailableTooltip}
                 yAxisUnits={AxisUnits.Duration}
               />

--- a/pkg/ui/workspaces/cluster-ui/src/statementDetails/timeseriesUtils.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/statementDetails/timeseriesUtils.ts
@@ -93,3 +93,19 @@ export function generateContentionTimeseries(
 
   return [ts, count];
 }
+
+export function generateCPUTimeseries(
+  stats: statementStatisticsPerAggregatedTs[],
+): AlignedData {
+  const ts: Array<number> = [];
+  const count: Array<number> = [];
+
+  stats.forEach(function (stat: statementStatisticsPerAggregatedTs) {
+    if (stat.stats.exec_stats.cpu_nanos) {
+      ts.push(TimestampToNumber(stat.aggregated_ts) * 1e3);
+      count.push(stat.stats.exec_stats.cpu_nanos.mean * 1e9);
+    }
+  });
+
+  return [ts, count];
+}


### PR DESCRIPTION
This commit adds a new chart for CPU time
on Statement Details page.

Part Of #87213

<img width="1508" alt="Screen Shot 2023-01-24 at 6 01 07 PM" src="https://user-images.githubusercontent.com/1017486/214440274-c48d3bb6-ecbe-47a2-861a-0a8407d219c4.png">


Release note (ui change): Add CPU Time chart to Statement Details page.