### PR TITLE
logictest: parameterize cluster setting directives

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/alter_table_locality
+++ b/pkg/ccl/logictestccl/testdata/logic_test/alter_table_locality
@@ -1,4 +1,4 @@
-# tenant-cluster-setting-override-opt: allow-zone-configs-for-secondary-tenants allow-multi-region-abstractions-for-secondary-tenants
+# tenant-cluster-setting-override-opt: sql.zone_configs.allow_for_secondary_tenant.enabled=true sql.multi_region.allow_abstractions_for_secondary_tenants.enabled=true
 # LogicTest: multiregion-9node-3region-3azs multiregion-9node-3region-3azs-no-los
 
 statement ok

--- a/pkg/ccl/logictestccl/testdata/logic_test/auto_rehoming
+++ b/pkg/ccl/logictestccl/testdata/logic_test/auto_rehoming
@@ -1,4 +1,4 @@
-# tenant-cluster-setting-override-opt: allow-multi-region-abstractions-for-secondary-tenants
+# tenant-cluster-setting-override-opt: sql.multi_region.allow_abstractions_for_secondary_tenants.enabled=true
 # LogicTest: local
 
 statement ok

--- a/pkg/ccl/logictestccl/testdata/logic_test/global_placement_restricted
+++ b/pkg/ccl/logictestccl/testdata/logic_test/global_placement_restricted
@@ -1,4 +1,4 @@
-# tenant-cluster-setting-override-opt: allow-multi-region-abstractions-for-secondary-tenants
+# tenant-cluster-setting-override-opt: sql.multi_region.allow_abstractions_for_secondary_tenants.enabled=true
 # LogicTest: multiregion-9node-3region-3azs multiregion-9node-3region-3azs-vec-off multiregion-9node-3region-3azs-no-los
 
 statement ok

--- a/pkg/ccl/logictestccl/testdata/logic_test/multi_region
+++ b/pkg/ccl/logictestccl/testdata/logic_test/multi_region
@@ -1,4 +1,4 @@
-# tenant-cluster-setting-override-opt: allow-multi-region-abstractions-for-secondary-tenants
+# tenant-cluster-setting-override-opt: sql.multi_region.allow_abstractions_for_secondary_tenants.enabled=true
 # knob-opt: sync-event-log
 # LogicTest: multiregion-9node-3region-3azs multiregion-9node-3region-3azs-tenant multiregion-9node-3region-3azs-no-los
 

--- a/pkg/ccl/logictestccl/testdata/logic_test/multi_region_alter_table_regional_by_row
+++ b/pkg/ccl/logictestccl/testdata/logic_test/multi_region_alter_table_regional_by_row
@@ -1,4 +1,4 @@
-# tenant-cluster-setting-override-opt: allow-multi-region-abstractions-for-secondary-tenants
+# tenant-cluster-setting-override-opt: sql.multi_region.allow_abstractions_for_secondary_tenants.enabled=true
 # LogicTest: multiregion-9node-3region-3azs
 
 # This file contains a regression test for ALTER TABLE ... REGIONAL BY ROW

--- a/pkg/ccl/logictestccl/testdata/logic_test/multi_region_backup
+++ b/pkg/ccl/logictestccl/testdata/logic_test/multi_region_backup
@@ -1,4 +1,4 @@
-# tenant-cluster-setting-override-opt: allow-zone-configs-for-secondary-tenants allow-multi-region-abstractions-for-secondary-tenants
+# tenant-cluster-setting-override-opt: sql.zone_configs.allow_for_secondary_tenant.enabled=true sql.multi_region.allow_abstractions_for_secondary_tenants.enabled=true
 # LogicTest: multiregion-9node-3region-3azs multiregion-9node-3region-3azs-no-los
 
 # Tests in this file assume no multi-region tenant setup as tenants have no

