### PR TITLE
cdc: remove 'nonsensitive' tag from changefeed description in telemetry logs

### DIFF
--- a/docs/generated/eventlog.md
+++ b/docs/generated/eventlog.md
@@ -2697,7 +2697,7 @@ was triggered.
 
 | Field | Description | Sensitive |
 |--|--|--|
-| `Description` | The description of that would show up in the job's description field, redacted | no |
+| `Description` | The description of that would show up in the job's description field, redacted | yes |
 | `SinkType` | The type of sink being emitted to (ex: kafka, nodelocal, webhook-https). | no |
 | `NumTables` | The number of tables listed in the query that the changefeed is to run on. | no |
 | `Resolved` | The behavior of emitted resolved spans (ex: yes, no, 10s) | no |
@@ -2717,7 +2717,7 @@ ChangefeedFailed events.
 
 | Field | Description | Sensitive |
 |--|--|--|
-| `Description` | The description of that would show up in the job's description field, redacted | no |
+| `Description` | The description of that would show up in the job's description field, redacted | yes |
 | `SinkType` | The type of sink being emitted to (ex: kafka, nodelocal, webhook-https). | no |
 | `NumTables` | The number of tables listed in the query that the changefeed is to run on. | no |
 | `Resolved` | The behavior of emitted resolved spans (ex: yes, no, 10s) | no |

--- a/pkg/util/log/eventpb/events.proto
+++ b/pkg/util/log/eventpb/events.proto
@@ -82,7 +82,7 @@ message CommonChangefeedEventDetails {
   CommonEventDetails common = 1 [(gogoproto.nullable) = false, (gogoproto.jsontag) = "", (gogoproto.embed) = true];
 
   // The description of that would show up in the job's description field, redacted
-  string description = 2 [(gogoproto.jsontag) = ",omitempty", (gogoproto.moretags) =  "redact:\"nonsensitive\""];
+  string description = 2 [(gogoproto.jsontag) = ",omitempty"];
 
   // The type of sink being emitted to (ex: kafka, nodelocal, webhook-https).
   string sink_type = 3 [(gogoproto.jsontag) = ",omitempty", (gogoproto.moretags) =  "redact:\"nonsensitive\""];

--- a/pkg/util/log/eventpb/json_encode_generated.go
+++ b/pkg/util/log/eventpb/json_encode_generated.go
@@ -1427,7 +1427,9 @@ func (m *CommonChangefeedEventDetails) AppendJSONFields(printComma bool, b redac
 		}
 		printComma = true
 		b = append(b, "\"Description\":\""...)
-		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(m.Description)))
+		b = append(b, redact.StartMarker()...)
+		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(redact.EscapeMarkers([]byte(m.Description)))))
+		b = append(b, redact.EndMarker()...)
 		b = append(b, '"')
 	}
 


### PR DESCRIPTION
Previously, the description field in changefeed telemetry logs was marked as `nonsensitive`. This is incorrect because the description field may contain an SQL statement which is not safe to report. This change removes the `nonsensitive` tag so the field is redacted by default.

Fixes: https://github.com/cockroachdb/cockroach/issues/95823
Epic: none
Release note: none