### PR TITLE
release-22.2: sql/schemachanger: exclude rules from dot import linting

### DIFF
--- a/pkg/testutils/lint/lint_test.go
+++ b/pkg/testutils/lint/lint_test.go
@@ -1786,6 +1786,7 @@ func TestLint(t *testing.T) {
 				stream.GrepNot(`pkg/server/dumpstore.*\.go.*"io/ioutil" has been deprecated since Go 1\.16: As of Go 1\.16`),
 				stream.GrepNot(`pkg/server/heapprofiler/profilestore_test\.go.*"io/ioutil" has been deprecated since Go 1\.16`),
 				stream.GrepNot(`pkg/util/log/file_api\.go.*"io/ioutil" has been deprecated since Go 1\.16`),
+				stream.GrepNot(`pkg/sql/schemachanger/scplan/internal/rules/.*/.*go:.* should not use dot imports \(ST1001\)`),
 			), func(s string) {
 				t.Errorf("\n%s", s)
 			}); err != nil {


### PR DESCRIPTION
Previously, when back porting some rules-related changes we excluded certain files from the dot import linter, these files were updated in the bazel builds properly. Unfortunately, the wrong area of code was touched manually backporting these changes, and the make based builds did not exclude this directory from the linter. This patch properly removes the declarative schema changer files from the dot import linter.

Epic: none
Release note: None
Release justification: not a functional code change