### PR TITLE
ui: hide list of statement for non-admins

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/indexDetailsPage/indexDetailsPage.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/indexDetailsPage/indexDetailsPage.tsx
@@ -395,47 +395,49 @@ export class IndexDetailsPage extends React.Component<
                 </SummaryCard>
               </Col>
             </Row>
-            <Row gutter={24} className={cx("row-spaced", "bottom-space")}>
-              <Col className="gutter-row" span={24}>
-                <SummaryCard className={cx("summary-card--row")}>
-                  <Heading type="h5">Index Usage</Heading>
-                  <TableStatistics
-                    pagination={stmtPagination}
-                    totalCount={statements.length}
-                    arrayItemName={"statement fingerprints using this index"}
-                    activeFilters={0}
-                  />
-                  <SortedTable
-                    data={statements}
-                    columns={makeStatementsColumns(
-                      statements,
-                      [],
-                      calculateTotalWorkload(statements),
-                      "statement",
-                      isTenant,
-                      hasViewActivityRedactedRole,
-                    ).filter(c => !(isTenant && c.hideIfTenant))}
-                    className={stmtCx("statements-table")}
-                    tableWrapperClassName={cx("table-scroll")}
-                    sortSetting={stmtSortSetting}
-                    onChangeSortSetting={this.onChangeSortSetting}
-                    pagination={stmtPagination}
-                    renderNoResult={
-                      <EmptyStatementsPlaceholder
-                        isEmptySearchResults={isEmptySearchResults}
-                        statementView={StatementViewType.USING_INDEX}
-                      />
-                    }
-                  />
-                  <Pagination
-                    pageSize={stmtPagination.pageSize}
-                    current={stmtPagination.current}
-                    total={statements.length}
-                    onChange={this.onChangePage}
-                  />
-                </SummaryCard>
-              </Col>
-            </Row>
+            {hasAdminRole && (
+              <Row gutter={24} className={cx("row-spaced", "bottom-space")}>
+                <Col className="gutter-row" span={24}>
+                  <SummaryCard className={cx("summary-card--row")}>
+                    <Heading type="h5">Index Usage</Heading>
+                    <TableStatistics
+                      pagination={stmtPagination}
+                      totalCount={statements.length}
+                      arrayItemName={"statement fingerprints using this index"}
+                      activeFilters={0}
+                    />
+                    <SortedTable
+                      data={statements}
+                      columns={makeStatementsColumns(
+                        statements,
+                        [],
+                        calculateTotalWorkload(statements),
+                        "statement",
+                        isTenant,
+                        hasViewActivityRedactedRole,
+                      ).filter(c => !(isTenant && c.hideIfTenant))}
+                      className={stmtCx("statements-table")}
+                      tableWrapperClassName={cx("table-scroll")}
+                      sortSetting={stmtSortSetting}
+                      onChangeSortSetting={this.onChangeSortSetting}
+                      pagination={stmtPagination}
+                      renderNoResult={
+                        <EmptyStatementsPlaceholder
+                          isEmptySearchResults={isEmptySearchResults}
+                          statementView={StatementViewType.USING_INDEX}
+                        />
+                      }
+                    />
+                    <Pagination
+                      pageSize={stmtPagination.pageSize}
+                      current={stmtPagination.current}
+                      total={statements.length}
+                      onChange={this.onChangePage}
+                    />
+                  </SummaryCard>
+                </Col>
+              </Row>
+            )}
           </section>
         </div>
       </div>


### PR DESCRIPTION
To get the list of fingerprints used by an index, we use the `system.statement_statistics` directly, but non-admins don't have access to system table.
Until #95756 or #95770 are done, we need to hide
this feature for non-admins.

Part Of #93087

Release note (ui change): Hide list of used fingerprint per index on Index Details page, for non-admin users.