### PR TITLE
opt: inverted-index accelerate filters of the form j->0 = '{"b": "c"}

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/inverted_index
+++ b/pkg/sql/logictest/testdata/logic_test/inverted_index
@@ -188,62 +188,62 @@ statement ok
 INSERT INTO d VALUES (31,  '{"a": {"b": "c", "d": "e"}, "f": "g"}')
 
 query IT
-SELECT * from d where b @> NULL ORDER BY a;
+SELECT * FROM d WHERE b @> NULL ORDER BY a;
 ----
 
 query IT
-SELECT * from d where b @> (NULL::JSONB) ORDER BY a;
+SELECT * FROM d WHERE b @> (NULL::JSONB) ORDER BY a;
 ----
 
 query IT
-SELECT * from d where b @>'{"a": "b"}' ORDER BY a;
+SELECT * FROM d WHERE b @>'{"a": "b"}' ORDER BY a;
 ----
 1  {"a": "b"}
 7  {"a": "b", "c": "d"}
 
 query IT
-SELECT * from d where b @> '{"a": {"b": [1]}}' ORDER BY a;
+SELECT * FROM d WHERE b @> '{"a": {"b": [1]}}' ORDER BY a;
 ----
 4  {"a": {"b": [1]}}
 5  {"a": {"b": [1, [2]]}}
 
 query IT
-SELECT * from d where b @> '{"a": {"b": [[2]]}}' ORDER BY a;
+SELECT * FROM d WHERE b @> '{"a": {"b": [[2]]}}' ORDER BY a;
 ----
 5  {"a": {"b": [1, [2]]}}
 6  {"a": {"b": [[2]]}}
 
 query IT
-SELECT * from d where b @> '{"a": {"b": true}}' ORDER BY a;
+SELECT * FROM d WHERE b @> '{"a": {"b": true}}' ORDER BY a;
 ----
 8  {"a": {"b": true}}
 
 query IT
-SELECT * from d where b @> '{"a": {"b": [[2]]}}' ORDER BY a;
+SELECT * FROM d WHERE b @> '{"a": {"b": [[2]]}}' ORDER BY a;
 ----
 5  {"a": {"b": [1, [2]]}}
 6  {"a": {"b": [[2]]}}
 
 query IT
-SELECT * from d where b @>'[1]' ORDER BY a;
+SELECT * FROM d WHERE b @>'[1]' ORDER BY a;
 ----
 2  [1, 2, 3, 4, "foo"]
 
 query IT
-SELECT * from d where b @>'[{"a": {"b": [1]}}]' ORDER BY a;
+SELECT * FROM d WHERE b @>'[{"a": {"b": [1]}}]' ORDER BY a;
 ----
 16  [{"a": {"b": [1, [2]]}}, "d"]
 
 statement ok
-DELETE from d WHERE a=1;
+DELETE FROM d WHERE a=1;
 
 query IT
-SELECT * from d where b @>'{"a": "b"}' ORDER BY a;
+SELECT * FROM d WHERE b @>'{"a": "b"}' ORDER BY a;
 ----
 7  {"a": "b", "c": "d"}
 
 statement ok
-PREPARE query (STRING, STRING) AS SELECT * from d where b->$1 = $2 ORDER BY a
+PREPARE query (STRING, STRING) AS SELECT * FROM d WHERE b->$1 = $2 ORDER BY a
 
 query IT
 EXECUTE query ('a', '"b"')
@@ -251,46 +251,46 @@ EXECUTE query ('a', '"b"')
 7  {"a": "b", "c": "d"}
 
 statement ok
-DELETE from d WHERE a=6;
+DELETE FROM d WHERE a=6;
 
 query IT
-SELECT * from d where b @> '{"a": {"b": [[2]]}}' ORDER BY a;
+SELECT * FROM d WHERE b @> '{"a": {"b": [[2]]}}' ORDER BY a;
 ----
 5  {"a": {"b": [1, [2]]}}
 
 query IT
-SELECT * from d where b @> '"a"' ORDER BY a;
+SELECT * FROM d WHERE b @> '"a"' ORDER BY a;
 ----
 10  "a"
 
 query IT
-SELECT * from d where b @> 'null' ORDER BY a;
+SELECT * FROM d WHERE b @> 'null' ORDER BY a;
 ----
 11  null
 
 query IT
-SELECT * from d where b @> 'true' ORDER BY a;
+SELECT * FROM d WHERE b @> 'true' ORDER BY a;
 ----
 12  true
 
 query IT
-SELECT * from d where b @> 'false' ORDER BY a;
+SELECT * FROM d WHERE b @> 'false' ORDER BY a;
 ----
 13  false
 
 query IT
-SELECT * from d where b @> '1' ORDER BY a;
+SELECT * FROM d WHERE b @> '1' ORDER BY a;
 ----
 2   [1, 2, 3, 4, "foo"]
 14  1
 
 query IT
-SELECT * from d where b @> '1.23' ORDER BY a;
+SELECT * FROM d WHERE b @> '1.23' ORDER BY a;
 ----
 15  1.23
 
 query IT
-SELECT * from d where b @> '{}' ORDER BY a;
+SELECT * FROM d WHERE b @> '{}' ORDER BY a;
 ----
 3   {"a": {"b": "c"}}
 4   {"a": {"b": [1]}}
@@ -303,7 +303,7 @@ SELECT * from d where b @> '{}' ORDER BY a;
 31  {"a": {"b": "c", "d": "e"}, "f": "g"}
 
 query IT
-SELECT * from d where b @> '[]' ORDER BY a;
+SELECT * FROM d WHERE b @> '[]' ORDER BY a;
 ----
 2   [1, 2, 3, 4, "foo"]
 16  [{"a": {"b": [1, [2]]}}, "d"]
@@ -313,7 +313,7 @@ statement ok
 INSERT INTO d VALUES (19, '["a", "a"]')
 
 query IT
-SELECT * from d where b @> '["a"]' ORDER BY a;
+SELECT * FROM d WHERE b @> '["a"]' ORDER BY a;
 ----
 19  ["a", "a"]
 
@@ -321,7 +321,7 @@ statement ok
 INSERT INTO d VALUES (20, '[{"a": "a"}, {"a": "a"}]')
 
 query IT
-SELECT * from d where b @> '[{"a": "a"}]' ORDER BY a;
+SELECT * FROM d WHERE b @> '[{"a": "a"}]' ORDER BY a;
 ----
 20  [{"a": "a"}, {"a": "a"}]
 
