### PR TITLE
concurrency: introduce lock.Mode concept 

### DIFF
--- a/pkg/kv/kvserver/concurrency/concurrency_manager_test.go
+++ b/pkg/kv/kvserver/concurrency/concurrency_manager_test.go
@@ -363,7 +363,7 @@ func TestConcurrencyManagerBasic(t *testing.T) {
 				}
 				var key string
 				d.ScanArgs(t, "key", &key)
-				strength := scanLockStrength(t, d)
+				strength := concurrency.ScanLockStrength(t, d)
 				if ok, txn := g.IsKeyLockedByConflictingTxn(roachpb.Key(key), strength); ok {
 					holder := "<nil>"
 					if txn != nil {

--- a/pkg/kv/kvserver/concurrency/datadriven_util_test.go
+++ b/pkg/kv/kvserver/concurrency/datadriven_util_test.go
@@ -79,24 +79,6 @@ func scanUserPriority(t *testing.T, d *datadriven.TestData) roachpb.UserPriority
 	}
 }
 
-func scanLockStrength(t *testing.T, d *datadriven.TestData) lock.Strength {
-	var strS string
-	d.ScanArgs(t, "strength", &strS)
-	switch strS {
-	case "none":
-		return lock.None
-	case "shared":
-		return lock.Shared
-	case "upgrade":
-		return lock.Upgrade
-	case "exclusive":
-		return lock.Exclusive
-	default:
-		d.Fatalf(t, "unknown lock strength: %s", strS)
-		return 0
-	}
-}
-
 func scanLockDurability(t *testing.T, d *datadriven.TestData) lock.Durability {
 	var durS string
 	d.ScanArgs(t, "dur", &durS)

--- a/pkg/kv/kvserver/concurrency/lock/BUILD.bazel
+++ b/pkg/kv/kvserver/concurrency/lock/BUILD.bazel
@@ -12,7 +12,12 @@ go_library(
     embed = [":lock_go_proto"],
     importpath = "github.com/cockroachdb/cockroach/pkg/kv/kvserver/concurrency/lock",
     visibility = ["//visibility:public"],
-    deps = ["@com_github_cockroachdb_redact//:redact"],
+    deps = [
+        "//pkg/settings",
+        "//pkg/util/hlc",
+        "@com_github_cockroachdb_errors//:errors",
+        "@com_github_cockroachdb_redact//:redact",
+    ],
 )
 
 proto_library(
@@ -25,6 +30,7 @@ proto_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/storage/enginepb:enginepb_proto",
+        "//pkg/util/hlc:hlc_proto",
         "@com_github_gogo_protobuf//gogoproto:gogo_proto",
         "@com_google_protobuf//:duration_proto",
     ],
@@ -38,18 +44,24 @@ go_proto_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/storage/enginepb",
+        "//pkg/util/hlc",
         "@com_github_gogo_protobuf//gogoproto",
     ],
 )
 
 go_test(
     name = "lock_test",
-    srcs = ["lock_waiter_test.go"],
+    srcs = [
+        "lock_waiter_test.go",
+        "locking_test.go",
+    ],
     args = ["-test.timeout=295s"],
     deps = [
         ":lock",
         "//pkg/roachpb",
+        "//pkg/settings/cluster",
         "//pkg/storage/enginepb",
+        "//pkg/testutils",
         "//pkg/util/hlc",
         "//pkg/util/uuid",
         "@com_github_cockroachdb_redact//:redact",

--- a/pkg/kv/kvserver/concurrency/lock/locking.go
+++ b/pkg/kv/kvserver/concurrency/lock/locking.go
@@ -61,8 +61,8 @@ func (m *Mode) Conflicts(sv *settings.Values, o *Mode) bool {
 		return false
 	case Shared:
 		return o.Strength == Exclusive || o.Strength == Intent
-	case Upgrade:
-		return o.Strength == Upgrade || o.Strength == Exclusive || o.Strength == Intent
+	case Update:
+		return o.Strength == Update || o.Strength == Exclusive || o.Strength == Intent
 	case Exclusive:
 		if ExclusiveLocksBlockNonLockingReads.Get(sv) {
 			// Only non-locking reads below the timestamp at which the lock is held
@@ -99,10 +99,10 @@ func MakeModeShared() Mode {
 	}
 }
 
-// MakeModeUpgrade constructs a Mode with strength Upgrade.
-func MakeModeUpgrade() Mode {
+// MakeModeUpdate constructs a Mode with strength Update.
+func MakeModeUpdate() Mode {
 	return Mode{
-		Strength: Upgrade,
+		Strength: Update,
 	}
 }
 

--- a/pkg/kv/kvserver/concurrency/lock/locking.go
+++ b/pkg/kv/kvserver/concurrency/lock/locking.go
@@ -12,7 +12,31 @@
 // concurrency control in the key-value layer.
 package lock
 
-import "fmt"
+import (
+	"fmt"
+
+	"github.com/cockroachdb/cockroach/pkg/settings"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+	"github.com/cockroachdb/errors"
+)
+
+// ExclusiveLocksBlockNonLockingReads dictates locking interactions between
+// non-locking reads and exclusive locks. Configuring this setting to true makes
+// it such that non-locking reads block on exclusive locks if their read
+// timestamp is at or above the timestamp at which the lock is held; however,
+// if this setting is set to false, non-locking reads do not block on exclusive
+// locks, regardless of their relative timestamp.
+//
+// The tradeoff here is between increased concurrency (non-locking reads become
+// non-blocking in the face of Exclusive locks) at the expense of forcing
+// Exclusive lock holders to perform a read refresh, which in turn may force
+// them to restart if the refresh fails.
+var ExclusiveLocksBlockNonLockingReads = settings.RegisterBoolSetting(
+	settings.SystemOnly,
+	"kv.lock.exclusive_locks_block_non_locking_reads.enabled",
+	"dictates the locking interactions between exclusive locks and non-locking reads",
+	true,
+)
 
 // MaxDurability is the maximum value in the Durability enum.
 const MaxDurability = Unreplicated
@@ -25,8 +49,84 @@ func init() {
 	}
 }
 
+// Conflicts returns whether the supplied lock mode conflicts with the receiver.
+// The conflict rules are as described in the compatibility matrix in
+// locking.pb.go.
+func (m *Mode) Conflicts(sv *settings.Values, o *Mode) bool {
+	if m.Empty() || o.Empty() {
+		panic("cannot check conflict for uninitialized locks")
+	}
+	switch m.Strength {
+	case None:
+		return false
+	case Shared:
+		return o.Strength == Exclusive || o.Strength == Intent
+	case Upgrade:
+		return o.Strength == Upgrade || o.Strength == Exclusive || o.Strength == Intent
+	case Exclusive:
+		if ExclusiveLocksBlockNonLockingReads.Get(sv) {
+			// Only non-locking reads below the timestamp at which the lock is held
+			// are allowed.
+			return !(o.Strength == None && o.Timestamp.Less(m.Timestamp))
+		}
+		return o.Strength != None // non-locking read.
+	case Intent:
+		// Only non-locking read, below held the timestamp at which the lock is held
+		// are allowed.
+		return !(o.Strength == None && o.Timestamp.Less(m.Timestamp))
+	default:
+		panic(errors.AssertionFailedf("unknown strength: %s", m.Strength))
+	}
+}
+
+// Empty returns true if m is an empty (uninitialized) lock Mode.
+func (m *Mode) Empty() bool {
+	return m.Strength == None && m.Timestamp.IsEmpty()
+}
+
+// MakeModeNone constructs a Mode with strength None.
+func MakeModeNone(ts hlc.Timestamp) Mode {
+	return Mode{
+		Strength:  None,
+		Timestamp: ts,
+	}
+}
+
+// MakeModeShared constructs a Mode with strength Shared.
+func MakeModeShared() Mode {
+	return Mode{
+		Strength: Shared,
+	}
+}
+
+// MakeModeUpgrade constructs a Mode with strength Upgrade.
+func MakeModeUpgrade() Mode {
+	return Mode{
+		Strength: Upgrade,
+	}
+}
+
+// MakeModeExclusive constructs a Mode with strength Exclusive.
+func MakeModeExclusive(ts hlc.Timestamp) Mode {
+	return Mode{
+		Strength:  Exclusive,
+		Timestamp: ts,
+	}
+}
+
+// MakeModeIntent constructs a Mode with strength Intent.
+func MakeModeIntent(ts hlc.Timestamp) Mode {
+	return Mode{
+		Strength:  Intent,
+		Timestamp: ts,
+	}
+}
+
 // SafeValue implements redact.SafeValue.
 func (Strength) SafeValue() {}
+
+// SafeValue implements redact.SafeValue.
+func (Mode) SafeValue() {}
 
 // SafeValue implements redact.SafeValue.
 func (Durability) SafeValue() {}

--- a/pkg/kv/kvserver/concurrency/lock/locking.proto
+++ b/pkg/kv/kvserver/concurrency/lock/locking.proto
@@ -13,46 +13,21 @@ package cockroach.kv.kvserver.concurrency.lock;
 option go_package = "lock";
 
 import "gogoproto/gogo.proto";
+import "util/hlc/timestamp.proto";
 
-// Strength represents the different locking modes that determine how key-values
-// can be accessed by concurrent transactions.
+// Strength represents the different locking strengths that determines how
+// key-values can be accessed by concurrent transactions.
 //
-// Locking modes apply to locks that are held with a per-key granularity. It is
-// up to users of the key-value layer to decide on which keys to acquire locks
-// for when imposing structure that can span multiple keys, such as SQL rows
-// (see column families and secondary indexes).
+// Strength applies to locks that are held with a per-key granularity. It is
+// up to the users of the key-value layer to decide on which keys to acquire
+// locks for when imposing structure that can span multiple keys, such as SQL
+// rows (see column families and secondary indexes).
 //
-// Locking modes have differing levels of strength, growing from "weakest" to
-// "strongest" in the order that the variants are presented in the enumeration.
-// The "stronger" a locking mode, the more protection it provides for the lock
-// holder but the more restrictive it is to concurrent transactions attempting
-// to access the same keys.
-//
-// Compatibility Matrix
-//
-// The following matrix presents the compatibility of locking strengths with one
-// another. A cell with an X means that the two strengths are incompatible with
-// each other and that they can not both be held on a given key by different
-// transactions, concurrently. A cell without an X means that the two strengths
-// are compatible with each other and that they can be held on a given key by
-// different transactions, concurrently.
-//
-//  +-----------+-----------+-----------+-----------+-----------+
-//  |           |   None    |  Shared   |  Upgrade  | Exclusive |
-//  +-----------+-----------+-----------+-----------+-----------+
-//  | None      |           |           |           |     X^†   |
-//  +-----------+-----------+-----------+-----------+-----------+
-//  | Shared    |           |           |     X     |     X     |
-//  +-----------+-----------+-----------+-----------+-----------+
-//  | Upgrade   |           |     X     |     X     |     X     |
-//  +-----------+-----------+-----------+-----------+-----------+
-//  | Exclusive |     X^†   |     X     |     X     |     X     |
-//  +-----------+-----------+-----------+-----------+-----------+
-//
-// [†] reads under optimistic concurrency control in CockroachDB only conflict
-// with Exclusive locks if the read's timestamp is equal to or greater than the
-// lock's timestamp. If the read's timestamp is below the Exclusive lock's
-// timestamp then the two are compatible.
+// Lock strengths grow from "weakest" to "strongest" in the order that the
+// variants are presented in the enumeration. The "stronger" a lock's strength,
+// the more restrictive it is to concurrent transactions attempting to access
+// the same keys. The strength compatibility detailing these interactions is
+// illustrated below.
 enum Strength {
   option (gogoproto.goproto_enum_prefix) = false;
 
@@ -100,41 +75,112 @@ enum Strength {
   // be aborted.
   //
   // To avoid this potential deadlock problem, an Upgrade lock can be used in
-  // place of a Shared lock. Upgrade locks are not compatible with any other
-  // form of locking. As with Shared locks, the lock holder of an Upgrade lock
-  // on a key is only allowed to read from the key while the lock is held.
-  // This resolves the deadlock scenario presented above because only one of
-  // the transactions would have been able to acquire an Upgrade lock at a
-  // time while reading the initial state of the KVs. This means that the
-  // Shared-to-Exclusive lock upgrade would never need to wait on another
-  // transaction to release its locks.
-  //
-  // Under pure pessimistic concurrency control, an Upgrade lock is equivalent
-  // to an Exclusive lock. However, unlike with Exclusive locks, reads under
-  // optimistic concurrency control do not conflict with Upgrade locks. This
-  // is because a transaction can only hold an Upgrade lock on keys that it
-  // has not yet modified. This improves concurrency between read and write
-  // transactions compared to if the writing transaction had immediately
-  // acquired an Exclusive lock.
-  //
-  // The trade-off here is twofold. First, if the Upgrade lock holder does
-  // convert its lock on a key to an Exclusive lock after an optimistic read
-  // has observed the state of the key, the transaction that performed the
-  // optimistic read may be unable to perform a successful read refresh if it
-  // attempts to refresh to a timestamp at or past the timestamp of the lock
-  // conversion. Second, the optimistic reads permitted while the Upgrade lock
-  // is held will bump the timestamp cache. This may result in the Upgrade
-  // lock holder being forced to increase its write timestamp when converting
-  // to an Exclusive lock, which in turn may force it to restart if its read
-  // refresh fails.
+  // place of a Shared lock. Upgrade locks are only compatible with other Shared
+  // locks. This means that unlike Shared locks, there may only be a single
+  // Upgrade lock holder for a given key. As with Shared locks, the lock holder
+  // of an Upgrade lock on a key is only allowed to read from the key while the
+  // lock is held. These two requirements help resolve the deadlock scenario
+  // presented above because only one of the transactions would be able to
+  // acquire an Upgrade lock at a time while reading the initial state of the
+  // KVs. This means only one transaction is allowed to upgrade its lock to
+  // Exclusive. It may have to wait for concurrent transactions to release their
+  // Shared locks, however, there is no deadlock hazard here as the Shared lock
   Upgrade = 2;
 
-  // Exclusive (X) locks are used by read-write and read-only operations and
-  // provide a transaction with exclusive access to a key. When an Exclusive
-  // lock is held by a transaction on a given key, no other transaction can
-  // read from or write to that key. The lock holder is free to read from and
-  // write to the key as frequently as it would like.
+  // Exclusive (X) locks are used by read-write and read-only operations to
+  // provide transactions with (potential) exclusive write access to a key. When
+  // an Exclusive lock is held by a transaction on a given key, no other
+  // transaction can write to that key.
+  //
+  // Exclusive locks may provide the lock holder exclusive read access to the
+  // key as well. This is a vestige of a time when there was no distinction
+  // between exclusive locks and intents; this behavior is configurable, using
+  // a cluster setting, and detailed under the compatibility matrix below.
+  //
+  // Unlike Intents, a transaction can only hold an Exclusive lock on keys that
+  // it has not yet modified. This allows optimistic reads to not conflict with
+  // Exclusive locks, and improves concurrency between read and write
+  // transactions. Note that for this to be meaningful, the write transaction
+  // must acquire Exclusive locks as it is executing and only lay down Intents
+  // once it is ready to commit.
+  //
+  // Configuring whether optimistic reads block or do not on Exclusive locks
+  // presents a twofold trade-off. First, if the Exclusive lock holder lays down
+  // an intent on a key after an optimistic read has observed the state of the
+  // key, the transaction that performed the optimistic read may be unable to
+  // perform a successful read refresh if it attempts to refresh to a timestamp
+  // at or past the timestamp of the Intent. Second, the optimistic read
+  // permitted while the Exclusive lock is held will bump the timestamp cache.
+  // This may result in the Exclusive lock holder being forced to increase its
+  // write timestamp when laying down an Intent, which in turn may force it to
+  // restart if its read refresh fails.
   Exclusive = 3;
+
+  // Intent (I) locks are are used by read-write operations to provide
+  // transactions sole access to a key. When an Intent lock is held by a
+  // transaction on a given key, no other transaction can read from or write to
+  // that key. The lock holder is free to read from and write to the key as
+  // frequently as it would like.
+  Intent = 4;
+}
+
+// Mode determines the level of protection a lock provides to the lock holder.
+// All locks that are held with a per-key granularity have an associated Mode.
+//
+// The protection a lock offers is primarily determined by the Strength it is
+// held with. However, lock Modes also contain auxiliary information (eg. the
+// timestamp at which the lock was acquired), which may be used in conjunction
+// with a lock's Strength to resolve conflicts between a lock holder and a
+// concurrent lock acquirer. This allows us to codify conflict rules as a pure
+// function of 2 lock Modes.
+//
+// Users of the key-value layer are expected to indicate locking intentions
+// using lock Strengths; lock Mode is an internal concept for the concurrency
+// package for conflict resolution.
+//
+// Compatibility Matrix
+//
+// The following matrix presents the compatibility of lock Modes with one
+// another. A cell with an X means that the two strengths are incompatible with
+// each other and that they can not both be held on a given key by different
+// transactions, concurrently. A cell without an X means that the two lock Modes
+// are compatible with each other and that they can be held on a given key by
+// different transactions, concurrently.
+//
+//  +------------+---------+-----------+-----------+-------------+----------+
+//  |            |   None  |  Shared   |  Upgrade  |  Exclusive  |  Intent  |
+//  +------------+---------+-----------+-----------+-------------+----------+
+//  | None       |         |           |           |      X^*    |    X^†   |
+//  +------------+---------+-----------+-----------+-------------+----------+
+//  | Shared     |         |           |           |      X      |    X     |
+//  +------------+---------+-----------+-----------+-------------+----------+
+//  | Upgrade    |         |           |     X     |      X      |    X     |
+//  +------------+---------+-----------+-----------+-------------+----------+
+//  | Exclusive  |   X^*   |     X     |     X     |      X      |    X     |
+//  +------------+---------+-----------+-----------+-------------+----------+
+//  | Intent     |   X^†   |     X     |     X     |      X      |    X     |
+//  +------------+---------+-----------+-----------+-------------+----------+
+//
+// [†] reads under optimistic concurrency control in CockroachDB only conflict
+// with Intent locks if the read's timestamp is equal to or greater than the
+// lock's timestamp. If the read's timestamp is below the Intent lock's
+// timestamp then the two are compatible.
+//
+// [*] historically, CockroachDB did not make a strength distinction between
+// Exclusive locks and Intents. As such, reads under optimistic concurrency
+// control would conflict with Exclusive locks if the read's timestamp was at or
+// above the Exclusive lock's timestamp. Now that there is a distinction between
+// Exclusive locks and Intents, non-locking reads do not block on Exclusive
+// locks, regardless of their timestamp. However, there is a desire to let users
+// opt into the old behavior using the ExclusiveLocksBlockNonLockingReads
+// cluster setting.
+message Mode {
+  // Strength in which the lock is held.
+  Strength strength = 1;
+
+  // Timestamp at which the lock was/is being acquired. This field must be set
+  // for None, Exclusive, and Intent locking strengths.
+  util.hlc.Timestamp timestamp = 2 [(gogoproto.nullable)=false];
 }
 
 // Durability represents the different durability properties of a lock acquired

--- a/pkg/kv/kvserver/concurrency/lock/locking.proto
+++ b/pkg/kv/kvserver/concurrency/lock/locking.proto
@@ -52,7 +52,7 @@ enum Strength {
   
   // Shared (S) locks are used by read-only operations and allow concurrent
   // transactions to read under pessimistic concurrency control. Shared locks
-  // are compatible with each other but are not compatible with Upgrade or
+  // are compatible with each other but are not compatible with Update or
   // Exclusive locks. This means that multiple transactions can hold a Shared
   // lock on the same key at the same time, but no other transaction can
   // modify the key at the same time. A holder of a Shared lock on a key is
@@ -62,7 +62,7 @@ enum Strength {
   // optimistically (see None).
   Shared = 1;
 
-  // Upgrade (U) locks are a hybrid of Shared and Exclusive locks which are
+  // Update (U) locks are a hybrid of Shared and Exclusive locks which are
   // used to prevent a common form of deadlock. When a transaction intends to
   // modify existing KVs, it is often the case that it reads the KVs first and
   // then attempts to modify them. Under pessimistic concurrency control, this
@@ -74,18 +74,19 @@ enum Strength {
   // occur. To resolve the deadlock, one of the two transactions would need to
   // be aborted.
   //
-  // To avoid this potential deadlock problem, an Upgrade lock can be used in
-  // place of a Shared lock. Upgrade locks are only compatible with other Shared
+  // To avoid this potential deadlock problem, an Update lock can be used in
+  // place of a Shared lock. Update locks are only compatible with other Shared
   // locks. This means that unlike Shared locks, there may only be a single
-  // Upgrade lock holder for a given key. As with Shared locks, the lock holder
-  // of an Upgrade lock on a key is only allowed to read from the key while the
+  // Update lock holder for a given key. As with Shared locks, the lock holder
+  // of an Update lock on a key is only allowed to read from the key while the
   // lock is held. These two requirements help resolve the deadlock scenario
   // presented above because only one of the transactions would be able to
-  // acquire an Upgrade lock at a time while reading the initial state of the
+  // acquire an Update lock at a time while reading the initial state of the
   // KVs. This means only one transaction is allowed to upgrade its lock to
   // Exclusive. It may have to wait for concurrent transactions to release their
   // Shared locks, however, there is no deadlock hazard here as the Shared lock
-  Upgrade = 2;
+  // holders are not waiting on the Update lock in any way.
+  Update = 2;
 
   // Exclusive (X) locks are used by read-write and read-only operations to
   // provide transactions with (potential) exclusive write access to a key. When
@@ -148,13 +149,13 @@ enum Strength {
 // different transactions, concurrently.
 //
 //  +------------+---------+-----------+-----------+-------------+----------+
-//  |            |   None  |  Shared   |  Upgrade  |  Exclusive  |  Intent  |
+//  |            |   None  |  Shared   |  Update   |  Exclusive  |  Intent  |
 //  +------------+---------+-----------+-----------+-------------+----------+
 //  | None       |         |           |           |      X^*    |    X^†   |
 //  +------------+---------+-----------+-----------+-------------+----------+
 //  | Shared     |         |           |           |      X      |    X     |
 //  +------------+---------+-----------+-----------+-------------+----------+
-//  | Upgrade    |         |           |     X     |      X      |    X     |
+//  | Update     |         |           |     X     |      X      |    X     |
 //  +------------+---------+-----------+-----------+-------------+----------+
 //  | Exclusive  |   X^*   |     X     |     X     |      X      |    X     |
 //  +------------+---------+-----------+-----------+-------------+----------+

--- a/pkg/kv/kvserver/concurrency/lock/locking_test.go
+++ b/pkg/kv/kvserver/concurrency/lock/locking_test.go
@@ -1,0 +1,343 @@
+// Copyright 2023 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package lock_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/concurrency/lock"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/testutils"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+	"github.com/stretchr/testify/require"
+)
+
+// TestCheckLockConflicts ensures the lock conflict semantics, as
+// illustrated in the compatibility matrix in locking.pb.go, are upheld.
+func TestCheckLockConflicts(t *testing.T) {
+	makeTS := func(nanos int64) hlc.Timestamp {
+		return hlc.Timestamp{
+			WallTime: nanos,
+		}
+	}
+
+	tsBelow := makeTS(1)
+	tsLock := makeTS(2)
+	tsAbove := makeTS(3)
+
+	testCases := []struct {
+		desc            string
+		heldLockMode    lock.Mode
+		toCheckLockMode lock.Mode
+		// Expectation for when non-locking reads do not block on Exclusive locks.
+		exp bool
+		// Expectation when non-locking reads do block on Exclusive locks. This
+		// distinction is only meaningful when testing for None <-> Exclusive lock
+		// mode interactions.
+		expExclusiveLocksBlockNonLockingReads bool
+	}{
+		// A. Held lock mode is "Shared".
+		// A1. Shared lock mode is doesn't conflict with non-locking reads.
+		{
+			desc:                                  "non-locking read, held shared lock",
+			heldLockMode:                          lock.MakeModeShared(),
+			toCheckLockMode:                       lock.MakeModeNone(tsLock),
+			exp:                                   false,
+			expExclusiveLocksBlockNonLockingReads: false,
+		},
+		// A2. Shared lock mode doesn't conflict with itself.
+		{
+			desc:                                  "shared lock acquisition, held shared lock",
+			heldLockMode:                          lock.MakeModeShared(),
+			toCheckLockMode:                       lock.MakeModeShared(),
+			exp:                                   false,
+			expExclusiveLocksBlockNonLockingReads: false,
+		},
+		// A3. Shared lock mode doesn't conflict with an Upgrade lock mode.
+		{
+			desc:                                  "upgrade lock acquisition, held shared lock",
+			heldLockMode:                          lock.MakeModeShared(),
+			toCheckLockMode:                       lock.MakeModeUpgrade(),
+			exp:                                   false,
+			expExclusiveLocksBlockNonLockingReads: false,
+		},
+		// A4. Shared lock mode conflicts with Exclusive lock mode.
+		{
+			desc:                                  "exclusive lock acquisition, held shared lock",
+			heldLockMode:                          lock.MakeModeShared(),
+			toCheckLockMode:                       lock.MakeModeExclusive(tsLock),
+			exp:                                   true,
+			expExclusiveLocksBlockNonLockingReads: true,
+		},
+		// A5. Shared lock mode conflicts with Intent lock mode.
+		{
+			desc:                                  "upgrade lock acquisition, held shared lock",
+			heldLockMode:                          lock.MakeModeShared(),
+			toCheckLockMode:                       lock.MakeModeIntent(tsLock),
+			exp:                                   true,
+			expExclusiveLocksBlockNonLockingReads: true,
+		},
+		// B. Held lock mode is "Upgrade".
+		// B1. Upgrade lock mode doesn't conflict with non-locking reads.
+		{
+			desc:                                  "non-locking read, held upgrade lock",
+			heldLockMode:                          lock.MakeModeUpgrade(),
+			toCheckLockMode:                       lock.MakeModeNone(tsLock),
+			exp:                                   false,
+			expExclusiveLocksBlockNonLockingReads: false,
+		},
+		// B2. Upgrade lock mode doesn't conflict with Shared lock mode.
+		{
+			desc:                                  "shared lock acquisition, held upgrade lock",
+			heldLockMode:                          lock.MakeModeUpgrade(),
+			toCheckLockMode:                       lock.MakeModeShared(),
+			exp:                                   false,
+			expExclusiveLocksBlockNonLockingReads: false,
+		},
+		// B3. Upgrade lock mode conflicts with a concurrent attempt to acquire an
+		// Upgrade lock.
+		{
+			desc:                                  "update lock acquisition, held update lock",
+			heldLockMode:                          lock.MakeModeUpgrade(),
+			toCheckLockMode:                       lock.MakeModeUpgrade(),
+			exp:                                   true,
+			expExclusiveLocksBlockNonLockingReads: true,
+		},
+		// B4. Upgrade lock mode conflicts with Exclusive lock mode.
+		{
+			desc:                                  "exclusive lock acquisition, held upgrade lock",
+			heldLockMode:                          lock.MakeModeUpgrade(),
+			toCheckLockMode:                       lock.MakeModeExclusive(tsLock),
+			exp:                                   true,
+			expExclusiveLocksBlockNonLockingReads: true,
+		},
+		// B5. Upgrade lock mode conflicts with Intent lock mode.
+		{
+			desc:                                  "upgrade lock acquisition, held shared lock",
+			heldLockMode:                          lock.MakeModeUpgrade(),
+			toCheckLockMode:                       lock.MakeModeIntent(tsLock),
+			exp:                                   true,
+			expExclusiveLocksBlockNonLockingReads: true,
+		},
+
+		// C. Held lock mode is "Exclusive".
+		// C1. Non-locking reads below the timestamp of Exclusive locks should never
+		// conflict.
+		{
+			desc:                                  "non-locking read at lower timestamp, held exclusive lock",
+			heldLockMode:                          lock.MakeModeExclusive(tsLock),
+			toCheckLockMode:                       lock.MakeModeNone(tsBelow),
+			exp:                                   false,
+			expExclusiveLocksBlockNonLockingReads: false,
+		},
+		// C2. Non-locking reads, at the same timestamp at which an Exclusive lock
+		// is held, conflict depending on the value of the
+		// ExclusiveLocksBlockNonLockingReads cluster setting.
+		{
+			desc:                                  "non-locking read at lock timestamp, held exclusive lock",
+			heldLockMode:                          lock.MakeModeExclusive(tsLock),
+			toCheckLockMode:                       lock.MakeModeNone(tsLock),
+			exp:                                   false,
+			expExclusiveLocksBlockNonLockingReads: true,
+		},
+		// C3. Ditto for non-locking reads above the timestamp of the Exclusive
+		// lock.
+		{
+			desc:                                  "non-locking read at lock timestamp, held exclusive lock",
+			heldLockMode:                          lock.MakeModeExclusive(tsLock),
+			toCheckLockMode:                       lock.MakeModeNone(tsAbove),
+			exp:                                   false,
+			expExclusiveLocksBlockNonLockingReads: true,
+		},
+		// C4. Exclusive lock mode conflicts with Shared lock mode.
+		{
+			desc:                                  "shared lock acquisition, held exclusive lock",
+			heldLockMode:                          lock.MakeModeExclusive(tsLock),
+			toCheckLockMode:                       lock.MakeModeShared(),
+			exp:                                   true,
+			expExclusiveLocksBlockNonLockingReads: true,
+		},
+		// C5. Exclusive lock mode conflicts with Upgrade lock mode.
+		{
+			desc:                                  "upgrade lock acquisition, held exclusive lock",
+			heldLockMode:                          lock.MakeModeExclusive(tsLock),
+			toCheckLockMode:                       lock.MakeModeUpgrade(),
+			exp:                                   true,
+			expExclusiveLocksBlockNonLockingReads: true,
+		},
+		// C6. Exclusive lock mode conflicts with Exclusive locks at lower
+		// timestamps.
+		{
+			desc:                                  "exclusive lock acquisition, held exclusive lock",
+			heldLockMode:                          lock.MakeModeExclusive(tsLock),
+			toCheckLockMode:                       lock.MakeModeExclusive(tsBelow),
+			exp:                                   true,
+			expExclusiveLocksBlockNonLockingReads: true,
+		},
+		// C7. Ditto for the "at timestamp" case.
+		{
+			desc:                                  "exclusive lock acquisition, held exclusive lock",
+			heldLockMode:                          lock.MakeModeExclusive(tsLock),
+			toCheckLockMode:                       lock.MakeModeExclusive(tsLock),
+			exp:                                   true,
+			expExclusiveLocksBlockNonLockingReads: true,
+		},
+		// C8. As well as the "above timestamp" case.
+		{
+			desc:                                  "exclusive lock acquisition, held exclusive lock",
+			heldLockMode:                          lock.MakeModeExclusive(tsLock),
+			toCheckLockMode:                       lock.MakeModeExclusive(tsAbove),
+			exp:                                   true,
+			expExclusiveLocksBlockNonLockingReads: true,
+		},
+		// C9. Exclusive lock mode conflicts with Intent lock mode at lower
+		// timestamps.
+		{
+			desc:                                  "intent lock mode acquisition, held exclusive lock",
+			heldLockMode:                          lock.MakeModeExclusive(tsLock),
+			toCheckLockMode:                       lock.MakeModeIntent(tsBelow),
+			exp:                                   true,
+			expExclusiveLocksBlockNonLockingReads: true,
+		},
+		// C10. Ditto for the "at timestamp" case.
+		{
+			desc:                                  "intent lock mode acquisition, held exclusive lock",
+			heldLockMode:                          lock.MakeModeExclusive(tsLock),
+			toCheckLockMode:                       lock.MakeModeIntent(tsLock),
+			exp:                                   true,
+			expExclusiveLocksBlockNonLockingReads: true,
+		},
+		// C11. As well as the "above timestamp" case.
+		{
+			desc:                                  "intent lock mode acquisition, held exclusive lock",
+			heldLockMode:                          lock.MakeModeExclusive(tsLock),
+			toCheckLockMode:                       lock.MakeModeIntent(tsAbove),
+			exp:                                   true,
+			expExclusiveLocksBlockNonLockingReads: true,
+		},
+
+		// D. Held lock mode is "Intent".
+		// D1. Non-locking reads below the timestamp of the Intent do not conflict.
+		{
+			desc:                                  "non-locking read at lower timestamp, held intent",
+			heldLockMode:                          lock.MakeModeIntent(tsLock),
+			toCheckLockMode:                       lock.MakeModeNone(tsBelow),
+			exp:                                   false,
+			expExclusiveLocksBlockNonLockingReads: false,
+		},
+		// D2. However, non-locking reads at the timestamp of the Intent conflict.
+		{
+			desc:                                  "non-locking read at lock timestamp, held intent",
+			heldLockMode:                          lock.MakeModeIntent(tsLock),
+			toCheckLockMode:                       lock.MakeModeNone(tsLock),
+			exp:                                   true,
+			expExclusiveLocksBlockNonLockingReads: true,
+		},
+		// D3. Ditto for non-locking reads above the Intent's timestamp.
+		{
+			desc:                                  "non-locking read at lock timestamp, held intent",
+			heldLockMode:                          lock.MakeModeIntent(tsLock),
+			toCheckLockMode:                       lock.MakeModeNone(tsAbove),
+			exp:                                   true,
+			expExclusiveLocksBlockNonLockingReads: true,
+		},
+		// D4. Intent lock mode conflicts with Shared lock mode.
+		{
+			desc:                                  "shared lock acquisition, held intent",
+			heldLockMode:                          lock.MakeModeIntent(tsLock),
+			toCheckLockMode:                       lock.MakeModeShared(),
+			exp:                                   true,
+			expExclusiveLocksBlockNonLockingReads: true,
+		},
+		// D5. Intent lock mode conflicts with Upgrade lock mode.
+		{
+			desc:                                  "upgrade lock acquisition, held intent",
+			heldLockMode:                          lock.MakeModeIntent(tsLock),
+			toCheckLockMode:                       lock.MakeModeUpgrade(),
+			exp:                                   true,
+			expExclusiveLocksBlockNonLockingReads: true,
+		},
+		// D6. Intent lock mode conflicts with Exclusive locks at lower
+		// timestamps.
+		{
+			desc:                                  "exclusive lock acquisition, held intent",
+			heldLockMode:                          lock.MakeModeIntent(tsLock),
+			toCheckLockMode:                       lock.MakeModeExclusive(tsBelow),
+			exp:                                   true,
+			expExclusiveLocksBlockNonLockingReads: true,
+		},
+		// D7. Ditto for the "at timestamp" case.
+		{
+			desc:                                  "exclusive lock acquisition, held intent",
+			heldLockMode:                          lock.MakeModeIntent(tsLock),
+			toCheckLockMode:                       lock.MakeModeExclusive(tsLock),
+			exp:                                   true,
+			expExclusiveLocksBlockNonLockingReads: true,
+		},
+		// D8. As well as the "above timestamp" case.
+		{
+			desc:                                  "exclusive lock acquisition, held intent",
+			heldLockMode:                          lock.MakeModeIntent(tsLock),
+			toCheckLockMode:                       lock.MakeModeExclusive(tsAbove),
+			exp:                                   true,
+			expExclusiveLocksBlockNonLockingReads: true,
+		},
+		// D9. Intent lock mode conflicts with another Intent lock mode at a
+		// lower timestamp.
+		{
+			desc:                                  "intent lock mode acquisition, held intent",
+			heldLockMode:                          lock.MakeModeIntent(tsLock),
+			toCheckLockMode:                       lock.MakeModeIntent(tsBelow),
+			exp:                                   true,
+			expExclusiveLocksBlockNonLockingReads: true,
+		},
+		// D10. Ditto for the "at timestamp" case.
+		{
+			desc:                                  "intent lock mode acquisition, held intent",
+			heldLockMode:                          lock.MakeModeIntent(tsLock),
+			toCheckLockMode:                       lock.MakeModeIntent(tsLock),
+			exp:                                   true,
+			expExclusiveLocksBlockNonLockingReads: true,
+		},
+		// D11. As well as the "above timestamp" case.
+		{
+			desc:                                  "intent lock mode acquisition, held intent",
+			heldLockMode:                          lock.MakeModeIntent(tsLock),
+			toCheckLockMode:                       lock.MakeModeIntent(tsAbove),
+			exp:                                   true,
+			expExclusiveLocksBlockNonLockingReads: true,
+		},
+	}
+
+	ctx := context.Background()
+	st := cluster.MakeTestingClusterSettings()
+
+	for _, tc := range testCases {
+		testutils.RunTrueAndFalse(t,
+			"exclusive-locks-block-non-locking-reads-override",
+			func(t *testing.T, exclusiveLocksBlockNonLockingReadsOverride bool) {
+				t.Run(tc.desc, func(t *testing.T) {
+					lock.ExclusiveLocksBlockNonLockingReads.Override(
+						ctx, &st.SV, exclusiveLocksBlockNonLockingReadsOverride,
+					)
+					exp := tc.exp
+					if exclusiveLocksBlockNonLockingReadsOverride {
+						exp = tc.expExclusiveLocksBlockNonLockingReads
+					}
+
+					require.Equal(
+						t, exp, tc.heldLockMode.Conflicts(&st.SV, &tc.toCheckLockMode),
+					)
+				})
+			})
+	}
+}

--- a/pkg/kv/kvserver/concurrency/lock/locking_test.go
+++ b/pkg/kv/kvserver/concurrency/lock/locking_test.go
@@ -62,11 +62,11 @@ func TestCheckLockConflicts(t *testing.T) {
 			exp:                                   false,
 			expExclusiveLocksBlockNonLockingReads: false,
 		},
-		// A3. Shared lock mode doesn't conflict with an Upgrade lock mode.
+		// A3. Shared lock mode doesn't conflict with an Update lock mode.
 		{
-			desc:                                  "upgrade lock acquisition, held shared lock",
+			desc:                                  "update lock acquisition, held shared lock",
 			heldLockMode:                          lock.MakeModeShared(),
-			toCheckLockMode:                       lock.MakeModeUpgrade(),
+			toCheckLockMode:                       lock.MakeModeUpdate(),
 			exp:                                   false,
 			expExclusiveLocksBlockNonLockingReads: false,
 		},
@@ -80,50 +80,50 @@ func TestCheckLockConflicts(t *testing.T) {
 		},
 		// A5. Shared lock mode conflicts with Intent lock mode.
 		{
-			desc:                                  "upgrade lock acquisition, held shared lock",
+			desc:                                  "update lock acquisition, held shared lock",
 			heldLockMode:                          lock.MakeModeShared(),
 			toCheckLockMode:                       lock.MakeModeIntent(tsLock),
 			exp:                                   true,
 			expExclusiveLocksBlockNonLockingReads: true,
 		},
-		// B. Held lock mode is "Upgrade".
-		// B1. Upgrade lock mode doesn't conflict with non-locking reads.
+		// B. Held lock mode is "Update".
+		// B1. Update lock mode doesn't conflict with non-locking reads.
 		{
-			desc:                                  "non-locking read, held upgrade lock",
-			heldLockMode:                          lock.MakeModeUpgrade(),
+			desc:                                  "non-locking read, held update lock",
+			heldLockMode:                          lock.MakeModeUpdate(),
 			toCheckLockMode:                       lock.MakeModeNone(tsLock),
 			exp:                                   false,
 			expExclusiveLocksBlockNonLockingReads: false,
 		},
-		// B2. Upgrade lock mode doesn't conflict with Shared lock mode.
+		// B2. Update lock mode doesn't conflict with Shared lock mode.
 		{
-			desc:                                  "shared lock acquisition, held upgrade lock",
-			heldLockMode:                          lock.MakeModeUpgrade(),
+			desc:                                  "shared lock acquisition, held update lock",
+			heldLockMode:                          lock.MakeModeUpdate(),
 			toCheckLockMode:                       lock.MakeModeShared(),
 			exp:                                   false,
 			expExclusiveLocksBlockNonLockingReads: false,
 		},
-		// B3. Upgrade lock mode conflicts with a concurrent attempt to acquire an
-		// Upgrade lock.
+		// B3. Update lock mode conflicts with a concurrent attempt to acquire an
+		// Update lock.
 		{
 			desc:                                  "update lock acquisition, held update lock",
-			heldLockMode:                          lock.MakeModeUpgrade(),
-			toCheckLockMode:                       lock.MakeModeUpgrade(),
+			heldLockMode:                          lock.MakeModeUpdate(),
+			toCheckLockMode:                       lock.MakeModeUpdate(),
 			exp:                                   true,
 			expExclusiveLocksBlockNonLockingReads: true,
 		},
-		// B4. Upgrade lock mode conflicts with Exclusive lock mode.
+		// B4. Update lock mode conflicts with Exclusive lock mode.
 		{
-			desc:                                  "exclusive lock acquisition, held upgrade lock",
-			heldLockMode:                          lock.MakeModeUpgrade(),
+			desc:                                  "exclusive lock acquisition, held update lock",
+			heldLockMode:                          lock.MakeModeUpdate(),
 			toCheckLockMode:                       lock.MakeModeExclusive(tsLock),
 			exp:                                   true,
 			expExclusiveLocksBlockNonLockingReads: true,
 		},
-		// B5. Upgrade lock mode conflicts with Intent lock mode.
+		// B5. Update lock mode conflicts with Intent lock mode.
 		{
-			desc:                                  "upgrade lock acquisition, held shared lock",
-			heldLockMode:                          lock.MakeModeUpgrade(),
+			desc:                                  "update lock acquisition, held shared lock",
+			heldLockMode:                          lock.MakeModeUpdate(),
 			toCheckLockMode:                       lock.MakeModeIntent(tsLock),
 			exp:                                   true,
 			expExclusiveLocksBlockNonLockingReads: true,
@@ -166,11 +166,11 @@ func TestCheckLockConflicts(t *testing.T) {
 			exp:                                   true,
 			expExclusiveLocksBlockNonLockingReads: true,
 		},
-		// C5. Exclusive lock mode conflicts with Upgrade lock mode.
+		// C5. Exclusive lock mode conflicts with Update lock mode.
 		{
-			desc:                                  "upgrade lock acquisition, held exclusive lock",
+			desc:                                  "update lock acquisition, held exclusive lock",
 			heldLockMode:                          lock.MakeModeExclusive(tsLock),
-			toCheckLockMode:                       lock.MakeModeUpgrade(),
+			toCheckLockMode:                       lock.MakeModeUpdate(),
 			exp:                                   true,
 			expExclusiveLocksBlockNonLockingReads: true,
 		},
@@ -258,11 +258,11 @@ func TestCheckLockConflicts(t *testing.T) {
 			exp:                                   true,
 			expExclusiveLocksBlockNonLockingReads: true,
 		},
-		// D5. Intent lock mode conflicts with Upgrade lock mode.
+		// D5. Intent lock mode conflicts with Update lock mode.
 		{
-			desc:                                  "upgrade lock acquisition, held intent",
+			desc:                                  "update lock acquisition, held intent",
 			heldLockMode:                          lock.MakeModeIntent(tsLock),
-			toCheckLockMode:                       lock.MakeModeUpgrade(),
+			toCheckLockMode:                       lock.MakeModeUpdate(),
 			exp:                                   true,
 			expExclusiveLocksBlockNonLockingReads: true,
 		},

--- a/pkg/kv/kvserver/concurrency/lock_table.go
+++ b/pkg/kv/kvserver/concurrency/lock_table.go
@@ -885,7 +885,7 @@ type lockWaitQueue struct {
 	// seqnums but at another key req2 wants to read and req1 wants to write and
 	// since req2 does not wait in the queue it acquires a read reservation
 	// before req1. See the discussion at the end of this comment section on how
-	// the behavior will extend when we start supporting Shared and Upgrade
+	// the behavior will extend when we start supporting Shared and Update
 	// locks.
 	//
 	// Non-transactional requests can do both reads and writes but cannot be
@@ -948,7 +948,7 @@ type lockWaitQueue struct {
 	//   This is a deadlock caused by the lock table unless req2 partially
 	//   breaks the reservation at A.
 	//
-	// Extension for Shared and Upgrade locks:
+	// Extension for Shared and Update locks:
 	// There are 3 aspects to consider: holders; reservers; the dependencies
 	// that need to be captured when waiting.
 	//

--- a/pkg/kv/kvserver/concurrency/lock_table_test.go
+++ b/pkg/kv/kvserver/concurrency/lock_table_test.go
@@ -497,7 +497,7 @@ func TestLockTableBasic(t *testing.T) {
 				}
 				var key string
 				d.ScanArgs(t, "k", &key)
-				strength := scanLockStrength(t, d)
+				strength := ScanLockStrength(t, d)
 				if ok, txn := g.IsKeyLockedByConflictingTxn(roachpb.Key(key), strength); ok {
 					holder := "<nil>"
 					if txn != nil {
@@ -714,7 +714,7 @@ func scanSpans(t *testing.T, d *datadriven.TestData, ts hlc.Timestamp) *spanset.
 	return spans
 }
 
-func scanLockStrength(t *testing.T, d *datadriven.TestData) lock.Strength {
+func ScanLockStrength(t *testing.T, d *datadriven.TestData) lock.Strength {
 	var strS string
 	d.ScanArgs(t, "strength", &strS)
 	switch strS {
@@ -722,8 +722,8 @@ func scanLockStrength(t *testing.T, d *datadriven.TestData) lock.Strength {
 		return lock.None
 	case "shared":
 		return lock.Shared
-	case "upgrade":
-		return lock.Upgrade
+	case "update":
+		return lock.Update
 	case "exclusive":
 		return lock.Exclusive
 	default:

--- a/pkg/kv/kvserver/replica_test.go
+++ b/pkg/kv/kvserver/replica_test.go
@@ -10923,7 +10923,7 @@ func TestReplicaServersideRefreshes(t *testing.T) {
 				expTS = ba.Txn.WriteTimestamp
 
 				scan := scanArgs(roachpb.Key("lscan"), roachpb.Key("lscan\x00"))
-				scan.KeyLocking = lock.Upgrade
+				scan.KeyLocking = lock.Update
 				ba.Add(scan)
 				return
 			},

--- a/pkg/sql/row/locking.go
+++ b/pkg/sql/row/locking.go
@@ -36,7 +36,7 @@ func GetKeyLockingStrength(lockStrength descpb.ScanLockingStrength) lock.Strengt
 		fallthrough
 	case descpb.ScanLockingStrength_FOR_UPDATE:
 		// We currently perform exclusive per-key locking when FOR_UPDATE is
-		// used because Upgrade locks have not yet been implemented.
+		// used because Update locks have not yet been implemented.
 		return lock.Exclusive
 
 	default:

--- a/pkg/testutils/lint/passes/redactcheck/redactcheck.go
+++ b/pkg/testutils/lint/passes/redactcheck/redactcheck.go
@@ -79,6 +79,7 @@ func runAnalyzer(pass *analysis.Pass) (interface{}, error) {
 					},
 					"github.com/cockroachdb/cockroach/pkg/kv/kvserver/concurrency/lock": {
 						"Durability": {},
+						"Mode":       {},
 						"Strength":   {},
 						"WaitPolicy": {},
 					},


### PR DESCRIPTION
This patch introduces the concept of a `lock.Mode`, which ties together
`lock.Strength` with other auxiliary information (read: timestamps) to
resolve conflicts between 2 lock holders.

Previously, `lock.Strength` was used both by users of the KV layer to
indicate desired locking intention and by the `concurrency` package
internally to do conflict resolution. `lock.Strength` continues to
do the former. With this change, `lock.Mode` assumes the responsibility
for the latter.

Given this motivation, this patch expresses lock compatiility/conflict
as pure functions of 2 `lock.Modes`.

This patch also introduces a new lock Strength, called Intent.
Conceptually, these are stronger than `Exclusive` locks and map on-to
the existing concept of Intents. The difference lies in their
interaction with non-locking reads. Non-locking reads conflict with
intents, whereas `Exclusive` locks do not. This is a forward looking
change with non-blocking reads in mind.

Note that non-locking reads not blocking on `Exclusive` locks changes
existing behavior. As such, we introduce a new cluster setting
(`kv.lock.exclusive_locks_block_non_locking_reads`) which, when set,
reverts to the old behavior. By default, this setting is set to true,
which means we're not changing any default behavior with this patch
just yet.

Informs https://github.com/cockroachdb/cockroach/issues/91545

Release note: None