### PR TITLE
kv: return error on invalid batch, don't fatal

### DIFF
--- a/pkg/kv/kvserver/stores.go
+++ b/pkg/kv/kvserver/stores.go
@@ -26,6 +26,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
+	"github.com/cockroachdb/errors"
 )
 
 // Stores provides methods to access a collection of stores. There's
@@ -189,7 +190,7 @@ func (ls *Stores) SendWithWriteBytes(
 	ctx context.Context, ba *roachpb.BatchRequest,
 ) (*roachpb.BatchResponse, *kvadmission.StoreWriteBytes, *roachpb.Error) {
 	if err := ba.ValidateForEvaluation(); err != nil {
-		log.Fatalf(ctx, "invalid batch (%s): %s", ba, err)
+		return nil, nil, roachpb.NewError(errors.Wrapf(err, "invalid batch (%s)", ba))
 	}
 
 	store, err := ls.GetStore(ba.Replica.StoreID)


### PR DESCRIPTION
This commit replaces logic that would crash the process on an invalid batch with logic that propagates the assertion error back to the sender of the batch. One misbehaved node that's sending out corrupt batches should not be able to cause other nodes to crash.

Release note: None
Epic: None