### PR TITLE
release-22.1: sql: correctly handle COLLATEd columns in COPY

### DIFF
--- a/pkg/jobs/registry_external_test.go
+++ b/pkg/jobs/registry_external_test.go
@@ -493,7 +493,7 @@ func TestErrorsPopulatedOnRetry(t *testing.T) {
 		errorIdx    = executionErrorRE.SubexpIndex("error")
 	)
 	parseTimestamp := func(t *testing.T, s string) time.Time {
-		ptc := tree.NewParseTimeContext(timeutil.Now())
+		ptc := tree.NewParseContext(timeutil.Now())
 		ts, _, err := tree.ParseDTimestamp(ptc, s, time.Microsecond)
 		require.NoError(t, err)
 		return ts.Time

--- a/pkg/sql/copy_in_test.go
+++ b/pkg/sql/copy_in_test.go
@@ -156,6 +156,7 @@ func TestCopyRandom(t *testing.T) {
 		CREATE TABLE IF NOT EXISTS d.t (
 			id INT PRIMARY KEY,
 			n INTERVAL,
+			cs TEXT COLLATE en_us_u_ks_level2,
 			o BOOL,
 			i INT,
 			f FLOAT,
@@ -182,7 +183,7 @@ func TestCopyRandom(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	stmt, err := txn.Prepare(pq.CopyInSchema("d", "t", "id", "n", "o", "i", "f", "e", "t", "ttz", "ts", "s", "b", "u", "ip", "tz", "geography", "geometry", "box2d"))
+	stmt, err := txn.Prepare(pq.CopyInSchema("d", "t", "id", "n", "cs", "o", "i", "f", "e", "t", "ttz", "ts", "s", "b", "u", "ip", "tz", "geography", "geometry", "box2d"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -191,6 +192,7 @@ func TestCopyRandom(t *testing.T) {
 	typs := []*types.T{
 		types.Int,
 		types.Interval,
+		types.MakeCollatedString(types.String, "en_us_u_ks_level2"),
 		types.Bool,
 		types.Int,
 		types.Float,
@@ -220,8 +222,11 @@ func TestCopyRandom(t *testing.T) {
 			} else {
 				d := randgen.RandDatum(rng, t, false)
 				ds = tree.AsStringWithFlags(d, tree.FmtBareStrings)
-				switch t {
-				case types.Float:
+				switch t.Family() {
+				case types.CollatedStringFamily:
+					// For collated strings, we just want the raw contents in COPY.
+					ds = d.(*tree.DCollatedString).Contents
+				case types.FloatFamily:
 					ds = strings.TrimSuffix(ds, ".0")
 				}
 			}

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -3171,7 +3171,7 @@ value if you rely on the HLC for accuracy.`,
 		stringOverload1(
 			func(ctx *tree.EvalContext, s string) (tree.Datum, error) {
 				ts, dependsOnContext, err := tree.ParseDTimestamp(
-					tree.NewParseTimeContext(ctx.GetTxnTimestamp(time.Microsecond).Time),
+					tree.NewParseContext(ctx.GetTxnTimestamp(time.Microsecond).Time),
 					s,
 					time.Microsecond,
 				)
@@ -3226,7 +3226,7 @@ value if you rely on the HLC for accuracy.`,
 		stringOverload1(
 			func(ctx *tree.EvalContext, s string) (tree.Datum, error) {
 				ts, dependsOnContext, err := tree.ParseDDate(
-					tree.NewParseTimeContext(ctx.GetTxnTimestamp(time.Microsecond).Time),
+					tree.NewParseContext(ctx.GetTxnTimestamp(time.Microsecond).Time),
 					s,
 				)
 				if err != nil {
@@ -3276,7 +3276,7 @@ value if you rely on the HLC for accuracy.`,
 		stringOverload1(
 			func(ctx *tree.EvalContext, s string) (tree.Datum, error) {
 				t, dependsOnContext, err := tree.ParseDTime(
-					tree.NewParseTimeContext(ctx.GetTxnTimestamp(time.Microsecond).Time),
+					tree.NewParseContext(ctx.GetTxnTimestamp(time.Microsecond).Time),
 					s,
 					time.Microsecond,
 				)
@@ -3358,7 +3358,7 @@ value if you rely on the HLC for accuracy.`,
 		stringOverload1(
 			func(ctx *tree.EvalContext, s string) (tree.Datum, error) {
 				t, dependsOnContext, err := tree.ParseDTimeTZ(
-					tree.NewParseTimeContext(ctx.GetTxnTimestamp(time.Microsecond).Time),
+					tree.NewParseContext(ctx.GetTxnTimestamp(time.Microsecond).Time),
 					s,
 					time.Microsecond,
 				)
@@ -9528,7 +9528,7 @@ func arrayNumInvertedIndexEntries(
 
 func parseContextFromDateStyle(
 	ctx *tree.EvalContext, dateStyleStr string,
-) (tree.ParseTimeContext, error) {
+) (tree.ParseContext, error) {
 	ds, err := pgdate.ParseDateStyle(dateStyleStr, pgdate.DefaultDateStyle())
 	if err != nil {
 		return nil, err
@@ -9536,9 +9536,9 @@ func parseContextFromDateStyle(
 	if ds.Style != pgdate.Style_ISO {
 		return nil, unimplemented.NewWithIssue(41773, "only ISO style is supported")
 	}
-	return tree.NewParseTimeContext(
+	return tree.NewParseContext(
 		ctx.GetTxnTimestamp(time.Microsecond).Time,
-		tree.NewParseTimeContextOptionDateStyle(ds),
+		tree.NewParseContextOptionDateStyle(ds),
 	), nil
 }
 

--- a/pkg/sql/sem/tree/constant.go
+++ b/pkg/sql/sem/tree/constant.go
@@ -587,7 +587,7 @@ func (expr *StrVal) ResolveAsType(
 		return ParseDByte(expr.s)
 
 	default:
-		ptCtx := simpleParseTimeContext{
+		ptCtx := &simpleParseContext{
 			// We can return any time, but not the zero value - it causes an error when
 			// parsing "yesterday".
 			RelativeParseTime: time.Date(2000, time.January, 2, 3, 4, 5, 0, time.UTC),

--- a/pkg/sql/sem/tree/datum.go
+++ b/pkg/sql/sem/tree/datum.go
@@ -1882,6 +1882,8 @@ type ParseContext interface {
 	// like "tomorrow", and also provides a default time.Location for
 	// parsed times.
 	GetRelativeParseTime() time.Time
+	// GetCollationEnv returns the collation environment.
+	GetCollationEnv() *CollationEnvironment
 	// GetIntervalStyle returns the interval style in the session.
 	GetIntervalStyle() duration.IntervalStyle
 	// GetDateStyle returns the date style in the session.
@@ -1914,14 +1916,20 @@ func NewParseContext(relativeParseTime time.Time, opts ...NewParseContextOption)
 }
 
 type simpleParseContext struct {
-	RelativeParseTime time.Time
-	DateStyle         pgdate.DateStyle
-	IntervalStyle     duration.IntervalStyle
+	RelativeParseTime    time.Time
+	CollationEnvironment CollationEnvironment
+	DateStyle            pgdate.DateStyle
+	IntervalStyle        duration.IntervalStyle
 }
 
 // GetRelativeParseTime implements ParseContext.
 func (ctx *simpleParseContext) GetRelativeParseTime() time.Time {
 	return ctx.RelativeParseTime
+}
+
+// GetCollationEnv implements ParseContext.
+func (ctx *simpleParseContext) GetCollationEnv() *CollationEnvironment {
+	return &ctx.CollationEnvironment
 }
 
 // GetIntervalStyle implements ParseContext.

--- a/pkg/sql/sem/tree/datum_integration_test.go
+++ b/pkg/sql/sem/tree/datum_integration_test.go
@@ -431,7 +431,7 @@ func TestParseDDate(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	ctx := tree.NewParseTimeContext(
+	ctx := tree.NewParseContext(
 		time.Date(2001, time.February, 3, 4, 5, 6, 1000, time.FixedZone("foo", -18000)),
 	)
 
@@ -554,7 +554,7 @@ func TestParseDTime(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	ctx := tree.NewParseTimeContext(
+	ctx := tree.NewParseContext(
 		time.Date(2001, time.February, 3, 4, 5, 6, 1000, time.FixedZone("foo", -18000)),
 	)
 	// Since ParseDTime shares most of the underlying parsing logic to
@@ -627,7 +627,7 @@ func TestParseDTimeError(t *testing.T) {
 
 func TestParseDTimeTZ(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	ctx := tree.NewParseTimeContext(
+	ctx := tree.NewParseContext(
 		time.Date(2001, time.February, 3, 4, 5, 6, 1000, time.FixedZone("foo", 18000)),
 	)
 
@@ -705,7 +705,7 @@ func TestParseDTimestamp(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	ctx := tree.NewParseTimeContext(
+	ctx := tree.NewParseContext(
 		time.Date(2001, time.February, 3, 4, 5, 6, 1000, time.FixedZone("foo", -18000)),
 	)
 
@@ -789,7 +789,7 @@ func TestParseDTimestampTZ(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	local := time.FixedZone("foo", -18000)
-	ctx := tree.NewParseTimeContext(time.Date(2001, time.February, 3, 4, 5, 6, 1000, local))
+	ctx := tree.NewParseContext(time.Date(2001, time.February, 3, 4, 5, 6, 1000, local))
 
 	testData := []struct {
 		str              string

--- a/pkg/sql/sem/tree/eval.go
+++ b/pkg/sql/sem/tree/eval.go
@@ -3984,7 +3984,7 @@ func TimestampToInexactDTimestamp(ts hlc.Timestamp) *DTimestamp {
 	return MustMakeDTimestamp(timeutil.Unix(0, ts.WallTime), time.Microsecond)
 }
 
-// GetRelativeParseTime implements ParseTimeContext.
+// GetRelativeParseTime implements ParseContext.
 func (ctx *EvalContext) GetRelativeParseTime() time.Time {
 	ret := ctx.TxnTimestamp
 	if ret.IsZero() {
@@ -4069,6 +4069,11 @@ func (ctx *EvalContext) GetDateStyle() pgdate.DateStyle {
 		return pgdate.DefaultDateStyle()
 	}
 	return ctx.SessionData().GetDateStyle()
+}
+
+// GetCollationEnv returns the collation env.
+func (ctx *EvalContext) GetCollationEnv() *CollationEnvironment {
+	return &ctx.CollationEnv
 }
 
 // Ctx returns the session's context.

--- a/pkg/sql/sem/tree/fuzz.go
+++ b/pkg/sql/sem/tree/fuzz.go
@@ -16,7 +16,7 @@ package tree
 import "github.com/cockroachdb/cockroach/pkg/util/timeutil"
 
 var (
-	timeCtx = NewParseTimeContext(timeutil.Now())
+	timeCtx = NewParseContext(timeutil.Now())
 )
 
 func FuzzParseDDecimal(data []byte) int {

--- a/pkg/sql/sem/tree/parse_array.go
+++ b/pkg/sql/sem/tree/parse_array.go
@@ -119,7 +119,7 @@ func (p *parseState) gobbleString(isTerminatingChar func(ch byte) bool) (out str
 
 type parseState struct {
 	s                string
-	ctx              ParseTimeContext
+	ctx              ParseContext
 	dependsOnContext bool
 	result           *DArray
 	t                *types.T
@@ -199,9 +199,9 @@ func (p *parseState) parseElement() error {
 // parameter of the array to parse.
 //
 // The dependsOnContext return value indicates if we had to consult the
-// ParseTimeContext (either for the time or the local timezone).
+// ParseContext (either for the time or the local timezone).
 func ParseDArrayFromString(
-	ctx ParseTimeContext, s string, t *types.T,
+	ctx ParseContext, s string, t *types.T,
 ) (_ *DArray, dependsOnContext bool, _ error) {
 	ret, dependsOnContext, err := doParseDArrayFromString(ctx, s, t)
 	if err != nil {
@@ -214,9 +214,9 @@ func ParseDArrayFromString(
 // except the error it returns isn't prettified as a parsing error.
 //
 // The dependsOnContext return value indicates if we had to consult the
-// ParseTimeContext (either for the time or the local timezone).
+// ParseContext (either for the time or the local timezone).
 func doParseDArrayFromString(
-	ctx ParseTimeContext, s string, t *types.T,
+	ctx ParseContext, s string, t *types.T,
 ) (_ *DArray, dependsOnContext bool, _ error) {
 	parser := parseState{
 		s:      s,

--- a/pkg/sql/sem/tree/parse_string.go
+++ b/pkg/sql/sem/tree/parse_string.go
@@ -74,6 +74,8 @@ func ParseAndRequireString(
 			}
 			d = NewDOid(*i)
 		}
+	case types.CollatedStringFamily:
+		d, err = NewDCollatedString(s, t.Locale(), ctx.GetCollationEnv())
 	case types.StringFamily:
 		// If the string type specifies a limit we truncate to that limit:
 		//   'hello'::CHAR(2) -> 'he'

--- a/pkg/sql/sem/tree/parse_string.go
+++ b/pkg/sql/sem/tree/parse_string.go
@@ -23,9 +23,9 @@ import (
 // strings are not handled.
 //
 // The dependsOnContext return value indicates if we had to consult the
-// ParseTimeContext (either for the time or the local timezone).
+// ParseContext (either for the time or the local timezone).
 func ParseAndRequireString(
-	t *types.T, s string, ctx ParseTimeContext,
+	t *types.T, s string, ctx ParseContext,
 ) (d Datum, dependsOnContext bool, err error) {
 	switch t.Family() {
 	case types.ArrayFamily:

--- a/pkg/sql/sem/tree/parse_tuple.go
+++ b/pkg/sql/sem/tree/parse_tuple.go
@@ -95,7 +95,7 @@ func (p *tupleParseState) gobbleString() (out string, err error) {
 type tupleParseState struct {
 	s                string
 	tupleIdx         int
-	ctx              ParseTimeContext
+	ctx              ParseContext
 	dependsOnContext bool
 	result           *DTuple
 	t                *types.T
@@ -174,9 +174,9 @@ func (p *tupleParseState) parseElement() error {
 // tuple to parse.
 //
 // The dependsOnContext return value indicates if we had to consult the
-// ParseTimeContext (either for the time or the local timezone).
+// ParseContext (either for the time or the local timezone).
 func ParseDTupleFromString(
-	ctx ParseTimeContext, s string, t *types.T,
+	ctx ParseContext, s string, t *types.T,
 ) (_ *DTuple, dependsOnContext bool, _ error) {
 	ret, dependsOnContext, err := doParseDTupleFromString(ctx, s, t)
 	if err != nil {
@@ -189,9 +189,9 @@ func ParseDTupleFromString(
 // except the error it returns isn't prettified as a parsing error.
 //
 // The dependsOnContext return value indicates if we had to consult the
-// ParseTimeContext (either for the time or the local timezone).
+// ParseContext (either for the time or the local timezone).
 func doParseDTupleFromString(
-	ctx ParseTimeContext, s string, t *types.T,
+	ctx ParseContext, s string, t *types.T,
 ) (_ *DTuple, dependsOnContext bool, _ error) {
 	if t.TupleContents() == nil {
 		return nil, false, errors.AssertionFailedf("not a tuple type %s (%T)", t, t)

--- a/pkg/sql/user.go
+++ b/pkg/sql/user.go
@@ -313,7 +313,7 @@ func retrieveAuthInfo(
 				// This is okay because the VALID UNTIL is stored as a string
 				// representation of a TimestampTZ which has the same underlying
 				// representation in the table as a Timestamp (UTC time).
-				timeCtx := tree.NewParseTimeContext(timeutil.Now())
+				timeCtx := tree.NewParseContext(timeutil.Now())
 				aInfo.ValidUntil, _, err = tree.ParseDTimestamp(timeCtx, ts, time.Microsecond)
 				if err != nil {
 					return aInfo, errors.Wrap(err,


### PR DESCRIPTION
Backport 2/2 commits from #95894.

/cc @cockroachdb/release

---

See individual commits for details.

Resolves #95887

Release justification: fixes a critical bug with COPY
