### PR TITLE
release-22.1: tracingpb: add goroutine ID to jaeger trace

### DIFF
--- a/pkg/util/tracing/recording.go
+++ b/pkg/util/tracing/recording.go
@@ -409,6 +409,13 @@ func (r Recording) ToJaegerJSON(stmt, comment, nodeStr string) (string, error) {
 			}}
 		}
 
+		if sp.GoroutineID != 0 {
+			s.Tags = append(s.Tags, jaegerjson.KeyValue{
+				Key:   "goroutine",
+				Value: sp.GoroutineID,
+				Type:  jaegerjson.Int64Type,
+			})
+		}
 		for k, v := range sp.Tags {
 			s.Tags = append(s.Tags, jaegerjson.KeyValue{
 				Key:   k,


### PR DESCRIPTION
Backport 1/1 commits from #96629.

/cc @cockroachdb/release

Release justification: observability improvement for L2.

---

This improves #96332 by including (as a tag) the goroutine ID under
which spans are created. This allows following the trace in a Go
execution trace if one is available.

<img width="584" alt="image" src="https://user-images.githubusercontent.com/5076964/216915979-4f2f5d00-0f09-47c8-a90e-18fc8f3c78f7.png">

Closes #96332.

Epic: none
Release note: None

