### PR TITLE
sql: use unimplemented error rather than syntax error for PL/pgSQL

### DIFF
--- a/pkg/sql/catalog/funcdesc/BUILD.bazel
+++ b/pkg/sql/catalog/funcdesc/BUILD.bazel
@@ -24,6 +24,7 @@ go_library(
         "//pkg/sql/sem/tree",
         "//pkg/sql/sem/volatility",
         "//pkg/sql/types",
+        "//pkg/util/errorutil/unimplemented",
         "//pkg/util/hlc",
         "//pkg/util/iterutil",
         "//pkg/util/protoutil",

--- a/pkg/sql/catalog/funcdesc/func_desc.go
+++ b/pkg/sql/catalog/funcdesc/func_desc.go
@@ -635,7 +635,7 @@ func (desc *immutable) getCreateExprLang() tree.FunctionLanguage {
 	case catpb.Function_SQL:
 		return tree.FunctionLangSQL
 	}
-	return 0
+	return tree.FunctionLangUnknown
 }
 
 func (desc *immutable) getCreateExprVolatility() tree.FunctionVolatility {

--- a/pkg/sql/catalog/funcdesc/helpers.go
+++ b/pkg/sql/catalog/funcdesc/helpers.go
@@ -15,6 +15,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/util/errorutil/unimplemented"
 )
 
 // VolatilityToProto converts sql statement input volatility to protobuf
@@ -54,9 +55,11 @@ func FunctionLangToProto(v tree.FunctionLanguage) (catpb.Function_Language, erro
 	switch v {
 	case tree.FunctionLangSQL:
 		return catpb.Function_SQL, nil
+	case tree.FunctionLangPlPgSQL:
+		return -1, unimplemented.NewWithIssue(91569, "PL/pgSQL is not yet supported")
 	}
 
-	return -1, pgerror.Newf(pgcode.InvalidParameterValue, "Unknown function language %q", v)
+	return -1, pgerror.Newf(pgcode.UndefinedObject, "language %q does not exist", v)
 }
 
 // ParamClassToProto converts sql statement input argument class to protobuf

--- a/pkg/sql/logictest/testdata/logic_test/udf
+++ b/pkg/sql/logictest/testdata/logic_test/udf
@@ -4,6 +4,24 @@ CREATE TABLE ab (
   b INT
 )
 
+statement error pgcode 0A000 unimplemented: PL/pgSQL is not yet supported
+CREATE FUNCTION populate() RETURNS integer AS $$
+DECLARE
+    -- declarations
+BEGIN
+    PERFORM my_function();
+END;
+$$ LANGUAGE plpgsql
+
+statement error pgcode 42704 language \"made_up_language\" does not exist
+CREATE FUNCTION populate() RETURNS integer AS $$
+DECLARE
+    -- declarations
+BEGIN
+    PERFORM my_function();
+END;
+$$ LANGUAGE made_up_language
+
 statement error pq: unimplemented: user-defined functions with SETOF return types are not supported
 CREATE FUNCTION f(a int) RETURNS SETOF INT LANGUAGE SQL AS 'SELECT 1'
 

