### PR TITLE
wip: ui: Improve network latency page to display consistent data

### DIFF
--- a/pkg/ui/workspaces/db-console/src/redux/apiReducers.ts
+++ b/pkg/ui/workspaces/db-console/src/redux/apiReducers.ts
@@ -507,6 +507,12 @@ const rawTraceReducerObj = new KeyedCachedDataReducer(
 );
 export const refreshRawTrace = rawTraceReducerObj.refresh;
 
+const networkLatencyReducerObj = new CachedDataReducer(
+  api.getNetworkConnectivity,
+  "networkLatency",
+);
+export const refreshNetworkLatency = networkLatencyReducerObj.refresh;
+
 export interface APIReducersState {
   cluster: CachedDataReducerState<api.ClusterResponseMessage>;
   events: CachedDataReducerState<clusterUiApi.EventsResponse>;
@@ -551,6 +557,7 @@ export interface APIReducersState {
   snapshots: KeyedCachedDataReducerState<clusterUiApi.ListTracingSnapshotsResponse>;
   snapshot: KeyedCachedDataReducerState<clusterUiApi.GetTracingSnapshotResponse>;
   rawTrace: KeyedCachedDataReducerState<clusterUiApi.GetTraceResponse>;
+  networkLatency: CachedDataReducerState<api.NetworkConnectivityResponse>;
 }
 
 export const apiReducersReducer = combineReducers<APIReducersState>({
@@ -602,6 +609,7 @@ export const apiReducersReducer = combineReducers<APIReducersState>({
   [snapshotsReducerObj.actionNamespace]: snapshotsReducerObj.reducer,
   [snapshotReducerObj.actionNamespace]: snapshotReducerObj.reducer,
   [rawTraceReducerObj.actionNamespace]: rawTraceReducerObj.reducer,
+  [networkLatencyReducerObj.actionNamespace]: networkLatencyReducerObj.reducer,
 });
 
 export { CachedDataReducerState, KeyedCachedDataReducerState };

--- a/pkg/ui/workspaces/db-console/src/util/api.ts
+++ b/pkg/ui/workspaces/db-console/src/util/api.ts
@@ -215,6 +215,11 @@ export type ListTracingSnapshotsRequestMessage =
 export type ListTracingSnapshotsResponseMessage =
   protos.cockroach.server.serverpb.ListTracingSnapshotsResponse;
 
+export type NetworkConnectivityRequest =
+  protos.cockroach.server.serverpb.NetworkConnectivityRequest;
+export type NetworkConnectivityResponse =
+  protos.cockroach.server.serverpb.NetworkConnectivityResponse;
+
 // API constants
 
 export const API_PREFIX = "_admin/v1";
@@ -873,6 +878,18 @@ export function getKeyVisualizerSamples(
   return timeoutFetch(
     serverpb.KeyVisSamplesResponse,
     `${STATUS_PREFIX}/keyvissamples`,
+    req as any,
+    timeout,
+  );
+}
+
+export function getNetworkConnectivity(
+  req: NetworkConnectivityRequest,
+  timeout?: moment.Duration,
+): Promise<NetworkConnectivityResponse> {
+  return timeoutFetch(
+    serverpb.NetworkConnectivityResponse,
+    `${STATUS_PREFIX}/connectivity`,
     req as any,
     timeout,
   );

--- a/pkg/ui/workspaces/db-console/src/util/query.ts
+++ b/pkg/ui/workspaces/db-console/src/util/query.ts
@@ -58,9 +58,13 @@ export function queryByName(location: Location, key: string): string | null {
 }
 
 export function getMatchParamByName(match: Match<any>, key: string) {
-  const param = match.params[key];
-  if (param) {
-    return decodeURIComponent(param);
-  }
-  return null;
+  return getParam(match.params, key);
 }
+
+export const getParam = (params: any, key: string) => {
+  if (!params) {
+    return null;
+  }
+  const param = params[key];
+  return param ? decodeURIComponent(param) : null;
+};

--- a/pkg/ui/workspaces/db-console/src/views/reports/containers/network/latency/index.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/reports/containers/network/latency/index.tsx
@@ -22,7 +22,7 @@ import { getValueFromString, Identity } from "..";
 import "./latency.styl";
 import { Empty } from "src/components/empty";
 
-interface StdDev {
+export interface StdDev {
   stddev: number;
   stddevMinus2: number;
   stddevMinus1: number;

--- a/pkg/ui/workspaces/db-console/src/views/reports/containers/network/latency/index.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/reports/containers/network/latency/index.tsx
@@ -43,14 +43,13 @@ interface DetailedRow {
   latency: number;
   identityB: Identity;
 }
-type DetailedIdentity = Identity & {
+export type DetailedIdentity = Identity & {
   row: DetailedRow[];
   title?: string;
 };
 
 // createHeaderCell creates and decorates a header cell.
 function createHeaderCell(
-  staleIDs: Set<number>,
   id: DetailedIdentity,
   key: string,
   isMultiple?: boolean,
@@ -60,7 +59,6 @@ function createHeaderCell(
   const className = classNames(
     "latency-table__cell",
     "latency-table__cell--header",
-    { "latency-table__cell--header-warning": staleIDs.has(id.nodeID) },
     { "latency-table__cell--start": isMultiple },
   );
   return (
@@ -122,6 +120,7 @@ const renderMultipleHeaders = (
   nodeId: string,
   multipleHeader: boolean,
 ) => {
+  // replace with createDetailedIdentityArray.
   const data: any = [];
   let rowLength = 0;
   const filteredData = displayIdentities.map(identityA => {
@@ -217,7 +216,19 @@ const getLatencyCell = (
           "latency-table__cell--stddev-even",
         ])}
       >
-        <Chip title="loading..." type="yellow" />
+        <Chip title="currently no connection" type="yellow" />
+      </td>
+    );
+  }
+  if (latency === -2) {
+    return (
+      <td
+        className={generateClassName([
+          "latency-table__cell",
+          "latency-table__cell--stddev-even",
+        ])}
+      >
+        <Chip title="connection not attempted" type="grey" />
       </td>
     );
   }
@@ -364,7 +375,6 @@ export const Latency: React.SFC<ILatencyProps> = ({
             {_.map(data, value =>
               _.map(value, (identity, index: number) =>
                 createHeaderCell(
-                  staleIDs,
                   identity,
                   `0-${value.nodeID}`,
                   index === 0,
@@ -393,7 +403,6 @@ export const Latency: React.SFC<ILatencyProps> = ({
                   </th>
                 )}
                 {createHeaderCell(
-                  staleIDs,
                   identityA,
                   `${identityA.nodeID}-0`,
                   false,

--- a/pkg/ui/workspaces/db-console/src/views/reports/containers/network/selectors.ts
+++ b/pkg/ui/workspaces/db-console/src/views/reports/containers/network/selectors.ts
@@ -1,0 +1,90 @@
+// Copyright 2023 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+import _ from "lodash";
+import { cockroach } from "src/js/protos";
+import { createSelector } from "reselect";
+import { util } from "@cockroachlabs/cluster-ui";
+import { AdminUIState } from "src/redux/state";
+import { nodesSummarySelector } from "src/redux/nodes";
+import { Identity } from ".";
+import { localityToString } from "../../components/nodeFilterList";
+
+import MembershipStatus = cockroach.kv.kvserver.liveness.livenesspb.MembershipStatus;
+
+export const selectNetworkLatencyState = (state: AdminUIState) =>
+  state.cachedData.networkLatency;
+
+// structure is e.g.:
+// latencies: {
+//  1: {
+//    latencies: {
+//      2: 100,
+//      3: 200,
+//    },
+//    liveness: 0,
+//  },
+// }
+export const selectNodeConnectivity = createSelector(
+  selectNetworkLatencyState,
+  state => state.data?.connectivity_by_node_id,
+);
+
+export const selectLastError = createSelector(
+  selectNetworkLatencyState,
+  state => state.lastError,
+);
+
+// selectValidLatencies constructs an array of latencies
+// that are non-negative. These values are to be used for
+// standard deviation related calculations.
+export const selectValidLatencies = createSelector(
+  selectNodeConnectivity,
+  nodeConnectivity => {
+    const latencies: number[] = [];
+    _.forEach(nodeConnectivity, connectivity => {
+      _.forEach(connectivity.latencies, latency => {
+        if (latency >= 0) {
+          latencies.push(util.NanoToMilli(latency));
+        }
+      });
+    });
+    return latencies;
+  },
+);
+
+// selectNodesByMembership receives a membership status and returns the node
+// ids that have that membership status.
+export const selectNodesByMembership = (membership: typeof MembershipStatus) =>
+  createSelector(selectNodeConnectivity, nodeConnectivity => {
+    const nodes: number[] = [];
+    _.map(nodeConnectivity, (v, k) => {
+      if (v.liveness?.membership === membership) {
+        nodes.push(parseInt(k));
+      }
+    });
+    return nodes;
+  });
+
+// createIdentityArray constructs an array of Identity.
+export const createIdentityArray = createSelector(
+  nodesSummarySelector,
+  nodesSummary => {
+    const identities: Identity[] = [];
+    _.map(nodesSummary.nodeStatuses, status => {
+      identities.push({
+        nodeID: status.desc.node_id,
+        address: status.desc.address.address_field,
+        locality: localityToString(status.desc.locality),
+        updatedAt: util.LongToMoment(status.updated_at),
+      });
+    });
+    return identities;
+  },
+);

--- a/pkg/ui/workspaces/db-console/src/views/reports/containers/network/selectors.ts
+++ b/pkg/ui/workspaces/db-console/src/views/reports/containers/network/selectors.ts
@@ -12,17 +12,30 @@ import { cockroach } from "src/js/protos";
 import { createSelector } from "reselect";
 import { util } from "@cockroachlabs/cluster-ui";
 import { AdminUIState } from "src/redux/state";
-import { nodesSummarySelector } from "src/redux/nodes";
-import { Identity } from ".";
+import {
+  LivenessStatus,
+  nodesSummarySelector,
+  selectLivenessRequestStatus,
+  selectNodeRequestStatus,
+} from "src/redux/nodes";
+import { getValueFromString, Identity, NoConnection } from ".";
 import { localityToString } from "../../components/nodeFilterList";
 
 import MembershipStatus = cockroach.kv.kvserver.liveness.livenesspb.MembershipStatus;
+import { FixLong } from "src/util/fixLong";
+import { DetailedIdentity } from "./latency";
+
+export const selectNodeSummaryErrors = createSelector(
+  selectNodeRequestStatus,
+  selectLivenessRequestStatus,
+  (nodes, liveness) => [nodes.lastError, liveness.lastError],
+);
 
 export const selectNetworkLatencyState = (state: AdminUIState) =>
   state.cachedData.networkLatency;
 
 // structure is e.g.:
-// latencies: {
+// {
 //  1: {
 //    latencies: {
 //      2: 100,
@@ -49,7 +62,7 @@ export const selectValidLatencies = createSelector(
   nodeConnectivity => {
     const latencies: number[] = [];
     _.forEach(nodeConnectivity, connectivity => {
-      _.forEach(connectivity.latencies, latency => {
+      _.forEach(connectivity?.latencies, latency => {
         if (latency >= 0) {
           latencies.push(util.NanoToMilli(latency));
         }
@@ -59,21 +72,39 @@ export const selectValidLatencies = createSelector(
   },
 );
 
-// selectNodesByMembership receives a membership status and returns the node
-// ids that have that membership status.
-export const selectNodesByMembership = (membership: typeof MembershipStatus) =>
-  createSelector(selectNodeConnectivity, nodeConnectivity => {
+// selectLiveNodes returns the node ids that have that active membership status.
+export const selectLiveNodeIDs = createSelector(
+  selectNodeConnectivity,
+  nodeConnectivity => {
     const nodes: number[] = [];
     _.map(nodeConnectivity, (v, k) => {
-      if (v.liveness?.membership === membership) {
+      if (v.liveness?.membership === MembershipStatus.ACTIVE) {
         nodes.push(parseInt(k));
       }
     });
     return nodes;
-  });
+  },
+);
+
+// selectNonLiveNodes returns node ids that don't have active membership status.
+export const selectNonLiveNodeIDs = createSelector(
+  selectNodeConnectivity,
+  nodeConnectivity => {
+    const nodes: number[] = [];
+    _.map(nodeConnectivity, (v, k) => {
+      if (
+        v.liveness?.membership === MembershipStatus.DECOMMISSIONED ||
+        v.liveness?.membership === MembershipStatus.DECOMMISSIONING
+      ) {
+        nodes.push(parseInt(k));
+      }
+    });
+    return nodes;
+  },
+);
 
 // createIdentityArray constructs an array of Identity.
-export const createIdentityArray = createSelector(
+export const selectIdentityArray = createSelector(
   nodesSummarySelector,
   nodesSummary => {
     const identities: Identity[] = [];
@@ -86,5 +117,157 @@ export const createIdentityArray = createSelector(
       });
     });
     return identities;
+  },
+);
+
+// selectNoConnectionNodes returns an array of NoConnectiones
+// that is determined by latencies returned either being a
+// negative value or having no entry.
+export const selectNoConnectionNodes = createSelector(
+  selectNodeConnectivity,
+  selectIdentityArray,
+  (nodeConnectivity, identities) => {
+    const noConnections: NoConnection[] = [];
+    if (!nodeConnectivity || !identities) {
+      return noConnections;
+    }
+    const nodeIDs = identities.map(identity => identity.nodeID);
+    identities.forEach(identity => {
+      const nodeID = identity.nodeID;
+      const latencyMap = nodeConnectivity.latencies[nodeID.toString()];
+      // First check for non entries that aren't the current nodeID.
+      nodeIDs
+        .filter(id => id !== nodeID)
+        .map(id => {
+          if (!latencyMap[id.toString()]) {
+            noConnections.push({
+              from: identity,
+              to: identities.find(toIdentity => toIdentity.nodeID === id),
+            });
+          }
+        });
+      // Next, check for any latencies less than 0.
+      _.map(latencyMap, (v, k) => {
+        if (v < 0) {
+          noConnections.push({
+            from: identity,
+            to: identities.find(
+              toIdentity => toIdentity.nodeID === parseInt(k),
+            ),
+          });
+        }
+      });
+    });
+    return noConnections;
+  },
+);
+
+// createDetailedIdentityArray is a method to construct DetailedIdentity
+// objects from a filtered Identity array and a latencies map. It needs
+// values passed in instead of taking directly from the store due to
+// sorting and filtering which may result in fewer identities.
+export const createDetailedIdentityArray = (
+  identities: Identity[],
+  networkMap: { [x: string]: any },
+  multipleHeader: boolean,
+  nodeId: string,
+): [DetailedIdentity[]] => {
+  const data: any = [];
+  let rowLength = 0;
+  const filteredData = identities.map(identityA => {
+    const row: any[] = [];
+    identities.forEach(identityB => {
+      const a = networkMap[identityA.toString()]?.latencies || {};
+      const latency = a[identityB.toString()] || null;
+      // The cases listed below are:
+      // if the identities are the same, if there was no
+      // latency entry (meaning never attempted connection),
+      // if there is a negative latency (meaning currently no
+      // connection), or a normal postive latency.
+      if (identityA.nodeID === identityB.nodeID) {
+        row.push({ latency: 0, identityB });
+      } else if (latency === null) {
+        row.push({ latency: -2, identityB });
+      } else if (latency < 0) {
+        row.push({ latency: -1, identityB });
+      } else {
+        const milliLatency = util.NanoToMilli(latency);
+        row.push({ milliLatency, identityB });
+      }
+    });
+    rowLength = row.length;
+    return { row, ...identityA };
+  });
+  // This block creates multiple arrays in data if the titles are different.
+  filteredData.forEach(value => {
+    const newValue = {
+      ...value,
+      title: multipleHeader
+        ? getValueFromString(nodeId, value.locality)
+        : value.locality,
+    };
+    if (data.length === 0) {
+      data[0] = new Array(newValue);
+    } else {
+      if (data[data.length - 1][0].title === newValue.title) {
+        data[data.length - 1].push(newValue);
+        data[data.length - 1][0].rowCount = data[data.length - 1].length;
+      } else {
+        data[data.length] = new Array(newValue);
+      }
+    }
+  });
+  return data;
+};
+
+// @santamaura to remove once NetworkConnectivity endpoint is available.
+export const nodesSummaryLatencies = createSelector(
+  nodesSummarySelector,
+  nodesSummary => {
+    const healthyIDs = _.chain(nodesSummary.nodeIDs)
+      .filter(
+        nodeID =>
+          nodesSummary.livenessStatusByNodeID[nodeID] ===
+          LivenessStatus.NODE_STATUS_LIVE,
+      )
+      .filter(nodeID => !_.isNil(nodesSummary.nodeStatusByID[nodeID].activity))
+      .map(nodeID => Number.parseInt(nodeID, 0))
+      .value();
+    return _.flatMap(healthyIDs, nodeIDa =>
+      _.chain(healthyIDs)
+        .without(nodeIDa)
+        .map(nodeIDb => nodesSummary.nodeStatusByID[nodeIDa].activity[nodeIDb])
+        .filter(activity => !_.isNil(activity) && !_.isNil(activity.latency))
+        .map(activity => util.NanoToMilli(FixLong(activity.latency).toNumber()))
+        .filter(ms => _.isFinite(ms) && ms > 0)
+        .value(),
+    );
+  },
+);
+
+export const nodesSummaryHealthyIDs = createSelector(
+  nodesSummarySelector,
+  nodesSummary => {
+    return _.chain(nodesSummary.nodeIDs)
+      .filter(
+        nodeID =>
+          nodesSummary.livenessStatusByNodeID[nodeID] ===
+          LivenessStatus.NODE_STATUS_LIVE,
+      )
+      .filter(nodeID => !_.isNil(nodesSummary.nodeStatusByID[nodeID].activity))
+      .map(nodeID => Number.parseInt(nodeID, 0));
+  },
+);
+
+export const nodesSummaryStaleIDs = createSelector(
+  nodesSummarySelector,
+  nodesSummary => {
+    return _.chain(nodesSummary.nodeIDs)
+      .filter(
+        nodeID =>
+          nodesSummary.livenessStatusByNodeID[nodeID] ===
+          LivenessStatus.NODE_STATUS_UNAVAILABLE,
+      )
+      .map(nodeID => Number.parseInt(nodeID, 0));
   },
 );

--- a/pkg/ui/workspaces/db-console/src/views/reports/containers/network/utils.ts
+++ b/pkg/ui/workspaces/db-console/src/views/reports/containers/network/utils.ts
@@ -1,0 +1,35 @@
+// Copyright 2023 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+import { deviation as d3Deviation, mean as d3Mean } from "d3";
+import _ from "lodash";
+import { StdDev } from "./latency";
+
+// getMean returns the mean of the array of numbers.
+export const getMean = (latencies: number[]): number => d3Mean(latencies);
+
+// createStdDev creates a StdDev.
+export const createStdDev = (latencies: number[]): StdDev => {
+  let stddev = d3Deviation(latencies);
+  if (_.isUndefined(stddev)) {
+    stddev = 0;
+  }
+  const mean = getMean(latencies);
+  const stddevPlus1 = stddev > 0 ? mean + stddev : 0;
+  const stddevPlus2 = stddev > 0 ? stddevPlus1 + stddev : 0;
+  const stddevMinus1 = stddev > 0 ? _.max([mean - stddev, 0]) : 0;
+  const stddevMinus2 = stddev > 0 ? _.max([stddevMinus1 - stddev, 0]) : 0;
+  return {
+    stddev,
+    stddevMinus2,
+    stddevMinus1,
+    stddevPlus1,
+    stddevPlus2,
+  };
+};


### PR DESCRIPTION
This PR makes a few changes to the network latency page:

- use of the new `NetworkConnectivity` endpoint to provide accurate latency data
- converted the main network component into a functional component to simplify some of the code
- Move the data manipulation related to node liveness, locality and latencies into selectors and external methods