### PR TITLE
kvserver: refactor Replica and Store updates on replica init

### DIFF
--- a/pkg/kv/kvserver/replica_init.go
+++ b/pkg/kv/kvserver/replica_init.go
@@ -75,7 +75,7 @@ func newInitializedReplica(store *Store, loaded kvstorage.LoadedReplicaState) (*
 // Replica.loadRaftMuLockedReplicaMuLocked() is called.
 //
 // TODO(#94912): we actually have another initialization path which should be
-// refactored: Store.markReplicaInitializedLockedReplLocked().
+// refactored: Replica.initFromSnapshotLockedRaftMuLocked().
 func newUninitializedReplica(
 	store *Store, rangeID roachpb.RangeID, replicaID roachpb.ReplicaID,
 ) *Replica {
@@ -220,6 +220,48 @@ func (r *Replica) initRaftMuLockedReplicaMuLocked(s kvstorage.LoadedReplicaState
 	// disappears.
 	if r.mu.state.Lease.Sequence > 0 {
 		r.mu.minLeaseProposedTS = r.Clock().NowAsClockTimestamp()
+	}
+
+	return nil
+}
+
+// initFromSnapshotLockedRaftMuLocked initializes a Replica when applying the
+// initial snapshot.
+func (r *Replica) initFromSnapshotLockedRaftMuLocked(
+	ctx context.Context, desc *roachpb.RangeDescriptor,
+) error {
+	if !desc.IsInitialized() {
+		return errors.AssertionFailedf("initializing replica with uninitialized desc: %s", desc)
+	}
+
+	r.setDescLockedRaftMuLocked(ctx, desc)
+	r.setStartKeyLocked(desc.StartKey)
+
+	// Unquiesce the replica. We don't allow uninitialized replicas to unquiesce,
+	// but now that the replica has been initialized, we unquiesce it as soon as
+	// possible. This replica was initialized in response to the reception of a
+	// snapshot from another replica. This means that the other replica is not
+	// quiesced, so we don't need to campaign or wake the leader. We just want
+	// to start ticking.
+	//
+	// NOTE: The fact that this replica is being initialized in response to the
+	// receipt of a snapshot means that its r.mu.internalRaftGroup must not be
+	// nil.
+	//
+	// NOTE: Unquiescing the replica here is not strictly necessary. As of the
+	// time of writing, this function is only ever called below handleRaftReady,
+	// which will always unquiesce any eligible replicas before completing. So in
+	// marking this replica as initialized, we have made it eligible to unquiesce.
+	// However, there is still a benefit to unquiecing here instead of letting
+	// handleRaftReady do it for us. The benefit is that handleRaftReady cannot
+	// make assumptions about the state of the other replicas in the range when it
+	// unquieces a replica, so when it does so, it also instructs the replica to
+	// campaign and to wake the leader (see maybeUnquiesceAndWakeLeaderLocked).
+	// We have more information here (see "This means that the other replica ..."
+	// above) and can make assumptions about the state of the other replicas in
+	// the range, so we can unquiesce without campaigning or waking the leader.
+	if !r.maybeUnquiesceWithOptionsLocked(false /* campaignOnWake */) {
+		return errors.AssertionFailedf("expected replica %s to unquiesce after initialization", desc)
 	}
 
 	return nil

--- a/pkg/kv/kvserver/replica_init.go
+++ b/pkg/kv/kvserver/replica_init.go
@@ -75,7 +75,7 @@ func newInitializedReplica(store *Store, loaded kvstorage.LoadedReplicaState) (*
 // Replica.loadRaftMuLockedReplicaMuLocked() is called.
 //
 // TODO(#94912): we actually have another initialization path which should be
-// refactored: Store.maybeMarkReplicaInitializedLockedReplLocked().
+// refactored: Store.markReplicaInitializedLockedReplLocked().
 func newUninitializedReplica(
 	store *Store, rangeID roachpb.RangeID, replicaID roachpb.ReplicaID,
 ) *Replica {

--- a/pkg/kv/kvserver/replica_raftstorage.go
+++ b/pkg/kv/kvserver/replica_raftstorage.go
@@ -553,6 +553,10 @@ func (r *Replica) applySnapshot(
 	}
 	stats.ingestion = timeutil.Now()
 
+	// The on-disk state is now committed, but the corresponding in-memory state
+	// has not yet been updated. Any errors past this point must therefore be
+	// treated as fatal.
+
 	state, err := stateloader.Make(desc.RangeID).Load(ctx, r.store.TODOEngine(), desc)
 	if err != nil {
 		log.Fatalf(ctx, "unable to load replica state: %s", err)
@@ -567,21 +571,20 @@ func (r *Replica) applySnapshot(
 			state.RaftAppliedIndexTerm, nonemptySnap.Metadata.Term)
 	}
 
-	// The on-disk state is now committed, but the corresponding in-memory state
-	// has not yet been updated. Any errors past this point must therefore be
-	// treated as fatal.
-
-	subPHs, err := r.clearSubsumedReplicaInMemoryData(ctx, subsumedRepls, mergedTombstoneReplicaID)
-	if err != nil {
-		log.Fatalf(ctx, "failed to clear in-memory data of subsumed replicas while applying snapshot: %+v", err)
-	}
-
 	// Read the prior read summary for this range, which was included in the
 	// snapshot. We may need to use it to bump our timestamp cache if we
 	// discover that we are the leaseholder as of the snapshot's log index.
 	prioReadSum, err := readsummary.Load(ctx, r.store.TODOEngine(), r.RangeID)
 	if err != nil {
 		log.Fatalf(ctx, "failed to read prior read summary after applying snapshot: %+v", err)
+	}
+
+	// The necessary on-disk state is read. Update the in-memory Replica and Store
+	// state now.
+
+	subPHs, err := r.clearSubsumedReplicaInMemoryData(ctx, subsumedRepls, mergedTombstoneReplicaID)
+	if err != nil {
+		log.Fatalf(ctx, "failed to clear in-memory data of subsumed replicas while applying snapshot: %+v", err)
 	}
 
 	// Atomically swap the placeholder, if any, for the replica, and update the

--- a/pkg/kv/kvserver/replica_raftstorage.go
+++ b/pkg/kv/kvserver/replica_raftstorage.go
@@ -403,7 +403,13 @@ func (r *Replica) applySnapshot(
 	if desc.RangeID != r.RangeID {
 		log.Fatalf(ctx, "unexpected range ID %d", desc.RangeID)
 	}
+	if !desc.IsInitialized() {
+		return errors.AssertionFailedf("applying snapshot with uninitialized desc: %s", desc)
+	}
 
+	// NB: since raftMu is held, this is not going to change out under us for the
+	// duration of this method. In particular, if this is true, then the replica
+	// must be in the store's uninitialized replicas map.
 	isInitialSnap := !r.IsInitialized()
 	{
 		var from, to roachpb.RKey
@@ -607,9 +613,15 @@ func (r *Replica) applySnapshot(
 	// NB: we lock `r.mu` only now because removePlaceholderLocked operates on
 	// replicasByKey and this may end up calling r.Desc().
 	r.mu.Lock()
-	r.setDescLockedRaftMuLocked(ctx, desc)
-	if err := r.store.maybeMarkReplicaInitializedLockedReplLocked(ctx, r); err != nil {
-		log.Fatalf(ctx, "unable to mark replica initialized while applying snapshot: %+v", err)
+	if isInitialSnap {
+		// NB: this will also call setDescLockedRaftMuLocked.
+		if err := initReplicaLocked(ctx, r, desc); err != nil {
+			log.Fatalf(ctx, "unable to initialize replica while applying snapshot: %+v", err)
+		} else if err := r.store.markReplicaInitializedLockedReplLocked(ctx, r); err != nil {
+			log.Fatalf(ctx, "unable to mark replica initialized while applying snapshot: %+v", err)
+		}
+	} else {
+		r.setDescLockedRaftMuLocked(ctx, desc)
 	}
 	// NOTE: even though we acquired the store mutex first (according to the
 	// lock ordering rules described on Store.mu), it is safe to drop it first

--- a/pkg/kv/kvserver/replica_raftstorage.go
+++ b/pkg/kv/kvserver/replica_raftstorage.go
@@ -615,7 +615,7 @@ func (r *Replica) applySnapshot(
 	r.mu.Lock()
 	if isInitialSnap {
 		// NB: this will also call setDescLockedRaftMuLocked.
-		if err := initReplicaLocked(ctx, r, desc); err != nil {
+		if err := r.initFromSnapshotLockedRaftMuLocked(ctx, desc); err != nil {
 			log.Fatalf(ctx, "unable to initialize replica while applying snapshot: %+v", err)
 		} else if err := r.store.markReplicaInitializedLockedReplLocked(ctx, r); err != nil {
 			log.Fatalf(ctx, "unable to mark replica initialized while applying snapshot: %+v", err)

--- a/pkg/kv/kvserver/store.go
+++ b/pkg/kv/kvserver/store.go
@@ -918,7 +918,8 @@ type Store struct {
 		// creatingReplicas stores IDs of all ranges for which there is an ongoing
 		// attempt to create a replica.
 		creatingReplicas map[roachpb.RangeID]struct{}
-		// All *Replica objects for which Replica.IsInitialized is false.
+		// All *Replica objects for which Replica.IsInitialized is false. Replicas
+		// are added to and removed from this map with Replica.raftMu locked.
 		//
 		// INVARIANT: any entry in this map is also in replicasByRangeID.
 		uninitReplicas map[roachpb.RangeID]*Replica // Map of uninitialized replicas by Range ID

--- a/pkg/kv/kvserver/store_create_replica.go
+++ b/pkg/kv/kvserver/store_create_replica.go
@@ -300,45 +300,6 @@ func (s *Store) addToReplicasByRangeIDLocked(repl *Replica) error {
 	return nil
 }
 
-// initReplicaLocked initializes a Replica when applying the initial snapshot.
-func initReplicaLocked(ctx context.Context, r *Replica, desc *roachpb.RangeDescriptor) error {
-	if !desc.IsInitialized() {
-		return errors.AssertionFailedf("initializing replica with uninitialized desc: %s", desc)
-	}
-
-	r.setDescLockedRaftMuLocked(ctx, desc)
-	r.setStartKeyLocked(desc.StartKey)
-
-	// Unquiesce the replica. We don't allow uninitialized replicas to unquiesce,
-	// but now that the replica has been initialized, we unquiesce it as soon as
-	// possible. This replica was initialized in response to the reception of a
-	// snapshot from another replica. This means that the other replica is not
-	// quiesced, so we don't need to campaign or wake the leader. We just want
-	// to start ticking.
-	//
-	// NOTE: The fact that this replica is being initialized in response to the
-	// receipt of a snapshot means that its r.mu.internalRaftGroup must not be
-	// nil.
-	//
-	// NOTE: Unquiescing the replica here is not strictly necessary. As of the
-	// time of writing, this function is only ever called below handleRaftReady,
-	// which will always unquiesce any eligible replicas before completing. So in
-	// marking this replica as initialized, we have made it eligible to unquiesce.
-	// However, there is still a benefit to unquiecing here instead of letting
-	// handleRaftReady do it for us. The benefit is that handleRaftReady cannot
-	// make assumptions about the state of the other replicas in the range when it
-	// unquieces a replica, so when it does so, it also instructs the replica to
-	// campaign and to wake the leader (see maybeUnquiesceAndWakeLeaderLocked).
-	// We have more information here (see "This means that the other replica ..."
-	// above) and can make assumptions about the state of the other replicas in
-	// the range, so we can unquiesce without campaigning or waking the leader.
-	if !r.maybeUnquiesceWithOptionsLocked(false /* campaignOnWake */) {
-		return errors.AssertionFailedf("expected replica %s to unquiesce after initialization", desc)
-	}
-
-	return nil
-}
-
 // markReplicaInitializedLocked updates the Store bookkeeping to reflect that
 // the given replica has transitioned from uninitialized to initialized state.
 // Requires that Store.mu and Replica.mu are locked.

--- a/pkg/kv/kvserver/store_replica_btree_test.go
+++ b/pkg/kv/kvserver/store_replica_btree_test.go
@@ -146,7 +146,7 @@ func TestStoreReplicaBTree_LookupPrecedingAndNextReplica(t *testing.T) {
 func TestStoreReplicaBTree_ReplicaCanBeLockedDuringInsert(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	// Verify that the replica can be locked while being inserted (and removed).
-	// This is important for `Store.maybeMarkReplicaInitializedLockedReplLocked`.
+	// This is important for `Store.markReplicaInitializedLockedReplLocked`.
 	ctx := context.Background()
 	repl := &Replica{}
 	k := roachpb.RKey("a")

--- a/pkg/kv/kvserver/store_split.go
+++ b/pkg/kv/kvserver/store_split.go
@@ -319,17 +319,6 @@ func (s *Store) SplitRange(
 
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	if exRng, ok := s.mu.uninitReplicas[rightDesc.RangeID]; rightReplOrNil != nil && ok {
-		// If we have an uninitialized replica of the new range we require pointer
-		// equivalence with rightRepl. See Store.splitTriggerPostApply().
-		if exRng != rightReplOrNil {
-			log.Fatalf(ctx, "found unexpected uninitialized replica: %s vs %s", exRng, rightReplOrNil)
-		}
-		// NB: We only remove from uninitReplicas here so that we don't leave open a
-		// window where a replica is temporarily not present in Store.mu.replicas.
-		delete(s.mu.uninitReplicas, rightDesc.RangeID)
-	}
-
 	leftRepl.setDescRaftMuLocked(ctx, newLeftDesc)
 
 	// Clear the LHS lock and txn wait-queues, to redirect to the RHS if
@@ -339,35 +328,27 @@ func (s *Store) SplitRange(
 	leftRepl.concMgr.OnRangeSplit()
 
 	if rightReplOrNil == nil {
-		// There is no rhs replica, so instead halve the load of the lhs
-		// replica.
+		// There is no RHS replica, so (heuristically) halve the load stats for the
+		// LHS, instead of splitting it between LHS and RHS.
 		throwawayRightStats := load.NewReplicaLoad(s.Clock(), nil)
 		leftRepl.loadStats.Split(throwawayRightStats)
-	} else {
-		rightRepl := rightReplOrNil
-		// Split the replica load of the lhs evenly (50:50) with the rhs. NB:
-		// that this ignores the split point and makes as simplifying
-		// assumption that distribution across all tracked load stats is
-		// identical.
-		leftRepl.loadStats.Split(rightRepl.loadStats)
-		rightRepl.mu.RLock()
-		if err := s.addToReplicasByKeyLockedReplicaRLocked(rightRepl); err != nil {
-			rightRepl.mu.RUnlock()
-			return errors.Wrapf(err, "unable to add replica %v", rightRepl)
-		}
-		rightRepl.mu.RUnlock()
+		return nil
+	}
+	rightRepl := rightReplOrNil
 
-		// Update the replica's cached byte thresholds. This is a no-op if the system
-		// config is not available, in which case we rely on the next gossip update
-		// to perform the update.
-		if err := rightRepl.updateRangeInfo(ctx, rightDesc); err != nil {
-			return err
-		}
+	// Split the replica load of the LHS evenly (50:50) with the RHS. NB: this
+	// ignores the split point, and makes as simplifying assumption that
+	// distribution across all tracked load stats is identical.
+	leftRepl.loadStats.Split(rightRepl.loadStats)
 
-		// Add the range to metrics and maybe gossip on capacity change.
-		s.metrics.ReplicaCount.Inc(1)
-		s.storeGossip.MaybeGossipOnCapacityChange(ctx, RangeAddEvent)
+	// Update the replica's cached byte thresholds. This is a no-op if the system
+	// config is not available, in which case we rely on the next gossip update to
+	// perform the update.
+	if err := rightRepl.updateRangeInfo(ctx, rightDesc); err != nil {
+		return err
 	}
 
-	return nil
+	rightRepl.mu.RLock()
+	defer rightRepl.mu.RUnlock()
+	return s.markReplicaInitializedLockedReplLocked(ctx, rightRepl)
 }


### PR DESCRIPTION
This PR further increases code sharing between the two replica initialization paths: split trigger and snapshot application. It also improves readability of these paths.

Touches #94912