### PR TITLE
parser: no-op if QUOTE '"' is specified in COPY

### DIFF
--- a/docs/generated/sql/bnf/stmt_block.bnf
+++ b/docs/generated/sql/bnf/stmt_block.bnf
@@ -2002,6 +2002,7 @@ copy_options ::=
 	| 'DELIMITER' string_or_placeholder
 	| 'NULL' string_or_placeholder
 	| 'HEADER'
+	| 'QUOTE' 'SCONST'
 
 db_object_name_component ::=
 	name

--- a/pkg/sql/copy/testdata/copyfrom
+++ b/pkg/sql/copy/testdata/copyfrom
@@ -2,6 +2,17 @@ exec-ddl
 CREATE TABLE t (a int)
 ----
 
+# copy quote without CSV not allowed.
+copy-error
+COPY t FROM STDIN QUOTE '"'
+----
+ERROR: QUOTE only supported with CSV format (SQLSTATE 0A000)
+
+copy-error
+COPY t FROM STDIN QUOTE 'x'
+----
+ERROR: QUOTE only supported with CSV format (SQLSTATE 0A000)
+
 # builtins not allowed
 copy-error
 COPY t FROM STDIN
@@ -10,7 +21,7 @@ random()
 ERROR: could not parse "random()" as type int: strconv.ParseInt: parsing "random()": invalid syntax (SQLSTATE 22P02)
 
 copy
-COPY t FROM STDIN
+COPY t FROM STDIN QUOTE '"' CSV
 ----
 0
 

--- a/pkg/sql/parser/parse_test.go
+++ b/pkg/sql/parser/parse_test.go
@@ -408,7 +408,6 @@ func TestUnimplementedSyntax(t *testing.T) {
 		{`COPY t FROM STDIN OIDS`, 41608, `oids`, ``},
 		{`COPY t FROM STDIN FREEZE`, 41608, `freeze`, ``},
 		{`COPY t FROM STDIN ENCODING 'utf-8'`, 41608, `encoding`, ``},
-		{`COPY t FROM STDIN QUOTE 'x'`, 41608, `quote`, ``},
 		{`COPY t FROM STDIN FORCE QUOTE *`, 41608, `quote`, ``},
 		{`COPY t FROM STDIN FORCE NULL *`, 41608, `force null`, ``},
 		{`COPY t FROM STDIN FORCE NOT NULL *`, 41608, `force not null`, ``},

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -3977,7 +3977,7 @@ copy_options:
   }
 | QUOTE SCONST
   {
-    return unimplementedWithIssueDetail(sqllex, 41608, "quote")
+    $$.val = &tree.CopyOptions{Quote: tree.NewStrVal($2)}
   }
 | ESCAPE SCONST error
   {

--- a/pkg/sql/parser/testdata/copy
+++ b/pkg/sql/parser/testdata/copy
@@ -15,6 +15,14 @@ COPY t (a, b, c) FROM STDIN -- literals removed
 COPY _ (_, _, _) FROM STDIN -- identifiers removed
 
 parse
+COPY t FROM STDIN QUOTE '"'
+----
+COPY t FROM STDIN WITH QUOTE '"' -- normalized!
+COPY t FROM STDIN WITH QUOTE ('"') -- fully parenthesized
+COPY t FROM STDIN WITH QUOTE '_' -- literals removed
+COPY _ FROM STDIN WITH QUOTE '"' -- identifiers removed
+
+parse
 COPY crdb_internal.file_upload FROM STDIN WITH destination = 'filename'
 ----
 COPY crdb_internal.file_upload FROM STDIN WITH destination = 'filename'

--- a/pkg/sql/sem/tree/copy.go
+++ b/pkg/sql/sem/tree/copy.go
@@ -31,6 +31,7 @@ type CopyOptions struct {
 	Null        Expr
 	Escape      *StrVal
 	Header      bool
+	Quote       *StrVal
 }
 
 var _ NodeFormatter = &CopyOptions{}
@@ -102,6 +103,11 @@ func (o *CopyOptions) Format(ctx *FmtCtx) {
 		maybeAddSep()
 		ctx.WriteString("HEADER")
 	}
+	if o.Quote != nil {
+		maybeAddSep()
+		ctx.WriteString("QUOTE ")
+		ctx.FormatNode(o.Quote)
+	}
 }
 
 // IsDefault returns true if this struct has default value.
@@ -144,6 +150,12 @@ func (o *CopyOptions) CombineWith(other *CopyOptions) error {
 	}
 	if other.Header {
 		o.Header = true
+	}
+	if other.Quote != nil {
+		if o.Quote != nil {
+			return pgerror.Newf(pgcode.Syntax, "quote option specified multiple times")
+		}
+		o.Quote = other.Quote
 	}
 	return nil
 }


### PR DESCRIPTION
Release note (sql change): `COPY ... FROM ... QUOTE '"'` will no longer error.

Epic: None

Informs: https://github.com/cockroachdb/cockroach/issues/85574

Release justification: fixes usability issues with third party tools that is really a no-op.