### PR TITLE
rowcontainer: support concurrent reads and some cleanup

### DIFF
--- a/pkg/sql/apply_join.go
+++ b/pkg/sql/apply_join.go
@@ -256,7 +256,7 @@ func (a *applyJoinNode) runNextRightSideIteration(params runParams, leftRow tree
 	if err := runPlanInsidePlan(ctx, params, plan, rowResultWriter); err != nil {
 		return err
 	}
-	a.run.rightRowsIterator = newRowContainerIterator(ctx, a.run.rightRows, a.rightTypes)
+	a.run.rightRowsIterator = newRowContainerIterator(ctx, a.run.rightRows)
 	return nil
 }
 

--- a/pkg/sql/buffer.go
+++ b/pkg/sql/buffer.go
@@ -81,7 +81,7 @@ type scanBufferNode struct {
 }
 
 func (n *scanBufferNode) startExec(params runParams) error {
-	n.iterator = newRowContainerIterator(params.ctx, n.buffer.rows, n.buffer.typs)
+	n.iterator = newRowContainerIterator(params.ctx, n.buffer.rows)
 	return nil
 }
 

--- a/pkg/sql/buffer_util.go
+++ b/pkg/sql/buffer_util.go
@@ -141,22 +141,12 @@ func (c *rowContainerHelper) Close(ctx context.Context) {
 // tree.Datums.
 type rowContainerIterator struct {
 	iter rowcontainer.RowIterator
-
-	typs   []*types.T
-	datums tree.Datums
-	da     tree.DatumAlloc
 }
 
 // newRowContainerIterator returns a new rowContainerIterator that must be
 // closed once no longer needed.
-func newRowContainerIterator(
-	ctx context.Context, c rowContainerHelper, typs []*types.T,
-) *rowContainerIterator {
-	i := &rowContainerIterator{
-		iter:   c.rows.NewIterator(ctx),
-		typs:   typs,
-		datums: make(tree.Datums, len(typs)),
-	}
+func newRowContainerIterator(ctx context.Context, c rowContainerHelper) *rowContainerIterator {
+	i := &rowContainerIterator{iter: c.rows.NewIterator(ctx)}
 	i.iter.Rewind()
 	return i
 }
@@ -175,10 +165,7 @@ func (i *rowContainerIterator) Next() (tree.Datums, error) {
 	if err != nil {
 		return nil, err
 	}
-	if err = rowenc.EncDatumRowToDatums(i.typs, i.datums, row, &i.da); err != nil {
-		return nil, err
-	}
-	return i.datums, nil
+	return row, nil
 }
 
 func (i *rowContainerIterator) Close() {

--- a/pkg/sql/distsql_running.go
+++ b/pkg/sql/distsql_running.go
@@ -1680,7 +1680,7 @@ func (dsp *DistSQLPlanner) planAndRunSubquery(
 		// TODO(yuzefovich): this is unfortunate - we're materializing all
 		// buffered rows into a single tuple kept in memory. Refactor it.
 		var result tree.DTuple
-		iterator := newRowContainerIterator(ctx, rows, typs)
+		iterator := newRowContainerIterator(ctx, rows)
 		defer iterator.Close()
 		for {
 			row, err := iterator.Next()
@@ -1725,7 +1725,7 @@ func (dsp *DistSQLPlanner) planAndRunSubquery(
 		case 0:
 			subqueryPlans[planIdx].result = tree.DNull
 		case 1:
-			iterator := newRowContainerIterator(ctx, rows, typs)
+			iterator := newRowContainerIterator(ctx, rows)
 			defer iterator.Close()
 			row, err := iterator.Next()
 			if err != nil {

--- a/pkg/sql/recursive_cte.go
+++ b/pkg/sql/recursive_cte.go
@@ -96,7 +96,7 @@ func (n *recursiveCTENode) Next(params runParams) (bool, error) {
 				return false, err
 			}
 		}
-		n.iterator = newRowContainerIterator(params.ctx, n.workingRows, n.typs)
+		n.iterator = newRowContainerIterator(params.ctx, n.workingRows)
 		n.initialDone = true
 	}
 
@@ -152,7 +152,7 @@ func (n *recursiveCTENode) Next(params runParams) (bool, error) {
 		return false, err
 	}
 
-	n.iterator = newRowContainerIterator(params.ctx, n.workingRows, n.typs)
+	n.iterator = newRowContainerIterator(params.ctx, n.workingRows)
 	n.currentRow, err = n.iterator.Next()
 	if err != nil {
 		return false, err

--- a/pkg/sql/routine.go
+++ b/pkg/sql/routine.go
@@ -98,7 +98,7 @@ func (p *planner) EvalRoutineExpr(
 
 	// Fetch the first row from the row container and return the first
 	// datum.
-	rightRowsIterator := newRowContainerIterator(ctx, rch, retTypes)
+	rightRowsIterator := newRowContainerIterator(ctx, rch)
 	defer rightRowsIterator.Close()
 	row, err := rightRowsIterator.Next()
 	if err != nil {

--- a/pkg/sql/rowcontainer/disk_row_container.go
+++ b/pkg/sql/rowcontainer/disk_row_container.go
@@ -38,10 +38,9 @@ type DiskRowContainer struct {
 	// diskAcc keeps track of disk usage.
 	diskAcc mon.BoundAccount
 	// bufferedRows buffers writes to the diskMap.
-	bufferedRows  diskmap.SortedDiskMapBatchWriter
-	scratchKey    []byte
-	scratchVal    []byte
-	scratchEncRow rowenc.EncDatumRow
+	bufferedRows diskmap.SortedDiskMapBatchWriter
+	scratchKey   []byte
+	scratchVal   []byte
 
 	// For computing mean encoded row bytes.
 	totalEncodedRowBytes uint64
@@ -104,14 +103,13 @@ func MakeDiskRowContainer(
 ) DiskRowContainer {
 	diskMap := e.NewSortedDiskMap()
 	d := DiskRowContainer{
-		diskMap:       diskMap,
-		diskAcc:       diskMonitor.MakeBoundAccount(),
-		types:         types,
-		ordering:      ordering,
-		scratchEncRow: make(rowenc.EncDatumRow, len(types)),
-		diskMonitor:   diskMonitor,
-		engine:        e,
-		datumAlloc:    &tree.DatumAlloc{},
+		diskMap:     diskMap,
+		diskAcc:     diskMonitor.MakeBoundAccount(),
+		types:       types,
+		ordering:    ordering,
+		diskMonitor: diskMonitor,
+		engine:      e,
+		datumAlloc:  &tree.DatumAlloc{},
 	}
 	d.bufferedRows = d.diskMap.NewBatchWriter()
 
@@ -337,7 +335,7 @@ func (d *DiskRowContainer) Reorder(ctx context.Context, ordering colinfo.ColumnO
 		} else if !ok {
 			break
 		}
-		row, err := i.Row()
+		row, err := i.EncRow()
 		if err != nil {
 			return err
 		}
@@ -394,45 +392,13 @@ func (d *DiskRowContainer) Close(ctx context.Context) {
 	d.diskAcc.Close(ctx)
 }
 
-// keyValToRow decodes a key and a value byte slice stored with AddRow() into
-// a rowenc.EncDatumRow. The returned EncDatumRow is only valid until the next
-// call to keyValToRow(). The passed in byte slices are used directly, and it is
-// the caller's responsibility to make sure they don't get modified.
-func (d *DiskRowContainer) keyValToRow(k []byte, v []byte) (rowenc.EncDatumRow, error) {
-	for i, orderInfo := range d.ordering {
-		// Types with composite key encodings are decoded from the value.
-		if colinfo.CanHaveCompositeKeyEncoding(d.types[orderInfo.ColIdx]) {
-			// Skip over the encoded key.
-			encLen, err := encoding.PeekLength(k)
-			if err != nil {
-				return nil, err
-			}
-			k = k[encLen:]
-			continue
-		}
-		var err error
-		col := orderInfo.ColIdx
-		d.scratchEncRow[col], k, err = rowenc.EncDatumFromBuffer(d.types[col], d.encodings[i], k)
-		if err != nil {
-			return nil, errors.NewAssertionErrorWithWrappedErrf(err,
-				"unable to decode row, column idx %d", errors.Safe(col))
-		}
-	}
-	for _, i := range d.valueIdxs {
-		var err error
-		d.scratchEncRow[i], v, err = rowenc.EncDatumFromBuffer(d.types[i], catenumpb.DatumEncoding_VALUE, v)
-		if err != nil {
-			return nil, errors.NewAssertionErrorWithWrappedErrf(err,
-				"unable to decode row, value idx %d", errors.Safe(i))
-		}
-	}
-	return d.scratchEncRow, nil
-}
-
 // diskRowIterator iterates over the rows in a DiskRowContainer.
 type diskRowIterator struct {
-	rowContainer *DiskRowContainer
-	rowBuf       bufalloc.ByteAllocator
+	rowContainer  *DiskRowContainer
+	rowBuf        bufalloc.ByteAllocator
+	scratchEncRow rowenc.EncDatumRow
+	scratchRow    tree.Datums
+	da            tree.DatumAlloc
 	diskmap.SortedDiskMapIterator
 }
 
@@ -442,7 +408,12 @@ func (d *DiskRowContainer) newIterator(ctx context.Context) diskRowIterator {
 	if err := d.bufferedRows.Flush(); err != nil {
 		log.Fatalf(ctx, "%v", err)
 	}
-	return diskRowIterator{rowContainer: d, SortedDiskMapIterator: d.diskMap.NewIterator()}
+	return diskRowIterator{
+		rowContainer:          d,
+		scratchEncRow:         make(rowenc.EncDatumRow, len(d.types)),
+		scratchRow:            make(tree.Datums, len(d.types)),
+		SortedDiskMapIterator: d.diskMap.NewIterator(),
+	}
 }
 
 // NewIterator is part of the SortableRowContainer interface.
@@ -454,9 +425,9 @@ func (d *DiskRowContainer) NewIterator(ctx context.Context) RowIterator {
 	return &i
 }
 
-// Row returns the current row. The returned rowenc.EncDatumRow is only valid
-// until the next call to Row().
-func (r *diskRowIterator) Row() (rowenc.EncDatumRow, error) {
+// EncRow returns the current row. The returned rowenc.EncDatumRow is only valid
+// until the next call to EncRow().
+func (r *diskRowIterator) EncRow() (rowenc.EncDatumRow, error) {
 	if ok, err := r.Valid(); err != nil {
 		return nil, errors.NewAssertionErrorWithWrappedErrf(err, "unable to check row validity")
 	} else if !ok {
@@ -465,14 +436,52 @@ func (r *diskRowIterator) Row() (rowenc.EncDatumRow, error) {
 
 	k := r.UnsafeKey()
 	v := r.UnsafeValue()
-	// keyValToRow will use the encoded key and value bytes as is by shoving
-	// them directly into the EncDatum, so we need to make a copy here. We
-	// cannot reuse the same byte slice across Row() calls because it would lead
-	// to modification of the EncDatums (which is not allowed).
+	// We will use the encoded key and value bytes as is by shoving them
+	// directly into the EncDatum, so we need to make a copy here. We cannot
+	// reuse the same byte slice across EncRow() calls because it would lead to
+	// modification of the EncDatums (which is not allowed).
 	r.rowBuf, k = r.rowBuf.Copy(k, len(v))
 	r.rowBuf, v = r.rowBuf.Copy(v, 0 /* extraCap */)
 
-	return r.rowContainer.keyValToRow(k, v)
+	for i, orderInfo := range r.rowContainer.ordering {
+		// Types with composite key encodings are decoded from the value.
+		if colinfo.CanHaveCompositeKeyEncoding(r.rowContainer.types[orderInfo.ColIdx]) {
+			// Skip over the encoded key.
+			encLen, err := encoding.PeekLength(k)
+			if err != nil {
+				return nil, err
+			}
+			k = k[encLen:]
+			continue
+		}
+		var err error
+		col := orderInfo.ColIdx
+		r.scratchEncRow[col], k, err = rowenc.EncDatumFromBuffer(r.rowContainer.types[col], r.rowContainer.encodings[i], k)
+		if err != nil {
+			return nil, errors.NewAssertionErrorWithWrappedErrf(err,
+				"unable to decode row, column idx %d", errors.Safe(col))
+		}
+	}
+	for _, i := range r.rowContainer.valueIdxs {
+		var err error
+		r.scratchEncRow[i], v, err = rowenc.EncDatumFromBuffer(r.rowContainer.types[i], catenumpb.DatumEncoding_VALUE, v)
+		if err != nil {
+			return nil, errors.NewAssertionErrorWithWrappedErrf(err,
+				"unable to decode row, value idx %d", errors.Safe(i))
+		}
+	}
+	return r.scratchEncRow, nil
+}
+
+// Row returns the current row. The returned row is only valid until the next
+// call to Row().
+func (r *diskRowIterator) Row() (tree.Datums, error) {
+	encRow, err := r.EncRow()
+	if err != nil {
+		return nil, err
+	}
+	err = rowenc.EncDatumRowToDatums(r.rowContainer.types, r.scratchRow, encRow, &r.da)
+	return r.scratchRow, err
 }
 
 func (r *diskRowIterator) Close() {
@@ -526,7 +535,17 @@ func (r *diskRowFinalIterator) Rewind() {
 	}
 }
 
-func (r *diskRowFinalIterator) Row() (rowenc.EncDatumRow, error) {
+func (r *diskRowFinalIterator) EncRow() (rowenc.EncDatumRow, error) {
+	row, err := r.diskRowIterator.EncRow()
+	if err != nil {
+		return nil, err
+	}
+	r.diskRowIterator.rowContainer.lastReadKey =
+		append(r.diskRowIterator.rowContainer.lastReadKey[:0], r.UnsafeKey()...)
+	return row, nil
+}
+
+func (r *diskRowFinalIterator) Row() (tree.Datums, error) {
 	row, err := r.diskRowIterator.Row()
 	if err != nil {
 		return nil, err

--- a/pkg/sql/rowcontainer/disk_row_container_test.go
+++ b/pkg/sql/rowcontainer/disk_row_container_test.go
@@ -37,11 +37,11 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// compareRows compares l and r according to a column ordering. Returns -1 if
+// compareEncRows compares l and r according to a column ordering. Returns -1 if
 // l < r, 0 if l == r, and 1 if l > r. If an error is returned the int returned
 // is invalid. Note that the comparison is only performed on the ordering
 // columns.
-func compareRows(
+func compareEncRows(
 	lTypes []*types.T,
 	l, r rowenc.EncDatumRow,
 	e *eval.Context,
@@ -50,7 +50,38 @@ func compareRows(
 ) (int, error) {
 	for _, orderInfo := range ordering {
 		col := orderInfo.ColIdx
-		cmp, err := l[col].Compare(lTypes[col], d, e, &r[orderInfo.ColIdx])
+		cmp, err := l[col].Compare(lTypes[col], d, e, &r[col])
+		if err != nil {
+			return 0, err
+		}
+		if cmp != 0 {
+			if orderInfo.Direction == encoding.Descending {
+				cmp = -cmp
+			}
+			return cmp, nil
+		}
+	}
+	return 0, nil
+}
+
+// compareRowToEncRow compares l and r according to a column ordering. Returns
+// -1 if l < r, 0 if l == r, and 1 if l > r. If an error is returned the int
+// returned is invalid. Note that the comparison is only performed on the
+// ordering columns.
+func compareRowToEncRow(
+	lTypes []*types.T,
+	l tree.Datums,
+	r rowenc.EncDatumRow,
+	e *eval.Context,
+	d *tree.DatumAlloc,
+	ordering colinfo.ColumnOrdering,
+) (int, error) {
+	for _, orderInfo := range ordering {
+		col := orderInfo.ColIdx
+		if err := r[col].EnsureDecoded(lTypes[col], d); err != nil {
+			return 0, err
+		}
+		cmp, err := l[col].CompareError(e, r[col].Datum)
 		if err != nil {
 			return 0, err
 		}
@@ -147,17 +178,17 @@ func TestDiskRowContainer(t *testing.T) {
 					} else if !ok {
 						t.Fatal("unexpectedly invalid")
 					}
-					readRow := make(rowenc.EncDatumRow, len(row))
+					readEncRow := make(rowenc.EncDatumRow, len(row))
 
-					temp, err := i.Row()
+					temp, err := i.EncRow()
 					if err != nil {
 						t.Fatal(err)
 					}
-					copy(readRow, temp)
+					copy(readEncRow, temp)
 
 					// Ensure the datum fields are set and no errors occur when
 					// decoding.
-					for i, encDatum := range readRow {
+					for i, encDatum := range readEncRow {
 						if err := encDatum.EnsureDecoded(typs[i], d.datumAlloc); err != nil {
 							t.Fatal(err)
 						}
@@ -165,10 +196,23 @@ func TestDiskRowContainer(t *testing.T) {
 
 					// Check equality of the row we wrote and the row we read.
 					for i := range row {
-						if cmp, err := readRow[i].Compare(typs[i], d.datumAlloc, &evalCtx, &row[i]); err != nil {
+						if cmp, err := readEncRow[i].Compare(typs[i], d.datumAlloc, &evalCtx, &row[i]); err != nil {
 							t.Fatal(err)
 						} else if cmp != 0 {
-							t.Fatalf("encoded %s but decoded %s", row.String(typs), readRow.String(typs))
+							t.Fatalf("encoded %s but decoded %s", row.String(typs), readEncRow.String(typs))
+						}
+					}
+
+					// Now check the tree.Datums row.
+					readRow, err := i.Row()
+					if err != nil {
+						t.Fatal(err)
+					}
+					for i := range row {
+						if cmp, err := readRow[i].CompareError(&evalCtx, row[i].Datum); err != nil {
+							t.Fatal(err)
+						} else if cmp != 0 {
+							t.Fatalf("read %s but expected %s", readRow.String(), row.String(typs))
 						}
 					}
 				}()
@@ -213,7 +257,7 @@ func TestDiskRowContainer(t *testing.T) {
 					} else if !ok {
 						break
 					}
-					row, err := i.Row()
+					row, err := i.EncRow()
 					if err != nil {
 						t.Fatal(err)
 					}
@@ -227,15 +271,17 @@ func TestDiskRowContainer(t *testing.T) {
 					}
 
 					// Check sorted order.
-					if cmp, err := compareRows(
-						types, sortedRows.EncRow(numKeysRead), row, &evalCtx, d.datumAlloc, ordering,
+					sortedRows.getEncRow(sortedRows.scratchEncRow, numKeysRead)
+					if cmp, err := compareEncRows(
+						types, sortedRows.scratchEncRow, row, &evalCtx, d.datumAlloc, ordering,
 					); err != nil {
 						t.Fatal(err)
 					} else if cmp != 0 {
+						sortedRows.getEncRow(sortedRows.scratchEncRow, numKeysRead)
 						t.Fatalf(
 							"expected %s to be equal to %s",
 							row.String(types),
-							sortedRows.EncRow(numKeysRead).String(types),
+							sortedRows.scratchEncRow.String(types),
 						)
 					}
 					numKeysRead++
@@ -318,7 +364,7 @@ func TestDiskRowContainer(t *testing.T) {
 			valid, err := iter.Valid()
 			require.True(t, valid)
 			require.NoError(t, err)
-			row, err := iter.Row()
+			row, err := iter.EncRow()
 			require.NoError(t, err)
 			require.Equal(t, rows[index].String(types), row.String(types))
 		}
@@ -472,7 +518,7 @@ func TestDiskRowContainerFinalIterator(t *testing.T) {
 			} else if !ok {
 				t.Fatalf("unexpectedly reached the end after %d rows read", rowsRead)
 			}
-			row, err := i.Row()
+			row, err := i.EncRow()
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -493,7 +539,7 @@ func TestDiskRowContainerFinalIterator(t *testing.T) {
 			} else if !ok {
 				break
 			}
-			row, err := i.Row()
+			row, err := i.EncRow()
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -524,7 +570,7 @@ func TestDiskRowContainerFinalIterator(t *testing.T) {
 		} else if !ok {
 			break
 		}
-		row, err := i.Row()
+		row, err := i.EncRow()
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -596,7 +642,7 @@ func TestDiskRowContainerUnsafeReset(t *testing.T) {
 			if ok, err := i.Valid(); err != nil || !ok {
 				t.Fatalf("unexpected i.Valid() return values: ok=%t, err=%s", ok, err)
 			}
-			row, err := i.Row()
+			row, err := i.EncRow()
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -623,7 +669,7 @@ func TestDiskRowContainerUnsafeReset(t *testing.T) {
 		} else if !ok {
 			break
 		}
-		_, err := i.Row()
+		_, err := i.EncRow()
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/pkg/sql/rowcontainer/hash_row_container.go
+++ b/pkg/sql/rowcontainer/hash_row_container.go
@@ -305,8 +305,9 @@ func (h *HashMemRowContainer) ReserveMarkMemoryMaybe(ctx context.Context) error 
 
 // hashMemRowBucketIterator iterates over the rows in a bucket.
 type hashMemRowBucketIterator struct {
-	*HashMemRowContainer
-	probeEqCols columns
+	container     *HashMemRowContainer
+	scratchEncRow rowenc.EncDatumRow
+	probeEqCols   columns
 	// rowIdxs are the indices of rows in the bucket.
 	rowIdxs []int
 	curIdx  int
@@ -319,8 +320,9 @@ func (h *HashMemRowContainer) NewBucketIterator(
 	ctx context.Context, row rowenc.EncDatumRow, probeEqCols columns,
 ) (RowMarkerIterator, error) {
 	ret := &hashMemRowBucketIterator{
-		HashMemRowContainer: h,
-		probeEqCols:         probeEqCols,
+		container:     h,
+		scratchEncRow: make(rowenc.EncDatumRow, len(h.types)),
+		probeEqCols:   probeEqCols,
 	}
 
 	if err := ret.Reset(ctx, row); err != nil {
@@ -344,45 +346,51 @@ func (i *hashMemRowBucketIterator) Next() {
 	i.curIdx++
 }
 
+// EncRow implements the RowIterator interface.
+func (i *hashMemRowBucketIterator) EncRow() (rowenc.EncDatumRow, error) {
+	i.container.getEncRow(i.scratchEncRow, i.rowIdxs[i.curIdx])
+	return i.scratchEncRow, nil
+}
+
 // Row implements the RowIterator interface.
-func (i *hashMemRowBucketIterator) Row() (rowenc.EncDatumRow, error) {
-	return i.EncRow(i.rowIdxs[i.curIdx]), nil
+func (i *hashMemRowBucketIterator) Row() (tree.Datums, error) {
+	return i.container.At(i.rowIdxs[i.curIdx]), nil
 }
 
 // IsMarked implements the RowMarkerIterator interface.
 func (i *hashMemRowBucketIterator) IsMarked(ctx context.Context) bool {
-	if !i.shouldMark {
+	if !i.container.shouldMark {
 		log.Fatal(ctx, "hash mem row container not set up for marking")
 	}
-	if i.marked == nil {
+	if i.container.marked == nil {
 		return false
 	}
 
-	return i.marked[i.rowIdxs[i.curIdx]]
+	return i.container.marked[i.rowIdxs[i.curIdx]]
 }
 
 // Mark implements the RowMarkerIterator interface.
 func (i *hashMemRowBucketIterator) Mark(ctx context.Context) error {
-	if !i.shouldMark {
+	if !i.container.shouldMark {
 		log.Fatal(ctx, "hash mem row container not set up for marking")
 	}
-	if i.marked == nil {
-		if !i.markMemoryReserved {
+	if i.container.marked == nil {
+		if !i.container.markMemoryReserved {
 			panic("mark memory should have been reserved already")
 		}
-		i.marked = make([]bool, i.Len())
+		i.container.marked = make([]bool, i.container.Len())
 	}
 
-	i.marked[i.rowIdxs[i.curIdx]] = true
+	i.container.marked[i.rowIdxs[i.curIdx]] = true
 	return nil
 }
 
 func (i *hashMemRowBucketIterator) Reset(ctx context.Context, row rowenc.EncDatumRow) error {
-	encoded, err := i.encodeEqualityCols(ctx, row, i.probeEqCols)
+	encoded, err := i.container.encodeEqualityCols(ctx, row, i.probeEqCols)
 	if err != nil {
 		return err
 	}
-	i.rowIdxs = i.buckets[string(encoded)]
+	i.rowIdxs = i.container.buckets[string(encoded)]
 	return nil
 }
 
@@ -391,8 +399,9 @@ func (i *hashMemRowBucketIterator) Close() {}
 
 // hashMemRowIterator iterates over all unmarked rows in a HashMemRowContainer.
 type hashMemRowIterator struct {
-	*HashMemRowContainer
-	curIdx int
+	container     *HashMemRowContainer
+	scratchEncRow rowenc.EncDatumRow
+	curIdx        int
 
 	// curKey contains the key that would be assigned to the current row if it
 	// were to be put on disk. It is needed to optimize the recreation of the
@@ -405,7 +414,7 @@ var _ RowIterator = &hashMemRowIterator{}
 
 // NewUnmarkedIterator implements the HashRowContainer interface.
 func (h *HashMemRowContainer) NewUnmarkedIterator(ctx context.Context) RowIterator {
-	return &hashMemRowIterator{HashMemRowContainer: h}
+	return &hashMemRowIterator{container: h, scratchEncRow: make(rowenc.EncDatumRow, len(h.types))}
 }
 
 // Rewind implements the RowIterator interface.
@@ -417,7 +426,7 @@ func (i *hashMemRowIterator) Rewind() {
 
 // Valid implements the RowIterator interface.
 func (i *hashMemRowIterator) Valid() (bool, error) {
-	return i.curIdx < i.Len(), nil
+	return i.curIdx < i.container.Len(), nil
 }
 
 // computeKey calculates the key for the current row as if the row is put on
@@ -428,9 +437,8 @@ func (i *hashMemRowIterator) computeKey() error {
 		return err
 	}
 
-	var row rowenc.EncDatumRow
 	if valid {
-		row = i.EncRow(i.curIdx)
+		i.container.getEncRow(i.scratchEncRow, i.curIdx)
 	} else {
 		if i.curIdx == 0 {
 			// There are no rows in the container, so the key corresponding to the
@@ -442,13 +450,18 @@ func (i *hashMemRowIterator) computeKey() error {
 		// will "simulate" the key corresponding to the non-existent row as the key
 		// to the last existing row plus one (plus one part is done below where we
 		// append the index of the row to curKey).
-		row = i.EncRow(i.curIdx - 1)
+		i.container.getEncRow(i.scratchEncRow, i.curIdx-1)
 	}
 
 	i.curKey = i.curKey[:0]
-	for _, col := range i.storedEqCols {
+	for _, col := range i.container.storedEqCols {
 		var err error
-		i.curKey, err = row[col].Encode(i.types[col], &i.columnEncoder.datumAlloc, catenumpb.DatumEncoding_ASCENDING_KEY, i.curKey)
+		i.curKey, err = i.scratchEncRow[col].Encode(
+			i.container.types[col],
+			&i.container.columnEncoder.datumAlloc,
+			catenumpb.DatumEncoding_ASCENDING_KEY,
+			i.curKey,
+		)
 		if err != nil {
 			return err
 		}
@@ -461,15 +474,21 @@ func (i *hashMemRowIterator) computeKey() error {
 func (i *hashMemRowIterator) Next() {
 	// Move the curIdx to the next unmarked row.
 	i.curIdx++
-	if i.marked != nil {
-		for ; i.curIdx < len(i.marked) && i.marked[i.curIdx]; i.curIdx++ {
+	if i.container.marked != nil {
+		for ; i.curIdx < len(i.container.marked) && i.container.marked[i.curIdx]; i.curIdx++ {
 		}
 	}
 }
 
+// EncRow implements the RowIterator interface.
+func (i *hashMemRowIterator) EncRow() (rowenc.EncDatumRow, error) {
+	i.container.getEncRow(i.scratchEncRow, i.curIdx)
+	return i.scratchEncRow, nil
+}
+
 // Row implements the RowIterator interface.
-func (i *hashMemRowIterator) Row() (rowenc.EncDatumRow, error) {
-	return i.EncRow(i.curIdx), nil
+func (i *hashMemRowIterator) Row() (tree.Datums, error) {
+	return i.container.At(i.curIdx), nil
 }
 
 // Close implements the RowIterator interface.
@@ -556,7 +575,7 @@ func (h *HashDiskRowContainer) IsEmpty() bool {
 // hashDiskRowBucketIterator iterates over the rows in a bucket.
 type hashDiskRowBucketIterator struct {
 	*diskRowIterator
-	*HashDiskRowContainer
+	container   *HashDiskRowContainer
 	probeEqCols columns
 	// haveMarkedRows returns true if we've marked rows since the last time we
 	// recreated our underlying diskRowIterator.
@@ -575,9 +594,9 @@ func (h *HashDiskRowContainer) NewBucketIterator(
 	ctx context.Context, row rowenc.EncDatumRow, probeEqCols columns,
 ) (RowMarkerIterator, error) {
 	ret := &hashDiskRowBucketIterator{
-		HashDiskRowContainer: h,
-		probeEqCols:          probeEqCols,
-		diskRowIterator:      h.NewIterator(ctx).(*diskRowIterator),
+		container:       h,
+		probeEqCols:     probeEqCols,
+		diskRowIterator: h.NewIterator(ctx).(*diskRowIterator),
 	}
 	if err := ret.Reset(ctx, row); err != nil {
 		ret.Close()
@@ -602,22 +621,36 @@ func (i *hashDiskRowBucketIterator) Valid() (bool, error) {
 	return bytes.HasPrefix(i.UnsafeKey(), i.encodedEqCols), nil
 }
 
+// EncRow implements the RowIterator interface.
+func (i *hashDiskRowBucketIterator) EncRow() (rowenc.EncDatumRow, error) {
+	row, err := i.diskRowIterator.EncRow()
+	if err != nil {
+		return nil, err
+	}
+
+	// Remove the mark from the end of the row.
+	if i.container.shouldMark {
+		row = row[:len(row)-1]
+	}
+	return row, nil
+}
+
 // Row implements the RowIterator interface.
-func (i *hashDiskRowBucketIterator) Row() (rowenc.EncDatumRow, error) {
+func (i *hashDiskRowBucketIterator) Row() (tree.Datums, error) {
 	row, err := i.diskRowIterator.Row()
 	if err != nil {
 		return nil, err
 	}
 
 	// Remove the mark from the end of the row.
-	if i.HashDiskRowContainer.shouldMark {
+	if i.container.shouldMark {
 		row = row[:len(row)-1]
 	}
 	return row, nil
 }
 
 func (i *hashDiskRowBucketIterator) Reset(ctx context.Context, row rowenc.EncDatumRow) error {
-	encoded, err := i.HashDiskRowContainer.encodeEqualityCols(ctx, row, i.probeEqCols)
+	encoded, err := i.container.encodeEqualityCols(ctx, row, i.probeEqCols)
 	if err != nil {
 		return err
 	}
@@ -627,14 +660,14 @@ func (i *hashDiskRowBucketIterator) Reset(ctx context.Context, row rowenc.EncDat
 		// TODO(jordan): do this less by keeping a cache of written marks.
 		i.haveMarkedRows = false
 		i.diskRowIterator.Close()
-		i.diskRowIterator = i.HashDiskRowContainer.NewIterator(ctx).(*diskRowIterator)
+		i.diskRowIterator = i.container.NewIterator(ctx).(*diskRowIterator)
 	}
 	return nil
 }
 
 // IsMarked implements the RowMarkerIterator interface.
 func (i *hashDiskRowBucketIterator) IsMarked(ctx context.Context) bool {
-	if !i.HashDiskRowContainer.shouldMark {
+	if !i.container.shouldMark {
 		log.Fatal(ctx, "hash disk row container not set up for marking")
 	}
 	ok, err := i.diskRowIterator.Valid()
@@ -648,7 +681,7 @@ func (i *hashDiskRowBucketIterator) IsMarked(ctx context.Context) bool {
 
 // Mark implements the RowMarkerIterator interface.
 func (i *hashDiskRowBucketIterator) Mark(ctx context.Context) error {
-	if !i.HashDiskRowContainer.shouldMark {
+	if !i.container.shouldMark {
 		log.Fatal(ctx, "hash disk row container not set up for marking")
 	}
 	i.haveMarkedRows = true
@@ -668,7 +701,7 @@ func (i *hashDiskRowBucketIterator) Mark(ctx context.Context) error {
 	// These marks only matter when using a hashDiskRowIterator to iterate over
 	// unmarked rows. The writes are flushed when creating a NewIterator() in
 	// NewUnmarkedIterator().
-	return i.HashDiskRowContainer.bufferedRows.Put(i.UnsafeKey(), rowVal)
+	return i.container.bufferedRows.Put(i.UnsafeKey(), rowVal)
 }
 
 // hashDiskRowIterator iterates over all unmarked rows in a
@@ -706,8 +739,20 @@ func (i *hashDiskRowIterator) Next() {
 	}
 }
 
+// EncRow implements the RowIterator interface.
+func (i *hashDiskRowIterator) EncRow() (rowenc.EncDatumRow, error) {
+	row, err := i.diskRowIterator.EncRow()
+	if err != nil {
+		return nil, err
+	}
+
+	// Remove the mark from the end of the row.
+	row = row[:len(row)-1]
+	return row, nil
+}
+
 // Row implements the RowIterator interface.
-func (i *hashDiskRowIterator) Row() (rowenc.EncDatumRow, error) {
+func (i *hashDiskRowIterator) Row() (tree.Datums, error) {
 	row, err := i.diskRowIterator.Row()
 	if err != nil {
 		return nil, err
@@ -916,7 +961,7 @@ func (h *HashDiskBackedRowContainer) SpillToDisk(ctx context.Context) error {
 		} else if !ok {
 			break
 		}
-		row, err := i.Row()
+		row, err := i.EncRow()
 		if err != nil {
 			return err
 		}

--- a/pkg/sql/rowcontainer/hash_row_container_test.go
+++ b/pkg/sql/rowcontainer/hash_row_container_test.go
@@ -111,7 +111,7 @@ func TestHashDiskBackedRowContainer(t *testing.T) {
 			// over all rows added so far.
 			i := rc.NewUnmarkedIterator(ctx)
 			defer i.Close()
-			if err := verifyRows(ctx, i, rows[:mid], &evalCtx, ordering); err != nil {
+			if err := verifyRows(i, rows[:mid], &evalCtx, ordering); err != nil {
 				t.Fatalf("verifying memory rows failed with: %s", err)
 			}
 		}()
@@ -129,7 +129,7 @@ func TestHashDiskBackedRowContainer(t *testing.T) {
 		func() {
 			i := rc.NewUnmarkedIterator(ctx)
 			defer i.Close()
-			if err := verifyRows(ctx, i, rows, &evalCtx, ordering); err != nil {
+			if err := verifyRows(i, rows, &evalCtx, ordering); err != nil {
 				t.Fatalf("verifying disk rows failed with: %s", err)
 			}
 		}()
@@ -213,11 +213,11 @@ func TestHashDiskBackedRowContainer(t *testing.T) {
 			} else if !ok {
 				break
 			}
-			row, err := i.Row()
+			row, err := i.EncRow()
 			if err != nil {
 				t.Fatal(err)
 			}
-			if cmp, err := compareRows(
+			if cmp, err := compareEncRows(
 				types.OneIntCol, row, rows[counter], &evalCtx, &tree.DatumAlloc{}, ordering,
 			); err != nil {
 				t.Fatal(err)
@@ -238,11 +238,11 @@ func TestHashDiskBackedRowContainer(t *testing.T) {
 			} else if !ok {
 				break
 			}
-			row, err := i.Row()
+			row, err := i.EncRow()
 			if err != nil {
 				t.Fatal(err)
 			}
-			if cmp, err := compareRows(
+			if cmp, err := compareEncRows(
 				types.OneIntCol, row, rows[counter], &evalCtx, &tree.DatumAlloc{}, ordering,
 			); err != nil {
 				t.Fatal(err)
@@ -288,11 +288,11 @@ func TestHashDiskBackedRowContainer(t *testing.T) {
 			} else if !ok {
 				break
 			}
-			row, err := i.Row()
+			row, err := i.EncRow()
 			if err != nil {
 				t.Fatal(err)
 			}
-			if cmp, err := compareRows(
+			if cmp, err := compareEncRows(
 				types.OneIntCol, row, rows[counter], &evalCtx, &tree.DatumAlloc{}, ordering,
 			); err != nil {
 				t.Fatal(err)
@@ -400,7 +400,7 @@ func TestHashDiskBackedRowContainerPreservesMatchesAndMarks(t *testing.T) {
 			// over all rows added so far.
 			i := rc.NewUnmarkedIterator(ctx)
 			defer i.Close()
-			if err := verifyRows(ctx, i, rows[:mid], &evalCtx, ordering); err != nil {
+			if err := verifyRows(i, rows[:mid], &evalCtx, ordering); err != nil {
 				t.Fatalf("verifying memory rows failed with: %s", err)
 			}
 		}()
@@ -418,7 +418,7 @@ func TestHashDiskBackedRowContainerPreservesMatchesAndMarks(t *testing.T) {
 		func() {
 			i := rc.NewUnmarkedIterator(ctx)
 			defer i.Close()
-			if err := verifyRows(ctx, i, rows, &evalCtx, ordering); err != nil {
+			if err := verifyRows(i, rows, &evalCtx, ordering); err != nil {
 				t.Fatalf("verifying disk rows failed with: %s", err)
 			}
 		}()
@@ -448,7 +448,7 @@ func TestHashDiskBackedRowContainerPreservesMatchesAndMarks(t *testing.T) {
 			// over all rows added so far.
 			i := rc.NewUnmarkedIterator(ctx)
 			defer i.Close()
-			if err := verifyRows(ctx, i, rows, &evalCtx, ordering); err != nil {
+			if err := verifyRows(i, rows, &evalCtx, ordering); err != nil {
 				t.Fatalf("verifying memory rows failed with: %s", err)
 			}
 		}()

--- a/pkg/sql/rowcontainer/kvstreamer_result_disk_buffer.go
+++ b/pkg/sql/rowcontainer/kvstreamer_result_disk_buffer.go
@@ -112,7 +112,7 @@ func (b *kvStreamerResultDiskBuffer) Deserialize(
 		b.iterResultID++
 	}
 	// Now we take the row representing the Result and deserialize it into r.
-	serialized, err := b.iter.Row()
+	serialized, err := b.iter.EncRow()
 	if err != nil {
 		return err
 	}

--- a/pkg/sql/rowcontainer/row_container.go
+++ b/pkg/sql/rowcontainer/row_container.go
@@ -33,6 +33,9 @@ import (
 
 // SortableRowContainer is a container used to store rows and optionally sort
 // these.
+// NOTE: methods of this interface are **not** safe for concurrent use. However,
+// separate RowIterators can be created to perform reads of the rows in the
+// container concurrently.
 type SortableRowContainer interface {
 	Len() int
 	// AddRow adds a row to the container. If an error is returned, then the
@@ -105,7 +108,9 @@ type DeDupingRowContainer interface {
 	Close(context.Context)
 }
 
-// RowIterator is a simple iterator used to iterate over sqlbase.EncDatumRows.
+// RowIterator is a simple iterator used to iterate over rows buffered in the
+// SortableRowContainer.
+//
 // Example use:
 //
 //	var i RowIterator
@@ -115,12 +120,15 @@ type DeDupingRowContainer interface {
 //		} else if !ok {
 //			break
 //		}
-//		row, err := i.Row()
+//		row, err := i.EncRow()
 //		if err != nil {
 //			// Handle error.
 //		}
 //		// Do something.
 //	}
+//
+// Multiple iterators can be created in order to iterate over the same container
+// concurrently.
 type RowIterator interface {
 	// Rewind seeks to the first row.
 	Rewind()
@@ -131,12 +139,20 @@ type RowIterator interface {
 	Valid() (bool, error)
 	// Next advances the iterator to the next row in the iteration.
 	Next()
-	// Row returns the current row. The returned row is only valid until the
-	// next call to Rewind() or Next(). However, datums in the row won't be
+	// EncRow returns the current row. The returned row is only valid until the
+	// next call to Rewind() or Next(). However, EncDatums in the row won't be
 	// modified, so shallow copying is sufficient.
-	Row() (rowenc.EncDatumRow, error)
+	EncRow() (rowenc.EncDatumRow, error)
+	// Row returns the current row. The returned row is only valid until the
+	// next call to Rewind() or Next(). However, tree.Datums in the row won't be
+	// modified, so shallow copying is sufficient.
+	//
+	// NOTE: it does *not* copy the row: callers must copy the row if they wish
+	// to mutate it.
+	Row() (tree.Datums, error)
 
 	// Close frees up resources held by the iterator.
+	// NOTE: unsafe for concurrent calls on different iterators.
 	Close()
 }
 
@@ -190,14 +206,14 @@ func (mc *MemRowContainer) Less(i, j int) bool {
 	return cmp < 0
 }
 
-// EncRow returns the idx-th row as an EncDatumRow. The slice itself is reused
-// so it is only valid until the next call to EncRow.
-func (mc *MemRowContainer) EncRow(idx int) rowenc.EncDatumRow {
+// getEncRow populates the given EncDatumRow with the values of the idx-th row.
+// The behavior is undefined if the given row is of a different width than the
+// rows stored in the container.
+func (mc *MemRowContainer) getEncRow(encRow rowenc.EncDatumRow, idx int) {
 	datums := mc.At(idx)
 	for i, d := range datums {
-		mc.scratchEncRow[i] = rowenc.DatumToEncDatum(mc.types[i], d)
+		encRow[i] = rowenc.DatumToEncDatum(mc.types[i], d)
 	}
-	return mc.scratchEncRow
 }
 
 // AddRow adds a row to the container.
@@ -270,8 +286,9 @@ func (mc *MemRowContainer) InitTopK() {
 // memRowIterator is a RowIterator that iterates over a MemRowContainer. This
 // iterator doesn't iterate over a snapshot of MemRowContainer.
 type memRowIterator struct {
-	*MemRowContainer
-	curIdx int
+	container     *MemRowContainer
+	curIdx        int
+	scratchEncRow rowenc.EncDatumRow
 }
 
 var _ RowIterator = &memRowIterator{}
@@ -280,7 +297,7 @@ var _ RowIterator = &memRowIterator{}
 // MemRowContainer. Note that this iterator doesn't iterate over a snapshot
 // of MemRowContainer.
 func (mc *MemRowContainer) NewIterator(_ context.Context) RowIterator {
-	return &memRowIterator{MemRowContainer: mc}
+	return &memRowIterator{container: mc, scratchEncRow: make(rowenc.EncDatumRow, len(mc.types))}
 }
 
 // Rewind implements the RowIterator interface.
@@ -290,7 +307,7 @@ func (i *memRowIterator) Rewind() {
 
 // Valid implements the RowIterator interface.
 func (i *memRowIterator) Valid() (bool, error) {
-	return i.curIdx < i.Len(), nil
+	return i.curIdx < i.container.Len(), nil
 }
 
 // Next implements the RowIterator interface.
@@ -298,9 +315,18 @@ func (i *memRowIterator) Next() {
 	i.curIdx++
 }
 
+// EncRow implements the RowIterator interface.
+func (i *memRowIterator) EncRow() (rowenc.EncDatumRow, error) {
+	datums := i.container.At(i.curIdx)
+	for colidx, d := range datums {
+		i.scratchEncRow[colidx] = rowenc.DatumToEncDatum(i.container.types[colidx], d)
+	}
+	return i.scratchEncRow, nil
+}
+
 // Row implements the RowIterator interface.
-func (i *memRowIterator) Row() (rowenc.EncDatumRow, error) {
-	return i.EncRow(i.curIdx), nil
+func (i *memRowIterator) Row() (tree.Datums, error) {
+	return i.container.At(i.curIdx), nil
 }
 
 // Close implements the RowIterator interface.
@@ -310,7 +336,8 @@ func (i *memRowIterator) Close() {}
 // This iterator doesn't iterate over a snapshot of MemRowContainer and deletes
 // rows as soon as they are iterated over to free up memory eagerly.
 type memRowFinalIterator struct {
-	*MemRowContainer
+	container     *MemRowContainer
+	scratchEncRow rowenc.EncDatumRow
 
 	ctx context.Context
 }
@@ -320,36 +347,43 @@ type memRowFinalIterator struct {
 // of MemRowContainer and that it deletes rows as soon as they are iterated
 // over.
 func (mc *MemRowContainer) NewFinalIterator(ctx context.Context) RowIterator {
-	return memRowFinalIterator{MemRowContainer: mc, ctx: ctx}
+	return &memRowFinalIterator{container: mc, scratchEncRow: make(rowenc.EncDatumRow, len(mc.types)), ctx: ctx}
 }
 
 // GetRow implements IndexedRowContainer.
 func (mc *MemRowContainer) GetRow(ctx context.Context, pos int) (eval.IndexedRow, error) {
-	return IndexedRow{Idx: pos, Row: mc.EncRow(pos)}, nil
+	mc.getEncRow(mc.scratchEncRow, pos)
+	return IndexedRow{Idx: pos, Row: mc.scratchEncRow}, nil
 }
 
-var _ RowIterator = memRowFinalIterator{}
+var _ RowIterator = &memRowFinalIterator{}
 
 // Rewind implements the RowIterator interface.
-func (i memRowFinalIterator) Rewind() {}
+func (i *memRowFinalIterator) Rewind() {}
 
 // Valid implements the RowIterator interface.
-func (i memRowFinalIterator) Valid() (bool, error) {
-	return i.Len() > 0, nil
+func (i *memRowFinalIterator) Valid() (bool, error) {
+	return i.container.Len() > 0, nil
 }
 
 // Next implements the RowIterator interface.
-func (i memRowFinalIterator) Next() {
-	i.PopFirst(i.ctx)
+func (i *memRowFinalIterator) Next() {
+	i.container.PopFirst(i.ctx)
+}
+
+// EncRow implements the RowIterator interface.
+func (i *memRowFinalIterator) EncRow() (rowenc.EncDatumRow, error) {
+	i.container.getEncRow(i.scratchEncRow, 0)
+	return i.scratchEncRow, nil
 }
 
 // Row implements the RowIterator interface.
-func (i memRowFinalIterator) Row() (rowenc.EncDatumRow, error) {
-	return i.EncRow(0), nil
+func (i *memRowFinalIterator) Row() (tree.Datums, error) {
+	return i.container.At(0), nil
 }
 
 // Close implements the RowIterator interface.
-func (i memRowFinalIterator) Close() {}
+func (i *memRowFinalIterator) Close() {}
 
 // DiskBackedRowContainer is a ReorderableRowContainer that uses a
 // MemRowContainer to store rows and spills back to disk automatically if
@@ -610,7 +644,7 @@ func (f *DiskBackedRowContainer) SpillToDisk(ctx context.Context) error {
 		} else if !ok {
 			break
 		}
-		memRow, err := i.Row()
+		memRow, err := i.EncRow()
 		if err != nil {
 			return err
 		}
@@ -812,7 +846,7 @@ func (f *DiskBackedIndexedRowContainer) GetRow(
 				return nil, errors.Errorf("row at pos %d not found", pos)
 			}
 			if f.idxRowIter == f.nextPosToCache {
-				rowWithIdx, err = f.diskRowIter.Row()
+				rowWithIdx, err = f.diskRowIter.EncRow()
 				if err != nil {
 					return nil, err
 				}
@@ -866,7 +900,9 @@ func (f *DiskBackedIndexedRowContainer) GetRow(
 			f.idxRowIter++
 		}
 	}
-	rowWithIdx = f.DiskBackedRowContainer.mrc.EncRow(pos)
+	mrc := f.DiskBackedRowContainer.mrc
+	mrc.getEncRow(mrc.scratchEncRow, pos)
+	rowWithIdx = mrc.scratchEncRow
 	row, rowIdx := rowWithIdx[:len(rowWithIdx)-1], rowWithIdx[len(rowWithIdx)-1].Datum
 	if idx, ok := rowIdx.(*tree.DInt); ok {
 		return IndexedRow{int(*idx), row}, nil
@@ -947,7 +983,7 @@ func (f *DiskBackedIndexedRowContainer) getRowWithoutCache(
 			panic(errors.AssertionFailedf("row at pos %d not found", pos))
 		}
 		if f.idxRowIter == pos {
-			rowWithIdx, err := f.diskRowIter.Row()
+			rowWithIdx, err := f.diskRowIter.EncRow()
 			if err != nil {
 				panic(err)
 			}

--- a/pkg/sql/rowcontainer/row_container_test.go
+++ b/pkg/sql/rowcontainer/row_container_test.go
@@ -40,9 +40,8 @@ import (
 )
 
 // verifyRows verifies that the rows read with the given RowIterator match up
-// with  the given rows. evalCtx and ordering are used to compare rows.
+// with the given rows. evalCtx and ordering are used to compare rows.
 func verifyRows(
-	ctx context.Context,
 	i RowIterator,
 	expectedRows rowenc.EncDatumRows,
 	evalCtx *eval.Context,
@@ -54,11 +53,22 @@ func verifyRows(
 		} else if !ok {
 			break
 		}
+		encRow, err := i.EncRow()
+		if err != nil {
+			return err
+		}
+		if cmp, err := compareEncRows(
+			types.OneIntCol, encRow, expectedRows[0], evalCtx, &tree.DatumAlloc{}, ordering,
+		); err != nil {
+			return err
+		} else if cmp != 0 {
+			return fmt.Errorf("unexpected enc row %v, expected %v", encRow, expectedRows[0])
+		}
 		row, err := i.Row()
 		if err != nil {
 			return err
 		}
-		if cmp, err := compareRows(
+		if cmp, err := compareRowToEncRow(
 			types.OneIntCol, row, expectedRows[0], evalCtx, &tree.DatumAlloc{}, ordering,
 		); err != nil {
 			return err
@@ -166,7 +176,7 @@ func TestRowContainerIterators(t *testing.T) {
 			func() {
 				i := mc.NewIterator(ctx)
 				defer i.Close()
-				if err := verifyRows(ctx, i, rows, evalCtx, ordering); err != nil {
+				if err := verifyRows(i, rows, evalCtx, ordering); err != nil {
 					t.Fatalf("rows mismatch on the run number %d: %s", k+1, err)
 				}
 			}()
@@ -179,7 +189,7 @@ func TestRowContainerIterators(t *testing.T) {
 	t.Run("NewFinalIterator", func(t *testing.T) {
 		i := mc.NewFinalIterator(ctx)
 		defer i.Close()
-		if err := verifyRows(ctx, i, rows, evalCtx, ordering); err != nil {
+		if err := verifyRows(i, rows, evalCtx, ordering); err != nil {
 			t.Fatal(err)
 		}
 		if mc.Len() != 0 {
@@ -208,56 +218,58 @@ func TestDiskBackedRowContainer(t *testing.T) {
 	}
 	defer tempEngine.Close()
 
-	// These monitors are started and stopped by subtests.
-	memoryMonitor := mon.NewMonitor(
-		"test-mem",
-		mon.MemoryResource,
-		nil,           /* curCount */
-		nil,           /* maxHist */
-		-1,            /* increment */
-		math.MaxInt64, /* noteworthy */
-		st,
-	)
-	diskMonitor := mon.NewMonitor(
-		"test-disk",
-		mon.DiskResource,
-		nil,           /* curCount */
-		nil,           /* maxHist */
-		-1,            /* increment */
-		math.MaxInt64, /* noteworthy */
-		st,
-	)
-
+	rng, _ := randutil.NewTestRand()
 	const numRows = 10
 	const numCols = 1
 	rows := randgen.MakeIntRows(numRows, numCols)
 	ordering := colinfo.ColumnOrdering{{ColIdx: 0, Direction: encoding.Ascending}}
 
-	rc := DiskBackedRowContainer{}
-	rc.Init(
-		ordering,
-		types.OneIntCol,
-		&evalCtx,
-		tempEngine,
-		memoryMonitor,
-		diskMonitor,
-	)
-	defer rc.Close(ctx)
+	getRowContainer := func(memReserved, diskReserved *mon.BoundAccount) (rc *DiskBackedRowContainer, memoryMonitor, diskMonitor *mon.BytesMonitor, cleanup func(context.Context)) {
+		memoryMonitor = mon.NewMonitor(
+			"test-mem",
+			mon.MemoryResource,
+			nil,           /* curCount */
+			nil,           /* maxHist */
+			-1,            /* increment */
+			math.MaxInt64, /* noteworthy */
+			st,
+		)
+		diskMonitor = mon.NewMonitor(
+			"test-disk",
+			mon.DiskResource,
+			nil,           /* curCount */
+			nil,           /* maxHist */
+			-1,            /* increment */
+			math.MaxInt64, /* noteworthy */
+			st,
+		)
+		memoryMonitor.Start(ctx, nil, memReserved)
+		diskMonitor.Start(ctx, nil, diskReserved)
+
+		rc = &DiskBackedRowContainer{}
+		rc.Init(
+			ordering,
+			types.OneIntCol,
+			&evalCtx,
+			tempEngine,
+			memoryMonitor,
+			diskMonitor,
+		)
+		cleanup = func(ctx context.Context) {
+			rc.Close(ctx)
+			diskMonitor.Stop(ctx)
+			memoryMonitor.Stop(ctx)
+		}
+		return rc, memoryMonitor, diskMonitor, cleanup
+	}
 
 	// NormalRun adds rows to a DiskBackedRowContainer, makes it spill to disk
 	// halfway through, keeps on adding rows, and then verifies that all rows
 	// were properly added to the DiskBackedRowContainer.
 	t.Run("NormalRun", func(t *testing.T) {
-		memoryMonitor.Start(ctx, nil, mon.NewStandaloneBudget(math.MaxInt64))
-		defer memoryMonitor.Stop(ctx)
-		diskMonitor.Start(ctx, nil, mon.NewStandaloneBudget(math.MaxInt64))
-		defer diskMonitor.Stop(ctx)
-
-		defer func() {
-			if err := rc.UnsafeReset(ctx); err != nil {
-				t.Fatal(err)
-			}
-		}()
+		memReserved, diskReserved := mon.NewStandaloneBudget(math.MaxInt64), mon.NewStandaloneBudget(math.MaxInt64)
+		rc, _, _, cleanup := getRowContainer(memReserved, diskReserved)
+		defer cleanup(ctx)
 
 		mid := len(rows) / 2
 		for i := 0; i < mid; i++ {
@@ -271,7 +283,7 @@ func TestDiskBackedRowContainer(t *testing.T) {
 		func() {
 			i := rc.NewIterator(ctx)
 			defer i.Close()
-			if err := verifyRows(ctx, i, rows[:mid], &evalCtx, ordering); err != nil {
+			if err := verifyRows(i, rows[:mid], &evalCtx, ordering); err != nil {
 				t.Fatalf("verifying memory rows failed with: %s", err)
 			}
 		}()
@@ -289,23 +301,16 @@ func TestDiskBackedRowContainer(t *testing.T) {
 		func() {
 			i := rc.NewIterator(ctx)
 			defer i.Close()
-			if err := verifyRows(ctx, i, rows, &evalCtx, ordering); err != nil {
+			if err := verifyRows(i, rows, &evalCtx, ordering); err != nil {
 				t.Fatalf("verifying disk rows failed with: %s", err)
 			}
 		}()
 	})
 
 	t.Run("AddRowOutOfMem", func(t *testing.T) {
-		memoryMonitor.Start(ctx, nil, mon.NewStandaloneBudget(1))
-		defer memoryMonitor.Stop(ctx)
-		diskMonitor.Start(ctx, nil, mon.NewStandaloneBudget(math.MaxInt64))
-		defer diskMonitor.Stop(ctx)
-
-		defer func() {
-			if err := rc.UnsafeReset(ctx); err != nil {
-				t.Fatal(err)
-			}
-		}()
+		memReserved, diskReserved := mon.NewStandaloneBudget(1), mon.NewStandaloneBudget(math.MaxInt64)
+		rc, memoryMonitor, diskMonitor, cleanup := getRowContainer(memReserved, diskReserved)
+		defer cleanup(ctx)
 
 		if err := rc.AddRow(ctx, rows[0]); err != nil {
 			t.Fatal(err)
@@ -322,16 +327,9 @@ func TestDiskBackedRowContainer(t *testing.T) {
 	})
 
 	t.Run("AddRowOutOfDisk", func(t *testing.T) {
-		memoryMonitor.Start(ctx, nil, mon.NewStandaloneBudget(1))
-		defer memoryMonitor.Stop(ctx)
-		diskMonitor.Start(ctx, nil, mon.NewStandaloneBudget(1))
-		defer diskMonitor.Stop(ctx)
-
-		defer func() {
-			if err := rc.UnsafeReset(ctx); err != nil {
-				t.Fatal(err)
-			}
-		}()
+		memReserved, diskReserved := mon.NewStandaloneBudget(1), mon.NewStandaloneBudget(1)
+		rc, memoryMonitor, diskMonitor, cleanup := getRowContainer(memReserved, diskReserved)
+		defer cleanup(ctx)
 
 		err := rc.AddRow(ctx, rows[0])
 		if code := pgerror.GetPGCode(err); code != pgcode.DiskFull {
@@ -347,6 +345,65 @@ func TestDiskBackedRowContainer(t *testing.T) {
 		}
 		if memoryMonitor.AllocBytes() != 0 {
 			t.Fatal("memory monitor reports unexpected usage")
+		}
+	})
+
+	// ConcurrentReads adds rows to a DiskBackedRowContainer (possibly spilling
+	// to disk at some point) and then verifies that all rows can be read
+	// concurrently (via separate iterators) from the container.
+	t.Run("ConcurrentReads", func(t *testing.T) {
+		memReserved, diskReserved := mon.NewStandaloneBudget(math.MaxInt64), mon.NewStandaloneBudget(math.MaxInt64)
+		rc, _, _, cleanup := getRowContainer(memReserved, diskReserved)
+		defer cleanup(ctx)
+
+		// Spill in 50% of cases.
+		spillAfter := numRows
+		if rng.Float64() < 0.5 {
+			spillAfter = rng.Intn(numRows - 1)
+		}
+		for i := 0; i < spillAfter; i++ {
+			if err := rc.AddRow(ctx, rows[i]); err != nil {
+				t.Fatal(err)
+			}
+		}
+		if rc.Spilled() {
+			t.Fatal("unexpectedly using disk")
+		}
+		if spillAfter < numRows {
+			if err := rc.SpillToDisk(ctx); err != nil {
+				t.Fatal(err)
+			}
+			if !rc.Spilled() {
+				t.Fatal("unexpectedly using memory")
+			}
+			for i := spillAfter; i < len(rows); i++ {
+				if err := rc.AddRow(ctx, rows[i]); err != nil {
+					t.Fatal(err)
+				}
+			}
+		}
+		numConcurrentReaders := 2 + rng.Intn(4)
+		errCh := make(chan error)
+		for i := 0; i < numConcurrentReaders; i++ {
+			// Creating and closing iterators must be done serially.
+			iterator := rc.NewIterator(ctx)
+			defer iterator.Close()
+			go func(iterator RowIterator) {
+				if err := verifyRows(iterator, rows, &evalCtx, ordering); err != nil {
+					errCh <- err
+				} else {
+					errCh <- nil
+				}
+			}(iterator)
+		}
+		var firstErr error
+		for i := 0; i < numConcurrentReaders; i++ {
+			if err := <-errCh; err != nil && firstErr == nil {
+				firstErr = err
+			}
+		}
+		if firstErr != nil {
+			t.Fatal(firstErr)
 		}
 	})
 }
@@ -462,7 +519,7 @@ func verifyOrdering(
 		} else if !ok {
 			break
 		}
-		row, err := i.Row()
+		row, err := i.EncRow()
 		if err != nil {
 			return err
 		}

--- a/pkg/sql/rowexec/hashjoiner.go
+++ b/pkg/sql/rowexec/hashjoiner.go
@@ -339,7 +339,7 @@ func (h *hashJoiner) probeRow() (
 	}
 
 	leftRow := h.probingRowState.row
-	rightRow, err := i.Row()
+	rightRow, err := i.EncRow()
 	if err != nil {
 		h.MoveToDraining(err)
 		return hjStateUnknown, nil, h.DrainHelper()
@@ -438,7 +438,7 @@ func (h *hashJoiner) emitRightUnmatched() (
 		return hjStateUnknown, nil, h.DrainHelper()
 	}
 
-	row, err := i.Row()
+	row, err := i.EncRow()
 	if err != nil {
 		h.MoveToDraining(err)
 		return hjStateUnknown, nil, h.DrainHelper()

--- a/pkg/sql/rowexec/sorter.go
+++ b/pkg/sql/rowexec/sorter.go
@@ -97,7 +97,7 @@ func (s *sorterBase) Next() (rowenc.EncDatumRow, *execinfrapb.ProducerMetadata) 
 			break
 		}
 
-		row, err := s.i.Row()
+		row, err := s.i.EncRow()
 		if err != nil {
 			s.MoveToDraining(err)
 			break
@@ -548,7 +548,7 @@ func (s *sortChunksProcessor) Next() (rowenc.EncDatumRow, *execinfrapb.ProducerM
 		}
 
 		// If we have an active chunk, get a row from it.
-		row, err := s.i.Row()
+		row, err := s.i.EncRow()
 		if err != nil {
 			s.MoveToDraining(err)
 			break

--- a/pkg/sql/rowexec/windower.go
+++ b/pkg/sql/rowexec/windower.go
@@ -645,7 +645,7 @@ func (w *windower) computeWindowFunctions(ctx context.Context, evalCtx *eval.Con
 		} else if !ok {
 			break
 		}
-		row, err := i.Row()
+		row, err := i.EncRow()
 		if err != nil {
 			return err
 		}
@@ -722,7 +722,7 @@ func (w *windower) populateNextOutputRow() (bool, error) {
 		} else if !ok {
 			return false, nil
 		}
-		inputRow, err := w.allRowsIterator.Row()
+		inputRow, err := w.allRowsIterator.EncRow()
 		w.allRowsIterator.Next()
 		if err != nil {
 			return false, err

--- a/pkg/sql/rowflow/routers.go
+++ b/pkg/sql/rowflow/routers.go
@@ -176,7 +176,7 @@ func (ro *routerOutput) popRowsLocked(ctx context.Context) ([]rowenc.EncDatumRow
 				} else if !ok {
 					break
 				}
-				row, err := i.Row()
+				row, err := i.EncRow()
 				if err != nil {
 					return err
 				}

--- a/pkg/util/mon/bytes_usage.go
+++ b/pkg/util/mon/bytes_usage.go
@@ -649,6 +649,7 @@ func (b *BoundAccount) Clear(ctx context.Context) {
 }
 
 // Close releases all the cumulated allocations of an account at once.
+// TODO(yuzefovich): consider removing this method in favor of Clear.
 func (b *BoundAccount) Close(ctx context.Context) {
 	if b == nil {
 		return


### PR DESCRIPTION
This commit refactors the row container infrastructure in order to make
it possible to read from a single container concurrently (via separate
iterators). It required moving some of the scratch space from the
container directly into the iterators (so that the iterators don't share
anything between each other) as well as making a similar adjustment to
the `pebbleMapIterator`. As a result, it is now possible to safely
concurrently iterate over all types of row containers; however, the
iterators need to be created and closed under mutex protection (which
seems like an acceptable limitation). This commit also makes a minor
change to make the container a named parameter inside of the iterator
(which makes it easier to see when an iterator is touching the
container).

The ability to read from the same row container (after all rows have
been added to it) concurrently will be utilized by the follow-up commit
in order to support validation of multiple FK and UNIQUE checks in
parallel.

Additionally, this commit improves `RowIterator` interface a bit by
renaming `Row` to `EncRow` (since the method returns `EncDatumRow`s) and
introducing a new `Row` implementation which returns `tree.Datums`. The
new method is now utilized in the `sql.rowContainerIterator` which
removes some of the unnecessary conversions between different row types.

Informs: #95184.

Release note: None