### PR TITLE
colfetcher: disable direct columnar scans for now

### DIFF
--- a/pkg/sql/colfetcher/cfetcher_wrapper.go
+++ b/pkg/sql/colfetcher/cfetcher_wrapper.go
@@ -24,7 +24,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/colmem"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
 	"github.com/cockroachdb/cockroach/pkg/storage"
-	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/mon"
 )
 
@@ -34,15 +33,16 @@ var DirectScansEnabled = settings.RegisterBoolSetting(
 	settings.TenantWritable,
 	"sql.distsql.direct_columnar_scans.enabled",
 	"set to true to enable the 'direct' columnar scans in the KV layer",
-	directScansEnabledDefault,
-)
-
-var directScansEnabledDefault = util.ConstantWithMetamorphicTestBool(
-	"direct-scans-enabled",
-	// TODO(yuzefovich, 23.1): update the default to 'true' for multi-tenant
-	// setups.
 	false,
 )
+
+// TODO(yuzefovich): uncomment this when #95937 is fixed.
+//var directScansEnabledDefault = util.ConstantWithMetamorphicTestBool(
+//	"direct-scans-enabled",
+//	// TODO(yuzefovich, 23.1): update the default to 'true' for multi-tenant
+//	// setups.
+//	false,
+//)
 
 // cFetcherWrapper implements the storage.CFetcherWrapper interface. See a large
 // comment in storage/col_mvcc.go for more details.


### PR DESCRIPTION
This commit disables direct columnar scans which are now randomly enabled in tests due to this feature having a data race at the moment.

Informs: #95937.

Release note: None