### PR TITLE
opt: simplify leak-proof boolean CASE statements

### DIFF
--- a/pkg/ccl/logictestccl/tests/3node-tenant/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/3node-tenant/generated_test.go
@@ -1501,6 +1501,13 @@ func TestTenantLogic_save_table(
 	runLogicTest(t, "save_table")
 }
 
+func TestTenantLogic_scalar(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "scalar")
+}
+
 func TestTenantLogic_scale(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/testdata/logic_test/scalar
+++ b/pkg/sql/logictest/testdata/logic_test/scalar
@@ -1,0 +1,383 @@
+# ------------------------------------------------------------------------------
+# Test with boolean CASE statements.
+# ------------------------------------------------------------------------------
+
+statement ok
+CREATE TABLE bools (a BOOL, b BOOL, c BOOL, d BOOL, e BOOL);
+INSERT INTO bools VALUES
+(True, True, True, True, True),
+(False, False, False, False, False),
+(True, False, True, False, True),
+(False, True, False, True, False),
+(True, False, False, False, False),
+(False, True, True, True, True),
+(True, False, True, True, True),
+(False, True, False, False, False),
+(NULL, True, True, True, True),
+(NULL, NULL, NULL, NULL, NULL),
+(True, NULL, True, NULL, True),
+(False, True, NULL, True, NULL),
+(True, NULL, NULL, NULL, NULL),
+(NULL, True, False, True, True),
+(True, NULL, True, True, True),
+(NULL, True, NULL, False, False);
+
+query BBBBBB rowsort
+SELECT CASE WHEN a THEN True WHEN b THEN True ELSE c END, * FROM bools;
+----
+true   true   true   true   true   true
+false  false  false  false  false  false
+true   true   false  true   false  true
+true   false  true   false  true   false
+true   true   false  false  false  false
+true   false  true   true   true   true
+true   true   false  true   true   true
+true   false  true   false  false  false
+true   NULL   true   true   true   true
+NULL   NULL   NULL   NULL   NULL   NULL
+true   true   NULL   true   NULL   true
+true   false  true   NULL   true   NULL
+true   true   NULL   NULL   NULL   NULL
+true   NULL   true   false  true   true
+true   true   NULL   true   true   true
+true   NULL   true   NULL   false  false
+
+query BBBBBB rowsort
+SELECT CASE WHEN a THEN True WHEN b THEN FALSE ELSE c END, * FROM bools;
+----
+true   true   true   true   true   true
+false  false  false  false  false  false
+true   true   false  true   false  true
+false  false  true   false  true   false
+true   true   false  false  false  false
+false  false  true   true   true   true
+true   true   false  true   true   true
+false  false  true   false  false  false
+false  NULL   true   true   true   true
+NULL   NULL   NULL   NULL   NULL   NULL
+true   true   NULL   true   NULL   true
+false  false  true   NULL   true   NULL
+true   true   NULL   NULL   NULL   NULL
+false  NULL   true   false  true   true
+true   true   NULL   true   true   true
+false  NULL   true   NULL   false  false
+
+query BBBBBB rowsort
+SELECT CASE WHEN a THEN False WHEN b THEN True ELSE c END, * FROM bools;
+----
+false  true   true   true   true   true
+false  false  false  false  false  false
+false  true   false  true   false  true
+true   false  true   false  true   false
+false  true   false  false  false  false
+true   false  true   true   true   true
+false  true   false  true   true   true
+true   false  true   false  false  false
+true   NULL   true   true   true   true
+NULL   NULL   NULL   NULL   NULL   NULL
+false  true   NULL   true   NULL   true
+true   false  true   NULL   true   NULL
+false  true   NULL   NULL   NULL   NULL
+true   NULL   true   false  true   true
+false  true   NULL   true   true   true
+true   NULL   true   NULL   false  false
+
+query BBBBBB rowsort
+SELECT CASE WHEN a THEN False WHEN b THEN False ELSE c END, * FROM bools;
+----
+false  true   true   true   true   true
+false  false  false  false  false  false
+false  true   false  true   false  true
+false  false  true   false  true   false
+false  true   false  false  false  false
+false  false  true   true   true   true
+false  true   false  true   true   true
+false  false  true   false  false  false
+false  NULL   true   true   true   true
+NULL   NULL   NULL   NULL   NULL   NULL
+false  true   NULL   true   NULL   true
+false  false  true   NULL   true   NULL
+false  true   NULL   NULL   NULL   NULL
+false  NULL   true   false  true   true
+false  true   NULL   true   true   true
+false  NULL   true   NULL   false  false
+
+query BBBBBB rowsort
+SELECT CASE False WHEN a THEN True WHEN b THEN True ELSE c END, * FROM bools;
+----
+true   true   true   true   true   true
+true   false  false  false  false  false
+true   true   false  true   false  true
+true   false  true   false  true   false
+true   true   false  false  false  false
+true   false  true   true   true   true
+true   true   false  true   true   true
+true   false  true   false  false  false
+true   NULL   true   true   true   true
+NULL   NULL   NULL   NULL   NULL   NULL
+true   true   NULL   true   NULL   true
+true   false  true   NULL   true   NULL
+NULL   true   NULL   NULL   NULL   NULL
+false  NULL   true   false  true   true
+true   true   NULL   true   true   true
+NULL   NULL   true   NULL   false  false
+
+query BBBBBB rowsort
+SELECT CASE False WHEN a THEN True WHEN b THEN FALSE ELSE c END, * FROM bools;
+----
+true   true   true   true   true   true
+true   false  false  false  false  false
+false  true   false  true   false  true
+true   false  true   false  true   false
+false  true   false  false  false  false
+true   false  true   true   true   true
+false  true   false  true   true   true
+true   false  true   false  false  false
+true   NULL   true   true   true   true
+NULL   NULL   NULL   NULL   NULL   NULL
+true   true   NULL   true   NULL   true
+true   false  true   NULL   true   NULL
+NULL   true   NULL   NULL   NULL   NULL
+false  NULL   true   false  true   true
+true   true   NULL   true   true   true
+NULL   NULL   true   NULL   false  false
+
+query BBBBBB rowsort
+SELECT CASE False WHEN a THEN False WHEN b THEN True ELSE c END, * FROM bools;
+----
+true   true   true   true   true   true
+false  false  false  false  false  false
+true   true   false  true   false  true
+false  false  true   false  true   false
+true   true   false  false  false  false
+false  false  true   true   true   true
+true   true   false  true   true   true
+false  false  true   false  false  false
+true   NULL   true   true   true   true
+NULL   NULL   NULL   NULL   NULL   NULL
+true   true   NULL   true   NULL   true
+false  false  true   NULL   true   NULL
+NULL   true   NULL   NULL   NULL   NULL
+false  NULL   true   false  true   true
+true   true   NULL   true   true   true
+NULL   NULL   true   NULL   false  false
+
+query BBBBBB rowsort
+SELECT CASE False WHEN a THEN False WHEN b THEN False ELSE c END, * FROM bools;
+----
+true   true   true   true   true   true
+false  false  false  false  false  false
+false  true   false  true   false  true
+false  false  true   false  true   false
+false  true   false  false  false  false
+false  false  true   true   true   true
+false  true   false  true   true   true
+false  false  true   false  false  false
+true   NULL   true   true   true   true
+NULL   NULL   NULL   NULL   NULL   NULL
+true   true   NULL   true   NULL   true
+false  false  true   NULL   true   NULL
+NULL   true   NULL   NULL   NULL   NULL
+false  NULL   true   false  true   true
+true   true   NULL   true   true   true
+NULL   NULL   true   NULL   false  false
+
+query BBBBBB rowsort
+SELECT CASE NULL WHEN a THEN True WHEN b THEN True WHEN NULL THEN True ELSE c END, * FROM bools;
+----
+true   true   true   true   true   true
+false  false  false  false  false  false
+true   true   false  true   false  true
+false  false  true   false  true   false
+false  true   false  false  false  false
+true   false  true   true   true   true
+true   true   false  true   true   true
+false  false  true   false  false  false
+true   NULL   true   true   true   true
+NULL   NULL   NULL   NULL   NULL   NULL
+true   true   NULL   true   NULL   true
+NULL   false  true   NULL   true   NULL
+NULL   true   NULL   NULL   NULL   NULL
+false  NULL   true   false  true   true
+true   true   NULL   true   true   true
+NULL   NULL   true   NULL   false  false
+
+query BBBBBB rowsort
+SELECT CASE NULL WHEN a THEN True WHEN b THEN False WHEN NULL THEN True ELSE c END, * FROM bools;
+----
+true   true   true   true   true   true
+false  false  false  false  false  false
+true   true   false  true   false  true
+false  false  true   false  true   false
+false  true   false  false  false  false
+true   false  true   true   true   true
+true   true   false  true   true   true
+false  false  true   false  false  false
+true   NULL   true   true   true   true
+NULL   NULL   NULL   NULL   NULL   NULL
+true   true   NULL   true   NULL   true
+NULL   false  true   NULL   true   NULL
+NULL   true   NULL   NULL   NULL   NULL
+false  NULL   true   false  true   true
+true   true   NULL   true   true   true
+NULL   NULL   true   NULL   false  false
+
+query BBBBBB rowsort
+SELECT CASE NULL WHEN a THEN False WHEN b THEN True WHEN NULL THEN True ELSE c END, * FROM bools;
+----
+true   true   true   true   true   true
+false  false  false  false  false  false
+true   true   false  true   false  true
+false  false  true   false  true   false
+false  true   false  false  false  false
+true   false  true   true   true   true
+true   true   false  true   true   true
+false  false  true   false  false  false
+true   NULL   true   true   true   true
+NULL   NULL   NULL   NULL   NULL   NULL
+true   true   NULL   true   NULL   true
+NULL   false  true   NULL   true   NULL
+NULL   true   NULL   NULL   NULL   NULL
+false  NULL   true   false  true   true
+true   true   NULL   true   true   true
+NULL   NULL   true   NULL   false  false
+
+query BBBBBB rowsort
+SELECT CASE NULL WHEN a THEN False WHEN b THEN False WHEN NULL THEN True ELSE c END, * FROM bools;
+----
+true   true   true   true   true   true
+false  false  false  false  false  false
+true   true   false  true   false  true
+false  false  true   false  true   false
+false  true   false  false  false  false
+true   false  true   true   true   true
+true   true   false  true   true   true
+false  false  true   false  false  false
+true   NULL   true   true   true   true
+NULL   NULL   NULL   NULL   NULL   NULL
+true   true   NULL   true   NULL   true
+NULL   false  true   NULL   true   NULL
+NULL   true   NULL   NULL   NULL   NULL
+false  NULL   true   false  true   true
+true   true   NULL   true   true   true
+NULL   NULL   true   NULL   false  false
+
+query BBBBBB rowsort
+SELECT CASE WHEN a OR b THEN True WHEN b AND c THEN True ELSE d OR NOT e END, * FROM bools;
+----
+true  true   true   true   true   true
+true  false  false  false  false  false
+true  true   false  true   false  true
+true  false  true   false  true   false
+true  true   false  false  false  false
+true  false  true   true   true   true
+true  true   false  true   true   true
+true  false  true   false  false  false
+true  NULL   true   true   true   true
+NULL  NULL   NULL   NULL   NULL   NULL
+true  true   NULL   true   NULL   true
+true  false  true   NULL   true   NULL
+true  true   NULL   NULL   NULL   NULL
+true  NULL   true   false  true   true
+true  true   NULL   true   true   true
+true  NULL   true   NULL   false  false
+
+query BBBBBB rowsort
+SELECT CASE WHEN a THEN NULL WHEN b THEN True ELSE c END, * FROM bools;
+----
+NULL   true   true   true   true   true
+false  false  false  false  false  false
+NULL   true   false  true   false  true
+true   false  true   false  true   false
+NULL   true   false  false  false  false
+true   false  true   true   true   true
+NULL   true   false  true   true   true
+true   false  true   false  false  false
+true   NULL   true   true   true   true
+NULL   NULL   NULL   NULL   NULL   NULL
+NULL   true   NULL   true   NULL   true
+true   false  true   NULL   true   NULL
+NULL   true   NULL   NULL   NULL   NULL
+true   NULL   true   false  true   true
+NULL   true   NULL   true   true   true
+true   NULL   true   NULL   false  false
+
+query BBBBBB rowsort
+SELECT CASE WHEN a THEN NULL WHEN b THEN FALSE ELSE c END, * FROM bools;
+----
+NULL   true   true   true   true   true
+false  false  false  false  false  false
+NULL   true   false  true   false  true
+false  false  true   false  true   false
+NULL   true   false  false  false  false
+false  false  true   true   true   true
+NULL   true   false  true   true   true
+false  false  true   false  false  false
+false  NULL   true   true   true   true
+NULL   NULL   NULL   NULL   NULL   NULL
+NULL   true   NULL   true   NULL   true
+false  false  true   NULL   true   NULL
+NULL   true   NULL   NULL   NULL   NULL
+false  NULL   true   false  true   true
+NULL   true   NULL   true   true   true
+false  NULL   true   NULL   false  false
+
+query BBBBBB rowsort
+SELECT CASE WHEN a THEN True WHEN b THEN NULL ELSE c END, * FROM bools;
+----
+true   true   true   true   true   true
+false  false  false  false  false  false
+true   true   false  true   false  true
+NULL   false  true   false  true   false
+true   true   false  false  false  false
+NULL   false  true   true   true   true
+true   true   false  true   true   true
+NULL   false  true   false  false  false
+NULL   NULL   true   true   true   true
+NULL   NULL   NULL   NULL   NULL   NULL
+true   true   NULL   true   NULL   true
+NULL   false  true   NULL   true   NULL
+true   true   NULL   NULL   NULL   NULL
+NULL   NULL   true   false  true   true
+true   true   NULL   true   true   true
+NULL   NULL   true   NULL   false  false
+
+query BBBBBB rowsort
+SELECT CASE WHEN a THEN False WHEN b THEN NULL ELSE c END, * FROM bools;
+----
+false  true   true   true   true   true
+false  false  false  false  false  false
+false  true   false  true   false  true
+NULL   false  true   false  true   false
+false  true   false  false  false  false
+NULL   false  true   true   true   true
+false  true   false  true   true   true
+NULL   false  true   false  false  false
+NULL   NULL   true   true   true   true
+NULL   NULL   NULL   NULL   NULL   NULL
+false  true   NULL   true   NULL   true
+NULL   false  true   NULL   true   NULL
+false  true   NULL   NULL   NULL   NULL
+NULL   NULL   true   false  true   true
+false  true   NULL   true   true   true
+NULL   NULL   true   NULL   false  false
+
+query BBBBBB rowsort
+SELECT CASE WHEN a THEN NULL WHEN b THEN NULL ELSE c END, * FROM bools;
+----
+NULL   true   true   true   true   true
+false  false  false  false  false  false
+NULL   true   false  true   false  true
+NULL   false  true   false  true   false
+NULL   true   false  false  false  false
+NULL   false  true   true   true   true
+NULL   true   false  true   true   true
+NULL   false  true   false  false  false
+NULL   NULL   true   true   true   true
+NULL   NULL   NULL   NULL   NULL   NULL
+NULL   true   NULL   true   NULL   true
+NULL   false  true   NULL   true   NULL
+NULL   true   NULL   NULL   NULL   NULL
+NULL   NULL   true   false  true   true
+NULL   true   NULL   true   true   true
+NULL   NULL   true   NULL   false  false

--- a/pkg/sql/logictest/tests/fakedist-disk/generated_test.go
+++ b/pkg/sql/logictest/tests/fakedist-disk/generated_test.go
@@ -1472,6 +1472,13 @@ func TestLogic_save_table(
 	runLogicTest(t, "save_table")
 }
 
+func TestLogic_scalar(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "scalar")
+}
+
 func TestLogic_scale(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/fakedist-vec-off/generated_test.go
+++ b/pkg/sql/logictest/tests/fakedist-vec-off/generated_test.go
@@ -1472,6 +1472,13 @@ func TestLogic_save_table(
 	runLogicTest(t, "save_table")
 }
 
+func TestLogic_scalar(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "scalar")
+}
+
 func TestLogic_scale(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/fakedist/generated_test.go
+++ b/pkg/sql/logictest/tests/fakedist/generated_test.go
@@ -1486,6 +1486,13 @@ func TestLogic_save_table(
 	runLogicTest(t, "save_table")
 }
 
+func TestLogic_scalar(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "scalar")
+}
+
 func TestLogic_scale(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/local-legacy-schema-changer/generated_test.go
+++ b/pkg/sql/logictest/tests/local-legacy-schema-changer/generated_test.go
@@ -1444,6 +1444,13 @@ func TestLogic_save_table(
 	runLogicTest(t, "save_table")
 }
 
+func TestLogic_scalar(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "scalar")
+}
+
 func TestLogic_scale(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/local-vec-off/generated_test.go
+++ b/pkg/sql/logictest/tests/local-vec-off/generated_test.go
@@ -1479,6 +1479,13 @@ func TestLogic_save_table(
 	runLogicTest(t, "save_table")
 }
 
+func TestLogic_scalar(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "scalar")
+}
+
 func TestLogic_scale(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/local/generated_test.go
+++ b/pkg/sql/logictest/tests/local/generated_test.go
@@ -1619,6 +1619,13 @@ func TestLogic_save_table(
 	runLogicTest(t, "save_table")
 }
 
+func TestLogic_scalar(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "scalar")
+}
+
 func TestLogic_scale(
 	t *testing.T,
 ) {

--- a/pkg/sql/opt/exec/execbuilder/testdata/udf
+++ b/pkg/sql/opt/exec/execbuilder/testdata/udf
@@ -294,3 +294,84 @@ vectorized: true
   columns: (f88259)
   size: 1 column, 1 row
   row 0, expr 0: f88259(333, 444)
+
+# Regression test for #96218. The CASE statement used to enforce strict behavior
+# for UDFs should not prevent decorrelation for non-volatile UDFs. This query
+# should be fully decorrelated.
+query T
+EXPLAIN SELECT
+  c.relname,
+  CASE WHEN c.relispartition THEN 'p' WHEN c.relkind IN ('m', 'v') THEN 'v' ELSE 't' END,
+  obj_description(c.oid, 'pg_class')
+FROM pg_catalog.pg_class c
+LEFT JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
+WHERE
+  c.relkind IN ('f', 'm', 'p', 'r', 'v')
+  AND n.nspname NOT IN ('pg_catalog', 'pg_toast')
+  AND pg_catalog.pg_table_is_visible(c.oid);
+----
+distribution: local
+vectorized: true
+·
+• render
+│
+└── • distinct
+    │ distinct on: rownum
+    │
+    └── • hash join (right outer)
+        │ equality: (objoid) = (oid)
+        │
+        ├── • hash join
+        │   │ equality: (relnamespace) = (oid)
+        │   │
+        │   ├── • virtual table lookup join
+        │   │   │ table: pg_class@pg_class_oid_idx
+        │   │   │ equality: (classoid) = (oid)
+        │   │   │ pred: relname = 'pg_class'
+        │   │   │
+        │   │   └── • filter
+        │   │       │ filter: objsubid = 0
+        │   │       │
+        │   │       └── • virtual table
+        │   │             table: pg_description@primary
+        │   │
+        │   └── • filter
+        │       │ filter: nspname = 'pg_catalog'
+        │       │
+        │       └── • virtual table
+        │             table: pg_namespace@primary
+        │
+        └── • ordinality
+            │
+            └── • filter
+                │ filter: nspname NOT IN ('pg_catalog', 'pg_toast')
+                │
+                └── • virtual table lookup join (left outer)
+                    │ table: pg_namespace@pg_namespace_oid_idx
+                    │ equality: (relnamespace) = (oid)
+                    │
+                    └── • filter
+                        │ filter: (((oid IS NULL) IS true) AND NULL) OR (((oid IS NULL) IS NOT true) AND "?column?")
+                        │
+                        └── • render
+                            │
+                            └── • distinct
+                                │ distinct on: rownum
+                                │
+                                └── • hash join
+                                    │ equality: (oid) = (oid)
+                                    │
+                                    ├── • virtual table lookup join
+                                    │   │ table: pg_namespace@pg_namespace_oid_idx
+                                    │   │ equality: (relnamespace) = (oid)
+                                    │   │
+                                    │   └── • virtual table
+                                    │         table: pg_class@primary
+                                    │
+                                    └── • filter
+                                        │ filter: relkind IN ('f', 'm', 'p', 'r', 'v')
+                                        │
+                                        └── • ordinality
+                                            │
+                                            └── • virtual table
+                                                  table: pg_class@primary

--- a/pkg/sql/opt/norm/rules/scalar.opt
+++ b/pkg/sql/opt/norm/rules/scalar.opt
@@ -320,6 +320,30 @@ $input
 =>
 (SimplifyWhens $condition $whens $orElse)
 
+# SimplifyLeakproofBooleanCase replaces a boolean CASE statement with an
+# equivalent boolean expression using AND and OR expressions. This is
+# possible when the following conditions are satisfied:
+#
+#   1. The CASE statement returns a boolean value.
+#   2. The CASE statement is leak-proof.
+#   3. The CASE condition is a *constant* boolean value (True, False, NULL).
+#   4. Each WHEN branch returns a *constant* boolean value.
+#
+# See the ConvertCaseToCondition comment for details and an example.
+#
+# This is useful (for example) for strict UDFs, because they are implemented
+# using a CASE statement that checks whether the arguments are NULL.
+[SimplifyLeakproofBooleanCase, Normalize]
+(Case
+    $condition:* & (IsConstantBool $condition)
+    $whens:* & (WhensReturnConstBool $whens)
+    $orElse:* &
+        (CaseReturnsBoolean $whens $orElse) &
+        (IsCaseLeakproof $condition $whens $orElse)
+)
+=>
+(ConvertCaseToCondition $condition $whens $orElse)
+
 # InlineAnyValuesSingleCol converts Any with Values input to AnyScalar.
 # This version handles the case where there is a single column.
 [InlineAnyValuesSingleCol, Normalize]

--- a/pkg/sql/opt/norm/testdata/rules/combo
+++ b/pkg/sql/opt/norm/testdata/rules/combo
@@ -1739,6 +1739,501 @@ SimplifyAndTrue
     └── projections
          └── case:15 [as=r:12, outer=(15)]
 ================================================================================
+SimplifyLeakproofBooleanCase
+  Cost: 2209.73
+================================================================================
+   project
+    ├── columns: r:12
+    ├── inner-join-apply
+    │    ├── columns: x:1!null case:15
+    │    ├── key: (1)
+    │    ├── fd: (1)-->(15)
+    │    ├── scan xy
+    │    │    ├── columns: x:1!null
+    │    │    └── key: (1)
+    │    ├── project
+    │    │    ├── columns: case:15
+    │    │    ├── outer: (1)
+    │    │    ├── cardinality: [1 - 1]
+    │    │    ├── key: ()
+    │    │    ├── fd: ()-->(15)
+    │    │    ├── scalar-group-by
+    │    │    │    ├── columns: bool_or:14
+    │    │    │    ├── outer: (1)
+    │    │    │    ├── cardinality: [1 - 1]
+    │    │    │    ├── key: ()
+    │    │    │    ├── fd: ()-->(14)
+    │    │    │    ├── project
+    │    │    │    │    ├── columns: notnull:13!null
+    │    │    │    │    ├── outer: (1)
+    │    │    │    │    ├── cardinality: [0 - 1]
+    │    │    │    │    ├── key: ()
+    │    │    │    │    ├── fd: ()-->(13)
+    │    │    │    │    ├── select
+    │    │    │    │    │    ├── columns: k:5!null i:6
+    │    │    │    │    │    ├── outer: (1)
+    │    │    │    │    │    ├── cardinality: [0 - 1]
+    │    │    │    │    │    ├── key: ()
+    │    │    │    │    │    ├── fd: ()-->(5,6)
+    │    │    │    │    │    ├── scan a
+    │    │    │    │    │    │    ├── columns: k:5!null i:6
+    │    │    │    │    │    │    ├── key: (5)
+    │    │    │    │    │    │    └── fd: (5)-->(6)
+    │    │    │    │    │    └── filters
+    │    │    │    │    │         ├── k:5 = x:1 [outer=(1,5), constraints=(/1: (/NULL - ]; /5: (/NULL - ]), fd=(1)==(5), (5)==(1)]
+    │    │    │    │    │         └── (i:6 = 5) IS NOT false [outer=(6)]
+    │    │    │    │    └── projections
+    │    │    │    │         └── i:6 IS NOT NULL [as=notnull:13, outer=(6)]
+    │    │    │    └── aggregations
+    │    │    │         └── bool-or [as=bool_or:14, outer=(13)]
+    │    │    │              └── notnull:13
+    │    │    └── projections
+  - │    │         └── CASE WHEN bool_or:14 THEN true WHEN bool_or:14 IS NULL THEN false ELSE CAST(NULL AS BOOL) END [as=case:15, outer=(14)]
+  + │    │         └── ((true = bool_or:14) IS true) OR (NOT (((true = (bool_or:14 IS NULL)) IS true) OR (NOT CAST(NULL AS BOOL)))) [as=case:15, outer=(14)]
+    │    └── filters (true)
+    └── projections
+         └── case:15 [as=r:12, outer=(15)]
+================================================================================
+CommuteConst
+  Cost: 2209.73
+================================================================================
+   project
+    ├── columns: r:12
+    ├── inner-join-apply
+    │    ├── columns: x:1!null case:15
+    │    ├── key: (1)
+    │    ├── fd: (1)-->(15)
+    │    ├── scan xy
+    │    │    ├── columns: x:1!null
+    │    │    └── key: (1)
+    │    ├── project
+    │    │    ├── columns: case:15
+    │    │    ├── outer: (1)
+    │    │    ├── cardinality: [1 - 1]
+    │    │    ├── key: ()
+    │    │    ├── fd: ()-->(15)
+    │    │    ├── scalar-group-by
+    │    │    │    ├── columns: bool_or:14
+    │    │    │    ├── outer: (1)
+    │    │    │    ├── cardinality: [1 - 1]
+    │    │    │    ├── key: ()
+    │    │    │    ├── fd: ()-->(14)
+    │    │    │    ├── project
+    │    │    │    │    ├── columns: notnull:13!null
+    │    │    │    │    ├── outer: (1)
+    │    │    │    │    ├── cardinality: [0 - 1]
+    │    │    │    │    ├── key: ()
+    │    │    │    │    ├── fd: ()-->(13)
+    │    │    │    │    ├── select
+    │    │    │    │    │    ├── columns: k:5!null i:6
+    │    │    │    │    │    ├── outer: (1)
+    │    │    │    │    │    ├── cardinality: [0 - 1]
+    │    │    │    │    │    ├── key: ()
+    │    │    │    │    │    ├── fd: ()-->(5,6)
+    │    │    │    │    │    ├── scan a
+    │    │    │    │    │    │    ├── columns: k:5!null i:6
+    │    │    │    │    │    │    ├── key: (5)
+    │    │    │    │    │    │    └── fd: (5)-->(6)
+    │    │    │    │    │    └── filters
+    │    │    │    │    │         ├── k:5 = x:1 [outer=(1,5), constraints=(/1: (/NULL - ]; /5: (/NULL - ]), fd=(1)==(5), (5)==(1)]
+    │    │    │    │    │         └── (i:6 = 5) IS NOT false [outer=(6)]
+    │    │    │    │    └── projections
+    │    │    │    │         └── i:6 IS NOT NULL [as=notnull:13, outer=(6)]
+    │    │    │    └── aggregations
+    │    │    │         └── bool-or [as=bool_or:14, outer=(13)]
+    │    │    │              └── notnull:13
+    │    │    └── projections
+  - │    │         └── ((true = bool_or:14) IS true) OR (NOT (((true = (bool_or:14 IS NULL)) IS true) OR (NOT CAST(NULL AS BOOL)))) [as=case:15, outer=(14)]
+  + │    │         └── ((true = bool_or:14) IS true) OR (NOT ((((bool_or:14 IS NULL) = true) IS true) OR (NOT CAST(NULL AS BOOL)))) [as=case:15, outer=(14)]
+    │    └── filters (true)
+    └── projections
+         └── case:15 [as=r:12, outer=(15)]
+================================================================================
+FoldEqTrue
+  Cost: 2209.73
+================================================================================
+   project
+    ├── columns: r:12
+    ├── inner-join-apply
+    │    ├── columns: x:1!null case:15
+    │    ├── key: (1)
+    │    ├── fd: (1)-->(15)
+    │    ├── scan xy
+    │    │    ├── columns: x:1!null
+    │    │    └── key: (1)
+    │    ├── project
+    │    │    ├── columns: case:15
+    │    │    ├── outer: (1)
+    │    │    ├── cardinality: [1 - 1]
+    │    │    ├── key: ()
+    │    │    ├── fd: ()-->(15)
+    │    │    ├── scalar-group-by
+    │    │    │    ├── columns: bool_or:14
+    │    │    │    ├── outer: (1)
+    │    │    │    ├── cardinality: [1 - 1]
+    │    │    │    ├── key: ()
+    │    │    │    ├── fd: ()-->(14)
+    │    │    │    ├── project
+    │    │    │    │    ├── columns: notnull:13!null
+    │    │    │    │    ├── outer: (1)
+    │    │    │    │    ├── cardinality: [0 - 1]
+    │    │    │    │    ├── key: ()
+    │    │    │    │    ├── fd: ()-->(13)
+    │    │    │    │    ├── select
+    │    │    │    │    │    ├── columns: k:5!null i:6
+    │    │    │    │    │    ├── outer: (1)
+    │    │    │    │    │    ├── cardinality: [0 - 1]
+    │    │    │    │    │    ├── key: ()
+    │    │    │    │    │    ├── fd: ()-->(5,6)
+    │    │    │    │    │    ├── scan a
+    │    │    │    │    │    │    ├── columns: k:5!null i:6
+    │    │    │    │    │    │    ├── key: (5)
+    │    │    │    │    │    │    └── fd: (5)-->(6)
+    │    │    │    │    │    └── filters
+    │    │    │    │    │         ├── k:5 = x:1 [outer=(1,5), constraints=(/1: (/NULL - ]; /5: (/NULL - ]), fd=(1)==(5), (5)==(1)]
+    │    │    │    │    │         └── (i:6 = 5) IS NOT false [outer=(6)]
+    │    │    │    │    └── projections
+    │    │    │    │         └── i:6 IS NOT NULL [as=notnull:13, outer=(6)]
+    │    │    │    └── aggregations
+    │    │    │         └── bool-or [as=bool_or:14, outer=(13)]
+    │    │    │              └── notnull:13
+    │    │    └── projections
+  - │    │         └── ((true = bool_or:14) IS true) OR (NOT ((((bool_or:14 IS NULL) = true) IS true) OR (NOT CAST(NULL AS BOOL)))) [as=case:15, outer=(14)]
+  + │    │         └── ((true = bool_or:14) IS true) OR (NOT (((bool_or:14 IS NULL) IS true) OR (NOT CAST(NULL AS BOOL)))) [as=case:15, outer=(14)]
+    │    └── filters (true)
+    └── projections
+         └── case:15 [as=r:12, outer=(15)]
+================================================================================
+FoldNotNull
+  Cost: 2209.73
+================================================================================
+   project
+    ├── columns: r:12
+    ├── inner-join-apply
+    │    ├── columns: x:1!null case:15
+    │    ├── key: (1)
+    │    ├── fd: (1)-->(15)
+    │    ├── scan xy
+    │    │    ├── columns: x:1!null
+    │    │    └── key: (1)
+    │    ├── project
+    │    │    ├── columns: case:15
+    │    │    ├── outer: (1)
+    │    │    ├── cardinality: [1 - 1]
+    │    │    ├── key: ()
+    │    │    ├── fd: ()-->(15)
+    │    │    ├── scalar-group-by
+    │    │    │    ├── columns: bool_or:14
+    │    │    │    ├── outer: (1)
+    │    │    │    ├── cardinality: [1 - 1]
+    │    │    │    ├── key: ()
+    │    │    │    ├── fd: ()-->(14)
+    │    │    │    ├── project
+    │    │    │    │    ├── columns: notnull:13!null
+    │    │    │    │    ├── outer: (1)
+    │    │    │    │    ├── cardinality: [0 - 1]
+    │    │    │    │    ├── key: ()
+    │    │    │    │    ├── fd: ()-->(13)
+    │    │    │    │    ├── select
+    │    │    │    │    │    ├── columns: k:5!null i:6
+    │    │    │    │    │    ├── outer: (1)
+    │    │    │    │    │    ├── cardinality: [0 - 1]
+    │    │    │    │    │    ├── key: ()
+    │    │    │    │    │    ├── fd: ()-->(5,6)
+    │    │    │    │    │    ├── scan a
+    │    │    │    │    │    │    ├── columns: k:5!null i:6
+    │    │    │    │    │    │    ├── key: (5)
+    │    │    │    │    │    │    └── fd: (5)-->(6)
+    │    │    │    │    │    └── filters
+    │    │    │    │    │         ├── k:5 = x:1 [outer=(1,5), constraints=(/1: (/NULL - ]; /5: (/NULL - ]), fd=(1)==(5), (5)==(1)]
+    │    │    │    │    │         └── (i:6 = 5) IS NOT false [outer=(6)]
+    │    │    │    │    └── projections
+    │    │    │    │         └── i:6 IS NOT NULL [as=notnull:13, outer=(6)]
+    │    │    │    └── aggregations
+    │    │    │         └── bool-or [as=bool_or:14, outer=(13)]
+    │    │    │              └── notnull:13
+    │    │    └── projections
+  - │    │         └── ((true = bool_or:14) IS true) OR (NOT (((bool_or:14 IS NULL) IS true) OR (NOT CAST(NULL AS BOOL)))) [as=case:15, outer=(14)]
+  + │    │         └── ((true = bool_or:14) IS true) OR (NOT (((bool_or:14 IS NULL) IS true) OR CAST(NULL AS BOOL))) [as=case:15, outer=(14)]
+    │    └── filters (true)
+    └── projections
+         └── case:15 [as=r:12, outer=(15)]
+================================================================================
+NegateOr
+  Cost: 2209.73
+================================================================================
+   project
+    ├── columns: r:12
+    ├── inner-join-apply
+    │    ├── columns: x:1!null case:15
+    │    ├── key: (1)
+    │    ├── fd: (1)-->(15)
+    │    ├── scan xy
+    │    │    ├── columns: x:1!null
+    │    │    └── key: (1)
+    │    ├── project
+    │    │    ├── columns: case:15
+    │    │    ├── outer: (1)
+    │    │    ├── cardinality: [1 - 1]
+    │    │    ├── key: ()
+    │    │    ├── fd: ()-->(15)
+    │    │    ├── scalar-group-by
+    │    │    │    ├── columns: bool_or:14
+    │    │    │    ├── outer: (1)
+    │    │    │    ├── cardinality: [1 - 1]
+    │    │    │    ├── key: ()
+    │    │    │    ├── fd: ()-->(14)
+    │    │    │    ├── project
+    │    │    │    │    ├── columns: notnull:13!null
+    │    │    │    │    ├── outer: (1)
+    │    │    │    │    ├── cardinality: [0 - 1]
+    │    │    │    │    ├── key: ()
+    │    │    │    │    ├── fd: ()-->(13)
+    │    │    │    │    ├── select
+    │    │    │    │    │    ├── columns: k:5!null i:6
+    │    │    │    │    │    ├── outer: (1)
+    │    │    │    │    │    ├── cardinality: [0 - 1]
+    │    │    │    │    │    ├── key: ()
+    │    │    │    │    │    ├── fd: ()-->(5,6)
+    │    │    │    │    │    ├── scan a
+    │    │    │    │    │    │    ├── columns: k:5!null i:6
+    │    │    │    │    │    │    ├── key: (5)
+    │    │    │    │    │    │    └── fd: (5)-->(6)
+    │    │    │    │    │    └── filters
+    │    │    │    │    │         ├── k:5 = x:1 [outer=(1,5), constraints=(/1: (/NULL - ]; /5: (/NULL - ]), fd=(1)==(5), (5)==(1)]
+    │    │    │    │    │         └── (i:6 = 5) IS NOT false [outer=(6)]
+    │    │    │    │    └── projections
+    │    │    │    │         └── i:6 IS NOT NULL [as=notnull:13, outer=(6)]
+    │    │    │    └── aggregations
+    │    │    │         └── bool-or [as=bool_or:14, outer=(13)]
+    │    │    │              └── notnull:13
+    │    │    └── projections
+  - │    │         └── ((true = bool_or:14) IS true) OR (NOT (((bool_or:14 IS NULL) IS true) OR CAST(NULL AS BOOL))) [as=case:15, outer=(14)]
+  + │    │         └── ((true = bool_or:14) IS true) OR ((NOT ((bool_or:14 IS NULL) IS true)) AND (NOT CAST(NULL AS BOOL))) [as=case:15, outer=(14)]
+    │    └── filters (true)
+    └── projections
+         └── case:15 [as=r:12, outer=(15)]
+================================================================================
+NegateComparison
+  Cost: 2209.73
+================================================================================
+   project
+    ├── columns: r:12
+    ├── inner-join-apply
+    │    ├── columns: x:1!null case:15
+    │    ├── key: (1)
+    │    ├── fd: (1)-->(15)
+    │    ├── scan xy
+    │    │    ├── columns: x:1!null
+    │    │    └── key: (1)
+    │    ├── project
+    │    │    ├── columns: case:15
+    │    │    ├── outer: (1)
+    │    │    ├── cardinality: [1 - 1]
+    │    │    ├── key: ()
+    │    │    ├── fd: ()-->(15)
+    │    │    ├── scalar-group-by
+    │    │    │    ├── columns: bool_or:14
+    │    │    │    ├── outer: (1)
+    │    │    │    ├── cardinality: [1 - 1]
+    │    │    │    ├── key: ()
+    │    │    │    ├── fd: ()-->(14)
+    │    │    │    ├── project
+    │    │    │    │    ├── columns: notnull:13!null
+    │    │    │    │    ├── outer: (1)
+    │    │    │    │    ├── cardinality: [0 - 1]
+    │    │    │    │    ├── key: ()
+    │    │    │    │    ├── fd: ()-->(13)
+    │    │    │    │    ├── select
+    │    │    │    │    │    ├── columns: k:5!null i:6
+    │    │    │    │    │    ├── outer: (1)
+    │    │    │    │    │    ├── cardinality: [0 - 1]
+    │    │    │    │    │    ├── key: ()
+    │    │    │    │    │    ├── fd: ()-->(5,6)
+    │    │    │    │    │    ├── scan a
+    │    │    │    │    │    │    ├── columns: k:5!null i:6
+    │    │    │    │    │    │    ├── key: (5)
+    │    │    │    │    │    │    └── fd: (5)-->(6)
+    │    │    │    │    │    └── filters
+    │    │    │    │    │         ├── k:5 = x:1 [outer=(1,5), constraints=(/1: (/NULL - ]; /5: (/NULL - ]), fd=(1)==(5), (5)==(1)]
+    │    │    │    │    │         └── (i:6 = 5) IS NOT false [outer=(6)]
+    │    │    │    │    └── projections
+    │    │    │    │         └── i:6 IS NOT NULL [as=notnull:13, outer=(6)]
+    │    │    │    └── aggregations
+    │    │    │         └── bool-or [as=bool_or:14, outer=(13)]
+    │    │    │              └── notnull:13
+    │    │    └── projections
+  - │    │         └── ((true = bool_or:14) IS true) OR ((NOT ((bool_or:14 IS NULL) IS true)) AND (NOT CAST(NULL AS BOOL))) [as=case:15, outer=(14)]
+  + │    │         └── ((true = bool_or:14) IS true) OR (((bool_or:14 IS NULL) IS NOT true) AND (NOT CAST(NULL AS BOOL))) [as=case:15, outer=(14)]
+    │    └── filters (true)
+    └── projections
+         └── case:15 [as=r:12, outer=(15)]
+================================================================================
+FoldNotNull
+  Cost: 2209.73
+================================================================================
+   project
+    ├── columns: r:12
+    ├── inner-join-apply
+    │    ├── columns: x:1!null case:15
+    │    ├── key: (1)
+    │    ├── fd: (1)-->(15)
+    │    ├── scan xy
+    │    │    ├── columns: x:1!null
+    │    │    └── key: (1)
+    │    ├── project
+    │    │    ├── columns: case:15
+    │    │    ├── outer: (1)
+    │    │    ├── cardinality: [1 - 1]
+    │    │    ├── key: ()
+    │    │    ├── fd: ()-->(15)
+    │    │    ├── scalar-group-by
+    │    │    │    ├── columns: bool_or:14
+    │    │    │    ├── outer: (1)
+    │    │    │    ├── cardinality: [1 - 1]
+    │    │    │    ├── key: ()
+    │    │    │    ├── fd: ()-->(14)
+    │    │    │    ├── project
+    │    │    │    │    ├── columns: notnull:13!null
+    │    │    │    │    ├── outer: (1)
+    │    │    │    │    ├── cardinality: [0 - 1]
+    │    │    │    │    ├── key: ()
+    │    │    │    │    ├── fd: ()-->(13)
+    │    │    │    │    ├── select
+    │    │    │    │    │    ├── columns: k:5!null i:6
+    │    │    │    │    │    ├── outer: (1)
+    │    │    │    │    │    ├── cardinality: [0 - 1]
+    │    │    │    │    │    ├── key: ()
+    │    │    │    │    │    ├── fd: ()-->(5,6)
+    │    │    │    │    │    ├── scan a
+    │    │    │    │    │    │    ├── columns: k:5!null i:6
+    │    │    │    │    │    │    ├── key: (5)
+    │    │    │    │    │    │    └── fd: (5)-->(6)
+    │    │    │    │    │    └── filters
+    │    │    │    │    │         ├── k:5 = x:1 [outer=(1,5), constraints=(/1: (/NULL - ]; /5: (/NULL - ]), fd=(1)==(5), (5)==(1)]
+    │    │    │    │    │         └── (i:6 = 5) IS NOT false [outer=(6)]
+    │    │    │    │    └── projections
+    │    │    │    │         └── i:6 IS NOT NULL [as=notnull:13, outer=(6)]
+    │    │    │    └── aggregations
+    │    │    │         └── bool-or [as=bool_or:14, outer=(13)]
+    │    │    │              └── notnull:13
+    │    │    └── projections
+  - │    │         └── ((true = bool_or:14) IS true) OR (((bool_or:14 IS NULL) IS NOT true) AND (NOT CAST(NULL AS BOOL))) [as=case:15, outer=(14)]
+  + │    │         └── ((true = bool_or:14) IS true) OR (((bool_or:14 IS NULL) IS NOT true) AND CAST(NULL AS BOOL)) [as=case:15, outer=(14)]
+    │    └── filters (true)
+    └── projections
+         └── case:15 [as=r:12, outer=(15)]
+================================================================================
+CommuteVar
+  Cost: 2209.73
+================================================================================
+   project
+    ├── columns: r:12
+    ├── inner-join-apply
+    │    ├── columns: x:1!null case:15
+    │    ├── key: (1)
+    │    ├── fd: (1)-->(15)
+    │    ├── scan xy
+    │    │    ├── columns: x:1!null
+    │    │    └── key: (1)
+    │    ├── project
+    │    │    ├── columns: case:15
+    │    │    ├── outer: (1)
+    │    │    ├── cardinality: [1 - 1]
+    │    │    ├── key: ()
+    │    │    ├── fd: ()-->(15)
+    │    │    ├── scalar-group-by
+    │    │    │    ├── columns: bool_or:14
+    │    │    │    ├── outer: (1)
+    │    │    │    ├── cardinality: [1 - 1]
+    │    │    │    ├── key: ()
+    │    │    │    ├── fd: ()-->(14)
+    │    │    │    ├── project
+    │    │    │    │    ├── columns: notnull:13!null
+    │    │    │    │    ├── outer: (1)
+    │    │    │    │    ├── cardinality: [0 - 1]
+    │    │    │    │    ├── key: ()
+    │    │    │    │    ├── fd: ()-->(13)
+    │    │    │    │    ├── select
+    │    │    │    │    │    ├── columns: k:5!null i:6
+    │    │    │    │    │    ├── outer: (1)
+    │    │    │    │    │    ├── cardinality: [0 - 1]
+    │    │    │    │    │    ├── key: ()
+    │    │    │    │    │    ├── fd: ()-->(5,6)
+    │    │    │    │    │    ├── scan a
+    │    │    │    │    │    │    ├── columns: k:5!null i:6
+    │    │    │    │    │    │    ├── key: (5)
+    │    │    │    │    │    │    └── fd: (5)-->(6)
+    │    │    │    │    │    └── filters
+    │    │    │    │    │         ├── k:5 = x:1 [outer=(1,5), constraints=(/1: (/NULL - ]; /5: (/NULL - ]), fd=(1)==(5), (5)==(1)]
+    │    │    │    │    │         └── (i:6 = 5) IS NOT false [outer=(6)]
+    │    │    │    │    └── projections
+    │    │    │    │         └── i:6 IS NOT NULL [as=notnull:13, outer=(6)]
+    │    │    │    └── aggregations
+    │    │    │         └── bool-or [as=bool_or:14, outer=(13)]
+    │    │    │              └── notnull:13
+    │    │    └── projections
+  - │    │         └── ((true = bool_or:14) IS true) OR (((bool_or:14 IS NULL) IS NOT true) AND CAST(NULL AS BOOL)) [as=case:15, outer=(14)]
+  + │    │         └── ((bool_or:14 = true) IS true) OR (((bool_or:14 IS NULL) IS NOT true) AND CAST(NULL AS BOOL)) [as=case:15, outer=(14)]
+    │    └── filters (true)
+    └── projections
+         └── case:15 [as=r:12, outer=(15)]
+================================================================================
+FoldEqTrue
+  Cost: 2209.73
+================================================================================
+   project
+    ├── columns: r:12
+    ├── inner-join-apply
+    │    ├── columns: x:1!null case:15
+    │    ├── key: (1)
+    │    ├── fd: (1)-->(15)
+    │    ├── scan xy
+    │    │    ├── columns: x:1!null
+    │    │    └── key: (1)
+    │    ├── project
+    │    │    ├── columns: case:15
+    │    │    ├── outer: (1)
+    │    │    ├── cardinality: [1 - 1]
+    │    │    ├── key: ()
+    │    │    ├── fd: ()-->(15)
+    │    │    ├── scalar-group-by
+    │    │    │    ├── columns: bool_or:14
+    │    │    │    ├── outer: (1)
+    │    │    │    ├── cardinality: [1 - 1]
+    │    │    │    ├── key: ()
+    │    │    │    ├── fd: ()-->(14)
+    │    │    │    ├── project
+    │    │    │    │    ├── columns: notnull:13!null
+    │    │    │    │    ├── outer: (1)
+    │    │    │    │    ├── cardinality: [0 - 1]
+    │    │    │    │    ├── key: ()
+    │    │    │    │    ├── fd: ()-->(13)
+    │    │    │    │    ├── select
+    │    │    │    │    │    ├── columns: k:5!null i:6
+    │    │    │    │    │    ├── outer: (1)
+    │    │    │    │    │    ├── cardinality: [0 - 1]
+    │    │    │    │    │    ├── key: ()
+    │    │    │    │    │    ├── fd: ()-->(5,6)
+    │    │    │    │    │    ├── scan a
+    │    │    │    │    │    │    ├── columns: k:5!null i:6
+    │    │    │    │    │    │    ├── key: (5)
+    │    │    │    │    │    │    └── fd: (5)-->(6)
+    │    │    │    │    │    └── filters
+    │    │    │    │    │         ├── k:5 = x:1 [outer=(1,5), constraints=(/1: (/NULL - ]; /5: (/NULL - ]), fd=(1)==(5), (5)==(1)]
+    │    │    │    │    │         └── (i:6 = 5) IS NOT false [outer=(6)]
+    │    │    │    │    └── projections
+    │    │    │    │         └── i:6 IS NOT NULL [as=notnull:13, outer=(6)]
+    │    │    │    └── aggregations
+    │    │    │         └── bool-or [as=bool_or:14, outer=(13)]
+    │    │    │              └── notnull:13
+    │    │    └── projections
+  - │    │         └── ((bool_or:14 = true) IS true) OR (((bool_or:14 IS NULL) IS NOT true) AND CAST(NULL AS BOOL)) [as=case:15, outer=(14)]
+  + │    │         └── (bool_or:14 IS true) OR (((bool_or:14 IS NULL) IS NOT true) AND CAST(NULL AS BOOL)) [as=case:15, outer=(14)]
+    │    └── filters (true)
+    └── projections
+         └── case:15 [as=r:12, outer=(15)]
+================================================================================
 TryDecorrelateProject
   Cost: 2239.74
 ================================================================================
@@ -1824,7 +2319,7 @@ TryDecorrelateProject
   + │    │    │    │              └── notnull:13
   + │    │    │    └── filters (true)
     │    │    └── projections
-    │    │         └── CASE WHEN bool_or:14 THEN true WHEN bool_or:14 IS NULL THEN false ELSE CAST(NULL AS BOOL) END [as=case:15, outer=(14)]
+    │    │         └── (bool_or:14 IS true) OR (((bool_or:14 IS NULL) IS NOT true) AND CAST(NULL AS BOOL)) [as=case:15, outer=(14)]
     │    └── filters (true)
     └── projections
          └── case:15 [as=r:12, outer=(15)]
@@ -1923,7 +2418,7 @@ TryDecorrelateScalarGroupBy
   + │    │    │    │                   └── notnull:13
     │    │    │    └── filters (true)
     │    │    └── projections
-    │    │         └── CASE WHEN bool_or:14 THEN true WHEN bool_or:14 IS NULL THEN false ELSE CAST(NULL AS BOOL) END [as=case:15, outer=(14)]
+    │    │         └── (bool_or:14 IS true) OR (((bool_or:14 IS NULL) IS NOT true) AND CAST(NULL AS BOOL)) [as=case:15, outer=(14)]
     │    └── filters (true)
     └── projections
          └── case:15 [as=r:12, outer=(15)]
@@ -2009,7 +2504,7 @@ TryDecorrelateProjectSelect
     │    │    │    │                   └── notnull:13
     │    │    │    └── filters (true)
     │    │    └── projections
-    │    │         └── CASE WHEN bool_or:14 THEN true WHEN bool_or:14 IS NULL THEN false ELSE CAST(NULL AS BOOL) END [as=case:15, outer=(14)]
+    │    │         └── (bool_or:14 IS true) OR (((bool_or:14 IS NULL) IS NOT true) AND CAST(NULL AS BOOL)) [as=case:15, outer=(14)]
     │    └── filters (true)
     └── projections
          └── case:15 [as=r:12, outer=(15)]
@@ -2072,7 +2567,7 @@ DecorrelateJoin
     │    │    │    │                   └── notnull:13
     │    │    │    └── filters (true)
     │    │    └── projections
-    │    │         └── CASE WHEN bool_or:14 THEN true WHEN bool_or:14 IS NULL THEN false ELSE CAST(NULL AS BOOL) END [as=case:15, outer=(14)]
+    │    │         └── (bool_or:14 IS true) OR (((bool_or:14 IS NULL) IS NOT true) AND CAST(NULL AS BOOL)) [as=case:15, outer=(14)]
     │    └── filters (true)
     └── projections
          └── case:15 [as=r:12, outer=(15)]
@@ -2147,7 +2642,7 @@ PushFilterIntoJoinRight
     │    │    │    │                   └── notnull:13
     │    │    │    └── filters (true)
     │    │    └── projections
-    │    │         └── CASE WHEN bool_or:14 THEN true WHEN bool_or:14 IS NULL THEN false ELSE CAST(NULL AS BOOL) END [as=case:15, outer=(14)]
+    │    │         └── (bool_or:14 IS true) OR (((bool_or:14 IS NULL) IS NOT true) AND CAST(NULL AS BOOL)) [as=case:15, outer=(14)]
     │    └── filters (true)
     └── projections
          └── case:15 [as=r:12, outer=(15)]
@@ -2222,7 +2717,7 @@ PushSelectIntoProject
     │    │    │    │                   └── notnull:13
     │    │    │    └── filters (true)
     │    │    └── projections
-    │    │         └── CASE WHEN bool_or:14 THEN true WHEN bool_or:14 IS NULL THEN false ELSE CAST(NULL AS BOOL) END [as=case:15, outer=(14)]
+    │    │         └── (bool_or:14 IS true) OR (((bool_or:14 IS NULL) IS NOT true) AND CAST(NULL AS BOOL)) [as=case:15, outer=(14)]
     │    └── filters (true)
     └── projections
          └── case:15 [as=r:12, outer=(15)]
@@ -2304,7 +2799,7 @@ EliminateSelect
     │    │    │    │                   └── notnull:13
     │    │    │    └── filters (true)
     │    │    └── projections
-    │    │         └── CASE WHEN bool_or:14 THEN true WHEN bool_or:14 IS NULL THEN false ELSE CAST(NULL AS BOOL) END [as=case:15, outer=(14)]
+    │    │         └── (bool_or:14 IS true) OR (((bool_or:14 IS NULL) IS NOT true) AND CAST(NULL AS BOOL)) [as=case:15, outer=(14)]
     │    └── filters (true)
     └── projections
          └── case:15 [as=r:12, outer=(15)]
@@ -2374,7 +2869,7 @@ PruneJoinRightCols
     │    │    │    │                   └── notnull:13
     │    │    │    └── filters (true)
     │    │    └── projections
-    │    │         └── CASE WHEN bool_or:14 THEN true WHEN bool_or:14 IS NULL THEN false ELSE CAST(NULL AS BOOL) END [as=case:15, outer=(14)]
+    │    │         └── (bool_or:14 IS true) OR (((bool_or:14 IS NULL) IS NOT true) AND CAST(NULL AS BOOL)) [as=case:15, outer=(14)]
     │    └── filters (true)
     └── projections
          └── case:15 [as=r:12, outer=(15)]
@@ -2465,7 +2960,7 @@ EliminateGroupByProject
     │    │    │    │                   └── notnull:13
     │    │    │    └── filters (true)
     │    │    └── projections
-    │    │         └── CASE WHEN bool_or:14 THEN true WHEN bool_or:14 IS NULL THEN false ELSE CAST(NULL AS BOOL) END [as=case:15, outer=(14)]
+    │    │         └── (bool_or:14 IS true) OR (((bool_or:14 IS NULL) IS NOT true) AND CAST(NULL AS BOOL)) [as=case:15, outer=(14)]
     │    └── filters (true)
     └── projections
          └── case:15 [as=r:12, outer=(15)]
@@ -2558,7 +3053,7 @@ EliminateProject
   + │    │    │    │              └── notnull:13
     │    │    │    └── filters (true)
     │    │    └── projections
-    │    │         └── CASE WHEN bool_or:14 THEN true WHEN bool_or:14 IS NULL THEN false ELSE CAST(NULL AS BOOL) END [as=case:15, outer=(14)]
+    │    │         └── (bool_or:14 IS true) OR (((bool_or:14 IS NULL) IS NOT true) AND CAST(NULL AS BOOL)) [as=case:15, outer=(14)]
     │    └── filters (true)
     └── projections
          └── case:15 [as=r:12, outer=(15)]
@@ -2643,7 +3138,7 @@ EliminateSelect
   + │    │    │         └── bool-or [as=bool_or:14, outer=(13)]
   + │    │    │              └── notnull:13
     │    │    └── projections
-    │    │         └── CASE WHEN bool_or:14 THEN true WHEN bool_or:14 IS NULL THEN false ELSE CAST(NULL AS BOOL) END [as=case:15, outer=(14)]
+    │    │         └── (bool_or:14 IS true) OR (((bool_or:14 IS NULL) IS NOT true) AND CAST(NULL AS BOOL)) [as=case:15, outer=(14)]
     │    └── filters (true)
     └── projections
          └── case:15 [as=r:12, outer=(15)]
@@ -2717,7 +3212,7 @@ EliminateSelect
   - │    │    │         └── bool-or [as=bool_or:14, outer=(13)]
   - │    │    │              └── notnull:13
   - │    │    └── projections
-  - │    │         └── CASE WHEN bool_or:14 THEN true WHEN bool_or:14 IS NULL THEN false ELSE CAST(NULL AS BOOL) END [as=case:15, outer=(14)]
+  - │    │         └── (bool_or:14 IS true) OR (((bool_or:14 IS NULL) IS NOT true) AND CAST(NULL AS BOOL)) [as=case:15, outer=(14)]
   - │    └── filters (true)
   + │    │    │    │    │    │    └── fd: (5)-->(6)
   + │    │    │    │    │    └── filters
@@ -2730,7 +3225,7 @@ EliminateSelect
   + │    │         └── bool-or [as=bool_or:14, outer=(13)]
   + │    │              └── notnull:13
   + │    └── projections
-  + │         └── CASE WHEN bool_or:14 THEN true WHEN bool_or:14 IS NULL THEN false ELSE CAST(NULL AS BOOL) END [as=case:15, outer=(14)]
+  + │         └── (bool_or:14 IS true) OR (((bool_or:14 IS NULL) IS NOT true) AND CAST(NULL AS BOOL)) [as=case:15, outer=(14)]
     └── projections
          └── case:15 [as=r:12, outer=(15)]
 ================================================================================
@@ -2779,7 +3274,7 @@ PruneProjectCols
     │    │         └── bool-or [as=bool_or:14, outer=(13)]
     │    │              └── notnull:13
     │    └── projections
-    │         └── CASE WHEN bool_or:14 THEN true WHEN bool_or:14 IS NULL THEN false ELSE CAST(NULL AS BOOL) END [as=case:15, outer=(14)]
+    │         └── (bool_or:14 IS true) OR (((bool_or:14 IS NULL) IS NOT true) AND CAST(NULL AS BOOL)) [as=case:15, outer=(14)]
     └── projections
          └── case:15 [as=r:12, outer=(15)]
 ================================================================================
@@ -2845,7 +3340,7 @@ InlineProjectInProject
   - │    │         └── bool-or [as=bool_or:14, outer=(13)]
   - │    │              └── notnull:13
   - │    └── projections
-  - │         └── CASE WHEN bool_or:14 THEN true WHEN bool_or:14 IS NULL THEN false ELSE CAST(NULL AS BOOL) END [as=case:15, outer=(14)]
+  - │         └── (bool_or:14 IS true) OR (((bool_or:14 IS NULL) IS NOT true) AND CAST(NULL AS BOOL)) [as=case:15, outer=(14)]
   + │    │    │    │    │    └── fd: (5)-->(6)
   + │    │    │    │    └── filters
   + │    │    │    │         └── (i:6 = 5) IS NOT false [outer=(6)]
@@ -2858,7 +3353,7 @@ InlineProjectInProject
   + │              └── notnull:13
     └── projections
   -      └── case:15 [as=r:12, outer=(15)]
-  +      └── CASE WHEN bool_or:14 THEN true WHEN bool_or:14 IS NULL THEN false ELSE CAST(NULL AS BOOL) END [as=r:12, outer=(14)]
+  +      └── (bool_or:14 IS true) OR (((bool_or:14 IS NULL) IS NOT true) AND CAST(NULL AS BOOL)) [as=r:12, outer=(14)]
 --------------------------------------------------------------------------------
 GenerateIndexScans (no changes)
 --------------------------------------------------------------------------------
@@ -2921,7 +3416,7 @@ CommuteLeftJoin (higher cost)
     │         └── bool-or [as=bool_or:14, outer=(13)]
     │              └── notnull:13
     └── projections
-         └── CASE WHEN bool_or:14 THEN true WHEN bool_or:14 IS NULL THEN false ELSE CAST(NULL AS BOOL) END [as=r:12, outer=(14)]
+         └── (bool_or:14 IS true) OR (((bool_or:14 IS NULL) IS NOT true) AND CAST(NULL AS BOOL)) [as=r:12, outer=(14)]
 ================================================================================
 GenerateMergeJoins
   Cost: 2256.64
@@ -2973,7 +3468,7 @@ GenerateMergeJoins
     │         └── bool-or [as=bool_or:14, outer=(13)]
     │              └── notnull:13
     └── projections
-         └── CASE WHEN bool_or:14 THEN true WHEN bool_or:14 IS NULL THEN false ELSE CAST(NULL AS BOOL) END [as=r:12, outer=(14)]
+         └── (bool_or:14 IS true) OR (((bool_or:14 IS NULL) IS NOT true) AND CAST(NULL AS BOOL)) [as=r:12, outer=(14)]
 --------------------------------------------------------------------------------
 HoistProjectFromLeftJoin (higher cost)
 --------------------------------------------------------------------------------
@@ -3032,7 +3527,7 @@ HoistProjectFromLeftJoin (higher cost)
     │         └── bool-or [as=bool_or:14, outer=(13)]
     │              └── notnull:13
     └── projections
-         └── CASE WHEN bool_or:14 THEN true WHEN bool_or:14 IS NULL THEN false ELSE CAST(NULL AS BOOL) END [as=r:12, outer=(14)]
+         └── (bool_or:14 IS true) OR (((bool_or:14 IS NULL) IS NOT true) AND CAST(NULL AS BOOL)) [as=r:12, outer=(14)]
 --------------------------------------------------------------------------------
 ReorderJoins (no changes)
 --------------------------------------------------------------------------------
@@ -3080,7 +3575,7 @@ CommuteLeftJoin (higher cost)
     │         └── bool-or [as=bool_or:14, outer=(13)]
     │              └── notnull:13
     └── projections
-         └── CASE WHEN bool_or:14 THEN true WHEN bool_or:14 IS NULL THEN false ELSE CAST(NULL AS BOOL) END [as=r:12, outer=(14)]
+         └── (bool_or:14 IS true) OR (((bool_or:14 IS NULL) IS NOT true) AND CAST(NULL AS BOOL)) [as=r:12, outer=(14)]
 --------------------------------------------------------------------------------
 GenerateMergeJoins (higher cost)
 --------------------------------------------------------------------------------
@@ -3131,7 +3626,7 @@ GenerateMergeJoins (higher cost)
     │         └── bool-or [as=bool_or:14, outer=(13)]
     │              └── notnull:13
     └── projections
-         └── CASE WHEN bool_or:14 THEN true WHEN bool_or:14 IS NULL THEN false ELSE CAST(NULL AS BOOL) END [as=r:12, outer=(14)]
+         └── (bool_or:14 IS true) OR (((bool_or:14 IS NULL) IS NOT true) AND CAST(NULL AS BOOL)) [as=r:12, outer=(14)]
 --------------------------------------------------------------------------------
 GenerateLookupJoinsWithFilter (higher cost)
 --------------------------------------------------------------------------------
@@ -3181,7 +3676,7 @@ GenerateLookupJoinsWithFilter (higher cost)
     │         └── bool-or [as=bool_or:14, outer=(13)]
     │              └── notnull:13
     └── projections
-         └── CASE WHEN bool_or:14 THEN true WHEN bool_or:14 IS NULL THEN false ELSE CAST(NULL AS BOOL) END [as=r:12, outer=(14)]
+         └── (bool_or:14 IS true) OR (((bool_or:14 IS NULL) IS NOT true) AND CAST(NULL AS BOOL)) [as=r:12, outer=(14)]
 --------------------------------------------------------------------------------
 GenerateMergeJoins (higher cost)
 --------------------------------------------------------------------------------
@@ -3231,7 +3726,7 @@ GenerateMergeJoins (higher cost)
     │         └── bool-or [as=bool_or:14, outer=(13)]
     │              └── notnull:13
     └── projections
-         └── CASE WHEN bool_or:14 THEN true WHEN bool_or:14 IS NULL THEN false ELSE CAST(NULL AS BOOL) END [as=r:12, outer=(14)]
+         └── (bool_or:14 IS true) OR (((bool_or:14 IS NULL) IS NOT true) AND CAST(NULL AS BOOL)) [as=r:12, outer=(14)]
 --------------------------------------------------------------------------------
 GenerateMergeJoins (higher cost)
 --------------------------------------------------------------------------------
@@ -3291,7 +3786,7 @@ GenerateMergeJoins (higher cost)
     │         └── bool-or [as=bool_or:14, outer=(13)]
     │              └── notnull:13
     └── projections
-         └── CASE WHEN bool_or:14 THEN true WHEN bool_or:14 IS NULL THEN false ELSE CAST(NULL AS BOOL) END [as=r:12, outer=(14)]
+         └── (bool_or:14 IS true) OR (((bool_or:14 IS NULL) IS NOT true) AND CAST(NULL AS BOOL)) [as=r:12, outer=(14)]
 ================================================================================
 GenerateStreamingGroupBy
   Cost: 2246.49
@@ -3340,7 +3835,7 @@ GenerateStreamingGroupBy
     │         └── bool-or [as=bool_or:14, outer=(13)]
     │              └── notnull:13
     └── projections
-         └── CASE WHEN bool_or:14 THEN true WHEN bool_or:14 IS NULL THEN false ELSE CAST(NULL AS BOOL) END [as=r:12, outer=(14)]
+         └── (bool_or:14 IS true) OR (((bool_or:14 IS NULL) IS NOT true) AND CAST(NULL AS BOOL)) [as=r:12, outer=(14)]
 ================================================================================
 Final best expression
   Cost: 2246.49
@@ -3388,4 +3883,4 @@ Final best expression
    │         └── bool-or [as=bool_or:14, outer=(13)]
    │              └── notnull:13
    └── projections
-        └── CASE WHEN bool_or:14 THEN true WHEN bool_or:14 IS NULL THEN false ELSE CAST(NULL AS BOOL) END [as=r:12, outer=(14)]
+        └── (bool_or:14 IS true) OR (((bool_or:14 IS NULL) IS NOT true) AND CAST(NULL AS BOOL)) [as=r:12, outer=(14)]

--- a/pkg/sql/opt/norm/testdata/rules/decorrelate
+++ b/pkg/sql/opt/norm/testdata/rules/decorrelate
@@ -931,7 +931,7 @@ project
  │         └── bool-or [as=bool_or:14, outer=(13)]
  │              └── notnull:13
  └── projections
-      └── CASE WHEN bool_or:14 THEN true WHEN bool_or:14 IS NULL THEN false ELSE CAST(NULL AS BOOL) END [as=r:12, outer=(14)]
+      └── (bool_or:14 IS true) OR (((bool_or:14 IS NULL) IS NOT true) AND CAST(NULL AS BOOL)) [as=r:12, outer=(14)]
 
 # Left join caused by zero or one cardinality subquery.
 norm expect=TryDecorrelateProjectSelect
@@ -1014,7 +1014,7 @@ project
  │         └── bool-or [as=bool_or:14, outer=(13)]
  │              └── notnull:13
  └── projections
-      └── CASE WHEN bool_or:14 THEN true WHEN bool_or:14 IS NULL THEN false ELSE CAST(NULL AS BOOL) END [as=r:12, outer=(14)]
+      └── (bool_or:14 IS true) OR (((bool_or:14 IS NULL) IS NOT true) AND CAST(NULL AS BOOL)) [as=r:12, outer=(14)]
 
 # Any clause with variable.
 norm expect=(TryDecorrelateProject,TryDecorrelateProjectSelect,TryDecorrelateScalarGroupBy)
@@ -1055,7 +1055,7 @@ project
  │         └── const-agg [as=i:2, outer=(2)]
  │              └── i:2
  └── projections
-      └── CASE WHEN bool_or:14 AND (i:2 IS NOT NULL) THEN true WHEN bool_or:14 IS NULL THEN false ELSE CAST(NULL AS BOOL) END [as=r:12, outer=(2,14)]
+      └── ((bool_or:14 AND (i:2 IS NOT NULL)) IS true) OR (((bool_or:14 IS NULL) IS NOT true) AND CAST(NULL AS BOOL)) [as=r:12, outer=(2,14)]
 
 # Any clause with more complex expression that must be cached.
 norm expect=(TryDecorrelateProject,TryDecorrelateProjectSelect,TryDecorrelateScalarGroupBy)
@@ -4434,55 +4434,49 @@ project
  ├── key: (1)
  ├── fd: (1)-->(2-5)
  └── select
-      ├── columns: k:1!null i:2 f:3 s:4 j:5 case:14
+      ├── columns: k:1!null i:2 f:3 s:4 j:5 bool_or:13
       ├── key: (1)
-      ├── fd: ()-->(14), (1)-->(2-5)
-      ├── project
-      │    ├── columns: case:14 k:1!null i:2 f:3 s:4 j:5
+      ├── fd: (1)-->(2-5,13)
+      ├── group-by (hash)
+      │    ├── columns: k:1!null i:2 f:3 s:4 j:5 bool_or:13
+      │    ├── grouping columns: k:1!null
       │    ├── key: (1)
-      │    ├── fd: (1)-->(2-5,14)
-      │    ├── group-by (hash)
-      │    │    ├── columns: k:1!null i:2 f:3 s:4 j:5 bool_or:13
-      │    │    ├── grouping columns: k:1!null
+      │    ├── fd: (1)-->(2-5,13)
+      │    ├── left-join (hash)
+      │    │    ├── columns: k:1!null i:2 f:3 s:4 j:5 x:8 y:9 notnull:12
+      │    │    ├── multiplicity: left-rows(exactly-one), right-rows(zero-or-one)
       │    │    ├── key: (1)
-      │    │    ├── fd: (1)-->(2-5,13)
-      │    │    ├── left-join (hash)
-      │    │    │    ├── columns: k:1!null i:2 f:3 s:4 j:5 x:8 y:9 notnull:12
-      │    │    │    ├── multiplicity: left-rows(exactly-one), right-rows(zero-or-one)
+      │    │    ├── fd: (1)-->(2-5,8,9,12), (8)-->(9), (9)~~>(12)
+      │    │    ├── scan a
+      │    │    │    ├── columns: k:1!null i:2 f:3 s:4 j:5
       │    │    │    ├── key: (1)
-      │    │    │    ├── fd: (1)-->(2-5,8,9,12), (8)-->(9), (9)~~>(12)
-      │    │    │    ├── scan a
-      │    │    │    │    ├── columns: k:1!null i:2 f:3 s:4 j:5
-      │    │    │    │    ├── key: (1)
-      │    │    │    │    └── fd: (1)-->(2-5)
-      │    │    │    ├── project
-      │    │    │    │    ├── columns: notnull:12!null x:8!null y:9
+      │    │    │    └── fd: (1)-->(2-5)
+      │    │    ├── project
+      │    │    │    ├── columns: notnull:12!null x:8!null y:9
+      │    │    │    ├── key: (8)
+      │    │    │    ├── fd: (8)-->(9), (9)-->(12)
+      │    │    │    ├── scan xy
+      │    │    │    │    ├── columns: x:8!null y:9
       │    │    │    │    ├── key: (8)
-      │    │    │    │    ├── fd: (8)-->(9), (9)-->(12)
-      │    │    │    │    ├── scan xy
-      │    │    │    │    │    ├── columns: x:8!null y:9
-      │    │    │    │    │    ├── key: (8)
-      │    │    │    │    │    └── fd: (8)-->(9)
-      │    │    │    │    └── projections
-      │    │    │    │         └── y:9 IS NOT NULL [as=notnull:12, outer=(9)]
-      │    │    │    └── filters
-      │    │    │         ├── x:8 = k:1 [outer=(1,8), constraints=(/1: (/NULL - ]; /8: (/NULL - ]), fd=(1)==(8), (8)==(1)]
-      │    │    │         └── (i:2 = y:9) IS NOT false [outer=(2,9)]
-      │    │    └── aggregations
-      │    │         ├── bool-or [as=bool_or:13, outer=(12)]
-      │    │         │    └── notnull:12
-      │    │         ├── const-agg [as=i:2, outer=(2)]
-      │    │         │    └── i:2
-      │    │         ├── const-agg [as=f:3, outer=(3)]
-      │    │         │    └── f:3
-      │    │         ├── const-agg [as=s:4, outer=(4)]
-      │    │         │    └── s:4
-      │    │         └── const-agg [as=j:5, outer=(5)]
-      │    │              └── j:5
-      │    └── projections
-      │         └── CASE WHEN bool_or:13 AND (i:2 IS NOT NULL) THEN true WHEN bool_or:13 IS NULL THEN false ELSE CAST(NULL AS BOOL) END [as=case:14, outer=(2,13)]
+      │    │    │    │    └── fd: (8)-->(9)
+      │    │    │    └── projections
+      │    │    │         └── y:9 IS NOT NULL [as=notnull:12, outer=(9)]
+      │    │    └── filters
+      │    │         ├── x:8 = k:1 [outer=(1,8), constraints=(/1: (/NULL - ]; /8: (/NULL - ]), fd=(1)==(8), (8)==(1)]
+      │    │         └── (i:2 = y:9) IS NOT false [outer=(2,9)]
+      │    └── aggregations
+      │         ├── bool-or [as=bool_or:13, outer=(12)]
+      │         │    └── notnull:12
+      │         ├── const-agg [as=i:2, outer=(2)]
+      │         │    └── i:2
+      │         ├── const-agg [as=f:3, outer=(3)]
+      │         │    └── f:3
+      │         ├── const-agg [as=s:4, outer=(4)]
+      │         │    └── s:4
+      │         └── const-agg [as=j:5, outer=(5)]
+      │              └── j:5
       └── filters
-           └── case:14 IS NULL [outer=(14), constraints=(/14: [/NULL - /NULL]; tight), fd=()-->(14)]
+           └── (((bool_or:13 AND (i:2 IS NOT NULL)) IS true) OR (((bool_or:13 IS NULL) IS NOT true) AND CAST(NULL AS BOOL))) IS NULL [outer=(2,13)]
 
 # Any with uncorrelated subquery (should not be hoisted).
 norm
@@ -4922,7 +4916,7 @@ project
  │         └── bool-or [as=bool_or:14, outer=(13)]
  │              └── notnull:13
  └── projections
-      └── CASE WHEN bool_or:14 THEN true WHEN bool_or:14 IS NULL THEN false ELSE CAST(NULL AS BOOL) END [as=r:12, outer=(14)]
+      └── (bool_or:14 IS true) OR (((bool_or:14 IS NULL) IS NOT true) AND CAST(NULL AS BOOL)) [as=r:12, outer=(14)]
 
 # Correlated subquery nested in uncorrelated subquery.
 norm expect=HoistProjectSubquery
@@ -5071,59 +5065,55 @@ SELECT j, y FROM a INNER JOIN xy ON x IN (SELECT v FROM uv WHERE u=y AND v=i) OR
 project
  ├── columns: j:5 y:9
  └── select
-      ├── columns: j:5 x:8!null y:9 case:18
-      ├── fd: (8)-->(9)
-      ├── project
-      │    ├── columns: case:18 j:5 x:8!null y:9
-      │    ├── fd: (8)-->(9)
-      │    ├── group-by (hash)
-      │    │    ├── columns: k:1!null j:5 x:8!null y:9 bool_or:17
-      │    │    ├── grouping columns: k:1!null x:8!null
+      ├── columns: k:1!null j:5 x:8!null y:9 bool_or:17
+      ├── key: (1,8)
+      ├── fd: (1)-->(5), (8)-->(9), (1,8)-->(5,9,17)
+      ├── group-by (hash)
+      │    ├── columns: k:1!null j:5 x:8!null y:9 bool_or:17
+      │    ├── grouping columns: k:1!null x:8!null
+      │    ├── key: (1,8)
+      │    ├── fd: (1)-->(5), (8)-->(9), (1,8)-->(5,9,17)
+      │    ├── left-join (hash)
+      │    │    ├── columns: k:1!null i:2 j:5 x:8!null y:9 u:12 v:13 notnull:16
+      │    │    ├── multiplicity: left-rows(exactly-one), right-rows(zero-or-more)
       │    │    ├── key: (1,8)
-      │    │    ├── fd: (1)-->(5), (8)-->(9), (1,8)-->(5,9,17)
-      │    │    ├── left-join (hash)
-      │    │    │    ├── columns: k:1!null i:2 j:5 x:8!null y:9 u:12 v:13 notnull:16
-      │    │    │    ├── multiplicity: left-rows(exactly-one), right-rows(zero-or-more)
+      │    │    ├── fd: (1)-->(2,5), (8)-->(9), (12)-->(13), (13)~~>(16), (1,8)-->(12,13,16)
+      │    │    ├── inner-join (cross)
+      │    │    │    ├── columns: k:1!null i:2 j:5 x:8!null y:9
       │    │    │    ├── key: (1,8)
-      │    │    │    ├── fd: (1)-->(2,5), (8)-->(9), (12)-->(13), (13)~~>(16), (1,8)-->(12,13,16)
-      │    │    │    ├── inner-join (cross)
-      │    │    │    │    ├── columns: k:1!null i:2 j:5 x:8!null y:9
-      │    │    │    │    ├── key: (1,8)
-      │    │    │    │    ├── fd: (1)-->(2,5), (8)-->(9)
-      │    │    │    │    ├── scan a
-      │    │    │    │    │    ├── columns: k:1!null i:2 j:5
-      │    │    │    │    │    ├── key: (1)
-      │    │    │    │    │    └── fd: (1)-->(2,5)
-      │    │    │    │    ├── scan xy
-      │    │    │    │    │    ├── columns: x:8!null y:9
-      │    │    │    │    │    ├── key: (8)
-      │    │    │    │    │    └── fd: (8)-->(9)
-      │    │    │    │    └── filters (true)
-      │    │    │    ├── project
-      │    │    │    │    ├── columns: notnull:16!null u:12!null v:13
+      │    │    │    ├── fd: (1)-->(2,5), (8)-->(9)
+      │    │    │    ├── scan a
+      │    │    │    │    ├── columns: k:1!null i:2 j:5
+      │    │    │    │    ├── key: (1)
+      │    │    │    │    └── fd: (1)-->(2,5)
+      │    │    │    ├── scan xy
+      │    │    │    │    ├── columns: x:8!null y:9
+      │    │    │    │    ├── key: (8)
+      │    │    │    │    └── fd: (8)-->(9)
+      │    │    │    └── filters (true)
+      │    │    ├── project
+      │    │    │    ├── columns: notnull:16!null u:12!null v:13
+      │    │    │    ├── key: (12)
+      │    │    │    ├── fd: (12)-->(13), (13)-->(16)
+      │    │    │    ├── scan uv
+      │    │    │    │    ├── columns: u:12!null v:13
       │    │    │    │    ├── key: (12)
-      │    │    │    │    ├── fd: (12)-->(13), (13)-->(16)
-      │    │    │    │    ├── scan uv
-      │    │    │    │    │    ├── columns: u:12!null v:13
-      │    │    │    │    │    ├── key: (12)
-      │    │    │    │    │    └── fd: (12)-->(13)
-      │    │    │    │    └── projections
-      │    │    │    │         └── v:13 IS NOT NULL [as=notnull:16, outer=(13)]
-      │    │    │    └── filters
-      │    │    │         ├── u:12 = y:9 [outer=(9,12), constraints=(/9: (/NULL - ]; /12: (/NULL - ]), fd=(9)==(12), (12)==(9)]
-      │    │    │         ├── v:13 = i:2 [outer=(2,13), constraints=(/2: (/NULL - ]; /13: (/NULL - ]), fd=(2)==(13), (13)==(2)]
-      │    │    │         └── (x:8 = v:13) IS NOT false [outer=(8,13)]
-      │    │    └── aggregations
-      │    │         ├── bool-or [as=bool_or:17, outer=(16)]
-      │    │         │    └── notnull:16
-      │    │         ├── const-agg [as=y:9, outer=(9)]
-      │    │         │    └── y:9
-      │    │         └── const-agg [as=j:5, outer=(5)]
-      │    │              └── j:5
-      │    └── projections
-      │         └── CASE WHEN bool_or:17 AND (x:8 IS NOT NULL) THEN true WHEN bool_or:17 IS NULL THEN false ELSE CAST(NULL AS BOOL) END [as=case:18, outer=(8,17)]
+      │    │    │    │    └── fd: (12)-->(13)
+      │    │    │    └── projections
+      │    │    │         └── v:13 IS NOT NULL [as=notnull:16, outer=(13)]
+      │    │    └── filters
+      │    │         ├── u:12 = y:9 [outer=(9,12), constraints=(/9: (/NULL - ]; /12: (/NULL - ]), fd=(9)==(12), (12)==(9)]
+      │    │         ├── v:13 = i:2 [outer=(2,13), constraints=(/2: (/NULL - ]; /13: (/NULL - ]), fd=(2)==(13), (13)==(2)]
+      │    │         └── (x:8 = v:13) IS NOT false [outer=(8,13)]
+      │    └── aggregations
+      │         ├── bool-or [as=bool_or:17, outer=(16)]
+      │         │    └── notnull:16
+      │         ├── const-agg [as=y:9, outer=(9)]
+      │         │    └── y:9
+      │         └── const-agg [as=j:5, outer=(5)]
+      │              └── j:5
       └── filters
-           └── case:18 OR (x:8 IS NULL) [outer=(8,18)]
+           └── (((bool_or:17 AND (x:8 IS NOT NULL)) IS true) OR (((bool_or:17 IS NULL) IS NOT true) AND CAST(NULL AS BOOL))) OR (x:8 IS NULL) [outer=(8,17)]
 
 
 # --------------------------------------------------
@@ -5256,7 +5246,7 @@ project
  │         └── bool-or [as=bool_or:14, outer=(13)]
  │              └── notnull:13
  └── projections
-      └── CASE WHEN bool_or:14 THEN true WHEN bool_or:14 IS NULL THEN false ELSE CAST(NULL AS BOOL) END [as=column1:16, outer=(14)]
+      └── (bool_or:14 IS true) OR (((bool_or:14 IS NULL) IS NOT true) AND CAST(NULL AS BOOL)) [as=column1:16, outer=(14)]
 
 # ---------------------------------------------------
 # HoistProjectSetSubquery + TryDecorrelateProjectSet

--- a/pkg/sql/opt/norm/testdata/rules/scalar
+++ b/pkg/sql/opt/norm/testdata/rules/scalar
@@ -29,6 +29,10 @@ CREATE TABLE b
 )
 ----
 