@@ -329,7 +329,7 @@ statement ok
 INSERT INTO d VALUES (21,  '[[[["a"]]], [[["a"]]]]')
 
 query IT
-SELECT * from d where b @> '[[[["a"]]]]' ORDER BY a;
+SELECT * FROM d WHERE b @> '[[[["a"]]]]' ORDER BY a;
 ----
 21  [[[["a"]]], [[["a"]]]]
 
@@ -337,12 +337,12 @@ statement ok
 INSERT INTO d VALUES (22,  '[1,2,3,1]')
 
 query IT
-SELECT * from d where b @> '[[[["a"]]]]' ORDER BY a;
+SELECT * FROM d WHERE b @> '[[[["a"]]]]' ORDER BY a;
 ----
 21  [[[["a"]]], [[["a"]]]]
 
 query IT
-SELECT * from d where b->'a' = '"b"'
+SELECT * FROM d WHERE b->'a' = '"b"'
 ----
 7  {"a": "b", "c": "d"}
 
@@ -353,13 +353,13 @@ statement ok
 INSERT INTO d VALUES (24,  '{"a": 123.123000}')
 
 query IT
-SELECT * from d where b @> '{"a": 123.123}' ORDER BY a;
+SELECT * FROM d WHERE b @> '{"a": 123.123}' ORDER BY a;
 ----
 23  {"a": 123.123}
 24  {"a": 123.123000}
 
 query IT
-SELECT * from d where b @> '{"a": 123.123000}' ORDER BY a;
+SELECT * FROM d WHERE b @> '{"a": 123.123000}' ORDER BY a;
 ----
 23  {"a": 123.123}
 24  {"a": 123.123000}
@@ -371,26 +371,26 @@ statement ok
 INSERT INTO d VALUES (26,  '[[], {}]')
 
 query IT
-SELECT * from d where b @> '{"a": [{}]}' ORDER BY a;
+SELECT * FROM d WHERE b @> '{"a": [{}]}' ORDER BY a;
 ----
 25  {"a": [{}]}
 
 
 query IT
-SELECT * from d where b @> '{"a": []}' ORDER BY a;
+SELECT * FROM d WHERE b @> '{"a": []}' ORDER BY a;
 ----
 25  {"a": [{}]}
 30  {"a": []}
 
 query IT
-SELECT * from d where b @> '[{}]' ORDER BY a;
+SELECT * FROM d WHERE b @> '[{}]' ORDER BY a;
 ----
 16  [{"a": {"b": [1, [2]]}}, "d"]
 20  [{"a": "a"}, {"a": "a"}]
 26  [[], {}]
 
 query IT
-SELECT * from d where b @> '[[]]' ORDER BY a;
+SELECT * FROM d WHERE b @> '[[]]' ORDER BY a;
 ----
 21  [[[["a"]]], [[["a"]]]]
 26  [[], {}]
@@ -399,51 +399,51 @@ statement ok
 INSERT INTO d VALUES (27,  '[true, false, null, 1.23, "a"]')
 
 query IT
-SELECT * from d where b @> 'true' ORDER BY a;
+SELECT * FROM d WHERE b @> 'true' ORDER BY a;
 ----
 12  true
 27  [true, false, null, 1.23, "a"]
 
 query IT
-SELECT * from d where b @> 'false' ORDER BY a;
+SELECT * FROM d WHERE b @> 'false' ORDER BY a;
 ----
 13  false
 27  [true, false, null, 1.23, "a"]
 
 query IT
-SELECT * from d where b @> '1.23' ORDER BY a;
+SELECT * FROM d WHERE b @> '1.23' ORDER BY a;
 ----
 15  1.23
 27  [true, false, null, 1.23, "a"]
 
 query IT
-SELECT * from d where b @> '"a"' ORDER BY a;
+SELECT * FROM d WHERE b @> '"a"' ORDER BY a;
 ----
 10  "a"
 19  ["a", "a"]
 27  [true, false, null, 1.23, "a"]
 
 query IT
-SELECT * from d where b IS NULL;
+SELECT * FROM d WHERE b IS NULL;
 ----
 29  NULL
 
 query IT
-SELECT * from d where b = NULL;
+SELECT * FROM d WHERE b = NULL;
 ----
 
 query IT
-SELECT * from d where b @> NULL;
+SELECT * FROM d WHERE b @> NULL;
 ----
 
 query IT
-SELECT * from d where b @> 'null' ORDER BY a;
+SELECT * FROM d WHERE b @> 'null' ORDER BY a;
 ----
 11  null
 27  [true, false, null, 1.23, "a"]
 
 query IT
-SELECT * from d where b @> '{"a": {}}' ORDER BY a;
+SELECT * FROM d WHERE b @> '{"a": {}}' ORDER BY a;
 ----
 3   {"a": {"b": "c"}}
 4   {"a": {"b": [1]}}
@@ -453,7 +453,7 @@ SELECT * from d where b @> '{"a": {}}' ORDER BY a;
 31  {"a": {"b": "c", "d": "e"}, "f": "g"}
 
 query IT
-SELECT * from d where b @> '{"a": []}' ORDER BY a;
+SELECT * FROM d WHERE b @> '{"a": []}' ORDER BY a;
 ----
 25  {"a": [{}]}
 30  {"a": []}
@@ -461,44 +461,44 @@ SELECT * from d where b @> '{"a": []}' ORDER BY a;
 ## Multi-path contains queries
 
 query IT
-SELECT * from d where b @> '{"a": {"b": "c"}, "f": "g"}'
+SELECT * FROM d WHERE b @> '{"a": {"b": "c"}, "f": "g"}'
 ----
 31  {"a": {"b": "c", "d": "e"}, "f": "g"}
 
 query IT
-SELECT * from d where b @> '{"a": {"b": "c", "d": "e"}, "f": "g"}'
+SELECT * FROM d WHERE b @> '{"a": {"b": "c", "d": "e"}, "f": "g"}'
 ----
 31  {"a": {"b": "c", "d": "e"}, "f": "g"}
 
 query IT
-SELECT * from d where b @> '{"c": "d", "a": "b"}'
+SELECT * FROM d WHERE b @> '{"c": "d", "a": "b"}'
 ----
 7  {"a": "b", "c": "d"}
 
 query IT
