### PR TITLE
cloud,ccl,*: break `sql` -> `cloud/externalconn/utils` dependency

### DIFF
--- a/pkg/ccl/changefeedccl/sink_external_connection.go
+++ b/pkg/ccl/changefeedccl/sink_external_connection.go
@@ -17,7 +17,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/cloud/externalconn/connectionpb"
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
 	"github.com/cockroachdb/cockroach/pkg/security/username"
-	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
 	"github.com/cockroachdb/cockroach/pkg/sql/isql"
 	"github.com/cockroachdb/errors"
@@ -66,30 +65,32 @@ func makeExternalConnectionSink(
 }
 
 func validateExternalConnectionSinkURI(
-	ctx context.Context, execCfg interface{}, user username.SQLUsername, uri string,
+	ctx context.Context, env externalconn.ExternalConnEnv, uri string,
 ) error {
 
-	serverCfg := execinfra.ServerConfig{ExternalStorageFromURI: func(ctx context.Context, uri string,
+	serverCfg := &execinfra.ServerConfig{ExternalStorageFromURI: func(ctx context.Context, uri string,
 		user username.SQLUsername, opts ...cloud.ExternalStorageOption) (cloud.ExternalStorage, error) {
 		return nil, nil
 	}}
 
 	// Pass through the server config, except for the WrapSink testing knob since that often assumes it's
 	// inside a job.
-	if actualExecCfg, ok := execCfg.(*sql.ExecutorConfig); ok {
-		serverCfg = actualExecCfg.DistSQLSrv.ServerConfig
-		if knobs, ok := serverCfg.TestingKnobs.Changefeed.(*TestingKnobs); ok && knobs.WrapSink != nil {
-			wrapSink := knobs.WrapSink
-			knobs.WrapSink = nil
-			defer func() { knobs.WrapSink = wrapSink }()
-		}
+
+	if s, ok := env.ServerCfg.(*execinfra.ServerConfig); ok && s != nil {
+		serverCfg = s
+	}
+
+	if knobs, ok := serverCfg.TestingKnobs.Changefeed.(*TestingKnobs); ok && knobs.WrapSink != nil {
+		wrapSink := knobs.WrapSink
+		knobs.WrapSink = nil
+		defer func() { knobs.WrapSink = wrapSink }()
 	}
 
 	// Validate the URI by creating a canary sink.
 	//
 	// TODO(adityamaru): When we add `CREATE EXTERNAL CONNECTION ... WITH` support
 	// to accept JSONConfig we should validate that here too.
-	_, err := getSink(ctx, &serverCfg, jobspb.ChangefeedDetails{SinkURI: uri}, nil, user,
+	_, err := getSink(ctx, serverCfg, jobspb.ChangefeedDetails{SinkURI: uri}, nil, env.Username,
 		jobspb.JobID(0), nil)
 	if err != nil {
 		return errors.Wrap(err, "invalid changefeed sink URI")

--- a/pkg/cloud/amazon/BUILD.bazel
+++ b/pkg/cloud/amazon/BUILD.bazel
@@ -19,7 +19,6 @@ go_library(
         "//pkg/cloud/externalconn/connectionpb",
         "//pkg/cloud/externalconn/utils",
         "//pkg/clusterversion",
-        "//pkg/security/username",
         "//pkg/server/telemetry",
         "//pkg/settings",
         "//pkg/settings/cluster",

--- a/pkg/cloud/amazon/aws_kms_connection.go
+++ b/pkg/cloud/amazon/aws_kms_connection.go
@@ -16,14 +16,13 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/cloud/externalconn"
 	"github.com/cockroachdb/cockroach/pkg/cloud/externalconn/connectionpb"
 	"github.com/cockroachdb/cockroach/pkg/cloud/externalconn/utils"
-	"github.com/cockroachdb/cockroach/pkg/security/username"
 	"github.com/cockroachdb/errors"
 )
 
 func validateAWSKMSConnectionURI(
-	ctx context.Context, execCfg interface{}, user username.SQLUsername, uri string,
+	ctx context.Context, env externalconn.ExternalConnEnv, uri string,
 ) error {
-	if err := utils.CheckKMSConnection(ctx, execCfg, user, uri); err != nil {
+	if err := utils.CheckKMSConnection(ctx, env, uri); err != nil {
 		return errors.Wrap(err, "failed to create AWS KMS external connection")
 	}
 	return nil

--- a/pkg/cloud/amazon/s3_connection.go
+++ b/pkg/cloud/amazon/s3_connection.go
@@ -16,14 +16,13 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/cloud/externalconn"
 	"github.com/cockroachdb/cockroach/pkg/cloud/externalconn/connectionpb"
 	"github.com/cockroachdb/cockroach/pkg/cloud/externalconn/utils"
-	"github.com/cockroachdb/cockroach/pkg/security/username"
 	"github.com/cockroachdb/errors"
 )
 
 func validateS3ConnectionURI(
-	ctx context.Context, execCfg interface{}, user username.SQLUsername, uri string,
+	ctx context.Context, env externalconn.ExternalConnEnv, uri string,
 ) error {
-	if err := utils.CheckExternalStorageConnection(ctx, execCfg, user, uri); err != nil {
+	if err := utils.CheckExternalStorageConnection(ctx, env, uri); err != nil {
 		return errors.Wrap(err, "failed to create s3 external connection")
 	}
 

--- a/pkg/cloud/azure/BUILD.bazel
+++ b/pkg/cloud/azure/BUILD.bazel
@@ -18,7 +18,6 @@ go_library(
         "//pkg/cloud/externalconn",
         "//pkg/cloud/externalconn/connectionpb",
         "//pkg/cloud/externalconn/utils",
-        "//pkg/security/username",
         "//pkg/server/telemetry",
         "//pkg/settings",
         "//pkg/settings/cluster",

--- a/pkg/cloud/azure/azure_connection.go
+++ b/pkg/cloud/azure/azure_connection.go
@@ -16,14 +16,13 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/cloud/externalconn"
 	"github.com/cockroachdb/cockroach/pkg/cloud/externalconn/connectionpb"
 	"github.com/cockroachdb/cockroach/pkg/cloud/externalconn/utils"
-	"github.com/cockroachdb/cockroach/pkg/security/username"
 	"github.com/cockroachdb/errors"
 )
 
 func validateAzureConnectionURI(
-	ctx context.Context, execCfg interface{}, user username.SQLUsername, uri string,
+	ctx context.Context, env externalconn.ExternalConnEnv, uri string,
 ) error {
-	if err := utils.CheckExternalStorageConnection(ctx, execCfg, user, uri); err != nil {
+	if err := utils.CheckExternalStorageConnection(ctx, env, uri); err != nil {
 		return errors.Wrap(err, "failed to create azure external connection")
 	}
 

--- a/pkg/cloud/azure/azure_kms_connection.go
+++ b/pkg/cloud/azure/azure_kms_connection.go
@@ -16,14 +16,13 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/cloud/externalconn"
 	"github.com/cockroachdb/cockroach/pkg/cloud/externalconn/connectionpb"
 	"github.com/cockroachdb/cockroach/pkg/cloud/externalconn/utils"
-	"github.com/cockroachdb/cockroach/pkg/security/username"
 	"github.com/cockroachdb/errors"
 )
 
 func validateAzureKMSConnectionURI(
-	ctx context.Context, execCfg interface{}, user username.SQLUsername, uri string,
+	ctx context.Context, execCfg externalconn.ExternalConnEnv, uri string,
 ) error {
-	if err := utils.CheckKMSConnection(ctx, execCfg, user, uri); err != nil {
+	if err := utils.CheckKMSConnection(ctx, execCfg, uri); err != nil {
 		return errors.Wrap(err, "failed to create Azure KMS external connection")
 	}
 

--- a/pkg/cloud/externalconn/BUILD.bazel
+++ b/pkg/cloud/externalconn/BUILD.bazel
@@ -18,6 +18,7 @@ go_library(
         "//pkg/cloud/cloudpb",
         "//pkg/cloud/externalconn/connectionpb",
         "//pkg/security/username",
+        "//pkg/settings/cluster",
         "//pkg/sql/catalog/colinfo",
         "//pkg/sql/isql",
         "//pkg/sql/pgwire/pgcode",

--- a/pkg/cloud/externalconn/connection.go
+++ b/pkg/cloud/externalconn/connection.go
@@ -15,7 +15,6 @@ import (
 	"net/url"
 
 	"github.com/cockroachdb/cockroach/pkg/cloud/externalconn/connectionpb"
-	"github.com/cockroachdb/cockroach/pkg/security/username"
 )
 
 // ExternalConnection is the interface to the external resource represented by
@@ -44,5 +43,4 @@ type ExternalConnection interface {
 // connectionParserFactory is the factory method that takes in an endpoint URI
 // for an external resource, and returns the ExternalConnection representation
 // of that URI.
-type connectionParserFactory func(ctx context.Context, execCfg interface{},
-	user username.SQLUsername, url *url.URL) (ExternalConnection, error)
+type connectionParserFactory func(ctx context.Context, env ExternalConnEnv, url *url.URL) (ExternalConnection, error)

--- a/pkg/cloud/externalconn/impl_registry.go
+++ b/pkg/cloud/externalconn/impl_registry.go
@@ -16,8 +16,11 @@ import (
 	"net/url"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/cloud"
 	"github.com/cockroachdb/cockroach/pkg/cloud/externalconn/connectionpb"
 	"github.com/cockroachdb/cockroach/pkg/security/username"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/sql/isql"
 	"github.com/cockroachdb/errors"
 )
 
@@ -52,19 +55,15 @@ type schemeRegistration struct {
 }
 
 func (s *schemeRegistration) parseAndValidateURI(
-	ctx context.Context,
-	execCfg interface{},
-	user username.SQLUsername,
-	uri *url.URL,
-	requestedValidations ...string,
+	ctx context.Context, env ExternalConnEnv, uri *url.URL, requestedValidations ...string,
 ) (ExternalConnection, error) {
-	conn, err := s.connectionParserFactory(ctx, execCfg, user, uri)
+	conn, err := s.connectionParserFactory(ctx, env, uri)
 	if err != nil {
 		return nil, err
 	}
 	for _, v := range requestedValidations {
 		if validationFn, ok := s.validations[v]; ok {
-			err = errors.CombineErrors(err, validationFn(ctx, execCfg, user, uri.String()))
+			err = errors.CombineErrors(err, validationFn(ctx, env, uri.String()))
 		}
 	}
 	return conn, err
@@ -109,7 +108,7 @@ func RegisterNamedValidation(providerScheme string, name string, validation Vali
 }
 
 func makeSimpleURIFactory(provider connectionpb.ConnectionProvider) connectionParserFactory {
-	return func(ctx context.Context, execCfg interface{}, user username.SQLUsername, uri *url.URL) (ExternalConnection, error) {
+	return func(ctx context.Context, env ExternalConnEnv, uri *url.URL) (ExternalConnection, error) {
 		connDetails := connectionpb.ConnectionDetails{
 			Provider: provider,
 			Details: &connectionpb.ConnectionDetails_SimpleURI{
@@ -125,7 +124,7 @@ func makeSimpleURIFactory(provider connectionpb.ConnectionProvider) connectionPa
 // ExternalConnectionFromURI returns an ExternalConnection for the given URI and runs the registered
 // default validation, which can involve making external calls.
 func ExternalConnectionFromURI(
-	ctx context.Context, execCfg interface{}, user username.SQLUsername, uri string,
+	ctx context.Context, env ExternalConnEnv, uri string,
 ) (ExternalConnection, error) {
 	externalConnectionURI, err := url.Parse(uri)
 	if err != nil {
@@ -138,11 +137,74 @@ func ExternalConnectionFromURI(
 		return nil, errors.Newf("no parseAndValidateFn found for external connection provider %s", externalConnectionURI.Scheme)
 	}
 
-	return parseAndValidateFn.parseAndValidateURI(ctx, execCfg, user, externalConnectionURI, defaultValidation)
+	return parseAndValidateFn.parseAndValidateURI(ctx, env, externalConnectionURI, defaultValidation)
 }
 
-// ValidationFn is the type taken by Register*Validation. Validation functions can ping the external connection.
-type ValidationFn func(ctx context.Context, execCfg interface{}, user username.SQLUsername, uri string) error
+// ExternalConnEnv contains parameters to be used to validate an external
+// connection.
+type ExternalConnEnv struct {
+	// Settings refers to the cluster settings that apply to the BackupKMSEnv.
+	Settings *cluster.Settings
+	// Conf represents the ExternalIODirConfig that applies to the BackupKMSEnv.
+	Conf *base.ExternalIODirConfig
+	// DB is the database handle that applies to the BackupKMSEnv.
+	Isqldb isql.DB
+	// Username is the user that applies to the BackupKMSEnv.
+	Username username.SQLUsername
+
+	ExternalStorageFromURIFactory cloud.ExternalStorageFromURIFactory
+
+	SkipCheckingExternalStorageConnection bool
+	SkipCheckingKMSConnection             bool
+	// ServerCfg is used to validate the external connection sink URI.
+	// It implements *execinfra.ServerConfig, and is declared as an interface
+	// here to avoid importing `execinfra` package to the sub-packages in the
+	// cloud pkg.
+	ServerCfg interface{}
+}
+
+var _ cloud.KMSEnv = &ExternalConnEnv{}
+
+func (s *ExternalConnEnv) ClusterSettings() *cluster.Settings {
+	return s.Settings
+}
+
+func (s *ExternalConnEnv) KMSConfig() *base.ExternalIODirConfig {
+	return s.Conf
+}
+
+func (s *ExternalConnEnv) DBHandle() isql.DB {
+	return s.Isqldb
+}
+
+func (s *ExternalConnEnv) User() username.SQLUsername {
+	return s.Username
+}
+
+func MakeExternalConnEnv(
+	settings *cluster.Settings,
+	conf *base.ExternalIODirConfig,
+	isqlDB isql.DB,
+	username username.SQLUsername,
+	externalStorageFromURIFactory cloud.ExternalStorageFromURIFactory,
+	skipCheckingExternalStorageConnection bool,
+	skipCheckingKMSConnection bool,
+	serverCfg interface{},
+) ExternalConnEnv {
+	return ExternalConnEnv{
+		Settings:                              settings,
+		Conf:                                  conf,
+		Isqldb:                                isqlDB,
+		SkipCheckingExternalStorageConnection: skipCheckingExternalStorageConnection,
+		SkipCheckingKMSConnection:             skipCheckingKMSConnection,
+		ExternalStorageFromURIFactory:         externalStorageFromURIFactory,
+		Username:                              username,
+		ServerCfg:                             serverCfg,
+	}
+}
+
+// ValidationFn is the type taken by Register*ValidationWithCloud. Validation functions can ping the external connection.
+type ValidationFn func(ctx context.Context, env ExternalConnEnv, uri string) error
 
 // TestingKnobs provide fine-grained control over the external connection
 // components for testing.

--- a/pkg/cloud/externalconn/utils/BUILD.bazel
+++ b/pkg/cloud/externalconn/utils/BUILD.bazel
@@ -7,12 +7,8 @@ go_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/cloud/externalconn/utils",
     visibility = ["//visibility:public"],
     deps = [
-        "//pkg/base",
         "//pkg/cloud",
-        "//pkg/security/username",
-        "//pkg/settings/cluster",
-        "//pkg/sql",
-        "//pkg/sql/isql",
+        "//pkg/cloud/externalconn",
         "//pkg/util/ioctx",
         "//pkg/util/log",
         "@com_github_cockroachdb_errors//:errors",

--- a/pkg/cloud/externalconn/utils/connection_utils.go
+++ b/pkg/cloud/externalconn/utils/connection_utils.go
@@ -16,12 +16,8 @@ import (
 	"io"
 	"strings"
 
-	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/cloud"
-	"github.com/cockroachdb/cockroach/pkg/security/username"
-	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
-	"github.com/cockroachdb/cockroach/pkg/sql"
-	"github.com/cockroachdb/cockroach/pkg/sql/isql"
+	"github.com/cockroachdb/cockroach/pkg/cloud/externalconn"
 	"github.com/cockroachdb/cockroach/pkg/util/ioctx"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/errors"
@@ -33,10 +29,9 @@ const markerFile = "crdb_external_storage_location"
 // back. This serves as a sanity check that the external connection represents
 // an ExternalStorage resource that can be connected and interacted with.
 func CheckExternalStorageConnection(
-	ctx context.Context, execCfg interface{}, user username.SQLUsername, uri string,
+	ctx context.Context, env externalconn.ExternalConnEnv, uri string,
 ) error {
-	cfg := execCfg.(*sql.ExecutorConfig)
-	es, err := cfg.DistSQLSrv.ExternalStorageFromURI(ctx, uri, user)
+	es, err := env.ExternalStorageFromURIFactory(ctx, uri, env.Username)
 	if err != nil {
 		return err
 	}
@@ -46,11 +41,8 @@ func CheckExternalStorageConnection(
 		}
 	}()
 
-	if cfg.ExternalConnectionTestingKnobs != nil &&
-		cfg.ExternalConnectionTestingKnobs.SkipCheckingExternalStorageConnection != nil {
-		if cfg.ExternalConnectionTestingKnobs.SkipCheckingExternalStorageConnection() {
-			return nil
-		}
+	if env.SkipCheckingExternalStorageConnection {
+		return nil
 	}
 
 	// Write a sentinel file.
@@ -91,45 +83,11 @@ func CheckExternalStorageConnection(
 	return nil
 }
 
-type externalConnectionKMSEnv struct {
-	execCfg *sql.ExecutorConfig
-	user    username.SQLUsername
-}
-
-// ClusterSettings implements the KMSEnv interface.
-func (e *externalConnectionKMSEnv) ClusterSettings() *cluster.Settings {
-	return e.execCfg.Settings
-}
-
-// KMSConfig implements the KMSEnv interface.
-func (e *externalConnectionKMSEnv) KMSConfig() *base.ExternalIODirConfig {
-	return &e.execCfg.ExternalIODirConfig
-}
-
-// DBHandle implements the KMSEnv interface.
-func (e *externalConnectionKMSEnv) DBHandle() isql.DB {
-	return e.execCfg.InternalDB
-}
-
-// User implements the KMSEnv interface.
-func (e *externalConnectionKMSEnv) User() username.SQLUsername {
-	return e.user
-}
-
-var _ cloud.KMSEnv = &externalConnectionKMSEnv{}
-
 // CheckKMSConnection encrypts, decrypts and matches the contents of a sentinel
 // file. This serves as a sanity check that the external connection represents a
 // KMS resource that can be connected and interacted with.
-func CheckKMSConnection(
-	ctx context.Context, execCfg interface{}, user username.SQLUsername, uri string,
-) error {
-	cfg := execCfg.(*sql.ExecutorConfig)
-	kmsEnv := &externalConnectionKMSEnv{
-		execCfg: cfg,
-		user:    user,
-	}
-	kms, err := cloud.KMSFromURI(ctx, uri, kmsEnv)
+func CheckKMSConnection(ctx context.Context, env externalconn.ExternalConnEnv, uri string) error {
+	kms, err := cloud.KMSFromURI(ctx, uri, &env)
 	if err != nil {
 		return err
 	}
@@ -139,11 +97,8 @@ func CheckKMSConnection(
 		}
 	}()
 
-	if cfg.ExternalConnectionTestingKnobs != nil &&
-		cfg.ExternalConnectionTestingKnobs.SkipCheckingKMSConnection != nil {
-		if cfg.ExternalConnectionTestingKnobs.SkipCheckingKMSConnection() {
-			return nil
-		}
+	if env.SkipCheckingKMSConnection {
+		return nil
 	}
 
 	// Encrypt and decrypt a sentinel file.

--- a/pkg/cloud/gcp/BUILD.bazel
+++ b/pkg/cloud/gcp/BUILD.bazel
@@ -20,7 +20,6 @@ go_library(
         "//pkg/cloud/externalconn/connectionpb",
         "//pkg/cloud/externalconn/utils",
         "//pkg/clusterversion",
-        "//pkg/security/username",
         "//pkg/server/telemetry",
         "//pkg/settings",
         "//pkg/settings/cluster",

--- a/pkg/cloud/gcp/gcp_kms_connection.go
+++ b/pkg/cloud/gcp/gcp_kms_connection.go
@@ -16,14 +16,13 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/cloud/externalconn"
 	"github.com/cockroachdb/cockroach/pkg/cloud/externalconn/connectionpb"
 	"github.com/cockroachdb/cockroach/pkg/cloud/externalconn/utils"
-	"github.com/cockroachdb/cockroach/pkg/security/username"
 	"github.com/cockroachdb/errors"
 )
 
 func validateGCPKMSConnectionURI(
-	ctx context.Context, execCfg interface{}, user username.SQLUsername, uri string,
+	ctx context.Context, env externalconn.ExternalConnEnv, uri string,
 ) error {
-	if err := utils.CheckKMSConnection(ctx, execCfg, user, uri); err != nil {
+	if err := utils.CheckKMSConnection(ctx, env, uri); err != nil {
 		return errors.Wrap(err, "failed to create GCP KMS external connection")
 	}
 

--- a/pkg/cloud/gcp/gcs_connection.go
+++ b/pkg/cloud/gcp/gcs_connection.go
@@ -16,14 +16,13 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/cloud/externalconn"
 	"github.com/cockroachdb/cockroach/pkg/cloud/externalconn/connectionpb"
 	"github.com/cockroachdb/cockroach/pkg/cloud/externalconn/utils"
-	"github.com/cockroachdb/cockroach/pkg/security/username"
 	"github.com/cockroachdb/errors"
 )
 
 func validateGCSConnectionURI(
-	ctx context.Context, execCfg interface{}, user username.SQLUsername, uri string,
+	ctx context.Context, env externalconn.ExternalConnEnv, uri string,
 ) error {
-	if err := utils.CheckExternalStorageConnection(ctx, execCfg, user, uri); err != nil {
+	if err := utils.CheckExternalStorageConnection(ctx, env, uri); err != nil {
 		return errors.Wrap(err, "failed to create gs external connection")
 	}
 

--- a/pkg/cloud/nodelocal/BUILD.bazel
+++ b/pkg/cloud/nodelocal/BUILD.bazel
@@ -18,7 +18,6 @@ go_library(
         "//pkg/cloud/externalconn/connectionpb",
         "//pkg/cloud/externalconn/utils",
         "//pkg/roachpb",
-        "//pkg/security/username",
         "//pkg/server/telemetry",
         "//pkg/settings/cluster",
         "//pkg/util/ioctx",

--- a/pkg/cloud/nodelocal/nodelocal_connection.go
+++ b/pkg/cloud/nodelocal/nodelocal_connection.go
@@ -16,14 +16,13 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/cloud/externalconn"
 	"github.com/cockroachdb/cockroach/pkg/cloud/externalconn/connectionpb"
 	"github.com/cockroachdb/cockroach/pkg/cloud/externalconn/utils"
-	"github.com/cockroachdb/cockroach/pkg/security/username"
 	"github.com/cockroachdb/errors"
 )
 
 func validateLocalFileConnectionURI(
-	ctx context.Context, execCfg interface{}, user username.SQLUsername, uri string,
+	ctx context.Context, env externalconn.ExternalConnEnv, uri string,
 ) error {
-	if err := utils.CheckExternalStorageConnection(ctx, execCfg, user, uri); err != nil {
+	if err := utils.CheckExternalStorageConnection(ctx, env, uri); err != nil {
 		return errors.Wrap(err, "failed to create nodelocal external connection")
 	}
 

--- a/pkg/cloud/userfile/file_table_connection.go
+++ b/pkg/cloud/userfile/file_table_connection.go
@@ -16,14 +16,13 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/cloud/externalconn"
 	"github.com/cockroachdb/cockroach/pkg/cloud/externalconn/connectionpb"
 	"github.com/cockroachdb/cockroach/pkg/cloud/externalconn/utils"
-	"github.com/cockroachdb/cockroach/pkg/security/username"
 	"github.com/cockroachdb/errors"
 )
 
 func validateUserfileConnectionURI(
-	ctx context.Context, execCfg interface{}, user username.SQLUsername, uri string,
+	ctx context.Context, env externalconn.ExternalConnEnv, uri string,
 ) error {
-	if err := utils.CheckExternalStorageConnection(ctx, execCfg, user, uri); err != nil {
+	if err := utils.CheckExternalStorageConnection(ctx, env, uri); err != nil {
 		return errors.Wrap(err, "failed to create userfile external connection")
 	}
 


### PR DESCRIPTION
This commit is to break `cloud/externalconn/utils/`'s dependency on the `sql` package, as `sql` is just used to get the `sql.ExecCfg` for the validation function for external connection uri. But in fact, only a few fields of `sql.ExecCfg` are used; hence it makes more sense just to use a lighter `externalconn.ExternalConnEnv`.

Release note: None
Epic: None