### PR TITLE
sql: improve the handling of tenant capabilities (fixups for #95013)

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/tenant_capability
+++ b/pkg/ccl/logictestccl/testdata/logic_test/tenant_capability
@@ -3,16 +3,19 @@
 statement ok
 SELECT crdb_internal.create_tenant(5, 'five')
 
-statement error error parsing capability "not_a_capability": invalid capability
+statement error unknown capability: "not_a_capability"
 ALTER TENANT [5] GRANT CAPABILITY not_a_capability=true
 
-statement error error parsing capability "can_admin_split": value must be bool
+statement error argument of ALTER TENANT CAPABILITY can_admin_split must be type bool, not type int
 ALTER TENANT [5] GRANT CAPABILITY can_admin_split=1
 
-statement error error parsing capability "not_a_capability": invalid capability
+statement error parameter "can_admin_split" requires a Boolean value
+ALTER TENANT [5] GRANT CAPABILITY can_admin_split=NULL
+
+statement error unknown capability: "not_a_capability"
 ALTER TENANT [5] REVOKE CAPABILITY not_a_capability
 
-statement error error parsing capability "can_admin_split": revoke must not specify value
+statement error no value allowed in revoke: "can_admin_split"
 ALTER TENANT [5] REVOKE CAPABILITY can_admin_split=false
 
 query ITTTT colnames
@@ -24,6 +27,10 @@ id  name  status  capability_name    capability_value
 
 statement ok
 ALTER TENANT [5] GRANT CAPABILITY can_admin_split=true
+
+# Check that composite expressions are evaluated properly.
+statement ok
+ALTER TENANT [5] GRANT CAPABILITY can_admin_split=(2=1+1)
 
 query ITTTT colnames
 SHOW TENANT 'five' WITH CAPABILITIES

--- a/pkg/sql/paramparse/paramparse.go
+++ b/pkg/sql/paramparse/paramparse.go
@@ -135,6 +135,25 @@ func DatumAsString(
 	return string(s), nil
 }
 
+// DatumAsBool transforms a tree.TypedExpr containing a Datum into a bool.
+func DatumAsBool(
+	ctx context.Context, evalCtx *eval.Context, name string, value tree.TypedExpr,
+) (bool, error) {
+	val, err := eval.Expr(ctx, evalCtx, value)
+	if err != nil {
+		return false, err
+	}
+	b, ok := tree.AsDBool(val)
+	if !ok {
+		err = pgerror.Newf(pgcode.InvalidParameterValue,
+			"parameter %q requires a Boolean value", name)
+		err = errors.WithDetailf(err,
+			"%s is a %s", value, errors.Safe(val.ResolvedType()))
+		return false, err
+	}
+	return bool(b), nil
+}
+
 // GetSingleBool returns the boolean if the input Datum is a DBool,
 // and returns a detailed error message if not.
 func GetSingleBool(name string, val tree.Datum) (*tree.DBool, error) {

--- a/pkg/sql/sem/tree/alter_tenant.go
+++ b/pkg/sql/sem/tree/alter_tenant.go
@@ -10,8 +10,6 @@
 
 package tree
 
-import "github.com/cockroachdb/errors"
-
 // ReplicationCutoverTime represent the user-specified cutover time
 type ReplicationCutoverTime struct {
 	Timestamp Expr
@@ -54,20 +52,6 @@ func (n *AlterTenantReplication) Format(ctx *FmtCtx) {
 type TenantCapability struct {
 	Name  string
 	Value Expr
-}
-
-func (c *TenantCapability) GetBoolValue(isRevoke bool) (bool, error) {
-	if c.Value == nil {
-		return false, nil
-	}
-	if isRevoke {
-		return false, errors.New("revoke must not specify value")
-	}
-	dBool, ok := AsDBool(c.Value)
-	if !ok {
-		return false, errors.New("value must be bool")
-	}
-	return bool(dBool), nil
 }
 
 // AlterTenantCapability represents an ALTER TENANT CAPABILITY statement.

--- a/pkg/sql/show_tenant.go
+++ b/pkg/sql/show_tenant.go
@@ -238,11 +238,12 @@ func (n *showTenantNode) getTenantValues(
 		capabilities := tenantInfo.Capabilities
 		values.capabilities = []showTenantNodeCapability{
 			{
-				name:  CanAdminSplitCapabilityName,
+				name:  canAdminSplitCapabilityName,
 				value: strconv.FormatBool(capabilities.CanAdminSplit),
 			},
 			{
-				name:  CanAdminUnsplitCapabilityName,
+				name: canAdminUnsplitCapabilityName,
+				// TODO(sql-sessions): handle this capability.
 				value: strconv.FormatBool(false),
 			},
 		}


### PR DESCRIPTION
The previous change had a few shortcomings:
- did not properly separate prepare/planning from execute.
- put evaluation code in the 'tree' package (we want it in sql)
- didn't set a foundation for non-bool capabilities

This commit fixes that.

Release note: None
Epic: CRDB-19504