### PR TITLE
sql: handle implicit record return types better

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/udf
+++ b/pkg/sql/logictest/testdata/logic_test/udf
@@ -3044,3 +3044,50 @@ query I
 SELECT count(descriptor) FROM system.descriptor WHERE id = $dropped_fn_id;
 ----
 0
+
+subtest udt_alter
+
+statement ok
+CREATE TABLE t_alter (
+  a INT PRIMARY KEY,
+  b INT
+)
+
+statement ok
+CREATE FUNCTION f_rtbl() RETURNS t_alter LANGUAGE SQL AS 'SELECT 1, 2;'
+
+query T
+SELECT f_rtbl();
+----
+(1,2)
+
+statement ok
+ALTER TABLE t_alter DROP COLUMN b;
+
+statement error pq: return type mismatch in function declared to return t_alter
+SELECT f_rtbl();
+
+statement ok
+ALTER TABLE t_alter ADD COLUMN b INT;
+
+query T
+SELECT f_rtbl();
+----
+(1,2)
+
+statement ok
+SET enable_experimental_alter_column_type_general=true
+
+statement ok
+ALTER TABLE t_alter ALTER b TYPE FLOAT;
+
+statement error pq: return type mismatch in function declared to return t_alter
+SELECT f_rtbl();
+
+statement ok
+ALTER TABLE t_alter ALTER b TYPE INT;
+
+query T
+SELECT f_rtbl();
+----
+(1,2)

--- a/pkg/sql/logictest/testdata/logic_test/udf_star
+++ b/pkg/sql/logictest/testdata/logic_test/udf_star
@@ -173,16 +173,20 @@ SELECT f_allcolsel_alias()
 ----
 (1,2)
 
+# Return an error after adding a column when the table is used as the return
+# type. Note that this behavior is ok for late binding.
 statement ok
 ALTER TABLE t_twocol ADD COLUMN c INT DEFAULT 5;
 
-# TODO(#95558): With early binding, postgres returns an error after adding a
-# column when the table is used as the return type. Note that this behavior is
-# ok for late binding.
-query T
+statement error pq: return type mismatch in function declared to return t_twocol
 SELECT f_unqualified_twocol()
-----
-(1,2)
+
+# Dropping the new column renders the function usable again.
+statement ok
+ALTER TABLE t_twocol DROP COLUMN c;
+
+statement ok
+SELECT f_unqualified_twocol()
 
 # Altering a column type is not allowed in postgres or CRDB.
 statement error pq: cannot alter type of column "b" because function "f_unqualified_twocol" depends on it

--- a/pkg/sql/schema_resolver.go
+++ b/pkg/sql/schema_resolver.go
@@ -320,6 +320,8 @@ func (sr *schemaResolver) ResolveType(
 }
 
 // ResolveTypeByOID implements the tree.TypeReferenceResolver interface.
+// Note: Type resolution only works for OIDs of user-defined types. Builtin
+// types do not need to be hydrated.
 func (sr *schemaResolver) ResolveTypeByOID(ctx context.Context, oid oid.Oid) (*types.T, error) {
 	return typedesc.ResolveHydratedTByOID(ctx, oid, sr)
 }


### PR DESCRIPTION
This PR validates the UDF return type at build time if it is a user-defined type. If the return type is no longer compatible with what the UDF body returns, we return an error instead. This is more in line with postgres behavior.

Fixes: #95558
Epic: CRDB-19496
Release note (sql change): UDFs with implicit record return types will return an error when called if the return type has been altered and is no longer compatible with the body of the UDF.