### PR TITLE
sql: add a SHOW CLUSTER SETTING sql.defaults deprecation notice

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/cluster_settings
+++ b/pkg/sql/logictest/testdata/logic_test/cluster_settings
@@ -326,3 +326,13 @@ WHERE variable IN ('jobs.scheduler.enabled', 'jobs.retention_time') ORDER BY 1
 ----
 jobs.retention_time     d  true   no-override
 jobs.scheduler.enabled  b  false  no-override
+
+query T noticetrace
+SHOW CLUSTER SETTING sql.defaults.distsql;
+----
+NOTICE: using global default sql.defaults.distsql is not recommended
+HINT: use the `ALTER ROLE ... SET` syntax to control session variable defaults at a finer-grained level. See: https://www.cockroachlabs.com/docs/v23.1/alter-role.html#set-default-session-variable-values-for-a-role
+
+query T noticetrace
+SHOW CLUSTER SETTING sql.notices.enabled
+----

--- a/pkg/sql/show_cluster_setting.go
+++ b/pkg/sql/show_cluster_setting.go
@@ -19,10 +19,12 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/clusterversion"
+	"github.com/cockroachdb/cockroach/pkg/docs"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/colinfo"
 	"github.com/cockroachdb/cockroach/pkg/sql/isql"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgnotice"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
@@ -124,6 +126,17 @@ func (p *planner) ShowClusterSetting(
 
 	if err := checkPrivilegesForSetting(ctx, p, name, "show"); err != nil {
 		return nil, err
+	}
+
+	if strings.HasPrefix(n.Name, "sql.defaults") {
+		p.BufferClientNotice(
+			ctx,
+			errors.WithHintf(
+				pgnotice.Newf("using global default %s is not recommended", n.Name),
+				"use the `ALTER ROLE ... SET` syntax to control session variable defaults at a finer-grained level. See: %s",
+				docs.URL("alter-role.html#set-default-session-variable-values-for-a-role"),
+			),
+		)
 	}
 
 	setting, ok := val.(settings.NonMaskedSetting)


### PR DESCRIPTION
Release note (sql change): The `ALTER ROLE` syntax` allows users to set default values for session variables making `SET CLUSTER SETTINGS sql.defaults...` redundant. This PR adds a notice to `SHOW CLUSTER SETTING sql.defaults...` that directs the user to use the `ALTER ROLE` syntax instead.

Fixes: #88520