### PR TITLE
schemachanger: improve state management

### DIFF
--- a/pkg/sql/schemachanger/corpus/corpus.go
+++ b/pkg/sql/schemachanger/corpus/corpus.go
@@ -138,7 +138,7 @@ func (cc *Collector) GetBeforeStage(
 			corpusName, corpusPrefix := makeCorpusName(parentName, t.Name(), p.Statements, stageIdx)
 			entry := &scpb.CorpusState{
 				Name:        corpusName,
-				Status:      p.Current,
+				Status:      p.Initial,
 				TargetState: &p.TargetState,
 				InRollback:  p.InRollback,
 				Revertible:  p.Revertible,
@@ -297,12 +297,11 @@ func (cr *Reader) GetNumEntries() int {
 // state.
 func (cr *Reader) GetCorpus(idx int) (name string, state *scpb.CurrentState) {
 	corpus := cr.diskState.CorpusArray[idx]
-	name = corpus.Name
-	state = &scpb.CurrentState{
+	return corpus.Name, &scpb.CurrentState{
 		TargetState: *corpus.TargetState,
+		Initial:     corpus.Status,
 		Current:     corpus.Status,
 		InRollback:  corpus.InRollback,
 		Revertible:  corpus.Revertible,
 	}
-	return name, state
 }

--- a/pkg/sql/schemachanger/scbuild/build.go
+++ b/pkg/sql/schemachanger/scbuild/build.go
@@ -29,21 +29,26 @@ import (
 	"github.com/cockroachdb/redact"
 )
 
-// Build constructs a new state from an initial state and a statement.
+// Build constructs a new state from an incumbent state and a statement.
 //
 // The function takes an AST for a DDL statement and constructs targets
-// which represent schema changes to be performed.
+// which represent schema changes to be performed. The incumbent state
+// is the schema changer state for the statement transaction, which reached
+// its present value from preceding calls to Build which were followed by the
+// execution of their corresponding statement phase stages. In other words,
+// the incumbent state encodes the schema change such as it has been defined
+// prior to this call, along with any in-transaction side effects.
 func Build(
-	ctx context.Context, dependencies Dependencies, initial scpb.CurrentState, n tree.Statement,
+	ctx context.Context, dependencies Dependencies, incumbent scpb.CurrentState, n tree.Statement,
 ) (_ scpb.CurrentState, err error) {
 	defer scerrors.StartEventf(
 		ctx,
 		"building declarative schema change targets for %s",
 		redact.Safe(n.StatementTag()),
 	).HandlePanicAndLogError(ctx, &err)
-	initial = initial.DeepCopy()
-	bs := newBuilderState(ctx, dependencies, initial)
-	els := newEventLogState(dependencies, initial, n)
+	incumbent = incumbent.DeepCopy()
+	bs := newBuilderState(ctx, dependencies, incumbent)
+	els := newEventLogState(dependencies, incumbent, n)
 	// TODO(fqazi): The optimizer can end up already modifying the statement above
 	// to fully resolve names. We need to take this into account for CTAS/CREATE
 	// VIEW statements.
@@ -61,13 +66,15 @@ func Build(
 	}
 	scbuildstmt.Process(b, an.GetStatement())
 	an.ValidateAnnotations()
-	els.statements[len(els.statements)-1].RedactedStatement = string(
+	currentStatementID := uint32(len(els.statements) - 1)
+	els.statements[currentStatementID].RedactedStatement = string(
 		dependencies.AstFormatter().FormatAstAsRedactableString(an.GetStatement(), &an.annotation))
 	ts := scpb.TargetState{
 		Targets:       make([]scpb.Target, 0, len(bs.output)),
 		Statements:    els.statements,
 		Authorization: els.authorization,
 	}
+	initial := make([]scpb.Status, 0, len(bs.output))
 	current := make([]scpb.Status, 0, len(bs.output))
 	version := dependencies.ClusterSettings().Version.ActiveVersion(ctx)
 	withLogEvent := make([]scpb.Target, 0, len(bs.output))
@@ -82,24 +89,9 @@ func Build(
 			// cluster version.
 			continue
 		}
-		if e.previous == scpb.InvalidTarget {
-			// The target was newly-defined by this build.
-			if e.target.Status() == e.current {
-				// Discard it if it's already fulfilled.
-				continue
-			}
-		} else if e.previous.InitialStatus() == scpb.Status_ABSENT && e.target == scpb.ToAbsent {
-			// The target was defined as an adding target by a previous build.
-			// This build redefines it as a dropping target.
-			// As far as the schema change is concerned, this is a no-op, so we
-			// discard this target.
-			// TODO(postamar): this might be too crude, the target's absence might
-			//   cause necessary statement-phase ops to be omitted, leading to
-			//   incorrect in-txn behaviour.
-			continue
-		}
 		t := scpb.MakeTarget(e.target, e.element, &e.metadata)
 		ts.Targets = append(ts.Targets, t)
+		initial = append(initial, e.initial)
 		current = append(current, e.current)
 		if e.withLogEvent {
 			withLogEvent = append(withLogEvent, t)
@@ -116,7 +108,11 @@ func Build(
 	})
 	// Write to event log and return.
 	logEvents(b, ts, withLogEvent)
-	return scpb.CurrentState{TargetState: ts, Current: current}, nil
+	return scpb.CurrentState{
+		TargetState: ts,
+		Initial:     initial,
+		Current:     current,
+	}, nil
 }
 
 // CheckIfSupported returns if a statement is fully supported by the declarative
@@ -137,12 +133,11 @@ type (
 type elementState struct {
 	// element is the element which identifies this structure.
 	element scpb.Element
-	// current is the current status of the element.
-	current scpb.Status
-	// target is the target to be fulfilled by the element status, if applicable,
-	// while previous is the target for this element as defined by an earlier call
-	// to scbuild.Build in the same transaction, if applicable.
-	previous, target scpb.TargetStatus
+	// current is the current status of the element;
+	// initial is the status of the element at the beginning of the transaction.
+	initial, current scpb.Status
+	// target indicates the status to be fulfilled by the element.
+	target scpb.TargetStatus
 	// metadata contains the target metadata to store in the resulting
 	// scpb.TargetState produced by the current call to scbuild.Build.
 	metadata scpb.TargetMetadata
@@ -193,7 +188,9 @@ type cachedDesc struct {
 }
 
 // newBuilderState constructs a builderState.
-func newBuilderState(ctx context.Context, d Dependencies, initial scpb.CurrentState) *builderState {
+func newBuilderState(
+	ctx context.Context, d Dependencies, incumbent scpb.CurrentState,
+) *builderState {
 	bs := builderState{
 		ctx:              ctx,
 		clusterSettings:  d.ClusterSettings(),
@@ -203,7 +200,7 @@ func newBuilderState(ctx context.Context, d Dependencies, initial scpb.CurrentSt
 		tr:               d.TableReader(),
 		auth:             d.AuthorizationAccessor(),
 		createPartCCL:    d.IndexPartitioningCCLCallback(),
-		output:           make([]elementState, 0, len(initial.Current)),
+		output:           make([]elementState, 0, len(incumbent.Current)),
 		descCache:        make(map[catid.DescID]*cachedDesc),
 		tempSchemas:      make(map[catid.DescID]catalog.SchemaDescriptor),
 		commentGetter:    d.DescriptorCommentGetter(),
@@ -214,12 +211,22 @@ func newBuilderState(ctx context.Context, d Dependencies, initial scpb.CurrentSt
 	if err != nil {
 		panic(err)
 	}
-	for _, t := range initial.TargetState.Targets {
+	for _, t := range incumbent.TargetState.Targets {
 		bs.ensureDescriptor(screl.GetDescID(t.Element()))
 	}
-	for i, t := range initial.TargetState.Targets {
-		ts := scpb.AsTargetStatus(t.TargetStatus)
-		bs.ensure(t.Element(), initial.Current[i], ts, ts, t.Metadata)
+	for i, t := range incumbent.TargetState.Targets {
+		src := elementState{
+			element:  t.Element(),
+			initial:  incumbent.Initial[i],
+			current:  incumbent.Current[i],
+			target:   scpb.AsTargetStatus(t.TargetStatus),
+			metadata: t.Metadata,
+		}
+		if dst := bs.getExistingElementState(src.element); dst != nil {
+			*dst = src
+		} else {
+			bs.addNewElementState(src)
+		}
 	}
 	return &bs
 }
@@ -244,8 +251,10 @@ type eventLogState struct {
 }
 
 // newEventLogState constructs an eventLogState.
-func newEventLogState(d Dependencies, initial scpb.CurrentState, n tree.Statement) *eventLogState {
-	stmts := initial.Statements
+func newEventLogState(
+	d Dependencies, incumbent scpb.CurrentState, n tree.Statement,
+) *eventLogState {
+	stmts := incumbent.Statements
 	els := eventLogState{
 		statements: append(stmts, scpb.Statement{
 			Statement:    n.String(),

--- a/pkg/sql/schemachanger/scexec/executor_external_test.go
+++ b/pkg/sql/schemachanger/scexec/executor_external_test.go
@@ -297,23 +297,23 @@ func TestSchemaChanger(t *testing.T) {
 					metadata,
 				),
 			}
-			current := []scpb.Status{
+			initial := []scpb.Status{
 				scpb.Status_ABSENT,
 				scpb.Status_ABSENT,
 				scpb.Status_ABSENT,
 				scpb.Status_ABSENT,
 			}
-			initial := scpb.CurrentState{
+			cs = scpb.CurrentState{
 				TargetState: scpb.TargetState{Statements: stmts, Targets: targets},
-				Current:     current,
+				Initial:     initial,
+				Current:     append([]scpb.Status{}, initial...),
 			}
-
-			sc := sctestutils.MakePlan(t, initial, scop.PreCommitPhase)
+			sc := sctestutils.MakePlan(t, cs, scop.PreCommitPhase)
 			stages := sc.StagesForCurrentPhase()
 			for _, s := range stages {
 				exDeps := ti.newExecDeps(txn)
 				require.NoError(t, sc.DecorateErrorWithPlanDetails(scexec.ExecuteStage(ctx, exDeps, scop.PostCommitPhase, s.Ops())))
-				cs = scpb.CurrentState{TargetState: initial.TargetState, Current: s.After}
+				cs = cs.WithCurrentStatuses(s.After)
 			}
 			return nil
 		}))
@@ -323,7 +323,7 @@ func TestSchemaChanger(t *testing.T) {
 			for _, s := range sc.Stages {
 				exDeps := ti.newExecDeps(txn)
 				require.NoError(t, sc.DecorateErrorWithPlanDetails(scexec.ExecuteStage(ctx, exDeps, scop.PostCommitPhase, s.Ops())))
-				after = scpb.CurrentState{TargetState: cs.TargetState, Current: s.After}
+				after = cs.WithCurrentStatuses(s.After)
 			}
 			return nil
 		}))
@@ -347,15 +347,15 @@ func TestSchemaChanger(t *testing.T) {
 				parsed, err := parser.Parse("ALTER TABLE db.foo ADD COLUMN j INT")
 				require.NoError(t, err)
 				require.Len(t, parsed, 1)
-				initial, err := scbuild.Build(ctx, buildDeps, scpb.CurrentState{}, parsed[0].AST.(*tree.AlterTable))
+				cs, err = scbuild.Build(ctx, buildDeps, scpb.CurrentState{}, parsed[0].AST.(*tree.AlterTable))
 				require.NoError(t, err)
 
 				{
-					sc := sctestutils.MakePlan(t, initial, scop.PreCommitPhase)
+					sc := sctestutils.MakePlan(t, cs, scop.PreCommitPhase)
 					for _, s := range sc.StagesForCurrentPhase() {
 						exDeps := ti.newExecDeps(txn)
 						require.NoError(t, sc.DecorateErrorWithPlanDetails(scexec.ExecuteStage(ctx, exDeps, scop.PostCommitPhase, s.Ops())))
-						cs = scpb.CurrentState{TargetState: initial.TargetState, Current: s.After}
+						cs = cs.WithCurrentStatuses(s.After)
 					}
 				}
 			})

--- a/pkg/sql/schemachanger/scpb/state.go
+++ b/pkg/sql/schemachanger/scpb/state.go
@@ -22,7 +22,11 @@ import (
 // elements in the target state.
 type CurrentState struct {
 	TargetState
-	Current []Status
+
+	// Current holds the current statuses of the elements in the TargetState.
+	// Initial is like Current, except in the statement transaction, in which
+	// it instead holds the statuses at the beginning of the transaction.
+	Initial, Current []Status
 
 	// InRollback captures whether the job is currently rolling back.
 	// This is important to ensure that the job can be moved to the proper
@@ -41,10 +45,19 @@ type CurrentState struct {
 	Revertible bool
 }
 
+// WithCurrentStatuses returns a shallow copy of the current state
+// with a new set of current statuses.
+func (s CurrentState) WithCurrentStatuses(current []Status) CurrentState {
+	ret := s
+	ret.Current = current
+	return ret
+}
+
 // DeepCopy returns a deep copy of the receiver.
 func (s CurrentState) DeepCopy() CurrentState {
 	return CurrentState{
 		TargetState: *protoutil.Clone(&s.TargetState).(*TargetState),
+		Initial:     append(make([]Status, 0, len(s.Initial)), s.Initial...),
 		Current:     append(make([]Status, 0, len(s.Current)), s.Current...),
 		InRollback:  s.InRollback,
 		Revertible:  s.Revertible,
@@ -154,6 +167,7 @@ func MakeCurrentStateFromDescriptors(descriptorStates []*DescriptorState) (Curre
 				cs.JobID,
 			)
 		}
+		s.Initial = append(s.Initial, cs.CurrentStatuses...)
 		s.Current = append(s.Current, cs.CurrentStatuses...)
 		s.Targets = append(s.Targets, cs.Targets...)
 		targetRanks = append(targetRanks, cs.TargetRanks...)
@@ -198,6 +212,7 @@ func (s *stateAndRanks) Less(i, j int) bool { return s.ranks[i] < s.ranks[j] }
 func (s *stateAndRanks) Swap(i, j int) {
 	s.ranks[i], s.ranks[j] = s.ranks[j], s.ranks[i]
 	s.Targets[i], s.Targets[j] = s.Targets[j], s.Targets[i]
+	s.Initial[i], s.Initial[j] = s.Initial[j], s.Initial[i]
 	s.Current[i], s.Current[j] = s.Current[j], s.Current[i]
 }
 

--- a/pkg/sql/schemachanger/scpb/transient.go
+++ b/pkg/sql/schemachanger/scpb/transient.go
@@ -18,6 +18,17 @@ func GetTransientEquivalent(s Status) (Status, bool) {
 	return equiv, ok
 }
 
+// GetNonTransientEquivalent is the reciprocal of GetTransientEquivalent
+// and therefore take a TRANSIENT_ Status as input.
+func GetNonTransientEquivalent(s Status) (Status, bool) {
+	for k, v := range transientEquivalent {
+		if v == s {
+			return k, true
+		}
+	}
+	return Status_UNKNOWN, false
+}
+
 var transientEquivalent = map[Status]Status{
 	Status_DELETE_ONLY:   Status_TRANSIENT_DELETE_ONLY,
 	Status_WRITE_ONLY:    Status_TRANSIENT_WRITE_ONLY,

--- a/pkg/sql/schemachanger/scplan/internal/scgraph/graph.go
+++ b/pkg/sql/schemachanger/scplan/internal/scgraph/graph.go
@@ -124,7 +124,7 @@ func New(cs scpb.CurrentState) (*Graph, error) {
 	g.depEdges = makeDepEdges(func(n *screl.Node) targetIdx {
 		return g.targetIdxMap[n.Target]
 	})
-	for i, status := range cs.Current {
+	for i, status := range cs.Initial {
 		t := &cs.Targets[i]
 		if existing, ok := g.targetIdxMap[t]; ok {
 			return nil, errors.Errorf("invalid initial state contains duplicate target: %v and %v", *t, cs.Targets[existing])

--- a/pkg/sql/schemachanger/scplan/internal/scgraph/graph_test.go
+++ b/pkg/sql/schemachanger/scplan/internal/scgraph/graph_test.go
@@ -107,7 +107,11 @@ func TestGraphRanks(t *testing.T) {
 			}
 		}
 		// Setup the nodes first.
-		graph, err := scgraph.New(scpb.CurrentState{TargetState: ts, Current: status})
+		graph, err := scgraph.New(scpb.CurrentState{
+			TargetState: ts,
+			Initial:     status,
+			Current:     status,
+		})
 		require.NoError(t, err)
 		// Setup op edges for all the nodes.
 		for idx := range tc.addNode {

--- a/pkg/sql/schemachanger/scplan/internal/scgraphviz/graphviz.go
+++ b/pkg/sql/schemachanger/scplan/internal/scgraphviz/graphviz.go
@@ -117,14 +117,14 @@ func drawStages(
 		targetNodes[idx] = tn
 	}
 
-	// Want to draw an edge to the initial target statuses with some dots
-	// or something.
-	curNodes := make([]dot.Node, len(cs.Current))
-	cur := cs.Current
+	// Want to draw an edge to the initial target statuses
+	// with some dots or something.
+	curNodes := make([]dot.Node, len(cs.Initial))
+	cur := cs.Initial
 	curDummy := targetsSubgraph.Node("dummy")
 	curDummy.Attr("shape", "point")
 	curDummy.Attr("style", "invis")
-	for i, status := range cs.Current {
+	for i, status := range cs.Initial {
 		label := targetStatusID(i, status)
 		tsn := stagesSubgraph.Node(fmt.Sprintf("initial %d", i))
 		tsn.Attr("label", label)
@@ -181,7 +181,7 @@ func drawDeps(cs scpb.CurrentState, g *scgraph.Graph) (*dot.Graph, error) {
 	depsSubgraph := dg.Subgraph("deps", dot.ClusterOption{})
 	targetsSubgraph := depsSubgraph.Subgraph("targets", dot.ClusterOption{})
 	statementsSubgraph := depsSubgraph.Subgraph("statements", dot.ClusterOption{})
-	targetNodes := make([]dot.Node, len(cs.Current))
+	targetNodes := make([]dot.Node, len(cs.Initial))
 	targetIdxMap := make(map[*scpb.Target]int)
 	// Add all the statements in their own section.
 	// Note: Explains can only have one statement, so we aren't
@@ -192,10 +192,10 @@ func drawDeps(cs scpb.CurrentState, g *scgraph.Graph) (*dot.Graph, error) {
 		stmtNode.Attr("fontsize", "9")
 		stmtNode.Attr("shape", "none")
 	}
-	targetStatusNodes := make([]map[scpb.Status]dot.Node, len(cs.Current))
-	for idx, status := range cs.Current {
+	targetStatusNodes := make([]map[scpb.Status]dot.Node, len(cs.Initial))
+	for idx, status := range cs.Initial {
 		t := &cs.TargetState.Targets[idx]
-		tn := targetsSubgraph.Node(itoa(idx, len(cs.Current)))
+		tn := targetsSubgraph.Node(itoa(idx, len(cs.Initial)))
 		tn.Attr("label", htmlLabel(t.Element()))
 		tn.Attr("fontsize", "9")
 		tn.Attr("shape", "none")
@@ -208,7 +208,7 @@ func drawDeps(cs scpb.CurrentState, g *scgraph.Graph) (*dot.Graph, error) {
 		targetStatusNodes[targetIdxMap[n.Target]][n.CurrentStatus] = tn
 		return nil
 	})
-	for idx, status := range cs.Current {
+	for idx, status := range cs.Initial {
 		nn := targetStatusNodes[idx][status]
 		tn := targetNodes[idx]
 		e := tn.Edge(nn)

--- a/pkg/sql/schemachanger/scplan/plan.go
+++ b/pkg/sql/schemachanger/scplan/plan.go
@@ -109,33 +109,7 @@ func makePlan(ctx context.Context, p *Plan) (err error) {
 	{
 		start := timeutil.Now()
 		// Generate the graph used to build the stages.
-		//
-		// For each element in the target set, the graph needs to cover all the
-		// statuses which may be visited by the remainder of the schema change.
-		// Most of the time, these transitions follow the directions of the
-		// op-edges in the graph (i.e. from top to bottom in the corresponding
-		// definition in the opgen package) with the notable exception of the first
-		// stage of the pre-commit phase, denoted as the "reset stage". In this
-		// stage, the element's status transitions in the opposite direction all
-		// the way back to the initial status. For this reason, any plan which
-		// might include this stage needs the full graph, not just the subset which
-		// covers the statuses from current to target.
-		oldCurrent := p.CurrentState.Current
-		if p.Params.ExecutionPhase <= scop.PreCommitPhase {
-			// We need the full graph at this point because the plan may transition
-			// back to the initial statuses at pre-commit time.
-			//
-			// Generate the full graph using the existing scpb.TargetState.
-			// This is necessary because scgraph.Graph queries rely on pointer
-			// equality. Instead, temporarily swap out the current statuses.
-			p.CurrentState.Current = make([]scpb.Status, len(p.CurrentState.Current))
-			for i, t := range p.Targets {
-				p.CurrentState.Current[i] = scpb.AsTargetStatus(t.TargetStatus).InitialStatus()
-			}
-		}
 		p.Graph = buildGraph(ctx, p.Params.ActiveVersion, p.CurrentState)
-		// Undo any swapping out of the current statuses.
-		p.CurrentState.Current = oldCurrent
 		if log.ExpensiveLogEnabled(ctx, 2) {
 			log.Infof(ctx, "graph generation took %v", timeutil.Since(start))
 		}

--- a/pkg/sql/schemachanger/scplan/plan_test.go
+++ b/pkg/sql/schemachanger/scplan/plan_test.go
@@ -139,10 +139,7 @@ func validatePlan(t *testing.T, plan *scplan.Plan) {
 			expected[j] = s
 		}
 		e := marshalOps(t, plan.TargetState, expected)
-		cs := scpb.CurrentState{
-			TargetState: plan.TargetState,
-			Current:     stage.Before,
-		}
+		cs := plan.CurrentState.WithCurrentStatuses(stage.Before)
 		truncatedPlan := sctestutils.MakePlan(t, cs, stage.Phase)
 		sctestutils.TruncateJobOps(&truncatedPlan)
 		a := marshalOps(t, plan.TargetState, truncatedPlan.Stages)

--- a/pkg/sql/schemachanger/scrun/scrun.go
+++ b/pkg/sql/schemachanger/scrun/scrun.go
@@ -103,7 +103,7 @@ func runTransactionPhase(
 		}
 		after = stages[i].After
 	}
-	return scpb.CurrentState{TargetState: state.TargetState, Current: after}, sc.JobID, nil
+	return state.WithCurrentStatuses(after), sc.JobID, nil
 }
 
 // RunSchemaChangesInJob contains the business logic for the Resume method of a


### PR DESCRIPTION
This commit endows the scpb.CurrentState with the set of element statuses which are in force at the beginning of the statement transaction. These are then used when planning the pre-commit reset stage.

This commit also rewrites the target-setting logic in the scbuild package in a more explicit manner with extra commentary.

This commit does not change any functional behavior in production.

Informs #88294.

Release note: None