### PR TITLE
ui: fix error message for upgrade

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/api/sqlApi.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/api/sqlApi.ts
@@ -148,12 +148,13 @@ function isUpgradeError(message: string): boolean {
  * @param message
  */
 export function sqlApiErrorMessage(message: string): string {
+  if (isUpgradeError(message)) {
+    return "This page may not be available during an upgrade.";
+  }
+
   message = message.replace("run-query-via-api: ", "");
   if (message.includes(":")) {
     return message.split(":")[1];
-  }
-  if (isUpgradeError(message)) {
-    message = "This page may not be available during an upgrade.";
   }
 
   return message;


### PR DESCRIPTION
Previously the `sqlApiErrorMessage` was returning
an error message before checking if it was an
upgrade error message.
This commit changes the order and already returns
the upgrade error message before doing the parse
of the original message.

Epic: None
Release note: none