### PR TITLE
acceptance: skip TestDockerCLI test_demo_partitioning.tcl only

### DIFF
--- a/pkg/cli/interactive_tests/test_demo_partitioning.tcl.disabled
+++ b/pkg/cli/interactive_tests/test_demo_partitioning.tcl.disabled
@@ -1,5 +1,9 @@
 #! /usr/bin/env expect -f
 
+# This test is skipped (flaky test) -- its filename lets it hide from the selector in
+# TestDockerCLI. Un-skip it by renaming after fixing
+# https://github.com/cockroachdb/cockroach/issues/96797.
+
 source [file join [file dirname $argv0] common.tcl]
 
 # Set a larger timeout as partitioning can be slow.


### PR DESCRIPTION
Renamed `test_demo_partitioning.tcl` to `test_demo_partitioning.tcl.disabled` which will cause TestDockerCLI to skip the test file.

Refs: #96797

Reason: flaky test

Epic: None

Release note: None