### PR TITLE
release-22.1: backport disk-stalled roachtest changes

### DIFF
--- a/pkg/cmd/roachtest/tests/decommission.go
+++ b/pkg/cmd/roachtest/tests/decommission.go
@@ -415,7 +415,11 @@ func runDecommission(
 				return err
 			}
 			startOpts := option.DefaultStartOpts()
-			startOpts.RoachprodOpts.ExtraArgs = append(startOpts.RoachprodOpts.ExtraArgs, fmt.Sprintf("--join %s --attrs=node%d", internalAddrs[0], node))
+			extraArgs := []string{
+				"--join", internalAddrs[0],
+				fmt.Sprintf("--attrs=node%d", node),
+			}
+			startOpts.RoachprodOpts.ExtraArgs = append(startOpts.RoachprodOpts.ExtraArgs, extraArgs...)
 			if err := c.StartE(ctx, t.L(), startOpts, install.MakeClusterSettings(), c.Node(node)); err != nil {
 				return err
 			}
@@ -914,7 +918,10 @@ func runDecommissionRandomized(ctx context.Context, t test.Test, c cluster.Clust
 			}
 			joinAddr := internalAddrs[0]
 			startOpts := option.DefaultStartOpts()
-			startOpts.RoachprodOpts.ExtraArgs = append(startOpts.RoachprodOpts.ExtraArgs, fmt.Sprintf("--join %s", joinAddr))
+			startOpts.RoachprodOpts.ExtraArgs = append(
+				startOpts.RoachprodOpts.ExtraArgs,
+				[]string{"--join", joinAddr}...,
+			)
 			c.Start(ctx, t.L(), startOpts, install.MakeClusterSettings(), c.Node(targetNode))
 		}
 

--- a/pkg/cmd/roachtest/tests/disk_stall.go
+++ b/pkg/cmd/roachtest/tests/disk_stall.go
@@ -15,125 +15,427 @@ import (
 	"fmt"
 	"math/rand"
 	"runtime"
+	"strconv"
 	"strings"
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/registry"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/spec"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/test"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/install"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+	"github.com/stretchr/testify/require"
 )
 
