### PR TITLE
storageccl: fix and reenable BenchmarkTimeBoundIterate

### DIFF
--- a/pkg/ccl/storageccl/engineccl/.gitignore
+++ b/pkg/ccl/storageccl/engineccl/.gitignore
@@ -1,3 +1,0 @@
-# Do not add environment-specific entries here (see the top-level .gitignore
-# for reasoning and alternatives).
-mvcc_data


### PR DESCRIPTION
This benchmark creates a `mvcc_data` directory in the current working dir (i.e. `pkg/ccl/storageccl/engineccl`) and reuses it if exists. Normally this would not be permitted in CI; but `mvcc_data` is in `.gitignore` so it doesn't trip the "assert workspace clean" CI step.

The leftover `mvcc_data` can be from an older version, which can cause mysterious CI failures.

This fix changes to generating the data in a temporary directory and cleans it up afterwards. The generation only takes a few seconds (significantly less than what it takes to run all benchmarks).

Release note: None
Epic: none