### PR TITLE
release-22.2: roachtest: display diff when failing system upgrade test

### DIFF
--- a/pkg/cmd/roachtest/tests/BUILD.bazel
+++ b/pkg/cmd/roachtest/tests/BUILD.bazel
@@ -230,6 +230,7 @@ go_library(
         "@com_github_kr_pretty//:pretty",
         "@com_github_lib_pq//:pq",
         "@com_github_montanaflynn_stats//:stats",
+        "@com_github_pmezard_go_difflib//difflib",
         "@com_github_prometheus_client_golang//api",
         "@com_github_prometheus_client_golang//api/prometheus/v1:prometheus",
         "@com_github_prometheus_common//model",


### PR DESCRIPTION
Backport 1/1 commits from #93610.

/cc @cockroachdb/release

---

Before this change, the test would not show diffs like this:

```
Diff:
@@ -29,11 +29,11 @@
 	"lastUpdated" TIMESTAMP NOT NULL DEFAULT now():::TIMESTAMP,
 	"valueType" STRING NULL,
 	CONSTRAINT "primary" PRIMARY KEY (name ASC),
 	FAMILY "fam_0_name_value_lastUpdated_valueType" (name, value, "lastUpdated", "valueType")
 );
-CREATE SEQUENCE public.descriptor_id_seq MINVALUE 1 MAXVALUE 9223372036854775807 INCREMENT 1 START 1;
+CREATE SEQUENCE public.descriptor_id_seq MINVALUE 1 MAXVALUE 9223372036854775807 INCREMENT 1 START 104;
 CREATE TABLE public.tenants (
 	id INT8 NOT NULL,
 	active BOOL NOT NULL DEFAULT true,
 	info BYTES NULL,
 	name STRING NULL AS (crdb_internal.pb_to_json('cockroach.sql.sqlbase.TenantInfo':::STRING, info)->>'name':::STRING) VIRTUAL,
----
```

release justification: testing only change

Epic: None

Relates to debugging https://github.com/cockroachdb/cockroach/issues/95503

Release note: None
