### PR TITLE
release-22.2: cloud/amazon: support external ID in AWS assume role

### DIFF
--- a/pkg/cloud/cloudpb/external_storage.go
+++ b/pkg/cloud/cloudpb/external_storage.go
@@ -10,6 +10,11 @@
 
 package cloudpb
 
+import (
+	"fmt"
+	"strings"
+)
+
 const (
 	// ExternalStorageAuthImplicit is used by ExternalStorage instances to
 	// indicate access via a node's "implicit" authorization (e.g. machine acct).
@@ -58,4 +63,36 @@ func (m *ExternalStorage) AccessIsWithExplicitAuth() bool {
 	default:
 		return false
 	}
+}
+
+const assumeRoleProviderExternalIDParam = "external_id"
+
+// EncodeAsString returns the string representation of the provider to be used
+// in URIs.
+func (p ExternalStorage_AssumeRoleProvider) EncodeAsString() string {
+	if p.Role == "" {
+		return ""
+	}
+
+	if p.ExternalID == "" {
+		return p.Role
+	}
+
+	return fmt.Sprintf("%s;%s=%s", p.Role, assumeRoleProviderExternalIDParam, p.ExternalID)
+
+}
+
+// DecodeRoleProviderString decodes a string into an
+// ExternalStorage_AssumeRoleProvider.
+func DecodeRoleProviderString(roleProviderString string) (p ExternalStorage_AssumeRoleProvider) {
+	parts := strings.Split(roleProviderString, ";")
+	p.Role = parts[0]
+
+	for pidx := 1; pidx < len(parts); pidx++ {
+		key, value, _ := strings.Cut(parts[pidx], "=")
+		if key == assumeRoleProviderExternalIDParam {
+			p.ExternalID = value
+		}
+	}
+	return p
 }

--- a/pkg/cloud/cloudpb/external_storage.proto
+++ b/pkg/cloud/cloudpb/external_storage.proto
@@ -38,6 +38,21 @@ message ExternalStorage {
   message Http {
     string baseUri = 1;
   }
+  // AssumeRoleProvider contains fields about the role that needs to be assumed
+  // in order to access the external storage.
+  message AssumeRoleProvider {
+    // Role, if non-empty, is the ARN of the AWS Role or the email address of
+    // the GCP Service Account that is being assumed.
+    string role = 1;
+    // ExternalID, if non-empty, is the external ID that must be passed along
+    // with the role in order to assume it. Some additional information about
+    // the issues that external IDs can address can be found on the AWS docs:
+    // https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_create_for-user_externalid.html
+    //
+    // Currently only AWS supports external ID, there is an open issue tracker
+    // for support in GCP: https://issuetracker.google.com/issues/217037003
+    string external_id = 2  [(gogoproto.customname) = "ExternalID"];
+  }
   message S3 {
     string bucket = 1;
     string prefix = 2;
@@ -54,12 +69,26 @@ message ExternalStorage {
 
     // RoleARN if non-empty, is the ARN of the role that should be assumed in
     // order to access this storage.
+    // TODO(rui): this field is currently kept for mixed-version state, remove
+    // in 23.2 in favor of AssumeRoleProvider.
     string role_arn = 12 [(gogoproto.customname) = "RoleARN"];
 
     // DelegateRoleARNs are the ARNs of intermediate roles in an assume role
     // chain. These roles will be assumed in the order they appear in the list
     // so that the role specified by RoleARN can be assumed.
+    // TODO(rui): this field is currently kept for mixed-version state, remove
+    // in 23.2 in favor of DelegateRoleProviders.
     repeated string delegate_role_arns = 13 [(gogoproto.customname) = "DelegateRoleARNs"];
+
+    // AssumeRoleProvider, if the role is non-empty, contains the ARN of the
+    // role that should be assumed in order to access this storage, as well as
+    // an optional external ID.
+    AssumeRoleProvider assume_role_provider = 14 [(gogoproto.nullable) = false];
+
+    // DelegateRoleProviders contain the ARNs of intermediate roles in an assume
+    // role chain. These roles will be assumed in the order they appear in the
+    // list so that the role specified in AssumeRoleProvider can be assumed.
+    repeated AssumeRoleProvider delegate_role_providers = 15 [(gogoproto.nullable) = false];
   }
   message GCS {
     string bucket = 1;


### PR DESCRIPTION
Backport 1/1 commits from #91040.

/cc @cockroachdb/release

---

Support passing in the optional external ID when assuming a role. This is done by extending the values of the comma-separated string value of the ASSUME_ROLE parameter to the format `<role>;external_id=<id>`. Users can still use the previous format of just `<role>` to specify a role without any external ID.

When using role chaining, each role in the chain can be associated with a different external ID. For example:
`ASSUME_ROLE=<roleA>;external_id=<idA>,<roleB>;external_id=<idB>,<roleC>` will use external ID `<idA>` to assume delegate `<roleA>`, then use external ID `<idB>` to assume delegate `<roleB>`, and finally no external ID to assume the final role `<roleC>`.

Additional documentation about external IDs can be found here: https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_create_for-user_externalid.html

Release note (enterprise change): Support passing in the optional external ID when assuming a role. This is done by extending the values of the comma-separated string value of the ASSUME_ROLE parameter to the format `<role>;external_id=<id>`. Users can still use the previous format of just `<role>` to specify a role without any external ID.

When using role chaining, each role in the chain can be associated with a different external ID. For example:
`ASSUME_ROLE=<roleA>;external_id=<idA>,<roleB>;external_id=<idB>,<roleC>` will use external ID `<idA>` to assume delegate `<roleA>`, then use external ID `<idB>` to assume delegate `<roleB>`, and finally no external ID to assume the final role `<roleC>`.

Addresses https://github.com/cockroachdb/cockroach/issues/90239

Release justification: low risk, high impact feature.