### PR TITLE
bulk,backupccl: log ExportRequest trace on failure

### DIFF
--- a/pkg/util/bulk/tracing_aggregator.go
+++ b/pkg/util/bulk/tracing_aggregator.go
@@ -89,8 +89,10 @@ func MakeTracingAggregatorWithSpan(
 	ctx context.Context, aggregatorName string, tracer *tracing.Tracer,
 ) (context.Context, *TracingAggregator) {
 	agg := &TracingAggregator{}
+
+	sp := tracing.SpanFromContext(ctx)
 	aggCtx, aggSpan := tracing.EnsureChildSpan(ctx, tracer, aggregatorName,
-		tracing.WithEventListeners(agg))
+		tracing.WithEventListeners(agg), tracing.WithRecording(sp.RecordingType()))
 
 	agg.mu.Lock()
 	defer agg.mu.Unlock()


### PR DESCRIPTION
This change adds logic to fetch the trace for each ExportRequest once it has returned a response or failed with an error. If the request failed with an error, we unconditionally log the trace, otherwise we log it when the appropriate vmodule is set.

This change also fixes a bug where the child context created by the tracing aggregator would not inherit its parent's RecordingMode. Today there is no mechanism to toggle a job's RecordingMode from Structured to Verbose, but when we do add the ability to do so we expect all operations in the job to collect information in accordance with that mode.

Fixes: #86047

Release note: None