### PR TITLE
kvserver: extract writeUnreplicatedSST

### DIFF
--- a/pkg/kv/kvserver/replica.go
+++ b/pkg/kv/kvserver/replica.go
@@ -863,6 +863,11 @@ func (r *Replica) ReplicaID() roachpb.ReplicaID {
 	return r.replicaID
 }
 
+// ID returns the FullReplicaID for the Replica.
+func (r *Replica) ID() storage.FullReplicaID {
+	return storage.FullReplicaID{RangeID: r.RangeID, ReplicaID: r.replicaID}
+}
+
 // cleanupFailedProposal cleans up after a proposal that has failed. It
 // clears any references to the proposal and releases associated quota.
 // It requires that Replica.mu is exclusively held.

--- a/pkg/kv/kvserver/replica_raftstorage.go
+++ b/pkg/kv/kvserver/replica_raftstorage.go
@@ -485,6 +485,9 @@ func (r *Replica) applySnapshot(
 	unreplicatedSSTFile, nonempty, err := writeUnreplicatedSST(
 		ctx, r.ID(), r.ClusterSettings(), nonemptySnap.Metadata, hs, &r.raftMu.stateLoader.StateLoader,
 	)
+	if err != nil {
+		return err
+	}
 	if nonempty {
 		// TODO(itsbilal): Write to SST directly in unreplicatedSST rather than
 		// buffering in a MemFile first.


### PR DESCRIPTION
This PR extracts a standalone method `writeUnreplicatedSST` that can be moved
to `kvstorage` at an appropriate time.

This is a sister PR to #96871, which does the same to some other SSTs created
in `applySnapshot`.

Epic: CRDB-220
Release note: None
