### PR TITLE
pgwire,server: clarify to SQL clients when they select the wrong tenant

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -914,7 +914,7 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 
 	// Initialize the pgwire pre-server, which initializes connections,
 	// sets up TLS and reads client status parameters.
-	pgPreServer := pgwire.MakePreServeConnHandler(
+	pgPreServer := pgwire.NewPreServeConnHandler(
 		cfg.AmbientCtx,
 		cfg.Config,
 		cfg.Settings,
@@ -1040,7 +1040,11 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 	sc := newServerController(ctx,
 		node, cfg.BaseConfig.IDContainer,
 		stopper, st,
-		lateBoundServer, &systemServerWrapper{server: lateBoundServer}, systemTenantNameContainer)
+		lateBoundServer,
+		&systemServerWrapper{server: lateBoundServer},
+		systemTenantNameContainer,
+		pgPreServer.SendRoutingError,
+	)
 
 	// Create the debug API server.
 	debugServer := debug.NewServer(
@@ -1116,7 +1120,7 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 		protectedtsProvider:    protectedtsProvider,
 		spanConfigSubscriber:   spanConfig.subscriber,
 		spanConfigReporter:     spanConfig.reporter,
-		pgPreServer:            &pgPreServer,
+		pgPreServer:            pgPreServer,
 		sqlServer:              sqlServer,
 		serverController:       sc,
 		externalStorageBuilder: externalStorageBuilder,

--- a/pkg/server/server_controller.go
+++ b/pkg/server/server_controller.go
@@ -98,6 +98,10 @@ type serverController struct {
 	// testArgs is used when creating new tenant servers.
 	testArgs map[roachpb.TenantName]base.TestSharedProcessTenantArgs
 
+	// sendSQLRoutingError is a callback to use to report
+	// a tenant routing error to the incoming client.
+	sendSQLRoutingError func(ctx context.Context, conn net.Conn, tenantName roachpb.TenantName)
+
 	mu struct {
 		syncutil.Mutex
 
@@ -122,6 +126,7 @@ func newServerController(
 	tenantServerCreator tenantServerCreator,
 	systemServer onDemandServer,
 	systemTenantNameContainer *roachpb.TenantNameContainer,
+	sendSQLRoutingError func(ctx context.Context, conn net.Conn, tenantName roachpb.TenantName),
 ) *serverController {
 	c := &serverController{
 		nodeID:              parentNodeID,
@@ -130,6 +135,7 @@ func newServerController(
 		testArgs:            make(map[roachpb.TenantName]base.TestSharedProcessTenantArgs),
 		stopper:             parentStopper,
 		tenantServerCreator: tenantServerCreator,
+		sendSQLRoutingError: sendSQLRoutingError,
 	}
 
 	// We make the serverState for the system mock the regular

--- a/pkg/server/tenant.go
+++ b/pkg/server/tenant.go
@@ -253,7 +253,7 @@ func NewTenantServer(
 	if !baseCfg.DisableSQLListener {
 		// Initialize the pgwire pre-server, which initializes connections,
 		// sets up TLS and reads client status parameters.
-		ps := pgwire.MakePreServeConnHandler(
+		pgPreServer = pgwire.NewPreServeConnHandler(
 			baseCfg.AmbientCtx,
 			baseCfg.Config,
 			args.Settings,
@@ -262,10 +262,9 @@ func NewTenantServer(
 			args.monitorAndMetrics.rootSQLMemoryMonitor,
 			false, /* acceptTenantName */
 		)
-		for _, m := range ps.Metrics() {
+		for _, m := range pgPreServer.Metrics() {
 			args.registry.AddMetricStruct(m)
 		}
-		pgPreServer = &ps
 	}
 
 	// Instantiate the SQL server proper.

--- a/pkg/sql/pgwire/BUILD.bazel
+++ b/pkg/sql/pgwire/BUILD.bazel
@@ -25,6 +25,7 @@ go_library(
         "//pkg/base",
         "//pkg/clusterversion",
         "//pkg/col/coldata",
+        "//pkg/roachpb",
         "//pkg/security",
         "//pkg/security/password",
         "//pkg/security/sessionrevival",


### PR DESCRIPTION
Fixes #92525.
Epic: CRDB-14537

Prior to this patch:
```
$ ./cockroach sql -d cluster:wo
ERROR: server closed the connection.
Is this a CockroachDB node?
unexpected EOF
```

After this patch:
```
$ ./cockroach sql -d cluster:woo
ERROR: service unavailable for target tenant (woo)
SQLSTATE: 08000
HINT: Double check your "-ccluster=" connection parameter or your "cluster:" database name prefix.
```

Release note: None