### PR TITLE
storage: don't modify the given cfg.Opts

### DIFF
--- a/pkg/cli/debug.go
+++ b/pkg/cli/debug.go
@@ -1532,17 +1532,14 @@ func pebbleCryptoInitializer() error {
 		}
 	}
 
-	cfg := storage.PebbleConfig{
-		StorageConfig: storageConfig,
-		Opts:          storage.DefaultPebbleOptions(),
-	}
-
-	// This has the side effect of storing the encrypted FS into cfg.Opts.FS.
-	_, _, err := storage.ResolveEncryptedEnvOptions(&cfg)
+	_, encryptedEnv, err := storage.ResolveEncryptedEnvOptions(&storageConfig, vfs.Default, false /* readOnly */)
 	if err != nil {
 		return err
 	}
-
-	pebbleToolFS.set(cfg.Opts.FS)
+	if encryptedEnv != nil {
+		pebbleToolFS.set(encryptedEnv.FS)
+	} else {
+		pebbleToolFS.set(vfs.Default)
+	}
 	return nil
 }

--- a/pkg/storage/pebble_file_registry.go
+++ b/pkg/storage/pebble_file_registry.go
@@ -90,8 +90,8 @@ const (
 
 // CheckNoRegistryFile checks that no registry file currently exists.
 // CheckNoRegistryFile should be called if the file registry will not be used.
-func (r *PebbleFileRegistry) CheckNoRegistryFile() error {
-	filename, err := atomicfs.ReadMarker(r.FS, r.DBDir, registryMarkerName)
+func CheckNoRegistryFile(fs vfs.FS, dbDir string) error {
+	filename, err := atomicfs.ReadMarker(fs, dbDir, registryMarkerName)
 	if oserror.IsNotExist(err) {
 		// ReadMarker may return oserror.IsNotExist if the data
 		// directory does not exist.

--- a/pkg/storage/pebble_file_registry_test.go
+++ b/pkg/storage/pebble_file_registry_test.go
@@ -190,12 +190,11 @@ func TestFileRegistryCheckNoFile(t *testing.T) {
 	mem := vfs.NewMem()
 	fileEntry :=
 		&enginepb.FileEntry{EnvType: enginepb.EnvType_Data, EncryptionSettings: []byte("foo")}
+	require.NoError(t, CheckNoRegistryFile(mem, "" /* dbDir */))
 	registry := &PebbleFileRegistry{FS: mem}
-	require.NoError(t, registry.CheckNoRegistryFile())
 	require.NoError(t, registry.Load())
 	require.NoError(t, registry.SetFileEntry("/foo", fileEntry))
-	registry = &PebbleFileRegistry{FS: mem}
-	require.Error(t, registry.CheckNoRegistryFile())
+	require.Error(t, CheckNoRegistryFile(mem, "" /* dbDir */))
 }
 
 func TestFileRegistryElideUnencrypted(t *testing.T) {
@@ -293,8 +292,8 @@ func TestFileRegistryRecordsReadAndWrite(t *testing.T) {
 	}
 
 	// Create a file registry and add entries for a few files.
+	require.NoError(t, CheckNoRegistryFile(mem, "" /* dbDir */))
 	registry1 := &PebbleFileRegistry{FS: mem}
-	require.NoError(t, registry1.CheckNoRegistryFile())
 	require.NoError(t, registry1.Load())
 	for filename, entry := range files {
 		require.NoError(t, registry1.SetFileEntry(filename, entry))
@@ -332,10 +331,7 @@ func TestFileRegistry(t *testing.T) {
 		switch d.Cmd {
 		case "check-no-registry-file":
 			require.Nil(t, registry)
-			registry = &PebbleFileRegistry{FS: fs}
-			err := registry.CheckNoRegistryFile()
-			registry = nil
-			if err == nil {
+			if err := CheckNoRegistryFile(fs, "" /* dbDir */); err == nil {
 				fmt.Fprintf(&buf, "OK\n")
 			} else {
 				fmt.Fprintf(&buf, "Error: %s\n", err)


### PR DESCRIPTION
This change improves the `NewPebble` code to not modify the given `cfg.Opts`. Such behavior is surprising and can trip up tests that reuse the same config.

Also, `ResolveEncryptedEnvOptions` and `wrapFilesystemMiddleware` no longer modify the `Options` directly; and `CheckNoRegistryFile` is now a standalone function.

Release note: None
Epic: none