### PR TITLE
rpc,security: simplify and enhance the client cert validation

### DIFF
--- a/pkg/rpc/auth.go
+++ b/pkg/rpc/auth.go
@@ -178,7 +178,7 @@ func (a kvAuth) authenticate(ctx context.Context) (roachpb.TenantID, error) {
 	// NodeUser. This is not a security concern, as RootUser has access to
 	// read and write all data, merely good hygiene. For example, there is
 	// no reason to permit the root user to send raw Raft RPCs.
-	certUserScope, err := security.GetCertificateUserScope(&tlsInfo.State)
+	certUserScope, err := security.GetCertificateUserScope(clientCert)
 	if err != nil {
 		return roachpb.TenantID{}, err
 	}

--- a/pkg/rpc/auth.go
+++ b/pkg/rpc/auth.go
@@ -17,7 +17,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/security/username"
 	"github.com/cockroachdb/cockroach/pkg/util/grpcutil"
-	"github.com/cockroachdb/errors"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials"
@@ -184,42 +183,32 @@ func (a kvAuth) authenticate(ctx context.Context) (roachpb.TenantID, error) {
 	}
 
 	// Confirm that the user scope is node/root. Otherwise, return an authentication error.
-	_, err = getActiveNodeOrUserScope(certUserScope, username.RootUser, a.tenant.tenantID)
-	if err != nil {
-		return roachpb.TenantID{}, authErrorf("client certificate %s cannot be used to perform RPC on tenant %d", clientCert.Subject, a.tenant.tenantID)
+	if err := checkRootOrNodeInScope(certUserScope, a.tenant.tenantID); err != nil {
+		return roachpb.TenantID{}, err
 	}
 
 	// User is node/root user authorized for this tenant, return success.
 	return roachpb.TenantID{}, nil
 }
 
-// getActiveNodeOrUserScope returns a node user scope if one is present in the set of certificate user scopes. If node
-// user scope is not present, it returns the user scope corresponding to the username parameter. The node user scope
-// will always override the user scope for authentication.
-func getActiveNodeOrUserScope(
-	certUserScope []security.CertificateUserScope, user string, serverTenantID roachpb.TenantID,
-) (security.CertificateUserScope, error) {
-	var userScope security.CertificateUserScope
+// checkRootOrNodeInScope checks that the root or node principals are
+// present in the cert user scopes.
+func checkRootOrNodeInScope(
+	certUserScope []security.CertificateUserScope, serverTenantID roachpb.TenantID,
+) (err error) {
 	for _, scope := range certUserScope {
+		// Only consider global scopes or scopes that match this server.
+		if !(scope.Global || scope.TenantID == serverTenantID) {
+			continue
+		}
+
 		// If we get a scope that matches the Node user, immediately return.
-		if scope.Username == username.NodeUser {
-			if scope.Global {
-				return scope, nil
-			}
-			// Confirm that the certificate scope and serverTenantID are the system tenant.
-			if scope.TenantID == roachpb.SystemTenantID && serverTenantID == roachpb.SystemTenantID {
-				return scope, nil
-			}
+		if scope.Username == username.NodeUser || scope.Username == username.RootUser {
+			return nil
 		}
-		if scope.Username == user && (scope.TenantID == serverTenantID || scope.Global) {
-			userScope = scope
-		}
-	}
-	// Double check we're not returning an empty scope
-	if userScope.Username == "" {
-		return userScope, errors.New("could not find active user scope for client certificate")
 	}
 
-	// Only return userScope if we haven't found a NodeUser.
-	return userScope, nil
+	return authErrorf(
+		"need root or node client cert to perform RPCs on this server (this is tenant %v; cert is valid for %s)",
+		serverTenantID, security.FormatUserScopes(certUserScope))
 }

--- a/pkg/rpc/auth_test.go
+++ b/pkg/rpc/auth_test.go
@@ -123,7 +123,7 @@ func TestAuthenticateTenant(t *testing.T) {
 		{systemID: stid, ous: nil, commonName: "root", tenantScope: 10,
 			expErr: `need root or node client cert to perform RPCs on this server \(this is tenant system; cert is valid for "root" on tenant 10\)`},
 		{systemID: tenTen, ous: correctOU, commonName: "10", expTenID: roachpb.TenantID{}},
-		{systemID: tenTen, ous: correctOU, commonName: "123", expErr: `this tenant \(10\) cannot serve requests from a server for tenant 123`},
+		{systemID: tenTen, ous: correctOU, commonName: "123", expErr: `client tenant identity \(123\) does not match server`},
 		{systemID: tenTen, ous: correctOU, commonName: "1", expErr: `invalid tenant ID 1 in Common Name \(CN\)`},
 		{systemID: tenTen, ous: nil, commonName: "root"},
 		{systemID: tenTen, ous: nil, commonName: "node"},

--- a/pkg/rpc/helpers_test.go
+++ b/pkg/rpc/helpers_test.go
@@ -39,7 +39,16 @@ func TestingNewWrappedServerStream(
 func TestingAuthenticateTenant(
 	ctx context.Context, serverTenantID roachpb.TenantID,
 ) (roachpb.TenantID, error) {
-	return kvAuth{tenant: tenantAuthorizer{tenantID: serverTenantID}}.authenticate(ctx)
+	_, authz, err := kvAuth{tenant: tenantAuthorizer{tenantID: serverTenantID}}.authenticateAndSelectAuthzRule(ctx)
+	if err != nil {
+		return roachpb.TenantID{}, err
+	}
+	switch z := authz.(type) {
+	case authzTenantServerToKVServer:
+		return roachpb.TenantID(z), nil
+	default:
+		return roachpb.TenantID{}, nil
+	}
 }
 
 // TestingAuthorizeTenantRequest performs authorization of a tenant request

--- a/pkg/security/auth_test.go
+++ b/pkg/security/auth_test.go
@@ -85,20 +85,10 @@ func makeFakeTLSState(t *testing.T, spec string) *tls.ConnectionState {
 
 func TestGetCertificateUserScope(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	t.Run("nil TLS state", func(t *testing.T) {
-		if _, err := security.GetCertificateUserScope(nil); err == nil {
-			t.Error("unexpected success")
-		}
-	})
-
-	t.Run("no certificates", func(t *testing.T) {
-		if _, err := security.GetCertificateUserScope(makeFakeTLSState(t, "")); err == nil {
-			t.Error("unexpected success")
-		}
-	})
-
 	t.Run("good request: single certificate", func(t *testing.T) {
-		if userScopes, err := security.GetCertificateUserScope(makeFakeTLSState(t, "foo")); err != nil {
+		state := makeFakeTLSState(t, "foo")
+		cert := state.PeerCertificates[0]
+		if userScopes, err := security.GetCertificateUserScope(cert); err != nil {
 			t.Error(err)
 		} else {
 			require.Equal(t, 1, len(userScopes))
@@ -108,7 +98,9 @@ func TestGetCertificateUserScope(t *testing.T) {
 	})
 
 	t.Run("request with multiple certs, but only one chain (eg: origin certs are client and CA)", func(t *testing.T) {
-		if userScopes, err := security.GetCertificateUserScope(makeFakeTLSState(t, "foo;CA")); err != nil {
+		state := makeFakeTLSState(t, "foo;CA")
+		cert := state.PeerCertificates[0]
+		if userScopes, err := security.GetCertificateUserScope(cert); err != nil {
 			t.Error(err)
 		} else {
 			require.Equal(t, 1, len(userScopes))
@@ -118,7 +110,9 @@ func TestGetCertificateUserScope(t *testing.T) {
 	})
 
 	t.Run("always use the first certificate", func(t *testing.T) {
-		if userScopes, err := security.GetCertificateUserScope(makeFakeTLSState(t, "foo;bar")); err != nil {
+		state := makeFakeTLSState(t, "foo;bar")
+		cert := state.PeerCertificates[0]
+		if userScopes, err := security.GetCertificateUserScope(cert); err != nil {
 			t.Error(err)
 		} else {
 			require.Equal(t, 1, len(userScopes))
@@ -128,7 +122,9 @@ func TestGetCertificateUserScope(t *testing.T) {
 	})
 
 	t.Run("extract all of the principals from the first certificate", func(t *testing.T) {
-		if userScopes, err := security.GetCertificateUserScope(makeFakeTLSState(t, "foo,dns:bar,dns:blah;CA")); err != nil {
+		state := makeFakeTLSState(t, "foo,dns:bar,dns:blah;CA")
+		cert := state.PeerCertificates[0]
+		if userScopes, err := security.GetCertificateUserScope(cert); err != nil {
 			t.Error(err)
 		} else {
 			require.Equal(t, 3, len(userScopes))
@@ -137,8 +133,9 @@ func TestGetCertificateUserScope(t *testing.T) {
 	})
 
 	t.Run("extracts username, tenantID from tenant URI SAN", func(t *testing.T) {
-		if userScopes, err := security.GetCertificateUserScope(
-			makeFakeTLSState(t, "foo,uri:crdb://tenant/123/user/foo;CA")); err != nil {
+		state := makeFakeTLSState(t, "foo,uri:crdb://tenant/123/user/foo;CA")
+		cert := state.PeerCertificates[0]
+		if userScopes, err := security.GetCertificateUserScope(cert); err != nil {
 			t.Error(err)
 		} else {
 			require.Equal(t, 1, len(userScopes))
@@ -149,8 +146,9 @@ func TestGetCertificateUserScope(t *testing.T) {
 	})
 
 	t.Run("extracts tenant URI SAN even when multiple URIs, where one URI is not of CRBD format", func(t *testing.T) {
-		if userScopes, err := security.GetCertificateUserScope(
-			makeFakeTLSState(t, "foo,uri:mycompany:sv:rootclient:dev:usw1,uri:crdb://tenant/123/user/foo;CA")); err != nil {
+		state := makeFakeTLSState(t, "foo,uri:mycompany:sv:rootclient:dev:usw1,uri:crdb://tenant/123/user/foo;CA")
+		cert := state.PeerCertificates[0]
+		if userScopes, err := security.GetCertificateUserScope(cert); err != nil {
 			t.Error(err)
 		} else {
 			require.Equal(t, 1, len(userScopes))
@@ -161,15 +159,17 @@ func TestGetCertificateUserScope(t *testing.T) {
 	})
 
 	t.Run("errors when tenant URI SAN is not of expected format, even if other URI SAN is provided", func(t *testing.T) {
-		userScopes, err := security.GetCertificateUserScope(
-			makeFakeTLSState(t, "foo,uri:mycompany:sv:rootclient:dev:usw1,uri:crdb://tenant/bad/format/123;CA"))
+		state := makeFakeTLSState(t, "foo,uri:mycompany:sv:rootclient:dev:usw1,uri:crdb://tenant/bad/format/123;CA")
+		cert := state.PeerCertificates[0]
+		userScopes, err := security.GetCertificateUserScope(cert)
 		require.Nil(t, userScopes)
 		require.ErrorContains(t, err, "invalid tenant URI SAN")
 	})
 
 	t.Run("falls back to global client cert when crdb URI SAN scheme is not followed", func(t *testing.T) {
-		if userScopes, err := security.GetCertificateUserScope(
-			makeFakeTLSState(t, "sanuri,uri:mycompany:sv:rootclient:dev:usw1;CA")); err != nil {
+		state := makeFakeTLSState(t, "sanuri,uri:mycompany:sv:rootclient:dev:usw1;CA")
+		cert := state.PeerCertificates[0]
+		if userScopes, err := security.GetCertificateUserScope(cert); err != nil {
 			t.Error(err)
 		} else {
 			require.Equal(t, 1, len(userScopes))
@@ -236,7 +236,9 @@ func TestGetCertificateUsersMapped(t *testing.T) {
 			if err := security.SetCertPrincipalMap(vals); err != nil {
 				t.Fatal(err)
 			}
-			userScopes, err := security.GetCertificateUserScope(makeFakeTLSState(t, c.spec))
+			state := makeFakeTLSState(t, c.spec)
+			cert := state.PeerCertificates[0]
+			userScopes, err := security.GetCertificateUserScope(cert)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/server/authentication_test.go
+++ b/pkg/server/authentication_test.go
@@ -833,7 +833,7 @@ func TestGRPCAuthentication(t *testing.T) {
 	for _, subsystem := range subsystems {
 		t.Run(fmt.Sprintf("bad-user/%s", subsystem.name), func(t *testing.T) {
 			err := subsystem.sendRPC(ctx, conn)
-			if exp := `client certificate CN=testuser,O=Cockroach cannot be used to perform RPC on tenant {1}`; !testutils.IsError(err, exp) {
+			if exp := `need root or node client cert to perform RPCs on this server`; !testutils.IsError(err, exp) {
 				t.Errorf("expected %q error, but got %v", exp, err)
 			}
 		})


### PR DESCRIPTION
Fixes #96174.
Prerequisite for #96153.
Epic: CRDB-14537

TLDR: this change enhances various aspects of TLS client cert
validation. Between other things, it makes the error clearer in case
of authentication failure.

Example, before:
```
ERROR: requested user demo is not authorized for tenant {2}
```

Example, after:
```
ERROR: certificate authentication failed for user "demo"
DETAIL: This is tenant system; cert is valid for "root" on all tenants.
```
