### PR TITLE
kvserver: extract kvstorage.DestroyReplica

### DIFF
--- a/pkg/kv/kvserver/client_store_test.go
+++ b/pkg/kv/kvserver/client_store_test.go
@@ -91,8 +91,7 @@ func TestStoreRaftReplicaID(t *testing.T) {
 	require.NoError(t, err)
 	repl, err := store.GetReplica(desc.RangeID)
 	require.NoError(t, err)
-	replicaID, found, err := stateloader.Make(desc.RangeID).LoadRaftReplicaID(ctx, store.Engine())
-	require.True(t, found)
+	replicaID, err := stateloader.Make(desc.RangeID).LoadRaftReplicaID(ctx, store.Engine())
 	require.NoError(t, err)
 	require.Equal(t, repl.ReplicaID(), replicaID.ReplicaID)
 
@@ -102,9 +101,8 @@ func TestStoreRaftReplicaID(t *testing.T) {
 	require.NoError(t, err)
 	rhsRepl, err := store.GetReplica(rhsDesc.RangeID)
 	require.NoError(t, err)
-	rhsReplicaID, found, err :=
+	rhsReplicaID, err :=
 		stateloader.Make(rhsDesc.RangeID).LoadRaftReplicaID(ctx, store.Engine())
-	require.True(t, found)
 	require.NoError(t, err)
 	require.Equal(t, rhsRepl.ReplicaID(), rhsReplicaID.ReplicaID)
 }

--- a/pkg/kv/kvserver/kvstorage/BUILD.bazel
+++ b/pkg/kv/kvserver/kvstorage/BUILD.bazel
@@ -17,6 +17,7 @@ go_library(
         "//pkg/keys",
         "//pkg/kv/kvserver/kvserverpb",
         "//pkg/kv/kvserver/logstore",
+        "//pkg/kv/kvserver/rditer",
         "//pkg/kv/kvserver/stateloader",
         "//pkg/roachpb",
         "//pkg/storage",

--- a/pkg/kv/kvserver/kvstorage/BUILD.bazel
+++ b/pkg/kv/kvserver/kvstorage/BUILD.bazel
@@ -5,6 +5,7 @@ go_library(
     name = "kvstorage",
     srcs = [
         "cluster_version.go",
+        "destroy.go",
         "doc.go",
         "init.go",
         "replica_state.go",

--- a/pkg/kv/kvserver/kvstorage/destroy.go
+++ b/pkg/kv/kvserver/kvstorage/destroy.go
@@ -1,0 +1,34 @@
+// Copyright 2023 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package kvstorage
+
+import "github.com/cockroachdb/cockroach/pkg/roachpb"
+
+// ClearRangeDataOptions specify which parts of a Replica are to be destroyed.
+type ClearRangeDataOptions struct {
+	// ClearReplicatedByRangeID indicates that replicated RangeID-based keys
+	// (abort span, etc) should be removed.
+	ClearReplicatedByRangeID bool
+	// ClearUnreplicatedByRangeID indicates that unreplicated RangeID-based keys
+	// (logstore state incl. HardState, etc) should be removed.
+	ClearUnreplicatedByRangeID bool
+	// ClearReplicatedBySpan causes the state machine data (i.e. the replicated state
+	// for the given RSpan) that is key-addressable (i.e. range descriptor, user keys,
+	// locks) to be removed. No data is removed if this is the zero span.
+	ClearReplicatedBySpan roachpb.RSpan
+
+	// If MustUseClearRange is true, a Pebble range tombstone will always be used
+	// to clear the key spans (unless empty). This is typically used when we need
+	// to write additional keys to an SST after this clear, e.g. a replica
+	// tombstone, since keys must be written in order. When this is false, a
+	// heuristic will be used instead.
+	MustUseClearRange bool
+}

--- a/pkg/kv/kvserver/kvstorage/destroy.go
+++ b/pkg/kv/kvserver/kvstorage/destroy.go
@@ -94,7 +94,13 @@ func ClearRangeData(
 }
 
 // DestroyReplica destroys all or a part of the Replica's state, installing a
-// RangeTombstone in its place.
+// RangeTombstone in its place. Due to merges, splits, etc, there is a need
+// to control which part of the state this method actually gets to remove,
+// which is done via the provided options[^1]; the caller is always responsible
+// for managing the remaining disk state accordingly.
+//
+// [^1] e.g., on a merge, the user data moves to the subsuming replica and must
+// not be cleared.
 func DestroyReplica(
 	ctx context.Context,
 	rangeID roachpb.RangeID,

--- a/pkg/kv/kvserver/kvstorage/destroy.go
+++ b/pkg/kv/kvserver/kvstorage/destroy.go
@@ -10,7 +10,31 @@
 
 package kvstorage
 
-import "github.com/cockroachdb/cockroach/pkg/roachpb"
+import (
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/rditer"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/storage"
+)
+
+const (
+	// ClearRangeThresholdPointKeys is the threshold (as number of point keys)
+	// beyond which we'll clear range data using a Pebble range tombstone rather
+	// than individual Pebble point tombstones.
+	//
+	// It is expensive for there to be many Pebble range tombstones in the same
+	// sstable because all of the tombstones in an sstable are loaded whenever the
+	// sstable is accessed. So we avoid using range deletion unless there is some
+	// minimum number of keys. The value here was pulled out of thin air. It might
+	// be better to make this dependent on the size of the data being deleted. Or
+	// perhaps we should fix Pebble to handle large numbers of range tombstones in
+	// an sstable better.
+	ClearRangeThresholdPointKeys = 64
+
+	// ClearRangeThresholdRangeKeys is the threshold (as number of range keys)
+	// beyond which we'll clear range data using a single RANGEKEYDEL across the
+	// span rather than clearing individual range keys.
+	ClearRangeThresholdRangeKeys = 8
+)
 
 // ClearRangeDataOptions specify which parts of a Replica are to be destroyed.
 type ClearRangeDataOptions struct {
@@ -31,4 +55,34 @@ type ClearRangeDataOptions struct {
 	// tombstone, since keys must be written in order. When this is false, a
 	// heuristic will be used instead.
 	MustUseClearRange bool
+}
+
+// ClearRangeData clears the data associated with a range descriptor selected
+// by the provided options.
+//
+// TODO(tbg): could rename this to XReplica. The use of "Range" in both the
+// "CRDB Range" and "storage.ClearRange" context in the setting of this method could
+// be confusing.
+func ClearRangeData(
+	rangeID roachpb.RangeID, reader storage.Reader, writer storage.Writer, opts ClearRangeDataOptions,
+) error {
+	keySpans := rditer.Select(rangeID, rditer.SelectOpts{
+		ReplicatedBySpan:      opts.ClearReplicatedBySpan,
+		ReplicatedByRangeID:   opts.ClearReplicatedByRangeID,
+		UnreplicatedByRangeID: opts.ClearUnreplicatedByRangeID,
+	})
+
+	pointKeyThreshold, rangeKeyThreshold := ClearRangeThresholdPointKeys, ClearRangeThresholdRangeKeys
+	if opts.MustUseClearRange {
+		pointKeyThreshold, rangeKeyThreshold = 1, 1
+	}
+
+	for _, keySpan := range keySpans {
+		if err := storage.ClearRangeWithHeuristic(
+			reader, writer, keySpan.Key, keySpan.EndKey, pointKeyThreshold, rangeKeyThreshold,
+		); err != nil {
+			return err
+		}
+	}
+	return nil
 }

--- a/pkg/kv/kvserver/kvstorage/replica_state.go
+++ b/pkg/kv/kvserver/kvstorage/replica_state.go
@@ -46,13 +46,11 @@ func LoadReplicaState(
 	replicaID roachpb.ReplicaID,
 ) (LoadedReplicaState, error) {
 	sl := stateloader.Make(desc.RangeID)
-	id, found, err := sl.LoadRaftReplicaID(ctx, eng)
+	id, err := sl.LoadRaftReplicaID(ctx, eng)
 	if err != nil {
 		return LoadedReplicaState{}, err
-	} else if !found {
-		return LoadedReplicaState{}, errors.AssertionFailedf(
-			"r%d: RaftReplicaID not found", desc.RangeID)
-	} else if loaded := id.ReplicaID; loaded != replicaID {
+	}
+	if loaded := id.ReplicaID; loaded != replicaID {
 		return LoadedReplicaState{}, errors.AssertionFailedf(
 			"r%d: loaded RaftReplicaID %d does not match %d", desc.RangeID, loaded, replicaID)
 	}

--- a/pkg/kv/kvserver/logstore/stateloader.go
+++ b/pkg/kv/kvserver/logstore/stateloader.go
@@ -203,8 +203,15 @@ func (sl StateLoader) SetRaftReplicaID(
 // LoadRaftReplicaID loads the RaftReplicaID.
 func (sl StateLoader) LoadRaftReplicaID(
 	ctx context.Context, reader storage.Reader,
-) (replicaID roachpb.RaftReplicaID, found bool, err error) {
-	found, err = storage.MVCCGetProto(ctx, reader, sl.RaftReplicaIDKey(),
+) (*roachpb.RaftReplicaID, error) {
+	var replicaID roachpb.RaftReplicaID
+	found, err := storage.MVCCGetProto(ctx, reader, sl.RaftReplicaIDKey(),
 		hlc.Timestamp{}, &replicaID, storage.MVCCGetOptions{})
-	return
+	if err != nil {
+		return nil, err
+	}
+	if !found {
+		return nil, errors.AssertionFailedf("no replicaID persisted")
+	}
+	return &replicaID, nil
 }

--- a/pkg/kv/kvserver/loqrecovery/recovery_env_test.go
+++ b/pkg/kv/kvserver/loqrecovery/recovery_env_test.go
@@ -747,7 +747,7 @@ func (e *quorumRecoveryEnv) handleDumpStore(t *testing.T, d datadriven.TestData)
 				descriptorViews = append(descriptorViews, descriptorView(desc))
 
 				sl := stateloader.Make(desc.RangeID)
-				raftReplicaID, _, err := sl.LoadRaftReplicaID(ctx, store.engine)
+				raftReplicaID, err := sl.LoadRaftReplicaID(ctx, store.engine)
 				if err != nil {
 					t.Fatalf("failed to load Raft replica ID: %v", err)
 				}

--- a/pkg/kv/kvserver/replica.go
+++ b/pkg/kv/kvserver/replica.go
@@ -1400,12 +1400,9 @@ func (r *Replica) assertStateRaftMuLockedReplicaMuRLocked(
 			log.Fatalf(ctx, "replica's replicaID %d diverges from descriptor %+v", r.replicaID, r.mu.state.Desc)
 		}
 	}
-	diskReplID, found, err := r.mu.stateLoader.LoadRaftReplicaID(ctx, reader)
+	diskReplID, err := r.mu.stateLoader.LoadRaftReplicaID(ctx, reader)
 	if err != nil {
 		log.Fatalf(ctx, "%s", err)
-	}
-	if !found {
-		log.Fatalf(ctx, "no replicaID persisted")
 	}
 	if diskReplID.ReplicaID != r.replicaID {
 		log.Fatalf(ctx, "disk replicaID %d does not match in-mem %d", diskReplID, r.replicaID)

--- a/pkg/kv/kvserver/replica_app_batch.go
+++ b/pkg/kv/kvserver/replica_app_batch.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvadmission"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverbase"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverpb"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvstorage"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
@@ -334,7 +335,7 @@ func (b *replicaAppBatch) runPostAddTriggersReplicaOnly(
 		// required for correctness, since the merge protocol should guarantee that
 		// no new replicas of the RHS can ever be created, but it doesn't hurt to
 		// be careful.
-		if err := preDestroyRaftMuLocked(ctx, rhsRepl.RangeID, b.batch, b.batch, mergedTombstoneReplicaID, clearRangeDataOptions{
+		if err := preDestroyRaftMuLocked(ctx, rhsRepl.RangeID, b.batch, b.batch, mergedTombstoneReplicaID, kvstorage.ClearRangeDataOptions{
 			ClearReplicatedByRangeID:   true,
 			ClearUnreplicatedByRangeID: true,
 		}); err != nil {
@@ -474,7 +475,7 @@ func (b *replicaAppBatch) runPostAddTriggersReplicaOnly(
 		// We've set the replica's in-mem status to reflect the pending destruction
 		// above, and preDestroyRaftMuLocked will also add a range tombstone to the
 		// batch, so that when we commit it, the removal is finalized.
-		if err := preDestroyRaftMuLocked(ctx, b.r.RangeID, b.batch, b.batch, change.NextReplicaID(), clearRangeDataOptions{
+		if err := preDestroyRaftMuLocked(ctx, b.r.RangeID, b.batch, b.batch, change.NextReplicaID(), kvstorage.ClearRangeDataOptions{
 			ClearReplicatedBySpan:      span,
 			ClearReplicatedByRangeID:   true,
 			ClearUnreplicatedByRangeID: true,

--- a/pkg/kv/kvserver/replica_app_batch.go
+++ b/pkg/kv/kvserver/replica_app_batch.go
@@ -335,7 +335,7 @@ func (b *replicaAppBatch) runPostAddTriggersReplicaOnly(
 		// required for correctness, since the merge protocol should guarantee that
 		// no new replicas of the RHS can ever be created, but it doesn't hurt to
 		// be careful.
-		if err := preDestroyRaftMuLocked(ctx, rhsRepl.RangeID, b.batch, b.batch, mergedTombstoneReplicaID, kvstorage.ClearRangeDataOptions{
+		if err := kvstorage.DestroyReplica(ctx, rhsRepl.RangeID, b.batch, b.batch, mergedTombstoneReplicaID, kvstorage.ClearRangeDataOptions{
 			ClearReplicatedByRangeID:   true,
 			ClearUnreplicatedByRangeID: true,
 		}); err != nil {
@@ -475,7 +475,7 @@ func (b *replicaAppBatch) runPostAddTriggersReplicaOnly(
 		// We've set the replica's in-mem status to reflect the pending destruction
 		// above, and preDestroyRaftMuLocked will also add a range tombstone to the
 		// batch, so that when we commit it, the removal is finalized.
-		if err := preDestroyRaftMuLocked(ctx, b.r.RangeID, b.batch, b.batch, change.NextReplicaID(), kvstorage.ClearRangeDataOptions{
+		if err := kvstorage.DestroyReplica(ctx, b.r.RangeID, b.batch, b.batch, change.NextReplicaID(), kvstorage.ClearRangeDataOptions{
 			ClearReplicatedBySpan:      span,
 			ClearReplicatedByRangeID:   true,
 			ClearUnreplicatedByRangeID: true,

--- a/pkg/kv/kvserver/replica_app_batch.go
+++ b/pkg/kv/kvserver/replica_app_batch.go
@@ -334,12 +334,10 @@ func (b *replicaAppBatch) runPostAddTriggersReplicaOnly(
 		// required for correctness, since the merge protocol should guarantee that
 		// no new replicas of the RHS can ever be created, but it doesn't hurt to
 		// be careful.
-		if err := rhsRepl.preDestroyRaftMuLocked(
-			ctx, b.batch, b.batch, mergedTombstoneReplicaID, clearRangeDataOptions{
-				ClearReplicatedByRangeID:   true,
-				ClearUnreplicatedByRangeID: true,
-			},
-		); err != nil {
+		if err := preDestroyRaftMuLocked(ctx, rhsRepl.RangeID, b.batch, b.batch, mergedTombstoneReplicaID, clearRangeDataOptions{
+			ClearReplicatedByRangeID:   true,
+			ClearUnreplicatedByRangeID: true,
+		}); err != nil {
 			return errors.Wrapf(err, "unable to destroy replica before merge")
 		}
 
@@ -476,17 +474,11 @@ func (b *replicaAppBatch) runPostAddTriggersReplicaOnly(
 		// We've set the replica's in-mem status to reflect the pending destruction
 		// above, and preDestroyRaftMuLocked will also add a range tombstone to the
 		// batch, so that when we commit it, the removal is finalized.
-		if err := b.r.preDestroyRaftMuLocked(
-			ctx,
-			b.batch,
-			b.batch,
-			change.NextReplicaID(),
-			clearRangeDataOptions{
-				ClearReplicatedBySpan:      span,
-				ClearReplicatedByRangeID:   true,
-				ClearUnreplicatedByRangeID: true,
-			},
-		); err != nil {
+		if err := preDestroyRaftMuLocked(ctx, b.r.RangeID, b.batch, b.batch, change.NextReplicaID(), clearRangeDataOptions{
+			ClearReplicatedBySpan:      span,
+			ClearReplicatedByRangeID:   true,
+			ClearUnreplicatedByRangeID: true,
+		}); err != nil {
 			return errors.Wrapf(err, "unable to destroy replica before removal")
 		}
 	}

--- a/pkg/kv/kvserver/replica_destroy.go
+++ b/pkg/kv/kvserver/replica_destroy.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/apply"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvstorage"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/logstore"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/storage"
@@ -79,7 +80,7 @@ func preDestroyRaftMuLocked(
 	reader storage.Reader,
 	writer storage.Writer,
 	nextReplicaID roachpb.ReplicaID,
-	opts clearRangeDataOptions,
+	opts kvstorage.ClearRangeDataOptions,
 ) error {
 	diskReplicaID, err := logstore.NewStateLoader(rangeID).LoadRaftReplicaID(ctx, reader)
 	if err != nil {
@@ -169,7 +170,7 @@ func (r *Replica) destroyRaftMuLocked(ctx context.Context, nextReplicaID roachpb
 	desc := r.Desc()
 	inited := desc.IsInitialized()
 
-	opts := clearRangeDataOptions{
+	opts := kvstorage.ClearRangeDataOptions{
 		ClearReplicatedBySpan: desc.RSpan(), // zero if !inited
 		// TODO(tbg): if it's uninitialized, we might as well clear
 		// the replicated state because there isn't any. This seems

--- a/pkg/kv/kvserver/replica_destroy.go
+++ b/pkg/kv/kvserver/replica_destroy.go
@@ -73,14 +73,14 @@ func (s destroyStatus) Removed() bool {
 // don't know the current replica ID.
 const mergedTombstoneReplicaID roachpb.ReplicaID = math.MaxInt32
 
-func (r *Replica) preDestroyRaftMuLocked(
+func preDestroyRaftMuLocked(
 	ctx context.Context,
+	rangeID roachpb.RangeID,
 	reader storage.Reader,
 	writer storage.Writer,
 	nextReplicaID roachpb.ReplicaID,
 	opts clearRangeDataOptions,
 ) error {
-	rangeID := r.RangeID
 	diskReplicaID, err := logstore.NewStateLoader(rangeID).LoadRaftReplicaID(ctx, reader)
 	if err != nil {
 		return err
@@ -179,13 +179,7 @@ func (r *Replica) destroyRaftMuLocked(ctx context.Context, nextReplicaID roachpb
 		ClearReplicatedByRangeID:   inited,
 		ClearUnreplicatedByRangeID: true,
 	}
-	if err := r.preDestroyRaftMuLocked(
-		ctx,
-		r.Engine(),
-		batch,
-		nextReplicaID,
-		opts,
-	); err != nil {
+	if err := preDestroyRaftMuLocked(ctx, r.RangeID, r.Engine(), batch, nextReplicaID, opts); err != nil {
 		return err
 	}
 	preTime := timeutil.Now()

--- a/pkg/kv/kvserver/replica_destroy.go
+++ b/pkg/kv/kvserver/replica_destroy.go
@@ -229,16 +229,7 @@ func (r *Replica) setTombstoneKey(
 		nextReplicaID = externalNextReplicaID
 	}
 	r.mu.Unlock()
-	return writeTombstoneKey(ctx, writer, r.RangeID, nextReplicaID)
-}
-
-func writeTombstoneKey(
-	ctx context.Context,
-	writer storage.Writer,
-	rangeID roachpb.RangeID,
-	nextReplicaID roachpb.ReplicaID,
-) error {
-	tombstoneKey := keys.RangeTombstoneKey(rangeID)
+	tombstoneKey := keys.RangeTombstoneKey(r.RangeID)
 	tombstone := &roachpb.RangeTombstone{
 		NextReplicaID: nextReplicaID,
 	}

--- a/pkg/kv/kvserver/replica_destroy.go
+++ b/pkg/kv/kvserver/replica_destroy.go
@@ -89,7 +89,7 @@ func preDestroyRaftMuLocked(
 	if diskReplicaID.ReplicaID >= nextReplicaID {
 		return errors.AssertionFailedf("replica r%d/%d must not survive its own tombstone", rangeID, diskReplicaID)
 	}
-	if err := clearRangeData(rangeID, reader, writer, opts); err != nil {
+	if err := kvstorage.ClearRangeData(rangeID, reader, writer, opts); err != nil {
 		return err
 	}
 

--- a/pkg/kv/kvserver/replica_destroy.go
+++ b/pkg/kv/kvserver/replica_destroy.go
@@ -78,17 +78,7 @@ func (r *Replica) preDestroyRaftMuLocked(
 	nextReplicaID roachpb.ReplicaID,
 	opts clearRangeDataOptions,
 ) error {
-	r.mu.RLock()
-	desc := r.descRLocked()
-	removed := r.mu.destroyStatus.Removed()
-	r.mu.RUnlock()
-
-	// The replica must be marked as destroyed before its data is removed. If
-	// not, we risk new commands being accepted and observing the missing data.
-	if !removed {
-		log.Fatalf(ctx, "replica not marked as destroyed before call to preDestroyRaftMuLocked: %v", r)
-	}
-	err := clearRangeData(desc.RangeID, reader, writer, opts)
+	err := clearRangeData(r.RangeID, reader, writer, opts)
 	if err != nil {
 		return err
 	}

--- a/pkg/kv/kvserver/replica_raftstorage.go
+++ b/pkg/kv/kvserver/replica_raftstorage.go
@@ -819,13 +819,7 @@ func clearSubsumedReplicaDiskData(
 			ClearUnreplicatedByRangeID: true,
 			MustUseClearRange:          true,
 		}
-		if err := sr.preDestroyRaftMuLocked(
-			ctx,
-			reader,
-			&subsumedReplSST,
-			subsumedNextReplicaID,
-			opts,
-		); err != nil {
+		if err := preDestroyRaftMuLocked(ctx, sr.RangeID, reader, &subsumedReplSST, subsumedNextReplicaID, opts); err != nil {
 			subsumedReplSST.Close()
 			return err
 		}

--- a/pkg/kv/kvserver/replica_raftstorage.go
+++ b/pkg/kv/kvserver/replica_raftstorage.go
@@ -750,7 +750,7 @@ func clearSubsumedReplicaDiskData(
 			ClearUnreplicatedByRangeID: true,
 			MustUseClearRange:          true,
 		}
-		if err := preDestroyRaftMuLocked(ctx, sr.RangeID, reader, &subsumedReplSST, subsumedNextReplicaID, opts); err != nil {
+		if err := kvstorage.DestroyReplica(ctx, sr.RangeID, reader, &subsumedReplSST, subsumedNextReplicaID, opts); err != nil {
 			subsumedReplSST.Close()
 			return err
 		}

--- a/pkg/kv/kvserver/store_split.go
+++ b/pkg/kv/kvserver/store_split.go
@@ -95,7 +95,7 @@ func splitPreApply(
 				log.Fatalf(ctx, "failed to load hard state for removed rhs: %v", err)
 			}
 		}
-		if err := clearRangeData(split.RightDesc.RangeID, readWriter, readWriter, kvstorage.ClearRangeDataOptions{
+		if err := kvstorage.ClearRangeData(split.RightDesc.RangeID, readWriter, readWriter, kvstorage.ClearRangeDataOptions{
 			// We know there isn't anything in these two replicated spans below in the
 			// right-hand side (before the current batch), so setting these options
 			// will in effect only clear the writes to the RHS replicated state we have

--- a/pkg/kv/kvserver/store_split.go
+++ b/pkg/kv/kvserver/store_split.go
@@ -95,7 +95,7 @@ func splitPreApply(
 				log.Fatalf(ctx, "failed to load hard state for removed rhs: %v", err)
 			}
 		}
-		if err := clearRangeData(split.RightDesc.RangeID, readWriter, readWriter, clearRangeDataOptions{
+		if err := clearRangeData(split.RightDesc.RangeID, readWriter, readWriter, kvstorage.ClearRangeDataOptions{
 			// We know there isn't anything in these two replicated spans below in the
 			// right-hand side (before the current batch), so setting these options
 			// will in effect only clear the writes to the RHS replicated state we have

--- a/pkg/kv/kvserver/store_test.go
+++ b/pkg/kv/kvserver/store_test.go
@@ -3784,10 +3784,9 @@ func TestStoreGetOrCreateReplicaWritesRaftReplicaID(t *testing.T) {
 		})
 	require.NoError(t, err)
 	require.True(t, created)
-	replicaID, found, err := repl.mu.stateLoader.LoadRaftReplicaID(ctx, tc.store.Engine())
+	replicaID, err := repl.mu.stateLoader.LoadRaftReplicaID(ctx, tc.store.Engine())
 	require.NoError(t, err)
-	require.True(t, found)
-	require.Equal(t, roachpb.RaftReplicaID{ReplicaID: 7}, replicaID)
+	require.Equal(t, &roachpb.RaftReplicaID{ReplicaID: 7}, replicaID)
 }
 
 func BenchmarkStoreGetReplica(b *testing.B) {


### PR DESCRIPTION
This series of commits extracts `(*Replica).preDestroyRaftMuLocked` into a
free-standing method `kvstorage.DestroyReplica`.

In doing so, it separates the in-memory and on-disk steps that are a part
of replica removal, and makes the on-disk steps unit testable.

Touches #93241.

Epic: CRDB-220
Release note: None
