### PR TITLE
[DNM] roachpb: include coldata.Batch'es in Scan and ReverseScan responses

### DIFF
--- a/pkg/roachpb/BUILD.bazel
+++ b/pkg/roachpb/BUILD.bazel
@@ -36,6 +36,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/base/serverident",
+        "//pkg/col/coldata",
         "//pkg/geo/geopb",
         "//pkg/keysbase",
         "//pkg/kv/kvnemesis/kvnemesisutil",

--- a/pkg/roachpb/api.proto
+++ b/pkg/roachpb/api.proto
@@ -593,6 +593,9 @@ message ScanRequest {
 
 // A ScanResponse is the return value from the Scan() method.
 message ScanResponse {
+  // TODO: figure out whether we should not auto-get String() implementation.
+  option (gogoproto.typedecl) = false;
+
   ResponseHeader header = 1 [(gogoproto.nullable) = false, (gogoproto.embed) = true];
   // Empty if no rows were scanned.
   repeated KeyValue rows = 2 [(gogoproto.nullable) = false];
@@ -650,6 +653,9 @@ message ReverseScanRequest {
 
 // A ReverseScanResponse is the return value from the ReverseScan() method.
 message ReverseScanResponse {
+  // TODO: figure out whether we should not auto-get String() implementation.
+  option (gogoproto.typedecl) = false;
+
   ResponseHeader header = 1 [(gogoproto.nullable) = false, (gogoproto.embed) = true];
   // Empty if no rows were scanned.
   repeated KeyValue rows = 2 [(gogoproto.nullable) = false];


### PR DESCRIPTION
This commit makes it so that we can pass `coldata.Batch`es directly via `ScanResponse` and `ReverseScanResponse` structs without serializing it. This is achieved by disabling the automatically-generated struct declaration and adding the corresponding field into the manually-written one. The protobuf message is unaware of this new field, so it won't attempt to serialize it.

There are a couple of questions:
- is this acceptable in general? We do have a precedent for doing something like this in `execinfrapb.Expression`.
- is making `roachpb` depend on `col/coldata` ok?

The alternative can be to define a custom protobuf message that would store `[]interface` and would not be serialized.

The use case for this is that we want to be able to pass `coldata.Batch`es during the direct columnar scan in-process, without serialization, if a request is evaluated locally (WIP available at #95033).

Release note: None