### PR TITLE
roachtest: fix parameters passed to require.NoError

### DIFF
--- a/pkg/cmd/roachtest/tests/multitenant_distsql.go
+++ b/pkg/cmd/roachtest/tests/multitenant_distsql.go
@@ -139,7 +139,7 @@ func runMultiTenantDistSQL(
 				default:
 					// procede to report error
 				}
-				require.NoError(t, err, li, iter)
+				require.NoError(t, err, "instance idx = %d, iter = %d", li, iter)
 				iter++
 			}
 		})


### PR DESCRIPTION
When context is passed to an assertion, the parameters *must* be a string format, followed by arguments (as you would in a call to `fmt.Sprintf`). The previous code would panic trying to cast int to string.

Informs #95416

Release note: None