### PR TITLE
kvstorage: move uninit replica creation to kvstorage

### DIFF
--- a/pkg/kv/kvserver/kvstorage/replica_state.go
+++ b/pkg/kv/kvserver/kvstorage/replica_state.go
@@ -13,10 +13,12 @@ package kvstorage
 import (
 	"context"
 
+	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverpb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/stateloader"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/storage"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/errors"
 	"go.etcd.io/raft/v3/raftpb"
 )
@@ -100,4 +102,63 @@ func (r LoadedReplicaState) check(storeID roachpb.StoreID) error {
 			"%+v does not contain replicaID %d for local store s%d", desc, r.ReplicaID, storeID)
 	}
 	return nil
+}
+
+// CreateUninitializedReplica creates an uninitialized replica in storage.
+// Returns roachpb.RaftGroupDeletedError if this replica can not be created
+// because it has been deleted.
+func CreateUninitializedReplica(
+	ctx context.Context,
+	eng storage.Engine,
+	storeID roachpb.StoreID,
+	rangeID roachpb.RangeID,
+	replicaID roachpb.ReplicaID,
+) error {
+	// Before creating the replica, see if there is a tombstone which would
+	// indicate that this replica has been removed.
+	tombstoneKey := keys.RangeTombstoneKey(rangeID)
+	var tombstone roachpb.RangeTombstone
+	if ok, err := storage.MVCCGetProto(
+		ctx, eng, tombstoneKey, hlc.Timestamp{}, &tombstone, storage.MVCCGetOptions{},
+	); err != nil {
+		return err
+	} else if ok && replicaID < tombstone.NextReplicaID {
+		return &roachpb.RaftGroupDeletedError{}
+	}
+
+	// Write the RaftReplicaID for this replica. This is the only place in the
+	// CockroachDB code that we are creating a new *uninitialized* replica.
+	// Note that it is possible that we have already created the HardState for
+	// an uninitialized replica, then crashed, and on recovery are receiving a
+	// raft message for the same or later replica.
+	// - Same replica: we are overwriting the RaftReplicaID with the same
+	//   value, which is harmless.
+	// - Later replica: there may be an existing HardState for the older
+	//   uninitialized replica with Commit=0 and non-zero Term and Vote. Using
+	//   the Term and Vote values for that older replica in the context of
+	//   this newer replica is harmless since it just limits the votes for
+	//   this replica.
+	//
+	// Compatibility:
+	// - v21.2 and v22.1: v22.1 unilaterally introduces RaftReplicaID (an
+	//   unreplicated range-id local key). If a v22.1 binary is rolled back at
+	//   a node, the fact that RaftReplicaID was written is harmless to a
+	//   v21.2 node since it does not read it. When a v21.2 drops an
+	//   initialized range, the RaftReplicaID will also be deleted because the
+	//   whole range-ID local key space is deleted.
+	// - v22.2: no changes: RaftReplicaID is written, but old Replicas may not
+	//   have it yet.
+	// - v23.1: at startup, we remove any uninitialized replicas that have a
+	//   HardState but no RaftReplicaID, see kvstorage.LoadAndReconcileReplicas.
+	//   So after first call to this method we have the invariant that all replicas
+	//   have a RaftReplicaID persisted.
+	sl := stateloader.Make(rangeID)
+	if err := sl.SetRaftReplicaID(ctx, eng, replicaID); err != nil {
+		return err
+	}
+
+	// Make sure that storage invariants for this uninitialized replica hold.
+	uninitDesc := roachpb.RangeDescriptor{RangeID: rangeID}
+	_, err := LoadReplicaState(ctx, eng, storeID, &uninitDesc, replicaID)
+	return err
 }


### PR DESCRIPTION
This commit factors out the code that creates an uninitialized replica in
storage, into the kvstorage package.

Part of #93898