### PR TITLE
cli: evaluate readiness prior to node decommission

### DIFF
--- a/pkg/cli/cliflags/flags.go
+++ b/pkg/cli/cliflags/flags.go
@@ -1251,6 +1251,26 @@ in the history of the cluster.`,
 as target of the decommissioning or recommissioning command.`,
 	}
 
+	NodeDecommissionChecks = FlagInfo{
+		Name: "checks",
+		Description: `
+Specifies how to evaluate readiness checks prior to node decommission.
+Takes any of the following values:
+<PRE>
+
+  - enabled  evaluate readiness prior to starting node decommission.
+  - strict   use strict readiness evaluation mode prior to node decommission.
+  - skip     skip readiness checks and immediately request node decommission.
+             Use when rerunning node decommission.
+</PRE>`,
+	}
+
+	NodeDecommissionDryRun = FlagInfo{
+		Name: "dry-run",
+		Description: `Only evaluate decommission readiness and check decommission
+status, without actually decommissioning the node.`,
+	}
+
 	NodeDrainSelf = FlagInfo{
 		Name: "self",
 		Description: `Use the node ID of the node connected to via --host

--- a/pkg/cli/context.go
+++ b/pkg/cli/context.go
@@ -543,6 +543,8 @@ func setDrainContextDefaults() {
 var nodeCtx struct {
 	nodeDecommissionWait   nodeDecommissionWaitType
 	nodeDecommissionSelf   bool
+	nodeDecommissionChecks nodeDecommissionCheckMode
+	nodeDecommissionDryRun bool
 	statusShowRanges       bool
 	statusShowStats        bool
 	statusShowDecommission bool
@@ -555,6 +557,8 @@ var nodeCtx struct {
 func setNodeContextDefaults() {
 	nodeCtx.nodeDecommissionWait = nodeDecommissionWaitAll
 	nodeCtx.nodeDecommissionSelf = false
+	nodeCtx.nodeDecommissionChecks = nodeDecommissionChecksEnabled
+	nodeCtx.nodeDecommissionDryRun = false
 	nodeCtx.statusShowRanges = false
 	nodeCtx.statusShowStats = false
 	nodeCtx.statusShowAll = false

--- a/pkg/cli/debug_recover_loss_of_quorum_test.go
+++ b/pkg/cli/debug_recover_loss_of_quorum_test.go
@@ -256,7 +256,7 @@ func TestLossOfQuorumRecovery(t *testing.T) {
 	adminClient := serverpb.NewAdminClient(grpcConn)
 
 	require.NoError(t, runDecommissionNodeImpl(
-		ctx, adminClient, nodeDecommissionWaitNone,
+		ctx, adminClient, nodeDecommissionWaitNone, nodeDecommissionChecksSkip, false,
 		[]roachpb.NodeID{roachpb.NodeID(2), roachpb.NodeID(3)}, tcAfter.Server(0).NodeID()),
 		"Failed to decommission removed nodes")
 

--- a/pkg/cli/flags.go
+++ b/pkg/cli/flags.go
@@ -700,6 +700,10 @@ func init() {
 	// Decommission command.
 	cliflagcfg.VarFlag(decommissionNodeCmd.Flags(), &nodeCtx.nodeDecommissionWait, cliflags.Wait)
 
+	// Decommission pre-check flags.
+	cliflagcfg.VarFlag(decommissionNodeCmd.Flags(), &nodeCtx.nodeDecommissionChecks, cliflags.NodeDecommissionChecks)
+	cliflagcfg.BoolFlag(decommissionNodeCmd.Flags(), &nodeCtx.nodeDecommissionDryRun, cliflags.NodeDecommissionDryRun)
+
 	// Decommission and recommission share --self.
 	for _, cmd := range []*cobra.Command{decommissionNodeCmd, recommissionNodeCmd} {
 		f := cmd.Flags()

--- a/pkg/cli/flags_util.go
+++ b/pkg/cli/flags_util.go
@@ -267,6 +267,47 @@ func (s *nodeDecommissionWaitType) Set(value string) error {
 	return nil
 }
 
+type nodeDecommissionCheckMode int
+
+const (
+	nodeDecommissionChecksSkip nodeDecommissionCheckMode = iota
+	nodeDecommissionChecksEnabled
+	nodeDecommissionChecksStrict
+)
+
+// Type implements the pflag.Value interface.
+func (s *nodeDecommissionCheckMode) Type() string { return "string" }
+
+// String implements the pflag.Value interface.
+func (s *nodeDecommissionCheckMode) String() string {
+	switch *s {
+	case nodeDecommissionChecksSkip:
+		return "skip"
+	case nodeDecommissionChecksEnabled:
+		return "enabled"
+	case nodeDecommissionChecksStrict:
+		return "strict"
+	default:
+		panic("unexpected node decommission check mode (possible values: enabled, strict, skip)")
+	}
+}
+
+// Set implements the pflag.Value interface.
+func (s *nodeDecommissionCheckMode) Set(value string) error {
+	switch value {
+	case "skip":
+		*s = nodeDecommissionChecksSkip
+	case "enabled":
+		*s = nodeDecommissionChecksEnabled
+	case "strict":
+		*s = nodeDecommissionChecksStrict
+	default:
+		return fmt.Errorf("invalid node decommission parameter: %s "+
+			"(possible values: enabled, strict, skip)", value)
+	}
+	return nil
+}
+
 // bytesOrPercentageValue is a flag that accepts an integer value, an integer
 // plus a unit (e.g. 32GB or 32GiB) or a percentage (e.g. 32%). In all these
 // cases, it transforms the string flag input into an int64 value.

--- a/pkg/cli/interactive_tests/test_cluster_name.tcl
+++ b/pkg/cli/interactive_tests/test_cluster_name.tcl
@@ -18,7 +18,7 @@ system "$argv init --insecure --host=localhost --cluster-name=foo"
 end_test
 
 start_test "Check that decommission works with a cluster-name provided"
-send "$argv node decommission 1 --insecure --host=localhost --wait=none --cluster-name=foo\r"
+send "$argv node decommission 1 --insecure --host=localhost --checks=skip --wait=none --cluster-name=foo\r"
 end_test
 
 start_test "Check that recommission works with cluster name verification disabled"

--- a/pkg/cli/interactive_tests/test_multiple_nodes.tcl
+++ b/pkg/cli/interactive_tests/test_multiple_nodes.tcl
@@ -26,10 +26,10 @@ eexpect "warning: node 2 is not decommissioned"
 eexpect eof
 
 start_test "Check that a double decommission prints out a warning"
-spawn $argv node decommission 2 --wait none
+spawn $argv node decommission 2 --wait none --checks skip
 eexpect eof
 
-spawn $argv node decommission 2 --wait none
+spawn $argv node decommission 2 --wait none --checks skip
 eexpect "warning: node 2 is already decommissioning or decommissioned"
 eexpect eof
 end_test

--- a/pkg/cli/node.go
+++ b/pkg/cli/node.go
@@ -295,7 +295,7 @@ func getStatusNodeAlignment() string {
 		align += "rrrrrr"
 	}
 	if nodeCtx.statusShowAll || nodeCtx.statusShowDecommission {
-		align += decommissionResponseAlignment()
+		align += decommissionStatusAlignment()
 	}
 	return align
 }
@@ -307,6 +307,11 @@ var decommissionNodesColumnHeaders = []string{
 	"is_decommissioning",
 	"membership",
 	"is_draining",
+}
+
+var decommissionNodesCheckAddlColumnHeaders = []string{
+	"readiness",
+	"blocking_ranges",
 }
 
 var decommissionNodeCmd = &cobra.Command{
@@ -371,7 +376,10 @@ func runDecommissionNode(cmd *cobra.Command, args []string) error {
 	}
 
 	c := serverpb.NewAdminClient(conn)
-	if err := runDecommissionNodeImpl(ctx, c, nodeCtx.nodeDecommissionWait, nodeIDs, localNodeID); err != nil {
+	if err := runDecommissionNodeImpl(ctx, c, nodeCtx.nodeDecommissionWait,
+		nodeCtx.nodeDecommissionChecks, nodeCtx.nodeDecommissionDryRun,
+		nodeIDs, localNodeID,
+	); err != nil {
 		cause := errors.UnwrapAll(err)
 		if s, ok := status.FromError(cause); ok && s.Code() == codes.NotFound {
 			// Are we trying to decommission a node that does not
@@ -455,6 +463,8 @@ func runDecommissionNodeImpl(
 	ctx context.Context,
 	c serverpb.AdminClient,
 	wait nodeDecommissionWaitType,
+	checks nodeDecommissionCheckMode,
+	dryRun bool,
 	nodeIDs []roachpb.NodeID,
 	localNodeID roachpb.NodeID,
 ) error {
@@ -471,21 +481,61 @@ func runDecommissionNodeImpl(
 	// sameStatusThreshold iterations), verbosity is automatically set.
 	// Some decommissioning replicas will be reported to the operator.
 	const sameStatusThreshold = 15
+	const preCheckBlockingRangeErrsToReport = 5
 	var (
 		numReplicaReport = 0
 		sameStatusCount  = 0
 	)
 
-	// Decommissioning a node is driven by a three-step process.
-	// 1) Mark each node as 'decommissioning'. In doing so, all replicas are
+	// Decommissioning a node is driven by a four-step process.
+	// 1) Evaluate decommission pre-check status. If node(s) are unready for
+	// decommission, report prior to initializing decommission and exit.
+	// 2) Mark each node as 'decommissioning'. In doing so, all replicas are
 	// slowly moved off of these nodes.
-	// 2) Drain each node.
-	// 3) Mark each node as 'decommissioned'.
+	// 3) Drain each node.
+	// 4) Mark each node as 'decommissioned'.
 	// Note: if the node serving the decommission request is a target node,
 	// the draining step for that node will be skipped. This is because
 	// after a drain, issuing a decommission RPC against this node will fail.
 	// TODO(cameron): update the note once decommission requests are
 	// routed to another selected "control" node in the cluster.
+	var preCheckReq *serverpb.DecommissionPreCheckRequest
+	var preCheckResp *serverpb.DecommissionPreCheckResponse
+	if checks > nodeDecommissionChecksSkip {
+		var err error
+		preCheckReq = &serverpb.DecommissionPreCheckRequest{
+			NodeIDs:         nodeIDs,
+			StrictReadiness: checks == nodeDecommissionChecksStrict,
+		}
+		preCheckResp, err = c.DecommissionPreCheck(ctx, preCheckReq)
+		if err != nil {
+			fmt.Fprintln(stderr)
+			return errors.Wrap(err, "while trying to check decommission readiness")
+		}
+	}
+
+	// On a dry run, we simply run checks (as above), and print the decommission
+	// status.
+	if dryRun || !decommissionPreCheckReady(preCheckResp) {
+		req := &serverpb.DecommissionStatusRequest{
+			NodeIDs: nodeIDs,
+		}
+		resp, err := c.DecommissionStatus(ctx, req)
+		if err != nil {
+			fmt.Fprintln(stderr)
+			return errors.Wrap(err, "while trying to check decommission status")
+		}
+		fmt.Fprintln(stderr)
+
+		err = printDecommissionStatusAndReadiness(*resp, preCheckResp)
+		if err == nil && !decommissionPreCheckReady(preCheckResp) {
+			printDecommissionBlockingErrorSummary(preCheckResp, preCheckBlockingRangeErrsToReport)
+			fmt.Fprintln(stderr)
+			err = errors.New("Cannot decommission nodes.")
+		}
+		return err
+	}
+
 	prevResponse := serverpb.DecommissionStatusResponse{}
 	for r := retry.StartWithCtx(ctx, opts); r.Next(); {
 		req := &serverpb.DecommissionRequest{
@@ -505,7 +555,7 @@ func runDecommissionNodeImpl(
 
 		if !reflect.DeepEqual(&prevResponse, resp) {
 			fmt.Fprintln(stderr)
-			if err = printDecommissionStatus(*resp); err != nil {
+			if err = printDecommissionStatusAndReadiness(*resp, preCheckResp); err != nil {
 				return err
 			}
 			prevResponse = *resp
@@ -523,6 +573,15 @@ func runDecommissionNodeImpl(
 			if sameStatusCount >= sameStatusThreshold && numReplicaReport == 0 {
 				// Configure a number of replicas to report.
 				numReplicaReport = 5
+				// Refresh pre-check results, if applicable.
+				if preCheckReq != nil {
+					if newPreCheckResp, err := c.DecommissionPreCheck(ctx, preCheckReq); err != nil {
+						fmt.Fprintln(stderr)
+						return errors.Wrap(err, "while trying to check decommission readiness")
+					} else {
+						preCheckResp = newPreCheckResp
+					}
+				}
 			} else {
 				sameStatusCount++
 			}
@@ -590,7 +649,7 @@ func runDecommissionNodeImpl(
 	return errors.New("maximum number of retries exceeded")
 }
 
-func decommissionResponseAlignment() string {
+func decommissionStatusAlignment() string {
 	return "rcrccc"
 }
 
@@ -614,6 +673,39 @@ func decommissionResponseValueToRows(
 	return rows
 }
 
+func decommissionReadinessAlignment() string {
+	return "cr"
+}
+
+func decommissionStatusAndReadinessAlignment() string {
+	return decommissionStatusAlignment() + decommissionReadinessAlignment()
+}
+
+// decommissionStatusAndReadinessValueToRows converts a
+// DecommissionStatusResponse Status as well as a DecommissionPreCheckResponse
+// NodeCheckResult to SQL-like result rows, so that we can pretty-print them.
+func decommissionStatusAndReadinessValueToRows(
+	statuses []serverpb.DecommissionStatusResponse_Status,
+	reportByNodeID map[roachpb.NodeID]serverpb.DecommissionPreCheckResponse_NodeCheckResult,
+) [][]string {
+	var rows [][]string
+	for _, node := range statuses {
+		report := reportByNodeID[node.NodeID]
+
+		rows = append(rows, []string{
+			strconv.FormatInt(int64(node.NodeID), 10),
+			strconv.FormatBool(node.IsLive),
+			strconv.FormatInt(node.ReplicaCount, 10),
+			strconv.FormatBool(!node.Membership.Active()),
+			node.Membership.String(),
+			strconv.FormatBool(node.Draining),
+			report.DecommissionReadiness.String(),
+			strconv.FormatInt(int64(len(report.CheckedRanges)), 10),
+		})
+	}
+	return rows
+}
+
 var recommissionNodeCmd = &cobra.Command{
 	Use:   "recommission { --self | <node id 1> [<node id 2> ...] }",
 	Short: "recommissions the node(s)",
@@ -625,9 +717,28 @@ signaling the affected nodes to participate in the cluster again.
 	RunE: clierrorplus.MaybeDecorateError(runRecommissionNode),
 }
 
+func printDecommissionStatusAndReadiness(
+	statusResp serverpb.DecommissionStatusResponse, checkResp *serverpb.DecommissionPreCheckResponse,
+) error {
+	if checkResp == nil {
+		return printDecommissionStatus(statusResp)
+	}
+
+	reportByNodeID := make(map[roachpb.NodeID]serverpb.DecommissionPreCheckResponse_NodeCheckResult)
+	for _, nodeCheckResult := range checkResp.CheckedNodes {
+		reportByNodeID[nodeCheckResult.NodeID] = nodeCheckResult
+	}
+
+	return sqlExecCtx.PrintQueryOutput(os.Stdout, stderr, append(decommissionNodesColumnHeaders, decommissionNodesCheckAddlColumnHeaders...),
+		clisqlexec.NewRowSliceIter(
+			decommissionStatusAndReadinessValueToRows(statusResp.Status, reportByNodeID),
+			decommissionStatusAndReadinessAlignment(),
+		))
+}
+
 func printDecommissionStatus(resp serverpb.DecommissionStatusResponse) error {
 	return sqlExecCtx.PrintQueryOutput(os.Stdout, stderr, decommissionNodesColumnHeaders,
-		clisqlexec.NewRowSliceIter(decommissionResponseValueToRows(resp.Status), decommissionResponseAlignment()))
+		clisqlexec.NewRowSliceIter(decommissionResponseValueToRows(resp.Status), decommissionStatusAlignment()))
 }
 
 func printDecommissionReplicas(resp serverpb.DecommissionStatusResponse) {
@@ -643,6 +754,54 @@ func printDecommissionReplicas(resp serverpb.DecommissionStatusResponse) {
 			)
 		}
 	}
+}
+
+func printDecommissionBlockingErrorSummary(
+	resp *serverpb.DecommissionPreCheckResponse, reportLimit int,
+) {
+	fmt.Fprintln(stderr, "\nranges blocking decommission detected")
+	reported := 0
+	for _, nodeCheckResult := range resp.CheckedNodes {
+		if nodeCheckResult.DecommissionReadiness != serverpb.DecommissionPreCheckResponse_ALLOCATION_ERRORS {
+			continue
+		}
+
+		errCountMap := make(map[string]int)
+		for _, rangeCheckResult := range nodeCheckResult.CheckedRanges {
+			errCountMap[rangeCheckResult.Error] += 1
+		}
+
+		for errMsg, count := range errCountMap {
+			if reported >= reportLimit {
+				fmt.Fprintf(stderr, "...more blocking errors detected.\n")
+				return
+			}
+			fmt.Fprintf(stderr,
+				"n%d has %d replicas blocked with error: \"%s\"\n",
+				nodeCheckResult.NodeID,
+				count,
+				errMsg,
+			)
+			reported++
+		}
+	}
+}
+
+// decommissionPreCheckReady checks if, given a valid response, there are any
+// nodes shown to not be ready for decommission.
+func decommissionPreCheckReady(resp *serverpb.DecommissionPreCheckResponse) bool {
+	// If we don't have a response value, this indicates that the pre-checks are
+	// disabled, and hence all nodes are implicitly ready for decommission.
+	if resp == nil {
+		return true
+	}
+	for _, nodeCheckResult := range resp.CheckedNodes {
+		if nodeCheckResult.DecommissionReadiness != serverpb.DecommissionPreCheckResponse_READY {
+			return false
+		}
+	}
+
+	return true
 }
 
 func runRecommissionNode(cmd *cobra.Command, args []string) error {

--- a/pkg/cli/zip_test.go
+++ b/pkg/cli/zip_test.go
@@ -436,7 +436,7 @@ func TestPartialZip(t *testing.T) {
 	// we're decommissioning a node in a 3-node cluster, so there's no node to
 	// up-replicate the under-replicated ranges to.
 	{
-		_, err := c.RunWithCapture(fmt.Sprintf("node decommission --wait=none %d", 2))
+		_, err := c.RunWithCapture(fmt.Sprintf("node decommission --checks=skip --wait=none %d", 2))
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/pkg/cmd/roachtest/tests/decommission.go
+++ b/pkg/cmd/roachtest/tests/decommission.go
@@ -405,7 +405,7 @@ func runDecommissionRandomized(ctx context.Context, t test.Test, c cluster.Clust
 
 		exp := [][]string{
 			decommissionHeader,
-			{strconv.Itoa(targetNode), "true", `\d+`, "true", "decommissioning", "false"},
+			{strconv.Itoa(targetNode), "true", `\d+`, "true", "decommissioning", "false", "ready|allocation errors", `\d+`},
 		}
 		if err := cli.MatchCSV(o, exp); err != nil {
 			t.Fatal(err)
@@ -484,7 +484,7 @@ func runDecommissionRandomized(ctx context.Context, t test.Test, c cluster.Clust
 
 				exp := [][]string{decommissionHeader}
 				for i := 1; i <= c.Spec().NodeCount; i++ {
-					rowRegex := []string{strconv.Itoa(i), "true", `\d+`, "true", "decommissioning", "false"}
+					rowRegex := []string{strconv.Itoa(i), "true", `\d+`, "true", "decommissioning", "false", "ready|allocation errors", `\d+`}
 					exp = append(exp, rowRegex)
 				}
 				if err := cli.MatchCSV(o, exp); err != nil {
@@ -605,8 +605,8 @@ func runDecommissionRandomized(ctx context.Context, t test.Test, c cluster.Clust
 
 			exp := [][]string{
 				decommissionHeader,
-				{strconv.Itoa(targetNodeA), "true|false", "0", "true", "decommissioned", "false"},
-				{strconv.Itoa(targetNodeB), "true|false", "0", "true", "decommissioned", "false"},
+				{strconv.Itoa(targetNodeA), "true|false", "0", "true", "decommissioned", "false", "ready|allocation errors", `\d+`},
+				{strconv.Itoa(targetNodeB), "true|false", "0", "true", "decommissioned", "false", "ready|allocation errors", `\d+`},
 				decommissionFooter,
 			}
 			return cli.MatchCSV(cli.RemoveMatchingLines(o, warningFilter), exp)
@@ -692,8 +692,8 @@ func runDecommissionRandomized(ctx context.Context, t test.Test, c cluster.Clust
 				decommissionHeader,
 				// NB: the "false" is liveness. We waited above for these nodes to
 				// vanish from `node ls`, so definitely not live at this point.
-				{strconv.Itoa(targetNodeA), "false", "0", "true", "decommissioned", "false"},
-				{strconv.Itoa(targetNodeB), "false", "0", "true", "decommissioned", "false"},
+				{strconv.Itoa(targetNodeA), "false", "0", "true", "decommissioned", "false", "already decommissioned", "0"},
+				{strconv.Itoa(targetNodeB), "false", "0", "true", "decommissioned", "false", "already decommissioned", "0"},
 				decommissionFooter,
 			}
 			if err := cli.MatchCSV(cli.RemoveMatchingLines(o, warningFilter), exp); err != nil {
@@ -785,7 +785,7 @@ func runDecommissionRandomized(ctx context.Context, t test.Test, c cluster.Clust
 
 		exp := [][]string{
 			decommissionHeader,
-			{strconv.Itoa(targetNode), "true|false", "0", "true", "decommissioned", "false"},
+			{strconv.Itoa(targetNode), "true|false", "0", "true", "decommissioned", "false", "already decommissioned", "0"},
 			decommissionFooter,
 		}
 		if err := cli.MatchCSV(cli.RemoveMatchingLines(o, warningFilter), exp); err != nil {
@@ -1001,13 +1001,13 @@ func runDecommissionDrains(ctx context.Context, t test.Test, c cluster.Cluster) 
 		// The expected output of decommission while the node is about to be drained/is draining.
 		expReplicasTransferred = [][]string{
 			decommissionHeader,
-			{strconv.Itoa(decommNodeID), "true|false", "0", "true", "decommissioning", "false"},
+			{strconv.Itoa(decommNodeID), "true|false", "0", "true", "decommissioning", "false", "ready", "0"},
 			decommissionFooter,
 		}
 		// The expected output of decommission once the node is finally marked as "decommissioned."
 		expDecommissioned = [][]string{
 			decommissionHeader,
-			{strconv.Itoa(decommNodeID), "true|false", "0", "true", "decommissioned", "false"},
+			{strconv.Itoa(decommNodeID), "true|false", "0", "true", "decommissioned", "false", "ready", "0"},
 			decommissionFooter,
 		}
 	)
@@ -1094,7 +1094,7 @@ func runDecommissionSlow(ctx context.Context, t test.Test, c cluster.Cluster) {
 				t.Status(fmt.Sprintf("decommissioning node %d", id))
 				return c.RunE(ctx,
 					c.Node(id),
-					fmt.Sprintf("./cockroach node decommission %d --insecure", id),
+					fmt.Sprintf("./cockroach node decommission %d --insecure --checks=skip", id),
 				)
 			}
 			return decom(id)
@@ -1120,7 +1120,7 @@ func runDecommissionSlow(ctx context.Context, t test.Test, c cluster.Cluster) {
 
 // Header from the output of `cockroach node decommission`.
 var decommissionHeader = []string{
-	"id", "is_live", "replicas", "is_decommissioning", "membership", "is_draining",
+	"id", "is_live", "replicas", "is_decommissioning", "membership", "is_draining", "readiness", "blocking_ranges",
 }
 
 // Footer from the output of `cockroach node decommission`, after successful

--- a/pkg/server/admin.go
+++ b/pkg/server/admin.go
@@ -2709,8 +2709,8 @@ func (s *systemAdminServer) DecommissionPreCheck(
 		}
 	}
 
-	// Evaluate readiness for each node to check based on how many ranges have
-	// replicas on the node that did not pass checks.
+	// Evaluate readiness by validating that there are no ranges with replicas on
+	// the given node(s) that did not pass checks.
 	for _, nID := range nodesToCheck {
 		numReplicas := len(results.replicasByNode[nID])
 		var readiness serverpb.DecommissionPreCheckResponse_NodeReadiness

--- a/pkg/server/serverpb/admin.go
+++ b/pkg/server/serverpb/admin.go
@@ -39,6 +39,21 @@ func (ts *TableStatsResponse) Add(ots *TableStatsResponse) {
 	}
 }
 
+func (r DecommissionPreCheckResponse_NodeReadiness) String() string {
+	switch r {
+	case DecommissionPreCheckResponse_UNKNOWN:
+		return "unknown"
+	case DecommissionPreCheckResponse_READY:
+		return "ready"
+	case DecommissionPreCheckResponse_ALREADY_DECOMMISSIONED:
+		return "already decommissioned"
+	case DecommissionPreCheckResponse_ALLOCATION_ERRORS:
+		return "allocation errors"
+	default:
+		panic("unknown decommission node readiness")
+	}
+}
+
 type TenantAdminServer interface {
 	Liveness(context.Context, *LivenessRequest) (*LivenessResponse, error)
 }

--- a/pkg/server/serverpb/admin.proto
+++ b/pkg/server/serverpb/admin.proto
@@ -503,6 +503,8 @@ message DecommissionPreCheckRequest {
 // associated error messages and traces, for each node.
 message DecommissionPreCheckResponse {
   enum NodeReadiness {
+    option (gogoproto.goproto_enum_stringer) = false;
+
     UNKNOWN = 0;
     READY = 1;
     ALREADY_DECOMMISSIONED = 2;


### PR DESCRIPTION
This changes the functionality of `cockroach node decommission` to run
preliminary readiness checks prior to starting the decommission of the
nodes. These checks, if they evaluate and find that nodes are not ready
for decommission, will report the errors observed and on which nodes so
that the cluster's configuration can be rectified prior to reattempting
node decommission.  The readiness checks are enabled by default, but can
be controlled with the following new flags:
```
--dry-run               Only evaluate decommission readiness and check decommission status, without
                        actually decommissioning the node.

--checks string         Specifies how to evaluate readiness checks prior to node decommission. Takes
                        any of the following values:
                            - enabled  evaluate readiness prior to starting node decommission.
                            - strict   use strict readiness evaluation mode prior to node decommission.
                            - skip     skip readiness checks and immediately request node decommission.
```

Issues blocking decommission are presented grouped by node and error, e.g.
```
$ ./cockroach node decommission 1 4 5 --insecure

  id | is_live | replicas | is_decommissioning | membership | is_draining |     readiness     | blocking_ranges
-----+---------+----------+--------------------+------------+-------------+-------------------+------------------
   1 |  true   |       53 |       false        |   active   |    false    | allocation errors |              47
   4 |  true   |       52 |       false        |   active   |    false    | allocation errors |              46
   5 |  true   |       54 |       false        |   active   |    false    | allocation errors |              48
(3 rows)

ranges blocking decommission detected

n1 has 34 replicas blocked with error: "0 of 1 live stores are able to take a new replica for the range (2 already have a voter, 0 already have a non-voter); likely not enough nodes in cluster"
n1 has 13 replicas blocked with error: "0 of 1 live stores are able to take a new replica for the range (2 already have a voter, 0 already have a non-voter); replicas must match constraints [{+node1:1} {+node4:1} {+node5:1}]; voting replicas must match voter_constraints []"
n4 has 13 replicas blocked with error: "0 of 1 live stores are able to take a new replica for the range (2 already have a voter, 0 already have a non-voter); replicas must match constraints [{+node1:1} {+node4:1} {+node5:1}]; voting replicas must match voter_constraints []"
n4 has 33 replicas blocked with error: "0 of 1 live stores are able to take a new replica for the range (2 already have a voter, 0 already have a non-voter); likely not enough nodes in cluster"
n5 has 35 replicas blocked with error: "0 of 1 live stores are able to take a new replica for the range (2 already have a voter, 0 already have a non-voter); likely not enough nodes in cluster"
...more blocking errors detected.

ERROR: Cannot decommission nodes.
Failed running "node decommission"
```

Fixes: https://github.com/cockroachdb/cockroach/issues/91893

Release note (cli change): `cockroach node decommission` operations now
preliminarily check the ability of the node to complete decommissioning,
given the cluster configuration and the ranges with replicas present
on the node. This step can be skipped by using the flag `--checks=skip`.
When errors are detected that would result in the inability to complete
node decommission, they will be printed to stderr and the command will
exit, instead of marking the node as `decommissioning` and beginning the
node decommission process.  When the strict readiness evaluation mode
is used by setting the flag `--checks=strict`, any ranges that need any
preliminary actions prior to replacement for the decommission process
(e.g. ranges that are not yet fully upreplicated) will block the
decommission process.