### PR TITLE
binfetcher: fix binary downloading for arm64 MacOS

### DIFF
--- a/pkg/util/binfetcher/binfetcher.go
+++ b/pkg/util/binfetcher/binfetcher.go
@@ -86,7 +86,11 @@ func (opts *Options) init() error {
 
 			goos := opts.GOOS
 			if opts.GOOS == "darwin" {
-				goos += "-10.9"
+				if opts.GOARCH == "arm64" {
+					goos += "-11.0"
+				} else {
+					goos += "-10.9"
+				}
 			} else if opts.GOOS == "windows" {
 				goos += "-6.2"
 			}


### PR DESCRIPTION
This patch updates the suffix used to fetch arm64 MacOS binaries
to match the naming scheme used to build releases.

Epic: None

Release note: None