--- a/pkg/ccl/logictestccl/testdata/logic_test/multi_region_default_primary_region
+++ b/pkg/ccl/logictestccl/testdata/logic_test/multi_region_default_primary_region
@@ -1,4 +1,4 @@
-# tenant-cluster-setting-override-opt: allow-multi-region-abstractions-for-secondary-tenants
+# tenant-cluster-setting-override-opt: sql.multi_region.allow_abstractions_for_secondary_tenants.enabled=true
 # LogicTest: multiregion-9node-3region-3azs multiregion-9node-3region-3azs-tenant multiregion-9node-3region-3azs-no-los
 
 statement ok

--- a/pkg/ccl/logictestccl/testdata/logic_test/multi_region_drop_region
+++ b/pkg/ccl/logictestccl/testdata/logic_test/multi_region_drop_region
@@ -1,4 +1,4 @@
-# tenant-cluster-setting-override-opt: allow-multi-region-abstractions-for-secondary-tenants
+# tenant-cluster-setting-override-opt: sql.multi_region.allow_abstractions_for_secondary_tenants.enabled=true
 # LogicTest: multiregion-9node-3region-3azs multiregion-9node-3region-3azs-tenant multiregion-9node-3region-3azs-no-los
 
 query TTTTT

--- a/pkg/ccl/logictestccl/testdata/logic_test/multi_region_foreign_key_lookup_join
+++ b/pkg/ccl/logictestccl/testdata/logic_test/multi_region_foreign_key_lookup_join
@@ -1,4 +1,4 @@
-# tenant-cluster-setting-override-opt: allow-multi-region-abstractions-for-secondary-tenants
+# tenant-cluster-setting-override-opt: sql.multi_region.allow_abstractions_for_secondary_tenants.enabled=true
 # LogicTest: multiregion-9node-3region-3azs !metamorphic-batch-sizes
 
 # Set the closed timestamp interval to be short to shorten the amount of time

--- a/pkg/ccl/logictestccl/testdata/logic_test/multi_region_import_export
+++ b/pkg/ccl/logictestccl/testdata/logic_test/multi_region_import_export
@@ -1,4 +1,4 @@
-# tenant-cluster-setting-override-opt: allow-multi-region-abstractions-for-secondary-tenants
+# tenant-cluster-setting-override-opt: sql.multi_region.allow_abstractions_for_secondary_tenants.enabled=true
 # LogicTest: multiregion-9node-3region-3azs multiregion-9node-3region-3azs-vec-off multiregion-9node-3region-3azs-no-los
 
 # Tests in this file assume no multi-region tenant setup as tenants have no

--- a/pkg/ccl/logictestccl/testdata/logic_test/multi_region_locality_optimized_search_query_behavior
+++ b/pkg/ccl/logictestccl/testdata/logic_test/multi_region_locality_optimized_search_query_behavior
@@ -1,4 +1,4 @@
-# tenant-cluster-setting-override-opt: allow-multi-region-abstractions-for-secondary-tenants
+# tenant-cluster-setting-override-opt: sql.multi_region.allow_abstractions_for_secondary_tenants.enabled=true
 # LogicTest: multiregion-9node-3region-3azs
 # TODO(#75864): enable multiregion-9node-3region-3azs-tenant.
 

--- a/pkg/ccl/logictestccl/testdata/logic_test/multi_region_privileges
+++ b/pkg/ccl/logictestccl/testdata/logic_test/multi_region_privileges
@@ -1,4 +1,4 @@
-# tenant-cluster-setting-override-opt: allow-multi-region-abstractions-for-secondary-tenants
+# tenant-cluster-setting-override-opt: sql.multi_region.allow_abstractions_for_secondary_tenants.enabled=true
 # LogicTest: multiregion-9node-3region-3azs multiregion-9node-3region-3azs-tenant multiregion-9node-3region-3azs-no-los
 
 user root

--- a/pkg/ccl/logictestccl/testdata/logic_test/multi_region_query_behavior
+++ b/pkg/ccl/logictestccl/testdata/logic_test/multi_region_query_behavior
@@ -1,4 +1,4 @@
-# tenant-cluster-setting-override-opt: allow-multi-region-abstractions-for-secondary-tenants
+# tenant-cluster-setting-override-opt: sql.multi_region.allow_abstractions_for_secondary_tenants.enabled=true
 # LogicTest: multiregion-9node-3region-3azs multiregion-9node-3region-3azs-no-los
 # TODO(#75864): enable multiregion-9node-3region-3azs-tenant.
 

