### PR TITLE
kvcoord: Return context error when context done

### DIFF
--- a/pkg/kv/kvclient/kvcoord/dist_sender_mux_rangefeed.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender_mux_rangefeed.go
@@ -345,7 +345,7 @@ func (m *rangefeedMuxer) receiveEventsFromNode(ctx context.Context, ms *muxClien
 			// Normally, when ctx is done, we would receive streamErr above.
 			// But it's possible that the context was canceled right after the last Recv(),
 			// and in that case we must exit.
-			return nil
+			return ctx.Err()
 		case <-m.demuxLoopDone:
 			// demuxLoop exited, and so should we (happens when main context group completes)
 			return nil


### PR DESCRIPTION
Fix a silly error which ignored the fact that in addition to receive loop, the caller may be blocked on Recv() call, and receiving both nil event and nil error would be suprising.

Fixes #96544
Fixes #96558

Releaste note: None