### PR TITLE
backuppb: fix incorrect ExportRequest throughput aggregation

### DIFF
--- a/pkg/ccl/backupccl/backuppb/BUILD.bazel
+++ b/pkg/ccl/backupccl/backuppb/BUILD.bazel
@@ -51,6 +51,7 @@ go_library(
         "//pkg/sql/protoreflect",
         "//pkg/sql/sem/tree",
         "//pkg/util/bulk",
+        "//pkg/util/hlc",
         "//pkg/util/uuid",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_gogo_protobuf//jsonpb",

--- a/pkg/ccl/backupccl/backuppb/backup.go
+++ b/pkg/ccl/backupccl/backuppb/backup.go
@@ -11,6 +11,7 @@ package backuppb
 import (
 	"encoding/json"
 	"fmt"
+	"math"
 
 	"github.com/cockroachdb/cockroach/pkg/cloud"
 	"github.com/cockroachdb/cockroach/pkg/multitenant/mtinfopb"
@@ -18,6 +19,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/protoreflect"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/util/bulk"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	_ "github.com/cockroachdb/cockroach/pkg/util/uuid" // required for backup.proto
 	"github.com/cockroachdb/errors"
 	"github.com/gogo/protobuf/jsonpb"
@@ -145,8 +147,9 @@ func (e *ExportStats) Render() []attribute.KeyValue {
 			Value: attribute.StringValue(fmt.Sprintf("%.2f MB", dataSizeMB)),
 		})
 
-		if e.Duration > 0 {
-			throughput := dataSizeMB / e.Duration.Seconds()
+		if !e.StartTime.IsEmpty() && !e.EndTime.IsEmpty() {
+			duration := e.EndTime.GoTime().Sub(e.StartTime.GoTime())
+			throughput := dataSizeMB / duration.Seconds()
 			tags = append(tags, attribute.KeyValue{
 				Key:   "throughput",
 				Value: attribute.StringValue(fmt.Sprintf("%.2f MB/s", throughput)),
@@ -159,7 +162,10 @@ func (e *ExportStats) Render() []attribute.KeyValue {
 
 // Identity implements the TracingAggregatorEvent interface.
 func (e *ExportStats) Identity() bulk.TracingAggregatorEvent {
-	return &ExportStats{}
+	return &ExportStats{
+		StartTime: hlc.Timestamp{WallTime: math.MaxInt64},
+		EndTime:   hlc.Timestamp{WallTime: math.MinInt64},
+	}
 }
 
 // Combine implements the TracingAggregatorEvent interface.
@@ -170,7 +176,20 @@ func (e *ExportStats) Combine(other bulk.TracingAggregatorEvent) {
 	}
 	e.NumFiles += otherExportStats.NumFiles
 	e.DataSize += otherExportStats.DataSize
+	// Duration should not be used in throughput calculations as adding durations
+	// of two ExportRequests does not account for concurrent evaluation of these
+	// requests.
 	e.Duration += otherExportStats.Duration
+
+	// We want to store the earliest of the StartTimes.
+	if otherExportStats.StartTime.Less(e.StartTime) {
+		e.StartTime = otherExportStats.StartTime
+	}
+
+	// We want to store the latest of the EndTimes.
+	if e.EndTime.Less(otherExportStats.EndTime) {
+		e.EndTime = otherExportStats.EndTime
+	}
 }
 
 // Tag implements the TracingAggregatorEvent interface.

--- a/pkg/ccl/backupccl/backuppb/backup.proto
+++ b/pkg/ccl/backupccl/backuppb/backup.proto
@@ -217,4 +217,9 @@ message ExportStats {
   // Duration is the total time taken to send an ExportRequest, receive an
   // ExportResponse and push the response on a channel.
   int64 duration = 3 [(gogoproto.casttype) = "time.Duration"];
+  // StartTime is the timestamp at which the ExportRequest was sent.
+  util.hlc.Timestamp start_time = 4 [(gogoproto.nullable) = false];
+  // EndTime is the timestamp at which an ExportResponse was received and pushed
+  // onto a channel.
+  util.hlc.Timestamp end_time = 5 [(gogoproto.nullable) = false];
 }


### PR DESCRIPTION
ExportStats are emitted on the return of every ExportRequest. A tracing aggregator on each backup processor listens for these events and maintains a running aggregate. This aggregate is then used to generate interesting metrics, one of which is the throughput in MB/sec at which this processor is processing ExportRequests.

Previously, we were naively using the `aggregatedBytes / aggregatedDuration` to compute this thorughput. This is incorrect because we process several ExportRequests concurrently per processor. To account for this we now maintain the earliest start time and the latest end time across the requests we have aggregated. When computing throughput we use the difference between these two timestamps as our denominator.

Fixes: #89579

Release note: None