### PR TITLE
cluster-ui: add `safesql` to `cluster-ui`

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/api/safesql.spec.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/api/safesql.spec.ts
@@ -1,0 +1,147 @@
+// Copyright 2023 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import { Format, Identifier, Join, SQL } from "./safesql";
+
+describe.only("safesql", () => {
+  test("format", () => {
+    type customString = string;
+    type customNum = number;
+
+    const testCases: {
+      expected: string;
+      formatted: string;
+    }[] = [
+      {
+        expected: `hello`,
+        formatted: Format(`hello`),
+      },
+      {
+        expected: `hello %`,
+        formatted: Format(`hello %%`),
+      },
+      {
+        expected: `hello 0`,
+        formatted: Format(`hello %1`, [0]),
+      },
+      {
+        expected: `hello 'world'`,
+        formatted: Format(`hello %1`, [`world`]),
+      },
+      {
+        expected: `hello '''world'''`,
+        formatted: Format(`hello %1`, [`'world'`]),
+      },
+      {
+        expected: `hello "world"`,
+        formatted: Format(`hello %1`, [new Identifier(`world`)]),
+      },
+      {
+        expected: `hello """world"""`,
+        formatted: Format(`hello %1`, [new Identifier(`"world"`)]),
+      },
+      {
+        expected: `hello world`,
+        formatted: Format(`hello %1`, [new SQL(`world`)]),
+      },
+      {
+        expected: `hello "world"`,
+        formatted: Format(`hello %1`, [new SQL(`"world"`)]),
+      },
+      {
+        expected: `hello 'beautiful' 'world'`,
+        formatted: Format(`hello %1 %2`, [`beautiful`, `world`]),
+      },
+      {
+        expected: `hello 'beautiful' 'world'`,
+        formatted: Format(`hello %2 %1`, [`world`, `beautiful`]),
+      },
+      {
+        expected: `hello 'world'`,
+        formatted: Format(`hello %1`, ["world" as customString]),
+      },
+      {
+        expected: `hello 1`,
+        formatted: Format(`hello %1`, [1 as customNum]),
+      },
+    ];
+
+    testCases.forEach(tc => {
+      expect(tc.formatted).toEqual(tc.expected);
+    });
+  });
+
+  test("format error", () => {
+    const testCases: {
+      expected: string;
+      format: string;
+      args: any[];
+    }[] = [
+      { format: `hello %s`, args: null, expected: `invalid placeholder: %s` },
+      { format: `hello %`, args: null, expected: `invalid placeholder: %` },
+      { format: `hello %1`, args: null, expected: `bad placeholder index: %1` },
+      {
+        format: `hello%1`,
+        args: null,
+        expected: `invalid separator: 'o' is not punctuation or whitespace`,
+      },
+      {
+        format: `hello %1`,
+        args: [new Date()],
+        expected: `bad argument 1: unsupported type: object`,
+      },
+    ];
+
+    testCases.forEach(tc => {
+      expect(() => {
+        Format(tc.format, tc.args);
+      }).toThrow(tc.expected);
+    });
+  });
+
+  test("join", () => {
+    const testCases: {
+      expected: string;
+      got: SQL;
+    }[] = [
+      {
+        expected: `1, 2, 3`,
+        got: Join([1, 2, 3], new SQL(", ")),
+      },
+      {
+        expected: `'a', 'b', 'c'`,
+        got: Join(["a", "b", "c"], new SQL(", ")),
+      },
+      {
+        expected: `'one item'`,
+        got: Join(["one item"], new SQL(", ")),
+      },
+      {
+        expected: `"IDENT_A" "IDENT_B" "IDENT_C"`,
+        got: Join(
+          [
+            new Identifier("IDENT_A"),
+            new Identifier("IDENT_B"),
+            new Identifier("IDENT_C"),
+          ],
+          new SQL(" "),
+        ),
+      },
+      {
+        expected: `1 'mixed' "ident"`,
+        got: Join([1, "mixed", new Identifier("ident")], new SQL(" ")),
+      },
+    ];
+
+    testCases.forEach(tc => {
+      expect(tc.got.SQLString()).toEqual(tc.expected);
+    });
+  });
+});

