### PR TITLE
cli/cliflags: update `max-offset` help text

### DIFF
--- a/pkg/cli/cliflags/flags.go
+++ b/pkg/cli/cliflags/flags.go
@@ -901,9 +901,11 @@ failures as well as the frequency of uncertainty-based read restarts.
 <PRE>
 
 </PRE>
-Note that this value must be the same on all nodes in the cluster. In order to
-change it, all nodes in the cluster must be stopped simultaneously and restarted
-with the new value.`,
+This value should be the same on all nodes in the cluster. It is allowed to
+differ such that the max-offset value can be changed via a rolling restart of
+the cluster, in which case the real clock offset between nodes must be below the
+smallest max-offset value of any node.
+`,
 	}
 
 	Store = FlagInfo{


### PR DESCRIPTION
Extracted from #96141.

---

The max offset was recently allowed to differ between nodes to allow changing it via a rolling restart. This patch updates the `--max-offset` help text to reflect this.

Epic: none
Release note: None