### PR TITLE
jobs,backupccl,importer: avoid job failure during drain

### DIFF
--- a/pkg/jobs/joberror/errors.go
+++ b/pkg/jobs/joberror/errors.go
@@ -57,9 +57,9 @@ func IsPermanentBulkJobError(err error) bool {
 	if err == nil {
 		return false
 	}
-
 	return !IsDistSQLRetryableError(err) &&
 		!grpcutil.IsClosedConnection(err) &&
+		!flowinfra.IsFlowRetryableError(err) &&
 		!flowinfra.IsNoInboundStreamConnectionError(err) &&
 		!kvcoord.IsSendError(err) &&
 		!isBreakerOpenError(err) &&

--- a/pkg/server/drain.go
+++ b/pkg/server/drain.go
@@ -347,6 +347,9 @@ func (s *drainServer) drainClients(
 		s.drainSleepFn(drainWait.Get(&s.sqlServer.execCfg.Settings.SV))
 	}
 
+	// Inform the job system that the node is draining.
+	s.sqlServer.jobRegistry.SetDraining(true)
+
 	// Wait for users to close the existing SQL connections.
 	// During this phase, the server is rejecting new SQL connections.
 	// The server exits this phase either once all SQL connections are closed,

--- a/pkg/sql/flowinfra/flow_registry.go
+++ b/pkg/sql/flowinfra/flow_registry.go
@@ -301,7 +301,7 @@ func (fr *FlowRegistry) RegisterFlow(
 
 	if draining {
 		return &flowRetryableError{cause: errors.Errorf(
-			"could not register flowID %d because the registry is draining",
+			"could not register flowID %s because the registry is draining",
 			id,
 		)}
 	}


### PR DESCRIPTION
In BACKUP, RESTORE, and IMPORT, the DistSQL flow started from the coordinator return with a retryable context cancellation during node draining.

The in-job retry loop will attempt to construct the flow again, but as the distsql server has already moved to a draining state, it immediately returns an error.

Previously, this error was permanent since our IsPermanentBulkJobError function was not checking flowinfra.IsFlowRetryableError. While this change fixes that, simply retrying the error is not sufficient. Since we are draining, the job will never succeed on this node.

To address this, the drain server now informs the job registry of the fact that it is draining. Our jobs check this state and return a retryable error, allowing another job to adopt the job.

Epic: None

Release note: Fix a bug in which RESTORE, BACKUP, and IMPORT jobs would fail if the coordinator node of the job was drained.