### PR TITLE
server,cli: enable emergency cluster access when tenant is unavailable

### DIFF
--- a/pkg/cli/cliflags/flags.go
+++ b/pkg/cli/cliflags/flags.go
@@ -458,6 +458,16 @@ or both forms can be used together, for example:
   --join=localhost:1234,localhost:2345 --join=localhost:3456</PRE>`,
 	}
 
+	DisablePreStartTenantServers = FlagInfo{
+		Name:   "disable-prestart-tenant-servers",
+		EnvVar: "COCKROACH_DISABLE_PRESTART_TENANT_SERVERS",
+		Description: `
+When set, the server will immediately start up and not wait for
+secondary tenant servers. This flag ensures the operator still can
+access the SQL interface to the system even when a tenant server is
+unable to function properly.`,
+	}
+
 	JoinPreferSRVRecords = FlagInfo{
 		Name: "experimental-dns-srv",
 		Description: `

--- a/pkg/cli/flags.go
+++ b/pkg/cli/flags.go
@@ -386,12 +386,16 @@ func init() {
 			_ = f.MarkHidden(cliflags.InitToken.Name)
 		}
 
-		// Node attributes.
-		//
-		// TODO(knz): do we want SQL-only servers to have node-level
-		// attributes too? Would this be useful for e.g. SQL query
-		// planning?
 		if cmd != connectInitCmd && cmd != connectJoinCmd {
+			// Allow an operator to "break the glass" and avoid
+			// waiting for (broken) secondary tenants to become ready.
+			cliflagcfg.BoolFlag(f, &serverCfg.DisablePreStartTenantServers, cliflags.DisablePreStartTenantServers)
+
+			// Node attributes.
+			//
+			// TODO(knz): do we want SQL-only servers to have node-level
+			// attributes too? Would this be useful for e.g. SQL query
+			// planning?
 			cliflagcfg.StringFlag(f, &serverCfg.Attrs, cliflags.Attrs)
 		}
 	}

--- a/pkg/cli/interactive_tests/test_tenant_first_start.tcl
+++ b/pkg/cli/interactive_tests/test_tenant_first_start.tcl
@@ -1,0 +1,33 @@
+#! /usr/bin/env expect -f
+
+source [file join [file dirname $argv0] common.tcl]
+
+start_server $argv
+
+system "$argv sql --no-line-editor -e 'CREATE TENANT foo; ALTER TENANT foo START SERVICE SHARED'"
+
+# Nuke the tenant keyspace from underneath the tenant record. this
+# ensures that the service will always fail to start.
+system "echo '{\"requests\": \[{\"deleteRange\": {\"header\": {\"key\": \"/oo=\", \"endKey\": \"//8=\"}}}\]}' | $argv debug send-kv-batch"
+
+stop_server $argv
+
+spawn /bin/bash
+send "PS1=':''/# '\r"
+
+set prompt ":/# "
+eexpect $prompt
+
+start_test "Check that the server can start properly if prestart is disabled."
+# Given that the tenant is busted, without the flag the server would fail to start
+# properly.
+send "$argv start-single-node --insecure --store=logs/db --disable-prestart-tenant-servers\r"
+eexpect "CockroachDB node starting"
+eexpect "restarted pre-existing node"
+interrupt
+eexpect "interrupted"
+eexpect $prompt
+end_test
+
+send "exit\r"
+eexpect eof

--- a/pkg/cli/interactive_tests/test_tenant_first_start.tcl
+++ b/pkg/cli/interactive_tests/test_tenant_first_start.tcl
@@ -29,5 +29,14 @@ eexpect "interrupted"
 eexpect $prompt
 end_test
 
+start_test "Check that the server properly fails to initialize if the pre-start tenants fail to start"
+send "$argv start-single-node --insecure --store=logs/db\r"
+eexpect ERROR
+eexpect "server startup failed"
+eexpect "failed to start the server controller"
+eexpect "does not exist"
+eexpect $prompt
+end_test
+
 send "exit\r"
 eexpect eof

