### PR TITLE
kvserver: fix rebalance obj test on arm mac

### DIFF
--- a/pkg/kv/kvserver/BUILD.bazel
+++ b/pkg/kv/kvserver/BUILD.bazel
@@ -430,6 +430,7 @@ go_test(
         "//pkg/util/ctxgroup",
         "//pkg/util/encoding",
         "//pkg/util/errorutil",
+        "//pkg/util/grunning",
         "//pkg/util/hlc",
         "//pkg/util/humanizeutil",
         "//pkg/util/leaktest",


### PR DESCRIPTION
Previosly,`TestRebalanceObjectiveManager` and
`TestLoadBasedRebalancingObjective` would assert assuming that it was possible for the test host to use `grunning`, however this is not true for ARM Mac.

This patch ammends these tests to test a subset of behavior when `grunning` isn't supported and then exit.

Fixes: #96934

Release note: None