### PR TITLE
release-22.1: Revert "sql: improve stack trace for get-user-timeout timeouts"

### DIFF
--- a/pkg/util/contextutil/context.go
+++ b/pkg/util/contextutil/context.go
@@ -79,18 +79,6 @@ func wrap(ctx context.Context, cancel context.CancelFunc) (context.Context, cont
 	}
 }
 
-// ctxWithStacktrace overrides Err to annotate context.DeadlineExceeded and
-// context.Canceled errors with a stacktrace.
-// See: https://github.com/cockroachdb/cockroach/issues/95794
-type ctxWithStacktrace struct {
-	context.Context
-}
-
-// Err implements the context.Context interface.
-func (ctx *ctxWithStacktrace) Err() error {
-	return errors.WithStack(ctx.Context.Err())
-}
-
 // RunWithTimeout runs a function with a timeout, the same way you'd do with
 // context.WithTimeout. It improves the opaque error messages returned by
 // WithTimeout by augmenting them with the op string that is passed in.
@@ -98,7 +86,6 @@ func RunWithTimeout(
 	ctx context.Context, op string, timeout time.Duration, fn func(ctx context.Context) error,
 ) error {
 	ctx, cancel := context.WithTimeout(ctx, timeout)
-	ctx = &ctxWithStacktrace{Context: ctx}
 	defer cancel()
 	start := timeutil.Now()
 	err := fn(ctx)

--- a/pkg/util/contextutil/context_test.go
+++ b/pkg/util/contextutil/context_test.go
@@ -12,7 +12,6 @@ package contextutil
 
 import (
 	"context"
-	"fmt"
 	"net"
 	"testing"
 	"time"
@@ -67,24 +66,6 @@ func TestRunWithTimeout(t *testing.T) {
 	if !errors.Is(err, context.DeadlineExceeded) {
 		t.Fatalf("RunWithTimeout should return an error with a DeadlineExceeded cause")
 	}
-}
-
-func testFuncA(ctx context.Context) error {
-	return testFuncB(ctx)
-}
-
-func testFuncB(ctx context.Context) error {
-	<-ctx.Done()
-	return ctx.Err()
-}
-
-func TestRunWithTimeoutCtxWithStacktrace(t *testing.T) {
-	ctx := context.Background()
-	err := RunWithTimeout(ctx, "foo", 1, testFuncA)
-	require.Error(t, err)
-	stacktrace := fmt.Sprintf("%+v", err)
-	require.Contains(t, stacktrace, "testFuncB")
-	require.Contains(t, stacktrace, "testFuncA")
 }
 
 // TestRunWithTimeoutWithoutDeadlineExceeded ensures that when a timeout on the


### PR DESCRIPTION
This reverts commit 60e39266ba8f7831cbc19d6a5df4e5563b8da6df.

Fixes #96167

Reverting due to failing test test_quit.tcl.

Release justification: resolve broken test

Release note: None