### PR TITLE
parser: allow string literals for region names

### DIFF
--- a/docs/generated/sql/bnf/alter_database_add_super_region.bnf
+++ b/docs/generated/sql/bnf/alter_database_add_super_region.bnf
@@ -1,2 +1,2 @@
 alter_database_add_super_region ::=
-	'ALTER' 'DATABASE' database_name 'ADD' 'SUPER' 'REGION' name 'VALUES' name_list
+	'ALTER' 'DATABASE' database_name 'ADD' 'SUPER' 'REGION' region_name 'VALUES' region_name_list

--- a/docs/generated/sql/bnf/alter_database_alter_super_region.bnf
+++ b/docs/generated/sql/bnf/alter_database_alter_super_region.bnf
@@ -1,2 +1,2 @@
 alter_database_alter_super_region ::=
-	'ALTER' 'DATABASE' database_name 'ALTER' 'SUPER' 'REGION' name 'VALUES' name_list
+	'ALTER' 'DATABASE' database_name 'ALTER' 'SUPER' 'REGION' region_name 'VALUES' region_name_list

--- a/docs/generated/sql/bnf/alter_database_drop_super_region.bnf
+++ b/docs/generated/sql/bnf/alter_database_drop_super_region.bnf
@@ -1,2 +1,2 @@
 alter_database_drop_super_region ::=
-	'ALTER' 'DATABASE' database_name 'DROP' 'SUPER' 'REGION' name
+	'ALTER' 'DATABASE' database_name 'DROP' 'SUPER' 'REGION' region_name

--- a/docs/generated/sql/bnf/stmt_block.bnf
+++ b/docs/generated/sql/bnf/stmt_block.bnf
@@ -2169,13 +2169,13 @@ alter_database_set_stmt ::=
 	'ALTER' 'DATABASE' database_name set_or_reset_clause
 
 alter_database_add_super_region ::=
-	'ALTER' 'DATABASE' database_name 'ADD' 'SUPER' 'REGION' name 'VALUES' name_list
+	'ALTER' 'DATABASE' database_name 'ADD' 'SUPER' 'REGION' region_name 'VALUES' region_name_list
 
 alter_database_alter_super_region ::=
-	'ALTER' 'DATABASE' database_name 'ALTER' 'SUPER' 'REGION' name 'VALUES' name_list
+	'ALTER' 'DATABASE' database_name 'ALTER' 'SUPER' 'REGION' region_name 'VALUES' region_name_list
 
 alter_database_drop_super_region ::=
-	'ALTER' 'DATABASE' database_name 'DROP' 'SUPER' 'REGION' name
+	'ALTER' 'DATABASE' database_name 'DROP' 'SUPER' 'REGION' region_name
 
 alter_database_set_secondary_region_stmt ::=
 	'ALTER' 'DATABASE' database_name 'SET' secondary_region_clause
@@ -2836,6 +2836,7 @@ sequence_option_list ::=
 
 region_name ::=
 	name
+	| 'SCONST'
 
 survival_goal_clause ::=
 	'SURVIVE' opt_equal 'REGION' 'FAILURE'
@@ -2847,6 +2848,9 @@ primary_region_clause ::=
 placement_clause ::=
 	'PLACEMENT' 'RESTRICTED'
 	| 'PLACEMENT' 'DEFAULT'
+
+region_name_list ::=
+	( region_name ) ( ( ',' region_name ) )*
 
 secondary_region_clause ::=
 	'SECONDARY' 'REGION' opt_equal region_name
@@ -2991,11 +2995,8 @@ opt_equal ::=
 region_or_regions ::=
 	'REGIONS'
 
-region_name_list ::=
-	name_list
-
 super_region_clause ::=
-	'SUPER' 'REGION' name 'VALUES' region_name_list
+	'SUPER' 'REGION' region_name 'VALUES' region_name_list
 
 opt_name ::=
 	name

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -2067,7 +2067,7 @@ alter_database_primary_region_stmt:
   }
 
 alter_database_add_super_region:
