### PR TITLE
release-22.2: storage: fix CheckSSTConflicts access of undefined buffer

### DIFF
--- a/pkg/storage/sst.go
+++ b/pkg/storage/sst.go
@@ -1003,7 +1003,7 @@ func CheckSSTConflicts(
 				// 2) the ext iterator became invalid
 				// 3) both iterators changed keys and the sst iterator's key is further
 				//    ahead.
-				if extChangedKeys && (!sstChangedKeys || (!extOK && sstOK) || extIter.UnsafeKey().Key.Compare(sstIter.UnsafeKey().Key) < 0) {
+				if sstOK && extChangedKeys && (!sstChangedKeys || !extOK || extIter.UnsafeKey().Key.Compare(sstIter.UnsafeKey().Key) < 0) {
 					extIter.SeekGE(MVCCKey{Key: sstIter.UnsafeKey().Key})
 					extOK, extErr = extIter.Valid()
 				}


### PR DESCRIPTION
This is a backport of the CheckSSTConflicts bug fix contained within #96685. Previously, CheckSSTConflicts would improperly access an invalid iterator's `UnsafeKey`, using it to seek another iterator.

Epic: None
Release note: None
Release justification: Fixes undefined behavior that could cause invalid conflict stats calculations.