### PR TITLE
instancestorage: read instances in a transaction

### DIFF
--- a/pkg/sql/sqlinstance/instancestorage/BUILD.bazel
+++ b/pkg/sql/sqlinstance/instancestorage/BUILD.bazel
@@ -28,6 +28,7 @@ go_library(
         "//pkg/sql/catalog/systemschema",
         "//pkg/sql/enum",
         "//pkg/sql/rowenc/valueside",
+        "//pkg/sql/sem/catid",
         "//pkg/sql/sem/tree",
         "//pkg/sql/sqlinstance",
         "//pkg/sql/sqlliveness",


### PR DESCRIPTION
This code change adds `(instancestorage.Reader).GetAllInstancesUsingTxn` to read all instances using the given `*kv.Txn`.

Release note: None
Epic: CRDB-18735