### PR TITLE
pkg/util/metric: fix HistogramMode for streamingingest histograms

### DIFF
--- a/pkg/ccl/streamingccl/streamingest/metrics.go
+++ b/pkg/ccl/streamingccl/streamingest/metrics.go
@@ -155,7 +155,6 @@ func MakeMetrics(histogramWindow time.Duration) metric.Struct {
 			Buckets:  metric.BatchProcessLatencyBuckets,
 			MaxVal:   streamingFlushHistMaxLatency.Nanoseconds(),
 			SigFigs:  1,
-			Mode:     metric.HistogramModePreferHdrLatency,
 		}),
 		CommitLatency: metric.NewHistogram(metric.HistogramOptions{
 			Metadata: metaReplicationCommitLatency,
@@ -163,7 +162,6 @@ func MakeMetrics(histogramWindow time.Duration) metric.Struct {
 			Buckets:  metric.BatchProcessLatencyBuckets,
 			MaxVal:   streamingCommitLatencyMaxValue.Nanoseconds(),
 			SigFigs:  1,
-			Mode:     metric.HistogramModePreferHdrLatency,
 		}),
 		AdmitLatency: metric.NewHistogram(metric.HistogramOptions{
 			Metadata: metaReplicationAdmitLatency,
@@ -171,7 +169,6 @@ func MakeMetrics(histogramWindow time.Duration) metric.Struct {
 			Buckets:  metric.BatchProcessLatencyBuckets,
 			MaxVal:   streamingAdmitLatencyMaxValue.Nanoseconds(),
 			SigFigs:  1,
-			Mode:     metric.HistogramModePreferHdrLatency,
 		}),
 		RunningCount:                metric.NewGauge(metaStreamsRunning),
 		EarliestDataCheckpointSpan:  metric.NewGauge(metaEarliestDataCheckpointSpan),

--- a/pkg/util/metric/aggmetric/agg_metric_test.go
+++ b/pkg/util/metric/aggmetric/agg_metric_test.go
@@ -13,7 +13,6 @@ package aggmetric_test
 import (
 	"bufio"
 	"bytes"
-	"fmt"
 	"sort"
 	"strings"
 	"testing"
@@ -93,7 +92,6 @@ func TestAggMetric(t *testing.T) {
 		g3.Inc(3)
 		g3.Dec(1)
 		f2.Update(1.5)
-		fmt.Println(r)
 		f3.Update(2.5)
 		h2.RecordValue(10)
 		h3.RecordValue(90)
@@ -105,7 +103,6 @@ func TestAggMetric(t *testing.T) {
 	})
 
 	t.Run("destroy", func(t *testing.T) {
-		fmt.Println(r)
 		g3.Unlink()
 		c2.Unlink()
 		f3.Unlink()


### PR DESCRIPTION
Ref: #96514

The above patch migrated all histogram constructors over to
use a generic constructor, which has the ability to specify
a HistogramMode. While preparing a backport of this patch,
I noticed that the following streamingest histograms were
incorrectly tagged with a HistogramMode of
HistogramModePreferHdrLatency:

1. FlushHistNanos
2. CommitLatency
3. AdmitLatency

If you look at the original migration, when HDR was still being
used, these histograms were *not* using the HDR latency defaults:

a82aa82#diff-1bc5bdba63149e8efeadce17e7eb62bb5cd1dcee22974b37881a627e13c0501dL137-L143

This patch fixes these histograms to no longer incorrectly specify
the HistogramModePreferHdrLatency mode in the histogram options.

This was also fixed in the backport PR https://github.com/cockroachdb/cockroach/pull/96514.

Release note: none

Part of https://github.com/cockroachdb/cockroach/issues/95833