-  ALTER DATABASE database_name ADD SUPER REGION name VALUES name_list
+  ALTER DATABASE database_name ADD SUPER REGION region_name VALUES region_name_list
   {
     $$.val = &tree.AlterDatabaseAddSuperRegion{
       DatabaseName: tree.Name($3),
@@ -2077,7 +2077,7 @@ alter_database_add_super_region:
   }
 
 alter_database_drop_super_region:
-  ALTER DATABASE database_name DROP SUPER REGION name
+  ALTER DATABASE database_name DROP SUPER REGION region_name
   {
     $$.val = &tree.AlterDatabaseDropSuperRegion{
       DatabaseName: tree.Name($3),
@@ -2086,7 +2086,7 @@ alter_database_drop_super_region:
   }
 
 alter_database_alter_super_region:
-  ALTER DATABASE database_name ALTER SUPER REGION name VALUES name_list
+  ALTER DATABASE database_name ALTER SUPER REGION region_name VALUES region_name_list
   {
     $$.val = &tree.AlterDatabaseAlterSuperRegion{
       DatabaseName: tree.Name($3),
@@ -3423,7 +3423,7 @@ alter_backup_schedule_cmd:
 sconst_or_placeholder:
   SCONST
   {
-    $$.val =  tree.NewStrVal($1)
+    $$.val = tree.NewStrVal($1)
   }
 | PLACEHOLDER
   {
@@ -11332,7 +11332,7 @@ opt_super_region_clause:
 }
 
 super_region_clause:
-SUPER REGION name VALUES region_name_list
+SUPER REGION region_name VALUES region_name_list
 {
   $$.val = tree.SuperRegion{Name: tree.Name($3), Regions: $5.nameList()}
 }
@@ -15653,11 +15653,18 @@ type_name:             db_object_name
 
 sequence_name:         db_object_name
 
-region_name:           name
+region_name:
+  name
+| SCONST
 
-region_name_list:      name_list
+region_name_list:
+  region_name
   {
-    $$.val = $1.nameList()
+    $$.val = tree.NameList{tree.Name($1)}
+  }
+| region_name_list ',' region_name
+  {
+    $$.val = append($1.nameList(), tree.Name($3))
   }
 
 schema_name:           name

--- a/pkg/sql/parser/testdata/create_database
+++ b/pkg/sql/parser/testdata/create_database
@@ -181,6 +181,17 @@ CREATE DATABASE a PRIMARY REGION "us-west-1" -- literals removed
 CREATE DATABASE _ PRIMARY REGION _ -- identifiers removed
 
 parse
+CREATE DATABASE a
+PRIMARY REGION 'us-west-1'
+REGIONS 'us-west-2'
+SUPER REGION uswest VALUES 'us-west-1', 'us-west-2'
+----
+CREATE DATABASE a PRIMARY REGION "us-west-1" REGIONS = "us-west-2" SUPER REGION uswest VALUES "us-west-1","us-west-2" -- normalized!
+CREATE DATABASE a PRIMARY REGION "us-west-1" REGIONS = "us-west-2" SUPER REGION uswest VALUES "us-west-1","us-west-2" -- fully parenthesized
+CREATE DATABASE a PRIMARY REGION "us-west-1" REGIONS = "us-west-2" SUPER REGION uswest VALUES "us-west-1","us-west-2" -- literals removed
+CREATE DATABASE _ PRIMARY REGION _ REGIONS = _ SUPER REGION _ VALUES _,_ -- identifiers removed
+
+parse
 CREATE DATABASE a PRIMARY REGION = "us-west-1"
 ----
 CREATE DATABASE a PRIMARY REGION "us-west-1" -- normalized!


### PR DESCRIPTION
Release note (sql change): Allow string literals for region names in DDL syntax instead of just quoted syntax.

Epic: None