### PR TITLE
ui: Cluster UI publishing workflow test

### DIFF
--- a/.github/workflows/cluster-ui-release.yml
+++ b/.github/workflows/cluster-ui-release.yml
@@ -32,10 +32,12 @@ jobs:
       uses: actions/setup-node@v3
       with:
         node-version: 16
+        registry-url: 'https://registry.npmjs.org'
+        always-auth: true
         cache: 'yarn'
         cache-dependency-path: pkg/ui/yarn.lock
       env:
-        NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
     - name: Check if version is published
       id: version-check
@@ -50,6 +52,8 @@ jobs:
           echo "to npm. Publishing step should be skipped. 🛑"
         else
           echo "published=no" >> $GITHUB_OUTPUT
+          echo
+          echo "✅ Cluster UI package version $PACKAGE_VERSION should be published. ✅"
         fi
 
     - name: Get Branch name
@@ -71,10 +75,12 @@ jobs:
     - name: Create version tag and push
       if: steps.version-check.outputs.published == 'no'
       run: |
-        TAGNAME="@cockroachlabs/cluster-ui@$(cat ./package.json | jq -r '.version')"
-        git tag $TAGNAME
-        git push origin $TAGNAME
+        TAGNAME="@cockroachlabs/cluster-ui@$(jq -r '.version' ./package.json)"
+        if ! [ $(git tag -l "$TAGNAME") ]; then
+          git tag $TAGNAME
+          git push origin $TAGNAME
+        fi
 
     - name: Publish patch version
       if: steps.version-check.outputs.published == 'no'
-      run: yarn publish --access public --tag ${{ steps.branch-name.outputs.branch }}
+      run: npm publish --access public --tag ${{ steps.branch-name.outputs.branch }} --ignore-scripts

--- a/pkg/ui/workspaces/cluster-ui/package.json
+++ b/pkg/ui/workspaces/cluster-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cockroachlabs/cluster-ui",
-  "version": "22.1.11",
+  "version": "22.1.12",
   "description": "Cluster UI is a library of large features shared between CockroachDB and CockroachCloud",
   "repository": {
     "type": "git",
@@ -8,6 +8,10 @@
   },
   "main": "dist/js/main.js",
   "types": "dist/types/index.d.ts",
+  "files": [
+    "dist/",
+    "AUTHORS"
+  ],
   "scripts": {
     "build": "npm-run-all -p build:typescript build:bundle",
     "build:bundle": "NODE_ENV=production webpack --display-error-details --mode=production",


### PR DESCRIPTION
This pull-request fixes a few bad assumptions on my part.

1) `actions/setup-node@v3` uses Yarn 2 by default which does not read the `NPM_TOKEN` environment variable or the `.npmrc` config.
2) `actions/setup-node@v3` creates an `.npmrc` internally and [uses](https://github.com/actions/setup-node/blob/v3.6.0/src/authutil.ts#L48) the `NODE_AUTH_TOKEN` environmental variable instead of `NPM_TOKEN`.
3) `actions/setup-node@v3` [doesn't seem to default](https://github.com/actions/setup-node/blob/v3.6.0/src/authutil.ts#L49) the npm registry in the `.npmrc`.

To test this out, I am making this PR from a source branch (instead of a fork) and have enabled `pull_request` as a trigger (which I will remove before merging). But to prove a successful runs,

- [publish_cluster_ui #14](https://github.com/cockroachdb/cockroach/actions/runs/4027168572/jobs/6922567034) published [22.1.12-publishtest.0](https://www.npmjs.com/package/@cockroachlabs/cluster-ui/v/22.1.12-publishtest.0)
- [publish_cluster_ui #15](https://github.com/cockroachdb/cockroach/actions/runs/4027319356/jobs/6922900294) published [22.1.12-publishtest.1](https://www.npmjs.com/package/@cockroachlabs/cluster-ui/v/22.1.12-publishtest.1)
- [publish_cluster_ui #16](https://github.com/cockroachdb/cockroach/actions/runs/4027568330/jobs/6923448840) published [22.1.12-publishtest.2](https://www.npmjs.com/package/@cockroachlabs/cluster-ui?activeTab=versions) (along with [tag](https://github.com/cockroachdb/cockroach/releases/tag/@cockroachlabs/cluster-ui@22.1.12-publishtest.2))

Note: I'm also adding `--ignore-scripts` to the publish command to not run the build twice.