### PR TITLE
randident: properly clamp unicode gen to 0-0x10FFFF

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/gen_test_objects
+++ b/pkg/sql/logictest/testdata/logic_test/gen_test_objects
@@ -123,8 +123,8 @@ ORDER BY table_name, column_name
 "                u3"      y        text
 "*t""1"          "%56x"   numeric
 "*t""1"          rowid    bigint
-"\\U3F862049u4"  rowid    bigint
-"\\U3F862049u4"  "y "     text
+"\\U00051024u4"  rowid    bigint
+"\\U00051024u4"  "y "     text
 "t%q3"           rowid    bigint
 "t%q3"           x        numeric
 t2               rowid    bigint
@@ -148,7 +148,7 @@ ORDER BY table_name, constraint_name
 ----
 "                u3"          pr̫imary
 "*t""1"          "PrimaRy̧"
-"\\U3F862049u4"  "primary"
+"\\U00051024u4"  "primary"
 "t%q3"           "primary"
 t2               "primary"
 t4               "primar'y"

--- a/pkg/util/randident/namegen.go
+++ b/pkg/util/randident/namegen.go
@@ -16,6 +16,7 @@ import (
 	"math/rand"
 	"strconv"
 	"strings"
+	"unicode/utf8"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/lexbase"
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
@@ -58,7 +59,7 @@ var escGenerators = []func(s *strings.Builder, r *rand.Rand){
 	func(s *strings.Builder, r *rand.Rand) { fmt.Fprintf(s, `%%%02x`, r.Int31n(256)) },
 	// SQL escape sequences.
 	func(s *strings.Builder, r *rand.Rand) { fmt.Fprintf(s, `\\u%04X`, r.Int31n(65536)) },
-	func(s *strings.Builder, r *rand.Rand) { fmt.Fprintf(s, `\\U%08X`, r.Uint32()) },
+	func(s *strings.Builder, r *rand.Rand) { fmt.Fprintf(s, `\\U%08X`, r.Int31n(utf8.MaxRune+1)) },
 }
 
 // GenerateOne generates one random name.


### PR DESCRIPTION
The last valid unicode character is 0x10FFFF, not 0xFFFFFFFF.

Release note: None
Epic: None