### PR TITLE
changefeedccl: handle changefeed replan with MuxRangefeed; default MuxRangefeed to true

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -134,12 +134,15 @@ func TestChangefeedReplanning(t *testing.T) {
 				DistSQL: &execinfra.TestingKnobs{
 					Changefeed: &TestingKnobs{
 						HandleDistChangefeedError: func(err error) error {
-							select {
-							case errChan <- err:
-								return err
-							default:
-								return nil
+							if errors.Is(err, sql.ErrPlanChanged) {
+								select {
+								case errChan <- err:
+									return err
+								default:
+									return nil
+								}
 							}
+							return nil
 						},
 						ShouldReplan: func(ctx context.Context, oldPlan, newPlan *sql.PhysicalPlan) bool {
 							select {
@@ -1013,13 +1016,11 @@ func TestChangefeedInitialScan(t *testing.T) {
 		for testName, changefeedStmt := range noInitialScanTests {
 			t.Run(testName, func(t *testing.T) {
 				sqlDB.Exec(t, `CREATE TABLE no_initial_scan (a INT PRIMARY KEY)`)
+				defer sqlDB.Exec(t, `DROP TABLE no_initial_scan`)
 				sqlDB.Exec(t, `INSERT INTO no_initial_scan VALUES (1)`)
 
 				noInitialScan := feed(t, f, changefeedStmt)
-				defer func() {
-					closeFeed(t, noInitialScan)
-					sqlDB.Exec(t, `DROP TABLE no_initial_scan`)
-				}()
+				defer closeFeed(t, noInitialScan)
 
 				expectResolvedTimestamp(t, noInitialScan)
 
@@ -1033,15 +1034,14 @@ func TestChangefeedInitialScan(t *testing.T) {
 		for testName, changefeedStmtFormat := range initialScanTests {
 			t.Run(testName, func(t *testing.T) {
 				sqlDB.Exec(t, `CREATE TABLE initial_scan (a INT PRIMARY KEY)`)
+				defer sqlDB.Exec(t, `DROP TABLE initial_scan`)
 				sqlDB.Exec(t, `INSERT INTO initial_scan VALUES (1), (2), (3)`)
 				var tsStr string
 				var i int
 				sqlDB.QueryRow(t, `SELECT count(*), cluster_logical_timestamp() from initial_scan`).Scan(&i, &tsStr)
 				initialScan := feed(t, f, fmt.Sprintf(changefeedStmtFormat, tsStr))
-				defer func() {
-					closeFeed(t, initialScan)
-					sqlDB.Exec(t, `DROP TABLE initial_scan`)
-				}()
+				defer closeFeed(t, initialScan)
+
 				assertPayloads(t, initialScan, []string{
 					`initial_scan: [1]->{"after": {"a": 1}}`,
 					`initial_scan: [2]->{"after": {"a": 2}}`,

--- a/pkg/ccl/changefeedccl/changefeedbase/settings.go
+++ b/pkg/ccl/changefeedccl/changefeedbase/settings.go
@@ -224,7 +224,7 @@ var UseMuxRangeFeed = settings.RegisterBoolSetting(
 	settings.TenantWritable,
 	"changefeed.mux_rangefeed.enabled",
 	"if true, changefeed uses multiplexing rangefeed RPC",
-	false,
+	util.ConstantWithMetamorphicTestBool("changefeed.mux_rangefeed.enabled", false),
 )
 
 // EventConsumerWorkers specifies the maximum number of workers to use when

--- a/pkg/ccl/changefeedccl/helpers_test.go
+++ b/pkg/ccl/changefeedccl/helpers_test.go
@@ -47,6 +47,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util"
+	"github.com/cockroachdb/cockroach/pkg/util/contextutil"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/log/eventpb"
@@ -93,7 +94,10 @@ func readNextMessages(
 		if ctx.Err() != nil {
 			return nil, ctx.Err()
 		}
-		log.Infof(context.Background(), "About to read a message from %v (%T)", f, f)
+		if log.V(1) {
+			log.Infof(context.Background(), "About to read a message (%d out of %d) from %v (%T)",
+				len(actual), numMessages, f, f)
+		}
 		m, err := f.Next()
 		if log.V(1) {
 			if m != nil {
@@ -248,10 +252,17 @@ func assertPayloadsTimeout() time.Duration {
 func withTimeout(
 	f cdctest.TestFeed, timeout time.Duration, fn func(ctx context.Context) error,
 ) error {
-	ctx, cancel := context.WithTimeout(context.Background(), timeout)
-	defer cancel()
-	defer stopFeedWhenDone(ctx, f)()
-	return fn(ctx)
+	var jobID jobspb.JobID
+	if jobFeed, ok := f.(cdctest.EnterpriseTestFeed); ok {
+		jobID = jobFeed.JobID()
+	}
+	return contextutil.RunWithTimeout(context.Background(),
+		fmt.Sprintf("withTimeout-%d", jobID), timeout,
+		func(ctx context.Context) error {
+			defer stopFeedWhenDone(ctx, f)()
+			return fn(ctx)
+		},
+	)
 }
 
 func assertPayloads(t testing.TB, f cdctest.TestFeed, expected []string) {

--- a/pkg/kv/kvclient/kvcoord/BUILD.bazel
+++ b/pkg/kv/kvclient/kvcoord/BUILD.bazel
@@ -70,7 +70,6 @@ go_library(
         "//pkg/util/errorutil/unimplemented",
         "//pkg/util/grpcutil",
         "//pkg/util/hlc",
-        "//pkg/util/intsets",
         "//pkg/util/iterutil",
         "//pkg/util/limit",
         "//pkg/util/log",

--- a/pkg/kv/kvclient/kvcoord/dist_sender_mux_rangefeed.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender_mux_rangefeed.go
@@ -12,13 +12,16 @@ package kvcoord
 
 import (
 	"context"
+	"sync"
 
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/rpc"
 	"github.com/cockroachdb/cockroach/pkg/util/ctxgroup"
-	"github.com/cockroachdb/cockroach/pkg/util/intsets"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/pprofutil"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
-	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+	"github.com/cockroachdb/logtags"
 )
 
 // rangefeedMuxer is responsible for coordination and management of mux
@@ -31,32 +34,38 @@ type rangefeedMuxer struct {
 	// Context group controlling execution of MuxRangeFeed calls.
 	g ctxgroup.Group
 
-	// State pertaining to actively executing MuxRangeFeeds.
-	mu struct {
+	mux struct {
+		// lock used to coordinate establishment and tear down of client connections.
 		syncutil.Mutex
-
-		// terminalErr set when a terminal error occurs.
-		// Subsequent calls to startMuxRangeFeed will return this error.
-		terminalErr error
 
 		// Each call to start new range feed gets a unique ID which is echoed back
 		// by MuxRangeFeed rpc.  This is done as a safety mechanism to make sure
 		// that we always send the event to the correct consumer -- even if the
 		// range feed is terminated and re-established rapidly.
 		nextStreamID int64
+		connectDone  chan error // Channel to communicate connect attempt completion.
 
-		// muxClient contains a nodeID->MuxRangeFeedClient.
-		muxClients map[roachpb.NodeID]*muxClientState
-		// producers maps streamID to the event producer -- data sent back to the
-		// consumer of range feed events.
-		producers map[int64]*channelRangeFeedEventProducer
+		// map of active MuxRangeFeed clients.
+		clients map[roachpb.NodeID]*muxClientState
 	}
+
+	// producers is a map of all rangefeeds running across all nodes.
+	// streamID -> *channelRangeFeedEventProducer.
+	producers sync.Map
 }
 
+// muxClientState is the state maintain for each MuxRangeFeed rpc.
+// Thread safe.
 type muxClientState struct {
-	client  roachpb.Internal_MuxRangeFeedClient
-	streams intsets.Fast
-	cancel  context.CancelFunc
+	// RPC state.
+	client roachpb.Internal_MuxRangeFeedClient
+	cancel context.CancelFunc
+
+	done    chan struct{} // Signaled to indicate MuxRangeFeed shutdown.
+	recvErr error         // Set when shutdown.
+
+	// Number of consumers (ranges) running on this node; accessed under rangefeedMuxer lock.
+	numStreams int
 }
 
 func newRangefeedMuxer(g ctxgroup.Group) *rangefeedMuxer {
@@ -64,9 +73,7 @@ func newRangefeedMuxer(g ctxgroup.Group) *rangefeedMuxer {
 		eventCh: make(chan *roachpb.MuxRangeFeedEvent),
 		g:       g,
 	}
-	m.mu.muxClients = make(map[roachpb.NodeID]*muxClientState)
-	m.mu.producers = make(map[int64]*channelRangeFeedEventProducer)
-
+	m.mux.clients = make(map[roachpb.NodeID]*muxClientState)
 	m.g.GoCtx(m.demuxLoop)
 
 	return m
@@ -75,214 +82,205 @@ func newRangefeedMuxer(g ctxgroup.Group) *rangefeedMuxer {
 // channelRangeFeedEventProducer is a rangeFeedEventProducer which receives
 // events on input channel, and returns events when Recv is called.
 type channelRangeFeedEventProducer struct {
-	ctx       context.Context
-	termErrCh chan struct{} // Signalled to propagate terminal error the consumer.
-	termErr   error         // Set when terminal error occurs.
-	eventCh   chan *roachpb.RangeFeedEvent
+	ctx      context.Context
+	termCtx  terminationContext           // node mux rangefeed termination context.
+	streamID int64                        // stream ID for this producer.
+	eventCh  chan *roachpb.RangeFeedEvent // consumer event channel.
 }
+
+var _ roachpb.RangeFeedEventProducer = (*channelRangeFeedEventProducer)(nil)
 
 // Recv implements rangeFeedEventProducer interface.
 func (c *channelRangeFeedEventProducer) Recv() (*roachpb.RangeFeedEvent, error) {
 	select {
 	case <-c.ctx.Done():
 		return nil, c.ctx.Err()
-	case <-c.termErrCh:
-		return nil, c.termErr
+	case <-c.termCtx.Done():
+		return nil, c.termCtx.Err()
 	case e := <-c.eventCh:
 		return e, nil
 	}
 }
-
-var _ roachpb.RangeFeedEventProducer = (*channelRangeFeedEventProducer)(nil)
 
 // startMuxRangeFeed begins the execution of rangefeed for the specified
 // RangeFeedRequest.
 // The passed in client is only needed to establish MuxRangeFeed RPC.
 func (m *rangefeedMuxer) startMuxRangeFeed(
 	ctx context.Context, client rpc.RestrictedInternalClient, req *roachpb.RangeFeedRequest,
-) (_ roachpb.RangeFeedEventProducer, cleanup func(), _ error) {
-	producer, rpcClient, streamID, cleanup, err := m.connect(ctx, client, req.Replica.NodeID)
-	if err != nil {
-		return nil, cleanup, err
+) (_ roachpb.RangeFeedEventProducer, _ func(), err error) {
+	// Grab a lock for the duration of connection setup.
+	m.mux.Lock()
+	defer m.mux.Unlock()
+
+	ms, found := m.mux.clients[req.Replica.NodeID]
+	if !found {
+		// Establish new MuxRangefeed for this node.
+		ms, err = m.startNodeMuxRangeFeed(client, req.Replica.NodeID)
+		if err != nil {
+			return nil, nil, err
+		}
+		m.mux.clients[req.Replica.NodeID] = ms
 	}
-	req.StreamID = streamID
-	if err := rpcClient.Send(req); err != nil {
-		return nil, cleanup, err
+
+	ms.numStreams++
+	m.mux.nextStreamID++
+	req.StreamID = m.mux.nextStreamID
+
+	streamCtx := logtags.AddTag(ctx, "stream", req.StreamID)
+	producer := &channelRangeFeedEventProducer{
+		ctx:      streamCtx,
+		termCtx:  ms,
+		streamID: req.StreamID,
+		eventCh:  make(chan *roachpb.RangeFeedEvent),
+	}
+	m.producers.Store(req.StreamID, producer)
+
+	if log.V(1) {
+		log.Info(streamCtx, "starting rangefeed")
+	}
+
+	cleanup := func() {
+		m.producers.Delete(req.StreamID)
+
+		m.mux.Lock()
+		defer m.mux.Unlock()
+
+		ms.numStreams--
+		if ms.numStreams == 0 {
+			delete(m.mux.clients, req.Replica.NodeID)
+			if log.V(1) {
+				log.InfofDepth(streamCtx, 1, "shut down inactive mux for node %d", req.Replica.NodeID)
+			}
+			ms.cancel()
+		}
+	}
+
+	if err := ms.client.Send(req); err != nil {
+		cleanup()
+		return nil, nil, err
 	}
 	return producer, cleanup, nil
 }
 
-// connect establishes MuxRangeFeed connection for the specified node, re-using
-// the existing one if one exists. Returns event producer, RPC client to send
-// requests on, the streamID which should be used when sending request, and a
-// cleanup function. Cleanup function never nil, and must always be invoked,
-// even if error is returned.
-func (m *rangefeedMuxer) connect(
-	ctx context.Context, client rpc.RestrictedInternalClient, nodeID roachpb.NodeID,
-) (
-	_ roachpb.RangeFeedEventProducer,
-	_ roachpb.Internal_MuxRangeFeedClient,
-	streamID int64,
-	cleanup func(),
-	_ error,
-) {
-	m.mu.Lock()
-	defer m.mu.Unlock()
+// startNodeMuxRangeFeed establishes MuxRangeFeed RPC with the node.
+// Runs under mux lock.
+func (m *rangefeedMuxer) startNodeMuxRangeFeed(
+	client rpc.RestrictedInternalClient, nodeID roachpb.NodeID,
+) (*muxClientState, error) {
+	if m.mux.connectDone == nil {
+		m.mux.connectDone = make(chan error, 1)
+	}
 
-	streamID = m.mu.nextStreamID
-	m.mu.nextStreamID++
+	ms := &muxClientState{done: make(chan struct{})}
 
-	cleanup = func() {
-		m.mu.Lock()
-		defer m.mu.Unlock()
+	// It is important that we start MuxRangeFeed RPC using long-lived
+	// context available in the main context group used for this muxer.
+	m.g.GoCtx(func(ctx context.Context) (err error) {
+		ctx = logtags.AddTag(ctx, "mux_n", nodeID)
+		// Add "generation" number to the context so that log messages and stacks can
+		// differentiate between multiple instances of mux rangefeed Go routine
+		// (this can happen when one was shutdown, then re-established).
+		ctx = logtags.AddTag(ctx, "gen", ms)
+		ctx, restore := pprofutil.SetProfilerLabelsFromCtxTags(ctx)
+		defer restore()
 
-		delete(m.mu.producers, streamID)
-		// Cleanup mux state if it exists; it may be nil if this function exits
-		// early (for example if MuxRangeFeed call fails, before muxState
-		// initialized).
-		muxState := m.mu.muxClients[nodeID]
-		if muxState != nil {
-			muxState.streams.Remove(int(streamID))
-			if muxState.streams.Len() == 0 {
-				// This node no longer has any active streams.
-				// Delete node from the muxClient list, and gracefully
-				// shutdown consumer go routine.
-				delete(m.mu.muxClients, nodeID)
-				muxState.cancel()
-			}
+		if log.V(1) {
+			log.Info(ctx, "Establishing MuxRangeFeed")
+			start := timeutil.Now()
+			defer func() {
+				log.Infof(ctx, "MuxRangeFeed terminating with recvErr=%v after %s", err, timeutil.Since(start))
+			}()
 		}
-	}
 
-	if m.mu.terminalErr != nil {
-		return nil, nil, streamID, cleanup, m.mu.terminalErr
-	}
+		ctx, ms.cancel = context.WithCancel(ctx)
+		defer ms.cancel()
 
-	var found bool
-	ms, found := m.mu.muxClients[nodeID]
-
-	if !found {
-		ctx, cancel := context.WithCancel(ctx)
-		stream, err := client.MuxRangeFeed(ctx)
+		ms.client, err = client.MuxRangeFeed(ctx)
+		m.mux.connectDone <- err
 		if err != nil {
-			cancel()
-			return nil, nil, streamID, cleanup, err
+			return err
 		}
+		return ms.receiveEvents(ctx, m.eventCh)
+	})
 
-		ms = &muxClientState{client: stream, cancel: cancel}
-		m.mu.muxClients[nodeID] = ms
-		m.g.GoCtx(func(ctx context.Context) error {
-			defer cancel()
-			return m.receiveEventsFromNode(ctx, nodeID, stream)
-		})
-	}
-
-	// Start RangeFeed for this request.
-	ms.streams.Add(int(streamID))
-
-	producer := &channelRangeFeedEventProducer{
-		ctx:       ctx,
-		termErrCh: make(chan struct{}),
-		eventCh:   make(chan *roachpb.RangeFeedEvent),
-	}
-	m.mu.producers[streamID] = producer
-	return producer, ms.client, streamID, cleanup, nil
+	return ms, <-m.mux.connectDone
 }
 
 // demuxLoop de-multiplexes events and sends them to appropriate rangefeed event
 // consumer.
-func (m *rangefeedMuxer) demuxLoop(ctx context.Context) error {
+func (m *rangefeedMuxer) demuxLoop(ctx context.Context) (retErr error) {
 	for {
 		select {
 		case <-ctx.Done():
 			return ctx.Err()
 		case e := <-m.eventCh:
-			m.mu.Lock()
-			producer, found := m.mu.producers[e.StreamID]
-			m.mu.Unlock()
+			var producer *channelRangeFeedEventProducer
+			if v, found := m.producers.Load(e.StreamID); found {
+				producer = v.(*channelRangeFeedEventProducer)
+			}
 
-			if !found {
-				return m.shutdownWithError(errors.AssertionFailedf(
-					"expected to find consumer for streamID=%d", e.StreamID),
-				)
+			// The stream may already have terminated (either producer is nil, or
+			// producer.termCtx.Done()). That's fine -- we may have encountered range
+			// split or similar rangefeed error, causing the caller to exit (and
+			// terminate this stream), but the server side stream termination is async
+			// and probabilistic (rangefeed registration output loop may have a
+			// checkpoint event available, *and* it may have context cancellation, but
+			// which one executes is a coin flip) and so it is possible that we may
+			// see additional event(s) arriving for a stream that is no longer active.
+			if producer == nil {
+				if log.V(1) {
+					log.Infof(ctx, "received stray event stream %d: %v", e.StreamID, e)
+				}
+				continue
 			}
 
 			select {
 			case <-ctx.Done():
 				return ctx.Err()
 			case producer.eventCh <- &e.RangeFeedEvent:
+			case <-producer.termCtx.Done():
+				if log.V(1) {
+					log.Infof(ctx, "received stray event stream %d: %v", e.StreamID, e)
+				}
 			}
 		}
 	}
 }
 
-// receiveEventsFromNode receives mux rangefeed events, and forwards them to the
-// consumer channel.
-func (m *rangefeedMuxer) receiveEventsFromNode(
-	ctx context.Context, nodeID roachpb.NodeID, stream roachpb.Internal_MuxRangeFeedClient,
+// terminationContext (inspired by context.Context) describes
+// termination information.
+type terminationContext interface {
+	Done() <-chan struct{}
+	Err() error
+}
+
+// receiveEvents receives mux rangefeed events, and forwards them to the consumer channel.
+func (s *muxClientState) receiveEvents(
+	ctx context.Context, eventCh chan<- *roachpb.MuxRangeFeedEvent,
 ) error {
 	for {
-		event, streamErr := stream.Recv()
+		event, streamErr := s.client.Recv()
 
 		if streamErr != nil {
-			m.propagateStreamTerminationErrorToConsumers(nodeID, streamErr)
-			// Since the stream error is handled above, we return nil to gracefully shut down
-			// this go routine.
+			s.recvErr = streamErr
+			close(s.done)
+			// Since the stream error is handled above, we return nil to gracefully
+			// shut down this go routine.
 			return nil //nolint:returnerrcheck
 		}
 
 		select {
 		case <-ctx.Done():
 			return ctx.Err()
-		case m.eventCh <- event:
+		case eventCh <- event:
 		}
 	}
 }
 
-// propagateStreamTerminationErrorToConsumers called when mux stream running on
-// a node encountered an error.  All consumers will receive the stream
-// termination error and will handle it appropriately.
-func (m *rangefeedMuxer) propagateStreamTerminationErrorToConsumers(
-	nodeID roachpb.NodeID, streamErr error,
-) {
-	// Grab muxStream associated with the node, and clear it out.
-	m.mu.Lock()
-	defer m.mu.Unlock()
-
-	ms, streamFound := m.mu.muxClients[nodeID]
-	delete(m.mu.muxClients, nodeID)
-	// Note: it's okay if the stream is not found; this can happen if the
-	// nodeID was already removed from muxClients because we're trying to gracefully
-	// shutdown receiveEventsFromNode go routine.
-	if streamFound {
-		ms.streams.ForEach(func(streamID int) {
-			p := m.mu.producers[int64(streamID)]
-			delete(m.mu.producers, int64(streamID))
-			if p != nil {
-				p.termErr = streamErr
-				close(p.termErrCh)
-			}
-		})
-	}
-
+func (s *muxClientState) Done() <-chan struct{} {
+	return s.done
 }
 
-// shutdownWithError terminates this rangefeedMuxer with a terminal error
-// (usually an assertion failure).  It's a bit unwieldy way to propagate this
-// error to the caller, but as soon as  one of consumers notices this terminal
-// error, the context should be cancelled.
-// Returns the terminal error passed in.
-func (m *rangefeedMuxer) shutdownWithError(terminalErr error) error {
-	// Okay to run this under the lock since as soon as a consumer sees this terminal
-	// error, the whole rangefeed should terminate.
-	m.mu.Lock()
-	defer m.mu.Unlock()
-
-	m.mu.terminalErr = terminalErr
-	for id, p := range m.mu.producers {
-		p.termErr = terminalErr
-		close(p.termErrCh)
-		delete(m.mu.producers, id)
-	}
-
-	return terminalErr
+func (s *muxClientState) Err() error {
+	return s.recvErr
 }


### PR DESCRIPTION
Flip `changefeed.mux_rangefeed.enabled` to true to have changefeeds use MuxRangefeed RPC.

Fixes #95781

Release note (enterprise change): Changefeed use MuxRangefeed RPC, which improves changefeed scalability.