### PR TITLE
kv: add MVCC local timestamp details to ReadWithinUncertaintyIntervalError

### DIFF
--- a/pkg/kv/kvclient/kvcoord/dist_sender_server_test.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender_server_test.go
@@ -1811,7 +1811,7 @@ func TestPropagateTxnOnError(t *testing.T) {
 			case *roachpb.ConditionalPutRequest:
 				if k.Equal(keyB) {
 					if atomic.AddInt32(&numCPuts, 1) == 1 {
-						pErr := roachpb.NewReadWithinUncertaintyIntervalError(hlc.Timestamp{}, hlc.Timestamp{}, hlc.ClockTimestamp{}, nil)
+						pErr := roachpb.NewReadWithinUncertaintyIntervalError(hlc.Timestamp{}, hlc.ClockTimestamp{}, nil, hlc.Timestamp{})
 						return roachpb.NewErrorWithTxn(pErr, fArgs.Hdr.Txn)
 					}
 				}
@@ -2046,7 +2046,7 @@ func TestTxnCoordSenderRetries(t *testing.T) {
 					return nil
 				}
 				err := roachpb.NewReadWithinUncertaintyIntervalError(
-					fArgs.Hdr.Timestamp, s.Clock().Now(), hlc.ClockTimestamp{}, fArgs.Hdr.Txn)
+					fArgs.Hdr.Timestamp, hlc.ClockTimestamp{}, fArgs.Hdr.Txn, s.Clock().Now())
 				return roachpb.NewErrorWithTxn(err, fArgs.Hdr.Txn)
 			}
 			return nil

--- a/pkg/kv/kvclient/kvcoord/dist_sender_server_test.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender_server_test.go
@@ -1811,7 +1811,7 @@ func TestPropagateTxnOnError(t *testing.T) {
 			case *roachpb.ConditionalPutRequest:
 				if k.Equal(keyB) {
 					if atomic.AddInt32(&numCPuts, 1) == 1 {
-						pErr := roachpb.NewReadWithinUncertaintyIntervalError(hlc.Timestamp{}, hlc.Timestamp{}, hlc.Timestamp{}, nil)
+						pErr := roachpb.NewReadWithinUncertaintyIntervalError(hlc.Timestamp{}, hlc.Timestamp{}, hlc.ClockTimestamp{}, nil)
 						return roachpb.NewErrorWithTxn(pErr, fArgs.Hdr.Txn)
 					}
 				}
@@ -2046,7 +2046,7 @@ func TestTxnCoordSenderRetries(t *testing.T) {
 					return nil
 				}
 				err := roachpb.NewReadWithinUncertaintyIntervalError(
-					fArgs.Hdr.Timestamp, s.Clock().Now(), hlc.Timestamp{}, fArgs.Hdr.Txn)
+					fArgs.Hdr.Timestamp, s.Clock().Now(), hlc.ClockTimestamp{}, fArgs.Hdr.Txn)
 				return roachpb.NewErrorWithTxn(err, fArgs.Hdr.Txn)
 			}
 			return nil

--- a/pkg/kv/kvclient/kvcoord/dist_sender_server_test.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender_server_test.go
@@ -1811,7 +1811,8 @@ func TestPropagateTxnOnError(t *testing.T) {
 			case *roachpb.ConditionalPutRequest:
 				if k.Equal(keyB) {
 					if atomic.AddInt32(&numCPuts, 1) == 1 {
-						pErr := roachpb.NewReadWithinUncertaintyIntervalError(hlc.Timestamp{}, hlc.ClockTimestamp{}, nil, hlc.Timestamp{})
+						pErr := roachpb.NewReadWithinUncertaintyIntervalError(
+							hlc.Timestamp{}, hlc.ClockTimestamp{}, nil, hlc.Timestamp{}, hlc.ClockTimestamp{})
 						return roachpb.NewErrorWithTxn(pErr, fArgs.Hdr.Txn)
 					}
 				}
@@ -2046,7 +2047,7 @@ func TestTxnCoordSenderRetries(t *testing.T) {
 					return nil
 				}
 				err := roachpb.NewReadWithinUncertaintyIntervalError(
-					fArgs.Hdr.Timestamp, hlc.ClockTimestamp{}, fArgs.Hdr.Txn, s.Clock().Now())
+					fArgs.Hdr.Timestamp, hlc.ClockTimestamp{}, fArgs.Hdr.Txn, s.Clock().Now(), hlc.ClockTimestamp{})
 				return roachpb.NewErrorWithTxn(err, fArgs.Hdr.Txn)
 			}
 			return nil

--- a/pkg/kv/kvclient/kvcoord/txn_coord_sender_test.go
+++ b/pkg/kv/kvclient/kvcoord/txn_coord_sender_test.go
@@ -758,7 +758,7 @@ func TestTxnCoordSenderTxnUpdatedOnError(t *testing.T) {
 				pErr := roachpb.NewErrorWithTxn(
 					roachpb.NewReadWithinUncertaintyIntervalError(
 						origTS,          // readTS
-						plus10,          // existingTS
+						plus10,          // valueTS
 						hlc.Timestamp{}, // localUncertaintyLimit
 						txn,
 					),
@@ -778,7 +778,7 @@ func TestTxnCoordSenderTxnUpdatedOnError(t *testing.T) {
 				pErr := roachpb.NewErrorWithTxn(
 					roachpb.NewReadWithinUncertaintyIntervalError(
 						origTS, // readTS
-						plus10, // existingTS
+						plus10, // valueTS
 						plus20, // localUncertaintyLimit
 						txn,
 					),

--- a/pkg/kv/kvclient/kvcoord/txn_coord_sender_test.go
+++ b/pkg/kv/kvclient/kvcoord/txn_coord_sender_test.go
@@ -757,9 +757,9 @@ func TestTxnCoordSenderTxnUpdatedOnError(t *testing.T) {
 			pErrGen: func(txn *roachpb.Transaction) *roachpb.Error {
 				pErr := roachpb.NewErrorWithTxn(
 					roachpb.NewReadWithinUncertaintyIntervalError(
-						origTS,          // readTS
-						plus10,          // valueTS
-						hlc.Timestamp{}, // localUncertaintyLimit
+						origTS,               // readTS
+						plus10,               // valueTS
+						hlc.ClockTimestamp{}, // localUncertaintyLimit
 						txn,
 					),
 					txn)
@@ -777,9 +777,9 @@ func TestTxnCoordSenderTxnUpdatedOnError(t *testing.T) {
 			pErrGen: func(txn *roachpb.Transaction) *roachpb.Error {
 				pErr := roachpb.NewErrorWithTxn(
 					roachpb.NewReadWithinUncertaintyIntervalError(
-						origTS, // readTS
-						plus10, // valueTS
-						plus20, // localUncertaintyLimit
+						origTS,                     // readTS
+						plus10,                     // valueTS
+						hlc.ClockTimestamp(plus20), // localUncertaintyLimit
 						txn,
 					),
 					txn)
@@ -1579,7 +1579,7 @@ func TestAbortTransactionOnCommitErrors(t *testing.T) {
 				txn.UpdateObservedTimestamp(nodeID, makeTS(123, 0).UnsafeToClockTimestamp())
 				return roachpb.NewErrorWithTxn(
 					roachpb.NewReadWithinUncertaintyIntervalError(
-						hlc.Timestamp{}, hlc.Timestamp{}, hlc.Timestamp{}, nil),
+						hlc.Timestamp{}, hlc.Timestamp{}, hlc.ClockTimestamp{}, nil),
 					&txn)
 			},
 			asyncAbort: false},

--- a/pkg/kv/kvclient/kvcoord/txn_coord_sender_test.go
+++ b/pkg/kv/kvclient/kvcoord/txn_coord_sender_test.go
@@ -758,9 +758,9 @@ func TestTxnCoordSenderTxnUpdatedOnError(t *testing.T) {
 				pErr := roachpb.NewErrorWithTxn(
 					roachpb.NewReadWithinUncertaintyIntervalError(
 						origTS,               // readTS
-						plus10,               // valueTS
 						hlc.ClockTimestamp{}, // localUncertaintyLimit
-						txn,
+						txn,                  // txn
+						plus10,               // valueTS
 					),
 					txn)
 				return pErr
@@ -778,9 +778,9 @@ func TestTxnCoordSenderTxnUpdatedOnError(t *testing.T) {
 				pErr := roachpb.NewErrorWithTxn(
 					roachpb.NewReadWithinUncertaintyIntervalError(
 						origTS,                     // readTS
-						plus10,                     // valueTS
 						hlc.ClockTimestamp(plus20), // localUncertaintyLimit
-						txn,
+						txn,                        // txn
+						plus10,                     // valueTS
 					),
 					txn)
 				return pErr
@@ -1579,7 +1579,7 @@ func TestAbortTransactionOnCommitErrors(t *testing.T) {
 				txn.UpdateObservedTimestamp(nodeID, makeTS(123, 0).UnsafeToClockTimestamp())
 				return roachpb.NewErrorWithTxn(
 					roachpb.NewReadWithinUncertaintyIntervalError(
-						hlc.Timestamp{}, hlc.Timestamp{}, hlc.ClockTimestamp{}, nil),
+						hlc.Timestamp{}, hlc.ClockTimestamp{}, nil, hlc.Timestamp{}),
 					&txn)
 			},
 			asyncAbort: false},

--- a/pkg/kv/kvclient/kvcoord/txn_coord_sender_test.go
+++ b/pkg/kv/kvclient/kvcoord/txn_coord_sender_test.go
@@ -761,6 +761,7 @@ func TestTxnCoordSenderTxnUpdatedOnError(t *testing.T) {
 						hlc.ClockTimestamp{}, // localUncertaintyLimit
 						txn,                  // txn
 						plus10,               // valueTS
+						hlc.ClockTimestamp{}, // localTS
 					),
 					txn)
 				return pErr
@@ -781,6 +782,7 @@ func TestTxnCoordSenderTxnUpdatedOnError(t *testing.T) {
 						hlc.ClockTimestamp(plus20), // localUncertaintyLimit
 						txn,                        // txn
 						plus10,                     // valueTS
+						hlc.ClockTimestamp{},       // localTS
 					),
 					txn)
 				return pErr
@@ -1579,7 +1581,7 @@ func TestAbortTransactionOnCommitErrors(t *testing.T) {
 				txn.UpdateObservedTimestamp(nodeID, makeTS(123, 0).UnsafeToClockTimestamp())
 				return roachpb.NewErrorWithTxn(
 					roachpb.NewReadWithinUncertaintyIntervalError(
-						hlc.Timestamp{}, hlc.ClockTimestamp{}, nil, hlc.Timestamp{}),
+						hlc.Timestamp{}, hlc.ClockTimestamp{}, nil, hlc.Timestamp{}, hlc.ClockTimestamp{}),
 					&txn)
 			},
 			asyncAbort: false},

--- a/pkg/kv/kvclient/kvcoord/txn_interceptor_span_refresher_test.go
+++ b/pkg/kv/kvclient/kvcoord/txn_interceptor_span_refresher_test.go
@@ -159,7 +159,7 @@ func TestTxnSpanRefresherRefreshesTransactions(t *testing.T) {
 			pErr: func() *roachpb.Error {
 				return roachpb.NewError(
 					&roachpb.ReadWithinUncertaintyIntervalError{
-						ExistingTimestamp: txn.WriteTimestamp.Add(25, 0),
+						ValueTimestamp: txn.WriteTimestamp.Add(25, 0),
 					})
 			},
 			expRefresh:   true,
@@ -169,7 +169,7 @@ func TestTxnSpanRefresherRefreshesTransactions(t *testing.T) {
 			pErr: func() *roachpb.Error {
 				return roachpb.NewError(
 					&roachpb.ReadWithinUncertaintyIntervalError{
-						ExistingTimestamp:     txn.WriteTimestamp.Add(25, 0),
+						ValueTimestamp:        txn.WriteTimestamp.Add(25, 0),
 						LocalUncertaintyLimit: txn.WriteTimestamp.Add(30, 0),
 					})
 			},

--- a/pkg/kv/kvclient/kvcoord/txn_interceptor_span_refresher_test.go
+++ b/pkg/kv/kvclient/kvcoord/txn_interceptor_span_refresher_test.go
@@ -170,7 +170,7 @@ func TestTxnSpanRefresherRefreshesTransactions(t *testing.T) {
 				return roachpb.NewError(
 					&roachpb.ReadWithinUncertaintyIntervalError{
 						ValueTimestamp:        txn.WriteTimestamp.Add(25, 0),
-						LocalUncertaintyLimit: txn.WriteTimestamp.Add(30, 0),
+						LocalUncertaintyLimit: hlc.ClockTimestamp(txn.WriteTimestamp.Add(30, 0)),
 					})
 			},
 			expRefresh:   true,

--- a/pkg/kv/kvclient/kvcoord/txn_test.go
+++ b/pkg/kv/kvclient/kvcoord/txn_test.go
@@ -649,7 +649,7 @@ func TestTxnCommitTimestampAdvancedByRefresh(t *testing.T) {
 				pErr := roachpb.NewReadWithinUncertaintyIntervalError(
 					txn.ReadTimestamp,
 					refreshTS,
-					hlc.Timestamp{},
+					hlc.ClockTimestamp{},
 					txn)
 				return roachpb.NewErrorWithTxn(pErr, txn)
 			}

--- a/pkg/kv/kvclient/kvcoord/txn_test.go
+++ b/pkg/kv/kvclient/kvcoord/txn_test.go
@@ -648,9 +648,9 @@ func TestTxnCommitTimestampAdvancedByRefresh(t *testing.T) {
 				refreshTS = txn.WriteTimestamp.Add(0, 1)
 				pErr := roachpb.NewReadWithinUncertaintyIntervalError(
 					txn.ReadTimestamp,
-					refreshTS,
 					hlc.ClockTimestamp{},
-					txn)
+					txn,
+					refreshTS)
 				return roachpb.NewErrorWithTxn(pErr, txn)
 			}
 			return nil

--- a/pkg/kv/kvclient/kvcoord/txn_test.go
+++ b/pkg/kv/kvclient/kvcoord/txn_test.go
@@ -650,7 +650,8 @@ func TestTxnCommitTimestampAdvancedByRefresh(t *testing.T) {
 					txn.ReadTimestamp,
 					hlc.ClockTimestamp{},
 					txn,
-					refreshTS)
+					refreshTS,
+					hlc.ClockTimestamp{})
 				return roachpb.NewErrorWithTxn(pErr, txn)
 			}
 			return nil

--- a/pkg/kv/kvserver/client_replica_test.go
+++ b/pkg/kv/kvserver/client_replica_test.go
@@ -739,7 +739,7 @@ func testTxnReadWithinUncertaintyIntervalAfterIntentResolution(
 		require.Equal(t, readerTxn.ReadTimestamp, rwuiErr.ReadTimestamp)
 		require.Equal(t, readerTxn.GlobalUncertaintyLimit, rwuiErr.GlobalUncertaintyLimit)
 		require.Equal(t, readerTxn.ObservedTimestamps, rwuiErr.ObservedTimestamps)
-		require.Equal(t, writerTxn.WriteTimestamp, rwuiErr.ExistingTimestamp)
+		require.Equal(t, writerTxn.WriteTimestamp, rwuiErr.ValueTimestamp)
 	}
 }
 

--- a/pkg/kv/kvserver/client_split_test.go
+++ b/pkg/kv/kvserver/client_split_test.go
@@ -2062,7 +2062,7 @@ func TestStoreRangeSplitRaceUninitializedRHS(t *testing.T) {
 			}
 			return roachpb.NewError(
 				roachpb.NewReadWithinUncertaintyIntervalError(
-					args.Hdr.Timestamp, args.Hdr.Timestamp, hlc.ClockTimestamp{}, nil,
+					args.Hdr.Timestamp, hlc.ClockTimestamp{}, nil, args.Hdr.Timestamp,
 				))
 		}
 		return nil

--- a/pkg/kv/kvserver/client_split_test.go
+++ b/pkg/kv/kvserver/client_split_test.go
@@ -2062,7 +2062,7 @@ func TestStoreRangeSplitRaceUninitializedRHS(t *testing.T) {
 			}
 			return roachpb.NewError(
 				roachpb.NewReadWithinUncertaintyIntervalError(
-					args.Hdr.Timestamp, args.Hdr.Timestamp, hlc.Timestamp{}, nil,
+					args.Hdr.Timestamp, args.Hdr.Timestamp, hlc.ClockTimestamp{}, nil,
 				))
 		}
 		return nil

--- a/pkg/kv/kvserver/client_split_test.go
+++ b/pkg/kv/kvserver/client_split_test.go
@@ -2062,7 +2062,7 @@ func TestStoreRangeSplitRaceUninitializedRHS(t *testing.T) {
 			}
 			return roachpb.NewError(
 				roachpb.NewReadWithinUncertaintyIntervalError(
-					args.Hdr.Timestamp, hlc.ClockTimestamp{}, nil, args.Hdr.Timestamp,
+					args.Hdr.Timestamp, hlc.ClockTimestamp{}, nil, args.Hdr.Timestamp, hlc.ClockTimestamp{},
 				))
 		}
 		return nil

