### PR TITLE
bulk: fix incorrect ingestion throughput aggregation

### DIFF
--- a/pkg/kv/bulk/bulkpb/BUILD.bazel
+++ b/pkg/kv/bulk/bulkpb/BUILD.bazel
@@ -8,7 +8,10 @@ proto_library(
     srcs = ["bulkpb.proto"],
     strip_import_prefix = "/pkg",
     visibility = ["//visibility:public"],
-    deps = ["@com_github_gogo_protobuf//gogoproto:gogo_proto"],
+    deps = [
+        "//pkg/util/hlc:hlc_proto",
+        "@com_github_gogo_protobuf//gogoproto:gogo_proto",
+    ],
 )
 
 go_proto_library(
@@ -17,7 +20,10 @@ go_proto_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/kv/bulk/bulkpb",
     proto = ":bulkpb_proto",
     visibility = ["//visibility:public"],
-    deps = ["@com_github_gogo_protobuf//gogoproto"],
+    deps = [
+        "//pkg/util/hlc",
+        "@com_github_gogo_protobuf//gogoproto",
+    ],
 )
 
 go_library(
@@ -29,6 +35,7 @@ go_library(
     deps = [
         "//pkg/roachpb",
         "//pkg/util/bulk",
+        "//pkg/util/hlc",
         "//pkg/util/humanizeutil",
         "//pkg/util/log",
         "@com_github_cockroachdb_redact//:redact",

--- a/pkg/kv/bulk/bulkpb/bulkpb.proto
+++ b/pkg/kv/bulk/bulkpb/bulkpb.proto
@@ -14,12 +14,16 @@ package cockroach.kv.bulk.bulkpb;
 option go_package = "bulkpb";
 
 import "gogoproto/gogo.proto";
+import "util/hlc/timestamp.proto";
 
 // IngestionPerformanceStats is a message containing information about the
 // creation of SSTables by an SSTBatcher or BufferingAdder.
 message IngestionPerformanceStats {
-  // DataSize is the total byte size of all the SST files ingested.
-  int64 data_size = 1;
+  // LogicalDataSize is the total byte size of all the KVs ingested.
+  int64 logical_data_size = 1;
+
+  // SSTDataSize is the total byte size of the SSTs sent to KV for ingestion.
+  int64 sst_data_size = 23 [(gogoproto.customname) = "SSTDataSize"];
 
   // Buffer Flushes is the number of buffer flushes.
   int64 buffer_flushes = 2;
@@ -72,8 +76,16 @@ message IngestionPerformanceStats {
   // CommitWait is the time spent waiting for commit timestamps.
   int64 commit_wait = 18  [(gogoproto.casttype) = "time.Duration"];
 
-  // Duration is the total ingestion time.
+  // Duration is the difference between the CurrentFlushTime and the
+  // PreviousFlushTime.
   int64 duration = 19  [(gogoproto.casttype) = "time.Duration"];
+
+  // LastFlushTime is the timestamp at which we completed the flush prior to the
+  // current flush.
+  util.hlc.Timestamp last_flush_time = 21 [(gogoproto.nullable) = false];
+
+  // CurrentFlushTime is the timestamp at which we finished the current flush.
+  util.hlc.Timestamp current_flush_time = 22 [(gogoproto.nullable) = false];
 
   // SendWaitByStore is the time spent sending batches to each store.
   map<int32, int64> send_wait_by_store = 20 [(gogoproto.castkey) = "github.com/cockroachdb/cockroach/pkg/roachpb.StoreID", (gogoproto.castvalue) = "time.Duration"];

--- a/pkg/kv/bulk/sst_batcher.go
+++ b/pkg/kv/bulk/sst_batcher.go
@@ -625,12 +625,15 @@ func (b *SSTBatcher) doFlush(ctx context.Context, reason int) error {
 		defer b.mu.Unlock()
 		summary.DataSize += int64(size)
 		summary.SSTDataSize += int64(len(data))
-		currentBatchStatsCopy.DataSize += int64(size)
+		currentBatchStatsCopy.LogicalDataSize += int64(size)
+		currentBatchStatsCopy.SSTDataSize += int64(len(data))
 		b.mu.totalRows.Add(summary)
 
 		afterFlush := timeutil.Now()
 		currentBatchStatsCopy.BatchWait += afterFlush.Sub(beforeFlush)
 		currentBatchStatsCopy.Duration = afterFlush.Sub(b.mu.lastFlush)
+		currentBatchStatsCopy.LastFlushTime = hlc.Timestamp{WallTime: b.mu.lastFlush.UnixNano()}
+		currentBatchStatsCopy.CurrentFlushTime = hlc.Timestamp{WallTime: afterFlush.UnixNano()}
 		b.mu.totalStats.Combine(currentBatchStatsCopy)
 		b.mu.lastFlush = afterFlush
 		if b.mu.tracingSpan != nil {

--- a/pkg/util/bulk/tracing_aggregator.go
+++ b/pkg/util/bulk/tracing_aggregator.go
@@ -32,8 +32,8 @@ type TracingAggregatorEvent interface {
 	Tag() string
 }
 
-// An TracingAggregator can be used to aggregate and render AggregatorEvents that are
-// emitted as part of its tracing spans' recording.
+// A TracingAggregator can be used to aggregate and render AggregatorEvents that
+// are emitted as part of its tracing spans' recording.
 type TracingAggregator struct {
 	mu struct {
 		syncutil.Mutex

--- a/pkg/util/bulk/tracing_aggregator_test.go
+++ b/pkg/util/bulk/tracing_aggregator_test.go
@@ -97,7 +97,8 @@ func TestIngestionPerformanceStatsAggregation(t *testing.T) {
 
 	makeEvent := func(v int64, sendWaitByStore map[roachpb.StoreID]time.Duration) *bulkpb.IngestionPerformanceStats {
 		return &bulkpb.IngestionPerformanceStats{
-			DataSize:          v,
+			LogicalDataSize:   v,
+			SSTDataSize:       v,
 			BufferFlushes:     v,
 			FlushesDueToSize:  v,
 			Batches:           v,


### PR DESCRIPTION
IngestionPerformanceStats are emitted on completion of every flush in the SSTBatcher. A tracing aggregator on each restore processor listens for these events and maintains a running aggregate. This aggregate is then used to generate interesting metrics, one of which is the throughput in MB/sec at which this processor is flushing + ingesting bytes..

Previously, we were naively using the aggregatedBytes / aggregatedDuration to compute this thorughput. This is incorrect because we process several flushes concurrently per processor. To account for this we now maintain the earliest start time and the latest end time across the requests we have aggregated. When computing throughput we use the difference between these two timestamps as our denominator.

Fixes: #89579

Release note: None