--- a/pkg/ccl/logictestccl/testdata/logic_test/multi_region_remote_access_error
+++ b/pkg/ccl/logictestccl/testdata/logic_test/multi_region_remote_access_error
@@ -1,4 +1,4 @@
-# tenant-cluster-setting-override-opt: allow-multi-region-abstractions-for-secondary-tenants
+# tenant-cluster-setting-override-opt: sql.multi_region.allow_abstractions_for_secondary_tenants.enabled=true
 # LogicTest: multiregion-9node-3region-3azs !metamorphic-batch-sizes
 # TODO(msirek): Make this test work with the multiregion-9node-3region-3azs-vec-off config
 # Currently this test and other multiregion tests may flake when run under

--- a/pkg/ccl/logictestccl/testdata/logic_test/multi_region_show
+++ b/pkg/ccl/logictestccl/testdata/logic_test/multi_region_show
@@ -1,4 +1,4 @@
-# tenant-cluster-setting-override-opt: allow-multi-region-abstractions-for-secondary-tenants
+# tenant-cluster-setting-override-opt: sql.multi_region.allow_abstractions_for_secondary_tenants.enabled=true
 # LogicTest: multiregion-9node-3region-3azs multiregion-9node-3region-3azs-tenant multiregion-9node-3region-3azs-no-los
 
 statement ok

--- a/pkg/ccl/logictestccl/testdata/logic_test/multi_region_zone_config_extensions
+++ b/pkg/ccl/logictestccl/testdata/logic_test/multi_region_zone_config_extensions
@@ -1,4 +1,4 @@
-# tenant-cluster-setting-override-opt: allow-multi-region-abstractions-for-secondary-tenants
+# tenant-cluster-setting-override-opt: sql.multi_region.allow_abstractions_for_secondary_tenants.enabled=true
 # LogicTest: multiregion-9node-3region-3azs multiregion-9node-3region-3azs-tenant
 
 query TTTTT

--- a/pkg/ccl/logictestccl/testdata/logic_test/multi_region_zone_configs
+++ b/pkg/ccl/logictestccl/testdata/logic_test/multi_region_zone_configs
@@ -1,4 +1,4 @@
-# tenant-cluster-setting-override-opt: allow-zone-configs-for-secondary-tenants allow-multi-region-abstractions-for-secondary-tenants
+# tenant-cluster-setting-override-opt: sql.zone_configs.allow_for_secondary_tenant.enabled=true sql.multi_region.allow_abstractions_for_secondary_tenants.enabled=true
 # LogicTest: multiregion-9node-3region-3azs multiregion-9node-3region-3azs-tenant multiregion-9node-3region-3azs-no-los
 
 query TTTTT

--- a/pkg/ccl/logictestccl/testdata/logic_test/multi_region_zone_configs_long_regions
+++ b/pkg/ccl/logictestccl/testdata/logic_test/multi_region_zone_configs_long_regions
@@ -1,4 +1,4 @@
-# tenant-cluster-setting-override-opt: allow-multi-region-abstractions-for-secondary-tenants
+# tenant-cluster-setting-override-opt: sql.multi_region.allow_abstractions_for_secondary_tenants.enabled=true
 # LogicTest: multiregion-3node-3superlongregions
 
 query TTTTT

--- a/pkg/ccl/logictestccl/testdata/logic_test/partitioning
+++ b/pkg/ccl/logictestccl/testdata/logic_test/partitioning
@@ -1,4 +1,4 @@
-# tenant-cluster-setting-override-opt: allow-zone-configs-for-secondary-tenants
+# tenant-cluster-setting-override-opt: sql.zone_configs.allow_for_secondary_tenant.enabled=true
 # LogicTest: local
 
 statement error syntax

