### PR TITLE
backupccl,kvserver: adds a max_allowed_file_size_overage field to ExportRequest

### DIFF
--- a/pkg/ccl/backupccl/backup_processor.go
+++ b/pkg/ccl/backupccl/backup_processor.go
@@ -365,12 +365,13 @@ func runBackupProcessor(
 					}
 
 					req := &roachpb.ExportRequest{
-						RequestHeader:  roachpb.RequestHeaderFromSpan(span.span),
-						ResumeKeyTS:    span.firstKeyTS,
-						StartTime:      span.start,
-						MVCCFilter:     spec.MVCCFilter,
-						TargetFileSize: batcheval.ExportRequestTargetFileSize.Get(&clusterSettings.SV),
-						SplitMidKey:    splitMidKey,
+						RequestHeader:             roachpb.RequestHeaderFromSpan(span.span),
+						ResumeKeyTS:               span.firstKeyTS,
+						StartTime:                 span.start,
+						MVCCFilter:                spec.MVCCFilter,
+						TargetFileSize:            batcheval.ExportRequestTargetFileSize.Get(&clusterSettings.SV),
+						MaxAllowedFileSizeOverage: batcheval.ExportRequestMaxAllowedFileSizeOverage.Get(&clusterSettings.SV),
+						SplitMidKey:               splitMidKey,
 					}
 
 					// If we're doing re-attempts but are not yet in the priority regime,

--- a/pkg/roachpb/api.proto
+++ b/pkg/roachpb/api.proto
@@ -1649,6 +1649,12 @@ message ExportRequest {
   // range keys.
   bool export_fingerprint = 14;
 
+  // MaxAllowedFileSizeOverage controls the maximum size in excess of the
+  // TargetFileSize which an exported SST may be. If this value is positive and
+  // an SST would exceed this size (due to large rows or large numbers of
+  // versions), then the export will fail.
+  int64 max_allowed_file_size_overage = 15;
+
   reserved 2, 5, 7, 8, 11;
 
   // Next ID: 15


### PR DESCRIPTION
This change passes in the value of kv.bulk_sst.max_allowed_overage as an argument in the ExportRequest instead of reading it at the time of evaluation. This allows tenants to configure this setting to a desired value instead of always using the system tenants cluster setting value.

Informs: #69435

Release note: None