+exec-ddl
+CREATE TABLE bools (a BOOL, b BOOL, c BOOL, d BOOL, e BOOL)
+----
+
 # --------------------------------------------------
 # CommuteVar
 # --------------------------------------------------
@@ -2371,3 +2375,272 @@ project
  └── projections
       ├── b.arr:5[1] [as=arr:8, outer=(5)]
       └── b.arr:5[2] [as=arr:9, outer=(5)]
+
+# --------------------------------------------------
+# SimplifyLeakproofBooleanCase
+# --------------------------------------------------
+
+# Expecting (a OR (b OR c)).
+norm expect=SimplifyLeakproofBooleanCase
+SELECT CASE WHEN a THEN True WHEN b THEN True ELSE c END FROM bools;
+----
+project
+ ├── columns: c:9
+ ├── scan bools
+ │    └── columns: a:1 b:2 bools.c:3
+ └── projections
+      └── (a:1 IS true) OR ((b:2 IS true) OR bools.c:3) [as=c:9, outer=(1-3)]
+
+# Expecting (a OR ((b IS NOT TRUE) AND c)). We use "b IS NOT True" instead of
+# "NOT b" because we want it to return True when b is NULL.
+norm expect=SimplifyLeakproofBooleanCase
+SELECT CASE WHEN a THEN True WHEN b THEN FALSE ELSE c END FROM bools;
+----
+project
+ ├── columns: c:9
+ ├── scan bools
+ │    └── columns: a:1 b:2 bools.c:3
+ └── projections
+      └── (a:1 IS true) OR ((b:2 IS NOT true) AND bools.c:3) [as=c:9, outer=(1-3)]
+
+# Expecting ((a IS NOT TRUE) AND (b OR c)).
+norm expect=SimplifyLeakproofBooleanCase
+SELECT CASE WHEN a THEN False WHEN b THEN True ELSE c END FROM bools;
+----
+project
+ ├── columns: c:9
+ ├── scan bools
+ │    └── columns: a:1 b:2 bools.c:3
+ └── projections
+      └── (a:1 IS NOT true) AND ((b:2 IS true) OR bools.c:3) [as=c:9, outer=(1-3)]
+
+# Expecting ((a IS NOT TRUE) AND ((b IS NOT TRUE) AND c)).
+norm expect=SimplifyLeakproofBooleanCase
+SELECT CASE WHEN a THEN False WHEN b THEN False ELSE c END FROM bools;
+----
+project
+ ├── columns: c:9
+ ├── scan bools
+ │    └── columns: a:1 b:2 bools.c:3
+ └── projections
+      └── ((a:1 IS NOT true) AND (b:2 IS NOT true)) AND bools.c:3 [as=c:9, outer=(1-3)]
+
+# CASE condition is False. Expecting ((NOT a) OR ((NOT b) OR c)).
+norm expect=SimplifyLeakproofBooleanCase
+SELECT CASE False WHEN a THEN True WHEN b THEN True ELSE c END FROM bools;
+----
+project
+ ├── columns: c:9
+ ├── scan bools
+ │    └── columns: a:1 b:2 bools.c:3
+ └── projections
+      └── ((NOT a:1) IS true) OR (((NOT b:2) IS true) OR bools.c:3) [as=c:9, outer=(1-3)]
+
+# CASE condition is False. Expecting ((NOT a) OR (((NOT b) IS NOT TRUE) AND c)).
+norm expect=SimplifyLeakproofBooleanCase
+SELECT CASE False WHEN a THEN True WHEN b THEN FALSE ELSE c END FROM bools;
+----
+project
+ ├── columns: c:9
+ ├── scan bools
+ │    └── columns: a:1 b:2 bools.c:3
+ └── projections
+      └── ((NOT a:1) IS true) OR (((NOT b:2) IS NOT true) AND bools.c:3) [as=c:9, outer=(1-3)]
+
+# CASE condition is False. Expecting (((NOT a) IS NOT TRUE) AND ((NOT b) OR c)).
+norm expect=SimplifyLeakproofBooleanCase
+SELECT CASE False WHEN a THEN False WHEN b THEN True ELSE c END FROM bools;
+----
+project
+ ├── columns: c:9
+ ├── scan bools
+ │    └── columns: a:1 b:2 bools.c:3
+ └── projections
+      └── ((NOT a:1) IS NOT true) AND (((NOT b:2) IS true) OR bools.c:3) [as=c:9, outer=(1-3)]
+
+# CASE condition is False.
+# Expecting (((NOT a) IS NOT TRUE) AND (((NOT b) IS NOT TRUE) AND c)).
+norm expect=SimplifyLeakproofBooleanCase
+SELECT CASE False WHEN a THEN False WHEN b THEN False ELSE c END FROM bools;
+----
+project
+ ├── columns: c:9
+ ├── scan bools
+ │    └── columns: a:1 b:2 bools.c:3
+ └── projections
+      └── (((NOT a:1) IS NOT true) AND ((NOT b:2) IS NOT true)) AND bools.c:3 [as=c:9, outer=(1-3)]
+
+# CASE condition is NULL. Expecting (c) because the WHEN branches are simplified
+# to NULL (even the WHEN NULL branch because NULL = NULL is NULL).
+norm expect=SimplifyLeakproofBooleanCase
+SELECT CASE NULL WHEN a THEN True WHEN b THEN True WHEN NULL THEN True ELSE c END FROM bools;
+----
+project
+ ├── columns: c:9
+ ├── scan bools
+ │    └── columns: bools.c:3
+ └── projections
+      └── bools.c:3 [as=c:9, outer=(3)]
+
+# CASE condition is NULL. Expecting (c).
+norm expect=SimplifyLeakproofBooleanCase
+SELECT CASE NULL WHEN a THEN True WHEN b THEN False WHEN NULL THEN True ELSE c END FROM bools;
+----
+project
+ ├── columns: c:9
+ ├── scan bools
+ │    └── columns: bools.c:3
+ └── projections
+      └── bools.c:3 [as=c:9, outer=(3)]
+
+# CASE condition is NULL. Expecting (c).
+norm expect=SimplifyLeakproofBooleanCase
+SELECT CASE NULL WHEN a THEN False WHEN b THEN True WHEN NULL THEN True ELSE c END FROM bools;
+----
+project
+ ├── columns: c:9
+ ├── scan bools
+ │    └── columns: bools.c:3
+ └── projections
+      └── bools.c:3 [as=c:9, outer=(3)]
+
+# CASE condition is NULL. Expecting (c).
+norm expect=SimplifyLeakproofBooleanCase
+SELECT CASE NULL WHEN a THEN False WHEN b THEN False WHEN NULL THEN True ELSE c END FROM bools;
+----
+project
+ ├── columns: c:9
+ ├── scan bools
+ │    └── columns: bools.c:3
+ └── projections
+      └── bools.c:3 [as=c:9, outer=(3)]
+
+# WHEN branch returns NULL.
+norm expect=SimplifyLeakproofBooleanCase
+SELECT CASE WHEN a THEN NULL WHEN b THEN True ELSE c END FROM bools;
+----
+project
+ ├── columns: c:9
+ ├── scan bools
+ │    └── columns: a:1 b:2 bools.c:3
+ └── projections
+      └── ((a:1 IS true) AND NULL) OR ((a:1 IS NOT true) AND ((b:2 IS true) OR bools.c:3)) [as=c:9, outer=(1-3)]
+
+# WHEN branch returns NULL.
+norm expect=SimplifyLeakproofBooleanCase
+SELECT CASE WHEN a THEN NULL WHEN b THEN FALSE ELSE c END FROM bools;
+----
+project
+ ├── columns: c:9
+ ├── scan bools
+ │    └── columns: a:1 b:2 bools.c:3
+ └── projections
+      └── ((a:1 IS true) AND NULL) OR (((a:1 IS NOT true) AND (b:2 IS NOT true)) AND bools.c:3) [as=c:9, outer=(1-3)]
+
+# WHEN branch returns NULL.
+norm expect=SimplifyLeakproofBooleanCase
+SELECT CASE WHEN a THEN True WHEN b THEN NULL ELSE c END FROM bools;
+----
+project
+ ├── columns: c:9
+ ├── scan bools
+ │    └── columns: a:1 b:2 bools.c:3
+ └── projections
+      └── (a:1 IS true) OR (((b:2 IS true) AND NULL) OR ((b:2 IS NOT true) AND bools.c:3)) [as=c:9, outer=(1-3)]
+
+# WHEN branch returns NULL.
+norm expect=SimplifyLeakproofBooleanCase
+SELECT CASE WHEN a THEN False WHEN b THEN NULL ELSE c END FROM bools;
+----
+project
+ ├── columns: c:9
+ ├── scan bools
+ │    └── columns: a:1 b:2 bools.c:3
+ └── projections
+      └── (a:1 IS NOT true) AND (((b:2 IS true) AND CAST(NULL AS BOOL)) OR ((b:2 IS NOT true) AND bools.c:3)) [as=c:9, outer=(1-3)]
+
+# Both WHEN branches return NULL.
+norm expect=SimplifyLeakproofBooleanCase
+SELECT CASE WHEN a THEN NULL WHEN b THEN NULL ELSE c END FROM bools;
+----
+project
+ ├── columns: c:9
+ ├── scan bools
+ │    └── columns: a:1 b:2 bools.c:3
+ └── projections
+      └── ((a:1 IS true) AND NULL) OR ((a:1 IS NOT true) AND (((b:2 IS true) AND NULL) OR ((b:2 IS NOT true) AND bools.c:3))) [as=c:9, outer=(1-3)]
+
+# More complex conditions.
+# Expecting ((a OR b) OR ((b AND c) OR (d OR (NOT e)))).
+norm expect=SimplifyLeakproofBooleanCase
+SELECT CASE WHEN a OR b THEN True WHEN b AND c THEN True ELSE d OR NOT e END FROM bools;
+----
+project
+ ├── columns: case:9
+ ├── scan bools
+ │    └── columns: a:1 b:2 c:3 d:4 e:5
+ └── projections
+      └── ((a:1 OR b:2) IS true) OR (((b:2 AND c:3) IS true) OR (d:4 OR (NOT e:5))) [as=case:9, outer=(1-5)]
+
+exec-ddl
+CREATE FUNCTION f(a INT, b INT) RETURNS BOOL LANGUAGE SQL VOLATILE AS $$
+  SELECT a + b < 0
+$$
+----
+
+# No-op because the CASE is not leak-proof.
+norm expect-not=SimplifyLeakproofBooleanCase
+SELECT CASE WHEN a THEN False WHEN b AND f(1, 2) THEN True ELSE c END FROM bools;
+----
+project
+ ├── columns: c:12
+ ├── volatile
+ ├── scan bools
+ │    └── columns: bools.a:1 bools.b:2 bools.c:3
+ └── projections
+      └── CASE WHEN bools.a:1 THEN false WHEN bools.b:2 AND f(1, 2) THEN true ELSE bools.c:3 END [as=c:12, outer=(1-3), volatile, udf]
+
+# No-op because the CASE is not leak-proof.
+norm expect-not=SimplifyLeakproofBooleanCase
+SELECT CASE WHEN a THEN False WHEN b THEN True ELSE c AND 1/0 > 0 END FROM bools;
+----
+project
+ ├── columns: case:9
+ ├── immutable
+ ├── scan bools
+ │    └── columns: a:1 b:2 c:3
+ └── projections
+      └── CASE WHEN a:1 THEN false WHEN b:2 THEN true ELSE c:3 AND ((1 / 0) > 0) END [as=case:9, outer=(1-3), immutable]
+
+# No-op because the CASE condition is not constant.
+norm expect-not=SimplifyLeakproofBooleanCase
+SELECT CASE a WHEN b THEN False WHEN c THEN True ELSE d END FROM bools;
+----
+project
+ ├── columns: d:9
+ ├── scan bools
+ │    └── columns: a:1 b:2 c:3 bools.d:4
+ └── projections
+      └── CASE a:1 WHEN b:2 THEN false WHEN c:3 THEN true ELSE bools.d:4 END [as=d:9, outer=(1-4)]
+
+# No-op because one of the WHEN branches returns a non-constant value.
+norm expect-not=SimplifyLeakproofBooleanCase
+SELECT CASE WHEN a THEN False WHEN b THEN d ELSE c END FROM bools;
+----
+project
+ ├── columns: c:9
+ ├── scan bools
+ │    └── columns: a:1 b:2 bools.c:3 d:4
+ └── projections
+      └── CASE WHEN a:1 THEN false WHEN b:2 THEN d:4 ELSE bools.c:3 END [as=c:9, outer=(1-4)]
+
+# No-op because the CASE returns the wrong type.
+norm expect-not=SimplifyLeakproofBooleanCase
+SELECT CASE WHEN a THEN 1 WHEN b THEN 0 ELSE -1 END FROM bools;
+----
+project
+ ├── columns: case:9
+ ├── scan bools
+ │    └── columns: a:1 b:2
+ └── projections
+      └── CASE WHEN a:1 THEN 1 WHEN b:2 THEN 0 ELSE -1 END [as=case:9, outer=(1,2)]

