### PR TITLE
colinfo: add missing type families into CanHaveCompositeKeyEncoding

### DIFF
--- a/pkg/sql/catalog/colinfo/column_type_properties.go
+++ b/pkg/sql/catalog/colinfo/column_type_properties.go
@@ -16,6 +16,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
+	"github.com/cockroachdb/errors"
 )
 
 // CheckDatumTypeFitsColumnType verifies that a given scalar value
@@ -80,12 +81,16 @@ func CanHaveCompositeKeyEncoding(typ *types.T) bool {
 		types.GeometryFamily,
 		types.GeographyFamily,
 		types.EnumFamily,
-		types.Box2DFamily:
+		types.Box2DFamily,
+		types.VoidFamily,
+		types.EncodedKeyFamily,
+		types.TSQueryFamily,
+		types.TSVectorFamily:
 		return false
 	case types.UnknownFamily,
 		types.AnyFamily:
-		fallthrough
-	default:
 		return true
+	default:
+		panic(errors.AssertionFailedf("unsupported column family for type %s", typ.SQLString()))
 	}
 }

--- a/pkg/sql/catalog/colinfo/column_type_properties_test.go
+++ b/pkg/sql/catalog/colinfo/column_type_properties_test.go
@@ -73,8 +73,6 @@ func TestCanHaveCompositeKeyEncoding(t *testing.T) {
 		{types.VarChar, false},
 		{types.MakeTuple([]*types.T{types.Int, types.Date}), false},
 		{types.MakeTuple([]*types.T{types.Float, types.Date}), true},
-		// Test that a made up type with a bogus family will return true.
-		{&types.T{InternalType: types.InternalType{Family: 1 << 29}}, true},
 	} {
 		// Note that sprint is used here because the bogus type family will
 		// panic when formatting to a string and sprint will catch that.
@@ -82,4 +80,9 @@ func TestCanHaveCompositeKeyEncoding(t *testing.T) {
 			require.Equal(t, tc.exp, CanHaveCompositeKeyEncoding(tc.typ))
 		})
 	}
+	// Test that a made up type with a bogus family will panic.
+	t.Run("bogus", func(t *testing.T) {
+		bogusType := &types.T{InternalType: types.InternalType{Family: 1 << 29}}
+		require.Panics(t, func() { CanHaveCompositeKeyEncoding(bogusType) })
+	})
 }

--- a/pkg/sql/logictest/testdata/logic_test/tsvector
+++ b/pkg/sql/logictest/testdata/logic_test/tsvector
@@ -235,3 +235,8 @@ SELECT a FROM a@a_a_idx WHERE a @@ 'ba:* & foo'
 # columns.
 statement error index \"a_a_idx\" is inverted and cannot be used for this query
 EXPLAIN SELECT * FROM a@a_a_idx WHERE a @@ b
+
+# Regression test for incorrectly marking TSVector type as composite (#95680).
+statement ok
+CREATE TABLE t95680 (c1 FLOAT NOT NULL, c2 TSVECTOR NOT NULL, INVERTED INDEX (c1 ASC, c2 ASC));
+INSERT INTO t95680 VALUES (1.0::FLOAT, e'\'kCrLZNl\' \'sVDj\' \'yO\' \'z\':54C,440B,519C,794B':::TSVECTOR);


### PR DESCRIPTION
This commit adds several missing type families into `CanHaveCompositeKeyEncoding` method. Some of these type families are internal and, probably, don't need to be handled, but we recently introduced TSVector and TSQuery types which were incorrectly marked as being composite since they were not mentioned explicitly in the type family switch. This commit also makes it so that we panic in this method if we forget to include a newly-introduced type into this switch.

Fixes: #95680.

Release note: None