### PR TITLE
ui: add CPU column on Insights

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/api/stmtInsightsApi.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/api/stmtInsightsApi.ts
@@ -67,6 +67,7 @@ export type StmtInsightsResponseRow = {
   problem: string;
   index_recommendations: string[];
   plan_gist: string;
+  cpu_sql_nanos: number;
 };
 
 const stmtColumns = `
@@ -94,7 +95,8 @@ last_retry_reason,
 causes,
 problem,
 index_recommendations,
-plan_gist
+plan_gist,
+cpu_sql_nanos
 `;
 
 const stmtInsightsOverviewQuery = (filters?: StmtInsightsReq): string => {
@@ -206,6 +208,7 @@ export function formatStmtInsights(
         InsightExecEnum.STATEMENT,
       ),
       planGist: row.plan_gist,
+      cpuSQLNanos: row.cpu_sql_nanos,
     } as StmtInsightEvent;
   });
 }

--- a/pkg/ui/workspaces/cluster-ui/src/api/txnInsightsApi.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/api/txnInsightsApi.ts
@@ -410,6 +410,7 @@ type TxnInsightsResponseRow = {
   problems: string[];
   causes: string[];
   stmt_execution_ids: string[];
+  cpu_sql_nanos: number;
 };
 
 type TxnQueryFilters = {
@@ -441,7 +442,8 @@ contention,
 last_retry_reason,
 problems,
 causes,
-stmt_execution_ids`;
+stmt_execution_ids,
+cpu_sql_nanos`;
 
   if (filters?.execID) {
     return `
@@ -503,6 +505,7 @@ function formatTxnInsightsRow(row: TxnInsightsResponseRow): TxnInsightEvent {
     contentionTime: moment.duration(row.contention ?? 0),
     insights,
     stmtExecutionIDs: row.stmt_execution_ids,
+    cpuSQLNanos: row.cpu_sql_nanos,
   };
 }
 

--- a/pkg/ui/workspaces/cluster-ui/src/insights/types.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/types.ts
@@ -28,23 +28,24 @@ export enum InsightExecEnum {
 
 // Common fields for both txn and stmt insights.
 export type InsightEventBase = {
-  transactionExecutionID: string;
-  transactionFingerprintID: string;
+  application: string;
+  contentionTime?: moment.Duration;
+  cpuSQLNanos: number;
+  elapsedTimeMillis: number;
+  endTime: Moment;
   implicitTxn: boolean;
-  sessionID: string;
-  username: string;
+  insights: Insight[];
   lastRetryReason?: string;
   priority: string;
+  query: string;
   retries: number;
-  application: string;
   rowsRead: number;
   rowsWritten: number;
+  sessionID: string;
   startTime: Moment;
-  endTime: Moment;
-  elapsedTimeMillis: number;
-  query: string;
-  contentionTime?: moment.Duration;
-  insights: Insight[];
+  transactionExecutionID: string;
+  transactionFingerprintID: string;
+  username: string;
 };
 
 export type TxnInsightEvent = InsightEventBase & {

--- a/pkg/ui/workspaces/cluster-ui/src/insights/utils.spec.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/utils.spec.ts
@@ -71,6 +71,7 @@ const statementInsightMock: StmtInsightEvent = {
   insights: [failedExecutionInsight(InsightExecEnum.STATEMENT)],
   indexRecommendations: [],
   planGist: "gist",
+  cpuSQLNanos: 50,
 };
 
 function mockStmtInsightEvent(
@@ -110,6 +111,7 @@ const txnInsightEventMock: TxnInsightEvent = {
   endTime: moment(),
   elapsedTimeMillis: 1,
   stmtExecutionIDs: [statementInsightMock.statementExecutionID],
+  cpuSQLNanos: 50,
 };
 
 function mockTxnInsightEvent(

--- a/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsightDetails/statementInsightDetailsOverviewTab.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsightDetails/statementInsightDetailsOverviewTab.tsx
@@ -118,6 +118,10 @@ export const StatementInsightDetailsOverviewTab: React.FC<
               value={Duration(insightDetails.elapsedTimeMillis * 1e6)}
             />
             <SummaryCardItem
+              label={"CPU Time"}
+              value={Duration(insightDetails.cpuSQLNanos)}
+            />
+            <SummaryCardItem
               label="Rows Read"
               value={Count(insightDetails.rowsRead)}
             />

--- a/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsightDetails/transactionInsightDetailsOverviewTab.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsightDetails/transactionInsightDetailsOverviewTab.tsx
@@ -140,6 +140,10 @@ export const TransactionInsightDetailsOverviewTab: React.FC<Props> = ({
                       value={Duration(txnDetails.elapsedTimeMillis * 1e6)}
                     />
                     <SummaryCardItem
+                      label="CPU Time"
+                      value={Duration(txnDetails.cpuSQLNanos)}
+                    />
+                    <SummaryCardItem
                       label="Rows Read"
                       value={Count(txnDetails.rowsRead)}
                     />

--- a/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsights/statementInsights/statementInsightsTable.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsights/statementInsights/statementInsightsTable.tsx
@@ -148,6 +148,13 @@ export function makeStatementInsightsColumns(
       showByDefault: false,
     },
     {
+      name: "cpu",
+      title: insightsTableTitles.cpu(execType),
+      cell: (item: StmtInsightEvent) => Duration(item.cpuSQLNanos),
+      sort: (item: StmtInsightEvent) => item.cpuSQLNanos,
+      showByDefault: false,
+    },
+    {
       name: "isFullScan",
       title: insightsTableTitles.isFullScan(execType),
       cell: (item: StmtInsightEvent) => String(item.isFullScan),

--- a/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsights/transactionInsights/transactionInsightsTable.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsights/transactionInsights/transactionInsightsTable.tsx
@@ -92,6 +92,13 @@ export function makeTransactionInsightsColumns(
       sort: item => item.contentionTime?.asMilliseconds() ?? 0,
     },
     {
+      name: "cpu",
+      title: insightsTableTitles.cpu(execType),
+      cell: item => Duration(item.cpuSQLNanos),
+      sort: item => item.cpuSQLNanos,
+      showByDefault: false,
+    },
+    {
       name: "applicationName",
       title: insightsTableTitles.applicationName(execType),
       cell: item => item.application,

--- a/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsights/util/insightsColumns.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsights/util/insightsColumns.tsx
@@ -34,6 +34,7 @@ export const insightsColumnLabels = {
   databaseName: "Database Name",
   tableName: "Table Name",
   indexName: "Index Name",
+  cpu: "CPU Time",
 };
 
 export type InsightsTableColumnKeys = keyof typeof insightsColumnLabels;
@@ -204,6 +205,12 @@ export const insightsTableTitles: InsightsTableTitleType = {
         {` to disk per execution for ${execType} within the specified time interval.`}
       </p>,
       "rowsProcessed",
+    );
+  },
+  cpu: (_: InsightExecEnum) => {
+    return makeToolTip(
+      <p>{`CPU Time spent executing within the specified time interval.`}</p>,
+      "cpu",
     );
   },
 };


### PR DESCRIPTION
Part Of https://github.com/cockroachdb/cockroach/issues/87213

Adds CPU Time column on Statement and Transaction
Insights pages and their respective details pages.

Transaction Overview
<img width="1398" alt="Screen Shot 2023-01-31 at 12 37 20 PM" src="https://user-images.githubusercontent.com/1017486/215839478-c5d999f3-4322-49bf-9467-8ee60d5ceb85.png">

Transaction Details
<img width="769" alt="Screen Shot 2023-01-31 at 12 37 52 PM" src="https://user-images.githubusercontent.com/1017486/215839559-c3893236-c22b-4b24-8186-098cc6e809af.png">

Statements Overview
<img width="757" alt="Screen Shot 2023-01-31 at 12 37 36 PM" src="https://user-images.githubusercontent.com/1017486/215839496-81b409e8-21c0-4d04-9bd2-8a1b94858304.png">

Statement Details
<img width="774" alt="Screen Shot 2023-01-31 at 12 37 43 PM" src="https://user-images.githubusercontent.com/1017486/215839518-0161df45-627c-4eed-9653-583de391c55e.png">


Release note (ui change): Add CPU Time to Statement and
Transaction Insights.