### PR TITLE
release-22.2: logictest: fix bug in let variable replacement

### DIFF
--- a/pkg/sql/logictest/logic.go
+++ b/pkg/sql/logictest/logic.go
@@ -1058,7 +1058,7 @@ func (t *logicTest) substituteVars(line string) string {
 		if replace, ok := t.varMap[varName]; ok {
 			return replace
 		}
-		return line
+		return varName
 	})
 }
 


### PR DESCRIPTION
Backport 1/3 commits from #95545.

/cc @cockroachdb/release

---

#### logictest: fix bug in let variable replacement

This commit fixes a bug in the implementation of the `let` command that
incorrectly matched and replaced parts of queries with dollar-quotes,
like `CREATE FUNCTION ... AS $$SELECT 1$$`.

Epic: None

Release note: None

Release justification: This is a test-only change.