--- a/pkg/sql/opt/norm/testdata/rules/udf
+++ b/pkg/sql/opt/norm/testdata/rules/udf
@@ -1,4 +1,8 @@
 exec-ddl
+CREATE TABLE xy (x INT, y INT);
+----
+
+exec-ddl
 CREATE FUNCTION one() RETURNS INT LANGUAGE SQL AS 'SELECT 1';
 ----
 
@@ -67,3 +71,69 @@ values
                      ├── fd: ()-->(4)
                      └── tuple
                           └── variable: i:1
+
+# The CASE expression cannot be optimized away for nullable non-constant
+# arguments of a volatile function.
+norm format=show-scalars
+SELECT strict_fn(x, 'foo', true) FROM xy;
+----
+project
+ ├── columns: strict_fn:10
+ ├── volatile
+ ├── scan xy
+ │    └── columns: x:1
+ └── projections
+      └── case [as=strict_fn:10, outer=(1), volatile, udf]
+           ├── true
+           ├── when
+           │    ├── is
+           │    │    ├── variable: x:1
+           │    │    └── null
+           │    └── null
+           └── udf: strict_fn
+                ├── params: i:6 t:7 b:8
+                ├── args
+                │    ├── variable: x:1
+                │    ├── const: 'foo'
+                │    └── true
+                └── body
+                     └── values
+                          ├── columns: i:9
+                          ├── outer: (6)
+                          ├── cardinality: [1 - 1]
+                          ├── key: ()
+                          ├── fd: ()-->(9)
+                          └── tuple
+                               └── variable: i:6
+
+exec-ddl
+CREATE FUNCTION strict_stable_fn(i INT, t TEXT, b BOOl) RETURNS BOOL STABLE STRICT LANGUAGE SQL AS 'SELECT i > 0'
+----
+
+# The CASE expression can be simplified after the stable function call is
+# hoisted.
+norm format=show-scalars
+SELECT * FROM xy WHERE strict_stable_fn(x, 'foo', true);
+----
+select
+ ├── columns: x:1!null y:2
+ ├── scan xy
+ │    └── columns: x:1 y:2
+ └── filters
+      └── or [outer=(1), constraints=(/1: [/1 - ])]
+           ├── and
+           │    ├── is
+           │    │    ├── is
+           │    │    │    ├── variable: x:1
+           │    │    │    └── null
+           │    │    └── true
+           │    └── null
+           └── and
+                ├── is-not
+                │    ├── is
+                │    │    ├── variable: x:1
+                │    │    └── null
+                │    └── true
+                └── gt
+                     ├── variable: x:1
+                     └── const: 0

