### PR TITLE
multitenant: skip TestTransientClusterMultiTenant

### DIFF
--- a/pkg/cli/democluster/demo_cluster_test.go
+++ b/pkg/cli/democluster/demo_cluster_test.go
@@ -260,6 +260,7 @@ func TestTransientClusterMultitenant(t *testing.T) {
 
 	// This test is too slow to complete under the race detector, sometimes.
 	skip.UnderRace(t)
+	skip.WithIssue(t, 96162)
 
 	defer TestingForceRandomizeDemoPorts()()
 


### PR DESCRIPTION
Informs #96162

Release note: None

Epic: none