### PR TITLE
codeowners: tenant streaming team → disaster recovery

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -173,10 +173,8 @@
 
 /pkg/ccl/jobsccl/            @cockroachdb/jobs-prs
 /pkg/ccl/changefeedccl/      @cockroachdb/cdc-prs
-# TODO(dt): either add the cockroach repository to this team or remove this team from
-# CODEOWNERS.
-#!/pkg/ccl/streamingccl/       @cockroachdb/tenant-streaming
 
+/pkg/ccl/streamingccl/       @cockroachdb/disaster-recovery
 /pkg/ccl/backupccl/          @cockroachdb/disaster-recovery
 /pkg/ccl/backupccl/*_job.go  @cockroachdb/disaster-recovery @cockroachdb/jobs-prs
 /pkg/ccl/storageccl/         @cockroachdb/disaster-recovery

--- a/TEAMS.yaml
+++ b/TEAMS.yaml
@@ -67,8 +67,6 @@ cockroachdb/cdc:
   aliases:
     cockroachdb/cdc-prs: other
   triage_column_id: 3570120
-cockroachdb/tenant-streaming:
-  triage_column_id: 0 # TODO
 cockroachdb/server:
   aliases:
     cockroachdb/cli-prs: other


### PR DESCRIPTION
Cleanup of old CODEOWNERS todo, C2C failures were not notifying the right team. 

Jira: none
Epic: none