--- a/pkg/ccl/logictestccl/testdata/logic_test/partitioning_hash_sharded_index_mr
+++ b/pkg/ccl/logictestccl/testdata/logic_test/partitioning_hash_sharded_index_mr
@@ -1,4 +1,4 @@
-# tenant-cluster-setting-override-opt: allow-multi-region-abstractions-for-secondary-tenants
+# tenant-cluster-setting-override-opt: sql.multi_region.allow_abstractions_for_secondary_tenants.enabled=true
 # LogicTest: multiregion-9node-3region-3azs multiregion-9node-3region-3azs-tenant multiregion-9node-3region-3azs-no-los
 
 statement ok

--- a/pkg/ccl/logictestccl/testdata/logic_test/placement
+++ b/pkg/ccl/logictestccl/testdata/logic_test/placement
@@ -1,4 +1,4 @@
-# tenant-cluster-setting-override-opt: allow-multi-region-abstractions-for-secondary-tenants
+# tenant-cluster-setting-override-opt: sql.multi_region.allow_abstractions_for_secondary_tenants.enabled=true
 # LogicTest: multiregion-9node-3region-3azs multiregion-9node-3region-3azs-vec-off multiregion-9node-3region-3azs-no-los
 
 statement error PLACEMENT requires that the session setting enable_multiregion_placement_policy is enabled

--- a/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row
+++ b/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row
@@ -1,4 +1,4 @@
-# tenant-cluster-setting-override-opt: allow-zone-configs-for-secondary-tenants allow-multi-region-abstractions-for-secondary-tenants
+# tenant-cluster-setting-override-opt: sql.zone_configs.allow_for_secondary_tenant.enabled=true sql.multi_region.allow_abstractions_for_secondary_tenants.enabled=true
 # LogicTest: multiregion-9node-3region-3azs multiregion-9node-3region-3azs-vec-off multiregion-9node-3region-3azs-tenant multiregion-9node-3region-3azs-no-los
 
 statement ok

--- a/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row_auto_rehoming
+++ b/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row_auto_rehoming
@@ -1,4 +1,4 @@
-# tenant-cluster-setting-override-opt: allow-multi-region-abstractions-for-secondary-tenants
+# tenant-cluster-setting-override-opt: sql.multi_region.allow_abstractions_for_secondary_tenants.enabled=true
 # LogicTest: multiregion-9node-3region-3azs multiregion-9node-3region-3azs-tenant multiregion-9node-3region-3azs-no-los
 
 statement ok

--- a/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row_hash_sharded_index
+++ b/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row_hash_sharded_index
@@ -1,4 +1,4 @@
-# tenant-cluster-setting-override-opt: allow-multi-region-abstractions-for-secondary-tenants
+# tenant-cluster-setting-override-opt: sql.multi_region.allow_abstractions_for_secondary_tenants.enabled=true
 # LogicTest: multiregion-9node-3region-3azs multiregion-9node-3region-3azs-no-los
 
 statement ok

--- a/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row_hash_sharded_index_query_plan
+++ b/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row_hash_sharded_index_query_plan
@@ -1,4 +1,4 @@
-# tenant-cluster-setting-override-opt: allow-multi-region-abstractions-for-secondary-tenants
+# tenant-cluster-setting-override-opt: sql.multi_region.allow_abstractions_for_secondary_tenants.enabled=true
 # LogicTest: multiregion-9node-3region-3azs !metamorphic-batch-sizes
 # TODO(#75864): enable multiregion-9node-3region-3azs-tenant
 

--- a/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row_placement_restricted
+++ b/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row_placement_restricted
@@ -1,4 +1,4 @@
-# tenant-cluster-setting-override-opt: allow-multi-region-abstractions-for-secondary-tenants
+# tenant-cluster-setting-override-opt: sql.multi_region.allow_abstractions_for_secondary_tenants.enabled=true
 # LogicTest: multiregion-9node-3region-3azs multiregion-9node-3region-3azs-vec-off multiregion-9node-3region-3azs-tenant multiregion-9node-3region-3azs-no-los
 
 statement ok

