### PR TITLE
kvflowcontroller: fix TestLint/TestStaticCheck

### DIFF
--- a/pkg/kv/kvserver/kvflowcontrol/kvflowcontroller/kvflowcontroller_simulation_test.go
+++ b/pkg/kv/kvserver/kvflowcontrol/kvflowcontroller/kvflowcontroller_simulation_test.go
@@ -287,7 +287,6 @@ func TestUsingSimulation(t *testing.T) {
 						}
 						switch unit {
 						case "μs", "us", "microseconds":
-							time.Microsecond.Nanoseconds()
 							options = append(options, asciitsdb.WithDivisor(float64(time.Microsecond.Nanoseconds())) /* ns => μs conversion  */)
 						case "ms", "milliseconds":
 							options = append(options, asciitsdb.WithDivisor(float64(time.Millisecond.Nanoseconds())) /* ns => μs conversion  */)


### PR DESCRIPTION
Started tripping in non-essential CI after #95905 with 'Nanoseconds is a pure function but its return value is ignored (SA4017)'.

Release note: None