### PR TITLE
server: properly initialize the cert manager in secondary tenants

### DIFF
--- a/pkg/security/certificate_manager.go
+++ b/pkg/security/certificate_manager.go
@@ -232,9 +232,10 @@ func (cm *CertificateManager) Metrics() CertificateMetrics {
 
 // RegisterSignalHandler registers a signal handler for SIGHUP, triggering a
 // refresh of the certificates directory on notification.
-func (cm *CertificateManager) RegisterSignalHandler(stopper *stop.Stopper) {
-	ctx := context.Background()
-	go func() {
+func (cm *CertificateManager) RegisterSignalHandler(
+	ctx context.Context, stopper *stop.Stopper,
+) error {
+	return stopper.RunAsyncTask(ctx, "refresh-certs", func(ctx context.Context) {
 		ch := sysutil.RefreshSignaledChan()
 		for {
 			select {
@@ -250,7 +251,7 @@ func (cm *CertificateManager) RegisterSignalHandler(stopper *stop.Stopper) {
 				}
 			}
 		}
-	}()
+	})
 }
 
 // CACert returns the CA cert. May be nil.

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -329,7 +329,7 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 		if err != nil {
 			return nil, err
 		}
-		cm.RegisterSignalHandler(stopper)
+		// Expose cert expirations in metrics.
 		registry.AddMetricStruct(cm.Metrics())
 	}
 
@@ -1220,6 +1220,18 @@ func (s *Server) PreStart(ctx context.Context) error {
 
 	// Start a context for the asynchronous network workers.
 	workersCtx := s.AnnotateCtx(context.Background())
+
+	if !s.cfg.Insecure {
+		cm, err := s.rpcContext.GetCertificateManager()
+		if err != nil {
+			return err
+		}
+		// Ensure that SIGHUP will make this cert manager reload its certs
+		// from disk.
+		if err := cm.RegisterSignalHandler(workersCtx, s.stopper); err != nil {
+			return err
+		}
+	}
 
 	// Start the time sanity checker.
 	s.startTime = timeutil.Now()

--- a/pkg/server/server_controller_new_server.go
+++ b/pkg/server/server_controller_new_server.go
@@ -291,8 +291,17 @@ func makeSharedProcessTenantServerConfig(
 	// See: https://github.com/cockroachdb/cockroach/issues/84585
 	baseCfg.SocketFile = ""
 
-	// TODO(knz): Make the TLS config separate per tenant.
-	// See https://cockroachlabs.atlassian.net/browse/CRDB-14539.
+	// Secondary tenant servers need access to the certs
+	// directory for two purposes:
+	// - to authenticate incoming RPC connections, until
+	//   this issue is resolved: https://github.com/cockroachdb/cockroach/issues/92524
+	// - to load client certs to present to the remote peer
+	//   on outgoing node-node connections.
+	//
+	// Regarding the second point, we currently still need a client
+	// tenant cert to be manually created. Error out if it's not ready.
+	// This check can go away when the following issue is resolved:
+	// https://github.com/cockroachdb/cockroach/issues/96215
 	baseCfg.SSLCertsDir = kvServerCfg.BaseConfig.SSLCertsDir
 	baseCfg.SSLCAKey = kvServerCfg.BaseConfig.SSLCAKey
 

--- a/pkg/server/tenant.go
+++ b/pkg/server/tenant.go
@@ -387,6 +387,18 @@ func (s *SQLServerWrapper) PreStart(ctx context.Context) error {
 	// Start a context for the asynchronous network workers.
 	workersCtx := s.AnnotateCtx(context.Background())
 
+	if !s.sqlServer.cfg.Insecure {
+		cm, err := s.rpcContext.GetCertificateManager()
+		if err != nil {
+			return err
+		}
+		// Ensure that SIGHUP will make this cert manager reload its certs
+		// from disk.
+		if err := cm.RegisterSignalHandler(workersCtx, s.stopper); err != nil {
+			return err
+		}
+	}
+
 	// If DisableHTTPListener is set, we are relying on the HTTP request
 	// routing performed by the serverController.
 	if !s.sqlServer.cfg.DisableHTTPListener {
@@ -823,6 +835,29 @@ func makeTenantSQLServerArgs(
 		Settings:         st,
 		Knobs:            rpcTestingKnobs,
 	})
+
+	if !baseCfg.Insecure {
+		// This check mirrors that done in NewServer().
+		// Needed for receiving RPC connections until
+		// this issue is fixed:
+		// https://github.com/cockroachdb/cockroach/issues/92524
+		if _, err := rpcContext.GetServerTLSConfig(); err != nil {
+			return sqlServerArgs{}, err
+		}
+		// Needed for outgoing connections, until this issue
+		// is fixed:
+		// https://github.com/cockroachdb/cockroach/issues/96215
+		if _, err := rpcContext.GetTenantTLSConfig(); err != nil {
+			return sqlServerArgs{}, err
+		}
+		cm, err := rpcContext.GetCertificateManager()
+		if err != nil {
+			return sqlServerArgs{}, err
+		}
+		// Expose cert expirations in metrics.
+		registry.AddMetricStruct(cm.Metrics())
+	}
+
 	registry.AddMetricStruct(rpcContext.Metrics())
 	registry.AddMetricStruct(rpcContext.RemoteClocks.Metrics())
 


### PR DESCRIPTION
First commit from #96222.
Epic: CRDB-14537.
Fixes #96226.
Fixes #94920.

Prior to this patch, the cert manager initialization was incomplete in
servers for secondary tenants, in two ways:

- it did not properly register its metrics.
- it did not properly listen to the SIGHUP signal for cert rotation.

Additionally, there was a bug whereby a missing tenant client cert
could cause a crash of the process. This is now averted by proper
error checking.
(A more general fix requires a larger refactor and will be performed
in https://github.com/cockroachdb/cockroach/pull/96233.)