### PR TITLE
release: skip nil GitHub events

### DIFF
--- a/pkg/cmd/release/github.go
+++ b/pkg/cmd/release/github.go
@@ -152,6 +152,9 @@ func (c *githubClientImpl) issueEvents(issueNum int) ([]githubEvent, error) {
 			return nil, fmt.Errorf("error calling Issues.ListIssueTimeline: %w", err)
 		}
 		for _, event := range events {
+			if event == nil {
+				continue
+			}
 			detail := githubEvent{
 				Event: *event.Event,
 			}


### PR DESCRIPTION
Previously, we referenced `*event.Event`, but in some cases the event objects are `nil`.

This PR skips the nil GitHub event objects.

Epic: none
Release note: None