### PR TITLE
upgrades: fix TestKeyVisualizerTablesMigration

### DIFF
--- a/pkg/upgrade/upgrades/key_visualizer_migration_test.go
+++ b/pkg/upgrade/upgrades/key_visualizer_migration_test.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/clusterversion"
+	"github.com/cockroachdb/cockroach/pkg/server"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
@@ -38,6 +39,12 @@ func TestKeyVisualizerTablesMigration(t *testing.T) {
 	tc := testcluster.StartTestCluster(t, 1, base.TestClusterArgs{
 		ServerArgs: base.TestServerArgs{
 			Settings: settings,
+			Knobs: base.TestingKnobs{
+				Server: &server.TestingKnobs{
+					DisableAutomaticVersionUpgrade: make(chan struct{}),
+					BinaryVersionOverride:          clusterversion.ByKey(clusterversion.V23_1KeyVisualizerTablesAndJobs - 1),
+				},
+			},
 		},
 	})
 


### PR DESCRIPTION
This test started failing for commits that introduced additional version gates, like in #95748. It's because we were not overriding the binary version the server started off with (it defaults to the last added version). It failed with:

```
  Error Trace:	pkg/upgrade/upgrades/helpers_test.go:67
                pkg/upgrade/upgrades/helpers_test.go:50
                pkg/upgrade/upgrades/key_visualizer_migration_test.go:48
  Error:      	pq: versions cannot be downgraded (attempting to downgrade from 1000022.2-34 to 1000022.2-32)
```

Release note: None