### PR TITLE
changefeedccl: Retry memory acquisition during scan

### DIFF
--- a/pkg/ccl/changefeedccl/kvfeed/BUILD.bazel
+++ b/pkg/ccl/changefeedccl/kvfeed/BUILD.bazel
@@ -31,6 +31,7 @@ go_library(
         "//pkg/util/limit",
         "//pkg/util/log",
         "//pkg/util/mon",
+        "//pkg/util/retry",
         "//pkg/util/span",
         "//pkg/util/timeutil",
         "@com_github_cockroachdb_errors//:errors",

--- a/pkg/ccl/changefeedccl/kvfeed/scanner.go
+++ b/pkg/ccl/changefeedccl/kvfeed/scanner.go
@@ -30,6 +30,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/limit"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/retry"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/errors"
 )
@@ -102,22 +103,15 @@ func (p *scanRequestScanner) Scan(ctx context.Context, sink kvevent.Writer, cfg 
 			return errors.CombineErrors(err, g.Wait())
 		}
 
-		var spanAlloc kvevent.Alloc
-		if allocator, ok := sink.(kvevent.MemAllocator); ok {
-			// Sink implements memory allocator interface, so acquire
-			// memory needed to hold scan reply.
-			spanAlloc, err = allocator.AcquireMemory(ctx, changefeedbase.ScanRequestSize.Get(&p.settings.SV))
-			if err != nil {
-				cancel()
-				return errors.CombineErrors(err, g.Wait())
-			}
-		}
-
 		g.GoCtx(func(ctx context.Context) error {
 			defer limAlloc.Release()
+			spanAlloc, err := p.tryAcquireMemory(ctx, sink)
+			if err != nil {
+				return err
+			}
 			defer spanAlloc.Release(ctx)
 
-			err := p.exportSpan(ctx, span, cfg.Timestamp, cfg.Boundary, cfg.WithDiff, sink, cfg.Knobs)
+			err = p.exportSpan(ctx, span, cfg.Timestamp, cfg.Boundary, cfg.WithDiff, sink, cfg.Knobs)
 			finished := atomic.AddInt64(&atomicFinished, 1)
 			if backfillDec != nil {
 				backfillDec()
@@ -129,6 +123,47 @@ func (p *scanRequestScanner) Scan(ctx context.Context, sink kvevent.Writer, cfg 
 		})
 	}
 	return g.Wait()
+}
+
+var logMemAcquireEvery = log.Every(5 * time.Second)
+
+// tryAcquireMemory attempts to acquire memory for span export.
+func (p *scanRequestScanner) tryAcquireMemory(
+	ctx context.Context, sink kvevent.Writer,
+) (alloc kvevent.Alloc, err error) {
+	allocator, ok := sink.(kvevent.MemAllocator)
+	if !ok {
+		// Not an allocator -- can't acquire memory.
+		return alloc, nil
+	}
+
+	// Begin by attempting to acquire memory for the request we're about to issue.
+	alloc, err = allocator.AcquireMemory(ctx, changefeedbase.ScanRequestSize.Get(&p.settings.SV))
+	if err == nil {
+		return alloc, nil
+	}
+
+	retryOpts := retry.Options{
+		InitialBackoff: 500 * time.Millisecond,
+		MaxBackoff:     10 * time.Second,
+	}
+
+	// We failed to acquire memory for this export.  Begin retry loop -- we may succeed
+	// in the future, once somebody releases memory.
+	for attempt := retry.StartWithCtx(ctx, retryOpts); attempt.Next(); {
+		// Sink implements memory allocator interface, so acquire
+		// memory needed to hold scan reply.
+		if logMemAcquireEvery.ShouldLog() {
+			log.Errorf(ctx, "Failed to acquire memory for export span: %s (attempt %d)",
+				err, attempt.CurrentAttempt()+1)
+		}
+		alloc, err = allocator.AcquireMemory(ctx, changefeedbase.ScanRequestSize.Get(&p.settings.SV))
+		if err == nil {
+			return alloc, nil
+		}
+	}
+
+	return alloc, ctx.Err()
 }
 
 func (p *scanRequestScanner) exportSpan(


### PR DESCRIPTION
Failure to acquire memory during scan export should not fail changefeed.  Recent change added accounting for memory used during the export.  However, the approach was too simplistic in that it would fail the changefeed if it failed to acquire memory.  This is particularly problematic as the old default value for the scan request size was 16MB, so acquiring 16MB*NumberOfScans could result in an out of memory error bubbling up and restarting the changefeed (with retryable error).

This PR instead retries memory acquisitions with some frequency instead of failing changefeed.

Fixes #96961

Release note: None