### PR TITLE
release-22.2: eval: fix internal error casting bytes to bit

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/show_ranges
+++ b/pkg/sql/logictest/testdata/logic_test/show_ranges
@@ -1,0 +1,10 @@
+# LogicTest: local
+
+subtest cast_error
+
+statement ok
+CREATE TABLE v0 (c1 BIT PRIMARY KEY );
+
+statement error pgcode 42846 pq: crdb_internal.encode_key\(\): invalid cast: bytes -> bit
+SHOW RANGE FROM TABLE v0 FOR ROW ( b'\x68')
+

--- a/pkg/sql/logictest/tests/local/generated_test.go
+++ b/pkg/sql/logictest/tests/local/generated_test.go
@@ -1815,6 +1815,13 @@ func TestLogic_show_indexes(
 	runLogicTest(t, "show_indexes")
 }
 
+func TestLogic_show_ranges(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "show_ranges")
+}
+
 func TestLogic_show_source(
 	t *testing.T,
 ) {

--- a/pkg/sql/sem/eval/cast.go
+++ b/pkg/sql/sem/eval/cast.go
@@ -143,10 +143,12 @@ func performCastWithoutPrecisionTruncation(
 			}
 			ba = &tree.DBitArray{BitArray: res}
 		}
-		if truncateWidth {
-			ba = tree.FormatBitArrayToType(ba, t)
+		if ba != nil {
+			if truncateWidth {
+				ba = tree.FormatBitArrayToType(ba, t)
+			}
+			return ba, nil
 		}
-		return ba, nil
 
 	case types.BoolFamily:
 		switch v := d.(type) {


### PR DESCRIPTION
Backport 1/1 commits from #96002.

/cc @cockroachdb/release

---

Fixes #95543

Release note (bug fix): This patch fixes an internal error which may occur in the SHOW RANGE FROM TABLE statement when the FOR ROW clause specifies a BYTE literal and the corresponding column data type is BIT.

Release justification: Very low risk fix for internal error casting bytes to bit
