### PR TITLE
asof: fix internal error on AOST expression requiring normalization

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/as_of
+++ b/pkg/sql/logictest/testdata/logic_test/as_of
@@ -142,3 +142,8 @@ SET TRANSACTION AS OF system time '-1s'
 
 statement ok
 ROLLBACK
+
+# Verify that an expression that requires normalization does not result in an
+# internal error.
+statement error pq: AS OF SYSTEM TIME: expected timestamp, decimal, or interval, got bool
+SELECT * FROM t AS OF SYSTEM TIME ('' BETWEEN '' AND '')

--- a/pkg/sql/sem/asof/BUILD.bazel
+++ b/pkg/sql/sem/asof/BUILD.bazel
@@ -10,6 +10,7 @@ go_library(
         "//pkg/sql/pgwire/pgcode",
         "//pkg/sql/pgwire/pgerror",
         "//pkg/sql/sem/eval",
+        "//pkg/sql/sem/normalize",
         "//pkg/sql/sem/tree",
         "//pkg/sql/types",
         "//pkg/util/duration",

--- a/pkg/sql/sem/asof/as_of.go
+++ b/pkg/sql/sem/asof/as_of.go
@@ -20,6 +20,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/eval"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/normalize"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util/duration"
@@ -192,7 +193,10 @@ func Eval(
 			return eval.AsOfSystemTime{}, newInvalidExprError()
 		}
 	}
-
+	var err error
+	if te, err = normalize.Expr(ctx, evalCtx, te); err != nil {
+		return eval.AsOfSystemTime{}, err
+	}
 	d, err := eval.Expr(ctx, evalCtx, te)
 	if err != nil {
 		return eval.AsOfSystemTime{}, err


### PR DESCRIPTION
Fixes #95604

This adds missing normalization of AS OF SYSTEM TIME expressions. Without normalization, some expressions such as range conditions may result in an internal error.

Release note (bug fix): This patch fixes internal errors which may occur on some AS OF SYSTEM TIME expressions.