### PR TITLE
roachtest: add aws weekly script

### DIFF
--- a/build/teamcity/cockroach/nightlies/roachtest_weekly_aws.sh
+++ b/build/teamcity/cockroach/nightlies/roachtest_weekly_aws.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+set -exuo pipefail
+
+dir="$(dirname $(dirname $(dirname $(dirname "${0}"))))"
+
+source "$dir/teamcity-support.sh"  # For $root
+source "$dir/teamcity-bazel-support.sh"  # For run_bazel
+
+BAZEL_SUPPORT_EXTRA_DOCKER_ARGS="-e LITERAL_ARTIFACTS_DIR=$root/artifacts -e AWS_ACCESS_KEY_ID -e AWS_ACCESS_KEY_ID_ASSUME_ROLE -e AWS_KMS_KEY_ARN_A -e AWS_KMS_KEY_ARN_B -e AWS_KMS_REGION_A -e AWS_KMS_REGION_B -e AWS_ROLE_ARN -e AWS_SECRET_ACCESS_KEY -e AWS_SECRET_ACCESS_KEY_ASSUME_ROLE -e BUILD_TAG -e BUILD_VCS_NUMBER -e CLOUD -e COCKROACH_DEV_LICENSE -e TESTS -e COUNT -e GITHUB_API_TOKEN -e GITHUB_ORG -e GITHUB_REPO -e GOOGLE_EPHEMERAL_CREDENTIALS -e SLACK_TOKEN -e TC_BUILDTYPE_ID -e TC_BUILD_BRANCH -e TC_BUILD_ID -e TC_SERVER_URL" \
+			       run_bazel build/teamcity/cockroach/nightlies/roachtest_weekly_aws_impl.sh

--- a/build/teamcity/cockroach/nightlies/roachtest_weekly_aws_impl.sh
+++ b/build/teamcity/cockroach/nightlies/roachtest_weekly_aws_impl.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+set -exuo pipefail
+
+dir="$(dirname $(dirname $(dirname $(dirname "${0}"))))"
+
+source "$dir/teamcity-support.sh"
+
+if [[ ! -f ~/.ssh/id_rsa.pub ]]; then
+  ssh-keygen -q -C "roachtest-weekly-bazel $(date)" -N "" -f ~/.ssh/id_rsa
+fi
+
+source $root/build/teamcity/cockroach/nightlies/roachtest_compile_bits.sh
+
+artifacts=/artifacts
+source $root/build/teamcity/util/roachtest_util.sh
+
+build/teamcity-roachtest-invoke.sh \
+  tag:aws-weekly \
+  --cloud="${CLOUD}" \
+  --build-tag="${BUILD_TAG}" \
+  --cluster-id "${TC_BUILD_ID}" \
+  --cockroach "$PWD/bin/cockroach" \
+  --artifacts=/artifacts \
+  --artifacts-literal="${LITERAL_ARTIFACTS_DIR:-}" \
+  --slack-token="${SLACK_TOKEN}"


### PR DESCRIPTION
This change adds the scripts to be used by the aws weekly roachtest teamcity job.

Release note: None
Epic: none