--- a/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row_query_behavior
+++ b/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row_query_behavior
@@ -1,4 +1,4 @@
-# tenant-cluster-setting-override-opt: allow-multi-region-abstractions-for-secondary-tenants
+# tenant-cluster-setting-override-opt: sql.multi_region.allow_abstractions_for_secondary_tenants.enabled=true
 # LogicTest: multiregion-9node-3region-3azs !metamorphic-batch-sizes
 # TODO(#75864): enable multiregion-9node-3region-3azs-tenant and/or revert
 # the commit that split these changes out.

--- a/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row_rename_column
+++ b/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row_rename_column
@@ -1,4 +1,4 @@
-# tenant-cluster-setting-override-opt: allow-multi-region-abstractions-for-secondary-tenants
+# tenant-cluster-setting-override-opt: sql.multi_region.allow_abstractions_for_secondary_tenants.enabled=true
 # LogicTest: multiregion-9node-3region-3azs multiregion-9node-3region-3azs-vec-off multiregion-9node-3region-3azs-tenant multiregion-9node-3region-3azs-no-los
 
 # This test seems to flake (#60717).

--- a/pkg/ccl/logictestccl/testdata/logic_test/regional_by_table_placement_restricted
+++ b/pkg/ccl/logictestccl/testdata/logic_test/regional_by_table_placement_restricted
@@ -1,4 +1,4 @@
-# tenant-cluster-setting-override-opt: allow-multi-region-abstractions-for-secondary-tenants
+# tenant-cluster-setting-override-opt: sql.multi_region.allow_abstractions_for_secondary_tenants.enabled=true
 # LogicTest: multiregion-9node-3region-3azs multiregion-9node-3region-3azs-vec-off multiregion-9node-3region-3azs-tenant multiregion-9node-3region-3azs-no-los
 
 statement ok

--- a/pkg/ccl/logictestccl/testdata/logic_test/secondary_region
+++ b/pkg/ccl/logictestccl/testdata/logic_test/secondary_region
@@ -1,4 +1,4 @@
-# tenant-cluster-setting-override-opt: allow-multi-region-abstractions-for-secondary-tenants
+# tenant-cluster-setting-override-opt: sql.multi_region.allow_abstractions_for_secondary_tenants.enabled=true
 # LogicTest: multiregion-15node-5region-3azs
 
 query TTTTT colnames

--- a/pkg/ccl/logictestccl/testdata/logic_test/super_regions
+++ b/pkg/ccl/logictestccl/testdata/logic_test/super_regions
@@ -1,4 +1,4 @@
-# tenant-cluster-setting-override-opt: allow-multi-region-abstractions-for-secondary-tenants
+# tenant-cluster-setting-override-opt: sql.multi_region.allow_abstractions_for_secondary_tenants.enabled=true
 # LogicTest: multiregion-15node-5region-3azs
 
 statement ok

--- a/pkg/ccl/logictestccl/testdata/logic_test/super_regions_backup
+++ b/pkg/ccl/logictestccl/testdata/logic_test/super_regions_backup
@@ -1,4 +1,4 @@
-# tenant-cluster-setting-override-opt: allow-multi-region-abstractions-for-secondary-tenants
+# tenant-cluster-setting-override-opt: sql.multi_region.allow_abstractions_for_secondary_tenants.enabled=true
 # LogicTest: multiregion-15node-5region-3azs
 
 statement ok

--- a/pkg/ccl/logictestccl/testdata/logic_test/super_regions_cluster_settings
+++ b/pkg/ccl/logictestccl/testdata/logic_test/super_regions_cluster_settings
@@ -1,4 +1,4 @@
-# tenant-cluster-setting-override-opt: allow-multi-region-abstractions-for-secondary-tenants
+# tenant-cluster-setting-override-opt: sql.multi_region.allow_abstractions_for_secondary_tenants.enabled=true
 # LogicTest: multiregion-15node-5region-3azs
 
 statement ok

--- a/pkg/ccl/logictestccl/testdata/logic_test/zone_config_secondary_tenants
+++ b/pkg/ccl/logictestccl/testdata/logic_test/zone_config_secondary_tenants
@@ -1,5 +1,5 @@
 # LogicTest: 3node-tenant
