### PR TITLE
tree: fix internal error in SOME, ANY, ALL expressions with the > operator

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/typing
+++ b/pkg/sql/logictest/testdata/logic_test/typing
@@ -261,3 +261,15 @@ SELECT CASE WHEN x > 1 THEN true ELSE NULL OR false END FROM (VALUES (1), (2)) A
 ----
 NULL
 true
+
+# Error "cannot determine type of empty array" should apply no matter the
+# operator, `>`, or `<`.
+query error pq: cannot determine type of empty array\. Consider casting to the desired type, for example ARRAY\[\]::int\[\]
+SELECT ARRAY[]::TIMESTAMPTZ[] >
+       SOME (ARRAY[TIMESTAMPTZ '1969-12-29T21:20:13+01'], ARRAY[NULL]);
+
+# Error "cannot determine type of empty array" should apply no matter the
+# operator, `>`, or `<`.
+query error pq: cannot determine type of empty array\. Consider casting to the desired type, for example ARRAY\[\]::int\[\]
+SELECT ARRAY[]::TIMESTAMPTZ[] <
+       SOME (ARRAY[TIMESTAMPTZ '1969-12-29T21:20:13+01'], ARRAY[NULL]);

--- a/pkg/sql/opt/memo/testdata/typing
+++ b/pkg/sql/opt/memo/testdata/typing
@@ -560,3 +560,48 @@ SELECT (ARRAY[]::color[]) IS NOT NULL
 values
  ├── columns: "?column?":1(bool!null)
  └── (true,) [type=tuple{bool}]
+
+# This comparison should succeed, no matter if `<` or `>` is used.
+build
+SELECT ARRAY[]::TIMESTAMPTZ[] < ARRAY[NULL];
+----
+project
+ ├── columns: "?column?":1(bool)
+ ├── values
+ │    └── () [type=tuple]
+ └── projections
+      └── ARRAY[] < ARRAY[NULL] [as="?column?":1, type=bool]
+
+build
+SELECT ARRAY[]::TIMESTAMPTZ[] > ARRAY[NULL];
+----
+project
+ ├── columns: "?column?":1(bool)
+ ├── values
+ │    └── () [type=tuple]
+ └── projections
+      └── ARRAY[] > ARRAY[NULL] [as="?column?":1, type=bool]
+
+# This comparison should succeed, no matter if `<` or `>` is used.
+build
+SELECT (ARRAY[TIMESTAMPTZ '1969-12-29T21:20:13'], ARRAY[]::TIMESTAMPTZ[]) >
+       (ARRAY[TIMESTAMPTZ '1969-12-29T21:20:13'], ARRAY[NULL]);
+----
+project
+ ├── columns: "?column?":1(bool)
+ ├── values
+ │    └── () [type=tuple]
+ └── projections
+      └── (ARRAY['1969-12-29T21:20:13'::TIMESTAMPTZ], ARRAY[]) > (ARRAY['1969-12-29T21:20:13'::TIMESTAMPTZ], ARRAY[NULL]) [as="?column?":1, type=bool]
+
+# This comparison should succeed, no matter if `<` or `>` is used.
+build
+SELECT (ARRAY[TIMESTAMPTZ '1969-12-29T21:20:13'], ARRAY[]::TIMESTAMPTZ[]) <
+       (ARRAY[TIMESTAMPTZ '1969-12-29T21:20:13'], ARRAY[NULL]);
+----
+project
+ ├── columns: "?column?":1(bool)
+ ├── values
+ │    └── () [type=tuple]
+ └── projections
+      └── (ARRAY['1969-12-29T21:20:13'::TIMESTAMPTZ], ARRAY[]) < (ARRAY['1969-12-29T21:20:13'::TIMESTAMPTZ], ARRAY[NULL]) [as="?column?":1, type=bool]

--- a/pkg/sql/sem/tree/type_check_test.go
+++ b/pkg/sql/sem/tree/type_check_test.go
@@ -294,7 +294,7 @@ func TestTypeCheckError(t *testing.T) {
 		{`3:::int[]`, `incompatible type annotation for 3 as int[], found type: int`},
 		{`B'1001'::decimal`, `invalid cast: varbit -> decimal`},
 		{`101.3::bit`, `invalid cast: decimal -> bit`},
-		{`ARRAY[1] = ARRAY['foo']`, `could not parse "foo" as type int`},
+		{`ARRAY[1] = ARRAY['foo']`, `unsupported comparison operator: <int[]> = <string[]>`},
 		{`ARRAY[1]::int[] = ARRAY[1.0]::decimal[]`, `unsupported comparison operator: <int[]> = <decimal[]>`},
 		{`ARRAY[1] @> ARRAY['foo']`, `unsupported comparison operator: <int[]> @> <string[]>`},
 		{`ARRAY[1]::int[] @> ARRAY[1.0]::decimal[]`, `unsupported comparison operator: <int[]> @> <decimal[]>`},


### PR DESCRIPTION
tree: fix asymmetric typing of > and < expressions
----
The expression `SELECT ARRAY[]::TIMESTAMPTZ[] < ARRAY[NULL];` returns
true, while `SELECT ARRAY[]::TIMESTAMPTZ[] > ARRAY[NULL];` errors with
"unsupported comparison operator: <timestamptz[]> > <string[]>".
This is due to asymmetric behavior in the overload type checker which
prefers to coerce expressions 2,3,4,etc. to the type of the first
expression. When the `>` expression is folded, it's converted to a
`<` expression with the inputs swapped, and type coercion is attempted
in the opposite direction.

The solution is to detect when type coercion in one direction succeeds
when the other direction fails, by calling `typeCheckSameTypedExprs` on
both orders, and initialize the overload type checker with the order which
succeeds.

Release note (bug fix): This patch fixes asymmetric typing of > and <
expressions which may cause erroring of expressions which are legal.

tree: fix internal error in SOME, ANY, ALL expressions with the > operator
----
An expression of the form `leftExpr > SOME(expr1, expr2, expr3...)`
may error out with an internal error while a similar expression,
`leftExpr < SOME(expr1, expr2, expr3...)` does not error out or returns
a sane, non-internal error message. The reason is that the overload type
checker is not symmetrical for type checking comparison expressions
involving tuples. `typeCheckTupleComparison` compares the left expression
with each tuple element, one-at-a-time. For each (left expression, tuple
element) pair, `typeCheckOverloadedExprs` is called to determine the common
type between them. If there is no type for the first expression passed as
a parameter to `typeCheckTupleComparison`, for example for expression `ARRAY[NULL]`,
we apply a desired type of `types.Any` to the expression here:
https://github.com/cockroachdb/cockroach/blob/ddb8efbca439de5698896e941bf96f139fa45849/pkg/sql/sem/tree/overload.go#L781

In this case, the resulting data type is STRING[]. This is no problem if the left
expression is typed first, but in the case of the `>` operation, when folding the
expression it is converted to a `<` operation, and the left and right expressions
are switched, causing the right expression to be typed before the left.

The solution is to specify via a parameter to `typeCheckComparisonOp` whether
the left and right expressions passed to `getOverloadTypeChecker` may be switched.
For SOME, ANY and ALL comparisons with a tuple on the right, switching is
disallowed, forcing the original left expression to be typed first.

Fixes #85390

Release note (bug fix): This patch fixes possible internal errors in SOME,
ANY and ALL expressions of the form: expr > SOME(expr1, expr2, expr3...)
