### PR TITLE
eval: fix internal error casting bytes to bit

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/show_ranges
+++ b/pkg/sql/logictest/testdata/logic_test/show_ranges
@@ -446,3 +446,11 @@ start_key                 end_key                  range_id  lease_holder  split
 <before:/Table/106/1/10>  …/20                     59        1             2262-04-11 23:47:16.854776 +0000 +0000
 …/20                      …/30                     60        1             2262-04-11 23:47:16.854776 +0000 +0000
 …/30                      <after:/Table/107/1/42>  61        1             2262-04-11 23:47:16.854776 +0000 +0000
+
+subtest cast_error
+
+statement ok
+CREATE TABLE v0 (c1 BIT PRIMARY KEY );
+
+statement error pgcode 42846 pq: crdb_internal.encode_key\(\): invalid cast: bytes -> bit
+SHOW RANGE FROM TABLE v0 FOR ROW ( b'\x68')

--- a/pkg/sql/sem/eval/cast.go
+++ b/pkg/sql/sem/eval/cast.go
@@ -149,10 +149,12 @@ func performCastWithoutPrecisionTruncation(
 			}
 			ba = &tree.DBitArray{BitArray: res}
 		}
-		if truncateWidth {
-			ba = tree.FormatBitArrayToType(ba, t)
+		if ba != nil {
+			if truncateWidth {
+				ba = tree.FormatBitArrayToType(ba, t)
+			}
+			return ba, nil
 		}
-		return ba, nil
 
 	case types.BoolFamily:
 		switch v := d.(type) {


### PR DESCRIPTION
Fixes #95543

Release note (bug fix): This patch fixes an internal error which may occur in the SHOW RANGE FROM TABLE statement when the FOR ROW clause specifies a BYTE literal and the corresponding column data type is BIT.