### PR TITLE
ui: databases page scales to handle large number of dbs

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/sortedtable/sortedtable.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/sortedtable/sortedtable.tsx
@@ -103,6 +103,7 @@ interface SortedTableProps<T> {
   pagination?: ISortedTablePagination;
   loading?: boolean;
   loadingLabel?: string;
+  disableSortSizeLimit?: number;
   // empty state for table
   empty?: boolean;
   emptyProps?: EmptyPanelProps;
@@ -225,6 +226,14 @@ export class SortedTable<T> extends React.Component<
       if (!sortSetting) {
         return this.paginatedData();
       }
+
+      if (
+        this.props.disableSortSizeLimit &&
+        data.length > this.props.disableSortSizeLimit
+      ) {
+        return this.paginatedData();
+      }
+
       const sortColumn = columns.find(c => c.name === sortSetting.columnTitle);
       if (!sortColumn || !sortColumn.sort) {
         return this.paginatedData();
@@ -253,13 +262,17 @@ export class SortedTable<T> extends React.Component<
       rollups: React.ReactNode[],
       columns: ColumnDescriptor<T>[],
     ) => {
+      const sort =
+        !this.props.disableSortSizeLimit ||
+        this.props.data.length <= this.props.disableSortSizeLimit;
+
       return columns.map((cd, ii): SortableColumn => {
         return {
           name: cd.name,
           title: cd.title,
           hideTitleUnderline: cd.hideTitleUnderline,
           cell: index => cd.cell(sorted[index]),
-          columnTitle: cd.sort ? cd.name : undefined,
+          columnTitle: sort && cd.sort ? cd.name : undefined,
           rollup: rollups[ii],
           className: cd.className,
           titleAlign: cd.titleAlign,

--- a/pkg/ui/workspaces/cluster-ui/src/sqlActivity/errorComponent.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/sqlActivity/errorComponent.tsx
@@ -17,9 +17,17 @@ const cx = classNames.bind(styles);
 interface SQLActivityErrorProps {
   statsType: string;
   timeout?: boolean;
+  error?: Error;
 }
 
 const LoadingError: React.FC<SQLActivityErrorProps> = props => {
+  if (props.error && props.error.name === "GetDatabaseInfoError") {
+    return (
+      <div className={cx("row")}>
+        <span>{props.error.message}</span>
+      </div>
+    );
+  }
   const error = props.timeout ? "a timeout" : "an unexpected error";
   return (
     <div className={cx("row")}>

--- a/pkg/ui/workspaces/db-console/src/util/fakeApi.ts
+++ b/pkg/ui/workspaces/db-console/src/util/fakeApi.ts
@@ -70,11 +70,6 @@ export function buildSQLApiDatabasesResponse(databases: string[]) {
   const rows: clusterUiApi.DatabasesColumns[] = databases.map(database => {
     return {
       database_name: database,
-      owner: "root",
-      primary_region: null,
-      secondary_region: null,
-      regions: ["gcp-europe-west1", "gcp-europe-west2"],
-      survival_goal: null,
     };
   });
   return {


### PR DESCRIPTION
The databases page displays partial results instead of
just showing an error message.

Sorting is disabled if there are more than 2 pages of results
which is currently configured to 40dbs. This still allows most 
user to use sort functionality, but prevents large customers
from breaking when it would need to do a network call per a
database.

The database details are now loaded on demand for the first
page only. Previously a network call was done for all databases 
which would result in 2k network calls. It now only loads the page
of details the user is looking at. 

part of: #94333

https://www.loom.com/share/31b213b2f1764d0f9868bd967b9388b8

Release note: none