### PR TITLE
release-22.1: roachtest/tpcc: retry prometheus query during DRT

### DIFF
--- a/pkg/cmd/roachtest/tests/drt.go
+++ b/pkg/cmd/roachtest/tests/drt.go
@@ -15,9 +15,12 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/prometheus"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/logger"
+	"github.com/cockroachdb/cockroach/pkg/util/retry"
 	"github.com/cockroachdb/errors"
+	promv1 "github.com/prometheus/client_golang/api/prometheus/v1"
 	"github.com/prometheus/common/model"
 )
 
@@ -153,27 +156,13 @@ func (ep *tpccChaosEventProcessor) checkMetrics(
 			ep.workloadNodeIP,
 			w.prometheusPort,
 		)
-		fromVal, warnings, err := ep.promClient.Query(
-			ctx,
-			q,
-			fromTime,
-		)
+		fromVal, err := ep.queryPrometheus(ctx, l, q, fromTime)
 		if err != nil {
 			return err
 		}
-		if len(warnings) > 0 {
-			return errors.Newf("found warnings querying prometheus: %s", warnings)
-		}
-		toVal, warnings, err := ep.promClient.Query(
-			ctx,
-			q,
-			toTime,
-		)
+		toVal, err := ep.queryPrometheus(ctx, l, q, toTime)
 		if err != nil {
 			return err
-		}
-		if len(warnings) > 0 {
-			return errors.Newf("found warnings querying prometheus: %s", warnings)
 		}
 
 		// Results are a vector with 1 element, so deserialize accordingly.
@@ -209,6 +198,29 @@ func (ep *tpccChaosEventProcessor) checkMetrics(
 		}
 	}
 	return nil
+}
+
+func (ep *tpccChaosEventProcessor) queryPrometheus(
+	ctx context.Context, l *logger.Logger, q string, ts time.Time,
+) (val model.Value, err error) {
+	rOpts := base.DefaultRetryOptions()
+	rOpts.MaxRetries = 5
+	var warnings promv1.Warnings
+	for r := retry.Start(rOpts); r.Next(); {
+		val, warnings, err = ep.promClient.Query(
+			ctx,
+			q,
+			ts,
+		)
+		if err == nil {
+			break
+		}
+		l.Printf("error querying prometheus, retrying: %+v", err)
+	}
+	if len(warnings) > 0 {
+		return nil, errors.Newf("found warnings querying prometheus: %s", warnings)
+	}
+	return val, err
 }
 
 func (ep *tpccChaosEventProcessor) writeErr(ctx context.Context, l *logger.Logger, err error) {

--- a/pkg/cmd/roachtest/tests/tpcc.go
+++ b/pkg/cmd/roachtest/tests/tpcc.go
@@ -264,7 +264,7 @@ func runTPCC(ctx context.Context, t test.Test, c cluster.Cluster, opts tpccOptio
 	// Check no errors from metrics.
 	if ep != nil {
 		if err := ep.err(); err != nil {
-			t.Fatal(err)
+			t.Fatal(errors.Wrap(err, "error detected during DRT"))
 		}
 	}
 }


### PR DESCRIPTION
Backport 1/1 commits from #96159.

/cc @cockroachdb/release

---

Previously, the prometheus endpoint may sometimes return an EOF error. This seems sporadic / random so I'm
making it retryable.

Release justification: bug fix tests only

Resolves #74684

Release note: None
