### PR TITLE
rpc,*: don't panic in `rpc.NewServerEx`

### DIFF
--- a/pkg/blobs/BUILD.bazel
+++ b/pkg/blobs/BUILD.bazel
@@ -55,6 +55,7 @@ go_test(
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_cockroachdb_errors//oserror",
         "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
     ],
 )
 

--- a/pkg/blobs/client_test.go
+++ b/pkg/blobs/client_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/netutil"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
 	"github.com/cockroachdb/errors"
+	"github.com/stretchr/testify/require"
 )
 
 func createTestResources(t testing.TB) (string, string, *stop.Stopper, func()) {
@@ -55,27 +56,24 @@ func setUpService(
 	localExternalDir string,
 	remoteExternalDir string,
 ) BlobClientFactory {
-	s := rpc.NewServer(rpcContext)
+	s, err := rpc.NewServer(rpcContext)
+	require.NoError(t, err)
+
 	remoteBlobServer, err := NewBlobService(remoteExternalDir)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
+
 	blobspb.RegisterBlobServer(s, remoteBlobServer)
 	ln, err := netutil.ListenAndServeGRPC(rpcContext.Stopper, s, util.TestAddr)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
-	s2 := rpc.NewServer(rpcContext)
+	s2, err := rpc.NewServer(rpcContext)
+	require.NoError(t, err)
 	localBlobServer, err := NewBlobService(localExternalDir)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
+
 	blobspb.RegisterBlobServer(s2, localBlobServer)
 	ln2, err := netutil.ListenAndServeGRPC(rpcContext.Stopper, s2, util.TestAddr)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	localDialer := nodedialer.New(rpcContext,
 		func(nodeID roachpb.NodeID) (net.Addr, error) {

--- a/pkg/ccl/kvccl/kvtenantccl/connector_test.go
+++ b/pkg/ccl/kvccl/kvtenantccl/connector_test.go
@@ -207,7 +207,8 @@ func TestConnectorGossipSubscription(t *testing.T) {
 	defer stopper.Stop(ctx)
 	clock := hlc.NewClockWithSystemTimeSource(time.Nanosecond /* maxOffset */)
 	rpcContext := rpc.NewInsecureTestingContext(ctx, clock, stopper)
-	s := rpc.NewServer(rpcContext)
+	s, err := rpc.NewServer(rpcContext)
+	require.NoError(t, err)
 
 	// Test setting the cluster ID by setting it to nil then ensuring it's later
 	// set to the original ID value.
@@ -359,7 +360,8 @@ func TestConnectorRangeLookup(t *testing.T) {
 	defer stopper.Stop(ctx)
 	clock := hlc.NewClockWithSystemTimeSource(time.Nanosecond /* maxOffset */)
 	rpcContext := rpc.NewInsecureTestingContext(ctx, clock, stopper)
-	s := rpc.NewServer(rpcContext)
+	s, err := rpc.NewServer(rpcContext)
+	require.NoError(t, err)
 
 	rangeLookupRespC := make(chan *roachpb.RangeLookupResponse, 1)
 	rangeLookupFn := func(_ context.Context, req *roachpb.RangeLookupRequest) (*roachpb.RangeLookupResponse, error) {
@@ -444,7 +446,8 @@ func TestConnectorRetriesUnreachable(t *testing.T) {
 
 	clock := hlc.NewClockWithSystemTimeSource(time.Nanosecond /* maxOffset */)
 	rpcContext := rpc.NewInsecureTestingContext(ctx, clock, stopper)
-	s := rpc.NewServer(rpcContext)
+	s, err := rpc.NewServer(rpcContext)
+	require.NoError(t, err)
 
 	node1 := &roachpb.NodeDescriptor{NodeID: 1, Address: util.MakeUnresolvedAddr("tcp", "1.1.1.1")}
 	node2 := &roachpb.NodeDescriptor{NodeID: 2, Address: util.MakeUnresolvedAddr("tcp", "2.2.2.2")}
@@ -539,7 +542,8 @@ func TestConnectorRetriesError(t *testing.T) {
 		gossipSubFn func(req *roachpb.GossipSubscriptionRequest, stream roachpb.Internal_GossipSubscriptionServer) error,
 		rangeLookupFn func(_ context.Context, req *roachpb.RangeLookupRequest) (*roachpb.RangeLookupResponse, error),
 	) string {
-		internalServer := rpc.NewServer(rpcContext)
+		internalServer, err := rpc.NewServer(rpcContext)
+		require.NoError(t, err)
 		roachpb.RegisterInternalServer(internalServer, &mockServer{rangeLookupFn: rangeLookupFn, gossipSubFn: gossipSubFn})
 		ln, err := net.Listen(util.TestAddr.Network(), util.TestAddr.String())
 		require.NoError(t, err)

--- a/pkg/ccl/kvccl/kvtenantccl/setting_overrides_test.go
+++ b/pkg/ccl/kvccl/kvtenantccl/setting_overrides_test.go
@@ -38,7 +38,8 @@ func TestConnectorSettingOverrides(t *testing.T) {
 	defer stopper.Stop(ctx)
 	clock := hlc.NewClockWithSystemTimeSource(time.Nanosecond /* maxOffset */)
 	rpcContext := rpc.NewInsecureTestingContext(ctx, clock, stopper)
-	s := rpc.NewServer(rpcContext)
+	s, err := rpc.NewServer(rpcContext)
+	require.NoError(t, err)
 
 	tenantID := roachpb.MustMakeTenantID(5)
 	gossipSubFn := func(req *roachpb.GossipSubscriptionRequest, stream roachpb.Internal_GossipSubscriptionServer) error {

--- a/pkg/gossip/BUILD.bazel
+++ b/pkg/gossip/BUILD.bazel
@@ -88,6 +88,7 @@ go_test(
         "//pkg/util/timeutil",
         "//pkg/util/uuid",
         "@com_github_cockroachdb_errors//:errors",
+        "@com_github_stretchr_testify//require",
         "@org_golang_google_grpc//:go_default_library",
     ],
 )

--- a/pkg/gossip/gossip_test.go
+++ b/pkg/gossip/gossip_test.go
@@ -35,6 +35,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 	"github.com/cockroachdb/errors"
+	"github.com/stretchr/testify/require"
 )
 
 // TestGossipInfoStore verifies operation of gossip instance infostore.
@@ -706,7 +707,8 @@ func TestGossipJoinTwoClusters(t *testing.T) {
 		clock := hlc.NewClockWithSystemTimeSource(time.Nanosecond /* maxOffset */)
 		rpcContext := rpc.NewInsecureTestingContextWithClusterID(ctx, clock, stopper, clusterID)
 
-		server := rpc.NewServer(rpcContext)
+		server, err := rpc.NewServer(rpcContext)
+		require.NoError(t, err)
 
 		// node ID must be non-zero
 		gnode := NewTest(roachpb.NodeID(i+1), stopper, metric.NewRegistry(), zonepb.DefaultZoneConfigRef())
@@ -717,9 +719,7 @@ func TestGossipJoinTwoClusters(t *testing.T) {
 		gnode.clusterID.Set(context.Background(), clusterIDs[i])
 
 		ln, err := netutil.ListenAndServeGRPC(stopper, server, util.IsolatedTestAddr)
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		addrs = append(addrs, ln.Addr())
 
 		// Only the third node has addresses.

--- a/pkg/gossip/simulation/network.go
+++ b/pkg/gossip/simulation/network.go
@@ -110,7 +110,10 @@ func NewNetwork(
 
 // CreateNode creates a simulation node and starts an RPC server for it.
 func (n *Network) CreateNode(defaultZoneConfig *zonepb.ZoneConfig) (*Node, error) {
-	server := rpc.NewServer(n.RPCContext)
+	server, err := rpc.NewServer(n.RPCContext)
+	if err != nil {
+		return nil, err
+	}
 	ln, err := net.Listen(util.IsolatedTestAddr.Network(), util.IsolatedTestAddr.String())
 	if err != nil {
 		return nil, err

--- a/pkg/kv/kvclient/kvcoord/send_test.go
+++ b/pkg/kv/kvclient/kvcoord/send_test.go
@@ -136,20 +136,17 @@ func TestSendToOneClient(t *testing.T) {
 	// checks to avoid log.Fatal.
 	rpcContext.TestingAllowNamedRPCToAnonymousServer = true
 
-	s := rpc.NewServer(rpcContext)
+	s, err := rpc.NewServer(rpcContext)
+	require.NoError(t, err)
 	roachpb.RegisterInternalServer(s, Node(0))
 	ln, err := netutil.ListenAndServeGRPC(rpcContext.Stopper, s, util.TestAddr)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	nodeDialer := nodedialer.New(rpcContext, func(roachpb.NodeID) (net.Addr, error) {
 		return ln.Addr(), nil
 	})
 
 	reply, err := sendBatch(ctx, t, nil, []net.Addr{ln.Addr()}, rpcContext, nodeDialer)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	if reply == nil {
 		t.Errorf("expected reply")
 	}

--- a/pkg/kv/kvserver/closedts/sidetransport/sender_test.go
+++ b/pkg/kv/kvserver/closedts/sidetransport/sender_test.go
@@ -336,7 +336,10 @@ func newMockSideTransportGRPCServerWithOpts(
 	}
 
 	clock := hlc.NewClockWithSystemTimeSource(time.Nanosecond /* maxOffset */)
-	grpcServer := rpc.NewServer(rpc.NewInsecureTestingContext(ctx, clock, stopper))
+	grpcServer, err := rpc.NewServer(rpc.NewInsecureTestingContext(ctx, clock, stopper))
+	if err != nil {
+		return nil, err
+	}
 	ctpb.RegisterSideTransportServer(grpcServer, receiver)
 	go func() {
 		_ /* err */ = grpcServer.Serve(lis)

--- a/pkg/kv/kvserver/raft_transport_test.go
+++ b/pkg/kv/kvserver/raft_transport_test.go
@@ -165,7 +165,8 @@ func (rttc *raftTransportTestContext) AddNode(nodeID roachpb.NodeID) *kvserver.R
 func (rttc *raftTransportTestContext) AddNodeWithoutGossip(
 	nodeID roachpb.NodeID, addr net.Addr, stopper *stop.Stopper,
 ) (*kvserver.RaftTransport, net.Addr) {
-	grpcServer := rpc.NewServer(rttc.nodeRPCContext)
+	grpcServer, err := rpc.NewServer(rttc.nodeRPCContext)
+	require.NoError(rttc.t, err)
 	ctwWithTracer := log.MakeTestingAmbientCtxWithNewTracer()
 	transport := kvserver.NewRaftTransport(
 		ctwWithTracer,
@@ -177,9 +178,7 @@ func (rttc *raftTransportTestContext) AddNodeWithoutGossip(
 	)
 	rttc.transports[nodeID] = transport
 	ln, err := netutil.ListenAndServeGRPC(stopper, grpcServer, addr)
-	if err != nil {
-		rttc.t.Fatal(err)
-	}
+	require.NoError(rttc.t, err)
 	return transport, ln.Addr()
 }
 

--- a/pkg/kv/kvserver/raft_transport_unit_test.go
+++ b/pkg/kv/kvserver/raft_transport_unit_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 	"github.com/cockroachdb/errors"
+	"github.com/stretchr/testify/require"
 )
 
 func TestRaftTransportStartNewQueue(t *testing.T) {
@@ -55,7 +56,8 @@ func TestRaftTransportStartNewQueue(t *testing.T) {
 
 	// mrs := &dummyMultiRaftServer{}
 
-	grpcServer := rpc.NewServer(rpcC)
+	grpcServer, err := rpc.NewServer(rpcC)
+	require.NoError(t, err)
 	// RegisterMultiRaftServer(grpcServer, mrs)
 
 	var addr net.Addr

--- a/pkg/kv/kvserver/store_test.go
+++ b/pkg/kv/kvserver/store_test.go
@@ -186,7 +186,8 @@ func createTestStoreWithoutStart(
 			Settings:  cfg.Settings,
 		})
 	stopper.SetTracer(cfg.AmbientCtx.Tracer)
-	server := rpc.NewServer(rpcContext) // never started
+	server, err := rpc.NewServer(rpcContext) // never started
+	require.NoError(t, err)
 
 	// Some tests inject their own Gossip and StorePool, via
 	// createTestAllocatorWithKnobs, at the time of writing

--- a/pkg/rpc/context_test.go
+++ b/pkg/rpc/context_test.go
@@ -491,7 +491,8 @@ func TestInternalClientAdapterRunsInterceptors(t *testing.T) {
 	serverCtx.Config.AdvertiseAddr = "127.0.0.1:8888"
 	serverCtx.NodeID.Set(context.Background(), 1)
 
-	_ /* server */, serverInterceptors := NewServerEx(serverCtx)
+	_ /* server */, serverInterceptors, err := NewServerEx(serverCtx)
+	require.NoError(t, err)
 
 	// Pile on one more interceptor to make sure it's called.
 	var serverUnaryInterceptor1Called, serverUnaryInterceptor2Called bool
@@ -592,7 +593,9 @@ func TestInternalClientAdapterWithClientStreamInterceptors(t *testing.T) {
 	serverCtx.Config.AdvertiseAddr = "127.0.0.1:8888"
 	serverCtx.NodeID.Set(context.Background(), 1)
 
-	_ /* server */, serverInterceptors := NewServerEx(serverCtx)
+	_ /* server */, serverInterceptors, err := NewServerEx(serverCtx)
+	require.NoError(t, err)
+
 	testutils.RunTrueAndFalse(t, "use_mux_rangefeed", func(t *testing.T, useMux bool) {
 		var clientInterceptors ClientInterceptorInfo
 		var s *testClientStream
@@ -667,7 +670,9 @@ func TestInternalClientAdapterWithServerStreamInterceptors(t *testing.T) {
 	serverCtx.Config.AdvertiseAddr = "127.0.0.1:8888"
 	serverCtx.NodeID.Set(context.Background(), 1)
 
-	_ /* server */, serverInterceptors := NewServerEx(serverCtx)
+	_ /* server */, serverInterceptors, err := NewServerEx(serverCtx)
+	require.NoError(t, err)
+
 	testutils.RunTrueAndFalse(t, "use_mux_rangefeed", func(t *testing.T, useMux bool) {
 		const int1Name = "interceptor 1"
 		serverInterceptors.StreamInterceptors = append(serverInterceptors.StreamInterceptors,
@@ -821,7 +826,9 @@ func BenchmarkInternalClientAdapter(b *testing.B) {
 	serverCtx.Config.AdvertiseAddr = "127.0.0.1:8888"
 	serverCtx.NodeID.Set(context.Background(), 1)
 
-	_, interceptors := NewServerEx(serverCtx)
+	_, interceptors, err := NewServerEx(serverCtx)
+	require.NoError(b, err)
+
 	internal := &internalServer{}
 	serverCtx.SetLocalInternalServer(
 		internal,
@@ -832,7 +839,7 @@ func BenchmarkInternalClientAdapter(b *testing.B) {
 	require.True(b, ok)
 	require.Equal(b, internal, lic.server)
 	ba := &roachpb.BatchRequest{}
-	_, err := lic.Batch(ctx, ba)
+	_, err = lic.Batch(ctx, ba)
 	require.NoError(b, err)
 
 	b.ReportAllocs()
@@ -2489,7 +2496,8 @@ func TestRejectDialOnQuiesce(t *testing.T) {
 		defer srvStopper.Stop(ctx)
 		serverCtx := newTestContext(clusID, clock, maxOffset, srvStopper)
 		serverCtx.NodeID.Set(ctx, serverNodeID)
-		s := NewServer(serverCtx)
+		s, err := NewServer(serverCtx)
+		require.NoError(t, err)
 		ln, err := netutil.ListenAndServeGRPC(srvStopper, s, util.TestAddr)
 		require.NoError(t, err)
 		addr = ln.Addr().String()

--- a/pkg/server/grpc_server.go
+++ b/pkg/server/grpc_server.go
@@ -30,16 +30,19 @@ type grpcServer struct {
 	mode                   serveMode
 }
 
-func newGRPCServer(rpcCtx *rpc.Context) *grpcServer {
+func newGRPCServer(rpcCtx *rpc.Context) (*grpcServer, error) {
 	s := &grpcServer{}
 	s.mode.set(modeInitializing)
-	srv, interceptorInfo := rpc.NewServerEx(
+	srv, interceptorInfo, err := rpc.NewServerEx(
 		rpcCtx, rpc.WithInterceptor(func(path string) error {
 			return s.intercept(path)
 		}))
+	if err != nil {
+		return nil, err
+	}
 	s.Server = srv
 	s.serverInterceptorsInfo = interceptorInfo
-	return s
+	return s, nil
 }
 
 type serveMode int32

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -340,7 +340,10 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 	// and after ValidateAddrs().
 	rpcContext.CheckCertificateAddrs(ctx)
 
-	grpcServer := newGRPCServer(rpcContext)
+	grpcServer, err := newGRPCServer(rpcContext)
+	if err != nil {
+		return nil, err
+	}
 	gossip.RegisterGossipServer(grpcServer.Server, g)
 
 	var dialerKnobs nodedialer.DialerTestingKnobs

--- a/pkg/server/tenant.go
+++ b/pkg/server/tenant.go
@@ -1002,7 +1002,10 @@ func makeTenantSQLServerArgs(
 	externalStorage := esb.makeExternalStorage
 	externalStorageFromURI := esb.makeExternalStorageFromURI
 
-	grpcServer := newGRPCServer(rpcContext)
+	grpcServer, err := newGRPCServer(rpcContext)
+	if err != nil {
+		return sqlServerArgs{}, err
+	}
 
 	sessionRegistry := sql.NewSessionRegistry()
 

--- a/pkg/sql/distsql/inbound_test.go
+++ b/pkg/sql/distsql/inbound_test.go
@@ -76,14 +76,13 @@ func TestOutboxInboundStreamIntegration(t *testing.T) {
 	// We're going to serve multiple node IDs with that one context. Disable node ID checks.
 	rpcContext.TestingAllowNamedRPCToAnonymousServer = true
 
-	rpcSrv := rpc.NewServer(rpcContext)
+	rpcSrv, err := rpc.NewServer(rpcContext)
+	require.NoError(t, err)
 	defer rpcSrv.Stop()
 
 	execinfrapb.RegisterDistSQLServer(rpcSrv, srv)
 	ln, err := netutil.ListenAndServeGRPC(stopper, rpcSrv, util.IsolatedTestAddr)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	// The outbox uses this stopper to run a goroutine.
 	outboxStopper := stop.NewStopper()

--- a/pkg/sql/execinfrapb/testutils.go
+++ b/pkg/sql/execinfrapb/testutils.go
@@ -53,7 +53,10 @@ func StartMockDistSQLServer(
 ) (uuid.UUID, *MockDistSQLServer, net.Addr, error) {
 	rpcContext := newInsecureRPCContext(ctx, stopper)
 	rpcContext.NodeID.Set(context.TODO(), roachpb.NodeID(sqlInstanceID))
-	server := rpc.NewServer(rpcContext)
+	server, err := rpc.NewServer(rpcContext)
+	if err != nil {
+		return uuid.Nil, nil, nil, err
+	}
 	mock := newMockDistSQLServer()
 	RegisterDistSQLServer(server, mock)
 	ln, err := netutil.ListenAndServeGRPC(stopper, server, util.IsolatedTestAddr)


### PR DESCRIPTION
Found while working on #96226.

Prior to this patch, the function `rpc.NewServerEx()` would panic if it was unable to loads its TLS settings. This is incorrect - we want to report a simple operational error in that case, since the problem is actionable.

The reason why this problem does not seem to directly impact production clusters is that there is another check in `server.NewServer()` that asserts the TLS settings are valid before constructing the rpc server.
This check was incomplete however, because there is a small race condition in between the two where the files could be removed after `server.NewServer()` finds them, and before `rpc.NewServer()` needs them.

We do not generally like `panic()` calls in production code, so this needed an improvement anyway.

Release note: None
Epic: CRDB-14537