--- a/pkg/kv/txn_test.go
+++ b/pkg/kv/txn_test.go
@@ -274,7 +274,7 @@ func TestRunTransactionRetryOnErrors(t *testing.T) {
 		err   error
 		retry bool // Expect retry?
 	}{
-		{roachpb.NewReadWithinUncertaintyIntervalError(hlc.Timestamp{}, hlc.Timestamp{}, hlc.Timestamp{}, nil), true},
+		{roachpb.NewReadWithinUncertaintyIntervalError(hlc.Timestamp{}, hlc.Timestamp{}, hlc.ClockTimestamp{}, nil), true},
 		{&roachpb.TransactionAbortedError{}, true},
 		{&roachpb.TransactionPushError{}, true},
 		{&roachpb.TransactionRetryError{}, true},

--- a/pkg/kv/txn_test.go
+++ b/pkg/kv/txn_test.go
@@ -274,7 +274,7 @@ func TestRunTransactionRetryOnErrors(t *testing.T) {
 		err   error
 		retry bool // Expect retry?
 	}{
-		{roachpb.NewReadWithinUncertaintyIntervalError(hlc.Timestamp{}, hlc.ClockTimestamp{}, nil, hlc.Timestamp{}), true},
+		{roachpb.NewReadWithinUncertaintyIntervalError(hlc.Timestamp{}, hlc.ClockTimestamp{}, nil, hlc.Timestamp{}, hlc.ClockTimestamp{}), true},
 		{&roachpb.TransactionAbortedError{}, true},
 		{&roachpb.TransactionPushError{}, true},
 		{&roachpb.TransactionRetryError{}, true},

--- a/pkg/kv/txn_test.go
+++ b/pkg/kv/txn_test.go
@@ -274,7 +274,7 @@ func TestRunTransactionRetryOnErrors(t *testing.T) {
 		err   error
 		retry bool // Expect retry?
 	}{
-		{roachpb.NewReadWithinUncertaintyIntervalError(hlc.Timestamp{}, hlc.Timestamp{}, hlc.ClockTimestamp{}, nil), true},
+		{roachpb.NewReadWithinUncertaintyIntervalError(hlc.Timestamp{}, hlc.ClockTimestamp{}, nil, hlc.Timestamp{}), true},
 		{&roachpb.TransactionAbortedError{}, true},
 		{&roachpb.TransactionPushError{}, true},
 		{&roachpb.TransactionRetryError{}, true},

--- a/pkg/roachpb/errors.go
+++ b/pkg/roachpb/errors.go
@@ -919,10 +919,9 @@ var _ transactionRestartError = &WriteTooOldError{}
 // NewReadWithinUncertaintyIntervalError creates a new uncertainty retry error.
 // The read and value timestamps as well as the txn are purely informational and
 // used for formatting the error message.
-// TODO(nvanbenschoten): change localUncertaintyLimit to hlc.ClockTimestamp.
 // TODO(nvanbenschoten): add localTs and include in error string.
 func NewReadWithinUncertaintyIntervalError(
-	readTS, valueTS, localUncertaintyLimit hlc.Timestamp, txn *Transaction,
+	readTS, valueTS hlc.Timestamp, localUncertaintyLimit hlc.ClockTimestamp, txn *Transaction,
 ) *ReadWithinUncertaintyIntervalError {
 	rwue := &ReadWithinUncertaintyIntervalError{
 		ReadTimestamp:         readTS,
@@ -1009,7 +1008,7 @@ func (e *ReadWithinUncertaintyIntervalError) RetryTimestamp() hlc.Timestamp {
 	// global uncertainty limit to determine uncertainty (see IsUncertain). In
 	// such cases, we're ok advancing just past the value's timestamp. Either
 	// way, we won't see the same value in our uncertainty interval on a retry.
-	ts.Forward(e.LocalUncertaintyLimit)
+	ts.Forward(e.LocalUncertaintyLimit.ToTimestamp())
 	return ts
 }
 

--- a/pkg/roachpb/errors.go
+++ b/pkg/roachpb/errors.go
@@ -919,12 +919,12 @@ var _ transactionRestartError = &WriteTooOldError{}
 // NewReadWithinUncertaintyIntervalError creates a new uncertainty retry error.
 // The read and value timestamps as well as the txn are purely informational and
 // used for formatting the error message.
-// TODO(nvanbenschoten): add localTs and include in error string.
 func NewReadWithinUncertaintyIntervalError(
 	readTS hlc.Timestamp,
 	localUncertaintyLimit hlc.ClockTimestamp,
 	txn *Transaction,
 	valueTS hlc.Timestamp,
+	localTS hlc.ClockTimestamp,
 ) *ReadWithinUncertaintyIntervalError {
 	var globalUncertaintyLimit hlc.Timestamp
 	var observedTSs []ObservedTimestamp
@@ -940,6 +940,7 @@ func NewReadWithinUncertaintyIntervalError(
 		ObservedTimestamps:     observedTSs,
 		// Information about the uncertain value.
 		ValueTimestamp: valueTS,
+		LocalTimestamp: localTS,
 	}
 }
 
@@ -949,18 +950,23 @@ func (e *ReadWithinUncertaintyIntervalError) SafeFormat(s redact.SafePrinter, _ 
 }
 
 func (e *ReadWithinUncertaintyIntervalError) printError(p Printer) {
+	var localTsStr redact.RedactableString
+	if e.ValueTimestamp != e.LocalTimestamp.ToTimestamp() {
+		localTsStr = redact.Sprintf(" (local=%s)", e.LocalTimestamp)
+	}
+
 	p.Printf("ReadWithinUncertaintyIntervalError: read at time %s encountered "+
-		"previous write with future timestamp %s within uncertainty interval `t <= "+
-		"(local=%v, global=%v)`; "+
+		"previous write with future timestamp %s%s within uncertainty interval `t <= "+
+		"(local=%s, global=%s)`; "+
 		"observed timestamps: ",
-		e.ReadTimestamp, e.ValueTimestamp, e.LocalUncertaintyLimit, e.GlobalUncertaintyLimit)
+		e.ReadTimestamp, e.ValueTimestamp, localTsStr, e.LocalUncertaintyLimit, e.GlobalUncertaintyLimit)
 
 	p.Printf("[")
 	for i, ot := range observedTimestampSlice(e.ObservedTimestamps) {
 		if i > 0 {
 			p.Printf(" ")
 		}
-		p.Printf("{%d %v}", ot.NodeID, ot.Timestamp)
+		p.Printf("{%d %s}", ot.NodeID, ot.Timestamp)
 	}
 	p.Printf("]")
 }

--- a/pkg/roachpb/errors.proto
+++ b/pkg/roachpb/errors.proto
@@ -135,6 +135,8 @@ message ReadWithinUncertaintyIntervalError {
 
   // Information about the uncertain value.
   optional util.hlc.Timestamp value_timestamp = 2 [(gogoproto.nullable) = false];
+  optional util.hlc.Timestamp local_timestamp = 6 [(gogoproto.nullable) = false,
+    (gogoproto.casttype) = "github.com/cockroachdb/cockroach/pkg/util/hlc.ClockTimestamp"];
 }
 
 // TransactionAbortedReason specifies what caused a TransactionAbortedError.

--- a/pkg/roachpb/errors.proto
+++ b/pkg/roachpb/errors.proto
@@ -117,7 +117,7 @@ message RangeKeyMismatchError {
 // A ReadWithinUncertaintyIntervalError indicates that a read at timestamp
 // encountered a write within the uncertainty interval of the reader.
 // The read should be retried at a higher timestamp; the timestamps contained
-// within are purely informational, though typically existing_timestamp is a
+// within are purely informational, though typically value_timestamp is a
 // lower bound for a new timestamp at which at least the read producing
 // this error would succeed on retry.
 message ReadWithinUncertaintyIntervalError {
@@ -127,7 +127,8 @@ message ReadWithinUncertaintyIntervalError {
   // error message.
   optional util.hlc.Timestamp read_timestamp = 1 [(gogoproto.nullable) = false];
   optional util.hlc.Timestamp value_timestamp = 2 [(gogoproto.nullable) = false];
-  optional util.hlc.Timestamp local_uncertainty_limit = 5 [(gogoproto.nullable) = false];
+  optional util.hlc.Timestamp local_uncertainty_limit = 5 [(gogoproto.nullable) = false,
+    (gogoproto.casttype) = "github.com/cockroachdb/cockroach/pkg/util/hlc.ClockTimestamp"];
   optional util.hlc.Timestamp global_uncertainty_limit = 3 [(gogoproto.nullable) = false];
   repeated roachpb.ObservedTimestamp observed_timestamps = 4 [(gogoproto.nullable) = false];
 }

--- a/pkg/roachpb/errors.proto
+++ b/pkg/roachpb/errors.proto
@@ -125,12 +125,16 @@ message ReadWithinUncertaintyIntervalError {
 
   // This data below is purely informational and used to tailor the
   // error message.
+
+  // Information about the reader.
   optional util.hlc.Timestamp read_timestamp = 1 [(gogoproto.nullable) = false];
-  optional util.hlc.Timestamp value_timestamp = 2 [(gogoproto.nullable) = false];
   optional util.hlc.Timestamp local_uncertainty_limit = 5 [(gogoproto.nullable) = false,
     (gogoproto.casttype) = "github.com/cockroachdb/cockroach/pkg/util/hlc.ClockTimestamp"];
   optional util.hlc.Timestamp global_uncertainty_limit = 3 [(gogoproto.nullable) = false];
   repeated roachpb.ObservedTimestamp observed_timestamps = 4 [(gogoproto.nullable) = false];
+
+  // Information about the uncertain value.
+  optional util.hlc.Timestamp value_timestamp = 2 [(gogoproto.nullable) = false];
 }
 
 // TransactionAbortedReason specifies what caused a TransactionAbortedError.

--- a/pkg/roachpb/errors.proto
+++ b/pkg/roachpb/errors.proto
@@ -126,7 +126,7 @@ message ReadWithinUncertaintyIntervalError {
   // This data below is purely informational and used to tailor the
   // error message.
   optional util.hlc.Timestamp read_timestamp = 1 [(gogoproto.nullable) = false];
-  optional util.hlc.Timestamp existing_timestamp = 2 [(gogoproto.nullable) = false];
+  optional util.hlc.Timestamp value_timestamp = 2 [(gogoproto.nullable) = false];
   optional util.hlc.Timestamp local_uncertainty_limit = 5 [(gogoproto.nullable) = false];
   optional util.hlc.Timestamp global_uncertainty_limit = 3 [(gogoproto.nullable) = false];
   repeated roachpb.ObservedTimestamp observed_timestamps = 4 [(gogoproto.nullable) = false];

--- a/pkg/roachpb/errors_test.go
+++ b/pkg/roachpb/errors_test.go
@@ -103,7 +103,7 @@ func TestErrorTxn(t *testing.T) {
 func TestReadWithinUncertaintyIntervalError(t *testing.T) {
 	{
 		rwueNew := NewReadWithinUncertaintyIntervalError(
-			hlc.Timestamp{WallTime: 1}, hlc.Timestamp{WallTime: 2}, hlc.Timestamp{WallTime: 2, Logical: 2},
+			hlc.Timestamp{WallTime: 1}, hlc.Timestamp{WallTime: 2}, hlc.ClockTimestamp{WallTime: 2, Logical: 2},
 			&Transaction{
 				GlobalUncertaintyLimit: hlc.Timestamp{WallTime: 3},
 				ObservedTimestamps:     []ObservedTimestamp{{NodeID: 12, Timestamp: hlc.ClockTimestamp{WallTime: 4}}},
@@ -118,7 +118,7 @@ func TestReadWithinUncertaintyIntervalError(t *testing.T) {
 
 	{
 		rwueOld := NewReadWithinUncertaintyIntervalError(
-			hlc.Timestamp{WallTime: 1}, hlc.Timestamp{WallTime: 2}, hlc.Timestamp{}, nil)
+			hlc.Timestamp{WallTime: 1}, hlc.Timestamp{WallTime: 2}, hlc.ClockTimestamp{}, nil)
 
 		expOld := "ReadWithinUncertaintyIntervalError: read at time 0.000000001,0 encountered " +
 			"previous write with future timestamp 0.000000002,0 within uncertainty interval " +
@@ -159,7 +159,7 @@ func TestErrorRedaction(t *testing.T) {
 	t.Run("uncertainty-restart", func(t *testing.T) {
 		// NB: most other errors don't redact properly. More elbow grease is needed.
 		wrappedPErr := NewError(NewReadWithinUncertaintyIntervalError(
-			hlc.Timestamp{WallTime: 1}, hlc.Timestamp{WallTime: 2}, hlc.Timestamp{WallTime: 2, Logical: 2},
+			hlc.Timestamp{WallTime: 1}, hlc.Timestamp{WallTime: 2}, hlc.ClockTimestamp{WallTime: 2, Logical: 2},
 			&Transaction{
 				GlobalUncertaintyLimit: hlc.Timestamp{WallTime: 3},
 				ObservedTimestamps:     []ObservedTimestamp{{NodeID: 12, Timestamp: hlc.ClockTimestamp{WallTime: 4}}},

--- a/pkg/roachpb/errors_test.go
+++ b/pkg/roachpb/errors_test.go
@@ -103,11 +103,13 @@ func TestErrorTxn(t *testing.T) {
 func TestReadWithinUncertaintyIntervalError(t *testing.T) {
 	{
 		rwueNew := NewReadWithinUncertaintyIntervalError(
-			hlc.Timestamp{WallTime: 1}, hlc.Timestamp{WallTime: 2}, hlc.ClockTimestamp{WallTime: 2, Logical: 2},
+			hlc.Timestamp{WallTime: 1},
+			hlc.ClockTimestamp{WallTime: 2, Logical: 2},
 			&Transaction{
 				GlobalUncertaintyLimit: hlc.Timestamp{WallTime: 3},
 				ObservedTimestamps:     []ObservedTimestamp{{NodeID: 12, Timestamp: hlc.ClockTimestamp{WallTime: 4}}},
-			})
+			},
+			hlc.Timestamp{WallTime: 2})
 		expNew := "ReadWithinUncertaintyIntervalError: read at time 0.000000001,0 encountered " +
 			"previous write with future timestamp 0.000000002,0 within uncertainty interval " +
 			"`t <= (local=0.000000002,2, global=0.000000003,0)`; observed timestamps: [{12 0.000000004,0}]"
@@ -118,7 +120,7 @@ func TestReadWithinUncertaintyIntervalError(t *testing.T) {
 
 	{
 		rwueOld := NewReadWithinUncertaintyIntervalError(
-			hlc.Timestamp{WallTime: 1}, hlc.Timestamp{WallTime: 2}, hlc.ClockTimestamp{}, nil)
+			hlc.Timestamp{WallTime: 1}, hlc.ClockTimestamp{}, nil, hlc.Timestamp{WallTime: 2})
 
 		expOld := "ReadWithinUncertaintyIntervalError: read at time 0.000000001,0 encountered " +
 			"previous write with future timestamp 0.000000002,0 within uncertainty interval " +
@@ -159,11 +161,14 @@ func TestErrorRedaction(t *testing.T) {
 	t.Run("uncertainty-restart", func(t *testing.T) {
 		// NB: most other errors don't redact properly. More elbow grease is needed.
 		wrappedPErr := NewError(NewReadWithinUncertaintyIntervalError(
-			hlc.Timestamp{WallTime: 1}, hlc.Timestamp{WallTime: 2}, hlc.ClockTimestamp{WallTime: 2, Logical: 2},
+			hlc.Timestamp{WallTime: 1},
+			hlc.ClockTimestamp{WallTime: 2, Logical: 2},
 			&Transaction{
 				GlobalUncertaintyLimit: hlc.Timestamp{WallTime: 3},
 				ObservedTimestamps:     []ObservedTimestamp{{NodeID: 12, Timestamp: hlc.ClockTimestamp{WallTime: 4}}},
-			}))
+			},
+			hlc.Timestamp{WallTime: 2},
+		))
 		txn := MakeTransaction("foo", Key("bar"), 1, hlc.Timestamp{WallTime: 1}, 1, 99)
 		txn.ID = uuid.Nil
 		txn.Priority = 1234

--- a/pkg/sql/drop_test.go
+++ b/pkg/sql/drop_test.go
@@ -1156,7 +1156,7 @@ WHERE
 			if put.Key.Equal(catalogkeys.MakeDescMetadataKey(keys.SystemSQLCodec, descpb.ID(tableID))) {
 				filterState.txnID = uuid.UUID{}
 				return roachpb.NewError(roachpb.NewReadWithinUncertaintyIntervalError(
-					request.Txn.ReadTimestamp, hlc.ClockTimestamp{}, request.Txn, afterInsert))
+					request.Txn.ReadTimestamp, hlc.ClockTimestamp{}, request.Txn, afterInsert, hlc.ClockTimestamp{}))
 			}
 		}
 		return nil

--- a/pkg/sql/drop_test.go
+++ b/pkg/sql/drop_test.go
@@ -1156,7 +1156,7 @@ WHERE
 			if put.Key.Equal(catalogkeys.MakeDescMetadataKey(keys.SystemSQLCodec, descpb.ID(tableID))) {
 				filterState.txnID = uuid.UUID{}
 				return roachpb.NewError(roachpb.NewReadWithinUncertaintyIntervalError(
-					request.Txn.ReadTimestamp, afterInsert, hlc.ClockTimestamp{}, request.Txn))
+					request.Txn.ReadTimestamp, hlc.ClockTimestamp{}, request.Txn, afterInsert))
 			}
 		}
 		return nil

--- a/pkg/sql/drop_test.go
+++ b/pkg/sql/drop_test.go
@@ -1156,7 +1156,7 @@ WHERE
 			if put.Key.Equal(catalogkeys.MakeDescMetadataKey(keys.SystemSQLCodec, descpb.ID(tableID))) {
 				filterState.txnID = uuid.UUID{}
 				return roachpb.NewError(roachpb.NewReadWithinUncertaintyIntervalError(
-					request.Txn.ReadTimestamp, afterInsert, hlc.Timestamp{}, request.Txn))
+					request.Txn.ReadTimestamp, afterInsert, hlc.ClockTimestamp{}, request.Txn))
 			}
 		}
 		return nil

--- a/pkg/sql/importer/exportcsv_test.go
+++ b/pkg/sql/importer/exportcsv_test.go
@@ -657,10 +657,11 @@ func TestProcessorEncountersUncertaintyError(t *testing.T) {
 									waitForUnblock()
 									return roachpb.NewError(
 										roachpb.NewReadWithinUncertaintyIntervalError(
-											ba.Timestamp,         /* readTs */
-											hlc.ClockTimestamp{}, /* localUncertaintyLimit */
-											ba.Txn,               /* txn */
-											ba.Timestamp.Add(1, 0) /* valueTS */))
+											ba.Timestamp,           /* readTs */
+											hlc.ClockTimestamp{},   /* localUncertaintyLimit */
+											ba.Txn,                 /* txn */
+											ba.Timestamp.Add(1, 0), /* valueTS */
+											hlc.ClockTimestamp{} /* localTS */))
 								}
 								return nil
 							},

--- a/pkg/sql/importer/exportcsv_test.go
+++ b/pkg/sql/importer/exportcsv_test.go
@@ -657,10 +657,10 @@ func TestProcessorEncountersUncertaintyError(t *testing.T) {
 									waitForUnblock()
 									return roachpb.NewError(
 										roachpb.NewReadWithinUncertaintyIntervalError(
-											ba.Timestamp,           /* readTs */
-											ba.Timestamp.Add(1, 0), /* valueTS */
-											hlc.ClockTimestamp{},   /* localUncertaintyLimit */
-											ba.Txn))
+											ba.Timestamp,         /* readTs */
+											hlc.ClockTimestamp{}, /* localUncertaintyLimit */
+											ba.Txn,               /* txn */
+											ba.Timestamp.Add(1, 0) /* valueTS */))
 								}
 								return nil
 							},

--- a/pkg/sql/importer/exportcsv_test.go
+++ b/pkg/sql/importer/exportcsv_test.go
@@ -659,7 +659,7 @@ func TestProcessorEncountersUncertaintyError(t *testing.T) {
 										roachpb.NewReadWithinUncertaintyIntervalError(
 											ba.Timestamp,           /* readTs */
 											ba.Timestamp.Add(1, 0), /* valueTS */
-											hlc.Timestamp{},        /* localUncertaintyLimit */
+											hlc.ClockTimestamp{},   /* localUncertaintyLimit */
 											ba.Txn))
 								}
 								return nil

--- a/pkg/sql/importer/exportcsv_test.go
+++ b/pkg/sql/importer/exportcsv_test.go
@@ -658,7 +658,7 @@ func TestProcessorEncountersUncertaintyError(t *testing.T) {
 									return roachpb.NewError(
 										roachpb.NewReadWithinUncertaintyIntervalError(
 											ba.Timestamp,           /* readTs */
-											ba.Timestamp.Add(1, 0), /* existingTs */
+											ba.Timestamp.Add(1, 0), /* valueTS */
 											hlc.Timestamp{},        /* localUncertaintyLimit */
 											ba.Txn))
 								}

--- a/pkg/sql/pgwire/pgerror/flatten_test.go
+++ b/pkg/sql/pgwire/pgerror/flatten_test.go
@@ -115,7 +115,7 @@ func TestFlatten(t *testing.T) {
 		{
 			errors.Wrap(
 				roachpb.NewTransactionRetryWithProtoRefreshError(
-					redact.Sprint(roachpb.NewReadWithinUncertaintyIntervalError(hlc.Timestamp{}, hlc.Timestamp{}, hlc.ClockTimestamp{}, nil)),
+					redact.Sprint(roachpb.NewReadWithinUncertaintyIntervalError(hlc.Timestamp{}, hlc.ClockTimestamp{}, nil, hlc.Timestamp{})),
 					uuid.MakeV4(),
 					roachpb.Transaction{},
 				),

--- a/pkg/sql/pgwire/pgerror/flatten_test.go
+++ b/pkg/sql/pgwire/pgerror/flatten_test.go
@@ -115,7 +115,7 @@ func TestFlatten(t *testing.T) {
 		{
 			errors.Wrap(
 				roachpb.NewTransactionRetryWithProtoRefreshError(
-					redact.Sprint(roachpb.NewReadWithinUncertaintyIntervalError(hlc.Timestamp{}, hlc.ClockTimestamp{}, nil, hlc.Timestamp{})),
+					redact.Sprint(roachpb.NewReadWithinUncertaintyIntervalError(hlc.Timestamp{}, hlc.ClockTimestamp{}, nil, hlc.Timestamp{}, hlc.ClockTimestamp{})),
 					uuid.MakeV4(),
 					roachpb.Transaction{},
 				),

--- a/pkg/sql/pgwire/pgerror/flatten_test.go
+++ b/pkg/sql/pgwire/pgerror/flatten_test.go
@@ -115,7 +115,7 @@ func TestFlatten(t *testing.T) {
 		{
 			errors.Wrap(
 				roachpb.NewTransactionRetryWithProtoRefreshError(
-					redact.Sprint(roachpb.NewReadWithinUncertaintyIntervalError(hlc.Timestamp{}, hlc.Timestamp{}, hlc.Timestamp{}, nil)),
+					redact.Sprint(roachpb.NewReadWithinUncertaintyIntervalError(hlc.Timestamp{}, hlc.Timestamp{}, hlc.ClockTimestamp{}, nil)),
 					uuid.MakeV4(),
 					roachpb.Transaction{},
 				),

--- a/pkg/sql/rowexec/processors_test.go
+++ b/pkg/sql/rowexec/processors_test.go
@@ -483,10 +483,10 @@ func TestDrainingProcessorSwallowsUncertaintyError(t *testing.T) {
 									blockedRead.Unlock()
 									return roachpb.NewError(
 										roachpb.NewReadWithinUncertaintyIntervalError(
-											ba.Timestamp,           /* readTs */
-											ba.Timestamp.Add(1, 0), /* valueTS */
-											hlc.ClockTimestamp{},   /* localUncertaintyLimit */
-											ba.Txn))
+											ba.Timestamp,         /* readTs */
+											hlc.ClockTimestamp{}, /* localUncertaintyLimit */
+											ba.Txn,               /* txn */
+											ba.Timestamp.Add(1, 0) /* valueTS */))
 								}
 								return nil
 							},
@@ -661,9 +661,9 @@ func TestUncertaintyErrorIsReturned(t *testing.T) {
 							return roachpb.NewError(
 								roachpb.NewReadWithinUncertaintyIntervalError(
 									ba.Timestamp,
-									ba.Timestamp.Add(1, 0),
 									hlc.ClockTimestamp{},
 									ba.Txn,
+									ba.Timestamp.Add(1, 0),
 								),
 							)
 						},

--- a/pkg/sql/rowexec/processors_test.go
+++ b/pkg/sql/rowexec/processors_test.go
@@ -484,7 +484,7 @@ func TestDrainingProcessorSwallowsUncertaintyError(t *testing.T) {
 									return roachpb.NewError(
 										roachpb.NewReadWithinUncertaintyIntervalError(
 											ba.Timestamp,           /* readTs */
-											ba.Timestamp.Add(1, 0), /* existingTs */
+											ba.Timestamp.Add(1, 0), /* valueTS */
 											hlc.Timestamp{},        /* localUncertaintyLimit */
 											ba.Txn))
 								}

--- a/pkg/sql/rowexec/processors_test.go
+++ b/pkg/sql/rowexec/processors_test.go
@@ -483,10 +483,11 @@ func TestDrainingProcessorSwallowsUncertaintyError(t *testing.T) {
 									blockedRead.Unlock()
 									return roachpb.NewError(
 										roachpb.NewReadWithinUncertaintyIntervalError(
-											ba.Timestamp,         /* readTs */
-											hlc.ClockTimestamp{}, /* localUncertaintyLimit */
-											ba.Txn,               /* txn */
-											ba.Timestamp.Add(1, 0) /* valueTS */))
+											ba.Timestamp,           /* readTs */
+											hlc.ClockTimestamp{},   /* localUncertaintyLimit */
+											ba.Txn,                 /* txn */
+											ba.Timestamp.Add(1, 0), /* valueTS */
+											hlc.ClockTimestamp{} /* localTS */))
 								}
 								return nil
 							},
@@ -664,6 +665,7 @@ func TestUncertaintyErrorIsReturned(t *testing.T) {
 									hlc.ClockTimestamp{},
 									ba.Txn,
 									ba.Timestamp.Add(1, 0),
+									hlc.ClockTimestamp{},
 								),
 							)
 						},

--- a/pkg/sql/rowexec/processors_test.go
+++ b/pkg/sql/rowexec/processors_test.go
@@ -485,7 +485,7 @@ func TestDrainingProcessorSwallowsUncertaintyError(t *testing.T) {
 										roachpb.NewReadWithinUncertaintyIntervalError(
 											ba.Timestamp,           /* readTs */
 											ba.Timestamp.Add(1, 0), /* valueTS */
-											hlc.Timestamp{},        /* localUncertaintyLimit */
+											hlc.ClockTimestamp{},   /* localUncertaintyLimit */
 											ba.Txn))
 								}
 								return nil
@@ -662,7 +662,7 @@ func TestUncertaintyErrorIsReturned(t *testing.T) {
 								roachpb.NewReadWithinUncertaintyIntervalError(
 									ba.Timestamp,
 									ba.Timestamp.Add(1, 0),
-									hlc.Timestamp{},
+									hlc.ClockTimestamp{},
 									ba.Txn,
 								),
 							)

--- a/pkg/sql/txn_restart_test.go
+++ b/pkg/sql/txn_restart_test.go
@@ -1183,7 +1183,7 @@ func TestReacquireLeaseOnRestart(t *testing.T) {
 						txn.ResetObservedTimestamps()
 						now := s.Clock().NowAsClockTimestamp()
 						txn.UpdateObservedTimestamp(s.(*server.TestServer).Gossip().NodeID.Get(), now)
-						return roachpb.NewErrorWithTxn(roachpb.NewReadWithinUncertaintyIntervalError(now.ToTimestamp(), now, txn, now.ToTimestamp()), txn)
+						return roachpb.NewErrorWithTxn(roachpb.NewReadWithinUncertaintyIntervalError(now.ToTimestamp(), now, txn, now.ToTimestamp(), now), txn)
 					}
 				}
 			}
@@ -1267,7 +1267,7 @@ func TestFlushUncommitedDescriptorCacheOnRestart(t *testing.T) {
 					txn.ResetObservedTimestamps()
 					now := s.Clock().NowAsClockTimestamp()
 					txn.UpdateObservedTimestamp(s.(*server.TestServer).Gossip().NodeID.Get(), now)
-					return roachpb.NewErrorWithTxn(roachpb.NewReadWithinUncertaintyIntervalError(now.ToTimestamp(), now, txn, now.ToTimestamp()), txn)
+					return roachpb.NewErrorWithTxn(roachpb.NewReadWithinUncertaintyIntervalError(now.ToTimestamp(), now, txn, now.ToTimestamp(), now), txn)
 				}
 			}
 			return nil
@@ -1354,7 +1354,8 @@ func TestDistSQLRetryableError(t *testing.T) {
 										fArgs.Hdr.Timestamp, /* readTS */
 										hlc.ClockTimestamp{},
 										nil,
-										hlc.Timestamp{})
+										hlc.Timestamp{},
+										hlc.ClockTimestamp{})
 									errTxn := fArgs.Hdr.Txn.Clone()
 									errTxn.UpdateObservedTimestamp(roachpb.NodeID(2), hlc.ClockTimestamp{})
 									pErr := roachpb.NewErrorWithTxn(err, errTxn)

--- a/pkg/sql/txn_restart_test.go
+++ b/pkg/sql/txn_restart_test.go
@@ -1183,7 +1183,7 @@ func TestReacquireLeaseOnRestart(t *testing.T) {
 						txn.ResetObservedTimestamps()
 						now := s.Clock().NowAsClockTimestamp()
 						txn.UpdateObservedTimestamp(s.(*server.TestServer).Gossip().NodeID.Get(), now)
-						return roachpb.NewErrorWithTxn(roachpb.NewReadWithinUncertaintyIntervalError(now.ToTimestamp(), now.ToTimestamp(), now.ToTimestamp(), txn), txn)
+						return roachpb.NewErrorWithTxn(roachpb.NewReadWithinUncertaintyIntervalError(now.ToTimestamp(), now.ToTimestamp(), now, txn), txn)
 					}
 				}
 			}
@@ -1267,7 +1267,7 @@ func TestFlushUncommitedDescriptorCacheOnRestart(t *testing.T) {
 					txn.ResetObservedTimestamps()
 					now := s.Clock().NowAsClockTimestamp()
 					txn.UpdateObservedTimestamp(s.(*server.TestServer).Gossip().NodeID.Get(), now)
-					return roachpb.NewErrorWithTxn(roachpb.NewReadWithinUncertaintyIntervalError(now.ToTimestamp(), now.ToTimestamp(), now.ToTimestamp(), txn), txn)
+					return roachpb.NewErrorWithTxn(roachpb.NewReadWithinUncertaintyIntervalError(now.ToTimestamp(), now.ToTimestamp(), now, txn), txn)
 				}
 			}
 			return nil
@@ -1353,7 +1353,7 @@ func TestDistSQLRetryableError(t *testing.T) {
 									err := roachpb.NewReadWithinUncertaintyIntervalError(
 										fArgs.Hdr.Timestamp, /* readTS */
 										hlc.Timestamp{},
-										hlc.Timestamp{},
+										hlc.ClockTimestamp{},
 										nil)
 									errTxn := fArgs.Hdr.Txn.Clone()
 									errTxn.UpdateObservedTimestamp(roachpb.NodeID(2), hlc.ClockTimestamp{})

--- a/pkg/sql/txn_restart_test.go
+++ b/pkg/sql/txn_restart_test.go
@@ -1183,7 +1183,7 @@ func TestReacquireLeaseOnRestart(t *testing.T) {
 						txn.ResetObservedTimestamps()
 						now := s.Clock().NowAsClockTimestamp()
 						txn.UpdateObservedTimestamp(s.(*server.TestServer).Gossip().NodeID.Get(), now)
-						return roachpb.NewErrorWithTxn(roachpb.NewReadWithinUncertaintyIntervalError(now.ToTimestamp(), now.ToTimestamp(), now, txn), txn)
+						return roachpb.NewErrorWithTxn(roachpb.NewReadWithinUncertaintyIntervalError(now.ToTimestamp(), now, txn, now.ToTimestamp()), txn)
 					}
 				}
 			}
@@ -1267,7 +1267,7 @@ func TestFlushUncommitedDescriptorCacheOnRestart(t *testing.T) {
 					txn.ResetObservedTimestamps()
 					now := s.Clock().NowAsClockTimestamp()
 					txn.UpdateObservedTimestamp(s.(*server.TestServer).Gossip().NodeID.Get(), now)
-					return roachpb.NewErrorWithTxn(roachpb.NewReadWithinUncertaintyIntervalError(now.ToTimestamp(), now.ToTimestamp(), now, txn), txn)
+					return roachpb.NewErrorWithTxn(roachpb.NewReadWithinUncertaintyIntervalError(now.ToTimestamp(), now, txn, now.ToTimestamp()), txn)
 				}
 			}
 			return nil
@@ -1352,9 +1352,9 @@ func TestDistSQLRetryableError(t *testing.T) {
 									restarted = true
 									err := roachpb.NewReadWithinUncertaintyIntervalError(
 										fArgs.Hdr.Timestamp, /* readTS */
-										hlc.Timestamp{},
 										hlc.ClockTimestamp{},
-										nil)
+										nil,
+										hlc.Timestamp{})
 									errTxn := fArgs.Hdr.Txn.Clone()
 									errTxn.UpdateObservedTimestamp(roachpb.NodeID(2), hlc.ClockTimestamp{})
 									pErr := roachpb.NewErrorWithTxn(err, errTxn)

