### PR TITLE
release-22.2: Revert "sql: improve stack trace for get-user-timeout timeouts"

### DIFF
--- a/pkg/util/contextutil/context.go
+++ b/pkg/util/contextutil/context.go
@@ -79,18 +79,6 @@ func wrap(ctx context.Context, cancel context.CancelFunc) (context.Context, cont
 	}
 }
 
-// ctxWithStacktrace overrides Err to annotate context.DeadlineExceeded and
-// context.Canceled errors with a stacktrace.
-// See: https://github.com/cockroachdb/cockroach/issues/95794
-type ctxWithStacktrace struct {
-	context.Context
-}
-
-// Err implements the context.Context interface.
-func (ctx *ctxWithStacktrace) Err() error {
-	return errors.WithStack(ctx.Context.Err())
-}
-
 // RunWithTimeout runs a function with a timeout, the same way you'd do with
 // context.WithTimeout. It improves the opaque error messages returned by
 // WithTimeout by augmenting them with the op string that is passed in.
@@ -98,7 +86,6 @@ func RunWithTimeout(
 	ctx context.Context, op string, timeout time.Duration, fn func(ctx context.Context) error,
 ) error {
 	ctx, cancel := context.WithTimeout(ctx, timeout)
-	ctx = &ctxWithStacktrace{Context: ctx}
 	defer cancel()
 	start := timeutil.Now()
 	err := fn(ctx)

--- a/pkg/util/contextutil/context_test.go
+++ b/pkg/util/contextutil/context_test.go
@@ -12,7 +12,6 @@ package contextutil
 
 import (
 	"context"
-	"fmt"
 	"net"
 	"testing"
 	"time"
@@ -69,24 +68,6 @@ func TestRunWithTimeout(t *testing.T) {
 	if !errors.Is(err, context.DeadlineExceeded) {
 		t.Fatalf("RunWithTimeout should return an error with a DeadlineExceeded cause")
 	}
-}
-
-func testFuncA(ctx context.Context) error {
-	return testFuncB(ctx)
-}
-
-func testFuncB(ctx context.Context) error {
-	<-ctx.Done()
-	return ctx.Err()
-}
-
-func TestRunWithTimeoutCtxWithStacktrace(t *testing.T) {
-	ctx := context.Background()
-	err := RunWithTimeout(ctx, "foo", 1, testFuncA)
-	require.Error(t, err)
-	stacktrace := fmt.Sprintf("%+v", err)
-	require.Contains(t, stacktrace, "testFuncB")
-	require.Contains(t, stacktrace, "testFuncA")
 }
 
 // TestRunWithTimeoutWithoutDeadlineExceeded ensures that when a timeout on the


### PR DESCRIPTION
This reverts commit f366520210152c6cd7c144f1df92c281c144061f.

gRPC does not expect the context to be wrapped, so it can get confused.

Release justification: revert risky change
Epic: None
Release note: None