### PR TITLE
multiregionccl: add another missing log scope

### DIFF
--- a/pkg/ccl/multiregionccl/regional_by_row_test.go
+++ b/pkg/ccl/multiregionccl/regional_by_row_test.go
@@ -855,6 +855,7 @@ USE t;
 	for _, regionChange := range regionChanges {
 		for _, rbrChange := range regionalByRowChanges {
 			t.Run(fmt.Sprintf("setup %s executing %s with racing %s", rbrChange.setup, regionChange.cmd, rbrChange.cmd), func(t *testing.T) {
+				defer log.Scope(t).Close(t)
 				interruptStartCh := make(chan struct{})
 				interruptEndCh := make(chan struct{})
 				performInterrupt := false


### PR DESCRIPTION
The test output files for this package were huge because of this.

Epic: none

Release note: None