### PR TITLE
ui: Update Cluster UI version to 22.1.13

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/package.json
+++ b/pkg/ui/workspaces/cluster-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cockroachlabs/cluster-ui",
-  "version": "22.1.12",
+  "version": "22.1.13",
   "description": "Cluster UI is a library of large features shared between CockroachDB and CockroachCloud",
   "repository": {
     "type": "git",


### PR DESCRIPTION
After merging a change to fix the auto-publishing workflow, I'm bumping the version to trigger a publish.