### PR TITLE
release-22.2: backupccl: skip UDFs not found when rewriting IDs in Schema

### DIFF
--- a/pkg/ccl/backupccl/testdata/backup-restore/user-defined-functions
+++ b/pkg/ccl/backupccl/testdata/backup-restore/user-defined-functions
@@ -310,3 +310,97 @@ exec-sql
 DROP TYPE sc1.enum1
 ----
 pq: cannot drop type "enum1" because other objects ([db1.sc1.f1]) still depend on it
+
+# Make sure that backup and restore individual tables from schema with UDF does
+# not crash.
+new-server name=s3
+----
+
+exec-sql cluster=s3
+CREATE DATABASE db1;
+CREATE SCHEMA sc1;
+CREATE TABLE sc1.t(a INT PRIMARY KEY);
+CREATE FUNCTION sc1.f() RETURNS INT LANGUAGE SQL AS $$ SELECT 1 $$;
+----
+
+# Make sure the original schema has function signatures
+query-sql
+WITH db_id AS (
+  SELECT id FROM system.namespace WHERE name = 'defaultdb'
+),
+schema_id AS (
+  SELECT ns.id
+  FROM system.namespace AS ns
+  JOIN db_id ON ns."parentID" = db_id.id
+  WHERE ns.name = 'sc1'
+)
+SELECT id FROM schema_id;
+----
+109
+
+query-sql
+WITH to_json AS (
+    SELECT
+      id,
+      crdb_internal.pb_to_json(
+        'cockroach.sql.sqlbase.Descriptor',
+        descriptor,
+        false
+      ) AS d
+    FROM
+      system.descriptor
+    WHERE id = 109
+)
+SELECT d->'schema'->>'functions'::string FROM to_json;
+----
+{"f": {"overloads": [{"id": 111, "returnType": {"family": "IntFamily", "oid": 20, "width": 64}}]}}
+
+exec-sql
+BACKUP TABLE sc1.t INTO 'nodelocal://0/test/'
+----
+
+exec-sql
+RESTORE TABLE sc1.t FROM LATEST IN 'nodelocal://0/test/' WITH into_db = 'db1';
+----
+
+exec-sql
+USE db1;
+----
+
+query-sql
+WITH db_id AS (
+  SELECT id FROM system.namespace WHERE name = 'db1'
+),
+schema_id AS (
+  SELECT ns.id
+  FROM system.namespace AS ns
+  JOIN db_id ON ns."parentID" = db_id.id
+  WHERE ns.name = 'sc1'
+)
+SELECT id FROM schema_id;
+----
+112
+
+query-sql
+WITH to_json AS (
+    SELECT
+      id,
+      crdb_internal.pb_to_json(
+        'cockroach.sql.sqlbase.Descriptor',
+        descriptor,
+        false
+      ) AS d
+    FROM
+      system.descriptor
+    WHERE id = 112
+)
+SELECT d->'schema'->>'functions'::string FROM to_json;
+----
+<nil>
+
+# Make sure proper error message is returned when trying to resolve the
+# function from the restore target db.
+query-sql
+SELECT f()
+----
+pq: unknown function: f(): function undefined

--- a/pkg/sql/catalog/rewrite/rewrite.go
+++ b/pkg/sql/catalog/rewrite/rewrite.go
@@ -525,20 +525,37 @@ func SchemaDescs(schemas []*schemadesc.Mutable, descriptorRewrites jobspb.DescRe
 		sc.ParentID = rewrite.ParentID
 
 		// Rewrite function ID and types ID in function signatures.
-		for _, fn := range sc.GetFunctions() {
+		newFns := make(map[string]descpb.SchemaDescriptor_Function)
+		for fnName, fn := range sc.GetFunctions() {
+			newSigs := make([]descpb.SchemaDescriptor_FunctionOverload, 0, len(fn.Overloads))
 			for i := range fn.Overloads {
-				overload := &fn.Overloads[i]
-				overload.ID = descriptorRewrites[overload.ID].ID
-				for _, typ := range overload.ArgTypes {
+				sig := &fn.Overloads[i]
+				// If the function is not found in the backup, we just skip. This only
+				// happens when restoring from a backup with `BACKUP TABLE` where the
+				// function descriptors are not backup.
+				fnDesc, ok := descriptorRewrites[sig.ID]
+				if !ok {
+					continue
+				}
+				sig.ID = fnDesc.ID
+				for _, typ := range sig.ArgTypes {
 					if err := rewriteIDsInTypesT(typ, descriptorRewrites); err != nil {
 						return err
 					}
 				}
-				if err := rewriteIDsInTypesT(overload.ReturnType, descriptorRewrites); err != nil {
+				if err := rewriteIDsInTypesT(sig.ReturnType, descriptorRewrites); err != nil {
 					return err
+				}
+				newSigs = append(newSigs, *sig)
+			}
+			if len(newSigs) > 0 {
+				newFns[fnName] = descpb.SchemaDescriptor_Function{
+					Name:      fnName,
+					Overloads: newSigs,
 				}
 			}
 		}
+		sc.Functions = newFns
 
 		if err := rewriteSchemaChangerState(sc, descriptorRewrites); err != nil {
 			return err


### PR DESCRIPTION
Backport 1/1 commits from #96911.

/cc @cockroachdb/release

---

Previously, if a BACKUP is created by doing BACKUP TABLE, and the parent schema of the tables has UDFs in it, RESTOREing the tables from the back crashes. This is because we store the signatures of UDFs in schema descriptor. Restoring a table also restores the parent schema if there is no schema with the same name exists in the target database. So when trying to rewrite the UDF ids in the schema descriptor, it crashes because function descriptors are not backed up at all.

This pr adds logic to skip those rewrites if function descriptor was not backed up.

Fixes: #96910

Release note (enterprise): this path fixes a bug where server would crash if trying to restore a table from a backup generated with `BACKUP TABLE` from a schema with user defined functions, and the restore target database doesn't have a schema with the same name.

Release justification: Low risk but necessary bug fix.