### PR TITLE
sql: use RLock in connExecutor.CancelQuery and connExecutor.CancelActiveQueries

### DIFF
--- a/pkg/server/status.go
+++ b/pkg/server/status.go
@@ -3056,7 +3056,7 @@ func (s *statusServer) CancelSession(
 		}, nil
 	}
 
-	if err := s.checkCancelPrivilege(ctx, reqUsername, session.BaseSessionUser()); err != nil {
+	if err := s.checkCancelPrivilege(ctx, reqUsername, session.SessionUser()); err != nil {
 		// NB: not using serverError() here since the priv checker
 		// already returns a proper gRPC error status.
 		return nil, err
@@ -3109,7 +3109,7 @@ func (s *statusServer) CancelQuery(
 		}, nil
 	}
 
-	if err := s.checkCancelPrivilege(ctx, reqUsername, session.BaseSessionUser()); err != nil {
+	if err := s.checkCancelPrivilege(ctx, reqUsername, session.SessionUser()); err != nil {
 		// NB: not using serverError() here since the priv checker
 		// already returns a proper gRPC error status.
 		return nil, err

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -2034,12 +2034,6 @@ type queryMeta struct {
 	database string
 }
 
-// cancel cancels the query associated with this queryMeta, by closing the
-// associated stmt context.
-func (q *queryMeta) cancel() {
-	q.cancelQuery()
-}
-
 // SessionDefaults mirrors fields in Session, for restoring default
 // configuration values in SET ... TO DEFAULT (or RESET ...) statements.
 type SessionDefaults map[string]string
@@ -2138,9 +2132,8 @@ func (r *SessionRegistry) deregister(
 }
 
 type RegistrySession interface {
-	user() username.SQLUsername
-	// BaseSessionUser returns the base session's username.
-	BaseSessionUser() username.SQLUsername
+	// SessionUser returns the session user's username.
+	SessionUser() username.SQLUsername
 	hasQuery(queryID clusterunique.ID) bool
 	// CancelQuery cancels the query specified by queryID if it exists.
 	CancelQuery(queryID clusterunique.ID) bool


### PR DESCRIPTION
Fixes #95994

`connExecutor.CancelQuery` and `connExecutor.CancelActiveQueries` do not modify `mu.ActiveQueries` or the `*queryMetas` inside so they can safely use `RLock` instead of `Lock`.

Release note: None