### PR TITLE
kv: Start nodes in a new status to prevent lease transfers

### DIFF
--- a/pkg/kv/kvserver/allocator/storepool/store_pool.go
+++ b/pkg/kv/kvserver/allocator/storepool/store_pool.go
@@ -162,6 +162,9 @@ func MakeStorePoolNodeLivenessFunc(nodeLiveness *liveness.NodeLiveness) NodeLive
 func LivenessStatus(
 	l livenesspb.Liveness, now time.Time, deadThreshold time.Duration,
 ) livenesspb.NodeLivenessStatus {
+	if l.Membership == livenesspb.MembershipStatus_STARTING {
+		return livenesspb.NodeLivenessStatus_STARTING
+	}
 	if l.IsDead(now, deadThreshold) {
 		if !l.Membership.Active() {
 			return livenesspb.NodeLivenessStatus_DECOMMISSIONED
@@ -292,7 +295,7 @@ func (sd *StoreDetail) status(
 		return storeStatusDead
 	case livenesspb.NodeLivenessStatus_DECOMMISSIONING:
 		return storeStatusDecommissioning
-	case livenesspb.NodeLivenessStatus_UNAVAILABLE:
+	case livenesspb.NodeLivenessStatus_UNAVAILABLE, livenesspb.NodeLivenessStatus_STARTING:
 		// We don't want to suspect a node on startup or when it's first added to a
 		// cluster, because we dont know its liveness yet.
 		if !sd.LastAvailable.IsZero() {

--- a/pkg/kv/kvserver/liveness/liveness.go
+++ b/pkg/kv/kvserver/liveness/liveness.go
@@ -566,7 +566,7 @@ func (nl *NodeLiveness) CreateLivenessRecord(ctx context.Context, nodeID roachpb
 	for r := retry.StartWithCtx(ctx, base.DefaultRetryOptions()); r.Next(); {
 		// We start off at epoch=0, entrusting the initial heartbeat to increment it
 		// to epoch=1 to signal the very first time the node is up and running.
-		liveness := livenesspb.Liveness{NodeID: nodeID, Epoch: 0}
+		liveness := livenesspb.Liveness{NodeID: nodeID, Epoch: 0, Membership: livenesspb.MembershipStatus_STARTING}
 
 		// We skip adding an expiration, we only really care about the liveness
 		// record existing within KV.

--- a/pkg/kv/kvserver/liveness/livenesspb/liveness.go
+++ b/pkg/kv/kvserver/liveness/livenesspb/liveness.go
@@ -89,6 +89,8 @@ func (c MembershipStatus) String() string {
 		return "decommissioning"
 	case MembershipStatus_DECOMMISSIONED:
 		return "decommissioned"
+	case MembershipStatus_STARTING:
+		return "starting"
 	default:
 		err := "unknown membership status, expected one of [active,decommissioning,decommissioned]"
 		panic(err)
@@ -100,14 +102,20 @@ func (c MembershipStatus) String() string {
 // (which also includes decommissioning a decommissioned node) the valid state
 // transitions for Membership are as follows:
 //
-//	Decommissioning  => Active
-//	Active           => Decommissioning
-//	Decommissioning  => Decommissioned
+//		Decommissioning  => Active
+//		Active           => Decommissioning
+//		Decommissioning  => Decommissioned
+//	  Starting         => *
 //
 // See diagram above the Membership type for more details.
 func ValidateTransition(old, new Liveness) error {
 	if old.Membership == new.Membership {
 		// No-op.
+		return nil
+	}
+
+	// Allow transition from STARTING to any status.
+	if old.Membership == MembershipStatus_STARTING {
 		return nil
 	}
 

--- a/pkg/kv/kvserver/liveness/livenesspb/liveness.proto
+++ b/pkg/kv/kvserver/liveness/livenesspb/liveness.proto
@@ -102,6 +102,11 @@ enum MembershipStatus {
   // TODO(irfansharif): We don't disallow the joining as yet (but will come in
   // as part of the Connect RPC subsystem).
   DECOMMISSIONED = 2;
+
+  // Starting represents a transient node status of a node that is starting up,
+  // but has not yet stabilized. It is active in most respects, however it
+  // should not be the targeted of lease or replica transfers.
+  STARTING = 3;
 }
 
 // NodeLivenessStatus describes the status of a node from the perspective of the
@@ -135,4 +140,6 @@ enum NodeLivenessStatus {
   NODE_STATUS_DECOMMISSIONED = 5 [(gogoproto.enumvalue_customname) = "DECOMMISSIONED"];
   // DRAINING indicates a node that is in the process of draining.
   NODE_STATUS_DRAINING = 6 [(gogoproto.enumvalue_customname) = "DRAINING"];
+  // STARTING indicates a node is starting up. This is a transient status.
+  NODE_STATUS_STARTING = 7 [(gogoproto.enumvalue_customname) = "STARTING"];
 }

--- a/pkg/kv/kvserver/store_init.go
+++ b/pkg/kv/kvserver/store_init.go
@@ -81,7 +81,7 @@ func WriteInitialClusterData(
 	//
 	// [1]: See `(*NodeLiveness).CreateLivenessRecord` and usages for where that happens.
 	// [2]: See `(*NodeLiveness).Start` for where that happens.
-	livenessRecord := livenesspb.Liveness{NodeID: kvstorage.FirstNodeID, Epoch: 0}
+	livenessRecord := livenesspb.Liveness{NodeID: kvstorage.FirstNodeID, Epoch: 0, Membership: livenesspb.MembershipStatus_STARTING}
 	if err := livenessVal.SetProto(&livenessRecord); err != nil {
 		return err
 	}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -921,9 +921,9 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 			cfg.ObsServiceAddr,
 			timeutil.DefaultTimeSource{},
 			cfg.Tracer,
-			5*time.Second, // maxStaleness
-			1<<20,         // triggerSizeBytes - 1MB
-			10*1<<20,      // maxBufferSizeBytes - 10MB
+			5*time.Second,                             // maxStaleness
+			1<<20,                                     // triggerSizeBytes - 1MB
+			10*1<<20,                                  // maxBufferSizeBytes - 10MB
 			sqlMonitorAndMetrics.rootSQLMemoryMonitor, // memMonitor - this is not "SQL" usage, but we don't have another memory pool
 		)
 		if err != nil {
@@ -1981,6 +1981,8 @@ func (s *Server) PreStart(ctx context.Context) error {
 	s.tsDB.PollSource(
 		s.cfg.AmbientCtx, s.recorder, base.DefaultMetricsSampleInterval, ts.Resolution10s, s.stopper,
 	)
+
+	s.node.updateNodeStatusOnceReady(ctx)
 
 	return maybeImportTS(ctx, s)
 }

--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -4484,7 +4484,7 @@ CREATE TABLE crdb_internal.gossip_liveness (
 				tree.NewDInt(tree.DInt(l.Epoch)),
 				tree.NewDString(l.Expiration.String()),
 				tree.MakeDBool(tree.DBool(l.Draining)),
-				tree.MakeDBool(tree.DBool(!l.Membership.Active())),
+				tree.MakeDBool(tree.DBool(l.Membership.Decommissioning() || l.Membership.Decommissioned())),
 				tree.NewDString(l.Membership.String()),
 				updatedTSDatum,
 			); err != nil {


### PR DESCRIPTION
Previously when a store started it immediately became a target for lease and replica transfers. This could cause problems if the store was still recovering from being down because it was behind on Raft updates. This patch adds a delay until publishing a membership status of ACTIVE until it has gone through its Raft backlog and cleaned up its LSM.

Epic: none
Release note (ops change): A node now transitions through an additional STARTING state on startup.