### PR TITLE
backupccl: temporarily skip restore-tenant test

### DIFF
--- a/pkg/ccl/backupccl/testdata/backup-restore/restore-tenants
+++ b/pkg/ccl/backupccl/testdata/backup-restore/restore-tenants
@@ -1,5 +1,6 @@
 # disabled to probabilistically run within a tenant because the test always runs from the host
 # tenant
+skip issue-num=96149
 
 new-cluster name=s1 disable-tenant
 ----


### PR DESCRIPTION
This test is fails because when it puts a tenant into the shared service mode, the CRDB process crashes because it cannot find the required certificates. We can fix this, but lets skip this to avoid blocking people while we do.

Epic: none

Release note: None