### PR TITLE
ui: Adjusting package.json to include types

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/package.json
+++ b/pkg/ui/workspaces/cluster-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cockroachlabs/cluster-ui",
-  "version": "22.1.13",
+  "version": "22.1.14",
   "description": "Cluster UI is a library of large features shared between CockroachDB and CockroachCloud",
   "repository": {
     "type": "git",
@@ -9,7 +9,7 @@
   "main": "dist/js/main.js",
   "types": "dist/types/index.d.ts",
   "files": [
-    "dist/",
+    "dist/*",
     "AUTHORS"
   ],
   "scripts": {


### PR DESCRIPTION
For unknown reasons[1], when publishing Cluster UI from `release-22.1` the Typescript type files are not being included in the `.tgz` file that is published to npm. Adding a wildcard to the `dist/` entry in the `files` property of the package.json seems to include them, so that change was made along with a version bump to publish Cluster UI when this change is merged.

[1]: the package.json `files` property is the same on branches release-22.1 and release-22.2, as well as the `.npmignore` and the `.gitignore` files. When publishing Cluster UI from branch release-22.2 the types are included, but publishing from release-22.1 they are not. Other factors considered were npm version, node version, and dependency versions.

Epic: none
Release note: None