### PR TITLE
workflow: Cluster UI autopublishing configuration fixes

### DIFF
--- a/.github/workflows/cluster-ui-release-next.yml
+++ b/.github/workflows/cluster-ui-release-next.yml
@@ -1,5 +1,6 @@
 name: Publish Cluster UI Pre-release
 on:
+  workflow_dispatch:
   push:
     branches:
       - master
@@ -31,10 +32,12 @@ jobs:
       uses: actions/setup-node@v3
       with:
         node-version: 16
+        registry-url: 'https://registry.npmjs.org'
+        always-auth: true
         cache: 'yarn'
         cache-dependency-path: pkg/ui/workspaces/cluster-ui/yarn.lock
       env:
-        NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
     - name: Check if version is published
       id: version-check
@@ -49,6 +52,8 @@ jobs:
           echo "to npm. Publishing step should be skipped. 🛑"
         else
           echo "published=no" >> $GITHUB_OUTPUT
+          echo
+          echo "✅ Cluster UI package version $PACKAGE_VERSION should be published. ✅"
         fi
 
     - name: Build Cluster UI
@@ -62,10 +67,12 @@ jobs:
     - name: Create version tag and push
       if: steps.version-check.outputs.published == 'no'
       run: |
-        TAGNAME="@cockroachlabs/cluster-ui@$(cat ./package.json | jq -r '.version')"
-        git tag $TAGNAME
-        git push origin $TAGNAME
+        TAGNAME="@cockroachlabs/cluster-ui@$(jq -r '.version' ./package.json)"
+        if ! [ $(git tag -l "$TAGNAME") ]; then
+          git tag $TAGNAME
+          git push origin $TAGNAME
+        fi
 
     - name: Publish prerelease version
       if: steps.version-check.outputs.published == 'no'
-      run: yarn publish --access public --tag next
+      run: npm publish --access public --tag next --ignore-scripts

--- a/.github/workflows/cluster-ui-release.yml
+++ b/.github/workflows/cluster-ui-release.yml
@@ -1,5 +1,6 @@
 name: Publish Cluster UI Release
 on:
+  workflow_dispatch:
   push:
     branches:
       - 'release-*'
@@ -31,10 +32,12 @@ jobs:
       uses: actions/setup-node@v3
       with:
         node-version: 16
+        registry-url: 'https://registry.npmjs.org'
+        always-auth: true
         cache: 'yarn'
         cache-dependency-path: pkg/ui/workspaces/cluster-ui/yarn.lock
       env:
-        NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
     - name: Check if version is published
       id: version-check
@@ -49,6 +52,8 @@ jobs:
           echo "to npm. Publishing step should be skipped. 🛑"
         else
           echo "published=no" >> $GITHUB_OUTPUT
+          echo
+          echo "✅ Cluster UI package version $PACKAGE_VERSION should be published. ✅"
         fi
 
     - name: Get Branch name
@@ -67,10 +72,12 @@ jobs:
     - name: Create version tag and push
       if: steps.version-check.outputs.published == 'no'
       run: |
-        TAGNAME="@cockroachlabs/cluster-ui@$(cat ./package.json | jq -r '.version')"
-        git tag $TAGNAME
-        git push origin $TAGNAME
+        TAGNAME="@cockroachlabs/cluster-ui@$(jq -r '.version' ./package.json)"
+        if ! [ $(git tag -l "$TAGNAME") ]; then
+          git tag $TAGNAME
+          git push origin $TAGNAME
+        fi
 
     - name: Publish patch version
       if: steps.version-check.outputs.published == 'no'
-      run: yarn publish --access public --tag ${{ steps.branch-name.outputs.branch }}
+      run: npm publish --access public --tag ${{ steps.branch-name.outputs.branch }} --ignore-scripts


### PR DESCRIPTION
Using action `actions/setup-node@v3` we need to provide specific configuration for the internally generated `.npmrc`. This commit sets `registry-url` and `always-auth` to be explicit and changes the environment variable `NPM_TOKEN` to `NODE_AUTH_TOKEN` since this is what the action uses internally to set the auth token. I'm also switching back to using `npm` to publish as the setup-node action uses Yarn2 internally which can not read npm configuration and must have its own `.yarnrc.yml` generated.

A couple more improvements were made (since I was here),
- Add explicit output when a package should be published
- Check for the existence of a git tag before creating one (to prevent duplicates)
- Adds `--ignore-scripts` option to publish command to prevent duplicate builds.

Test publish - [Publish Cluster UI Pre-release #73](https://github.com/cockroachdb/cockroach/actions/runs/4027917363) (published [23.1.0-publishtest.0](https://www.npmjs.com/package/@cockroachlabs/cluster-ui/v/23.1.0-publishtest.0) and created [tag](https://github.com/cockroachdb/cockroach/releases/tag/%40cockroachlabs%2Fcluster-ui%4023.1.0-publishtest.0)) 

Epic: none

Release note: None