### PR TITLE
pkg/compose: bootstrap CCL for TestComposeCompare

### DIFF
--- a/build/teamcity/cockroach/nightlies/compose.sh
+++ b/build/teamcity/cockroach/nightlies/compose.sh
@@ -25,6 +25,7 @@ $BAZCI --artifacts_dir=$ARTIFACTS_DIR -- \
        "--sandbox_writable_path=$ARTIFACTS_DIR" \
        "--test_tmpdir=$ARTIFACTS_DIR" \
        --test_env=GO_TEST_WRAP_TESTV=1 \
+       --test_env=COCKROACH_DEV_LICENSE=$COCKROACH_DEV_LICENSE \
        --test_arg -cockroach --test_arg $COCKROACH \
        --test_arg -compare --test_arg $COMPAREBIN \
        --test_timeout=1800 || exit_status=$?

--- a/pkg/compose/BUILD.bazel
+++ b/pkg/compose/BUILD.bazel
@@ -19,7 +19,10 @@ go_test(
     embed = [":compose"],
     gotags = ["compose"],
     tags = ["integration"],
-    deps = ["//pkg/build/bazel"],
+    deps = [
+        "//pkg/build/bazel",
+        "//pkg/util/envutil",
+    ],
 )
 
 get_x_data(name = "get_x_data")

--- a/pkg/compose/compare/compare/BUILD.bazel
+++ b/pkg/compose/compare/compare/BUILD.bazel
@@ -21,8 +21,10 @@ go_test(
         "//pkg/internal/sqlsmith",
         "//pkg/sql/randgen",
         "//pkg/testutils",
+        "//pkg/util/envutil",
         "//pkg/util/randutil",
         "@com_github_jackc_pgx_v4//:pgx",
+        "@com_github_stretchr_testify//require",
     ],
 )
 

--- a/pkg/compose/compare/compare/compare_test.go
+++ b/pkg/compose/compare/compare/compare_test.go
@@ -19,6 +19,7 @@ package compare
 import (
 	"context"
 	"flag"
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -28,8 +29,10 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/internal/sqlsmith"
 	"github.com/cockroachdb/cockroach/pkg/sql/randgen"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
+	"github.com/cockroachdb/cockroach/pkg/util/envutil"
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
 	"github.com/jackc/pgx/v4"
+	"github.com/stretchr/testify/require"
 )
 
 var (
@@ -38,6 +41,10 @@ var (
 )
 
 func TestCompare(t *testing.T) {
+	// N.B. randomized SQL workload performed by this test may require CCL
+	var license = envutil.EnvOrDefaultString("COCKROACH_DEV_LICENSE", "")
+	require.NotEmptyf(t, license, "COCKROACH_DEV_LICENSE must be set")
+
 	uris := map[string]struct {
 		addr string
 		init []string
@@ -57,6 +64,8 @@ func TestCompare(t *testing.T) {
 		"cockroach1": {
 			addr: "postgresql://root@cockroach1:26257/postgres?sslmode=disable",
 			init: []string{
+				"SET CLUSTER SETTING cluster.organization = 'Cockroach Labs - Production Testing'",
+				fmt.Sprintf("SET CLUSTER SETTING enterprise.license = '%s'", license),
 				"drop database if exists postgres",
 				"create database postgres",
 			},
@@ -64,6 +73,8 @@ func TestCompare(t *testing.T) {
 		"cockroach2": {
 			addr: "postgresql://root@cockroach2:26257/postgres?sslmode=disable",
 			init: []string{
+				"SET CLUSTER SETTING cluster.organization = 'Cockroach Labs - Production Testing'",
+				fmt.Sprintf("SET CLUSTER SETTING enterprise.license = '%s'", license),
 				"drop database if exists postgres",
 				"create database postgres",
 			},

--- a/pkg/compose/compare/docker-compose.yml
+++ b/pkg/compose/compare/docker-compose.yml
@@ -17,6 +17,8 @@ services:
       - "${COCKROACH_PATH}:/cockroach/cockroach"
   test:
     image: ubuntu:xenial-20170214
+    environment:
+      - COCKROACH_DEV_LICENSE=$COCKROACH_DEV_LICENSE
     # compare.test is a binary built by the pkg/compose/prepare.sh in non-bazel builds
     command: /compare/compare.test -each ${EACH} -test.run ${TESTS} -artifacts ${ARTIFACTS}
     depends_on:

--- a/pkg/compose/compose_test.go
+++ b/pkg/compose/compose_test.go
@@ -28,6 +28,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/build/bazel"
+	"github.com/cockroachdb/cockroach/pkg/util/envutil"
 )
 
 var (
@@ -113,6 +114,7 @@ func TestComposeCompare(t *testing.T) {
 		fmt.Sprintf("COCKROACH_PATH=%s", cockroachBin),
 		fmt.Sprintf("COMPARE_DIR_PATH=%s", compareDir),
 		fmt.Sprintf("ARTIFACTS=%s", *flagArtifacts),
+		fmt.Sprintf("COCKROACH_DEV_LICENSE=%s", envutil.EnvOrDefaultString("COCKROACH_DEV_LICENSE", "")),
 	}
 	out, err := cmd.CombinedOutput()
 	if err != nil {


### PR DESCRIPTION
The nightly TestComposeCompare integration test uses a randomized SQL workload (a dialect denoted by sqlsmith.PostgresMode) to compare the results against Postgres. Additionally, it runs a second instance of CockroachDB using a series of mutators, e.g., randgen.StatisticsMutator, intended to alter table statistics, indexes, etc., but not the actual table data. Thus, all three data sources are expected to return the same result, for a given SQL query, modulo ignored SQL errors.

Some of the generated SQL may require CCL as can be seen from a number of previous test failures. This change bootstraps an environment variable (COCKROACH_DEV_LICENSE), similarly to roachprod and roachtest. The environment variable is passed via CI; it's also in our dev. environment, including gceworker.
The test aborts in case COCKROACH_DEV_LICENSE is empty.

Epic: none

Informs: https://github.com/cockroachdb/cockroach/issues/82867

Release note: None