### PR TITLE
sql: increase minimal max_range_size to 64MiB

### DIFF
--- a/pkg/base/constants.go
+++ b/pkg/base/constants.go
@@ -50,9 +50,6 @@ const (
 	// when a job opts in to dumping its execution traces.
 	InflightTraceDir = "inflight_trace_dump"
 
-	// MinRangeMaxBytes is the minimum value for range max bytes.
-	MinRangeMaxBytes = 64 << 10 // 64 KB
-
 	// ObsServiceEmbedFlagValue is the special value of the --obsservice-addr flag
 	// configuring the CRDB node to run the Obs Service internally.
 	ObsServiceEmbedFlagValue = "embed"

--- a/pkg/bench/rttanalysis/alter_table_bench_test.go
+++ b/pkg/bench/rttanalysis/alter_table_bench_test.go
@@ -207,7 +207,7 @@ func init() {
 			Name:  "alter table configure zone ranges",
 			Setup: `CREATE TABLE alter_table(a INT);`,
 			Stmt: "ALTER TABLE alter_table CONFIGURE ZONE USING " +
-				"range_min_bytes = 0, range_max_bytes = 90000",
+				"range_min_bytes = 0, range_max_bytes = 500000000",
 		},
 	})
 }

--- a/pkg/ccl/backupccl/backup_test.go
+++ b/pkg/ccl/backupccl/backup_test.go
@@ -9522,7 +9522,7 @@ func TestExportRequestBelowGCThresholdOnDataExcludedFromBackup(t *testing.T) {
 	_, err = conn.Exec("SET CLUSTER SETTING kv.closed_timestamp.target_duration = '100ms'") // speeds up the test
 	require.NoError(t, err)
 
-	const tableRangeMaxBytes = 1 << 18
+	const tableRangeMaxBytes = 100 << 20
 	_, err = conn.Exec("ALTER TABLE foo CONFIGURE ZONE USING "+
 		"gc.ttlseconds = 1, range_max_bytes = $1, range_min_bytes = 1<<10;", tableRangeMaxBytes)
 	require.NoError(t, err)
@@ -9606,7 +9606,7 @@ func TestExcludeDataFromBackupDoesNotHoldupGC(t *testing.T) {
 	// Exclude the table from backup so that it does not hold up GC.
 	runner.Exec(t, `ALTER TABLE test.foo SET (exclude_data_from_backup = true)`)
 
-	const tableRangeMaxBytes = 1 << 18
+	const tableRangeMaxBytes = 100 << 20
 	runner.Exec(t, "ALTER TABLE test.foo CONFIGURE ZONE USING "+
 		"gc.ttlseconds = 1, range_max_bytes = $1, range_min_bytes = 1<<10;", tableRangeMaxBytes)
 

--- a/pkg/ccl/logictestccl/testdata/logic_test/distsql_partitioning
+++ b/pkg/ccl/logictestccl/testdata/logic_test/distsql_partitioning
@@ -345,13 +345,13 @@ statement ok
 ALTER INDEX partitioning.inheritance@inheritance_pkey PARTITION BY LIST (x) ( PARTITION p1 VALUES IN (1))
 
 statement ok
-ALTER DATABASE partitioning CONFIGURE ZONE USING range_min_bytes=64000, range_max_bytes=75000
+ALTER DATABASE partitioning CONFIGURE ZONE USING range_min_bytes=64000, range_max_bytes=75000000
 
 query TTTTTTTTT
 SHOW PARTITIONS FROM TABLE partitioning.inheritance
 ----
 partitioning  inheritance  p1  NULL  x  inheritance@inheritance_pkey  (1)  NULL  range_min_bytes = 64000,
-                                                                                 range_max_bytes = 75000,
+                                                                                 range_max_bytes = 75000000,
                                                                                  gc.ttlseconds = 14400,
                                                                                  num_replicas = 3,
                                                                                  constraints = '[]',
@@ -364,7 +364,7 @@ query TTTTTTTTT
 SHOW PARTITIONS FROM TABLE partitioning.inheritance
 ----
 partitioning  inheritance  p1  NULL  x  inheritance@inheritance_pkey  (1)  NULL  range_min_bytes = 64000,
-range_max_bytes = 75000,
+range_max_bytes = 75000000,
 gc.ttlseconds = 80000,
 num_replicas = 3,
 constraints = '[]',
@@ -377,7 +377,7 @@ query TTTTTTTTT
 SHOW PARTITIONS FROM TABLE partitioning.inheritance
 ----
 partitioning  inheritance  p1  NULL  x  inheritance@inheritance_pkey  (1)  NULL  range_min_bytes = 64000,
-range_max_bytes = 75000,
+range_max_bytes = 75000000,
 gc.ttlseconds = 80000,
 num_replicas = 5,
 constraints = '[]',
@@ -390,7 +390,7 @@ query TTTTTTTTT
 SHOW PARTITIONS FROM TABLE partitioning.inheritance
 ----
 partitioning  inheritance  p1  NULL  x  inheritance@inheritance_pkey  (1)  constraints = '[+dc=dc1]'  range_min_bytes = 64000,
-range_max_bytes = 75000,
+range_max_bytes = 75000000,
 gc.ttlseconds = 80000,
 num_replicas = 5,
 constraints = '[+dc=dc1]',

--- a/pkg/ccl/logictestccl/testdata/logic_test/multi_region_zone_configs
+++ b/pkg/ccl/logictestccl/testdata/logic_test/multi_region_zone_configs
@@ -123,14 +123,14 @@ statement ok
 ALTER DATABASE "mr-zone-configs" CONFIGURE ZONE USING gc.ttlseconds = 5
 
 statement ok
-ALTER DATABASE "mr-zone-configs" CONFIGURE ZONE USING range_min_bytes = 1000, range_max_bytes = 100000
+ALTER DATABASE "mr-zone-configs" CONFIGURE ZONE USING range_min_bytes = 1000, range_max_bytes = 100000000
 
 query TT
 SHOW ZONE CONFIGURATION FOR DATABASE "mr-zone-configs"
 ----
 DATABASE "mr-zone-configs"  ALTER DATABASE "mr-zone-configs" CONFIGURE ZONE USING
                             range_min_bytes = 1000,
-                            range_max_bytes = 100000,
+                            range_max_bytes = 100000000,
                             gc.ttlseconds = 5,
                             num_replicas = 5,
                             num_voters = 3,
@@ -149,7 +149,7 @@ SHOW ZONE CONFIGURATION FOR DATABASE "mr-zone-configs"
 ----
 DATABASE "mr-zone-configs"  ALTER DATABASE "mr-zone-configs" CONFIGURE ZONE USING
                             range_min_bytes = 1000,
-                            range_max_bytes = 100000,
+                            range_max_bytes = 100000000,
                             gc.ttlseconds = 5,
                             num_replicas = 5,
                             num_voters = 3,
@@ -170,7 +170,7 @@ SHOW ZONE CONFIGURATION FOR DATABASE "mr-zone-configs"
 ----
 DATABASE "mr-zone-configs"  ALTER DATABASE "mr-zone-configs" CONFIGURE ZONE USING
                             range_min_bytes = 1000,
-                            range_max_bytes = 100000,
+                            range_max_bytes = 100000000,
                             gc.ttlseconds = 5,
                             num_replicas = 5,
                             num_voters = 5,
@@ -243,7 +243,7 @@ SHOW ZONE CONFIGURATION FOR DATABASE "mr-zone-configs"
 ----
 DATABASE "mr-zone-configs"  ALTER DATABASE "mr-zone-configs" CONFIGURE ZONE USING
                             range_min_bytes = 1000,
-                            range_max_bytes = 100000,
+                            range_max_bytes = 100000000,
                             gc.ttlseconds = 5,
                             num_replicas = 5,
                             num_voters = 3,
@@ -302,7 +302,7 @@ SHOW ZONE CONFIGURATION FOR DATABASE "mr-zone-configs"
 ----
 DATABASE "mr-zone-configs"  ALTER DATABASE "mr-zone-configs" CONFIGURE ZONE USING
                             range_min_bytes = 1000,
-                            range_max_bytes = 100000,
+                            range_max_bytes = 100000000,
                             gc.ttlseconds = 100000,
                             num_replicas = 4,
                             num_voters = 3,
@@ -323,7 +323,7 @@ SHOW ZONE CONFIGURATION FOR DATABASE "mr-zone-configs"
 ----
 DATABASE "mr-zone-configs"  ALTER DATABASE "mr-zone-configs" CONFIGURE ZONE USING
                             range_min_bytes = 1000,
-                            range_max_bytes = 100000,
+                            range_max_bytes = 100000000,
                             gc.ttlseconds = 100000,
                             num_replicas = 3,
                             num_voters = 3,
@@ -344,7 +344,7 @@ SHOW ZONE CONFIGURATION FOR DATABASE "mr-zone-configs"
 ----
 DATABASE "mr-zone-configs"  ALTER DATABASE "mr-zone-configs" CONFIGURE ZONE USING
                             range_min_bytes = 1000,
-                            range_max_bytes = 100000,
+                            range_max_bytes = 100000000,
                             gc.ttlseconds = 100000,
                             num_replicas = 3,
                             num_voters = 3,
@@ -365,7 +365,7 @@ SHOW ZONE CONFIGURATION FOR DATABASE "mr-zone-configs"
 ----
 DATABASE "mr-zone-configs"  ALTER DATABASE "mr-zone-configs" CONFIGURE ZONE USING
                             range_min_bytes = 1000,
-                            range_max_bytes = 100000,
+                            range_max_bytes = 100000000,
                             gc.ttlseconds = 100000,
                             num_replicas = 3,
                             constraints = '[]',
@@ -443,7 +443,7 @@ SHOW ZONE CONFIGURATION FOR TABLE regional_by_row
 ----
 TABLE regional_by_row  ALTER TABLE regional_by_row CONFIGURE ZONE USING
                        range_min_bytes = 1000,
-                       range_max_bytes = 100000,
+                       range_max_bytes = 100000000,
                        gc.ttlseconds = 10,
                        num_replicas = 10,
                        num_voters = 3,
@@ -504,7 +504,7 @@ SHOW ZONE CONFIGURATION FOR INDEX regional_by_row@regional_by_row_pkey
 ----
 TABLE regional_by_row  ALTER TABLE regional_by_row CONFIGURE ZONE USING
                        range_min_bytes = 1000,
-                       range_max_bytes = 100000,
+                       range_max_bytes = 100000000,
                        gc.ttlseconds = 10,
                        num_replicas = 5,
                        num_voters = 3,
@@ -517,7 +517,7 @@ SHOW ZONE CONFIGURATION FOR INDEX regional_by_row@regional_by_row_i_idx
 ----
 TABLE regional_by_row  ALTER TABLE regional_by_row CONFIGURE ZONE USING
                        range_min_bytes = 1000,
-                       range_max_bytes = 100000,
+                       range_max_bytes = 100000000,
                        gc.ttlseconds = 10,
                        num_replicas = 5,
                        num_voters = 3,
@@ -530,7 +530,7 @@ SHOW ZONE CONFIGURATION FOR TABLE regional_by_row
 ----
 TABLE regional_by_row  ALTER TABLE regional_by_row CONFIGURE ZONE USING
                        range_min_bytes = 1000,
-                       range_max_bytes = 100000,
+                       range_max_bytes = 100000000,
                        gc.ttlseconds = 10,
                        num_replicas = 5,
                        num_voters = 3,
@@ -598,7 +598,7 @@ SHOW ZONE CONFIGURATION FOR TABLE regional_by_row
 ----
 TABLE regional_by_row  ALTER TABLE regional_by_row CONFIGURE ZONE USING
                        range_min_bytes = 1000,
-                       range_max_bytes = 100000,
+                       range_max_bytes = 100000000,
                        gc.ttlseconds = 100000,
                        global_reads = false,
                        num_replicas = 5,
@@ -617,7 +617,7 @@ SHOW ZONE CONFIGURATION FOR TABLE regional_by_row
 ----
 TABLE regional_by_row  ALTER TABLE regional_by_row CONFIGURE ZONE USING
                        range_min_bytes = 1000,
-                       range_max_bytes = 100000,
+                       range_max_bytes = 100000000,
                        gc.ttlseconds = 100000,
                        global_reads = true,
                        num_replicas = 5,
@@ -667,7 +667,7 @@ SHOW ZONE CONFIGURATION FOR INDEX regional_by_row_as@regional_by_row_as_pkey
 ----
 INDEX regional_by_row_as@regional_by_row_as_pkey  ALTER INDEX regional_by_row_as@regional_by_row_as_pkey CONFIGURE ZONE USING
                                   range_min_bytes = 1000,
-                                  range_max_bytes = 100000,
+                                  range_max_bytes = 100000000,
                                   gc.ttlseconds = 100000,
                                   num_replicas = 10,
                                   num_voters = 3,
@@ -688,7 +688,7 @@ SHOW ZONE CONFIGURATION FOR INDEX regional_by_row_as@regional_by_row_as_pkey
 ----
 DATABASE "mr-zone-configs"  ALTER DATABASE "mr-zone-configs" CONFIGURE ZONE USING
                             range_min_bytes = 1000,
-                            range_max_bytes = 100000,
+                            range_max_bytes = 100000000,
                             gc.ttlseconds = 100000,
                             num_replicas = 5,
                             num_voters = 3,
@@ -737,7 +737,7 @@ SHOW ZONE CONFIGURATION FOR DATABASE "mr-zone-configs"
 ----
 DATABASE "mr-zone-configs"  ALTER DATABASE "mr-zone-configs" CONFIGURE ZONE USING
                             range_min_bytes = 1000,
-                            range_max_bytes = 100000,
+                            range_max_bytes = 100000000,
                             gc.ttlseconds = 100000,
                             num_replicas = 5,
                             num_voters = 3,

--- a/pkg/ccl/partitionccl/drop_test.go
+++ b/pkg/ccl/partitionccl/drop_test.go
@@ -217,7 +217,8 @@ SELECT job_id
 	              PARTITION c VALUES IN ('c')
 	  )`)
 		tdb.Exec(t, `CREATE INDEX idx ON t (e)`)
-		tdb.Exec(t, `ALTER PARTITION a OF TABLE t CONFIGURE ZONE USING range_min_bytes = 123456, range_max_bytes = 654321`)
+		tdb.Exec(t, `ALTER PARTITION a OF TABLE t CONFIGURE ZONE USING range_min_bytes = 123456, 
+range_max_bytes = 654321000`)
 		tdb.Exec(t, `ALTER INDEX t@idx CONFIGURE ZONE USING gc.ttlseconds = 1`)
 		tdb.Exec(t, `DROP INDEX t@idx`)
 
@@ -271,8 +272,10 @@ SELECT job_id
 	              PARTITION ci VALUES IN ('c')
 	          )`,
 		)
