### PR TITLE
tenantrate: allow `TestCloser` to run on up to 180 cores machines

### DIFF
--- a/pkg/kv/kvserver/tenantrate/limiter_test.go
+++ b/pkg/kv/kvserver/tenantrate/limiter_test.go
@@ -55,7 +55,7 @@ func TestCloser(t *testing.T) {
 	// First Wait call will not block.
 	require.NoError(t, limiter.Wait(ctx, tenantcostmodel.TestingRequestInfo(1, 1, 1)))
 	errCh := make(chan error, 1)
-	go func() { errCh <- limiter.Wait(ctx, tenantcostmodel.TestingRequestInfo(1, 1, 1<<31)) }()
+	go func() { errCh <- limiter.Wait(ctx, tenantcostmodel.TestingRequestInfo(1, 1, 1<<33)) }()
 	testutils.SucceedsSoon(t, func() error {
 		if timers := timeSource.Timers(); len(timers) != 1 {
 			return errors.Errorf("expected 1 timer, found %d", len(timers))


### PR DESCRIPTION
Currently, `TestCloser` only runs as expected on machines with <= 45 cores. When the number of cores is more than 45, the initial `burst` value will make the initial `current` tokens value in the token bucket high enough to allow the request to acquire quota on the fast path instead of waiting.

This code change quadruples the number of cores on which this test can run normally by quadrupling the request size.

Release note: None
Epic: none

Closes #96467