### PR TITLE
ui: add search, filter and time picker on index details

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/indexDetailsPage/indexDetails.selectors.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/indexDetailsPage/indexDetails.selectors.ts
@@ -31,6 +31,7 @@ import {
 import { BreadcrumbItem } from "../breadcrumbs";
 import { RecommendationType as RecType } from "./indexDetailsPage";
 import { nodeRegionsByIDSelector } from "../store/nodes";
+import { selectTimeScale } from "src/store/utils/selectors";
 const { RecommendationType } = cockroach.sql.IndexRecommendation;
 
 export const selectIndexDetails = createSelector(
@@ -47,6 +48,7 @@ export const selectIndexDetails = createSelector(
   (state: AppState) => selectHasViewActivityRedactedRole(state),
   (state: AppState) => nodeRegionsByIDSelector(state),
   (state: AppState) => selectHasAdminRole(state),
+  (state: AppState) => selectTimeScale(state),
   (
     database,
     schema,
@@ -57,6 +59,7 @@ export const selectIndexDetails = createSelector(
     hasViewActivityRedactedRole,
     nodeRegions,
     hasAdminRole,
+    timeScale,
   ): IndexDetailsPageData => {
     const stats = indexStats[generateTableID(database, table)];
     const details = stats?.data?.statistics.filter(
@@ -89,6 +92,7 @@ export const selectIndexDetails = createSelector(
         index,
       ),
       isTenant: isTenant,
+      timeScale: timeScale,
       hasViewActivityRedactedRole: hasViewActivityRedactedRole,
       hasAdminRole: hasAdminRole,
       nodeRegions: nodeRegions,

--- a/pkg/ui/workspaces/cluster-ui/src/indexDetailsPage/indexDetailsConnected.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/indexDetailsPage/indexDetailsConnected.ts
@@ -17,6 +17,8 @@ import { connect } from "react-redux";
 import { actions as indexStatsActions } from "src/store/indexStats/indexStats.reducer";
 import { cockroach } from "@cockroachlabs/crdb-protobuf-client";
 import { actions as nodesActions } from "../store/nodes";
+import { TimeScale } from "../timeScaleDropdown";
+import { actions as sqlStatsActions } from "../store/sqlStats";
 
 const mapStateToProps = (state: AppState, props: RouteComponentProps) => {
   return selectIndexDetails(state, props);
@@ -43,6 +45,13 @@ const mapDispatchToProps = (dispatch: Dispatch): IndexDetailPageActions => ({
   },
   refreshNodes: () => dispatch(nodesActions.refresh()),
   refreshUserSQLRoles: () => dispatch(uiConfigActions.refreshUserSQLRoles()),
+  onTimeScaleChange: (ts: TimeScale) => {
+    dispatch(
+      sqlStatsActions.updateTimeScale({
+        ts: ts,
+      }),
+    );
+  },
 });
 
 export const ConnectedIndexDetailsPage = withRouter<any, any>(

--- a/pkg/ui/workspaces/cluster-ui/src/indexDetailsPage/indexDetailsPage.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/indexDetailsPage/indexDetailsPage.tsx
@@ -35,6 +35,8 @@ import {
   Count,
   DATE_FORMAT_24_UTC,
   performanceTuningRecipes,
+  unique,
+  unset,
 } from "../util";
 import {
   getStatementsUsingIndex,
@@ -52,6 +54,24 @@ import { Pagination } from "../pagination";
 import { TableStatistics } from "../tableStatistics";
 import { EmptyStatementsPlaceholder } from "../statementsPage/emptyStatementsPlaceholder";
 import { StatementViewType } from "../statementsPage/statementPageTypes";
+import { PageConfig, PageConfigItem } from "src/pageConfig";
+import {
+  TimeScale,
+  timeScale1hMinOptions,
+  TimeScaleDropdown,
+} from "../timeScaleDropdown";
+import { Search } from "../search";
+import {
+  calculateActiveFilters,
+  defaultFilters,
+  Filter,
+  Filters,
+} from "../queryFilter";
+import { commonStyles } from "../common";
+import { Loading } from "src";
+import LoadingError from "../sqlActivity/errorComponent";
+import { INTERNAL_APP_NAME_PREFIX } from "../recentExecutions/recentStatementUtils";
+import { filteredStatementsData } from "../sqlActivity/util";
 
 const cx = classNames.bind(styles);
 const stmtCx = classNames.bind(statementsStyles);
@@ -90,6 +110,7 @@ export interface IndexDetailsPageData {
   hasViewActivityRedactedRole?: UIConfigState["hasViewActivityRedactedRole"];
   hasAdminRole?: UIConfigState["hasAdminRole"];
   nodeRegions: { [nodeId: string]: string };
+  timeScale: TimeScale;
 }
 
 interface IndexDetails {
@@ -116,39 +137,61 @@ export interface IndexDetailPageActions {
   resetIndexUsageStats?: (database: string, table: string) => void;
   refreshNodes?: () => void;
   refreshUserSQLRoles: () => void;
+  onTimeScaleChange: (ts: TimeScale) => void;
 }
 
 export type IndexDetailsPageProps = IndexDetailsPageData &
   IndexDetailPageActions;
 
 interface IndexDetailsPageState {
+  activeFilters: number;
+  filters?: Filters;
+  search: string;
+  lastStatementsError: Error | null;
+  lastStatementsUpdated: moment.Moment | null;
   statements: AggregateStatistics[];
-  stmtSortSetting: SortSetting;
   stmtPagination: ISortedTablePagination;
+  stmtSortSetting: SortSetting;
 }
 
 export class IndexDetailsPage extends React.Component<
   IndexDetailsPageProps,
   IndexDetailsPageState
 > {
+  refreshDataInterval: NodeJS.Timeout;
   constructor(props: IndexDetailsPageProps) {
     super(props);
 
     this.state = {
       stmtSortSetting: {
         ascending: true,
-        columnTitle: "statementTime",
+        columnTitle: "time",
       },
       stmtPagination: {
         pageSize: 10,
         current: 1,
       },
       statements: [],
+      lastStatementsUpdated: null,
+      lastStatementsError: null,
+      search: null,
+      activeFilters: 0,
+      filters: defaultFilters,
     };
   }
 
   componentDidMount(): void {
     this.refresh();
+
+    this.refreshDataInterval = setInterval(() => {
+      this.refreshStatementsList();
+    }, 100);
+  }
+
+  componentWillUnmount(): void {
+    if (this.refreshDataInterval) {
+      clearInterval(this.refreshDataInterval);
+    }
   }
 
   componentDidUpdate(): void {
@@ -166,6 +209,50 @@ export class IndexDetailsPage extends React.Component<
     this.setState({ stmtPagination: { ...stmtPagination, current } });
   };
 
+  resetPagination = (): void => {
+    this.setState({
+      stmtPagination: {
+        current: 1,
+        pageSize: 10,
+      },
+    });
+  };
+
+  onSubmitSearchField = (search: string): void => {
+    this.setState({ search: search });
+    this.resetPagination();
+  };
+
+  onClearSearchField = (): void => {
+    this.onSubmitSearchField("");
+  };
+
+  onSubmitFilters = (filters: Filters): void => {
+    this.setState({
+      filters: filters,
+      activeFilters: calculateActiveFilters(filters),
+    });
+
+    this.resetPagination();
+  };
+
+  onClearFilters = (): void => {
+    this.setState({
+      filters: defaultFilters,
+      activeFilters: 0,
+    });
+
+    this.resetPagination();
+  };
+
+  changeTimeScale = (ts: TimeScale): void => {
+    if (this.props.onTimeScaleChange) {
+      this.props.onTimeScaleChange(ts);
+    }
+    this.setState({ lastStatementsUpdated: null });
+    this.refresh();
+  };
+
   private refresh() {
     this.props.refreshUserSQLRoles();
     if (this.props.refreshNodes != null) {
@@ -177,17 +264,39 @@ export class IndexDetailsPage extends React.Component<
         this.props.tableName,
       );
     }
+  }
 
-    const req: StatementsUsingIndexRequest = StatementsListRequestFromDetails(
-      this.props.details.tableID,
-      this.props.details.indexID,
-      this.props.databaseName,
-      null,
-    );
-    getStatementsUsingIndex(req).then(res => {
-      populateRegionNodeForStatements(res, this.props.nodeRegions);
-      this.setState({ statements: res });
-    });
+  private refreshStatementsList(): void {
+    const noData = this.state.lastStatementsUpdated == null;
+    const movingTimeScaleWithPeriodPassed =
+      this.props.timeScale.key !== "Custom" &&
+      moment().diff(this.state.lastStatementsUpdated, "minutes") >= 5;
+    if (
+      (noData || movingTimeScaleWithPeriodPassed) &&
+      this.props.details.loaded
+    ) {
+      const req: StatementsUsingIndexRequest = StatementsListRequestFromDetails(
+        this.props.details.tableID,
+        this.props.details.indexID,
+        this.props.databaseName,
+        this.props.timeScale,
+      );
+      getStatementsUsingIndex(req)
+        .then(res => {
+          populateRegionNodeForStatements(res, this.props.nodeRegions);
+          this.setState({
+            statements: res,
+            lastStatementsUpdated: moment(),
+            lastStatementsError: null,
+          });
+        })
+        .catch(error => {
+          this.setState({
+            lastStatementsUpdated: moment(),
+            lastStatementsError: error,
+          });
+        });
+    }
   }
 
   private getTimestampString(timestamp: Moment): string {
@@ -197,6 +306,26 @@ export class IndexDetailsPage extends React.Component<
     } else {
       return timestamp.format(DATE_FORMAT_24_UTC);
     }
+  }
+
+  private getApps(): string[] {
+    const { statements } = this.state;
+    let sawBlank = false;
+    let sawInternal = false;
+    const apps: { [app: string]: boolean } = {};
+    statements.forEach((statement: AggregateStatistics) => {
+      if (statement.applicationName.startsWith(INTERNAL_APP_NAME_PREFIX)) {
+        sawInternal = true;
+      } else if (statement.applicationName) {
+        apps[statement.applicationName] = true;
+      } else {
+        sawBlank = true;
+      }
+    });
+    return []
+      .concat(sawInternal ? [INTERNAL_APP_NAME_PREFIX] : [])
+      .concat(sawBlank ? [unset] : [])
+      .concat(Object.keys(apps).sort());
   }
 
   private renderIndexRecommendations(
@@ -275,10 +404,58 @@ export class IndexDetailsPage extends React.Component<
     );
   }
 
+  private filteredStatements = (): AggregateStatistics[] => {
+    const { filters, search, statements } = this.state;
+    const { nodeRegions, isTenant } = this.props;
+    let filteredStatements = statements;
+    const isInternal = (statement: AggregateStatistics) =>
+      statement.applicationName.startsWith(INTERNAL_APP_NAME_PREFIX);
+
+    if (filters.app && filters.app !== "All") {
+      const criteria = decodeURIComponent(filters.app).split(",");
+      let showInternal = false;
+      if (criteria.includes(INTERNAL_APP_NAME_PREFIX)) {
+        showInternal = true;
+      }
+      if (criteria.includes(unset)) {
+        criteria.push("");
+      }
+
+      filteredStatements = statements.filter(
+        (statement: AggregateStatistics) =>
+          (showInternal && isInternal(statement)) ||
+          criteria.includes(statement.applicationName),
+      );
+    }
+    return filteredStatementsData(
+      filters,
+      search,
+      filteredStatements,
+      nodeRegions,
+      isTenant,
+    );
+  };
+
   render(): React.ReactElement {
-    const { statements, stmtSortSetting, stmtPagination } = this.state;
-    const { isTenant, hasViewActivityRedactedRole, hasAdminRole } = this.props;
-    const isEmptySearchResults = statements?.length > 0;
+    const {
+      statements,
+      stmtSortSetting,
+      stmtPagination,
+      search,
+      activeFilters,
+      filters,
+    } = this.state;
+    const { nodeRegions, isTenant, hasViewActivityRedactedRole, hasAdminRole } =
+      this.props;
+    const apps = this.getApps();
+    const nodes = Object.keys(nodeRegions)
+      .map(n => Number(n))
+      .sort();
+    const regions = unique(
+      nodes.map(node => nodeRegions[node.toString()]),
+    ).sort();
+
+    const filteredStmts = this.filteredStatements();
 
     return (
       <div className={cx("page-container")}>
@@ -400,40 +577,92 @@ export class IndexDetailsPage extends React.Component<
                 <Col className="gutter-row" span={24}>
                   <SummaryCard className={cx("summary-card--row")}>
                     <Heading type="h5">Index Usage</Heading>
-                    <TableStatistics
-                      pagination={stmtPagination}
-                      totalCount={statements.length}
-                      arrayItemName={"statement fingerprints using this index"}
-                      activeFilters={0}
-                    />
-                    <SortedTable
-                      data={statements}
-                      columns={makeStatementsColumns(
-                        statements,
-                        [],
-                        calculateTotalWorkload(statements),
-                        "statement",
-                        isTenant,
-                        hasViewActivityRedactedRole,
-                      ).filter(c => !(isTenant && c.hideIfTenant))}
-                      className={stmtCx("statements-table")}
-                      tableWrapperClassName={cx("table-scroll")}
-                      sortSetting={stmtSortSetting}
-                      onChangeSortSetting={this.onChangeSortSetting}
-                      pagination={stmtPagination}
-                      renderNoResult={
-                        <EmptyStatementsPlaceholder
-                          isEmptySearchResults={isEmptySearchResults}
-                          statementView={StatementViewType.USING_INDEX}
+                    <PageConfig whiteBkg={true}>
+                      <PageConfigItem>
+                        <Search
+                          onSubmit={this.onSubmitSearchField}
+                          onClear={this.onClearSearchField}
+                          defaultValue={search}
                         />
+                      </PageConfigItem>
+                      <PageConfigItem>
+                        <Filter
+                          onSubmitFilters={this.onSubmitFilters}
+                          appNames={apps}
+                          regions={regions}
+                          nodes={nodes.map(n => "n" + n)}
+                          activeFilters={activeFilters}
+                          filters={filters}
+                          hideTimeLabel={true}
+                          showDB={false}
+                          showSqlType={true}
+                          showScan={true}
+                          showRegions={regions.length > 1}
+                          showNodes={!isTenant && nodes.length > 1}
+                        />
+                      </PageConfigItem>
+                      <PageConfigItem className={commonStyles("separator")}>
+                        <TimeScaleDropdown
+                          options={timeScale1hMinOptions}
+                          currentScale={this.props.timeScale}
+                          setTimeScale={this.changeTimeScale}
+                        />
+                      </PageConfigItem>
+                    </PageConfig>
+                    <Loading
+                      loading={statements == null}
+                      page="index details"
+                      error={this.state.lastStatementsError}
+                      renderError={() =>
+                        LoadingError({
+                          statsType: "statements",
+                          timeout: this.state.lastStatementsError?.message
+                            ?.toLowerCase()
+                            .includes("timeout"),
+                        })
                       }
-                    />
-                    <Pagination
-                      pageSize={stmtPagination.pageSize}
-                      current={stmtPagination.current}
-                      total={statements.length}
-                      onChange={this.onChangePage}
-                    />
+                    >
+                      <TableStatistics
+                        pagination={stmtPagination}
+                        totalCount={filteredStmts.length}
+                        arrayItemName={
+                          "most executed statement fingerprints using this index"
+                        }
+                        activeFilters={activeFilters}
+                        onClearFilters={this.onClearFilters}
+                      />
+                      <SortedTable
+                        data={filteredStmts}
+                        columns={makeStatementsColumns(
+                          statements,
+                          [],
+                          calculateTotalWorkload(statements),
+                          "statement",
+                          isTenant,
+                          hasViewActivityRedactedRole,
+                        ).filter(c => !(isTenant && c.hideIfTenant))}
+                        className={stmtCx("statements-table")}
+                        tableWrapperClassName={cx("table-scroll")}
+                        sortSetting={stmtSortSetting}
+                        onChangeSortSetting={this.onChangeSortSetting}
+                        pagination={stmtPagination}
+                        renderNoResult={
+                          <EmptyStatementsPlaceholder
+                            isEmptySearchResults={
+                              (search?.length > 0 || activeFilters > 0) &&
+                              filteredStmts?.length === 0
+                            }
+                            statementView={StatementViewType.USING_INDEX}
+                          />
+                        }
+                      />
+                      <Pagination
+                        pageSize={stmtPagination.pageSize}
+                        current={stmtPagination.current}
+                        total={filteredStmts.length}
+                        onChange={this.onChangePage}
+                      />
+                    </Loading>
                   </SummaryCard>
                 </Col>
               </Row>

--- a/pkg/ui/workspaces/cluster-ui/src/pageConfig/pageConfig.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/pageConfig/pageConfig.tsx
@@ -16,12 +16,13 @@ import { CockroachCloudContext } from "../contexts";
 export interface PageConfigProps {
   layout?: "list" | "spread";
   children?: React.ReactNode;
+  whiteBkg?: boolean;
 }
 
 const cx = classnames.bind(styles);
 
 export function PageConfig(props: PageConfigProps): React.ReactElement {
-  const isCockroachCloud = useContext(CockroachCloudContext);
+  const whiteBkg = useContext(CockroachCloudContext) || props.whiteBkg;
 
   const classes = cx({
     "page-config__list": props.layout !== "spread",
@@ -31,7 +32,7 @@ export function PageConfig(props: PageConfigProps): React.ReactElement {
   return (
     <div
       className={cx("page-config", {
-        "page-config__white-background": isCockroachCloud,
+        "page-config__white-background": whiteBkg,
       })}
     >
       <ul className={classes}>{props.children}</ul>

--- a/pkg/ui/workspaces/cluster-ui/src/queryFilter/filter.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/queryFilter/filter.tsx
@@ -385,8 +385,8 @@ export class Filter extends React.Component<QueryFilter, FilterState> {
   };
 
   isOptionSelected = (option: string, field: string): boolean => {
-    const selection = field.split(",");
-    return selection.length > 0 && selection.includes(option);
+    const selection = field?.split(",");
+    return selection?.length > 0 && selection?.includes(option);
   };
 
   render(): React.ReactElement {
@@ -458,7 +458,7 @@ export class Filter extends React.Component<QueryFilter, FilterState> {
         }))
       : [];
     const appValue = appsOptions.filter(option => {
-      return filters.app.split(",").includes(option.label);
+      return filters.app?.split(",").includes(option.label);
     });
     const appFilter = (
       <div>
@@ -696,8 +696,8 @@ export class Filter extends React.Component<QueryFilter, FilterState> {
         ]
       : [];
 
-    const sqlTypeValue = sqlTypes.filter(option => {
-      return filters.sqlType.split(",").includes(option.label);
+    const sqlTypeValue = sqlTypes?.filter(option => {
+      return filters.sqlType?.split(",").includes(option.label);
     });
     const sqlTypeFilter = (
       <div>

--- a/pkg/ui/workspaces/cluster-ui/src/sqlActivity/util.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/sqlActivity/util.tsx
@@ -1,0 +1,90 @@
+// Copyright 2023 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import { Filters, getTimeValueInSeconds } from "../queryFilter";
+import { AggregateStatistics } from "../statementsTable";
+import { containAny, unset } from "../util";
+import { filterBySearchQuery } from "../statementsPage";
+
+export function filteredStatementsData(
+  filters: Filters,
+  search: string,
+  statements: AggregateStatistics[],
+  nodeRegions: { [key: string]: string },
+  isTenant: boolean,
+): AggregateStatistics[] {
+  const timeValue = getTimeValueInSeconds(filters);
+  const sqlTypes =
+    filters.sqlType.length > 0
+      ? filters.sqlType.split(",").map(function (sqlType: string) {
+          // Adding "Type" to match the value on the Statement
+          // Possible values: TypeDDL, TypeDML, TypeDCL and TypeTCL
+          return "Type" + sqlType;
+        })
+      : [];
+  const databases =
+    filters.database.length > 0 ? filters.database.split(",") : [];
+  if (databases.includes(unset)) {
+    databases.push("");
+  }
+  const regions = filters.regions.length > 0 ? filters.regions.split(",") : [];
+  const nodes = filters.nodes.length > 0 ? filters.nodes.split(",") : [];
+
+  // Return statements filtered by the values selected on the filter and
+  // the search text. A statement must match all selected filters to be
+  // displayed on the table.
+  // Current filters: search text, database, fullScan, service latency,
+  // SQL Type, nodes and regions.
+  return statements
+    .filter(
+      statement =>
+        databases.length == 0 || databases.includes(statement.database),
+    )
+    .filter(statement => (filters.fullScan ? statement.fullScan : true))
+    .filter(
+      statement =>
+        statement.stats.service_lat.mean >= timeValue || timeValue === "empty",
+    )
+    .filter(
+      statement =>
+        sqlTypes.length == 0 || sqlTypes.includes(statement.stats.sql_type),
+    )
+    .filter(
+      // The statement must contain at least one value from the selected regions
+      // list if the list is not empty.
+      statement =>
+        regions.length == 0 ||
+        (statement.stats.nodes &&
+          containAny(
+            statement.stats.nodes.map(
+              node => nodeRegions[node.toString()],
+              regions,
+            ),
+            regions,
+          )),
+    )
+    .filter(
+      // The statement must contain at least one value from the selected nodes
+      // list if the list is not empty.
+      // If the cluster is a tenant cluster we don't care
+      // about nodes.
+      statement =>
+        isTenant ||
+        nodes.length == 0 ||
+        (statement.stats.nodes &&
+          containAny(
+            statement.stats.nodes.map(node => "n" + node),
+            nodes,
+          )),
+    )
+    .filter(statement =>
+      search ? filterBySearchQuery(statement, search) : true,
+    );
+}

--- a/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.module.scss
@@ -12,8 +12,7 @@ cl-table-container {
   height: 32px;
 }
 
-.cl-count-title,
-.last-cleared-title {
+@mixin statistics-label {
   font-family: $font-family--base;
   font-size: 14px;
   padding: 0px;
@@ -25,6 +24,17 @@ cl-table-container {
   .label {
     font-family: $font-family--bold;
     color: $colors--neutral-7;
+  }
+}
+
+.cl-count-title,
+.last-cleared-title {
+  @include statistics-label;
+}
+
+.cl-table-statistic {
+  .cl-count-title {
+    @include statistics-label;
   }
 }
 

--- a/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.tsx
@@ -28,18 +28,11 @@ import {
   defaultFilters,
   Filter,
   Filters,
-  getTimeValueInSeconds,
   handleFiltersFromQueryString,
   updateFiltersQueryParamsOnTab,
 } from "../queryFilter";
 
-import {
-  calculateTotalWorkload,
-  containAny,
-  syncHistory,
-  unique,
-  unset,
-} from "src/util";
+import { calculateTotalWorkload, syncHistory, unique } from "src/util";
 import {
   AggregateStatistics,
   makeStatementsColumns,
@@ -84,6 +77,7 @@ import {
   InsertStmtDiagnosticRequest,
   StatementDiagnosticsReport,
 } from "../api";
+import { filteredStatementsData } from "../sqlActivity/util";
 
 const cx = classNames.bind(styles);
 const sortableTableCx = classNames.bind(sortableTableStyles);
@@ -492,80 +486,6 @@ export class StatementsPage extends React.Component<
     );
   };
 
-  filteredStatementsData = (): AggregateStatistics[] => {
-    const { filters } = this.state;
-    const { search, statements, nodeRegions, isTenant } = this.props;
-    const timeValue = getTimeValueInSeconds(filters);
-    const sqlTypes =
-      filters.sqlType.length > 0
-        ? filters.sqlType.split(",").map(function (sqlType: string) {
-            // Adding "Type" to match the value on the Statement
-            // Possible values: TypeDDL, TypeDML, TypeDCL and TypeTCL
-            return "Type" + sqlType;
-          })
-        : [];
-    const databases =
-      filters.database.length > 0 ? filters.database.split(",") : [];
-    if (databases.includes(unset)) {
-      databases.push("");
-    }
-    const regions =
-      filters.regions.length > 0 ? filters.regions.split(",") : [];
-    const nodes = filters.nodes.length > 0 ? filters.nodes.split(",") : [];
-
-    // Return statements filtered by the values selected on the filter and
-    // the search text. A statement must match all selected filters to be
-    // displayed on the table.
-    // Current filters: search text, database, fullScan, service latency,
-    // SQL Type, nodes and regions.
-    return statements
-      .filter(
-        statement =>
-          databases.length == 0 || databases.includes(statement.database),
-      )
-      .filter(statement => (filters.fullScan ? statement.fullScan : true))
-      .filter(
-        statement =>
-          statement.stats.service_lat.mean >= timeValue ||
-          timeValue === "empty",
-      )
-      .filter(
-        statement =>
-          sqlTypes.length == 0 || sqlTypes.includes(statement.stats.sql_type),
-      )
-      .filter(
-        // The statement must contain at least one value from the selected regions
-        // list if the list is not empty.
-        statement =>
-          regions.length == 0 ||
-          (statement.stats.nodes &&
-            containAny(
-              statement.stats.nodes.map(
-                node => nodeRegions[node.toString()],
-                regions,
-              ),
-              regions,
-            )),
-      )
-      .filter(
-        // The statement must contain at least one value from the selected nodes
-        // list if the list is not empty.
-        // If the cluster is a tenant cluster we don't care
-        // about nodes.
-        statement =>
-          isTenant ||
-          nodes.length == 0 ||
-          (statement.stats.nodes &&
-            containAny(
-              statement.stats.nodes.map(node => "n" + node),
-              nodes,
-            )),
-      )
-      .filter(statement =>
-        search ? filterBySearchQuery(statement, search) : true,
-      );
-  };
-
   renderStatements = (regions: string[]): React.ReactElement => {
     const { pagination, filters, activeFilters } = this.state;
     const {
@@ -580,7 +500,13 @@ export class StatementsPage extends React.Component<
       sortSetting,
       search,
     } = this.props;
-    const data = this.filteredStatementsData();
+    const data = filteredStatementsData(
+      filters,
+      search,
+      statements,
+      nodeRegions,
+      isTenant,
+    );
     const totalWorkload = calculateTotalWorkload(statements);
     const totalCount = data.length;
     const isEmptySearchResults = statements?.length > 0 && search?.length > 0;

--- a/pkg/ui/workspaces/db-console/src/views/databases/indexDetailsPage/redux.spec.ts
+++ b/pkg/ui/workspaces/db-console/src/views/databases/indexDetailsPage/redux.spec.ts
@@ -16,6 +16,7 @@ import {
   IndexDetailPageActions,
   IndexDetailsPageData,
   util,
+  TimeScale,
 } from "@cockroachlabs/cluster-ui";
 
 import { AdminUIState, createAdminUIStore } from "src/redux/state";
@@ -57,6 +58,14 @@ function fakeRouteComponentProps(
     },
   };
 }
+
+const timeScale: TimeScale = {
+  key: "Past 10 Minutes",
+  windowSize: moment.duration(10, "minutes"),
+  windowValid: moment.duration(10, "seconds"),
+  sampleSize: moment.duration(10, "seconds"),
+  fixedWindowEnd: false,
+};
 
 class TestDriver {
   private readonly actions: IndexDetailPageActions;
@@ -104,6 +113,8 @@ class TestDriver {
     delete expected.details.lastRead;
     delete this.properties().details.lastReset;
     delete expected.details.lastReset;
+    delete this.properties().timeScale;
+    delete expected.timeScale;
     expect(this.properties()).toEqual(expected);
   }
 
@@ -136,6 +147,9 @@ describe("Index Details Page", function () {
         indexName: "INDEX",
         isTenant: false,
         nodeRegions: {},
+        hasAdminRole: undefined,
+        hasViewActivityRedactedRole: undefined,
+        timeScale: timeScale,
         details: {
           loading: false,
           loaded: false,
@@ -188,6 +202,9 @@ describe("Index Details Page", function () {
       indexName: "INDEX",
       isTenant: false,
       nodeRegions: {},
+      timeScale: timeScale,
+      hasAdminRole: undefined,
+      hasViewActivityRedactedRole: undefined,
       details: {
         loading: false,
         loaded: true,

--- a/pkg/ui/workspaces/db-console/src/views/databases/indexDetailsPage/redux.ts
+++ b/pkg/ui/workspaces/db-console/src/views/databases/indexDetailsPage/redux.ts
@@ -37,6 +37,8 @@ import {
   selectHasAdminRole,
 } from "src/redux/user";
 import { nodeRegionsByIDSelector } from "src/redux/nodes";
+import { setGlobalTimeScaleAction } from "src/redux/statements";
+import { selectTimeScale } from "src/redux/timeScale";
 const { RecommendationType } = cockroach.sql.IndexRecommendation;
 
 export const mapStateToProps = createSelector(
@@ -50,6 +52,7 @@ export const mapStateToProps = createSelector(
   state => selectHasViewActivityRedactedRole(state),
   state => nodeRegionsByIDSelector(state),
   state => selectHasAdminRole(state),
+  state => selectTimeScale(state),
   (
     database,
     table,
@@ -58,6 +61,7 @@ export const mapStateToProps = createSelector(
     hasViewActivityRedactedRole,
     nodeRegions,
     hasAdminRole,
+    timeScale,
   ): IndexDetailsPageData => {
     const stats = indexStats[generateTableID(database, table)];
     const details = stats?.data?.statistics.filter(
@@ -88,6 +92,7 @@ export const mapStateToProps = createSelector(
       hasViewActivityRedactedRole: hasViewActivityRedactedRole,
       hasAdminRole: hasAdminRole,
       nodeRegions: nodeRegions,
+      timeScale: timeScale,
       details: {
         loading: !!stats?.inFlight,
         loaded: !!stats?.valid,
@@ -112,4 +117,5 @@ export const mapDispatchToProps = {
   resetIndexUsageStats: resetIndexUsageStatsAction,
   refreshNodes,
   refreshUserSQLRoles,
+  onTimeScaleChange: setGlobalTimeScaleAction,
 };


### PR DESCRIPTION
Fixes #93087

This commit adds search, filters and time picker for the list of fingerprints most used per index, on the Index Details page.

It also limits to 20 fingerprints until we can make improvements to use pagination on our calls with
sql-over-http.

With no filters
<img width="1669" alt="Screen Shot 2023-01-27 at 1 37 35 PM" src="https://user-images.githubusercontent.com/1017486/215167830-bd119e13-a875-49bd-9c8d-305230dd4b01.png">

With filters
<img width="1508" alt="Screen Shot 2023-01-27 at 1 37 49 PM" src="https://user-images.githubusercontent.com/1017486/215167846-c668d79a-7a59-420e-b96c-2eff6a50aca6.png">


https://www.loom.com/share/d4129452593a40198902a5f2539d8568

Release note (ui change): Add search, filter and time picker for the list of most used statement fingerprints on the Index Details page.