-		tdb.Exec(t, `ALTER PARTITION ai OF INDEX t@idx CONFIGURE ZONE USING range_min_bytes = 123456,range_max_bytes = 654321`)
-		tdb.Exec(t, `ALTER PARTITION a OF TABLE t CONFIGURE ZONE USING range_min_bytes = 123456, range_max_bytes = 654321`)
+		tdb.Exec(t, `ALTER PARTITION ai OF INDEX t@idx CONFIGURE ZONE USING range_min_bytes = 123456,
+range_max_bytes = 654321000`)
+		tdb.Exec(t, `ALTER PARTITION a OF TABLE t CONFIGURE ZONE USING range_min_bytes = 123456, 
+range_max_bytes = 654321000`)
 		tdb.Exec(t, `ALTER INDEX t@idx CONFIGURE ZONE USING gc.ttlseconds = 1`)
 		tdb.Exec(t, `DROP INDEX t@idx`)
 		tdb.Exec(t, `DROP TABLE t`)

--- a/pkg/ccl/spanconfigccl/spanconfigsqltranslatorccl/testdata/indexes
+++ b/pkg/ccl/spanconfigccl/spanconfigsqltranslatorccl/testdata/indexes
@@ -71,7 +71,7 @@ translate database=db table=t
 # Configure a zone config field on the table, so that it is no longer a
 # placeholder zone config.
 exec-sql
