### PR TITLE
server: add missing RPC metrics for secondary tenants

### DIFF
--- a/pkg/server/tenant.go
+++ b/pkg/server/tenant.go
@@ -823,6 +823,9 @@ func makeTenantSQLServerArgs(
 		Settings:         st,
 		Knobs:            rpcTestingKnobs,
 	})
+	registry.AddMetricStruct(rpcContext.Metrics())
+	registry.AddMetricStruct(rpcContext.RemoteClocks.Metrics())
+
 	// If there is a local KV server, hook this SQLServer to it so that the
 	// SQLServer can perform some RPCs directly, without going through gRPC.
 	if lsi := sqlCfg.LocalKVServerInfo; lsi != nil {


### PR DESCRIPTION
This patch adds the missing two AddMetricStruct calls on the rpcContext.

I have manually audited the remainder of the code to compare with that of `NewServer()` in `server.go`. These were the main two that were missing (there's another one, which I will also fix in a later commit).

Generally, this entire function would benefit from the same approach we've used when we refactored `PreStart`: reorganize the code so that the two functions (from `server.go` and `tenant.go`) can be compared side-by-side to identify mismatches.
This is left to future work.

Release note: None
Epic: CRDB-14537