### PR TITLE
roachprod: remove string splitting logic for arguments

### DIFF
--- a/pkg/cmd/roachtest/tests/decommission.go
+++ b/pkg/cmd/roachtest/tests/decommission.go
@@ -343,7 +343,11 @@ func runDecommission(
 				return err
 			}
 			startOpts := option.DefaultStartOpts()
-			startOpts.RoachprodOpts.ExtraArgs = append(startOpts.RoachprodOpts.ExtraArgs, fmt.Sprintf("--join %s --attrs=node%d", internalAddrs[0], node))
+			extraArgs := []string{
+				"--join", internalAddrs[0],
+				fmt.Sprintf("--attrs=node%d", node),
+			}
+			startOpts.RoachprodOpts.ExtraArgs = append(startOpts.RoachprodOpts.ExtraArgs, extraArgs...)
 			if err := c.StartE(ctx, t.L(), startOpts, install.MakeClusterSettings(), c.Node(node)); err != nil {
 				return err
 			}
@@ -842,7 +846,10 @@ func runDecommissionRandomized(ctx context.Context, t test.Test, c cluster.Clust
 			}
 			joinAddr := internalAddrs[0]
 			startOpts := option.DefaultStartOpts()
-			startOpts.RoachprodOpts.ExtraArgs = append(startOpts.RoachprodOpts.ExtraArgs, fmt.Sprintf("--join %s", joinAddr))
+			startOpts.RoachprodOpts.ExtraArgs = append(
+				startOpts.RoachprodOpts.ExtraArgs,
+				[]string{"--join", joinAddr}...,
+			)
 			c.Start(ctx, t.L(), startOpts, install.MakeClusterSettings(), c.Node(targetNode))
 		}
 

--- a/pkg/roachprod/install/cockroach.go
+++ b/pkg/roachprod/install/cockroach.go
@@ -86,7 +86,11 @@ func argExists(args []string, target string) int {
 type StartOpts struct {
 	Target     StartTarget
 	Sequential bool
-	ExtraArgs  []string
+	// ExtraArgs are extra arguments used when starting the node. Multiple
+	// arguments should be passed as separate items in the slice. For example:
+	//   Instead of: []string{"--flag foo bar"}
+	//   Use:        []string{"--flag", "foo", "bar"}
+	ExtraArgs []string
 
 	// ScheduleBackups starts a backup schedule once the cluster starts
 	ScheduleBackups    bool
@@ -557,7 +561,7 @@ func (c *SyncedCluster) generateStartArgs(
 		if err != nil {
 			return nil, err
 		}
-		args = append(args, strings.Split(expandedArg, " ")...)
+		args = append(args, expandedArg)
 	}
 
 	return args, nil


### PR DESCRIPTION
Currently, if `ExtraArgs` (a `[]string`) is specified for the start options for a cluster, and an argument in the slice contains whitespace, the argument will be split into sub-arguments.

This results in situations where an argument intended to be interpreted as a literal string is split into separate arguments. E.g.

```
ExtraArgs = []{"'foo bar baz'"} // becomes "'foo" "bar" "baz'"
```

Remove the string splitting logic, instead relying on callers to specify arguments as already "pre-split".

Improve documentation.

Release note: None.

Epic: None.