### PR TITLE
logictest: remove smallEngineBlocks randomization

### DIFF
--- a/pkg/ccl/sqlitelogictestccl/tests/3node-tenant/generated_test.go
+++ b/pkg/ccl/sqlitelogictestccl/tests/3node-tenant/generated_test.go
@@ -70,12 +70,10 @@ func runSqliteLogicTest(t *testing.T, file string) {
 	// SQLLite logic tests can be very memory intensive, so we give them larger
 	// limit than other logic tests get. Also some of the 'delete' files become
 	// extremely slow when MVCC range tombstones are enabled for point deletes,
-	// so we disable that. Similarly, some of the 'view' files are too slow
-	// when small engine blocks are enabled.
+	// so we disable that.
 	serverArgs := logictest.TestServerArgs{
 		MaxSQLMemoryLimit: 512 << 20, // 512 MiB
 		DisableUseMVCCRangeTombstonesForPointDeletes: true,
-		DisableSmallEngineBlocks:                     true,
 		// Some sqlite tests with very low bytes limit value are too slow, so
 		// ensure 3 KiB lower bound.
 		BatchBytesLimitLowerBound: 3 << 10, // 3 KiB

--- a/pkg/cmd/generate-logictest/templates.go
+++ b/pkg/cmd/generate-logictest/templates.go
@@ -90,12 +90,10 @@ func runSqliteLogicTest(t *testing.T, file string) {
 	// SQLLite logic tests can be very memory intensive, so we give them larger
 	// limit than other logic tests get. Also some of the 'delete' files become
 	// extremely slow when MVCC range tombstones are enabled for point deletes,
-	// so we disable that. Similarly, some of the 'view' files are too slow
-	// when small engine blocks are enabled.
+	// so we disable that.
 	serverArgs := logictest.TestServerArgs{
 		MaxSQLMemoryLimit: 512 << 20, // 512 MiB
 		DisableUseMVCCRangeTombstonesForPointDeletes: true,
-		DisableSmallEngineBlocks:                     true,
 		// Some sqlite tests with very low bytes limit value are too slow, so
 		// ensure 3 KiB lower bound.
 		BatchBytesLimitLowerBound: 3 << 10, // 3 KiB

--- a/pkg/sql/logictest/logic.go
+++ b/pkg/sql/logictest/logic.go
@@ -565,10 +565,6 @@ var (
 	useMVCCRangeTombstonesForPointDeletes = util.ConstantWithMetamorphicTestBool(
 		"logictest-use-mvcc-range-tombstones-for-point-deletes", false)
 
-	// smallEngineBlocks configures Pebble with a block size of 1 byte, to provoke
-	// bugs in time-bound iterators.
-	smallEngineBlocks = util.ConstantWithMetamorphicTestBool("logictest-small-engine-blocks", false)
-
 	// BackupRestoreProbability is the environment variable for `3node-backup` config.
 	backupRestoreProbability = envutil.EnvOrDefaultFloat64("COCKROACH_LOGIC_TEST_BACKUP_RESTORE_PROBABILITY", 0.0)
 )
@@ -1328,7 +1324,6 @@ func (t *logicTest) newCluster(
 	shouldUseMVCCRangeTombstonesForPointDeletes := useMVCCRangeTombstonesForPointDeletes && !serverArgs.DisableUseMVCCRangeTombstonesForPointDeletes
 	ignoreMVCCRangeTombstoneErrors := supportsMVCCRangeTombstones &&
 		(globalMVCCRangeTombstone || shouldUseMVCCRangeTombstonesForPointDeletes)
-	useSmallEngineBlocks := smallEngineBlocks && !serverArgs.DisableSmallEngineBlocks
 
 	params := base.TestClusterArgs{
 		ServerArgs: base.TestServerArgs{
@@ -1347,7 +1342,6 @@ func (t *logicTest) newCluster(
 						UseRangeTombstonesForPointDeletes: supportsMVCCRangeTombstones &&
 							shouldUseMVCCRangeTombstonesForPointDeletes,
 					},
-					SmallEngineBlocks: useSmallEngineBlocks,
 				},
 				SQLEvalContext: &eval.TestingKnobs{
 					AssertBinaryExprReturnTypes:     true,
@@ -4054,9 +4048,6 @@ type TestServerArgs struct {
 	// If set, then we will disable the metamorphic randomization of
 	// useMVCCRangeTombstonesForPointDeletes variable.
 	DisableUseMVCCRangeTombstonesForPointDeletes bool
-	// If set, then we will disable the metamorphic randomization of
-	// smallEngineBlocks variable.
-	DisableSmallEngineBlocks bool
 	// If positive, it provides a lower bound for the default-batch-bytes-limit
 	// metamorphic constant.
 	BatchBytesLimitLowerBound int64

--- a/pkg/sql/sqlitelogictest/tests/fakedist-disk/generated_test.go
+++ b/pkg/sql/sqlitelogictest/tests/fakedist-disk/generated_test.go
@@ -70,12 +70,10 @@ func runSqliteLogicTest(t *testing.T, file string) {
 	// SQLLite logic tests can be very memory intensive, so we give them larger
 	// limit than other logic tests get. Also some of the 'delete' files become
 	// extremely slow when MVCC range tombstones are enabled for point deletes,
-	// so we disable that. Similarly, some of the 'view' files are too slow
-	// when small engine blocks are enabled.
+	// so we disable that.
 	serverArgs := logictest.TestServerArgs{
 		MaxSQLMemoryLimit: 512 << 20, // 512 MiB
 		DisableUseMVCCRangeTombstonesForPointDeletes: true,
-		DisableSmallEngineBlocks:                     true,
 		// Some sqlite tests with very low bytes limit value are too slow, so
 		// ensure 3 KiB lower bound.
 		BatchBytesLimitLowerBound: 3 << 10, // 3 KiB

--- a/pkg/sql/sqlitelogictest/tests/fakedist-vec-off/generated_test.go
+++ b/pkg/sql/sqlitelogictest/tests/fakedist-vec-off/generated_test.go
@@ -70,12 +70,10 @@ func runSqliteLogicTest(t *testing.T, file string) {
 	// SQLLite logic tests can be very memory intensive, so we give them larger
 	// limit than other logic tests get. Also some of the 'delete' files become
 	// extremely slow when MVCC range tombstones are enabled for point deletes,
-	// so we disable that. Similarly, some of the 'view' files are too slow
-	// when small engine blocks are enabled.
+	// so we disable that.
 	serverArgs := logictest.TestServerArgs{
 		MaxSQLMemoryLimit: 512 << 20, // 512 MiB
 		DisableUseMVCCRangeTombstonesForPointDeletes: true,
-		DisableSmallEngineBlocks:                     true,
 		// Some sqlite tests with very low bytes limit value are too slow, so
 		// ensure 3 KiB lower bound.
 		BatchBytesLimitLowerBound: 3 << 10, // 3 KiB

--- a/pkg/sql/sqlitelogictest/tests/fakedist/generated_test.go
+++ b/pkg/sql/sqlitelogictest/tests/fakedist/generated_test.go
@@ -70,12 +70,10 @@ func runSqliteLogicTest(t *testing.T, file string) {
 	// SQLLite logic tests can be very memory intensive, so we give them larger
 	// limit than other logic tests get. Also some of the 'delete' files become
 	// extremely slow when MVCC range tombstones are enabled for point deletes,
-	// so we disable that. Similarly, some of the 'view' files are too slow
-	// when small engine blocks are enabled.
+	// so we disable that.
 	serverArgs := logictest.TestServerArgs{
 		MaxSQLMemoryLimit: 512 << 20, // 512 MiB
 		DisableUseMVCCRangeTombstonesForPointDeletes: true,
-		DisableSmallEngineBlocks:                     true,
 		// Some sqlite tests with very low bytes limit value are too slow, so
 		// ensure 3 KiB lower bound.
 		BatchBytesLimitLowerBound: 3 << 10, // 3 KiB

--- a/pkg/sql/sqlitelogictest/tests/local-legacy-schema-changer/generated_test.go
+++ b/pkg/sql/sqlitelogictest/tests/local-legacy-schema-changer/generated_test.go
@@ -70,12 +70,10 @@ func runSqliteLogicTest(t *testing.T, file string) {
 	// SQLLite logic tests can be very memory intensive, so we give them larger
 	// limit than other logic tests get. Also some of the 'delete' files become
 	// extremely slow when MVCC range tombstones are enabled for point deletes,
-	// so we disable that. Similarly, some of the 'view' files are too slow
-	// when small engine blocks are enabled.
+	// so we disable that.
 	serverArgs := logictest.TestServerArgs{
 		MaxSQLMemoryLimit: 512 << 20, // 512 MiB
 		DisableUseMVCCRangeTombstonesForPointDeletes: true,
-		DisableSmallEngineBlocks:                     true,
 		// Some sqlite tests with very low bytes limit value are too slow, so
 		// ensure 3 KiB lower bound.
 		BatchBytesLimitLowerBound: 3 << 10, // 3 KiB

--- a/pkg/sql/sqlitelogictest/tests/local-vec-off/generated_test.go
+++ b/pkg/sql/sqlitelogictest/tests/local-vec-off/generated_test.go
@@ -70,12 +70,10 @@ func runSqliteLogicTest(t *testing.T, file string) {
 	// SQLLite logic tests can be very memory intensive, so we give them larger
 	// limit than other logic tests get. Also some of the 'delete' files become
 	// extremely slow when MVCC range tombstones are enabled for point deletes,
-	// so we disable that. Similarly, some of the 'view' files are too slow
-	// when small engine blocks are enabled.
+	// so we disable that.
 	serverArgs := logictest.TestServerArgs{
 		MaxSQLMemoryLimit: 512 << 20, // 512 MiB
 		DisableUseMVCCRangeTombstonesForPointDeletes: true,
-		DisableSmallEngineBlocks:                     true,
 		// Some sqlite tests with very low bytes limit value are too slow, so
 		// ensure 3 KiB lower bound.
 		BatchBytesLimitLowerBound: 3 << 10, // 3 KiB

--- a/pkg/sql/sqlitelogictest/tests/local/generated_test.go
+++ b/pkg/sql/sqlitelogictest/tests/local/generated_test.go
@@ -70,12 +70,10 @@ func runSqliteLogicTest(t *testing.T, file string) {
 	// SQLLite logic tests can be very memory intensive, so we give them larger
 	// limit than other logic tests get. Also some of the 'delete' files become
 	// extremely slow when MVCC range tombstones are enabled for point deletes,
-	// so we disable that. Similarly, some of the 'view' files are too slow
-	// when small engine blocks are enabled.
+	// so we disable that.
 	serverArgs := logictest.TestServerArgs{
 		MaxSQLMemoryLimit: 512 << 20, // 512 MiB
 		DisableUseMVCCRangeTombstonesForPointDeletes: true,
-		DisableSmallEngineBlocks:                     true,
 		// Some sqlite tests with very low bytes limit value are too slow, so
 		// ensure 3 KiB lower bound.
 		BatchBytesLimitLowerBound: 3 << 10, // 3 KiB


### PR DESCRIPTION
This metamorphic randomization has caused some flakiness (due to a subset of tests taking very long time) so is now removed. This feature should be tested in a more targeted fashion.

Fixes: #95799.
Fixes: #95829

Release note: None