### PR TITLE
kvserver: shard liveness range

### DIFF
--- a/pkg/keys/spans.go
+++ b/pkg/keys/spans.go
@@ -52,5 +52,5 @@ var (
 	// Meta1Span: needed to find other ranges.
 	// Meta2MaxSpan: between meta and system ranges.
 	// NodeLivenessSpan: liveness information on nodes in the cluster.
-	NoSplitSpans = []roachpb.Span{Meta1Span, Meta2MaxSpan, NodeLivenessSpan}
+	NoSplitSpans = []roachpb.Span{Meta1Span, Meta2MaxSpan}
 )

--- a/pkg/kv/kvserver/replica_init.go
+++ b/pkg/kv/kvserver/replica_init.go
@@ -11,7 +11,6 @@
 package kvserver
 
 import (
-	"bytes"
 	"context"
 	"time"
 
@@ -377,7 +376,7 @@ func (r *Replica) setDescLockedRaftMuLocked(ctx context.Context, desc *roachpb.R
 
 	// Prioritize the NodeLiveness Range in the Raft scheduler above all other
 	// Ranges to ensure that liveness never sees high Raft scheduler latency.
-	if bytes.HasPrefix(desc.StartKey, keys.NodeLivenessPrefix) {
+	/*if bytes.HasPrefix(desc.StartKey, keys.NodeLivenessPrefix) {
 		r.store.scheduler.SetPriorityID(desc.RangeID)
-	}
+	}*/
 }

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -1906,6 +1906,13 @@ func (s *Server) PreStart(ctx context.Context) error {
 		return errors.Wrap(err, "failed to start the server controller")
 	}
 
+	// Split the liveness range at this node's key.
+	err = s.db.AdminSplit(ctx, keys.NodeLivenessKey(s.node.Descriptor.NodeID), hlc.MaxTimestamp)
+	if err != nil {
+		return err
+	}
+	log.Infof(ctx, "split liveness range at %s", keys.NodeLivenessKey(s.node.Descriptor.NodeID))
+
 	log.Event(ctx, "server initialized")
 
 	// Begin recording time series data collected by the status monitor.


### PR DESCRIPTION
This patch is a proof of concept of a sharded, per-node liveness range. It demonstrates that sharding the liveness range is viable, but a shippable version should at the very least also pin the leaseholder to the node itself.

Epic: none
Release note: None