### PR TITLE
ui: fix conversion of CPU

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/barCharts/barCharts.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/barCharts/barCharts.tsx
@@ -123,7 +123,7 @@ export const contentionBarChart = barChartFactory(
 export const cpuBarChart = barChartFactory(
   "grey",
   cpuBars,
-  v => Duration(v * 1e9),
+  v => Duration(v),
   cpuStdDev,
 );
 export const maxMemUsageBarChart = barChartFactory(

--- a/pkg/ui/workspaces/cluster-ui/src/statementDetails/timeseriesUtils.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/statementDetails/timeseriesUtils.ts
@@ -103,7 +103,7 @@ export function generateCPUTimeseries(
   stats.forEach(function (stat: statementStatisticsPerAggregatedTs) {
     if (stat.stats.exec_stats.cpu_sql_nanos) {
       ts.push(TimestampToNumber(stat.aggregated_ts) * 1e3);
-      count.push(stat.stats.exec_stats.cpu_sql_nanos.mean * 1e9);
+      count.push(stat.stats.exec_stats.cpu_sql_nanos.mean);
     }
   });
 

--- a/pkg/ui/workspaces/cluster-ui/src/transactionsTable/transactionsBarCharts.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionsTable/transactionsBarCharts.ts
@@ -119,7 +119,7 @@ export const transactionsContentionBarChart = barChartFactory(
 export const transactionsCPUBarChart = barChartFactory(
   "grey",
   cpuBar,
-  v => Duration(v * 1e9),
+  v => Duration(v),
   cpuStdDev,
 );
 export const transactionsMaxMemUsageBarChart = barChartFactory(


### PR DESCRIPTION
The CPU is already in nanos, so there is no need
to multiply by 1e9 when calling on our UI functions.

Fixes #96303

The values on the images were stored as 123456789 nanos
<img width="461" alt="Screen Shot 2023-01-31 at 4 34 05 PM" src="https://user-images.githubusercontent.com/1017486/215889281-bb4bfb82-a730-4b86-aeb4-06d8a3304407.png">

<img width="840" alt="Screen Shot 2023-01-31 at 4 34 22 PM" src="https://user-images.githubusercontent.com/1017486/215889303-4090e380-d572-4f9a-bc0f-3955446e4070.png">


Release note: None