### PR TITLE
*: Properly support partial UNIQUE WITHOUT INDEX referencing type descs

### DIFF
--- a/pkg/sql/BUILD.bazel
+++ b/pkg/sql/BUILD.bazel
@@ -666,6 +666,7 @@ go_test(
         "txn_restart_test.go",
         "txn_state_test.go",
         "type_change_test.go",
+        "unique_without_index_test.go",
         "unsplit_range_test.go",
         "unsplit_test.go",
         "upsert_test.go",

--- a/pkg/sql/schemachanger/scplan/internal/opgen/opgen_unique_without_index_constraint.go
+++ b/pkg/sql/schemachanger/scplan/internal/opgen/opgen_unique_without_index_constraint.go
@@ -44,15 +44,6 @@ func init() {
 						BackReferencedTableID: this.TableID,
 					}
 				}),
-				emit(func(this *scpb.UniqueWithoutIndexConstraint) *scop.UpdateTableBackReferencesInSequences {
-					if this.Predicate == nil || this.Predicate.UsesSequenceIDs == nil || len(this.Predicate.UsesSequenceIDs) == 0 {
-						return nil
-					}
-					return &scop.UpdateTableBackReferencesInSequences{
-						SequenceIDs:           this.Predicate.UsesSequenceIDs,
-						BackReferencedTableID: this.TableID,
-					}
-				}),
 			),
 			to(scpb.Status_VALIDATED,
 				emit(func(this *scpb.UniqueWithoutIndexConstraint) *scop.ValidateConstraint {
@@ -90,6 +81,15 @@ func init() {
 					return &scop.RemoveUniqueWithoutIndexConstraint{
 						TableID:      this.TableID,
 						ConstraintID: this.ConstraintID,
+					}
+				}),
+				emit(func(this *scpb.UniqueWithoutIndexConstraint) *scop.UpdateTableBackReferencesInTypes {
+					if this.Predicate == nil || this.Predicate.UsesTypeIDs == nil || len(this.Predicate.UsesTypeIDs) == 0 {
+						return nil
+					}
+					return &scop.UpdateTableBackReferencesInTypes{
+						TypeIDs:               this.Predicate.UsesTypeIDs,
+						BackReferencedTableID: this.TableID,
 					}
 				}),
 			),

--- a/pkg/sql/unique_without_index_test.go
+++ b/pkg/sql/unique_without_index_test.go
@@ -1,0 +1,73 @@
+// Copyright 2023 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package sql
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/keys"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/desctestutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/stretchr/testify/require"
+)
+
+// TestUWIConstraintReferencingTypes tests that adding/dropping
+// unique without index constraints that reference other type descriptors
+// properly adds/drops back-references in the type descriptor.
+func TestUWIConstraintReferencingTypes(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	ctx := context.Background()
+
+	testutils.RunTrueAndFalse(t, "test-in-both-legacy-and-declarative-schema-changer", func(
+		t *testing.T, useDeclarativeSchemaChanger bool,
+	) {
+		s, sqlDB, kvDB := serverutils.StartServer(t, base.TestServerArgs{})
+		defer s.Stopper().Stop(ctx)
+		tdb := sqlutils.MakeSQLRunner(sqlDB)
+
+		if useDeclarativeSchemaChanger {
+			tdb.Exec(t, "SET use_declarative_schema_changer = on;")
+		} else {
+			tdb.Exec(t, "SET use_declarative_schema_changer = off;")
+		}
+		tdb.Exec(t, "SET experimental_enable_unique_without_index_constraints = true;")
+		tdb.Exec(t, "CREATE TYPE typ AS ENUM ('a', 'b');")
+		tdb.Exec(t, "CREATE TABLE t (i INT PRIMARY KEY, j STRING);")
+		tdb.Exec(t, "ALTER TABLE t ADD UNIQUE WITHOUT INDEX (j) WHERE (j::typ != 'a');")
+
+		// Ensure that `typ` has a back-reference to table `t`.
+		tableDesc := desctestutils.TestingGetPublicTableDescriptor(kvDB, keys.SystemSQLCodec,
+			"defaultdb", "t")
+		typDesc := desctestutils.TestingGetPublicTypeDescriptor(kvDB, keys.SystemSQLCodec,
+			"defaultdb", "typ")
+		require.Equal(t, []descpb.ID{tableDesc.GetID()}, typDesc.GetReferencingDescriptorIDs())
+
+		// Ensure that dropping `typ` fails because `typ` is referenced by the constraint.
+		tdb.ExpectErr(t, `pq: cannot drop type "typ" because other objects \(\[defaultdb.public.t\]\) still depend on it`, "DROP TYPE typ")
+
+		// Ensure that dropping the constraint removes the back-reference from `typ`.
+		tdb.Exec(t, "ALTER TABLE t DROP CONSTRAINT unique_j")
+		typDesc = desctestutils.TestingGetPublicTypeDescriptor(kvDB, keys.SystemSQLCodec,
+			"defaultdb", "typ")
+		require.Nil(t, typDesc.GetReferencingDescriptorIDs())
+
+		// Ensure that now we can succeed dropping `typ`.
+		tdb.Exec(t, "DROP TYPE typ")
+	})
+}


### PR DESCRIPTION
Previously if a partial UNIQUE WITHOUT INDEX references a type descriptor in its predicate, we didn't add back-references in the type descriptor, both in the legacy and declarative schema changer. This commit fixes this.

Fixes #96678
Release note: None
