### PR TITLE
sql: add spaces to delimiter in uniqueness violation error

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/insert
+++ b/pkg/sql/logictest/testdata/logic_test/insert
@@ -335,7 +335,7 @@ INSERT INTO abc VALUES (1, 2, 10)
 
 # Verify we get the correct message, even though internally the ConditionalPut
 # for the index key will also fail.
-statement error pgcode 23505 duplicate key value violates unique constraint "abc_pkey"\nDETAIL: Key \(a,b\)=\(1,2\) already exists\.
+statement error pgcode 23505 duplicate key value violates unique constraint "abc_pkey"\nDETAIL: Key \(a, b\)=\(1, 2\) already exists\.
 INSERT INTO abc VALUES (1, 2, 20)
 
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/unique
+++ b/pkg/sql/logictest/testdata/logic_test/unique
@@ -361,10 +361,10 @@ NULL  5
 statement ok
 INSERT INTO uniq_computed_pk (i, s, d) VALUES (1, 'a', 1.0), (2, 'b', 2.0)
 
-statement error pgcode 23505 pq: duplicate key value violates unique constraint "uniq_computed_pk_pkey"\nDETAIL: Key \(c_i_expr,i\)=\('bar',1\) already exists\.
+statement error pgcode 23505 pq: duplicate key value violates unique constraint "uniq_computed_pk_pkey"\nDETAIL: Key \(c_i_expr, i\)=\('bar', 1\) already exists\.
 INSERT INTO uniq_computed_pk (i, s, d) VALUES (1, 'c', 3.0)
 
-statement error pgcode 23505 pq: duplicate key value violates unique constraint "uniq_computed_pk_c_s_s_key"\nDETAIL: Key \(c_s,s\)=\('b','b'\) already exists\.
+statement error pgcode 23505 pq: duplicate key value violates unique constraint "uniq_computed_pk_c_s_s_key"\nDETAIL: Key \(c_s, s\)=\('b', 'b'\) already exists\.
 INSERT INTO uniq_computed_pk (i, s, d) VALUES (3, 'b', 3.0)
 
 statement error pgcode 23505 pq: duplicate key value violates unique constraint "unique_d"\nDETAIL: Key \(d\)=\(1\.00\) already exists\.
@@ -542,10 +542,10 @@ NULL  10
 # Check that uniqueness violations are detected in a table with UNIQUE indexes
 # containing computed columns that are dependent on UNIQUE WITHOUT INDEX
 # columns.
-statement error pgcode 23505 pq: duplicate key value violates unique constraint "uniq_computed_pk_pkey"\nDETAIL: Key \(c_i_expr,i\)=\('bar',1\) already exists\.
+statement error pgcode 23505 pq: duplicate key value violates unique constraint "uniq_computed_pk_pkey"\nDETAIL: Key \(c_i_expr, i\)=\('bar', 1\) already exists\.
 UPDATE uniq_computed_pk SET i = 1 WHERE i = 2
 
-statement error pgcode 23505 pq: duplicate key value violates unique constraint "uniq_computed_pk_c_s_s_key"\nDETAIL: Key \(c_s,s\)=\('a','a'\) already exists\.
+statement error pgcode 23505 pq: duplicate key value violates unique constraint "uniq_computed_pk_c_s_s_key"\nDETAIL: Key \(c_s, s\)=\('a', 'a'\) already exists\.
 UPDATE uniq_computed_pk SET s = 'a' WHERE i = 2
 
 statement error pgcode 23505 pq: duplicate key value violates unique constraint "unique_d"\nDETAIL: Key \(d\)=\(1\.00\) already exists\.
@@ -825,10 +825,10 @@ i
 # Check that uniqueness violations are detected in a table with UNIQUE indexes
 # containing computed columns that are dependent on UNIQUE WITHOUT INDEX
 # columns.
-statement error pgcode 23505 pq: duplicate key value violates unique constraint "uniq_computed_pk_pkey"\nDETAIL: Key \(c_i_expr,i\)=\('bar',2\) already exists\.
+statement error pgcode 23505 pq: duplicate key value violates unique constraint "uniq_computed_pk_pkey"\nDETAIL: Key \(c_i_expr, i\)=\('bar', 2\) already exists\.
 INSERT INTO uniq_computed_pk (i, s, d) VALUES (1, 'a', 1.0) ON CONFLICT (s) DO UPDATE SET i = 2
 
