### PR TITLE
release-22.1: sql: fix SHOW GRANTS FOR public

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/grant_revoke_with_grant_option
+++ b/pkg/sql/logictest/testdata/logic_test/grant_revoke_with_grant_option
@@ -15,6 +15,19 @@ CREATE USER testuser2
 statement ok
 CREATE USER target
 
+# Check privileges that `public` has by default, ignoring types and virtual tables.
+query TTTTTB colnames
+SELECT * FROM [SHOW GRANTS FOR public] WHERE relation_name IS NULL
+----
+database_name  schema_name         relation_name  grantee  privilege_type  is_grantable
+test           crdb_internal       NULL           public   USAGE           false
+test           information_schema  NULL           public   USAGE           false
+test           pg_catalog          NULL           public   USAGE           false
+test           pg_extension        NULL           public   USAGE           false
+test           public              NULL           public   CREATE          false
+test           public              NULL           public   USAGE           false
+test           NULL                NULL           public   CONNECT         false
+
 statement error grant options cannot be granted to "public" role
 GRANT ALL PRIVILEGES ON TABLE t TO public WITH GRANT OPTION
 

--- a/pkg/sql/logictest/testdata/logic_test/grant_role
+++ b/pkg/sql/logictest/testdata/logic_test/grant_role
@@ -1,0 +1,34 @@
+# Test that no-op grant role command is actually no-op (i.e. does not perform schema change)
+subtest no_op_grant_role
+
+statement ok
+CREATE USER developer WITH CREATEDB
+
+statement ok
+CREATE USER roach WITH PASSWORD NULL
+
+statement ok
+GRANT developer TO roach
+
+# Remember the current table version for `system.role_members`.
+let $role_members_version
+SELECT crdb_internal.pb_to_json('cockroach.sql.sqlbase.Descriptor', descriptor)->'table'->>'version' FROM system.descriptor WHERE id = 'system.public.role_members'::REGCLASS
+
+# Repeatedly grant membership of `developer` to `roach` which it's already a member of.
+statement ok
+GRANT developer TO roach
+
+# Assert that it's indeed a no-op by checking the 'role_members' table's version remains the same
+query B
+SELECT crdb_internal.pb_to_json('cockroach.sql.sqlbase.Descriptor', descriptor)->'table'->>'version' = $role_members_version::STRING FROM system.descriptor WHERE id = 'system.public.role_members'::REGCLASS
+----
+true
+
+# GRANT or REVOKE on the public role should result in "not exists"
+subtest grant_revoke_public
+
+statement error role/user public does not exist
+GRANT testuser TO public
+
+statement error role/user public does not exist
+REVOKE testuser FROM public


### PR DESCRIPTION
Backport 1/1 commits from #96957.

/cc @cockroachdb/release

Release justification: bug fix

---

fixes https://github.com/cockroachdb/cockroach/issues/96948

Release note (bug fix): Fixed the `SHOW GRANTS FOR public` command so it works correctly. Previously, this would return an error saying that the `public` role does not exist.