-# tenant-cluster-setting-override-opt: allow-zone-configs-for-secondary-tenants
+# tenant-cluster-setting-override-opt: sql.zone_configs.allow_for_secondary_tenant.enabled=true
 # Zone config logic tests that are only meant to work for secondary tenants.
 
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/distsql_tenant_locality
+++ b/pkg/sql/logictest/testdata/logic_test/distsql_tenant_locality
@@ -1,5 +1,5 @@
 # LogicTest: 3node-tenant-multiregion
-# tenant-cluster-setting-override-opt: allow-split-at-for-secondary-tenants allow-zone-configs-for-secondary-tenants allow-multi-region-abstractions-for-secondary-tenants
+# tenant-cluster-setting-override-opt: sql.split_at.allow_for_secondary_tenant.enabled=true sql.zone_configs.allow_for_secondary_tenant.enabled=true sql.multi_region.allow_abstractions_for_secondary_tenants.enabled=true
 
 # Create a table on the secondary tenant.
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/sql_keys
+++ b/pkg/sql/logictest/testdata/logic_test/sql_keys
@@ -1,5 +1,5 @@
 # LogicTest: local 3node-tenant
-# tenant-cluster-setting-override-opt: allow-split-at-for-secondary-tenants
+# tenant-cluster-setting-override-opt: sql.split_at.allow_for_secondary_tenant.enabled=true
 
 # This test depends on table ID's being stable, so add new tests at the bottom
 # of the file.

--- a/pkg/sql/logictest/testdata/logic_test/zone_config
+++ b/pkg/sql/logictest/testdata/logic_test/zone_config
@@ -1,6 +1,6 @@
 # As these tests are run for both the system tenant and secondary tenants, we
 # turn on the setting that gates setting zone configs for system tenants.
-# tenant-cluster-setting-override-opt: allow-zone-configs-for-secondary-tenants
+# tenant-cluster-setting-override-opt: sql.zone_configs.allow_for_secondary_tenant.enabled=true
 
 # Check that we can alter the default zone config.
 statement ok

--- a/pkg/sql/opt/exec/execbuilder/testdata/distsql_tenant
+++ b/pkg/sql/opt/exec/execbuilder/testdata/distsql_tenant
@@ -1,5 +1,5 @@
 # LogicTest: 3node-tenant
-# tenant-cluster-setting-override-opt: allow-zone-configs-for-secondary-tenants allow-multi-region-abstractions-for-secondary-tenants
+# tenant-cluster-setting-override-opt: sql.zone_configs.allow_for_secondary_tenant.enabled=true sql.multi_region.allow_abstractions_for_secondary_tenants.enabled=true
 
 statement ok
 CREATE TABLE tbl1 (a INT PRIMARY KEY, b INT)

--- a/pkg/sql/opt/exec/execbuilder/testdata/distsql_tenant_locality
+++ b/pkg/sql/opt/exec/execbuilder/testdata/distsql_tenant_locality
@@ -1,5 +1,5 @@
 # LogicTest: 3node-tenant-multiregion
-# tenant-cluster-setting-override-opt: allow-split-at-for-secondary-tenants allow-zone-configs-for-secondary-tenants allow-multi-region-abstractions-for-secondary-tenants
+# tenant-cluster-setting-override-opt: sql.split_at.allow_for_secondary_tenant.enabled=true sql.zone_configs.allow_for_secondary_tenant.enabled=true sql.multi_region.allow_abstractions_for_secondary_tenants.enabled=true
 
 # Create a table on the secondary tenant.
 statement ok


### PR DESCRIPTION
Informs #96189

Cluster setting directives are currently hard coded which requires
boiler plate each time a new one is added.
example:
```
tenant-cluster-setting-override-opt: allow-zone-configs-for-secondary-tenants
```

This patch makes the cluster setting directives parameterized with the
cluster setting name and value to avoid this.
example:
```
tenant-cluster-setting-override-opt: sql.zone_configs.allow_for_secondary_tenant.enabled=true
```

Logic tests for tenant capabilities should have a directive
to set capabilities similar to cluster settings. This will be done
in a separate PR, but the goal is to be able to set them like this:
```
tenant-capability-override-opt: can_admin_split=true
```

Release note: None