### PR TITLE
sql/schemachanger: limit which op/dep rule helpers are shared

### DIFF
--- a/pkg/sql/schemachanger/scplan/internal/rules/current/BUILD.bazel
+++ b/pkg/sql/schemachanger/scplan/internal/rules/current/BUILD.bazel
@@ -17,6 +17,7 @@ go_library(
         "dep_garbage_collection.go",
         "dep_swap_index.go",
         "dep_two_version.go",
+        "helpers.go",
         "op_drop.go",
         "op_index_and_column.go",
         "registry.go",
@@ -24,6 +25,7 @@ go_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scplan/internal/rules/current",
     visibility = ["//pkg/sql/schemachanger/scplan:__subpackages__"],
     deps = [
+        "//pkg/clusterversion",
         "//pkg/sql/schemachanger/rel",
         "//pkg/sql/schemachanger/scpb",
         "//pkg/sql/schemachanger/scplan/internal/opgen",
@@ -31,6 +33,7 @@ go_library(
         "//pkg/sql/schemachanger/scplan/internal/scgraph",
         "//pkg/sql/schemachanger/screl",
         "//pkg/sql/sem/catid",
+        "@com_github_cockroachdb_errors//:errors",
     ],
 )
 

--- a/pkg/sql/schemachanger/scplan/internal/rules/current/assertions_test.go
+++ b/pkg/sql/schemachanger/scplan/internal/rules/current/assertions_test.go
@@ -62,7 +62,7 @@ func nonNilElement(element scpb.Element) scpb.Element {
 // One exception is foreign key constraint, which is not simple dependent nor data
 // element but it has a screl.ReferencedDescID attribute.
 func checkSimpleDependentsReferenceDescID(e scpb.Element) error {
-	if IsSimpleDependent(e) || IsData(e) {
+	if isSimpleDependent(e) || isData(e) {
 		return nil
 	}
 	if _, ok := e.(*scpb.ForeignKeyConstraint); ok {
@@ -85,15 +85,15 @@ func checkToAbsentCategories(e scpb.Element) error {
 	s1 := opgen.NextStatus(e, scpb.Status_ABSENT, s0)
 	switch s1 {
 	case scpb.Status_DROPPED:
-		if IsDescriptor(e) || IsData(e) {
+		if isDescriptor(e) || isData(e) {
 			return nil
 		}
 	case scpb.Status_VALIDATED, scpb.Status_WRITE_ONLY, scpb.Status_DELETE_ONLY:
-		if IsSubjectTo2VersionInvariant(e) {
+		if isSubjectTo2VersionInvariant(e) {
 			return nil
 		}
 	case scpb.Status_ABSENT:
-		if IsSimpleDependent(e) {
+		if isSimpleDependent(e) {
 			return nil
 		}
 	}
@@ -103,7 +103,7 @@ func checkToAbsentCategories(e scpb.Element) error {
 // Assert that isWithTypeT covers all elements with embedded TypeTs.
 func checkIsWithTypeT(e scpb.Element) error {
 	return screl.WalkTypes(e, func(t *types.T) error {
-		if IsWithTypeT(e) {
+		if isWithTypeT(e) {
 			return nil
 		}
 		return errors.New("should verify isWithTypeT but doesn't")
@@ -120,7 +120,7 @@ func checkIsWithExpression(e scpb.Element) error {
 		case *scpb.RowLevelTTL:
 			return nil
 		}
-		if IsWithExpression(e) {
+		if isWithExpression(e) {
 			return nil
 		}
 		return errors.New("should verify isWithExpression but doesn't")
@@ -131,12 +131,12 @@ func checkIsWithExpression(e scpb.Element) error {
 // element.
 func checkIsColumnDependent(e scpb.Element) error {
 	// Exclude columns themselves.
-	if IsColumn(e) {
+	if isColumn(e) {
 		return nil
 	}
 	// A column dependent should have a ColumnID attribute.
 	_, err := screl.Schema.GetAttribute(screl.ColumnID, e)
-	if IsColumnDependent(e) {
+	if isColumnDependent(e) {
 		if err != nil {
 			return errors.New("verifies isColumnDependent but doesn't have ColumnID attr")
 		}
@@ -150,12 +150,12 @@ func checkIsColumnDependent(e scpb.Element) error {
 // element.
 func checkIsIndexDependent(e scpb.Element) error {
 	// Exclude indexes themselves and their data.
-	if IsIndex(e) || IsData(e) || IsSupportedNonIndexBackedConstraint(e) {
+	if isIndex(e) || isData(e) || isSupportedNonIndexBackedConstraint(e) {
 		return nil
 	}
 	// An index dependent should have an IndexID attribute.
 	_, err := screl.Schema.GetAttribute(screl.IndexID, e)
-	if IsIndexDependent(e) {
+	if isIndexDependent(e) {
 		if err != nil {
 			return errors.New("verifies isIndexDependent but doesn't have IndexID attr")
 		}
@@ -169,12 +169,12 @@ func checkIsIndexDependent(e scpb.Element) error {
 // element.
 func checkIsConstraintDependent(e scpb.Element) error {
 	// Exclude constraints themselves.
-	if IsConstraint(e) {
+	if isConstraint(e) {
 		return nil
 	}
 	// A constraint dependent should have a ConstraintID attribute.
 	_, err := screl.Schema.GetAttribute(screl.ConstraintID, e)
-	if IsConstraintDependent(e) {
+	if isConstraintDependent(e) {
 		if err != nil {
 			return errors.New("verifies isConstraintDependent but doesn't have ConstraintID attr")
 		}

--- a/pkg/sql/schemachanger/scplan/internal/rules/current/dep_add_column.go
+++ b/pkg/sql/schemachanger/scplan/internal/rules/current/dep_add_column.go
@@ -29,7 +29,7 @@ func init() {
 		func(from, to NodeVars) rel.Clauses {
 			return rel.Clauses{
 				from.Type((*scpb.Column)(nil)),
-				to.TypeFilter(IsColumnDependent),
+				to.TypeFilter(rulesVersionKey, isColumnDependent),
 				JoinOnColumnID(from, to, "table-id", "col-id"),
 				StatusesToPublicOrTransient(from, scpb.Status_DELETE_ONLY, to, scpb.Status_PUBLIC),
 			}
@@ -42,7 +42,7 @@ func init() {
 		"dependent", "column",
 		func(from, to NodeVars) rel.Clauses {
 			return rel.Clauses{
-				from.TypeFilter(IsColumnDependent),
+				from.TypeFilter(rulesVersionKey, isColumnDependent),
 				to.Type((*scpb.Column)(nil)),
 				JoinOnColumnID(from, to, "table-id", "col-id"),
 				StatusesToPublicOrTransient(from, scpb.Status_PUBLIC, to, scpb.Status_PUBLIC),

--- a/pkg/sql/schemachanger/scplan/internal/rules/current/dep_add_constraint.go
+++ b/pkg/sql/schemachanger/scplan/internal/rules/current/dep_add_constraint.go
@@ -26,8 +26,8 @@ func init() {
 		"dependent", "constraint",
 		func(from, to NodeVars) rel.Clauses {
 			return rel.Clauses{
-				from.TypeFilter(IsConstraintDependent),
-				to.TypeFilter(IsConstraint),
+				from.TypeFilter(rulesVersionKey, isConstraintDependent),
+				to.TypeFilter(rulesVersionKey, isConstraint),
 				JoinOnConstraintID(from, to, "table-id", "constraint-id"),
 				StatusesToPublicOrTransient(from, scpb.Status_PUBLIC, to, scpb.Status_PUBLIC),
 			}

--- a/pkg/sql/schemachanger/scplan/internal/rules/current/dep_add_index.go
+++ b/pkg/sql/schemachanger/scplan/internal/rules/current/dep_add_index.go
@@ -32,7 +32,7 @@ func init() {
 					(*scpb.PrimaryIndex)(nil),
 					(*scpb.SecondaryIndex)(nil),
 				),
-				to.TypeFilter(IsIndexDependent),
+				to.TypeFilter(rulesVersionKey, isIndexDependent),
 				JoinOnIndexID(from, to, "table-id", "index-id"),
 				StatusesToPublicOrTransient(from, scpb.Status_BACKFILL_ONLY, to, scpb.Status_PUBLIC),
 			}
@@ -46,7 +46,7 @@ func init() {
 		func(from, to NodeVars) rel.Clauses {
 			return rel.Clauses{
 				from.Type((*scpb.TemporaryIndex)(nil)),
-				to.TypeFilter(IsIndexDependent),
+				to.TypeFilter(rulesVersionKey, isIndexDependent),
 				JoinOnIndexID(from, to, "table-id", "index-id"),
 				StatusesToPublicOrTransient(from, scpb.Status_DELETE_ONLY, to, scpb.Status_PUBLIC),
 			}
@@ -59,8 +59,8 @@ func init() {
 		"dependent", "index",
 		func(from, to NodeVars) rel.Clauses {
 			return rel.Clauses{
-				from.TypeFilter(IsIndexDependent),
-				to.TypeFilter(IsIndex),
+				from.TypeFilter(rulesVersionKey, isIndexDependent),
+				to.TypeFilter(rulesVersionKey, isIndex),
 				JoinOnIndexID(from, to, "table-id", "index-id"),
 				StatusesToPublicOrTransient(from, scpb.Status_PUBLIC, to, scpb.Status_PUBLIC),
 			}

--- a/pkg/sql/schemachanger/scplan/internal/rules/current/dep_add_index_and_constraint.go
+++ b/pkg/sql/schemachanger/scplan/internal/rules/current/dep_add_index_and_constraint.go
@@ -28,7 +28,7 @@ func init() {
 		func(from, to NodeVars) rel.Clauses {
 			return rel.Clauses{
 				from.Type((*scpb.PrimaryIndex)(nil)),
-				to.TypeFilter(IsSupportedNonIndexBackedConstraint),
+				to.TypeFilter(rulesVersionKey, isSupportedNonIndexBackedConstraint),
 				JoinOnDescID(from, to, "table-id"),
 				JoinOn(
 					from, screl.IndexID,

--- a/pkg/sql/schemachanger/scplan/internal/rules/current/dep_drop_column.go
+++ b/pkg/sql/schemachanger/scplan/internal/rules/current/dep_drop_column.go
@@ -29,7 +29,7 @@ func init() {
 		func(from, to NodeVars) rel.Clauses {
 			return rel.Clauses{
 				from.Type((*scpb.Column)(nil)),
-				to.TypeFilter(IsColumnDependent),
+				to.TypeFilter(rulesVersionKey, isColumnDependent),
 				JoinOnColumnID(from, to, "table-id", "col-id"),
 			}
 		},
@@ -42,7 +42,7 @@ func init() {
 		scpb.Status_ABSENT, scpb.Status_ABSENT,
 		func(from, to NodeVars) rel.Clauses {
 			return rel.Clauses{
-				from.TypeFilter(IsColumnDependent),
+				from.TypeFilter(rulesVersionKey, isColumnDependent),
 				to.Type((*scpb.Column)(nil)),
 				JoinOnColumnID(from, to, "table-id", "col-id"),
 			}
@@ -59,7 +59,7 @@ func init() {
 		"dependent", "column-type",
 		func(from, to NodeVars) rel.Clauses {
 			return rel.Clauses{
-				from.TypeFilter(IsColumnTypeDependent),
+				from.TypeFilter(rulesVersionKey, isColumnTypeDependent),
 				to.Type((*scpb.ColumnType)(nil)),
 				JoinOnColumnID(from, to, "table-id", "col-id"),
 				StatusesToAbsent(from, scpb.Status_ABSENT, to, scpb.Status_ABSENT),
@@ -89,7 +89,7 @@ func init() {
 		func(from, to NodeVars) rel.Clauses {
 			return rel.Clauses{
 				from.Type((*scpb.ColumnType)(nil)),
-				from.DescriptorIsNotBeingDropped(),
+				descriptorIsNotBeingDropped(from.El),
 				to.Type((*scpb.Column)(nil)),
 				JoinOnColumnID(from, to, "table-id", "col-id"),
 				StatusesToAbsent(from, scpb.Status_ABSENT, to, scpb.Status_ABSENT),

--- a/pkg/sql/schemachanger/scplan/internal/rules/current/dep_drop_constraint.go
+++ b/pkg/sql/schemachanger/scplan/internal/rules/current/dep_drop_constraint.go
@@ -31,8 +31,8 @@ func init() {
 		scpb.Status_VALIDATED, scpb.Status_ABSENT,
 		func(from, to NodeVars) rel.Clauses {
 			return rel.Clauses{
-				from.TypeFilter(IsSupportedNonIndexBackedConstraint),
-				to.TypeFilter(IsConstraintDependent),
+				from.TypeFilter(rulesVersionKey, isSupportedNonIndexBackedConstraint),
+				to.TypeFilter(rulesVersionKey, isConstraintDependent),
 				JoinOnConstraintID(from, to, "table-id", "constraint-id"),
 			}
 		},
@@ -45,8 +45,8 @@ func init() {
 		scpb.Status_ABSENT, scpb.Status_ABSENT,
 		func(from, to NodeVars) rel.Clauses {
 			return rel.Clauses{
-				from.TypeFilter(IsConstraintDependent),
-				to.TypeFilter(IsSupportedNonIndexBackedConstraint),
+				from.TypeFilter(rulesVersionKey, isConstraintDependent),
+				to.TypeFilter(rulesVersionKey, isSupportedNonIndexBackedConstraint),
 				JoinOnConstraintID(from, to, "table-id", "constraint-id"),
 			}
 		},

--- a/pkg/sql/schemachanger/scplan/internal/rules/current/dep_drop_index.go
+++ b/pkg/sql/schemachanger/scplan/internal/rules/current/dep_drop_index.go
@@ -28,8 +28,8 @@ func init() {
 		scpb.Status_VALIDATED, scpb.Status_ABSENT,
 		func(from, to NodeVars) rel.Clauses {
 			return rel.Clauses{
-				from.TypeFilter(IsIndex),
-				to.TypeFilter(IsIndexDependent),
+				from.TypeFilter(rulesVersionKey, isIndex),
+				to.TypeFilter(rulesVersionKey, isIndexDependent),
 				JoinOnIndexID(from, to, "table-id", "index-id"),
 			}
 		},
@@ -41,8 +41,8 @@ func init() {
 		scpb.Status_ABSENT, scpb.Status_ABSENT,
 		func(from, to NodeVars) rel.Clauses {
 			return rel.Clauses{
-				from.TypeFilter(IsIndexDependent),
-				to.TypeFilter(IsIndex),
+				from.TypeFilter(rulesVersionKey, isIndexDependent),
+				to.TypeFilter(rulesVersionKey, isIndex),
 				JoinOnIndexID(from, to, "table-id", "index-id"),
 			}
 		},
@@ -87,7 +87,7 @@ func init() {
 		func(from, to NodeVars) rel.Clauses {
 			return rel.Clauses{
 				from.Type((*scpb.IndexColumn)(nil)),
-				to.TypeFilter(IsIndex),
+				to.TypeFilter(rulesVersionKey, isIndex),
 				JoinOnIndexID(from, to, "table-id", "index-id"),
 			}
 		},
@@ -113,7 +113,7 @@ func init() {
 		func(from, to NodeVars) rel.Clauses {
 			return rel.Clauses{
 				from.Type((*scpb.SecondaryIndexPartial)(nil)),
-				from.DescriptorIsNotBeingDropped(),
+				descriptorIsNotBeingDropped(from.El),
 				to.Type((*scpb.SecondaryIndex)(nil)),
 				JoinOnIndexID(from, to, "table-id", "index-id"),
 			}

--- a/pkg/sql/schemachanger/scplan/internal/rules/current/dep_drop_index_and_column.go
+++ b/pkg/sql/schemachanger/scplan/internal/rules/current/dep_drop_index_and_column.go
@@ -36,7 +36,7 @@ func init() {
 				to.Type((*scpb.Column)(nil)),
 				ColumnInIndex(ic, from, relationID, columnID, "index-id"),
 				JoinOnColumnID(ic, to, relationID, columnID),
-				ic.DescriptorIsNotBeingDropped(),
+				descriptorIsNotBeingDropped(ic.El),
 			}
 		})
 
@@ -52,7 +52,7 @@ func init() {
 				ColumnInIndex(ic, from, relationID, columnID, "index-id"),
 				JoinOnColumnID(ic, to, relationID, columnID),
 				StatusesToAbsent(from, scpb.Status_VALIDATED, to, scpb.Status_WRITE_ONLY),
-				ic.DescriptorIsNotBeingDropped(),
+				descriptorIsNotBeingDropped(ic.El),
 				rel.Filter("isIndexKeyColumnKey", ic.El)(
 					func(ic *scpb.IndexColumn) bool {
 						return ic.Kind == scpb.IndexColumn_KEY

--- a/pkg/sql/schemachanger/scplan/internal/rules/current/dep_drop_object.go
+++ b/pkg/sql/schemachanger/scplan/internal/rules/current/dep_drop_object.go
@@ -34,7 +34,7 @@ func init() {
 		"dropped", "absent",
 		func(from, to NodeVars) rel.Clauses {
 			return rel.Clauses{
-				from.TypeFilter(IsDescriptor),
+				from.TypeFilter(rulesVersionKey, isDescriptor),
 				from.El.AttrEqVar(screl.DescID, "_"),
 				from.El.AttrEqVar(rel.Self, to.El),
 				StatusesToAbsent(from, scpb.Status_DROPPED, to, scpb.Status_ABSENT),
@@ -47,8 +47,8 @@ func init() {
 		"descriptor", "dependent",
 		func(from, to NodeVars) rel.Clauses {
 			return rel.Clauses{
-				from.TypeFilter(IsDescriptor),
-				to.TypeFilter(IsSimpleDependent),
+				from.TypeFilter(rulesVersionKey, isDescriptor),
+				to.TypeFilter(rulesVersionKey, isSimpleDependent),
 				JoinOnDescID(from, to, "desc-id"),
 				StatusesToAbsent(from, scpb.Status_DROPPED, to, scpb.Status_ABSENT),
 			}
@@ -61,7 +61,7 @@ func init() {
 		func(from, to NodeVars) rel.Clauses {
 			return rel.Clauses{
 				from.Type((*scpb.Table)(nil), (*scpb.View)(nil), (*scpb.Sequence)(nil)),
-				to.TypeFilter(IsColumn),
+				to.TypeFilter(rulesVersionKey, isColumn),
 				JoinOnDescID(from, to, "desc-id"),
 				StatusesToAbsent(from, scpb.Status_DROPPED, to, scpb.Status_WRITE_ONLY),
 			}
@@ -74,7 +74,7 @@ func init() {
 		func(from, to NodeVars) rel.Clauses {
 			return rel.Clauses{
 				from.Type((*scpb.Table)(nil), (*scpb.View)(nil)),
-				to.TypeFilter(IsIndex),
+				to.TypeFilter(rulesVersionKey, isIndex),
 				JoinOnDescID(from, to, "desc-id"),
 				StatusesToAbsent(from, scpb.Status_DROPPED, to, scpb.Status_VALIDATED),
 			}
@@ -88,7 +88,7 @@ func init() {
 		func(from, to NodeVars) rel.Clauses {
 			return rel.Clauses{
 				from.Type((*scpb.Table)(nil)),
-				to.TypeFilter(IsSupportedNonIndexBackedConstraint),
+				to.TypeFilter(rulesVersionKey, isSupportedNonIndexBackedConstraint),
 				JoinOnDescID(from, to, "desc-id"),
 				StatusesToAbsent(from, scpb.Status_DROPPED, to, scpb.Status_WRITE_ONLY),
 			}
@@ -114,8 +114,8 @@ func init() {
 		"referenced-descriptor", "referencing-via-attr",
 		func(from, to NodeVars) rel.Clauses {
 			return rel.Clauses{
-				from.TypeFilter(IsDescriptor),
-				to.TypeFilter(IsSimpleDependent),
+				from.TypeFilter(rulesVersionKey, isDescriptor),
+				to.TypeFilter(rulesVersionKey, isSimpleDependent),
 				JoinReferencedDescID(to, from, "desc-id"),
 				StatusesToAbsent(from, scpb.Status_DROPPED, to, scpb.Status_ABSENT),
 			}
@@ -129,10 +129,10 @@ func init() {
 		func(from, to NodeVars) rel.Clauses {
 			fromDescID := rel.Var("fromDescID")
 			return rel.Clauses{
-				from.TypeFilter(IsTypeDescriptor),
+				from.TypeFilter(rulesVersionKey, isTypeDescriptor),
 				from.DescIDEq(fromDescID),
 				to.ReferencedTypeDescIDsContain(fromDescID),
-				to.TypeFilter(IsSimpleDependent, Or(IsWithTypeT, IsWithExpression)),
+				to.TypeFilter(rulesVersionKey, isSimpleDependent, Or(isWithTypeT, isWithExpression)),
 				StatusesToAbsent(from, scpb.Status_DROPPED, to, scpb.Status_ABSENT),
 			}
 		},
@@ -148,7 +148,7 @@ func init() {
 				from.Type((*scpb.Sequence)(nil)),
 				from.DescIDEq(seqID),
 				to.ReferencedSequenceIDsContains(seqID),
-				to.TypeFilter(IsSimpleDependent, IsWithExpression),
+				to.TypeFilter(rulesVersionKey, isSimpleDependent, isWithExpression),
 				StatusesToAbsent(from, scpb.Status_DROPPED, to, scpb.Status_ABSENT),
 			}
 		},

--- a/pkg/sql/schemachanger/scplan/internal/rules/current/dep_garbage_collection.go
+++ b/pkg/sql/schemachanger/scplan/internal/rules/current/dep_garbage_collection.go
@@ -31,7 +31,7 @@ func init() {
 		"table", "data",
 		func(from, to NodeVars) rel.Clauses {
 			return rel.Clauses{
-				from.TypeFilter(IsDescriptor),
+				from.TypeFilter(rulesVersionKey, isDescriptor),
 				to.Type((*scpb.TableData)(nil)),
 				JoinOnDescID(from, to, "table-id"),
 				StatusesToAbsent(from, scpb.Status_ABSENT, to, scpb.Status_DROPPED),
@@ -45,7 +45,7 @@ func init() {
 		"database", "data",
 		func(from, to NodeVars) rel.Clauses {
 			return rel.Clauses{
-				from.TypeFilter(IsDescriptor),
+				from.TypeFilter(rulesVersionKey, isDescriptor),
 				to.Type((*scpb.DatabaseData)(nil)),
 				JoinOnDescID(from, to, "db-id"),
 				StatusesToAbsent(from, scpb.Status_ABSENT, to, scpb.Status_DROPPED),
@@ -60,7 +60,7 @@ func init() {
 		scpb.Status_ABSENT, scpb.Status_DROPPED,
 		func(from, to NodeVars) rel.Clauses {
 			return rel.Clauses{
-				from.TypeFilter(IsIndex),
+				from.TypeFilter(rulesVersionKey, isIndex),
 				to.Type((*scpb.IndexData)(nil)),
 				JoinOnIndexID(from, to, "table-id", "index-id"),
 			}
@@ -87,8 +87,8 @@ func init() {
 		scpb.Status_DROPPED, scpb.Status_DROPPED,
 		func(from, to NodeVars) rel.Clauses {
 			return rel.Clauses{
-				from.TypeFilter(IsData),
-				to.TypeFilter(IsData),
+				from.TypeFilter(rulesVersionKey, isData),
+				to.TypeFilter(rulesVersionKey, isData),
 				JoinOnDescID(from, to, "desc-id"),
 				FilterElements("SmallerIDsFirst", from, to, func(a, b scpb.Element) bool {
 					aDescID, aIdxID := dataIDs(a)

--- a/pkg/sql/schemachanger/scplan/internal/rules/current/dep_two_version.go
+++ b/pkg/sql/schemachanger/scplan/internal/rules/current/dep_two_version.go
@@ -69,7 +69,7 @@ func init() {
 			from.Target.AttrEq(screl.TargetStatus, targetStatus.Status()),
 			from.Node.AttrEq(screl.CurrentStatus, t.From()),
 			to.Node.AttrEq(screl.CurrentStatus, t.To()),
-			from.DescriptorIsNotBeingDropped(),
+			descriptorIsNotBeingDropped(from.El),
 		}
 		if len(prePrevStatuses) > 0 {
 			clauses = append(clauses,
@@ -104,7 +104,7 @@ func init() {
 		}
 	}
 	_ = ForEachElement(func(el scpb.Element) error {
-		if !IsSubjectTo2VersionInvariant(el) {
+		if !isSubjectTo2VersionInvariant(el) {
 			return nil
 		}
 		if opgen.HasPublic(el) {

--- a/pkg/sql/schemachanger/scplan/internal/rules/current/helpers.go
+++ b/pkg/sql/schemachanger/scplan/internal/rules/current/helpers.go
@@ -1,0 +1,224 @@
+// Copyright 2023 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package current
+
+import (
+	"github.com/cockroachdb/cockroach/pkg/clusterversion"
+	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/rel"
+	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scplan/internal/rules"
+	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/screl"
+	"github.com/cockroachdb/errors"
+)
+
+const (
+	// rulesVersion version of elements that can be appended to rel rule names.
+	rulesVersion = "-23.1"
+)
+
+// rulesVersionKey version of elements used by this rule set.
+var rulesVersionKey = clusterversion.V23_1
+
+// descriptorIsNotBeingDropped creates a clause which leads to the outer clause
+// failing to unify if the passed element is part of a descriptor and
+// that descriptor is being dropped.
+var descriptorIsNotBeingDropped = screl.Schema.DefNotJoin1(
+	"descriptorIsNotBeingDropped"+rulesVersion, "element", func(
+		element rel.Var,
+	) rel.Clauses {
+		descriptor := rules.MkNodeVars("descriptor")
+		return rel.Clauses{
+			descriptor.TypeFilter(rulesVersionKey, isDescriptor),
+			descriptor.JoinTarget(),
+			rules.JoinOnDescIDUntyped(descriptor.El, element, "id"),
+			descriptor.TargetStatus(scpb.ToAbsent),
+		}
+	},
+)
+
+// isDescriptor returns true for a descriptor-element, i.e. an element which
+// owns its corresponding descriptor.
+func isDescriptor(e scpb.Element) bool {
+	switch e.(type) {
+	case *scpb.Database, *scpb.Schema, *scpb.Table, *scpb.View, *scpb.Sequence,
+		*scpb.AliasType, *scpb.EnumType, *scpb.CompositeType:
+		return true
+	}
+	return false
+}
+
+// IsDescriptor returns true for a descriptor-element, i.e. an element which
+// owns its corresponding descriptor. This is only used for exports
+func IsDescriptor(e scpb.Element) bool {
+	return isDescriptor(e)
+}
+
+func isSubjectTo2VersionInvariant(e scpb.Element) bool {
+	// TODO(ajwerner): This should include constraints and enum values but it
+	// currently does not because we do not support dropping them unless we're
+	// dropping the descriptor and we do not support adding them.
+	return isIndex(e) || isColumn(e) || isSupportedNonIndexBackedConstraint(e)
+}
+
+func isIndex(e scpb.Element) bool {
+	switch e.(type) {
+	case *scpb.PrimaryIndex, *scpb.SecondaryIndex, *scpb.TemporaryIndex:
+		return true
+	}
+	return false
+}
+
+func isColumn(e scpb.Element) bool {
+	_, ok := e.(*scpb.Column)
+	return ok
+}
+
+func isSimpleDependent(e scpb.Element) bool {
+	return !isDescriptor(e) && !isSubjectTo2VersionInvariant(e) && !isData(e)
+}
+
+func getTypeT(element scpb.Element) (*scpb.TypeT, error) {
+	switch e := element.(type) {
+	case *scpb.ColumnType:
+		if e == nil {
+			return nil, nil
+		}
+		return &e.TypeT, nil
+	case *scpb.AliasType:
+		if e == nil {
+			return nil, nil
+		}
+		return &e.TypeT, nil
+	}
+	return nil, errors.AssertionFailedf("element %T does not have an embedded scpb.TypeT", element)
+}
+
+func isWithTypeT(element scpb.Element) bool {
+	_, err := getTypeT(element)
+	return err == nil
+}
+
+func getExpression(element scpb.Element) (*scpb.Expression, error) {
+	switch e := element.(type) {
+	case *scpb.ColumnType:
+		if e == nil {
+			return nil, nil
+		}
+		return e.ComputeExpr, nil
+	case *scpb.ColumnDefaultExpression:
+		if e == nil {
+			return nil, nil
+		}
+		return &e.Expression, nil
+	case *scpb.ColumnOnUpdateExpression:
+		if e == nil {
+			return nil, nil
+		}
+		return &e.Expression, nil
+	case *scpb.SecondaryIndexPartial:
+		if e == nil {
+			return nil, nil
+		}
+		return &e.Expression, nil
+	case *scpb.CheckConstraint:
+		if e == nil {
+			return nil, nil
+		}
+		return &e.Expression, nil
+	}
+	return nil, errors.AssertionFailedf("element %T does not have an embedded scpb.Expression", element)
+}
+
+func isWithExpression(element scpb.Element) bool {
+	_, err := getExpression(element)
+	return err == nil
+}
+
+func isTypeDescriptor(element scpb.Element) bool {
+	switch element.(type) {
+	case *scpb.EnumType, *scpb.AliasType, *scpb.CompositeType:
+		return true
+	default:
+		return false
+	}
+}
+
+func isColumnDependent(e scpb.Element) bool {
+	switch e.(type) {
+	case *scpb.ColumnType:
+		return true
+	case *scpb.ColumnName, *scpb.ColumnComment, *scpb.IndexColumn:
+		return true
+	}
+	return isColumnTypeDependent(e)
+}
+
+func isColumnTypeDependent(e scpb.Element) bool {
+	switch e.(type) {
+	case *scpb.SequenceOwner, *scpb.ColumnDefaultExpression, *scpb.ColumnOnUpdateExpression:
+		return true
+	}
+	return false
+}
+
+func isIndexDependent(e scpb.Element) bool {
+	switch e.(type) {
+	case *scpb.IndexName, *scpb.IndexComment, *scpb.IndexColumn:
+		return true
+	case *scpb.IndexPartitioning, *scpb.SecondaryIndexPartial:
+		return true
+	}
+	return false
+}
+
+// isSupportedNonIndexBackedConstraint a non-index-backed constraint is one of {Check, FK, UniqueWithoutIndex}. We only
+// support Check for now.
+// TODO (xiang): Expand this predicate to include other non-index-backed constraints
+// when we properly support adding/dropping them in the new schema changer.
+func isSupportedNonIndexBackedConstraint(e scpb.Element) bool {
+	switch e.(type) {
+	case *scpb.CheckConstraint, *scpb.ForeignKeyConstraint, *scpb.UniqueWithoutIndexConstraint:
+		return true
+	}
+	return false
+}
+
+func isConstraint(e scpb.Element) bool {
+	switch e.(type) {
+	case *scpb.PrimaryIndex, *scpb.SecondaryIndex, *scpb.TemporaryIndex:
+		return true
+	case *scpb.CheckConstraint, *scpb.UniqueWithoutIndexConstraint, *scpb.ForeignKeyConstraint:
+		return true
+	}
+	return false
+}
+
+func isConstraintDependent(e scpb.Element) bool {
+	switch e.(type) {
+	case *scpb.ConstraintWithoutIndexName:
+		return true
+	case *scpb.ConstraintComment:
+		return true
+	}
+	return false
+}
+
+func isData(e scpb.Element) bool {
+	switch e.(type) {
+	case *scpb.DatabaseData:
+		return true
+	case *scpb.TableData:
+		return true
+	case *scpb.IndexData:
+		return true
+	}
+	return false
+}

--- a/pkg/sql/schemachanger/scplan/internal/rules/current/op_drop.go
+++ b/pkg/sql/schemachanger/scplan/internal/rules/current/op_drop.go
@@ -130,7 +130,7 @@ func init() {
 				(*scpb.Table)(nil),
 				(*scpb.View)(nil),
 			),
-			index.TypeFilter(IsIndex),
+			index.TypeFilter(rulesVersionKey, isIndex),
 			dep.Type(
 				(*scpb.IndexName)(nil),
 				(*scpb.IndexPartitioning)(nil),
@@ -234,7 +234,7 @@ func init() {
 		"skip element removal ops on descriptor drop",
 		dep.Node,
 		screl.MustQuery(
-			desc.TypeFilter(IsDescriptor),
+			desc.TypeFilter(rulesVersionKey, isDescriptor),
 			dep.Type(
 				(*scpb.ColumnFamily)(nil),
 				(*scpb.Owner)(nil),

--- a/pkg/sql/schemachanger/scplan/internal/rules/current/op_index_and_column.go
+++ b/pkg/sql/schemachanger/scplan/internal/rules/current/op_index_and_column.go
@@ -29,7 +29,7 @@ func init() {
 		ic.Node,
 		screl.MustQuery(
 			ic.Type((*scpb.IndexColumn)(nil)),
-			index.TypeFilter(IsIndex),
+			index.TypeFilter(rulesVersionKey, isIndex),
 			JoinOnIndexID(ic, index, relationID, indexID),
 			ic.JoinTargetNode(),
 			ic.TargetStatus(scpb.ToAbsent, scpb.Transient),

--- a/pkg/sql/schemachanger/scplan/internal/rules/current/testdata/deprules
+++ b/pkg/sql/schemachanger/scplan/internal/rules/current/testdata/deprules
@@ -9,15 +9,15 @@ ColumnInIndex($index-column, $index, $table-id, $column-id, $index-id):
 ColumnInSwappedInPrimaryIndex($index-column, $index, $table-id, $column-id, $index-id):
     - ColumnInIndex($index-column, $index, $table-id, $column-id, $index-id)
     - sourceIndexIsSet($index)
-DescriptorIsNotBeingDropped($element):
+ToPublicOrTransient($target1, $target2):
+    - $target1[TargetStatus] IN [PUBLIC, TRANSIENT_ABSENT]
+    - $target2[TargetStatus] IN [PUBLIC, TRANSIENT_ABSENT]
+descriptorIsNotBeingDropped-23.1($element):
     not-join:
         - $descriptor[Type] IN ['*scpb.Database', '*scpb.Schema', '*scpb.View', '*scpb.Sequence', '*scpb.Table', '*scpb.EnumType', '*scpb.AliasType', '*scpb.CompositeType']
         - joinTarget($descriptor, $descriptor-Target)
         - joinOnDescID($descriptor, $element, $id)
         - $descriptor-Target[TargetStatus] = ABSENT
-ToPublicOrTransient($target1, $target2):
-    - $target1[TargetStatus] IN [PUBLIC, TRANSIENT_ABSENT]
-    - $target2[TargetStatus] IN [PUBLIC, TRANSIENT_ABSENT]
 joinOnColumnID($a, $b, $desc-id, $col-id):
     - joinOnDescID($a, $b, $desc-id)
     - $a[ColumnID] = $col-id
@@ -113,7 +113,7 @@ deprules
     - $prev-Target[TargetStatus] = ABSENT
     - $prev-Node[CurrentStatus] = PUBLIC
     - $next-Node[CurrentStatus] = VALIDATED
-    - DescriptorIsNotBeingDropped($prev)
+    - descriptorIsNotBeingDropped-23.1($prev)
     - joinTargetNode($prev, $prev-Target, $prev-Node)
     - joinTargetNode($next, $next-Target, $next-Node)
 - name: 'CheckConstraint transitions to ABSENT uphold 2-version invariant: VALIDATED->ABSENT'
@@ -129,7 +129,7 @@ deprules
     - $prev-Target[TargetStatus] = ABSENT
     - $prev-Node[CurrentStatus] = VALIDATED
     - $next-Node[CurrentStatus] = ABSENT
-    - DescriptorIsNotBeingDropped($prev)
+    - descriptorIsNotBeingDropped-23.1($prev)
     - nodeNotExistsWithStatusIn_WRITE_ONLY($prev-Target)
     - joinTargetNode($prev, $prev-Target, $prev-Node)
     - joinTargetNode($next, $next-Target, $next-Node)
@@ -146,7 +146,7 @@ deprules
     - $prev-Target[TargetStatus] = ABSENT
     - $prev-Node[CurrentStatus] = WRITE_ONLY
     - $next-Node[CurrentStatus] = VALIDATED
-    - DescriptorIsNotBeingDropped($prev)
+    - descriptorIsNotBeingDropped-23.1($prev)
     - joinTargetNode($prev, $prev-Target, $prev-Node)
     - joinTargetNode($next, $next-Target, $next-Node)
 - name: 'CheckConstraint transitions to PUBLIC uphold 2-version invariant: ABSENT->WRITE_ONLY'
@@ -162,7 +162,7 @@ deprules
     - $prev-Target[TargetStatus] = PUBLIC
     - $prev-Node[CurrentStatus] = ABSENT
     - $next-Node[CurrentStatus] = WRITE_ONLY
-    - DescriptorIsNotBeingDropped($prev)
+    - descriptorIsNotBeingDropped-23.1($prev)
     - joinTargetNode($prev, $prev-Target, $prev-Node)
     - joinTargetNode($next, $next-Target, $next-Node)
 - name: 'CheckConstraint transitions to PUBLIC uphold 2-version invariant: VALIDATED->PUBLIC'
@@ -178,7 +178,7 @@ deprules
     - $prev-Target[TargetStatus] = PUBLIC
     - $prev-Node[CurrentStatus] = VALIDATED
     - $next-Node[CurrentStatus] = PUBLIC
-    - DescriptorIsNotBeingDropped($prev)
+    - descriptorIsNotBeingDropped-23.1($prev)
     - joinTargetNode($prev, $prev-Target, $prev-Node)
     - joinTargetNode($next, $next-Target, $next-Node)
 - name: 'CheckConstraint transitions to PUBLIC uphold 2-version invariant: WRITE_ONLY->VALIDATED'
@@ -194,7 +194,7 @@ deprules
     - $prev-Target[TargetStatus] = PUBLIC
     - $prev-Node[CurrentStatus] = WRITE_ONLY
     - $next-Node[CurrentStatus] = VALIDATED
-    - DescriptorIsNotBeingDropped($prev)
+    - descriptorIsNotBeingDropped-23.1($prev)
     - joinTargetNode($prev, $prev-Target, $prev-Node)
     - joinTargetNode($next, $next-Target, $next-Node)
 - name: 'Column transitions to ABSENT uphold 2-version invariant: DELETE_ONLY->ABSENT'
@@ -210,7 +210,7 @@ deprules
     - $prev-Target[TargetStatus] = ABSENT
     - $prev-Node[CurrentStatus] = DELETE_ONLY
     - $next-Node[CurrentStatus] = ABSENT
-    - DescriptorIsNotBeingDropped($prev)
+    - descriptorIsNotBeingDropped-23.1($prev)
     - joinTargetNode($prev, $prev-Target, $prev-Node)
     - joinTargetNode($next, $next-Target, $next-Node)
 - name: 'Column transitions to ABSENT uphold 2-version invariant: PUBLIC->WRITE_ONLY'
@@ -226,7 +226,7 @@ deprules
     - $prev-Target[TargetStatus] = ABSENT
     - $prev-Node[CurrentStatus] = PUBLIC
     - $next-Node[CurrentStatus] = WRITE_ONLY
-    - DescriptorIsNotBeingDropped($prev)
+    - descriptorIsNotBeingDropped-23.1($prev)
     - joinTargetNode($prev, $prev-Target, $prev-Node)
     - joinTargetNode($next, $next-Target, $next-Node)
 - name: 'Column transitions to ABSENT uphold 2-version invariant: WRITE_ONLY->DELETE_ONLY'
@@ -242,7 +242,7 @@ deprules
     - $prev-Target[TargetStatus] = ABSENT
     - $prev-Node[CurrentStatus] = WRITE_ONLY
     - $next-Node[CurrentStatus] = DELETE_ONLY
-    - DescriptorIsNotBeingDropped($prev)
+    - descriptorIsNotBeingDropped-23.1($prev)
     - joinTargetNode($prev, $prev-Target, $prev-Node)
     - joinTargetNode($next, $next-Target, $next-Node)
 - name: 'Column transitions to PUBLIC uphold 2-version invariant: ABSENT->DELETE_ONLY'
@@ -258,7 +258,7 @@ deprules
     - $prev-Target[TargetStatus] = PUBLIC
     - $prev-Node[CurrentStatus] = ABSENT
     - $next-Node[CurrentStatus] = DELETE_ONLY
-    - DescriptorIsNotBeingDropped($prev)
+    - descriptorIsNotBeingDropped-23.1($prev)
     - joinTargetNode($prev, $prev-Target, $prev-Node)
     - joinTargetNode($next, $next-Target, $next-Node)
 - name: 'Column transitions to PUBLIC uphold 2-version invariant: DELETE_ONLY->WRITE_ONLY'
@@ -274,7 +274,7 @@ deprules
     - $prev-Target[TargetStatus] = PUBLIC
     - $prev-Node[CurrentStatus] = DELETE_ONLY
     - $next-Node[CurrentStatus] = WRITE_ONLY
-    - DescriptorIsNotBeingDropped($prev)
+    - descriptorIsNotBeingDropped-23.1($prev)
     - joinTargetNode($prev, $prev-Target, $prev-Node)
     - joinTargetNode($next, $next-Target, $next-Node)
 - name: 'Column transitions to PUBLIC uphold 2-version invariant: WRITE_ONLY->PUBLIC'
@@ -290,7 +290,7 @@ deprules
     - $prev-Target[TargetStatus] = PUBLIC
     - $prev-Node[CurrentStatus] = WRITE_ONLY
     - $next-Node[CurrentStatus] = PUBLIC
-    - DescriptorIsNotBeingDropped($prev)
+    - descriptorIsNotBeingDropped-23.1($prev)
     - joinTargetNode($prev, $prev-Target, $prev-Node)
     - joinTargetNode($next, $next-Target, $next-Node)
 - name: DEFAULT or ON UPDATE existence precedes writes to column
@@ -319,7 +319,7 @@ deprules
     - $prev-Target[TargetStatus] = ABSENT
     - $prev-Node[CurrentStatus] = PUBLIC
     - $next-Node[CurrentStatus] = VALIDATED
-    - DescriptorIsNotBeingDropped($prev)
+    - descriptorIsNotBeingDropped-23.1($prev)
     - joinTargetNode($prev, $prev-Target, $prev-Node)
     - joinTargetNode($next, $next-Target, $next-Node)
 - name: 'ForeignKeyConstraint transitions to ABSENT uphold 2-version invariant: VALIDATED->ABSENT'
@@ -335,7 +335,7 @@ deprules
     - $prev-Target[TargetStatus] = ABSENT
     - $prev-Node[CurrentStatus] = VALIDATED
     - $next-Node[CurrentStatus] = ABSENT
-    - DescriptorIsNotBeingDropped($prev)
+    - descriptorIsNotBeingDropped-23.1($prev)
     - nodeNotExistsWithStatusIn_WRITE_ONLY($prev-Target)
     - joinTargetNode($prev, $prev-Target, $prev-Node)
     - joinTargetNode($next, $next-Target, $next-Node)
@@ -352,7 +352,7 @@ deprules
     - $prev-Target[TargetStatus] = ABSENT
     - $prev-Node[CurrentStatus] = WRITE_ONLY
     - $next-Node[CurrentStatus] = VALIDATED
-    - DescriptorIsNotBeingDropped($prev)
+    - descriptorIsNotBeingDropped-23.1($prev)
     - joinTargetNode($prev, $prev-Target, $prev-Node)
     - joinTargetNode($next, $next-Target, $next-Node)
 - name: 'ForeignKeyConstraint transitions to PUBLIC uphold 2-version invariant: ABSENT->WRITE_ONLY'
@@ -368,7 +368,7 @@ deprules
     - $prev-Target[TargetStatus] = PUBLIC
     - $prev-Node[CurrentStatus] = ABSENT
     - $next-Node[CurrentStatus] = WRITE_ONLY
-    - DescriptorIsNotBeingDropped($prev)
+    - descriptorIsNotBeingDropped-23.1($prev)
     - joinTargetNode($prev, $prev-Target, $prev-Node)
     - joinTargetNode($next, $next-Target, $next-Node)
 - name: 'ForeignKeyConstraint transitions to PUBLIC uphold 2-version invariant: VALIDATED->PUBLIC'
@@ -384,7 +384,7 @@ deprules
     - $prev-Target[TargetStatus] = PUBLIC
     - $prev-Node[CurrentStatus] = VALIDATED
     - $next-Node[CurrentStatus] = PUBLIC
-    - DescriptorIsNotBeingDropped($prev)
+    - descriptorIsNotBeingDropped-23.1($prev)
     - joinTargetNode($prev, $prev-Target, $prev-Node)
     - joinTargetNode($next, $next-Target, $next-Node)
 - name: 'ForeignKeyConstraint transitions to PUBLIC uphold 2-version invariant: WRITE_ONLY->VALIDATED'
@@ -400,7 +400,7 @@ deprules
     - $prev-Target[TargetStatus] = PUBLIC
     - $prev-Node[CurrentStatus] = WRITE_ONLY
     - $next-Node[CurrentStatus] = VALIDATED
-    - DescriptorIsNotBeingDropped($prev)
+    - descriptorIsNotBeingDropped-23.1($prev)
     - joinTargetNode($prev, $prev-Target, $prev-Node)
     - joinTargetNode($next, $next-Target, $next-Node)
 - name: 'PrimaryIndex transitions to ABSENT uphold 2-version invariant: BACKFILLED->DELETE_ONLY'
@@ -416,7 +416,7 @@ deprules
     - $prev-Target[TargetStatus] = ABSENT
     - $prev-Node[CurrentStatus] = BACKFILLED
     - $next-Node[CurrentStatus] = DELETE_ONLY
-    - DescriptorIsNotBeingDropped($prev)
+    - descriptorIsNotBeingDropped-23.1($prev)
     - joinTargetNode($prev, $prev-Target, $prev-Node)
     - joinTargetNode($next, $next-Target, $next-Node)
 - name: 'PrimaryIndex transitions to ABSENT uphold 2-version invariant: BACKFILL_ONLY->DELETE_ONLY'
@@ -432,7 +432,7 @@ deprules
     - $prev-Target[TargetStatus] = ABSENT
     - $prev-Node[CurrentStatus] = BACKFILL_ONLY
     - $next-Node[CurrentStatus] = DELETE_ONLY
-    - DescriptorIsNotBeingDropped($prev)
+    - descriptorIsNotBeingDropped-23.1($prev)
     - joinTargetNode($prev, $prev-Target, $prev-Node)
     - joinTargetNode($next, $next-Target, $next-Node)
 - name: 'PrimaryIndex transitions to ABSENT uphold 2-version invariant: DELETE_ONLY->ABSENT'
@@ -448,7 +448,7 @@ deprules
     - $prev-Target[TargetStatus] = ABSENT
     - $prev-Node[CurrentStatus] = DELETE_ONLY
     - $next-Node[CurrentStatus] = ABSENT
-    - DescriptorIsNotBeingDropped($prev)
+    - descriptorIsNotBeingDropped-23.1($prev)
     - nodeNotExistsWithStatusIn_TRANSIENT_DELETE_ONLY_BACKFILLED_TRANSIENT_BACKFILLED_BACKFILL_ONLY_TRANSIENT_BACKFILL_ONLY($prev-Target)
     - joinTargetNode($prev, $prev-Target, $prev-Node)
     - joinTargetNode($next, $next-Target, $next-Node)
@@ -465,7 +465,7 @@ deprules
     - $prev-Target[TargetStatus] = ABSENT
     - $prev-Node[CurrentStatus] = MERGED
     - $next-Node[CurrentStatus] = WRITE_ONLY
-    - DescriptorIsNotBeingDropped($prev)
+    - descriptorIsNotBeingDropped-23.1($prev)
     - joinTargetNode($prev, $prev-Target, $prev-Node)
     - joinTargetNode($next, $next-Target, $next-Node)
 - name: 'PrimaryIndex transitions to ABSENT uphold 2-version invariant: MERGE_ONLY->WRITE_ONLY'
@@ -481,7 +481,7 @@ deprules
     - $prev-Target[TargetStatus] = ABSENT
     - $prev-Node[CurrentStatus] = MERGE_ONLY
     - $next-Node[CurrentStatus] = WRITE_ONLY
-    - DescriptorIsNotBeingDropped($prev)
+    - descriptorIsNotBeingDropped-23.1($prev)
     - joinTargetNode($prev, $prev-Target, $prev-Node)
     - joinTargetNode($next, $next-Target, $next-Node)
 - name: 'PrimaryIndex transitions to ABSENT uphold 2-version invariant: PUBLIC->VALIDATED'
@@ -497,7 +497,7 @@ deprules
     - $prev-Target[TargetStatus] = ABSENT
     - $prev-Node[CurrentStatus] = PUBLIC
     - $next-Node[CurrentStatus] = VALIDATED
-    - DescriptorIsNotBeingDropped($prev)
+    - descriptorIsNotBeingDropped-23.1($prev)
     - joinTargetNode($prev, $prev-Target, $prev-Node)
     - joinTargetNode($next, $next-Target, $next-Node)
 - name: 'PrimaryIndex transitions to ABSENT uphold 2-version invariant: TRANSIENT_ABSENT->ABSENT'
@@ -513,7 +513,7 @@ deprules
     - $prev-Target[TargetStatus] = ABSENT
     - $prev-Node[CurrentStatus] = TRANSIENT_ABSENT
     - $next-Node[CurrentStatus] = ABSENT
-    - DescriptorIsNotBeingDropped($prev)
+    - descriptorIsNotBeingDropped-23.1($prev)
     - joinTargetNode($prev, $prev-Target, $prev-Node)
     - joinTargetNode($next, $next-Target, $next-Node)
 - name: 'PrimaryIndex transitions to ABSENT uphold 2-version invariant: TRANSIENT_BACKFILLED->DELETE_ONLY'
@@ -529,7 +529,7 @@ deprules
     - $prev-Target[TargetStatus] = ABSENT
     - $prev-Node[CurrentStatus] = TRANSIENT_BACKFILLED
     - $next-Node[CurrentStatus] = DELETE_ONLY
-    - DescriptorIsNotBeingDropped($prev)
+    - descriptorIsNotBeingDropped-23.1($prev)
     - joinTargetNode($prev, $prev-Target, $prev-Node)
     - joinTargetNode($next, $next-Target, $next-Node)
 - name: 'PrimaryIndex transitions to ABSENT uphold 2-version invariant: TRANSIENT_BACKFILL_ONLY->DELETE_ONLY'
@@ -545,7 +545,7 @@ deprules
     - $prev-Target[TargetStatus] = ABSENT
     - $prev-Node[CurrentStatus] = TRANSIENT_BACKFILL_ONLY
     - $next-Node[CurrentStatus] = DELETE_ONLY
-    - DescriptorIsNotBeingDropped($prev)
+    - descriptorIsNotBeingDropped-23.1($prev)
     - joinTargetNode($prev, $prev-Target, $prev-Node)
     - joinTargetNode($next, $next-Target, $next-Node)
 - name: 'PrimaryIndex transitions to ABSENT uphold 2-version invariant: TRANSIENT_DELETE_ONLY->DELETE_ONLY'
@@ -561,7 +561,7 @@ deprules
     - $prev-Target[TargetStatus] = ABSENT
     - $prev-Node[CurrentStatus] = TRANSIENT_DELETE_ONLY
     - $next-Node[CurrentStatus] = DELETE_ONLY
-    - DescriptorIsNotBeingDropped($prev)
+    - descriptorIsNotBeingDropped-23.1($prev)
     - joinTargetNode($prev, $prev-Target, $prev-Node)
     - joinTargetNode($next, $next-Target, $next-Node)
 - name: 'PrimaryIndex transitions to ABSENT uphold 2-version invariant: TRANSIENT_MERGED->WRITE_ONLY'
@@ -577,7 +577,7 @@ deprules
     - $prev-Target[TargetStatus] = ABSENT
     - $prev-Node[CurrentStatus] = TRANSIENT_MERGED
     - $next-Node[CurrentStatus] = WRITE_ONLY
-    - DescriptorIsNotBeingDropped($prev)
+    - descriptorIsNotBeingDropped-23.1($prev)
     - joinTargetNode($prev, $prev-Target, $prev-Node)
     - joinTargetNode($next, $next-Target, $next-Node)
 - name: 'PrimaryIndex transitions to ABSENT uphold 2-version invariant: TRANSIENT_MERGE_ONLY->WRITE_ONLY'
@@ -593,7 +593,7 @@ deprules
     - $prev-Target[TargetStatus] = ABSENT
     - $prev-Node[CurrentStatus] = TRANSIENT_MERGE_ONLY
     - $next-Node[CurrentStatus] = WRITE_ONLY
-    - DescriptorIsNotBeingDropped($prev)
+    - descriptorIsNotBeingDropped-23.1($prev)
     - joinTargetNode($prev, $prev-Target, $prev-Node)
     - joinTargetNode($next, $next-Target, $next-Node)
 - name: 'PrimaryIndex transitions to ABSENT uphold 2-version invariant: TRANSIENT_VALIDATED->VALIDATED'
@@ -609,7 +609,7 @@ deprules
     - $prev-Target[TargetStatus] = ABSENT
     - $prev-Node[CurrentStatus] = TRANSIENT_VALIDATED
     - $next-Node[CurrentStatus] = VALIDATED
-    - DescriptorIsNotBeingDropped($prev)
+    - descriptorIsNotBeingDropped-23.1($prev)
     - joinTargetNode($prev, $prev-Target, $prev-Node)
     - joinTargetNode($next, $next-Target, $next-Node)
 - name: 'PrimaryIndex transitions to ABSENT uphold 2-version invariant: TRANSIENT_WRITE_ONLY->WRITE_ONLY'
@@ -625,7 +625,7 @@ deprules
     - $prev-Target[TargetStatus] = ABSENT
     - $prev-Node[CurrentStatus] = TRANSIENT_WRITE_ONLY
     - $next-Node[CurrentStatus] = WRITE_ONLY
-    - DescriptorIsNotBeingDropped($prev)
+    - descriptorIsNotBeingDropped-23.1($prev)
     - joinTargetNode($prev, $prev-Target, $prev-Node)
     - joinTargetNode($next, $next-Target, $next-Node)
 - name: 'PrimaryIndex transitions to ABSENT uphold 2-version invariant: VALIDATED->WRITE_ONLY'
@@ -641,7 +641,7 @@ deprules
     - $prev-Target[TargetStatus] = ABSENT
     - $prev-Node[CurrentStatus] = VALIDATED
     - $next-Node[CurrentStatus] = WRITE_ONLY
-    - DescriptorIsNotBeingDropped($prev)
+    - descriptorIsNotBeingDropped-23.1($prev)
     - nodeNotExistsWithStatusIn_TRANSIENT_VALIDATED($prev-Target)
     - joinTargetNode($prev, $prev-Target, $prev-Node)
     - joinTargetNode($next, $next-Target, $next-Node)
@@ -658,7 +658,7 @@ deprules
     - $prev-Target[TargetStatus] = ABSENT
     - $prev-Node[CurrentStatus] = WRITE_ONLY
     - $next-Node[CurrentStatus] = DELETE_ONLY
-    - DescriptorIsNotBeingDropped($prev)
+    - descriptorIsNotBeingDropped-23.1($prev)
     - nodeNotExistsWithStatusIn_VALIDATED_TRANSIENT_WRITE_ONLY_MERGE_ONLY_TRANSIENT_MERGE_ONLY_MERGED_TRANSIENT_MERGED($prev-Target)
     - joinTargetNode($prev, $prev-Target, $prev-Node)
     - joinTargetNode($next, $next-Target, $next-Node)
@@ -675,7 +675,7 @@ deprules
     - $prev-Target[TargetStatus] = PUBLIC
     - $prev-Node[CurrentStatus] = ABSENT
     - $next-Node[CurrentStatus] = BACKFILL_ONLY
-    - DescriptorIsNotBeingDropped($prev)
+    - descriptorIsNotBeingDropped-23.1($prev)
     - joinTargetNode($prev, $prev-Target, $prev-Node)
     - joinTargetNode($next, $next-Target, $next-Node)
 - name: 'PrimaryIndex transitions to PUBLIC uphold 2-version invariant: BACKFILLED->DELETE_ONLY'
@@ -691,7 +691,7 @@ deprules
     - $prev-Target[TargetStatus] = PUBLIC
     - $prev-Node[CurrentStatus] = BACKFILLED
     - $next-Node[CurrentStatus] = DELETE_ONLY
-    - DescriptorIsNotBeingDropped($prev)
+    - descriptorIsNotBeingDropped-23.1($prev)
     - joinTargetNode($prev, $prev-Target, $prev-Node)
     - joinTargetNode($next, $next-Target, $next-Node)
 - name: 'PrimaryIndex transitions to PUBLIC uphold 2-version invariant: BACKFILL_ONLY->BACKFILLED'
@@ -707,7 +707,7 @@ deprules
     - $prev-Target[TargetStatus] = PUBLIC
     - $prev-Node[CurrentStatus] = BACKFILL_ONLY
     - $next-Node[CurrentStatus] = BACKFILLED
-    - DescriptorIsNotBeingDropped($prev)
+    - descriptorIsNotBeingDropped-23.1($prev)
     - joinTargetNode($prev, $prev-Target, $prev-Node)
     - joinTargetNode($next, $next-Target, $next-Node)
 - name: 'PrimaryIndex transitions to PUBLIC uphold 2-version invariant: DELETE_ONLY->MERGE_ONLY'
@@ -723,7 +723,7 @@ deprules
     - $prev-Target[TargetStatus] = PUBLIC
     - $prev-Node[CurrentStatus] = DELETE_ONLY
     - $next-Node[CurrentStatus] = MERGE_ONLY
-    - DescriptorIsNotBeingDropped($prev)
+    - descriptorIsNotBeingDropped-23.1($prev)
     - joinTargetNode($prev, $prev-Target, $prev-Node)
     - joinTargetNode($next, $next-Target, $next-Node)
 - name: 'PrimaryIndex transitions to PUBLIC uphold 2-version invariant: MERGED->WRITE_ONLY'
@@ -739,7 +739,7 @@ deprules
     - $prev-Target[TargetStatus] = PUBLIC
     - $prev-Node[CurrentStatus] = MERGED
     - $next-Node[CurrentStatus] = WRITE_ONLY
-    - DescriptorIsNotBeingDropped($prev)
+    - descriptorIsNotBeingDropped-23.1($prev)
     - joinTargetNode($prev, $prev-Target, $prev-Node)
     - joinTargetNode($next, $next-Target, $next-Node)
 - name: 'PrimaryIndex transitions to PUBLIC uphold 2-version invariant: MERGE_ONLY->MERGED'
@@ -755,7 +755,7 @@ deprules
     - $prev-Target[TargetStatus] = PUBLIC
     - $prev-Node[CurrentStatus] = MERGE_ONLY
     - $next-Node[CurrentStatus] = MERGED
-    - DescriptorIsNotBeingDropped($prev)
+    - descriptorIsNotBeingDropped-23.1($prev)
     - joinTargetNode($prev, $prev-Target, $prev-Node)
     - joinTargetNode($next, $next-Target, $next-Node)
 - name: 'PrimaryIndex transitions to PUBLIC uphold 2-version invariant: VALIDATED->PUBLIC'
@@ -771,7 +771,7 @@ deprules
     - $prev-Target[TargetStatus] = PUBLIC
     - $prev-Node[CurrentStatus] = VALIDATED
     - $next-Node[CurrentStatus] = PUBLIC
-    - DescriptorIsNotBeingDropped($prev)
+    - descriptorIsNotBeingDropped-23.1($prev)
     - joinTargetNode($prev, $prev-Target, $prev-Node)
     - joinTargetNode($next, $next-Target, $next-Node)
 - name: 'PrimaryIndex transitions to PUBLIC uphold 2-version invariant: WRITE_ONLY->VALIDATED'
@@ -787,7 +787,7 @@ deprules
     - $prev-Target[TargetStatus] = PUBLIC
     - $prev-Node[CurrentStatus] = WRITE_ONLY
     - $next-Node[CurrentStatus] = VALIDATED
-    - DescriptorIsNotBeingDropped($prev)
+    - descriptorIsNotBeingDropped-23.1($prev)
     - joinTargetNode($prev, $prev-Target, $prev-Node)
     - joinTargetNode($next, $next-Target, $next-Node)
 - name: 'PrimaryIndex transitions to TRANSIENT_ABSENT uphold 2-version invariant: ABSENT->BACKFILL_ONLY'
@@ -803,7 +803,7 @@ deprules
     - $prev-Target[TargetStatus] = TRANSIENT_ABSENT
     - $prev-Node[CurrentStatus] = ABSENT
     - $next-Node[CurrentStatus] = BACKFILL_ONLY
-    - DescriptorIsNotBeingDropped($prev)
+    - descriptorIsNotBeingDropped-23.1($prev)
     - joinTargetNode($prev, $prev-Target, $prev-Node)
     - joinTargetNode($next, $next-Target, $next-Node)
 - name: 'PrimaryIndex transitions to TRANSIENT_ABSENT uphold 2-version invariant: BACKFILLED->DELETE_ONLY'
@@ -819,7 +819,7 @@ deprules
     - $prev-Target[TargetStatus] = TRANSIENT_ABSENT
     - $prev-Node[CurrentStatus] = BACKFILLED
     - $next-Node[CurrentStatus] = DELETE_ONLY
-    - DescriptorIsNotBeingDropped($prev)
+    - descriptorIsNotBeingDropped-23.1($prev)
     - joinTargetNode($prev, $prev-Target, $prev-Node)
     - joinTargetNode($next, $next-Target, $next-Node)
 - name: 'PrimaryIndex transitions to TRANSIENT_ABSENT uphold 2-version invariant: BACKFILL_ONLY->BACKFILLED'
@@ -835,7 +835,7 @@ deprules
     - $prev-Target[TargetStatus] = TRANSIENT_ABSENT
     - $prev-Node[CurrentStatus] = BACKFILL_ONLY
     - $next-Node[CurrentStatus] = BACKFILLED
-    - DescriptorIsNotBeingDropped($prev)
+    - descriptorIsNotBeingDropped-23.1($prev)
     - joinTargetNode($prev, $prev-Target, $prev-Node)
     - joinTargetNode($next, $next-Target, $next-Node)
 - name: 'PrimaryIndex transitions to TRANSIENT_ABSENT uphold 2-version invariant: DELETE_ONLY->MERGE_ONLY'
@@ -851,7 +851,7 @@ deprules
     - $prev-Target[TargetStatus] = TRANSIENT_ABSENT
     - $prev-Node[CurrentStatus] = DELETE_ONLY
     - $next-Node[CurrentStatus] = MERGE_ONLY
-    - DescriptorIsNotBeingDropped($prev)
+    - descriptorIsNotBeingDropped-23.1($prev)
     - joinTargetNode($prev, $prev-Target, $prev-Node)
     - joinTargetNode($next, $next-Target, $next-Node)
 - name: 'PrimaryIndex transitions to TRANSIENT_ABSENT uphold 2-version invariant: MERGED->WRITE_ONLY'
@@ -867,7 +867,7 @@ deprules
     - $prev-Target[TargetStatus] = TRANSIENT_ABSENT
     - $prev-Node[CurrentStatus] = MERGED
     - $next-Node[CurrentStatus] = WRITE_ONLY
-    - DescriptorIsNotBeingDropped($prev)
+    - descriptorIsNotBeingDropped-23.1($prev)
     - joinTargetNode($prev, $prev-Target, $prev-Node)
     - joinTargetNode($next, $next-Target, $next-Node)
 - name: 'PrimaryIndex transitions to TRANSIENT_ABSENT uphold 2-version invariant: MERGE_ONLY->MERGED'
@@ -883,7 +883,7 @@ deprules
     - $prev-Target[TargetStatus] = TRANSIENT_ABSENT
     - $prev-Node[CurrentStatus] = MERGE_ONLY
     - $next-Node[CurrentStatus] = MERGED
-    - DescriptorIsNotBeingDropped($prev)
+    - descriptorIsNotBeingDropped-23.1($prev)
     - joinTargetNode($prev, $prev-Target, $prev-Node)
     - joinTargetNode($next, $next-Target, $next-Node)
 - name: 'PrimaryIndex transitions to TRANSIENT_ABSENT uphold 2-version invariant: PUBLIC->TRANSIENT_VALIDATED'
@@ -899,7 +899,7 @@ deprules
     - $prev-Target[TargetStatus] = TRANSIENT_ABSENT
     - $prev-Node[CurrentStatus] = PUBLIC
     - $next-Node[CurrentStatus] = TRANSIENT_VALIDATED
-    - DescriptorIsNotBeingDropped($prev)
+    - descriptorIsNotBeingDropped-23.1($prev)
     - joinTargetNode($prev, $prev-Target, $prev-Node)
     - joinTargetNode($next, $next-Target, $next-Node)
 - name: 'PrimaryIndex transitions to TRANSIENT_ABSENT uphold 2-version invariant: TRANSIENT_BACKFILLED->TRANSIENT_DELETE_ONLY'
@@ -915,7 +915,7 @@ deprules
     - $prev-Target[TargetStatus] = TRANSIENT_ABSENT
     - $prev-Node[CurrentStatus] = TRANSIENT_BACKFILLED
     - $next-Node[CurrentStatus] = TRANSIENT_DELETE_ONLY
-    - DescriptorIsNotBeingDropped($prev)
+    - descriptorIsNotBeingDropped-23.1($prev)
     - joinTargetNode($prev, $prev-Target, $prev-Node)
     - joinTargetNode($next, $next-Target, $next-Node)
 - name: 'PrimaryIndex transitions to TRANSIENT_ABSENT uphold 2-version invariant: TRANSIENT_BACKFILL_ONLY->TRANSIENT_DELETE_ONLY'
@@ -931,7 +931,7 @@ deprules
     - $prev-Target[TargetStatus] = TRANSIENT_ABSENT
     - $prev-Node[CurrentStatus] = TRANSIENT_BACKFILL_ONLY
     - $next-Node[CurrentStatus] = TRANSIENT_DELETE_ONLY
-    - DescriptorIsNotBeingDropped($prev)
+    - descriptorIsNotBeingDropped-23.1($prev)
     - joinTargetNode($prev, $prev-Target, $prev-Node)
     - joinTargetNode($next, $next-Target, $next-Node)
 - name: 'PrimaryIndex transitions to TRANSIENT_ABSENT uphold 2-version invariant: TRANSIENT_DELETE_ONLY->TRANSIENT_ABSENT'
@@ -947,7 +947,7 @@ deprules
     - $prev-Target[TargetStatus] = TRANSIENT_ABSENT
     - $prev-Node[CurrentStatus] = TRANSIENT_DELETE_ONLY
     - $next-Node[CurrentStatus] = TRANSIENT_ABSENT
-    - DescriptorIsNotBeingDropped($prev)
+    - descriptorIsNotBeingDropped-23.1($prev)
     - nodeNotExistsWithStatusIn_TRANSIENT_BACKFILLED_TRANSIENT_BACKFILL_ONLY($prev-Target)
     - joinTargetNode($prev, $prev-Target, $prev-Node)
     - joinTargetNode($next, $next-Target, $next-Node)
@@ -964,7 +964,7 @@ deprules
     - $prev-Target[TargetStatus] = TRANSIENT_ABSENT
     - $prev-Node[CurrentStatus] = TRANSIENT_MERGED
     - $next-Node[CurrentStatus] = TRANSIENT_WRITE_ONLY
-    - DescriptorIsNotBeingDropped($prev)
+    - descriptorIsNotBeingDropped-23.1($prev)
     - joinTargetNode($prev, $prev-Target, $prev-Node)
     - joinTargetNode($next, $next-Target, $next-Node)
 - name: 'PrimaryIndex transitions to TRANSIENT_ABSENT uphold 2-version invariant: TRANSIENT_MERGE_ONLY->TRANSIENT_WRITE_ONLY'
@@ -980,7 +980,7 @@ deprules
     - $prev-Target[TargetStatus] = TRANSIENT_ABSENT
     - $prev-Node[CurrentStatus] = TRANSIENT_MERGE_ONLY
     - $next-Node[CurrentStatus] = TRANSIENT_WRITE_ONLY
-    - DescriptorIsNotBeingDropped($prev)
+    - descriptorIsNotBeingDropped-23.1($prev)
     - joinTargetNode($prev, $prev-Target, $prev-Node)
     - joinTargetNode($next, $next-Target, $next-Node)
 - name: 'PrimaryIndex transitions to TRANSIENT_ABSENT uphold 2-version invariant: TRANSIENT_VALIDATED->TRANSIENT_WRITE_ONLY'
@@ -996,7 +996,7 @@ deprules
     - $prev-Target[TargetStatus] = TRANSIENT_ABSENT
     - $prev-Node[CurrentStatus] = TRANSIENT_VALIDATED
     - $next-Node[CurrentStatus] = TRANSIENT_WRITE_ONLY
-    - DescriptorIsNotBeingDropped($prev)
+    - descriptorIsNotBeingDropped-23.1($prev)
     - joinTargetNode($prev, $prev-Target, $prev-Node)
     - joinTargetNode($next, $next-Target, $next-Node)
 - name: 'PrimaryIndex transitions to TRANSIENT_ABSENT uphold 2-version invariant: TRANSIENT_WRITE_ONLY->TRANSIENT_DELETE_ONLY'
@@ -1012,7 +1012,7 @@ deprules
     - $prev-Target[TargetStatus] = TRANSIENT_ABSENT
     - $prev-Node[CurrentStatus] = TRANSIENT_WRITE_ONLY
     - $next-Node[CurrentStatus] = TRANSIENT_DELETE_ONLY
-    - DescriptorIsNotBeingDropped($prev)
+    - descriptorIsNotBeingDropped-23.1($prev)
     - nodeNotExistsWithStatusIn_TRANSIENT_VALIDATED_TRANSIENT_MERGE_ONLY_TRANSIENT_MERGED($prev-Target)
     - joinTargetNode($prev, $prev-Target, $prev-Node)
     - joinTargetNode($next, $next-Target, $next-Node)
@@ -1029,7 +1029,7 @@ deprules
     - $prev-Target[TargetStatus] = TRANSIENT_ABSENT
     - $prev-Node[CurrentStatus] = VALIDATED
     - $next-Node[CurrentStatus] = PUBLIC
-    - DescriptorIsNotBeingDropped($prev)
+    - descriptorIsNotBeingDropped-23.1($prev)
     - joinTargetNode($prev, $prev-Target, $prev-Node)
     - joinTargetNode($next, $next-Target, $next-Node)
 - name: 'PrimaryIndex transitions to TRANSIENT_ABSENT uphold 2-version invariant: WRITE_ONLY->VALIDATED'
@@ -1045,7 +1045,7 @@ deprules
     - $prev-Target[TargetStatus] = TRANSIENT_ABSENT
     - $prev-Node[CurrentStatus] = WRITE_ONLY
     - $next-Node[CurrentStatus] = VALIDATED
-    - DescriptorIsNotBeingDropped($prev)
+    - descriptorIsNotBeingDropped-23.1($prev)
     - joinTargetNode($prev, $prev-Target, $prev-Node)
     - joinTargetNode($next, $next-Target, $next-Node)
 - name: 'SecondaryIndex transitions to ABSENT uphold 2-version invariant: BACKFILLED->DELETE_ONLY'
@@ -1061,7 +1061,7 @@ deprules
     - $prev-Target[TargetStatus] = ABSENT
     - $prev-Node[CurrentStatus] = BACKFILLED
     - $next-Node[CurrentStatus] = DELETE_ONLY
-    - DescriptorIsNotBeingDropped($prev)
+    - descriptorIsNotBeingDropped-23.1($prev)
     - joinTargetNode($prev, $prev-Target, $prev-Node)
     - joinTargetNode($next, $next-Target, $next-Node)
 - name: 'SecondaryIndex transitions to ABSENT uphold 2-version invariant: BACKFILL_ONLY->DELETE_ONLY'
@@ -1077,7 +1077,7 @@ deprules
     - $prev-Target[TargetStatus] = ABSENT
     - $prev-Node[CurrentStatus] = BACKFILL_ONLY
     - $next-Node[CurrentStatus] = DELETE_ONLY
-    - DescriptorIsNotBeingDropped($prev)
+    - descriptorIsNotBeingDropped-23.1($prev)
     - joinTargetNode($prev, $prev-Target, $prev-Node)
     - joinTargetNode($next, $next-Target, $next-Node)
 - name: 'SecondaryIndex transitions to ABSENT uphold 2-version invariant: DELETE_ONLY->ABSENT'
@@ -1093,7 +1093,7 @@ deprules
     - $prev-Target[TargetStatus] = ABSENT
     - $prev-Node[CurrentStatus] = DELETE_ONLY
     - $next-Node[CurrentStatus] = ABSENT
-    - DescriptorIsNotBeingDropped($prev)
+    - descriptorIsNotBeingDropped-23.1($prev)
     - nodeNotExistsWithStatusIn_BACKFILLED_BACKFILL_ONLY($prev-Target)
     - joinTargetNode($prev, $prev-Target, $prev-Node)
     - joinTargetNode($next, $next-Target, $next-Node)
@@ -1110,7 +1110,7 @@ deprules
     - $prev-Target[TargetStatus] = ABSENT
     - $prev-Node[CurrentStatus] = MERGED
     - $next-Node[CurrentStatus] = WRITE_ONLY
-    - DescriptorIsNotBeingDropped($prev)
+    - descriptorIsNotBeingDropped-23.1($prev)
     - joinTargetNode($prev, $prev-Target, $prev-Node)
     - joinTargetNode($next, $next-Target, $next-Node)
 - name: 'SecondaryIndex transitions to ABSENT uphold 2-version invariant: MERGE_ONLY->WRITE_ONLY'
@@ -1126,7 +1126,7 @@ deprules
     - $prev-Target[TargetStatus] = ABSENT
     - $prev-Node[CurrentStatus] = MERGE_ONLY
     - $next-Node[CurrentStatus] = WRITE_ONLY
-    - DescriptorIsNotBeingDropped($prev)
+    - descriptorIsNotBeingDropped-23.1($prev)
     - joinTargetNode($prev, $prev-Target, $prev-Node)
     - joinTargetNode($next, $next-Target, $next-Node)
 - name: 'SecondaryIndex transitions to ABSENT uphold 2-version invariant: PUBLIC->VALIDATED'
@@ -1142,7 +1142,7 @@ deprules
     - $prev-Target[TargetStatus] = ABSENT
     - $prev-Node[CurrentStatus] = PUBLIC
     - $next-Node[CurrentStatus] = VALIDATED
-    - DescriptorIsNotBeingDropped($prev)
+    - descriptorIsNotBeingDropped-23.1($prev)
     - joinTargetNode($prev, $prev-Target, $prev-Node)
     - joinTargetNode($next, $next-Target, $next-Node)
 - name: 'SecondaryIndex transitions to ABSENT uphold 2-version invariant: VALIDATED->WRITE_ONLY'
@@ -1158,7 +1158,7 @@ deprules
     - $prev-Target[TargetStatus] = ABSENT
     - $prev-Node[CurrentStatus] = VALIDATED
     - $next-Node[CurrentStatus] = WRITE_ONLY
-    - DescriptorIsNotBeingDropped($prev)
+    - descriptorIsNotBeingDropped-23.1($prev)
     - joinTargetNode($prev, $prev-Target, $prev-Node)
     - joinTargetNode($next, $next-Target, $next-Node)
 - name: 'SecondaryIndex transitions to ABSENT uphold 2-version invariant: WRITE_ONLY->DELETE_ONLY'
@@ -1174,7 +1174,7 @@ deprules
     - $prev-Target[TargetStatus] = ABSENT
     - $prev-Node[CurrentStatus] = WRITE_ONLY
     - $next-Node[CurrentStatus] = DELETE_ONLY
-    - DescriptorIsNotBeingDropped($prev)
+    - descriptorIsNotBeingDropped-23.1($prev)
     - nodeNotExistsWithStatusIn_VALIDATED_MERGE_ONLY_MERGED($prev-Target)
     - joinTargetNode($prev, $prev-Target, $prev-Node)
     - joinTargetNode($next, $next-Target, $next-Node)
@@ -1191,7 +1191,7 @@ deprules
     - $prev-Target[TargetStatus] = PUBLIC
     - $prev-Node[CurrentStatus] = ABSENT
     - $next-Node[CurrentStatus] = BACKFILL_ONLY
-    - DescriptorIsNotBeingDropped($prev)
+    - descriptorIsNotBeingDropped-23.1($prev)
     - joinTargetNode($prev, $prev-Target, $prev-Node)
     - joinTargetNode($next, $next-Target, $next-Node)
 - name: 'SecondaryIndex transitions to PUBLIC uphold 2-version invariant: BACKFILLED->DELETE_ONLY'
@@ -1207,7 +1207,7 @@ deprules
     - $prev-Target[TargetStatus] = PUBLIC
     - $prev-Node[CurrentStatus] = BACKFILLED
     - $next-Node[CurrentStatus] = DELETE_ONLY
-    - DescriptorIsNotBeingDropped($prev)
+    - descriptorIsNotBeingDropped-23.1($prev)
     - joinTargetNode($prev, $prev-Target, $prev-Node)
     - joinTargetNode($next, $next-Target, $next-Node)
 - name: 'SecondaryIndex transitions to PUBLIC uphold 2-version invariant: BACKFILL_ONLY->BACKFILLED'
@@ -1223,7 +1223,7 @@ deprules
     - $prev-Target[TargetStatus] = PUBLIC
     - $prev-Node[CurrentStatus] = BACKFILL_ONLY
     - $next-Node[CurrentStatus] = BACKFILLED
-    - DescriptorIsNotBeingDropped($prev)
+    - descriptorIsNotBeingDropped-23.1($prev)
     - joinTargetNode($prev, $prev-Target, $prev-Node)
     - joinTargetNode($next, $next-Target, $next-Node)
 - name: 'SecondaryIndex transitions to PUBLIC uphold 2-version invariant: DELETE_ONLY->MERGE_ONLY'
@@ -1239,7 +1239,7 @@ deprules
     - $prev-Target[TargetStatus] = PUBLIC
     - $prev-Node[CurrentStatus] = DELETE_ONLY
     - $next-Node[CurrentStatus] = MERGE_ONLY
-    - DescriptorIsNotBeingDropped($prev)
+    - descriptorIsNotBeingDropped-23.1($prev)
     - joinTargetNode($prev, $prev-Target, $prev-Node)
     - joinTargetNode($next, $next-Target, $next-Node)
 - name: 'SecondaryIndex transitions to PUBLIC uphold 2-version invariant: MERGED->WRITE_ONLY'
@@ -1255,7 +1255,7 @@ deprules
     - $prev-Target[TargetStatus] = PUBLIC
     - $prev-Node[CurrentStatus] = MERGED
     - $next-Node[CurrentStatus] = WRITE_ONLY
-    - DescriptorIsNotBeingDropped($prev)
+    - descriptorIsNotBeingDropped-23.1($prev)
     - joinTargetNode($prev, $prev-Target, $prev-Node)
     - joinTargetNode($next, $next-Target, $next-Node)
 - name: 'SecondaryIndex transitions to PUBLIC uphold 2-version invariant: MERGE_ONLY->MERGED'
@@ -1271,7 +1271,7 @@ deprules
     - $prev-Target[TargetStatus] = PUBLIC
     - $prev-Node[CurrentStatus] = MERGE_ONLY
     - $next-Node[CurrentStatus] = MERGED
-    - DescriptorIsNotBeingDropped($prev)
+    - descriptorIsNotBeingDropped-23.1($prev)
     - joinTargetNode($prev, $prev-Target, $prev-Node)
     - joinTargetNode($next, $next-Target, $next-Node)
 - name: 'SecondaryIndex transitions to PUBLIC uphold 2-version invariant: VALIDATED->PUBLIC'
@@ -1287,7 +1287,7 @@ deprules
     - $prev-Target[TargetStatus] = PUBLIC
     - $prev-Node[CurrentStatus] = VALIDATED
     - $next-Node[CurrentStatus] = PUBLIC
-    - DescriptorIsNotBeingDropped($prev)
+    - descriptorIsNotBeingDropped-23.1($prev)
     - joinTargetNode($prev, $prev-Target, $prev-Node)
     - joinTargetNode($next, $next-Target, $next-Node)
 - name: 'SecondaryIndex transitions to PUBLIC uphold 2-version invariant: WRITE_ONLY->VALIDATED'
@@ -1303,7 +1303,7 @@ deprules
     - $prev-Target[TargetStatus] = PUBLIC
     - $prev-Node[CurrentStatus] = WRITE_ONLY
     - $next-Node[CurrentStatus] = VALIDATED
-    - DescriptorIsNotBeingDropped($prev)
+    - descriptorIsNotBeingDropped-23.1($prev)
     - joinTargetNode($prev, $prev-Target, $prev-Node)
     - joinTargetNode($next, $next-Target, $next-Node)
 - name: 'TemporaryIndex transitions to ABSENT uphold 2-version invariant: DELETE_ONLY->ABSENT'
@@ -1319,7 +1319,7 @@ deprules
     - $prev-Target[TargetStatus] = ABSENT
     - $prev-Node[CurrentStatus] = DELETE_ONLY
     - $next-Node[CurrentStatus] = ABSENT
-    - DescriptorIsNotBeingDropped($prev)
+    - descriptorIsNotBeingDropped-23.1($prev)
     - nodeNotExistsWithStatusIn_TRANSIENT_DELETE_ONLY($prev-Target)
     - joinTargetNode($prev, $prev-Target, $prev-Node)
     - joinTargetNode($next, $next-Target, $next-Node)
@@ -1336,7 +1336,7 @@ deprules
     - $prev-Target[TargetStatus] = ABSENT
     - $prev-Node[CurrentStatus] = TRANSIENT_ABSENT
     - $next-Node[CurrentStatus] = ABSENT
-    - DescriptorIsNotBeingDropped($prev)
+    - descriptorIsNotBeingDropped-23.1($prev)
     - joinTargetNode($prev, $prev-Target, $prev-Node)
     - joinTargetNode($next, $next-Target, $next-Node)
 - name: 'TemporaryIndex transitions to ABSENT uphold 2-version invariant: TRANSIENT_DELETE_ONLY->DELETE_ONLY'
@@ -1352,7 +1352,7 @@ deprules
     - $prev-Target[TargetStatus] = ABSENT
     - $prev-Node[CurrentStatus] = TRANSIENT_DELETE_ONLY
     - $next-Node[CurrentStatus] = DELETE_ONLY
-    - DescriptorIsNotBeingDropped($prev)
+    - descriptorIsNotBeingDropped-23.1($prev)
     - joinTargetNode($prev, $prev-Target, $prev-Node)
     - joinTargetNode($next, $next-Target, $next-Node)
 - name: 'TemporaryIndex transitions to ABSENT uphold 2-version invariant: WRITE_ONLY->DELETE_ONLY'
@@ -1368,7 +1368,7 @@ deprules
     - $prev-Target[TargetStatus] = ABSENT
     - $prev-Node[CurrentStatus] = WRITE_ONLY
     - $next-Node[CurrentStatus] = DELETE_ONLY
-    - DescriptorIsNotBeingDropped($prev)
+    - descriptorIsNotBeingDropped-23.1($prev)
     - joinTargetNode($prev, $prev-Target, $prev-Node)
     - joinTargetNode($next, $next-Target, $next-Node)
 - name: 'TemporaryIndex transitions to TRANSIENT_ABSENT uphold 2-version invariant: ABSENT->DELETE_ONLY'
@@ -1384,7 +1384,7 @@ deprules
     - $prev-Target[TargetStatus] = TRANSIENT_ABSENT
     - $prev-Node[CurrentStatus] = ABSENT
     - $next-Node[CurrentStatus] = DELETE_ONLY
-    - DescriptorIsNotBeingDropped($prev)
+    - descriptorIsNotBeingDropped-23.1($prev)
     - joinTargetNode($prev, $prev-Target, $prev-Node)
     - joinTargetNode($next, $next-Target, $next-Node)
 - name: 'TemporaryIndex transitions to TRANSIENT_ABSENT uphold 2-version invariant: DELETE_ONLY->WRITE_ONLY'
@@ -1400,7 +1400,7 @@ deprules
     - $prev-Target[TargetStatus] = TRANSIENT_ABSENT
     - $prev-Node[CurrentStatus] = DELETE_ONLY
     - $next-Node[CurrentStatus] = WRITE_ONLY
-    - DescriptorIsNotBeingDropped($prev)
+    - descriptorIsNotBeingDropped-23.1($prev)
     - joinTargetNode($prev, $prev-Target, $prev-Node)
     - joinTargetNode($next, $next-Target, $next-Node)
 - name: 'TemporaryIndex transitions to TRANSIENT_ABSENT uphold 2-version invariant: TRANSIENT_DELETE_ONLY->TRANSIENT_ABSENT'
@@ -1416,7 +1416,7 @@ deprules
     - $prev-Target[TargetStatus] = TRANSIENT_ABSENT
     - $prev-Node[CurrentStatus] = TRANSIENT_DELETE_ONLY
     - $next-Node[CurrentStatus] = TRANSIENT_ABSENT
-    - DescriptorIsNotBeingDropped($prev)
+    - descriptorIsNotBeingDropped-23.1($prev)
     - joinTargetNode($prev, $prev-Target, $prev-Node)
     - joinTargetNode($next, $next-Target, $next-Node)
 - name: 'TemporaryIndex transitions to TRANSIENT_ABSENT uphold 2-version invariant: WRITE_ONLY->TRANSIENT_DELETE_ONLY'
@@ -1432,7 +1432,7 @@ deprules
     - $prev-Target[TargetStatus] = TRANSIENT_ABSENT
     - $prev-Node[CurrentStatus] = WRITE_ONLY
     - $next-Node[CurrentStatus] = TRANSIENT_DELETE_ONLY
-    - DescriptorIsNotBeingDropped($prev)
+    - descriptorIsNotBeingDropped-23.1($prev)
     - joinTargetNode($prev, $prev-Target, $prev-Node)
     - joinTargetNode($next, $next-Target, $next-Node)
 - name: 'UniqueWithoutIndexConstraint transitions to ABSENT uphold 2-version invariant: PUBLIC->VALIDATED'
@@ -1448,7 +1448,7 @@ deprules
     - $prev-Target[TargetStatus] = ABSENT
     - $prev-Node[CurrentStatus] = PUBLIC
     - $next-Node[CurrentStatus] = VALIDATED
-    - DescriptorIsNotBeingDropped($prev)
+    - descriptorIsNotBeingDropped-23.1($prev)
     - joinTargetNode($prev, $prev-Target, $prev-Node)
     - joinTargetNode($next, $next-Target, $next-Node)
 - name: 'UniqueWithoutIndexConstraint transitions to ABSENT uphold 2-version invariant: VALIDATED->ABSENT'
@@ -1464,7 +1464,7 @@ deprules
     - $prev-Target[TargetStatus] = ABSENT
     - $prev-Node[CurrentStatus] = VALIDATED
     - $next-Node[CurrentStatus] = ABSENT
-    - DescriptorIsNotBeingDropped($prev)
+    - descriptorIsNotBeingDropped-23.1($prev)
     - nodeNotExistsWithStatusIn_WRITE_ONLY($prev-Target)
     - joinTargetNode($prev, $prev-Target, $prev-Node)
     - joinTargetNode($next, $next-Target, $next-Node)
@@ -1481,7 +1481,7 @@ deprules
     - $prev-Target[TargetStatus] = ABSENT
     - $prev-Node[CurrentStatus] = WRITE_ONLY
     - $next-Node[CurrentStatus] = VALIDATED
-    - DescriptorIsNotBeingDropped($prev)
+    - descriptorIsNotBeingDropped-23.1($prev)
     - joinTargetNode($prev, $prev-Target, $prev-Node)
     - joinTargetNode($next, $next-Target, $next-Node)
 - name: 'UniqueWithoutIndexConstraint transitions to PUBLIC uphold 2-version invariant: ABSENT->WRITE_ONLY'
@@ -1497,7 +1497,7 @@ deprules
     - $prev-Target[TargetStatus] = PUBLIC
     - $prev-Node[CurrentStatus] = ABSENT
     - $next-Node[CurrentStatus] = WRITE_ONLY
-    - DescriptorIsNotBeingDropped($prev)
+    - descriptorIsNotBeingDropped-23.1($prev)
     - joinTargetNode($prev, $prev-Target, $prev-Node)
     - joinTargetNode($next, $next-Target, $next-Node)
 - name: 'UniqueWithoutIndexConstraint transitions to PUBLIC uphold 2-version invariant: VALIDATED->PUBLIC'
@@ -1513,7 +1513,7 @@ deprules
     - $prev-Target[TargetStatus] = PUBLIC
     - $prev-Node[CurrentStatus] = VALIDATED
     - $next-Node[CurrentStatus] = PUBLIC
-    - DescriptorIsNotBeingDropped($prev)
+    - descriptorIsNotBeingDropped-23.1($prev)
     - joinTargetNode($prev, $prev-Target, $prev-Node)
     - joinTargetNode($next, $next-Target, $next-Node)
 - name: 'UniqueWithoutIndexConstraint transitions to PUBLIC uphold 2-version invariant: WRITE_ONLY->VALIDATED'
@@ -1529,7 +1529,7 @@ deprules
     - $prev-Target[TargetStatus] = PUBLIC
     - $prev-Node[CurrentStatus] = WRITE_ONLY
     - $next-Node[CurrentStatus] = VALIDATED
-    - DescriptorIsNotBeingDropped($prev)
+    - descriptorIsNotBeingDropped-23.1($prev)
     - joinTargetNode($prev, $prev-Target, $prev-Node)
     - joinTargetNode($next, $next-Target, $next-Node)
 - name: column dependents exist before column becomes public
@@ -1686,7 +1686,7 @@ deprules
   to: column-Node
   query:
     - $column-type[Type] = '*scpb.ColumnType'
-    - DescriptorIsNotBeingDropped($column-type)
+    - descriptorIsNotBeingDropped-23.1($column-type)
     - $column[Type] = '*scpb.Column'
     - joinOnColumnID($column-type, $column, $table-id, $col-id)
     - toAbsent($column-type-Target, $column-Target)
@@ -2378,7 +2378,7 @@ deprules
     - $column[Type] = '*scpb.Column'
     - ColumnInIndex($index-column, $index, $table-id, $column-id, $index-id)
     - joinOnColumnID($index-column, $column, $table-id, $column-id)
-    - DescriptorIsNotBeingDropped($index-column)
+    - descriptorIsNotBeingDropped-23.1($index-column)
     - toAbsent($index-Target, $column-Target)
     - $index-Node[CurrentStatus] = ABSENT
     - $column-Node[CurrentStatus] = ABSENT
@@ -2393,7 +2393,7 @@ deprules
     - $column[Type] = '*scpb.Column'
     - ColumnInIndex($index-column, $index, $table-id, $column-id, $index-id)
     - joinOnColumnID($index-column, $column, $table-id, $column-id)
-    - DescriptorIsNotBeingDropped($index-column)
+    - descriptorIsNotBeingDropped-23.1($index-column)
     - transient($index-Target, $column-Target)
     - $index-Node[CurrentStatus] = TRANSIENT_ABSENT
     - $column-Node[CurrentStatus] = TRANSIENT_ABSENT
@@ -2408,7 +2408,7 @@ deprules
     - $column[Type] = '*scpb.Column'
     - ColumnInIndex($index-column, $index, $table-id, $column-id, $index-id)
     - joinOnColumnID($index-column, $column, $table-id, $column-id)
-    - DescriptorIsNotBeingDropped($index-column)
+    - descriptorIsNotBeingDropped-23.1($index-column)
     - $index-Target[TargetStatus] = TRANSIENT_ABSENT
     - $index-Node[CurrentStatus] = TRANSIENT_ABSENT
     - $column-Target[TargetStatus] = ABSENT
@@ -2424,7 +2424,7 @@ deprules
     - $column[Type] = '*scpb.Column'
     - ColumnInIndex($index-column, $index, $table-id, $column-id, $index-id)
     - joinOnColumnID($index-column, $column, $table-id, $column-id)
-    - DescriptorIsNotBeingDropped($index-column)
+    - descriptorIsNotBeingDropped-23.1($index-column)
     - $index-Target[TargetStatus] = ABSENT
     - $index-Node[CurrentStatus] = ABSENT
     - $column-Target[TargetStatus] = TRANSIENT_ABSENT
@@ -2457,7 +2457,7 @@ deprules
   to: index-Node
   query:
     - $partial-predicate[Type] = '*scpb.SecondaryIndexPartial'
-    - DescriptorIsNotBeingDropped($partial-predicate)
+    - descriptorIsNotBeingDropped-23.1($partial-predicate)
     - $index[Type] = '*scpb.SecondaryIndex'
     - joinOnIndexID($partial-predicate, $index, $table-id, $index-id)
     - toAbsent($partial-predicate-Target, $index-Target)
@@ -2471,7 +2471,7 @@ deprules
   to: index-Node
   query:
     - $partial-predicate[Type] = '*scpb.SecondaryIndexPartial'
-    - DescriptorIsNotBeingDropped($partial-predicate)
+    - descriptorIsNotBeingDropped-23.1($partial-predicate)
     - $index[Type] = '*scpb.SecondaryIndex'
     - joinOnIndexID($partial-predicate, $index, $table-id, $index-id)
     - transient($partial-predicate-Target, $index-Target)
@@ -2485,7 +2485,7 @@ deprules
   to: index-Node
   query:
     - $partial-predicate[Type] = '*scpb.SecondaryIndexPartial'
-    - DescriptorIsNotBeingDropped($partial-predicate)
+    - descriptorIsNotBeingDropped-23.1($partial-predicate)
     - $index[Type] = '*scpb.SecondaryIndex'
     - joinOnIndexID($partial-predicate, $index, $table-id, $index-id)
     - $partial-predicate-Target[TargetStatus] = TRANSIENT_ABSENT
@@ -2500,7 +2500,7 @@ deprules
   to: index-Node
   query:
     - $partial-predicate[Type] = '*scpb.SecondaryIndexPartial'
-    - DescriptorIsNotBeingDropped($partial-predicate)
+    - descriptorIsNotBeingDropped-23.1($partial-predicate)
     - $index[Type] = '*scpb.SecondaryIndex'
     - joinOnIndexID($partial-predicate, $index, $table-id, $index-id)
     - $partial-predicate-Target[TargetStatus] = ABSENT
@@ -2830,7 +2830,7 @@ deprules
     - toAbsent($index-Target, $column-Target)
     - $index-Node[CurrentStatus] = VALIDATED
     - $column-Node[CurrentStatus] = WRITE_ONLY
-    - DescriptorIsNotBeingDropped($index-column)
+    - descriptorIsNotBeingDropped-23.1($index-column)
     - isIndexKeyColumnKey(*scpb.IndexColumn)($index-column)
     - joinTargetNode($index, $index-Target, $index-Node)
     - joinTargetNode($column, $column-Target, $column-Node)

--- a/pkg/sql/schemachanger/scplan/internal/rules/current/testdata/oprules
+++ b/pkg/sql/schemachanger/scplan/internal/rules/current/testdata/oprules
@@ -9,15 +9,15 @@ ColumnInIndex($index-column, $index, $table-id, $column-id, $index-id):
 ColumnInSwappedInPrimaryIndex($index-column, $index, $table-id, $column-id, $index-id):
     - ColumnInIndex($index-column, $index, $table-id, $column-id, $index-id)
     - sourceIndexIsSet($index)
-DescriptorIsNotBeingDropped($element):
+ToPublicOrTransient($target1, $target2):
+    - $target1[TargetStatus] IN [PUBLIC, TRANSIENT_ABSENT]
+    - $target2[TargetStatus] IN [PUBLIC, TRANSIENT_ABSENT]
+descriptorIsNotBeingDropped-23.1($element):
     not-join:
         - $descriptor[Type] IN ['*scpb.Database', '*scpb.Schema', '*scpb.View', '*scpb.Sequence', '*scpb.Table', '*scpb.EnumType', '*scpb.AliasType', '*scpb.CompositeType']
         - joinTarget($descriptor, $descriptor-Target)
         - joinOnDescID($descriptor, $element, $id)
         - $descriptor-Target[TargetStatus] = ABSENT
-ToPublicOrTransient($target1, $target2):
-    - $target1[TargetStatus] IN [PUBLIC, TRANSIENT_ABSENT]
-    - $target2[TargetStatus] IN [PUBLIC, TRANSIENT_ABSENT]
 joinOnColumnID($a, $b, $desc-id, $col-id):
     - joinOnDescID($a, $b, $desc-id)
     - $a[ColumnID] = $col-id

--- a/pkg/sql/schemachanger/scplan/internal/rules/helpers.go
+++ b/pkg/sql/schemachanger/scplan/internal/rules/helpers.go
@@ -85,7 +85,7 @@ func StatusesTransient(
 }
 
 func JoinOnDescID(a, b NodeVars, descriptorIDVar rel.Var) rel.Clause {
-	return joinOnDescIDUntyped(a.El, b.El, descriptorIDVar)
+	return JoinOnDescIDUntyped(a.El, b.El, descriptorIDVar)
 }
 
 func JoinReferencedDescID(a, b NodeVars, descriptorIDVar rel.Var) rel.Clause {
@@ -156,7 +156,7 @@ var (
 				referenced.AttrEqVar(screl.DescID, id),
 			}
 		})
-	joinOnDescIDUntyped = screl.Schema.Def3(
+	JoinOnDescIDUntyped = screl.Schema.Def3(
 		"joinOnDescID", "a", "b", "id", func(
 			a, b, id rel.Var,
 		) rel.Clauses {
@@ -169,7 +169,7 @@ var (
 			a, b, descID, indexID rel.Var,
 		) rel.Clauses {
 			return rel.Clauses{
-				joinOnDescIDUntyped(a, b, descID),
+				JoinOnDescIDUntyped(a, b, descID),
 				indexID.Entities(screl.IndexID, a, b),
 			}
 		},
@@ -179,7 +179,7 @@ var (
 			a, b, descID, colID rel.Var,
 		) rel.Clauses {
 			return rel.Clauses{
-				joinOnDescIDUntyped(a, b, descID),
+				JoinOnDescIDUntyped(a, b, descID),
 				colID.Entities(screl.ColumnID, a, b),
 			}
 		},
@@ -189,7 +189,7 @@ var (
 			a, b, descID, constraintID rel.Var,
 		) rel.Clauses {
 			return rel.Clauses{
-				joinOnDescIDUntyped(a, b, descID),
+				JoinOnDescIDUntyped(a, b, descID),
 				constraintID.Entities(screl.ConstraintID, a, b),
 			}
 		},
@@ -244,7 +244,7 @@ func ForEachElement(fn func(element scpb.Element) error) error {
 }
 
 func ForEachElementInActiveVersion(
-	fn func(element scpb.Element) error, version clusterversion.ClusterVersion,
+	version clusterversion.ClusterVersion, fn func(element scpb.Element) error,
 ) error {
 	var ep scpb.ElementProto
 	vep := reflect.ValueOf(ep)
@@ -257,179 +257,6 @@ func ForEachElementInActiveVersion(
 		}
 	}
 	return nil
-}
-
-// IsDescriptor returns true for a descriptor-element, i.e. an element which
-// owns its corresponding descriptor.
-func IsDescriptor(e scpb.Element) bool {
-	switch e.(type) {
-	case *scpb.Database, *scpb.Schema, *scpb.Table, *scpb.View, *scpb.Sequence,
-		*scpb.AliasType, *scpb.EnumType, *scpb.CompositeType:
-		return true
-	}
-	return false
-}
-
-func IsSubjectTo2VersionInvariant(e scpb.Element) bool {
-	// TODO(ajwerner): This should include constraints and enum values but it
-	// currently does not because we do not support dropping them unless we're
-	// dropping the descriptor and we do not support adding them.
-	return IsIndex(e) || IsColumn(e) || IsSupportedNonIndexBackedConstraint(e)
-}
-
-func IsIndex(e scpb.Element) bool {
-	switch e.(type) {
-	case *scpb.PrimaryIndex, *scpb.SecondaryIndex, *scpb.TemporaryIndex:
-		return true
-	}
-	return false
-}
-
-func IsColumn(e scpb.Element) bool {
-	_, ok := e.(*scpb.Column)
-	return ok
-}
-
-func IsSimpleDependent(e scpb.Element) bool {
-	return !IsDescriptor(e) && !IsSubjectTo2VersionInvariant(e) && !IsData(e)
-}
-
-func getTypeT(element scpb.Element) (*scpb.TypeT, error) {
-	switch e := element.(type) {
-	case *scpb.ColumnType:
-		if e == nil {
-			return nil, nil
-		}
-		return &e.TypeT, nil
-	case *scpb.AliasType:
-		if e == nil {
-			return nil, nil
-		}
-		return &e.TypeT, nil
-	}
-	return nil, errors.AssertionFailedf("element %T does not have an embedded scpb.TypeT", element)
-}
-
-func IsWithTypeT(element scpb.Element) bool {
-	_, err := getTypeT(element)
-	return err == nil
-}
-
-func getExpression(element scpb.Element) (*scpb.Expression, error) {
-	switch e := element.(type) {
-	case *scpb.ColumnType:
-		if e == nil {
-			return nil, nil
-		}
-		return e.ComputeExpr, nil
-	case *scpb.ColumnDefaultExpression:
-		if e == nil {
-			return nil, nil
-		}
-		return &e.Expression, nil
-	case *scpb.ColumnOnUpdateExpression:
-		if e == nil {
-			return nil, nil
-		}
-		return &e.Expression, nil
-	case *scpb.SecondaryIndexPartial:
-		if e == nil {
-			return nil, nil
-		}
-		return &e.Expression, nil
-	case *scpb.CheckConstraint:
-		if e == nil {
-			return nil, nil
-		}
-		return &e.Expression, nil
-	}
-	return nil, errors.AssertionFailedf("element %T does not have an embedded scpb.Expression", element)
-}
-
-func IsWithExpression(element scpb.Element) bool {
-	_, err := getExpression(element)
-	return err == nil
-}
-
-func IsTypeDescriptor(element scpb.Element) bool {
-	switch element.(type) {
-	case *scpb.EnumType, *scpb.AliasType, *scpb.CompositeType:
-		return true
-	default:
-		return false
-	}
-}
-
-func IsColumnDependent(e scpb.Element) bool {
-	switch e.(type) {
-	case *scpb.ColumnType:
-		return true
-	case *scpb.ColumnName, *scpb.ColumnComment, *scpb.IndexColumn:
-		return true
-	}
-	return IsColumnTypeDependent(e)
-}
-
-func IsColumnTypeDependent(e scpb.Element) bool {
-	switch e.(type) {
-	case *scpb.SequenceOwner, *scpb.ColumnDefaultExpression, *scpb.ColumnOnUpdateExpression:
-		return true
-	}
-	return false
-}
-
-func IsIndexDependent(e scpb.Element) bool {
-	switch e.(type) {
-	case *scpb.IndexName, *scpb.IndexComment, *scpb.IndexColumn:
-		return true
-	case *scpb.IndexPartitioning, *scpb.SecondaryIndexPartial:
-		return true
-	}
-	return false
-}
-
-// IsSupportedNonIndexBackedConstraint a non-index-backed constraint is one of {Check, FK, UniqueWithoutIndex}. We only
-// support Check for now.
-// TODO (xiang): Expand this predicate to include other non-index-backed constraints
-// when we properly support adding/dropping them in the new schema changer.
-func IsSupportedNonIndexBackedConstraint(e scpb.Element) bool {
-	switch e.(type) {
-	case *scpb.CheckConstraint, *scpb.ForeignKeyConstraint, *scpb.UniqueWithoutIndexConstraint:
-		return true
-	}
-	return false
-}
-
-func IsConstraint(e scpb.Element) bool {
-	switch e.(type) {
-	case *scpb.PrimaryIndex, *scpb.SecondaryIndex, *scpb.TemporaryIndex:
-		return true
-	case *scpb.CheckConstraint, *scpb.UniqueWithoutIndexConstraint, *scpb.ForeignKeyConstraint:
-		return true
-	}
-	return false
-}
-
-func IsConstraintDependent(e scpb.Element) bool {
-	switch e.(type) {
-	case *scpb.ConstraintWithoutIndexName:
-		return true
-	case *scpb.ConstraintComment:
-		return true
-	}
-	return false
-}
-
-func IsData(e scpb.Element) bool {
-	switch e.(type) {
-	case *scpb.DatabaseData:
-		return true
-	case *scpb.TableData:
-		return true
-	case *scpb.IndexData:
-		return true
-	}
-	return false
 }
 
 type elementTypePredicate = func(e scpb.Element) bool
@@ -506,23 +333,6 @@ func RegisterDepRuleForDrop(
 		)
 	})
 }
-
-// descriptorIsNotBeingDropped creates a clause which leads to the outer clause
-// failing to unify if the passed element is part of a descriptor and
-// that descriptor is being dropped.
-var descriptorIsNotBeingDropped = screl.Schema.DefNotJoin1(
-	"DescriptorIsNotBeingDropped", "element", func(
-		element rel.Var,
-	) rel.Clauses {
-		descriptor := MkNodeVars("descriptor")
-		return rel.Clauses{
-			descriptor.TypeFilter(IsDescriptor),
-			descriptor.JoinTarget(),
-			joinOnDescIDUntyped(descriptor.El, element, "id"),
-			descriptor.TargetStatus(scpb.ToAbsent),
-		}
-	},
-)
 
 // notJoinOnNodeWithStatusIn is a cache to memoize getNotJoinOnNodeWithStatusIn.
 var notJoinOnNodeWithStatusIn = map[string]rel.Rule1{}

--- a/pkg/sql/schemachanger/scplan/internal/rules/release_22_2/BUILD.bazel
+++ b/pkg/sql/schemachanger/scplan/internal/rules/release_22_2/BUILD.bazel
@@ -15,6 +15,7 @@ go_library(
         "dep_drop_object.go",
         "dep_swap_index.go",
         "dep_two_version.go",
+        "helpers.go",
         "op_drop.go",
         "op_index_and_column.go",
         "registry.go",
@@ -23,12 +24,14 @@ go_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scplan/internal/rules/release_22_2",
     visibility = ["//pkg/sql/schemachanger/scplan:__subpackages__"],
     deps = [
+        "//pkg/clusterversion",
         "//pkg/sql/schemachanger/rel",
         "//pkg/sql/schemachanger/scpb",
         "//pkg/sql/schemachanger/scplan/internal/opgen",
         "//pkg/sql/schemachanger/scplan/internal/rules",
         "//pkg/sql/schemachanger/scplan/internal/scgraph",
         "//pkg/sql/schemachanger/screl",
+        "@com_github_cockroachdb_errors//:errors",
     ],
 )
 

--- a/pkg/sql/schemachanger/scplan/internal/rules/release_22_2/assertions_test.go
+++ b/pkg/sql/schemachanger/scplan/internal/rules/release_22_2/assertions_test.go
@@ -44,13 +44,13 @@ func TestRuleAssertions(t *testing.T) {
 		nameParts := strings.Split(fullName, "rules.")
 		shortName := nameParts[len(nameParts)-1]
 		t.Run(shortName, func(t *testing.T) {
-			_ = ForEachElementInActiveVersion(func(e scpb.Element) error {
+			_ = ForEachElementInActiveVersion(version, func(e scpb.Element) error {
 				e = nonNilElement(e)
 				if err := fn(e); err != nil {
 					t.Errorf("%T: %+v", e, err)
 				}
 				return nil
-			}, version)
+			})
 		})
 	}
 }
@@ -62,7 +62,7 @@ func nonNilElement(element scpb.Element) scpb.Element {
 // Assert that only simple dependents (non-descriptor, non-index, non-column)
 // have screl.ReferencedDescID attributes.
 func checkSimpleDependentsReferenceDescID(e scpb.Element) error {
-	if IsSimpleDependent(e) {
+	if isSimpleDependent(e) {
 		return nil
 	}
 	if _, ok := e.(*scpb.ForeignKeyConstraint); ok {
@@ -85,15 +85,15 @@ func checkToAbsentCategories(e scpb.Element) error {
 	s1 := opgen.NextStatus(e, scpb.Status_ABSENT, s0)
 	switch s1 {
 	case scpb.Status_TXN_DROPPED, scpb.Status_DROPPED:
-		if IsDescriptor(e) {
+		if isDescriptor(e) {
 			return nil
 		}
 	case scpb.Status_VALIDATED, scpb.Status_WRITE_ONLY, scpb.Status_DELETE_ONLY:
-		if IsSubjectTo2VersionInvariant(e) {
+		if isSubjectTo2VersionInvariant(e) || isSupportedNonIndexBackedConstraint(e) {
 			return nil
 		}
 	case scpb.Status_ABSENT:
-		if IsSimpleDependent(e) {
+		if isSimpleDependent(e) {
 			return nil
 		}
 	}
@@ -103,7 +103,7 @@ func checkToAbsentCategories(e scpb.Element) error {
 // Assert that isWithTypeT covers all elements with embedded TypeTs.
 func checkIsWithTypeT(e scpb.Element) error {
 	return screl.WalkTypes(e, func(t *types.T) error {
-		if IsWithTypeT(e) {
+		if isWithTypeT(e) {
 			return nil
 		}
 		return errors.New("should verify isWithTypeT but doesn't")
@@ -120,37 +120,37 @@ func checkIsWithExpression(e scpb.Element) error {
 		case *scpb.RowLevelTTL:
 			return nil
 		}
-		if IsWithExpression(e) {
+		if isWithExpression(e) {
 			return nil
 		}
 		return errors.New("should verify isWithExpression but doesn't")
 	})
 }
 
-// Assert that rules.IsColumnDependent covers all dependent elements of a column
+// Assert that rules.isColumnDependent covers all dependent elements of a column
 // element.
 func checkIsColumnDependent(e scpb.Element) error {
 	// Exclude columns themselves.
-	if IsColumn(e) {
+	if isColumn(e) {
 		return nil
 	}
 	// A column dependent should have a ColumnID attribute.
 	_, err := screl.Schema.GetAttribute(screl.ColumnID, e)
-	if IsColumnDependent(e) {
+	if isColumnDependent(e) {
 		if err != nil {
-			return errors.New("verifies rules.IsColumnDependent but doesn't have ColumnID attr")
+			return errors.New("verifies rules.isColumnDependent but doesn't have ColumnID attr")
 		}
 	} else if err == nil {
-		return errors.New("has ColumnID attr but doesn't verify rules.IsColumnDependent")
+		return errors.New("has ColumnID attr but doesn't verify rules.isColumnDependent")
 	}
 	return nil
 }
 
-// Assert that rules.IsIndexDependent covers all dependent elements of an index
+// Assert that rules.isIndexDependent covers all dependent elements of an index
 // element.
 func checkIsIndexDependent(e scpb.Element) error {
 	// Exclude indexes themselves.
-	if IsIndex(e) || IsSupportedNonIndexBackedConstraint(e) {
+	if IsIndex(e) || isSupportedNonIndexBackedConstraint(e) {
 		return nil
 	}
 	// Skip check constraints, in 22.2 these didn't have
@@ -160,12 +160,12 @@ func checkIsIndexDependent(e scpb.Element) error {
 	}
 	// An index dependent should have an IndexID attribute.
 	_, err := screl.Schema.GetAttribute(screl.IndexID, e)
-	if IsIndexDependent(e) {
+	if isIndexDependent(e) {
 		if err != nil {
-			return errors.New("verifies rules.IsIndexDependent but doesn't have IndexID attr")
+			return errors.New("verifies rules.isIndexDependent but doesn't have IndexID attr")
 		}
 	} else if err == nil {
-		return errors.New("has IndexID attr but doesn't verify rules.IsIndexDependent")
+		return errors.New("has IndexID attr but doesn't verify rules.isIndexDependent")
 	}
 	return nil
 }
@@ -174,17 +174,17 @@ func checkIsIndexDependent(e scpb.Element) error {
 // element.
 func checkIsConstraintDependent(e scpb.Element) error {
 	// Exclude constraints themselves.
-	if IsConstraint(e) {
+	if isConstraint(e) {
 		return nil
 	}
 	// A constraint dependent should have a ConstraintID attribute.
 	_, err := screl.Schema.GetAttribute(screl.ConstraintID, e)
-	if IsConstraintDependent(e) {
+	if isConstraintDependent(e) {
 		if err != nil {
-			return errors.New("verifies rules.IsConstraintDependent but doesn't have ConstraintID attr")
+			return errors.New("verifies rules.isConstraintDependent but doesn't have ConstraintID attr")
 		}
 	} else if err == nil {
-		return errors.New("has ConstraintID attr but doesn't verify rules.IsConstraintDependent")
+		return errors.New("has ConstraintID attr but doesn't verify rules.isConstraintDependent")
 	}
 	return nil
 }

--- a/pkg/sql/schemachanger/scplan/internal/rules/release_22_2/dep_add_column.go
+++ b/pkg/sql/schemachanger/scplan/internal/rules/release_22_2/dep_add_column.go
@@ -29,7 +29,7 @@ func init() {
 		func(from, to NodeVars) rel.Clauses {
 			return rel.Clauses{
 				from.Type((*scpb.Column)(nil)),
-				to.TypeFilter(IsColumnDependent),
+				to.TypeFilter(rulesVersionKey, isColumnDependent),
 				JoinOnColumnID(from, to, "table-id", "col-id"),
 				StatusesToPublicOrTransient(from, scpb.Status_DELETE_ONLY, to, scpb.Status_PUBLIC),
 			}
@@ -42,7 +42,7 @@ func init() {
 		"dependent", "column",
 		func(from, to NodeVars) rel.Clauses {
 			return rel.Clauses{
-				from.TypeFilter(IsColumnDependent),
+				from.TypeFilter(rulesVersionKey, isColumnDependent),
 				to.Type((*scpb.Column)(nil)),
 				JoinOnColumnID(from, to, "table-id", "col-id"),
 				StatusesToPublicOrTransient(from, scpb.Status_PUBLIC, to, scpb.Status_PUBLIC),

--- a/pkg/sql/schemachanger/scplan/internal/rules/release_22_2/dep_add_constraint.go
+++ b/pkg/sql/schemachanger/scplan/internal/rules/release_22_2/dep_add_constraint.go
@@ -27,8 +27,8 @@ func init() {
 		"constraint", "dependent",
 		func(from, to NodeVars) rel.Clauses {
 			return rel.Clauses{
-				from.TypeFilter(IsConstraint),
-				to.TypeFilter(IsConstraintDependent),
+				from.TypeFilter(rulesVersionKey, isConstraint),
+				to.TypeFilter(rulesVersionKey, isConstraintDependent),
 				JoinOnConstraintID(from, to, "table-id", "constraint-id"),
 				StatusesToPublicOrTransient(from, scpb.Status_PUBLIC, to, scpb.Status_PUBLIC),
 			}

--- a/pkg/sql/schemachanger/scplan/internal/rules/release_22_2/dep_add_index.go
+++ b/pkg/sql/schemachanger/scplan/internal/rules/release_22_2/dep_add_index.go
@@ -32,7 +32,7 @@ func init() {
 					(*scpb.PrimaryIndex)(nil),
 					(*scpb.SecondaryIndex)(nil),
 				),
-				to.TypeFilter(IsIndexDependent),
+				to.TypeFilter(rulesVersionKey, isIndexDependent),
 				JoinOnIndexID(from, to, "table-id", "index-id"),
 				StatusesToPublicOrTransient(from, scpb.Status_BACKFILL_ONLY, to, scpb.Status_PUBLIC),
 			}
@@ -46,7 +46,7 @@ func init() {
 		func(from, to NodeVars) rel.Clauses {
 			return rel.Clauses{
 				from.Type((*scpb.TemporaryIndex)(nil)),
-				to.TypeFilter(IsIndexDependent),
+				to.TypeFilter(rulesVersionKey, isIndexDependent),
 				JoinOnIndexID(from, to, "table-id", "index-id"),
 				StatusesToPublicOrTransient(from, scpb.Status_DELETE_ONLY, to, scpb.Status_PUBLIC),
 			}
@@ -59,8 +59,8 @@ func init() {
 		"dependent", "index",
 		func(from, to NodeVars) rel.Clauses {
 			return rel.Clauses{
-				from.TypeFilter(IsIndexDependent),
-				to.TypeFilter(IsIndex),
+				from.TypeFilter(rulesVersionKey, isIndexDependent),
+				to.TypeFilter(rulesVersionKey, IsIndex),
 				JoinOnIndexID(from, to, "table-id", "index-id"),
 				StatusesToPublicOrTransient(from, scpb.Status_PUBLIC, to, scpb.Status_PUBLIC),
 			}

--- a/pkg/sql/schemachanger/scplan/internal/rules/release_22_2/dep_drop_column.go
+++ b/pkg/sql/schemachanger/scplan/internal/rules/release_22_2/dep_drop_column.go
@@ -29,7 +29,7 @@ func init() {
 		func(from, to NodeVars) rel.Clauses {
 			return rel.Clauses{
 				from.Type((*scpb.Column)(nil)),
-				to.TypeFilter(IsColumnDependent),
+				to.TypeFilter(rulesVersionKey, isColumnDependent),
 				JoinOnColumnID(from, to, "table-id", "col-id"),
 			}
 		},
@@ -42,7 +42,7 @@ func init() {
 		scpb.Status_ABSENT, scpb.Status_ABSENT,
 		func(from, to NodeVars) rel.Clauses {
 			return rel.Clauses{
-				from.TypeFilter(IsColumnDependent),
+				from.TypeFilter(rulesVersionKey, isColumnDependent),
 				to.Type((*scpb.Column)(nil)),
 				JoinOnColumnID(from, to, "table-id", "col-id"),
 			}
@@ -59,7 +59,7 @@ func init() {
 		"dependent", "column-type",
 		func(from, to NodeVars) rel.Clauses {
 			return rel.Clauses{
-				from.TypeFilter(IsColumnTypeDependent),
+				from.TypeFilter(rulesVersionKey, isColumnTypeDependent),
 				to.Type((*scpb.ColumnType)(nil)),
 				JoinOnColumnID(from, to, "table-id", "col-id"),
 				StatusesToAbsent(from, scpb.Status_ABSENT, to, scpb.Status_ABSENT),
@@ -89,7 +89,7 @@ func init() {
 		func(from, to NodeVars) rel.Clauses {
 			return rel.Clauses{
 				from.Type((*scpb.ColumnType)(nil)),
-				from.DescriptorIsNotBeingDropped(),
+				descriptorIsNotBeingDropped(from.El),
 				to.Type((*scpb.Column)(nil)),
 				JoinOnColumnID(from, to, "table-id", "col-id"),
 				StatusesToAbsent(from, scpb.Status_ABSENT, to, scpb.Status_ABSENT),

--- a/pkg/sql/schemachanger/scplan/internal/rules/release_22_2/dep_drop_constraint.go
+++ b/pkg/sql/schemachanger/scplan/internal/rules/release_22_2/dep_drop_constraint.go
@@ -28,8 +28,8 @@ func init() {
 		scpb.Status_ABSENT, scpb.Status_ABSENT,
 		func(from, to NodeVars) rel.Clauses {
 			return rel.Clauses{
-				from.TypeFilter(IsConstraintDependent),
-				to.TypeFilter(IsConstraint, Not(IsIndex)),
+				from.TypeFilter(rulesVersionKey, isConstraintDependent),
+				to.TypeFilter(rulesVersionKey, isConstraint, Not(IsIndex)),
 				JoinOnConstraintID(from, to, "table-id", "constraint-id"),
 			}
 		},
@@ -42,8 +42,8 @@ func init() {
 		scpb.Status_VALIDATED, scpb.Status_ABSENT,
 		func(from, to NodeVars) rel.Clauses {
 			return rel.Clauses{
-				from.TypeFilter(IsConstraintDependent),
-				to.TypeFilter(IsConstraint, IsIndex),
+				from.TypeFilter(rulesVersionKey, isConstraintDependent),
+				to.TypeFilter(rulesVersionKey, isConstraint, IsIndex),
 				JoinOnConstraintID(from, to, "table-id", "constraint-id"),
 			}
 		},

--- a/pkg/sql/schemachanger/scplan/internal/rules/release_22_2/dep_drop_index.go
+++ b/pkg/sql/schemachanger/scplan/internal/rules/release_22_2/dep_drop_index.go
@@ -28,8 +28,8 @@ func init() {
 		scpb.Status_VALIDATED, scpb.Status_ABSENT,
 		func(from, to NodeVars) rel.Clauses {
 			return rel.Clauses{
-				from.TypeFilter(IsIndex),
-				to.TypeFilter(IsIndexDependent),
+				from.TypeFilter(rulesVersionKey, IsIndex),
+				to.TypeFilter(rulesVersionKey, isIndexDependent),
 				JoinOnIndexID(from, to, "table-id", "index-id"),
 			}
 		},
@@ -41,8 +41,8 @@ func init() {
 		scpb.Status_ABSENT, scpb.Status_ABSENT,
 		func(from, to NodeVars) rel.Clauses {
 			return rel.Clauses{
-				from.TypeFilter(IsIndexDependent),
-				to.TypeFilter(IsIndex),
+				from.TypeFilter(rulesVersionKey, isIndexDependent),
+				to.TypeFilter(rulesVersionKey, IsIndex),
 				JoinOnIndexID(from, to, "table-id", "index-id"),
 			}
 		},
@@ -72,7 +72,7 @@ func init() {
 		func(from, to NodeVars) rel.Clauses {
 			return rel.Clauses{
 				from.Type((*scpb.IndexColumn)(nil)),
-				to.TypeFilter(IsIndex),
+				to.TypeFilter(rulesVersionKey, IsIndex),
 				JoinOnIndexID(from, to, "table-id", "index-id"),
 			}
 		},
@@ -98,7 +98,7 @@ func init() {
 		func(from, to NodeVars) rel.Clauses {
 			return rel.Clauses{
 				from.Type((*scpb.SecondaryIndexPartial)(nil)),
-				from.DescriptorIsNotBeingDropped(),
+				descriptorIsNotBeingDropped(from.El),
 				to.Type((*scpb.SecondaryIndex)(nil)),
 				JoinOnIndexID(from, to, "table-id", "index-id"),
 			}

--- a/pkg/sql/schemachanger/scplan/internal/rules/release_22_2/dep_drop_index_and_column.go
+++ b/pkg/sql/schemachanger/scplan/internal/rules/release_22_2/dep_drop_index_and_column.go
@@ -36,7 +36,7 @@ func init() {
 				to.Type((*scpb.Column)(nil)),
 				ColumnInIndex(ic, from, relationID, columnID, "index-id"),
 				JoinOnColumnID(ic, to, relationID, columnID),
-				ic.DescriptorIsNotBeingDropped(),
+				descriptorIsNotBeingDropped(ic.El),
 			}
 		})
 
@@ -52,7 +52,7 @@ func init() {
 				ColumnInIndex(ic, from, relationID, columnID, "index-id"),
 				JoinOnColumnID(ic, to, relationID, columnID),
 				StatusesToAbsent(from, scpb.Status_VALIDATED, to, scpb.Status_WRITE_ONLY),
-				ic.DescriptorIsNotBeingDropped(),
+				descriptorIsNotBeingDropped(ic.El),
 				rel.Filter("rules.IsIndexKeyColumnKey", ic.El)(
 					func(ic *scpb.IndexColumn) bool {
 						return ic.Kind == scpb.IndexColumn_KEY

--- a/pkg/sql/schemachanger/scplan/internal/rules/release_22_2/dep_drop_object.go
+++ b/pkg/sql/schemachanger/scplan/internal/rules/release_22_2/dep_drop_object.go
@@ -39,7 +39,7 @@ func init() {
 		"txn_dropped", "dropped",
 		func(from, to NodeVars) rel.Clauses {
 			return rel.Clauses{
-				from.TypeFilter(IsDescriptor),
+				from.TypeFilter(rulesVersionKey, isDescriptor),
 				from.El.AttrEqVar(screl.DescID, "_"),
 				from.El.AttrEqVar(rel.Self, to.El),
 				StatusesToAbsent(from, scpb.Status_TXN_DROPPED, to, scpb.Status_DROPPED),
@@ -51,7 +51,7 @@ func init() {
 		"dropped", "absent",
 		func(from, to NodeVars) rel.Clauses {
 			return rel.Clauses{
-				from.TypeFilter(IsDescriptor),
+				from.TypeFilter(rulesVersionKey, isDescriptor),
 				from.El.AttrEqVar(screl.DescID, "_"),
 				from.El.AttrEqVar(rel.Self, to.El),
 				StatusesToAbsent(from, scpb.Status_DROPPED, to, scpb.Status_ABSENT),
@@ -64,8 +64,8 @@ func init() {
 		"descriptor", "dependent",
 		func(from, to NodeVars) rel.Clauses {
 			return rel.Clauses{
-				from.TypeFilter(IsDescriptor),
-				to.TypeFilter(IsSimpleDependent),
+				from.TypeFilter(rulesVersionKey, isDescriptor),
+				to.TypeFilter(rulesVersionKey, isSimpleDependent),
 				JoinOnDescID(from, to, "desc-id"),
 				StatusesToAbsent(from, scpb.Status_DROPPED, to, scpb.Status_ABSENT),
 				FromHasPublicStatusIfFromIsTableAndToIsRowLevelTTL(from.Target, from.El, to.El),
@@ -78,8 +78,8 @@ func init() {
 		"descriptor", "idx-or-col",
 		func(from, to NodeVars) rel.Clauses {
 			return rel.Clauses{
-				from.TypeFilter(IsDescriptor),
-				to.TypeFilter(IsSubjectTo2VersionInvariant),
+				from.TypeFilter(rulesVersionKey, isDescriptor),
+				to.TypeFilter(rulesVersionKey, isSubjectTo2VersionInvariant),
 				JoinOnDescID(from, to, "desc-id"),
 				StatusesToAbsent(from, scpb.Status_ABSENT, to, scpb.Status_ABSENT),
 			}
@@ -104,8 +104,8 @@ func init() {
 		"referenced-descriptor", "referencing-via-attr",
 		func(from, to NodeVars) rel.Clauses {
 			return rel.Clauses{
-				from.TypeFilter(IsDescriptor),
-				to.TypeFilter(IsSimpleDependent),
+				from.TypeFilter(rulesVersionKey, isDescriptor),
+				to.TypeFilter(rulesVersionKey, isSimpleDependent),
 				JoinReferencedDescID(to, from, "desc-id"),
 				StatusesToAbsent(from, scpb.Status_DROPPED, to, scpb.Status_ABSENT),
 			}
@@ -119,11 +119,11 @@ func init() {
 		func(from, to NodeVars) rel.Clauses {
 			fromDescID := rel.Var("fromDescID")
 			return rel.Clauses{
-				from.TypeFilter(IsTypeDescriptor),
+				from.TypeFilter(rulesVersionKey, isTypeDescriptor),
 				from.JoinTargetNode(),
 				from.DescIDEq(fromDescID),
 				to.ReferencedTypeDescIDsContain(fromDescID),
-				to.TypeFilter(IsSimpleDependent, Or(IsWithTypeT, IsWithExpression)),
+				to.TypeFilter(rulesVersionKey, isSimpleDependent, Or(isWithTypeT, isWithExpression)),
 				StatusesToAbsent(from, scpb.Status_DROPPED, to, scpb.Status_ABSENT),
 			}
 		},
@@ -140,7 +140,7 @@ func init() {
 				from.JoinTargetNode(),
 				from.DescIDEq(seqID),
 				to.ReferencedSequenceIDsContains(seqID),
-				to.TypeFilter(IsSimpleDependent, IsWithExpression),
+				to.TypeFilter(rulesVersionKey, isSimpleDependent, isWithExpression),
 				StatusesToAbsent(from, scpb.Status_DROPPED, to, scpb.Status_ABSENT),
 			}
 		},

--- a/pkg/sql/schemachanger/scplan/internal/rules/release_22_2/dep_two_version.go
+++ b/pkg/sql/schemachanger/scplan/internal/rules/release_22_2/dep_two_version.go
@@ -69,7 +69,7 @@ func init() {
 			from.Target.AttrEq(screl.TargetStatus, targetStatus.Status()),
 			from.Node.AttrEq(screl.CurrentStatus, t.From()),
 			to.Node.AttrEq(screl.CurrentStatus, t.To()),
-			from.DescriptorIsNotBeingDropped(),
+			descriptorIsNotBeingDropped(from.El),
 		}
 		if len(prePrevStatuses) > 0 {
 			clauses = append(clauses,
@@ -104,7 +104,7 @@ func init() {
 		}
 	}
 	_ = ForEachElement(func(el scpb.Element) error {
-		if !IsSubjectTo2VersionInvariant(el) {
+		if !isSubjectTo2VersionInvariant(el) {
 			return nil
 		}
 		if opgen.HasPublic(el) {

--- a/pkg/sql/schemachanger/scplan/internal/rules/release_22_2/helpers.go
+++ b/pkg/sql/schemachanger/scplan/internal/rules/release_22_2/helpers.go
@@ -1,0 +1,206 @@
+// Copyright 2023 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package release_22_2
+
+import (
+	"github.com/cockroachdb/cockroach/pkg/clusterversion"
+	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/rel"
+	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scplan/internal/rules"
+	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/screl"
+	"github.com/cockroachdb/errors"
+)
+
+const (
+	// rulesVersion version of elements that can be appended to rel rule names.
+	rulesVersion = "-22.2"
+)
+
+// rulesVersionKey version of elements used by this rule set.
+var rulesVersionKey = clusterversion.V22_2
+
+// descriptorIsNotBeingDropped creates a clause which leads to the outer clause
+// failing to unify if the passed element is part of a descriptor and
+// that descriptor is being dropped.
+var descriptorIsNotBeingDropped = screl.Schema.DefNotJoin1(
+	"descriptorIsNotBeingDropped"+rulesVersion, "element", func(
+		element rel.Var,
+	) rel.Clauses {
+		descriptor := rules.MkNodeVars("descriptor")
+		return rel.Clauses{
+			descriptor.TypeFilter(rulesVersionKey, isDescriptor),
+			descriptor.JoinTarget(),
+			rules.JoinOnDescIDUntyped(descriptor.El, element, "id"),
+			descriptor.TargetStatus(scpb.ToAbsent),
+		}
+	},
+)
+
+// isDescriptor returns true for a descriptor-element, i.e. an element which
+// owns its corresponding descriptor.
+func isDescriptor(e scpb.Element) bool {
+	switch e.(type) {
+	case *scpb.Database, *scpb.Schema, *scpb.Table, *scpb.View, *scpb.Sequence,
+		*scpb.AliasType, *scpb.EnumType:
+		return true
+	}
+	return false
+}
+
+func isSubjectTo2VersionInvariant(e scpb.Element) bool {
+	// TODO(ajwerner): This should include constraints and enum values but it
+	// currently does not because we do not support dropping them unless we're
+	// dropping the descriptor and we do not support adding them.
+	return IsIndex(e) || isColumn(e)
+}
+
+func IsIndex(e scpb.Element) bool {
+	switch e.(type) {
+	case *scpb.PrimaryIndex, *scpb.SecondaryIndex, *scpb.TemporaryIndex:
+		return true
+	}
+	return false
+}
+
+func isColumn(e scpb.Element) bool {
+	_, ok := e.(*scpb.Column)
+	return ok
+}
+
+func isSimpleDependent(e scpb.Element) bool {
+	return !isDescriptor(e) && !isSubjectTo2VersionInvariant(e)
+}
+
+func getTypeT(element scpb.Element) (*scpb.TypeT, error) {
+	switch e := element.(type) {
+	case *scpb.ColumnType:
+		if e == nil {
+			return nil, nil
+		}
+		return &e.TypeT, nil
+	case *scpb.AliasType:
+		if e == nil {
+			return nil, nil
+		}
+		return &e.TypeT, nil
+	}
+	return nil, errors.AssertionFailedf("element %T does not have an embedded scpb.TypeT", element)
+}
+
+func isWithTypeT(element scpb.Element) bool {
+	_, err := getTypeT(element)
+	return err == nil
+}
+
+func getExpression(element scpb.Element) (*scpb.Expression, error) {
+	switch e := element.(type) {
+	case *scpb.ColumnType:
+		if e == nil {
+			return nil, nil
+		}
+		return e.ComputeExpr, nil
+	case *scpb.ColumnDefaultExpression:
+		if e == nil {
+			return nil, nil
+		}
+		return &e.Expression, nil
+	case *scpb.ColumnOnUpdateExpression:
+		if e == nil {
+			return nil, nil
+		}
+		return &e.Expression, nil
+	case *scpb.SecondaryIndexPartial:
+		if e == nil {
+			return nil, nil
+		}
+		return &e.Expression, nil
+	case *scpb.CheckConstraint:
+		if e == nil {
+			return nil, nil
+		}
+		return &e.Expression, nil
+	}
+	return nil, errors.AssertionFailedf("element %T does not have an embedded scpb.Expression", element)
+}
+
+func isWithExpression(element scpb.Element) bool {
+	_, err := getExpression(element)
+	return err == nil
+}
+
+func isTypeDescriptor(element scpb.Element) bool {
+	switch element.(type) {
+	case *scpb.EnumType, *scpb.AliasType:
+		return true
+	default:
+		return false
+	}
+}
+
+func isColumnDependent(e scpb.Element) bool {
+	switch e.(type) {
+	case *scpb.ColumnType:
+		return true
+	case *scpb.ColumnName, *scpb.ColumnComment, *scpb.IndexColumn:
+		return true
+	}
+	return isColumnTypeDependent(e)
+}
+
+func isColumnTypeDependent(e scpb.Element) bool {
+	switch e.(type) {
+	case *scpb.SequenceOwner, *scpb.ColumnDefaultExpression, *scpb.ColumnOnUpdateExpression:
+		return true
+	}
+	return false
+}
+
+func isIndexDependent(e scpb.Element) bool {
+	switch e.(type) {
+	case *scpb.IndexName, *scpb.IndexComment, *scpb.IndexColumn:
+		return true
+	case *scpb.IndexPartitioning, *scpb.SecondaryIndexPartial:
+		return true
+	}
+	return false
+}
+
+// isSupportedNonIndexBackedConstraint a non-index-backed constraint is one of {Check, FK, UniqueWithoutIndex}. We only
+// support Check for now.
+// TODO (xiang): Expand this predicate to include other non-index-backed constraints
+// when we properly support adding/dropping them in the new schema changer.
+func isSupportedNonIndexBackedConstraint(e scpb.Element) bool {
+	switch e.(type) {
+	case *scpb.CheckConstraint, *scpb.ForeignKeyConstraint, *scpb.UniqueWithoutIndexConstraint:
+		return true
+	}
+	return false
+}
+
+func isConstraint(e scpb.Element) bool {
+	switch e.(type) {
+	case *scpb.PrimaryIndex, *scpb.SecondaryIndex, *scpb.TemporaryIndex:
+		return true
+	case *scpb.CheckConstraint, *scpb.UniqueWithoutIndexConstraint, *scpb.ForeignKeyConstraint:
+		return true
+	}
+	return false
+}
+
+func isConstraintDependent(e scpb.Element) bool {
+	switch e.(type) {
+	case *scpb.ConstraintWithoutIndexName:
+		return true
+	case *scpb.ConstraintComment:
+		return true
+	}
+	return false
+}

--- a/pkg/sql/schemachanger/scplan/internal/rules/release_22_2/op_drop.go
+++ b/pkg/sql/schemachanger/scplan/internal/rules/release_22_2/op_drop.go
@@ -130,7 +130,7 @@ func init() {
 				(*scpb.Table)(nil),
 				(*scpb.View)(nil),
 			),
-			index.TypeFilter(IsIndex),
+			index.TypeFilter(rulesVersionKey, IsIndex),
 			dep.Type(
 				(*scpb.IndexName)(nil),
 				(*scpb.IndexPartitioning)(nil),
@@ -230,7 +230,7 @@ func init() {
 		"skip element removal ops on descriptor drop",
 		dep.Node,
 		screl.MustQuery(
-			desc.TypeFilter(IsDescriptor),
+			desc.TypeFilter(rulesVersionKey, isDescriptor),
 			dep.Type(
 				(*scpb.ColumnFamily)(nil),
 				(*scpb.Owner)(nil),

--- a/pkg/sql/schemachanger/scplan/internal/rules/release_22_2/op_index_and_column.go
+++ b/pkg/sql/schemachanger/scplan/internal/rules/release_22_2/op_index_and_column.go
@@ -29,7 +29,7 @@ func init() {
 		ic.Node,
 		screl.MustQuery(
 			ic.Type((*scpb.IndexColumn)(nil)),
-			index.TypeFilter(IsIndex),
+			index.TypeFilter(rulesVersionKey, IsIndex),
 			JoinOnIndexID(ic, index, relationID, indexID),
 			ic.JoinTargetNode(),
 			ic.TargetStatus(scpb.ToAbsent, scpb.Transient),

--- a/pkg/sql/schemachanger/scplan/internal/rules/release_22_2/testdata/deprules
+++ b/pkg/sql/schemachanger/scplan/internal/rules/release_22_2/testdata/deprules
@@ -9,15 +9,15 @@ ColumnInIndex($index-column, $index, $table-id, $column-id, $index-id):
 ColumnInSwappedInPrimaryIndex($index-column, $index, $table-id, $column-id, $index-id):
     - ColumnInIndex($index-column, $index, $table-id, $column-id, $index-id)
     - sourceIndexIsSet($index)
-DescriptorIsNotBeingDropped($element):
-    not-join:
-        - $descriptor[Type] IN ['*scpb.Database', '*scpb.Schema', '*scpb.View', '*scpb.Sequence', '*scpb.Table', '*scpb.EnumType', '*scpb.AliasType', '*scpb.CompositeType']
-        - joinTarget($descriptor, $descriptor-Target)
-        - joinOnDescID($descriptor, $element, $id)
-        - $descriptor-Target[TargetStatus] = ABSENT
 ToPublicOrTransient($target1, $target2):
     - $target1[TargetStatus] IN [PUBLIC, TRANSIENT_ABSENT]
     - $target2[TargetStatus] IN [PUBLIC, TRANSIENT_ABSENT]
+descriptorIsNotBeingDropped-22.2($element):
+    not-join:
+        - $descriptor[Type] IN ['*scpb.Database', '*scpb.Schema', '*scpb.View', '*scpb.Sequence', '*scpb.Table', '*scpb.EnumType', '*scpb.AliasType']
+        - joinTarget($descriptor, $descriptor-Target)
+        - joinOnDescID($descriptor, $element, $id)
+        - $descriptor-Target[TargetStatus] = ABSENT
 fromHasPublicStatusIfFromIsTableAndToIsRowLevelTTL($fromTarget, $fromEl, $toEl):
     not-join:
         - $fromEl[Type] = '*scpb.Table'
@@ -95,11 +95,6 @@ nodeNotExistsWithStatusIn_VALIDATED_TRANSIENT_WRITE_ONLY_MERGE_ONLY_TRANSIENT_ME
         - $n[Type] = '*screl.Node'
         - $n[Target] = $sharedTarget
         - $n[CurrentStatus] IN [VALIDATED, TRANSIENT_WRITE_ONLY, MERGE_ONLY, TRANSIENT_MERGE_ONLY, MERGED, TRANSIENT_MERGED]
-nodeNotExistsWithStatusIn_WRITE_ONLY($sharedTarget):
-    not-join:
-        - $n[Type] = '*screl.Node'
-        - $n[Target] = $sharedTarget
-        - $n[CurrentStatus] IN [WRITE_ONLY]
 sourceIndexIsSet($index):
     - $index[SourceIndexID] != 0
 toAbsent($target1, $target2):
@@ -111,103 +106,6 @@ transient($target1, $target2):
 
 deprules
 ----
-- name: 'CheckConstraint transitions to ABSENT uphold 2-version invariant: PUBLIC->VALIDATED'
-  from: prev-Node
-  kind: PreviousTransactionPrecedence
-  to: next-Node
-  query:
-    - $prev[Type] = '*scpb.CheckConstraint'
-    - $next[Type] = '*scpb.CheckConstraint'
-    - $prev[DescID] = $_
-    - $prev[Self] = $next
-    - $prev-Target[Self] = $next-Target
-    - $prev-Target[TargetStatus] = ABSENT
-    - $prev-Node[CurrentStatus] = PUBLIC
-    - $next-Node[CurrentStatus] = VALIDATED
-    - DescriptorIsNotBeingDropped($prev)
-    - joinTargetNode($prev, $prev-Target, $prev-Node)
-    - joinTargetNode($next, $next-Target, $next-Node)
-- name: 'CheckConstraint transitions to ABSENT uphold 2-version invariant: VALIDATED->ABSENT'
-  from: prev-Node
-  kind: PreviousTransactionPrecedence
-  to: next-Node
-  query:
-    - $prev[Type] = '*scpb.CheckConstraint'
-    - $next[Type] = '*scpb.CheckConstraint'
-    - $prev[DescID] = $_
-    - $prev[Self] = $next
-    - $prev-Target[Self] = $next-Target
-    - $prev-Target[TargetStatus] = ABSENT
-    - $prev-Node[CurrentStatus] = VALIDATED
-    - $next-Node[CurrentStatus] = ABSENT
-    - DescriptorIsNotBeingDropped($prev)
-    - nodeNotExistsWithStatusIn_WRITE_ONLY($prev-Target)
-    - joinTargetNode($prev, $prev-Target, $prev-Node)
-    - joinTargetNode($next, $next-Target, $next-Node)
-- name: 'CheckConstraint transitions to ABSENT uphold 2-version invariant: WRITE_ONLY->VALIDATED'
-  from: prev-Node
-  kind: PreviousTransactionPrecedence
-  to: next-Node
-  query:
-    - $prev[Type] = '*scpb.CheckConstraint'
-    - $next[Type] = '*scpb.CheckConstraint'
-    - $prev[DescID] = $_
-    - $prev[Self] = $next
-    - $prev-Target[Self] = $next-Target
-    - $prev-Target[TargetStatus] = ABSENT
-    - $prev-Node[CurrentStatus] = WRITE_ONLY
-    - $next-Node[CurrentStatus] = VALIDATED
-    - DescriptorIsNotBeingDropped($prev)
-    - joinTargetNode($prev, $prev-Target, $prev-Node)
-    - joinTargetNode($next, $next-Target, $next-Node)
-- name: 'CheckConstraint transitions to PUBLIC uphold 2-version invariant: ABSENT->WRITE_ONLY'
-  from: prev-Node
-  kind: PreviousTransactionPrecedence
-  to: next-Node
-  query:
-    - $prev[Type] = '*scpb.CheckConstraint'
-    - $next[Type] = '*scpb.CheckConstraint'
-    - $prev[DescID] = $_
-    - $prev[Self] = $next
-    - $prev-Target[Self] = $next-Target
-    - $prev-Target[TargetStatus] = PUBLIC
-    - $prev-Node[CurrentStatus] = ABSENT
-    - $next-Node[CurrentStatus] = WRITE_ONLY
-    - DescriptorIsNotBeingDropped($prev)
-    - joinTargetNode($prev, $prev-Target, $prev-Node)
-    - joinTargetNode($next, $next-Target, $next-Node)
-- name: 'CheckConstraint transitions to PUBLIC uphold 2-version invariant: VALIDATED->PUBLIC'
-  from: prev-Node
-  kind: PreviousTransactionPrecedence
-  to: next-Node
-  query:
-    - $prev[Type] = '*scpb.CheckConstraint'
-    - $next[Type] = '*scpb.CheckConstraint'
-    - $prev[DescID] = $_
-    - $prev[Self] = $next
-    - $prev-Target[Self] = $next-Target
-    - $prev-Target[TargetStatus] = PUBLIC
-    - $prev-Node[CurrentStatus] = VALIDATED
-    - $next-Node[CurrentStatus] = PUBLIC
-    - DescriptorIsNotBeingDropped($prev)
-    - joinTargetNode($prev, $prev-Target, $prev-Node)
-    - joinTargetNode($next, $next-Target, $next-Node)
-- name: 'CheckConstraint transitions to PUBLIC uphold 2-version invariant: WRITE_ONLY->VALIDATED'
-  from: prev-Node
-  kind: PreviousTransactionPrecedence
-  to: next-Node
-  query:
-    - $prev[Type] = '*scpb.CheckConstraint'
-    - $next[Type] = '*scpb.CheckConstraint'
-    - $prev[DescID] = $_
-    - $prev[Self] = $next
-    - $prev-Target[Self] = $next-Target
-    - $prev-Target[TargetStatus] = PUBLIC
-    - $prev-Node[CurrentStatus] = WRITE_ONLY
-    - $next-Node[CurrentStatus] = VALIDATED
-    - DescriptorIsNotBeingDropped($prev)
-    - joinTargetNode($prev, $prev-Target, $prev-Node)
-    - joinTargetNode($next, $next-Target, $next-Node)
 - name: 'Column transitions to ABSENT uphold 2-version invariant: DELETE_ONLY->ABSENT'
   from: prev-Node
   kind: PreviousTransactionPrecedence
@@ -221,7 +119,7 @@ deprules
     - $prev-Target[TargetStatus] = ABSENT
     - $prev-Node[CurrentStatus] = DELETE_ONLY
     - $next-Node[CurrentStatus] = ABSENT
-    - DescriptorIsNotBeingDropped($prev)
+    - descriptorIsNotBeingDropped-22.2($prev)
     - joinTargetNode($prev, $prev-Target, $prev-Node)
     - joinTargetNode($next, $next-Target, $next-Node)
 - name: 'Column transitions to ABSENT uphold 2-version invariant: PUBLIC->WRITE_ONLY'
@@ -237,7 +135,7 @@ deprules
     - $prev-Target[TargetStatus] = ABSENT
     - $prev-Node[CurrentStatus] = PUBLIC
     - $next-Node[CurrentStatus] = WRITE_ONLY
-    - DescriptorIsNotBeingDropped($prev)
+    - descriptorIsNotBeingDropped-22.2($prev)
     - joinTargetNode($prev, $prev-Target, $prev-Node)
     - joinTargetNode($next, $next-Target, $next-Node)
 - name: 'Column transitions to ABSENT uphold 2-version invariant: WRITE_ONLY->DELETE_ONLY'
@@ -253,7 +151,7 @@ deprules
     - $prev-Target[TargetStatus] = ABSENT
     - $prev-Node[CurrentStatus] = WRITE_ONLY
     - $next-Node[CurrentStatus] = DELETE_ONLY
-    - DescriptorIsNotBeingDropped($prev)
+    - descriptorIsNotBeingDropped-22.2($prev)
     - joinTargetNode($prev, $prev-Target, $prev-Node)
     - joinTargetNode($next, $next-Target, $next-Node)
 - name: 'Column transitions to PUBLIC uphold 2-version invariant: ABSENT->DELETE_ONLY'
@@ -269,7 +167,7 @@ deprules
     - $prev-Target[TargetStatus] = PUBLIC
     - $prev-Node[CurrentStatus] = ABSENT
     - $next-Node[CurrentStatus] = DELETE_ONLY
-    - DescriptorIsNotBeingDropped($prev)
+    - descriptorIsNotBeingDropped-22.2($prev)
     - joinTargetNode($prev, $prev-Target, $prev-Node)
     - joinTargetNode($next, $next-Target, $next-Node)
 - name: 'Column transitions to PUBLIC uphold 2-version invariant: DELETE_ONLY->WRITE_ONLY'
@@ -285,7 +183,7 @@ deprules
     - $prev-Target[TargetStatus] = PUBLIC
     - $prev-Node[CurrentStatus] = DELETE_ONLY
     - $next-Node[CurrentStatus] = WRITE_ONLY
-    - DescriptorIsNotBeingDropped($prev)
+    - descriptorIsNotBeingDropped-22.2($prev)
     - joinTargetNode($prev, $prev-Target, $prev-Node)
     - joinTargetNode($next, $next-Target, $next-Node)
 - name: 'Column transitions to PUBLIC uphold 2-version invariant: WRITE_ONLY->PUBLIC'
@@ -301,7 +199,7 @@ deprules
     - $prev-Target[TargetStatus] = PUBLIC
     - $prev-Node[CurrentStatus] = WRITE_ONLY
     - $next-Node[CurrentStatus] = PUBLIC
-    - DescriptorIsNotBeingDropped($prev)
+    - descriptorIsNotBeingDropped-22.2($prev)
     - joinTargetNode($prev, $prev-Target, $prev-Node)
     - joinTargetNode($next, $next-Target, $next-Node)
 - name: DEFAULT or ON UPDATE existence precedes writes to column
@@ -317,103 +215,6 @@ deprules
     - $column-Node[CurrentStatus] = WRITE_ONLY
     - joinTargetNode($expr, $expr-Target, $expr-Node)
     - joinTargetNode($column, $column-Target, $column-Node)
-- name: 'ForeignKeyConstraint transitions to ABSENT uphold 2-version invariant: PUBLIC->VALIDATED'
-  from: prev-Node
-  kind: PreviousTransactionPrecedence
-  to: next-Node
-  query:
-    - $prev[Type] = '*scpb.ForeignKeyConstraint'
-    - $next[Type] = '*scpb.ForeignKeyConstraint'
-    - $prev[DescID] = $_
-    - $prev[Self] = $next
-    - $prev-Target[Self] = $next-Target
-    - $prev-Target[TargetStatus] = ABSENT
-    - $prev-Node[CurrentStatus] = PUBLIC
-    - $next-Node[CurrentStatus] = VALIDATED
-    - DescriptorIsNotBeingDropped($prev)
-    - joinTargetNode($prev, $prev-Target, $prev-Node)
-    - joinTargetNode($next, $next-Target, $next-Node)
-- name: 'ForeignKeyConstraint transitions to ABSENT uphold 2-version invariant: VALIDATED->ABSENT'
-  from: prev-Node
-  kind: PreviousTransactionPrecedence
-  to: next-Node
-  query:
-    - $prev[Type] = '*scpb.ForeignKeyConstraint'
-    - $next[Type] = '*scpb.ForeignKeyConstraint'
-    - $prev[DescID] = $_
-    - $prev[Self] = $next
-    - $prev-Target[Self] = $next-Target
-    - $prev-Target[TargetStatus] = ABSENT
-    - $prev-Node[CurrentStatus] = VALIDATED
-    - $next-Node[CurrentStatus] = ABSENT
-    - DescriptorIsNotBeingDropped($prev)
-    - nodeNotExistsWithStatusIn_WRITE_ONLY($prev-Target)
-    - joinTargetNode($prev, $prev-Target, $prev-Node)
-    - joinTargetNode($next, $next-Target, $next-Node)
-- name: 'ForeignKeyConstraint transitions to ABSENT uphold 2-version invariant: WRITE_ONLY->VALIDATED'
-  from: prev-Node
-  kind: PreviousTransactionPrecedence
-  to: next-Node
-  query:
-    - $prev[Type] = '*scpb.ForeignKeyConstraint'
-    - $next[Type] = '*scpb.ForeignKeyConstraint'
-    - $prev[DescID] = $_
-    - $prev[Self] = $next
-    - $prev-Target[Self] = $next-Target
-    - $prev-Target[TargetStatus] = ABSENT
-    - $prev-Node[CurrentStatus] = WRITE_ONLY
-    - $next-Node[CurrentStatus] = VALIDATED
-    - DescriptorIsNotBeingDropped($prev)
-    - joinTargetNode($prev, $prev-Target, $prev-Node)
-    - joinTargetNode($next, $next-Target, $next-Node)
-- name: 'ForeignKeyConstraint transitions to PUBLIC uphold 2-version invariant: ABSENT->WRITE_ONLY'
-  from: prev-Node
-  kind: PreviousTransactionPrecedence
-  to: next-Node
-  query:
-    - $prev[Type] = '*scpb.ForeignKeyConstraint'
-    - $next[Type] = '*scpb.ForeignKeyConstraint'
-    - $prev[DescID] = $_
-    - $prev[Self] = $next
-    - $prev-Target[Self] = $next-Target
-    - $prev-Target[TargetStatus] = PUBLIC
-    - $prev-Node[CurrentStatus] = ABSENT
-    - $next-Node[CurrentStatus] = WRITE_ONLY
-    - DescriptorIsNotBeingDropped($prev)
-    - joinTargetNode($prev, $prev-Target, $prev-Node)
-    - joinTargetNode($next, $next-Target, $next-Node)
-- name: 'ForeignKeyConstraint transitions to PUBLIC uphold 2-version invariant: VALIDATED->PUBLIC'
-  from: prev-Node
-  kind: PreviousTransactionPrecedence
-  to: next-Node
-  query:
-    - $prev[Type] = '*scpb.ForeignKeyConstraint'
-    - $next[Type] = '*scpb.ForeignKeyConstraint'
-    - $prev[DescID] = $_
-    - $prev[Self] = $next
-    - $prev-Target[Self] = $next-Target
-    - $prev-Target[TargetStatus] = PUBLIC
-    - $prev-Node[CurrentStatus] = VALIDATED
-    - $next-Node[CurrentStatus] = PUBLIC
-    - DescriptorIsNotBeingDropped($prev)
-    - joinTargetNode($prev, $prev-Target, $prev-Node)
-    - joinTargetNode($next, $next-Target, $next-Node)
-- name: 'ForeignKeyConstraint transitions to PUBLIC uphold 2-version invariant: WRITE_ONLY->VALIDATED'
-  from: prev-Node
-  kind: PreviousTransactionPrecedence
-  to: next-Node
-  query:
-    - $prev[Type] = '*scpb.ForeignKeyConstraint'
-    - $next[Type] = '*scpb.ForeignKeyConstraint'
-    - $prev[DescID] = $_
-    - $prev[Self] = $next
-    - $prev-Target[Self] = $next-Target
-    - $prev-Target[TargetStatus] = PUBLIC
-    - $prev-Node[CurrentStatus] = WRITE_ONLY
-    - $next-Node[CurrentStatus] = VALIDATED
-    - DescriptorIsNotBeingDropped($prev)
-    - joinTargetNode($prev, $prev-Target, $prev-Node)
-    - joinTargetNode($next, $next-Target, $next-Node)
 - name: 'PrimaryIndex transitions to ABSENT uphold 2-version invariant: BACKFILLED->DELETE_ONLY'
   from: prev-Node
   kind: PreviousTransactionPrecedence
@@ -427,7 +228,7 @@ deprules
     - $prev-Target[TargetStatus] = ABSENT
     - $prev-Node[CurrentStatus] = BACKFILLED
     - $next-Node[CurrentStatus] = DELETE_ONLY
-    - DescriptorIsNotBeingDropped($prev)
+    - descriptorIsNotBeingDropped-22.2($prev)
     - joinTargetNode($prev, $prev-Target, $prev-Node)
     - joinTargetNode($next, $next-Target, $next-Node)
 - name: 'PrimaryIndex transitions to ABSENT uphold 2-version invariant: BACKFILL_ONLY->DELETE_ONLY'
@@ -443,7 +244,7 @@ deprules
     - $prev-Target[TargetStatus] = ABSENT
     - $prev-Node[CurrentStatus] = BACKFILL_ONLY
     - $next-Node[CurrentStatus] = DELETE_ONLY
-    - DescriptorIsNotBeingDropped($prev)
+    - descriptorIsNotBeingDropped-22.2($prev)
     - joinTargetNode($prev, $prev-Target, $prev-Node)
     - joinTargetNode($next, $next-Target, $next-Node)
 - name: 'PrimaryIndex transitions to ABSENT uphold 2-version invariant: DELETE_ONLY->ABSENT'
@@ -459,7 +260,7 @@ deprules
     - $prev-Target[TargetStatus] = ABSENT
     - $prev-Node[CurrentStatus] = DELETE_ONLY
     - $next-Node[CurrentStatus] = ABSENT
-    - DescriptorIsNotBeingDropped($prev)
+    - descriptorIsNotBeingDropped-22.2($prev)
     - nodeNotExistsWithStatusIn_TRANSIENT_DELETE_ONLY_BACKFILLED_TRANSIENT_BACKFILLED_BACKFILL_ONLY_TRANSIENT_BACKFILL_ONLY($prev-Target)
     - joinTargetNode($prev, $prev-Target, $prev-Node)
     - joinTargetNode($next, $next-Target, $next-Node)
@@ -476,7 +277,7 @@ deprules
     - $prev-Target[TargetStatus] = ABSENT
     - $prev-Node[CurrentStatus] = MERGED
     - $next-Node[CurrentStatus] = WRITE_ONLY
-    - DescriptorIsNotBeingDropped($prev)
+    - descriptorIsNotBeingDropped-22.2($prev)
     - joinTargetNode($prev, $prev-Target, $prev-Node)
     - joinTargetNode($next, $next-Target, $next-Node)
 - name: 'PrimaryIndex transitions to ABSENT uphold 2-version invariant: MERGE_ONLY->WRITE_ONLY'
@@ -492,7 +293,7 @@ deprules
     - $prev-Target[TargetStatus] = ABSENT
     - $prev-Node[CurrentStatus] = MERGE_ONLY
     - $next-Node[CurrentStatus] = WRITE_ONLY
-    - DescriptorIsNotBeingDropped($prev)
+    - descriptorIsNotBeingDropped-22.2($prev)
     - joinTargetNode($prev, $prev-Target, $prev-Node)
     - joinTargetNode($next, $next-Target, $next-Node)
 - name: 'PrimaryIndex transitions to ABSENT uphold 2-version invariant: PUBLIC->VALIDATED'
@@ -508,7 +309,7 @@ deprules
     - $prev-Target[TargetStatus] = ABSENT
     - $prev-Node[CurrentStatus] = PUBLIC
     - $next-Node[CurrentStatus] = VALIDATED
-    - DescriptorIsNotBeingDropped($prev)
+    - descriptorIsNotBeingDropped-22.2($prev)
     - joinTargetNode($prev, $prev-Target, $prev-Node)
     - joinTargetNode($next, $next-Target, $next-Node)
 - name: 'PrimaryIndex transitions to ABSENT uphold 2-version invariant: TRANSIENT_ABSENT->ABSENT'
@@ -524,7 +325,7 @@ deprules
     - $prev-Target[TargetStatus] = ABSENT
     - $prev-Node[CurrentStatus] = TRANSIENT_ABSENT
     - $next-Node[CurrentStatus] = ABSENT
-    - DescriptorIsNotBeingDropped($prev)
+    - descriptorIsNotBeingDropped-22.2($prev)
     - joinTargetNode($prev, $prev-Target, $prev-Node)
     - joinTargetNode($next, $next-Target, $next-Node)
 - name: 'PrimaryIndex transitions to ABSENT uphold 2-version invariant: TRANSIENT_BACKFILLED->DELETE_ONLY'
@@ -540,7 +341,7 @@ deprules
     - $prev-Target[TargetStatus] = ABSENT
     - $prev-Node[CurrentStatus] = TRANSIENT_BACKFILLED
     - $next-Node[CurrentStatus] = DELETE_ONLY
-    - DescriptorIsNotBeingDropped($prev)
+    - descriptorIsNotBeingDropped-22.2($prev)
     - joinTargetNode($prev, $prev-Target, $prev-Node)
     - joinTargetNode($next, $next-Target, $next-Node)
 - name: 'PrimaryIndex transitions to ABSENT uphold 2-version invariant: TRANSIENT_BACKFILL_ONLY->DELETE_ONLY'
@@ -556,7 +357,7 @@ deprules
     - $prev-Target[TargetStatus] = ABSENT
     - $prev-Node[CurrentStatus] = TRANSIENT_BACKFILL_ONLY
     - $next-Node[CurrentStatus] = DELETE_ONLY
-    - DescriptorIsNotBeingDropped($prev)
+    - descriptorIsNotBeingDropped-22.2($prev)
     - joinTargetNode($prev, $prev-Target, $prev-Node)
     - joinTargetNode($next, $next-Target, $next-Node)
 - name: 'PrimaryIndex transitions to ABSENT uphold 2-version invariant: TRANSIENT_DELETE_ONLY->DELETE_ONLY'
@@ -572,7 +373,7 @@ deprules
     - $prev-Target[TargetStatus] = ABSENT
     - $prev-Node[CurrentStatus] = TRANSIENT_DELETE_ONLY
     - $next-Node[CurrentStatus] = DELETE_ONLY
-    - DescriptorIsNotBeingDropped($prev)
+    - descriptorIsNotBeingDropped-22.2($prev)
     - joinTargetNode($prev, $prev-Target, $prev-Node)
     - joinTargetNode($next, $next-Target, $next-Node)
 - name: 'PrimaryIndex transitions to ABSENT uphold 2-version invariant: TRANSIENT_MERGED->WRITE_ONLY'
@@ -588,7 +389,7 @@ deprules
     - $prev-Target[TargetStatus] = ABSENT
     - $prev-Node[CurrentStatus] = TRANSIENT_MERGED
     - $next-Node[CurrentStatus] = WRITE_ONLY
-    - DescriptorIsNotBeingDropped($prev)
+    - descriptorIsNotBeingDropped-22.2($prev)
     - joinTargetNode($prev, $prev-Target, $prev-Node)
     - joinTargetNode($next, $next-Target, $next-Node)
 - name: 'PrimaryIndex transitions to ABSENT uphold 2-version invariant: TRANSIENT_MERGE_ONLY->WRITE_ONLY'
@@ -604,7 +405,7 @@ deprules
     - $prev-Target[TargetStatus] = ABSENT
     - $prev-Node[CurrentStatus] = TRANSIENT_MERGE_ONLY
     - $next-Node[CurrentStatus] = WRITE_ONLY
-    - DescriptorIsNotBeingDropped($prev)
+    - descriptorIsNotBeingDropped-22.2($prev)
     - joinTargetNode($prev, $prev-Target, $prev-Node)
     - joinTargetNode($next, $next-Target, $next-Node)
 - name: 'PrimaryIndex transitions to ABSENT uphold 2-version invariant: TRANSIENT_VALIDATED->VALIDATED'
@@ -620,7 +421,7 @@ deprules
     - $prev-Target[TargetStatus] = ABSENT
     - $prev-Node[CurrentStatus] = TRANSIENT_VALIDATED
     - $next-Node[CurrentStatus] = VALIDATED
-    - DescriptorIsNotBeingDropped($prev)
+    - descriptorIsNotBeingDropped-22.2($prev)
     - joinTargetNode($prev, $prev-Target, $prev-Node)
     - joinTargetNode($next, $next-Target, $next-Node)
 - name: 'PrimaryIndex transitions to ABSENT uphold 2-version invariant: TRANSIENT_WRITE_ONLY->WRITE_ONLY'
@@ -636,7 +437,7 @@ deprules
     - $prev-Target[TargetStatus] = ABSENT
     - $prev-Node[CurrentStatus] = TRANSIENT_WRITE_ONLY
     - $next-Node[CurrentStatus] = WRITE_ONLY
-    - DescriptorIsNotBeingDropped($prev)
+    - descriptorIsNotBeingDropped-22.2($prev)
     - joinTargetNode($prev, $prev-Target, $prev-Node)
     - joinTargetNode($next, $next-Target, $next-Node)
 - name: 'PrimaryIndex transitions to ABSENT uphold 2-version invariant: VALIDATED->WRITE_ONLY'
@@ -652,7 +453,7 @@ deprules
     - $prev-Target[TargetStatus] = ABSENT
     - $prev-Node[CurrentStatus] = VALIDATED
     - $next-Node[CurrentStatus] = WRITE_ONLY
-    - DescriptorIsNotBeingDropped($prev)
+    - descriptorIsNotBeingDropped-22.2($prev)
     - nodeNotExistsWithStatusIn_TRANSIENT_VALIDATED($prev-Target)
     - joinTargetNode($prev, $prev-Target, $prev-Node)
     - joinTargetNode($next, $next-Target, $next-Node)
@@ -669,7 +470,7 @@ deprules
     - $prev-Target[TargetStatus] = ABSENT
     - $prev-Node[CurrentStatus] = WRITE_ONLY
     - $next-Node[CurrentStatus] = DELETE_ONLY
-    - DescriptorIsNotBeingDropped($prev)
+    - descriptorIsNotBeingDropped-22.2($prev)
     - nodeNotExistsWithStatusIn_VALIDATED_TRANSIENT_WRITE_ONLY_MERGE_ONLY_TRANSIENT_MERGE_ONLY_MERGED_TRANSIENT_MERGED($prev-Target)
     - joinTargetNode($prev, $prev-Target, $prev-Node)
     - joinTargetNode($next, $next-Target, $next-Node)
@@ -686,7 +487,7 @@ deprules
     - $prev-Target[TargetStatus] = PUBLIC
     - $prev-Node[CurrentStatus] = ABSENT
     - $next-Node[CurrentStatus] = BACKFILL_ONLY
-    - DescriptorIsNotBeingDropped($prev)
+    - descriptorIsNotBeingDropped-22.2($prev)
     - joinTargetNode($prev, $prev-Target, $prev-Node)
     - joinTargetNode($next, $next-Target, $next-Node)
 - name: 'PrimaryIndex transitions to PUBLIC uphold 2-version invariant: BACKFILLED->DELETE_ONLY'
@@ -702,7 +503,7 @@ deprules
     - $prev-Target[TargetStatus] = PUBLIC
     - $prev-Node[CurrentStatus] = BACKFILLED
     - $next-Node[CurrentStatus] = DELETE_ONLY
-    - DescriptorIsNotBeingDropped($prev)
+    - descriptorIsNotBeingDropped-22.2($prev)
     - joinTargetNode($prev, $prev-Target, $prev-Node)
     - joinTargetNode($next, $next-Target, $next-Node)
 - name: 'PrimaryIndex transitions to PUBLIC uphold 2-version invariant: BACKFILL_ONLY->BACKFILLED'
@@ -718,7 +519,7 @@ deprules
     - $prev-Target[TargetStatus] = PUBLIC
     - $prev-Node[CurrentStatus] = BACKFILL_ONLY
     - $next-Node[CurrentStatus] = BACKFILLED
-    - DescriptorIsNotBeingDropped($prev)
+    - descriptorIsNotBeingDropped-22.2($prev)
     - joinTargetNode($prev, $prev-Target, $prev-Node)
     - joinTargetNode($next, $next-Target, $next-Node)
 - name: 'PrimaryIndex transitions to PUBLIC uphold 2-version invariant: DELETE_ONLY->MERGE_ONLY'
@@ -734,7 +535,7 @@ deprules
     - $prev-Target[TargetStatus] = PUBLIC
     - $prev-Node[CurrentStatus] = DELETE_ONLY
     - $next-Node[CurrentStatus] = MERGE_ONLY
-    - DescriptorIsNotBeingDropped($prev)
+    - descriptorIsNotBeingDropped-22.2($prev)
     - joinTargetNode($prev, $prev-Target, $prev-Node)
     - joinTargetNode($next, $next-Target, $next-Node)
 - name: 'PrimaryIndex transitions to PUBLIC uphold 2-version invariant: MERGED->WRITE_ONLY'
@@ -750,7 +551,7 @@ deprules
     - $prev-Target[TargetStatus] = PUBLIC
     - $prev-Node[CurrentStatus] = MERGED
     - $next-Node[CurrentStatus] = WRITE_ONLY
-    - DescriptorIsNotBeingDropped($prev)
+    - descriptorIsNotBeingDropped-22.2($prev)
     - joinTargetNode($prev, $prev-Target, $prev-Node)
     - joinTargetNode($next, $next-Target, $next-Node)
 - name: 'PrimaryIndex transitions to PUBLIC uphold 2-version invariant: MERGE_ONLY->MERGED'
@@ -766,7 +567,7 @@ deprules
     - $prev-Target[TargetStatus] = PUBLIC
     - $prev-Node[CurrentStatus] = MERGE_ONLY
     - $next-Node[CurrentStatus] = MERGED
-    - DescriptorIsNotBeingDropped($prev)
+    - descriptorIsNotBeingDropped-22.2($prev)
     - joinTargetNode($prev, $prev-Target, $prev-Node)
     - joinTargetNode($next, $next-Target, $next-Node)
 - name: 'PrimaryIndex transitions to PUBLIC uphold 2-version invariant: VALIDATED->PUBLIC'
@@ -782,7 +583,7 @@ deprules
     - $prev-Target[TargetStatus] = PUBLIC
     - $prev-Node[CurrentStatus] = VALIDATED
     - $next-Node[CurrentStatus] = PUBLIC
-    - DescriptorIsNotBeingDropped($prev)
+    - descriptorIsNotBeingDropped-22.2($prev)
     - joinTargetNode($prev, $prev-Target, $prev-Node)
     - joinTargetNode($next, $next-Target, $next-Node)
 - name: 'PrimaryIndex transitions to PUBLIC uphold 2-version invariant: WRITE_ONLY->VALIDATED'
@@ -798,7 +599,7 @@ deprules
     - $prev-Target[TargetStatus] = PUBLIC
     - $prev-Node[CurrentStatus] = WRITE_ONLY
     - $next-Node[CurrentStatus] = VALIDATED
-    - DescriptorIsNotBeingDropped($prev)
+    - descriptorIsNotBeingDropped-22.2($prev)
     - joinTargetNode($prev, $prev-Target, $prev-Node)
     - joinTargetNode($next, $next-Target, $next-Node)
 - name: 'PrimaryIndex transitions to TRANSIENT_ABSENT uphold 2-version invariant: ABSENT->BACKFILL_ONLY'
@@ -814,7 +615,7 @@ deprules
     - $prev-Target[TargetStatus] = TRANSIENT_ABSENT
     - $prev-Node[CurrentStatus] = ABSENT
     - $next-Node[CurrentStatus] = BACKFILL_ONLY
-    - DescriptorIsNotBeingDropped($prev)
+    - descriptorIsNotBeingDropped-22.2($prev)
     - joinTargetNode($prev, $prev-Target, $prev-Node)
     - joinTargetNode($next, $next-Target, $next-Node)
 - name: 'PrimaryIndex transitions to TRANSIENT_ABSENT uphold 2-version invariant: BACKFILLED->DELETE_ONLY'
@@ -830,7 +631,7 @@ deprules
     - $prev-Target[TargetStatus] = TRANSIENT_ABSENT
     - $prev-Node[CurrentStatus] = BACKFILLED
     - $next-Node[CurrentStatus] = DELETE_ONLY
-    - DescriptorIsNotBeingDropped($prev)
+    - descriptorIsNotBeingDropped-22.2($prev)
     - joinTargetNode($prev, $prev-Target, $prev-Node)
     - joinTargetNode($next, $next-Target, $next-Node)
 - name: 'PrimaryIndex transitions to TRANSIENT_ABSENT uphold 2-version invariant: BACKFILL_ONLY->BACKFILLED'
@@ -846,7 +647,7 @@ deprules
     - $prev-Target[TargetStatus] = TRANSIENT_ABSENT
     - $prev-Node[CurrentStatus] = BACKFILL_ONLY
     - $next-Node[CurrentStatus] = BACKFILLED
-    - DescriptorIsNotBeingDropped($prev)
+    - descriptorIsNotBeingDropped-22.2($prev)
     - joinTargetNode($prev, $prev-Target, $prev-Node)
     - joinTargetNode($next, $next-Target, $next-Node)
 - name: 'PrimaryIndex transitions to TRANSIENT_ABSENT uphold 2-version invariant: DELETE_ONLY->MERGE_ONLY'
@@ -862,7 +663,7 @@ deprules
     - $prev-Target[TargetStatus] = TRANSIENT_ABSENT
     - $prev-Node[CurrentStatus] = DELETE_ONLY
     - $next-Node[CurrentStatus] = MERGE_ONLY
-    - DescriptorIsNotBeingDropped($prev)
+    - descriptorIsNotBeingDropped-22.2($prev)
     - joinTargetNode($prev, $prev-Target, $prev-Node)
     - joinTargetNode($next, $next-Target, $next-Node)
 - name: 'PrimaryIndex transitions to TRANSIENT_ABSENT uphold 2-version invariant: MERGED->WRITE_ONLY'
@@ -878,7 +679,7 @@ deprules
     - $prev-Target[TargetStatus] = TRANSIENT_ABSENT
     - $prev-Node[CurrentStatus] = MERGED
     - $next-Node[CurrentStatus] = WRITE_ONLY
-    - DescriptorIsNotBeingDropped($prev)
+    - descriptorIsNotBeingDropped-22.2($prev)
     - joinTargetNode($prev, $prev-Target, $prev-Node)
     - joinTargetNode($next, $next-Target, $next-Node)
 - name: 'PrimaryIndex transitions to TRANSIENT_ABSENT uphold 2-version invariant: MERGE_ONLY->MERGED'
@@ -894,7 +695,7 @@ deprules
     - $prev-Target[TargetStatus] = TRANSIENT_ABSENT
     - $prev-Node[CurrentStatus] = MERGE_ONLY
     - $next-Node[CurrentStatus] = MERGED
-    - DescriptorIsNotBeingDropped($prev)
+    - descriptorIsNotBeingDropped-22.2($prev)
     - joinTargetNode($prev, $prev-Target, $prev-Node)
     - joinTargetNode($next, $next-Target, $next-Node)
 - name: 'PrimaryIndex transitions to TRANSIENT_ABSENT uphold 2-version invariant: PUBLIC->TRANSIENT_VALIDATED'
@@ -910,7 +711,7 @@ deprules
     - $prev-Target[TargetStatus] = TRANSIENT_ABSENT
     - $prev-Node[CurrentStatus] = PUBLIC
     - $next-Node[CurrentStatus] = TRANSIENT_VALIDATED
-    - DescriptorIsNotBeingDropped($prev)
+    - descriptorIsNotBeingDropped-22.2($prev)
     - joinTargetNode($prev, $prev-Target, $prev-Node)
     - joinTargetNode($next, $next-Target, $next-Node)
 - name: 'PrimaryIndex transitions to TRANSIENT_ABSENT uphold 2-version invariant: TRANSIENT_BACKFILLED->TRANSIENT_DELETE_ONLY'
@@ -926,7 +727,7 @@ deprules
     - $prev-Target[TargetStatus] = TRANSIENT_ABSENT
     - $prev-Node[CurrentStatus] = TRANSIENT_BACKFILLED
     - $next-Node[CurrentStatus] = TRANSIENT_DELETE_ONLY
-    - DescriptorIsNotBeingDropped($prev)
+    - descriptorIsNotBeingDropped-22.2($prev)
     - joinTargetNode($prev, $prev-Target, $prev-Node)
     - joinTargetNode($next, $next-Target, $next-Node)
 - name: 'PrimaryIndex transitions to TRANSIENT_ABSENT uphold 2-version invariant: TRANSIENT_BACKFILL_ONLY->TRANSIENT_DELETE_ONLY'
@@ -942,7 +743,7 @@ deprules
     - $prev-Target[TargetStatus] = TRANSIENT_ABSENT
     - $prev-Node[CurrentStatus] = TRANSIENT_BACKFILL_ONLY
     - $next-Node[CurrentStatus] = TRANSIENT_DELETE_ONLY
-    - DescriptorIsNotBeingDropped($prev)
+    - descriptorIsNotBeingDropped-22.2($prev)
     - joinTargetNode($prev, $prev-Target, $prev-Node)
     - joinTargetNode($next, $next-Target, $next-Node)
 - name: 'PrimaryIndex transitions to TRANSIENT_ABSENT uphold 2-version invariant: TRANSIENT_DELETE_ONLY->TRANSIENT_ABSENT'
@@ -958,7 +759,7 @@ deprules
     - $prev-Target[TargetStatus] = TRANSIENT_ABSENT
     - $prev-Node[CurrentStatus] = TRANSIENT_DELETE_ONLY
     - $next-Node[CurrentStatus] = TRANSIENT_ABSENT
-    - DescriptorIsNotBeingDropped($prev)
+    - descriptorIsNotBeingDropped-22.2($prev)
     - nodeNotExistsWithStatusIn_TRANSIENT_BACKFILLED_TRANSIENT_BACKFILL_ONLY($prev-Target)
     - joinTargetNode($prev, $prev-Target, $prev-Node)
     - joinTargetNode($next, $next-Target, $next-Node)
@@ -975,7 +776,7 @@ deprules
     - $prev-Target[TargetStatus] = TRANSIENT_ABSENT
     - $prev-Node[CurrentStatus] = TRANSIENT_MERGED
     - $next-Node[CurrentStatus] = TRANSIENT_WRITE_ONLY
-    - DescriptorIsNotBeingDropped($prev)
+    - descriptorIsNotBeingDropped-22.2($prev)
     - joinTargetNode($prev, $prev-Target, $prev-Node)
     - joinTargetNode($next, $next-Target, $next-Node)
 - name: 'PrimaryIndex transitions to TRANSIENT_ABSENT uphold 2-version invariant: TRANSIENT_MERGE_ONLY->TRANSIENT_WRITE_ONLY'
@@ -991,7 +792,7 @@ deprules
     - $prev-Target[TargetStatus] = TRANSIENT_ABSENT
     - $prev-Node[CurrentStatus] = TRANSIENT_MERGE_ONLY
     - $next-Node[CurrentStatus] = TRANSIENT_WRITE_ONLY
-    - DescriptorIsNotBeingDropped($prev)
+    - descriptorIsNotBeingDropped-22.2($prev)
     - joinTargetNode($prev, $prev-Target, $prev-Node)
     - joinTargetNode($next, $next-Target, $next-Node)
 - name: 'PrimaryIndex transitions to TRANSIENT_ABSENT uphold 2-version invariant: TRANSIENT_VALIDATED->TRANSIENT_WRITE_ONLY'
@@ -1007,7 +808,7 @@ deprules
     - $prev-Target[TargetStatus] = TRANSIENT_ABSENT
     - $prev-Node[CurrentStatus] = TRANSIENT_VALIDATED
     - $next-Node[CurrentStatus] = TRANSIENT_WRITE_ONLY
-    - DescriptorIsNotBeingDropped($prev)
+    - descriptorIsNotBeingDropped-22.2($prev)
     - joinTargetNode($prev, $prev-Target, $prev-Node)
     - joinTargetNode($next, $next-Target, $next-Node)
 - name: 'PrimaryIndex transitions to TRANSIENT_ABSENT uphold 2-version invariant: TRANSIENT_WRITE_ONLY->TRANSIENT_DELETE_ONLY'
@@ -1023,7 +824,7 @@ deprules
     - $prev-Target[TargetStatus] = TRANSIENT_ABSENT
     - $prev-Node[CurrentStatus] = TRANSIENT_WRITE_ONLY
     - $next-Node[CurrentStatus] = TRANSIENT_DELETE_ONLY
-    - DescriptorIsNotBeingDropped($prev)
+    - descriptorIsNotBeingDropped-22.2($prev)
     - nodeNotExistsWithStatusIn_TRANSIENT_VALIDATED_TRANSIENT_MERGE_ONLY_TRANSIENT_MERGED($prev-Target)
     - joinTargetNode($prev, $prev-Target, $prev-Node)
     - joinTargetNode($next, $next-Target, $next-Node)
@@ -1040,7 +841,7 @@ deprules
     - $prev-Target[TargetStatus] = TRANSIENT_ABSENT
     - $prev-Node[CurrentStatus] = VALIDATED
     - $next-Node[CurrentStatus] = PUBLIC
-    - DescriptorIsNotBeingDropped($prev)
+    - descriptorIsNotBeingDropped-22.2($prev)
     - joinTargetNode($prev, $prev-Target, $prev-Node)
     - joinTargetNode($next, $next-Target, $next-Node)
 - name: 'PrimaryIndex transitions to TRANSIENT_ABSENT uphold 2-version invariant: WRITE_ONLY->VALIDATED'
@@ -1056,7 +857,7 @@ deprules
     - $prev-Target[TargetStatus] = TRANSIENT_ABSENT
     - $prev-Node[CurrentStatus] = WRITE_ONLY
     - $next-Node[CurrentStatus] = VALIDATED
-    - DescriptorIsNotBeingDropped($prev)
+    - descriptorIsNotBeingDropped-22.2($prev)
     - joinTargetNode($prev, $prev-Target, $prev-Node)
     - joinTargetNode($next, $next-Target, $next-Node)
 - name: 'SecondaryIndex transitions to ABSENT uphold 2-version invariant: BACKFILLED->DELETE_ONLY'
@@ -1072,7 +873,7 @@ deprules
     - $prev-Target[TargetStatus] = ABSENT
     - $prev-Node[CurrentStatus] = BACKFILLED
     - $next-Node[CurrentStatus] = DELETE_ONLY
-    - DescriptorIsNotBeingDropped($prev)
+    - descriptorIsNotBeingDropped-22.2($prev)
     - joinTargetNode($prev, $prev-Target, $prev-Node)
     - joinTargetNode($next, $next-Target, $next-Node)
 - name: 'SecondaryIndex transitions to ABSENT uphold 2-version invariant: BACKFILL_ONLY->DELETE_ONLY'
@@ -1088,7 +889,7 @@ deprules
     - $prev-Target[TargetStatus] = ABSENT
     - $prev-Node[CurrentStatus] = BACKFILL_ONLY
     - $next-Node[CurrentStatus] = DELETE_ONLY
-    - DescriptorIsNotBeingDropped($prev)
+    - descriptorIsNotBeingDropped-22.2($prev)
     - joinTargetNode($prev, $prev-Target, $prev-Node)
     - joinTargetNode($next, $next-Target, $next-Node)
 - name: 'SecondaryIndex transitions to ABSENT uphold 2-version invariant: DELETE_ONLY->ABSENT'
@@ -1104,7 +905,7 @@ deprules
     - $prev-Target[TargetStatus] = ABSENT
     - $prev-Node[CurrentStatus] = DELETE_ONLY
     - $next-Node[CurrentStatus] = ABSENT
-    - DescriptorIsNotBeingDropped($prev)
+    - descriptorIsNotBeingDropped-22.2($prev)
     - nodeNotExistsWithStatusIn_BACKFILLED_BACKFILL_ONLY($prev-Target)
     - joinTargetNode($prev, $prev-Target, $prev-Node)
     - joinTargetNode($next, $next-Target, $next-Node)
@@ -1121,7 +922,7 @@ deprules
     - $prev-Target[TargetStatus] = ABSENT
     - $prev-Node[CurrentStatus] = MERGED
     - $next-Node[CurrentStatus] = WRITE_ONLY
-    - DescriptorIsNotBeingDropped($prev)
+    - descriptorIsNotBeingDropped-22.2($prev)
     - joinTargetNode($prev, $prev-Target, $prev-Node)
     - joinTargetNode($next, $next-Target, $next-Node)
 - name: 'SecondaryIndex transitions to ABSENT uphold 2-version invariant: MERGE_ONLY->WRITE_ONLY'
@@ -1137,7 +938,7 @@ deprules
     - $prev-Target[TargetStatus] = ABSENT
     - $prev-Node[CurrentStatus] = MERGE_ONLY
     - $next-Node[CurrentStatus] = WRITE_ONLY
-    - DescriptorIsNotBeingDropped($prev)
+    - descriptorIsNotBeingDropped-22.2($prev)
     - joinTargetNode($prev, $prev-Target, $prev-Node)
     - joinTargetNode($next, $next-Target, $next-Node)
 - name: 'SecondaryIndex transitions to ABSENT uphold 2-version invariant: PUBLIC->VALIDATED'
@@ -1153,7 +954,7 @@ deprules
     - $prev-Target[TargetStatus] = ABSENT
     - $prev-Node[CurrentStatus] = PUBLIC
     - $next-Node[CurrentStatus] = VALIDATED
-    - DescriptorIsNotBeingDropped($prev)
+    - descriptorIsNotBeingDropped-22.2($prev)
     - joinTargetNode($prev, $prev-Target, $prev-Node)
     - joinTargetNode($next, $next-Target, $next-Node)
 - name: 'SecondaryIndex transitions to ABSENT uphold 2-version invariant: VALIDATED->WRITE_ONLY'
@@ -1169,7 +970,7 @@ deprules
     - $prev-Target[TargetStatus] = ABSENT
     - $prev-Node[CurrentStatus] = VALIDATED
     - $next-Node[CurrentStatus] = WRITE_ONLY
-    - DescriptorIsNotBeingDropped($prev)
+    - descriptorIsNotBeingDropped-22.2($prev)
     - joinTargetNode($prev, $prev-Target, $prev-Node)
     - joinTargetNode($next, $next-Target, $next-Node)
 - name: 'SecondaryIndex transitions to ABSENT uphold 2-version invariant: WRITE_ONLY->DELETE_ONLY'
@@ -1185,7 +986,7 @@ deprules
     - $prev-Target[TargetStatus] = ABSENT
     - $prev-Node[CurrentStatus] = WRITE_ONLY
     - $next-Node[CurrentStatus] = DELETE_ONLY
-    - DescriptorIsNotBeingDropped($prev)
+    - descriptorIsNotBeingDropped-22.2($prev)
     - nodeNotExistsWithStatusIn_VALIDATED_MERGE_ONLY_MERGED($prev-Target)
     - joinTargetNode($prev, $prev-Target, $prev-Node)
     - joinTargetNode($next, $next-Target, $next-Node)
@@ -1202,7 +1003,7 @@ deprules
     - $prev-Target[TargetStatus] = PUBLIC
     - $prev-Node[CurrentStatus] = ABSENT
     - $next-Node[CurrentStatus] = BACKFILL_ONLY
-    - DescriptorIsNotBeingDropped($prev)
+    - descriptorIsNotBeingDropped-22.2($prev)
     - joinTargetNode($prev, $prev-Target, $prev-Node)
     - joinTargetNode($next, $next-Target, $next-Node)
 - name: 'SecondaryIndex transitions to PUBLIC uphold 2-version invariant: BACKFILLED->DELETE_ONLY'
@@ -1218,7 +1019,7 @@ deprules
     - $prev-Target[TargetStatus] = PUBLIC
     - $prev-Node[CurrentStatus] = BACKFILLED
     - $next-Node[CurrentStatus] = DELETE_ONLY
-    - DescriptorIsNotBeingDropped($prev)
+    - descriptorIsNotBeingDropped-22.2($prev)
     - joinTargetNode($prev, $prev-Target, $prev-Node)
     - joinTargetNode($next, $next-Target, $next-Node)
 - name: 'SecondaryIndex transitions to PUBLIC uphold 2-version invariant: BACKFILL_ONLY->BACKFILLED'
@@ -1234,7 +1035,7 @@ deprules
     - $prev-Target[TargetStatus] = PUBLIC
     - $prev-Node[CurrentStatus] = BACKFILL_ONLY
     - $next-Node[CurrentStatus] = BACKFILLED
-    - DescriptorIsNotBeingDropped($prev)
+    - descriptorIsNotBeingDropped-22.2($prev)
     - joinTargetNode($prev, $prev-Target, $prev-Node)
     - joinTargetNode($next, $next-Target, $next-Node)
 - name: 'SecondaryIndex transitions to PUBLIC uphold 2-version invariant: DELETE_ONLY->MERGE_ONLY'
@@ -1250,7 +1051,7 @@ deprules
     - $prev-Target[TargetStatus] = PUBLIC
     - $prev-Node[CurrentStatus] = DELETE_ONLY
     - $next-Node[CurrentStatus] = MERGE_ONLY
-    - DescriptorIsNotBeingDropped($prev)
+    - descriptorIsNotBeingDropped-22.2($prev)
     - joinTargetNode($prev, $prev-Target, $prev-Node)
     - joinTargetNode($next, $next-Target, $next-Node)
 - name: 'SecondaryIndex transitions to PUBLIC uphold 2-version invariant: MERGED->WRITE_ONLY'
@@ -1266,7 +1067,7 @@ deprules
     - $prev-Target[TargetStatus] = PUBLIC
     - $prev-Node[CurrentStatus] = MERGED
     - $next-Node[CurrentStatus] = WRITE_ONLY
-    - DescriptorIsNotBeingDropped($prev)
+    - descriptorIsNotBeingDropped-22.2($prev)
     - joinTargetNode($prev, $prev-Target, $prev-Node)
     - joinTargetNode($next, $next-Target, $next-Node)
 - name: 'SecondaryIndex transitions to PUBLIC uphold 2-version invariant: MERGE_ONLY->MERGED'
@@ -1282,7 +1083,7 @@ deprules
     - $prev-Target[TargetStatus] = PUBLIC
     - $prev-Node[CurrentStatus] = MERGE_ONLY
     - $next-Node[CurrentStatus] = MERGED
-    - DescriptorIsNotBeingDropped($prev)
+    - descriptorIsNotBeingDropped-22.2($prev)
     - joinTargetNode($prev, $prev-Target, $prev-Node)
     - joinTargetNode($next, $next-Target, $next-Node)
 - name: 'SecondaryIndex transitions to PUBLIC uphold 2-version invariant: VALIDATED->PUBLIC'
@@ -1298,7 +1099,7 @@ deprules
     - $prev-Target[TargetStatus] = PUBLIC
     - $prev-Node[CurrentStatus] = VALIDATED
     - $next-Node[CurrentStatus] = PUBLIC
-    - DescriptorIsNotBeingDropped($prev)
+    - descriptorIsNotBeingDropped-22.2($prev)
     - joinTargetNode($prev, $prev-Target, $prev-Node)
     - joinTargetNode($next, $next-Target, $next-Node)
 - name: 'SecondaryIndex transitions to PUBLIC uphold 2-version invariant: WRITE_ONLY->VALIDATED'
@@ -1314,7 +1115,7 @@ deprules
     - $prev-Target[TargetStatus] = PUBLIC
     - $prev-Node[CurrentStatus] = WRITE_ONLY
     - $next-Node[CurrentStatus] = VALIDATED
-    - DescriptorIsNotBeingDropped($prev)
+    - descriptorIsNotBeingDropped-22.2($prev)
     - joinTargetNode($prev, $prev-Target, $prev-Node)
     - joinTargetNode($next, $next-Target, $next-Node)
 - name: 'TemporaryIndex transitions to ABSENT uphold 2-version invariant: DELETE_ONLY->ABSENT'
@@ -1330,7 +1131,7 @@ deprules
     - $prev-Target[TargetStatus] = ABSENT
     - $prev-Node[CurrentStatus] = DELETE_ONLY
     - $next-Node[CurrentStatus] = ABSENT
-    - DescriptorIsNotBeingDropped($prev)
+    - descriptorIsNotBeingDropped-22.2($prev)
     - nodeNotExistsWithStatusIn_TRANSIENT_DELETE_ONLY($prev-Target)
     - joinTargetNode($prev, $prev-Target, $prev-Node)
     - joinTargetNode($next, $next-Target, $next-Node)
@@ -1347,7 +1148,7 @@ deprules
     - $prev-Target[TargetStatus] = ABSENT
     - $prev-Node[CurrentStatus] = TRANSIENT_ABSENT
     - $next-Node[CurrentStatus] = ABSENT
-    - DescriptorIsNotBeingDropped($prev)
+    - descriptorIsNotBeingDropped-22.2($prev)
     - joinTargetNode($prev, $prev-Target, $prev-Node)
     - joinTargetNode($next, $next-Target, $next-Node)
 - name: 'TemporaryIndex transitions to ABSENT uphold 2-version invariant: TRANSIENT_DELETE_ONLY->DELETE_ONLY'
@@ -1363,7 +1164,7 @@ deprules
     - $prev-Target[TargetStatus] = ABSENT
     - $prev-Node[CurrentStatus] = TRANSIENT_DELETE_ONLY
     - $next-Node[CurrentStatus] = DELETE_ONLY
-    - DescriptorIsNotBeingDropped($prev)
+    - descriptorIsNotBeingDropped-22.2($prev)
     - joinTargetNode($prev, $prev-Target, $prev-Node)
     - joinTargetNode($next, $next-Target, $next-Node)
 - name: 'TemporaryIndex transitions to ABSENT uphold 2-version invariant: WRITE_ONLY->DELETE_ONLY'
@@ -1379,7 +1180,7 @@ deprules
     - $prev-Target[TargetStatus] = ABSENT
     - $prev-Node[CurrentStatus] = WRITE_ONLY
     - $next-Node[CurrentStatus] = DELETE_ONLY
-    - DescriptorIsNotBeingDropped($prev)
+    - descriptorIsNotBeingDropped-22.2($prev)
     - joinTargetNode($prev, $prev-Target, $prev-Node)
     - joinTargetNode($next, $next-Target, $next-Node)
 - name: 'TemporaryIndex transitions to TRANSIENT_ABSENT uphold 2-version invariant: ABSENT->DELETE_ONLY'
@@ -1395,7 +1196,7 @@ deprules
     - $prev-Target[TargetStatus] = TRANSIENT_ABSENT
     - $prev-Node[CurrentStatus] = ABSENT
     - $next-Node[CurrentStatus] = DELETE_ONLY
-    - DescriptorIsNotBeingDropped($prev)
+    - descriptorIsNotBeingDropped-22.2($prev)
     - joinTargetNode($prev, $prev-Target, $prev-Node)
     - joinTargetNode($next, $next-Target, $next-Node)
 - name: 'TemporaryIndex transitions to TRANSIENT_ABSENT uphold 2-version invariant: DELETE_ONLY->WRITE_ONLY'
@@ -1411,7 +1212,7 @@ deprules
     - $prev-Target[TargetStatus] = TRANSIENT_ABSENT
     - $prev-Node[CurrentStatus] = DELETE_ONLY
     - $next-Node[CurrentStatus] = WRITE_ONLY
-    - DescriptorIsNotBeingDropped($prev)
+    - descriptorIsNotBeingDropped-22.2($prev)
     - joinTargetNode($prev, $prev-Target, $prev-Node)
     - joinTargetNode($next, $next-Target, $next-Node)
 - name: 'TemporaryIndex transitions to TRANSIENT_ABSENT uphold 2-version invariant: TRANSIENT_DELETE_ONLY->TRANSIENT_ABSENT'
@@ -1427,7 +1228,7 @@ deprules
     - $prev-Target[TargetStatus] = TRANSIENT_ABSENT
     - $prev-Node[CurrentStatus] = TRANSIENT_DELETE_ONLY
     - $next-Node[CurrentStatus] = TRANSIENT_ABSENT
-    - DescriptorIsNotBeingDropped($prev)
+    - descriptorIsNotBeingDropped-22.2($prev)
     - joinTargetNode($prev, $prev-Target, $prev-Node)
     - joinTargetNode($next, $next-Target, $next-Node)
 - name: 'TemporaryIndex transitions to TRANSIENT_ABSENT uphold 2-version invariant: WRITE_ONLY->TRANSIENT_DELETE_ONLY'
@@ -1443,104 +1244,7 @@ deprules
     - $prev-Target[TargetStatus] = TRANSIENT_ABSENT
     - $prev-Node[CurrentStatus] = WRITE_ONLY
     - $next-Node[CurrentStatus] = TRANSIENT_DELETE_ONLY
-    - DescriptorIsNotBeingDropped($prev)
-    - joinTargetNode($prev, $prev-Target, $prev-Node)
-    - joinTargetNode($next, $next-Target, $next-Node)
-- name: 'UniqueWithoutIndexConstraint transitions to ABSENT uphold 2-version invariant: PUBLIC->VALIDATED'
-  from: prev-Node
-  kind: PreviousTransactionPrecedence
-  to: next-Node
-  query:
-    - $prev[Type] = '*scpb.UniqueWithoutIndexConstraint'
-    - $next[Type] = '*scpb.UniqueWithoutIndexConstraint'
-    - $prev[DescID] = $_
-    - $prev[Self] = $next
-    - $prev-Target[Self] = $next-Target
-    - $prev-Target[TargetStatus] = ABSENT
-    - $prev-Node[CurrentStatus] = PUBLIC
-    - $next-Node[CurrentStatus] = VALIDATED
-    - DescriptorIsNotBeingDropped($prev)
-    - joinTargetNode($prev, $prev-Target, $prev-Node)
-    - joinTargetNode($next, $next-Target, $next-Node)
-- name: 'UniqueWithoutIndexConstraint transitions to ABSENT uphold 2-version invariant: VALIDATED->ABSENT'
-  from: prev-Node
-  kind: PreviousTransactionPrecedence
-  to: next-Node
-  query:
-    - $prev[Type] = '*scpb.UniqueWithoutIndexConstraint'
-    - $next[Type] = '*scpb.UniqueWithoutIndexConstraint'
-    - $prev[DescID] = $_
-    - $prev[Self] = $next
-    - $prev-Target[Self] = $next-Target
-    - $prev-Target[TargetStatus] = ABSENT
-    - $prev-Node[CurrentStatus] = VALIDATED
-    - $next-Node[CurrentStatus] = ABSENT
-    - DescriptorIsNotBeingDropped($prev)
-    - nodeNotExistsWithStatusIn_WRITE_ONLY($prev-Target)
-    - joinTargetNode($prev, $prev-Target, $prev-Node)
-    - joinTargetNode($next, $next-Target, $next-Node)
-- name: 'UniqueWithoutIndexConstraint transitions to ABSENT uphold 2-version invariant: WRITE_ONLY->VALIDATED'
-  from: prev-Node
-  kind: PreviousTransactionPrecedence
-  to: next-Node
-  query:
-    - $prev[Type] = '*scpb.UniqueWithoutIndexConstraint'
-    - $next[Type] = '*scpb.UniqueWithoutIndexConstraint'
-    - $prev[DescID] = $_
-    - $prev[Self] = $next
-    - $prev-Target[Self] = $next-Target
-    - $prev-Target[TargetStatus] = ABSENT
-    - $prev-Node[CurrentStatus] = WRITE_ONLY
-    - $next-Node[CurrentStatus] = VALIDATED
-    - DescriptorIsNotBeingDropped($prev)
-    - joinTargetNode($prev, $prev-Target, $prev-Node)
-    - joinTargetNode($next, $next-Target, $next-Node)
-- name: 'UniqueWithoutIndexConstraint transitions to PUBLIC uphold 2-version invariant: ABSENT->WRITE_ONLY'
-  from: prev-Node
-  kind: PreviousTransactionPrecedence
-  to: next-Node
-  query:
-    - $prev[Type] = '*scpb.UniqueWithoutIndexConstraint'
-    - $next[Type] = '*scpb.UniqueWithoutIndexConstraint'
-    - $prev[DescID] = $_
-    - $prev[Self] = $next
-    - $prev-Target[Self] = $next-Target
-    - $prev-Target[TargetStatus] = PUBLIC
-    - $prev-Node[CurrentStatus] = ABSENT
-    - $next-Node[CurrentStatus] = WRITE_ONLY
-    - DescriptorIsNotBeingDropped($prev)
-    - joinTargetNode($prev, $prev-Target, $prev-Node)
-    - joinTargetNode($next, $next-Target, $next-Node)
-- name: 'UniqueWithoutIndexConstraint transitions to PUBLIC uphold 2-version invariant: VALIDATED->PUBLIC'
-  from: prev-Node
-  kind: PreviousTransactionPrecedence
-  to: next-Node
-  query:
-    - $prev[Type] = '*scpb.UniqueWithoutIndexConstraint'
-    - $next[Type] = '*scpb.UniqueWithoutIndexConstraint'
-    - $prev[DescID] = $_
-    - $prev[Self] = $next
-    - $prev-Target[Self] = $next-Target
-    - $prev-Target[TargetStatus] = PUBLIC
-    - $prev-Node[CurrentStatus] = VALIDATED
-    - $next-Node[CurrentStatus] = PUBLIC
-    - DescriptorIsNotBeingDropped($prev)
-    - joinTargetNode($prev, $prev-Target, $prev-Node)
-    - joinTargetNode($next, $next-Target, $next-Node)
-- name: 'UniqueWithoutIndexConstraint transitions to PUBLIC uphold 2-version invariant: WRITE_ONLY->VALIDATED'
-  from: prev-Node
-  kind: PreviousTransactionPrecedence
-  to: next-Node
-  query:
-    - $prev[Type] = '*scpb.UniqueWithoutIndexConstraint'
-    - $next[Type] = '*scpb.UniqueWithoutIndexConstraint'
-    - $prev[DescID] = $_
-    - $prev[Self] = $next
-    - $prev-Target[Self] = $next-Target
-    - $prev-Target[TargetStatus] = PUBLIC
-    - $prev-Node[CurrentStatus] = WRITE_ONLY
-    - $next-Node[CurrentStatus] = VALIDATED
-    - DescriptorIsNotBeingDropped($prev)
+    - descriptorIsNotBeingDropped-22.2($prev)
     - joinTargetNode($prev, $prev-Target, $prev-Node)
     - joinTargetNode($next, $next-Target, $next-Node)
 - name: column dependents exist before column becomes public
@@ -1697,7 +1401,7 @@ deprules
   to: column-Node
   query:
     - $column-type[Type] = '*scpb.ColumnType'
-    - DescriptorIsNotBeingDropped($column-type)
+    - descriptorIsNotBeingDropped-22.2($column-type)
     - $column[Type] = '*scpb.Column'
     - joinOnColumnID($column-type, $column, $table-id, $col-id)
     - toAbsent($column-type-Target, $column-Target)
@@ -1939,7 +1643,7 @@ deprules
   kind: PreviousTransactionPrecedence
   to: absent-Node
   query:
-    - $dropped[Type] IN ['*scpb.Database', '*scpb.Schema', '*scpb.View', '*scpb.Sequence', '*scpb.Table', '*scpb.EnumType', '*scpb.AliasType', '*scpb.CompositeType']
+    - $dropped[Type] IN ['*scpb.Database', '*scpb.Schema', '*scpb.View', '*scpb.Sequence', '*scpb.Table', '*scpb.EnumType', '*scpb.AliasType']
     - $dropped[DescID] = $_
     - $dropped[Self] = $absent
     - toAbsent($dropped-Target, $absent-Target)
@@ -1952,7 +1656,7 @@ deprules
   kind: PreviousStagePrecedence
   to: dropped-Node
   query:
-    - $txn_dropped[Type] IN ['*scpb.Database', '*scpb.Schema', '*scpb.View', '*scpb.Sequence', '*scpb.Table', '*scpb.EnumType', '*scpb.AliasType', '*scpb.CompositeType']
+    - $txn_dropped[Type] IN ['*scpb.Database', '*scpb.Schema', '*scpb.View', '*scpb.Sequence', '*scpb.Table', '*scpb.EnumType', '*scpb.AliasType']
     - $txn_dropped[DescID] = $_
     - $txn_dropped[Self] = $dropped
     - toAbsent($txn_dropped-Target, $dropped-Target)
@@ -1965,8 +1669,8 @@ deprules
   kind: SameStagePrecedence
   to: dependent-Node
   query:
-    - $descriptor[Type] IN ['*scpb.Database', '*scpb.Schema', '*scpb.View', '*scpb.Sequence', '*scpb.Table', '*scpb.EnumType', '*scpb.AliasType', '*scpb.CompositeType']
-    - $dependent[Type] IN ['*scpb.ColumnFamily', '*scpb.TableComment', '*scpb.RowLevelTTL', '*scpb.TableZoneConfig', '*scpb.TablePartitioning', '*scpb.TableLocalityGlobal', '*scpb.TableLocalityPrimaryRegion', '*scpb.TableLocalitySecondaryRegion', '*scpb.TableLocalityRegionalByRow', '*scpb.ColumnName', '*scpb.ColumnType', '*scpb.ColumnDefaultExpression', '*scpb.ColumnOnUpdateExpression', '*scpb.SequenceOwner', '*scpb.ColumnComment', '*scpb.IndexName', '*scpb.IndexPartitioning', '*scpb.SecondaryIndexPartial', '*scpb.IndexComment', '*scpb.IndexColumn', '*scpb.ConstraintWithoutIndexName', '*scpb.ConstraintComment', '*scpb.Namespace', '*scpb.Owner', '*scpb.UserPrivileges', '*scpb.DatabaseRegionConfig', '*scpb.DatabaseRoleSetting', '*scpb.DatabaseComment', '*scpb.SchemaParent', '*scpb.SchemaComment', '*scpb.ObjectParent', '*scpb.EnumTypeValue', '*scpb.CompositeTypeAttrType', '*scpb.CompositeTypeAttrName']
+    - $descriptor[Type] IN ['*scpb.Database', '*scpb.Schema', '*scpb.View', '*scpb.Sequence', '*scpb.Table', '*scpb.EnumType', '*scpb.AliasType']
+    - $dependent[Type] IN ['*scpb.ColumnFamily', '*scpb.UniqueWithoutIndexConstraint', '*scpb.CheckConstraint', '*scpb.ForeignKeyConstraint', '*scpb.TableComment', '*scpb.RowLevelTTL', '*scpb.TableZoneConfig', '*scpb.TableLocalityGlobal', '*scpb.TableLocalityPrimaryRegion', '*scpb.TableLocalitySecondaryRegion', '*scpb.TableLocalityRegionalByRow', '*scpb.ColumnName', '*scpb.ColumnType', '*scpb.ColumnDefaultExpression', '*scpb.ColumnOnUpdateExpression', '*scpb.SequenceOwner', '*scpb.ColumnComment', '*scpb.IndexName', '*scpb.IndexPartitioning', '*scpb.SecondaryIndexPartial', '*scpb.IndexComment', '*scpb.IndexColumn', '*scpb.ConstraintWithoutIndexName', '*scpb.ConstraintComment', '*scpb.Namespace', '*scpb.Owner', '*scpb.UserPrivileges', '*scpb.DatabaseRegionConfig', '*scpb.DatabaseRoleSetting', '*scpb.DatabaseComment', '*scpb.SchemaParent', '*scpb.SchemaComment', '*scpb.ObjectParent', '*scpb.EnumTypeValue']
     - joinOnDescID($descriptor, $dependent, $desc-id)
     - toAbsent($descriptor-Target, $dependent-Target)
     - $descriptor-Node[CurrentStatus] = DROPPED
@@ -1979,8 +1683,8 @@ deprules
   kind: SameStagePrecedence
   to: referencing-via-attr-Node
   query:
-    - $referenced-descriptor[Type] IN ['*scpb.Database', '*scpb.Schema', '*scpb.View', '*scpb.Sequence', '*scpb.Table', '*scpb.EnumType', '*scpb.AliasType', '*scpb.CompositeType']
-    - $referencing-via-attr[Type] IN ['*scpb.ColumnFamily', '*scpb.TableComment', '*scpb.RowLevelTTL', '*scpb.TableZoneConfig', '*scpb.TablePartitioning', '*scpb.TableLocalityGlobal', '*scpb.TableLocalityPrimaryRegion', '*scpb.TableLocalitySecondaryRegion', '*scpb.TableLocalityRegionalByRow', '*scpb.ColumnName', '*scpb.ColumnType', '*scpb.ColumnDefaultExpression', '*scpb.ColumnOnUpdateExpression', '*scpb.SequenceOwner', '*scpb.ColumnComment', '*scpb.IndexName', '*scpb.IndexPartitioning', '*scpb.SecondaryIndexPartial', '*scpb.IndexComment', '*scpb.IndexColumn', '*scpb.ConstraintWithoutIndexName', '*scpb.ConstraintComment', '*scpb.Namespace', '*scpb.Owner', '*scpb.UserPrivileges', '*scpb.DatabaseRegionConfig', '*scpb.DatabaseRoleSetting', '*scpb.DatabaseComment', '*scpb.SchemaParent', '*scpb.SchemaComment', '*scpb.ObjectParent', '*scpb.EnumTypeValue', '*scpb.CompositeTypeAttrType', '*scpb.CompositeTypeAttrName']
+    - $referenced-descriptor[Type] IN ['*scpb.Database', '*scpb.Schema', '*scpb.View', '*scpb.Sequence', '*scpb.Table', '*scpb.EnumType', '*scpb.AliasType']
+    - $referencing-via-attr[Type] IN ['*scpb.ColumnFamily', '*scpb.UniqueWithoutIndexConstraint', '*scpb.CheckConstraint', '*scpb.ForeignKeyConstraint', '*scpb.TableComment', '*scpb.RowLevelTTL', '*scpb.TableZoneConfig', '*scpb.TableLocalityGlobal', '*scpb.TableLocalityPrimaryRegion', '*scpb.TableLocalitySecondaryRegion', '*scpb.TableLocalityRegionalByRow', '*scpb.ColumnName', '*scpb.ColumnType', '*scpb.ColumnDefaultExpression', '*scpb.ColumnOnUpdateExpression', '*scpb.SequenceOwner', '*scpb.ColumnComment', '*scpb.IndexName', '*scpb.IndexPartitioning', '*scpb.SecondaryIndexPartial', '*scpb.IndexComment', '*scpb.IndexColumn', '*scpb.ConstraintWithoutIndexName', '*scpb.ConstraintComment', '*scpb.Namespace', '*scpb.Owner', '*scpb.UserPrivileges', '*scpb.DatabaseRegionConfig', '*scpb.DatabaseRoleSetting', '*scpb.DatabaseComment', '*scpb.SchemaParent', '*scpb.SchemaComment', '*scpb.ObjectParent', '*scpb.EnumTypeValue']
     - joinReferencedDescID($referencing-via-attr, $referenced-descriptor, $desc-id)
     - toAbsent($referenced-descriptor-Target, $referencing-via-attr-Target)
     - $referenced-descriptor-Node[CurrentStatus] = DROPPED
@@ -1996,7 +1700,7 @@ deprules
     - joinTargetNode($referenced-descriptor, $referenced-descriptor-Target, $referenced-descriptor-Node)
     - $referenced-descriptor[DescID] = $seqID
     - $referencing-via-expr[ReferencedSequenceIDs] CONTAINS $seqID
-    - $referencing-via-expr[Type] IN ['*scpb.ColumnType', '*scpb.ColumnDefaultExpression', '*scpb.ColumnOnUpdateExpression', '*scpb.SecondaryIndexPartial']
+    - $referencing-via-expr[Type] IN ['*scpb.CheckConstraint', '*scpb.ColumnType', '*scpb.ColumnDefaultExpression', '*scpb.ColumnOnUpdateExpression', '*scpb.SecondaryIndexPartial']
     - toAbsent($referenced-descriptor-Target, $referencing-via-expr-Target)
     - $referenced-descriptor-Node[CurrentStatus] = DROPPED
     - $referencing-via-expr-Node[CurrentStatus] = ABSENT
@@ -2007,11 +1711,11 @@ deprules
   kind: SameStagePrecedence
   to: referencing-via-type-Node
   query:
-    - $referenced-descriptor[Type] IN ['*scpb.EnumType', '*scpb.AliasType', '*scpb.CompositeType']
+    - $referenced-descriptor[Type] IN ['*scpb.EnumType', '*scpb.AliasType']
     - joinTargetNode($referenced-descriptor, $referenced-descriptor-Target, $referenced-descriptor-Node)
     - $referenced-descriptor[DescID] = $fromDescID
     - $referencing-via-type[ReferencedTypeIDs] CONTAINS $fromDescID
-    - $referencing-via-type[Type] IN ['*scpb.ColumnType', '*scpb.ColumnDefaultExpression', '*scpb.ColumnOnUpdateExpression', '*scpb.SecondaryIndexPartial']
+    - $referencing-via-type[Type] IN ['*scpb.CheckConstraint', '*scpb.ColumnType', '*scpb.ColumnDefaultExpression', '*scpb.ColumnOnUpdateExpression', '*scpb.SecondaryIndexPartial']
     - toAbsent($referenced-descriptor-Target, $referencing-via-type-Target)
     - $referenced-descriptor-Node[CurrentStatus] = DROPPED
     - $referencing-via-type-Node[CurrentStatus] = ABSENT
@@ -2022,8 +1726,8 @@ deprules
   kind: SameStagePrecedence
   to: idx-or-col-Node
   query:
-    - $descriptor[Type] IN ['*scpb.Database', '*scpb.Schema', '*scpb.View', '*scpb.Sequence', '*scpb.Table', '*scpb.EnumType', '*scpb.AliasType', '*scpb.CompositeType']
-    - $idx-or-col[Type] IN ['*scpb.Column', '*scpb.PrimaryIndex', '*scpb.SecondaryIndex', '*scpb.TemporaryIndex', '*scpb.UniqueWithoutIndexConstraint', '*scpb.CheckConstraint', '*scpb.ForeignKeyConstraint']
+    - $descriptor[Type] IN ['*scpb.Database', '*scpb.Schema', '*scpb.View', '*scpb.Sequence', '*scpb.Table', '*scpb.EnumType', '*scpb.AliasType']
+    - $idx-or-col[Type] IN ['*scpb.Column', '*scpb.PrimaryIndex', '*scpb.SecondaryIndex', '*scpb.TemporaryIndex']
     - joinOnDescID($descriptor, $idx-or-col, $desc-id)
     - toAbsent($descriptor-Target, $idx-or-col-Target)
     - $descriptor-Node[CurrentStatus] = ABSENT
@@ -2174,7 +1878,7 @@ deprules
     - $column[Type] = '*scpb.Column'
     - ColumnInIndex($index-column, $index, $table-id, $column-id, $index-id)
     - joinOnColumnID($index-column, $column, $table-id, $column-id)
-    - DescriptorIsNotBeingDropped($index-column)
+    - descriptorIsNotBeingDropped-22.2($index-column)
     - toAbsent($index-Target, $column-Target)
     - $index-Node[CurrentStatus] = ABSENT
     - $column-Node[CurrentStatus] = ABSENT
@@ -2189,7 +1893,7 @@ deprules
     - $column[Type] = '*scpb.Column'
     - ColumnInIndex($index-column, $index, $table-id, $column-id, $index-id)
     - joinOnColumnID($index-column, $column, $table-id, $column-id)
-    - DescriptorIsNotBeingDropped($index-column)
+    - descriptorIsNotBeingDropped-22.2($index-column)
     - transient($index-Target, $column-Target)
     - $index-Node[CurrentStatus] = TRANSIENT_ABSENT
     - $column-Node[CurrentStatus] = TRANSIENT_ABSENT
@@ -2204,7 +1908,7 @@ deprules
     - $column[Type] = '*scpb.Column'
     - ColumnInIndex($index-column, $index, $table-id, $column-id, $index-id)
     - joinOnColumnID($index-column, $column, $table-id, $column-id)
-    - DescriptorIsNotBeingDropped($index-column)
+    - descriptorIsNotBeingDropped-22.2($index-column)
     - $index-Target[TargetStatus] = TRANSIENT_ABSENT
     - $index-Node[CurrentStatus] = TRANSIENT_ABSENT
     - $column-Target[TargetStatus] = ABSENT
@@ -2220,7 +1924,7 @@ deprules
     - $column[Type] = '*scpb.Column'
     - ColumnInIndex($index-column, $index, $table-id, $column-id, $index-id)
     - joinOnColumnID($index-column, $column, $table-id, $column-id)
-    - DescriptorIsNotBeingDropped($index-column)
+    - descriptorIsNotBeingDropped-22.2($index-column)
     - $index-Target[TargetStatus] = ABSENT
     - $index-Node[CurrentStatus] = ABSENT
     - $column-Target[TargetStatus] = TRANSIENT_ABSENT
@@ -2253,7 +1957,7 @@ deprules
   to: index-Node
   query:
     - $partial-predicate[Type] = '*scpb.SecondaryIndexPartial'
-    - DescriptorIsNotBeingDropped($partial-predicate)
+    - descriptorIsNotBeingDropped-22.2($partial-predicate)
     - $index[Type] = '*scpb.SecondaryIndex'
     - joinOnIndexID($partial-predicate, $index, $table-id, $index-id)
     - toAbsent($partial-predicate-Target, $index-Target)
@@ -2267,7 +1971,7 @@ deprules
   to: index-Node
   query:
     - $partial-predicate[Type] = '*scpb.SecondaryIndexPartial'
-    - DescriptorIsNotBeingDropped($partial-predicate)
+    - descriptorIsNotBeingDropped-22.2($partial-predicate)
     - $index[Type] = '*scpb.SecondaryIndex'
     - joinOnIndexID($partial-predicate, $index, $table-id, $index-id)
     - transient($partial-predicate-Target, $index-Target)
@@ -2281,7 +1985,7 @@ deprules
   to: index-Node
   query:
     - $partial-predicate[Type] = '*scpb.SecondaryIndexPartial'
-    - DescriptorIsNotBeingDropped($partial-predicate)
+    - descriptorIsNotBeingDropped-22.2($partial-predicate)
     - $index[Type] = '*scpb.SecondaryIndex'
     - joinOnIndexID($partial-predicate, $index, $table-id, $index-id)
     - $partial-predicate-Target[TargetStatus] = TRANSIENT_ABSENT
@@ -2296,7 +2000,7 @@ deprules
   to: index-Node
   query:
     - $partial-predicate[Type] = '*scpb.SecondaryIndexPartial'
-    - DescriptorIsNotBeingDropped($partial-predicate)
+    - descriptorIsNotBeingDropped-22.2($partial-predicate)
     - $index[Type] = '*scpb.SecondaryIndex'
     - joinOnIndexID($partial-predicate, $index, $table-id, $index-id)
     - $partial-predicate-Target[TargetStatus] = ABSENT
@@ -2449,7 +2153,7 @@ deprules
     - toAbsent($index-Target, $column-Target)
     - $index-Node[CurrentStatus] = VALIDATED
     - $column-Node[CurrentStatus] = WRITE_ONLY
-    - DescriptorIsNotBeingDropped($index-column)
+    - descriptorIsNotBeingDropped-22.2($index-column)
     - rules.IsIndexKeyColumnKey(*scpb.IndexColumn)($index-column)
     - joinTargetNode($index, $index-Target, $index-Node)
     - joinTargetNode($column, $column-Target, $column-Node)

--- a/pkg/sql/schemachanger/scplan/internal/rules/release_22_2/testdata/oprules
+++ b/pkg/sql/schemachanger/scplan/internal/rules/release_22_2/testdata/oprules
@@ -9,15 +9,15 @@ ColumnInIndex($index-column, $index, $table-id, $column-id, $index-id):
 ColumnInSwappedInPrimaryIndex($index-column, $index, $table-id, $column-id, $index-id):
     - ColumnInIndex($index-column, $index, $table-id, $column-id, $index-id)
     - sourceIndexIsSet($index)
-DescriptorIsNotBeingDropped($element):
-    not-join:
-        - $descriptor[Type] IN ['*scpb.Database', '*scpb.Schema', '*scpb.View', '*scpb.Sequence', '*scpb.Table', '*scpb.EnumType', '*scpb.AliasType', '*scpb.CompositeType']
-        - joinTarget($descriptor, $descriptor-Target)
-        - joinOnDescID($descriptor, $element, $id)
-        - $descriptor-Target[TargetStatus] = ABSENT
 ToPublicOrTransient($target1, $target2):
     - $target1[TargetStatus] IN [PUBLIC, TRANSIENT_ABSENT]
     - $target2[TargetStatus] IN [PUBLIC, TRANSIENT_ABSENT]
+descriptorIsNotBeingDropped-22.2($element):
+    not-join:
+        - $descriptor[Type] IN ['*scpb.Database', '*scpb.Schema', '*scpb.View', '*scpb.Sequence', '*scpb.Table', '*scpb.EnumType', '*scpb.AliasType']
+        - joinTarget($descriptor, $descriptor-Target)
+        - joinOnDescID($descriptor, $element, $id)
+        - $descriptor-Target[TargetStatus] = ABSENT
 fromHasPublicStatusIfFromIsTableAndToIsRowLevelTTL($fromTarget, $fromEl, $toEl):
     not-join:
         - $fromEl[Type] = '*scpb.Table'
@@ -95,11 +95,6 @@ nodeNotExistsWithStatusIn_VALIDATED_TRANSIENT_WRITE_ONLY_MERGE_ONLY_TRANSIENT_ME
         - $n[Type] = '*screl.Node'
         - $n[Target] = $sharedTarget
         - $n[CurrentStatus] IN [VALIDATED, TRANSIENT_WRITE_ONLY, MERGE_ONLY, TRANSIENT_MERGE_ONLY, MERGED, TRANSIENT_MERGED]
-nodeNotExistsWithStatusIn_WRITE_ONLY($sharedTarget):
-    not-join:
-        - $n[Type] = '*screl.Node'
-        - $n[Target] = $sharedTarget
-        - $n[CurrentStatus] IN [WRITE_ONLY]
 sourceIndexIsSet($index):
     - $index[SourceIndexID] != 0
 toAbsent($target1, $target2):
@@ -163,7 +158,7 @@ oprules
 - name: skip element removal ops on descriptor drop
   from: dep-Node
   query:
-    - $desc[Type] IN ['*scpb.Database', '*scpb.Schema', '*scpb.View', '*scpb.Sequence', '*scpb.Table', '*scpb.EnumType', '*scpb.AliasType', '*scpb.CompositeType']
+    - $desc[Type] IN ['*scpb.Database', '*scpb.Schema', '*scpb.View', '*scpb.Sequence', '*scpb.Table', '*scpb.EnumType', '*scpb.AliasType']
     - $dep[Type] IN ['*scpb.ColumnFamily', '*scpb.Owner', '*scpb.UserPrivileges', '*scpb.EnumTypeValue']
     - joinOnDescID($desc, $dep, $desc-id)
     - joinTarget($desc, $desc-Target)

--- a/pkg/sql/schemachanger/scplan/internal/scstage/BUILD.bazel
+++ b/pkg/sql/schemachanger/scplan/internal/scstage/BUILD.bazel
@@ -15,7 +15,7 @@ go_library(
         "//pkg/sql/catalog/descpb",
         "//pkg/sql/schemachanger/scop",
         "//pkg/sql/schemachanger/scpb",
-        "//pkg/sql/schemachanger/scplan/internal/rules",
+        "//pkg/sql/schemachanger/scplan/internal/rules/current",
         "//pkg/sql/schemachanger/scplan/internal/scgraph",
         "//pkg/sql/schemachanger/screl",
         "//pkg/util/iterutil",

--- a/pkg/sql/schemachanger/scplan/internal/scstage/build.go
+++ b/pkg/sql/schemachanger/scplan/internal/scstage/build.go
@@ -21,7 +21,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scop"
 	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scpb"
-	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scplan/internal/rules"
+	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scplan/internal/rules/current"
 	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scplan/internal/scgraph"
 	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/screl"
 	"github.com/cockroachdb/cockroach/pkg/util/iterutil"
@@ -876,7 +876,7 @@ func (bc buildContext) makeDescriptorStates(cur, next *Stage) map[descpb.ID]*scp
 	// if we haven't reached the non-revertible post-commit phase yet.
 	if cur.Phase == scop.PostCommitNonRevertiblePhase {
 		for i, t := range bc.targetState.Targets {
-			if !rules.IsDescriptor(t.Element()) || t.TargetStatus != scpb.Status_ABSENT {
+			if !current.IsDescriptor(t.Element()) || t.TargetStatus != scpb.Status_ABSENT {
 				continue
 			}
 			descID := screl.GetDescID(t.Element())


### PR DESCRIPTION
Previously, the rules helpers were generally shared between releases inside the declarative schema changer. This could be problematic, since some helpers may get modified as new elements get added between releases. To address this, this patch moves most helpers back into individual rules, leaving a small subset as shared.

Additionally, this patch version gates TypeFilter, so that only elements for a given release are visible. When comparing 22.2 versus the compatibility release the majority of differences are now linked with sorting changes and some constraint related adjustments (element renames and minor rules adjustment for ops).

Epic: none
Release note: None