### PR TITLE
spanconfig: rename setting to `spanconfig.storage_coalesce_adjacent.enabled`

### DIFF
--- a/pkg/settings/registry.go
+++ b/pkg/settings/registry.go
@@ -159,6 +159,8 @@ var retiredSettings = map[string]struct{}{
 	"sql.distsql.drain.cancel_after_wait.enabled":    {},
 	"changefeed.active_protected_timestamps.enabled": {},
 	"jobs.scheduler.single_node_scheduler.enabled":   {},
+	// renamed.
+	"spanconfig.host_coalesce_adjacent.enabled": {},
 }
 
 // sqlDefaultSettings is the list of "grandfathered" existing sql.defaults

--- a/pkg/sql/generate_objects_test.go
+++ b/pkg/sql/generate_objects_test.go
@@ -46,7 +46,7 @@ func BenchmarkGenerateObjects(b *testing.B) {
 
 	// Disable auto stats and range splits, which introduce noise.
 	db.Exec(b, `SET CLUSTER SETTING sql.stats.automatic_collection.enabled = false`)
-	db.Exec(b, `SET CLUSTER SETTING spanconfig.host_coalesce_adjacent.enabled = true`)
+	db.Exec(b, `SET CLUSTER SETTING spanconfig.storage_coalesce_adjacent.enabled = true`)
 
 	for _, bench := range benches {
 		b.Run(bench.name, func(b *testing.B) {


### PR DESCRIPTION
Fixes #96187. 
Epic: CRDB-23559

Our terminology is "tenant" vs "storage cluster". The word "host" is not used anywhere in CockroachDB (it is a term specific to CC Serverless) and so should not be included in setting names.

There is no release note because the functionality is not yet visible to end-users.

Release note: None