### PR TITLE
clusterversion: bump minBinary to 22.2

### DIFF
--- a/pkg/ccl/storageccl/engineccl/BUILD.bazel
+++ b/pkg/ccl/storageccl/engineccl/BUILD.bazel
@@ -50,6 +50,7 @@ go_test(
         "//pkg/storage/enginepb",
         "//pkg/testutils",
         "//pkg/testutils/datapathutils",
+        "//pkg/testutils/skip",
         "//pkg/testutils/storageutils",
         "//pkg/util/encoding",
         "//pkg/util/hlc",

--- a/pkg/ccl/storageccl/engineccl/bench_test.go
+++ b/pkg/ccl/storageccl/engineccl/bench_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -166,6 +167,8 @@ func runIterate(
 }
 
 func BenchmarkTimeBoundIterate(b *testing.B) {
+	skip.WithIssue(b, 95530, "bump minBinary to 22.2. Skip 22.2 mixed-version tests for future cleanup")
+
 	for _, loadFactor := range []float32{1.0, 0.5, 0.1, 0.05, 0.0} {
 		b.Run(fmt.Sprintf("LoadFactor=%.2f", loadFactor), func(b *testing.B) {
 			b.Run("NormalIterator", func(b *testing.B) {

--- a/pkg/clusterversion/cockroach_versions.go
+++ b/pkg/clusterversion/cockroach_versions.go
@@ -785,7 +785,7 @@ var versionsSingleton = func() keyedVersions {
 var V23_1 = versionsSingleton[len(versionsSingleton)-1].Key
 
 const (
-	BinaryMinSupportedVersionKey = V22_1
+	BinaryMinSupportedVersionKey = V22_2
 )
 
 // TODO(irfansharif): clusterversion.binary{,MinimumSupported}Version

--- a/pkg/sql/create_function_test.go
+++ b/pkg/sql/create_function_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/tests"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -154,6 +155,8 @@ SELECT nextval(105:::REGCLASS);`,
 
 func TestGatingCreateFunction(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+
+	skip.WithIssue(t, 95530, "bump minBinary to 22.2. Skip 22.2 mixed-version tests for future cleanup")
 
 	t.Run("new_schema_changer_version_enabled", func(t *testing.T) {
 		params, _ := tests.CreateTestServerParams()

--- a/pkg/storage/sst_writer_test.go
+++ b/pkg/storage/sst_writer_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -77,6 +78,8 @@ func makePebbleSST(t testing.TB, kvs []MVCCKeyValue, ingestion bool) []byte {
 
 func TestMakeIngestionWriterOptions(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+
+	skip.WithIssue(t, 95530, "bump minBinary to 22.2. Skip 22.2 mixed-version tests for future cleanup")
 
 	testCases := []struct {
 		name string

--- a/pkg/upgrade/upgrades/alter_sql_instances_locality_test.go
+++ b/pkg/upgrade/upgrades/alter_sql_instances_locality_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/catconstants"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
 	"github.com/cockroachdb/cockroach/pkg/upgrade/upgrades"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
@@ -35,6 +36,8 @@ import (
 func TestAlterSystemSqlInstancesTable(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
+
+	skip.WithIssue(t, 95530, "bump minBinary to 22.2. Skip 22.2 mixed-version tests for future cleanup")
 
 	clusterArgs := base.TestClusterArgs{
 		ServerArgs: base.TestServerArgs{

--- a/pkg/upgrade/upgrades/alter_statement_statistics_index_recommendations_test.go
+++ b/pkg/upgrade/upgrades/alter_statement_statistics_index_recommendations_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/catconstants"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
 	"github.com/cockroachdb/cockroach/pkg/upgrade/upgrades"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
@@ -36,6 +37,8 @@ import (
 func TestAlterSystemStatementStatisticsTable(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
+
+	skip.WithIssue(t, 95530, "bump minBinary to 22.2. Skip 22.2 mixed-version tests for future cleanup")
 
 	clusterArgs := base.TestClusterArgs{
 		ServerArgs: base.TestServerArgs{

--- a/pkg/upgrade/upgrades/builtins_test.go
+++ b/pkg/upgrade/upgrades/builtins_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/server"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
@@ -26,6 +27,8 @@ import (
 func TestIsAtLeastVersionBuiltin(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
+
+	skip.WithIssue(t, 95530, "bump minBinary to 22.2. Skip 22.2 mixed-version tests for future cleanup")
 
 	clusterArgs := base.TestClusterArgs{
 		ServerArgs: base.TestServerArgs{

--- a/pkg/upgrade/upgrades/ensure_sql_schema_telemetry_schedule_test.go
+++ b/pkg/upgrade/upgrades/ensure_sql_schema_telemetry_schedule_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/builtins/builtinconstants"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
@@ -39,6 +40,8 @@ import (
 
 func TestSchemaTelemetrySchedule(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+
+	skip.WithIssue(t, 95530, "bump minBinary to 22.2. Skip 22.2 mixed-version tests for future cleanup")
 
 	// We want to ensure that the migration will succeed when run again.
 	// To ensure that it will, we inject a failure when trying to mark

--- a/pkg/upgrade/upgrades/sampled_stmt_diagnostics_requests_test.go
+++ b/pkg/upgrade/upgrades/sampled_stmt_diagnostics_requests_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/tabledesc"
 	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
 	"github.com/cockroachdb/cockroach/pkg/upgrade/upgrades"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
@@ -35,6 +36,8 @@ import (
 func TestSampledStmtDiagReqsMigration(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
+
+	skip.WithIssue(t, 95530, "bump minBinary to 22.2. Skip 22.2 mixed-version tests for future cleanup")
 
 	clusterArgs := base.TestClusterArgs{
 		ServerArgs: base.TestServerArgs{

--- a/pkg/upgrade/upgrades/wait_for_schema_changes_test.go
+++ b/pkg/upgrade/upgrades/wait_for_schema_changes_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/tests"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/ctxgroup"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
@@ -38,6 +39,8 @@ import (
 func TestWaitForSchemaChangeMigration(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
+
+	skip.WithIssue(t, 95530, "bump minBinary to 22.2. Skip 22.2 mixed-version tests for future cleanup")
 
 	ctx := context.Background()
 	testCases := []struct {
@@ -195,6 +198,8 @@ func TestWaitForSchemaChangeMigration(t *testing.T) {
 func TestWaitForSchemaChangeMigrationSynthetic(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
+
+	skip.WithIssue(t, 95530, "bump minBinary to 22.2. Skip 22.2 mixed-version tests for future cleanup")
 
 	ctx := context.Background()
 


### PR DESCRIPTION
This PR bumps binaryMinSupportedVersion to 22.2 before cutting the 23.1
release branch, as part of the stability period process.

In previous stability periods, the work of deleting pre-22.2 gates/tests
and bumping binaryMinSupportedVersion was done at the same time. For 23.1,
we will break this up into smaller tasks:

- This PR will just bump binaryMinSupportedVersion to 22.2, skipping 22.2
  mixed-version tests as needed to bump this value.
- The clean-up of pre-22.2 gates and 22.2 mixed-version tests will be done
  via follow-up work/issues.

Issue: #95530
Epic: CRDB-23572

Release note: None