### PR TITLE
clusterversion: remove TODOPreV22_1

### DIFF
--- a/pkg/ccl/changefeedccl/BUILD.bazel
+++ b/pkg/ccl/changefeedccl/BUILD.bazel
@@ -211,7 +211,6 @@ go_test(
         "//pkg/ccl/utilccl",
         "//pkg/cloud",
         "//pkg/cloud/impl:cloudimpl",
-        "//pkg/clusterversion",
         "//pkg/gossip",
         "//pkg/internal/sqlsmith",
         "//pkg/jobs",

--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -39,7 +39,6 @@ import (
 	_ "github.com/cockroachdb/cockroach/pkg/ccl/partitionccl"
 	"github.com/cockroachdb/cockroach/pkg/ccl/utilccl"
 	_ "github.com/cockroachdb/cockroach/pkg/cloud/impl" // registers cloud storage providers
-	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/internal/sqlsmith"
 	"github.com/cockroachdb/cockroach/pkg/jobs"
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
@@ -296,10 +295,6 @@ func TestChangefeedIdleness(t *testing.T) {
 		sqlDB := sqlutils.MakeSQLRunner(s.DB)
 		changefeedbase.IdleTimeout.Override(
 			context.Background(), &s.Server.ClusterSettings().SV, 3*time.Second)
-
-		// Idleness functionality is version gated
-		knobs := s.TestingKnobs.Server.(*server.TestingKnobs)
-		knobs.BinaryVersionOverride = clusterversion.ByKey(clusterversion.TODOPreV22_1)
 
 		registry := s.Server.JobRegistry().(*jobs.Registry)
 		currentlyIdle := registry.MetricsStruct().JobMetrics[jobspb.TypeChangefeed].CurrentlyIdle

--- a/pkg/clusterversion/cockroach_versions.go
+++ b/pkg/clusterversion/cockroach_versions.go
@@ -420,10 +420,6 @@ func (k Key) String() string {
 	return ByKey(k).String()
 }
 
-// TODOPreV22_1 is an alias for V22_1 for use in any version gate/check that
-// previously referenced a < 22.1 version until that check/gate can be removed.
-const TODOPreV22_1 = V22_1
-
 // Offset every version +1M major versions into the future if this is a dev branch.
 const DevOffset = 1000000
 

--- a/pkg/sql/logictest/testdata/logic_test/alter_database_convert_to_schema
+++ b/pkg/sql/logictest/testdata/logic_test/alter_database_convert_to_schema
@@ -4,5 +4,5 @@ USE parent;
 CREATE DATABASE pgdatabase;
 USE test;
 
-statement error pq: cannot perform ALTER DATABASE CONVERT TO SCHEMA in version
+statement error pq: cannot perform ALTER DATABASE CONVERT TO SCHEMA
 ALTER DATABASE parent CONVERT TO SCHEMA WITH PARENT pgdatabase

--- a/pkg/sql/logictest/testdata/logic_test/schema_change_feature_flags
+++ b/pkg/sql/logictest/testdata/logic_test/schema_change_feature_flags
@@ -73,7 +73,7 @@ statement error pq: feature ALTER DATABASE is part of the schema change category
 ALTER DATABASE d RENAME TO r
 
 # Test REPARENT DATABASE
-statement error pq: cannot perform ALTER DATABASE CONVERT TO SCHEMA in version
+statement error pq: cannot perform ALTER DATABASE CONVERT TO SCHEMA
 ALTER DATABASE d CONVERT TO SCHEMA WITH PARENT test
 
 # Test ALTER TABLE PARTITION BY.

--- a/pkg/sql/reparent_database.go
+++ b/pkg/sql/reparent_database.go
@@ -13,7 +13,6 @@ package sql
 import (
 	"context"
 
-	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
@@ -22,7 +21,5 @@ import (
 func (p *planner) ReparentDatabase(
 	ctx context.Context, n *tree.ReparentDatabase,
 ) (planNode, error) {
-	return nil, pgerror.Newf(pgcode.FeatureNotSupported,
-		"cannot perform ALTER DATABASE CONVERT TO SCHEMA in version %v and beyond",
-		clusterversion.TODOPreV22_1)
+	return nil, pgerror.Newf(pgcode.FeatureNotSupported, "cannot perform ALTER DATABASE CONVERT TO SCHEMA")
 }

--- a/pkg/sql/syntheticprivilege/BUILD.bazel
+++ b/pkg/sql/syntheticprivilege/BUILD.bazel
@@ -13,7 +13,6 @@ go_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/sql/syntheticprivilege",
     visibility = ["//visibility:public"],
     deps = [
-        "//pkg/clusterversion",
         "//pkg/security/username",
         "//pkg/sql/catalog/catpb",
         "//pkg/sql/catalog/descpb",

--- a/pkg/sql/syntheticprivilege/global_privilege.go
+++ b/pkg/sql/syntheticprivilege/global_privilege.go
@@ -11,7 +11,6 @@
 package syntheticprivilege
 
 import (
-	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/cat"
@@ -35,11 +34,6 @@ var _ Object = &GlobalPrivilege{}
 // GetPath implements the Object interface.
 func (p *GlobalPrivilege) GetPath() string {
 	return "/global/"
-}
-
-// SystemPrivilegesTableVersionGate implements the Object interface.
-func (p *GlobalPrivilege) SystemPrivilegesTableVersionGate() clusterversion.Key {
-	return clusterversion.TODOPreV22_1
 }
 
 // GlobalPrivilegeObject is one of one since it is global.

--- a/pkg/storage/min_version_test.go
+++ b/pkg/storage/min_version_test.go
@@ -101,12 +101,11 @@ func TestSetMinVersion(t *testing.T) {
 	defer p.Close()
 	require.Equal(t, pebble.FormatMostCompatible, p.db.FormatMajorVersion())
 
-	// Advancing the store cluster version to TODOPreV22_1
-	// should also advance the store's format major version.
-	err = p.SetMinVersion(clusterversion.ByKey(clusterversion.TODOPreV22_1))
+	// Advancing the store cluster version to V22_2 should also advance the
+	// store's format major version.
+	err = p.SetMinVersion(clusterversion.ByKey(clusterversion.V22_2))
 	require.NoError(t, err)
-	require.Equal(t, pebble.FormatSplitUserKeysMarked, p.db.FormatMajorVersion())
-
+	require.Equal(t, pebble.FormatPrePebblev1Marked, p.db.FormatMajorVersion())
 }
 
 func TestMinVersion_IsNotEncrypted(t *testing.T) {

--- a/pkg/storage/pebble.go
+++ b/pkg/storage/pebble.go
@@ -1964,30 +1964,26 @@ func (p *Pebble) SetMinVersion(version roachpb.Version) error {
 	// at a version X+1, it is guaranteed that all nodes have already ratcheted
 	// their store version to the version X that enabled the feature at the Pebble
 	// level.
-	formatVers := pebble.FormatMostCompatible
+	var formatVers pebble.FormatMajorVersion
 	// Cases are ordered from newer to older versions.
 	switch {
 	case !version.Less(clusterversion.ByKey(clusterversion.V23_1EnsurePebbleFormatSSTableValueBlocks)):
-		if formatVers < pebble.FormatSSTableValueBlocks {
-			formatVers = pebble.FormatSSTableValueBlocks
-		}
+		formatVers = pebble.FormatSSTableValueBlocks
+
 	case !version.Less(clusterversion.ByKey(clusterversion.V22_2PebbleFormatPrePebblev1Marked)):
-		if formatVers < pebble.FormatPrePebblev1Marked {
-			formatVers = pebble.FormatPrePebblev1Marked
-		}
+		formatVers = pebble.FormatPrePebblev1Marked
+
 	case !version.Less(clusterversion.ByKey(clusterversion.V22_2EnsurePebbleFormatVersionRangeKeys)):
-		if formatVers < pebble.FormatRangeKeys {
-			formatVers = pebble.FormatRangeKeys
-		}
+		formatVers = pebble.FormatRangeKeys
+
 	case !version.Less(clusterversion.ByKey(clusterversion.V22_2PebbleFormatSplitUserKeysMarkedCompacted)):
-		if formatVers < pebble.FormatSplitUserKeysMarkedCompacted {
-			formatVers = pebble.FormatSplitUserKeysMarkedCompacted
-		}
-	case !version.Less(clusterversion.ByKey(clusterversion.TODOPreV22_1)):
-		if formatVers < pebble.FormatSplitUserKeysMarked {
-			formatVers = pebble.FormatSplitUserKeysMarked
-		}
+		formatVers = pebble.FormatSplitUserKeysMarkedCompacted
+
+	default:
+		// Corresponds to V22_1.
+		formatVers = pebble.FormatSplitUserKeysMarked
 	}
+
 	if p.db.FormatMajorVersion() < formatVers {
 		if err := p.db.RatchetFormatMajorVersion(formatVers); err != nil {
 			return errors.Wrap(err, "ratcheting format major version")


### PR DESCRIPTION
This change removes this constant and the obsolete code that uses it.

Release note: None
Epic: None