### PR TITLE
streamingest: fix returned cutover time on `complete to latest`

### DIFF
--- a/pkg/ccl/streamingccl/streamingest/alter_replication_job.go
+++ b/pkg/ccl/streamingccl/streamingest/alter_replication_job.go
@@ -175,13 +175,12 @@ func alterReplicationJobHook(
 		jobRegistry := p.ExecCfg().JobRegistry
 		if alterTenantStmt.Cutover != nil {
 			pts := p.ExecCfg().ProtectedTimestampProvider.WithTxn(p.InternalSQLTxn())
-			if err := alterTenantJobCutover(
-				ctx, p.InternalSQLTxn(), jobRegistry, pts,
-				alterTenantStmt, tenInfo, cutoverTime,
-			); err != nil {
+			actualCutoverTime, err := alterTenantJobCutover(
+				ctx, p.InternalSQLTxn(), jobRegistry, pts, alterTenantStmt, tenInfo, cutoverTime)
+			if err != nil {
 				return err
 			}
-			resultsCh <- tree.Datums{eval.TimestampToDecimalDatum(cutoverTime)}
+			resultsCh <- tree.Datums{eval.TimestampToDecimalDatum(actualCutoverTime)}
 		} else if !alterTenantStmt.Options.IsDefault() {
 			if err := alterTenantOptions(ctx, p.InternalSQLTxn(), jobRegistry, options, tenInfo); err != nil {
 				return err
@@ -209,6 +208,9 @@ func alterReplicationJobHook(
 	return fn, nil, nil, false, nil
 }
 
+// alterTenantJobCutover returns the cutover timestamp that was used to initiate
+// the cutover process - if the command is 'ALTER TENANT .. COMPLETE REPLICATION
+// TO LATEST' then the frontier high water timestamp is used.
 func alterTenantJobCutover(
 	ctx context.Context,
 	txn isql.Txn,
@@ -217,25 +219,26 @@ func alterTenantJobCutover(
 	alterTenantStmt *tree.AlterTenantReplication,
 	tenInfo *mtinfopb.TenantInfo,
 	cutoverTime hlc.Timestamp,
-) error {
+) (hlc.Timestamp, error) {
 	if alterTenantStmt == nil || alterTenantStmt.Cutover == nil {
-		return errors.AssertionFailedf("unexpected nil ALTER TENANT cutover expression")
+		return hlc.Timestamp{}, errors.AssertionFailedf("unexpected nil ALTER TENANT cutover expression")
 	}
 
 	tenantName := tenInfo.Name
 	job, err := jobRegistry.LoadJobWithTxn(ctx, tenInfo.TenantReplicationJobID, txn)
 	if err != nil {
-		return err
+		return hlc.Timestamp{}, err
 	}
 	details, ok := job.Details().(jobspb.StreamIngestionDetails)
 	if !ok {
-		return errors.Newf("job with id %d is not a stream ingestion job", job.ID())
+		return hlc.Timestamp{}, errors.Newf("job with id %d is not a stream ingestion job", job.ID())
 	}
 	progress := job.Progress()
 	if alterTenantStmt.Cutover.Latest {
 		ts := progress.GetHighWater()
 		if ts == nil || ts.IsEmpty() {
-			return errors.Newf("replicated tenant %q has not yet recorded a safe replication time", tenantName)
+			return hlc.Timestamp{},
+				errors.Newf("replicated tenant %q has not yet recorded a safe replication time", tenantName)
 		}
 		cutoverTime = *ts
 	}
@@ -246,25 +249,26 @@ func alterTenantJobCutover(
 	// Check that the timestamp is above our retained timestamp.
 	stats, err := replicationutils.GetStreamIngestionStatsNoHeartbeat(ctx, details, progress)
 	if err != nil {
-		return err
+		return hlc.Timestamp{}, err
 	}
 	if stats.IngestionDetails.ProtectedTimestampRecordID == nil {
-		return errors.Newf("replicated tenant %q (%d) has not yet recorded a retained timestamp",
+		return hlc.Timestamp{}, errors.Newf("replicated tenant %q (%d) has not yet recorded a retained timestamp",
 			tenantName, tenInfo.ID)
 	} else {
 		record, err := ptp.GetRecord(ctx, *stats.IngestionDetails.ProtectedTimestampRecordID)
 		if err != nil {
-			return err
+			return hlc.Timestamp{}, err
 		}
 		if cutoverTime.Less(record.Timestamp) {
-			return errors.Newf("cutover time %s is before earliest safe cutover time %s", cutoverTime, record.Timestamp)
+			return hlc.Timestamp{}, errors.Newf("cutover time %s is before earliest safe cutover time %s",
+				cutoverTime, record.Timestamp)
 		}
 	}
 	if err := completeStreamIngestion(ctx, jobRegistry, txn, tenInfo.TenantReplicationJobID, cutoverTime); err != nil {
-		return err
+		return hlc.Timestamp{}, err
 	}
 
-	return nil
+	return cutoverTime, nil
 }
 
 func alterTenantOptions(

--- a/pkg/ccl/streamingccl/streamingest/alter_replication_job_test.go
+++ b/pkg/ccl/streamingccl/streamingest/alter_replication_job_test.go
@@ -26,6 +26,59 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestAlterTenantCompleteToTime(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+	args := replicationtestutils.DefaultTenantStreamingClustersArgs
+
+	c, cleanup := replicationtestutils.CreateTenantStreamingClusters(ctx, t, args)
+	defer cleanup()
+	producerJobID, ingestionJobID := c.StartStreamReplication(ctx)
+
+	jobutils.WaitForJobToRun(t, c.SrcSysSQL, jobspb.JobID(producerJobID))
+	jobutils.WaitForJobToRun(t, c.DestSysSQL, jobspb.JobID(ingestionJobID))
+
+	c.WaitUntilHighWatermark(c.SrcCluster.Server(0).Clock().Now(), jobspb.JobID(ingestionJobID))
+
+	var cutoverTime time.Time
+	c.DestSysSQL.QueryRow(t, "SELECT clock_timestamp()").Scan(&cutoverTime)
+
+	var cutoverStr string
+	c.DestSysSQL.QueryRow(c.T, `ALTER TENANT $1 COMPLETE REPLICATION TO SYSTEM TIME $2::string`,
+		args.DestTenantName, cutoverTime).Scan(&cutoverStr)
+	cutoverOutput := replicationtestutils.DecimalTimeToHLC(t, cutoverStr)
+	require.Equal(t, cutoverTime, cutoverOutput.GoTime())
+	jobutils.WaitForJobToSucceed(c.T, c.DestSysSQL, jobspb.JobID(ingestionJobID))
+}
+
+func TestAlterTenantCompleteToLatest(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+	args := replicationtestutils.DefaultTenantStreamingClustersArgs
+
+	c, cleanup := replicationtestutils.CreateTenantStreamingClusters(ctx, t, args)
+	defer cleanup()
+	producerJobID, ingestionJobID := c.StartStreamReplication(ctx)
+
+	jobutils.WaitForJobToRun(t, c.SrcSysSQL, jobspb.JobID(producerJobID))
+	jobutils.WaitForJobToRun(t, c.DestSysSQL, jobspb.JobID(ingestionJobID))
+
+	highWater := c.SrcCluster.Server(0).Clock().Now()
+	c.WaitUntilHighWatermark(highWater, jobspb.JobID(ingestionJobID))
+
+	var cutoverStr string
+	c.DestSysSQL.QueryRow(c.T, `ALTER TENANT $1 COMPLETE REPLICATION TO LATEST`,
+		args.DestTenantName).Scan(&cutoverStr)
+	cutoverOutput := replicationtestutils.DecimalTimeToHLC(t, cutoverStr)
+	require.GreaterOrEqual(t, cutoverOutput.GoTime(), highWater.GoTime())
+	require.LessOrEqual(t, cutoverOutput.GoTime(), c.SrcCluster.Server(0).Clock().Now().GoTime())
+	jobutils.WaitForJobToSucceed(c.T, c.DestSysSQL, jobspb.JobID(ingestionJobID))
+}
+
 func TestAlterTenantPauseResume(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)


### PR DESCRIPTION
Currently when cutting over to the LATEST high watermark, the sql command prints that that cutover was done to timestamp 0.

This commit fixes this bug.

Fixes: #95901

Epic: CRDB-18752

Release note: None