### PR TITLE
kv: perform PushTxn(PUSH_TIMESTAMP) without Raft consensus

### DIFF
--- a/pkg/kv/kvserver/batcheval/cmd_end_transaction_test.go
+++ b/pkg/kv/kvserver/batcheval/cmd_end_transaction_test.go
@@ -93,8 +93,9 @@ func TestEndTxnUpdatesTransactionRecord(t *testing.T) {
 	testCases := []struct {
 		name string
 		// Replica state.
-		existingTxn  *roachpb.TransactionRecord
-		canCreateTxn func() (can bool, minTS hlc.Timestamp)
+		existingTxn    *roachpb.TransactionRecord
+		canCreateTxn   bool
+		minTxnCommitTS hlc.Timestamp
 		// Request state.
 		headerTxn      *roachpb.Transaction
 		commit         bool
@@ -110,8 +111,7 @@ func TestEndTxnUpdatesTransactionRecord(t *testing.T) {
 			// there are intents to clean up.
 			name: "record missing, try rollback",
 			// Replica state.
-			existingTxn:  nil,
-			canCreateTxn: nil, // not needed
+			existingTxn: nil,
 			// Request state.
 			headerTxn: headerTxn,
 			commit:    false,
@@ -125,8 +125,7 @@ func TestEndTxnUpdatesTransactionRecord(t *testing.T) {
 			// when all intents are on the transaction record's range.
 			name: "record missing, try rollback without intents",
 			// Replica state.
-			existingTxn:  nil,
-			canCreateTxn: nil, // not needed
+			existingTxn: nil,
 			// Request state.
 			headerTxn:   headerTxn,
 			commit:      false,
@@ -143,7 +142,7 @@ func TestEndTxnUpdatesTransactionRecord(t *testing.T) {
 			name: "record missing, can't create, try stage",
 			// Replica state.
 			existingTxn:  nil,
-			canCreateTxn: func() (bool, hlc.Timestamp) { return false, hlc.Timestamp{} },
+			canCreateTxn: false,
 			// Request state.
 			headerTxn:      headerTxn,
 			commit:         true,
@@ -158,7 +157,7 @@ func TestEndTxnUpdatesTransactionRecord(t *testing.T) {
 			name: "record missing, can't create, try commit",
 			// Replica state.
 			existingTxn:  nil,
-			canCreateTxn: func() (bool, hlc.Timestamp) { return false, hlc.Timestamp{} },
+			canCreateTxn: false,
 			// Request state.
 			headerTxn: headerTxn,
 			commit:    true,
@@ -171,7 +170,7 @@ func TestEndTxnUpdatesTransactionRecord(t *testing.T) {
 			name: "record missing, can create, try stage",
 			// Replica state.
 			existingTxn:  nil,
-			canCreateTxn: func() (bool, hlc.Timestamp) { return true, hlc.Timestamp{} },
+			canCreateTxn: true,
 			// Request state.
 			headerTxn:      headerTxn,
 			commit:         true,
@@ -185,7 +184,7 @@ func TestEndTxnUpdatesTransactionRecord(t *testing.T) {
 			name: "record missing, can create, try commit",
 			// Replica state.
 			existingTxn:  nil,
-			canCreateTxn: func() (bool, hlc.Timestamp) { return true, hlc.Timestamp{} },
+			canCreateTxn: true,
 			// Request state.
 			headerTxn: headerTxn,
 			commit:    true,
@@ -198,7 +197,7 @@ func TestEndTxnUpdatesTransactionRecord(t *testing.T) {
 			name: "record missing, can create, try stage without intents",
 			// Replica state.
 			existingTxn:  nil,
-			canCreateTxn: func() (bool, hlc.Timestamp) { return true, hlc.Timestamp{} },
+			canCreateTxn: true,
 			// Request state.
 			headerTxn:      headerTxn,
 			commit:         true,
@@ -219,7 +218,7 @@ func TestEndTxnUpdatesTransactionRecord(t *testing.T) {
 			name: "record missing, can create, try commit without intents",
 			// Replica state.
 			existingTxn:  nil,
-			canCreateTxn: func() (bool, hlc.Timestamp) { return true, hlc.Timestamp{} },
+			canCreateTxn: true,
 			// Request state.
 			headerTxn:   headerTxn,
 			commit:      true,
@@ -236,7 +235,7 @@ func TestEndTxnUpdatesTransactionRecord(t *testing.T) {
 			name: "record missing, can create, try stage at pushed timestamp",
 			// Replica state.
 			existingTxn:  nil,
-			canCreateTxn: func() (bool, hlc.Timestamp) { return true, hlc.Timestamp{} },
+			canCreateTxn: true,
 			// Request state.
 			headerTxn:      pushedHeaderTxn,
 			commit:         true,
@@ -251,7 +250,7 @@ func TestEndTxnUpdatesTransactionRecord(t *testing.T) {
 			name: "record missing, can create, try commit at pushed timestamp",
 			// Replica state.
 			existingTxn:  nil,
-			canCreateTxn: func() (bool, hlc.Timestamp) { return true, hlc.Timestamp{} },
+			canCreateTxn: true,
 			// Request state.
 			headerTxn: pushedHeaderTxn,
 			commit:    true,
@@ -265,7 +264,7 @@ func TestEndTxnUpdatesTransactionRecord(t *testing.T) {
 			name: "record missing, can create, try stage at pushed timestamp after refresh",
 			// Replica state.
 			existingTxn:  nil,
-			canCreateTxn: func() (bool, hlc.Timestamp) { return true, hlc.Timestamp{} },
+			canCreateTxn: true,
 			// Request state.
 			headerTxn:      refreshedHeaderTxn,
 			commit:         true,
@@ -284,7 +283,7 @@ func TestEndTxnUpdatesTransactionRecord(t *testing.T) {
 			name: "record missing, can create, try commit at pushed timestamp after refresh",
 			// Replica state.
 			existingTxn:  nil,
-			canCreateTxn: func() (bool, hlc.Timestamp) { return true, hlc.Timestamp{} },
+			canCreateTxn: true,
 			// Request state.
 			headerTxn: refreshedHeaderTxn,
 			commit:    true,
@@ -297,11 +296,12 @@ func TestEndTxnUpdatesTransactionRecord(t *testing.T) {
 		},
 		{
 			// A PushTxn(TIMESTAMP) request bumped the minimum timestamp that the
-			// transaction can be created with. This will trigger a retry error.
-			name: "record missing, can create with min timestamp, try stage",
+			// transaction can be committed with. This will trigger a retry error.
+			name: "record missing, can commit with min timestamp, try stage",
 			// Replica state.
-			existingTxn:  nil,
-			canCreateTxn: func() (bool, hlc.Timestamp) { return true, ts2 },
+			existingTxn:    nil,
+			canCreateTxn:   true,
+			minTxnCommitTS: ts2,
 			// Request state.
 			headerTxn:      headerTxn,
 			commit:         true,
@@ -311,11 +311,12 @@ func TestEndTxnUpdatesTransactionRecord(t *testing.T) {
 		},
 		{
 			// A PushTxn(TIMESTAMP) request bumped the minimum timestamp that the
-			// transaction can be created with. This will trigger a retry error.
-			name: "record missing, can create with min timestamp, try commit",
+			// transaction can be committed with. This will trigger a retry error.
+			name: "record missing, can commit with min timestamp, try commit",
 			// Replica state.
-			existingTxn:  nil,
-			canCreateTxn: func() (bool, hlc.Timestamp) { return true, ts2 },
+			existingTxn:    nil,
+			canCreateTxn:   true,
+			minTxnCommitTS: ts2,
 			// Request state.
 			headerTxn: headerTxn,
 			commit:    true,
@@ -324,12 +325,13 @@ func TestEndTxnUpdatesTransactionRecord(t *testing.T) {
 		},
 		{
 			// A PushTxn(TIMESTAMP) request bumped the minimum timestamp that
-			// the transaction can be created with. Luckily, the transaction has
+			// the transaction can be committed with. Luckily, the transaction has
 			// already refreshed above this time, so it can avoid a retry error.
-			name: "record missing, can create with min timestamp, try stage at pushed timestamp after refresh",
+			name: "record missing, can commit with min timestamp, try stage at pushed timestamp after refresh",
 			// Replica state.
-			existingTxn:  nil,
-			canCreateTxn: func() (bool, hlc.Timestamp) { return true, ts2 },
+			existingTxn:    nil,
+			canCreateTxn:   true,
+			minTxnCommitTS: ts2,
 			// Request state.
 			headerTxn:      refreshedHeaderTxn,
 			commit:         true,
@@ -343,12 +345,13 @@ func TestEndTxnUpdatesTransactionRecord(t *testing.T) {
 		},
 		{
 			// A PushTxn(TIMESTAMP) request bumped the minimum timestamp that
-			// the transaction can be created with. Luckily, the transaction has
+			// the transaction can be committed with. Luckily, the transaction has
 			// already refreshed above this time, so it can avoid a retry error.
-			name: "record missing, can create with min timestamp, try commit at pushed timestamp after refresh",
+			name: "record missing, can commit with min timestamp, try commit at pushed timestamp after refresh",
 			// Replica state.
-			existingTxn:  nil,
-			canCreateTxn: func() (bool, hlc.Timestamp) { return true, ts2 },
+			existingTxn:    nil,
+			canCreateTxn:   true,
+			minTxnCommitTS: ts2,
 			// Request state.
 			headerTxn: refreshedHeaderTxn,
 			commit:    true,
@@ -365,7 +368,7 @@ func TestEndTxnUpdatesTransactionRecord(t *testing.T) {
 			name: "record missing, can create, try stage after write too old",
 			// Replica state.
 			existingTxn:  nil,
-			canCreateTxn: func() (bool, hlc.Timestamp) { return true, hlc.Timestamp{} },
+			canCreateTxn: true,
 			// Request state.
 			headerTxn: func() *roachpb.Transaction {
 				clone := txn.Clone()
@@ -383,7 +386,7 @@ func TestEndTxnUpdatesTransactionRecord(t *testing.T) {
 			name: "record missing, can create, try commit after write too old",
 			// Replica state.
 			existingTxn:  nil,
-			canCreateTxn: func() (bool, hlc.Timestamp) { return true, hlc.Timestamp{} },
+			canCreateTxn: true,
 			// Request state.
 			headerTxn: func() *roachpb.Transaction {
 				clone := txn.Clone()
@@ -407,9 +410,8 @@ func TestEndTxnUpdatesTransactionRecord(t *testing.T) {
 			expTxn: abortedRecord,
 		},
 		{
-			// Standard case where a transaction record is created during a
-			// parallel commit. The record already exists because it has been
-			// heartbeated.
+			// Standard case where a transaction record is staged by a parallel
+			// commit. The record already exists because it has been heartbeated.
 			name: "record pending, try stage",
 			// Replica state.
 			existingTxn: pendingRecord,
@@ -421,9 +423,9 @@ func TestEndTxnUpdatesTransactionRecord(t *testing.T) {
 			expTxn: stagingRecord,
 		},
 		{
-			// Standard case where a transaction record is created during a
-			// non-parallel commit. The record already exists because it has
-			// been heartbeated.
+			// Standard case where a transaction record is committed during a
+			// non-parallel commit. The record already exists because it has been
+			// heartbeated.
 			name: "record pending, try commit",
 			// Replica state.
 			existingTxn: pendingRecord,
@@ -496,6 +498,74 @@ func TestEndTxnUpdatesTransactionRecord(t *testing.T) {
 			}(),
 		},
 		{
+			// A PushTxn(TIMESTAMP) request bumped the minimum timestamp that the
+			// transaction can be committed with. The record already exists because
+			// it has been heartbeated. This will trigger a retry error.
+			name: "record pending, can commit with min timestamp, try stage",
+			// Replica state.
+			existingTxn:    pendingRecord,
+			minTxnCommitTS: ts2,
+			// Request state.
+			headerTxn:      headerTxn,
+			commit:         true,
+			inFlightWrites: writes,
+			// Expected result.
+			expError: "TransactionRetryError: retry txn (RETRY_SERIALIZABLE)",
+		},
+		{
+			// A PushTxn(TIMESTAMP) request bumped the minimum timestamp that the
+			// transaction can be committed with. The record already exists because
+			// it has been heartbeated. This will trigger a retry error.
+			name: "record pending, can commit with min timestamp, try commit",
+			// Replica state.
+			existingTxn:    pendingRecord,
+			minTxnCommitTS: ts2,
+			// Request state.
+			headerTxn: headerTxn,
+			commit:    true,
+			// Expected result.
+			expError: "TransactionRetryError: retry txn (RETRY_SERIALIZABLE)",
+		},
+		{
+			// A PushTxn(TIMESTAMP) request bumped the minimum timestamp that
+			// the transaction can be committed with. The record already exists
+			// because it has been heartbeated. Luckily, the transaction has
+			// already refreshed above this time, so it can avoid a retry error.
+			name: "record pending, can commit with min timestamp, try stage at pushed timestamp after refresh",
+			// Replica state.
+			existingTxn:    pendingRecord,
+			minTxnCommitTS: ts2,
+			// Request state.
+			headerTxn:      refreshedHeaderTxn,
+			commit:         true,
+			inFlightWrites: writes,
+			// Expected result.
+			expTxn: func() *roachpb.TransactionRecord {
+				record := *stagingRecord
+				record.WriteTimestamp.Forward(ts2)
+				return &record
+			}(),
+		},
+		{
+			// A PushTxn(TIMESTAMP) request bumped the minimum timestamp that
+			// the transaction can be committed with. The record already exists
+			// because it has been heartbeated. Luckily, the transaction has
+			// already refreshed above this time, so it can avoid a retry error.
+			name: "record pending, can commit with min timestamp, try commit at pushed timestamp after refresh",
+			// Replica state.
+			existingTxn:    pendingRecord,
+			minTxnCommitTS: ts2,
+			// Request state.
+			headerTxn: refreshedHeaderTxn,
+			commit:    true,
+			// Expected result.
+			expTxn: func() *roachpb.TransactionRecord {
+				record := *committedRecord
+				record.WriteTimestamp.Forward(ts2)
+				return &record
+			}(),
+		},
+		{
 			// The transaction has run into a WriteTooOld error during its
 			// lifetime. The stage will be rejected.
 			name: "record pending, try stage after write too old",
@@ -547,7 +617,7 @@ func TestEndTxnUpdatesTransactionRecord(t *testing.T) {
 			}(),
 		},
 		{
-			// Standard case where a transaction record is created during a
+			// Standard case where a transaction record is staged during a
 			// parallel commit after it has written a record at a lower epoch.
 			// The existing record is upgraded.
 			name: "record pending, try stage at higher epoch",
@@ -566,7 +636,7 @@ func TestEndTxnUpdatesTransactionRecord(t *testing.T) {
 			}(),
 		},
 		{
-			// Standard case where a transaction record is created during a
+			// Standard case where a transaction record is committed during a
 			// non-parallel commit after it has written a record at a lower
 			// epoch. The existing record is upgraded.
 			name: "record pending, try commit at higher epoch",
@@ -628,7 +698,7 @@ func TestEndTxnUpdatesTransactionRecord(t *testing.T) {
 			expError: "found txn in indeterminate STAGING state",
 		},
 		{
-			// Standard case where a transaction record is created during a
+			// Standard case where a transaction record is re-staged during a
 			// parallel commit. The record already exists because of a failed
 			// parallel commit attempt.
 			name: "record staging, try re-stage",
@@ -642,9 +712,9 @@ func TestEndTxnUpdatesTransactionRecord(t *testing.T) {
 			expTxn: stagingRecord,
 		},
 		{
-			// Standard case where a transaction record is created during a
-			// non-parallel commit. The record already exists because of a
-			// failed parallel commit attempt.
+			// Standard case where a transaction record is explicitly committed.
+			// The record already exists and is staging because it was previously
+			// implicitly committed.
 			name: "record staging, try commit",
 			// Replica state.
 			existingTxn: stagingRecord,
@@ -655,8 +725,39 @@ func TestEndTxnUpdatesTransactionRecord(t *testing.T) {
 			expTxn: committedRecord,
 		},
 		{
-			// Non-standard case where a transaction record is created during a
+			// Standard case where a transaction record is re-staged during a
 			// parallel commit. The record already exists because of a failed
+			// parallel commit attempt. The timestamp cache's minimum commit
+			// timestamp is ignored when the transaction record is staging.
+			name: "record staging, can commit with min timestamp, try re-stage",
+			// Replica state.
+			existingTxn: stagingRecord,
+			// Request state.
+			headerTxn:      headerTxn,
+			minTxnCommitTS: ts2,
+			commit:         true,
+			inFlightWrites: writes,
+			// Expected result.
+			expTxn: stagingRecord,
+		},
+		{
+			// Non-standard case where a transaction record is explicitly committed.
+			// The record already exists and is staging because it was previously
+			// implicitly committed. The timestamp cache's minimum commit timestamp is
+			// ignored when the transaction record is staging.
+			name: "record staging, can commit with min timestamp, try commit",
+			// Replica state.
+			existingTxn:    stagingRecord,
+			minTxnCommitTS: ts2,
+			// Request state.
+			headerTxn: headerTxn,
+			commit:    true,
+			// Expected result.
+			expTxn: committedRecord,
+		},
+		{
+			// Non-standard case where a transaction record is re-staged during
+			// a parallel commit. The record already exists because of a failed
 			// parallel commit attempt. The re-stage will fail because of the
 			// pushed timestamp.
 			name: "record staging, try re-stage at pushed timestamp",
@@ -670,7 +771,7 @@ func TestEndTxnUpdatesTransactionRecord(t *testing.T) {
 			expError: "TransactionRetryError: retry txn (RETRY_SERIALIZABLE)",
 		},
 		{
-			// Non-standard case where a transaction record is created during
+			// Non-standard case where a transaction record is committed during
 			// a non-parallel commit. The record already exists because of a
 			// failed parallel commit attempt. The commit will fail because of
 			// the pushed timestamp.
@@ -702,8 +803,8 @@ func TestEndTxnUpdatesTransactionRecord(t *testing.T) {
 			}(),
 		},
 		{
-			// Non-standard case where a transaction record is created during a
-			// parallel commit. The record already exists because of a failed
+			// Non-standard case where a transaction record is re-staged during
+			// a parallel commit. The record already exists because of a failed
 			// parallel commit attempt in a prior epoch.
 			name: "record staging, try re-stage at higher epoch",
 			// Replica state.
@@ -721,7 +822,7 @@ func TestEndTxnUpdatesTransactionRecord(t *testing.T) {
 			}(),
 		},
 		{
-			// Non-standard case where a transaction record is created during
+			// Non-standard case where a transaction record is committed during
 			// a non-parallel commit. The record already exists because of a
 			// failed parallel commit attempt in a prior epoch.
 			name: "record staging, try commit at higher epoch",
@@ -739,8 +840,8 @@ func TestEndTxnUpdatesTransactionRecord(t *testing.T) {
 			}(),
 		},
 		{
-			// Non-standard case where a transaction record is created during a
-			// parallel commit. The record already exists because of a failed
+			// Non-standard case where a transaction record is re-staged during
+			// a parallel commit. The record already exists because of a failed
 			// parallel commit attempt in a prior epoch. The re-stage will fail
 			// because of the pushed timestamp.
 			name: "record staging, try re-stage at higher epoch and pushed timestamp",
@@ -754,8 +855,8 @@ func TestEndTxnUpdatesTransactionRecord(t *testing.T) {
 			expError: "TransactionRetryError: retry txn (RETRY_SERIALIZABLE)",
 		},
 		{
-			// Non-standard case where a transaction record is created during a
-			// non-parallel commit. The record already exists because of a
+			// Non-standard case where a transaction record is committed during
+			// a non-parallel commit. The record already exists because of a
 			// failed parallel commit attempt in a prior epoch. The commit will
 			// fail because of the pushed timestamp.
 			name: "record staging, try commit at higher epoch and pushed timestamp",
@@ -936,12 +1037,14 @@ func TestEndTxnUpdatesTransactionRecord(t *testing.T) {
 				EvalCtx: (&MockEvalCtx{
 					Desc:      &desc,
 					AbortSpan: as,
-					CanCreateTxn: func() (bool, hlc.Timestamp, roachpb.TransactionAbortedReason) {
-						require.NotNil(t, c.canCreateTxn, "CanCreateTxnRecord unexpectedly called")
-						if can, minTS := c.canCreateTxn(); can {
-							return true, minTS, 0
+					CanCreateTxnRecordFn: func() (bool, roachpb.TransactionAbortedReason) {
+						if c.canCreateTxn {
+							return true, 0
 						}
-						return false, hlc.Timestamp{}, roachpb.ABORT_REASON_ABORTED_RECORD_FOUND
+						return false, roachpb.ABORT_REASON_ABORTED_RECORD_FOUND
+					},
+					MinTxnCommitTSFn: func() hlc.Timestamp {
+						return c.minTxnCommitTS
 					},
 				}).EvalContext(),
 				Args: &req,
@@ -1047,9 +1150,6 @@ func TestPartialRollbackOnEndTransaction(t *testing.T) {
 		if _, err := EndTxn(ctx, batch, CommandArgs{
 			EvalCtx: (&MockEvalCtx{
 				Desc: &desc,
-				CanCreateTxn: func() (bool, hlc.Timestamp, roachpb.TransactionAbortedReason) {
-					return true, ts, 0
-				},
 			}).EvalContext(),
 			Args: &req,
 			Header: roachpb.Header{
@@ -1162,9 +1262,6 @@ func TestCommitWaitBeforeIntentResolutionIfCommitTrigger(t *testing.T) {
 					EvalCtx: (&MockEvalCtx{
 						Desc:  &desc,
 						Clock: clock,
-						CanCreateTxn: func() (bool, hlc.Timestamp, roachpb.TransactionAbortedReason) {
-							return true, hlc.Timestamp{}, 0
-						},
 					}).EvalContext(),
 					Args: &req,
 					Header: roachpb.Header{

--- a/pkg/kv/kvserver/batcheval/cmd_push_txn.go
+++ b/pkg/kv/kvserver/batcheval/cmd_push_txn.go
@@ -15,6 +15,7 @@ import (
 	"context"
 	"time"
 
+	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/batcheval/result"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/spanset"
@@ -298,10 +299,21 @@ func PushTxn(
 	case roachpb.PUSH_ABORT:
 		// If aborting the transaction, set the new status.
 		reply.PusheeTxn.Status = roachpb.ABORTED
-		// If the transaction record was already present, forward the timestamp
-		// to accommodate AbortSpan GC. See method comment for details.
+		// Forward the timestamp to accommodate AbortSpan GC. See method comment for
+		// details.
+		reply.PusheeTxn.WriteTimestamp.Forward(reply.PusheeTxn.LastActive())
+		// If the transaction record was already present, persist the updates to it.
+		// If not, then we don't want to create it. This could allow for finalized
+		// transactions to be revived. Instead, we obey the invariant that only the
+		// transaction's own coordinator can issue requests that create its
+		// transaction record. To ensure that a timestamp push or an abort is
+		// respected for transactions without transaction records, we rely on markers
+		// in the timestamp cache.
 		if ok {
-			reply.PusheeTxn.WriteTimestamp.Forward(reply.PusheeTxn.LastActive())
+			txnRecord := reply.PusheeTxn.AsRecord()
+			if err := storage.MVCCPutProto(ctx, readWriter, cArgs.Stats, key, hlc.Timestamp{}, hlc.ClockTimestamp{}, nil, &txnRecord); err != nil {
+				return result.Result{}, err
+			}
 		}
 	case roachpb.PUSH_TIMESTAMP:
 		if existTxn.Status != roachpb.PENDING {
@@ -309,27 +321,23 @@ func PushTxn(
 				"PUSH_TIMESTAMP succeeded against non-PENDING txn: %v", existTxn)
 		}
 		// Otherwise, update timestamp to be one greater than the request's
-		// timestamp. This new timestamp will be use to update the read timestamp
-		// cache. If the transaction record was not already present then we rely on
-		// the timestamp cache to prevent the record from ever being written with a
-		// timestamp beneath this timestamp.
+		// timestamp. This new timestamp will be used to update the read timestamp
+		// cache. We rely on the timestamp cache to prevent the record from ever
+		// being committed with a timestamp beneath this timestamp.
 		reply.PusheeTxn.WriteTimestamp.Forward(args.PushTo)
+		// If the transaction record was already present, continue to update the
+		// transaction record until all nodes are running v23.1. v22.2 nodes won't
+		// know to check the timestamp cache again on commit to learn about any
+		// successful timestamp pushes.
+		// TODO(nvanbenschoten): remove this logic in v23.2.
+		if ok && !cArgs.EvalCtx.ClusterSettings().Version.IsActive(ctx, clusterversion.V23_1) {
+			txnRecord := reply.PusheeTxn.AsRecord()
+			if err := storage.MVCCPutProto(ctx, readWriter, cArgs.Stats, key, hlc.Timestamp{}, hlc.ClockTimestamp{}, nil, &txnRecord); err != nil {
+				return result.Result{}, err
+			}
+		}
 	default:
 		return result.Result{}, errors.AssertionFailedf("unexpected push type: %v", pushType)
-	}
-
-	// If the transaction record was already present, persist the updates to it.
-	// If not, then we don't want to create it. This could allow for finalized
-	// transactions to be revived. Instead, we obey the invariant that only the
-	// transaction's own coordinator can issue requests that create its
-	// transaction record. To ensure that a timestamp push or an abort is
-	// respected for transactions without transaction records, we rely on markers
-	// in the timestamp cache.
-	if ok {
-		txnRecord := reply.PusheeTxn.AsRecord()
-		if err := storage.MVCCPutProto(ctx, readWriter, cArgs.Stats, key, hlc.Timestamp{}, hlc.ClockTimestamp{}, nil, &txnRecord); err != nil {
-			return result.Result{}, err
-		}
 	}
 
 	result := result.Result{}

--- a/pkg/kv/kvserver/batcheval/transaction_test.go
+++ b/pkg/kv/kvserver/batcheval/transaction_test.go
@@ -739,9 +739,6 @@ func TestUpdateAbortSpan(t *testing.T) {
 				ClusterSettings: st,
 				Desc:            &desc,
 				AbortSpan:       as,
-				CanCreateTxn: func() (bool, hlc.Timestamp, roachpb.TransactionAbortedReason) {
-					return true, hlc.Timestamp{}, 0
-				},
 			}
 			ms := enginepb.MVCCStats{}
 			if c.before != nil {

--- a/pkg/kv/kvserver/replica_eval_context_span.go
+++ b/pkg/kv/kvserver/replica_eval_context_span.go
@@ -146,11 +146,23 @@ func (rec SpanSetReplicaEvalContext) GetLastSplitQPS(ctx context.Context) float6
 // for details about its arguments, return values, and preconditions.
 func (rec SpanSetReplicaEvalContext) CanCreateTxnRecord(
 	ctx context.Context, txnID uuid.UUID, txnKey []byte, txnMinTS hlc.Timestamp,
-) (bool, hlc.Timestamp, roachpb.TransactionAbortedReason) {
+) (bool, roachpb.TransactionAbortedReason) {
 	rec.ss.AssertAllowed(spanset.SpanReadOnly,
 		roachpb.Span{Key: keys.TransactionKey(txnKey, txnID)},
 	)
 	return rec.i.CanCreateTxnRecord(ctx, txnID, txnKey, txnMinTS)
+}
+
+// MinTxnCommitTS determines the minimum timestamp at which a transaction with
+// the provided ID and key can commit. See Replica.MinTxnCommitTS for details
+// about its arguments, return values, and preconditions.
+func (rec SpanSetReplicaEvalContext) MinTxnCommitTS(
+	ctx context.Context, txnID uuid.UUID, txnKey []byte,
+) hlc.Timestamp {
+	rec.ss.AssertAllowed(spanset.SpanReadOnly,
+		roachpb.Span{Key: keys.TransactionKey(txnKey, txnID)},
+	)
+	return rec.i.MinTxnCommitTS(ctx, txnID, txnKey)
 }
 
 // GetGCThreshold returns the GC threshold of the Range, typically updated when

--- a/pkg/kv/kvserver/replica_test.go
+++ b/pkg/kv/kvserver/replica_test.go
@@ -12290,9 +12290,9 @@ func TestTxnRecordLifecycleTransitions(t *testing.T) {
 				return sendWrappedWithErr(roachpb.Header{}, &pt)
 			},
 			expTxn: func(txn *roachpb.Transaction, pushTs hlc.Timestamp) roachpb.TransactionRecord {
-				record := txn.AsRecord()
+				record := txnWithStatus(roachpb.ABORTED)(txn, pushTs)
 				record.Epoch = txn.Epoch + 1
-				record.WriteTimestamp.Forward(pushTs)
+				record.WriteTimestamp = record.WriteTimestamp.Add(0, 1)
 				record.Priority = pusher.Priority - 1
 				return record
 			},

--- a/pkg/kv/kvserver/replica_test.go
+++ b/pkg/kv/kvserver/replica_test.go
@@ -11991,12 +11991,11 @@ func TestTxnRecordLifecycleTransitions(t *testing.T) {
 				pt.PushTo = now
 				return sendWrappedWithErr(roachpb.Header{}, &pt)
 			},
-			expTxn: func(txn *roachpb.Transaction, pushTs hlc.Timestamp) roachpb.TransactionRecord {
-				record := txn.AsRecord()
-				record.WriteTimestamp.Forward(pushTs)
-				record.Priority = pusher.Priority - 1
-				return record
-			},
+			// The transaction record **is not** updated in this case. Instead, the
+			// push is communicated through the timestamp cache. When the pushee goes
+			// to commit, it will consult the timestamp cache and find that it must
+			// commit above the push timestamp.
+			expTxn: txnWithoutChanges,
 		},
 		{
 			name: "push transaction (abort) after heartbeat transaction",

--- a/pkg/kv/kvserver/replica_tscache.go
+++ b/pkg/kv/kvserver/replica_tscache.go
@@ -390,11 +390,9 @@ func (r *Replica) applyTimestampCache(
 // the provided transaction information. Callers must provide the transaction's
 // minimum timestamp across all epochs, along with its ID and its key.
 //
-// If the method return true, it also returns the minimum provisional commit
-// timestamp that the record can be created with. If the method returns false,
-// it returns the reason that transaction record was rejected. If the method
-// ever determines that a transaction record must be rejected, it will continue
-// to reject that transaction going forwards.
+// If the method returns false, it returns the reason that transaction record
+// was rejected. If the method ever determines that a transaction record must be
+// rejected, it will continue to reject that transaction going forwards.
 //
 // The method performs two critical roles:
 //
@@ -403,14 +401,17 @@ func (r *Replica) applyTimestampCache(
 //     to be created after the transaction has already been finalized and its
 //     record cleaned up.
 //
-//  2. It serves as the mechanism by which successful push requests convey
-//     information to transactions who have not yet written their transaction
-//     record. In doing so, it ensures that transaction records are created
-//     with a sufficiently high timestamp after a successful PushTxn(TIMESTAMP)
-//     and ensures that transactions records are never created at all after a
-//     successful PushTxn(ABORT). As a result of this mechanism, a transaction
-//     never needs to explicitly create the transaction record for contending
-//     transactions.
+//  2. It serves as the mechanism through which successful PushTxn(ABORT)
+//     requests convey information to pushee transactions who have not yet
+//     written their transaction record. In doing so, it ensures that
+//     transactions records are never created for the pushee after a successful
+//     PushTxn(ABORT). As a result of this mechanism, a pusher transaction never
+//     needs to create the transaction record for contending transactions that
+//     it forms write-write conflicts with.
+//
+//     NOTE: write-read conflicts result in PushTxn(TIMESTAMP) requests, which
+//     coordinate with pushee transactions through the MinTxnCommitTS mechanism
+//     (see below).
 //
 // In addition, it is used when considering 1PC evaluation, to avoid checking
 // for a transaction record on disk.
@@ -431,10 +432,10 @@ func (r *Replica) applyTimestampCache(
 //	                                                                   HeartbeatTxn
 //	                 PushTxn(TIMESTAMP)                              then: update record
 //	                 then: v1 -> push.ts                                   v2 -> txn.ts
-//	                     +------+        HeartbeatTxn                    +------+
-//	   PushTxn(ABORT)    |      |        if: v2 < txn.orig               |      |   PushTxn(TIMESTAMP)
-//	  then: v2 -> txn.ts |      v        then: txn.ts -> v1              |      v  then: update record
-//	                +-----------------+        v2 -> txn.ts      +--------------------+
+//	                     +------+                                        +------+
+//	   PushTxn(ABORT)    |      |        HeartbeatTxn                    |      |   PushTxn(TIMESTAMP)
+//	  then: v2 -> txn.ts |      v        if: v2 < txn.orig               |      v  then: v1 -> push.ts
+//	                +-----------------+  then: v2 -> txn.ts      +--------------------+
 //	           +----|                 |  else: fail              |                    |----+
 //	           |    |                 |------------------------->|                    |    |
 //	           |    |  no txn record  |                          | txn record written |    |
@@ -442,22 +443,23 @@ func (r *Replica) applyTimestampCache(
 //	                |                 |__  if: v2 < txn.orig     |                    |
 //	                +-----------------+  \__ then: txn.ts -> v1  +--------------------+
 //	                   |            ^       \__ else: fail       _/   |            ^
-//	                   |            |          \__             _/     |            |
-//	EndTxn(!STAGING)   |            |             \__        _/       | EndTxn(STAGING)
-//	if: v2 < txn.orig  |   Eager GC |                \____ _/______   |            |
-//	then: v2 -> txn.ts |      or    |                    _/        \  |            | HeartbeatTxn
+//	EndTxn(!STAGING)   |            |          \__             _/     | EndTxn(STAGING)
+//	if: v2 < txn.orig  |            |             \__        _/       | then: txn.ts -> v1
+//	then: txn.ts -> v1 |   Eager GC |                \____ _/______   |            |
+//	      v2 -> txn.ts |      or    |                    _/        \  |            | HeartbeatTxn
 //	else: fail         |   GC queue |  /----------------/          |  |            | if: epoch update
 //	                   v            | v    EndTxn(!STAGING)        v  v            |
 //	               +--------------------+  or PushTxn(ABORT)     +--------------------+
-//	               |                    |  then: v2 -> txn.ts    |                    |
-//	          +--->|                    |<-----------------------|                    |----+
+//	               |                    |  then: txn.ts -> v1    |                    |
+//	               |                    |        v2 -> txn.ts    |                    |
+//	          +--->|                    |                        |                    |----+
 //	          |    | txn record written |                        | txn record written |    |
 //	          |    |     [finalized]    |                        |      [staging]     |    |
 //	          +----|                    |                        |                    |<---+
-//	  PushTxn(*)   +--------------------+                        +--------------------+
-//	  then: no-op                    ^   PushTxn(*) + RecoverTxn    |              EndTxn(STAGING)
-//	                                 |     then: v2 -> txn.ts       |              or HeartbeatTxn
-//	                                 +------------------------------+            then: update record
+//	  PushTxn(*)   +--------------------+  EndTxn(!STAGING)      +--------------------+
+//	  then: no-op                    ^     or PushTxn(*) + RecoverTxn   |          EndTxn(STAGING)
+//	                                 |     then: v2 -> txn.ts           |          or HeartbeatTxn
+//	                                 +----------------------------------+        then: update record
 //
 // In the diagram, CanCreateTxnRecord is consulted in all three of the
 // state transitions that move away from the "no txn record" state.
@@ -518,27 +520,17 @@ func (r *Replica) applyTimestampCache(
 // system.
 func (r *Replica) CanCreateTxnRecord(
 	ctx context.Context, txnID uuid.UUID, txnKey []byte, txnMinTS hlc.Timestamp,
-) (ok bool, minCommitTS hlc.Timestamp, reason roachpb.TransactionAbortedReason) {
-	// Consult the timestamp cache with the transaction's key. The timestamp
-	// cache is used in two ways for transactions without transaction records.
-	// The timestamp cache is used to push the timestamp of transactions
-	// that don't have transaction records. The timestamp cache is used
-	// to abort transactions entirely that don't have transaction records.
+) (ok bool, reason roachpb.TransactionAbortedReason) {
+	// Consult the timestamp cache with the transaction's key. The timestamp cache
+	// is used to abort transactions that don't have transaction records.
 	//
 	// Using this strategy, we enforce the invariant that only requests sent
 	// from a transaction's own coordinator can create its transaction record.
 	// However, once a transaction record is written, other concurrent actors
 	// can modify it. This is reflected in the diagram above.
 	tombstoneKey := transactionTombstoneMarker(txnKey, txnID)
-	pushKey := transactionPushMarker(txnKey, txnID)
 
-	// Look in the timestamp cache to see if there is an entry for this
-	// transaction, which indicates the minimum timestamp that the transaction
-	// can commit at. This is used by pushers to push the timestamp of a
-	// transaction that hasn't yet written its transaction record.
-	minCommitTS, _ = r.store.tsCache.GetMax(pushKey, nil /* end */)
-
-	// Also look in the timestamp cache to see if there is a tombstone entry for
+	// Look in the timestamp cache to see if there is a tombstone entry for
 	// this transaction, which indicates that this transaction has already written
 	// a transaction record. If there is an entry, then we return a retriable
 	// error: if this is a re-evaluation, then the error will be transformed into
@@ -561,26 +553,54 @@ func (r *Replica) CanCreateTxnRecord(
 			// If there were other requests in the EndTxn batch, then the client would
 			// still have trouble reconstructing the result, but at least it could
 			// provide a non-ambiguous error to the application.
-			return false, hlc.Timestamp{},
-				roachpb.ABORT_REASON_RECORD_ALREADY_WRITTEN_POSSIBLE_REPLAY
+			return false, roachpb.ABORT_REASON_RECORD_ALREADY_WRITTEN_POSSIBLE_REPLAY
 		case uuid.Nil:
 			lease, _ /* nextLease */ := r.GetLease()
 			// Recognize the case where a lease started recently. Lease transfers bump
 			// the ts cache low water mark.
 			if tombstoneTimestamp == lease.Start.ToTimestamp() {
-				return false, hlc.Timestamp{}, roachpb.ABORT_REASON_NEW_LEASE_PREVENTS_TXN
+				return false, roachpb.ABORT_REASON_NEW_LEASE_PREVENTS_TXN
 			}
-			return false, hlc.Timestamp{}, roachpb.ABORT_REASON_TIMESTAMP_CACHE_REJECTED
+			return false, roachpb.ABORT_REASON_TIMESTAMP_CACHE_REJECTED
 		default:
 			// If we find another transaction's ID then that transaction has
 			// aborted us before our transaction record was written. It obeyed
 			// the restriction that it couldn't create a transaction record for
 			// us, so it recorded a tombstone cache instead to prevent us
 			// from ever creating a transaction record.
-			return false, hlc.Timestamp{}, roachpb.ABORT_REASON_ABORTED_RECORD_FOUND
+			return false, roachpb.ABORT_REASON_ABORTED_RECORD_FOUND
 		}
 	}
-	return true, minCommitTS, 0
+
+	return true, 0
+}
+
+// MinTxnCommitTS determines the minimum timestamp at which a transaction with
+// the provided ID and key can commit.
+//
+// The method serves as a mechanism through which successful PushTxn(TIMESTAMP)
+// requests convey information to pushee transactions. In doing so, it ensures
+// that transaction records are committed with a sufficiently high timestamp
+// after a successful PushTxn(TIMESTAMP). As a result of this mechanism, a
+// transaction never needs to write to the transaction record for contending
+// transactions that it forms write-read conflicts with.
+//
+// NOTE: write-write conflicts result in PushTxn(ABORT) requests, which
+// coordinate with pushee transactions through the CanCreateTxnRecord mechanism
+// (see above).
+//
+// The mechanism is detailed in the transaction record state machine above on
+// CanCreateTxnRecord.
+func (r *Replica) MinTxnCommitTS(
+	ctx context.Context, txnID uuid.UUID, txnKey []byte,
+) hlc.Timestamp {
+	// Look in the timestamp cache to see if there is a push marker entry for this
+	// transaction, which contains the minimum timestamp that the transaction can
+	// commit at. This is used by pushers to push the timestamp of a transaction
+	// without writing to the pushee's transaction record.
+	pushKey := transactionPushMarker(txnKey, txnID)
+	minCommitTS, _ := r.store.tsCache.GetMax(pushKey, nil /* end */)
+	return minCommitTS
 }
 
 // Pseudo range local key suffixes used to construct "marker" keys for use


### PR DESCRIPTION
This PR contains a sequence of three commits that combine to resolve https://github.com/cockroachdb/cockroach/issues/94728.

### check txn push marker on commit, not txn record creation

The first commit moves the point when a transaction checks the timestamp cache for its minimum commit timestamp from transaction record creation time back to commit time. This allows us to use the timestamp cache to communicate successful `PushTxn(TIMESTAMP)` to a pushee with an existing record without rewriting its transaction record.

For details, see the changes to the state machine diagram attached to `Replica.CanCreateTxnRecord` for a visual depiction of this change.

### always promote PUSH_TIMESTAMP to PUSH_ABORT on failed staging record 

The second commit simplifies logic in PushTxnRequest that promoted a `PUSH_TIMESTAMP` to a `PUSH_ABORT` when it 
 found a STAGING transaction record that it knew to be part of a failed parallel commit attempt.

The logic tried to be smart and minimize the cases where it needed to promote a `PUSH_TIMESTAMP` to a `PUSH_ABORT`. It was avoiding doing so if it had previously found an intent with a higher epoch. In practice, this optimization doesn't seem to matter. It was also making logic in a following commit harder to write because it was preserving cases where a `PUSH_TIMESTAMP` would succeed against a STAGING transaction record. We don't want to support such state transitions, so eliminate them.

### don't rewrite txn record on PushTxn(TIMESTAMP)

With the previous two commits, transactions will check the timestamp cache before committing to determine whether they have had their commit timestamp pushed. The final commit exploits this to avoid ever rewriting a transaction's record on a timestamp push. Instead, the timestamp cache is used, regardless of whether the record already existed or not. Doing so avoids consensus.

Release note: None