### PR TITLE
backupccl: reassign functions for rewritten schemas

### DIFF
--- a/pkg/ccl/backupccl/testdata/backup-restore/user-defined-functions
+++ b/pkg/ccl/backupccl/testdata/backup-restore/user-defined-functions
@@ -299,21 +299,85 @@ new-cluster name=s3
 
 exec-sql cluster=s3
 CREATE DATABASE db1;
-CREATE TABLE t(a INT PRIMARY KEY);
-CREATE FUNCTION f() RETURNS INT LANGUAGE SQL AS $$ SELECT 1 $$;
+CREATE SCHEMA sc1;
+CREATE TABLE sc1.t(a INT PRIMARY KEY);
+CREATE FUNCTION sc1.f() RETURNS INT LANGUAGE SQL AS $$ SELECT 1 $$;
+----
+
+# Make sure the original schema has function signatures
+query-sql
+WITH db_id AS (
+  SELECT id FROM system.namespace WHERE name = 'defaultdb'
+),
+schema_id AS (
+  SELECT ns.id
+  FROM system.namespace AS ns
+  JOIN db_id ON ns."parentID" = db_id.id
+  WHERE ns.name = 'sc1'
+)
+SELECT id FROM schema_id;
+----
+109
+
+query-sql
+WITH to_json AS (
+    SELECT
+      id,
+      crdb_internal.pb_to_json(
+        'cockroach.sql.sqlbase.Descriptor',
+        descriptor,
+        false
+      ) AS d
+    FROM
+      system.descriptor
+    WHERE id = 109
+)
+SELECT d->'schema'->>'functions'::string FROM to_json;
+----
+{"f": {"signatures": [{"id": 111, "returnType": {"family": "IntFamily", "oid": 20, "width": 64}}]}}
+
+exec-sql
+BACKUP TABLE sc1.t INTO 'nodelocal://0/test/'
 ----
 
 exec-sql
-BACKUP TABLE t INTO 'nodelocal://0/test/'
-----
-
-exec-sql
-RESTORE TABLE t FROM LATEST IN 'nodelocal://0/test/' WITH into_db = 'db1';
+RESTORE TABLE sc1.t FROM LATEST IN 'nodelocal://0/test/' WITH into_db = 'db1';
 ----
 
 exec-sql
 USE db1;
 ----
+
+query-sql
+WITH db_id AS (
+  SELECT id FROM system.namespace WHERE name = 'db1'
+),
+schema_id AS (
+  SELECT ns.id
+  FROM system.namespace AS ns
+  JOIN db_id ON ns."parentID" = db_id.id
+  WHERE ns.name = 'sc1'
+)
+SELECT id FROM schema_id;
+----
+112
+
+query-sql
+WITH to_json AS (
+    SELECT
+      id,
+      crdb_internal.pb_to_json(
+        'cockroach.sql.sqlbase.Descriptor',
+        descriptor,
+        false
+      ) AS d
+    FROM
+      system.descriptor
+    WHERE id = 112
+)
+SELECT d->'schema'->>'functions'::string FROM to_json;
+----
+<nil>
 
 # Make sure proper error message is returned when trying to resolve the
 # function from the restore target db.

--- a/pkg/sql/catalog/rewrite/rewrite.go
+++ b/pkg/sql/catalog/rewrite/rewrite.go
@@ -566,6 +566,7 @@ func SchemaDescs(schemas []*schemadesc.Mutable, descriptorRewrites jobspb.DescRe
 				}
 			}
 		}
+		sc.Functions = newFns
 
 		if err := rewriteSchemaChangerState(sc, descriptorRewrites); err != nil {
 			return err


### PR DESCRIPTION
Forgot to assign the new function signatures to schema in #96911. This pr fixes that and also added more tests to make sure functions in schema descriptor looks good.

Epic: None
Release note: None