-ALTER TABLE db.t CONFIGURE ZONE USING range_min_bytes = 1000, range_max_bytes=100000;
+ALTER TABLE db.t CONFIGURE ZONE USING range_min_bytes = 1000, range_max_bytes=100000000;
 ----
 
 query-sql
@@ -79,7 +79,7 @@ SHOW ZONE CONFIGURATION FOR INDEX db.t@idx
 ----
 INDEX db.public.t@idx ALTER INDEX db.public.t@idx CONFIGURE ZONE USING
 	range_min_bytes = 1000,
-	range_max_bytes = 100000,
+	range_max_bytes = 100000000,
 	gc.ttlseconds = 25,
 	num_replicas = 7,
 	num_voters = 5,
@@ -89,6 +89,6 @@ INDEX db.public.t@idx ALTER INDEX db.public.t@idx CONFIGURE ZONE USING
 
 translate database=db table=t
 ----
-/Table/106{-/2}                            range_max_bytes=100000 range_min_bytes=1000 ttl_seconds=3600 num_replicas=7
-/Table/106/{2-3}                           range_max_bytes=100000 range_min_bytes=1000 ttl_seconds=25 num_replicas=7 num_voters=5
-/Table/10{6/3-7}                           range_max_bytes=100000 range_min_bytes=1000 ttl_seconds=3600 num_replicas=7
+/Table/106{-/2}                            range_max_bytes=100000000 range_min_bytes=1000 ttl_seconds=3600 num_replicas=7
+/Table/106/{2-3}                           range_max_bytes=100000000 range_min_bytes=1000 ttl_seconds=25 num_replicas=7 num_voters=5
+/Table/10{6/3-7}                           range_max_bytes=100000000 range_min_bytes=1000 ttl_seconds=3600 num_replicas=7

