### PR TITLE
opt: execute correlated Exists as Routines and and allow Exists in UDFs

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/subquery
+++ b/pkg/sql/logictest/testdata/logic_test/subquery
@@ -606,6 +606,16 @@ SELECT count(*) FROM corr2
 ----
 1
 
+# Uncorrelated EXISTS subqueries within correlated subqueries can be executed.
+query I
+SELECT i FROM (VALUES (1), (2)) v(i)
+WHERE CASE
+  WHEN i < 3 THEN (SELECT 1/i = 1 FROM (VALUES (1)) WHERE EXISTS (SELECT * FROM corr))
+  ELSE false
+END
+----
+1
+
 
 subtest regressions
 

--- a/pkg/sql/logictest/testdata/logic_test/subquery
+++ b/pkg/sql/logictest/testdata/logic_test/subquery
@@ -524,10 +524,24 @@ k  i   prev_i
 4  40  33
 5  50  40
 
-# TODO(mgartner): Execute correlated EXISTS subqueries.
-statement error could not decorrelate subquery
+query II
 SELECT * FROM corr
 WHERE CASE WHEN k < 5 THEN EXISTS (SELECT i FROM corr tmp WHERE i = corr.k*10) END
+----
+1  10
+3  30
+4  40
+
+query IIB
+SELECT *,
+  CASE WHEN k < 5 THEN EXISTS (SELECT i FROM corr tmp WHERE i = corr.k*10) END
+FROM corr
+----
+1  10  true
+2  22  false
+3  30  true
+4  40  true
+5  50  NULL
 
 # TODO(mgartner): Execute correlated <op> ANY subqueries.
 statement error could not decorrelate subquery
@@ -611,6 +625,22 @@ query I
 SELECT i FROM (VALUES (1), (2)) v(i)
 WHERE CASE
   WHEN i < 3 THEN (SELECT 1/i = 1 FROM (VALUES (1)) WHERE EXISTS (SELECT * FROM corr))
+  ELSE false
+END
+----
+1
+
+# Correlated EXISTS subqueries within correlated subqueries can be executed.
+query I
+SELECT i FROM (VALUES (1), (10)) v(i)
+WHERE CASE
+  WHEN i > 0 THEN (
+    SELECT i/1 = j FROM (VALUES (1), (10)) w(j)
+    WHERE CASE
+      WHEN j > 0 THEN EXISTS (SELECT * FROM corr WHERE k/1 = j)
+      ELSE false
+    END
+  )
   ELSE false
 END
 ----

--- a/pkg/sql/logictest/testdata/logic_test/udf
+++ b/pkg/sql/logictest/testdata/logic_test/udf
@@ -2796,6 +2796,22 @@ SELECT a, sub_is_odd(a) FROM sub_all WHERE sub_is_odd(a) OR sub_is_odd(a) IS NUL
 5  true
 6  NULL
 
+# UDF with an uncorrelated EXISTS.
+statement ok
+CREATE FUNCTION sub_first() RETURNS INT LANGUAGE SQL AS $$
+  SELECT a FROM sub_all WHERE EXISTS (SELECT a FROM sub_odd) ORDER BY a LIMIT 1
+$$
+
+query II rowsort
+SELECT sub_first(), a FROM sub_all
+----
+1  1
+1  2
+1  3
+1  4
+1  5
+1  6
+
 
 subtest variadic
 

--- a/pkg/sql/logictest/testdata/logic_test/udf
+++ b/pkg/sql/logictest/testdata/logic_test/udf
@@ -2812,6 +2812,26 @@ SELECT sub_first(), a FROM sub_all
 1  5
 1  6
 
+# UDF with a correlated EXISTS.
+statement ok
+CREATE FUNCTION sub_two() RETURNS INT LANGUAGE SQL AS $$
+  SELECT a FROM sub_all WHERE CASE
+    WHEN a > 1 THEN EXISTS (SELECT 0 FROM sub_odd WHERE sub_odd.a = sub_all.a+1)
+    ELSE false
+  END
+  ORDER BY a LIMIT 1
+$$
+
+query II rowsort
+SELECT a, sub_two() FROM sub_all
+----
+1  2
+2  2
+3  2
+4  2
+5  2
+6  2
+
 
 subtest variadic
 
@@ -2922,10 +2942,10 @@ SELECT oid, proname, pronamespace, proowner, prolang, proleakproof, proisstrict,
 FROM pg_catalog.pg_proc WHERE proname IN ('f_93314', 'f_93314_alias', 'f_93314_comp', 'f_93314_comp_t')
 ORDER BY oid;
 ----
-100264  f_93314         105  1546506610  14  false  false  false  v  0  100263  ·  {}  NULL  SELECT i, e FROM test.public.t_93314 ORDER BY i LIMIT 1;
-100266  f_93314_alias   105  1546506610  14  false  false  false  v  0  100265  ·  {}  NULL  SELECT i, e FROM test.public.t_93314_alias ORDER BY i LIMIT 1;
-100270  f_93314_comp    105  1546506610  14  false  false  false  v  0  100267  ·  {}  NULL  SELECT (1, 2);
-100271  f_93314_comp_t  105  1546506610  14  false  false  false  v  0  100269  ·  {}  NULL  SELECT a, c FROM test.public.t_93314_comp LIMIT 1;
+100266  f_93314         105  1546506610  14  false  false  false  v  0  100265  ·  {}  NULL  SELECT i, e FROM test.public.t_93314 ORDER BY i LIMIT 1;
+100268  f_93314_alias   105  1546506610  14  false  false  false  v  0  100267  ·  {}  NULL  SELECT i, e FROM test.public.t_93314_alias ORDER BY i LIMIT 1;
+100272  f_93314_comp    105  1546506610  14  false  false  false  v  0  100269  ·  {}  NULL  SELECT (1, 2);
+100273  f_93314_comp_t  105  1546506610  14  false  false  false  v  0  100271  ·  {}  NULL  SELECT a, c FROM test.public.t_93314_comp LIMIT 1;
 
 # Regression test for #95240. Strict UDFs that are inlined should result in NULL
 # when presented with NULL arguments.

--- a/pkg/sql/opt/exec/execbuilder/builder.go
+++ b/pkg/sql/opt/exec/execbuilder/builder.go
@@ -329,6 +329,10 @@ func (b *Builder) decorrelationError() error {
 	return errors.Errorf("could not decorrelate subquery")
 }
 
