### PR TITLE
release-22.1: builtins: array_to_string should traverse nested arrays

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/builtin_function
+++ b/pkg/sql/logictest/testdata/logic_test/builtin_function
@@ -2480,6 +2480,18 @@ SELECT array_to_string(NULL, ','), array_to_string(NULL, 'foo', 'zerp')
 ----
 NULL  NULL
 
+# Builtin array_to_string should recursively search nested arrays.
+query T
+SELECT array_to_string(ARRAY[ARRAY[ARRAY[5,6], ARRAY[2,3]], ARRAY[ARRAY[7,8], ARRAY[4,44]]], ' ');
+----
+5 6 2 3 7 8 4 44
+
+# Builtin array_to_string should recursively search nested arrays.
+query T
+SELECT array_to_string(ARRAY[(SELECT ARRAY[1,2]::int2vector)],' ');
+----
+1 2
+
 subtest pg_is_in_recovery
 
 query B colnames


### PR DESCRIPTION
Backport 1/1 commits from #95802.

/cc @cockroachdb/release

---

Fixes #95588

In Postgres, `array_to_string` traverses nested arrays and prints their contents. In CRDB, the nested array structures are printed out. For example,
`SELECT array_to_string(ARRAY[ARRAY[ARRAY[5,6], ARRAY[2,3]]], ' ');`

CRDB Result: `ARRAY[ARRAY[5:::INT8,6:::INT8],ARRAY[2:::INT8,3:::INT8]]` Postgres Result: `5 6 2 3`

This fix brings the behavior of `array_to_string` in line with Postgres, and avoids printing the nested ARRAY structures.

Some tools like GoldenGate rely on Postgres-compatible  behavior of `array_to_string` for proper functioning.

Release note (bug fix): This patch fixes the array_to_string built-in function so that nested arrays are traversed without printing 'ARRAY' at each nesting level.

Release Justification: Fixes incorrect output from the array_to_string builtin function.