--- a/pkg/ccl/spanconfigccl/spanconfigsqltranslatorccl/testdata/tenant/indexes
+++ b/pkg/ccl/spanconfigccl/spanconfigsqltranslatorccl/testdata/tenant/indexes
@@ -71,7 +71,7 @@ translate database=db table=t
 # Configure a zone config field on the table, so that it is no longer a
 # placeholder zone config.
 exec-sql
-ALTER TABLE db.t CONFIGURE ZONE USING range_min_bytes = 1000, range_max_bytes=100000;
+ALTER TABLE db.t CONFIGURE ZONE USING range_min_bytes = 1000, range_max_bytes=100000000;
 ----
 
 query-sql
@@ -79,7 +79,7 @@ SHOW ZONE CONFIGURATION FOR INDEX db.t@idx
 ----
 INDEX db.public.t@idx ALTER INDEX db.public.t@idx CONFIGURE ZONE USING
 	range_min_bytes = 1000,
-	range_max_bytes = 100000,
+	range_max_bytes = 100000000,
 	gc.ttlseconds = 25,
 	num_replicas = 7,
 	num_voters = 5,
@@ -89,9 +89,9 @@ INDEX db.public.t@idx ALTER INDEX db.public.t@idx CONFIGURE ZONE USING
 
 translate database=db table=t
 ----
-/Tenant/10/Table/106{-/2}                  range_max_bytes=100000 range_min_bytes=1000 ttl_seconds=3600 num_replicas=7
-/Tenant/10/Table/106/{2-3}                 range_max_bytes=100000 range_min_bytes=1000 ttl_seconds=25 num_replicas=7 num_voters=5
-/Tenant/10/Table/10{6/3-7}                 range_max_bytes=100000 range_min_bytes=1000 ttl_seconds=3600 num_replicas=7
+/Tenant/10/Table/106{-/2}                  range_max_bytes=100000000 range_min_bytes=1000 ttl_seconds=3600 num_replicas=7
+/Tenant/10/Table/106/{2-3}                 range_max_bytes=100000000 range_min_bytes=1000 ttl_seconds=25 num_replicas=7 num_voters=5
+/Tenant/10/Table/10{6/3-7}                 range_max_bytes=100000000 range_min_bytes=1000 ttl_seconds=3600 num_replicas=7
 
 block-gc-jobs
 ----
@@ -105,12 +105,12 @@ ALTER INDEX db.t@idx2 CONFIGURE ZONE USING gc.ttlseconds = 1;
 # Both the newly added index and the temporary index have the configured zone configuration.
 translate database=db table=t
 ----
-/Tenant/10/Table/106{-/2}                  range_max_bytes=100000 range_min_bytes=1000 ttl_seconds=3600 num_replicas=7
-/Tenant/10/Table/106/{2-3}                 range_max_bytes=100000 range_min_bytes=1000 ttl_seconds=25 num_replicas=7 num_voters=5
-/Tenant/10/Table/106/{3-4}                 range_max_bytes=100000 range_min_bytes=1000 ttl_seconds=3600 num_replicas=7
-/Tenant/10/Table/106/{4-5}                 range_max_bytes=100000 range_min_bytes=1000 ttl_seconds=1 num_replicas=7
-/Tenant/10/Table/106/{5-6}                 range_max_bytes=100000 range_min_bytes=1000 ttl_seconds=1 num_replicas=7
-/Tenant/10/Table/10{6/6-7}                 range_max_bytes=100000 range_min_bytes=1000 ttl_seconds=3600 num_replicas=7
+/Tenant/10/Table/106{-/2}                  range_max_bytes=100000000 range_min_bytes=1000 ttl_seconds=3600 num_replicas=7
+/Tenant/10/Table/106/{2-3}                 range_max_bytes=100000000 range_min_bytes=1000 ttl_seconds=25 num_replicas=7 num_voters=5
+/Tenant/10/Table/106/{3-4}                 range_max_bytes=100000000 range_min_bytes=1000 ttl_seconds=3600 num_replicas=7
+/Tenant/10/Table/106/{4-5}                 range_max_bytes=100000000 range_min_bytes=1000 ttl_seconds=1 num_replicas=7
+/Tenant/10/Table/106/{5-6}                 range_max_bytes=100000000 range_min_bytes=1000 ttl_seconds=1 num_replicas=7
+/Tenant/10/Table/10{6/6-7}                 range_max_bytes=100000000 range_min_bytes=1000 ttl_seconds=3600 num_replicas=7
 
 unblock-gc-jobs
 ----
@@ -122,11 +122,11 @@ SHOW JOBS WHEN COMPLETE (SELECT job_id FROM [SHOW JOBS])
 # The zone configuration for the temporary index is cleaned up
 translate database=db table=t
 ----
