### PR TITLE
cli: update hot-ranges.sh to include cpu_time

### DIFF
--- a/pkg/cli/zip.go
+++ b/pkg/cli/zip.go
@@ -278,7 +278,7 @@ find . -name cpu.pprof -print0 | xargs -0 go tool pprof -tags
 	{
 		s := zc.clusterPrinter.start("hot range summary script")
 		if err := z.createRaw(s, debugBase+"/hot-ranges.sh", []byte(`#!/bin/sh
-for stat in "queries" "writes" "reads" "write_bytes" "read_bytes"; do
+for stat in "queries" "writes" "reads" "write_bytes" "read_bytes" "cpu_time"; do
 	echo "$stat"
 	find . -path './nodes/*/ranges/*.json' -print0 | xargs -0 grep "$stat"_per_second | sort -rhk3 | head -n 10
 done
@@ -291,7 +291,7 @@ done
 	{
 		s := zc.clusterPrinter.start("tenant hot range summary script")
 		if err := z.createRaw(s, debugBase+"/hot-ranges-tenant.sh", []byte(`#!/bin/sh
-for stat in "queries" "writes" "reads" "write_bytes" "read_bytes"; do
+for stat in "queries" "writes" "reads" "write_bytes" "read_bytes" "cpu_time"; do
     echo "$stat"_per_second
     find . -path './tenant_ranges/*/*.json' -print0 | xargs -0 grep "$stat"_per_second | sort -rhk3 | head -n 10
 done


### PR DESCRIPTION
Previously, `cpu_time_per_second` was not included in the `hot-ranges.sh` utility. This patch updates the utility script to include `cpu_time_per_second`.

resolves: #96212

Release note (cli change): Add `cpu_time_per_second` to the `hot-ranges.sh` and `hot-ranges-tenant.sh` utility debug zip scripts.