### PR TITLE
colfetcher: fix a possible "race" around IndexFetchSpec

### DIFF
--- a/pkg/sql/colfetcher/cfetcher_wrapper.go
+++ b/pkg/sql/colfetcher/cfetcher_wrapper.go
@@ -24,6 +24,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/colmem"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
 	"github.com/cockroachdb/cockroach/pkg/storage"
+	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/mon"
 )
 
@@ -33,16 +34,15 @@ var DirectScansEnabled = settings.RegisterBoolSetting(
 	settings.TenantWritable,
 	"sql.distsql.direct_columnar_scans.enabled",
 	"set to true to enable the 'direct' columnar scans in the KV layer",
-	false,
+	directScansEnabledDefault,
 )
 
-// TODO(yuzefovich): uncomment this when #95937 is fixed.
-//var directScansEnabledDefault = util.ConstantWithMetamorphicTestBool(
-//	"direct-scans-enabled",
-//	// TODO(yuzefovich, 23.1): update the default to 'true' for multi-tenant
-//	// setups.
-//	false,
-//)
+var directScansEnabledDefault = util.ConstantWithMetamorphicTestBool(
+	"direct-scans-enabled",
+	// TODO(yuzefovich, 23.1): update the default to 'true' for multi-tenant
+	// setups.
+	false,
+)
 
 // cFetcherWrapper implements the storage.CFetcherWrapper interface. See a large
 // comment in storage/col_mvcc.go for more details.


### PR DESCRIPTION
Previously, it was possible to encounter a "data race" when using the
direct columnar scans. In particular, the `fetchpb.IndexFetchSpec` is
now included in the `BatchRequest` and also is embeded by value into
`execinfrapb.TableReaderSpec`. Previously, we would take a reference to
that value and would plumb it into the `BatchRequest`. Importantly, the
`TableReaderSpec` is put back to its pool (and fully unset, including
the index fetch spec) at the flow cleanup time. This setup made it
possible for the race transport to report a "data race" since the
`BatchRequest`s are currently assumed to be immutable. The "data race"
is in quotes because it's a false positive from
`kvcoord.GRPCTransportFactory` (which continues to read the
`BatchRequest` even after the response was received). This is now fixed
by making a copy of the `IndexFetchSpec` when creating a
`ColBatchDirectScan`.

Fixes: #95937.

Release note: None