### PR TITLE
acceptance: skip TestDockerCLI

### DIFF
--- a/pkg/acceptance/cli_test.go
+++ b/pkg/acceptance/cli_test.go
@@ -33,6 +33,7 @@ var cmdBase = []string{
 }
 
 func TestDockerCLI(t *testing.T) {
+	skip.WithIssue(t, 96797, "flaky test")
 	s := log.Scope(t)
 	defer s.Close(t)
 


### PR DESCRIPTION
Refs: #96797

Reason: flaky test

Generated by bin/skip-test.

Release justification: non-production code changes

Epic: None

Release note: None