### PR TITLE
ccl/backupccl: enable restore from metadata SST

### DIFF
--- a/pkg/ccl/backupccl/backup_job.go
+++ b/pkg/ccl/backupccl/backup_job.go
@@ -131,7 +131,7 @@ func backup(
 	defaultStore cloud.ExternalStorage,
 	storageByLocalityKV map[string]*cloudpb.ExternalStorage,
 	job *jobs.Job,
-	backupManifest *backuppb.BackupManifest,
+	backupManifest *backupinfo.BackupManifestAdapter,
 	makeExternalStorage cloud.ExternalStorageFactory,
 	encryption *jobspb.BackupEncryptionOptions,
 	statsCache *stats.TableStatisticsCache,
@@ -149,21 +149,24 @@ func backup(
 	// TODO(benesch): verify these files, rather than accepting them as truth
 	// blindly.
 	// No concurrency yet, so these assignments are safe.
-	it, err := makeBackupManifestFileIterator(ctx, execCtx.ExecCfg().DistSQLSrv.ExternalStorage,
-		*backupManifest, encryption, &kmsEnv)
+	it, err := backupManifest.NewFileIter(ctx)
 	if err != nil {
 		return roachpb.RowCount{}, err
 	}
-	defer it.close()
-	for f, hasNext := it.next(); hasNext; f, hasNext = it.next() {
+	defer it.Close()
+	for ; ; it.Next() {
+		if ok, err := it.Valid(); err != nil {
+			return roachpb.RowCount{}, err
+		} else if !ok {
+			break
+		}
+
+		f := it.Value()
 		if f.StartTime.IsEmpty() && !f.EndTime.IsEmpty() {
 			completedIntroducedSpans = append(completedIntroducedSpans, f.Span)
 		} else {
 			completedSpans = append(completedSpans, f.Span)
 		}
-	}
-	if it.err() != nil {
-		return roachpb.RowCount{}, it.err()
 	}
 
 	// Subtract out any completed spans.
@@ -200,9 +203,9 @@ func backup(
 		urisByLocalityKV,
 		encryption,
 		&kmsEnv,
-		roachpb.MVCCFilter(backupManifest.MVCCFilter),
-		backupManifest.StartTime,
-		backupManifest.EndTime,
+		roachpb.MVCCFilter(backupManifest.MVCCFilter()),
+		backupManifest.StartTime(),
+		backupManifest.EndTime(),
 	)
 	if err != nil {
 		return roachpb.RowCount{}, err
@@ -237,12 +240,12 @@ func backup(
 			if err := types.UnmarshalAny(&progress.ProgressDetails, &progDetails); err != nil {
 				log.Errorf(ctx, "unable to unmarshal backup progress details: %+v", err)
 			}
-			if backupManifest.RevisionStartTime.Less(progDetails.RevStartTime) {
-				backupManifest.RevisionStartTime = progDetails.RevStartTime
+			if backupManifest.RevisionStartTime().Less(progDetails.RevStartTime) {
+				backupManifest.BackupManifest.RevisionStartTime = progDetails.RevStartTime
 			}
 			for _, file := range progDetails.Files {
 				backupManifest.Files = append(backupManifest.Files, file)
-				backupManifest.EntryCounts.Add(file.EntryCounts)
+				backupManifest.BackupManifest.EntryCounts.Add(file.EntryCounts)
 				numBackedUpFiles++
 			}
 
@@ -255,12 +258,12 @@ func backup(
 			if timeutil.Since(lastCheckpoint) > interval {
 				resumerSpan.RecordStructured(&backuppb.BackupProgressTraceEvent{
 					TotalNumFiles:     numBackedUpFiles,
-					TotalEntryCounts:  backupManifest.EntryCounts,
-					RevisionStartTime: backupManifest.RevisionStartTime,
+					TotalEntryCounts:  backupManifest.EntryCounts(),
+					RevisionStartTime: backupManifest.RevisionStartTime(),
 				})
 
 				err := backupinfo.WriteBackupManifestCheckpoint(
-					ctx, defaultURI, encryption, &kmsEnv, backupManifest, execCtx.ExecCfg(), execCtx.User(),
+					ctx, defaultURI, encryption, &kmsEnv, backupManifest.BackupManifest, execCtx.ExecCfg(), execCtx.User(),
 				)
 				if err != nil {
 					log.Errorf(ctx, "unable to checkpoint backup descriptor: %+v", err)
@@ -291,7 +294,7 @@ func backup(
 	}
 
 	backupID := uuid.MakeV4()
-	backupManifest.ID = backupID
+	backupManifest.BackupManifest.ID = backupID
 	// Write additional partial descriptors to each node for partitioned backups.
 	if len(storageByLocalityKV) > 0 {
 		resumerSpan.RecordStructured(&types.StringValue{Value: "writing partition descriptors for partitioned backup"})
@@ -302,14 +305,14 @@ func backup(
 
 		nextPartitionedDescFilenameID := 1
 		for kv, conf := range storageByLocalityKV {
-			backupManifest.LocalityKVs = append(backupManifest.LocalityKVs, kv)
+			backupManifest.BackupManifest.LocalityKVs = append(backupManifest.BackupManifest.LocalityKVs, kv)
 			// Set a unique filename for each partition backup descriptor. The ID
 			// ensures uniqueness, and the kv string appended to the end is for
 			// readability.
 			filename := fmt.Sprintf("%s_%d_%s", backupPartitionDescriptorPrefix,
 				nextPartitionedDescFilenameID, backupinfo.SanitizeLocalityKV(kv))
 			nextPartitionedDescFilenameID++
-			backupManifest.PartitionDescriptorFilenames = append(backupManifest.PartitionDescriptorFilenames, filename)
+			backupManifest.BackupManifest.PartitionDescriptorFilenames = append(backupManifest.BackupManifest.PartitionDescriptorFilenames, filename)
 			desc := backuppb.BackupPartitionDescriptor{
 				LocalityKV: kv,
 				Files:      filesByLocalityKV[kv],
@@ -337,7 +340,7 @@ func backup(
 	// because a mixed-version cluster with 23.1 nodes will read the
 	// `BACKUP_METADATA` instead.
 	if err := backupinfo.WriteBackupManifest(ctx, defaultStore, backupbase.BackupManifestName,
-		encryption, &kmsEnv, backupManifest); err != nil {
+		encryption, &kmsEnv, backupManifest.BackupManifest); err != nil {
 		return roachpb.RowCount{}, err
 	}
 
@@ -348,7 +351,7 @@ func backup(
 	// reading backup manifests to `metadata.sst` we can stop writing the slim
 	// manifest.
 	if err := backupinfo.WriteFilesListMetadataWithSSTs(ctx, defaultStore, encryption,
-		&kmsEnv, backupManifest); err != nil {
+		&kmsEnv, backupManifest.BackupManifest); err != nil {
 		return roachpb.RowCount{}, err
 	}
 
@@ -358,7 +361,7 @@ func backup(
 	}
 
 	if backupinfo.WriteMetadataSST.Get(&settings.SV) {
-		if err := backupinfo.WriteBackupMetadataSST(ctx, defaultStore, encryption, &kmsEnv, backupManifest,
+		if err := backupinfo.WriteBackupMetadataSST(ctx, defaultStore, encryption, &kmsEnv, backupManifest.BackupManifest,
 			statsTable.Statistics); err != nil {
 			err = errors.Wrap(err, "writing forward-compat metadata sst")
 			if !build.IsRelease() {
@@ -368,7 +371,7 @@ func backup(
 		}
 	}
 
-	return backupManifest.EntryCounts, nil
+	return backupManifest.EntryCounts(), nil
 }
 
 func releaseProtectedTimestamp(
@@ -509,7 +512,7 @@ func (b *backupResumer) Resume(ctx context.Context, execCtx interface{}) error {
 		}
 	}
 
-	var backupManifest *backuppb.BackupManifest
+	var backupManifest *backupinfo.BackupManifestAdapter
 
 	// Populate the BackupDetails with the resolved backup
 	// destination, and construct the BackupManifest to be written
@@ -529,7 +532,7 @@ func (b *backupResumer) Resume(ctx context.Context, execCtx interface{}) error {
 				return err
 			}
 			details = backupDetails
-			backupManifest = &m
+			backupManifest = m
 			return nil
 		}); err != nil {
 			return err
@@ -551,7 +554,7 @@ func (b *backupResumer) Resume(ctx context.Context, execCtx interface{}) error {
 				) error {
 					ptp := p.ExecCfg().ProtectedTimestampProvider.WithTxn(txn)
 					return protectTimestampForBackup(
-						ctx, b.job.ID(), ptp, backupManifest, details,
+						ctx, b.job.ID(), ptp, backupManifest.BackupManifest, details,
 					)
 				}); err != nil {
 					return err
@@ -564,7 +567,7 @@ func (b *backupResumer) Resume(ctx context.Context, execCtx interface{}) error {
 		}
 
 		if err := backupinfo.WriteBackupManifestCheckpoint(
-			ctx, details.URI, details.EncryptionOptions, &kmsEnv, backupManifest, p.ExecCfg(), p.User(),
+			ctx, details.URI, details.EncryptionOptions, &kmsEnv, backupManifest.BackupManifest, p.ExecCfg(), p.User(),
 		); err != nil {
 			return err
 		}
@@ -617,7 +620,7 @@ func (b *backupResumer) Resume(ctx context.Context, execCtx interface{}) error {
 		lic := utilccl.CheckEnterpriseEnabled(
 			p.ExecCfg().Settings, p.ExecCfg().NodeInfo.LogicalClusterID(), "",
 		) != nil
-		collectTelemetry(ctx, backupManifest, initialDetails, details, lic, b.job.ID())
+		collectTelemetry(ctx, backupManifest.BackupManifest, initialDetails, details, lic, b.job.ID())
 	}
 
 	// For all backups, partitioned or not, the main BACKUP manifest is stored at
@@ -662,11 +665,14 @@ func (b *backupResumer) Resume(ctx context.Context, execCtx interface{}) error {
 	}()
 
 	if backupManifest == nil || forceReadBackupManifest {
-		backupManifest, memSize, err = b.readManifestOnResume(ctx, &mem, p.ExecCfg(), defaultStore,
+		var m *backuppb.BackupManifest
+		m, memSize, err = b.readManifestOnResume(ctx, &mem, p.ExecCfg(), defaultStore,
 			details, p.User(), &kmsEnv)
 		if err != nil {
 			return err
 		}
+
+		backupManifest = backupinfo.NewBackupManifestAdapter(m, defaultStore, details.EncryptionOptions, &kmsEnv, p.ExecCfg().DistSQLSrv.ExternalStorage)
 	}
 
 	statsCache := p.ExecCfg().TableStatsCache
@@ -713,13 +719,15 @@ func (b *backupResumer) Resume(ctx context.Context, execCtx interface{}) error {
 		// Reload the backup manifest to pick up any spans we may have completed on
 		// previous attempts.
 		var reloadBackupErr error
+		var m *backuppb.BackupManifest
 		mem.Shrink(ctx, memSize)
 		memSize = 0
-		backupManifest, memSize, reloadBackupErr = b.readManifestOnResume(ctx, &mem, p.ExecCfg(),
+		m, memSize, reloadBackupErr = b.readManifestOnResume(ctx, &mem, p.ExecCfg(),
 			defaultStore, details, p.User(), &kmsEnv)
 		if reloadBackupErr != nil {
 			return errors.Wrap(reloadBackupErr, "could not reload backup manifest when retrying")
 		}
+		backupManifest = backupinfo.NewBackupManifestAdapter(m, defaultStore, details.EncryptionOptions, &kmsEnv, p.ExecCfg().DistSQLSrv.ExternalStorage)
 	}
 
 	// We have exhausted retries, but we have not seen a "PermanentBulkJobError" so
@@ -762,7 +770,7 @@ func (b *backupResumer) Resume(ctx context.Context, execCtx interface{}) error {
 	// listing of the directory it is in -- it exists only to save us a
 	// potentially expensive listing of a giant backup collection to find the most
 	// recent completed entry.
-	if backupManifest.StartTime.IsEmpty() && details.CollectionURI != "" {
+	if backupManifest.StartTime().IsEmpty() && details.CollectionURI != "" {
 		backupURI, err := url.Parse(details.URI)
 		if err != nil {
 			return err
@@ -849,8 +857,9 @@ func getBackupDetailAndManifest(
 	initialDetails jobspb.BackupDetails,
 	user username.SQLUsername,
 	backupDestination backupdest.ResolvedDestination,
-) (jobspb.BackupDetails, backuppb.BackupManifest, error) {
+) (jobspb.BackupDetails, *backupinfo.BackupManifestAdapter, error) {
 	makeCloudStorage := execCfg.DistSQLSrv.ExternalStorageFromURI
+	storeFactory := execCfg.DistSQLSrv.ExternalStorage
 
 	kmsEnv := backupencryption.MakeBackupKMSEnv(
 		execCfg.Settings,
@@ -862,39 +871,39 @@ func getBackupDetailAndManifest(
 	mem := execCfg.RootMemoryMonitor.MakeBoundAccount()
 	defer mem.Close(ctx)
 
-	var prevBackups []backuppb.BackupManifest
+	var prevBackups []backupinfo.BackupManifest
 	var baseEncryptionOptions *jobspb.BackupEncryptionOptions
 	if len(backupDestination.PrevBackupURIs) != 0 {
 		var err error
 		baseEncryptionOptions, err = backupencryption.GetEncryptionFromBase(ctx, user, makeCloudStorage,
 			backupDestination.PrevBackupURIs[0], *initialDetails.EncryptionOptions, &kmsEnv)
 		if err != nil {
-			return jobspb.BackupDetails{}, backuppb.BackupManifest{}, err
+			return jobspb.BackupDetails{}, nil, err
 		}
 
 		var memSize int64
 		prevBackups, memSize, err = backupinfo.GetBackupManifests(ctx, &mem, user,
-			makeCloudStorage, backupDestination.PrevBackupURIs, baseEncryptionOptions, &kmsEnv)
+			makeCloudStorage, storeFactory, backupDestination.PrevBackupURIs, baseEncryptionOptions, &kmsEnv, jobspb.BackupManifestReadMode_ForceManifest)
 
 		if err != nil {
-			return jobspb.BackupDetails{}, backuppb.BackupManifest{}, err
+			return jobspb.BackupDetails{}, nil, err
 		}
 		defer mem.Shrink(ctx, memSize)
 	}
 
 	if len(prevBackups) > 0 {
 		baseManifest := prevBackups[0]
-		if baseManifest.DescriptorCoverage == tree.AllDescriptors &&
+		if baseManifest.DescriptorCoverage() == tree.AllDescriptors &&
 			!initialDetails.FullCluster {
-			return jobspb.BackupDetails{}, backuppb.BackupManifest{}, errors.Errorf("cannot append a backup of specific tables or databases to a cluster backup")
+			return jobspb.BackupDetails{}, nil, errors.Errorf("cannot append a backup of specific tables or databases to a cluster backup")
 		}
 
 		if err := requireEnterprise(execCfg, "incremental"); err != nil {
-			return jobspb.BackupDetails{}, backuppb.BackupManifest{}, err
+			return jobspb.BackupDetails{}, nil, err
 		}
-		lastEndTime := prevBackups[len(prevBackups)-1].EndTime
+		lastEndTime := prevBackups[len(prevBackups)-1].EndTime()
 		if lastEndTime.Compare(initialDetails.EndTime) > 0 {
-			return jobspb.BackupDetails{}, backuppb.BackupManifest{},
+			return jobspb.BackupDetails{}, nil,
 				errors.Newf("`AS OF SYSTEM TIME` %s must be greater than "+
 					"the previous backup's end time of %s.",
 					initialDetails.EndTime.GoTime(), lastEndTime.GoTime())
@@ -913,11 +922,11 @@ func getBackupDetailAndManifest(
 		// IDs are how we identify tables, and those are only meaningful in the
 		// context of their own cluster, so we need to ensure we only allow
 		// incremental previous backups that we created.
-		if fromCluster := prevBackup.ClusterID; !fromCluster.Equal(execCfg.NodeInfo.LogicalClusterID()) {
-			return jobspb.BackupDetails{}, backuppb.BackupManifest{}, errors.Newf("previous BACKUP belongs to cluster %s", fromCluster.String())
+		if fromCluster := prevBackup.ClusterID(); !fromCluster.Equal(execCfg.NodeInfo.LogicalClusterID()) {
+			return jobspb.BackupDetails{}, nil, errors.Newf("previous BACKUP belongs to cluster %s", fromCluster.String())
 		}
 
-		prevLocalityKVs := prevBackup.LocalityKVs
+		prevLocalityKVs := prevBackup.LocalityKVs()
 
 		// Checks that each layer in the backup uses the same localities
 		// Does NOT check that each locality/layer combination is actually at the
@@ -933,7 +942,7 @@ func getBackupDetailAndManifest(
 			// necessary, because the default locality defines the backup manifest
 			// location. If that URI isn't right, the backup chain will fail to
 			// load.
-			return jobspb.BackupDetails{}, backuppb.BackupManifest{}, errors.Newf(
+			return jobspb.BackupDetails{}, nil, errors.Newf(
 				"Requested backup has localities %s, but a previous backup layer in this collection has localities %s. "+
 					"Mismatched backup layers are not supported. Please take a new full backup with the new localities, or an "+
 					"incremental backup with matching localities.",
@@ -956,7 +965,7 @@ func getBackupDetailAndManifest(
 		baseEncryptionOptions,
 		&kmsEnv)
 	if err != nil {
-		return jobspb.BackupDetails{}, backuppb.BackupManifest{}, err
+		return jobspb.BackupDetails{}, nil, err
 	}
 
 	backupManifest, err := createBackupManifest(
@@ -964,9 +973,12 @@ func getBackupDetailAndManifest(
 		execCfg,
 		txn,
 		updatedDetails,
-		prevBackups)
+		prevBackups,
+		user,
+		&kmsEnv,
+	)
 	if err != nil {
-		return jobspb.BackupDetails{}, backuppb.BackupManifest{}, err
+		return jobspb.BackupDetails{}, nil, err
 	}
 
 	return updatedDetails, backupManifest, nil

--- a/pkg/ccl/backupccl/backup_metadata_test.go
+++ b/pkg/ccl/backupccl/backup_metadata_test.go
@@ -10,7 +10,6 @@ package backupccl_test
 
 import (
 	"context"
-	"sort"
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
@@ -26,7 +25,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/isql"
-	"github.com/cockroachdb/cockroach/pkg/sql/stats"
 	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/ioctx"
@@ -128,7 +126,7 @@ func checkMetadata(
 	checkStats(ctx, t, store, m, bm, &kmsEnv)
 }
 
-func checkManifest(t *testing.T, m *backuppb.BackupManifest, bm *backupinfo.BackupMetadata) {
+func checkManifest(t *testing.T, m *backuppb.BackupManifest, bm backupinfo.BackupManifest) {
 	expectedManifest := *m
 	expectedManifest.Descriptors = nil
 	expectedManifest.DescriptorChanges = nil
@@ -138,53 +136,50 @@ func checkManifest(t *testing.T, m *backuppb.BackupManifest, bm *backupinfo.Back
 	expectedManifest.StatisticsFilenames = nil
 	expectedManifest.Tenants = nil
 
-	require.Equal(t, expectedManifest, bm.BackupManifest)
+	require.Equal(t, expectedManifest, *bm.Manifest())
 }
 
 func checkDescriptors(
-	ctx context.Context, t *testing.T, m *backuppb.BackupManifest, bm *backupinfo.BackupMetadata,
+	ctx context.Context, t *testing.T, m *backuppb.BackupManifest, bm backupinfo.BackupManifest,
 ) {
 	var metaDescs []descpb.Descriptor
-	var desc descpb.Descriptor
 
-	it := bm.DescIter(ctx)
+	it := bm.NewDescIter(ctx)
 	defer it.Close()
-	for it.Next(&desc) {
-		metaDescs = append(metaDescs, desc)
-	}
+	for ; ; it.Next() {
+		if ok, err := it.Valid(); err != nil {
+			t.Fatal(err)
+		} else if !ok {
+			break
+		}
 
-	if it.Err() != nil {
-		t.Fatal(it.Err())
+		metaDescs = append(metaDescs, *it.Value())
 	}
 
 	require.Equal(t, m.Descriptors, metaDescs)
 }
 
 func checkDescriptorChanges(
-	ctx context.Context, t *testing.T, m *backuppb.BackupManifest, bm *backupinfo.BackupMetadata,
+	ctx context.Context, t *testing.T, m *backuppb.BackupManifest, bm backupinfo.BackupManifest,
 ) {
 	var metaRevs []backuppb.BackupManifest_DescriptorRevision
-	var rev backuppb.BackupManifest_DescriptorRevision
-	it := bm.DescriptorChangesIter(ctx)
+	it := bm.NewDescriptorChangesIter(ctx)
 	defer it.Close()
 
-	for it.Next(&rev) {
-		metaRevs = append(metaRevs, rev)
+	for ; ; it.Next() {
+		if ok, err := it.Valid(); err != nil {
+			t.Fatal(err)
+		} else if !ok {
+			break
+		}
+		metaRevs = append(metaRevs, *it.Value())
 	}
-	if it.Err() != nil {
-		t.Fatal(it.Err())
-	}
-
-	// Descriptor Changes are sorted by time in the manifest.
-	sort.Slice(metaRevs, func(i, j int) bool {
-		return metaRevs[i].Time.Less(metaRevs[j].Time)
-	})
 
 	require.Equal(t, m.DescriptorChanges, metaRevs)
 }
 
 func checkFiles(
-	ctx context.Context, t *testing.T, m *backuppb.BackupManifest, bm *backupinfo.BackupMetadata,
+	ctx context.Context, t *testing.T, m *backuppb.BackupManifest, bm backupinfo.BackupManifest,
 ) {
 	var metaFiles []backuppb.BackupManifest_File
 	it, err := bm.NewFileIter(ctx)
@@ -209,53 +204,59 @@ func checkFiles(
 }
 
 func checkSpans(
-	ctx context.Context, t *testing.T, m *backuppb.BackupManifest, bm *backupinfo.BackupMetadata,
+	ctx context.Context, t *testing.T, m *backuppb.BackupManifest, bm backupinfo.BackupManifest,
 ) {
 	var metaSpans []roachpb.Span
-	var span roachpb.Span
-	it := bm.SpanIter(ctx)
+	it := bm.NewSpanIter(ctx)
 	defer it.Close()
 
-	for it.Next(&span) {
-		metaSpans = append(metaSpans, span)
-	}
-	if it.Err() != nil {
-		t.Fatal(it.Err())
+	for ; ; it.Next() {
+		if ok, err := it.Valid(); err != nil {
+			t.Fatal(err)
+		} else if !ok {
+			break
+		}
+
+		metaSpans = append(metaSpans, it.Value())
 	}
 
 	require.Equal(t, m.Spans, metaSpans)
 }
 
 func checkIntroducedSpans(
-	ctx context.Context, t *testing.T, m *backuppb.BackupManifest, bm *backupinfo.BackupMetadata,
+	ctx context.Context, t *testing.T, m *backuppb.BackupManifest, bm backupinfo.BackupManifest,
 ) {
 	var metaSpans []roachpb.Span
-	var span roachpb.Span
-	it := bm.IntroducedSpanIter(ctx)
+	it := bm.NewIntroducedSpanIter(ctx)
 	defer it.Close()
-	for it.Next(&span) {
-		metaSpans = append(metaSpans, span)
-	}
-	if it.Err() != nil {
-		t.Fatal(it.Err())
+
+	for ; ; it.Next() {
+		if ok, err := it.Valid(); err != nil {
+			t.Fatal(err)
+		} else if !ok {
+			break
+		}
+		metaSpans = append(metaSpans, it.Value())
 	}
 
 	require.Equal(t, m.IntroducedSpans, metaSpans)
 }
 
 func checkTenants(
-	ctx context.Context, t *testing.T, m *backuppb.BackupManifest, bm *backupinfo.BackupMetadata,
+	ctx context.Context, t *testing.T, m *backuppb.BackupManifest, bm backupinfo.BackupManifest,
 ) {
 	var metaTenants []descpb.TenantInfoWithUsage
-	var tenant descpb.TenantInfoWithUsage
-	it := bm.TenantIter(ctx)
+	it := bm.NewTenantIter(ctx)
 	defer it.Close()
 
-	for it.Next(&tenant) {
-		metaTenants = append(metaTenants, tenant)
-	}
-	if it.Err() != nil {
-		t.Fatal(it.Err())
+	for ; ; it.Next() {
+		if ok, err := it.Valid(); err != nil {
+			t.Fatal(err)
+		} else if !ok {
+			break
+		}
+
+		metaTenants = append(metaTenants, it.Value())
 	}
 
 	require.Equal(t, m.Tenants, metaTenants)
@@ -266,25 +267,25 @@ func checkStats(
 	t *testing.T,
 	store cloud.ExternalStorage,
 	m *backuppb.BackupManifest,
-	bm *backupinfo.BackupMetadata,
+	bm backupinfo.BackupManifest,
 	kmsEnv cloud.KMSEnv,
 ) {
-	expectedStats, err := backupinfo.GetStatisticsFromBackup(ctx, store, nil, kmsEnv, *m)
+	manifestAdapter := backupinfo.NewBackupManifestAdapter(m, store, nil, kmsEnv, nil)
+	manifestStatsIt := manifestAdapter.NewStatsIter(ctx)
+	defer manifestStatsIt.Close()
+
+	expectedStats, err := backupinfo.CollectToSlice(manifestStatsIt)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	var metaStats = make([]*stats.TableStatisticProto, 0)
-	var s *stats.TableStatisticProto
-	it := bm.StatsIter(ctx)
+	it := bm.NewStatsIter(ctx)
 	defer it.Close()
+	metaStats, err := backupinfo.CollectToSlice(it)
+	if err != nil {
+		t.Fatal(err)
+	}
 
-	for it.Next(&s) {
-		metaStats = append(metaStats, s)
-	}
-	if it.Err() != nil {
-		t.Fatal(it.Err())
-	}
 	require.Equal(t, expectedStats, metaStats)
 }
 

--- a/pkg/ccl/backupccl/backup_test.go
+++ b/pkg/ccl/backupccl/backup_test.go
@@ -86,6 +86,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/eval"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/stats"
+	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/jobutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
@@ -4269,7 +4270,7 @@ func TestEncryptedBackup(t *testing.T) {
 			sqlDB.ExpectErr(t, expectedShowError,
 				fmt.Sprintf(`SHOW BACKUP $1 WITH %s`, incorrectEncryptionOption), backupLoc1)
 			sqlDB.ExpectErr(t,
-				`file appears encrypted -- try specifying one of "encryption_passphrase" or "kms"`,
+				`(file appears encrypted -- try specifying one of "encryption_passphrase" or "kms"|invalid table \(bad magic number\))`,
 				`SHOW BACKUP $1`, backupLoc1)
 			sqlDB.ExpectErr(t, `could not find or read encryption information`,
 				fmt.Sprintf(`SHOW BACKUP $1 WITH %s`, encryptionOption), plainBackupLoc1)
@@ -8279,6 +8280,7 @@ func TestManifestTooNew(t *testing.T) {
 	defer log.Scope(t).Close(t)
 	_, sqlDB, rawDir, cleanupFn := backupRestoreTestSetup(t, singleNode, 1, InitManualReplication)
 	defer cleanupFn()
+	sqlDB.Exec(t, `SET CLUSTER SETTING restore.manifest_read.mode = 'forceManifest'`)
 	sqlDB.Exec(t, `CREATE DATABASE r1`)
 	sqlDB.Exec(t, `BACKUP DATABASE r1 TO 'nodelocal://0/too_new'`)
 	sqlDB.Exec(t, `DROP DATABASE r1`)
@@ -8331,6 +8333,120 @@ func TestManifestTooNew(t *testing.T) {
 	checksum, err = backupinfo.GetChecksum(manifestData)
 	require.NoError(t, err)
 	require.NoError(t, os.WriteFile(manifestPath+backupinfo.BackupManifestChecksumSuffix, checksum, 0644 /* perm */))
+	// Prove we can restore again.
+	sqlDB.Exec(t, `RESTORE DATABASE r1 FROM 'nodelocal://0/too_new'`)
+	sqlDB.Exec(t, `DROP DATABASE r1`)
+}
+
+func TestMetadataTooNew(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	tc, sqlDB, rawDir, cleanupFn := backupRestoreTestSetup(t, singleNode, 1, InitManualReplication)
+	defer cleanupFn()
+
+	sqlDB.Exec(t, `SET CLUSTER SETTING restore.manifest_read.mode = 'forceMetadataSST'`)
+	sqlDB.Exec(t, `CREATE DATABASE r1`)
+	sqlDB.Exec(t, `BACKUP DATABASE r1 TO 'nodelocal://0/too_new'`)
+	sqlDB.Exec(t, `DROP DATABASE r1`)
+	// Prove we can restore.
+	sqlDB.Exec(t, `RESTORE DATABASE r1 FROM 'nodelocal://0/too_new'`)
+	sqlDB.Exec(t, `DROP DATABASE r1`)
+
+	clusterSettings := tc.Server(0).ClusterSettings()
+	ctx := context.Background()
+
+	store, err := cloud.ExternalStorageFromURI(
+		ctx,
+		"nodelocal://0/too_new",
+		base.ExternalIODirConfig{},
+		clusterSettings,
+		blobs.NewLocalOnlyBlobClientFactory(rawDir),
+		username.RootUserName(),
+		tc.Servers[0].InternalDB().(isql.DB),
+		nil, /* limiters */
+		cloud.NilMetrics,
+	)
+
+	require.NoError(t, err)
+
+	var iterOpts = storage.IterOptions{
+		KeyTypes:   storage.IterKeyTypePointsAndRanges,
+		LowerBound: keys.LocalMax,
+		UpperBound: keys.MaxKey,
+	}
+	iter, err := storageccl.ExternalSSTReader(ctx, []storageccl.StoreFile{{store, backupinfo.MetadataSSTName}}, nil, iterOpts)
+	require.NoError(t, err)
+
+	var keys []storage.MVCCKey
+	var values [][]byte
+
+	for iter.SeekGE(storage.MVCCKey{}); ; iter.Next() {
+		if ok, err := iter.Valid(); err != nil {
+			t.Fatal(err)
+		} else if !ok {
+			break
+		}
+
+		keys = append(keys, iter.UnsafeKey().Clone())
+		value, err := iter.UnsafeValue()
+		require.NoError(t, err)
+		values = append(values, value)
+	}
+
+	modifyManifest := func(mutation func(*backuppb.BackupManifest)) {
+		require.NoError(t, store.Delete(ctx, backupinfo.MetadataSSTName))
+
+		writer, err := store.Writer(ctx, backupinfo.MetadataSSTName)
+		require.NoError(t, err)
+		defer writer.Close()
+
+		sstWriter := storage.MakeBackupSSTWriter(ctx, clusterSettings, writer)
+		defer sstWriter.Close()
+
+		for i := range keys {
+			if keys[i].Key.Equal([]byte(backupinfo.SSTBackupKey)) {
+				var sstManifest backuppb.BackupManifest
+				value := values[i]
+				require.NoError(t, protoutil.Unmarshal(value, &sstManifest))
+				mutation(&sstManifest)
+				manifestData, err := protoutil.Marshal(&sstManifest)
+				require.NoError(t, err)
+
+				require.NoError(t, sstWriter.PutUnversioned([]byte(backupinfo.SSTBackupKey), manifestData))
+			} else {
+				value := values[i]
+				if keys[i].Timestamp.IsEmpty() {
+					require.NoError(t, sstWriter.PutUnversioned(keys[i].Key, value))
+				} else {
+					require.NoError(t, sstWriter.PutRawMVCC(keys[i], value))
+				}
+			}
+
+		}
+	}
+
+	// Bump the version and write it back out to make it look newer.
+	modifyManifest(func(manifest *backuppb.BackupManifest) {
+		manifest.ClusterVersion = roachpb.Version{Major: math.MaxInt32, Minor: 1}
+	})
+
+	// Verify we reject it.
+	sqlDB.ExpectErr(t, "backup from version 2147483647.1 is newer than current version", `RESTORE DATABASE r1 FROM 'nodelocal://0/too_new'`)
+
+	// Bump the version down and write it back out to make it look older.
+	modifyManifest(func(manifest *backuppb.BackupManifest) {
+		manifest.ClusterVersion = roachpb.Version{Major: 20, Minor: 2, Internal: 2}
+	})
+
+	// Prove we can restore again.
+	sqlDB.Exec(t, `RESTORE DATABASE r1 FROM 'nodelocal://0/too_new'`)
+	sqlDB.Exec(t, `DROP DATABASE r1`)
+
+	// Nil out the version to match an old backup that lacked it.
+	modifyManifest(func(manifest *backuppb.BackupManifest) {
+		manifest.ClusterVersion = roachpb.Version{}
+	})
+
 	// Prove we can restore again.
 	sqlDB.Exec(t, `RESTORE DATABASE r1 FROM 'nodelocal://0/too_new'`)
 	sqlDB.Exec(t, `DROP DATABASE r1`)

--- a/pkg/ccl/backupccl/backupdest/BUILD.bazel
+++ b/pkg/ccl/backupccl/backupdest/BUILD.bazel
@@ -12,7 +12,6 @@ go_library(
     deps = [
         "//pkg/ccl/backupccl/backupbase",
         "//pkg/ccl/backupccl/backupinfo",
-        "//pkg/ccl/backupccl/backuppb",
         "//pkg/ccl/backupccl/backuputils",
         "//pkg/cloud",
         "//pkg/cloud/cloudpb",

--- a/pkg/ccl/backupccl/backupdest/incrementals.go
+++ b/pkg/ccl/backupccl/backupdest/incrementals.go
@@ -16,8 +16,10 @@ import (
 	"strings"
 
 	"github.com/cockroachdb/cockroach/pkg/ccl/backupccl/backupbase"
+	"github.com/cockroachdb/cockroach/pkg/ccl/backupccl/backupinfo"
 	"github.com/cockroachdb/cockroach/pkg/ccl/backupccl/backuputils"
 	"github.com/cockroachdb/cockroach/pkg/cloud"
+	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
 	"github.com/cockroachdb/cockroach/pkg/security/username"
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
@@ -54,34 +56,63 @@ func CollectionAndSubdir(path string, subdir string) (string, string) {
 // If includeManifest is true the returned paths are to the manifests for the
 // prior backup, otherwise it is just to the backup path.
 func FindPriorBackups(
-	ctx context.Context, store cloud.ExternalStorage, includeManifest bool,
+	ctx context.Context,
+	store cloud.ExternalStorage,
+	includeManifest bool,
+	mode jobspb.BackupManifestReadMode,
 ) ([]string, error) {
 	ctx, sp := tracing.ChildSpan(ctx, "backupdest.FindPriorBackups")
 	defer sp.Finish()
 
-	var prev []string
+	prevDirsAndManifest := make(map[string]string)
 	if err := store.List(ctx, "", backupbase.ListingDelimDataSlash, func(p string) error {
-		if ok, err := path.Match(incBackupSubdirGlob+backupbase.BackupManifestName, p); err != nil {
-			return err
-		} else if ok {
-			if !includeManifest {
-				p = strings.TrimSuffix(p, "/"+backupbase.BackupManifestName)
+		if mode != jobspb.BackupManifestReadMode_ForceManifest {
+			if ok, err := path.Match(incBackupSubdirGlob+backupinfo.MetadataSSTName, p); err != nil {
+				return err
+			} else if ok {
+
+				dir := strings.TrimSuffix(p, "/"+backupinfo.MetadataSSTName)
+				// We always will prefer using the metadata SST if we are not forced
+				// into using the manifest.
+				prevDirsAndManifest[dir] = p
+
+				return nil
 			}
-			prev = append(prev, p)
-			return nil
 		}
-		if ok, err := path.Match(incBackupSubdirGlob+backupbase.BackupOldManifestName, p); err != nil {
-			return err
-		} else if ok {
-			if !includeManifest {
-				p = strings.TrimSuffix(p, "/"+backupbase.BackupOldManifestName)
+
+		if mode != jobspb.BackupManifestReadMode_ForceMetadataSST {
+			if ok, err := path.Match(incBackupSubdirGlob+backupbase.BackupManifestName, p); err != nil {
+				return err
+			} else if ok {
+				dir := strings.TrimSuffix(p, "/"+backupbase.BackupManifestName)
+				if _, exist := prevDirsAndManifest[dir]; !exist || mode == jobspb.BackupManifestReadMode_ForceManifest {
+					prevDirsAndManifest[dir] = p
+				}
+				return nil
 			}
-			prev = append(prev, p)
+			if ok, err := path.Match(incBackupSubdirGlob+backupbase.BackupOldManifestName, p); err != nil {
+				return err
+			} else if ok {
+				dir := strings.TrimSuffix(p, "/"+backupbase.BackupOldManifestName)
+				if _, exist := prevDirsAndManifest[dir]; !exist || mode == jobspb.BackupManifestReadMode_ForceManifest {
+					prevDirsAndManifest[dir] = p
+				}
+			}
 		}
 		return nil
 	}); err != nil {
 		return nil, errors.Wrap(err, "reading previous backup layers")
 	}
+
+	var prev []string
+	for dir, p := range prevDirsAndManifest {
+		if includeManifest {
+			prev = append(prev, p)
+		} else {
+			prev = append(prev, dir)
+		}
+	}
+
 	sort.Strings(prev)
 	return prev, nil
 }
@@ -89,7 +120,11 @@ func FindPriorBackups(
 // backupsFromLocation is a small helper function to retrieve all prior
 // backups from the specified location.
 func backupsFromLocation(
-	ctx context.Context, user username.SQLUsername, execCfg *sql.ExecutorConfig, loc string,
+	ctx context.Context,
+	user username.SQLUsername,
+	execCfg *sql.ExecutorConfig,
+	loc string,
+	mode jobspb.BackupManifestReadMode,
 ) ([]string, error) {
 	ctx, sp := tracing.ChildSpan(ctx, "backupdest.backupsFromLocation")
 	defer sp.Finish()
@@ -100,7 +135,7 @@ func backupsFromLocation(
 		return nil, errors.Wrapf(err, "failed to open backup storage location")
 	}
 	defer store.Close()
-	prev, err := FindPriorBackups(ctx, store, false)
+	prev, err := FindPriorBackups(ctx, store, false, mode)
 	return prev, err
 }
 
@@ -144,6 +179,7 @@ func ResolveIncrementalsBackupLocation(
 	explicitIncrementalCollections []string,
 	fullBackupCollections []string,
 	subdir string,
+	mode jobspb.BackupManifestReadMode,
 ) ([]string, error) {
 	ctx, sp := tracing.ChildSpan(ctx, "backupdest.ResolveIncrementalsBackupLocation")
 	defer sp.Finish()
@@ -159,7 +195,7 @@ func ResolveIncrementalsBackupLocation(
 		// knows this isn't a usable incrementals store.
 		// Some callers will abort, e.g. BACKUP. Others will proceed with a
 		// warning, e.g. SHOW and RESTORE.
-		_, err = backupsFromLocation(ctx, user, execCfg, incPaths[0])
+		_, err = backupsFromLocation(ctx, user, execCfg, incPaths[0], mode)
 		if err != nil {
 			return nil, err
 		}
@@ -175,7 +211,7 @@ func ResolveIncrementalsBackupLocation(
 	// incremental layer iff all of them do. So it suffices to check only the
 	// first.
 	// Check we can read from this location, though we don't need the backups here.
-	prevOld, err := backupsFromLocation(ctx, user, execCfg, resolvedIncrementalsBackupLocationOld[0])
+	prevOld, err := backupsFromLocation(ctx, user, execCfg, resolvedIncrementalsBackupLocationOld[0], mode)
 	if err != nil {
 		return nil, err
 	}
@@ -185,7 +221,7 @@ func ResolveIncrementalsBackupLocation(
 		return nil, err
 	}
 
-	prev, err := backupsFromLocation(ctx, user, execCfg, resolvedIncrementalsBackupLocation[0])
+	prev, err := backupsFromLocation(ctx, user, execCfg, resolvedIncrementalsBackupLocation[0], mode)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/ccl/backupccl/backupinfo/BUILD.bazel
+++ b/pkg/ccl/backupccl/backupinfo/BUILD.bazel
@@ -11,6 +11,7 @@ go_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/ccl/backupccl/backupinfo",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/build",
         "//pkg/ccl/backupccl/backupbase",
         "//pkg/ccl/backupccl/backupencryption",
         "//pkg/ccl/backupccl/backuppb",
@@ -49,6 +50,7 @@ go_library(
         "//pkg/util/syncutil",
         "//pkg/util/timeutil",
         "//pkg/util/tracing",
+        "//pkg/util/uuid",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_klauspost_compress//gzip",
     ],

--- a/pkg/ccl/backupccl/backupinfo/backup_metadata.go
+++ b/pkg/ccl/backupccl/backupinfo/backup_metadata.go
@@ -16,21 +16,29 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/cockroachdb/cockroach/pkg/build"
 	"github.com/cockroachdb/cockroach/pkg/ccl/backupccl/backupencryption"
 	"github.com/cockroachdb/cockroach/pkg/ccl/backupccl/backuppb"
 	"github.com/cockroachdb/cockroach/pkg/ccl/storageccl"
 	"github.com/cockroachdb/cockroach/pkg/cloud"
+	"github.com/cockroachdb/cockroach/pkg/cloud/cloudpb"
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/protoreflect"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/stats"
 	"github.com/cockroachdb/cockroach/pkg/storage"
+	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/json"
+	"github.com/cockroachdb/cockroach/pkg/util/mon"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
+	"github.com/cockroachdb/cockroach/pkg/util/tracing"
+	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 	"github.com/cockroachdb/errors"
 )
 
@@ -43,14 +51,39 @@ const (
 	BackupMetadataFilesListPath = "filelist.sst"
 	// FileInfoPath is the name of the SST file containing the
 	// BackupManifest_Files of the backup.
-	FileInfoPath     = "fileinfo.sst"
-	sstBackupKey     = "backup"
+	FileInfoPath = "fileinfo.sst"
+	// SSTBackupKey is the key in the metadata SST corresponding to the backup
+	// manifest.
+	SSTBackupKey     = "backup"
 	sstDescsPrefix   = "desc/"
 	sstFilesPrefix   = "file/"
 	sstNamesPrefix   = "name/"
 	sstSpansPrefix   = "span/"
 	sstStatsPrefix   = "stats/"
 	sstTenantsPrefix = "tenant/"
+)
+
+const (
+	manifestReadModePreferMetadataSST = "preferMetadataSST"
+	manifestReadModeForceMetadataSST  = "forceMetadataSST"
+	manifestReadModeForceManifest     = "forceManifest"
+)
+
+// RestoreManifestReadMode controls how the manifest is read from backups during
+// restore. forceMetadata and forceManifest forces restore to read only the
+// metadata SST and the backup manifest file respectively. While
+// preferMetadataSST allows restore to read from both, but the metadata SST
+// first.
+var RestoreManifestReadMode = settings.RegisterEnumSetting(
+	settings.TenantWritable,
+	"restore.manifest_read.mode",
+	"mode to read the backup manifest during restore",
+	util.ConstantWithMetamorphicTestChoice("restore-manifest-mode", manifestReadModeForceMetadataSST, manifestReadModePreferMetadataSST, manifestReadModeForceManifest).(string),
+	map[int64]string{
+		int64(jobspb.BackupManifestReadMode_PreferMetadataSST): manifestReadModePreferMetadataSST,
+		int64(jobspb.BackupManifestReadMode_ForceMetadataSST):  manifestReadModeForceMetadataSST,
+		int64(jobspb.BackupManifestReadMode_ForceManifest):     manifestReadModeForceManifest,
+	},
 )
 
 var iterOpts = storage.IterOptions{
@@ -197,7 +230,17 @@ func writeManifestToMetadata(
 	if err != nil {
 		return err
 	}
-	return sst.PutUnversioned(roachpb.Key(sstBackupKey), b)
+	return sst.PutUnversioned(roachpb.Key(SSTBackupKey), b)
+}
+
+func descChangesLess(
+	left *backuppb.BackupManifest_DescriptorRevision,
+	right *backuppb.BackupManifest_DescriptorRevision,
+) bool {
+	if left.ID == right.ID {
+		return !left.Time.Less(right.Time)
+	}
+	return left.ID < right.ID
 }
 
 func writeDescsToMetadata(
@@ -206,12 +249,7 @@ func writeDescsToMetadata(
 	// Add descriptors from revisions if available, Descriptors if not.
 	if len(m.DescriptorChanges) > 0 {
 		sort.Slice(m.DescriptorChanges, func(i, j int) bool {
-			if m.DescriptorChanges[i].ID < m.DescriptorChanges[j].ID {
-				return true
-			} else if m.DescriptorChanges[i].ID == m.DescriptorChanges[j].ID {
-				return !m.DescriptorChanges[i].Time.Less(m.DescriptorChanges[j].Time)
-			}
-			return false
+			return descChangesLess(&m.DescriptorChanges[i], &m.DescriptorChanges[j])
 		})
 		for _, i := range m.DescriptorChanges {
 			k := encodeDescSSTKey(i.ID)
@@ -248,7 +286,7 @@ func writeDescsToMetadata(
 			// changes in an incremental backup, it's helpful to have existing
 			// descriptors at the start time, so we don't have to look back further
 			// than the very last backup.
-			if m.StartTime.IsEmpty() {
+			if m.StartTime.IsEmpty() || m.MVCCFilter == backuppb.MVCCFilter_Latest {
 				if err := sst.PutUnversioned(k, b); err != nil {
 					return err
 				}
@@ -262,6 +300,7 @@ func writeDescsToMetadata(
 	return nil
 }
 
+// FileCmp gives an ordering to two backuppb.BackupManifest_File.
 func FileCmp(left backuppb.BackupManifest_File, right backuppb.BackupManifest_File) int {
 	if cmp := left.Span.Key.Compare(right.Span.Key); cmp != 0 {
 		return cmp
@@ -781,7 +820,7 @@ func DebugDumpMetadataSST(
 		}
 		k := iter.UnsafeKey()
 		switch {
-		case bytes.Equal(k.Key, []byte(sstBackupKey)):
+		case bytes.Equal(k.Key, []byte(SSTBackupKey)):
 			v, err := iter.UnsafeValue()
 			if err != nil {
 				return err
@@ -899,10 +938,120 @@ func DebugDumpMetadataSST(
 	return nil
 }
 
-// BackupMetadata holds all of the data in backuppb.BackupManifest except a few repeated
-// fields such as descriptors or spans. BackupMetadata provides iterator methods
+// Iterator is an interface to iterate a collection of objects of type T.
+type Iterator[T any] interface {
+	// Valid must be called after any call to Next(). It returns (true, nil) if
+	// the iterator points to a valid value, and (false, nil) if the iterator has
+	// moved past the last value. It returns (false, err) if there is an error in
+	// the iterator.
+	Valid() (bool, error)
+
+	// Value returns the current value. The returned value is only valid until the
+	// next call to Next(). is only valid until the
+	Value() T
+
+	// Next advances the iterator to the next value.
+	Next()
+
+	// Close closes the iterator.
+	Close()
+}
+
+// CollectToSlice iterates over all objects in iterator and collects them into a
+// slice.
+func CollectToSlice[T any](iterator Iterator[T]) ([]T, error) {
+	var values []T
+	for ; ; iterator.Next() {
+		if ok, err := iterator.Valid(); err != nil {
+			return nil, err
+		} else if !ok {
+			break
+		}
+
+		values = append(values, iterator.Value())
+	}
+	return values, nil
+}
+
+// BackupManifest is the metadata for a backup.
+type BackupManifest interface {
+	// StartTime returns the start time of the data included in this backup.
+	StartTime() hlc.Timestamp
+	// EndTime returns the end time of the data included in this backup.
+	EndTime() hlc.Timestamp
+
+	MVCCFilter() backuppb.MVCCFilter
+
+	// RevisionStartTime denotes the start time of revisions.
+	// Even if StartTime is zero, we only get revisions since gc threshold, so
+	// do not allow AS OF SYSTEM TIME before RevisionStartTime.
+	RevisionStartTime() hlc.Timestamp
+
+	// NewSpanIter returns an iterator for the spans requested for backup. The
+	// keyranges covered by `files` may be a subset of this if there were ranges
+	// with no changes since the last backup. For all tables in the backup
+	// descriptor, these spans must completely cover each table's span. For
+	// example, if a table with ID 51 were being backed up, then the span
+	// `/Table/5{1-2}` must be completely covered.
+	NewSpanIter(ctx context.Context) Iterator[roachpb.Span]
+
+	// NewIntroducedSpanIter returns an iterator for introduced spans, which are a
+	// subset of spans, set only when creating incremental backups that cover
+	// spans not included in a previous backup. Spans contained here are covered
+	// in the interval (0, startTime], which, in conjunction with the coverage
+	// from (startTime, endTime] implied for all spans in Spans, results in
+	// coverage from [0, endTime] for these spans.
+	// The first set of spans in this field are new spans that did not exist in
+	// the previous backup (a new index, for example), while the remaining spans
+	// are re-introduced spans, which need to be backed up again from (0,
+	// startTime] because a non-mvcc operation may have occurred on this span. See
+	// the getReintroducedSpans() for more information.
+	NewIntroducedSpanIter(ctx context.Context) Iterator[roachpb.Span]
+	NewDescriptorChangesIter(ctx context.Context) Iterator[*backuppb.BackupManifest_DescriptorRevision]
+	NewFileIter(ctx context.Context) (Iterator[*backuppb.BackupManifest_File], error)
+	NewDescIter(ctx context.Context) Iterator[*descpb.Descriptor]
+	NewTenantIter(ctx context.Context) Iterator[descpb.TenantInfoWithUsage]
+	NewStatsIter(ctx context.Context) Iterator[*stats.TableStatisticProto]
+
+	// TenantsDeprecated is deprecated; it is only retained to allow restoring
+	// older backups.
+	TenantsDeprecated() []descpb.TenantInfo
+
+	// CompleteDBs are databases in descriptors that have all tables also in
+	// descriptors.
+	CompleteDBs() []descpb.ID
+	EntryCounts() roachpb.RowCount
+	Dir() cloudpb.ExternalStorage
+	SetDir(cloudpb.ExternalStorage)
+	FormatVersion() uint32
+	ClusterID() uuid.UUID
+
+	// NodeID is the node ID of the gateway node (which writes the descriptor).
+	NodeID() roachpb.NodeID
+	// BuildInfo is the build info of the gateway node (which writes the descriptor).
+	BuildInfo() build.Info
+	ClusterVersion() roachpb.Version
+	ID() uuid.UUID
+	PartitionDescriptorFilenames() []string
+	LocalityKVs() []string
+
+	// DeprecatedStatistics is used by backups in 19.2 and 20.1 where a backup
+	// manifest stores all the table statistics in the field. Stats for later
+	// versions can be accessed by iterators created by NewStatsIter.
+	DeprecatedStatistics() []*stats.TableStatisticProto
+	DescriptorCoverage() tree.DescriptorCoverage
+
+	Manifest() *backuppb.BackupManifest
+
+	// SortFiles sorts the files in the BackupManifest. It may be a no-op if the
+	// files are already sorted.
+	SortFiles()
+}
+
+// backupMetadata holds all of the data in backuppb.BackupManifest except a few repeated
+// fields such as descriptors or spans. backupMetadata provides iterator methods
 // so that the excluded fields can be accessed in a streaming manner.
-type BackupMetadata struct {
+type backupMetadata struct {
 	backuppb.BackupManifest
 	store    cloud.ExternalStorage
 	enc      *jobspb.BackupEncryptionOptions
@@ -910,14 +1059,16 @@ type BackupMetadata struct {
 	kmsEnv   cloud.KMSEnv
 }
 
-// NewBackupMetadata returns a new BackupMetadata instance.
+var _ BackupManifest = &backupMetadata{}
+
+// NewBackupMetadata returns a new backupMetadata instance.
 func NewBackupMetadata(
 	ctx context.Context,
 	exportStore cloud.ExternalStorage,
 	sstFileName string,
 	encryption *jobspb.BackupEncryptionOptions,
 	kmsEnv cloud.KMSEnv,
-) (*BackupMetadata, error) {
+) (BackupManifest, error) {
 	var encOpts *roachpb.FileEncryptionOptions
 	if encryption != nil {
 		key, err := backupencryption.GetEncryptionKey(ctx, encryption, kmsEnv)
@@ -934,12 +1085,12 @@ func NewBackupMetadata(
 	defer iter.Close()
 
 	var sstManifest backuppb.BackupManifest
-	iter.SeekGE(storage.MakeMVCCMetadataKey([]byte(sstBackupKey)))
+	iter.SeekGE(storage.MakeMVCCMetadataKey([]byte(SSTBackupKey)))
 	ok, err := iter.Valid()
 	if err != nil {
 		return nil, err
 	}
-	if !ok || !iter.UnsafeKey().Key.Equal([]byte(sstBackupKey)) {
+	if !ok || !iter.UnsafeKey().Key.Equal([]byte(SSTBackupKey)) {
 		return nil, errors.Errorf("metadata SST does not contain backup manifest")
 	}
 
@@ -951,37 +1102,136 @@ func NewBackupMetadata(
 		return nil, err
 	}
 
-	return &BackupMetadata{BackupManifest: sstManifest, store: exportStore,
+	return &backupMetadata{BackupManifest: sstManifest, store: exportStore,
 		enc: encryption, filename: sstFileName, kmsEnv: kmsEnv}, nil
+}
+
+// IsIncremental returns if the BackupManifest corresponds to an incremental
+// backup.
+func IsIncremental(b BackupManifest) bool {
+	return !b.StartTime().IsEmpty()
+}
+
+func (b *backupMetadata) StartTime() hlc.Timestamp {
+	return b.BackupManifest.StartTime
+}
+
+func (b *backupMetadata) EndTime() hlc.Timestamp {
+	return b.BackupManifest.EndTime
+}
+
+func (b *backupMetadata) MVCCFilter() backuppb.MVCCFilter {
+	return b.BackupManifest.MVCCFilter
+}
+
+func (b *backupMetadata) RevisionStartTime() hlc.Timestamp {
+	return b.BackupManifest.RevisionStartTime
+}
+
+func (b *backupMetadata) CompleteDBs() []descpb.ID {
+	return b.BackupManifest.CompleteDbs
+}
+
+func (b *backupMetadata) EntryCounts() roachpb.RowCount {
+	return b.BackupManifest.EntryCounts
+}
+
+func (b *backupMetadata) Dir() cloudpb.ExternalStorage {
+	return b.BackupManifest.Dir
+}
+
+func (b *backupMetadata) SetDir(dir cloudpb.ExternalStorage) {
+	b.BackupManifest.Dir = dir
+}
+
+func (b *backupMetadata) FormatVersion() uint32 {
+	return b.BackupManifest.FormatVersion
+}
+
+func (b *backupMetadata) ClusterID() uuid.UUID {
+	return b.BackupManifest.ClusterID
+}
+
+func (b *backupMetadata) NodeID() roachpb.NodeID {
+	return b.BackupManifest.NodeID
+}
+
+func (b *backupMetadata) BuildInfo() build.Info {
+	return b.BackupManifest.BuildInfo
+}
+
+func (b *backupMetadata) ClusterVersion() roachpb.Version {
+	return b.BackupManifest.ClusterVersion
+}
+
+func (b *backupMetadata) ID() uuid.UUID {
+	return b.BackupManifest.ID
+}
+
+func (b *backupMetadata) PartitionDescriptorFilenames() []string {
+	return b.BackupManifest.PartitionDescriptorFilenames
+}
+
+func (b *backupMetadata) LocalityKVs() []string {
+	return b.BackupManifest.LocalityKVs
+}
+
+func (b *backupMetadata) DescriptorCoverage() tree.DescriptorCoverage {
+	return b.BackupManifest.DescriptorCoverage
+}
+
+func (b *backupMetadata) HasExternalFilesList() bool {
+	return false
+}
+
+func (b *backupMetadata) TenantsDeprecated() []descpb.TenantInfo {
+	return nil
+}
+
+func (b *backupMetadata) DeprecatedStatistics() []*stats.TableStatisticProto {
+	return nil
+}
+
+func (b *backupMetadata) SortFiles() {
+	// No-op, files in backup metadata are already sorted.
+}
+
+func (b *backupMetadata) Manifest() *backuppb.BackupManifest {
+	return &b.BackupManifest
 }
 
 // SpanIterator is a simple iterator to iterate over roachpb.Spans.
 type SpanIterator struct {
 	backing bytesIter
 	filter  func(key storage.MVCCKey) bool
+	value   *roachpb.Span
 	err     error
 }
 
-// SpanIter creates a new SpanIterator for the backup metadata.
-func (b *BackupMetadata) SpanIter(ctx context.Context) SpanIterator {
+// NewSpanIter creates a new SpanIterator for the backup metadata.
+func (b *backupMetadata) NewSpanIter(ctx context.Context) Iterator[roachpb.Span] {
 	backing := makeBytesIter(ctx, b.store, b.filename, []byte(sstSpansPrefix), b.enc,
 		true, b.kmsEnv)
-	return SpanIterator{
+	it := SpanIterator{
 		backing: backing,
 	}
+	it.Next()
+	return &it
 }
 
-// IntroducedSpanIter creates a new IntroducedSpanIterator for the backup metadata.
-func (b *BackupMetadata) IntroducedSpanIter(ctx context.Context) SpanIterator {
+// NewIntroducedSpanIter creates a new IntroducedSpanIterator for the backup metadata.
+func (b *backupMetadata) NewIntroducedSpanIter(ctx context.Context) Iterator[roachpb.Span] {
 	backing := makeBytesIter(ctx, b.store, b.filename, []byte(sstSpansPrefix), b.enc,
 		false, b.kmsEnv)
 
-	return SpanIterator{
+	it := SpanIterator{
 		backing: backing,
 		filter: func(key storage.MVCCKey) bool {
 			return key.Timestamp == hlc.Timestamp{}
 		},
 	}
+	it.Next()
+	return &it
 }
 
 // Close closes the iterator.
@@ -989,37 +1239,40 @@ func (si *SpanIterator) Close() {
 	si.backing.close()
 }
 
-// Err returns the iterator's error
-func (si *SpanIterator) Err() error {
+func (si *SpanIterator) Valid() (bool, error) {
 	if si.err != nil {
-		return si.err
+		return false, si.err
 	}
-	return si.backing.err()
+	return si.value != nil, si.err
 }
 
-// Next retrieves the next span in the iterator.
-//
-// Next returns true if next element was successfully unmarshalled into span,
-// and false if there are no more elements or if an error was encountered. When
-// Next returns false, the user should call the Err method to verify the
-// existence of an error.
-func (si *SpanIterator) Next(span *roachpb.Span) bool {
+// Value implements the Iterator interface.
+func (si *SpanIterator) Value() roachpb.Span {
+	if si.value == nil {
+		return roachpb.Span{}
+	}
+	return *si.value
+}
+
+// Next implements the Iterator interface.
+func (si *SpanIterator) Next() {
 	wrapper := resultWrapper{}
+	var nextSpan *roachpb.Span
 
 	for si.backing.next(&wrapper) {
 		if si.filter == nil || si.filter(wrapper.key) {
 			sp, err := decodeSpanSSTKey(wrapper.key.Key)
 			if err != nil {
 				si.err = err
-				return false
+				return
 			}
 
-			*span = sp
-			return true
+			nextSpan = &sp
+			break
 		}
 	}
 
-	return false
+	si.value = nextSpan
 }
 
 // FileIterator is a simple iterator to iterate over backuppb.BackupManifest_File.
@@ -1030,7 +1283,9 @@ type FileIterator struct {
 }
 
 // NewFileIter creates a new FileIterator for the backup metadata.
-func (b *BackupMetadata) NewFileIter(ctx context.Context) (*FileIterator, error) {
+func (b *backupMetadata) NewFileIter(
+	ctx context.Context,
+) (Iterator[*backuppb.BackupManifest_File], error) {
 	fileInfoIter := makeBytesIter(ctx, b.store, b.filename, []byte(sstFilesPrefix), b.enc,
 		false, b.kmsEnv)
 	defer fileInfoIter.close()
@@ -1113,12 +1368,12 @@ func (fi *FileIterator) Valid() (bool, error) {
 	return true, nil
 }
 
-// Value returns the current value of the iterator, if valid.
+// Value implements the Iterator interface.
 func (fi *FileIterator) Value() *backuppb.BackupManifest_File {
 	return fi.file
 }
 
-// Next advances the iterator the the next value.
+// Next implements the Iterator interface.
 func (fi *FileIterator) Next() {
 	fi.mergedIterator.Next()
 	fi.file = nil
@@ -1134,16 +1389,18 @@ func (fi *FileIterator) Reset() {
 // DescIterator is a simple iterator to iterate over descpb.Descriptors.
 type DescIterator struct {
 	backing bytesIter
+	value   *descpb.Descriptor
 	err     error
 }
 
-// DescIter creates a new DescIterator for the backup metadata.
-func (b *BackupMetadata) DescIter(ctx context.Context) DescIterator {
-	backing := makeBytesIter(ctx, b.store, b.filename, []byte(sstDescsPrefix), b.enc,
-		true, b.kmsEnv)
-	return DescIterator{
+// NewDescIter creates a new DescIterator for the backup metadata.
+func (b *backupMetadata) NewDescIter(ctx context.Context) Iterator[*descpb.Descriptor] {
+	backing := makeBytesIter(ctx, b.store, b.filename, []byte(sstDescsPrefix), b.enc, true, b.kmsEnv)
+	it := DescIterator{
 		backing: backing,
 	}
+	it.Next()
+	return &it
 }
 
 // Close closes the iterator.
@@ -1151,52 +1408,61 @@ func (di *DescIterator) Close() {
 	di.backing.close()
 }
 
-// Err returns the iterator's error.
-func (di *DescIterator) Err() error {
+// Valid implements the Iterator interface.
+func (di *DescIterator) Valid() (bool, error) {
 	if di.err != nil {
-		return di.err
+		return false, di.err
 	}
-	return di.backing.err()
+	return di.value != nil, nil
 }
 
-// Next retrieves the next descriptor in the iterator.
-//
-// Next returns true if next element was successfully unmarshalled into desc ,
-// and false if there are no more elements or if an error was encountered. When
-// Next returns false, the user should call the Err method to verify the
-// existence of an error.
-func (di *DescIterator) Next(desc *descpb.Descriptor) bool {
-	wrapper := resultWrapper{}
+// Value implements the Iterator interface.
+func (di *DescIterator) Value() *descpb.Descriptor {
+	return di.value
+}
 
+// Next implements the Iterator interface.
+func (di *DescIterator) Next() {
+	if di.err != nil {
+		return
+	}
+
+	wrapper := resultWrapper{}
+	var nextValue *descpb.Descriptor
+	descHolder := descpb.Descriptor{}
 	for di.backing.next(&wrapper) {
-		err := protoutil.Unmarshal(wrapper.value, desc)
+		err := protoutil.Unmarshal(wrapper.value, &descHolder)
 		if err != nil {
 			di.err = err
-			return false
+			return
 		}
 
-		tbl, db, typ, sc, fn := descpb.GetDescriptors(desc)
+		tbl, db, typ, sc, fn := descpb.GetDescriptors(&descHolder)
 		if tbl != nil || db != nil || typ != nil || sc != nil || fn != nil {
-			return true
+			nextValue = &descHolder
+			break
 		}
 	}
 
-	return false
+	di.value = nextValue
 }
 
 // TenantIterator is a simple iterator to iterate over TenantInfoWithUsages.
 type TenantIterator struct {
 	backing bytesIter
+	value   *descpb.TenantInfoWithUsage
 	err     error
 }
 
-// TenantIter creates a new TenantIterator for the backup metadata.
-func (b *BackupMetadata) TenantIter(ctx context.Context) TenantIterator {
+// NewTenantIter creates a new TenantIterator for the backup metadata.
+func (b *backupMetadata) NewTenantIter(ctx context.Context) Iterator[descpb.TenantInfoWithUsage] {
 	backing := makeBytesIter(ctx, b.store, b.filename, []byte(sstTenantsPrefix), b.enc,
 		false, b.kmsEnv)
-	return TenantIterator{
+	it := TenantIterator{
 		backing: backing,
 	}
+	it.Next()
+	return &it
 }
 
 // Close closes the iterator.
@@ -1204,62 +1470,91 @@ func (ti *TenantIterator) Close() {
 	ti.backing.close()
 }
 
-// Err returns the iterator's error.
-func (ti *TenantIterator) Err() error {
+// Valid implements the Iterator interface.
+func (ti *TenantIterator) Valid() (bool, error) {
 	if ti.err != nil {
-		return ti.err
+		return false, ti.err
 	}
-	return ti.backing.err()
+	return ti.value != nil, nil
 }
 
-// Next retrieves the next tenant in the iterator.
-//
-// Next returns true if next element was successfully unmarshalled into tenant,
-// and false if there are no more elements or if an error was encountered. When
-// Next returns false, the user should call the Err method to verify the
-// existence of an error.
-func (ti *TenantIterator) Next(tenant *descpb.TenantInfoWithUsage) bool {
+// Value implements the Iterator interface.
+func (ti *TenantIterator) Value() descpb.TenantInfoWithUsage {
+	if ti.value == nil {
+		return descpb.TenantInfoWithUsage{}
+	}
+	return *ti.value
+}
+
+// Next implements the Iterator interface.
+func (ti *TenantIterator) Next() {
+	if ti.err != nil {
+		return
+	}
+
 	wrapper := resultWrapper{}
 	ok := ti.backing.next(&wrapper)
 	if !ok {
-		return false
+		if ti.backing.err() != nil {
+			ti.err = ti.backing.err()
+		}
+		ti.value = nil
+		return
 	}
 
-	err := protoutil.Unmarshal(wrapper.value, tenant)
+	tenant := descpb.TenantInfoWithUsage{}
+
+	err := protoutil.Unmarshal(wrapper.value, &tenant)
 	if err != nil {
 		ti.err = err
-		return false
+		return
 	}
 
-	return true
+	ti.value = &tenant
 }
 
 // DescriptorRevisionIterator is a simple iterator to iterate over backuppb.BackupManifest_DescriptorRevisions.
 type DescriptorRevisionIterator struct {
 	backing bytesIter
 	err     error
+	value   *backuppb.BackupManifest_DescriptorRevision
 }
 
-// DescriptorChangesIter creates a new DescriptorChangesIterator for the backup metadata.
-func (b *BackupMetadata) DescriptorChangesIter(ctx context.Context) DescriptorRevisionIterator {
-	backing := makeBytesIter(ctx, b.store, b.filename, []byte(sstDescsPrefix), b.enc,
-		false, b.kmsEnv)
-	return DescriptorRevisionIterator{
+// NewDescriptorChangesIter creates a new DescriptorChangesIterator for the backup metadata.
+func (b *backupMetadata) NewDescriptorChangesIter(
+	ctx context.Context,
+) Iterator[*backuppb.BackupManifest_DescriptorRevision] {
+	var backing bytesIter
+	if b.MVCCFilter() == backuppb.MVCCFilter_Latest {
+		backing = makeNoOpBytesIter()
+	} else {
+		backing = makeBytesIter(ctx, b.store, b.filename, []byte(sstDescsPrefix), b.enc,
+			false, b.kmsEnv)
+	}
+	dri := DescriptorRevisionIterator{
 		backing: backing,
 	}
+
+	dri.Next()
+	return &dri
+}
+
+// Valid implements the Iterator interface.
+func (dri *DescriptorRevisionIterator) Valid() (bool, error) {
+	if dri.err != nil {
+		return false, dri.err
+	}
+	return dri.value != nil, nil
+}
+
+// Value implements the Iterator interface.
+func (dri *DescriptorRevisionIterator) Value() *backuppb.BackupManifest_DescriptorRevision {
+	return dri.value
 }
 
 // Close closes the iterator.
 func (dri *DescriptorRevisionIterator) Close() {
 	dri.backing.close()
-}
-
-// Err returns the iterator's error.
-func (dri *DescriptorRevisionIterator) Err() error {
-	if dri.err != nil {
-		return dri.err
-	}
-	return dri.backing.err()
 }
 
 // Next retrieves the next descriptor revision in the iterator.
@@ -1268,62 +1563,70 @@ func (dri *DescriptorRevisionIterator) Err() error {
 // revision, and false if there are no more elements or if an error was
 // encountered. When Next returns false, the user should call the Err method to
 // verify the existence of an error.
-func (dri *DescriptorRevisionIterator) Next(
-	revision *backuppb.BackupManifest_DescriptorRevision,
-) bool {
+func (dri *DescriptorRevisionIterator) Next() {
+	if dri.err != nil {
+		return
+	}
+
 	wrapper := resultWrapper{}
 	ok := dri.backing.next(&wrapper)
 	if !ok {
-		return false
+		if err := dri.backing.err(); err != nil {
+			dri.err = err
+		}
+
+		dri.value = nil
+		return
 	}
 
-	err := unmarshalWrapper(&wrapper, revision)
+	nextRev, err := unmarshalWrapper(&wrapper)
 	if err != nil {
 		dri.err = err
-		return false
+		return
 	}
 
-	return true
+	dri.value = &nextRev
 }
 
-func unmarshalWrapper(
-	wrapper *resultWrapper, rev *backuppb.BackupManifest_DescriptorRevision,
-) error {
+func unmarshalWrapper(wrapper *resultWrapper) (backuppb.BackupManifest_DescriptorRevision, error) {
 	var desc *descpb.Descriptor
 	if len(wrapper.value) > 0 {
 		desc = &descpb.Descriptor{}
 		err := protoutil.Unmarshal(wrapper.value, desc)
 		if err != nil {
-			return err
+			return backuppb.BackupManifest_DescriptorRevision{}, err
 		}
 	}
 
 	id, err := decodeDescSSTKey(wrapper.key.Key)
 	if err != nil {
-		return err
+		return backuppb.BackupManifest_DescriptorRevision{}, err
 	}
 
-	*rev = backuppb.BackupManifest_DescriptorRevision{
+	rev := backuppb.BackupManifest_DescriptorRevision{
 		Desc: desc,
 		ID:   id,
 		Time: wrapper.key.Timestamp,
 	}
-	return nil
+	return rev, nil
 }
 
 // StatsIterator is a simple iterator to iterate over stats.TableStatisticProtos.
 type StatsIterator struct {
 	backing bytesIter
+	value   *stats.TableStatisticProto
 	err     error
 }
 
-// StatsIter creates a new StatsIterator for the backup metadata.
-func (b *BackupMetadata) StatsIter(ctx context.Context) StatsIterator {
+// NewStatsIter creates a new StatsIterator for the backup metadata.
+func (b *backupMetadata) NewStatsIter(ctx context.Context) Iterator[*stats.TableStatisticProto] {
 	backing := makeBytesIter(ctx, b.store, b.filename, []byte(sstStatsPrefix), b.enc,
 		false, b.kmsEnv)
-	return StatsIterator{
+	it := StatsIterator{
 		backing: backing,
 	}
+	it.Next()
+	return &it
 }
 
 // Close closes the iterator.
@@ -1331,37 +1634,43 @@ func (si *StatsIterator) Close() {
 	si.backing.close()
 }
 
-// Err returns the iterator's error.
-func (si *StatsIterator) Err() error {
+// Valid implements the Iterator interface.
+func (si *StatsIterator) Valid() (bool, error) {
 	if si.err != nil {
-		return si.err
+		return false, si.err
 	}
-	return si.backing.err()
+	return si.value != nil, nil
 }
 
-// Next retrieves the next stats proto in the iterator.
-//
-// Next returns true if next element was successfully unmarshalled into
-// statsPtr, and false if there are no more elements or if an error was
-// encountered. When Next returns false, the user should call the Err method to verify the
-// existence of an error.
-func (si *StatsIterator) Next(statsPtr **stats.TableStatisticProto) bool {
+// Value implements the Iterator interface.
+func (si *StatsIterator) Value() *stats.TableStatisticProto {
+	return si.value
+}
+
+func (si *StatsIterator) Next() {
+	if si.err != nil {
+		return
+	}
+
 	wrapper := resultWrapper{}
 	ok := si.backing.next(&wrapper)
 
 	if !ok {
-		return false
+		if err := si.backing.err(); err != nil {
+			si.err = err
+		}
+		si.value = nil
+		return
 	}
 
 	var s stats.TableStatisticProto
 	err := protoutil.Unmarshal(wrapper.value, &s)
 	if err != nil {
 		si.err = err
-		return false
+		return
 	}
 
-	*statsPtr = &s
-	return true
+	si.value = &s
 }
 
 type bytesIter struct {
@@ -1404,8 +1713,15 @@ func makeBytesIter(
 	}
 }
 
+func makeNoOpBytesIter() bytesIter {
+	return bytesIter{}
+}
 func (bi *bytesIter) next(resWrapper *resultWrapper) bool {
 	if bi.iterError != nil {
+		return false
+	}
+
+	if bi.Iter == nil {
 		return false
 	}
 
@@ -1450,4 +1766,288 @@ func (bi *bytesIter) close() {
 type resultWrapper struct {
 	key   storage.MVCCKey
 	value []byte
+}
+
+// ReadBackupMetadataFromStore reads a backup metadata SST from the store and
+// returns it.
+// TODO(rui): Add memory monitor.
+func ReadBackupMetadataFromStore(
+	ctx context.Context,
+	mem *mon.BoundAccount,
+	exportStore cloud.ExternalStorage,
+	encryption *jobspb.BackupEncryptionOptions,
+	kmsEnv cloud.KMSEnv,
+) (BackupManifest, int64, error) {
+	ctx, sp := tracing.ChildSpan(ctx, "backupinfo.ReadBackupMetadataFromStore")
+	defer sp.Finish()
+
+	metadata, err := NewBackupMetadata(ctx, exportStore, MetadataSSTName, encryption, kmsEnv)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	metadata.SetDir(exportStore.Conf())
+	return metadata, 0, nil
+}
+
+// BackupManifestAdapter adapts a backuppb.BackupManifest to the BackupManifest
+// interface.
+type BackupManifestAdapter struct {
+	*backuppb.BackupManifest
+	exportStore  cloud.ExternalStorage
+	encryption   *jobspb.BackupEncryptionOptions
+	kmsEnv       cloud.KMSEnv
+	storeFactory cloud.ExternalStorageFactory
+}
+
+var _ BackupManifest = &BackupManifestAdapter{}
+
+// NewBackupManifestAdapter constructs a BackupManifestAdapter from a backup
+// manifest protobuf.
+func NewBackupManifestAdapter(
+	manifest *backuppb.BackupManifest,
+	exportStore cloud.ExternalStorage,
+	encryption *jobspb.BackupEncryptionOptions,
+	kmsEnv cloud.KMSEnv,
+	storeFactory cloud.ExternalStorageFactory,
+) *BackupManifestAdapter {
+	sort.Slice(manifest.DescriptorChanges, func(i, j int) bool {
+		return descChangesLess(&manifest.DescriptorChanges[i], &manifest.DescriptorChanges[j])
+	})
+	return &BackupManifestAdapter{
+		BackupManifest: manifest,
+		exportStore:    exportStore,
+		encryption:     encryption,
+		kmsEnv:         kmsEnv,
+		storeFactory:   storeFactory,
+	}
+}
+
+func (b *BackupManifestAdapter) NewSpanIter(ctx context.Context) Iterator[roachpb.Span] {
+	return newSliceIterator(b.Spans)
+}
+
+func (b *BackupManifestAdapter) NewIntroducedSpanIter(ctx context.Context) Iterator[roachpb.Span] {
+	return newSliceIterator(b.IntroducedSpans)
+}
+
+func (b *BackupManifestAdapter) NewDescriptorChangesIter(
+	ctx context.Context,
+) Iterator[*backuppb.BackupManifest_DescriptorRevision] {
+	return newSlicePointerIterator(b.DescriptorChanges)
+}
+
+func (b *BackupManifestAdapter) NewFileIter(
+	ctx context.Context,
+) (Iterator[*backuppb.BackupManifest_File], error) {
+	if b.HasExternalFilesList {
+		es, err := b.storeFactory(ctx, b.Dir())
+		if err != nil {
+			return nil, err
+		}
+		storeFile := storageccl.StoreFile{
+			Store:    es,
+			FilePath: BackupMetadataFilesListPath,
+		}
+		var encOpts *roachpb.FileEncryptionOptions
+		if b.encryption != nil {
+			key, err := backupencryption.GetEncryptionKey(ctx, b.encryption, b.kmsEnv)
+			if err != nil {
+				return nil, err
+			}
+			encOpts = &roachpb.FileEncryptionOptions{Key: key}
+		}
+		return NewFileSSTIter(ctx, storeFile, encOpts)
+	}
+
+	return newSlicePointerIterator(b.Files), nil
+}
+
+func (b *BackupManifestAdapter) NewDescIter(ctx context.Context) Iterator[*descpb.Descriptor] {
+	return newSlicePointerIterator(b.Descriptors)
+}
+
+func (b *BackupManifestAdapter) NewTenantIter(
+	ctx context.Context,
+) Iterator[descpb.TenantInfoWithUsage] {
+	return newSliceIterator(b.Tenants)
+}
+
+func (b *BackupManifestAdapter) NewStatsIter(
+	ctx context.Context,
+) Iterator[*stats.TableStatisticProto] {
+	ctx, sp := tracing.ChildSpan(ctx, "BackupManifestAdapter.NewStatsIter")
+	defer sp.Finish()
+
+	// This part deals with pre-20.2 stats format where backup statistics
+	// are stored as a field in backup manifests instead of in their
+	// individual files.
+	if b.DeprecatedStatistics() != nil {
+		return newSliceIterator(b.DeprecatedStatistics())
+	}
+
+	tableStatistics := make([]*stats.TableStatisticProto, 0, len(b.StatisticsFilenames))
+	uniqueFileNames := make(map[string]struct{})
+	for _, fname := range b.StatisticsFilenames {
+		if _, exists := uniqueFileNames[fname]; !exists {
+			uniqueFileNames[fname] = struct{}{}
+			myStatsTable, err := readTableStatistics(ctx, b.exportStore, fname, b.encryption, b.kmsEnv)
+			if err != nil {
+				break
+			}
+			tableStatistics = append(tableStatistics, myStatsTable.Statistics...)
+		}
+	}
+
+	return newSliceIterator(tableStatistics)
+}
+
+func (b *BackupManifestAdapter) StartTime() hlc.Timestamp {
+	return b.BackupManifest.StartTime
+}
+
+func (b *BackupManifestAdapter) EndTime() hlc.Timestamp {
+	return b.BackupManifest.EndTime
+}
+
+func (b *BackupManifestAdapter) MVCCFilter() backuppb.MVCCFilter {
+	return b.BackupManifest.MVCCFilter
+}
+
+func (b *BackupManifestAdapter) RevisionStartTime() hlc.Timestamp {
+	return b.BackupManifest.RevisionStartTime
+}
+
+func (b *BackupManifestAdapter) TenantsDeprecated() []descpb.TenantInfo {
+	return b.BackupManifest.TenantsDeprecated
+}
+
+func (b *BackupManifestAdapter) CompleteDBs() []descpb.ID {
+	return b.BackupManifest.CompleteDbs
+}
+
+func (b *BackupManifestAdapter) EntryCounts() roachpb.RowCount {
+	return b.BackupManifest.EntryCounts
+}
+
+func (b *BackupManifestAdapter) Dir() cloudpb.ExternalStorage {
+	return b.BackupManifest.Dir
+}
+
+func (b *BackupManifestAdapter) SetDir(dir cloudpb.ExternalStorage) {
+	b.BackupManifest.Dir = dir
+}
+
+func (b *BackupManifestAdapter) FormatVersion() uint32 {
+	return b.BackupManifest.FormatVersion
+}
+
+func (b *BackupManifestAdapter) ClusterID() uuid.UUID {
+	return b.BackupManifest.ClusterID
+}
+
+func (b *BackupManifestAdapter) NodeID() roachpb.NodeID {
+	return b.BackupManifest.NodeID
+}
+
+func (b *BackupManifestAdapter) BuildInfo() build.Info {
+	return b.BackupManifest.BuildInfo
+}
+
+func (b *BackupManifestAdapter) ClusterVersion() roachpb.Version {
+	return b.BackupManifest.ClusterVersion
+}
+
+func (b *BackupManifestAdapter) ID() uuid.UUID {
+	return b.BackupManifest.ID
+}
+
+func (b *BackupManifestAdapter) PartitionDescriptorFilenames() []string {
+	return b.BackupManifest.PartitionDescriptorFilenames
+}
+
+func (b *BackupManifestAdapter) LocalityKVs() []string {
+	return b.BackupManifest.LocalityKVs
+}
+
+func (b *BackupManifestAdapter) DeprecatedStatistics() []*stats.TableStatisticProto {
+	return b.BackupManifest.DeprecatedStatistics
+}
+
+func (b *BackupManifestAdapter) DescriptorCoverage() tree.DescriptorCoverage {
+	return b.BackupManifest.DescriptorCoverage
+}
+
+func (b *BackupManifestAdapter) SortFiles() {
+	sort.Sort(BackupFileDescriptors(b.Files))
+}
+
+func (b *BackupManifestAdapter) Manifest() *backuppb.BackupManifest {
+	return b.BackupManifest
+}
+
+type sliceIterator[T any] struct {
+	backingSlice []T
+	idx          int
+	defaultValue T
+}
+
+var _ Iterator[any] = &sliceIterator[any]{}
+
+func newSliceIterator[T any](backing []T) *sliceIterator[T] {
+	return &sliceIterator[T]{
+		backingSlice: backing,
+	}
+}
+
+// Valid implements the Iterator interface.
+func (s *sliceIterator[T]) Valid() (bool, error) {
+	return s.idx < len(s.backingSlice), nil
+}
+
+func (s *sliceIterator[T]) Value() T {
+	if s.idx < len(s.backingSlice) {
+		return s.backingSlice[s.idx]
+	}
+
+	return s.defaultValue
+}
+
+func (s *sliceIterator[T]) Next() {
+	s.idx++
+}
+
+func (s *sliceIterator[T]) Close() {
+}
+
+type slicePointerIterator[T any] struct {
+	backingSlice []T
+	idx          int
+}
+
+var _ Iterator[*backuppb.BackupManifest_DescriptorRevision] = &slicePointerIterator[backuppb.BackupManifest_DescriptorRevision]{}
+
+func newSlicePointerIterator[T any](backing []T) *slicePointerIterator[T] {
+	return &slicePointerIterator[T]{
+		backingSlice: backing,
+	}
+}
+
+func (s *slicePointerIterator[T]) Valid() (bool, error) {
+	return s.idx < len(s.backingSlice), nil
+}
+
+func (s *slicePointerIterator[T]) Value() *T {
+	if s.idx < len(s.backingSlice) {
+		return &s.backingSlice[s.idx]
+	}
+
+	return nil
+}
+
+func (s *slicePointerIterator[T]) Next() {
+	s.idx++
+}
+
+func (s *slicePointerIterator[T]) Close() {
 }

--- a/pkg/ccl/backupccl/backupinfo/manifest_handling.go
+++ b/pkg/ccl/backupccl/backupinfo/manifest_handling.go
@@ -42,8 +42,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
-	"github.com/cockroachdb/cockroach/pkg/sql/stats"
-	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/ctxgroup"
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
@@ -92,7 +90,7 @@ var WriteMetadataSST = settings.RegisterBoolSetting(
 	settings.TenantWritable,
 	"kv.bulkio.write_metadata_sst.enabled",
 	"write experimental new format BACKUP metadata file",
-	util.ConstantWithMetamorphicTestBool("write-metadata-sst", false),
+	true,
 )
 
 // IsGZipped detects whether the given bytes represent GZipped data. This check
@@ -130,35 +128,51 @@ func ReadBackupManifestFromURI(
 	uri string,
 	user username.SQLUsername,
 	makeExternalStorageFromURI cloud.ExternalStorageFromURIFactory,
+	storeFactory cloud.ExternalStorageFactory,
 	encryption *jobspb.BackupEncryptionOptions,
 	kmsEnv cloud.KMSEnv,
-) (backuppb.BackupManifest, int64, error) {
+	mode jobspb.BackupManifestReadMode,
+) (BackupManifest, int64, error) {
 	exportStore, err := makeExternalStorageFromURI(ctx, uri, user)
 
 	if err != nil {
-		return backuppb.BackupManifest{}, 0, err
+		return nil, 0, err
 	}
 	defer exportStore.Close()
-	return ReadBackupManifestFromStore(ctx, mem, exportStore, encryption, kmsEnv)
+	return ReadBackupManifestFromStore(ctx, mem, exportStore, encryption, kmsEnv, storeFactory, mode)
 }
 
-// ReadBackupManifestFromStore reads and unmarshalls a BackupManifest from the
-// store and returns it with the size it reserved for it from the boundAccount.
+// ReadBackupManifestFromStore reads a BackupManifest from the store and returns
+// it with the size it reserved for it from the boundAccount.
 func ReadBackupManifestFromStore(
 	ctx context.Context,
 	mem *mon.BoundAccount,
 	exportStore cloud.ExternalStorage,
 	encryption *jobspb.BackupEncryptionOptions,
 	kmsEnv cloud.KMSEnv,
-) (backuppb.BackupManifest, int64, error) {
+	storeFactory cloud.ExternalStorageFactory,
+	mode jobspb.BackupManifestReadMode,
+) (BackupManifest, int64, error) {
 	ctx, sp := tracing.ChildSpan(ctx, "backupinfo.ReadBackupManifestFromStore")
 	defer sp.Finish()
+
+	if mode != jobspb.BackupManifestReadMode_ForceManifest {
+		m, memSize, err := ReadBackupMetadataFromStore(ctx, mem, exportStore, encryption, kmsEnv)
+		if err == nil {
+			m.SetDir(exportStore.Conf())
+			return m, memSize, err
+		}
+
+		if mode == jobspb.BackupManifestReadMode_ForceMetadataSST || !errors.Is(err, cloud.ErrFileDoesNotExist) {
+			return nil, 0, err
+		}
+	}
 
 	manifest, memSize, err := ReadBackupManifest(ctx, mem, exportStore, backupbase.BackupMetadataName,
 		encryption, kmsEnv)
 	if err != nil {
 		if !errors.Is(err, cloud.ErrFileDoesNotExist) {
-			return backuppb.BackupManifest{}, 0, err
+			return nil, 0, err
 		}
 
 		// If we did not find `BACKUP_METADATA` we look for the
@@ -168,7 +182,7 @@ func ReadBackupManifestFromStore(
 			backupbase.BackupManifestName, encryption, kmsEnv)
 		if backupManifestErr != nil {
 			if !errors.Is(backupManifestErr, cloud.ErrFileDoesNotExist) {
-				return backuppb.BackupManifest{}, 0, err
+				return nil, 0, err
 			}
 
 			// If we did not find a `BACKUP_MANIFEST` we look for a `BACKUP` file as
@@ -179,7 +193,7 @@ func ReadBackupManifestFromStore(
 			oldBackupManifest, oldBackupManifestMemSize, oldBackupManifestErr := ReadBackupManifest(ctx, mem, exportStore,
 				backupbase.BackupOldManifestName, encryption, kmsEnv)
 			if oldBackupManifestErr != nil {
-				return backuppb.BackupManifest{}, 0, oldBackupManifestErr
+				return nil, 0, oldBackupManifestErr
 			} else {
 				// We found a `BACKUP` manifest file.
 				manifest = oldBackupManifest
@@ -191,8 +205,10 @@ func ReadBackupManifestFromStore(
 			memSize = backupManifestMemSize
 		}
 	}
-	manifest.Dir = exportStore.Conf()
-	return manifest, memSize, nil
+
+	manifestAdapter := NewBackupManifestAdapter(&manifest, exportStore, encryption, kmsEnv, storeFactory)
+	manifestAdapter.SetDir(exportStore.Conf())
+	return manifestAdapter, memSize, nil
 }
 
 // compressData compresses data buffer and returns compressed
@@ -492,40 +508,6 @@ func readTableStatistics(
 	return &tableStats, err
 }
 
-// GetStatisticsFromBackup retrieves Statistics from backup manifest,
-// either through the Statistics field or from the files.
-func GetStatisticsFromBackup(
-	ctx context.Context,
-	exportStore cloud.ExternalStorage,
-	encryption *jobspb.BackupEncryptionOptions,
-	kmsEnv cloud.KMSEnv,
-	backup backuppb.BackupManifest,
-) ([]*stats.TableStatisticProto, error) {
-	ctx, sp := tracing.ChildSpan(ctx, "backupinfo.GetStatisticsFromBackup")
-	defer sp.Finish()
-
-	// This part deals with pre-20.2 stats format where backup statistics
-	// are stored as a field in backup manifests instead of in their
-	// individual files.
-	if backup.DeprecatedStatistics != nil {
-		return backup.DeprecatedStatistics, nil
-	}
-	tableStatistics := make([]*stats.TableStatisticProto, 0, len(backup.StatisticsFilenames))
-	uniqueFileNames := make(map[string]struct{})
-	for _, fname := range backup.StatisticsFilenames {
-		if _, exists := uniqueFileNames[fname]; !exists {
-			uniqueFileNames[fname] = struct{}{}
-			myStatsTable, err := readTableStatistics(ctx, exportStore, fname, encryption, kmsEnv)
-			if err != nil {
-				return tableStatistics, err
-			}
-			tableStatistics = append(tableStatistics, myStatsTable.Statistics...)
-		}
-	}
-
-	return tableStatistics, nil
-}
-
 // WriteBackupLock is responsible for writing a job ID suffixed
 // `BACKUP-LOCK` file that will prevent concurrent backups from writing to the
 // same location.
@@ -737,14 +719,16 @@ func LoadBackupManifestsAtTime(
 	uris []string,
 	user username.SQLUsername,
 	makeExternalStorageFromURI cloud.ExternalStorageFromURIFactory,
+	storeFactory cloud.ExternalStorageFactory,
 	encryption *jobspb.BackupEncryptionOptions,
 	kmsEnv cloud.KMSEnv,
 	asOf hlc.Timestamp,
-) ([]backuppb.BackupManifest, int64, error) {
+	mode jobspb.BackupManifestReadMode,
+) ([]BackupManifest, int64, error) {
 	ctx, sp := tracing.ChildSpan(ctx, "backupinfo.LoadBackupManifests")
 	defer sp.Finish()
 
-	backupManifests := make([]backuppb.BackupManifest, len(uris))
+	backupManifests := make([]BackupManifest, len(uris))
 	var reserved int64
 	defer func() {
 		if reserved != 0 {
@@ -752,12 +736,12 @@ func LoadBackupManifestsAtTime(
 		}
 	}()
 	for i, uri := range uris {
-		desc, memSize, err := ReadBackupManifestFromURI(ctx, mem, uri, user, makeExternalStorageFromURI,
-			encryption, kmsEnv)
+		desc, memSize, err := ReadBackupManifestFromURI(ctx, mem, uri, user, makeExternalStorageFromURI, storeFactory,
+			encryption, kmsEnv, mode)
 		if err != nil {
 			return nil, 0, errors.Wrapf(err, "failed to read backup descriptor")
 		}
-		if !asOf.IsEmpty() && asOf.Less(desc.StartTime) {
+		if !asOf.IsEmpty() && asOf.Less(desc.StartTime()) {
 			break
 		}
 		reserved += memSize
@@ -783,7 +767,7 @@ func GetLocalityInfo(
 	ctx context.Context,
 	stores []cloud.ExternalStorage,
 	uris []string,
-	mainBackupManifest backuppb.BackupManifest,
+	mainBackupManifest BackupManifest,
 	encryption *jobspb.BackupEncryptionOptions,
 	kmsEnv cloud.KMSEnv,
 	prefix string,
@@ -795,7 +779,7 @@ func GetLocalityInfo(
 	// Now get the list of expected partial per-store backup manifest filenames
 	// and attempt to find them.
 	urisByOrigLocality := make(map[string]string)
-	for _, filename := range mainBackupManifest.PartitionDescriptorFilenames {
+	for _, filename := range mainBackupManifest.PartitionDescriptorFilenames() {
 		if prefix != "" {
 			filename = path.Join(prefix, filename)
 		}
@@ -811,10 +795,10 @@ func GetLocalityInfo(
 			// the same place.
 			if desc, _, err := readBackupPartitionDescriptor(ctx, nil /*mem*/, store, filename,
 				encryption, kmsEnv); err == nil {
-				if desc.BackupID != mainBackupManifest.ID {
+				if desc.BackupID != mainBackupManifest.ID() {
 					return info, errors.Errorf(
 						"expected backup part to have backup ID %s, found %s",
-						mainBackupManifest.ID, desc.BackupID,
+						mainBackupManifest.ID(), desc.BackupID,
 					)
 				}
 				origLocalityKV := desc.LocalityKV
@@ -846,33 +830,33 @@ func GetLocalityInfo(
 // the requested time.
 func ValidateEndTimeAndTruncate(
 	defaultURIs []string,
-	mainBackupManifests []backuppb.BackupManifest,
+	mainBackupManifests []BackupManifest,
 	localityInfo []jobspb.RestoreDetails_BackupLocalityInfo,
 	endTime hlc.Timestamp,
-) ([]string, []backuppb.BackupManifest, []jobspb.RestoreDetails_BackupLocalityInfo, error) {
+) ([]string, []BackupManifest, []jobspb.RestoreDetails_BackupLocalityInfo, error) {
 	if endTime.IsEmpty() {
 		return defaultURIs, mainBackupManifests, localityInfo, nil
 	}
 	for i, b := range mainBackupManifests {
 		// Find the backup that covers the requested time.
-		if !(b.StartTime.Less(endTime) && endTime.LessEq(b.EndTime)) {
+		if !(b.StartTime().Less(endTime) && endTime.LessEq(b.EndTime())) {
 			continue
 		}
 
 		// Ensure that the backup actually has revision history.
-		if !endTime.Equal(b.EndTime) {
-			if b.MVCCFilter != backuppb.MVCCFilter_All {
+		if !endTime.Equal(b.EndTime()) {
+			if b.MVCCFilter() != backuppb.MVCCFilter_All {
 				const errPrefix = "invalid RESTORE timestamp: restoring to arbitrary time requires that BACKUP for requested time be created with 'revision_history' option."
 				if i == 0 {
 					return nil, nil, nil, errors.Errorf(
 						errPrefix+" nearest backup time is %s",
-						timeutil.Unix(0, b.EndTime.WallTime).UTC(),
+						timeutil.Unix(0, b.EndTime().WallTime).UTC(),
 					)
 				}
 				return nil, nil, nil, errors.Errorf(
 					errPrefix+" nearest BACKUP times are %s or %s",
-					timeutil.Unix(0, mainBackupManifests[i-1].EndTime.WallTime).UTC(),
-					timeutil.Unix(0, b.EndTime.WallTime).UTC(),
+					timeutil.Unix(0, mainBackupManifests[i-1].EndTime().WallTime).UTC(),
+					timeutil.Unix(0, b.EndTime().WallTime).UTC(),
 				)
 			}
 			// Ensure that the revision history actually covers the requested time -
@@ -880,10 +864,10 @@ func ValidateEndTimeAndTruncate(
 			// example if start time is 0 (full backup), the revision history was
 			// only captured since the GC window. Note that the RevisionStartTime is
 			// the latest for ranges backed up.
-			if endTime.LessEq(b.RevisionStartTime) {
+			if endTime.LessEq(b.RevisionStartTime()) {
 				return nil, nil, nil, errors.Errorf(
 					"invalid RESTORE timestamp: BACKUP for requested time only has revision history"+
-						" from %v", timeutil.Unix(0, b.RevisionStartTime.WallTime).UTC(),
+						" from %v", timeutil.Unix(0, b.RevisionStartTime().WallTime).UTC(),
 				)
 			}
 		}
@@ -896,68 +880,74 @@ func ValidateEndTimeAndTruncate(
 	)
 }
 
-// GetBackupIndexAtTime returns the index of the latest backup in
-// `backupManifests` with a StartTime >= asOf.
-func GetBackupIndexAtTime(
-	backupManifests []backuppb.BackupManifest, asOf hlc.Timestamp,
-) (int, error) {
-	if len(backupManifests) == 0 {
-		return -1, errors.New("expected a nonempty backup manifest list, got an empty list")
-	}
-	backupManifestIndex := len(backupManifests) - 1
-	if asOf.IsEmpty() {
-		return backupManifestIndex, nil
-	}
-	for ind, b := range backupManifests {
-		if asOf.Less(b.StartTime) {
-			break
-		}
-		backupManifestIndex = ind
-	}
-	return backupManifestIndex, nil
-}
-
 // LoadSQLDescsFromBackupsAtTime returns the Descriptors found in the last
 // (latest) backup with a StartTime >= asOf.
+//
+// TODO(rui): note that materializing all descriptors doesn't scale with cluster
+// size. We temporarily materialize all descriptors here to limit the scope of
+// changes required to use BackupManifest with iterating repeated fields in
+// restore.
 func LoadSQLDescsFromBackupsAtTime(
-	backupManifests []backuppb.BackupManifest, asOf hlc.Timestamp,
-) ([]catalog.Descriptor, backuppb.BackupManifest, error) {
+	ctx context.Context, backupManifests []BackupManifest, asOf hlc.Timestamp,
+) ([]catalog.Descriptor, BackupManifest, error) {
 	lastBackupManifest := backupManifests[len(backupManifests)-1]
 
 	if asOf.IsEmpty() {
-		if lastBackupManifest.DescriptorCoverage != tree.AllDescriptors {
-			descs, err := BackupManifestDescriptors(&lastBackupManifest)
-			return descs, lastBackupManifest, err
+		if lastBackupManifest.DescriptorCoverage() != tree.AllDescriptors {
+			descs, err := BackupManifestDescriptors(ctx, lastBackupManifest)
+			if err != nil {
+				return nil, nil, err
+			}
+			return descs, lastBackupManifest, nil
 		}
 
 		// Cluster backups with revision history may have included previous database
 		// versions of database descriptors in lastBackupManifest.Descriptors. Find
 		// the correct set of descriptors by going through their revisions. See
 		// #68541.
-		asOf = lastBackupManifest.EndTime
+		asOf = lastBackupManifest.EndTime()
 	}
 
 	for _, b := range backupManifests {
-		if asOf.Less(b.StartTime) {
+		if asOf.Less(b.StartTime()) {
 			break
 		}
 		lastBackupManifest = b
 	}
-	if len(lastBackupManifest.DescriptorChanges) == 0 {
-		descs, err := BackupManifestDescriptors(&lastBackupManifest)
-		return descs, lastBackupManifest, err
+	descRevIt := lastBackupManifest.NewDescriptorChangesIter(ctx)
+	defer descRevIt.Close()
+	if ok, err := descRevIt.Valid(); err != nil {
+		return nil, nil, err
+	} else if !ok {
+		descs, err := BackupManifestDescriptors(ctx, lastBackupManifest)
+		if err != nil {
+			return nil, nil, err
+		}
+		return descs, lastBackupManifest, nil
 	}
 
-	byID := make(map[descpb.ID]catalog.DescriptorBuilder, len(lastBackupManifest.Descriptors))
-	for _, rev := range lastBackupManifest.DescriptorChanges {
-		if asOf.Less(rev.Time) {
+	byID := make(map[descpb.ID]catalog.DescriptorBuilder, 0)
+	prevRevID := descpb.InvalidID
+	for ; ; descRevIt.Next() {
+		if ok, err := descRevIt.Valid(); err != nil {
+			return nil, nil, err
+		} else if !ok {
 			break
 		}
-		if rev.Desc == nil {
-			delete(byID, rev.ID)
-		} else {
+
+		rev := descRevIt.Value()
+		if asOf.Less(rev.Time) {
+			continue
+		}
+
+		if rev.ID == prevRevID {
+			continue
+		}
+
+		if rev.Desc != nil {
 			byID[rev.ID] = newDescriptorBuilder(rev.Desc, rev.Time)
 		}
+		prevRevID = rev.ID
 	}
 
 	allDescs := make([]catalog.Descriptor, 0, len(byID))
@@ -968,7 +958,7 @@ func LoadSQLDescsFromBackupsAtTime(
 		// A revision may have been captured before it was in a DB that is
 		// backed up -- if the DB is missing, filter the object.
 		if err := b.RunPostDeserializationChanges(); err != nil {
-			return nil, backuppb.BackupManifest{}, err
+			return nil, nil, err
 		}
 		desc := b.BuildCreatedMutable()
 		var isObject bool
@@ -1141,11 +1131,20 @@ func TempCheckpointFileNameForJob(jobID jobspb.JobID) string {
 // BackupManifestDescriptors returns the descriptors encoded in the manifest as
 // a slice of mutable descriptors.
 func BackupManifestDescriptors(
-	backupManifest *backuppb.BackupManifest,
+	ctx context.Context, backupManifest BackupManifest,
 ) ([]catalog.Descriptor, error) {
-	ret := make([]catalog.Descriptor, 0, len(backupManifest.Descriptors))
-	for i := range backupManifest.Descriptors {
-		b := newDescriptorBuilder(&backupManifest.Descriptors[i], backupManifest.EndTime)
+	descIt := backupManifest.NewDescIter(ctx)
+	defer descIt.Close()
+
+	ret := make([]catalog.Descriptor, 0)
+	for ; ; descIt.Next() {
+		if ok, err := descIt.Valid(); err != nil {
+			return nil, err
+		} else if !ok {
+			break
+		}
+
+		b := newDescriptorBuilder(descIt.Value(), backupManifest.EndTime())
 		if b == nil {
 			continue
 		}
@@ -1373,14 +1372,16 @@ func GetBackupManifests(
 	mem *mon.BoundAccount,
 	user username.SQLUsername,
 	makeCloudStorage cloud.ExternalStorageFromURIFactory,
+	storeFactory cloud.ExternalStorageFactory,
 	backupURIs []string,
 	encryption *jobspb.BackupEncryptionOptions,
 	kmsEnv cloud.KMSEnv,
-) ([]backuppb.BackupManifest, int64, error) {
+	mode jobspb.BackupManifestReadMode,
+) ([]BackupManifest, int64, error) {
 	ctx, sp := tracing.ChildSpan(ctx, "backupinfo.GetBackupManifests")
 	defer sp.Finish()
 
-	manifests := make([]backuppb.BackupManifest, len(backupURIs))
+	manifests := make([]BackupManifest, len(backupURIs))
 	if len(backupURIs) == 0 {
 		return manifests, 0, nil
 	}
@@ -1409,7 +1410,7 @@ func GetBackupManifests(
 			// descriptors around.
 			uri := backupURIs[i]
 			desc, size, err := ReadBackupManifestFromURI(
-				ctx, &subMem, uri, user, makeCloudStorage, encryption, kmsEnv,
+				ctx, &subMem, uri, user, makeCloudStorage, storeFactory, encryption, kmsEnv, mode,
 			)
 			if err != nil {
 				return errors.Wrapf(err, "failed to read backup from %q",
@@ -1439,12 +1440,26 @@ func GetBackupManifests(
 }
 
 // MakeBackupCodec returns the codec that was used to encode the keys in the backup.
-func MakeBackupCodec(manifest backuppb.BackupManifest) (keys.SQLCodec, error) {
+func MakeBackupCodec(ctx context.Context, bm BackupManifest) (keys.SQLCodec, error) {
 	backupCodec := keys.SystemSQLCodec
-	if len(manifest.Spans) != 0 && !manifest.HasTenants() {
+	spanIt := bm.NewSpanIter(ctx)
+	defer spanIt.Close()
+	tenantIt := bm.NewTenantIter(ctx)
+	defer tenantIt.Close()
+
+	hasSpans, err := spanIt.Valid()
+	if err != nil {
+		return backupCodec, err
+	}
+	hasTenants, err := tenantIt.Valid()
+	if err != nil {
+		return backupCodec, err
+	}
+
+	if hasSpans && !hasTenants {
 		// If there are no tenant targets, then the entire keyspace covered by
 		// Spans must lie in 1 tenant.
-		_, backupTenantID, err := keys.DecodeTenantPrefix(manifest.Spans[0].Key)
+		_, backupTenantID, err := keys.DecodeTenantPrefix(spanIt.Value().Key)
 		if err != nil {
 			return backupCodec, err
 		}

--- a/pkg/ccl/backupccl/bench_covering_test.go
+++ b/pkg/ccl/backupccl/bench_covering_test.go
@@ -13,6 +13,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/ccl/backupccl/backupinfo"
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 	"github.com/cockroachdb/cockroach/pkg/util/ctxgroup"
@@ -39,10 +40,17 @@ func BenchmarkCoverageChecks(b *testing.B) {
 								b.Run(fmt.Sprintf("slim=%t", hasExternalFilesList), func(b *testing.B) {
 									backups, err := MockBackupChain(ctx, numBackups, numSpans, baseFiles, r, hasExternalFilesList, execCfg)
 									require.NoError(b, err)
+
+									spanIt := backups[numBackups-1].NewSpanIter(ctx)
+									defer spanIt.Close()
+
+									requiredSpans, err := backupinfo.CollectToSlice(spanIt)
+									require.NoError(b, err)
+
 									b.ResetTimer()
 
 									for i := 0; i < b.N; i++ {
-										if err := checkCoverage(ctx, backups[numBackups-1].Spans, backups); err != nil {
+										if err := checkCoverage(ctx, requiredSpans, backups); err != nil {
 											b.Fatal(err)
 										}
 									}
@@ -75,16 +83,19 @@ func BenchmarkRestoreEntryCover(b *testing.B) {
 									func(b *testing.B) {
 										backups, err := MockBackupChain(ctx, numBackups, numSpans, baseFiles, r, hasExternalFilesList, execCfg)
 										require.NoError(b, err)
+
+										spanIt := backups[numBackups-1].NewSpanIter(ctx)
+										defer spanIt.Close()
+
+										requiredSpans, err := backupinfo.CollectToSlice(spanIt)
+										require.NoError(b, err)
+
 										b.ResetTimer()
 										for i := 0; i < b.N; i++ {
-											if err := checkCoverage(ctx, backups[numBackups-1].Spans, backups); err != nil {
+											if err := checkCoverage(ctx, requiredSpans, backups); err != nil {
 												b.Fatal(err)
 											}
-											introducedSpanFrontier, err := createIntroducedSpanFrontier(backups, hlc.Timestamp{})
-											require.NoError(b, err)
-
-											layerToBackupManifestFileIterFactory, err := getBackupManifestFileIters(ctx, &execCfg,
-												backups, nil, nil)
+											introducedSpanFrontier, err := createIntroducedSpanFrontier(ctx, backups, hlc.Timestamp{})
 											require.NoError(b, err)
 
 											spanCh := make(chan execinfrapb.RestoreSpanEntry, 1000)
@@ -92,8 +103,8 @@ func BenchmarkRestoreEntryCover(b *testing.B) {
 											g := ctxgroup.WithContext(ctx)
 											g.GoCtx(func(ctx context.Context) error {
 												defer close(spanCh)
-												return generateAndSendImportSpans(ctx, backups[numBackups-1].Spans, backups,
-													layerToBackupManifestFileIterFactory, nil, introducedSpanFrontier, nil, 0, spanCh, false)
+												return generateAndSendImportSpans(ctx, requiredSpans, backups,
+													nil, introducedSpanFrontier, nil, 0, spanCh, false)
 											})
 
 											var cov []execinfrapb.RestoreSpanEntry

--- a/pkg/ccl/backupccl/full_cluster_backup_restore_test.go
+++ b/pkg/ccl/backupccl/full_cluster_backup_restore_test.go
@@ -614,6 +614,7 @@ func TestClusterRestoreFailCleanup(t *testing.T) {
 	// the test all together, setting the cluster setting to false which triggers
 	// the failure.
 	sqlDB.Exec(t, "SET CLUSTER SETTING kv.bulkio.write_metadata_sst.enabled=false")
+	sqlDB.Exec(t, `SET CLUSTER SETTING restore.manifest_read.mode = 'forceManifest'`)
 
 	// Setup the system systemTablesToVerify to ensure that they are copied to the new cluster.
 	// Populate system.users.
@@ -648,6 +649,7 @@ func TestClusterRestoreFailCleanup(t *testing.T) {
 	t.Run("during restoration of data", func(t *testing.T) {
 		_, sqlDBRestore, cleanupEmptyCluster := backupRestoreTestSetupEmpty(t, singleNode, tempDir, InitManualReplication, base.TestClusterArgs{})
 		defer cleanupEmptyCluster()
+		sqlDBRestore.Exec(t, `SET CLUSTER SETTING restore.manifest_read.mode = 'forceManifest'`)
 		sqlDBRestore.ExpectErr(t, "sst: no such file", `RESTORE FROM 'nodelocal://1/missing-ssts'`)
 		// Verify the failed RESTORE added some DROP tables.
 		// Note that the system tables here correspond to the temporary tables
@@ -692,6 +694,8 @@ func TestClusterRestoreFailCleanup(t *testing.T) {
 				}}
 				tcRestore, sqlDBRestore, cleanupEmptyCluster := backupRestoreTestSetupEmpty(t, singleNode, tempDir, InitManualReplication, args)
 				defer cleanupEmptyCluster()
+
+				sqlDBRestore.Exec(t, `SET CLUSTER SETTING restore.manifest_read.mode = 'forceManifest'`)
 
 				// Inject a retry error, that returns once.
 				alreadyErrored := false
@@ -741,6 +745,7 @@ func TestClusterRestoreFailCleanup(t *testing.T) {
 			}
 		}
 
+		sqlDBRestore.Exec(t, `SET CLUSTER SETTING restore.manifest_read.mode = 'forceManifest'`)
 		sqlDBRestore.ExpectErr(t, "injected error", `RESTORE FROM $1`, localFoo)
 		// Verify the failed RESTORE added some DROP tables.
 		// Note that the system tables here correspond to the temporary tables
@@ -785,6 +790,7 @@ func TestClusterRestoreFailCleanup(t *testing.T) {
 			}
 		}
 
+		sqlDBRestore.Exec(t, `SET CLUSTER SETTING restore.manifest_read.mode = 'forceManifest'`)
 		sqlDBRestore.ExpectErr(t, "injected error", `RESTORE FROM $1`, localFoo)
 	})
 }

--- a/pkg/ccl/backupccl/restore_mid_schema_change_test.go
+++ b/pkg/ccl/backupccl/restore_mid_schema_change_test.go
@@ -264,6 +264,9 @@ func restoreMidSchemaChange(
 		if isSchemaOnly {
 			restoreQuery = restoreQuery + "with schema_only"
 		}
+
+		sqlDB.Exec(t, `SET CLUSTER SETTING restore.manifest_read.mode = 'forceManifest'`)
+
 		log.Infof(context.Background(), "%+v", sqlDB.QueryStr(t, "SHOW BACKUP $1", localFoo))
 		sqlDB.Exec(t, restoreQuery, localFoo)
 		// Wait for all jobs to terminate. Some may fail since we don't restore

--- a/pkg/ccl/backupccl/restore_old_sequences_test.go
+++ b/pkg/ccl/backupccl/restore_old_sequences_test.go
@@ -72,6 +72,7 @@ func restoreOldSequencesTest(exportDir string, isSchemaOnly bool) func(t *testin
 		defer cleanup()
 		err := os.Symlink(exportDir, filepath.Join(dir, "foo"))
 		require.NoError(t, err)
+		sqlDB.Exec(t, `SET CLUSTER SETTING restore.manifest_read.mode = 'forceManifest'`)
 		sqlDB.Exec(t, `CREATE DATABASE test`)
 		var unused string
 		var importedRows int

--- a/pkg/ccl/backupccl/restore_old_versions_test.go
+++ b/pkg/ccl/backupccl/restore_old_versions_test.go
@@ -183,8 +183,10 @@ func TestRestoreOldVersions(t *testing.T) {
 			err = os.Symlink(exportDir, filepath.Join(externalDir, "foo"))
 			require.NoError(t, err)
 
+			sqlDB.Exec(t, `SET CLUSTER SETTING restore.manifest_read.mode = 'forceManifest'`)
 			sqlDB.Exec(t, `RESTORE FROM $1`, localFoo)
 			sqlDB.Exec(t, `DROP DATABASE db1;`)
+			sqlDB.Exec(t, `SET CLUSTER SETTING restore.manifest_read.mode = 'forceManifest'`)
 			sqlDB.Exec(t, `RESTORE DATABASE db1 FROM $1`, localFoo)
 			sqlDB.CheckQueryResults(t,
 				`SELECT count(*) FROM [SHOW DATABASES] WHERE database_name = 'db1'`,
@@ -228,6 +230,8 @@ func TestRestoreOldVersions(t *testing.T) {
 			}()
 			err = os.Symlink(exportDir, filepath.Join(externalDir, "foo"))
 			require.NoError(t, err)
+
+			sqlDB.Exec(t, `SET CLUSTER SETTING restore.manifest_read.mode = 'forceManifest'`)
 
 			// Expect this restore to fail.
 			sqlDB.ExpectErr(t, `type "t" has unknown ParentID 50`, `RESTORE DATABASE otherdb FROM $1`, localFoo)
@@ -323,6 +327,7 @@ func restoreOldVersionTestWithInterleave(exportDir string) func(t *testing.T) {
 		defer cleanup()
 		err := os.Symlink(exportDir, filepath.Join(dir, "foo"))
 		require.NoError(t, err)
+		sqlDB.Exec(t, `SET CLUSTER SETTING restore.manifest_read.mode = 'forceManifest'`)
 		sqlDB.Exec(t, `CREATE DATABASE test`)
 		// Restore should now fail.
 		sqlDB.ExpectErr(t,
@@ -369,6 +374,8 @@ func runOldVersionMultiRegionTest(exportDir string) func(t *testing.T) {
 		require.NoError(t, os.Symlink(exportDir, filepath.Join(dir, "external_backup_dir")))
 
 		sqlDB := sqlutils.MakeSQLRunner(tc.Conns[0])
+
+		sqlDB.Exec(t, `SET CLUSTER SETTING restore.manifest_read.mode = 'forceManifest'`)
 
 		var unused string
 		var importedRows int
@@ -423,6 +430,7 @@ func restoreOldVersionTest(exportDir string) func(t *testing.T) {
 		defer cleanup()
 		err := os.Symlink(exportDir, filepath.Join(dir, "foo"))
 		require.NoError(t, err)
+		sqlDB.Exec(t, `SET CLUSTER SETTING restore.manifest_read.mode = 'forceManifest'`)
 		sqlDB.Exec(t, `CREATE DATABASE test`)
 		var unused string
 		var importedRows int
@@ -464,6 +472,7 @@ func restoreV201ZoneconfigPrivilegeTest(exportDir string) func(t *testing.T) {
 		defer cleanup()
 		err := os.Symlink(exportDir, filepath.Join(tmpDir, "foo"))
 		require.NoError(t, err)
+		sqlDB.Exec(t, `SET CLUSTER SETTING restore.manifest_read.mode = 'forceManifest'`)
 		sqlDB.Exec(t, `RESTORE FROM $1`, localFoo)
 		testDBGrants := [][]string{
 			{"test", "admin", "ALL", "true"},
@@ -497,6 +506,7 @@ func restoreOldVersionFKRevTest(exportDir string) func(t *testing.T) {
 		defer cleanup()
 		err := os.Symlink(exportDir, filepath.Join(dir, "foo"))
 		require.NoError(t, err)
+		sqlDB.Exec(t, `SET CLUSTER SETTING restore.manifest_read.mode = 'forceManifest'`)
 		sqlDB.Exec(t, `CREATE DATABASE ts`)
 		sqlDB.Exec(t, `RESTORE test.rev_times FROM $1 WITH into_db = 'ts'`, localFoo)
 		for _, ts := range sqlDB.QueryStr(t, `SELECT logical_time FROM ts.rev_times`) {
@@ -544,6 +554,8 @@ func deprecatedRestoreOldVersionClusterTest(exportDir string) func(t *testing.T)
 		}()
 		err := os.Symlink(exportDir, filepath.Join(externalDir, "foo"))
 		require.NoError(t, err)
+
+		sqlDB.Exec(t, `SET CLUSTER SETTING restore.manifest_read.mode = 'forceManifest'`)
 
 		// Ensure that the restore succeeds.
 		sqlDB.Exec(t, `RESTORE FROM $1`, localFoo)
@@ -595,6 +607,8 @@ func restoreOldVersionClusterTest(exportDir string) func(t *testing.T) {
 		}()
 		err := os.Symlink(exportDir, filepath.Join(externalDir, "foo"))
 		require.NoError(t, err)
+
+		sqlDB.Exec(t, `SET CLUSTER SETTING restore.manifest_read.mode = 'forceManifest'`)
 
 		// Ensure that the restore succeeds.
 		sqlDB.Exec(t, `RESTORE FROM $1`, localFoo)
@@ -819,6 +833,9 @@ func TestRestoreOldBackupMissingOfflineIndexes(t *testing.T) {
 			restoreTC := testcluster.StartTestCluster(t, singleNode, base.TestClusterArgs{ServerArgs: args})
 			defer restoreTC.Stopper().Stop(context.Background())
 			sqlDBRestore := sqlutils.MakeSQLRunner(restoreTC.Conns[0])
+
+			sqlDBRestore.Exec(t, `SET CLUSTER SETTING restore.manifest_read.mode = 'forceManifest'`)
+
 			from := strings.Join(backupDirs[:i], `,`)
 			sqlDBRestore.Exec(t, fmt.Sprintf(`RESTORE FROM %s`, from))
 
@@ -897,6 +914,8 @@ func TestRestoreWithDroppedSchemaCorruption(t *testing.T) {
 	tdb := sqlutils.MakeSQLRunner(sqlDB)
 	defer s.Stopper().Stop(ctx)
 
+	tdb.Exec(t, `SET CLUSTER SETTING restore.manifest_read.mode = 'forceManifest'`)
+
 	tdb.Exec(t, fmt.Sprintf("RESTORE DATABASE %s FROM '%s'", dbName, fromDir))
 	query := fmt.Sprintf("SELECT database_name FROM [SHOW DATABASES] WHERE database_name = '%s'", dbName)
 	tdb.CheckQueryResults(t, query, [][]string{{dbName}})
@@ -945,6 +964,7 @@ func restorePublicSchemaRemap(exportDir string) func(t *testing.T) {
 		err := os.Symlink(exportDir, filepath.Join(tmpDir, "foo"))
 		require.NoError(t, err)
 
+		sqlDB.Exec(t, `SET CLUSTER SETTING restore.manifest_read.mode = 'forceManifest'`)
 		sqlDB.Exec(t, fmt.Sprintf("RESTORE DATABASE d FROM '%s'", localFoo))
 
 		var restoredDBID, publicSchemaID int
@@ -1005,6 +1025,8 @@ func restoreSyntheticPublicSchemaNamespaceEntryCleanupOnFail(exportDir string) f
 		err := os.Symlink(exportDir, filepath.Join(tmpDir, "foo"))
 		require.NoError(t, err)
 
+		sqlDB.Exec(t, `SET CLUSTER SETTING restore.manifest_read.mode = 'forceManifest'`)
+
 		for _, server := range tc.Servers {
 			registry := server.JobRegistry().(*jobs.Registry)
 			registry.TestingResumerCreationKnobs = map[jobspb.Type]func(raw jobs.Resumer) jobs.Resumer{
@@ -1048,6 +1070,7 @@ func fullClusterRestoreUsersWithoutIDs(exportDir string) func(t *testing.T) {
 		err := os.Symlink(exportDir, filepath.Join(tmpDir, "foo"))
 		require.NoError(t, err)
 
+		sqlDB.Exec(t, `SET CLUSTER SETTING restore.manifest_read.mode = 'forceManifest'`)
 		sqlDB.Exec(t, fmt.Sprintf("RESTORE FROM '%s'", localFoo))
 
 		sqlDB.CheckQueryResults(t, `SELECT username, "hashedPassword", "isRole", user_id >= 100 FROM system.users`, [][]string{
@@ -1110,6 +1133,7 @@ func restoreSystemUsersWithoutIDs(exportDir string) func(t *testing.T) {
 		err := os.Symlink(exportDir, filepath.Join(tmpDir, "foo"))
 		require.NoError(t, err)
 
+		sqlDB.Exec(t, `SET CLUSTER SETTING restore.manifest_read.mode = 'forceManifest'`)
 		sqlDB.Exec(t, fmt.Sprintf("RESTORE SYSTEM USERS FROM '%s'", localFoo))
 
 		sqlDB.CheckQueryResults(t, `SELECT username, "hashedPassword", "isRole", user_id FROM system.users`, [][]string{
@@ -1190,6 +1214,7 @@ func fullClusterRestoreSystemRoleMembersWithoutIDs(exportDir string) func(t *tes
 		err := os.Symlink(exportDir, filepath.Join(tmpDir, "foo"))
 		require.NoError(t, err)
 
+		sqlDB.Exec(t, `SET CLUSTER SETTING restore.manifest_read.mode = 'forceManifest'`)
 		sqlDB.Exec(t, fmt.Sprintf("RESTORE FROM '%s'", localFoo))
 
 		sqlDB.CheckQueryResults(t, "SELECT * FROM system.role_members", [][]string{

--- a/pkg/ccl/backupccl/restore_planning.go
+++ b/pkg/ccl/backupccl/restore_planning.go
@@ -19,7 +19,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/ccl/backupccl/backupdest"
 	"github.com/cockroachdb/cockroach/pkg/ccl/backupccl/backupencryption"
 	"github.com/cockroachdb/cockroach/pkg/ccl/backupccl/backupinfo"
-	"github.com/cockroachdb/cockroach/pkg/ccl/backupccl/backuppb"
 	"github.com/cockroachdb/cockroach/pkg/ccl/backupccl/backuputils"
 	"github.com/cockroachdb/cockroach/pkg/ccl/multiregionccl"
 	"github.com/cockroachdb/cockroach/pkg/ccl/storageccl"
@@ -797,15 +796,26 @@ func maybeUpgradeDescriptors(descs []catalog.Descriptor, skipFKsWithNoMatchingTa
 // "other" table is missing from the set provided are omitted during the
 // upgrade, instead of causing an error to be returned.
 func maybeUpgradeDescriptorsInBackupManifests(
-	backupManifests []backuppb.BackupManifest, skipFKsWithNoMatchingTable bool,
+	ctx context.Context, backups []backupinfo.BackupManifest, skipFKsWithNoMatchingTable bool,
 ) error {
-	if len(backupManifests) == 0 {
+	if len(backups) == 0 {
 		return nil
 	}
 
-	descriptors := make([]catalog.Descriptor, 0, len(backupManifests[0].Descriptors))
-	for i := range backupManifests {
-		descs, err := backupinfo.BackupManifestDescriptors(&backupManifests[i])
+	// Only upgrade descriptors in the manifest if we have an adapted manifest, as
+	// backup metadata is not old enough to need upgrades.
+	adapters := make([]*backupinfo.BackupManifestAdapter, len(backups))
+	for i := range backups {
+		if adapter, ok := backups[i].(*backupinfo.BackupManifestAdapter); ok {
+			adapters[i] = adapter
+		} else {
+			return nil
+		}
+	}
+
+	descriptors := make([]catalog.Descriptor, 0, len(adapters[0].Descriptors))
+	for i := range adapters {
+		descs, err := backupinfo.BackupManifestDescriptors(ctx, adapters[i])
 		if err != nil {
 			return err
 		}
@@ -818,8 +828,8 @@ func maybeUpgradeDescriptorsInBackupManifests(
 	}
 
 	k := 0
-	for i := range backupManifests {
-		manifest := &backupManifests[i]
+	for i := range adapters {
+		manifest := adapters[i]
 		for j := range manifest.Descriptors {
 			manifest.Descriptors[j] = *descriptors[k].DescriptorProto()
 			k++
@@ -1411,6 +1421,8 @@ func doRestorePlan(
 		fullyResolvedSubdir = subdir
 	}
 
+	manifestReadMode := jobspb.BackupManifestReadMode(backupinfo.RestoreManifestReadMode.Get(&p.ExecCfg().Settings.SV))
+
 	fullyResolvedBaseDirectory, err := backuputils.AppendPaths(from[0][:], fullyResolvedSubdir)
 	if err != nil {
 		return err
@@ -1423,6 +1435,7 @@ func doRestorePlan(
 		incFrom,
 		from[0],
 		fullyResolvedSubdir,
+		manifestReadMode,
 	)
 	if err != nil {
 		if errors.Is(err, cloud.ErrListingUnsupported) {
@@ -1439,6 +1452,7 @@ func doRestorePlan(
 	//
 	// Note that incremental _backup_ requests to this location will fail loudly instead.
 	mkStore := p.ExecCfg().DistSQLSrv.ExternalStorageFromURI
+	storeFactory := p.ExecCfg().DistSQLSrv.ExternalStorage
 	baseStores, cleanupFn, err := backupdest.MakeBackupDestinationStores(ctx, p.User(), mkStore,
 		fullyResolvedBaseDirectory)
 	if err != nil {
@@ -1512,22 +1526,22 @@ func doRestorePlan(
 	// directories, return the URIs and manifests of all backup layers in all
 	// localities.
 	var defaultURIs []string
-	var mainBackupManifests []backuppb.BackupManifest
+	var mainBackupManifests []backupinfo.BackupManifest
 	var localityInfo []jobspb.RestoreDetails_BackupLocalityInfo
 	var memReserved int64
 	if len(from) <= 1 {
 		// Incremental layers are not specified explicitly. They will be searched for automatically.
 		// This could be either INTO-syntax, OR TO-syntax.
 		defaultURIs, mainBackupManifests, localityInfo, memReserved, err = backupdest.ResolveBackupManifests(
-			ctx, &mem, baseStores, incStores, mkStore, fullyResolvedBaseDirectory,
-			fullyResolvedIncrementalsDirectory, endTime, encryption, &kmsEnv, p.User(),
+			ctx, &mem, baseStores, incStores, mkStore, storeFactory, fullyResolvedBaseDirectory,
+			fullyResolvedIncrementalsDirectory, endTime, encryption, &kmsEnv, p.User(), manifestReadMode,
 		)
 	} else {
 		// Incremental layers are specified explicitly.
 		// This implies the old, deprecated TO-syntax.
 		defaultURIs, mainBackupManifests, localityInfo, memReserved, err =
-			backupdest.DeprecatedResolveBackupManifestsExplicitIncrementals(ctx, &mem, mkStore, from,
-				endTime, encryption, &kmsEnv, p.User())
+			backupdest.DeprecatedResolveBackupManifestsExplicitIncrementals(ctx, &mem, mkStore, storeFactory, from,
+				endTime, encryption, &kmsEnv, p.User(), manifestReadMode)
 	}
 
 	if err != nil {
@@ -1539,7 +1553,7 @@ func doRestorePlan(
 
 	currentVersion := p.ExecCfg().Settings.Version.ActiveVersion(ctx)
 	for i := range mainBackupManifests {
-		if v := mainBackupManifests[i].ClusterVersion; v.Major != 0 {
+		if v := mainBackupManifests[i].ClusterVersion(); v.Major != 0 {
 			// This is the "cluster" version that does not change between patches but
 			// rather just tracks migrations run. If the backup is more migrated than
 			// this cluster, then this cluster isn't ready to restore this backup.
@@ -1551,7 +1565,7 @@ func doRestorePlan(
 
 	if restoreStmt.DescriptorCoverage == tree.AllDescriptors {
 		// Validate that the backup is a full cluster backup if a full cluster restore was requested.
-		if mainBackupManifests[0].DescriptorCoverage == tree.RequestedDescriptors {
+		if mainBackupManifests[0].DescriptorCoverage() == tree.RequestedDescriptors {
 			return errors.Errorf("full cluster RESTORE can only be used on full cluster BACKUP files")
 		}
 
@@ -1565,7 +1579,7 @@ func doRestorePlan(
 		}
 	}
 
-	backupCodec, err := backupinfo.MakeBackupCodec(mainBackupManifests[0])
+	backupCodec, err := backupinfo.MakeBackupCodec(ctx, mainBackupManifests[0])
 	if err != nil {
 		return err
 	}
@@ -1578,9 +1592,24 @@ func doRestorePlan(
 	wasOffline := make(map[tableAndIndex]hlc.Timestamp)
 
 	for _, m := range mainBackupManifests {
-		spans := roachpb.Spans(m.Spans)
-		for i := range m.Descriptors {
-			table, _, _, _, _ := descpb.GetDescriptors(&m.Descriptors[i])
+		var spans roachpb.Spans
+		spanIt := m.NewSpanIter(ctx)
+		defer spanIt.Close()
+		if spans, err = backupinfo.CollectToSlice(spanIt); err != nil {
+			return err
+		}
+
+		descIt := m.NewDescIter(ctx)
+		defer descIt.Close()
+
+		for ; ; descIt.Next() {
+			if ok, err := descIt.Valid(); err != nil {
+				return err
+			} else if !ok {
+				break
+			}
+
+			table, _, _, _, _ := descpb.GetDescriptors(descIt.Value())
 			if table == nil {
 				continue
 			}
@@ -1594,7 +1623,7 @@ func doRestorePlan(
 					if index.Adding() && spans.ContainsKey(backupCodec.IndexPrefix(uint32(table.ID), uint32(index.GetID()))) {
 						k := tableAndIndex{tableID: table.ID, indexID: index.GetID()}
 						if _, ok := wasOffline[k]; !ok {
-							wasOffline[k] = m.EndTime
+							wasOffline[k] = m.EndTime()
 						}
 					}
 					return nil
@@ -1613,7 +1642,7 @@ func doRestorePlan(
 				"use SHOW BACKUP to find correct targets")
 	}
 
-	if err := checkMissingIntroducedSpans(sqlDescs, mainBackupManifests, endTime, backupCodec); err != nil {
+	if err := checkMissingIntroducedSpans(ctx, sqlDescs, mainBackupManifests, endTime, backupCodec); err != nil {
 		return err
 	}
 
@@ -1873,6 +1902,7 @@ func doRestorePlan(
 		PreRewriteTenantId: oldTenantID,
 		SchemaOnly:         restoreStmt.Options.SchemaOnly,
 		VerifyData:         restoreStmt.Options.VerifyData,
+		ManifestReadMode:   manifestReadMode,
 	}
 
 	jr := jobs.Record{

--- a/pkg/ccl/backupccl/restore_span_covering_test.go
+++ b/pkg/ccl/backupccl/restore_span_covering_test.go
@@ -48,7 +48,7 @@ func MockBackupChain(
 	r *rand.Rand,
 	hasExternalFilesList bool,
 	execCfg sql.ExecutorConfig,
-) ([]backuppb.BackupManifest, error) {
+) ([]backupinfo.BackupManifest, error) {
 	backups := make([]backuppb.BackupManifest, length)
 	ts := hlc.Timestamp{WallTime: time.Second.Nanoseconds()}
 
@@ -129,7 +129,13 @@ func MockBackupChain(
 		// A non-nil Dir more accurately models the footprint of produced coverings.
 		backups[i].Dir = config
 	}
-	return backups, nil
+
+	adapters := make([]backupinfo.BackupManifest, len(backups))
+	for i := range backups {
+		storeFactory := execCfg.DistSQLSrv.ExternalStorage
+		adapters[i] = backupinfo.NewBackupManifestAdapter(&backups[i], nil, nil, nil, storeFactory)
+	}
+	return adapters, nil
 }
 
 // checkRestoreCovering verifies that a covering actually uses every span of
@@ -147,7 +153,7 @@ func MockBackupChain(
 // check back in when I figure out what the expected partition count should be.
 func checkRestoreCovering(
 	ctx context.Context,
-	backups []backuppb.BackupManifest,
+	backups []backupinfo.BackupManifest,
 	spans roachpb.Spans,
 	cov []execinfrapb.RestoreSpanEntry,
 	merged bool,
@@ -155,7 +161,7 @@ func checkRestoreCovering(
 ) error {
 	required := make(map[string]*roachpb.SpanGroup)
 
-	introducedSpanFrontier, err := createIntroducedSpanFrontier(backups, hlc.Timestamp{})
+	introducedSpanFrontier, err := createIntroducedSpanFrontier(ctx, backups, hlc.Timestamp{})
 	if err != nil {
 		return err
 	}
@@ -167,7 +173,7 @@ func checkRestoreCovering(
 			introducedSpanFrontier.Entries(func(s roachpb.Span,
 				ts hlc.Timestamp) (done spanUtils.OpResult) {
 				if span.Overlaps(s) {
-					if b.EndTime.Less(ts) {
+					if b.EndTime().Less(ts) {
 						coveredLater = true
 					}
 					return spanUtils.StopMatch
@@ -179,13 +185,18 @@ func checkRestoreCovering(
 				// for explanation.
 				continue
 			}
-			it, err := makeBackupManifestFileIterator(ctx, storageFactory, b,
-				nil, nil)
+			it, err := b.NewFileIter(ctx)
 			if err != nil {
 				return err
 			}
-			defer it.close()
-			for f, hasNext := it.next(); hasNext; f, hasNext = it.next() {
+			defer it.Close()
+			for ; ; it.Next() {
+				if ok, err := it.Valid(); err != nil {
+					return err
+				} else if !ok {
+					break
+				}
+				f := it.Value()
 				if sp := span.Intersect(f.Span); sp.Valid() {
 					if required[f.Path] == nil {
 						required[f.Path] = &roachpb.SpanGroup{}
@@ -195,9 +206,6 @@ func checkRestoreCovering(
 						last = sp.EndKey
 					}
 				}
-			}
-			if it.err() != nil {
-				return it.err()
 			}
 		}
 	}
@@ -230,8 +238,7 @@ const noSpanTargetSize = 0
 func makeImportSpans(
 	ctx context.Context,
 	spans []roachpb.Span,
-	backups []backuppb.BackupManifest,
-	layerToBackupManifestFileIterFactory layerToBackupManifestFileIterFactory,
+	backups []backupinfo.BackupManifest,
 	targetSize int64,
 	introducedSpanFrontier *spanUtils.Frontier,
 	useSimpleImportSpans bool,
@@ -246,7 +253,7 @@ func makeImportSpans(
 		return nil
 	})
 
-	err := generateAndSendImportSpans(ctx, spans, backups, layerToBackupManifestFileIterFactory, nil, introducedSpanFrontier, nil, targetSize, spanCh, useSimpleImportSpans)
+	err := generateAndSendImportSpans(ctx, spans, backups, nil, introducedSpanFrontier, nil, targetSize, spanCh, useSimpleImportSpans)
 	close(spanCh)
 
 	if err != nil {
@@ -264,7 +271,7 @@ func TestRestoreEntryCoverExample(t *testing.T) {
 	const numAccounts = 1
 	ctx := context.Background()
 
-	tc, _, _, cleanupFn := backupRestoreTestSetup(t, singleNode, numAccounts,
+	_, _, _, cleanupFn := backupRestoreTestSetup(t, singleNode, numAccounts,
 		InitManualReplication)
 	defer cleanupFn()
 
@@ -284,31 +291,32 @@ func TestRestoreEntryCoverExample(t *testing.T) {
 
 	// Setup and test the example in the comment of makeSimpleImportSpans.
 	spans := []roachpb.Span{sp("a", "f"), sp("f", "i"), sp("l", "m")}
-	backups := []backuppb.BackupManifest{
-		{Files: []backuppb.BackupManifest_File{f("a", "c", "1"), f("c", "e", "2"), f("h", "i", "3")}},
-		{Files: []backuppb.BackupManifest_File{f("b", "d", "4"), f("g", "i", "5")}},
-		{Files: []backuppb.BackupManifest_File{f("a", "h", "6"), f("j", "k", "7")}},
-		{Files: []backuppb.BackupManifest_File{f("h", "i", "8"), f("l", "m", "9")}},
+	adapters := []*backupinfo.BackupManifestAdapter{
+		{BackupManifest: &backuppb.BackupManifest{Files: []backuppb.BackupManifest_File{f("a", "c", "1"), f("c", "e", "2"), f("h", "i", "3")}}},
+		{BackupManifest: &backuppb.BackupManifest{Files: []backuppb.BackupManifest_File{f("b", "d", "4"), f("g", "i", "5")}}},
+		{BackupManifest: &backuppb.BackupManifest{Files: []backuppb.BackupManifest_File{f("a", "h", "6"), f("j", "k", "7")}}},
+		{BackupManifest: &backuppb.BackupManifest{Files: []backuppb.BackupManifest_File{f("h", "i", "8"), f("l", "m", "9")}}},
 	}
 
-	for i := range backups {
-		backups[i].StartTime = hlc.Timestamp{WallTime: int64(i)}
-		backups[i].EndTime = hlc.Timestamp{WallTime: int64(i + 1)}
+	for i := range adapters {
+		adapters[i].BackupManifest.StartTime = hlc.Timestamp{WallTime: int64(i)}
+		adapters[i].BackupManifest.EndTime = hlc.Timestamp{WallTime: int64(i + 1)}
 
-		for j := range backups[i].Files {
+		for j := range adapters[i].Files {
 			// Pretend every span has 1MB.
-			backups[i].Files[j].EntryCounts.DataSize = 1 << 20
+			adapters[i].Files[j].EntryCounts.DataSize = 1 << 20
 		}
+	}
+
+	backups := make([]backupinfo.BackupManifest, len(adapters))
+	for i := range adapters {
+		backups[i] = adapters[i]
 	}
 
 	emptySpanFrontier, err := spanUtils.MakeFrontier(roachpb.Span{})
 	require.NoError(t, err)
 
-	execCfg := tc.Server(0).ExecutorConfig().(sql.ExecutorConfig)
-	layerToBackupManifestFileIterFactory, err := getBackupManifestFileIters(ctx, &execCfg,
-		backups, nil, nil)
-	require.NoError(t, err)
-	cover, err := makeImportSpans(ctx, spans, backups, layerToBackupManifestFileIterFactory, noSpanTargetSize, emptySpanFrontier, false)
+	cover, err := makeImportSpans(ctx, spans, backups, noSpanTargetSize, emptySpanFrontier, false)
 	require.NoError(t, err)
 	require.Equal(t, []execinfrapb.RestoreSpanEntry{
 		{Span: sp("a", "b"), Files: paths("1", "6")},
@@ -320,7 +328,7 @@ func TestRestoreEntryCoverExample(t *testing.T) {
 		{Span: sp("l", "m"), Files: paths("9")},
 	}, cover)
 
-	coverSized, err := makeImportSpans(ctx, spans, backups, layerToBackupManifestFileIterFactory, 2<<20, emptySpanFrontier, false)
+	coverSized, err := makeImportSpans(ctx, spans, backups, 2<<20, emptySpanFrontier, false)
 	require.NoError(t, err)
 	require.Equal(t, []execinfrapb.RestoreSpanEntry{
 		{Span: sp("a", "b"), Files: paths("1", "6")},
@@ -332,11 +340,11 @@ func TestRestoreEntryCoverExample(t *testing.T) {
 	}, coverSized)
 
 	// check that introduced spans are properly elided
-	backups[2].IntroducedSpans = []roachpb.Span{sp("a", "f")}
-	introducedSpanFrontier, err := createIntroducedSpanFrontier(backups, hlc.Timestamp{})
+	adapters[2].IntroducedSpans = []roachpb.Span{sp("a", "f")}
+	introducedSpanFrontier, err := createIntroducedSpanFrontier(ctx, backups, hlc.Timestamp{})
 	require.NoError(t, err)
 
-	coverIntroduced, err := makeImportSpans(ctx, spans, backups, layerToBackupManifestFileIterFactory, noSpanTargetSize, introducedSpanFrontier, false)
+	coverIntroduced, err := makeImportSpans(ctx, spans, backups, noSpanTargetSize, introducedSpanFrontier, false)
 	require.NoError(t, err)
 	require.Equal(t, []execinfrapb.RestoreSpanEntry{
 		{Span: sp("a", "f"), Files: paths("6")},
@@ -387,7 +395,7 @@ func createMockManifest(
 	info mockBackupInfo,
 	endTime hlc.Timestamp,
 	path string,
-) backuppb.BackupManifest {
+) *backupinfo.BackupManifestAdapter {
 	tables, _ := createMockTables(info)
 
 	spans, err := spansForAllTableIndexes(execCfg, tables,
@@ -400,8 +408,10 @@ func createMockManifest(
 		files = append(files, backuppb.BackupManifest_File{Span: sp, Path: path})
 	}
 
-	return backuppb.BackupManifest{Spans: spans,
+	manifest := backuppb.BackupManifest{Spans: spans,
 		EndTime: endTime, Files: files}
+
+	return backupinfo.NewBackupManifestAdapter(&manifest, nil, nil, nil, nil)
 }
 
 // TestRestoreEntryCoverReIntroducedSpans checks that all reintroduced spans are
@@ -527,30 +537,30 @@ func TestRestoreEntryCoverReIntroducedSpans(t *testing.T) {
 	incBackupPath := "inc"
 	for _, test := range testCases {
 		t.Run(test.name, func(t *testing.T) {
-			backups := []backuppb.BackupManifest{
+			adapters := []*backupinfo.BackupManifestAdapter{
 				createMockManifest(t, &execCfg, test.full, hlc.Timestamp{WallTime: int64(1)}, fullBackupPath),
 				createMockManifest(t, &execCfg, test.inc, hlc.Timestamp{WallTime: int64(2)}, incBackupPath),
+			}
+			backups := make([]backupinfo.BackupManifest, len(adapters))
+			for i := range adapters {
+				backups[i] = adapters[i]
 			}
 
 			// Create the IntroducedSpans field for incremental backup.
 			incTables, reIntroducedTables := createMockTables(test.inc)
 
-			newSpans := filterSpans(backups[1].Spans, backups[0].Spans)
+			newSpans := filterSpans(adapters[1].Spans, adapters[0].Spans)
 			reIntroducedSpans, err := spansForAllTableIndexes(&execCfg, reIntroducedTables, nil)
 			require.NoError(t, err)
-			backups[1].IntroducedSpans = append(newSpans, reIntroducedSpans...)
+			adapters[1].IntroducedSpans = append(newSpans, reIntroducedSpans...)
 
 			restoreSpans := spansForAllRestoreTableIndexes(execCfg.Codec, incTables, nil, false)
 			require.Equal(t, test.expectedRestoreSpanCount, len(restoreSpans))
 
-			introducedSpanFrontier, err := createIntroducedSpanFrontier(backups, hlc.Timestamp{})
+			introducedSpanFrontier, err := createIntroducedSpanFrontier(ctx, backups, hlc.Timestamp{})
 			require.NoError(t, err)
 
-			layerToBackupManifestFileIterFactory, err := getBackupManifestFileIters(ctx,
-				&execCfg, backups, nil, nil)
-			require.NoError(t, err)
-			cover, err := makeImportSpans(ctx, restoreSpans, backups, layerToBackupManifestFileIterFactory,
-				0, introducedSpanFrontier, false)
+			cover, err := makeImportSpans(ctx, restoreSpans, backups, 0, introducedSpanFrontier, false)
 			require.NoError(t, err)
 
 			for _, reIntroTable := range reIntroducedTables {
@@ -590,19 +600,21 @@ func TestRestoreEntryCover(t *testing.T) {
 						backups, err := MockBackupChain(ctx, numBackups, spans, files, r, hasExternalFilesList, execCfg)
 						require.NoError(t, err)
 
+						spanIt := backups[numBackups-1].NewSpanIter(ctx)
+						defer spanIt.Close()
+
+						requiredSpans, err := backupinfo.CollectToSlice(spanIt)
+						require.NoError(t, err)
+
 						for _, target := range []int64{0, 1, 4, 100, 1000} {
 							t.Run(fmt.Sprintf("numBackups=%d, numSpans=%d, numFiles=%d, merge=%d, slim=%t, simple=%t",
 								numBackups, spans, files, target, hasExternalFilesList, simpleImportSpans), func(t *testing.T) {
-								introducedSpanFrontier, err := createIntroducedSpanFrontier(backups, hlc.Timestamp{})
+								introducedSpanFrontier, err := createIntroducedSpanFrontier(ctx, backups, hlc.Timestamp{})
 								require.NoError(t, err)
 
-								layerToBackupManifestFileIterFactory, err := getBackupManifestFileIters(ctx,
-									&execCfg, backups, nil, nil)
+								cover, err := makeImportSpans(ctx, requiredSpans, backups, target<<20, introducedSpanFrontier, simpleImportSpans)
 								require.NoError(t, err)
-								cover, err := makeImportSpans(ctx, backups[numBackups-1].Spans, backups,
-									layerToBackupManifestFileIterFactory, target<<20, introducedSpanFrontier, simpleImportSpans)
-								require.NoError(t, err)
-								require.NoError(t, checkRestoreCovering(ctx, backups, backups[numBackups-1].Spans,
+								require.NoError(t, checkRestoreCovering(ctx, backups, requiredSpans,
 									cover, target != noSpanTargetSize, execCfg.DistSQLSrv.ExternalStorage))
 							})
 						}

--- a/pkg/ccl/backupccl/show_test.go
+++ b/pkg/ccl/backupccl/show_test.go
@@ -743,6 +743,8 @@ func showUpgradedForeignKeysTest(exportDir string) func(t *testing.T) {
 		err := os.Symlink(exportDir, filepath.Join(dir, "foo"))
 		require.NoError(t, err)
 
+		sqlDB.Exec(t, `SET CLUSTER SETTING restore.manifest_read.mode = 'forceManifest'`)
+
 		type testCase struct {
 			table                     string
 			expectedForeignKeyPattern string

--- a/pkg/ccl/backupccl/testdata/backup-restore/encrypted-backups
+++ b/pkg/ccl/backupccl/testdata/backup-restore/encrypted-backups
@@ -22,7 +22,7 @@ BACKUP INTO 'nodelocal://1/full3' WITH kms='testkms:///cmk?AUTH=implicit';
 ----
 
 # No passphrase results in an error.
-exec-sql expect-error-regex=(file appears encrypted)
+exec-sql expect-error-regex=(invalid table \(bad magic number\)|file appears encrypted)
 SELECT object_name, object_type, backup_type FROM [SHOW BACKUP FROM LATEST IN 'nodelocal://1/full']
 ----
 regex matches error
@@ -39,7 +39,7 @@ public schema full
 public schema full
 public schema full
 
-exec-sql expect-error-regex=(file appears encrypted)
+exec-sql expect-error-regex=(invalid table \(bad magic number\)|file appears encrypted)
 SELECT object_name, object_type, backup_type FROM [SHOW BACKUP FROM LATEST IN 'nodelocal://1/full2'
 WITH incremental_location='nodelocal://1/inc'] WHERE database_name <> 'system' ORDER BY (backup_type, object_name);
 ----

--- a/pkg/ccl/backupccl/testdata/backup-restore/in-progress-import-missing
+++ b/pkg/ccl/backupccl/testdata/backup-restore/in-progress-import-missing
@@ -25,6 +25,10 @@
 new-cluster name=s1 allow-implicit-access disable-tenant
 ----
 
+exec-sql
+SET CLUSTER SETTING restore.manifest_read.mode = 'forceManifest'
+----
+
 # Link 4 backup chains:
 # 1. A corrupt database backup chain with revision history
 link-backup cluster=s1 src-path=restore_importing_tables,database dest-path=database
@@ -213,6 +217,10 @@ SELECT count(*) FROM d.goodfoo;
 
 # Check the cluster level restore
 new-cluster name=s2 share-io-dir=s1 allow-implicit-access disable-tenant
+----
+
+exec-sql
+SET CLUSTER SETTING restore.manifest_read.mode = 'forceManifest'
 ----
 
 exec-sql

--- a/pkg/ccl/backupccl/testdata/backup-restore/in-progress-import-rollback
+++ b/pkg/ccl/backupccl/testdata/backup-restore/in-progress-import-rollback
@@ -36,6 +36,9 @@ exec-sql
 SET CLUSTER SETTING kv.bulkio.write_metadata_sst.enabled = false;
 ----
 
+exec-sql
+SET CLUSTER SETTING restore.manifest_read.mode = 'forceManifest';
+----
 
 exec-sql
 SET CLUSTER SETTING storage.mvcc.range_tombstones.enabled = false;

--- a/pkg/ccl/backupccl/testdata/backup-restore/show_backup
+++ b/pkg/ccl/backupccl/testdata/backup-restore/show_backup
@@ -4,6 +4,11 @@
 new-cluster name=s1 allow-implicit-access
 ----
 
+# Pre 23.1 backups will only have backup manifest.
+exec-sql
+SET CLUSTER SETTING restore.manifest_read.mode = 'forceManifest';
+----
+
 link-backup cluster=s1 src-path=show_backup_validate,invalidDependOnBy_21.1 dest-path=invalidDependOnBy_21.1
 ----
 

--- a/pkg/jobs/jobspb/jobs.proto
+++ b/pkg/jobs/jobspb/jobs.proto
@@ -207,6 +207,14 @@ message SchedulePTSChainingRecord {
   PTSAction action = 2;
 }
 
+// We set the default mode to force using backup manifests for mixed version
+// compatibility as ManifestReadMode is passed inside job detail protos.
+enum BackupManifestReadMode {
+  ForceManifest = 0;
+  ForceMetadataSST = 1;
+  PreferMetadataSST = 2;
+}
+
 message BackupDetails {
   // Destination describes the specification of where to backup to, either the
   // path or collection and subdir of that collection. This may not be the same
@@ -444,12 +452,10 @@ message RestoreDetails {
     (gogoproto.customtype) = "github.com/cockroachdb/cockroach/pkg/util/uuid.UUID"
   ];
 
-  // NEXT ID: 29.
+  BackupManifestReadMode manifest_read_mode = 29;
+
+  // NEXT ID: 30.
 }
-
-
-
-
 
 message RestoreProgress {
   bytes high_water = 1;

--- a/pkg/sql/execinfrapb/processors_bulk_io.proto
+++ b/pkg/sql/execinfrapb/processors_bulk_io.proto
@@ -420,4 +420,5 @@ message GenerativeSplitAndScatterSpec {
   optional int64 num_nodes = 17[(gogoproto.nullable) = false];
   optional int64 job_id = 18 [(gogoproto.nullable) = false, (gogoproto.customname) = "JobID"];
   optional bool use_simple_import_spans = 19 [(gogoproto.nullable) = false];
+  optional jobs.jobspb.BackupManifestReadMode manifest_read_mode = 20 [(gogoproto.nullable) = false];
 }


### PR DESCRIPTION
In 22.1, the metadata SST was introduced and written along the manifest during
every backup. This SST had separate key-values for all repeated fields in the
manifest so that they can be streamed in future backup and restore jobs to
reduce the memory used by those jobs. This patch introduces the ability to
restore from the manifest SST and avoids the need to maintain copies of
repeated fields such as files and descriptors in memory. The largest
improvement from this change compared to the previous work done with slim
manifests is via the memory saved from having to load all descriptors from all
manifests in an incremental chain.

Release note: None