-SELECT * from d where b @> '{"c": "d", "a": "b", "f": "g"}'
+SELECT * FROM d WHERE b @> '{"c": "d", "a": "b", "f": "g"}'
 ----
 
 query IT
-SELECT * from d where b @> '{"a": "b", "c": "e"}'
+SELECT * FROM d WHERE b @> '{"a": "b", "c": "e"}'
 ----
 
 query IT
-SELECT * from d where b @> '{"a": "e", "c": "d"}'
+SELECT * FROM d WHERE b @> '{"a": "e", "c": "d"}'
 ----
 
 query IT
-SELECT * from d where b @> '["d", {"a": {"b": [1]}}]'
-----
-16  [{"a": {"b": [1, [2]]}}, "d"]
-
-query IT
-SELECT * from d where b @> '["d", {"a": {"b": [[2]]}}]'
+SELECT * FROM d WHERE b @> '["d", {"a": {"b": [1]}}]'
 ----
 16  [{"a": {"b": [1, [2]]}}, "d"]
 
 query IT
-SELECT * from d where b @> '[{"a": {"b": [[2]]}}, "d"]'
+SELECT * FROM d WHERE b @> '["d", {"a": {"b": [[2]]}}]'
+----
+16  [{"a": {"b": [1, [2]]}}, "d"]
+
+query IT
+SELECT * FROM d WHERE b @> '[{"a": {"b": [[2]]}}, "d"]'
 ----
 16  [{"a": {"b": [1, [2]]}}, "d"]
 
@@ -544,12 +544,12 @@ statement error index "dogs" is inverted and cannot be used for this query
 SELECT count(*) FROM users@dogs
 
 query T
-SELECT user_profile from users where user_profile @> '{"first_name":"Lola"}';
+SELECT user_profile FROM users WHERE user_profile @> '{"first_name":"Lola"}';
 ----
 {"first_name": "Lola", "friends": 547, "last_name": "Dog", "location": "NYC", "online": true}
 
 query T
-SELECT user_profile from users where user_profile @> '{"first_name":"Ernie"}';
+SELECT user_profile FROM users WHERE user_profile @> '{"first_name":"Ernie"}';
 ----
  {"first_name": "Ernie", "location": "Brooklyn", "status": "Looking for treats"}
 
@@ -560,7 +560,7 @@ statement ok
 INSERT INTO update_test VALUES (1, '0');
 
 query IT
-SELECT * from update_test WHERE j @> '0';
+SELECT * FROM update_test WHERE j @> '0';
 ----
 1 0
 
@@ -568,11 +568,11 @@ statement ok
 UPDATE update_test SET j = '{"a":"b", "c":"d"}' WHERE i = 1;
 
 query IT
-SELECT * from update_test WHERE j @> '0';
+SELECT * FROM update_test WHERE j @> '0';
 ----
 
 query IT
-SELECT * from update_test WHERE j @> '{"a":"b"}';
+SELECT * FROM update_test WHERE j @> '{"a":"b"}';
 ----
 1 {"a": "b", "c": "d"}
 
@@ -583,16 +583,16 @@ statement ok
 UPDATE update_test SET j = ('"shortValue"') WHERE i = 2;
 
 query IT
-SELECT * from update_test where j @> '"shortValue"';
+SELECT * FROM update_test WHERE j @> '"shortValue"';
 ----
 2 "shortValue"
 
 query IT
-SELECT * from update_test where j @> '{"longKey1":"longValue1"}';
+SELECT * FROM update_test WHERE j @> '{"longKey1":"longValue1"}';
 ----
 
 query IT
-SELECT * from update_test where j @> '{"longKey2":"longValue2"}';
+SELECT * FROM update_test WHERE j @> '{"longKey2":"longValue2"}';
 ----
 
 statement ok
@@ -608,7 +608,7 @@ statement ok
 INSERT INTO update_test VALUES (3, '["a", "b", "c"]');
 
 query IT
-SELECT * from update_test where j @> '["a"]' ORDER BY i;
+SELECT * FROM update_test WHERE j @> '["a"]' ORDER BY i;
 ----
 2 ["a", "a"]
 3 ["a", "b", "c"]
@@ -617,12 +617,12 @@ statement ok
 UPDATE update_test SET j = '["b", "c", "e"]' WHERE i = 3;
 
 query IT
-SELECT * from update_test where j @> '["a"]' ORDER BY i;
+SELECT * FROM update_test WHERE j @> '["a"]' ORDER BY i;
 ----
 2 ["a", "a"]
 
 query IT
-SELECT * from update_test where j @> '["b"]' ORDER BY i;
+SELECT * FROM update_test WHERE j @> '["b"]' ORDER BY i;
 ----
 3 ["b", "c", "e"]
 
@@ -634,13 +634,13 @@ statement ok
 UPDATE update_test SET j = '["b", "a"]' WHERE i = 4;
 
 query IT
-SELECT * from update_test where j @> '["a"]' ORDER BY i;
+SELECT * FROM update_test WHERE j @> '["a"]' ORDER BY i;
 ----
 2 ["a", "a"]
 4 ["b", "a"]
 
 query IT
-SELECT * from update_test where j @> '["b"]' ORDER BY i;
+SELECT * FROM update_test WHERE j @> '["b"]' ORDER BY i;
 ----
 3 ["b", "c", "e"]
 4 ["b", "a"]
@@ -649,13 +649,13 @@ statement ok
 UPSERT INTO update_test VALUES (4, '["a", "b"]');
 
 query IT
-SELECT * from update_test where j @> '["a"]' ORDER BY i;
+SELECT * FROM update_test WHERE j @> '["a"]' ORDER BY i;
 ----
 2 ["a", "a"]
 4 ["a", "b"]
 
 query IT
-SELECT * from update_test where j @> '["b"]' ORDER BY i;
+SELECT * FROM update_test WHERE j @> '["b"]' ORDER BY i;
 ----
 3 ["b", "c", "e"]
 4 ["a", "b"]
@@ -665,7 +665,7 @@ statement ok
 UPSERT INTO update_test VALUES (3, '["c", "e", "f"]');
 
 query IT
-SELECT * from update_test where j @> '["c"]' ORDER BY i;
+SELECT * FROM update_test WHERE j @> '["c"]' ORDER BY i;
 ----
 3  ["c", "e", "f"]
 
