### PR TITLE
[bug] *: reproduce tenant stampeding another's span configs

### DIFF
--- a/pkg/ccl/spanconfigccl/spanconfigreconcilerccl/testdata/multitenant/bug
+++ b/pkg/ccl/spanconfigccl/spanconfigreconcilerccl/testdata/multitenant/bug
@@ -1,0 +1,127 @@
+# BUG: Show how creation of a tenant can end up overwriting span config state
+# for another tenant, and that the other tenant is not equipped to deal with it.
+
+reconcile
+----
+
+mutations discard
+----
+
+# Initialize tenant=11. To try and split at the end of the tenant boundary,
+# notice how we end up writing a record for a key that logically belongs to the
+# next tenant, tenant=12? That's weird.
+initialize tenant=11
+----
+
+state offset=57 limit=2
+----
+...
+/Tenant/11{-\x00}                          database system (tenant)
+/Tenant/12{-\x00}                          database system (tenant)
+
+# Start the reconciliation loop for the tenant=11. It'll first clear out its own
+# first-key record and install span configs for its SQL state. It won't touch
+# the record we created at in the tenant=12 keyspace because it's not taught to
+# look there, and neither should it. The keyspace it's responsible for is its
+# own.
+reconcile tenant=11
+----
+
+# Peek near the start of the span_configurations table where tenant=11's records
+# are stored. The first one is from the start of its keyspace to start of
+# table with ID=4: /Tenant/11{-/Table/4}.
+state offset=56 limit=5
+----
+...
+/Table/5{7-8}                              ttl_seconds=3600 ignore_strict_gc=true num_replicas=5 rangefeed_enabled=true
+/Tenant/11{-/Table/4}                      database system (tenant)
+/Tenant/11/Table/{4-5}                     database system (tenant)
+/Tenant/11/Table/{5-6}                     database system (tenant)
+/Tenant/11/Table/{6-7}                     database system (tenant)
+...
+
+# Peek near the end of the span_configurations table where tenant=11's records
+# are stored. The last one is for its last system table:
+# /Tenant/11/Table/5{7-8}. Right now the split is at /Tenant/12. Which is fine.
+state offset=99 limit=2
+----
+...
+/Tenant/11/Table/5{7-8}                    database system (tenant)
+/Tenant/12{-\x00}                          database system (tenant)
+
+# Just another view of what the tenant's reconciler actually did. It got rid of
+# the original, single-key /Tenant/11{-\x00} record, and replaced it with
+# /Tenant/11{-/Table/4}, just like the comment above said. The remaining upserts
+# are for its SQL state.
+mutations tenant=11
+----
+delete /Tenant/11{-\x00}
+upsert /Tenant/11{-/Table/4}               database system (tenant)
+upsert /Tenant/11/Table/{4-5}              database system (tenant)
+upsert /Tenant/11/Table/{5-6}              database system (tenant)
+upsert /Tenant/11/Table/{6-7}              database system (tenant)
+upsert /Tenant/11/Table/{7-8}              database system (tenant)
+upsert /Tenant/11/Table/1{1-2}             database system (tenant)
+upsert /Tenant/11/Table/1{2-3}             database system (tenant)
+upsert /Tenant/11/Table/1{3-4}             database system (tenant)
+upsert /Tenant/11/Table/1{4-5}             database system (tenant)
+upsert /Tenant/11/Table/1{5-6}             database system (tenant)
+upsert /Tenant/11/Table/{19-20}            database system (tenant)
+upsert /Tenant/11/Table/2{0-1}             database system (tenant)
+upsert /Tenant/11/Table/2{1-2}             database system (tenant)
+upsert /Tenant/11/Table/2{3-4}             database system (tenant)
+upsert /Tenant/11/Table/2{4-5}             database system (tenant)
+upsert /Tenant/11/Table/2{5-6}             database system (tenant)
+upsert /Tenant/11/Table/2{6-7}             database system (tenant)
+upsert /Tenant/11/Table/2{7-8}             database system (tenant)
+upsert /Tenant/11/Table/2{8-9}             database system (tenant)
+upsert /Tenant/11/NamespaceTable/{30-Max}  database system (tenant)
+upsert /Tenant/11/{NamespaceTable/Max-Table/32} database system (tenant)
+upsert /Tenant/11/Table/3{2-3}             database system (tenant)
+upsert /Tenant/11/Table/3{3-4}             database system (tenant)
+upsert /Tenant/11/Table/3{4-5}             database system (tenant)
+upsert /Tenant/11/Table/3{5-6}             database system (tenant)
+upsert /Tenant/11/Table/3{6-7}             database system (tenant)
+upsert /Tenant/11/Table/3{7-8}             database system (tenant)
+upsert /Tenant/11/Table/{39-40}            database system (tenant)
+upsert /Tenant/11/Table/4{0-1}             database system (tenant)
+upsert /Tenant/11/Table/4{1-2}             database system (tenant)
+upsert /Tenant/11/Table/4{2-3}             database system (tenant)
+upsert /Tenant/11/Table/4{3-4}             database system (tenant)
+upsert /Tenant/11/Table/4{4-5}             database system (tenant)
+upsert /Tenant/11/Table/4{6-7}             database system (tenant)
+upsert /Tenant/11/Table/4{8-9}             database system (tenant)
+upsert /Tenant/11/Table/5{0-1}             database system (tenant)
+upsert /Tenant/11/Table/5{1-2}             database system (tenant)
+upsert /Tenant/11/Table/5{2-3}             database system (tenant)
+upsert /Tenant/11/Table/5{3-4}             database system (tenant)
+upsert /Tenant/11/Table/5{4-5}             database system (tenant)
+upsert /Tenant/11/Table/5{5-6}             database system (tenant)
+upsert /Tenant/11/Table/5{6-7}             database system (tenant)
+upsert /Tenant/11/Table/5{7-8}             database system (tenant)
+
+# Now for the bug. We'll create tenant=10, but see that it actually ends up
+# overwriting span config state for the already-reconciling tenant=11. That
+# tenant's reconciler is not expecting this! It operates with the invariant that
+# it's the only writer of span configs for its keyspan, which we're simply
+# breaking.
+initialize tenant=10
+----
+
+# We re-inserted a record at /Tenant/11{-\x00}, and split up tenant=11's own
+# span config records in the process. Previously tenant=11's first record was
+/Tenant/11{-/Table/4}. Now it's /Tenant/11{-\x00}. If tenant=11 had set some
+span config for that keyspan, tenant=10's creation just nuked it.
+----
+...
+/Tenant/10{-\x00}                          database system (tenant)
+/Tenant/11{-\x00}                          database system (tenant)
+/Tenant/11/Table/{4-5}                     database system (tenant)
+/Tenant/11/Table/{5-6}                     database system (tenant)
+/Tenant/11/Table/{6-7}                     database system (tenant)
+...
+
+# And tenant=11, since it assumes its the only writer, simply does not observe
+# this mutation.
+mutations tenant=11
+----

--- a/pkg/sql/tenant_creation.go
+++ b/pkg/sql/tenant_creation.go
@@ -353,6 +353,12 @@ func CreateTenantRecord(
 	// This adds a split at the end of the tenant keyspace. This split would
 	// eventually be created when the next tenant is created, but until then
 	// this tenant's EndKey will be /Max which is outside of it's keyspace.
+	//
+	// BUG: This is the next tenant ID's prefix start. We're writing span config
+	// records over a keyspace that "belongs" to another tenant. That tenant, if
+	// it has started its span config reconciliation job, is assuming an
+	// invariant that its the only entity writing span config records that
+	// overlap with its keyspan. Which we're violating here.
 	tenantPrefixEnd := tenantPrefix.PrefixEnd()
 	endRecord, err := spanconfig.MakeRecord(spanconfig.MakeTargetFromSpan(roachpb.Span{
 		Key:    tenantPrefixEnd,


### PR DESCRIPTION
Reproduction for https://github.com/cockroachdb/cockroach/issues/95882.

Release note: None