### PR TITLE
optbuilder: fix internal error in LATERAL queries with redundant function calls

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/srfs
+++ b/pkg/sql/logictest/testdata/logic_test/srfs
@@ -1270,3 +1270,34 @@ SELECT (x).* FROM (SELECT unnest(ARRAY[t58438.*]) FROM t58438) v(x);
 1  2
 3  4
 5  6
+
+subtest redundant_zip_expression
+
+statement ok
+SET testing_optimizer_disable_rule_probability = 1.0;
+
+statement ok
+CREATE TABLE t95615 (c1 INET PRIMARY KEY)
+
+statement ok
+INSERT INTO t95615 VALUES ('192.168.0.1'::INET)
+
+# Test that a redundant function call in a ProjectSet doesn't crash due to
+# being built into more than one zip expression.
+query TTTI
+SELECT * FROM t95615, LATERAL ROWS FROM (hostmask(c1), hostmask(c1)) WITH ORDINALITY
+----
+192.168.0.1  0.0.0.0  0.0.0.0  1
+
+statement ok
+CREATE FUNCTION f95615() RETURNS FLOAT IMMUTABLE LEAKPROOF LANGUAGE SQL AS 'SELECT 1.1'
+
+# A redundant UDF call should be added only once in a zip expression and not
+# error out.
+query TFFI
+SELECT * FROM t95615, LATERAL ROWS FROM (f95615(), f95615()) WITH ORDINALITY
+----
+192.168.0.1  1.1  1.1  1
+
+statement ok
+RESET testing_optimizer_disable_rule_probability

--- a/pkg/sql/opt/optbuilder/testdata/srfs
+++ b/pkg/sql/opt/optbuilder/testdata/srfs
@@ -1089,3 +1089,51 @@ project
  │         └── filters (true)
  └── projections
       └── a:6 || 'foo' [as="?column?":8]
+
+exec-ddl
+CREATE TABLE t95615 (c1 INET PRIMARY KEY);
+----
+
+# Only a single hostmask function should be added as a zip expression.
+build
+SELECT * FROM t95615, LATERAL ROWS FROM (hostmask(c1), hostmask(c1)) WITH ORDINALITY;
+----
+project
+ ├── columns: c1:1!null hostmask:4 hostmask:4 ordinality:5!null
+ └── inner-join-apply
+      ├── columns: c1:1!null crdb_internal_mvcc_timestamp:2 tableoid:3 hostmask:4 ordinality:5!null
+      ├── scan t95615
+      │    └── columns: c1:1!null crdb_internal_mvcc_timestamp:2 tableoid:3
+      ├── ordinality
+      │    ├── columns: hostmask:4 ordinality:5!null
+      │    └── project-set
+      │         ├── columns: hostmask:4
+      │         ├── values
+      │         │    └── ()
+      │         └── zip
+      │              └── hostmask(c1:1)
+      └── filters (true)
+
+exec-ddl
+CREATE FUNCTION f95615() RETURNS FLOAT IMMUTABLE LEAKPROOF LANGUAGE SQL AS 'SELECT 1.1'
+----
+
+# A redundant UDF call should not be added as a zip expression.
+build
+SELECT * FROM t95615, LATERAL ROWS FROM (f95615(), f95615()) WITH ORDINALITY
+----
+project
+ ├── columns: c1:1!null f95615:6 f95615:6 ordinality:9!null
+ └── inner-join-apply
+      ├── columns: c1:1!null crdb_internal_mvcc_timestamp:2 tableoid:3 f95615:6 ordinality:9!null
+      ├── scan t95615
+      │    └── columns: c1:1!null crdb_internal_mvcc_timestamp:2 tableoid:3
+      ├── ordinality
+      │    ├── columns: f95615:6 ordinality:9!null
+      │    └── project-set
+      │         ├── columns: f95615:6
+      │         ├── values
+      │         │    └── ()
+      │         └── zip
+      │              └── f95615()
+      └── filters (true)


### PR DESCRIPTION
Fixes #95615

Function `optbuilder.Builder.buildZip` may try to build 2 identical function
calls into 2 zip expressions, each one adding one or more columns to the
output. However, if buildZip's called to `buildScalar` recognizes a scalar
expression has already been built, it skips adding a new output columns and
returns the previously-built output column. This mismatch in the number of
output columns actually built, and the number of columns communicated to
the parent expression via `outScope` confuses the execution engine, and in
this case we error out because the expected data type of one column doesn't
match the actual data type.

The fix is to skip building zip expressions with redundant expressions which
already exist in `outScope`.

Release note (bug fix): This patch fixes rare internal errors in LATERAL
queries with redundant function calls.