### PR TITLE
keyvisualizer: Fix keyvisualizer.sample_interval setting

### DIFF
--- a/pkg/keyvisualizer/spanstatscollector/span_stats_collector.go
+++ b/pkg/keyvisualizer/spanstatscollector/span_stats_collector.go
@@ -88,8 +88,8 @@ func (s *SpanStatsCollector) Start(ctx context.Context, stopper *stop.Stopper) {
 		func(ctx context.Context) {
 			s.reset()
 			t := timeutil.NewTimer()
-			samplePeriod := keyvissettings.SampleInterval.Get(&s.settings.SV)
 			for {
+				samplePeriod := keyvissettings.SampleInterval.Get(&s.settings.SV)
 				now := timeutil.Now()
 
 				// The current time is truncated to synchronize the sample
@@ -191,6 +191,7 @@ func discardStaleUpdates(currentTime time.Time, updates []boundaryUpdate) []boun
 			// The boundary update at index 0 will never be applied,
 			// so it can be discarded.
 			updates[0] = boundaryUpdate{}
+			updates = updates[1:]
 		} else {
 			// The update at boundary index 0 should be applied,
 			// so no more discarding is needed.

--- a/pkg/ui/workspaces/db-console/src/views/keyVisualizer/index.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/keyVisualizer/index.tsx
@@ -158,6 +158,10 @@ class KeyVisualizerContainer extends React.Component<
     const { samples, yOffsetsForKey, hottestBucket, keys } =
       buildKeyVisualizerProps(this.state, this.props.timeScale);
 
+    if (samples.length === 0 || Object.keys(keys).length === 0) {
+      return <div>Waiting for samples...</div>;
+    }
+
     return (
       <div style={{ position: "relative" }}>
         <KeyVisualizerTimeWindow />
@@ -194,7 +198,7 @@ const KeyVisualizerPage: React.FunctionComponent<
     return (
       <div>
         <p>To enable the key visualizer, run the following SQL statement:</p>
-        <pre>SET CLUSTER SETTING keyvisualizer.job.enabled = true;</pre>
+        <pre>SET CLUSTER SETTING {EnabledSetting} = true;</pre>
       </div>
     );
   }


### PR DESCRIPTION
This commit fixes a deadlock that occurred when adjusting the cluster setting `keyvisualizer.sample_interval` if the key visualizer was enabled. Now, users can adjust the sample interval without issue.

This commit also corrects the name of the enabled cluster setting displayed to the user, and shows a simple loading message before samples are available.

Epic: none
Release note: None