### PR TITLE
relase-22.1: backupccl: default `kv.bulkio.write_metadata_sst.enabled` to false

### DIFF
--- a/pkg/ccl/backupccl/backup_metadata_test.go
+++ b/pkg/ccl/backupccl/backup_metadata_test.go
@@ -41,6 +41,7 @@ func TestMetadataSST(t *testing.T) {
 	defer cleanupFn()
 
 	// Check that backup metadata is correct on full cluster backup.
+	sqlDB.Exec(t, `SET CLUSTER SETTING kv.bulkio.write_metadata_sst.enabled = true`)
 	sqlDB.Exec(t, `BACKUP TO $1`, userfile)
 	checkMetadata(ctx, t, tc, userfile)
 

--- a/pkg/ccl/backupccl/manifest_handling.go
+++ b/pkg/ccl/backupccl/manifest_handling.go
@@ -120,7 +120,7 @@ var writeMetadataSST = settings.RegisterBoolSetting(
 	settings.TenantWritable,
 	"kv.bulkio.write_metadata_sst.enabled",
 	"write experimental new format BACKUP metadata file",
-	true,
+	false,
 )
 var errEncryptionInfoRead = errors.New(`ENCRYPTION-INFO not found`)
 


### PR DESCRIPTION
This change defaults `kv.bulkio.write_metadata_sst.enabled` to false.
This setting controls whether or not we write an experimental version
of backup metadata alongside the metadata that is actually used when
restoring a backup. In future releases we have discovered bugs in the
logic guarded by this setting. Note, we do not expect backups to fail
on release builds even if this setting is enabled. However, this
setting already defaults false in 22.2 and so it makes sense to flip
it off in 22.1 as well.

Release note (sql change): `kv.bulkio.write_metadata_sst.enabled` now
defaults to false. This change does not affect backup or restore.

Release justification: low risk change to existing functionality

Epic: None