-/Tenant/10/Table/106{-/2}                  range_max_bytes=100000 range_min_bytes=1000 ttl_seconds=3600 num_replicas=7
-/Tenant/10/Table/106/{2-3}                 range_max_bytes=100000 range_min_bytes=1000 ttl_seconds=25 num_replicas=7 num_voters=5
-/Tenant/10/Table/106/{3-4}                 range_max_bytes=100000 range_min_bytes=1000 ttl_seconds=3600 num_replicas=7
-/Tenant/10/Table/106/{4-5}                 range_max_bytes=100000 range_min_bytes=1000 ttl_seconds=1 num_replicas=7
-/Tenant/10/Table/10{6/5-7}                 range_max_bytes=100000 range_min_bytes=1000 ttl_seconds=3600 num_replicas=7
+/Tenant/10/Table/106{-/2}                  range_max_bytes=100000000 range_min_bytes=1000 ttl_seconds=3600 num_replicas=7
+/Tenant/10/Table/106/{2-3}                 range_max_bytes=100000000 range_min_bytes=1000 ttl_seconds=25 num_replicas=7 num_voters=5
+/Tenant/10/Table/106/{3-4}                 range_max_bytes=100000000 range_min_bytes=1000 ttl_seconds=3600 num_replicas=7
+/Tenant/10/Table/106/{4-5}                 range_max_bytes=100000000 range_min_bytes=1000 ttl_seconds=1 num_replicas=7
+/Tenant/10/Table/10{6/5-7}                 range_max_bytes=100000000 range_min_bytes=1000 ttl_seconds=3600 num_replicas=7
 
 # Create and drop an index inside the same transaction. The related
 # zone configuration should also be cleaned up.

--- a/pkg/config/zonepb/BUILD.bazel
+++ b/pkg/config/zonepb/BUILD.bazel
@@ -13,11 +13,11 @@ go_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/config/zonepb",
     visibility = ["//visibility:public"],
     deps = [
-        "//pkg/base",
         "//pkg/clusterversion",
         "//pkg/keys",
         "//pkg/roachpb",
         "//pkg/sql/sem/tree",
+        "//pkg/util/envutil",
         "//pkg/util/log",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_gogo_protobuf//proto",

--- a/pkg/config/zonepb/zone_test.go
+++ b/pkg/config/zonepb/zone_test.go
@@ -64,6 +64,13 @@ func TestZoneConfigValidate(t *testing.T) {
 		{
 			ZoneConfig{
 				NumReplicas:   proto.Int32(1),
+				RangeMaxBytes: proto.Int64(60 << 20),
+			},
+			"RangeMaxBytes 62914560 less than minimum allowed",
+		},
+		{
+			ZoneConfig{
+				NumReplicas:   proto.Int32(1),
 				RangeMaxBytes: DefaultZoneConfig().RangeMaxBytes,
 				GC:            &GCPolicy{TTLSeconds: 0},
 			},

--- a/pkg/kv/kvserver/client_replica_backpressure_test.go
+++ b/pkg/kv/kvserver/client_replica_backpressure_test.go
@@ -47,10 +47,12 @@ func TestBackpressureNotAppliedWhenReducingRangeSize(t *testing.T) {
 	// range size parameters. We want something not too tiny but also not too big
 	// that it takes a while to load.
 	const (
-		rowSize  = 16 << 10  // 16 KiB
-		dataSize = 512 << 10 // 512 KiB
-		numRows  = dataSize / rowSize
+		rowSize             = 5 << 20   // 5 MiB
+		dataSize            = 200 << 20 // 200 MiB
+		numRows             = dataSize / rowSize
+		min_range_max_bytes = 64 << 20 // 64 MiB
 	)
+	val := randutil.RandBytes(rRand, rowSize)
 
 	// setup will set up a testcluster with a table filled with data. All splits
 	// will be blocked until the returned closure is called.
@@ -105,7 +107,7 @@ func TestBackpressureNotAppliedWhenReducingRangeSize(t *testing.T) {
 
 		for i := 0; i < numRows; i++ {
 			tdb.Exec(t, "UPSERT INTO foo VALUES ($1, $2)",
-				rRand.Intn(numRows), randutil.RandBytes(rRand, rowSize))
+				rRand.Intn(numRows), val)
 		}
 
 		// Block splits and return.
@@ -177,19 +179,18 @@ func TestBackpressureNotAppliedWhenReducingRangeSize(t *testing.T) {
 		defer unblockSplits()
 
 		tdb.Exec(t, "ALTER TABLE foo CONFIGURE ZONE USING "+
-			"range_max_bytes = $1, range_min_bytes = $2", dataSize/5, dataSize/10)
-		waitForSpanConfig(t, tc, tablePrefix, dataSize/5)
+			"range_max_bytes = $1, range_min_bytes = $2", min_range_max_bytes, dataSize/10)
+		waitForSpanConfig(t, tc, tablePrefix, min_range_max_bytes)
 
 		// Don't observe backpressure.
 		tdb.Exec(t, "UPSERT INTO foo VALUES ($1, $2)",
-			rRand.Intn(10000000), randutil.RandBytes(rRand, rowSize))
+			rRand.Intn(10000000), val)
 	})
 
 	t.Run("no backpressure when much larger on new node", func(t *testing.T) {
 		tc, args, tdb, tablePrefix, unblockSplits, _ := setup(t, 1)
 		defer tc.Stopper().Stop(ctx)
 		defer unblockSplits()
-
 		// We didn't want to have to load too much data into these ranges because
 		// it makes the testing slower so let's lower the threshold at which we'll
 		// consider the range to be way over the backpressure limit from megabytes
@@ -197,15 +198,15 @@ func TestBackpressureNotAppliedWhenReducingRangeSize(t *testing.T) {
 		tdb.Exec(t, "SET CLUSTER SETTING kv.range.backpressure_byte_tolerance = '1 KiB'")
 
 		tdb.Exec(t, "ALTER TABLE foo CONFIGURE ZONE USING "+
-			"range_max_bytes = $1, range_min_bytes = $2", dataSize/5, dataSize/10)
-		waitForSpanConfig(t, tc, tablePrefix, dataSize/5)
+			"range_max_bytes = $1, range_min_bytes = $2", min_range_max_bytes, dataSize/10)
+		waitForSpanConfig(t, tc, tablePrefix, min_range_max_bytes)
 
 		// Then we'll add a new server and move the table there.
 		moveTableToNewStore(t, tc, args, tablePrefix)
 
 		// Don't observe backpressure.
 		tdb.Exec(t, "UPSERT INTO foo VALUES ($1, $2)",
-			rRand.Intn(10000000), randutil.RandBytes(rRand, rowSize))
+			rRand.Intn(10000000), val)
 	})
 
 	t.Run("no backpressure when near limit on existing node", func(t *testing.T) {
@@ -224,7 +225,7 @@ func TestBackpressureNotAppliedWhenReducingRangeSize(t *testing.T) {
 		// backpressureByteTolerance. We won't see backpressure because the range
 		// will remember its previous zone config setting.
 		s, repl := getFirstStoreReplica(t, tc.Server(0), tablePrefix.Next())
-		newMax := repl.GetMVCCStats().Total()/2 - 32<<10
+		newMax := repl.GetMVCCStats().Total()/2 - 32<<20
 		newMin := newMax / 4
 		tdb.Exec(t, "ALTER TABLE foo CONFIGURE ZONE USING "+
 			"range_max_bytes = $1, range_min_bytes = $2", newMax, newMin)
@@ -233,7 +234,7 @@ func TestBackpressureNotAppliedWhenReducingRangeSize(t *testing.T) {
 		// Don't observe backpressure because we remember the previous max size on
 		// this node.
 		tdb.Exec(t, "UPSERT INTO foo VALUES ($1, $2)",
-			rRand.Intn(10000000), randutil.RandBytes(rRand, rowSize))
+			rRand.Intn(10000000), val)
 
 		// Allow one split to occur and make sure that the remembered value is
 		// cleared.
@@ -247,6 +248,7 @@ func TestBackpressureNotAppliedWhenReducingRangeSize(t *testing.T) {
 			return nil
 		})
 	})
