### PR TITLE
roachtest/tpcc: retry prometheus query during DRT

### DIFF
--- a/pkg/cmd/roachtest/tests/tpcc.go
+++ b/pkg/cmd/roachtest/tests/tpcc.go
@@ -299,7 +299,7 @@ func runTPCC(ctx context.Context, t test.Test, c cluster.Cluster, opts tpccOptio
 	// Check no errors from metrics.
 	if ep != nil {
 		if err := ep.err(); err != nil {
-			t.Fatal(err)
+			t.Fatal(errors.Wrap(err, "error detected during DRT"))
 		}
 	}
 }


### PR DESCRIPTION
Previously, the prometheus endpoint may sometimes return an EOF error. This seems sporadic / random so I'm
making it retryable.

Release justification: bug fix tests only

Resolves #74684

Release note: None