--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -257,6 +257,11 @@ type BaseConfig struct {
 	// These events are meant for the Observability Service, but they might pass
 	// through an OpenTelemetry Collector.
 	ObsServiceAddr string
+
+	// DisablePreStartTenantServers prevents the serverController from
+	// starting up and waiting on initialization of shared-process
+	// secondary tenant servers.
+	DisablePreStartTenantServers bool
 }
 
 // MakeBaseConfig returns a BaseConfig with default values.

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -2019,6 +2019,7 @@ func (s *Server) PreStart(ctx context.Context) error {
 	// Let the server controller start watching tenant service mode changes.
 	if err := s.serverController.start(workersCtx,
 		s.node.execCfg.InternalDB.Executor(),
+		!s.cfg.DisablePreStartTenantServers,
 	); err != nil {
 		return errors.Wrap(err, "failed to start the server controller")
 	}

--- a/pkg/server/server_controller.go
+++ b/pkg/server/server_controller.go
@@ -14,6 +14,7 @@ import (
 	"context"
 	"net"
 	"net/http"
+	"sync/atomic"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
@@ -94,11 +95,12 @@ type serverController struct {
 		// TODO(knz): Detect when the mapping of name to tenant ID has
 		// changed, and invalidate the entry.
 		servers map[roachpb.TenantName]serverState
-
-		// nextServerIdx is the index to provide to the next call to
-		// newServerFn.
-		nextServerIdx int
 	}
+
+	// nextServerIdx is the index to provide to the next call to
+	// newServerFn. This is updated concurrently, use the atomic
+	// package to access.
+	nextServerIdx atomic.Uint32
 }
 
 func newServerController(

--- a/pkg/server/server_controller_orchestration.go
+++ b/pkg/server/server_controller_orchestration.go
@@ -32,12 +32,18 @@ import (
 
 // start monitors changes to the service mode and updates
 // the running servers accordingly.
-func (c *serverController) start(ctx context.Context, ie isql.Executor) error {
-	// We perform one round of updates synchronously, to ensure that
-	// any tenants already in service mode SHARED get a chance to boot
-	// up before we signal readiness.
-	if err := c.startInitialSecondaryTenantServers(ctx, ie); err != nil {
-		return err
+func (c *serverController) start(
+	ctx context.Context, ie isql.Executor, autoStartAndWaitForSharedServers bool,
+) error {
+	if autoStartAndWaitForSharedServers {
+		// We perform one round of updates synchronously, to ensure that
+		// any tenants already in service mode SHARED get a chance to boot
+		// up before we signal readiness.
+		if err := c.startInitialSecondaryTenantServers(ctx, ie); err != nil {
+			return err
+		}
+	} else {
+		log.Infof(ctx, "not waiting for secondary tenant servers to become ready")
 	}
 
 	// Run the detection of which servers should be started or stopped.

--- a/pkg/server/server_controller_orchestration_method.go
+++ b/pkg/server/server_controller_orchestration_method.go
@@ -117,6 +117,9 @@ type serverOrchestrator interface {
 		// tenantName is the name of the tenant for which a server should
 		// be created.
 		tenantName roachpb.TenantName,
+		// retryStartupOnFailure indicates whether the server startup should
+		// retry until it succeeds.
+		retryStartupOnFailure bool,
 		// finalizeFn is called when the server is fully stopped.
 		// This is always called, even if there is a server startup error.
 		// It is also called asynchronously, possibly after

--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -908,7 +908,10 @@ func (ts *TestServer) StartSharedProcessTenant(
 	}
 
 	// Instantiate the tenant server.
-	s, err := ts.Server.serverController.startAndWaitForRunningServer(ctx, args.TenantName)
+	s, err := ts.Server.serverController.startAndWaitForRunningServer(ctx, args.TenantName,
+		false, /* expectNoEntryYet */
+		true,  /* retryStartupOnFailure */
+	)
 	if err != nil {
 		return nil, nil, err
 	}


### PR DESCRIPTION
Fixes #96547.
Epic: CRDB-23559

See individual commits for details.