### PR TITLE
sql: refactor FunctionProperties and Overload

### DIFF
--- a/pkg/ccl/changefeedccl/encoder_json.go
+++ b/pkg/ccl/changefeedccl/encoder_json.go
@@ -426,7 +426,8 @@ func init() {
 			}
 			return tree.NewDBytes(tree.DBytes(o)), nil
 		},
-		Info: "Strings can be of the form 'resolved' or 'resolved=1s'.",
+		Class: tree.NormalClass,
+		Info:  "Strings can be of the form 'resolved' or 'resolved=1s'.",
 		// Probably actually stable, but since this is tightly coupled to changefeed logic by design,
 		// best to be defensive.
 		Volatility: volatility.Volatile,

--- a/pkg/ccl/utilccl/builtins.go
+++ b/pkg/ccl/utilccl/builtins.go
@@ -16,7 +16,6 @@ import (
 // RegisterCCLBuiltin adds a builtin defined in CCL code to the global builtins registry.
 func RegisterCCLBuiltin(name string, description string, overload tree.Overload) {
 	props := tree.FunctionProperties{
-		Class:    tree.NormalClass,
 		Category: `CCL-only internal function`,
 	}
 

--- a/pkg/cmd/docgen/funcs.go
+++ b/pkg/cmd/docgen/funcs.go
@@ -191,7 +191,7 @@ func generateFunctions(from []string, categorize bool) []byte {
 			}
 			// We generate docs for both aggregates and window functions in separate
 			// files, so we want to omit them when processing all builtins.
-			if categorize && (props.Class == tree.AggregateClass || props.Class == tree.WindowClass) {
+			if categorize && (fn.Class == tree.AggregateClass || fn.Class == tree.WindowClass) {
 				continue
 			}
 			args := fn.Types.String()

--- a/pkg/internal/sqlsmith/scalar.go
+++ b/pkg/internal/sqlsmith/scalar.go
@@ -440,11 +440,11 @@ func makeFunc(s *Smither, ctx Context, typ *types.T, refs colRefs) (tree.TypedEx
 		args = append(args, castType(arg, argTyp))
 	}
 
-	if fn.def.Class == tree.WindowClass && s.disableWindowFuncs {
+	if fn.overload.Class == tree.WindowClass && s.disableWindowFuncs {
 		return nil, false
 	}
 
-	if fn.def.Class == tree.AggregateClass && s.disableAggregateFuncs {
+	if fn.overload.Class == tree.AggregateClass && s.disableAggregateFuncs {
 		return nil, false
 	}
 
@@ -452,7 +452,8 @@ func makeFunc(s *Smither, ctx Context, typ *types.T, refs colRefs) (tree.TypedEx
 	// Use a window function if:
 	// - we chose an aggregate function, then 1/6 chance, but not if we're in a HAVING (noWindow == true)
 	// - we explicitly chose a window function
-	if fn.def.Class == tree.WindowClass || (!s.disableWindowFuncs && !ctx.noWindow && s.d6() == 1 && fn.def.Class == tree.AggregateClass) {
+	if fn.overload.Class == tree.WindowClass ||
+		(!s.disableWindowFuncs && !ctx.noWindow && s.d6() == 1 && fn.overload.Class == tree.AggregateClass) {
 		var parts tree.Exprs
 		s.sample(len(refs), 2, func(i int) {
 			parts = append(parts, refs[i].item)

--- a/pkg/internal/sqlsmith/schema.go
+++ b/pkg/internal/sqlsmith/schema.go
@@ -519,9 +519,6 @@ var functions = func() map[tree.FunctionClass]map[oid.Oid][]function {
 		if skip {
 			continue
 		}
-		if _, ok := m[def.Class]; !ok {
-			m[def.Class] = map[oid.Oid][]function{}
-		}
 		// Ignore pg compat functions since many are unimplemented.
 		if def.Category == "Compatibility" {
 			continue
@@ -530,6 +527,9 @@ var functions = func() map[tree.FunctionClass]map[oid.Oid][]function {
 			continue
 		}
 		for _, ov := range def.Definition {
+			if m[ov.Class] == nil {
+				m[ov.Class] = map[oid.Oid][]function{}
+			}
 			// Ignore documented unusable functions.
 			if strings.Contains(ov.Info, "Not usable") {
 				continue
@@ -544,7 +544,7 @@ var functions = func() map[tree.FunctionClass]map[oid.Oid][]function {
 			if !found {
 				continue
 			}
-			m[def.Class][typ.Oid()] = append(m[def.Class][typ.Oid()], function{
+			m[ov.Class][typ.Oid()] = append(m[ov.Class][typ.Oid()], function{
 				def:      def,
 				overload: ov,
 			})

--- a/pkg/sql/opt/norm/fold_constants_funcs.go
+++ b/pkg/sql/opt/norm/fold_constants_funcs.go
@@ -621,7 +621,7 @@ func (c *CustomFuncs) FoldColumnAccess(
 // See FoldFunctionWithNullArg for more details.
 func (c *CustomFuncs) CanFoldFunctionWithNullArg(private *memo.FunctionPrivate) bool {
 	return !private.Overload.CalledOnNullInput &&
-		private.Properties.Class == tree.NormalClass
+		private.Overload.Class == tree.NormalClass
 }
 
 // HasNullArg returns true if one of args is Null.
@@ -647,7 +647,7 @@ func (c *CustomFuncs) FoldFunction(
 ) (_ opt.ScalarExpr, ok bool) {
 	// Non-normal function classes (aggregate, window, generator) cannot be
 	// folded into a single constant.
-	if private.Properties.Class != tree.NormalClass {
+	if private.Overload.Class != tree.NormalClass {
 		return nil, false
 	}
 

--- a/pkg/sql/pg_catalog.go
+++ b/pkg/sql/pg_catalog.go
@@ -2354,9 +2354,7 @@ https://www.postgresql.org/docs/9.6/view-pg-prepared-statements.html`,
 }
 
 func addPgProcBuiltinRow(name string, addRow func(...tree.Datum) error) error {
-	props, overloads := builtinsregistry.GetBuiltinProperties(name)
-	isAggregate := props.Class == tree.AggregateClass
-	isWindow := props.Class == tree.WindowClass
+	_, overloads := builtinsregistry.GetBuiltinProperties(name)
 	nspOid := tree.NewDOid(catconstants.PgCatalogID)
 	const crdbInternal = catconstants.CRDBInternalSchemaName + "."
 	if strings.HasPrefix(name, crdbInternal) {
@@ -2364,19 +2362,21 @@ func addPgProcBuiltinRow(name string, addRow func(...tree.Datum) error) error {
 		name = name[len(crdbInternal):]
 	}
 
-	var kind tree.Datum
-	switch {
-	case isAggregate:
-		kind = tree.NewDString("a")
-	case isWindow:
-		kind = tree.NewDString("w")
-	default:
-		kind = tree.NewDString("f")
-	}
-
 	for _, builtin := range overloads {
 		dName := tree.NewDName(name)
 		dSrc := tree.NewDString(name)
+
+		isAggregate := builtin.Class == tree.AggregateClass
+		isWindow := builtin.Class == tree.WindowClass
+		var kind tree.Datum
+		switch {
+		case isAggregate:
+			kind = tree.NewDString("a")
+		case isWindow:
+			kind = tree.NewDString("w")
+		default:
+			kind = tree.NewDString("f")
+		}
 
 		var retType tree.Datum
 		isRetSet := false

--- a/pkg/sql/rowexec/project_set.go
+++ b/pkg/sql/rowexec/project_set.go
@@ -120,7 +120,7 @@ func newProjectSetProcessor(
 		if err != nil {
 			return nil, err
 		}
-		if tFunc, ok := helper.Expr.(*tree.FuncExpr); ok && tFunc.IsGeneratorApplication() {
+		if tFunc, ok := helper.Expr.(*tree.FuncExpr); ok && tFunc.IsGeneratorClass() {
 			// Expr is a set-generating function.
 			ps.funcs[i] = tFunc
 			ps.mustBeStreaming = ps.mustBeStreaming || tFunc.IsVectorizeStreaming()

--- a/pkg/sql/sem/builtins/aggregate_builtins.go
+++ b/pkg/sql/sem/builtins/aggregate_builtins.go
@@ -40,12 +40,11 @@ import (
 func init() {
 	// Add all aggregates to the builtins map after a few sanity checks.
 	for k, v := range aggregates {
-
-		if v.props.Class != tree.AggregateClass {
-			panic(errors.AssertionFailedf("%s: aggregate functions should be marked with the tree.AggregateClass "+
-				"function class, found %v", k, v))
-		}
 		for _, a := range v.overloads {
+			if a.Class != tree.AggregateClass {
+				panic(errors.AssertionFailedf("%s: aggregate functions should be marked with the tree.AggregateClass "+
+					"function class, found %v", k, v))
+			}
 			if a.AggregateFunc == nil {
 				panic(errors.AssertionFailedf("%s: aggregate functions should have eval.AggregateFunc constructors, "+
 					"found %v", k, a))
@@ -58,10 +57,6 @@ func init() {
 
 		registerBuiltin(k, v)
 	}
-}
-
-func aggProps() tree.FunctionProperties {
-	return tree.FunctionProperties{Class: tree.AggregateClass}
 }
 
 // allMaxMinAggregateTypes contains extra types that aren't in
@@ -97,7 +92,7 @@ var allMaxMinAggregateTypes = append(
 // These functions are also identified with Class == tree.AggregateClass.
 // The properties are reachable via tree.FunctionDefinition.
 var aggregates = map[string]builtinDefinition{
-	"array_agg": setProps(aggProps(),
+	"array_agg": setProps(tree.FunctionProperties{},
 		arrayBuiltin(func(t *types.T) tree.Overload {
 			return makeAggOverloadWithReturnType(
 				[]*types.T{t},
@@ -117,7 +112,7 @@ var aggregates = map[string]builtinDefinition{
 		}),
 	),
 
-	"avg": makeBuiltin(aggProps(),
+	"avg": makeBuiltin(tree.FunctionProperties{},
 		makeImmutableAggOverload([]*types.T{types.Int}, types.Decimal, newIntAvgAggregate,
 			"Calculates the average of the selected values."),
 		makeImmutableAggOverload([]*types.T{types.Float}, types.Float, newFloatAvgAggregate,
@@ -128,31 +123,31 @@ var aggregates = map[string]builtinDefinition{
 			"Calculates the average of the selected values."),
 	),
 
-	"bit_and": makeBuiltin(aggProps(),
+	"bit_and": makeBuiltin(tree.FunctionProperties{},
 		makeImmutableAggOverload([]*types.T{types.Int}, types.Int, newIntBitAndAggregate,
 			"Calculates the bitwise AND of all non-null input values, or null if none."),
 		makeImmutableAggOverload([]*types.T{types.VarBit}, types.VarBit, newBitBitAndAggregate,
 			"Calculates the bitwise AND of all non-null input values, or null if none."),
 	),
 
-	"bit_or": makeBuiltin(aggProps(),
+	"bit_or": makeBuiltin(tree.FunctionProperties{},
 		makeImmutableAggOverload([]*types.T{types.Int}, types.Int, newIntBitOrAggregate,
 			"Calculates the bitwise OR of all non-null input values, or null if none."),
 		makeImmutableAggOverload([]*types.T{types.VarBit}, types.VarBit, newBitBitOrAggregate,
 			"Calculates the bitwise OR of all non-null input values, or null if none."),
 	),
 
-	"bool_and": makeBuiltin(aggProps(),
+	"bool_and": makeBuiltin(tree.FunctionProperties{},
 		makeImmutableAggOverload([]*types.T{types.Bool}, types.Bool, newBoolAndAggregate,
 			"Calculates the boolean value of `AND`ing all selected values."),
 	),
 
-	"bool_or": makeBuiltin(aggProps(),
+	"bool_or": makeBuiltin(tree.FunctionProperties{},
 		makeImmutableAggOverload([]*types.T{types.Bool}, types.Bool, newBoolOrAggregate,
 			"Calculates the boolean value of `OR`ing all selected values."),
 	),
 
-	"concat_agg": makeBuiltin(aggProps(),
+	"concat_agg": makeBuiltin(tree.FunctionProperties{},
 		makeImmutableAggOverload([]*types.T{types.String}, types.String, newStringConcatAggregate,
 			"Concatenates all selected values."),
 		makeImmutableAggOverload([]*types.T{types.Bytes}, types.Bytes, newBytesConcatAggregate,
@@ -171,63 +166,63 @@ var aggregates = map[string]builtinDefinition{
 		"Calculates the population covariance of the selected values.",
 	),
 
-	"final_covar_pop": makePrivate(makeBuiltin(aggProps(),
+	"final_covar_pop": makePrivate(makeBuiltin(tree.FunctionProperties{},
 		makeImmutableAggOverload([]*types.T{types.DecimalArray}, types.Float, newFinalCovarPopAggregate,
 			"Calculates the population covariance of the selected values in final stage."),
 	)),
 
-	"final_regr_sxx": makePrivate(makeBuiltin(aggProps(),
+	"final_regr_sxx": makePrivate(makeBuiltin(tree.FunctionProperties{},
 		makeImmutableAggOverload([]*types.T{types.DecimalArray}, types.Float, newFinalRegrSXXAggregate,
 			"Calculates sum of squares of the independent variable in final stage."),
 	)),
 
-	"final_regr_sxy": makePrivate(makeBuiltin(aggProps(),
+	"final_regr_sxy": makePrivate(makeBuiltin(tree.FunctionProperties{},
 		makeImmutableAggOverload([]*types.T{types.DecimalArray}, types.Float, newFinalRegrSXYAggregate,
 			"Calculates sum of products of independent times dependent variable in final stage."),
 	)),
 
-	"final_regr_syy": makePrivate(makeBuiltin(aggProps(),
+	"final_regr_syy": makePrivate(makeBuiltin(tree.FunctionProperties{},
 		makeImmutableAggOverload([]*types.T{types.DecimalArray}, types.Float, newFinalRegrSYYAggregate,
 			"Calculates sum of squares of the dependent variable in final stage."),
 	)),
 
-	"final_regr_avgx": makePrivate(makeBuiltin(aggProps(),
+	"final_regr_avgx": makePrivate(makeBuiltin(tree.FunctionProperties{},
 		makeImmutableAggOverload([]*types.T{types.DecimalArray}, types.Float, newFinalRegressionAvgXAggregate,
 			"Calculates the average of the independent variable (sum(X)/N) in final stage."),
 	)),
 
-	"final_regr_avgy": makePrivate(makeBuiltin(aggProps(),
+	"final_regr_avgy": makePrivate(makeBuiltin(tree.FunctionProperties{},
 		makeImmutableAggOverload([]*types.T{types.DecimalArray}, types.Float, newFinalRegressionAvgYAggregate,
 			"Calculates the average of the dependent variable (sum(Y)/N) in final stage."),
 	)),
 
-	"final_regr_intercept": makePrivate(makeBuiltin(aggProps(),
+	"final_regr_intercept": makePrivate(makeBuiltin(tree.FunctionProperties{},
 		makeImmutableAggOverload([]*types.T{types.DecimalArray}, types.Float, newFinalRegressionInterceptAggregate,
 			"Calculates y-intercept of the least-squares-fit linear equation determined by the (X, Y) pairs in final stage."),
 	)),
 
-	"final_regr_r2": makePrivate(makeBuiltin(aggProps(),
+	"final_regr_r2": makePrivate(makeBuiltin(tree.FunctionProperties{},
 		makeImmutableAggOverload([]*types.T{types.DecimalArray}, types.Float, newFinalRegressionR2Aggregate,
 			"Calculates square of the correlation coefficient in final stage."),
 	)),
 
-	"final_regr_slope": makePrivate(makeBuiltin(aggProps(),
+	"final_regr_slope": makePrivate(makeBuiltin(tree.FunctionProperties{},
 		makeImmutableAggOverload([]*types.T{types.DecimalArray}, types.Float, newFinalRegressionSlopeAggregate,
 			"Calculates slope of the least-squares-fit linear equation determined by the (X, Y) pairs in final stage."),
 	)),
 
-	"final_corr": makePrivate(makeBuiltin(aggProps(),
+	"final_corr": makePrivate(makeBuiltin(tree.FunctionProperties{},
 		makeImmutableAggOverload([]*types.T{types.DecimalArray}, types.Float, newFinalCorrAggregate,
 			"Calculates the correlation coefficient of the selected values in final stage."),
 	)),
 
-	"final_covar_samp": makePrivate(makeBuiltin(aggProps(),
+	"final_covar_samp": makePrivate(makeBuiltin(tree.FunctionProperties{},
 		makeImmutableAggOverload([]*types.T{types.DecimalArray}, types.Float, newFinalCovarSampAggregate,
 			"Calculates the sample covariance of the selected values in final stage."),
 	)),
 
 	// The input signature is: SQRDIFF, SUM, COUNT
-	"final_sqrdiff": makePrivate(makeBuiltin(aggProps(),
+	"final_sqrdiff": makePrivate(makeBuiltin(tree.FunctionProperties{},
 		makeImmutableAggOverload(
 			[]*types.T{types.Decimal, types.Decimal, types.Int},
 			types.Decimal,
@@ -281,7 +276,7 @@ var aggregates = map[string]builtinDefinition{
 		newRegressionSYYAggregate, "Calculates sum of squares of the dependent variable.",
 	),
 
-	"regr_count": makeBuiltin(aggProps(),
+	"regr_count": makeBuiltin(tree.FunctionProperties{},
 		makeImmutableAggOverload([]*types.T{types.Float, types.Float}, types.Int, newRegressionCountAggregate,
 			"Calculates number of input rows in which both expressions are nonnull."),
 		makeImmutableAggOverload([]*types.T{types.Int, types.Int}, types.Int, newRegressionCountAggregate,
@@ -302,12 +297,12 @@ var aggregates = map[string]builtinDefinition{
 			"Calculates number of input rows in which both expressions are nonnull."),
 	),
 
-	"count": makeBuiltin(aggProps(),
+	"count": makeBuiltin(tree.FunctionProperties{},
 		makeAggOverload([]*types.T{types.Any}, types.Int, newCountAggregate,
 			"Calculates the number of selected elements.", volatility.Immutable, true /* calledOnNullInput */),
 	),
 
-	"count_rows": makeBuiltin(aggProps(),
+	"count_rows": makeBuiltin(tree.FunctionProperties{},
 		tree.Overload{
 			Types:         tree.ParamTypes{},
 			ReturnType:    tree.FixedReturnType(types.Int),
@@ -320,17 +315,18 @@ var aggregates = map[string]builtinDefinition{
 					},
 				)
 			}),
+			Class:      tree.AggregateClass,
 			Info:       "Calculates the number of rows.",
 			Volatility: volatility.Immutable,
 		},
 	),
 
-	"every": makeBuiltin(aggProps(),
+	"every": makeBuiltin(tree.FunctionProperties{},
 		makeImmutableAggOverload([]*types.T{types.Bool}, types.Bool, newBoolAndAggregate,
 			"Calculates the boolean value of `AND`ing all selected values."),
 	),
 
-	"max": collectOverloads(aggProps(), allMaxMinAggregateTypes,
+	"max": collectOverloads(tree.FunctionProperties{}, allMaxMinAggregateTypes,
 		func(t *types.T) tree.Overload {
 			info := "Identifies the maximum selected value."
 			return makeImmutableAggOverloadWithReturnType(
@@ -338,7 +334,7 @@ var aggregates = map[string]builtinDefinition{
 			)
 		}),
 
-	"min": collectOverloads(aggProps(), allMaxMinAggregateTypes,
+	"min": collectOverloads(tree.FunctionProperties{}, allMaxMinAggregateTypes,
 		func(t *types.T) tree.Overload {
 			info := "Identifies the minimum selected value."
 			return makeImmutableAggOverloadWithReturnType(
@@ -346,19 +342,19 @@ var aggregates = map[string]builtinDefinition{
 			)
 		}),
 
-	"string_agg": makeBuiltin(aggProps(),
+	"string_agg": makeBuiltin(tree.FunctionProperties{},
 		makeAggOverload([]*types.T{types.String, types.String}, types.String, newStringConcatAggregate,
 			"Concatenates all selected values using the provided delimiter.", volatility.Immutable, true /* calledOnNullInput */),
 		makeAggOverload([]*types.T{types.Bytes, types.Bytes}, types.Bytes, newBytesConcatAggregate,
 			"Concatenates all selected values using the provided delimiter.", volatility.Immutable, true /* calledOnNullInput */),
 	),
 
-	"sum_int": makeBuiltin(aggProps(),
+	"sum_int": makeBuiltin(tree.FunctionProperties{},
 		makeImmutableAggOverload([]*types.T{types.Int}, types.Int, newSmallIntSumAggregate,
 			"Calculates the sum of the selected values."),
 	),
 
-	"sum": makeBuiltin(aggProps(),
+	"sum": makeBuiltin(tree.FunctionProperties{},
 		makeImmutableAggOverload([]*types.T{types.Int}, types.Decimal, newIntSumAggregate,
 			"Calculates the sum of the selected values."),
 		makeImmutableAggOverload([]*types.T{types.Float}, types.Float, newFloatSumAggregate,
@@ -369,7 +365,7 @@ var aggregates = map[string]builtinDefinition{
 			"Calculates the sum of the selected values."),
 	),
 
-	"sqrdiff": makeBuiltin(aggProps(),
+	"sqrdiff": makeBuiltin(tree.FunctionProperties{},
 		makeImmutableAggOverload([]*types.T{types.Int}, types.Decimal, newIntSqrDiffAggregate,
 			"Calculates the sum of squared differences from the mean of the selected values."),
 		makeImmutableAggOverload([]*types.T{types.Decimal}, types.Decimal, newDecimalSqrDiffAggregate,
@@ -389,7 +385,7 @@ var aggregates = map[string]builtinDefinition{
 	// #10495.
 
 	// The input signature is: SQDIFF, SUM, COUNT
-	"final_variance": makePrivate(makeBuiltin(aggProps(),
+	"final_variance": makePrivate(makeBuiltin(tree.FunctionProperties{},
 		makeImmutableAggOverload(
 			[]*types.T{types.Decimal, types.Decimal, types.Int},
 			types.Decimal,
@@ -404,7 +400,7 @@ var aggregates = map[string]builtinDefinition{
 		),
 	)),
 
-	"final_var_pop": makePrivate(makeBuiltin(aggProps(),
+	"final_var_pop": makePrivate(makeBuiltin(tree.FunctionProperties{},
 		makeImmutableAggOverload(
 			[]*types.T{types.Decimal, types.Decimal, types.Int},
 			types.Decimal,
@@ -419,7 +415,7 @@ var aggregates = map[string]builtinDefinition{
 		),
 	)),
 
-	"final_stddev": makePrivate(makeBuiltin(aggProps(),
+	"final_stddev": makePrivate(makeBuiltin(tree.FunctionProperties{},
 		makeImmutableAggOverload(
 			[]*types.T{types.Decimal, types.Decimal, types.Int},
 			types.Decimal,
@@ -434,7 +430,7 @@ var aggregates = map[string]builtinDefinition{
 		),
 	)),
 
-	"final_stddev_pop": makePrivate(makeBuiltin(aggProps(),
+	"final_stddev_pop": makePrivate(makeBuiltin(tree.FunctionProperties{},
 		makeImmutableAggOverload(
 			[]*types.T{types.Decimal, types.Decimal, types.Int},
 			types.Decimal,
@@ -452,7 +448,7 @@ var aggregates = map[string]builtinDefinition{
 	// variance is a historical alias for var_samp.
 	"variance": makeVarianceBuiltin(),
 	"var_samp": makeVarianceBuiltin(),
-	"var_pop": makeBuiltin(aggProps(),
+	"var_pop": makeBuiltin(tree.FunctionProperties{},
 		makeImmutableAggOverload([]*types.T{types.Int}, types.Decimal, newIntVarPopAggregate,
 			"Calculates the population variance of the selected values."),
 		makeImmutableAggOverload([]*types.T{types.Decimal}, types.Decimal, newDecimalVarPopAggregate,
@@ -464,7 +460,7 @@ var aggregates = map[string]builtinDefinition{
 	// stddev is a historical alias for stddev_samp.
 	"stddev":      makeStdDevBuiltin(),
 	"stddev_samp": makeStdDevBuiltin(),
-	"stddev_pop": makeBuiltin(aggProps(),
+	"stddev_pop": makeBuiltin(tree.FunctionProperties{},
 		makeImmutableAggOverload([]*types.T{types.Int}, types.Decimal, newIntStdDevPopAggregate,
 			"Calculates the population standard deviation of the selected values."),
 		makeImmutableAggOverload([]*types.T{types.Decimal}, types.Decimal, newDecimalStdDevPopAggregate,
@@ -473,35 +469,34 @@ var aggregates = map[string]builtinDefinition{
 			"Calculates the population standard deviation of the selected values."),
 	),
 
-	"xor_agg": makeBuiltin(aggProps(),
+	"xor_agg": makeBuiltin(tree.FunctionProperties{},
 		makeImmutableAggOverload([]*types.T{types.Bytes}, types.Bytes, newBytesXorAggregate,
 			"Calculates the bitwise XOR of the selected values."),
 		makeImmutableAggOverload([]*types.T{types.Int}, types.Int, newIntXorAggregate,
 			"Calculates the bitwise XOR of the selected values."),
 	),
 
-	"json_agg": makeBuiltin(aggProps(),
+	"json_agg": makeBuiltin(tree.FunctionProperties{},
 		makeAggOverload([]*types.T{types.Any}, types.Jsonb, newJSONAggregate,
 			"Aggregates values as a JSON or JSONB array.", volatility.Stable, true /* calledOnNullInput */),
 	),
 
-	"jsonb_agg": makeBuiltin(aggProps(),
+	"jsonb_agg": makeBuiltin(tree.FunctionProperties{},
 		makeAggOverload([]*types.T{types.Any}, types.Jsonb, newJSONAggregate,
 			"Aggregates values as a JSON or JSONB array.", volatility.Stable, true /* calledOnNullInput */),
 	),
 
-	"json_object_agg": makeBuiltin(aggProps(),
+	"json_object_agg": makeBuiltin(tree.FunctionProperties{},
 		makeAggOverload([]*types.T{types.String, types.Any}, types.Jsonb, newJSONObjectAggregate,
 			"Aggregates values as a JSON or JSONB object.", volatility.Stable, true /* calledOnNullInput */),
 	),
-	"jsonb_object_agg": makeBuiltin(aggProps(),
+	"jsonb_object_agg": makeBuiltin(tree.FunctionProperties{},
 		makeAggOverload([]*types.T{types.String, types.Any}, types.Jsonb, newJSONObjectAggregate,
 			"Aggregates values as a JSON or JSONB object.", volatility.Stable, true /* calledOnNullInput */),
 	),
 
 	"st_makeline": makeBuiltin(
 		tree.FunctionProperties{
-			Class:                   tree.AggregateClass,
 			AvailableOnPublicSchema: true,
 		},
 		makeAggOverload(
@@ -523,7 +518,6 @@ var aggregates = map[string]builtinDefinition{
 	),
 	"st_extent": makeBuiltin(
 		tree.FunctionProperties{
-			Class:                   tree.AggregateClass,
 			AvailableOnPublicSchema: true,
 		},
 		makeAggOverload(
@@ -546,7 +540,7 @@ var aggregates = map[string]builtinDefinition{
 	"st_collect":    makeSTCollectBuiltin(),
 	"st_memcollect": makeSTCollectBuiltin(),
 
-	AnyNotNull: makePrivate(makeBuiltin(aggProps(),
+	AnyNotNull: makePrivate(makeBuiltin(tree.FunctionProperties{},
 		makeImmutableAggOverloadWithReturnType(
 			[]*types.T{types.Any},
 			tree.IdentityReturnType(0),
@@ -555,7 +549,7 @@ var aggregates = map[string]builtinDefinition{
 		))),
 
 	// Ordered-set aggregations.
-	"percentile_disc": makeBuiltin(aggProps(),
+	"percentile_disc": makeBuiltin(tree.FunctionProperties{},
 		makeImmutableAggOverloadWithReturnType(
 			[]*types.T{types.Float},
 			func(args []tree.TypedExpr) *types.T { return tree.UnknownReturnType },
@@ -571,7 +565,7 @@ var aggregates = map[string]builtinDefinition{
 				"exceeds the specified fractions.",
 		),
 	),
-	"percentile_disc_impl": makePrivate(collectOverloads(aggProps(), types.Scalar,
+	"percentile_disc_impl": makePrivate(collectOverloads(tree.FunctionProperties{}, types.Scalar,
 		func(t *types.T) tree.Overload {
 			return makeImmutableAggOverload([]*types.T{types.Float, t}, t, newPercentileDiscAggregate,
 				"Implementation of percentile_disc.",
@@ -583,7 +577,7 @@ var aggregates = map[string]builtinDefinition{
 			)
 		},
 	)),
-	"percentile_cont": makeBuiltin(aggProps(),
+	"percentile_cont": makeBuiltin(tree.FunctionProperties{},
 		makeImmutableAggOverload(
 			[]*types.T{types.Float},
 			types.Float,
@@ -613,7 +607,7 @@ var aggregates = map[string]builtinDefinition{
 				"interpolating between adjacent input intervals if needed.",
 		),
 	),
-	"percentile_cont_impl": makePrivate(makeBuiltin(aggProps(),
+	"percentile_cont_impl": makePrivate(makeBuiltin(tree.FunctionProperties{},
 		makeImmutableAggOverload(
 			[]*types.T{types.Float, types.Float},
 			types.Float,
@@ -736,6 +730,7 @@ func makeAggOverloadWithReturnType(
 				},
 			)
 		}),
+		Class:             tree.AggregateClass,
 		Info:              info,
 		Volatility:        volatility,
 		CalledOnNullInput: calledOnNullInput,
@@ -743,7 +738,7 @@ func makeAggOverloadWithReturnType(
 }
 
 func makeStdDevBuiltin() builtinDefinition {
-	return makeBuiltin(aggProps(),
+	return makeBuiltin(tree.FunctionProperties{},
 		makeImmutableAggOverload([]*types.T{types.Int}, types.Decimal, newIntStdDevAggregate,
 			"Calculates the standard deviation of the selected values."),
 		makeImmutableAggOverload([]*types.T{types.Decimal}, types.Decimal, newDecimalStdDevAggregate,
@@ -756,7 +751,6 @@ func makeStdDevBuiltin() builtinDefinition {
 func makeSTCollectBuiltin() builtinDefinition {
 	return makeBuiltin(
 		tree.FunctionProperties{
-			Class:                   tree.AggregateClass,
 			AvailableOnPublicSchema: true,
 		},
 		makeAggOverload(
@@ -775,7 +769,6 @@ func makeSTCollectBuiltin() builtinDefinition {
 func makeSTUnionBuiltin() builtinDefinition {
 	return makeBuiltin(
 		tree.FunctionProperties{
-			Class:                   tree.AggregateClass,
 			AvailableOnPublicSchema: true,
 		},
 		makeAggOverload(
@@ -816,7 +809,7 @@ func makeRegressionAggregate(
 	info string,
 	ret *types.T,
 ) builtinDefinition {
-	return makeBuiltin(aggProps(),
+	return makeBuiltin(tree.FunctionProperties{},
 		makeImmutableAggOverload([]*types.T{types.Float, types.Float}, ret, aggregateFunc, info),
 		makeImmutableAggOverload([]*types.T{types.Int, types.Int}, ret, aggregateFunc, info),
 		makeImmutableAggOverload([]*types.T{types.Decimal, types.Decimal}, ret, aggregateFunc, info),
@@ -1148,7 +1141,7 @@ func (agg *stExtentAgg) Size() int64 {
 }
 
 func makeVarianceBuiltin() builtinDefinition {
-	return makeBuiltin(aggProps(),
+	return makeBuiltin(tree.FunctionProperties{},
 		makeImmutableAggOverload([]*types.T{types.Int}, types.Decimal, newIntVarianceAggregate,
 			"Calculates the variance of the selected values."),
 		makeImmutableAggOverload([]*types.T{types.Decimal}, types.Decimal, newDecimalVarianceAggregate,

--- a/pkg/sql/sem/builtins/generator_builtins.go
+++ b/pkg/sql/sem/builtins/generator_builtins.go
@@ -55,9 +55,11 @@ var _ eval.ValueGenerator = &arrayValueGenerator{}
 func init() {
 	// Add all windows to the builtins map after a few sanity checks.
 	for k, v := range generators {
-		if v.props.Class != tree.GeneratorClass {
-			panic(errors.AssertionFailedf("generator functions should be marked with the tree.GeneratorClass "+
-				"function class, found %v", v))
+		for _, g := range v.overloads {
+			if g.Class != tree.GeneratorClass {
+				panic(errors.AssertionFailedf("generator functions should be marked with the tree.GeneratorClass "+
+					"function class, found %v", v))
+			}
 		}
 		registerBuiltin(k, v)
 	}
@@ -65,14 +67,12 @@ func init() {
 
 func genProps() tree.FunctionProperties {
 	return tree.FunctionProperties{
-		Class:    tree.GeneratorClass,
 		Category: builtinconstants.CategoryGenerator,
 	}
 }
 
 func jsonGenPropsWithLabels(returnLabels []string) tree.FunctionProperties {
 	return tree.FunctionProperties{
-		Class:        tree.GeneratorClass,
 		Category:     builtinconstants.CategoryJSON,
 		ReturnLabels: returnLabels,
 	}
@@ -80,7 +80,6 @@ func jsonGenPropsWithLabels(returnLabels []string) tree.FunctionProperties {
 
 func recordGenProps() tree.FunctionProperties {
 	return tree.FunctionProperties{
-		Class:             tree.GeneratorClass,
 		Category:          builtinconstants.CategoryGenerator,
 		ReturnsRecordType: true,
 	}
@@ -399,7 +398,6 @@ var generators = map[string]builtinDefinition{
 
 	"crdb_internal.check_consistency": makeBuiltin(
 		tree.FunctionProperties{
-			Class:            tree.GeneratorClass,
 			Category:         builtinconstants.CategorySystemInfo,
 			DistsqlBlocklist: true, // see #88222
 		},
@@ -425,7 +423,6 @@ var generators = map[string]builtinDefinition{
 
 	"crdb_internal.list_sql_keys_in_range": makeBuiltin(
 		tree.FunctionProperties{
-			Class:    tree.GeneratorClass,
 			Category: builtinconstants.CategorySystemInfo,
 		},
 		makeGeneratorOverload(
@@ -441,7 +438,6 @@ var generators = map[string]builtinDefinition{
 
 	"crdb_internal.payloads_for_span": makeBuiltin(
 		tree.FunctionProperties{
-			Class:    tree.GeneratorClass,
 			Category: builtinconstants.CategorySystemInfo,
 		},
 		makeGeneratorOverload(
@@ -456,7 +452,6 @@ var generators = map[string]builtinDefinition{
 	),
 	"crdb_internal.payloads_for_trace": makeBuiltin(
 		tree.FunctionProperties{
-			Class:    tree.GeneratorClass,
 			Category: builtinconstants.CategorySystemInfo,
 		},
 		makeGeneratorOverload(
@@ -470,9 +465,7 @@ var generators = map[string]builtinDefinition{
 		),
 	),
 	"crdb_internal.show_create_all_schemas": makeBuiltin(
-		tree.FunctionProperties{
-			Class: tree.GeneratorClass,
-		},
+		tree.FunctionProperties{},
 		makeGeneratorOverload(
 			tree.ParamTypes{
 				{Name: "database_name", Typ: types.String},
@@ -486,9 +479,7 @@ The output can be used to recreate a database.'
 		),
 	),
 	"crdb_internal.show_create_all_tables": makeBuiltin(
-		tree.FunctionProperties{
-			Class: tree.GeneratorClass,
-		},
+		tree.FunctionProperties{},
 		makeGeneratorOverload(
 			tree.ParamTypes{
 				{Name: "database_name", Typ: types.String},
@@ -507,9 +498,7 @@ The output can be used to recreate a database.'
 		),
 	),
 	"crdb_internal.show_create_all_types": makeBuiltin(
-		tree.FunctionProperties{
-			Class: tree.GeneratorClass,
-		},
+		tree.FunctionProperties{},
 		makeGeneratorOverload(
 			tree.ParamTypes{
 				{Name: "database_name", Typ: types.String},
@@ -523,9 +512,7 @@ The output can be used to recreate a database.'
 		),
 	),
 	"crdb_internal.decode_plan_gist": makeBuiltin(
-		tree.FunctionProperties{
-			Class: tree.GeneratorClass,
-		},
+		tree.FunctionProperties{},
 		makeGeneratorOverload(
 			tree.ParamTypes{
 				{Name: "gist", Typ: types.String},
@@ -538,9 +525,7 @@ The output can be used to recreate a database.'
 		),
 	),
 	"crdb_internal.decode_external_plan_gist": makeBuiltin(
-		tree.FunctionProperties{
-			Class: tree.GeneratorClass,
-		},
+		tree.FunctionProperties{},
 		makeGeneratorOverload(
 			tree.ParamTypes{
 				{Name: "gist", Typ: types.String},
@@ -553,9 +538,7 @@ The output can be used to recreate a database.'
 		),
 	),
 	"crdb_internal.gen_rand_ident": makeBuiltin(
-		tree.FunctionProperties{
-			Class: tree.GeneratorClass,
-		},
+		tree.FunctionProperties{},
 		makeGeneratorOverload(
 			tree.ParamTypes{
 				{Name: "name_pattern", Typ: types.String},
@@ -673,6 +656,7 @@ func makeGeneratorOverloadWithReturnType(
 		Types:      in,
 		ReturnType: retType,
 		Generator:  g,
+		Class:      tree.GeneratorClass,
 		Info:       info,
 		Volatility: volatility,
 	}
@@ -1579,7 +1563,6 @@ func (g *jsonEachGenerator) Values() (tree.Datums, error) {
 }
 
 var jsonPopulateProps = tree.FunctionProperties{
-	Class:    tree.GeneratorClass,
 	Category: builtinconstants.CategoryJSON,
 }
 
@@ -1603,6 +1586,7 @@ func makeJSONPopulateImpl(gen eval.GeneratorWithExprsOverload, info string) tree
 		Types:              tree.ParamTypes{{Name: "base", Typ: types.Any}, {Name: "from_json", Typ: types.Jsonb}},
 		ReturnType:         tree.IdentityReturnType(0),
 		GeneratorWithExprs: gen,
+		Class:              tree.GeneratorClass,
 		Info:               info,
 		Volatility:         volatility.Stable,
 		// The typical way to call json_populate_record is to send NULL::atype

--- a/pkg/sql/sem/builtins/generator_probe_ranges.go
+++ b/pkg/sql/sem/builtins/generator_probe_ranges.go
@@ -37,9 +37,11 @@ import (
 func init() {
 	// Add all windows to the Builtins map after a few sanity checks.
 	for k, v := range probeRangesGenerators {
-		if v.props.Class != tree.GeneratorClass {
-			panic(errors.AssertionFailedf("generator functions should be marked with the tree.GeneratorClass "+
-				"function class, found %v", v))
+		for _, g := range v.overloads {
+			if g.Class != tree.GeneratorClass {
+				panic(errors.AssertionFailedf("generator functions should be marked with the tree.GeneratorClass "+
+					"function class, found %v", v))
+			}
 		}
 		registerBuiltin(k, v)
 	}
@@ -49,7 +51,6 @@ var probeRangesGenerators = map[string]builtinDefinition{
 	"crdb_internal.probe_ranges": makeBuiltin(
 		tree.FunctionProperties{
 			Category:     builtinconstants.CategorySystemInfo,
-			Class:        tree.GeneratorClass,
 			Undocumented: true,
 		},
 		makeGeneratorOverload(

--- a/pkg/sql/sem/builtins/geo_builtins.go
+++ b/pkg/sql/sem/builtins/geo_builtins.go
@@ -6262,7 +6262,6 @@ The parent_only boolean is always ignored.`,
 
 	"addgeometrycolumn": makeBuiltin(
 		tree.FunctionProperties{
-			Class:    tree.SQLClass,
 			Category: builtinconstants.CategorySpatial,
 		},
 		tree.Overload{
@@ -6301,6 +6300,7 @@ The parent_only boolean is always ignored.`,
 					bool(tree.MustBeDBool(args[5])),
 				)
 			},
+			Class: tree.SQLClass,
 			Info: infoBuilder{
 				info: `Adds a new geometry column to an existing table and returns metadata about the column created.`,
 			}.String(),
@@ -6343,6 +6343,7 @@ The parent_only boolean is always ignored.`,
 					bool(tree.MustBeDBool(args[6])),
 				)
 			},
+			Class: tree.SQLClass,
 			Info: infoBuilder{
 				info: `Adds a new geometry column to an existing table and returns metadata about the column created.`,
 			}.String(),
@@ -6386,6 +6387,7 @@ The parent_only boolean is always ignored.`,
 					bool(tree.MustBeDBool(args[7])),
 				)
 			},
+			Class: tree.SQLClass,
 			Info: infoBuilder{
 				info: `Adds a new geometry column to an existing table and returns metadata about the column created.`,
 			}.String(),
@@ -6426,6 +6428,7 @@ The parent_only boolean is always ignored.`,
 					true, /* useTypmod */
 				)
 			},
+			Class: tree.SQLClass,
 			Info: infoBuilder{
 				info: `Adds a new geometry column to an existing table and returns metadata about the column created.`,
 			}.String(),
@@ -6467,6 +6470,7 @@ The parent_only boolean is always ignored.`,
 					true, /* useTypmod */
 				)
 			},
+			Class: tree.SQLClass,
 			Info: infoBuilder{
 				info: `Adds a new geometry column to an existing table and returns metadata about the column created.`,
 			}.String(),
@@ -6509,6 +6513,7 @@ The parent_only boolean is always ignored.`,
 					true, /* useTypmod */
 				)
 			},
+			Class: tree.SQLClass,
 			Info: infoBuilder{
 				info: `Adds a new geometry column to an existing table and returns metadata about the column created.`,
 			}.String(),
@@ -6644,6 +6649,7 @@ The parent_only boolean is always ignored.`,
 			Types:      tree.ParamTypes{{Name: "geometry", Typ: types.Geometry}},
 			ReturnType: tree.FixedReturnType(minimumBoundingRadiusReturnType),
 			Generator:  eval.GeneratorOverload(makeMinimumBoundGenerator),
+			Class:      tree.GeneratorClass,
 			Info:       "Returns a record containing the center point and radius of the smallest circle that can fully contains the given geometry.",
 			Volatility: volatility.Immutable,
 		}),

--- a/pkg/sql/sem/builtins/replication_builtins.go
+++ b/pkg/sql/sem/builtins/replication_builtins.go
@@ -195,7 +195,6 @@ var replicationBuiltins = map[string]builtinDefinition{
 		tree.FunctionProperties{
 			Category:           builtinconstants.CategoryStreamIngestion,
 			DistsqlBlocklist:   false,
-			Class:              tree.GeneratorClass,
 			VectorizeStreaming: true,
 		},
 		makeGeneratorOverload(

--- a/pkg/sql/sem/builtins/window_builtins.go
+++ b/pkg/sql/sem/builtins/window_builtins.go
@@ -25,11 +25,11 @@ import (
 func init() {
 	// Add all windows to the builtins map after a few sanity checks.
 	for k, v := range windows {
-		if v.props.Class != tree.WindowClass {
-			panic(errors.AssertionFailedf("%s: window functions should be marked with the tree.WindowClass "+
-				"function class, found %v", k, v))
-		}
 		for _, w := range v.overloads {
+			if w.Class != tree.WindowClass {
+				panic(errors.AssertionFailedf("%s: window functions should be marked with the tree.WindowClass "+
+					"function class, found %v", k, v))
+			}
 			if w.WindowFunc == nil {
 				panic(errors.AssertionFailedf("%s: window functions should have eval.WindowFunc constructors, "+
 					"found %v", k, w))
@@ -39,17 +39,11 @@ func init() {
 	}
 }
 
-func winProps() tree.FunctionProperties {
-	return tree.FunctionProperties{
-		Class: tree.WindowClass,
-	}
-}
-
 // windows are a special class of builtin functions that can only be applied
 // as window functions using an OVER clause.
 // See `windowFuncHolder` in the sql package.
 var windows = map[string]builtinDefinition{
-	"row_number": makeBuiltin(winProps(),
+	"row_number": makeBuiltin(tree.FunctionProperties{},
 		makeWindowOverload(
 			tree.ParamTypes{},
 			types.Int,
@@ -58,7 +52,7 @@ var windows = map[string]builtinDefinition{
 			volatility.Immutable,
 		),
 	),
-	"rank": makeBuiltin(winProps(),
+	"rank": makeBuiltin(tree.FunctionProperties{},
 		makeWindowOverload(
 			tree.ParamTypes{},
 			types.Int,
@@ -67,7 +61,7 @@ var windows = map[string]builtinDefinition{
 			volatility.Immutable,
 		),
 	),
-	"dense_rank": makeBuiltin(winProps(),
+	"dense_rank": makeBuiltin(tree.FunctionProperties{},
 		makeWindowOverload(
 			tree.ParamTypes{},
 			types.Int,
@@ -76,7 +70,7 @@ var windows = map[string]builtinDefinition{
 			volatility.Immutable,
 		),
 	),
-	"percent_rank": makeBuiltin(winProps(),
+	"percent_rank": makeBuiltin(tree.FunctionProperties{},
 		makeWindowOverload(
 			tree.ParamTypes{},
 			types.Float,
@@ -85,7 +79,7 @@ var windows = map[string]builtinDefinition{
 			volatility.Immutable,
 		),
 	),
-	"cume_dist": makeBuiltin(winProps(),
+	"cume_dist": makeBuiltin(tree.FunctionProperties{},
 		makeWindowOverload(
 			tree.ParamTypes{},
 			types.Float,
@@ -95,7 +89,7 @@ var windows = map[string]builtinDefinition{
 			volatility.Immutable,
 		),
 	),
-	"ntile": makeBuiltin(winProps(),
+	"ntile": makeBuiltin(tree.FunctionProperties{},
 		makeWindowOverload(
 			tree.ParamTypes{{Name: "n", Typ: types.Int}},
 			types.Int,
@@ -105,7 +99,7 @@ var windows = map[string]builtinDefinition{
 		),
 	),
 	"lag": collectOverloads(
-		winProps(),
+		tree.FunctionProperties{},
 		types.Scalar,
 		func(t *types.T) tree.Overload {
 			return makeWindowOverload(
@@ -143,7 +137,7 @@ var windows = map[string]builtinDefinition{
 			)
 		},
 	),
-	"lead": collectOverloads(winProps(), types.Scalar,
+	"lead": collectOverloads(tree.FunctionProperties{}, types.Scalar,
 		func(t *types.T) tree.Overload {
 			return makeWindowOverload(
 				tree.ParamTypes{{Name: "val", Typ: t}},
@@ -179,7 +173,7 @@ var windows = map[string]builtinDefinition{
 		},
 	),
 	"first_value": collectOverloads(
-		winProps(),
+		tree.FunctionProperties{},
 		types.Scalar,
 		func(t *types.T) tree.Overload {
 			return makeWindowOverload(
@@ -191,7 +185,7 @@ var windows = map[string]builtinDefinition{
 			)
 		}),
 	"last_value": collectOverloads(
-		winProps(),
+		tree.FunctionProperties{},
 		types.Scalar,
 		func(t *types.T) tree.Overload {
 			return makeWindowOverload(
@@ -202,7 +196,7 @@ var windows = map[string]builtinDefinition{
 				volatility.Immutable,
 			)
 		}),
-	"nth_value": collectOverloads(winProps(), types.Scalar,
+	"nth_value": collectOverloads(tree.FunctionProperties{}, types.Scalar,
 		func(t *types.T) tree.Overload {
 			return makeWindowOverload(
 				tree.ParamTypes{
@@ -224,6 +218,7 @@ func makeWindowOverload(
 		Types:      in,
 		ReturnType: tree.FixedReturnType(ret),
 		WindowFunc: f,
+		Class:      tree.WindowClass,
 		Info:       info,
 		Volatility: volatility,
 	}

--- a/pkg/sql/sem/tree/constant_eval.go
+++ b/pkg/sql/sem/tree/constant_eval.go
@@ -22,7 +22,7 @@ import (
 func OperatorIsImmutable(expr Expr) bool {
 	switch t := expr.(type) {
 	case *FuncExpr:
-		return t.fnProps.Class == NormalClass && t.fn.Volatility <= volatility.Immutable
+		return t.ResolvedOverload().Class == NormalClass && t.fn.Volatility <= volatility.Immutable
 
 	case *CastExpr:
 		v, ok := cast.LookupCastVolatility(t.Expr.(TypedExpr).ResolvedType(), t.typ)

--- a/pkg/sql/sem/tree/expr.go
+++ b/pkg/sql/sem/tree/expr.go
@@ -1296,7 +1296,7 @@ func (node *FuncExpr) ResolvedOverload() *Overload {
 // IsGeneratorClass returns true if the resolved overload metadata is of
 // the GeneratorClass.
 func (node *FuncExpr) IsGeneratorClass() bool {
-	return node.fnProps != nil && node.fnProps.Class == GeneratorClass
+	return node.ResolvedOverload() != nil && node.ResolvedOverload().Class == GeneratorClass
 }
 
 // IsWindowFunctionApplication returns true iff the function is being applied as a window function.

--- a/pkg/sql/sem/tree/expr.go
+++ b/pkg/sql/sem/tree/expr.go
@@ -1295,15 +1295,8 @@ func (node *FuncExpr) ResolvedOverload() *Overload {
 
 // IsGeneratorClass returns true if the resolved overload metadata is of
 // the GeneratorClass.
-//
-// TODO(ajwerner): Figure out how this differs from IsGeneratorApplication.
 func (node *FuncExpr) IsGeneratorClass() bool {
 	return node.fnProps != nil && node.fnProps.Class == GeneratorClass
-}
-
-// IsGeneratorApplication returns true iff the function applied is a generator (SRF).
-func (node *FuncExpr) IsGeneratorApplication() bool {
-	return node.fn != nil && (node.fn.Generator != nil || node.fn.GeneratorWithExprs != nil)
 }
 
 // IsWindowFunctionApplication returns true iff the function is being applied as a window function.

--- a/pkg/sql/sem/tree/function_definition.go
+++ b/pkg/sql/sem/tree/function_definition.go
@@ -100,9 +100,6 @@ type FunctionProperties struct {
 	// get rid of this blocklist.
 	DistsqlBlocklist bool
 
-	// Class is the kind of built-in function (normal/aggregate/window/etc.)
-	Class FunctionClass
-
 	// Category is used to generate documentation strings.
 	Category string
 
@@ -157,35 +154,6 @@ type FunctionProperties struct {
 func (fp *FunctionProperties) ShouldDocument() bool {
 	return !(fp.Undocumented || fp.Private)
 }
-
-// FunctionClass specifies the class of the builtin function.
-type FunctionClass int
-
-const (
-	// NormalClass is a standard builtin function.
-	NormalClass FunctionClass = iota
-	// AggregateClass is a builtin aggregate function.
-	AggregateClass
-	// WindowClass is a builtin window function.
-	WindowClass
-	// GeneratorClass is a builtin generator function.
-	GeneratorClass
-	// SQLClass is a builtin function that executes a SQL statement as a side
-	// effect of the function call.
-	//
-	// For example, AddGeometryColumn is a SQLClass function that executes an
-	// ALTER TABLE ... ADD COLUMN statement to add a geometry column to an
-	// existing table. It returns metadata about the column added.
-	//
-	// All builtin functions of this class should include a definition for
-	// Overload.SQLFn, which returns the SQL statement to be executed. They
-	// should also include a definition for Overload.Fn, which is executed
-	// like a NormalClass function and returns a Datum.
-	SQLClass
-)
-
-// Avoid vet warning about unused enum value.
-var _ = NormalClass
 
 // NewFunctionDefinition allocates a function definition corresponding
 // to the given built-in definition.

--- a/pkg/sql/sem/tree/overload.go
+++ b/pkg/sql/sem/tree/overload.go
@@ -86,6 +86,32 @@ type SQLFnOverload interface {
 	SQLFn()
 }
 
+// FunctionClass specifies the class of the builtin function.
+type FunctionClass int
+
+const (
+	// NormalClass is a standard builtin function.
+	NormalClass FunctionClass = iota
+	// AggregateClass is a builtin aggregate function.
+	AggregateClass
+	// WindowClass is a builtin window function.
+	WindowClass
+	// GeneratorClass is a builtin generator function.
+	GeneratorClass
+	// SQLClass is a builtin function that executes a SQL statement as a side
+	// effect of the function call.
+	//
+	// For example, AddGeometryColumn is a SQLClass function that executes an
+	// ALTER TABLE ... ADD COLUMN statement to add a geometry column to an
+	// existing table. It returns metadata about the column added.
+	//
+	// All builtin functions of this class should include a definition for
+	// Overload.SQLFn, which returns the SQL statement to be executed. They
+	// should also include a definition for Overload.Fn, which is executed
+	// like a NormalClass function and returns a Datum.
+	SQLClass
+)
+
 // Overload is one of the overloads of a built-in function.
 // Each FunctionDefinition may contain one or more overloads.
 type Overload struct {
@@ -115,6 +141,9 @@ type Overload struct {
 
 	// Only one of the "Fn", "FnWithExprs", "Generate", "GeneratorWithExprs",
 	// "SQLFn" and "Body" attributes can be set.
+
+	// Class is the kind of built-in function (normal/aggregate/window/etc.)
+	Class FunctionClass
 
 	// Fn is the normal builtin implementation function. It's for functions that
 	// take in Datums and return a Datum.


### PR DESCRIPTION
#### sql: remove FuncExpr.IsGeneratorApplication

`FuncExpr.IsGeneratorApplication` has been removed and its single usage
has been replaced with with `FuncExpr.IsGeneratorClass`.

Release note: None

#### sql: move FunctionClass from FunctionProperties to Overload

`FunctionProperties` are attached to a `FunctionDefinition`, which is
simply a collection of overloads that share the same name. Most of the
fields in `FunctionProperties` are, however, overload-specific. They
should be moved to the `Overload` struct. In the long-term,
the hierarchy of function definitions, each with child function overloads,
should be flattened to a just overloads.

This commit takes one step in this direction.

Epic: CRDB-20370

Release note: None
