### PR TITLE
release-22.2: roachtest: fix helper to install go1.19.4

### DIFF
--- a/pkg/cmd/roachtest/tests/go_helpers.go
+++ b/pkg/cmd/roachtest/tests/go_helpers.go
@@ -49,7 +49,7 @@ func installGolang(
 	}
 	if err := repeatRunE(
 		ctx, t, c, node, "verify tarball", `sha256sum -c - <<EOF
-3ca65ff0606054b076c009d3bb3b8aba0032b75ac690de716be5c44ce57da052 /tmp/go.tgz
+c9c08f783325c4cf840a94333159cc937f05f75d36a8b307951d5bd959cf2ab8 /tmp/go.tgz
 EOF`,
 	); err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
Backport 1/1 commits from https://github.com/cockroachdb/cockroach/pull/94145.

/cc https://github.com/orgs/cockroachdb/teams/release

fixes #96140 
fixes #96139
fixes #96138
fixes #96137
fixes #96134 

----

The change in ce39332b015ffa650c20f89d6eb9a90abf042e8a accidentally used the checksum for the macos download instead of the linux download.

Release note: None
Release justification: Test only changes