### PR TITLE
builtins: crdb_internal.hide_sql_constants should not error on parse

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/builtin_function
+++ b/pkg/sql/logictest/testdata/logic_test/builtin_function
@@ -3752,6 +3752,18 @@ SELECT crdb_internal.hide_sql_constants(NULL)
 NULL
 
 query T
+SELECT crdb_internal.hide_sql_constants('not a sql stmt')
+----
+·
+
+
+query T
+select crdb_internal.hide_sql_constants(e'\r');
+----
+·
+
+
+query T
 SELECT crdb_internal.hide_sql_constants(create_statement) from crdb_internal.create_statements where descriptor_name = 'foo'
 ----
 CREATE TABLE public.foo (a INT8 NULL, rowid INT8 NOT NULL NOT VISIBLE DEFAULT unique_rowid(), CONSTRAINT foo_pkey PRIMARY KEY (rowid ASC))

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -7712,7 +7712,10 @@ expires until the statement bundle is collected`,
 
 				parsed, err := parser.ParseOne(sql)
 				if err != nil {
-					return nil, err
+					// If parsing is unsuccessful, we shouldn't return an error, however
+					// we can't return the original stmt since this function is used to
+					// hide sensitive information.
+					return tree.NewDString(""), nil //nolint:returnerrcheck
 				}
 				sqlNoConstants := tree.AsStringWithFlags(parsed.AST, tree.FmtHideConstants)
 				return tree.NewDString(sqlNoConstants), nil
@@ -7743,7 +7746,7 @@ expires until the statement bundle is collected`,
 					if len(sql) != 0 {
 						parsed, err := parser.ParseOne(sql)
 						if err != nil {
-							return nil, err
+							return tree.NewDString(sqlNoConstants), nil //nolint:returnerrcheck
 						}
 
 						sqlNoConstants = tree.AsStringWithFlags(parsed.AST, tree.FmtHideConstants)


### PR DESCRIPTION
Previously, if crdb_internal.hide_sql_constants is unable to parse the provided string as a sql statement, it returned an error. Instead, we should just return the empty string to make it less disruptive.

Epic: none
Fixes: #96555

Release note: None