### PR TITLE
loqrecovery: use local leaseholder status in replica check

### DIFF
--- a/pkg/kv/kvserver/loqrecovery/BUILD.bazel
+++ b/pkg/kv/kvserver/loqrecovery/BUILD.bazel
@@ -94,6 +94,7 @@ go_test(
         "//pkg/util/log",
         "//pkg/util/protoutil",
         "//pkg/util/randutil",
+        "//pkg/util/strutil",
         "//pkg/util/timeutil",
         "//pkg/util/uuid",
         "@com_github_cockroachdb_datadriven//:datadriven",

--- a/pkg/kv/kvserver/loqrecovery/collect.go
+++ b/pkg/kv/kvserver/loqrecovery/collect.go
@@ -160,6 +160,8 @@ func visitStoreReplicas(
 			return err
 		}
 
+		localIsLeaseholder := rstate.Lease != nil && rstate.Lease.Replica.StoreID == storeID
+
 		return send(loqrecoverypb.ReplicaInfo{
 			StoreID:                  storeID,
 			NodeID:                   nodeID,
@@ -167,6 +169,7 @@ func visitStoreReplicas(
 			RaftAppliedIndex:         rstate.RaftAppliedIndex,
 			RaftCommittedIndex:       hstate.Commit,
 			RaftLogDescriptorChanges: rangeUpdates,
+			LocalAssumesLeaseholder:  localIsLeaseholder,
 		})
 	}); err != nil {
 		return err

--- a/pkg/kv/kvserver/loqrecovery/loqrecoverypb/recovery.proto
+++ b/pkg/kv/kvserver/loqrecovery/loqrecoverypb/recovery.proto
@@ -114,6 +114,11 @@ message ReplicaUpdatePlan {
     (gogoproto.casttype) = "github.com/cockroachdb/cockroach/pkg/roachpb.NodeID"];
   // ClusterID contains id of the cluster from which info was collected.
   string cluster_id = 4 [(gogoproto.customname) = "ClusterID"];
+  // StaleLeaseholderNodeIDs is a set of node IDs that need to be restarted even
+  // they have no scheduled changes. This is needed to get rid of range leases
+  // that they hold and that can't be shed because quorum is lost on the ranges.
+  repeated int32 stale_leaseholder_node_ids = 5 [(gogoproto.customname) = "StaleLeaseholderNodeIDs",
+    (gogoproto.casttype) = "github.com/cockroachdb/cockroach/pkg/roachpb.NodeID"];
 }
 
 // ReplicaRecoveryRecord is a struct that loss of quorum recovery commands

--- a/pkg/kv/kvserver/loqrecovery/loqrecoverypb/recovery.proto
+++ b/pkg/kv/kvserver/loqrecovery/loqrecoverypb/recovery.proto
@@ -50,6 +50,8 @@ message ReplicaInfo {
   uint64 raft_committed_index = 5;
   repeated DescriptorChangeInfo raft_log_descriptor_changes = 6 [(gogoproto.nullable) = false,
     (gogoproto.jsontag) = "raft_log_descriptor_changes,omitempty"];
+  bool local_assumes_leaseholder = 7 [
+    (gogoproto.jsontag) = "raft_log_descriptor_changes,omitempty"];
 }
 
 // Collection of replica information gathered in a collect-info run.

