### PR TITLE
sql: remove round-trips from common DISCARD ALL

### DIFF
--- a/pkg/bench/rttanalysis/BUILD.bazel
+++ b/pkg/bench/rttanalysis/BUILD.bazel
@@ -38,6 +38,7 @@ go_test(
         "alter_table_bench_test.go",
         "bench_test.go",
         "create_alter_role_bench_test.go",
+        "discard_bench_test.go",
         "drop_bench_test.go",
         "generate_objects_bench_test.go",
         "grant_revoke_bench_test.go",

--- a/pkg/bench/rttanalysis/discard_bench_test.go
+++ b/pkg/bench/rttanalysis/discard_bench_test.go
@@ -1,0 +1,53 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package rttanalysis
+
+import "testing"
+
+func BenchmarkDiscard(b *testing.B) { reg.Run(b) }
+func init() {
+	reg.Register("Discard", []RoundTripBenchTestCase{
+		{
+			Name: "DISCARD ALL, no tables",
+			Setup: `DROP DATABASE IF EXISTS db CASCADE; 
+CREATE DATABASE db;`,
+			Stmt: "DISCARD ALL",
+		},
+		{
+			Name: "DISCARD ALL, 1 tables in 1 db",
+			Setup: `
+SET experimental_enable_temp_tables = true;
+DROP DATABASE IF EXISTS db CASCADE; 
+CREATE DATABASE db; 
+USE db; 
+CREATE TEMPORARY TABLE foo(i int);
+`,
+			Stmt: "DISCARD ALL",
+		},
+		{
+			Name: "DISCARD ALL, 2 tables in 2 dbs",
+			Setup: `
+SET experimental_enable_temp_tables = true;
+DROP DATABASE IF EXISTS db CASCADE; 
+CREATE DATABASE db; 
+USE db; 
+CREATE TEMPORARY TABLE foo(i int);
+CREATE TEMPORARY TABLE bar(i int);
+DROP DATABASE IF EXISTS db2 CASCADE; 
+CREATE DATABASE db2; 
+USE db2; 
+CREATE TEMPORARY TABLE foo(i int);
+CREATE TEMPORARY TABLE bar(i int);
+`,
+			Stmt: "DISCARD ALL",
+		},
+	})
+}

--- a/pkg/bench/rttanalysis/testdata/benchmark_expectations
+++ b/pkg/bench/rttanalysis/testdata/benchmark_expectations
@@ -31,6 +31,9 @@ exp,benchmark
 15,CreateRole/create_role_with_2_options
 18,CreateRole/create_role_with_3_options
 13,CreateRole/create_role_with_no_options
+18,"Discard/DISCARD_ALL,_1_tables_in_1_db"
+21,"Discard/DISCARD_ALL,_2_tables_in_2_dbs"
+9,"Discard/DISCARD_ALL,_no_tables"
 10,DropDatabase/drop_database_0_tables
 11,DropDatabase/drop_database_1_table
 11,DropDatabase/drop_database_2_tables
@@ -47,11 +50,11 @@ exp,benchmark
 12,DropView/drop_1_view
 13,DropView/drop_2_views
 13,DropView/drop_3_views
-5,GenerateObjects/generate_50000_tables
 5,GenerateObjects/generate_1000_tables_-_this_test_should_use_the_same_number_of_RTTs_as_for_10_tables
-5,GenerateObjects/generate_10_tables
 12,GenerateObjects/generate_100_tables_from_template
+5,GenerateObjects/generate_10_tables
 16,GenerateObjects/generate_10x10_schemas_and_tables_in_existing_db
+5,GenerateObjects/generate_50000_tables
 9,Grant/grant_all_on_1_table
 9,Grant/grant_all_on_2_tables
 9,Grant/grant_all_on_3_tables

--- a/pkg/bench/rttanalysis/testdata/benchmark_expectations
+++ b/pkg/bench/rttanalysis/testdata/benchmark_expectations
@@ -31,9 +31,9 @@ exp,benchmark
 15,CreateRole/create_role_with_2_options
 18,CreateRole/create_role_with_3_options
 13,CreateRole/create_role_with_no_options
-18,"Discard/DISCARD_ALL,_1_tables_in_1_db"
-21,"Discard/DISCARD_ALL,_2_tables_in_2_dbs"
-1,"Discard/DISCARD_ALL,_no_tables"
+12,"Discard/DISCARD_ALL,_1_tables_in_1_db"
+15,"Discard/DISCARD_ALL,_2_tables_in_2_dbs"
+0,"Discard/DISCARD_ALL,_no_tables"
 10,DropDatabase/drop_database_0_tables
 11,DropDatabase/drop_database_1_table
 11,DropDatabase/drop_database_2_tables

--- a/pkg/bench/rttanalysis/testdata/benchmark_expectations
+++ b/pkg/bench/rttanalysis/testdata/benchmark_expectations
@@ -33,7 +33,7 @@ exp,benchmark
 13,CreateRole/create_role_with_no_options
 18,"Discard/DISCARD_ALL,_1_tables_in_1_db"
 21,"Discard/DISCARD_ALL,_2_tables_in_2_dbs"
-9,"Discard/DISCARD_ALL,_no_tables"
+1,"Discard/DISCARD_ALL,_no_tables"
 10,DropDatabase/drop_database_0_tables
 11,DropDatabase/drop_database_1_table
 11,DropDatabase/drop_database_2_tables

--- a/pkg/sql/discard.go
+++ b/pkg/sql/discard.go
@@ -84,14 +84,26 @@ func (n *discardNode) startExec(params runParams) error {
 }
 
 func deleteTempTables(ctx context.Context, p *planner) error {
+	// If this session has no temp schemas, then there is nothing to do here.
+	// This is the common case.
+	if len(p.SessionData().DatabaseIDToTempSchemaID) == 0 {
+		return nil
+	}
 	codec := p.execCfg.Codec
 	descCol := p.Descriptors()
+	// Note: grabbing all the databases here is somewhat suspect. It appears
+	// that the logic related to maintaining the set of database temp schemas
+	// is somewhat incomplete, so there can be temp schemas in the sessiondata
+	// map which don't exist any longer.
 	allDbDescs, err := descCol.GetAllDatabaseDescriptors(ctx, p.Txn())
 	if err != nil {
 		return err
 	}
 	g := p.byNameGetterBuilder().MaybeGet()
 	for _, db := range allDbDescs {
+		if _, ok := p.SessionData().DatabaseIDToTempSchemaID[uint32(db.GetID())]; !ok {
+			continue
+		}
 		sc, err := g.Schema(ctx, db, p.TemporarySchemaName())
 		if err != nil {
 			return err

--- a/pkg/sql/user.go
+++ b/pkg/sql/user.go
@@ -546,7 +546,7 @@ func (p *planner) setRole(ctx context.Context, local bool, s username.SQLUsernam
 	sessionUser := p.SessionData().SessionUser()
 	becomeUser := sessionUser
 	// Check the role exists - if so, populate becomeUser.
-	if !s.IsNoneRole() {
+	if !s.IsNoneRole() && s != sessionUser {
 		becomeUser = s
 
 		exists, err := p.RoleExists(ctx, becomeUser)


### PR DESCRIPTION
#### sql: avoid checking if a role exists when setting to the current role

This is an uncached round-trip. It makes `DISCARD` expensive.
In https://github.com/cockroachdb/cockroach/pull/86485 we implemented
`SET SESSION AUTHORIZATION DEFAULT`, this added an extra sql query to
`DISCARD ALL` to check if the role we'd become exists. This is almost
certainly unintentional in the case where the role we'd become is the
current session role. I think this just happened because of code
consolidation.

We now no longer check if the current session role exists. This removes
the last round-trip from DISCARD ALL.

#### sql: use in-memory session data to decide what to do in DISCARD

In #86246 we introduced logic to discard schemas when running DISCARD ALL and DISCARD TEMP. This logic did expensive kv operations unconditionally; if the session knew it had never created a temporary schema, we'd still fetch all databases and proceed to search all databases for a temp schema. This is very expensive.

Fixes: #95864

Release note (performance improvement): In 22.2, logic was added to make
`SET SESSION AUTHORIZATION DEFAULT` not a no-op. This implementation used
more general code for setting the role for a session which made sure that
the role exists. The check for whether a role exists is currently uncached.
We don't need to check if the role we already are exists. This improves the
performance of `DISCARD ALL` in addition to `SET SESSION AUTHORIZATION
DEFAULT`.


Release note (performance improvement): In 22.2, we introduced support for `DISCARD TEMP` and made `DISCARD ALL` actually discard temp tables. This implementation ran expensive logic to discover temp schemas rather than consulting in-memory data structures. As a result, `DISCARD ALL`, which is issued regularly by connection pools, became an expensive operation when it should be cheap. This problem is now resolved.