### PR TITLE
release-22.1: sql: docker cli quit test fix

### DIFF
--- a/pkg/util/contextutil/context.go
+++ b/pkg/util/contextutil/context.go
@@ -91,6 +91,11 @@ func (ctx *ctxWithStacktrace) Err() error {
 	return errors.WithStack(ctx.Context.Err())
 }
 
+// UnwrapContext implements the ContextWrapper interface.
+func (ctx *ctxWithStacktrace) UnwrapContext() context.Context {
+	return ctx.Context
+}
+
 // RunWithTimeout runs a function with a timeout, the same way you'd do with
 // context.WithTimeout. It improves the opaque error messages returned by
 // WithTimeout by augmenting them with the op string that is passed in.


### PR DESCRIPTION
Fixes #96167
Release justification: fixes a test
    
gRPC toRPCErr(...) expects Context.Err() to return an unwrapped
context.DeadlineExceeded to indicate a timeout. We started wrapping
the error in #95797 to add a stack trace.

We now unwrap the context right before passing to gRPC so that
it identifies the timeout correctly.

Release note: None