### PR TITLE
release-22.1: sql: ensure leases aren't used when validing fk in txn

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/schema_change_in_txn
+++ b/pkg/sql/logictest/testdata/logic_test/schema_change_in_txn
@@ -1926,3 +1926,42 @@ DROP INDEX t1_57592@idx;
 
 statement error pgcode XXA00 there is no unique constraint matching given keys for referenced table t1_57592
 COMMIT
+
+# This is a regression test to handle the case where a newly created table or
+# a previously unleased table are referenced in a transaction involving
+# transactional constraint validation.
+subtest validate_constraint_referencing_modified_table
+
+
+statement ok
+CREATE TABLE t1 (id STRING PRIMARY KEY, other_id STRING NOT NULL);
+CREATE TABLE t2 (id STRING PRIMARY KEY);
+ALTER TABLE t1 ADD CONSTRAINT fk FOREIGN KEY (other_id) REFERENCES t2(id) NOT VALID;
+BEGIN;
+SET TRANSACTION PRIORITY HIGH;
+ALTER TABLE t2 RENAME TO t3;
+ALTER TABLE t1 VALIDATE CONSTRAINT fk;
+COMMIT;
+DROP TABLE t1, t3 CASCADE
+
+
+statement ok
+CREATE TABLE t1 (id STRING PRIMARY KEY, other_id STRING NOT NULL);
+CREATE TABLE t2 (id STRING PRIMARY KEY);
+ALTER TABLE t1 ADD CONSTRAINT fk FOREIGN KEY (other_id) REFERENCES t2(id) NOT VALID;
+BEGIN;
+SET TRANSACTION PRIORITY HIGH;
+ALTER TABLE t1 RENAME TO t3;
+ALTER TABLE t3 VALIDATE CONSTRAINT fk;
+COMMIT;
+DROP TABLE t2, t3 CASCADE
+
+statement ok
+BEGIN;
+SET TRANSACTION PRIORITY HIGH;
+CREATE TABLE t1 (id STRING PRIMARY KEY, other_id STRING NOT NULL);
+CREATE TABLE t2 (id STRING PRIMARY KEY);
+ALTER TABLE t1 ADD CONSTRAINT fk FOREIGN KEY (other_id) REFERENCES t2(id);
+ALTER TABLE t1 VALIDATE CONSTRAINT fk;
+COMMIT;
+DROP TABLE t1, t2 CASCADE


### PR DESCRIPTION
When validating a foreign key in a transaction and the referenced table has been modified in the same transaction, we'd fail to notice this fact and use the regular descriptor leasing protocol to fetch the descriptor. Due to implementation details of the leasing protocol, the behavior is that we'd use a high priority transaction to attempt to lease the descriptor, fail, and then fall back to resolving the correct value using the appropriate transaction. Thus, we did not suffer a correctness problem in the case where the table is newly created. Furthermore, we didn't really have a problem generally when the descriptor is not newly created but the constraint is, because we'd defer the validation to an async job. The hazard is that the transaction would be pushed into the future by the attempt to lease the descriptor, which can lead to restarts, or, worse, if the user transaction used PRIORITY HIGH, we'd end up with a deadlock.

Epic: none

Release justification: Fixes a bug

Release note (bug fix): Fixed a bug where spurious transaction restarts could occur when validating a FOREIGN KEY in the same transaction where the referenced table is modified. If the transaction was running at PRIORITY HIGH, deadlocks could occur.