### PR TITLE
roachtest: decommission disable roachprod init on restarts

### DIFF
--- a/pkg/cmd/roachtest/option/options.go
+++ b/pkg/cmd/roachtest/option/options.go
@@ -36,6 +36,16 @@ func DefaultStartOptsNoBackups() StartOpts {
 	return StartOpts{RoachprodOpts: roachprod.DefaultStartOpts()}
 }
 
+// DefaultStartSingleNodeOpts returns StartOpts with default values,
+// but no init. This is helpful if node is not going to start gracefully or
+// will be terminated as init could fail even if it is a noop for a running
+// cluster.
+func DefaultStartSingleNodeOpts() StartOpts {
+	startOpts := StartOpts{RoachprodOpts: roachprod.DefaultStartOpts()}
+	startOpts.RoachprodOpts.SkipInit = true
+	return startOpts
+}
+
 // StopOpts is a type that combines the stop options needed by roachprod and roachtest.
 type StopOpts struct {
 	RoachprodOpts roachprod.StopOpts

--- a/pkg/cmd/roachtest/tests/decommission.go
+++ b/pkg/cmd/roachtest/tests/decommission.go
@@ -342,7 +342,7 @@ func runDecommission(
 			if err != nil {
 				return err
 			}
-			startOpts := option.DefaultStartOpts()
+			startOpts := option.DefaultStartSingleNodeOpts()
 			extraArgs := []string{
 				"--join", internalAddrs[0],
 				fmt.Sprintf("--attrs=node%d", node),
@@ -708,7 +708,7 @@ func runDecommissionRandomized(ctx context.Context, t test.Test, c cluster.Clust
 				targetNodeA, targetNodeB, runNode)
 			c.Stop(ctx, t.L(), option.DefaultStopOpts(), c.Nodes(targetNodeA, targetNodeB))
 			// The node is in a decomissioned state, so don't attempt to run scheduled backups.
-			c.Start(ctx, t.L(), option.DefaultStartOptsNoBackups(), settings, c.Nodes(targetNodeA, targetNodeB))
+			c.Start(ctx, t.L(), option.DefaultStartSingleNodeOpts(), settings, c.Nodes(targetNodeA, targetNodeB))
 
 			if _, err := h.recommission(ctx, c.Nodes(targetNodeA, targetNodeB), runNode); err == nil {
 				t.Fatalf("expected recommission to fail")
@@ -770,7 +770,7 @@ func runDecommissionRandomized(ctx context.Context, t test.Test, c cluster.Clust
 
 			// Bring targetNode it back up to verify that its replicas still get
 			// removed.
-			c.Start(ctx, t.L(), option.DefaultStartOpts(), settings, c.Node(targetNode))
+			c.Start(ctx, t.L(), option.DefaultStartSingleNodeOpts(), settings, c.Node(targetNode))
 		}
 
 		// Run decommission a second time to wait until the replicas have
@@ -846,7 +846,7 @@ func runDecommissionRandomized(ctx context.Context, t test.Test, c cluster.Clust
 				t.Fatal(err)
 			}
 			joinAddr := internalAddrs[0]
-			startOpts := option.DefaultStartOpts()
+			startOpts := option.DefaultStartSingleNodeOpts()
 			startOpts.RoachprodOpts.ExtraArgs = append(
 				startOpts.RoachprodOpts.ExtraArgs,
 				[]string{"--join", joinAddr}...,


### PR DESCRIPTION
Roachtest Cluster.Start() will always try to init cluster and do one time ops if not explicitly disabled. This is not a good fit for tests that introduce failures as post start operations could fail and thus break test.
This commit adds default options that prevent init and changes decommission test to use them when restarting nodes.

Release note: None

Fixes #96791