### PR TITLE
storage: add string repr for FullReplicaID

### DIFF
--- a/pkg/storage/BUILD.bazel
+++ b/pkg/storage/BUILD.bazel
@@ -91,6 +91,7 @@ go_library(
         "@com_github_cockroachdb_pebble//vfs",
         "@com_github_cockroachdb_pebble//vfs/atomicfs",
         "@com_github_cockroachdb_redact//:redact",
+        "@com_github_cockroachdb_redact//interfaces",
         "@com_github_dustin_go_humanize//:go-humanize",
         "@com_github_elastic_gosigar//:gosigar",
         "@com_github_gogo_protobuf//proto",

--- a/pkg/storage/replicas_storage.go
+++ b/pkg/storage/replicas_storage.go
@@ -12,6 +12,8 @@ package storage
 
 import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/redact"
+	"github.com/cockroachdb/redact/interfaces"
 	"go.etcd.io/raft/v3/raftpb"
 )
 
@@ -538,6 +540,17 @@ type FullReplicaID struct {
 	RangeID roachpb.RangeID
 	// ReplicaID is the id of the replica.
 	ReplicaID roachpb.ReplicaID
+}
+
+// SafeFormat implements redact.SafeFormatter. It prints as
+// r<rangeID>/<replicaID>.
+func (id FullReplicaID) SafeFormat(s interfaces.SafePrinter, _ rune) {
+	s.Printf("r%d/%d", id.RangeID, id.ReplicaID)
+}
+
+// String formats a store for debug output.
+func (id FullReplicaID) String() string {
+	return redact.StringWithoutMarkers(id)
 }
 
 // ReplicaInfo provides the replica ID and state pair.


### PR DESCRIPTION
Helpful for subsequent unit testing involving this type.

NB: this type is in the wrong place. Now's not the time
to move it.

Epic: none
Release note: None