+func (b *Builder) decorrelationMutationError() error {
+	return errors.Errorf("could not decorrelate subquery with mutation")
+}
+
 // builtWithExpr is metadata regarding a With expression which has already been
 // added to the set of subqueries for the query.
 type builtWithExpr struct {

--- a/pkg/sql/opt/exec/execbuilder/scalar.go
+++ b/pkg/sql/opt/exec/execbuilder/scalar.go
@@ -17,6 +17,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/exec"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/norm"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/props"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/props/physical"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/xform"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/builtins/builtinsregistry"
@@ -583,11 +584,93 @@ func (b *Builder) buildExistsSubquery(
 	ctx *buildScalarCtx, scalar opt.ScalarExpr,
 ) (tree.TypedExpr, error) {
 	exists := scalar.(*memo.ExistsExpr)
-	// We cannot execute correlated subqueries.
-	// TODO(mgartner): Plan correlated EXISTS subqueries using tree.RoutineExpr.
-	// See buildSubquery.
-	if !exists.Input.Relational().OuterCols.Empty() {
-		return nil, b.decorrelationError()
+	input := exists.Input
+
+	// Build correlated EXISTS subqueries as lazily-evaluated routines.
+	//
+	// Routines do not have a special mode for existential subqueries, like the
+	// legacy, eager-evaluation subquery machinery does, so we must transform
+	// the Exists expression. The transformation is modelled after the
+	// ConvertUncorrelatedExistsToCoalesceSubquery normalization rule. The
+	// transformation is effectively:
+	//
+	//   EXISTS (<input>)
+	//   =>
+	//   COALESCE((SELECT true FROM (<input>) LIMIT 1), false)
+	//
+	// We don't implement this as a normalization rule for correlated subqueries
+	// because the transformation would prevent decorrelation rules from turning
+	// the Exists expression into a join, if it is possible. Marking the rule as
+	// LowPriority would not be sufficient because the rule would operate on the
+	// Exists scalar expression, while the decorrelation rules operate on
+	// relational expressions that contain Exists expresions. The Exists would
+	// always be converted to a Coalesce before the decorrelation rules can
+	// match.
+	if outerCols := input.Relational().OuterCols; !outerCols.Empty() {
+		// Routines do not yet support mutations.
+		// TODO(mgartner): Lift this restriction once routines support
+		// mutations.
+		if input.Relational().CanMutate {
+			return nil, b.decorrelationMutationError()
+		}
+
+		// The outer columns of the subquery become the parameters of the
+		// routine.
+		params := outerCols.ToList()
+
+		// The outer columns of the subquery, as indexed columns, are the
+		// arguments of the routine.
+		args := make(tree.TypedExprs, len(params))
+		for i := range args {
+			args[i] = b.indexedVar(ctx, b.mem.Metadata(), params[i])
+		}
+
+		// Create a new column for the boolean result.
+		existsCol := b.mem.Metadata().AddColumn("exists", types.Bool)
+
+		// Create a single-element RelListExpr representing the subquery.
+		aliasedCol := opt.AliasedColumn{
+			Alias: b.mem.Metadata().ColumnMeta(existsCol).Alias,
+			ID:    existsCol,
+		}
+		stmts := memo.RelListExpr{memo.RelRequiredPropsExpr{
+			RelExpr: input,
+			PhysProps: &physical.Required{
+				Presentation: physical.Presentation{aliasedCol},
+			},
+		}}
+
+		// Create an wrapRootExprFn that wraps input in a Limit and a Project.
+		wrapRootExpr := func(f *norm.Factory, e memo.RelExpr) opt.Expr {
+			return f.ConstructProject(
+				f.ConstructLimit(
+					e,
+					f.ConstructConst(tree.NewDInt(tree.DInt(1)), types.Int),
+					props.OrderingChoice{},
+				),
+				memo.ProjectionsExpr{f.ConstructProjectionsItem(memo.TrueSingleton, existsCol)},
+				opt.ColSet{}, /* passthrough */
+			)
+		}
+
+		// Create a plan generator that can plan the single statement
+		// representing the subquery, and wrap the routine in a COALESCE.
+		planGen := b.buildRoutinePlanGenerator(
+			params,
+			stmts,
+			true, /* allowOuterWithRefs */
+			wrapRootExpr,
+		)
+		return tree.NewTypedCoalesceExpr(tree.TypedExprs{
+			tree.NewTypedRoutineExpr(
+				"exists",
+				args,
+				planGen,
+				types.Bool,
+				false, /* enableStepping */
+			),
+			tree.DBoolFalse,
+		}, types.Bool), nil
 	}
 
 	// Build the execution plan for the subquery. Note that the subquery could
@@ -627,7 +710,7 @@ func (b *Builder) buildSubquery(
 		// TODO(mgartner): Lift this restriction once routines support
 		// mutations.
 		if input.Relational().CanMutate {
-			return nil, b.decorrelationError()
+			return nil, b.decorrelationMutationError()
 		}
 
 		// The outer columns of the subquery become the parameters of the
@@ -657,7 +740,12 @@ func (b *Builder) buildSubquery(
 
 		// Create a tree.RoutinePlanFn that can plan the single statement
 		// representing the subquery.
-		planGen := b.buildRoutinePlanGenerator(params, stmts, true /* allowOuterWithRefs */)
+		planGen := b.buildRoutinePlanGenerator(
+			params,
+			stmts,
+			true, /* allowOuterWithRefs */
+			nil,  /* wrapRootExpr */
+		)
 		return tree.NewTypedRoutineExpr(
 			"subquery",
 			args,
@@ -782,7 +870,12 @@ func (b *Builder) buildUDF(ctx *buildScalarCtx, scalar opt.ScalarExpr) (tree.Typ
 
 	// Create a tree.RoutinePlanFn that can plan the statements in the UDF body.
 	// TODO(mgartner): Add support for WITH expressions inside UDF bodies.
-	planGen := b.buildRoutinePlanGenerator(udf.Params, udf.Body, false /* allowOuterWithRefs */)
+	planGen := b.buildRoutinePlanGenerator(
+		udf.Params,
+		udf.Body,
+		false, /* allowOuterWithRefs */
+		nil,   /* wrapRootExpr */
+	)
 
 	// Enable stepping for volatile functions so that statements within the UDF
 	// see mutations made by the invoking statement and by previous executed
@@ -798,10 +891,20 @@ func (b *Builder) buildUDF(ctx *buildScalarCtx, scalar opt.ScalarExpr) (tree.Typ
 	), nil
 }
 
-// buildRoutinePlanGenerator returns a tree.RoutinePlanFn that can plan the statements
-// in a routine that has one or more arguments.
+type wrapRootExprFn func(f *norm.Factory, e memo.RelExpr) opt.Expr
+
+// buildRoutinePlanGenerator returns a tree.RoutinePlanFn that can plan the
+// statements in a routine that has one or more arguments.
+//
+// The returned tree.RoutinePlanFn copies one of the statements into a new memo
+// for re-optimization each time it is called. By default, parameter references
+// are replaced with constant argument values when the plan function is called.
+// If allowOuterWithRefs is true, then With binding are copied to the new memo
+// so that WithScans within a statement can be planned and executed.
+// wrapRootExpr allows the root expression of all statements to be replaced with
+// an arbitrary expression.
 func (b *Builder) buildRoutinePlanGenerator(
-	params opt.ColList, stmts memo.RelListExpr, allowOuterWithRefs bool,
+	params opt.ColList, stmts memo.RelListExpr, allowOuterWithRefs bool, wrapRootExpr wrapRootExprFn,
 ) tree.RoutinePlanGenerator {
 	// argOrd returns the ordinal of the argument within the arguments list that
 	// can be substituted for each reference to the given function parameter
@@ -875,7 +978,12 @@ func (b *Builder) buildRoutinePlanGenerator(
 					}
 					// Fall through.
 				}
-				return f.CopyAndReplaceDefault(e, replaceFn)
+
+				replaced := f.CopyAndReplaceDefault(e, replaceFn)
+				if wrapRootExpr != nil && e == stmt.RelExpr {
+					replaced = wrapRootExpr(f, replaced.(memo.RelExpr))
+				}
+				return replaced
 			}
 			f.CopyAndReplace(stmt, stmt.PhysProps, replaceFn)
 

--- a/pkg/sql/opt/exec/execbuilder/scalar.go
+++ b/pkg/sql/opt/exec/execbuilder/scalar.go
@@ -592,6 +592,12 @@ func (b *Builder) buildExistsSubquery(
 
 	// Build the execution plan for the subquery. Note that the subquery could
 	// have subqueries of its own which are added to b.subqueries.
+	//
+	// TODO(mgartner): This path should never be executed because the
+	// ConvertUncorrelatedExistsToCoalesceSubquery converts all uncorrelated
+	// Exists with Coalesce+Subquery expressions. Remove this and the execution
+	// support for the Exists mode. Remember to mark
+	// ConvertUncorrelatedExistsToCoalesceSubquery as an essential rule.
 	plan, err := b.buildRelational(exists.Input)
 	if err != nil {
 		return nil, err

--- a/pkg/sql/opt/exec/execbuilder/testdata/subquery
+++ b/pkg/sql/opt/exec/execbuilder/testdata/subquery
@@ -101,14 +101,16 @@ vectorized: true
 │
 └── • subquery
     │ id: @S1
-    │ original sql: EXISTS (SELECT a FROM abc)
-    │ exec mode: exists
+    │ original sql: (SELECT a FROM abc)
+    │ exec mode: one row
     │
-    └── • scan
-          missing stats
-          table: abc@abc_pkey
-          spans: LIMITED SCAN
-          limit: 1
+    └── • render
+        │
+        └── • scan
+              missing stats
+              table: abc@abc_pkey
+              spans: LIMITED SCAN
+              limit: 1
 
 query T
 EXPLAIN (VERBOSE) SELECT * FROM abc WHERE a = (SELECT max(a) FROM abc WHERE EXISTS(SELECT * FROM abc WHERE c=a+3))
@@ -132,23 +134,27 @@ vectorized: true
 │
 ├── • subquery
 │   │ id: @S1
-│   │ original sql: EXISTS (SELECT * FROM abc WHERE c = (a + 3))
-│   │ exec mode: exists
+│   │ original sql: (SELECT * FROM abc WHERE c = (a + 3))
+│   │ exec mode: one row
 │   │
-│   └── • limit
-│       │ columns: (a, b, c)
-│       │ count: 1
+│   └── • render
+│       │ columns: (column16)
+│       │ render column16: true
 │       │
-│       └── • filter
-│           │ columns: (a, b, c)
-│           │ estimated row count: 330 (missing stats)
-│           │ filter: c = (a + 3)
+│       └── • limit
+│           │ columns: (a, c)
+│           │ count: 1
 │           │
-│           └── • scan
-│                 columns: (a, b, c)
-│                 estimated row count: 1,000 (missing stats)
-│                 table: abc@abc_pkey
-│                 spans: FULL SCAN (SOFT LIMIT)
+│           └── • filter
+│               │ columns: (a, c)
+│               │ estimated row count: 330 (missing stats)
+│               │ filter: c = (a + 3)
+│               │
+│               └── • scan
+│                     columns: (a, c)
+│                     estimated row count: 1,000 (missing stats)
+│                     table: abc@abc_pkey
+│                     spans: FULL SCAN (SOFT LIMIT)
 │
 └── • subquery
     │ id: @S2
@@ -168,7 +174,7 @@ vectorized: true
                 │ columns: (a)
                 │ ordering: -a
                 │ estimated row count: 333 (missing stats)
-                │ filter: @S1
+                │ filter: COALESCE(@S1, false)
                 │
                 └── • revscan
                       columns: (a)

--- a/pkg/sql/opt/exec/execbuilder/testdata/subquery
+++ b/pkg/sql/opt/exec/execbuilder/testdata/subquery
@@ -518,3 +518,47 @@ Scan /Table/110/1/1/0
 Scan /Table/110/1/2/0
 Scan /Table/110/1/3/0
 Scan /Table/110/1/4/0
+
+# Case where the EXISTS subquery in a filter cannot be hoisted into an
+# apply-join.
+query T
+EXPLAIN (VERBOSE)
+SELECT * FROM corr
+WHERE CASE WHEN k < 5 THEN EXISTS (SELECT i FROM corr tmp WHERE i = corr.k*10) END
+----
+distribution: local
+vectorized: true
+·
+• filter
+│ columns: (k, i)
+│ estimated row count: 333 (missing stats)
+│ filter: CASE WHEN k < 5 THEN COALESCE(exists(k), false) ELSE CAST(NULL AS BOOL) END
+│
+└── • scan
+      columns: (k, i)
+      estimated row count: 1,000 (missing stats)
+      table: corr@corr_pkey
+      spans: FULL SCAN
+
+# Case where the EXISTS subquery in a projection cannot be hoisted into an
+# apply-join.
+query T
+EXPLAIN (VERBOSE)
+SELECT *,
+  CASE WHEN k < 5 THEN EXISTS (SELECT i FROM corr tmp WHERE i = corr.k*10) END
+FROM corr
+----
+distribution: local
+vectorized: true
+·
+• render
+│ columns: (k, i, "case")
+│ render case: CASE WHEN k < 5 THEN COALESCE(exists(k), false) ELSE CAST(NULL AS BOOL) END
+│ render k: k
+│ render i: i
+│
+└── • scan
+      columns: (k, i)
+      estimated row count: 1,000 (missing stats)
+      table: corr@corr_pkey
+      spans: FULL SCAN

--- a/pkg/sql/opt/exec/execbuilder/testdata/udf
+++ b/pkg/sql/opt/exec/execbuilder/testdata/udf
@@ -181,6 +181,60 @@ Scan /Table/113/1/30/0
 Scan /Table/112/{1-2}
 Scan /Table/113/1/30/0
 
+statement ok
+CREATE FUNCTION sub_fn3() RETURNS INT LANGUAGE SQL AS 'SELECT a FROM sub1 WHERE EXISTS (SELECT a FROM sub2 WHERE a = 30)'
+
+# A query with an uncorrelated EXISTS within a UDF.
+query T
+EXPLAIN (VERBOSE) SELECT * FROM sub3 WHERE sub_fn3() = 3
+----
+distribution: local
+vectorized: true
+·
+• filter
+│ columns: (a)
+│ estimated row count: 333 (missing stats)
+│ filter: sub_fn3() = 3
+│
+└── • scan
+      columns: (a)
+      estimated row count: 1,000 (missing stats)
+      table: sub3@sub3_pkey
+      spans: FULL SCAN
+
+statement ok
+CREATE FUNCTION sub_fn4() RETURNS INT LANGUAGE SQL AS $$
+  SELECT a FROM sub1 WHERE CASE
+    WHEN a > 0 THEN EXISTS (SELECT 1 FROM sub2 WHERE a/10 = sub1.a)
+    ELSE false
+  END
+$$
+
+# A query with a correlated EXISTS within a UDF.
+query T
+EXPLAIN (VERBOSE) SELECT * FROM sub3 WHERE sub_fn4() = 3
+----
+distribution: local
+vectorized: true
+·
+• filter
+│ columns: (a)
+│ estimated row count: 333 (missing stats)
+│ filter: sub_fn4() = 3
+│
+└── • scan
+      columns: (a)
+      estimated row count: 1,000 (missing stats)
+      table: sub3@sub3_pkey
+      spans: FULL SCAN
+
+query I
+SELECT sub_fn4() FROM generate_series(1, 3)
+----
+1
+1
+1
+
 
 subtest regressions
 

--- a/pkg/sql/opt/indexrec/testdata/index
+++ b/pkg/sql/opt/indexrec/testdata/index
@@ -849,79 +849,99 @@ ORDER BY t1.k, t2.i, t1.i DESC
 ----
 creation: CREATE INDEX ON t1 (k, i DESC);
 creation: CREATE INDEX ON t2 (k) STORING (i);
-creation: CREATE INDEX ON t3 (f) STORING (k, i);
+creation: CREATE INDEX ON t3 (f) STORING (k);
 --
 optimal plan:
 sort (segmented)
  ├── columns: k:1 i:2 i:9
- ├── cost: 2432.08954
+ ├── cost: 2432.08948
  ├── ordering: +1,+9,-2
  └── project
       ├── columns: t1.k:1 t1.i:2 t2.i:9
-      ├── cost: 2279.40821
+      ├── cost: 2279.40815
       ├── ordering: +1
       └── left-join (merge)
            ├── columns: t1.k:1 t1.i:2 t2.k:8 t2.i:9
            ├── left ordering: +1
            ├── right ordering: +8
-           ├── cost: 2268.08102
+           ├── cost: 2268.08095
            ├── ordering: +1
            ├── select
            │    ├── columns: t1.k:1 t1.i:2
-           │    ├── cost: 1130.09358
+           │    ├── cost: 1130.09355
            │    ├── ordering: +1
            │    ├── scan t1@_hyp_1
            │    │    ├── columns: t1.k:1 t1.i:2
            │    │    ├── cost: 1098.72
            │    │    └── ordering: +1
            │    └── filters
-           │         └── exists [subquery]
-           │              └── limit
-           │                   ├── columns: t3.k:14!null t3.i:15 t3.f:16!null
-           │                   ├── cardinality: [0 - 1]
-           │                   ├── cost: 21.3435766
-           │                   ├── key: ()
-           │                   ├── fd: ()-->(14-16)
-           │                   ├── select
-           │                   │    ├── columns: t3.k:14!null t3.i:15 t3.f:16!null
-           │                   │    ├── cost: 21.3235766
-           │                   │    ├── limit hint: 1.00
-           │                   │    ├── scan t3@_hyp_1
-           │                   │    │    ├── columns: t3.k:14 t3.i:15 t3.f:16!null
-           │                   │    │    ├── constraint: /16/18: (/NULL - ]
-           │                   │    │    ├── cost: 21.2632432
-           │                   │    │    └── limit hint: 3.00
-           │                   │    └── filters
-           │                   │         └── t3.f:16 > t3.k:14 [outer=(14,16), constraints=(/14: (/NULL - ]; /16: (/NULL - ])]
-           │                   └── 1
+           │         └── coalesce [subquery]
+           │              ├── subquery
+           │              │    └── project
+           │              │         ├── columns: column21:21!null
+           │              │         ├── cardinality: [0 - 1]
+           │              │         ├── cost: 21.3435466
+           │              │         ├── key: ()
+           │              │         ├── fd: ()-->(21)
+           │              │         ├── limit
+           │              │         │    ├── columns: t3.k:14!null t3.f:16!null
+           │              │         │    ├── cardinality: [0 - 1]
+           │              │         │    ├── cost: 21.3135466
+           │              │         │    ├── key: ()
+           │              │         │    ├── fd: ()-->(14,16)
+           │              │         │    ├── select
+           │              │         │    │    ├── columns: t3.k:14!null t3.f:16!null
+           │              │         │    │    ├── cost: 21.2935466
+           │              │         │    │    ├── limit hint: 1.00
+           │              │         │    │    ├── scan t3@_hyp_1
+           │              │         │    │    │    ├── columns: t3.k:14 t3.f:16!null
+           │              │         │    │    │    ├── constraint: /16/18: (/NULL - ]
+           │              │         │    │    │    ├── cost: 21.2332132
+           │              │         │    │    │    └── limit hint: 3.00
+           │              │         │    │    └── filters
+           │              │         │    │         └── t3.f:16 > t3.k:14 [outer=(14,16), constraints=(/14: (/NULL - ]; /16: (/NULL - ])]
+           │              │         │    └── 1
+           │              │         └── projections
+           │              │              └── true [as=column21:21]
+           │              └── false
            ├── select
            │    ├── columns: t2.k:8 t2.i:9
-           │    ├── cost: 1119.99358
+           │    ├── cost: 1119.99355
            │    ├── ordering: +8
            │    ├── scan t2@_hyp_2
            │    │    ├── columns: t2.k:8 t2.i:9
            │    │    ├── cost: 1088.62
            │    │    └── ordering: +8
            │    └── filters
-           │         └── exists [subquery]
-           │              └── limit
-           │                   ├── columns: t3.k:14!null t3.i:15 t3.f:16!null
-           │                   ├── cardinality: [0 - 1]
-           │                   ├── cost: 21.3435766
-           │                   ├── key: ()
-           │                   ├── fd: ()-->(14-16)
-           │                   ├── select
-           │                   │    ├── columns: t3.k:14!null t3.i:15 t3.f:16!null
-           │                   │    ├── cost: 21.3235766
-           │                   │    ├── limit hint: 1.00
-           │                   │    ├── scan t3@_hyp_1
-           │                   │    │    ├── columns: t3.k:14 t3.i:15 t3.f:16!null
-           │                   │    │    ├── constraint: /16/18: (/NULL - ]
-           │                   │    │    ├── cost: 21.2632432
-           │                   │    │    └── limit hint: 3.00
-           │                   │    └── filters
-           │                   │         └── t3.f:16 > t3.k:14 [outer=(14,16), constraints=(/14: (/NULL - ]; /16: (/NULL - ])]
-           │                   └── 1
+           │         └── coalesce [subquery]
+           │              ├── subquery
+           │              │    └── project
+           │              │         ├── columns: column21:21!null
+           │              │         ├── cardinality: [0 - 1]
+           │              │         ├── cost: 21.3435466
+           │              │         ├── key: ()
+           │              │         ├── fd: ()-->(21)
+           │              │         ├── limit
+           │              │         │    ├── columns: t3.k:14!null t3.f:16!null
+           │              │         │    ├── cardinality: [0 - 1]
+           │              │         │    ├── cost: 21.3135466
+           │              │         │    ├── key: ()
+           │              │         │    ├── fd: ()-->(14,16)
+           │              │         │    ├── select
+           │              │         │    │    ├── columns: t3.k:14!null t3.f:16!null
+           │              │         │    │    ├── cost: 21.2935466
+           │              │         │    │    ├── limit hint: 1.00
+           │              │         │    │    ├── scan t3@_hyp_1
+           │              │         │    │    │    ├── columns: t3.k:14 t3.f:16!null
+           │              │         │    │    │    ├── constraint: /16/18: (/NULL - ]
+           │              │         │    │    │    ├── cost: 21.2332132
+           │              │         │    │    │    └── limit hint: 3.00
+           │              │         │    │    └── filters
+           │              │         │    │         └── t3.f:16 > t3.k:14 [outer=(14,16), constraints=(/14: (/NULL - ]; /16: (/NULL - ])]
+           │              │         │    └── 1
+           │              │         └── projections
+           │              │              └── true [as=column21:21]
+           │              └── false
            └── filters (true)
 
 # Tests for set operation indexes. See rule 6 in indexrec.FindIndexCandidateSet.

--- a/pkg/sql/opt/memo/check_expr.go
+++ b/pkg/sql/opt/memo/check_expr.go
@@ -430,6 +430,14 @@ func checkExprOrdering(e opt.Expr) {
 				}
 			}
 		}
+	case *SubqueryPrivate:
+		if !ordering.Any() && e.Op() != opt.ArrayFlattenOp {
+			panic(errors.AssertionFailedf(
+				"subquery ordering not allowed in op: %s",
+				redact.Safe(e.Op()),
+			))
+		}
+		return
 	default:
 		return
 	}

--- a/pkg/sql/opt/norm/general_funcs.go
+++ b/pkg/sql/opt/norm/general_funcs.go
@@ -299,6 +299,11 @@ func (c *CustomFuncs) DuplicateColumnIDs(
 	return newTableID, newColIDs
 }
 
+// MakeBoolCol creates a new column of type Bool and returns its ID.
+func (c *CustomFuncs) MakeBoolCol() opt.ColumnID {
+	return c.mem.Metadata().AddColumn("", types.Bool)
+}
+
 // ----------------------------------------------------------------------
 //
 // Outer column functions

--- a/pkg/sql/opt/norm/rules/scalar.opt
+++ b/pkg/sql/opt/norm/rules/scalar.opt
@@ -216,6 +216,40 @@ $input
     $subqueryPrivate
 )
 
+# ConvertUncorrelatedExistsToCoalesceSubquery converts an uncorrelated Exists
+# expression to a Coalesce expression with a Subquery. For example:
+#
+#   SELECT EXISTS (
+#     SELECT * FROM b
+#   ) FROM a
+#   =>
+#   SELECT COALESCE(
+#     (SELECT true FROM (SELECT * FROM b) LIMIT 1),
+#     false
+#   ) FROM a
+#
+# This transformation simplifies execbuilder and execution code - we do not need
+# a special execution mode for uncorrelated Exists.
+#
+# Note: We can use an empty ordering for the Limit because Exists never have an
+# ordering.
+[ConvertUncorrelatedExistsToCoalesceSubquery, Normalize]
+(Exists $input:* & ^(HasOuterCols $input) $subqueryPrivate:*)
+=>
+(Coalesce
+    [
+        (Subquery
+            (Project
+                (Limit $input (IntConst 1) (EmptyOrdering))
+                [ (ProjectionsItem (True) (MakeBoolCol)) ]
+                (MakeEmptyColSet)
+            )
+            $subqueryPrivate
+        )
+        (False)
+    ]
+)
+
 # IntroduceExistsLimit inserts a LIMIT 1 "under" Exists so as to save resources
 # to make the EXISTS determination.
 #
@@ -229,6 +263,9 @@ $input
 # when a general-purpose apply operator is supported - in that case it can be
 # definitely worthwhile pushing down a LIMIT 1 to limit the amount of work done
 # on every row.)
+#
+# TODO(mgartner): This rule should never be triggered because
+# ConvertUncorrelatedExistsToCoalesceSubquery should apply first. Remove it.
 [IntroduceExistsLimit, Normalize]
 (Exists
     $input:* & ^(HasOuterCols $input) & ^(HasZeroOrOneRow $input)

--- a/pkg/sql/opt/norm/testdata/rules/decorrelate
+++ b/pkg/sql/opt/norm/testdata/rules/decorrelate
@@ -1557,30 +1557,39 @@ select
  │    ├── (1,)
  │    └── (2,)
  └── filters
-      └── exists [subquery]
-           └── limit
-                ├── columns: k:2!null i:3!null x:9!null y:10!null
-                ├── cardinality: [0 - 1]
-                ├── key: ()
-                ├── fd: ()-->(2,3,9,10), (9)==(2), (3)==(10), (10)==(3), (2)==(9)
-                ├── inner-join (hash)
-                │    ├── columns: k:2!null i:3!null x:9!null y:10!null
-                │    ├── multiplicity: left-rows(zero-or-one), right-rows(zero-or-one)
-                │    ├── key: (9)
-                │    ├── fd: (2)-->(3), (9)-->(10), (2)==(9), (9)==(2), (3)==(10), (10)==(3)
-                │    ├── limit hint: 1.00
-                │    ├── scan a
-                │    │    ├── columns: k:2!null i:3
-                │    │    ├── key: (2)
-                │    │    └── fd: (2)-->(3)
-                │    ├── scan xy
-                │    │    ├── columns: x:9!null y:10
-                │    │    ├── key: (9)
-                │    │    └── fd: (9)-->(10)
-                │    └── filters
-                │         ├── x:9 = k:2 [outer=(2,9), constraints=(/2: (/NULL - ]; /9: (/NULL - ]), fd=(2)==(9), (9)==(2)]
-                │         └── i:3 = y:10 [outer=(3,10), constraints=(/3: (/NULL - ]; /10: (/NULL - ]), fd=(3)==(10), (10)==(3)]
-                └── 1
+      └── coalesce [subquery]
+           ├── subquery
+           │    └── project
+           │         ├── columns: column18:18!null
+           │         ├── cardinality: [0 - 1]
+           │         ├── key: ()
+           │         ├── fd: ()-->(18)
+           │         ├── limit
+           │         │    ├── columns: k:2!null i:3!null x:9!null y:10!null
+           │         │    ├── cardinality: [0 - 1]
+           │         │    ├── key: ()
+           │         │    ├── fd: ()-->(2,3,9,10), (9)==(2), (3)==(10), (10)==(3), (2)==(9)
+           │         │    ├── inner-join (hash)
+           │         │    │    ├── columns: k:2!null i:3!null x:9!null y:10!null
+           │         │    │    ├── multiplicity: left-rows(zero-or-one), right-rows(zero-or-one)
+           │         │    │    ├── key: (9)
+           │         │    │    ├── fd: (2)-->(3), (9)-->(10), (2)==(9), (9)==(2), (3)==(10), (10)==(3)
+           │         │    │    ├── limit hint: 1.00
+           │         │    │    ├── scan a
+           │         │    │    │    ├── columns: k:2!null i:3
+           │         │    │    │    ├── key: (2)
+           │         │    │    │    └── fd: (2)-->(3)
+           │         │    │    ├── scan xy
+           │         │    │    │    ├── columns: x:9!null y:10
+           │         │    │    │    ├── key: (9)
+           │         │    │    │    └── fd: (9)-->(10)
+           │         │    │    └── filters
+           │         │    │         ├── x:9 = k:2 [outer=(2,9), constraints=(/2: (/NULL - ]; /9: (/NULL - ]), fd=(2)==(9), (9)==(2)]
+           │         │    │         └── i:3 = y:10 [outer=(3,10), constraints=(/3: (/NULL - ]; /10: (/NULL - ]), fd=(3)==(10), (10)==(3)]
+           │         │    └── 1
+           │         └── projections
+           │              └── true [as=column18:18]
+           └── false
 
 norm expect=TryDecorrelateInnerLeftJoin
 SELECT *
@@ -3834,18 +3843,22 @@ select
  │    ├── key: (1)
  │    └── fd: (1)-->(2-5)
  └── filters
-      └── exists [subquery]
-           └── limit
-                ├── columns: x:8!null y:9
-                ├── cardinality: [0 - 1]
-                ├── key: ()
-                ├── fd: ()-->(8,9)
-                ├── scan xy
-                │    ├── columns: x:8!null y:9
-                │    ├── key: (8)
-                │    ├── fd: (8)-->(9)
-                │    └── limit hint: 1.00
-                └── 1
+      └── coalesce [subquery]
+           ├── subquery
+           │    └── project
+           │         ├── columns: column12:12!null
+           │         ├── cardinality: [0 - 1]
+           │         ├── key: ()
+           │         ├── fd: ()-->(12)
+           │         ├── limit
+           │         │    ├── cardinality: [0 - 1]
+           │         │    ├── key: ()
+           │         │    ├── scan xy
+           │         │    │    └── limit hint: 1.00
+           │         │    └── 1
+           │         └── projections
+           │              └── true [as=column12:12]
+           └── false
 
 # Hoist nested EXISTS.
 norm expect=HoistSelectExists
@@ -3961,18 +3974,22 @@ select
  │    └── fd: (1)-->(2-5)
  └── filters
       └── not [subquery]
-           └── exists
-                └── limit
-                     ├── columns: x:8!null y:9
-                     ├── cardinality: [0 - 1]
-                     ├── key: ()
-                     ├── fd: ()-->(8,9)
-                     ├── scan xy
-                     │    ├── columns: x:8!null y:9
-                     │    ├── key: (8)
-                     │    ├── fd: (8)-->(9)
-                     │    └── limit hint: 1.00
-                     └── 1
+           └── coalesce
+                ├── subquery
+                │    └── project
+                │         ├── columns: column12:12!null
+                │         ├── cardinality: [0 - 1]
+                │         ├── key: ()
+                │         ├── fd: ()-->(12)
+                │         ├── limit
+                │         │    ├── cardinality: [0 - 1]
+                │         │    ├── key: ()
+                │         │    ├── scan xy
+                │         │    │    └── limit hint: 1.00
+                │         │    └── 1
+                │         └── projections
+                │              └── true [as=column12:12]
+                └── false
 
 # --------------------------------------------------
 # HoistSelectExists + HoistSelectNotExists
@@ -4550,37 +4567,37 @@ project
  ├── key: (1)
  ├── fd: (1)-->(2-5)
  └── select
-      ├── columns: k:1!null i:2 f:3 s:4 j:5 true_agg:17
+      ├── columns: k:1!null i:2 f:3 s:4 j:5 true_agg:18
       ├── key: (1)
-      ├── fd: (1)-->(2-5,17)
+      ├── fd: (1)-->(2-5,18)
       ├── group-by (hash)
-      │    ├── columns: k:1!null i:2 f:3 s:4 j:5 true_agg:17
+      │    ├── columns: k:1!null i:2 f:3 s:4 j:5 true_agg:18
       │    ├── grouping columns: k:1!null
       │    ├── key: (1)
-      │    ├── fd: (1)-->(2-5,17)
+      │    ├── fd: (1)-->(2-5,18)
       │    ├── left-join (hash)
-      │    │    ├── columns: k:1!null i:2 f:3 s:4 j:5 x:12 true:16
+      │    │    ├── columns: k:1!null i:2 f:3 s:4 j:5 x:12 true:17
       │    │    ├── multiplicity: left-rows(exactly-one), right-rows(zero-or-one)
       │    │    ├── key: (1)
-      │    │    ├── fd: (1)-->(2-5,12,16)
+      │    │    ├── fd: (1)-->(2-5,12,17)
       │    │    ├── scan a
       │    │    │    ├── columns: k:1!null i:2 f:3 s:4 j:5
       │    │    │    ├── key: (1)
       │    │    │    └── fd: (1)-->(2-5)
       │    │    ├── project
-      │    │    │    ├── columns: true:16!null x:12!null
+      │    │    │    ├── columns: true:17!null x:12!null
       │    │    │    ├── key: (12)
-      │    │    │    ├── fd: ()-->(16)
+      │    │    │    ├── fd: ()-->(17)
       │    │    │    ├── scan xy
       │    │    │    │    ├── columns: x:12!null
       │    │    │    │    └── key: (12)
       │    │    │    └── projections
-      │    │    │         └── true [as=true:16]
+      │    │    │         └── true [as=true:17]
       │    │    └── filters
       │    │         └── x:12 = k:1 [outer=(1,12), constraints=(/1: (/NULL - ]; /12: (/NULL - ]), fd=(1)==(12), (12)==(1)]
       │    └── aggregations
-      │         ├── const-not-null-agg [as=true_agg:17, outer=(16)]
-      │         │    └── true:16
+      │         ├── const-not-null-agg [as=true_agg:18, outer=(17)]
+      │         │    └── true:17
       │         ├── const-agg [as=i:2, outer=(2)]
       │         │    └── i:2
       │         ├── const-agg [as=f:3, outer=(3)]
@@ -4590,20 +4607,24 @@ project
       │         └── const-agg [as=j:5, outer=(5)]
       │              └── j:5
       └── filters
-           └── or [outer=(17), subquery]
-                ├── exists
-                │    └── limit
-                │         ├── columns: x:8!null y:9
-                │         ├── cardinality: [0 - 1]
-                │         ├── key: ()
-                │         ├── fd: ()-->(8,9)
-                │         ├── scan xy
-                │         │    ├── columns: x:8!null y:9
-                │         │    ├── key: (8)
-                │         │    ├── fd: (8)-->(9)
-                │         │    └── limit hint: 1.00
-                │         └── 1
-                └── true_agg:17 IS NOT NULL
+           └── or [outer=(18), subquery]
+                ├── coalesce
+                │    ├── subquery
+                │    │    └── project
+                │    │         ├── columns: column16:16!null
+                │    │         ├── cardinality: [0 - 1]
+                │    │         ├── key: ()
+                │    │         ├── fd: ()-->(16)
+                │    │         ├── limit
+                │    │         │    ├── cardinality: [0 - 1]
+                │    │         │    ├── key: ()
+                │    │         │    ├── scan xy
+                │    │         │    │    └── limit hint: 1.00
+                │    │         │    └── 1
+                │    │         └── projections
+                │    │              └── true [as=column16:16]
+                │    └── false
+                └── true_agg:18 IS NOT NULL
 
 # --------------------------------------------------
 # HoistProjectSubquery
@@ -4641,7 +4662,7 @@ SELECT
 FROM a
 ----
 project
- ├── columns: a:29!null x:30 y:31 b:32 exists:33 count:34!null
+ ├── columns: a:29!null x:30 y:31 b:32 exists:34 count:35!null
  ├── fd: ()-->(29)
  ├── group-by (hash)
  │    ├── columns: k:1!null xy.x:8 count_rows:28!null
@@ -4691,19 +4712,23 @@ project
       │    ├── scan xy
       │    │    └── columns: xy.y:17
       │    └── 5
-      ├── exists [as=exists:33, subquery]
-      │    └── limit
-      │         ├── columns: xy.x:20!null xy.y:21
-      │         ├── cardinality: [0 - 1]
-      │         ├── key: ()
-      │         ├── fd: ()-->(20,21)
-      │         ├── scan xy
-      │         │    ├── columns: xy.x:20!null xy.y:21
-      │         │    ├── key: (20)
-      │         │    ├── fd: (20)-->(21)
-      │         │    └── limit hint: 1.00
-      │         └── 1
-      └── count_rows:28 [as=count:34, outer=(28)]
+      ├── coalesce [as=exists:34, subquery]
+      │    ├── subquery
+      │    │    └── project
+      │    │         ├── columns: column33:33!null
+      │    │         ├── cardinality: [0 - 1]
+      │    │         ├── key: ()
+      │    │         ├── fd: ()-->(33)
+      │    │         ├── limit
+      │    │         │    ├── cardinality: [0 - 1]
+      │    │         │    ├── key: ()
+      │    │         │    ├── scan xy
+      │    │         │    │    └── limit hint: 1.00
+      │    │         │    └── 1
+      │    │         └── projections
+      │    │              └── true [as=column33:33]
+      │    └── false
+      └── count_rows:28 [as=count:35, outer=(28)]
 
 # Subquery in GroupBy aggregate (optbuilder creates correlated Project).
 norm expect=HoistProjectSubquery
@@ -4904,43 +4929,45 @@ norm expect=HoistProjectSubquery
 SELECT EXISTS(SELECT EXISTS(SELECT * FROM xy WHERE y=i) FROM a)
 ----
 values
- ├── columns: exists:16
+ ├── columns: exists:17
  ├── cardinality: [1 - 1]
  ├── key: ()
- ├── fd: ()-->(16)
+ ├── fd: ()-->(17)
  └── tuple
-      └── exists
-           └── limit
-                ├── columns: k:1!null i:2 y:9 true:13
-                ├── cardinality: [0 - 1]
-                ├── key: ()
-                ├── fd: ()-->(1,2,9,13)
-                ├── left-join (hash)
-                │    ├── columns: k:1!null i:2 y:9 true:13
-                │    ├── multiplicity: left-rows(one-or-more), right-rows(zero-or-one)
-                │    ├── fd: ()-->(1,2,9)
-                │    ├── limit hint: 1.00
-                │    ├── limit
-                │    │    ├── columns: k:1!null i:2
-                │    │    ├── cardinality: [0 - 1]
-                │    │    ├── key: ()
-                │    │    ├── fd: ()-->(1,2)
-                │    │    ├── scan a
-                │    │    │    ├── columns: k:1!null i:2
-                │    │    │    ├── key: (1)
-                │    │    │    ├── fd: (1)-->(2)
-                │    │    │    └── limit hint: 1.00
-                │    │    └── 1
-                │    ├── project
-                │    │    ├── columns: true:13!null y:9
-                │    │    ├── fd: ()-->(13)
-                │    │    ├── scan xy
-                │    │    │    └── columns: y:9
-                │    │    └── projections
-                │    │         └── true [as=true:13]
-                │    └── filters
-                │         └── y:9 = i:2 [outer=(2,9), constraints=(/2: (/NULL - ]; /9: (/NULL - ]), fd=(2)==(9), (9)==(2)]
-                └── 1
+      └── coalesce
+           ├── subquery
+           │    └── project
+           │         ├── columns: column16:16!null
+           │         ├── cardinality: [0 - 1]
+           │         ├── key: ()
+           │         ├── fd: ()-->(16)
+           │         ├── limit
+           │         │    ├── columns: i:2 y:9
+           │         │    ├── cardinality: [0 - 1]
+           │         │    ├── key: ()
+           │         │    ├── fd: ()-->(2,9)
+           │         │    ├── left-join (hash)
+           │         │    │    ├── columns: i:2 y:9
+           │         │    │    ├── multiplicity: left-rows(one-or-more), right-rows(zero-or-one)
+           │         │    │    ├── fd: ()-->(2,9)
+           │         │    │    ├── limit hint: 1.00
+           │         │    │    ├── limit
+           │         │    │    │    ├── columns: i:2
+           │         │    │    │    ├── cardinality: [0 - 1]
+           │         │    │    │    ├── key: ()
+           │         │    │    │    ├── fd: ()-->(2)
+           │         │    │    │    ├── scan a
+           │         │    │    │    │    ├── columns: i:2
+           │         │    │    │    │    └── limit hint: 1.00
+           │         │    │    │    └── 1
+           │         │    │    ├── scan xy
+           │         │    │    │    └── columns: y:9
+           │         │    │    └── filters
+           │         │    │         └── y:9 = i:2 [outer=(2,9), constraints=(/2: (/NULL - ]; /9: (/NULL - ]), fd=(2)==(9), (9)==(2)]
+           │         │    └── 1
+           │         └── projections
+           │              └── true [as=column16:16]
+           └── false
 
 # Don't hoist uncorrelated subquery.
 norm
@@ -5711,22 +5738,31 @@ select
  │    ├── key: (1)
  │    └── fd: (1)-->(2-5)
  └── filters
-      └── exists [subquery]
-           └── limit
-                ├── columns: y:9!null
-                ├── cardinality: [0 - 1]
-                ├── key: ()
-                ├── fd: ()-->(9)
-                ├── select
-                │    ├── columns: y:9!null
-                │    ├── fd: ()-->(9)
-                │    ├── limit hint: 1.00
-                │    ├── scan xy
-                │    │    ├── columns: y:9
-                │    │    └── limit hint: 100.00
-                │    └── filters
-                │         └── y:9 = 5 [outer=(9), constraints=(/9: [/5 - /5]; tight), fd=()-->(9)]
-                └── 1
+      └── coalesce [subquery]
+           ├── subquery
+           │    └── project
+           │         ├── columns: column12:12!null
+           │         ├── cardinality: [0 - 1]
+           │         ├── key: ()
+           │         ├── fd: ()-->(12)
+           │         ├── limit
+           │         │    ├── columns: y:9!null
+           │         │    ├── cardinality: [0 - 1]
+           │         │    ├── key: ()
+           │         │    ├── fd: ()-->(9)
+           │         │    ├── select
+           │         │    │    ├── columns: y:9!null
+           │         │    │    ├── fd: ()-->(9)
+           │         │    │    ├── limit hint: 1.00
+           │         │    │    ├── scan xy
+           │         │    │    │    ├── columns: y:9
+           │         │    │    │    └── limit hint: 100.00
+           │         │    │    └── filters
+           │         │    │         └── y:9 = 5 [outer=(9), constraints=(/9: [/5 - /5]; tight), fd=()-->(9)]
+           │         │    └── 1
+           │         └── projections
+           │              └── true [as=column12:12]
+           └── false
 
 # ANY in Join On condition.
 norm expect=NormalizeJoinAnyFilter
@@ -5847,21 +5883,30 @@ select
  │    └── fd: (1)-->(2-5)
  └── filters
       └── not [subquery]
-           └── exists
-                └── limit
-                     ├── columns: y:9
-                     ├── cardinality: [0 - 1]
-                     ├── key: ()
-                     ├── fd: ()-->(9)
-                     ├── select
-                     │    ├── columns: y:9
-                     │    ├── limit hint: 1.00
-                     │    ├── scan xy
-                     │    │    ├── columns: y:9
-                     │    │    └── limit hint: 3.00
-                     │    └── filters
-                     │         └── (y:9 = 5) IS NOT false [outer=(9)]
-                     └── 1
+           └── coalesce
+                ├── subquery
+                │    └── project
+                │         ├── columns: column12:12!null
+                │         ├── cardinality: [0 - 1]
+                │         ├── key: ()
+                │         ├── fd: ()-->(12)
+                │         ├── limit
+                │         │    ├── columns: y:9
+                │         │    ├── cardinality: [0 - 1]
+                │         │    ├── key: ()
+                │         │    ├── fd: ()-->(9)
+                │         │    ├── select
+                │         │    │    ├── columns: y:9
+                │         │    │    ├── limit hint: 1.00
+                │         │    │    ├── scan xy
+                │         │    │    │    ├── columns: y:9
+                │         │    │    │    └── limit hint: 3.00
+                │         │    │    └── filters
+                │         │    │         └── (y:9 = 5) IS NOT false [outer=(9)]
+                │         │    └── 1
+                │         └── projections
+                │              └── true [as=column12:12]
+                └── false
 
 # NOT ANY in Join On condition.
 norm expect=NormalizeJoinNotAnyFilter

--- a/pkg/sql/opt/norm/testdata/rules/groupby
+++ b/pkg/sql/opt/norm/testdata/rules/groupby
@@ -727,26 +727,26 @@ ON CONFLICT (c1) DO UPDATE SET c3=1
 upsert nullablecols
  ├── arbiter indexes: nullablecols_c1_key
  ├── columns: <none>
- ├── canary column: rowid:24
- ├── fetch columns: c1:21 c2:22 c3:23 rowid:24
+ ├── canary column: rowid:25
+ ├── fetch columns: c1:22 c2:23 c3:24 rowid:25
  ├── insert-mapping:
  │    ├── i:8 => c1:1
  │    ├── i:8 => c2:2
  │    ├── i:8 => c3:3
  │    └── i:8 => rowid:4
  ├── update-mapping:
- │    └── upsert_c3:30 => c3:3
+ │    └── upsert_c3:31 => c3:3
  ├── cardinality: [0 - 0]
  ├── volatile, mutations
  └── project
-      ├── columns: upsert_c3:30!null i:8!null c1:21 c2:22 c3:23 rowid:24
-      ├── key: (8,24)
-      ├── fd: (24)-->(21-23), (21)~~>(22-24), (22,23)~~>(21,24), (8,24)-->(30)
+      ├── columns: upsert_c3:31!null i:8!null c1:22 c2:23 c3:24 rowid:25
+      ├── key: (8,25)
+      ├── fd: (25)-->(22-24), (22)~~>(23-25), (23,24)~~>(22,25), (8,25)-->(31)
       ├── left-join (hash)
-      │    ├── columns: i:8!null c1:21 c2:22 c3:23 rowid:24
+      │    ├── columns: i:8!null c1:22 c2:23 c3:24 rowid:25
       │    ├── multiplicity: left-rows(exactly-one), right-rows(zero-or-one)
-      │    ├── key: (8,24)
-      │    ├── fd: (24)-->(21-23), (21)~~>(22-24), (22,23)~~>(21,24)
+      │    ├── key: (8,25)
+      │    ├── fd: (25)-->(22-24), (22)~~>(23-25), (23,24)~~>(22,25)
       │    ├── ensure-upsert-distinct-on
       │    │    ├── columns: i:8!null
       │    │    ├── grouping columns: i:8!null
@@ -761,27 +761,31 @@ upsert nullablecols
       │    │         │    ├── key: (7)
       │    │         │    └── fd: (7)-->(8)
       │    │         └── filters
-      │    │              ├── exists [subquery]
-      │    │              │    └── limit
-      │    │              │         ├── columns: k:14!null i:15!null f:16 s:17!null j:18
-      │    │              │         ├── cardinality: [0 - 1]
-      │    │              │         ├── key: ()
-      │    │              │         ├── fd: ()-->(14-18)
-      │    │              │         ├── scan a
-      │    │              │         │    ├── columns: k:14!null i:15!null f:16 s:17!null j:18
-      │    │              │         │    ├── key: (14)
-      │    │              │         │    ├── fd: (14)-->(15-18), (15,17)-->(14,16,18), (15,16)~~>(14,17,18)
-      │    │              │         │    └── limit hint: 1.00
-      │    │              │         └── 1
+      │    │              ├── coalesce [subquery]
+      │    │              │    ├── subquery
+      │    │              │    │    └── project
+      │    │              │    │         ├── columns: column21:21!null
+      │    │              │    │         ├── cardinality: [0 - 1]
+      │    │              │    │         ├── key: ()
+      │    │              │    │         ├── fd: ()-->(21)
+      │    │              │    │         ├── limit
+      │    │              │    │         │    ├── cardinality: [0 - 1]
+      │    │              │    │         │    ├── key: ()
+      │    │              │    │         │    ├── scan a
+      │    │              │    │         │    │    └── limit hint: 1.00
+      │    │              │    │         │    └── 1
+      │    │              │    │         └── projections
+      │    │              │    │              └── true [as=column21:21]
+      │    │              │    └── false
       │    │              └── k:7 > 0 [outer=(7), constraints=(/7: [/1 - ]; tight)]
       │    ├── scan nullablecols
-      │    │    ├── columns: c1:21 c2:22 c3:23 rowid:24!null
-      │    │    ├── key: (24)
-      │    │    └── fd: (24)-->(21-23), (21)~~>(22-24), (22,23)~~>(21,24)
+      │    │    ├── columns: c1:22 c2:23 c3:24 rowid:25!null
+      │    │    ├── key: (25)
+      │    │    └── fd: (25)-->(22-24), (22)~~>(23-25), (23,24)~~>(22,25)
       │    └── filters
-      │         └── i:8 = c1:21 [outer=(8,21), constraints=(/8: (/NULL - ]; /21: (/NULL - ]), fd=(8)==(21), (21)==(8)]
+      │         └── i:8 = c1:22 [outer=(8,22), constraints=(/8: (/NULL - ]; /22: (/NULL - ]), fd=(8)==(22), (22)==(8)]
       └── projections
-           └── CASE WHEN rowid:24 IS NULL THEN i:8 ELSE 1 END [as=upsert_c3:30, outer=(8,24)]
+           └── CASE WHEN rowid:25 IS NULL THEN i:8 ELSE 1 END [as=upsert_c3:31, outer=(8,25)]
 
 # Don't eliminate project if it computes extra column(s).
 norm expect-not=EliminateGroupByProject

--- a/pkg/sql/opt/norm/testdata/rules/inline
+++ b/pkg/sql/opt/norm/testdata/rules/inline
@@ -258,19 +258,28 @@ values
  ├── key: ()
  ├── fd: ()-->(10)
  └── tuple
-      └── exists
-           └── select
-                ├── columns: k:3!null i:4!null f:5 s:6 j:7
-                ├── cardinality: [0 - 1]
-                ├── key: ()
-                ├── fd: ()-->(3-7)
-                ├── scan a
-                │    ├── columns: k:3!null i:4 f:5 s:6 j:7
-                │    ├── key: (3)
-                │    └── fd: (3)-->(4-7)
-                └── filters
-                     ├── k:3 = 1 [outer=(3), constraints=(/3: [/1 - /1]; tight), fd=()-->(3)]
-                     └── i:4 = 2 [outer=(4), constraints=(/4: [/2 - /2]; tight), fd=()-->(4)]
+      └── coalesce
+           ├── subquery
+           │    └── project
+           │         ├── columns: column11:11!null
+           │         ├── cardinality: [0 - 1]
+           │         ├── key: ()
+           │         ├── fd: ()-->(11)
+           │         ├── select
+           │         │    ├── columns: k:3!null i:4!null
+           │         │    ├── cardinality: [0 - 1]
+           │         │    ├── key: ()
+           │         │    ├── fd: ()-->(3,4)
+           │         │    ├── scan a
+           │         │    │    ├── columns: k:3!null i:4
+           │         │    │    ├── key: (3)
+           │         │    │    └── fd: (3)-->(4)
+           │         │    └── filters
+           │         │         ├── k:3 = 1 [outer=(3), constraints=(/3: [/1 - /1]; tight), fd=()-->(3)]
+           │         │         └── i:4 = 2 [outer=(4), constraints=(/4: [/2 - /2]; tight), fd=()-->(4)]
+           │         └── projections
+           │              └── true [as=column11:11]
+           └── false
 
 # Do not inline constants from Values expression with multiple rows.
 norm expect-not=InlineProjectConstants
@@ -990,33 +999,40 @@ norm expect=InlineProjectInProject
 SELECT EXISTS(SELECT * FROM xy WHERE x=1 OR x=2), expr*2 AS r FROM (SELECT k+1 AS expr FROM a)
 ----
 project
- ├── columns: exists:13 r:14!null
+ ├── columns: exists:14 r:15!null
  ├── immutable
  ├── scan a
  │    ├── columns: k:1!null
  │    └── key: (1)
  └── projections
-      ├── exists [as=exists:13, subquery]
-      │    └── limit
-      │         ├── columns: x:9!null y:10
-      │         ├── cardinality: [0 - 1]
-      │         ├── key: ()
-      │         ├── fd: ()-->(9,10)
-      │         ├── select
-      │         │    ├── columns: x:9!null y:10
-      │         │    ├── cardinality: [0 - 2]
-      │         │    ├── key: (9)
-      │         │    ├── fd: (9)-->(10)
-      │         │    ├── limit hint: 1.00
-      │         │    ├── scan xy
-      │         │    │    ├── columns: x:9!null y:10
-      │         │    │    ├── key: (9)
-      │         │    │    ├── fd: (9)-->(10)
-      │         │    │    └── limit hint: 500.00
-      │         │    └── filters
-      │         │         └── (x:9 = 1) OR (x:9 = 2) [outer=(9), constraints=(/9: [/1 - /1] [/2 - /2]; tight)]
-      │         └── 1
-      └── (k:1 + 1) * 2 [as=r:14, outer=(1), immutable]
+      ├── coalesce [as=exists:14, subquery]
+      │    ├── subquery
+      │    │    └── project
+      │    │         ├── columns: column13:13!null
+      │    │         ├── cardinality: [0 - 1]
+      │    │         ├── key: ()
+      │    │         ├── fd: ()-->(13)
+      │    │         ├── limit
+      │    │         │    ├── columns: x:9!null
+      │    │         │    ├── cardinality: [0 - 1]
+      │    │         │    ├── key: ()
+      │    │         │    ├── fd: ()-->(9)
+      │    │         │    ├── select
+      │    │         │    │    ├── columns: x:9!null
+      │    │         │    │    ├── cardinality: [0 - 2]
+      │    │         │    │    ├── key: (9)
+      │    │         │    │    ├── limit hint: 1.00
+      │    │         │    │    ├── scan xy
+      │    │         │    │    │    ├── columns: x:9!null
+      │    │         │    │    │    ├── key: (9)
+      │    │         │    │    │    └── limit hint: 500.00
+      │    │         │    │    └── filters
+      │    │         │    │         └── (x:9 = 1) OR (x:9 = 2) [outer=(9), constraints=(/9: [/1 - /1] [/2 - /2]; tight)]
+      │    │         │    └── 1
+      │    │         └── projections
+      │    │              └── true [as=column13:13]
+      │    └── false
+      └── (k:1 + 1) * 2 [as=r:15, outer=(1), immutable]
 
 # Correlated subquery should be hoisted as usual.
 norm expect=InlineProjectInProject

--- a/pkg/sql/opt/norm/testdata/rules/scalar
+++ b/pkg/sql/opt/norm/testdata/rules/scalar
@@ -428,18 +428,22 @@ select
  │    ├── key: (1)
  │    └── fd: (1)-->(2-5)
  └── filters
-      └── exists [subquery]
-           └── limit
-                ├── columns: k:8!null i:9
-                ├── cardinality: [0 - 1]
-                ├── key: ()
-                ├── fd: ()-->(8,9)
-                ├── scan a
-                │    ├── columns: k:8!null i:9
-                │    ├── key: (8)
-                │    ├── fd: (8)-->(9)
-                │    └── limit hint: 1.00
-                └── 1
+      └── coalesce [subquery]
+           ├── subquery
+           │    └── project
+           │         ├── columns: column17:17!null
+           │         ├── cardinality: [0 - 1]
+           │         ├── key: ()
+           │         ├── fd: ()-->(17)
+           │         ├── limit
+           │         │    ├── cardinality: [0 - 1]
+           │         │    ├── key: ()
+           │         │    ├── scan a
+           │         │    │    └── limit hint: 1.00
+           │         │    └── 1
+           │         └── projections
+           │              └── true [as=column17:17]
+           └── false
 
 # --------------------------------------------------
 # EliminateExistsGroupBy
@@ -458,20 +462,22 @@ select
  │    ├── key: (1)
  │    └── fd: (1)-->(2-5)
  └── filters
-      └── exists [subquery]
-           └── scalar-group-by
-                ├── columns: max:15
-                ├── cardinality: [1 - 1]
-                ├── key: ()
-                ├── fd: ()-->(15)
-                ├── values
-                │    ├── columns: s:11!null
-                │    ├── cardinality: [0 - 0]
-                │    ├── key: ()
-                │    └── fd: ()-->(11)
-                └── aggregations
-                     └── max [as=max:15, outer=(11)]
-                          └── s:11
+      └── coalesce [subquery]
+           ├── subquery
+           │    └── project
+           │         ├── columns: column16:16!null
+           │         ├── cardinality: [1 - 1]
+           │         ├── key: ()
+           │         ├── fd: ()-->(16)
+           │         ├── scalar-group-by
+           │         │    ├── cardinality: [1 - 1]
+           │         │    ├── key: ()
+           │         │    └── values
+           │         │         ├── cardinality: [0 - 0]
+           │         │         └── key: ()
+           │         └── projections
+           │              └── true [as=column16:16]
+           └── false
 
 norm expect=EliminateExistsGroupBy
 SELECT * FROM a WHERE EXISTS(SELECT DISTINCT s FROM a)
@@ -485,16 +491,22 @@ select
  │    ├── key: (1)
  │    └── fd: (1)-->(2-5)
  └── filters
-      └── exists [subquery]
-           └── limit
-                ├── columns: s:11
-                ├── cardinality: [0 - 1]
-                ├── key: ()
-                ├── fd: ()-->(11)
-                ├── scan a
-                │    ├── columns: s:11
-                │    └── limit hint: 1.00
-                └── 1
+      └── coalesce [subquery]
+           ├── subquery
+           │    └── project
+           │         ├── columns: column15:15!null
+           │         ├── cardinality: [0 - 1]
+           │         ├── key: ()
+           │         ├── fd: ()-->(15)
+           │         ├── limit
+           │         │    ├── cardinality: [0 - 1]
+           │         │    ├── key: ()
+           │         │    ├── scan a
+           │         │    │    └── limit hint: 1.00
+           │         │    └── 1
+           │         └── projections
+           │              └── true [as=column15:15]
+           └── false
 
 norm expect=EliminateExistsGroupBy
 SELECT * FROM a WHERE EXISTS(SELECT DISTINCT ON (i) s FROM a)
@@ -508,16 +520,22 @@ select
  │    ├── key: (1)
  │    └── fd: (1)-->(2-5)
  └── filters
-      └── exists [subquery]
-           └── limit
-                ├── columns: i:9 s:11
-                ├── cardinality: [0 - 1]
-                ├── key: ()
-                ├── fd: ()-->(9,11)
-                ├── scan a
-                │    ├── columns: i:9 s:11
-                │    └── limit hint: 1.00
-                └── 1
+      └── coalesce [subquery]
+           ├── subquery
+           │    └── project
+           │         ├── columns: column15:15!null
+           │         ├── cardinality: [0 - 1]
+           │         ├── key: ()
+           │         ├── fd: ()-->(15)
+           │         ├── limit
+           │         │    ├── cardinality: [0 - 1]
+           │         │    ├── key: ()
+           │         │    ├── scan a
+           │         │    │    └── limit hint: 1.00
+           │         │    └── 1
+           │         └── projections
+           │              └── true [as=column15:15]
+           └── false
 
 # Ensure that EliminateExistsGroupBy does not activate for an EnsureDistinctOn.
 norm expect-not=EliminateExistsGroupBy
@@ -532,33 +550,38 @@ select
  │    ├── key: (1)
  │    └── fd: (1)-->(2-5)
  └── filters
-      └── exists [subquery]
-           └── limit
-                ├── columns: k:8!null xy.y:16
-                ├── cardinality: [0 - 1]
-                ├── key: ()
-                ├── fd: ()-->(8,16)
-                ├── ensure-distinct-on
-                │    ├── columns: k:8!null xy.y:16
-                │    ├── grouping columns: k:8!null
-                │    ├── error: "more than one row returned by a subquery used as an expression"
-                │    ├── key: (8)
-                │    ├── fd: (8)-->(16)
-                │    ├── limit hint: 1.00
-                │    ├── left-join (hash)
-                │    │    ├── columns: k:8!null xy.y:16
-                │    │    ├── multiplicity: left-rows(one-or-more), right-rows(zero-or-one)
-                │    │    ├── scan a
-                │    │    │    ├── columns: k:8!null
-                │    │    │    └── key: (8)
-                │    │    ├── scan xy
-                │    │    │    └── columns: xy.y:16
-                │    │    └── filters
-                │    │         └── xy.y:16 = k:8 [outer=(8,16), constraints=(/8: (/NULL - ]; /16: (/NULL - ]), fd=(8)==(16), (16)==(8)]
-                │    └── aggregations
-                │         └── const-agg [as=xy.y:16, outer=(16)]
-                │              └── xy.y:16
-                └── 1
+      └── coalesce [subquery]
+           ├── subquery
+           │    └── project
+           │         ├── columns: column20:20!null
+           │         ├── cardinality: [0 - 1]
+           │         ├── key: ()
+           │         ├── fd: ()-->(20)
+           │         ├── limit
+           │         │    ├── columns: k:8!null
+           │         │    ├── cardinality: [0 - 1]
+           │         │    ├── key: ()
+           │         │    ├── fd: ()-->(8)
+           │         │    ├── ensure-distinct-on
+           │         │    │    ├── columns: k:8!null
+           │         │    │    ├── grouping columns: k:8!null
+           │         │    │    ├── error: "more than one row returned by a subquery used as an expression"
+           │         │    │    ├── key: (8)
+           │         │    │    ├── limit hint: 1.00
+           │         │    │    └── left-join (hash)
+           │         │    │         ├── columns: k:8!null xy.y:16
+           │         │    │         ├── multiplicity: left-rows(one-or-more), right-rows(zero-or-one)
+           │         │    │         ├── scan a
+           │         │    │         │    ├── columns: k:8!null
+           │         │    │         │    └── key: (8)
+           │         │    │         ├── scan xy
+           │         │    │         │    └── columns: xy.y:16
+           │         │    │         └── filters
+           │         │    │              └── xy.y:16 = k:8 [outer=(8,16), constraints=(/8: (/NULL - ]; /16: (/NULL - ]), fd=(8)==(16), (16)==(8)]
+           │         │    └── 1
+           │         └── projections
+           │              └── true [as=column20:20]
+           └── false
 
 # --------------------------------------------------
 # EliminateExistsGroupBy + EliminateExistsProject
@@ -575,16 +598,22 @@ select
  │    ├── key: (1)
  │    └── fd: (1)-->(2-5)
  └── filters
-      └── exists [subquery]
-           └── limit
-                ├── columns: i:9 s:11
-                ├── cardinality: [0 - 1]
-                ├── key: ()
-                ├── fd: ()-->(9,11)
-                ├── scan a
-                │    ├── columns: i:9 s:11
-                │    └── limit hint: 1.00
-                └── 1
+      └── coalesce [subquery]
+           ├── subquery
+           │    └── project
+           │         ├── columns: column16:16!null
+           │         ├── cardinality: [0 - 1]
+           │         ├── key: ()
+           │         ├── fd: ()-->(16)
+           │         ├── limit
+           │         │    ├── cardinality: [0 - 1]
+           │         │    ├── key: ()
+           │         │    ├── scan a
+           │         │    │    └── limit hint: 1.00
+           │         │    └── 1
+           │         └── projections
+           │              └── true [as=column16:16]
+           └── false
 
 # --------------------------------------------------
 # InlineExistsSelectTuple
@@ -707,9 +736,121 @@ semi-join (hash)
       └── b:2 = column15:15 [outer=(2,15), constraints=(/2: (/NULL - ]; /15: (/NULL - ]), fd=(2)==(15), (15)==(2)]
 
 # --------------------------------------------------
+# ConvertUncorrelatedExistsToCoalesceSubquery
+# --------------------------------------------------
+
+norm expect=ConvertUncorrelatedExistsToCoalesceSubquery
+SELECT * FROM a WHERE EXISTS(SELECT i FROM a)
+----
+select
+ ├── columns: k:1!null i:2 f:3 s:4 arr:5
+ ├── key: (1)
+ ├── fd: (1)-->(2-5)
+ ├── scan a
+ │    ├── columns: k:1!null i:2 f:3 s:4 arr:5
+ │    ├── key: (1)
+ │    └── fd: (1)-->(2-5)
+ └── filters
+      └── coalesce [subquery]
+           ├── subquery
+           │    └── project
+           │         ├── columns: column15:15!null
+           │         ├── cardinality: [0 - 1]
+           │         ├── key: ()
+           │         ├── fd: ()-->(15)
+           │         ├── limit
+           │         │    ├── cardinality: [0 - 1]
+           │         │    ├── key: ()
+           │         │    ├── scan a
+           │         │    │    └── limit hint: 1.00
+           │         │    └── 1
+           │         └── projections
+           │              └── true [as=column15:15]
+           └── false
+
+norm expect=ConvertUncorrelatedExistsToCoalesceSubquery
+SELECT EXISTS(SELECT * FROM (VALUES (1))) FROM a
+----
+project
+ ├── columns: exists:10
+ ├── scan a
+ └── projections
+      └── coalesce [as=exists:10, subquery]
+           ├── subquery
+           │    └── values
+           │         ├── columns: column9:9!null
+           │         ├── cardinality: [1 - 1]
+           │         ├── key: ()
+           │         ├── fd: ()-->(9)
+           │         └── (true,)
+           └── false
+
+norm expect=ConvertUncorrelatedExistsToCoalesceSubquery
+SELECT * FROM a a1 JOIN a a2 ON EXISTS(SELECT * FROM (VALUES (1)))
+----
+inner-join (cross)
+ ├── columns: k:1!null i:2 f:3 s:4 arr:5 k:8!null i:9 f:10 s:11 arr:12
+ ├── key: (1,8)
+ ├── fd: (1)-->(2-5), (8)-->(9-12)
+ ├── select
+ │    ├── columns: a1.k:1!null a1.i:2 a1.f:3 a1.s:4 a1.arr:5
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2-5)
+ │    ├── scan a [as=a1]
+ │    │    ├── columns: a1.k:1!null a1.i:2 a1.f:3 a1.s:4 a1.arr:5
+ │    │    ├── key: (1)
+ │    │    └── fd: (1)-->(2-5)
+ │    └── filters
+ │         └── coalesce [subquery]
+ │              ├── subquery
+ │              │    └── values
+ │              │         ├── columns: column16:16!null
+ │              │         ├── cardinality: [1 - 1]
+ │              │         ├── key: ()
+ │              │         ├── fd: ()-->(16)
+ │              │         └── (true,)
+ │              └── false
+ ├── select
+ │    ├── columns: a2.k:8!null a2.i:9 a2.f:10 a2.s:11 a2.arr:12
+ │    ├── key: (8)
+ │    ├── fd: (8)-->(9-12)
+ │    ├── scan a [as=a2]
+ │    │    ├── columns: a2.k:8!null a2.i:9 a2.f:10 a2.s:11 a2.arr:12
+ │    │    ├── key: (8)
+ │    │    └── fd: (8)-->(9-12)
+ │    └── filters
+ │         └── coalesce [subquery]
+ │              ├── subquery
+ │              │    └── values
+ │              │         ├── columns: column16:16!null
+ │              │         ├── cardinality: [1 - 1]
+ │              │         ├── key: ()
+ │              │         ├── fd: ()-->(16)
+ │              │         └── (true,)
+ │              └── false
+ └── filters (true)
+
+# Don't convert Exists if it is correlated.
+norm expect-not=ConvertUncorrelatedExistsToCoalesceSubquery
+SELECT * FROM a a1 WHERE EXISTS(SELECT i FROM a a2 where a1.i = a2.i)
+----
+semi-join (hash)
+ ├── columns: k:1!null i:2 f:3 s:4 arr:5
+ ├── key: (1)
+ ├── fd: (1)-->(2-5)
+ ├── scan a [as=a1]
+ │    ├── columns: a1.k:1!null a1.i:2 a1.f:3 a1.s:4 a1.arr:5
+ │    ├── key: (1)
+ │    └── fd: (1)-->(2-5)
+ ├── scan a [as=a2]
+ │    └── columns: a2.i:9
+ └── filters
+      └── a1.i:2 = a2.i:9 [outer=(2,9), constraints=(/2: (/NULL - ]; /9: (/NULL - ]), fd=(2)==(9), (9)==(2)]
+
+# --------------------------------------------------
 # IntroduceExistsLimit
 # --------------------------------------------------
-norm expect=IntroduceExistsLimit
+norm expect=IntroduceExistsLimit disable=ConvertUncorrelatedExistsToCoalesceSubquery
 SELECT * FROM a WHERE EXISTS(SELECT i FROM a)
 ----
 select
@@ -750,7 +891,7 @@ semi-join (hash)
       └── a1.i:2 = a2.i:9 [outer=(2,9), constraints=(/2: (/NULL - ]; /9: (/NULL - ]), fd=(2)==(9), (9)==(2)]
 
 # Don't introduce a limit when the subquery has one row.
-norm expect-not=IntroduceExistsLimit
+norm expect-not=IntroduceExistsLimit disable=ConvertUncorrelatedExistsToCoalesceSubquery
 SELECT * FROM a WHERE EXISTS(SELECT * FROM (VALUES (1)))
 ----
 select
@@ -815,8 +956,8 @@ values
  ├── key: ()
  └── fd: ()-->(1-5)
 
-# Don't eliminate a limit from a non-correlated subquery.
-norm expect-not=EliminateExistsLimit
+# Don't eliminate a limit from an uncorrelated subquery.
+norm expect-not=EliminateExistsLimit disable=ConvertUncorrelatedExistsToCoalesceSubquery
 SELECT * FROM a WHERE EXISTS(SELECT * FROM a LIMIT 1)
 ----
 select

--- a/pkg/sql/opt/norm/testdata/rules/select
+++ b/pkg/sql/opt/norm/testdata/rules/select
@@ -1955,18 +1955,26 @@ select
  │              └── filters
  │                   └── random() < 0.5 [volatile]
  └── filters
-      └── exists [subquery]
-           └── select
-                ├── columns: a.k:32!null a.i:33 a.f:34 a.s:35 a.j:36
-                ├── cardinality: [0 - 1]
-                ├── key: ()
-                ├── fd: ()-->(32-36)
-                ├── scan a
-                │    ├── columns: a.k:32!null a.i:33 a.f:34 a.s:35 a.j:36
-                │    ├── key: (32)
-                │    └── fd: (32)-->(33-36)
-                └── filters
-                     └── a.k:32 = 1 [outer=(32), constraints=(/32: [/1 - /1]; tight), fd=()-->(32)]
+      └── coalesce [subquery]
+           ├── subquery
+           │    └── project
+           │         ├── columns: column39:39!null
+           │         ├── cardinality: [0 - 1]
+           │         ├── key: ()
+           │         ├── fd: ()-->(39)
+           │         ├── select
+           │         │    ├── columns: a.k:32!null
+           │         │    ├── cardinality: [0 - 1]
+           │         │    ├── key: ()
+           │         │    ├── fd: ()-->(32)
+           │         │    ├── scan a
+           │         │    │    ├── columns: a.k:32!null
+           │         │    │    └── key: (32)
+           │         │    └── filters
+           │         │         └── a.k:32 = 1 [outer=(32), constraints=(/32: [/1 - /1]; tight), fd=()-->(32)]
+           │         └── projections
+           │              └── true [as=column39:39]
+           └── false
 
 # No-op case because the filter references outer columns.
 norm expect-not=PushFilterIntoSetOp

--- a/pkg/sql/opt/xform/testdata/rules/cycle
+++ b/pkg/sql/opt/xform/testdata/rules/cycle
@@ -90,7 +90,7 @@ expropt disable=MemoCycleTestRelRule skip-race
 ----
 error: memo group optimization passes surpassed limit of 100000; there may be a cycle in the memo
 details:
-memo (not optimized, ~4KB, required=[], cycle=[G1->G4->G6->G9->G1])
+memo (not optimized, ~6KB, required=[], cycle=[G1->G4->G6->G9->G10->G12->G13->G1])
  ├── G1: (memo-cycle-test-rel G2 G3) (select G2 G4)
  ├── G2: (scan uv,cols=(1,2)) (scan uv@uv_v_idx,cols=(1,2))
  │    ├── [limit hint: 1000.00]
@@ -102,7 +102,13 @@ memo (not optimized, ~4KB, required=[], cycle=[G1->G4->G6->G9->G1])
  ├── G3: (filters G5)
  ├── G4: (filters G6)
  ├── G5: (eq G7 G8)
- ├── G6: (exists G9 &{<nil>  0 unknown true})
+ ├── G6: (coalesce G9)
  ├── G7: (variable v)
  ├── G8: (const 1)
- └── G9: (limit G1 G8)
+ ├── G9: (scalar-list G10 G11)
+ ├── G10: (subquery G12 &{<nil>  0 unknown false})
+ ├── G11: (false)
+ ├── G12: (project G13 G14)
+ ├── G13: (limit G1 G8)
+ ├── G14: (projections G15)
+ └── G15: (true)

--- a/pkg/sql/opt/xform/testdata/rules/disjunction_in_join
+++ b/pkg/sql/opt/xform/testdata/rules/disjunction_in_join
@@ -705,21 +705,30 @@ select
  │    ├── columns: a1:1!null a2:2!null a3:3!null a4:4!null
  │    └── key: (1-4)
  └── filters
-      └── exists [subquery]
-           └── limit
-                ├── columns: d1:7 d2:8
-                ├── cardinality: [0 - 1]
-                ├── key: ()
-                ├── fd: ()-->(7,8)
-                ├── select
-                │    ├── columns: d1:7 d2:8
-                │    ├── limit hint: 1.00
-                │    ├── scan d
-                │    │    ├── columns: d1:7 d2:8
-                │    │    └── limit hint: 50.25
-                │    └── filters
-                │         └── (d1:7 = 4) OR (d2:8 = 50) [outer=(7,8)]
-                └── 1
+      └── coalesce [subquery]
+           ├── subquery
+           │    └── project
+           │         ├── columns: column15:15!null
+           │         ├── cardinality: [0 - 1]
+           │         ├── key: ()
+           │         ├── fd: ()-->(15)
+           │         ├── limit
+           │         │    ├── columns: d1:7 d2:8
+           │         │    ├── cardinality: [0 - 1]
+           │         │    ├── key: ()
+           │         │    ├── fd: ()-->(7,8)
+           │         │    ├── select
+           │         │    │    ├── columns: d1:7 d2:8
+           │         │    │    ├── limit hint: 1.00
+           │         │    │    ├── scan d
+           │         │    │    │    ├── columns: d1:7 d2:8
+           │         │    │    │    └── limit hint: 50.25
+           │         │    │    └── filters
+           │         │    │         └── (d1:7 = 4) OR (d2:8 = 50) [outer=(7,8)]
+           │         │    └── 1
+           │         └── projections
+           │              └── true [as=column15:15]
+           └── false
 
 opt expect-not=SplitDisjunctionOfJoinTerms
 SELECT * FROM a WHERE EXISTS (SELECT 1 FROM c, d WHERE d1 = 4 OR c2 = 50 HAVING sum(d4) > 40)
@@ -732,31 +741,41 @@ select
  │    ├── columns: a1:1!null a2:2!null a3:3!null a4:4!null
  │    └── key: (1-4)
  └── filters
-      └── exists [immutable, subquery]
-           └── select
-                ├── columns: sum:21!null
-                ├── cardinality: [0 - 1]
-                ├── immutable
-                ├── key: ()
-                ├── fd: ()-->(21)
-                ├── scalar-group-by
-                │    ├── columns: sum:21
-                │    ├── cardinality: [1 - 1]
-                │    ├── key: ()
-                │    ├── fd: ()-->(21)
-                │    ├── inner-join (cross)
-                │    │    ├── columns: c2:8 d1:14 d4:17
-                │    │    ├── scan c
-                │    │    │    └── columns: c2:8
-                │    │    ├── scan d
-                │    │    │    └── columns: d1:14 d4:17
-                │    │    └── filters
-                │    │         └── (d1:14 = 4) OR (c2:8 = 50) [outer=(8,14)]
-                │    └── aggregations
-                │         └── sum [as=sum:21, outer=(17)]
-                │              └── d4:17
-                └── filters
-                     └── sum:21 > 40 [outer=(21), immutable, constraints=(/21: (/40 - ]; tight)]
+      └── coalesce [immutable, subquery]
+           ├── subquery
+           │    └── project
+           │         ├── columns: column23:23!null
+           │         ├── cardinality: [0 - 1]
+           │         ├── immutable
+           │         ├── key: ()
+           │         ├── fd: ()-->(23)
+           │         ├── select
+           │         │    ├── columns: sum:21!null
+           │         │    ├── cardinality: [0 - 1]
+           │         │    ├── immutable
+           │         │    ├── key: ()
+           │         │    ├── fd: ()-->(21)
+           │         │    ├── scalar-group-by
+           │         │    │    ├── columns: sum:21
+           │         │    │    ├── cardinality: [1 - 1]
+           │         │    │    ├── key: ()
+           │         │    │    ├── fd: ()-->(21)
+           │         │    │    ├── inner-join (cross)
+           │         │    │    │    ├── columns: c2:8 d1:14 d4:17
+           │         │    │    │    ├── scan c
+           │         │    │    │    │    └── columns: c2:8
+           │         │    │    │    ├── scan d
+           │         │    │    │    │    └── columns: d1:14 d4:17
+           │         │    │    │    └── filters
+           │         │    │    │         └── (d1:14 = 4) OR (c2:8 = 50) [outer=(8,14)]
+           │         │    │    └── aggregations
+           │         │    │         └── sum [as=sum:21, outer=(17)]
+           │         │    │              └── d4:17
+           │         │    └── filters
+           │         │         └── sum:21 > 40 [outer=(21), immutable, constraints=(/21: (/40 - ]; tight)]
+           │         └── projections
+           │              └── true [as=column23:23]
+           └── false
 
 opt expect=SplitDisjunctionOfJoinTerms
 SELECT * FROM a WHERE EXISTS (SELECT 1 FROM c, d WHERE c1 = d2 or c2 = d1)
@@ -768,66 +787,75 @@ select
  │    ├── columns: a1:1!null a2:2!null a3:3!null a4:4!null
  │    └── key: (1-4)
  └── filters
-      └── exists [subquery]
-           └── limit
-                ├── columns: c1:7 c2:8 d1:14 d2:15
-                ├── cardinality: [0 - 1]
-                ├── key: ()
-                ├── fd: ()-->(7,8,14,15)
-                ├── project
-                │    ├── columns: c1:7 c2:8 d1:14 d2:15
-                │    ├── limit hint: 1.00
-                │    └── distinct-on
-                │         ├── columns: c1:7 c2:8 c.rowid:11!null d1:14 d2:15 d.rowid:18!null
-                │         ├── grouping columns: c.rowid:11!null d.rowid:18!null
-                │         ├── key: (11,18)
-                │         ├── fd: (11,18)-->(7,8,14,15)
-                │         ├── limit hint: 1.00
-                │         ├── union-all
-                │         │    ├── columns: c1:7 c2:8 c.rowid:11!null d1:14 d2:15 d.rowid:18!null
-                │         │    ├── left columns: c1:22 c2:23 c.rowid:26 d1:29 d2:30 d.rowid:33
-                │         │    ├── right columns: c1:36 c2:37 c.rowid:40 d1:43 d2:44 d.rowid:47
-                │         │    ├── limit hint: 1.20
-                │         │    ├── inner-join (hash)
-                │         │    │    ├── columns: c1:22!null c2:23 c.rowid:26!null d1:29 d2:30!null d.rowid:33!null
-                │         │    │    ├── key: (26,33)
-                │         │    │    ├── fd: (26)-->(22,23), (33)-->(29,30), (22)==(30), (30)==(22)
-                │         │    │    ├── limit hint: 1.20
-                │         │    │    ├── scan c
-                │         │    │    │    ├── columns: c1:22 c2:23 c.rowid:26!null
-                │         │    │    │    ├── key: (26)
-                │         │    │    │    └── fd: (26)-->(22,23)
-                │         │    │    ├── scan d
-                │         │    │    │    ├── columns: d1:29 d2:30 d.rowid:33!null
-                │         │    │    │    ├── key: (33)
-                │         │    │    │    └── fd: (33)-->(29,30)
-                │         │    │    └── filters
-                │         │    │         └── c1:22 = d2:30 [outer=(22,30), constraints=(/22: (/NULL - ]; /30: (/NULL - ]), fd=(22)==(30), (30)==(22)]
-                │         │    └── inner-join (hash)
-                │         │         ├── columns: c1:36 c2:37!null c.rowid:40!null d1:43!null d2:44 d.rowid:47!null
-                │         │         ├── key: (40,47)
-                │         │         ├── fd: (40)-->(36,37), (47)-->(43,44), (37)==(43), (43)==(37)
-                │         │         ├── limit hint: 1.20
-                │         │         ├── scan c
-                │         │         │    ├── columns: c1:36 c2:37 c.rowid:40!null
-                │         │         │    ├── key: (40)
-                │         │         │    └── fd: (40)-->(36,37)
-                │         │         ├── scan d
-                │         │         │    ├── columns: d1:43 d2:44 d.rowid:47!null
-                │         │         │    ├── key: (47)
-                │         │         │    └── fd: (47)-->(43,44)
-                │         │         └── filters
-                │         │              └── c2:37 = d1:43 [outer=(37,43), constraints=(/37: (/NULL - ]; /43: (/NULL - ]), fd=(37)==(43), (43)==(37)]
-                │         └── aggregations
-                │              ├── const-agg [as=c1:7, outer=(7)]
-                │              │    └── c1:7
-                │              ├── const-agg [as=c2:8, outer=(8)]
-                │              │    └── c2:8
-                │              ├── const-agg [as=d1:14, outer=(14)]
-                │              │    └── d1:14
-                │              └── const-agg [as=d2:15, outer=(15)]
-                │                   └── d2:15
-                └── 1
+      └── coalesce [subquery]
+           ├── subquery
+           │    └── project
+           │         ├── columns: column22:22!null
+           │         ├── cardinality: [0 - 1]
+           │         ├── key: ()
+           │         ├── fd: ()-->(22)
+           │         ├── limit
+           │         │    ├── columns: c1:7 c2:8 d1:14 d2:15
+           │         │    ├── cardinality: [0 - 1]
+           │         │    ├── key: ()
+           │         │    ├── fd: ()-->(7,8,14,15)
+           │         │    ├── project
+           │         │    │    ├── columns: c1:7 c2:8 d1:14 d2:15
+           │         │    │    ├── limit hint: 1.00
+           │         │    │    └── distinct-on
+           │         │    │         ├── columns: c1:7 c2:8 c.rowid:11!null d1:14 d2:15 d.rowid:18!null
+           │         │    │         ├── grouping columns: c.rowid:11!null d.rowid:18!null
+           │         │    │         ├── key: (11,18)
+           │         │    │         ├── fd: (11,18)-->(7,8,14,15)
+           │         │    │         ├── limit hint: 1.00
+           │         │    │         ├── union-all
+           │         │    │         │    ├── columns: c1:7 c2:8 c.rowid:11!null d1:14 d2:15 d.rowid:18!null
+           │         │    │         │    ├── left columns: c1:23 c2:24 c.rowid:27 d1:30 d2:31 d.rowid:34
+           │         │    │         │    ├── right columns: c1:37 c2:38 c.rowid:41 d1:44 d2:45 d.rowid:48
+           │         │    │         │    ├── limit hint: 1.20
+           │         │    │         │    ├── inner-join (hash)
+           │         │    │         │    │    ├── columns: c1:23!null c2:24 c.rowid:27!null d1:30 d2:31!null d.rowid:34!null
+           │         │    │         │    │    ├── key: (27,34)
+           │         │    │         │    │    ├── fd: (27)-->(23,24), (34)-->(30,31), (23)==(31), (31)==(23)
+           │         │    │         │    │    ├── limit hint: 1.20
+           │         │    │         │    │    ├── scan c
+           │         │    │         │    │    │    ├── columns: c1:23 c2:24 c.rowid:27!null
+           │         │    │         │    │    │    ├── key: (27)
+           │         │    │         │    │    │    └── fd: (27)-->(23,24)
+           │         │    │         │    │    ├── scan d
+           │         │    │         │    │    │    ├── columns: d1:30 d2:31 d.rowid:34!null
+           │         │    │         │    │    │    ├── key: (34)
+           │         │    │         │    │    │    └── fd: (34)-->(30,31)
+           │         │    │         │    │    └── filters
+           │         │    │         │    │         └── c1:23 = d2:31 [outer=(23,31), constraints=(/23: (/NULL - ]; /31: (/NULL - ]), fd=(23)==(31), (31)==(23)]
+           │         │    │         │    └── inner-join (hash)
+           │         │    │         │         ├── columns: c1:37 c2:38!null c.rowid:41!null d1:44!null d2:45 d.rowid:48!null
+           │         │    │         │         ├── key: (41,48)
+           │         │    │         │         ├── fd: (41)-->(37,38), (48)-->(44,45), (38)==(44), (44)==(38)
+           │         │    │         │         ├── limit hint: 1.20
+           │         │    │         │         ├── scan c
+           │         │    │         │         │    ├── columns: c1:37 c2:38 c.rowid:41!null
+           │         │    │         │         │    ├── key: (41)
+           │         │    │         │         │    └── fd: (41)-->(37,38)
+           │         │    │         │         ├── scan d
+           │         │    │         │         │    ├── columns: d1:44 d2:45 d.rowid:48!null
+           │         │    │         │         │    ├── key: (48)
+           │         │    │         │         │    └── fd: (48)-->(44,45)
+           │         │    │         │         └── filters
+           │         │    │         │              └── c2:38 = d1:44 [outer=(38,44), constraints=(/38: (/NULL - ]; /44: (/NULL - ]), fd=(38)==(44), (44)==(38)]
+           │         │    │         └── aggregations
+           │         │    │              ├── const-agg [as=c1:7, outer=(7)]
+           │         │    │              │    └── c1:7
+           │         │    │              ├── const-agg [as=c2:8, outer=(8)]
+           │         │    │              │    └── c2:8
+           │         │    │              ├── const-agg [as=d1:14, outer=(14)]
+           │         │    │              │    └── d1:14
+           │         │    │              └── const-agg [as=d2:15, outer=(15)]
+           │         │    │                   └── d2:15
+           │         │    └── 1
+           │         └── projections
+           │              └── true [as=column22:22]
+           └── false
 
 opt expect=SplitDisjunctionOfJoinTerms
 SELECT * FROM a WHERE (a1, a2) IN (SELECT c1, d1 FROM c, d WHERE c3 = d3 or c3 = d4)
@@ -1232,44 +1260,53 @@ select
  │    └── key: (1-4)
  └── filters
       └── not [subquery]
-           └── exists
-                └── limit
-                     ├── columns: b1:7 b2:8
-                     ├── cardinality: [0 - 1]
-                     ├── key: ()
-                     ├── fd: ()-->(7,8)
-                     ├── project
-                     │    ├── columns: b1:7 b2:8
-                     │    ├── limit hint: 1.00
-                     │    └── distinct-on
-                     │         ├── columns: b1:7 b2:8 rowid:11!null
-                     │         ├── grouping columns: rowid:11!null
-                     │         ├── key: (11)
-                     │         ├── fd: (11)-->(7,8)
-                     │         ├── limit hint: 1.00
-                     │         ├── union-all
-                     │         │    ├── columns: b1:7 b2:8 rowid:11!null
-                     │         │    ├── left columns: b1:15 b2:16 rowid:19
-                     │         │    ├── right columns: b1:22 b2:23 rowid:26
-                     │         │    ├── limit hint: 1.21
-                     │         │    ├── scan b@b_b1_b2_idx
-                     │         │    │    ├── columns: b1:15!null b2:16 rowid:19!null
-                     │         │    │    ├── constraint: /15/16/19: [/4 - /4]
-                     │         │    │    ├── key: (19)
-                     │         │    │    ├── fd: ()-->(15), (19)-->(16)
-                     │         │    │    └── limit hint: 1.21
-                     │         │    └── scan b@b_b2_idx
-                     │         │         ├── columns: b1:22 b2:23!null rowid:26!null
-                     │         │         ├── constraint: /23/26: [/50 - /50]
-                     │         │         ├── key: (26)
-                     │         │         ├── fd: ()-->(23), (26)-->(22)
-                     │         │         └── limit hint: 1.21
-                     │         └── aggregations
-                     │              ├── const-agg [as=b1:7, outer=(7)]
-                     │              │    └── b1:7
-                     │              └── const-agg [as=b2:8, outer=(8)]
-                     │                   └── b2:8
-                     └── 1
+           └── coalesce
+                ├── subquery
+                │    └── project
+                │         ├── columns: column15:15!null
+                │         ├── cardinality: [0 - 1]
+                │         ├── key: ()
+                │         ├── fd: ()-->(15)
+                │         ├── limit
+                │         │    ├── columns: b1:7 b2:8
+                │         │    ├── cardinality: [0 - 1]
+                │         │    ├── key: ()
+                │         │    ├── fd: ()-->(7,8)
+                │         │    ├── project
+                │         │    │    ├── columns: b1:7 b2:8
+                │         │    │    ├── limit hint: 1.00
+                │         │    │    └── distinct-on
+                │         │    │         ├── columns: b1:7 b2:8 rowid:11!null
+                │         │    │         ├── grouping columns: rowid:11!null
+                │         │    │         ├── key: (11)
+                │         │    │         ├── fd: (11)-->(7,8)
+                │         │    │         ├── limit hint: 1.00
+                │         │    │         ├── union-all
+                │         │    │         │    ├── columns: b1:7 b2:8 rowid:11!null
+                │         │    │         │    ├── left columns: b1:16 b2:17 rowid:20
+                │         │    │         │    ├── right columns: b1:23 b2:24 rowid:27
+                │         │    │         │    ├── limit hint: 1.21
+                │         │    │         │    ├── scan b@b_b1_b2_idx
+                │         │    │         │    │    ├── columns: b1:16!null b2:17 rowid:20!null
+                │         │    │         │    │    ├── constraint: /16/17/20: [/4 - /4]
+                │         │    │         │    │    ├── key: (20)
+                │         │    │         │    │    ├── fd: ()-->(16), (20)-->(17)
+                │         │    │         │    │    └── limit hint: 1.21
+                │         │    │         │    └── scan b@b_b2_idx
+                │         │    │         │         ├── columns: b1:23 b2:24!null rowid:27!null
+                │         │    │         │         ├── constraint: /24/27: [/50 - /50]
+                │         │    │         │         ├── key: (27)
+                │         │    │         │         ├── fd: ()-->(24), (27)-->(23)
+                │         │    │         │         └── limit hint: 1.21
+                │         │    │         └── aggregations
+                │         │    │              ├── const-agg [as=b1:7, outer=(7)]
+                │         │    │              │    └── b1:7
+                │         │    │              └── const-agg [as=b2:8, outer=(8)]
+                │         │    │                   └── b2:8
+                │         │    └── 1
+                │         └── projections
+                │              └── true [as=column15:15]
+                └── false
 
 opt expect-not=SplitDisjunctionOfJoinTerms
 SELECT * FROM a WHERE NOT EXISTS (SELECT 1 FROM c, d WHERE d1 = 4 OR c2 = 50 or d2+c3 > 5)
@@ -1283,24 +1320,34 @@ select
  │    └── key: (1-4)
  └── filters
       └── not [immutable, subquery]
-           └── exists
-                └── limit
-                     ├── columns: c2:8 c3:9 d1:14 d2:15
-                     ├── cardinality: [0 - 1]
-                     ├── immutable
-                     ├── key: ()
-                     ├── fd: ()-->(8,9,14,15)
-                     ├── inner-join (cross)
-                     │    ├── columns: c2:8 c3:9 d1:14 d2:15
-                     │    ├── immutable
-                     │    ├── limit hint: 1.00
-                     │    ├── scan c
-                     │    │    └── columns: c2:8 c3:9
-                     │    ├── scan d
-                     │    │    └── columns: d1:14 d2:15
-                     │    └── filters
-                     │         └── ((d1:14 = 4) OR (c2:8 = 50)) OR ((d2:15 + c3:9) > 5) [outer=(8,9,14,15), immutable]
-                     └── 1
+           └── coalesce
+                ├── subquery
+                │    └── project
+                │         ├── columns: column22:22!null
+                │         ├── cardinality: [0 - 1]
+                │         ├── immutable
+                │         ├── key: ()
+                │         ├── fd: ()-->(22)
+                │         ├── limit
+                │         │    ├── columns: c2:8 c3:9 d1:14 d2:15
+                │         │    ├── cardinality: [0 - 1]
+                │         │    ├── immutable
+                │         │    ├── key: ()
+                │         │    ├── fd: ()-->(8,9,14,15)
+                │         │    ├── inner-join (cross)
+                │         │    │    ├── columns: c2:8 c3:9 d1:14 d2:15
+                │         │    │    ├── immutable
+                │         │    │    ├── limit hint: 1.00
+                │         │    │    ├── scan c
+                │         │    │    │    └── columns: c2:8 c3:9
+                │         │    │    ├── scan d
+                │         │    │    │    └── columns: d1:14 d2:15
+                │         │    │    └── filters
+                │         │    │         └── ((d1:14 = 4) OR (c2:8 = 50)) OR ((d2:15 + c3:9) > 5) [outer=(8,9,14,15), immutable]
+                │         │    └── 1
+                │         └── projections
+                │              └── true [as=column22:22]
+                └── false
 
 opt expect=SplitDisjunctionOfJoinTerms
 SELECT * FROM a WHERE NOT EXISTS (SELECT 1 FROM c, d WHERE c3 = d4 or c4 = d3)
@@ -1313,66 +1360,75 @@ select
  │    └── key: (1-4)
  └── filters
       └── not [subquery]
-           └── exists
-                └── limit
-                     ├── columns: c3:9 c4:10 d3:16 d4:17
-                     ├── cardinality: [0 - 1]
-                     ├── key: ()
-                     ├── fd: ()-->(9,10,16,17)
-                     ├── project
-                     │    ├── columns: c3:9 c4:10 d3:16 d4:17
-                     │    ├── limit hint: 1.00
-                     │    └── distinct-on
-                     │         ├── columns: c3:9 c4:10 c.rowid:11!null d3:16 d4:17 d.rowid:18!null
-                     │         ├── grouping columns: c.rowid:11!null d.rowid:18!null
-                     │         ├── key: (11,18)
-                     │         ├── fd: (11,18)-->(9,10,16,17)
-                     │         ├── limit hint: 1.00
-                     │         ├── union-all
-                     │         │    ├── columns: c3:9 c4:10 c.rowid:11!null d3:16 d4:17 d.rowid:18!null
-                     │         │    ├── left columns: c3:24 c4:25 c.rowid:26 d3:31 d4:32 d.rowid:33
-                     │         │    ├── right columns: c3:38 c4:39 c.rowid:40 d3:45 d4:46 d.rowid:47
-                     │         │    ├── limit hint: 1.20
-                     │         │    ├── inner-join (hash)
-                     │         │    │    ├── columns: c3:24!null c4:25 c.rowid:26!null d3:31 d4:32!null d.rowid:33!null
-                     │         │    │    ├── key: (26,33)
-                     │         │    │    ├── fd: (26)-->(24,25), (33)-->(31,32), (24)==(32), (32)==(24)
-                     │         │    │    ├── limit hint: 1.20
-                     │         │    │    ├── scan c
-                     │         │    │    │    ├── columns: c3:24 c4:25 c.rowid:26!null
-                     │         │    │    │    ├── key: (26)
-                     │         │    │    │    └── fd: (26)-->(24,25)
-                     │         │    │    ├── scan d
-                     │         │    │    │    ├── columns: d3:31 d4:32 d.rowid:33!null
-                     │         │    │    │    ├── key: (33)
-                     │         │    │    │    └── fd: (33)-->(31,32)
-                     │         │    │    └── filters
-                     │         │    │         └── c3:24 = d4:32 [outer=(24,32), constraints=(/24: (/NULL - ]; /32: (/NULL - ]), fd=(24)==(32), (32)==(24)]
-                     │         │    └── inner-join (hash)
-                     │         │         ├── columns: c3:38 c4:39!null c.rowid:40!null d3:45!null d4:46 d.rowid:47!null
-                     │         │         ├── key: (40,47)
-                     │         │         ├── fd: (40)-->(38,39), (47)-->(45,46), (39)==(45), (45)==(39)
-                     │         │         ├── limit hint: 1.20
-                     │         │         ├── scan c
-                     │         │         │    ├── columns: c3:38 c4:39 c.rowid:40!null
-                     │         │         │    ├── key: (40)
-                     │         │         │    └── fd: (40)-->(38,39)
-                     │         │         ├── scan d
-                     │         │         │    ├── columns: d3:45 d4:46 d.rowid:47!null
-                     │         │         │    ├── key: (47)
-                     │         │         │    └── fd: (47)-->(45,46)
-                     │         │         └── filters
-                     │         │              └── c4:39 = d3:45 [outer=(39,45), constraints=(/39: (/NULL - ]; /45: (/NULL - ]), fd=(39)==(45), (45)==(39)]
-                     │         └── aggregations
-                     │              ├── const-agg [as=c3:9, outer=(9)]
-                     │              │    └── c3:9
-                     │              ├── const-agg [as=c4:10, outer=(10)]
-                     │              │    └── c4:10
-                     │              ├── const-agg [as=d3:16, outer=(16)]
-                     │              │    └── d3:16
-                     │              └── const-agg [as=d4:17, outer=(17)]
-                     │                   └── d4:17
-                     └── 1
+           └── coalesce
+                ├── subquery
+                │    └── project
+                │         ├── columns: column22:22!null
+                │         ├── cardinality: [0 - 1]
+                │         ├── key: ()
+                │         ├── fd: ()-->(22)
+                │         ├── limit
+                │         │    ├── columns: c3:9 c4:10 d3:16 d4:17
+                │         │    ├── cardinality: [0 - 1]
+                │         │    ├── key: ()
+                │         │    ├── fd: ()-->(9,10,16,17)
+                │         │    ├── project
+                │         │    │    ├── columns: c3:9 c4:10 d3:16 d4:17
+                │         │    │    ├── limit hint: 1.00
+                │         │    │    └── distinct-on
+                │         │    │         ├── columns: c3:9 c4:10 c.rowid:11!null d3:16 d4:17 d.rowid:18!null
+                │         │    │         ├── grouping columns: c.rowid:11!null d.rowid:18!null
+                │         │    │         ├── key: (11,18)
+                │         │    │         ├── fd: (11,18)-->(9,10,16,17)
+                │         │    │         ├── limit hint: 1.00
+                │         │    │         ├── union-all
+                │         │    │         │    ├── columns: c3:9 c4:10 c.rowid:11!null d3:16 d4:17 d.rowid:18!null
+                │         │    │         │    ├── left columns: c3:25 c4:26 c.rowid:27 d3:32 d4:33 d.rowid:34
+                │         │    │         │    ├── right columns: c3:39 c4:40 c.rowid:41 d3:46 d4:47 d.rowid:48
+                │         │    │         │    ├── limit hint: 1.20
+                │         │    │         │    ├── inner-join (hash)
+                │         │    │         │    │    ├── columns: c3:25!null c4:26 c.rowid:27!null d3:32 d4:33!null d.rowid:34!null
+                │         │    │         │    │    ├── key: (27,34)
+                │         │    │         │    │    ├── fd: (27)-->(25,26), (34)-->(32,33), (25)==(33), (33)==(25)
+                │         │    │         │    │    ├── limit hint: 1.20
+                │         │    │         │    │    ├── scan c
+                │         │    │         │    │    │    ├── columns: c3:25 c4:26 c.rowid:27!null
+                │         │    │         │    │    │    ├── key: (27)
+                │         │    │         │    │    │    └── fd: (27)-->(25,26)
+                │         │    │         │    │    ├── scan d
+                │         │    │         │    │    │    ├── columns: d3:32 d4:33 d.rowid:34!null
+                │         │    │         │    │    │    ├── key: (34)
+                │         │    │         │    │    │    └── fd: (34)-->(32,33)
+                │         │    │         │    │    └── filters
+                │         │    │         │    │         └── c3:25 = d4:33 [outer=(25,33), constraints=(/25: (/NULL - ]; /33: (/NULL - ]), fd=(25)==(33), (33)==(25)]
+                │         │    │         │    └── inner-join (hash)
+                │         │    │         │         ├── columns: c3:39 c4:40!null c.rowid:41!null d3:46!null d4:47 d.rowid:48!null
+                │         │    │         │         ├── key: (41,48)
+                │         │    │         │         ├── fd: (41)-->(39,40), (48)-->(46,47), (40)==(46), (46)==(40)
+                │         │    │         │         ├── limit hint: 1.20
+                │         │    │         │         ├── scan c
+                │         │    │         │         │    ├── columns: c3:39 c4:40 c.rowid:41!null
+                │         │    │         │         │    ├── key: (41)
+                │         │    │         │         │    └── fd: (41)-->(39,40)
+                │         │    │         │         ├── scan d
+                │         │    │         │         │    ├── columns: d3:46 d4:47 d.rowid:48!null
+                │         │    │         │         │    ├── key: (48)
+                │         │    │         │         │    └── fd: (48)-->(46,47)
+                │         │    │         │         └── filters
+                │         │    │         │              └── c4:40 = d3:46 [outer=(40,46), constraints=(/40: (/NULL - ]; /46: (/NULL - ]), fd=(40)==(46), (46)==(40)]
+                │         │    │         └── aggregations
+                │         │    │              ├── const-agg [as=c3:9, outer=(9)]
+                │         │    │              │    └── c3:9
+                │         │    │              ├── const-agg [as=c4:10, outer=(10)]
+                │         │    │              │    └── c4:10
+                │         │    │              ├── const-agg [as=d3:16, outer=(16)]
+                │         │    │              │    └── d3:16
+                │         │    │              └── const-agg [as=d4:17, outer=(17)]
+                │         │    │                   └── d4:17
+                │         │    └── 1
+                │         └── projections
+                │              └── true [as=column22:22]
+                └── false
 
 opt expect=SplitDisjunctionOfJoinTerms
 SELECT * FROM a WHERE (a1, a2) NOT IN (SELECT c1, d1 FROM c, d WHERE c3 = d3 or c3 = d4)

--- a/pkg/sql/opt/xform/testdata/rules/scan
+++ b/pkg/sql/opt/xform/testdata/rules/scan
@@ -1031,20 +1031,29 @@ distribute
            │    ├── key: (3)
            │    └── fd: (3)-->(1,2,5), (5)~~>(1-3)
            └── filters
-                └── exists [subquery]
-                     └── locality-optimized-search
-                          ├── cardinality: [0 - 1]
-                          ├── key: ()
-                          ├── scan abc_part@b_idx
-                          │    ├── constraint: /18/21: [/'east' - /'east']
-                          │    ├── limit: 1
-                          │    └── key: ()
-                          └── scan abc_part@b_idx
-                               ├── constraint: /26/29
-                               │    ├── [/'central' - /'central']
-                               │    └── [/'west' - /'west']
-                               ├── limit: 1
-                               └── key: ()
+                └── coalesce [subquery]
+                     ├── subquery
+                     │    └── project
+                     │         ├── columns: column18:18!null
+                     │         ├── cardinality: [0 - 1]
+                     │         ├── key: ()
+                     │         ├── fd: ()-->(18)
+                     │         ├── locality-optimized-search
+                     │         │    ├── cardinality: [0 - 1]
+                     │         │    ├── key: ()
+                     │         │    ├── scan abc_part@b_idx
+                     │         │    │    ├── constraint: /19/22: [/'east' - /'east']
+                     │         │    │    ├── limit: 1
+                     │         │    │    └── key: ()
+                     │         │    └── scan abc_part@b_idx
+                     │         │         ├── constraint: /27/30
+                     │         │         │    ├── [/'central' - /'central']
+                     │         │         │    └── [/'west' - /'west']
+                     │         │         ├── limit: 1
+                     │         │         └── key: ()
+                     │         └── projections
+                     │              └── true [as=column18:18]
+                     └── false
 
 # Partitioning without CHECK constraints
 exec-ddl

--- a/pkg/sql/opt/xform/testdata/rules/select
+++ b/pkg/sql/opt/xform/testdata/rules/select
@@ -7572,55 +7572,69 @@ project
       ├── fd: (1)-->(2,3)
       ├── union-all
       │    ├── columns: d.k:1!null d.u:2 d.v:3
-      │    ├── left columns: d.k:12 d.u:13 d.v:14
-      │    ├── right columns: d.k:18 d.u:19 d.v:20
+      │    ├── left columns: d.k:13 d.u:14 d.v:15
+      │    ├── right columns: d.k:19 d.u:20 d.v:21
       │    ├── ordering: +1
       │    ├── index-join d
-      │    │    ├── columns: d.k:12!null d.u:13!null d.v:14
-      │    │    ├── key: (12)
-      │    │    ├── fd: ()-->(13), (12)-->(14)
-      │    │    ├── ordering: +12 opt(13) [actual: +12]
+      │    │    ├── columns: d.k:13!null d.u:14!null d.v:15
+      │    │    ├── key: (13)
+      │    │    ├── fd: ()-->(14), (13)-->(15)
+      │    │    ├── ordering: +13 opt(14) [actual: +13]
       │    │    └── select
-      │    │         ├── columns: d.k:12!null d.u:13!null
-      │    │         ├── key: (12)
-      │    │         ├── fd: ()-->(13)
-      │    │         ├── ordering: +12 opt(13) [actual: +12]
+      │    │         ├── columns: d.k:13!null d.u:14!null
+      │    │         ├── key: (13)
+      │    │         ├── fd: ()-->(14)
+      │    │         ├── ordering: +13 opt(14) [actual: +13]
       │    │         ├── scan d@u
-      │    │         │    ├── columns: d.k:12!null d.u:13!null
-      │    │         │    ├── constraint: /13/12: [/1 - /1]
-      │    │         │    ├── key: (12)
-      │    │         │    ├── fd: ()-->(13)
-      │    │         │    └── ordering: +12 opt(13) [actual: +12]
+      │    │         │    ├── columns: d.k:13!null d.u:14!null
+      │    │         │    ├── constraint: /14/13: [/1 - /1]
+      │    │         │    ├── key: (13)
+      │    │         │    ├── fd: ()-->(14)
+      │    │         │    └── ordering: +13 opt(14) [actual: +13]
       │    │         └── filters
-      │    │              └── exists [subquery]
-      │    │                   └── scan a
-      │    │                        ├── columns: a.u:8 a.v:9
-      │    │                        ├── limit: 1
-      │    │                        ├── key: ()
-      │    │                        └── fd: ()-->(8,9)
+      │    │              └── coalesce [subquery]
+      │    │                   ├── subquery
+      │    │                   │    └── project
+      │    │                   │         ├── columns: column12:12!null
+      │    │                   │         ├── cardinality: [0 - 1]
+      │    │                   │         ├── key: ()
+      │    │                   │         ├── fd: ()-->(12)
+      │    │                   │         ├── scan a
+      │    │                   │         │    ├── limit: 1
+      │    │                   │         │    └── key: ()
+      │    │                   │         └── projections
+      │    │                   │              └── true [as=column12:12]
+      │    │                   └── false
       │    └── index-join d
-      │         ├── columns: d.k:18!null d.u:19 d.v:20!null
-      │         ├── key: (18)
-      │         ├── fd: ()-->(20), (18)-->(19)
-      │         ├── ordering: +18 opt(20) [actual: +18]
+      │         ├── columns: d.k:19!null d.u:20 d.v:21!null
+      │         ├── key: (19)
+      │         ├── fd: ()-->(21), (19)-->(20)
+      │         ├── ordering: +19 opt(21) [actual: +19]
       │         └── select
-      │              ├── columns: d.k:18!null d.v:20!null
-      │              ├── key: (18)
-      │              ├── fd: ()-->(20)
-      │              ├── ordering: +18 opt(20) [actual: +18]
+      │              ├── columns: d.k:19!null d.v:21!null
+      │              ├── key: (19)
+      │              ├── fd: ()-->(21)
+      │              ├── ordering: +19 opt(21) [actual: +19]
       │              ├── scan d@v
-      │              │    ├── columns: d.k:18!null d.v:20!null
-      │              │    ├── constraint: /20/18: [/1 - /1]
-      │              │    ├── key: (18)
-      │              │    ├── fd: ()-->(20)
-      │              │    └── ordering: +18 opt(20) [actual: +18]
+      │              │    ├── columns: d.k:19!null d.v:21!null
+      │              │    ├── constraint: /21/19: [/1 - /1]
+      │              │    ├── key: (19)
+      │              │    ├── fd: ()-->(21)
+      │              │    └── ordering: +19 opt(21) [actual: +19]
       │              └── filters
-      │                   └── exists [subquery]
-      │                        └── scan a
-      │                             ├── columns: a.u:8 a.v:9
-      │                             ├── limit: 1
-      │                             ├── key: ()
-      │                             └── fd: ()-->(8,9)
+      │                   └── coalesce [subquery]
+      │                        ├── subquery
+      │                        │    └── project
+      │                        │         ├── columns: column12:12!null
+      │                        │         ├── cardinality: [0 - 1]
+      │                        │         ├── key: ()
+      │                        │         ├── fd: ()-->(12)
+      │                        │         ├── scan a
+      │                        │         │    ├── limit: 1
+      │                        │         │    └── key: ()
+      │                        │         └── projections
+      │                        │              └── true [as=column12:12]
+      │                        └── false
       └── aggregations
            ├── const-agg [as=d.u:2, outer=(2)]
            │    └── d.u:2
@@ -9089,55 +9103,69 @@ project
       ├── fd: (1)-->(2,3)
       ├── union-all
       │    ├── columns: d.k:1!null d.u:2 d.v:3
-      │    ├── left columns: d.k:12 d.u:13 d.v:14
-      │    ├── right columns: d.k:18 d.u:19 d.v:20
+      │    ├── left columns: d.k:13 d.u:14 d.v:15
+      │    ├── right columns: d.k:19 d.u:20 d.v:21
       │    ├── ordering: +1
       │    ├── index-join d
-      │    │    ├── columns: d.k:12!null d.u:13!null d.v:14
-      │    │    ├── key: (12)
-      │    │    ├── fd: ()-->(13), (12)-->(14)
-      │    │    ├── ordering: +12 opt(13) [actual: +12]
+      │    │    ├── columns: d.k:13!null d.u:14!null d.v:15
+      │    │    ├── key: (13)
+      │    │    ├── fd: ()-->(14), (13)-->(15)
+      │    │    ├── ordering: +13 opt(14) [actual: +13]
       │    │    └── select
-      │    │         ├── columns: d.k:12!null d.u:13!null
-      │    │         ├── key: (12)
-      │    │         ├── fd: ()-->(13)
-      │    │         ├── ordering: +12 opt(13) [actual: +12]
+      │    │         ├── columns: d.k:13!null d.u:14!null
+      │    │         ├── key: (13)
+      │    │         ├── fd: ()-->(14)
+      │    │         ├── ordering: +13 opt(14) [actual: +13]
       │    │         ├── scan d@u
-      │    │         │    ├── columns: d.k:12!null d.u:13!null
-      │    │         │    ├── constraint: /13/12: [/1 - /1]
-      │    │         │    ├── key: (12)
-      │    │         │    ├── fd: ()-->(13)
-      │    │         │    └── ordering: +12 opt(13) [actual: +12]
+      │    │         │    ├── columns: d.k:13!null d.u:14!null
+      │    │         │    ├── constraint: /14/13: [/1 - /1]
+      │    │         │    ├── key: (13)
+      │    │         │    ├── fd: ()-->(14)
+      │    │         │    └── ordering: +13 opt(14) [actual: +13]
       │    │         └── filters
-      │    │              └── exists [subquery]
-      │    │                   └── scan a
-      │    │                        ├── columns: a.u:8 a.v:9
-      │    │                        ├── limit: 1
-      │    │                        ├── key: ()
-      │    │                        └── fd: ()-->(8,9)
+      │    │              └── coalesce [subquery]
+      │    │                   ├── subquery
+      │    │                   │    └── project
+      │    │                   │         ├── columns: column12:12!null
+      │    │                   │         ├── cardinality: [0 - 1]
+      │    │                   │         ├── key: ()
+      │    │                   │         ├── fd: ()-->(12)
+      │    │                   │         ├── scan a
+      │    │                   │         │    ├── limit: 1
+      │    │                   │         │    └── key: ()
+      │    │                   │         └── projections
+      │    │                   │              └── true [as=column12:12]
+      │    │                   └── false
       │    └── index-join d
-      │         ├── columns: d.k:18!null d.u:19 d.v:20!null
-      │         ├── key: (18)
-      │         ├── fd: ()-->(20), (18)-->(19)
-      │         ├── ordering: +18 opt(20) [actual: +18]
+      │         ├── columns: d.k:19!null d.u:20 d.v:21!null
+      │         ├── key: (19)
+      │         ├── fd: ()-->(21), (19)-->(20)
+      │         ├── ordering: +19 opt(21) [actual: +19]
       │         └── select
-      │              ├── columns: d.k:18!null d.v:20!null
-      │              ├── key: (18)
-      │              ├── fd: ()-->(20)
-      │              ├── ordering: +18 opt(20) [actual: +18]
+      │              ├── columns: d.k:19!null d.v:21!null
+      │              ├── key: (19)
+      │              ├── fd: ()-->(21)
+      │              ├── ordering: +19 opt(21) [actual: +19]
       │              ├── scan d@v
-      │              │    ├── columns: d.k:18!null d.v:20!null
-      │              │    ├── constraint: /20/18: [/1 - /1]
-      │              │    ├── key: (18)
-      │              │    ├── fd: ()-->(20)
-      │              │    └── ordering: +18 opt(20) [actual: +18]
+      │              │    ├── columns: d.k:19!null d.v:21!null
+      │              │    ├── constraint: /21/19: [/1 - /1]
+      │              │    ├── key: (19)
+      │              │    ├── fd: ()-->(21)
+      │              │    └── ordering: +19 opt(21) [actual: +19]
       │              └── filters
-      │                   └── exists [subquery]
-      │                        └── scan a
-      │                             ├── columns: a.u:8 a.v:9
-      │                             ├── limit: 1
-      │                             ├── key: ()
-      │                             └── fd: ()-->(8,9)
+      │                   └── coalesce [subquery]
+      │                        ├── subquery
+      │                        │    └── project
+      │                        │         ├── columns: column12:12!null
+      │                        │         ├── cardinality: [0 - 1]
+      │                        │         ├── key: ()
+      │                        │         ├── fd: ()-->(12)
+      │                        │         ├── scan a
+      │                        │         │    ├── limit: 1
+      │                        │         │    └── key: ()
+      │                        │         └── projections
+      │                        │              └── true [as=column12:12]
+      │                        └── false
       └── aggregations
            ├── const-agg [as=d.u:2, outer=(2)]
            │    └── d.u:2


### PR DESCRIPTION
#### opt: add SubqueryPrivate.Ordering check to CheckExpr

Expressions with `SubqueryPrivate` fields are not optimized with respect
to any ordering, except for `ArrayFlatten` expressions. This commit adds
a check to `CheckExpr` to ensure that `SubqueryPrivate.Ordering` is only
set for `ArrayFlatten`.

Release note: None

#### opt: convert uncorrelated Exists to Coalesce+Subquery expressions

This commit adds the `ConvertUncorrelatedExistsToCoalesceSubquery`
normalization rule which transforms uncorrelated Exists into
Coalesce+Subquery expressions. Below is an example of the transformation
made.

    SELECT EXISTS (
      SELECT * FROM b
    ) FROM a
    =>
    SELECT COALESCE(
      (SELECT true FROM (SELECT * FROM b) LIMIT 1),
      false
    ) FROM a

By eliminating the uncorrelated Exists, we now support execution of
uncorrelated Exists that are within correlated subqueries or UDFs. These
are supported without execbuilder changes because execbuilder already
knows how to build correlated Subquery expressions within correlated
subqueries or UDFs.

This change also makes the `exists` subquery execution mode, which only
works for uncorrelated subqueries, obsolete. The related code paths
should never be executed. I plan on removing them in a future commit.

Release note: None

#### opt: build correlated Exists as Coalesce+Routine expressions

This commit allows for the execution of correlated Exists subqueries by
building them as Coalesce+Routine expressions in execbuilder.

Routines do not have a special mode for Exists subqueries, like the
legacy, eager-evaluation subquery machinery does, so we must transform
the Exists expression. The transformation is modelled after the
ConvertUncorrelatedExistsToCoalesceSubquery normalization rule. The
transformation is effectively:

    EXISTS (<input>)
    =>
    COALESCE((SELECT true FROM (<input>) LIMIT 1), false)

We don't implement this as a normalization rule for correlated Exists
subqueries because the transformation would prevent decorrelation rules
from turning the Exists expression into a join, if it is possible.
Marking the rule as LowPriority would not be sufficient because the rule
would operate on the Exists scalar expression, while the decorrelation
rules operate on relational expressions that contain Exists expresions.
The Exists would always be converted to a Coalesce before the
decorrelation rules can match.

Informs: #87291

Epic: CRDB-19257

Release note (sql change): Some queries with `EXISTS` subqueries which
previously resulted in the error "could not decorrelate subquery" now
succeed.
