### PR TITLE
opt: mark ConvertUncorrelatedExistsToCoalesceSubquery as essential

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/scalar.go
+++ b/pkg/sql/opt/exec/execbuilder/scalar.go
@@ -679,8 +679,7 @@ func (b *Builder) buildExistsSubquery(
 	// TODO(mgartner): This path should never be executed because the
 	// ConvertUncorrelatedExistsToCoalesceSubquery converts all uncorrelated
 	// Exists with Coalesce+Subquery expressions. Remove this and the execution
-	// support for the Exists mode. Remember to mark
-	// ConvertUncorrelatedExistsToCoalesceSubquery as an essential rule.
+	// support for the Exists mode.
 	plan, err := b.buildRelational(exists.Input)
 	if err != nil {
 		return nil, err
@@ -1032,5 +1031,5 @@ func (b *Builder) buildRoutinePlanGenerator(
 }
 
 func expectedLazyRoutineError(typ string) error {
-	return errors.AssertionFailedf("expected %s to be lazily planned as routines", typ)
+	return errors.AssertionFailedf("expected %s to be lazily planned as a routine", typ)
 }

--- a/pkg/sql/opt/xform/optimizer.go
+++ b/pkg/sql/opt/xform/optimizer.go
@@ -1078,6 +1078,9 @@ func (o *Optimizer) disableRulesRandom(probability float64) {
 		int(opt.PruneScanCols),
 		// Needed to ensure that the input of a RangeExpr is always an AndExpr.
 		int(opt.SimplifyRange),
+		// Needed to ensure that all uncorrelated EXISTS subqueries are
+		// converted to COALESCE+subquery expressions.
+		int(opt.ConvertUncorrelatedExistsToCoalesceSubquery),
 	)
 
 	var disabledRules RuleSet


### PR DESCRIPTION
This rule converts uncorrelated `EXISTS` subqueries into
`COALESCE`+subquery expressions. It is essential because execbuilder
cannot plan lazily-executed, uncorrelated `EXISTS` subqueries.

Fixes #95546

Release note: None
