### PR TITLE
sql/schemachanger: forward fit compatibility changes for 22.2 rules

### DIFF
--- a/pkg/sql/schemachanger/scplan/internal/rules/release_22_2/dep_add_column.go
+++ b/pkg/sql/schemachanger/scplan/internal/rules/release_22_2/dep_add_column.go
@@ -98,17 +98,6 @@ func init() {
 			status := rel.Var("status")
 			return rel.Clauses{
 				from.Type((*scpb.Column)(nil)),
-				// Join first on the target and node to only explore all columns
-				// which are being added as opposed to all columns. If we joined
-				// first on the columns, we'd be filtering the cross product of
-				// table columns. If a relation has a lot of columns, this can hurt.
-				// It's less likely that we have a very large number of columns which
-				// are being added. We'll want to do something else here when we start
-				// creating tables and all the columns are being added.
-				//
-				// The "right" answer is to push ordering predicates into rel; it also
-				// is maintaining sorted data structures.
-				from.JoinTargetNode(),
 				to.Type((*scpb.Column)(nil)),
 				JoinOnDescID(from, to, "table-id"),
 				ToPublicOrTransient(from, to),

--- a/pkg/sql/schemachanger/scplan/internal/rules/release_22_2/dep_drop_column.go
+++ b/pkg/sql/schemachanger/scplan/internal/rules/release_22_2/dep_drop_column.go
@@ -83,7 +83,7 @@ func init() {
 	// which also hold references to other descriptors. The rule prior to this one
 	// ensures that they transition to ABSENT before scpb.ColumnType does.
 	registerDepRule(
-		"column type removed right before column when rules.Not dropping relation",
+		"column type removed right before column when not dropping relation",
 		scgraph.SameStagePrecedence,
 		"column-type", "column",
 		func(from, to NodeVars) rel.Clauses {

--- a/pkg/sql/schemachanger/scplan/internal/rules/release_22_2/dep_drop_constraint.go
+++ b/pkg/sql/schemachanger/scplan/internal/rules/release_22_2/dep_drop_constraint.go
@@ -23,7 +23,7 @@ func init() {
 
 	registerDepRuleForDrop(
 		"constraint dependent absent right before constraint",
-		scgraph.Precedence,
+		scgraph.SameStagePrecedence,
 		"dependent", "constraint",
 		scpb.Status_ABSENT, scpb.Status_ABSENT,
 		func(from, to NodeVars) rel.Clauses {

--- a/pkg/sql/schemachanger/scplan/internal/rules/release_22_2/dep_drop_index.go
+++ b/pkg/sql/schemachanger/scplan/internal/rules/release_22_2/dep_drop_index.go
@@ -91,7 +91,7 @@ func init() {
 	// should be able to express the _absence_ of a target element as a query
 	// clause.
 	registerDepRuleForDrop(
-		"partial predicate removed right before secondary index when rules.Not dropping relation",
+		"partial predicate removed right before secondary index when not dropping relation",
 		scgraph.SameStagePrecedence,
 		"partial-predicate", "index",
 		scpb.Status_ABSENT, scpb.Status_ABSENT,

--- a/pkg/sql/schemachanger/scplan/internal/rules/release_22_2/helpers.go
+++ b/pkg/sql/schemachanger/scplan/internal/rules/release_22_2/helpers.go
@@ -55,6 +55,12 @@ func isDescriptor(e scpb.Element) bool {
 	return false
 }
 
+// IsDescriptor returns true for a descriptor-element, i.e. an element which
+// owns its corresponding descriptor. This is only used for exports
+func IsDescriptor(e scpb.Element) bool {
+	return isDescriptor(e)
+}
+
 func isSubjectTo2VersionInvariant(e scpb.Element) bool {
 	// TODO(ajwerner): This should include constraints and enum values but it
 	// currently does not because we do not support dropping them unless we're
@@ -62,6 +68,7 @@ func isSubjectTo2VersionInvariant(e scpb.Element) bool {
 	return IsIndex(e) || isColumn(e)
 }
 
+// IsIndex returns if an element is an index type.
 func IsIndex(e scpb.Element) bool {
 	switch e.(type) {
 	case *scpb.PrimaryIndex, *scpb.SecondaryIndex, *scpb.TemporaryIndex:

--- a/pkg/sql/schemachanger/scplan/internal/rules/release_22_2/op_drop.go
+++ b/pkg/sql/schemachanger/scplan/internal/rules/release_22_2/op_drop.go
@@ -169,8 +169,6 @@ func init() {
 				(*scpb.View)(nil),
 			),
 			constraint.Type(
-				(*scpb.CheckConstraint)(nil),
-				(*scpb.ForeignKeyConstraint)(nil),
 				(*scpb.UniqueWithoutIndexConstraint)(nil),
 			),
 

--- a/pkg/sql/schemachanger/scplan/internal/rules/release_22_2/testdata/deprules
+++ b/pkg/sql/schemachanger/scplan/internal/rules/release_22_2/testdata/deprules
@@ -1395,7 +1395,7 @@ deprules
     - $column-type-Node[CurrentStatus] = ABSENT
     - joinTargetNode($dependent, $dependent-Target, $dependent-Node)
     - joinTargetNode($column-type, $column-type-Target, $column-type-Node)
-- name: column type removed right before column when rules.Not dropping relation
+- name: column type removed right before column when not dropping relation
   from: column-type-Node
   kind: SameStagePrecedence
   to: column-Node
@@ -1411,7 +1411,7 @@ deprules
     - joinTargetNode($column, $column-Target, $column-Node)
 - name: constraint dependent absent right before constraint
   from: dependent-Node
-  kind: Precedence
+  kind: SameStagePrecedence
   to: constraint-Node
   query:
     - $dependent[Type] IN ['*scpb.ConstraintWithoutIndexName', '*scpb.ConstraintComment']
@@ -1424,7 +1424,7 @@ deprules
     - joinTargetNode($constraint, $constraint-Target, $constraint-Node)
 - name: constraint dependent absent right before constraint
   from: dependent-Node
-  kind: Precedence
+  kind: SameStagePrecedence
   to: constraint-Node
   query:
     - $dependent[Type] IN ['*scpb.ConstraintWithoutIndexName', '*scpb.ConstraintComment']
@@ -1437,7 +1437,7 @@ deprules
     - joinTargetNode($constraint, $constraint-Target, $constraint-Node)
 - name: constraint dependent absent right before constraint
   from: dependent-Node
-  kind: Precedence
+  kind: SameStagePrecedence
   to: constraint-Node
   query:
     - $dependent[Type] IN ['*scpb.ConstraintWithoutIndexName', '*scpb.ConstraintComment']
@@ -1451,7 +1451,7 @@ deprules
     - joinTargetNode($constraint, $constraint-Target, $constraint-Node)
 - name: constraint dependent absent right before constraint
   from: dependent-Node
-  kind: Precedence
+  kind: SameStagePrecedence
   to: constraint-Node
   query:
     - $dependent[Type] IN ['*scpb.ConstraintWithoutIndexName', '*scpb.ConstraintComment']
@@ -1740,7 +1740,6 @@ deprules
   to: earlier-column-Node
   query:
     - $later-column[Type] = '*scpb.Column'
-    - joinTargetNode($later-column, $later-column-Target, $later-column-Node)
     - $earlier-column[Type] = '*scpb.Column'
     - joinOnDescID($later-column, $earlier-column, $table-id)
     - ToPublicOrTransient($later-column-Target, $earlier-column-Target)
@@ -1951,7 +1950,7 @@ deprules
     - $new-primary-index-Node[CurrentStatus] = PUBLIC
     - joinTargetNode($old-primary-index, $old-primary-index-Target, $old-primary-index-Node)
     - joinTargetNode($new-primary-index, $new-primary-index-Target, $new-primary-index-Node)
-- name: partial predicate removed right before secondary index when rules.Not dropping relation
+- name: partial predicate removed right before secondary index when not dropping relation
   from: partial-predicate-Node
   kind: SameStagePrecedence
   to: index-Node
@@ -1965,7 +1964,7 @@ deprules
     - $index-Node[CurrentStatus] = ABSENT
     - joinTargetNode($partial-predicate, $partial-predicate-Target, $partial-predicate-Node)
     - joinTargetNode($index, $index-Target, $index-Node)
-- name: partial predicate removed right before secondary index when rules.Not dropping relation
+- name: partial predicate removed right before secondary index when not dropping relation
   from: partial-predicate-Node
   kind: SameStagePrecedence
   to: index-Node
@@ -1979,7 +1978,7 @@ deprules
     - $index-Node[CurrentStatus] = TRANSIENT_ABSENT
     - joinTargetNode($partial-predicate, $partial-predicate-Target, $partial-predicate-Node)
     - joinTargetNode($index, $index-Target, $index-Node)
-- name: partial predicate removed right before secondary index when rules.Not dropping relation
+- name: partial predicate removed right before secondary index when not dropping relation
   from: partial-predicate-Node
   kind: SameStagePrecedence
   to: index-Node
@@ -1994,7 +1993,7 @@ deprules
     - $index-Node[CurrentStatus] = ABSENT
     - joinTargetNode($partial-predicate, $partial-predicate-Target, $partial-predicate-Node)
     - joinTargetNode($index, $index-Target, $index-Node)
-- name: partial predicate removed right before secondary index when rules.Not dropping relation
+- name: partial predicate removed right before secondary index when not dropping relation
   from: partial-predicate-Node
   kind: SameStagePrecedence
   to: index-Node

--- a/pkg/sql/schemachanger/scplan/internal/rules/release_22_2/testdata/oprules
+++ b/pkg/sql/schemachanger/scplan/internal/rules/release_22_2/testdata/oprules
@@ -149,7 +149,7 @@ oprules
   from: constraint-Node
   query:
     - $relation[Type] IN ['*scpb.Table', '*scpb.View']
-    - $constraint[Type] IN ['*scpb.CheckConstraint', '*scpb.ForeignKeyConstraint', '*scpb.UniqueWithoutIndexConstraint']
+    - $constraint[Type] = '*scpb.UniqueWithoutIndexConstraint'
     - joinOnDescID($relation, $constraint, $relation-id)
     - joinTarget($relation, $relation-Target)
     - $relation-Target[TargetStatus] = ABSENT


### PR DESCRIPTION
Informs: #95849

Previously, some constraint-related rules in the 22.2 set incorrectly used logic for 23.X. This patch addresses those to get compatibility back. Additionally, some minor clean-up in rules-related helpers to ensure proper compatibility.

With this change, a manual diff shows both branches are now equal in terms of rules (outside of renames). A roachtest will be coming soon to assert this.

Epic: none
Release note: None