### PR TITLE
backupccl: return error if fileSpanStartAndEndKeyIterator yields unordered keys

### DIFF
--- a/pkg/ccl/backupccl/restore_span_covering.go
+++ b/pkg/ccl/backupccl/restore_span_covering.go
@@ -746,6 +746,13 @@ func (i *fileSpanStartAndEndKeyIterator) next() {
 			heap.Push(i.heap, minItem)
 		}
 	}
+	if ok, _ := i.valid(); !ok {
+		return
+	}
+	if prevKey.Compare(i.value()) >= 0 {
+		i.err = errors.New("out of order backup keys")
+		return
+	}
 }
 
 func (i *fileSpanStartAndEndKeyIterator) valid() (bool, error) {


### PR DESCRIPTION
This patch modifies the fileSpanStartAndEndKeyIterator to return an error if it surfaces out of order keys. Further, this patch adds unit tests to ensure expected behavior of the backupManifestFileIterator and the FileSpanStartAndEndKeyIterator.

Epic: None

Release note: None