--- a/pkg/sql/opt/optbuilder/BUILD.bazel
+++ b/pkg/sql/opt/optbuilder/BUILD.bazel
@@ -52,6 +52,7 @@ go_library(
         "//pkg/settings",
         "//pkg/sql/catalog/colinfo",
         "//pkg/sql/catalog/descpb",
+        "//pkg/sql/catalog/funcdesc",
         "//pkg/sql/catalog/schemaexpr",
         "//pkg/sql/catalog/seqexpr",
         "//pkg/sql/catalog/tabledesc",

--- a/pkg/sql/opt/optbuilder/create_function.go
+++ b/pkg/sql/opt/optbuilder/create_function.go
@@ -12,6 +12,7 @@ package optbuilder
 
 import (
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/funcdesc"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/typedesc"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
@@ -81,6 +82,10 @@ func (b *Builder) buildCreateFunction(cf *tree.CreateFunction, inScope *scope) (
 			funcBodyStr = string(opt)
 		case tree.FunctionLanguage:
 			languageFound = true
+			// Check the language here, before attempting to parse the function body.
+			if _, err := funcdesc.FunctionLangToProto(opt); err != nil {
+				panic(err)
+			}
 		}
 	}
 

--- a/pkg/sql/opt/testutils/testcat/function.go
+++ b/pkg/sql/opt/testutils/testcat/function.go
@@ -146,8 +146,8 @@ func collectFuncOptions(
 			}
 
 		case tree.FunctionLanguage:
-			if t != tree.FunctionLangSQL {
-				panic(fmt.Errorf("LANGUAGE must be SQL"))
+			if t != tree.FunctionLangSQL && t != tree.FunctionLangPlPgSQL {
+				panic(fmt.Errorf("LANGUAGE must be SQL or plpgsql"))
 			}
 
 		default:

--- a/pkg/sql/parser/testdata/create_function
+++ b/pkg/sql/parser/testdata/create_function
@@ -495,3 +495,53 @@ using the support form.
 We appreciate your feedback.
 ----
 ----
+
+parse
+CREATE FUNCTION populate() RETURNS integer AS $$
+DECLARE
+    -- declarations
+BEGIN
+    PERFORM my_function();
+END;
+$$ LANGUAGE plpgsql
+----
+CREATE FUNCTION populate()
+	RETURNS INT8
+	LANGUAGE plpgsql
+	AS $$
+DECLARE
+    -- declarations
+BEGIN
+    PERFORM my_function();
+END;
+$$ -- normalized!
+CREATE FUNCTION populate()
+	RETURNS INT8
+	LANGUAGE plpgsql
+	AS $$
+DECLARE
+    -- declarations
+BEGIN
+    PERFORM my_function();
+END;
+$$ -- fully parenthesized
+CREATE FUNCTION populate()
+	RETURNS INT8
+	LANGUAGE plpgsql
+	AS $$
+DECLARE
+    -- declarations
+BEGIN
+    PERFORM my_function();
+END;
+$$ -- literals removed
+CREATE FUNCTION _()
+	RETURNS INT8
+	LANGUAGE plpgsql
+	AS $$
+DECLARE
+    -- declarations
+BEGIN
+    PERFORM my_function();
+END;
+$$ -- identifiers removed

--- a/pkg/sql/sem/tree/udf.go
+++ b/pkg/sql/sem/tree/udf.go
@@ -235,33 +235,34 @@ func (node FunctionLeakproof) Format(ctx *FmtCtx) {
 
 // FunctionLanguage indicates the language of the statements in the UDF function
 // body.
-type FunctionLanguage int
+type FunctionLanguage string
 
 const (
-	_ FunctionLanguage = iota
-	// FunctionLangSQL represent SQL language.
-	FunctionLangSQL
+	// FunctionLangUnknown represents an unknown language.
+	FunctionLangUnknown FunctionLanguage = "unknown"
+	// FunctionLangSQL represents SQL language.
+	FunctionLangSQL FunctionLanguage = "SQL"
+	// FunctionLangPlPgSQL represents the PL/pgSQL procedural language.
+	FunctionLangPlPgSQL FunctionLanguage = "plpgsql"
 )
 
 // Format implements the NodeFormatter interface.
 func (node FunctionLanguage) Format(ctx *FmtCtx) {
 	ctx.WriteString("LANGUAGE ")
-	switch node {
-	case FunctionLangSQL:
-		ctx.WriteString("SQL")
-	default:
-		panic(pgerror.New(pgcode.InvalidParameterValue, "Unknown function option"))
-	}
+	ctx.WriteString(string(node))
 }
 
 // AsFunctionLanguage converts a string to a FunctionLanguage if applicable.
-// Error is returned if string does not represent a valid UDF language.
+// No error is returned if string does not represent a valid UDF language;
+// unknown languages result in an error later.
 func AsFunctionLanguage(lang string) (FunctionLanguage, error) {
 	switch strings.ToLower(lang) {
 	case "sql":
 		return FunctionLangSQL, nil
+	case "plpgsql":
+		return FunctionLangPlPgSQL, nil
 	}
-	return 0, errors.Newf("language %q does not exist", lang)
+	return FunctionLanguage(lang), nil
 }
 
 // FunctionBodyStr is a string containing all statements in a UDF body.
@@ -523,34 +524,34 @@ func MaybeFailOnUDFUsage(expr TypedExpr) error {
 // function options in the given slice.
 func ValidateFuncOptions(options FunctionOptions) error {
 	var hasLang, hasBody, hasLeakProof, hasVolatility, hasNullInputBehavior bool
-	err := func(opt FunctionOption) error {
+	conflictingErr := func(opt FunctionOption) error {
 		return errors.Wrapf(ErrConflictingFunctionOption, "%s", AsString(opt))
 	}
 	for _, option := range options {
 		switch option.(type) {
 		case FunctionLanguage:
 			if hasLang {
-				return err(option)
+				return conflictingErr(option)
 			}
 			hasLang = true
 		case FunctionBodyStr:
 			if hasBody {
-				return err(option)
+				return conflictingErr(option)
 			}
 			hasBody = true
 		case FunctionLeakproof:
 			if hasLeakProof {
-				return err(option)
+				return conflictingErr(option)
 			}
 			hasLeakProof = true
 		case FunctionVolatility:
 			if hasVolatility {
-				return err(option)
+				return conflictingErr(option)
 			}
 			hasVolatility = true
 		case FunctionNullInputBehavior:
 			if hasNullInputBehavior {
-				return err(option)
+				return conflictingErr(option)
 			}
 			hasNullInputBehavior = true
 		default:


### PR DESCRIPTION
fixes https://github.com/cockroachdb/cockroach/issues/96720

This change does not affect anything user-facing, but it allows us to parse CREATE FUNCTION statements that use `LANGUAGE plpgsql`. The plpgsql grammar is still not supported, so this will still show an error to the user. However, since parsing succeeds, the statement will be sent to telemetry logs, allowing us to analyze which parts of the plpgsql grammar that customers are trying to use.

Release note: None