### PR TITLE
sql: implement function OID reference

### DIFF
--- a/docs/generated/sql/bnf/stmt_block.bnf
+++ b/docs/generated/sql/bnf/stmt_block.bnf
@@ -3491,11 +3491,11 @@ opt_interval_qualifier ::=
 	| 
 
 func_application ::=
-	func_name '(' ')'
-	| func_name '(' expr_list opt_sort_clause ')'
-	| func_name '(' 'ALL' expr_list opt_sort_clause ')'
-	| func_name '(' 'DISTINCT' expr_list ')'
-	| func_name '(' '*' ')'
+	func_application_name '(' ')'
+	| func_application_name '(' expr_list opt_sort_clause ')'
+	| func_application_name '(' 'ALL' expr_list opt_sort_clause ')'
+	| func_application_name '(' 'DISTINCT' expr_list ')'
+	| func_application_name '(' '*' ')'
 
 within_group_clause ::=
 	'WITHIN' 'GROUP' '(' single_sort_clause ')'
@@ -3747,10 +3747,9 @@ rowsfrom_item ::=
 opt_col_def_list ::=
 	'(' col_def_list ')'
 
-func_name ::=
-	type_function_name
-	| prefixed_column_path
-	| 'INDEX'
+func_application_name ::=
+	func_name
+	| 'OID_FUNCTION_REF' iconst32
 
 single_sort_clause ::=
 	'ORDER' 'BY' sortby
@@ -3898,10 +3897,10 @@ create_as_params ::=
 col_def_list ::=
 	( col_def ) ( ( ',' col_def ) )*
 
-type_function_name ::=
-	'identifier'
-	| unreserved_keyword
-	| type_func_name_keyword
+func_name ::=
+	type_function_name
+	| prefixed_column_path
+	| 'INDEX'
 
 opt_existing_window_name ::=
 	name
@@ -3941,6 +3940,11 @@ trim_list ::=
 	a_expr 'FROM' expr_list
 	| 'FROM' expr_list
 	| expr_list
+
+type_function_name ::=
+	'identifier'
+	| unreserved_keyword
+	| type_func_name_keyword
 
 char_aliases ::=
 	'CHAR'

