### PR TITLE
logictest: skip another flaky test in ranges

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/ranges
+++ b/pkg/sql/logictest/testdata/logic_test/ranges
@@ -599,10 +599,12 @@ subtest show_range_index_for_row_columns
 statement ok
 CREATE TABLE tbl_with_idx_for_row(i INT, INDEX idx (i));
 
-query TTIITTTTT colnames
-SHOW RANGE FROM INDEX tbl_with_idx_for_row@idx FOR ROW (NULL, 0)
-----
-start_key                     end_key  range_id  lease_holder  lease_holder_locality  replicas  replica_localities      voting_replicas  non_voting_replicas
-<before:/Table/130/1/"\x80">  …        94        1             region=test,dc=dc1     {1}       {"region=test,dc=dc1"}  {1}              {}
+# TODO(#96136): Re-enable this test after making it deterministic.
+# query TTIITTTTT colnames
+# query TTIITTTTT colnames
+# SHOW RANGE FROM INDEX tbl_with_idx_for_row@idx FOR ROW (NULL, 0)
+# ----
+# start_key                     end_key  range_id  lease_holder  lease_holder_locality  replicas  replica_localities      voting_replicas  non_voting_replicas
+# <before:/Table/130/1/"\x80">  …        94        1             region=test,dc=dc1     {1}       {"region=test,dc=dc1"}  {1}              {}
 
 subtest end


### PR DESCRIPTION
This commit skips a flaky test that I missed in #96271.

Informs #96136

Epic: None

Release note: None