### PR TITLE
roachtest/awsdms: fix race condition that can cause panics

### DIFF
--- a/pkg/cmd/roachtest/tests/awsdms.go
+++ b/pkg/cmd/roachtest/tests/awsdms.go
@@ -327,9 +327,11 @@ func checkDMSNoPKTableError(ctx context.Context, t test.Test, dmsCli *dms.Client
 					}
 				}
 				for _, task := range dmsTasks.ReplicationTasks {
-					if task.ReplicationTaskStats.TablesErrored == 1 {
-						t.L().Printf("table error was found")
-						return nil
+					if task.ReplicationTaskStats != nil {
+						if task.ReplicationTaskStats.TablesErrored == 1 {
+							t.L().Printf("table error was found")
+							return nil
+						}
 					}
 				}
 				return errors.New("no table error found yet")


### PR DESCRIPTION
In #95518, we added a new test case to check for a table error during the DMS process. However there is a race when the check happens depending on how quickly tasks have ran and the task ReplicationTaskStats can be nil and we tried to access field on the nil object that was returned from the API call.

This commit checks that the ReplicationTaskStat is not nil before accessing the TablesErrored property.

Fixes: #93305
Release note: None