### PR TITLE
storage: fix bug in legacySSTIterator.SeekGE

### DIFF
--- a/pkg/storage/sst_iterator.go
+++ b/pkg/storage/sst_iterator.go
@@ -62,7 +62,9 @@ type legacySSTIterator struct {
 	sst  *sstable.Reader
 	iter sstable.Iterator
 
-	mvccKey   MVCCKey
+	// Unstable key.
+	mvccKey MVCCKey
+	// Unstable value.
 	value     []byte
 	iterValid bool
 	err       error
@@ -151,8 +153,8 @@ func (r *legacySSTIterator) SeekGE(key MVCCKey) {
 	if r.iterValid && r.err == nil && r.verify && r.mvccKey.IsValue() {
 		r.verifyValue()
 	}
-	r.prevSeekKey.Key = append(r.prevSeekKey.Key[:0], r.mvccKey.Key...)
-	r.prevSeekKey.Timestamp = r.mvccKey.Timestamp
+	r.prevSeekKey.Key = append(r.prevSeekKey.Key[:0], key.Key...)
+	r.prevSeekKey.Timestamp = key.Timestamp
 	r.seekGELastOp = true
 }
 


### PR DESCRIPTION
The optimization to do trySeekUsingNext was incorrectly setting the prevSeekKey using an old unstable key. This causes TestLegacySSTIterator to fail consistently on my machine.

The legacySSTIterator is not used in v22.2, but the same bug also exists in v22.1. This is likely not a correctness bug in v22.1 since callers seek to monotonically increasing keys.

Epic: none

Release note: None