### PR TITLE
server: honor and validate the service mode for SQL pods

### DIFF
--- a/pkg/ccl/multitenantccl/tenantcapabilitiesccl/testdata/can_admin_scatter
+++ b/pkg/ccl/multitenantccl/tenantcapabilitiesccl/testdata/can_admin_scatter
@@ -1,7 +1,7 @@
 query-sql-system
 SELECT * FROM [SHOW TENANT [10] WITH CAPABILITIES] WHERE capability_name = 'can_admin_scatter'
 ----
-10 tenant-10 ready none can_admin_scatter true
+10 tenant-10 ready external can_admin_scatter true
 
 exec-sql-tenant
 CREATE TABLE t(a INT)

--- a/pkg/ccl/multitenantccl/tenantcapabilitiesccl/testdata/can_admin_split
+++ b/pkg/ccl/multitenantccl/tenantcapabilitiesccl/testdata/can_admin_split
@@ -1,7 +1,7 @@
 query-sql-system
 SELECT * FROM [SHOW TENANT [10] WITH CAPABILITIES] WHERE capability_name = 'can_admin_split'
 ----
-10 tenant-10 ready none can_admin_split true
+10 tenant-10 ready external can_admin_split true
 
 exec-sql-tenant
 CREATE TABLE t(a INT)

--- a/pkg/ccl/multitenantccl/tenantcapabilitiesccl/testdata/can_admin_unsplit
+++ b/pkg/ccl/multitenantccl/tenantcapabilitiesccl/testdata/can_admin_unsplit
@@ -1,7 +1,7 @@
 query-sql-system
 SELECT * FROM [SHOW TENANT [10] WITH CAPABILITIES] WHERE capability_name = 'can_admin_unsplit'
 ----
-10 tenant-10 ready none can_admin_unsplit false
+10 tenant-10 ready external can_admin_unsplit false
 
 exec-sql-tenant
 CREATE TABLE t(a INT)

