### PR TITLE
release-22.2: sql: fix extra round trips during DISCARD, fix temp discard bug

### DIFF
--- a/pkg/bench/rttanalysis/BUILD.bazel
+++ b/pkg/bench/rttanalysis/BUILD.bazel
@@ -38,6 +38,7 @@ go_test(
         "alter_table_bench_test.go",
         "bench_test.go",
         "create_alter_role_bench_test.go",
+        "discard_bench_test.go",
         "drop_bench_test.go",
         "grant_revoke_bench_test.go",
         "grant_revoke_role_bench_test.go",

--- a/pkg/bench/rttanalysis/discard_bench_test.go
+++ b/pkg/bench/rttanalysis/discard_bench_test.go
@@ -1,0 +1,53 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package rttanalysis
+
+import "testing"
+
+func BenchmarkDiscard(b *testing.B) { reg.Run(b) }
+func init() {
+	reg.Register("Discard", []RoundTripBenchTestCase{
+		{
+			Name: "DISCARD ALL, no tables",
+			Setup: `DROP DATABASE IF EXISTS db CASCADE; 
+CREATE DATABASE db;`,
+			Stmt: "DISCARD ALL",
+		},
+		{
+			Name: "DISCARD ALL, 1 tables in 1 db",
+			Setup: `
+SET experimental_enable_temp_tables = true;
+DROP DATABASE IF EXISTS db CASCADE; 
+CREATE DATABASE db; 
+USE db; 
+CREATE TEMPORARY TABLE foo(i int);
+`,
+			Stmt: "DISCARD ALL",
+		},
+		{
+			Name: "DISCARD ALL, 2 tables in 2 dbs",
+			Setup: `
+SET experimental_enable_temp_tables = true;
+DROP DATABASE IF EXISTS db CASCADE; 
+CREATE DATABASE db; 
+USE db; 
+CREATE TEMPORARY TABLE foo(i int);
+CREATE TEMPORARY TABLE bar(i int);
+DROP DATABASE IF EXISTS db2 CASCADE; 
+CREATE DATABASE db2; 
+USE db2; 
+CREATE TEMPORARY TABLE foo(i int);
+CREATE TEMPORARY TABLE bar(i int);
+`,
+			Stmt: "DISCARD ALL",
+		},
+	})
+}

--- a/pkg/bench/rttanalysis/testdata/benchmark_expectations
+++ b/pkg/bench/rttanalysis/testdata/benchmark_expectations
@@ -33,7 +33,7 @@ exp,benchmark
 14,CreateRole/create_role_with_no_options
 19,"Discard/DISCARD_ALL,_1_tables_in_1_db"
 47,"Discard/DISCARD_ALL,_2_tables_in_2_dbs"
-9,"Discard/DISCARD_ALL,_no_tables"
+1,"Discard/DISCARD_ALL,_no_tables"
 14,DropDatabase/drop_database_0_tables
 16,DropDatabase/drop_database_1_table
 18,DropDatabase/drop_database_2_tables

--- a/pkg/bench/rttanalysis/testdata/benchmark_expectations
+++ b/pkg/bench/rttanalysis/testdata/benchmark_expectations
@@ -31,6 +31,9 @@ exp,benchmark
 16,CreateRole/create_role_with_2_options
 19,CreateRole/create_role_with_3_options
 14,CreateRole/create_role_with_no_options
+19,"Discard/DISCARD_ALL,_1_tables_in_1_db"
+47,"Discard/DISCARD_ALL,_2_tables_in_2_dbs"
+9,"Discard/DISCARD_ALL,_no_tables"
 14,DropDatabase/drop_database_0_tables
 16,DropDatabase/drop_database_1_table
 18,DropDatabase/drop_database_2_tables

--- a/pkg/bench/rttanalysis/testdata/benchmark_expectations
+++ b/pkg/bench/rttanalysis/testdata/benchmark_expectations
@@ -31,9 +31,9 @@ exp,benchmark
 16,CreateRole/create_role_with_2_options
 19,CreateRole/create_role_with_3_options
 14,CreateRole/create_role_with_no_options
-19,"Discard/DISCARD_ALL,_1_tables_in_1_db"
-47,"Discard/DISCARD_ALL,_2_tables_in_2_dbs"
-1,"Discard/DISCARD_ALL,_no_tables"
+18,"Discard/DISCARD_ALL,_1_tables_in_1_db"
+46,"Discard/DISCARD_ALL,_2_tables_in_2_dbs"
+0,"Discard/DISCARD_ALL,_no_tables"
 14,DropDatabase/drop_database_0_tables
 16,DropDatabase/drop_database_1_table
 18,DropDatabase/drop_database_2_tables

--- a/pkg/sql/discard.go
+++ b/pkg/sql/discard.go
@@ -86,6 +86,11 @@ func (n *discardNode) startExec(params runParams) error {
 }
 
 func deleteTempTables(ctx context.Context, p *planner) error {
+	// If this session has no temp schemas, then there is nothing to do here.
+	// This is the common case.
+	if len(p.SessionData().DatabaseIDToTempSchemaID) == 0 {
+		return nil
+	}
 	return p.WithInternalExecutor(ctx, func(ctx context.Context, txn *kv.Txn, ie sqlutil.InternalExecutor) error {
 		codec := p.execCfg.Codec
 		descCol := p.Descriptors()

--- a/pkg/sql/logictest/testdata/logic_test/temp_table
+++ b/pkg/sql/logictest/testdata/logic_test/temp_table
@@ -347,4 +347,44 @@ to_drop.pg_temp.testuser_tmp
 to_drop.pg_temp.tempuser_view
 to_drop.pg_temp.root_temp
 
+subtest create_after_discard_and_drop_database
+
+statement ok
+ALTER ROLE testuser WITH CREATEDB;
+
 user testuser
+
+statement ok
+CREATE DATABASE to_drop
+
+statement ok
+USE to_drop
+
+statement ok
+CREATE TEMPORARY TABLE t (i INT PRIMARY KEY);
+
+statement ok
+SELECT * FROM pg_temp.t
+
+statement ok
+DISCARD TEMP
+
+statement error pgcode 42P01 relation "pg_temp.t" does not exist
+SELECT * FROM pg_temp.t
+
+statement ok
+USE defaultdb;
+DROP DATABASE to_drop CASCADE;
+
+statement ok
+CREATE DATABASE to_drop
+
+statement ok
+CREATE TEMPORARY TABLE t (i INT PRIMARY KEY);
+
+statement ok
+SELECT * FROM pg_temp.t
+
+statement ok
+USE defaultdb;
+DROP DATABASE to_drop CASCADE;

--- a/pkg/sql/user.go
+++ b/pkg/sql/user.go
@@ -563,7 +563,7 @@ func (p *planner) setRole(ctx context.Context, local bool, s username.SQLUsernam
 	sessionUser := p.SessionData().SessionUser()
 	becomeUser := sessionUser
 	// Check the role exists - if so, populate becomeUser.
-	if !s.IsNoneRole() {
+	if !s.IsNoneRole() && s != sessionUser {
 		becomeUser = s
 
 		exists, err := p.RoleExists(ctx, becomeUser)


### PR DESCRIPTION
Backport 3/3 commits from #95876.
Also tacks on another bug fix.

Release justification: fixes severe regression when using pg_bouncer

Fixes #95864

/cc @cockroachdb/release

---

#### sql: avoid checking if a role exists when setting to the current role

This is an uncached round-trip. It makes `DISCARD` expensive.
In https://github.com/cockroachdb/cockroach/pull/86485 we implemented
`SET SESSION AUTHORIZATION DEFAULT`, this added an extra sql query to
`DISCARD ALL` to check if the role we'd become exists. This is almost
certainly unintentional in the case where the role we'd become is the
current session role. I think this just happened because of code
consolidation.

We now no longer check if the current session role exists. This removes
the last round-trip from DISCARD ALL.

#### sql: use in-memory session data to decide what to do in DISCARD

In #86246 we introduced logic to discard schemas when running DISCARD ALL and DISCARD TEMP. This logic did expensive kv operations unconditionally; if the session knew it had never created a temporary schema, we'd still fetch all databases and proceed to search all databases for a temp schema. This is very expensive.

Fixes: #95864

#### sql: reset the temporary schemas after injecting them

If this was not done, there'd be a bug in `DISCARD ALL` and
`DISCARD TEMP` which would prevent temporary schemas from working for
the rest of the session because the `descs.Collection` would have a
handle to the wrong object

Release note (bug fix): Fixed a bug in experimental temporary schemas whereby
`DISCARD ALL` or `DISCARD TEMP` could prevent temporary tables from working.

Release note (performance improvement): In 22.2, logic was added to make
`SET SESSION AUTHORIZATION DEFAULT` not a no-op. This implementation used
more general code for setting the role for a session which made sure that
the role exists. The check for whether a role exists is currently uncached.
We don't need to check if the role we already are exists. This improves the
performance of `DISCARD ALL` in addition to `SET SESSION AUTHORIZATION
DEFAULT`.


Release note (performance improvement): In 22.2, we introduced support for `DISCARD TEMP` and made `DISCARD ALL` actually discard temp tables. This implementation ran expensive logic to discover temp schemas rather than consulting in-memory data structures. As a result, `DISCARD ALL`, which is issued regularly by connection pools, became an expensive operation when it should be cheap. This problem is now resolved.