--- a/pkg/storage/pebble_mvcc_scanner.go
+++ b/pkg/storage/pebble_mvcc_scanner.go
@@ -738,7 +738,7 @@ func (p *pebbleMVCCScanner) maybeFailOnMoreRecent() {
 // Returns an uncertainty error with the specified timestamp and p.txn.
 func (p *pebbleMVCCScanner) uncertaintyError(ts hlc.Timestamp) (ok bool) {
 	p.err = roachpb.NewReadWithinUncertaintyIntervalError(
-		p.ts, ts, p.uncertainty.LocalLimit, p.txn)
+		p.ts, p.uncertainty.LocalLimit, p.txn, ts)
 	p.results.clear()
 	p.intents.Reset()
 	return false

--- a/pkg/storage/pebble_mvcc_scanner.go
+++ b/pkg/storage/pebble_mvcc_scanner.go
@@ -738,7 +738,7 @@ func (p *pebbleMVCCScanner) maybeFailOnMoreRecent() {
 // Returns an uncertainty error with the specified timestamp and p.txn.
 func (p *pebbleMVCCScanner) uncertaintyError(ts hlc.Timestamp) (ok bool) {
 	p.err = roachpb.NewReadWithinUncertaintyIntervalError(
-		p.ts, ts, p.uncertainty.LocalLimit.ToTimestamp(), p.txn)
+		p.ts, ts, p.uncertainty.LocalLimit, p.txn)
 	p.results.clear()
 	p.intents.Reset()
 	return false

--- a/pkg/storage/testdata/mvcc_histories/range_tombstone_gets
+++ b/pkg/storage/testdata/mvcc_histories/range_tombstone_gets
@@ -380,7 +380,7 @@ run error
 get k=k ts=1 globalUncertaintyLimit=4
 ----
 get: "k" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 1.000000000,0 encountered previous write with future timestamp 4.000000000,0 within uncertainty interval `t <= (local=0,0, global=0,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 1.000000000,0 encountered previous write with future timestamp 4.000000000,0 (local=3.000000000,0) within uncertainty interval `t <= (local=0,0, global=0,0)`; observed timestamps: []
 
 run ok
 get k=k ts=1 globalUncertaintyLimit=4 localUncertaintyLimit=1
@@ -396,4 +396,4 @@ run error
 get k=k ts=1 globalUncertaintyLimit=4 localUncertaintyLimit=3
 ----
 get: "k" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 1.000000000,0 encountered previous write with future timestamp 4.000000000,0 within uncertainty interval `t <= (local=3.000000000,0, global=0,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 1.000000000,0 encountered previous write with future timestamp 4.000000000,0 (local=3.000000000,0) within uncertainty interval `t <= (local=3.000000000,0, global=0,0)`; observed timestamps: []

--- a/pkg/storage/testdata/mvcc_histories/range_tombstone_scans
+++ b/pkg/storage/testdata/mvcc_histories/range_tombstone_scans
@@ -528,7 +528,7 @@ run error
 scan k=j end=l ts=1 globalUncertaintyLimit=4
 ----
 scan: "j"-"l" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 1.000000000,0 encountered previous write with future timestamp 4.000000000,0 within uncertainty interval `t <= (local=0,0, global=0,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 1.000000000,0 encountered previous write with future timestamp 4.000000000,0 (local=3.000000000,0) within uncertainty interval `t <= (local=0,0, global=0,0)`; observed timestamps: []
 
 run ok
 scan k=j end=l ts=1 globalUncertaintyLimit=4 localUncertaintyLimit=1
@@ -544,4 +544,4 @@ run error
 scan k=j end=l ts=1 globalUncertaintyLimit=4 localUncertaintyLimit=3
 ----
 scan: "j"-"l" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 1.000000000,0 encountered previous write with future timestamp 4.000000000,0 within uncertainty interval `t <= (local=3.000000000,0, global=0,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 1.000000000,0 encountered previous write with future timestamp 4.000000000,0 (local=3.000000000,0) within uncertainty interval `t <= (local=3.000000000,0, global=0,0)`; observed timestamps: []

--- a/pkg/storage/testdata/mvcc_histories/uncertainty_interval_with_local_uncertainty_limit
+++ b/pkg/storage/testdata/mvcc_histories/uncertainty_interval_with_local_uncertainty_limit
@@ -204,13 +204,13 @@ run error
 get t=txn1 k=k2 localUncertaintyLimit=5,0
 ----
 get: "k2" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0 within uncertainty interval `t <= (local=5.000000000,0, global=10.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0 (local=5.000000000,0) within uncertainty interval `t <= (local=5.000000000,0, global=10.000000000,0)`; observed timestamps: []
 
 run error
 scan t=txn1 k=k2 localUncertaintyLimit=5,0
 ----
 scan: "k2"-"k2\x00" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0 within uncertainty interval `t <= (local=5.000000000,0, global=10.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0 (local=5.000000000,0) within uncertainty interval `t <= (local=5.000000000,0, global=10.000000000,0)`; observed timestamps: []
 
 run ok
 get t=txn1 k=k3 localUncertaintyLimit=5,0
@@ -226,13 +226,13 @@ run error
 get t=txn1 k=k4 localUncertaintyLimit=5,0
 ----
 get: "k4" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0 within uncertainty interval `t <= (local=5.000000000,0, global=10.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0 (local=5.000000000,0) within uncertainty interval `t <= (local=5.000000000,0, global=10.000000000,0)`; observed timestamps: []
 
 run error
 scan t=txn1 k=k4 localUncertaintyLimit=5,0
 ----
 scan: "k4"-"k4\x00" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0 within uncertainty interval `t <= (local=5.000000000,0, global=10.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0 (local=5.000000000,0) within uncertainty interval `t <= (local=5.000000000,0, global=10.000000000,0)`; observed timestamps: []
 
 run ok
 get t=txn1 k=k5 localUncertaintyLimit=5,0
@@ -248,13 +248,13 @@ run error
 get t=txn1 k=k6 localUncertaintyLimit=5,0
 ----
 get: "k6" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0 within uncertainty interval `t <= (local=5.000000000,0, global=10.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0 (local=5.000000000,0) within uncertainty interval `t <= (local=5.000000000,0, global=10.000000000,0)`; observed timestamps: []
 
 run error
 scan t=txn1 k=k6 localUncertaintyLimit=5,0
 ----
 scan: "k6"-"k6\x00" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0 within uncertainty interval `t <= (local=5.000000000,0, global=10.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0 (local=5.000000000,0) within uncertainty interval `t <= (local=5.000000000,0, global=10.000000000,0)`; observed timestamps: []
 
 run ok
 get t=txn1 k=k7 localUncertaintyLimit=5,0
@@ -270,13 +270,13 @@ run error
 get t=txn1 k=k8 localUncertaintyLimit=5,0
 ----
 get: "k8" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0 within uncertainty interval `t <= (local=5.000000000,0, global=10.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0 (local=5.000000000,0) within uncertainty interval `t <= (local=5.000000000,0, global=10.000000000,0)`; observed timestamps: []
 
 run error
 scan t=txn1 k=k8 localUncertaintyLimit=5,0
 ----
 scan: "k8"-"k8\x00" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0 within uncertainty interval `t <= (local=5.000000000,0, global=10.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0 (local=5.000000000,0) within uncertainty interval `t <= (local=5.000000000,0, global=10.000000000,0)`; observed timestamps: []
 
 
 run ok
@@ -299,13 +299,13 @@ run error
 get t=txn2 k=k2 localUncertaintyLimit=5,0
 ----
 get: "k2" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0 within uncertainty interval `t <= (local=5.000000000,0, global=15.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0 (local=5.000000000,0) within uncertainty interval `t <= (local=5.000000000,0, global=15.000000000,0)`; observed timestamps: []
 
 run error
 scan t=txn2 k=k2 localUncertaintyLimit=5,0
 ----
 scan: "k2"-"k2\x00" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0 within uncertainty interval `t <= (local=5.000000000,0, global=15.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0 (local=5.000000000,0) within uncertainty interval `t <= (local=5.000000000,0, global=15.000000000,0)`; observed timestamps: []
 
 run ok
 get t=txn2 k=k3 localUncertaintyLimit=5,0
@@ -321,13 +321,13 @@ run error
 get t=txn2 k=k4 localUncertaintyLimit=5,0
 ----
 get: "k4" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0 within uncertainty interval `t <= (local=5.000000000,0, global=15.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0 (local=5.000000000,0) within uncertainty interval `t <= (local=5.000000000,0, global=15.000000000,0)`; observed timestamps: []
 
 run error
 scan t=txn2 k=k4 localUncertaintyLimit=5,0
 ----
 scan: "k4"-"k4\x00" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0 within uncertainty interval `t <= (local=5.000000000,0, global=15.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0 (local=5.000000000,0) within uncertainty interval `t <= (local=5.000000000,0, global=15.000000000,0)`; observed timestamps: []
 
 run ok
 get t=txn2 k=k5 localUncertaintyLimit=5,0
@@ -343,13 +343,13 @@ run error
 get t=txn2 k=k6 localUncertaintyLimit=5,0
 ----
 get: "k6" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0 within uncertainty interval `t <= (local=5.000000000,0, global=15.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0 (local=5.000000000,0) within uncertainty interval `t <= (local=5.000000000,0, global=15.000000000,0)`; observed timestamps: []
 
 run error
 scan t=txn2 k=k6 localUncertaintyLimit=5,0
 ----
 scan: "k6"-"k6\x00" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0 within uncertainty interval `t <= (local=5.000000000,0, global=15.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0 (local=5.000000000,0) within uncertainty interval `t <= (local=5.000000000,0, global=15.000000000,0)`; observed timestamps: []
 
 run ok
 get t=txn2 k=k7 localUncertaintyLimit=5,0
@@ -365,13 +365,13 @@ run error
 get t=txn2 k=k8 localUncertaintyLimit=5,0
 ----
 get: "k8" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0 within uncertainty interval `t <= (local=5.000000000,0, global=15.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0 (local=5.000000000,0) within uncertainty interval `t <= (local=5.000000000,0, global=15.000000000,0)`; observed timestamps: []
 
 run error
 scan t=txn2 k=k8 localUncertaintyLimit=5,0
 ----
 scan: "k8"-"k8\x00" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0 within uncertainty interval `t <= (local=5.000000000,0, global=15.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0 (local=5.000000000,0) within uncertainty interval `t <= (local=5.000000000,0, global=15.000000000,0)`; observed timestamps: []
 
 
 run ok
@@ -394,13 +394,13 @@ run error
 get t=txn3 k=k2 localUncertaintyLimit=5,0
 ----
 get: "k2" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0 within uncertainty interval `t <= (local=5.000000000,0, global=20.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0 (local=5.000000000,0) within uncertainty interval `t <= (local=5.000000000,0, global=20.000000000,0)`; observed timestamps: []
 
 run error
 scan t=txn3 k=k2 localUncertaintyLimit=5,0
 ----
 scan: "k2"-"k2\x00" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0 within uncertainty interval `t <= (local=5.000000000,0, global=20.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0 (local=5.000000000,0) within uncertainty interval `t <= (local=5.000000000,0, global=20.000000000,0)`; observed timestamps: []
 
 run ok
 get t=txn3 k=k3 localUncertaintyLimit=5,0
@@ -416,13 +416,13 @@ run error
 get t=txn3 k=k4 localUncertaintyLimit=5,0
 ----
 get: "k4" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0 within uncertainty interval `t <= (local=5.000000000,0, global=20.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0 (local=5.000000000,0) within uncertainty interval `t <= (local=5.000000000,0, global=20.000000000,0)`; observed timestamps: []
 
 run error
 scan t=txn3 k=k4 localUncertaintyLimit=5,0
 ----
 scan: "k4"-"k4\x00" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0 within uncertainty interval `t <= (local=5.000000000,0, global=20.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0 (local=5.000000000,0) within uncertainty interval `t <= (local=5.000000000,0, global=20.000000000,0)`; observed timestamps: []
 
 run ok
 get t=txn3 k=k5 localUncertaintyLimit=5,0
@@ -438,13 +438,13 @@ run error
 get t=txn3 k=k6 localUncertaintyLimit=5,0
 ----
 get: "k6" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0 within uncertainty interval `t <= (local=5.000000000,0, global=20.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0 (local=5.000000000,0) within uncertainty interval `t <= (local=5.000000000,0, global=20.000000000,0)`; observed timestamps: []
 
 run error
 scan t=txn3 k=k6 localUncertaintyLimit=5,0
 ----
 scan: "k6"-"k6\x00" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0 within uncertainty interval `t <= (local=5.000000000,0, global=20.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0 (local=5.000000000,0) within uncertainty interval `t <= (local=5.000000000,0, global=20.000000000,0)`; observed timestamps: []
 
 run ok
 get t=txn3 k=k7 localUncertaintyLimit=5,0
@@ -460,13 +460,13 @@ run error
 get t=txn3 k=k8 localUncertaintyLimit=5,0
 ----
 get: "k8" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0 within uncertainty interval `t <= (local=5.000000000,0, global=20.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0 (local=5.000000000,0) within uncertainty interval `t <= (local=5.000000000,0, global=20.000000000,0)`; observed timestamps: []
 
 run error
 scan t=txn3 k=k8 localUncertaintyLimit=5,0
 ----
 scan: "k8"-"k8\x00" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0 within uncertainty interval `t <= (local=5.000000000,0, global=20.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0 (local=5.000000000,0) within uncertainty interval `t <= (local=5.000000000,0, global=20.000000000,0)`; observed timestamps: []
 
 
 run ok
@@ -489,13 +489,13 @@ run error
 get t=txn4 k=k2 localUncertaintyLimit=5,0
 ----
 get: "k2" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0 within uncertainty interval `t <= (local=5.000000000,0, global=25.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0 (local=5.000000000,0) within uncertainty interval `t <= (local=5.000000000,0, global=25.000000000,0)`; observed timestamps: []
 
 run error
 scan t=txn4 k=k2 localUncertaintyLimit=5,0
 ----
 scan: "k2"-"k2\x00" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0 within uncertainty interval `t <= (local=5.000000000,0, global=25.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0 (local=5.000000000,0) within uncertainty interval `t <= (local=5.000000000,0, global=25.000000000,0)`; observed timestamps: []
 
 run ok
 get t=txn4 k=k3 localUncertaintyLimit=5,0
@@ -511,13 +511,13 @@ run error
 get t=txn4 k=k4 localUncertaintyLimit=5,0
 ----
 get: "k4" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0 within uncertainty interval `t <= (local=5.000000000,0, global=25.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0 (local=5.000000000,0) within uncertainty interval `t <= (local=5.000000000,0, global=25.000000000,0)`; observed timestamps: []
 
 run error
 scan t=txn4 k=k4 localUncertaintyLimit=5,0
 ----
 scan: "k4"-"k4\x00" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0 within uncertainty interval `t <= (local=5.000000000,0, global=25.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0 (local=5.000000000,0) within uncertainty interval `t <= (local=5.000000000,0, global=25.000000000,0)`; observed timestamps: []
 
 run ok
 get t=txn4 k=k5 localUncertaintyLimit=5,0
@@ -533,13 +533,13 @@ run error
 get t=txn4 k=k6 localUncertaintyLimit=5,0
 ----
 get: "k6" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0 within uncertainty interval `t <= (local=5.000000000,0, global=25.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0 (local=5.000000000,0) within uncertainty interval `t <= (local=5.000000000,0, global=25.000000000,0)`; observed timestamps: []
 
 run error
 scan t=txn4 k=k6 localUncertaintyLimit=5,0
 ----
 scan: "k6"-"k6\x00" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0 within uncertainty interval `t <= (local=5.000000000,0, global=25.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0 (local=5.000000000,0) within uncertainty interval `t <= (local=5.000000000,0, global=25.000000000,0)`; observed timestamps: []
 
 run ok
 get t=txn4 k=k7 localUncertaintyLimit=5,0
@@ -555,13 +555,13 @@ run error
 get t=txn4 k=k8 localUncertaintyLimit=5,0
 ----
 get: "k8" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0 within uncertainty interval `t <= (local=5.000000000,0, global=25.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0 (local=5.000000000,0) within uncertainty interval `t <= (local=5.000000000,0, global=25.000000000,0)`; observed timestamps: []
 
 run error
 scan t=txn4 k=k8 localUncertaintyLimit=5,0
 ----
 scan: "k8"-"k8\x00" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0 within uncertainty interval `t <= (local=5.000000000,0, global=25.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0 (local=5.000000000,0) within uncertainty interval `t <= (local=5.000000000,0, global=25.000000000,0)`; observed timestamps: []
 
 
 run ok
@@ -586,13 +586,13 @@ run error
 get t=txn5 k=k2 localUncertaintyLimit=10,0
 ----
 get: "k2" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0 within uncertainty interval `t <= (local=10.000000000,0, global=15.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0 (local=5.000000000,0) within uncertainty interval `t <= (local=10.000000000,0, global=15.000000000,0)`; observed timestamps: []
 
 run error
 scan t=txn5 k=k2 localUncertaintyLimit=10,0
 ----
 scan: "k2"-"k2\x00" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0 within uncertainty interval `t <= (local=10.000000000,0, global=15.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0 (local=5.000000000,0) within uncertainty interval `t <= (local=10.000000000,0, global=15.000000000,0)`; observed timestamps: []
 
 run error
 get t=txn5 k=k3 localUncertaintyLimit=10,0
@@ -610,13 +610,13 @@ run error
 get t=txn5 k=k4 localUncertaintyLimit=10,0
 ----
 get: "k4" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0 within uncertainty interval `t <= (local=10.000000000,0, global=15.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0 (local=5.000000000,0) within uncertainty interval `t <= (local=10.000000000,0, global=15.000000000,0)`; observed timestamps: []
 
 run error
 scan t=txn5 k=k4 localUncertaintyLimit=10,0
 ----
 scan: "k4"-"k4\x00" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0 within uncertainty interval `t <= (local=10.000000000,0, global=15.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0 (local=5.000000000,0) within uncertainty interval `t <= (local=10.000000000,0, global=15.000000000,0)`; observed timestamps: []
 
 run error
 get t=txn5 k=k5 localUncertaintyLimit=10,0
@@ -634,13 +634,13 @@ run error
 get t=txn5 k=k6 localUncertaintyLimit=10,0
 ----
 get: "k6" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0 within uncertainty interval `t <= (local=10.000000000,0, global=15.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0 (local=5.000000000,0) within uncertainty interval `t <= (local=10.000000000,0, global=15.000000000,0)`; observed timestamps: []
 
 run error
 scan t=txn5 k=k6 localUncertaintyLimit=10,0
 ----
 scan: "k6"-"k6\x00" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0 within uncertainty interval `t <= (local=10.000000000,0, global=15.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0 (local=5.000000000,0) within uncertainty interval `t <= (local=10.000000000,0, global=15.000000000,0)`; observed timestamps: []
 
 run error
 get t=txn5 k=k7 localUncertaintyLimit=10,0
@@ -658,13 +658,13 @@ run error
 get t=txn5 k=k8 localUncertaintyLimit=10,0
 ----
 get: "k8" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0 within uncertainty interval `t <= (local=10.000000000,0, global=15.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0 (local=5.000000000,0) within uncertainty interval `t <= (local=10.000000000,0, global=15.000000000,0)`; observed timestamps: []
 
 run error
 scan t=txn5 k=k8 localUncertaintyLimit=10,0
 ----
 scan: "k8"-"k8\x00" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0 within uncertainty interval `t <= (local=10.000000000,0, global=15.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0 (local=5.000000000,0) within uncertainty interval `t <= (local=10.000000000,0, global=15.000000000,0)`; observed timestamps: []
 
 
 run ok
@@ -689,37 +689,37 @@ run error
 get t=txn6 k=k2 localUncertaintyLimit=10,0
 ----
 get: "k2" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0 within uncertainty interval `t <= (local=10.000000000,0, global=20.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0 (local=5.000000000,0) within uncertainty interval `t <= (local=10.000000000,0, global=20.000000000,0)`; observed timestamps: []
 
 run error
 scan t=txn6 k=k2 localUncertaintyLimit=10,0
 ----
 scan: "k2"-"k2\x00" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0 within uncertainty interval `t <= (local=10.000000000,0, global=20.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0 (local=5.000000000,0) within uncertainty interval `t <= (local=10.000000000,0, global=20.000000000,0)`; observed timestamps: []
 
 run error
 get t=txn6 k=k3 localUncertaintyLimit=10,0
 ----
 get: "k3" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0 within uncertainty interval `t <= (local=10.000000000,0, global=20.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0 (local=10.000000000,0) within uncertainty interval `t <= (local=10.000000000,0, global=20.000000000,0)`; observed timestamps: []
 
 run error
 scan t=txn6 k=k3 localUncertaintyLimit=10,0
 ----
 scan: "k3"-"k3\x00" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0 within uncertainty interval `t <= (local=10.000000000,0, global=20.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0 (local=10.000000000,0) within uncertainty interval `t <= (local=10.000000000,0, global=20.000000000,0)`; observed timestamps: []
 
 run error
 get t=txn6 k=k4 localUncertaintyLimit=10,0
 ----
 get: "k4" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0 within uncertainty interval `t <= (local=10.000000000,0, global=20.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0 (local=10.000000000,0) within uncertainty interval `t <= (local=10.000000000,0, global=20.000000000,0)`; observed timestamps: []
 
 run error
 scan t=txn6 k=k4 localUncertaintyLimit=10,0
 ----
 scan: "k4"-"k4\x00" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0 within uncertainty interval `t <= (local=10.000000000,0, global=20.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0 (local=10.000000000,0) within uncertainty interval `t <= (local=10.000000000,0, global=20.000000000,0)`; observed timestamps: []
 
 run error
 get t=txn6 k=k5 localUncertaintyLimit=10,0
@@ -737,37 +737,37 @@ run error
 get t=txn6 k=k6 localUncertaintyLimit=10,0
 ----
 get: "k6" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0 within uncertainty interval `t <= (local=10.000000000,0, global=20.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0 (local=5.000000000,0) within uncertainty interval `t <= (local=10.000000000,0, global=20.000000000,0)`; observed timestamps: []
 
 run error
 scan t=txn6 k=k6 localUncertaintyLimit=10,0
 ----
 scan: "k6"-"k6\x00" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0 within uncertainty interval `t <= (local=10.000000000,0, global=20.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0 (local=5.000000000,0) within uncertainty interval `t <= (local=10.000000000,0, global=20.000000000,0)`; observed timestamps: []
 
 run error
 get t=txn6 k=k7 localUncertaintyLimit=10,0
 ----
 get: "k7" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0 within uncertainty interval `t <= (local=10.000000000,0, global=20.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0 (local=10.000000000,0) within uncertainty interval `t <= (local=10.000000000,0, global=20.000000000,0)`; observed timestamps: []
 
 run error
 scan t=txn6 k=k7 localUncertaintyLimit=10,0
 ----
 scan: "k7"-"k7\x00" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0 within uncertainty interval `t <= (local=10.000000000,0, global=20.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0 (local=10.000000000,0) within uncertainty interval `t <= (local=10.000000000,0, global=20.000000000,0)`; observed timestamps: []
 
 run error
 get t=txn6 k=k8 localUncertaintyLimit=10,0
 ----
 get: "k8" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0 within uncertainty interval `t <= (local=10.000000000,0, global=20.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0 (local=10.000000000,0) within uncertainty interval `t <= (local=10.000000000,0, global=20.000000000,0)`; observed timestamps: []
 
 run error
 scan t=txn6 k=k8 localUncertaintyLimit=10,0
 ----
 scan: "k8"-"k8\x00" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0 within uncertainty interval `t <= (local=10.000000000,0, global=20.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0 (local=10.000000000,0) within uncertainty interval `t <= (local=10.000000000,0, global=20.000000000,0)`; observed timestamps: []
 
 
 run ok
@@ -792,37 +792,37 @@ run error
 get t=txn7 k=k2 localUncertaintyLimit=10,0
 ----
 get: "k2" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0 within uncertainty interval `t <= (local=10.000000000,0, global=25.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0 (local=5.000000000,0) within uncertainty interval `t <= (local=10.000000000,0, global=25.000000000,0)`; observed timestamps: []
 
 run error
 scan t=txn7 k=k2 localUncertaintyLimit=10,0
 ----
 scan: "k2"-"k2\x00" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0 within uncertainty interval `t <= (local=10.000000000,0, global=25.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0 (local=5.000000000,0) within uncertainty interval `t <= (local=10.000000000,0, global=25.000000000,0)`; observed timestamps: []
 
 run error
 get t=txn7 k=k3 localUncertaintyLimit=10,0
 ----
 get: "k3" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0 within uncertainty interval `t <= (local=10.000000000,0, global=25.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0 (local=10.000000000,0) within uncertainty interval `t <= (local=10.000000000,0, global=25.000000000,0)`; observed timestamps: []
 
 run error
 scan t=txn7 k=k3 localUncertaintyLimit=10,0
 ----
 scan: "k3"-"k3\x00" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0 within uncertainty interval `t <= (local=10.000000000,0, global=25.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0 (local=10.000000000,0) within uncertainty interval `t <= (local=10.000000000,0, global=25.000000000,0)`; observed timestamps: []
 
 run error
 get t=txn7 k=k4 localUncertaintyLimit=10,0
 ----
 get: "k4" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0 within uncertainty interval `t <= (local=10.000000000,0, global=25.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0 (local=10.000000000,0) within uncertainty interval `t <= (local=10.000000000,0, global=25.000000000,0)`; observed timestamps: []
 
 run error
 scan t=txn7 k=k4 localUncertaintyLimit=10,0
 ----
 scan: "k4"-"k4\x00" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0 within uncertainty interval `t <= (local=10.000000000,0, global=25.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0 (local=10.000000000,0) within uncertainty interval `t <= (local=10.000000000,0, global=25.000000000,0)`; observed timestamps: []
 
 run error
 get t=txn7 k=k5 localUncertaintyLimit=10,0
@@ -840,37 +840,37 @@ run error
 get t=txn7 k=k6 localUncertaintyLimit=10,0
 ----
 get: "k6" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0 within uncertainty interval `t <= (local=10.000000000,0, global=25.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0 (local=5.000000000,0) within uncertainty interval `t <= (local=10.000000000,0, global=25.000000000,0)`; observed timestamps: []
 
 run error
 scan t=txn7 k=k6 localUncertaintyLimit=10,0
 ----
 scan: "k6"-"k6\x00" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0 within uncertainty interval `t <= (local=10.000000000,0, global=25.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0 (local=5.000000000,0) within uncertainty interval `t <= (local=10.000000000,0, global=25.000000000,0)`; observed timestamps: []
 
 run error
 get t=txn7 k=k7 localUncertaintyLimit=10,0
 ----
 get: "k7" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0 within uncertainty interval `t <= (local=10.000000000,0, global=25.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0 (local=10.000000000,0) within uncertainty interval `t <= (local=10.000000000,0, global=25.000000000,0)`; observed timestamps: []
 
 run error
 scan t=txn7 k=k7 localUncertaintyLimit=10,0
 ----
 scan: "k7"-"k7\x00" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0 within uncertainty interval `t <= (local=10.000000000,0, global=25.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0 (local=10.000000000,0) within uncertainty interval `t <= (local=10.000000000,0, global=25.000000000,0)`; observed timestamps: []
 
 run error
 get t=txn7 k=k8 localUncertaintyLimit=10,0
 ----
 get: "k8" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0 within uncertainty interval `t <= (local=10.000000000,0, global=25.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0 (local=10.000000000,0) within uncertainty interval `t <= (local=10.000000000,0, global=25.000000000,0)`; observed timestamps: []
 
 run error
 scan t=txn7 k=k8 localUncertaintyLimit=10,0
 ----
 scan: "k8"-"k8\x00" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0 within uncertainty interval `t <= (local=10.000000000,0, global=25.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0 (local=10.000000000,0) within uncertainty interval `t <= (local=10.000000000,0, global=25.000000000,0)`; observed timestamps: []
 
 
 run ok
@@ -895,37 +895,37 @@ run error
 get t=txn8 k=k2 localUncertaintyLimit=15,0
 ----
 get: "k2" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0 within uncertainty interval `t <= (local=15.000000000,0, global=20.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0 (local=5.000000000,0) within uncertainty interval `t <= (local=15.000000000,0, global=20.000000000,0)`; observed timestamps: []
 
 run error
 scan t=txn8 k=k2 localUncertaintyLimit=15,0
 ----
 scan: "k2"-"k2\x00" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0 within uncertainty interval `t <= (local=15.000000000,0, global=20.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0 (local=5.000000000,0) within uncertainty interval `t <= (local=15.000000000,0, global=20.000000000,0)`; observed timestamps: []
 
 run error
 get t=txn8 k=k3 localUncertaintyLimit=15,0
 ----
 get: "k3" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0 within uncertainty interval `t <= (local=15.000000000,0, global=20.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0 (local=10.000000000,0) within uncertainty interval `t <= (local=15.000000000,0, global=20.000000000,0)`; observed timestamps: []
 
 run error
 scan t=txn8 k=k3 localUncertaintyLimit=15,0
 ----
 scan: "k3"-"k3\x00" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0 within uncertainty interval `t <= (local=15.000000000,0, global=20.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0 (local=10.000000000,0) within uncertainty interval `t <= (local=15.000000000,0, global=20.000000000,0)`; observed timestamps: []
 
 run error
 get t=txn8 k=k4 localUncertaintyLimit=15,0
 ----
 get: "k4" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0 within uncertainty interval `t <= (local=15.000000000,0, global=20.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0 (local=10.000000000,0) within uncertainty interval `t <= (local=15.000000000,0, global=20.000000000,0)`; observed timestamps: []
 
 run error
 scan t=txn8 k=k4 localUncertaintyLimit=15,0
 ----
 scan: "k4"-"k4\x00" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0 within uncertainty interval `t <= (local=15.000000000,0, global=20.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0 (local=10.000000000,0) within uncertainty interval `t <= (local=15.000000000,0, global=20.000000000,0)`; observed timestamps: []
 
 run error
 get t=txn8 k=k5 localUncertaintyLimit=15,0
@@ -943,37 +943,37 @@ run error
 get t=txn8 k=k6 localUncertaintyLimit=15,0
 ----
 get: "k6" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0 within uncertainty interval `t <= (local=15.000000000,0, global=20.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0 (local=5.000000000,0) within uncertainty interval `t <= (local=15.000000000,0, global=20.000000000,0)`; observed timestamps: []
 
 run error
 scan t=txn8 k=k6 localUncertaintyLimit=15,0
 ----
 scan: "k6"-"k6\x00" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0 within uncertainty interval `t <= (local=15.000000000,0, global=20.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0 (local=5.000000000,0) within uncertainty interval `t <= (local=15.000000000,0, global=20.000000000,0)`; observed timestamps: []
 
 run error
 get t=txn8 k=k7 localUncertaintyLimit=15,0
 ----
 get: "k7" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0 within uncertainty interval `t <= (local=15.000000000,0, global=20.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0 (local=10.000000000,0) within uncertainty interval `t <= (local=15.000000000,0, global=20.000000000,0)`; observed timestamps: []
 
 run error
 scan t=txn8 k=k7 localUncertaintyLimit=15,0
 ----
 scan: "k7"-"k7\x00" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0 within uncertainty interval `t <= (local=15.000000000,0, global=20.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0 (local=10.000000000,0) within uncertainty interval `t <= (local=15.000000000,0, global=20.000000000,0)`; observed timestamps: []
 
 run error
 get t=txn8 k=k8 localUncertaintyLimit=15,0
 ----
 get: "k8" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0 within uncertainty interval `t <= (local=15.000000000,0, global=20.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0 (local=10.000000000,0) within uncertainty interval `t <= (local=15.000000000,0, global=20.000000000,0)`; observed timestamps: []
 
 run error
 scan t=txn8 k=k8 localUncertaintyLimit=15,0
 ----
 scan: "k8"-"k8\x00" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0 within uncertainty interval `t <= (local=15.000000000,0, global=20.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0 (local=10.000000000,0) within uncertainty interval `t <= (local=15.000000000,0, global=20.000000000,0)`; observed timestamps: []
 
 
 run ok
@@ -998,37 +998,37 @@ run error
 get t=txn9 k=k2 localUncertaintyLimit=15,0
 ----
 get: "k2" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0 within uncertainty interval `t <= (local=15.000000000,0, global=25.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0 (local=5.000000000,0) within uncertainty interval `t <= (local=15.000000000,0, global=25.000000000,0)`; observed timestamps: []
 
 run error
 scan t=txn9 k=k2 localUncertaintyLimit=15,0
 ----
 scan: "k2"-"k2\x00" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0 within uncertainty interval `t <= (local=15.000000000,0, global=25.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0 (local=5.000000000,0) within uncertainty interval `t <= (local=15.000000000,0, global=25.000000000,0)`; observed timestamps: []
 
 run error
 get t=txn9 k=k3 localUncertaintyLimit=15,0
 ----
 get: "k3" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0 within uncertainty interval `t <= (local=15.000000000,0, global=25.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0 (local=10.000000000,0) within uncertainty interval `t <= (local=15.000000000,0, global=25.000000000,0)`; observed timestamps: []
 
 run error
 scan t=txn9 k=k3 localUncertaintyLimit=15,0
 ----
 scan: "k3"-"k3\x00" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0 within uncertainty interval `t <= (local=15.000000000,0, global=25.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0 (local=10.000000000,0) within uncertainty interval `t <= (local=15.000000000,0, global=25.000000000,0)`; observed timestamps: []
 
 run error
 get t=txn9 k=k4 localUncertaintyLimit=15,0
 ----
 get: "k4" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0 within uncertainty interval `t <= (local=15.000000000,0, global=25.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0 (local=10.000000000,0) within uncertainty interval `t <= (local=15.000000000,0, global=25.000000000,0)`; observed timestamps: []
 
 run error
 scan t=txn9 k=k4 localUncertaintyLimit=15,0
 ----
 scan: "k4"-"k4\x00" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0 within uncertainty interval `t <= (local=15.000000000,0, global=25.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0 (local=10.000000000,0) within uncertainty interval `t <= (local=15.000000000,0, global=25.000000000,0)`; observed timestamps: []
 
 run error
 get t=txn9 k=k5 localUncertaintyLimit=15,0
@@ -1046,37 +1046,37 @@ run error
 get t=txn9 k=k6 localUncertaintyLimit=15,0
 ----
 get: "k6" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0 within uncertainty interval `t <= (local=15.000000000,0, global=25.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0 (local=5.000000000,0) within uncertainty interval `t <= (local=15.000000000,0, global=25.000000000,0)`; observed timestamps: []
 
 run error
 scan t=txn9 k=k6 localUncertaintyLimit=15,0
 ----
 scan: "k6"-"k6\x00" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0 within uncertainty interval `t <= (local=15.000000000,0, global=25.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0 (local=5.000000000,0) within uncertainty interval `t <= (local=15.000000000,0, global=25.000000000,0)`; observed timestamps: []
 
 run error
 get t=txn9 k=k7 localUncertaintyLimit=15,0
 ----
 get: "k7" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0 within uncertainty interval `t <= (local=15.000000000,0, global=25.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0 (local=10.000000000,0) within uncertainty interval `t <= (local=15.000000000,0, global=25.000000000,0)`; observed timestamps: []
 
 run error
 scan t=txn9 k=k7 localUncertaintyLimit=15,0
 ----
 scan: "k7"-"k7\x00" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0 within uncertainty interval `t <= (local=15.000000000,0, global=25.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0 (local=10.000000000,0) within uncertainty interval `t <= (local=15.000000000,0, global=25.000000000,0)`; observed timestamps: []
 
 run error
 get t=txn9 k=k8 localUncertaintyLimit=15,0
 ----
 get: "k8" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0 within uncertainty interval `t <= (local=15.000000000,0, global=25.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0 (local=10.000000000,0) within uncertainty interval `t <= (local=15.000000000,0, global=25.000000000,0)`; observed timestamps: []
 
 run error
 scan t=txn9 k=k8 localUncertaintyLimit=15,0
 ----
 scan: "k8"-"k8\x00" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0 within uncertainty interval `t <= (local=15.000000000,0, global=25.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0 (local=10.000000000,0) within uncertainty interval `t <= (local=15.000000000,0, global=25.000000000,0)`; observed timestamps: []
 
 
 run ok
@@ -1113,25 +1113,25 @@ run error
 get t=txn10 k=k3 localUncertaintyLimit=20,0
 ----
 get: "k3" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0 within uncertainty interval `t <= (local=20.000000000,0, global=25.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0 (local=10.000000000,0) within uncertainty interval `t <= (local=20.000000000,0, global=25.000000000,0)`; observed timestamps: []
 
 run error
 scan t=txn10 k=k3 localUncertaintyLimit=20,0
 ----
 scan: "k3"-"k3\x00" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0 within uncertainty interval `t <= (local=20.000000000,0, global=25.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0 (local=10.000000000,0) within uncertainty interval `t <= (local=20.000000000,0, global=25.000000000,0)`; observed timestamps: []
 
 run error
 get t=txn10 k=k4 localUncertaintyLimit=20,0
 ----
 get: "k4" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0 within uncertainty interval `t <= (local=20.000000000,0, global=25.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0 (local=10.000000000,0) within uncertainty interval `t <= (local=20.000000000,0, global=25.000000000,0)`; observed timestamps: []
 
 run error
 scan t=txn10 k=k4 localUncertaintyLimit=20,0
 ----
 scan: "k4"-"k4\x00" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0 within uncertainty interval `t <= (local=20.000000000,0, global=25.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0 (local=10.000000000,0) within uncertainty interval `t <= (local=20.000000000,0, global=25.000000000,0)`; observed timestamps: []
 
 run error
 get t=txn10 k=k5 localUncertaintyLimit=20,0
@@ -1161,25 +1161,25 @@ run error
 get t=txn10 k=k7 localUncertaintyLimit=20,0
 ----
 get: "k7" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0 within uncertainty interval `t <= (local=20.000000000,0, global=25.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0 (local=10.000000000,0) within uncertainty interval `t <= (local=20.000000000,0, global=25.000000000,0)`; observed timestamps: []
 
 run error
 scan t=txn10 k=k7 localUncertaintyLimit=20,0
 ----
 scan: "k7"-"k7\x00" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0 within uncertainty interval `t <= (local=20.000000000,0, global=25.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0 (local=10.000000000,0) within uncertainty interval `t <= (local=20.000000000,0, global=25.000000000,0)`; observed timestamps: []
 
 run error
 get t=txn10 k=k8 localUncertaintyLimit=20,0
 ----
 get: "k8" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0 within uncertainty interval `t <= (local=20.000000000,0, global=25.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0 (local=10.000000000,0) within uncertainty interval `t <= (local=20.000000000,0, global=25.000000000,0)`; observed timestamps: []
 
 run error
 scan t=txn10 k=k8 localUncertaintyLimit=20,0
 ----
 scan: "k8"-"k8\x00" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0 within uncertainty interval `t <= (local=20.000000000,0, global=25.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0 (local=10.000000000,0) within uncertainty interval `t <= (local=20.000000000,0, global=25.000000000,0)`; observed timestamps: []
 
 
 run ok
@@ -1299,25 +1299,25 @@ run error
 get t=txn12 k=k3 localUncertaintyLimit=10,0
 ----
 get: "k3" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 10.000000000,0 encountered previous write with future timestamp 20.000000000,0 within uncertainty interval `t <= (local=10.000000000,0, global=20.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 10.000000000,0 encountered previous write with future timestamp 20.000000000,0 (local=10.000000000,0) within uncertainty interval `t <= (local=10.000000000,0, global=20.000000000,0)`; observed timestamps: []
 
 run error
 scan t=txn12 k=k3 localUncertaintyLimit=10,0
 ----
 scan: "k3"-"k3\x00" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 10.000000000,0 encountered previous write with future timestamp 20.000000000,0 within uncertainty interval `t <= (local=10.000000000,0, global=20.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 10.000000000,0 encountered previous write with future timestamp 20.000000000,0 (local=10.000000000,0) within uncertainty interval `t <= (local=10.000000000,0, global=20.000000000,0)`; observed timestamps: []
 
 run error
 get t=txn12 k=k4 localUncertaintyLimit=10,0
 ----
 get: "k4" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 10.000000000,0 encountered previous write with future timestamp 20.000000000,0 within uncertainty interval `t <= (local=10.000000000,0, global=20.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 10.000000000,0 encountered previous write with future timestamp 20.000000000,0 (local=10.000000000,0) within uncertainty interval `t <= (local=10.000000000,0, global=20.000000000,0)`; observed timestamps: []
 
 run error
 scan t=txn12 k=k4 localUncertaintyLimit=10,0
 ----
 scan: "k4"-"k4\x00" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 10.000000000,0 encountered previous write with future timestamp 20.000000000,0 within uncertainty interval `t <= (local=10.000000000,0, global=20.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 10.000000000,0 encountered previous write with future timestamp 20.000000000,0 (local=10.000000000,0) within uncertainty interval `t <= (local=10.000000000,0, global=20.000000000,0)`; observed timestamps: []
 
 run ok
 get t=txn12 k=k5 localUncertaintyLimit=10,0
@@ -1343,25 +1343,25 @@ run error
 get t=txn12 k=k7 localUncertaintyLimit=10,0
 ----
 get: "k7" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 10.000000000,0 encountered previous write with future timestamp 20.000000000,0 within uncertainty interval `t <= (local=10.000000000,0, global=20.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 10.000000000,0 encountered previous write with future timestamp 20.000000000,0 (local=10.000000000,0) within uncertainty interval `t <= (local=10.000000000,0, global=20.000000000,0)`; observed timestamps: []
 
 run error
 scan t=txn12 k=k7 localUncertaintyLimit=10,0
 ----
 scan: "k7"-"k7\x00" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 10.000000000,0 encountered previous write with future timestamp 20.000000000,0 within uncertainty interval `t <= (local=10.000000000,0, global=20.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 10.000000000,0 encountered previous write with future timestamp 20.000000000,0 (local=10.000000000,0) within uncertainty interval `t <= (local=10.000000000,0, global=20.000000000,0)`; observed timestamps: []
 
 run error
 get t=txn12 k=k8 localUncertaintyLimit=10,0
 ----
 get: "k8" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 10.000000000,0 encountered previous write with future timestamp 20.000000000,0 within uncertainty interval `t <= (local=10.000000000,0, global=20.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 10.000000000,0 encountered previous write with future timestamp 20.000000000,0 (local=10.000000000,0) within uncertainty interval `t <= (local=10.000000000,0, global=20.000000000,0)`; observed timestamps: []
 
 run error
 scan t=txn12 k=k8 localUncertaintyLimit=10,0
 ----
 scan: "k8"-"k8\x00" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 10.000000000,0 encountered previous write with future timestamp 20.000000000,0 within uncertainty interval `t <= (local=10.000000000,0, global=20.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 10.000000000,0 encountered previous write with future timestamp 20.000000000,0 (local=10.000000000,0) within uncertainty interval `t <= (local=10.000000000,0, global=20.000000000,0)`; observed timestamps: []
 
 
 run ok
@@ -1394,25 +1394,25 @@ run error
 get t=txn13 k=k3 localUncertaintyLimit=10,0
 ----
 get: "k3" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 10.000000000,0 encountered previous write with future timestamp 20.000000000,0 within uncertainty interval `t <= (local=10.000000000,0, global=25.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 10.000000000,0 encountered previous write with future timestamp 20.000000000,0 (local=10.000000000,0) within uncertainty interval `t <= (local=10.000000000,0, global=25.000000000,0)`; observed timestamps: []
 
 run error
 scan t=txn13 k=k3 localUncertaintyLimit=10,0
 ----
 scan: "k3"-"k3\x00" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 10.000000000,0 encountered previous write with future timestamp 20.000000000,0 within uncertainty interval `t <= (local=10.000000000,0, global=25.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 10.000000000,0 encountered previous write with future timestamp 20.000000000,0 (local=10.000000000,0) within uncertainty interval `t <= (local=10.000000000,0, global=25.000000000,0)`; observed timestamps: []
 
 run error
 get t=txn13 k=k4 localUncertaintyLimit=10,0
 ----
 get: "k4" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 10.000000000,0 encountered previous write with future timestamp 20.000000000,0 within uncertainty interval `t <= (local=10.000000000,0, global=25.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 10.000000000,0 encountered previous write with future timestamp 20.000000000,0 (local=10.000000000,0) within uncertainty interval `t <= (local=10.000000000,0, global=25.000000000,0)`; observed timestamps: []
 
 run error
 scan t=txn13 k=k4 localUncertaintyLimit=10,0
 ----
 scan: "k4"-"k4\x00" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 10.000000000,0 encountered previous write with future timestamp 20.000000000,0 within uncertainty interval `t <= (local=10.000000000,0, global=25.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 10.000000000,0 encountered previous write with future timestamp 20.000000000,0 (local=10.000000000,0) within uncertainty interval `t <= (local=10.000000000,0, global=25.000000000,0)`; observed timestamps: []
 
 run ok
 get t=txn13 k=k5 localUncertaintyLimit=10,0
@@ -1438,25 +1438,25 @@ run error
 get t=txn13 k=k7 localUncertaintyLimit=10,0
 ----
 get: "k7" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 10.000000000,0 encountered previous write with future timestamp 20.000000000,0 within uncertainty interval `t <= (local=10.000000000,0, global=25.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 10.000000000,0 encountered previous write with future timestamp 20.000000000,0 (local=10.000000000,0) within uncertainty interval `t <= (local=10.000000000,0, global=25.000000000,0)`; observed timestamps: []
 
 run error
 scan t=txn13 k=k7 localUncertaintyLimit=10,0
 ----
 scan: "k7"-"k7\x00" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 10.000000000,0 encountered previous write with future timestamp 20.000000000,0 within uncertainty interval `t <= (local=10.000000000,0, global=25.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 10.000000000,0 encountered previous write with future timestamp 20.000000000,0 (local=10.000000000,0) within uncertainty interval `t <= (local=10.000000000,0, global=25.000000000,0)`; observed timestamps: []
 
 run error
 get t=txn13 k=k8 localUncertaintyLimit=10,0
 ----
 get: "k8" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 10.000000000,0 encountered previous write with future timestamp 20.000000000,0 within uncertainty interval `t <= (local=10.000000000,0, global=25.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 10.000000000,0 encountered previous write with future timestamp 20.000000000,0 (local=10.000000000,0) within uncertainty interval `t <= (local=10.000000000,0, global=25.000000000,0)`; observed timestamps: []
 
 run error
 scan t=txn13 k=k8 localUncertaintyLimit=10,0
 ----
 scan: "k8"-"k8\x00" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 10.000000000,0 encountered previous write with future timestamp 20.000000000,0 within uncertainty interval `t <= (local=10.000000000,0, global=25.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 10.000000000,0 encountered previous write with future timestamp 20.000000000,0 (local=10.000000000,0) within uncertainty interval `t <= (local=10.000000000,0, global=25.000000000,0)`; observed timestamps: []
 
 
 run ok
@@ -1489,25 +1489,25 @@ run error
 get t=txn14 k=k3 localUncertaintyLimit=15,0
 ----
 get: "k3" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 10.000000000,0 encountered previous write with future timestamp 20.000000000,0 within uncertainty interval `t <= (local=15.000000000,0, global=20.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 10.000000000,0 encountered previous write with future timestamp 20.000000000,0 (local=10.000000000,0) within uncertainty interval `t <= (local=15.000000000,0, global=20.000000000,0)`; observed timestamps: []
 
 run error
 scan t=txn14 k=k3 localUncertaintyLimit=15,0
 ----
 scan: "k3"-"k3\x00" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 10.000000000,0 encountered previous write with future timestamp 20.000000000,0 within uncertainty interval `t <= (local=15.000000000,0, global=20.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 10.000000000,0 encountered previous write with future timestamp 20.000000000,0 (local=10.000000000,0) within uncertainty interval `t <= (local=15.000000000,0, global=20.000000000,0)`; observed timestamps: []
 
 run error
 get t=txn14 k=k4 localUncertaintyLimit=15,0
 ----
 get: "k4" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 10.000000000,0 encountered previous write with future timestamp 20.000000000,0 within uncertainty interval `t <= (local=15.000000000,0, global=20.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 10.000000000,0 encountered previous write with future timestamp 20.000000000,0 (local=10.000000000,0) within uncertainty interval `t <= (local=15.000000000,0, global=20.000000000,0)`; observed timestamps: []
 
 run error
 scan t=txn14 k=k4 localUncertaintyLimit=15,0
 ----
 scan: "k4"-"k4\x00" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 10.000000000,0 encountered previous write with future timestamp 20.000000000,0 within uncertainty interval `t <= (local=15.000000000,0, global=20.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 10.000000000,0 encountered previous write with future timestamp 20.000000000,0 (local=10.000000000,0) within uncertainty interval `t <= (local=15.000000000,0, global=20.000000000,0)`; observed timestamps: []
 
 run ok
 get t=txn14 k=k5 localUncertaintyLimit=15,0
@@ -1533,25 +1533,25 @@ run error
 get t=txn14 k=k7 localUncertaintyLimit=15,0
 ----
 get: "k7" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 10.000000000,0 encountered previous write with future timestamp 20.000000000,0 within uncertainty interval `t <= (local=15.000000000,0, global=20.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 10.000000000,0 encountered previous write with future timestamp 20.000000000,0 (local=10.000000000,0) within uncertainty interval `t <= (local=15.000000000,0, global=20.000000000,0)`; observed timestamps: []
 
 run error
 scan t=txn14 k=k7 localUncertaintyLimit=15,0
 ----
 scan: "k7"-"k7\x00" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 10.000000000,0 encountered previous write with future timestamp 20.000000000,0 within uncertainty interval `t <= (local=15.000000000,0, global=20.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 10.000000000,0 encountered previous write with future timestamp 20.000000000,0 (local=10.000000000,0) within uncertainty interval `t <= (local=15.000000000,0, global=20.000000000,0)`; observed timestamps: []
 
 run error
 get t=txn14 k=k8 localUncertaintyLimit=15,0
 ----
 get: "k8" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 10.000000000,0 encountered previous write with future timestamp 20.000000000,0 within uncertainty interval `t <= (local=15.000000000,0, global=20.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 10.000000000,0 encountered previous write with future timestamp 20.000000000,0 (local=10.000000000,0) within uncertainty interval `t <= (local=15.000000000,0, global=20.000000000,0)`; observed timestamps: []
 
 run error
 scan t=txn14 k=k8 localUncertaintyLimit=15,0
 ----
 scan: "k8"-"k8\x00" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 10.000000000,0 encountered previous write with future timestamp 20.000000000,0 within uncertainty interval `t <= (local=15.000000000,0, global=20.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 10.000000000,0 encountered previous write with future timestamp 20.000000000,0 (local=10.000000000,0) within uncertainty interval `t <= (local=15.000000000,0, global=20.000000000,0)`; observed timestamps: []
 
 
 run ok
@@ -1584,25 +1584,25 @@ run error
 get t=txn15 k=k3 localUncertaintyLimit=15,0
 ----
 get: "k3" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 10.000000000,0 encountered previous write with future timestamp 20.000000000,0 within uncertainty interval `t <= (local=15.000000000,0, global=25.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 10.000000000,0 encountered previous write with future timestamp 20.000000000,0 (local=10.000000000,0) within uncertainty interval `t <= (local=15.000000000,0, global=25.000000000,0)`; observed timestamps: []
 
 run error
 scan t=txn15 k=k3 localUncertaintyLimit=15,0
 ----
 scan: "k3"-"k3\x00" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 10.000000000,0 encountered previous write with future timestamp 20.000000000,0 within uncertainty interval `t <= (local=15.000000000,0, global=25.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 10.000000000,0 encountered previous write with future timestamp 20.000000000,0 (local=10.000000000,0) within uncertainty interval `t <= (local=15.000000000,0, global=25.000000000,0)`; observed timestamps: []
 
 run error
 get t=txn15 k=k4 localUncertaintyLimit=15,0
 ----
 get: "k4" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 10.000000000,0 encountered previous write with future timestamp 20.000000000,0 within uncertainty interval `t <= (local=15.000000000,0, global=25.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 10.000000000,0 encountered previous write with future timestamp 20.000000000,0 (local=10.000000000,0) within uncertainty interval `t <= (local=15.000000000,0, global=25.000000000,0)`; observed timestamps: []
 
 run error
 scan t=txn15 k=k4 localUncertaintyLimit=15,0
 ----
 scan: "k4"-"k4\x00" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 10.000000000,0 encountered previous write with future timestamp 20.000000000,0 within uncertainty interval `t <= (local=15.000000000,0, global=25.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 10.000000000,0 encountered previous write with future timestamp 20.000000000,0 (local=10.000000000,0) within uncertainty interval `t <= (local=15.000000000,0, global=25.000000000,0)`; observed timestamps: []
 
 run ok
 get t=txn15 k=k5 localUncertaintyLimit=15,0
@@ -1628,25 +1628,25 @@ run error
 get t=txn15 k=k7 localUncertaintyLimit=15,0
 ----
 get: "k7" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 10.000000000,0 encountered previous write with future timestamp 20.000000000,0 within uncertainty interval `t <= (local=15.000000000,0, global=25.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 10.000000000,0 encountered previous write with future timestamp 20.000000000,0 (local=10.000000000,0) within uncertainty interval `t <= (local=15.000000000,0, global=25.000000000,0)`; observed timestamps: []
 
 run error
 scan t=txn15 k=k7 localUncertaintyLimit=15,0
 ----
 scan: "k7"-"k7\x00" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 10.000000000,0 encountered previous write with future timestamp 20.000000000,0 within uncertainty interval `t <= (local=15.000000000,0, global=25.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 10.000000000,0 encountered previous write with future timestamp 20.000000000,0 (local=10.000000000,0) within uncertainty interval `t <= (local=15.000000000,0, global=25.000000000,0)`; observed timestamps: []
 
 run error
 get t=txn15 k=k8 localUncertaintyLimit=15,0
 ----
 get: "k8" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 10.000000000,0 encountered previous write with future timestamp 20.000000000,0 within uncertainty interval `t <= (local=15.000000000,0, global=25.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 10.000000000,0 encountered previous write with future timestamp 20.000000000,0 (local=10.000000000,0) within uncertainty interval `t <= (local=15.000000000,0, global=25.000000000,0)`; observed timestamps: []
 
 run error
 scan t=txn15 k=k8 localUncertaintyLimit=15,0
 ----
 scan: "k8"-"k8\x00" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 10.000000000,0 encountered previous write with future timestamp 20.000000000,0 within uncertainty interval `t <= (local=15.000000000,0, global=25.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 10.000000000,0 encountered previous write with future timestamp 20.000000000,0 (local=10.000000000,0) within uncertainty interval `t <= (local=15.000000000,0, global=25.000000000,0)`; observed timestamps: []
 
 
 run ok
@@ -1683,25 +1683,25 @@ run error
 get t=txn16 k=k3 localUncertaintyLimit=20,0
 ----
 get: "k3" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 10.000000000,0 encountered previous write with future timestamp 20.000000000,0 within uncertainty interval `t <= (local=20.000000000,0, global=25.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 10.000000000,0 encountered previous write with future timestamp 20.000000000,0 (local=10.000000000,0) within uncertainty interval `t <= (local=20.000000000,0, global=25.000000000,0)`; observed timestamps: []
 
 run error
 scan t=txn16 k=k3 localUncertaintyLimit=20,0
 ----
 scan: "k3"-"k3\x00" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 10.000000000,0 encountered previous write with future timestamp 20.000000000,0 within uncertainty interval `t <= (local=20.000000000,0, global=25.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 10.000000000,0 encountered previous write with future timestamp 20.000000000,0 (local=10.000000000,0) within uncertainty interval `t <= (local=20.000000000,0, global=25.000000000,0)`; observed timestamps: []
 
 run error
 get t=txn16 k=k4 localUncertaintyLimit=20,0
 ----
 get: "k4" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 10.000000000,0 encountered previous write with future timestamp 20.000000000,0 within uncertainty interval `t <= (local=20.000000000,0, global=25.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 10.000000000,0 encountered previous write with future timestamp 20.000000000,0 (local=10.000000000,0) within uncertainty interval `t <= (local=20.000000000,0, global=25.000000000,0)`; observed timestamps: []
 
 run error
 scan t=txn16 k=k4 localUncertaintyLimit=20,0
 ----
 scan: "k4"-"k4\x00" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 10.000000000,0 encountered previous write with future timestamp 20.000000000,0 within uncertainty interval `t <= (local=20.000000000,0, global=25.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 10.000000000,0 encountered previous write with future timestamp 20.000000000,0 (local=10.000000000,0) within uncertainty interval `t <= (local=20.000000000,0, global=25.000000000,0)`; observed timestamps: []
 
 run error
 get t=txn16 k=k5 localUncertaintyLimit=20,0
@@ -1731,25 +1731,25 @@ run error
 get t=txn16 k=k7 localUncertaintyLimit=20,0
 ----
 get: "k7" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 10.000000000,0 encountered previous write with future timestamp 20.000000000,0 within uncertainty interval `t <= (local=20.000000000,0, global=25.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 10.000000000,0 encountered previous write with future timestamp 20.000000000,0 (local=10.000000000,0) within uncertainty interval `t <= (local=20.000000000,0, global=25.000000000,0)`; observed timestamps: []
 
 run error
 scan t=txn16 k=k7 localUncertaintyLimit=20,0
 ----
 scan: "k7"-"k7\x00" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 10.000000000,0 encountered previous write with future timestamp 20.000000000,0 within uncertainty interval `t <= (local=20.000000000,0, global=25.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 10.000000000,0 encountered previous write with future timestamp 20.000000000,0 (local=10.000000000,0) within uncertainty interval `t <= (local=20.000000000,0, global=25.000000000,0)`; observed timestamps: []
 
 run error
 get t=txn16 k=k8 localUncertaintyLimit=20,0
 ----
 get: "k8" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 10.000000000,0 encountered previous write with future timestamp 20.000000000,0 within uncertainty interval `t <= (local=20.000000000,0, global=25.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 10.000000000,0 encountered previous write with future timestamp 20.000000000,0 (local=10.000000000,0) within uncertainty interval `t <= (local=20.000000000,0, global=25.000000000,0)`; observed timestamps: []
 
 run error
 scan t=txn16 k=k8 localUncertaintyLimit=20,0
 ----
 scan: "k8"-"k8\x00" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 10.000000000,0 encountered previous write with future timestamp 20.000000000,0 within uncertainty interval `t <= (local=20.000000000,0, global=25.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 10.000000000,0 encountered previous write with future timestamp 20.000000000,0 (local=10.000000000,0) within uncertainty interval `t <= (local=20.000000000,0, global=25.000000000,0)`; observed timestamps: []
 
 
 run ok
@@ -1782,25 +1782,25 @@ run error
 get t=txn17 k=k3 localUncertaintyLimit=15,0
 ----
 get: "k3" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 15.000000000,0 encountered previous write with future timestamp 20.000000000,0 within uncertainty interval `t <= (local=15.000000000,0, global=20.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 15.000000000,0 encountered previous write with future timestamp 20.000000000,0 (local=10.000000000,0) within uncertainty interval `t <= (local=15.000000000,0, global=20.000000000,0)`; observed timestamps: []
 
 run error
 scan t=txn17 k=k3 localUncertaintyLimit=15,0
 ----
 scan: "k3"-"k3\x00" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 15.000000000,0 encountered previous write with future timestamp 20.000000000,0 within uncertainty interval `t <= (local=15.000000000,0, global=20.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 15.000000000,0 encountered previous write with future timestamp 20.000000000,0 (local=10.000000000,0) within uncertainty interval `t <= (local=15.000000000,0, global=20.000000000,0)`; observed timestamps: []
 
 run error
 get t=txn17 k=k4 localUncertaintyLimit=15,0
 ----
 get: "k4" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 15.000000000,0 encountered previous write with future timestamp 20.000000000,0 within uncertainty interval `t <= (local=15.000000000,0, global=20.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 15.000000000,0 encountered previous write with future timestamp 20.000000000,0 (local=10.000000000,0) within uncertainty interval `t <= (local=15.000000000,0, global=20.000000000,0)`; observed timestamps: []
 
 run error
 scan t=txn17 k=k4 localUncertaintyLimit=15,0
 ----
 scan: "k4"-"k4\x00" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 15.000000000,0 encountered previous write with future timestamp 20.000000000,0 within uncertainty interval `t <= (local=15.000000000,0, global=20.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 15.000000000,0 encountered previous write with future timestamp 20.000000000,0 (local=10.000000000,0) within uncertainty interval `t <= (local=15.000000000,0, global=20.000000000,0)`; observed timestamps: []
 
 run ok
 get t=txn17 k=k5 localUncertaintyLimit=15,0
@@ -1826,25 +1826,25 @@ run error
 get t=txn17 k=k7 localUncertaintyLimit=15,0
 ----
 get: "k7" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 15.000000000,0 encountered previous write with future timestamp 20.000000000,0 within uncertainty interval `t <= (local=15.000000000,0, global=20.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 15.000000000,0 encountered previous write with future timestamp 20.000000000,0 (local=10.000000000,0) within uncertainty interval `t <= (local=15.000000000,0, global=20.000000000,0)`; observed timestamps: []
 
 run error
 scan t=txn17 k=k7 localUncertaintyLimit=15,0
 ----
 scan: "k7"-"k7\x00" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 15.000000000,0 encountered previous write with future timestamp 20.000000000,0 within uncertainty interval `t <= (local=15.000000000,0, global=20.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 15.000000000,0 encountered previous write with future timestamp 20.000000000,0 (local=10.000000000,0) within uncertainty interval `t <= (local=15.000000000,0, global=20.000000000,0)`; observed timestamps: []
 
 run error
 get t=txn17 k=k8 localUncertaintyLimit=15,0
 ----
 get: "k8" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 15.000000000,0 encountered previous write with future timestamp 20.000000000,0 within uncertainty interval `t <= (local=15.000000000,0, global=20.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 15.000000000,0 encountered previous write with future timestamp 20.000000000,0 (local=10.000000000,0) within uncertainty interval `t <= (local=15.000000000,0, global=20.000000000,0)`; observed timestamps: []
 
 run error
 scan t=txn17 k=k8 localUncertaintyLimit=15,0
 ----
 scan: "k8"-"k8\x00" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 15.000000000,0 encountered previous write with future timestamp 20.000000000,0 within uncertainty interval `t <= (local=15.000000000,0, global=20.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 15.000000000,0 encountered previous write with future timestamp 20.000000000,0 (local=10.000000000,0) within uncertainty interval `t <= (local=15.000000000,0, global=20.000000000,0)`; observed timestamps: []
 
 
 run ok
@@ -1877,25 +1877,25 @@ run error
 get t=txn18 k=k3 localUncertaintyLimit=15,0
 ----
 get: "k3" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 15.000000000,0 encountered previous write with future timestamp 20.000000000,0 within uncertainty interval `t <= (local=15.000000000,0, global=25.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 15.000000000,0 encountered previous write with future timestamp 20.000000000,0 (local=10.000000000,0) within uncertainty interval `t <= (local=15.000000000,0, global=25.000000000,0)`; observed timestamps: []
 
 run error
 scan t=txn18 k=k3 localUncertaintyLimit=15,0
 ----
 scan: "k3"-"k3\x00" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 15.000000000,0 encountered previous write with future timestamp 20.000000000,0 within uncertainty interval `t <= (local=15.000000000,0, global=25.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 15.000000000,0 encountered previous write with future timestamp 20.000000000,0 (local=10.000000000,0) within uncertainty interval `t <= (local=15.000000000,0, global=25.000000000,0)`; observed timestamps: []
 
 run error
 get t=txn18 k=k4 localUncertaintyLimit=15,0
 ----
 get: "k4" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 15.000000000,0 encountered previous write with future timestamp 20.000000000,0 within uncertainty interval `t <= (local=15.000000000,0, global=25.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 15.000000000,0 encountered previous write with future timestamp 20.000000000,0 (local=10.000000000,0) within uncertainty interval `t <= (local=15.000000000,0, global=25.000000000,0)`; observed timestamps: []
 
 run error
 scan t=txn18 k=k4 localUncertaintyLimit=15,0
 ----
 scan: "k4"-"k4\x00" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 15.000000000,0 encountered previous write with future timestamp 20.000000000,0 within uncertainty interval `t <= (local=15.000000000,0, global=25.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 15.000000000,0 encountered previous write with future timestamp 20.000000000,0 (local=10.000000000,0) within uncertainty interval `t <= (local=15.000000000,0, global=25.000000000,0)`; observed timestamps: []
 
 run ok
 get t=txn18 k=k5 localUncertaintyLimit=15,0
@@ -1921,25 +1921,25 @@ run error
 get t=txn18 k=k7 localUncertaintyLimit=15,0
 ----
 get: "k7" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 15.000000000,0 encountered previous write with future timestamp 20.000000000,0 within uncertainty interval `t <= (local=15.000000000,0, global=25.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 15.000000000,0 encountered previous write with future timestamp 20.000000000,0 (local=10.000000000,0) within uncertainty interval `t <= (local=15.000000000,0, global=25.000000000,0)`; observed timestamps: []
 
 run error
 scan t=txn18 k=k7 localUncertaintyLimit=15,0
 ----
 scan: "k7"-"k7\x00" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 15.000000000,0 encountered previous write with future timestamp 20.000000000,0 within uncertainty interval `t <= (local=15.000000000,0, global=25.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 15.000000000,0 encountered previous write with future timestamp 20.000000000,0 (local=10.000000000,0) within uncertainty interval `t <= (local=15.000000000,0, global=25.000000000,0)`; observed timestamps: []
 
 run error
 get t=txn18 k=k8 localUncertaintyLimit=15,0
 ----
 get: "k8" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 15.000000000,0 encountered previous write with future timestamp 20.000000000,0 within uncertainty interval `t <= (local=15.000000000,0, global=25.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 15.000000000,0 encountered previous write with future timestamp 20.000000000,0 (local=10.000000000,0) within uncertainty interval `t <= (local=15.000000000,0, global=25.000000000,0)`; observed timestamps: []
 
 run error
 scan t=txn18 k=k8 localUncertaintyLimit=15,0
 ----
 scan: "k8"-"k8\x00" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 15.000000000,0 encountered previous write with future timestamp 20.000000000,0 within uncertainty interval `t <= (local=15.000000000,0, global=25.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 15.000000000,0 encountered previous write with future timestamp 20.000000000,0 (local=10.000000000,0) within uncertainty interval `t <= (local=15.000000000,0, global=25.000000000,0)`; observed timestamps: []
 
 
 run ok
@@ -1976,25 +1976,25 @@ run error
 get t=txn19 k=k3 localUncertaintyLimit=20,0
 ----
 get: "k3" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 15.000000000,0 encountered previous write with future timestamp 20.000000000,0 within uncertainty interval `t <= (local=20.000000000,0, global=25.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 15.000000000,0 encountered previous write with future timestamp 20.000000000,0 (local=10.000000000,0) within uncertainty interval `t <= (local=20.000000000,0, global=25.000000000,0)`; observed timestamps: []
 
 run error
 scan t=txn19 k=k3 localUncertaintyLimit=20,0
 ----
 scan: "k3"-"k3\x00" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 15.000000000,0 encountered previous write with future timestamp 20.000000000,0 within uncertainty interval `t <= (local=20.000000000,0, global=25.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 15.000000000,0 encountered previous write with future timestamp 20.000000000,0 (local=10.000000000,0) within uncertainty interval `t <= (local=20.000000000,0, global=25.000000000,0)`; observed timestamps: []
 
 run error
 get t=txn19 k=k4 localUncertaintyLimit=20,0
 ----
 get: "k4" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 15.000000000,0 encountered previous write with future timestamp 20.000000000,0 within uncertainty interval `t <= (local=20.000000000,0, global=25.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 15.000000000,0 encountered previous write with future timestamp 20.000000000,0 (local=10.000000000,0) within uncertainty interval `t <= (local=20.000000000,0, global=25.000000000,0)`; observed timestamps: []
 
 run error
 scan t=txn19 k=k4 localUncertaintyLimit=20,0
 ----
 scan: "k4"-"k4\x00" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 15.000000000,0 encountered previous write with future timestamp 20.000000000,0 within uncertainty interval `t <= (local=20.000000000,0, global=25.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 15.000000000,0 encountered previous write with future timestamp 20.000000000,0 (local=10.000000000,0) within uncertainty interval `t <= (local=20.000000000,0, global=25.000000000,0)`; observed timestamps: []
 
 run error
 get t=txn19 k=k5 localUncertaintyLimit=20,0
@@ -2024,25 +2024,25 @@ run error
 get t=txn19 k=k7 localUncertaintyLimit=20,0
 ----
 get: "k7" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 15.000000000,0 encountered previous write with future timestamp 20.000000000,0 within uncertainty interval `t <= (local=20.000000000,0, global=25.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 15.000000000,0 encountered previous write with future timestamp 20.000000000,0 (local=10.000000000,0) within uncertainty interval `t <= (local=20.000000000,0, global=25.000000000,0)`; observed timestamps: []
 
 run error
 scan t=txn19 k=k7 localUncertaintyLimit=20,0
 ----
 scan: "k7"-"k7\x00" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 15.000000000,0 encountered previous write with future timestamp 20.000000000,0 within uncertainty interval `t <= (local=20.000000000,0, global=25.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 15.000000000,0 encountered previous write with future timestamp 20.000000000,0 (local=10.000000000,0) within uncertainty interval `t <= (local=20.000000000,0, global=25.000000000,0)`; observed timestamps: []
 
 run error
 get t=txn19 k=k8 localUncertaintyLimit=20,0
 ----
 get: "k8" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 15.000000000,0 encountered previous write with future timestamp 20.000000000,0 within uncertainty interval `t <= (local=20.000000000,0, global=25.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 15.000000000,0 encountered previous write with future timestamp 20.000000000,0 (local=10.000000000,0) within uncertainty interval `t <= (local=20.000000000,0, global=25.000000000,0)`; observed timestamps: []
 
 run error
 scan t=txn19 k=k8 localUncertaintyLimit=20,0
 ----
 scan: "k8"-"k8\x00" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 15.000000000,0 encountered previous write with future timestamp 20.000000000,0 within uncertainty interval `t <= (local=20.000000000,0, global=25.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 15.000000000,0 encountered previous write with future timestamp 20.000000000,0 (local=10.000000000,0) within uncertainty interval `t <= (local=20.000000000,0, global=25.000000000,0)`; observed timestamps: []
 
 
 run ok
@@ -2246,13 +2246,13 @@ run error
 get k=k2 ts=5,0 localUncertaintyLimit=5,0 globalUncertaintyLimit=15,0
 ----
 get: "k2" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0 within uncertainty interval `t <= (local=5.000000000,0, global=0,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0 (local=5.000000000,0) within uncertainty interval `t <= (local=5.000000000,0, global=0,0)`; observed timestamps: []
 
 run error
 scan k=k2 ts=5,0 localUncertaintyLimit=5,0 globalUncertaintyLimit=15,0
 ----
 scan: "k2"-"k2\x00" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0 within uncertainty interval `t <= (local=5.000000000,0, global=0,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0 (local=5.000000000,0) within uncertainty interval `t <= (local=5.000000000,0, global=0,0)`; observed timestamps: []
 
 run ok
 get k=k3 ts=5,0 localUncertaintyLimit=5,0 globalUncertaintyLimit=15,0
@@ -2268,13 +2268,13 @@ run error
 get k=k4 ts=5,0 localUncertaintyLimit=5,0 globalUncertaintyLimit=15,0
 ----
 get: "k4" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0 within uncertainty interval `t <= (local=5.000000000,0, global=0,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0 (local=5.000000000,0) within uncertainty interval `t <= (local=5.000000000,0, global=0,0)`; observed timestamps: []
 
 run error
 scan k=k4 ts=5,0 localUncertaintyLimit=5,0 globalUncertaintyLimit=15,0
 ----
 scan: "k4"-"k4\x00" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0 within uncertainty interval `t <= (local=5.000000000,0, global=0,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0 (local=5.000000000,0) within uncertainty interval `t <= (local=5.000000000,0, global=0,0)`; observed timestamps: []
 
 run ok
 get k=k5 ts=5,0 localUncertaintyLimit=5,0 globalUncertaintyLimit=15,0
@@ -2290,13 +2290,13 @@ run error
 get k=k6 ts=5,0 localUncertaintyLimit=5,0 globalUncertaintyLimit=15,0
 ----
 get: "k6" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0 within uncertainty interval `t <= (local=5.000000000,0, global=0,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0 (local=5.000000000,0) within uncertainty interval `t <= (local=5.000000000,0, global=0,0)`; observed timestamps: []
 
 run error
 scan k=k6 ts=5,0 localUncertaintyLimit=5,0 globalUncertaintyLimit=15,0
 ----
 scan: "k6"-"k6\x00" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0 within uncertainty interval `t <= (local=5.000000000,0, global=0,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0 (local=5.000000000,0) within uncertainty interval `t <= (local=5.000000000,0, global=0,0)`; observed timestamps: []
 
 run ok
 get k=k7 ts=5,0 localUncertaintyLimit=5,0 globalUncertaintyLimit=15,0
@@ -2312,13 +2312,13 @@ run error
 get k=k8 ts=5,0 localUncertaintyLimit=5,0 globalUncertaintyLimit=15,0
 ----
 get: "k8" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0 within uncertainty interval `t <= (local=5.000000000,0, global=0,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0 (local=5.000000000,0) within uncertainty interval `t <= (local=5.000000000,0, global=0,0)`; observed timestamps: []
 
 run error
 scan k=k8 ts=5,0 localUncertaintyLimit=5,0 globalUncertaintyLimit=15,0
 ----
 scan: "k8"-"k8\x00" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0 within uncertainty interval `t <= (local=5.000000000,0, global=0,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0 (local=5.000000000,0) within uncertainty interval `t <= (local=5.000000000,0, global=0,0)`; observed timestamps: []
 
 run ok
 get k=k1 ts=5,0 localUncertaintyLimit=5,0 globalUncertaintyLimit=25,0
@@ -2334,13 +2334,13 @@ run error
 get k=k2 ts=5,0 localUncertaintyLimit=5,0 globalUncertaintyLimit=25,0
 ----
 get: "k2" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0 within uncertainty interval `t <= (local=5.000000000,0, global=0,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0 (local=5.000000000,0) within uncertainty interval `t <= (local=5.000000000,0, global=0,0)`; observed timestamps: []
 
 run error
 scan k=k2 ts=5,0 localUncertaintyLimit=5,0 globalUncertaintyLimit=25,0
 ----
 scan: "k2"-"k2\x00" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0 within uncertainty interval `t <= (local=5.000000000,0, global=0,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0 (local=5.000000000,0) within uncertainty interval `t <= (local=5.000000000,0, global=0,0)`; observed timestamps: []
 
 run ok
 get k=k3 ts=5,0 localUncertaintyLimit=5,0 globalUncertaintyLimit=25,0
@@ -2356,13 +2356,13 @@ run error
 get k=k4 ts=5,0 localUncertaintyLimit=5,0 globalUncertaintyLimit=25,0
 ----
 get: "k4" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0 within uncertainty interval `t <= (local=5.000000000,0, global=0,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0 (local=5.000000000,0) within uncertainty interval `t <= (local=5.000000000,0, global=0,0)`; observed timestamps: []
 
 run error
 scan k=k4 ts=5,0 localUncertaintyLimit=5,0 globalUncertaintyLimit=25,0
 ----
 scan: "k4"-"k4\x00" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0 within uncertainty interval `t <= (local=5.000000000,0, global=0,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0 (local=5.000000000,0) within uncertainty interval `t <= (local=5.000000000,0, global=0,0)`; observed timestamps: []
 
 run ok
 get k=k5 ts=5,0 localUncertaintyLimit=5,0 globalUncertaintyLimit=25,0
@@ -2378,13 +2378,13 @@ run error
 get k=k6 ts=5,0 localUncertaintyLimit=5,0 globalUncertaintyLimit=25,0
 ----
 get: "k6" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0 within uncertainty interval `t <= (local=5.000000000,0, global=0,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0 (local=5.000000000,0) within uncertainty interval `t <= (local=5.000000000,0, global=0,0)`; observed timestamps: []
 
 run error
 scan k=k6 ts=5,0 localUncertaintyLimit=5,0 globalUncertaintyLimit=25,0
 ----
 scan: "k6"-"k6\x00" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0 within uncertainty interval `t <= (local=5.000000000,0, global=0,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0 (local=5.000000000,0) within uncertainty interval `t <= (local=5.000000000,0, global=0,0)`; observed timestamps: []
 
 run ok
 get k=k7 ts=5,0 localUncertaintyLimit=5,0 globalUncertaintyLimit=25,0
@@ -2400,13 +2400,13 @@ run error
 get k=k8 ts=5,0 localUncertaintyLimit=5,0 globalUncertaintyLimit=25,0
 ----
 get: "k8" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0 within uncertainty interval `t <= (local=5.000000000,0, global=0,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0 (local=5.000000000,0) within uncertainty interval `t <= (local=5.000000000,0, global=0,0)`; observed timestamps: []
 
 run error
 scan k=k8 ts=5,0 localUncertaintyLimit=5,0 globalUncertaintyLimit=25,0
 ----
 scan: "k8"-"k8\x00" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0 within uncertainty interval `t <= (local=5.000000000,0, global=0,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0 (local=5.000000000,0) within uncertainty interval `t <= (local=5.000000000,0, global=0,0)`; observed timestamps: []
 
 run error
 get k=k1 ts=5,0 localUncertaintyLimit=15,0 globalUncertaintyLimit=15,0
@@ -2424,13 +2424,13 @@ run error
 get k=k2 ts=5,0 localUncertaintyLimit=15,0 globalUncertaintyLimit=15,0
 ----
 get: "k2" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0 within uncertainty interval `t <= (local=15.000000000,0, global=0,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0 (local=5.000000000,0) within uncertainty interval `t <= (local=15.000000000,0, global=0,0)`; observed timestamps: []
 
 run error
 scan k=k2 ts=5,0 localUncertaintyLimit=15,0 globalUncertaintyLimit=15,0
 ----
 scan: "k2"-"k2\x00" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0 within uncertainty interval `t <= (local=15.000000000,0, global=0,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0 (local=5.000000000,0) within uncertainty interval `t <= (local=15.000000000,0, global=0,0)`; observed timestamps: []
 
 run error
 get k=k3 ts=5,0 localUncertaintyLimit=15,0 globalUncertaintyLimit=15,0
@@ -2448,13 +2448,13 @@ run error
 get k=k4 ts=5,0 localUncertaintyLimit=15,0 globalUncertaintyLimit=15,0
 ----
 get: "k4" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0 within uncertainty interval `t <= (local=15.000000000,0, global=0,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0 (local=5.000000000,0) within uncertainty interval `t <= (local=15.000000000,0, global=0,0)`; observed timestamps: []
 
 run error
 scan k=k4 ts=5,0 localUncertaintyLimit=15,0 globalUncertaintyLimit=15,0
 ----
 scan: "k4"-"k4\x00" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0 within uncertainty interval `t <= (local=15.000000000,0, global=0,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0 (local=5.000000000,0) within uncertainty interval `t <= (local=15.000000000,0, global=0,0)`; observed timestamps: []
 
 run error
 get k=k5 ts=5,0 localUncertaintyLimit=15,0 globalUncertaintyLimit=15,0
@@ -2472,13 +2472,13 @@ run error
 get k=k6 ts=5,0 localUncertaintyLimit=15,0 globalUncertaintyLimit=15,0
 ----
 get: "k6" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0 within uncertainty interval `t <= (local=15.000000000,0, global=0,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0 (local=5.000000000,0) within uncertainty interval `t <= (local=15.000000000,0, global=0,0)`; observed timestamps: []
 
 run error
 scan k=k6 ts=5,0 localUncertaintyLimit=15,0 globalUncertaintyLimit=15,0
 ----
 scan: "k6"-"k6\x00" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0 within uncertainty interval `t <= (local=15.000000000,0, global=0,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0 (local=5.000000000,0) within uncertainty interval `t <= (local=15.000000000,0, global=0,0)`; observed timestamps: []
 
 run error
 get k=k7 ts=5,0 localUncertaintyLimit=15,0 globalUncertaintyLimit=15,0
@@ -2496,13 +2496,13 @@ run error
 get k=k8 ts=5,0 localUncertaintyLimit=15,0 globalUncertaintyLimit=15,0
 ----
 get: "k8" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0 within uncertainty interval `t <= (local=15.000000000,0, global=0,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0 (local=5.000000000,0) within uncertainty interval `t <= (local=15.000000000,0, global=0,0)`; observed timestamps: []
 
 run error
 scan k=k8 ts=5,0 localUncertaintyLimit=15,0 globalUncertaintyLimit=15,0
 ----
 scan: "k8"-"k8\x00" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0 within uncertainty interval `t <= (local=15.000000000,0, global=0,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0 (local=5.000000000,0) within uncertainty interval `t <= (local=15.000000000,0, global=0,0)`; observed timestamps: []
 
 run error
 get k=k1 ts=5,0 localUncertaintyLimit=15,0 globalUncertaintyLimit=25,0
@@ -2520,37 +2520,37 @@ run error
 get k=k2 ts=5,0 localUncertaintyLimit=15,0 globalUncertaintyLimit=25,0
 ----
 get: "k2" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0 within uncertainty interval `t <= (local=15.000000000,0, global=0,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0 (local=5.000000000,0) within uncertainty interval `t <= (local=15.000000000,0, global=0,0)`; observed timestamps: []
 
 run error
 scan k=k2 ts=5,0 localUncertaintyLimit=15,0 globalUncertaintyLimit=25,0
 ----
 scan: "k2"-"k2\x00" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0 within uncertainty interval `t <= (local=15.000000000,0, global=0,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0 (local=5.000000000,0) within uncertainty interval `t <= (local=15.000000000,0, global=0,0)`; observed timestamps: []
 
 run error
 get k=k3 ts=5,0 localUncertaintyLimit=15,0 globalUncertaintyLimit=25,0
 ----
 get: "k3" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0 within uncertainty interval `t <= (local=15.000000000,0, global=0,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0 (local=10.000000000,0) within uncertainty interval `t <= (local=15.000000000,0, global=0,0)`; observed timestamps: []
 
 run error
 scan k=k3 ts=5,0 localUncertaintyLimit=15,0 globalUncertaintyLimit=25,0
 ----
 scan: "k3"-"k3\x00" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0 within uncertainty interval `t <= (local=15.000000000,0, global=0,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0 (local=10.000000000,0) within uncertainty interval `t <= (local=15.000000000,0, global=0,0)`; observed timestamps: []
 
 run error
 get k=k4 ts=5,0 localUncertaintyLimit=15,0 globalUncertaintyLimit=25,0
 ----
 get: "k4" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0 within uncertainty interval `t <= (local=15.000000000,0, global=0,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0 (local=10.000000000,0) within uncertainty interval `t <= (local=15.000000000,0, global=0,0)`; observed timestamps: []
 
 run error
 scan k=k4 ts=5,0 localUncertaintyLimit=15,0 globalUncertaintyLimit=25,0
 ----
 scan: "k4"-"k4\x00" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0 within uncertainty interval `t <= (local=15.000000000,0, global=0,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0 (local=10.000000000,0) within uncertainty interval `t <= (local=15.000000000,0, global=0,0)`; observed timestamps: []
 
 run error
 get k=k5 ts=5,0 localUncertaintyLimit=15,0 globalUncertaintyLimit=25,0
@@ -2568,37 +2568,37 @@ run error
 get k=k6 ts=5,0 localUncertaintyLimit=15,0 globalUncertaintyLimit=25,0
 ----
 get: "k6" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0 within uncertainty interval `t <= (local=15.000000000,0, global=0,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0 (local=5.000000000,0) within uncertainty interval `t <= (local=15.000000000,0, global=0,0)`; observed timestamps: []
 
 run error
 scan k=k6 ts=5,0 localUncertaintyLimit=15,0 globalUncertaintyLimit=25,0
 ----
 scan: "k6"-"k6\x00" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0 within uncertainty interval `t <= (local=15.000000000,0, global=0,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0 (local=5.000000000,0) within uncertainty interval `t <= (local=15.000000000,0, global=0,0)`; observed timestamps: []
 
 run error
 get k=k7 ts=5,0 localUncertaintyLimit=15,0 globalUncertaintyLimit=25,0
 ----
 get: "k7" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0 within uncertainty interval `t <= (local=15.000000000,0, global=0,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0 (local=10.000000000,0) within uncertainty interval `t <= (local=15.000000000,0, global=0,0)`; observed timestamps: []
 
 run error
 scan k=k7 ts=5,0 localUncertaintyLimit=15,0 globalUncertaintyLimit=25,0
 ----
 scan: "k7"-"k7\x00" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0 within uncertainty interval `t <= (local=15.000000000,0, global=0,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0 (local=10.000000000,0) within uncertainty interval `t <= (local=15.000000000,0, global=0,0)`; observed timestamps: []
 
 run error
 get k=k8 ts=5,0 localUncertaintyLimit=15,0 globalUncertaintyLimit=25,0
 ----
 get: "k8" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0 within uncertainty interval `t <= (local=15.000000000,0, global=0,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0 (local=10.000000000,0) within uncertainty interval `t <= (local=15.000000000,0, global=0,0)`; observed timestamps: []
 
 run error
 scan k=k8 ts=5,0 localUncertaintyLimit=15,0 globalUncertaintyLimit=25,0
 ----
 scan: "k8"-"k8\x00" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0 within uncertainty interval `t <= (local=15.000000000,0, global=0,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0 (local=10.000000000,0) within uncertainty interval `t <= (local=15.000000000,0, global=0,0)`; observed timestamps: []
 
 run error
 get k=k1 ts=5,0 localUncertaintyLimit=25,0 globalUncertaintyLimit=25,0
@@ -2628,25 +2628,25 @@ run error
 get k=k3 ts=5,0 localUncertaintyLimit=25,0 globalUncertaintyLimit=25,0
 ----
 get: "k3" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0 within uncertainty interval `t <= (local=25.000000000,0, global=0,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0 (local=10.000000000,0) within uncertainty interval `t <= (local=25.000000000,0, global=0,0)`; observed timestamps: []
 
 run error
 scan k=k3 ts=5,0 localUncertaintyLimit=25,0 globalUncertaintyLimit=25,0
 ----
 scan: "k3"-"k3\x00" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0 within uncertainty interval `t <= (local=25.000000000,0, global=0,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0 (local=10.000000000,0) within uncertainty interval `t <= (local=25.000000000,0, global=0,0)`; observed timestamps: []
 
 run error
 get k=k4 ts=5,0 localUncertaintyLimit=25,0 globalUncertaintyLimit=25,0
 ----
 get: "k4" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0 within uncertainty interval `t <= (local=25.000000000,0, global=0,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0 (local=10.000000000,0) within uncertainty interval `t <= (local=25.000000000,0, global=0,0)`; observed timestamps: []
 
 run error
 scan k=k4 ts=5,0 localUncertaintyLimit=25,0 globalUncertaintyLimit=25,0
 ----
 scan: "k4"-"k4\x00" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0 within uncertainty interval `t <= (local=25.000000000,0, global=0,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0 (local=10.000000000,0) within uncertainty interval `t <= (local=25.000000000,0, global=0,0)`; observed timestamps: []
 
 run error
 get k=k5 ts=5,0 localUncertaintyLimit=25,0 globalUncertaintyLimit=25,0
@@ -2676,25 +2676,25 @@ run error
 get k=k7 ts=5,0 localUncertaintyLimit=25,0 globalUncertaintyLimit=25,0
 ----
 get: "k7" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0 within uncertainty interval `t <= (local=25.000000000,0, global=0,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0 (local=10.000000000,0) within uncertainty interval `t <= (local=25.000000000,0, global=0,0)`; observed timestamps: []
 
 run error
 scan k=k7 ts=5,0 localUncertaintyLimit=25,0 globalUncertaintyLimit=25,0
 ----
 scan: "k7"-"k7\x00" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0 within uncertainty interval `t <= (local=25.000000000,0, global=0,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0 (local=10.000000000,0) within uncertainty interval `t <= (local=25.000000000,0, global=0,0)`; observed timestamps: []
 
 run error
 get k=k8 ts=5,0 localUncertaintyLimit=25,0 globalUncertaintyLimit=25,0
 ----
 get: "k8" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0 within uncertainty interval `t <= (local=25.000000000,0, global=0,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0 (local=10.000000000,0) within uncertainty interval `t <= (local=25.000000000,0, global=0,0)`; observed timestamps: []
 
 run error
 scan k=k8 ts=5,0 localUncertaintyLimit=25,0 globalUncertaintyLimit=25,0
 ----
 scan: "k8"-"k8\x00" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0 within uncertainty interval `t <= (local=25.000000000,0, global=0,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0 (local=10.000000000,0) within uncertainty interval `t <= (local=25.000000000,0, global=0,0)`; observed timestamps: []
 
 run ok
 get k=k1 ts=15,0 localUncertaintyLimit=15,0 globalUncertaintyLimit=15,0
@@ -2800,25 +2800,25 @@ run error
 get k=k3 ts=15,0 localUncertaintyLimit=15,0 globalUncertaintyLimit=25,0
 ----
 get: "k3" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 15.000000000,0 encountered previous write with future timestamp 20.000000000,0 within uncertainty interval `t <= (local=15.000000000,0, global=0,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 15.000000000,0 encountered previous write with future timestamp 20.000000000,0 (local=10.000000000,0) within uncertainty interval `t <= (local=15.000000000,0, global=0,0)`; observed timestamps: []
 
 run error
 scan k=k3 ts=15,0 localUncertaintyLimit=15,0 globalUncertaintyLimit=25,0
 ----
 scan: "k3"-"k3\x00" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 15.000000000,0 encountered previous write with future timestamp 20.000000000,0 within uncertainty interval `t <= (local=15.000000000,0, global=0,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 15.000000000,0 encountered previous write with future timestamp 20.000000000,0 (local=10.000000000,0) within uncertainty interval `t <= (local=15.000000000,0, global=0,0)`; observed timestamps: []
 
 run error
 get k=k4 ts=15,0 localUncertaintyLimit=15,0 globalUncertaintyLimit=25,0
 ----
 get: "k4" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 15.000000000,0 encountered previous write with future timestamp 20.000000000,0 within uncertainty interval `t <= (local=15.000000000,0, global=0,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 15.000000000,0 encountered previous write with future timestamp 20.000000000,0 (local=10.000000000,0) within uncertainty interval `t <= (local=15.000000000,0, global=0,0)`; observed timestamps: []
 
 run error
 scan k=k4 ts=15,0 localUncertaintyLimit=15,0 globalUncertaintyLimit=25,0
 ----
 scan: "k4"-"k4\x00" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 15.000000000,0 encountered previous write with future timestamp 20.000000000,0 within uncertainty interval `t <= (local=15.000000000,0, global=0,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 15.000000000,0 encountered previous write with future timestamp 20.000000000,0 (local=10.000000000,0) within uncertainty interval `t <= (local=15.000000000,0, global=0,0)`; observed timestamps: []
 
 run ok
 get k=k5 ts=15,0 localUncertaintyLimit=15,0 globalUncertaintyLimit=25,0
@@ -2844,25 +2844,25 @@ run error
 get k=k7 ts=15,0 localUncertaintyLimit=15,0 globalUncertaintyLimit=25,0
 ----
 get: "k7" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 15.000000000,0 encountered previous write with future timestamp 20.000000000,0 within uncertainty interval `t <= (local=15.000000000,0, global=0,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 15.000000000,0 encountered previous write with future timestamp 20.000000000,0 (local=10.000000000,0) within uncertainty interval `t <= (local=15.000000000,0, global=0,0)`; observed timestamps: []
 
 run error
 scan k=k7 ts=15,0 localUncertaintyLimit=15,0 globalUncertaintyLimit=25,0
 ----
 scan: "k7"-"k7\x00" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 15.000000000,0 encountered previous write with future timestamp 20.000000000,0 within uncertainty interval `t <= (local=15.000000000,0, global=0,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 15.000000000,0 encountered previous write with future timestamp 20.000000000,0 (local=10.000000000,0) within uncertainty interval `t <= (local=15.000000000,0, global=0,0)`; observed timestamps: []
 
 run error
 get k=k8 ts=15,0 localUncertaintyLimit=15,0 globalUncertaintyLimit=25,0
 ----
 get: "k8" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 15.000000000,0 encountered previous write with future timestamp 20.000000000,0 within uncertainty interval `t <= (local=15.000000000,0, global=0,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 15.000000000,0 encountered previous write with future timestamp 20.000000000,0 (local=10.000000000,0) within uncertainty interval `t <= (local=15.000000000,0, global=0,0)`; observed timestamps: []
 
 run error
 scan k=k8 ts=15,0 localUncertaintyLimit=15,0 globalUncertaintyLimit=25,0
 ----
 scan: "k8"-"k8\x00" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 15.000000000,0 encountered previous write with future timestamp 20.000000000,0 within uncertainty interval `t <= (local=15.000000000,0, global=0,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 15.000000000,0 encountered previous write with future timestamp 20.000000000,0 (local=10.000000000,0) within uncertainty interval `t <= (local=15.000000000,0, global=0,0)`; observed timestamps: []
 
 run error
 get k=k1 ts=15,0 localUncertaintyLimit=25,0 globalUncertaintyLimit=25,0
@@ -2892,25 +2892,25 @@ run error
 get k=k3 ts=15,0 localUncertaintyLimit=25,0 globalUncertaintyLimit=25,0
 ----
 get: "k3" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 15.000000000,0 encountered previous write with future timestamp 20.000000000,0 within uncertainty interval `t <= (local=25.000000000,0, global=0,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 15.000000000,0 encountered previous write with future timestamp 20.000000000,0 (local=10.000000000,0) within uncertainty interval `t <= (local=25.000000000,0, global=0,0)`; observed timestamps: []
 
 run error
 scan k=k3 ts=15,0 localUncertaintyLimit=25,0 globalUncertaintyLimit=25,0
 ----
 scan: "k3"-"k3\x00" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 15.000000000,0 encountered previous write with future timestamp 20.000000000,0 within uncertainty interval `t <= (local=25.000000000,0, global=0,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 15.000000000,0 encountered previous write with future timestamp 20.000000000,0 (local=10.000000000,0) within uncertainty interval `t <= (local=25.000000000,0, global=0,0)`; observed timestamps: []
 
 run error
 get k=k4 ts=15,0 localUncertaintyLimit=25,0 globalUncertaintyLimit=25,0
 ----
 get: "k4" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 15.000000000,0 encountered previous write with future timestamp 20.000000000,0 within uncertainty interval `t <= (local=25.000000000,0, global=0,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 15.000000000,0 encountered previous write with future timestamp 20.000000000,0 (local=10.000000000,0) within uncertainty interval `t <= (local=25.000000000,0, global=0,0)`; observed timestamps: []
 
 run error
 scan k=k4 ts=15,0 localUncertaintyLimit=25,0 globalUncertaintyLimit=25,0
 ----
 scan: "k4"-"k4\x00" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 15.000000000,0 encountered previous write with future timestamp 20.000000000,0 within uncertainty interval `t <= (local=25.000000000,0, global=0,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 15.000000000,0 encountered previous write with future timestamp 20.000000000,0 (local=10.000000000,0) within uncertainty interval `t <= (local=25.000000000,0, global=0,0)`; observed timestamps: []
 
 run error
 get k=k5 ts=15,0 localUncertaintyLimit=25,0 globalUncertaintyLimit=25,0
@@ -2940,25 +2940,25 @@ run error
 get k=k7 ts=15,0 localUncertaintyLimit=25,0 globalUncertaintyLimit=25,0
 ----
 get: "k7" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 15.000000000,0 encountered previous write with future timestamp 20.000000000,0 within uncertainty interval `t <= (local=25.000000000,0, global=0,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 15.000000000,0 encountered previous write with future timestamp 20.000000000,0 (local=10.000000000,0) within uncertainty interval `t <= (local=25.000000000,0, global=0,0)`; observed timestamps: []
 
 run error
 scan k=k7 ts=15,0 localUncertaintyLimit=25,0 globalUncertaintyLimit=25,0
 ----
 scan: "k7"-"k7\x00" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 15.000000000,0 encountered previous write with future timestamp 20.000000000,0 within uncertainty interval `t <= (local=25.000000000,0, global=0,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 15.000000000,0 encountered previous write with future timestamp 20.000000000,0 (local=10.000000000,0) within uncertainty interval `t <= (local=25.000000000,0, global=0,0)`; observed timestamps: []
 
 run error
 get k=k8 ts=15,0 localUncertaintyLimit=25,0 globalUncertaintyLimit=25,0
 ----
 get: "k8" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 15.000000000,0 encountered previous write with future timestamp 20.000000000,0 within uncertainty interval `t <= (local=25.000000000,0, global=0,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 15.000000000,0 encountered previous write with future timestamp 20.000000000,0 (local=10.000000000,0) within uncertainty interval `t <= (local=25.000000000,0, global=0,0)`; observed timestamps: []
 
 run error
 scan k=k8 ts=15,0 localUncertaintyLimit=25,0 globalUncertaintyLimit=25,0
 ----
 scan: "k8"-"k8\x00" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 15.000000000,0 encountered previous write with future timestamp 20.000000000,0 within uncertainty interval `t <= (local=25.000000000,0, global=0,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 15.000000000,0 encountered previous write with future timestamp 20.000000000,0 (local=10.000000000,0) within uncertainty interval `t <= (local=25.000000000,0, global=0,0)`; observed timestamps: []
 
 run ok
 get k=k1 ts=25,0 localUncertaintyLimit=25,0 globalUncertaintyLimit=25,0

--- a/pkg/storage/testdata/mvcc_histories/uncertainty_interval_with_local_uncertainty_limit_and_synthetic_timestamps
+++ b/pkg/storage/testdata/mvcc_histories/uncertainty_interval_with_local_uncertainty_limit_and_synthetic_timestamps
@@ -204,13 +204,13 @@ run error
 get t=txn1 k=k2 localUncertaintyLimit=5,0
 ----
 get: "k2" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0? within uncertainty interval `t <= (local=5.000000000,0, global=10.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0? (local=0,1) within uncertainty interval `t <= (local=5.000000000,0, global=10.000000000,0)`; observed timestamps: []
 
 run error
 scan t=txn1 k=k2 localUncertaintyLimit=5,0
 ----
 scan: "k2"-"k2\x00" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0? within uncertainty interval `t <= (local=5.000000000,0, global=10.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0? (local=0,1) within uncertainty interval `t <= (local=5.000000000,0, global=10.000000000,0)`; observed timestamps: []
 
 run ok
 get t=txn1 k=k3 localUncertaintyLimit=5,0
@@ -226,13 +226,13 @@ run error
 get t=txn1 k=k4 localUncertaintyLimit=5,0
 ----
 get: "k4" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0? within uncertainty interval `t <= (local=5.000000000,0, global=10.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0? (local=0,1) within uncertainty interval `t <= (local=5.000000000,0, global=10.000000000,0)`; observed timestamps: []
 
 run error
 scan t=txn1 k=k4 localUncertaintyLimit=5,0
 ----
 scan: "k4"-"k4\x00" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0? within uncertainty interval `t <= (local=5.000000000,0, global=10.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0? (local=0,1) within uncertainty interval `t <= (local=5.000000000,0, global=10.000000000,0)`; observed timestamps: []
 
 run ok
 get t=txn1 k=k5 localUncertaintyLimit=5,0
@@ -248,13 +248,13 @@ run error
 get t=txn1 k=k6 localUncertaintyLimit=5,0
 ----
 get: "k6" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0? within uncertainty interval `t <= (local=5.000000000,0, global=10.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0? (local=0,1) within uncertainty interval `t <= (local=5.000000000,0, global=10.000000000,0)`; observed timestamps: []
 
 run error
 scan t=txn1 k=k6 localUncertaintyLimit=5,0
 ----
 scan: "k6"-"k6\x00" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0? within uncertainty interval `t <= (local=5.000000000,0, global=10.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0? (local=0,1) within uncertainty interval `t <= (local=5.000000000,0, global=10.000000000,0)`; observed timestamps: []
 
 run ok
 get t=txn1 k=k7 localUncertaintyLimit=5,0
@@ -270,13 +270,13 @@ run error
 get t=txn1 k=k8 localUncertaintyLimit=5,0
 ----
 get: "k8" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0? within uncertainty interval `t <= (local=5.000000000,0, global=10.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0? (local=0,1) within uncertainty interval `t <= (local=5.000000000,0, global=10.000000000,0)`; observed timestamps: []
 
 run error
 scan t=txn1 k=k8 localUncertaintyLimit=5,0
 ----
 scan: "k8"-"k8\x00" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0? within uncertainty interval `t <= (local=5.000000000,0, global=10.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0? (local=0,1) within uncertainty interval `t <= (local=5.000000000,0, global=10.000000000,0)`; observed timestamps: []
 
 
 run ok
@@ -299,13 +299,13 @@ run error
 get t=txn2 k=k2 localUncertaintyLimit=5,0
 ----
 get: "k2" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0? within uncertainty interval `t <= (local=5.000000000,0, global=15.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0? (local=0,1) within uncertainty interval `t <= (local=5.000000000,0, global=15.000000000,0)`; observed timestamps: []
 
 run error
 scan t=txn2 k=k2 localUncertaintyLimit=5,0
 ----
 scan: "k2"-"k2\x00" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0? within uncertainty interval `t <= (local=5.000000000,0, global=15.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0? (local=0,1) within uncertainty interval `t <= (local=5.000000000,0, global=15.000000000,0)`; observed timestamps: []
 
 run ok
 get t=txn2 k=k3 localUncertaintyLimit=5,0
@@ -321,13 +321,13 @@ run error
 get t=txn2 k=k4 localUncertaintyLimit=5,0
 ----
 get: "k4" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0? within uncertainty interval `t <= (local=5.000000000,0, global=15.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0? (local=0,1) within uncertainty interval `t <= (local=5.000000000,0, global=15.000000000,0)`; observed timestamps: []
 
 run error
 scan t=txn2 k=k4 localUncertaintyLimit=5,0
 ----
 scan: "k4"-"k4\x00" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0? within uncertainty interval `t <= (local=5.000000000,0, global=15.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0? (local=0,1) within uncertainty interval `t <= (local=5.000000000,0, global=15.000000000,0)`; observed timestamps: []
 
 run ok
 get t=txn2 k=k5 localUncertaintyLimit=5,0
@@ -343,13 +343,13 @@ run error
 get t=txn2 k=k6 localUncertaintyLimit=5,0
 ----
 get: "k6" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0? within uncertainty interval `t <= (local=5.000000000,0, global=15.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0? (local=0,1) within uncertainty interval `t <= (local=5.000000000,0, global=15.000000000,0)`; observed timestamps: []
 
 run error
 scan t=txn2 k=k6 localUncertaintyLimit=5,0
 ----
 scan: "k6"-"k6\x00" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0? within uncertainty interval `t <= (local=5.000000000,0, global=15.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0? (local=0,1) within uncertainty interval `t <= (local=5.000000000,0, global=15.000000000,0)`; observed timestamps: []
 
 run ok
 get t=txn2 k=k7 localUncertaintyLimit=5,0
@@ -365,13 +365,13 @@ run error
 get t=txn2 k=k8 localUncertaintyLimit=5,0
 ----
 get: "k8" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0? within uncertainty interval `t <= (local=5.000000000,0, global=15.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0? (local=0,1) within uncertainty interval `t <= (local=5.000000000,0, global=15.000000000,0)`; observed timestamps: []
 
 run error
 scan t=txn2 k=k8 localUncertaintyLimit=5,0
 ----
 scan: "k8"-"k8\x00" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0? within uncertainty interval `t <= (local=5.000000000,0, global=15.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0? (local=0,1) within uncertainty interval `t <= (local=5.000000000,0, global=15.000000000,0)`; observed timestamps: []
 
 
 run ok
@@ -394,37 +394,37 @@ run error
 get t=txn3 k=k2 localUncertaintyLimit=5,0
 ----
 get: "k2" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0? within uncertainty interval `t <= (local=5.000000000,0, global=20.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0? (local=0,1) within uncertainty interval `t <= (local=5.000000000,0, global=20.000000000,0)`; observed timestamps: []
 
 run error
 scan t=txn3 k=k2 localUncertaintyLimit=5,0
 ----
 scan: "k2"-"k2\x00" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0? within uncertainty interval `t <= (local=5.000000000,0, global=20.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0? (local=0,1) within uncertainty interval `t <= (local=5.000000000,0, global=20.000000000,0)`; observed timestamps: []
 
 run error
 get t=txn3 k=k3 localUncertaintyLimit=5,0
 ----
 get: "k3" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0? within uncertainty interval `t <= (local=5.000000000,0, global=20.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=5.000000000,0, global=20.000000000,0)`; observed timestamps: []
 
 run error
 scan t=txn3 k=k3 localUncertaintyLimit=5,0
 ----
 scan: "k3"-"k3\x00" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0? within uncertainty interval `t <= (local=5.000000000,0, global=20.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=5.000000000,0, global=20.000000000,0)`; observed timestamps: []
 
 run error
 get t=txn3 k=k4 localUncertaintyLimit=5,0
 ----
 get: "k4" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0? within uncertainty interval `t <= (local=5.000000000,0, global=20.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=5.000000000,0, global=20.000000000,0)`; observed timestamps: []
 
 run error
 scan t=txn3 k=k4 localUncertaintyLimit=5,0
 ----
 scan: "k4"-"k4\x00" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0? within uncertainty interval `t <= (local=5.000000000,0, global=20.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=5.000000000,0, global=20.000000000,0)`; observed timestamps: []
 
 run ok
 get t=txn3 k=k5 localUncertaintyLimit=5,0
@@ -440,37 +440,37 @@ run error
 get t=txn3 k=k6 localUncertaintyLimit=5,0
 ----
 get: "k6" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0? within uncertainty interval `t <= (local=5.000000000,0, global=20.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0? (local=0,1) within uncertainty interval `t <= (local=5.000000000,0, global=20.000000000,0)`; observed timestamps: []
 
 run error
 scan t=txn3 k=k6 localUncertaintyLimit=5,0
 ----
 scan: "k6"-"k6\x00" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0? within uncertainty interval `t <= (local=5.000000000,0, global=20.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0? (local=0,1) within uncertainty interval `t <= (local=5.000000000,0, global=20.000000000,0)`; observed timestamps: []
 
 run error
 get t=txn3 k=k7 localUncertaintyLimit=5,0
 ----
 get: "k7" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0? within uncertainty interval `t <= (local=5.000000000,0, global=20.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=5.000000000,0, global=20.000000000,0)`; observed timestamps: []
 
 run error
 scan t=txn3 k=k7 localUncertaintyLimit=5,0
 ----
 scan: "k7"-"k7\x00" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0? within uncertainty interval `t <= (local=5.000000000,0, global=20.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=5.000000000,0, global=20.000000000,0)`; observed timestamps: []
 
 run error
 get t=txn3 k=k8 localUncertaintyLimit=5,0
 ----
 get: "k8" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0? within uncertainty interval `t <= (local=5.000000000,0, global=20.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=5.000000000,0, global=20.000000000,0)`; observed timestamps: []
 
 run error
 scan t=txn3 k=k8 localUncertaintyLimit=5,0
 ----
 scan: "k8"-"k8\x00" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0? within uncertainty interval `t <= (local=5.000000000,0, global=20.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=5.000000000,0, global=20.000000000,0)`; observed timestamps: []
 
 
 run ok
@@ -493,37 +493,37 @@ run error
 get t=txn4 k=k2 localUncertaintyLimit=5,0
 ----
 get: "k2" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0? within uncertainty interval `t <= (local=5.000000000,0, global=25.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0? (local=0,1) within uncertainty interval `t <= (local=5.000000000,0, global=25.000000000,0)`; observed timestamps: []
 
 run error
 scan t=txn4 k=k2 localUncertaintyLimit=5,0
 ----
 scan: "k2"-"k2\x00" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0? within uncertainty interval `t <= (local=5.000000000,0, global=25.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0? (local=0,1) within uncertainty interval `t <= (local=5.000000000,0, global=25.000000000,0)`; observed timestamps: []
 
 run error
 get t=txn4 k=k3 localUncertaintyLimit=5,0
 ----
 get: "k3" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0? within uncertainty interval `t <= (local=5.000000000,0, global=25.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=5.000000000,0, global=25.000000000,0)`; observed timestamps: []
 
 run error
 scan t=txn4 k=k3 localUncertaintyLimit=5,0
 ----
 scan: "k3"-"k3\x00" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0? within uncertainty interval `t <= (local=5.000000000,0, global=25.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=5.000000000,0, global=25.000000000,0)`; observed timestamps: []
 
 run error
 get t=txn4 k=k4 localUncertaintyLimit=5,0
 ----
 get: "k4" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0? within uncertainty interval `t <= (local=5.000000000,0, global=25.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=5.000000000,0, global=25.000000000,0)`; observed timestamps: []
 
 run error
 scan t=txn4 k=k4 localUncertaintyLimit=5,0
 ----
 scan: "k4"-"k4\x00" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0? within uncertainty interval `t <= (local=5.000000000,0, global=25.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=5.000000000,0, global=25.000000000,0)`; observed timestamps: []
 
 run ok
 get t=txn4 k=k5 localUncertaintyLimit=5,0
@@ -539,37 +539,37 @@ run error
 get t=txn4 k=k6 localUncertaintyLimit=5,0
 ----
 get: "k6" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0? within uncertainty interval `t <= (local=5.000000000,0, global=25.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0? (local=0,1) within uncertainty interval `t <= (local=5.000000000,0, global=25.000000000,0)`; observed timestamps: []
 
 run error
 scan t=txn4 k=k6 localUncertaintyLimit=5,0
 ----
 scan: "k6"-"k6\x00" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0? within uncertainty interval `t <= (local=5.000000000,0, global=25.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0? (local=0,1) within uncertainty interval `t <= (local=5.000000000,0, global=25.000000000,0)`; observed timestamps: []
 
 run error
 get t=txn4 k=k7 localUncertaintyLimit=5,0
 ----
 get: "k7" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0? within uncertainty interval `t <= (local=5.000000000,0, global=25.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=5.000000000,0, global=25.000000000,0)`; observed timestamps: []
 
 run error
 scan t=txn4 k=k7 localUncertaintyLimit=5,0
 ----
 scan: "k7"-"k7\x00" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0? within uncertainty interval `t <= (local=5.000000000,0, global=25.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=5.000000000,0, global=25.000000000,0)`; observed timestamps: []
 
 run error
 get t=txn4 k=k8 localUncertaintyLimit=5,0
 ----
 get: "k8" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0? within uncertainty interval `t <= (local=5.000000000,0, global=25.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=5.000000000,0, global=25.000000000,0)`; observed timestamps: []
 
 run error
 scan t=txn4 k=k8 localUncertaintyLimit=5,0
 ----
 scan: "k8"-"k8\x00" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0? within uncertainty interval `t <= (local=5.000000000,0, global=25.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=5.000000000,0, global=25.000000000,0)`; observed timestamps: []
 
 
 run ok
@@ -594,13 +594,13 @@ run error
 get t=txn5 k=k2 localUncertaintyLimit=10,0
 ----
 get: "k2" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0? within uncertainty interval `t <= (local=10.000000000,0, global=15.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0? (local=0,1) within uncertainty interval `t <= (local=10.000000000,0, global=15.000000000,0)`; observed timestamps: []
 
 run error
 scan t=txn5 k=k2 localUncertaintyLimit=10,0
 ----
 scan: "k2"-"k2\x00" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0? within uncertainty interval `t <= (local=10.000000000,0, global=15.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0? (local=0,1) within uncertainty interval `t <= (local=10.000000000,0, global=15.000000000,0)`; observed timestamps: []
 
 run error
 get t=txn5 k=k3 localUncertaintyLimit=10,0
@@ -618,13 +618,13 @@ run error
 get t=txn5 k=k4 localUncertaintyLimit=10,0
 ----
 get: "k4" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0? within uncertainty interval `t <= (local=10.000000000,0, global=15.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0? (local=0,1) within uncertainty interval `t <= (local=10.000000000,0, global=15.000000000,0)`; observed timestamps: []
 
 run error
 scan t=txn5 k=k4 localUncertaintyLimit=10,0
 ----
 scan: "k4"-"k4\x00" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0? within uncertainty interval `t <= (local=10.000000000,0, global=15.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0? (local=0,1) within uncertainty interval `t <= (local=10.000000000,0, global=15.000000000,0)`; observed timestamps: []
 
 run error
 get t=txn5 k=k5 localUncertaintyLimit=10,0
@@ -642,13 +642,13 @@ run error
 get t=txn5 k=k6 localUncertaintyLimit=10,0
 ----
 get: "k6" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0? within uncertainty interval `t <= (local=10.000000000,0, global=15.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0? (local=0,1) within uncertainty interval `t <= (local=10.000000000,0, global=15.000000000,0)`; observed timestamps: []
 
 run error
 scan t=txn5 k=k6 localUncertaintyLimit=10,0
 ----
 scan: "k6"-"k6\x00" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0? within uncertainty interval `t <= (local=10.000000000,0, global=15.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0? (local=0,1) within uncertainty interval `t <= (local=10.000000000,0, global=15.000000000,0)`; observed timestamps: []
 
 run error
 get t=txn5 k=k7 localUncertaintyLimit=10,0
@@ -666,13 +666,13 @@ run error
 get t=txn5 k=k8 localUncertaintyLimit=10,0
 ----
 get: "k8" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0? within uncertainty interval `t <= (local=10.000000000,0, global=15.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0? (local=0,1) within uncertainty interval `t <= (local=10.000000000,0, global=15.000000000,0)`; observed timestamps: []
 
 run error
 scan t=txn5 k=k8 localUncertaintyLimit=10,0
 ----
 scan: "k8"-"k8\x00" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0? within uncertainty interval `t <= (local=10.000000000,0, global=15.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0? (local=0,1) within uncertainty interval `t <= (local=10.000000000,0, global=15.000000000,0)`; observed timestamps: []
 
 
 run ok
@@ -697,37 +697,37 @@ run error
 get t=txn6 k=k2 localUncertaintyLimit=10,0
 ----
 get: "k2" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0? within uncertainty interval `t <= (local=10.000000000,0, global=20.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0? (local=0,1) within uncertainty interval `t <= (local=10.000000000,0, global=20.000000000,0)`; observed timestamps: []
 
 run error
 scan t=txn6 k=k2 localUncertaintyLimit=10,0
 ----
 scan: "k2"-"k2\x00" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0? within uncertainty interval `t <= (local=10.000000000,0, global=20.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0? (local=0,1) within uncertainty interval `t <= (local=10.000000000,0, global=20.000000000,0)`; observed timestamps: []
 
 run error
 get t=txn6 k=k3 localUncertaintyLimit=10,0
 ----
 get: "k3" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0? within uncertainty interval `t <= (local=10.000000000,0, global=20.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=10.000000000,0, global=20.000000000,0)`; observed timestamps: []
 
 run error
 scan t=txn6 k=k3 localUncertaintyLimit=10,0
 ----
 scan: "k3"-"k3\x00" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0? within uncertainty interval `t <= (local=10.000000000,0, global=20.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=10.000000000,0, global=20.000000000,0)`; observed timestamps: []
 
 run error
 get t=txn6 k=k4 localUncertaintyLimit=10,0
 ----
 get: "k4" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0? within uncertainty interval `t <= (local=10.000000000,0, global=20.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=10.000000000,0, global=20.000000000,0)`; observed timestamps: []
 
 run error
 scan t=txn6 k=k4 localUncertaintyLimit=10,0
 ----
 scan: "k4"-"k4\x00" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0? within uncertainty interval `t <= (local=10.000000000,0, global=20.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=10.000000000,0, global=20.000000000,0)`; observed timestamps: []
 
 run error
 get t=txn6 k=k5 localUncertaintyLimit=10,0
@@ -745,37 +745,37 @@ run error
 get t=txn6 k=k6 localUncertaintyLimit=10,0
 ----
 get: "k6" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0? within uncertainty interval `t <= (local=10.000000000,0, global=20.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0? (local=0,1) within uncertainty interval `t <= (local=10.000000000,0, global=20.000000000,0)`; observed timestamps: []
 
 run error
 scan t=txn6 k=k6 localUncertaintyLimit=10,0
 ----
 scan: "k6"-"k6\x00" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0? within uncertainty interval `t <= (local=10.000000000,0, global=20.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0? (local=0,1) within uncertainty interval `t <= (local=10.000000000,0, global=20.000000000,0)`; observed timestamps: []
 
 run error
 get t=txn6 k=k7 localUncertaintyLimit=10,0
 ----
 get: "k7" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0? within uncertainty interval `t <= (local=10.000000000,0, global=20.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=10.000000000,0, global=20.000000000,0)`; observed timestamps: []
 
 run error
 scan t=txn6 k=k7 localUncertaintyLimit=10,0
 ----
 scan: "k7"-"k7\x00" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0? within uncertainty interval `t <= (local=10.000000000,0, global=20.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=10.000000000,0, global=20.000000000,0)`; observed timestamps: []
 
 run error
 get t=txn6 k=k8 localUncertaintyLimit=10,0
 ----
 get: "k8" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0? within uncertainty interval `t <= (local=10.000000000,0, global=20.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=10.000000000,0, global=20.000000000,0)`; observed timestamps: []
 
 run error
 scan t=txn6 k=k8 localUncertaintyLimit=10,0
 ----
 scan: "k8"-"k8\x00" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0? within uncertainty interval `t <= (local=10.000000000,0, global=20.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=10.000000000,0, global=20.000000000,0)`; observed timestamps: []
 
 
 run ok
@@ -800,37 +800,37 @@ run error
 get t=txn7 k=k2 localUncertaintyLimit=10,0
 ----
 get: "k2" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0? within uncertainty interval `t <= (local=10.000000000,0, global=25.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0? (local=0,1) within uncertainty interval `t <= (local=10.000000000,0, global=25.000000000,0)`; observed timestamps: []
 
 run error
 scan t=txn7 k=k2 localUncertaintyLimit=10,0
 ----
 scan: "k2"-"k2\x00" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0? within uncertainty interval `t <= (local=10.000000000,0, global=25.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0? (local=0,1) within uncertainty interval `t <= (local=10.000000000,0, global=25.000000000,0)`; observed timestamps: []
 
 run error
 get t=txn7 k=k3 localUncertaintyLimit=10,0
 ----
 get: "k3" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0? within uncertainty interval `t <= (local=10.000000000,0, global=25.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=10.000000000,0, global=25.000000000,0)`; observed timestamps: []
 
 run error
 scan t=txn7 k=k3 localUncertaintyLimit=10,0
 ----
 scan: "k3"-"k3\x00" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0? within uncertainty interval `t <= (local=10.000000000,0, global=25.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=10.000000000,0, global=25.000000000,0)`; observed timestamps: []
 
 run error
 get t=txn7 k=k4 localUncertaintyLimit=10,0
 ----
 get: "k4" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0? within uncertainty interval `t <= (local=10.000000000,0, global=25.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=10.000000000,0, global=25.000000000,0)`; observed timestamps: []
 
 run error
 scan t=txn7 k=k4 localUncertaintyLimit=10,0
 ----
 scan: "k4"-"k4\x00" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0? within uncertainty interval `t <= (local=10.000000000,0, global=25.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=10.000000000,0, global=25.000000000,0)`; observed timestamps: []
 
 run error
 get t=txn7 k=k5 localUncertaintyLimit=10,0
@@ -848,37 +848,37 @@ run error
 get t=txn7 k=k6 localUncertaintyLimit=10,0
 ----
 get: "k6" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0? within uncertainty interval `t <= (local=10.000000000,0, global=25.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0? (local=0,1) within uncertainty interval `t <= (local=10.000000000,0, global=25.000000000,0)`; observed timestamps: []
 
 run error
 scan t=txn7 k=k6 localUncertaintyLimit=10,0
 ----
 scan: "k6"-"k6\x00" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0? within uncertainty interval `t <= (local=10.000000000,0, global=25.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0? (local=0,1) within uncertainty interval `t <= (local=10.000000000,0, global=25.000000000,0)`; observed timestamps: []
 
 run error
 get t=txn7 k=k7 localUncertaintyLimit=10,0
 ----
 get: "k7" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0? within uncertainty interval `t <= (local=10.000000000,0, global=25.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=10.000000000,0, global=25.000000000,0)`; observed timestamps: []
 
 run error
 scan t=txn7 k=k7 localUncertaintyLimit=10,0
 ----
 scan: "k7"-"k7\x00" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0? within uncertainty interval `t <= (local=10.000000000,0, global=25.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=10.000000000,0, global=25.000000000,0)`; observed timestamps: []
 
 run error
 get t=txn7 k=k8 localUncertaintyLimit=10,0
 ----
 get: "k8" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0? within uncertainty interval `t <= (local=10.000000000,0, global=25.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=10.000000000,0, global=25.000000000,0)`; observed timestamps: []
 
 run error
 scan t=txn7 k=k8 localUncertaintyLimit=10,0
 ----
 scan: "k8"-"k8\x00" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0? within uncertainty interval `t <= (local=10.000000000,0, global=25.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=10.000000000,0, global=25.000000000,0)`; observed timestamps: []
 
 
 run ok
@@ -903,37 +903,37 @@ run error
 get t=txn8 k=k2 localUncertaintyLimit=15,0
 ----
 get: "k2" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0? within uncertainty interval `t <= (local=15.000000000,0, global=20.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0? (local=0,1) within uncertainty interval `t <= (local=15.000000000,0, global=20.000000000,0)`; observed timestamps: []
 
 run error
 scan t=txn8 k=k2 localUncertaintyLimit=15,0
 ----
 scan: "k2"-"k2\x00" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0? within uncertainty interval `t <= (local=15.000000000,0, global=20.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0? (local=0,1) within uncertainty interval `t <= (local=15.000000000,0, global=20.000000000,0)`; observed timestamps: []
 
 run error
 get t=txn8 k=k3 localUncertaintyLimit=15,0
 ----
 get: "k3" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0? within uncertainty interval `t <= (local=15.000000000,0, global=20.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=15.000000000,0, global=20.000000000,0)`; observed timestamps: []
 
 run error
 scan t=txn8 k=k3 localUncertaintyLimit=15,0
 ----
 scan: "k3"-"k3\x00" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0? within uncertainty interval `t <= (local=15.000000000,0, global=20.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=15.000000000,0, global=20.000000000,0)`; observed timestamps: []
 
 run error
 get t=txn8 k=k4 localUncertaintyLimit=15,0
 ----
 get: "k4" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0? within uncertainty interval `t <= (local=15.000000000,0, global=20.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=15.000000000,0, global=20.000000000,0)`; observed timestamps: []
 
 run error
 scan t=txn8 k=k4 localUncertaintyLimit=15,0
 ----
 scan: "k4"-"k4\x00" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0? within uncertainty interval `t <= (local=15.000000000,0, global=20.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=15.000000000,0, global=20.000000000,0)`; observed timestamps: []
 
 run error
 get t=txn8 k=k5 localUncertaintyLimit=15,0
@@ -951,37 +951,37 @@ run error
 get t=txn8 k=k6 localUncertaintyLimit=15,0
 ----
 get: "k6" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0? within uncertainty interval `t <= (local=15.000000000,0, global=20.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0? (local=0,1) within uncertainty interval `t <= (local=15.000000000,0, global=20.000000000,0)`; observed timestamps: []
 
 run error
 scan t=txn8 k=k6 localUncertaintyLimit=15,0
 ----
 scan: "k6"-"k6\x00" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0? within uncertainty interval `t <= (local=15.000000000,0, global=20.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0? (local=0,1) within uncertainty interval `t <= (local=15.000000000,0, global=20.000000000,0)`; observed timestamps: []
 
 run error
 get t=txn8 k=k7 localUncertaintyLimit=15,0
 ----
 get: "k7" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0? within uncertainty interval `t <= (local=15.000000000,0, global=20.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=15.000000000,0, global=20.000000000,0)`; observed timestamps: []
 
 run error
 scan t=txn8 k=k7 localUncertaintyLimit=15,0
 ----
 scan: "k7"-"k7\x00" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0? within uncertainty interval `t <= (local=15.000000000,0, global=20.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=15.000000000,0, global=20.000000000,0)`; observed timestamps: []
 
 run error
 get t=txn8 k=k8 localUncertaintyLimit=15,0
 ----
 get: "k8" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0? within uncertainty interval `t <= (local=15.000000000,0, global=20.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=15.000000000,0, global=20.000000000,0)`; observed timestamps: []
 
 run error
 scan t=txn8 k=k8 localUncertaintyLimit=15,0
 ----
 scan: "k8"-"k8\x00" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0? within uncertainty interval `t <= (local=15.000000000,0, global=20.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=15.000000000,0, global=20.000000000,0)`; observed timestamps: []
 
 
 run ok
@@ -1006,37 +1006,37 @@ run error
 get t=txn9 k=k2 localUncertaintyLimit=15,0
 ----
 get: "k2" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0? within uncertainty interval `t <= (local=15.000000000,0, global=25.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0? (local=0,1) within uncertainty interval `t <= (local=15.000000000,0, global=25.000000000,0)`; observed timestamps: []
 
 run error
 scan t=txn9 k=k2 localUncertaintyLimit=15,0
 ----
 scan: "k2"-"k2\x00" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0? within uncertainty interval `t <= (local=15.000000000,0, global=25.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0? (local=0,1) within uncertainty interval `t <= (local=15.000000000,0, global=25.000000000,0)`; observed timestamps: []
 
 run error
 get t=txn9 k=k3 localUncertaintyLimit=15,0
 ----
 get: "k3" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0? within uncertainty interval `t <= (local=15.000000000,0, global=25.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=15.000000000,0, global=25.000000000,0)`; observed timestamps: []
 
 run error
 scan t=txn9 k=k3 localUncertaintyLimit=15,0
 ----
 scan: "k3"-"k3\x00" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0? within uncertainty interval `t <= (local=15.000000000,0, global=25.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=15.000000000,0, global=25.000000000,0)`; observed timestamps: []
 
 run error
 get t=txn9 k=k4 localUncertaintyLimit=15,0
 ----
 get: "k4" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0? within uncertainty interval `t <= (local=15.000000000,0, global=25.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=15.000000000,0, global=25.000000000,0)`; observed timestamps: []
 
 run error
 scan t=txn9 k=k4 localUncertaintyLimit=15,0
 ----
 scan: "k4"-"k4\x00" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0? within uncertainty interval `t <= (local=15.000000000,0, global=25.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=15.000000000,0, global=25.000000000,0)`; observed timestamps: []
 
 run error
 get t=txn9 k=k5 localUncertaintyLimit=15,0
@@ -1054,37 +1054,37 @@ run error
 get t=txn9 k=k6 localUncertaintyLimit=15,0
 ----
 get: "k6" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0? within uncertainty interval `t <= (local=15.000000000,0, global=25.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0? (local=0,1) within uncertainty interval `t <= (local=15.000000000,0, global=25.000000000,0)`; observed timestamps: []
 
 run error
 scan t=txn9 k=k6 localUncertaintyLimit=15,0
 ----
 scan: "k6"-"k6\x00" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0? within uncertainty interval `t <= (local=15.000000000,0, global=25.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0? (local=0,1) within uncertainty interval `t <= (local=15.000000000,0, global=25.000000000,0)`; observed timestamps: []
 
 run error
 get t=txn9 k=k7 localUncertaintyLimit=15,0
 ----
 get: "k7" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0? within uncertainty interval `t <= (local=15.000000000,0, global=25.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=15.000000000,0, global=25.000000000,0)`; observed timestamps: []
 
 run error
 scan t=txn9 k=k7 localUncertaintyLimit=15,0
 ----
 scan: "k7"-"k7\x00" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0? within uncertainty interval `t <= (local=15.000000000,0, global=25.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=15.000000000,0, global=25.000000000,0)`; observed timestamps: []
 
 run error
 get t=txn9 k=k8 localUncertaintyLimit=15,0
 ----
 get: "k8" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0? within uncertainty interval `t <= (local=15.000000000,0, global=25.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=15.000000000,0, global=25.000000000,0)`; observed timestamps: []
 
 run error
 scan t=txn9 k=k8 localUncertaintyLimit=15,0
 ----
 scan: "k8"-"k8\x00" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0? within uncertainty interval `t <= (local=15.000000000,0, global=25.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=15.000000000,0, global=25.000000000,0)`; observed timestamps: []
 
 
 run ok
@@ -1121,25 +1121,25 @@ run error
 get t=txn10 k=k3 localUncertaintyLimit=20,0
 ----
 get: "k3" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0? within uncertainty interval `t <= (local=20.000000000,0, global=25.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=20.000000000,0, global=25.000000000,0)`; observed timestamps: []
 
 run error
 scan t=txn10 k=k3 localUncertaintyLimit=20,0
 ----
 scan: "k3"-"k3\x00" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0? within uncertainty interval `t <= (local=20.000000000,0, global=25.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=20.000000000,0, global=25.000000000,0)`; observed timestamps: []
 
 run error
 get t=txn10 k=k4 localUncertaintyLimit=20,0
 ----
 get: "k4" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0? within uncertainty interval `t <= (local=20.000000000,0, global=25.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=20.000000000,0, global=25.000000000,0)`; observed timestamps: []
 
 run error
 scan t=txn10 k=k4 localUncertaintyLimit=20,0
 ----
 scan: "k4"-"k4\x00" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0? within uncertainty interval `t <= (local=20.000000000,0, global=25.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=20.000000000,0, global=25.000000000,0)`; observed timestamps: []
 
 run error
 get t=txn10 k=k5 localUncertaintyLimit=20,0
@@ -1169,25 +1169,25 @@ run error
 get t=txn10 k=k7 localUncertaintyLimit=20,0
 ----
 get: "k7" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0? within uncertainty interval `t <= (local=20.000000000,0, global=25.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=20.000000000,0, global=25.000000000,0)`; observed timestamps: []
 
 run error
 scan t=txn10 k=k7 localUncertaintyLimit=20,0
 ----
 scan: "k7"-"k7\x00" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0? within uncertainty interval `t <= (local=20.000000000,0, global=25.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=20.000000000,0, global=25.000000000,0)`; observed timestamps: []
 
 run error
 get t=txn10 k=k8 localUncertaintyLimit=20,0
 ----
 get: "k8" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0? within uncertainty interval `t <= (local=20.000000000,0, global=25.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=20.000000000,0, global=25.000000000,0)`; observed timestamps: []
 
 run error
 scan t=txn10 k=k8 localUncertaintyLimit=20,0
 ----
 scan: "k8"-"k8\x00" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0? within uncertainty interval `t <= (local=20.000000000,0, global=25.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=20.000000000,0, global=25.000000000,0)`; observed timestamps: []
 
 
 run ok
@@ -1307,25 +1307,25 @@ run error
 get t=txn12 k=k3 localUncertaintyLimit=10,0
 ----
 get: "k3" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 10.000000000,0 encountered previous write with future timestamp 20.000000000,0? within uncertainty interval `t <= (local=10.000000000,0, global=20.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 10.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=10.000000000,0, global=20.000000000,0)`; observed timestamps: []
 
 run error
 scan t=txn12 k=k3 localUncertaintyLimit=10,0
 ----
 scan: "k3"-"k3\x00" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 10.000000000,0 encountered previous write with future timestamp 20.000000000,0? within uncertainty interval `t <= (local=10.000000000,0, global=20.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 10.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=10.000000000,0, global=20.000000000,0)`; observed timestamps: []
 
 run error
 get t=txn12 k=k4 localUncertaintyLimit=10,0
 ----
 get: "k4" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 10.000000000,0 encountered previous write with future timestamp 20.000000000,0? within uncertainty interval `t <= (local=10.000000000,0, global=20.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 10.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=10.000000000,0, global=20.000000000,0)`; observed timestamps: []
 
 run error
 scan t=txn12 k=k4 localUncertaintyLimit=10,0
 ----
 scan: "k4"-"k4\x00" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 10.000000000,0 encountered previous write with future timestamp 20.000000000,0? within uncertainty interval `t <= (local=10.000000000,0, global=20.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 10.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=10.000000000,0, global=20.000000000,0)`; observed timestamps: []
 
 run ok
 get t=txn12 k=k5 localUncertaintyLimit=10,0
@@ -1351,25 +1351,25 @@ run error
 get t=txn12 k=k7 localUncertaintyLimit=10,0
 ----
 get: "k7" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 10.000000000,0 encountered previous write with future timestamp 20.000000000,0? within uncertainty interval `t <= (local=10.000000000,0, global=20.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 10.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=10.000000000,0, global=20.000000000,0)`; observed timestamps: []
 
 run error
 scan t=txn12 k=k7 localUncertaintyLimit=10,0
 ----
 scan: "k7"-"k7\x00" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 10.000000000,0 encountered previous write with future timestamp 20.000000000,0? within uncertainty interval `t <= (local=10.000000000,0, global=20.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 10.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=10.000000000,0, global=20.000000000,0)`; observed timestamps: []
 
 run error
 get t=txn12 k=k8 localUncertaintyLimit=10,0
 ----
 get: "k8" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 10.000000000,0 encountered previous write with future timestamp 20.000000000,0? within uncertainty interval `t <= (local=10.000000000,0, global=20.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 10.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=10.000000000,0, global=20.000000000,0)`; observed timestamps: []
 
 run error
 scan t=txn12 k=k8 localUncertaintyLimit=10,0
 ----
 scan: "k8"-"k8\x00" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 10.000000000,0 encountered previous write with future timestamp 20.000000000,0? within uncertainty interval `t <= (local=10.000000000,0, global=20.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 10.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=10.000000000,0, global=20.000000000,0)`; observed timestamps: []
 
 
 run ok
@@ -1402,25 +1402,25 @@ run error
 get t=txn13 k=k3 localUncertaintyLimit=10,0
 ----
 get: "k3" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 10.000000000,0 encountered previous write with future timestamp 20.000000000,0? within uncertainty interval `t <= (local=10.000000000,0, global=25.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 10.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=10.000000000,0, global=25.000000000,0)`; observed timestamps: []
 
 run error
 scan t=txn13 k=k3 localUncertaintyLimit=10,0
 ----
 scan: "k3"-"k3\x00" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 10.000000000,0 encountered previous write with future timestamp 20.000000000,0? within uncertainty interval `t <= (local=10.000000000,0, global=25.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 10.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=10.000000000,0, global=25.000000000,0)`; observed timestamps: []
 
 run error
 get t=txn13 k=k4 localUncertaintyLimit=10,0
 ----
 get: "k4" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 10.000000000,0 encountered previous write with future timestamp 20.000000000,0? within uncertainty interval `t <= (local=10.000000000,0, global=25.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 10.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=10.000000000,0, global=25.000000000,0)`; observed timestamps: []
 
 run error
 scan t=txn13 k=k4 localUncertaintyLimit=10,0
 ----
 scan: "k4"-"k4\x00" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 10.000000000,0 encountered previous write with future timestamp 20.000000000,0? within uncertainty interval `t <= (local=10.000000000,0, global=25.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 10.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=10.000000000,0, global=25.000000000,0)`; observed timestamps: []
 
 run ok
 get t=txn13 k=k5 localUncertaintyLimit=10,0
@@ -1446,25 +1446,25 @@ run error
 get t=txn13 k=k7 localUncertaintyLimit=10,0
 ----
 get: "k7" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 10.000000000,0 encountered previous write with future timestamp 20.000000000,0? within uncertainty interval `t <= (local=10.000000000,0, global=25.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 10.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=10.000000000,0, global=25.000000000,0)`; observed timestamps: []
 
 run error
 scan t=txn13 k=k7 localUncertaintyLimit=10,0
 ----
 scan: "k7"-"k7\x00" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 10.000000000,0 encountered previous write with future timestamp 20.000000000,0? within uncertainty interval `t <= (local=10.000000000,0, global=25.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 10.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=10.000000000,0, global=25.000000000,0)`; observed timestamps: []
 
 run error
 get t=txn13 k=k8 localUncertaintyLimit=10,0
 ----
 get: "k8" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 10.000000000,0 encountered previous write with future timestamp 20.000000000,0? within uncertainty interval `t <= (local=10.000000000,0, global=25.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 10.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=10.000000000,0, global=25.000000000,0)`; observed timestamps: []
 
 run error
 scan t=txn13 k=k8 localUncertaintyLimit=10,0
 ----
 scan: "k8"-"k8\x00" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 10.000000000,0 encountered previous write with future timestamp 20.000000000,0? within uncertainty interval `t <= (local=10.000000000,0, global=25.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 10.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=10.000000000,0, global=25.000000000,0)`; observed timestamps: []
 
 
 run ok
@@ -1497,25 +1497,25 @@ run error
 get t=txn14 k=k3 localUncertaintyLimit=15,0
 ----
 get: "k3" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 10.000000000,0 encountered previous write with future timestamp 20.000000000,0? within uncertainty interval `t <= (local=15.000000000,0, global=20.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 10.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=15.000000000,0, global=20.000000000,0)`; observed timestamps: []
 
 run error
 scan t=txn14 k=k3 localUncertaintyLimit=15,0
 ----
 scan: "k3"-"k3\x00" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 10.000000000,0 encountered previous write with future timestamp 20.000000000,0? within uncertainty interval `t <= (local=15.000000000,0, global=20.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 10.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=15.000000000,0, global=20.000000000,0)`; observed timestamps: []
 
 run error
 get t=txn14 k=k4 localUncertaintyLimit=15,0
 ----
 get: "k4" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 10.000000000,0 encountered previous write with future timestamp 20.000000000,0? within uncertainty interval `t <= (local=15.000000000,0, global=20.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 10.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=15.000000000,0, global=20.000000000,0)`; observed timestamps: []
 
 run error
 scan t=txn14 k=k4 localUncertaintyLimit=15,0
 ----
 scan: "k4"-"k4\x00" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 10.000000000,0 encountered previous write with future timestamp 20.000000000,0? within uncertainty interval `t <= (local=15.000000000,0, global=20.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 10.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=15.000000000,0, global=20.000000000,0)`; observed timestamps: []
 
 run ok
 get t=txn14 k=k5 localUncertaintyLimit=15,0
@@ -1541,25 +1541,25 @@ run error
 get t=txn14 k=k7 localUncertaintyLimit=15,0
 ----
 get: "k7" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 10.000000000,0 encountered previous write with future timestamp 20.000000000,0? within uncertainty interval `t <= (local=15.000000000,0, global=20.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 10.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=15.000000000,0, global=20.000000000,0)`; observed timestamps: []
 
 run error
 scan t=txn14 k=k7 localUncertaintyLimit=15,0
 ----
 scan: "k7"-"k7\x00" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 10.000000000,0 encountered previous write with future timestamp 20.000000000,0? within uncertainty interval `t <= (local=15.000000000,0, global=20.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 10.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=15.000000000,0, global=20.000000000,0)`; observed timestamps: []
 
 run error
 get t=txn14 k=k8 localUncertaintyLimit=15,0
 ----
 get: "k8" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 10.000000000,0 encountered previous write with future timestamp 20.000000000,0? within uncertainty interval `t <= (local=15.000000000,0, global=20.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 10.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=15.000000000,0, global=20.000000000,0)`; observed timestamps: []
 
 run error
 scan t=txn14 k=k8 localUncertaintyLimit=15,0
 ----
 scan: "k8"-"k8\x00" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 10.000000000,0 encountered previous write with future timestamp 20.000000000,0? within uncertainty interval `t <= (local=15.000000000,0, global=20.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 10.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=15.000000000,0, global=20.000000000,0)`; observed timestamps: []
 
 
 run ok
@@ -1592,25 +1592,25 @@ run error
 get t=txn15 k=k3 localUncertaintyLimit=15,0
 ----
 get: "k3" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 10.000000000,0 encountered previous write with future timestamp 20.000000000,0? within uncertainty interval `t <= (local=15.000000000,0, global=25.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 10.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=15.000000000,0, global=25.000000000,0)`; observed timestamps: []
 
 run error
 scan t=txn15 k=k3 localUncertaintyLimit=15,0
 ----
 scan: "k3"-"k3\x00" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 10.000000000,0 encountered previous write with future timestamp 20.000000000,0? within uncertainty interval `t <= (local=15.000000000,0, global=25.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 10.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=15.000000000,0, global=25.000000000,0)`; observed timestamps: []
 
 run error
 get t=txn15 k=k4 localUncertaintyLimit=15,0
 ----
 get: "k4" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 10.000000000,0 encountered previous write with future timestamp 20.000000000,0? within uncertainty interval `t <= (local=15.000000000,0, global=25.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 10.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=15.000000000,0, global=25.000000000,0)`; observed timestamps: []
 
 run error
 scan t=txn15 k=k4 localUncertaintyLimit=15,0
 ----
 scan: "k4"-"k4\x00" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 10.000000000,0 encountered previous write with future timestamp 20.000000000,0? within uncertainty interval `t <= (local=15.000000000,0, global=25.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 10.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=15.000000000,0, global=25.000000000,0)`; observed timestamps: []
 
 run ok
 get t=txn15 k=k5 localUncertaintyLimit=15,0
@@ -1636,25 +1636,25 @@ run error
 get t=txn15 k=k7 localUncertaintyLimit=15,0
 ----
 get: "k7" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 10.000000000,0 encountered previous write with future timestamp 20.000000000,0? within uncertainty interval `t <= (local=15.000000000,0, global=25.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 10.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=15.000000000,0, global=25.000000000,0)`; observed timestamps: []
 
 run error
 scan t=txn15 k=k7 localUncertaintyLimit=15,0
 ----
 scan: "k7"-"k7\x00" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 10.000000000,0 encountered previous write with future timestamp 20.000000000,0? within uncertainty interval `t <= (local=15.000000000,0, global=25.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 10.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=15.000000000,0, global=25.000000000,0)`; observed timestamps: []
 
 run error
 get t=txn15 k=k8 localUncertaintyLimit=15,0
 ----
 get: "k8" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 10.000000000,0 encountered previous write with future timestamp 20.000000000,0? within uncertainty interval `t <= (local=15.000000000,0, global=25.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 10.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=15.000000000,0, global=25.000000000,0)`; observed timestamps: []
 
 run error
 scan t=txn15 k=k8 localUncertaintyLimit=15,0
 ----
 scan: "k8"-"k8\x00" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 10.000000000,0 encountered previous write with future timestamp 20.000000000,0? within uncertainty interval `t <= (local=15.000000000,0, global=25.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 10.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=15.000000000,0, global=25.000000000,0)`; observed timestamps: []
 
 
 run ok
@@ -1691,25 +1691,25 @@ run error
 get t=txn16 k=k3 localUncertaintyLimit=20,0
 ----
 get: "k3" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 10.000000000,0 encountered previous write with future timestamp 20.000000000,0? within uncertainty interval `t <= (local=20.000000000,0, global=25.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 10.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=20.000000000,0, global=25.000000000,0)`; observed timestamps: []
 
 run error
 scan t=txn16 k=k3 localUncertaintyLimit=20,0
 ----
 scan: "k3"-"k3\x00" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 10.000000000,0 encountered previous write with future timestamp 20.000000000,0? within uncertainty interval `t <= (local=20.000000000,0, global=25.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 10.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=20.000000000,0, global=25.000000000,0)`; observed timestamps: []
 
 run error
 get t=txn16 k=k4 localUncertaintyLimit=20,0
 ----
 get: "k4" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 10.000000000,0 encountered previous write with future timestamp 20.000000000,0? within uncertainty interval `t <= (local=20.000000000,0, global=25.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 10.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=20.000000000,0, global=25.000000000,0)`; observed timestamps: []
 
 run error
 scan t=txn16 k=k4 localUncertaintyLimit=20,0
 ----
 scan: "k4"-"k4\x00" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 10.000000000,0 encountered previous write with future timestamp 20.000000000,0? within uncertainty interval `t <= (local=20.000000000,0, global=25.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 10.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=20.000000000,0, global=25.000000000,0)`; observed timestamps: []
 
 run error
 get t=txn16 k=k5 localUncertaintyLimit=20,0
@@ -1739,25 +1739,25 @@ run error
 get t=txn16 k=k7 localUncertaintyLimit=20,0
 ----
 get: "k7" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 10.000000000,0 encountered previous write with future timestamp 20.000000000,0? within uncertainty interval `t <= (local=20.000000000,0, global=25.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 10.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=20.000000000,0, global=25.000000000,0)`; observed timestamps: []
 
 run error
 scan t=txn16 k=k7 localUncertaintyLimit=20,0
 ----
 scan: "k7"-"k7\x00" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 10.000000000,0 encountered previous write with future timestamp 20.000000000,0? within uncertainty interval `t <= (local=20.000000000,0, global=25.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 10.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=20.000000000,0, global=25.000000000,0)`; observed timestamps: []
 
 run error
 get t=txn16 k=k8 localUncertaintyLimit=20,0
 ----
 get: "k8" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 10.000000000,0 encountered previous write with future timestamp 20.000000000,0? within uncertainty interval `t <= (local=20.000000000,0, global=25.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 10.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=20.000000000,0, global=25.000000000,0)`; observed timestamps: []
 
 run error
 scan t=txn16 k=k8 localUncertaintyLimit=20,0
 ----
 scan: "k8"-"k8\x00" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 10.000000000,0 encountered previous write with future timestamp 20.000000000,0? within uncertainty interval `t <= (local=20.000000000,0, global=25.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 10.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=20.000000000,0, global=25.000000000,0)`; observed timestamps: []
 
 
 run ok
@@ -1790,25 +1790,25 @@ run error
 get t=txn17 k=k3 localUncertaintyLimit=15,0
 ----
 get: "k3" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 15.000000000,0 encountered previous write with future timestamp 20.000000000,0? within uncertainty interval `t <= (local=15.000000000,0, global=20.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 15.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=15.000000000,0, global=20.000000000,0)`; observed timestamps: []
 
 run error
 scan t=txn17 k=k3 localUncertaintyLimit=15,0
 ----
 scan: "k3"-"k3\x00" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 15.000000000,0 encountered previous write with future timestamp 20.000000000,0? within uncertainty interval `t <= (local=15.000000000,0, global=20.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 15.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=15.000000000,0, global=20.000000000,0)`; observed timestamps: []
 
 run error
 get t=txn17 k=k4 localUncertaintyLimit=15,0
 ----
 get: "k4" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 15.000000000,0 encountered previous write with future timestamp 20.000000000,0? within uncertainty interval `t <= (local=15.000000000,0, global=20.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 15.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=15.000000000,0, global=20.000000000,0)`; observed timestamps: []
 
 run error
 scan t=txn17 k=k4 localUncertaintyLimit=15,0
 ----
 scan: "k4"-"k4\x00" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 15.000000000,0 encountered previous write with future timestamp 20.000000000,0? within uncertainty interval `t <= (local=15.000000000,0, global=20.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 15.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=15.000000000,0, global=20.000000000,0)`; observed timestamps: []
 
 run ok
 get t=txn17 k=k5 localUncertaintyLimit=15,0
@@ -1834,25 +1834,25 @@ run error
 get t=txn17 k=k7 localUncertaintyLimit=15,0
 ----
 get: "k7" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 15.000000000,0 encountered previous write with future timestamp 20.000000000,0? within uncertainty interval `t <= (local=15.000000000,0, global=20.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 15.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=15.000000000,0, global=20.000000000,0)`; observed timestamps: []
 
 run error
 scan t=txn17 k=k7 localUncertaintyLimit=15,0
 ----
 scan: "k7"-"k7\x00" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 15.000000000,0 encountered previous write with future timestamp 20.000000000,0? within uncertainty interval `t <= (local=15.000000000,0, global=20.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 15.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=15.000000000,0, global=20.000000000,0)`; observed timestamps: []
 
 run error
 get t=txn17 k=k8 localUncertaintyLimit=15,0
 ----
 get: "k8" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 15.000000000,0 encountered previous write with future timestamp 20.000000000,0? within uncertainty interval `t <= (local=15.000000000,0, global=20.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 15.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=15.000000000,0, global=20.000000000,0)`; observed timestamps: []
 
 run error
 scan t=txn17 k=k8 localUncertaintyLimit=15,0
 ----
 scan: "k8"-"k8\x00" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 15.000000000,0 encountered previous write with future timestamp 20.000000000,0? within uncertainty interval `t <= (local=15.000000000,0, global=20.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 15.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=15.000000000,0, global=20.000000000,0)`; observed timestamps: []
 
 
 run ok
@@ -1885,25 +1885,25 @@ run error
 get t=txn18 k=k3 localUncertaintyLimit=15,0
 ----
 get: "k3" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 15.000000000,0 encountered previous write with future timestamp 20.000000000,0? within uncertainty interval `t <= (local=15.000000000,0, global=25.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 15.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=15.000000000,0, global=25.000000000,0)`; observed timestamps: []
 
 run error
 scan t=txn18 k=k3 localUncertaintyLimit=15,0
 ----
 scan: "k3"-"k3\x00" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 15.000000000,0 encountered previous write with future timestamp 20.000000000,0? within uncertainty interval `t <= (local=15.000000000,0, global=25.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 15.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=15.000000000,0, global=25.000000000,0)`; observed timestamps: []
 
 run error
 get t=txn18 k=k4 localUncertaintyLimit=15,0
 ----
 get: "k4" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 15.000000000,0 encountered previous write with future timestamp 20.000000000,0? within uncertainty interval `t <= (local=15.000000000,0, global=25.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 15.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=15.000000000,0, global=25.000000000,0)`; observed timestamps: []
 
 run error
 scan t=txn18 k=k4 localUncertaintyLimit=15,0
 ----
 scan: "k4"-"k4\x00" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 15.000000000,0 encountered previous write with future timestamp 20.000000000,0? within uncertainty interval `t <= (local=15.000000000,0, global=25.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 15.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=15.000000000,0, global=25.000000000,0)`; observed timestamps: []
 
 run ok
 get t=txn18 k=k5 localUncertaintyLimit=15,0
@@ -1929,25 +1929,25 @@ run error
 get t=txn18 k=k7 localUncertaintyLimit=15,0
 ----
 get: "k7" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 15.000000000,0 encountered previous write with future timestamp 20.000000000,0? within uncertainty interval `t <= (local=15.000000000,0, global=25.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 15.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=15.000000000,0, global=25.000000000,0)`; observed timestamps: []
 
 run error
 scan t=txn18 k=k7 localUncertaintyLimit=15,0
 ----
 scan: "k7"-"k7\x00" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 15.000000000,0 encountered previous write with future timestamp 20.000000000,0? within uncertainty interval `t <= (local=15.000000000,0, global=25.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 15.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=15.000000000,0, global=25.000000000,0)`; observed timestamps: []
 
 run error
 get t=txn18 k=k8 localUncertaintyLimit=15,0
 ----
 get: "k8" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 15.000000000,0 encountered previous write with future timestamp 20.000000000,0? within uncertainty interval `t <= (local=15.000000000,0, global=25.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 15.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=15.000000000,0, global=25.000000000,0)`; observed timestamps: []
 
 run error
 scan t=txn18 k=k8 localUncertaintyLimit=15,0
 ----
 scan: "k8"-"k8\x00" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 15.000000000,0 encountered previous write with future timestamp 20.000000000,0? within uncertainty interval `t <= (local=15.000000000,0, global=25.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 15.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=15.000000000,0, global=25.000000000,0)`; observed timestamps: []
 
 
 run ok
@@ -1984,25 +1984,25 @@ run error
 get t=txn19 k=k3 localUncertaintyLimit=20,0
 ----
 get: "k3" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 15.000000000,0 encountered previous write with future timestamp 20.000000000,0? within uncertainty interval `t <= (local=20.000000000,0, global=25.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 15.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=20.000000000,0, global=25.000000000,0)`; observed timestamps: []
 
 run error
 scan t=txn19 k=k3 localUncertaintyLimit=20,0
 ----
 scan: "k3"-"k3\x00" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 15.000000000,0 encountered previous write with future timestamp 20.000000000,0? within uncertainty interval `t <= (local=20.000000000,0, global=25.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 15.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=20.000000000,0, global=25.000000000,0)`; observed timestamps: []
 
 run error
 get t=txn19 k=k4 localUncertaintyLimit=20,0
 ----
 get: "k4" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 15.000000000,0 encountered previous write with future timestamp 20.000000000,0? within uncertainty interval `t <= (local=20.000000000,0, global=25.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 15.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=20.000000000,0, global=25.000000000,0)`; observed timestamps: []
 
 run error
 scan t=txn19 k=k4 localUncertaintyLimit=20,0
 ----
 scan: "k4"-"k4\x00" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 15.000000000,0 encountered previous write with future timestamp 20.000000000,0? within uncertainty interval `t <= (local=20.000000000,0, global=25.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 15.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=20.000000000,0, global=25.000000000,0)`; observed timestamps: []
 
 run error
 get t=txn19 k=k5 localUncertaintyLimit=20,0
@@ -2032,25 +2032,25 @@ run error
 get t=txn19 k=k7 localUncertaintyLimit=20,0
 ----
 get: "k7" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 15.000000000,0 encountered previous write with future timestamp 20.000000000,0? within uncertainty interval `t <= (local=20.000000000,0, global=25.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 15.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=20.000000000,0, global=25.000000000,0)`; observed timestamps: []
 
 run error
 scan t=txn19 k=k7 localUncertaintyLimit=20,0
 ----
 scan: "k7"-"k7\x00" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 15.000000000,0 encountered previous write with future timestamp 20.000000000,0? within uncertainty interval `t <= (local=20.000000000,0, global=25.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 15.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=20.000000000,0, global=25.000000000,0)`; observed timestamps: []
 
 run error
 get t=txn19 k=k8 localUncertaintyLimit=20,0
 ----
 get: "k8" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 15.000000000,0 encountered previous write with future timestamp 20.000000000,0? within uncertainty interval `t <= (local=20.000000000,0, global=25.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 15.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=20.000000000,0, global=25.000000000,0)`; observed timestamps: []
 
 run error
 scan t=txn19 k=k8 localUncertaintyLimit=20,0
 ----
 scan: "k8"-"k8\x00" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 15.000000000,0 encountered previous write with future timestamp 20.000000000,0? within uncertainty interval `t <= (local=20.000000000,0, global=25.000000000,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 15.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=20.000000000,0, global=25.000000000,0)`; observed timestamps: []
 
 
 run ok
@@ -2254,13 +2254,13 @@ run error
 get k=k2 ts=5,0 localUncertaintyLimit=5,0 globalUncertaintyLimit=15,0
 ----
 get: "k2" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0? within uncertainty interval `t <= (local=5.000000000,0, global=0,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0? (local=0,1) within uncertainty interval `t <= (local=5.000000000,0, global=0,0)`; observed timestamps: []
 
 run error
 scan k=k2 ts=5,0 localUncertaintyLimit=5,0 globalUncertaintyLimit=15,0
 ----
 scan: "k2"-"k2\x00" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0? within uncertainty interval `t <= (local=5.000000000,0, global=0,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0? (local=0,1) within uncertainty interval `t <= (local=5.000000000,0, global=0,0)`; observed timestamps: []
 
 run ok
 get k=k3 ts=5,0 localUncertaintyLimit=5,0 globalUncertaintyLimit=15,0
@@ -2276,13 +2276,13 @@ run error
 get k=k4 ts=5,0 localUncertaintyLimit=5,0 globalUncertaintyLimit=15,0
 ----
 get: "k4" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0? within uncertainty interval `t <= (local=5.000000000,0, global=0,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0? (local=0,1) within uncertainty interval `t <= (local=5.000000000,0, global=0,0)`; observed timestamps: []
 
 run error
 scan k=k4 ts=5,0 localUncertaintyLimit=5,0 globalUncertaintyLimit=15,0
 ----
 scan: "k4"-"k4\x00" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0? within uncertainty interval `t <= (local=5.000000000,0, global=0,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0? (local=0,1) within uncertainty interval `t <= (local=5.000000000,0, global=0,0)`; observed timestamps: []
 
 run ok
 get k=k5 ts=5,0 localUncertaintyLimit=5,0 globalUncertaintyLimit=15,0
@@ -2298,13 +2298,13 @@ run error
 get k=k6 ts=5,0 localUncertaintyLimit=5,0 globalUncertaintyLimit=15,0
 ----
 get: "k6" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0? within uncertainty interval `t <= (local=5.000000000,0, global=0,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0? (local=0,1) within uncertainty interval `t <= (local=5.000000000,0, global=0,0)`; observed timestamps: []
 
 run error
 scan k=k6 ts=5,0 localUncertaintyLimit=5,0 globalUncertaintyLimit=15,0
 ----
 scan: "k6"-"k6\x00" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0? within uncertainty interval `t <= (local=5.000000000,0, global=0,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0? (local=0,1) within uncertainty interval `t <= (local=5.000000000,0, global=0,0)`; observed timestamps: []
 
 run ok
 get k=k7 ts=5,0 localUncertaintyLimit=5,0 globalUncertaintyLimit=15,0
@@ -2320,13 +2320,13 @@ run error
 get k=k8 ts=5,0 localUncertaintyLimit=5,0 globalUncertaintyLimit=15,0
 ----
 get: "k8" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0? within uncertainty interval `t <= (local=5.000000000,0, global=0,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0? (local=0,1) within uncertainty interval `t <= (local=5.000000000,0, global=0,0)`; observed timestamps: []
 
 run error
 scan k=k8 ts=5,0 localUncertaintyLimit=5,0 globalUncertaintyLimit=15,0
 ----
 scan: "k8"-"k8\x00" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0? within uncertainty interval `t <= (local=5.000000000,0, global=0,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0? (local=0,1) within uncertainty interval `t <= (local=5.000000000,0, global=0,0)`; observed timestamps: []
 
 run ok
 get k=k1 ts=5,0 localUncertaintyLimit=5,0 globalUncertaintyLimit=25,0
@@ -2342,37 +2342,37 @@ run error
 get k=k2 ts=5,0 localUncertaintyLimit=5,0 globalUncertaintyLimit=25,0
 ----
 get: "k2" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0? within uncertainty interval `t <= (local=5.000000000,0, global=0,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0? (local=0,1) within uncertainty interval `t <= (local=5.000000000,0, global=0,0)`; observed timestamps: []
 
 run error
 scan k=k2 ts=5,0 localUncertaintyLimit=5,0 globalUncertaintyLimit=25,0
 ----
 scan: "k2"-"k2\x00" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0? within uncertainty interval `t <= (local=5.000000000,0, global=0,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0? (local=0,1) within uncertainty interval `t <= (local=5.000000000,0, global=0,0)`; observed timestamps: []
 
 run error
 get k=k3 ts=5,0 localUncertaintyLimit=5,0 globalUncertaintyLimit=25,0
 ----
 get: "k3" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0? within uncertainty interval `t <= (local=5.000000000,0, global=0,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=5.000000000,0, global=0,0)`; observed timestamps: []
 
 run error
 scan k=k3 ts=5,0 localUncertaintyLimit=5,0 globalUncertaintyLimit=25,0
 ----
 scan: "k3"-"k3\x00" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0? within uncertainty interval `t <= (local=5.000000000,0, global=0,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=5.000000000,0, global=0,0)`; observed timestamps: []
 
 run error
 get k=k4 ts=5,0 localUncertaintyLimit=5,0 globalUncertaintyLimit=25,0
 ----
 get: "k4" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0? within uncertainty interval `t <= (local=5.000000000,0, global=0,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=5.000000000,0, global=0,0)`; observed timestamps: []
 
 run error
 scan k=k4 ts=5,0 localUncertaintyLimit=5,0 globalUncertaintyLimit=25,0
 ----
 scan: "k4"-"k4\x00" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0? within uncertainty interval `t <= (local=5.000000000,0, global=0,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=5.000000000,0, global=0,0)`; observed timestamps: []
 
 run ok
 get k=k5 ts=5,0 localUncertaintyLimit=5,0 globalUncertaintyLimit=25,0
@@ -2388,37 +2388,37 @@ run error
 get k=k6 ts=5,0 localUncertaintyLimit=5,0 globalUncertaintyLimit=25,0
 ----
 get: "k6" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0? within uncertainty interval `t <= (local=5.000000000,0, global=0,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0? (local=0,1) within uncertainty interval `t <= (local=5.000000000,0, global=0,0)`; observed timestamps: []
 
 run error
 scan k=k6 ts=5,0 localUncertaintyLimit=5,0 globalUncertaintyLimit=25,0
 ----
 scan: "k6"-"k6\x00" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0? within uncertainty interval `t <= (local=5.000000000,0, global=0,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0? (local=0,1) within uncertainty interval `t <= (local=5.000000000,0, global=0,0)`; observed timestamps: []
 
 run error
 get k=k7 ts=5,0 localUncertaintyLimit=5,0 globalUncertaintyLimit=25,0
 ----
 get: "k7" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0? within uncertainty interval `t <= (local=5.000000000,0, global=0,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=5.000000000,0, global=0,0)`; observed timestamps: []
 
 run error
 scan k=k7 ts=5,0 localUncertaintyLimit=5,0 globalUncertaintyLimit=25,0
 ----
 scan: "k7"-"k7\x00" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0? within uncertainty interval `t <= (local=5.000000000,0, global=0,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=5.000000000,0, global=0,0)`; observed timestamps: []
 
 run error
 get k=k8 ts=5,0 localUncertaintyLimit=5,0 globalUncertaintyLimit=25,0
 ----
 get: "k8" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0? within uncertainty interval `t <= (local=5.000000000,0, global=0,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=5.000000000,0, global=0,0)`; observed timestamps: []
 
 run error
 scan k=k8 ts=5,0 localUncertaintyLimit=5,0 globalUncertaintyLimit=25,0
 ----
 scan: "k8"-"k8\x00" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0? within uncertainty interval `t <= (local=5.000000000,0, global=0,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=5.000000000,0, global=0,0)`; observed timestamps: []
 
 run error
 get k=k1 ts=5,0 localUncertaintyLimit=15,0 globalUncertaintyLimit=15,0
@@ -2436,13 +2436,13 @@ run error
 get k=k2 ts=5,0 localUncertaintyLimit=15,0 globalUncertaintyLimit=15,0
 ----
 get: "k2" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0? within uncertainty interval `t <= (local=15.000000000,0, global=0,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0? (local=0,1) within uncertainty interval `t <= (local=15.000000000,0, global=0,0)`; observed timestamps: []
 
 run error
 scan k=k2 ts=5,0 localUncertaintyLimit=15,0 globalUncertaintyLimit=15,0
 ----
 scan: "k2"-"k2\x00" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0? within uncertainty interval `t <= (local=15.000000000,0, global=0,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0? (local=0,1) within uncertainty interval `t <= (local=15.000000000,0, global=0,0)`; observed timestamps: []
 
 run error
 get k=k3 ts=5,0 localUncertaintyLimit=15,0 globalUncertaintyLimit=15,0
@@ -2460,13 +2460,13 @@ run error
 get k=k4 ts=5,0 localUncertaintyLimit=15,0 globalUncertaintyLimit=15,0
 ----
 get: "k4" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0? within uncertainty interval `t <= (local=15.000000000,0, global=0,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0? (local=0,1) within uncertainty interval `t <= (local=15.000000000,0, global=0,0)`; observed timestamps: []
 
 run error
 scan k=k4 ts=5,0 localUncertaintyLimit=15,0 globalUncertaintyLimit=15,0
 ----
 scan: "k4"-"k4\x00" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0? within uncertainty interval `t <= (local=15.000000000,0, global=0,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0? (local=0,1) within uncertainty interval `t <= (local=15.000000000,0, global=0,0)`; observed timestamps: []
 
 run error
 get k=k5 ts=5,0 localUncertaintyLimit=15,0 globalUncertaintyLimit=15,0
@@ -2484,13 +2484,13 @@ run error
 get k=k6 ts=5,0 localUncertaintyLimit=15,0 globalUncertaintyLimit=15,0
 ----
 get: "k6" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0? within uncertainty interval `t <= (local=15.000000000,0, global=0,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0? (local=0,1) within uncertainty interval `t <= (local=15.000000000,0, global=0,0)`; observed timestamps: []
 
 run error
 scan k=k6 ts=5,0 localUncertaintyLimit=15,0 globalUncertaintyLimit=15,0
 ----
 scan: "k6"-"k6\x00" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0? within uncertainty interval `t <= (local=15.000000000,0, global=0,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0? (local=0,1) within uncertainty interval `t <= (local=15.000000000,0, global=0,0)`; observed timestamps: []
 
 run error
 get k=k7 ts=5,0 localUncertaintyLimit=15,0 globalUncertaintyLimit=15,0
@@ -2508,13 +2508,13 @@ run error
 get k=k8 ts=5,0 localUncertaintyLimit=15,0 globalUncertaintyLimit=15,0
 ----
 get: "k8" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0? within uncertainty interval `t <= (local=15.000000000,0, global=0,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0? (local=0,1) within uncertainty interval `t <= (local=15.000000000,0, global=0,0)`; observed timestamps: []
 
 run error
 scan k=k8 ts=5,0 localUncertaintyLimit=15,0 globalUncertaintyLimit=15,0
 ----
 scan: "k8"-"k8\x00" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0? within uncertainty interval `t <= (local=15.000000000,0, global=0,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0? (local=0,1) within uncertainty interval `t <= (local=15.000000000,0, global=0,0)`; observed timestamps: []
 
 run error
 get k=k1 ts=5,0 localUncertaintyLimit=15,0 globalUncertaintyLimit=25,0
@@ -2532,37 +2532,37 @@ run error
 get k=k2 ts=5,0 localUncertaintyLimit=15,0 globalUncertaintyLimit=25,0
 ----
 get: "k2" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0? within uncertainty interval `t <= (local=15.000000000,0, global=0,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0? (local=0,1) within uncertainty interval `t <= (local=15.000000000,0, global=0,0)`; observed timestamps: []
 
 run error
 scan k=k2 ts=5,0 localUncertaintyLimit=15,0 globalUncertaintyLimit=25,0
 ----
 scan: "k2"-"k2\x00" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0? within uncertainty interval `t <= (local=15.000000000,0, global=0,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0? (local=0,1) within uncertainty interval `t <= (local=15.000000000,0, global=0,0)`; observed timestamps: []
 
 run error
 get k=k3 ts=5,0 localUncertaintyLimit=15,0 globalUncertaintyLimit=25,0
 ----
 get: "k3" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0? within uncertainty interval `t <= (local=15.000000000,0, global=0,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=15.000000000,0, global=0,0)`; observed timestamps: []
 
 run error
 scan k=k3 ts=5,0 localUncertaintyLimit=15,0 globalUncertaintyLimit=25,0
 ----
 scan: "k3"-"k3\x00" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0? within uncertainty interval `t <= (local=15.000000000,0, global=0,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=15.000000000,0, global=0,0)`; observed timestamps: []
 
 run error
 get k=k4 ts=5,0 localUncertaintyLimit=15,0 globalUncertaintyLimit=25,0
 ----
 get: "k4" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0? within uncertainty interval `t <= (local=15.000000000,0, global=0,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=15.000000000,0, global=0,0)`; observed timestamps: []
 
 run error
 scan k=k4 ts=5,0 localUncertaintyLimit=15,0 globalUncertaintyLimit=25,0
 ----
 scan: "k4"-"k4\x00" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0? within uncertainty interval `t <= (local=15.000000000,0, global=0,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=15.000000000,0, global=0,0)`; observed timestamps: []
 
 run error
 get k=k5 ts=5,0 localUncertaintyLimit=15,0 globalUncertaintyLimit=25,0
@@ -2580,37 +2580,37 @@ run error
 get k=k6 ts=5,0 localUncertaintyLimit=15,0 globalUncertaintyLimit=25,0
 ----
 get: "k6" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0? within uncertainty interval `t <= (local=15.000000000,0, global=0,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0? (local=0,1) within uncertainty interval `t <= (local=15.000000000,0, global=0,0)`; observed timestamps: []
 
 run error
 scan k=k6 ts=5,0 localUncertaintyLimit=15,0 globalUncertaintyLimit=25,0
 ----
 scan: "k6"-"k6\x00" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0? within uncertainty interval `t <= (local=15.000000000,0, global=0,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 10.000000000,0? (local=0,1) within uncertainty interval `t <= (local=15.000000000,0, global=0,0)`; observed timestamps: []
 
 run error
 get k=k7 ts=5,0 localUncertaintyLimit=15,0 globalUncertaintyLimit=25,0
 ----
 get: "k7" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0? within uncertainty interval `t <= (local=15.000000000,0, global=0,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=15.000000000,0, global=0,0)`; observed timestamps: []
 
 run error
 scan k=k7 ts=5,0 localUncertaintyLimit=15,0 globalUncertaintyLimit=25,0
 ----
 scan: "k7"-"k7\x00" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0? within uncertainty interval `t <= (local=15.000000000,0, global=0,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=15.000000000,0, global=0,0)`; observed timestamps: []
 
 run error
 get k=k8 ts=5,0 localUncertaintyLimit=15,0 globalUncertaintyLimit=25,0
 ----
 get: "k8" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0? within uncertainty interval `t <= (local=15.000000000,0, global=0,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=15.000000000,0, global=0,0)`; observed timestamps: []
 
 run error
 scan k=k8 ts=5,0 localUncertaintyLimit=15,0 globalUncertaintyLimit=25,0
 ----
 scan: "k8"-"k8\x00" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0? within uncertainty interval `t <= (local=15.000000000,0, global=0,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=15.000000000,0, global=0,0)`; observed timestamps: []
 
 run error
 get k=k1 ts=5,0 localUncertaintyLimit=25,0 globalUncertaintyLimit=25,0
@@ -2640,25 +2640,25 @@ run error
 get k=k3 ts=5,0 localUncertaintyLimit=25,0 globalUncertaintyLimit=25,0
 ----
 get: "k3" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0? within uncertainty interval `t <= (local=25.000000000,0, global=0,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=25.000000000,0, global=0,0)`; observed timestamps: []
 
 run error
 scan k=k3 ts=5,0 localUncertaintyLimit=25,0 globalUncertaintyLimit=25,0
 ----
 scan: "k3"-"k3\x00" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0? within uncertainty interval `t <= (local=25.000000000,0, global=0,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=25.000000000,0, global=0,0)`; observed timestamps: []
 
 run error
 get k=k4 ts=5,0 localUncertaintyLimit=25,0 globalUncertaintyLimit=25,0
 ----
 get: "k4" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0? within uncertainty interval `t <= (local=25.000000000,0, global=0,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=25.000000000,0, global=0,0)`; observed timestamps: []
 
 run error
 scan k=k4 ts=5,0 localUncertaintyLimit=25,0 globalUncertaintyLimit=25,0
 ----
 scan: "k4"-"k4\x00" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0? within uncertainty interval `t <= (local=25.000000000,0, global=0,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=25.000000000,0, global=0,0)`; observed timestamps: []
 
 run error
 get k=k5 ts=5,0 localUncertaintyLimit=25,0 globalUncertaintyLimit=25,0
@@ -2688,25 +2688,25 @@ run error
 get k=k7 ts=5,0 localUncertaintyLimit=25,0 globalUncertaintyLimit=25,0
 ----
 get: "k7" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0? within uncertainty interval `t <= (local=25.000000000,0, global=0,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=25.000000000,0, global=0,0)`; observed timestamps: []
 
 run error
 scan k=k7 ts=5,0 localUncertaintyLimit=25,0 globalUncertaintyLimit=25,0
 ----
 scan: "k7"-"k7\x00" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0? within uncertainty interval `t <= (local=25.000000000,0, global=0,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=25.000000000,0, global=0,0)`; observed timestamps: []
 
 run error
 get k=k8 ts=5,0 localUncertaintyLimit=25,0 globalUncertaintyLimit=25,0
 ----
 get: "k8" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0? within uncertainty interval `t <= (local=25.000000000,0, global=0,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=25.000000000,0, global=0,0)`; observed timestamps: []
 
 run error
 scan k=k8 ts=5,0 localUncertaintyLimit=25,0 globalUncertaintyLimit=25,0
 ----
 scan: "k8"-"k8\x00" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0? within uncertainty interval `t <= (local=25.000000000,0, global=0,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 5.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=25.000000000,0, global=0,0)`; observed timestamps: []
 
 run ok
 get k=k1 ts=15,0 localUncertaintyLimit=15,0 globalUncertaintyLimit=15,0
@@ -2812,25 +2812,25 @@ run error
 get k=k3 ts=15,0 localUncertaintyLimit=15,0 globalUncertaintyLimit=25,0
 ----
 get: "k3" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 15.000000000,0 encountered previous write with future timestamp 20.000000000,0? within uncertainty interval `t <= (local=15.000000000,0, global=0,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 15.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=15.000000000,0, global=0,0)`; observed timestamps: []
 
 run error
 scan k=k3 ts=15,0 localUncertaintyLimit=15,0 globalUncertaintyLimit=25,0
 ----
 scan: "k3"-"k3\x00" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 15.000000000,0 encountered previous write with future timestamp 20.000000000,0? within uncertainty interval `t <= (local=15.000000000,0, global=0,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 15.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=15.000000000,0, global=0,0)`; observed timestamps: []
 
 run error
 get k=k4 ts=15,0 localUncertaintyLimit=15,0 globalUncertaintyLimit=25,0
 ----
 get: "k4" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 15.000000000,0 encountered previous write with future timestamp 20.000000000,0? within uncertainty interval `t <= (local=15.000000000,0, global=0,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 15.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=15.000000000,0, global=0,0)`; observed timestamps: []
 
 run error
 scan k=k4 ts=15,0 localUncertaintyLimit=15,0 globalUncertaintyLimit=25,0
 ----
 scan: "k4"-"k4\x00" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 15.000000000,0 encountered previous write with future timestamp 20.000000000,0? within uncertainty interval `t <= (local=15.000000000,0, global=0,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 15.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=15.000000000,0, global=0,0)`; observed timestamps: []
 
 run ok
 get k=k5 ts=15,0 localUncertaintyLimit=15,0 globalUncertaintyLimit=25,0
@@ -2856,25 +2856,25 @@ run error
 get k=k7 ts=15,0 localUncertaintyLimit=15,0 globalUncertaintyLimit=25,0
 ----
 get: "k7" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 15.000000000,0 encountered previous write with future timestamp 20.000000000,0? within uncertainty interval `t <= (local=15.000000000,0, global=0,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 15.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=15.000000000,0, global=0,0)`; observed timestamps: []
 
 run error
 scan k=k7 ts=15,0 localUncertaintyLimit=15,0 globalUncertaintyLimit=25,0
 ----
 scan: "k7"-"k7\x00" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 15.000000000,0 encountered previous write with future timestamp 20.000000000,0? within uncertainty interval `t <= (local=15.000000000,0, global=0,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 15.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=15.000000000,0, global=0,0)`; observed timestamps: []
 
 run error
 get k=k8 ts=15,0 localUncertaintyLimit=15,0 globalUncertaintyLimit=25,0
 ----
 get: "k8" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 15.000000000,0 encountered previous write with future timestamp 20.000000000,0? within uncertainty interval `t <= (local=15.000000000,0, global=0,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 15.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=15.000000000,0, global=0,0)`; observed timestamps: []
 
 run error
 scan k=k8 ts=15,0 localUncertaintyLimit=15,0 globalUncertaintyLimit=25,0
 ----
 scan: "k8"-"k8\x00" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 15.000000000,0 encountered previous write with future timestamp 20.000000000,0? within uncertainty interval `t <= (local=15.000000000,0, global=0,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 15.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=15.000000000,0, global=0,0)`; observed timestamps: []
 
 run error
 get k=k1 ts=15,0 localUncertaintyLimit=25,0 globalUncertaintyLimit=25,0
@@ -2904,25 +2904,25 @@ run error
 get k=k3 ts=15,0 localUncertaintyLimit=25,0 globalUncertaintyLimit=25,0
 ----
 get: "k3" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 15.000000000,0 encountered previous write with future timestamp 20.000000000,0? within uncertainty interval `t <= (local=25.000000000,0, global=0,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 15.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=25.000000000,0, global=0,0)`; observed timestamps: []
 
 run error
 scan k=k3 ts=15,0 localUncertaintyLimit=25,0 globalUncertaintyLimit=25,0
 ----
 scan: "k3"-"k3\x00" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 15.000000000,0 encountered previous write with future timestamp 20.000000000,0? within uncertainty interval `t <= (local=25.000000000,0, global=0,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 15.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=25.000000000,0, global=0,0)`; observed timestamps: []
 
 run error
 get k=k4 ts=15,0 localUncertaintyLimit=25,0 globalUncertaintyLimit=25,0
 ----
 get: "k4" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 15.000000000,0 encountered previous write with future timestamp 20.000000000,0? within uncertainty interval `t <= (local=25.000000000,0, global=0,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 15.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=25.000000000,0, global=0,0)`; observed timestamps: []
 
 run error
 scan k=k4 ts=15,0 localUncertaintyLimit=25,0 globalUncertaintyLimit=25,0
 ----
 scan: "k4"-"k4\x00" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 15.000000000,0 encountered previous write with future timestamp 20.000000000,0? within uncertainty interval `t <= (local=25.000000000,0, global=0,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 15.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=25.000000000,0, global=0,0)`; observed timestamps: []
 
 run error
 get k=k5 ts=15,0 localUncertaintyLimit=25,0 globalUncertaintyLimit=25,0
@@ -2952,25 +2952,25 @@ run error
 get k=k7 ts=15,0 localUncertaintyLimit=25,0 globalUncertaintyLimit=25,0
 ----
 get: "k7" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 15.000000000,0 encountered previous write with future timestamp 20.000000000,0? within uncertainty interval `t <= (local=25.000000000,0, global=0,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 15.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=25.000000000,0, global=0,0)`; observed timestamps: []
 
 run error
 scan k=k7 ts=15,0 localUncertaintyLimit=25,0 globalUncertaintyLimit=25,0
 ----
 scan: "k7"-"k7\x00" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 15.000000000,0 encountered previous write with future timestamp 20.000000000,0? within uncertainty interval `t <= (local=25.000000000,0, global=0,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 15.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=25.000000000,0, global=0,0)`; observed timestamps: []
 
 run error
 get k=k8 ts=15,0 localUncertaintyLimit=25,0 globalUncertaintyLimit=25,0
 ----
 get: "k8" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 15.000000000,0 encountered previous write with future timestamp 20.000000000,0? within uncertainty interval `t <= (local=25.000000000,0, global=0,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 15.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=25.000000000,0, global=0,0)`; observed timestamps: []
 
 run error
 scan k=k8 ts=15,0 localUncertaintyLimit=25,0 globalUncertaintyLimit=25,0
 ----
 scan: "k8"-"k8\x00" -> <no data>
-error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 15.000000000,0 encountered previous write with future timestamp 20.000000000,0? within uncertainty interval `t <= (local=25.000000000,0, global=0,0)`; observed timestamps: []
+error: (*roachpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 15.000000000,0 encountered previous write with future timestamp 20.000000000,0? (local=0,1) within uncertainty interval `t <= (local=25.000000000,0, global=0,0)`; observed timestamps: []
 
 run ok
 get k=k1 ts=25,0 localUncertaintyLimit=25,0 globalUncertaintyLimit=25,0


### PR DESCRIPTION
This PR adds details about MVCC local timestamps to ReadWithinUncertaintyIntervalErrors. This provides more information about the cause of uncertainty errors.

The PR also includes a series of minor refactors to clean up this code.

Release note: None
Epic: None