### PR TITLE
sql: don't propagate spans from local processors as metadata

### DIFF
--- a/pkg/server/node_tenant_test.go
+++ b/pkg/server/node_tenant_test.go
@@ -89,6 +89,7 @@ func TestNewSpanFields(t *testing.T) {
 		StructuredRecords          []tracingpb.StructuredRecord
 		StructuredRecordsSizeBytes int64
 		ChildrenMetadata           map[string]tracingpb.OperationMetadata
+		HasBarrier                 bool
 	}
 	_ = (*calcifiedRecordedSpan)((*tracingpb.RecordedSpan)(nil))
 }

--- a/pkg/sql/backfill/mvcc_index_merger.go
+++ b/pkg/sql/backfill/mvcc_index_merger.go
@@ -107,10 +107,10 @@ const indexBackfillMergeProgressReportInterval = 10 * time.Second
 func (ibm *IndexBackfillMerger) Run(ctx context.Context) {
 	opName := "IndexBackfillMerger"
 	ctx = logtags.AddTag(ctx, opName, int(ibm.spec.Table.ID))
-	ctx, span := execinfra.ProcessorSpan(ctx, opName)
+	ctx, span := execinfra.ProcessorSpan(ctx, ibm.flowCtx, opName)
 	defer span.Finish()
 	defer ibm.output.ProducerDone()
-	defer execinfra.SendTraceData(ctx, ibm.output)
+	defer execinfra.SendTraceData(ctx, ibm.flowCtx, ibm.output)
 
 	mu := struct {
 		syncutil.Mutex

--- a/pkg/sql/colexec/colbuilder/execplan.go
+++ b/pkg/sql/colexec/colbuilder/execplan.go
@@ -435,6 +435,7 @@ func (r opResult) createDiskBackedSort(
 			outputUnlimitedAllocator := colmem.NewAllocator(ctx, accounts[2], factory)
 			diskAccount := args.MonitorRegistry.CreateDiskAccount(ctx, flowCtx, opName, processorID)
 			es := colexecdisk.NewExternalSorter(
+				flowCtx,
 				sortUnlimitedAllocator,
 				mergeUnlimitedAllocator,
 				outputUnlimitedAllocator,

--- a/pkg/sql/colexec/colexecbase/simple_project_test.go
+++ b/pkg/sql/colexec/colexecbase/simple_project_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/colexec/colexecbase"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexec/colexectestutils"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexecop"
+	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -121,7 +122,7 @@ func TestSimpleProjectOpWithUnorderedSynchronizer(t *testing.T) {
 			for i := range parallelUnorderedSynchronizerInputs {
 				parallelUnorderedSynchronizerInputs[i].Root = inputs[i]
 			}
-			input = colexec.NewParallelUnorderedSynchronizer(testAllocator, parallelUnorderedSynchronizerInputs, &wg)
+			input = colexec.NewParallelUnorderedSynchronizer(&execinfra.FlowCtx{Local: true, Gateway: true}, testAllocator, parallelUnorderedSynchronizerInputs, &wg)
 			input = colexecbase.NewSimpleProjectOp(input, len(inputTypes), []uint32{0})
 			return colexecbase.NewConstOp(testAllocator, input, types.Int, constVal, 1)
 		})

--- a/pkg/sql/colexec/ordered_synchronizer_test.go
+++ b/pkg/sql/colexec/ordered_synchronizer_test.go
@@ -148,7 +148,7 @@ func TestOrderedSync(t *testing.T) {
 			typs[i] = types.Int
 		}
 		colexectestutils.RunTests(t, testAllocator, tc.sources, tc.expected, colexectestutils.OrderedVerifier, func(inputs []colexecop.Operator) (colexecop.Operator, error) {
-			return NewOrderedSynchronizer(testAllocator, execinfra.DefaultMemoryLimit, colexectestutils.MakeInputs(inputs), typs, tc.ordering, 0 /* tuplesToMerge */), nil
+			return NewOrderedSynchronizer(&execinfra.FlowCtx{Gateway: true}, testAllocator, execinfra.DefaultMemoryLimit, colexectestutils.MakeInputs(inputs), typs, tc.ordering, 0 /* tuplesToMerge */), nil
 		})
 	}
 }
@@ -189,7 +189,7 @@ func TestOrderedSyncRandomInput(t *testing.T) {
 		inputs[i].Root = colexectestutils.NewOpTestInput(testAllocator, batchSize, sources[i], typs)
 	}
 	ordering := colinfo.ColumnOrdering{{ColIdx: 0, Direction: encoding.Ascending}}
-	op := NewOrderedSynchronizer(testAllocator, execinfra.DefaultMemoryLimit, inputs, typs, ordering, 0 /* tuplesToMerge */)
+	op := NewOrderedSynchronizer(&execinfra.FlowCtx{Gateway: true}, testAllocator, execinfra.DefaultMemoryLimit, inputs, typs, ordering, 0 /* tuplesToMerge */)
 	op.Init(context.Background())
 	out := colexectestutils.NewOpTestOutput(op, expected)
 	if err := out.Verify(); err != nil {
@@ -218,7 +218,7 @@ func BenchmarkOrderedSynchronizer(b *testing.B) {
 	}
 
 	ordering := colinfo.ColumnOrdering{{ColIdx: 0, Direction: encoding.Ascending}}
-	op := NewOrderedSynchronizer(testAllocator, execinfra.DefaultMemoryLimit, inputs, typs, ordering, 0 /* tuplesToMerge */)
+	op := NewOrderedSynchronizer(&execinfra.FlowCtx{Gateway: true}, testAllocator, execinfra.DefaultMemoryLimit, inputs, typs, ordering, 0 /* tuplesToMerge */)
 	op.Init(ctx)
 
 	b.SetBytes(8 * int64(coldata.BatchSize()) * numInputs)

--- a/pkg/sql/colexec/ordered_synchronizer_tmpl.go
+++ b/pkg/sql/colexec/ordered_synchronizer_tmpl.go
@@ -57,7 +57,8 @@ const _TYPE_WIDTH = 0
 // stream are assumed to be ordered according to the same set of columns.
 type OrderedSynchronizer struct {
 	colexecop.InitHelper
-	span *tracing.Span
+	flowCtx *execinfra.FlowCtx
+	span    *tracing.Span
 
 	accountingHelper      colmem.SetAccountingHelper
 	inputs                []colexecargs.OpWithMetaInfo
@@ -107,6 +108,7 @@ func (o *OrderedSynchronizer) Child(nth int, verbose bool) execopnode.OpNode {
 // - tuplesToMerge, if positive, indicates the total number of tuples that will
 // be emitted by all inputs, use 0 if unknown.
 func NewOrderedSynchronizer(
+	flowCtx *execinfra.FlowCtx,
 	allocator *colmem.Allocator,
 	memoryLimit int64,
 	inputs []colexecargs.OpWithMetaInfo,
@@ -115,6 +117,7 @@ func NewOrderedSynchronizer(
 	tuplesToMerge int64,
 ) *OrderedSynchronizer {
 	os := &OrderedSynchronizer{
+		flowCtx:               flowCtx,
 		inputs:                inputs,
 		ordering:              ordering,
 		typs:                  typs,
@@ -232,7 +235,7 @@ func (o *OrderedSynchronizer) Init(ctx context.Context) {
 	if !o.InitHelper.Init(ctx) {
 		return
 	}
-	o.Ctx, o.span = execinfra.ProcessorSpan(o.Ctx, "ordered sync")
+	o.Ctx, o.span = execinfra.ProcessorSpan(o.Ctx, o.flowCtx, "ordered sync")
 	o.inputIndices = make([]int, len(o.inputs))
 	for i := range o.inputs {
 		o.inputs[i].Root.Init(o.Ctx)
@@ -252,7 +255,7 @@ func (o *OrderedSynchronizer) DrainMeta() []execinfrapb.ProducerMetadata {
 				o.span.RecordStructured(stats.GetStats())
 			}
 		}
-		if meta := execinfra.GetTraceDataAsMetadata(o.span); meta != nil {
+		if meta := execinfra.GetTraceDataAsMetadata(o.flowCtx, o.span); meta != nil {
 			bufferedMeta = append(bufferedMeta, *meta)
 		}
 	}

--- a/pkg/sql/colexec/parallel_unordered_synchronizer_test.go
+++ b/pkg/sql/colexec/parallel_unordered_synchronizer_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/colexecerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexecop"
 	"github.com/cockroachdb/cockroach/pkg/sql/colmem"
+	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
@@ -127,8 +128,7 @@ func TestParallelUnorderedSynchronizer(t *testing.T) {
 	ctx, cancelFn := context.WithCancel(context.Background())
 
 	var wg sync.WaitGroup
-	s := NewParallelUnorderedSynchronizer(testAllocator, inputs, &wg)
-	s.LocalPlan = true
+	s := NewParallelUnorderedSynchronizer(&execinfra.FlowCtx{Local: true, Gateway: true}, testAllocator, inputs, &wg)
 	s.Init(ctx)
 
 	t.Run(fmt.Sprintf("numInputs=%d/numBatches=%d/terminationScenario=%d", numInputs, numBatches, terminationScenario), func(t *testing.T) {
@@ -229,7 +229,7 @@ func TestUnorderedSynchronizerNoLeaksOnError(t *testing.T) {
 	}
 
 	var wg sync.WaitGroup
-	s := NewParallelUnorderedSynchronizer(testAllocator, inputs, &wg)
+	s := NewParallelUnorderedSynchronizer(&execinfra.FlowCtx{Local: true, Gateway: true}, testAllocator, inputs, &wg)
 	s.Init(ctx)
 	for {
 		if err := colexecerror.CatchVectorizedRuntimeError(func() { _ = s.Next() }); err != nil {
@@ -261,7 +261,7 @@ func BenchmarkParallelUnorderedSynchronizer(b *testing.B) {
 	}
 	var wg sync.WaitGroup
 	ctx, cancelFn := context.WithCancel(context.Background())
-	s := NewParallelUnorderedSynchronizer(testAllocator, inputs, &wg)
+	s := NewParallelUnorderedSynchronizer(&execinfra.FlowCtx{Local: true, Gateway: true}, testAllocator, inputs, &wg)
 	s.Init(ctx)
 	b.SetBytes(8 * int64(coldata.BatchSize()))
 	b.ResetTimer()

--- a/pkg/sql/colexec/serial_unordered_synchronizer.go
+++ b/pkg/sql/colexec/serial_unordered_synchronizer.go
@@ -31,7 +31,8 @@ import (
 // we want to run it in the RootTxn.
 type SerialUnorderedSynchronizer struct {
 	colexecop.InitHelper
-	span *tracing.Span
+	flowCtx *execinfra.FlowCtx
+	span    *tracing.Span
 
 	inputs []colexecargs.OpWithMetaInfo
 	// curSerialInputIdx indicates the index of the current input being consumed.
@@ -66,11 +67,13 @@ func (s *SerialUnorderedSynchronizer) Child(nth int, verbose bool) execopnode.Op
 
 // NewSerialUnorderedSynchronizer creates a new SerialUnorderedSynchronizer.
 func NewSerialUnorderedSynchronizer(
+	flowCtx *execinfra.FlowCtx,
 	inputs []colexecargs.OpWithMetaInfo,
 	serialInputIdxExclusiveUpperBound uint32,
 	exceedsInputIdxExclusiveUpperBoundError error,
 ) *SerialUnorderedSynchronizer {
 	return &SerialUnorderedSynchronizer{
+		flowCtx:                                 flowCtx,
 		inputs:                                  inputs,
 		serialInputIdxExclusiveUpperBound:       serialInputIdxExclusiveUpperBound,
 		exceedsInputIdxExclusiveUpperBoundError: exceedsInputIdxExclusiveUpperBoundError,
@@ -82,7 +85,7 @@ func (s *SerialUnorderedSynchronizer) Init(ctx context.Context) {
 	if !s.InitHelper.Init(ctx) {
 		return
 	}
-	s.Ctx, s.span = execinfra.ProcessorSpan(s.Ctx, "serial unordered sync")
+	s.Ctx, s.span = execinfra.ProcessorSpan(s.Ctx, s.flowCtx, "serial unordered sync")
 	for _, input := range s.inputs {
 		input.Root.Init(s.Ctx)
 	}
@@ -115,7 +118,7 @@ func (s *SerialUnorderedSynchronizer) DrainMeta() []execinfrapb.ProducerMetadata
 				s.span.RecordStructured(stats.GetStats())
 			}
 		}
-		if meta := execinfra.GetTraceDataAsMetadata(s.span); meta != nil {
+		if meta := execinfra.GetTraceDataAsMetadata(s.flowCtx, s.span); meta != nil {
 			bufferedMeta = append(bufferedMeta, *meta)
 		}
 	}

--- a/pkg/sql/colexec/serial_unordered_synchronizer_test.go
+++ b/pkg/sql/colexec/serial_unordered_synchronizer_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/colexec/colexecargs"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexec/colexectestutils"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexecop"
+	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
@@ -54,7 +55,9 @@ func TestSerialUnorderedSynchronizer(t *testing.T) {
 			},
 		}
 	}
-	s := NewSerialUnorderedSynchronizer(inputs,
+	s := NewSerialUnorderedSynchronizer(
+		&execinfra.FlowCtx{Gateway: true},
+		inputs,
 		0,   /* serialInputIdxExclusiveUpperBound */
 		nil, /* exceedsInputIdxExclusiveUpperBoundError */
 	)

--- a/pkg/sql/colfetcher/colbatch_direct_scan.go
+++ b/pkg/sql/colfetcher/colbatch_direct_scan.go
@@ -52,11 +52,7 @@ func (s *ColBatchDirectScan) Init(ctx context.Context) {
 	if !s.InitHelper.Init(ctx) {
 		return
 	}
-	// If tracing is enabled, we need to start a child span so that the only
-	// contention events present in the recording would be because of this
-	// fetcher. Note that ProcessorSpan method itself will check whether tracing
-	// is enabled.
-	s.Ctx, s.tracingSpan = execinfra.ProcessorSpan(s.Ctx, "colbatchdirectscan")
+	s.Ctx, s.tracingSpan = execinfra.ProcessorSpan(s.Ctx, s.flowCtx, "colbatchdirectscan")
 	var err error
 	s.deser, err = colserde.NewRecordBatchSerializer(s.resultTypes)
 	if err != nil {

--- a/pkg/sql/colfetcher/colbatch_scan.go
+++ b/pkg/sql/colfetcher/colbatch_scan.go
@@ -85,12 +85,12 @@ func (s *colBatchScanBase) GetRowsRead() int64 {
 
 // GetContentionInfo is part of the colexecop.KVReader interface.
 func (s *colBatchScanBase) GetContentionInfo() (time.Duration, []roachpb.ContentionEvent) {
-	return execstats.GetCumulativeContentionTime(s.Ctx, nil /* recording */)
+	return execstats.GetCumulativeContentionInfo(s.Ctx, nil /* recordingUpToBarrier */)
 }
 
 // GetScanStats is part of the colexecop.KVReader interface.
 func (s *colBatchScanBase) GetScanStats() execstats.ScanStats {
-	return execstats.GetScanStats(s.Ctx, nil /* recording */)
+	return execstats.GetScanStats(s.Ctx, nil /* recordingUpToBarrier */)
 }
 
 // Release implements the execreleasable.Releasable interface.

--- a/pkg/sql/colfetcher/index_join.go
+++ b/pkg/sql/colfetcher/index_join.go
@@ -409,7 +409,7 @@ func (s *ColIndexJoin) GetKVCPUTime() time.Duration {
 
 // GetContentionInfo is part of the colexecop.KVReader interface.
 func (s *ColIndexJoin) GetContentionInfo() (time.Duration, []roachpb.ContentionEvent) {
-	return execstats.GetCumulativeContentionTime(s.Ctx, nil /* recording */)
+	return execstats.GetCumulativeContentionInfo(s.Ctx, nil /* recordingUpToBarrier */)
 }
 
 // inputBatchSizeLimit is a batch size limit for the number of input rows that
@@ -663,7 +663,7 @@ func adjustMemEstimate(estimate int64) int64 {
 
 // GetScanStats is part of the colexecop.KVReader interface.
 func (s *ColIndexJoin) GetScanStats() execstats.ScanStats {
-	return execstats.GetScanStats(s.Ctx, nil /* recording */)
+	return execstats.GetScanStats(s.Ctx, nil /* recordingUpToBarrier */)
 }
 
 // Release implements the execinfra.Releasable interface.

--- a/pkg/sql/colflow/colrpc/colrpc_test.go
+++ b/pkg/sql/colflow/colrpc/colrpc_test.go
@@ -278,6 +278,7 @@ func TestOutboxInbox(t *testing.T) {
 			outboxConverterMemAcc := testMemMonitor.MakeBoundAccount()
 			defer outboxConverterMemAcc.Close(ctx)
 			outbox, err := NewOutbox(
+				&execinfra.FlowCtx{Gateway: false},
 				colmem.NewAllocator(outboxCtx, &outboxMemAcc, coldata.StandardColumnFactory),
 				&outboxConverterMemAcc, colexecargs.OpWithMetaInfo{Root: input}, typs, nil, /* getStats */
 			)
@@ -521,6 +522,7 @@ func TestInboxHostCtxCancellation(t *testing.T) {
 	outboxMemAcc := testMemMonitor.MakeBoundAccount()
 	defer outboxMemAcc.Close(outboxHostCtx)
 	outbox, err := NewOutbox(
+		&execinfra.FlowCtx{Gateway: false},
 		colmem.NewAllocator(outboxHostCtx, &outboxMemAcc, coldata.StandardColumnFactory),
 		testMemAcc, colexecargs.OpWithMetaInfo{Root: outboxInput}, typs, nil, /* getStats */
 	)
@@ -702,6 +704,7 @@ func TestOutboxInboxMetadataPropagation(t *testing.T) {
 				expectedMetadata = tc.overrideExpectedMetadata
 			}
 			outbox, err := NewOutbox(
+				&execinfra.FlowCtx{Gateway: false},
 				colmem.NewAllocator(ctx, &outboxMemAcc, coldata.StandardColumnFactory),
 				testMemAcc,
 				colexecargs.OpWithMetaInfo{
@@ -798,6 +801,7 @@ func BenchmarkOutboxInbox(b *testing.B) {
 	outboxMemAcc := testMemMonitor.MakeBoundAccount()
 	defer outboxMemAcc.Close(ctx)
 	outbox, err := NewOutbox(
+		&execinfra.FlowCtx{Gateway: false},
 		colmem.NewAllocator(ctx, &outboxMemAcc, coldata.StandardColumnFactory),
 		testMemAcc, colexecargs.OpWithMetaInfo{Root: input}, typs, nil, /* getStats */
 	)
@@ -863,6 +867,7 @@ func TestOutboxStreamIDPropagation(t *testing.T) {
 	outboxMemAcc := testMemMonitor.MakeBoundAccount()
 	defer outboxMemAcc.Close(ctx)
 	outbox, err := NewOutbox(
+		&execinfra.FlowCtx{Gateway: false},
 		colmem.NewAllocator(ctx, &outboxMemAcc, coldata.StandardColumnFactory),
 		testMemAcc, colexecargs.OpWithMetaInfo{Root: input}, typs, nil, /* getStats */
 	)

--- a/pkg/sql/colflow/colrpc/outbox_test.go
+++ b/pkg/sql/colflow/colrpc/outbox_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/colexecerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexecop"
 	"github.com/cockroachdb/cockroach/pkg/sql/colmem"
+	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
@@ -40,7 +41,7 @@ func TestOutboxCatchesPanics(t *testing.T) {
 		rpcLayer = makeMockFlowStreamRPCLayer()
 	)
 	input.Init(ctx)
-	outbox, err := NewOutbox(testAllocator, testMemAcc, colexecargs.OpWithMetaInfo{Root: input}, typs, nil /* getStats */)
+	outbox, err := NewOutbox(&execinfra.FlowCtx{Gateway: false}, testAllocator, testMemAcc, colexecargs.OpWithMetaInfo{Root: input}, typs, nil /* getStats */)
 	require.NoError(t, err)
 
 	// This test relies on the fact that BatchBuffer panics when there are no
@@ -96,6 +97,7 @@ func TestOutboxDrainsMetadataSources(t *testing.T) {
 	newOutboxWithMetaSources := func() (*Outbox, *uint32, error) {
 		var sourceDrained uint32
 		outbox, err := NewOutbox(
+			&execinfra.FlowCtx{Gateway: false},
 			testAllocator,
 			testMemAcc,
 			colexecargs.OpWithMetaInfo{

--- a/pkg/sql/colflow/flow_coordinator.go
+++ b/pkg/sql/colflow/flow_coordinator.go
@@ -267,7 +267,7 @@ func (f *BatchFlowCoordinator) pushError(err error) execinfra.ConsumerStatus {
 func (f *BatchFlowCoordinator) Run(ctx context.Context) {
 	status := execinfra.NeedMoreRows
 
-	ctx, span := execinfra.ProcessorSpan(ctx, "batch flow coordinator")
+	ctx, span := execinfra.ProcessorSpan(ctx, f.flowCtx, "batch flow coordinator")
 	if span != nil {
 		if span.IsVerbose() {
 			span.SetTag(execinfrapb.FlowIDTagKey, attribute.StringValue(f.flowCtx.ID.String()))
@@ -314,7 +314,7 @@ func (f *BatchFlowCoordinator) Run(ctx context.Context) {
 		for _, s := range f.input.StatsCollectors {
 			span.RecordStructured(s.GetStats())
 		}
-		if meta := execinfra.GetTraceDataAsMetadata(span); meta != nil {
+		if meta := execinfra.GetTraceDataAsMetadata(f.flowCtx, span); meta != nil {
 			status = f.output.PushBatch(nil /* batch */, meta)
 			if status == execinfra.ConsumerClosed {
 				return

--- a/pkg/sql/colflow/routers_test.go
+++ b/pkg/sql/colflow/routers_test.go
@@ -907,6 +907,7 @@ func TestHashRouterOneOutput(t *testing.T) {
 			converterMemAcc := tu.testMemMonitor.MakeBoundAccount()
 			defer converterMemAcc.Close(ctx)
 			r, routerOutputs := NewHashRouter(
+				&execinfra.FlowCtx{Gateway: true},
 				[]*colmem.Allocator{tu.testAllocator},
 				colexecargs.OpWithMetaInfo{
 					Root: colexectestutils.NewOpFixedSelTestInput(tu.testAllocator, sel, len(sel), data, typs),
@@ -1342,6 +1343,7 @@ func BenchmarkHashRouter(b *testing.B) {
 					defer converterMemAcc.Close(ctx)
 				}
 				r, outputs := NewHashRouter(
+					&execinfra.FlowCtx{Gateway: true},
 					allocators,
 					colexecargs.OpWithMetaInfo{Root: input},
 					typs,

--- a/pkg/sql/colflow/vectorized_flow_test.go
+++ b/pkg/sql/colflow/vectorized_flow_test.go
@@ -47,6 +47,7 @@ type callbackRemoteComponentCreator struct {
 var _ remoteComponentCreator = &callbackRemoteComponentCreator{}
 
 func (c callbackRemoteComponentCreator) newOutbox(
+	_ *execinfra.FlowCtx,
 	allocator *colmem.Allocator,
 	converterMemAcc *mon.BoundAccount,
 	input colexecargs.OpWithMetaInfo,
@@ -219,7 +220,7 @@ func TestDrainOnlyInputDAG(t *testing.T) {
 			require.Len(t, input.MetadataSources, 1)
 			inbox := colexec.MaybeUnwrapInvariantsChecker(input.MetadataSources[0].(colexecop.Operator)).(*colrpc.Inbox)
 			require.Len(t, inboxToNumInputTypes[inbox], numInputTypesToOutbox)
-			return colrpc.NewOutbox(allocator, converterMemAcc, input, typs, nil /* getStats */)
+			return colrpc.NewOutbox(&execinfra.FlowCtx{Gateway: false}, allocator, converterMemAcc, input, typs, nil /* getStats */)
 		},
 		newInboxFn: func(allocator *colmem.Allocator, typs []*types.T, streamID execinfrapb.StreamID) (*colrpc.Inbox, error) {
 			inbox, err := colrpc.NewInbox(allocator, typs, streamID)

--- a/pkg/sql/plan_node_to_row_source.go
+++ b/pkg/sql/plan_node_to_row_source.go
@@ -262,7 +262,7 @@ func (p *planNodeToRowSource) execStatsForTrace() *execinfrapb.ComponentStats {
 	// Propagate RUs from IO requests.
 	// TODO(drewk): we should consider propagating other stats for planNode
 	// operators.
-	scanStats := execstats.GetScanStats(p.Ctx(), p.ExecStatsTrace)
+	scanStats := execstats.GetScanStats(p.Ctx(), p.StructuredUpToBarrier)
 	if scanStats.ConsumedRU == 0 {
 		return nil
 	}

--- a/pkg/sql/rowexec/backfiller.go
+++ b/pkg/sql/rowexec/backfiller.go
@@ -90,10 +90,10 @@ func (*backfiller) MustBeStreaming() bool {
 func (b *backfiller) Run(ctx context.Context) {
 	opName := fmt.Sprintf("%sBackfiller", b.name)
 	ctx = logtags.AddTag(ctx, opName, int(b.spec.Table.ID))
-	ctx, span := execinfra.ProcessorSpan(ctx, opName)
+	ctx, span := execinfra.ProcessorSpan(ctx, b.flowCtx, opName)
 	defer span.Finish()
 	meta := b.doRun(ctx)
-	execinfra.SendTraceData(ctx, b.output)
+	execinfra.SendTraceData(ctx, b.flowCtx, b.output)
 	if emitHelper(ctx, b.output, &b.out, nil /* row */, meta, func(ctx context.Context) {}) {
 		b.output.ProducerDone()
 	}

--- a/pkg/sql/rowexec/indexbackfiller.go
+++ b/pkg/sql/rowexec/indexbackfiller.go
@@ -343,10 +343,10 @@ func (ib *indexBackfiller) Run(ctx context.Context) {
 	opName := "indexBackfillerProcessor"
 	ctx = logtags.AddTag(ctx, "job", ib.spec.JobID)
 	ctx = logtags.AddTag(ctx, opName, int(ib.spec.Table.ID))
-	ctx, span := execinfra.ProcessorSpan(ctx, opName)
+	ctx, span := execinfra.ProcessorSpan(ctx, ib.flowCtx, opName)
 	defer span.Finish()
 	defer ib.output.ProducerDone()
-	defer execinfra.SendTraceData(ctx, ib.output)
+	defer execinfra.SendTraceData(ctx, ib.flowCtx, ib.output)
 	defer ib.Close(ctx)
 
 	progCh := make(chan execinfrapb.RemoteProducerMetadata_BulkProcessorProgress)

--- a/pkg/sql/rowexec/inverted_joiner.go
+++ b/pkg/sql/rowexec/inverted_joiner.go
@@ -763,8 +763,8 @@ func (ij *invertedJoiner) execStatsForTrace() *execinfrapb.ComponentStats {
 	if !ok {
 		return nil
 	}
-	ij.scanStats = execstats.GetScanStats(ij.Ctx(), ij.ExecStatsTrace)
-	contentionTime, contentionEvents := execstats.GetCumulativeContentionTime(ij.Ctx(), ij.ExecStatsTrace)
+	ij.scanStats = execstats.GetScanStats(ij.Ctx(), ij.StructuredUpToBarrier)
+	contentionTime, contentionEvents := execstats.GetCumulativeContentionInfo(ij.Ctx(), ij.StructuredUpToBarrier)
 	ret := execinfrapb.ComponentStats{
 		Inputs: []execinfrapb.InputStats{is},
 		KV: execinfrapb.KVStats{

--- a/pkg/sql/rowexec/joinreader.go
+++ b/pkg/sql/rowexec/joinreader.go
@@ -1190,8 +1190,8 @@ func (jr *joinReader) execStatsForTrace() *execinfrapb.ComponentStats {
 		return nil
 	}
 
-	jr.scanStats = execstats.GetScanStats(jr.Ctx(), jr.ExecStatsTrace)
-	contentionTime, contentionEvents := execstats.GetCumulativeContentionTime(jr.Ctx(), jr.ExecStatsTrace)
+	jr.scanStats = execstats.GetScanStats(jr.Ctx(), jr.StructuredUpToBarrier)
+	contentionTime, contentionEvents := execstats.GetCumulativeContentionInfo(jr.Ctx(), jr.StructuredUpToBarrier)
 	ret := &execinfrapb.ComponentStats{
 		Inputs: []execinfrapb.InputStats{is},
 		KV: execinfrapb.KVStats{

--- a/pkg/sql/rowexec/sample_aggregator.go
+++ b/pkg/sql/rowexec/sample_aggregator.go
@@ -186,7 +186,7 @@ func newSampleAggregator(
 }
 
 func (s *sampleAggregator) pushTrailingMeta(ctx context.Context) {
-	execinfra.SendTraceData(ctx, s.Output)
+	execinfra.SendTraceData(ctx, s.FlowCtx, s.Output)
 }
 
 // Run is part of the Processor interface.

--- a/pkg/sql/rowexec/sampler.go
+++ b/pkg/sql/rowexec/sampler.go
@@ -49,7 +49,6 @@ type sketchInfo struct {
 type samplerProcessor struct {
 	execinfra.ProcessorBase
 
-	flowCtx         *execinfra.FlowCtx
 	input           execinfra.RowSource
 	memAcc          mon.BoundAccount
 	sr              stats.SampleReservoir
@@ -119,7 +118,6 @@ func newSamplerProcessor(
 	// enough.
 	memMonitor := execinfra.NewLimitedMonitor(ctx, flowCtx.Mon, flowCtx, "sampler-mem")
 	s := &samplerProcessor{
-		flowCtx:         flowCtx,
 		input:           input,
 		memAcc:          memMonitor.MakeBoundAccount(),
 		sketches:        make([]sketchInfo, len(spec.Sketches)),
@@ -218,7 +216,7 @@ func newSamplerProcessor(
 }
 
 func (s *samplerProcessor) pushTrailingMeta(ctx context.Context) {
-	execinfra.SendTraceData(ctx, s.Output)
+	execinfra.SendTraceData(ctx, s.FlowCtx, s.Output)
 }
 
 // Run is part of the Processor interface.
@@ -278,7 +276,7 @@ func (s *samplerProcessor) mainLoop(ctx context.Context) (earlyExit bool, err er
 				//  - if it is lower than cpuUsageMinThrottle, we do not throttle;
 				//  - if it is higher than cpuUsageMaxThrottle, we throttle all the way;
 				//  - in-between, we scale the idle time proportionally.
-				usage := s.flowCtx.Cfg.RuntimeStats.GetCPUCombinedPercentNorm()
+				usage := s.FlowCtx.Cfg.RuntimeStats.GetCPUCombinedPercentNorm()
 
 				if usage > cpuUsageMinThrottle {
 					fractionIdle := s.maxFractionIdle
@@ -308,7 +306,7 @@ func (s *samplerProcessor) mainLoop(ctx context.Context) (earlyExit bool, err er
 					case <-timer.C:
 						timer.Read = true
 						break
-					case <-s.flowCtx.Stopper().ShouldQuiesce():
+					case <-s.FlowCtx.Stopper().ShouldQuiesce():
 						break
 					}
 				}

--- a/pkg/sql/rowexec/tablereader.go
+++ b/pkg/sql/rowexec/tablereader.go
@@ -308,8 +308,8 @@ func (tr *tableReader) execStatsForTrace() *execinfrapb.ComponentStats {
 	if !ok {
 		return nil
 	}
-	tr.scanStats = execstats.GetScanStats(tr.Ctx(), tr.ExecStatsTrace)
-	contentionTime, contentionEvents := execstats.GetCumulativeContentionTime(tr.Ctx(), tr.ExecStatsTrace)
+	tr.scanStats = execstats.GetScanStats(tr.Ctx(), tr.StructuredUpToBarrier)
+	contentionTime, contentionEvents := execstats.GetCumulativeContentionInfo(tr.Ctx(), tr.StructuredUpToBarrier)
 	ret := &execinfrapb.ComponentStats{
 		KV: execinfrapb.KVStats{
 			BytesRead:           optional.MakeUint(uint64(tr.fetcher.GetBytesRead())),

--- a/pkg/sql/rowexec/zigzagjoiner.go
+++ b/pkg/sql/rowexec/zigzagjoiner.go
@@ -847,9 +847,9 @@ func (z *zigzagJoiner) ConsumerClosed() {
 
 // execStatsForTrace implements ProcessorBase.ExecStatsForTrace.
 func (z *zigzagJoiner) execStatsForTrace() *execinfrapb.ComponentStats {
-	z.scanStats = execstats.GetScanStats(z.Ctx(), z.ExecStatsTrace)
+	z.scanStats = execstats.GetScanStats(z.Ctx(), z.StructuredUpToBarrier)
 
-	contentionTime, contentionEvents := execstats.GetCumulativeContentionTime(z.Ctx(), z.ExecStatsTrace)
+	contentionTime, contentionEvents := execstats.GetCumulativeContentionInfo(z.Ctx(), z.StructuredUpToBarrier)
 	kvStats := execinfrapb.KVStats{
 		BytesRead:           optional.MakeUint(uint64(z.getBytesRead())),
 		ContentionTime:      optional.MakeTimeValue(contentionTime),

--- a/pkg/util/tracing/span_options.go
+++ b/pkg/util/tracing/span_options.go
@@ -63,10 +63,11 @@ type spanOptions struct {
 	// (for example for the purposes of the active spans registry), so the child
 	// span cannot simply be created as a root.
 	//
-	// For example, in the case of DistSQL, each processor in a flow has its own
-	// span, as a child of the flow. The DistSQL infrastructure organizes the
-	// collection of each processor span recording independently, without relying
-	// on collecting the recording of the flow's span.
+	// For example, in the case of DistSQL, each processor in a remote flow has
+	// its own span, as a child of the flow. The DistSQL infrastructure
+	// organizes the collection of each processor span recording (on the remote
+	// nodes) independently, without relying on collecting the recording of the
+	// flow's span.
 	ParentDoesNotCollectRecording bool
 	RemoteParent                  SpanMeta               // see WithRemoteParentFromSpanMeta
 	RefType                       spanReferenceType      // see WithFollowsFrom
@@ -328,10 +329,11 @@ func (o detachedRecording) apply(opts spanOptions) spanOptions {
 // relationship is still useful (for example for the purposes of the active
 // spans registry), so the child span cannot simply be created as a root.
 //
-// For example, in the case of DistSQL, each processor in a flow has its own
-// span, as a child of the flow. The DistSQL infrastructure organizes the
-// collection of each processor span recording independently, without relying
-// on collecting the recording of the flow's span.
+// For example, in the case of DistSQL, each processor in a remote flow has its
+// own span, as a child of the flow. The DistSQL infrastructure organizes the
+// collection of each processor span recording (on the remote nodes)
+// independently, without relying on collecting the recording of the flow's
+// span.
 //
 // In the case when the parent's recording is collected through the span
 // registry, this option is ignore since, in that case, we want as much info as
@@ -524,7 +526,8 @@ func (o hasBarrier) apply(opts spanOptions) spanOptions {
 // trace from the child while also providing a way for the parent to examine the
 // structured events that were recorded directly into the parent or its children
 // with no barrier. For example, this behavior allows us to attribute the
-// contention events precisely to the DistSQL processor that ran into them.
+// contention events precisely to the DistSQL processor, running on the gateway,
+// that ran into them.
 func WithHasBarrier() SpanOption {
 	return hasBarrierSingleton
 }

--- a/pkg/util/tracing/tracer.go
+++ b/pkg/util/tracing/tracer.go
@@ -986,6 +986,7 @@ func (t *Tracer) newSpan(
 	otelSpan oteltrace.Span,
 	netTr trace.Trace,
 	sterile bool,
+	hasBarrier bool,
 ) *Span {
 	if t.testing.MaintainAllocationCounters {
 		atomic.AddInt32(&t.spansCreated, 1)
@@ -994,7 +995,7 @@ func (t *Tracer) newSpan(
 	h.span.reset(
 		traceID, spanID, operation, goroutineID,
 		startTime, logTags, eventListeners, kind,
-		otelSpan, netTr, sterile)
+		otelSpan, netTr, sterile, hasBarrier)
 	return &h.span
 }
 
@@ -1199,7 +1200,7 @@ child operation: %s, tracer created at:
 	s := t.newSpan(
 		traceID, spanID, opName, uint64(goid.Get()),
 		startTime, opts.LogTags, opts.EventListeners, opts.SpanKind,
-		otelSpan, netTr, opts.Sterile)
+		otelSpan, netTr, opts.Sterile, opts.HasBarrier)
 
 	s.i.crdb.SetRecordingType(opts.recordingType())
 	s.i.crdb.parentSpanID = opts.parentSpanID()

--- a/pkg/util/tracing/tracingpb/recorded_span.proto
+++ b/pkg/util/tracing/tracingpb/recorded_span.proto
@@ -133,6 +133,9 @@ message RecordedSpan {
   // view of the various operations that are being traced as part of a span.
   map<string, OperationMetadata> children_metadata = 19 [(gogoproto.nullable) = false];
 
+  // True if there is a barrier between this span and its parent.
+  bool has_barrier = 21;
+
   reserved 5,6,10,11,15;
 }
 


### PR DESCRIPTION
**sql: improve how some exec stats are collected**

This commit improves how we collect the scan stats as well as the
contention information. Previously, we would analyze the recording of
a processor that could - in theory - include its children. In practice,
this wasn't the case since at the moment each processor creates
a tracing span with the detached option. However, the follow-up commit
will change that, so this commit clarifies how we do things.

In particular, it introduces a new notion of "barrier" between the
tracing spans, and we now insert a barrier between spans created for
DistSQL processors. The "disconnect" is a lot weaker than the detached
option with the only effect being not including the children behind the
barrier in a newly introduced method
`GetStructuredRecordingUpToBarrier`. This method is now utilized for
both the scan stats and the contention info. (Note that previously for
the latter we were using the "configured" recording which was an
overkill in case the verbose recording is used, and this is now fixed.)
Without this barrier, once the detached option is removed, a processor
could incorrectly think that it experienced contention when, in fact, it
was the processor's input which experienced it. We also cannot simply
look at the structured events of the processor's span while ignoring all
of its children because the contention events are not recorded into that
span directly. This notion of a "barrier" seems like the easiest
solution.

Release note: None

**sql: don't propagate spans from local processors as metadata**

This commit changes how we create tracing spans for components of the
flow on the gateway. Previously, we would always create them with the
detached option, and, as a result, we needed to collect the traces and
propagate them as metadata to be imported by the DistSQLReceiver into
the span of the flow on the gateway. However, this is not necessary to
do so on the gateway - we can just let the regular tracing behavior to
happen there. We only need to be careful about inserting the barrier
(introduced in the previous commit) to be able to attribute the
contention events and the scan stats to the correct processor.

The main benefit of this change is that we now preserve the hierarchy of
the tracing spans in the gateway flows making them much more
understandable when viewing via the jaeger. Perhaps this is also a minor
performance improvement since the native trace collection is probably
faster than having to import the trace data via the metadata, as was
done previously.

An additional improvement can be made to create the spans with the
detached recording only for the root components of the remote flows.
This is left as a TODO for now.

Epic: None

Release note: None