-statement error pgcode 23505 pq: duplicate key value violates unique constraint "uniq_computed_pk_c_s_s_key"\nDETAIL: Key \(c_s,s\)=\('b','b'\) already exists\.
+statement error pgcode 23505 pq: duplicate key value violates unique constraint "uniq_computed_pk_c_s_s_key"\nDETAIL: Key \(c_s, s\)=\('b', 'b'\) already exists\.
 UPSERT INTO uniq_computed_pk (i, s, d) VALUES (3, 'b', 3.0)
 
 statement error pgcode 23505 pq: duplicate key value violates unique constraint "unique_d"\nDETAIL: Key \(d\)=\(2\.00\) already exists\.

--- a/pkg/sql/logictest/testdata/logic_test/update
+++ b/pkg/sql/logictest/testdata/logic_test/update
@@ -356,7 +356,7 @@ CREATE TABLE pks (
 statement count 2
 INSERT INTO pks VALUES (1, 2, 3), (4, 5, 3)
 
-statement error duplicate key value violates unique constraint "i"\nDETAIL: Key \(k2,v\)=\(5,3\) already exists\.
+statement error duplicate key value violates unique constraint "i"\nDETAIL: Key \(k2, v\)=\(5, 3\) already exists\.
 UPDATE pks SET k2 = 5 where k1 = 1
 
 # Test updating only one of the columns of a multi-column primary key.

--- a/pkg/sql/logictest/testdata/logic_test/upsert
+++ b/pkg/sql/logictest/testdata/logic_test/upsert
@@ -1080,7 +1080,7 @@ SELECT * FROM tdup@tdup_y_z_key
 3  2     NULL
 
 # Verify that duplicate secondary key fails with regular conflict error.
-statement error pq: duplicate key value violates unique constraint "tdup_y_z_key"\nDETAIL: Key \(y,z\)=\(1,2\) already exists\.
+statement error pq: duplicate key value violates unique constraint "tdup_y_z_key"\nDETAIL: Key \(y, z\)=\(1, 2\) already exists\.
 INSERT INTO tdup VALUES (6, 1, 1), (7, 1, 2) ON CONFLICT (y, z) DO UPDATE SET z=2
 
 # With constant grouping columns (no error).

--- a/pkg/sql/opt/exec/execbuilder/testdata/update
+++ b/pkg/sql/opt/exec/execbuilder/testdata/update
@@ -282,7 +282,7 @@ CREATE TABLE pks (
 statement count 2
 INSERT INTO pks VALUES (1, 2, 3), (4, 5, 3)
 
-statement error duplicate key value violates unique constraint "i"\nDETAIL: Key \(k2,v\)=\(5,3\) already exists\.
+statement error duplicate key value violates unique constraint "i"\nDETAIL: Key \(k2, v\)=\(5, 3\) already exists\.
 UPDATE pks SET k2 = 5 where k1 = 1
 
 # Test updating only one of the columns of a multi-column primary key.

--- a/pkg/sql/row/errors.go
+++ b/pkg/sql/row/errors.go
@@ -128,8 +128,8 @@ func NewUniquenessConstraintViolationError(
 		), indexName),
 		fmt.Sprintf(
 			"Key (%s)=(%s) already exists.",
-			strings.Join(names[skipCols:], ","),
-			strings.Join(values[skipCols:], ","),
+			strings.Join(names[skipCols:], ", "),
+			strings.Join(values[skipCols:], ", "),
 		),
 	)
 }


### PR DESCRIPTION
Whenever a mutation statement violates a uniqueness constraint we return a specific error which shows the affected row. This error is formatted to match the corresponding error in Postgres.

We create this error in two places. In one place (`pkg/sql/opt/exec/execbuilder/mutation.go`) we were using ", " as the delimter between values, which matches Postgres. But in the other place (`pkg/sql/row/errors.go`) we were using "," (without a space).

This patch adds the space.

Epic: None

Release note (bug fix): Fix formatting of uniqueness violation errors to match the corresponding errors from PostgreSQL.