### PR TITLE
workflow: Cluster UI autopublishing fix

### DIFF
--- a/.github/workflows/cluster-ui-release.yml
+++ b/.github/workflows/cluster-ui-release.yml
@@ -32,10 +32,12 @@ jobs:
       uses: actions/setup-node@v3
       with:
         node-version: 16
+        registry-url: 'https://registry.npmjs.org'
+        always-auth: true
         cache: 'yarn'
         cache-dependency-path: pkg/ui/workspaces/cluster-ui/yarn.lock
       env:
-        NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
     - name: Check if version is published
       id: version-check
@@ -50,6 +52,8 @@ jobs:
           echo "to npm. Publishing step should be skipped. 🛑"
         else
           echo "published=no" >> $GITHUB_OUTPUT
+          echo
+          echo "✅ Cluster UI package version $PACKAGE_VERSION should be published. ✅"
         fi
 
     - name: Get Branch name
@@ -68,10 +72,12 @@ jobs:
     - name: Create version tag and push
       if: steps.version-check.outputs.published == 'no'
       run: |
-        TAGNAME="@cockroachlabs/cluster-ui@$(cat ./package.json | jq -r '.version')"
-        git tag $TAGNAME
-        git push origin $TAGNAME
+        TAGNAME="@cockroachlabs/cluster-ui@$(jq -r '.version' ./package.json)"
+        if ! [ $(git tag -l "$TAGNAME") ]; then
+          git tag $TAGNAME
+          git push origin $TAGNAME
+        fi
 
     - name: Publish patch version
       if: steps.version-check.outputs.published == 'no'
-      run: yarn publish --access public --tag ${{ steps.branch-name.outputs.branch }}
+      run: npm publish --access public --tag ${{ steps.branch-name.outputs.branch }} --ignore-scripts

--- a/pkg/ui/workspaces/cluster-ui/package.json
+++ b/pkg/ui/workspaces/cluster-ui/package.json
@@ -8,6 +8,10 @@
   },
   "main": "dist/js/main.js",
   "types": "dist/types/index.d.ts",
+  "files": [
+    "dist/",
+    "AUTHORS"
+  ],
   "scripts": {
     "build": "npm-run-all -p build:typescript build:bundle",
     "build:bundle": "NODE_ENV=production webpack --display-error-details --mode=production",


### PR DESCRIPTION
Using action `actions/setup-node@v3` we need to provide specific configuration for the internally generated `.npmrc`. This commit sets `registry-url` and `always-auth` to be explicit and changes the environment variable `NPM_TOKEN` to `NODE_AUTH_TOKEN` since this is what the action uses internally to set the auth token. I'm also switching back to using `npm` to publish as the setup-node action uses Yarn2 internally which can not read npm configuration and must have its own `.yarnrc.yml` generated.

A couple more improvements were made (since I was here),
- Add explicit output when a package should be published
- Check for the existence of a git tag before creating one (to prevent duplicates)
- Adds `--ignore-scripts` option to publish command to prevent duplicate builds. 

Test published for this PR, [publish_cluster_ui #17](https://github.com/cockroachdb/cockroach/actions/runs/4027808329/jobs/6923975372) published [22.2.1-publishtest.0](https://www.npmjs.com/package/@cockroachlabs/cluster-ui/v/22.2.1-publishtest.0) (along with git [tag](https://github.com/cockroachdb/cockroach/releases/tag/%40cockroachlabs%2Fcluster-ui%4022.2.1-publishtest.0)) 

Epic: none
Release note: None