### PR TITLE
tracingpb: add goroutine ID to jaeger trace

### DIFF
--- a/pkg/util/tracing/tracingpb/recording.go
+++ b/pkg/util/tracing/tracingpb/recording.go
@@ -454,6 +454,13 @@ func (r Recording) ToJaegerJSON(stmt, comment, nodeStr string) (string, error) {
 			}}
 		}
 
+		if sp.GoroutineID != 0 {
+			s.Tags = append(s.Tags, jaegerjson.KeyValue{
+				Key:   "goroutine",
+				Value: sp.GoroutineID,
+				Type:  jaegerjson.Int64Type,
+			})
+		}
 		for _, tagGroup := range sp.TagGroups {
 			for _, tag := range tagGroup.Tags {
 				var prefix string


### PR DESCRIPTION
This improves #96332 by including (as a tag) the goroutine ID under
which spans are created. This allows following the trace in a Go
execution trace if one is available.

<img width="584" alt="image" src="https://user-images.githubusercontent.com/5076964/216915979-4f2f5d00-0f09-47c8-a90e-18fc8f3c78f7.png">

Closes #96332.

Epic: none
Release note: None
