### PR TITLE
release-22.1: ui: cache sqlroles results

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/api/userApi.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/api/userApi.ts
@@ -14,9 +14,7 @@ import { fetchData } from "src/api";
 export type UserSQLRolesRequestMessage = cockroach.server.serverpb.UserSQLRolesRequest;
 export type UserSQLRolesResponseMessage = cockroach.server.serverpb.UserSQLRolesResponse;
 
-export function getUserSQLRoles(
-  req: UserSQLRolesRequestMessage,
-): Promise<UserSQLRolesResponseMessage> {
+export function getUserSQLRoles(): Promise<UserSQLRolesResponseMessage> {
   return fetchData(
     cockroach.server.serverpb.UserSQLRolesResponse,
     `/_status/sqlroles`,

--- a/pkg/ui/workspaces/cluster-ui/src/store/sagas.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/store/sagas.ts
@@ -33,6 +33,6 @@ export function* sagas(cacheInvalidationPeriod?: number): SagaIterator {
     fork(notifificationsSaga),
     fork(sqlStatsSaga),
     fork(sqlDetailsStatsSaga),
-    fork(uiConfigSaga),
+    fork(uiConfigSaga, cacheInvalidationPeriod),
   ]);
 }

--- a/pkg/ui/workspaces/cluster-ui/src/store/uiConfig/uiConfig.reducer.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/store/uiConfig/uiConfig.reducer.ts
@@ -10,7 +10,7 @@
 
 import { createSlice, PayloadAction } from "@reduxjs/toolkit";
 import { merge } from "lodash";
-import { DOMAIN_NAME } from "../utils";
+import { DOMAIN_NAME, noopReducer } from "../utils";
 import { cockroach } from "@cockroachlabs/crdb-protobuf-client";
 export type UserSQLRolesRequest = cockroach.server.serverpb.UserSQLRolesRequest;
 
@@ -57,15 +57,17 @@ const uiConfigSlice = createSlice({
     update: (state, action: PayloadAction<Partial<UIConfigState>>) => {
       merge(state, action.payload);
     },
-    refreshUserSQLRoles: (
-      state,
-      action?: PayloadAction<UserSQLRolesRequest>,
-    ) => {
+    receivedUserSQLRoles: (state, action: PayloadAction<string[]>) => {
       if (action?.payload) {
-        const resp = action.payload.toJSON();
-        state.userSQLRoles = resp["roles"];
+        state.userSQLRoles = action.payload;
       }
     },
+    invalidatedUserSQLRoles: state => {
+      state.userSQLRoles = [];
+    },
+    // Define actions that don't change state
+    refreshUserSQLRoles: noopReducer,
+    requestUserSQLRoles: noopReducer,
   },
 });
 


### PR DESCRIPTION
Backport 1/1 commits from #95852.

/cc @cockroachdb/release

---

Previously, the call to get sql roles was constantly being requested. This commits adds a cache limit, so it will only get request after the expiration time.

https://www.loom.com/share/6814309f91234fa2b17490df8160bde6

Epic: None
Release note: None

---

Release justification: bug fix