+
 	// This case is very similar to the above case but differs in that the range
 	// is moved to a new node after the range size is decreased. This new node
 	// never knew about the old, larger range size, and thus will backpressure
@@ -260,7 +262,7 @@ func TestBackpressureNotAppliedWhenReducingRangeSize(t *testing.T) {
 		// Now we'll change the range_max_bytes to be half the range size less a
 		// bit. This is the range where we expect to observe backpressure.
 		_, repl := getFirstStoreReplica(t, tc.Server(0), tablePrefix.Next())
-		newMax := repl.GetMVCCStats().Total()/2 - 32<<10
+		newMax := repl.GetMVCCStats().Total()/2 - 32<<20
 		newMin := newMax / 4
 		tdb.Exec(t, "ALTER TABLE foo CONFIGURE ZONE USING "+
 			"range_max_bytes = $1, range_min_bytes = $2", newMax, newMin)

--- a/pkg/kv/kvserver/client_split_test.go
+++ b/pkg/kv/kvserver/client_split_test.go
@@ -1042,10 +1042,10 @@ func fillRange(
 			return
 		}
 		if key == nil || !singleKey {
-			key = append(append([]byte(nil), prefix...), randutil.RandBytes(src, 100)...)
+			key = append(append([]byte(nil), prefix...), randutil.RandBytes(src, 1000)...)
 			key = keys.MakeFamilyKey(key, src.Uint32())
 		}
-		val := randutil.RandBytes(src, int(src.Int31n(1<<8)))
+		val := randutil.RandBytes(src, 200000)
 		pArgs := putArgs(key, val)
 		_, pErr := kv.SendWrappedWith(context.Background(), store, kvpb.Header{
 			RangeID: rangeID,
@@ -1088,7 +1088,7 @@ func TestStoreZoneUpdateAndRangeSplit(t *testing.T) {
 	tdb.Exec(t, "CREATE TABLE t ()")
 	var descID uint32
 	tdb.QueryRow(t, "SELECT 't'::regclass::int").Scan(&descID)
-	const maxBytes, minBytes = 1 << 16, 1 << 14
+	const maxBytes, minBytes = 100 << 20, 1 << 14
 	tdb.Exec(t, "ALTER TABLE t CONFIGURE ZONE USING range_max_bytes = $1, range_min_bytes = $2",
 		maxBytes, minBytes)
 
@@ -1164,7 +1164,7 @@ func TestStoreRangeSplitWithMaxBytesUpdate(t *testing.T) {
 	tdb.Exec(t, "CREATE TABLE t ()")
 	var descID uint32
 	tdb.QueryRow(t, "SELECT 't'::regclass::int").Scan(&descID)
-	const maxBytes, minBytes = 1 << 16, 1 << 14
+	const maxBytes, minBytes = 100 << 20, 1 << 14
 	tdb.Exec(t, "ALTER TABLE t CONFIGURE ZONE USING range_max_bytes = $1, range_min_bytes = $2",
 		maxBytes, minBytes)
 

--- a/pkg/kv/kvserver/replicate_queue_test.go
+++ b/pkg/kv/kvserver/replicate_queue_test.go
@@ -1757,8 +1757,7 @@ func TestLargeUnsplittableRangeReplicate(t *testing.T) {
 	skip.UnderDeadlockWithIssue(t, 38565)
 	ctx := context.Background()
 
-	// Create a cluster with really small ranges.
-	const rangeMaxSize = base.MinRangeMaxBytes
+	const rangeMaxSize = 64 << 20
 	zcfg := zonepb.DefaultZoneConfig()
 	zcfg.RangeMinBytes = proto.Int64(rangeMaxSize / 2)
 	zcfg.RangeMaxBytes = proto.Int64(rangeMaxSize)
@@ -1778,12 +1777,13 @@ func TestLargeUnsplittableRangeReplicate(t *testing.T) {
 	)
 	defer tc.Stopper().Stop(ctx)
 
-	// We're going to create a table with a big row and a small row. We'll split
-	// the table in between the rows, to produce a large range and a small one.
-	// Then we'll increase the replication factor to 5 and check that both ranges
-	// behave the same - i.e. they both get up-replicated. For the purposes of
-	// this test we're only worried about the large one up-replicating, but we
-	// test the small one as a control so that we don't fool ourselves.
+	// We're going to create a table with many versions of a big row and a small
+	// row. We'll split the table in between the rows, to produce a large range
+	// and a small one. Then we'll increase the replication factor to 5 and check
+	// that both ranges behave the same - i.e. they both get up-replicated. For
+	// the purposes of this test we're only worried about the large one
+	// up-replicating, but we test the small one as a control so that we don't
+	// fool ourselves.
 
 	// Disable the queues so they don't mess with our manual relocation. We'll
 	// re-enable them later.
@@ -1802,14 +1802,20 @@ func TestLargeUnsplittableRangeReplicate(t *testing.T) {
 	toggleReplicationQueues(tc, true /* active */)
 	toggleSplitQueues(tc, true /* active */)
 
-	// We're going to create a row that's larger than range_max_bytes, but not
-	// large enough that write back-pressuring kicks in and refuses it.
+	// We're going to create a large row, but now large enough that write
+	// back-pressuring kicks in and refuses it.
 	var sb strings.Builder
-	for i := 0; i < 1.5*rangeMaxSize; i++ {
+	for i := 0; i < rangeMaxSize/8; i++ {
 		sb.WriteRune('a')
 	}
-	_, err = db.Exec("INSERT INTO t(i,s) VALUES (1, $1)", sb.String())
-	require.NoError(t, err)
+
+	// Write 16 versions of the same row. This way the range won't be able to split.
+	for i := 0; i < 16; i++ {
+		_, err = db.Exec("UPSERT INTO t(i,s) VALUES (1, $1)", sb.String())
+		require.NoError(t, err)
+	}
+
+	// Write a small row into the second range.
 	_, err = db.Exec("INSERT INTO t(i,s) VALUES (2, 'b')")
 	require.NoError(t, err)
 

--- a/pkg/server/decommission_test.go
+++ b/pkg/server/decommission_test.go
@@ -120,9 +120,9 @@ func TestDecommissionPreCheckEvaluation(t *testing.T) {
 	runQueries(setupQueries...)
 	alterQueries := []string{
 		"ALTER TABLE test.tblA CONFIGURE ZONE USING num_replicas = 3, constraints = '{+west: 1, +central: 1, +east: 1}', " +
-			"range_max_bytes = 500000, range_min_bytes = 100",
+			"range_max_bytes = 500000000, range_min_bytes = 100",
 		"ALTER TABLE test.tblB CONFIGURE ZONE USING num_replicas = 3, constraints = '{+east}', " +
-			"range_max_bytes = 500000, range_min_bytes = 100",
+			"range_max_bytes = 500000000, range_min_bytes = 100",
 	}
 	runQueries(alterQueries...)
 	tblAID, err := firstSvr.admin.queryTableID(ctx, username.RootUserName(), "test", "tblA")
@@ -139,8 +139,8 @@ func TestDecommissionPreCheckEvaluation(t *testing.T) {
 	require.NoError(t, err)
 
 	// Ensure all nodes have the correct span configs for tblA and tblB.
-	waitForSpanConfig(t, tc, rDescA.StartKey, 500000)
-	waitForSpanConfig(t, tc, rDescB.StartKey, 500000)
+	waitForSpanConfig(t, tc, rDescA.StartKey, 500000000)
+	waitForSpanConfig(t, tc, rDescB.StartKey, 500000000)
 
 	// Transfer tblA to [west, central, east] and tblB to [east].
 	tc.AddVotersOrFatal(t, startKeyTblA, tc.Target(1), tc.Target(2), tc.Target(4))
@@ -229,7 +229,7 @@ func TestDecommissionPreCheckOddToEven(t *testing.T) {
 	runQueries(setupQueries...)
 	alterQueries := []string{
 		"ALTER TABLE test.tblA CONFIGURE ZONE USING num_replicas = 5, " +
-			"range_max_bytes = 500000, range_min_bytes = 100",
+			"range_max_bytes = 500000000, range_min_bytes = 100",
 	}
 	runQueries(alterQueries...)
 	tblAID, err := firstSvr.admin.queryTableID(ctx, username.RootUserName(), "test", "tblA")
@@ -241,7 +241,7 @@ func TestDecommissionPreCheckOddToEven(t *testing.T) {
 	require.NoError(t, err)
 
 	// Ensure all nodes have the correct span configs for tblA.
-	waitForSpanConfig(t, tc, rDescA.StartKey, 500000)
+	waitForSpanConfig(t, tc, rDescA.StartKey, 500000000)
 
 	// Transfer tblA to all nodes.
 	tc.AddVotersOrFatal(t, startKeyTblA, tc.Target(1), tc.Target(2), tc.Target(3), tc.Target(4))

--- a/pkg/sql/logictest/testdata/logic_test/zone_config
+++ b/pkg/sql/logictest/testdata/logic_test/zone_config
@@ -75,7 +75,7 @@ SELECT zone_id, raw_config_sql FROM [SHOW ZONE CONFIGURATION FOR TABLE a]
 statement ok
 ALTER TABLE a CONFIGURE ZONE USING
   range_min_bytes = 200000 + 1,
-  range_max_bytes = 300000 + 1,
+  range_max_bytes = 100000000 + 1,
   gc.ttlseconds = 3000 + 600,
   num_replicas = floor(1.2)::int,
   constraints = '[+region=test]',
@@ -103,7 +103,7 @@ SELECT zone_id, raw_config_sql FROM [SHOW ZONE CONFIGURATION FOR TABLE a]
 ----
 106  ALTER TABLE a CONFIGURE ZONE USING
      range_min_bytes = 200001,
-     range_max_bytes = 300001,
+     range_max_bytes = 100000001,
      gc.ttlseconds = 3600,
      num_replicas = 1,
      constraints = '[+region=test]',
@@ -111,14 +111,14 @@ SELECT zone_id, raw_config_sql FROM [SHOW ZONE CONFIGURATION FOR TABLE a]
 
 # Check that we can set just one value without altering the others.
 statement ok
-ALTER TABLE a CONFIGURE ZONE USING range_max_bytes = 400000
+ALTER TABLE a CONFIGURE ZONE USING range_max_bytes = 400000000
 
 query IT
 SELECT zone_id, raw_config_sql FROM [SHOW ZONE CONFIGURATION FOR TABLE a]
 ----
 106  ALTER TABLE a CONFIGURE ZONE USING
      range_min_bytes = 200001,
-     range_max_bytes = 400000,
+     range_max_bytes = 400000000,
      gc.ttlseconds = 3600,
      num_replicas = 1,
      constraints = '[+region=test]',
@@ -154,7 +154,7 @@ SELECT zone_id, raw_config_sql FROM [SHOW ZONE CONFIGURATION FOR TABLE a]
 ----
 106  ALTER TABLE a CONFIGURE ZONE USING
      range_min_bytes = 200001,
-     range_max_bytes = 400000,
+     range_max_bytes = 400000000,
      gc.ttlseconds = 3600,
      num_replicas = 1,
      constraints = '[+region=test]',
@@ -170,7 +170,7 @@ a  CREATE TABLE public.a (
    );
    ALTER TABLE test.public.a CONFIGURE ZONE USING
      range_min_bytes = 200001,
-     range_max_bytes = 400000,
+     range_max_bytes = 400000000,
      gc.ttlseconds = 3600,
      num_replicas = 1,
      constraints = '[+region=test]',

--- a/pkg/sql/logictest/testdata/logic_test/zone_config_system_tenant
+++ b/pkg/sql/logictest/testdata/logic_test/zone_config_system_tenant
@@ -95,7 +95,7 @@ SELECT 'db2.t'::REGCLASS::INT
 # in either of these tables for id = $t_id.
 statement ok
 BEGIN;
-ALTER TABLE db2.t CONFIGURE ZONE USING range_max_bytes = 1<<24, range_min_bytes = 1<<20;
+ALTER TABLE db2.t CONFIGURE ZONE USING range_max_bytes = 64<<20, range_min_bytes = 1<<20;
 DROP TABLE db2.t;
 COMMIT;
 
@@ -105,7 +105,7 @@ SELECT crdb_internal.pb_to_json('cockroach.roachpb.SpanConfig', config)
 FROM system.span_configurations
 WHERE end_key > (SELECT crdb_internal.table_span($t_id)[1])
 ----
-{"gcPolicy": {"ttlSeconds": 14400}, "numReplicas": 3, "rangeMaxBytes": "16777216", "rangeMinBytes": "1048576"}
+{"gcPolicy": {"ttlSeconds": 14400}, "numReplicas": 3, "rangeMaxBytes": "67108864", "rangeMinBytes": "1048576"}
 
 statement ok
 CREATE TABLE db2.t2 (i INT PRIMARY KEY);
@@ -123,7 +123,7 @@ SELECT crdb_internal.pb_to_json('cockroach.roachpb.SpanConfig', config)
 FROM system.span_configurations
 WHERE end_key > (SELECT crdb_internal.table_span($t_id)[1])
 ----
-{"gcPolicy": {"ttlSeconds": 90001}, "numReplicas": 3, "rangeMaxBytes": "16777216", "rangeMinBytes": "1048576"}
+{"gcPolicy": {"ttlSeconds": 90001}, "numReplicas": 3, "rangeMaxBytes": "67108864", "rangeMinBytes": "1048576"}
 {"gcPolicy": {"ttlSeconds": 90001}, "numReplicas": 3, "rangeMaxBytes": "1073741824", "rangeMinBytes": "67108864"}
 
 # Check that dropped relations can have their GC TTLs altered.

--- a/pkg/sql/zone_config_test.go
+++ b/pkg/sql/zone_config_test.go
@@ -95,7 +95,7 @@ func TestGetZoneConfig(t *testing.T) {
 	defaultZoneConfig := zonepb.DefaultSystemZoneConfig()
 	defaultZoneConfig.NumReplicas = proto.Int32(1)
 	defaultZoneConfig.RangeMinBytes = proto.Int64(1 << 20)
-	defaultZoneConfig.RangeMaxBytes = proto.Int64(1 << 21)
+	defaultZoneConfig.RangeMaxBytes = proto.Int64(100 << 20)
 	defaultZoneConfig.GC = &zonepb.GCPolicy{TTLSeconds: 60}
 	require.NoError(t, defaultZoneConfig.Validate())
 	params.Knobs.Server = &server.TestingKnobs{
@@ -331,7 +331,7 @@ func TestCascadingZoneConfig(t *testing.T) {
 	defaultZoneConfig := zonepb.DefaultZoneConfig()
 	defaultZoneConfig.NumReplicas = proto.Int32(1)
 	defaultZoneConfig.RangeMinBytes = proto.Int64(1 << 20)
-	defaultZoneConfig.RangeMaxBytes = proto.Int64(1 << 21)
+	defaultZoneConfig.RangeMaxBytes = proto.Int64(100 << 20)
 	defaultZoneConfig.GC = &zonepb.GCPolicy{TTLSeconds: 60}
 	require.NoError(t, defaultZoneConfig.Validate())
 	params.Knobs.Server = &server.TestingKnobs{


### PR DESCRIPTION
We've seen that small range sizes can be detrimental to various components. This PR makes it so users can't lower max_range_size below 64MiB (half of the default min_range_size), instead of 64KiB previously.

Release note: Small ranges have been known to cause problems in various CRDB subsystems. This PR prevents setting max_range_size below COCKROACH_MIN_RANGE_MAX_BYTES, an environment variable which defaults to 64MiB (half of the default minimum range size). 

Epic: https://cockroachlabs.atlassian.net/browse/CRDB-24182
Fixes: https://github.com/cockroachdb/cockroach/issues/96549