### PR TITLE
backup: fail instead of pausing when out of retries

### DIFF
--- a/pkg/ccl/backupccl/backup_job.go
+++ b/pkg/ccl/backupccl/backup_job.go
@@ -722,14 +722,12 @@ func (b *backupResumer) Resume(ctx context.Context, execCtx interface{}) error {
 		}
 	}
 
-	// We have exhausted retries, but we have not seen a "PermanentBulkJobError" so
-	// it is possible that this is a transient error that is taking longer than
-	// our configured retry to go away.
-	//
-	// Let's pause the job instead of failing it so that the user can decide
-	// whether to resume it or cancel it.
+	// We have exhausted retries without getting a "PermanentBulkJobError", but
+	// something must be wrong if we keep seeing errors so give up and fail to
+	// ensure that any alerting on failures is triggered and that any subsequent
+	// schedule runs are not blocked.
 	if err != nil {
-		return jobs.MarkPauseRequestError(errors.Wrap(err, "exhausted retries"))
+		return errors.Wrap(err, "exhausted retries")
 	}
 
 	var backupDetails jobspb.BackupDetails


### PR DESCRIPTION
This changes backups to fail with the most recent error instead of pausing when they run out of retries while hitting non-permanent errors. This is desired as a failed backup is expected to be more likely to be seen and noticed in monitoring (number of failed jobs increments, they show up red on jobs page, etc) and becuase a backup schedule it then able to trigger subsequent jobs instead of wiating on the incomplete paused job that will never resume or complete without human intervention.

Release note (ops change): a BACKUP which encounters too many retryable errors will now fail instead of pausing to allow subsequent backups the chance to succeed.

Epic: CRDB-21953