### PR TITLE
kvserver: fix locking before addToReplicasByKey*

### DIFF
--- a/pkg/kv/kvserver/replica_consistency_test.go
+++ b/pkg/kv/kvserver/replica_consistency_test.go
@@ -98,6 +98,10 @@ func TestStoreCheckpointSpans(t *testing.T) {
 	addReplica := func(rangeID roachpb.RangeID, start, end string) {
 		desc := makeDesc(rangeID, start, end)
 		r := &Replica{RangeID: rangeID, startKey: desc.StartKey}
+		// NB: locking is unnecessary during Replica creation, but this is to work
+		// around the mutex hold asserts in "Locked" methods below.
+		r.mu.Lock()
+		defer r.mu.Unlock()
 		r.mu.state.Desc = &desc
 		r.isInitialized.Set(desc.IsInitialized())
 		require.NoError(t, s.addToReplicasByRangeIDLocked(r))

--- a/pkg/kv/kvserver/store.go
+++ b/pkg/kv/kvserver/store.go
@@ -1893,7 +1893,7 @@ func (s *Store) Start(ctx context.Context, stopper *stop.Stopper) error {
 		err = s.addToReplicasByRangeIDLocked(rep)
 		if err == nil {
 			// NB: no locking of the Replica is needed since it's being created, but
-			// just in case.
+			// it is asserted on in "Locked" methods.
 			rep.mu.RLock()
 			err = s.addToReplicasByKeyLockedReplicaRLocked(rep)
 			rep.mu.RUnlock()


### PR DESCRIPTION
This commit fixes test failures under `--race` which see `r.mu` not locked in methods that require it. The mutex lock wasn't necessary during `struct` creation, but now is done to work around the test failures.

Release note: none
Epic: none