-// RegisterDiskStalledDetection registers the disk stall test.
-func RegisterDiskStalledDetection(r registry.Registry) {
-	for _, affectsLogDir := range []bool{false, true} {
-		for _, affectsDataDir := range []bool{false, true} {
+// registerDiskStalledDetection registers the disk stall test.
+func registerDiskStalledDetection(r registry.Registry) {
+	stallers := map[string]func(test.Test, cluster.Cluster) diskStaller{
+		"dmsetup": func(t test.Test, c cluster.Cluster) diskStaller { return &dmsetupDiskStaller{t: t, c: c} },
+		"cgroup/read-write/logs-too=false": func(t test.Test, c cluster.Cluster) diskStaller {
+			return &cgroupDiskStaller{t: t, c: c, readOrWrite: []string{"write", "read"}}
+		},
+		"cgroup/read-write/logs-too=true": func(t test.Test, c cluster.Cluster) diskStaller {
+			return &cgroupDiskStaller{t: t, c: c, readOrWrite: []string{"write", "read"}, logsToo: true}
+		},
+		"cgroup/write-only/logs-too=true": func(t test.Test, c cluster.Cluster) diskStaller {
+			return &cgroupDiskStaller{t: t, c: c, readOrWrite: []string{"write"}, logsToo: true}
+		},
+	}
+	for name, makeStaller := range stallers {
+		name, makeStaller := name, makeStaller
+		r.Add(registry.TestSpec{
+			Name:    fmt.Sprintf("disk-stalled/%s", name),
+			Owner:   registry.OwnerStorage,
+			Cluster: r.MakeClusterSpec(4),
+			Timeout: 20 * time.Minute,
+			Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
+				runDiskStalledDetection(ctx, t, c, makeStaller(t, c))
+			},
+			// Encryption is implemented within the virtual filesystem layer,
+			// just like disk-health monitoring. It's important to exercise
+			// encryption-at-rest to ensure there is not unmonitored I/O within
+			// the encryption-at-rest implementation that could indefinitely
+			// stall the process during a disk stall.
+			EncryptionSupport: registry.EncryptionMetamorphic,
+		})
+	}
+
+	for _, stallLogDir := range []bool{false, true} {
+		for _, stallDataDir := range []bool{false, true} {
 			// Grab copies of the args because we'll pass them into a closure.
 			// Everyone's favorite bug to write in Go.
-			affectsLogDir := affectsLogDir
-			affectsDataDir := affectsDataDir
+			stallLogDir := stallLogDir
+			stallDataDir := stallDataDir
 			r.Add(registry.TestSpec{
+				Skip:        "#95886",
+				SkipDetails: "The test current only induces a 50us disk-stall, which cannot be reliably detected.",
 				Name: fmt.Sprintf(
-					"disk-stalled/log=%t,data=%t",
-					affectsLogDir, affectsDataDir,
+					"disk-stalled/fuse/log=%t,data=%t",
+					stallLogDir, stallDataDir,
 				),
 				Owner:   registry.OwnerStorage,
-				Cluster: r.MakeClusterSpec(1),
+				Cluster: r.MakeClusterSpec(4),
 				Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
-					runDiskStalledDetection(ctx, t, c, affectsLogDir, affectsDataDir)
+					runDiskStalledDetection(ctx, t, c, &fuseDiskStaller{
+						t:         t,
+						c:         c,
+						stallLogs: stallLogDir,
+						stallData: stallDataDir,
+					})
 				},
+				EncryptionSupport: registry.EncryptionMetamorphic,
 			})
 		}
 	}
 }
 
-func runDiskStalledDetection(
-	ctx context.Context, t test.Test, c cluster.Cluster, affectsLogDir bool, affectsDataDir bool,
-) {
-	if c.IsLocal() && runtime.GOOS != "linux" {
-		t.Fatalf("must run on linux os, found %s", runtime.GOOS)
-	}
+func runDiskStalledDetection(ctx context.Context, t test.Test, c cluster.Cluster, s diskStaller) {
+	const maxSyncDur = 10 * time.Second
+	startOpts := option.DefaultStartOpts()
+	startSettings := install.MakeClusterSettings()
+	startSettings.Env = append(startSettings.Env,
+		"COCKROACH_AUTO_BALLAST=false",
+		fmt.Sprintf("COCKROACH_LOG_MAX_SYNC_DURATION=%s", maxSyncDur),
+		fmt.Sprintf("COCKROACH_ENGINE_MAX_SYNC_DURATION_DEFAULT=%s", maxSyncDur))
 
-	n := c.Node(1)
+	t.Status("setting up disk staller")
+	s.Setup(ctx)
+	defer s.Cleanup(ctx)
 
+	t.Status("starting cluster")
 	c.Put(ctx, t.Cockroach(), "./cockroach")
-	c.Run(ctx, n, "sudo umount -f {store-dir}/faulty || true")
-	c.Run(ctx, n, "mkdir -p {store-dir}/{real,faulty} || true")
-	// Make sure the actual logs are downloaded as artifacts.
-	c.Run(ctx, n, "rm -f logs && ln -s {store-dir}/real/logs logs || true")
+	c.Start(ctx, t.L(), startOpts, startSettings, c.Range(1, 3))
 
-	t.Status("setting up charybdefs")
-
-	if err := c.Install(ctx, t.L(), n, "charybdefs"); err != nil {
-		t.Fatal(err)
+	// Assert the process monotonic times are as expected.
+	start, ok := getProcessStartMonotonic(ctx, t, c, 1)
+	if !ok {
+		t.Fatal("unable to retrieve process start time; did Cockroach not start?")
 	}
-	c.Run(ctx, n, "sudo charybdefs {store-dir}/faulty -oallow_other,modules=subdir,subdir={store-dir}/real")
-	c.Run(ctx, n, "sudo mkdir -p {store-dir}/real/logs")
-	c.Run(ctx, n, "sudo chmod -R 777 {store-dir}/{real,faulty}")
-
-	errCh := make(chan install.RunResultDetails)
-
-	// NB: charybdefs' delay nemesis introduces 50ms per syscall. It would
-	// be nicer to introduce a longer delay, but this works.
-	tooShortSync := 40 * time.Millisecond
-
-	maxLogSync := time.Hour
-	logDir := "real/logs"
-	if affectsLogDir {
-		logDir = "faulty/logs"
-		maxLogSync = tooShortSync
-	}
-	maxDataSync := time.Hour
-	dataDir := "real"
-	if affectsDataDir {
-		maxDataSync = tooShortSync
-		dataDir = "faulty"
+	if exit, exitOk := getProcessExitMonotonic(ctx, t, c, 1); exitOk {
+		t.Fatalf("process has an exit monotonic time of %d; did Cockroach already exit?", exit)
 	}
 
-	tStarted := timeutil.Now()
-	dur := 10 * time.Minute
-	if !affectsDataDir && !affectsLogDir {
-		dur = 30 * time.Second
+	adminUIAddrs, err := c.ExternalAdminUIAddr(ctx, t.L(), c.Nodes(2))
+	require.NoError(t, err)
+	adminURL := adminUIAddrs[0]
+
+	c.Run(ctx, c.Node(4), `./cockroach workload init kv --splits 1000 {pgurl:1}`)
+	// Open SQL connections—one to n1, the node that will be stalled, and one to
+	// n2 that should remain open and active for the remainder.
+	n1Conn := c.Conn(ctx, t.L(), 1)
+	defer n1Conn.Close()
+	n2conn := c.Conn(ctx, t.L(), 2)
+	defer n2conn.Close()
+	require.NoError(t, n1Conn.PingContext(ctx))
+	_, err = n2conn.ExecContext(ctx, `USE kv;`)
+	require.NoError(t, err)
+
+	// Wait for upreplication.
+	require.NoError(t, WaitFor3XReplication(ctx, t, n2conn))
+
+	t.Status("starting workload")
+	workloadStartAt := timeutil.Now()
+	m := c.NewMonitor(ctx, c.Range(1, 3))
+	m.Go(func(ctx context.Context) error {
+		c.Run(ctx, c.Node(4), `./cockroach workload run kv --read-percent 50 `+
+			`--duration 10m --concurrency 256 --max-rate 2048 --tolerate-errors `+
+			` --min-block-bytes=512 --max-block-bytes=512 `+
+			`{pgurl:1-3}`)
+		return nil
+	})
+
+	// Wait between [3m,6m) before stalling the disk.
+	pauseDur := 3*time.Minute + time.Duration(rand.Intn(3))*time.Minute
+	pauseBeforeStall := time.After(pauseDur)
+	t.Status("pausing ", pauseDur, " before inducing write stall")
+	select {
+	case <-ctx.Done():
+		t.Fatalf("context done before stall: %s", ctx.Err())
+	case <-pauseBeforeStall:
 	}
 
-	go func() {
-		t.WorkerStatus("running server")
-		result, err := c.RunWithDetailsSingleNode(ctx, t.L(), n,
-			fmt.Sprintf("timeout --signal 9 %ds env "+
-				"COCKROACH_ENGINE_MAX_SYNC_DURATION_DEFAULT=%s "+
-				"COCKROACH_LOG_MAX_SYNC_DURATION=%s "+
-				"COCKROACH_AUTO_BALLAST=false "+
-				"./cockroach start-single-node --insecure --store {store-dir}/%s --log '{sinks: {stderr: {filter: INFO}}, file-defaults: {dir: \"{store-dir}/%s\"}}'",
-				int(dur.Seconds()), maxDataSync, maxLogSync, dataDir, logDir,
-			),
-		)
-		if err != nil {
-			result.Err = err
+	stallAt := timeutil.Now()
+	response := mustGetMetrics(t, adminURL, workloadStartAt, stallAt, []tsQuery{
+		{name: "cr.node.txn.commits", queryType: total},
+	})
+	cum := response.Results[0].Datapoints
+	totalTxnsPreStall := cum[len(cum)-1].Value - cum[0].Value
+	t.L().PrintfCtx(ctx, "%.2f transactions completed before stall", totalTxnsPreStall)
+
+	t.Status("inducing write stall")
+	m.ExpectDeath()
+	s.Stall(ctx, c.Node(1))
+	defer s.Unstall(ctx, c.Node(1))
+
+	// Wait twice the maximum sync duration and check if our SQL connection to
+	// node 1 is still alive. It should've been terminated.
+	{
+		t.Status("waiting ", 2*maxSyncDur, " before checking SQL conn to n1")
+		select {
+		case <-ctx.Done():
+			t.Fatal(ctx.Err())
+		case <-time.After(2 * maxSyncDur):
 		}
-		errCh <- result
-	}()
-
-	time.Sleep(time.Duration(rand.Intn(5)) * time.Second)
-
-	t.Status("blocking storage")
-	c.Run(ctx, n, "charybdefs-nemesis --delay")
-
-	result := <-errCh
-	if result.Err == nil {
-		t.Fatalf("expected an error: %s", result.Stdout)
+		t.Status("pinging SQL connection to n1")
+		err := n1Conn.PingContext(ctx)
+		t.L().PrintfCtx(ctx, "pinging n1's connection: %s", err)
+		if err == nil {
+			t.Fatal("connection to n1 is still alive")
+		}
 	}
 
-	// This test can also run in sanity check mode to make sure it doesn't fail
-	// due to the aggressive env vars above.
-	expectMsg := affectsDataDir || affectsLogDir
-
-	if expectMsg != strings.Contains(result.Stderr, "disk stall detected") {
-		t.Fatalf("unexpected output: %v", result.Err)
-	} else if elapsed := timeutil.Since(tStarted); !expectMsg && elapsed < dur {
-		t.Fatalf("no disk stall injected, but process terminated too early after %s (expected >= %s)", elapsed, dur)
+	// Let the workload continue after the stall.
+	{
+		workloadPauseDur := 10*time.Minute - timeutil.Since(workloadStartAt)
+		t.Status("letting workload continue for ", workloadPauseDur, " with n1 stalled")
+		select {
+		case <-ctx.Done():
+			t.Fatal(ctx.Err())
+		case <-time.After(workloadPauseDur):
+		}
 	}
 
-	c.Run(ctx, n, "charybdefs-nemesis --clear")
-	c.Run(ctx, n, "sudo umount {store-dir}/faulty")
+	{
+		now := timeutil.Now()
+		response := mustGetMetrics(t, adminURL, workloadStartAt, now, []tsQuery{
+			{name: "cr.node.txn.commits", queryType: total},
+		})
+		cum := response.Results[0].Datapoints
+		totalTxnsPostStall := cum[len(cum)-1].Value - totalTxnsPreStall
+		preStallTPS := totalTxnsPreStall / stallAt.Sub(workloadStartAt).Seconds()
+		postStallTPS := totalTxnsPostStall / now.Sub(stallAt).Seconds()
+		t.L().PrintfCtx(ctx, "%.2f total transactions committed after stall\n", totalTxnsPostStall)
+		t.L().PrintfCtx(ctx, "pre-stall tps: %.2f, post-stall tps: %.2f\n", preStallTPS, postStallTPS)
+		if postStallTPS < preStallTPS/2 {
+			t.Fatalf("post-stall TPS %.2f is less than 50%% of pre-stall TPS %.2f", postStallTPS, preStallTPS)
+		}
+	}
+
+	{
+		t.Status("counting kv rows")
+		var rowCount int
+		require.NoError(t, n2conn.QueryRowContext(ctx, `SELECT count(v) FROM kv`).Scan(&rowCount))
+		t.L().PrintfCtx(ctx, "Scan found %d rows.\n", rowCount)
+	}
+
+	// Unstall the stalled node. It should be able to be reaped.
+	s.Unstall(ctx, c.Node(1))
+	time.Sleep(1 * time.Second)
+	exit, ok := getProcessExitMonotonic(ctx, t, c, 1)
+	if !ok {
+		t.Fatalf("unable to retrieve process exit time; stall went undetected")
+	}
+	t.L().PrintfCtx(ctx, "node exited at %s after test start\n", exit-start)
+}
+
+func getProcessStartMonotonic(
+	ctx context.Context, t test.Test, c cluster.Cluster, nodeID int,
+) (time.Duration, bool) {
+	return getProcessMonotonicTimestamp(ctx, t, c, nodeID, "ActiveEnterTimestampMonotonic")
+}
+
+func getProcessExitMonotonic(
+	ctx context.Context, t test.Test, c cluster.Cluster, nodeID int,
+) (time.Duration, bool) {
+	return getProcessMonotonicTimestamp(ctx, t, c, nodeID, "ActiveExitTimestampMonotonic")
+}
+
+func getProcessMonotonicTimestamp(
+	ctx context.Context, t test.Test, c cluster.Cluster, nodeID int, prop string,
+) (time.Duration, bool) {
+	details, err := c.RunWithDetailsSingleNode(ctx, t.L(), c.Node(nodeID),
+		"systemctl show cockroach.service --property="+prop)
+	require.NoError(t, err)
+	require.NoError(t, details.Err)
+	parts := strings.Split(details.Stdout, "=")
+	if len(parts) < 2 {
+		return 0, false
+	}
+	s := strings.TrimSpace(parts[1])
+	if s == "" {
+		return 0, false
+	}
+	u, err := strconv.ParseUint(s, 10, 64)
+	if err != nil {
+		t.Fatalf("unable to parse monotonic timestamp %q: %s", parts[1], err)
+	}
+	if u == 0 {
+		return 0, false
+	}
+	return time.Duration(u) * time.Microsecond, true
+}
+
+type diskStaller interface {
+	Setup(ctx context.Context)
+	Cleanup(ctx context.Context)
+	Stall(ctx context.Context, nodes option.NodeListOption)
+	Unstall(ctx context.Context, nodes option.NodeListOption)
+	DataDir() string
+	LogDir() string
+}
+
+type dmsetupDiskStaller struct {
+	t test.Test
+	c cluster.Cluster
+}
+
+var _ diskStaller = (*dmsetupDiskStaller)(nil)
+
+func (s *dmsetupDiskStaller) device() string { return getDevice(s.t, s.c.Spec()) }
+
+func (s *dmsetupDiskStaller) Setup(ctx context.Context) {
+	dev := s.device()
+	s.c.Run(ctx, s.c.All(), `sudo umount /mnt/data1`)
+	s.c.Run(ctx, s.c.All(), `sudo dmsetup remove_all`)
+	s.c.Run(ctx, s.c.All(), `echo "0 $(sudo blockdev --getsz `+dev+`) linear `+dev+` 0" | `+
+		`sudo dmsetup create data1`)
+	s.c.Run(ctx, s.c.All(), `sudo mount /dev/mapper/data1 /mnt/data1`)
+}
+
+func (s *dmsetupDiskStaller) Cleanup(ctx context.Context) {
+	s.c.Run(ctx, s.c.All(), `sudo umount /mnt/data1`)
+	s.c.Run(ctx, s.c.All(), `sudo dmsetup remove_all`)
+	s.c.Run(ctx, s.c.All(), `sudo mount /mnt/data1`)
+}
+
+func (s *dmsetupDiskStaller) Stall(ctx context.Context, nodes option.NodeListOption) {
+	s.c.Run(ctx, nodes, `sudo dmsetup suspend --noflush --nolockfs data1`)
+}
+
+func (s *dmsetupDiskStaller) Unstall(ctx context.Context, nodes option.NodeListOption) {
+	s.c.Run(ctx, nodes, `sudo dmsetup resume data1`)
+}
+
+func (s *dmsetupDiskStaller) DataDir() string { return "{store-dir}" }
+func (s *dmsetupDiskStaller) LogDir() string  { return "logs" }
+
+type cgroupDiskStaller struct {
+	t           test.Test
+	c           cluster.Cluster
+	readOrWrite []string
+	logsToo     bool
+}
+
+var _ diskStaller = (*cgroupDiskStaller)(nil)
+
+func (s *cgroupDiskStaller) DataDir() string { return "{store-dir}" }
+func (s *cgroupDiskStaller) LogDir() string {
+	return "logs"
+}
+func (s *cgroupDiskStaller) Setup(ctx context.Context) {
+	if s.logsToo {
+		s.c.Run(ctx, s.c.All(), "mkdir -p {store-dir}/logs")
+		s.c.Run(ctx, s.c.All(), "rm -f logs && ln -s {store-dir}/logs logs || true")
+	}
+}
+func (s *cgroupDiskStaller) Cleanup(ctx context.Context) {}
+
+func (s *cgroupDiskStaller) Stall(ctx context.Context, nodes option.NodeListOption) {
+	// Shuffle the order of read and write stall initiation.
+	rand.Shuffle(len(s.readOrWrite), func(i, j int) {
+		s.readOrWrite[i], s.readOrWrite[j] = s.readOrWrite[j], s.readOrWrite[i]
+	})
+	for _, rw := range s.readOrWrite {
+		s.setThroughput(ctx, nodes, rw, 1)
+	}
+}
+
+func (s *cgroupDiskStaller) Unstall(ctx context.Context, nodes option.NodeListOption) {
+	for _, rw := range s.readOrWrite {
+		s.setThroughput(ctx, nodes, rw, 0)
+	}
+}
+
+func (s *cgroupDiskStaller) device() (major, minor int) {
+	// TODO(jackson): Programmatically determine the device major,minor numbers.
+	// eg,:
+	//    deviceName := getDevice(s.t, s.c.Spec())
+	//    `cat /proc/partitions` and find `deviceName`
+	switch s.c.Spec().Cloud {
+	case spec.GCE:
+		// ls -l /dev/nvme0n1
+		// brw-rw---- 1 root disk 259, 0 Jan 26 20:05 /dev/nvme0n1
+		return 259, 0
+	default:
+		s.t.Fatalf("unsupported cloud %q", s.c.Spec().Cloud)
+		return 0, 0
+	}
+}
+
+func (s *cgroupDiskStaller) setThroughput(
+	ctx context.Context, nodes option.NodeListOption, readOrWrite string, bytesPerSecond int,
+) {
+	major, minor := s.device()
+	s.c.Run(ctx, nodes, "sudo", "/bin/bash", "-c", fmt.Sprintf(
+		"'echo %d:%d %d > /sys/fs/cgroup/blkio/blkio.throttle.%s_bps_device'",
+		major,
+		minor,
+		bytesPerSecond,
+		readOrWrite,
+	))
+}
+
+// fuseDiskStaller uses a FUSE filesystem (charybdefs) to insert an artifical
+// delay on all I/O.
+type fuseDiskStaller struct {
+	t         test.Test
+	c         cluster.Cluster
+	stallLogs bool
+	stallData bool
+}
+
+var _ diskStaller = (*fuseDiskStaller)(nil)
+
+func (s *fuseDiskStaller) DataDir() string {
+	if s.stallData {
+		return "{store-dir}/faulty"
+	}
+	return "{store-dir}/real"
+}
+
+func (s *fuseDiskStaller) LogDir() string {
+	if s.stallLogs {
+		return "{store-dir}/faulty/logs"
+	}
+	return "{store-dir}/real/logs"
+}
+
+func (s *fuseDiskStaller) Setup(ctx context.Context) {
+	if s.c.IsLocal() && runtime.GOOS != "linux" {
+		s.t.Fatalf("must run on linux os, found %s", runtime.GOOS)
+	}
+	s.t.Status("setting up charybdefs")
+	require.NoError(s.t, s.c.Install(ctx, s.t.L(), s.c.All(), "charybdefs"))
+	s.c.Run(ctx, s.c.All(), "sudo umount -f {store-dir}/faulty || true")
+	s.c.Run(ctx, s.c.All(), "mkdir -p {store-dir}/{real,faulty} || true")
+	s.c.Run(ctx, s.c.All(), "rm -f logs && ln -s {store-dir}/real/logs logs || true")
+	s.c.Run(ctx, s.c.All(), "sudo charybdefs {store-dir}/faulty -oallow_other,modules=subdir,subdir={store-dir}/real")
+	s.c.Run(ctx, s.c.All(), "sudo mkdir -p {store-dir}/real/logs")
+	s.c.Run(ctx, s.c.All(), "sudo chmod -R 777 {store-dir}/{real,faulty}")
+}
+
+func (s *fuseDiskStaller) Cleanup(ctx context.Context) {
+	s.c.Run(ctx, s.c.All(), "sudo umount {store-dir}/faulty")
+}
+
+func (s *fuseDiskStaller) Stall(ctx context.Context, nodes option.NodeListOption) {
+	s.c.Run(ctx, nodes, "charybdefs-nemesis --delay")
+}
+
+func (s *fuseDiskStaller) Unstall(ctx context.Context, nodes option.NodeListOption) {
+	s.c.Run(ctx, nodes, "charybdefs-nemesis --clear")
+}
+
+func getDevice(t test.Test, s spec.ClusterSpec) string {
+	switch s.Cloud {
+	case spec.GCE:
+		return "/dev/nvme0n1"
+	case spec.AWS:
+		return "/dev/nvme1n1"
+	default:
+		t.Fatalf("unsupported cloud %q", s.Cloud)
+		return ""
+	}
 }

--- a/pkg/cmd/roachtest/tests/registry.go
+++ b/pkg/cmd/roachtest/tests/registry.go
@@ -32,7 +32,7 @@ func RegisterTests(r registry.Registry) {
 	registerCopy(r)
 	registerDecommission(r)
 	registerDiskFull(r)
-	RegisterDiskStalledDetection(r)
+	registerDiskStalledDetection(r)
 	registerDjango(r)
 	registerDrain(r)
 	registerDrop(r)

--- a/pkg/roachprod/install/cockroach.go
+++ b/pkg/roachprod/install/cockroach.go
@@ -105,7 +105,11 @@ func argExists(args []string, target string) int {
 type StartOpts struct {
 	Target     StartTarget
 	Sequential bool
-	ExtraArgs  []string
+	// ExtraArgs are extra arguments used when starting the node. Multiple
+	// arguments should be passed as separate items in the slice. For example:
+	//   Instead of: []string{"--flag foo bar"}
+	//   Use:        []string{"--flag", "foo", "bar"}
+	ExtraArgs []string
 
 	// systemd limits on resources.
 	NumFilesLimit int64
@@ -558,7 +562,7 @@ func (c *SyncedCluster) generateStartArgs(
 		if err != nil {
 			return nil, err
 		}
-		args = append(args, strings.Split(expandedArg, " ")...)
+		args = append(args, expandedArg)
 	}
 
 	return args, nil

--- a/pkg/roachprod/install/cockroach.go
+++ b/pkg/roachprod/install/cockroach.go
@@ -418,10 +418,14 @@ func (c *SyncedCluster) generateStartCmd(
 	if err != nil {
 		return "", err
 	}
+	keyCmd, err := c.generateKeyCmd(ctx, l, node, startOpts)
+	if err != nil {
+		return "", err
+	}
 
 	return execStartTemplate(startTemplateData{
 		LogDir: c.LogDir(node),
-		KeyCmd: c.generateKeyCmd(node, startOpts),
+		KeyCmd: keyCmd,
 		EnvVars: append(append([]string{
 			fmt.Sprintf("ROACHPROD=%s", c.roachprodEnvValue(node)),
 			"GOTRACEBACK=crash",
@@ -553,16 +557,18 @@ func (c *SyncedCluster) generateStartArgs(
 		args = append(args, c.generateStartFlagsSQL(node, startOpts, vers)...)
 	}
 
+	args = append(args, startOpts.ExtraArgs...)
+
 	// Argument template expansion is node specific (e.g. for {store-dir}).
 	e := expander{
 		node: node,
 	}
-	for _, arg := range startOpts.ExtraArgs {
+	for i, arg := range args {
 		expandedArg, err := e.expand(ctx, l, c, arg)
 		if err != nil {
 			return nil, err
 		}
-		args = append(args, expandedArg)
+		args[i] = expandedArg
 	}
 
 	return args, nil
@@ -585,9 +591,14 @@ func (c *SyncedCluster) generateStartFlagsKV(
 			args = append(args, `--store`,
 				`path=`+storeDir+`,attrs=`+fmt.Sprintf("store%d", i))
 		}
-	} else {
+	} else if startOpts.ExtraArgs[idx] == "--store=" {
+		// The flag and path were provided together. Strip the flag prefix.
 		storeDir := strings.TrimPrefix(startOpts.ExtraArgs[idx], "--store=")
 		storeDirs = append(storeDirs, storeDir)
+	} else {
+		// Else, the store flag and path were specified as separate arguments. The
+		// path is the subsequent arg.
+		storeDirs = append(storeDirs, startOpts.ExtraArgs[idx+1])
 	}
 
 	if startOpts.EncryptedStores {
@@ -718,9 +729,11 @@ func (c *SyncedCluster) generateInitCmd(node Node) string {
 	return initCmd
 }
 
-func (c *SyncedCluster) generateKeyCmd(node Node, startOpts StartOpts) string {
+func (c *SyncedCluster) generateKeyCmd(
+	ctx context.Context, l *logger.Logger, node Node, startOpts StartOpts,
+) (string, error) {
 	if !startOpts.EncryptedStores {
-		return ""
+		return "", nil
 	}
 
 	var storeDirs []string
@@ -729,9 +742,14 @@ func (c *SyncedCluster) generateKeyCmd(node Node, startOpts StartOpts) string {
 			storeDir := c.NodeDir(node, i)
 			storeDirs = append(storeDirs, storeDir)
 		}
-	} else {
+	} else if startOpts.ExtraArgs[storeArgIdx] == "--store=" {
+		// The flag and path were provided together. Strip the flag prefix.
 		storeDir := strings.TrimPrefix(startOpts.ExtraArgs[storeArgIdx], "--store=")
 		storeDirs = append(storeDirs, storeDir)
+	} else {
+		// Else, the store flag and path were specified as separate arguments. The
+		// path is the subsequent arg.
+		storeDirs = append(storeDirs, startOpts.ExtraArgs[storeArgIdx+1])
 	}
 
 	// Command to create the store key.
@@ -743,7 +761,13 @@ func (c *SyncedCluster) generateKeyCmd(node Node, startOpts StartOpts) string {
 				openssl rand -out %[1]s/aes-128.key 48;
 			fi;`, storeDir)
 	}
-	return keyCmd.String()
+
+	e := expander{node: node}
+	expanded, err := e.expand(ctx, l, c, keyCmd.String())
+	if err != nil {
+		return "", err
+	}
+	return expanded, nil
 }
 
 func (c *SyncedCluster) useStartSingleNode() bool {

--- a/pkg/roachprod/install/install.go
+++ b/pkg/roachprod/install/install.go
@@ -54,8 +54,7 @@ sudo service cassandra stop;
     sudo rm -rf "${charybde_dir}" "${nemesis_path}" /usr/local/bin/charybdefs{,-nemesis}
     sudo mkdir -p "${charybde_dir}"
     sudo chmod 777 "${charybde_dir}"
-    # TODO(bilal): Change URL back to scylladb/charybdefs once https://github.com/scylladb/charybdefs/pull/28 is merged.
-    git clone --depth 1 "https://github.com/itsbilal/charybdefs.git" "${charybde_dir}"
+    git clone --depth 1 --branch crl "https://github.com/cockroachdb/charybdefs.git" "${charybde_dir}"
 
     cd "${charybde_dir}"
     thrift -r --gen cpp server.thrift


### PR DESCRIPTION
Backport of #95865, #96092, and #96094 to `release-22.1`.

Note that the `failover` roachtest was _not_ backported.

Fixes #96850.

Fixes #96848.

Release justification: Test only.

---

**cmd/roachtest: adapt disk-stall detection roachtest**

Move the existing disk-stall/* roachtests under disk-stall/fuse/* (for the FUSE
filesystem approach to stalling) and skip them for now. Currently, they're not
capable of stalling the disk longer 50us (see https://github.com/cockroachdb/cockroach/issues/95886), which makes them
unreliable at exercising stalls.

Add two new roachtests, disk-stall/dmsetup and disk-stall/cgroup that use
dmsetup and cgroup bandwidth restrctions respectively to reliably induce a
write stall for an indefinite duration.

Informs https://github.com/cockroachdb/cockroach/issues/94373.
Epic: None
Release note: None

**roachprod: remove string splitting logic for arguments**

Currently, if `ExtraArgs` (a `[]string`) is specified for the start
options for a cluster, and an argument in the slice contains whitespace,
the argument will be split into sub-arguments.

This results in situations where an argument intended to be interpreted
as a literal string is split into separate arguments. E.g.

```
ExtraArgs = []{"'foo bar baz'"} // becomes "'foo" "bar" "baz'"
```

Remove the string splitting logic, instead relying on callers to specify
arguments as already "pre-split".

Update two existing usages of `ExtraArgs` to pre-split the arguments.

Improve documentation.

Release note: None.

**roachtest: unskip fuse disk-stall roachtest variant**

The `fuse` variant of the `disk-stalled` roachtest was skipped in
\https://github.com/cockroachdb/cockroach/pull/95865.

Re-enable the skipped variant, updating it to make use of our forked
version of `charybdefs`. This fork includes a patch that allows for
specifying a delay time for syscalls, making it possible to simulate a
complete disk stall. Previously, delay times were limited to 50ms, which
meant that the detection time had to be even lower (e.g. 40ms), which
was not representative of how Cockroach is configured in practice.

Allow the roachprod infrastructure to interpolate strings such as
`{store-dir}`, etc. when provided as `ExtraArgs` or the `KeyCmd`. Fix by
expanding expanding all args, rather than just `ExtraArgs`.

Fixes https://github.com/cockroachdb/cockroach/issues/95874.

Release note: None.