### PR TITLE
backupccl,changefeedccl: properly display name if resource exists

### DIFF
--- a/pkg/ccl/backupccl/create_scheduled_backup.go
+++ b/pkg/ccl/backupccl/create_scheduled_backup.go
@@ -166,7 +166,7 @@ func doCreateBackupSchedules(
 
 		if exists {
 			p.BufferClientNotice(ctx,
-				pgnotice.Newf("schedule %q already exists, skipping", eval.scheduleLabel),
+				pgnotice.Newf("schedule %q already exists, skipping", *eval.scheduleLabel),
 			)
 			return nil
 		}

--- a/pkg/ccl/changefeedccl/scheduled_changefeed.go
+++ b/pkg/ccl/changefeedccl/scheduled_changefeed.go
@@ -562,7 +562,7 @@ func doCreateChangefeedSchedule(
 
 			if exists {
 				p.BufferClientNotice(ctx,
-					pgnotice.Newf("schedule %q already exists, skipping", spec.scheduleLabel),
+					pgnotice.Newf("schedule %q already exists, skipping", *spec.scheduleLabel),
 				)
 				return nil
 			}


### PR DESCRIPTION
Previously, we were passing a `*string` to a string formatting function (`pgnotice.Newf`) with the `%q` verb. This leads to messages being displayed to the user that look like:

```
NOTICE: schedule %!q(*string=0xc006b324e0) already exists, skipping
```

This properly dereferences the pointer before printing.

Epic: none

Release note: None