--- a/pkg/ccl/changefeedccl/cdceval/func_resolver.go
+++ b/pkg/ccl/changefeedccl/cdceval/func_resolver.go
@@ -88,13 +88,13 @@ func (rs *cdcFunctionResolver) ResolveFunction(
 // ResolveFunctionByOID implements FunctionReferenceResolver interface.
 func (rs *cdcFunctionResolver) ResolveFunctionByOID(
 	ctx context.Context, oid oid.Oid,
-) (string, *tree.Overload, error) {
+) (*tree.FunctionName, *tree.Overload, error) {
 	fnName, overload, err := rs.wrapped.ResolveFunctionByOID(ctx, oid)
 	if err != nil {
-		return "", nil, err
+		return nil, nil, err
 	}
-	if err := checkOverloadSupported(fnName, overload); err != nil {
-		return "", nil, err
+	if err := checkOverloadSupported(fnName.Object(), overload); err != nil {
+		return nil, nil, err
 	}
 	return fnName, overload, err
 }

--- a/pkg/ccl/logictestccl/tests/3node-tenant/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/3node-tenant/generated_test.go
@@ -2019,6 +2019,13 @@ func TestTenantLogic_udf(
 	runLogicTest(t, "udf")
 }
 
+func TestTenantLogic_udf_oid_ref(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "udf_oid_ref")
+}
+
 func TestTenantLogic_union(
 	t *testing.T,
 ) {

--- a/pkg/sql/faketreeeval/evalctx.go
+++ b/pkg/sql/faketreeeval/evalctx.go
@@ -446,8 +446,8 @@ func (ep *DummyEvalPlanner) ResolveFunction(
 // ResolveFunctionByOID implements FunctionReferenceResolver interface.
 func (ep *DummyEvalPlanner) ResolveFunctionByOID(
 	ctx context.Context, oid oid.Oid,
-) (string, *tree.Overload, error) {
-	return "", nil, errors.AssertionFailedf("ResolveFunctionByOID unimplemented")
+) (*tree.FunctionName, *tree.Overload, error) {
+	return nil, nil, errors.AssertionFailedf("ResolveFunctionByOID unimplemented")
 }
 
 // GetMultiregionConfig is part of the eval.Planner interface.

--- a/pkg/sql/importer/import_table_creation.go
+++ b/pkg/sql/importer/import_table_creation.go
@@ -431,6 +431,6 @@ func (r fkResolver) ResolveFunction(
 // ResolveFunctionByOID implements the resolver.SchemaResolver interface.
 func (r fkResolver) ResolveFunctionByOID(
 	ctx context.Context, oid oid.Oid,
-) (string, *tree.Overload, error) {
-	return "", nil, errSchemaResolver
+) (*tree.FunctionName, *tree.Overload, error) {
+	return nil, nil, errSchemaResolver
 }

--- a/pkg/sql/logictest/testdata/logic_test/udf_oid_ref
+++ b/pkg/sql/logictest/testdata/logic_test/udf_oid_ref
@@ -1,0 +1,54 @@
+query T
+SELECT @F1074('hello,world', ',')
+----
+{hello,world}
+
+statement ok
+CREATE TABLE t1(a INT PRIMARY KEY, b STRING DEFAULT (@F1074('hello,world', ',')))
+
+statement ok
+INSERT INTO t1(a) VALUES (1)
+
+query IT
+SELECT * FROM t1
+----
+1  {hello,world}
+
+statement ok
+INSERT INTO t1 VALUES (2, 'hello,new,world')
+
+statement ok
+CREATE INDEX idx ON t1(@F1074(b,','))
+
+query IT
+SELECT * FROM t1@idx WHERE @F1074(b, ',') = ARRAY['hello','new','world']
+----
+2  hello,new,world
+
+statement ok
+ALTER TABLE t1 ADD CONSTRAINT c_len CHECK (@F814(b) > 2)
+
+statement error pq: failed to satisfy CHECK constraint (length(b) > 2:::INT8)
+INSERT INTO t1 VALUES (3, 'a')
+
+statement ok
+CREATE FUNCTION f1() RETURNS INT LANGUAGE SQL AS $$ SELECT 1 $$
+
+let $fn_oid
+SELECT oid FROM pg_catalog.pg_proc WHERE proname = 'f1'
+
+query I
+SELECT @F$fn_oid()
+----
+1
+
+statement ok
+CREATE FUNCTION f2(a STRING) RETURNS STRING LANGUAGE SQL AS $$ SELECT a $$
+
+let $fn_oid
+SELECT oid FROM pg_catalog.pg_proc WHERE proname = 'f2'
+
+query T
+SELECT @F$fn_oid('hello world')
+----
+hello world

--- a/pkg/sql/logictest/tests/fakedist-disk/generated_test.go
+++ b/pkg/sql/logictest/tests/fakedist-disk/generated_test.go
@@ -1990,6 +1990,13 @@ func TestLogic_udf(
 	runLogicTest(t, "udf")
 }
 
+func TestLogic_udf_oid_ref(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "udf_oid_ref")
+}
+
 func TestLogic_union(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/fakedist-vec-off/generated_test.go
+++ b/pkg/sql/logictest/tests/fakedist-vec-off/generated_test.go
@@ -1997,6 +1997,13 @@ func TestLogic_udf(
 	runLogicTest(t, "udf")
 }
 
+func TestLogic_udf_oid_ref(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "udf_oid_ref")
+}
+
 func TestLogic_union(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/fakedist/generated_test.go
+++ b/pkg/sql/logictest/tests/fakedist/generated_test.go
@@ -2011,6 +2011,13 @@ func TestLogic_udf(
 	runLogicTest(t, "udf")
 }
 
+func TestLogic_udf_oid_ref(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "udf_oid_ref")
+}
+
 func TestLogic_union(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/local-legacy-schema-changer/generated_test.go
+++ b/pkg/sql/logictest/tests/local-legacy-schema-changer/generated_test.go
@@ -1976,6 +1976,13 @@ func TestLogic_udf(
 	runLogicTest(t, "udf")
 }
 
+func TestLogic_udf_oid_ref(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "udf_oid_ref")
+}
+
 func TestLogic_union(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/local-vec-off/generated_test.go
+++ b/pkg/sql/logictest/tests/local-vec-off/generated_test.go
@@ -2011,6 +2011,13 @@ func TestLogic_udf(
 	runLogicTest(t, "udf")
 }
 
+func TestLogic_udf_oid_ref(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "udf_oid_ref")
+}
+
 func TestLogic_union(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/local/generated_test.go
+++ b/pkg/sql/logictest/tests/local/generated_test.go
@@ -2200,6 +2200,13 @@ func TestLogic_udf(
 	runLogicTest(t, "udf")
 }
 
+func TestLogic_udf_oid_ref(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "udf_oid_ref")
+}
+
 func TestLogic_union(
 	t *testing.T,
 ) {

--- a/pkg/sql/opt/cat/catalog.go
+++ b/pkg/sql/opt/cat/catalog.go
@@ -155,7 +155,7 @@ type Catalog interface {
 	) (*tree.ResolvedFunctionDefinition, error)
 
 	// ResolveFunctionByOID resolves a function overload by OID.
-	ResolveFunctionByOID(ctx context.Context, oid oid.Oid) (string, *tree.Overload, error)
+	ResolveFunctionByOID(ctx context.Context, oid oid.Oid) (*tree.FunctionName, *tree.Overload, error)
 
 	// CheckPrivilege verifies that the current user has the given privilege on
 	// the given catalog object. If not, then CheckPrivilege returns an error.

--- a/pkg/sql/opt/testutils/testcat/function.go
+++ b/pkg/sql/opt/testutils/testcat/function.go
@@ -51,8 +51,8 @@ func (tc *Catalog) ResolveFunction(
 // ResolveFunctionByOID part of the tree.FunctionReferenceResolver interface.
 func (tc *Catalog) ResolveFunctionByOID(
 	ctx context.Context, oid oid.Oid,
-) (string, *tree.Overload, error) {
-	return "", nil, errors.AssertionFailedf("ResolveFunctionByOID not supported in test catalog")
+) (*tree.FunctionName, *tree.Overload, error) {
+	return nil, nil, errors.AssertionFailedf("ResolveFunctionByOID not supported in test catalog")
 }
 
 // CreateFunction handles the CREATE FUNCTION statement.

--- a/pkg/sql/opt_catalog.go
+++ b/pkg/sql/opt_catalog.go
@@ -344,7 +344,7 @@ func (oc *optCatalog) ResolveFunction(
 
 func (oc *optCatalog) ResolveFunctionByOID(
 	ctx context.Context, oid oid.Oid,
-) (string, *tree.Overload, error) {
+) (*tree.FunctionName, *tree.Overload, error) {
 	return oc.planner.ResolveFunctionByOID(ctx, oid)
 }
 

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -734,6 +734,9 @@ func (u *sqlSymUnion) scrubOption() tree.ScrubOption {
 func (u *sqlSymUnion) resolvableFuncRefFromName() tree.ResolvableFunctionReference {
     return tree.ResolvableFunctionReference{FunctionReference: u.unresolvedName()}
 }
+func (u *sqlSymUnion) resolvableFuncRef() tree.ResolvableFunctionReference {
+    return u.val.(tree.ResolvableFunctionReference)
+}
 func (u *sqlSymUnion) rowsFromExpr() *tree.RowsFromExpr {
     return u.val.(*tree.RowsFromExpr)
 }
@@ -948,6 +951,7 @@ func (u *sqlSymUnion) showTenantOpts() tree.ShowTenantOptions {
 
 %token <str> OF OFF OFFSET OID OIDS OIDVECTOR OLD_KMS ON ONLY OPT OPTION OPTIONS OR
 %token <str> ORDER ORDINALITY OTHERS OUT OUTER OVER OVERLAPS OVERLAY OWNED OWNER OPERATOR
+%token <str> OID_FUNCTION_REF
 
 %token <str> PARALLEL PARENT PARTIAL PARTITION PARTITIONS PASSWORD PAUSE PAUSED PHYSICAL PLACEMENT PLACING
 %token <str> PLAN PLANS POINT POINTM POINTZ POINTZM POLYGON POLYGONM POLYGONZ POLYGONZM
@@ -1370,6 +1374,7 @@ func (u *sqlSymUnion) showTenantOpts() tree.ShowTenantOptions {
 %type <tree.KVOption> role_option password_clause valid_until_clause
 %type <tree.Operator> subquery_op
 %type <*tree.UnresolvedName> func_name func_name_no_crdb_extra
+%type <tree.ResolvableFunctionReference> func_application_name
 %type <str> opt_class opt_collate
 
 %type <str> cursor_name database_name index_name opt_index_name column_name insert_column_item statistics_name window_name opt_in_database
@@ -14264,7 +14269,7 @@ d_expr:
     if err != nil { return setErr(sqllex, err) }
     $$.val = d
   }
-| func_name '(' expr_list opt_sort_clause ')' SCONST { return unimplemented(sqllex, $1.unresolvedName().String() + "(...) SCONST") }
+| func_application_name '(' expr_list opt_sort_clause ')' SCONST { return unimplemented(sqllex, $1.resolvableFuncRef().String() + "(...) SCONST") }
 | typed_literal
   {
     $$.val = $1.expr()
@@ -14351,31 +14356,44 @@ d_expr:
 | GROUPING '(' expr_list ')' { return unimplemented(sqllex, "d_expr grouping") }
 
 func_application:
-  func_name '(' ')'
+  func_application_name '(' ')'
   {
-    $$.val = &tree.FuncExpr{Func: $1.resolvableFuncRefFromName()}
+    $$.val = &tree.FuncExpr{Func: $1.resolvableFuncRef()}
   }
-| func_name '(' expr_list opt_sort_clause ')'
+| func_application_name '(' expr_list opt_sort_clause ')'
   {
-    $$.val = &tree.FuncExpr{Func: $1.resolvableFuncRefFromName(), Exprs: $3.exprs(), OrderBy: $4.orderBy(), AggType: tree.GeneralAgg}
+    $$.val = &tree.FuncExpr{Func: $1.resolvableFuncRef(), Exprs: $3.exprs(), OrderBy: $4.orderBy(), AggType: tree.GeneralAgg}
   }
-| func_name '(' VARIADIC a_expr opt_sort_clause ')' { return unimplemented(sqllex, "variadic") }
-| func_name '(' expr_list ',' VARIADIC a_expr opt_sort_clause ')' { return unimplemented(sqllex, "variadic") }
-| func_name '(' ALL expr_list opt_sort_clause ')'
+| func_application_name '(' VARIADIC a_expr opt_sort_clause ')' { return unimplemented(sqllex, "variadic") }
+| func_application_name '(' expr_list ',' VARIADIC a_expr opt_sort_clause ')' { return unimplemented(sqllex, "variadic") }
+| func_application_name '(' ALL expr_list opt_sort_clause ')'
   {
-    $$.val = &tree.FuncExpr{Func: $1.resolvableFuncRefFromName(), Type: tree.AllFuncType, Exprs: $4.exprs(), OrderBy: $5.orderBy(), AggType: tree.GeneralAgg}
+    $$.val = &tree.FuncExpr{Func: $1.resolvableFuncRef(), Type: tree.AllFuncType, Exprs: $4.exprs(), OrderBy: $5.orderBy(), AggType: tree.GeneralAgg}
   }
 // TODO(ridwanmsharif): Once DISTINCT is supported by window aggregates,
 // allow ordering to be specified below.
-| func_name '(' DISTINCT expr_list ')'
+| func_application_name '(' DISTINCT expr_list ')'
   {
-    $$.val = &tree.FuncExpr{Func: $1.resolvableFuncRefFromName(), Type: tree.DistinctFuncType, Exprs: $4.exprs()}
+    $$.val = &tree.FuncExpr{Func: $1.resolvableFuncRef(), Type: tree.DistinctFuncType, Exprs: $4.exprs()}
   }
-| func_name '(' '*' ')'
+| func_application_name '(' '*' ')'
   {
-    $$.val = &tree.FuncExpr{Func: $1.resolvableFuncRefFromName(), Exprs: tree.Exprs{tree.StarExpr()}}
+    $$.val = &tree.FuncExpr{Func: $1.resolvableFuncRef(), Exprs: tree.Exprs{tree.StarExpr()}}
   }
-| func_name '(' error { return helpWithFunction(sqllex, $1.resolvableFuncRefFromName()) }
+| func_application_name '(' error { return helpWithFunction(sqllex, $1.resolvableFuncRef()) }
+
+func_application_name:
+  func_name
+  {
+    $$.val = $1.resolvableFuncRefFromName()
+  }
+| OID_FUNCTION_REF iconst32
+  {
+    id := $2.int32()
+    $$.val = tree.ResolvableFunctionReference{
+      FunctionReference: &tree.OIDFunctionReference{OID: oid.Oid(id)},
+    }
+  }
 
 // typed_literal represents expressions like INT '4', or generally <TYPE> SCONST.
 // This rule handles both the case of qualified and non-qualified typenames.

--- a/pkg/sql/parser/testdata/select_numeric_func_expr
+++ b/pkg/sql/parser/testdata/select_numeric_func_expr
@@ -1,0 +1,55 @@
+parse
+SELECT @F1074()
+----
+SELECT @F1074()
+SELECT (@F1074()) -- fully parenthesized
+SELECT @F1074() -- literals removed
+SELECT @F1074() -- identifiers removed
+
+parse
+SELECT @F1074('hello,world', ',')
+----
+SELECT @F1074('hello,world', ',')
+SELECT (@F1074(('hello,world'), (','))) -- fully parenthesized
+SELECT @F1074('_', '_') -- literals removed
+SELECT @F1074('hello,world', ',') -- identifiers removed
+
+parse
+SELECT @F1074(@F1074('hello,world', ','))
+----
+SELECT @F1074(@F1074('hello,world', ','))
+SELECT (@F1074((@F1074(('hello,world'), (','))))) -- fully parenthesized
+SELECT @F1074(@F1074('_', '_')) -- literals removed
+SELECT @F1074(@F1074('hello,world', ',')) -- identifiers removed
+
+parse
+SELECT @F1074(*)
+----
+SELECT @F1074(*)
+SELECT (@F1074((*))) -- fully parenthesized
+SELECT @F1074(*) -- literals removed
+SELECT @F1074(*) -- identifiers removed
+
+parse
+SELECT @F1074('hello','word' ORDER BY a)
+----
+SELECT @F1074('hello', 'word' ORDER BY a) -- normalized!
+SELECT (@F1074(('hello'), ('word') ORDER BY (a))) -- fully parenthesized
+SELECT @F1074('_', '_' ORDER BY a) -- literals removed
+SELECT @F1074('hello', 'word' ORDER BY _) -- identifiers removed
+
+parse
+SELECT @F1074(ALL 'hello', 'world' ORDER BY a)
+----
+SELECT @F1074(ALL 'hello', 'world' ORDER BY a)
+SELECT (@F1074(ALL ('hello'), ('world') ORDER BY (a))) -- fully parenthesized
+SELECT @F1074(ALL '_', '_' ORDER BY a) -- literals removed
+SELECT @F1074(ALL 'hello', 'world' ORDER BY _) -- identifiers removed
+
+parse
+SELECT @F1074(DISTINCT 'hello', 'world')
+----
+SELECT @F1074(DISTINCT 'hello', 'world')
+SELECT (@F1074(DISTINCT ('hello'), ('world'))) -- fully parenthesized
+SELECT @F1074(DISTINCT '_', '_') -- literals removed
+SELECT @F1074(DISTINCT 'hello', 'world') -- identifiers removed

--- a/pkg/sql/pg_catalog.go
+++ b/pkg/sql/pg_catalog.go
@@ -2642,7 +2642,7 @@ https://www.postgresql.org/docs/9.5/catalog-pg-proc.html`,
 						return false, err
 					}
 
-					err = addPgProcBuiltinRow(name, addRow)
+					err = addPgProcBuiltinRow(name.Object(), addRow)
 					if err != nil {
 						return false, err
 					}

--- a/pkg/sql/scanner/scan.go
+++ b/pkg/sql/scanner/scan.go
@@ -391,6 +391,10 @@ func (s *Scanner) Scan(lval ScanSymType) {
 			s.pos++
 			lval.SetID(lexbase.AT_AT)
 			return
+		case 'F': // @F
+			s.pos++
+			lval.SetID(lexbase.OID_FUNCTION_REF)
+			return
 		}
 		return
 

--- a/pkg/sql/schema_resolver.go
+++ b/pkg/sql/schema_resolver.go
@@ -534,31 +534,31 @@ func maybeLookUpUDF(
 
 func (sr *schemaResolver) ResolveFunctionByOID(
 	ctx context.Context, oid oid.Oid,
-) (name string, fn *tree.Overload, err error) {
+) (name *tree.FunctionName, fn *tree.Overload, err error) {
 	if !funcdesc.IsOIDUserDefinedFunc(oid) {
-		name, ok := tree.OidToBuiltinName[oid]
+		qol, ok := tree.OidToQualifiedBuiltinOverload[oid]
 		if !ok {
-			return "", nil, errors.Wrapf(tree.ErrFunctionUndefined, "function %d not found", oid)
+			return nil, nil, errors.Wrapf(tree.ErrFunctionUndefined, "function %d not found", oid)
 		}
-		funcDef := tree.FunDefs[name]
-		for _, o := range funcDef.Definition {
-			if o.Oid == oid {
-				return funcDef.Name, o, nil
-			}
-		}
+		fnName := tree.MakeQualifiedFunctionName(sr.CurrentDatabase(), qol.Schema, tree.OidToBuiltinName[oid])
+		return &fnName, qol.Overload, nil
 	}
 
 	g := sr.byIDGetterBuilder().WithoutNonPublic().WithoutOtherParent(sr.typeResolutionDbID).Get()
 	descID := funcdesc.UserDefinedFunctionOIDToID(oid)
 	funcDesc, err := g.Function(ctx, descID)
 	if err != nil {
-		return "", nil, err
+		return nil, nil, err
 	}
 	ret, err := funcDesc.ToOverload()
 	if err != nil {
-		return "", nil, err
+		return nil, nil, err
 	}
-	return funcDesc.GetName(), ret, nil
+	fnName, err := sr.getQualifiedFunctionName(ctx, funcDesc)
+	if err != nil {
+		return nil, nil, err
+	}
+	return fnName, ret, nil
 }
 
 // NewSkippingCacheSchemaResolver constructs a schemaResolver which always skip

--- a/pkg/sql/schemachanger/scdeps/build_deps.go
+++ b/pkg/sql/schemachanger/scdeps/build_deps.go
@@ -238,7 +238,7 @@ func (d *buildDeps) ResolveFunction(
 // ResolveFunctionByOID implements the scbuild.CatalogReader interface.
 func (d *buildDeps) ResolveFunctionByOID(
 	ctx context.Context, oid oid.Oid,
-) (string, *tree.Overload, error) {
+) (*tree.FunctionName, *tree.Overload, error) {
 	return d.schemaResolver.ResolveFunctionByOID(ctx, oid)
 }
 

--- a/pkg/sql/sem/builtins/BUILD.bazel
+++ b/pkg/sql/sem/builtins/BUILD.bazel
@@ -205,6 +205,7 @@ go_test(
         "//pkg/util/syncutil",
         "//pkg/util/timeutil",
         "@com_github_lib_pq//:pq",
+        "@com_github_lib_pq//oid",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
     ],

--- a/pkg/sql/sem/eval/cast.go
+++ b/pkg/sql/sem/eval/cast.go
@@ -998,7 +998,7 @@ func performIntToOidCast(
 			}
 			return nil, err
 		}
-		return tree.NewDOidWithTypeAndName(o, t, name), nil
+		return tree.NewDOidWithTypeAndName(o, t, name.Object()), nil
 
 	default:
 		if v == 0 {

--- a/pkg/sql/sem/tree/function_definition.go
+++ b/pkg/sql/sem/tree/function_definition.go
@@ -198,6 +198,10 @@ var ResolvedBuiltinFuncDefs map[string]*ResolvedFunctionDefinition
 // package because of dependency issues: we can't use oidHasher from this file.
 var OidToBuiltinName map[oid.Oid]string
 
+// OidToQualifiedBuiltinOverload is a map from builtin function OID to an
+// qualified overload.
+var OidToQualifiedBuiltinOverload map[oid.Oid]QualifiedOverload
+
 // Format implements the NodeFormatter interface.
 func (fd *FunctionDefinition) Format(ctx *FmtCtx) {
 	ctx.WriteString(fd.Name)

--- a/pkg/sql/sem/tree/function_name.go
+++ b/pkg/sql/sem/tree/function_name.go
@@ -57,7 +57,7 @@ type FunctionReferenceResolver interface {
 	// there is no function with the same oid.
 	ResolveFunctionByOID(
 		ctx context.Context, oid oid.Oid,
-	) (string, *Overload, error)
+	) (*FunctionName, *Overload, error)
 }
 
 // ResolvableFunctionReference implements the editable reference call of a
@@ -113,6 +113,17 @@ func (ref *ResolvableFunctionReference) Resolve(
 		}
 		ref.FunctionReference = fd
 		return fd, nil
+	case *OIDFunctionReference:
+		fnName, o, err := resolver.ResolveFunctionByOID(ctx, t.OID)
+		if err != nil {
+			return nil, err
+		}
+		fd := &ResolvedFunctionDefinition{
+			Name:      fnName.Object(),
+			Overloads: []QualifiedOverload{{Schema: fnName.Schema(), Overload: o}},
+		}
+		ref.FunctionReference = fd
+		return fd, nil
 	default:
 		return nil, errors.AssertionFailedf("unknown resolvable function reference type %s", t)
 	}
@@ -146,3 +157,16 @@ var _ FunctionReference = &ResolvedFunctionDefinition{}
 func (*UnresolvedName) functionReference()             {}
 func (*FunctionDefinition) functionReference()         {}
 func (*ResolvedFunctionDefinition) functionReference() {}
+func (*OIDFunctionReference) functionReference()       {}
+
+type OIDFunctionReference struct {
+	OID oid.Oid
+}
+
+func (o *OIDFunctionReference) String() string {
+	return AsString(o)
+}
+
+func (o *OIDFunctionReference) Format(ctx *FmtCtx) {
+	ctx.WriteString(fmt.Sprintf("@F%d", o.OID))
+}


### PR DESCRIPTION
This commit implements `@F` OID references syntax of functions. With this change, functions can be called with oid numerical representation. For example `SELECT @F('helloworld')`. The intention of this syntax is only for internal serialization of references to UDFs. But it's general enough for builtin funtions as well.

Fixes: #83231

Release note: None