### PR TITLE
testlogic: deflake new_schema_changer test case

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/new_schema_changer
+++ b/pkg/sql/logictest/testdata/logic_test/new_schema_changer
@@ -1091,7 +1091,8 @@ DROP VIEW v1ev CASCADE;
 
 query IT
 SELECT "reportingID", info::JSONB - 'Timestamp' - 'DescriptorID'
-FROM system.eventlog;
+FROM system.eventlog
+ORDER BY "timestamp", info DESC
 ----
 1  {"CascadeDroppedViews": ["test.public.v4ev"], "EventType": "drop_view", "Statement": "DROP VIEW test.public.v1ev CASCADE", "Tag": "DROP VIEW", "User": "root", "ViewName": "test.public.v1ev"}
 1  {"EventType": "finish_schema_change", "InstanceID": 1}


### PR DESCRIPTION
The expected output of a system.eventlog query was rewritten in e333a39c7e106f11c7f87968d6b37e9b5dee0c95 with more than one record but the query was missing an ORDER clause, leading to non-deterministic output. This commit fixes this by adding the missing ORDER clause.

Fixes #95825.

Release note: None