### PR TITLE
sql/physicalplan: allow passing replica oracle to planning

### DIFF
--- a/pkg/sql/BUILD.bazel
+++ b/pkg/sql/BUILD.bazel
@@ -751,6 +751,7 @@ go_test(
         "//pkg/sql/pgwire/pgerror",
         "//pkg/sql/pgwire/pgwirebase",
         "//pkg/sql/physicalplan",
+        "//pkg/sql/physicalplan/replicaoracle",
         "//pkg/sql/privilege",
         "//pkg/sql/querycache",
         "//pkg/sql/randgen",

--- a/pkg/sql/backfill.go
+++ b/pkg/sql/backfill.go
@@ -36,6 +36,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/isql"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
+	"github.com/cockroachdb/cockroach/pkg/sql/physicalplan"
 	"github.com/cockroachdb/cockroach/pkg/sql/row"
 	"github.com/cockroachdb/cockroach/pkg/sql/rowexec"
 	"github.com/cockroachdb/cockroach/pkg/sql/rowinfra"
@@ -848,7 +849,7 @@ func NumRangesInSpans(
 	ctx context.Context, db *kv.DB, distSQLPlanner *DistSQLPlanner, spans []roachpb.Span,
 ) (int, error) {
 	txn := db.NewTxn(ctx, "num-ranges-in-spans")
-	spanResolver := distSQLPlanner.spanResolver.NewSpanResolverIterator(txn)
+	spanResolver := distSQLPlanner.spanResolver.NewSpanResolverIterator(txn, physicalplan.DefaultReplicaChooser)
 	rangeIds := make(map[int64]struct{})
 	for _, span := range spans {
 		// For each span, iterate the spanResolver until it's exhausted, storing
@@ -882,7 +883,7 @@ func NumRangesInSpanContainedBy(
 	containedBy []roachpb.Span,
 ) (total, inContainedBy int, _ error) {
 	txn := db.NewTxn(ctx, "num-ranges-in-spans")
-	spanResolver := distSQLPlanner.spanResolver.NewSpanResolverIterator(txn)
+	spanResolver := distSQLPlanner.spanResolver.NewSpanResolverIterator(txn, physicalplan.DefaultReplicaChooser)
 	// For each span, iterate the spanResolver until it's exhausted, storing
 	// the found range ids in the map to de-duplicate them.
 	spanResolver.Seek(ctx, outerSpan, kvcoord.Ascending)

--- a/pkg/sql/distsql_physical_planner.go
+++ b/pkg/sql/distsql_physical_planner.go
@@ -4386,6 +4386,19 @@ func (dsp *DistSQLPlanner) NewPlanningCtx(
 	txn *kv.Txn,
 	distributionType DistributionType,
 ) *PlanningCtx {
+	return dsp.NewPlanningCtxWithOracle(ctx, evalCtx, planner, txn, distributionType, physicalplan.DefaultReplicaChooser)
+}
+
+// NewPlanningCtxWithOracle is a variant of NewPlanningCtx that allows passing a
+// replica choice oracle as well.
+func (dsp *DistSQLPlanner) NewPlanningCtxWithOracle(
+	ctx context.Context,
+	evalCtx *extendedEvalContext,
+	planner *planner,
+	txn *kv.Txn,
+	distributionType DistributionType,
+	oracle replicaoracle.Oracle,
+) *PlanningCtx {
 	distribute := distributionType == DistributionTypeAlways || (distributionType == DistributionTypeSystemTenantOnly && evalCtx.Codec.ForSystemTenant())
 	infra := physicalplan.NewPhysicalInfrastructure(uuid.FastMakeV4(), dsp.gatewaySQLInstanceID)
 	planCtx := &PlanningCtx{
@@ -4419,7 +4432,7 @@ func (dsp *DistSQLPlanner) NewPlanningCtx(
 		// we still need to instantiate a full planning context.
 		planCtx.parallelizeScansIfLocal = true
 	}
-	planCtx.spanIter = dsp.spanResolver.NewSpanResolverIterator(txn)
+	planCtx.spanIter = dsp.spanResolver.NewSpanResolverIterator(txn, oracle)
 	planCtx.nodeStatuses = make(map[base.SQLInstanceID]NodeStatus)
 	planCtx.nodeStatuses[dsp.gatewaySQLInstanceID] = NodeOK
 	return planCtx

--- a/pkg/sql/distsql_physical_planner_test.go
+++ b/pkg/sql/distsql_physical_planner_test.go
@@ -40,6 +40,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/physicalplan"
+	"github.com/cockroachdb/cockroach/pkg/sql/physicalplan/replicaoracle"
 	"github.com/cockroachdb/cockroach/pkg/sql/randgen"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/eval"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
@@ -577,7 +578,9 @@ type testSpanResolver struct {
 }
 
 // NewSpanResolverIterator is part of the SpanResolver interface.
-func (tsr *testSpanResolver) NewSpanResolverIterator(_ *kv.Txn) physicalplan.SpanResolverIterator {
+func (tsr *testSpanResolver) NewSpanResolverIterator(
+	txn *kv.Txn, optionalOracle replicaoracle.Oracle,
+) physicalplan.SpanResolverIterator {
 	return &testSpanResolverIterator{tsr: tsr}
 }
 

--- a/pkg/sql/physicalplan/fake_span_resolver.go
+++ b/pkg/sql/physicalplan/fake_span_resolver.go
@@ -19,6 +19,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvclient/kvcoord"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/physicalplan/replicaoracle"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
 )
@@ -65,7 +66,9 @@ type fakeSpanResolverIterator struct {
 }
 
 // NewSpanResolverIterator is part of the SpanResolver interface.
-func (fsr *fakeSpanResolver) NewSpanResolverIterator(txn *kv.Txn) SpanResolverIterator {
+func (fsr *fakeSpanResolver) NewSpanResolverIterator(
+	txn *kv.Txn, optionalOracle replicaoracle.Oracle,
+) SpanResolverIterator {
 	rng, _ := randutil.NewTestRand()
 	return &fakeSpanResolverIterator{fsr: fsr, db: txn.DB(), rng: rng}
 }

--- a/pkg/sql/physicalplan/fake_span_resolver_test.go
+++ b/pkg/sql/physicalplan/fake_span_resolver_test.go
@@ -54,7 +54,7 @@ func TestFakeSpanResolver(t *testing.T) {
 	db := tc.Server(0).DB()
 
 	txn := kv.NewTxn(ctx, db, tc.Server(0).NodeID())
-	it := resolver.NewSpanResolverIterator(txn)
+	it := resolver.NewSpanResolverIterator(txn, nil)
 
 	tableDesc := desctestutils.TestingGetPublicTableDescriptor(db, keys.SystemSQLCodec, "test", "t")
 	primIdxValDirs := catalogkeys.IndexKeyValDirs(tableDesc.GetPrimaryIndex())

--- a/pkg/sql/physicalplan/replicaoracle/oracle_test.go
+++ b/pkg/sql/physicalplan/replicaoracle/oracle_test.go
@@ -41,7 +41,7 @@ func TestClosest(t *testing.T) {
 		ctx := context.Background()
 		stopper := stop.NewStopper()
 		defer stopper.Stop(ctx)
-		g, _ := makeGossip(t, stopper)
+		g, _ := makeGossip(t, stopper, []int{2, 3})
 		nd2, err := g.GetNodeDescriptor(2)
 		require.NoError(t, err)
 		o := NewOracle(ClosestChoice, Config{
@@ -82,7 +82,7 @@ func TestClosest(t *testing.T) {
 	})
 }
 
-func makeGossip(t *testing.T, stopper *stop.Stopper) (*gossip.Gossip, *hlc.Clock) {
+func makeGossip(t *testing.T, stopper *stop.Stopper, nodeIDs []int) (*gossip.Gossip, *hlc.Clock) {
 	clock := hlc.NewClockWithSystemTimeSource(time.Nanosecond /* maxOffset */)
 
 	const nodeID = 1
@@ -93,7 +93,8 @@ func makeGossip(t *testing.T, stopper *stop.Stopper) (*gossip.Gossip, *hlc.Clock
 	if err := g.AddInfo(gossip.KeySentinel, nil, time.Hour); err != nil {
 		t.Fatal(err)
 	}
-	for i := roachpb.NodeID(2); i <= 3; i++ {
+	for _, id := range nodeIDs {
+		i := roachpb.NodeID(id)
 		err := g.AddInfoProto(gossip.MakeNodeIDKey(i), newNodeDesc(i), gossip.NodeDescriptorTTL)
 		if err != nil {
 			t.Fatal(err)
@@ -114,5 +115,50 @@ func newNodeDesc(nodeID roachpb.NodeID) *roachpb.NodeDescriptor {
 				},
 			},
 		},
+	}
+}
+
+func TestPreferFollower(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	ctx := context.Background()
+	stopper := stop.NewStopper()
+	defer stopper.Stop(ctx)
+	g, _ := makeGossip(t, stopper, []int{2, 3, 4, 5, 6})
+	o := NewOracle(PreferFollowerChoice, Config{
+		NodeDescs: g,
+	})
+	internalReplicas := []roachpb.ReplicaDescriptor{
+		{ReplicaID: 2, NodeID: 2, StoreID: 2, Type: roachpb.VOTER_FULL},
+		{ReplicaID: 3, NodeID: 3, StoreID: 3, Type: roachpb.VOTER_FULL},
+		{ReplicaID: 4, NodeID: 4, StoreID: 4, Type: roachpb.VOTER_FULL},
+		{ReplicaID: 5, NodeID: 5, StoreID: 5, Type: roachpb.NON_VOTER},
+		{ReplicaID: 6, NodeID: 6, StoreID: 6, Type: roachpb.NON_VOTER},
+	}
+	rand.Shuffle(len(internalReplicas), func(i, j int) {
+		internalReplicas[i], internalReplicas[j] = internalReplicas[j], internalReplicas[i]
+	})
+	info, err := o.ChoosePreferredReplica(
+		ctx,
+		nil, /* txn */
+		&roachpb.RangeDescriptor{
+			InternalReplicas: internalReplicas,
+		},
+		nil, /* leaseHolder */
+		roachpb.LAG_BY_CLUSTER_SETTING,
+		QueryState{},
+	)
+	if err != nil {
+		t.Fatalf("Failed to choose follower replica: %v", err)
+	}
+
+	fullVoters := make(map[roachpb.NodeID]bool)
+	for _, r := range internalReplicas {
+		if r.Type == roachpb.VOTER_FULL {
+			fullVoters[r.NodeID] = true
+		}
+	}
+
+	if fullVoters[info.NodeID] {
+		t.Fatalf("Chose a VOTER_FULL replica: %d", info.NodeID)
 	}
 }

--- a/pkg/sql/physicalplan/span_resolver_test.go
+++ b/pkg/sql/physicalplan/span_resolver_test.go
@@ -111,7 +111,7 @@ func TestSpanResolverUsesCaches(t *testing.T) {
 
 	// Resolve the spans. Since the range descriptor cache doesn't have any
 	// leases, all the ranges should be grouped and "assigned" to replica 0.
-	replicas, err := resolveSpans(context.Background(), lr.NewSpanResolverIterator(nil), spans...)
+	replicas, err := resolveSpans(context.Background(), lr.NewSpanResolverIterator(nil, nil), spans...)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -138,7 +138,7 @@ func TestSpanResolverUsesCaches(t *testing.T) {
 	if err := populateCache(tc.Conns[3], 3 /* expectedNumRows */); err != nil {
 		t.Fatal(err)
 	}
-	replicas, err = resolveSpans(context.Background(), lr.NewSpanResolverIterator(nil), spans...)
+	replicas, err = resolveSpans(context.Background(), lr.NewSpanResolverIterator(nil, nil), spans...)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -209,7 +209,7 @@ func TestSpanResolver(t *testing.T) {
 		replicaoracle.BinPackingChoice)
 
 	ctx := context.Background()
-	it := lr.NewSpanResolverIterator(nil)
+	it := lr.NewSpanResolverIterator(nil, nil)
 
 	testCases := []struct {
 		spans    []roachpb.Span
@@ -308,7 +308,7 @@ func TestMixedDirections(t *testing.T) {
 		replicaoracle.BinPackingChoice)
 
 	ctx := context.Background()
-	it := lr.NewSpanResolverIterator(nil)
+	it := lr.NewSpanResolverIterator(nil, nil)
 
 	spans := []spanWithDir{
 		orient(kvcoord.Ascending, makeSpan(tableDesc, 11, 15))[0],


### PR DESCRIPTION
This PR pulls out a subset of the changes in #93810, namely allowing a replica-choice oracle to be passed on a per-plan basis, but without changing which oracle is actually used in any existing planning, and only introducing the API for future users. 

This refactors span resolver and the physical planning methods to allow passing a replica-choice oracle per planning instead of using a fixed oracle (either bin-packing or closest depending on server type). The existing API that uses the default oracle is kept as is for all existing callers, while a new WithOracle variant is added for future callers who wish to pass their own oracle.

An new oracle that prefers followers over leaseholders is also added here, however it is not used at this time.

Release note: none.
Epic: none.