### PR TITLE
builtins: check_consistency now requires admin role

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/crdb_internal
+++ b/pkg/sql/logictest/testdata/logic_test/crdb_internal
@@ -702,6 +702,9 @@ select * from crdb_internal.gossip_alerts
 query error pq: only users with the admin role are allowed to read crdb_internal.node_inflight_trace_spans
 select * from crdb_internal.node_inflight_trace_spans
 
+query error pq: crdb_internal.check_consistency requires admin privileges
+SELECT * FROM crdb_internal.check_consistency(true, b'\x02', b'\x04')
+
 # Anyone can see the executable version.
 query T
 select regexp_replace(crdb_internal.node_executable_version()::string, '(-\d+)?$', '');

--- a/pkg/sql/sem/builtins/generator_builtins.go
+++ b/pkg/sql/sem/builtins/generator_builtins.go
@@ -1945,6 +1945,14 @@ func makeCheckConsistencyGenerator(
 			errorutil.FeatureNotAvailableToNonSystemTenantsIssue)
 	}
 
+	isAdmin, err := evalCtx.SessionAccessor.HasAdminRole(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if !isAdmin {
+		return nil, pgerror.New(pgcode.InsufficientPrivilege, "crdb_internal.check_consistency requires admin privileges")
+	}
+
 	keyFrom := roachpb.Key(*args[1].(*tree.DBytes))
 	keyTo := roachpb.Key(*args[2].(*tree.DBytes))
 


### PR DESCRIPTION
Resolve #88224

`crdb_internal.check_consistency` is an expensive operation that previously could be invoked by regular users. Now admin role is required.

Release note: None