--- a/pkg/sql/opt/ops/scalar.opt
+++ b/pkg/sql/opt/ops/scalar.opt
@@ -721,8 +721,7 @@ define Case {
 }
 
 # When represents a single WHEN ... THEN ... condition inside a CASE statement.
-# It is the type of each list item in Whens (except for the last item which is
-# a raw expression for the ELSE statement).
+# It is the type of each list item in Whens.
 [Scalar]
 define When {
     Condition ScalarExpr

--- a/pkg/sql/opt/xform/testdata/rules/disjunction_in_join
+++ b/pkg/sql/opt/xform/testdata/rules/disjunction_in_join
@@ -3744,7 +3744,7 @@ project
       │    │         └── bool-or [as=bool_or:20, outer=(19)]
       │    │              └── notnull:19
       │    └── projections
-      │         └── CASE WHEN bool_or:20 AND (t1.a2:2 IS NOT NULL) THEN true WHEN bool_or:20 IS NULL THEN false ELSE CAST(NULL AS BOOL) END [as=case:21, outer=(2,20)]
+      │         └── ((bool_or:20 AND (t1.a2:2 IS NOT NULL)) IS true) OR (((bool_or:20 IS NULL) IS NOT true) AND CAST(NULL AS BOOL)) [as=case:21, outer=(2,20)]
       └── filters
            └── or [outer=(2,21), correlated-subquery]
                 ├── case:21
@@ -3801,7 +3801,7 @@ project
       │    │         └── bool-or [as=bool_or:20, outer=(19)]
       │    │              └── notnull:19
       │    └── projections
-      │         └── CASE WHEN bool_or:20 AND (t1.a2:2 IS NOT NULL) THEN true WHEN bool_or:20 IS NULL THEN false ELSE CAST(NULL AS BOOL) END [as=case:21, outer=(2,20)]
+      │         └── ((bool_or:20 AND (t1.a2:2 IS NOT NULL)) IS true) OR (((bool_or:20 IS NULL) IS NOT true) AND CAST(NULL AS BOOL)) [as=case:21, outer=(2,20)]
       └── filters
            └── or [outer=(2,21), correlated-subquery]
                 ├── NOT case:21


### PR DESCRIPTION
This patch adds a normalization rule `SimplifyLeakproofBooleanCase` that replaces a leak-proof boolean CASE statement with an equivalent boolean expression built using `AND` and `OR` operators. This is possible when the following conditions are satisfied:
  1. The CASE statement returns a boolean value.
  2. The CASE statement is leak-proof.
  3. The CASE condition is a *constant* boolean value (True, False, NULL).
  4. Each WHEN branch returns a *constant* boolean value.

Example:
```
CASE WHEN a THEN False WHEN b THEN True ELSE c END
=>
((a IS NOT True) AND (b OR c))
```
See the `ConvertCaseToCondition` comment for details.

This is useful for strict UDFs, which implement the argument NULL check using a CASE statement.

Informs #96218

Release note: None