### PR TITLE
cluster-ui: remove `.only` from test

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/api/safesql.spec.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/api/safesql.spec.ts
@@ -10,7 +10,7 @@
 
 import { Format, Identifier, Join, SQL } from "./safesql";
 
-describe.only("safesql", () => {
+describe("safesql", () => {
   test("format", () => {
     type customString = string;
     type customNum = number;


### PR DESCRIPTION
Epic: none

Removes a `.only` from test file on `cluster-ui`.

Release note: None