### PR TITLE
pkg/cloud: Add implicit authentication to Azure Storage & KMS

### DIFF
--- a/pkg/ccl/cloudccl/cloudprivilege/privileges_test.go
+++ b/pkg/ccl/cloudccl/cloudprivilege/privileges_test.go
@@ -113,9 +113,19 @@ func TestURIRequiresAdminOrPrivilege(t *testing.T) {
 			isAPrivilegedOperation: false,
 		},
 		{
-			name:                   "azure",
+			name:                   "azure-legacy",
 			uri:                    "azure://foo/bar?AZURE_ACCOUNT_NAME=random&AZURE_ACCOUNT_KEY=random",
 			isAPrivilegedOperation: false,
+		},
+		{
+			name:                   "azure-specified",
+			uri:                    "azure://foo/bar?AUTH=specified&AZURE_ACCOUNT_NAME=random&AZURE_CLIENT_ID=id&AZURE_CLIENT_SECRET=sec&AZURE_TENANT_ID=ten",
+			isAPrivilegedOperation: false,
+		},
+		{
+			name:                   "azure-implicit",
+			uri:                    "azure://foo/bar?AUTH=implicit&AZURE_ACCOUNT_NAME=random",
+			isAPrivilegedOperation: true,
 		},
 	} {
 		t.Run(tc.name+"-via-import", func(t *testing.T) {

--- a/pkg/cloud/azure/azure_kms.go
+++ b/pkg/cloud/azure/azure_kms.go
@@ -16,10 +16,12 @@ import (
 	"net/url"
 	"strings"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 	kms "github.com/Azure/azure-sdk-for-go/sdk/keyvault/azkeys"
 	"github.com/Azure/go-autorest/autorest/azure"
 	"github.com/cockroachdb/cockroach/pkg/cloud"
+	"github.com/cockroachdb/cockroach/pkg/cloud/cloudpb"
 	"github.com/cockroachdb/errors"
 )
 
@@ -54,20 +56,31 @@ type kmsURIParams struct {
 	clientID     string
 	clientSecret string
 	tenantID     string
+
+	auth cloudpb.AzureAuth
 }
 
 // resolveKMSURIParams parses the `kmsURI` for all the supported KMS parameters.
-func resolveKMSURIParams(kmsURI cloud.ConsumeURL) (kmsURIParams, error) {
+func resolveKMSURIParams(kmsURI *url.URL) (kmsURIParams, error) {
+	kmsConsumeURL := cloud.ConsumeURL{URL: kmsURI}
+	auth, err := azureAuthMethod(kmsURI, &kmsConsumeURL)
+	if err != nil {
+		return kmsURIParams{}, err
+	}
+	if !(auth == cloudpb.AzureAuth_EXPLICIT || auth == cloudpb.AzureAuth_IMPLICIT) {
+		return kmsURIParams{}, errors.New("azure kms requires explicit auth (RBAC) or implicit auth")
+	}
 	params := kmsURIParams{
-		vaultName:    kmsURI.ConsumeParam(AzureVaultName),
-		environment:  kmsURI.ConsumeParam(AzureEnvironmentKeyParam),
-		clientID:     kmsURI.ConsumeParam(AzureClientIDParam),
-		clientSecret: kmsURI.ConsumeParam(AzureClientSecretParam),
-		tenantID:     kmsURI.ConsumeParam(AzureTenantIDParam),
+		vaultName:    kmsConsumeURL.ConsumeParam(AzureVaultName),
+		environment:  kmsConsumeURL.ConsumeParam(AzureEnvironmentKeyParam),
+		clientID:     kmsConsumeURL.ConsumeParam(AzureClientIDParam),
+		clientSecret: kmsConsumeURL.ConsumeParam(AzureClientSecretParam),
+		tenantID:     kmsConsumeURL.ConsumeParam(AzureTenantIDParam),
+		auth:         auth,
 	}
 
 	// Validate that all the passed in parameters are supported.
-	if unknownParams := kmsURI.RemainingQueryParams(); len(unknownParams) > 0 {
+	if unknownParams := kmsConsumeURL.RemainingQueryParams(); len(unknownParams) > 0 {
 		return kmsURIParams{}, errors.Errorf(
 			`unknown KMS query parameters: %s`, strings.Join(unknownParams, ", "))
 	}
@@ -86,29 +99,47 @@ func MakeAzureKMS(ctx context.Context, uri string, env cloud.KMSEnv) (cloud.KMS,
 	if kmsURI.Path == "/" {
 		return nil, errors.Newf("path component of the KMS cannot be empty; must contain the Customer Managed Key")
 	}
-
-	kmsConsumeURL := cloud.ConsumeURL{URL: kmsURI}
 	// Extract the URI parameters required to setup the Azure KMS session.
-	kmsURIParams, err := resolveKMSURIParams(kmsConsumeURL)
+	kmsURIParams, err := resolveKMSURIParams(kmsURI)
 	if err != nil {
 		return nil, err
 	}
 
 	missingParams := make([]string, 0)
+	extraParams := make([]string, 0)
 	if kmsURIParams.vaultName == "" {
 		missingParams = append(missingParams, AzureVaultName)
 	}
-	if kmsURIParams.clientID == "" {
-		missingParams = append(missingParams, AzureClientIDParam)
+
+	if kmsURIParams.auth == cloudpb.AzureAuth_EXPLICIT {
+		if kmsURIParams.clientID == "" {
+			missingParams = append(missingParams, AzureClientIDParam)
+		}
+		if kmsURIParams.clientSecret == "" {
+			missingParams = append(missingParams, AzureClientSecretParam)
+		}
+		if kmsURIParams.tenantID == "" {
+			missingParams = append(missingParams, AzureTenantIDParam)
+		}
 	}
-	if kmsURIParams.clientSecret == "" {
-		missingParams = append(missingParams, AzureClientSecretParam)
+
+	if kmsURIParams.auth == cloudpb.AzureAuth_IMPLICIT {
+		if kmsURIParams.clientID != "" {
+			extraParams = append(extraParams, AzureClientIDParam)
+		}
+		if kmsURIParams.clientSecret != "" {
+			extraParams = append(extraParams, AzureClientSecretParam)
+		}
+		if kmsURIParams.tenantID != "" {
+			extraParams = append(extraParams, AzureTenantIDParam)
+		}
 	}
-	if kmsURIParams.tenantID == "" {
-		missingParams = append(missingParams, AzureTenantIDParam)
-	}
+
 	if len(missingParams) != 0 {
-		return nil, errors.Errorf("kms URI expected but did not receive: %s", strings.Join(missingParams, ", "))
+		return nil, errors.Errorf("kms explicit auth URI expected but did not receive: %s", strings.Join(missingParams, ", "))
+	}
+	if len(extraParams) != 0 {
+		return nil, errors.Errorf("kms implicit auth URI does not support: %s", strings.Join(missingParams, ", "))
 	}
 
 	if kmsURIParams.environment == "" {
@@ -116,13 +147,6 @@ func MakeAzureKMS(ctx context.Context, uri string, env cloud.KMSEnv) (cloud.KMS,
 		// which itself defaults to this for backwards compatibility.
 		kmsURIParams.environment = azure.PublicCloud.Name
 	}
-
-	//TODO(benbardin): Implicit auth.
-	credential, err := azidentity.NewClientSecretCredential(kmsURIParams.tenantID, kmsURIParams.clientID, kmsURIParams.clientSecret, nil)
-	if err != nil {
-		return nil, errors.Wrap(err, "azure kms client secret credential")
-	}
-
 	azureEnv, err := azure.EnvironmentFromName(kmsURIParams.environment)
 	if err != nil {
 		return nil, errors.Wrap(err, "azure kms environment")
@@ -132,10 +156,36 @@ func MakeAzureKMS(ctx context.Context, uri string, env cloud.KMSEnv) (cloud.KMS,
 	if err != nil {
 		return nil, errors.Wrap(err, "azure kms vault url")
 	}
+
+	var credential azcore.TokenCredential
+
+	switch kmsURIParams.auth {
+	case cloudpb.AzureAuth_EXPLICIT:
+		credential, err = azidentity.NewClientSecretCredential(kmsURIParams.tenantID, kmsURIParams.clientID, kmsURIParams.clientSecret, nil)
+		if err != nil {
+			return nil, errors.Wrap(err, "azure kms client secret credential")
+		}
+	case cloudpb.AzureAuth_IMPLICIT:
+		if env.KMSConfig().DisableImplicitCredentials {
+			return nil, errors.New(
+				"implicit credentials disallowed for azure due to --external-io-implicit-credentials flag")
+		}
+		// The Default credential supports env vars and managed identity magic.
+		// We rely on the former for testing and the latter in prod.
+		// https://learn.microsoft.com/en-us/dotnet/api/azure.identity.defaultazurecredential
+		credential, err = azidentity.NewDefaultAzureCredential(nil)
+		if err != nil {
+			return nil, errors.Wrap(err, "azure managed identity credential")
+		}
+	default:
+		return nil, errors.Errorf("azure kms unsupported auth value: %v", kmsURIParams.auth)
+	}
+
 	client, err := kms.NewClient(u.String(), credential, nil)
 	if err != nil {
 		return nil, errors.Wrap(err, "azure kms vault client")
 	}
+
 	keyTokens := strings.Split(strings.TrimPrefix(kmsURI.Path, "/"), "/")
 	if len(keyTokens) != 2 {
 		return nil, errors.New("azure kms key must be of form 'id/version'")

--- a/pkg/cloud/azure/azure_kms_test.go
+++ b/pkg/cloud/azure/azure_kms_test.go
@@ -86,8 +86,25 @@ func TestEncryptDecryptAzure(t *testing.T) {
 		require.Error(t, err)
 	})
 
-	t.Run("succeeds", func(t *testing.T) {
+	t.Run("explicit auth", func(t *testing.T) {
 		uri := fmt.Sprintf("azure-kms:///%s/%s?%s", cfg.keyName, cfg.keyVersion, params.Encode())
+		cloud.KMSEncryptDecrypt(t, uri, &cloud.TestKMSEnv{
+			Settings:         azureKMSTestSettings,
+			ExternalIOConfig: &base.ExternalIODirConfig{},
+		})
+	})
+
+	t.Run("implicit auth", func(t *testing.T) {
+		redactedParams := make(url.Values)
+		for k, v := range params {
+			redactedParams[k] = v
+		}
+		redactedParams.Del(AzureClientIDParam)
+		redactedParams.Del(AzureClientSecretParam)
+		redactedParams.Del(AzureTenantIDParam)
+		redactedParams.Add(cloud.AuthParam, cloud.AuthParamImplicit)
+
+		uri := fmt.Sprintf("azure-kms:///%s/%s?%s", cfg.keyName, cfg.keyVersion, redactedParams.Encode())
 		cloud.KMSEncryptDecrypt(t, uri, &cloud.TestKMSEnv{
 			Settings:         azureKMSTestSettings,
 			ExternalIOConfig: &base.ExternalIODirConfig{},

--- a/pkg/cloud/cloudpb/external_storage.go
+++ b/pkg/cloud/cloudpb/external_storage.go
@@ -41,8 +41,7 @@ func (m *ExternalStorage) AccessIsWithExplicitAuth() bool {
 	case ExternalStorageProvider_gs:
 		return m.GoogleCloudConfig.Auth == ExternalStorageAuthSpecified
 	case ExternalStorageProvider_azure:
-		// Azure storage only uses explicitly supplied credentials.
-		return true
+		return m.AzureConfig.Auth == AzureAuth_LEGACY || m.AzureConfig.Auth == AzureAuth_EXPLICIT
 	case ExternalStorageProvider_userfile:
 		// userfile always checks the user performing the action has grants on the
 		// table used.

--- a/pkg/cloud/cloudpb/external_storage.proto
+++ b/pkg/cloud/cloudpb/external_storage.proto
@@ -27,6 +27,12 @@ enum ExternalStorageProvider {
   external = 9;
 }
 
+enum AzureAuth {
+  LEGACY = 0;  // Storage account key
+  EXPLICIT = 1;  // App Registration + RBAC
+  IMPLICIT = 2;  // Environment Credentials or Managed Service
+}
+
 message ExternalStorage {
   ExternalStorageProvider provider = 1;
 
@@ -130,6 +136,8 @@ message ExternalStorage {
     string client_id = 6 [(gogoproto.customname) = "ClientID"];
     string client_secret = 7;
     string tenant_id = 8 [(gogoproto.customname) = "TenantID"];
+
+    AzureAuth auth = 9;
   }
   message FileTable {
     // User interacting with the external storage. This is used to check access


### PR DESCRIPTION
This enables users to authenticate to Azure Storage and KeyVault with the Azure Default Credential, described here: https://learn.microsoft.com/en-us/azure/developer/go/azure-sdk-authentication. This supports environmental variable authentication, and also authentication via managed identity if CRDB is running on an Azure platform.

The Azure documentation describes which environment variables to set (Tenant ID, Client ID, Client Secret) for RBAC. Once selected, appropriate permissions must still be granted to the authenticating Client to use requested Azure resources. These permissions are described in https://github.com/cockroachdb/cockroach/pull/96459.

Release note (enterprise change): Add support for implicit authentication to Azure Storage and KMS using Azure RBAC.

Informs: https://github.com/cockroachdb/cockroach/issues/96972