### PR TITLE
rules: avoid O(columns^2) behavior with a small change

### DIFF
--- a/pkg/sql/schemachanger/scplan/internal/rules/current/dep_add_column.go
+++ b/pkg/sql/schemachanger/scplan/internal/rules/current/dep_add_column.go
@@ -98,6 +98,17 @@ func init() {
 			status := rel.Var("status")
 			return rel.Clauses{
 				from.Type((*scpb.Column)(nil)),
+				// Join first on the target and node to only explore all columns
+				// which are being added as opposed to all columns. If we joined
+				// first on the columns, we'd be filtering the cross product of
+				// table columns. If a relation has a lot of columns, this can hurt.
+				// It's less likely that we have a very large number of columns which
+				// are being added. We'll want to do something else here when we start
+				// creating tables and all the columns are being added.
+				//
+				// The "right" answer is to push ordering predicates into rel; it also
+				// is maintaining sorted data structures.
+				from.JoinTargetNode(),
 				to.Type((*scpb.Column)(nil)),
 				JoinOnDescID(from, to, "table-id"),
 				ToPublicOrTransient(from, to),

--- a/pkg/sql/schemachanger/scplan/internal/rules/current/testdata/deprules
+++ b/pkg/sql/schemachanger/scplan/internal/rules/current/testdata/deprules
@@ -2130,6 +2130,7 @@ deprules
   to: earlier-column-Node
   query:
     - $later-column[Type] = '*scpb.Column'
+    - joinTargetNode($later-column, $later-column-Target, $later-column-Node)
     - $earlier-column[Type] = '*scpb.Column'
     - joinOnDescID($later-column, $earlier-column, $table-id)
     - ToPublicOrTransient($later-column-Target, $earlier-column-Target)

--- a/pkg/sql/schemachanger/scplan/internal/rules/release_22_2/dep_add_column.go
+++ b/pkg/sql/schemachanger/scplan/internal/rules/release_22_2/dep_add_column.go
@@ -98,6 +98,17 @@ func init() {
 			status := rel.Var("status")
 			return rel.Clauses{
 				from.Type((*scpb.Column)(nil)),
+				// Join first on the target and node to only explore all columns
+				// which are being added as opposed to all columns. If we joined
+				// first on the columns, we'd be filtering the cross product of
+				// table columns. If a relation has a lot of columns, this can hurt.
+				// It's less likely that we have a very large number of columns which
+				// are being added. We'll want to do something else here when we start
+				// creating tables and all the columns are being added.
+				//
+				// The "right" answer is to push ordering predicates into rel; it also
+				// is maintaining sorted data structures.
+				from.JoinTargetNode(),
 				to.Type((*scpb.Column)(nil)),
 				JoinOnDescID(from, to, "table-id"),
 				ToPublicOrTransient(from, to),

--- a/pkg/sql/schemachanger/scplan/internal/rules/release_22_2/testdata/deprules
+++ b/pkg/sql/schemachanger/scplan/internal/rules/release_22_2/testdata/deprules
@@ -2036,6 +2036,7 @@ deprules
   to: earlier-column-Node
   query:
     - $later-column[Type] = '*scpb.Column'
+    - joinTargetNode($later-column, $later-column-Target, $later-column-Node)
     - $earlier-column[Type] = '*scpb.Column'
     - joinOnDescID($later-column, $earlier-column, $table-id)
     - ToPublicOrTransient($later-column-Target, $earlier-column-Target)


### PR DESCRIPTION
Epic: None

Release note (performance improvement): Fixed a bug which could lead to very slow drop when tables or views have a very large number of columns >1000.