### PR TITLE
sql: disallow statement sources in UDFs

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/udf
+++ b/pkg/sql/logictest/testdata/logic_test/udf
@@ -2696,6 +2696,9 @@ subtest cte
 statement error pgcode 0A000 unimplemented: CTE usage inside a function definition
 CREATE FUNCTION err() RETURNS INT LANGUAGE SQL AS 'WITH s AS (SELECT a FROM t) SELECT a FROM s'
 
+statement error pgcode 0A000 unimplemented: statement source \(square bracket syntax\) within user-defined function
+CREATE FUNCTION err() RETURNS INT LANGUAGE SQL AS 'SELECT a FROM [SELECT 1] a(a)'
+
 
 subtest recursion
 

--- a/pkg/sql/opt/optbuilder/select.go
+++ b/pkg/sql/opt/optbuilder/select.go
@@ -173,6 +173,11 @@ func (b *Builder) buildDataSource(
 		// This is the special '[ ... ]' syntax. We treat this as syntactic sugar
 		// for a top-level CTE, so it cannot refer to anything in the input scope.
 		// See #41078.
+		if b.insideFuncDef {
+			panic(unimplemented.NewWithIssue(
+				92961, "statement source (square bracket syntax) within user-defined function",
+			))
+		}
 		emptyScope := b.allocScope()
 		innerScope := b.buildStmt(source.Statement, nil /* desiredTypes */, emptyScope)
 		if len(innerScope.cols) == 0 {


### PR DESCRIPTION
Statement source (square bracket) syntax is no longer allowed in UDFs,
preventing panics that occur when evaluating a UDF with a statement
source. Panics occur because these expressions are built as CTEs, which
are not currently supported within UDFs (see #92961).

Fixes #95554

Release note (bug fix): Statement source (square bracket) syntax is no
longer allowed in user-defined functions. Prior to this fix, using
this syntax in a UDF would cause a panic. This restriction will be
lifted in the future.