--- a/pkg/ccl/testccl/sqlccl/tenant_gc_test.go
+++ b/pkg/ccl/testccl/sqlccl/tenant_gc_test.go
@@ -318,6 +318,7 @@ func TestGCTenantJobWaitsForProtectedTimestamps(t *testing.T) {
 		tenantStopper.Stop(ctx)
 
 		// Drop the record.
+		sqlDB.Exec(t, `ALTER TENANT [$1] STOP SERVICE`, tenID.ToUint64())
 		sqlDB.Exec(t, `DROP TENANT [$1]`, tenID.ToUint64())
 
 		sqlDB.CheckQueryResultsRetry(

--- a/pkg/kv/kvclient/kvtenant/connector.go
+++ b/pkg/kv/kvclient/kvtenant/connector.go
@@ -27,6 +27,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvclient/rangecache"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
 	"github.com/cockroachdb/cockroach/pkg/multitenant/mtinfopb"
+	"github.com/cockroachdb/cockroach/pkg/multitenant/tenantcapabilities"
 	"github.com/cockroachdb/cockroach/pkg/multitenant/tenantcapabilities/tenantcapabilitiespb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/rpc"
@@ -69,6 +70,10 @@ func init() {
 type Connector interface {
 	// Start starts the connector.
 	Start(context.Context) error
+
+	// TenantInfo retrieves current metadata about the tenant record and
+	// an update channel to track changes
+	TenantInfo() (tenantcapabilities.Entry, <-chan struct{})
 
 	// NodeDescStore provides information on each of the KV nodes in the cluster
 	// in the form of NodeDescriptors and StoreDescriptors. This obviates the

--- a/pkg/multitenant/tenantcapabilities/interfaces.go
+++ b/pkg/multitenant/tenantcapabilities/interfaces.go
@@ -86,6 +86,11 @@ type Entry struct {
 	ServiceMode        mtinfopb.TenantServiceMode
 }
 
+// Ready indicates whether the metadata record is populated.
+func (e Entry) Ready() bool {
+	return e.TenantCapabilities != nil
+}
+
 // Update represents an update to the global tenant capability state.
 type Update struct {
 	Entry

--- a/pkg/server/server_sql.go
+++ b/pkg/server/server_sql.go
@@ -44,6 +44,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/liveness/livenesspb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/protectedts"
 	"github.com/cockroachdb/cockroach/pkg/multitenant"
+	"github.com/cockroachdb/cockroach/pkg/multitenant/mtinfopb"
 	"github.com/cockroachdb/cockroach/pkg/multitenant/tenantcapabilities"
 	"github.com/cockroachdb/cockroach/pkg/obs"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
@@ -210,6 +211,9 @@ type SQLServer struct {
 
 	// Tenant migration server for use in tenant tests.
 	migrationServer *TenantMigrationServer
+
+	// serviceMode is the service mode this server was started with.
+	serviceMode mtinfopb.TenantServiceMode
 }
 
 // sqlServerOptionalKVArgs are the arguments supplied to newSQLServer which are
@@ -258,6 +262,7 @@ type sqlServerOptionalKVArgs struct {
 type sqlServerOptionalTenantArgs struct {
 	tenantConnect      kvtenant.Connector
 	spanLimiterFactory spanLimiterFactory
+	serviceMode        mtinfopb.TenantServiceMode
 
 	promRuleExporter *metric.PrometheusRuleExporter
 }
@@ -1382,6 +1387,7 @@ func newSQLServer(ctx context.Context, cfg sqlServerArgs) (*SQLServer, error) {
 		cfg:                            cfg.BaseConfig,
 		internalDBMemMonitor:           internalDBMonitor,
 		upgradeManager:                 upgradeMgr,
+		serviceMode:                    cfg.serviceMode,
 	}, nil
 }
 
@@ -1397,6 +1403,9 @@ func (s *SQLServer) preStart(
 	// determined.
 	if s.tenantConnect != nil {
 		if err := s.tenantConnect.Start(ctx); err != nil {
+			return err
+		}
+		if err := s.startCheckService(ctx, stopper); err != nil {
 			return err
 		}
 	}
@@ -1681,6 +1690,69 @@ func (s *SQLServer) preStart(
 		}
 	}))
 
+	return nil
+}
+
+// startCheckService verifies that the tenant has the right
+// service mode initially, then starts an async checker
+// to stop the server if the service mode changes.
+func (s *SQLServer) startCheckService(ctx context.Context, stopper *stop.Stopper) error {
+	if s.tenantConnect == nil {
+		return errors.AssertionFailedf("programming error: can only check service with a tenant connector")
+	}
+
+	var entry tenantcapabilities.Entry
+	var updateCh <-chan struct{}
+	check := func() error {
+		entry, updateCh = s.tenantConnect.TenantInfo()
+		return checkServerModeMatchesEntry(s.serviceMode, entry)
+	}
+
+	// Do a synchronous check, to prevent starting the SQL service
+	// outright if the service mode is initially incorrect.
+	if err := check(); err != nil {
+		return err
+	}
+
+	return stopper.RunAsyncTask(ctx, "check-tenant-service", func(ctx context.Context) {
+		for {
+			select {
+			case <-stopper.ShouldQuiesce():
+				return
+			case <-ctx.Done():
+				return
+			case <-updateCh:
+				if err := check(); err != nil {
+					s.stopTrigger.signalStop(ctx,
+						MakeShutdownRequest(ShutdownReasonFatalError, err))
+				}
+			}
+		}
+	})
+}
+
+func checkServerModeMatchesEntry(
+	expectedMode mtinfopb.TenantServiceMode, entry tenantcapabilities.Entry,
+) error {
+	if !entry.Ready() {
+		// At the version this check was introduced, the server was
+		// already modified to provide metadata during the initial
+		// handshake.
+		//
+		// If we don't have the metadata here, this means that the
+		// connector is talking to an older-version server.
+		return errors.AssertionFailedf("storage layer did not communicate metadata, is it running an older binary version than the client?")
+	}
+
+	if actualMode := entry.ServiceMode; expectedMode != actualMode {
+		return errors.Newf("service check failed: expected service mode %v, record says %v", expectedMode, actualMode)
+	}
+	// Extra sanity check. This should never happen (we should enforce
+	// a valid data state when the service mode is not NONE) but it's
+	// cheap to check.
+	if expected, actual := mtinfopb.DataStateReady, entry.DataState; expected != actual {
+		return errors.AssertionFailedf("service check failed: expected data state %v, record says %v", expected, actual)
+	}
 	return nil
 }
 


### PR DESCRIPTION
Rebased on top of #105441.
Fixes #93145.
Fixes #83650.

Epic: CRDB-26691

TLDR: this makes SQL servers only accept to start if their data state
is "ready" and their deployment type (e.g. separate process) matches
the configured service mode in the tenant record.
Additionally, the SQL server spontaneously terminates if
their service mode or data state is not valid any more (e.g
as a result of DROP TENANT or ALTER TENANT STOP SERVICE).

----

Prior to this patch, there wasn't a good story about the lifecycle
of separate-process SQL servers ("SQL pods"):

- if a SQL server was started against a non-existent tenant,
  an obscure error would be raised (`database "[1]" does not exist`)
- if a SQL server was started while a tenant was being added
  (keyspace not yet valid), no check would be performed and
  data corruption could ensue.
- if the tenant record/keyspace was dropped while the SQL server was
  running, SQL clients would start encountering obscure errors.

This commit fixes the situation by checking the tenant metadata:

- once, during SQL server startup, at which point server startup
  is prevented if the service check fails;
- then, asynchronously, whenever the metadata is updated, such that
  any service check failure results in a graceful shutdown of the SQL
  service.

The check proper validates:
- that the tenant record exists;
- that the data state is "ready";
- that the configured service mode matches that requested by the SQL
  server.

Examples output upon error:

- non-existent tenant:
  ```
  tenant service check failed: missing record
  ```

- attempting to start separate-process server while
  tenant is running as shared-process:
  ```
  tenant service check failed: service mode check failed: expected external, record says shared
  ```

- after ALTER TENANT STOP SERVICE:
  ```
  tenant service check failed: service mode check failed: expected external, record says none
  ```

- after DROP TENANT:
  ```
  tenant service check failed: service mode check failed: expected external, record says dropping
  ```

Release note: None

