### PR TITLE
sql: fix SHOW GRANTS FOR public

### DIFF
--- a/pkg/sql/delegate/show_grants.go
+++ b/pkg/sql/delegate/show_grants.go
@@ -377,9 +377,16 @@ SELECT database_name,
 		if err != nil {
 			return nil, err
 		}
-		userExists, err := d.catalog.RoleExists(d.ctx, user)
-		if err != nil {
-			return nil, err
+		// The `public` role is a pseudo-role, so we check it separately. RoleExists
+		// should not return true for `public` since other operations like GRANT and
+		// REVOKE should fail with a "role `public` does not exist" error if they
+		// are used with `public`.
+		userExists := user.IsPublicRole()
+		if !userExists {
+			userExists, err = d.catalog.RoleExists(d.ctx, user)
+			if err != nil {
+				return nil, err
+			}
 		}
 		if !userExists {
 			return nil, sqlerrors.NewUndefinedUserError(user)

--- a/pkg/sql/logictest/testdata/logic_test/grant_revoke_with_grant_option
+++ b/pkg/sql/logictest/testdata/logic_test/grant_revoke_with_grant_option
@@ -7,6 +7,19 @@ CREATE USER testuser2
 statement ok
 CREATE USER target
 
+# Check privileges that `public` has by default, ignoring types and virtual tables.
+query TTTTTB colnames
+SELECT * FROM [SHOW GRANTS FOR public] WHERE relation_name IS NULL
+----
+database_name  schema_name         relation_name  grantee  privilege_type  is_grantable
+test           crdb_internal       NULL           public   USAGE           false
+test           information_schema  NULL           public   USAGE           false
+test           pg_catalog          NULL           public   USAGE           false
+test           pg_extension        NULL           public   USAGE           false
+test           public              NULL           public   CREATE          false
+test           public              NULL           public   USAGE           false
+test           NULL                NULL           public   CONNECT         false
+
 statement error grant options cannot be granted to "public" role
 GRANT ALL PRIVILEGES ON TABLE t TO public WITH GRANT OPTION
 

--- a/pkg/sql/logictest/testdata/logic_test/grant_role
+++ b/pkg/sql/logictest/testdata/logic_test/grant_role
@@ -23,3 +23,12 @@ query B
 SELECT crdb_internal.pb_to_json('cockroach.sql.sqlbase.Descriptor', descriptor)->'table'->>'version' = $role_members_version::STRING FROM system.descriptor WHERE id = 'system.public.role_members'::REGCLASS
 ----
 true
+
+# GRANT or REVOKE on the public role should result in "not exists"
+subtest grant_revoke_public
+
+statement error pgcode 42704 role/user \"public\" does not exist
+GRANT testuser TO public
+
+statement error pgcode 42704 role/user \"public\" does not exist
+REVOKE testuser FROM public

--- a/pkg/sql/logictest/testdata/logic_test/set_role
+++ b/pkg/sql/logictest/testdata/logic_test/set_role
@@ -15,13 +15,13 @@ GRANT ALL ON TABLE testuser.testuser_table TO testuser
 statement error role name "public" is reserved
 CREATE ROLE public
 
-statement error pgcode 22023 role public does not exist
+statement error pgcode 42704 role/user \"public\" does not exist
 SET ROLE public
 
 statement error role name "node" is reserved
 CREATE ROLE node
 
-statement error pgcode 22023 role node does not exist
+statement error pgcode 42704 role/user \"node\" does not exist
 SET ROLE node
 
 # Check root can reset and become itself.
@@ -38,7 +38,7 @@ none
 statement ok
 RESET ROLE
 
-statement error pgcode 22023 role non_existent_user does not exist
+statement error pgcode 42704 role/user \"non_existent_user\" does not exist
 SET ROLE non_existent_user
 
 query TTTT

--- a/pkg/sql/user.go
+++ b/pkg/sql/user.go
@@ -28,6 +28,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessioninit"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlerrors"
 	"github.com/cockroachdb/cockroach/pkg/sql/syntheticprivilege"
 	"github.com/cockroachdb/cockroach/pkg/util/contextutil"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -545,11 +546,7 @@ func (p *planner) setRole(ctx context.Context, local bool, s username.SQLUsernam
 			return err
 		}
 		if !exists {
-			return pgerror.Newf(
-				pgcode.InvalidParameterValue,
-				"role %s does not exist",
-				becomeUser.Normalized(),
-			)
+			return sqlerrors.NewUndefinedUserError(becomeUser)
 		}
 	}
 


### PR DESCRIPTION
fixes https://github.com/cockroachdb/cockroach/issues/96948

Release note (bug fix): Fixed the `SHOW GRANTS FOR public` command so it works correctly. Previously, this would return an error saying that the `public` role does not exist.