### PR TITLE
workload: support import parallelism for multi-tenant cluster

### DIFF
--- a/pkg/ccl/workloadccl/BUILD.bazel
+++ b/pkg/ccl/workloadccl/BUILD.bazel
@@ -52,6 +52,7 @@ go_test(
         "//pkg/testutils/testcluster",
         "//pkg/util/envutil",
         "//pkg/util/leaktest",
+        "//pkg/util/log",
         "//pkg/util/randutil",
         "//pkg/util/timeutil",
         "//pkg/workload",

--- a/pkg/ccl/workloadccl/fixture.go
+++ b/pkg/ccl/workloadccl/fixture.go
@@ -206,10 +206,6 @@ func csvServerPaths(
 	return paths
 }
 
-// Specify an explicit empty prefix for crdb_internal to avoid an error if
-// the database we're connected to does not exist.
-const numNodesQuery = `SELECT count(node_id) FROM "".crdb_internal.gossip_liveness`
-
 // MakeFixture regenerates a fixture, storing it to GCS. It is expected that the
 // generator will have had Configure called on it.
 //
@@ -330,6 +326,29 @@ func (l ImportDataLoader) InitialDataLoad(
 	return bytes, nil
 }
 
+// Specify an explicit empty prefix for crdb_internal to avoid an error if
+// the database we're connected to does not exist.
+const numNodesQuery = `SELECT count(node_id) FROM "".crdb_internal.gossip_liveness`
+const numNodesQuerySQLInstances = `SELECT count(1) FROM system.sql_instances WHERE addr IS NOT NULL`
+
+func getNodeCount(ctx context.Context, sqlDB *gosql.DB) (int, error) {
+	var numNodes int
+	if err := sqlDB.QueryRow(numNodesQuery).Scan(&numNodes); err != nil {
+		// If the query is unsupported because we're in
+		// multi-tenant mode, use the sql_instances table.
+		if !strings.Contains(err.Error(), errorutil.UnsupportedWithMultiTenancyMessage) {
+			return 0, err
+
+		}
+	} else {
+		return numNodes, nil
+	}
+	if err := sqlDB.QueryRow(numNodesQuerySQLInstances).Scan(&numNodes); err != nil {
+		return 0, err
+	}
+	return numNodes, nil
+}
+
 // ImportFixture works like MakeFixture, but instead of stopping halfway or
 // writing a backup to cloud storage, it finishes ingesting the data.
 // It also includes the option to inject pre-calculated table statistics if
@@ -349,18 +368,9 @@ func ImportFixture(
 		)
 	}
 
-	var numNodes int
-	if err := sqlDB.QueryRow(numNodesQuery).Scan(&numNodes); err != nil {
-		if strings.Contains(err.Error(), errorutil.UnsupportedWithMultiTenancyMessage) {
-			// If the query is unsupported because we're in multi-tenant mode. Assume
-			// that the cluster has 1 node for the purposes of running CSV servers.
-			// Tenants won't use DistSQL to parallelize IMPORT across SQL pods. Doing
-			// something better here is tracked in:
-			//  https://github.com/cockroachdb/cockroach/issues/78968
-			numNodes = 1
-		} else {
-			return 0, err
-		}
+	numNodes, err := getNodeCount(ctx, sqlDB)
+	if err != nil {
+		return 0, err
 	}
 
 	var bytesAtomic int64

--- a/pkg/ccl/workloadccl/fixture_test.go
+++ b/pkg/ccl/workloadccl/fixture_test.go
@@ -87,6 +87,8 @@ func (g fixtureTestGen) Tables() []workload.Table {
 
 func TestFixture(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
 	ctx := context.Background()
 
 	// This test is brittle and requires manual intervention to run.
@@ -169,6 +171,7 @@ func TestFixture(t *testing.T) {
 
 func TestImportFixture(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
 
 	ctx := context.Background()
 
@@ -224,6 +227,8 @@ func TestImportFixture(t *testing.T) {
 
 func TestImportFixtureCSVServer(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
 	ctx := context.Background()
 	ts := httptest.NewServer(workload.CSVMux(workload.Registered()))
 	defer ts.Close()

--- a/pkg/ccl/workloadccl/fixture_test.go
+++ b/pkg/ccl/workloadccl/fixture_test.go
@@ -182,12 +182,7 @@ func TestImportFixture(t *testing.T) {
 	stats.DefaultRefreshInterval = time.Millisecond
 	stats.DefaultAsOfTime = 10 * time.Millisecond
 
-	s, db, _ := serverutils.StartServer(t,
-		// Need to disable the test tenant until we have a fix for #75449.
-		base.TestServerArgs{
-			DisableDefaultTestTenant: true,
-		},
-	)
+	s, db, _ := serverutils.StartServer(t, base.TestServerArgs{})
 	defer s.Stopper().Stop(ctx)
 	sqlDB := sqlutils.MakeSQLRunner(db)
 
@@ -236,8 +231,6 @@ func TestImportFixtureCSVServer(t *testing.T) {
 	s, db, _ := serverutils.StartServer(t,
 		base.TestServerArgs{
 			UseDatabase: `d`,
-			// Test fails within a test tenant due to #75449.
-			DisableDefaultTestTenant: true,
 		},
 	)
 	defer s.Stopper().Stop(ctx)


### PR DESCRIPTION
All nodes now produce entries in the sql_instances table, so we are able to use that table to get a node count even when running against a secondary tenant.

I've kept the original query in place to support older clusters.

Fixes #78968

Release note: None