### PR TITLE
roachtest: better logging of GitHub-related logic

### DIFF
--- a/pkg/cmd/bazci/githubpost/BUILD.bazel
+++ b/pkg/cmd/bazci/githubpost/BUILD.bazel
@@ -11,6 +11,7 @@ go_library(
         "//pkg/cmd/internal/issues",
         "//pkg/internal/codeowners",
         "//pkg/internal/team",
+        "//pkg/roachprod/logger",
         "@com_github_cockroachdb_errors//:errors",
     ],
 )

--- a/pkg/cmd/bazci/githubpost/githubpost.go
+++ b/pkg/cmd/bazci/githubpost/githubpost.go
@@ -38,6 +38,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/cmd/internal/issues"
 	"github.com/cockroachdb/cockroach/pkg/internal/codeowners"
 	"github.com/cockroachdb/cockroach/pkg/internal/team"
+	"github.com/cockroachdb/cockroach/pkg/roachprod/logger"
 	"github.com/cockroachdb/errors"
 )
 
@@ -95,7 +96,11 @@ func getIssueFilerForFormatter(formatterName string) func(ctx context.Context, f
 
 	return func(ctx context.Context, f failure) error {
 		fmter, req := reqFromFailure(ctx, f)
-		return issues.Post(ctx, fmter, req)
+		l, err := logger.RootLogger("", false)
+		if err != nil {
+			return err
+		}
+		return issues.Post(ctx, l, fmter, req)
 	}
 }
 

--- a/pkg/cmd/internal/issues/BUILD.bazel
+++ b/pkg/cmd/internal/issues/BUILD.bazel
@@ -12,6 +12,7 @@ go_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/cmd/internal/issues",
     visibility = ["//pkg/cmd:__subpackages__"],
     deps = [
+        "//pkg/roachprod/logger",
         "//pkg/util/version",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_google_go_github//github",
@@ -31,6 +32,7 @@ go_test(
     data = glob(["testdata/**"]),
     embed = [":issues"],
     deps = [
+        "//pkg/roachprod/logger",
         "//pkg/testutils/datapathutils",
         "//pkg/testutils/skip",
         "@com_github_cockroachdb_datadriven//:datadriven",

--- a/pkg/cmd/roachtest/BUILD.bazel
+++ b/pkg/cmd/roachtest/BUILD.bazel
@@ -75,6 +75,7 @@ go_test(
     args = ["-test.timeout=55s"],
     embed = [":roachtest_lib"],
     deps = [
+        "//pkg/cmd/internal/issues",
         "//pkg/cmd/roachtest/cluster",
         "//pkg/cmd/roachtest/option",
         "//pkg/cmd/roachtest/registry",

--- a/pkg/cmd/roachtest/github.go
+++ b/pkg/cmd/roachtest/github.go
@@ -29,7 +29,7 @@ type githubIssues struct {
 	l            *logger.Logger
 	cluster      *clusterImpl
 	vmCreateOpts *vm.CreateOpts
-	issuePoster  func(ctx context.Context, formatter issues.IssueFormatter, req issues.PostRequest) error
+	issuePoster  func(context.Context, *logger.Logger, issues.IssueFormatter, issues.PostRequest) error
 	teamLoader   func() (team.Map, error)
 }
 
@@ -59,13 +59,55 @@ func roachtestPrefix(p string) string {
 	return "ROACHTEST_" + p
 }
 
-func (g *githubIssues) shouldPost(t test.Test) bool {
-	opts := issues.DefaultOptionsFromEnv()
-	return !g.disable && opts.CanPost() &&
-		opts.IsReleaseBranch() &&
-		t.Spec().(*registry.TestSpec).Run != nil &&
-		// NB: check NodeCount > 0 to avoid posting issues from this pkg's unit tests.
-		t.Spec().(*registry.TestSpec).Cluster.NodeCount > 0
+// postIssueCondition encapsulates a condition that causes issue
+// posting to be skipped. The `reason` field contains a textual
+// description as to why issue posting was skipped.
+type postIssueCondition struct {
+	cond   func(g *githubIssues, t test.Test) bool
+	reason string
+}
+
+var defaultOpts = issues.DefaultOptionsFromEnv()
+
+var skipConditions = []postIssueCondition{
+	{
+		cond:   func(g *githubIssues, _ test.Test) bool { return g.disable },
+		reason: "issue posting was disabled via command line flag",
+	},
+	{
+		cond:   func(g *githubIssues, _ test.Test) bool { return !defaultOpts.CanPost() },
+		reason: "GitHub API token not set",
+	},
+	{
+		cond:   func(g *githubIssues, _ test.Test) bool { return !defaultOpts.IsReleaseBranch() },
+		reason: fmt.Sprintf("not a release branch: %q", defaultOpts.Branch),
+	},
+	{
+		cond:   func(_ *githubIssues, t test.Test) bool { return t.Spec().(*registry.TestSpec).Run == nil },
+		reason: "TestSpec.Run is nil",
+	},
+	{
+		cond:   func(_ *githubIssues, t test.Test) bool { return t.Spec().(*registry.TestSpec).Cluster.NodeCount == 0 },
+		reason: "Cluster.NodeCount is zero",
+	},
+}
+
+// shouldPost two values: whether GitHub posting should happen, and a
+// reason for skipping (non-empty only when posting should *not*
+// happen).
+func (g *githubIssues) shouldPost(t test.Test) (bool, string) {
+	post := true
+	var reason string
+
+	for _, sc := range skipConditions {
+		if sc.cond(g, t) {
+			post = false
+			reason = sc.reason
+			break
+		}
+	}
+
+	return post, reason
 }
 
 func (g *githubIssues) createPostRequest(
@@ -160,7 +202,9 @@ func (g *githubIssues) createPostRequest(
 }
 
 func (g *githubIssues) MaybePost(t *testImpl, message string) error {
-	if !g.shouldPost(t) {
+	doPost, skipReason := g.shouldPost(t)
+	if !doPost {
+		g.l.Printf("skipping GitHub issue posting (%s)", skipReason)
 		return nil
 	}
 
@@ -176,6 +220,7 @@ func (g *githubIssues) MaybePost(t *testImpl, message string) error {
 
 	return g.issuePoster(
 		context.Background(),
+		g.l,
 		issues.UnitTestFormatter,
 		g.createPostRequest(t, cat, message),
 	)

--- a/pkg/roachprod/logger/log.go
+++ b/pkg/roachprod/logger/log.go
@@ -99,7 +99,7 @@ type Logger struct {
 // If path is empty, logs will go to stdout/Stderr.
 func (cfg *Config) NewLogger(path string) (*Logger, error) {
 	if path == "" {
-		// Log to os.Stdout/Stderr is no other options are passed in.
+		// Log to os.Stdout/Stderr if no other options are passed in.
 		stdout := cfg.Stdout
 		if stdout == nil {
 			stdout = os.Stdout


### PR DESCRIPTION
Whenever a roachtest fails on a release branch, we should either create a new issue with the failure, or comment on an existing issue. However, the logic to decide when to create an issue and the creation process itself are relatively complex. If a roachtest fails on a nightly build and we don't get a corresponding issue, there's no way to understand _why_ that happened: issue posting could have been mistakenly skipped, or maybe an error creating the issue was swallowed in the process.

This commit adds appropriate logging to the GitHub issue poster: if issue creation is skipped, the corresponding reason is logged; in addition, any errors encountered in the process of creating the issue/comment are also logged.

Epic: None

Release note: None