--- a/pkg/ui/workspaces/cluster-ui/src/api/safesql.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/api/safesql.ts
@@ -1,0 +1,273 @@
+// Copyright 2023 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+// SQLStringer is an interface that can be implemented by types to customize how
+// they are formatted into SQL by Format.
+export interface SQLStringer {
+  SQLString: () => string;
+}
+
+function isSQLStringer(s: any): s is SQLStringer {
+  // Check that s is not null/undefined (truthy) and has SQLString implemented.
+  return s && (s as SQLStringer).SQLString !== undefined;
+}
+
+// TODO(thomas): @knz says: the quoting rules for usernames are different from
+// both strings and identifiers! So you might want to do something similar to
+// crdb and make security.SQLUsername a special case here.
+
+// Identifier provides proper quoting of SQL identifiers (such as column,
+// table, and database names) when used as arguments to Format.
+export class Identifier implements SQLStringer {
+  i: string;
+  constructor(identifier: string) {
+    this.i = identifier;
+  }
+
+  // SQLString implements the SQLStringer interface.
+  SQLString = (): string => {
+    return QuoteIdentifier(this.i);
+  };
+}
+
+// QualifiedIdentifier provides proper quoting of a qualified identifier
+// with an arbitrary number of components (e.g. <schema>.<table>.<column>)
+// when used as an argument to Format.
+export class QualifiedIdentifier implements SQLStringer {
+  qi: string[];
+  constructor(identifiers: string[]) {
+    this.qi = identifiers;
+  }
+
+  // SQLString implements the SQLStringer interface.
+  SQLString = (): string => {
+    const quotedParts = this.qi.map(iden => new Identifier(iden).SQLString());
+    return quotedParts.join(".");
+  };
+}
+
+// SQL encapsulates a known safe SQL fragment. It should not be used with SQL
+// from an external source or SQL containing identifiers.
+//
+// Use of this type presents a security risk: the encapsulated content should
+// come from a trusted source, as it will be included verbatim in the output
+// when used as an argument to Format().
+export class SQL implements SQLStringer {
+  sql: string;
+  constructor(sql: string) {
+    this.sql = sql;
+  }
+
+  // SQLString implements the SQLStringer interface.
+  SQLString = (): string => {
+    return this.sql;
+  };
+}
+
+// QuoteIdentifier quotes an "identifier" (e.g. a table or a column name) to be
+// used as part of an SQL statement.  For example:
+//
+//    tblname := "my_table"
+//    data := "my_data"
+//    quoted := pq.QuoteIdentifier(tblname)
+//    err := db.Exec(fmt.Sprintf("INSERT INTO %s VALUES ($1)", quoted), data)
+//
+// Any double quotes in name will be escaped.  The quoted identifier will be
+// case sensitive when used in a query.  If the input string contains a zero
+// byte, the result will be truncated immediately before it.
+// Cribbed from https://github.com/lib/pq and Typescript-ified.
+function QuoteIdentifier(name: string): string {
+  // Use a search regex to replace all occurrences instead of just the first occurrence.
+  const search = /"/g;
+  return `"` + name.replace(search, `""`) + `"`;
+}
+
+// QuoteLiteral quotes a 'literal' (e.g. a parameter, often used to pass literal
+// to DDL and other statements that do not accept parameters) to be used as part
+// of an SQL statement.  For example:
+//
+//    exp_date := pq.QuoteLiteral("2023-01-05 15:00:00Z")
+//    err := db.Exec(fmt.Sprintf("CREATE ROLE my_user VALID UNTIL %s", exp_date))
+//
+// Any single quotes in name will be escaped. Any backslashes (i.e. "\") will be
+// replaced by two backslashes (i.e. "\\") and the C-style escape identifier
+// that PostgreSQL provides ('E') will be prepended to the string.
+// Cribbed from https://github.com/lib/pq and Typescript-ified.
+function QuoteLiteral(literal: string): string {
+  // This follows the PostgreSQL internal algorithm for handling quoted literals
+  // from libpq, which can be found in the "PQEscapeStringInternal" function,
+  // which is found in the libpq/fe-exec.c source file:
+  // https://git.postgresql.org/gitweb/?p=postgresql.git;a=blob;f=src/interfaces/libpq/fe-exec.c
+  //
+  // substitute any single-quotes (') with two single-quotes ('')
+
+  // Use a search regex to replace all occurrences instead of just the first occurrence.
+  const search = /'/g;
+  literal = literal.replace(search, `''`);
+  // determine if the string has any backslashes (\) in it.
+  // if it does, replace any backslashes (\) with two backslashes (\\)
+  // then, we need to wrap the entire string with a PostgreSQL
+  // C-style escape. Per how "PQEscapeStringInternal" handles this case, we
+  // also add a space before the "E"
+  if (literal.includes(`\\`)) {
+    literal = literal.replace(`\\`, `\\\\`);
+    literal = ` E'` + literal + `'`;
+  } else {
+    // otherwise, we can just wrap the literal with a pair of single quotes
+    literal = `'` + literal + `'`;
+  }
+  return literal;
+}
+
+function parseArgIdx(s: string, i: number): [number, number] {
+  if (i >= s.length || s[i] < "0" || s[i] > "9") {
+    // Not a valid number.
+    return [-1, i];
+  }
+
+  const end = s.length;
+  let idx = 0;
+  while (i < end && "0" < s[i] && s[i] <= "9") {
+    if (idx >= 1e6) {
+      // Too large an argument index specifier.
+      return [-1, i];
+    }
+    idx = idx * 10 + (s.codePointAt(i) - "0".codePointAt(0));
+    i++;
+  }
+  return [idx, i];
+}
+
+// Format formats a SQL string, recognizing %1, %2, etc as placeholders and
+// replacing them with the corresponding arguments (1-indexed). Unlike
+// printf-style formatting, the placeholders must be preceded by punctuation or
+// whitespace. This prevents errors such as `xxx_%1` from being formatted as
+// `xxx_'%1'` which is almost certainly incorrect.
+//
+// Formatting of the argument proceeds by the following rules:
+//
+// - if args[i] has a SQLString() method, it is used
+// - if args[i] is a string type, it is quoted as a literal (pq.QuoteLiteral)
+// - if args[i] is an integer type, it is formatted as %d
+// - otherwise, panic with an error
+export function Format(format: string, args?: any[]): string {
+  let resultString = "";
+  // The loop structure here is adapted from the stdlib fmt.Sprintf code, but
+  // heavily simplified because we don't have to support different verbs, only
+  // formatting of different types.
+  let i = 0;
+  const end = format.length;
+  while (i < end) {
+    let start = i;
+    while (i < end && format[i] !== "%") {
+      i++;
+    }
+    if (start < i) {
+      resultString += format.slice(start, i);
+    }
+    if (i >= end) {
+      break;
+    }
+
+    if (i > 0) {
+      const lastChar = format.substring(0, i).slice(-1);
+      if (!(lastChar == "=" || isPunct(lastChar) || isSpace(lastChar))) {
+        throw new Error(
+          `invalid separator: '${lastChar}' is not punctuation or whitespace`,
+        );
+      }
+    }
+
+    start = i;
+    i++;
+    if (i < end && format[i] === "%") {
+      i++;
+      resultString += "%";
+      continue;
+    }
+
+    let argIdx: number;
+    [argIdx, i] = parseArgIdx(format, i);
+    if (argIdx === -1) {
+      throw new Error(`invalid placeholder: ${format.slice(start)}`);
+    }
+    // Check for:
+    // - invalid argument index
+    // - valid argument index but no arguments
+    // - valid argument index but exceeds arguments length
+    if (argIdx < 1 || !args || argIdx > args.length) {
+      throw new Error(`bad placeholder index: ${format.slice(start)}`);
+    }
+
+    const arg = args[argIdx - 1];
+    let errString: string;
+    [resultString, errString] = writeFormattedArg(arg, resultString);
+    if (errString !== "") {
+      throw new Error(`bad argument ${argIdx}: ${errString}`);
+    }
+  }
+
+  return resultString;
+}
+
+// Join concatenates the given elements with the given separator, formatting each element per Format.
+// A type parameter is used here as we typically expect to see a slice of a concrete type passed as `args`
+// and using one avoids the need to convert the slice.
+export function Join<Type>(args: Type[], sep: SQL): SQL {
+  let b = "";
+  for (let i = 0; i < args.length; i++) {
+    if (i > 0) {
+      b += sep.SQLString();
+    }
+    let errString: string;
+    [b, errString] = writeFormattedArg(args[i], b);
+    if (errString !== "") {
+      throw new Error(errString);
+    }
+  }
+  return new SQL(b);
+}
+
+function writeFormattedArg(arg: any, b: string): [string, string] {
+  if (isSQLStringer(arg)) {
+    b += arg.SQLString();
+    return [b, ""];
+  }
+  const type = typeof arg;
+  if (type === "number") {
+    b += arg;
+    return [b, ""];
+  }
+  if (type === "string") {
+    b += QuoteLiteral(arg.toString());
+    return [b, ""];
+  }
+  return ["", "unsupported type: " + type];
+}
+
+function isPunct(char: string): boolean {
+  return !!char.match(/^[.,:!?]/);
+}
+
+function isSpace(char: string): boolean {
+  switch (char) {
+    case "\t":
+    case "\n":
+    case "\v":
+    case "\f":
+    case "\r":
+    case " ":
+    case String.fromCharCode(0x85):
+    case String.fromCharCode(0xa0):
+      return true;
+    default:
+      return false;
+  }
+}


### PR DESCRIPTION
Epic: none

This change ports the `safesql` package from managed-service to cluster-ui. Safesql ensures that SQL literals/identifiers are properly quoted.

Release note: None