### PR TITLE
release-22.2: opt: fix logical properties calculation for locality optimized join

### DIFF
--- a/pkg/sql/opt/lookupjoin/constraint_builder.go
+++ b/pkg/sql/opt/lookupjoin/constraint_builder.go
@@ -79,10 +79,10 @@ type Constraint struct {
 	// be projected on the lookup join's input.
 	InputProjections memo.ProjectionsExpr
 
-	// ConstFilters contains constant equalities and ranges in either KeyCols or
-	// LookupExpr that are used to aid selectivity estimation. See
-	// memo.LookupJoinPrivate.ConstFilters.
-	ConstFilters memo.FiltersExpr
+	// AllLookupFilters contains equalities and other filters in either KeyCols or
+	// LookupExpr that are used to aid selectivity estimation and logical props
+	// calculation. See memo.LookupJoinPrivate.AllLookupFilters.
+	AllLookupFilters memo.FiltersExpr
 
 	// RemainingFilters contains explicit ON filters that are not represented by
 	// KeyCols or LookupExpr. These filters must be included as ON filters in
@@ -193,7 +193,7 @@ func (b *ConstraintBuilder) Build(
 	rightSideCols := make(opt.ColList, 0, numIndexKeyCols)
 	var inputProjections memo.ProjectionsExpr
 	var lookupExpr memo.FiltersExpr
-	var constFilters memo.FiltersExpr
+	var allLookupFilters memo.FiltersExpr
 	var filterOrdsToExclude util.FastIntSet
 	foundLookupCols := false
 	lookupExprRequired := false
@@ -237,6 +237,7 @@ func (b *ConstraintBuilder) Build(
 		idxCol := b.table.IndexColumnID(index, j)
 		idxColIsDesc := index.Column(j).Descending
 		if eqIdx, ok := rightEq.Find(idxCol); ok {
+			allLookupFilters = append(allLookupFilters, allFilters[eqFilterOrds[eqIdx]])
 			addEqualityColumns(leftEq[eqIdx], idxCol)
 			filterOrdsToExclude.Add(eqFilterOrds[eqIdx])
 			foundEqualityCols = true
@@ -291,7 +292,7 @@ func (b *ConstraintBuilder) Build(
 				b.f.ConstructConstVal(foundVals[0], idxColType),
 				constColID,
 			))
-			constFilters = append(constFilters, allFilters[allIdx])
+			allLookupFilters = append(allLookupFilters, allFilters[allIdx])
 			addEqualityColumns(constColID, idxCol)
 			filterOrdsToExclude.Add(allIdx)
 			continue
@@ -314,7 +315,7 @@ func (b *ConstraintBuilder) Build(
 				})
 			}
 			lookupExpr = append(lookupExpr, valsFilter)
-			constFilters = append(constFilters, valsFilter)
+			allLookupFilters = append(allLookupFilters, allFilters[allIdx])
 			filterOrdsToExclude.Add(allIdx)
 			continue
 		}
