### PR TITLE
release-22.1: sql: wrap stacktraceless errors with errors.Wrap

### DIFF
--- a/pkg/kv/kvclient/kvcoord/transport.go
+++ b/pkg/kv/kvclient/kvcoord/transport.go
@@ -225,7 +225,10 @@ func (gt *grpcTransport) sendBatch(
 			span.ImportRemoteSpans(reply.CollectedSpans)
 		}
 	}
-	return reply, err
+	if err != nil {
+		return nil, errors.Wrapf(err, "ba: %s RPC error", ba.String())
+	}
+	return reply, nil
 }
 
 // NextInternalClient returns the next InternalClient to use for performing

--- a/pkg/kv/kvnemesis/applier_test.go
+++ b/pkg/kv/kvnemesis/applier_test.go
@@ -60,7 +60,7 @@ func TestApplier(t *testing.T) {
 		// Trim out context canceled location, which can be non-deterministic.
 		// The wrapped string around the context canceled error depends on where
 		// the context cancellation was noticed.
-		actual = regexp.MustCompile(` aborted .*: context canceled`).ReplaceAllString(actual, ` context canceled`)
+		actual = regexp.MustCompile(` (aborted .*|txn exec): context canceled`).ReplaceAllString(actual, ` context canceled`)
 		assert.Equal(t, strings.TrimSpace(expected), strings.TrimSpace(actual))
 	}
 

--- a/pkg/kv/txn.go
+++ b/pkg/kv/txn.go
@@ -988,7 +988,7 @@ func (txn *Txn) exec(ctx context.Context, fn func(context.Context, *Txn) error) 
 	// error condition this loop isn't capable of handling.
 	for {
 		if err := ctx.Err(); err != nil {
-			return err
+			return errors.Wrap(err, "txn exec")
 		}
 		err = fn(ctx, txn)
 

--- a/pkg/rpc/context.go
+++ b/pkg/rpc/context.go
@@ -319,7 +319,7 @@ func (c *Connection) Connect(ctx context.Context) (*grpc.ClientConn, error) {
 	case <-c.stopper.ShouldQuiesce():
 		return nil, errors.Errorf("stopped")
 	case <-ctx.Done():
-		return nil, ctx.Err()
+		return nil, errors.Wrap(ctx.Err(), "connect")
 	}
 
 	// If connection is invalid, return latest heartbeat error.

--- a/pkg/server/init.go
+++ b/pkg/server/init.go
@@ -472,7 +472,7 @@ func (s *initServer) attemptJoinTo(
 
 		status, ok := grpcstatus.FromError(errors.UnwrapAll(err))
 		if !ok {
-			return nil, err
+			return nil, errors.Wrap(err, "failed to join cluster")
 		}
 
 		// TODO(irfansharif): Here we're logging the error and also returning

--- a/pkg/sql/user.go
+++ b/pkg/sql/user.go
@@ -85,7 +85,7 @@ func GetUserSessionInitInfo(
 	pwRetrieveFn func(ctx context.Context) (expired bool, hashedPassword security.PasswordHash, err error),
 	err error,
 ) {
-	runFn := getUserInfoRunFn(execCfg, username, "get-user-timeout")
+	runFn := getUserInfoRunFn(execCfg, username, "get-user-session")
 
 	if username.IsRootUser() {
 		// As explained above, for root we report that the user exists
@@ -215,7 +215,7 @@ func retrieveSessionInitInfoWithCache(
 			retrieveAuthInfo,
 		)
 		if retErr != nil {
-			return retErr
+			return errors.Wrap(retErr, "get auth info error")
 		}
 		// Avoid looking up default settings for root and non-existent users.
 		if username.IsRootUser() || !aInfo.UserExists {
@@ -231,7 +231,7 @@ func retrieveSessionInitInfoWithCache(
 			databaseName,
 			retrieveDefaultSettings,
 		)
-		return retErr
+		return errors.Wrap(retErr, "get default settings error")
 	}(); err != nil {
 		// Failed to retrieve the user account. Report in logs for later investigation.
 		log.Warningf(ctx, "user lookup for %q failed: %v", username, err)
@@ -678,7 +678,7 @@ func updateUserPasswordHash(
 	username security.SQLUsername,
 	prevHash, newHash []byte,
 ) error {
-	runFn := getUserInfoRunFn(execCfg, username, "set-hash-timeout")
+	runFn := getUserInfoRunFn(execCfg, username, "set-user-password-hash")
 
 	return runFn(ctx, func(ctx context.Context) error {
 		return DescsTxn(ctx, execCfg, func(ctx context.Context, txn *kv.Txn, d *descs.Collection) error {

--- a/pkg/util/limit/limiter.go
+++ b/pkg/util/limit/limiter.go
@@ -46,7 +46,7 @@ func MakeConcurrentRequestLimiter(spanName string, limit int) ConcurrentRequestL
 // is forced to block.
 func (l *ConcurrentRequestLimiter) Begin(ctx context.Context) (Reservation, error) {
 	if err := ctx.Err(); err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "limiter begin")
 	}
 
 	res, err := l.sem.TryAcquire(ctx, 1)


### PR DESCRIPTION
Backport 1/1 commits from #96659.

/cc @cockroachdb/release

---

Fixes #95794

This replaces the previous attempt to add logging here #95797.

The context itself cannot be augmented to add a stack trace to errors because
it interferes with grpc timeout logic - gRPC compares errors directly without
checking causes https://github.com/grpc/grpc-go/blob/v1.46.0/rpc_util.go#L833.
Although the method signature allows it, `Context.Err()` should not be
overriden to customize the error:
```
// If Done is not yet closed, Err returns nil.
// If Done is closed, Err returns a non-nil error explaining why:
// Canceled if the context was canceled
// or DeadlineExceeded if the context's deadline passed.
// After Err returns a non-nil error, successive calls to Err return the same error.
Err() error
```
Additionally, a child context of the augmented context may end up being used
which will circumvent the stack trace capture.

This change instead wraps `errors.Wrap` in a few places that might end up
helping debug the original problem:
1) Where we call `Context.Err()` directly.
2) Where gRPC returns an error after possibly calling `Context.Err()`
   internally or returns an error that does not have a stack trace.

Release note: None

Release justification: Logging enhancement