@@ -689,23 +689,23 @@ INSERT INTO del_cascade_test(delete_cascade, j) VALUES (1, '["a", "b"]'), (2, '{
 
 
 query IT
-SELECT * from del_cascade_test ORDER BY delete_cascade;
+SELECT * FROM del_cascade_test ORDER BY delete_cascade;
 ----
 1  ["a", "b"]
 2  {"a": "b", "c": "d"}
 3  ["b", "c"]
 
 statement ok
-DELETE FROM update_test where j @> '["c"]'
+DELETE FROM update_test WHERE j @> '["c"]'
 
 query IT
-SELECT * from del_cascade_test ORDER BY delete_cascade;
+SELECT * FROM del_cascade_test ORDER BY delete_cascade;
 ----
 1  ["a", "b"]
 2  {"a": "b", "c": "d"}
 
 query IT
-SELECT * from del_cascade_test ORDER BY delete_cascade;
+SELECT * FROM del_cascade_test ORDER BY delete_cascade;
 ----
 1  ["a", "b"]
 2  {"a": "b", "c": "d"}
@@ -717,7 +717,7 @@ statement ok
 INSERT INTO update_cascade_test(update_cascade, j) VALUES (1, '["a", "b"]'), (2, '{"a":"b", "c":"d"}'), (3, '["b", "c"]')
 
 query IT
-SELECT * from update_cascade_test ORDER BY update_cascade;
+SELECT * FROM update_cascade_test ORDER BY update_cascade;
 ----
 1  ["a", "b"]
 2  {"a": "b", "c": "d"}
@@ -733,7 +733,7 @@ statement ok
 UPDATE update_test SET (i,j)  = (5, '{"a":"b", "a":"b"}') WHERE i = 1;
 
 query IT
-SELECT * from update_cascade_test ORDER BY update_cascade;
+SELECT * FROM update_cascade_test ORDER BY update_cascade;
 ----
 2  {"a": "b", "c": "d"}
 3  ["b", "c"]
@@ -802,7 +802,87 @@ INSERT INTO f VALUES
   (32, '{}'),
   (33, '[]'),
   (34, '{"a": {"b": []}}'),
-  (35, '["a"]')
+  (35, '["a"]'),
+  (36, '[[]]'),
+  (37, '[{"a": [0, "b"]}, null, 1]'),
+  (38, '[[0, 1, 2], {"b": "c"}]'),
+  (39, '[[0, [1, 2]]]')
+
+query T
+SELECT j FROM f@i WHERE j->0 = '[]' ORDER BY k
+----
+[[]]
+
+query T
+SELECT j FROM f@i WHERE j->0 = '"a"' ORDER BY k
+----
+["a"]
+
+query T
+SELECT j FROM f@i WHERE j->0 = '"d"' ORDER BY k
+----
+
+query T
+SELECT j FROM f@i WHERE j->0 = '[0, 1, 2, 3]' ORDER BY k
+----
+
+query T
+SELECT j FROM f@i WHERE j->1 = '"d"' ORDER BY k
+----
+[{"a": {"b": "c"}}, "d", "e"]
+
+query T
+SELECT j FROM f@i WHERE j->2 = '"e"' ORDER BY k
+----
+[{"a": {"b": "c"}}, "d", "e"]
+
+
+query T
+SELECT j FROM f@i WHERE j->0->1 = '[1, 2]' ORDER BY k
+----
+[[0, [1, 2]]]
+
+query T
+SELECT j FROM f@i WHERE j->0 = '{"a": {"b": "c"}}' ORDER BY k
+----
+[{"a": {"b": "c"}}, "d", "e"]
+
+query T
+SELECT j FROM f@i WHERE j->'a'->0 = '1' ORDER BY k
+----
+{"a": [1, 2]}
+{"a": [1, 2, null]}
+
+query T
+SELECT j FROM f@i WHERE j->'a'->2 = 'null' ORDER BY k
+----
+{"a": [1, 2, null]}
+
+query T
+SELECT j FROM f@i WHERE j->0->'a'->0 = '0' ORDER BY k
+----
+[{"a": [0, "b"]}, null, 1]
+
+query T
+SELECT j FROM f@i WHERE j->0->'a'->1 = '"b"' ORDER BY k
+----
+[{"a": [0, "b"]}, null, 1]
+
+query T
+SELECT j FROM f@i WHERE j->0->0 = '0' ORDER BY k
+----
+[[0, 1, 2], {"b": "c"}]
+[[0, [1, 2]]]
+
+query T
+SELECT j FROM f@i WHERE j->0->1 = '[1, 2]' ORDER BY k
+----
+[[0, [1, 2]]]
+
+query T
+SELECT j FROM f@i WHERE j->0->0 = '0' AND j->0->1 = '[1, 2]' ORDER BY k
+----
+[[0, [1, 2]]]
 
 query T
 SELECT j FROM f@i WHERE j->'a' = '1' ORDER BY k
@@ -1229,17 +1309,17 @@ c  CREATE TABLE public.c (
    )
 
 query ITT
-SELECT * from c WHERE bar @> ARRAY['foo']
+SELECT * FROM c WHERE bar @> ARRAY['foo']
 ----
 1  {}  {foo,bar,baz}
 
 query ITT
-SELECT * from c WHERE bar @> ARRAY['bar', 'baz']
+SELECT * FROM c WHERE bar @> ARRAY['bar', 'baz']
 ----
 1  {}  {foo,bar,baz}
 
 query ITT
-SELECT * from c WHERE bar @> ARRAY['bar', 'qux']
+SELECT * FROM c WHERE bar @> ARRAY['bar', 'qux']
 ----
 
 statement ok

--- a/pkg/sql/opt/exec/execbuilder/testdata/inverted_index
+++ b/pkg/sql/opt/exec/execbuilder/testdata/inverted_index
@@ -1151,6 +1151,377 @@ vectorized: true
               table: d@foo_inv
               spans: /"a"/{}-/"a"/{}/PrefixEnd /???-/??? /"b"/{}-/"b"/{}/PrefixEnd /???-/???
 
+# Replicating the logic tests for filters with an integer on the RHS of the
+# fetch value.
+query T
+EXPLAIN (VERBOSE) SELECT * from d WHERE b->0 = '[]' ORDER BY a
+----
+distribution: local
+vectorized: true
+·
+• filter
+│ columns: (a, b)
+│ ordering: +a
+│ estimated row count: 111 (missing stats)
+│ filter: (b->0) = '[]'
+│
+└── • index join
+    │ columns: (a, b)
+    │ ordering: +a
+    │ estimated row count: 111 (missing stats)
+    │ table: d@d_pkey
+    │ key columns: a
+    │
+    └── • sort
+        │ columns: (a)
+        │ ordering: +a
+        │ estimated row count: 111 (missing stats)
+        │ order: +a
+        │
+        └── • project
+            │ columns: (a)
+            │
+            └── • inverted filter
+                │ columns: (a, b_inverted_key)
+                │ estimated row count: 111 (missing stats)
+                │ inverted column: b_inverted_key
+                │ num spans: 2
+                │
+                └── • scan
+                      columns: (a, b_inverted_key)
+                      estimated row count: 111 (missing stats)
+                      table: d@foo_inv
+                      spans: /Arr/[]-/Arr/{} /???-/???
+
+query T
+EXPLAIN (VERBOSE) SELECT * FROM d WHERE b->0 = '"a"'
+----
+distribution: local
+vectorized: true
+·
+• filter
+│ columns: (a, b)
+│ estimated row count: 111 (missing stats)
+│ filter: (b->0) = '"a"'
+│
+└── • index join
+    │ columns: (a, b)
+    │ estimated row count: 111 (missing stats)
+    │ table: d@d_pkey
+    │ key columns: a
+    │
+    └── • scan
+          columns: (a)
+          estimated row count: 111 (missing stats)
+          table: d@foo_inv
+          spans: /Arr/"a"-/Arr/"a"/PrefixEnd
+
+query T
+EXPLAIN (VERBOSE) SELECT b FROM d WHERE b->1 = '"d"'
+----
+distribution: local
+vectorized: true
+·
+• filter
+│ columns: (b)
+│ estimated row count: 111 (missing stats)
+│ filter: (b->1) = '"d"'
+│
+└── • index join
+    │ columns: (b)
+    │ estimated row count: 111 (missing stats)
+    │ table: d@d_pkey
+    │ key columns: a
+    │
+    └── • scan
+          columns: (a)
+          estimated row count: 111 (missing stats)
+          table: d@foo_inv
+          spans: /Arr/"d"-/Arr/"d"/PrefixEnd
+
+query T
+EXPLAIN (VERBOSE) SELECT b FROM d@foo_inv WHERE b->1 = '[1, 2]'
+----
+distribution: local
+vectorized: true
+·
+• project
+│ columns: (b)
+│
+└── • lookup join (inner)
+    │ columns: (a, b)
+    │ estimated row count: 111 (missing stats)
+    │ table: d@d_pkey
+    │ equality: (a) = (a)
+    │ equality cols are key
+    │ pred: (b->1) = '[1, 2]'
+    │
+    └── • project
+        │ columns: (a)
+        │
+        └── • zigzag join
+              columns: (a, b_inverted_key, a, b_inverted_key)
+              estimated row count: 12 (missing stats)
+              left table: d@foo_inv
+              left columns: (a, b_inverted_key)
+              left fixed values: 1 column
+              right table: d@foo_inv
+              right columns: (a, b_inverted_key)
+              right fixed values: 1 column
+
+query T
+EXPLAIN (VERBOSE) SELECT b FROM d WHERE b->0 = '{"a": {"b": "c"}}'
+----
+distribution: local
+vectorized: true
+·
+• filter
+│ columns: (b)
+│ estimated row count: 111 (missing stats)
+│ filter: (b->0) = '{"a": {"b": "c"}}'
+│
+└── • index join
+    │ columns: (b)
+    │ estimated row count: 111 (missing stats)
+    │ table: d@d_pkey
+    │ key columns: a
+    │
+    └── • scan
+          columns: (a)
+          estimated row count: 111 (missing stats)
+          table: d@foo_inv
+          spans: /Arr/"a"/"b"/"c"-/Arr/"a"/"b"/"c"/PrefixEnd
+
+query T
+EXPLAIN (VERBOSE) SELECT b FROM d WHERE b->'a'->0 = '1'
+----
+distribution: local
+vectorized: true
+·
+• filter
+│ columns: (b)
+│ estimated row count: 111 (missing stats)
+│ filter: ((b->'a')->0) = '1'
+│
+└── • index join
+    │ columns: (b)
+    │ estimated row count: 111 (missing stats)
+    │ table: d@d_pkey
+    │ key columns: a
+    │
+    └── • scan
+          columns: (a)
+          estimated row count: 111 (missing stats)
+          table: d@foo_inv
+          spans: /"a"/Arr/1-/"a"/Arr/1/PrefixEnd
+
+query T
+EXPLAIN (VERBOSE) SELECT b from d WHERE b->'a'->2 = 'null' ORDER BY a
+----
+distribution: local
+vectorized: true
+·
+• project
+│ columns: (b)
+│
+└── • filter
+    │ columns: (a, b)
+    │ ordering: +a
+    │ estimated row count: 111 (missing stats)
+    │ filter: ((b->'a')->2) = 'null'
+    │
+    └── • index join
+        │ columns: (a, b)
+        │ ordering: +a
+        │ estimated row count: 111 (missing stats)
+        │ table: d@d_pkey
+        │ key columns: a
+        │
+        └── • sort
+            │ columns: (a)
+            │ ordering: +a
+            │ estimated row count: 111 (missing stats)
+            │ order: +a
+            │
+            └── • scan
+                  columns: (a)
+                  estimated row count: 111 (missing stats)
+                  table: d@foo_inv
+                  spans: /"a"/Arr/NULL-/"a"/Arr/!NULL
+
+query T
+EXPLAIN (VERBOSE) SELECT b FROM d WHERE b->0->'a'->0 = '0' ORDER BY A
+----
+distribution: local
+vectorized: true
+·
+• project
+│ columns: (b)
+│
+└── • filter
+    │ columns: (a, b)
+    │ ordering: +a
+    │ estimated row count: 111 (missing stats)
+    │ filter: (((b->0)->'a')->0) = '0'
+    │
+    └── • index join
+        │ columns: (a, b)
+        │ ordering: +a
+        │ estimated row count: 111 (missing stats)
+        │ table: d@d_pkey
+        │ key columns: a
+        │
+        └── • sort
+            │ columns: (a)
+            │ ordering: +a
+            │ estimated row count: 111 (missing stats)
+            │ order: +a
+            │
+            └── • scan
+                  columns: (a)
+                  estimated row count: 111 (missing stats)
+                  table: d@foo_inv
+                  spans: /Arr/"a"/Arr/0-/Arr/"a"/Arr/0/PrefixEnd
+
+query T
+EXPLAIN (VERBOSE) SELECT b FROM d WHERE b->0->0 = '0' ORDER BY A
+----
+distribution: local
+vectorized: true
+·
+• project
+│ columns: (b)
+│
+└── • filter
+    │ columns: (a, b)
+    │ ordering: +a
+    │ estimated row count: 111 (missing stats)
+    │ filter: ((b->0)->0) = '0'
+    │
+    └── • index join
+        │ columns: (a, b)
+        │ ordering: +a
+        │ estimated row count: 111 (missing stats)
+        │ table: d@d_pkey
+        │ key columns: a
+        │
+        └── • sort
+            │ columns: (a)
+            │ ordering: +a
+            │ estimated row count: 111 (missing stats)
+            │ order: +a
+            │
+            └── • scan
+                  columns: (a)
+                  estimated row count: 111 (missing stats)
+                  table: d@foo_inv
+                  spans: /Arr/Arr/0-/Arr/Arr/0/PrefixEnd
+
+query T
+EXPLAIN (VERBOSE) SELECT b FROM d WHERE b->0->1 = '[1,2]' ORDER BY a
+----
+distribution: local
+vectorized: true
+·
+• project
+│ columns: (b)
+│
+└── • lookup join (inner)
+    │ columns: (a, b)
+    │ ordering: +a
+    │ estimated row count: 111 (missing stats)
+    │ table: d@d_pkey
+    │ equality: (a) = (a)
+    │ equality cols are key
+    │ pred: ((b->0)->1) = '[1, 2]'
+    │
+    └── • sort
+        │ columns: (a)
+        │ ordering: +a
+        │ estimated row count: 12 (missing stats)
+        │ order: +a
+        │
+        └── • project
+            │ columns: (a)
+            │
+            └── • zigzag join
+                  columns: (a, b_inverted_key, a, b_inverted_key)
+                  estimated row count: 12 (missing stats)
+                  left table: d@foo_inv
+                  left columns: (a, b_inverted_key)
+                  left fixed values: 1 column
+                  right table: d@foo_inv
+                  right columns: (a, b_inverted_key)
+                  right fixed values: 1 column
+
+query T
+EXPLAIN (VERBOSE) SELECT b FROM d WHERE (b->0 = '[1, 2]') AND (b->1 = '[1]')
+----
+distribution: local
+vectorized: true
+·
+• project
+│ columns: (b)
+│
+└── • lookup join (inner)
+    │ columns: (a, b)
+    │ estimated row count: 12 (missing stats)
+    │ table: d@d_pkey
+    │ equality: (a) = (a)
+    │ equality cols are key
+    │ pred: ((b->0) = '[1, 2]') AND ((b->1) = '[1]')
+    │
+    └── • project
+        │ columns: (a)
+        │
+        └── • zigzag join
+              columns: (a, b_inverted_key, a, b_inverted_key)
+              estimated row count: 12 (missing stats)
+              left table: d@foo_inv
+              left columns: (a, b_inverted_key)
+              left fixed values: 1 column
+              right table: d@foo_inv
+              right columns: (a, b_inverted_key)
+              right fixed values: 1 column
+
+# Inverted indices won't be used for queries of the form
+# b->0 @> '{"b": "c"}'
+query T
+EXPLAIN (VERBOSE) SELECT b FROM d WHERE b->0 @> '{"b": "c"}'
+----
+distribution: local
+vectorized: true
+·
+• filter
+│ columns: (b)
+│ estimated row count: 111 (missing stats)
+│ filter: (b->0) @> '{"b": "c"}'
+│
+└── • scan
+      columns: (b)
+      estimated row count: 1,000 (missing stats)
+      table: d@d_pkey
+      spans: FULL SCAN
+
+# Inverted indices won't be used for queries of the form
+# b->0 <@ '{"b": "c"}'
+query T
+EXPLAIN (VERBOSE) SELECT b FROM d WHERE b->0 <@ '{"b": "c"}'
+----
+distribution: local
+vectorized: true
+·
+• filter
+│ columns: (b)
+│ estimated row count: 333 (missing stats)
+│ filter: (b->0) <@ '{"b": "c"}'
+│
+└── • scan
+      columns: (b)
+      estimated row count: 1,000 (missing stats)
+      table: d@d_pkey
+      spans: FULL SCAN
+
 # Stats reflect the following, with some histogram buckets removed:
 # insert into d select g, '[1,2]' from generate_series(1,1000) g(g);
 # insert into d select g, '[[1, 2]]' from generate_series(1001,50000) g(g);

--- a/pkg/sql/opt/invertedidx/json_array.go
+++ b/pkg/sql/opt/invertedidx/json_array.go
@@ -529,7 +529,7 @@ func (j *jsonOrArrayFilterPlanner) extractJSONFetchValEqCondition(
 	}
 
 	// Collect a slice of keys from the fetch val expression.
-	var keys []string
+	var keys tree.Datums
 	keys = j.collectKeys(keys, left)
 	if len(keys) == 0 {
 		return inverted.NonInvertedColExpression{}
@@ -548,6 +548,28 @@ func (j *jsonOrArrayFilterPlanner) extractJSONFetchValEqCondition(
 	typ := val.JSON.Type()
 	if typ == json.ArrayJSONType || typ == json.ObjectJSONType {
 		invertedExpr.SetNotTight()
+	}
+
+	// If a key is of the type DInt, the InvertedExpression generated is
+	// not tight. This is because key encodings for JSON arrays don't
+	// contain the respective index positions for each of their elements.
+	// A JSON array of the form ["a", 31] will have the following encoding
+	// into an index key:
+	//
+	// 1/2/arr/a/pk1
+	// 1/2/arr/31/pk1
+	//
+	// where arr is an ARRAY type tag used to indicate that the next key is
+	// part of an array, 1 is the table id, 2 is the inverted index id and
+	// pk is a primary key of a row in the table. Since the array
+	// elements do not have their respective indices stored in
+	// the encoding, the original filter needs to be applied after the initial
+	// scan.
+	for i := range keys {
+		if _, ok := keys[i].(*tree.DInt); ok {
+			invertedExpr.SetNotTight()
+			break
+		}
 	}
 	return invertedExpr
 }
@@ -584,10 +606,18 @@ func (j *jsonOrArrayFilterPlanner) extractJSONFetchValContainsCondition(
 	}
 
 	// Collect a slice of keys from the fetch val expression.
-	var keys []string
+	var keys tree.Datums
 	keys = j.collectKeys(keys, left)
 	if len(keys) == 0 {
 		return inverted.NonInvertedColExpression{}
+	}
+
+	// Not using inverted indices, yet, for filters of the form
+	// j->0 @> '{"b": "c"}' or j->0 <@ '{"b": "c"}'
+	for i := range keys {
+		if _, ok := keys[i].(*tree.DString); !ok {
+			return inverted.NonInvertedColExpression{}
+		}
 	}
 
 	// Build a new JSON object with the collected keys and val.
@@ -638,22 +668,30 @@ func (j *jsonOrArrayFilterPlanner) extractJSONFetchValContainsCondition(
 //
 // As an example, when left is (j->'a'->'b') and right is ('1'), the keys
 // {"b", "a"} are collected and the JSON object {"a": {"b": 1}} is built.
+//
+// Moreover, the index of the fetch value can also be a DInt, the Int
+// Datum which refers to an index of a JSON array. In this case, as an
+// example, left can be (j->0) and right can be ('1') resulting in the
+// collected keys to become {0} with the JSON object built as ['1'].
 func (j *jsonOrArrayFilterPlanner) collectKeys(
-	currKeys []string, fetch *memo.FetchValExpr,
-) (keys []string) {
+	currKeys tree.Datums, fetch *memo.FetchValExpr,
+) (keys tree.Datums) {
 	// The right side of the fetch val expression, the Index field, must be
-	// a constant string. If not, then we cannot build an inverted
-	// expression.
+	// a constant string or an integer. If not, then we cannot build an
+	// inverted expression.
 	if !memo.CanExtractConstDatum(fetch.Index) {
 		return nil
 	}
-	key, ok := memo.ExtractConstDatum(fetch.Index).(*tree.DString)
-	if !ok {
+	key := memo.ExtractConstDatum(fetch.Index)
+
+	switch key.(type) {
+	case *tree.DString, *tree.DInt:
+	default:
 		return nil
 	}
 
 	// Append the key to the list of keys.
-	keys = append(currKeys, string(*key))
+	keys = append(currKeys, key)
 
 	// If the left side of the fetch val expression, the Json field, is a
 	// variable or expression corresponding to the index column, then we
@@ -678,7 +716,7 @@ func (j *jsonOrArrayFilterPlanner) collectKeys(
 // {"a", "b"} as keys, "c" as val, and construct {"a": "b": ["c"]}.
 // An array of the constructed JSONs is returned.
 func buildFetchContainmentObjects(
-	keys []string, val json.JSON, containedBy bool,
+	keys tree.Datums, val json.JSON, containedBy bool,
 ) ([]json.JSON, error) {
 	var objs []json.JSON
 	typ := val.Type()
@@ -745,16 +783,41 @@ func buildFetchContainmentObjects(
 // Where the keys and val are extracted from a fetch val expression by the
 // caller. Note that key0 is the outer-most fetch val index, so the expression
 // j->'a'->'b' = 1 results in {"a": {"b": 1}}.
-func buildObject(keys []string, val json.JSON) json.JSON {
-	var obj json.JSON
+//
+// It can also construct a new JSON array in the form:
+//
+// [val]
+//
+// where val is extracted from a fetch val expression and an array
+// is built due to the filter being of the form j->index_pos = val, where
+// index_pos is an integer that denotes the index position in a JSON array.
+// An array is built with val at position 0 (regardless of the actual value
+// of index_pos), since the index position of the JSON array is not present
+// in the inverted index key. This removes the need for the actual integer
+// value of the index position and the original filter will be applied after
+// the initial scan.
+
+// Moreover, the function can also result in creating JSON objects that are
+// a combination of both JSON objects and JSON arrays.
+// For example, the expression j->0->'a' = 1 results in [{'a': 1}].
+func buildObject(keys tree.Datums, val json.JSON) json.JSON {
 	for i := 0; i < len(keys); i++ {
-		b := json.NewObjectBuilder(1)
-		if i == 0 {
-			b.Add(keys[i], val)
-		} else {
-			b.Add(keys[i], obj)
+		switch t := keys[i].(type) {
+		case *tree.DString:
+			b := json.NewObjectBuilder(1)
+			b.Add(string(*t), val)
+			val = b.Build()
+		case *tree.DInt:
+			b := json.NewArrayBuilder(1)
+			// We never look at the integer value of the key since
+			// the integer value, denoting an index position in the
+			// JSON array, is never considered while building an
+			// inverted expression. The inverted expression generated
+			// is thus not tight and will thus have the original
+			// filter applied.
+			b.Add(val)
+			val = b.Build()
 		}
-		obj = b.Build()
 	}
-	return obj
+	return val
 }

--- a/pkg/sql/opt/invertedidx/json_array_test.go
+++ b/pkg/sql/opt/invertedidx/json_array_test.go
@@ -461,10 +461,12 @@ func TestTryFilterJsonOrArrayIndex(t *testing.T) {
 			unique:   true,
 		},
 		{
-			// Integer indexes are not yet supported.
-			filters:  "j->0 = '1'",
-			indexOrd: jsonOrd,
-			ok:       false,
+			filters:          "j->0 = '1'",
+			indexOrd:         jsonOrd,
+			ok:               true,
+			tight:            false,
+			unique:           true,
+			remainingFilters: "j->0 = '1'",
 		},
 		{
 			// Arrays on the right side of the equality are supported.
@@ -505,10 +507,44 @@ func TestTryFilterJsonOrArrayIndex(t *testing.T) {
 			unique:   true,
 		},
 		{
-			// Integer indexes are not yet supported.
-			filters:  "j->0->'b' = '1'",
-			indexOrd: jsonOrd,
-			ok:       false,
+			filters:          "j->0->'b' = '1'",
+			indexOrd:         jsonOrd,
+			ok:               true,
+			tight:            false,
+			unique:           true,
+			remainingFilters: "j->0->'b' = '1'",
+		},
+		{
+			filters:          "j->'b'->0->'a'->1 = '1'",
+			indexOrd:         jsonOrd,
+			ok:               true,
+			tight:            false,
+			unique:           true,
+			remainingFilters: "j->'b'->0->'a'->1 = '1'",
+		},
+		{
+			filters:          "j->'a'->0->1 = '1'",
+			indexOrd:         jsonOrd,
+			ok:               true,
+			tight:            false,
+			unique:           true,
+			remainingFilters: "j->'a'->0->1 = '1'",
+		},
+		{
+			filters:          "j->'a'->0 = '1' AND j->'a'->1 = '1'",
+			indexOrd:         jsonOrd,
+			ok:               true,
+			tight:            false,
+			unique:           true,
+			remainingFilters: "j->'a'->0 = '1' AND j->'a'->1 = '1'",
+		},
+		{
+			filters:          "j->'a'->0 = '1' OR j->'a'->1 = '1'",
+			indexOrd:         jsonOrd,
+			ok:               true,
+			tight:            false,
+			unique:           false,
+			remainingFilters: "j->'a'->0 = '1' OR j->'a'->1 = '1'",
 		},
 		{
 			// The inner most expression is not a fetch val expression with an

--- a/pkg/sql/opt/xform/testdata/rules/select
+++ b/pkg/sql/opt/xform/testdata/rules/select
@@ -2842,10 +2842,92 @@ project
       └── filters
            └── (j:4->'a') != '"b"' [outer=(4), immutable]
 
-# Do not generate an inverted scan when the index of the fetch val operator is
-# not a string.
-opt expect-not=GenerateInvertedIndexScans
+# Generate an inverted scan when the index of the fetch val operator is
+# an integer and right side to the equality is a JSON string. Since
+# the inverted expression is not tight, the original filter should be
+# applied.
+opt expect=GenerateInvertedIndexScans
 SELECT k FROM b WHERE j->0 = '"b"'
+----
+project
+ ├── columns: k:1!null
+ ├── immutable
+ ├── key: (1)
+ └── select
+      ├── columns: k:1!null j:4
+      ├── immutable
+      ├── key: (1)
+      ├── fd: (1)-->(4)
+      ├── index-join b
+      │    ├── columns: k:1!null j:4
+      │    ├── key: (1)
+      │    ├── fd: (1)-->(4)
+      │    └── scan b@j_inv_idx
+      │         ├── columns: k:1!null
+      │         ├── inverted constraint: /7/1
+      │         │    └── spans: ["7\x00\x03\x00\x01\x12b\x00\x01", "7\x00\x03\x00\x01\x12b\x00\x01"]
+      │         └── key: (1)
+      └── filters
+           └── (j:4->0) = '"b"' [outer=(4), immutable]
+
+# Generate an inverted scan when the index of the fetch val operator is
+# integer and the right side to the equality is a JSON object.
+# Since the inverted expression is not tight, a filter should be applied.
+opt expect=GenerateInvertedIndexScans
+SELECT k FROM b WHERE j->0 = '{"a": "b"}'
+----
+project
+ ├── columns: k:1!null
+ ├── immutable
+ ├── key: (1)
+ └── select
+      ├── columns: k:1!null j:4
+      ├── immutable
+      ├── key: (1)
+      ├── fd: (1)-->(4)
+      ├── index-join b
+      │    ├── columns: k:1!null j:4
+      │    ├── key: (1)
+      │    ├── fd: (1)-->(4)
+      │    └── scan b@j_inv_idx
+      │         ├── columns: k:1!null
+      │         ├── inverted constraint: /7/1
+      │         │    └── spans: ["7\x00\x03a\x00\x01\x12b\x00\x01", "7\x00\x03a\x00\x01\x12b\x00\x01"]
+      │         └── key: (1)
+      └── filters
+           └── (j:4->0) = '{"a": "b"}' [outer=(4), immutable]
+
+# Generate an inverted scan when the index of the fetch val operator is
+# an integer and the right side to the equality is a JSON
+# array. Since the inverted expression is not tight, a
+# filter should be applied.
+opt expect=GenerateInvertedIndexScans
+SELECT k FROM b WHERE j->0 = '[1, 2]'
+----
+project
+ ├── columns: k:1!null
+ ├── immutable
+ ├── key: (1)
+ └── inner-join (lookup b)
+      ├── columns: k:1!null j:4
+      ├── key columns: [1] = [1]
+      ├── lookup columns are key
+      ├── immutable
+      ├── key: (1)
+      ├── fd: (1)-->(4)
+      ├── inner-join (zigzag b@j_inv_idx b@j_inv_idx)
+      │    ├── columns: k:1!null
+      │    ├── eq columns: [1] = [1]
+      │    ├── left fixed columns: [7] = ['\x370003000300012a0200']
+      │    ├── right fixed columns: [7] = ['\x370003000300012a0400']
+      │    └── filters (true)
+      └── filters
+           └── (j:4->0) = '[1, 2]' [outer=(4), immutable]
+
+# Do not generate an inverted scan when the index of the fetch val operator
+# is not a string and there is a containment operator.
+opt expect-not=GenerateInvertedIndexScans
+SELECT k FROM b WHERE j->0 @> '{"b": "c"}'
 ----
 project
  ├── columns: k:1!null
@@ -2861,7 +2943,29 @@ project
       │    ├── key: (1)
       │    └── fd: (1)-->(4)
       └── filters
-           └── (j:4->0) = '"b"' [outer=(4), immutable]
+           └── (j:4->0) @> '{"b": "c"}' [outer=(4), immutable]
+
+# Do not generate an inverted scan when the index of the fetch val operator
+# is not a string and there is a containment operator.
+opt expect-not=GenerateInvertedIndexScans
+SELECT k FROM b WHERE j->0 <@ '{"b": "c"}'
+----
+project
+ ├── columns: k:1!null
+ ├── immutable
+ ├── key: (1)
+ └── select
+      ├── columns: k:1!null j:4
+      ├── immutable
+      ├── key: (1)
+      ├── fd: (1)-->(4)
+      ├── scan b
+      │    ├── columns: k:1!null j:4
+      │    ├── key: (1)
+      │    └── fd: (1)-->(4)
+      └── filters
+           └── (j:4->0) <@ '{"b": "c"}' [outer=(4), immutable]
+
 
 # Generate an inverted scan when right side of the equality is an array.
 opt expect=GenerateInvertedIndexScans


### PR DESCRIPTION
Previously, the optimizer did not plan inverted index scans for filters having an integer as the index for the fetch value in a filter.

To address this, the current changes supports building JSON objects with both integer and strings. This will now support index values to now be integers, a combination of integers, strings and a combination of integers and strings.

Fixes: https://github.com/cockroachdb/cockroach/issues/94666

Release note: None