### PR TITLE
sqlinstance: fix value encoding in MR schema

### DIFF
--- a/pkg/ccl/multiregionccl/cold_start_latency_test.go
+++ b/pkg/ccl/multiregionccl/cold_start_latency_test.go
@@ -49,7 +49,6 @@ func TestColdStartLatency(t *testing.T) {
 	defer log.Scope(t).Close(t)
 	skip.UnderRace(t, "too slow")
 	skip.UnderStress(t, "too slow")
-	skip.WithIssue(t, 95644)
 	defer envutil.TestSetEnv(t, "COCKROACH_MR_SYSTEM_DATABASE", "1")()
 
 	// We'll need to make some per-node args to assign the different
@@ -160,9 +159,6 @@ func TestColdStartLatency(t *testing.T) {
 		if !isTenant {
 			stmts = append(stmts,
 				"ALTER TENANT ALL SET CLUSTER SETTING sql.zone_configs.allow_for_secondary_tenant.enabled = true",
-				// Disable automatic stats because it gets upset about the way we change the column
-				// structure.
-				"ALTER TENANT ALL SET CLUSTER SETTING sql.stats.automatic_collection.enabled = false",
 				"ALTER TENANT ALL SET CLUSTER SETTING sql.multi_region.allow_abstractions_for_secondary_tenants.enabled = true",
 				`alter range meta configure zone using constraints = '{"+region=us-east1": 1, "+region=us-west1": 1, "+region=europe-west1": 1}';`)
 		} else {

--- a/pkg/sql/sqlinstance/instancestorage/BUILD.bazel
+++ b/pkg/sql/sqlinstance/instancestorage/BUILD.bazel
@@ -28,7 +28,6 @@ go_library(
         "//pkg/sql/catalog/systemschema",
         "//pkg/sql/enum",
         "//pkg/sql/rowenc/valueside",
-        "//pkg/sql/sem/catid",
         "//pkg/sql/sem/tree",
         "//pkg/sql/sqlinstance",
         "//pkg/sql/sqlliveness",
@@ -49,6 +48,7 @@ go_library(
 go_test(
     name = "instancestorage_test",
     srcs = [
+        "helpers_test.go",
         "instancereader_test.go",
         "instancestorage_internal_test.go",
         "instancestorage_test.go",
@@ -67,8 +67,8 @@ go_test(
         "//pkg/security/securitytest",
         "//pkg/server",
         "//pkg/settings/cluster",
-        "//pkg/sql/catalog/descpb",
         "//pkg/sql/catalog/descs",
+        "//pkg/sql/catalog/desctestutils",
         "//pkg/sql/catalog/systemschema",
         "//pkg/sql/enum",
         "//pkg/sql/sqlinstance",
@@ -76,6 +76,7 @@ go_test(
         "//pkg/sql/sqlliveness/slstorage",
         "//pkg/testutils",
         "//pkg/testutils/serverutils",
+        "//pkg/testutils/skip",
         "//pkg/testutils/sqlutils",
         "//pkg/testutils/testcluster",
         "//pkg/util/encoding",
@@ -89,6 +90,7 @@ go_test(
         "//pkg/util/timeutil",
         "//pkg/util/uuid",
         "@com_github_cockroachdb_errors//:errors",
+        "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
     ],
 )

--- a/pkg/sql/sqlinstance/instancestorage/helpers_test.go
+++ b/pkg/sql/sqlinstance/instancestorage/helpers_test.go
@@ -1,0 +1,31 @@
+// Copyright 2023 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package instancestorage
+
+import (
+	"strings"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/systemschema"
+)
+
+// GetTableSQLForDatabase is a testing helper to construct the appropriate
+// table schema for a given database taking into consideration whether we're
+// configured for the MR schema.
+func GetTableSQLForDatabase(dbName string) string {
+	schema := systemschema.SQLInstancesTableSchema
+	if systemschema.TestSupportMultiRegion() {
+		schema = systemschema.MrSQLInstancesTableSchema
+	}
+	schema = strings.Replace(schema,
+		`CREATE TABLE system.sql_instances`,
+		`CREATE TABLE "`+dbName+`".sql_instances`, 1)
+	return schema
+}

--- a/pkg/sql/sqlinstance/instancestorage/instancestorage.go
+++ b/pkg/sql/sqlinstance/instancestorage/instancestorage.go
@@ -27,8 +27,9 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql"
-	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descs"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/systemschema"
 	"github.com/cockroachdb/cockroach/pkg/sql/enum"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlinstance"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlliveness"
@@ -115,13 +116,13 @@ func (r *instancerow) isAvailable() bool {
 func NewTestingStorage(
 	db *kv.DB,
 	codec keys.SQLCodec,
-	sqlInstancesTableID descpb.ID,
+	table catalog.TableDescriptor,
 	slReader sqlliveness.Reader,
 	settings *cluster.Settings,
 ) *Storage {
 	s := &Storage{
 		db:       db,
-		rowcodec: makeRowCodec(codec, sqlInstancesTableID),
+		rowcodec: makeRowCodec(codec, table),
 		slReader: slReader,
 		settings: settings,
 	}
@@ -132,7 +133,7 @@ func NewTestingStorage(
 func NewStorage(
 	db *kv.DB, codec keys.SQLCodec, slReader sqlliveness.Reader, settings *cluster.Settings,
 ) *Storage {
-	return NewTestingStorage(db, codec, keys.SQLInstancesTableID, slReader, settings)
+	return NewTestingStorage(db, codec, systemschema.SQLInstancesTable(), slReader, settings)
 }
 
 // CreateNodeInstance claims a unique instance identifier for the SQL pod, and

--- a/pkg/sql/sqlinstance/instancestorage/instancestorage_test.go
+++ b/pkg/sql/sqlinstance/instancestorage/instancestorage_test.go
@@ -16,7 +16,6 @@ import (
 	"fmt"
 	"math/rand"
 	"sort"
-	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -24,8 +23,8 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
-	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descs"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/desctestutils"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/systemschema"
 	"github.com/cockroachdb/cockroach/pkg/sql/enum"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlinstance"
@@ -34,6 +33,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlliveness/slstorage"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
@@ -43,6 +43,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 	"github.com/cockroachdb/errors"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -70,15 +71,13 @@ func TestStorage(t *testing.T) {
 	) {
 		dbName := t.Name()
 		tDB.Exec(t, `CREATE DATABASE "`+dbName+`"`)
-		schema := strings.Replace(systemschema.SQLInstancesTableSchema,
-			`CREATE TABLE system.sql_instances`,
-			`CREATE TABLE "`+dbName+`".sql_instances`, 1)
+		schema := instancestorage.GetTableSQLForDatabase(dbName)
 		tDB.Exec(t, schema)
-		tableID := getTableID(t, tDB, dbName, "sql_instances")
+		table := desctestutils.TestingGetPublicTableDescriptor(kvDB, s.Codec(), dbName, "sql_instances")
 		clock := hlc.NewClock(timeutil.NewTestTimeSource(), base.DefaultMaxClockOffset)
 		stopper := stop.NewStopper()
 		slStorage := slstorage.NewFakeStorage()
-		storage := instancestorage.NewTestingStorage(kvDB, keys.SystemSQLCodec, tableID, slStorage, s.ClusterSettings())
+		storage := instancestorage.NewTestingStorage(kvDB, keys.SystemSQLCodec, table, slStorage, s.ClusterSettings())
 		return stopper, storage, slStorage, clock
 	}
 
@@ -278,15 +277,13 @@ func TestSQLAccess(t *testing.T) {
 	tDB := sqlutils.MakeSQLRunner(sqlDB)
 	dbName := t.Name()
 	tDB.Exec(t, `CREATE DATABASE "`+dbName+`"`)
-	schema := strings.Replace(systemschema.SQLInstancesTableSchema,
-		`CREATE TABLE system.sql_instances`,
-		`CREATE TABLE "`+dbName+`".sql_instances`, 1)
+	schema := instancestorage.GetTableSQLForDatabase(dbName)
 	tDB.Exec(t, schema)
-	tableID := getTableID(t, tDB, dbName, "sql_instances")
+	table := desctestutils.TestingGetPublicTableDescriptor(kvDB, s.Codec(), dbName, "sql_instances")
 	stopper := stop.NewStopper()
 	defer stopper.Stop(ctx)
 	storage := instancestorage.NewTestingStorage(
-		kvDB, keys.SystemSQLCodec, tableID, slstorage.NewFakeStorage(), s.ClusterSettings())
+		kvDB, keys.SystemSQLCodec, table, slstorage.NewFakeStorage(), s.ClusterSettings())
 	const (
 		tierStr         = "region=test1,zone=test2"
 		expiration      = time.Minute
@@ -315,7 +312,10 @@ func TestSQLAccess(t *testing.T) {
 	var parsedAddr gosql.NullString
 	var parsedSqlAddr gosql.NullString
 	var parsedLocality gosql.NullString
-	rows.Next()
+	if !assert.True(t, rows.Next()) {
+		require.NoError(t, rows.Err())
+		require.NoError(t, rows.Close())
+	}
 	err = rows.Scan(&parsedInstanceID, &parsedAddr, &parsedSqlAddr, &parsedSessionID, &parsedLocality)
 	require.NoError(t, err)
 	require.Equal(t, instance.InstanceID, parsedInstanceID)
@@ -342,6 +342,10 @@ func TestSQLAccess(t *testing.T) {
 func TestRefreshSession(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
+
+	if systemschema.TestSupportMultiRegion() {
+		skip.IgnoreLintf(t, "this test gets run twice and is not set up for use with the MR schema")
+	}
 
 	ctx := context.Background()
 	s, sqlDB, _ := serverutils.StartServer(t, base.TestServerArgs{Locality: roachpb.Locality{Tiers: []roachpb.Tier{{Key: "abc", Value: "xyz"}}}})
@@ -398,15 +402,13 @@ func TestConcurrentCreateAndRelease(t *testing.T) {
 	tDB := sqlutils.MakeSQLRunner(sqlDB)
 	dbName := t.Name()
 	tDB.Exec(t, `CREATE DATABASE "`+dbName+`"`)
-	schema := strings.Replace(systemschema.SQLInstancesTableSchema,
-		`CREATE TABLE system.sql_instances`,
-		`CREATE TABLE "`+dbName+`".sql_instances`, 1)
+	schema := instancestorage.GetTableSQLForDatabase(dbName)
 	tDB.Exec(t, schema)
-	tableID := getTableID(t, tDB, dbName, "sql_instances")
+	table := desctestutils.TestingGetPublicTableDescriptor(kvDB, s.Codec(), dbName, "sql_instances")
 	stopper := stop.NewStopper()
 	slStorage := slstorage.NewFakeStorage()
 	defer stopper.Stop(ctx)
-	storage := instancestorage.NewTestingStorage(kvDB, keys.SystemSQLCodec, tableID, slStorage, s.ClusterSettings())
+	storage := instancestorage.NewTestingStorage(kvDB, keys.SystemSQLCodec, table, slStorage, s.ClusterSettings())
 	instancestorage.PreallocatedCount.Override(ctx, &s.ClusterSettings().SV, 1)
 
 	const (
@@ -547,11 +549,9 @@ func TestReclaimLoop(t *testing.T) {
 	tDB := sqlutils.MakeSQLRunner(sqlDB)
 	dbName := t.Name()
 	tDB.Exec(t, `CREATE DATABASE "`+dbName+`"`)
-	schema := strings.Replace(systemschema.SQLInstancesTableSchema,
-		`CREATE TABLE system.sql_instances`,
-		`CREATE TABLE "`+dbName+`".sql_instances`, 1)
+	schema := instancestorage.GetTableSQLForDatabase(dbName)
 	tDB.Exec(t, schema)
-	tableID := getTableID(t, tDB, dbName, "sql_instances")
+	tableID := desctestutils.TestingGetPublicTableDescriptor(kvDB, s.Codec(), dbName, "sql_instances")
 	slStorage := slstorage.NewFakeStorage()
 	storage := instancestorage.NewTestingStorage(kvDB, keys.SystemSQLCodec, tableID, slStorage, s.ClusterSettings())
 	storage.TestingKnobs.JitteredIntervalFn = func(d time.Duration) time.Duration {
@@ -675,20 +675,6 @@ func TestReclaimLoop(t *testing.T) {
 			require.Empty(t, instance.Locality)
 		}
 	}
-}
-
-func getTableID(
-	t *testing.T, db *sqlutils.SQLRunner, dbName, tableName string,
-) (tableID descpb.ID) {
-	t.Helper()
-	db.QueryRow(t, `
- select u.id
-  from system.namespace t
-  join system.namespace u
-  on t.id = u."parentID"
-  where t.name = $1 and u.name = $2`,
-		dbName, tableName).Scan(&tableID)
-	return tableID
 }
 
 func sortInstances(instances []sqlinstance.InstanceInfo) {

--- a/pkg/sql/sqlinstance/instancestorage/row_codec_test.go
+++ b/pkg/sql/sqlinstance/instancestorage/row_codec_test.go
@@ -26,7 +26,7 @@ import (
 )
 
 const (
-	tableID  = 42
+	tableID  = 46
 	tenantID = 1337
 )
 
@@ -40,11 +40,11 @@ func TestRowCodec(t *testing.T) {
 
 	t.Run("RegionalByRow", func(t *testing.T) {
 		defer envutil.TestSetEnv(t, "COCKROACH_MR_SYSTEM_DATABASE", "1")()
-		testEncoder(t, makeRowCodec(codec, tableID), tenantID)
+		testEncoder(t, makeRowCodec(codec, systemschema.SQLInstancesTable()), tenantID)
 	})
 	t.Run("RegionalByTable", func(t *testing.T) {
 		defer envutil.TestSetEnv(t, "COCKROACH_MR_SYSTEM_DATABASE", "0")()
-		testEncoder(t, makeRowCodec(codec, tableID), tenantID)
+		testEncoder(t, makeRowCodec(codec, systemschema.SQLInstancesTable()), tenantID)
 	})
 }
 


### PR DESCRIPTION
In the MR schema, the region is column 5 and the sql_addr is column 6. The encoding logic hard-coded the idea that the sql_addr was column 5. This lead to invariants being violated when decoding rows because they ended up not having a column 6 value populated despite it being expected.

This lead to failing tests at quite a distance. We never really read the values with sql outside of that test. That test ran long enough that automatic stats would end up running.

This also removes the ultimately incorrect band-aid introduced in #95767 which merely served to make the problem more rare.

This is fallout from #94630 not dealing with the MR table structures.

Fixes: #95763
Fixes: #95644

Release note: None