### PR TITLE
kvcoord: Fix termination race in mux rangefeed

### DIFF
--- a/pkg/kv/kvclient/kvcoord/dist_sender_mux_rangefeed.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender_mux_rangefeed.go
@@ -23,6 +23,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/pprofutil"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/logtags"
 )
 
@@ -348,7 +349,7 @@ func (m *rangefeedMuxer) receiveEventsFromNode(ctx context.Context, ms *muxClien
 			return ctx.Err()
 		case <-m.demuxLoopDone:
 			// demuxLoop exited, and so should we (happens when main context group completes)
-			return nil
+			return errors.Wrapf(context.Canceled, "demux loop terminated")
 		case m.eventCh <- event:
 		}
 	}


### PR DESCRIPTION
Fixes #96784
Fixes #96517

Ensure receiveEventsFromNode never returns nil error. Returning nil error may trigger a race where the client, blocked in Recv(), observes termination signal, and returns nil event and nil error.  This could happen during rangefeed tear down, where context cancellation races with running rangefeed.

Release note: None