--- a/pkg/kv/kvserver/loqrecovery/plan.go
+++ b/pkg/kv/kvserver/loqrecovery/plan.go
@@ -87,6 +87,7 @@ type PlannedReplicaUpdate struct {
 	// Discarded replicas based on survivor descriptor content.
 	DiscardedAvailableReplicas roachpb.ReplicaSet
 	DiscardedDeadReplicas      roachpb.ReplicaSet
+	DiscardedLeaseholders      roachpb.ReplicaSet
 	// Discarded actual replicas from stores (including stale).
 	DiscardedReplicasCount int
 	NextReplicaID          roachpb.ReplicaID
@@ -156,10 +157,14 @@ func PlanReplicas(
 
 	updates := make([]loqrecoverypb.ReplicaUpdate, len(report.PlannedUpdates))
 	updatedLocations := make(locationsMap)
+	nodesWithDiscardedLeaseholders := make(map[roachpb.NodeID]interface{})
 	for i, u := range report.PlannedUpdates {
 		updates[i] = u.asReplicaUpdate()
 		updatedLocations.add(u.NewReplica.NodeID, u.NewReplica.StoreID)
 		report.DiscardedNonSurvivors += u.DiscardedReplicasCount
+		for _, r := range u.DiscardedLeaseholders.Descriptors() {
+			nodesWithDiscardedLeaseholders[r.NodeID] = struct{}{}
+		}
 	}
 	report.UpdatedNodes = updatedLocations.asSortedSlice()
 
@@ -167,15 +172,22 @@ func PlanReplicas(
 	for id := range deadNodes {
 		decommissionNodeIDs = append(decommissionNodeIDs, id)
 	}
-	sort.Slice(decommissionNodeIDs, func(i, j int) bool {
-		return decommissionNodeIDs[i] < decommissionNodeIDs[j]
-	})
+	sort.Sort(roachpb.NodeIDSlice(decommissionNodeIDs))
+
+	var staleLeaseholderNodes []roachpb.NodeID
+	for node := range nodesWithDiscardedLeaseholders {
+		if _, ok := updatedLocations[node]; !ok {
+			staleLeaseholderNodes = append(staleLeaseholderNodes, node)
+		}
+	}
+	sort.Sort(roachpb.NodeIDSlice(staleLeaseholderNodes))
 
 	return loqrecoverypb.ReplicaUpdatePlan{
-		Updates:               updates,
-		PlanID:                planID,
-		DecommissionedNodeIDs: decommissionNodeIDs,
-		ClusterID:             clusterInfo.ClusterID,
+		Updates:                 updates,
+		PlanID:                  planID,
+		DecommissionedNodeIDs:   decommissionNodeIDs,
+		ClusterID:               clusterInfo.ClusterID,
+		StaleLeaseholderNodeIDs: staleLeaseholderNodes,
 	}, report, err
 }
 
@@ -397,22 +409,12 @@ func rankReplicasBySurvivability(replicas []loqrecoverypb.ReplicaInfo) rankedRep
 		// When finding the best suitable replica evaluate 3 conditions in order:
 		//  - replica is a voter
 		//  - replica has the higher range committed index
+		//  - replica thinks it is the leaseholder
 		//  - replica has the higher store id
 		//
 		// Note: that an outgoing voter cannot be designated, as the only
 		// replication change it could make is to turn itself into a learner, at
 		// which point the range is completely messed up.
-		//
-		// Note: a better heuristic might be to choose the leaseholder store, not
-		// the largest store, as this avoids the problem of requests still hanging
-		// after running the tool in a rolling-restart fashion (when the lease-
-		// holder is under a valid epoch and was ont chosen as designated
-		// survivor). However, this choice is less deterministic, as leaseholders
-		// are more likely to change than replication configs. The hanging would
-		// independently be fixed by the below issue, so staying with largest store
-		// is likely the right choice. See:
-		//
-		// https://github.com/cockroachdb/cockroach/issues/33007
 		voterI := isVoter(replicas[i])
 		voterJ := isVoter(replicas[j])
 		if voterI > voterJ {
@@ -562,10 +564,14 @@ func makeReplicaUpdateIfNeeded(
 	// Replicas that belong to available nodes, but discarded as they are
 	// not preferred choice.
 	discardedAvailable := roachpb.ReplicaSet{}
+	discardedLeaseholders := roachpb.ReplicaSet{}
 	for _, storeReplica := range p[1:] {
 		discardedDead.RemoveReplica(storeReplica.NodeID, storeReplica.StoreID)
 		r, _ := storeReplica.Desc.GetReplicaDescriptor(storeReplica.StoreID)
 		discardedAvailable.AddReplica(r)
+		if storeReplica.LocalAssumesLeaseholder {
+			discardedLeaseholders.AddReplica(r)
+		}
 	}
 
 	// The range needs to be recovered and this replica is a designated survivor.
@@ -586,6 +592,7 @@ func makeReplicaUpdateIfNeeded(
 		StoreID:                    p.storeID(),
 		DiscardedAvailableReplicas: discardedAvailable,
 		DiscardedDeadReplicas:      discardedDead,
+		DiscardedLeaseholders:      discardedLeaseholders,
 		DiscardedReplicasCount:     len(p) - 1,
 		NextReplicaID:              nextReplicaID + nextReplicaIDIncrement + 1,
 	}, true

--- a/pkg/kv/kvserver/loqrecovery/plan.go
+++ b/pkg/kv/kvserver/loqrecovery/plan.go
@@ -427,6 +427,9 @@ func rankReplicasBySurvivability(replicas []loqrecoverypb.ReplicaInfo) rankedRep
 		if replicas[i].RaftAppliedIndex < replicas[j].RaftAppliedIndex {
 			return false
 		}
+		if replicas[i].LocalAssumesLeaseholder != replicas[j].LocalAssumesLeaseholder {
+			return replicas[i].LocalAssumesLeaseholder
+		}
 		return replicas[i].StoreID > replicas[j].StoreID
 	})
 	return replicas

--- a/pkg/kv/kvserver/loqrecovery/server_integration_test.go
+++ b/pkg/kv/kvserver/loqrecovery/server_integration_test.go
@@ -277,6 +277,7 @@ func TestStageRecoveryPlans(t *testing.T) {
 	plan.Updates = []loqrecoverypb.ReplicaUpdate{
 		createRecoveryForRange(t, tc, sk, 3),
 	}
+	plan.StaleLeaseholderNodeIDs = []roachpb.NodeID{1}
 	res, err := adm.RecoveryStagePlan(ctx, &serverpb.RecoveryStagePlanRequest{Plan: &plan, AllNodes: true})
 	require.NoError(t, err, "failed to stage plan")
 	require.Empty(t, res.Errors, "unexpected errors in stage response")
@@ -285,7 +286,7 @@ func TestStageRecoveryPlans(t *testing.T) {
 	resp, err = adm.RecoveryVerify(ctx, &serverpb.RecoveryVerifyRequest{})
 	require.NoError(t, err)
 	statuses := aggregateStatusByNode(resp)
-	require.Nil(t, statuses[1].PendingPlanID, "unexpected plan id on node 1")
+	require.Equal(t, &plan.PlanID, statuses[1].PendingPlanID, "incorrect plan id on node 1")
 	require.Nil(t, statuses[2].PendingPlanID, "unexpected plan id on node 2")
 	require.Equal(t, &plan.PlanID, statuses[3].PendingPlanID, "incorrect plan id on node 3")
 }

--- a/pkg/kv/kvserver/loqrecovery/testdata/leaseholder_discarded
+++ b/pkg/kv/kvserver/loqrecovery/testdata/leaseholder_discarded
@@ -1,0 +1,86 @@
+# Tests verifying when leaseholder replica is discarded, it is reflected in the plan
+# as node that needs to be restarted.
+
+# First use case where we can successfully resolve replica by store ID.
+# With two out of five replicas remaining and leaseholder losing based
+# on applied index will cause its node to be marked for restart even if
+# there are no changes to apply.
+
+replication-data
+- StoreID: 1
+  RangeID: 1
+  StartKey: /Min
+  EndKey: /Max
+  Replicas:
+  - { NodeID: 1, StoreID: 1, ReplicaID: 1, Leaseholder: true}  # this is a leaseholder, but it lags behind another replica
+  - { NodeID: 2, StoreID: 2, ReplicaID: 2}
+  - { NodeID: 3, StoreID: 3, ReplicaID: 3}
+  - { NodeID: 4, StoreID: 4, ReplicaID: 4}
+  - { NodeID: 5, StoreID: 5, ReplicaID: 5}
+  RangeAppliedIndex: 7
+  RaftCommittedIndex: 8
+- StoreID: 2
+  RangeID: 1
+  StartKey: /Min
+  EndKey: /Max
+  Replicas:
+  - { NodeID: 1, StoreID: 1, ReplicaID: 1, Leaseholder: true}
+  - { NodeID: 2, StoreID: 2, ReplicaID: 2}  # this replica has the same state n1 but has higher storeID but not a leaseholder
+  - { NodeID: 3, StoreID: 3, ReplicaID: 3}
+  - { NodeID: 4, StoreID: 4, ReplicaID: 4}
+  - { NodeID: 5, StoreID: 5, ReplicaID: 5}
+  RangeAppliedIndex: 10
+  RaftCommittedIndex: 13
+----
+ok
+
+collect-replica-info stores=(1,2)
+----
+ok
+
+make-plan
+----
+Replica updates:
+- RangeID: 1
+  StartKey: /Min
+  OldReplicaID: 2
+  NewReplica:
+    NodeID: 2
+    StoreID: 2
+    ReplicaID: 16
+  NextReplicaID: 17
+Decommissioned nodes:
+[n3, n4, n5]
+Nodes to restart:
+[n1]
+
+apply-plan stores=(1,2)
+----
+ok
+
+dump-store stores=(1,2)
+----
+- NodeID: 1
+  StoreID: 1
+  Descriptors:
+  - RangeID: 1
+    StartKey: /Min
+    Replicas:
+    - Replica: {NodeID: 1, StoreID: 1, ReplicaID: 1}
+    - Replica: {NodeID: 2, StoreID: 2, ReplicaID: 2}
+    - Replica: {NodeID: 3, StoreID: 3, ReplicaID: 3}
+    - Replica: {NodeID: 4, StoreID: 4, ReplicaID: 4}
+    - Replica: {NodeID: 5, StoreID: 5, ReplicaID: 5}
+  LocalData:
+  - RangeID: 1
+    RaftReplicaID: 1
+- NodeID: 2
+  StoreID: 2
+  Descriptors:
+  - RangeID: 1
+    StartKey: /Min
+    Replicas:
+    - Replica: {NodeID: 2, StoreID: 2, ReplicaID: 16}
+  LocalData:
+  - RangeID: 1
+    RaftReplicaID: 16

--- a/pkg/kv/kvserver/loqrecovery/testdata/leaseholder_wins
+++ b/pkg/kv/kvserver/loqrecovery/testdata/leaseholder_wins
@@ -10,11 +10,11 @@ replication-data
   StartKey: /Min
   EndKey: /Max
   Replicas:
-  - { NodeID: 1, StoreID: 1, ReplicaID: 1}  # this replica is identical to one in store 2 but has lower storeID 1
+  - { NodeID: 1, StoreID: 1, ReplicaID: 1, Leaseholder: true}  # this replica is identical to one in store 2 but thinks its a leaseholder
   - { NodeID: 2, StoreID: 2, ReplicaID: 2}
   - { NodeID: 3, StoreID: 3, ReplicaID: 3}
   - { NodeID: 4, StoreID: 4, ReplicaID: 4}
-  - { NodeID: 5, StoreID: 5, ReplicaID: 5, Leaseholder: true}
+  - { NodeID: 5, StoreID: 5, ReplicaID: 5}
   RangeAppliedIndex: 10
   RaftCommittedIndex: 13
 - StoreID: 2
@@ -22,11 +22,11 @@ replication-data
   StartKey: /Min
   EndKey: /Max
   Replicas:
-  - { NodeID: 1, StoreID: 1, ReplicaID: 1}
-  - { NodeID: 2, StoreID: 2, ReplicaID: 2}  # this replica has the same state n1 but has higher storeID so it wins
+  - { NodeID: 1, StoreID: 1, ReplicaID: 1, Leaseholder: true}
+  - { NodeID: 2, StoreID: 2, ReplicaID: 2}  # this replica has the same state n1 but has higher storeID but not a leaseholder
   - { NodeID: 3, StoreID: 3, ReplicaID: 3}
   - { NodeID: 4, StoreID: 4, ReplicaID: 4}
-  - { NodeID: 5, StoreID: 5, ReplicaID: 5, Leaseholder: true}
+  - { NodeID: 5, StoreID: 5, ReplicaID: 5}
   RangeAppliedIndex: 10
   RaftCommittedIndex: 13
 ----
@@ -41,10 +41,10 @@ make-plan
 Replica updates:
 - RangeID: 1
   StartKey: /Min
-  OldReplicaID: 2
+  OldReplicaID: 1
   NewReplica:
-    NodeID: 2
-    StoreID: 2
+    NodeID: 1
+    StoreID: 1
     ReplicaID: 16
   NextReplicaID: 17
 Decommissioned nodes:
@@ -62,6 +62,16 @@ dump-store stores=(1,2)
   - RangeID: 1
     StartKey: /Min
     Replicas:
+    - Replica: {NodeID: 1, StoreID: 1, ReplicaID: 16}
+  LocalData:
+  - RangeID: 1
+    RaftReplicaID: 16
+- NodeID: 2
+  StoreID: 2
+  Descriptors:
+  - RangeID: 1
+    StartKey: /Min
+    Replicas:
     - Replica: {NodeID: 1, StoreID: 1, ReplicaID: 1}
     - Replica: {NodeID: 2, StoreID: 2, ReplicaID: 2}
     - Replica: {NodeID: 3, StoreID: 3, ReplicaID: 3}
@@ -69,17 +79,7 @@ dump-store stores=(1,2)
     - Replica: {NodeID: 5, StoreID: 5, ReplicaID: 5}
   LocalData:
   - RangeID: 1
-    RaftReplicaID: 1
-- NodeID: 2
-  StoreID: 2
-  Descriptors:
-  - RangeID: 1
-    StartKey: /Min
-    Replicas:
-    - Replica: {NodeID: 2, StoreID: 2, ReplicaID: 16}
-  LocalData:
-  - RangeID: 1
-    RaftReplicaID: 16
+    RaftReplicaID: 2
 
 # This case is checking that highest store rule still holds when we have
 # range metadata available.
@@ -89,11 +89,11 @@ replication-data
   StartKey: /Min
   EndKey: /Max
   Replicas:
-  - { NodeID: 1, StoreID: 1, ReplicaID: 1}  # this replica is identical to one in store 2 but has lower storeID 1
+  - { NodeID: 1, StoreID: 1, ReplicaID: 1, Leaseholder: true}  # this replica is identical to one in store 2 but thinks its a leaseholder
   - { NodeID: 2, StoreID: 2, ReplicaID: 2}
   - { NodeID: 3, StoreID: 3, ReplicaID: 3}
   - { NodeID: 4, StoreID: 4, ReplicaID: 4}
-  - { NodeID: 5, StoreID: 5, ReplicaID: 5, Leaseholder: true}
+  - { NodeID: 5, StoreID: 5, ReplicaID: 5}
   RangeAppliedIndex: 10
   RaftCommittedIndex: 13
 - StoreID: 2
@@ -101,11 +101,11 @@ replication-data
   StartKey: /Min
   EndKey: /Max
   Replicas:
-  - { NodeID: 1, StoreID: 1, ReplicaID: 1}
-  - { NodeID: 2, StoreID: 2, ReplicaID: 2}  # this replica has the same state n1 but has higher storeID so it wins
+  - { NodeID: 1, StoreID: 1, ReplicaID: 1, Leaseholder: true}
+  - { NodeID: 2, StoreID: 2, ReplicaID: 2}  # this replica has the same state n1 but has higher storeID but not a leaseholder
   - { NodeID: 3, StoreID: 3, ReplicaID: 3}
   - { NodeID: 4, StoreID: 4, ReplicaID: 4}
-  - { NodeID: 5, StoreID: 5, ReplicaID: 5, Leaseholder: true}
+  - { NodeID: 5, StoreID: 5, ReplicaID: 5}
   RangeAppliedIndex: 10
   RaftCommittedIndex: 13
 ----
@@ -132,10 +132,10 @@ make-plan
 Replica updates:
 - RangeID: 1
   StartKey: /Min
-  OldReplicaID: 2
+  OldReplicaID: 1
   NewReplica:
-    NodeID: 2
-    StoreID: 2
+    NodeID: 1
+    StoreID: 1
     ReplicaID: 16
   NextReplicaID: 17
 Decommissioned nodes:
@@ -153,6 +153,16 @@ dump-store stores=(1,2)
   - RangeID: 1
     StartKey: /Min
     Replicas:
+    - Replica: {NodeID: 1, StoreID: 1, ReplicaID: 16}
+  LocalData:
+  - RangeID: 1
+    RaftReplicaID: 16
+- NodeID: 2
+  StoreID: 2
+  Descriptors:
+  - RangeID: 1
+    StartKey: /Min
+    Replicas:
     - Replica: {NodeID: 1, StoreID: 1, ReplicaID: 1}
     - Replica: {NodeID: 2, StoreID: 2, ReplicaID: 2}
     - Replica: {NodeID: 3, StoreID: 3, ReplicaID: 3}
@@ -160,14 +170,4 @@ dump-store stores=(1,2)
     - Replica: {NodeID: 5, StoreID: 5, ReplicaID: 5}
   LocalData:
   - RangeID: 1
-    RaftReplicaID: 1
-- NodeID: 2
-  StoreID: 2
-  Descriptors:
-  - RangeID: 1
-    StartKey: /Min
-    Replicas:
-    - Replica: {NodeID: 2, StoreID: 2, ReplicaID: 16}
-  LocalData:
-  - RangeID: 1
-    RaftReplicaID: 16
+    RaftReplicaID: 2

--- a/pkg/kv/kvserver/loqrecovery/testdata/leaseholder_wins
+++ b/pkg/kv/kvserver/loqrecovery/testdata/leaseholder_wins
@@ -1,8 +1,9 @@
 # Tests verifying that voter with max StoreID would be designated survivor.
 
-# First use case where we can successfully resolve replica by store ID.
-# With two out of five replicas remaining, check that replica with highest
-# store ID is chosen as a survivor.
+# First use case where we can successfully resolve replicas by leaseholder
+# status.
+# With two out of five replicas remaining, check that replica that thinks
+# it was/is a leaseholder is chosen if everything else is the same.
 
 replication-data
 - StoreID: 1
@@ -81,7 +82,7 @@ dump-store stores=(1,2)
   - RangeID: 1
     RaftReplicaID: 2
 
-# This case is checking that highest store rule still holds when we have
+# This case is checking that leaseholder rule still holds when we have
 # range metadata available.
 replication-data
 - StoreID: 1

--- a/pkg/kv/kvserver/loqrecovery/utils.go
+++ b/pkg/kv/kvserver/loqrecovery/utils.go
@@ -35,9 +35,7 @@ func (s storeIDSet) storeSliceFromSet() []roachpb.StoreID {
 	for k := range s {
 		storeIDs = append(storeIDs, k)
 	}
-	sort.Slice(storeIDs, func(i, j int) bool {
-		return storeIDs[i] < storeIDs[j]
-	})
+	sort.Sort(roachpb.StoreIDSlice(storeIDs))
 	return storeIDs
 }
 
@@ -141,14 +139,8 @@ func (m locationsMap) joinNodeIDs() string {
 	for k := range m {
 		nodeIDs = append(nodeIDs, k)
 	}
-	sort.Slice(nodeIDs, func(i, j int) bool {
-		return nodeIDs[i] < nodeIDs[j]
-	})
-	nodeNames := make([]string, 0, len(m))
-	for _, id := range nodeIDs {
-		nodeNames = append(nodeNames, fmt.Sprintf("n%d", id))
-	}
-	return strings.Join(nodeNames, ", ")
+	sort.Sort(roachpb.NodeIDSlice(nodeIDs))
+	return strutil.JoinIDs("n", nodeIDs)
 }
 
 func keyMax(key1 roachpb.RKey, key2 roachpb.RKey) roachpb.RKey {

--- a/pkg/roachpb/metadata.go
+++ b/pkg/roachpb/metadata.go
@@ -37,6 +37,13 @@ func (n NodeID) String() string {
 // SafeValue implements the redact.SafeValue interface.
 func (n NodeID) SafeValue() {}
 
+// NodeIDSlice implements sort.Interface.
+type NodeIDSlice []NodeID
+
+func (s NodeIDSlice) Len() int           { return len(s) }
+func (s NodeIDSlice) Swap(i, j int)      { s[i], s[j] = s[j], s[i] }
+func (s NodeIDSlice) Less(i, j int) bool { return s[i] < s[j] }
+
 // StoreID is a custom type for a cockroach store ID.
 type StoreID int32
 


### PR DESCRIPTION
Previously the rule that is used to pick winning replica looked
on max committed index in the raft log and resoved ties using
store id. This works well in case of 3 replicas and 5+ replicas
if leaseholder is lost (or node with leaseholder restarted).
However for half-online approach not all nodes are restarted and
last leaseholder could be alive and without quorum preventing
recovery.

This commit adds leaseholder status on collected replicas and
then uses previous leaseholders as survivors if all else is
equal. This helps reducing uncertainty and number of nodes that
needs restarting.

Release note: None

Fixes #96264