### PR TITLE
roachtest: set range tombstones flag accordingly

### DIFF
--- a/pkg/cmd/roachtest/tests/import_cancellation.go
+++ b/pkg/cmd/roachtest/tests/import_cancellation.go
@@ -36,7 +36,7 @@ func registerImportCancellation(r registry.Registry) {
 			Timeout: 4 * time.Hour,
 			Cluster: r.MakeClusterSpec(6, spec.CPU(32)),
 			Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
-				runImportCancellation(ctx, t, c, false)
+				runImportCancellation(ctx, t, c, rangeTombstones)
 			},
 		})
 	}


### PR DESCRIPTION
Fix a bug in the `import-cancellation` roachtest whereby range tombstones are always disabled.

Release note: None.

Epic: CRDB-20465