### PR TITLE
[WIP] scbuild: support DROP TYPE ... CASCADE

### DIFF
--- a/pkg/ccl/schemachangerccl/backup_base_generated_test.go
+++ b/pkg/ccl/schemachangerccl/backup_base_generated_test.go
@@ -173,3 +173,8 @@ func TestBackup_base_drop_table(t *testing.T) {
 	defer log.Scope(t).Close(t)
 	sctest.Backup(t, "pkg/sql/schemachanger/testdata/end_to_end/drop_table", newCluster)
 }
+func TestBackup_base_drop_type_cascade(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	sctest.Backup(t, "pkg/sql/schemachanger/testdata/end_to_end/drop_type_cascade", newCluster)
+}

--- a/pkg/sql/catalog/rewrite/BUILD.bazel
+++ b/pkg/sql/catalog/rewrite/BUILD.bazel
@@ -20,7 +20,6 @@ go_library(
         "//pkg/sql/parser",
         "//pkg/sql/pgwire/pgcode",
         "//pkg/sql/pgwire/pgerror",
-        "//pkg/sql/schemachanger/scpb",
         "//pkg/sql/schemachanger/screl",
         "//pkg/sql/sem/catid",
         "//pkg/sql/sem/tree",

--- a/pkg/sql/logictest/testdata/logic_test/alter_table
+++ b/pkg/sql/logictest/testdata/logic_test/alter_table
@@ -1742,7 +1742,7 @@ uwi_child  uwi_child_d_fkey  FOREIGN KEY  FOREIGN KEY (d) REFERENCES unique_with
 uwi_child  uwi_child_pkey    PRIMARY KEY  PRIMARY KEY (rowid ASC)                                   true
 
 # Attempting to drop a column with a foreign key reference fails.
-statement error pq: "unique_d" is referenced by foreign key from table "uwi_child"
+statement error pgcode 2BP01 is referenced by foreign key from table "uwi_child"
 ALTER TABLE unique_without_index DROP COLUMN d
 
 # It succeeds if we use CASCADE, and also drops the fk reference.

--- a/pkg/sql/logictest/testdata/logic_test/drop_type
+++ b/pkg/sql/logictest/testdata/logic_test/drop_type
@@ -449,7 +449,9 @@ CREATE TABLE t (k schema_to_drop.typ PRIMARY KEY);
 statement ok
 CREATE TABLE schema_to_drop.t (k schema_to_drop.typ PRIMARY KEY);
 
-statement error pgcode 0A000 unimplemented: cannot drop type "test.schema_to_drop.(_)?typ" because other objects \(\[test\.public\.t\]\) still depend on it
+skipif config local-legacy-schema-changer
+skipif config local-mixed-22.2-23.1
+statement error pgcode 42P10 column "k" is referenced by the primary key
 DROP SCHEMA schema_to_drop CASCADE;
 
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/new_schema_changer
+++ b/pkg/sql/logictest/testdata/logic_test/new_schema_changer
@@ -364,6 +364,20 @@ CREATE VIEW v7_dep AS (SELECT i FROM t6@idx WHERE k < 'a'::typ6)
 statement error annot drop type "typ6" because other objects \(\[test.public.t6 test.public.v7_dep\]\) still depend on it
 DROP TYPE typ6
 
+statement ok
+DROP TYPE typ6 CASCADE
+
+statement ok
+DROP TYPE typ5 CASCADE
+
+statement ok
+DROP TYPE typ4 CASCADE
+
+statement ok
+DROP TYPE typ3 CASCADE
+
+statement ok
+DROP TYPE typ CASCADE
 
 subtest view_sanity
 

--- a/pkg/sql/pgwire/testdata/pgtest/notice
+++ b/pkg/sql/pgwire/testdata/pgtest/notice
@@ -55,7 +55,7 @@ Query {"String": "DROP INDEX t_x_idx"}
 until crdb_only
 CommandComplete
 ----
-{"Severity":"NOTICE","SeverityUnlocalized":"NOTICE","Code":"00000","Message":"the data for dropped indexes is reclaimed asynchronously","Detail":"","Hint":"The reclamation delay can be customized in the zone configuration for the table.","Position":0,"InternalPosition":0,"InternalQuery":"","Where":"","SchemaName":"","TableName":"","ColumnName":"","DataTypeName":"","ConstraintName":"","File":"drop_index.go","Line":66,"Routine":"DropIndex","UnknownFields":null}
+{"Severity":"NOTICE","SeverityUnlocalized":"NOTICE","Code":"00000","Message":"the data for dropped indexes is reclaimed asynchronously","Detail":"","Hint":"The reclamation delay can be customized in the zone configuration for the table.","Position":0,"InternalPosition":0,"InternalQuery":"","Where":"","SchemaName":"","TableName":"","ColumnName":"","DataTypeName":"","ConstraintName":"","File":"drop_index.go","Line":65,"Routine":"DropIndex","UnknownFields":null}
 {"Type":"CommandComplete","CommandTag":"DROP INDEX"}
 
 until noncrdb_only

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_table_alter_primary_key.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_table_alter_primary_key.go
@@ -180,7 +180,7 @@ func alterPrimaryKey(b BuildCtx, tn *tree.TableName, tbl *scpb.Table, t alterPri
 	// Drop the rowid column, if applicable.
 	if rowidToDrop != nil {
 		elts := b.QueryByID(rowidToDrop.TableID).Filter(hasColumnIDAttrFilter(rowidToDrop.ColumnID))
-		dropColumn(b, tn, tbl, t.n, rowidToDrop, elts, tree.DropRestrict)
+		dropColumn(b, t.n, tbl, rowidToDrop, elts, tree.DropRestrict)
 	}
 
 	// Construct and add elements for a unique secondary index created on

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_table_drop_constraint.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_table_drop_constraint.go
@@ -43,11 +43,11 @@ func alterTableDropConstraint(
 	// Dropping UNIQUE constraint: error out as not implemented.
 	droppingUniqueConstraintNotImplemented(constraintElems, t)
 
-	constraintElems.ForEachElementStatus(func(
-		_ scpb.Status, _ scpb.TargetStatus, e scpb.Element,
-	) {
-		b.Drop(e)
-	})
+	constraintElems.Filter(notAbsentTargetFilter).ForEachElementStatus(
+		func(_ scpb.Status, _ scpb.TargetStatus, e scpb.Element) {
+			b.Drop(e)
+		},
+	)
 }
 
 func fallBackIfDroppingPrimaryKey(

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/drop_database.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/drop_database.go
@@ -35,7 +35,7 @@ func DropDatabase(b BuildCtx, n *tree.DropDatabase) {
 	b.IncrementSchemaChangeDropCounter("database")
 	// Perform explicit or implicit DROP DATABASE CASCADE.
 	if n.DropBehavior == tree.DropCascade || (n.DropBehavior == tree.DropDefault && !b.SessionData().SafeUpdates) {
-		dropCascadeDescriptor(b, db.DatabaseID)
+		dropCascadeDescriptor(b, n, db.DatabaseID)
 		b.LogEventForExistingTarget(db)
 		return
 	}

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/drop_schema.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/drop_schema.go
@@ -43,7 +43,7 @@ func DropSchema(b BuildCtx, n *tree.DropSchema) {
 			panic(scerrors.NotImplementedErrorf(n, "dropping a temporary schema"))
 		}
 		if n.DropBehavior == tree.DropCascade {
-			dropCascadeDescriptor(b, sc.SchemaID)
+			dropCascadeDescriptor(b, n, sc.SchemaID)
 			toCheckBackrefs = append(toCheckBackrefs, sc.SchemaID)
 		} else if dropRestrictDescriptor(b, sc.SchemaID) {
 			toCheckBackrefs = append(toCheckBackrefs, sc.SchemaID)

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/drop_sequence.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/drop_sequence.go
@@ -42,7 +42,7 @@ func DropSequence(b BuildCtx, n *tree.DropSequence) {
 			panic(scerrors.NotImplementedErrorf(n, "dropping a temporary sequence"))
 		}
 		if n.DropBehavior == tree.DropCascade {
-			dropCascadeDescriptor(b, seq.SequenceID)
+			dropCascadeDescriptor(b, n, seq.SequenceID)
 		} else if dropRestrictDescriptor(b, seq.SequenceID) {
 			// Drop sequence owner even for RESTRICT.
 			scpb.ForEachSequenceOwner(

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/drop_type.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/drop_type.go
@@ -15,7 +15,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
-	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scerrors"
 	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/catid"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
@@ -24,9 +23,6 @@ import (
 
 // DropType implements DROP TYPE.
 func DropType(b BuildCtx, n *tree.DropType) {
-	if n.DropBehavior == tree.DropCascade {
-		panic(scerrors.NotImplementedErrorf(n, "DROP TYPE CASCADE is not yet supported"))
-	}
 	var toCheckBackrefs []catid.DescID
 	arrayTypesToAlsoCheck := make(map[catid.DescID]catid.DescID)
 	for _, name := range n.Names {
@@ -53,7 +49,7 @@ func DropType(b BuildCtx, n *tree.DropType) {
 		b.SetUnresolvedNameAnnotation(name, &tn)
 		// Drop the type.
 		if n.DropBehavior == tree.DropCascade {
-			dropCascadeDescriptor(b, typeID)
+			dropCascadeDescriptor(b, n, typeID)
 		} else {
 			if dropRestrictDescriptor(b, typeID) {
 				toCheckBackrefs = append(toCheckBackrefs, typeID)

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/drop_view.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/drop_view.go
@@ -51,7 +51,7 @@ func DropView(b BuildCtx, n *tree.DropView) {
 			panic(pgerror.Newf(pgcode.WrongObjectType, "%q is not a materialized view", name.ObjectName))
 		}
 		if n.DropBehavior == tree.DropCascade {
-			dropCascadeDescriptor(b, view.ViewID)
+			dropCascadeDescriptor(b, n, view.ViewID)
 		} else if dropRestrictDescriptor(b, view.ViewID) {
 			toCheckBackrefs = append(toCheckBackrefs, view.ViewID)
 		}

--- a/pkg/sql/schemachanger/scbuild/testdata/drop_type_cascade
+++ b/pkg/sql/schemachanger/scbuild/testdata/drop_type_cascade
@@ -1,0 +1,225 @@
+setup
+SET experimental_enable_unique_without_index_constraints = true;
+CREATE TYPE defaultdb.typ AS ENUM('a');
+CREATE TYPE defaultdb.ctyp AS (a INT, b INT);
+CREATE TYPE defaultdb.greeting AS ENUM('hello', 'hi');
+CREATE VIEW defaultdb.view AS SELECT 'hi'::defaultdb.greeting AS hi;
+CREATE TABLE defaultdb.tbl (
+  id INT PRIMARY KEY,
+  gs greeting AS ('hi'::defaultdb.greeting) STORED,
+  gv string AS ('hello'::defaultdb.greeting::STRING) VIRTUAL,
+  other greeting[],
+  name STRING NOT NULL,
+  CONSTRAINT mycheck CHECK (gs::STRING = name),
+  CONSTRAINT myuwi UNIQUE WITHOUT INDEX (name) WHERE ('hi'::defaultdb.greeting::STRING = 'hi'),
+  INDEX partial (name) WHERE (gs::STRING = 'hi')
+);
+----
+
+build
+DROP TYPE defaultdb.typ
+----
+- [[Namespace:{DescID: 104, Name: typ, ReferencedDescID: 100}, ABSENT], PUBLIC]
+  {databaseId: 100, descriptorId: 104, name: typ, schemaId: 101}
+- [[Owner:{DescID: 104}, ABSENT], PUBLIC]
+  {descriptorId: 104, owner: root}
+- [[UserPrivileges:{DescID: 104, Name: admin}, ABSENT], PUBLIC]
+  {descriptorId: 104, privileges: "2", userName: admin, withGrantOption: "2"}
+- [[UserPrivileges:{DescID: 104, Name: public}, ABSENT], PUBLIC]
+  {descriptorId: 104, privileges: "512", userName: public}
+- [[UserPrivileges:{DescID: 104, Name: root}, ABSENT], PUBLIC]
+  {descriptorId: 104, privileges: "2", userName: root, withGrantOption: "2"}
+- [[EnumType:{DescID: 104}, ABSENT], PUBLIC]
+  {arrayTypeId: 105, typeId: 104}
+- [[EnumTypeValue:{DescID: 104, Name: a}, ABSENT], PUBLIC]
+  {logicalRepresentation: a, physicalRepresentation: gA==, typeId: 104}
+- [[ObjectParent:{DescID: 104, ReferencedDescID: 101}, ABSENT], PUBLIC]
+  {objectId: 104, parentSchemaId: 101}
+- [[Namespace:{DescID: 105, Name: _typ, ReferencedDescID: 100}, ABSENT], PUBLIC]
+  {databaseId: 100, descriptorId: 105, name: _typ, schemaId: 101}
+- [[Owner:{DescID: 105}, ABSENT], PUBLIC]
+  {descriptorId: 105, owner: root}
+- [[UserPrivileges:{DescID: 105, Name: admin}, ABSENT], PUBLIC]
+  {descriptorId: 105, privileges: "2", userName: admin, withGrantOption: "2"}
+- [[UserPrivileges:{DescID: 105, Name: public}, ABSENT], PUBLIC]
+  {descriptorId: 105, privileges: "512", userName: public}
+- [[UserPrivileges:{DescID: 105, Name: root}, ABSENT], PUBLIC]
+  {descriptorId: 105, privileges: "2", userName: root, withGrantOption: "2"}
+- [[AliasType:{DescID: 105, ReferencedTypeIDs: [104 105]}, ABSENT], PUBLIC]
+  {closedTypeIds: [104, 105], type: {arrayContents: {family: EnumFamily, oid: 100104, udtMetadata: {arrayTypeOid: 100105}}, arrayElemType: EnumFamily, family: ArrayFamily, oid: 100105}, typeId: 105}
+- [[ObjectParent:{DescID: 105, ReferencedDescID: 101}, ABSENT], PUBLIC]
+  {objectId: 105, parentSchemaId: 101}
+
+build
+DROP TYPE defaultdb.ctyp
+----
+- [[Namespace:{DescID: 106, Name: ctyp, ReferencedDescID: 100}, ABSENT], PUBLIC]
+  {databaseId: 100, descriptorId: 106, name: ctyp, schemaId: 101}
+- [[Owner:{DescID: 106}, ABSENT], PUBLIC]
+  {descriptorId: 106, owner: root}
+- [[UserPrivileges:{DescID: 106, Name: admin}, ABSENT], PUBLIC]
+  {descriptorId: 106, privileges: "2", userName: admin, withGrantOption: "2"}
+- [[UserPrivileges:{DescID: 106, Name: public}, ABSENT], PUBLIC]
+  {descriptorId: 106, privileges: "512", userName: public}
+- [[UserPrivileges:{DescID: 106, Name: root}, ABSENT], PUBLIC]
+  {descriptorId: 106, privileges: "2", userName: root, withGrantOption: "2"}
+- [[CompositeType:{DescID: 106}, ABSENT], PUBLIC]
+  {arrayTypeId: 107, typeId: 106}
+- [[CompositeTypeAttrName:{DescID: 106, Name: a}, ABSENT], PUBLIC]
+  {compositeTypeId: 106, name: a}
+- [[CompositeTypeAttrType:{DescID: 106}, ABSENT], PUBLIC]
+  {compositeTypeId: 106, type: {family: IntFamily, oid: 20, width: 64}}
+- [[CompositeTypeAttrName:{DescID: 106, Name: b}, ABSENT], PUBLIC]
+  {compositeTypeId: 106, name: b}
+- [[ObjectParent:{DescID: 106, ReferencedDescID: 101}, ABSENT], PUBLIC]
+  {objectId: 106, parentSchemaId: 101}
+- [[Namespace:{DescID: 107, Name: _ctyp, ReferencedDescID: 100}, ABSENT], PUBLIC]
+  {databaseId: 100, descriptorId: 107, name: _ctyp, schemaId: 101}
+- [[Owner:{DescID: 107}, ABSENT], PUBLIC]
+  {descriptorId: 107, owner: root}
+- [[UserPrivileges:{DescID: 107, Name: admin}, ABSENT], PUBLIC]
+  {descriptorId: 107, privileges: "2", userName: admin, withGrantOption: "2"}
+- [[UserPrivileges:{DescID: 107, Name: public}, ABSENT], PUBLIC]
+  {descriptorId: 107, privileges: "512", userName: public}
+- [[UserPrivileges:{DescID: 107, Name: root}, ABSENT], PUBLIC]
+  {descriptorId: 107, privileges: "2", userName: root, withGrantOption: "2"}
+- [[AliasType:{DescID: 107, ReferencedTypeIDs: [106 107]}, ABSENT], PUBLIC]
+  {closedTypeIds: [106, 107], type: {arrayContents: {family: TupleFamily, oid: 100106, tupleContents: [{family: IntFamily, oid: 20, width: 64}, {family: IntFamily, oid: 20, width: 64}], tupleLabels: [a, b], udtMetadata: {arrayTypeOid: 100107}}, arrayElemType: TupleFamily, family: ArrayFamily, oid: 100107}, typeId: 107}
+- [[ObjectParent:{DescID: 107, ReferencedDescID: 101}, ABSENT], PUBLIC]
+  {objectId: 107, parentSchemaId: 101}
+
+build
+DROP TYPE defaultdb.greeting CASCADE
+----
+- [[Namespace:{DescID: 108, Name: greeting, ReferencedDescID: 100}, ABSENT], PUBLIC]
+  {databaseId: 100, descriptorId: 108, name: greeting, schemaId: 101}
+- [[Owner:{DescID: 108}, ABSENT], PUBLIC]
+  {descriptorId: 108, owner: root}
+- [[UserPrivileges:{DescID: 108, Name: admin}, ABSENT], PUBLIC]
+  {descriptorId: 108, privileges: "2", userName: admin, withGrantOption: "2"}
+- [[UserPrivileges:{DescID: 108, Name: public}, ABSENT], PUBLIC]
+  {descriptorId: 108, privileges: "512", userName: public}
+- [[UserPrivileges:{DescID: 108, Name: root}, ABSENT], PUBLIC]
+  {descriptorId: 108, privileges: "2", userName: root, withGrantOption: "2"}
+- [[EnumType:{DescID: 108}, ABSENT], PUBLIC]
+  {arrayTypeId: 109, typeId: 108}
+- [[EnumTypeValue:{DescID: 108, Name: hello}, ABSENT], PUBLIC]
+  {logicalRepresentation: hello, physicalRepresentation: QA==, typeId: 108}
+- [[EnumTypeValue:{DescID: 108, Name: hi}, ABSENT], PUBLIC]
+  {logicalRepresentation: hi, physicalRepresentation: gA==, typeId: 108}
+- [[ObjectParent:{DescID: 108, ReferencedDescID: 101}, ABSENT], PUBLIC]
+  {objectId: 108, parentSchemaId: 101}
+- [[Namespace:{DescID: 109, Name: _greeting, ReferencedDescID: 100}, ABSENT], PUBLIC]
+  {databaseId: 100, descriptorId: 109, name: _greeting, schemaId: 101}
+- [[Owner:{DescID: 109}, ABSENT], PUBLIC]
+  {descriptorId: 109, owner: root}
+- [[UserPrivileges:{DescID: 109, Name: admin}, ABSENT], PUBLIC]
+  {descriptorId: 109, privileges: "2", userName: admin, withGrantOption: "2"}
+- [[UserPrivileges:{DescID: 109, Name: public}, ABSENT], PUBLIC]
+  {descriptorId: 109, privileges: "512", userName: public}
+- [[UserPrivileges:{DescID: 109, Name: root}, ABSENT], PUBLIC]
+  {descriptorId: 109, privileges: "2", userName: root, withGrantOption: "2"}
+- [[AliasType:{DescID: 109, ReferencedTypeIDs: [108 109]}, ABSENT], PUBLIC]
+  {closedTypeIds: [108, 109], type: {arrayContents: {family: EnumFamily, oid: 100108, udtMetadata: {arrayTypeOid: 100109}}, arrayElemType: EnumFamily, family: ArrayFamily, oid: 100109}, typeId: 109}
+- [[ObjectParent:{DescID: 109, ReferencedDescID: 101}, ABSENT], PUBLIC]
+  {objectId: 109, parentSchemaId: 101}
+- [[Namespace:{DescID: 110, Name: view, ReferencedDescID: 100}, ABSENT], PUBLIC]
+  {databaseId: 100, descriptorId: 110, name: view, schemaId: 101}
+- [[Owner:{DescID: 110}, ABSENT], PUBLIC]
+  {descriptorId: 110, owner: root}
+- [[UserPrivileges:{DescID: 110, Name: admin}, ABSENT], PUBLIC]
+  {descriptorId: 110, privileges: "2", userName: admin, withGrantOption: "2"}
+- [[UserPrivileges:{DescID: 110, Name: root}, ABSENT], PUBLIC]
+  {descriptorId: 110, privileges: "2", userName: root, withGrantOption: "2"}
+- [[View:{DescID: 110}, ABSENT], PUBLIC]
+  {forwardReferences: [], usesTypeIds: [108, 109], viewId: 110}
+- [[ObjectParent:{DescID: 110, ReferencedDescID: 101}, ABSENT], PUBLIC]
+  {objectId: 110, parentSchemaId: 101}
+- [[Column:{DescID: 110, ColumnID: 1}, ABSENT], PUBLIC]
+  {columnId: 1, pgAttributeNum: 1, tableId: 110}
+- [[ColumnName:{DescID: 110, Name: hi, ColumnID: 1}, ABSENT], PUBLIC]
+  {columnId: 1, name: hi, tableId: 110}
+- [[ColumnType:{DescID: 110, ReferencedTypeIDs: [108 109], ColumnFamilyID: 0, ColumnID: 1}, ABSENT], PUBLIC]
+  {closedTypeIds: [108, 109], columnId: 1, elementCreationMetadata: {in231OrLater: true}, isNullable: true, tableId: 110, type: {family: EnumFamily, oid: 100108, udtMetadata: {arrayTypeOid: 100109}}}
+- [[Column:{DescID: 110, ColumnID: 4294967295}, ABSENT], PUBLIC]
+  {columnId: 4.294967295e+09, isHidden: true, isSystemColumn: true, pgAttributeNum: 4.294967295e+09, tableId: 110}
+- [[ColumnName:{DescID: 110, Name: crdb_internal_mvcc_timestamp, ColumnID: 4294967295}, ABSENT], PUBLIC]
+  {columnId: 4.294967295e+09, name: crdb_internal_mvcc_timestamp, tableId: 110}
+- [[ColumnType:{DescID: 110, ColumnFamilyID: 0, ColumnID: 4294967295}, ABSENT], PUBLIC]
+  {columnId: 4.294967295e+09, elementCreationMetadata: {in231OrLater: true}, isNullable: true, tableId: 110, type: {family: DecimalFamily, oid: 1700}}
+- [[Column:{DescID: 110, ColumnID: 4294967294}, ABSENT], PUBLIC]
+  {columnId: 4.294967294e+09, isHidden: true, isSystemColumn: true, pgAttributeNum: 4.294967294e+09, tableId: 110}
+- [[ColumnName:{DescID: 110, Name: tableoid, ColumnID: 4294967294}, ABSENT], PUBLIC]
+  {columnId: 4.294967294e+09, name: tableoid, tableId: 110}
+- [[ColumnType:{DescID: 110, ColumnFamilyID: 0, ColumnID: 4294967294}, ABSENT], PUBLIC]
+  {columnId: 4.294967294e+09, elementCreationMetadata: {in231OrLater: true}, isNullable: true, tableId: 110, type: {family: OidFamily, oid: 26}}
+- [[Column:{DescID: 111, ColumnID: 2}, ABSENT], PUBLIC]
+  {columnId: 2, pgAttributeNum: 2, tableId: 111}
+- [[ColumnName:{DescID: 111, Name: gs, ColumnID: 2}, ABSENT], PUBLIC]
+  {columnId: 2, name: gs, tableId: 111}
+- [[ColumnType:{DescID: 111, ReferencedTypeIDs: [108 109], ColumnFamilyID: 0, ColumnID: 2}, ABSENT], PUBLIC]
+  {closedTypeIds: [108, 109], columnId: 2, computeExpr: {expr: 'x''80'':::@100108', usesTypeIds: [108, 109]}, elementCreationMetadata: {in231OrLater: true}, isNullable: true, tableId: 111, type: {family: EnumFamily, oid: 100108, udtMetadata: {arrayTypeOid: 100109}}}
+- [[Column:{DescID: 111, ColumnID: 3}, ABSENT], PUBLIC]
+  {columnId: 3, pgAttributeNum: 3, tableId: 111}
+- [[ColumnName:{DescID: 111, Name: gv, ColumnID: 3}, ABSENT], PUBLIC]
+  {columnId: 3, name: gv, tableId: 111}
+- [[ColumnType:{DescID: 111, ColumnFamilyID: 0, ColumnID: 3}, ABSENT], PUBLIC]
+  {columnId: 3, computeExpr: {expr: 'x''40'':::@100108::STRING', usesTypeIds: [108, 109]}, elementCreationMetadata: {in231OrLater: true}, isNullable: true, isVirtual: true, tableId: 111, type: {family: StringFamily, oid: 25}}
+- [[Column:{DescID: 111, ColumnID: 4}, ABSENT], PUBLIC]
+  {columnId: 4, pgAttributeNum: 4, tableId: 111}
+- [[ColumnName:{DescID: 111, Name: other, ColumnID: 4}, ABSENT], PUBLIC]
+  {columnId: 4, name: other, tableId: 111}
+- [[ColumnType:{DescID: 111, ReferencedTypeIDs: [108 109], ColumnFamilyID: 0, ColumnID: 4}, ABSENT], PUBLIC]
+  {closedTypeIds: [108, 109], columnId: 4, elementCreationMetadata: {in231OrLater: true}, isNullable: true, tableId: 111, type: {arrayContents: {family: EnumFamily, oid: 100108, udtMetadata: {arrayTypeOid: 100109}}, arrayElemType: EnumFamily, family: ArrayFamily, oid: 100109}}
+- [[IndexColumn:{DescID: 111, ColumnID: 1, IndexID: 1}, ABSENT], PUBLIC]
+  {columnId: 1, indexId: 1, tableId: 111}
+- [[IndexColumn:{DescID: 111, ColumnID: 2, IndexID: 1}, ABSENT], PUBLIC]
+  {columnId: 2, indexId: 1, kind: STORED, tableId: 111}
+- [[IndexColumn:{DescID: 111, ColumnID: 4, IndexID: 1}, ABSENT], PUBLIC]
+  {columnId: 4, indexId: 1, kind: STORED, ordinalInKind: 1, tableId: 111}
+- [[IndexColumn:{DescID: 111, ColumnID: 5, IndexID: 1}, ABSENT], PUBLIC]
+  {columnId: 5, indexId: 1, kind: STORED, ordinalInKind: 2, tableId: 111}
+- [[PrimaryIndex:{DescID: 111, IndexID: 1, ConstraintID: 1}, ABSENT], PUBLIC]
+  {constraintId: 1, indexId: 1, isUnique: true, tableId: 111}
+- [[IndexName:{DescID: 111, Name: tbl_pkey, IndexID: 1}, ABSENT], PUBLIC]
+  {indexId: 1, name: tbl_pkey, tableId: 111}
+- [[IndexData:{DescID: 111, IndexID: 1}, ABSENT], PUBLIC]
+  {indexId: 1, tableId: 111}
+- [[IndexColumn:{DescID: 111, ColumnID: 5, IndexID: 2}, ABSENT], PUBLIC]
+  {columnId: 5, indexId: 2, tableId: 111}
+- [[IndexColumn:{DescID: 111, ColumnID: 1, IndexID: 2}, ABSENT], PUBLIC]
+  {columnId: 1, indexId: 2, kind: KEY_SUFFIX, tableId: 111}
+- [[SecondaryIndexPartial:{DescID: 111, IndexID: 2}, ABSENT], PUBLIC]
+  {expr: 'gs::STRING = ''hi'':::STRING', indexId: 2, referencedColumnIds: [2], tableId: 111}
+- [[SecondaryIndex:{DescID: 111, IndexID: 2, ConstraintID: 0}, ABSENT], PUBLIC]
+  {indexId: 2, tableId: 111}
+- [[IndexName:{DescID: 111, Name: partial, IndexID: 2}, ABSENT], PUBLIC]
+  {indexId: 2, name: partial, tableId: 111}
+- [[IndexData:{DescID: 111, IndexID: 2}, ABSENT], PUBLIC]
+  {indexId: 2, tableId: 111}
+- [[UniqueWithoutIndexConstraint:{DescID: 111, ConstraintID: 3}, ABSENT], PUBLIC]
+  {columnIds: [5], constraintId: 3, predicate: {expr: 'x''80'':::@100108::STRING = ''hi'':::STRING', usesTypeIds: [108, 109]}, tableId: 111}
+- [[ConstraintWithoutIndexName:{DescID: 111, Name: myuwi, ConstraintID: 3}, ABSENT], PUBLIC]
+  {constraintId: 3, name: myuwi, tableId: 111}
+- [[CheckConstraint:{DescID: 111, IndexID: 0, ConstraintID: 2}, ABSENT], PUBLIC]
+  {columnIds: [2, 5], constraintId: 2, expr: 'gs::STRING = name', referencedColumnIds: [2, 5], tableId: 111}
+- [[ConstraintWithoutIndexName:{DescID: 111, Name: mycheck, ConstraintID: 2}, ABSENT], PUBLIC]
+  {constraintId: 2, name: mycheck, tableId: 111}
+- [[PrimaryIndex:{DescID: 111, IndexID: 3, ConstraintID: 4, TemporaryIndexID: 4, SourceIndexID: 1}, PUBLIC], ABSENT]
+  {constraintId: 4, indexId: 3, isUnique: true, sourceIndexId: 1, tableId: 111, temporaryIndexId: 4}
+- [[IndexName:{DescID: 111, Name: tbl_pkey, IndexID: 3}, PUBLIC], ABSENT]
+  {indexId: 3, name: tbl_pkey, tableId: 111}
+- [[IndexColumn:{DescID: 111, ColumnID: 1, IndexID: 3}, PUBLIC], ABSENT]
+  {columnId: 1, indexId: 3, tableId: 111}
+- [[IndexColumn:{DescID: 111, ColumnID: 5, IndexID: 3}, PUBLIC], ABSENT]
+  {columnId: 5, indexId: 3, kind: STORED, tableId: 111}
+- [[IndexData:{DescID: 111, IndexID: 3}, PUBLIC], ABSENT]
+  {indexId: 3, tableId: 111}
+- [[TemporaryIndex:{DescID: 111, IndexID: 4, ConstraintID: 5, SourceIndexID: 1}, TRANSIENT_ABSENT], ABSENT]
+  {constraintId: 5, indexId: 4, isUnique: true, sourceIndexId: 1, tableId: 111}
+- [[IndexColumn:{DescID: 111, ColumnID: 1, IndexID: 4}, TRANSIENT_ABSENT], ABSENT]
+  {columnId: 1, indexId: 4, tableId: 111}
+- [[IndexColumn:{DescID: 111, ColumnID: 5, IndexID: 4}, PUBLIC], ABSENT]
+  {columnId: 5, indexId: 4, kind: STORED, tableId: 111}
+- [[IndexData:{DescID: 111, IndexID: 4}, TRANSIENT_ABSENT], ABSENT]
+  {indexId: 4, tableId: 111}

--- a/pkg/sql/schemachanger/scbuild/testdata/unimplemented_alter_table
+++ b/pkg/sql/schemachanger/scbuild/testdata/unimplemented_alter_table
@@ -21,22 +21,6 @@ ALTER TABLE defaultdb.foo ALTER COLUMN i SET DATA TYPE STRING
 ----
 
 unimplemented
-ALTER TABLE defaultdb.foo DROP COLUMN k
-----
-
-unimplemented
-ALTER TABLE defaultdb.foo DROP COLUMN l CASCADE;
-----
-
-unimplemented
-ALTER TABLE defaultdb.foo DROP COLUMN m
-----
-
-unimplemented
-ALTER TABLE defaultdb.foo DROP COLUMN n
-----
-
-unimplemented
 ALTER TABLE defaultdb.foo DROP COLUMN o, ADD COLUMN p INT
 ----
 

--- a/pkg/sql/schemachanger/scbuild/testdata/unimplemented_drop
+++ b/pkg/sql/schemachanger/scbuild/testdata/unimplemented_drop
@@ -1,7 +1,0 @@
-setup
-CREATE TYPE defaultdb.greeting AS ENUM('hello', 'hi')
-----
-
-unimplemented
-DROP TYPE defaultdb.greeting CASCADE
-----

--- a/pkg/sql/schemachanger/scdecomp/decomp.go
+++ b/pkg/sql/schemachanger/scdecomp/decomp.go
@@ -441,6 +441,14 @@ func (w *walkCtx) walkColumn(tbl catalog.TableDescriptor, col catalog.Column) {
 			expr, err := w.newExpression(col.GetComputeExpr())
 			onErrPanic(err)
 			columnType.ComputeExpr = expr
+			// TODO (postamar): move the computed expression to a separate element
+			// In the meantime we recompute the ClosedTypeIDs to ensure that
+			// DROP TYPE ... CASCADE works correctly.
+			newClosedTypeIDs := catalog.MakeDescriptorIDSet(columnType.ClosedTypeIDs...)
+			for _, id := range columnType.ComputeExpr.UsesTypeIDs {
+				newClosedTypeIDs.Add(id)
+			}
+			columnType.ClosedTypeIDs = newClosedTypeIDs.Ordered()
 		}
 		w.ev(scpb.Status_PUBLIC, columnType)
 	}

--- a/pkg/sql/schemachanger/scplan/testdata/alter_table_drop_column
+++ b/pkg/sql/schemachanger/scplan/testdata/alter_table_drop_column
@@ -460,7 +460,7 @@ PostCommitNonRevertiblePhase stage 1 of 3 with 25 MutationType ops
     *scop.UpdateSchemaChangerJob
       IsNonCancelable: true
       JobID: 1
-PostCommitNonRevertiblePhase stage 2 of 3 with 8 MutationType ops
+PostCommitNonRevertiblePhase stage 2 of 3 with 9 MutationType ops
   transitions:
     [[PrimaryIndex:{DescID: 107, IndexID: 1, ConstraintID: 2}, ABSENT], VALIDATED] -> DELETE_ONLY
     [[SecondaryIndex:{DescID: 107, IndexID: 2, ConstraintID: 1}, ABSENT], DELETE_ONLY] -> ABSENT
@@ -484,6 +484,9 @@ PostCommitNonRevertiblePhase stage 2 of 3 with 8 MutationType ops
       DescriptorID: 105
     *scop.SetJobStateOnDescriptor
       DescriptorID: 107
+    *scop.RemoveJobStateFromDescriptor
+      DescriptorID: 108
+      JobID: 1
     *scop.UpdateSchemaChangerJob
       DescriptorIDsToRemove:
       - 108
@@ -1556,7 +1559,7 @@ PostCommitNonRevertiblePhase stage 1 of 3 with 27 MutationType ops
     *scop.UpdateSchemaChangerJob
       IsNonCancelable: true
       JobID: 1
-PostCommitNonRevertiblePhase stage 2 of 3 with 9 MutationType ops
+PostCommitNonRevertiblePhase stage 2 of 3 with 10 MutationType ops
   transitions:
     [[PrimaryIndex:{DescID: 107, IndexID: 1, ConstraintID: 2}, ABSENT], VALIDATED] -> DELETE_ONLY
     [[SecondaryIndex:{DescID: 107, IndexID: 2, ConstraintID: 1}, ABSENT], DELETE_ONLY] -> ABSENT
@@ -1582,6 +1585,9 @@ PostCommitNonRevertiblePhase stage 2 of 3 with 9 MutationType ops
       DescriptorID: 106
     *scop.SetJobStateOnDescriptor
       DescriptorID: 107
+    *scop.RemoveJobStateFromDescriptor
+      DescriptorID: 108
+      JobID: 1
     *scop.UpdateSchemaChangerJob
       DescriptorIDsToRemove:
       - 108

--- a/pkg/sql/schemachanger/scplan/testdata/drop_index
+++ b/pkg/sql/schemachanger/scplan/testdata/drop_index
@@ -782,7 +782,7 @@ PreCommitPhase stage 2 of 2 with 11 MutationType ops
       - statement: DROP INDEX idx4 CASCADE
         redactedstatement: DROP INDEX ‹defaultdb›.public.‹t1›@‹idx4› CASCADE
         statementtag: DROP INDEX
-PostCommitNonRevertiblePhase stage 1 of 2 with 5 MutationType ops
+PostCommitNonRevertiblePhase stage 1 of 2 with 6 MutationType ops
   transitions:
     [[SecondaryIndex:{DescID: 104, IndexID: 8, ConstraintID: 5}, ABSENT], VALIDATED] -> DELETE_ONLY
     [[IndexName:{DescID: 104, Name: idx4, IndexID: 8}, ABSENT], PUBLIC] -> ABSENT
@@ -799,6 +799,9 @@ PostCommitNonRevertiblePhase stage 1 of 2 with 5 MutationType ops
       TableID: 104
     *scop.SetJobStateOnDescriptor
       DescriptorID: 104
+    *scop.RemoveJobStateFromDescriptor
+      DescriptorID: 105
+      JobID: 1
     *scop.UpdateSchemaChangerJob
       DescriptorIDsToRemove:
       - 105
@@ -1224,7 +1227,7 @@ PreCommitPhase stage 2 of 2 with 14 MutationType ops
       - statement: DROP INDEX v2@idx CASCADE
         redactedstatement: DROP INDEX ‹defaultdb›.public.‹v2›@‹idx› CASCADE
         statementtag: DROP INDEX
-PostCommitNonRevertiblePhase stage 1 of 2 with 6 MutationType ops
+PostCommitNonRevertiblePhase stage 1 of 2 with 7 MutationType ops
   transitions:
     [[SecondaryIndex:{DescID: 106, IndexID: 2, ConstraintID: 0}, ABSENT], VALIDATED] -> DELETE_ONLY
     [[IndexName:{DescID: 106, Name: idx, IndexID: 2}, ABSENT], PUBLIC] -> ABSENT
@@ -1251,6 +1254,9 @@ PostCommitNonRevertiblePhase stage 1 of 2 with 6 MutationType ops
       TableID: 107
     *scop.SetJobStateOnDescriptor
       DescriptorID: 106
+    *scop.RemoveJobStateFromDescriptor
+      DescriptorID: 107
+      JobID: 1
     *scop.UpdateSchemaChangerJob
       DescriptorIDsToRemove:
       - 107

--- a/pkg/sql/schemachanger/scplan/testdata/drop_type_cascade
+++ b/pkg/sql/schemachanger/scplan/testdata/drop_type_cascade
@@ -1,0 +1,1381 @@
+setup
+SET experimental_enable_unique_without_index_constraints = true;
+CREATE TYPE greeting AS ENUM('hello', 'hi');
+CREATE VIEW view AS SELECT 'hi'::greeting AS hi;
+CREATE TABLE tbl (
+  id INT PRIMARY KEY,
+  gs greeting AS ('hi'::greeting) STORED,
+  gv string AS ('hello'::greeting::STRING) VIRTUAL,
+  other greeting[],
+  name STRING NOT NULL,
+  CONSTRAINT mycheck CHECK (gs::STRING = name),
+  CONSTRAINT myuwi UNIQUE WITHOUT INDEX (name) WHERE ('hi'::greeting::STRING = 'hi'),
+  INDEX partial (name) WHERE (gs::STRING = 'hi')
+);
+----
+
+ops
+DROP TYPE greeting CASCADE
+----
+StatementPhase stage 1 of 1 with 21 MutationType ops
+  transitions:
+    [[Namespace:{DescID: 106, Name: view, ReferencedDescID: 100}, ABSENT], PUBLIC] -> ABSENT
+    [[Owner:{DescID: 106}, ABSENT], PUBLIC] -> ABSENT
+    [[UserPrivileges:{DescID: 106, Name: admin}, ABSENT], PUBLIC] -> ABSENT
+    [[UserPrivileges:{DescID: 106, Name: root}, ABSENT], PUBLIC] -> ABSENT
+    [[View:{DescID: 106}, ABSENT], PUBLIC] -> DROPPED
+    [[ObjectParent:{DescID: 106, ReferencedDescID: 101}, ABSENT], PUBLIC] -> ABSENT
+    [[Column:{DescID: 106, ColumnID: 1}, ABSENT], PUBLIC] -> WRITE_ONLY
+    [[ColumnName:{DescID: 106, Name: hi, ColumnID: 1}, ABSENT], PUBLIC] -> ABSENT
+    [[Column:{DescID: 106, ColumnID: 4294967295}, ABSENT], PUBLIC] -> WRITE_ONLY
+    [[ColumnName:{DescID: 106, Name: crdb_internal_mvcc_timestamp, ColumnID: 4294967295}, ABSENT], PUBLIC] -> ABSENT
+    [[ColumnType:{DescID: 106, ColumnFamilyID: 0, ColumnID: 4294967295}, ABSENT], PUBLIC] -> ABSENT
+    [[Column:{DescID: 106, ColumnID: 4294967294}, ABSENT], PUBLIC] -> WRITE_ONLY
+    [[ColumnName:{DescID: 106, Name: tableoid, ColumnID: 4294967294}, ABSENT], PUBLIC] -> ABSENT
+    [[ColumnType:{DescID: 106, ColumnFamilyID: 0, ColumnID: 4294967294}, ABSENT], PUBLIC] -> ABSENT
+    [[Column:{DescID: 107, ColumnID: 2}, ABSENT], PUBLIC] -> WRITE_ONLY
+    [[ColumnName:{DescID: 107, Name: gs, ColumnID: 2}, ABSENT], PUBLIC] -> ABSENT
+    [[Column:{DescID: 107, ColumnID: 3}, ABSENT], PUBLIC] -> WRITE_ONLY
+    [[ColumnName:{DescID: 107, Name: gv, ColumnID: 3}, ABSENT], PUBLIC] -> ABSENT
+    [[Column:{DescID: 107, ColumnID: 4}, ABSENT], PUBLIC] -> WRITE_ONLY
+    [[ColumnName:{DescID: 107, Name: other, ColumnID: 4}, ABSENT], PUBLIC] -> ABSENT
+    [[IndexColumn:{DescID: 107, ColumnID: 5, IndexID: 2}, ABSENT], PUBLIC] -> ABSENT
+    [[IndexColumn:{DescID: 107, ColumnID: 1, IndexID: 2}, ABSENT], PUBLIC] -> ABSENT
+    [[SecondaryIndex:{DescID: 107, IndexID: 2, ConstraintID: 0}, ABSENT], PUBLIC] -> VALIDATED
+    [[UniqueWithoutIndexConstraint:{DescID: 107, ConstraintID: 3}, ABSENT], PUBLIC] -> VALIDATED
+    [[ConstraintWithoutIndexName:{DescID: 107, Name: myuwi, ConstraintID: 3}, ABSENT], PUBLIC] -> ABSENT
+    [[CheckConstraint:{DescID: 107, IndexID: 0, ConstraintID: 2}, ABSENT], PUBLIC] -> VALIDATED
+    [[ConstraintWithoutIndexName:{DescID: 107, Name: mycheck, ConstraintID: 2}, ABSENT], PUBLIC] -> ABSENT
+    [[PrimaryIndex:{DescID: 107, IndexID: 3, ConstraintID: 4, TemporaryIndexID: 4, SourceIndexID: 1}, PUBLIC], ABSENT] -> BACKFILL_ONLY
+    [[IndexColumn:{DescID: 107, ColumnID: 1, IndexID: 3}, PUBLIC], ABSENT] -> PUBLIC
+    [[IndexColumn:{DescID: 107, ColumnID: 5, IndexID: 3}, PUBLIC], ABSENT] -> PUBLIC
+    [[IndexData:{DescID: 107, IndexID: 3}, PUBLIC], ABSENT] -> PUBLIC
+    [[TemporaryIndex:{DescID: 107, IndexID: 4, ConstraintID: 5, SourceIndexID: 1}, TRANSIENT_ABSENT], ABSENT] -> DELETE_ONLY
+    [[IndexColumn:{DescID: 107, ColumnID: 1, IndexID: 4}, TRANSIENT_ABSENT], ABSENT] -> TRANSIENT_ABSENT
+    [[IndexColumn:{DescID: 107, ColumnID: 5, IndexID: 4}, PUBLIC], ABSENT] -> PUBLIC
+  ops:
+    *scop.MarkDescriptorAsDropped
+      DescriptorID: 106
+    *scop.RemoveBackReferenceInTypes
+      BackReferencedDescriptorID: 106
+      TypeIDs:
+      - 104
+      - 105
+    *scop.RemoveObjectParent
+      ObjectID: 106
+      ParentSchemaID: 101
+    *scop.MakePublicColumnWriteOnly
+      ColumnID: 2
+      TableID: 107
+    *scop.SetColumnName
+      ColumnID: 2
+      Name: crdb_internal_column_2_name_placeholder
+      TableID: 107
+    *scop.MakePublicColumnWriteOnly
+      ColumnID: 3
+      TableID: 107
+    *scop.SetColumnName
+      ColumnID: 3
+      Name: crdb_internal_column_3_name_placeholder
+      TableID: 107
+    *scop.MakePublicColumnWriteOnly
+      ColumnID: 4
+      TableID: 107
+    *scop.SetColumnName
+      ColumnID: 4
+      Name: crdb_internal_column_4_name_placeholder
+      TableID: 107
+    *scop.MakePublicSecondaryIndexWriteOnly
+      IndexID: 2
+      TableID: 107
+    *scop.MakePublicUniqueWithoutIndexConstraintValidated
+      ConstraintID: 3
+      TableID: 107
+    *scop.SetConstraintName
+      ConstraintID: 3
+      Name: crdb_internal_constraint_3_name_placeholder
+      TableID: 107
+    *scop.MakePublicCheckConstraintValidated
+      ConstraintID: 2
+      TableID: 107
+    *scop.SetConstraintName
+      ConstraintID: 2
+      Name: crdb_internal_constraint_2_name_placeholder
+      TableID: 107
+    *scop.MakeAbsentIndexBackfilling
+      Index:
+        ConstraintID: 4
+        IndexID: 3
+        IsUnique: true
+        SourceIndexID: 1
+        TableID: 107
+        TemporaryIndexID: 4
+    *scop.AddColumnToIndex
+      ColumnID: 1
+      IndexID: 3
+      TableID: 107
+    *scop.AddColumnToIndex
+      ColumnID: 5
+      IndexID: 3
+      Kind: 2
+      TableID: 107
+    *scop.MakeAbsentTempIndexDeleteOnly
+      Index:
+        ConstraintID: 5
+        IndexID: 4
+        IsUnique: true
+        SourceIndexID: 1
+        TableID: 107
+    *scop.AddColumnToIndex
+      ColumnID: 1
+      IndexID: 4
+      TableID: 107
+    *scop.AddColumnToIndex
+      ColumnID: 5
+      IndexID: 4
+      Kind: 2
+      TableID: 107
+    *scop.DrainDescriptorName
+      Namespace:
+        DatabaseID: 100
+        DescriptorID: 106
+        Name: view
+        SchemaID: 101
+PreCommitPhase stage 1 of 2 with 1 MutationType op
+  transitions:
+    [[Namespace:{DescID: 106, Name: view, ReferencedDescID: 100}, ABSENT], ABSENT] -> PUBLIC
+    [[Owner:{DescID: 106}, ABSENT], ABSENT] -> PUBLIC
+    [[UserPrivileges:{DescID: 106, Name: admin}, ABSENT], ABSENT] -> PUBLIC
+    [[UserPrivileges:{DescID: 106, Name: root}, ABSENT], ABSENT] -> PUBLIC
+    [[View:{DescID: 106}, ABSENT], DROPPED] -> PUBLIC
+    [[ObjectParent:{DescID: 106, ReferencedDescID: 101}, ABSENT], ABSENT] -> PUBLIC
+    [[Column:{DescID: 106, ColumnID: 1}, ABSENT], WRITE_ONLY] -> PUBLIC
+    [[ColumnName:{DescID: 106, Name: hi, ColumnID: 1}, ABSENT], ABSENT] -> PUBLIC
+    [[Column:{DescID: 106, ColumnID: 4294967295}, ABSENT], WRITE_ONLY] -> PUBLIC
+    [[ColumnName:{DescID: 106, Name: crdb_internal_mvcc_timestamp, ColumnID: 4294967295}, ABSENT], ABSENT] -> PUBLIC
+    [[ColumnType:{DescID: 106, ColumnFamilyID: 0, ColumnID: 4294967295}, ABSENT], ABSENT] -> PUBLIC
+    [[Column:{DescID: 106, ColumnID: 4294967294}, ABSENT], WRITE_ONLY] -> PUBLIC
+    [[ColumnName:{DescID: 106, Name: tableoid, ColumnID: 4294967294}, ABSENT], ABSENT] -> PUBLIC
+    [[ColumnType:{DescID: 106, ColumnFamilyID: 0, ColumnID: 4294967294}, ABSENT], ABSENT] -> PUBLIC
+    [[Column:{DescID: 107, ColumnID: 2}, ABSENT], WRITE_ONLY] -> PUBLIC
+    [[ColumnName:{DescID: 107, Name: gs, ColumnID: 2}, ABSENT], ABSENT] -> PUBLIC
+    [[Column:{DescID: 107, ColumnID: 3}, ABSENT], WRITE_ONLY] -> PUBLIC
+    [[ColumnName:{DescID: 107, Name: gv, ColumnID: 3}, ABSENT], ABSENT] -> PUBLIC
+    [[Column:{DescID: 107, ColumnID: 4}, ABSENT], WRITE_ONLY] -> PUBLIC
+    [[ColumnName:{DescID: 107, Name: other, ColumnID: 4}, ABSENT], ABSENT] -> PUBLIC
+    [[IndexColumn:{DescID: 107, ColumnID: 5, IndexID: 2}, ABSENT], ABSENT] -> PUBLIC
+    [[IndexColumn:{DescID: 107, ColumnID: 1, IndexID: 2}, ABSENT], ABSENT] -> PUBLIC
+    [[SecondaryIndex:{DescID: 107, IndexID: 2, ConstraintID: 0}, ABSENT], VALIDATED] -> PUBLIC
+    [[UniqueWithoutIndexConstraint:{DescID: 107, ConstraintID: 3}, ABSENT], VALIDATED] -> PUBLIC
+    [[ConstraintWithoutIndexName:{DescID: 107, Name: myuwi, ConstraintID: 3}, ABSENT], ABSENT] -> PUBLIC
+    [[CheckConstraint:{DescID: 107, IndexID: 0, ConstraintID: 2}, ABSENT], VALIDATED] -> PUBLIC
+    [[ConstraintWithoutIndexName:{DescID: 107, Name: mycheck, ConstraintID: 2}, ABSENT], ABSENT] -> PUBLIC
+    [[PrimaryIndex:{DescID: 107, IndexID: 3, ConstraintID: 4, TemporaryIndexID: 4, SourceIndexID: 1}, PUBLIC], BACKFILL_ONLY] -> ABSENT
+    [[IndexColumn:{DescID: 107, ColumnID: 1, IndexID: 3}, PUBLIC], PUBLIC] -> ABSENT
+    [[IndexColumn:{DescID: 107, ColumnID: 5, IndexID: 3}, PUBLIC], PUBLIC] -> ABSENT
+    [[IndexData:{DescID: 107, IndexID: 3}, PUBLIC], PUBLIC] -> ABSENT
+    [[TemporaryIndex:{DescID: 107, IndexID: 4, ConstraintID: 5, SourceIndexID: 1}, TRANSIENT_ABSENT], DELETE_ONLY] -> ABSENT
+    [[IndexColumn:{DescID: 107, ColumnID: 1, IndexID: 4}, TRANSIENT_ABSENT], TRANSIENT_ABSENT] -> ABSENT
+    [[IndexColumn:{DescID: 107, ColumnID: 5, IndexID: 4}, PUBLIC], PUBLIC] -> ABSENT
+  ops:
+    *scop.UndoAllInTxnImmediateMutationOpSideEffects
+      {}
+PreCommitPhase stage 2 of 2 with 24 MutationType ops
+  transitions:
+    [[Column:{DescID: 107, ColumnID: 2}, ABSENT], PUBLIC] -> WRITE_ONLY
+    [[ColumnName:{DescID: 107, Name: gs, ColumnID: 2}, ABSENT], PUBLIC] -> ABSENT
+    [[Column:{DescID: 107, ColumnID: 3}, ABSENT], PUBLIC] -> WRITE_ONLY
+    [[ColumnName:{DescID: 107, Name: gv, ColumnID: 3}, ABSENT], PUBLIC] -> ABSENT
+    [[Column:{DescID: 107, ColumnID: 4}, ABSENT], PUBLIC] -> WRITE_ONLY
+    [[ColumnName:{DescID: 107, Name: other, ColumnID: 4}, ABSENT], PUBLIC] -> ABSENT
+    [[SecondaryIndex:{DescID: 107, IndexID: 2, ConstraintID: 0}, ABSENT], PUBLIC] -> VALIDATED
+    [[UniqueWithoutIndexConstraint:{DescID: 107, ConstraintID: 3}, ABSENT], PUBLIC] -> VALIDATED
+    [[ConstraintWithoutIndexName:{DescID: 107, Name: myuwi, ConstraintID: 3}, ABSENT], PUBLIC] -> ABSENT
+    [[CheckConstraint:{DescID: 107, IndexID: 0, ConstraintID: 2}, ABSENT], PUBLIC] -> VALIDATED
+    [[ConstraintWithoutIndexName:{DescID: 107, Name: mycheck, ConstraintID: 2}, ABSENT], PUBLIC] -> ABSENT
+    [[PrimaryIndex:{DescID: 107, IndexID: 3, ConstraintID: 4, TemporaryIndexID: 4, SourceIndexID: 1}, PUBLIC], ABSENT] -> BACKFILL_ONLY
+    [[IndexColumn:{DescID: 107, ColumnID: 1, IndexID: 3}, PUBLIC], ABSENT] -> PUBLIC
+    [[IndexColumn:{DescID: 107, ColumnID: 5, IndexID: 3}, PUBLIC], ABSENT] -> PUBLIC
+    [[IndexData:{DescID: 107, IndexID: 3}, PUBLIC], ABSENT] -> PUBLIC
+    [[TemporaryIndex:{DescID: 107, IndexID: 4, ConstraintID: 5, SourceIndexID: 1}, TRANSIENT_ABSENT], ABSENT] -> DELETE_ONLY
+    [[IndexColumn:{DescID: 107, ColumnID: 1, IndexID: 4}, TRANSIENT_ABSENT], ABSENT] -> PUBLIC
+    [[IndexColumn:{DescID: 107, ColumnID: 5, IndexID: 4}, PUBLIC], ABSENT] -> PUBLIC
+  ops:
+    *scop.MakePublicColumnWriteOnly
+      ColumnID: 2
+      TableID: 107
+    *scop.SetColumnName
+      ColumnID: 2
+      Name: crdb_internal_column_2_name_placeholder
+      TableID: 107
+    *scop.MakePublicColumnWriteOnly
+      ColumnID: 3
+      TableID: 107
+    *scop.SetColumnName
+      ColumnID: 3
+      Name: crdb_internal_column_3_name_placeholder
+      TableID: 107
+    *scop.MakePublicColumnWriteOnly
+      ColumnID: 4
+      TableID: 107
+    *scop.SetColumnName
+      ColumnID: 4
+      Name: crdb_internal_column_4_name_placeholder
+      TableID: 107
+    *scop.MakePublicSecondaryIndexWriteOnly
+      IndexID: 2
+      TableID: 107
+    *scop.MakePublicUniqueWithoutIndexConstraintValidated
+      ConstraintID: 3
+      TableID: 107
+    *scop.SetConstraintName
+      ConstraintID: 3
+      Name: crdb_internal_constraint_3_name_placeholder
+      TableID: 107
+    *scop.MakePublicCheckConstraintValidated
+      ConstraintID: 2
+      TableID: 107
+    *scop.SetConstraintName
+      ConstraintID: 2
+      Name: crdb_internal_constraint_2_name_placeholder
+      TableID: 107
+    *scop.MakeAbsentIndexBackfilling
+      Index:
+        ConstraintID: 4
+        IndexID: 3
+        IsUnique: true
+        SourceIndexID: 1
+        TableID: 107
+        TemporaryIndexID: 4
+    *scop.MaybeAddSplitForIndex
+      IndexID: 3
+      TableID: 107
+    *scop.AddColumnToIndex
+      ColumnID: 1
+      IndexID: 3
+      TableID: 107
+    *scop.AddColumnToIndex
+      ColumnID: 5
+      IndexID: 3
+      Kind: 2
+      TableID: 107
+    *scop.MakeAbsentTempIndexDeleteOnly
+      Index:
+        ConstraintID: 5
+        IndexID: 4
+        IsUnique: true
+        SourceIndexID: 1
+        TableID: 107
+    *scop.MaybeAddSplitForIndex
+      IndexID: 4
+      TableID: 107
+    *scop.AddColumnToIndex
+      ColumnID: 1
+      IndexID: 4
+      TableID: 107
+    *scop.AddColumnToIndex
+      ColumnID: 5
+      IndexID: 4
+      Kind: 2
+      TableID: 107
+    *scop.SetJobStateOnDescriptor
+      DescriptorID: 104
+      Initialize: true
+    *scop.SetJobStateOnDescriptor
+      DescriptorID: 105
+      Initialize: true
+    *scop.SetJobStateOnDescriptor
+      DescriptorID: 106
+      Initialize: true
+    *scop.SetJobStateOnDescriptor
+      DescriptorID: 107
+      Initialize: true
+    *scop.CreateSchemaChangerJob
+      Authorization:
+        UserName: root
+      DescriptorIDs:
+      - 104
+      - 105
+      - 106
+      - 107
+      JobID: 1
+      RunningStatus: PostCommitPhase stage 1 of 7 with 1 MutationType op pending
+      Statements:
+      - statement: DROP TYPE greeting CASCADE
+        redactedstatement: DROP TYPE ‹defaultdb›.‹public›.‹greeting› CASCADE
+        statementtag: DROP TYPE
+PostCommitPhase stage 1 of 7 with 6 MutationType ops
+  transitions:
+    [[TemporaryIndex:{DescID: 107, IndexID: 4, ConstraintID: 5, SourceIndexID: 1}, TRANSIENT_ABSENT], DELETE_ONLY] -> WRITE_ONLY
+    [[IndexData:{DescID: 107, IndexID: 4}, TRANSIENT_ABSENT], ABSENT] -> PUBLIC
+  ops:
+    *scop.MakeDeleteOnlyIndexWriteOnly
+      IndexID: 4
+      TableID: 107
+    *scop.SetJobStateOnDescriptor
+      DescriptorID: 104
+    *scop.SetJobStateOnDescriptor
+      DescriptorID: 105
+    *scop.SetJobStateOnDescriptor
+      DescriptorID: 106
+    *scop.SetJobStateOnDescriptor
+      DescriptorID: 107
+    *scop.UpdateSchemaChangerJob
+      JobID: 1
+PostCommitPhase stage 2 of 7 with 1 BackfillType op
+  transitions:
+    [[PrimaryIndex:{DescID: 107, IndexID: 3, ConstraintID: 4, TemporaryIndexID: 4, SourceIndexID: 1}, PUBLIC], BACKFILL_ONLY] -> BACKFILLED
+  ops:
+    *scop.BackfillIndex
+      IndexID: 3
+      SourceIndexID: 1
+      TableID: 107
+PostCommitPhase stage 3 of 7 with 6 MutationType ops
+  transitions:
+    [[PrimaryIndex:{DescID: 107, IndexID: 3, ConstraintID: 4, TemporaryIndexID: 4, SourceIndexID: 1}, PUBLIC], BACKFILLED] -> DELETE_ONLY
+  ops:
+    *scop.MakeBackfillingIndexDeleteOnly
+      IndexID: 3
+      TableID: 107
+    *scop.SetJobStateOnDescriptor
+      DescriptorID: 104
+    *scop.SetJobStateOnDescriptor
+      DescriptorID: 105
+    *scop.SetJobStateOnDescriptor
+      DescriptorID: 106
+    *scop.SetJobStateOnDescriptor
+      DescriptorID: 107
+    *scop.UpdateSchemaChangerJob
+      JobID: 1
+PostCommitPhase stage 4 of 7 with 6 MutationType ops
+  transitions:
+    [[PrimaryIndex:{DescID: 107, IndexID: 3, ConstraintID: 4, TemporaryIndexID: 4, SourceIndexID: 1}, PUBLIC], DELETE_ONLY] -> MERGE_ONLY
+  ops:
+    *scop.MakeBackfilledIndexMerging
+      IndexID: 3
+      TableID: 107
+    *scop.SetJobStateOnDescriptor
+      DescriptorID: 104
+    *scop.SetJobStateOnDescriptor
+      DescriptorID: 105
+    *scop.SetJobStateOnDescriptor
+      DescriptorID: 106
+    *scop.SetJobStateOnDescriptor
+      DescriptorID: 107
+    *scop.UpdateSchemaChangerJob
+      JobID: 1
+PostCommitPhase stage 5 of 7 with 1 BackfillType op
+  transitions:
+    [[PrimaryIndex:{DescID: 107, IndexID: 3, ConstraintID: 4, TemporaryIndexID: 4, SourceIndexID: 1}, PUBLIC], MERGE_ONLY] -> MERGED
+  ops:
+    *scop.MergeIndex
+      BackfilledIndexID: 3
+      TableID: 107
+      TemporaryIndexID: 4
+PostCommitPhase stage 6 of 7 with 6 MutationType ops
+  transitions:
+    [[PrimaryIndex:{DescID: 107, IndexID: 3, ConstraintID: 4, TemporaryIndexID: 4, SourceIndexID: 1}, PUBLIC], MERGED] -> WRITE_ONLY
+  ops:
+    *scop.MakeMergedIndexWriteOnly
+      IndexID: 3
+      TableID: 107
+    *scop.SetJobStateOnDescriptor
+      DescriptorID: 104
+    *scop.SetJobStateOnDescriptor
+      DescriptorID: 105
+    *scop.SetJobStateOnDescriptor
+      DescriptorID: 106
+    *scop.SetJobStateOnDescriptor
+      DescriptorID: 107
+    *scop.UpdateSchemaChangerJob
+      JobID: 1
+PostCommitPhase stage 7 of 7 with 1 ValidationType op
+  transitions:
+    [[PrimaryIndex:{DescID: 107, IndexID: 3, ConstraintID: 4, TemporaryIndexID: 4, SourceIndexID: 1}, PUBLIC], WRITE_ONLY] -> VALIDATED
+  ops:
+    *scop.ValidateIndex
+      IndexID: 3
+      TableID: 107
+PostCommitNonRevertiblePhase stage 1 of 4 with 23 MutationType ops
+  transitions:
+    [[Namespace:{DescID: 106, Name: view, ReferencedDescID: 100}, ABSENT], PUBLIC] -> ABSENT
+    [[Owner:{DescID: 106}, ABSENT], PUBLIC] -> ABSENT
+    [[UserPrivileges:{DescID: 106, Name: admin}, ABSENT], PUBLIC] -> ABSENT
+    [[UserPrivileges:{DescID: 106, Name: root}, ABSENT], PUBLIC] -> ABSENT
+    [[View:{DescID: 106}, ABSENT], PUBLIC] -> DROPPED
+    [[ObjectParent:{DescID: 106, ReferencedDescID: 101}, ABSENT], PUBLIC] -> ABSENT
+    [[Column:{DescID: 106, ColumnID: 1}, ABSENT], PUBLIC] -> DELETE_ONLY
+    [[ColumnName:{DescID: 106, Name: hi, ColumnID: 1}, ABSENT], PUBLIC] -> ABSENT
+    [[Column:{DescID: 106, ColumnID: 4294967295}, ABSENT], PUBLIC] -> ABSENT
+    [[ColumnName:{DescID: 106, Name: crdb_internal_mvcc_timestamp, ColumnID: 4294967295}, ABSENT], PUBLIC] -> ABSENT
+    [[ColumnType:{DescID: 106, ColumnFamilyID: 0, ColumnID: 4294967295}, ABSENT], PUBLIC] -> ABSENT
+    [[Column:{DescID: 106, ColumnID: 4294967294}, ABSENT], PUBLIC] -> ABSENT
+    [[ColumnName:{DescID: 106, Name: tableoid, ColumnID: 4294967294}, ABSENT], PUBLIC] -> ABSENT
+    [[ColumnType:{DescID: 106, ColumnFamilyID: 0, ColumnID: 4294967294}, ABSENT], PUBLIC] -> ABSENT
+    [[Column:{DescID: 107, ColumnID: 2}, ABSENT], WRITE_ONLY] -> DELETE_ONLY
+    [[Column:{DescID: 107, ColumnID: 3}, ABSENT], WRITE_ONLY] -> DELETE_ONLY
+    [[Column:{DescID: 107, ColumnID: 4}, ABSENT], WRITE_ONLY] -> DELETE_ONLY
+    [[IndexColumn:{DescID: 107, ColumnID: 1, IndexID: 1}, ABSENT], PUBLIC] -> ABSENT
+    [[IndexColumn:{DescID: 107, ColumnID: 2, IndexID: 1}, ABSENT], PUBLIC] -> ABSENT
+    [[IndexColumn:{DescID: 107, ColumnID: 4, IndexID: 1}, ABSENT], PUBLIC] -> ABSENT
+    [[IndexColumn:{DescID: 107, ColumnID: 5, IndexID: 1}, ABSENT], PUBLIC] -> ABSENT
+    [[PrimaryIndex:{DescID: 107, IndexID: 1, ConstraintID: 1}, ABSENT], PUBLIC] -> VALIDATED
+    [[IndexName:{DescID: 107, Name: tbl_pkey, IndexID: 1}, ABSENT], PUBLIC] -> ABSENT
+    [[IndexColumn:{DescID: 107, ColumnID: 5, IndexID: 2}, ABSENT], PUBLIC] -> ABSENT
+    [[IndexColumn:{DescID: 107, ColumnID: 1, IndexID: 2}, ABSENT], PUBLIC] -> ABSENT
+    [[SecondaryIndex:{DescID: 107, IndexID: 2, ConstraintID: 0}, ABSENT], VALIDATED] -> DELETE_ONLY
+    [[IndexName:{DescID: 107, Name: partial, IndexID: 2}, ABSENT], PUBLIC] -> ABSENT
+    [[UniqueWithoutIndexConstraint:{DescID: 107, ConstraintID: 3}, ABSENT], VALIDATED] -> ABSENT
+    [[CheckConstraint:{DescID: 107, IndexID: 0, ConstraintID: 2}, ABSENT], VALIDATED] -> ABSENT
+    [[PrimaryIndex:{DescID: 107, IndexID: 3, ConstraintID: 4, TemporaryIndexID: 4, SourceIndexID: 1}, PUBLIC], VALIDATED] -> PUBLIC
+    [[IndexName:{DescID: 107, Name: tbl_pkey, IndexID: 3}, PUBLIC], ABSENT] -> PUBLIC
+    [[TemporaryIndex:{DescID: 107, IndexID: 4, ConstraintID: 5, SourceIndexID: 1}, TRANSIENT_ABSENT], WRITE_ONLY] -> TRANSIENT_DELETE_ONLY
+    [[IndexColumn:{DescID: 107, ColumnID: 1, IndexID: 4}, TRANSIENT_ABSENT], PUBLIC] -> TRANSIENT_ABSENT
+  ops:
+    *scop.MarkDescriptorAsDropped
+      DescriptorID: 106
+    *scop.RemoveBackReferenceInTypes
+      BackReferencedDescriptorID: 106
+      TypeIDs:
+      - 104
+      - 105
+    *scop.RemoveObjectParent
+      ObjectID: 106
+      ParentSchemaID: 101
+    *scop.MakeWriteOnlyColumnDeleteOnly
+      ColumnID: 2
+      TableID: 107
+    *scop.MakeWriteOnlyColumnDeleteOnly
+      ColumnID: 3
+      TableID: 107
+    *scop.MakeWriteOnlyColumnDeleteOnly
+      ColumnID: 4
+      TableID: 107
+    *scop.MakePublicPrimaryIndexWriteOnly
+      IndexID: 1
+      TableID: 107
+    *scop.SetIndexName
+      IndexID: 1
+      Name: crdb_internal_index_1_name_placeholder
+      TableID: 107
+    *scop.RemoveUniqueWithoutIndexConstraint
+      ConstraintID: 3
+      TableID: 107
+    *scop.RemoveCheckConstraint
+      ConstraintID: 2
+      TableID: 107
+    *scop.SetIndexName
+      IndexID: 3
+      Name: tbl_pkey
+      TableID: 107
+    *scop.MakeWriteOnlyIndexDeleteOnly
+      IndexID: 4
+      TableID: 107
+    *scop.DrainDescriptorName
+      Namespace:
+        DatabaseID: 100
+        DescriptorID: 106
+        Name: view
+        SchemaID: 101
+    *scop.MakeWriteOnlyIndexDeleteOnly
+      IndexID: 2
+      TableID: 107
+    *scop.SetIndexName
+      IndexID: 2
+      Name: crdb_internal_index_2_name_placeholder
+      TableID: 107
+    *scop.MakeValidatedPrimaryIndexPublic
+      IndexID: 3
+      TableID: 107
+    *scop.MakeDeleteOnlyColumnAbsent
+      ColumnID: 4294967295
+      TableID: 106
+    *scop.MakeDeleteOnlyColumnAbsent
+      ColumnID: 4294967294
+      TableID: 106
+    *scop.SetJobStateOnDescriptor
+      DescriptorID: 104
+    *scop.SetJobStateOnDescriptor
+      DescriptorID: 105
+    *scop.SetJobStateOnDescriptor
+      DescriptorID: 106
+    *scop.SetJobStateOnDescriptor
+      DescriptorID: 107
+    *scop.UpdateSchemaChangerJob
+      IsNonCancelable: true
+      JobID: 1
+PostCommitNonRevertiblePhase stage 2 of 4 with 12 MutationType ops
+  transitions:
+    [[Column:{DescID: 107, ColumnID: 3}, ABSENT], DELETE_ONLY] -> ABSENT
+    [[ColumnType:{DescID: 107, ColumnFamilyID: 0, ColumnID: 3}, ABSENT], PUBLIC] -> ABSENT
+    [[PrimaryIndex:{DescID: 107, IndexID: 1, ConstraintID: 1}, ABSENT], VALIDATED] -> DELETE_ONLY
+    [[SecondaryIndexPartial:{DescID: 107, IndexID: 2}, ABSENT], PUBLIC] -> ABSENT
+    [[SecondaryIndex:{DescID: 107, IndexID: 2, ConstraintID: 0}, ABSENT], DELETE_ONLY] -> ABSENT
+    [[TemporaryIndex:{DescID: 107, IndexID: 4, ConstraintID: 5, SourceIndexID: 1}, TRANSIENT_ABSENT], TRANSIENT_DELETE_ONLY] -> TRANSIENT_ABSENT
+  ops:
+    *scop.RemoveDroppedColumnType
+      ColumnID: 3
+      TableID: 107
+    *scop.UpdateTableBackReferencesInTypes
+      BackReferencedTableID: 107
+      TypeIDs:
+      - 104
+      - 105
+    *scop.RemoveDroppedIndexPartialPredicate
+      IndexID: 2
+      TableID: 107
+    *scop.MakeIndexAbsent
+      IndexID: 2
+      TableID: 107
+    *scop.MakeIndexAbsent
+      IndexID: 4
+      TableID: 107
+    *scop.MakeDeleteOnlyColumnAbsent
+      ColumnID: 3
+      TableID: 107
+    *scop.MakeWriteOnlyIndexDeleteOnly
+      IndexID: 1
+      TableID: 107
+    *scop.SetJobStateOnDescriptor
+      DescriptorID: 104
+    *scop.SetJobStateOnDescriptor
+      DescriptorID: 105
+    *scop.SetJobStateOnDescriptor
+      DescriptorID: 106
+    *scop.SetJobStateOnDescriptor
+      DescriptorID: 107
+    *scop.UpdateSchemaChangerJob
+      IsNonCancelable: true
+      JobID: 1
+PostCommitNonRevertiblePhase stage 3 of 4 with 25 MutationType ops
+  transitions:
+    [[Namespace:{DescID: 104, Name: greeting, ReferencedDescID: 100}, ABSENT], PUBLIC] -> ABSENT
+    [[Owner:{DescID: 104}, ABSENT], PUBLIC] -> ABSENT
+    [[UserPrivileges:{DescID: 104, Name: admin}, ABSENT], PUBLIC] -> ABSENT
+    [[UserPrivileges:{DescID: 104, Name: public}, ABSENT], PUBLIC] -> ABSENT
+    [[UserPrivileges:{DescID: 104, Name: root}, ABSENT], PUBLIC] -> ABSENT
+    [[EnumType:{DescID: 104}, ABSENT], PUBLIC] -> DROPPED
+    [[EnumTypeValue:{DescID: 104, Name: hello}, ABSENT], PUBLIC] -> ABSENT
+    [[EnumTypeValue:{DescID: 104, Name: hi}, ABSENT], PUBLIC] -> ABSENT
+    [[ObjectParent:{DescID: 104, ReferencedDescID: 101}, ABSENT], PUBLIC] -> ABSENT
+    [[Namespace:{DescID: 105, Name: _greeting, ReferencedDescID: 100}, ABSENT], PUBLIC] -> ABSENT
+    [[Owner:{DescID: 105}, ABSENT], PUBLIC] -> ABSENT
+    [[UserPrivileges:{DescID: 105, Name: admin}, ABSENT], PUBLIC] -> ABSENT
+    [[UserPrivileges:{DescID: 105, Name: public}, ABSENT], PUBLIC] -> ABSENT
+    [[UserPrivileges:{DescID: 105, Name: root}, ABSENT], PUBLIC] -> ABSENT
+    [[AliasType:{DescID: 105, ReferencedTypeIDs: [104 105]}, ABSENT], PUBLIC] -> DROPPED
+    [[ObjectParent:{DescID: 105, ReferencedDescID: 101}, ABSENT], PUBLIC] -> ABSENT
+    [[View:{DescID: 106}, ABSENT], DROPPED] -> ABSENT
+    [[Column:{DescID: 106, ColumnID: 1}, ABSENT], DELETE_ONLY] -> ABSENT
+    [[ColumnType:{DescID: 106, ReferencedTypeIDs: [104 105], ColumnFamilyID: 0, ColumnID: 1}, ABSENT], PUBLIC] -> ABSENT
+    [[Column:{DescID: 107, ColumnID: 2}, ABSENT], DELETE_ONLY] -> ABSENT
+    [[ColumnType:{DescID: 107, ReferencedTypeIDs: [104 105], ColumnFamilyID: 0, ColumnID: 2}, ABSENT], PUBLIC] -> ABSENT
+    [[Column:{DescID: 107, ColumnID: 4}, ABSENT], DELETE_ONLY] -> ABSENT
+    [[ColumnType:{DescID: 107, ReferencedTypeIDs: [104 105], ColumnFamilyID: 0, ColumnID: 4}, ABSENT], PUBLIC] -> ABSENT
+    [[PrimaryIndex:{DescID: 107, IndexID: 1, ConstraintID: 1}, ABSENT], DELETE_ONLY] -> ABSENT
+    [[IndexData:{DescID: 107, IndexID: 1}, ABSENT], PUBLIC] -> ABSENT
+    [[IndexData:{DescID: 107, IndexID: 2}, ABSENT], PUBLIC] -> ABSENT
+    [[IndexData:{DescID: 107, IndexID: 4}, TRANSIENT_ABSENT], PUBLIC] -> TRANSIENT_ABSENT
+  ops:
+    *scop.MarkDescriptorAsDropped
+      DescriptorID: 104
+    *scop.RemoveObjectParent
+      ObjectID: 104
+      ParentSchemaID: 101
+    *scop.MarkDescriptorAsDropped
+      DescriptorID: 105
+    *scop.RemoveObjectParent
+      ObjectID: 105
+      ParentSchemaID: 101
+    *scop.RemoveDroppedColumnType
+      ColumnID: 1
+      TableID: 106
+    *scop.UpdateTableBackReferencesInTypes
+      BackReferencedTableID: 106
+      TypeIDs:
+      - 104
+      - 105
+    *scop.RemoveDroppedColumnType
+      ColumnID: 2
+      TableID: 107
+    *scop.UpdateTableBackReferencesInTypes
+      BackReferencedTableID: 107
+      TypeIDs:
+      - 104
+      - 105
+    *scop.RemoveDroppedColumnType
+      ColumnID: 4
+      TableID: 107
+    *scop.UpdateTableBackReferencesInTypes
+      BackReferencedTableID: 107
+      TypeIDs:
+      - 104
+      - 105
+    *scop.MakeIndexAbsent
+      IndexID: 1
+      TableID: 107
+    *scop.CreateGCJobForIndex
+      IndexID: 1
+      StatementForDropJob:
+        Statement: DROP TYPE defaultdb.public.greeting CASCADE
+      TableID: 107
+    *scop.CreateGCJobForIndex
+      IndexID: 2
+      StatementForDropJob:
+        Statement: DROP TYPE defaultdb.public.greeting CASCADE
+      TableID: 107
+    *scop.CreateGCJobForIndex
+      IndexID: 4
+      StatementForDropJob:
+        Statement: DROP TYPE defaultdb.public.greeting CASCADE
+      TableID: 107
+    *scop.DrainDescriptorName
+      Namespace:
+        DatabaseID: 100
+        DescriptorID: 104
+        Name: greeting
+        SchemaID: 101
+    *scop.DrainDescriptorName
+      Namespace:
+        DatabaseID: 100
+        DescriptorID: 105
+        Name: _greeting
+        SchemaID: 101
+    *scop.MakeDeleteOnlyColumnAbsent
+      ColumnID: 1
+      TableID: 106
+    *scop.MakeDeleteOnlyColumnAbsent
+      ColumnID: 2
+      TableID: 107
+    *scop.MakeDeleteOnlyColumnAbsent
+      ColumnID: 4
+      TableID: 107
+    *scop.DeleteDescriptor
+      DescriptorID: 106
+    *scop.SetJobStateOnDescriptor
+      DescriptorID: 104
+    *scop.SetJobStateOnDescriptor
+      DescriptorID: 105
+    *scop.RemoveJobStateFromDescriptor
+      DescriptorID: 106
+      JobID: 1
+    *scop.SetJobStateOnDescriptor
+      DescriptorID: 107
+    *scop.UpdateSchemaChangerJob
+      DescriptorIDsToRemove:
+      - 106
+      IsNonCancelable: true
+      JobID: 1
+PostCommitNonRevertiblePhase stage 4 of 4 with 6 MutationType ops
+  transitions:
+    [[EnumType:{DescID: 104}, ABSENT], DROPPED] -> ABSENT
+    [[AliasType:{DescID: 105, ReferencedTypeIDs: [104 105]}, ABSENT], DROPPED] -> ABSENT
+  ops:
+    *scop.DeleteDescriptor
+      DescriptorID: 104
+    *scop.DeleteDescriptor
+      DescriptorID: 105
+    *scop.RemoveJobStateFromDescriptor
+      DescriptorID: 104
+      JobID: 1
+    *scop.RemoveJobStateFromDescriptor
+      DescriptorID: 105
+      JobID: 1
+    *scop.RemoveJobStateFromDescriptor
+      DescriptorID: 107
+      JobID: 1
+    *scop.UpdateSchemaChangerJob
+      DescriptorIDsToRemove:
+      - 104
+      - 105
+      - 107
+      IsNonCancelable: true
+      JobID: 1
+
+deps
+DROP TYPE greeting CASCADE
+----
+- from: [AliasType:{DescID: 105, ReferencedTypeIDs: [104 105]}, DROPPED]
+  to:   [AliasType:{DescID: 105, ReferencedTypeIDs: [104 105]}, ABSENT]
+  kind: PreviousStagePrecedence
+  rule: descriptor dropped in transaction before removal
+- from: [AliasType:{DescID: 105, ReferencedTypeIDs: [104 105]}, DROPPED]
+  to:   [ColumnType:{DescID: 106, ReferencedTypeIDs: [104 105], ColumnFamilyID: 0, ColumnID: 1}, ABSENT]
+  kind: SameStagePrecedence
+  rule: descriptor drop right before removing dependent with type ref
+- from: [AliasType:{DescID: 105, ReferencedTypeIDs: [104 105]}, DROPPED]
+  to:   [ColumnType:{DescID: 107, ReferencedTypeIDs: [104 105], ColumnFamilyID: 0, ColumnID: 2}, ABSENT]
+  kind: SameStagePrecedence
+  rule: descriptor drop right before removing dependent with type ref
+- from: [AliasType:{DescID: 105, ReferencedTypeIDs: [104 105]}, DROPPED]
+  to:   [ColumnType:{DescID: 107, ReferencedTypeIDs: [104 105], ColumnFamilyID: 0, ColumnID: 4}, ABSENT]
+  kind: SameStagePrecedence
+  rule: descriptor drop right before removing dependent with type ref
+- from: [AliasType:{DescID: 105, ReferencedTypeIDs: [104 105]}, DROPPED]
+  to:   [Namespace:{DescID: 105, Name: _greeting, ReferencedDescID: 100}, ABSENT]
+  kind: Precedence
+  rule: descriptor dropped before dependent element removal
+- from: [AliasType:{DescID: 105, ReferencedTypeIDs: [104 105]}, DROPPED]
+  to:   [ObjectParent:{DescID: 105, ReferencedDescID: 101}, ABSENT]
+  kind: SameStagePrecedence
+  rules: [descriptor dropped before dependent element removal; descriptor dropped right before removing back-reference in its parent descriptor]
+- from: [AliasType:{DescID: 105, ReferencedTypeIDs: [104 105]}, DROPPED]
+  to:   [Owner:{DescID: 105}, ABSENT]
+  kind: Precedence
+  rule: descriptor dropped before dependent element removal
+- from: [AliasType:{DescID: 105, ReferencedTypeIDs: [104 105]}, DROPPED]
+  to:   [UserPrivileges:{DescID: 105, Name: admin}, ABSENT]
+  kind: Precedence
+  rule: descriptor dropped before dependent element removal
+- from: [AliasType:{DescID: 105, ReferencedTypeIDs: [104 105]}, DROPPED]
+  to:   [UserPrivileges:{DescID: 105, Name: public}, ABSENT]
+  kind: Precedence
+  rule: descriptor dropped before dependent element removal
+- from: [AliasType:{DescID: 105, ReferencedTypeIDs: [104 105]}, DROPPED]
+  to:   [UserPrivileges:{DescID: 105, Name: root}, ABSENT]
+  kind: Precedence
+  rule: descriptor dropped before dependent element removal
+- from: [CheckConstraint:{DescID: 107, IndexID: 0, ConstraintID: 2}, PUBLIC]
+  to:   [CheckConstraint:{DescID: 107, IndexID: 0, ConstraintID: 2}, VALIDATED]
+  kind: PreviousStagePrecedence
+  rule: CheckConstraint transitions to ABSENT uphold 2-version invariant: PUBLIC->VALIDATED
+- from: [CheckConstraint:{DescID: 107, IndexID: 0, ConstraintID: 2}, VALIDATED]
+  to:   [CheckConstraint:{DescID: 107, IndexID: 0, ConstraintID: 2}, ABSENT]
+  kind: PreviousStagePrecedence
+  rule: CheckConstraint transitions to ABSENT uphold 2-version invariant: VALIDATED->ABSENT
+- from: [CheckConstraint:{DescID: 107, IndexID: 0, ConstraintID: 2}, VALIDATED]
+  to:   [ConstraintWithoutIndexName:{DescID: 107, Name: mycheck, ConstraintID: 2}, ABSENT]
+  kind: Precedence
+  rule: constraint no longer public before dependents
+- from: [Column:{DescID: 106, ColumnID: 1}, ABSENT]
+  to:   [View:{DescID: 106}, ABSENT]
+  kind: Precedence
+  rule: non-data dependents removed before descriptor
+- from: [Column:{DescID: 106, ColumnID: 1}, WRITE_ONLY]
+  to:   [ColumnName:{DescID: 106, Name: hi, ColumnID: 1}, ABSENT]
+  kind: Precedence
+  rule: column no longer public before dependents
+- from: [Column:{DescID: 106, ColumnID: 1}, WRITE_ONLY]
+  to:   [ColumnType:{DescID: 106, ReferencedTypeIDs: [104 105], ColumnFamilyID: 0, ColumnID: 1}, ABSENT]
+  kind: Precedence
+  rule: column no longer public before dependents
+- from: [Column:{DescID: 106, ColumnID: 4294967294}, ABSENT]
+  to:   [View:{DescID: 106}, ABSENT]
+  kind: Precedence
+  rule: non-data dependents removed before descriptor
+- from: [Column:{DescID: 106, ColumnID: 4294967294}, WRITE_ONLY]
+  to:   [ColumnName:{DescID: 106, Name: tableoid, ColumnID: 4294967294}, ABSENT]
+  kind: Precedence
+  rule: column no longer public before dependents
+- from: [Column:{DescID: 106, ColumnID: 4294967294}, WRITE_ONLY]
+  to:   [ColumnType:{DescID: 106, ColumnFamilyID: 0, ColumnID: 4294967294}, ABSENT]
+  kind: Precedence
+  rule: column no longer public before dependents
+- from: [Column:{DescID: 106, ColumnID: 4294967295}, ABSENT]
+  to:   [View:{DescID: 106}, ABSENT]
+  kind: Precedence
+  rule: non-data dependents removed before descriptor
+- from: [Column:{DescID: 106, ColumnID: 4294967295}, WRITE_ONLY]
+  to:   [ColumnName:{DescID: 106, Name: crdb_internal_mvcc_timestamp, ColumnID: 4294967295}, ABSENT]
+  kind: Precedence
+  rule: column no longer public before dependents
+- from: [Column:{DescID: 106, ColumnID: 4294967295}, WRITE_ONLY]
+  to:   [ColumnType:{DescID: 106, ColumnFamilyID: 0, ColumnID: 4294967295}, ABSENT]
+  kind: Precedence
+  rule: column no longer public before dependents
+- from: [Column:{DescID: 107, ColumnID: 2}, DELETE_ONLY]
+  to:   [Column:{DescID: 107, ColumnID: 2}, ABSENT]
+  kind: PreviousStagePrecedence
+  rule: Column transitions to ABSENT uphold 2-version invariant: DELETE_ONLY->ABSENT
+- from: [Column:{DescID: 107, ColumnID: 2}, PUBLIC]
+  to:   [Column:{DescID: 107, ColumnID: 2}, WRITE_ONLY]
+  kind: PreviousStagePrecedence
+  rule: Column transitions to ABSENT uphold 2-version invariant: PUBLIC->WRITE_ONLY
+- from: [Column:{DescID: 107, ColumnID: 2}, WRITE_ONLY]
+  to:   [Column:{DescID: 107, ColumnID: 2}, DELETE_ONLY]
+  kind: PreviousStagePrecedence
+  rule: Column transitions to ABSENT uphold 2-version invariant: WRITE_ONLY->DELETE_ONLY
+- from: [Column:{DescID: 107, ColumnID: 2}, WRITE_ONLY]
+  to:   [ColumnName:{DescID: 107, Name: gs, ColumnID: 2}, ABSENT]
+  kind: Precedence
+  rule: column no longer public before dependents
+- from: [Column:{DescID: 107, ColumnID: 2}, WRITE_ONLY]
+  to:   [ColumnType:{DescID: 107, ReferencedTypeIDs: [104 105], ColumnFamilyID: 0, ColumnID: 2}, ABSENT]
+  kind: Precedence
+  rule: column no longer public before dependents
+- from: [Column:{DescID: 107, ColumnID: 2}, WRITE_ONLY]
+  to:   [IndexColumn:{DescID: 107, ColumnID: 2, IndexID: 1}, ABSENT]
+  kind: Precedence
+  rule: column no longer public before dependents
+- from: [Column:{DescID: 107, ColumnID: 3}, DELETE_ONLY]
+  to:   [Column:{DescID: 107, ColumnID: 3}, ABSENT]
+  kind: PreviousStagePrecedence
+  rule: Column transitions to ABSENT uphold 2-version invariant: DELETE_ONLY->ABSENT
+- from: [Column:{DescID: 107, ColumnID: 3}, PUBLIC]
+  to:   [Column:{DescID: 107, ColumnID: 3}, WRITE_ONLY]
+  kind: PreviousStagePrecedence
+  rule: Column transitions to ABSENT uphold 2-version invariant: PUBLIC->WRITE_ONLY
+- from: [Column:{DescID: 107, ColumnID: 3}, WRITE_ONLY]
+  to:   [Column:{DescID: 107, ColumnID: 3}, DELETE_ONLY]
+  kind: PreviousStagePrecedence
+  rule: Column transitions to ABSENT uphold 2-version invariant: WRITE_ONLY->DELETE_ONLY
+- from: [Column:{DescID: 107, ColumnID: 3}, WRITE_ONLY]
+  to:   [ColumnName:{DescID: 107, Name: gv, ColumnID: 3}, ABSENT]
+  kind: Precedence
+  rule: column no longer public before dependents
+- from: [Column:{DescID: 107, ColumnID: 3}, WRITE_ONLY]
+  to:   [ColumnType:{DescID: 107, ColumnFamilyID: 0, ColumnID: 3}, ABSENT]
+  kind: Precedence
+  rule: column no longer public before dependents
+- from: [Column:{DescID: 107, ColumnID: 4}, DELETE_ONLY]
+  to:   [Column:{DescID: 107, ColumnID: 4}, ABSENT]
+  kind: PreviousStagePrecedence
+  rule: Column transitions to ABSENT uphold 2-version invariant: DELETE_ONLY->ABSENT
+- from: [Column:{DescID: 107, ColumnID: 4}, PUBLIC]
+  to:   [Column:{DescID: 107, ColumnID: 4}, WRITE_ONLY]
+  kind: PreviousStagePrecedence
+  rule: Column transitions to ABSENT uphold 2-version invariant: PUBLIC->WRITE_ONLY
+- from: [Column:{DescID: 107, ColumnID: 4}, WRITE_ONLY]
+  to:   [Column:{DescID: 107, ColumnID: 4}, DELETE_ONLY]
+  kind: PreviousStagePrecedence
+  rule: Column transitions to ABSENT uphold 2-version invariant: WRITE_ONLY->DELETE_ONLY
+- from: [Column:{DescID: 107, ColumnID: 4}, WRITE_ONLY]
+  to:   [ColumnName:{DescID: 107, Name: other, ColumnID: 4}, ABSENT]
+  kind: Precedence
+  rule: column no longer public before dependents
+- from: [Column:{DescID: 107, ColumnID: 4}, WRITE_ONLY]
+  to:   [ColumnType:{DescID: 107, ReferencedTypeIDs: [104 105], ColumnFamilyID: 0, ColumnID: 4}, ABSENT]
+  kind: Precedence
+  rule: column no longer public before dependents
+- from: [Column:{DescID: 107, ColumnID: 4}, WRITE_ONLY]
+  to:   [IndexColumn:{DescID: 107, ColumnID: 4, IndexID: 1}, ABSENT]
+  kind: Precedence
+  rule: column no longer public before dependents
+- from: [ColumnName:{DescID: 106, Name: crdb_internal_mvcc_timestamp, ColumnID: 4294967295}, ABSENT]
+  to:   [Column:{DescID: 106, ColumnID: 4294967295}, ABSENT]
+  kind: Precedence
+  rule: dependents removed before column
+- from: [ColumnName:{DescID: 106, Name: crdb_internal_mvcc_timestamp, ColumnID: 4294967295}, ABSENT]
+  to:   [View:{DescID: 106}, ABSENT]
+  kind: Precedence
+  rule: non-data dependents removed before descriptor
+- from: [ColumnName:{DescID: 106, Name: hi, ColumnID: 1}, ABSENT]
+  to:   [Column:{DescID: 106, ColumnID: 1}, ABSENT]
+  kind: Precedence
+  rule: dependents removed before column
+- from: [ColumnName:{DescID: 106, Name: hi, ColumnID: 1}, ABSENT]
+  to:   [View:{DescID: 106}, ABSENT]
+  kind: Precedence
+  rule: non-data dependents removed before descriptor
+- from: [ColumnName:{DescID: 106, Name: tableoid, ColumnID: 4294967294}, ABSENT]
+  to:   [Column:{DescID: 106, ColumnID: 4294967294}, ABSENT]
+  kind: Precedence
+  rule: dependents removed before column
+- from: [ColumnName:{DescID: 106, Name: tableoid, ColumnID: 4294967294}, ABSENT]
+  to:   [View:{DescID: 106}, ABSENT]
+  kind: Precedence
+  rule: non-data dependents removed before descriptor
+- from: [ColumnName:{DescID: 107, Name: gs, ColumnID: 2}, ABSENT]
+  to:   [Column:{DescID: 107, ColumnID: 2}, ABSENT]
+  kind: Precedence
+  rule: dependents removed before column
+- from: [ColumnName:{DescID: 107, Name: gv, ColumnID: 3}, ABSENT]
+  to:   [Column:{DescID: 107, ColumnID: 3}, ABSENT]
+  kind: Precedence
+  rule: dependents removed before column
+- from: [ColumnName:{DescID: 107, Name: other, ColumnID: 4}, ABSENT]
+  to:   [Column:{DescID: 107, ColumnID: 4}, ABSENT]
+  kind: Precedence
+  rule: dependents removed before column
+- from: [ColumnType:{DescID: 106, ColumnFamilyID: 0, ColumnID: 4294967294}, ABSENT]
+  to:   [Column:{DescID: 106, ColumnID: 4294967294}, ABSENT]
+  kind: Precedence
+  rule: dependents removed before column
+- from: [ColumnType:{DescID: 106, ColumnFamilyID: 0, ColumnID: 4294967294}, ABSENT]
+  to:   [View:{DescID: 106}, ABSENT]
+  kind: Precedence
+  rule: non-data dependents removed before descriptor
+- from: [ColumnType:{DescID: 106, ColumnFamilyID: 0, ColumnID: 4294967295}, ABSENT]
+  to:   [Column:{DescID: 106, ColumnID: 4294967295}, ABSENT]
+  kind: Precedence
+  rule: dependents removed before column
+- from: [ColumnType:{DescID: 106, ColumnFamilyID: 0, ColumnID: 4294967295}, ABSENT]
+  to:   [View:{DescID: 106}, ABSENT]
+  kind: Precedence
+  rule: non-data dependents removed before descriptor
+- from: [ColumnType:{DescID: 106, ReferencedTypeIDs: [104 105], ColumnFamilyID: 0, ColumnID: 1}, ABSENT]
+  to:   [Column:{DescID: 106, ColumnID: 1}, ABSENT]
+  kind: Precedence
+  rule: dependents removed before column
+- from: [ColumnType:{DescID: 106, ReferencedTypeIDs: [104 105], ColumnFamilyID: 0, ColumnID: 1}, ABSENT]
+  to:   [View:{DescID: 106}, ABSENT]
+  kind: Precedence
+  rule: non-data dependents removed before descriptor
+- from: [ColumnType:{DescID: 107, ColumnFamilyID: 0, ColumnID: 3}, ABSENT]
+  to:   [Column:{DescID: 107, ColumnID: 3}, ABSENT]
+  kind: SameStagePrecedence
+  rules: [dependents removed before column; column type removed right before column when not dropping relation]
+- from: [ColumnType:{DescID: 107, ReferencedTypeIDs: [104 105], ColumnFamilyID: 0, ColumnID: 2}, ABSENT]
+  to:   [Column:{DescID: 107, ColumnID: 2}, ABSENT]
+  kind: SameStagePrecedence
+  rules: [dependents removed before column; column type removed right before column when not dropping relation]
+- from: [ColumnType:{DescID: 107, ReferencedTypeIDs: [104 105], ColumnFamilyID: 0, ColumnID: 4}, ABSENT]
+  to:   [Column:{DescID: 107, ColumnID: 4}, ABSENT]
+  kind: SameStagePrecedence
+  rules: [dependents removed before column; column type removed right before column when not dropping relation]
+- from: [ConstraintWithoutIndexName:{DescID: 107, Name: mycheck, ConstraintID: 2}, ABSENT]
+  to:   [CheckConstraint:{DescID: 107, IndexID: 0, ConstraintID: 2}, ABSENT]
+  kind: Precedence
+  rule: dependents removed before constraint
+- from: [ConstraintWithoutIndexName:{DescID: 107, Name: myuwi, ConstraintID: 3}, ABSENT]
+  to:   [UniqueWithoutIndexConstraint:{DescID: 107, ConstraintID: 3}, ABSENT]
+  kind: Precedence
+  rule: dependents removed before constraint
+- from: [EnumType:{DescID: 104}, DROPPED]
+  to:   [ColumnType:{DescID: 106, ReferencedTypeIDs: [104 105], ColumnFamilyID: 0, ColumnID: 1}, ABSENT]
+  kind: SameStagePrecedence
+  rule: descriptor drop right before removing dependent with type ref
+- from: [EnumType:{DescID: 104}, DROPPED]
+  to:   [ColumnType:{DescID: 107, ReferencedTypeIDs: [104 105], ColumnFamilyID: 0, ColumnID: 2}, ABSENT]
+  kind: SameStagePrecedence
+  rule: descriptor drop right before removing dependent with type ref
+- from: [EnumType:{DescID: 104}, DROPPED]
+  to:   [ColumnType:{DescID: 107, ReferencedTypeIDs: [104 105], ColumnFamilyID: 0, ColumnID: 4}, ABSENT]
+  kind: SameStagePrecedence
+  rule: descriptor drop right before removing dependent with type ref
+- from: [EnumType:{DescID: 104}, DROPPED]
+  to:   [EnumType:{DescID: 104}, ABSENT]
+  kind: PreviousStagePrecedence
+  rule: descriptor dropped in transaction before removal
+- from: [EnumType:{DescID: 104}, DROPPED]
+  to:   [EnumTypeValue:{DescID: 104, Name: hello}, ABSENT]
+  kind: Precedence
+  rule: descriptor dropped before dependent element removal
+- from: [EnumType:{DescID: 104}, DROPPED]
+  to:   [EnumTypeValue:{DescID: 104, Name: hi}, ABSENT]
+  kind: Precedence
+  rule: descriptor dropped before dependent element removal
+- from: [EnumType:{DescID: 104}, DROPPED]
+  to:   [Namespace:{DescID: 104, Name: greeting, ReferencedDescID: 100}, ABSENT]
+  kind: Precedence
+  rule: descriptor dropped before dependent element removal
+- from: [EnumType:{DescID: 104}, DROPPED]
+  to:   [ObjectParent:{DescID: 104, ReferencedDescID: 101}, ABSENT]
+  kind: SameStagePrecedence
+  rules: [descriptor dropped before dependent element removal; descriptor dropped right before removing back-reference in its parent descriptor]
+- from: [EnumType:{DescID: 104}, DROPPED]
+  to:   [Owner:{DescID: 104}, ABSENT]
+  kind: Precedence
+  rule: descriptor dropped before dependent element removal
+- from: [EnumType:{DescID: 104}, DROPPED]
+  to:   [UserPrivileges:{DescID: 104, Name: admin}, ABSENT]
+  kind: Precedence
+  rule: descriptor dropped before dependent element removal
+- from: [EnumType:{DescID: 104}, DROPPED]
+  to:   [UserPrivileges:{DescID: 104, Name: public}, ABSENT]
+  kind: Precedence
+  rule: descriptor dropped before dependent element removal
+- from: [EnumType:{DescID: 104}, DROPPED]
+  to:   [UserPrivileges:{DescID: 104, Name: root}, ABSENT]
+  kind: Precedence
+  rule: descriptor dropped before dependent element removal
+- from: [EnumTypeValue:{DescID: 104, Name: hello}, ABSENT]
+  to:   [EnumType:{DescID: 104}, ABSENT]
+  kind: Precedence
+  rule: non-data dependents removed before descriptor
+- from: [EnumTypeValue:{DescID: 104, Name: hi}, ABSENT]
+  to:   [EnumType:{DescID: 104}, ABSENT]
+  kind: Precedence
+  rule: non-data dependents removed before descriptor
+- from: [IndexColumn:{DescID: 107, ColumnID: 1, IndexID: 1}, ABSENT]
+  to:   [PrimaryIndex:{DescID: 107, IndexID: 1, ConstraintID: 1}, ABSENT]
+  kind: Precedence
+  rule: dependents removed before index
+- from: [IndexColumn:{DescID: 107, ColumnID: 1, IndexID: 2}, ABSENT]
+  to:   [SecondaryIndex:{DescID: 107, IndexID: 2, ConstraintID: 0}, ABSENT]
+  kind: Precedence
+  rule: dependents removed before index
+- from: [IndexColumn:{DescID: 107, ColumnID: 1, IndexID: 3}, PUBLIC]
+  to:   [PrimaryIndex:{DescID: 107, IndexID: 3, ConstraintID: 4, TemporaryIndexID: 4, SourceIndexID: 1}, BACKFILLED]
+  kind: Precedence
+  rule: index-column added to index before index is backfilled
+- from: [IndexColumn:{DescID: 107, ColumnID: 1, IndexID: 3}, PUBLIC]
+  to:   [PrimaryIndex:{DescID: 107, IndexID: 3, ConstraintID: 4, TemporaryIndexID: 4, SourceIndexID: 1}, PUBLIC]
+  kind: Precedence
+  rule: index dependents exist before index becomes public
+- from: [IndexColumn:{DescID: 107, ColumnID: 1, IndexID: 4}, PUBLIC]
+  to:   [TemporaryIndex:{DescID: 107, IndexID: 4, ConstraintID: 5, SourceIndexID: 1}, WRITE_ONLY]
+  kind: Precedence
+  rule: index-column added to index before temp index receives writes
+- from: [IndexColumn:{DescID: 107, ColumnID: 1, IndexID: 4}, TRANSIENT_ABSENT]
+  to:   [TemporaryIndex:{DescID: 107, IndexID: 4, ConstraintID: 5, SourceIndexID: 1}, TRANSIENT_ABSENT]
+  kind: Precedence
+  rule: dependents removed before index
+- from: [IndexColumn:{DescID: 107, ColumnID: 2, IndexID: 1}, ABSENT]
+  to:   [Column:{DescID: 107, ColumnID: 2}, ABSENT]
+  kind: Precedence
+  rule: dependents removed before column
+- from: [IndexColumn:{DescID: 107, ColumnID: 2, IndexID: 1}, ABSENT]
+  to:   [PrimaryIndex:{DescID: 107, IndexID: 1, ConstraintID: 1}, ABSENT]
+  kind: Precedence
+  rule: dependents removed before index
+- from: [IndexColumn:{DescID: 107, ColumnID: 4, IndexID: 1}, ABSENT]
+  to:   [Column:{DescID: 107, ColumnID: 4}, ABSENT]
+  kind: Precedence
+  rule: dependents removed before column
+- from: [IndexColumn:{DescID: 107, ColumnID: 4, IndexID: 1}, ABSENT]
+  to:   [PrimaryIndex:{DescID: 107, IndexID: 1, ConstraintID: 1}, ABSENT]
+  kind: Precedence
+  rule: dependents removed before index
+- from: [IndexColumn:{DescID: 107, ColumnID: 5, IndexID: 1}, ABSENT]
+  to:   [PrimaryIndex:{DescID: 107, IndexID: 1, ConstraintID: 1}, ABSENT]
+  kind: Precedence
+  rule: dependents removed before index
+- from: [IndexColumn:{DescID: 107, ColumnID: 5, IndexID: 2}, ABSENT]
+  to:   [SecondaryIndex:{DescID: 107, IndexID: 2, ConstraintID: 0}, ABSENT]
+  kind: Precedence
+  rule: dependents removed before index
+- from: [IndexColumn:{DescID: 107, ColumnID: 5, IndexID: 3}, PUBLIC]
+  to:   [PrimaryIndex:{DescID: 107, IndexID: 3, ConstraintID: 4, TemporaryIndexID: 4, SourceIndexID: 1}, BACKFILLED]
+  kind: Precedence
+  rule: index-column added to index before index is backfilled
+- from: [IndexColumn:{DescID: 107, ColumnID: 5, IndexID: 3}, PUBLIC]
+  to:   [PrimaryIndex:{DescID: 107, IndexID: 3, ConstraintID: 4, TemporaryIndexID: 4, SourceIndexID: 1}, PUBLIC]
+  kind: Precedence
+  rule: index dependents exist before index becomes public
+- from: [IndexData:{DescID: 107, IndexID: 1}, DROPPED]
+  to:   [IndexData:{DescID: 107, IndexID: 2}, DROPPED]
+  kind: SameStagePrecedence
+  rule: schedule all GC jobs for a descriptor in the same stage
+- from: [IndexData:{DescID: 107, IndexID: 1}, DROPPED]
+  to:   [IndexData:{DescID: 107, IndexID: 4}, TRANSIENT_DROPPED]
+  kind: SameStagePrecedence
+  rule: schedule all GC jobs for a descriptor in the same stage
+- from: [IndexData:{DescID: 107, IndexID: 2}, DROPPED]
+  to:   [IndexData:{DescID: 107, IndexID: 4}, TRANSIENT_DROPPED]
+  kind: SameStagePrecedence
+  rule: schedule all GC jobs for a descriptor in the same stage
+- from: [IndexName:{DescID: 107, Name: partial, IndexID: 2}, ABSENT]
+  to:   [SecondaryIndex:{DescID: 107, IndexID: 2, ConstraintID: 0}, ABSENT]
+  kind: Precedence
+  rule: dependents removed before index
+- from: [IndexName:{DescID: 107, Name: tbl_pkey, IndexID: 1}, ABSENT]
+  to:   [PrimaryIndex:{DescID: 107, IndexID: 1, ConstraintID: 1}, ABSENT]
+  kind: Precedence
+  rule: dependents removed before index
+- from: [IndexName:{DescID: 107, Name: tbl_pkey, IndexID: 3}, PUBLIC]
+  to:   [PrimaryIndex:{DescID: 107, IndexID: 3, ConstraintID: 4, TemporaryIndexID: 4, SourceIndexID: 1}, PUBLIC]
+  kind: SameStagePrecedence
+  rules: [index dependents exist before index becomes public; primary index named right before index becomes public]
+- from: [Namespace:{DescID: 104, Name: greeting, ReferencedDescID: 100}, ABSENT]
+  to:   [EnumType:{DescID: 104}, ABSENT]
+  kind: Precedence
+  rule: non-data dependents removed before descriptor
+- from: [Namespace:{DescID: 105, Name: _greeting, ReferencedDescID: 100}, ABSENT]
+  to:   [AliasType:{DescID: 105, ReferencedTypeIDs: [104 105]}, ABSENT]
+  kind: Precedence
+  rule: non-data dependents removed before descriptor
+- from: [Namespace:{DescID: 106, Name: view, ReferencedDescID: 100}, ABSENT]
+  to:   [View:{DescID: 106}, ABSENT]
+  kind: Precedence
+  rule: non-data dependents removed before descriptor
+- from: [ObjectParent:{DescID: 104, ReferencedDescID: 101}, ABSENT]
+  to:   [EnumType:{DescID: 104}, ABSENT]
+  kind: Precedence
+  rule: non-data dependents removed before descriptor
+- from: [ObjectParent:{DescID: 105, ReferencedDescID: 101}, ABSENT]
+  to:   [AliasType:{DescID: 105, ReferencedTypeIDs: [104 105]}, ABSENT]
+  kind: Precedence
+  rule: non-data dependents removed before descriptor
+- from: [ObjectParent:{DescID: 106, ReferencedDescID: 101}, ABSENT]
+  to:   [View:{DescID: 106}, ABSENT]
+  kind: Precedence
+  rule: non-data dependents removed before descriptor
+- from: [Owner:{DescID: 104}, ABSENT]
+  to:   [EnumType:{DescID: 104}, ABSENT]
+  kind: Precedence
+  rule: non-data dependents removed before descriptor
+- from: [Owner:{DescID: 105}, ABSENT]
+  to:   [AliasType:{DescID: 105, ReferencedTypeIDs: [104 105]}, ABSENT]
+  kind: Precedence
+  rule: non-data dependents removed before descriptor
+- from: [Owner:{DescID: 106}, ABSENT]
+  to:   [View:{DescID: 106}, ABSENT]
+  kind: Precedence
+  rule: non-data dependents removed before descriptor
+- from: [PrimaryIndex:{DescID: 107, IndexID: 1, ConstraintID: 1}, ABSENT]
+  to:   [Column:{DescID: 107, ColumnID: 2}, ABSENT]
+  kind: Precedence
+  rule: indexes containing column reach absent before column
+- from: [PrimaryIndex:{DescID: 107, IndexID: 1, ConstraintID: 1}, ABSENT]
+  to:   [Column:{DescID: 107, ColumnID: 4}, ABSENT]
+  kind: Precedence
+  rule: indexes containing column reach absent before column
+- from: [PrimaryIndex:{DescID: 107, IndexID: 1, ConstraintID: 1}, ABSENT]
+  to:   [IndexData:{DescID: 107, IndexID: 1}, DROPPED]
+  kind: Precedence
+  rule: index removed before garbage collection
+- from: [PrimaryIndex:{DescID: 107, IndexID: 1, ConstraintID: 1}, DELETE_ONLY]
+  to:   [PrimaryIndex:{DescID: 107, IndexID: 1, ConstraintID: 1}, ABSENT]
+  kind: PreviousStagePrecedence
+  rule: PrimaryIndex transitions to ABSENT uphold 2-version invariant: DELETE_ONLY->ABSENT
+- from: [PrimaryIndex:{DescID: 107, IndexID: 1, ConstraintID: 1}, PUBLIC]
+  to:   [PrimaryIndex:{DescID: 107, IndexID: 1, ConstraintID: 1}, VALIDATED]
+  kind: PreviousStagePrecedence
+  rule: PrimaryIndex transitions to ABSENT uphold 2-version invariant: PUBLIC->VALIDATED
+- from: [PrimaryIndex:{DescID: 107, IndexID: 1, ConstraintID: 1}, VALIDATED]
+  to:   [IndexColumn:{DescID: 107, ColumnID: 1, IndexID: 1}, ABSENT]
+  kind: Precedence
+  rule: index no longer public before dependents
+- from: [PrimaryIndex:{DescID: 107, IndexID: 1, ConstraintID: 1}, VALIDATED]
+  to:   [IndexColumn:{DescID: 107, ColumnID: 2, IndexID: 1}, ABSENT]
+  kind: Precedence
+  rule: index no longer public before dependents
+- from: [PrimaryIndex:{DescID: 107, IndexID: 1, ConstraintID: 1}, VALIDATED]
+  to:   [IndexColumn:{DescID: 107, ColumnID: 4, IndexID: 1}, ABSENT]
+  kind: Precedence
+  rule: index no longer public before dependents
+- from: [PrimaryIndex:{DescID: 107, IndexID: 1, ConstraintID: 1}, VALIDATED]
+  to:   [IndexColumn:{DescID: 107, ColumnID: 5, IndexID: 1}, ABSENT]
+  kind: Precedence
+  rule: index no longer public before dependents
+- from: [PrimaryIndex:{DescID: 107, IndexID: 1, ConstraintID: 1}, VALIDATED]
+  to:   [IndexName:{DescID: 107, Name: tbl_pkey, IndexID: 1}, ABSENT]
+  kind: Precedence
+  rule: index no longer public before dependents
+- from: [PrimaryIndex:{DescID: 107, IndexID: 1, ConstraintID: 1}, VALIDATED]
+  to:   [PrimaryIndex:{DescID: 107, IndexID: 1, ConstraintID: 1}, WRITE_ONLY]
+  kind: PreviousStagePrecedence
+  rule: PrimaryIndex transitions to ABSENT uphold 2-version invariant: VALIDATED->WRITE_ONLY
+- from: [PrimaryIndex:{DescID: 107, IndexID: 1, ConstraintID: 1}, VALIDATED]
+  to:   [PrimaryIndex:{DescID: 107, IndexID: 3, ConstraintID: 4, TemporaryIndexID: 4, SourceIndexID: 1}, PUBLIC]
+  kind: SameStagePrecedence
+  rule: primary index swap
+- from: [PrimaryIndex:{DescID: 107, IndexID: 3, ConstraintID: 4, TemporaryIndexID: 4, SourceIndexID: 1}, ABSENT]
+  to:   [PrimaryIndex:{DescID: 107, IndexID: 3, ConstraintID: 4, TemporaryIndexID: 4, SourceIndexID: 1}, BACKFILL_ONLY]
+  kind: PreviousStagePrecedence
+  rule: PrimaryIndex transitions to PUBLIC uphold 2-version invariant: ABSENT->BACKFILL_ONLY
+- from: [PrimaryIndex:{DescID: 107, IndexID: 3, ConstraintID: 4, TemporaryIndexID: 4, SourceIndexID: 1}, BACKFILLED]
+  to:   [PrimaryIndex:{DescID: 107, IndexID: 3, ConstraintID: 4, TemporaryIndexID: 4, SourceIndexID: 1}, DELETE_ONLY]
+  kind: PreviousStagePrecedence
+  rule: PrimaryIndex transitions to PUBLIC uphold 2-version invariant: BACKFILLED->DELETE_ONLY
+- from: [PrimaryIndex:{DescID: 107, IndexID: 3, ConstraintID: 4, TemporaryIndexID: 4, SourceIndexID: 1}, BACKFILL_ONLY]
+  to:   [IndexColumn:{DescID: 107, ColumnID: 1, IndexID: 3}, PUBLIC]
+  kind: Precedence
+  rule: index existence precedes index dependents
+- from: [PrimaryIndex:{DescID: 107, IndexID: 3, ConstraintID: 4, TemporaryIndexID: 4, SourceIndexID: 1}, BACKFILL_ONLY]
+  to:   [IndexColumn:{DescID: 107, ColumnID: 5, IndexID: 3}, PUBLIC]
+  kind: Precedence
+  rule: index existence precedes index dependents
+- from: [PrimaryIndex:{DescID: 107, IndexID: 3, ConstraintID: 4, TemporaryIndexID: 4, SourceIndexID: 1}, BACKFILL_ONLY]
+  to:   [IndexData:{DescID: 107, IndexID: 3}, PUBLIC]
+  kind: SameStagePrecedence
+  rule: index data exists as soon as index accepts backfills
+- from: [PrimaryIndex:{DescID: 107, IndexID: 3, ConstraintID: 4, TemporaryIndexID: 4, SourceIndexID: 1}, BACKFILL_ONLY]
+  to:   [IndexName:{DescID: 107, Name: tbl_pkey, IndexID: 3}, PUBLIC]
+  kind: Precedence
+  rule: index existence precedes index dependents
+- from: [PrimaryIndex:{DescID: 107, IndexID: 3, ConstraintID: 4, TemporaryIndexID: 4, SourceIndexID: 1}, BACKFILL_ONLY]
+  to:   [PrimaryIndex:{DescID: 107, IndexID: 3, ConstraintID: 4, TemporaryIndexID: 4, SourceIndexID: 1}, BACKFILLED]
+  kind: PreviousStagePrecedence
+  rule: PrimaryIndex transitions to PUBLIC uphold 2-version invariant: BACKFILL_ONLY->BACKFILLED
+- from: [PrimaryIndex:{DescID: 107, IndexID: 3, ConstraintID: 4, TemporaryIndexID: 4, SourceIndexID: 1}, DELETE_ONLY]
+  to:   [PrimaryIndex:{DescID: 107, IndexID: 3, ConstraintID: 4, TemporaryIndexID: 4, SourceIndexID: 1}, MERGE_ONLY]
+  kind: PreviousStagePrecedence
+  rule: PrimaryIndex transitions to PUBLIC uphold 2-version invariant: DELETE_ONLY->MERGE_ONLY
+- from: [PrimaryIndex:{DescID: 107, IndexID: 3, ConstraintID: 4, TemporaryIndexID: 4, SourceIndexID: 1}, MERGED]
+  to:   [PrimaryIndex:{DescID: 107, IndexID: 3, ConstraintID: 4, TemporaryIndexID: 4, SourceIndexID: 1}, WRITE_ONLY]
+  kind: PreviousStagePrecedence
+  rule: PrimaryIndex transitions to PUBLIC uphold 2-version invariant: MERGED->WRITE_ONLY
+- from: [PrimaryIndex:{DescID: 107, IndexID: 3, ConstraintID: 4, TemporaryIndexID: 4, SourceIndexID: 1}, MERGE_ONLY]
+  to:   [PrimaryIndex:{DescID: 107, IndexID: 3, ConstraintID: 4, TemporaryIndexID: 4, SourceIndexID: 1}, MERGED]
+  kind: PreviousStagePrecedence
+  rule: PrimaryIndex transitions to PUBLIC uphold 2-version invariant: MERGE_ONLY->MERGED
+- from: [PrimaryIndex:{DescID: 107, IndexID: 3, ConstraintID: 4, TemporaryIndexID: 4, SourceIndexID: 1}, VALIDATED]
+  to:   [PrimaryIndex:{DescID: 107, IndexID: 3, ConstraintID: 4, TemporaryIndexID: 4, SourceIndexID: 1}, PUBLIC]
+  kind: PreviousStagePrecedence
+  rule: PrimaryIndex transitions to PUBLIC uphold 2-version invariant: VALIDATED->PUBLIC
+- from: [PrimaryIndex:{DescID: 107, IndexID: 3, ConstraintID: 4, TemporaryIndexID: 4, SourceIndexID: 1}, WRITE_ONLY]
+  to:   [PrimaryIndex:{DescID: 107, IndexID: 3, ConstraintID: 4, TemporaryIndexID: 4, SourceIndexID: 1}, VALIDATED]
+  kind: PreviousStagePrecedence
+  rule: PrimaryIndex transitions to PUBLIC uphold 2-version invariant: WRITE_ONLY->VALIDATED
+- from: [SecondaryIndex:{DescID: 107, IndexID: 2, ConstraintID: 0}, ABSENT]
+  to:   [IndexData:{DescID: 107, IndexID: 2}, DROPPED]
+  kind: Precedence
+  rule: index removed before garbage collection
+- from: [SecondaryIndex:{DescID: 107, IndexID: 2, ConstraintID: 0}, DELETE_ONLY]
+  to:   [IndexName:{DescID: 107, Name: partial, IndexID: 2}, ABSENT]
+  kind: Precedence
+  rule: index no longer public before index name
+- from: [SecondaryIndex:{DescID: 107, IndexID: 2, ConstraintID: 0}, DELETE_ONLY]
+  to:   [SecondaryIndex:{DescID: 107, IndexID: 2, ConstraintID: 0}, ABSENT]
+  kind: PreviousStagePrecedence
+  rule: SecondaryIndex transitions to ABSENT uphold 2-version invariant: DELETE_ONLY->ABSENT
+- from: [SecondaryIndex:{DescID: 107, IndexID: 2, ConstraintID: 0}, PUBLIC]
+  to:   [SecondaryIndex:{DescID: 107, IndexID: 2, ConstraintID: 0}, VALIDATED]
+  kind: PreviousStagePrecedence
+  rule: SecondaryIndex transitions to ABSENT uphold 2-version invariant: PUBLIC->VALIDATED
+- from: [SecondaryIndex:{DescID: 107, IndexID: 2, ConstraintID: 0}, VALIDATED]
+  to:   [IndexColumn:{DescID: 107, ColumnID: 1, IndexID: 2}, ABSENT]
+  kind: Precedence
+  rule: index no longer public before dependents
+- from: [SecondaryIndex:{DescID: 107, IndexID: 2, ConstraintID: 0}, VALIDATED]
+  to:   [IndexColumn:{DescID: 107, ColumnID: 5, IndexID: 2}, ABSENT]
+  kind: Precedence
+  rule: index no longer public before dependents
+- from: [SecondaryIndex:{DescID: 107, IndexID: 2, ConstraintID: 0}, VALIDATED]
+  to:   [IndexName:{DescID: 107, Name: partial, IndexID: 2}, ABSENT]
+  kind: Precedence
+  rule: index no longer public before dependents
+- from: [SecondaryIndex:{DescID: 107, IndexID: 2, ConstraintID: 0}, VALIDATED]
+  to:   [SecondaryIndex:{DescID: 107, IndexID: 2, ConstraintID: 0}, WRITE_ONLY]
+  kind: PreviousStagePrecedence
+  rule: SecondaryIndex transitions to ABSENT uphold 2-version invariant: VALIDATED->WRITE_ONLY
+- from: [SecondaryIndex:{DescID: 107, IndexID: 2, ConstraintID: 0}, VALIDATED]
+  to:   [SecondaryIndexPartial:{DescID: 107, IndexID: 2}, ABSENT]
+  kind: Precedence
+  rule: index no longer public before dependents
+- from: [SecondaryIndexPartial:{DescID: 107, IndexID: 2}, ABSENT]
+  to:   [SecondaryIndex:{DescID: 107, IndexID: 2, ConstraintID: 0}, ABSENT]
+  kind: SameStagePrecedence
+  rules: [dependents removed before index; partial predicate removed right before secondary index when not dropping relation]
+- from: [TemporaryIndex:{DescID: 107, IndexID: 4, ConstraintID: 5, SourceIndexID: 1}, ABSENT]
+  to:   [TemporaryIndex:{DescID: 107, IndexID: 4, ConstraintID: 5, SourceIndexID: 1}, DELETE_ONLY]
+  kind: PreviousStagePrecedence
+  rule: TemporaryIndex transitions to TRANSIENT_ABSENT uphold 2-version invariant: ABSENT->DELETE_ONLY
+- from: [TemporaryIndex:{DescID: 107, IndexID: 4, ConstraintID: 5, SourceIndexID: 1}, DELETE_ONLY]
+  to:   [IndexColumn:{DescID: 107, ColumnID: 1, IndexID: 4}, PUBLIC]
+  kind: Precedence
+  rule: temp index existence precedes index dependents
+- from: [TemporaryIndex:{DescID: 107, IndexID: 4, ConstraintID: 5, SourceIndexID: 1}, DELETE_ONLY]
+  to:   [IndexColumn:{DescID: 107, ColumnID: 5, IndexID: 4}, PUBLIC]
+  kind: Precedence
+  rule: temp index existence precedes index dependents
+- from: [TemporaryIndex:{DescID: 107, IndexID: 4, ConstraintID: 5, SourceIndexID: 1}, DELETE_ONLY]
+  to:   [TemporaryIndex:{DescID: 107, IndexID: 4, ConstraintID: 5, SourceIndexID: 1}, WRITE_ONLY]
+  kind: PreviousStagePrecedence
+  rule: TemporaryIndex transitions to TRANSIENT_ABSENT uphold 2-version invariant: DELETE_ONLY->WRITE_ONLY
+- from: [TemporaryIndex:{DescID: 107, IndexID: 4, ConstraintID: 5, SourceIndexID: 1}, TRANSIENT_ABSENT]
+  to:   [IndexData:{DescID: 107, IndexID: 4}, TRANSIENT_DROPPED]
+  kind: Precedence
+  rule: index removed before garbage collection
+- from: [TemporaryIndex:{DescID: 107, IndexID: 4, ConstraintID: 5, SourceIndexID: 1}, TRANSIENT_DELETE_ONLY]
+  to:   [TemporaryIndex:{DescID: 107, IndexID: 4, ConstraintID: 5, SourceIndexID: 1}, TRANSIENT_ABSENT]
+  kind: PreviousStagePrecedence
+  rule: TemporaryIndex transitions to TRANSIENT_ABSENT uphold 2-version invariant: TRANSIENT_DELETE_ONLY->TRANSIENT_ABSENT
+- from: [TemporaryIndex:{DescID: 107, IndexID: 4, ConstraintID: 5, SourceIndexID: 1}, WRITE_ONLY]
+  to:   [IndexData:{DescID: 107, IndexID: 4}, PUBLIC]
+  kind: SameStagePrecedence
+  rule: temp index data exists as soon as temp index accepts writes
+- from: [TemporaryIndex:{DescID: 107, IndexID: 4, ConstraintID: 5, SourceIndexID: 1}, WRITE_ONLY]
+  to:   [PrimaryIndex:{DescID: 107, IndexID: 3, ConstraintID: 4, TemporaryIndexID: 4, SourceIndexID: 1}, BACKFILLED]
+  kind: Precedence
+  rule: temp index is WRITE_ONLY before backfill
+- from: [TemporaryIndex:{DescID: 107, IndexID: 4, ConstraintID: 5, SourceIndexID: 1}, WRITE_ONLY]
+  to:   [TemporaryIndex:{DescID: 107, IndexID: 4, ConstraintID: 5, SourceIndexID: 1}, TRANSIENT_DELETE_ONLY]
+  kind: PreviousStagePrecedence
+  rule: TemporaryIndex transitions to TRANSIENT_ABSENT uphold 2-version invariant: WRITE_ONLY->TRANSIENT_DELETE_ONLY
+- from: [UniqueWithoutIndexConstraint:{DescID: 107, ConstraintID: 3}, PUBLIC]
+  to:   [UniqueWithoutIndexConstraint:{DescID: 107, ConstraintID: 3}, VALIDATED]
+  kind: PreviousStagePrecedence
+  rule: UniqueWithoutIndexConstraint transitions to ABSENT uphold 2-version invariant: PUBLIC->VALIDATED
+- from: [UniqueWithoutIndexConstraint:{DescID: 107, ConstraintID: 3}, VALIDATED]
+  to:   [ConstraintWithoutIndexName:{DescID: 107, Name: myuwi, ConstraintID: 3}, ABSENT]
+  kind: Precedence
+  rule: constraint no longer public before dependents
+- from: [UniqueWithoutIndexConstraint:{DescID: 107, ConstraintID: 3}, VALIDATED]
+  to:   [UniqueWithoutIndexConstraint:{DescID: 107, ConstraintID: 3}, ABSENT]
+  kind: PreviousStagePrecedence
+  rule: UniqueWithoutIndexConstraint transitions to ABSENT uphold 2-version invariant: VALIDATED->ABSENT
+- from: [UserPrivileges:{DescID: 104, Name: admin}, ABSENT]
+  to:   [EnumType:{DescID: 104}, ABSENT]
+  kind: Precedence
+  rule: non-data dependents removed before descriptor
+- from: [UserPrivileges:{DescID: 104, Name: public}, ABSENT]
+  to:   [EnumType:{DescID: 104}, ABSENT]
+  kind: Precedence
+  rule: non-data dependents removed before descriptor
+- from: [UserPrivileges:{DescID: 104, Name: root}, ABSENT]
+  to:   [EnumType:{DescID: 104}, ABSENT]
+  kind: Precedence
+  rule: non-data dependents removed before descriptor
+- from: [UserPrivileges:{DescID: 105, Name: admin}, ABSENT]
+  to:   [AliasType:{DescID: 105, ReferencedTypeIDs: [104 105]}, ABSENT]
+  kind: Precedence
+  rule: non-data dependents removed before descriptor
+- from: [UserPrivileges:{DescID: 105, Name: public}, ABSENT]
+  to:   [AliasType:{DescID: 105, ReferencedTypeIDs: [104 105]}, ABSENT]
+  kind: Precedence
+  rule: non-data dependents removed before descriptor
+- from: [UserPrivileges:{DescID: 105, Name: root}, ABSENT]
+  to:   [AliasType:{DescID: 105, ReferencedTypeIDs: [104 105]}, ABSENT]
+  kind: Precedence
+  rule: non-data dependents removed before descriptor
+- from: [UserPrivileges:{DescID: 106, Name: admin}, ABSENT]
+  to:   [View:{DescID: 106}, ABSENT]
+  kind: Precedence
+  rule: non-data dependents removed before descriptor
+- from: [UserPrivileges:{DescID: 106, Name: root}, ABSENT]
+  to:   [View:{DescID: 106}, ABSENT]
+  kind: Precedence
+  rule: non-data dependents removed before descriptor
+- from: [View:{DescID: 106}, DROPPED]
+  to:   [Column:{DescID: 106, ColumnID: 1}, WRITE_ONLY]
+  kind: Precedence
+  rule: relation dropped before dependent column
+- from: [View:{DescID: 106}, DROPPED]
+  to:   [Column:{DescID: 106, ColumnID: 4294967294}, WRITE_ONLY]
+  kind: Precedence
+  rule: relation dropped before dependent column
+- from: [View:{DescID: 106}, DROPPED]
+  to:   [Column:{DescID: 106, ColumnID: 4294967295}, WRITE_ONLY]
+  kind: Precedence
+  rule: relation dropped before dependent column
+- from: [View:{DescID: 106}, DROPPED]
+  to:   [ColumnName:{DescID: 106, Name: crdb_internal_mvcc_timestamp, ColumnID: 4294967295}, ABSENT]
+  kind: Precedence
+  rule: descriptor dropped before dependent element removal
+- from: [View:{DescID: 106}, DROPPED]
+  to:   [ColumnName:{DescID: 106, Name: hi, ColumnID: 1}, ABSENT]
+  kind: Precedence
+  rule: descriptor dropped before dependent element removal
+- from: [View:{DescID: 106}, DROPPED]
+  to:   [ColumnName:{DescID: 106, Name: tableoid, ColumnID: 4294967294}, ABSENT]
+  kind: Precedence
+  rule: descriptor dropped before dependent element removal
+- from: [View:{DescID: 106}, DROPPED]
+  to:   [ColumnType:{DescID: 106, ColumnFamilyID: 0, ColumnID: 4294967294}, ABSENT]
+  kind: Precedence
+  rule: descriptor dropped before dependent element removal
+- from: [View:{DescID: 106}, DROPPED]
+  to:   [ColumnType:{DescID: 106, ColumnFamilyID: 0, ColumnID: 4294967295}, ABSENT]
+  kind: Precedence
+  rule: descriptor dropped before dependent element removal
+- from: [View:{DescID: 106}, DROPPED]
+  to:   [ColumnType:{DescID: 106, ReferencedTypeIDs: [104 105], ColumnFamilyID: 0, ColumnID: 1}, ABSENT]
+  kind: Precedence
+  rule: descriptor dropped before dependent element removal
+- from: [View:{DescID: 106}, DROPPED]
+  to:   [Namespace:{DescID: 106, Name: view, ReferencedDescID: 100}, ABSENT]
+  kind: Precedence
+  rule: descriptor dropped before dependent element removal
+- from: [View:{DescID: 106}, DROPPED]
+  to:   [ObjectParent:{DescID: 106, ReferencedDescID: 101}, ABSENT]
+  kind: SameStagePrecedence
+  rules: [descriptor dropped before dependent element removal; descriptor dropped right before removing back-reference in its parent descriptor]
+- from: [View:{DescID: 106}, DROPPED]
+  to:   [Owner:{DescID: 106}, ABSENT]
+  kind: Precedence
+  rule: descriptor dropped before dependent element removal
+- from: [View:{DescID: 106}, DROPPED]
+  to:   [UserPrivileges:{DescID: 106, Name: admin}, ABSENT]
+  kind: Precedence
+  rule: descriptor dropped before dependent element removal
+- from: [View:{DescID: 106}, DROPPED]
+  to:   [UserPrivileges:{DescID: 106, Name: root}, ABSENT]
+  kind: Precedence
+  rule: descriptor dropped before dependent element removal
+- from: [View:{DescID: 106}, DROPPED]
+  to:   [View:{DescID: 106}, ABSENT]
+  kind: PreviousStagePrecedence
+  rule: descriptor dropped in transaction before removal

--- a/pkg/sql/schemachanger/scplan/testdata/drop_view
+++ b/pkg/sql/schemachanger/scplan/testdata/drop_view
@@ -1,111 +1,142 @@
 setup
-CREATE TABLE defaultdb.t1 (id INT PRIMARY KEY, name varchar(256));
+CREATE TYPE defaultdb.golden_girl AS ENUM ('Sophia', 'Dorothy', 'Rose', 'Blanche');
+CREATE TABLE defaultdb.t1 (id INT PRIMARY KEY, name defaultdb.golden_girl);
 CREATE VIEW defaultdb.v1 AS (SELECT name FROM defaultdb.t1);
 ----
 
 ops
 DROP VIEW defaultdb.v1
 ----
-StatementPhase stage 1 of 1 with 4 MutationType ops
+StatementPhase stage 1 of 1 with 7 MutationType ops
   transitions:
-    [[Namespace:{DescID: 105, Name: v1, ReferencedDescID: 100}, ABSENT], PUBLIC] -> ABSENT
-    [[Owner:{DescID: 105}, ABSENT], PUBLIC] -> ABSENT
-    [[UserPrivileges:{DescID: 105, Name: admin}, ABSENT], PUBLIC] -> ABSENT
-    [[UserPrivileges:{DescID: 105, Name: root}, ABSENT], PUBLIC] -> ABSENT
-    [[View:{DescID: 105}, ABSENT], PUBLIC] -> DROPPED
-    [[ObjectParent:{DescID: 105, ReferencedDescID: 101}, ABSENT], PUBLIC] -> ABSENT
-    [[Column:{DescID: 105, ColumnID: 1}, ABSENT], PUBLIC] -> WRITE_ONLY
-    [[ColumnName:{DescID: 105, Name: name, ColumnID: 1}, ABSENT], PUBLIC] -> ABSENT
-    [[ColumnType:{DescID: 105, ColumnFamilyID: 0, ColumnID: 1}, ABSENT], PUBLIC] -> ABSENT
-    [[Column:{DescID: 105, ColumnID: 4294967295}, ABSENT], PUBLIC] -> WRITE_ONLY
-    [[ColumnName:{DescID: 105, Name: crdb_internal_mvcc_timestamp, ColumnID: 4294967295}, ABSENT], PUBLIC] -> ABSENT
-    [[ColumnType:{DescID: 105, ColumnFamilyID: 0, ColumnID: 4294967295}, ABSENT], PUBLIC] -> ABSENT
-    [[Column:{DescID: 105, ColumnID: 4294967294}, ABSENT], PUBLIC] -> WRITE_ONLY
-    [[ColumnName:{DescID: 105, Name: tableoid, ColumnID: 4294967294}, ABSENT], PUBLIC] -> ABSENT
-    [[ColumnType:{DescID: 105, ColumnFamilyID: 0, ColumnID: 4294967294}, ABSENT], PUBLIC] -> ABSENT
+    [[Namespace:{DescID: 107, Name: v1, ReferencedDescID: 100}, ABSENT], PUBLIC] -> ABSENT
+    [[Owner:{DescID: 107}, ABSENT], PUBLIC] -> ABSENT
+    [[UserPrivileges:{DescID: 107, Name: admin}, ABSENT], PUBLIC] -> ABSENT
+    [[UserPrivileges:{DescID: 107, Name: root}, ABSENT], PUBLIC] -> ABSENT
+    [[View:{DescID: 107}, ABSENT], PUBLIC] -> DROPPED
+    [[ObjectParent:{DescID: 107, ReferencedDescID: 101}, ABSENT], PUBLIC] -> ABSENT
+    [[Column:{DescID: 107, ColumnID: 1}, ABSENT], PUBLIC] -> WRITE_ONLY
+    [[ColumnName:{DescID: 107, Name: name, ColumnID: 1}, ABSENT], PUBLIC] -> ABSENT
+    [[ColumnType:{DescID: 107, ReferencedTypeIDs: [104 105], ColumnFamilyID: 0, ColumnID: 1}, ABSENT], PUBLIC] -> ABSENT
+    [[Column:{DescID: 107, ColumnID: 4294967295}, ABSENT], PUBLIC] -> WRITE_ONLY
+    [[ColumnName:{DescID: 107, Name: crdb_internal_mvcc_timestamp, ColumnID: 4294967295}, ABSENT], PUBLIC] -> ABSENT
+    [[ColumnType:{DescID: 107, ColumnFamilyID: 0, ColumnID: 4294967295}, ABSENT], PUBLIC] -> ABSENT
+    [[Column:{DescID: 107, ColumnID: 4294967294}, ABSENT], PUBLIC] -> WRITE_ONLY
+    [[ColumnName:{DescID: 107, Name: tableoid, ColumnID: 4294967294}, ABSENT], PUBLIC] -> ABSENT
+    [[ColumnType:{DescID: 107, ColumnFamilyID: 0, ColumnID: 4294967294}, ABSENT], PUBLIC] -> ABSENT
   ops:
     *scop.MarkDescriptorAsDropped
-      DescriptorID: 105
-    *scop.RemoveBackReferencesInRelations
-      BackReferencedID: 105
-      RelationIDs:
+      DescriptorID: 107
+    *scop.RemoveBackReferenceInTypes
+      BackReferencedDescriptorID: 107
+      TypeIDs:
       - 104
+    *scop.RemoveBackReferencesInRelations
+      BackReferencedID: 107
+      RelationIDs:
+      - 106
     *scop.RemoveObjectParent
-      ObjectID: 105
+      ObjectID: 107
       ParentSchemaID: 101
+    *scop.RemoveDroppedColumnType
+      ColumnID: 1
+      TableID: 107
+    *scop.UpdateTableBackReferencesInTypes
+      BackReferencedTableID: 107
+      TypeIDs:
+      - 104
+      - 105
     *scop.DrainDescriptorName
       Namespace:
         DatabaseID: 100
-        DescriptorID: 105
+        DescriptorID: 107
         Name: v1
         SchemaID: 101
 PreCommitPhase stage 1 of 2 with 1 MutationType op
   transitions:
-    [[Namespace:{DescID: 105, Name: v1, ReferencedDescID: 100}, ABSENT], ABSENT] -> PUBLIC
-    [[Owner:{DescID: 105}, ABSENT], ABSENT] -> PUBLIC
-    [[UserPrivileges:{DescID: 105, Name: admin}, ABSENT], ABSENT] -> PUBLIC
-    [[UserPrivileges:{DescID: 105, Name: root}, ABSENT], ABSENT] -> PUBLIC
-    [[View:{DescID: 105}, ABSENT], DROPPED] -> PUBLIC
-    [[ObjectParent:{DescID: 105, ReferencedDescID: 101}, ABSENT], ABSENT] -> PUBLIC
-    [[Column:{DescID: 105, ColumnID: 1}, ABSENT], WRITE_ONLY] -> PUBLIC
-    [[ColumnName:{DescID: 105, Name: name, ColumnID: 1}, ABSENT], ABSENT] -> PUBLIC
-    [[ColumnType:{DescID: 105, ColumnFamilyID: 0, ColumnID: 1}, ABSENT], ABSENT] -> PUBLIC
-    [[Column:{DescID: 105, ColumnID: 4294967295}, ABSENT], WRITE_ONLY] -> PUBLIC
-    [[ColumnName:{DescID: 105, Name: crdb_internal_mvcc_timestamp, ColumnID: 4294967295}, ABSENT], ABSENT] -> PUBLIC
-    [[ColumnType:{DescID: 105, ColumnFamilyID: 0, ColumnID: 4294967295}, ABSENT], ABSENT] -> PUBLIC
-    [[Column:{DescID: 105, ColumnID: 4294967294}, ABSENT], WRITE_ONLY] -> PUBLIC
-    [[ColumnName:{DescID: 105, Name: tableoid, ColumnID: 4294967294}, ABSENT], ABSENT] -> PUBLIC
-    [[ColumnType:{DescID: 105, ColumnFamilyID: 0, ColumnID: 4294967294}, ABSENT], ABSENT] -> PUBLIC
+    [[Namespace:{DescID: 107, Name: v1, ReferencedDescID: 100}, ABSENT], ABSENT] -> PUBLIC
+    [[Owner:{DescID: 107}, ABSENT], ABSENT] -> PUBLIC
+    [[UserPrivileges:{DescID: 107, Name: admin}, ABSENT], ABSENT] -> PUBLIC
+    [[UserPrivileges:{DescID: 107, Name: root}, ABSENT], ABSENT] -> PUBLIC
+    [[View:{DescID: 107}, ABSENT], DROPPED] -> PUBLIC
+    [[ObjectParent:{DescID: 107, ReferencedDescID: 101}, ABSENT], ABSENT] -> PUBLIC
+    [[Column:{DescID: 107, ColumnID: 1}, ABSENT], WRITE_ONLY] -> PUBLIC
+    [[ColumnName:{DescID: 107, Name: name, ColumnID: 1}, ABSENT], ABSENT] -> PUBLIC
+    [[ColumnType:{DescID: 107, ReferencedTypeIDs: [104 105], ColumnFamilyID: 0, ColumnID: 1}, ABSENT], ABSENT] -> PUBLIC
+    [[Column:{DescID: 107, ColumnID: 4294967295}, ABSENT], WRITE_ONLY] -> PUBLIC
+    [[ColumnName:{DescID: 107, Name: crdb_internal_mvcc_timestamp, ColumnID: 4294967295}, ABSENT], ABSENT] -> PUBLIC
+    [[ColumnType:{DescID: 107, ColumnFamilyID: 0, ColumnID: 4294967295}, ABSENT], ABSENT] -> PUBLIC
+    [[Column:{DescID: 107, ColumnID: 4294967294}, ABSENT], WRITE_ONLY] -> PUBLIC
+    [[ColumnName:{DescID: 107, Name: tableoid, ColumnID: 4294967294}, ABSENT], ABSENT] -> PUBLIC
+    [[ColumnType:{DescID: 107, ColumnFamilyID: 0, ColumnID: 4294967294}, ABSENT], ABSENT] -> PUBLIC
   ops:
     *scop.UndoAllInTxnImmediateMutationOpSideEffects
       {}
-PreCommitPhase stage 2 of 2 with 10 MutationType ops
+PreCommitPhase stage 2 of 2 with 15 MutationType ops
   transitions:
-    [[Namespace:{DescID: 105, Name: v1, ReferencedDescID: 100}, ABSENT], PUBLIC] -> ABSENT
-    [[Owner:{DescID: 105}, ABSENT], PUBLIC] -> ABSENT
-    [[UserPrivileges:{DescID: 105, Name: admin}, ABSENT], PUBLIC] -> ABSENT
-    [[UserPrivileges:{DescID: 105, Name: root}, ABSENT], PUBLIC] -> ABSENT
-    [[View:{DescID: 105}, ABSENT], PUBLIC] -> DROPPED
-    [[ObjectParent:{DescID: 105, ReferencedDescID: 101}, ABSENT], PUBLIC] -> ABSENT
-    [[Column:{DescID: 105, ColumnID: 1}, ABSENT], PUBLIC] -> ABSENT
-    [[ColumnName:{DescID: 105, Name: name, ColumnID: 1}, ABSENT], PUBLIC] -> ABSENT
-    [[ColumnType:{DescID: 105, ColumnFamilyID: 0, ColumnID: 1}, ABSENT], PUBLIC] -> ABSENT
-    [[Column:{DescID: 105, ColumnID: 4294967295}, ABSENT], PUBLIC] -> ABSENT
-    [[ColumnName:{DescID: 105, Name: crdb_internal_mvcc_timestamp, ColumnID: 4294967295}, ABSENT], PUBLIC] -> ABSENT
-    [[ColumnType:{DescID: 105, ColumnFamilyID: 0, ColumnID: 4294967295}, ABSENT], PUBLIC] -> ABSENT
-    [[Column:{DescID: 105, ColumnID: 4294967294}, ABSENT], PUBLIC] -> ABSENT
-    [[ColumnName:{DescID: 105, Name: tableoid, ColumnID: 4294967294}, ABSENT], PUBLIC] -> ABSENT
-    [[ColumnType:{DescID: 105, ColumnFamilyID: 0, ColumnID: 4294967294}, ABSENT], PUBLIC] -> ABSENT
+    [[Namespace:{DescID: 107, Name: v1, ReferencedDescID: 100}, ABSENT], PUBLIC] -> ABSENT
+    [[Owner:{DescID: 107}, ABSENT], PUBLIC] -> ABSENT
+    [[UserPrivileges:{DescID: 107, Name: admin}, ABSENT], PUBLIC] -> ABSENT
+    [[UserPrivileges:{DescID: 107, Name: root}, ABSENT], PUBLIC] -> ABSENT
+    [[View:{DescID: 107}, ABSENT], PUBLIC] -> DROPPED
+    [[ObjectParent:{DescID: 107, ReferencedDescID: 101}, ABSENT], PUBLIC] -> ABSENT
+    [[Column:{DescID: 107, ColumnID: 1}, ABSENT], PUBLIC] -> ABSENT
+    [[ColumnName:{DescID: 107, Name: name, ColumnID: 1}, ABSENT], PUBLIC] -> ABSENT
+    [[ColumnType:{DescID: 107, ReferencedTypeIDs: [104 105], ColumnFamilyID: 0, ColumnID: 1}, ABSENT], PUBLIC] -> ABSENT
+    [[Column:{DescID: 107, ColumnID: 4294967295}, ABSENT], PUBLIC] -> ABSENT
+    [[ColumnName:{DescID: 107, Name: crdb_internal_mvcc_timestamp, ColumnID: 4294967295}, ABSENT], PUBLIC] -> ABSENT
+    [[ColumnType:{DescID: 107, ColumnFamilyID: 0, ColumnID: 4294967295}, ABSENT], PUBLIC] -> ABSENT
+    [[Column:{DescID: 107, ColumnID: 4294967294}, ABSENT], PUBLIC] -> ABSENT
+    [[ColumnName:{DescID: 107, Name: tableoid, ColumnID: 4294967294}, ABSENT], PUBLIC] -> ABSENT
+    [[ColumnType:{DescID: 107, ColumnFamilyID: 0, ColumnID: 4294967294}, ABSENT], PUBLIC] -> ABSENT
   ops:
     *scop.MarkDescriptorAsDropped
-      DescriptorID: 105
-    *scop.RemoveBackReferencesInRelations
-      BackReferencedID: 105
-      RelationIDs:
+      DescriptorID: 107
+    *scop.RemoveBackReferenceInTypes
+      BackReferencedDescriptorID: 107
+      TypeIDs:
       - 104
+    *scop.RemoveBackReferencesInRelations
+      BackReferencedID: 107
+      RelationIDs:
+      - 106
     *scop.RemoveObjectParent
-      ObjectID: 105
+      ObjectID: 107
       ParentSchemaID: 101
+    *scop.RemoveDroppedColumnType
+      ColumnID: 1
+      TableID: 107
+    *scop.UpdateTableBackReferencesInTypes
+      BackReferencedTableID: 107
+      TypeIDs:
+      - 104
+      - 105
     *scop.DrainDescriptorName
       Namespace:
         DatabaseID: 100
-        DescriptorID: 105
+        DescriptorID: 107
         Name: v1
         SchemaID: 101
     *scop.MakeDeleteOnlyColumnAbsent
       ColumnID: 1
-      TableID: 105
+      TableID: 107
     *scop.MakeDeleteOnlyColumnAbsent
       ColumnID: 4294967295
-      TableID: 105
+      TableID: 107
     *scop.MakeDeleteOnlyColumnAbsent
       ColumnID: 4294967294
-      TableID: 105
+      TableID: 107
     *scop.SetJobStateOnDescriptor
       DescriptorID: 104
       Initialize: true
     *scop.SetJobStateOnDescriptor
       DescriptorID: 105
+      Initialize: true
+    *scop.SetJobStateOnDescriptor
+      DescriptorID: 106
+      Initialize: true
+    *scop.SetJobStateOnDescriptor
+      DescriptorID: 107
       Initialize: true
     *scop.CreateSchemaChangerJob
       Authorization:
@@ -113,6 +144,8 @@ PreCommitPhase stage 2 of 2 with 10 MutationType ops
       DescriptorIDs:
       - 104
       - 105
+      - 106
+      - 107
       JobID: 1
       NonCancelable: true
       RunningStatus: PostCommitNonRevertiblePhase stage 1 of 1 with 1 MutationType op pending
@@ -120,190 +153,198 @@ PreCommitPhase stage 2 of 2 with 10 MutationType ops
       - statement: DROP VIEW defaultdb.v1
         redactedstatement: DROP VIEW ‹defaultdb›.public.‹v1›
         statementtag: DROP VIEW
-PostCommitNonRevertiblePhase stage 1 of 1 with 4 MutationType ops
+PostCommitNonRevertiblePhase stage 1 of 1 with 6 MutationType ops
   transitions:
-    [[View:{DescID: 105}, ABSENT], DROPPED] -> ABSENT
+    [[View:{DescID: 107}, ABSENT], DROPPED] -> ABSENT
   ops:
     *scop.DeleteDescriptor
-      DescriptorID: 105
+      DescriptorID: 107
     *scop.RemoveJobStateFromDescriptor
       DescriptorID: 104
       JobID: 1
     *scop.RemoveJobStateFromDescriptor
       DescriptorID: 105
       JobID: 1
+    *scop.RemoveJobStateFromDescriptor
+      DescriptorID: 106
+      JobID: 1
+    *scop.RemoveJobStateFromDescriptor
+      DescriptorID: 107
+      JobID: 1
     *scop.UpdateSchemaChangerJob
       DescriptorIDsToRemove:
       - 104
       - 105
+      - 106
+      - 107
       IsNonCancelable: true
       JobID: 1
 
 deps
 DROP VIEW defaultdb.v1
 ----
-- from: [Column:{DescID: 105, ColumnID: 1}, ABSENT]
-  to:   [View:{DescID: 105}, ABSENT]
+- from: [Column:{DescID: 107, ColumnID: 1}, ABSENT]
+  to:   [View:{DescID: 107}, ABSENT]
   kind: Precedence
   rule: non-data dependents removed before descriptor
-- from: [Column:{DescID: 105, ColumnID: 1}, WRITE_ONLY]
-  to:   [ColumnName:{DescID: 105, Name: name, ColumnID: 1}, ABSENT]
+- from: [Column:{DescID: 107, ColumnID: 1}, WRITE_ONLY]
+  to:   [ColumnName:{DescID: 107, Name: name, ColumnID: 1}, ABSENT]
   kind: Precedence
   rule: column no longer public before dependents
-- from: [Column:{DescID: 105, ColumnID: 1}, WRITE_ONLY]
-  to:   [ColumnType:{DescID: 105, ColumnFamilyID: 0, ColumnID: 1}, ABSENT]
+- from: [Column:{DescID: 107, ColumnID: 1}, WRITE_ONLY]
+  to:   [ColumnType:{DescID: 107, ReferencedTypeIDs: [104 105], ColumnFamilyID: 0, ColumnID: 1}, ABSENT]
   kind: Precedence
   rule: column no longer public before dependents
-- from: [Column:{DescID: 105, ColumnID: 4294967294}, ABSENT]
-  to:   [View:{DescID: 105}, ABSENT]
+- from: [Column:{DescID: 107, ColumnID: 4294967294}, ABSENT]
+  to:   [View:{DescID: 107}, ABSENT]
   kind: Precedence
   rule: non-data dependents removed before descriptor
-- from: [Column:{DescID: 105, ColumnID: 4294967294}, WRITE_ONLY]
-  to:   [ColumnName:{DescID: 105, Name: tableoid, ColumnID: 4294967294}, ABSENT]
+- from: [Column:{DescID: 107, ColumnID: 4294967294}, WRITE_ONLY]
+  to:   [ColumnName:{DescID: 107, Name: tableoid, ColumnID: 4294967294}, ABSENT]
   kind: Precedence
   rule: column no longer public before dependents
-- from: [Column:{DescID: 105, ColumnID: 4294967294}, WRITE_ONLY]
-  to:   [ColumnType:{DescID: 105, ColumnFamilyID: 0, ColumnID: 4294967294}, ABSENT]
+- from: [Column:{DescID: 107, ColumnID: 4294967294}, WRITE_ONLY]
+  to:   [ColumnType:{DescID: 107, ColumnFamilyID: 0, ColumnID: 4294967294}, ABSENT]
   kind: Precedence
   rule: column no longer public before dependents
-- from: [Column:{DescID: 105, ColumnID: 4294967295}, ABSENT]
-  to:   [View:{DescID: 105}, ABSENT]
+- from: [Column:{DescID: 107, ColumnID: 4294967295}, ABSENT]
+  to:   [View:{DescID: 107}, ABSENT]
   kind: Precedence
   rule: non-data dependents removed before descriptor
-- from: [Column:{DescID: 105, ColumnID: 4294967295}, WRITE_ONLY]
-  to:   [ColumnName:{DescID: 105, Name: crdb_internal_mvcc_timestamp, ColumnID: 4294967295}, ABSENT]
+- from: [Column:{DescID: 107, ColumnID: 4294967295}, WRITE_ONLY]
+  to:   [ColumnName:{DescID: 107, Name: crdb_internal_mvcc_timestamp, ColumnID: 4294967295}, ABSENT]
   kind: Precedence
   rule: column no longer public before dependents
-- from: [Column:{DescID: 105, ColumnID: 4294967295}, WRITE_ONLY]
-  to:   [ColumnType:{DescID: 105, ColumnFamilyID: 0, ColumnID: 4294967295}, ABSENT]
+- from: [Column:{DescID: 107, ColumnID: 4294967295}, WRITE_ONLY]
+  to:   [ColumnType:{DescID: 107, ColumnFamilyID: 0, ColumnID: 4294967295}, ABSENT]
   kind: Precedence
   rule: column no longer public before dependents
-- from: [ColumnName:{DescID: 105, Name: crdb_internal_mvcc_timestamp, ColumnID: 4294967295}, ABSENT]
-  to:   [Column:{DescID: 105, ColumnID: 4294967295}, ABSENT]
+- from: [ColumnName:{DescID: 107, Name: crdb_internal_mvcc_timestamp, ColumnID: 4294967295}, ABSENT]
+  to:   [Column:{DescID: 107, ColumnID: 4294967295}, ABSENT]
   kind: Precedence
   rule: dependents removed before column
-- from: [ColumnName:{DescID: 105, Name: crdb_internal_mvcc_timestamp, ColumnID: 4294967295}, ABSENT]
-  to:   [View:{DescID: 105}, ABSENT]
+- from: [ColumnName:{DescID: 107, Name: crdb_internal_mvcc_timestamp, ColumnID: 4294967295}, ABSENT]
+  to:   [View:{DescID: 107}, ABSENT]
   kind: Precedence
   rule: non-data dependents removed before descriptor
-- from: [ColumnName:{DescID: 105, Name: name, ColumnID: 1}, ABSENT]
-  to:   [Column:{DescID: 105, ColumnID: 1}, ABSENT]
+- from: [ColumnName:{DescID: 107, Name: name, ColumnID: 1}, ABSENT]
+  to:   [Column:{DescID: 107, ColumnID: 1}, ABSENT]
   kind: Precedence
   rule: dependents removed before column
-- from: [ColumnName:{DescID: 105, Name: name, ColumnID: 1}, ABSENT]
-  to:   [View:{DescID: 105}, ABSENT]
+- from: [ColumnName:{DescID: 107, Name: name, ColumnID: 1}, ABSENT]
+  to:   [View:{DescID: 107}, ABSENT]
   kind: Precedence
   rule: non-data dependents removed before descriptor
-- from: [ColumnName:{DescID: 105, Name: tableoid, ColumnID: 4294967294}, ABSENT]
-  to:   [Column:{DescID: 105, ColumnID: 4294967294}, ABSENT]
+- from: [ColumnName:{DescID: 107, Name: tableoid, ColumnID: 4294967294}, ABSENT]
+  to:   [Column:{DescID: 107, ColumnID: 4294967294}, ABSENT]
   kind: Precedence
   rule: dependents removed before column
-- from: [ColumnName:{DescID: 105, Name: tableoid, ColumnID: 4294967294}, ABSENT]
-  to:   [View:{DescID: 105}, ABSENT]
+- from: [ColumnName:{DescID: 107, Name: tableoid, ColumnID: 4294967294}, ABSENT]
+  to:   [View:{DescID: 107}, ABSENT]
   kind: Precedence
   rule: non-data dependents removed before descriptor
-- from: [ColumnType:{DescID: 105, ColumnFamilyID: 0, ColumnID: 1}, ABSENT]
-  to:   [Column:{DescID: 105, ColumnID: 1}, ABSENT]
+- from: [ColumnType:{DescID: 107, ColumnFamilyID: 0, ColumnID: 4294967294}, ABSENT]
+  to:   [Column:{DescID: 107, ColumnID: 4294967294}, ABSENT]
   kind: Precedence
   rule: dependents removed before column
-- from: [ColumnType:{DescID: 105, ColumnFamilyID: 0, ColumnID: 1}, ABSENT]
-  to:   [View:{DescID: 105}, ABSENT]
+- from: [ColumnType:{DescID: 107, ColumnFamilyID: 0, ColumnID: 4294967294}, ABSENT]
+  to:   [View:{DescID: 107}, ABSENT]
   kind: Precedence
   rule: non-data dependents removed before descriptor
-- from: [ColumnType:{DescID: 105, ColumnFamilyID: 0, ColumnID: 4294967294}, ABSENT]
-  to:   [Column:{DescID: 105, ColumnID: 4294967294}, ABSENT]
+- from: [ColumnType:{DescID: 107, ColumnFamilyID: 0, ColumnID: 4294967295}, ABSENT]
+  to:   [Column:{DescID: 107, ColumnID: 4294967295}, ABSENT]
   kind: Precedence
   rule: dependents removed before column
-- from: [ColumnType:{DescID: 105, ColumnFamilyID: 0, ColumnID: 4294967294}, ABSENT]
-  to:   [View:{DescID: 105}, ABSENT]
+- from: [ColumnType:{DescID: 107, ColumnFamilyID: 0, ColumnID: 4294967295}, ABSENT]
+  to:   [View:{DescID: 107}, ABSENT]
   kind: Precedence
   rule: non-data dependents removed before descriptor
-- from: [ColumnType:{DescID: 105, ColumnFamilyID: 0, ColumnID: 4294967295}, ABSENT]
-  to:   [Column:{DescID: 105, ColumnID: 4294967295}, ABSENT]
+- from: [ColumnType:{DescID: 107, ReferencedTypeIDs: [104 105], ColumnFamilyID: 0, ColumnID: 1}, ABSENT]
+  to:   [Column:{DescID: 107, ColumnID: 1}, ABSENT]
   kind: Precedence
   rule: dependents removed before column
-- from: [ColumnType:{DescID: 105, ColumnFamilyID: 0, ColumnID: 4294967295}, ABSENT]
-  to:   [View:{DescID: 105}, ABSENT]
+- from: [ColumnType:{DescID: 107, ReferencedTypeIDs: [104 105], ColumnFamilyID: 0, ColumnID: 1}, ABSENT]
+  to:   [View:{DescID: 107}, ABSENT]
   kind: Precedence
   rule: non-data dependents removed before descriptor
-- from: [Namespace:{DescID: 105, Name: v1, ReferencedDescID: 100}, ABSENT]
-  to:   [View:{DescID: 105}, ABSENT]
+- from: [Namespace:{DescID: 107, Name: v1, ReferencedDescID: 100}, ABSENT]
+  to:   [View:{DescID: 107}, ABSENT]
   kind: Precedence
   rule: non-data dependents removed before descriptor
-- from: [ObjectParent:{DescID: 105, ReferencedDescID: 101}, ABSENT]
-  to:   [View:{DescID: 105}, ABSENT]
+- from: [ObjectParent:{DescID: 107, ReferencedDescID: 101}, ABSENT]
+  to:   [View:{DescID: 107}, ABSENT]
   kind: Precedence
   rule: non-data dependents removed before descriptor
-- from: [Owner:{DescID: 105}, ABSENT]
-  to:   [View:{DescID: 105}, ABSENT]
+- from: [Owner:{DescID: 107}, ABSENT]
+  to:   [View:{DescID: 107}, ABSENT]
   kind: Precedence
   rule: non-data dependents removed before descriptor
-- from: [UserPrivileges:{DescID: 105, Name: admin}, ABSENT]
-  to:   [View:{DescID: 105}, ABSENT]
+- from: [UserPrivileges:{DescID: 107, Name: admin}, ABSENT]
+  to:   [View:{DescID: 107}, ABSENT]
   kind: Precedence
   rule: non-data dependents removed before descriptor
-- from: [UserPrivileges:{DescID: 105, Name: root}, ABSENT]
-  to:   [View:{DescID: 105}, ABSENT]
+- from: [UserPrivileges:{DescID: 107, Name: root}, ABSENT]
+  to:   [View:{DescID: 107}, ABSENT]
   kind: Precedence
   rule: non-data dependents removed before descriptor
-- from: [View:{DescID: 105}, DROPPED]
-  to:   [Column:{DescID: 105, ColumnID: 1}, WRITE_ONLY]
+- from: [View:{DescID: 107}, DROPPED]
+  to:   [Column:{DescID: 107, ColumnID: 1}, WRITE_ONLY]
   kind: Precedence
   rule: relation dropped before dependent column
-- from: [View:{DescID: 105}, DROPPED]
-  to:   [Column:{DescID: 105, ColumnID: 4294967294}, WRITE_ONLY]
+- from: [View:{DescID: 107}, DROPPED]
+  to:   [Column:{DescID: 107, ColumnID: 4294967294}, WRITE_ONLY]
   kind: Precedence
   rule: relation dropped before dependent column
-- from: [View:{DescID: 105}, DROPPED]
-  to:   [Column:{DescID: 105, ColumnID: 4294967295}, WRITE_ONLY]
+- from: [View:{DescID: 107}, DROPPED]
+  to:   [Column:{DescID: 107, ColumnID: 4294967295}, WRITE_ONLY]
   kind: Precedence
   rule: relation dropped before dependent column
-- from: [View:{DescID: 105}, DROPPED]
-  to:   [ColumnName:{DescID: 105, Name: crdb_internal_mvcc_timestamp, ColumnID: 4294967295}, ABSENT]
+- from: [View:{DescID: 107}, DROPPED]
+  to:   [ColumnName:{DescID: 107, Name: crdb_internal_mvcc_timestamp, ColumnID: 4294967295}, ABSENT]
   kind: Precedence
   rule: descriptor dropped before dependent element removal
-- from: [View:{DescID: 105}, DROPPED]
-  to:   [ColumnName:{DescID: 105, Name: name, ColumnID: 1}, ABSENT]
+- from: [View:{DescID: 107}, DROPPED]
+  to:   [ColumnName:{DescID: 107, Name: name, ColumnID: 1}, ABSENT]
   kind: Precedence
   rule: descriptor dropped before dependent element removal
-- from: [View:{DescID: 105}, DROPPED]
-  to:   [ColumnName:{DescID: 105, Name: tableoid, ColumnID: 4294967294}, ABSENT]
+- from: [View:{DescID: 107}, DROPPED]
+  to:   [ColumnName:{DescID: 107, Name: tableoid, ColumnID: 4294967294}, ABSENT]
   kind: Precedence
   rule: descriptor dropped before dependent element removal
-- from: [View:{DescID: 105}, DROPPED]
-  to:   [ColumnType:{DescID: 105, ColumnFamilyID: 0, ColumnID: 1}, ABSENT]
+- from: [View:{DescID: 107}, DROPPED]
+  to:   [ColumnType:{DescID: 107, ColumnFamilyID: 0, ColumnID: 4294967294}, ABSENT]
   kind: Precedence
   rule: descriptor dropped before dependent element removal
-- from: [View:{DescID: 105}, DROPPED]
-  to:   [ColumnType:{DescID: 105, ColumnFamilyID: 0, ColumnID: 4294967294}, ABSENT]
+- from: [View:{DescID: 107}, DROPPED]
+  to:   [ColumnType:{DescID: 107, ColumnFamilyID: 0, ColumnID: 4294967295}, ABSENT]
   kind: Precedence
   rule: descriptor dropped before dependent element removal
-- from: [View:{DescID: 105}, DROPPED]
-  to:   [ColumnType:{DescID: 105, ColumnFamilyID: 0, ColumnID: 4294967295}, ABSENT]
+- from: [View:{DescID: 107}, DROPPED]
+  to:   [ColumnType:{DescID: 107, ReferencedTypeIDs: [104 105], ColumnFamilyID: 0, ColumnID: 1}, ABSENT]
   kind: Precedence
   rule: descriptor dropped before dependent element removal
-- from: [View:{DescID: 105}, DROPPED]
-  to:   [Namespace:{DescID: 105, Name: v1, ReferencedDescID: 100}, ABSENT]
+- from: [View:{DescID: 107}, DROPPED]
+  to:   [Namespace:{DescID: 107, Name: v1, ReferencedDescID: 100}, ABSENT]
   kind: Precedence
   rule: descriptor dropped before dependent element removal
-- from: [View:{DescID: 105}, DROPPED]
-  to:   [ObjectParent:{DescID: 105, ReferencedDescID: 101}, ABSENT]
+- from: [View:{DescID: 107}, DROPPED]
+  to:   [ObjectParent:{DescID: 107, ReferencedDescID: 101}, ABSENT]
   kind: SameStagePrecedence
   rules: [descriptor dropped before dependent element removal; descriptor dropped right before removing back-reference in its parent descriptor]
-- from: [View:{DescID: 105}, DROPPED]
-  to:   [Owner:{DescID: 105}, ABSENT]
+- from: [View:{DescID: 107}, DROPPED]
+  to:   [Owner:{DescID: 107}, ABSENT]
   kind: Precedence
   rule: descriptor dropped before dependent element removal
-- from: [View:{DescID: 105}, DROPPED]
-  to:   [UserPrivileges:{DescID: 105, Name: admin}, ABSENT]
+- from: [View:{DescID: 107}, DROPPED]
+  to:   [UserPrivileges:{DescID: 107, Name: admin}, ABSENT]
   kind: Precedence
   rule: descriptor dropped before dependent element removal
-- from: [View:{DescID: 105}, DROPPED]
-  to:   [UserPrivileges:{DescID: 105, Name: root}, ABSENT]
+- from: [View:{DescID: 107}, DROPPED]
+  to:   [UserPrivileges:{DescID: 107, Name: root}, ABSENT]
   kind: Precedence
   rule: descriptor dropped before dependent element removal
-- from: [View:{DescID: 105}, DROPPED]
-  to:   [View:{DescID: 105}, ABSENT]
+- from: [View:{DescID: 107}, DROPPED]
+  to:   [View:{DescID: 107}, ABSENT]
   kind: PreviousStagePrecedence
   rule: descriptor dropped in transaction before removal
 
@@ -318,42 +359,9 @@ CREATE VIEW v5 AS (SELECT 'a'::defaultdb.typ::string AS k, n2, n1 from defaultdb
 ops
 DROP VIEW defaultdb.v1 CASCADE
 ----
-StatementPhase stage 1 of 1 with 21 MutationType ops
+StatementPhase stage 1 of 1 with 43 MutationType ops
   transitions:
-    [[Namespace:{DescID: 105, Name: v1, ReferencedDescID: 100}, ABSENT], PUBLIC] -> ABSENT
-    [[Owner:{DescID: 105}, ABSENT], PUBLIC] -> ABSENT
-    [[UserPrivileges:{DescID: 105, Name: admin}, ABSENT], PUBLIC] -> ABSENT
-    [[UserPrivileges:{DescID: 105, Name: root}, ABSENT], PUBLIC] -> ABSENT
-    [[View:{DescID: 105}, ABSENT], PUBLIC] -> DROPPED
-    [[ObjectParent:{DescID: 105, ReferencedDescID: 101}, ABSENT], PUBLIC] -> ABSENT
-    [[Column:{DescID: 105, ColumnID: 1}, ABSENT], PUBLIC] -> WRITE_ONLY
-    [[ColumnName:{DescID: 105, Name: name, ColumnID: 1}, ABSENT], PUBLIC] -> ABSENT
-    [[ColumnType:{DescID: 105, ColumnFamilyID: 0, ColumnID: 1}, ABSENT], PUBLIC] -> ABSENT
-    [[Column:{DescID: 105, ColumnID: 4294967295}, ABSENT], PUBLIC] -> WRITE_ONLY
-    [[ColumnName:{DescID: 105, Name: crdb_internal_mvcc_timestamp, ColumnID: 4294967295}, ABSENT], PUBLIC] -> ABSENT
-    [[ColumnType:{DescID: 105, ColumnFamilyID: 0, ColumnID: 4294967295}, ABSENT], PUBLIC] -> ABSENT
-    [[Column:{DescID: 105, ColumnID: 4294967294}, ABSENT], PUBLIC] -> WRITE_ONLY
-    [[ColumnName:{DescID: 105, Name: tableoid, ColumnID: 4294967294}, ABSENT], PUBLIC] -> ABSENT
-    [[ColumnType:{DescID: 105, ColumnFamilyID: 0, ColumnID: 4294967294}, ABSENT], PUBLIC] -> ABSENT
-    [[Namespace:{DescID: 106, Name: v2, ReferencedDescID: 100}, ABSENT], PUBLIC] -> ABSENT
-    [[Owner:{DescID: 106}, ABSENT], PUBLIC] -> ABSENT
-    [[UserPrivileges:{DescID: 106, Name: admin}, ABSENT], PUBLIC] -> ABSENT
-    [[UserPrivileges:{DescID: 106, Name: root}, ABSENT], PUBLIC] -> ABSENT
-    [[View:{DescID: 106}, ABSENT], PUBLIC] -> DROPPED
-    [[ObjectParent:{DescID: 106, ReferencedDescID: 101}, ABSENT], PUBLIC] -> ABSENT
-    [[Column:{DescID: 106, ColumnID: 1}, ABSENT], PUBLIC] -> WRITE_ONLY
-    [[ColumnName:{DescID: 106, Name: n1, ColumnID: 1}, ABSENT], PUBLIC] -> ABSENT
-    [[ColumnType:{DescID: 106, ColumnFamilyID: 0, ColumnID: 1}, ABSENT], PUBLIC] -> ABSENT
-    [[Column:{DescID: 106, ColumnID: 2}, ABSENT], PUBLIC] -> WRITE_ONLY
-    [[ColumnName:{DescID: 106, Name: n2, ColumnID: 2}, ABSENT], PUBLIC] -> ABSENT
-    [[ColumnType:{DescID: 106, ColumnFamilyID: 0, ColumnID: 2}, ABSENT], PUBLIC] -> ABSENT
-    [[Column:{DescID: 106, ColumnID: 4294967295}, ABSENT], PUBLIC] -> WRITE_ONLY
-    [[ColumnName:{DescID: 106, Name: crdb_internal_mvcc_timestamp, ColumnID: 4294967295}, ABSENT], PUBLIC] -> ABSENT
-    [[ColumnType:{DescID: 106, ColumnFamilyID: 0, ColumnID: 4294967295}, ABSENT], PUBLIC] -> ABSENT
-    [[Column:{DescID: 106, ColumnID: 4294967294}, ABSENT], PUBLIC] -> WRITE_ONLY
-    [[ColumnName:{DescID: 106, Name: tableoid, ColumnID: 4294967294}, ABSENT], PUBLIC] -> ABSENT
-    [[ColumnType:{DescID: 106, ColumnFamilyID: 0, ColumnID: 4294967294}, ABSENT], PUBLIC] -> ABSENT
-    [[Namespace:{DescID: 107, Name: v3, ReferencedDescID: 100}, ABSENT], PUBLIC] -> ABSENT
+    [[Namespace:{DescID: 107, Name: v1, ReferencedDescID: 100}, ABSENT], PUBLIC] -> ABSENT
     [[Owner:{DescID: 107}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 107, Name: admin}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 107, Name: root}, ABSENT], PUBLIC] -> ABSENT
@@ -361,173 +369,262 @@ StatementPhase stage 1 of 1 with 21 MutationType ops
     [[ObjectParent:{DescID: 107, ReferencedDescID: 101}, ABSENT], PUBLIC] -> ABSENT
     [[Column:{DescID: 107, ColumnID: 1}, ABSENT], PUBLIC] -> WRITE_ONLY
     [[ColumnName:{DescID: 107, Name: name, ColumnID: 1}, ABSENT], PUBLIC] -> ABSENT
-    [[ColumnType:{DescID: 107, ColumnFamilyID: 0, ColumnID: 1}, ABSENT], PUBLIC] -> ABSENT
-    [[Column:{DescID: 107, ColumnID: 2}, ABSENT], PUBLIC] -> WRITE_ONLY
-    [[ColumnName:{DescID: 107, Name: n1, ColumnID: 2}, ABSENT], PUBLIC] -> ABSENT
-    [[ColumnType:{DescID: 107, ColumnFamilyID: 0, ColumnID: 2}, ABSENT], PUBLIC] -> ABSENT
+    [[ColumnType:{DescID: 107, ReferencedTypeIDs: [104 105], ColumnFamilyID: 0, ColumnID: 1}, ABSENT], PUBLIC] -> ABSENT
     [[Column:{DescID: 107, ColumnID: 4294967295}, ABSENT], PUBLIC] -> WRITE_ONLY
     [[ColumnName:{DescID: 107, Name: crdb_internal_mvcc_timestamp, ColumnID: 4294967295}, ABSENT], PUBLIC] -> ABSENT
     [[ColumnType:{DescID: 107, ColumnFamilyID: 0, ColumnID: 4294967295}, ABSENT], PUBLIC] -> ABSENT
     [[Column:{DescID: 107, ColumnID: 4294967294}, ABSENT], PUBLIC] -> WRITE_ONLY
     [[ColumnName:{DescID: 107, Name: tableoid, ColumnID: 4294967294}, ABSENT], PUBLIC] -> ABSENT
     [[ColumnType:{DescID: 107, ColumnFamilyID: 0, ColumnID: 4294967294}, ABSENT], PUBLIC] -> ABSENT
-    [[Namespace:{DescID: 108, Name: v4, ReferencedDescID: 100}, ABSENT], PUBLIC] -> ABSENT
+    [[Namespace:{DescID: 108, Name: v2, ReferencedDescID: 100}, ABSENT], PUBLIC] -> ABSENT
     [[Owner:{DescID: 108}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 108, Name: admin}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 108, Name: root}, ABSENT], PUBLIC] -> ABSENT
     [[View:{DescID: 108}, ABSENT], PUBLIC] -> DROPPED
     [[ObjectParent:{DescID: 108, ReferencedDescID: 101}, ABSENT], PUBLIC] -> ABSENT
     [[Column:{DescID: 108, ColumnID: 1}, ABSENT], PUBLIC] -> WRITE_ONLY
-    [[ColumnName:{DescID: 108, Name: n2, ColumnID: 1}, ABSENT], PUBLIC] -> ABSENT
-    [[ColumnType:{DescID: 108, ColumnFamilyID: 0, ColumnID: 1}, ABSENT], PUBLIC] -> ABSENT
+    [[ColumnName:{DescID: 108, Name: n1, ColumnID: 1}, ABSENT], PUBLIC] -> ABSENT
+    [[ColumnType:{DescID: 108, ReferencedTypeIDs: [104 105], ColumnFamilyID: 0, ColumnID: 1}, ABSENT], PUBLIC] -> ABSENT
     [[Column:{DescID: 108, ColumnID: 2}, ABSENT], PUBLIC] -> WRITE_ONLY
-    [[ColumnName:{DescID: 108, Name: n1, ColumnID: 2}, ABSENT], PUBLIC] -> ABSENT
-    [[ColumnType:{DescID: 108, ColumnFamilyID: 0, ColumnID: 2}, ABSENT], PUBLIC] -> ABSENT
+    [[ColumnName:{DescID: 108, Name: n2, ColumnID: 2}, ABSENT], PUBLIC] -> ABSENT
+    [[ColumnType:{DescID: 108, ReferencedTypeIDs: [104 105], ColumnFamilyID: 0, ColumnID: 2}, ABSENT], PUBLIC] -> ABSENT
     [[Column:{DescID: 108, ColumnID: 4294967295}, ABSENT], PUBLIC] -> WRITE_ONLY
     [[ColumnName:{DescID: 108, Name: crdb_internal_mvcc_timestamp, ColumnID: 4294967295}, ABSENT], PUBLIC] -> ABSENT
     [[ColumnType:{DescID: 108, ColumnFamilyID: 0, ColumnID: 4294967295}, ABSENT], PUBLIC] -> ABSENT
     [[Column:{DescID: 108, ColumnID: 4294967294}, ABSENT], PUBLIC] -> WRITE_ONLY
     [[ColumnName:{DescID: 108, Name: tableoid, ColumnID: 4294967294}, ABSENT], PUBLIC] -> ABSENT
     [[ColumnType:{DescID: 108, ColumnFamilyID: 0, ColumnID: 4294967294}, ABSENT], PUBLIC] -> ABSENT
-    [[Namespace:{DescID: 111, Name: v5, ReferencedDescID: 100}, ABSENT], PUBLIC] -> ABSENT
-    [[Owner:{DescID: 111}, ABSENT], PUBLIC] -> ABSENT
-    [[UserPrivileges:{DescID: 111, Name: admin}, ABSENT], PUBLIC] -> ABSENT
-    [[UserPrivileges:{DescID: 111, Name: root}, ABSENT], PUBLIC] -> ABSENT
-    [[View:{DescID: 111}, ABSENT], PUBLIC] -> DROPPED
-    [[ObjectParent:{DescID: 111, ReferencedDescID: 101}, ABSENT], PUBLIC] -> ABSENT
-    [[Column:{DescID: 111, ColumnID: 1}, ABSENT], PUBLIC] -> WRITE_ONLY
-    [[ColumnName:{DescID: 111, Name: k, ColumnID: 1}, ABSENT], PUBLIC] -> ABSENT
-    [[ColumnType:{DescID: 111, ColumnFamilyID: 0, ColumnID: 1}, ABSENT], PUBLIC] -> ABSENT
-    [[Column:{DescID: 111, ColumnID: 2}, ABSENT], PUBLIC] -> WRITE_ONLY
-    [[ColumnName:{DescID: 111, Name: n2, ColumnID: 2}, ABSENT], PUBLIC] -> ABSENT
-    [[ColumnType:{DescID: 111, ColumnFamilyID: 0, ColumnID: 2}, ABSENT], PUBLIC] -> ABSENT
-    [[Column:{DescID: 111, ColumnID: 3}, ABSENT], PUBLIC] -> WRITE_ONLY
-    [[ColumnName:{DescID: 111, Name: n1, ColumnID: 3}, ABSENT], PUBLIC] -> ABSENT
-    [[ColumnType:{DescID: 111, ColumnFamilyID: 0, ColumnID: 3}, ABSENT], PUBLIC] -> ABSENT
-    [[Column:{DescID: 111, ColumnID: 4294967295}, ABSENT], PUBLIC] -> WRITE_ONLY
-    [[ColumnName:{DescID: 111, Name: crdb_internal_mvcc_timestamp, ColumnID: 4294967295}, ABSENT], PUBLIC] -> ABSENT
-    [[ColumnType:{DescID: 111, ColumnFamilyID: 0, ColumnID: 4294967295}, ABSENT], PUBLIC] -> ABSENT
-    [[Column:{DescID: 111, ColumnID: 4294967294}, ABSENT], PUBLIC] -> WRITE_ONLY
-    [[ColumnName:{DescID: 111, Name: tableoid, ColumnID: 4294967294}, ABSENT], PUBLIC] -> ABSENT
-    [[ColumnType:{DescID: 111, ColumnFamilyID: 0, ColumnID: 4294967294}, ABSENT], PUBLIC] -> ABSENT
+    [[Namespace:{DescID: 109, Name: v3, ReferencedDescID: 100}, ABSENT], PUBLIC] -> ABSENT
+    [[Owner:{DescID: 109}, ABSENT], PUBLIC] -> ABSENT
+    [[UserPrivileges:{DescID: 109, Name: admin}, ABSENT], PUBLIC] -> ABSENT
+    [[UserPrivileges:{DescID: 109, Name: root}, ABSENT], PUBLIC] -> ABSENT
+    [[View:{DescID: 109}, ABSENT], PUBLIC] -> DROPPED
+    [[ObjectParent:{DescID: 109, ReferencedDescID: 101}, ABSENT], PUBLIC] -> ABSENT
+    [[Column:{DescID: 109, ColumnID: 1}, ABSENT], PUBLIC] -> WRITE_ONLY
+    [[ColumnName:{DescID: 109, Name: name, ColumnID: 1}, ABSENT], PUBLIC] -> ABSENT
+    [[ColumnType:{DescID: 109, ReferencedTypeIDs: [104 105], ColumnFamilyID: 0, ColumnID: 1}, ABSENT], PUBLIC] -> ABSENT
+    [[Column:{DescID: 109, ColumnID: 2}, ABSENT], PUBLIC] -> WRITE_ONLY
+    [[ColumnName:{DescID: 109, Name: n1, ColumnID: 2}, ABSENT], PUBLIC] -> ABSENT
+    [[ColumnType:{DescID: 109, ReferencedTypeIDs: [104 105], ColumnFamilyID: 0, ColumnID: 2}, ABSENT], PUBLIC] -> ABSENT
+    [[Column:{DescID: 109, ColumnID: 4294967295}, ABSENT], PUBLIC] -> WRITE_ONLY
+    [[ColumnName:{DescID: 109, Name: crdb_internal_mvcc_timestamp, ColumnID: 4294967295}, ABSENT], PUBLIC] -> ABSENT
+    [[ColumnType:{DescID: 109, ColumnFamilyID: 0, ColumnID: 4294967295}, ABSENT], PUBLIC] -> ABSENT
+    [[Column:{DescID: 109, ColumnID: 4294967294}, ABSENT], PUBLIC] -> WRITE_ONLY
+    [[ColumnName:{DescID: 109, Name: tableoid, ColumnID: 4294967294}, ABSENT], PUBLIC] -> ABSENT
+    [[ColumnType:{DescID: 109, ColumnFamilyID: 0, ColumnID: 4294967294}, ABSENT], PUBLIC] -> ABSENT
+    [[Namespace:{DescID: 110, Name: v4, ReferencedDescID: 100}, ABSENT], PUBLIC] -> ABSENT
+    [[Owner:{DescID: 110}, ABSENT], PUBLIC] -> ABSENT
+    [[UserPrivileges:{DescID: 110, Name: admin}, ABSENT], PUBLIC] -> ABSENT
+    [[UserPrivileges:{DescID: 110, Name: root}, ABSENT], PUBLIC] -> ABSENT
+    [[View:{DescID: 110}, ABSENT], PUBLIC] -> DROPPED
+    [[ObjectParent:{DescID: 110, ReferencedDescID: 101}, ABSENT], PUBLIC] -> ABSENT
+    [[Column:{DescID: 110, ColumnID: 1}, ABSENT], PUBLIC] -> WRITE_ONLY
+    [[ColumnName:{DescID: 110, Name: n2, ColumnID: 1}, ABSENT], PUBLIC] -> ABSENT
+    [[ColumnType:{DescID: 110, ReferencedTypeIDs: [104 105], ColumnFamilyID: 0, ColumnID: 1}, ABSENT], PUBLIC] -> ABSENT
+    [[Column:{DescID: 110, ColumnID: 2}, ABSENT], PUBLIC] -> WRITE_ONLY
+    [[ColumnName:{DescID: 110, Name: n1, ColumnID: 2}, ABSENT], PUBLIC] -> ABSENT
+    [[ColumnType:{DescID: 110, ReferencedTypeIDs: [104 105], ColumnFamilyID: 0, ColumnID: 2}, ABSENT], PUBLIC] -> ABSENT
+    [[Column:{DescID: 110, ColumnID: 4294967295}, ABSENT], PUBLIC] -> WRITE_ONLY
+    [[ColumnName:{DescID: 110, Name: crdb_internal_mvcc_timestamp, ColumnID: 4294967295}, ABSENT], PUBLIC] -> ABSENT
+    [[ColumnType:{DescID: 110, ColumnFamilyID: 0, ColumnID: 4294967295}, ABSENT], PUBLIC] -> ABSENT
+    [[Column:{DescID: 110, ColumnID: 4294967294}, ABSENT], PUBLIC] -> WRITE_ONLY
+    [[ColumnName:{DescID: 110, Name: tableoid, ColumnID: 4294967294}, ABSENT], PUBLIC] -> ABSENT
+    [[ColumnType:{DescID: 110, ColumnFamilyID: 0, ColumnID: 4294967294}, ABSENT], PUBLIC] -> ABSENT
+    [[Namespace:{DescID: 113, Name: v5, ReferencedDescID: 100}, ABSENT], PUBLIC] -> ABSENT
+    [[Owner:{DescID: 113}, ABSENT], PUBLIC] -> ABSENT
+    [[UserPrivileges:{DescID: 113, Name: admin}, ABSENT], PUBLIC] -> ABSENT
+    [[UserPrivileges:{DescID: 113, Name: root}, ABSENT], PUBLIC] -> ABSENT
+    [[View:{DescID: 113}, ABSENT], PUBLIC] -> DROPPED
+    [[ObjectParent:{DescID: 113, ReferencedDescID: 101}, ABSENT], PUBLIC] -> ABSENT
+    [[Column:{DescID: 113, ColumnID: 1}, ABSENT], PUBLIC] -> WRITE_ONLY
+    [[ColumnName:{DescID: 113, Name: k, ColumnID: 1}, ABSENT], PUBLIC] -> ABSENT
+    [[ColumnType:{DescID: 113, ColumnFamilyID: 0, ColumnID: 1}, ABSENT], PUBLIC] -> ABSENT
+    [[Column:{DescID: 113, ColumnID: 2}, ABSENT], PUBLIC] -> WRITE_ONLY
+    [[ColumnName:{DescID: 113, Name: n2, ColumnID: 2}, ABSENT], PUBLIC] -> ABSENT
+    [[ColumnType:{DescID: 113, ReferencedTypeIDs: [104 105], ColumnFamilyID: 0, ColumnID: 2}, ABSENT], PUBLIC] -> ABSENT
+    [[Column:{DescID: 113, ColumnID: 3}, ABSENT], PUBLIC] -> WRITE_ONLY
+    [[ColumnName:{DescID: 113, Name: n1, ColumnID: 3}, ABSENT], PUBLIC] -> ABSENT
+    [[ColumnType:{DescID: 113, ReferencedTypeIDs: [104 105], ColumnFamilyID: 0, ColumnID: 3}, ABSENT], PUBLIC] -> ABSENT
+    [[Column:{DescID: 113, ColumnID: 4294967295}, ABSENT], PUBLIC] -> WRITE_ONLY
+    [[ColumnName:{DescID: 113, Name: crdb_internal_mvcc_timestamp, ColumnID: 4294967295}, ABSENT], PUBLIC] -> ABSENT
+    [[ColumnType:{DescID: 113, ColumnFamilyID: 0, ColumnID: 4294967295}, ABSENT], PUBLIC] -> ABSENT
+    [[Column:{DescID: 113, ColumnID: 4294967294}, ABSENT], PUBLIC] -> WRITE_ONLY
+    [[ColumnName:{DescID: 113, Name: tableoid, ColumnID: 4294967294}, ABSENT], PUBLIC] -> ABSENT
+    [[ColumnType:{DescID: 113, ColumnFamilyID: 0, ColumnID: 4294967294}, ABSENT], PUBLIC] -> ABSENT
   ops:
     *scop.MarkDescriptorAsDropped
-      DescriptorID: 105
-    *scop.RemoveBackReferencesInRelations
-      BackReferencedID: 105
-      RelationIDs:
-      - 104
-    *scop.RemoveObjectParent
-      ObjectID: 105
-      ParentSchemaID: 101
-    *scop.MarkDescriptorAsDropped
-      DescriptorID: 106
-    *scop.RemoveBackReferencesInRelations
-      BackReferencedID: 106
-      RelationIDs:
-      - 105
-    *scop.RemoveObjectParent
-      ObjectID: 106
-      ParentSchemaID: 101
-    *scop.MarkDescriptorAsDropped
       DescriptorID: 107
+    *scop.RemoveBackReferenceInTypes
+      BackReferencedDescriptorID: 107
+      TypeIDs:
+      - 104
     *scop.RemoveBackReferencesInRelations
       BackReferencedID: 107
       RelationIDs:
-      - 105
       - 106
     *scop.RemoveObjectParent
       ObjectID: 107
       ParentSchemaID: 101
+    *scop.RemoveDroppedColumnType
+      ColumnID: 1
+      TableID: 107
+    *scop.UpdateTableBackReferencesInTypes
+      BackReferencedTableID: 107
+      TypeIDs:
+      - 104
+      - 105
     *scop.MarkDescriptorAsDropped
       DescriptorID: 108
+    *scop.RemoveBackReferenceInTypes
+      BackReferencedDescriptorID: 108
+      TypeIDs:
+      - 104
     *scop.RemoveBackReferencesInRelations
       BackReferencedID: 108
       RelationIDs:
-      - 106
+      - 107
     *scop.RemoveObjectParent
       ObjectID: 108
       ParentSchemaID: 101
-    *scop.MarkDescriptorAsDropped
-      DescriptorID: 111
-    *scop.RemoveBackReferenceInTypes
-      BackReferencedDescriptorID: 111
+    *scop.RemoveDroppedColumnType
+      ColumnID: 1
+      TableID: 108
+    *scop.UpdateTableBackReferencesInTypes
+      BackReferencedTableID: 108
       TypeIDs:
-      - 109
-      - 110
+      - 104
+      - 105
+    *scop.RemoveDroppedColumnType
+      ColumnID: 2
+      TableID: 108
+    *scop.UpdateTableBackReferencesInTypes
+      BackReferencedTableID: 108
+      TypeIDs:
+      - 104
+      - 105
+    *scop.MarkDescriptorAsDropped
+      DescriptorID: 109
+    *scop.RemoveBackReferenceInTypes
+      BackReferencedDescriptorID: 109
+      TypeIDs:
+      - 104
     *scop.RemoveBackReferencesInRelations
-      BackReferencedID: 111
+      BackReferencedID: 109
+      RelationIDs:
+      - 107
+      - 108
+    *scop.RemoveObjectParent
+      ObjectID: 109
+      ParentSchemaID: 101
+    *scop.RemoveDroppedColumnType
+      ColumnID: 1
+      TableID: 109
+    *scop.UpdateTableBackReferencesInTypes
+      BackReferencedTableID: 109
+      TypeIDs:
+      - 104
+      - 105
+    *scop.RemoveDroppedColumnType
+      ColumnID: 2
+      TableID: 109
+    *scop.UpdateTableBackReferencesInTypes
+      BackReferencedTableID: 109
+      TypeIDs:
+      - 104
+      - 105
+    *scop.MarkDescriptorAsDropped
+      DescriptorID: 110
+    *scop.RemoveBackReferenceInTypes
+      BackReferencedDescriptorID: 110
+      TypeIDs:
+      - 104
+    *scop.RemoveBackReferencesInRelations
+      BackReferencedID: 110
       RelationIDs:
       - 108
     *scop.RemoveObjectParent
-      ObjectID: 111
+      ObjectID: 110
       ParentSchemaID: 101
+    *scop.RemoveDroppedColumnType
+      ColumnID: 1
+      TableID: 110
+    *scop.UpdateTableBackReferencesInTypes
+      BackReferencedTableID: 110
+      TypeIDs:
+      - 104
+      - 105
+    *scop.RemoveDroppedColumnType
+      ColumnID: 2
+      TableID: 110
+    *scop.UpdateTableBackReferencesInTypes
+      BackReferencedTableID: 110
+      TypeIDs:
+      - 104
+      - 105
+    *scop.MarkDescriptorAsDropped
+      DescriptorID: 113
+    *scop.RemoveBackReferenceInTypes
+      BackReferencedDescriptorID: 113
+      TypeIDs:
+      - 104
+      - 111
+      - 112
+    *scop.RemoveBackReferencesInRelations
+      BackReferencedID: 113
+      RelationIDs:
+      - 110
+    *scop.RemoveObjectParent
+      ObjectID: 113
+      ParentSchemaID: 101
+    *scop.RemoveDroppedColumnType
+      ColumnID: 2
+      TableID: 113
+    *scop.UpdateTableBackReferencesInTypes
+      BackReferencedTableID: 113
+      TypeIDs:
+      - 104
+      - 105
+    *scop.RemoveDroppedColumnType
+      ColumnID: 3
+      TableID: 113
+    *scop.UpdateTableBackReferencesInTypes
+      BackReferencedTableID: 113
+      TypeIDs:
+      - 104
+      - 105
     *scop.DrainDescriptorName
       Namespace:
         DatabaseID: 100
-        DescriptorID: 105
+        DescriptorID: 107
         Name: v1
         SchemaID: 101
     *scop.DrainDescriptorName
       Namespace:
         DatabaseID: 100
-        DescriptorID: 106
+        DescriptorID: 108
         Name: v2
         SchemaID: 101
     *scop.DrainDescriptorName
       Namespace:
         DatabaseID: 100
-        DescriptorID: 107
+        DescriptorID: 109
         Name: v3
         SchemaID: 101
     *scop.DrainDescriptorName
       Namespace:
         DatabaseID: 100
-        DescriptorID: 108
+        DescriptorID: 110
         Name: v4
         SchemaID: 101
     *scop.DrainDescriptorName
       Namespace:
         DatabaseID: 100
-        DescriptorID: 111
+        DescriptorID: 113
         Name: v5
         SchemaID: 101
 PreCommitPhase stage 1 of 2 with 1 MutationType op
   transitions:
-    [[Namespace:{DescID: 105, Name: v1, ReferencedDescID: 100}, ABSENT], ABSENT] -> PUBLIC
-    [[Owner:{DescID: 105}, ABSENT], ABSENT] -> PUBLIC
-    [[UserPrivileges:{DescID: 105, Name: admin}, ABSENT], ABSENT] -> PUBLIC
-    [[UserPrivileges:{DescID: 105, Name: root}, ABSENT], ABSENT] -> PUBLIC
-    [[View:{DescID: 105}, ABSENT], DROPPED] -> PUBLIC
-    [[ObjectParent:{DescID: 105, ReferencedDescID: 101}, ABSENT], ABSENT] -> PUBLIC
-    [[Column:{DescID: 105, ColumnID: 1}, ABSENT], WRITE_ONLY] -> PUBLIC
-    [[ColumnName:{DescID: 105, Name: name, ColumnID: 1}, ABSENT], ABSENT] -> PUBLIC
-    [[ColumnType:{DescID: 105, ColumnFamilyID: 0, ColumnID: 1}, ABSENT], ABSENT] -> PUBLIC
-    [[Column:{DescID: 105, ColumnID: 4294967295}, ABSENT], WRITE_ONLY] -> PUBLIC
-    [[ColumnName:{DescID: 105, Name: crdb_internal_mvcc_timestamp, ColumnID: 4294967295}, ABSENT], ABSENT] -> PUBLIC
-    [[ColumnType:{DescID: 105, ColumnFamilyID: 0, ColumnID: 4294967295}, ABSENT], ABSENT] -> PUBLIC
-    [[Column:{DescID: 105, ColumnID: 4294967294}, ABSENT], WRITE_ONLY] -> PUBLIC
-    [[ColumnName:{DescID: 105, Name: tableoid, ColumnID: 4294967294}, ABSENT], ABSENT] -> PUBLIC
-    [[ColumnType:{DescID: 105, ColumnFamilyID: 0, ColumnID: 4294967294}, ABSENT], ABSENT] -> PUBLIC
-    [[Namespace:{DescID: 106, Name: v2, ReferencedDescID: 100}, ABSENT], ABSENT] -> PUBLIC
-    [[Owner:{DescID: 106}, ABSENT], ABSENT] -> PUBLIC
-    [[UserPrivileges:{DescID: 106, Name: admin}, ABSENT], ABSENT] -> PUBLIC
-    [[UserPrivileges:{DescID: 106, Name: root}, ABSENT], ABSENT] -> PUBLIC
-    [[View:{DescID: 106}, ABSENT], DROPPED] -> PUBLIC
-    [[ObjectParent:{DescID: 106, ReferencedDescID: 101}, ABSENT], ABSENT] -> PUBLIC
-    [[Column:{DescID: 106, ColumnID: 1}, ABSENT], WRITE_ONLY] -> PUBLIC
-    [[ColumnName:{DescID: 106, Name: n1, ColumnID: 1}, ABSENT], ABSENT] -> PUBLIC
-    [[ColumnType:{DescID: 106, ColumnFamilyID: 0, ColumnID: 1}, ABSENT], ABSENT] -> PUBLIC
-    [[Column:{DescID: 106, ColumnID: 2}, ABSENT], WRITE_ONLY] -> PUBLIC
-    [[ColumnName:{DescID: 106, Name: n2, ColumnID: 2}, ABSENT], ABSENT] -> PUBLIC
-    [[ColumnType:{DescID: 106, ColumnFamilyID: 0, ColumnID: 2}, ABSENT], ABSENT] -> PUBLIC
-    [[Column:{DescID: 106, ColumnID: 4294967295}, ABSENT], WRITE_ONLY] -> PUBLIC
-    [[ColumnName:{DescID: 106, Name: crdb_internal_mvcc_timestamp, ColumnID: 4294967295}, ABSENT], ABSENT] -> PUBLIC
-    [[ColumnType:{DescID: 106, ColumnFamilyID: 0, ColumnID: 4294967295}, ABSENT], ABSENT] -> PUBLIC
-    [[Column:{DescID: 106, ColumnID: 4294967294}, ABSENT], WRITE_ONLY] -> PUBLIC
-    [[ColumnName:{DescID: 106, Name: tableoid, ColumnID: 4294967294}, ABSENT], ABSENT] -> PUBLIC
-    [[ColumnType:{DescID: 106, ColumnFamilyID: 0, ColumnID: 4294967294}, ABSENT], ABSENT] -> PUBLIC
-    [[Namespace:{DescID: 107, Name: v3, ReferencedDescID: 100}, ABSENT], ABSENT] -> PUBLIC
+    [[Namespace:{DescID: 107, Name: v1, ReferencedDescID: 100}, ABSENT], ABSENT] -> PUBLIC
     [[Owner:{DescID: 107}, ABSENT], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 107, Name: admin}, ABSENT], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 107, Name: root}, ABSENT], ABSENT] -> PUBLIC
@@ -535,94 +632,94 @@ PreCommitPhase stage 1 of 2 with 1 MutationType op
     [[ObjectParent:{DescID: 107, ReferencedDescID: 101}, ABSENT], ABSENT] -> PUBLIC
     [[Column:{DescID: 107, ColumnID: 1}, ABSENT], WRITE_ONLY] -> PUBLIC
     [[ColumnName:{DescID: 107, Name: name, ColumnID: 1}, ABSENT], ABSENT] -> PUBLIC
-    [[ColumnType:{DescID: 107, ColumnFamilyID: 0, ColumnID: 1}, ABSENT], ABSENT] -> PUBLIC
-    [[Column:{DescID: 107, ColumnID: 2}, ABSENT], WRITE_ONLY] -> PUBLIC
-    [[ColumnName:{DescID: 107, Name: n1, ColumnID: 2}, ABSENT], ABSENT] -> PUBLIC
-    [[ColumnType:{DescID: 107, ColumnFamilyID: 0, ColumnID: 2}, ABSENT], ABSENT] -> PUBLIC
+    [[ColumnType:{DescID: 107, ReferencedTypeIDs: [104 105], ColumnFamilyID: 0, ColumnID: 1}, ABSENT], ABSENT] -> PUBLIC
     [[Column:{DescID: 107, ColumnID: 4294967295}, ABSENT], WRITE_ONLY] -> PUBLIC
     [[ColumnName:{DescID: 107, Name: crdb_internal_mvcc_timestamp, ColumnID: 4294967295}, ABSENT], ABSENT] -> PUBLIC
     [[ColumnType:{DescID: 107, ColumnFamilyID: 0, ColumnID: 4294967295}, ABSENT], ABSENT] -> PUBLIC
     [[Column:{DescID: 107, ColumnID: 4294967294}, ABSENT], WRITE_ONLY] -> PUBLIC
     [[ColumnName:{DescID: 107, Name: tableoid, ColumnID: 4294967294}, ABSENT], ABSENT] -> PUBLIC
     [[ColumnType:{DescID: 107, ColumnFamilyID: 0, ColumnID: 4294967294}, ABSENT], ABSENT] -> PUBLIC
-    [[Namespace:{DescID: 108, Name: v4, ReferencedDescID: 100}, ABSENT], ABSENT] -> PUBLIC
+    [[Namespace:{DescID: 108, Name: v2, ReferencedDescID: 100}, ABSENT], ABSENT] -> PUBLIC
     [[Owner:{DescID: 108}, ABSENT], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 108, Name: admin}, ABSENT], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 108, Name: root}, ABSENT], ABSENT] -> PUBLIC
     [[View:{DescID: 108}, ABSENT], DROPPED] -> PUBLIC
     [[ObjectParent:{DescID: 108, ReferencedDescID: 101}, ABSENT], ABSENT] -> PUBLIC
     [[Column:{DescID: 108, ColumnID: 1}, ABSENT], WRITE_ONLY] -> PUBLIC
-    [[ColumnName:{DescID: 108, Name: n2, ColumnID: 1}, ABSENT], ABSENT] -> PUBLIC
-    [[ColumnType:{DescID: 108, ColumnFamilyID: 0, ColumnID: 1}, ABSENT], ABSENT] -> PUBLIC
+    [[ColumnName:{DescID: 108, Name: n1, ColumnID: 1}, ABSENT], ABSENT] -> PUBLIC
+    [[ColumnType:{DescID: 108, ReferencedTypeIDs: [104 105], ColumnFamilyID: 0, ColumnID: 1}, ABSENT], ABSENT] -> PUBLIC
     [[Column:{DescID: 108, ColumnID: 2}, ABSENT], WRITE_ONLY] -> PUBLIC
-    [[ColumnName:{DescID: 108, Name: n1, ColumnID: 2}, ABSENT], ABSENT] -> PUBLIC
-    [[ColumnType:{DescID: 108, ColumnFamilyID: 0, ColumnID: 2}, ABSENT], ABSENT] -> PUBLIC
+    [[ColumnName:{DescID: 108, Name: n2, ColumnID: 2}, ABSENT], ABSENT] -> PUBLIC
+    [[ColumnType:{DescID: 108, ReferencedTypeIDs: [104 105], ColumnFamilyID: 0, ColumnID: 2}, ABSENT], ABSENT] -> PUBLIC
     [[Column:{DescID: 108, ColumnID: 4294967295}, ABSENT], WRITE_ONLY] -> PUBLIC
     [[ColumnName:{DescID: 108, Name: crdb_internal_mvcc_timestamp, ColumnID: 4294967295}, ABSENT], ABSENT] -> PUBLIC
     [[ColumnType:{DescID: 108, ColumnFamilyID: 0, ColumnID: 4294967295}, ABSENT], ABSENT] -> PUBLIC
     [[Column:{DescID: 108, ColumnID: 4294967294}, ABSENT], WRITE_ONLY] -> PUBLIC
     [[ColumnName:{DescID: 108, Name: tableoid, ColumnID: 4294967294}, ABSENT], ABSENT] -> PUBLIC
     [[ColumnType:{DescID: 108, ColumnFamilyID: 0, ColumnID: 4294967294}, ABSENT], ABSENT] -> PUBLIC
-    [[Namespace:{DescID: 111, Name: v5, ReferencedDescID: 100}, ABSENT], ABSENT] -> PUBLIC
-    [[Owner:{DescID: 111}, ABSENT], ABSENT] -> PUBLIC
-    [[UserPrivileges:{DescID: 111, Name: admin}, ABSENT], ABSENT] -> PUBLIC
-    [[UserPrivileges:{DescID: 111, Name: root}, ABSENT], ABSENT] -> PUBLIC
-    [[View:{DescID: 111}, ABSENT], DROPPED] -> PUBLIC
-    [[ObjectParent:{DescID: 111, ReferencedDescID: 101}, ABSENT], ABSENT] -> PUBLIC
-    [[Column:{DescID: 111, ColumnID: 1}, ABSENT], WRITE_ONLY] -> PUBLIC
-    [[ColumnName:{DescID: 111, Name: k, ColumnID: 1}, ABSENT], ABSENT] -> PUBLIC
-    [[ColumnType:{DescID: 111, ColumnFamilyID: 0, ColumnID: 1}, ABSENT], ABSENT] -> PUBLIC
-    [[Column:{DescID: 111, ColumnID: 2}, ABSENT], WRITE_ONLY] -> PUBLIC
-    [[ColumnName:{DescID: 111, Name: n2, ColumnID: 2}, ABSENT], ABSENT] -> PUBLIC
-    [[ColumnType:{DescID: 111, ColumnFamilyID: 0, ColumnID: 2}, ABSENT], ABSENT] -> PUBLIC
-    [[Column:{DescID: 111, ColumnID: 3}, ABSENT], WRITE_ONLY] -> PUBLIC
-    [[ColumnName:{DescID: 111, Name: n1, ColumnID: 3}, ABSENT], ABSENT] -> PUBLIC
-    [[ColumnType:{DescID: 111, ColumnFamilyID: 0, ColumnID: 3}, ABSENT], ABSENT] -> PUBLIC
-    [[Column:{DescID: 111, ColumnID: 4294967295}, ABSENT], WRITE_ONLY] -> PUBLIC
-    [[ColumnName:{DescID: 111, Name: crdb_internal_mvcc_timestamp, ColumnID: 4294967295}, ABSENT], ABSENT] -> PUBLIC
-    [[ColumnType:{DescID: 111, ColumnFamilyID: 0, ColumnID: 4294967295}, ABSENT], ABSENT] -> PUBLIC
-    [[Column:{DescID: 111, ColumnID: 4294967294}, ABSENT], WRITE_ONLY] -> PUBLIC
-    [[ColumnName:{DescID: 111, Name: tableoid, ColumnID: 4294967294}, ABSENT], ABSENT] -> PUBLIC
-    [[ColumnType:{DescID: 111, ColumnFamilyID: 0, ColumnID: 4294967294}, ABSENT], ABSENT] -> PUBLIC
+    [[Namespace:{DescID: 109, Name: v3, ReferencedDescID: 100}, ABSENT], ABSENT] -> PUBLIC
+    [[Owner:{DescID: 109}, ABSENT], ABSENT] -> PUBLIC
+    [[UserPrivileges:{DescID: 109, Name: admin}, ABSENT], ABSENT] -> PUBLIC
+    [[UserPrivileges:{DescID: 109, Name: root}, ABSENT], ABSENT] -> PUBLIC
+    [[View:{DescID: 109}, ABSENT], DROPPED] -> PUBLIC
+    [[ObjectParent:{DescID: 109, ReferencedDescID: 101}, ABSENT], ABSENT] -> PUBLIC
+    [[Column:{DescID: 109, ColumnID: 1}, ABSENT], WRITE_ONLY] -> PUBLIC
+    [[ColumnName:{DescID: 109, Name: name, ColumnID: 1}, ABSENT], ABSENT] -> PUBLIC
+    [[ColumnType:{DescID: 109, ReferencedTypeIDs: [104 105], ColumnFamilyID: 0, ColumnID: 1}, ABSENT], ABSENT] -> PUBLIC
+    [[Column:{DescID: 109, ColumnID: 2}, ABSENT], WRITE_ONLY] -> PUBLIC
+    [[ColumnName:{DescID: 109, Name: n1, ColumnID: 2}, ABSENT], ABSENT] -> PUBLIC
+    [[ColumnType:{DescID: 109, ReferencedTypeIDs: [104 105], ColumnFamilyID: 0, ColumnID: 2}, ABSENT], ABSENT] -> PUBLIC
+    [[Column:{DescID: 109, ColumnID: 4294967295}, ABSENT], WRITE_ONLY] -> PUBLIC
+    [[ColumnName:{DescID: 109, Name: crdb_internal_mvcc_timestamp, ColumnID: 4294967295}, ABSENT], ABSENT] -> PUBLIC
+    [[ColumnType:{DescID: 109, ColumnFamilyID: 0, ColumnID: 4294967295}, ABSENT], ABSENT] -> PUBLIC
+    [[Column:{DescID: 109, ColumnID: 4294967294}, ABSENT], WRITE_ONLY] -> PUBLIC
+    [[ColumnName:{DescID: 109, Name: tableoid, ColumnID: 4294967294}, ABSENT], ABSENT] -> PUBLIC
+    [[ColumnType:{DescID: 109, ColumnFamilyID: 0, ColumnID: 4294967294}, ABSENT], ABSENT] -> PUBLIC
+    [[Namespace:{DescID: 110, Name: v4, ReferencedDescID: 100}, ABSENT], ABSENT] -> PUBLIC
+    [[Owner:{DescID: 110}, ABSENT], ABSENT] -> PUBLIC
+    [[UserPrivileges:{DescID: 110, Name: admin}, ABSENT], ABSENT] -> PUBLIC
+    [[UserPrivileges:{DescID: 110, Name: root}, ABSENT], ABSENT] -> PUBLIC
+    [[View:{DescID: 110}, ABSENT], DROPPED] -> PUBLIC
+    [[ObjectParent:{DescID: 110, ReferencedDescID: 101}, ABSENT], ABSENT] -> PUBLIC
+    [[Column:{DescID: 110, ColumnID: 1}, ABSENT], WRITE_ONLY] -> PUBLIC
+    [[ColumnName:{DescID: 110, Name: n2, ColumnID: 1}, ABSENT], ABSENT] -> PUBLIC
+    [[ColumnType:{DescID: 110, ReferencedTypeIDs: [104 105], ColumnFamilyID: 0, ColumnID: 1}, ABSENT], ABSENT] -> PUBLIC
+    [[Column:{DescID: 110, ColumnID: 2}, ABSENT], WRITE_ONLY] -> PUBLIC
+    [[ColumnName:{DescID: 110, Name: n1, ColumnID: 2}, ABSENT], ABSENT] -> PUBLIC
+    [[ColumnType:{DescID: 110, ReferencedTypeIDs: [104 105], ColumnFamilyID: 0, ColumnID: 2}, ABSENT], ABSENT] -> PUBLIC
+    [[Column:{DescID: 110, ColumnID: 4294967295}, ABSENT], WRITE_ONLY] -> PUBLIC
+    [[ColumnName:{DescID: 110, Name: crdb_internal_mvcc_timestamp, ColumnID: 4294967295}, ABSENT], ABSENT] -> PUBLIC
+    [[ColumnType:{DescID: 110, ColumnFamilyID: 0, ColumnID: 4294967295}, ABSENT], ABSENT] -> PUBLIC
+    [[Column:{DescID: 110, ColumnID: 4294967294}, ABSENT], WRITE_ONLY] -> PUBLIC
+    [[ColumnName:{DescID: 110, Name: tableoid, ColumnID: 4294967294}, ABSENT], ABSENT] -> PUBLIC
+    [[ColumnType:{DescID: 110, ColumnFamilyID: 0, ColumnID: 4294967294}, ABSENT], ABSENT] -> PUBLIC
+    [[Namespace:{DescID: 113, Name: v5, ReferencedDescID: 100}, ABSENT], ABSENT] -> PUBLIC
+    [[Owner:{DescID: 113}, ABSENT], ABSENT] -> PUBLIC
+    [[UserPrivileges:{DescID: 113, Name: admin}, ABSENT], ABSENT] -> PUBLIC
+    [[UserPrivileges:{DescID: 113, Name: root}, ABSENT], ABSENT] -> PUBLIC
+    [[View:{DescID: 113}, ABSENT], DROPPED] -> PUBLIC
+    [[ObjectParent:{DescID: 113, ReferencedDescID: 101}, ABSENT], ABSENT] -> PUBLIC
+    [[Column:{DescID: 113, ColumnID: 1}, ABSENT], WRITE_ONLY] -> PUBLIC
+    [[ColumnName:{DescID: 113, Name: k, ColumnID: 1}, ABSENT], ABSENT] -> PUBLIC
+    [[ColumnType:{DescID: 113, ColumnFamilyID: 0, ColumnID: 1}, ABSENT], ABSENT] -> PUBLIC
+    [[Column:{DescID: 113, ColumnID: 2}, ABSENT], WRITE_ONLY] -> PUBLIC
+    [[ColumnName:{DescID: 113, Name: n2, ColumnID: 2}, ABSENT], ABSENT] -> PUBLIC
+    [[ColumnType:{DescID: 113, ReferencedTypeIDs: [104 105], ColumnFamilyID: 0, ColumnID: 2}, ABSENT], ABSENT] -> PUBLIC
+    [[Column:{DescID: 113, ColumnID: 3}, ABSENT], WRITE_ONLY] -> PUBLIC
+    [[ColumnName:{DescID: 113, Name: n1, ColumnID: 3}, ABSENT], ABSENT] -> PUBLIC
+    [[ColumnType:{DescID: 113, ReferencedTypeIDs: [104 105], ColumnFamilyID: 0, ColumnID: 3}, ABSENT], ABSENT] -> PUBLIC
+    [[Column:{DescID: 113, ColumnID: 4294967295}, ABSENT], WRITE_ONLY] -> PUBLIC
+    [[ColumnName:{DescID: 113, Name: crdb_internal_mvcc_timestamp, ColumnID: 4294967295}, ABSENT], ABSENT] -> PUBLIC
+    [[ColumnType:{DescID: 113, ColumnFamilyID: 0, ColumnID: 4294967295}, ABSENT], ABSENT] -> PUBLIC
+    [[Column:{DescID: 113, ColumnID: 4294967294}, ABSENT], WRITE_ONLY] -> PUBLIC
+    [[ColumnName:{DescID: 113, Name: tableoid, ColumnID: 4294967294}, ABSENT], ABSENT] -> PUBLIC
+    [[ColumnType:{DescID: 113, ColumnFamilyID: 0, ColumnID: 4294967294}, ABSENT], ABSENT] -> PUBLIC
   ops:
     *scop.UndoAllInTxnImmediateMutationOpSideEffects
       {}
-PreCommitPhase stage 2 of 2 with 50 MutationType ops
+PreCommitPhase stage 2 of 2 with 74 MutationType ops
   transitions:
-    [[Namespace:{DescID: 105, Name: v1, ReferencedDescID: 100}, ABSENT], PUBLIC] -> ABSENT
-    [[Owner:{DescID: 105}, ABSENT], PUBLIC] -> ABSENT
-    [[UserPrivileges:{DescID: 105, Name: admin}, ABSENT], PUBLIC] -> ABSENT
-    [[UserPrivileges:{DescID: 105, Name: root}, ABSENT], PUBLIC] -> ABSENT
-    [[View:{DescID: 105}, ABSENT], PUBLIC] -> DROPPED
-    [[ObjectParent:{DescID: 105, ReferencedDescID: 101}, ABSENT], PUBLIC] -> ABSENT
-    [[Column:{DescID: 105, ColumnID: 1}, ABSENT], PUBLIC] -> ABSENT
-    [[ColumnName:{DescID: 105, Name: name, ColumnID: 1}, ABSENT], PUBLIC] -> ABSENT
-    [[ColumnType:{DescID: 105, ColumnFamilyID: 0, ColumnID: 1}, ABSENT], PUBLIC] -> ABSENT
-    [[Column:{DescID: 105, ColumnID: 4294967295}, ABSENT], PUBLIC] -> ABSENT
-    [[ColumnName:{DescID: 105, Name: crdb_internal_mvcc_timestamp, ColumnID: 4294967295}, ABSENT], PUBLIC] -> ABSENT
-    [[ColumnType:{DescID: 105, ColumnFamilyID: 0, ColumnID: 4294967295}, ABSENT], PUBLIC] -> ABSENT
-    [[Column:{DescID: 105, ColumnID: 4294967294}, ABSENT], PUBLIC] -> ABSENT
-    [[ColumnName:{DescID: 105, Name: tableoid, ColumnID: 4294967294}, ABSENT], PUBLIC] -> ABSENT
-    [[ColumnType:{DescID: 105, ColumnFamilyID: 0, ColumnID: 4294967294}, ABSENT], PUBLIC] -> ABSENT
-    [[Namespace:{DescID: 106, Name: v2, ReferencedDescID: 100}, ABSENT], PUBLIC] -> ABSENT
-    [[Owner:{DescID: 106}, ABSENT], PUBLIC] -> ABSENT
-    [[UserPrivileges:{DescID: 106, Name: admin}, ABSENT], PUBLIC] -> ABSENT
-    [[UserPrivileges:{DescID: 106, Name: root}, ABSENT], PUBLIC] -> ABSENT
-    [[View:{DescID: 106}, ABSENT], PUBLIC] -> DROPPED
-    [[ObjectParent:{DescID: 106, ReferencedDescID: 101}, ABSENT], PUBLIC] -> ABSENT
-    [[Column:{DescID: 106, ColumnID: 1}, ABSENT], PUBLIC] -> ABSENT
-    [[ColumnName:{DescID: 106, Name: n1, ColumnID: 1}, ABSENT], PUBLIC] -> ABSENT
-    [[ColumnType:{DescID: 106, ColumnFamilyID: 0, ColumnID: 1}, ABSENT], PUBLIC] -> ABSENT
-    [[Column:{DescID: 106, ColumnID: 2}, ABSENT], PUBLIC] -> ABSENT
-    [[ColumnName:{DescID: 106, Name: n2, ColumnID: 2}, ABSENT], PUBLIC] -> ABSENT
-    [[ColumnType:{DescID: 106, ColumnFamilyID: 0, ColumnID: 2}, ABSENT], PUBLIC] -> ABSENT
-    [[Column:{DescID: 106, ColumnID: 4294967295}, ABSENT], PUBLIC] -> ABSENT
-    [[ColumnName:{DescID: 106, Name: crdb_internal_mvcc_timestamp, ColumnID: 4294967295}, ABSENT], PUBLIC] -> ABSENT
-    [[ColumnType:{DescID: 106, ColumnFamilyID: 0, ColumnID: 4294967295}, ABSENT], PUBLIC] -> ABSENT
-    [[Column:{DescID: 106, ColumnID: 4294967294}, ABSENT], PUBLIC] -> ABSENT
-    [[ColumnName:{DescID: 106, Name: tableoid, ColumnID: 4294967294}, ABSENT], PUBLIC] -> ABSENT
-    [[ColumnType:{DescID: 106, ColumnFamilyID: 0, ColumnID: 4294967294}, ABSENT], PUBLIC] -> ABSENT
-    [[Namespace:{DescID: 107, Name: v3, ReferencedDescID: 100}, ABSENT], PUBLIC] -> ABSENT
+    [[Namespace:{DescID: 107, Name: v1, ReferencedDescID: 100}, ABSENT], PUBLIC] -> ABSENT
     [[Owner:{DescID: 107}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 107, Name: admin}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 107, Name: root}, ABSENT], PUBLIC] -> ABSENT
@@ -630,163 +727,261 @@ PreCommitPhase stage 2 of 2 with 50 MutationType ops
     [[ObjectParent:{DescID: 107, ReferencedDescID: 101}, ABSENT], PUBLIC] -> ABSENT
     [[Column:{DescID: 107, ColumnID: 1}, ABSENT], PUBLIC] -> ABSENT
     [[ColumnName:{DescID: 107, Name: name, ColumnID: 1}, ABSENT], PUBLIC] -> ABSENT
-    [[ColumnType:{DescID: 107, ColumnFamilyID: 0, ColumnID: 1}, ABSENT], PUBLIC] -> ABSENT
-    [[Column:{DescID: 107, ColumnID: 2}, ABSENT], PUBLIC] -> ABSENT
-    [[ColumnName:{DescID: 107, Name: n1, ColumnID: 2}, ABSENT], PUBLIC] -> ABSENT
-    [[ColumnType:{DescID: 107, ColumnFamilyID: 0, ColumnID: 2}, ABSENT], PUBLIC] -> ABSENT
+    [[ColumnType:{DescID: 107, ReferencedTypeIDs: [104 105], ColumnFamilyID: 0, ColumnID: 1}, ABSENT], PUBLIC] -> ABSENT
     [[Column:{DescID: 107, ColumnID: 4294967295}, ABSENT], PUBLIC] -> ABSENT
     [[ColumnName:{DescID: 107, Name: crdb_internal_mvcc_timestamp, ColumnID: 4294967295}, ABSENT], PUBLIC] -> ABSENT
     [[ColumnType:{DescID: 107, ColumnFamilyID: 0, ColumnID: 4294967295}, ABSENT], PUBLIC] -> ABSENT
     [[Column:{DescID: 107, ColumnID: 4294967294}, ABSENT], PUBLIC] -> ABSENT
     [[ColumnName:{DescID: 107, Name: tableoid, ColumnID: 4294967294}, ABSENT], PUBLIC] -> ABSENT
     [[ColumnType:{DescID: 107, ColumnFamilyID: 0, ColumnID: 4294967294}, ABSENT], PUBLIC] -> ABSENT
-    [[Namespace:{DescID: 108, Name: v4, ReferencedDescID: 100}, ABSENT], PUBLIC] -> ABSENT
+    [[Namespace:{DescID: 108, Name: v2, ReferencedDescID: 100}, ABSENT], PUBLIC] -> ABSENT
     [[Owner:{DescID: 108}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 108, Name: admin}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 108, Name: root}, ABSENT], PUBLIC] -> ABSENT
     [[View:{DescID: 108}, ABSENT], PUBLIC] -> DROPPED
     [[ObjectParent:{DescID: 108, ReferencedDescID: 101}, ABSENT], PUBLIC] -> ABSENT
     [[Column:{DescID: 108, ColumnID: 1}, ABSENT], PUBLIC] -> ABSENT
-    [[ColumnName:{DescID: 108, Name: n2, ColumnID: 1}, ABSENT], PUBLIC] -> ABSENT
-    [[ColumnType:{DescID: 108, ColumnFamilyID: 0, ColumnID: 1}, ABSENT], PUBLIC] -> ABSENT
+    [[ColumnName:{DescID: 108, Name: n1, ColumnID: 1}, ABSENT], PUBLIC] -> ABSENT
+    [[ColumnType:{DescID: 108, ReferencedTypeIDs: [104 105], ColumnFamilyID: 0, ColumnID: 1}, ABSENT], PUBLIC] -> ABSENT
     [[Column:{DescID: 108, ColumnID: 2}, ABSENT], PUBLIC] -> ABSENT
-    [[ColumnName:{DescID: 108, Name: n1, ColumnID: 2}, ABSENT], PUBLIC] -> ABSENT
-    [[ColumnType:{DescID: 108, ColumnFamilyID: 0, ColumnID: 2}, ABSENT], PUBLIC] -> ABSENT
+    [[ColumnName:{DescID: 108, Name: n2, ColumnID: 2}, ABSENT], PUBLIC] -> ABSENT
+    [[ColumnType:{DescID: 108, ReferencedTypeIDs: [104 105], ColumnFamilyID: 0, ColumnID: 2}, ABSENT], PUBLIC] -> ABSENT
     [[Column:{DescID: 108, ColumnID: 4294967295}, ABSENT], PUBLIC] -> ABSENT
     [[ColumnName:{DescID: 108, Name: crdb_internal_mvcc_timestamp, ColumnID: 4294967295}, ABSENT], PUBLIC] -> ABSENT
     [[ColumnType:{DescID: 108, ColumnFamilyID: 0, ColumnID: 4294967295}, ABSENT], PUBLIC] -> ABSENT
     [[Column:{DescID: 108, ColumnID: 4294967294}, ABSENT], PUBLIC] -> ABSENT
     [[ColumnName:{DescID: 108, Name: tableoid, ColumnID: 4294967294}, ABSENT], PUBLIC] -> ABSENT
     [[ColumnType:{DescID: 108, ColumnFamilyID: 0, ColumnID: 4294967294}, ABSENT], PUBLIC] -> ABSENT
-    [[Namespace:{DescID: 111, Name: v5, ReferencedDescID: 100}, ABSENT], PUBLIC] -> ABSENT
-    [[Owner:{DescID: 111}, ABSENT], PUBLIC] -> ABSENT
-    [[UserPrivileges:{DescID: 111, Name: admin}, ABSENT], PUBLIC] -> ABSENT
-    [[UserPrivileges:{DescID: 111, Name: root}, ABSENT], PUBLIC] -> ABSENT
-    [[View:{DescID: 111}, ABSENT], PUBLIC] -> DROPPED
-    [[ObjectParent:{DescID: 111, ReferencedDescID: 101}, ABSENT], PUBLIC] -> ABSENT
-    [[Column:{DescID: 111, ColumnID: 1}, ABSENT], PUBLIC] -> ABSENT
-    [[ColumnName:{DescID: 111, Name: k, ColumnID: 1}, ABSENT], PUBLIC] -> ABSENT
-    [[ColumnType:{DescID: 111, ColumnFamilyID: 0, ColumnID: 1}, ABSENT], PUBLIC] -> ABSENT
-    [[Column:{DescID: 111, ColumnID: 2}, ABSENT], PUBLIC] -> ABSENT
-    [[ColumnName:{DescID: 111, Name: n2, ColumnID: 2}, ABSENT], PUBLIC] -> ABSENT
-    [[ColumnType:{DescID: 111, ColumnFamilyID: 0, ColumnID: 2}, ABSENT], PUBLIC] -> ABSENT
-    [[Column:{DescID: 111, ColumnID: 3}, ABSENT], PUBLIC] -> ABSENT
-    [[ColumnName:{DescID: 111, Name: n1, ColumnID: 3}, ABSENT], PUBLIC] -> ABSENT
-    [[ColumnType:{DescID: 111, ColumnFamilyID: 0, ColumnID: 3}, ABSENT], PUBLIC] -> ABSENT
-    [[Column:{DescID: 111, ColumnID: 4294967295}, ABSENT], PUBLIC] -> ABSENT
-    [[ColumnName:{DescID: 111, Name: crdb_internal_mvcc_timestamp, ColumnID: 4294967295}, ABSENT], PUBLIC] -> ABSENT
-    [[ColumnType:{DescID: 111, ColumnFamilyID: 0, ColumnID: 4294967295}, ABSENT], PUBLIC] -> ABSENT
-    [[Column:{DescID: 111, ColumnID: 4294967294}, ABSENT], PUBLIC] -> ABSENT
-    [[ColumnName:{DescID: 111, Name: tableoid, ColumnID: 4294967294}, ABSENT], PUBLIC] -> ABSENT
-    [[ColumnType:{DescID: 111, ColumnFamilyID: 0, ColumnID: 4294967294}, ABSENT], PUBLIC] -> ABSENT
+    [[Namespace:{DescID: 109, Name: v3, ReferencedDescID: 100}, ABSENT], PUBLIC] -> ABSENT
+    [[Owner:{DescID: 109}, ABSENT], PUBLIC] -> ABSENT
+    [[UserPrivileges:{DescID: 109, Name: admin}, ABSENT], PUBLIC] -> ABSENT
+    [[UserPrivileges:{DescID: 109, Name: root}, ABSENT], PUBLIC] -> ABSENT
+    [[View:{DescID: 109}, ABSENT], PUBLIC] -> DROPPED
+    [[ObjectParent:{DescID: 109, ReferencedDescID: 101}, ABSENT], PUBLIC] -> ABSENT
+    [[Column:{DescID: 109, ColumnID: 1}, ABSENT], PUBLIC] -> ABSENT
+    [[ColumnName:{DescID: 109, Name: name, ColumnID: 1}, ABSENT], PUBLIC] -> ABSENT
+    [[ColumnType:{DescID: 109, ReferencedTypeIDs: [104 105], ColumnFamilyID: 0, ColumnID: 1}, ABSENT], PUBLIC] -> ABSENT
+    [[Column:{DescID: 109, ColumnID: 2}, ABSENT], PUBLIC] -> ABSENT
+    [[ColumnName:{DescID: 109, Name: n1, ColumnID: 2}, ABSENT], PUBLIC] -> ABSENT
+    [[ColumnType:{DescID: 109, ReferencedTypeIDs: [104 105], ColumnFamilyID: 0, ColumnID: 2}, ABSENT], PUBLIC] -> ABSENT
+    [[Column:{DescID: 109, ColumnID: 4294967295}, ABSENT], PUBLIC] -> ABSENT
+    [[ColumnName:{DescID: 109, Name: crdb_internal_mvcc_timestamp, ColumnID: 4294967295}, ABSENT], PUBLIC] -> ABSENT
+    [[ColumnType:{DescID: 109, ColumnFamilyID: 0, ColumnID: 4294967295}, ABSENT], PUBLIC] -> ABSENT
+    [[Column:{DescID: 109, ColumnID: 4294967294}, ABSENT], PUBLIC] -> ABSENT
+    [[ColumnName:{DescID: 109, Name: tableoid, ColumnID: 4294967294}, ABSENT], PUBLIC] -> ABSENT
+    [[ColumnType:{DescID: 109, ColumnFamilyID: 0, ColumnID: 4294967294}, ABSENT], PUBLIC] -> ABSENT
+    [[Namespace:{DescID: 110, Name: v4, ReferencedDescID: 100}, ABSENT], PUBLIC] -> ABSENT
+    [[Owner:{DescID: 110}, ABSENT], PUBLIC] -> ABSENT
+    [[UserPrivileges:{DescID: 110, Name: admin}, ABSENT], PUBLIC] -> ABSENT
+    [[UserPrivileges:{DescID: 110, Name: root}, ABSENT], PUBLIC] -> ABSENT
+    [[View:{DescID: 110}, ABSENT], PUBLIC] -> DROPPED
+    [[ObjectParent:{DescID: 110, ReferencedDescID: 101}, ABSENT], PUBLIC] -> ABSENT
+    [[Column:{DescID: 110, ColumnID: 1}, ABSENT], PUBLIC] -> ABSENT
+    [[ColumnName:{DescID: 110, Name: n2, ColumnID: 1}, ABSENT], PUBLIC] -> ABSENT
+    [[ColumnType:{DescID: 110, ReferencedTypeIDs: [104 105], ColumnFamilyID: 0, ColumnID: 1}, ABSENT], PUBLIC] -> ABSENT
+    [[Column:{DescID: 110, ColumnID: 2}, ABSENT], PUBLIC] -> ABSENT
+    [[ColumnName:{DescID: 110, Name: n1, ColumnID: 2}, ABSENT], PUBLIC] -> ABSENT
+    [[ColumnType:{DescID: 110, ReferencedTypeIDs: [104 105], ColumnFamilyID: 0, ColumnID: 2}, ABSENT], PUBLIC] -> ABSENT
+    [[Column:{DescID: 110, ColumnID: 4294967295}, ABSENT], PUBLIC] -> ABSENT
+    [[ColumnName:{DescID: 110, Name: crdb_internal_mvcc_timestamp, ColumnID: 4294967295}, ABSENT], PUBLIC] -> ABSENT
+    [[ColumnType:{DescID: 110, ColumnFamilyID: 0, ColumnID: 4294967295}, ABSENT], PUBLIC] -> ABSENT
+    [[Column:{DescID: 110, ColumnID: 4294967294}, ABSENT], PUBLIC] -> ABSENT
+    [[ColumnName:{DescID: 110, Name: tableoid, ColumnID: 4294967294}, ABSENT], PUBLIC] -> ABSENT
+    [[ColumnType:{DescID: 110, ColumnFamilyID: 0, ColumnID: 4294967294}, ABSENT], PUBLIC] -> ABSENT
+    [[Namespace:{DescID: 113, Name: v5, ReferencedDescID: 100}, ABSENT], PUBLIC] -> ABSENT
+    [[Owner:{DescID: 113}, ABSENT], PUBLIC] -> ABSENT
+    [[UserPrivileges:{DescID: 113, Name: admin}, ABSENT], PUBLIC] -> ABSENT
+    [[UserPrivileges:{DescID: 113, Name: root}, ABSENT], PUBLIC] -> ABSENT
+    [[View:{DescID: 113}, ABSENT], PUBLIC] -> DROPPED
+    [[ObjectParent:{DescID: 113, ReferencedDescID: 101}, ABSENT], PUBLIC] -> ABSENT
+    [[Column:{DescID: 113, ColumnID: 1}, ABSENT], PUBLIC] -> ABSENT
+    [[ColumnName:{DescID: 113, Name: k, ColumnID: 1}, ABSENT], PUBLIC] -> ABSENT
+    [[ColumnType:{DescID: 113, ColumnFamilyID: 0, ColumnID: 1}, ABSENT], PUBLIC] -> ABSENT
+    [[Column:{DescID: 113, ColumnID: 2}, ABSENT], PUBLIC] -> ABSENT
+    [[ColumnName:{DescID: 113, Name: n2, ColumnID: 2}, ABSENT], PUBLIC] -> ABSENT
+    [[ColumnType:{DescID: 113, ReferencedTypeIDs: [104 105], ColumnFamilyID: 0, ColumnID: 2}, ABSENT], PUBLIC] -> ABSENT
+    [[Column:{DescID: 113, ColumnID: 3}, ABSENT], PUBLIC] -> ABSENT
+    [[ColumnName:{DescID: 113, Name: n1, ColumnID: 3}, ABSENT], PUBLIC] -> ABSENT
+    [[ColumnType:{DescID: 113, ReferencedTypeIDs: [104 105], ColumnFamilyID: 0, ColumnID: 3}, ABSENT], PUBLIC] -> ABSENT
+    [[Column:{DescID: 113, ColumnID: 4294967295}, ABSENT], PUBLIC] -> ABSENT
+    [[ColumnName:{DescID: 113, Name: crdb_internal_mvcc_timestamp, ColumnID: 4294967295}, ABSENT], PUBLIC] -> ABSENT
+    [[ColumnType:{DescID: 113, ColumnFamilyID: 0, ColumnID: 4294967295}, ABSENT], PUBLIC] -> ABSENT
+    [[Column:{DescID: 113, ColumnID: 4294967294}, ABSENT], PUBLIC] -> ABSENT
+    [[ColumnName:{DescID: 113, Name: tableoid, ColumnID: 4294967294}, ABSENT], PUBLIC] -> ABSENT
+    [[ColumnType:{DescID: 113, ColumnFamilyID: 0, ColumnID: 4294967294}, ABSENT], PUBLIC] -> ABSENT
   ops:
     *scop.MarkDescriptorAsDropped
-      DescriptorID: 105
-    *scop.RemoveBackReferencesInRelations
-      BackReferencedID: 105
-      RelationIDs:
-      - 104
-    *scop.RemoveObjectParent
-      ObjectID: 105
-      ParentSchemaID: 101
-    *scop.MarkDescriptorAsDropped
-      DescriptorID: 106
-    *scop.RemoveBackReferencesInRelations
-      BackReferencedID: 106
-      RelationIDs:
-      - 105
-    *scop.RemoveObjectParent
-      ObjectID: 106
-      ParentSchemaID: 101
-    *scop.MarkDescriptorAsDropped
       DescriptorID: 107
+    *scop.RemoveBackReferenceInTypes
+      BackReferencedDescriptorID: 107
+      TypeIDs:
+      - 104
     *scop.RemoveBackReferencesInRelations
       BackReferencedID: 107
       RelationIDs:
-      - 105
       - 106
     *scop.RemoveObjectParent
       ObjectID: 107
       ParentSchemaID: 101
+    *scop.RemoveDroppedColumnType
+      ColumnID: 1
+      TableID: 107
+    *scop.UpdateTableBackReferencesInTypes
+      BackReferencedTableID: 107
+      TypeIDs:
+      - 104
+      - 105
     *scop.MarkDescriptorAsDropped
       DescriptorID: 108
+    *scop.RemoveBackReferenceInTypes
+      BackReferencedDescriptorID: 108
+      TypeIDs:
+      - 104
     *scop.RemoveBackReferencesInRelations
       BackReferencedID: 108
       RelationIDs:
-      - 106
+      - 107
     *scop.RemoveObjectParent
       ObjectID: 108
       ParentSchemaID: 101
-    *scop.MarkDescriptorAsDropped
-      DescriptorID: 111
-    *scop.RemoveBackReferenceInTypes
-      BackReferencedDescriptorID: 111
+    *scop.RemoveDroppedColumnType
+      ColumnID: 1
+      TableID: 108
+    *scop.UpdateTableBackReferencesInTypes
+      BackReferencedTableID: 108
       TypeIDs:
-      - 109
-      - 110
+      - 104
+      - 105
+    *scop.RemoveDroppedColumnType
+      ColumnID: 2
+      TableID: 108
+    *scop.UpdateTableBackReferencesInTypes
+      BackReferencedTableID: 108
+      TypeIDs:
+      - 104
+      - 105
+    *scop.MarkDescriptorAsDropped
+      DescriptorID: 109
+    *scop.RemoveBackReferenceInTypes
+      BackReferencedDescriptorID: 109
+      TypeIDs:
+      - 104
     *scop.RemoveBackReferencesInRelations
-      BackReferencedID: 111
+      BackReferencedID: 109
+      RelationIDs:
+      - 107
+      - 108
+    *scop.RemoveObjectParent
+      ObjectID: 109
+      ParentSchemaID: 101
+    *scop.RemoveDroppedColumnType
+      ColumnID: 1
+      TableID: 109
+    *scop.UpdateTableBackReferencesInTypes
+      BackReferencedTableID: 109
+      TypeIDs:
+      - 104
+      - 105
+    *scop.RemoveDroppedColumnType
+      ColumnID: 2
+      TableID: 109
+    *scop.UpdateTableBackReferencesInTypes
+      BackReferencedTableID: 109
+      TypeIDs:
+      - 104
+      - 105
+    *scop.MarkDescriptorAsDropped
+      DescriptorID: 110
+    *scop.RemoveBackReferenceInTypes
+      BackReferencedDescriptorID: 110
+      TypeIDs:
+      - 104
+    *scop.RemoveBackReferencesInRelations
+      BackReferencedID: 110
       RelationIDs:
       - 108
     *scop.RemoveObjectParent
-      ObjectID: 111
+      ObjectID: 110
       ParentSchemaID: 101
+    *scop.RemoveDroppedColumnType
+      ColumnID: 1
+      TableID: 110
+    *scop.UpdateTableBackReferencesInTypes
+      BackReferencedTableID: 110
+      TypeIDs:
+      - 104
+      - 105
+    *scop.RemoveDroppedColumnType
+      ColumnID: 2
+      TableID: 110
+    *scop.UpdateTableBackReferencesInTypes
+      BackReferencedTableID: 110
+      TypeIDs:
+      - 104
+      - 105
+    *scop.MarkDescriptorAsDropped
+      DescriptorID: 113
+    *scop.RemoveBackReferenceInTypes
+      BackReferencedDescriptorID: 113
+      TypeIDs:
+      - 104
+      - 111
+      - 112
+    *scop.RemoveBackReferencesInRelations
+      BackReferencedID: 113
+      RelationIDs:
+      - 110
+    *scop.RemoveObjectParent
+      ObjectID: 113
+      ParentSchemaID: 101
+    *scop.RemoveDroppedColumnType
+      ColumnID: 2
+      TableID: 113
+    *scop.UpdateTableBackReferencesInTypes
+      BackReferencedTableID: 113
+      TypeIDs:
+      - 104
+      - 105
+    *scop.RemoveDroppedColumnType
+      ColumnID: 3
+      TableID: 113
+    *scop.UpdateTableBackReferencesInTypes
+      BackReferencedTableID: 113
+      TypeIDs:
+      - 104
+      - 105
     *scop.DrainDescriptorName
       Namespace:
         DatabaseID: 100
-        DescriptorID: 105
+        DescriptorID: 107
         Name: v1
         SchemaID: 101
     *scop.DrainDescriptorName
       Namespace:
         DatabaseID: 100
-        DescriptorID: 106
+        DescriptorID: 108
         Name: v2
         SchemaID: 101
     *scop.DrainDescriptorName
       Namespace:
         DatabaseID: 100
-        DescriptorID: 107
+        DescriptorID: 109
         Name: v3
         SchemaID: 101
     *scop.DrainDescriptorName
       Namespace:
         DatabaseID: 100
-        DescriptorID: 108
+        DescriptorID: 110
         Name: v4
         SchemaID: 101
     *scop.DrainDescriptorName
       Namespace:
         DatabaseID: 100
-        DescriptorID: 111
+        DescriptorID: 113
         Name: v5
         SchemaID: 101
     *scop.MakeDeleteOnlyColumnAbsent
       ColumnID: 1
-      TableID: 105
-    *scop.MakeDeleteOnlyColumnAbsent
-      ColumnID: 4294967295
-      TableID: 105
-    *scop.MakeDeleteOnlyColumnAbsent
-      ColumnID: 4294967294
-      TableID: 105
-    *scop.MakeDeleteOnlyColumnAbsent
-      ColumnID: 1
-      TableID: 106
-    *scop.MakeDeleteOnlyColumnAbsent
-      ColumnID: 2
-      TableID: 106
-    *scop.MakeDeleteOnlyColumnAbsent
-      ColumnID: 4294967295
-      TableID: 106
-    *scop.MakeDeleteOnlyColumnAbsent
-      ColumnID: 4294967294
-      TableID: 106
-    *scop.MakeDeleteOnlyColumnAbsent
-      ColumnID: 1
-      TableID: 107
-    *scop.MakeDeleteOnlyColumnAbsent
-      ColumnID: 2
       TableID: 107
     *scop.MakeDeleteOnlyColumnAbsent
       ColumnID: 4294967295
@@ -808,19 +1003,43 @@ PreCommitPhase stage 2 of 2 with 50 MutationType ops
       TableID: 108
     *scop.MakeDeleteOnlyColumnAbsent
       ColumnID: 1
-      TableID: 111
+      TableID: 109
     *scop.MakeDeleteOnlyColumnAbsent
       ColumnID: 2
-      TableID: 111
+      TableID: 109
+    *scop.MakeDeleteOnlyColumnAbsent
+      ColumnID: 4294967295
+      TableID: 109
+    *scop.MakeDeleteOnlyColumnAbsent
+      ColumnID: 4294967294
+      TableID: 109
+    *scop.MakeDeleteOnlyColumnAbsent
+      ColumnID: 1
+      TableID: 110
+    *scop.MakeDeleteOnlyColumnAbsent
+      ColumnID: 2
+      TableID: 110
+    *scop.MakeDeleteOnlyColumnAbsent
+      ColumnID: 4294967295
+      TableID: 110
+    *scop.MakeDeleteOnlyColumnAbsent
+      ColumnID: 4294967294
+      TableID: 110
+    *scop.MakeDeleteOnlyColumnAbsent
+      ColumnID: 1
+      TableID: 113
+    *scop.MakeDeleteOnlyColumnAbsent
+      ColumnID: 2
+      TableID: 113
     *scop.MakeDeleteOnlyColumnAbsent
       ColumnID: 3
-      TableID: 111
+      TableID: 113
     *scop.MakeDeleteOnlyColumnAbsent
       ColumnID: 4294967295
-      TableID: 111
+      TableID: 113
     *scop.MakeDeleteOnlyColumnAbsent
       ColumnID: 4294967294
-      TableID: 111
+      TableID: 113
     *scop.SetJobStateOnDescriptor
       DescriptorID: 104
       Initialize: true
@@ -844,6 +1063,12 @@ PreCommitPhase stage 2 of 2 with 50 MutationType ops
       Initialize: true
     *scop.SetJobStateOnDescriptor
       DescriptorID: 111
+      Initialize: true
+    *scop.SetJobStateOnDescriptor
+      DescriptorID: 112
+      Initialize: true
+    *scop.SetJobStateOnDescriptor
+      DescriptorID: 113
       Initialize: true
     *scop.CreateSchemaChangerJob
       Authorization:
@@ -857,6 +1082,8 @@ PreCommitPhase stage 2 of 2 with 50 MutationType ops
       - 109
       - 110
       - 111
+      - 112
+      - 113
       JobID: 1
       NonCancelable: true
       RunningStatus: PostCommitNonRevertiblePhase stage 1 of 1 with 5 MutationType ops pending
@@ -864,24 +1091,24 @@ PreCommitPhase stage 2 of 2 with 50 MutationType ops
       - statement: DROP VIEW defaultdb.v1 CASCADE
         redactedstatement: DROP VIEW ‹defaultdb›.public.‹v1› CASCADE
         statementtag: DROP VIEW
-PostCommitNonRevertiblePhase stage 1 of 1 with 14 MutationType ops
+PostCommitNonRevertiblePhase stage 1 of 1 with 16 MutationType ops
   transitions:
-    [[View:{DescID: 105}, ABSENT], DROPPED] -> ABSENT
-    [[View:{DescID: 106}, ABSENT], DROPPED] -> ABSENT
     [[View:{DescID: 107}, ABSENT], DROPPED] -> ABSENT
     [[View:{DescID: 108}, ABSENT], DROPPED] -> ABSENT
-    [[View:{DescID: 111}, ABSENT], DROPPED] -> ABSENT
+    [[View:{DescID: 109}, ABSENT], DROPPED] -> ABSENT
+    [[View:{DescID: 110}, ABSENT], DROPPED] -> ABSENT
+    [[View:{DescID: 113}, ABSENT], DROPPED] -> ABSENT
   ops:
-    *scop.DeleteDescriptor
-      DescriptorID: 105
-    *scop.DeleteDescriptor
-      DescriptorID: 106
     *scop.DeleteDescriptor
       DescriptorID: 107
     *scop.DeleteDescriptor
       DescriptorID: 108
     *scop.DeleteDescriptor
-      DescriptorID: 111
+      DescriptorID: 109
+    *scop.DeleteDescriptor
+      DescriptorID: 110
+    *scop.DeleteDescriptor
+      DescriptorID: 113
     *scop.RemoveJobStateFromDescriptor
       DescriptorID: 104
       JobID: 1
@@ -906,6 +1133,12 @@ PostCommitNonRevertiblePhase stage 1 of 1 with 14 MutationType ops
     *scop.RemoveJobStateFromDescriptor
       DescriptorID: 111
       JobID: 1
+    *scop.RemoveJobStateFromDescriptor
+      DescriptorID: 112
+      JobID: 1
+    *scop.RemoveJobStateFromDescriptor
+      DescriptorID: 113
+      JobID: 1
     *scop.UpdateSchemaChangerJob
       DescriptorIDsToRemove:
       - 104
@@ -916,96 +1149,14 @@ PostCommitNonRevertiblePhase stage 1 of 1 with 14 MutationType ops
       - 109
       - 110
       - 111
+      - 112
+      - 113
       IsNonCancelable: true
       JobID: 1
 
 deps
 DROP VIEW defaultdb.v1 CASCADE
 ----
-- from: [Column:{DescID: 105, ColumnID: 1}, ABSENT]
-  to:   [View:{DescID: 105}, ABSENT]
-  kind: Precedence
-  rule: non-data dependents removed before descriptor
-- from: [Column:{DescID: 105, ColumnID: 1}, WRITE_ONLY]
-  to:   [ColumnName:{DescID: 105, Name: name, ColumnID: 1}, ABSENT]
-  kind: Precedence
-  rule: column no longer public before dependents
-- from: [Column:{DescID: 105, ColumnID: 1}, WRITE_ONLY]
-  to:   [ColumnType:{DescID: 105, ColumnFamilyID: 0, ColumnID: 1}, ABSENT]
-  kind: Precedence
-  rule: column no longer public before dependents
-- from: [Column:{DescID: 105, ColumnID: 4294967294}, ABSENT]
-  to:   [View:{DescID: 105}, ABSENT]
-  kind: Precedence
-  rule: non-data dependents removed before descriptor
-- from: [Column:{DescID: 105, ColumnID: 4294967294}, WRITE_ONLY]
-  to:   [ColumnName:{DescID: 105, Name: tableoid, ColumnID: 4294967294}, ABSENT]
-  kind: Precedence
-  rule: column no longer public before dependents
-- from: [Column:{DescID: 105, ColumnID: 4294967294}, WRITE_ONLY]
-  to:   [ColumnType:{DescID: 105, ColumnFamilyID: 0, ColumnID: 4294967294}, ABSENT]
-  kind: Precedence
-  rule: column no longer public before dependents
-- from: [Column:{DescID: 105, ColumnID: 4294967295}, ABSENT]
-  to:   [View:{DescID: 105}, ABSENT]
-  kind: Precedence
-  rule: non-data dependents removed before descriptor
-- from: [Column:{DescID: 105, ColumnID: 4294967295}, WRITE_ONLY]
-  to:   [ColumnName:{DescID: 105, Name: crdb_internal_mvcc_timestamp, ColumnID: 4294967295}, ABSENT]
-  kind: Precedence
-  rule: column no longer public before dependents
-- from: [Column:{DescID: 105, ColumnID: 4294967295}, WRITE_ONLY]
-  to:   [ColumnType:{DescID: 105, ColumnFamilyID: 0, ColumnID: 4294967295}, ABSENT]
-  kind: Precedence
-  rule: column no longer public before dependents
-- from: [Column:{DescID: 106, ColumnID: 1}, ABSENT]
-  to:   [View:{DescID: 106}, ABSENT]
-  kind: Precedence
-  rule: non-data dependents removed before descriptor
-- from: [Column:{DescID: 106, ColumnID: 1}, WRITE_ONLY]
-  to:   [ColumnName:{DescID: 106, Name: n1, ColumnID: 1}, ABSENT]
-  kind: Precedence
-  rule: column no longer public before dependents
-- from: [Column:{DescID: 106, ColumnID: 1}, WRITE_ONLY]
-  to:   [ColumnType:{DescID: 106, ColumnFamilyID: 0, ColumnID: 1}, ABSENT]
-  kind: Precedence
-  rule: column no longer public before dependents
-- from: [Column:{DescID: 106, ColumnID: 2}, ABSENT]
-  to:   [View:{DescID: 106}, ABSENT]
-  kind: Precedence
-  rule: non-data dependents removed before descriptor
-- from: [Column:{DescID: 106, ColumnID: 2}, WRITE_ONLY]
-  to:   [ColumnName:{DescID: 106, Name: n2, ColumnID: 2}, ABSENT]
-  kind: Precedence
-  rule: column no longer public before dependents
-- from: [Column:{DescID: 106, ColumnID: 2}, WRITE_ONLY]
-  to:   [ColumnType:{DescID: 106, ColumnFamilyID: 0, ColumnID: 2}, ABSENT]
-  kind: Precedence
-  rule: column no longer public before dependents
-- from: [Column:{DescID: 106, ColumnID: 4294967294}, ABSENT]
-  to:   [View:{DescID: 106}, ABSENT]
-  kind: Precedence
-  rule: non-data dependents removed before descriptor
-- from: [Column:{DescID: 106, ColumnID: 4294967294}, WRITE_ONLY]
-  to:   [ColumnName:{DescID: 106, Name: tableoid, ColumnID: 4294967294}, ABSENT]
-  kind: Precedence
-  rule: column no longer public before dependents
-- from: [Column:{DescID: 106, ColumnID: 4294967294}, WRITE_ONLY]
-  to:   [ColumnType:{DescID: 106, ColumnFamilyID: 0, ColumnID: 4294967294}, ABSENT]
-  kind: Precedence
-  rule: column no longer public before dependents
-- from: [Column:{DescID: 106, ColumnID: 4294967295}, ABSENT]
-  to:   [View:{DescID: 106}, ABSENT]
-  kind: Precedence
-  rule: non-data dependents removed before descriptor
-- from: [Column:{DescID: 106, ColumnID: 4294967295}, WRITE_ONLY]
-  to:   [ColumnName:{DescID: 106, Name: crdb_internal_mvcc_timestamp, ColumnID: 4294967295}, ABSENT]
-  kind: Precedence
-  rule: column no longer public before dependents
-- from: [Column:{DescID: 106, ColumnID: 4294967295}, WRITE_ONLY]
-  to:   [ColumnType:{DescID: 106, ColumnFamilyID: 0, ColumnID: 4294967295}, ABSENT]
-  kind: Precedence
-  rule: column no longer public before dependents
 - from: [Column:{DescID: 107, ColumnID: 1}, ABSENT]
   to:   [View:{DescID: 107}, ABSENT]
   kind: Precedence
@@ -1015,19 +1166,7 @@ DROP VIEW defaultdb.v1 CASCADE
   kind: Precedence
   rule: column no longer public before dependents
 - from: [Column:{DescID: 107, ColumnID: 1}, WRITE_ONLY]
-  to:   [ColumnType:{DescID: 107, ColumnFamilyID: 0, ColumnID: 1}, ABSENT]
-  kind: Precedence
-  rule: column no longer public before dependents
-- from: [Column:{DescID: 107, ColumnID: 2}, ABSENT]
-  to:   [View:{DescID: 107}, ABSENT]
-  kind: Precedence
-  rule: non-data dependents removed before descriptor
-- from: [Column:{DescID: 107, ColumnID: 2}, WRITE_ONLY]
-  to:   [ColumnName:{DescID: 107, Name: n1, ColumnID: 2}, ABSENT]
-  kind: Precedence
-  rule: column no longer public before dependents
-- from: [Column:{DescID: 107, ColumnID: 2}, WRITE_ONLY]
-  to:   [ColumnType:{DescID: 107, ColumnFamilyID: 0, ColumnID: 2}, ABSENT]
+  to:   [ColumnType:{DescID: 107, ReferencedTypeIDs: [104 105], ColumnFamilyID: 0, ColumnID: 1}, ABSENT]
   kind: Precedence
   rule: column no longer public before dependents
 - from: [Column:{DescID: 107, ColumnID: 4294967294}, ABSENT]
@@ -1059,11 +1198,11 @@ DROP VIEW defaultdb.v1 CASCADE
   kind: Precedence
   rule: non-data dependents removed before descriptor
 - from: [Column:{DescID: 108, ColumnID: 1}, WRITE_ONLY]
-  to:   [ColumnName:{DescID: 108, Name: n2, ColumnID: 1}, ABSENT]
+  to:   [ColumnName:{DescID: 108, Name: n1, ColumnID: 1}, ABSENT]
   kind: Precedence
   rule: column no longer public before dependents
 - from: [Column:{DescID: 108, ColumnID: 1}, WRITE_ONLY]
-  to:   [ColumnType:{DescID: 108, ColumnFamilyID: 0, ColumnID: 1}, ABSENT]
+  to:   [ColumnType:{DescID: 108, ReferencedTypeIDs: [104 105], ColumnFamilyID: 0, ColumnID: 1}, ABSENT]
   kind: Precedence
   rule: column no longer public before dependents
 - from: [Column:{DescID: 108, ColumnID: 2}, ABSENT]
@@ -1071,11 +1210,11 @@ DROP VIEW defaultdb.v1 CASCADE
   kind: Precedence
   rule: non-data dependents removed before descriptor
 - from: [Column:{DescID: 108, ColumnID: 2}, WRITE_ONLY]
-  to:   [ColumnName:{DescID: 108, Name: n1, ColumnID: 2}, ABSENT]
+  to:   [ColumnName:{DescID: 108, Name: n2, ColumnID: 2}, ABSENT]
   kind: Precedence
   rule: column no longer public before dependents
 - from: [Column:{DescID: 108, ColumnID: 2}, WRITE_ONLY]
-  to:   [ColumnType:{DescID: 108, ColumnFamilyID: 0, ColumnID: 2}, ABSENT]
+  to:   [ColumnType:{DescID: 108, ReferencedTypeIDs: [104 105], ColumnFamilyID: 0, ColumnID: 2}, ABSENT]
   kind: Precedence
   rule: column no longer public before dependents
 - from: [Column:{DescID: 108, ColumnID: 4294967294}, ABSENT]
@@ -1102,135 +1241,167 @@ DROP VIEW defaultdb.v1 CASCADE
   to:   [ColumnType:{DescID: 108, ColumnFamilyID: 0, ColumnID: 4294967295}, ABSENT]
   kind: Precedence
   rule: column no longer public before dependents
-- from: [Column:{DescID: 111, ColumnID: 1}, ABSENT]
-  to:   [View:{DescID: 111}, ABSENT]
+- from: [Column:{DescID: 109, ColumnID: 1}, ABSENT]
+  to:   [View:{DescID: 109}, ABSENT]
   kind: Precedence
   rule: non-data dependents removed before descriptor
-- from: [Column:{DescID: 111, ColumnID: 1}, WRITE_ONLY]
-  to:   [ColumnName:{DescID: 111, Name: k, ColumnID: 1}, ABSENT]
+- from: [Column:{DescID: 109, ColumnID: 1}, WRITE_ONLY]
+  to:   [ColumnName:{DescID: 109, Name: name, ColumnID: 1}, ABSENT]
   kind: Precedence
   rule: column no longer public before dependents
-- from: [Column:{DescID: 111, ColumnID: 1}, WRITE_ONLY]
-  to:   [ColumnType:{DescID: 111, ColumnFamilyID: 0, ColumnID: 1}, ABSENT]
+- from: [Column:{DescID: 109, ColumnID: 1}, WRITE_ONLY]
+  to:   [ColumnType:{DescID: 109, ReferencedTypeIDs: [104 105], ColumnFamilyID: 0, ColumnID: 1}, ABSENT]
   kind: Precedence
   rule: column no longer public before dependents
-- from: [Column:{DescID: 111, ColumnID: 2}, ABSENT]
-  to:   [View:{DescID: 111}, ABSENT]
+- from: [Column:{DescID: 109, ColumnID: 2}, ABSENT]
+  to:   [View:{DescID: 109}, ABSENT]
   kind: Precedence
   rule: non-data dependents removed before descriptor
-- from: [Column:{DescID: 111, ColumnID: 2}, WRITE_ONLY]
-  to:   [ColumnName:{DescID: 111, Name: n2, ColumnID: 2}, ABSENT]
+- from: [Column:{DescID: 109, ColumnID: 2}, WRITE_ONLY]
+  to:   [ColumnName:{DescID: 109, Name: n1, ColumnID: 2}, ABSENT]
   kind: Precedence
   rule: column no longer public before dependents
-- from: [Column:{DescID: 111, ColumnID: 2}, WRITE_ONLY]
-  to:   [ColumnType:{DescID: 111, ColumnFamilyID: 0, ColumnID: 2}, ABSENT]
+- from: [Column:{DescID: 109, ColumnID: 2}, WRITE_ONLY]
+  to:   [ColumnType:{DescID: 109, ReferencedTypeIDs: [104 105], ColumnFamilyID: 0, ColumnID: 2}, ABSENT]
   kind: Precedence
   rule: column no longer public before dependents
-- from: [Column:{DescID: 111, ColumnID: 3}, ABSENT]
-  to:   [View:{DescID: 111}, ABSENT]
+- from: [Column:{DescID: 109, ColumnID: 4294967294}, ABSENT]
+  to:   [View:{DescID: 109}, ABSENT]
   kind: Precedence
   rule: non-data dependents removed before descriptor
-- from: [Column:{DescID: 111, ColumnID: 3}, WRITE_ONLY]
-  to:   [ColumnName:{DescID: 111, Name: n1, ColumnID: 3}, ABSENT]
+- from: [Column:{DescID: 109, ColumnID: 4294967294}, WRITE_ONLY]
+  to:   [ColumnName:{DescID: 109, Name: tableoid, ColumnID: 4294967294}, ABSENT]
   kind: Precedence
   rule: column no longer public before dependents
-- from: [Column:{DescID: 111, ColumnID: 3}, WRITE_ONLY]
-  to:   [ColumnType:{DescID: 111, ColumnFamilyID: 0, ColumnID: 3}, ABSENT]
+- from: [Column:{DescID: 109, ColumnID: 4294967294}, WRITE_ONLY]
+  to:   [ColumnType:{DescID: 109, ColumnFamilyID: 0, ColumnID: 4294967294}, ABSENT]
   kind: Precedence
   rule: column no longer public before dependents
-- from: [Column:{DescID: 111, ColumnID: 4294967294}, ABSENT]
-  to:   [View:{DescID: 111}, ABSENT]
+- from: [Column:{DescID: 109, ColumnID: 4294967295}, ABSENT]
+  to:   [View:{DescID: 109}, ABSENT]
   kind: Precedence
   rule: non-data dependents removed before descriptor
-- from: [Column:{DescID: 111, ColumnID: 4294967294}, WRITE_ONLY]
-  to:   [ColumnName:{DescID: 111, Name: tableoid, ColumnID: 4294967294}, ABSENT]
+- from: [Column:{DescID: 109, ColumnID: 4294967295}, WRITE_ONLY]
+  to:   [ColumnName:{DescID: 109, Name: crdb_internal_mvcc_timestamp, ColumnID: 4294967295}, ABSENT]
   kind: Precedence
   rule: column no longer public before dependents
-- from: [Column:{DescID: 111, ColumnID: 4294967294}, WRITE_ONLY]
-  to:   [ColumnType:{DescID: 111, ColumnFamilyID: 0, ColumnID: 4294967294}, ABSENT]
+- from: [Column:{DescID: 109, ColumnID: 4294967295}, WRITE_ONLY]
+  to:   [ColumnType:{DescID: 109, ColumnFamilyID: 0, ColumnID: 4294967295}, ABSENT]
   kind: Precedence
   rule: column no longer public before dependents
-- from: [Column:{DescID: 111, ColumnID: 4294967295}, ABSENT]
-  to:   [View:{DescID: 111}, ABSENT]
+- from: [Column:{DescID: 110, ColumnID: 1}, ABSENT]
+  to:   [View:{DescID: 110}, ABSENT]
   kind: Precedence
   rule: non-data dependents removed before descriptor
-- from: [Column:{DescID: 111, ColumnID: 4294967295}, WRITE_ONLY]
-  to:   [ColumnName:{DescID: 111, Name: crdb_internal_mvcc_timestamp, ColumnID: 4294967295}, ABSENT]
+- from: [Column:{DescID: 110, ColumnID: 1}, WRITE_ONLY]
+  to:   [ColumnName:{DescID: 110, Name: n2, ColumnID: 1}, ABSENT]
   kind: Precedence
   rule: column no longer public before dependents
-- from: [Column:{DescID: 111, ColumnID: 4294967295}, WRITE_ONLY]
-  to:   [ColumnType:{DescID: 111, ColumnFamilyID: 0, ColumnID: 4294967295}, ABSENT]
+- from: [Column:{DescID: 110, ColumnID: 1}, WRITE_ONLY]
+  to:   [ColumnType:{DescID: 110, ReferencedTypeIDs: [104 105], ColumnFamilyID: 0, ColumnID: 1}, ABSENT]
   kind: Precedence
   rule: column no longer public before dependents
-- from: [ColumnName:{DescID: 105, Name: crdb_internal_mvcc_timestamp, ColumnID: 4294967295}, ABSENT]
-  to:   [Column:{DescID: 105, ColumnID: 4294967295}, ABSENT]
-  kind: Precedence
-  rule: dependents removed before column
-- from: [ColumnName:{DescID: 105, Name: crdb_internal_mvcc_timestamp, ColumnID: 4294967295}, ABSENT]
-  to:   [View:{DescID: 105}, ABSENT]
+- from: [Column:{DescID: 110, ColumnID: 2}, ABSENT]
+  to:   [View:{DescID: 110}, ABSENT]
   kind: Precedence
   rule: non-data dependents removed before descriptor
-- from: [ColumnName:{DescID: 105, Name: name, ColumnID: 1}, ABSENT]
-  to:   [Column:{DescID: 105, ColumnID: 1}, ABSENT]
+- from: [Column:{DescID: 110, ColumnID: 2}, WRITE_ONLY]
+  to:   [ColumnName:{DescID: 110, Name: n1, ColumnID: 2}, ABSENT]
   kind: Precedence
-  rule: dependents removed before column
-- from: [ColumnName:{DescID: 105, Name: name, ColumnID: 1}, ABSENT]
-  to:   [View:{DescID: 105}, ABSENT]
+  rule: column no longer public before dependents
+- from: [Column:{DescID: 110, ColumnID: 2}, WRITE_ONLY]
+  to:   [ColumnType:{DescID: 110, ReferencedTypeIDs: [104 105], ColumnFamilyID: 0, ColumnID: 2}, ABSENT]
   kind: Precedence
-  rule: non-data dependents removed before descriptor
-- from: [ColumnName:{DescID: 105, Name: tableoid, ColumnID: 4294967294}, ABSENT]
-  to:   [Column:{DescID: 105, ColumnID: 4294967294}, ABSENT]
-  kind: Precedence
-  rule: dependents removed before column
-- from: [ColumnName:{DescID: 105, Name: tableoid, ColumnID: 4294967294}, ABSENT]
-  to:   [View:{DescID: 105}, ABSENT]
+  rule: column no longer public before dependents
+- from: [Column:{DescID: 110, ColumnID: 4294967294}, ABSENT]
+  to:   [View:{DescID: 110}, ABSENT]
   kind: Precedence
   rule: non-data dependents removed before descriptor
-- from: [ColumnName:{DescID: 106, Name: crdb_internal_mvcc_timestamp, ColumnID: 4294967295}, ABSENT]
-  to:   [Column:{DescID: 106, ColumnID: 4294967295}, ABSENT]
+- from: [Column:{DescID: 110, ColumnID: 4294967294}, WRITE_ONLY]
+  to:   [ColumnName:{DescID: 110, Name: tableoid, ColumnID: 4294967294}, ABSENT]
   kind: Precedence
-  rule: dependents removed before column
-- from: [ColumnName:{DescID: 106, Name: crdb_internal_mvcc_timestamp, ColumnID: 4294967295}, ABSENT]
-  to:   [View:{DescID: 106}, ABSENT]
+  rule: column no longer public before dependents
+- from: [Column:{DescID: 110, ColumnID: 4294967294}, WRITE_ONLY]
+  to:   [ColumnType:{DescID: 110, ColumnFamilyID: 0, ColumnID: 4294967294}, ABSENT]
   kind: Precedence
-  rule: non-data dependents removed before descriptor
-- from: [ColumnName:{DescID: 106, Name: n1, ColumnID: 1}, ABSENT]
-  to:   [Column:{DescID: 106, ColumnID: 1}, ABSENT]
-  kind: Precedence
-  rule: dependents removed before column
-- from: [ColumnName:{DescID: 106, Name: n1, ColumnID: 1}, ABSENT]
-  to:   [View:{DescID: 106}, ABSENT]
+  rule: column no longer public before dependents
+- from: [Column:{DescID: 110, ColumnID: 4294967295}, ABSENT]
+  to:   [View:{DescID: 110}, ABSENT]
   kind: Precedence
   rule: non-data dependents removed before descriptor
-- from: [ColumnName:{DescID: 106, Name: n2, ColumnID: 2}, ABSENT]
-  to:   [Column:{DescID: 106, ColumnID: 2}, ABSENT]
+- from: [Column:{DescID: 110, ColumnID: 4294967295}, WRITE_ONLY]
+  to:   [ColumnName:{DescID: 110, Name: crdb_internal_mvcc_timestamp, ColumnID: 4294967295}, ABSENT]
   kind: Precedence
-  rule: dependents removed before column
-- from: [ColumnName:{DescID: 106, Name: n2, ColumnID: 2}, ABSENT]
-  to:   [View:{DescID: 106}, ABSENT]
+  rule: column no longer public before dependents
+- from: [Column:{DescID: 110, ColumnID: 4294967295}, WRITE_ONLY]
+  to:   [ColumnType:{DescID: 110, ColumnFamilyID: 0, ColumnID: 4294967295}, ABSENT]
   kind: Precedence
-  rule: non-data dependents removed before descriptor
-- from: [ColumnName:{DescID: 106, Name: tableoid, ColumnID: 4294967294}, ABSENT]
-  to:   [Column:{DescID: 106, ColumnID: 4294967294}, ABSENT]
-  kind: Precedence
-  rule: dependents removed before column
-- from: [ColumnName:{DescID: 106, Name: tableoid, ColumnID: 4294967294}, ABSENT]
-  to:   [View:{DescID: 106}, ABSENT]
+  rule: column no longer public before dependents
+- from: [Column:{DescID: 113, ColumnID: 1}, ABSENT]
+  to:   [View:{DescID: 113}, ABSENT]
   kind: Precedence
   rule: non-data dependents removed before descriptor
+- from: [Column:{DescID: 113, ColumnID: 1}, WRITE_ONLY]
+  to:   [ColumnName:{DescID: 113, Name: k, ColumnID: 1}, ABSENT]
+  kind: Precedence
+  rule: column no longer public before dependents
+- from: [Column:{DescID: 113, ColumnID: 1}, WRITE_ONLY]
+  to:   [ColumnType:{DescID: 113, ColumnFamilyID: 0, ColumnID: 1}, ABSENT]
+  kind: Precedence
+  rule: column no longer public before dependents
+- from: [Column:{DescID: 113, ColumnID: 2}, ABSENT]
+  to:   [View:{DescID: 113}, ABSENT]
+  kind: Precedence
+  rule: non-data dependents removed before descriptor
+- from: [Column:{DescID: 113, ColumnID: 2}, WRITE_ONLY]
+  to:   [ColumnName:{DescID: 113, Name: n2, ColumnID: 2}, ABSENT]
+  kind: Precedence
+  rule: column no longer public before dependents
+- from: [Column:{DescID: 113, ColumnID: 2}, WRITE_ONLY]
+  to:   [ColumnType:{DescID: 113, ReferencedTypeIDs: [104 105], ColumnFamilyID: 0, ColumnID: 2}, ABSENT]
+  kind: Precedence
+  rule: column no longer public before dependents
+- from: [Column:{DescID: 113, ColumnID: 3}, ABSENT]
+  to:   [View:{DescID: 113}, ABSENT]
+  kind: Precedence
+  rule: non-data dependents removed before descriptor
+- from: [Column:{DescID: 113, ColumnID: 3}, WRITE_ONLY]
+  to:   [ColumnName:{DescID: 113, Name: n1, ColumnID: 3}, ABSENT]
+  kind: Precedence
+  rule: column no longer public before dependents
+- from: [Column:{DescID: 113, ColumnID: 3}, WRITE_ONLY]
+  to:   [ColumnType:{DescID: 113, ReferencedTypeIDs: [104 105], ColumnFamilyID: 0, ColumnID: 3}, ABSENT]
+  kind: Precedence
+  rule: column no longer public before dependents
+- from: [Column:{DescID: 113, ColumnID: 4294967294}, ABSENT]
+  to:   [View:{DescID: 113}, ABSENT]
+  kind: Precedence
+  rule: non-data dependents removed before descriptor
+- from: [Column:{DescID: 113, ColumnID: 4294967294}, WRITE_ONLY]
+  to:   [ColumnName:{DescID: 113, Name: tableoid, ColumnID: 4294967294}, ABSENT]
+  kind: Precedence
+  rule: column no longer public before dependents
+- from: [Column:{DescID: 113, ColumnID: 4294967294}, WRITE_ONLY]
+  to:   [ColumnType:{DescID: 113, ColumnFamilyID: 0, ColumnID: 4294967294}, ABSENT]
+  kind: Precedence
+  rule: column no longer public before dependents
+- from: [Column:{DescID: 113, ColumnID: 4294967295}, ABSENT]
+  to:   [View:{DescID: 113}, ABSENT]
+  kind: Precedence
+  rule: non-data dependents removed before descriptor
+- from: [Column:{DescID: 113, ColumnID: 4294967295}, WRITE_ONLY]
+  to:   [ColumnName:{DescID: 113, Name: crdb_internal_mvcc_timestamp, ColumnID: 4294967295}, ABSENT]
+  kind: Precedence
+  rule: column no longer public before dependents
+- from: [Column:{DescID: 113, ColumnID: 4294967295}, WRITE_ONLY]
+  to:   [ColumnType:{DescID: 113, ColumnFamilyID: 0, ColumnID: 4294967295}, ABSENT]
+  kind: Precedence
+  rule: column no longer public before dependents
 - from: [ColumnName:{DescID: 107, Name: crdb_internal_mvcc_timestamp, ColumnID: 4294967295}, ABSENT]
   to:   [Column:{DescID: 107, ColumnID: 4294967295}, ABSENT]
   kind: Precedence
   rule: dependents removed before column
 - from: [ColumnName:{DescID: 107, Name: crdb_internal_mvcc_timestamp, ColumnID: 4294967295}, ABSENT]
-  to:   [View:{DescID: 107}, ABSENT]
-  kind: Precedence
-  rule: non-data dependents removed before descriptor
-- from: [ColumnName:{DescID: 107, Name: n1, ColumnID: 2}, ABSENT]
-  to:   [Column:{DescID: 107, ColumnID: 2}, ABSENT]
-  kind: Precedence
-  rule: dependents removed before column
-- from: [ColumnName:{DescID: 107, Name: n1, ColumnID: 2}, ABSENT]
   to:   [View:{DescID: 107}, ABSENT]
   kind: Precedence
   rule: non-data dependents removed before descriptor
@@ -1258,19 +1429,19 @@ DROP VIEW defaultdb.v1 CASCADE
   to:   [View:{DescID: 108}, ABSENT]
   kind: Precedence
   rule: non-data dependents removed before descriptor
-- from: [ColumnName:{DescID: 108, Name: n1, ColumnID: 2}, ABSENT]
-  to:   [Column:{DescID: 108, ColumnID: 2}, ABSENT]
-  kind: Precedence
-  rule: dependents removed before column
-- from: [ColumnName:{DescID: 108, Name: n1, ColumnID: 2}, ABSENT]
-  to:   [View:{DescID: 108}, ABSENT]
-  kind: Precedence
-  rule: non-data dependents removed before descriptor
-- from: [ColumnName:{DescID: 108, Name: n2, ColumnID: 1}, ABSENT]
+- from: [ColumnName:{DescID: 108, Name: n1, ColumnID: 1}, ABSENT]
   to:   [Column:{DescID: 108, ColumnID: 1}, ABSENT]
   kind: Precedence
   rule: dependents removed before column
-- from: [ColumnName:{DescID: 108, Name: n2, ColumnID: 1}, ABSENT]
+- from: [ColumnName:{DescID: 108, Name: n1, ColumnID: 1}, ABSENT]
+  to:   [View:{DescID: 108}, ABSENT]
+  kind: Precedence
+  rule: non-data dependents removed before descriptor
+- from: [ColumnName:{DescID: 108, Name: n2, ColumnID: 2}, ABSENT]
+  to:   [Column:{DescID: 108, ColumnID: 2}, ABSENT]
+  kind: Precedence
+  rule: dependents removed before column
+- from: [ColumnName:{DescID: 108, Name: n2, ColumnID: 2}, ABSENT]
   to:   [View:{DescID: 108}, ABSENT]
   kind: Precedence
   rule: non-data dependents removed before descriptor
@@ -1282,116 +1453,108 @@ DROP VIEW defaultdb.v1 CASCADE
   to:   [View:{DescID: 108}, ABSENT]
   kind: Precedence
   rule: non-data dependents removed before descriptor
-- from: [ColumnName:{DescID: 111, Name: crdb_internal_mvcc_timestamp, ColumnID: 4294967295}, ABSENT]
-  to:   [Column:{DescID: 111, ColumnID: 4294967295}, ABSENT]
+- from: [ColumnName:{DescID: 109, Name: crdb_internal_mvcc_timestamp, ColumnID: 4294967295}, ABSENT]
+  to:   [Column:{DescID: 109, ColumnID: 4294967295}, ABSENT]
   kind: Precedence
   rule: dependents removed before column
-- from: [ColumnName:{DescID: 111, Name: crdb_internal_mvcc_timestamp, ColumnID: 4294967295}, ABSENT]
-  to:   [View:{DescID: 111}, ABSENT]
+- from: [ColumnName:{DescID: 109, Name: crdb_internal_mvcc_timestamp, ColumnID: 4294967295}, ABSENT]
+  to:   [View:{DescID: 109}, ABSENT]
   kind: Precedence
   rule: non-data dependents removed before descriptor
-- from: [ColumnName:{DescID: 111, Name: k, ColumnID: 1}, ABSENT]
-  to:   [Column:{DescID: 111, ColumnID: 1}, ABSENT]
+- from: [ColumnName:{DescID: 109, Name: n1, ColumnID: 2}, ABSENT]
+  to:   [Column:{DescID: 109, ColumnID: 2}, ABSENT]
   kind: Precedence
   rule: dependents removed before column
-- from: [ColumnName:{DescID: 111, Name: k, ColumnID: 1}, ABSENT]
-  to:   [View:{DescID: 111}, ABSENT]
+- from: [ColumnName:{DescID: 109, Name: n1, ColumnID: 2}, ABSENT]
+  to:   [View:{DescID: 109}, ABSENT]
   kind: Precedence
   rule: non-data dependents removed before descriptor
-- from: [ColumnName:{DescID: 111, Name: n1, ColumnID: 3}, ABSENT]
-  to:   [Column:{DescID: 111, ColumnID: 3}, ABSENT]
+- from: [ColumnName:{DescID: 109, Name: name, ColumnID: 1}, ABSENT]
+  to:   [Column:{DescID: 109, ColumnID: 1}, ABSENT]
   kind: Precedence
   rule: dependents removed before column
-- from: [ColumnName:{DescID: 111, Name: n1, ColumnID: 3}, ABSENT]
-  to:   [View:{DescID: 111}, ABSENT]
+- from: [ColumnName:{DescID: 109, Name: name, ColumnID: 1}, ABSENT]
+  to:   [View:{DescID: 109}, ABSENT]
   kind: Precedence
   rule: non-data dependents removed before descriptor
-- from: [ColumnName:{DescID: 111, Name: n2, ColumnID: 2}, ABSENT]
-  to:   [Column:{DescID: 111, ColumnID: 2}, ABSENT]
+- from: [ColumnName:{DescID: 109, Name: tableoid, ColumnID: 4294967294}, ABSENT]
+  to:   [Column:{DescID: 109, ColumnID: 4294967294}, ABSENT]
   kind: Precedence
   rule: dependents removed before column
-- from: [ColumnName:{DescID: 111, Name: n2, ColumnID: 2}, ABSENT]
-  to:   [View:{DescID: 111}, ABSENT]
+- from: [ColumnName:{DescID: 109, Name: tableoid, ColumnID: 4294967294}, ABSENT]
+  to:   [View:{DescID: 109}, ABSENT]
   kind: Precedence
   rule: non-data dependents removed before descriptor
-- from: [ColumnName:{DescID: 111, Name: tableoid, ColumnID: 4294967294}, ABSENT]
-  to:   [Column:{DescID: 111, ColumnID: 4294967294}, ABSENT]
+- from: [ColumnName:{DescID: 110, Name: crdb_internal_mvcc_timestamp, ColumnID: 4294967295}, ABSENT]
+  to:   [Column:{DescID: 110, ColumnID: 4294967295}, ABSENT]
   kind: Precedence
   rule: dependents removed before column
-- from: [ColumnName:{DescID: 111, Name: tableoid, ColumnID: 4294967294}, ABSENT]
-  to:   [View:{DescID: 111}, ABSENT]
+- from: [ColumnName:{DescID: 110, Name: crdb_internal_mvcc_timestamp, ColumnID: 4294967295}, ABSENT]
+  to:   [View:{DescID: 110}, ABSENT]
   kind: Precedence
   rule: non-data dependents removed before descriptor
-- from: [ColumnType:{DescID: 105, ColumnFamilyID: 0, ColumnID: 1}, ABSENT]
-  to:   [Column:{DescID: 105, ColumnID: 1}, ABSENT]
+- from: [ColumnName:{DescID: 110, Name: n1, ColumnID: 2}, ABSENT]
+  to:   [Column:{DescID: 110, ColumnID: 2}, ABSENT]
   kind: Precedence
   rule: dependents removed before column
-- from: [ColumnType:{DescID: 105, ColumnFamilyID: 0, ColumnID: 1}, ABSENT]
-  to:   [View:{DescID: 105}, ABSENT]
+- from: [ColumnName:{DescID: 110, Name: n1, ColumnID: 2}, ABSENT]
+  to:   [View:{DescID: 110}, ABSENT]
   kind: Precedence
   rule: non-data dependents removed before descriptor
-- from: [ColumnType:{DescID: 105, ColumnFamilyID: 0, ColumnID: 4294967294}, ABSENT]
-  to:   [Column:{DescID: 105, ColumnID: 4294967294}, ABSENT]
+- from: [ColumnName:{DescID: 110, Name: n2, ColumnID: 1}, ABSENT]
+  to:   [Column:{DescID: 110, ColumnID: 1}, ABSENT]
   kind: Precedence
   rule: dependents removed before column
-- from: [ColumnType:{DescID: 105, ColumnFamilyID: 0, ColumnID: 4294967294}, ABSENT]
-  to:   [View:{DescID: 105}, ABSENT]
+- from: [ColumnName:{DescID: 110, Name: n2, ColumnID: 1}, ABSENT]
+  to:   [View:{DescID: 110}, ABSENT]
   kind: Precedence
   rule: non-data dependents removed before descriptor
-- from: [ColumnType:{DescID: 105, ColumnFamilyID: 0, ColumnID: 4294967295}, ABSENT]
-  to:   [Column:{DescID: 105, ColumnID: 4294967295}, ABSENT]
+- from: [ColumnName:{DescID: 110, Name: tableoid, ColumnID: 4294967294}, ABSENT]
+  to:   [Column:{DescID: 110, ColumnID: 4294967294}, ABSENT]
   kind: Precedence
   rule: dependents removed before column
-- from: [ColumnType:{DescID: 105, ColumnFamilyID: 0, ColumnID: 4294967295}, ABSENT]
-  to:   [View:{DescID: 105}, ABSENT]
+- from: [ColumnName:{DescID: 110, Name: tableoid, ColumnID: 4294967294}, ABSENT]
+  to:   [View:{DescID: 110}, ABSENT]
   kind: Precedence
   rule: non-data dependents removed before descriptor
-- from: [ColumnType:{DescID: 106, ColumnFamilyID: 0, ColumnID: 1}, ABSENT]
-  to:   [Column:{DescID: 106, ColumnID: 1}, ABSENT]
+- from: [ColumnName:{DescID: 113, Name: crdb_internal_mvcc_timestamp, ColumnID: 4294967295}, ABSENT]
+  to:   [Column:{DescID: 113, ColumnID: 4294967295}, ABSENT]
   kind: Precedence
   rule: dependents removed before column
-- from: [ColumnType:{DescID: 106, ColumnFamilyID: 0, ColumnID: 1}, ABSENT]
-  to:   [View:{DescID: 106}, ABSENT]
+- from: [ColumnName:{DescID: 113, Name: crdb_internal_mvcc_timestamp, ColumnID: 4294967295}, ABSENT]
+  to:   [View:{DescID: 113}, ABSENT]
   kind: Precedence
   rule: non-data dependents removed before descriptor
-- from: [ColumnType:{DescID: 106, ColumnFamilyID: 0, ColumnID: 2}, ABSENT]
-  to:   [Column:{DescID: 106, ColumnID: 2}, ABSENT]
+- from: [ColumnName:{DescID: 113, Name: k, ColumnID: 1}, ABSENT]
+  to:   [Column:{DescID: 113, ColumnID: 1}, ABSENT]
   kind: Precedence
   rule: dependents removed before column
-- from: [ColumnType:{DescID: 106, ColumnFamilyID: 0, ColumnID: 2}, ABSENT]
-  to:   [View:{DescID: 106}, ABSENT]
+- from: [ColumnName:{DescID: 113, Name: k, ColumnID: 1}, ABSENT]
+  to:   [View:{DescID: 113}, ABSENT]
   kind: Precedence
   rule: non-data dependents removed before descriptor
-- from: [ColumnType:{DescID: 106, ColumnFamilyID: 0, ColumnID: 4294967294}, ABSENT]
-  to:   [Column:{DescID: 106, ColumnID: 4294967294}, ABSENT]
+- from: [ColumnName:{DescID: 113, Name: n1, ColumnID: 3}, ABSENT]
+  to:   [Column:{DescID: 113, ColumnID: 3}, ABSENT]
   kind: Precedence
   rule: dependents removed before column
-- from: [ColumnType:{DescID: 106, ColumnFamilyID: 0, ColumnID: 4294967294}, ABSENT]
-  to:   [View:{DescID: 106}, ABSENT]
+- from: [ColumnName:{DescID: 113, Name: n1, ColumnID: 3}, ABSENT]
+  to:   [View:{DescID: 113}, ABSENT]
   kind: Precedence
   rule: non-data dependents removed before descriptor
-- from: [ColumnType:{DescID: 106, ColumnFamilyID: 0, ColumnID: 4294967295}, ABSENT]
-  to:   [Column:{DescID: 106, ColumnID: 4294967295}, ABSENT]
+- from: [ColumnName:{DescID: 113, Name: n2, ColumnID: 2}, ABSENT]
+  to:   [Column:{DescID: 113, ColumnID: 2}, ABSENT]
   kind: Precedence
   rule: dependents removed before column
-- from: [ColumnType:{DescID: 106, ColumnFamilyID: 0, ColumnID: 4294967295}, ABSENT]
-  to:   [View:{DescID: 106}, ABSENT]
+- from: [ColumnName:{DescID: 113, Name: n2, ColumnID: 2}, ABSENT]
+  to:   [View:{DescID: 113}, ABSENT]
   kind: Precedence
   rule: non-data dependents removed before descriptor
-- from: [ColumnType:{DescID: 107, ColumnFamilyID: 0, ColumnID: 1}, ABSENT]
-  to:   [Column:{DescID: 107, ColumnID: 1}, ABSENT]
+- from: [ColumnName:{DescID: 113, Name: tableoid, ColumnID: 4294967294}, ABSENT]
+  to:   [Column:{DescID: 113, ColumnID: 4294967294}, ABSENT]
   kind: Precedence
   rule: dependents removed before column
-- from: [ColumnType:{DescID: 107, ColumnFamilyID: 0, ColumnID: 1}, ABSENT]
-  to:   [View:{DescID: 107}, ABSENT]
-  kind: Precedence
-  rule: non-data dependents removed before descriptor
-- from: [ColumnType:{DescID: 107, ColumnFamilyID: 0, ColumnID: 2}, ABSENT]
-  to:   [Column:{DescID: 107, ColumnID: 2}, ABSENT]
-  kind: Precedence
-  rule: dependents removed before column
-- from: [ColumnType:{DescID: 107, ColumnFamilyID: 0, ColumnID: 2}, ABSENT]
-  to:   [View:{DescID: 107}, ABSENT]
+- from: [ColumnName:{DescID: 113, Name: tableoid, ColumnID: 4294967294}, ABSENT]
+  to:   [View:{DescID: 113}, ABSENT]
   kind: Precedence
   rule: non-data dependents removed before descriptor
 - from: [ColumnType:{DescID: 107, ColumnFamilyID: 0, ColumnID: 4294967294}, ABSENT]
@@ -1410,20 +1573,12 @@ DROP VIEW defaultdb.v1 CASCADE
   to:   [View:{DescID: 107}, ABSENT]
   kind: Precedence
   rule: non-data dependents removed before descriptor
-- from: [ColumnType:{DescID: 108, ColumnFamilyID: 0, ColumnID: 1}, ABSENT]
-  to:   [Column:{DescID: 108, ColumnID: 1}, ABSENT]
+- from: [ColumnType:{DescID: 107, ReferencedTypeIDs: [104 105], ColumnFamilyID: 0, ColumnID: 1}, ABSENT]
+  to:   [Column:{DescID: 107, ColumnID: 1}, ABSENT]
   kind: Precedence
   rule: dependents removed before column
-- from: [ColumnType:{DescID: 108, ColumnFamilyID: 0, ColumnID: 1}, ABSENT]
-  to:   [View:{DescID: 108}, ABSENT]
-  kind: Precedence
-  rule: non-data dependents removed before descriptor
-- from: [ColumnType:{DescID: 108, ColumnFamilyID: 0, ColumnID: 2}, ABSENT]
-  to:   [Column:{DescID: 108, ColumnID: 2}, ABSENT]
-  kind: Precedence
-  rule: dependents removed before column
-- from: [ColumnType:{DescID: 108, ColumnFamilyID: 0, ColumnID: 2}, ABSENT]
-  to:   [View:{DescID: 108}, ABSENT]
+- from: [ColumnType:{DescID: 107, ReferencedTypeIDs: [104 105], ColumnFamilyID: 0, ColumnID: 1}, ABSENT]
+  to:   [View:{DescID: 107}, ABSENT]
   kind: Precedence
   rule: non-data dependents removed before descriptor
 - from: [ColumnType:{DescID: 108, ColumnFamilyID: 0, ColumnID: 4294967294}, ABSENT]
@@ -1442,72 +1597,144 @@ DROP VIEW defaultdb.v1 CASCADE
   to:   [View:{DescID: 108}, ABSENT]
   kind: Precedence
   rule: non-data dependents removed before descriptor
-- from: [ColumnType:{DescID: 111, ColumnFamilyID: 0, ColumnID: 1}, ABSENT]
-  to:   [Column:{DescID: 111, ColumnID: 1}, ABSENT]
+- from: [ColumnType:{DescID: 108, ReferencedTypeIDs: [104 105], ColumnFamilyID: 0, ColumnID: 1}, ABSENT]
+  to:   [Column:{DescID: 108, ColumnID: 1}, ABSENT]
   kind: Precedence
   rule: dependents removed before column
-- from: [ColumnType:{DescID: 111, ColumnFamilyID: 0, ColumnID: 1}, ABSENT]
-  to:   [View:{DescID: 111}, ABSENT]
-  kind: Precedence
-  rule: non-data dependents removed before descriptor
-- from: [ColumnType:{DescID: 111, ColumnFamilyID: 0, ColumnID: 2}, ABSENT]
-  to:   [Column:{DescID: 111, ColumnID: 2}, ABSENT]
-  kind: Precedence
-  rule: dependents removed before column
-- from: [ColumnType:{DescID: 111, ColumnFamilyID: 0, ColumnID: 2}, ABSENT]
-  to:   [View:{DescID: 111}, ABSENT]
-  kind: Precedence
-  rule: non-data dependents removed before descriptor
-- from: [ColumnType:{DescID: 111, ColumnFamilyID: 0, ColumnID: 3}, ABSENT]
-  to:   [Column:{DescID: 111, ColumnID: 3}, ABSENT]
-  kind: Precedence
-  rule: dependents removed before column
-- from: [ColumnType:{DescID: 111, ColumnFamilyID: 0, ColumnID: 3}, ABSENT]
-  to:   [View:{DescID: 111}, ABSENT]
-  kind: Precedence
-  rule: non-data dependents removed before descriptor
-- from: [ColumnType:{DescID: 111, ColumnFamilyID: 0, ColumnID: 4294967294}, ABSENT]
-  to:   [Column:{DescID: 111, ColumnID: 4294967294}, ABSENT]
-  kind: Precedence
-  rule: dependents removed before column
-- from: [ColumnType:{DescID: 111, ColumnFamilyID: 0, ColumnID: 4294967294}, ABSENT]
-  to:   [View:{DescID: 111}, ABSENT]
-  kind: Precedence
-  rule: non-data dependents removed before descriptor
-- from: [ColumnType:{DescID: 111, ColumnFamilyID: 0, ColumnID: 4294967295}, ABSENT]
-  to:   [Column:{DescID: 111, ColumnID: 4294967295}, ABSENT]
-  kind: Precedence
-  rule: dependents removed before column
-- from: [ColumnType:{DescID: 111, ColumnFamilyID: 0, ColumnID: 4294967295}, ABSENT]
-  to:   [View:{DescID: 111}, ABSENT]
-  kind: Precedence
-  rule: non-data dependents removed before descriptor
-- from: [Namespace:{DescID: 105, Name: v1, ReferencedDescID: 100}, ABSENT]
-  to:   [View:{DescID: 105}, ABSENT]
-  kind: Precedence
-  rule: non-data dependents removed before descriptor
-- from: [Namespace:{DescID: 106, Name: v2, ReferencedDescID: 100}, ABSENT]
-  to:   [View:{DescID: 106}, ABSENT]
-  kind: Precedence
-  rule: non-data dependents removed before descriptor
-- from: [Namespace:{DescID: 107, Name: v3, ReferencedDescID: 100}, ABSENT]
-  to:   [View:{DescID: 107}, ABSENT]
-  kind: Precedence
-  rule: non-data dependents removed before descriptor
-- from: [Namespace:{DescID: 108, Name: v4, ReferencedDescID: 100}, ABSENT]
+- from: [ColumnType:{DescID: 108, ReferencedTypeIDs: [104 105], ColumnFamilyID: 0, ColumnID: 1}, ABSENT]
   to:   [View:{DescID: 108}, ABSENT]
   kind: Precedence
   rule: non-data dependents removed before descriptor
-- from: [Namespace:{DescID: 111, Name: v5, ReferencedDescID: 100}, ABSENT]
-  to:   [View:{DescID: 111}, ABSENT]
+- from: [ColumnType:{DescID: 108, ReferencedTypeIDs: [104 105], ColumnFamilyID: 0, ColumnID: 2}, ABSENT]
+  to:   [Column:{DescID: 108, ColumnID: 2}, ABSENT]
+  kind: Precedence
+  rule: dependents removed before column
+- from: [ColumnType:{DescID: 108, ReferencedTypeIDs: [104 105], ColumnFamilyID: 0, ColumnID: 2}, ABSENT]
+  to:   [View:{DescID: 108}, ABSENT]
   kind: Precedence
   rule: non-data dependents removed before descriptor
-- from: [ObjectParent:{DescID: 105, ReferencedDescID: 101}, ABSENT]
-  to:   [View:{DescID: 105}, ABSENT]
+- from: [ColumnType:{DescID: 109, ColumnFamilyID: 0, ColumnID: 4294967294}, ABSENT]
+  to:   [Column:{DescID: 109, ColumnID: 4294967294}, ABSENT]
+  kind: Precedence
+  rule: dependents removed before column
+- from: [ColumnType:{DescID: 109, ColumnFamilyID: 0, ColumnID: 4294967294}, ABSENT]
+  to:   [View:{DescID: 109}, ABSENT]
   kind: Precedence
   rule: non-data dependents removed before descriptor
-- from: [ObjectParent:{DescID: 106, ReferencedDescID: 101}, ABSENT]
-  to:   [View:{DescID: 106}, ABSENT]
+- from: [ColumnType:{DescID: 109, ColumnFamilyID: 0, ColumnID: 4294967295}, ABSENT]
+  to:   [Column:{DescID: 109, ColumnID: 4294967295}, ABSENT]
+  kind: Precedence
+  rule: dependents removed before column
+- from: [ColumnType:{DescID: 109, ColumnFamilyID: 0, ColumnID: 4294967295}, ABSENT]
+  to:   [View:{DescID: 109}, ABSENT]
+  kind: Precedence
+  rule: non-data dependents removed before descriptor
+- from: [ColumnType:{DescID: 109, ReferencedTypeIDs: [104 105], ColumnFamilyID: 0, ColumnID: 1}, ABSENT]
+  to:   [Column:{DescID: 109, ColumnID: 1}, ABSENT]
+  kind: Precedence
+  rule: dependents removed before column
+- from: [ColumnType:{DescID: 109, ReferencedTypeIDs: [104 105], ColumnFamilyID: 0, ColumnID: 1}, ABSENT]
+  to:   [View:{DescID: 109}, ABSENT]
+  kind: Precedence
+  rule: non-data dependents removed before descriptor
+- from: [ColumnType:{DescID: 109, ReferencedTypeIDs: [104 105], ColumnFamilyID: 0, ColumnID: 2}, ABSENT]
+  to:   [Column:{DescID: 109, ColumnID: 2}, ABSENT]
+  kind: Precedence
+  rule: dependents removed before column
+- from: [ColumnType:{DescID: 109, ReferencedTypeIDs: [104 105], ColumnFamilyID: 0, ColumnID: 2}, ABSENT]
+  to:   [View:{DescID: 109}, ABSENT]
+  kind: Precedence
+  rule: non-data dependents removed before descriptor
+- from: [ColumnType:{DescID: 110, ColumnFamilyID: 0, ColumnID: 4294967294}, ABSENT]
+  to:   [Column:{DescID: 110, ColumnID: 4294967294}, ABSENT]
+  kind: Precedence
+  rule: dependents removed before column
+- from: [ColumnType:{DescID: 110, ColumnFamilyID: 0, ColumnID: 4294967294}, ABSENT]
+  to:   [View:{DescID: 110}, ABSENT]
+  kind: Precedence
+  rule: non-data dependents removed before descriptor
+- from: [ColumnType:{DescID: 110, ColumnFamilyID: 0, ColumnID: 4294967295}, ABSENT]
+  to:   [Column:{DescID: 110, ColumnID: 4294967295}, ABSENT]
+  kind: Precedence
+  rule: dependents removed before column
+- from: [ColumnType:{DescID: 110, ColumnFamilyID: 0, ColumnID: 4294967295}, ABSENT]
+  to:   [View:{DescID: 110}, ABSENT]
+  kind: Precedence
+  rule: non-data dependents removed before descriptor
+- from: [ColumnType:{DescID: 110, ReferencedTypeIDs: [104 105], ColumnFamilyID: 0, ColumnID: 1}, ABSENT]
+  to:   [Column:{DescID: 110, ColumnID: 1}, ABSENT]
+  kind: Precedence
+  rule: dependents removed before column
+- from: [ColumnType:{DescID: 110, ReferencedTypeIDs: [104 105], ColumnFamilyID: 0, ColumnID: 1}, ABSENT]
+  to:   [View:{DescID: 110}, ABSENT]
+  kind: Precedence
+  rule: non-data dependents removed before descriptor
+- from: [ColumnType:{DescID: 110, ReferencedTypeIDs: [104 105], ColumnFamilyID: 0, ColumnID: 2}, ABSENT]
+  to:   [Column:{DescID: 110, ColumnID: 2}, ABSENT]
+  kind: Precedence
+  rule: dependents removed before column
+- from: [ColumnType:{DescID: 110, ReferencedTypeIDs: [104 105], ColumnFamilyID: 0, ColumnID: 2}, ABSENT]
+  to:   [View:{DescID: 110}, ABSENT]
+  kind: Precedence
+  rule: non-data dependents removed before descriptor
+- from: [ColumnType:{DescID: 113, ColumnFamilyID: 0, ColumnID: 1}, ABSENT]
+  to:   [Column:{DescID: 113, ColumnID: 1}, ABSENT]
+  kind: Precedence
+  rule: dependents removed before column
+- from: [ColumnType:{DescID: 113, ColumnFamilyID: 0, ColumnID: 1}, ABSENT]
+  to:   [View:{DescID: 113}, ABSENT]
+  kind: Precedence
+  rule: non-data dependents removed before descriptor
+- from: [ColumnType:{DescID: 113, ColumnFamilyID: 0, ColumnID: 4294967294}, ABSENT]
+  to:   [Column:{DescID: 113, ColumnID: 4294967294}, ABSENT]
+  kind: Precedence
+  rule: dependents removed before column
+- from: [ColumnType:{DescID: 113, ColumnFamilyID: 0, ColumnID: 4294967294}, ABSENT]
+  to:   [View:{DescID: 113}, ABSENT]
+  kind: Precedence
+  rule: non-data dependents removed before descriptor
+- from: [ColumnType:{DescID: 113, ColumnFamilyID: 0, ColumnID: 4294967295}, ABSENT]
+  to:   [Column:{DescID: 113, ColumnID: 4294967295}, ABSENT]
+  kind: Precedence
+  rule: dependents removed before column
+- from: [ColumnType:{DescID: 113, ColumnFamilyID: 0, ColumnID: 4294967295}, ABSENT]
+  to:   [View:{DescID: 113}, ABSENT]
+  kind: Precedence
+  rule: non-data dependents removed before descriptor
+- from: [ColumnType:{DescID: 113, ReferencedTypeIDs: [104 105], ColumnFamilyID: 0, ColumnID: 2}, ABSENT]
+  to:   [Column:{DescID: 113, ColumnID: 2}, ABSENT]
+  kind: Precedence
+  rule: dependents removed before column
+- from: [ColumnType:{DescID: 113, ReferencedTypeIDs: [104 105], ColumnFamilyID: 0, ColumnID: 2}, ABSENT]
+  to:   [View:{DescID: 113}, ABSENT]
+  kind: Precedence
+  rule: non-data dependents removed before descriptor
+- from: [ColumnType:{DescID: 113, ReferencedTypeIDs: [104 105], ColumnFamilyID: 0, ColumnID: 3}, ABSENT]
+  to:   [Column:{DescID: 113, ColumnID: 3}, ABSENT]
+  kind: Precedence
+  rule: dependents removed before column
+- from: [ColumnType:{DescID: 113, ReferencedTypeIDs: [104 105], ColumnFamilyID: 0, ColumnID: 3}, ABSENT]
+  to:   [View:{DescID: 113}, ABSENT]
+  kind: Precedence
+  rule: non-data dependents removed before descriptor
+- from: [Namespace:{DescID: 107, Name: v1, ReferencedDescID: 100}, ABSENT]
+  to:   [View:{DescID: 107}, ABSENT]
+  kind: Precedence
+  rule: non-data dependents removed before descriptor
+- from: [Namespace:{DescID: 108, Name: v2, ReferencedDescID: 100}, ABSENT]
+  to:   [View:{DescID: 108}, ABSENT]
+  kind: Precedence
+  rule: non-data dependents removed before descriptor
+- from: [Namespace:{DescID: 109, Name: v3, ReferencedDescID: 100}, ABSENT]
+  to:   [View:{DescID: 109}, ABSENT]
+  kind: Precedence
+  rule: non-data dependents removed before descriptor
+- from: [Namespace:{DescID: 110, Name: v4, ReferencedDescID: 100}, ABSENT]
+  to:   [View:{DescID: 110}, ABSENT]
+  kind: Precedence
+  rule: non-data dependents removed before descriptor
+- from: [Namespace:{DescID: 113, Name: v5, ReferencedDescID: 100}, ABSENT]
+  to:   [View:{DescID: 113}, ABSENT]
   kind: Precedence
   rule: non-data dependents removed before descriptor
 - from: [ObjectParent:{DescID: 107, ReferencedDescID: 101}, ABSENT]
@@ -1518,16 +1745,16 @@ DROP VIEW defaultdb.v1 CASCADE
   to:   [View:{DescID: 108}, ABSENT]
   kind: Precedence
   rule: non-data dependents removed before descriptor
-- from: [ObjectParent:{DescID: 111, ReferencedDescID: 101}, ABSENT]
-  to:   [View:{DescID: 111}, ABSENT]
+- from: [ObjectParent:{DescID: 109, ReferencedDescID: 101}, ABSENT]
+  to:   [View:{DescID: 109}, ABSENT]
   kind: Precedence
   rule: non-data dependents removed before descriptor
-- from: [Owner:{DescID: 105}, ABSENT]
-  to:   [View:{DescID: 105}, ABSENT]
+- from: [ObjectParent:{DescID: 110, ReferencedDescID: 101}, ABSENT]
+  to:   [View:{DescID: 110}, ABSENT]
   kind: Precedence
   rule: non-data dependents removed before descriptor
-- from: [Owner:{DescID: 106}, ABSENT]
-  to:   [View:{DescID: 106}, ABSENT]
+- from: [ObjectParent:{DescID: 113, ReferencedDescID: 101}, ABSENT]
+  to:   [View:{DescID: 113}, ABSENT]
   kind: Precedence
   rule: non-data dependents removed before descriptor
 - from: [Owner:{DescID: 107}, ABSENT]
@@ -1538,24 +1765,16 @@ DROP VIEW defaultdb.v1 CASCADE
   to:   [View:{DescID: 108}, ABSENT]
   kind: Precedence
   rule: non-data dependents removed before descriptor
-- from: [Owner:{DescID: 111}, ABSENT]
-  to:   [View:{DescID: 111}, ABSENT]
+- from: [Owner:{DescID: 109}, ABSENT]
+  to:   [View:{DescID: 109}, ABSENT]
   kind: Precedence
   rule: non-data dependents removed before descriptor
-- from: [UserPrivileges:{DescID: 105, Name: admin}, ABSENT]
-  to:   [View:{DescID: 105}, ABSENT]
+- from: [Owner:{DescID: 110}, ABSENT]
+  to:   [View:{DescID: 110}, ABSENT]
   kind: Precedence
   rule: non-data dependents removed before descriptor
-- from: [UserPrivileges:{DescID: 105, Name: root}, ABSENT]
-  to:   [View:{DescID: 105}, ABSENT]
-  kind: Precedence
-  rule: non-data dependents removed before descriptor
-- from: [UserPrivileges:{DescID: 106, Name: admin}, ABSENT]
-  to:   [View:{DescID: 106}, ABSENT]
-  kind: Precedence
-  rule: non-data dependents removed before descriptor
-- from: [UserPrivileges:{DescID: 106, Name: root}, ABSENT]
-  to:   [View:{DescID: 106}, ABSENT]
+- from: [Owner:{DescID: 113}, ABSENT]
+  to:   [View:{DescID: 113}, ABSENT]
   kind: Precedence
   rule: non-data dependents removed before descriptor
 - from: [UserPrivileges:{DescID: 107, Name: admin}, ABSENT]
@@ -1574,152 +1793,32 @@ DROP VIEW defaultdb.v1 CASCADE
   to:   [View:{DescID: 108}, ABSENT]
   kind: Precedence
   rule: non-data dependents removed before descriptor
-- from: [UserPrivileges:{DescID: 111, Name: admin}, ABSENT]
-  to:   [View:{DescID: 111}, ABSENT]
+- from: [UserPrivileges:{DescID: 109, Name: admin}, ABSENT]
+  to:   [View:{DescID: 109}, ABSENT]
   kind: Precedence
   rule: non-data dependents removed before descriptor
-- from: [UserPrivileges:{DescID: 111, Name: root}, ABSENT]
-  to:   [View:{DescID: 111}, ABSENT]
+- from: [UserPrivileges:{DescID: 109, Name: root}, ABSENT]
+  to:   [View:{DescID: 109}, ABSENT]
   kind: Precedence
   rule: non-data dependents removed before descriptor
-- from: [View:{DescID: 105}, DROPPED]
-  to:   [Column:{DescID: 105, ColumnID: 1}, WRITE_ONLY]
+- from: [UserPrivileges:{DescID: 110, Name: admin}, ABSENT]
+  to:   [View:{DescID: 110}, ABSENT]
   kind: Precedence
-  rule: relation dropped before dependent column
-- from: [View:{DescID: 105}, DROPPED]
-  to:   [Column:{DescID: 105, ColumnID: 4294967294}, WRITE_ONLY]
+  rule: non-data dependents removed before descriptor
+- from: [UserPrivileges:{DescID: 110, Name: root}, ABSENT]
+  to:   [View:{DescID: 110}, ABSENT]
   kind: Precedence
-  rule: relation dropped before dependent column
-- from: [View:{DescID: 105}, DROPPED]
-  to:   [Column:{DescID: 105, ColumnID: 4294967295}, WRITE_ONLY]
+  rule: non-data dependents removed before descriptor
+- from: [UserPrivileges:{DescID: 113, Name: admin}, ABSENT]
+  to:   [View:{DescID: 113}, ABSENT]
   kind: Precedence
-  rule: relation dropped before dependent column
-- from: [View:{DescID: 105}, DROPPED]
-  to:   [ColumnName:{DescID: 105, Name: crdb_internal_mvcc_timestamp, ColumnID: 4294967295}, ABSENT]
+  rule: non-data dependents removed before descriptor
+- from: [UserPrivileges:{DescID: 113, Name: root}, ABSENT]
+  to:   [View:{DescID: 113}, ABSENT]
   kind: Precedence
-  rule: descriptor dropped before dependent element removal
-- from: [View:{DescID: 105}, DROPPED]
-  to:   [ColumnName:{DescID: 105, Name: name, ColumnID: 1}, ABSENT]
-  kind: Precedence
-  rule: descriptor dropped before dependent element removal
-- from: [View:{DescID: 105}, DROPPED]
-  to:   [ColumnName:{DescID: 105, Name: tableoid, ColumnID: 4294967294}, ABSENT]
-  kind: Precedence
-  rule: descriptor dropped before dependent element removal
-- from: [View:{DescID: 105}, DROPPED]
-  to:   [ColumnType:{DescID: 105, ColumnFamilyID: 0, ColumnID: 1}, ABSENT]
-  kind: Precedence
-  rule: descriptor dropped before dependent element removal
-- from: [View:{DescID: 105}, DROPPED]
-  to:   [ColumnType:{DescID: 105, ColumnFamilyID: 0, ColumnID: 4294967294}, ABSENT]
-  kind: Precedence
-  rule: descriptor dropped before dependent element removal
-- from: [View:{DescID: 105}, DROPPED]
-  to:   [ColumnType:{DescID: 105, ColumnFamilyID: 0, ColumnID: 4294967295}, ABSENT]
-  kind: Precedence
-  rule: descriptor dropped before dependent element removal
-- from: [View:{DescID: 105}, DROPPED]
-  to:   [Namespace:{DescID: 105, Name: v1, ReferencedDescID: 100}, ABSENT]
-  kind: Precedence
-  rule: descriptor dropped before dependent element removal
-- from: [View:{DescID: 105}, DROPPED]
-  to:   [ObjectParent:{DescID: 105, ReferencedDescID: 101}, ABSENT]
-  kind: SameStagePrecedence
-  rules: [descriptor dropped before dependent element removal; descriptor dropped right before removing back-reference in its parent descriptor]
-- from: [View:{DescID: 105}, DROPPED]
-  to:   [Owner:{DescID: 105}, ABSENT]
-  kind: Precedence
-  rule: descriptor dropped before dependent element removal
-- from: [View:{DescID: 105}, DROPPED]
-  to:   [UserPrivileges:{DescID: 105, Name: admin}, ABSENT]
-  kind: Precedence
-  rule: descriptor dropped before dependent element removal
-- from: [View:{DescID: 105}, DROPPED]
-  to:   [UserPrivileges:{DescID: 105, Name: root}, ABSENT]
-  kind: Precedence
-  rule: descriptor dropped before dependent element removal
-- from: [View:{DescID: 105}, DROPPED]
-  to:   [View:{DescID: 105}, ABSENT]
-  kind: PreviousStagePrecedence
-  rule: descriptor dropped in transaction before removal
-- from: [View:{DescID: 106}, DROPPED]
-  to:   [Column:{DescID: 106, ColumnID: 1}, WRITE_ONLY]
-  kind: Precedence
-  rule: relation dropped before dependent column
-- from: [View:{DescID: 106}, DROPPED]
-  to:   [Column:{DescID: 106, ColumnID: 2}, WRITE_ONLY]
-  kind: Precedence
-  rule: relation dropped before dependent column
-- from: [View:{DescID: 106}, DROPPED]
-  to:   [Column:{DescID: 106, ColumnID: 4294967294}, WRITE_ONLY]
-  kind: Precedence
-  rule: relation dropped before dependent column
-- from: [View:{DescID: 106}, DROPPED]
-  to:   [Column:{DescID: 106, ColumnID: 4294967295}, WRITE_ONLY]
-  kind: Precedence
-  rule: relation dropped before dependent column
-- from: [View:{DescID: 106}, DROPPED]
-  to:   [ColumnName:{DescID: 106, Name: crdb_internal_mvcc_timestamp, ColumnID: 4294967295}, ABSENT]
-  kind: Precedence
-  rule: descriptor dropped before dependent element removal
-- from: [View:{DescID: 106}, DROPPED]
-  to:   [ColumnName:{DescID: 106, Name: n1, ColumnID: 1}, ABSENT]
-  kind: Precedence
-  rule: descriptor dropped before dependent element removal
-- from: [View:{DescID: 106}, DROPPED]
-  to:   [ColumnName:{DescID: 106, Name: n2, ColumnID: 2}, ABSENT]
-  kind: Precedence
-  rule: descriptor dropped before dependent element removal
-- from: [View:{DescID: 106}, DROPPED]
-  to:   [ColumnName:{DescID: 106, Name: tableoid, ColumnID: 4294967294}, ABSENT]
-  kind: Precedence
-  rule: descriptor dropped before dependent element removal
-- from: [View:{DescID: 106}, DROPPED]
-  to:   [ColumnType:{DescID: 106, ColumnFamilyID: 0, ColumnID: 1}, ABSENT]
-  kind: Precedence
-  rule: descriptor dropped before dependent element removal
-- from: [View:{DescID: 106}, DROPPED]
-  to:   [ColumnType:{DescID: 106, ColumnFamilyID: 0, ColumnID: 2}, ABSENT]
-  kind: Precedence
-  rule: descriptor dropped before dependent element removal
-- from: [View:{DescID: 106}, DROPPED]
-  to:   [ColumnType:{DescID: 106, ColumnFamilyID: 0, ColumnID: 4294967294}, ABSENT]
-  kind: Precedence
-  rule: descriptor dropped before dependent element removal
-- from: [View:{DescID: 106}, DROPPED]
-  to:   [ColumnType:{DescID: 106, ColumnFamilyID: 0, ColumnID: 4294967295}, ABSENT]
-  kind: Precedence
-  rule: descriptor dropped before dependent element removal
-- from: [View:{DescID: 106}, DROPPED]
-  to:   [Namespace:{DescID: 106, Name: v2, ReferencedDescID: 100}, ABSENT]
-  kind: Precedence
-  rule: descriptor dropped before dependent element removal
-- from: [View:{DescID: 106}, DROPPED]
-  to:   [ObjectParent:{DescID: 106, ReferencedDescID: 101}, ABSENT]
-  kind: SameStagePrecedence
-  rules: [descriptor dropped before dependent element removal; descriptor dropped right before removing back-reference in its parent descriptor]
-- from: [View:{DescID: 106}, DROPPED]
-  to:   [Owner:{DescID: 106}, ABSENT]
-  kind: Precedence
-  rule: descriptor dropped before dependent element removal
-- from: [View:{DescID: 106}, DROPPED]
-  to:   [UserPrivileges:{DescID: 106, Name: admin}, ABSENT]
-  kind: Precedence
-  rule: descriptor dropped before dependent element removal
-- from: [View:{DescID: 106}, DROPPED]
-  to:   [UserPrivileges:{DescID: 106, Name: root}, ABSENT]
-  kind: Precedence
-  rule: descriptor dropped before dependent element removal
-- from: [View:{DescID: 106}, DROPPED]
-  to:   [View:{DescID: 106}, ABSENT]
-  kind: PreviousStagePrecedence
-  rule: descriptor dropped in transaction before removal
+  rule: non-data dependents removed before descriptor
 - from: [View:{DescID: 107}, DROPPED]
   to:   [Column:{DescID: 107, ColumnID: 1}, WRITE_ONLY]
-  kind: Precedence
-  rule: relation dropped before dependent column
-- from: [View:{DescID: 107}, DROPPED]
-  to:   [Column:{DescID: 107, ColumnID: 2}, WRITE_ONLY]
   kind: Precedence
   rule: relation dropped before dependent column
 - from: [View:{DescID: 107}, DROPPED]
@@ -1735,23 +1834,11 @@ DROP VIEW defaultdb.v1 CASCADE
   kind: Precedence
   rule: descriptor dropped before dependent element removal
 - from: [View:{DescID: 107}, DROPPED]
-  to:   [ColumnName:{DescID: 107, Name: n1, ColumnID: 2}, ABSENT]
-  kind: Precedence
-  rule: descriptor dropped before dependent element removal
-- from: [View:{DescID: 107}, DROPPED]
   to:   [ColumnName:{DescID: 107, Name: name, ColumnID: 1}, ABSENT]
   kind: Precedence
   rule: descriptor dropped before dependent element removal
 - from: [View:{DescID: 107}, DROPPED]
   to:   [ColumnName:{DescID: 107, Name: tableoid, ColumnID: 4294967294}, ABSENT]
-  kind: Precedence
-  rule: descriptor dropped before dependent element removal
-- from: [View:{DescID: 107}, DROPPED]
-  to:   [ColumnType:{DescID: 107, ColumnFamilyID: 0, ColumnID: 1}, ABSENT]
-  kind: Precedence
-  rule: descriptor dropped before dependent element removal
-- from: [View:{DescID: 107}, DROPPED]
-  to:   [ColumnType:{DescID: 107, ColumnFamilyID: 0, ColumnID: 2}, ABSENT]
   kind: Precedence
   rule: descriptor dropped before dependent element removal
 - from: [View:{DescID: 107}, DROPPED]
@@ -1763,7 +1850,11 @@ DROP VIEW defaultdb.v1 CASCADE
   kind: Precedence
   rule: descriptor dropped before dependent element removal
 - from: [View:{DescID: 107}, DROPPED]
-  to:   [Namespace:{DescID: 107, Name: v3, ReferencedDescID: 100}, ABSENT]
+  to:   [ColumnType:{DescID: 107, ReferencedTypeIDs: [104 105], ColumnFamilyID: 0, ColumnID: 1}, ABSENT]
+  kind: Precedence
+  rule: descriptor dropped before dependent element removal
+- from: [View:{DescID: 107}, DROPPED]
+  to:   [Namespace:{DescID: 107, Name: v1, ReferencedDescID: 100}, ABSENT]
   kind: Precedence
   rule: descriptor dropped before dependent element removal
 - from: [View:{DescID: 107}, DROPPED]
@@ -1807,23 +1898,15 @@ DROP VIEW defaultdb.v1 CASCADE
   kind: Precedence
   rule: descriptor dropped before dependent element removal
 - from: [View:{DescID: 108}, DROPPED]
-  to:   [ColumnName:{DescID: 108, Name: n1, ColumnID: 2}, ABSENT]
+  to:   [ColumnName:{DescID: 108, Name: n1, ColumnID: 1}, ABSENT]
   kind: Precedence
   rule: descriptor dropped before dependent element removal
 - from: [View:{DescID: 108}, DROPPED]
-  to:   [ColumnName:{DescID: 108, Name: n2, ColumnID: 1}, ABSENT]
+  to:   [ColumnName:{DescID: 108, Name: n2, ColumnID: 2}, ABSENT]
   kind: Precedence
   rule: descriptor dropped before dependent element removal
 - from: [View:{DescID: 108}, DROPPED]
   to:   [ColumnName:{DescID: 108, Name: tableoid, ColumnID: 4294967294}, ABSENT]
-  kind: Precedence
-  rule: descriptor dropped before dependent element removal
-- from: [View:{DescID: 108}, DROPPED]
-  to:   [ColumnType:{DescID: 108, ColumnFamilyID: 0, ColumnID: 1}, ABSENT]
-  kind: Precedence
-  rule: descriptor dropped before dependent element removal
-- from: [View:{DescID: 108}, DROPPED]
-  to:   [ColumnType:{DescID: 108, ColumnFamilyID: 0, ColumnID: 2}, ABSENT]
   kind: Precedence
   rule: descriptor dropped before dependent element removal
 - from: [View:{DescID: 108}, DROPPED]
@@ -1835,7 +1918,15 @@ DROP VIEW defaultdb.v1 CASCADE
   kind: Precedence
   rule: descriptor dropped before dependent element removal
 - from: [View:{DescID: 108}, DROPPED]
-  to:   [Namespace:{DescID: 108, Name: v4, ReferencedDescID: 100}, ABSENT]
+  to:   [ColumnType:{DescID: 108, ReferencedTypeIDs: [104 105], ColumnFamilyID: 0, ColumnID: 1}, ABSENT]
+  kind: Precedence
+  rule: descriptor dropped before dependent element removal
+- from: [View:{DescID: 108}, DROPPED]
+  to:   [ColumnType:{DescID: 108, ReferencedTypeIDs: [104 105], ColumnFamilyID: 0, ColumnID: 2}, ABSENT]
+  kind: Precedence
+  rule: descriptor dropped before dependent element removal
+- from: [View:{DescID: 108}, DROPPED]
+  to:   [Namespace:{DescID: 108, Name: v2, ReferencedDescID: 100}, ABSENT]
   kind: Precedence
   rule: descriptor dropped before dependent element removal
 - from: [View:{DescID: 108}, DROPPED]
@@ -1858,87 +1949,231 @@ DROP VIEW defaultdb.v1 CASCADE
   to:   [View:{DescID: 108}, ABSENT]
   kind: PreviousStagePrecedence
   rule: descriptor dropped in transaction before removal
-- from: [View:{DescID: 111}, DROPPED]
-  to:   [Column:{DescID: 111, ColumnID: 1}, WRITE_ONLY]
+- from: [View:{DescID: 109}, DROPPED]
+  to:   [Column:{DescID: 109, ColumnID: 1}, WRITE_ONLY]
   kind: Precedence
   rule: relation dropped before dependent column
-- from: [View:{DescID: 111}, DROPPED]
-  to:   [Column:{DescID: 111, ColumnID: 2}, WRITE_ONLY]
+- from: [View:{DescID: 109}, DROPPED]
+  to:   [Column:{DescID: 109, ColumnID: 2}, WRITE_ONLY]
   kind: Precedence
   rule: relation dropped before dependent column
-- from: [View:{DescID: 111}, DROPPED]
-  to:   [Column:{DescID: 111, ColumnID: 3}, WRITE_ONLY]
+- from: [View:{DescID: 109}, DROPPED]
+  to:   [Column:{DescID: 109, ColumnID: 4294967294}, WRITE_ONLY]
   kind: Precedence
   rule: relation dropped before dependent column
-- from: [View:{DescID: 111}, DROPPED]
-  to:   [Column:{DescID: 111, ColumnID: 4294967294}, WRITE_ONLY]
+- from: [View:{DescID: 109}, DROPPED]
+  to:   [Column:{DescID: 109, ColumnID: 4294967295}, WRITE_ONLY]
   kind: Precedence
   rule: relation dropped before dependent column
-- from: [View:{DescID: 111}, DROPPED]
-  to:   [Column:{DescID: 111, ColumnID: 4294967295}, WRITE_ONLY]
-  kind: Precedence
-  rule: relation dropped before dependent column
-- from: [View:{DescID: 111}, DROPPED]
-  to:   [ColumnName:{DescID: 111, Name: crdb_internal_mvcc_timestamp, ColumnID: 4294967295}, ABSENT]
+- from: [View:{DescID: 109}, DROPPED]
+  to:   [ColumnName:{DescID: 109, Name: crdb_internal_mvcc_timestamp, ColumnID: 4294967295}, ABSENT]
   kind: Precedence
   rule: descriptor dropped before dependent element removal
-- from: [View:{DescID: 111}, DROPPED]
-  to:   [ColumnName:{DescID: 111, Name: k, ColumnID: 1}, ABSENT]
+- from: [View:{DescID: 109}, DROPPED]
+  to:   [ColumnName:{DescID: 109, Name: n1, ColumnID: 2}, ABSENT]
   kind: Precedence
   rule: descriptor dropped before dependent element removal
-- from: [View:{DescID: 111}, DROPPED]
-  to:   [ColumnName:{DescID: 111, Name: n1, ColumnID: 3}, ABSENT]
+- from: [View:{DescID: 109}, DROPPED]
+  to:   [ColumnName:{DescID: 109, Name: name, ColumnID: 1}, ABSENT]
   kind: Precedence
   rule: descriptor dropped before dependent element removal
-- from: [View:{DescID: 111}, DROPPED]
-  to:   [ColumnName:{DescID: 111, Name: n2, ColumnID: 2}, ABSENT]
+- from: [View:{DescID: 109}, DROPPED]
+  to:   [ColumnName:{DescID: 109, Name: tableoid, ColumnID: 4294967294}, ABSENT]
   kind: Precedence
   rule: descriptor dropped before dependent element removal
-- from: [View:{DescID: 111}, DROPPED]
-  to:   [ColumnName:{DescID: 111, Name: tableoid, ColumnID: 4294967294}, ABSENT]
+- from: [View:{DescID: 109}, DROPPED]
+  to:   [ColumnType:{DescID: 109, ColumnFamilyID: 0, ColumnID: 4294967294}, ABSENT]
   kind: Precedence
   rule: descriptor dropped before dependent element removal
-- from: [View:{DescID: 111}, DROPPED]
-  to:   [ColumnType:{DescID: 111, ColumnFamilyID: 0, ColumnID: 1}, ABSENT]
+- from: [View:{DescID: 109}, DROPPED]
+  to:   [ColumnType:{DescID: 109, ColumnFamilyID: 0, ColumnID: 4294967295}, ABSENT]
   kind: Precedence
   rule: descriptor dropped before dependent element removal
-- from: [View:{DescID: 111}, DROPPED]
-  to:   [ColumnType:{DescID: 111, ColumnFamilyID: 0, ColumnID: 2}, ABSENT]
+- from: [View:{DescID: 109}, DROPPED]
+  to:   [ColumnType:{DescID: 109, ReferencedTypeIDs: [104 105], ColumnFamilyID: 0, ColumnID: 1}, ABSENT]
   kind: Precedence
   rule: descriptor dropped before dependent element removal
-- from: [View:{DescID: 111}, DROPPED]
-  to:   [ColumnType:{DescID: 111, ColumnFamilyID: 0, ColumnID: 3}, ABSENT]
+- from: [View:{DescID: 109}, DROPPED]
+  to:   [ColumnType:{DescID: 109, ReferencedTypeIDs: [104 105], ColumnFamilyID: 0, ColumnID: 2}, ABSENT]
   kind: Precedence
   rule: descriptor dropped before dependent element removal
-- from: [View:{DescID: 111}, DROPPED]
-  to:   [ColumnType:{DescID: 111, ColumnFamilyID: 0, ColumnID: 4294967294}, ABSENT]
+- from: [View:{DescID: 109}, DROPPED]
+  to:   [Namespace:{DescID: 109, Name: v3, ReferencedDescID: 100}, ABSENT]
   kind: Precedence
   rule: descriptor dropped before dependent element removal
-- from: [View:{DescID: 111}, DROPPED]
-  to:   [ColumnType:{DescID: 111, ColumnFamilyID: 0, ColumnID: 4294967295}, ABSENT]
-  kind: Precedence
-  rule: descriptor dropped before dependent element removal
-- from: [View:{DescID: 111}, DROPPED]
-  to:   [Namespace:{DescID: 111, Name: v5, ReferencedDescID: 100}, ABSENT]
-  kind: Precedence
-  rule: descriptor dropped before dependent element removal
-- from: [View:{DescID: 111}, DROPPED]
-  to:   [ObjectParent:{DescID: 111, ReferencedDescID: 101}, ABSENT]
+- from: [View:{DescID: 109}, DROPPED]
+  to:   [ObjectParent:{DescID: 109, ReferencedDescID: 101}, ABSENT]
   kind: SameStagePrecedence
   rules: [descriptor dropped before dependent element removal; descriptor dropped right before removing back-reference in its parent descriptor]
-- from: [View:{DescID: 111}, DROPPED]
-  to:   [Owner:{DescID: 111}, ABSENT]
+- from: [View:{DescID: 109}, DROPPED]
+  to:   [Owner:{DescID: 109}, ABSENT]
   kind: Precedence
   rule: descriptor dropped before dependent element removal
-- from: [View:{DescID: 111}, DROPPED]
-  to:   [UserPrivileges:{DescID: 111, Name: admin}, ABSENT]
+- from: [View:{DescID: 109}, DROPPED]
+  to:   [UserPrivileges:{DescID: 109, Name: admin}, ABSENT]
   kind: Precedence
   rule: descriptor dropped before dependent element removal
-- from: [View:{DescID: 111}, DROPPED]
-  to:   [UserPrivileges:{DescID: 111, Name: root}, ABSENT]
+- from: [View:{DescID: 109}, DROPPED]
+  to:   [UserPrivileges:{DescID: 109, Name: root}, ABSENT]
   kind: Precedence
   rule: descriptor dropped before dependent element removal
-- from: [View:{DescID: 111}, DROPPED]
-  to:   [View:{DescID: 111}, ABSENT]
+- from: [View:{DescID: 109}, DROPPED]
+  to:   [View:{DescID: 109}, ABSENT]
+  kind: PreviousStagePrecedence
+  rule: descriptor dropped in transaction before removal
+- from: [View:{DescID: 110}, DROPPED]
+  to:   [Column:{DescID: 110, ColumnID: 1}, WRITE_ONLY]
+  kind: Precedence
+  rule: relation dropped before dependent column
+- from: [View:{DescID: 110}, DROPPED]
+  to:   [Column:{DescID: 110, ColumnID: 2}, WRITE_ONLY]
+  kind: Precedence
+  rule: relation dropped before dependent column
+- from: [View:{DescID: 110}, DROPPED]
+  to:   [Column:{DescID: 110, ColumnID: 4294967294}, WRITE_ONLY]
+  kind: Precedence
+  rule: relation dropped before dependent column
+- from: [View:{DescID: 110}, DROPPED]
+  to:   [Column:{DescID: 110, ColumnID: 4294967295}, WRITE_ONLY]
+  kind: Precedence
+  rule: relation dropped before dependent column
+- from: [View:{DescID: 110}, DROPPED]
+  to:   [ColumnName:{DescID: 110, Name: crdb_internal_mvcc_timestamp, ColumnID: 4294967295}, ABSENT]
+  kind: Precedence
+  rule: descriptor dropped before dependent element removal
+- from: [View:{DescID: 110}, DROPPED]
+  to:   [ColumnName:{DescID: 110, Name: n1, ColumnID: 2}, ABSENT]
+  kind: Precedence
+  rule: descriptor dropped before dependent element removal
+- from: [View:{DescID: 110}, DROPPED]
+  to:   [ColumnName:{DescID: 110, Name: n2, ColumnID: 1}, ABSENT]
+  kind: Precedence
+  rule: descriptor dropped before dependent element removal
+- from: [View:{DescID: 110}, DROPPED]
+  to:   [ColumnName:{DescID: 110, Name: tableoid, ColumnID: 4294967294}, ABSENT]
+  kind: Precedence
+  rule: descriptor dropped before dependent element removal
+- from: [View:{DescID: 110}, DROPPED]
+  to:   [ColumnType:{DescID: 110, ColumnFamilyID: 0, ColumnID: 4294967294}, ABSENT]
+  kind: Precedence
+  rule: descriptor dropped before dependent element removal
+- from: [View:{DescID: 110}, DROPPED]
+  to:   [ColumnType:{DescID: 110, ColumnFamilyID: 0, ColumnID: 4294967295}, ABSENT]
+  kind: Precedence
+  rule: descriptor dropped before dependent element removal
+- from: [View:{DescID: 110}, DROPPED]
+  to:   [ColumnType:{DescID: 110, ReferencedTypeIDs: [104 105], ColumnFamilyID: 0, ColumnID: 1}, ABSENT]
+  kind: Precedence
+  rule: descriptor dropped before dependent element removal
+- from: [View:{DescID: 110}, DROPPED]
+  to:   [ColumnType:{DescID: 110, ReferencedTypeIDs: [104 105], ColumnFamilyID: 0, ColumnID: 2}, ABSENT]
+  kind: Precedence
+  rule: descriptor dropped before dependent element removal
+- from: [View:{DescID: 110}, DROPPED]
+  to:   [Namespace:{DescID: 110, Name: v4, ReferencedDescID: 100}, ABSENT]
+  kind: Precedence
+  rule: descriptor dropped before dependent element removal
+- from: [View:{DescID: 110}, DROPPED]
+  to:   [ObjectParent:{DescID: 110, ReferencedDescID: 101}, ABSENT]
+  kind: SameStagePrecedence
+  rules: [descriptor dropped before dependent element removal; descriptor dropped right before removing back-reference in its parent descriptor]
+- from: [View:{DescID: 110}, DROPPED]
+  to:   [Owner:{DescID: 110}, ABSENT]
+  kind: Precedence
+  rule: descriptor dropped before dependent element removal
+- from: [View:{DescID: 110}, DROPPED]
+  to:   [UserPrivileges:{DescID: 110, Name: admin}, ABSENT]
+  kind: Precedence
+  rule: descriptor dropped before dependent element removal
+- from: [View:{DescID: 110}, DROPPED]
+  to:   [UserPrivileges:{DescID: 110, Name: root}, ABSENT]
+  kind: Precedence
+  rule: descriptor dropped before dependent element removal
+- from: [View:{DescID: 110}, DROPPED]
+  to:   [View:{DescID: 110}, ABSENT]
+  kind: PreviousStagePrecedence
+  rule: descriptor dropped in transaction before removal
+- from: [View:{DescID: 113}, DROPPED]
+  to:   [Column:{DescID: 113, ColumnID: 1}, WRITE_ONLY]
+  kind: Precedence
+  rule: relation dropped before dependent column
+- from: [View:{DescID: 113}, DROPPED]
+  to:   [Column:{DescID: 113, ColumnID: 2}, WRITE_ONLY]
+  kind: Precedence
+  rule: relation dropped before dependent column
+- from: [View:{DescID: 113}, DROPPED]
+  to:   [Column:{DescID: 113, ColumnID: 3}, WRITE_ONLY]
+  kind: Precedence
+  rule: relation dropped before dependent column
+- from: [View:{DescID: 113}, DROPPED]
+  to:   [Column:{DescID: 113, ColumnID: 4294967294}, WRITE_ONLY]
+  kind: Precedence
+  rule: relation dropped before dependent column
+- from: [View:{DescID: 113}, DROPPED]
+  to:   [Column:{DescID: 113, ColumnID: 4294967295}, WRITE_ONLY]
+  kind: Precedence
+  rule: relation dropped before dependent column
+- from: [View:{DescID: 113}, DROPPED]
+  to:   [ColumnName:{DescID: 113, Name: crdb_internal_mvcc_timestamp, ColumnID: 4294967295}, ABSENT]
+  kind: Precedence
+  rule: descriptor dropped before dependent element removal
+- from: [View:{DescID: 113}, DROPPED]
+  to:   [ColumnName:{DescID: 113, Name: k, ColumnID: 1}, ABSENT]
+  kind: Precedence
+  rule: descriptor dropped before dependent element removal
+- from: [View:{DescID: 113}, DROPPED]
+  to:   [ColumnName:{DescID: 113, Name: n1, ColumnID: 3}, ABSENT]
+  kind: Precedence
+  rule: descriptor dropped before dependent element removal
+- from: [View:{DescID: 113}, DROPPED]
+  to:   [ColumnName:{DescID: 113, Name: n2, ColumnID: 2}, ABSENT]
+  kind: Precedence
+  rule: descriptor dropped before dependent element removal
+- from: [View:{DescID: 113}, DROPPED]
+  to:   [ColumnName:{DescID: 113, Name: tableoid, ColumnID: 4294967294}, ABSENT]
+  kind: Precedence
+  rule: descriptor dropped before dependent element removal
+- from: [View:{DescID: 113}, DROPPED]
+  to:   [ColumnType:{DescID: 113, ColumnFamilyID: 0, ColumnID: 1}, ABSENT]
+  kind: Precedence
+  rule: descriptor dropped before dependent element removal
+- from: [View:{DescID: 113}, DROPPED]
+  to:   [ColumnType:{DescID: 113, ColumnFamilyID: 0, ColumnID: 4294967294}, ABSENT]
+  kind: Precedence
+  rule: descriptor dropped before dependent element removal
+- from: [View:{DescID: 113}, DROPPED]
+  to:   [ColumnType:{DescID: 113, ColumnFamilyID: 0, ColumnID: 4294967295}, ABSENT]
+  kind: Precedence
+  rule: descriptor dropped before dependent element removal
+- from: [View:{DescID: 113}, DROPPED]
+  to:   [ColumnType:{DescID: 113, ReferencedTypeIDs: [104 105], ColumnFamilyID: 0, ColumnID: 2}, ABSENT]
+  kind: Precedence
+  rule: descriptor dropped before dependent element removal
+- from: [View:{DescID: 113}, DROPPED]
+  to:   [ColumnType:{DescID: 113, ReferencedTypeIDs: [104 105], ColumnFamilyID: 0, ColumnID: 3}, ABSENT]
+  kind: Precedence
+  rule: descriptor dropped before dependent element removal
+- from: [View:{DescID: 113}, DROPPED]
+  to:   [Namespace:{DescID: 113, Name: v5, ReferencedDescID: 100}, ABSENT]
+  kind: Precedence
+  rule: descriptor dropped before dependent element removal
+- from: [View:{DescID: 113}, DROPPED]
+  to:   [ObjectParent:{DescID: 113, ReferencedDescID: 101}, ABSENT]
+  kind: SameStagePrecedence
+  rules: [descriptor dropped before dependent element removal; descriptor dropped right before removing back-reference in its parent descriptor]
+- from: [View:{DescID: 113}, DROPPED]
+  to:   [Owner:{DescID: 113}, ABSENT]
+  kind: Precedence
+  rule: descriptor dropped before dependent element removal
+- from: [View:{DescID: 113}, DROPPED]
+  to:   [UserPrivileges:{DescID: 113, Name: admin}, ABSENT]
+  kind: Precedence
+  rule: descriptor dropped before dependent element removal
+- from: [View:{DescID: 113}, DROPPED]
+  to:   [UserPrivileges:{DescID: 113, Name: root}, ABSENT]
+  kind: Precedence
+  rule: descriptor dropped before dependent element removal
+- from: [View:{DescID: 113}, DROPPED]
+  to:   [View:{DescID: 113}, ABSENT]
   kind: PreviousStagePrecedence
   rule: descriptor dropped in transaction before removal

--- a/pkg/sql/schemachanger/sctest/cumulative.go
+++ b/pkg/sql/schemachanger/sctest/cumulative.go
@@ -669,7 +669,11 @@ func Rollback(t *testing.T, relPath string, newCluster NewClusterFunc) {
 // minus any COMMENT ON statements because these aren't consistently backed up.
 const fetchDescriptorStateQuery = `
 SELECT
-	split_part(create_statement, ';', 1) AS create_statement
+	regexp_replace(
+	    split_part(create_statement, ';', 1),
+	    'CREATE VIEW (.*) AS SELECT .*',
+	    'CREATE VIEW \1 AS SELECT ...'
+	) AS create_statement
 FROM
 	( 
 		SELECT descriptor_id, create_statement FROM crdb_internal.create_schema_statements

--- a/pkg/sql/schemachanger/sctest_generated_test.go
+++ b/pkg/sql/schemachanger/sctest_generated_test.go
@@ -795,3 +795,28 @@ func TestRollback_drop_table(t *testing.T) {
 	defer log.Scope(t).Close(t)
 	sctest.Rollback(t, "pkg/sql/schemachanger/testdata/end_to_end/drop_table", sctest.SingleNodeCluster)
 }
+func TestEndToEndSideEffects_drop_type_cascade(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	sctest.EndToEndSideEffects(t, "pkg/sql/schemachanger/testdata/end_to_end/drop_type_cascade", sctest.SingleNodeCluster)
+}
+func TestExecuteWithDMLInjection_drop_type_cascade(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	sctest.ExecuteWithDMLInjection(t, "pkg/sql/schemachanger/testdata/end_to_end/drop_type_cascade", sctest.SingleNodeCluster)
+}
+func TestGenerateSchemaChangeCorpus_drop_type_cascade(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	sctest.GenerateSchemaChangeCorpus(t, "pkg/sql/schemachanger/testdata/end_to_end/drop_type_cascade", sctest.SingleNodeCluster)
+}
+func TestPause_drop_type_cascade(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	sctest.Pause(t, "pkg/sql/schemachanger/testdata/end_to_end/drop_type_cascade", sctest.SingleNodeCluster)
+}
+func TestRollback_drop_type_cascade(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	sctest.Rollback(t, "pkg/sql/schemachanger/testdata/end_to_end/drop_type_cascade", sctest.SingleNodeCluster)
+}

--- a/pkg/sql/schemachanger/testdata/end_to_end/create_function_in_txn
+++ b/pkg/sql/schemachanger/testdata/end_to_end/create_function_in_txn
@@ -498,11 +498,22 @@ upsert descriptor #104
   +  version: "7"
 upsert descriptor #105
   ...
-             1 $$"
-           statementTag: CREATE FUNCTION
+       authorization:
+         userName: root
+  -    currentStatuses: <redacted>
+       jobId: "1"
+  -    relevantStatements:
+  -    - statement:
+  -        redactedStatement: "CREATE FUNCTION ‹defaultdb›.‹public›.‹t›()\n\tRETURNS
+  -          INT8\n\tLANGUAGE SQL\n\tAS $$SELECT 1;$$"
+  -        statement: "CREATE FUNCTION t()\n\tRETURNS INT8\n\tLANGUAGE SQL\n\tAS $$ SELECT
+  -          1 $$"
+  -        statementTag: CREATE FUNCTION
   -    revertible: true
-       targetRanks: <redacted>
-       targets: <redacted>
+  -    targetRanks: <redacted>
+  -    targets: <redacted>
+     functionBody: SELECT 1;
+     id: 105
   ...
          oid: 20
          width: 64
@@ -578,17 +589,7 @@ upsert descriptor #105
   -  declarativeSchemaChangerState:
   -    authorization:
   -      userName: root
-  -    currentStatuses: <redacted>
   -    jobId: "1"
-  -    relevantStatements:
-  -    - statement:
-  -        redactedStatement: "CREATE FUNCTION ‹defaultdb›.‹public›.‹t›()\n\tRETURNS
-  -          INT8\n\tLANGUAGE SQL\n\tAS $$SELECT 1;$$"
-  -        statement: "CREATE FUNCTION t()\n\tRETURNS INT8\n\tLANGUAGE SQL\n\tAS $$ SELECT
-  -          1 $$"
-  -        statementTag: CREATE FUNCTION
-  -    targetRanks: <redacted>
-  -    targets: <redacted>
      functionBody: SELECT 1;
      id: 105
   ...

--- a/pkg/sql/schemachanger/testdata/end_to_end/drop_index_with_materialized_view_dep
+++ b/pkg/sql/schemachanger/testdata/end_to_end/drop_index_with_materialized_view_dep
@@ -244,7 +244,7 @@ notified job registry to adopt jobs: [1]
 begin transaction #2
 commit transaction #2
 begin transaction #3
-## PostCommitNonRevertiblePhase stage 1 of 2 with 6 MutationType ops
+## PostCommitNonRevertiblePhase stage 1 of 2 with 7 MutationType ops
 upsert descriptor #105
   ...
          keySuffixColumnIds:
@@ -265,6 +265,30 @@ upsert descriptor #105
   -  version: "11"
   +  version: "12"
      viewQuery: SELECT i, j FROM defaultdb.public.t1
+upsert descriptor #106
+  ...
+     createAsOfTime:
+       wallTime: "1640995200000000000"
+  -  declarativeSchemaChangerState:
+  -    authorization:
+  -      userName: root
+  -    currentStatuses: <redacted>
+  -    jobId: "1"
+  -    relevantStatements:
+  -    - statement:
+  -        redactedStatement: DROP INDEX ‹defaultdb›.‹public›.‹v2›@‹idx› CASCADE
+  -        statement: DROP INDEX idx CASCADE
+  -        statementTag: DROP INDEX
+  -    targetRanks: <redacted>
+  -    targets: <redacted>
+     dependsOn:
+     - 105
+  ...
+     state: DROP
+     unexposedParentSchemaId: 101
+  -  version: "3"
+  +  version: "4"
+     viewQuery: SELECT j FROM defaultdb.public.v2@idx
 persist all catalog changes to storage
 create job #2 (non-cancelable: true): "GC for DROP INDEX defaultdb.public.v2@idx CASCADE"
   descriptor IDs: [106]

--- a/pkg/sql/schemachanger/testdata/end_to_end/drop_type_cascade
+++ b/pkg/sql/schemachanger/testdata/end_to_end/drop_type_cascade
@@ -1,0 +1,1336 @@
+setup
+SET experimental_enable_unique_without_index_constraints = true;
+CREATE TYPE greeting AS ENUM('hello', 'hi');
+CREATE VIEW view AS SELECT 'hi'::greeting::string AS c;
+CREATE TABLE tbl (
+  id INT PRIMARY KEY,
+  gs greeting AS ('hi'::greeting) STORED,
+  gv string AS ('hello'::greeting::STRING) VIRTUAL,
+  other greeting[],
+  name STRING NOT NULL DEFAULT 'noname',
+  CONSTRAINT mycheck CHECK (gs::STRING = name),
+  CONSTRAINT myuwi UNIQUE WITHOUT INDEX (name) WHERE ('hi'::greeting::STRING = 'hi'),
+  INDEX partial (name) WHERE (gs::STRING = 'hi')
+);
+----
+...
++object {100 101 greeting} -> 104
++object {100 101 _greeting} -> 105
++object {100 101 view} -> 106
++object {100 101 tbl} -> 107
+
+stage-exec phase=PostCommitPhase stage=:
+INSERT INTO tbl VALUES($stageKey);
+INSERT INTO tbl VALUES($stageKey + 1);
+----
+
+# Each insert will be injected twice per stage, so we should always,
+# see a count of 2.
+stage-query phase=PostCommitPhase stage=:
+SELECT count(*)=$successfulStageCount*2 FROM tbl;
+----
+true
+
+
+stage-exec phase=PostCommitNonRevertiblePhase stage=:
+INSERT INTO tbl VALUES($stageKey);
+INSERT INTO tbl VALUES($stageKey + 1);
+----
+
+# Each insert will be injected twice per stage, so we should always,
+# see a count of 2.
+stage-query phase=PostCommitNonRevertiblePhase stage=:
+SELECT count(*)=$successfulStageCount*2 FROM tbl;
+----
+true
+
+test
+DROP TYPE greeting CASCADE
+----
+begin transaction #1
+# begin StatementPhase
+checking for feature: DROP TYPE
+increment telemetry for sql.udts.drop_enum
+write *eventpb.DropType to event log:
+  sql:
+    descriptorId: 104
+    statement: DROP TYPE ‹defaultdb›.‹public›.‹greeting› CASCADE
+    tag: DROP TYPE
+    user: root
+  typeName: defaultdb.public.greeting
+## StatementPhase stage 1 of 1 with 21 MutationType ops
+delete object namespace entry {100 101 view} -> 106
+upsert descriptor #104
+  ...
+       version: 2
+     referencingDescriptorIds:
+  -  - 106
+     - 107
+  -  version: "3"
+  +  version: "4"
+upsert descriptor #105
+  ...
+       version: 2
+     referencingDescriptorIds:
+  -  - 106
+     - 107
+  -  version: "3"
+  +  version: "4"
+upsert descriptor #106
+  ...
+     replacementOf:
+       time: {}
+  +  state: DROP
+     unexposedParentSchemaId: 101
+  -  version: "1"
+  +  version: "2"
+     viewQuery: SELECT b'\x80':::@100104::STRING AS c
+upsert descriptor #107
+  ...
+       - 5
+       constraintId: 2
+  -    expr: gs::STRING = name
+  -    name: mycheck
+  +    expr: crdb_internal_column_2_name_placeholder::STRING = name
+  +    name: crdb_internal_constraint_2_name_placeholder
+  +    validity: Dropping
+     columns:
+     - id: 1
+  ...
+         oid: 20
+         width: 64
+  -  - computeExpr: x'80':::@100104
+  -    id: 2
+  -    name: gs
+  -    nullable: true
+  -    type:
+  -      family: EnumFamily
+  -      oid: 100104
+  -      udtMetadata:
+  -        arrayTypeOid: 100105
+  -  - computeExpr: x'40':::@100104::STRING
+  -    id: 3
+  -    name: gv
+  -    nullable: true
+  -    type:
+  -      family: StringFamily
+  -      oid: 25
+  -    virtual: true
+  -  - id: 4
+  -    name: other
+  -    nullable: true
+  -    type:
+  -      arrayContents:
+  -        family: EnumFamily
+  -        oid: 100104
+  -        udtMetadata:
+  -          arrayTypeOid: 100105
+  -      arrayElemType: EnumFamily
+  -      family: ArrayFamily
+  -      oid: 100105
+     - defaultExpr: '''noname'':::STRING'
+       id: 5
+  ...
+       columnNames:
+       - id
+  -    - gs
+  -    - other
+  +    - crdb_internal_column_2_name_placeholder
+  +    - crdb_internal_column_4_name_placeholder
+       - name
+       name: primary
+     formatVersion: 3
+     id: 107
+  -  indexes:
+  -  - createdAtNanos: "1640995200000000000"
+  -    foreignKey: {}
+  -    geoConfig: {}
+  -    id: 2
+  -    interleave: {}
+  -    keyColumnDirections:
+  -    - ASC
+  -    keyColumnIds:
+  -    - 5
+  -    keyColumnNames:
+  -    - name
+  -    keySuffixColumnIds:
+  -    - 1
+  -    name: partial
+  -    partitioning: {}
+  -    predicate: gs::STRING = 'hi':::STRING
+  -    sharded: {}
+  -    version: 3
+  +  indexes: []
+     modificationTime: {}
+  +  mutations:
+  +  - column:
+  +      computeExpr: b'\x80':::@100104
+  +      id: 2
+  +      name: crdb_internal_column_2_name_placeholder
+  +      nullable: true
+  +      type:
+  +        family: EnumFamily
+  +        oid: 100104
+  +        udtMetadata:
+  +          arrayTypeOid: 100105
+  +    direction: DROP
+  +    mutationId: 1
+  +    state: WRITE_ONLY
+  +  - column:
+  +      computeExpr: b'@':::@100104::STRING
+  +      id: 3
+  +      name: crdb_internal_column_3_name_placeholder
+  +      nullable: true
+  +      type:
+  +        family: StringFamily
+  +        oid: 25
+  +      virtual: true
+  +    direction: DROP
+  +    mutationId: 1
+  +    state: WRITE_ONLY
+  +  - column:
+  +      id: 4
+  +      name: crdb_internal_column_4_name_placeholder
+  +      nullable: true
+  +      type:
+  +        arrayContents:
+  +          family: EnumFamily
+  +          oid: 100104
+  +          udtMetadata:
+  +            arrayTypeOid: 100105
+  +        arrayElemType: EnumFamily
+  +        family: ArrayFamily
+  +        oid: 100105
+  +    direction: DROP
+  +    mutationId: 1
+  +    state: WRITE_ONLY
+  +  - direction: DROP
+  +    index:
+  +      createdAtNanos: "1640995200000000000"
+  +      foreignKey: {}
+  +      geoConfig: {}
+  +      id: 2
+  +      interleave: {}
+  +      keyColumnDirections:
+  +      - ASC
+  +      keyColumnIds:
+  +      - 5
+  +      keyColumnNames:
+  +      - name
+  +      keySuffixColumnIds:
+  +      - 1
+  +      name: partial
+  +      partitioning: {}
+  +      predicate: crdb_internal_column_2_name_placeholder::STRING = 'hi':::STRING
+  +      sharded: {}
+  +      version: 3
+  +    mutationId: 1
+  +    state: WRITE_ONLY
+  +  - constraint:
+  +      check: {}
+  +      constraintType: UNIQUE_WITHOUT_INDEX
+  +      foreignKey: {}
+  +      name: myuwi
+  +      uniqueWithoutIndexConstraint:
+  +        columnIds:
+  +        - 5
+  +        constraintId: 3
+  +        name: crdb_internal_constraint_3_name_placeholder
+  +        predicate: x'80':::@100104::STRING = 'hi':::STRING
+  +        tableId: 107
+  +        validity: Dropping
+  +    direction: DROP
+  +    mutationId: 1
+  +    state: WRITE_ONLY
+  +  - constraint:
+  +      check:
+  +        columnIds:
+  +        - 2
+  +        - 5
+  +        constraintId: 2
+  +        expr: crdb_internal_column_2_name_placeholder::STRING = name
+  +        name: mycheck
+  +        validity: Dropping
+  +      foreignKey: {}
+  +      name: mycheck
+  +      uniqueWithoutIndexConstraint: {}
+  +    direction: DROP
+  +    mutationId: 1
+  +    state: WRITE_ONLY
+  +  - direction: ADD
+  +    index:
+  +      constraintId: 4
+  +      createdExplicitly: true
+  +      encodingType: 1
+  +      foreignKey: {}
+  +      geoConfig: {}
+  +      id: 3
+  +      interleave: {}
+  +      keyColumnDirections:
+  +      - ASC
+  +      keyColumnIds:
+  +      - 1
+  +      keyColumnNames:
+  +      - id
+  +      name: crdb_internal_index_3_name_placeholder
+  +      partitioning: {}
+  +      sharded: {}
+  +      storeColumnIds:
+  +      - 5
+  +      storeColumnNames:
+  +      - name
+  +      unique: true
+  +      version: 4
+  +    mutationId: 1
+  +    state: BACKFILLING
+  +  - direction: ADD
+  +    index:
+  +      constraintId: 5
+  +      createdExplicitly: true
+  +      encodingType: 1
+  +      foreignKey: {}
+  +      geoConfig: {}
+  +      id: 4
+  +      interleave: {}
+  +      keyColumnDirections:
+  +      - ASC
+  +      keyColumnIds:
+  +      - 1
+  +      keyColumnNames:
+  +      - id
+  +      name: crdb_internal_index_4_name_placeholder
+  +      partitioning: {}
+  +      sharded: {}
+  +      storeColumnIds:
+  +      - 5
+  +      storeColumnNames:
+  +      - name
+  +      unique: true
+  +      useDeletePreservingEncoding: true
+  +      version: 4
+  +    mutationId: 1
+  +    state: DELETE_ONLY
+     name: tbl
+     nextColumnId: 6
+  -  nextConstraintId: 4
+  +  nextConstraintId: 6
+     nextFamilyId: 1
+  -  nextIndexId: 3
+  +  nextIndexId: 5
+     nextMutationId: 1
+     parentId: 100
+  ...
+       - 5
+       storeColumnNames:
+  -    - gs
+  -    - other
+  +    - crdb_internal_column_2_name_placeholder
+  +    - crdb_internal_column_4_name_placeholder
+       - name
+       unique: true
+  ...
+       time: {}
+     unexposedParentSchemaId: 101
+  -  uniqueWithoutIndexConstraints:
+  -  - columnIds:
+  -    - 5
+  -    constraintId: 3
+  -    name: myuwi
+  -    predicate: x'80':::@100104::STRING = 'hi':::STRING
+  -    tableId: 107
+  -  version: "1"
+  +  version: "2"
+# end StatementPhase
+# begin PreCommitPhase
+## PreCommitPhase stage 1 of 2 with 1 MutationType op
+undo all catalog changes within txn #1
+persist all catalog changes to storage
+## PreCommitPhase stage 2 of 2 with 24 MutationType ops
+upsert descriptor #104
+   type:
+     arrayTypeId: 105
+  +  declarativeSchemaChangerState:
+  +    authorization:
+  +      userName: root
+  +    currentStatuses: <redacted>
+  +    jobId: "1"
+  +    relevantStatements:
+  +    - statement:
+  +        redactedStatement: DROP TYPE ‹defaultdb›.‹public›.‹greeting› CASCADE
+  +        statement: DROP TYPE greeting CASCADE
+  +        statementTag: DROP TYPE
+  +    revertible: true
+  +    targetRanks: <redacted>
+  +    targets: <redacted>
+     enumMembers:
+     - logicalRepresentation: hello
+  ...
+     - 106
+     - 107
+  -  version: "3"
+  +  version: "4"
+upsert descriptor #105
+  ...
+       family: ArrayFamily
+       oid: 100105
+  +  declarativeSchemaChangerState:
+  +    authorization:
+  +      userName: root
+  +    currentStatuses: <redacted>
+  +    jobId: "1"
+  +    relevantStatements:
+  +    - statement:
+  +        redactedStatement: DROP TYPE ‹defaultdb›.‹public›.‹greeting› CASCADE
+  +        statement: DROP TYPE greeting CASCADE
+  +        statementTag: DROP TYPE
+  +    revertible: true
+  +    targetRanks: <redacted>
+  +    targets: <redacted>
+     id: 105
+     kind: ALIAS
+  ...
+     - 106
+     - 107
+  -  version: "3"
+  +  version: "4"
+upsert descriptor #106
+  ...
+     createAsOfTime:
+       wallTime: "1640995200000000000"
+  +  declarativeSchemaChangerState:
+  +    authorization:
+  +      userName: root
+  +    currentStatuses: <redacted>
+  +    jobId: "1"
+  +    relevantStatements:
+  +    - statement:
+  +        redactedStatement: DROP TYPE ‹defaultdb›.‹public›.‹greeting› CASCADE
+  +        statement: DROP TYPE greeting CASCADE
+  +        statementTag: DROP TYPE
+  +    revertible: true
+  +    targetRanks: <redacted>
+  +    targets: <redacted>
+     dependsOnTypes:
+     - 104
+  ...
+       time: {}
+     unexposedParentSchemaId: 101
+  -  version: "1"
+  +  version: "2"
+     viewQuery: SELECT b'\x80':::@100104::STRING AS c
+upsert descriptor #107
+  ...
+       - 5
+       constraintId: 2
+  -    expr: gs::STRING = name
+  -    name: mycheck
+  +    expr: crdb_internal_column_2_name_placeholder::STRING = name
+  +    name: crdb_internal_constraint_2_name_placeholder
+  +    validity: Dropping
+     columns:
+     - id: 1
+  ...
+         oid: 20
+         width: 64
+  -  - computeExpr: x'80':::@100104
+  -    id: 2
+  -    name: gs
+  -    nullable: true
+  -    type:
+  -      family: EnumFamily
+  -      oid: 100104
+  -      udtMetadata:
+  -        arrayTypeOid: 100105
+  -  - computeExpr: x'40':::@100104::STRING
+  -    id: 3
+  -    name: gv
+  -    nullable: true
+  -    type:
+  -      family: StringFamily
+  -      oid: 25
+  -    virtual: true
+  -  - id: 4
+  -    name: other
+  -    nullable: true
+  -    type:
+  -      arrayContents:
+  -        family: EnumFamily
+  -        oid: 100104
+  -        udtMetadata:
+  -          arrayTypeOid: 100105
+  -      arrayElemType: EnumFamily
+  -      family: ArrayFamily
+  -      oid: 100105
+     - defaultExpr: '''noname'':::STRING'
+       id: 5
+  ...
+     createAsOfTime:
+       wallTime: "1640995200000000000"
+  +  declarativeSchemaChangerState:
+  +    authorization:
+  +      userName: root
+  +    currentStatuses: <redacted>
+  +    jobId: "1"
+  +    relevantStatements:
+  +    - statement:
+  +        redactedStatement: DROP TYPE ‹defaultdb›.‹public›.‹greeting› CASCADE
+  +        statement: DROP TYPE greeting CASCADE
+  +        statementTag: DROP TYPE
+  +    revertible: true
+  +    targetRanks: <redacted>
+  +    targets: <redacted>
+     families:
+     - columnIds:
+  ...
+       columnNames:
+       - id
+  -    - gs
+  -    - other
+  +    - crdb_internal_column_2_name_placeholder
+  +    - crdb_internal_column_4_name_placeholder
+       - name
+       name: primary
+     formatVersion: 3
+     id: 107
+  -  indexes:
+  -  - createdAtNanos: "1640995200000000000"
+  -    foreignKey: {}
+  -    geoConfig: {}
+  -    id: 2
+  -    interleave: {}
+  -    keyColumnDirections:
+  -    - ASC
+  -    keyColumnIds:
+  -    - 5
+  -    keyColumnNames:
+  -    - name
+  -    keySuffixColumnIds:
+  -    - 1
+  -    name: partial
+  -    partitioning: {}
+  -    predicate: gs::STRING = 'hi':::STRING
+  -    sharded: {}
+  -    version: 3
+  +  indexes: []
+     modificationTime: {}
+  +  mutations:
+  +  - column:
+  +      computeExpr: b'\x80':::@100104
+  +      id: 2
+  +      name: crdb_internal_column_2_name_placeholder
+  +      nullable: true
+  +      type:
+  +        family: EnumFamily
+  +        oid: 100104
+  +        udtMetadata:
+  +          arrayTypeOid: 100105
+  +    direction: DROP
+  +    mutationId: 1
+  +    state: WRITE_ONLY
+  +  - column:
+  +      computeExpr: b'@':::@100104::STRING
+  +      id: 3
+  +      name: crdb_internal_column_3_name_placeholder
+  +      nullable: true
+  +      type:
+  +        family: StringFamily
+  +        oid: 25
+  +      virtual: true
+  +    direction: DROP
+  +    mutationId: 1
+  +    state: WRITE_ONLY
+  +  - column:
+  +      id: 4
+  +      name: crdb_internal_column_4_name_placeholder
+  +      nullable: true
+  +      type:
+  +        arrayContents:
+  +          family: EnumFamily
+  +          oid: 100104
+  +          udtMetadata:
+  +            arrayTypeOid: 100105
+  +        arrayElemType: EnumFamily
+  +        family: ArrayFamily
+  +        oid: 100105
+  +    direction: DROP
+  +    mutationId: 1
+  +    state: WRITE_ONLY
+  +  - direction: DROP
+  +    index:
+  +      createdAtNanos: "1640995200000000000"
+  +      foreignKey: {}
+  +      geoConfig: {}
+  +      id: 2
+  +      interleave: {}
+  +      keyColumnDirections:
+  +      - ASC
+  +      keyColumnIds:
+  +      - 5
+  +      keyColumnNames:
+  +      - name
+  +      keySuffixColumnIds:
+  +      - 1
+  +      name: partial
+  +      partitioning: {}
+  +      predicate: crdb_internal_column_2_name_placeholder::STRING = 'hi':::STRING
+  +      sharded: {}
+  +      version: 3
+  +    mutationId: 1
+  +    state: WRITE_ONLY
+  +  - constraint:
+  +      check: {}
+  +      constraintType: UNIQUE_WITHOUT_INDEX
+  +      foreignKey: {}
+  +      name: myuwi
+  +      uniqueWithoutIndexConstraint:
+  +        columnIds:
+  +        - 5
+  +        constraintId: 3
+  +        name: crdb_internal_constraint_3_name_placeholder
+  +        predicate: x'80':::@100104::STRING = 'hi':::STRING
+  +        tableId: 107
+  +        validity: Dropping
+  +    direction: DROP
+  +    mutationId: 1
+  +    state: WRITE_ONLY
+  +  - constraint:
+  +      check:
+  +        columnIds:
+  +        - 2
+  +        - 5
+  +        constraintId: 2
+  +        expr: crdb_internal_column_2_name_placeholder::STRING = name
+  +        name: mycheck
+  +        validity: Dropping
+  +      foreignKey: {}
+  +      name: mycheck
+  +      uniqueWithoutIndexConstraint: {}
+  +    direction: DROP
+  +    mutationId: 1
+  +    state: WRITE_ONLY
+  +  - direction: ADD
+  +    index:
+  +      constraintId: 4
+  +      createdExplicitly: true
+  +      encodingType: 1
+  +      foreignKey: {}
+  +      geoConfig: {}
+  +      id: 3
+  +      interleave: {}
+  +      keyColumnDirections:
+  +      - ASC
+  +      keyColumnIds:
+  +      - 1
+  +      keyColumnNames:
+  +      - id
+  +      name: crdb_internal_index_3_name_placeholder
+  +      partitioning: {}
+  +      sharded: {}
+  +      storeColumnIds:
+  +      - 5
+  +      storeColumnNames:
+  +      - name
+  +      unique: true
+  +      version: 4
+  +    mutationId: 1
+  +    state: BACKFILLING
+  +  - direction: ADD
+  +    index:
+  +      constraintId: 5
+  +      createdExplicitly: true
+  +      encodingType: 1
+  +      foreignKey: {}
+  +      geoConfig: {}
+  +      id: 4
+  +      interleave: {}
+  +      keyColumnDirections:
+  +      - ASC
+  +      keyColumnIds:
+  +      - 1
+  +      keyColumnNames:
+  +      - id
+  +      name: crdb_internal_index_4_name_placeholder
+  +      partitioning: {}
+  +      sharded: {}
+  +      storeColumnIds:
+  +      - 5
+  +      storeColumnNames:
+  +      - name
+  +      unique: true
+  +      useDeletePreservingEncoding: true
+  +      version: 4
+  +    mutationId: 1
+  +    state: DELETE_ONLY
+     name: tbl
+     nextColumnId: 6
+  -  nextConstraintId: 4
+  +  nextConstraintId: 6
+     nextFamilyId: 1
+  -  nextIndexId: 3
+  +  nextIndexId: 5
+     nextMutationId: 1
+     parentId: 100
+  ...
+       - 5
+       storeColumnNames:
+  -    - gs
+  -    - other
+  +    - crdb_internal_column_2_name_placeholder
+  +    - crdb_internal_column_4_name_placeholder
+       - name
+       unique: true
+  ...
+       time: {}
+     unexposedParentSchemaId: 101
+  -  uniqueWithoutIndexConstraints:
+  -  - columnIds:
+  -    - 5
+  -    constraintId: 3
+  -    name: myuwi
+  -    predicate: x'80':::@100104::STRING = 'hi':::STRING
+  -    tableId: 107
+  -  version: "1"
+  +  version: "2"
+persist all catalog changes to storage
+create job #1 (non-cancelable: false): "DROP TYPE defaultdb.public.greeting CASCADE"
+  descriptor IDs: [104 105 106 107]
+# end PreCommitPhase
+commit transaction #1
+notified job registry to adopt jobs: [1]
+# begin PostCommitPhase
+begin transaction #2
+commit transaction #2
+begin transaction #3
+## PostCommitPhase stage 1 of 7 with 6 MutationType ops
+upsert descriptor #104
+  ...
+     - 106
+     - 107
+  -  version: "4"
+  +  version: "5"
+upsert descriptor #105
+  ...
+     - 106
+     - 107
+  -  version: "4"
+  +  version: "5"
+upsert descriptor #106
+  ...
+       time: {}
+     unexposedParentSchemaId: 101
+  -  version: "2"
+  +  version: "3"
+     viewQuery: SELECT b'\x80':::@100104::STRING AS c
+upsert descriptor #107
+  ...
+         version: 4
+       mutationId: 1
+  -    state: DELETE_ONLY
+  +    state: WRITE_ONLY
+     name: tbl
+     nextColumnId: 6
+  ...
+       time: {}
+     unexposedParentSchemaId: 101
+  -  version: "2"
+  +  version: "3"
+persist all catalog changes to storage
+update progress of schema change job #1: "PostCommitPhase stage 2 of 7 with 1 BackfillType op pending"
+commit transaction #3
+begin transaction #4
+## PostCommitPhase stage 2 of 7 with 1 BackfillType op
+backfill indexes [3] from index #1 in table #107
+commit transaction #4
+begin transaction #5
+## PostCommitPhase stage 3 of 7 with 6 MutationType ops
+upsert descriptor #104
+  ...
+     - 106
+     - 107
+  -  version: "5"
+  +  version: "6"
+upsert descriptor #105
+  ...
+     - 106
+     - 107
+  -  version: "5"
+  +  version: "6"
+upsert descriptor #106
+  ...
+       time: {}
+     unexposedParentSchemaId: 101
+  -  version: "3"
+  +  version: "4"
+     viewQuery: SELECT b'\x80':::@100104::STRING AS c
+upsert descriptor #107
+  ...
+         version: 4
+       mutationId: 1
+  -    state: BACKFILLING
+  +    state: DELETE_ONLY
+     - direction: ADD
+       index:
+  ...
+       time: {}
+     unexposedParentSchemaId: 101
+  -  version: "3"
+  +  version: "4"
+persist all catalog changes to storage
+update progress of schema change job #1: "PostCommitPhase stage 4 of 7 with 1 MutationType op pending"
+commit transaction #5
+begin transaction #6
+## PostCommitPhase stage 4 of 7 with 6 MutationType ops
+upsert descriptor #104
+  ...
+     - 106
+     - 107
+  -  version: "6"
+  +  version: "7"
+upsert descriptor #105
+  ...
+     - 106
+     - 107
+  -  version: "6"
+  +  version: "7"
+upsert descriptor #106
+  ...
+       time: {}
+     unexposedParentSchemaId: 101
+  -  version: "4"
+  +  version: "5"
+     viewQuery: SELECT b'\x80':::@100104::STRING AS c
+upsert descriptor #107
+  ...
+         version: 4
+       mutationId: 1
+  -    state: DELETE_ONLY
+  +    state: MERGING
+     - direction: ADD
+       index:
+  ...
+       time: {}
+     unexposedParentSchemaId: 101
+  -  version: "4"
+  +  version: "5"
+persist all catalog changes to storage
+update progress of schema change job #1: "PostCommitPhase stage 5 of 7 with 1 BackfillType op pending"
+commit transaction #6
+begin transaction #7
+## PostCommitPhase stage 5 of 7 with 1 BackfillType op
+merge temporary indexes [4] into backfilled indexes [3] in table #107
+commit transaction #7
+begin transaction #8
+## PostCommitPhase stage 6 of 7 with 6 MutationType ops
+upsert descriptor #104
+  ...
+     - 106
+     - 107
+  -  version: "7"
+  +  version: "8"
+upsert descriptor #105
+  ...
+     - 106
+     - 107
+  -  version: "7"
+  +  version: "8"
+upsert descriptor #106
+  ...
+       time: {}
+     unexposedParentSchemaId: 101
+  -  version: "5"
+  +  version: "6"
+     viewQuery: SELECT b'\x80':::@100104::STRING AS c
+upsert descriptor #107
+  ...
+         version: 4
+       mutationId: 1
+  -    state: MERGING
+  +    state: WRITE_ONLY
+     - direction: ADD
+       index:
+  ...
+       time: {}
+     unexposedParentSchemaId: 101
+  -  version: "5"
+  +  version: "6"
+persist all catalog changes to storage
+update progress of schema change job #1: "PostCommitPhase stage 7 of 7 with 1 ValidationType op pending"
+commit transaction #8
+begin transaction #9
+## PostCommitPhase stage 7 of 7 with 1 ValidationType op
+validate forward indexes [3] in table #107
+commit transaction #9
+begin transaction #10
+## PostCommitNonRevertiblePhase stage 1 of 4 with 24 MutationType ops
+delete object namespace entry {100 101 view} -> 106
+upsert descriptor #104
+  ...
+           statement: DROP TYPE greeting CASCADE
+           statementTag: DROP TYPE
+  -    revertible: true
+       targetRanks: <redacted>
+       targets: <redacted>
+  ...
+       version: 2
+     referencingDescriptorIds:
+  -  - 106
+     - 107
+  -  version: "8"
+  +  version: "9"
+upsert descriptor #105
+  ...
+           statement: DROP TYPE greeting CASCADE
+           statementTag: DROP TYPE
+  -    revertible: true
+       targetRanks: <redacted>
+       targets: <redacted>
+  ...
+       version: 2
+     referencingDescriptorIds:
+  -  - 106
+     - 107
+  -  version: "8"
+  +  version: "9"
+upsert descriptor #106
+  ...
+           statement: DROP TYPE greeting CASCADE
+           statementTag: DROP TYPE
+  -    revertible: true
+       targetRanks: <redacted>
+       targets: <redacted>
+  ...
+     replacementOf:
+       time: {}
+  +  state: DROP
+     unexposedParentSchemaId: 101
+  -  version: "6"
+  +  version: "7"
+     viewQuery: SELECT b'\x80':::@100104::STRING AS c
+upsert descriptor #107
+   table:
+  -  checks:
+  -  - columnIds:
+  -    - 2
+  -    - 5
+  -    constraintId: 2
+  -    expr: crdb_internal_column_2_name_placeholder::STRING = name
+  -    name: crdb_internal_constraint_2_name_placeholder
+  -    validity: Dropping
+  +  checks: []
+     columns:
+     - id: 1
+  ...
+           statement: DROP TYPE greeting CASCADE
+           statementTag: DROP TYPE
+  -    revertible: true
+       targetRanks: <redacted>
+       targets: <redacted>
+  ...
+       direction: DROP
+       mutationId: 1
+  -    state: WRITE_ONLY
+  +    state: DELETE_ONLY
+     - column:
+         computeExpr: b'@':::@100104::STRING
+  ...
+       direction: DROP
+       mutationId: 1
+  -    state: WRITE_ONLY
+  +    state: DELETE_ONLY
+     - column:
+         id: 4
+  ...
+       direction: DROP
+       mutationId: 1
+  -    state: WRITE_ONLY
+  +    state: DELETE_ONLY
+     - direction: DROP
+       index:
+  ...
+         keySuffixColumnIds:
+         - 1
+  -      name: partial
+  +      name: crdb_internal_index_2_name_placeholder
+         partitioning: {}
+         predicate: crdb_internal_column_2_name_placeholder::STRING = 'hi':::STRING
+  ...
+         version: 3
+       mutationId: 1
+  -    state: WRITE_ONLY
+  -  - constraint:
+  -      check: {}
+  -      constraintType: UNIQUE_WITHOUT_INDEX
+  -      foreignKey: {}
+  -      name: myuwi
+  -      uniqueWithoutIndexConstraint:
+  -        columnIds:
+  -        - 5
+  -        constraintId: 3
+  -        name: crdb_internal_constraint_3_name_placeholder
+  -        predicate: x'80':::@100104::STRING = 'hi':::STRING
+  -        tableId: 107
+  -        validity: Dropping
+  -    direction: DROP
+  -    mutationId: 1
+  -    state: WRITE_ONLY
+  -  - constraint:
+  -      check:
+  -        columnIds:
+  -        - 2
+  -        - 5
+  -        constraintId: 2
+  -        expr: crdb_internal_column_2_name_placeholder::STRING = name
+  -        name: mycheck
+  -        validity: Dropping
+  -      foreignKey: {}
+  -      name: mycheck
+  -      uniqueWithoutIndexConstraint: {}
+  -    direction: DROP
+  -    mutationId: 1
+  -    state: WRITE_ONLY
+  -  - direction: ADD
+  +    state: DELETE_ONLY
+  +  - direction: DROP
+       index:
+  -      constraintId: 4
+  +      constraintId: 5
+         createdExplicitly: true
+         encodingType: 1
+         foreignKey: {}
+         geoConfig: {}
+  -      id: 3
+  +      id: 4
+         interleave: {}
+         keyColumnDirections:
+  ...
+         keyColumnNames:
+         - id
+  -      name: crdb_internal_index_3_name_placeholder
+  +      name: crdb_internal_index_4_name_placeholder
+         partitioning: {}
+         sharded: {}
+  ...
+         - name
+         unique: true
+  +      useDeletePreservingEncoding: true
+         version: 4
+       mutationId: 1
+  -    state: WRITE_ONLY
+  -  - direction: ADD
+  +    state: DELETE_ONLY
+  +  - direction: DROP
+       index:
+  -      constraintId: 5
+  -      createdExplicitly: true
+  +      constraintId: 1
+  +      createdAtNanos: "1640995200000000000"
+         encodingType: 1
+         foreignKey: {}
+         geoConfig: {}
+  -      id: 4
+  +      id: 1
+         interleave: {}
+         keyColumnDirections:
+  ...
+         keyColumnNames:
+         - id
+  -      name: crdb_internal_index_4_name_placeholder
+  +      name: crdb_internal_index_1_name_placeholder
+         partitioning: {}
+         sharded: {}
+         storeColumnIds:
+  +      - 2
+  +      - 4
+         - 5
+         storeColumnNames:
+  +      - crdb_internal_column_2_name_placeholder
+  +      - crdb_internal_column_4_name_placeholder
+         - name
+         unique: true
+  -      useDeletePreservingEncoding: true
+         version: 4
+       mutationId: 1
+  ...
+     parentId: 100
+     primaryIndex:
+  -    constraintId: 1
+  -    createdAtNanos: "1640995200000000000"
+  +    constraintId: 4
+  +    createdExplicitly: true
+       encodingType: 1
+       foreignKey: {}
+       geoConfig: {}
+  -    id: 1
+  +    id: 3
+       interleave: {}
+       keyColumnDirections:
+  ...
+       sharded: {}
+       storeColumnIds:
+  -    - 2
+  -    - 4
+       - 5
+       storeColumnNames:
+  -    - crdb_internal_column_2_name_placeholder
+  -    - crdb_internal_column_4_name_placeholder
+       - name
+       unique: true
+  ...
+       time: {}
+     unexposedParentSchemaId: 101
+  -  version: "6"
+  +  version: "7"
+persist all catalog changes to storage
+update progress of schema change job #1: "PostCommitNonRevertiblePhase stage 2 of 4 with 5 MutationType ops pending"
+set schema change job #1 to non-cancellable
+commit transaction #10
+begin transaction #11
+## PostCommitNonRevertiblePhase stage 2 of 4 with 10 MutationType ops
+upsert descriptor #104
+  ...
+     referencingDescriptorIds:
+     - 107
+  -  version: "9"
+  +  version: "10"
+upsert descriptor #105
+  ...
+     referencingDescriptorIds:
+     - 107
+  -  version: "9"
+  +  version: "10"
+upsert descriptor #107
+  ...
+     - direction: DROP
+       index:
+  -      createdAtNanos: "1640995200000000000"
+  -      foreignKey: {}
+  -      geoConfig: {}
+  -      id: 2
+  -      interleave: {}
+  -      keyColumnDirections:
+  -      - ASC
+  -      keyColumnIds:
+  -      - 5
+  -      keyColumnNames:
+  -      - name
+  -      keySuffixColumnIds:
+  -      - 1
+  -      name: crdb_internal_index_2_name_placeholder
+  -      partitioning: {}
+  -      predicate: crdb_internal_column_2_name_placeholder::STRING = 'hi':::STRING
+  -      sharded: {}
+  -      version: 3
+  -    mutationId: 1
+  -    state: DELETE_ONLY
+  -  - direction: DROP
+  -    index:
+  -      constraintId: 5
+  -      createdExplicitly: true
+  -      encodingType: 1
+  -      foreignKey: {}
+  -      geoConfig: {}
+  -      id: 4
+  -      interleave: {}
+  -      keyColumnDirections:
+  -      - ASC
+  -      keyColumnIds:
+  -      - 1
+  -      keyColumnNames:
+  -      - id
+  -      name: crdb_internal_index_4_name_placeholder
+  -      partitioning: {}
+  -      sharded: {}
+  -      storeColumnIds:
+  -      - 5
+  -      storeColumnNames:
+  -      - name
+  -      unique: true
+  -      useDeletePreservingEncoding: true
+  -      version: 4
+  -    mutationId: 1
+  -    state: DELETE_ONLY
+  -  - direction: DROP
+  -    index:
+         constraintId: 1
+         createdAtNanos: "1640995200000000000"
+  ...
+         version: 4
+       mutationId: 1
+  -    state: WRITE_ONLY
+  +    state: DELETE_ONLY
+     name: tbl
+     nextColumnId: 6
+  ...
+       time: {}
+     unexposedParentSchemaId: 101
+  -  version: "7"
+  +  version: "8"
+delete descriptor #106
+persist all catalog changes to storage
+update progress of schema change job #1: "PostCommitNonRevertiblePhase stage 3 of 4 with 19 MutationType ops pending"
+set schema change job #1 to non-cancellable
+updated schema change job #1 descriptor IDs to [104 105 107]
+commit transaction #11
+begin transaction #12
+## PostCommitNonRevertiblePhase stage 3 of 4 with 23 MutationType ops
+delete object namespace entry {100 101 greeting} -> 104
+delete object namespace entry {100 101 _greeting} -> 105
+upsert descriptor #104
+  ...
+     referencingDescriptorIds:
+     - 107
+  -  version: "10"
+  +  state: DROP
+  +  version: "11"
+upsert descriptor #105
+  ...
+     referencingDescriptorIds:
+     - 107
+  -  version: "10"
+  +  state: DROP
+  +  version: "11"
+upsert descriptor #107
+  ...
+       authorization:
+         userName: root
+  -    currentStatuses: <redacted>
+       jobId: "1"
+  -    relevantStatements:
+  -    - statement:
+  -        redactedStatement: DROP TYPE ‹defaultdb›.‹public›.‹greeting› CASCADE
+  -        statement: DROP TYPE greeting CASCADE
+  -        statementTag: DROP TYPE
+  -    targetRanks: <redacted>
+  -    targets: <redacted>
+     families:
+     - columnIds:
+       - 1
+  -    - 2
+  -    - 4
+       - 5
+       columnNames:
+       - id
+  -    - crdb_internal_column_2_name_placeholder
+  -    - crdb_internal_column_4_name_placeholder
+       - name
+       name: primary
+  ...
+     indexes: []
+     modificationTime: {}
+  -  mutations:
+  -  - column:
+  -      computeExpr: b'\x80':::@100104
+  -      id: 2
+  -      name: crdb_internal_column_2_name_placeholder
+  -      nullable: true
+  -      type:
+  -        family: EnumFamily
+  -        oid: 100104
+  -        udtMetadata:
+  -          arrayTypeOid: 100105
+  -    direction: DROP
+  -    mutationId: 1
+  -    state: DELETE_ONLY
+  -  - column:
+  -      computeExpr: b'@':::@100104::STRING
+  -      id: 3
+  -      name: crdb_internal_column_3_name_placeholder
+  -      nullable: true
+  -      type:
+  -        family: StringFamily
+  -        oid: 25
+  -      virtual: true
+  -    direction: DROP
+  -    mutationId: 1
+  -    state: DELETE_ONLY
+  -  - column:
+  -      id: 4
+  -      name: crdb_internal_column_4_name_placeholder
+  -      nullable: true
+  -      type:
+  -        arrayContents:
+  -          family: EnumFamily
+  -          oid: 100104
+  -          udtMetadata:
+  -            arrayTypeOid: 100105
+  -        arrayElemType: EnumFamily
+  -        family: ArrayFamily
+  -        oid: 100105
+  -    direction: DROP
+  -    mutationId: 1
+  -    state: DELETE_ONLY
+  -  - direction: DROP
+  -    index:
+  -      constraintId: 1
+  -      createdAtNanos: "1640995200000000000"
+  -      encodingType: 1
+  -      foreignKey: {}
+  -      geoConfig: {}
+  -      id: 1
+  -      interleave: {}
+  -      keyColumnDirections:
+  -      - ASC
+  -      keyColumnIds:
+  -      - 1
+  -      keyColumnNames:
+  -      - id
+  -      name: crdb_internal_index_1_name_placeholder
+  -      partitioning: {}
+  -      sharded: {}
+  -      storeColumnIds:
+  -      - 2
+  -      - 4
+  -      - 5
+  -      storeColumnNames:
+  -      - crdb_internal_column_2_name_placeholder
+  -      - crdb_internal_column_4_name_placeholder
+  -      - name
+  -      unique: true
+  -      version: 4
+  -    mutationId: 1
+  -    state: DELETE_ONLY
+  +  mutations: []
+     name: tbl
+     nextColumnId: 6
+  ...
+       time: {}
+     unexposedParentSchemaId: 101
+  -  version: "8"
+  +  version: "9"
+persist all catalog changes to storage
+create job #2 (non-cancelable: true): "GC for DROP TYPE defaultdb.public.greeting CASCADE"
+  descriptor IDs: [107]
+update progress of schema change job #1: "PostCommitNonRevertiblePhase stage 4 of 4 with 2 MutationType ops pending"
+commit transaction #12
+notified job registry to adopt jobs: [2]
+begin transaction #13
+## PostCommitNonRevertiblePhase stage 4 of 4 with 6 MutationType ops
+upsert descriptor #107
+  ...
+     createAsOfTime:
+       wallTime: "1640995200000000000"
+  -  declarativeSchemaChangerState:
+  -    authorization:
+  -      userName: root
+  -    jobId: "1"
+     families:
+     - columnIds:
+  ...
+       time: {}
+     unexposedParentSchemaId: 101
+  -  version: "9"
+  +  version: "10"
+delete descriptor #104
+delete descriptor #105
+persist all catalog changes to storage
+update progress of schema change job #1: "all stages completed"
+set schema change job #1 to non-cancellable
+updated schema change job #1 descriptor IDs to [106]
+write *eventpb.FinishSchemaChange to event log:
+  sc:
+    descriptorId: 104
+write *eventpb.FinishSchemaChange to event log:
+  sc:
+    descriptorId: 107
+commit transaction #13
+# end PostCommitPhase

--- a/pkg/sql/schemachanger/testdata/explain/drop_index_with_materialized_view_dep
+++ b/pkg/sql/schemachanger/testdata/explain/drop_index_with_materialized_view_dep
@@ -132,12 +132,13 @@ Schema change plan for DROP INDEX ‹defaultdb›.‹public›.‹v2›@‹idx�
       │    │    ├── DROPPED   → ABSENT      View:{DescID: 106}
       │    │    ├── PUBLIC    → ABSENT      IndexData:{DescID: 106, IndexID: 1}
       │    │    └── PUBLIC    → ABSENT      TableData:{DescID: 106, ReferencedDescID: 100}
-      │    └── 6 Mutation operations
+      │    └── 7 Mutation operations
       │         ├── CreateGCJobForTable {"DatabaseID":100,"TableID":106}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":2,"TableID":105}
       │         ├── SetIndexName {"IndexID":2,"Name":"crdb_internal_in...","TableID":105}
       │         ├── CreateGCJobForIndex {"IndexID":1,"TableID":106}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":105}
+      │         ├── RemoveJobStateFromDescriptor {"DescriptorID":106}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
       └── Stage 2 of 2 in PostCommitNonRevertiblePhase
            ├── 2 elements transitioning toward ABSENT

--- a/pkg/sql/schemachanger/testdata/explain/drop_type_cascade
+++ b/pkg/sql/schemachanger/testdata/explain/drop_type_cascade
@@ -1,0 +1,374 @@
+/* setup */
+SET experimental_enable_unique_without_index_constraints = true;
+CREATE TYPE greeting AS ENUM('hello', 'hi');
+CREATE VIEW view AS SELECT 'hi'::greeting::string AS c;
+CREATE TABLE tbl (
+  id INT PRIMARY KEY,
+  gs greeting AS ('hi'::greeting) STORED,
+  gv string AS ('hello'::greeting::STRING) VIRTUAL,
+  other greeting[],
+  name STRING NOT NULL DEFAULT 'noname',
+  CONSTRAINT mycheck CHECK (gs::STRING = name),
+  CONSTRAINT myuwi UNIQUE WITHOUT INDEX (name) WHERE ('hi'::greeting::STRING = 'hi'),
+  INDEX partial (name) WHERE (gs::STRING = 'hi')
+);
+
+/* test */
+EXPLAIN (ddl) DROP TYPE greeting CASCADE;
+----
+Schema change plan for DROP TYPE ‹defaultdb›.‹public›.‹greeting› CASCADE;
+ ├── StatementPhase
+ │    └── Stage 1 of 1 in StatementPhase
+ │         ├── 5 elements transitioning toward PUBLIC
+ │         │    ├── ABSENT → BACKFILL_ONLY    PrimaryIndex:{DescID: 107, IndexID: 3, ConstraintID: 4, TemporaryIndexID: 4, SourceIndexID: 1}
+ │         │    ├── ABSENT → PUBLIC           IndexColumn:{DescID: 107, ColumnID: 1, IndexID: 3}
+ │         │    ├── ABSENT → PUBLIC           IndexColumn:{DescID: 107, ColumnID: 5, IndexID: 3}
+ │         │    ├── ABSENT → PUBLIC           IndexData:{DescID: 107, IndexID: 3}
+ │         │    └── ABSENT → PUBLIC           IndexColumn:{DescID: 107, ColumnID: 5, IndexID: 4}
+ │         ├── 2 elements transitioning toward TRANSIENT_ABSENT
+ │         │    ├── ABSENT → DELETE_ONLY      TemporaryIndex:{DescID: 107, IndexID: 4, ConstraintID: 5, SourceIndexID: 1}
+ │         │    └── ABSENT → TRANSIENT_ABSENT IndexColumn:{DescID: 107, ColumnID: 1, IndexID: 4}
+ │         ├── 28 elements transitioning toward ABSENT
+ │         │    ├── PUBLIC → ABSENT           Namespace:{DescID: 106, Name: view, ReferencedDescID: 100}
+ │         │    ├── PUBLIC → ABSENT           Owner:{DescID: 106}
+ │         │    ├── PUBLIC → ABSENT           UserPrivileges:{DescID: 106, Name: admin}
+ │         │    ├── PUBLIC → ABSENT           UserPrivileges:{DescID: 106, Name: root}
+ │         │    ├── PUBLIC → DROPPED          View:{DescID: 106}
+ │         │    ├── PUBLIC → ABSENT           ObjectParent:{DescID: 106, ReferencedDescID: 101}
+ │         │    ├── PUBLIC → WRITE_ONLY       Column:{DescID: 106, ColumnID: 1}
+ │         │    ├── PUBLIC → ABSENT           ColumnName:{DescID: 106, Name: c, ColumnID: 1}
+ │         │    ├── PUBLIC → ABSENT           ColumnType:{DescID: 106, ColumnFamilyID: 0, ColumnID: 1}
+ │         │    ├── PUBLIC → WRITE_ONLY       Column:{DescID: 106, ColumnID: 4294967295}
+ │         │    ├── PUBLIC → ABSENT           ColumnName:{DescID: 106, Name: crdb_internal_mvcc_timestamp, ColumnID: 4294967295}
+ │         │    ├── PUBLIC → ABSENT           ColumnType:{DescID: 106, ColumnFamilyID: 0, ColumnID: 4294967295}
+ │         │    ├── PUBLIC → WRITE_ONLY       Column:{DescID: 106, ColumnID: 4294967294}
+ │         │    ├── PUBLIC → ABSENT           ColumnName:{DescID: 106, Name: tableoid, ColumnID: 4294967294}
+ │         │    ├── PUBLIC → ABSENT           ColumnType:{DescID: 106, ColumnFamilyID: 0, ColumnID: 4294967294}
+ │         │    ├── PUBLIC → WRITE_ONLY       Column:{DescID: 107, ColumnID: 2}
+ │         │    ├── PUBLIC → ABSENT           ColumnName:{DescID: 107, Name: gs, ColumnID: 2}
+ │         │    ├── PUBLIC → WRITE_ONLY       Column:{DescID: 107, ColumnID: 3}
+ │         │    ├── PUBLIC → ABSENT           ColumnName:{DescID: 107, Name: gv, ColumnID: 3}
+ │         │    ├── PUBLIC → WRITE_ONLY       Column:{DescID: 107, ColumnID: 4}
+ │         │    ├── PUBLIC → ABSENT           ColumnName:{DescID: 107, Name: other, ColumnID: 4}
+ │         │    ├── PUBLIC → ABSENT           IndexColumn:{DescID: 107, ColumnID: 5, IndexID: 2}
+ │         │    ├── PUBLIC → ABSENT           IndexColumn:{DescID: 107, ColumnID: 1, IndexID: 2}
+ │         │    ├── PUBLIC → VALIDATED        SecondaryIndex:{DescID: 107, IndexID: 2, ConstraintID: 0}
+ │         │    ├── PUBLIC → VALIDATED        UniqueWithoutIndexConstraint:{DescID: 107, ConstraintID: 3}
+ │         │    ├── PUBLIC → ABSENT           ConstraintWithoutIndexName:{DescID: 107, Name: myuwi, ConstraintID: 3}
+ │         │    ├── PUBLIC → VALIDATED        CheckConstraint:{DescID: 107, IndexID: 0, ConstraintID: 2}
+ │         │    └── PUBLIC → ABSENT           ConstraintWithoutIndexName:{DescID: 107, Name: mycheck, ConstraintID: 2}
+ │         └── 21 Mutation operations
+ │              ├── MarkDescriptorAsDropped {"DescriptorID":106}
+ │              ├── RemoveBackReferenceInTypes {"BackReferencedDescriptorID":106}
+ │              ├── RemoveObjectParent {"ObjectID":106,"ParentSchemaID":101}
+ │              ├── MakePublicColumnWriteOnly {"ColumnID":2,"TableID":107}
+ │              ├── SetColumnName {"ColumnID":2,"Name":"crdb_internal_co...","TableID":107}
+ │              ├── MakePublicColumnWriteOnly {"ColumnID":3,"TableID":107}
+ │              ├── SetColumnName {"ColumnID":3,"Name":"crdb_internal_co...","TableID":107}
+ │              ├── MakePublicColumnWriteOnly {"ColumnID":4,"TableID":107}
+ │              ├── SetColumnName {"ColumnID":4,"Name":"crdb_internal_co...","TableID":107}
+ │              ├── MakePublicSecondaryIndexWriteOnly {"IndexID":2,"TableID":107}
+ │              ├── MakePublicUniqueWithoutIndexConstraintValidated {"ConstraintID":3,"TableID":107}
+ │              ├── SetConstraintName {"ConstraintID":3,"Name":"crdb_internal_co...","TableID":107}
+ │              ├── MakePublicCheckConstraintValidated {"ConstraintID":2,"TableID":107}
+ │              ├── SetConstraintName {"ConstraintID":2,"Name":"crdb_internal_co...","TableID":107}
+ │              ├── MakeAbsentIndexBackfilling {"Index":{"ConstraintID":4,"IndexID":3,"IsUnique":true,"SourceIndexID":1,"TableID":107,"TemporaryIndexID":4}}
+ │              ├── AddColumnToIndex {"ColumnID":1,"IndexID":3,"TableID":107}
+ │              ├── AddColumnToIndex {"ColumnID":5,"IndexID":3,"Kind":2,"TableID":107}
+ │              ├── MakeAbsentTempIndexDeleteOnly {"Index":{"ConstraintID":5,"IndexID":4,"IsUnique":true,"SourceIndexID":1,"TableID":107}}
+ │              ├── AddColumnToIndex {"ColumnID":1,"IndexID":4,"TableID":107}
+ │              ├── AddColumnToIndex {"ColumnID":5,"IndexID":4,"Kind":2,"TableID":107}
+ │              └── DrainDescriptorName {"Namespace":{"DatabaseID":100,"DescriptorID":106,"Name":"view","SchemaID":101}}
+ ├── PreCommitPhase
+ │    ├── Stage 1 of 2 in PreCommitPhase
+ │    │    ├── 5 elements transitioning toward PUBLIC
+ │    │    │    ├── BACKFILL_ONLY    → ABSENT PrimaryIndex:{DescID: 107, IndexID: 3, ConstraintID: 4, TemporaryIndexID: 4, SourceIndexID: 1}
+ │    │    │    ├── PUBLIC           → ABSENT IndexColumn:{DescID: 107, ColumnID: 1, IndexID: 3}
+ │    │    │    ├── PUBLIC           → ABSENT IndexColumn:{DescID: 107, ColumnID: 5, IndexID: 3}
+ │    │    │    ├── PUBLIC           → ABSENT IndexData:{DescID: 107, IndexID: 3}
+ │    │    │    └── PUBLIC           → ABSENT IndexColumn:{DescID: 107, ColumnID: 5, IndexID: 4}
+ │    │    ├── 2 elements transitioning toward TRANSIENT_ABSENT
+ │    │    │    ├── DELETE_ONLY      → ABSENT TemporaryIndex:{DescID: 107, IndexID: 4, ConstraintID: 5, SourceIndexID: 1}
+ │    │    │    └── TRANSIENT_ABSENT → ABSENT IndexColumn:{DescID: 107, ColumnID: 1, IndexID: 4}
+ │    │    ├── 28 elements transitioning toward ABSENT
+ │    │    │    ├── ABSENT           → PUBLIC Namespace:{DescID: 106, Name: view, ReferencedDescID: 100}
+ │    │    │    ├── ABSENT           → PUBLIC Owner:{DescID: 106}
+ │    │    │    ├── ABSENT           → PUBLIC UserPrivileges:{DescID: 106, Name: admin}
+ │    │    │    ├── ABSENT           → PUBLIC UserPrivileges:{DescID: 106, Name: root}
+ │    │    │    ├── DROPPED          → PUBLIC View:{DescID: 106}
+ │    │    │    ├── ABSENT           → PUBLIC ObjectParent:{DescID: 106, ReferencedDescID: 101}
+ │    │    │    ├── WRITE_ONLY       → PUBLIC Column:{DescID: 106, ColumnID: 1}
+ │    │    │    ├── ABSENT           → PUBLIC ColumnName:{DescID: 106, Name: c, ColumnID: 1}
+ │    │    │    ├── ABSENT           → PUBLIC ColumnType:{DescID: 106, ColumnFamilyID: 0, ColumnID: 1}
+ │    │    │    ├── WRITE_ONLY       → PUBLIC Column:{DescID: 106, ColumnID: 4294967295}
+ │    │    │    ├── ABSENT           → PUBLIC ColumnName:{DescID: 106, Name: crdb_internal_mvcc_timestamp, ColumnID: 4294967295}
+ │    │    │    ├── ABSENT           → PUBLIC ColumnType:{DescID: 106, ColumnFamilyID: 0, ColumnID: 4294967295}
+ │    │    │    ├── WRITE_ONLY       → PUBLIC Column:{DescID: 106, ColumnID: 4294967294}
+ │    │    │    ├── ABSENT           → PUBLIC ColumnName:{DescID: 106, Name: tableoid, ColumnID: 4294967294}
+ │    │    │    ├── ABSENT           → PUBLIC ColumnType:{DescID: 106, ColumnFamilyID: 0, ColumnID: 4294967294}
+ │    │    │    ├── WRITE_ONLY       → PUBLIC Column:{DescID: 107, ColumnID: 2}
+ │    │    │    ├── ABSENT           → PUBLIC ColumnName:{DescID: 107, Name: gs, ColumnID: 2}
+ │    │    │    ├── WRITE_ONLY       → PUBLIC Column:{DescID: 107, ColumnID: 3}
+ │    │    │    ├── ABSENT           → PUBLIC ColumnName:{DescID: 107, Name: gv, ColumnID: 3}
+ │    │    │    ├── WRITE_ONLY       → PUBLIC Column:{DescID: 107, ColumnID: 4}
+ │    │    │    ├── ABSENT           → PUBLIC ColumnName:{DescID: 107, Name: other, ColumnID: 4}
+ │    │    │    ├── ABSENT           → PUBLIC IndexColumn:{DescID: 107, ColumnID: 5, IndexID: 2}
+ │    │    │    ├── ABSENT           → PUBLIC IndexColumn:{DescID: 107, ColumnID: 1, IndexID: 2}
+ │    │    │    ├── VALIDATED        → PUBLIC SecondaryIndex:{DescID: 107, IndexID: 2, ConstraintID: 0}
+ │    │    │    ├── VALIDATED        → PUBLIC UniqueWithoutIndexConstraint:{DescID: 107, ConstraintID: 3}
+ │    │    │    ├── ABSENT           → PUBLIC ConstraintWithoutIndexName:{DescID: 107, Name: myuwi, ConstraintID: 3}
+ │    │    │    ├── VALIDATED        → PUBLIC CheckConstraint:{DescID: 107, IndexID: 0, ConstraintID: 2}
+ │    │    │    └── ABSENT           → PUBLIC ConstraintWithoutIndexName:{DescID: 107, Name: mycheck, ConstraintID: 2}
+ │    │    └── 1 Mutation operation
+ │    │         └── UndoAllInTxnImmediateMutationOpSideEffects
+ │    └── Stage 2 of 2 in PreCommitPhase
+ │         ├── 5 elements transitioning toward PUBLIC
+ │         │    ├── ABSENT → BACKFILL_ONLY PrimaryIndex:{DescID: 107, IndexID: 3, ConstraintID: 4, TemporaryIndexID: 4, SourceIndexID: 1}
+ │         │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 107, ColumnID: 1, IndexID: 3}
+ │         │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 107, ColumnID: 5, IndexID: 3}
+ │         │    ├── ABSENT → PUBLIC        IndexData:{DescID: 107, IndexID: 3}
+ │         │    └── ABSENT → PUBLIC        IndexColumn:{DescID: 107, ColumnID: 5, IndexID: 4}
+ │         ├── 2 elements transitioning toward TRANSIENT_ABSENT
+ │         │    ├── ABSENT → DELETE_ONLY   TemporaryIndex:{DescID: 107, IndexID: 4, ConstraintID: 5, SourceIndexID: 1}
+ │         │    └── ABSENT → PUBLIC        IndexColumn:{DescID: 107, ColumnID: 1, IndexID: 4}
+ │         ├── 11 elements transitioning toward ABSENT
+ │         │    ├── PUBLIC → WRITE_ONLY    Column:{DescID: 107, ColumnID: 2}
+ │         │    ├── PUBLIC → ABSENT        ColumnName:{DescID: 107, Name: gs, ColumnID: 2}
+ │         │    ├── PUBLIC → WRITE_ONLY    Column:{DescID: 107, ColumnID: 3}
+ │         │    ├── PUBLIC → ABSENT        ColumnName:{DescID: 107, Name: gv, ColumnID: 3}
+ │         │    ├── PUBLIC → WRITE_ONLY    Column:{DescID: 107, ColumnID: 4}
+ │         │    ├── PUBLIC → ABSENT        ColumnName:{DescID: 107, Name: other, ColumnID: 4}
+ │         │    ├── PUBLIC → VALIDATED     SecondaryIndex:{DescID: 107, IndexID: 2, ConstraintID: 0}
+ │         │    ├── PUBLIC → VALIDATED     UniqueWithoutIndexConstraint:{DescID: 107, ConstraintID: 3}
+ │         │    ├── PUBLIC → ABSENT        ConstraintWithoutIndexName:{DescID: 107, Name: myuwi, ConstraintID: 3}
+ │         │    ├── PUBLIC → VALIDATED     CheckConstraint:{DescID: 107, IndexID: 0, ConstraintID: 2}
+ │         │    └── PUBLIC → ABSENT        ConstraintWithoutIndexName:{DescID: 107, Name: mycheck, ConstraintID: 2}
+ │         └── 24 Mutation operations
+ │              ├── MakePublicColumnWriteOnly {"ColumnID":2,"TableID":107}
+ │              ├── SetColumnName {"ColumnID":2,"Name":"crdb_internal_co...","TableID":107}
+ │              ├── MakePublicColumnWriteOnly {"ColumnID":3,"TableID":107}
+ │              ├── SetColumnName {"ColumnID":3,"Name":"crdb_internal_co...","TableID":107}
+ │              ├── MakePublicColumnWriteOnly {"ColumnID":4,"TableID":107}
+ │              ├── SetColumnName {"ColumnID":4,"Name":"crdb_internal_co...","TableID":107}
+ │              ├── MakePublicSecondaryIndexWriteOnly {"IndexID":2,"TableID":107}
+ │              ├── MakePublicUniqueWithoutIndexConstraintValidated {"ConstraintID":3,"TableID":107}
+ │              ├── SetConstraintName {"ConstraintID":3,"Name":"crdb_internal_co...","TableID":107}
+ │              ├── MakePublicCheckConstraintValidated {"ConstraintID":2,"TableID":107}
+ │              ├── SetConstraintName {"ConstraintID":2,"Name":"crdb_internal_co...","TableID":107}
+ │              ├── MakeAbsentIndexBackfilling {"Index":{"ConstraintID":4,"IndexID":3,"IsUnique":true,"SourceIndexID":1,"TableID":107,"TemporaryIndexID":4}}
+ │              ├── MaybeAddSplitForIndex {"IndexID":3,"TableID":107}
+ │              ├── AddColumnToIndex {"ColumnID":1,"IndexID":3,"TableID":107}
+ │              ├── AddColumnToIndex {"ColumnID":5,"IndexID":3,"Kind":2,"TableID":107}
+ │              ├── MakeAbsentTempIndexDeleteOnly {"Index":{"ConstraintID":5,"IndexID":4,"IsUnique":true,"SourceIndexID":1,"TableID":107}}
+ │              ├── MaybeAddSplitForIndex {"IndexID":4,"TableID":107}
+ │              ├── AddColumnToIndex {"ColumnID":1,"IndexID":4,"TableID":107}
+ │              ├── AddColumnToIndex {"ColumnID":5,"IndexID":4,"Kind":2,"TableID":107}
+ │              ├── SetJobStateOnDescriptor {"DescriptorID":104,"Initialize":true}
+ │              ├── SetJobStateOnDescriptor {"DescriptorID":105,"Initialize":true}
+ │              ├── SetJobStateOnDescriptor {"DescriptorID":106,"Initialize":true}
+ │              ├── SetJobStateOnDescriptor {"DescriptorID":107,"Initialize":true}
+ │              └── CreateSchemaChangerJob {"RunningStatus":"PostCommitPhase ..."}
+ ├── PostCommitPhase
+ │    ├── Stage 1 of 7 in PostCommitPhase
+ │    │    ├── 2 elements transitioning toward TRANSIENT_ABSENT
+ │    │    │    ├── DELETE_ONLY → WRITE_ONLY TemporaryIndex:{DescID: 107, IndexID: 4, ConstraintID: 5, SourceIndexID: 1}
+ │    │    │    └── ABSENT      → PUBLIC     IndexData:{DescID: 107, IndexID: 4}
+ │    │    └── 6 Mutation operations
+ │    │         ├── MakeDeleteOnlyIndexWriteOnly {"IndexID":4,"TableID":107}
+ │    │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
+ │    │         ├── SetJobStateOnDescriptor {"DescriptorID":105}
+ │    │         ├── SetJobStateOnDescriptor {"DescriptorID":106}
+ │    │         ├── SetJobStateOnDescriptor {"DescriptorID":107}
+ │    │         └── UpdateSchemaChangerJob {"RunningStatus":"PostCommitPhase ..."}
+ │    ├── Stage 2 of 7 in PostCommitPhase
+ │    │    ├── 1 element transitioning toward PUBLIC
+ │    │    │    └── BACKFILL_ONLY → BACKFILLED PrimaryIndex:{DescID: 107, IndexID: 3, ConstraintID: 4, TemporaryIndexID: 4, SourceIndexID: 1}
+ │    │    └── 1 Backfill operation
+ │    │         └── BackfillIndex {"IndexID":3,"SourceIndexID":1,"TableID":107}
+ │    ├── Stage 3 of 7 in PostCommitPhase
+ │    │    ├── 1 element transitioning toward PUBLIC
+ │    │    │    └── BACKFILLED → DELETE_ONLY PrimaryIndex:{DescID: 107, IndexID: 3, ConstraintID: 4, TemporaryIndexID: 4, SourceIndexID: 1}
+ │    │    └── 6 Mutation operations
+ │    │         ├── MakeBackfillingIndexDeleteOnly {"IndexID":3,"TableID":107}
+ │    │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
+ │    │         ├── SetJobStateOnDescriptor {"DescriptorID":105}
+ │    │         ├── SetJobStateOnDescriptor {"DescriptorID":106}
+ │    │         ├── SetJobStateOnDescriptor {"DescriptorID":107}
+ │    │         └── UpdateSchemaChangerJob {"RunningStatus":"PostCommitPhase ..."}
+ │    ├── Stage 4 of 7 in PostCommitPhase
+ │    │    ├── 1 element transitioning toward PUBLIC
+ │    │    │    └── DELETE_ONLY → MERGE_ONLY PrimaryIndex:{DescID: 107, IndexID: 3, ConstraintID: 4, TemporaryIndexID: 4, SourceIndexID: 1}
+ │    │    └── 6 Mutation operations
+ │    │         ├── MakeBackfilledIndexMerging {"IndexID":3,"TableID":107}
+ │    │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
+ │    │         ├── SetJobStateOnDescriptor {"DescriptorID":105}
+ │    │         ├── SetJobStateOnDescriptor {"DescriptorID":106}
+ │    │         ├── SetJobStateOnDescriptor {"DescriptorID":107}
+ │    │         └── UpdateSchemaChangerJob {"RunningStatus":"PostCommitPhase ..."}
+ │    ├── Stage 5 of 7 in PostCommitPhase
+ │    │    ├── 1 element transitioning toward PUBLIC
+ │    │    │    └── MERGE_ONLY → MERGED PrimaryIndex:{DescID: 107, IndexID: 3, ConstraintID: 4, TemporaryIndexID: 4, SourceIndexID: 1}
+ │    │    └── 1 Backfill operation
+ │    │         └── MergeIndex {"BackfilledIndexID":3,"TableID":107,"TemporaryIndexID":4}
+ │    ├── Stage 6 of 7 in PostCommitPhase
+ │    │    ├── 1 element transitioning toward PUBLIC
+ │    │    │    └── MERGED → WRITE_ONLY PrimaryIndex:{DescID: 107, IndexID: 3, ConstraintID: 4, TemporaryIndexID: 4, SourceIndexID: 1}
+ │    │    └── 6 Mutation operations
+ │    │         ├── MakeMergedIndexWriteOnly {"IndexID":3,"TableID":107}
+ │    │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
+ │    │         ├── SetJobStateOnDescriptor {"DescriptorID":105}
+ │    │         ├── SetJobStateOnDescriptor {"DescriptorID":106}
+ │    │         ├── SetJobStateOnDescriptor {"DescriptorID":107}
+ │    │         └── UpdateSchemaChangerJob {"RunningStatus":"PostCommitPhase ..."}
+ │    └── Stage 7 of 7 in PostCommitPhase
+ │         ├── 1 element transitioning toward PUBLIC
+ │         │    └── WRITE_ONLY → VALIDATED PrimaryIndex:{DescID: 107, IndexID: 3, ConstraintID: 4, TemporaryIndexID: 4, SourceIndexID: 1}
+ │         └── 1 Validation operation
+ │              └── ValidateIndex {"IndexID":3,"TableID":107}
+ └── PostCommitNonRevertiblePhase
+      ├── Stage 1 of 4 in PostCommitNonRevertiblePhase
+      │    ├── 2 elements transitioning toward PUBLIC
+      │    │    ├── VALIDATED  → PUBLIC                PrimaryIndex:{DescID: 107, IndexID: 3, ConstraintID: 4, TemporaryIndexID: 4, SourceIndexID: 1}
+      │    │    └── ABSENT     → PUBLIC                IndexName:{DescID: 107, Name: tbl_pkey, IndexID: 3}
+      │    ├── 2 elements transitioning toward TRANSIENT_ABSENT
+      │    │    ├── WRITE_ONLY → TRANSIENT_DELETE_ONLY TemporaryIndex:{DescID: 107, IndexID: 4, ConstraintID: 5, SourceIndexID: 1}
+      │    │    └── PUBLIC     → TRANSIENT_ABSENT      IndexColumn:{DescID: 107, ColumnID: 1, IndexID: 4}
+      │    ├── 30 elements transitioning toward ABSENT
+      │    │    ├── PUBLIC     → ABSENT                Namespace:{DescID: 106, Name: view, ReferencedDescID: 100}
+      │    │    ├── PUBLIC     → ABSENT                Owner:{DescID: 106}
+      │    │    ├── PUBLIC     → ABSENT                UserPrivileges:{DescID: 106, Name: admin}
+      │    │    ├── PUBLIC     → ABSENT                UserPrivileges:{DescID: 106, Name: root}
+      │    │    ├── PUBLIC     → DROPPED               View:{DescID: 106}
+      │    │    ├── PUBLIC     → ABSENT                ObjectParent:{DescID: 106, ReferencedDescID: 101}
+      │    │    ├── PUBLIC     → ABSENT                Column:{DescID: 106, ColumnID: 1}
+      │    │    ├── PUBLIC     → ABSENT                ColumnName:{DescID: 106, Name: c, ColumnID: 1}
+      │    │    ├── PUBLIC     → ABSENT                ColumnType:{DescID: 106, ColumnFamilyID: 0, ColumnID: 1}
+      │    │    ├── PUBLIC     → ABSENT                Column:{DescID: 106, ColumnID: 4294967295}
+      │    │    ├── PUBLIC     → ABSENT                ColumnName:{DescID: 106, Name: crdb_internal_mvcc_timestamp, ColumnID: 4294967295}
+      │    │    ├── PUBLIC     → ABSENT                ColumnType:{DescID: 106, ColumnFamilyID: 0, ColumnID: 4294967295}
+      │    │    ├── PUBLIC     → ABSENT                Column:{DescID: 106, ColumnID: 4294967294}
+      │    │    ├── PUBLIC     → ABSENT                ColumnName:{DescID: 106, Name: tableoid, ColumnID: 4294967294}
+      │    │    ├── PUBLIC     → ABSENT                ColumnType:{DescID: 106, ColumnFamilyID: 0, ColumnID: 4294967294}
+      │    │    ├── WRITE_ONLY → DELETE_ONLY           Column:{DescID: 107, ColumnID: 2}
+      │    │    ├── WRITE_ONLY → DELETE_ONLY           Column:{DescID: 107, ColumnID: 3}
+      │    │    ├── WRITE_ONLY → DELETE_ONLY           Column:{DescID: 107, ColumnID: 4}
+      │    │    ├── PUBLIC     → ABSENT                IndexColumn:{DescID: 107, ColumnID: 1, IndexID: 1}
+      │    │    ├── PUBLIC     → ABSENT                IndexColumn:{DescID: 107, ColumnID: 2, IndexID: 1}
+      │    │    ├── PUBLIC     → ABSENT                IndexColumn:{DescID: 107, ColumnID: 4, IndexID: 1}
+      │    │    ├── PUBLIC     → ABSENT                IndexColumn:{DescID: 107, ColumnID: 5, IndexID: 1}
+      │    │    ├── PUBLIC     → VALIDATED             PrimaryIndex:{DescID: 107, IndexID: 1, ConstraintID: 1}
+      │    │    ├── PUBLIC     → ABSENT                IndexName:{DescID: 107, Name: tbl_pkey, IndexID: 1}
+      │    │    ├── PUBLIC     → ABSENT                IndexColumn:{DescID: 107, ColumnID: 5, IndexID: 2}
+      │    │    ├── PUBLIC     → ABSENT                IndexColumn:{DescID: 107, ColumnID: 1, IndexID: 2}
+      │    │    ├── VALIDATED  → DELETE_ONLY           SecondaryIndex:{DescID: 107, IndexID: 2, ConstraintID: 0}
+      │    │    ├── PUBLIC     → ABSENT                IndexName:{DescID: 107, Name: partial, IndexID: 2}
+      │    │    ├── VALIDATED  → ABSENT                UniqueWithoutIndexConstraint:{DescID: 107, ConstraintID: 3}
+      │    │    └── VALIDATED  → ABSENT                CheckConstraint:{DescID: 107, IndexID: 0, ConstraintID: 2}
+      │    └── 24 Mutation operations
+      │         ├── MarkDescriptorAsDropped {"DescriptorID":106}
+      │         ├── RemoveBackReferenceInTypes {"BackReferencedDescriptorID":106}
+      │         ├── RemoveObjectParent {"ObjectID":106,"ParentSchemaID":101}
+      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":2,"TableID":107}
+      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":3,"TableID":107}
+      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":4,"TableID":107}
+      │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":1,"TableID":107}
+      │         ├── SetIndexName {"IndexID":1,"Name":"crdb_internal_in...","TableID":107}
+      │         ├── RemoveUniqueWithoutIndexConstraint {"ConstraintID":3,"TableID":107}
+      │         ├── RemoveCheckConstraint {"ConstraintID":2,"TableID":107}
+      │         ├── SetIndexName {"IndexID":3,"Name":"tbl_pkey","TableID":107}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":4,"TableID":107}
+      │         ├── DrainDescriptorName {"Namespace":{"DatabaseID":100,"DescriptorID":106,"Name":"view","SchemaID":101}}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":2,"TableID":107}
+      │         ├── SetIndexName {"IndexID":2,"Name":"crdb_internal_in...","TableID":107}
+      │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":3,"TableID":107}
+      │         ├── MakeDeleteOnlyColumnAbsent {"ColumnID":1,"TableID":106}
+      │         ├── MakeDeleteOnlyColumnAbsent {"ColumnID":4294967295,"TableID":106}
+      │         ├── MakeDeleteOnlyColumnAbsent {"ColumnID":4294967294,"TableID":106}
+      │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
+      │         ├── SetJobStateOnDescriptor {"DescriptorID":105}
+      │         ├── SetJobStateOnDescriptor {"DescriptorID":106}
+      │         ├── SetJobStateOnDescriptor {"DescriptorID":107}
+      │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
+      ├── Stage 2 of 4 in PostCommitNonRevertiblePhase
+      │    ├── 1 element transitioning toward TRANSIENT_ABSENT
+      │    │    └── TRANSIENT_DELETE_ONLY → TRANSIENT_ABSENT TemporaryIndex:{DescID: 107, IndexID: 4, ConstraintID: 5, SourceIndexID: 1}
+      │    ├── 4 elements transitioning toward ABSENT
+      │    │    ├── DROPPED               → ABSENT           View:{DescID: 106}
+      │    │    ├── VALIDATED             → DELETE_ONLY      PrimaryIndex:{DescID: 107, IndexID: 1, ConstraintID: 1}
+      │    │    ├── PUBLIC                → ABSENT           SecondaryIndexPartial:{DescID: 107, IndexID: 2}
+      │    │    └── DELETE_ONLY           → ABSENT           SecondaryIndex:{DescID: 107, IndexID: 2, ConstraintID: 0}
+      │    └── 10 Mutation operations
+      │         ├── DeleteDescriptor {"DescriptorID":106}
+      │         ├── RemoveDroppedIndexPartialPredicate {"IndexID":2,"TableID":107}
+      │         ├── MakeIndexAbsent {"IndexID":2,"TableID":107}
+      │         ├── MakeIndexAbsent {"IndexID":4,"TableID":107}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":1,"TableID":107}
+      │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
+      │         ├── SetJobStateOnDescriptor {"DescriptorID":105}
+      │         ├── RemoveJobStateFromDescriptor {"DescriptorID":106}
+      │         ├── SetJobStateOnDescriptor {"DescriptorID":107}
+      │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
+      ├── Stage 3 of 4 in PostCommitNonRevertiblePhase
+      │    ├── 1 element transitioning toward TRANSIENT_ABSENT
+      │    │    └── PUBLIC      → TRANSIENT_ABSENT IndexData:{DescID: 107, IndexID: 4}
+      │    ├── 25 elements transitioning toward ABSENT
+      │    │    ├── PUBLIC      → ABSENT           Namespace:{DescID: 104, Name: greeting, ReferencedDescID: 100}
+      │    │    ├── PUBLIC      → ABSENT           Owner:{DescID: 104}
+      │    │    ├── PUBLIC      → ABSENT           UserPrivileges:{DescID: 104, Name: admin}
+      │    │    ├── PUBLIC      → ABSENT           UserPrivileges:{DescID: 104, Name: public}
+      │    │    ├── PUBLIC      → ABSENT           UserPrivileges:{DescID: 104, Name: root}
+      │    │    ├── PUBLIC      → DROPPED          EnumType:{DescID: 104}
+      │    │    ├── PUBLIC      → ABSENT           EnumTypeValue:{DescID: 104, Name: hello}
+      │    │    ├── PUBLIC      → ABSENT           EnumTypeValue:{DescID: 104, Name: hi}
+      │    │    ├── PUBLIC      → ABSENT           ObjectParent:{DescID: 104, ReferencedDescID: 101}
+      │    │    ├── PUBLIC      → ABSENT           Namespace:{DescID: 105, Name: _greeting, ReferencedDescID: 100}
+      │    │    ├── PUBLIC      → ABSENT           Owner:{DescID: 105}
+      │    │    ├── PUBLIC      → ABSENT           UserPrivileges:{DescID: 105, Name: admin}
+      │    │    ├── PUBLIC      → ABSENT           UserPrivileges:{DescID: 105, Name: public}
+      │    │    ├── PUBLIC      → ABSENT           UserPrivileges:{DescID: 105, Name: root}
+      │    │    ├── PUBLIC      → DROPPED          AliasType:{DescID: 105, ReferencedTypeIDs: [104 105]}
+      │    │    ├── PUBLIC      → ABSENT           ObjectParent:{DescID: 105, ReferencedDescID: 101}
+      │    │    ├── DELETE_ONLY → ABSENT           Column:{DescID: 107, ColumnID: 2}
+      │    │    ├── PUBLIC      → ABSENT           ColumnType:{DescID: 107, ReferencedTypeIDs: [104 105], ColumnFamilyID: 0, ColumnID: 2}
+      │    │    ├── DELETE_ONLY → ABSENT           Column:{DescID: 107, ColumnID: 3}
+      │    │    ├── PUBLIC      → ABSENT           ColumnType:{DescID: 107, ReferencedTypeIDs: [104 105], ColumnFamilyID: 0, ColumnID: 3}
+      │    │    ├── DELETE_ONLY → ABSENT           Column:{DescID: 107, ColumnID: 4}
+      │    │    ├── PUBLIC      → ABSENT           ColumnType:{DescID: 107, ReferencedTypeIDs: [104 105], ColumnFamilyID: 0, ColumnID: 4}
+      │    │    ├── DELETE_ONLY → ABSENT           PrimaryIndex:{DescID: 107, IndexID: 1, ConstraintID: 1}
+      │    │    ├── PUBLIC      → ABSENT           IndexData:{DescID: 107, IndexID: 1}
+      │    │    └── PUBLIC      → ABSENT           IndexData:{DescID: 107, IndexID: 2}
+      │    └── 23 Mutation operations
+      │         ├── MarkDescriptorAsDropped {"DescriptorID":104}
+      │         ├── RemoveObjectParent {"ObjectID":104,"ParentSchemaID":101}
+      │         ├── MarkDescriptorAsDropped {"DescriptorID":105}
+      │         ├── RemoveObjectParent {"ObjectID":105,"ParentSchemaID":101}
+      │         ├── RemoveDroppedColumnType {"ColumnID":2,"TableID":107}
+      │         ├── UpdateTableBackReferencesInTypes {"BackReferencedTableID":107}
+      │         ├── RemoveDroppedColumnType {"ColumnID":3,"TableID":107}
+      │         ├── UpdateTableBackReferencesInTypes {"BackReferencedTableID":107}
+      │         ├── RemoveDroppedColumnType {"ColumnID":4,"TableID":107}
+      │         ├── UpdateTableBackReferencesInTypes {"BackReferencedTableID":107}
+      │         ├── MakeIndexAbsent {"IndexID":1,"TableID":107}
+      │         ├── CreateGCJobForIndex {"IndexID":1,"TableID":107}
+      │         ├── CreateGCJobForIndex {"IndexID":2,"TableID":107}
+      │         ├── CreateGCJobForIndex {"IndexID":4,"TableID":107}
+      │         ├── DrainDescriptorName {"Namespace":{"DatabaseID":100,"DescriptorID":104,"Name":"greeting","SchemaID":101}}
+      │         ├── DrainDescriptorName {"Namespace":{"DatabaseID":100,"DescriptorID":105,"Name":"_greeting","SchemaID":101}}
+      │         ├── MakeDeleteOnlyColumnAbsent {"ColumnID":2,"TableID":107}
+      │         ├── MakeDeleteOnlyColumnAbsent {"ColumnID":3,"TableID":107}
+      │         ├── MakeDeleteOnlyColumnAbsent {"ColumnID":4,"TableID":107}
+      │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
+      │         ├── SetJobStateOnDescriptor {"DescriptorID":105}
+      │         ├── SetJobStateOnDescriptor {"DescriptorID":107}
+      │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
+      └── Stage 4 of 4 in PostCommitNonRevertiblePhase
+           ├── 2 elements transitioning toward ABSENT
+           │    ├── DROPPED → ABSENT EnumType:{DescID: 104}
+           │    └── DROPPED → ABSENT AliasType:{DescID: 105, ReferencedTypeIDs: [104 105]}
+           └── 6 Mutation operations
+                ├── DeleteDescriptor {"DescriptorID":104}
+                ├── DeleteDescriptor {"DescriptorID":105}
+                ├── RemoveJobStateFromDescriptor {"DescriptorID":104}
+                ├── RemoveJobStateFromDescriptor {"DescriptorID":105}
+                ├── RemoveJobStateFromDescriptor {"DescriptorID":107}
+                └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"all stages compl..."}

--- a/pkg/sql/schemachanger/testdata/explain/drop_type_cascade.rollback_1_of_7
+++ b/pkg/sql/schemachanger/testdata/explain/drop_type_cascade.rollback_1_of_7
@@ -1,0 +1,66 @@
+/* setup */
+SET experimental_enable_unique_without_index_constraints = true;
+CREATE TYPE greeting AS ENUM('hello', 'hi');
+CREATE VIEW view AS SELECT 'hi'::greeting::string AS c;
+CREATE TABLE tbl (
+  id INT PRIMARY KEY,
+  gs greeting AS ('hi'::greeting) STORED,
+  gv string AS ('hello'::greeting::STRING) VIRTUAL,
+  other greeting[],
+  name STRING NOT NULL DEFAULT 'noname',
+  CONSTRAINT mycheck CHECK (gs::STRING = name),
+  CONSTRAINT myuwi UNIQUE WITHOUT INDEX (name) WHERE ('hi'::greeting::STRING = 'hi'),
+  INDEX partial (name) WHERE (gs::STRING = 'hi')
+);
+
+/* test */
+DROP TYPE greeting CASCADE;
+EXPLAIN (ddl) rollback at post-commit stage 1 of 7;
+----
+Schema change plan for rolling back DROP TYPE ‹defaultdb›.‹public›.‹greeting› CASCADE;
+ └── PostCommitNonRevertiblePhase
+      └── Stage 1 of 1 in PostCommitNonRevertiblePhase
+           ├── 11 elements transitioning toward PUBLIC
+           │    ├── WRITE_ONLY    → PUBLIC Column:{DescID: 107, ColumnID: 2}
+           │    ├── ABSENT        → PUBLIC ColumnName:{DescID: 107, Name: gs, ColumnID: 2}
+           │    ├── WRITE_ONLY    → PUBLIC Column:{DescID: 107, ColumnID: 3}
+           │    ├── ABSENT        → PUBLIC ColumnName:{DescID: 107, Name: gv, ColumnID: 3}
+           │    ├── WRITE_ONLY    → PUBLIC Column:{DescID: 107, ColumnID: 4}
+           │    ├── ABSENT        → PUBLIC ColumnName:{DescID: 107, Name: other, ColumnID: 4}
+           │    ├── VALIDATED     → PUBLIC SecondaryIndex:{DescID: 107, IndexID: 2, ConstraintID: 0}
+           │    ├── VALIDATED     → PUBLIC UniqueWithoutIndexConstraint:{DescID: 107, ConstraintID: 3}
+           │    ├── ABSENT        → PUBLIC ConstraintWithoutIndexName:{DescID: 107, Name: myuwi, ConstraintID: 3}
+           │    ├── VALIDATED     → PUBLIC CheckConstraint:{DescID: 107, IndexID: 0, ConstraintID: 2}
+           │    └── ABSENT        → PUBLIC ConstraintWithoutIndexName:{DescID: 107, Name: mycheck, ConstraintID: 2}
+           ├── 7 elements transitioning toward ABSENT
+           │    ├── BACKFILL_ONLY → ABSENT PrimaryIndex:{DescID: 107, IndexID: 3, ConstraintID: 4, TemporaryIndexID: 4, SourceIndexID: 1}
+           │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 107, ColumnID: 1, IndexID: 3}
+           │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 107, ColumnID: 5, IndexID: 3}
+           │    ├── PUBLIC        → ABSENT IndexData:{DescID: 107, IndexID: 3}
+           │    ├── DELETE_ONLY   → ABSENT TemporaryIndex:{DescID: 107, IndexID: 4, ConstraintID: 5, SourceIndexID: 1}
+           │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 107, ColumnID: 1, IndexID: 4}
+           │    └── PUBLIC        → ABSENT IndexColumn:{DescID: 107, ColumnID: 5, IndexID: 4}
+           └── 23 Mutation operations
+                ├── SetColumnName {"ColumnID":2,"Name":"gs","TableID":107}
+                ├── SetColumnName {"ColumnID":3,"Name":"gv","TableID":107}
+                ├── SetColumnName {"ColumnID":4,"Name":"other","TableID":107}
+                ├── MakeValidatedSecondaryIndexPublic {"IndexID":2,"TableID":107}
+                ├── RefreshStats {"TableID":107}
+                ├── SetConstraintName {"ConstraintID":3,"Name":"myuwi","TableID":107}
+                ├── SetConstraintName {"ConstraintID":2,"Name":"mycheck","TableID":107}
+                ├── MakeWriteOnlyColumnPublic {"ColumnID":2,"TableID":107}
+                ├── RefreshStats {"TableID":107}
+                ├── MakeWriteOnlyColumnPublic {"ColumnID":3,"TableID":107}
+                ├── RefreshStats {"TableID":107}
+                ├── MakeWriteOnlyColumnPublic {"ColumnID":4,"TableID":107}
+                ├── RefreshStats {"TableID":107}
+                ├── MakeValidatedUniqueWithoutIndexConstraintPublic {"ConstraintID":3,"TableID":107}
+                ├── MakeValidatedCheckConstraintPublic {"ConstraintID":2,"TableID":107}
+                ├── MakeIndexAbsent {"IndexID":3,"TableID":107}
+                ├── CreateGCJobForIndex {"IndexID":3,"TableID":107}
+                ├── MakeIndexAbsent {"IndexID":4,"TableID":107}
+                ├── RemoveJobStateFromDescriptor {"DescriptorID":104}
+                ├── RemoveJobStateFromDescriptor {"DescriptorID":105}
+                ├── RemoveJobStateFromDescriptor {"DescriptorID":106}
+                ├── RemoveJobStateFromDescriptor {"DescriptorID":107}
+                └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"all stages compl..."}

--- a/pkg/sql/schemachanger/testdata/explain/drop_type_cascade.rollback_2_of_7
+++ b/pkg/sql/schemachanger/testdata/explain/drop_type_cascade.rollback_2_of_7
@@ -1,0 +1,78 @@
+/* setup */
+SET experimental_enable_unique_without_index_constraints = true;
+CREATE TYPE greeting AS ENUM('hello', 'hi');
+CREATE VIEW view AS SELECT 'hi'::greeting::string AS c;
+CREATE TABLE tbl (
+  id INT PRIMARY KEY,
+  gs greeting AS ('hi'::greeting) STORED,
+  gv string AS ('hello'::greeting::STRING) VIRTUAL,
+  other greeting[],
+  name STRING NOT NULL DEFAULT 'noname',
+  CONSTRAINT mycheck CHECK (gs::STRING = name),
+  CONSTRAINT myuwi UNIQUE WITHOUT INDEX (name) WHERE ('hi'::greeting::STRING = 'hi'),
+  INDEX partial (name) WHERE (gs::STRING = 'hi')
+);
+
+/* test */
+DROP TYPE greeting CASCADE;
+EXPLAIN (ddl) rollback at post-commit stage 2 of 7;
+----
+Schema change plan for rolling back DROP TYPE ‹defaultdb›.‹public›.‹greeting› CASCADE;
+ └── PostCommitNonRevertiblePhase
+      ├── Stage 1 of 2 in PostCommitNonRevertiblePhase
+      │    ├── 11 elements transitioning toward PUBLIC
+      │    │    ├── WRITE_ONLY    → PUBLIC      Column:{DescID: 107, ColumnID: 2}
+      │    │    ├── ABSENT        → PUBLIC      ColumnName:{DescID: 107, Name: gs, ColumnID: 2}
+      │    │    ├── WRITE_ONLY    → PUBLIC      Column:{DescID: 107, ColumnID: 3}
+      │    │    ├── ABSENT        → PUBLIC      ColumnName:{DescID: 107, Name: gv, ColumnID: 3}
+      │    │    ├── WRITE_ONLY    → PUBLIC      Column:{DescID: 107, ColumnID: 4}
+      │    │    ├── ABSENT        → PUBLIC      ColumnName:{DescID: 107, Name: other, ColumnID: 4}
+      │    │    ├── VALIDATED     → PUBLIC      SecondaryIndex:{DescID: 107, IndexID: 2, ConstraintID: 0}
+      │    │    ├── VALIDATED     → PUBLIC      UniqueWithoutIndexConstraint:{DescID: 107, ConstraintID: 3}
+      │    │    ├── ABSENT        → PUBLIC      ConstraintWithoutIndexName:{DescID: 107, Name: myuwi, ConstraintID: 3}
+      │    │    ├── VALIDATED     → PUBLIC      CheckConstraint:{DescID: 107, IndexID: 0, ConstraintID: 2}
+      │    │    └── ABSENT        → PUBLIC      ConstraintWithoutIndexName:{DescID: 107, Name: mycheck, ConstraintID: 2}
+      │    ├── 6 elements transitioning toward ABSENT
+      │    │    ├── BACKFILL_ONLY → ABSENT      PrimaryIndex:{DescID: 107, IndexID: 3, ConstraintID: 4, TemporaryIndexID: 4, SourceIndexID: 1}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 107, ColumnID: 1, IndexID: 3}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 107, ColumnID: 5, IndexID: 3}
+      │    │    ├── WRITE_ONLY    → DELETE_ONLY TemporaryIndex:{DescID: 107, IndexID: 4, ConstraintID: 5, SourceIndexID: 1}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 107, ColumnID: 1, IndexID: 4}
+      │    │    └── PUBLIC        → ABSENT      IndexColumn:{DescID: 107, ColumnID: 5, IndexID: 4}
+      │    └── 22 Mutation operations
+      │         ├── SetColumnName {"ColumnID":2,"Name":"gs","TableID":107}
+      │         ├── SetColumnName {"ColumnID":3,"Name":"gv","TableID":107}
+      │         ├── SetColumnName {"ColumnID":4,"Name":"other","TableID":107}
+      │         ├── MakeValidatedSecondaryIndexPublic {"IndexID":2,"TableID":107}
+      │         ├── RefreshStats {"TableID":107}
+      │         ├── SetConstraintName {"ConstraintID":3,"Name":"myuwi","TableID":107}
+      │         ├── SetConstraintName {"ConstraintID":2,"Name":"mycheck","TableID":107}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":4,"TableID":107}
+      │         ├── MakeWriteOnlyColumnPublic {"ColumnID":2,"TableID":107}
+      │         ├── RefreshStats {"TableID":107}
+      │         ├── MakeWriteOnlyColumnPublic {"ColumnID":3,"TableID":107}
+      │         ├── RefreshStats {"TableID":107}
+      │         ├── MakeWriteOnlyColumnPublic {"ColumnID":4,"TableID":107}
+      │         ├── RefreshStats {"TableID":107}
+      │         ├── MakeValidatedUniqueWithoutIndexConstraintPublic {"ConstraintID":3,"TableID":107}
+      │         ├── MakeValidatedCheckConstraintPublic {"ConstraintID":2,"TableID":107}
+      │         ├── MakeIndexAbsent {"IndexID":3,"TableID":107}
+      │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
+      │         ├── SetJobStateOnDescriptor {"DescriptorID":105}
+      │         ├── SetJobStateOnDescriptor {"DescriptorID":106}
+      │         ├── SetJobStateOnDescriptor {"DescriptorID":107}
+      │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
+      └── Stage 2 of 2 in PostCommitNonRevertiblePhase
+           ├── 3 elements transitioning toward ABSENT
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 107, IndexID: 3}
+           │    ├── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 107, IndexID: 4, ConstraintID: 5, SourceIndexID: 1}
+           │    └── PUBLIC      → ABSENT IndexData:{DescID: 107, IndexID: 4}
+           └── 8 Mutation operations
+                ├── CreateGCJobForIndex {"IndexID":3,"TableID":107}
+                ├── MakeIndexAbsent {"IndexID":4,"TableID":107}
+                ├── CreateGCJobForIndex {"IndexID":4,"TableID":107}
+                ├── RemoveJobStateFromDescriptor {"DescriptorID":104}
+                ├── RemoveJobStateFromDescriptor {"DescriptorID":105}
+                ├── RemoveJobStateFromDescriptor {"DescriptorID":106}
+                ├── RemoveJobStateFromDescriptor {"DescriptorID":107}
+                └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"all stages compl..."}

--- a/pkg/sql/schemachanger/testdata/explain/drop_type_cascade.rollback_3_of_7
+++ b/pkg/sql/schemachanger/testdata/explain/drop_type_cascade.rollback_3_of_7
@@ -1,0 +1,78 @@
+/* setup */
+SET experimental_enable_unique_without_index_constraints = true;
+CREATE TYPE greeting AS ENUM('hello', 'hi');
+CREATE VIEW view AS SELECT 'hi'::greeting::string AS c;
+CREATE TABLE tbl (
+  id INT PRIMARY KEY,
+  gs greeting AS ('hi'::greeting) STORED,
+  gv string AS ('hello'::greeting::STRING) VIRTUAL,
+  other greeting[],
+  name STRING NOT NULL DEFAULT 'noname',
+  CONSTRAINT mycheck CHECK (gs::STRING = name),
+  CONSTRAINT myuwi UNIQUE WITHOUT INDEX (name) WHERE ('hi'::greeting::STRING = 'hi'),
+  INDEX partial (name) WHERE (gs::STRING = 'hi')
+);
+
+/* test */
+DROP TYPE greeting CASCADE;
+EXPLAIN (ddl) rollback at post-commit stage 3 of 7;
+----
+Schema change plan for rolling back DROP TYPE ‹defaultdb›.‹public›.‹greeting› CASCADE;
+ └── PostCommitNonRevertiblePhase
+      ├── Stage 1 of 2 in PostCommitNonRevertiblePhase
+      │    ├── 11 elements transitioning toward PUBLIC
+      │    │    ├── WRITE_ONLY    → PUBLIC      Column:{DescID: 107, ColumnID: 2}
+      │    │    ├── ABSENT        → PUBLIC      ColumnName:{DescID: 107, Name: gs, ColumnID: 2}
+      │    │    ├── WRITE_ONLY    → PUBLIC      Column:{DescID: 107, ColumnID: 3}
+      │    │    ├── ABSENT        → PUBLIC      ColumnName:{DescID: 107, Name: gv, ColumnID: 3}
+      │    │    ├── WRITE_ONLY    → PUBLIC      Column:{DescID: 107, ColumnID: 4}
+      │    │    ├── ABSENT        → PUBLIC      ColumnName:{DescID: 107, Name: other, ColumnID: 4}
+      │    │    ├── VALIDATED     → PUBLIC      SecondaryIndex:{DescID: 107, IndexID: 2, ConstraintID: 0}
+      │    │    ├── VALIDATED     → PUBLIC      UniqueWithoutIndexConstraint:{DescID: 107, ConstraintID: 3}
+      │    │    ├── ABSENT        → PUBLIC      ConstraintWithoutIndexName:{DescID: 107, Name: myuwi, ConstraintID: 3}
+      │    │    ├── VALIDATED     → PUBLIC      CheckConstraint:{DescID: 107, IndexID: 0, ConstraintID: 2}
+      │    │    └── ABSENT        → PUBLIC      ConstraintWithoutIndexName:{DescID: 107, Name: mycheck, ConstraintID: 2}
+      │    ├── 6 elements transitioning toward ABSENT
+      │    │    ├── BACKFILL_ONLY → ABSENT      PrimaryIndex:{DescID: 107, IndexID: 3, ConstraintID: 4, TemporaryIndexID: 4, SourceIndexID: 1}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 107, ColumnID: 1, IndexID: 3}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 107, ColumnID: 5, IndexID: 3}
+      │    │    ├── WRITE_ONLY    → DELETE_ONLY TemporaryIndex:{DescID: 107, IndexID: 4, ConstraintID: 5, SourceIndexID: 1}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 107, ColumnID: 1, IndexID: 4}
+      │    │    └── PUBLIC        → ABSENT      IndexColumn:{DescID: 107, ColumnID: 5, IndexID: 4}
+      │    └── 22 Mutation operations
+      │         ├── SetColumnName {"ColumnID":2,"Name":"gs","TableID":107}
+      │         ├── SetColumnName {"ColumnID":3,"Name":"gv","TableID":107}
+      │         ├── SetColumnName {"ColumnID":4,"Name":"other","TableID":107}
+      │         ├── MakeValidatedSecondaryIndexPublic {"IndexID":2,"TableID":107}
+      │         ├── RefreshStats {"TableID":107}
+      │         ├── SetConstraintName {"ConstraintID":3,"Name":"myuwi","TableID":107}
+      │         ├── SetConstraintName {"ConstraintID":2,"Name":"mycheck","TableID":107}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":4,"TableID":107}
+      │         ├── MakeWriteOnlyColumnPublic {"ColumnID":2,"TableID":107}
+      │         ├── RefreshStats {"TableID":107}
+      │         ├── MakeWriteOnlyColumnPublic {"ColumnID":3,"TableID":107}
+      │         ├── RefreshStats {"TableID":107}
+      │         ├── MakeWriteOnlyColumnPublic {"ColumnID":4,"TableID":107}
+      │         ├── RefreshStats {"TableID":107}
+      │         ├── MakeValidatedUniqueWithoutIndexConstraintPublic {"ConstraintID":3,"TableID":107}
+      │         ├── MakeValidatedCheckConstraintPublic {"ConstraintID":2,"TableID":107}
+      │         ├── MakeIndexAbsent {"IndexID":3,"TableID":107}
+      │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
+      │         ├── SetJobStateOnDescriptor {"DescriptorID":105}
+      │         ├── SetJobStateOnDescriptor {"DescriptorID":106}
+      │         ├── SetJobStateOnDescriptor {"DescriptorID":107}
+      │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
+      └── Stage 2 of 2 in PostCommitNonRevertiblePhase
+           ├── 3 elements transitioning toward ABSENT
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 107, IndexID: 3}
+           │    ├── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 107, IndexID: 4, ConstraintID: 5, SourceIndexID: 1}
+           │    └── PUBLIC      → ABSENT IndexData:{DescID: 107, IndexID: 4}
+           └── 8 Mutation operations
+                ├── CreateGCJobForIndex {"IndexID":3,"TableID":107}
+                ├── MakeIndexAbsent {"IndexID":4,"TableID":107}
+                ├── CreateGCJobForIndex {"IndexID":4,"TableID":107}
+                ├── RemoveJobStateFromDescriptor {"DescriptorID":104}
+                ├── RemoveJobStateFromDescriptor {"DescriptorID":105}
+                ├── RemoveJobStateFromDescriptor {"DescriptorID":106}
+                ├── RemoveJobStateFromDescriptor {"DescriptorID":107}
+                └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"all stages compl..."}

--- a/pkg/sql/schemachanger/testdata/explain/drop_type_cascade.rollback_4_of_7
+++ b/pkg/sql/schemachanger/testdata/explain/drop_type_cascade.rollback_4_of_7
@@ -1,0 +1,78 @@
+/* setup */
+SET experimental_enable_unique_without_index_constraints = true;
+CREATE TYPE greeting AS ENUM('hello', 'hi');
+CREATE VIEW view AS SELECT 'hi'::greeting::string AS c;
+CREATE TABLE tbl (
+  id INT PRIMARY KEY,
+  gs greeting AS ('hi'::greeting) STORED,
+  gv string AS ('hello'::greeting::STRING) VIRTUAL,
+  other greeting[],
+  name STRING NOT NULL DEFAULT 'noname',
+  CONSTRAINT mycheck CHECK (gs::STRING = name),
+  CONSTRAINT myuwi UNIQUE WITHOUT INDEX (name) WHERE ('hi'::greeting::STRING = 'hi'),
+  INDEX partial (name) WHERE (gs::STRING = 'hi')
+);
+
+/* test */
+DROP TYPE greeting CASCADE;
+EXPLAIN (ddl) rollback at post-commit stage 4 of 7;
+----
+Schema change plan for rolling back DROP TYPE ‹defaultdb›.‹public›.‹greeting› CASCADE;
+ └── PostCommitNonRevertiblePhase
+      ├── Stage 1 of 2 in PostCommitNonRevertiblePhase
+      │    ├── 11 elements transitioning toward PUBLIC
+      │    │    ├── WRITE_ONLY  → PUBLIC      Column:{DescID: 107, ColumnID: 2}
+      │    │    ├── ABSENT      → PUBLIC      ColumnName:{DescID: 107, Name: gs, ColumnID: 2}
+      │    │    ├── WRITE_ONLY  → PUBLIC      Column:{DescID: 107, ColumnID: 3}
+      │    │    ├── ABSENT      → PUBLIC      ColumnName:{DescID: 107, Name: gv, ColumnID: 3}
+      │    │    ├── WRITE_ONLY  → PUBLIC      Column:{DescID: 107, ColumnID: 4}
+      │    │    ├── ABSENT      → PUBLIC      ColumnName:{DescID: 107, Name: other, ColumnID: 4}
+      │    │    ├── VALIDATED   → PUBLIC      SecondaryIndex:{DescID: 107, IndexID: 2, ConstraintID: 0}
+      │    │    ├── VALIDATED   → PUBLIC      UniqueWithoutIndexConstraint:{DescID: 107, ConstraintID: 3}
+      │    │    ├── ABSENT      → PUBLIC      ConstraintWithoutIndexName:{DescID: 107, Name: myuwi, ConstraintID: 3}
+      │    │    ├── VALIDATED   → PUBLIC      CheckConstraint:{DescID: 107, IndexID: 0, ConstraintID: 2}
+      │    │    └── ABSENT      → PUBLIC      ConstraintWithoutIndexName:{DescID: 107, Name: mycheck, ConstraintID: 2}
+      │    ├── 6 elements transitioning toward ABSENT
+      │    │    ├── DELETE_ONLY → ABSENT      PrimaryIndex:{DescID: 107, IndexID: 3, ConstraintID: 4, TemporaryIndexID: 4, SourceIndexID: 1}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 107, ColumnID: 1, IndexID: 3}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 107, ColumnID: 5, IndexID: 3}
+      │    │    ├── WRITE_ONLY  → DELETE_ONLY TemporaryIndex:{DescID: 107, IndexID: 4, ConstraintID: 5, SourceIndexID: 1}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 107, ColumnID: 1, IndexID: 4}
+      │    │    └── PUBLIC      → ABSENT      IndexColumn:{DescID: 107, ColumnID: 5, IndexID: 4}
+      │    └── 22 Mutation operations
+      │         ├── SetColumnName {"ColumnID":2,"Name":"gs","TableID":107}
+      │         ├── SetColumnName {"ColumnID":3,"Name":"gv","TableID":107}
+      │         ├── SetColumnName {"ColumnID":4,"Name":"other","TableID":107}
+      │         ├── MakeValidatedSecondaryIndexPublic {"IndexID":2,"TableID":107}
+      │         ├── RefreshStats {"TableID":107}
+      │         ├── SetConstraintName {"ConstraintID":3,"Name":"myuwi","TableID":107}
+      │         ├── SetConstraintName {"ConstraintID":2,"Name":"mycheck","TableID":107}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":4,"TableID":107}
+      │         ├── MakeWriteOnlyColumnPublic {"ColumnID":2,"TableID":107}
+      │         ├── RefreshStats {"TableID":107}
+      │         ├── MakeWriteOnlyColumnPublic {"ColumnID":3,"TableID":107}
+      │         ├── RefreshStats {"TableID":107}
+      │         ├── MakeWriteOnlyColumnPublic {"ColumnID":4,"TableID":107}
+      │         ├── RefreshStats {"TableID":107}
+      │         ├── MakeValidatedUniqueWithoutIndexConstraintPublic {"ConstraintID":3,"TableID":107}
+      │         ├── MakeValidatedCheckConstraintPublic {"ConstraintID":2,"TableID":107}
+      │         ├── MakeIndexAbsent {"IndexID":3,"TableID":107}
+      │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
+      │         ├── SetJobStateOnDescriptor {"DescriptorID":105}
+      │         ├── SetJobStateOnDescriptor {"DescriptorID":106}
+      │         ├── SetJobStateOnDescriptor {"DescriptorID":107}
+      │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
+      └── Stage 2 of 2 in PostCommitNonRevertiblePhase
+           ├── 3 elements transitioning toward ABSENT
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 107, IndexID: 3}
+           │    ├── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 107, IndexID: 4, ConstraintID: 5, SourceIndexID: 1}
+           │    └── PUBLIC      → ABSENT IndexData:{DescID: 107, IndexID: 4}
+           └── 8 Mutation operations
+                ├── CreateGCJobForIndex {"IndexID":3,"TableID":107}
+                ├── MakeIndexAbsent {"IndexID":4,"TableID":107}
+                ├── CreateGCJobForIndex {"IndexID":4,"TableID":107}
+                ├── RemoveJobStateFromDescriptor {"DescriptorID":104}
+                ├── RemoveJobStateFromDescriptor {"DescriptorID":105}
+                ├── RemoveJobStateFromDescriptor {"DescriptorID":106}
+                ├── RemoveJobStateFromDescriptor {"DescriptorID":107}
+                └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"all stages compl..."}

--- a/pkg/sql/schemachanger/testdata/explain/drop_type_cascade.rollback_5_of_7
+++ b/pkg/sql/schemachanger/testdata/explain/drop_type_cascade.rollback_5_of_7
@@ -1,0 +1,80 @@
+/* setup */
+SET experimental_enable_unique_without_index_constraints = true;
+CREATE TYPE greeting AS ENUM('hello', 'hi');
+CREATE VIEW view AS SELECT 'hi'::greeting::string AS c;
+CREATE TABLE tbl (
+  id INT PRIMARY KEY,
+  gs greeting AS ('hi'::greeting) STORED,
+  gv string AS ('hello'::greeting::STRING) VIRTUAL,
+  other greeting[],
+  name STRING NOT NULL DEFAULT 'noname',
+  CONSTRAINT mycheck CHECK (gs::STRING = name),
+  CONSTRAINT myuwi UNIQUE WITHOUT INDEX (name) WHERE ('hi'::greeting::STRING = 'hi'),
+  INDEX partial (name) WHERE (gs::STRING = 'hi')
+);
+
+/* test */
+DROP TYPE greeting CASCADE;
+EXPLAIN (ddl) rollback at post-commit stage 5 of 7;
+----
+Schema change plan for rolling back DROP TYPE ‹defaultdb›.‹public›.‹greeting› CASCADE;
+ └── PostCommitNonRevertiblePhase
+      ├── Stage 1 of 2 in PostCommitNonRevertiblePhase
+      │    ├── 11 elements transitioning toward PUBLIC
+      │    │    ├── WRITE_ONLY → PUBLIC      Column:{DescID: 107, ColumnID: 2}
+      │    │    ├── ABSENT     → PUBLIC      ColumnName:{DescID: 107, Name: gs, ColumnID: 2}
+      │    │    ├── WRITE_ONLY → PUBLIC      Column:{DescID: 107, ColumnID: 3}
+      │    │    ├── ABSENT     → PUBLIC      ColumnName:{DescID: 107, Name: gv, ColumnID: 3}
+      │    │    ├── WRITE_ONLY → PUBLIC      Column:{DescID: 107, ColumnID: 4}
+      │    │    ├── ABSENT     → PUBLIC      ColumnName:{DescID: 107, Name: other, ColumnID: 4}
+      │    │    ├── VALIDATED  → PUBLIC      SecondaryIndex:{DescID: 107, IndexID: 2, ConstraintID: 0}
+      │    │    ├── VALIDATED  → PUBLIC      UniqueWithoutIndexConstraint:{DescID: 107, ConstraintID: 3}
+      │    │    ├── ABSENT     → PUBLIC      ConstraintWithoutIndexName:{DescID: 107, Name: myuwi, ConstraintID: 3}
+      │    │    ├── VALIDATED  → PUBLIC      CheckConstraint:{DescID: 107, IndexID: 0, ConstraintID: 2}
+      │    │    └── ABSENT     → PUBLIC      ConstraintWithoutIndexName:{DescID: 107, Name: mycheck, ConstraintID: 2}
+      │    ├── 6 elements transitioning toward ABSENT
+      │    │    ├── MERGE_ONLY → DELETE_ONLY PrimaryIndex:{DescID: 107, IndexID: 3, ConstraintID: 4, TemporaryIndexID: 4, SourceIndexID: 1}
+      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 107, ColumnID: 1, IndexID: 3}
+      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 107, ColumnID: 5, IndexID: 3}
+      │    │    ├── WRITE_ONLY → DELETE_ONLY TemporaryIndex:{DescID: 107, IndexID: 4, ConstraintID: 5, SourceIndexID: 1}
+      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 107, ColumnID: 1, IndexID: 4}
+      │    │    └── PUBLIC     → ABSENT      IndexColumn:{DescID: 107, ColumnID: 5, IndexID: 4}
+      │    └── 22 Mutation operations
+      │         ├── SetColumnName {"ColumnID":2,"Name":"gs","TableID":107}
+      │         ├── SetColumnName {"ColumnID":3,"Name":"gv","TableID":107}
+      │         ├── SetColumnName {"ColumnID":4,"Name":"other","TableID":107}
+      │         ├── MakeValidatedSecondaryIndexPublic {"IndexID":2,"TableID":107}
+      │         ├── RefreshStats {"TableID":107}
+      │         ├── SetConstraintName {"ConstraintID":3,"Name":"myuwi","TableID":107}
+      │         ├── SetConstraintName {"ConstraintID":2,"Name":"mycheck","TableID":107}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":4,"TableID":107}
+      │         ├── MakeWriteOnlyColumnPublic {"ColumnID":2,"TableID":107}
+      │         ├── RefreshStats {"TableID":107}
+      │         ├── MakeWriteOnlyColumnPublic {"ColumnID":3,"TableID":107}
+      │         ├── RefreshStats {"TableID":107}
+      │         ├── MakeWriteOnlyColumnPublic {"ColumnID":4,"TableID":107}
+      │         ├── RefreshStats {"TableID":107}
+      │         ├── MakeValidatedUniqueWithoutIndexConstraintPublic {"ConstraintID":3,"TableID":107}
+      │         ├── MakeValidatedCheckConstraintPublic {"ConstraintID":2,"TableID":107}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":3,"TableID":107}
+      │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
+      │         ├── SetJobStateOnDescriptor {"DescriptorID":105}
+      │         ├── SetJobStateOnDescriptor {"DescriptorID":106}
+      │         ├── SetJobStateOnDescriptor {"DescriptorID":107}
+      │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
+      └── Stage 2 of 2 in PostCommitNonRevertiblePhase
+           ├── 4 elements transitioning toward ABSENT
+           │    ├── DELETE_ONLY → ABSENT PrimaryIndex:{DescID: 107, IndexID: 3, ConstraintID: 4, TemporaryIndexID: 4, SourceIndexID: 1}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 107, IndexID: 3}
+           │    ├── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 107, IndexID: 4, ConstraintID: 5, SourceIndexID: 1}
+           │    └── PUBLIC      → ABSENT IndexData:{DescID: 107, IndexID: 4}
+           └── 9 Mutation operations
+                ├── MakeIndexAbsent {"IndexID":3,"TableID":107}
+                ├── CreateGCJobForIndex {"IndexID":3,"TableID":107}
+                ├── MakeIndexAbsent {"IndexID":4,"TableID":107}
+                ├── CreateGCJobForIndex {"IndexID":4,"TableID":107}
+                ├── RemoveJobStateFromDescriptor {"DescriptorID":104}
+                ├── RemoveJobStateFromDescriptor {"DescriptorID":105}
+                ├── RemoveJobStateFromDescriptor {"DescriptorID":106}
+                ├── RemoveJobStateFromDescriptor {"DescriptorID":107}
+                └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"all stages compl..."}

--- a/pkg/sql/schemachanger/testdata/explain/drop_type_cascade.rollback_6_of_7
+++ b/pkg/sql/schemachanger/testdata/explain/drop_type_cascade.rollback_6_of_7
@@ -1,0 +1,80 @@
+/* setup */
+SET experimental_enable_unique_without_index_constraints = true;
+CREATE TYPE greeting AS ENUM('hello', 'hi');
+CREATE VIEW view AS SELECT 'hi'::greeting::string AS c;
+CREATE TABLE tbl (
+  id INT PRIMARY KEY,
+  gs greeting AS ('hi'::greeting) STORED,
+  gv string AS ('hello'::greeting::STRING) VIRTUAL,
+  other greeting[],
+  name STRING NOT NULL DEFAULT 'noname',
+  CONSTRAINT mycheck CHECK (gs::STRING = name),
+  CONSTRAINT myuwi UNIQUE WITHOUT INDEX (name) WHERE ('hi'::greeting::STRING = 'hi'),
+  INDEX partial (name) WHERE (gs::STRING = 'hi')
+);
+
+/* test */
+DROP TYPE greeting CASCADE;
+EXPLAIN (ddl) rollback at post-commit stage 6 of 7;
+----
+Schema change plan for rolling back DROP TYPE ‹defaultdb›.‹public›.‹greeting› CASCADE;
+ └── PostCommitNonRevertiblePhase
+      ├── Stage 1 of 2 in PostCommitNonRevertiblePhase
+      │    ├── 11 elements transitioning toward PUBLIC
+      │    │    ├── WRITE_ONLY → PUBLIC      Column:{DescID: 107, ColumnID: 2}
+      │    │    ├── ABSENT     → PUBLIC      ColumnName:{DescID: 107, Name: gs, ColumnID: 2}
+      │    │    ├── WRITE_ONLY → PUBLIC      Column:{DescID: 107, ColumnID: 3}
+      │    │    ├── ABSENT     → PUBLIC      ColumnName:{DescID: 107, Name: gv, ColumnID: 3}
+      │    │    ├── WRITE_ONLY → PUBLIC      Column:{DescID: 107, ColumnID: 4}
+      │    │    ├── ABSENT     → PUBLIC      ColumnName:{DescID: 107, Name: other, ColumnID: 4}
+      │    │    ├── VALIDATED  → PUBLIC      SecondaryIndex:{DescID: 107, IndexID: 2, ConstraintID: 0}
+      │    │    ├── VALIDATED  → PUBLIC      UniqueWithoutIndexConstraint:{DescID: 107, ConstraintID: 3}
+      │    │    ├── ABSENT     → PUBLIC      ConstraintWithoutIndexName:{DescID: 107, Name: myuwi, ConstraintID: 3}
+      │    │    ├── VALIDATED  → PUBLIC      CheckConstraint:{DescID: 107, IndexID: 0, ConstraintID: 2}
+      │    │    └── ABSENT     → PUBLIC      ConstraintWithoutIndexName:{DescID: 107, Name: mycheck, ConstraintID: 2}
+      │    ├── 6 elements transitioning toward ABSENT
+      │    │    ├── MERGE_ONLY → DELETE_ONLY PrimaryIndex:{DescID: 107, IndexID: 3, ConstraintID: 4, TemporaryIndexID: 4, SourceIndexID: 1}
+      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 107, ColumnID: 1, IndexID: 3}
+      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 107, ColumnID: 5, IndexID: 3}
+      │    │    ├── WRITE_ONLY → DELETE_ONLY TemporaryIndex:{DescID: 107, IndexID: 4, ConstraintID: 5, SourceIndexID: 1}
+      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 107, ColumnID: 1, IndexID: 4}
+      │    │    └── PUBLIC     → ABSENT      IndexColumn:{DescID: 107, ColumnID: 5, IndexID: 4}
+      │    └── 22 Mutation operations
+      │         ├── SetColumnName {"ColumnID":2,"Name":"gs","TableID":107}
+      │         ├── SetColumnName {"ColumnID":3,"Name":"gv","TableID":107}
+      │         ├── SetColumnName {"ColumnID":4,"Name":"other","TableID":107}
+      │         ├── MakeValidatedSecondaryIndexPublic {"IndexID":2,"TableID":107}
+      │         ├── RefreshStats {"TableID":107}
+      │         ├── SetConstraintName {"ConstraintID":3,"Name":"myuwi","TableID":107}
+      │         ├── SetConstraintName {"ConstraintID":2,"Name":"mycheck","TableID":107}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":4,"TableID":107}
+      │         ├── MakeWriteOnlyColumnPublic {"ColumnID":2,"TableID":107}
+      │         ├── RefreshStats {"TableID":107}
+      │         ├── MakeWriteOnlyColumnPublic {"ColumnID":3,"TableID":107}
+      │         ├── RefreshStats {"TableID":107}
+      │         ├── MakeWriteOnlyColumnPublic {"ColumnID":4,"TableID":107}
+      │         ├── RefreshStats {"TableID":107}
+      │         ├── MakeValidatedUniqueWithoutIndexConstraintPublic {"ConstraintID":3,"TableID":107}
+      │         ├── MakeValidatedCheckConstraintPublic {"ConstraintID":2,"TableID":107}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":3,"TableID":107}
+      │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
+      │         ├── SetJobStateOnDescriptor {"DescriptorID":105}
+      │         ├── SetJobStateOnDescriptor {"DescriptorID":106}
+      │         ├── SetJobStateOnDescriptor {"DescriptorID":107}
+      │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
+      └── Stage 2 of 2 in PostCommitNonRevertiblePhase
+           ├── 4 elements transitioning toward ABSENT
+           │    ├── DELETE_ONLY → ABSENT PrimaryIndex:{DescID: 107, IndexID: 3, ConstraintID: 4, TemporaryIndexID: 4, SourceIndexID: 1}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 107, IndexID: 3}
+           │    ├── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 107, IndexID: 4, ConstraintID: 5, SourceIndexID: 1}
+           │    └── PUBLIC      → ABSENT IndexData:{DescID: 107, IndexID: 4}
+           └── 9 Mutation operations
+                ├── MakeIndexAbsent {"IndexID":3,"TableID":107}
+                ├── CreateGCJobForIndex {"IndexID":3,"TableID":107}
+                ├── MakeIndexAbsent {"IndexID":4,"TableID":107}
+                ├── CreateGCJobForIndex {"IndexID":4,"TableID":107}
+                ├── RemoveJobStateFromDescriptor {"DescriptorID":104}
+                ├── RemoveJobStateFromDescriptor {"DescriptorID":105}
+                ├── RemoveJobStateFromDescriptor {"DescriptorID":106}
+                ├── RemoveJobStateFromDescriptor {"DescriptorID":107}
+                └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"all stages compl..."}

--- a/pkg/sql/schemachanger/testdata/explain/drop_type_cascade.rollback_7_of_7
+++ b/pkg/sql/schemachanger/testdata/explain/drop_type_cascade.rollback_7_of_7
@@ -1,0 +1,80 @@
+/* setup */
+SET experimental_enable_unique_without_index_constraints = true;
+CREATE TYPE greeting AS ENUM('hello', 'hi');
+CREATE VIEW view AS SELECT 'hi'::greeting::string AS c;
+CREATE TABLE tbl (
+  id INT PRIMARY KEY,
+  gs greeting AS ('hi'::greeting) STORED,
+  gv string AS ('hello'::greeting::STRING) VIRTUAL,
+  other greeting[],
+  name STRING NOT NULL DEFAULT 'noname',
+  CONSTRAINT mycheck CHECK (gs::STRING = name),
+  CONSTRAINT myuwi UNIQUE WITHOUT INDEX (name) WHERE ('hi'::greeting::STRING = 'hi'),
+  INDEX partial (name) WHERE (gs::STRING = 'hi')
+);
+
+/* test */
+DROP TYPE greeting CASCADE;
+EXPLAIN (ddl) rollback at post-commit stage 7 of 7;
+----
+Schema change plan for rolling back DROP TYPE ‹defaultdb›.‹public›.‹greeting› CASCADE;
+ └── PostCommitNonRevertiblePhase
+      ├── Stage 1 of 2 in PostCommitNonRevertiblePhase
+      │    ├── 11 elements transitioning toward PUBLIC
+      │    │    ├── WRITE_ONLY → PUBLIC      Column:{DescID: 107, ColumnID: 2}
+      │    │    ├── ABSENT     → PUBLIC      ColumnName:{DescID: 107, Name: gs, ColumnID: 2}
+      │    │    ├── WRITE_ONLY → PUBLIC      Column:{DescID: 107, ColumnID: 3}
+      │    │    ├── ABSENT     → PUBLIC      ColumnName:{DescID: 107, Name: gv, ColumnID: 3}
+      │    │    ├── WRITE_ONLY → PUBLIC      Column:{DescID: 107, ColumnID: 4}
+      │    │    ├── ABSENT     → PUBLIC      ColumnName:{DescID: 107, Name: other, ColumnID: 4}
+      │    │    ├── VALIDATED  → PUBLIC      SecondaryIndex:{DescID: 107, IndexID: 2, ConstraintID: 0}
+      │    │    ├── VALIDATED  → PUBLIC      UniqueWithoutIndexConstraint:{DescID: 107, ConstraintID: 3}
+      │    │    ├── ABSENT     → PUBLIC      ConstraintWithoutIndexName:{DescID: 107, Name: myuwi, ConstraintID: 3}
+      │    │    ├── VALIDATED  → PUBLIC      CheckConstraint:{DescID: 107, IndexID: 0, ConstraintID: 2}
+      │    │    └── ABSENT     → PUBLIC      ConstraintWithoutIndexName:{DescID: 107, Name: mycheck, ConstraintID: 2}
+      │    ├── 6 elements transitioning toward ABSENT
+      │    │    ├── WRITE_ONLY → DELETE_ONLY PrimaryIndex:{DescID: 107, IndexID: 3, ConstraintID: 4, TemporaryIndexID: 4, SourceIndexID: 1}
+      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 107, ColumnID: 1, IndexID: 3}
+      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 107, ColumnID: 5, IndexID: 3}
+      │    │    ├── WRITE_ONLY → DELETE_ONLY TemporaryIndex:{DescID: 107, IndexID: 4, ConstraintID: 5, SourceIndexID: 1}
+      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 107, ColumnID: 1, IndexID: 4}
+      │    │    └── PUBLIC     → ABSENT      IndexColumn:{DescID: 107, ColumnID: 5, IndexID: 4}
+      │    └── 22 Mutation operations
+      │         ├── SetColumnName {"ColumnID":2,"Name":"gs","TableID":107}
+      │         ├── SetColumnName {"ColumnID":3,"Name":"gv","TableID":107}
+      │         ├── SetColumnName {"ColumnID":4,"Name":"other","TableID":107}
+      │         ├── MakeValidatedSecondaryIndexPublic {"IndexID":2,"TableID":107}
+      │         ├── RefreshStats {"TableID":107}
+      │         ├── SetConstraintName {"ConstraintID":3,"Name":"myuwi","TableID":107}
+      │         ├── SetConstraintName {"ConstraintID":2,"Name":"mycheck","TableID":107}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":3,"TableID":107}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":4,"TableID":107}
+      │         ├── MakeWriteOnlyColumnPublic {"ColumnID":2,"TableID":107}
+      │         ├── RefreshStats {"TableID":107}
+      │         ├── MakeWriteOnlyColumnPublic {"ColumnID":3,"TableID":107}
+      │         ├── RefreshStats {"TableID":107}
+      │         ├── MakeWriteOnlyColumnPublic {"ColumnID":4,"TableID":107}
+      │         ├── RefreshStats {"TableID":107}
+      │         ├── MakeValidatedUniqueWithoutIndexConstraintPublic {"ConstraintID":3,"TableID":107}
+      │         ├── MakeValidatedCheckConstraintPublic {"ConstraintID":2,"TableID":107}
+      │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
+      │         ├── SetJobStateOnDescriptor {"DescriptorID":105}
+      │         ├── SetJobStateOnDescriptor {"DescriptorID":106}
+      │         ├── SetJobStateOnDescriptor {"DescriptorID":107}
+      │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
+      └── Stage 2 of 2 in PostCommitNonRevertiblePhase
+           ├── 4 elements transitioning toward ABSENT
+           │    ├── DELETE_ONLY → ABSENT PrimaryIndex:{DescID: 107, IndexID: 3, ConstraintID: 4, TemporaryIndexID: 4, SourceIndexID: 1}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 107, IndexID: 3}
+           │    ├── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 107, IndexID: 4, ConstraintID: 5, SourceIndexID: 1}
+           │    └── PUBLIC      → ABSENT IndexData:{DescID: 107, IndexID: 4}
+           └── 9 Mutation operations
+                ├── MakeIndexAbsent {"IndexID":3,"TableID":107}
+                ├── CreateGCJobForIndex {"IndexID":3,"TableID":107}
+                ├── MakeIndexAbsent {"IndexID":4,"TableID":107}
+                ├── CreateGCJobForIndex {"IndexID":4,"TableID":107}
+                ├── RemoveJobStateFromDescriptor {"DescriptorID":104}
+                ├── RemoveJobStateFromDescriptor {"DescriptorID":105}
+                ├── RemoveJobStateFromDescriptor {"DescriptorID":106}
+                ├── RemoveJobStateFromDescriptor {"DescriptorID":107}
+                └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"all stages compl..."}

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_index_with_materialized_view_dep
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_index_with_materialized_view_dep
@@ -943,7 +943,7 @@ EXPLAIN (ddl, verbose) DROP INDEX idx CASCADE;
     │   │       └── • SameStagePrecedence dependency from ABSENT View:{DescID: 106}
     │   │             rule: "table removed right before garbage collection"
     │   │
-    │   └── • 6 Mutation operations
+    │   └── • 7 Mutation operations
     │       │
     │       ├── • CreateGCJobForTable
     │       │     DatabaseID: 100
@@ -968,6 +968,10 @@ EXPLAIN (ddl, verbose) DROP INDEX idx CASCADE;
     │       │
     │       ├── • SetJobStateOnDescriptor
     │       │     DescriptorID: 105
+    │       │
+    │       ├── • RemoveJobStateFromDescriptor
+    │       │     DescriptorID: 106
+    │       │     JobID: 1
     │       │
     │       └── • UpdateSchemaChangerJob
     │             DescriptorIDsToRemove:

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_type_cascade
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_type_cascade
@@ -1,0 +1,1990 @@
+/* setup */
+SET experimental_enable_unique_without_index_constraints = true;
+CREATE TYPE greeting AS ENUM('hello', 'hi');
+CREATE VIEW view AS SELECT 'hi'::greeting::string AS c;
+CREATE TABLE tbl (
+  id INT PRIMARY KEY,
+  gs greeting AS ('hi'::greeting) STORED,
+  gv string AS ('hello'::greeting::STRING) VIRTUAL,
+  other greeting[],
+  name STRING NOT NULL DEFAULT 'noname',
+  CONSTRAINT mycheck CHECK (gs::STRING = name),
+  CONSTRAINT myuwi UNIQUE WITHOUT INDEX (name) WHERE ('hi'::greeting::STRING = 'hi'),
+  INDEX partial (name) WHERE (gs::STRING = 'hi')
+);
+
+/* test */
+EXPLAIN (ddl, verbose) DROP TYPE greeting CASCADE;
+----
+• Schema change plan for DROP TYPE ‹defaultdb›.‹public›.‹greeting› CASCADE;
+│
+├── • StatementPhase
+│   │
+│   └── • Stage 1 of 1 in StatementPhase
+│       │
+│       ├── • 5 elements transitioning toward PUBLIC
+│       │   │
+│       │   ├── • PrimaryIndex:{DescID: 107, IndexID: 3, ConstraintID: 4, TemporaryIndexID: 4, SourceIndexID: 1}
+│       │   │   │ ABSENT → BACKFILL_ONLY
+│       │   │   │
+│       │   │   └── • PreviousStagePrecedence dependency from ABSENT PrimaryIndex:{DescID: 107, IndexID: 3, ConstraintID: 4, TemporaryIndexID: 4, SourceIndexID: 1}
+│       │   │         rule: "PrimaryIndex transitions to PUBLIC uphold 2-version invariant: ABSENT->BACKFILL_ONLY"
+│       │   │
+│       │   ├── • IndexColumn:{DescID: 107, ColumnID: 1, IndexID: 3}
+│       │   │   │ ABSENT → PUBLIC
+│       │   │   │
+│       │   │   └── • Precedence dependency from BACKFILL_ONLY PrimaryIndex:{DescID: 107, IndexID: 3, ConstraintID: 4, TemporaryIndexID: 4, SourceIndexID: 1}
+│       │   │         rule: "index existence precedes index dependents"
+│       │   │
+│       │   ├── • IndexColumn:{DescID: 107, ColumnID: 5, IndexID: 3}
+│       │   │   │ ABSENT → PUBLIC
+│       │   │   │
+│       │   │   └── • Precedence dependency from BACKFILL_ONLY PrimaryIndex:{DescID: 107, IndexID: 3, ConstraintID: 4, TemporaryIndexID: 4, SourceIndexID: 1}
+│       │   │         rule: "index existence precedes index dependents"
+│       │   │
+│       │   ├── • IndexData:{DescID: 107, IndexID: 3}
+│       │   │   │ ABSENT → PUBLIC
+│       │   │   │
+│       │   │   └── • SameStagePrecedence dependency from BACKFILL_ONLY PrimaryIndex:{DescID: 107, IndexID: 3, ConstraintID: 4, TemporaryIndexID: 4, SourceIndexID: 1}
+│       │   │         rule: "index data exists as soon as index accepts backfills"
+│       │   │
+│       │   └── • IndexColumn:{DescID: 107, ColumnID: 5, IndexID: 4}
+│       │       │ ABSENT → PUBLIC
+│       │       │
+│       │       └── • Precedence dependency from DELETE_ONLY TemporaryIndex:{DescID: 107, IndexID: 4, ConstraintID: 5, SourceIndexID: 1}
+│       │             rule: "temp index existence precedes index dependents"
+│       │
+│       ├── • 2 elements transitioning toward TRANSIENT_ABSENT
+│       │   │
+│       │   ├── • TemporaryIndex:{DescID: 107, IndexID: 4, ConstraintID: 5, SourceIndexID: 1}
+│       │   │   │ ABSENT → DELETE_ONLY
+│       │   │   │
+│       │   │   └── • PreviousStagePrecedence dependency from ABSENT TemporaryIndex:{DescID: 107, IndexID: 4, ConstraintID: 5, SourceIndexID: 1}
+│       │   │         rule: "TemporaryIndex transitions to TRANSIENT_ABSENT uphold 2-version invariant: ABSENT->DELETE_ONLY"
+│       │   │
+│       │   └── • IndexColumn:{DescID: 107, ColumnID: 1, IndexID: 4}
+│       │       │ ABSENT → TRANSIENT_ABSENT
+│       │       │
+│       │       ├── • Precedence dependency from DELETE_ONLY TemporaryIndex:{DescID: 107, IndexID: 4, ConstraintID: 5, SourceIndexID: 1}
+│       │       │     rule: "temp index existence precedes index dependents"
+│       │       │
+│       │       └── • skip PUBLIC → TRANSIENT_ABSENT operations
+│       │             rule: "skip index-column removal ops on index removal"
+│       │
+│       ├── • 28 elements transitioning toward ABSENT
+│       │   │
+│       │   ├── • Namespace:{DescID: 106, Name: view, ReferencedDescID: 100}
+│       │   │   │ PUBLIC → ABSENT
+│       │   │   │
+│       │   │   └── • Precedence dependency from DROPPED View:{DescID: 106}
+│       │   │         rule: "descriptor dropped before dependent element removal"
+│       │   │
+│       │   ├── • Owner:{DescID: 106}
+│       │   │   │ PUBLIC → ABSENT
+│       │   │   │
+│       │   │   ├── • Precedence dependency from DROPPED View:{DescID: 106}
+│       │   │   │     rule: "descriptor dropped before dependent element removal"
+│       │   │   │
+│       │   │   └── • skip PUBLIC → ABSENT operations
+│       │   │         rule: "skip element removal ops on descriptor drop"
+│       │   │
+│       │   ├── • UserPrivileges:{DescID: 106, Name: admin}
+│       │   │   │ PUBLIC → ABSENT
+│       │   │   │
+│       │   │   ├── • Precedence dependency from DROPPED View:{DescID: 106}
+│       │   │   │     rule: "descriptor dropped before dependent element removal"
+│       │   │   │
+│       │   │   └── • skip PUBLIC → ABSENT operations
+│       │   │         rule: "skip element removal ops on descriptor drop"
+│       │   │
+│       │   ├── • UserPrivileges:{DescID: 106, Name: root}
+│       │   │   │ PUBLIC → ABSENT
+│       │   │   │
+│       │   │   ├── • Precedence dependency from DROPPED View:{DescID: 106}
+│       │   │   │     rule: "descriptor dropped before dependent element removal"
+│       │   │   │
+│       │   │   └── • skip PUBLIC → ABSENT operations
+│       │   │         rule: "skip element removal ops on descriptor drop"
+│       │   │
+│       │   ├── • View:{DescID: 106}
+│       │   │     PUBLIC → DROPPED
+│       │   │
+│       │   ├── • ObjectParent:{DescID: 106, ReferencedDescID: 101}
+│       │   │   │ PUBLIC → ABSENT
+│       │   │   │
+│       │   │   └── • SameStagePrecedence dependency from DROPPED View:{DescID: 106}
+│       │   │         rule: "descriptor dropped before dependent element removal"
+│       │   │         rule: "descriptor dropped right before removing back-reference in its parent descriptor"
+│       │   │
+│       │   ├── • Column:{DescID: 106, ColumnID: 1}
+│       │   │   │ PUBLIC → WRITE_ONLY
+│       │   │   │
+│       │   │   ├── • Precedence dependency from DROPPED View:{DescID: 106}
+│       │   │   │     rule: "relation dropped before dependent column"
+│       │   │   │
+│       │   │   └── • skip PUBLIC → WRITE_ONLY operations
+│       │   │         rule: "skip column removal ops on relation drop"
+│       │   │
+│       │   ├── • ColumnName:{DescID: 106, Name: c, ColumnID: 1}
+│       │   │   │ PUBLIC → ABSENT
+│       │   │   │
+│       │   │   ├── • Precedence dependency from DROPPED View:{DescID: 106}
+│       │   │   │     rule: "descriptor dropped before dependent element removal"
+│       │   │   │
+│       │   │   ├── • Precedence dependency from WRITE_ONLY Column:{DescID: 106, ColumnID: 1}
+│       │   │   │     rule: "column no longer public before dependents"
+│       │   │   │
+│       │   │   └── • skip PUBLIC → ABSENT operations
+│       │   │         rule: "skip column dependents removal ops on relation drop"
+│       │   │
+│       │   ├── • ColumnType:{DescID: 106, ColumnFamilyID: 0, ColumnID: 1}
+│       │   │   │ PUBLIC → ABSENT
+│       │   │   │
+│       │   │   ├── • Precedence dependency from DROPPED View:{DescID: 106}
+│       │   │   │     rule: "descriptor dropped before dependent element removal"
+│       │   │   │
+│       │   │   └── • Precedence dependency from WRITE_ONLY Column:{DescID: 106, ColumnID: 1}
+│       │   │         rule: "column no longer public before dependents"
+│       │   │
+│       │   ├── • Column:{DescID: 106, ColumnID: 4294967295}
+│       │   │   │ PUBLIC → WRITE_ONLY
+│       │   │   │
+│       │   │   ├── • Precedence dependency from DROPPED View:{DescID: 106}
+│       │   │   │     rule: "relation dropped before dependent column"
+│       │   │   │
+│       │   │   └── • skip PUBLIC → WRITE_ONLY operations
+│       │   │         rule: "skip column removal ops on relation drop"
+│       │   │
+│       │   ├── • ColumnName:{DescID: 106, Name: crdb_internal_mvcc_timestamp, ColumnID: 4294967295}
+│       │   │   │ PUBLIC → ABSENT
+│       │   │   │
+│       │   │   ├── • Precedence dependency from DROPPED View:{DescID: 106}
+│       │   │   │     rule: "descriptor dropped before dependent element removal"
+│       │   │   │
+│       │   │   ├── • Precedence dependency from WRITE_ONLY Column:{DescID: 106, ColumnID: 4294967295}
+│       │   │   │     rule: "column no longer public before dependents"
+│       │   │   │
+│       │   │   └── • skip PUBLIC → ABSENT operations
+│       │   │         rule: "skip column dependents removal ops on relation drop"
+│       │   │
+│       │   ├── • ColumnType:{DescID: 106, ColumnFamilyID: 0, ColumnID: 4294967295}
+│       │   │   │ PUBLIC → ABSENT
+│       │   │   │
+│       │   │   ├── • Precedence dependency from DROPPED View:{DescID: 106}
+│       │   │   │     rule: "descriptor dropped before dependent element removal"
+│       │   │   │
+│       │   │   └── • Precedence dependency from WRITE_ONLY Column:{DescID: 106, ColumnID: 4294967295}
+│       │   │         rule: "column no longer public before dependents"
+│       │   │
+│       │   ├── • Column:{DescID: 106, ColumnID: 4294967294}
+│       │   │   │ PUBLIC → WRITE_ONLY
+│       │   │   │
+│       │   │   ├── • Precedence dependency from DROPPED View:{DescID: 106}
+│       │   │   │     rule: "relation dropped before dependent column"
+│       │   │   │
+│       │   │   └── • skip PUBLIC → WRITE_ONLY operations
+│       │   │         rule: "skip column removal ops on relation drop"
+│       │   │
+│       │   ├── • ColumnName:{DescID: 106, Name: tableoid, ColumnID: 4294967294}
+│       │   │   │ PUBLIC → ABSENT
+│       │   │   │
+│       │   │   ├── • Precedence dependency from DROPPED View:{DescID: 106}
+│       │   │   │     rule: "descriptor dropped before dependent element removal"
+│       │   │   │
+│       │   │   ├── • Precedence dependency from WRITE_ONLY Column:{DescID: 106, ColumnID: 4294967294}
+│       │   │   │     rule: "column no longer public before dependents"
+│       │   │   │
+│       │   │   └── • skip PUBLIC → ABSENT operations
+│       │   │         rule: "skip column dependents removal ops on relation drop"
+│       │   │
+│       │   ├── • ColumnType:{DescID: 106, ColumnFamilyID: 0, ColumnID: 4294967294}
+│       │   │   │ PUBLIC → ABSENT
+│       │   │   │
+│       │   │   ├── • Precedence dependency from DROPPED View:{DescID: 106}
+│       │   │   │     rule: "descriptor dropped before dependent element removal"
+│       │   │   │
+│       │   │   └── • Precedence dependency from WRITE_ONLY Column:{DescID: 106, ColumnID: 4294967294}
+│       │   │         rule: "column no longer public before dependents"
+│       │   │
+│       │   ├── • Column:{DescID: 107, ColumnID: 2}
+│       │   │   │ PUBLIC → WRITE_ONLY
+│       │   │   │
+│       │   │   └── • PreviousStagePrecedence dependency from PUBLIC Column:{DescID: 107, ColumnID: 2}
+│       │   │         rule: "Column transitions to ABSENT uphold 2-version invariant: PUBLIC->WRITE_ONLY"
+│       │   │
+│       │   ├── • ColumnName:{DescID: 107, Name: gs, ColumnID: 2}
+│       │   │   │ PUBLIC → ABSENT
+│       │   │   │
+│       │   │   └── • Precedence dependency from WRITE_ONLY Column:{DescID: 107, ColumnID: 2}
+│       │   │         rule: "column no longer public before dependents"
+│       │   │
+│       │   ├── • Column:{DescID: 107, ColumnID: 3}
+│       │   │   │ PUBLIC → WRITE_ONLY
+│       │   │   │
+│       │   │   └── • PreviousStagePrecedence dependency from PUBLIC Column:{DescID: 107, ColumnID: 3}
+│       │   │         rule: "Column transitions to ABSENT uphold 2-version invariant: PUBLIC->WRITE_ONLY"
+│       │   │
+│       │   ├── • ColumnName:{DescID: 107, Name: gv, ColumnID: 3}
+│       │   │   │ PUBLIC → ABSENT
+│       │   │   │
+│       │   │   └── • Precedence dependency from WRITE_ONLY Column:{DescID: 107, ColumnID: 3}
+│       │   │         rule: "column no longer public before dependents"
+│       │   │
+│       │   ├── • Column:{DescID: 107, ColumnID: 4}
+│       │   │   │ PUBLIC → WRITE_ONLY
+│       │   │   │
+│       │   │   └── • PreviousStagePrecedence dependency from PUBLIC Column:{DescID: 107, ColumnID: 4}
+│       │   │         rule: "Column transitions to ABSENT uphold 2-version invariant: PUBLIC->WRITE_ONLY"
+│       │   │
+│       │   ├── • ColumnName:{DescID: 107, Name: other, ColumnID: 4}
+│       │   │   │ PUBLIC → ABSENT
+│       │   │   │
+│       │   │   └── • Precedence dependency from WRITE_ONLY Column:{DescID: 107, ColumnID: 4}
+│       │   │         rule: "column no longer public before dependents"
+│       │   │
+│       │   ├── • IndexColumn:{DescID: 107, ColumnID: 5, IndexID: 2}
+│       │   │   │ PUBLIC → ABSENT
+│       │   │   │
+│       │   │   ├── • Precedence dependency from VALIDATED SecondaryIndex:{DescID: 107, IndexID: 2, ConstraintID: 0}
+│       │   │   │     rule: "index no longer public before dependents"
+│       │   │   │
+│       │   │   └── • skip PUBLIC → ABSENT operations
+│       │   │         rule: "skip index-column removal ops on index removal"
+│       │   │
+│       │   ├── • IndexColumn:{DescID: 107, ColumnID: 1, IndexID: 2}
+│       │   │   │ PUBLIC → ABSENT
+│       │   │   │
+│       │   │   ├── • Precedence dependency from VALIDATED SecondaryIndex:{DescID: 107, IndexID: 2, ConstraintID: 0}
+│       │   │   │     rule: "index no longer public before dependents"
+│       │   │   │
+│       │   │   └── • skip PUBLIC → ABSENT operations
+│       │   │         rule: "skip index-column removal ops on index removal"
+│       │   │
+│       │   ├── • SecondaryIndex:{DescID: 107, IndexID: 2, ConstraintID: 0}
+│       │   │   │ PUBLIC → VALIDATED
+│       │   │   │
+│       │   │   └── • PreviousStagePrecedence dependency from PUBLIC SecondaryIndex:{DescID: 107, IndexID: 2, ConstraintID: 0}
+│       │   │         rule: "SecondaryIndex transitions to ABSENT uphold 2-version invariant: PUBLIC->VALIDATED"
+│       │   │
+│       │   ├── • UniqueWithoutIndexConstraint:{DescID: 107, ConstraintID: 3}
+│       │   │   │ PUBLIC → VALIDATED
+│       │   │   │
+│       │   │   └── • PreviousStagePrecedence dependency from PUBLIC UniqueWithoutIndexConstraint:{DescID: 107, ConstraintID: 3}
+│       │   │         rule: "UniqueWithoutIndexConstraint transitions to ABSENT uphold 2-version invariant: PUBLIC->VALIDATED"
+│       │   │
+│       │   ├── • ConstraintWithoutIndexName:{DescID: 107, Name: myuwi, ConstraintID: 3}
+│       │   │   │ PUBLIC → ABSENT
+│       │   │   │
+│       │   │   └── • Precedence dependency from VALIDATED UniqueWithoutIndexConstraint:{DescID: 107, ConstraintID: 3}
+│       │   │         rule: "constraint no longer public before dependents"
+│       │   │
+│       │   ├── • CheckConstraint:{DescID: 107, IndexID: 0, ConstraintID: 2}
+│       │   │   │ PUBLIC → VALIDATED
+│       │   │   │
+│       │   │   └── • PreviousStagePrecedence dependency from PUBLIC CheckConstraint:{DescID: 107, IndexID: 0, ConstraintID: 2}
+│       │   │         rule: "CheckConstraint transitions to ABSENT uphold 2-version invariant: PUBLIC->VALIDATED"
+│       │   │
+│       │   └── • ConstraintWithoutIndexName:{DescID: 107, Name: mycheck, ConstraintID: 2}
+│       │       │ PUBLIC → ABSENT
+│       │       │
+│       │       └── • Precedence dependency from VALIDATED CheckConstraint:{DescID: 107, IndexID: 0, ConstraintID: 2}
+│       │             rule: "constraint no longer public before dependents"
+│       │
+│       └── • 21 Mutation operations
+│           │
+│           ├── • MarkDescriptorAsDropped
+│           │     DescriptorID: 106
+│           │
+│           ├── • RemoveBackReferenceInTypes
+│           │     BackReferencedDescriptorID: 106
+│           │     TypeIDs:
+│           │     - 104
+│           │     - 105
+│           │
+│           ├── • RemoveObjectParent
+│           │     ObjectID: 106
+│           │     ParentSchemaID: 101
+│           │
+│           ├── • MakePublicColumnWriteOnly
+│           │     ColumnID: 2
+│           │     TableID: 107
+│           │
+│           ├── • SetColumnName
+│           │     ColumnID: 2
+│           │     Name: crdb_internal_column_2_name_placeholder
+│           │     TableID: 107
+│           │
+│           ├── • MakePublicColumnWriteOnly
+│           │     ColumnID: 3
+│           │     TableID: 107
+│           │
+│           ├── • SetColumnName
+│           │     ColumnID: 3
+│           │     Name: crdb_internal_column_3_name_placeholder
+│           │     TableID: 107
+│           │
+│           ├── • MakePublicColumnWriteOnly
+│           │     ColumnID: 4
+│           │     TableID: 107
+│           │
+│           ├── • SetColumnName
+│           │     ColumnID: 4
+│           │     Name: crdb_internal_column_4_name_placeholder
+│           │     TableID: 107
+│           │
+│           ├── • MakePublicSecondaryIndexWriteOnly
+│           │     IndexID: 2
+│           │     TableID: 107
+│           │
+│           ├── • MakePublicUniqueWithoutIndexConstraintValidated
+│           │     ConstraintID: 3
+│           │     TableID: 107
+│           │
+│           ├── • SetConstraintName
+│           │     ConstraintID: 3
+│           │     Name: crdb_internal_constraint_3_name_placeholder
+│           │     TableID: 107
+│           │
+│           ├── • MakePublicCheckConstraintValidated
+│           │     ConstraintID: 2
+│           │     TableID: 107
+│           │
+│           ├── • SetConstraintName
+│           │     ConstraintID: 2
+│           │     Name: crdb_internal_constraint_2_name_placeholder
+│           │     TableID: 107
+│           │
+│           ├── • MakeAbsentIndexBackfilling
+│           │     Index:
+│           │       ConstraintID: 4
+│           │       IndexID: 3
+│           │       IsUnique: true
+│           │       SourceIndexID: 1
+│           │       TableID: 107
+│           │       TemporaryIndexID: 4
+│           │
+│           ├── • AddColumnToIndex
+│           │     ColumnID: 1
+│           │     IndexID: 3
+│           │     TableID: 107
+│           │
+│           ├── • AddColumnToIndex
+│           │     ColumnID: 5
+│           │     IndexID: 3
+│           │     Kind: 2
+│           │     TableID: 107
+│           │
+│           ├── • MakeAbsentTempIndexDeleteOnly
+│           │     Index:
+│           │       ConstraintID: 5
+│           │       IndexID: 4
+│           │       IsUnique: true
+│           │       SourceIndexID: 1
+│           │       TableID: 107
+│           │
+│           ├── • AddColumnToIndex
+│           │     ColumnID: 1
+│           │     IndexID: 4
+│           │     TableID: 107
+│           │
+│           ├── • AddColumnToIndex
+│           │     ColumnID: 5
+│           │     IndexID: 4
+│           │     Kind: 2
+│           │     TableID: 107
+│           │
+│           └── • DrainDescriptorName
+│                 Namespace:
+│                   DatabaseID: 100
+│                   DescriptorID: 106
+│                   Name: view
+│                   SchemaID: 101
+│
+├── • PreCommitPhase
+│   │
+│   ├── • Stage 1 of 2 in PreCommitPhase
+│   │   │
+│   │   ├── • 5 elements transitioning toward PUBLIC
+│   │   │   │
+│   │   │   ├── • PrimaryIndex:{DescID: 107, IndexID: 3, ConstraintID: 4, TemporaryIndexID: 4, SourceIndexID: 1}
+│   │   │   │     BACKFILL_ONLY → ABSENT
+│   │   │   │
+│   │   │   ├── • IndexColumn:{DescID: 107, ColumnID: 1, IndexID: 3}
+│   │   │   │     PUBLIC → ABSENT
+│   │   │   │
+│   │   │   ├── • IndexColumn:{DescID: 107, ColumnID: 5, IndexID: 3}
+│   │   │   │     PUBLIC → ABSENT
+│   │   │   │
+│   │   │   ├── • IndexData:{DescID: 107, IndexID: 3}
+│   │   │   │     PUBLIC → ABSENT
+│   │   │   │
+│   │   │   └── • IndexColumn:{DescID: 107, ColumnID: 5, IndexID: 4}
+│   │   │         PUBLIC → ABSENT
+│   │   │
+│   │   ├── • 2 elements transitioning toward TRANSIENT_ABSENT
+│   │   │   │
+│   │   │   ├── • TemporaryIndex:{DescID: 107, IndexID: 4, ConstraintID: 5, SourceIndexID: 1}
+│   │   │   │     DELETE_ONLY → ABSENT
+│   │   │   │
+│   │   │   └── • IndexColumn:{DescID: 107, ColumnID: 1, IndexID: 4}
+│   │   │         TRANSIENT_ABSENT → ABSENT
+│   │   │
+│   │   ├── • 28 elements transitioning toward ABSENT
+│   │   │   │
+│   │   │   ├── • Namespace:{DescID: 106, Name: view, ReferencedDescID: 100}
+│   │   │   │     ABSENT → PUBLIC
+│   │   │   │
+│   │   │   ├── • Owner:{DescID: 106}
+│   │   │   │     ABSENT → PUBLIC
+│   │   │   │
+│   │   │   ├── • UserPrivileges:{DescID: 106, Name: admin}
+│   │   │   │     ABSENT → PUBLIC
+│   │   │   │
+│   │   │   ├── • UserPrivileges:{DescID: 106, Name: root}
+│   │   │   │     ABSENT → PUBLIC
+│   │   │   │
+│   │   │   ├── • View:{DescID: 106}
+│   │   │   │     DROPPED → PUBLIC
+│   │   │   │
+│   │   │   ├── • ObjectParent:{DescID: 106, ReferencedDescID: 101}
+│   │   │   │     ABSENT → PUBLIC
+│   │   │   │
+│   │   │   ├── • Column:{DescID: 106, ColumnID: 1}
+│   │   │   │     WRITE_ONLY → PUBLIC
+│   │   │   │
+│   │   │   ├── • ColumnName:{DescID: 106, Name: c, ColumnID: 1}
+│   │   │   │     ABSENT → PUBLIC
+│   │   │   │
+│   │   │   ├── • ColumnType:{DescID: 106, ColumnFamilyID: 0, ColumnID: 1}
+│   │   │   │     ABSENT → PUBLIC
+│   │   │   │
+│   │   │   ├── • Column:{DescID: 106, ColumnID: 4294967295}
+│   │   │   │     WRITE_ONLY → PUBLIC
+│   │   │   │
+│   │   │   ├── • ColumnName:{DescID: 106, Name: crdb_internal_mvcc_timestamp, ColumnID: 4294967295}
+│   │   │   │     ABSENT → PUBLIC
+│   │   │   │
+│   │   │   ├── • ColumnType:{DescID: 106, ColumnFamilyID: 0, ColumnID: 4294967295}
+│   │   │   │     ABSENT → PUBLIC
+│   │   │   │
+│   │   │   ├── • Column:{DescID: 106, ColumnID: 4294967294}
+│   │   │   │     WRITE_ONLY → PUBLIC
+│   │   │   │
+│   │   │   ├── • ColumnName:{DescID: 106, Name: tableoid, ColumnID: 4294967294}
+│   │   │   │     ABSENT → PUBLIC
+│   │   │   │
+│   │   │   ├── • ColumnType:{DescID: 106, ColumnFamilyID: 0, ColumnID: 4294967294}
+│   │   │   │     ABSENT → PUBLIC
+│   │   │   │
+│   │   │   ├── • Column:{DescID: 107, ColumnID: 2}
+│   │   │   │     WRITE_ONLY → PUBLIC
+│   │   │   │
+│   │   │   ├── • ColumnName:{DescID: 107, Name: gs, ColumnID: 2}
+│   │   │   │     ABSENT → PUBLIC
+│   │   │   │
+│   │   │   ├── • Column:{DescID: 107, ColumnID: 3}
+│   │   │   │     WRITE_ONLY → PUBLIC
+│   │   │   │
+│   │   │   ├── • ColumnName:{DescID: 107, Name: gv, ColumnID: 3}
+│   │   │   │     ABSENT → PUBLIC
+│   │   │   │
+│   │   │   ├── • Column:{DescID: 107, ColumnID: 4}
+│   │   │   │     WRITE_ONLY → PUBLIC
+│   │   │   │
+│   │   │   ├── • ColumnName:{DescID: 107, Name: other, ColumnID: 4}
+│   │   │   │     ABSENT → PUBLIC
+│   │   │   │
+│   │   │   ├── • IndexColumn:{DescID: 107, ColumnID: 5, IndexID: 2}
+│   │   │   │     ABSENT → PUBLIC
+│   │   │   │
+│   │   │   ├── • IndexColumn:{DescID: 107, ColumnID: 1, IndexID: 2}
+│   │   │   │     ABSENT → PUBLIC
+│   │   │   │
+│   │   │   ├── • SecondaryIndex:{DescID: 107, IndexID: 2, ConstraintID: 0}
+│   │   │   │     VALIDATED → PUBLIC
+│   │   │   │
+│   │   │   ├── • UniqueWithoutIndexConstraint:{DescID: 107, ConstraintID: 3}
+│   │   │   │     VALIDATED → PUBLIC
+│   │   │   │
+│   │   │   ├── • ConstraintWithoutIndexName:{DescID: 107, Name: myuwi, ConstraintID: 3}
+│   │   │   │     ABSENT → PUBLIC
+│   │   │   │
+│   │   │   ├── • CheckConstraint:{DescID: 107, IndexID: 0, ConstraintID: 2}
+│   │   │   │     VALIDATED → PUBLIC
+│   │   │   │
+│   │   │   └── • ConstraintWithoutIndexName:{DescID: 107, Name: mycheck, ConstraintID: 2}
+│   │   │         ABSENT → PUBLIC
+│   │   │
+│   │   └── • 1 Mutation operation
+│   │       │
+│   │       └── • UndoAllInTxnImmediateMutationOpSideEffects
+│   │             {}
+│   │
+│   └── • Stage 2 of 2 in PreCommitPhase
+│       │
+│       ├── • 5 elements transitioning toward PUBLIC
+│       │   │
+│       │   ├── • PrimaryIndex:{DescID: 107, IndexID: 3, ConstraintID: 4, TemporaryIndexID: 4, SourceIndexID: 1}
+│       │   │   │ ABSENT → BACKFILL_ONLY
+│       │   │   │
+│       │   │   └── • PreviousStagePrecedence dependency from ABSENT PrimaryIndex:{DescID: 107, IndexID: 3, ConstraintID: 4, TemporaryIndexID: 4, SourceIndexID: 1}
+│       │   │         rule: "PrimaryIndex transitions to PUBLIC uphold 2-version invariant: ABSENT->BACKFILL_ONLY"
+│       │   │
+│       │   ├── • IndexColumn:{DescID: 107, ColumnID: 1, IndexID: 3}
+│       │   │   │ ABSENT → PUBLIC
+│       │   │   │
+│       │   │   └── • Precedence dependency from BACKFILL_ONLY PrimaryIndex:{DescID: 107, IndexID: 3, ConstraintID: 4, TemporaryIndexID: 4, SourceIndexID: 1}
+│       │   │         rule: "index existence precedes index dependents"
+│       │   │
+│       │   ├── • IndexColumn:{DescID: 107, ColumnID: 5, IndexID: 3}
+│       │   │   │ ABSENT → PUBLIC
+│       │   │   │
+│       │   │   └── • Precedence dependency from BACKFILL_ONLY PrimaryIndex:{DescID: 107, IndexID: 3, ConstraintID: 4, TemporaryIndexID: 4, SourceIndexID: 1}
+│       │   │         rule: "index existence precedes index dependents"
+│       │   │
+│       │   ├── • IndexData:{DescID: 107, IndexID: 3}
+│       │   │   │ ABSENT → PUBLIC
+│       │   │   │
+│       │   │   └── • SameStagePrecedence dependency from BACKFILL_ONLY PrimaryIndex:{DescID: 107, IndexID: 3, ConstraintID: 4, TemporaryIndexID: 4, SourceIndexID: 1}
+│       │   │         rule: "index data exists as soon as index accepts backfills"
+│       │   │
+│       │   └── • IndexColumn:{DescID: 107, ColumnID: 5, IndexID: 4}
+│       │       │ ABSENT → PUBLIC
+│       │       │
+│       │       └── • Precedence dependency from DELETE_ONLY TemporaryIndex:{DescID: 107, IndexID: 4, ConstraintID: 5, SourceIndexID: 1}
+│       │             rule: "temp index existence precedes index dependents"
+│       │
+│       ├── • 2 elements transitioning toward TRANSIENT_ABSENT
+│       │   │
+│       │   ├── • TemporaryIndex:{DescID: 107, IndexID: 4, ConstraintID: 5, SourceIndexID: 1}
+│       │   │   │ ABSENT → DELETE_ONLY
+│       │   │   │
+│       │   │   └── • PreviousStagePrecedence dependency from ABSENT TemporaryIndex:{DescID: 107, IndexID: 4, ConstraintID: 5, SourceIndexID: 1}
+│       │   │         rule: "TemporaryIndex transitions to TRANSIENT_ABSENT uphold 2-version invariant: ABSENT->DELETE_ONLY"
+│       │   │
+│       │   └── • IndexColumn:{DescID: 107, ColumnID: 1, IndexID: 4}
+│       │       │ ABSENT → PUBLIC
+│       │       │
+│       │       └── • Precedence dependency from DELETE_ONLY TemporaryIndex:{DescID: 107, IndexID: 4, ConstraintID: 5, SourceIndexID: 1}
+│       │             rule: "temp index existence precedes index dependents"
+│       │
+│       ├── • 11 elements transitioning toward ABSENT
+│       │   │
+│       │   ├── • Column:{DescID: 107, ColumnID: 2}
+│       │   │   │ PUBLIC → WRITE_ONLY
+│       │   │   │
+│       │   │   └── • PreviousStagePrecedence dependency from PUBLIC Column:{DescID: 107, ColumnID: 2}
+│       │   │         rule: "Column transitions to ABSENT uphold 2-version invariant: PUBLIC->WRITE_ONLY"
+│       │   │
+│       │   ├── • ColumnName:{DescID: 107, Name: gs, ColumnID: 2}
+│       │   │   │ PUBLIC → ABSENT
+│       │   │   │
+│       │   │   └── • Precedence dependency from WRITE_ONLY Column:{DescID: 107, ColumnID: 2}
+│       │   │         rule: "column no longer public before dependents"
+│       │   │
+│       │   ├── • Column:{DescID: 107, ColumnID: 3}
+│       │   │   │ PUBLIC → WRITE_ONLY
+│       │   │   │
+│       │   │   └── • PreviousStagePrecedence dependency from PUBLIC Column:{DescID: 107, ColumnID: 3}
+│       │   │         rule: "Column transitions to ABSENT uphold 2-version invariant: PUBLIC->WRITE_ONLY"
+│       │   │
+│       │   ├── • ColumnName:{DescID: 107, Name: gv, ColumnID: 3}
+│       │   │   │ PUBLIC → ABSENT
+│       │   │   │
+│       │   │   └── • Precedence dependency from WRITE_ONLY Column:{DescID: 107, ColumnID: 3}
+│       │   │         rule: "column no longer public before dependents"
+│       │   │
+│       │   ├── • Column:{DescID: 107, ColumnID: 4}
+│       │   │   │ PUBLIC → WRITE_ONLY
+│       │   │   │
+│       │   │   └── • PreviousStagePrecedence dependency from PUBLIC Column:{DescID: 107, ColumnID: 4}
+│       │   │         rule: "Column transitions to ABSENT uphold 2-version invariant: PUBLIC->WRITE_ONLY"
+│       │   │
+│       │   ├── • ColumnName:{DescID: 107, Name: other, ColumnID: 4}
+│       │   │   │ PUBLIC → ABSENT
+│       │   │   │
+│       │   │   └── • Precedence dependency from WRITE_ONLY Column:{DescID: 107, ColumnID: 4}
+│       │   │         rule: "column no longer public before dependents"
+│       │   │
+│       │   ├── • SecondaryIndex:{DescID: 107, IndexID: 2, ConstraintID: 0}
+│       │   │   │ PUBLIC → VALIDATED
+│       │   │   │
+│       │   │   └── • PreviousStagePrecedence dependency from PUBLIC SecondaryIndex:{DescID: 107, IndexID: 2, ConstraintID: 0}
+│       │   │         rule: "SecondaryIndex transitions to ABSENT uphold 2-version invariant: PUBLIC->VALIDATED"
+│       │   │
+│       │   ├── • UniqueWithoutIndexConstraint:{DescID: 107, ConstraintID: 3}
+│       │   │   │ PUBLIC → VALIDATED
+│       │   │   │
+│       │   │   └── • PreviousStagePrecedence dependency from PUBLIC UniqueWithoutIndexConstraint:{DescID: 107, ConstraintID: 3}
+│       │   │         rule: "UniqueWithoutIndexConstraint transitions to ABSENT uphold 2-version invariant: PUBLIC->VALIDATED"
+│       │   │
+│       │   ├── • ConstraintWithoutIndexName:{DescID: 107, Name: myuwi, ConstraintID: 3}
+│       │   │   │ PUBLIC → ABSENT
+│       │   │   │
+│       │   │   └── • Precedence dependency from VALIDATED UniqueWithoutIndexConstraint:{DescID: 107, ConstraintID: 3}
+│       │   │         rule: "constraint no longer public before dependents"
+│       │   │
+│       │   ├── • CheckConstraint:{DescID: 107, IndexID: 0, ConstraintID: 2}
+│       │   │   │ PUBLIC → VALIDATED
+│       │   │   │
+│       │   │   └── • PreviousStagePrecedence dependency from PUBLIC CheckConstraint:{DescID: 107, IndexID: 0, ConstraintID: 2}
+│       │   │         rule: "CheckConstraint transitions to ABSENT uphold 2-version invariant: PUBLIC->VALIDATED"
+│       │   │
+│       │   └── • ConstraintWithoutIndexName:{DescID: 107, Name: mycheck, ConstraintID: 2}
+│       │       │ PUBLIC → ABSENT
+│       │       │
+│       │       └── • Precedence dependency from VALIDATED CheckConstraint:{DescID: 107, IndexID: 0, ConstraintID: 2}
+│       │             rule: "constraint no longer public before dependents"
+│       │
+│       └── • 24 Mutation operations
+│           │
+│           ├── • MakePublicColumnWriteOnly
+│           │     ColumnID: 2
+│           │     TableID: 107
+│           │
+│           ├── • SetColumnName
+│           │     ColumnID: 2
+│           │     Name: crdb_internal_column_2_name_placeholder
+│           │     TableID: 107
+│           │
+│           ├── • MakePublicColumnWriteOnly
+│           │     ColumnID: 3
+│           │     TableID: 107
+│           │
+│           ├── • SetColumnName
+│           │     ColumnID: 3
+│           │     Name: crdb_internal_column_3_name_placeholder
+│           │     TableID: 107
+│           │
+│           ├── • MakePublicColumnWriteOnly
+│           │     ColumnID: 4
+│           │     TableID: 107
+│           │
+│           ├── • SetColumnName
+│           │     ColumnID: 4
+│           │     Name: crdb_internal_column_4_name_placeholder
+│           │     TableID: 107
+│           │
+│           ├── • MakePublicSecondaryIndexWriteOnly
+│           │     IndexID: 2
+│           │     TableID: 107
+│           │
+│           ├── • MakePublicUniqueWithoutIndexConstraintValidated
+│           │     ConstraintID: 3
+│           │     TableID: 107
+│           │
+│           ├── • SetConstraintName
+│           │     ConstraintID: 3
+│           │     Name: crdb_internal_constraint_3_name_placeholder
+│           │     TableID: 107
+│           │
+│           ├── • MakePublicCheckConstraintValidated
+│           │     ConstraintID: 2
+│           │     TableID: 107
+│           │
+│           ├── • SetConstraintName
+│           │     ConstraintID: 2
+│           │     Name: crdb_internal_constraint_2_name_placeholder
+│           │     TableID: 107
+│           │
+│           ├── • MakeAbsentIndexBackfilling
+│           │     Index:
+│           │       ConstraintID: 4
+│           │       IndexID: 3
+│           │       IsUnique: true
+│           │       SourceIndexID: 1
+│           │       TableID: 107
+│           │       TemporaryIndexID: 4
+│           │
+│           ├── • MaybeAddSplitForIndex
+│           │     IndexID: 3
+│           │     TableID: 107
+│           │
+│           ├── • AddColumnToIndex
+│           │     ColumnID: 1
+│           │     IndexID: 3
+│           │     TableID: 107
+│           │
+│           ├── • AddColumnToIndex
+│           │     ColumnID: 5
+│           │     IndexID: 3
+│           │     Kind: 2
+│           │     TableID: 107
+│           │
+│           ├── • MakeAbsentTempIndexDeleteOnly
+│           │     Index:
+│           │       ConstraintID: 5
+│           │       IndexID: 4
+│           │       IsUnique: true
+│           │       SourceIndexID: 1
+│           │       TableID: 107
+│           │
+│           ├── • MaybeAddSplitForIndex
+│           │     IndexID: 4
+│           │     TableID: 107
+│           │
+│           ├── • AddColumnToIndex
+│           │     ColumnID: 1
+│           │     IndexID: 4
+│           │     TableID: 107
+│           │
+│           ├── • AddColumnToIndex
+│           │     ColumnID: 5
+│           │     IndexID: 4
+│           │     Kind: 2
+│           │     TableID: 107
+│           │
+│           ├── • SetJobStateOnDescriptor
+│           │     DescriptorID: 104
+│           │     Initialize: true
+│           │
+│           ├── • SetJobStateOnDescriptor
+│           │     DescriptorID: 105
+│           │     Initialize: true
+│           │
+│           ├── • SetJobStateOnDescriptor
+│           │     DescriptorID: 106
+│           │     Initialize: true
+│           │
+│           ├── • SetJobStateOnDescriptor
+│           │     DescriptorID: 107
+│           │     Initialize: true
+│           │
+│           └── • CreateSchemaChangerJob
+│                 Authorization:
+│                   UserName: root
+│                 DescriptorIDs:
+│                 - 104
+│                 - 105
+│                 - 106
+│                 - 107
+│                 JobID: 1
+│                 RunningStatus: PostCommitPhase stage 1 of 7 with 1 MutationType op pending
+│                 Statements:
+│                 - statement: DROP TYPE greeting CASCADE
+│                   redactedstatement: DROP TYPE ‹defaultdb›.‹public›.‹greeting› CASCADE
+│                   statementtag: DROP TYPE
+│
+├── • PostCommitPhase
+│   │
+│   ├── • Stage 1 of 7 in PostCommitPhase
+│   │   │
+│   │   ├── • 2 elements transitioning toward TRANSIENT_ABSENT
+│   │   │   │
+│   │   │   ├── • TemporaryIndex:{DescID: 107, IndexID: 4, ConstraintID: 5, SourceIndexID: 1}
+│   │   │   │   │ DELETE_ONLY → WRITE_ONLY
+│   │   │   │   │
+│   │   │   │   ├── • PreviousStagePrecedence dependency from DELETE_ONLY TemporaryIndex:{DescID: 107, IndexID: 4, ConstraintID: 5, SourceIndexID: 1}
+│   │   │   │   │     rule: "TemporaryIndex transitions to TRANSIENT_ABSENT uphold 2-version invariant: DELETE_ONLY->WRITE_ONLY"
+│   │   │   │   │
+│   │   │   │   └── • Precedence dependency from PUBLIC IndexColumn:{DescID: 107, ColumnID: 1, IndexID: 4}
+│   │   │   │         rule: "index-column added to index before temp index receives writes"
+│   │   │   │
+│   │   │   └── • IndexData:{DescID: 107, IndexID: 4}
+│   │   │       │ ABSENT → PUBLIC
+│   │   │       │
+│   │   │       └── • SameStagePrecedence dependency from WRITE_ONLY TemporaryIndex:{DescID: 107, IndexID: 4, ConstraintID: 5, SourceIndexID: 1}
+│   │   │             rule: "temp index data exists as soon as temp index accepts writes"
+│   │   │
+│   │   └── • 6 Mutation operations
+│   │       │
+│   │       ├── • MakeDeleteOnlyIndexWriteOnly
+│   │       │     IndexID: 4
+│   │       │     TableID: 107
+│   │       │
+│   │       ├── • SetJobStateOnDescriptor
+│   │       │     DescriptorID: 104
+│   │       │
+│   │       ├── • SetJobStateOnDescriptor
+│   │       │     DescriptorID: 105
+│   │       │
+│   │       ├── • SetJobStateOnDescriptor
+│   │       │     DescriptorID: 106
+│   │       │
+│   │       ├── • SetJobStateOnDescriptor
+│   │       │     DescriptorID: 107
+│   │       │
+│   │       └── • UpdateSchemaChangerJob
+│   │             JobID: 1
+│   │             RunningStatus: PostCommitPhase stage 2 of 7 with 1 BackfillType op pending
+│   │
+│   ├── • Stage 2 of 7 in PostCommitPhase
+│   │   │
+│   │   ├── • 1 element transitioning toward PUBLIC
+│   │   │   │
+│   │   │   └── • PrimaryIndex:{DescID: 107, IndexID: 3, ConstraintID: 4, TemporaryIndexID: 4, SourceIndexID: 1}
+│   │   │       │ BACKFILL_ONLY → BACKFILLED
+│   │   │       │
+│   │   │       ├── • PreviousStagePrecedence dependency from BACKFILL_ONLY PrimaryIndex:{DescID: 107, IndexID: 3, ConstraintID: 4, TemporaryIndexID: 4, SourceIndexID: 1}
+│   │   │       │     rule: "PrimaryIndex transitions to PUBLIC uphold 2-version invariant: BACKFILL_ONLY->BACKFILLED"
+│   │   │       │
+│   │   │       ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 107, ColumnID: 1, IndexID: 3}
+│   │   │       │     rule: "index-column added to index before index is backfilled"
+│   │   │       │
+│   │   │       ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 107, ColumnID: 5, IndexID: 3}
+│   │   │       │     rule: "index-column added to index before index is backfilled"
+│   │   │       │
+│   │   │       └── • Precedence dependency from WRITE_ONLY TemporaryIndex:{DescID: 107, IndexID: 4, ConstraintID: 5, SourceIndexID: 1}
+│   │   │             rule: "temp index is WRITE_ONLY before backfill"
+│   │   │
+│   │   └── • 1 Backfill operation
+│   │       │
+│   │       └── • BackfillIndex
+│   │             IndexID: 3
+│   │             SourceIndexID: 1
+│   │             TableID: 107
+│   │
+│   ├── • Stage 3 of 7 in PostCommitPhase
+│   │   │
+│   │   ├── • 1 element transitioning toward PUBLIC
+│   │   │   │
+│   │   │   └── • PrimaryIndex:{DescID: 107, IndexID: 3, ConstraintID: 4, TemporaryIndexID: 4, SourceIndexID: 1}
+│   │   │       │ BACKFILLED → DELETE_ONLY
+│   │   │       │
+│   │   │       └── • PreviousStagePrecedence dependency from BACKFILLED PrimaryIndex:{DescID: 107, IndexID: 3, ConstraintID: 4, TemporaryIndexID: 4, SourceIndexID: 1}
+│   │   │             rule: "PrimaryIndex transitions to PUBLIC uphold 2-version invariant: BACKFILLED->DELETE_ONLY"
+│   │   │
+│   │   └── • 6 Mutation operations
+│   │       │
+│   │       ├── • MakeBackfillingIndexDeleteOnly
+│   │       │     IndexID: 3
+│   │       │     TableID: 107
+│   │       │
+│   │       ├── • SetJobStateOnDescriptor
+│   │       │     DescriptorID: 104
+│   │       │
+│   │       ├── • SetJobStateOnDescriptor
+│   │       │     DescriptorID: 105
+│   │       │
+│   │       ├── • SetJobStateOnDescriptor
+│   │       │     DescriptorID: 106
+│   │       │
+│   │       ├── • SetJobStateOnDescriptor
+│   │       │     DescriptorID: 107
+│   │       │
+│   │       └── • UpdateSchemaChangerJob
+│   │             JobID: 1
+│   │             RunningStatus: PostCommitPhase stage 4 of 7 with 1 MutationType op pending
+│   │
+│   ├── • Stage 4 of 7 in PostCommitPhase
+│   │   │
+│   │   ├── • 1 element transitioning toward PUBLIC
+│   │   │   │
+│   │   │   └── • PrimaryIndex:{DescID: 107, IndexID: 3, ConstraintID: 4, TemporaryIndexID: 4, SourceIndexID: 1}
+│   │   │       │ DELETE_ONLY → MERGE_ONLY
+│   │   │       │
+│   │   │       └── • PreviousStagePrecedence dependency from DELETE_ONLY PrimaryIndex:{DescID: 107, IndexID: 3, ConstraintID: 4, TemporaryIndexID: 4, SourceIndexID: 1}
+│   │   │             rule: "PrimaryIndex transitions to PUBLIC uphold 2-version invariant: DELETE_ONLY->MERGE_ONLY"
+│   │   │
+│   │   └── • 6 Mutation operations
+│   │       │
+│   │       ├── • MakeBackfilledIndexMerging
+│   │       │     IndexID: 3
+│   │       │     TableID: 107
+│   │       │
+│   │       ├── • SetJobStateOnDescriptor
+│   │       │     DescriptorID: 104
+│   │       │
+│   │       ├── • SetJobStateOnDescriptor
+│   │       │     DescriptorID: 105
+│   │       │
+│   │       ├── • SetJobStateOnDescriptor
+│   │       │     DescriptorID: 106
+│   │       │
+│   │       ├── • SetJobStateOnDescriptor
+│   │       │     DescriptorID: 107
+│   │       │
+│   │       └── • UpdateSchemaChangerJob
+│   │             JobID: 1
+│   │             RunningStatus: PostCommitPhase stage 5 of 7 with 1 BackfillType op pending
+│   │
+│   ├── • Stage 5 of 7 in PostCommitPhase
+│   │   │
+│   │   ├── • 1 element transitioning toward PUBLIC
+│   │   │   │
+│   │   │   └── • PrimaryIndex:{DescID: 107, IndexID: 3, ConstraintID: 4, TemporaryIndexID: 4, SourceIndexID: 1}
+│   │   │       │ MERGE_ONLY → MERGED
+│   │   │       │
+│   │   │       └── • PreviousStagePrecedence dependency from MERGE_ONLY PrimaryIndex:{DescID: 107, IndexID: 3, ConstraintID: 4, TemporaryIndexID: 4, SourceIndexID: 1}
+│   │   │             rule: "PrimaryIndex transitions to PUBLIC uphold 2-version invariant: MERGE_ONLY->MERGED"
+│   │   │
+│   │   └── • 1 Backfill operation
+│   │       │
+│   │       └── • MergeIndex
+│   │             BackfilledIndexID: 3
+│   │             TableID: 107
+│   │             TemporaryIndexID: 4
+│   │
+│   ├── • Stage 6 of 7 in PostCommitPhase
+│   │   │
+│   │   ├── • 1 element transitioning toward PUBLIC
+│   │   │   │
+│   │   │   └── • PrimaryIndex:{DescID: 107, IndexID: 3, ConstraintID: 4, TemporaryIndexID: 4, SourceIndexID: 1}
+│   │   │       │ MERGED → WRITE_ONLY
+│   │   │       │
+│   │   │       └── • PreviousStagePrecedence dependency from MERGED PrimaryIndex:{DescID: 107, IndexID: 3, ConstraintID: 4, TemporaryIndexID: 4, SourceIndexID: 1}
+│   │   │             rule: "PrimaryIndex transitions to PUBLIC uphold 2-version invariant: MERGED->WRITE_ONLY"
+│   │   │
+│   │   └── • 6 Mutation operations
+│   │       │
+│   │       ├── • MakeMergedIndexWriteOnly
+│   │       │     IndexID: 3
+│   │       │     TableID: 107
+│   │       │
+│   │       ├── • SetJobStateOnDescriptor
+│   │       │     DescriptorID: 104
+│   │       │
+│   │       ├── • SetJobStateOnDescriptor
+│   │       │     DescriptorID: 105
+│   │       │
+│   │       ├── • SetJobStateOnDescriptor
+│   │       │     DescriptorID: 106
+│   │       │
+│   │       ├── • SetJobStateOnDescriptor
+│   │       │     DescriptorID: 107
+│   │       │
+│   │       └── • UpdateSchemaChangerJob
+│   │             JobID: 1
+│   │             RunningStatus: PostCommitPhase stage 7 of 7 with 1 ValidationType op pending
+│   │
+│   └── • Stage 7 of 7 in PostCommitPhase
+│       │
+│       ├── • 1 element transitioning toward PUBLIC
+│       │   │
+│       │   └── • PrimaryIndex:{DescID: 107, IndexID: 3, ConstraintID: 4, TemporaryIndexID: 4, SourceIndexID: 1}
+│       │       │ WRITE_ONLY → VALIDATED
+│       │       │
+│       │       └── • PreviousStagePrecedence dependency from WRITE_ONLY PrimaryIndex:{DescID: 107, IndexID: 3, ConstraintID: 4, TemporaryIndexID: 4, SourceIndexID: 1}
+│       │             rule: "PrimaryIndex transitions to PUBLIC uphold 2-version invariant: WRITE_ONLY->VALIDATED"
+│       │
+│       └── • 1 Validation operation
+│           │
+│           └── • ValidateIndex
+│                 IndexID: 3
+│                 TableID: 107
+│
+└── • PostCommitNonRevertiblePhase
+    │
+    ├── • Stage 1 of 4 in PostCommitNonRevertiblePhase
+    │   │
+    │   ├── • 2 elements transitioning toward PUBLIC
+    │   │   │
+    │   │   ├── • PrimaryIndex:{DescID: 107, IndexID: 3, ConstraintID: 4, TemporaryIndexID: 4, SourceIndexID: 1}
+    │   │   │   │ VALIDATED → PUBLIC
+    │   │   │   │
+    │   │   │   ├── • SameStagePrecedence dependency from VALIDATED PrimaryIndex:{DescID: 107, IndexID: 1, ConstraintID: 1}
+    │   │   │   │     rule: "primary index swap"
+    │   │   │   │
+    │   │   │   ├── • PreviousStagePrecedence dependency from VALIDATED PrimaryIndex:{DescID: 107, IndexID: 3, ConstraintID: 4, TemporaryIndexID: 4, SourceIndexID: 1}
+    │   │   │   │     rule: "PrimaryIndex transitions to PUBLIC uphold 2-version invariant: VALIDATED->PUBLIC"
+    │   │   │   │
+    │   │   │   ├── • SameStagePrecedence dependency from PUBLIC IndexName:{DescID: 107, Name: tbl_pkey, IndexID: 3}
+    │   │   │   │     rule: "index dependents exist before index becomes public"
+    │   │   │   │     rule: "primary index named right before index becomes public"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 107, ColumnID: 1, IndexID: 3}
+    │   │   │   │     rule: "index dependents exist before index becomes public"
+    │   │   │   │
+    │   │   │   └── • Precedence dependency from PUBLIC IndexColumn:{DescID: 107, ColumnID: 5, IndexID: 3}
+    │   │   │         rule: "index dependents exist before index becomes public"
+    │   │   │
+    │   │   └── • IndexName:{DescID: 107, Name: tbl_pkey, IndexID: 3}
+    │   │       │ ABSENT → PUBLIC
+    │   │       │
+    │   │       └── • Precedence dependency from BACKFILL_ONLY PrimaryIndex:{DescID: 107, IndexID: 3, ConstraintID: 4, TemporaryIndexID: 4, SourceIndexID: 1}
+    │   │             rule: "index existence precedes index dependents"
+    │   │
+    │   ├── • 2 elements transitioning toward TRANSIENT_ABSENT
+    │   │   │
+    │   │   ├── • TemporaryIndex:{DescID: 107, IndexID: 4, ConstraintID: 5, SourceIndexID: 1}
+    │   │   │   │ WRITE_ONLY → TRANSIENT_DELETE_ONLY
+    │   │   │   │
+    │   │   │   └── • PreviousStagePrecedence dependency from WRITE_ONLY TemporaryIndex:{DescID: 107, IndexID: 4, ConstraintID: 5, SourceIndexID: 1}
+    │   │   │         rule: "TemporaryIndex transitions to TRANSIENT_ABSENT uphold 2-version invariant: WRITE_ONLY->TRANSIENT_DELETE_ONLY"
+    │   │   │
+    │   │   └── • IndexColumn:{DescID: 107, ColumnID: 1, IndexID: 4}
+    │   │       │ PUBLIC → TRANSIENT_ABSENT
+    │   │       │
+    │   │       └── • skip PUBLIC → TRANSIENT_ABSENT operations
+    │   │             rule: "skip index-column removal ops on index removal"
+    │   │
+    │   ├── • 30 elements transitioning toward ABSENT
+    │   │   │
+    │   │   ├── • Namespace:{DescID: 106, Name: view, ReferencedDescID: 100}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   └── • Precedence dependency from DROPPED View:{DescID: 106}
+    │   │   │         rule: "descriptor dropped before dependent element removal"
+    │   │   │
+    │   │   ├── • Owner:{DescID: 106}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from DROPPED View:{DescID: 106}
+    │   │   │   │     rule: "descriptor dropped before dependent element removal"
+    │   │   │   │
+    │   │   │   └── • skip PUBLIC → ABSENT operations
+    │   │   │         rule: "skip element removal ops on descriptor drop"
+    │   │   │
+    │   │   ├── • UserPrivileges:{DescID: 106, Name: admin}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from DROPPED View:{DescID: 106}
+    │   │   │   │     rule: "descriptor dropped before dependent element removal"
+    │   │   │   │
+    │   │   │   └── • skip PUBLIC → ABSENT operations
+    │   │   │         rule: "skip element removal ops on descriptor drop"
+    │   │   │
+    │   │   ├── • UserPrivileges:{DescID: 106, Name: root}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from DROPPED View:{DescID: 106}
+    │   │   │   │     rule: "descriptor dropped before dependent element removal"
+    │   │   │   │
+    │   │   │   └── • skip PUBLIC → ABSENT operations
+    │   │   │         rule: "skip element removal ops on descriptor drop"
+    │   │   │
+    │   │   ├── • View:{DescID: 106}
+    │   │   │     PUBLIC → DROPPED
+    │   │   │
+    │   │   ├── • ObjectParent:{DescID: 106, ReferencedDescID: 101}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   └── • SameStagePrecedence dependency from DROPPED View:{DescID: 106}
+    │   │   │         rule: "descriptor dropped before dependent element removal"
+    │   │   │         rule: "descriptor dropped right before removing back-reference in its parent descriptor"
+    │   │   │
+    │   │   ├── • Column:{DescID: 106, ColumnID: 1}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from DROPPED View:{DescID: 106}
+    │   │   │   │     rule: "relation dropped before dependent column"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from ABSENT ColumnName:{DescID: 106, Name: c, ColumnID: 1}
+    │   │   │   │     rule: "dependents removed before column"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from ABSENT ColumnType:{DescID: 106, ColumnFamilyID: 0, ColumnID: 1}
+    │   │   │   │     rule: "dependents removed before column"
+    │   │   │   │
+    │   │   │   ├── • skip PUBLIC → WRITE_ONLY operations
+    │   │   │   │     rule: "skip column removal ops on relation drop"
+    │   │   │   │
+    │   │   │   └── • skip WRITE_ONLY → DELETE_ONLY operations
+    │   │   │         rule: "skip column removal ops on relation drop"
+    │   │   │
+    │   │   ├── • ColumnName:{DescID: 106, Name: c, ColumnID: 1}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from DROPPED View:{DescID: 106}
+    │   │   │   │     rule: "descriptor dropped before dependent element removal"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from WRITE_ONLY Column:{DescID: 106, ColumnID: 1}
+    │   │   │   │     rule: "column no longer public before dependents"
+    │   │   │   │
+    │   │   │   └── • skip PUBLIC → ABSENT operations
+    │   │   │         rule: "skip column dependents removal ops on relation drop"
+    │   │   │
+    │   │   ├── • ColumnType:{DescID: 106, ColumnFamilyID: 0, ColumnID: 1}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from DROPPED View:{DescID: 106}
+    │   │   │   │     rule: "descriptor dropped before dependent element removal"
+    │   │   │   │
+    │   │   │   └── • Precedence dependency from WRITE_ONLY Column:{DescID: 106, ColumnID: 1}
+    │   │   │         rule: "column no longer public before dependents"
+    │   │   │
+    │   │   ├── • Column:{DescID: 106, ColumnID: 4294967295}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from DROPPED View:{DescID: 106}
+    │   │   │   │     rule: "relation dropped before dependent column"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from ABSENT ColumnName:{DescID: 106, Name: crdb_internal_mvcc_timestamp, ColumnID: 4294967295}
+    │   │   │   │     rule: "dependents removed before column"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from ABSENT ColumnType:{DescID: 106, ColumnFamilyID: 0, ColumnID: 4294967295}
+    │   │   │   │     rule: "dependents removed before column"
+    │   │   │   │
+    │   │   │   ├── • skip PUBLIC → WRITE_ONLY operations
+    │   │   │   │     rule: "skip column removal ops on relation drop"
+    │   │   │   │
+    │   │   │   └── • skip WRITE_ONLY → DELETE_ONLY operations
+    │   │   │         rule: "skip column removal ops on relation drop"
+    │   │   │
+    │   │   ├── • ColumnName:{DescID: 106, Name: crdb_internal_mvcc_timestamp, ColumnID: 4294967295}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from DROPPED View:{DescID: 106}
+    │   │   │   │     rule: "descriptor dropped before dependent element removal"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from WRITE_ONLY Column:{DescID: 106, ColumnID: 4294967295}
+    │   │   │   │     rule: "column no longer public before dependents"
+    │   │   │   │
+    │   │   │   └── • skip PUBLIC → ABSENT operations
+    │   │   │         rule: "skip column dependents removal ops on relation drop"
+    │   │   │
+    │   │   ├── • ColumnType:{DescID: 106, ColumnFamilyID: 0, ColumnID: 4294967295}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from DROPPED View:{DescID: 106}
+    │   │   │   │     rule: "descriptor dropped before dependent element removal"
+    │   │   │   │
+    │   │   │   └── • Precedence dependency from WRITE_ONLY Column:{DescID: 106, ColumnID: 4294967295}
+    │   │   │         rule: "column no longer public before dependents"
+    │   │   │
+    │   │   ├── • Column:{DescID: 106, ColumnID: 4294967294}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from DROPPED View:{DescID: 106}
+    │   │   │   │     rule: "relation dropped before dependent column"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from ABSENT ColumnName:{DescID: 106, Name: tableoid, ColumnID: 4294967294}
+    │   │   │   │     rule: "dependents removed before column"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from ABSENT ColumnType:{DescID: 106, ColumnFamilyID: 0, ColumnID: 4294967294}
+    │   │   │   │     rule: "dependents removed before column"
+    │   │   │   │
+    │   │   │   ├── • skip PUBLIC → WRITE_ONLY operations
+    │   │   │   │     rule: "skip column removal ops on relation drop"
+    │   │   │   │
+    │   │   │   └── • skip WRITE_ONLY → DELETE_ONLY operations
+    │   │   │         rule: "skip column removal ops on relation drop"
+    │   │   │
+    │   │   ├── • ColumnName:{DescID: 106, Name: tableoid, ColumnID: 4294967294}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from DROPPED View:{DescID: 106}
+    │   │   │   │     rule: "descriptor dropped before dependent element removal"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from WRITE_ONLY Column:{DescID: 106, ColumnID: 4294967294}
+    │   │   │   │     rule: "column no longer public before dependents"
+    │   │   │   │
+    │   │   │   └── • skip PUBLIC → ABSENT operations
+    │   │   │         rule: "skip column dependents removal ops on relation drop"
+    │   │   │
+    │   │   ├── • ColumnType:{DescID: 106, ColumnFamilyID: 0, ColumnID: 4294967294}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from DROPPED View:{DescID: 106}
+    │   │   │   │     rule: "descriptor dropped before dependent element removal"
+    │   │   │   │
+    │   │   │   └── • Precedence dependency from WRITE_ONLY Column:{DescID: 106, ColumnID: 4294967294}
+    │   │   │         rule: "column no longer public before dependents"
+    │   │   │
+    │   │   ├── • Column:{DescID: 107, ColumnID: 2}
+    │   │   │   │ WRITE_ONLY → DELETE_ONLY
+    │   │   │   │
+    │   │   │   └── • PreviousStagePrecedence dependency from WRITE_ONLY Column:{DescID: 107, ColumnID: 2}
+    │   │   │         rule: "Column transitions to ABSENT uphold 2-version invariant: WRITE_ONLY->DELETE_ONLY"
+    │   │   │
+    │   │   ├── • Column:{DescID: 107, ColumnID: 3}
+    │   │   │   │ WRITE_ONLY → DELETE_ONLY
+    │   │   │   │
+    │   │   │   └── • PreviousStagePrecedence dependency from WRITE_ONLY Column:{DescID: 107, ColumnID: 3}
+    │   │   │         rule: "Column transitions to ABSENT uphold 2-version invariant: WRITE_ONLY->DELETE_ONLY"
+    │   │   │
+    │   │   ├── • Column:{DescID: 107, ColumnID: 4}
+    │   │   │   │ WRITE_ONLY → DELETE_ONLY
+    │   │   │   │
+    │   │   │   └── • PreviousStagePrecedence dependency from WRITE_ONLY Column:{DescID: 107, ColumnID: 4}
+    │   │   │         rule: "Column transitions to ABSENT uphold 2-version invariant: WRITE_ONLY->DELETE_ONLY"
+    │   │   │
+    │   │   ├── • IndexColumn:{DescID: 107, ColumnID: 1, IndexID: 1}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from VALIDATED PrimaryIndex:{DescID: 107, IndexID: 1, ConstraintID: 1}
+    │   │   │   │     rule: "index no longer public before dependents"
+    │   │   │   │
+    │   │   │   └── • skip PUBLIC → ABSENT operations
+    │   │   │         rule: "skip index-column removal ops on index removal"
+    │   │   │
+    │   │   ├── • IndexColumn:{DescID: 107, ColumnID: 2, IndexID: 1}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from WRITE_ONLY Column:{DescID: 107, ColumnID: 2}
+    │   │   │   │     rule: "column no longer public before dependents"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from VALIDATED PrimaryIndex:{DescID: 107, IndexID: 1, ConstraintID: 1}
+    │   │   │   │     rule: "index no longer public before dependents"
+    │   │   │   │
+    │   │   │   └── • skip PUBLIC → ABSENT operations
+    │   │   │         rule: "skip index-column removal ops on index removal"
+    │   │   │
+    │   │   ├── • IndexColumn:{DescID: 107, ColumnID: 4, IndexID: 1}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from WRITE_ONLY Column:{DescID: 107, ColumnID: 4}
+    │   │   │   │     rule: "column no longer public before dependents"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from VALIDATED PrimaryIndex:{DescID: 107, IndexID: 1, ConstraintID: 1}
+    │   │   │   │     rule: "index no longer public before dependents"
+    │   │   │   │
+    │   │   │   └── • skip PUBLIC → ABSENT operations
+    │   │   │         rule: "skip index-column removal ops on index removal"
+    │   │   │
+    │   │   ├── • IndexColumn:{DescID: 107, ColumnID: 5, IndexID: 1}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from VALIDATED PrimaryIndex:{DescID: 107, IndexID: 1, ConstraintID: 1}
+    │   │   │   │     rule: "index no longer public before dependents"
+    │   │   │   │
+    │   │   │   └── • skip PUBLIC → ABSENT operations
+    │   │   │         rule: "skip index-column removal ops on index removal"
+    │   │   │
+    │   │   ├── • PrimaryIndex:{DescID: 107, IndexID: 1, ConstraintID: 1}
+    │   │   │   │ PUBLIC → VALIDATED
+    │   │   │   │
+    │   │   │   └── • PreviousStagePrecedence dependency from PUBLIC PrimaryIndex:{DescID: 107, IndexID: 1, ConstraintID: 1}
+    │   │   │         rule: "PrimaryIndex transitions to ABSENT uphold 2-version invariant: PUBLIC->VALIDATED"
+    │   │   │
+    │   │   ├── • IndexName:{DescID: 107, Name: tbl_pkey, IndexID: 1}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   └── • Precedence dependency from VALIDATED PrimaryIndex:{DescID: 107, IndexID: 1, ConstraintID: 1}
+    │   │   │         rule: "index no longer public before dependents"
+    │   │   │
+    │   │   ├── • IndexColumn:{DescID: 107, ColumnID: 5, IndexID: 2}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from VALIDATED SecondaryIndex:{DescID: 107, IndexID: 2, ConstraintID: 0}
+    │   │   │   │     rule: "index no longer public before dependents"
+    │   │   │   │
+    │   │   │   └── • skip PUBLIC → ABSENT operations
+    │   │   │         rule: "skip index-column removal ops on index removal"
+    │   │   │
+    │   │   ├── • IndexColumn:{DescID: 107, ColumnID: 1, IndexID: 2}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from VALIDATED SecondaryIndex:{DescID: 107, IndexID: 2, ConstraintID: 0}
+    │   │   │   │     rule: "index no longer public before dependents"
+    │   │   │   │
+    │   │   │   └── • skip PUBLIC → ABSENT operations
+    │   │   │         rule: "skip index-column removal ops on index removal"
+    │   │   │
+    │   │   ├── • SecondaryIndex:{DescID: 107, IndexID: 2, ConstraintID: 0}
+    │   │   │   │ VALIDATED → DELETE_ONLY
+    │   │   │   │
+    │   │   │   └── • PreviousStagePrecedence dependency from VALIDATED SecondaryIndex:{DescID: 107, IndexID: 2, ConstraintID: 0}
+    │   │   │         rule: "SecondaryIndex transitions to ABSENT uphold 2-version invariant: VALIDATED->WRITE_ONLY"
+    │   │   │
+    │   │   ├── • IndexName:{DescID: 107, Name: partial, IndexID: 2}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from DELETE_ONLY SecondaryIndex:{DescID: 107, IndexID: 2, ConstraintID: 0}
+    │   │   │   │     rule: "index no longer public before index name"
+    │   │   │   │
+    │   │   │   └── • Precedence dependency from VALIDATED SecondaryIndex:{DescID: 107, IndexID: 2, ConstraintID: 0}
+    │   │   │         rule: "index no longer public before dependents"
+    │   │   │
+    │   │   ├── • UniqueWithoutIndexConstraint:{DescID: 107, ConstraintID: 3}
+    │   │   │   │ VALIDATED → ABSENT
+    │   │   │   │
+    │   │   │   ├── • PreviousStagePrecedence dependency from VALIDATED UniqueWithoutIndexConstraint:{DescID: 107, ConstraintID: 3}
+    │   │   │   │     rule: "UniqueWithoutIndexConstraint transitions to ABSENT uphold 2-version invariant: VALIDATED->ABSENT"
+    │   │   │   │
+    │   │   │   └── • Precedence dependency from ABSENT ConstraintWithoutIndexName:{DescID: 107, Name: myuwi, ConstraintID: 3}
+    │   │   │         rule: "dependents removed before constraint"
+    │   │   │
+    │   │   └── • CheckConstraint:{DescID: 107, IndexID: 0, ConstraintID: 2}
+    │   │       │ VALIDATED → ABSENT
+    │   │       │
+    │   │       ├── • PreviousStagePrecedence dependency from VALIDATED CheckConstraint:{DescID: 107, IndexID: 0, ConstraintID: 2}
+    │   │       │     rule: "CheckConstraint transitions to ABSENT uphold 2-version invariant: VALIDATED->ABSENT"
+    │   │       │
+    │   │       └── • Precedence dependency from ABSENT ConstraintWithoutIndexName:{DescID: 107, Name: mycheck, ConstraintID: 2}
+    │   │             rule: "dependents removed before constraint"
+    │   │
+    │   └── • 24 Mutation operations
+    │       │
+    │       ├── • MarkDescriptorAsDropped
+    │       │     DescriptorID: 106
+    │       │
+    │       ├── • RemoveBackReferenceInTypes
+    │       │     BackReferencedDescriptorID: 106
+    │       │     TypeIDs:
+    │       │     - 104
+    │       │     - 105
+    │       │
+    │       ├── • RemoveObjectParent
+    │       │     ObjectID: 106
+    │       │     ParentSchemaID: 101
+    │       │
+    │       ├── • MakeWriteOnlyColumnDeleteOnly
+    │       │     ColumnID: 2
+    │       │     TableID: 107
+    │       │
+    │       ├── • MakeWriteOnlyColumnDeleteOnly
+    │       │     ColumnID: 3
+    │       │     TableID: 107
+    │       │
+    │       ├── • MakeWriteOnlyColumnDeleteOnly
+    │       │     ColumnID: 4
+    │       │     TableID: 107
+    │       │
+    │       ├── • MakePublicPrimaryIndexWriteOnly
+    │       │     IndexID: 1
+    │       │     TableID: 107
+    │       │
+    │       ├── • SetIndexName
+    │       │     IndexID: 1
+    │       │     Name: crdb_internal_index_1_name_placeholder
+    │       │     TableID: 107
+    │       │
+    │       ├── • RemoveUniqueWithoutIndexConstraint
+    │       │     ConstraintID: 3
+    │       │     TableID: 107
+    │       │
+    │       ├── • RemoveCheckConstraint
+    │       │     ConstraintID: 2
+    │       │     TableID: 107
+    │       │
+    │       ├── • SetIndexName
+    │       │     IndexID: 3
+    │       │     Name: tbl_pkey
+    │       │     TableID: 107
+    │       │
+    │       ├── • MakeWriteOnlyIndexDeleteOnly
+    │       │     IndexID: 4
+    │       │     TableID: 107
+    │       │
+    │       ├── • DrainDescriptorName
+    │       │     Namespace:
+    │       │       DatabaseID: 100
+    │       │       DescriptorID: 106
+    │       │       Name: view
+    │       │       SchemaID: 101
+    │       │
+    │       ├── • MakeWriteOnlyIndexDeleteOnly
+    │       │     IndexID: 2
+    │       │     TableID: 107
+    │       │
+    │       ├── • SetIndexName
+    │       │     IndexID: 2
+    │       │     Name: crdb_internal_index_2_name_placeholder
+    │       │     TableID: 107
+    │       │
+    │       ├── • MakeValidatedPrimaryIndexPublic
+    │       │     IndexID: 3
+    │       │     TableID: 107
+    │       │
+    │       ├── • MakeDeleteOnlyColumnAbsent
+    │       │     ColumnID: 1
+    │       │     TableID: 106
+    │       │
+    │       ├── • MakeDeleteOnlyColumnAbsent
+    │       │     ColumnID: 4294967295
+    │       │     TableID: 106
+    │       │
+    │       ├── • MakeDeleteOnlyColumnAbsent
+    │       │     ColumnID: 4294967294
+    │       │     TableID: 106
+    │       │
+    │       ├── • SetJobStateOnDescriptor
+    │       │     DescriptorID: 104
+    │       │
+    │       ├── • SetJobStateOnDescriptor
+    │       │     DescriptorID: 105
+    │       │
+    │       ├── • SetJobStateOnDescriptor
+    │       │     DescriptorID: 106
+    │       │
+    │       ├── • SetJobStateOnDescriptor
+    │       │     DescriptorID: 107
+    │       │
+    │       └── • UpdateSchemaChangerJob
+    │             IsNonCancelable: true
+    │             JobID: 1
+    │             RunningStatus: PostCommitNonRevertiblePhase stage 2 of 4 with 5 MutationType ops pending
+    │
+    ├── • Stage 2 of 4 in PostCommitNonRevertiblePhase
+    │   │
+    │   ├── • 1 element transitioning toward TRANSIENT_ABSENT
+    │   │   │
+    │   │   └── • TemporaryIndex:{DescID: 107, IndexID: 4, ConstraintID: 5, SourceIndexID: 1}
+    │   │       │ TRANSIENT_DELETE_ONLY → TRANSIENT_ABSENT
+    │   │       │
+    │   │       ├── • PreviousStagePrecedence dependency from TRANSIENT_DELETE_ONLY TemporaryIndex:{DescID: 107, IndexID: 4, ConstraintID: 5, SourceIndexID: 1}
+    │   │       │     rule: "TemporaryIndex transitions to TRANSIENT_ABSENT uphold 2-version invariant: TRANSIENT_DELETE_ONLY->TRANSIENT_ABSENT"
+    │   │       │
+    │   │       └── • Precedence dependency from TRANSIENT_ABSENT IndexColumn:{DescID: 107, ColumnID: 1, IndexID: 4}
+    │   │             rule: "dependents removed before index"
+    │   │
+    │   ├── • 4 elements transitioning toward ABSENT
+    │   │   │
+    │   │   ├── • View:{DescID: 106}
+    │   │   │   │ DROPPED → ABSENT
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from ABSENT Namespace:{DescID: 106, Name: view, ReferencedDescID: 100}
+    │   │   │   │     rule: "non-data dependents removed before descriptor"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from ABSENT Owner:{DescID: 106}
+    │   │   │   │     rule: "non-data dependents removed before descriptor"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from ABSENT UserPrivileges:{DescID: 106, Name: admin}
+    │   │   │   │     rule: "non-data dependents removed before descriptor"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from ABSENT UserPrivileges:{DescID: 106, Name: root}
+    │   │   │   │     rule: "non-data dependents removed before descriptor"
+    │   │   │   │
+    │   │   │   ├── • PreviousStagePrecedence dependency from DROPPED View:{DescID: 106}
+    │   │   │   │     rule: "descriptor dropped in transaction before removal"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from ABSENT ObjectParent:{DescID: 106, ReferencedDescID: 101}
+    │   │   │   │     rule: "non-data dependents removed before descriptor"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from ABSENT Column:{DescID: 106, ColumnID: 1}
+    │   │   │   │     rule: "non-data dependents removed before descriptor"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from ABSENT ColumnName:{DescID: 106, Name: c, ColumnID: 1}
+    │   │   │   │     rule: "non-data dependents removed before descriptor"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from ABSENT ColumnType:{DescID: 106, ColumnFamilyID: 0, ColumnID: 1}
+    │   │   │   │     rule: "non-data dependents removed before descriptor"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from ABSENT Column:{DescID: 106, ColumnID: 4294967295}
+    │   │   │   │     rule: "non-data dependents removed before descriptor"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from ABSENT ColumnName:{DescID: 106, Name: crdb_internal_mvcc_timestamp, ColumnID: 4294967295}
+    │   │   │   │     rule: "non-data dependents removed before descriptor"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from ABSENT ColumnType:{DescID: 106, ColumnFamilyID: 0, ColumnID: 4294967295}
+    │   │   │   │     rule: "non-data dependents removed before descriptor"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from ABSENT Column:{DescID: 106, ColumnID: 4294967294}
+    │   │   │   │     rule: "non-data dependents removed before descriptor"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from ABSENT ColumnName:{DescID: 106, Name: tableoid, ColumnID: 4294967294}
+    │   │   │   │     rule: "non-data dependents removed before descriptor"
+    │   │   │   │
+    │   │   │   └── • Precedence dependency from ABSENT ColumnType:{DescID: 106, ColumnFamilyID: 0, ColumnID: 4294967294}
+    │   │   │         rule: "non-data dependents removed before descriptor"
+    │   │   │
+    │   │   ├── • PrimaryIndex:{DescID: 107, IndexID: 1, ConstraintID: 1}
+    │   │   │   │ VALIDATED → DELETE_ONLY
+    │   │   │   │
+    │   │   │   └── • PreviousStagePrecedence dependency from VALIDATED PrimaryIndex:{DescID: 107, IndexID: 1, ConstraintID: 1}
+    │   │   │         rule: "PrimaryIndex transitions to ABSENT uphold 2-version invariant: VALIDATED->WRITE_ONLY"
+    │   │   │
+    │   │   ├── • SecondaryIndexPartial:{DescID: 107, IndexID: 2}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   └── • Precedence dependency from VALIDATED SecondaryIndex:{DescID: 107, IndexID: 2, ConstraintID: 0}
+    │   │   │         rule: "index no longer public before dependents"
+    │   │   │
+    │   │   └── • SecondaryIndex:{DescID: 107, IndexID: 2, ConstraintID: 0}
+    │   │       │ DELETE_ONLY → ABSENT
+    │   │       │
+    │   │       ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 107, ColumnID: 5, IndexID: 2}
+    │   │       │     rule: "dependents removed before index"
+    │   │       │
+    │   │       ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 107, ColumnID: 1, IndexID: 2}
+    │   │       │     rule: "dependents removed before index"
+    │   │       │
+    │   │       ├── • SameStagePrecedence dependency from ABSENT SecondaryIndexPartial:{DescID: 107, IndexID: 2}
+    │   │       │     rule: "dependents removed before index"
+    │   │       │     rule: "partial predicate removed right before secondary index when not dropping relation"
+    │   │       │
+    │   │       ├── • PreviousStagePrecedence dependency from DELETE_ONLY SecondaryIndex:{DescID: 107, IndexID: 2, ConstraintID: 0}
+    │   │       │     rule: "SecondaryIndex transitions to ABSENT uphold 2-version invariant: DELETE_ONLY->ABSENT"
+    │   │       │
+    │   │       └── • Precedence dependency from ABSENT IndexName:{DescID: 107, Name: partial, IndexID: 2}
+    │   │             rule: "dependents removed before index"
+    │   │
+    │   └── • 10 Mutation operations
+    │       │
+    │       ├── • DeleteDescriptor
+    │       │     DescriptorID: 106
+    │       │
+    │       ├── • RemoveDroppedIndexPartialPredicate
+    │       │     IndexID: 2
+    │       │     TableID: 107
+    │       │
+    │       ├── • MakeIndexAbsent
+    │       │     IndexID: 2
+    │       │     TableID: 107
+    │       │
+    │       ├── • MakeIndexAbsent
+    │       │     IndexID: 4
+    │       │     TableID: 107
+    │       │
+    │       ├── • MakeWriteOnlyIndexDeleteOnly
+    │       │     IndexID: 1
+    │       │     TableID: 107
+    │       │
+    │       ├── • SetJobStateOnDescriptor
+    │       │     DescriptorID: 104
+    │       │
+    │       ├── • SetJobStateOnDescriptor
+    │       │     DescriptorID: 105
+    │       │
+    │       ├── • RemoveJobStateFromDescriptor
+    │       │     DescriptorID: 106
+    │       │     JobID: 1
+    │       │
+    │       ├── • SetJobStateOnDescriptor
+    │       │     DescriptorID: 107
+    │       │
+    │       └── • UpdateSchemaChangerJob
+    │             DescriptorIDsToRemove:
+    │             - 106
+    │             IsNonCancelable: true
+    │             JobID: 1
+    │             RunningStatus: PostCommitNonRevertiblePhase stage 3 of 4 with 19 MutationType ops
+    │               pending
+    │
+    ├── • Stage 3 of 4 in PostCommitNonRevertiblePhase
+    │   │
+    │   ├── • 1 element transitioning toward TRANSIENT_ABSENT
+    │   │   │
+    │   │   └── • IndexData:{DescID: 107, IndexID: 4}
+    │   │       │ PUBLIC → TRANSIENT_ABSENT
+    │   │       │
+    │   │       ├── • SameStagePrecedence dependency from DROPPED IndexData:{DescID: 107, IndexID: 1}
+    │   │       │     rule: "schedule all GC jobs for a descriptor in the same stage"
+    │   │       │
+    │   │       ├── • SameStagePrecedence dependency from DROPPED IndexData:{DescID: 107, IndexID: 2}
+    │   │       │     rule: "schedule all GC jobs for a descriptor in the same stage"
+    │   │       │
+    │   │       └── • Precedence dependency from TRANSIENT_ABSENT TemporaryIndex:{DescID: 107, IndexID: 4, ConstraintID: 5, SourceIndexID: 1}
+    │   │             rule: "index removed before garbage collection"
+    │   │
+    │   ├── • 25 elements transitioning toward ABSENT
+    │   │   │
+    │   │   ├── • Namespace:{DescID: 104, Name: greeting, ReferencedDescID: 100}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   └── • Precedence dependency from DROPPED EnumType:{DescID: 104}
+    │   │   │         rule: "descriptor dropped before dependent element removal"
+    │   │   │
+    │   │   ├── • Owner:{DescID: 104}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from DROPPED EnumType:{DescID: 104}
+    │   │   │   │     rule: "descriptor dropped before dependent element removal"
+    │   │   │   │
+    │   │   │   └── • skip PUBLIC → ABSENT operations
+    │   │   │         rule: "skip element removal ops on descriptor drop"
+    │   │   │
+    │   │   ├── • UserPrivileges:{DescID: 104, Name: admin}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from DROPPED EnumType:{DescID: 104}
+    │   │   │   │     rule: "descriptor dropped before dependent element removal"
+    │   │   │   │
+    │   │   │   └── • skip PUBLIC → ABSENT operations
+    │   │   │         rule: "skip element removal ops on descriptor drop"
+    │   │   │
+    │   │   ├── • UserPrivileges:{DescID: 104, Name: public}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from DROPPED EnumType:{DescID: 104}
+    │   │   │   │     rule: "descriptor dropped before dependent element removal"
+    │   │   │   │
+    │   │   │   └── • skip PUBLIC → ABSENT operations
+    │   │   │         rule: "skip element removal ops on descriptor drop"
+    │   │   │
+    │   │   ├── • UserPrivileges:{DescID: 104, Name: root}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from DROPPED EnumType:{DescID: 104}
+    │   │   │   │     rule: "descriptor dropped before dependent element removal"
+    │   │   │   │
+    │   │   │   └── • skip PUBLIC → ABSENT operations
+    │   │   │         rule: "skip element removal ops on descriptor drop"
+    │   │   │
+    │   │   ├── • EnumType:{DescID: 104}
+    │   │   │     PUBLIC → DROPPED
+    │   │   │
+    │   │   ├── • EnumTypeValue:{DescID: 104, Name: hello}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from DROPPED EnumType:{DescID: 104}
+    │   │   │   │     rule: "descriptor dropped before dependent element removal"
+    │   │   │   │
+    │   │   │   └── • skip PUBLIC → ABSENT operations
+    │   │   │         rule: "skip element removal ops on descriptor drop"
+    │   │   │
+    │   │   ├── • EnumTypeValue:{DescID: 104, Name: hi}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from DROPPED EnumType:{DescID: 104}
+    │   │   │   │     rule: "descriptor dropped before dependent element removal"
+    │   │   │   │
+    │   │   │   └── • skip PUBLIC → ABSENT operations
+    │   │   │         rule: "skip element removal ops on descriptor drop"
+    │   │   │
+    │   │   ├── • ObjectParent:{DescID: 104, ReferencedDescID: 101}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   └── • SameStagePrecedence dependency from DROPPED EnumType:{DescID: 104}
+    │   │   │         rule: "descriptor dropped before dependent element removal"
+    │   │   │         rule: "descriptor dropped right before removing back-reference in its parent descriptor"
+    │   │   │
+    │   │   ├── • Namespace:{DescID: 105, Name: _greeting, ReferencedDescID: 100}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   └── • Precedence dependency from DROPPED AliasType:{DescID: 105, ReferencedTypeIDs: [104 105]}
+    │   │   │         rule: "descriptor dropped before dependent element removal"
+    │   │   │
+    │   │   ├── • Owner:{DescID: 105}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from DROPPED AliasType:{DescID: 105, ReferencedTypeIDs: [104 105]}
+    │   │   │   │     rule: "descriptor dropped before dependent element removal"
+    │   │   │   │
+    │   │   │   └── • skip PUBLIC → ABSENT operations
+    │   │   │         rule: "skip element removal ops on descriptor drop"
+    │   │   │
+    │   │   ├── • UserPrivileges:{DescID: 105, Name: admin}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from DROPPED AliasType:{DescID: 105, ReferencedTypeIDs: [104 105]}
+    │   │   │   │     rule: "descriptor dropped before dependent element removal"
+    │   │   │   │
+    │   │   │   └── • skip PUBLIC → ABSENT operations
+    │   │   │         rule: "skip element removal ops on descriptor drop"
+    │   │   │
+    │   │   ├── • UserPrivileges:{DescID: 105, Name: public}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from DROPPED AliasType:{DescID: 105, ReferencedTypeIDs: [104 105]}
+    │   │   │   │     rule: "descriptor dropped before dependent element removal"
+    │   │   │   │
+    │   │   │   └── • skip PUBLIC → ABSENT operations
+    │   │   │         rule: "skip element removal ops on descriptor drop"
+    │   │   │
+    │   │   ├── • UserPrivileges:{DescID: 105, Name: root}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from DROPPED AliasType:{DescID: 105, ReferencedTypeIDs: [104 105]}
+    │   │   │   │     rule: "descriptor dropped before dependent element removal"
+    │   │   │   │
+    │   │   │   └── • skip PUBLIC → ABSENT operations
+    │   │   │         rule: "skip element removal ops on descriptor drop"
+    │   │   │
+    │   │   ├── • AliasType:{DescID: 105, ReferencedTypeIDs: [104 105]}
+    │   │   │     PUBLIC → DROPPED
+    │   │   │
+    │   │   ├── • ObjectParent:{DescID: 105, ReferencedDescID: 101}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   └── • SameStagePrecedence dependency from DROPPED AliasType:{DescID: 105, ReferencedTypeIDs: [104 105]}
+    │   │   │         rule: "descriptor dropped before dependent element removal"
+    │   │   │         rule: "descriptor dropped right before removing back-reference in its parent descriptor"
+    │   │   │
+    │   │   ├── • Column:{DescID: 107, ColumnID: 2}
+    │   │   │   │ DELETE_ONLY → ABSENT
+    │   │   │   │
+    │   │   │   ├── • PreviousStagePrecedence dependency from DELETE_ONLY Column:{DescID: 107, ColumnID: 2}
+    │   │   │   │     rule: "Column transitions to ABSENT uphold 2-version invariant: DELETE_ONLY->ABSENT"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from ABSENT ColumnName:{DescID: 107, Name: gs, ColumnID: 2}
+    │   │   │   │     rule: "dependents removed before column"
+    │   │   │   │
+    │   │   │   ├── • SameStagePrecedence dependency from ABSENT ColumnType:{DescID: 107, ReferencedTypeIDs: [104 105], ColumnFamilyID: 0, ColumnID: 2}
+    │   │   │   │     rule: "dependents removed before column"
+    │   │   │   │     rule: "column type removed right before column when not dropping relation"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 107, ColumnID: 2, IndexID: 1}
+    │   │   │   │     rule: "dependents removed before column"
+    │   │   │   │
+    │   │   │   └── • Precedence dependency from ABSENT PrimaryIndex:{DescID: 107, IndexID: 1, ConstraintID: 1}
+    │   │   │         rule: "indexes containing column reach absent before column"
+    │   │   │
+    │   │   ├── • ColumnType:{DescID: 107, ReferencedTypeIDs: [104 105], ColumnFamilyID: 0, ColumnID: 2}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   ├── • SameStagePrecedence dependency from DROPPED EnumType:{DescID: 104}
+    │   │   │   │     rule: "descriptor drop right before removing dependent with type ref"
+    │   │   │   │
+    │   │   │   ├── • SameStagePrecedence dependency from DROPPED AliasType:{DescID: 105, ReferencedTypeIDs: [104 105]}
+    │   │   │   │     rule: "descriptor drop right before removing dependent with type ref"
+    │   │   │   │
+    │   │   │   └── • Precedence dependency from WRITE_ONLY Column:{DescID: 107, ColumnID: 2}
+    │   │   │         rule: "column no longer public before dependents"
+    │   │   │
+    │   │   ├── • Column:{DescID: 107, ColumnID: 3}
+    │   │   │   │ DELETE_ONLY → ABSENT
+    │   │   │   │
+    │   │   │   ├── • PreviousStagePrecedence dependency from DELETE_ONLY Column:{DescID: 107, ColumnID: 3}
+    │   │   │   │     rule: "Column transitions to ABSENT uphold 2-version invariant: DELETE_ONLY->ABSENT"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from ABSENT ColumnName:{DescID: 107, Name: gv, ColumnID: 3}
+    │   │   │   │     rule: "dependents removed before column"
+    │   │   │   │
+    │   │   │   └── • SameStagePrecedence dependency from ABSENT ColumnType:{DescID: 107, ReferencedTypeIDs: [104 105], ColumnFamilyID: 0, ColumnID: 3}
+    │   │   │         rule: "dependents removed before column"
+    │   │   │         rule: "column type removed right before column when not dropping relation"
+    │   │   │
+    │   │   ├── • ColumnType:{DescID: 107, ReferencedTypeIDs: [104 105], ColumnFamilyID: 0, ColumnID: 3}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   ├── • SameStagePrecedence dependency from DROPPED EnumType:{DescID: 104}
+    │   │   │   │     rule: "descriptor drop right before removing dependent with type ref"
+    │   │   │   │
+    │   │   │   ├── • SameStagePrecedence dependency from DROPPED AliasType:{DescID: 105, ReferencedTypeIDs: [104 105]}
+    │   │   │   │     rule: "descriptor drop right before removing dependent with type ref"
+    │   │   │   │
+    │   │   │   └── • Precedence dependency from WRITE_ONLY Column:{DescID: 107, ColumnID: 3}
+    │   │   │         rule: "column no longer public before dependents"
+    │   │   │
+    │   │   ├── • Column:{DescID: 107, ColumnID: 4}
+    │   │   │   │ DELETE_ONLY → ABSENT
+    │   │   │   │
+    │   │   │   ├── • PreviousStagePrecedence dependency from DELETE_ONLY Column:{DescID: 107, ColumnID: 4}
+    │   │   │   │     rule: "Column transitions to ABSENT uphold 2-version invariant: DELETE_ONLY->ABSENT"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from ABSENT ColumnName:{DescID: 107, Name: other, ColumnID: 4}
+    │   │   │   │     rule: "dependents removed before column"
+    │   │   │   │
+    │   │   │   ├── • SameStagePrecedence dependency from ABSENT ColumnType:{DescID: 107, ReferencedTypeIDs: [104 105], ColumnFamilyID: 0, ColumnID: 4}
+    │   │   │   │     rule: "dependents removed before column"
+    │   │   │   │     rule: "column type removed right before column when not dropping relation"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 107, ColumnID: 4, IndexID: 1}
+    │   │   │   │     rule: "dependents removed before column"
+    │   │   │   │
+    │   │   │   └── • Precedence dependency from ABSENT PrimaryIndex:{DescID: 107, IndexID: 1, ConstraintID: 1}
+    │   │   │         rule: "indexes containing column reach absent before column"
+    │   │   │
+    │   │   ├── • ColumnType:{DescID: 107, ReferencedTypeIDs: [104 105], ColumnFamilyID: 0, ColumnID: 4}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   ├── • SameStagePrecedence dependency from DROPPED EnumType:{DescID: 104}
+    │   │   │   │     rule: "descriptor drop right before removing dependent with type ref"
+    │   │   │   │
+    │   │   │   ├── • SameStagePrecedence dependency from DROPPED AliasType:{DescID: 105, ReferencedTypeIDs: [104 105]}
+    │   │   │   │     rule: "descriptor drop right before removing dependent with type ref"
+    │   │   │   │
+    │   │   │   └── • Precedence dependency from WRITE_ONLY Column:{DescID: 107, ColumnID: 4}
+    │   │   │         rule: "column no longer public before dependents"
+    │   │   │
+    │   │   ├── • PrimaryIndex:{DescID: 107, IndexID: 1, ConstraintID: 1}
+    │   │   │   │ DELETE_ONLY → ABSENT
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 107, ColumnID: 1, IndexID: 1}
+    │   │   │   │     rule: "dependents removed before index"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 107, ColumnID: 2, IndexID: 1}
+    │   │   │   │     rule: "dependents removed before index"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 107, ColumnID: 4, IndexID: 1}
+    │   │   │   │     rule: "dependents removed before index"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 107, ColumnID: 5, IndexID: 1}
+    │   │   │   │     rule: "dependents removed before index"
+    │   │   │   │
+    │   │   │   ├── • PreviousStagePrecedence dependency from DELETE_ONLY PrimaryIndex:{DescID: 107, IndexID: 1, ConstraintID: 1}
+    │   │   │   │     rule: "PrimaryIndex transitions to ABSENT uphold 2-version invariant: DELETE_ONLY->ABSENT"
+    │   │   │   │
+    │   │   │   └── • Precedence dependency from ABSENT IndexName:{DescID: 107, Name: tbl_pkey, IndexID: 1}
+    │   │   │         rule: "dependents removed before index"
+    │   │   │
+    │   │   ├── • IndexData:{DescID: 107, IndexID: 1}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   └── • Precedence dependency from ABSENT PrimaryIndex:{DescID: 107, IndexID: 1, ConstraintID: 1}
+    │   │   │         rule: "index removed before garbage collection"
+    │   │   │
+    │   │   └── • IndexData:{DescID: 107, IndexID: 2}
+    │   │       │ PUBLIC → ABSENT
+    │   │       │
+    │   │       ├── • SameStagePrecedence dependency from DROPPED IndexData:{DescID: 107, IndexID: 1}
+    │   │       │     rule: "schedule all GC jobs for a descriptor in the same stage"
+    │   │       │
+    │   │       └── • Precedence dependency from ABSENT SecondaryIndex:{DescID: 107, IndexID: 2, ConstraintID: 0}
+    │   │             rule: "index removed before garbage collection"
+    │   │
+    │   └── • 23 Mutation operations
+    │       │
+    │       ├── • MarkDescriptorAsDropped
+    │       │     DescriptorID: 104
+    │       │
+    │       ├── • RemoveObjectParent
+    │       │     ObjectID: 104
+    │       │     ParentSchemaID: 101
+    │       │
+    │       ├── • MarkDescriptorAsDropped
+    │       │     DescriptorID: 105
+    │       │
+    │       ├── • RemoveObjectParent
+    │       │     ObjectID: 105
+    │       │     ParentSchemaID: 101
+    │       │
+    │       ├── • RemoveDroppedColumnType
+    │       │     ColumnID: 2
+    │       │     TableID: 107
+    │       │
+    │       ├── • UpdateTableBackReferencesInTypes
+    │       │     BackReferencedTableID: 107
+    │       │     TypeIDs:
+    │       │     - 104
+    │       │     - 105
+    │       │
+    │       ├── • RemoveDroppedColumnType
+    │       │     ColumnID: 3
+    │       │     TableID: 107
+    │       │
+    │       ├── • UpdateTableBackReferencesInTypes
+    │       │     BackReferencedTableID: 107
+    │       │     TypeIDs:
+    │       │     - 104
+    │       │     - 105
+    │       │
+    │       ├── • RemoveDroppedColumnType
+    │       │     ColumnID: 4
+    │       │     TableID: 107
+    │       │
+    │       ├── • UpdateTableBackReferencesInTypes
+    │       │     BackReferencedTableID: 107
+    │       │     TypeIDs:
+    │       │     - 104
+    │       │     - 105
+    │       │
+    │       ├── • MakeIndexAbsent
+    │       │     IndexID: 1
+    │       │     TableID: 107
+    │       │
+    │       ├── • CreateGCJobForIndex
+    │       │     IndexID: 1
+    │       │     StatementForDropJob:
+    │       │       Statement: DROP TYPE defaultdb.public.greeting CASCADE
+    │       │     TableID: 107
+    │       │
+    │       ├── • CreateGCJobForIndex
+    │       │     IndexID: 2
+    │       │     StatementForDropJob:
+    │       │       Statement: DROP TYPE defaultdb.public.greeting CASCADE
+    │       │     TableID: 107
+    │       │
+    │       ├── • CreateGCJobForIndex
+    │       │     IndexID: 4
+    │       │     StatementForDropJob:
+    │       │       Statement: DROP TYPE defaultdb.public.greeting CASCADE
+    │       │     TableID: 107
+    │       │
+    │       ├── • DrainDescriptorName
+    │       │     Namespace:
+    │       │       DatabaseID: 100
+    │       │       DescriptorID: 104
+    │       │       Name: greeting
+    │       │       SchemaID: 101
+    │       │
+    │       ├── • DrainDescriptorName
+    │       │     Namespace:
+    │       │       DatabaseID: 100
+    │       │       DescriptorID: 105
+    │       │       Name: _greeting
+    │       │       SchemaID: 101
+    │       │
+    │       ├── • MakeDeleteOnlyColumnAbsent
+    │       │     ColumnID: 2
+    │       │     TableID: 107
+    │       │
+    │       ├── • MakeDeleteOnlyColumnAbsent
+    │       │     ColumnID: 3
+    │       │     TableID: 107
+    │       │
+    │       ├── • MakeDeleteOnlyColumnAbsent
+    │       │     ColumnID: 4
+    │       │     TableID: 107
+    │       │
+    │       ├── • SetJobStateOnDescriptor
+    │       │     DescriptorID: 104
+    │       │
+    │       ├── • SetJobStateOnDescriptor
+    │       │     DescriptorID: 105
+    │       │
+    │       ├── • SetJobStateOnDescriptor
+    │       │     DescriptorID: 107
+    │       │
+    │       └── • UpdateSchemaChangerJob
+    │             IsNonCancelable: true
+    │             JobID: 1
+    │             RunningStatus: PostCommitNonRevertiblePhase stage 4 of 4 with 2 MutationType ops pending
+    │
+    └── • Stage 4 of 4 in PostCommitNonRevertiblePhase
+        │
+        ├── • 2 elements transitioning toward ABSENT
+        │   │
+        │   ├── • EnumType:{DescID: 104}
+        │   │   │ DROPPED → ABSENT
+        │   │   │
+        │   │   ├── • Precedence dependency from ABSENT Namespace:{DescID: 104, Name: greeting, ReferencedDescID: 100}
+        │   │   │     rule: "non-data dependents removed before descriptor"
+        │   │   │
+        │   │   ├── • Precedence dependency from ABSENT Owner:{DescID: 104}
+        │   │   │     rule: "non-data dependents removed before descriptor"
+        │   │   │
+        │   │   ├── • Precedence dependency from ABSENT UserPrivileges:{DescID: 104, Name: admin}
+        │   │   │     rule: "non-data dependents removed before descriptor"
+        │   │   │
+        │   │   ├── • Precedence dependency from ABSENT UserPrivileges:{DescID: 104, Name: public}
+        │   │   │     rule: "non-data dependents removed before descriptor"
+        │   │   │
+        │   │   ├── • Precedence dependency from ABSENT UserPrivileges:{DescID: 104, Name: root}
+        │   │   │     rule: "non-data dependents removed before descriptor"
+        │   │   │
+        │   │   ├── • PreviousStagePrecedence dependency from DROPPED EnumType:{DescID: 104}
+        │   │   │     rule: "descriptor dropped in transaction before removal"
+        │   │   │
+        │   │   ├── • Precedence dependency from ABSENT EnumTypeValue:{DescID: 104, Name: hello}
+        │   │   │     rule: "non-data dependents removed before descriptor"
+        │   │   │
+        │   │   ├── • Precedence dependency from ABSENT EnumTypeValue:{DescID: 104, Name: hi}
+        │   │   │     rule: "non-data dependents removed before descriptor"
+        │   │   │
+        │   │   └── • Precedence dependency from ABSENT ObjectParent:{DescID: 104, ReferencedDescID: 101}
+        │   │         rule: "non-data dependents removed before descriptor"
+        │   │
+        │   └── • AliasType:{DescID: 105, ReferencedTypeIDs: [104 105]}
+        │       │ DROPPED → ABSENT
+        │       │
+        │       ├── • Precedence dependency from ABSENT Namespace:{DescID: 105, Name: _greeting, ReferencedDescID: 100}
+        │       │     rule: "non-data dependents removed before descriptor"
+        │       │
+        │       ├── • Precedence dependency from ABSENT Owner:{DescID: 105}
+        │       │     rule: "non-data dependents removed before descriptor"
+        │       │
+        │       ├── • Precedence dependency from ABSENT UserPrivileges:{DescID: 105, Name: admin}
+        │       │     rule: "non-data dependents removed before descriptor"
+        │       │
+        │       ├── • Precedence dependency from ABSENT UserPrivileges:{DescID: 105, Name: public}
+        │       │     rule: "non-data dependents removed before descriptor"
+        │       │
+        │       ├── • Precedence dependency from ABSENT UserPrivileges:{DescID: 105, Name: root}
+        │       │     rule: "non-data dependents removed before descriptor"
+        │       │
+        │       ├── • PreviousStagePrecedence dependency from DROPPED AliasType:{DescID: 105, ReferencedTypeIDs: [104 105]}
+        │       │     rule: "descriptor dropped in transaction before removal"
+        │       │
+        │       └── • Precedence dependency from ABSENT ObjectParent:{DescID: 105, ReferencedDescID: 101}
+        │             rule: "non-data dependents removed before descriptor"
+        │
+        └── • 6 Mutation operations
+            │
+            ├── • DeleteDescriptor
+            │     DescriptorID: 104
+            │
+            ├── • DeleteDescriptor
+            │     DescriptorID: 105
+            │
+            ├── • RemoveJobStateFromDescriptor
+            │     DescriptorID: 104
+            │     JobID: 1
+            │
+            ├── • RemoveJobStateFromDescriptor
+            │     DescriptorID: 105
+            │     JobID: 1
+            │
+            ├── • RemoveJobStateFromDescriptor
+            │     DescriptorID: 107
+            │     JobID: 1
+            │
+            └── • UpdateSchemaChangerJob
+                  DescriptorIDsToRemove:
+                  - 104
+                  - 105
+                  - 107
+                  IsNonCancelable: true
+                  JobID: 1
+                  RunningStatus: all stages completed

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_type_cascade.rollback_1_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_type_cascade.rollback_1_of_7
@@ -1,0 +1,291 @@
+/* setup */
+SET experimental_enable_unique_without_index_constraints = true;
+CREATE TYPE greeting AS ENUM('hello', 'hi');
+CREATE VIEW view AS SELECT 'hi'::greeting::string AS c;
+CREATE TABLE tbl (
+  id INT PRIMARY KEY,
+  gs greeting AS ('hi'::greeting) STORED,
+  gv string AS ('hello'::greeting::STRING) VIRTUAL,
+  other greeting[],
+  name STRING NOT NULL DEFAULT 'noname',
+  CONSTRAINT mycheck CHECK (gs::STRING = name),
+  CONSTRAINT myuwi UNIQUE WITHOUT INDEX (name) WHERE ('hi'::greeting::STRING = 'hi'),
+  INDEX partial (name) WHERE (gs::STRING = 'hi')
+);
+
+/* test */
+DROP TYPE greeting CASCADE;
+EXPLAIN (ddl, verbose) rollback at post-commit stage 1 of 7;
+----
+• Schema change plan for rolling back DROP TYPE ‹defaultdb›.‹public›.‹greeting› CASCADE;
+│
+└── • PostCommitNonRevertiblePhase
+    │
+    └── • Stage 1 of 1 in PostCommitNonRevertiblePhase
+        │
+        ├── • 11 elements transitioning toward PUBLIC
+        │   │
+        │   ├── • Column:{DescID: 107, ColumnID: 2}
+        │   │   │ WRITE_ONLY → PUBLIC
+        │   │   │
+        │   │   ├── • PreviousStagePrecedence dependency from WRITE_ONLY Column:{DescID: 107, ColumnID: 2}
+        │   │   │     rule: "Column transitions to PUBLIC uphold 2-version invariant: WRITE_ONLY->PUBLIC"
+        │   │   │
+        │   │   ├── • Precedence dependency from PUBLIC ColumnName:{DescID: 107, Name: gs, ColumnID: 2}
+        │   │   │     rule: "column dependents exist before column becomes public"
+        │   │   │
+        │   │   ├── • Precedence dependency from PUBLIC ColumnType:{DescID: 107, ReferencedTypeIDs: [104 105], ColumnFamilyID: 0, ColumnID: 2}
+        │   │   │     rule: "column dependents exist before column becomes public"
+        │   │   │
+        │   │   └── • Precedence dependency from PUBLIC IndexColumn:{DescID: 107, ColumnID: 2, IndexID: 1}
+        │   │         rule: "column dependents exist before column becomes public"
+        │   │
+        │   ├── • ColumnName:{DescID: 107, Name: gs, ColumnID: 2}
+        │   │     ABSENT → PUBLIC
+        │   │
+        │   ├── • Column:{DescID: 107, ColumnID: 3}
+        │   │   │ WRITE_ONLY → PUBLIC
+        │   │   │
+        │   │   ├── • SameStagePrecedence dependency from PUBLIC Column:{DescID: 107, ColumnID: 2}
+        │   │   │     rule: "ensure columns are in increasing order"
+        │   │   │
+        │   │   ├── • PreviousStagePrecedence dependency from WRITE_ONLY Column:{DescID: 107, ColumnID: 3}
+        │   │   │     rule: "Column transitions to PUBLIC uphold 2-version invariant: WRITE_ONLY->PUBLIC"
+        │   │   │
+        │   │   ├── • Precedence dependency from PUBLIC ColumnName:{DescID: 107, Name: gv, ColumnID: 3}
+        │   │   │     rule: "column dependents exist before column becomes public"
+        │   │   │
+        │   │   └── • Precedence dependency from PUBLIC ColumnType:{DescID: 107, ReferencedTypeIDs: [104 105], ColumnFamilyID: 0, ColumnID: 3}
+        │   │         rule: "column dependents exist before column becomes public"
+        │   │
+        │   ├── • ColumnName:{DescID: 107, Name: gv, ColumnID: 3}
+        │   │     ABSENT → PUBLIC
+        │   │
+        │   ├── • Column:{DescID: 107, ColumnID: 4}
+        │   │   │ WRITE_ONLY → PUBLIC
+        │   │   │
+        │   │   ├── • SameStagePrecedence dependency from PUBLIC Column:{DescID: 107, ColumnID: 2}
+        │   │   │     rule: "ensure columns are in increasing order"
+        │   │   │
+        │   │   ├── • SameStagePrecedence dependency from PUBLIC Column:{DescID: 107, ColumnID: 3}
+        │   │   │     rule: "ensure columns are in increasing order"
+        │   │   │
+        │   │   ├── • PreviousStagePrecedence dependency from WRITE_ONLY Column:{DescID: 107, ColumnID: 4}
+        │   │   │     rule: "Column transitions to PUBLIC uphold 2-version invariant: WRITE_ONLY->PUBLIC"
+        │   │   │
+        │   │   ├── • Precedence dependency from PUBLIC ColumnName:{DescID: 107, Name: other, ColumnID: 4}
+        │   │   │     rule: "column dependents exist before column becomes public"
+        │   │   │
+        │   │   ├── • Precedence dependency from PUBLIC ColumnType:{DescID: 107, ReferencedTypeIDs: [104 105], ColumnFamilyID: 0, ColumnID: 4}
+        │   │   │     rule: "column dependents exist before column becomes public"
+        │   │   │
+        │   │   └── • Precedence dependency from PUBLIC IndexColumn:{DescID: 107, ColumnID: 4, IndexID: 1}
+        │   │         rule: "column dependents exist before column becomes public"
+        │   │
+        │   ├── • ColumnName:{DescID: 107, Name: other, ColumnID: 4}
+        │   │     ABSENT → PUBLIC
+        │   │
+        │   ├── • SecondaryIndex:{DescID: 107, IndexID: 2, ConstraintID: 0}
+        │   │   │ VALIDATED → PUBLIC
+        │   │   │
+        │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 107, ColumnID: 5, IndexID: 2}
+        │   │   │     rule: "index dependents exist before index becomes public"
+        │   │   │
+        │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 107, ColumnID: 1, IndexID: 2}
+        │   │   │     rule: "index dependents exist before index becomes public"
+        │   │   │
+        │   │   ├── • Precedence dependency from PUBLIC SecondaryIndexPartial:{DescID: 107, IndexID: 2}
+        │   │   │     rule: "index dependents exist before index becomes public"
+        │   │   │
+        │   │   ├── • PreviousStagePrecedence dependency from VALIDATED SecondaryIndex:{DescID: 107, IndexID: 2, ConstraintID: 0}
+        │   │   │     rule: "SecondaryIndex transitions to PUBLIC uphold 2-version invariant: VALIDATED->PUBLIC"
+        │   │   │
+        │   │   └── • Precedence dependency from PUBLIC IndexName:{DescID: 107, Name: partial, IndexID: 2}
+        │   │         rule: "index dependents exist before index becomes public"
+        │   │
+        │   ├── • UniqueWithoutIndexConstraint:{DescID: 107, ConstraintID: 3}
+        │   │   │ VALIDATED → PUBLIC
+        │   │   │
+        │   │   ├── • PreviousStagePrecedence dependency from VALIDATED UniqueWithoutIndexConstraint:{DescID: 107, ConstraintID: 3}
+        │   │   │     rule: "UniqueWithoutIndexConstraint transitions to PUBLIC uphold 2-version invariant: VALIDATED->PUBLIC"
+        │   │   │
+        │   │   └── • SameStagePrecedence dependency from PUBLIC ConstraintWithoutIndexName:{DescID: 107, Name: myuwi, ConstraintID: 3}
+        │   │         rule: "constraint dependent public right before constraint"
+        │   │
+        │   ├── • ConstraintWithoutIndexName:{DescID: 107, Name: myuwi, ConstraintID: 3}
+        │   │     ABSENT → PUBLIC
+        │   │
+        │   ├── • CheckConstraint:{DescID: 107, IndexID: 0, ConstraintID: 2}
+        │   │   │ VALIDATED → PUBLIC
+        │   │   │
+        │   │   ├── • PreviousStagePrecedence dependency from VALIDATED CheckConstraint:{DescID: 107, IndexID: 0, ConstraintID: 2}
+        │   │   │     rule: "CheckConstraint transitions to PUBLIC uphold 2-version invariant: VALIDATED->PUBLIC"
+        │   │   │
+        │   │   └── • SameStagePrecedence dependency from PUBLIC ConstraintWithoutIndexName:{DescID: 107, Name: mycheck, ConstraintID: 2}
+        │   │         rule: "constraint dependent public right before constraint"
+        │   │
+        │   └── • ConstraintWithoutIndexName:{DescID: 107, Name: mycheck, ConstraintID: 2}
+        │         ABSENT → PUBLIC
+        │
+        ├── • 7 elements transitioning toward ABSENT
+        │   │
+        │   ├── • PrimaryIndex:{DescID: 107, IndexID: 3, ConstraintID: 4, TemporaryIndexID: 4, SourceIndexID: 1}
+        │   │   │ BACKFILL_ONLY → ABSENT
+        │   │   │
+        │   │   ├── • PreviousStagePrecedence dependency from BACKFILL_ONLY PrimaryIndex:{DescID: 107, IndexID: 3, ConstraintID: 4, TemporaryIndexID: 4, SourceIndexID: 1}
+        │   │   │     rule: "PrimaryIndex transitions to ABSENT uphold 2-version invariant: BACKFILL_ONLY->DELETE_ONLY"
+        │   │   │
+        │   │   ├── • Precedence dependency from ABSENT IndexName:{DescID: 107, Name: tbl_pkey, IndexID: 3}
+        │   │   │     rule: "dependents removed before index"
+        │   │   │
+        │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 107, ColumnID: 1, IndexID: 3}
+        │   │   │     rule: "dependents removed before index"
+        │   │   │
+        │   │   └── • Precedence dependency from ABSENT IndexColumn:{DescID: 107, ColumnID: 5, IndexID: 3}
+        │   │         rule: "dependents removed before index"
+        │   │
+        │   ├── • IndexColumn:{DescID: 107, ColumnID: 1, IndexID: 3}
+        │   │   │ PUBLIC → ABSENT
+        │   │   │
+        │   │   └── • skip PUBLIC → ABSENT operations
+        │   │         rule: "skip index-column removal ops on index removal"
+        │   │
+        │   ├── • IndexColumn:{DescID: 107, ColumnID: 5, IndexID: 3}
+        │   │   │ PUBLIC → ABSENT
+        │   │   │
+        │   │   └── • skip PUBLIC → ABSENT operations
+        │   │         rule: "skip index-column removal ops on index removal"
+        │   │
+        │   ├── • IndexData:{DescID: 107, IndexID: 3}
+        │   │   │ PUBLIC → ABSENT
+        │   │   │
+        │   │   └── • Precedence dependency from ABSENT PrimaryIndex:{DescID: 107, IndexID: 3, ConstraintID: 4, TemporaryIndexID: 4, SourceIndexID: 1}
+        │   │         rule: "index removed before garbage collection"
+        │   │
+        │   ├── • TemporaryIndex:{DescID: 107, IndexID: 4, ConstraintID: 5, SourceIndexID: 1}
+        │   │   │ DELETE_ONLY → ABSENT
+        │   │   │
+        │   │   ├── • PreviousStagePrecedence dependency from DELETE_ONLY TemporaryIndex:{DescID: 107, IndexID: 4, ConstraintID: 5, SourceIndexID: 1}
+        │   │   │     rule: "TemporaryIndex transitions to ABSENT uphold 2-version invariant: DELETE_ONLY->ABSENT"
+        │   │   │
+        │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 107, ColumnID: 1, IndexID: 4}
+        │   │   │     rule: "dependents removed before index"
+        │   │   │
+        │   │   └── • Precedence dependency from ABSENT IndexColumn:{DescID: 107, ColumnID: 5, IndexID: 4}
+        │   │         rule: "dependents removed before index"
+        │   │
+        │   ├── • IndexColumn:{DescID: 107, ColumnID: 1, IndexID: 4}
+        │   │   │ PUBLIC → ABSENT
+        │   │   │
+        │   │   └── • skip PUBLIC → ABSENT operations
+        │   │         rule: "skip index-column removal ops on index removal"
+        │   │
+        │   └── • IndexColumn:{DescID: 107, ColumnID: 5, IndexID: 4}
+        │       │ PUBLIC → ABSENT
+        │       │
+        │       └── • skip PUBLIC → ABSENT operations
+        │             rule: "skip index-column removal ops on index removal"
+        │
+        └── • 23 Mutation operations
+            │
+            ├── • SetColumnName
+            │     ColumnID: 2
+            │     Name: gs
+            │     TableID: 107
+            │
+            ├── • SetColumnName
+            │     ColumnID: 3
+            │     Name: gv
+            │     TableID: 107
+            │
+            ├── • SetColumnName
+            │     ColumnID: 4
+            │     Name: other
+            │     TableID: 107
+            │
+            ├── • MakeValidatedSecondaryIndexPublic
+            │     IndexID: 2
+            │     TableID: 107
+            │
+            ├── • RefreshStats
+            │     TableID: 107
+            │
+            ├── • SetConstraintName
+            │     ConstraintID: 3
+            │     Name: myuwi
+            │     TableID: 107
+            │
+            ├── • SetConstraintName
+            │     ConstraintID: 2
+            │     Name: mycheck
+            │     TableID: 107
+            │
+            ├── • MakeWriteOnlyColumnPublic
+            │     ColumnID: 2
+            │     TableID: 107
+            │
+            ├── • RefreshStats
+            │     TableID: 107
+            │
+            ├── • MakeWriteOnlyColumnPublic
+            │     ColumnID: 3
+            │     TableID: 107
+            │
+            ├── • RefreshStats
+            │     TableID: 107
+            │
+            ├── • MakeWriteOnlyColumnPublic
+            │     ColumnID: 4
+            │     TableID: 107
+            │
+            ├── • RefreshStats
+            │     TableID: 107
+            │
+            ├── • MakeValidatedUniqueWithoutIndexConstraintPublic
+            │     ConstraintID: 3
+            │     TableID: 107
+            │
+            ├── • MakeValidatedCheckConstraintPublic
+            │     ConstraintID: 2
+            │     TableID: 107
+            │
+            ├── • MakeIndexAbsent
+            │     IndexID: 3
+            │     TableID: 107
+            │
+            ├── • CreateGCJobForIndex
+            │     IndexID: 3
+            │     StatementForDropJob:
+            │       Rollback: true
+            │       Statement: DROP TYPE defaultdb.public.greeting CASCADE
+            │     TableID: 107
+            │
+            ├── • MakeIndexAbsent
+            │     IndexID: 4
+            │     TableID: 107
+            │
+            ├── • RemoveJobStateFromDescriptor
+            │     DescriptorID: 104
+            │     JobID: 1
+            │
+            ├── • RemoveJobStateFromDescriptor
+            │     DescriptorID: 105
+            │     JobID: 1
+            │
+            ├── • RemoveJobStateFromDescriptor
+            │     DescriptorID: 106
+            │     JobID: 1
+            │
+            ├── • RemoveJobStateFromDescriptor
+            │     DescriptorID: 107
+            │     JobID: 1
+            │
+            └── • UpdateSchemaChangerJob
+                  DescriptorIDsToRemove:
+                  - 104
+                  - 105
+                  - 106
+                  - 107
+                  IsNonCancelable: true
+                  JobID: 1
+                  RunningStatus: all stages completed

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_type_cascade.rollback_2_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_type_cascade.rollback_2_of_7
@@ -1,0 +1,340 @@
+/* setup */
+SET experimental_enable_unique_without_index_constraints = true;
+CREATE TYPE greeting AS ENUM('hello', 'hi');
+CREATE VIEW view AS SELECT 'hi'::greeting::string AS c;
+CREATE TABLE tbl (
+  id INT PRIMARY KEY,
+  gs greeting AS ('hi'::greeting) STORED,
+  gv string AS ('hello'::greeting::STRING) VIRTUAL,
+  other greeting[],
+  name STRING NOT NULL DEFAULT 'noname',
+  CONSTRAINT mycheck CHECK (gs::STRING = name),
+  CONSTRAINT myuwi UNIQUE WITHOUT INDEX (name) WHERE ('hi'::greeting::STRING = 'hi'),
+  INDEX partial (name) WHERE (gs::STRING = 'hi')
+);
+
+/* test */
+DROP TYPE greeting CASCADE;
+EXPLAIN (ddl, verbose) rollback at post-commit stage 2 of 7;
+----
+• Schema change plan for rolling back DROP TYPE ‹defaultdb›.‹public›.‹greeting› CASCADE;
+│
+└── • PostCommitNonRevertiblePhase
+    │
+    ├── • Stage 1 of 2 in PostCommitNonRevertiblePhase
+    │   │
+    │   ├── • 11 elements transitioning toward PUBLIC
+    │   │   │
+    │   │   ├── • Column:{DescID: 107, ColumnID: 2}
+    │   │   │   │ WRITE_ONLY → PUBLIC
+    │   │   │   │
+    │   │   │   ├── • PreviousStagePrecedence dependency from WRITE_ONLY Column:{DescID: 107, ColumnID: 2}
+    │   │   │   │     rule: "Column transitions to PUBLIC uphold 2-version invariant: WRITE_ONLY->PUBLIC"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC ColumnName:{DescID: 107, Name: gs, ColumnID: 2}
+    │   │   │   │     rule: "column dependents exist before column becomes public"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC ColumnType:{DescID: 107, ReferencedTypeIDs: [104 105], ColumnFamilyID: 0, ColumnID: 2}
+    │   │   │   │     rule: "column dependents exist before column becomes public"
+    │   │   │   │
+    │   │   │   └── • Precedence dependency from PUBLIC IndexColumn:{DescID: 107, ColumnID: 2, IndexID: 1}
+    │   │   │         rule: "column dependents exist before column becomes public"
+    │   │   │
+    │   │   ├── • ColumnName:{DescID: 107, Name: gs, ColumnID: 2}
+    │   │   │     ABSENT → PUBLIC
+    │   │   │
+    │   │   ├── • Column:{DescID: 107, ColumnID: 3}
+    │   │   │   │ WRITE_ONLY → PUBLIC
+    │   │   │   │
+    │   │   │   ├── • SameStagePrecedence dependency from PUBLIC Column:{DescID: 107, ColumnID: 2}
+    │   │   │   │     rule: "ensure columns are in increasing order"
+    │   │   │   │
+    │   │   │   ├── • PreviousStagePrecedence dependency from WRITE_ONLY Column:{DescID: 107, ColumnID: 3}
+    │   │   │   │     rule: "Column transitions to PUBLIC uphold 2-version invariant: WRITE_ONLY->PUBLIC"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC ColumnName:{DescID: 107, Name: gv, ColumnID: 3}
+    │   │   │   │     rule: "column dependents exist before column becomes public"
+    │   │   │   │
+    │   │   │   └── • Precedence dependency from PUBLIC ColumnType:{DescID: 107, ReferencedTypeIDs: [104 105], ColumnFamilyID: 0, ColumnID: 3}
+    │   │   │         rule: "column dependents exist before column becomes public"
+    │   │   │
+    │   │   ├── • ColumnName:{DescID: 107, Name: gv, ColumnID: 3}
+    │   │   │     ABSENT → PUBLIC
+    │   │   │
+    │   │   ├── • Column:{DescID: 107, ColumnID: 4}
+    │   │   │   │ WRITE_ONLY → PUBLIC
+    │   │   │   │
+    │   │   │   ├── • SameStagePrecedence dependency from PUBLIC Column:{DescID: 107, ColumnID: 2}
+    │   │   │   │     rule: "ensure columns are in increasing order"
+    │   │   │   │
+    │   │   │   ├── • SameStagePrecedence dependency from PUBLIC Column:{DescID: 107, ColumnID: 3}
+    │   │   │   │     rule: "ensure columns are in increasing order"
+    │   │   │   │
+    │   │   │   ├── • PreviousStagePrecedence dependency from WRITE_ONLY Column:{DescID: 107, ColumnID: 4}
+    │   │   │   │     rule: "Column transitions to PUBLIC uphold 2-version invariant: WRITE_ONLY->PUBLIC"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC ColumnName:{DescID: 107, Name: other, ColumnID: 4}
+    │   │   │   │     rule: "column dependents exist before column becomes public"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC ColumnType:{DescID: 107, ReferencedTypeIDs: [104 105], ColumnFamilyID: 0, ColumnID: 4}
+    │   │   │   │     rule: "column dependents exist before column becomes public"
+    │   │   │   │
+    │   │   │   └── • Precedence dependency from PUBLIC IndexColumn:{DescID: 107, ColumnID: 4, IndexID: 1}
+    │   │   │         rule: "column dependents exist before column becomes public"
+    │   │   │
+    │   │   ├── • ColumnName:{DescID: 107, Name: other, ColumnID: 4}
+    │   │   │     ABSENT → PUBLIC
+    │   │   │
+    │   │   ├── • SecondaryIndex:{DescID: 107, IndexID: 2, ConstraintID: 0}
+    │   │   │   │ VALIDATED → PUBLIC
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 107, ColumnID: 5, IndexID: 2}
+    │   │   │   │     rule: "index dependents exist before index becomes public"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 107, ColumnID: 1, IndexID: 2}
+    │   │   │   │     rule: "index dependents exist before index becomes public"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC SecondaryIndexPartial:{DescID: 107, IndexID: 2}
+    │   │   │   │     rule: "index dependents exist before index becomes public"
+    │   │   │   │
+    │   │   │   ├── • PreviousStagePrecedence dependency from VALIDATED SecondaryIndex:{DescID: 107, IndexID: 2, ConstraintID: 0}
+    │   │   │   │     rule: "SecondaryIndex transitions to PUBLIC uphold 2-version invariant: VALIDATED->PUBLIC"
+    │   │   │   │
+    │   │   │   └── • Precedence dependency from PUBLIC IndexName:{DescID: 107, Name: partial, IndexID: 2}
+    │   │   │         rule: "index dependents exist before index becomes public"
+    │   │   │
+    │   │   ├── • UniqueWithoutIndexConstraint:{DescID: 107, ConstraintID: 3}
+    │   │   │   │ VALIDATED → PUBLIC
+    │   │   │   │
+    │   │   │   ├── • PreviousStagePrecedence dependency from VALIDATED UniqueWithoutIndexConstraint:{DescID: 107, ConstraintID: 3}
+    │   │   │   │     rule: "UniqueWithoutIndexConstraint transitions to PUBLIC uphold 2-version invariant: VALIDATED->PUBLIC"
+    │   │   │   │
+    │   │   │   └── • SameStagePrecedence dependency from PUBLIC ConstraintWithoutIndexName:{DescID: 107, Name: myuwi, ConstraintID: 3}
+    │   │   │         rule: "constraint dependent public right before constraint"
+    │   │   │
+    │   │   ├── • ConstraintWithoutIndexName:{DescID: 107, Name: myuwi, ConstraintID: 3}
+    │   │   │     ABSENT → PUBLIC
+    │   │   │
+    │   │   ├── • CheckConstraint:{DescID: 107, IndexID: 0, ConstraintID: 2}
+    │   │   │   │ VALIDATED → PUBLIC
+    │   │   │   │
+    │   │   │   ├── • PreviousStagePrecedence dependency from VALIDATED CheckConstraint:{DescID: 107, IndexID: 0, ConstraintID: 2}
+    │   │   │   │     rule: "CheckConstraint transitions to PUBLIC uphold 2-version invariant: VALIDATED->PUBLIC"
+    │   │   │   │
+    │   │   │   └── • SameStagePrecedence dependency from PUBLIC ConstraintWithoutIndexName:{DescID: 107, Name: mycheck, ConstraintID: 2}
+    │   │   │         rule: "constraint dependent public right before constraint"
+    │   │   │
+    │   │   └── • ConstraintWithoutIndexName:{DescID: 107, Name: mycheck, ConstraintID: 2}
+    │   │         ABSENT → PUBLIC
+    │   │
+    │   ├── • 6 elements transitioning toward ABSENT
+    │   │   │
+    │   │   ├── • PrimaryIndex:{DescID: 107, IndexID: 3, ConstraintID: 4, TemporaryIndexID: 4, SourceIndexID: 1}
+    │   │   │   │ BACKFILL_ONLY → ABSENT
+    │   │   │   │
+    │   │   │   ├── • PreviousStagePrecedence dependency from BACKFILL_ONLY PrimaryIndex:{DescID: 107, IndexID: 3, ConstraintID: 4, TemporaryIndexID: 4, SourceIndexID: 1}
+    │   │   │   │     rule: "PrimaryIndex transitions to ABSENT uphold 2-version invariant: BACKFILL_ONLY->DELETE_ONLY"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from ABSENT IndexName:{DescID: 107, Name: tbl_pkey, IndexID: 3}
+    │   │   │   │     rule: "dependents removed before index"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 107, ColumnID: 1, IndexID: 3}
+    │   │   │   │     rule: "dependents removed before index"
+    │   │   │   │
+    │   │   │   └── • Precedence dependency from ABSENT IndexColumn:{DescID: 107, ColumnID: 5, IndexID: 3}
+    │   │   │         rule: "dependents removed before index"
+    │   │   │
+    │   │   ├── • IndexColumn:{DescID: 107, ColumnID: 1, IndexID: 3}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   └── • skip PUBLIC → ABSENT operations
+    │   │   │         rule: "skip index-column removal ops on index removal"
+    │   │   │
+    │   │   ├── • IndexColumn:{DescID: 107, ColumnID: 5, IndexID: 3}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   └── • skip PUBLIC → ABSENT operations
+    │   │   │         rule: "skip index-column removal ops on index removal"
+    │   │   │
+    │   │   ├── • TemporaryIndex:{DescID: 107, IndexID: 4, ConstraintID: 5, SourceIndexID: 1}
+    │   │   │   │ WRITE_ONLY → DELETE_ONLY
+    │   │   │   │
+    │   │   │   └── • PreviousStagePrecedence dependency from WRITE_ONLY TemporaryIndex:{DescID: 107, IndexID: 4, ConstraintID: 5, SourceIndexID: 1}
+    │   │   │         rule: "TemporaryIndex transitions to ABSENT uphold 2-version invariant: WRITE_ONLY->DELETE_ONLY"
+    │   │   │
+    │   │   ├── • IndexColumn:{DescID: 107, ColumnID: 1, IndexID: 4}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   └── • skip PUBLIC → ABSENT operations
+    │   │   │         rule: "skip index-column removal ops on index removal"
+    │   │   │
+    │   │   └── • IndexColumn:{DescID: 107, ColumnID: 5, IndexID: 4}
+    │   │       │ PUBLIC → ABSENT
+    │   │       │
+    │   │       └── • skip PUBLIC → ABSENT operations
+    │   │             rule: "skip index-column removal ops on index removal"
+    │   │
+    │   └── • 22 Mutation operations
+    │       │
+    │       ├── • SetColumnName
+    │       │     ColumnID: 2
+    │       │     Name: gs
+    │       │     TableID: 107
+    │       │
+    │       ├── • SetColumnName
+    │       │     ColumnID: 3
+    │       │     Name: gv
+    │       │     TableID: 107
+    │       │
+    │       ├── • SetColumnName
+    │       │     ColumnID: 4
+    │       │     Name: other
+    │       │     TableID: 107
+    │       │
+    │       ├── • MakeValidatedSecondaryIndexPublic
+    │       │     IndexID: 2
+    │       │     TableID: 107
+    │       │
+    │       ├── • RefreshStats
+    │       │     TableID: 107
+    │       │
+    │       ├── • SetConstraintName
+    │       │     ConstraintID: 3
+    │       │     Name: myuwi
+    │       │     TableID: 107
+    │       │
+    │       ├── • SetConstraintName
+    │       │     ConstraintID: 2
+    │       │     Name: mycheck
+    │       │     TableID: 107
+    │       │
+    │       ├── • MakeWriteOnlyIndexDeleteOnly
+    │       │     IndexID: 4
+    │       │     TableID: 107
+    │       │
+    │       ├── • MakeWriteOnlyColumnPublic
+    │       │     ColumnID: 2
+    │       │     TableID: 107
+    │       │
+    │       ├── • RefreshStats
+    │       │     TableID: 107
+    │       │
+    │       ├── • MakeWriteOnlyColumnPublic
+    │       │     ColumnID: 3
+    │       │     TableID: 107
+    │       │
+    │       ├── • RefreshStats
+    │       │     TableID: 107
+    │       │
+    │       ├── • MakeWriteOnlyColumnPublic
+    │       │     ColumnID: 4
+    │       │     TableID: 107
+    │       │
+    │       ├── • RefreshStats
+    │       │     TableID: 107
+    │       │
+    │       ├── • MakeValidatedUniqueWithoutIndexConstraintPublic
+    │       │     ConstraintID: 3
+    │       │     TableID: 107
+    │       │
+    │       ├── • MakeValidatedCheckConstraintPublic
+    │       │     ConstraintID: 2
+    │       │     TableID: 107
+    │       │
+    │       ├── • MakeIndexAbsent
+    │       │     IndexID: 3
+    │       │     TableID: 107
+    │       │
+    │       ├── • SetJobStateOnDescriptor
+    │       │     DescriptorID: 104
+    │       │
+    │       ├── • SetJobStateOnDescriptor
+    │       │     DescriptorID: 105
+    │       │
+    │       ├── • SetJobStateOnDescriptor
+    │       │     DescriptorID: 106
+    │       │
+    │       ├── • SetJobStateOnDescriptor
+    │       │     DescriptorID: 107
+    │       │
+    │       └── • UpdateSchemaChangerJob
+    │             IsNonCancelable: true
+    │             JobID: 1
+    │             RunningStatus: PostCommitNonRevertiblePhase stage 2 of 2 with 3 MutationType ops pending
+    │
+    └── • Stage 2 of 2 in PostCommitNonRevertiblePhase
+        │
+        ├── • 3 elements transitioning toward ABSENT
+        │   │
+        │   ├── • IndexData:{DescID: 107, IndexID: 3}
+        │   │   │ PUBLIC → ABSENT
+        │   │   │
+        │   │   └── • Precedence dependency from ABSENT PrimaryIndex:{DescID: 107, IndexID: 3, ConstraintID: 4, TemporaryIndexID: 4, SourceIndexID: 1}
+        │   │         rule: "index removed before garbage collection"
+        │   │
+        │   ├── • TemporaryIndex:{DescID: 107, IndexID: 4, ConstraintID: 5, SourceIndexID: 1}
+        │   │   │ DELETE_ONLY → ABSENT
+        │   │   │
+        │   │   ├── • PreviousStagePrecedence dependency from DELETE_ONLY TemporaryIndex:{DescID: 107, IndexID: 4, ConstraintID: 5, SourceIndexID: 1}
+        │   │   │     rule: "TemporaryIndex transitions to ABSENT uphold 2-version invariant: DELETE_ONLY->ABSENT"
+        │   │   │
+        │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 107, ColumnID: 1, IndexID: 4}
+        │   │   │     rule: "dependents removed before index"
+        │   │   │
+        │   │   └── • Precedence dependency from ABSENT IndexColumn:{DescID: 107, ColumnID: 5, IndexID: 4}
+        │   │         rule: "dependents removed before index"
+        │   │
+        │   └── • IndexData:{DescID: 107, IndexID: 4}
+        │       │ PUBLIC → ABSENT
+        │       │
+        │       ├── • SameStagePrecedence dependency from DROPPED IndexData:{DescID: 107, IndexID: 3}
+        │       │     rule: "schedule all GC jobs for a descriptor in the same stage"
+        │       │
+        │       └── • Precedence dependency from ABSENT TemporaryIndex:{DescID: 107, IndexID: 4, ConstraintID: 5, SourceIndexID: 1}
+        │             rule: "index removed before garbage collection"
+        │
+        └── • 8 Mutation operations
+            │
+            ├── • CreateGCJobForIndex
+            │     IndexID: 3
+            │     StatementForDropJob:
+            │       Rollback: true
+            │       Statement: DROP TYPE defaultdb.public.greeting CASCADE
+            │     TableID: 107
+            │
+            ├── • MakeIndexAbsent
+            │     IndexID: 4
+            │     TableID: 107
+            │
+            ├── • CreateGCJobForIndex
+            │     IndexID: 4
+            │     StatementForDropJob:
+            │       Rollback: true
+            │       Statement: DROP TYPE defaultdb.public.greeting CASCADE
+            │     TableID: 107
+            │
+            ├── • RemoveJobStateFromDescriptor
+            │     DescriptorID: 104
+            │     JobID: 1
+            │
+            ├── • RemoveJobStateFromDescriptor
+            │     DescriptorID: 105
+            │     JobID: 1
+            │
+            ├── • RemoveJobStateFromDescriptor
+            │     DescriptorID: 106
+            │     JobID: 1
+            │
+            ├── • RemoveJobStateFromDescriptor
+            │     DescriptorID: 107
+            │     JobID: 1
+            │
+            └── • UpdateSchemaChangerJob
+                  DescriptorIDsToRemove:
+                  - 104
+                  - 105
+                  - 106
+                  - 107
+                  IsNonCancelable: true
+                  JobID: 1
+                  RunningStatus: all stages completed

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_type_cascade.rollback_3_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_type_cascade.rollback_3_of_7
@@ -1,0 +1,340 @@
+/* setup */
+SET experimental_enable_unique_without_index_constraints = true;
+CREATE TYPE greeting AS ENUM('hello', 'hi');
+CREATE VIEW view AS SELECT 'hi'::greeting::string AS c;
+CREATE TABLE tbl (
+  id INT PRIMARY KEY,
+  gs greeting AS ('hi'::greeting) STORED,
+  gv string AS ('hello'::greeting::STRING) VIRTUAL,
+  other greeting[],
+  name STRING NOT NULL DEFAULT 'noname',
+  CONSTRAINT mycheck CHECK (gs::STRING = name),
+  CONSTRAINT myuwi UNIQUE WITHOUT INDEX (name) WHERE ('hi'::greeting::STRING = 'hi'),
+  INDEX partial (name) WHERE (gs::STRING = 'hi')
+);
+
+/* test */
+DROP TYPE greeting CASCADE;
+EXPLAIN (ddl, verbose) rollback at post-commit stage 3 of 7;
+----
+• Schema change plan for rolling back DROP TYPE ‹defaultdb›.‹public›.‹greeting› CASCADE;
+│
+└── • PostCommitNonRevertiblePhase
+    │
+    ├── • Stage 1 of 2 in PostCommitNonRevertiblePhase
+    │   │
+    │   ├── • 11 elements transitioning toward PUBLIC
+    │   │   │
+    │   │   ├── • Column:{DescID: 107, ColumnID: 2}
+    │   │   │   │ WRITE_ONLY → PUBLIC
+    │   │   │   │
+    │   │   │   ├── • PreviousStagePrecedence dependency from WRITE_ONLY Column:{DescID: 107, ColumnID: 2}
+    │   │   │   │     rule: "Column transitions to PUBLIC uphold 2-version invariant: WRITE_ONLY->PUBLIC"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC ColumnName:{DescID: 107, Name: gs, ColumnID: 2}
+    │   │   │   │     rule: "column dependents exist before column becomes public"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC ColumnType:{DescID: 107, ReferencedTypeIDs: [104 105], ColumnFamilyID: 0, ColumnID: 2}
+    │   │   │   │     rule: "column dependents exist before column becomes public"
+    │   │   │   │
+    │   │   │   └── • Precedence dependency from PUBLIC IndexColumn:{DescID: 107, ColumnID: 2, IndexID: 1}
+    │   │   │         rule: "column dependents exist before column becomes public"
+    │   │   │
+    │   │   ├── • ColumnName:{DescID: 107, Name: gs, ColumnID: 2}
+    │   │   │     ABSENT → PUBLIC
+    │   │   │
+    │   │   ├── • Column:{DescID: 107, ColumnID: 3}
+    │   │   │   │ WRITE_ONLY → PUBLIC
+    │   │   │   │
+    │   │   │   ├── • SameStagePrecedence dependency from PUBLIC Column:{DescID: 107, ColumnID: 2}
+    │   │   │   │     rule: "ensure columns are in increasing order"
+    │   │   │   │
+    │   │   │   ├── • PreviousStagePrecedence dependency from WRITE_ONLY Column:{DescID: 107, ColumnID: 3}
+    │   │   │   │     rule: "Column transitions to PUBLIC uphold 2-version invariant: WRITE_ONLY->PUBLIC"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC ColumnName:{DescID: 107, Name: gv, ColumnID: 3}
+    │   │   │   │     rule: "column dependents exist before column becomes public"
+    │   │   │   │
+    │   │   │   └── • Precedence dependency from PUBLIC ColumnType:{DescID: 107, ReferencedTypeIDs: [104 105], ColumnFamilyID: 0, ColumnID: 3}
+    │   │   │         rule: "column dependents exist before column becomes public"
+    │   │   │
+    │   │   ├── • ColumnName:{DescID: 107, Name: gv, ColumnID: 3}
+    │   │   │     ABSENT → PUBLIC
+    │   │   │
+    │   │   ├── • Column:{DescID: 107, ColumnID: 4}
+    │   │   │   │ WRITE_ONLY → PUBLIC
+    │   │   │   │
+    │   │   │   ├── • SameStagePrecedence dependency from PUBLIC Column:{DescID: 107, ColumnID: 2}
+    │   │   │   │     rule: "ensure columns are in increasing order"
+    │   │   │   │
+    │   │   │   ├── • SameStagePrecedence dependency from PUBLIC Column:{DescID: 107, ColumnID: 3}
+    │   │   │   │     rule: "ensure columns are in increasing order"
+    │   │   │   │
+    │   │   │   ├── • PreviousStagePrecedence dependency from WRITE_ONLY Column:{DescID: 107, ColumnID: 4}
+    │   │   │   │     rule: "Column transitions to PUBLIC uphold 2-version invariant: WRITE_ONLY->PUBLIC"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC ColumnName:{DescID: 107, Name: other, ColumnID: 4}
+    │   │   │   │     rule: "column dependents exist before column becomes public"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC ColumnType:{DescID: 107, ReferencedTypeIDs: [104 105], ColumnFamilyID: 0, ColumnID: 4}
+    │   │   │   │     rule: "column dependents exist before column becomes public"
+    │   │   │   │
+    │   │   │   └── • Precedence dependency from PUBLIC IndexColumn:{DescID: 107, ColumnID: 4, IndexID: 1}
+    │   │   │         rule: "column dependents exist before column becomes public"
+    │   │   │
+    │   │   ├── • ColumnName:{DescID: 107, Name: other, ColumnID: 4}
+    │   │   │     ABSENT → PUBLIC
+    │   │   │
+    │   │   ├── • SecondaryIndex:{DescID: 107, IndexID: 2, ConstraintID: 0}
+    │   │   │   │ VALIDATED → PUBLIC
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 107, ColumnID: 5, IndexID: 2}
+    │   │   │   │     rule: "index dependents exist before index becomes public"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 107, ColumnID: 1, IndexID: 2}
+    │   │   │   │     rule: "index dependents exist before index becomes public"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC SecondaryIndexPartial:{DescID: 107, IndexID: 2}
+    │   │   │   │     rule: "index dependents exist before index becomes public"
+    │   │   │   │
+    │   │   │   ├── • PreviousStagePrecedence dependency from VALIDATED SecondaryIndex:{DescID: 107, IndexID: 2, ConstraintID: 0}
+    │   │   │   │     rule: "SecondaryIndex transitions to PUBLIC uphold 2-version invariant: VALIDATED->PUBLIC"
+    │   │   │   │
+    │   │   │   └── • Precedence dependency from PUBLIC IndexName:{DescID: 107, Name: partial, IndexID: 2}
+    │   │   │         rule: "index dependents exist before index becomes public"
+    │   │   │
+    │   │   ├── • UniqueWithoutIndexConstraint:{DescID: 107, ConstraintID: 3}
+    │   │   │   │ VALIDATED → PUBLIC
+    │   │   │   │
+    │   │   │   ├── • PreviousStagePrecedence dependency from VALIDATED UniqueWithoutIndexConstraint:{DescID: 107, ConstraintID: 3}
+    │   │   │   │     rule: "UniqueWithoutIndexConstraint transitions to PUBLIC uphold 2-version invariant: VALIDATED->PUBLIC"
+    │   │   │   │
+    │   │   │   └── • SameStagePrecedence dependency from PUBLIC ConstraintWithoutIndexName:{DescID: 107, Name: myuwi, ConstraintID: 3}
+    │   │   │         rule: "constraint dependent public right before constraint"
+    │   │   │
+    │   │   ├── • ConstraintWithoutIndexName:{DescID: 107, Name: myuwi, ConstraintID: 3}
+    │   │   │     ABSENT → PUBLIC
+    │   │   │
+    │   │   ├── • CheckConstraint:{DescID: 107, IndexID: 0, ConstraintID: 2}
+    │   │   │   │ VALIDATED → PUBLIC
+    │   │   │   │
+    │   │   │   ├── • PreviousStagePrecedence dependency from VALIDATED CheckConstraint:{DescID: 107, IndexID: 0, ConstraintID: 2}
+    │   │   │   │     rule: "CheckConstraint transitions to PUBLIC uphold 2-version invariant: VALIDATED->PUBLIC"
+    │   │   │   │
+    │   │   │   └── • SameStagePrecedence dependency from PUBLIC ConstraintWithoutIndexName:{DescID: 107, Name: mycheck, ConstraintID: 2}
+    │   │   │         rule: "constraint dependent public right before constraint"
+    │   │   │
+    │   │   └── • ConstraintWithoutIndexName:{DescID: 107, Name: mycheck, ConstraintID: 2}
+    │   │         ABSENT → PUBLIC
+    │   │
+    │   ├── • 6 elements transitioning toward ABSENT
+    │   │   │
+    │   │   ├── • PrimaryIndex:{DescID: 107, IndexID: 3, ConstraintID: 4, TemporaryIndexID: 4, SourceIndexID: 1}
+    │   │   │   │ BACKFILL_ONLY → ABSENT
+    │   │   │   │
+    │   │   │   ├── • PreviousStagePrecedence dependency from BACKFILL_ONLY PrimaryIndex:{DescID: 107, IndexID: 3, ConstraintID: 4, TemporaryIndexID: 4, SourceIndexID: 1}
+    │   │   │   │     rule: "PrimaryIndex transitions to ABSENT uphold 2-version invariant: BACKFILL_ONLY->DELETE_ONLY"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from ABSENT IndexName:{DescID: 107, Name: tbl_pkey, IndexID: 3}
+    │   │   │   │     rule: "dependents removed before index"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 107, ColumnID: 1, IndexID: 3}
+    │   │   │   │     rule: "dependents removed before index"
+    │   │   │   │
+    │   │   │   └── • Precedence dependency from ABSENT IndexColumn:{DescID: 107, ColumnID: 5, IndexID: 3}
+    │   │   │         rule: "dependents removed before index"
+    │   │   │
+    │   │   ├── • IndexColumn:{DescID: 107, ColumnID: 1, IndexID: 3}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   └── • skip PUBLIC → ABSENT operations
+    │   │   │         rule: "skip index-column removal ops on index removal"
+    │   │   │
+    │   │   ├── • IndexColumn:{DescID: 107, ColumnID: 5, IndexID: 3}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   └── • skip PUBLIC → ABSENT operations
+    │   │   │         rule: "skip index-column removal ops on index removal"
+    │   │   │
+    │   │   ├── • TemporaryIndex:{DescID: 107, IndexID: 4, ConstraintID: 5, SourceIndexID: 1}
+    │   │   │   │ WRITE_ONLY → DELETE_ONLY
+    │   │   │   │
+    │   │   │   └── • PreviousStagePrecedence dependency from WRITE_ONLY TemporaryIndex:{DescID: 107, IndexID: 4, ConstraintID: 5, SourceIndexID: 1}
+    │   │   │         rule: "TemporaryIndex transitions to ABSENT uphold 2-version invariant: WRITE_ONLY->DELETE_ONLY"
+    │   │   │
+    │   │   ├── • IndexColumn:{DescID: 107, ColumnID: 1, IndexID: 4}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   └── • skip PUBLIC → ABSENT operations
+    │   │   │         rule: "skip index-column removal ops on index removal"
+    │   │   │
+    │   │   └── • IndexColumn:{DescID: 107, ColumnID: 5, IndexID: 4}
+    │   │       │ PUBLIC → ABSENT
+    │   │       │
+    │   │       └── • skip PUBLIC → ABSENT operations
+    │   │             rule: "skip index-column removal ops on index removal"
+    │   │
+    │   └── • 22 Mutation operations
+    │       │
+    │       ├── • SetColumnName
+    │       │     ColumnID: 2
+    │       │     Name: gs
+    │       │     TableID: 107
+    │       │
+    │       ├── • SetColumnName
+    │       │     ColumnID: 3
+    │       │     Name: gv
+    │       │     TableID: 107
+    │       │
+    │       ├── • SetColumnName
+    │       │     ColumnID: 4
+    │       │     Name: other
+    │       │     TableID: 107
+    │       │
+    │       ├── • MakeValidatedSecondaryIndexPublic
+    │       │     IndexID: 2
+    │       │     TableID: 107
+    │       │
+    │       ├── • RefreshStats
+    │       │     TableID: 107
+    │       │
+    │       ├── • SetConstraintName
+    │       │     ConstraintID: 3
+    │       │     Name: myuwi
+    │       │     TableID: 107
+    │       │
+    │       ├── • SetConstraintName
+    │       │     ConstraintID: 2
+    │       │     Name: mycheck
+    │       │     TableID: 107
+    │       │
+    │       ├── • MakeWriteOnlyIndexDeleteOnly
+    │       │     IndexID: 4
+    │       │     TableID: 107
+    │       │
+    │       ├── • MakeWriteOnlyColumnPublic
+    │       │     ColumnID: 2
+    │       │     TableID: 107
+    │       │
+    │       ├── • RefreshStats
+    │       │     TableID: 107
+    │       │
+    │       ├── • MakeWriteOnlyColumnPublic
+    │       │     ColumnID: 3
+    │       │     TableID: 107
+    │       │
+    │       ├── • RefreshStats
+    │       │     TableID: 107
+    │       │
+    │       ├── • MakeWriteOnlyColumnPublic
+    │       │     ColumnID: 4
+    │       │     TableID: 107
+    │       │
+    │       ├── • RefreshStats
+    │       │     TableID: 107
+    │       │
+    │       ├── • MakeValidatedUniqueWithoutIndexConstraintPublic
+    │       │     ConstraintID: 3
+    │       │     TableID: 107
+    │       │
+    │       ├── • MakeValidatedCheckConstraintPublic
+    │       │     ConstraintID: 2
+    │       │     TableID: 107
+    │       │
+    │       ├── • MakeIndexAbsent
+    │       │     IndexID: 3
+    │       │     TableID: 107
+    │       │
+    │       ├── • SetJobStateOnDescriptor
+    │       │     DescriptorID: 104
+    │       │
+    │       ├── • SetJobStateOnDescriptor
+    │       │     DescriptorID: 105
+    │       │
+    │       ├── • SetJobStateOnDescriptor
+    │       │     DescriptorID: 106
+    │       │
+    │       ├── • SetJobStateOnDescriptor
+    │       │     DescriptorID: 107
+    │       │
+    │       └── • UpdateSchemaChangerJob
+    │             IsNonCancelable: true
+    │             JobID: 1
+    │             RunningStatus: PostCommitNonRevertiblePhase stage 2 of 2 with 3 MutationType ops pending
+    │
+    └── • Stage 2 of 2 in PostCommitNonRevertiblePhase
+        │
+        ├── • 3 elements transitioning toward ABSENT
+        │   │
+        │   ├── • IndexData:{DescID: 107, IndexID: 3}
+        │   │   │ PUBLIC → ABSENT
+        │   │   │
+        │   │   └── • Precedence dependency from ABSENT PrimaryIndex:{DescID: 107, IndexID: 3, ConstraintID: 4, TemporaryIndexID: 4, SourceIndexID: 1}
+        │   │         rule: "index removed before garbage collection"
+        │   │
+        │   ├── • TemporaryIndex:{DescID: 107, IndexID: 4, ConstraintID: 5, SourceIndexID: 1}
+        │   │   │ DELETE_ONLY → ABSENT
+        │   │   │
+        │   │   ├── • PreviousStagePrecedence dependency from DELETE_ONLY TemporaryIndex:{DescID: 107, IndexID: 4, ConstraintID: 5, SourceIndexID: 1}
+        │   │   │     rule: "TemporaryIndex transitions to ABSENT uphold 2-version invariant: DELETE_ONLY->ABSENT"
+        │   │   │
+        │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 107, ColumnID: 1, IndexID: 4}
+        │   │   │     rule: "dependents removed before index"
+        │   │   │
+        │   │   └── • Precedence dependency from ABSENT IndexColumn:{DescID: 107, ColumnID: 5, IndexID: 4}
+        │   │         rule: "dependents removed before index"
+        │   │
+        │   └── • IndexData:{DescID: 107, IndexID: 4}
+        │       │ PUBLIC → ABSENT
+        │       │
+        │       ├── • SameStagePrecedence dependency from DROPPED IndexData:{DescID: 107, IndexID: 3}
+        │       │     rule: "schedule all GC jobs for a descriptor in the same stage"
+        │       │
+        │       └── • Precedence dependency from ABSENT TemporaryIndex:{DescID: 107, IndexID: 4, ConstraintID: 5, SourceIndexID: 1}
+        │             rule: "index removed before garbage collection"
+        │
+        └── • 8 Mutation operations
+            │
+            ├── • CreateGCJobForIndex
+            │     IndexID: 3
+            │     StatementForDropJob:
+            │       Rollback: true
+            │       Statement: DROP TYPE defaultdb.public.greeting CASCADE
+            │     TableID: 107
+            │
+            ├── • MakeIndexAbsent
+            │     IndexID: 4
+            │     TableID: 107
+            │
+            ├── • CreateGCJobForIndex
+            │     IndexID: 4
+            │     StatementForDropJob:
+            │       Rollback: true
+            │       Statement: DROP TYPE defaultdb.public.greeting CASCADE
+            │     TableID: 107
+            │
+            ├── • RemoveJobStateFromDescriptor
+            │     DescriptorID: 104
+            │     JobID: 1
+            │
+            ├── • RemoveJobStateFromDescriptor
+            │     DescriptorID: 105
+            │     JobID: 1
+            │
+            ├── • RemoveJobStateFromDescriptor
+            │     DescriptorID: 106
+            │     JobID: 1
+            │
+            ├── • RemoveJobStateFromDescriptor
+            │     DescriptorID: 107
+            │     JobID: 1
+            │
+            └── • UpdateSchemaChangerJob
+                  DescriptorIDsToRemove:
+                  - 104
+                  - 105
+                  - 106
+                  - 107
+                  IsNonCancelable: true
+                  JobID: 1
+                  RunningStatus: all stages completed

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_type_cascade.rollback_4_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_type_cascade.rollback_4_of_7
@@ -1,0 +1,340 @@
+/* setup */
+SET experimental_enable_unique_without_index_constraints = true;
+CREATE TYPE greeting AS ENUM('hello', 'hi');
+CREATE VIEW view AS SELECT 'hi'::greeting::string AS c;
+CREATE TABLE tbl (
+  id INT PRIMARY KEY,
+  gs greeting AS ('hi'::greeting) STORED,
+  gv string AS ('hello'::greeting::STRING) VIRTUAL,
+  other greeting[],
+  name STRING NOT NULL DEFAULT 'noname',
+  CONSTRAINT mycheck CHECK (gs::STRING = name),
+  CONSTRAINT myuwi UNIQUE WITHOUT INDEX (name) WHERE ('hi'::greeting::STRING = 'hi'),
+  INDEX partial (name) WHERE (gs::STRING = 'hi')
+);
+
+/* test */
+DROP TYPE greeting CASCADE;
+EXPLAIN (ddl, verbose) rollback at post-commit stage 4 of 7;
+----
+• Schema change plan for rolling back DROP TYPE ‹defaultdb›.‹public›.‹greeting› CASCADE;
+│
+└── • PostCommitNonRevertiblePhase
+    │
+    ├── • Stage 1 of 2 in PostCommitNonRevertiblePhase
+    │   │
+    │   ├── • 11 elements transitioning toward PUBLIC
+    │   │   │
+    │   │   ├── • Column:{DescID: 107, ColumnID: 2}
+    │   │   │   │ WRITE_ONLY → PUBLIC
+    │   │   │   │
+    │   │   │   ├── • PreviousStagePrecedence dependency from WRITE_ONLY Column:{DescID: 107, ColumnID: 2}
+    │   │   │   │     rule: "Column transitions to PUBLIC uphold 2-version invariant: WRITE_ONLY->PUBLIC"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC ColumnName:{DescID: 107, Name: gs, ColumnID: 2}
+    │   │   │   │     rule: "column dependents exist before column becomes public"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC ColumnType:{DescID: 107, ReferencedTypeIDs: [104 105], ColumnFamilyID: 0, ColumnID: 2}
+    │   │   │   │     rule: "column dependents exist before column becomes public"
+    │   │   │   │
+    │   │   │   └── • Precedence dependency from PUBLIC IndexColumn:{DescID: 107, ColumnID: 2, IndexID: 1}
+    │   │   │         rule: "column dependents exist before column becomes public"
+    │   │   │
+    │   │   ├── • ColumnName:{DescID: 107, Name: gs, ColumnID: 2}
+    │   │   │     ABSENT → PUBLIC
+    │   │   │
+    │   │   ├── • Column:{DescID: 107, ColumnID: 3}
+    │   │   │   │ WRITE_ONLY → PUBLIC
+    │   │   │   │
+    │   │   │   ├── • SameStagePrecedence dependency from PUBLIC Column:{DescID: 107, ColumnID: 2}
+    │   │   │   │     rule: "ensure columns are in increasing order"
+    │   │   │   │
+    │   │   │   ├── • PreviousStagePrecedence dependency from WRITE_ONLY Column:{DescID: 107, ColumnID: 3}
+    │   │   │   │     rule: "Column transitions to PUBLIC uphold 2-version invariant: WRITE_ONLY->PUBLIC"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC ColumnName:{DescID: 107, Name: gv, ColumnID: 3}
+    │   │   │   │     rule: "column dependents exist before column becomes public"
+    │   │   │   │
+    │   │   │   └── • Precedence dependency from PUBLIC ColumnType:{DescID: 107, ReferencedTypeIDs: [104 105], ColumnFamilyID: 0, ColumnID: 3}
+    │   │   │         rule: "column dependents exist before column becomes public"
+    │   │   │
+    │   │   ├── • ColumnName:{DescID: 107, Name: gv, ColumnID: 3}
+    │   │   │     ABSENT → PUBLIC
+    │   │   │
+    │   │   ├── • Column:{DescID: 107, ColumnID: 4}
+    │   │   │   │ WRITE_ONLY → PUBLIC
+    │   │   │   │
+    │   │   │   ├── • SameStagePrecedence dependency from PUBLIC Column:{DescID: 107, ColumnID: 2}
+    │   │   │   │     rule: "ensure columns are in increasing order"
+    │   │   │   │
+    │   │   │   ├── • SameStagePrecedence dependency from PUBLIC Column:{DescID: 107, ColumnID: 3}
+    │   │   │   │     rule: "ensure columns are in increasing order"
+    │   │   │   │
+    │   │   │   ├── • PreviousStagePrecedence dependency from WRITE_ONLY Column:{DescID: 107, ColumnID: 4}
+    │   │   │   │     rule: "Column transitions to PUBLIC uphold 2-version invariant: WRITE_ONLY->PUBLIC"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC ColumnName:{DescID: 107, Name: other, ColumnID: 4}
+    │   │   │   │     rule: "column dependents exist before column becomes public"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC ColumnType:{DescID: 107, ReferencedTypeIDs: [104 105], ColumnFamilyID: 0, ColumnID: 4}
+    │   │   │   │     rule: "column dependents exist before column becomes public"
+    │   │   │   │
+    │   │   │   └── • Precedence dependency from PUBLIC IndexColumn:{DescID: 107, ColumnID: 4, IndexID: 1}
+    │   │   │         rule: "column dependents exist before column becomes public"
+    │   │   │
+    │   │   ├── • ColumnName:{DescID: 107, Name: other, ColumnID: 4}
+    │   │   │     ABSENT → PUBLIC
+    │   │   │
+    │   │   ├── • SecondaryIndex:{DescID: 107, IndexID: 2, ConstraintID: 0}
+    │   │   │   │ VALIDATED → PUBLIC
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 107, ColumnID: 5, IndexID: 2}
+    │   │   │   │     rule: "index dependents exist before index becomes public"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 107, ColumnID: 1, IndexID: 2}
+    │   │   │   │     rule: "index dependents exist before index becomes public"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC SecondaryIndexPartial:{DescID: 107, IndexID: 2}
+    │   │   │   │     rule: "index dependents exist before index becomes public"
+    │   │   │   │
+    │   │   │   ├── • PreviousStagePrecedence dependency from VALIDATED SecondaryIndex:{DescID: 107, IndexID: 2, ConstraintID: 0}
+    │   │   │   │     rule: "SecondaryIndex transitions to PUBLIC uphold 2-version invariant: VALIDATED->PUBLIC"
+    │   │   │   │
+    │   │   │   └── • Precedence dependency from PUBLIC IndexName:{DescID: 107, Name: partial, IndexID: 2}
+    │   │   │         rule: "index dependents exist before index becomes public"
+    │   │   │
+    │   │   ├── • UniqueWithoutIndexConstraint:{DescID: 107, ConstraintID: 3}
+    │   │   │   │ VALIDATED → PUBLIC
+    │   │   │   │
+    │   │   │   ├── • PreviousStagePrecedence dependency from VALIDATED UniqueWithoutIndexConstraint:{DescID: 107, ConstraintID: 3}
+    │   │   │   │     rule: "UniqueWithoutIndexConstraint transitions to PUBLIC uphold 2-version invariant: VALIDATED->PUBLIC"
+    │   │   │   │
+    │   │   │   └── • SameStagePrecedence dependency from PUBLIC ConstraintWithoutIndexName:{DescID: 107, Name: myuwi, ConstraintID: 3}
+    │   │   │         rule: "constraint dependent public right before constraint"
+    │   │   │
+    │   │   ├── • ConstraintWithoutIndexName:{DescID: 107, Name: myuwi, ConstraintID: 3}
+    │   │   │     ABSENT → PUBLIC
+    │   │   │
+    │   │   ├── • CheckConstraint:{DescID: 107, IndexID: 0, ConstraintID: 2}
+    │   │   │   │ VALIDATED → PUBLIC
+    │   │   │   │
+    │   │   │   ├── • PreviousStagePrecedence dependency from VALIDATED CheckConstraint:{DescID: 107, IndexID: 0, ConstraintID: 2}
+    │   │   │   │     rule: "CheckConstraint transitions to PUBLIC uphold 2-version invariant: VALIDATED->PUBLIC"
+    │   │   │   │
+    │   │   │   └── • SameStagePrecedence dependency from PUBLIC ConstraintWithoutIndexName:{DescID: 107, Name: mycheck, ConstraintID: 2}
+    │   │   │         rule: "constraint dependent public right before constraint"
+    │   │   │
+    │   │   └── • ConstraintWithoutIndexName:{DescID: 107, Name: mycheck, ConstraintID: 2}
+    │   │         ABSENT → PUBLIC
+    │   │
+    │   ├── • 6 elements transitioning toward ABSENT
+    │   │   │
+    │   │   ├── • PrimaryIndex:{DescID: 107, IndexID: 3, ConstraintID: 4, TemporaryIndexID: 4, SourceIndexID: 1}
+    │   │   │   │ DELETE_ONLY → ABSENT
+    │   │   │   │
+    │   │   │   ├── • PreviousStagePrecedence dependency from DELETE_ONLY PrimaryIndex:{DescID: 107, IndexID: 3, ConstraintID: 4, TemporaryIndexID: 4, SourceIndexID: 1}
+    │   │   │   │     rule: "PrimaryIndex transitions to ABSENT uphold 2-version invariant: DELETE_ONLY->ABSENT"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from ABSENT IndexName:{DescID: 107, Name: tbl_pkey, IndexID: 3}
+    │   │   │   │     rule: "dependents removed before index"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 107, ColumnID: 1, IndexID: 3}
+    │   │   │   │     rule: "dependents removed before index"
+    │   │   │   │
+    │   │   │   └── • Precedence dependency from ABSENT IndexColumn:{DescID: 107, ColumnID: 5, IndexID: 3}
+    │   │   │         rule: "dependents removed before index"
+    │   │   │
+    │   │   ├── • IndexColumn:{DescID: 107, ColumnID: 1, IndexID: 3}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   └── • skip PUBLIC → ABSENT operations
+    │   │   │         rule: "skip index-column removal ops on index removal"
+    │   │   │
+    │   │   ├── • IndexColumn:{DescID: 107, ColumnID: 5, IndexID: 3}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   └── • skip PUBLIC → ABSENT operations
+    │   │   │         rule: "skip index-column removal ops on index removal"
+    │   │   │
+    │   │   ├── • TemporaryIndex:{DescID: 107, IndexID: 4, ConstraintID: 5, SourceIndexID: 1}
+    │   │   │   │ WRITE_ONLY → DELETE_ONLY
+    │   │   │   │
+    │   │   │   └── • PreviousStagePrecedence dependency from WRITE_ONLY TemporaryIndex:{DescID: 107, IndexID: 4, ConstraintID: 5, SourceIndexID: 1}
+    │   │   │         rule: "TemporaryIndex transitions to ABSENT uphold 2-version invariant: WRITE_ONLY->DELETE_ONLY"
+    │   │   │
+    │   │   ├── • IndexColumn:{DescID: 107, ColumnID: 1, IndexID: 4}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   └── • skip PUBLIC → ABSENT operations
+    │   │   │         rule: "skip index-column removal ops on index removal"
+    │   │   │
+    │   │   └── • IndexColumn:{DescID: 107, ColumnID: 5, IndexID: 4}
+    │   │       │ PUBLIC → ABSENT
+    │   │       │
+    │   │       └── • skip PUBLIC → ABSENT operations
+    │   │             rule: "skip index-column removal ops on index removal"
+    │   │
+    │   └── • 22 Mutation operations
+    │       │
+    │       ├── • SetColumnName
+    │       │     ColumnID: 2
+    │       │     Name: gs
+    │       │     TableID: 107
+    │       │
+    │       ├── • SetColumnName
+    │       │     ColumnID: 3
+    │       │     Name: gv
+    │       │     TableID: 107
+    │       │
+    │       ├── • SetColumnName
+    │       │     ColumnID: 4
+    │       │     Name: other
+    │       │     TableID: 107
+    │       │
+    │       ├── • MakeValidatedSecondaryIndexPublic
+    │       │     IndexID: 2
+    │       │     TableID: 107
+    │       │
+    │       ├── • RefreshStats
+    │       │     TableID: 107
+    │       │
+    │       ├── • SetConstraintName
+    │       │     ConstraintID: 3
+    │       │     Name: myuwi
+    │       │     TableID: 107
+    │       │
+    │       ├── • SetConstraintName
+    │       │     ConstraintID: 2
+    │       │     Name: mycheck
+    │       │     TableID: 107
+    │       │
+    │       ├── • MakeWriteOnlyIndexDeleteOnly
+    │       │     IndexID: 4
+    │       │     TableID: 107
+    │       │
+    │       ├── • MakeWriteOnlyColumnPublic
+    │       │     ColumnID: 2
+    │       │     TableID: 107
+    │       │
+    │       ├── • RefreshStats
+    │       │     TableID: 107
+    │       │
+    │       ├── • MakeWriteOnlyColumnPublic
+    │       │     ColumnID: 3
+    │       │     TableID: 107
+    │       │
+    │       ├── • RefreshStats
+    │       │     TableID: 107
+    │       │
+    │       ├── • MakeWriteOnlyColumnPublic
+    │       │     ColumnID: 4
+    │       │     TableID: 107
+    │       │
+    │       ├── • RefreshStats
+    │       │     TableID: 107
+    │       │
+    │       ├── • MakeValidatedUniqueWithoutIndexConstraintPublic
+    │       │     ConstraintID: 3
+    │       │     TableID: 107
+    │       │
+    │       ├── • MakeValidatedCheckConstraintPublic
+    │       │     ConstraintID: 2
+    │       │     TableID: 107
+    │       │
+    │       ├── • MakeIndexAbsent
+    │       │     IndexID: 3
+    │       │     TableID: 107
+    │       │
+    │       ├── • SetJobStateOnDescriptor
+    │       │     DescriptorID: 104
+    │       │
+    │       ├── • SetJobStateOnDescriptor
+    │       │     DescriptorID: 105
+    │       │
+    │       ├── • SetJobStateOnDescriptor
+    │       │     DescriptorID: 106
+    │       │
+    │       ├── • SetJobStateOnDescriptor
+    │       │     DescriptorID: 107
+    │       │
+    │       └── • UpdateSchemaChangerJob
+    │             IsNonCancelable: true
+    │             JobID: 1
+    │             RunningStatus: PostCommitNonRevertiblePhase stage 2 of 2 with 3 MutationType ops pending
+    │
+    └── • Stage 2 of 2 in PostCommitNonRevertiblePhase
+        │
+        ├── • 3 elements transitioning toward ABSENT
+        │   │
+        │   ├── • IndexData:{DescID: 107, IndexID: 3}
+        │   │   │ PUBLIC → ABSENT
+        │   │   │
+        │   │   └── • Precedence dependency from ABSENT PrimaryIndex:{DescID: 107, IndexID: 3, ConstraintID: 4, TemporaryIndexID: 4, SourceIndexID: 1}
+        │   │         rule: "index removed before garbage collection"
+        │   │
+        │   ├── • TemporaryIndex:{DescID: 107, IndexID: 4, ConstraintID: 5, SourceIndexID: 1}
+        │   │   │ DELETE_ONLY → ABSENT
+        │   │   │
+        │   │   ├── • PreviousStagePrecedence dependency from DELETE_ONLY TemporaryIndex:{DescID: 107, IndexID: 4, ConstraintID: 5, SourceIndexID: 1}
+        │   │   │     rule: "TemporaryIndex transitions to ABSENT uphold 2-version invariant: DELETE_ONLY->ABSENT"
+        │   │   │
+        │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 107, ColumnID: 1, IndexID: 4}
+        │   │   │     rule: "dependents removed before index"
+        │   │   │
+        │   │   └── • Precedence dependency from ABSENT IndexColumn:{DescID: 107, ColumnID: 5, IndexID: 4}
+        │   │         rule: "dependents removed before index"
+        │   │
+        │   └── • IndexData:{DescID: 107, IndexID: 4}
+        │       │ PUBLIC → ABSENT
+        │       │
+        │       ├── • SameStagePrecedence dependency from DROPPED IndexData:{DescID: 107, IndexID: 3}
+        │       │     rule: "schedule all GC jobs for a descriptor in the same stage"
+        │       │
+        │       └── • Precedence dependency from ABSENT TemporaryIndex:{DescID: 107, IndexID: 4, ConstraintID: 5, SourceIndexID: 1}
+        │             rule: "index removed before garbage collection"
+        │
+        └── • 8 Mutation operations
+            │
+            ├── • CreateGCJobForIndex
+            │     IndexID: 3
+            │     StatementForDropJob:
+            │       Rollback: true
+            │       Statement: DROP TYPE defaultdb.public.greeting CASCADE
+            │     TableID: 107
+            │
+            ├── • MakeIndexAbsent
+            │     IndexID: 4
+            │     TableID: 107
+            │
+            ├── • CreateGCJobForIndex
+            │     IndexID: 4
+            │     StatementForDropJob:
+            │       Rollback: true
+            │       Statement: DROP TYPE defaultdb.public.greeting CASCADE
+            │     TableID: 107
+            │
+            ├── • RemoveJobStateFromDescriptor
+            │     DescriptorID: 104
+            │     JobID: 1
+            │
+            ├── • RemoveJobStateFromDescriptor
+            │     DescriptorID: 105
+            │     JobID: 1
+            │
+            ├── • RemoveJobStateFromDescriptor
+            │     DescriptorID: 106
+            │     JobID: 1
+            │
+            ├── • RemoveJobStateFromDescriptor
+            │     DescriptorID: 107
+            │     JobID: 1
+            │
+            └── • UpdateSchemaChangerJob
+                  DescriptorIDsToRemove:
+                  - 104
+                  - 105
+                  - 106
+                  - 107
+                  IsNonCancelable: true
+                  JobID: 1
+                  RunningStatus: all stages completed

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_type_cascade.rollback_5_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_type_cascade.rollback_5_of_7
@@ -1,0 +1,350 @@
+/* setup */
+SET experimental_enable_unique_without_index_constraints = true;
+CREATE TYPE greeting AS ENUM('hello', 'hi');
+CREATE VIEW view AS SELECT 'hi'::greeting::string AS c;
+CREATE TABLE tbl (
+  id INT PRIMARY KEY,
+  gs greeting AS ('hi'::greeting) STORED,
+  gv string AS ('hello'::greeting::STRING) VIRTUAL,
+  other greeting[],
+  name STRING NOT NULL DEFAULT 'noname',
+  CONSTRAINT mycheck CHECK (gs::STRING = name),
+  CONSTRAINT myuwi UNIQUE WITHOUT INDEX (name) WHERE ('hi'::greeting::STRING = 'hi'),
+  INDEX partial (name) WHERE (gs::STRING = 'hi')
+);
+
+/* test */
+DROP TYPE greeting CASCADE;
+EXPLAIN (ddl, verbose) rollback at post-commit stage 5 of 7;
+----
+• Schema change plan for rolling back DROP TYPE ‹defaultdb›.‹public›.‹greeting› CASCADE;
+│
+└── • PostCommitNonRevertiblePhase
+    │
+    ├── • Stage 1 of 2 in PostCommitNonRevertiblePhase
+    │   │
+    │   ├── • 11 elements transitioning toward PUBLIC
+    │   │   │
+    │   │   ├── • Column:{DescID: 107, ColumnID: 2}
+    │   │   │   │ WRITE_ONLY → PUBLIC
+    │   │   │   │
+    │   │   │   ├── • PreviousStagePrecedence dependency from WRITE_ONLY Column:{DescID: 107, ColumnID: 2}
+    │   │   │   │     rule: "Column transitions to PUBLIC uphold 2-version invariant: WRITE_ONLY->PUBLIC"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC ColumnName:{DescID: 107, Name: gs, ColumnID: 2}
+    │   │   │   │     rule: "column dependents exist before column becomes public"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC ColumnType:{DescID: 107, ReferencedTypeIDs: [104 105], ColumnFamilyID: 0, ColumnID: 2}
+    │   │   │   │     rule: "column dependents exist before column becomes public"
+    │   │   │   │
+    │   │   │   └── • Precedence dependency from PUBLIC IndexColumn:{DescID: 107, ColumnID: 2, IndexID: 1}
+    │   │   │         rule: "column dependents exist before column becomes public"
+    │   │   │
+    │   │   ├── • ColumnName:{DescID: 107, Name: gs, ColumnID: 2}
+    │   │   │     ABSENT → PUBLIC
+    │   │   │
+    │   │   ├── • Column:{DescID: 107, ColumnID: 3}
+    │   │   │   │ WRITE_ONLY → PUBLIC
+    │   │   │   │
+    │   │   │   ├── • SameStagePrecedence dependency from PUBLIC Column:{DescID: 107, ColumnID: 2}
+    │   │   │   │     rule: "ensure columns are in increasing order"
+    │   │   │   │
+    │   │   │   ├── • PreviousStagePrecedence dependency from WRITE_ONLY Column:{DescID: 107, ColumnID: 3}
+    │   │   │   │     rule: "Column transitions to PUBLIC uphold 2-version invariant: WRITE_ONLY->PUBLIC"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC ColumnName:{DescID: 107, Name: gv, ColumnID: 3}
+    │   │   │   │     rule: "column dependents exist before column becomes public"
+    │   │   │   │
+    │   │   │   └── • Precedence dependency from PUBLIC ColumnType:{DescID: 107, ReferencedTypeIDs: [104 105], ColumnFamilyID: 0, ColumnID: 3}
+    │   │   │         rule: "column dependents exist before column becomes public"
+    │   │   │
+    │   │   ├── • ColumnName:{DescID: 107, Name: gv, ColumnID: 3}
+    │   │   │     ABSENT → PUBLIC
+    │   │   │
+    │   │   ├── • Column:{DescID: 107, ColumnID: 4}
+    │   │   │   │ WRITE_ONLY → PUBLIC
+    │   │   │   │
+    │   │   │   ├── • SameStagePrecedence dependency from PUBLIC Column:{DescID: 107, ColumnID: 2}
+    │   │   │   │     rule: "ensure columns are in increasing order"
+    │   │   │   │
+    │   │   │   ├── • SameStagePrecedence dependency from PUBLIC Column:{DescID: 107, ColumnID: 3}
+    │   │   │   │     rule: "ensure columns are in increasing order"
+    │   │   │   │
+    │   │   │   ├── • PreviousStagePrecedence dependency from WRITE_ONLY Column:{DescID: 107, ColumnID: 4}
+    │   │   │   │     rule: "Column transitions to PUBLIC uphold 2-version invariant: WRITE_ONLY->PUBLIC"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC ColumnName:{DescID: 107, Name: other, ColumnID: 4}
+    │   │   │   │     rule: "column dependents exist before column becomes public"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC ColumnType:{DescID: 107, ReferencedTypeIDs: [104 105], ColumnFamilyID: 0, ColumnID: 4}
+    │   │   │   │     rule: "column dependents exist before column becomes public"
+    │   │   │   │
+    │   │   │   └── • Precedence dependency from PUBLIC IndexColumn:{DescID: 107, ColumnID: 4, IndexID: 1}
+    │   │   │         rule: "column dependents exist before column becomes public"
+    │   │   │
+    │   │   ├── • ColumnName:{DescID: 107, Name: other, ColumnID: 4}
+    │   │   │     ABSENT → PUBLIC
+    │   │   │
+    │   │   ├── • SecondaryIndex:{DescID: 107, IndexID: 2, ConstraintID: 0}
+    │   │   │   │ VALIDATED → PUBLIC
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 107, ColumnID: 5, IndexID: 2}
+    │   │   │   │     rule: "index dependents exist before index becomes public"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 107, ColumnID: 1, IndexID: 2}
+    │   │   │   │     rule: "index dependents exist before index becomes public"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC SecondaryIndexPartial:{DescID: 107, IndexID: 2}
+    │   │   │   │     rule: "index dependents exist before index becomes public"
+    │   │   │   │
+    │   │   │   ├── • PreviousStagePrecedence dependency from VALIDATED SecondaryIndex:{DescID: 107, IndexID: 2, ConstraintID: 0}
+    │   │   │   │     rule: "SecondaryIndex transitions to PUBLIC uphold 2-version invariant: VALIDATED->PUBLIC"
+    │   │   │   │
+    │   │   │   └── • Precedence dependency from PUBLIC IndexName:{DescID: 107, Name: partial, IndexID: 2}
+    │   │   │         rule: "index dependents exist before index becomes public"
+    │   │   │
+    │   │   ├── • UniqueWithoutIndexConstraint:{DescID: 107, ConstraintID: 3}
+    │   │   │   │ VALIDATED → PUBLIC
+    │   │   │   │
+    │   │   │   ├── • PreviousStagePrecedence dependency from VALIDATED UniqueWithoutIndexConstraint:{DescID: 107, ConstraintID: 3}
+    │   │   │   │     rule: "UniqueWithoutIndexConstraint transitions to PUBLIC uphold 2-version invariant: VALIDATED->PUBLIC"
+    │   │   │   │
+    │   │   │   └── • SameStagePrecedence dependency from PUBLIC ConstraintWithoutIndexName:{DescID: 107, Name: myuwi, ConstraintID: 3}
+    │   │   │         rule: "constraint dependent public right before constraint"
+    │   │   │
+    │   │   ├── • ConstraintWithoutIndexName:{DescID: 107, Name: myuwi, ConstraintID: 3}
+    │   │   │     ABSENT → PUBLIC
+    │   │   │
+    │   │   ├── • CheckConstraint:{DescID: 107, IndexID: 0, ConstraintID: 2}
+    │   │   │   │ VALIDATED → PUBLIC
+    │   │   │   │
+    │   │   │   ├── • PreviousStagePrecedence dependency from VALIDATED CheckConstraint:{DescID: 107, IndexID: 0, ConstraintID: 2}
+    │   │   │   │     rule: "CheckConstraint transitions to PUBLIC uphold 2-version invariant: VALIDATED->PUBLIC"
+    │   │   │   │
+    │   │   │   └── • SameStagePrecedence dependency from PUBLIC ConstraintWithoutIndexName:{DescID: 107, Name: mycheck, ConstraintID: 2}
+    │   │   │         rule: "constraint dependent public right before constraint"
+    │   │   │
+    │   │   └── • ConstraintWithoutIndexName:{DescID: 107, Name: mycheck, ConstraintID: 2}
+    │   │         ABSENT → PUBLIC
+    │   │
+    │   ├── • 6 elements transitioning toward ABSENT
+    │   │   │
+    │   │   ├── • PrimaryIndex:{DescID: 107, IndexID: 3, ConstraintID: 4, TemporaryIndexID: 4, SourceIndexID: 1}
+    │   │   │   │ MERGE_ONLY → DELETE_ONLY
+    │   │   │   │
+    │   │   │   └── • PreviousStagePrecedence dependency from MERGE_ONLY PrimaryIndex:{DescID: 107, IndexID: 3, ConstraintID: 4, TemporaryIndexID: 4, SourceIndexID: 1}
+    │   │   │         rule: "PrimaryIndex transitions to ABSENT uphold 2-version invariant: MERGE_ONLY->WRITE_ONLY"
+    │   │   │
+    │   │   ├── • IndexColumn:{DescID: 107, ColumnID: 1, IndexID: 3}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   └── • skip PUBLIC → ABSENT operations
+    │   │   │         rule: "skip index-column removal ops on index removal"
+    │   │   │
+    │   │   ├── • IndexColumn:{DescID: 107, ColumnID: 5, IndexID: 3}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   └── • skip PUBLIC → ABSENT operations
+    │   │   │         rule: "skip index-column removal ops on index removal"
+    │   │   │
+    │   │   ├── • TemporaryIndex:{DescID: 107, IndexID: 4, ConstraintID: 5, SourceIndexID: 1}
+    │   │   │   │ WRITE_ONLY → DELETE_ONLY
+    │   │   │   │
+    │   │   │   └── • PreviousStagePrecedence dependency from WRITE_ONLY TemporaryIndex:{DescID: 107, IndexID: 4, ConstraintID: 5, SourceIndexID: 1}
+    │   │   │         rule: "TemporaryIndex transitions to ABSENT uphold 2-version invariant: WRITE_ONLY->DELETE_ONLY"
+    │   │   │
+    │   │   ├── • IndexColumn:{DescID: 107, ColumnID: 1, IndexID: 4}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   └── • skip PUBLIC → ABSENT operations
+    │   │   │         rule: "skip index-column removal ops on index removal"
+    │   │   │
+    │   │   └── • IndexColumn:{DescID: 107, ColumnID: 5, IndexID: 4}
+    │   │       │ PUBLIC → ABSENT
+    │   │       │
+    │   │       └── • skip PUBLIC → ABSENT operations
+    │   │             rule: "skip index-column removal ops on index removal"
+    │   │
+    │   └── • 22 Mutation operations
+    │       │
+    │       ├── • SetColumnName
+    │       │     ColumnID: 2
+    │       │     Name: gs
+    │       │     TableID: 107
+    │       │
+    │       ├── • SetColumnName
+    │       │     ColumnID: 3
+    │       │     Name: gv
+    │       │     TableID: 107
+    │       │
+    │       ├── • SetColumnName
+    │       │     ColumnID: 4
+    │       │     Name: other
+    │       │     TableID: 107
+    │       │
+    │       ├── • MakeValidatedSecondaryIndexPublic
+    │       │     IndexID: 2
+    │       │     TableID: 107
+    │       │
+    │       ├── • RefreshStats
+    │       │     TableID: 107
+    │       │
+    │       ├── • SetConstraintName
+    │       │     ConstraintID: 3
+    │       │     Name: myuwi
+    │       │     TableID: 107
+    │       │
+    │       ├── • SetConstraintName
+    │       │     ConstraintID: 2
+    │       │     Name: mycheck
+    │       │     TableID: 107
+    │       │
+    │       ├── • MakeWriteOnlyIndexDeleteOnly
+    │       │     IndexID: 4
+    │       │     TableID: 107
+    │       │
+    │       ├── • MakeWriteOnlyColumnPublic
+    │       │     ColumnID: 2
+    │       │     TableID: 107
+    │       │
+    │       ├── • RefreshStats
+    │       │     TableID: 107
+    │       │
+    │       ├── • MakeWriteOnlyColumnPublic
+    │       │     ColumnID: 3
+    │       │     TableID: 107
+    │       │
+    │       ├── • RefreshStats
+    │       │     TableID: 107
+    │       │
+    │       ├── • MakeWriteOnlyColumnPublic
+    │       │     ColumnID: 4
+    │       │     TableID: 107
+    │       │
+    │       ├── • RefreshStats
+    │       │     TableID: 107
+    │       │
+    │       ├── • MakeValidatedUniqueWithoutIndexConstraintPublic
+    │       │     ConstraintID: 3
+    │       │     TableID: 107
+    │       │
+    │       ├── • MakeValidatedCheckConstraintPublic
+    │       │     ConstraintID: 2
+    │       │     TableID: 107
+    │       │
+    │       ├── • MakeWriteOnlyIndexDeleteOnly
+    │       │     IndexID: 3
+    │       │     TableID: 107
+    │       │
+    │       ├── • SetJobStateOnDescriptor
+    │       │     DescriptorID: 104
+    │       │
+    │       ├── • SetJobStateOnDescriptor
+    │       │     DescriptorID: 105
+    │       │
+    │       ├── • SetJobStateOnDescriptor
+    │       │     DescriptorID: 106
+    │       │
+    │       ├── • SetJobStateOnDescriptor
+    │       │     DescriptorID: 107
+    │       │
+    │       └── • UpdateSchemaChangerJob
+    │             IsNonCancelable: true
+    │             JobID: 1
+    │             RunningStatus: PostCommitNonRevertiblePhase stage 2 of 2 with 4 MutationType ops pending
+    │
+    └── • Stage 2 of 2 in PostCommitNonRevertiblePhase
+        │
+        ├── • 4 elements transitioning toward ABSENT
+        │   │
+        │   ├── • PrimaryIndex:{DescID: 107, IndexID: 3, ConstraintID: 4, TemporaryIndexID: 4, SourceIndexID: 1}
+        │   │   │ DELETE_ONLY → ABSENT
+        │   │   │
+        │   │   ├── • PreviousStagePrecedence dependency from DELETE_ONLY PrimaryIndex:{DescID: 107, IndexID: 3, ConstraintID: 4, TemporaryIndexID: 4, SourceIndexID: 1}
+        │   │   │     rule: "PrimaryIndex transitions to ABSENT uphold 2-version invariant: DELETE_ONLY->ABSENT"
+        │   │   │
+        │   │   ├── • Precedence dependency from ABSENT IndexName:{DescID: 107, Name: tbl_pkey, IndexID: 3}
+        │   │   │     rule: "dependents removed before index"
+        │   │   │
+        │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 107, ColumnID: 1, IndexID: 3}
+        │   │   │     rule: "dependents removed before index"
+        │   │   │
+        │   │   └── • Precedence dependency from ABSENT IndexColumn:{DescID: 107, ColumnID: 5, IndexID: 3}
+        │   │         rule: "dependents removed before index"
+        │   │
+        │   ├── • IndexData:{DescID: 107, IndexID: 3}
+        │   │   │ PUBLIC → ABSENT
+        │   │   │
+        │   │   └── • Precedence dependency from ABSENT PrimaryIndex:{DescID: 107, IndexID: 3, ConstraintID: 4, TemporaryIndexID: 4, SourceIndexID: 1}
+        │   │         rule: "index removed before garbage collection"
+        │   │
+        │   ├── • TemporaryIndex:{DescID: 107, IndexID: 4, ConstraintID: 5, SourceIndexID: 1}
+        │   │   │ DELETE_ONLY → ABSENT
+        │   │   │
+        │   │   ├── • PreviousStagePrecedence dependency from DELETE_ONLY TemporaryIndex:{DescID: 107, IndexID: 4, ConstraintID: 5, SourceIndexID: 1}
+        │   │   │     rule: "TemporaryIndex transitions to ABSENT uphold 2-version invariant: DELETE_ONLY->ABSENT"
+        │   │   │
+        │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 107, ColumnID: 1, IndexID: 4}
+        │   │   │     rule: "dependents removed before index"
+        │   │   │
+        │   │   └── • Precedence dependency from ABSENT IndexColumn:{DescID: 107, ColumnID: 5, IndexID: 4}
+        │   │         rule: "dependents removed before index"
+        │   │
+        │   └── • IndexData:{DescID: 107, IndexID: 4}
+        │       │ PUBLIC → ABSENT
+        │       │
+        │       ├── • SameStagePrecedence dependency from DROPPED IndexData:{DescID: 107, IndexID: 3}
+        │       │     rule: "schedule all GC jobs for a descriptor in the same stage"
+        │       │
+        │       └── • Precedence dependency from ABSENT TemporaryIndex:{DescID: 107, IndexID: 4, ConstraintID: 5, SourceIndexID: 1}
+        │             rule: "index removed before garbage collection"
+        │
+        └── • 9 Mutation operations
+            │
+            ├── • MakeIndexAbsent
+            │     IndexID: 3
+            │     TableID: 107
+            │
+            ├── • CreateGCJobForIndex
+            │     IndexID: 3
+            │     StatementForDropJob:
+            │       Rollback: true
+            │       Statement: DROP TYPE defaultdb.public.greeting CASCADE
+            │     TableID: 107
+            │
+            ├── • MakeIndexAbsent
+            │     IndexID: 4
+            │     TableID: 107
+            │
+            ├── • CreateGCJobForIndex
+            │     IndexID: 4
+            │     StatementForDropJob:
+            │       Rollback: true
+            │       Statement: DROP TYPE defaultdb.public.greeting CASCADE
+            │     TableID: 107
+            │
+            ├── • RemoveJobStateFromDescriptor
+            │     DescriptorID: 104
+            │     JobID: 1
+            │
+            ├── • RemoveJobStateFromDescriptor
+            │     DescriptorID: 105
+            │     JobID: 1
+            │
+            ├── • RemoveJobStateFromDescriptor
+            │     DescriptorID: 106
+            │     JobID: 1
+            │
+            ├── • RemoveJobStateFromDescriptor
+            │     DescriptorID: 107
+            │     JobID: 1
+            │
+            └── • UpdateSchemaChangerJob
+                  DescriptorIDsToRemove:
+                  - 104
+                  - 105
+                  - 106
+                  - 107
+                  IsNonCancelable: true
+                  JobID: 1
+                  RunningStatus: all stages completed

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_type_cascade.rollback_6_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_type_cascade.rollback_6_of_7
@@ -1,0 +1,350 @@
+/* setup */
+SET experimental_enable_unique_without_index_constraints = true;
+CREATE TYPE greeting AS ENUM('hello', 'hi');
+CREATE VIEW view AS SELECT 'hi'::greeting::string AS c;
+CREATE TABLE tbl (
+  id INT PRIMARY KEY,
+  gs greeting AS ('hi'::greeting) STORED,
+  gv string AS ('hello'::greeting::STRING) VIRTUAL,
+  other greeting[],
+  name STRING NOT NULL DEFAULT 'noname',
+  CONSTRAINT mycheck CHECK (gs::STRING = name),
+  CONSTRAINT myuwi UNIQUE WITHOUT INDEX (name) WHERE ('hi'::greeting::STRING = 'hi'),
+  INDEX partial (name) WHERE (gs::STRING = 'hi')
+);
+
+/* test */
+DROP TYPE greeting CASCADE;
+EXPLAIN (ddl, verbose) rollback at post-commit stage 6 of 7;
+----
+• Schema change plan for rolling back DROP TYPE ‹defaultdb›.‹public›.‹greeting› CASCADE;
+│
+└── • PostCommitNonRevertiblePhase
+    │
+    ├── • Stage 1 of 2 in PostCommitNonRevertiblePhase
+    │   │
+    │   ├── • 11 elements transitioning toward PUBLIC
+    │   │   │
+    │   │   ├── • Column:{DescID: 107, ColumnID: 2}
+    │   │   │   │ WRITE_ONLY → PUBLIC
+    │   │   │   │
+    │   │   │   ├── • PreviousStagePrecedence dependency from WRITE_ONLY Column:{DescID: 107, ColumnID: 2}
+    │   │   │   │     rule: "Column transitions to PUBLIC uphold 2-version invariant: WRITE_ONLY->PUBLIC"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC ColumnName:{DescID: 107, Name: gs, ColumnID: 2}
+    │   │   │   │     rule: "column dependents exist before column becomes public"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC ColumnType:{DescID: 107, ReferencedTypeIDs: [104 105], ColumnFamilyID: 0, ColumnID: 2}
+    │   │   │   │     rule: "column dependents exist before column becomes public"
+    │   │   │   │
+    │   │   │   └── • Precedence dependency from PUBLIC IndexColumn:{DescID: 107, ColumnID: 2, IndexID: 1}
+    │   │   │         rule: "column dependents exist before column becomes public"
+    │   │   │
+    │   │   ├── • ColumnName:{DescID: 107, Name: gs, ColumnID: 2}
+    │   │   │     ABSENT → PUBLIC
+    │   │   │
+    │   │   ├── • Column:{DescID: 107, ColumnID: 3}
+    │   │   │   │ WRITE_ONLY → PUBLIC
+    │   │   │   │
+    │   │   │   ├── • SameStagePrecedence dependency from PUBLIC Column:{DescID: 107, ColumnID: 2}
+    │   │   │   │     rule: "ensure columns are in increasing order"
+    │   │   │   │
+    │   │   │   ├── • PreviousStagePrecedence dependency from WRITE_ONLY Column:{DescID: 107, ColumnID: 3}
+    │   │   │   │     rule: "Column transitions to PUBLIC uphold 2-version invariant: WRITE_ONLY->PUBLIC"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC ColumnName:{DescID: 107, Name: gv, ColumnID: 3}
+    │   │   │   │     rule: "column dependents exist before column becomes public"
+    │   │   │   │
+    │   │   │   └── • Precedence dependency from PUBLIC ColumnType:{DescID: 107, ReferencedTypeIDs: [104 105], ColumnFamilyID: 0, ColumnID: 3}
+    │   │   │         rule: "column dependents exist before column becomes public"
+    │   │   │
+    │   │   ├── • ColumnName:{DescID: 107, Name: gv, ColumnID: 3}
+    │   │   │     ABSENT → PUBLIC
+    │   │   │
+    │   │   ├── • Column:{DescID: 107, ColumnID: 4}
+    │   │   │   │ WRITE_ONLY → PUBLIC
+    │   │   │   │
+    │   │   │   ├── • SameStagePrecedence dependency from PUBLIC Column:{DescID: 107, ColumnID: 2}
+    │   │   │   │     rule: "ensure columns are in increasing order"
+    │   │   │   │
+    │   │   │   ├── • SameStagePrecedence dependency from PUBLIC Column:{DescID: 107, ColumnID: 3}
+    │   │   │   │     rule: "ensure columns are in increasing order"
+    │   │   │   │
+    │   │   │   ├── • PreviousStagePrecedence dependency from WRITE_ONLY Column:{DescID: 107, ColumnID: 4}
+    │   │   │   │     rule: "Column transitions to PUBLIC uphold 2-version invariant: WRITE_ONLY->PUBLIC"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC ColumnName:{DescID: 107, Name: other, ColumnID: 4}
+    │   │   │   │     rule: "column dependents exist before column becomes public"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC ColumnType:{DescID: 107, ReferencedTypeIDs: [104 105], ColumnFamilyID: 0, ColumnID: 4}
+    │   │   │   │     rule: "column dependents exist before column becomes public"
+    │   │   │   │
+    │   │   │   └── • Precedence dependency from PUBLIC IndexColumn:{DescID: 107, ColumnID: 4, IndexID: 1}
+    │   │   │         rule: "column dependents exist before column becomes public"
+    │   │   │
+    │   │   ├── • ColumnName:{DescID: 107, Name: other, ColumnID: 4}
+    │   │   │     ABSENT → PUBLIC
+    │   │   │
+    │   │   ├── • SecondaryIndex:{DescID: 107, IndexID: 2, ConstraintID: 0}
+    │   │   │   │ VALIDATED → PUBLIC
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 107, ColumnID: 5, IndexID: 2}
+    │   │   │   │     rule: "index dependents exist before index becomes public"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 107, ColumnID: 1, IndexID: 2}
+    │   │   │   │     rule: "index dependents exist before index becomes public"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC SecondaryIndexPartial:{DescID: 107, IndexID: 2}
+    │   │   │   │     rule: "index dependents exist before index becomes public"
+    │   │   │   │
+    │   │   │   ├── • PreviousStagePrecedence dependency from VALIDATED SecondaryIndex:{DescID: 107, IndexID: 2, ConstraintID: 0}
+    │   │   │   │     rule: "SecondaryIndex transitions to PUBLIC uphold 2-version invariant: VALIDATED->PUBLIC"
+    │   │   │   │
+    │   │   │   └── • Precedence dependency from PUBLIC IndexName:{DescID: 107, Name: partial, IndexID: 2}
+    │   │   │         rule: "index dependents exist before index becomes public"
+    │   │   │
+    │   │   ├── • UniqueWithoutIndexConstraint:{DescID: 107, ConstraintID: 3}
+    │   │   │   │ VALIDATED → PUBLIC
+    │   │   │   │
+    │   │   │   ├── • PreviousStagePrecedence dependency from VALIDATED UniqueWithoutIndexConstraint:{DescID: 107, ConstraintID: 3}
+    │   │   │   │     rule: "UniqueWithoutIndexConstraint transitions to PUBLIC uphold 2-version invariant: VALIDATED->PUBLIC"
+    │   │   │   │
+    │   │   │   └── • SameStagePrecedence dependency from PUBLIC ConstraintWithoutIndexName:{DescID: 107, Name: myuwi, ConstraintID: 3}
+    │   │   │         rule: "constraint dependent public right before constraint"
+    │   │   │
+    │   │   ├── • ConstraintWithoutIndexName:{DescID: 107, Name: myuwi, ConstraintID: 3}
+    │   │   │     ABSENT → PUBLIC
+    │   │   │
+    │   │   ├── • CheckConstraint:{DescID: 107, IndexID: 0, ConstraintID: 2}
+    │   │   │   │ VALIDATED → PUBLIC
+    │   │   │   │
+    │   │   │   ├── • PreviousStagePrecedence dependency from VALIDATED CheckConstraint:{DescID: 107, IndexID: 0, ConstraintID: 2}
+    │   │   │   │     rule: "CheckConstraint transitions to PUBLIC uphold 2-version invariant: VALIDATED->PUBLIC"
+    │   │   │   │
+    │   │   │   └── • SameStagePrecedence dependency from PUBLIC ConstraintWithoutIndexName:{DescID: 107, Name: mycheck, ConstraintID: 2}
+    │   │   │         rule: "constraint dependent public right before constraint"
+    │   │   │
+    │   │   └── • ConstraintWithoutIndexName:{DescID: 107, Name: mycheck, ConstraintID: 2}
+    │   │         ABSENT → PUBLIC
+    │   │
+    │   ├── • 6 elements transitioning toward ABSENT
+    │   │   │
+    │   │   ├── • PrimaryIndex:{DescID: 107, IndexID: 3, ConstraintID: 4, TemporaryIndexID: 4, SourceIndexID: 1}
+    │   │   │   │ MERGE_ONLY → DELETE_ONLY
+    │   │   │   │
+    │   │   │   └── • PreviousStagePrecedence dependency from MERGE_ONLY PrimaryIndex:{DescID: 107, IndexID: 3, ConstraintID: 4, TemporaryIndexID: 4, SourceIndexID: 1}
+    │   │   │         rule: "PrimaryIndex transitions to ABSENT uphold 2-version invariant: MERGE_ONLY->WRITE_ONLY"
+    │   │   │
+    │   │   ├── • IndexColumn:{DescID: 107, ColumnID: 1, IndexID: 3}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   └── • skip PUBLIC → ABSENT operations
+    │   │   │         rule: "skip index-column removal ops on index removal"
+    │   │   │
+    │   │   ├── • IndexColumn:{DescID: 107, ColumnID: 5, IndexID: 3}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   └── • skip PUBLIC → ABSENT operations
+    │   │   │         rule: "skip index-column removal ops on index removal"
+    │   │   │
+    │   │   ├── • TemporaryIndex:{DescID: 107, IndexID: 4, ConstraintID: 5, SourceIndexID: 1}
+    │   │   │   │ WRITE_ONLY → DELETE_ONLY
+    │   │   │   │
+    │   │   │   └── • PreviousStagePrecedence dependency from WRITE_ONLY TemporaryIndex:{DescID: 107, IndexID: 4, ConstraintID: 5, SourceIndexID: 1}
+    │   │   │         rule: "TemporaryIndex transitions to ABSENT uphold 2-version invariant: WRITE_ONLY->DELETE_ONLY"
+    │   │   │
+    │   │   ├── • IndexColumn:{DescID: 107, ColumnID: 1, IndexID: 4}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   └── • skip PUBLIC → ABSENT operations
+    │   │   │         rule: "skip index-column removal ops on index removal"
+    │   │   │
+    │   │   └── • IndexColumn:{DescID: 107, ColumnID: 5, IndexID: 4}
+    │   │       │ PUBLIC → ABSENT
+    │   │       │
+    │   │       └── • skip PUBLIC → ABSENT operations
+    │   │             rule: "skip index-column removal ops on index removal"
+    │   │
+    │   └── • 22 Mutation operations
+    │       │
+    │       ├── • SetColumnName
+    │       │     ColumnID: 2
+    │       │     Name: gs
+    │       │     TableID: 107
+    │       │
+    │       ├── • SetColumnName
+    │       │     ColumnID: 3
+    │       │     Name: gv
+    │       │     TableID: 107
+    │       │
+    │       ├── • SetColumnName
+    │       │     ColumnID: 4
+    │       │     Name: other
+    │       │     TableID: 107
+    │       │
+    │       ├── • MakeValidatedSecondaryIndexPublic
+    │       │     IndexID: 2
+    │       │     TableID: 107
+    │       │
+    │       ├── • RefreshStats
+    │       │     TableID: 107
+    │       │
+    │       ├── • SetConstraintName
+    │       │     ConstraintID: 3
+    │       │     Name: myuwi
+    │       │     TableID: 107
+    │       │
+    │       ├── • SetConstraintName
+    │       │     ConstraintID: 2
+    │       │     Name: mycheck
+    │       │     TableID: 107
+    │       │
+    │       ├── • MakeWriteOnlyIndexDeleteOnly
+    │       │     IndexID: 4
+    │       │     TableID: 107
+    │       │
+    │       ├── • MakeWriteOnlyColumnPublic
+    │       │     ColumnID: 2
+    │       │     TableID: 107
+    │       │
+    │       ├── • RefreshStats
+    │       │     TableID: 107
+    │       │
+    │       ├── • MakeWriteOnlyColumnPublic
+    │       │     ColumnID: 3
+    │       │     TableID: 107
+    │       │
+    │       ├── • RefreshStats
+    │       │     TableID: 107
+    │       │
+    │       ├── • MakeWriteOnlyColumnPublic
+    │       │     ColumnID: 4
+    │       │     TableID: 107
+    │       │
+    │       ├── • RefreshStats
+    │       │     TableID: 107
+    │       │
+    │       ├── • MakeValidatedUniqueWithoutIndexConstraintPublic
+    │       │     ConstraintID: 3
+    │       │     TableID: 107
+    │       │
+    │       ├── • MakeValidatedCheckConstraintPublic
+    │       │     ConstraintID: 2
+    │       │     TableID: 107
+    │       │
+    │       ├── • MakeWriteOnlyIndexDeleteOnly
+    │       │     IndexID: 3
+    │       │     TableID: 107
+    │       │
+    │       ├── • SetJobStateOnDescriptor
+    │       │     DescriptorID: 104
+    │       │
+    │       ├── • SetJobStateOnDescriptor
+    │       │     DescriptorID: 105
+    │       │
+    │       ├── • SetJobStateOnDescriptor
+    │       │     DescriptorID: 106
+    │       │
+    │       ├── • SetJobStateOnDescriptor
+    │       │     DescriptorID: 107
+    │       │
+    │       └── • UpdateSchemaChangerJob
+    │             IsNonCancelable: true
+    │             JobID: 1
+    │             RunningStatus: PostCommitNonRevertiblePhase stage 2 of 2 with 4 MutationType ops pending
+    │
+    └── • Stage 2 of 2 in PostCommitNonRevertiblePhase
+        │
+        ├── • 4 elements transitioning toward ABSENT
+        │   │
+        │   ├── • PrimaryIndex:{DescID: 107, IndexID: 3, ConstraintID: 4, TemporaryIndexID: 4, SourceIndexID: 1}
+        │   │   │ DELETE_ONLY → ABSENT
+        │   │   │
+        │   │   ├── • PreviousStagePrecedence dependency from DELETE_ONLY PrimaryIndex:{DescID: 107, IndexID: 3, ConstraintID: 4, TemporaryIndexID: 4, SourceIndexID: 1}
+        │   │   │     rule: "PrimaryIndex transitions to ABSENT uphold 2-version invariant: DELETE_ONLY->ABSENT"
+        │   │   │
+        │   │   ├── • Precedence dependency from ABSENT IndexName:{DescID: 107, Name: tbl_pkey, IndexID: 3}
+        │   │   │     rule: "dependents removed before index"
+        │   │   │
+        │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 107, ColumnID: 1, IndexID: 3}
+        │   │   │     rule: "dependents removed before index"
+        │   │   │
+        │   │   └── • Precedence dependency from ABSENT IndexColumn:{DescID: 107, ColumnID: 5, IndexID: 3}
+        │   │         rule: "dependents removed before index"
+        │   │
+        │   ├── • IndexData:{DescID: 107, IndexID: 3}
+        │   │   │ PUBLIC → ABSENT
+        │   │   │
+        │   │   └── • Precedence dependency from ABSENT PrimaryIndex:{DescID: 107, IndexID: 3, ConstraintID: 4, TemporaryIndexID: 4, SourceIndexID: 1}
+        │   │         rule: "index removed before garbage collection"
+        │   │
+        │   ├── • TemporaryIndex:{DescID: 107, IndexID: 4, ConstraintID: 5, SourceIndexID: 1}
+        │   │   │ DELETE_ONLY → ABSENT
+        │   │   │
+        │   │   ├── • PreviousStagePrecedence dependency from DELETE_ONLY TemporaryIndex:{DescID: 107, IndexID: 4, ConstraintID: 5, SourceIndexID: 1}
+        │   │   │     rule: "TemporaryIndex transitions to ABSENT uphold 2-version invariant: DELETE_ONLY->ABSENT"
+        │   │   │
+        │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 107, ColumnID: 1, IndexID: 4}
+        │   │   │     rule: "dependents removed before index"
+        │   │   │
+        │   │   └── • Precedence dependency from ABSENT IndexColumn:{DescID: 107, ColumnID: 5, IndexID: 4}
+        │   │         rule: "dependents removed before index"
+        │   │
+        │   └── • IndexData:{DescID: 107, IndexID: 4}
+        │       │ PUBLIC → ABSENT
+        │       │
+        │       ├── • SameStagePrecedence dependency from DROPPED IndexData:{DescID: 107, IndexID: 3}
+        │       │     rule: "schedule all GC jobs for a descriptor in the same stage"
+        │       │
+        │       └── • Precedence dependency from ABSENT TemporaryIndex:{DescID: 107, IndexID: 4, ConstraintID: 5, SourceIndexID: 1}
+        │             rule: "index removed before garbage collection"
+        │
+        └── • 9 Mutation operations
+            │
+            ├── • MakeIndexAbsent
+            │     IndexID: 3
+            │     TableID: 107
+            │
+            ├── • CreateGCJobForIndex
+            │     IndexID: 3
+            │     StatementForDropJob:
+            │       Rollback: true
+            │       Statement: DROP TYPE defaultdb.public.greeting CASCADE
+            │     TableID: 107
+            │
+            ├── • MakeIndexAbsent
+            │     IndexID: 4
+            │     TableID: 107
+            │
+            ├── • CreateGCJobForIndex
+            │     IndexID: 4
+            │     StatementForDropJob:
+            │       Rollback: true
+            │       Statement: DROP TYPE defaultdb.public.greeting CASCADE
+            │     TableID: 107
+            │
+            ├── • RemoveJobStateFromDescriptor
+            │     DescriptorID: 104
+            │     JobID: 1
+            │
+            ├── • RemoveJobStateFromDescriptor
+            │     DescriptorID: 105
+            │     JobID: 1
+            │
+            ├── • RemoveJobStateFromDescriptor
+            │     DescriptorID: 106
+            │     JobID: 1
+            │
+            ├── • RemoveJobStateFromDescriptor
+            │     DescriptorID: 107
+            │     JobID: 1
+            │
+            └── • UpdateSchemaChangerJob
+                  DescriptorIDsToRemove:
+                  - 104
+                  - 105
+                  - 106
+                  - 107
+                  IsNonCancelable: true
+                  JobID: 1
+                  RunningStatus: all stages completed

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_type_cascade.rollback_7_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_type_cascade.rollback_7_of_7
@@ -1,0 +1,350 @@
+/* setup */
+SET experimental_enable_unique_without_index_constraints = true;
+CREATE TYPE greeting AS ENUM('hello', 'hi');
+CREATE VIEW view AS SELECT 'hi'::greeting::string AS c;
+CREATE TABLE tbl (
+  id INT PRIMARY KEY,
+  gs greeting AS ('hi'::greeting) STORED,
+  gv string AS ('hello'::greeting::STRING) VIRTUAL,
+  other greeting[],
+  name STRING NOT NULL DEFAULT 'noname',
+  CONSTRAINT mycheck CHECK (gs::STRING = name),
+  CONSTRAINT myuwi UNIQUE WITHOUT INDEX (name) WHERE ('hi'::greeting::STRING = 'hi'),
+  INDEX partial (name) WHERE (gs::STRING = 'hi')
+);
+
+/* test */
+DROP TYPE greeting CASCADE;
+EXPLAIN (ddl, verbose) rollback at post-commit stage 7 of 7;
+----
+• Schema change plan for rolling back DROP TYPE ‹defaultdb›.‹public›.‹greeting› CASCADE;
+│
+└── • PostCommitNonRevertiblePhase
+    │
+    ├── • Stage 1 of 2 in PostCommitNonRevertiblePhase
+    │   │
+    │   ├── • 11 elements transitioning toward PUBLIC
+    │   │   │
+    │   │   ├── • Column:{DescID: 107, ColumnID: 2}
+    │   │   │   │ WRITE_ONLY → PUBLIC
+    │   │   │   │
+    │   │   │   ├── • PreviousStagePrecedence dependency from WRITE_ONLY Column:{DescID: 107, ColumnID: 2}
+    │   │   │   │     rule: "Column transitions to PUBLIC uphold 2-version invariant: WRITE_ONLY->PUBLIC"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC ColumnName:{DescID: 107, Name: gs, ColumnID: 2}
+    │   │   │   │     rule: "column dependents exist before column becomes public"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC ColumnType:{DescID: 107, ReferencedTypeIDs: [104 105], ColumnFamilyID: 0, ColumnID: 2}
+    │   │   │   │     rule: "column dependents exist before column becomes public"
+    │   │   │   │
+    │   │   │   └── • Precedence dependency from PUBLIC IndexColumn:{DescID: 107, ColumnID: 2, IndexID: 1}
+    │   │   │         rule: "column dependents exist before column becomes public"
+    │   │   │
+    │   │   ├── • ColumnName:{DescID: 107, Name: gs, ColumnID: 2}
+    │   │   │     ABSENT → PUBLIC
+    │   │   │
+    │   │   ├── • Column:{DescID: 107, ColumnID: 3}
+    │   │   │   │ WRITE_ONLY → PUBLIC
+    │   │   │   │
+    │   │   │   ├── • SameStagePrecedence dependency from PUBLIC Column:{DescID: 107, ColumnID: 2}
+    │   │   │   │     rule: "ensure columns are in increasing order"
+    │   │   │   │
+    │   │   │   ├── • PreviousStagePrecedence dependency from WRITE_ONLY Column:{DescID: 107, ColumnID: 3}
+    │   │   │   │     rule: "Column transitions to PUBLIC uphold 2-version invariant: WRITE_ONLY->PUBLIC"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC ColumnName:{DescID: 107, Name: gv, ColumnID: 3}
+    │   │   │   │     rule: "column dependents exist before column becomes public"
+    │   │   │   │
+    │   │   │   └── • Precedence dependency from PUBLIC ColumnType:{DescID: 107, ReferencedTypeIDs: [104 105], ColumnFamilyID: 0, ColumnID: 3}
+    │   │   │         rule: "column dependents exist before column becomes public"
+    │   │   │
+    │   │   ├── • ColumnName:{DescID: 107, Name: gv, ColumnID: 3}
+    │   │   │     ABSENT → PUBLIC
+    │   │   │
+    │   │   ├── • Column:{DescID: 107, ColumnID: 4}
+    │   │   │   │ WRITE_ONLY → PUBLIC
+    │   │   │   │
+    │   │   │   ├── • SameStagePrecedence dependency from PUBLIC Column:{DescID: 107, ColumnID: 2}
+    │   │   │   │     rule: "ensure columns are in increasing order"
+    │   │   │   │
+    │   │   │   ├── • SameStagePrecedence dependency from PUBLIC Column:{DescID: 107, ColumnID: 3}
+    │   │   │   │     rule: "ensure columns are in increasing order"
+    │   │   │   │
+    │   │   │   ├── • PreviousStagePrecedence dependency from WRITE_ONLY Column:{DescID: 107, ColumnID: 4}
+    │   │   │   │     rule: "Column transitions to PUBLIC uphold 2-version invariant: WRITE_ONLY->PUBLIC"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC ColumnName:{DescID: 107, Name: other, ColumnID: 4}
+    │   │   │   │     rule: "column dependents exist before column becomes public"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC ColumnType:{DescID: 107, ReferencedTypeIDs: [104 105], ColumnFamilyID: 0, ColumnID: 4}
+    │   │   │   │     rule: "column dependents exist before column becomes public"
+    │   │   │   │
+    │   │   │   └── • Precedence dependency from PUBLIC IndexColumn:{DescID: 107, ColumnID: 4, IndexID: 1}
+    │   │   │         rule: "column dependents exist before column becomes public"
+    │   │   │
+    │   │   ├── • ColumnName:{DescID: 107, Name: other, ColumnID: 4}
+    │   │   │     ABSENT → PUBLIC
+    │   │   │
+    │   │   ├── • SecondaryIndex:{DescID: 107, IndexID: 2, ConstraintID: 0}
+    │   │   │   │ VALIDATED → PUBLIC
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 107, ColumnID: 5, IndexID: 2}
+    │   │   │   │     rule: "index dependents exist before index becomes public"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 107, ColumnID: 1, IndexID: 2}
+    │   │   │   │     rule: "index dependents exist before index becomes public"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC SecondaryIndexPartial:{DescID: 107, IndexID: 2}
+    │   │   │   │     rule: "index dependents exist before index becomes public"
+    │   │   │   │
+    │   │   │   ├── • PreviousStagePrecedence dependency from VALIDATED SecondaryIndex:{DescID: 107, IndexID: 2, ConstraintID: 0}
+    │   │   │   │     rule: "SecondaryIndex transitions to PUBLIC uphold 2-version invariant: VALIDATED->PUBLIC"
+    │   │   │   │
+    │   │   │   └── • Precedence dependency from PUBLIC IndexName:{DescID: 107, Name: partial, IndexID: 2}
+    │   │   │         rule: "index dependents exist before index becomes public"
+    │   │   │
+    │   │   ├── • UniqueWithoutIndexConstraint:{DescID: 107, ConstraintID: 3}
+    │   │   │   │ VALIDATED → PUBLIC
+    │   │   │   │
+    │   │   │   ├── • PreviousStagePrecedence dependency from VALIDATED UniqueWithoutIndexConstraint:{DescID: 107, ConstraintID: 3}
+    │   │   │   │     rule: "UniqueWithoutIndexConstraint transitions to PUBLIC uphold 2-version invariant: VALIDATED->PUBLIC"
+    │   │   │   │
+    │   │   │   └── • SameStagePrecedence dependency from PUBLIC ConstraintWithoutIndexName:{DescID: 107, Name: myuwi, ConstraintID: 3}
+    │   │   │         rule: "constraint dependent public right before constraint"
+    │   │   │
+    │   │   ├── • ConstraintWithoutIndexName:{DescID: 107, Name: myuwi, ConstraintID: 3}
+    │   │   │     ABSENT → PUBLIC
+    │   │   │
+    │   │   ├── • CheckConstraint:{DescID: 107, IndexID: 0, ConstraintID: 2}
+    │   │   │   │ VALIDATED → PUBLIC
+    │   │   │   │
+    │   │   │   ├── • PreviousStagePrecedence dependency from VALIDATED CheckConstraint:{DescID: 107, IndexID: 0, ConstraintID: 2}
+    │   │   │   │     rule: "CheckConstraint transitions to PUBLIC uphold 2-version invariant: VALIDATED->PUBLIC"
+    │   │   │   │
+    │   │   │   └── • SameStagePrecedence dependency from PUBLIC ConstraintWithoutIndexName:{DescID: 107, Name: mycheck, ConstraintID: 2}
+    │   │   │         rule: "constraint dependent public right before constraint"
+    │   │   │
+    │   │   └── • ConstraintWithoutIndexName:{DescID: 107, Name: mycheck, ConstraintID: 2}
+    │   │         ABSENT → PUBLIC
+    │   │
+    │   ├── • 6 elements transitioning toward ABSENT
+    │   │   │
+    │   │   ├── • PrimaryIndex:{DescID: 107, IndexID: 3, ConstraintID: 4, TemporaryIndexID: 4, SourceIndexID: 1}
+    │   │   │   │ WRITE_ONLY → DELETE_ONLY
+    │   │   │   │
+    │   │   │   └── • PreviousStagePrecedence dependency from WRITE_ONLY PrimaryIndex:{DescID: 107, IndexID: 3, ConstraintID: 4, TemporaryIndexID: 4, SourceIndexID: 1}
+    │   │   │         rule: "PrimaryIndex transitions to ABSENT uphold 2-version invariant: WRITE_ONLY->DELETE_ONLY"
+    │   │   │
+    │   │   ├── • IndexColumn:{DescID: 107, ColumnID: 1, IndexID: 3}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   └── • skip PUBLIC → ABSENT operations
+    │   │   │         rule: "skip index-column removal ops on index removal"
+    │   │   │
+    │   │   ├── • IndexColumn:{DescID: 107, ColumnID: 5, IndexID: 3}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   └── • skip PUBLIC → ABSENT operations
+    │   │   │         rule: "skip index-column removal ops on index removal"
+    │   │   │
+    │   │   ├── • TemporaryIndex:{DescID: 107, IndexID: 4, ConstraintID: 5, SourceIndexID: 1}
+    │   │   │   │ WRITE_ONLY → DELETE_ONLY
+    │   │   │   │
+    │   │   │   └── • PreviousStagePrecedence dependency from WRITE_ONLY TemporaryIndex:{DescID: 107, IndexID: 4, ConstraintID: 5, SourceIndexID: 1}
+    │   │   │         rule: "TemporaryIndex transitions to ABSENT uphold 2-version invariant: WRITE_ONLY->DELETE_ONLY"
+    │   │   │
+    │   │   ├── • IndexColumn:{DescID: 107, ColumnID: 1, IndexID: 4}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   └── • skip PUBLIC → ABSENT operations
+    │   │   │         rule: "skip index-column removal ops on index removal"
+    │   │   │
+    │   │   └── • IndexColumn:{DescID: 107, ColumnID: 5, IndexID: 4}
+    │   │       │ PUBLIC → ABSENT
+    │   │       │
+    │   │       └── • skip PUBLIC → ABSENT operations
+    │   │             rule: "skip index-column removal ops on index removal"
+    │   │
+    │   └── • 22 Mutation operations
+    │       │
+    │       ├── • SetColumnName
+    │       │     ColumnID: 2
+    │       │     Name: gs
+    │       │     TableID: 107
+    │       │
+    │       ├── • SetColumnName
+    │       │     ColumnID: 3
+    │       │     Name: gv
+    │       │     TableID: 107
+    │       │
+    │       ├── • SetColumnName
+    │       │     ColumnID: 4
+    │       │     Name: other
+    │       │     TableID: 107
+    │       │
+    │       ├── • MakeValidatedSecondaryIndexPublic
+    │       │     IndexID: 2
+    │       │     TableID: 107
+    │       │
+    │       ├── • RefreshStats
+    │       │     TableID: 107
+    │       │
+    │       ├── • SetConstraintName
+    │       │     ConstraintID: 3
+    │       │     Name: myuwi
+    │       │     TableID: 107
+    │       │
+    │       ├── • SetConstraintName
+    │       │     ConstraintID: 2
+    │       │     Name: mycheck
+    │       │     TableID: 107
+    │       │
+    │       ├── • MakeWriteOnlyIndexDeleteOnly
+    │       │     IndexID: 3
+    │       │     TableID: 107
+    │       │
+    │       ├── • MakeWriteOnlyIndexDeleteOnly
+    │       │     IndexID: 4
+    │       │     TableID: 107
+    │       │
+    │       ├── • MakeWriteOnlyColumnPublic
+    │       │     ColumnID: 2
+    │       │     TableID: 107
+    │       │
+    │       ├── • RefreshStats
+    │       │     TableID: 107
+    │       │
+    │       ├── • MakeWriteOnlyColumnPublic
+    │       │     ColumnID: 3
+    │       │     TableID: 107
+    │       │
+    │       ├── • RefreshStats
+    │       │     TableID: 107
+    │       │
+    │       ├── • MakeWriteOnlyColumnPublic
+    │       │     ColumnID: 4
+    │       │     TableID: 107
+    │       │
+    │       ├── • RefreshStats
+    │       │     TableID: 107
+    │       │
+    │       ├── • MakeValidatedUniqueWithoutIndexConstraintPublic
+    │       │     ConstraintID: 3
+    │       │     TableID: 107
+    │       │
+    │       ├── • MakeValidatedCheckConstraintPublic
+    │       │     ConstraintID: 2
+    │       │     TableID: 107
+    │       │
+    │       ├── • SetJobStateOnDescriptor
+    │       │     DescriptorID: 104
+    │       │
+    │       ├── • SetJobStateOnDescriptor
+    │       │     DescriptorID: 105
+    │       │
+    │       ├── • SetJobStateOnDescriptor
+    │       │     DescriptorID: 106
+    │       │
+    │       ├── • SetJobStateOnDescriptor
+    │       │     DescriptorID: 107
+    │       │
+    │       └── • UpdateSchemaChangerJob
+    │             IsNonCancelable: true
+    │             JobID: 1
+    │             RunningStatus: PostCommitNonRevertiblePhase stage 2 of 2 with 4 MutationType ops pending
+    │
+    └── • Stage 2 of 2 in PostCommitNonRevertiblePhase
+        │
+        ├── • 4 elements transitioning toward ABSENT
+        │   │
+        │   ├── • PrimaryIndex:{DescID: 107, IndexID: 3, ConstraintID: 4, TemporaryIndexID: 4, SourceIndexID: 1}
+        │   │   │ DELETE_ONLY → ABSENT
+        │   │   │
+        │   │   ├── • PreviousStagePrecedence dependency from DELETE_ONLY PrimaryIndex:{DescID: 107, IndexID: 3, ConstraintID: 4, TemporaryIndexID: 4, SourceIndexID: 1}
+        │   │   │     rule: "PrimaryIndex transitions to ABSENT uphold 2-version invariant: DELETE_ONLY->ABSENT"
+        │   │   │
+        │   │   ├── • Precedence dependency from ABSENT IndexName:{DescID: 107, Name: tbl_pkey, IndexID: 3}
+        │   │   │     rule: "dependents removed before index"
+        │   │   │
+        │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 107, ColumnID: 1, IndexID: 3}
+        │   │   │     rule: "dependents removed before index"
+        │   │   │
+        │   │   └── • Precedence dependency from ABSENT IndexColumn:{DescID: 107, ColumnID: 5, IndexID: 3}
+        │   │         rule: "dependents removed before index"
+        │   │
+        │   ├── • IndexData:{DescID: 107, IndexID: 3}
+        │   │   │ PUBLIC → ABSENT
+        │   │   │
+        │   │   └── • Precedence dependency from ABSENT PrimaryIndex:{DescID: 107, IndexID: 3, ConstraintID: 4, TemporaryIndexID: 4, SourceIndexID: 1}
+        │   │         rule: "index removed before garbage collection"
+        │   │
+        │   ├── • TemporaryIndex:{DescID: 107, IndexID: 4, ConstraintID: 5, SourceIndexID: 1}
+        │   │   │ DELETE_ONLY → ABSENT
+        │   │   │
+        │   │   ├── • PreviousStagePrecedence dependency from DELETE_ONLY TemporaryIndex:{DescID: 107, IndexID: 4, ConstraintID: 5, SourceIndexID: 1}
+        │   │   │     rule: "TemporaryIndex transitions to ABSENT uphold 2-version invariant: DELETE_ONLY->ABSENT"
+        │   │   │
+        │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 107, ColumnID: 1, IndexID: 4}
+        │   │   │     rule: "dependents removed before index"
+        │   │   │
+        │   │   └── • Precedence dependency from ABSENT IndexColumn:{DescID: 107, ColumnID: 5, IndexID: 4}
+        │   │         rule: "dependents removed before index"
+        │   │
+        │   └── • IndexData:{DescID: 107, IndexID: 4}
+        │       │ PUBLIC → ABSENT
+        │       │
+        │       ├── • SameStagePrecedence dependency from DROPPED IndexData:{DescID: 107, IndexID: 3}
+        │       │     rule: "schedule all GC jobs for a descriptor in the same stage"
+        │       │
+        │       └── • Precedence dependency from ABSENT TemporaryIndex:{DescID: 107, IndexID: 4, ConstraintID: 5, SourceIndexID: 1}
+        │             rule: "index removed before garbage collection"
+        │
+        └── • 9 Mutation operations
+            │
+            ├── • MakeIndexAbsent
+            │     IndexID: 3
+            │     TableID: 107
+            │
+            ├── • CreateGCJobForIndex
+            │     IndexID: 3
+            │     StatementForDropJob:
+            │       Rollback: true
+            │       Statement: DROP TYPE defaultdb.public.greeting CASCADE
+            │     TableID: 107
+            │
+            ├── • MakeIndexAbsent
+            │     IndexID: 4
+            │     TableID: 107
+            │
+            ├── • CreateGCJobForIndex
+            │     IndexID: 4
+            │     StatementForDropJob:
+            │       Rollback: true
+            │       Statement: DROP TYPE defaultdb.public.greeting CASCADE
+            │     TableID: 107
+            │
+            ├── • RemoveJobStateFromDescriptor
+            │     DescriptorID: 104
+            │     JobID: 1
+            │
+            ├── • RemoveJobStateFromDescriptor
+            │     DescriptorID: 105
+            │     JobID: 1
+            │
+            ├── • RemoveJobStateFromDescriptor
+            │     DescriptorID: 106
+            │     JobID: 1
+            │
+            ├── • RemoveJobStateFromDescriptor
+            │     DescriptorID: 107
+            │     JobID: 1
+            │
+            └── • UpdateSchemaChangerJob
+                  DescriptorIDsToRemove:
+                  - 104
+                  - 105
+                  - 106
+                  - 107
+                  IsNonCancelable: true
+                  JobID: 1
+                  RunningStatus: all stages completed


### PR DESCRIPTION
Recently, we've added support for constraint removal in the declarative
schema changer. This now makes it possible to support DROP TYPE ...
CASCADE statements. As a result, DROP OWNED BY now also performs
correctly when user-defined types are involved and no longer returns an
error.

This commit also extends the coverage of the declarative schema
changer's ALTER TABLE ... DROP COLUMN support, which no longer punts to
the legacy schema changer when the column to drop is referenced in
a constraint. Now, the constraint gets dropped.

Fixes #51480.
Fixes #55908.

Release note (sql change): DROP TYPE ... CASCADE is now supported and no
longer returns an error. Consequently DROP OWNED BY no longer returns an
error when it tries to drop a type in a cascading manner.