@@ -327,12 +328,14 @@ func (b *ConstraintBuilder) Build(
 		if foundStart {
 			convertToLookupExpr()
 			lookupExpr = append(lookupExpr, allFilters[startIdx])
+			allLookupFilters = append(allLookupFilters, allFilters[startIdx])
 			filterOrdsToExclude.Add(startIdx)
 			foundLookupCols = true
 		}
 		if foundEnd {
 			convertToLookupExpr()
 			lookupExpr = append(lookupExpr, allFilters[endIdx])
+			allLookupFilters = append(allLookupFilters, allFilters[endIdx])
 			filterOrdsToExclude.Add(endIdx)
 			foundLookupCols = true
 		}
@@ -354,7 +357,7 @@ func (b *ConstraintBuilder) Build(
 			// A constant range filter could be found.
 			convertToLookupExpr()
 			lookupExpr = append(lookupExpr, *rangeFilter)
-			constFilters = append(constFilters, *rangeFilter)
+			allLookupFilters = append(allLookupFilters, allFilters[filterIdx])
 			filterOrdsToExclude.Add(filterIdx)
 			if remaining != nil {
 				remainingFilters = append(remainingFilters, *remaining)
@@ -383,7 +386,7 @@ func (b *ConstraintBuilder) Build(
 		RightSideCols:    rightSideCols,
 		LookupExpr:       lookupExpr,
 		InputProjections: inputProjections,
-		ConstFilters:     constFilters,
+		AllLookupFilters: allLookupFilters,
 	}
 
 	// Reduce the remaining filters.

--- a/pkg/sql/opt/memo/logical_props_builder.go
+++ b/pkg/sql/opt/memo/logical_props_builder.go
@@ -2276,7 +2276,7 @@ func (h *joinPropsHelper) init(b *logicalPropsBuilder, joinExpr RelExpr) {
 		ensureLookupJoinInputProps(join, &b.sb)
 		h.joinType = join.JoinType
 		h.rightProps = &join.lookupProps
-		h.filters = append(join.On, join.LookupExpr...)
+		h.filters = append(join.On, join.AllLookupFilters...)
 		b.addFiltersToFuncDep(h.filters, &h.filtersFD)
 		h.filterNotNullCols = b.rejectNullCols(h.filters)
 

--- a/pkg/sql/opt/memo/statistics_builder.go
+++ b/pkg/sql/opt/memo/statistics_builder.go
@@ -3077,14 +3077,12 @@ func (sb *statisticsBuilder) filterRelExpr(
 func (sb *statisticsBuilder) applyFilters(
 	filters FiltersExpr, e RelExpr, relProps *props.Relational, skipOrTermAccounting bool,
 ) (numUnappliedConjuncts float64, constrainedCols, histCols opt.ColSet) {
-	// Special hack for lookup and inverted joins. Add constant filters from the
-	// equality conditions.
+	// Special hack for inverted joins. Add constant filters from the equality
+	// conditions.
 	// TODO(rytaft): the correct way to do this is probably to fully implement
 	// histograms in Project and Join expressions, and use them in
 	// selectivityFromEquivalencies. See Issue #38082.
 	switch t := e.(type) {
-	case *LookupJoinExpr:
-		filters = append(filters, t.ConstFilters...)
 	case *InvertedJoinExpr:
 		filters = append(filters, t.ConstFilters...)
 	}

--- a/pkg/sql/opt/ops/relational.opt
+++ b/pkg/sql/opt/ops/relational.opt
@@ -463,10 +463,12 @@ define LookupJoinPrivate {
     # this lookup join.
     LocalityOptimized bool
 
-    # ConstFilters contains the constant filters that are represented as equality
-    # conditions on the KeyCols. These filters are needed by the statistics code to
-    # correctly estimate selectivity.
-    ConstFilters FiltersExpr
+    # AllLookupFilters synthesizes all the filters that are represented as
+    # equality conditions on the KeyCols, as well as the filters in LookupExpr
+    # and RemoteLookupExpr. These filters are needed by the statistics code to
+    # correctly estimate selectivity as well as by the logicalPropsBuilder for
+    # calculating logical properties.
+    AllLookupFilters FiltersExpr
 
     # Locking represents the row-level locking mode of the LookupJoin in the
     # lookup table. Most lookup joins leave this unset (Strength = ForNone),


### PR DESCRIPTION
Backport 1/1 commits from #95713.

/cc @cockroachdb/release

---

This commit fixes a bug when calculating the logical properties for a locality optimized lookup join where we would incorrectly determine that the `crdb_region` column was constant. In fact, `crdb_region` is only constant in the local lookup expr of the join; the remote lookup expr contains one or more other possible values for this column.

I don't know of any actual incorrect results caused by this issue, so I'm not setting a release note. However, incorrect logical properties are always bad and can in theory cause incorrect results.

Epic: None
Release note: None

---

Release justification: low risk bug fix
