### PR TITLE
sql: refactor checkCancelPrivilege to avoid unessessary hasAdminRole call

### DIFF
--- a/pkg/server/admin.go
+++ b/pkg/server/admin.go
@@ -1647,7 +1647,7 @@ func (s *adminServer) RangeLog(
 	ctx = s.AnnotateCtx(ctx)
 
 	// Range keys, even when pretty-printed, contain PII.
-	user, _, err := s.getUserAndRole(ctx)
+	user, err := userFromContext(ctx)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Fixes #95993

Reorders the logic in `checkCancelPrivilege` to only call `hasAdminRole` when necessary.

Release note: None