### PR TITLE
rpc: cleanup latencyInfos for closed connection

### DIFF
--- a/pkg/rpc/clock_offset.go
+++ b/pkg/rpc/clock_offset.go
@@ -172,6 +172,14 @@ func (r *RemoteClockMonitor) AllLatencies() map[roachpb.NodeID]time.Duration {
 	return result
 }
 
+// OnDisconnect removes all information associated with the provided peer.
+func (r *RemoteClockMonitor) OnDisconnect(ctx context.Context, addr string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	delete(r.mu.offsets, addr)
+	delete(r.mu.latencyInfos, addr)
+}
+
 // UpdateOffset is a thread-safe way to update the remote clock and latency
 // measurements.
 //

--- a/pkg/rpc/context.go
+++ b/pkg/rpc/context.go
@@ -2224,6 +2224,9 @@ func (rpcCtx *Context) runHeartbeat(
 		} else {
 			close(conn.initialHeartbeatDone) // unblock any waiters
 		}
+		if rpcCtx.RemoteClocks != nil {
+			rpcCtx.RemoteClocks.OnDisconnect(ctx, target)
+		}
 	}()
 
 	{

--- a/pkg/rpc/context.go
+++ b/pkg/rpc/context.go
@@ -2225,7 +2225,7 @@ func (rpcCtx *Context) runHeartbeat(
 			close(conn.initialHeartbeatDone) // unblock any waiters
 		}
 		if rpcCtx.RemoteClocks != nil {
-			rpcCtx.RemoteClocks.OnDisconnect(ctx, target)
+			rpcCtx.RemoteClocks.OnDisconnect(ctx, conn.remoteNodeID)
 		}
 	}()
 
@@ -2236,6 +2236,9 @@ func (rpcCtx *Context) runHeartbeat(
 			// Note that grpcConn will actually connect in the background, so it's
 			// unusual to hit this case.
 			return err
+		}
+		if rpcCtx.RemoteClocks != nil {
+			rpcCtx.RemoteClocks.OnConnect(ctx, conn.remoteNodeID)
 		}
 	}
 

--- a/pkg/rpc/context_test.go
+++ b/pkg/rpc/context_test.go
@@ -1421,6 +1421,80 @@ func TestFailedOffsetMeasurement(t *testing.T) {
 	})
 }
 
+// TestLatencyInfoCleanup tests that latencyInfo is cleaned up for closed connection
+// to avoid reporting stale information.
+func TestLatencyInfoCleanupOnClosedConnection(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	stopper := stop.NewStopper()
+	defer stopper.Stop(context.Background())
+
+	// Shared cluster ID by all RPC peers (this ensures that the peers
+	// don't talk to servers from unrelated tests by accident).
+	clusterID := uuid.MakeV4()
+	ctx := context.Background()
+
+	serverClock := timeutil.NewManualTime(timeutil.Unix(0, 20))
+	maxOffset := time.Duration(0)
+	serverCtx := newTestContext(clusterID, serverClock, maxOffset, stopper)
+	const serverNodeID = 1
+	serverCtx.NodeID.Set(ctx, serverNodeID)
+	s := newTestServer(t, serverCtx)
+	RegisterHeartbeatServer(s, &HeartbeatService{
+		clock:              serverClock,
+		remoteClockMonitor: serverCtx.RemoteClocks,
+		clusterID:          serverCtx.StorageClusterID,
+		nodeID:             serverCtx.NodeID,
+		settings:           serverCtx.Settings,
+	})
+
+	ln, err := netutil.ListenAndServeGRPC(serverCtx.Stopper, s, util.TestAddr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	remoteAddr := ln.Addr().String()
+
+	// Create a client clock that is behind the server clock.
+	clientClock := &AdvancingClock{time: timeutil.Unix(0, 10)}
+	clientMaxOffset := time.Duration(0)
+	clientCtx := newTestContext(clusterID, clientClock, clientMaxOffset, stopper)
+	// Make the interval shorter to speed up the test.
+	clientCtx.Config.RPCHeartbeatInterval = 1 * time.Millisecond
+	clientCtx.Config.RPCHeartbeatTimeout = 1 * time.Millisecond
+
+	conn, err := clientCtx.GRPCDialNode(remoteAddr, serverNodeID, DefaultClass).Connect(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	clientClock.setAdvancementInterval(
+		maximumPingDurationMult*clientMaxOffset + 1*time.Nanosecond)
+
+	testutils.SucceedsSoon(t, func() error {
+		clientCtx.RemoteClocks.mu.Lock()
+		defer clientCtx.RemoteClocks.mu.Unlock()
+
+		if li, ok := clientCtx.RemoteClocks.mu.latencyInfos[remoteAddr]; !ok {
+			return errors.Errorf("expected to have latencyInfos %s, but it was not", li)
+		}
+		return nil
+	})
+
+	// Close connection to simulate network disruption.
+	err = conn.Close()
+	require.NoError(t, err)
+
+	testutils.SucceedsSoon(t, func() error {
+		clientCtx.RemoteClocks.mu.Lock()
+		defer clientCtx.RemoteClocks.mu.Unlock()
+
+		if li, ok := clientCtx.RemoteClocks.mu.latencyInfos[remoteAddr]; ok {
+			return errors.Errorf("expected to have removed latencyInfos, but found: %s", li)
+		}
+		return nil
+	})
+}
+
 type AdvancingClock struct {
 	syncutil.Mutex
 	time                time.Time


### PR DESCRIPTION
Before, `RemoteClockMonitor` tracked most recent measurements on remote latency from connected node and didn't clean up this info after connection is closed. It led to keeping stale information about latency between nodes even if it doesn't exist anymore. Current change introduces `OnDisconnect` func that is called when heartbeat failed and connection closed.
This change will be necessary for upcoming changes to properly observe network partition between particular nodes.

Release note: None

Related to [CRDB-21710](https://cockroachlabs.atlassian.net/browse/CRDB-21710)
Resolves #95772