### PR TITLE
clusterversion: remove replication version gates

### DIFF
--- a/pkg/clusterversion/cockroach_versions.go
+++ b/pkg/clusterversion/cockroach_versions.go
@@ -215,9 +215,6 @@ const (
 	// probabilistically collects stmt bundles, controlled by the user provided
 	// sampling rate.
 	TODODelete_V22_2SampledStmtDiagReqs
-	// TODODelete_V22_2AddSSTableTombstones allows writing MVCC point tombstones via AddSSTable.
-	// Previously, SSTs containing these could error.
-	TODODelete_V22_2AddSSTableTombstones
 	// TODODelete_V22_2SystemPrivilegesTable adds system.privileges table.
 	TODODelete_V22_2SystemPrivilegesTable
 	// TODODelete_V22_2EnablePredicateProjectionChangefeed indicates that changefeeds support
@@ -518,10 +515,6 @@ var rawVersionsSingleton = keyedVersions{
 	{
 		Key:     TODODelete_V22_2SampledStmtDiagReqs,
 		Version: roachpb.Version{Major: 22, Minor: 1, Internal: 20},
-	},
-	{
-		Key:     TODODelete_V22_2AddSSTableTombstones,
-		Version: roachpb.Version{Major: 22, Minor: 1, Internal: 22},
 	},
 	{
 		Key:     TODODelete_V22_2SystemPrivilegesTable,

--- a/pkg/clusterversion/cockroach_versions.go
+++ b/pkg/clusterversion/cockroach_versions.go
@@ -285,9 +285,6 @@ const (
 	// schema changes to complete. After this point, no non-MVCC
 	// AddSSTable calls will be used outside of tenant streaming.
 	TODODelete_V22_2NoNonMVCCAddSSTable
-	// TODODelete_V22_2GCHintInReplicaState adds GC hint to replica state. When this version is
-	// enabled, replicas will populate GC hint and update them when necessary.
-	TODODelete_V22_2GCHintInReplicaState
 	// TODODelete_V22_2UpdateInvalidColumnIDsInSequenceBackReferences looks for invalid column
 	// ids in sequences' back references and attempts a best-effort-based matching
 	// to update those column IDs.
@@ -595,10 +592,6 @@ var rawVersionsSingleton = keyedVersions{
 	{
 		Key:     TODODelete_V22_2NoNonMVCCAddSSTable,
 		Version: roachpb.Version{Major: 22, Minor: 1, Internal: 62},
-	},
-	{
-		Key:     TODODelete_V22_2GCHintInReplicaState,
-		Version: roachpb.Version{Major: 22, Minor: 1, Internal: 64},
 	},
 	{
 		Key:     TODODelete_V22_2UpdateInvalidColumnIDsInSequenceBackReferences,

--- a/pkg/kv/kvserver/batcheval/cmd_delete_range.go
+++ b/pkg/kv/kvserver/batcheval/cmd_delete_range.go
@@ -14,7 +14,6 @@ import (
 	"context"
 	"time"
 
-	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/batcheval/result"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverpb"
@@ -136,9 +135,7 @@ func DeleteRange(
 			if !hint.ForwardLatestRangeDeleteTimestamp(h.Timestamp) {
 				return nil
 			}
-			canUseGCHint := cArgs.EvalCtx.ClusterSettings().Version.IsActive(ctx,
-				clusterversion.TODODelete_V22_2GCHintInReplicaState)
-			if updated, err := sl.SetGCHint(ctx, readWriter, cArgs.Stats, hint, canUseGCHint); err != nil || !updated {
+			if updated, err := sl.SetGCHint(ctx, readWriter, cArgs.Stats, hint); err != nil || !updated {
 				return err
 			}
 			res.Replicated.State = &kvserverpb.ReplicaState{

--- a/pkg/kv/kvserver/batcheval/cmd_end_transaction.go
+++ b/pkg/kv/kvserver/batcheval/cmd_end_transaction.go
@@ -1120,12 +1120,9 @@ func splitTriggerHelper(
 		if gcThreshold.IsEmpty() {
 			log.VEventf(ctx, 1, "LHS's GCThreshold of split is not set")
 		}
-		gcHint := &roachpb.GCHint{}
-		if split.WriteGCHint {
-			gcHint, err = sl.LoadGCHint(ctx, batch)
-			if err != nil {
-				return enginepb.MVCCStats{}, result.Result{}, errors.Wrap(err, "unable to load GCHint")
-			}
+		gcHint, err := sl.LoadGCHint(ctx, batch)
+		if err != nil {
+			return enginepb.MVCCStats{}, result.Result{}, errors.Wrap(err, "unable to load GCHint")
 		}
 
 		// Writing the initial state is subtle since this also seeds the Raft
@@ -1163,7 +1160,7 @@ func splitTriggerHelper(
 		}
 		*h.AbsPostSplitRight(), err = stateloader.WriteInitialReplicaState(
 			ctx, batch, *h.AbsPostSplitRight(), split.RightDesc, rightLease,
-			*gcThreshold, *gcHint, replicaVersion, split.WriteGCHint,
+			*gcThreshold, *gcHint, replicaVersion,
 		)
 		if err != nil {
 			return enginepb.MVCCStats{}, result.Result{}, errors.Wrap(err, "unable to write initial Replica state")
@@ -1282,7 +1279,7 @@ func mergeTrigger(
 			return result.Result{}, err
 		}
 		if lhsHint.Merge(rhsHint, rec.GetMVCCStats().HasNoUserData(), merge.RightMVCCStats.HasNoUserData()) {
-			updated, err := lhsLoader.SetGCHint(ctx, batch, ms, lhsHint, merge.WriteGCHint)
+			updated, err := lhsLoader.SetGCHint(ctx, batch, ms, lhsHint)
 			if err != nil {
 				return result.Result{}, err
 			}

--- a/pkg/kv/kvserver/batcheval/cmd_gc.go
+++ b/pkg/kv/kvserver/batcheval/cmd_gc.go
@@ -280,9 +280,7 @@ func GC(
 				res.Replicated.State = &kvserverpb.ReplicaState{
 					GCHint: hint,
 				}
-				// If we got here, that means hint is already not empty and is enabled by
-				// version gate.
-				if _, err := sl.SetGCHint(ctx, readWriter, cArgs.Stats, hint, true); err != nil {
+				if _, err := sl.SetGCHint(ctx, readWriter, cArgs.Stats, hint); err != nil {
 					return result.Result{}, err
 				}
 			}

--- a/pkg/kv/kvserver/loqrecovery/recovery_env_test.go
+++ b/pkg/kv/kvserver/loqrecovery/recovery_env_test.go
@@ -327,7 +327,7 @@ func (e *quorumRecoveryEnv) handleReplicationData(t *testing.T, d datadriven.Tes
 		}
 
 		sl := stateloader.Make(replica.RangeID)
-		if _, err := sl.Save(ctx, eng, replicaState, true /* gcHintsEnabled */); err != nil {
+		if _, err := sl.Save(ctx, eng, replicaState); err != nil {
 			t.Fatalf("failed to save raft replica state into store: %v", err)
 		}
 		if err := sl.SetHardState(ctx, eng, hardState); err != nil {

--- a/pkg/kv/kvserver/replica_command.go
+++ b/pkg/kv/kvserver/replica_command.go
@@ -225,17 +225,14 @@ func splitTxnAttempt(
 		return err
 	}
 
-	gcHintsAllowed := store.ClusterSettings().Version.IsActive(ctx, clusterversion.TODODelete_V22_2GCHintInReplicaState)
-
 	// End the transaction manually, instead of letting RunTransaction
 	// loop do it, in order to provide a split trigger.
 	b.AddRawRequest(&roachpb.EndTxnRequest{
 		Commit: true,
 		InternalCommitTrigger: &roachpb.InternalCommitTrigger{
 			SplitTrigger: &roachpb.SplitTrigger{
-				LeftDesc:    *leftDesc,
-				RightDesc:   *rightDesc,
-				WriteGCHint: gcHintsAllowed,
+				LeftDesc:  *leftDesc,
+				RightDesc: *rightDesc,
 			},
 		},
 	})
@@ -761,8 +758,6 @@ func (r *Replica) AdminMerge(
 			return errors.Wrap(err, "waiting for all right-hand replicas to catch up")
 		}
 
-		gcHintsAllowed := r.ClusterSettings().Version.IsActive(ctx, clusterversion.TODODelete_V22_2GCHintInReplicaState)
-
 		// Successful subsume, so we're guaranteed that the right-hand range will
 		// not serve another request unless this transaction aborts. End the
 		// transaction manually in order to provide a merge trigger.
@@ -777,7 +772,6 @@ func (r *Replica) AdminMerge(
 					FreezeStart:          rhsSnapshotRes.FreezeStart,
 					RightClosedTimestamp: rhsSnapshotRes.ClosedTimestamp,
 					RightReadSummary:     rhsSnapshotRes.ReadSummary,
-					WriteGCHint:          gcHintsAllowed,
 				},
 			},
 		})

--- a/pkg/kv/kvserver/stateloader/initial.go
+++ b/pkg/kv/kvserver/stateloader/initial.go
@@ -47,7 +47,6 @@ func WriteInitialReplicaState(
 	gcThreshold hlc.Timestamp,
 	gcHint roachpb.GCHint,
 	replicaVersion roachpb.Version,
-	gcHintsAllowed bool,
 ) (enginepb.MVCCStats, error) {
 	rsl := Make(desc.RangeID)
 	var s kvserverpb.ReplicaState
@@ -92,7 +91,7 @@ func WriteInitialReplicaState(
 		log.Fatalf(ctx, "expected trivial version, but found %+v", existingVersion)
 	}
 
-	newMS, err := rsl.Save(ctx, readWriter, s, gcHintsAllowed)
+	newMS, err := rsl.Save(ctx, readWriter, s)
 	if err != nil {
 		return enginepb.MVCCStats{}, err
 	}
@@ -116,7 +115,7 @@ func WriteInitialRangeState(
 
 	if _, err := WriteInitialReplicaState(
 		ctx, readWriter, initialMS, desc, initialLease, initialGCThreshold, initialGCHint,
-		replicaVersion, true, /* 22.2: GCHintInReplicaState */
+		replicaVersion,
 	); err != nil {
 		return err
 	}

--- a/pkg/kv/kvserver/stateloader/stateloader.go
+++ b/pkg/kv/kvserver/stateloader/stateloader.go
@@ -114,10 +114,7 @@ func (rsl StateLoader) Load(
 // missing whenever save is called. Optional values should be reserved
 // strictly for use in Result. Do before merge.
 func (rsl StateLoader) Save(
-	ctx context.Context,
-	readWriter storage.ReadWriter,
-	state kvserverpb.ReplicaState,
-	gcHintEnabled bool,
+	ctx context.Context, readWriter storage.ReadWriter, state kvserverpb.ReplicaState,
 ) (enginepb.MVCCStats, error) {
 	ms := state.Stats
 	if err := rsl.SetLease(ctx, readWriter, ms, *state.Lease); err != nil {
@@ -126,10 +123,8 @@ func (rsl StateLoader) Save(
 	if err := rsl.SetGCThreshold(ctx, readWriter, ms, state.GCThreshold); err != nil {
 		return enginepb.MVCCStats{}, err
 	}
-	if gcHintEnabled {
-		if _, err := rsl.SetGCHint(ctx, readWriter, ms, state.GCHint, gcHintEnabled); err != nil {
-			return enginepb.MVCCStats{}, err
-		}
+	if _, err := rsl.SetGCHint(ctx, readWriter, ms, state.GCHint); err != nil {
+		return enginepb.MVCCStats{}, err
 	}
 	// TODO(sep-raft-log): SetRaftTruncatedState will be in a separate batch when
 	// the Raft log engine is separated. Figure out the ordering required here.
@@ -297,15 +292,8 @@ func (rsl StateLoader) LoadGCHint(
 
 // SetGCHint writes the GC hint.
 func (rsl StateLoader) SetGCHint(
-	ctx context.Context,
-	readWriter storage.ReadWriter,
-	ms *enginepb.MVCCStats,
-	hint *roachpb.GCHint,
-	gcHintEnabled bool,
+	ctx context.Context, readWriter storage.ReadWriter, ms *enginepb.MVCCStats, hint *roachpb.GCHint,
 ) (updated bool, _ error) {
-	if !gcHintEnabled {
-		return false, nil
-	}
 	if hint == nil {
 		return false, errors.New("cannot persist nil GCHint")
 	}

--- a/pkg/kv/kvserver/store_snapshot.go
+++ b/pkg/kv/kvserver/store_snapshot.go
@@ -15,7 +15,6 @@ import (
 	"io"
 	"time"
 
-	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/allocator/storepool"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverbase"
@@ -1361,18 +1360,6 @@ func SendEmptySnapshot(
 		return err
 	}
 
-	supportsGCHints := st.Version.IsActive(ctx, clusterversion.TODODelete_V22_2GCHintInReplicaState)
-	// SendEmptySnapshot is only used by the cockroach debug reset-quorum tool.
-	// It is experimental and unlikely to be used in cluster versions that are
-	// older than GCHintInReplicaState. We do not want the cluster version to
-	// fully dictate the value of the supportsGCHints parameter, since if this
-	// node's view of the version is stale we could regress to a state before the
-	// migration. Instead, we return an error if the cluster version is old.
-	if !supportsGCHints {
-		return errors.Errorf("cluster version is too old %s",
-			st.Version.ActiveVersionOrEmpty(ctx))
-	}
-
 	ms, err = stateloader.WriteInitialReplicaState(
 		ctx,
 		eng,
@@ -1382,7 +1369,6 @@ func SendEmptySnapshot(
 		hlc.Timestamp{}, // gcThreshold
 		roachpb.GCHint{},
 		st.Version.ActiveVersionOrEmpty(ctx).Version,
-		supportsGCHints, /* 22.2: GCHintInReplicaState */
 	)
 	if err != nil {
 		return err

--- a/pkg/roachpb/api.proto
+++ b/pkg/roachpb/api.proto
@@ -1802,11 +1802,6 @@ message AdminVerifyProtectedTimestampResponse {
 // inline values). It cannot be used in a transaction, cannot be split across
 // ranges, and must be alone in a batch.
 //
-// In 22.1, AddSSTable does not support MVCC point tombstones in SSTs, and may
-// return an error when given these. 22.2 does allow this, but check the
-// AddSSTableTombstones version gate first to make sure there are no 22.1 nodes
-// left in the cluster.
-//
 // MVCC range tombstones are supported in 22.2, but check the
 // MVCCRangeTombstones version gate before writing them.
 //

--- a/pkg/roachpb/data.proto
+++ b/pkg/roachpb/data.proto
@@ -129,13 +129,7 @@ message SplitTrigger {
   RangeDescriptor left_desc = 1 [(gogoproto.nullable) = false];
   RangeDescriptor right_desc = 2 [(gogoproto.nullable) = false];
 
-  // WriteGCHint is a version gate to only enable writing GC hints in split
-  // trigger if cluster was upgraded to required version.
-  // TODO(replication): remove this field in the 23.2 cycle (i.e. on master
-  // after 23.1 has been cut).
-  bool write_gc_hint = 4 [(gogoproto.customname) = "WriteGCHint"];
-
-  reserved 3;
+  reserved 3, 4;
 }
 
 // A MergeTrigger is run after a successful commit of an AdminMerge


### PR DESCRIPTION
**clusterversion: remove `AddSSTableTombstones` version gate**

Epic: none
Release note: None
  
**clusterversion: remove `GCHintInReplicaState` cluster version**

Also removes `roachpb.SplitTrigger.WriteGCHint` since we now always write GC hints.

Resolves #96760.

Epic: none
Release note: None