### PR TITLE
sql: fix column_default in info_schema so literals are quoted

### DIFF
--- a/pkg/server/admin_test.go
+++ b/pkg/server/admin_test.go
@@ -714,7 +714,7 @@ func TestAdminAPITableDetails(t *testing.T) {
 		name, dbName, tblName, pkName string
 	}{
 		{name: "lower", dbName: "test", tblName: "tbl", pkName: "tbl_pkey"},
-		{name: "lower", dbName: "test", tblName: `testschema.tbl`, pkName: "tbl_pkey"},
+		{name: "lower other schema", dbName: "test", tblName: `testschema.tbl`, pkName: "tbl_pkey"},
 		{name: "lower with space", dbName: "test test", tblName: `"tbl tbl"`, pkName: "tbl tbl_pkey"},
 		{name: "upper", dbName: "TEST", tblName: `"TBL"`, pkName: "TBL_pkey"}, // Regression test for issue #14056
 	} {
@@ -778,7 +778,7 @@ func TestAdminAPITableDetails(t *testing.T) {
 				{Name: "nulls_allowed", Type: "INT8", Nullable: true, DefaultValue: ""},
 				{Name: "nulls_not_allowed", Type: "INT8", Nullable: false, DefaultValue: "1000"},
 				{Name: "default2", Type: "INT8", Nullable: true, DefaultValue: "2"},
-				{Name: "string_default", Type: "STRING", Nullable: true, DefaultValue: "default_string"},
+				{Name: "string_default", Type: "STRING", Nullable: true, DefaultValue: "'default_string'"},
 				{Name: "rowid", Type: "INT8", Nullable: false, DefaultValue: "unique_rowid()", Hidden: true},
 			}
 			testutils.SortStructs(expColumns, "Name")

--- a/pkg/sql/information_schema.go
+++ b/pkg/sql/information_schema.go
@@ -441,7 +441,7 @@ https://www.postgresql.org/docs/9.5/infoschema-columns.html`,
 				colDefault := tree.DNull
 				if column.HasDefault() {
 					colExpr, err := schemaexpr.FormatExprForDisplay(
-						ctx, table, column.GetDefaultExpr(), &p.semaCtx, p.SessionData(), tree.FmtPgwireText,
+						ctx, table, column.GetDefaultExpr(), &p.semaCtx, p.SessionData(), tree.FmtParsableNumerics,
 					)
 					if err != nil {
 						return err

--- a/pkg/sql/logictest/testdata/logic_test/enums
+++ b/pkg/sql/logictest/testdata/logic_test/enums
@@ -536,8 +536,8 @@ WHERE
 ORDER BY
   column_name
 ----
-y  hello
-z  hello IS OF (test.public.greeting, test.public.greeting)
+y  'hello'
+z  'hello' IS OF (test.public.greeting, test.public.greeting)
 
 # Test computed columns with enum values.
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/information_schema
+++ b/pkg/sql/logictest/testdata/logic_test/information_schema
@@ -2410,7 +2410,7 @@ WHERE table_schema = 'public' AND table_name = 'with_defaults'
 ----
 table_name     column_name  column_default
 with_defaults  a            9
-with_defaults  b            default
+with_defaults  b            'default'
 with_defaults  c            NULL
 with_defaults  d            NULL
 with_defaults  rowid        unique_rowid()

--- a/pkg/sql/logictest/testdata/logic_test/system
+++ b/pkg/sql/logictest/testdata/logic_test/system
@@ -250,10 +250,10 @@ descriptor  BYTES  true   NULL  ·  {primary}  false
 query TTBTTTB
 SHOW COLUMNS FROM system.users
 ----
-username        STRING  false  NULL  ·  {primary,users_user_id_idx}  false
-hashedPassword  BYTES   true   NULL  ·  {primary}                    false
-isRole          BOOL    false  f     ·  {primary}                    false
-user_id         OID     false  NULL  ·  {primary,users_user_id_idx}  false
+username        STRING  false  NULL   ·  {primary,users_user_id_idx}  false
+hashedPassword  BYTES   true   NULL   ·  {primary}                    false
+isRole          BOOL    false  false  ·  {primary}                    false
+user_id         OID     false  NULL   ·  {primary,users_user_id_idx}  false
 
 query TTBTTTB
 SHOW COLUMNS FROM system.zones


### PR DESCRIPTION
fixes https://github.com/cockroachdb/cockroach/issues/96098

In bc3fccd2e4b14b07d2572434203dd8f548523623, the format flags were changed to use FmtPgWireText for
information_schema.columns(column_default). This does not work for string literals, since that format does not wrap literals in single quotes.

Now we've changed to FmtParsableNumerics, which does properly add quotes, and also avoids adding the `:::` type annotation as FmtPgWireText does.

No release note since this bug was never released.

Release note: None