### PR TITLE
ui: fix time scale selection

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/api/indexDetailsApi.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/api/indexDetailsApi.ts
@@ -20,7 +20,7 @@ import {
   StatementRawFormat,
 } from "src/api";
 import moment from "moment";
-import { TimeScale, toDateRange } from "../timeScaleDropdown";
+import { TimeScale, toRoundedDateRange } from "../timeScaleDropdown";
 import { AggregateStatistics } from "../statementsTable";
 import { INTERNAL_APP_NAME_PREFIX } from "../recentExecutions/recentStatementUtils";
 
@@ -79,7 +79,7 @@ export function StatementsListRequestFromDetails(
   ts: TimeScale,
 ): StatementsUsingIndexRequest {
   if (ts === null) return { table, index, database };
-  const [start, end] = toDateRange(ts);
+  const [start, end] = toRoundedDateRange(ts);
   return { table, index, database, start, end };
 }
 


### PR DESCRIPTION
When making a call to retrieve the list of fingerprints per index, it was suppose to use the round dates from the time picker, otherwise it wouldn't get the rounded hour that has the aggregated timestamp.

Epic: None
Release note: None