### PR TITLE
allocator: fix panic when accessing nil store descriptor

### DIFF
--- a/pkg/kv/kvserver/allocator/storepool/store_pool.go
+++ b/pkg/kv/kvserver/allocator/storepool/store_pool.go
@@ -620,14 +620,14 @@ func (sp *StorePool) UpdateLocalStoreAfterRelocate(
 
 	updateTargets := func(targets []roachpb.ReplicationTarget) {
 		for _, target := range targets {
-			if toDetail := sp.GetStoreDetailLocked(target.StoreID); toDetail != nil {
+			if toDetail := sp.GetStoreDetailLocked(target.StoreID); toDetail.Desc != nil {
 				toDetail.Desc.Capacity.RangeCount++
 			}
 		}
 	}
 	updatePrevious := func(previous []roachpb.ReplicaDescriptor) {
 		for _, old := range previous {
-			if toDetail := sp.GetStoreDetailLocked(old.StoreID); toDetail != nil {
+			if toDetail := sp.GetStoreDetailLocked(old.StoreID); toDetail.Desc != nil {
 				toDetail.Desc.Capacity.RangeCount--
 			}
 		}


### PR DESCRIPTION
Previously allocator was trying to update store descriptor counters on unitialized stores. Instead of checking if detail is nil which should never happen, it should check if descriptor in detail is not nil as it is only eventually populated by gossip.

Release note: None

Fixes #96654