### PR TITLE
kv/kvserver: skip TestDelegateSnapshot

### DIFF
--- a/pkg/kv/kvserver/replica_learner_test.go
+++ b/pkg/kv/kvserver/replica_learner_test.go
@@ -356,7 +356,7 @@ func TestAddReplicaWithReceiverThrottling(t *testing.T) {
 func TestDelegateSnapshot(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	skip.UnderStress(t, "Occasionally fails until 87553 is resolved")
+	skip.WithIssue(t, 96841, "Occasionally fails until 87553 is resolved")
 
 	ctx := context.Background()
 


### PR DESCRIPTION
Refs: #96841

Reason: flaky test

Release justification: non-production code changes

Release note: None