### PR TITLE
sql: use udf in check constraint

### DIFF
--- a/docs/generated/sql/bnf/stmt_block.bnf
+++ b/docs/generated/sql/bnf/stmt_block.bnf
@@ -1360,6 +1360,7 @@ unreserved_keyword ::=
 	| 'SKIP_MISSING_SEQUENCES'
 	| 'SKIP_MISSING_SEQUENCE_OWNERS'
 	| 'SKIP_MISSING_VIEWS'
+	| 'SKIP_MISSING_UDFS'
 	| 'SNAPSHOT'
 	| 'SPLIT'
 	| 'SQL'
@@ -2615,6 +2616,7 @@ restore_options ::=
 	| 'SKIP_MISSING_SEQUENCES'
 	| 'SKIP_MISSING_SEQUENCE_OWNERS'
 	| 'SKIP_MISSING_VIEWS'
+	| 'SKIP_MISSING_UDFS'
 	| 'DETACHED'
 	| 'SKIP_LOCALITIES_CHECK'
 	| 'DEBUG_PAUSE_ON' '=' string_or_placeholder
@@ -3438,6 +3440,7 @@ bare_label_keywords ::=
 	| 'TRANSFORM'
 	| 'VOLATILE'
 	| 'SETOF'
+	| 'SKIP_MISSING_VIEWS'
 
 opt_col_def_list_no_types ::=
 	'(' col_def_list_no_types ')'

--- a/pkg/ccl/backupccl/backup_telemetry.go
+++ b/pkg/ccl/backupccl/backup_telemetry.go
@@ -65,6 +65,7 @@ const (
 	telemetryOptionSkipMissingViews          = "skip_missing_views"
 	telemetryOptionSkipLocalitiesCheck       = "skip_localities_check"
 	telemetryOptionSchemaOnly                = "schema_only"
+	telemetryOptionSkipMissingUDFs           = "skip_missing_udfs"
 )
 
 // logBackupTelemetry publishes an eventpb.RecoveryEvent about a manually
@@ -395,6 +396,9 @@ func logRestoreTelemetry(
 	}
 	if opts.SkipMissingSequenceOwners {
 		options = append(options, telemetryOptionSkipMissingSequenceOwners)
+	}
+	if opts.SkipMissingUDFs {
+		options = append(options, telemetryOptionSkipMissingUDFs)
 	}
 	if opts.Detached {
 		options = append(options, telemetryOptionDetached)

--- a/pkg/ccl/backupccl/testdata/backup-restore/user-defined-functions-in-checks
+++ b/pkg/ccl/backupccl/testdata/backup-restore/user-defined-functions-in-checks
@@ -1,0 +1,228 @@
+# Test backing up and restoring a database with user defined functions.
+new-cluster name=s
+----
+
+exec-sql
+CREATE DATABASE db1;
+USE db1;
+CREATE SCHEMA sc1;
+CREATE FUNCTION sc1.f1(a INT) RETURNS INT LANGUAGE SQL AS $$
+  SELECT a + 1;
+$$;
+CREATE TABLE sc1.t1(a INT PRIMARY KEY, b INT CHECK(sc1.f1(b) > 1));
+----
+
+exec-sql
+BACKUP DATABASE db1 INTO 'nodelocal://0/test/'
+----
+
+query-sql
+WITH descs AS (
+  SHOW BACKUP LATEST IN 'nodelocal://0/test/'
+)
+SELECT database_name, parent_schema_name, object_name, object_type, is_full_cluster FROM descs
+----
+<nil> <nil> db1 database false
+db1 <nil> public schema false
+db1 <nil> sc1 schema false
+db1 sc1 f1 function false
+db1 sc1 t1 table false
+
+exec-sql
+RESTORE DATABASE db1 FROM LATEST IN 'nodelocal://0/test/' WITH new_db_name = db1_new
+----
+
+exec-sql
+USE db1_new
+----
+
+# Make sure function ids in CHECK constraint are rewritten.
+query-sql
+SELECT create_statement FROM [SHOW CREATE TABLE sc1.t1]
+----
+CREATE TABLE sc1.t1 (
+	a INT8 NOT NULL,
+	b INT8 NULL,
+	CONSTRAINT t1_pkey PRIMARY KEY (a ASC),
+	CONSTRAINT check_b CHECK (sc1.f1(b) > 1:::INT8)
+)
+
+# Make sure that the CHECK constraint still applies correctly
+query-sql
+INSERT INTO sc1.t1 VALUES (1, 0)
+----
+pq: failed to satisfy CHECK constraint (sc1.f1(b) > 1:::INT8)
+
+# Make sure dependency IDs are rewritten.
+# Note that technically this only tests forward-reference IDs in depended-on
+# objects are rewritten. But since we have cross-references validation, so this
+# also means back-references in UDF descriptor are good.
+exec-sql
+DROP FUNCTION sc1.f1
+----
+pq: cannot drop function "f1" because other objects ([db1_new.sc1.t1]) still depend on it
+
+# Test backing up and restoring a full cluster with user defined function.
+new-cluster name=s1
+----
+
+exec-sql cluster=s1
+CREATE DATABASE db1;
+USE db1;
+CREATE SCHEMA sc1;
+CREATE FUNCTION sc1.f1(a INT) RETURNS INT LANGUAGE SQL AS $$
+  SELECT a + 1;
+$$;
+CREATE TABLE sc1.t1(a INT PRIMARY KEY, b INT CHECK(sc1.f1(b) > 1));
+----
+
+exec-sql
+BACKUP INTO 'nodelocal://0/test/'
+----
+
+query-sql
+WITH descs AS (
+  SHOW BACKUP LATEST IN 'nodelocal://0/test/'
+)
+SELECT
+  database_name, parent_schema_name, object_name, object_type, is_full_cluster
+FROM
+  descs
+WHERE
+  database_name = 'db1'
+----
+db1 <nil> public schema true
+db1 <nil> sc1 schema true
+db1 sc1 f1 function true
+db1 sc1 t1 table true
+
+# Start a new cluster with the same IO dir.
+new-cluster name=s2 share-io-dir=s1
+----
+
+# Restore into the new cluster.
+exec-sql cluster=s2
+RESTORE FROM LATEST IN 'nodelocal://0/test/'
+----
+
+exec-sql
+USE db1
+----
+
+# Make sure function ids in CHECK constraint are rewritten.
+query-sql
+SELECT create_statement FROM [SHOW CREATE TABLE sc1.f1]
+----
+pq: relation "sc1.f1" does not exist
+
+# Make sure that CHECK constraint still applies correctly
+query-sql
+INSERT INTO sc1.t1 VALUES (1, 0)
+----
+pq: failed to satisfy CHECK constraint (sc1.f1(b) > 1:::INT8)
+
+# Make sure dependency IDs are rewritten.
+# Note that technically this only tests forward-reference IDs in depended-on
+# objects are rewritten. But since we have cross-references validation, so this
+# also means back-references in UDF descriptor are good.
+exec-sql
+DROP FUNCTION sc1.f1
+----
+pq: cannot drop function "f1" because other objects ([db1.sc1.t1]) still depend on it
+
+# Make sure that backup and restore individual tables referencing UDFs able to
+# drop check constraints.
+new-cluster name=s3
+----
+
+exec-sql cluster=s3
+CREATE DATABASE db1;
+CREATE DATABASE db2;
+CREATE DATABASE db3;
+USE db1;
+CREATE SCHEMA sc1;
+CREATE FUNCTION sc1.f1(a INT) RETURNS INT LANGUAGE SQL AS $$
+  SELECT a + 1;
+$$;
+CREATE TABLE sc1.t1(a INT PRIMARY KEY, b INT CHECK(sc1.f1(b) > 1));
+----
+
+exec-sql
+BACKUP DATABASE db1 INTO 'nodelocal://0/test/'
+----
+
+query-sql
+WITH descs AS (
+  SHOW BACKUP LATEST IN 'nodelocal://0/test/'
+)
+SELECT database_name, parent_schema_name, object_name, object_type, is_full_cluster FROM descs
+----
+<nil> <nil> db1 database false
+db1 <nil> public schema false
+db1 <nil> sc1 schema false
+db1 sc1 f1 function false
+db1 sc1 t1 table false
+
+exec-sql
+RESTORE TABLE sc1.t1 FROM LATEST IN 'nodelocal://0/test/' WITH into_db = 'db2';
+----
+pq: cannot restore table "t1" without referenced function 114 (or "skip_missing_udfs" option)
+
+exec-sql
+RESTORE TABLE sc1.t1 FROM LATEST IN 'nodelocal://0/test/' WITH into_db = 'db2', skip_missing_udfs;
+----
+
+exec-sql
+USE db2
+----
+
+# Make sure CHECK constraint is dropped.
+query-sql
+SELECT create_statement FROM [SHOW CREATE TABLE sc1.t1]
+----
+CREATE TABLE sc1.t1 (
+	a INT8 NOT NULL,
+	b INT8 NULL,
+	CONSTRAINT t1_pkey PRIMARY KEY (a ASC)
+)
+
+exec-sql
+USE db1
+----
+
+exec-sql
+BACKUP TABLE sc1.t1 INTO 'nodelocal://0/test/'
+----
+
+query-sql
+WITH descs AS (
+  SHOW BACKUP LATEST IN 'nodelocal://0/test/'
+)
+SELECT database_name, parent_schema_name, object_name, object_type, is_full_cluster FROM descs
+----
+<nil> <nil> db1 database false
+db1 <nil> sc1 schema false
+db1 sc1 t1 table false
+
+exec-sql
+RESTORE TABLE sc1.t1 FROM LATEST IN 'nodelocal://0/test/' WITH into_db = 'db3';
+----
+pq: cannot restore table "t1" without referenced function 114 (or "skip_missing_udfs" option)
+
+exec-sql
+RESTORE TABLE sc1.t1 FROM LATEST IN 'nodelocal://0/test/' WITH into_db = 'db3', skip_missing_udfs;
+----
+
+exec-sql
+USE db3
+----
+
+# Make sure CHECK constraint is dropped.
+query-sql
+SELECT create_statement FROM [SHOW CREATE TABLE sc1.t1]
+----
+CREATE TABLE sc1.t1 (
+	a INT8 NOT NULL,
+	b INT8 NULL,
+	CONSTRAINT t1_pkey PRIMARY KEY (a ASC)
+)

--- a/pkg/ccl/logictestccl/tests/3node-tenant/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/3node-tenant/generated_test.go
@@ -2026,6 +2026,13 @@ func TestTenantLogic_udf(
 	runLogicTest(t, "udf")
 }
 
+func TestTenantLogic_udf_in_constraints(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "udf_in_constraints")
+}
+
 func TestTenantLogic_udf_oid_ref(
 	t *testing.T,
 ) {

--- a/pkg/ccl/schemachangerccl/backup_base_generated_test.go
+++ b/pkg/ccl/schemachangerccl/backup_base_generated_test.go
@@ -38,6 +38,11 @@ func TestBackup_base_add_column_no_default(t *testing.T) {
 	defer log.Scope(t).Close(t)
 	sctest.Backup(t, "pkg/sql/schemachanger/testdata/end_to_end/add_column_no_default", newCluster)
 }
+func TestBackup_base_alter_table_add_check_udf(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	sctest.Backup(t, "pkg/sql/schemachanger/testdata/end_to_end/alter_table_add_check_udf", newCluster)
+}
 func TestBackup_base_alter_table_add_check_unvalidated(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)

--- a/pkg/ccl/schemachangerccl/backup_base_mixed_generated_test.go
+++ b/pkg/ccl/schemachangerccl/backup_base_mixed_generated_test.go
@@ -38,6 +38,11 @@ func TestBackupMixedVersionElements_base_add_column_no_default(t *testing.T) {
 	defer log.Scope(t).Close(t)
 	sctest.BackupMixedVersionElements(t, "pkg/sql/schemachanger/testdata/end_to_end/add_column_no_default", newClusterMixed)
 }
+func TestBackupMixedVersionElements_base_alter_table_add_check_udf(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	sctest.BackupMixedVersionElements(t, "pkg/sql/schemachanger/testdata/end_to_end/alter_table_add_check_udf", newClusterMixed)
+}
 func TestBackupMixedVersionElements_base_alter_table_add_check_unvalidated(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)

--- a/pkg/ccl/schemachangerccl/testdata/decomp/multiregion
+++ b/pkg/ccl/schemachangerccl/testdata/decomp/multiregion
@@ -278,6 +278,7 @@ ElementState:
     expr: unique_rowid()
     referencedColumnIds: []
     tableId: 110
+    usesFunctionIds: []
     usesSequenceIds: []
     usesTypeIds: []
   Status: PUBLIC
@@ -555,6 +556,7 @@ ElementState:
     expr: unique_rowid()
     referencedColumnIds: []
     tableId: 109
+    usesFunctionIds: []
     usesSequenceIds: []
     usesTypeIds: []
   Status: PUBLIC
@@ -883,6 +885,7 @@ ElementState:
     expr: default_to_database_primary_region(gateway_region())::@100106
     referencedColumnIds: []
     tableId: 108
+    usesFunctionIds: []
     usesSequenceIds: []
     usesTypeIds:
     - 106

--- a/pkg/sql/BUILD.bazel
+++ b/pkg/sql/BUILD.bazel
@@ -118,6 +118,7 @@ go_library(
         "explain_vec.go",
         "export.go",
         "filter.go",
+        "function_references.go",
         "generate_objects.go",
         "gossip.go",
         "grant_revoke.go",

--- a/pkg/sql/add_column.go
+++ b/pkg/sql/add_column.go
@@ -140,6 +140,7 @@ func (p *planner) addColumnImpl(
 	if d.IsComputed() {
 		serializedExpr, _, err := schemaexpr.ValidateComputedColumnExpression(
 			params.ctx, n.tableDesc, d, tn, tree.ComputedColumnExprContext(d.IsVirtual()), params.p.SemaCtx(),
+			params.ExecCfg().Settings.Version.ActiveVersion(params.ctx),
 		)
 		if err != nil {
 			return err

--- a/pkg/sql/add_column.go
+++ b/pkg/sql/add_column.go
@@ -139,7 +139,7 @@ func (p *planner) addColumnImpl(
 
 	if d.IsComputed() {
 		serializedExpr, _, err := schemaexpr.ValidateComputedColumnExpression(
-			params.ctx, n.tableDesc, d, tn, "computed column", params.p.SemaCtx(),
+			params.ctx, n.tableDesc, d, tn, tree.ComputedColumnExprContext(d.IsVirtual()), params.p.SemaCtx(),
 		)
 		if err != nil {
 			return err

--- a/pkg/sql/alter_column_type.go
+++ b/pkg/sql/alter_column_type.go
@@ -286,6 +286,7 @@ func alterColumnTypeGeneral(
 			&params.p.semaCtx,
 			volatility.Volatile,
 			tn,
+			params.ExecCfg().Settings.Version.ActiveVersion(ctx),
 		)
 
 		if err != nil {

--- a/pkg/sql/alter_column_type.go
+++ b/pkg/sql/alter_column_type.go
@@ -282,7 +282,7 @@ func alterColumnTypeGeneral(
 			tableDesc,
 			using,
 			toType,
-			"ALTER COLUMN TYPE USING EXPRESSION",
+			tree.AlterColumnTypeUsingExpr,
 			&params.p.semaCtx,
 			volatility.Volatile,
 			tn,

--- a/pkg/sql/backfill.go
+++ b/pkg/sql/backfill.go
@@ -463,6 +463,23 @@ func (sc *SchemaChanger) dropConstraints(
 						constraint,
 					)
 				}
+				// Either it's found or not we need to always try to remove the references.
+				// 1. If it's found, we should just remove reference.
+				// 2. If it's not found, which means it's in a rollback or job retry, we
+				// should remove the reference we added earlier before constraint
+				// validation's failure.
+				ck := constraint.AsCheck()
+				backrefFns, err := removeCheckBackReferenceInFunctions(
+					ctx, scTable, ck.CheckDesc(), txn.Descriptors(), txn.KV(),
+				)
+				if err != nil {
+					return err
+				}
+				for _, fn := range backrefFns {
+					if err := txn.Descriptors().WriteDescToBatch(ctx, true /* kvTrace */, fn, b); err != nil {
+						return err
+					}
+				}
 			} else if fk := constraint.AsForeignKey(); fk != nil {
 				var foundExisting bool
 				for j := range scTable.OutboundFKs {
@@ -602,6 +619,22 @@ func (sc *SchemaChanger) addConstraints(
 				}
 				if !found {
 					scTable.Checks = append(scTable.Checks, ck.CheckDesc())
+					fnIDs, err := scTable.GetAllReferencedFunctionIDsInConstraint(ck.GetConstraintID())
+					if err != nil {
+						return err
+					}
+					for _, fnID := range fnIDs.Ordered() {
+						fnDesc, err := txn.Descriptors().MutableByID(txn.KV()).Function(ctx, fnID)
+						if err != nil {
+							return err
+						}
+						if err := fnDesc.AddConstraintReference(scTable.GetID(), ck.GetConstraintID()); err != nil {
+							return err
+						}
+						if err := txn.Descriptors().WriteDescToBatch(ctx, true /* kvTrace */, fnDesc, b); err != nil {
+							return err
+						}
+					}
 				}
 			} else if fk := constraint.AsForeignKey(); fk != nil {
 				var foundExisting bool
@@ -759,6 +792,7 @@ func (sc *SchemaChanger) validateConstraints(
 				resolver := descs.NewDistSQLTypeResolver(collection, txn.KV())
 				semaCtx := tree.MakeSemaContext()
 				semaCtx.TypeResolver = &resolver
+				semaCtx.FunctionResolver = descs.NewDistSQLFunctionResolver(collection, txn.KV())
 				// TODO (rohany): When to release this? As of now this is only going to get released
 				//  after the check is validated.
 				defer func() { collection.ReleaseAll(ctx) }()
@@ -1529,7 +1563,8 @@ func ValidateConstraint(
 		resolver := NewSkippingCacheSchemaResolver(txn.Descriptors(), sessiondata.NewStack(sessionData), txn.KV(), nil /* authAccessor */)
 		semaCtx := tree.MakeSemaContext()
 		semaCtx.TypeResolver = resolver
-		semaCtx.TableNameResolver = resolver
+		semaCtx.NameResolver = resolver
+		semaCtx.FunctionResolver = descs.NewDistSQLFunctionResolver(txn.Descriptors(), txn.KV())
 		defer func() { txn.Descriptors().ReleaseAll(ctx) }()
 
 		switch catalog.GetConstraintType(constraint) {
@@ -2459,6 +2494,9 @@ func runSchemaChangesInTxn(
 					for i := range tableDesc.Checks {
 						if tableDesc.Checks[i].Name == c.GetName() {
 							tableDesc.Checks = append(tableDesc.Checks[:i], tableDesc.Checks[i+1:]...)
+							if err := planner.removeCheckBackReferenceInFunctions(ctx, tableDesc, c.AsCheck().CheckDesc()); err != nil {
+								return err
+							}
 							break
 						}
 					}

--- a/pkg/sql/catalog/descpb/structured.proto
+++ b/pkg/sql/catalog/descpb/structured.proto
@@ -968,6 +968,11 @@ message TableDescriptor {
   repeated uint32 dependsOnTypes = 45 [(gogoproto.customname) = "DependsOnTypes",
     (gogoproto.casttype) = "ID"];
 
+  // The IDs of all functions that this depends on.
+  // Only ever populated if this descriptor is for a view.
+  repeated uint32 depends_on_functions = 55 [(gogoproto.customname) = "DependsOnFunctions",
+    (gogoproto.casttype) = "ID"];
+
   message Reference {
     option (gogoproto.equal) = true;
     // The ID of the relation that depends on this one.
@@ -1165,7 +1170,7 @@ message TableDescriptor {
   // This field is non zero if this table is offline during an import.
   optional int64 import_start_wall_time = 54 [(gogoproto.nullable) = false, (gogoproto.customname) = "ImportStartWallTime"];
 
-  // Next ID: 55
+  // Next ID: 56
 }
 
 // SurvivalGoal is the survival goal for a database.

--- a/pkg/sql/catalog/descriptor.go
+++ b/pkg/sql/catalog/descriptor.go
@@ -578,6 +578,16 @@ type TableDescriptor interface {
 		databaseDesc DatabaseDescriptor, getType func(descpb.ID) (TypeDescriptor, error),
 	) (referencedAnywhere, referencedInColumns descpb.IDs, _ error)
 
+	// GetAllReferencedFunctionIDs returns descriptor IDs of all user defined
+	// functions referenced in this table.
+	GetAllReferencedFunctionIDs() (DescriptorIDSet, error)
+
+	// GetAllReferencedFunctionIDsInConstraint returns descriptor IDs of all user
+	// defined functions referenced in this check constraint.
+	GetAllReferencedFunctionIDsInConstraint(
+		cstID descpb.ConstraintID,
+	) (DescriptorIDSet, error)
+
 	// ForeachDependedOnBy runs a function on all indexes, including those being
 	// added in the mutations.
 	ForeachDependedOnBy(f func(dep *descpb.TableDescriptor_Reference) error) error
@@ -589,6 +599,9 @@ type TableDescriptor interface {
 	// GetDependsOnTypes returns the IDs of all types that this view depends on.
 	// It's only non-nil if IsView is true.
 	GetDependsOnTypes() []descpb.ID
+	// GetDependsOnFunctions returns the IDs of all functions that this view
+	// depends on. It's only non-nil if IsView is true.
+	GetDependsOnFunctions() []descpb.ID
 
 	// AllConstraints returns all constraints in this table, regardless if
 	// they're enforced yet or not. The ordering of the constraints within this

--- a/pkg/sql/catalog/descriptor_id_set.go
+++ b/pkg/sql/catalog/descriptor_id_set.go
@@ -117,6 +117,11 @@ func (s *ConstraintIDSet) Len() int {
 	return s.set.Len()
 }
 
+// Contains checks if the set contains the given id.
+func (s *ConstraintIDSet) Contains(id descpb.ConstraintID) bool {
+	return s.set.Contains(int(id))
+}
+
 // Ordered returns all ids as a ordered slice.
 func (s *ConstraintIDSet) Ordered() []descpb.ConstraintID {
 	if s.Empty() {

--- a/pkg/sql/catalog/descriptor_id_set.go
+++ b/pkg/sql/catalog/descriptor_id_set.go
@@ -82,3 +82,49 @@ func (d DescriptorIDSet) Difference(o DescriptorIDSet) DescriptorIDSet {
 func (d DescriptorIDSet) Union(o DescriptorIDSet) DescriptorIDSet {
 	return DescriptorIDSet{set: d.set.Union(o.set)}
 }
+
+// ConstraintIDSet stores an unordered set of descriptor ids.
+type ConstraintIDSet struct {
+	set intsets.Fast
+}
+
+// MakeConstraintIDSet returns a set initialized with the given values.
+func MakeConstraintIDSet(ids ...descpb.ConstraintID) ConstraintIDSet {
+	s := ConstraintIDSet{}
+	for _, id := range ids {
+		s.Add(id)
+	}
+	return s
+}
+
+// Add adds an id to the set. No-op if the id is already in the set.
+func (s *ConstraintIDSet) Add(id descpb.ConstraintID) {
+	s.set.Add(int(id))
+}
+
+// Remove removes the ID from the set.
+func (s *ConstraintIDSet) Remove(id descpb.ConstraintID) {
+	s.set.Remove(int(id))
+}
+
+// Empty returns true if the set is empty.
+func (s *ConstraintIDSet) Empty() bool {
+	return s.set.Empty()
+}
+
+// Len returns the number of ids in the set.
+func (s *ConstraintIDSet) Len() int {
+	return s.set.Len()
+}
+
+// Ordered returns all ids as a ordered slice.
+func (s *ConstraintIDSet) Ordered() []descpb.ConstraintID {
+	if s.Empty() {
+		return nil
+	}
+	result := make([]descpb.ConstraintID, 0, s.Len())
+	s.set.ForEach(func(i int) {
+		result = append(result, descpb.ConstraintID(i))
+	})
+	return result
+}

--- a/pkg/sql/catalog/descs/BUILD.bazel
+++ b/pkg/sql/catalog/descs/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
     srcs = [
         "collection.go",
         "descriptor.go",
+        "dist_sql_function_resolver.go",
         "dist_sql_type_resolver.go",
         "errors.go",
         "factory.go",

--- a/pkg/sql/catalog/descs/dist_sql_function_resolver.go
+++ b/pkg/sql/catalog/descs/dist_sql_function_resolver.go
@@ -1,0 +1,91 @@
+// Copyright 2023 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package descs
+
+import (
+	"context"
+
+	"github.com/cockroachdb/cockroach/pkg/kv"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/funcdesc"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/errors"
+	"github.com/lib/pq/oid"
+)
+
+// DistSQLFunctionResolver is a tree.FunctionReferenceResolver that resolves
+// builtin function by name while resolves user defined function by oid. Given
+// the fact that expression in tables are serialized. We only serialize user
+// defined function into OID references, but not builtin functions.
+// TODO(chengxiong): extract resolution logics in schema_resolver.go into
+// separate package so that it can be reused here.
+type DistSQLFunctionResolver struct {
+	g ByIDGetter
+}
+
+// NewDistSQLFunctionResolver returns a new DistSQLFunctionResolver.
+func NewDistSQLFunctionResolver(descs *Collection, txn *kv.Txn) *DistSQLFunctionResolver {
+	return &DistSQLFunctionResolver{
+		g: descs.ByIDWithLeased(txn).Get(),
+	}
+}
+
+// ResolveFunction implements tree.FunctionReferenceResolver interface.
+// It only resolves builtin functions.
+// TODO(chengxiong): extract resolution logics in schema_resolver.go into
+// separate package so that it can be reused here.
+func (d *DistSQLFunctionResolver) ResolveFunction(
+	ctx context.Context, name *tree.UnresolvedName, path tree.SearchPath,
+) (*tree.ResolvedFunctionDefinition, error) {
+	fn, err := name.ToFunctionName()
+	if err != nil {
+		return nil, err
+	}
+	// Get builtin and udf functions if there is any match.
+	builtinDef, err := tree.GetBuiltinFuncDefinition(fn, path)
+	if err != nil {
+		return nil, err
+	}
+	if builtinDef == nil {
+		return nil, errors.Wrapf(tree.ErrFunctionUndefined, "function %s not found", fn.Object())
+	}
+	return builtinDef, nil
+}
+
+// ResolveFunctionByOID implements tree.FunctionReferenceResolver interface.
+// It only resolves user defined functions.
+// TODO(chengxiong): extract resolution logics in schema_resolver.go into
+// separate package so that it can be reused here.
+func (d *DistSQLFunctionResolver) ResolveFunctionByOID(
+	ctx context.Context, oid oid.Oid,
+) (*tree.FunctionName, *tree.Overload, error) {
+	if !funcdesc.IsOIDUserDefinedFunc(oid) {
+		return nil, nil, errors.Wrapf(tree.ErrFunctionUndefined, "function %d not found", oid)
+	}
+	descID := funcdesc.UserDefinedFunctionOIDToID(oid)
+	funcDesc, err := d.g.Function(ctx, descID)
+	if err != nil {
+		return nil, nil, err
+	}
+	ret, err := funcDesc.ToOverload()
+	if err != nil {
+		return nil, nil, err
+	}
+	db, err := d.g.Database(ctx, funcDesc.GetParentID())
+	if err != nil {
+		return nil, nil, err
+	}
+	sc, err := d.g.Schema(ctx, funcDesc.GetParentSchemaID())
+	if err != nil {
+		return nil, nil, err
+	}
+	fnName := tree.MakeQualifiedFunctionName(db.GetName(), sc.GetName(), funcDesc.GetName())
+	return &fnName, ret, nil
+}

--- a/pkg/sql/catalog/rewrite/rewrite.go
+++ b/pkg/sql/catalog/rewrite/rewrite.go
@@ -71,6 +71,48 @@ func TableDescs(
 		table.UnexposedParentSchemaID = tableRewrite.ParentSchemaID
 		table.ParentID = tableRewrite.ParentID
 
+		// Rewrite CHECK constraints before function IDs in expressions are
+		// rewritten. Check constraint mutations are also dropped if any function
+		// referenced are missing.
+		var newChecks []*descpb.TableDescriptor_CheckConstraint
+		for i := range table.Checks {
+			fnIDs, err := table.GetAllReferencedFunctionIDsInConstraint(table.Checks[i].ConstraintID)
+			if err != nil {
+				return err
+			}
+			allFnFound := true
+			for _, fnID := range fnIDs.Ordered() {
+				if _, ok := descriptorRewrites[fnID]; !ok {
+					allFnFound = false
+					break
+				}
+			}
+			if allFnFound {
+				newChecks = append(newChecks, table.Checks[i])
+			}
+		}
+		table.Checks = newChecks
+		var newMutations []descpb.DescriptorMutation
+		for i := range table.Mutations {
+			keepMutation := true
+			if c := table.Mutations[i].GetConstraint(); c != nil && c.ConstraintType == descpb.ConstraintToUpdate_CHECK {
+				fnIDs, err := table.GetAllReferencedFunctionIDsInConstraint(c.Check.ConstraintID)
+				if err != nil {
+					return err
+				}
+				for _, fnID := range fnIDs.Ordered() {
+					if _, ok := descriptorRewrites[fnID]; !ok {
+						keepMutation = false
+						break
+					}
+				}
+			}
+			if keepMutation {
+				newMutations = append(newMutations, table.Mutations[i])
+			}
+		}
+		table.Mutations = newMutations
+
 		// Remap type IDs and sequence IDs in all serialized expressions within the TableDescriptor.
 		// TODO (rohany): This needs tests once partial indexes are ready.
 		if err := tabledesc.ForEachExprStringInTableDesc(table, func(expr *string) error {
@@ -81,6 +123,12 @@ func TableDescs(
 			*expr = newExpr
 
 			newExpr, err = rewriteSequencesInExpr(*expr, descriptorRewrites)
+			if err != nil {
+				return err
+			}
+			*expr = newExpr
+
+			newExpr, err = rewriteFunctionsInExpr(*expr, descriptorRewrites)
 			if err != nil {
 				return err
 			}
@@ -360,6 +408,40 @@ func rewriteSequencesInExpr(expr string, rewrites jobspb.DescRewriteMap) (string
 	return newExpr.String(), nil
 }
 
+func rewriteFunctionsInExpr(expr string, rewrites jobspb.DescRewriteMap) (string, error) {
+	parsed, err := parser.ParseExpr(expr)
+	if err != nil {
+		return "", err
+	}
+
+	replaceFunc := func(ex tree.Expr) (recurse bool, newExpr tree.Expr, err error) {
+		funcExpr, ok := ex.(*tree.FuncExpr)
+		if !ok {
+			return true, ex, nil
+		}
+		oidRef, ok := funcExpr.Func.FunctionReference.(*tree.FunctionOID)
+		if !ok {
+			return true, ex, nil
+		}
+		if !funcdesc.IsOIDUserDefinedFunc(oidRef.OID) {
+			return true, ex, nil
+		}
+		fnID := funcdesc.UserDefinedFunctionOIDToID(oidRef.OID)
+		rewriteID := catid.FuncIDToOID(rewrites[fnID].ID)
+		newFuncExpr := *funcExpr
+		newFuncExpr.Func = tree.ResolvableFunctionReference{
+			FunctionReference: &tree.FunctionOID{OID: rewriteID},
+		}
+		return true, &newFuncExpr, nil
+	}
+
+	newExpr, err := tree.SimpleVisit(parsed, replaceFunc)
+	if err != nil {
+		return "", err
+	}
+	return newExpr.String(), nil
+}
+
 func makeSequenceReplaceFunc(
 	rewrites jobspb.DescRewriteMap,
 ) func(expr tree.Expr) (recurse bool, newExpr tree.Expr, err error) {
@@ -589,6 +671,8 @@ func rewriteSchemaChangerState(
 			err = errors.Wrap(err, "rewriting declarative schema changer state")
 		}
 	}()
+
+	var droppedConstraints catalog.ConstraintIDSet
 	for i := 0; i < len(state.Targets); i++ {
 		t := &state.Targets[i]
 		if err := screl.WalkDescIDs(t.Element(), func(id *descpb.ID) error {
@@ -604,9 +688,9 @@ func rewriteSchemaChangerState(
 			*id = rewrite.ID
 			return nil
 		}); err != nil {
-			// We'll permit this in the special case of a schema parent element.
 			switch el := t.Element().(type) {
 			case *scpb.SchemaParent:
+				// We'll permit this in the special case of a schema parent element.
 				_, scExists := descriptorRewrites[el.SchemaID]
 				if !scExists && state.CurrentStatuses[i] == scpb.Status_ABSENT {
 					state.Targets = append(state.Targets[:i], state.Targets[i+1:]...)
@@ -615,6 +699,15 @@ func rewriteSchemaChangerState(
 					i--
 					continue
 				}
+			case *scpb.CheckConstraint:
+				// IF there is any dependency missing for check constraint, we just drop
+				// the target.
+				state.Targets = append(state.Targets[:i], state.Targets[i+1:]...)
+				state.CurrentStatuses = append(state.CurrentStatuses[:i], state.CurrentStatuses[i+1:]...)
+				state.TargetRanks = append(state.TargetRanks[:i], state.TargetRanks[i+1:]...)
+				i--
+				droppedConstraints.Add(el.ConstraintID)
+				continue
 			}
 			return errors.Wrap(err, "rewriting descriptor ids")
 		}
@@ -631,6 +724,10 @@ func rewriteSchemaChangerState(
 			if err != nil {
 				return errors.Wrapf(err, "rewriting expression sequence references: %q", newExpr)
 			}
+			newExpr, err = rewriteFunctionsInExpr(newExpr, descriptorRewrites)
+			if err != nil {
+				return errors.Wrapf(err, "rewriting expression function references: %q", newExpr)
+			}
 			*expr = catpb.Expression(newExpr)
 			return nil
 		}); err != nil {
@@ -643,6 +740,22 @@ func rewriteSchemaChangerState(
 		}
 		// TODO(ajwerner): Remember to rewrite views when the time comes. Currently
 		// views are not handled by the declarative schema changer.
+	}
+
+	for i := 0; i < len(state.Targets); i++ {
+		t := &state.Targets[i]
+		if err := screl.WalkConstraintIDs(t.Element(), func(id *catid.ConstraintID) error {
+			if !droppedConstraints.Contains(*id) {
+				return nil
+			}
+			state.Targets = append(state.Targets[:i], state.Targets[i+1:]...)
+			state.CurrentStatuses = append(state.CurrentStatuses[:i], state.CurrentStatuses[i+1:]...)
+			state.TargetRanks = append(state.TargetRanks[:i], state.TargetRanks[i+1:]...)
+			i--
+			return nil
+		}); err != nil {
+			return err
+		}
 	}
 	d.SetDeclarativeSchemaChangerState(state)
 	return nil
@@ -757,6 +870,17 @@ func FunctionDescs(
 				return errors.AssertionFailedf(
 					"cannot restore function %q because referenced type %d was not found",
 					fnDesc.Name, typID)
+			}
+		}
+
+		// Rewrite back reference IDs.
+		for i, dep := range fnDesc.DependedOnBy {
+			if depRewrite, ok := descriptorRewrites[dep.ID]; ok {
+				fnDesc.DependedOnBy[i].ID = depRewrite.ID
+			} else {
+				return errors.AssertionFailedf(
+					"cannot restore function %q because back referenced relation %d was not found",
+					fnDesc.Name, dep.ID)
 			}
 		}
 	}

--- a/pkg/sql/catalog/schemaexpr/BUILD.bazel
+++ b/pkg/sql/catalog/schemaexpr/BUILD.bazel
@@ -25,6 +25,7 @@ go_library(
         "//pkg/sql/catalog/catpb",
         "//pkg/sql/catalog/colinfo",
         "//pkg/sql/catalog/descpb",
+        "//pkg/sql/catalog/funcdesc",
         "//pkg/sql/parser",
         "//pkg/sql/pgwire/pgcode",
         "//pkg/sql/pgwire/pgerror",

--- a/pkg/sql/catalog/schemaexpr/BUILD.bazel
+++ b/pkg/sql/catalog/schemaexpr/BUILD.bazel
@@ -21,6 +21,7 @@ go_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/sql/catalog/schemaexpr",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/clusterversion",
         "//pkg/sql/catalog",
         "//pkg/sql/catalog/catpb",
         "//pkg/sql/catalog/colinfo",
@@ -60,6 +61,7 @@ go_test(
     data = glob(["testdata/**"]),
     embed = [":schemaexpr"],
     deps = [
+        "//pkg/clusterversion",
         "//pkg/sql/catalog",
         "//pkg/sql/catalog/colinfo",
         "//pkg/sql/catalog/descpb",

--- a/pkg/sql/catalog/schemaexpr/check_constraint.go
+++ b/pkg/sql/catalog/schemaexpr/check_constraint.go
@@ -15,6 +15,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
@@ -76,7 +77,7 @@ func (b *CheckConstraintBuilder) MarkNameInUse(name string) {
 // Note that mutable functions are currently allowed, unlike in partial index
 // predicates, but using them can lead to unexpected behavior.
 func (b *CheckConstraintBuilder) Build(
-	c *tree.CheckConstraintTableDef,
+	c *tree.CheckConstraintTableDef, version clusterversion.ClusterVersion,
 ) (*descpb.TableDescriptor_CheckConstraint, error) {
 	name := string(c.Name)
 
@@ -99,6 +100,7 @@ func (b *CheckConstraintBuilder) Build(
 		b.semaCtx,
 		volatility.Volatile,
 		&b.tableName,
+		version,
 	)
 	if err != nil {
 		return nil, err

--- a/pkg/sql/catalog/schemaexpr/check_constraint.go
+++ b/pkg/sql/catalog/schemaexpr/check_constraint.go
@@ -95,7 +95,7 @@ func (b *CheckConstraintBuilder) Build(
 		b.desc,
 		c.Expr,
 		types.Bool,
-		"CHECK",
+		tree.CheckConstraintExpr,
 		b.semaCtx,
 		volatility.Volatile,
 		&b.tableName,

--- a/pkg/sql/catalog/schemaexpr/check_constraint_test.go
+++ b/pkg/sql/catalog/schemaexpr/check_constraint_test.go
@@ -14,6 +14,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/schemaexpr"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/builtins"
@@ -114,7 +115,7 @@ func TestCheckConstraintBuilder_Build(t *testing.T) {
 
 			ckDef := &tree.CheckConstraintTableDef{Name: tree.Name(d.name), Expr: expr}
 
-			ck, err := builder.Build(ckDef)
+			ck, err := builder.Build(ckDef, clusterversion.TestingClusterVersion)
 
 			if !d.expectedValid {
 				if err == nil {

--- a/pkg/sql/catalog/schemaexpr/column.go
+++ b/pkg/sql/catalog/schemaexpr/column.go
@@ -322,10 +322,10 @@ func replaceColumnVars(
 	return ReplaceColumnVars(rootExpr, lookupFn)
 }
 
-// ReplaceIDsWithFQNames walks the given expr and replaces occurrences
+// ReplaceSequenceIDsWithFQNames walks the given expr and replaces occurrences
 // of regclass IDs in the expr with the descriptor's fully qualified name.
 // For example, nextval(12345::REGCLASS) => nextval('foo.public.seq').
-func ReplaceIDsWithFQNames(
+func ReplaceSequenceIDsWithFQNames(
 	ctx context.Context, rootExpr tree.Expr, semaCtx *tree.SemaContext,
 ) (tree.Expr, error) {
 	replaceFn := func(expr tree.Expr) (recurse bool, newExpr tree.Expr, err error) {
@@ -334,13 +334,13 @@ func ReplaceIDsWithFQNames(
 			return true, expr, nil
 		}
 		// If it's not a sequence or the resolution fails, skip this node.
-		seqName, err := semaCtx.TableNameResolver.GetQualifiedTableNameByID(ctx, id, tree.ResolveRequireSequenceDesc)
+		seqName, err := semaCtx.NameResolver.GetQualifiedTableNameByID(ctx, id, tree.ResolveRequireSequenceDesc)
 		if err != nil {
 			return true, expr, nil //nolint:returnerrcheck
 		}
 
 		// Omit the database qualification if the sequence lives in the current database.
-		currDb := semaCtx.TableNameResolver.CurrentDatabase()
+		currDb := semaCtx.NameResolver.CurrentDatabase()
 		if seqName.Catalog() == currDb {
 			seqName.CatalogName = ""
 			seqName.ExplicitCatalog = false

--- a/pkg/sql/catalog/schemaexpr/computed_column.go
+++ b/pkg/sql/catalog/schemaexpr/computed_column.go
@@ -15,6 +15,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
@@ -49,6 +50,7 @@ func ValidateComputedColumnExpression(
 	tn *tree.TableName,
 	context tree.SchemaExprContext,
 	semaCtx *tree.SemaContext,
+	version clusterversion.ClusterVersion,
 ) (serializedExpr string, _ *types.T, _ error) {
 	if d.HasDefaultExpr() {
 		return "", nil, pgerror.Newf(
@@ -103,6 +105,7 @@ func ValidateComputedColumnExpression(
 		semaCtx,
 		volatility.Immutable,
 		tn,
+		version,
 	)
 	if err != nil {
 		return "", nil, err

--- a/pkg/sql/catalog/schemaexpr/computed_column.go
+++ b/pkg/sql/catalog/schemaexpr/computed_column.go
@@ -47,7 +47,7 @@ func ValidateComputedColumnExpression(
 	desc catalog.TableDescriptor,
 	d *tree.ColumnTableDef,
 	tn *tree.TableName,
-	context string,
+	context tree.SchemaExprContext,
 	semaCtx *tree.SemaContext,
 ) (serializedExpr string, _ *types.T, _ error) {
 	if d.HasDefaultExpr() {
@@ -133,7 +133,7 @@ func ValidateComputedColumnExpression(
 			return "", nil, err
 		}
 		if len(mutationColumnNames) > 0 {
-			if context == "index element" {
+			if context == tree.ExpressionIndexElementExpr {
 				return "", nil, unimplemented.Newf(
 					"index element expression referencing mutation columns",
 					"index element expression referencing columns (%s) added in the current transaction",

--- a/pkg/sql/catalog/schemaexpr/expr.go
+++ b/pkg/sql/catalog/schemaexpr/expr.go
@@ -606,9 +606,9 @@ func maybeReplaceUDFNameWithOIDReferenceInTypedExpr(
 	return newExpr.(tree.TypedExpr), nil
 }
 
-// GetUdfIDs extracts all UDF descriptor ids from the given expression,
+// GetUDFIDs extracts all UDF descriptor ids from the given expression,
 // assuming that the UDF names has been replaced with OID references.
-func GetUdfIDs(e tree.Expr) (catalog.DescriptorIDSet, error) {
+func GetUDFIDs(e tree.Expr) (catalog.DescriptorIDSet, error) {
 	var fnIDs catalog.DescriptorIDSet
 	if _, err := tree.SimpleVisit(e, func(ckExpr tree.Expr) (recurse bool, newExpr tree.Expr, err error) {
 		switch t := ckExpr.(type) {

--- a/pkg/sql/catalog/schemaexpr/expr.go
+++ b/pkg/sql/catalog/schemaexpr/expr.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/colinfo"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/funcdesc"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
@@ -79,7 +80,7 @@ func DequalifyAndValidateExprImpl(
 	ctx context.Context,
 	expr tree.Expr,
 	typ *types.T,
-	context string,
+	context tree.SchemaExprContext,
 	semaCtx *tree.SemaContext,
 	maxVolatility volatility.V,
 	tn *tree.TableName,
@@ -114,8 +115,16 @@ func DequalifyAndValidateExprImpl(
 		return "", nil, colIDs, err
 	}
 
-	if err := tree.MaybeFailOnUDFUsage(typedExpr); err != nil {
+	if err := tree.MaybeFailOnUDFUsage(typedExpr, context); err != nil {
 		return "", nil, colIDs, unimplemented.NewWithIssue(83234, "usage of user-defined function from relations not supported")
+	}
+
+	// We need to do the rewrite here before the expression is serialized because
+	// the serialization would drop the prefixes to functions.
+	//
+	typedExpr, err = maybeReplaceUDFNameWithOIDReferenceInTypedExpr(typedExpr)
+	if err != nil {
+		return "", nil, colIDs, err
 	}
 
 	return tree.Serialize(typedExpr), typedExpr.ResolvedType(), colIDs, nil
@@ -131,7 +140,7 @@ func DequalifyAndValidateExpr(
 	desc catalog.TableDescriptor,
 	expr tree.Expr,
 	typ *types.T,
-	context string,
+	context tree.SchemaExprContext,
 	semaCtx *tree.SemaContext,
 	maxVolatility volatility.V,
 	tn *tree.TableName,
@@ -284,7 +293,7 @@ func formatExprForDisplayImpl(
 		return "", err
 	}
 	// Replace any IDs in the expr with their fully qualified names.
-	replacedExpr, err := ReplaceIDsWithFQNames(ctx, expr, semaCtx)
+	replacedExpr, err := ReplaceSequenceIDsWithFQNames(ctx, expr, semaCtx)
 	if err != nil {
 		return "", err
 	}
@@ -437,7 +446,7 @@ func SanitizeVarFreeExpr(
 	ctx context.Context,
 	expr tree.Expr,
 	expectedType *types.T,
-	context string,
+	context tree.SchemaExprContext,
 	semaCtx *tree.SemaContext,
 	maxVolatility volatility.V,
 	allowAssignmentCast bool,
@@ -469,7 +478,7 @@ func SanitizeVarFreeExpr(
 	default:
 		panic(errors.AssertionFailedf("maxVolatility %s not supported", maxVolatility))
 	}
-	semaCtx.Properties.Require(context, flags)
+	semaCtx.Properties.Require(string(context), flags)
 
 	typedExpr, err := tree.TypeCheck(ctx, expr, semaCtx, expectedType)
 	if err != nil {
@@ -551,7 +560,7 @@ func ValidateTTLExpirationExpression(
 		tableDesc,
 		expr,
 		types.TimestampTZ,
-		"ttl_expiration_expression",
+		tree.TTLExpirationExpr,
 		semaCtx,
 		volatility.Immutable,
 		tableName,
@@ -561,4 +570,51 @@ func ValidateTTLExpirationExpression(
 
 	// todo: check dropped column here?
 	return nil
+}
+
+func maybeReplaceUDFNameWithOIDReferenceInTypedExpr(
+	typedExpr tree.TypedExpr,
+) (tree.TypedExpr, error) {
+	replaceFunc := func(ex tree.Expr) (recurse bool, newExpr tree.Expr, err error) {
+		funcExpr, ok := ex.(*tree.FuncExpr)
+		if !ok {
+			return true, ex, nil
+		}
+		if funcExpr.ResolvedOverload() == nil {
+			return false, nil, errors.AssertionFailedf("function expression has not been type checked")
+		}
+		// We only want to replace with OID reference when it's a UDF.
+		if !funcExpr.ResolvedOverload().IsUDF {
+			return true, ex, nil
+		}
+		newFuncExpr := *funcExpr
+		newFuncExpr.Func = tree.ResolvableFunctionReference{
+			FunctionReference: &tree.FunctionOID{OID: funcExpr.ResolvedOverload().Oid},
+		}
+		return true, &newFuncExpr, nil
+	}
+
+	newExpr, err := tree.SimpleVisit(typedExpr, replaceFunc)
+	if err != nil {
+		return nil, err
+	}
+	return newExpr.(tree.TypedExpr), nil
+}
+
+// GetUdfIDs extracts all UDF descriptor ids from the given expression,
+// assuming that the UDF names has been replaced with OID references.
+func GetUdfIDs(e tree.Expr) (catalog.DescriptorIDSet, error) {
+	var fnIDs catalog.DescriptorIDSet
+	if _, err := tree.SimpleVisit(e, func(ckExpr tree.Expr) (recurse bool, newExpr tree.Expr, err error) {
+		switch t := ckExpr.(type) {
+		case *tree.FuncExpr:
+			if ref, ok := t.Func.FunctionReference.(*tree.FunctionOID); ok && funcdesc.IsOIDUserDefinedFunc(ref.OID) {
+				fnIDs.Add(funcdesc.UserDefinedFunctionOIDToID(ref.OID))
+			}
+		}
+		return true, ckExpr, nil
+	}); err != nil {
+		return catalog.DescriptorIDSet{}, err
+	}
+	return fnIDs, nil
 }

--- a/pkg/sql/catalog/schemaexpr/expr_test.go
+++ b/pkg/sql/catalog/schemaexpr/expr_test.go
@@ -14,6 +14,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/schemaexpr"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/builtins"
@@ -87,6 +88,7 @@ func TestValidateExpr(t *testing.T) {
 				&semaCtx,
 				d.maxVolatility,
 				&tn,
+				clusterversion.TestingClusterVersion,
 			)
 
 			if !d.expectedValid {

--- a/pkg/sql/catalog/schemaexpr/partial_index.go
+++ b/pkg/sql/catalog/schemaexpr/partial_index.go
@@ -13,6 +13,7 @@ package schemaexpr
 import (
 	"context"
 
+	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
@@ -45,6 +46,7 @@ func ValidatePartialIndexPredicate(
 	e tree.Expr,
 	tn *tree.TableName,
 	semaCtx *tree.SemaContext,
+	version clusterversion.ClusterVersion,
 ) (string, error) {
 	expr, _, cols, err := DequalifyAndValidateExpr(
 		ctx,
@@ -55,6 +57,7 @@ func ValidatePartialIndexPredicate(
 		semaCtx,
 		volatility.Immutable,
 		tn,
+		version,
 	)
 	if err != nil {
 		return "", err

--- a/pkg/sql/catalog/schemaexpr/partial_index.go
+++ b/pkg/sql/catalog/schemaexpr/partial_index.go
@@ -51,7 +51,7 @@ func ValidatePartialIndexPredicate(
 		desc,
 		e,
 		types.Bool,
-		"index predicate",
+		tree.IndexPredicateExpr,
 		semaCtx,
 		volatility.Immutable,
 		tn,

--- a/pkg/sql/catalog/schemaexpr/partial_index_test.go
+++ b/pkg/sql/catalog/schemaexpr/partial_index_test.go
@@ -14,6 +14,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/schemaexpr"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/builtins"
@@ -90,7 +91,7 @@ func TestIndexPredicateValidator_Validate(t *testing.T) {
 			}
 
 			deqExpr, err := schemaexpr.ValidatePartialIndexPredicate(
-				ctx, desc, expr, &tn, &semaCtx,
+				ctx, desc, expr, &tn, &semaCtx, clusterversion.TestingClusterVersion,
 			)
 
 			if !d.expectedValid {

--- a/pkg/sql/catalog/schemaexpr/unique_contraint.go
+++ b/pkg/sql/catalog/schemaexpr/unique_contraint.go
@@ -42,7 +42,7 @@ func ValidateUniqueWithoutIndexPredicate(
 		desc,
 		pred,
 		types.Bool,
-		"unique without index predicate",
+		tree.UniqueWithoutIndexPredicateExpr,
 		semaCtx,
 		volatility.Immutable,
 		&tn,

--- a/pkg/sql/catalog/schemaexpr/unique_contraint.go
+++ b/pkg/sql/catalog/schemaexpr/unique_contraint.go
@@ -13,6 +13,7 @@ package schemaexpr
 import (
 	"context"
 
+	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/volatility"
@@ -36,6 +37,7 @@ func ValidateUniqueWithoutIndexPredicate(
 	desc catalog.TableDescriptor,
 	pred tree.Expr,
 	semaCtx *tree.SemaContext,
+	version clusterversion.ClusterVersion,
 ) (string, error) {
 	expr, _, _, err := DequalifyAndValidateExpr(
 		ctx,
@@ -46,6 +48,7 @@ func ValidateUniqueWithoutIndexPredicate(
 		semaCtx,
 		volatility.Immutable,
 		&tn,
+		version,
 	)
 	if err != nil {
 		return "", err

--- a/pkg/sql/catalog/seqexpr/BUILD.bazel
+++ b/pkg/sql/catalog/seqexpr/BUILD.bazel
@@ -9,6 +9,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/sql/catalog/descpb",
+        "//pkg/sql/catalog/funcdesc",
         "//pkg/sql/parser",
         "//pkg/sql/pgwire/pgcode",
         "//pkg/sql/pgwire/pgerror",

--- a/pkg/sql/catalog/tabledesc/BUILD.bazel
+++ b/pkg/sql/catalog/tabledesc/BUILD.bazel
@@ -33,6 +33,7 @@ go_library(
         "//pkg/sql/catalog/colinfo",
         "//pkg/sql/catalog/descpb",
         "//pkg/sql/catalog/fetchpb",
+        "//pkg/sql/catalog/funcdesc",
         "//pkg/sql/catalog/internal/validate",
         "//pkg/sql/catalog/multiregion",
         "//pkg/sql/catalog/schemaexpr",

--- a/pkg/sql/catalog/tabledesc/structured.go
+++ b/pkg/sql/catalog/tabledesc/structured.go
@@ -26,6 +26,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/colinfo"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/internal/validate"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/schemaexpr"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/typedesc"
 	"github.com/cockroachdb/cockroach/pkg/sql/lexbase"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
@@ -363,6 +364,42 @@ func (desc *wrapper) GetAllReferencedTypeIDs(
 	}
 
 	return ids.Ordered(), referencedInColumns, nil
+}
+
+// GetAllReferencedFunctionIDs implements the TableDescriptor interface.
+func (desc *wrapper) GetAllReferencedFunctionIDs() (catalog.DescriptorIDSet, error) {
+	var ret catalog.DescriptorIDSet
+	for _, c := range desc.AllConstraints() {
+		ids, err := desc.GetAllReferencedFunctionIDsInConstraint(c.GetConstraintID())
+		if err != nil {
+			return catalog.DescriptorIDSet{}, err
+		}
+		ret = ret.Union(ids)
+	}
+	// TODO(chengxiong): add logic to extract references from columns and indexes
+	// when UDFs are allowed in them.
+	return ret.Union(catalog.MakeDescriptorIDSet(desc.DependsOnFunctions...)), nil
+}
+
+// GetAllReferencedFunctionIDsInConstraint implements the TableDescriptor
+// interface.
+func (desc *wrapper) GetAllReferencedFunctionIDsInConstraint(
+	cstID descpb.ConstraintID,
+) (catalog.DescriptorIDSet, error) {
+	c := catalog.FindConstraintByID(desc, cstID)
+	ck := c.AsCheck()
+	if ck == nil {
+		return catalog.DescriptorIDSet{}, nil
+	}
+	ckExpr, err := parser.ParseExpr(ck.GetExpr())
+	if err != nil {
+		return catalog.DescriptorIDSet{}, err
+	}
+	ret, err := schemaexpr.GetUdfIDs(ckExpr)
+	if err != nil {
+		return catalog.DescriptorIDSet{}, err
+	}
+	return ret, nil
 }
 
 // getAllReferencedTypesInTableColumns returns a map of all user defined
@@ -1177,7 +1214,9 @@ func (desc *Mutable) FindActiveOrNewColumnByName(name tree.Name) (catalog.Column
 // DropConstraint drops a constraint, either by removing it from the table
 // descriptor or by queuing a mutation for a schema change.
 func (desc *Mutable) DropConstraint(
-	constraint catalog.Constraint, removeFKBackRef func(catalog.ForeignKeyConstraint) error,
+	constraint catalog.Constraint,
+	removeFKBackRef func(catalog.ForeignKeyConstraint) error,
+	removeFnBackRef func(*descpb.TableDescriptor_CheckConstraint) error,
 ) error {
 	if u := constraint.AsUniqueWithIndex(); u != nil {
 		if u.Primary() {
@@ -1227,6 +1266,9 @@ func (desc *Mutable) DropConstraint(
 				// unless the cluster is fully upgraded to 19.2, for backward
 				// compatibility.
 				if ck.IsConstraintUnvalidated() {
+					if err := removeFnBackRef(c); err != nil {
+						return err
+					}
 					desc.Checks = append(desc.Checks[:i], desc.Checks[i+1:]...)
 					return nil
 				}

--- a/pkg/sql/catalog/tabledesc/structured.go
+++ b/pkg/sql/catalog/tabledesc/structured.go
@@ -385,7 +385,7 @@ func (desc *wrapper) GetAllReferencedFunctionIDs() (catalog.DescriptorIDSet, err
 // interface.
 func (desc *wrapper) GetAllReferencedFunctionIDsInConstraint(
 	cstID descpb.ConstraintID,
-) (catalog.DescriptorIDSet, error) {
+) (fnIDs catalog.DescriptorIDSet, err error) {
 	c := catalog.FindConstraintByID(desc, cstID)
 	ck := c.AsCheck()
 	if ck == nil {
@@ -395,7 +395,7 @@ func (desc *wrapper) GetAllReferencedFunctionIDsInConstraint(
 	if err != nil {
 		return catalog.DescriptorIDSet{}, err
 	}
-	ret, err := schemaexpr.GetUdfIDs(ckExpr)
+	ret, err := schemaexpr.GetUDFIDs(ckExpr)
 	if err != nil {
 		return catalog.DescriptorIDSet{}, err
 	}

--- a/pkg/sql/catalog/tabledesc/table.go
+++ b/pkg/sql/catalog/tabledesc/table.go
@@ -166,7 +166,7 @@ func MakeColumnDefDescs(
 		if err != nil {
 			return nil, err
 		}
-		if err := tree.MaybeFailOnUDFUsage(ret.DefaultExpr); err != nil {
+		if err := tree.MaybeFailOnUDFUsage(ret.DefaultExpr, tree.ColumnDefaultExpr); err != nil {
 			return nil, err
 		}
 
@@ -189,7 +189,7 @@ func MakeColumnDefDescs(
 		if err != nil {
 			return nil, err
 		}
-		if err := tree.MaybeFailOnUDFUsage(ret.OnUpdateExpr); err != nil {
+		if err := tree.MaybeFailOnUDFUsage(ret.OnUpdateExpr, tree.ColumnOnUpdateExpr); err != nil {
 			return nil, err
 		}
 

--- a/pkg/sql/catalog/tabledesc/table.go
+++ b/pkg/sql/catalog/tabledesc/table.go
@@ -22,6 +22,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/colinfo"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/funcdesc"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/schemaexpr"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
@@ -166,7 +167,7 @@ func MakeColumnDefDescs(
 		if err != nil {
 			return nil, err
 		}
-		if err := tree.MaybeFailOnUDFUsage(ret.DefaultExpr, tree.ColumnDefaultExpr); err != nil {
+		if err := funcdesc.MaybeFailOnUDFUsage(ret.DefaultExpr, tree.ColumnDefaultExpr, evalCtx.Settings.Version.ActiveVersion(ctx)); err != nil {
 			return nil, err
 		}
 
@@ -189,7 +190,7 @@ func MakeColumnDefDescs(
 		if err != nil {
 			return nil, err
 		}
-		if err := tree.MaybeFailOnUDFUsage(ret.OnUpdateExpr, tree.ColumnOnUpdateExpr); err != nil {
+		if err := funcdesc.MaybeFailOnUDFUsage(ret.OnUpdateExpr, tree.ColumnOnUpdateExpr, evalCtx.Settings.Version.ActiveVersion(ctx)); err != nil {
 			return nil, err
 		}
 

--- a/pkg/sql/catalog/tabledesc/validate.go
+++ b/pkg/sql/catalog/tabledesc/validate.go
@@ -81,6 +81,13 @@ func (desc *wrapper) GetReferencedDescIDs() (catalog.DescriptorIDSet, error) {
 			ids.Add(col.GetUsesSequenceID(i))
 		}
 	}
+	for _, cst := range desc.Checks {
+		fnIDs, err := desc.GetAllReferencedFunctionIDsInConstraint(cst.ConstraintID)
+		if err != nil {
+			return catalog.DescriptorIDSet{}, err
+		}
+		fnIDs.ForEach(ids.Add)
+	}
 	// Collect user defined type IDs in expressions.
 	// All serialized expressions within a table descriptor are serialized
 	// with type annotations as IDs, so this visitor will collect them all.
@@ -104,6 +111,9 @@ func (desc *wrapper) GetReferencedDescIDs() (catalog.DescriptorIDSet, error) {
 		ids.Add(id)
 	}
 	for _, id := range desc.GetDependsOnTypes() {
+		ids.Add(id)
+	}
+	for _, id := range desc.GetDependsOnFunctions() {
 		ids.Add(id)
 	}
 	for _, ref := range desc.GetDependedOnBy() {
@@ -167,22 +177,19 @@ func (desc *wrapper) ValidateForwardReferences(
 		for _, id := range desc.DependsOnTypes {
 			vea.Report(desc.validateOutboundTypeRef(id, vdg))
 		}
+		for _, id := range desc.DependsOnFunctions {
+			vea.Report(desc.validateOutboundFuncRef(id, vdg))
+		}
 	}
 
-	for _, id := range desc.DependsOn {
-		depDesc, err := vdg.GetDescriptor(id)
+	// Check all functions referenced by constraint exists.
+	for _, cst := range desc.Checks {
+		fnIDs, err := desc.GetAllReferencedFunctionIDsInConstraint(cst.ConstraintID)
 		if err != nil {
-			vea.Report(errors.NewAssertionErrorWithWrappedErrf(err, "invalid depends-on forward reference"))
-			continue
+			vea.Report(errors.Wrap(err, "invalid referenced functions IDs in constraint"))
 		}
-		switch depDesc.DescriptorType() {
-		case catalog.Table:
-			vea.Report(catalog.ValidateOutboundTableRef(id, vdg))
-		case catalog.Function:
-			vea.Report(desc.validateOutboundFuncRef(id, vdg))
-		default:
-			vea.Report(errors.AssertionFailedf("depends on unexpected %s %s (%d)",
-				depDesc.DescriptorType(), depDesc.GetName(), depDesc.GetID()))
+		for _, fnID := range fnIDs.Ordered() {
+			vea.Report(desc.validateOutboundFuncRef(fnID, vdg))
 		}
 	}
 
@@ -241,27 +248,42 @@ func (desc *wrapper) ValidateBackReferences(
 		vea.Report(desc.validateInboundFK(&desc.InboundFKs[i], vdg))
 	}
 
+	// Check all functions referenced by constraint exists.
+	for _, cst := range desc.Checks {
+		fnIDs, err := desc.GetAllReferencedFunctionIDsInConstraint(cst.ConstraintID)
+		if err != nil {
+			vea.Report(errors.Wrap(err, "invalid referenced functions IDs in constraint"))
+		}
+		for _, fnID := range fnIDs.Ordered() {
+			fn, err := vdg.GetFunctionDescriptor(fnID)
+			if err != nil {
+				vea.Report(err)
+				continue
+			}
+			vea.Report(desc.validateOutboundFuncRefBackReferenceForConstraint(fn, cst.ConstraintID))
+		}
+	}
+
 	// For views, check dependent relations.
 	if desc.IsView() {
 		for _, id := range desc.DependsOnTypes {
 			typ, _ := vdg.GetTypeDescriptor(id)
 			vea.Report(desc.validateOutboundTypeRefBackReference(typ))
 		}
+		for _, id := range desc.DependsOnFunctions {
+			fn, _ := vdg.GetFunctionDescriptor(id)
+			vea.Report(desc.validateOutboundFuncRefBackReference(fn))
+		}
 	}
 
 	for _, id := range desc.DependsOn {
-		ref, _ := vdg.GetDescriptor(id)
+		ref, _ := vdg.GetTableDescriptor(id)
 		if ref == nil {
 			// Don't follow up on backward references for invalid or irrelevant
 			// forward references.
 			continue
 		}
-		switch refDesc := ref.(type) {
-		case catalog.TableDescriptor:
-			vea.Report(catalog.ValidateOutboundTableRefBackReference(desc.GetID(), refDesc))
-		case catalog.FunctionDescriptor:
-			vea.Report(desc.validateOutboundFuncRefBackReference(refDesc))
-		}
+		vea.Report(catalog.ValidateOutboundTableRefBackReference(desc.GetID(), ref))
 	}
 
 	// Check relation back-references to relations and functions.
@@ -315,6 +337,23 @@ func (desc *wrapper) validateOutboundFuncRefBackReference(ref catalog.FunctionDe
 	for _, dep := range ref.GetDependedOnBy() {
 		if dep.ID == desc.GetID() {
 			return nil
+		}
+	}
+	return errors.AssertionFailedf("depends-on function %q (%d) has no corresponding depended-on-by back reference",
+		ref.GetName(), ref.GetID())
+}
+
+func (desc *wrapper) validateOutboundFuncRefBackReferenceForConstraint(
+	ref catalog.FunctionDescriptor, cstID descpb.ConstraintID,
+) error {
+	for _, dep := range ref.GetDependedOnBy() {
+		if dep.ID != desc.GetID() {
+			continue
+		}
+		for _, id := range dep.ConstraintIDs {
+			if id == cstID {
+				return nil
+			}
 		}
 	}
 	return errors.AssertionFailedf("depends-on function %q (%d) has no corresponding depended-on-by back reference",

--- a/pkg/sql/create_function_test.go
+++ b/pkg/sql/create_function_test.go
@@ -190,6 +190,48 @@ func TestGatingCreateFunction(t *testing.T) {
 	})
 }
 
+func TestVersionGatingUDFInCheckConstraints(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	t.Run("new_schema_changer_version_enabled", func(t *testing.T) {
+		params, _ := tests.CreateTestServerParams()
+		// Override binary version to be older.
+		params.Knobs.Server = &server.TestingKnobs{
+			DisableAutomaticVersionUpgrade: make(chan struct{}),
+			BinaryVersionOverride:          clusterversion.ByKey(clusterversion.V23_1),
+		}
+
+		s, sqlDB, _ := serverutils.StartServer(t, params)
+		defer s.Stopper().Stop(context.Background())
+
+		_, err := sqlDB.Exec(`CREATE FUNCTION f() RETURNS INT LANGUAGE SQL AS $$ SELECT 1 $$`)
+		require.NoError(t, err)
+		_, err = sqlDB.Exec(`CREATE TABLE t(a INT CHECK (f() > 0));`)
+		require.NoError(t, err)
+	})
+
+	t.Run("new_schema_changer_version_disabled", func(t *testing.T) {
+		params, _ := tests.CreateTestServerParams()
+		// Override binary version to be older.
+		params.Knobs.Server = &server.TestingKnobs{
+			DisableAutomaticVersionUpgrade: make(chan struct{}),
+			BinaryVersionOverride:          clusterversion.ByKey(clusterversion.V23_1 - 1),
+		}
+
+		s, sqlDB, _ := serverutils.StartServer(t, params)
+		defer s.Stopper().Stop(context.Background())
+
+		// Need to turn new schema changer off, because function related rules are
+		// only valid in 23.1.
+		_, err := sqlDB.Exec(`SET use_declarative_schema_changer = 'off'`)
+		require.NoError(t, err)
+		_, err = sqlDB.Exec(`CREATE FUNCTION f() RETURNS INT LANGUAGE SQL AS $$ SELECT 1 $$`)
+		require.NoError(t, err)
+		_, err = sqlDB.Exec(`CREATE TABLE t(a INT CHECK (f() > 0));`)
+		require.Equal(t, "pq: unimplemented: usage of user-defined function from relations not supported", err.Error())
+	})
+}
+
 func TestCreateOrReplaceFunctionUpdateReferences(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)

--- a/pkg/sql/create_index.go
+++ b/pkg/sql/create_index.go
@@ -504,7 +504,7 @@ func replaceExpressionElemsWithVirtualCols(
 				desc,
 				colDef,
 				tn,
-				"index element",
+				tree.ExpressionIndexElementExpr,
 				semaCtx,
 			)
 			if err != nil {

--- a/pkg/sql/create_index.go
+++ b/pkg/sql/create_index.go
@@ -112,7 +112,7 @@ func (p *planner) maybeSetupConstraintForShard(
 		return err
 	}
 	ckBuilder := schemaexpr.MakeCheckConstraintBuilder(ctx, p.tableName, tableDesc, &p.semaCtx)
-	ckDesc, err := ckBuilder.Build(ckDef)
+	ckDesc, err := ckBuilder.Build(ckDef, p.ExecCfg().Settings.Version.ActiveVersion(ctx))
 	if err != nil {
 		return err
 	}
@@ -170,6 +170,7 @@ func makeIndexDescriptor(
 		n.Inverted,
 		false, /* isNewTable */
 		params.p.SemaCtx(),
+		params.ExecCfg().Settings.Version.ActiveVersion(params.ctx),
 	); err != nil {
 		return nil, err
 	}
@@ -255,6 +256,7 @@ func makeIndexDescriptor(
 	if n.Predicate != nil {
 		expr, err := schemaexpr.ValidatePartialIndexPredicate(
 			params.ctx, tableDesc, n.Predicate, &n.Table, params.p.SemaCtx(),
+			params.ExecCfg().Settings.Version.ActiveVersion(params.ctx),
 		)
 		if err != nil {
 			return nil, err
@@ -474,6 +476,7 @@ func replaceExpressionElemsWithVirtualCols(
 	isInverted bool,
 	isNewTable bool,
 	semaCtx *tree.SemaContext,
+	version clusterversion.ClusterVersion,
 ) error {
 	findExistingExprIndexCol := func(expr string) (colName string, ok bool) {
 		for _, col := range desc.AllColumns() {
@@ -506,6 +509,7 @@ func replaceExpressionElemsWithVirtualCols(
 				tn,
 				tree.ExpressionIndexElementExpr,
 				semaCtx,
+				version,
 			)
 			if err != nil {
 				return err

--- a/pkg/sql/drop_cascade.go
+++ b/pkg/sql/drop_cascade.go
@@ -266,7 +266,7 @@ func (d *dropCascadeState) canDropType(
 	if len(referencedButNotDropping) == 0 {
 		return nil
 	}
-	dependentNames, err := p.getFullyQualifiedTableNamesFromIDs(ctx, referencedButNotDropping)
+	dependentNames, err := p.getFullyQualifiedNamesFromIDs(ctx, referencedButNotDropping)
 	if err != nil {
 		return errors.Wrapf(err, "type %q has dependent objects", typ.Name)
 	}

--- a/pkg/sql/drop_table.go
+++ b/pkg/sql/drop_table.go
@@ -15,9 +15,11 @@ import (
 	"fmt"
 
 	"github.com/cockroachdb/cockroach/pkg/jobs"
+	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/server/telemetry"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descs"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/funcdesc"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/tabledesc"
 	"github.com/cockroachdb/cockroach/pkg/sql/isql"
@@ -264,6 +266,15 @@ func (p *planner) dropTableImpl(
 		}
 	}
 
+	// Remove function dependencies
+	fnIDs, err := tableDesc.GetAllReferencedFunctionIDs()
+	if err != nil {
+		return nil, err
+	}
+	if err := p.removeFunctionReferences(ctx, fnIDs, tableDesc); err != nil {
+		return nil, err
+	}
+
 	// Drop all views that depend on this table, assuming that we wouldn't have
 	// made it to this point if `cascade` wasn't enabled.
 	// Copy out the set of dependencies as it may be overwritten in the loop.
@@ -327,7 +338,7 @@ func (p *planner) dropTableImpl(
 		return droppedViews, err
 	}
 
-	err := p.initiateDropTable(ctx, tableDesc, !droppingParent, jobDesc)
+	err = p.initiateDropTable(ctx, tableDesc, !droppingParent, jobDesc)
 	return droppedViews, err
 }
 
@@ -546,6 +557,62 @@ func (p *planner) removeFKBackReference(
 	jobDesc := fmt.Sprintf("updating table %q after removing constraint %q from table %q", referencedTableDesc.GetName(), ref.Name, name.FQString())
 
 	return p.writeSchemaChange(ctx, referencedTableDesc, descpb.InvalidMutationID, jobDesc)
+}
+
+func (p *planner) removeFunctionReferences(
+	ctx context.Context, fnIDs catalog.DescriptorIDSet, tableDesc catalog.TableDescriptor,
+) error {
+	for _, id := range fnIDs.Ordered() {
+		fnDesc, err := p.descCollection.MutableByID(p.Txn()).Function(ctx, id)
+		if err != nil {
+			return err
+		}
+		fnDesc.RemoveReference(tableDesc.GetID())
+		if err := p.writeFuncSchemaChange(ctx, fnDesc); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (p *planner) removeCheckBackReferenceInFunctions(
+	ctx context.Context, tableDesc *tabledesc.Mutable, ck *descpb.TableDescriptor_CheckConstraint,
+) error {
+	fns, err := removeCheckBackReferenceInFunctions(
+		ctx, tableDesc, ck, p.Descriptors(), p.Txn(),
+	)
+	if err != nil {
+		return err
+	}
+	for _, fn := range fns {
+		if err := p.writeFuncSchemaChange(ctx, fn); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func removeCheckBackReferenceInFunctions(
+	ctx context.Context,
+	tableDesc *tabledesc.Mutable,
+	ck *descpb.TableDescriptor_CheckConstraint,
+	descCollection *descs.Collection,
+	txn *kv.Txn,
+) ([]*funcdesc.Mutable, error) {
+	fnIDs, err := tableDesc.GetAllReferencedFunctionIDsInConstraint(ck.ConstraintID)
+	if err != nil {
+		return nil, err
+	}
+	ret := make([]*funcdesc.Mutable, 0, fnIDs.Len())
+	for _, id := range fnIDs.Ordered() {
+		fnDesc, err := descCollection.MutableByID(txn).Function(ctx, id)
+		if err != nil {
+			return nil, err
+		}
+		fnDesc.RemoveConstraintReference(tableDesc.GetID(), ck.ConstraintID)
+		ret = append(ret, fnDesc)
+	}
+	return ret, nil
 }
 
 // removeFKBackReferenceFromTable edits the supplied referencedTableDesc to

--- a/pkg/sql/drop_type.go
+++ b/pkg/sql/drop_type.go
@@ -121,7 +121,7 @@ func (p *planner) canDropTypeDesc(
 		return err
 	}
 	if len(desc.ReferencingDescriptorIDs) > 0 && behavior != tree.DropCascade {
-		dependentNames, err := p.getFullyQualifiedTableNamesFromIDs(ctx, desc.ReferencingDescriptorIDs)
+		dependentNames, err := p.getFullyQualifiedNamesFromIDs(ctx, desc.ReferencingDescriptorIDs)
 		if err != nil {
 			return errors.Wrapf(err, "type %q has dependent objects", desc.Name)
 		}

--- a/pkg/sql/function_references.go
+++ b/pkg/sql/function_references.go
@@ -1,0 +1,40 @@
+// Copyright 2023 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package sql
+
+import (
+	"context"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
+)
+
+func (p *planner) updateFunctionReferencesForCheck(
+	ctx context.Context, tblDesc catalog.TableDescriptor, ck *descpb.TableDescriptor_CheckConstraint,
+) error {
+	udfIDs, err := tblDesc.GetAllReferencedFunctionIDsInConstraint(ck.ConstraintID)
+	if err != nil {
+		return err
+	}
+	for _, id := range udfIDs.Ordered() {
+		fnDesc, err := p.descCollection.MutableByID(p.txn).Function(ctx, id)
+		if err != nil {
+			return err
+		}
+		if err := fnDesc.AddConstraintReference(tblDesc.GetID(), ck.ConstraintID); err != nil {
+			return err
+		}
+		if err := p.writeFuncSchemaChange(ctx, fnDesc); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/pkg/sql/importer/import_table_creation.go
+++ b/pkg/sql/importer/import_table_creation.go
@@ -421,6 +421,13 @@ func (r fkResolver) GetQualifiedTableNameByID(
 	return nil, errSchemaResolver
 }
 
+// GetQualifiedFunctionNameByID implements the resolver.SchemaResolver interface.
+func (r fkResolver) GetQualifiedFunctionNameByID(
+	ctx context.Context, id int64,
+) (*tree.FunctionName, error) {
+	return nil, errSchemaResolver
+}
+
 // ResolveFunction implements the resolver.SchemaResolver interface.
 func (r fkResolver) ResolveFunction(
 	ctx context.Context, name *tree.UnresolvedName, path tree.SearchPath,

--- a/pkg/sql/logictest/testdata/logic_test/computed
+++ b/pkg/sql/logictest/testdata/logic_test/computed
@@ -283,14 +283,14 @@ CREATE TABLE tmp (x INT)
 statement ok
 DROP TABLE tmp
 
-statement error expected computed column expression to have type int, but .* has type string
+statement error expected STORED COMPUTED COLUMN expression to have type int, but ''not an integer!'::STRING' has type string
 CREATE TABLE y (
   a INT AS ('not an integer!'::STRING) STORED
 )
 
 # We utilize the types from other columns.
 
-statement error expected computed column expression to have type int, but 'a' has type string
+statement error expected STORED COMPUTED COLUMN expression to have type int, but 'a' has type string
 CREATE TABLE y (
   a STRING,
   b INT AS (a) STORED
@@ -301,57 +301,57 @@ CREATE TABLE x (
   a INT
 )
 
-statement error expected computed column expression to have type string, but .* has type int
+statement error expected STORED COMPUTED COLUMN expression to have type string, but .* has type int
 ALTER TABLE x ADD COLUMN err STRING AS (10::INT) STORED
 
 statement ok
 DROP TABLE x
 
-statement error context-dependent operators are not allowed in computed column
+statement error now\(\): context-dependent operators are not allowed in STORED COMPUTED COLUMN
 CREATE TABLE y (
   a TIMESTAMP AS (now()) STORED
 )
 
-statement error context-dependent operators are not allowed in computed column
+statement error string::timestamptz: context-dependent operators are not allowed in STORED COMPUTED COLUM
 CREATE TABLE y (
   a STRING,
   b TIMESTAMPTZ AS (a::TIMESTAMPTZ) STORED
 )
 
 # Make sure the error has a hint that mentions parse_timestamp().
-statement error context-dependent operators are not allowed in computed column.*\nHINT:.*use parse_timestamp
+statement error string::timestamp: context-dependent operators are not allowed in STORED COMPUTED COLUMN\nHINT:.*use parse_timestamp
 CREATE TABLE y (
   a STRING,
   b TIMESTAMP AS (a::TIMESTAMP) STORED
 )
 
 # Make sure the error has a hint that mentions AT TIME ZONE.
-statement error context-dependent operators are not allowed in computed column.*\nHINT:.*AT TIME ZONE
+statement error timestamptz::string: context-dependent operators are not allowed in STORED COMPUTED COLUMN\nHINT:.*AT TIME ZONE
 CREATE TABLE y (
   a TIMESTAMPTZ,
   b STRING AS (a::STRING) STORED
 )
 
 # Make sure the error has a hint that mentions AT TIME ZONE.
-statement error context-dependent operators are not allowed in computed column.*\nHINT:.*AT TIME ZONE
+statement error timestamptz::timestamp: context-dependent operators are not allowed in STORED COMPUTED COLUMN\nHINT: TIMESTAMPTZ to TIMESTAMP
 CREATE TABLE y (
   a TIMESTAMPTZ,
   b TIMESTAMP AS (a::TIMESTAMP) STORED
 )
 
-statement error context-dependent operators are not allowed in computed column
+statement error \+: context-dependent operators are not allowed in STORED COMPUTED COLUMN
 CREATE TABLE y (
   a TIMESTAMPTZ,
   b INTERVAL,
   c TIMESTAMPTZ AS (a+ b) STORED
 )
 
-statement error volatile functions are not allowed in computed column
+statement error concat\(\): uuid_v4\(\): volatile functions are not allowed in STORED COMPUTED COLUMN
 CREATE TABLE y (
   a STRING AS (concat('foo', uuid_v4()::STRING)) STORED
 )
 
-statement error computed column expression cannot reference computed columns
+statement error STORED COMPUTED COLUMN expression cannot reference computed columns
 CREATE TABLE y (
   a INT AS (3) STORED,
   b INT AS (a) STORED
@@ -362,12 +362,12 @@ CREATE TABLE y (
   b INT AS (a) STORED
 )
 
-statement error aggregate functions are not allowed in computed column
+statement error count\(\): aggregate functions are not allowed in STORED COMPUTED COLUMN
 CREATE TABLE y (
   b INT AS (count(1)) STORED
 )
 
-statement error computed column cannot have default values
+statement error STORED COMPUTED COLUMN cannot have default values
 CREATE TABLE y (
   a INT AS (3) STORED DEFAULT 4
 )
@@ -461,10 +461,10 @@ p_default  p_null  c_default  c_null
 statement ok
 CREATE TABLE tt (i INT8 AS (1) STORED)
 
-statement error variable sub-expressions are not allowed in computed column
+statement error variable sub-expressions are not allowed in STORED COMPUTED COLUMN
 ALTER TABLE tt ADD COLUMN c STRING AS ((SELECT NULL)) STORED
 
-statement error computed column expression cannot reference computed columns
+statement error STORED COMPUTED COLUMN expression cannot reference computed columns
 ALTER TABLE tt ADD COLUMN c INT8 AS (i) STORED
 
 # Composite FK.
@@ -505,7 +505,7 @@ ALTER TABLE y ADD FOREIGN KEY (r) REFERENCES x (a)
 statement ok
 DROP TABLE y
 
-statement error variable sub-expressions are not allowed in computed column
+statement error variable sub-expressions are not allowed in STORED COMPUTED COLUMN
 CREATE TABLE y (
   r INT AS ((SELECT 1)) STORED
 )
@@ -920,13 +920,13 @@ t42418  CREATE TABLE public.t42418 (
         )
 
 # Tests for computed column rewrites.
-statement error context-dependent operators are not allowed in computed column
+statement error timestamptz::string: context-dependent operators are not allowed in STORED COMPUTED COLUMN
 CREATE TABLE trewrite(k INT PRIMARY KEY, ts TIMESTAMPTZ, c STRING AS (ts::STRING) STORED, FAMILY (k,ts,c))
 
 statement ok
 SET experimental_computed_column_rewrites = "(ts :: STRING) -> ((ts AT TIME ZONE 'utc')::STRING)";
 
-statement error timestamp::string: context-dependent operators are not allowed in computed column
+statement error timestamp::string: context-dependent operators are not allowed in STORED COMPUTED COLUMN
 CREATE TABLE trewrite(k INT PRIMARY KEY, ts TIMESTAMPTZ, c STRING AS (ts::STRING) STORED, FAMILY (k,ts,c))
 
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/datetime
+++ b/pkg/sql/logictest/testdata/logic_test/datetime
@@ -1762,32 +1762,32 @@ set datestyle = 'ymd'
 statement ok
 reset datestyle
 
-statement error context-dependent operators are not allowed in computed column\nHINT: TIMESTAMP to STRING casts are dependent on DateStyle; consider using to_char\(timestamp\) instead\.
+statement error context-dependent operators are not allowed in STORED COMPUTED COLUMN\nHINT: TIMESTAMP to STRING casts are dependent on DateStyle; consider using to_char\(timestamp\) instead\.
 CREATE TABLE invalid_table (
   invalid_col string AS ('2020-05-12 10:12:13'::timestamp::string) STORED
 )
 
-statement error context-dependent operators are not allowed in computed column\nHINT: DATE to STRING casts are dependent on DateStyle; consider using to_char\(date\) instead\.
+statement error context-dependent operators are not allowed in STORED COMPUTED COLUMN\nHINT: DATE to STRING casts are dependent on DateStyle; consider using to_char\(date\) instead\.
 CREATE TABLE invalid_table (
   invalid_col string AS ('2020-05-12 10:12:13'::date::string) STORED
 )
 
-statement error context-dependent operators are not allowed in computed column\nHINT: STRING to TIMESTAMP casts are context-dependent because of relative timestamp strings like 'now' and session settings such as DateStyle; use parse_timestamp\(string\) instead\.
+statement error context-dependent operators are not allowed in STORED COMPUTED COLUMN\nHINT: STRING to TIMESTAMP casts are context-dependent because of relative timestamp strings like 'now' and session settings such as DateStyle; use parse_timestamp\(string\) instead\.
 CREATE TABLE invalid_table (
   invalid_col timestamp AS ('2020-05-12 10:12:13'::string::timestamp) STORED
 )
 
-statement error context-dependent operators are not allowed in computed column\nHINT: STRING to DATE casts depend on session DateStyle; use parse_date\(string\) instead
+statement error context-dependent operators are not allowed in STORED COMPUTED COLUMN\nHINT: STRING to DATE casts depend on session DateStyle; use parse_date\(string\) instead
 CREATE TABLE invalid_table (
   invalid_col date AS ('2020-05-12 10:12:13'::string::date) STORED
 )
 
-statement error context-dependent operators are not allowed in computed column\nHINT: STRING to TIME casts depend on session DateStyle; use parse_time\(string\) instead
+statement error context-dependent operators are not allowed in STORED COMPUTED COLUMN\nHINT: STRING to TIME casts depend on session DateStyle; use parse_time\(string\) instead
 CREATE TABLE invalid_table (
   invalid_col time AS ('2020-05-12 10:12:13'::string::time) STORED
 )
 
-statement error context-dependent operators are not allowed in computed column\nHINT: STRING to TIMETZ casts depend on session DateStyle; use parse_timetz\(string\) instead
+statement error context-dependent operators are not allowed in STORED COMPUTED COLUMN\nHINT: STRING to TIMETZ casts depend on session DateStyle; use parse_timetz\(string\) instead
 CREATE TABLE invalid_table (
   invalid_col timetz AS ('2020-05-12 10:12:13'::string::timetz) STORED
 )

--- a/pkg/sql/logictest/testdata/logic_test/expression_index
+++ b/pkg/sql/logictest/testdata/logic_test/expression_index
@@ -79,13 +79,13 @@ SELECT * FROM (
 ----
 {"computeExpr": "a + 10:::INT8", "id": 3, "inaccessible": true, "name": "crdb_internal_idx_expr_1", "nullable": true, "type": {"family": "IntFamily", "oid": 20, "width": 64}, "virtual": true}
 
-statement error volatile functions are not allowed in index element
+statement error random\(\): volatile functions are not allowed in EXPRESSION INDEX ELEMENT
 CREATE TABLE err (a INT, INDEX ((a + random()::INT)))
 
 statement error column \"z\" does not exist
 CREATE TABLE err (a INT, INDEX ((a + z)))
 
-statement error index element expression cannot reference computed columns
+statement error EXPRESSION INDEX ELEMENT expression cannot reference computed columns
 CREATE TABLE err (a INT, comp INT AS (a + 10) STORED, INDEX ((comp + 100)))
 
 statement error type of index element NULL is ambiguous.*\nHINT: consider adding a type cast to the expression
@@ -112,13 +112,13 @@ CREATE TABLE err (a INT, b INT, INVERTED INDEX (a, (row(a, b))))
 statement error the last column in an inverted index cannot have the DESC option
 CREATE TABLE err (a INT, j JSON, INVERTED INDEX (a, (j->'a') DESC))
 
-statement error volatile functions are not allowed in index element
+statement error random\(\): volatile functions are not allowed in EXPRESSION INDEX ELEMENT
 CREATE TABLE err (a INT, INDEX ((a + random()::INT)))
 
 statement error column \"z\" does not exist
 CREATE TABLE err (a INT, INDEX ((a + z)))
 
-statement error index element expression cannot reference computed columns
+statement error EXPRESSION INDEX ELEMENT expression cannot reference computed columns
 CREATE TABLE err (a INT, comp INT AS (a + 10) STORED, INDEX ((comp + 10)))
 
 # TODO(mgartner): Postgres does not allow unique constraints with expressions,
@@ -306,13 +306,13 @@ ALTER TABLE t ADD COLUMN crdb_internal_idx_expr INT
 statement ok
 ALTER TABLE t DROP COLUMN crdb_internal_idx_expr
 
-statement error volatile functions are not allowed in index element
+statement error random\(\): volatile functions are not allowed in EXPRESSION INDEX ELEMENT
 CREATE INDEX err ON t ((a + random()::INT))
 
 statement error column \"z\" does not exist
 CREATE INDEX err ON t ((a + z))
 
-statement error index element expression cannot reference computed columns
+statement error EXPRESSION INDEX ELEMENT expression cannot reference computed columns
 CREATE INDEX err ON t ((comp + 10))
 
 statement error type of index element NULL is ambiguous.*\nHINT: consider adding a type cast to the expression
@@ -978,7 +978,7 @@ ALTER TABLE t72012 ALTER COLUMN col SET NOT NULL
 # between string types and reg* types.
 subtest 74216
 
-statement error context-dependent operators are not allowed in index element
+statement error regtype::string: context-dependent operators are not allowed in EXPRESSION INDEX ELEMENT
 CREATE TABLE t74216 (
     a REGTYPE,
     UNIQUE ((a::STRING))

--- a/pkg/sql/logictest/testdata/logic_test/interval
+++ b/pkg/sql/logictest/testdata/logic_test/interval
@@ -409,12 +409,12 @@ SET intervalstyle = 'sql_standard'
 statement ok
 SET intervalstyle = DEFAULT
 
-statement error context-dependent operators are not allowed in computed column\nHINT: INTERVAL to STRING casts depend on IntervalStyle; consider using to_char\(interval\)
+statement error interval::string: context-dependent operators are not allowed in STORED COMPUTED COLUMN\nHINT: INTERVAL to STRING casts depend on IntervalStyle; consider using to_char\(interval\)
 CREATE TABLE invalid_table (
   invalid_col string AS ('1 hour'::interval::string) STORED
 )
 
-statement error string::interval: context-dependent operators are not allowed in computed column\nHINT: STRING to INTERVAL casts depend on session IntervalStyle; use parse_interval\(string\) instead
+statement error string::interval: context-dependent operators are not allowed in STORED COMPUTED COLUMN\nHINT: STRING to INTERVAL casts depend on session IntervalStyle; use parse_interval\(string\) instead
 CREATE TABLE invalid_table (
   invalid_col interval AS ('1 hour'::string::interval) STORED
 )

--- a/pkg/sql/logictest/testdata/logic_test/new_schema_changer
+++ b/pkg/sql/logictest/testdata/logic_test/new_schema_changer
@@ -806,7 +806,7 @@ select $desc_count_pre_drop-$desc_count_post_drop
 statement ok
 CREATE TABLE trewrite(k INT PRIMARY KEY, ts TIMESTAMPTZ, FAMILY (k,ts))
 
-statement error context-dependent operators are not allowed in computed column
+statement error timestamptz::string: context-dependent operators are not allowed in STORED COMPUTED COLUMN
 ALTER TABLE trewrite ADD COLUMN c STRING AS (ts::STRING) STORED
 
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/partial_index
+++ b/pkg/sql/logictest/testdata/logic_test/partial_index
@@ -11,7 +11,7 @@ statement ok
 CREATE TABLE t3 (a INT, INDEX (a) WHERE abs(1) > 2)
 
 # Don't allow non-boolean expressions.
-statement error expected index predicate expression to have type bool, but '1' has type int
+statement error expected INDEX PREDICATE expression to have type bool, but '1' has type int
 CREATE TABLE error (a INT, INDEX (a) WHERE 1)
 
 # Don't allow columns not in table.
@@ -20,36 +20,36 @@ CREATE TABLE error (a INT, INDEX (a) WHERE b = 3)
 
 # Don't allow non-immutable operators.
 # TODO(mgartner): The error code for this should be 42P17, not 0A000.
-statement error pgcode 0A000 now\(\): context-dependent operators are not allowed in index predicate
+statement error pgcode 0A000 now\(\): context-dependent operators are not allowed in INDEX PREDICATE
 CREATE TABLE error (t TIMESTAMPTZ, INDEX (t) WHERE t < now())
 
-statement error pgcode 0A000 timestamptz::string: context-dependent operators are not allowed in index predicate
+statement error pgcode 0A000 timestamptz::string: context-dependent operators are not allowed in INDEX PREDICATE
 CREATE TABLE error (t TIMESTAMPTZ, INDEX (t) WHERE t::string = 'foo')
 
-statement error pgcode 0A000 =: context-dependent operators are not allowed in index predicate
+statement error pgcode 0A000 =: context-dependent operators are not allowed in INDEX PREDICATE
 CREATE TABLE error (t TIMESTAMPTZ, i TIMESTAMP, INDEX (t) WHERE i = t)
 
-statement error pgcode 0A000 random\(\): volatile functions are not allowed in index predicate
+statement error pgcode 0A000 random\(\): volatile functions are not allowed in INDEX PREDICATE
 CREATE TABLE error (t FLOAT, INDEX (t) WHERE t < random())
 
 # Don't allow variable subexpressions.
-statement error pgcode 42601 variable sub-expressions are not allowed in index predicate
+statement error pgcode 42601 variable sub-expressions are not allowed in INDEX PREDICATE
 CREATE TABLE error (a INT, INDEX (a) WHERE count(*) = 1)
 
 # Don't allow subqueries.
-statement error pgcode 42601 variable sub-expressions are not allowed in index predicate
+statement error pgcode 42601 variable sub-expressions are not allowed in INDEX PREDICATE
 CREATE TABLE error (a INT, INDEX (a) WHERE (SELECT true))
 
 # Don't allow aggregate functions.
-statement error pgcode 42803 aggregate functions are not allowed in index predicate
+statement error pgcode 42803 aggregate functions are not allowed in INDEX PREDICATE
 CREATE TABLE error (a INT, INDEX (a) WHERE sum(a) > 1)
 
 # Don't allow window functions.
-statement error pgcode 42P20 window functions are not allowed in index predicate
+statement error pgcode 42P20 window functions are not allowed in INDEX PREDICATE
 CREATE TABLE error (a INT, INDEX (a) WHERE row_number() OVER () > 1)
 
 # Don't allow set-returning functions.
-statement error pgcode 0A000 generator functions are not allowed in index predicate
+statement error pgcode 0A000 generator functions are not allowed in INDEX PREDICATE
 CREATE TABLE error (a INT, INDEX (a) WHERE generate_series(1, 1))
 
 # Fail on bad types.
@@ -73,7 +73,7 @@ CREATE TABLE error (a INT, INDEX (a) WHERE unknown.error.a > 9)
 statement ok
 CREATE TABLE t4 (a INT, UNIQUE INDEX (a) WHERE a = 0)
 
-statement error expected index predicate expression to have type bool, but '1' has type int
+statement error expected INDEX PREDICATE expression to have type bool, but '1' has type int
 CREATE TABLE error (a INT, UNIQUE INDEX (a) WHERE 1)
 
 # Validate CREATE INDEX predicate.
@@ -85,7 +85,7 @@ statement ok
 CREATE INDEX t5i ON t5 (a) WHERE a = 0
 
 # Don't allow invalid predicates.
-statement error expected index predicate expression to have type bool, but '1' has type int
+statement error expected INDEX PREDICATE expression to have type bool, but '1' has type int
 CREATE INDEX error ON t5 (a) WHERE 1
 
 # Don't allow references to other tables in predicates.

--- a/pkg/sql/logictest/testdata/logic_test/row_level_ttl
+++ b/pkg/sql/logictest/testdata/logic_test/row_level_ttl
@@ -28,7 +28,7 @@ subtest end
 
 subtest ttl_expiration_expression_must_be_timestamptz
 
-statement error expected ttl_expiration_expression expression to have type timestamptz, but 'text' has type string
+statement error expected TTL EXPIRATION EXPRESSION expression to have type timestamptz, but 'text' has type string
 CREATE TABLE tbl (id INT PRIMARY KEY, text TEXT) WITH (ttl_expiration_expression = 'text')
 
 subtest end
@@ -674,7 +674,7 @@ CREATE TABLE tbl_alter_table_ttl_expiration_expression (
   FAMILY (id, text, expire_at)
 )
 
-statement error expected ttl_expiration_expression expression to have type timestamptz, but 'text' has type string
+statement error expected TTL EXPIRATION EXPRESSION expression to have type timestamptz, but 'text' has type string
 ALTER TABLE tbl_alter_table_ttl_expiration_expression SET (ttl_expiration_expression = 'text')
 
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/srfs
+++ b/pkg/sql/logictest/testdata/logic_test/srfs
@@ -862,7 +862,7 @@ CREATE TABLE uu (x INT DEFAULT generate_series(1, 3))
 statement error generator functions are not allowed in CHECK
 CREATE TABLE uu (x INT CHECK (generate_series(1, 3) < 3))
 
-statement error generator functions are not allowed in computed column
+statement error generate_series\(\): generator functions are not allowed in STORED COMPUTED COLUMN
 CREATE TABLE uu (x INT AS (generate_series(1, 3)) STORED)
 
 subtest correlated_srf

--- a/pkg/sql/logictest/testdata/logic_test/udf
+++ b/pkg/sql/logictest/testdata/logic_test/udf
@@ -563,9 +563,6 @@ statement error pq: unimplemented: usage of user-defined function from relations
 CREATE TABLE test_tbl_t (a INT PRIMARY KEY, b INT AS (test_tbl_f() + 1) STORED);
 
 statement error pq: unimplemented: usage of user-defined function from relations not supported
-CREATE TABLE test_tbl_t (a INT PRIMARY KEY, b INT CHECK (test_tbl_f() > 0));
-
-statement error pq: unimplemented: usage of user-defined function from relations not supported
 CREATE TABLE test_tbl_t (a INT PRIMARY KEY, b INT, INDEX idx_b(test_tbl_f()));
 
 statement ok
@@ -576,12 +573,6 @@ CREATE INDEX t_idx ON test_tbl_t(test_tbl_f());
 
 statement error pq: unimplemented: usage of user-defined function from relations not supported
 CREATE INDEX t_idx ON test_tbl_t(b) WHERE test_tbl_f() > 0;
-
-statement error pq: unimplemented: usage of user-defined function from relations not supported
-ALTER TABLE test_tbl_t ADD CONSTRAINT bgt CHECK (test_tbl_f() > 1);
-
-statement error pq: unimplemented: usage of user-defined function from relations not supported
-ALTER TABLE test_tbl_t ADD COLUMN c int CHECK (test_tbl_f() > 0);
 
 statement error pq: unimplemented: usage of user-defined function from relations not supported
 ALTER TABLE test_tbl_t ADD COLUMN c int AS (test_tbl_f()) stored;

--- a/pkg/sql/logictest/testdata/logic_test/udf_in_constraints
+++ b/pkg/sql/logictest/testdata/logic_test/udf_in_constraints
@@ -1,0 +1,394 @@
+statement ok
+CREATE FUNCTION f1(a INT) RETURNS INT LANGUAGE SQL AS $$ SELECT a + 1 $$;
+
+statement ok
+CREATE VIEW v_checks AS
+SELECT
+     id,
+     jsonb_pretty(
+       crdb_internal.pb_to_json(
+         'cockroach.sql.sqlbase.Descriptor',
+         descriptor,
+         false
+       )->'table'->'checks'
+     ) as checks
+FROM system.descriptor
+
+statement ok
+CREATE FUNCTION get_checks(table_id INT) RETURNS STRING
+LANGUAGE SQL
+AS $$
+  SELECT checks
+  FROM v_checks
+  WHERE id = table_id
+$$;
+
+statement ok
+CREATE VIEW v_fn_depended_on_by AS
+SELECT
+     id,
+     jsonb_pretty(
+       crdb_internal.pb_to_json(
+         'cockroach.sql.sqlbase.Descriptor',
+         descriptor,
+         false
+       )->'function'->'dependedOnBy'
+     ) as depended_on_by
+FROM system.descriptor
+
+statement ok
+CREATE FUNCTION get_fn_depended_on_by(function_id INT) RETURNS STRING
+LANGUAGE SQL
+AS $$
+  SELECT depended_on_by
+  FROM v_fn_depended_on_by
+  WHERE id = function_id
+$$;
+
+# Make sure that check constraint expression is properly serialized and
+# deserialized.
+statement ok
+CREATE TABLE t1(
+  a INT PRIMARY KEY,
+  b INT CHECK (f1(b) > 1),
+  FAMILY fam_0 (a, b)
+);
+
+let $tbl_id
+SELECT id FROM system.namespace WHERE name = 't1';
+
+query T
+SELECT get_checks($tbl_id);
+----
+[
+    {
+        "columnIds": [
+            2
+        ],
+        "constraintId": 2,
+        "expr": "[FUNCTION 100106](b) \u003e 1:::INT8",
+        "name": "check_b"
+    }
+]
+
+query T
+SELECT create_statement FROM [SHOW CREATE TABLE t1];
+----
+CREATE TABLE public.t1 (
+  a INT8 NOT NULL,
+  b INT8 NULL,
+  CONSTRAINT t1_pkey PRIMARY KEY (a ASC),
+  FAMILY fam_0 (a, b),
+  CONSTRAINT check_b CHECK (public.f1(b) > 1:::INT8)
+)
+
+# Make sure back references are tracked properly.
+let $fn_id
+SELECT oid::int - 100000 FROM pg_catalog.pg_proc WHERE proname = 'f1';
+
+query T
+SELECT get_fn_depended_on_by($fn_id)
+----
+[
+    {
+        "constraintIds": [
+            2
+        ],
+        "id": 111
+    }
+]
+
+# Make sure ADD CONSTRAINT works as expected.
+statement ok
+ALTER TABLE t1 ADD CONSTRAINT cka CHECK (f1(a) > 1);
+
+query T
+SELECT get_checks($tbl_id);
+----
+[
+    {
+        "columnIds": [
+            2
+        ],
+        "constraintId": 2,
+        "expr": "[FUNCTION 100106](b) \u003e 1:::INT8",
+        "name": "check_b"
+    },
+    {
+        "columnIds": [
+            1
+        ],
+        "constraintId": 3,
+        "expr": "[FUNCTION 100106](a) \u003e 1:::INT8",
+        "name": "cka"
+    }
+]
+
+query T
+SELECT get_fn_depended_on_by($fn_id)
+----
+[
+    {
+        "constraintIds": [
+            2,
+            3
+        ],
+        "id": 111
+    }
+]
+
+# Make sure references from different tables are tracked properly.
+statement ok
+CREATE TABLE t2(
+  a INT PRIMARY KEY,
+  b INT CHECK (f1(b) > 1),
+  CONSTRAINT cka CHECK (f1(a) > 1)
+);
+
+query T
+SELECT get_fn_depended_on_by($fn_id)
+----
+[
+    {
+        "constraintIds": [
+            2,
+            3
+        ],
+        "id": 111
+    },
+    {
+        "constraintIds": [
+            2,
+            3
+        ],
+        "id": 112
+    }
+]
+
+# Make sure DROP CONSTRAINT remove references properly.
+statement ok
+ALTER TABLE t2 DROP CONSTRAINT check_b;
+
+query T
+SELECT get_fn_depended_on_by($fn_id)
+----
+[
+    {
+        "constraintIds": [
+            2,
+            3
+        ],
+        "id": 111
+    },
+    {
+        "constraintIds": [
+            2
+        ],
+        "id": 112
+    }
+]
+
+statement ok
+ALTER TABLE t2 DROP CONSTRAINT cka;
+
+query T
+SELECT get_fn_depended_on_by($fn_id)
+----
+[
+    {
+        "constraintIds": [
+            2,
+            3
+        ],
+        "id": 111
+    }
+]
+
+# Make sure that DROP TABLE remove references properly.
+statement ok
+DROP TABLE t1;
+
+query T
+SELECT get_fn_depended_on_by($fn_id)
+----
+NULL
+
+# Make sure function cannot be dropped if used in constraints
+statement ok
+CREATE TABLE t1(
+  a INT PRIMARY KEY,
+  b INT CHECK (f1(b) > 1),
+  FAMILY fam_0 (a, b)
+);
+
+statement error cannot drop function "f1" because other objects \(\[test.public.t1\]\) still depend on it
+DROP FUNCTION f1;
+
+statement ok
+ALTER TABLE t1 DROP CONSTRAINT check_b;
+
+statement ok
+DROP FUNCTION f1;
+
+statement ok
+DROP TABLE t1;
+
+# Make sure that CREATE FUNCTION and CREATE TABLE works in one txn.
+statement ok
+BEGIN;
+CREATE FUNCTION f1(a INT) RETURNS INT LANGUAGE SQL AS $$ SELECT a + 1 $$;
+CREATE TABLE t1(
+  a INT PRIMARY KEY,
+  b INT CHECK (f1(b) > 1),
+  FAMILY fam_0 (a, b)
+);
+END;
+
+let $tbl_id
+SELECT id FROM system.namespace WHERE name = 't1';
+
+let $fn_id
+SELECT oid::int - 100000 FROM pg_catalog.pg_proc WHERE proname = 'f1';
+
+query T
+SELECT get_checks($tbl_id);
+----
+[
+    {
+        "columnIds": [
+            2
+        ],
+        "constraintId": 2,
+        "expr": "[FUNCTION 100114](b) \u003e 1:::INT8",
+        "name": "check_b"
+    }
+]
+
+query T
+SELECT get_fn_depended_on_by($fn_id);
+----
+[
+    {
+        "constraintIds": [
+            2
+        ],
+        "id": 115
+    }
+]
+
+statement ok
+BEGIN;
+DROP TABLE t1;
+DROP FUNCTION f1;
+END;
+
+# Make sure that CREATE FUNCTION and ADD CONSTRAINT works in one txn.
+statement ok
+CREATE TABLE t1 (
+  a INT PRIMARY KEY,
+  b INT,
+  FAMILY fam_0 (a, b)
+);
+
+statement ok
+BEGIN;
+CREATE FUNCTION f1(a INT) RETURNS INT LANGUAGE SQL AS $$ SELECT a + 1 $$;
+ALTER TABLE t1 ADD CONSTRAINT check_b CHECK (f1(b) > 1);
+END;
+
+let $tbl_id
+SELECT id FROM system.namespace WHERE name = 't1';
+
+let $fn_id
+SELECT oid::int - 100000 FROM pg_catalog.pg_proc WHERE proname = 'f1';
+
+query T
+SELECT get_checks($tbl_id);
+----
+[
+    {
+        "columnIds": [
+            2
+        ],
+        "constraintId": 2,
+        "expr": "[FUNCTION 100117](b) \u003e 1:::INT8",
+        "name": "check_b"
+    }
+]
+
+query T
+SELECT get_fn_depended_on_by($fn_id);
+----
+[
+    {
+        "constraintIds": [
+            2
+        ],
+        "id": 116
+    }
+]
+
+skipif config local-legacy-schema-changer
+statement ok
+SET use_declarative_schema_changer = 'unsafe_always';
+
+# In legacy schema changer, constraints are formally dropped in jobs.
+# So by the point we do DROP FUNCTION, constraints are still there.
+skipif config local-legacy-schema-changer
+statement ok
+BEGIN;
+ALTER TABLE t1 DROP CONSTRAINT check_b;
+DROP FUNCTION f1;
+END;
+
+statement ok
+DROP TABLE t1;
+
+skipif config local-legacy-schema-changer
+statement ok
+SET use_declarative_schema_changer = 'on';
+
+# Make sure check constraint actually validates.
+
+statement ok
+CREATE OR REPLACE FUNCTION f1(a INT) RETURNS INT LANGUAGE SQL AS $$ SELECT a + 1 $$;
+CREATE TABLE t1 (
+  a INT PRIMARY KEY,
+  b INT CHECK (f1(b) > 1),
+  FAMILY fam_0 (a, b)
+);
+
+statement error failed to satisfy CHECK constraint \(public\.f1\(b\) > 1:::INT8\)
+INSERT INTO t1 VALUES (1,0);
+
+statement ok
+INSERT INTO t1 VALUES (1,1);
+
+statement error validation of CHECK "public\.f1\(a\) > 10:::INT8" failed on row: a=1, b=1
+ALTER TABLE t1 ADD CONSTRAINT cka CHECK (f1(a) > 10);
+
+# Make sure that schema prefix is preserved through serialization and
+# deserialization.
+
+statement ok
+CREATE DATABASE db1;
+USE db1;
+CREATE SCHEMA sc1;
+CREATE FUNCTION sc1.f1(a INT) RETURNS INT LANGUAGE SQL AS $$ SELECT a + 1 $$;
+CREATE FUNCTION sc1.f1() RETURNS INT LANGUAGE SQL AS $$ SELECT 1 $$;
+CREATE TABLE t(
+  a INT PRIMARY KEY,
+  b INT CHECK (sc1.f1(b) > 1),
+  FAMILY fam_0_b_a (b, a)
+);
+
+query T
+SELECT create_statement FROM [SHOW CREATE TABLE t]
+----
+CREATE TABLE public.t (
+  a INT8 NOT NULL,
+  b INT8 NULL,
+  CONSTRAINT t_pkey PRIMARY KEY (a ASC),
+  FAMILY fam_0_b_a (b, a),
+  CONSTRAINT check_b CHECK (sc1.f1(b) > 1:::INT8)
+)

--- a/pkg/sql/logictest/testdata/logic_test/udf_oid_ref
+++ b/pkg/sql/logictest/testdata/logic_test/udf_oid_ref
@@ -59,7 +59,7 @@ hello world
 
 # Make sure that argument types are still checked even we know which function
 # overload to use.
-statement error pq: unknown signature: f2\(int\)
+statement error pq: unknown signature: public.f2\(int\)
 SELECT [FUNCTION $fn_oid](123)
 
 # Make sure that renaming does not break the reference.

--- a/pkg/sql/logictest/testdata/logic_test/virtual_columns
+++ b/pkg/sql/logictest/testdata/logic_test/virtual_columns
@@ -785,7 +785,7 @@ a  b   v   x  y   z
 2  20  22  3  21  22
 3  30  33  4  31  33
 
-statement error computed column expression cannot reference computed columns
+statement error VIRTUAL COMPUTED COLUMN expression cannot reference computed columns
 ALTER TABLE sc ADD COLUMN u INT AS (a+v) VIRTUAL
 
 statement ok

--- a/pkg/sql/logictest/tests/fakedist-disk/generated_test.go
+++ b/pkg/sql/logictest/tests/fakedist-disk/generated_test.go
@@ -1997,6 +1997,13 @@ func TestLogic_udf(
 	runLogicTest(t, "udf")
 }
 
+func TestLogic_udf_in_constraints(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "udf_in_constraints")
+}
+
 func TestLogic_udf_oid_ref(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/fakedist-vec-off/generated_test.go
+++ b/pkg/sql/logictest/tests/fakedist-vec-off/generated_test.go
@@ -2004,6 +2004,13 @@ func TestLogic_udf(
 	runLogicTest(t, "udf")
 }
 
+func TestLogic_udf_in_constraints(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "udf_in_constraints")
+}
+
 func TestLogic_udf_oid_ref(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/fakedist/generated_test.go
+++ b/pkg/sql/logictest/tests/fakedist/generated_test.go
@@ -2018,6 +2018,13 @@ func TestLogic_udf(
 	runLogicTest(t, "udf")
 }
 
+func TestLogic_udf_in_constraints(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "udf_in_constraints")
+}
+
 func TestLogic_udf_oid_ref(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/local-legacy-schema-changer/generated_test.go
+++ b/pkg/sql/logictest/tests/local-legacy-schema-changer/generated_test.go
@@ -1983,6 +1983,13 @@ func TestLogic_udf(
 	runLogicTest(t, "udf")
 }
 
+func TestLogic_udf_in_constraints(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "udf_in_constraints")
+}
+
 func TestLogic_udf_oid_ref(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/local-vec-off/generated_test.go
+++ b/pkg/sql/logictest/tests/local-vec-off/generated_test.go
@@ -2018,6 +2018,13 @@ func TestLogic_udf(
 	runLogicTest(t, "udf")
 }
 
+func TestLogic_udf_in_constraints(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "udf_in_constraints")
+}
+
 func TestLogic_udf_oid_ref(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/local/generated_test.go
+++ b/pkg/sql/logictest/tests/local/generated_test.go
@@ -2207,6 +2207,13 @@ func TestLogic_udf(
 	runLogicTest(t, "udf")
 }
 
+func TestLogic_udf_in_constraints(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "udf_in_constraints")
+}
+
 func TestLogic_udf_oid_ref(
 	t *testing.T,
 ) {

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -969,7 +969,7 @@ func (u *sqlSymUnion) showTenantOpts() tree.ShowTenantOptions {
 %token <str> SEARCH SECOND SECONDARY SECURITY SELECT SEQUENCE SEQUENCES
 %token <str> SERIALIZABLE SERVER SERVICE SESSION SESSIONS SESSION_USER SET SETOF SETS SETTING SETTINGS
 %token <str> SHARE SHARED SHOW SIMILAR SIMPLE SKIP SKIP_LOCALITIES_CHECK SKIP_MISSING_FOREIGN_KEYS
-%token <str> SKIP_MISSING_SEQUENCES SKIP_MISSING_SEQUENCE_OWNERS SKIP_MISSING_VIEWS SMALLINT SMALLSERIAL SNAPSHOT SOME SPLIT SQL
+%token <str> SKIP_MISSING_SEQUENCES SKIP_MISSING_SEQUENCE_OWNERS SKIP_MISSING_VIEWS SKIP_MISSING_UDFS SMALLINT SMALLSERIAL SNAPSHOT SOME SPLIT SQL
 %token <str> SQLLOGIN
 %token <str> STABLE START STATE STATISTICS STATUS STDIN STDOUT STOP STREAM STRICT STRING STORAGE STORE STORED STORING SUBSTRING SUPER
 %token <str> SUPPORT SURVIVE SURVIVAL SYMMETRIC SYNTAX SYSTEM SQRT SUBSCRIPTION STATEMENTS
@@ -3555,6 +3555,7 @@ drop_external_connection_stmt:
 //    skip_missing_sequences: ignore sequence dependencies
 //    skip_missing_views: skip restoring views because of dependencies that cannot be restored
 //    skip_missing_sequence_owners: remove sequence-table ownership dependencies before restoring
+//    skip_missing_udfs: skip restoring
 //    encryption_passphrase=passphrase: decrypt BACKUP with specified passphrase
 //    kms="[kms_provider]://[kms_host]/[master_key_identifier]?[parameters]" : decrypt backups using KMS
 //    detached: execute restore job asynchronously, without waiting for its completion
@@ -3699,6 +3700,10 @@ restore_options:
 | SKIP_MISSING_VIEWS
   {
     $$.val = &tree.RestoreOptions{SkipMissingViews: true}
+  }
+| SKIP_MISSING_UDFS
+  {
+    $$.val = &tree.RestoreOptions{SkipMissingUDFs: true}
   }
 | DETACHED
   {
@@ -16315,6 +16320,7 @@ unreserved_keyword:
 | SKIP_MISSING_SEQUENCES
 | SKIP_MISSING_SEQUENCE_OWNERS
 | SKIP_MISSING_VIEWS
+| SKIP_MISSING_UDFS
 | SNAPSHOT
 | SPLIT
 | SQL
@@ -16426,6 +16432,7 @@ bare_label_keywords:
 | TRANSFORM
 | VOLATILE
 | SETOF
+| SKIP_MISSING_VIEWS
 
 // Column identifier --- keywords that can be column, table, etc names.
 //

--- a/pkg/sql/parser/testdata/backup_restore
+++ b/pkg/sql/parser/testdata/backup_restore
@@ -701,23 +701,23 @@ RESTORE FROM 'a' WITH into_db = 'foo', skip_missing_foreign_keys, skip_localitie
 
 parse
 RESTORE foo FROM 'bar' WITH OPTIONS (encryption_passphrase='secret', into_db='baz', debug_pause_on='error',
-skip_missing_foreign_keys, skip_missing_sequences, skip_missing_sequence_owners, skip_missing_views, detached, skip_localities_check)
+skip_missing_foreign_keys, skip_missing_sequences, skip_missing_sequence_owners, skip_missing_views, skip_missing_udfs, detached, skip_localities_check)
 ----
-RESTORE TABLE foo FROM 'bar' WITH encryption_passphrase = '*****', into_db = 'baz', debug_pause_on = 'error', skip_missing_foreign_keys, skip_missing_sequence_owners, skip_missing_sequences, skip_missing_views, detached, skip_localities_check -- normalized!
-RESTORE TABLE (foo) FROM ('bar') WITH encryption_passphrase = '*****', into_db = ('baz'), debug_pause_on = ('error'), skip_missing_foreign_keys, skip_missing_sequence_owners, skip_missing_sequences, skip_missing_views, detached, skip_localities_check -- fully parenthesized
-RESTORE TABLE foo FROM '_' WITH encryption_passphrase = '*****', into_db = '_', debug_pause_on = '_', skip_missing_foreign_keys, skip_missing_sequence_owners, skip_missing_sequences, skip_missing_views, detached, skip_localities_check -- literals removed
-RESTORE TABLE _ FROM 'bar' WITH encryption_passphrase = '*****', into_db = 'baz', debug_pause_on = 'error', skip_missing_foreign_keys, skip_missing_sequence_owners, skip_missing_sequences, skip_missing_views, detached, skip_localities_check -- identifiers removed
-RESTORE TABLE foo FROM 'bar' WITH encryption_passphrase = 'secret', into_db = 'baz', debug_pause_on = 'error', skip_missing_foreign_keys, skip_missing_sequence_owners, skip_missing_sequences, skip_missing_views, detached, skip_localities_check -- passwords exposed
+RESTORE TABLE foo FROM 'bar' WITH encryption_passphrase = '*****', into_db = 'baz', debug_pause_on = 'error', skip_missing_foreign_keys, skip_missing_sequence_owners, skip_missing_sequences, skip_missing_views, skip_missing_udfs, detached, skip_localities_check -- normalized!
+RESTORE TABLE (foo) FROM ('bar') WITH encryption_passphrase = '*****', into_db = ('baz'), debug_pause_on = ('error'), skip_missing_foreign_keys, skip_missing_sequence_owners, skip_missing_sequences, skip_missing_views, skip_missing_udfs, detached, skip_localities_check -- fully parenthesized
+RESTORE TABLE foo FROM '_' WITH encryption_passphrase = '*****', into_db = '_', debug_pause_on = '_', skip_missing_foreign_keys, skip_missing_sequence_owners, skip_missing_sequences, skip_missing_views, skip_missing_udfs, detached, skip_localities_check -- literals removed
+RESTORE TABLE _ FROM 'bar' WITH encryption_passphrase = '*****', into_db = 'baz', debug_pause_on = 'error', skip_missing_foreign_keys, skip_missing_sequence_owners, skip_missing_sequences, skip_missing_views, skip_missing_udfs, detached, skip_localities_check -- identifiers removed
+RESTORE TABLE foo FROM 'bar' WITH encryption_passphrase = 'secret', into_db = 'baz', debug_pause_on = 'error', skip_missing_foreign_keys, skip_missing_sequence_owners, skip_missing_sequences, skip_missing_views, skip_missing_udfs, detached, skip_localities_check -- passwords exposed
 
 parse
 RESTORE foo FROM 'bar' WITH ENCRYPTION_PASSPHRASE = 'secret', INTO_DB=baz, DEBUG_PAUSE_ON='error',
-SKIP_MISSING_FOREIGN_KEYS, SKIP_MISSING_SEQUENCES, SKIP_MISSING_SEQUENCE_OWNERS, SKIP_MISSING_VIEWS, SKIP_LOCALITIES_CHECK
+SKIP_MISSING_FOREIGN_KEYS, SKIP_MISSING_SEQUENCES, SKIP_MISSING_SEQUENCE_OWNERS, SKIP_MISSING_VIEWS, SKIP_LOCALITIES_CHECK, SKIP_MISSING_UDFS
 ----
-RESTORE TABLE foo FROM 'bar' WITH encryption_passphrase = '*****', into_db = 'baz', debug_pause_on = 'error', skip_missing_foreign_keys, skip_missing_sequence_owners, skip_missing_sequences, skip_missing_views, skip_localities_check -- normalized!
-RESTORE TABLE (foo) FROM ('bar') WITH encryption_passphrase = '*****', into_db = ('baz'), debug_pause_on = ('error'), skip_missing_foreign_keys, skip_missing_sequence_owners, skip_missing_sequences, skip_missing_views, skip_localities_check -- fully parenthesized
-RESTORE TABLE foo FROM '_' WITH encryption_passphrase = '*****', into_db = '_', debug_pause_on = '_', skip_missing_foreign_keys, skip_missing_sequence_owners, skip_missing_sequences, skip_missing_views, skip_localities_check -- literals removed
-RESTORE TABLE _ FROM 'bar' WITH encryption_passphrase = '*****', into_db = 'baz', debug_pause_on = 'error', skip_missing_foreign_keys, skip_missing_sequence_owners, skip_missing_sequences, skip_missing_views, skip_localities_check -- identifiers removed
-RESTORE TABLE foo FROM 'bar' WITH encryption_passphrase = 'secret', into_db = 'baz', debug_pause_on = 'error', skip_missing_foreign_keys, skip_missing_sequence_owners, skip_missing_sequences, skip_missing_views, skip_localities_check -- passwords exposed
+RESTORE TABLE foo FROM 'bar' WITH encryption_passphrase = '*****', into_db = 'baz', debug_pause_on = 'error', skip_missing_foreign_keys, skip_missing_sequence_owners, skip_missing_sequences, skip_missing_views, skip_missing_udfs, skip_localities_check -- normalized!
+RESTORE TABLE (foo) FROM ('bar') WITH encryption_passphrase = '*****', into_db = ('baz'), debug_pause_on = ('error'), skip_missing_foreign_keys, skip_missing_sequence_owners, skip_missing_sequences, skip_missing_views, skip_missing_udfs, skip_localities_check -- fully parenthesized
+RESTORE TABLE foo FROM '_' WITH encryption_passphrase = '*****', into_db = '_', debug_pause_on = '_', skip_missing_foreign_keys, skip_missing_sequence_owners, skip_missing_sequences, skip_missing_views, skip_missing_udfs, skip_localities_check -- literals removed
+RESTORE TABLE _ FROM 'bar' WITH encryption_passphrase = '*****', into_db = 'baz', debug_pause_on = 'error', skip_missing_foreign_keys, skip_missing_sequence_owners, skip_missing_sequences, skip_missing_views, skip_missing_udfs, skip_localities_check -- identifiers removed
+RESTORE TABLE foo FROM 'bar' WITH encryption_passphrase = 'secret', into_db = 'baz', debug_pause_on = 'error', skip_missing_foreign_keys, skip_missing_sequence_owners, skip_missing_sequences, skip_missing_views, skip_missing_udfs, skip_localities_check -- passwords exposed
 
 parse
 RESTORE TENANT 36 FROM ($1, $2) AS OF SYSTEM TIME '1'
@@ -849,6 +849,14 @@ at or near "detached": syntax error: detached option specified multiple times
 DETAIL: source SQL:
 RESTORE foo FROM 'bar' WITH detached, skip_missing_views, detached
                                                           ^
+
+error
+RESTORE foo FROM 'bar' WITH skip_missing_udfs, skip_missing_views, skip_missing_udfs
+----
+at or near "skip_missing_udfs": syntax error: skip_missing_udfs specified multiple times
+DETAIL: source SQL:
+RESTORE foo FROM 'bar' WITH skip_missing_udfs, skip_missing_views, skip_missing_udfs
+                                                                   ^
 
 error
 BACKUP ROLE foo, bar TO 'baz'

--- a/pkg/sql/planner.go
+++ b/pkg/sql/planner.go
@@ -810,7 +810,7 @@ func (p *planner) resetPlanner(
 	p.semaCtx.Annotations = nil
 	p.semaCtx.TypeResolver = p
 	p.semaCtx.FunctionResolver = p
-	p.semaCtx.TableNameResolver = p
+	p.semaCtx.NameResolver = p
 	p.semaCtx.DateStyle = sd.GetDateStyle()
 	p.semaCtx.IntervalStyle = sd.GetIntervalStyle()
 

--- a/pkg/sql/resolver.go
+++ b/pkg/sql/resolver.go
@@ -562,9 +562,9 @@ func (p *planner) getDescriptorsFromTargetListForPrivilegeChange(
 	return descs, nil
 }
 
-// getFullyQualifiedTableNamesFromIDs resolves a list of table IDs to their
+// getFullyQualifiedNamesFromIDs resolves a list of table IDs to their
 // fully qualified names.
-func (p *planner) getFullyQualifiedTableNamesFromIDs(
+func (p *planner) getFullyQualifiedNamesFromIDs(
 	ctx context.Context, ids []descpb.ID,
 ) (fullyQualifiedNames []string, _ error) {
 	for _, id := range ids {

--- a/pkg/sql/schema_resolver.go
+++ b/pkg/sql/schema_resolver.go
@@ -263,6 +263,18 @@ func (sr *schemaResolver) getQualifiedTableName(
 	return &tbName, nil
 }
 
+// GetQualifiedFunctionNameByID returns the qualified name of the table,
+// view or sequence represented by the provided ID and table kind.
+func (sr *schemaResolver) GetQualifiedFunctionNameByID(
+	ctx context.Context, id int64,
+) (*tree.FunctionName, error) {
+	fn, err := sr.descCollection.ByIDWithLeased(sr.txn).WithoutNonPublic().Get().Function(ctx, descpb.ID(id))
+	if err != nil {
+		return nil, err
+	}
+	return sr.getQualifiedFunctionName(ctx, fn)
+}
+
 func (sr *schemaResolver) getQualifiedFunctionName(
 	ctx context.Context, fnDesc catalog.FunctionDescriptor,
 ) (*tree.FunctionName, error) {

--- a/pkg/sql/schemachanger/scbuild/builder_state.go
+++ b/pkg/sql/schemachanger/scbuild/builder_state.go
@@ -615,6 +615,7 @@ func (b *builderState) ComputedColumnExpression(tbl *scpb.Table, d *tree.ColumnT
 		&tn,
 		tree.ComputedColumnExprContext(d.IsVirtual()),
 		b.semaCtx,
+		b.clusterSettings.Version.ActiveVersion(b.ctx),
 	)
 	if err != nil {
 		// This may be referencing newly added columns, so cheat and return
@@ -651,7 +652,8 @@ func (b *builderState) PartialIndexPredicateExpression(
 		b.descCache[tableID].desc.(catalog.TableDescriptor),
 		expr,
 		&tn,
-		b.semaCtx)
+		b.semaCtx,
+		b.clusterSettings.Version.ActiveVersion(b.ctx))
 	if err != nil {
 		panic(err)
 	}

--- a/pkg/sql/schemachanger/scbuild/builder_state.go
+++ b/pkg/sql/schemachanger/scbuild/builder_state.go
@@ -583,7 +583,7 @@ func (b *builderState) WrapExpression(tableID catid.DescID, expr tree.Expr) *scp
 		}
 	}
 	// Collect function IDs
-	fnIDs, err := schemaexpr.GetUdfIDs(expr)
+	fnIDs, err := schemaexpr.GetUDFIDs(expr)
 	if err != nil {
 		panic(err)
 	}

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_table_add_constraint.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_table_add_constraint.go
@@ -93,7 +93,7 @@ func alterTableAddCheck(
 	// See the comments of DequalifyAndValidateExprImpl for criteria.
 	ckDef := t.ConstraintDef.(*tree.CheckConstraintTableDef)
 	ckExpr, _, colIDs, err := schemaexpr.DequalifyAndValidateExprImpl(b, ckDef.Expr, types.Bool,
-		"CHECK", b.SemaCtx(), volatility.Volatile, tn,
+		tree.CheckConstraintExpr, b.SemaCtx(), volatility.Volatile, tn,
 		func() colinfo.ResultColumns {
 			return getNonDropResultColumns(b, tbl.TableID)
 		},
@@ -467,7 +467,7 @@ func alterTableAddUniqueWithoutIndex(
 
 	// 4. If there is a predicate, validate it.
 	if d.Predicate != nil {
-		predicate, _, _, err := schemaexpr.DequalifyAndValidateExprImpl(b, d.Predicate, types.Bool, "unique without index predicate", b.SemaCtx(), volatility.Immutable, tn,
+		predicate, _, _, err := schemaexpr.DequalifyAndValidateExprImpl(b, d.Predicate, types.Bool, tree.UniqueWithoutIndexPredicateExpr, b.SemaCtx(), volatility.Immutable, tn,
 			func() colinfo.ResultColumns {
 				return getNonDropResultColumns(b, tbl.TableID)
 			},

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_table_add_constraint.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_table_add_constraint.go
@@ -93,7 +93,7 @@ func alterTableAddCheck(
 	// See the comments of DequalifyAndValidateExprImpl for criteria.
 	ckDef := t.ConstraintDef.(*tree.CheckConstraintTableDef)
 	ckExpr, _, colIDs, err := schemaexpr.DequalifyAndValidateExprImpl(b, ckDef.Expr, types.Bool,
-		tree.CheckConstraintExpr, b.SemaCtx(), volatility.Volatile, tn,
+		tree.CheckConstraintExpr, b.SemaCtx(), volatility.Volatile, tn, b.ClusterSettings().Version.ActiveVersion(b),
 		func() colinfo.ResultColumns {
 			return getNonDropResultColumns(b, tbl.TableID)
 		},
@@ -467,7 +467,8 @@ func alterTableAddUniqueWithoutIndex(
 
 	// 4. If there is a predicate, validate it.
 	if d.Predicate != nil {
-		predicate, _, _, err := schemaexpr.DequalifyAndValidateExprImpl(b, d.Predicate, types.Bool, tree.UniqueWithoutIndexPredicateExpr, b.SemaCtx(), volatility.Immutable, tn,
+		predicate, _, _, err := schemaexpr.DequalifyAndValidateExprImpl(b, d.Predicate, types.Bool,
+			tree.UniqueWithoutIndexPredicateExpr, b.SemaCtx(), volatility.Immutable, tn, b.ClusterSettings().Version.ActiveVersion(b),
 			func() colinfo.ResultColumns {
 				return getNonDropResultColumns(b, tbl.TableID)
 			},

--- a/pkg/sql/schemachanger/scbuild/tree_context_builder.go
+++ b/pkg/sql/schemachanger/scbuild/tree_context_builder.go
@@ -33,7 +33,7 @@ func newSemaCtx(d Dependencies) *tree.SemaContext {
 	semaCtx.SearchPath = &d.SessionData().SearchPath
 	semaCtx.TypeResolver = d.CatalogReader()
 	semaCtx.FunctionResolver = d.CatalogReader()
-	semaCtx.TableNameResolver = d.CatalogReader()
+	semaCtx.NameResolver = d.CatalogReader()
 	semaCtx.DateStyle = d.SessionData().GetDateStyle()
 	semaCtx.IntervalStyle = d.SessionData().GetIntervalStyle()
 	return &semaCtx

--- a/pkg/sql/schemachanger/scdecomp/decomp.go
+++ b/pkg/sql/schemachanger/scdecomp/decomp.go
@@ -824,5 +824,8 @@ func (w *walkCtx) walkFunction(fnDesc catalog.FunctionDescriptor) {
 			}
 		}
 	}
+	for _, backRef := range fnDesc.GetDependedOnBy() {
+		w.backRefs.Add(backRef.ID)
+	}
 	w.ev(scpb.Status_PUBLIC, fnBody)
 }

--- a/pkg/sql/schemachanger/scdecomp/helpers.go
+++ b/pkg/sql/schemachanger/scdecomp/helpers.go
@@ -107,10 +107,15 @@ func (w *walkCtx) newExpression(expr string) (*scpb.Expression, error) {
 	if err != nil {
 		return nil, err
 	}
+	referencedFnIDs, err := schemaexpr.GetUdfIDs(e)
+	if err != nil {
+		return nil, err
+	}
 	return &scpb.Expression{
 		Expr:                catpb.Expression(expr),
 		UsesTypeIDs:         typIDs.Ordered(),
 		UsesSequenceIDs:     seqIDs.Ordered(),
+		UsesFunctionIDs:     referencedFnIDs.Ordered(),
 		ReferencedColumnIDs: referencedColumns.Ordered(),
 	}, nil
 }

--- a/pkg/sql/schemachanger/scdecomp/helpers.go
+++ b/pkg/sql/schemachanger/scdecomp/helpers.go
@@ -107,7 +107,7 @@ func (w *walkCtx) newExpression(expr string) (*scpb.Expression, error) {
 	if err != nil {
 		return nil, err
 	}
-	referencedFnIDs, err := schemaexpr.GetUdfIDs(e)
+	referencedFnIDs, err := schemaexpr.GetUDFIDs(e)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sql/schemachanger/scdecomp/testdata/sequence
+++ b/pkg/sql/schemachanger/scdecomp/testdata/sequence
@@ -304,6 +304,7 @@ ElementState:
     expr: nextval(104:::REGCLASS)
     referencedColumnIds: []
     tableId: 105
+    usesFunctionIds: []
     usesSequenceIds:
     - 104
     usesTypeIds: []
@@ -313,6 +314,7 @@ ElementState:
     expr: 123:::INT8
     referencedColumnIds: []
     tableId: 105
+    usesFunctionIds: []
     usesSequenceIds: []
     usesTypeIds: []
   Status: PUBLIC

--- a/pkg/sql/schemachanger/scdecomp/testdata/table
+++ b/pkg/sql/schemachanger/scdecomp/testdata/table
@@ -19,6 +19,8 @@ ALTER TABLE tbl ADD CONSTRAINT mycheck2 CHECK (id < 10) NOT VALID;
 ALTER TABLE tbl ADD CONSTRAINT myuwi1 UNIQUE WITHOUT INDEX (price);
 ALTER TABLE tbl ADD CONSTRAINT myuwi2 UNIQUE WITHOUT INDEX (price) NOT VALID;
 ALTER TABLE tbl ADD CONSTRAINT myfk2 FOREIGN KEY (id) REFERENCES parent (id) NOT VALID;
+CREATE FUNCTION f(a INT) RETURNS INT LANGUAGE SQL AS $$ SELECT a + 1 $$;
+ALTER TABLE tbl ADD CONSTRAINT mycheck3 CHECK (f(id) > 1);
 ----
 
 decompose
@@ -325,6 +327,7 @@ ElementState:
     sourceIndexId: 0
     tableId: 105
     temporaryIndexId: 0
+    usesFunctionIds: []
     usesSequenceIds: []
     usesTypeIds: []
   Status: PUBLIC
@@ -353,6 +356,22 @@ ElementState:
     referencedColumnIds:
     - 1
     tableId: 105
+    usesFunctionIds: []
+    usesSequenceIds: []
+    usesTypeIds: []
+  Status: PUBLIC
+- CheckConstraint:
+    columnIds:
+    - 1
+    constraintId: 8
+    expr: '[FUNCTION 100106](id) > 1:::INT8'
+    fromHashShardedColumn: false
+    indexIdForValidation: 0
+    referencedColumnIds:
+    - 1
+    tableId: 105
+    usesFunctionIds:
+    - 106
     usesSequenceIds: []
     usesTypeIds: []
   Status: PUBLIC
@@ -364,6 +383,7 @@ ElementState:
     referencedColumnIds:
     - 1
     tableId: 105
+    usesFunctionIds: []
     usesSequenceIds: []
     usesTypeIds: []
   Status: PUBLIC
@@ -692,6 +712,11 @@ ElementState:
     name: myfk2
     tableId: 105
   Status: PUBLIC
+- ConstraintWithoutIndexName:
+    constraintId: 8
+    name: mycheck3
+    tableId: 105
+  Status: PUBLIC
 - ConstraintComment:
     comment: must have a parent
     constraintId: 2
@@ -1012,12 +1037,12 @@ BackReferencedIDs:
 ElementState:
 - Table:
     isTemporary: false
-    tableId: 108
+    tableId: 109
   Status: PUBLIC
 - ColumnFamily:
     familyId: 0
     name: primary
-    tableId: 108
+    tableId: 109
   Status: PUBLIC
 - Column:
     columnId: 1
@@ -1027,7 +1052,7 @@ ElementState:
     isInaccessible: false
     isSystemColumn: false
     pgAttributeNum: 1
-    tableId: 108
+    tableId: 109
   Status: PUBLIC
 - Column:
     columnId: 2
@@ -1037,7 +1062,7 @@ ElementState:
     isInaccessible: false
     isSystemColumn: false
     pgAttributeNum: 2
-    tableId: 108
+    tableId: 109
   Status: PUBLIC
 - Column:
     columnId: 4.294967294e+09
@@ -1047,7 +1072,7 @@ ElementState:
     isInaccessible: false
     isSystemColumn: true
     pgAttributeNum: 4.294967294e+09
-    tableId: 108
+    tableId: 109
   Status: PUBLIC
 - Column:
     columnId: 4.294967295e+09
@@ -1057,7 +1082,7 @@ ElementState:
     isInaccessible: false
     isSystemColumn: true
     pgAttributeNum: 4.294967295e+09
-    tableId: 108
+    tableId: 109
   Status: PUBLIC
 - PrimaryIndex:
     constraintId: 1
@@ -1070,49 +1095,50 @@ ElementState:
     isUnique: true
     sharding: null
     sourceIndexId: 0
-    tableId: 108
+    tableId: 109
     temporaryIndexId: 0
   Status: PUBLIC
 - TableData:
     databaseId: 100
-    tableId: 108
+    tableId: 109
   Status: PUBLIC
 - ColumnName:
     columnId: 1
     name: v
-    tableId: 108
+    tableId: 109
   Status: PUBLIC
 - ColumnName:
     columnId: 2
     name: rowid
-    tableId: 108
+    tableId: 109
   Status: PUBLIC
 - ColumnName:
     columnId: 4.294967294e+09
     name: tableoid
-    tableId: 108
+    tableId: 109
   Status: PUBLIC
 - ColumnName:
     columnId: 4.294967295e+09
     name: crdb_internal_mvcc_timestamp
-    tableId: 108
+    tableId: 109
   Status: PUBLIC
 - ColumnType:
     closedTypeIds: []
     columnId: 1
     computeExpr:
-      expr: x'80':::@100106::STRING
+      expr: x'80':::@100107::STRING
       referencedColumnIds: []
+      usesFunctionIds: []
       usesSequenceIds: []
       usesTypeIds:
-      - 106
       - 107
+      - 108
     elementCreationMetadata:
       in231OrLater: true
     familyId: 0
     isNullable: true
     isVirtual: false
-    tableId: 108
+    tableId: 109
     type:
       arrayContents: null
       arrayDimensions: []
@@ -1139,7 +1165,7 @@ ElementState:
     familyId: 0
     isNullable: false
     isVirtual: false
-    tableId: 108
+    tableId: 109
     type:
       arrayContents: null
       arrayDimensions: []
@@ -1166,7 +1192,7 @@ ElementState:
     familyId: 0
     isNullable: true
     isVirtual: false
-    tableId: 108
+    tableId: 109
     type:
       arrayContents: null
       arrayDimensions: []
@@ -1193,7 +1219,7 @@ ElementState:
     familyId: 0
     isNullable: true
     isVirtual: false
-    tableId: 108
+    tableId: 109
     type:
       arrayContents: null
       arrayDimensions: []
@@ -1215,19 +1241,20 @@ ElementState:
     columnId: 2
     expr: unique_rowid()
     referencedColumnIds: []
-    tableId: 108
+    tableId: 109
+    usesFunctionIds: []
     usesSequenceIds: []
     usesTypeIds: []
   Status: PUBLIC
 - ColumnNotNull:
     columnId: 2
     indexIdForValidation: 0
-    tableId: 108
+    tableId: 109
   Status: PUBLIC
 - IndexName:
     indexId: 1
     name: greeter_pkey
-    tableId: 108
+    tableId: 109
   Status: PUBLIC
 - IndexColumn:
     columnId: 1
@@ -1237,7 +1264,7 @@ ElementState:
     invertedKind: 0
     kind: STORED
     ordinalInKind: 0
-    tableId: 108
+    tableId: 109
   Status: PUBLIC
 - IndexColumn:
     columnId: 2
@@ -1247,35 +1274,35 @@ ElementState:
     invertedKind: 0
     kind: KEY
     ordinalInKind: 0
-    tableId: 108
+    tableId: 109
   Status: PUBLIC
 - IndexData:
     indexId: 1
-    tableId: 108
+    tableId: 109
   Status: PUBLIC
 - Namespace:
     databaseId: 100
-    descriptorId: 108
+    descriptorId: 109
     name: greeter
     schemaId: 101
   Status: PUBLIC
 - Owner:
-    descriptorId: 108
+    descriptorId: 109
     owner: root
   Status: PUBLIC
 - UserPrivileges:
-    descriptorId: 108
+    descriptorId: 109
     privileges: "2"
     userName: admin
     withGrantOption: "2"
   Status: PUBLIC
 - UserPrivileges:
-    descriptorId: 108
+    descriptorId: 109
     privileges: "2"
     userName: root
     withGrantOption: "2"
   Status: PUBLIC
 - ObjectParent:
-    objectId: 108
+    objectId: 109
     parentSchemaId: 101
   Status: PUBLIC

--- a/pkg/sql/schemachanger/scdecomp/testdata/type
+++ b/pkg/sql/schemachanger/scdecomp/testdata/type
@@ -182,6 +182,7 @@ ElementState:
     sourceIndexId: 0
     tableId: 108
     temporaryIndexId: 0
+    usesFunctionIds: []
     usesSequenceIds: []
     usesTypeIds: []
   Status: PUBLIC
@@ -193,6 +194,7 @@ ElementState:
     predicate:
       expr: x'80':::@100104::STRING = 'hi':::STRING
       referencedColumnIds: []
+      usesFunctionIds: []
       usesSequenceIds: []
       usesTypeIds:
       - 104
@@ -211,6 +213,7 @@ ElementState:
     - 3
     - 5
     tableId: 108
+    usesFunctionIds: []
     usesSequenceIds: []
     usesTypeIds: []
   Status: PUBLIC
@@ -261,6 +264,7 @@ ElementState:
     computeExpr:
       expr: x'80':::@100104
       referencedColumnIds: []
+      usesFunctionIds: []
       usesSequenceIds: []
       usesTypeIds:
       - 104
@@ -342,6 +346,7 @@ ElementState:
     computeExpr:
       expr: x'80':::@100106
       referencedColumnIds: []
+      usesFunctionIds: []
       usesSequenceIds: []
       usesTypeIds:
       - 106
@@ -842,6 +847,7 @@ ElementState:
     sourceIndexId: 0
     tableId: 111
     temporaryIndexId: 0
+    usesFunctionIds: []
     usesSequenceIds: []
     usesTypeIds: []
   Status: PUBLIC
@@ -855,6 +861,7 @@ ElementState:
     referencedColumnIds:
     - 2
     tableId: 111
+    usesFunctionIds: []
     usesSequenceIds: []
     usesTypeIds: []
   Status: PUBLIC
@@ -1052,6 +1059,7 @@ ElementState:
     computeExpr:
       expr: (3:::INT8, 'foo':::STRING)
       referencedColumnIds: []
+      usesFunctionIds: []
       usesSequenceIds: []
       usesTypeIds: []
     elementCreationMetadata:
@@ -1117,6 +1125,7 @@ ElementState:
     computeExpr:
       expr: (4:::INT8, 'foo':::STRING)
       referencedColumnIds: []
+      usesFunctionIds: []
       usesSequenceIds: []
       usesTypeIds: []
     elementCreationMetadata:
@@ -1290,6 +1299,7 @@ ElementState:
       expr: (c).a
       referencedColumnIds:
       - 2
+      usesFunctionIds: []
       usesSequenceIds: []
       usesTypeIds: []
     elementCreationMetadata:

--- a/pkg/sql/schemachanger/scdeps/build_deps.go
+++ b/pkg/sql/schemachanger/scdeps/build_deps.go
@@ -249,6 +249,13 @@ func (d *buildDeps) GetQualifiedTableNameByID(
 	return d.schemaResolver.GetQualifiedTableNameByID(ctx, id, requiredType)
 }
 
+// GetQualifiedTableNameByID implements the scbuild.CatalogReader interface.
+func (d *buildDeps) GetQualifiedFunctionNameByID(
+	ctx context.Context, id int64,
+) (*tree.FunctionName, error) {
+	return d.schemaResolver.GetQualifiedFunctionNameByID(ctx, id)
+}
+
 // CurrentDatabase implements the scbuild.CatalogReader interface.
 func (d *buildDeps) CurrentDatabase() string {
 	return d.schemaResolver.CurrentDatabase()

--- a/pkg/sql/schemachanger/scexec/scmutationexec/constraint.go
+++ b/pkg/sql/schemachanger/scexec/scmutationexec/constraint.go
@@ -91,10 +91,10 @@ func (i *immediateVisitor) AddCheckConstraint(
 	return nil
 }
 
-func (m *immediateVisitor) MakeAbsentColumnNotNullWriteOnly(
+func (i *immediateVisitor) MakeAbsentColumnNotNullWriteOnly(
 	ctx context.Context, op scop.MakeAbsentColumnNotNullWriteOnly,
 ) error {
-	tbl, err := m.checkOutTable(ctx, op.TableID)
+	tbl, err := i.checkOutTable(ctx, op.TableID)
 	if err != nil || tbl.Dropped() {
 		return err
 	}

--- a/pkg/sql/schemachanger/scexec/scmutationexec/references.go
+++ b/pkg/sql/schemachanger/scexec/scmutationexec/references.go
@@ -281,19 +281,6 @@ func (i *immediateVisitor) RemoveTableConstraintBackReferencesFromFunctions(
 	return nil
 }
 
-func (i *immediateVisitor) RemoveAllTableBackReferencesFromFunctions(
-	ctx context.Context, op scop.RemoveAllTableBackReferencesFromFunctions,
-) error {
-	for _, fnID := range op.FunctionIDs {
-		fnDesc, err := i.checkOutFunction(ctx, fnID)
-		if err != nil {
-			return err
-		}
-		fnDesc.RemoveReference(op.BackReferencedTableID)
-	}
-	return nil
-}
-
 // Look through `seqID`'s dependedOnBy slice, find the back-reference to `tblID`,
 // and update it to either
 //   - upsert `colID` to ColumnIDs field of that back-reference, if `forwardRefs` contains `seqID`; or

--- a/pkg/sql/schemachanger/scexec/scmutationexec/references.go
+++ b/pkg/sql/schemachanger/scexec/scmutationexec/references.go
@@ -253,6 +253,47 @@ func (i *immediateVisitor) UpdateTableBackReferencesInSequences(
 	return nil
 }
 
+func (i *immediateVisitor) AddTableConstraintBackReferencesInFunctions(
+	ctx context.Context, op scop.AddTableConstraintBackReferencesInFunctions,
+) error {
+	for _, fnID := range op.FunctionIDs {
+		fnDesc, err := i.checkOutFunction(ctx, fnID)
+		if err != nil {
+			return err
+		}
+		if err := fnDesc.AddConstraintReference(op.BackReferencedTableID, op.BackReferencedConstraintID); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (i *immediateVisitor) RemoveTableConstraintBackReferencesFromFunctions(
+	ctx context.Context, op scop.RemoveTableConstraintBackReferencesFromFunctions,
+) error {
+	for _, fnID := range op.FunctionIDs {
+		fnDesc, err := i.checkOutFunction(ctx, fnID)
+		if err != nil {
+			return err
+		}
+		fnDesc.RemoveConstraintReference(op.BackReferencedTableID, op.BackReferencedConstraintID)
+	}
+	return nil
+}
+
+func (i *immediateVisitor) RemoveAllTableBackReferencesFromFunctions(
+	ctx context.Context, op scop.RemoveAllTableBackReferencesFromFunctions,
+) error {
+	for _, fnID := range op.FunctionIDs {
+		fnDesc, err := i.checkOutFunction(ctx, fnID)
+		if err != nil {
+			return err
+		}
+		fnDesc.RemoveReference(op.BackReferencedTableID)
+	}
+	return nil
+}
+
 // Look through `seqID`'s dependedOnBy slice, find the back-reference to `tblID`,
 // and update it to either
 //   - upsert `colID` to ColumnIDs field of that back-reference, if `forwardRefs` contains `seqID`; or

--- a/pkg/sql/schemachanger/scop/immediate_mutation.go
+++ b/pkg/sql/schemachanger/scop/immediate_mutation.go
@@ -516,14 +516,6 @@ type RemoveTableConstraintBackReferencesFromFunctions struct {
 	FunctionIDs                []descpb.ID
 }
 
-// RemoveAllTableBackReferencesFromFunctions removes all back references to a
-// table from referenced functions.
-type RemoveAllTableBackReferencesFromFunctions struct {
-	immediateMutationOp
-	BackReferencedTableID descpb.ID
-	FunctionIDs           []descpb.ID
-}
-
 // SetColumnName renames a column.
 type SetColumnName struct {
 	immediateMutationOp

--- a/pkg/sql/schemachanger/scop/immediate_mutation.go
+++ b/pkg/sql/schemachanger/scop/immediate_mutation.go
@@ -498,6 +498,32 @@ type RemoveBackReferencesInRelations struct {
 	RelationIDs      []descpb.ID
 }
 
+// AddTableConstraintBackReferencesInFunctions adds back references to CHECK
+// constraint to referenced functions.
+type AddTableConstraintBackReferencesInFunctions struct {
+	immediateMutationOp
+	BackReferencedTableID      descpb.ID
+	BackReferencedConstraintID descpb.ConstraintID
+	FunctionIDs                []descpb.ID
+}
+
+// RemoveTableConstraintBackReferencesFromFunctions removes back references to
+// CHECK constraint from referenced functions.
+type RemoveTableConstraintBackReferencesFromFunctions struct {
+	immediateMutationOp
+	BackReferencedTableID      descpb.ID
+	BackReferencedConstraintID descpb.ConstraintID
+	FunctionIDs                []descpb.ID
+}
+
+// RemoveAllTableBackReferencesFromFunctions removes all back references to a
+// table from referenced functions.
+type RemoveAllTableBackReferencesFromFunctions struct {
+	immediateMutationOp
+	BackReferencedTableID descpb.ID
+	FunctionIDs           []descpb.ID
+}
+
 // SetColumnName renames a column.
 type SetColumnName struct {
 	immediateMutationOp

--- a/pkg/sql/schemachanger/scop/immediate_mutation_visitor_generated.go
+++ b/pkg/sql/schemachanger/scop/immediate_mutation_visitor_generated.go
@@ -83,7 +83,6 @@ type ImmediateMutationVisitor interface {
 	RemoveBackReferencesInRelations(context.Context, RemoveBackReferencesInRelations) error
 	AddTableConstraintBackReferencesInFunctions(context.Context, AddTableConstraintBackReferencesInFunctions) error
 	RemoveTableConstraintBackReferencesFromFunctions(context.Context, RemoveTableConstraintBackReferencesFromFunctions) error
-	RemoveAllTableBackReferencesFromFunctions(context.Context, RemoveAllTableBackReferencesFromFunctions) error
 	SetColumnName(context.Context, SetColumnName) error
 	SetIndexName(context.Context, SetIndexName) error
 	SetConstraintName(context.Context, SetConstraintName) error
@@ -423,11 +422,6 @@ func (op AddTableConstraintBackReferencesInFunctions) Visit(ctx context.Context,
 // Visit is part of the ImmediateMutationOp interface.
 func (op RemoveTableConstraintBackReferencesFromFunctions) Visit(ctx context.Context, v ImmediateMutationVisitor) error {
 	return v.RemoveTableConstraintBackReferencesFromFunctions(ctx, op)
-}
-
-// Visit is part of the ImmediateMutationOp interface.
-func (op RemoveAllTableBackReferencesFromFunctions) Visit(ctx context.Context, v ImmediateMutationVisitor) error {
-	return v.RemoveAllTableBackReferencesFromFunctions(ctx, op)
 }
 
 // Visit is part of the ImmediateMutationOp interface.

--- a/pkg/sql/schemachanger/scop/immediate_mutation_visitor_generated.go
+++ b/pkg/sql/schemachanger/scop/immediate_mutation_visitor_generated.go
@@ -81,6 +81,9 @@ type ImmediateMutationVisitor interface {
 	RemoveBackReferenceInTypes(context.Context, RemoveBackReferenceInTypes) error
 	UpdateTableBackReferencesInSequences(context.Context, UpdateTableBackReferencesInSequences) error
 	RemoveBackReferencesInRelations(context.Context, RemoveBackReferencesInRelations) error
+	AddTableConstraintBackReferencesInFunctions(context.Context, AddTableConstraintBackReferencesInFunctions) error
+	RemoveTableConstraintBackReferencesFromFunctions(context.Context, RemoveTableConstraintBackReferencesFromFunctions) error
+	RemoveAllTableBackReferencesFromFunctions(context.Context, RemoveAllTableBackReferencesFromFunctions) error
 	SetColumnName(context.Context, SetColumnName) error
 	SetIndexName(context.Context, SetIndexName) error
 	SetConstraintName(context.Context, SetConstraintName) error
@@ -410,6 +413,21 @@ func (op UpdateTableBackReferencesInSequences) Visit(ctx context.Context, v Imme
 // Visit is part of the ImmediateMutationOp interface.
 func (op RemoveBackReferencesInRelations) Visit(ctx context.Context, v ImmediateMutationVisitor) error {
 	return v.RemoveBackReferencesInRelations(ctx, op)
+}
+
+// Visit is part of the ImmediateMutationOp interface.
+func (op AddTableConstraintBackReferencesInFunctions) Visit(ctx context.Context, v ImmediateMutationVisitor) error {
+	return v.AddTableConstraintBackReferencesInFunctions(ctx, op)
+}
+
+// Visit is part of the ImmediateMutationOp interface.
+func (op RemoveTableConstraintBackReferencesFromFunctions) Visit(ctx context.Context, v ImmediateMutationVisitor) error {
+	return v.RemoveTableConstraintBackReferencesFromFunctions(ctx, op)
+}
+
+// Visit is part of the ImmediateMutationOp interface.
+func (op RemoveAllTableBackReferencesFromFunctions) Visit(ctx context.Context, v ImmediateMutationVisitor) error {
+	return v.RemoveAllTableBackReferencesFromFunctions(ctx, op)
 }
 
 // Visit is part of the ImmediateMutationOp interface.

--- a/pkg/sql/schemachanger/scpb/elements.proto
+++ b/pkg/sql/schemachanger/scpb/elements.proto
@@ -166,6 +166,8 @@ message Expression {
 
   // ReferencedColumnIDs stores the IDs of the columns referenced by the expression.
   repeated uint32 referenced_column_ids = 4 [(gogoproto.customname) = "ReferencedColumnIDs", (gogoproto.casttype) = "github.com/cockroachdb/cockroach/pkg/sql/sem/catid.ColumnID"];
+
+  repeated uint32 uses_function_ids = 5 [(gogoproto.customname) = "UsesFunctionIDs", (gogoproto.casttype) = "github.com/cockroachdb/cockroach/pkg/sql/sem/catid.DescID"];
 }
 
 message Column {

--- a/pkg/sql/schemachanger/scplan/internal/opgen/opgen_check_constraint.go
+++ b/pkg/sql/schemachanger/scplan/internal/opgen/opgen_check_constraint.go
@@ -49,6 +49,16 @@ func init() {
 						BackReferencedTableID: this.TableID,
 					}
 				}),
+				emit(func(this *scpb.CheckConstraint) *scop.AddTableConstraintBackReferencesInFunctions {
+					if len(this.UsesFunctionIDs) == 0 {
+						return nil
+					}
+					return &scop.AddTableConstraintBackReferencesInFunctions{
+						FunctionIDs:                this.UsesFunctionIDs,
+						BackReferencedTableID:      this.TableID,
+						BackReferencedConstraintID: this.ConstraintID,
+					}
+				}),
 			),
 			to(scpb.Status_VALIDATED,
 				emit(func(this *scpb.CheckConstraint) *scop.ValidateConstraint {
@@ -103,6 +113,16 @@ func init() {
 					return &scop.UpdateTableBackReferencesInSequences{
 						SequenceIDs:           this.UsesSequenceIDs,
 						BackReferencedTableID: this.TableID,
+					}
+				}),
+				emit(func(this *scpb.CheckConstraint) *scop.RemoveTableConstraintBackReferencesFromFunctions {
+					if len(this.UsesFunctionIDs) == 0 {
+						return nil
+					}
+					return &scop.RemoveTableConstraintBackReferencesFromFunctions{
+						FunctionIDs:                this.UsesFunctionIDs,
+						BackReferencedTableID:      this.TableID,
+						BackReferencedConstraintID: this.ConstraintID,
 					}
 				}),
 			),

--- a/pkg/sql/schemachanger/scplan/testdata/alter_table_add_check_udf
+++ b/pkg/sql/schemachanger/scplan/testdata/alter_table_add_check_udf
@@ -1,0 +1,116 @@
+setup
+CREATE TABLE t (i INT PRIMARY KEY, b INT);
+CREATE FUNCTION f(b INT) RETURNS INT LANGUAGE SQL AS $$ SELECT b + 1 $$;
+----
+
+ops
+ALTER TABLE t ADD CONSTRAINT check_b CHECK (f(b) > 1);
+----
+StatementPhase stage 1 of 1 with 2 MutationType ops
+  transitions:
+    [[CheckConstraint:{DescID: 104, IndexID: 0, ConstraintID: 2}, PUBLIC], ABSENT] -> WRITE_ONLY
+  ops:
+    *scop.AddCheckConstraint
+      CheckExpr: '[FUNCTION 100105](b) > 1:::INT8'
+      ColumnIDs:
+      - 2
+      ConstraintID: 2
+      TableID: 104
+      Validity: 2
+    *scop.AddTableConstraintBackReferencesInFunctions
+      BackReferencedConstraintID: 2
+      BackReferencedTableID: 104
+      FunctionIDs:
+      - 105
+PreCommitPhase stage 1 of 2 with 1 MutationType op
+  transitions:
+    [[CheckConstraint:{DescID: 104, IndexID: 0, ConstraintID: 2}, PUBLIC], WRITE_ONLY] -> ABSENT
+  ops:
+    *scop.UndoAllInTxnImmediateMutationOpSideEffects
+      {}
+PreCommitPhase stage 2 of 2 with 5 MutationType ops
+  transitions:
+    [[CheckConstraint:{DescID: 104, IndexID: 0, ConstraintID: 2}, PUBLIC], ABSENT] -> WRITE_ONLY
+  ops:
+    *scop.AddCheckConstraint
+      CheckExpr: '[FUNCTION 100105](b) > 1:::INT8'
+      ColumnIDs:
+      - 2
+      ConstraintID: 2
+      TableID: 104
+      Validity: 2
+    *scop.AddTableConstraintBackReferencesInFunctions
+      BackReferencedConstraintID: 2
+      BackReferencedTableID: 104
+      FunctionIDs:
+      - 105
+    *scop.SetJobStateOnDescriptor
+      DescriptorID: 104
+      Initialize: true
+    *scop.SetJobStateOnDescriptor
+      DescriptorID: 105
+      Initialize: true
+    *scop.CreateSchemaChangerJob
+      Authorization:
+        UserName: root
+      DescriptorIDs:
+      - 104
+      - 105
+      JobID: 1
+      RunningStatus: PostCommitPhase stage 1 of 2 with 1 ValidationType op pending
+      Statements:
+      - statement: ALTER TABLE t ADD CONSTRAINT check_b CHECK (f(b) > 1)
+        redactedstatement: ALTER TABLE ‹defaultdb›.public.‹t› ADD CONSTRAINT ‹check_b› CHECK
+          (f(‹b›) > ‹1›)
+        statementtag: ALTER TABLE
+PostCommitPhase stage 1 of 2 with 1 ValidationType op
+  transitions:
+    [[CheckConstraint:{DescID: 104, IndexID: 0, ConstraintID: 2}, PUBLIC], WRITE_ONLY] -> VALIDATED
+  ops:
+    *scop.ValidateConstraint
+      ConstraintID: 2
+      TableID: 104
+PostCommitPhase stage 2 of 2 with 5 MutationType ops
+  transitions:
+    [[CheckConstraint:{DescID: 104, IndexID: 0, ConstraintID: 2}, PUBLIC], VALIDATED] -> PUBLIC
+    [[ConstraintWithoutIndexName:{DescID: 104, Name: check_b, ConstraintID: 2}, PUBLIC], ABSENT] -> PUBLIC
+  ops:
+    *scop.SetConstraintName
+      ConstraintID: 2
+      Name: check_b
+      TableID: 104
+    *scop.MakeValidatedCheckConstraintPublic
+      ConstraintID: 2
+      TableID: 104
+    *scop.RemoveJobStateFromDescriptor
+      DescriptorID: 104
+      JobID: 1
+    *scop.RemoveJobStateFromDescriptor
+      DescriptorID: 105
+      JobID: 1
+    *scop.UpdateSchemaChangerJob
+      DescriptorIDsToRemove:
+      - 104
+      - 105
+      IsNonCancelable: true
+      JobID: 1
+
+deps
+ALTER TABLE t ADD CONSTRAINT check_b CHECK (f(b) > 1);
+----
+- from: [CheckConstraint:{DescID: 104, IndexID: 0, ConstraintID: 2}, ABSENT]
+  to:   [CheckConstraint:{DescID: 104, IndexID: 0, ConstraintID: 2}, WRITE_ONLY]
+  kind: PreviousStagePrecedence
+  rule: CheckConstraint transitions to PUBLIC uphold 2-version invariant: ABSENT->WRITE_ONLY
+- from: [CheckConstraint:{DescID: 104, IndexID: 0, ConstraintID: 2}, VALIDATED]
+  to:   [CheckConstraint:{DescID: 104, IndexID: 0, ConstraintID: 2}, PUBLIC]
+  kind: PreviousStagePrecedence
+  rule: CheckConstraint transitions to PUBLIC uphold 2-version invariant: VALIDATED->PUBLIC
+- from: [CheckConstraint:{DescID: 104, IndexID: 0, ConstraintID: 2}, WRITE_ONLY]
+  to:   [CheckConstraint:{DescID: 104, IndexID: 0, ConstraintID: 2}, VALIDATED]
+  kind: PreviousStagePrecedence
+  rule: CheckConstraint transitions to PUBLIC uphold 2-version invariant: WRITE_ONLY->VALIDATED
+- from: [ConstraintWithoutIndexName:{DescID: 104, Name: check_b, ConstraintID: 2}, PUBLIC]
+  to:   [CheckConstraint:{DescID: 104, IndexID: 0, ConstraintID: 2}, PUBLIC]
+  kind: SameStagePrecedence
+  rule: constraint dependent public right before complex constraint

--- a/pkg/sql/schemachanger/scplan/testdata/create_function
+++ b/pkg/sql/schemachanger/scplan/testdata/create_function
@@ -281,3 +281,73 @@ PreCommitPhase stage 2 of 2 with 11 MutationType ops
         ParentSchemaID: 101
     *scop.MarkDescriptorAsPublic
       DescriptorID: 109
+
+deps
+CREATE FUNCTION f(a notmyworkday) RETURNS INT VOLATILE LANGUAGE SQL AS $$
+  SELECT a FROM t;
+  SELECT b FROM t@t_idx_b;
+  SELECT c FROM t@t_idx_c;
+  SELECT a FROM v;
+  SELECT nextval('sq1');
+$$;
+----
+- from: [Function:{DescID: 110}, DESCRIPTOR_ADDED]
+  to:   [FunctionBody:{DescID: 110}, PUBLIC]
+  kind: Precedence
+  rule: descriptor existence precedes dependents
+- from: [Function:{DescID: 110}, DESCRIPTOR_ADDED]
+  to:   [FunctionName:{DescID: 110}, PUBLIC]
+  kind: Precedence
+  rule: descriptor existence precedes dependents
+- from: [Function:{DescID: 110}, DESCRIPTOR_ADDED]
+  to:   [FunctionVolatility:{DescID: 110}, PUBLIC]
+  kind: Precedence
+  rule: descriptor existence precedes dependents
+- from: [Function:{DescID: 110}, DESCRIPTOR_ADDED]
+  to:   [ObjectParent:{DescID: 110, ReferencedDescID: 101}, PUBLIC]
+  kind: Precedence
+  rule: descriptor existence precedes dependents
+- from: [Function:{DescID: 110}, DESCRIPTOR_ADDED]
+  to:   [Owner:{DescID: 110}, PUBLIC]
+  kind: Precedence
+  rule: descriptor existence precedes dependents
+- from: [Function:{DescID: 110}, DESCRIPTOR_ADDED]
+  to:   [UserPrivileges:{DescID: 110, Name: admin}, PUBLIC]
+  kind: Precedence
+  rule: descriptor existence precedes dependents
+- from: [Function:{DescID: 110}, DESCRIPTOR_ADDED]
+  to:   [UserPrivileges:{DescID: 110, Name: root}, PUBLIC]
+  kind: Precedence
+  rule: descriptor existence precedes dependents
+- from: [FunctionBody:{DescID: 110}, PUBLIC]
+  to:   [Function:{DescID: 110}, PUBLIC]
+  kind: Precedence
+  rule: dependents exist before descriptor becomes public
+- from: [FunctionName:{DescID: 110}, PUBLIC]
+  to:   [Function:{DescID: 110}, PUBLIC]
+  kind: Precedence
+  rule: dependents exist before descriptor becomes public
+- from: [FunctionName:{DescID: 110}, PUBLIC]
+  to:   [ObjectParent:{DescID: 110, ReferencedDescID: 101}, PUBLIC]
+  kind: Precedence
+  rule: function name should be set before parent ids
+- from: [FunctionVolatility:{DescID: 110}, PUBLIC]
+  to:   [Function:{DescID: 110}, PUBLIC]
+  kind: Precedence
+  rule: dependents exist before descriptor becomes public
+- from: [ObjectParent:{DescID: 110, ReferencedDescID: 101}, PUBLIC]
+  to:   [Function:{DescID: 110}, PUBLIC]
+  kind: Precedence
+  rule: dependents exist before descriptor becomes public
+- from: [Owner:{DescID: 110}, PUBLIC]
+  to:   [Function:{DescID: 110}, PUBLIC]
+  kind: Precedence
+  rule: dependents exist before descriptor becomes public
+- from: [UserPrivileges:{DescID: 110, Name: admin}, PUBLIC]
+  to:   [Function:{DescID: 110}, PUBLIC]
+  kind: Precedence
+  rule: dependents exist before descriptor becomes public
+- from: [UserPrivileges:{DescID: 110, Name: root}, PUBLIC]
+  to:   [Function:{DescID: 110}, PUBLIC]
+  kind: Precedence
+  rule: dependents exist before descriptor becomes public

--- a/pkg/sql/schemachanger/screl/walk.go
+++ b/pkg/sql/schemachanger/screl/walk.go
@@ -49,6 +49,12 @@ func WalkColumnIDs(e scpb.Element, f func(id *catid.ColumnID) error) error {
 	})
 }
 
+func WalkConstraintIDs(e scpb.Element, f func(id *catid.ConstraintID) error) error {
+	return walk(reflect.TypeOf((*catid.ConstraintID)(nil)), e, func(i interface{}) error {
+		return f(i.(*catid.ConstraintID))
+	})
+}
+
 // walk will use reflection to find all values which are either scalars
 // types or pointers types and pass them to f as pointers. The
 // expectation is that the input is a pointer to some structure so that

--- a/pkg/sql/schemachanger/sctest/BUILD.bazel
+++ b/pkg/sql/schemachanger/sctest/BUILD.bazel
@@ -35,6 +35,7 @@ go_library(
         "//pkg/sql/schemachanger/scplan/scviz",
         "//pkg/sql/schemachanger/screl",
         "//pkg/sql/schemachanger/scrun",
+        "//pkg/sql/sem/tree",
         "//pkg/sql/sessiondata",
         "//pkg/sql/sessiondatapb",
         "//pkg/testutils",

--- a/pkg/sql/schemachanger/sctest_generated_test.go
+++ b/pkg/sql/schemachanger/sctest_generated_test.go
@@ -120,6 +120,31 @@ func TestRollback_add_column_no_default(t *testing.T) {
 	defer log.Scope(t).Close(t)
 	sctest.Rollback(t, "pkg/sql/schemachanger/testdata/end_to_end/add_column_no_default", sctest.SingleNodeCluster)
 }
+func TestEndToEndSideEffects_alter_table_add_check_udf(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	sctest.EndToEndSideEffects(t, "pkg/sql/schemachanger/testdata/end_to_end/alter_table_add_check_udf", sctest.SingleNodeCluster)
+}
+func TestExecuteWithDMLInjection_alter_table_add_check_udf(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	sctest.ExecuteWithDMLInjection(t, "pkg/sql/schemachanger/testdata/end_to_end/alter_table_add_check_udf", sctest.SingleNodeCluster)
+}
+func TestGenerateSchemaChangeCorpus_alter_table_add_check_udf(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	sctest.GenerateSchemaChangeCorpus(t, "pkg/sql/schemachanger/testdata/end_to_end/alter_table_add_check_udf", sctest.SingleNodeCluster)
+}
+func TestPause_alter_table_add_check_udf(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	sctest.Pause(t, "pkg/sql/schemachanger/testdata/end_to_end/alter_table_add_check_udf", sctest.SingleNodeCluster)
+}
+func TestRollback_alter_table_add_check_udf(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	sctest.Rollback(t, "pkg/sql/schemachanger/testdata/end_to_end/alter_table_add_check_udf", sctest.SingleNodeCluster)
+}
 func TestEndToEndSideEffects_alter_table_add_check_unvalidated(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)

--- a/pkg/sql/schemachanger/sctest_mixed_generated_test.go
+++ b/pkg/sql/schemachanger/sctest_mixed_generated_test.go
@@ -40,6 +40,11 @@ func TestValidateMixedVersionElements_add_column_no_default(t *testing.T) {
 	defer log.Scope(t).Close(t)
 	sctest.ValidateMixedVersionElements(t, "pkg/sql/schemachanger/testdata/end_to_end/add_column_no_default", sctest.SingleNodeMixedCluster)
 }
+func TestValidateMixedVersionElements_alter_table_add_check_udf(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	sctest.ValidateMixedVersionElements(t, "pkg/sql/schemachanger/testdata/end_to_end/alter_table_add_check_udf", sctest.SingleNodeMixedCluster)
+}
 func TestValidateMixedVersionElements_alter_table_add_check_unvalidated(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_add_check_udf
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_add_check_udf
@@ -1,0 +1,255 @@
+setup
+CREATE TABLE t (i INT PRIMARY KEY, b INT);
+CREATE FUNCTION f(b INT) RETURNS INT LANGUAGE SQL AS $$ SELECT b + 1 $$;
+----
+...
++object {100 101 t} -> 104
+
+test
+ALTER TABLE t ADD CONSTRAINT check_b CHECK (f(b) > 1);
+----
+begin transaction #1
+# begin StatementPhase
+checking for feature: ALTER TABLE
+increment telemetry for sql.schema.alter_table
+increment telemetry for sql.schema.alter_table.add_constraint
+write *eventpb.AlterTable to event log:
+  mutationId: 1
+  sql:
+    descriptorId: 104
+    statement: ALTER TABLE ‹defaultdb›.‹public›.‹t› ADD CONSTRAINT ‹check_b› CHECK (f(‹b›)
+      > ‹1›)
+    tag: ALTER TABLE
+    user: root
+  tableName: defaultdb.public.t
+## StatementPhase stage 1 of 1 with 2 MutationType ops
+upsert descriptor #104
+   table:
+  +  checks:
+  +  - columnIds:
+  +    - 2
+  +    constraintId: 2
+  +    expr: '[FUNCTION 100105](b) > 1:::INT8'
+  +    name: crdb_internal_constraint_2_name_placeholder
+  +    validity: Validating
+     columns:
+     - id: 1
+  ...
+     id: 104
+     modificationTime: {}
+  +  mutations:
+  +  - constraint:
+  +      check:
+  +        columnIds:
+  +        - 2
+  +        constraintId: 2
+  +        expr: '[FUNCTION 100105](b) > 1:::INT8'
+  +        name: crdb_internal_constraint_2_name_placeholder
+  +        validity: Validating
+  +      foreignKey: {}
+  +      name: crdb_internal_constraint_2_name_placeholder
+  +      uniqueWithoutIndexConstraint: {}
+  +    direction: ADD
+  +    mutationId: 1
+  +    state: WRITE_ONLY
+     name: t
+     nextColumnId: 3
+  -  nextConstraintId: 2
+  +  nextConstraintId: 3
+     nextFamilyId: 1
+     nextIndexId: 2
+  ...
+       time: {}
+     unexposedParentSchemaId: 101
+  -  version: "1"
+  +  version: "2"
+upsert descriptor #105
+   function:
+  +  dependedOnBy:
+  +  - constraintIds:
+  +    - 2
+  +    id: 104
+     functionBody: SELECT b + 1;
+     id: 105
+  ...
+         oid: 20
+         width: 64
+  -  version: "1"
+  +  version: "2"
+     volatility: VOLATILE
+# end StatementPhase
+# begin PreCommitPhase
+## PreCommitPhase stage 1 of 2 with 1 MutationType op
+undo all catalog changes within txn #1
+persist all catalog changes to storage
+## PreCommitPhase stage 2 of 2 with 5 MutationType ops
+upsert descriptor #104
+   table:
+  +  checks:
+  +  - columnIds:
+  +    - 2
+  +    constraintId: 2
+  +    expr: '[FUNCTION 100105](b) > 1:::INT8'
+  +    name: crdb_internal_constraint_2_name_placeholder
+  +    validity: Validating
+     columns:
+     - id: 1
+  ...
+     createAsOfTime:
+       wallTime: "1640995200000000000"
+  +  declarativeSchemaChangerState:
+  +    authorization:
+  +      userName: root
+  +    currentStatuses: <redacted>
+  +    jobId: "1"
+  +    relevantStatements:
+  +    - statement:
+  +        redactedStatement: ALTER TABLE ‹defaultdb›.‹public›.‹t› ADD CONSTRAINT ‹check_b›
+  +          CHECK (f(‹b›) > ‹1›)
+  +        statement: ALTER TABLE t ADD CONSTRAINT check_b CHECK (f(b) > 1)
+  +        statementTag: ALTER TABLE
+  +    revertible: true
+  +    targetRanks: <redacted>
+  +    targets: <redacted>
+     families:
+     - columnIds:
+  ...
+     id: 104
+     modificationTime: {}
+  +  mutations:
+  +  - constraint:
+  +      check:
+  +        columnIds:
+  +        - 2
+  +        constraintId: 2
+  +        expr: '[FUNCTION 100105](b) > 1:::INT8'
+  +        name: crdb_internal_constraint_2_name_placeholder
+  +        validity: Validating
+  +      foreignKey: {}
+  +      name: crdb_internal_constraint_2_name_placeholder
+  +      uniqueWithoutIndexConstraint: {}
+  +    direction: ADD
+  +    mutationId: 1
+  +    state: WRITE_ONLY
+     name: t
+     nextColumnId: 3
+  -  nextConstraintId: 2
+  +  nextConstraintId: 3
+     nextFamilyId: 1
+     nextIndexId: 2
+  ...
+       time: {}
+     unexposedParentSchemaId: 101
+  -  version: "1"
+  +  version: "2"
+upsert descriptor #105
+   function:
+  +  declarativeSchemaChangerState:
+  +    authorization:
+  +      userName: root
+  +    jobId: "1"
+  +    revertible: true
+  +  dependedOnBy:
+  +  - constraintIds:
+  +    - 2
+  +    id: 104
+     functionBody: SELECT b + 1;
+     id: 105
+  ...
+         oid: 20
+         width: 64
+  -  version: "1"
+  +  version: "2"
+     volatility: VOLATILE
+persist all catalog changes to storage
+create job #1 (non-cancelable: false): "ALTER TABLE defaultdb.public.t ADD CONSTRAINT check_b CHECK (f(b) > 1)"
+  descriptor IDs: [104 105]
+# end PreCommitPhase
+commit transaction #1
+notified job registry to adopt jobs: [1]
+# begin PostCommitPhase
+begin transaction #2
+commit transaction #2
+begin transaction #3
+## PostCommitPhase stage 1 of 2 with 1 ValidationType op
+validate CHECK constraint crdb_internal_constraint_2_name_placeholder in table #104
+commit transaction #3
+begin transaction #4
+## PostCommitPhase stage 2 of 2 with 5 MutationType ops
+upsert descriptor #104
+  ...
+       constraintId: 2
+       expr: '[FUNCTION 100105](b) > 1:::INT8'
+  -    name: crdb_internal_constraint_2_name_placeholder
+  -    validity: Validating
+  +    name: check_b
+     columns:
+     - id: 1
+  ...
+     createAsOfTime:
+       wallTime: "1640995200000000000"
+  -  declarativeSchemaChangerState:
+  -    authorization:
+  -      userName: root
+  -    currentStatuses: <redacted>
+  -    jobId: "1"
+  -    relevantStatements:
+  -    - statement:
+  -        redactedStatement: ALTER TABLE ‹defaultdb›.‹public›.‹t› ADD CONSTRAINT ‹check_b›
+  -          CHECK (f(‹b›) > ‹1›)
+  -        statement: ALTER TABLE t ADD CONSTRAINT check_b CHECK (f(b) > 1)
+  -        statementTag: ALTER TABLE
+  -    revertible: true
+  -    targetRanks: <redacted>
+  -    targets: <redacted>
+     families:
+     - columnIds:
+  ...
+     id: 104
+     modificationTime: {}
+  -  mutations:
+  -  - constraint:
+  -      check:
+  -        columnIds:
+  -        - 2
+  -        constraintId: 2
+  -        expr: '[FUNCTION 100105](b) > 1:::INT8'
+  -        name: crdb_internal_constraint_2_name_placeholder
+  -        validity: Validating
+  -      foreignKey: {}
+  -      name: crdb_internal_constraint_2_name_placeholder
+  -      uniqueWithoutIndexConstraint: {}
+  -    direction: ADD
+  -    mutationId: 1
+  -    state: WRITE_ONLY
+     name: t
+     nextColumnId: 3
+  ...
+       time: {}
+     unexposedParentSchemaId: 101
+  -  version: "2"
+  +  version: "3"
+upsert descriptor #105
+   function:
+  -  declarativeSchemaChangerState:
+  -    authorization:
+  -      userName: root
+  -    jobId: "1"
+  -    revertible: true
+     dependedOnBy:
+     - constraintIds:
+  ...
+         oid: 20
+         width: 64
+  -  version: "2"
+  +  version: "3"
+     volatility: VOLATILE
+persist all catalog changes to storage
+update progress of schema change job #1: "all stages completed"
+set schema change job #1 to non-cancellable
+updated schema change job #1 descriptor IDs to []
+write *eventpb.FinishSchemaChange to event log:
+  sc:
+    descriptorId: 104
+commit transaction #4
+# end PostCommitPhase

--- a/pkg/sql/schemachanger/testdata/explain/alter_table_add_check_udf
+++ b/pkg/sql/schemachanger/testdata/explain/alter_table_add_check_udf
@@ -1,0 +1,46 @@
+/* setup */
+CREATE TABLE t (i INT PRIMARY KEY, b INT);
+CREATE FUNCTION f(b INT) RETURNS INT LANGUAGE SQL AS $$ SELECT b + 1 $$;
+
+/* test */
+EXPLAIN (ddl) ALTER TABLE t ADD CONSTRAINT check_b CHECK (f(b) > 1);
+----
+Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› ADD CONSTRAINT ‹check_b› CHECK (f(‹b›) > ‹1›);
+ ├── StatementPhase
+ │    └── Stage 1 of 1 in StatementPhase
+ │         ├── 1 element transitioning toward PUBLIC
+ │         │    └── ABSENT → WRITE_ONLY CheckConstraint:{DescID: 104, IndexID: 0, ConstraintID: 2}
+ │         └── 2 Mutation operations
+ │              ├── AddCheckConstraint {"CheckExpr":"[FUNCTION 100105...","ConstraintID":2,"TableID":104,"Validity":2}
+ │              └── AddTableConstraintBackReferencesInFunctions {"BackReferencedConstraintID":2,"BackReferencedTableID":104}
+ ├── PreCommitPhase
+ │    ├── Stage 1 of 2 in PreCommitPhase
+ │    │    ├── 1 element transitioning toward PUBLIC
+ │    │    │    └── WRITE_ONLY → ABSENT CheckConstraint:{DescID: 104, IndexID: 0, ConstraintID: 2}
+ │    │    └── 1 Mutation operation
+ │    │         └── UndoAllInTxnImmediateMutationOpSideEffects
+ │    └── Stage 2 of 2 in PreCommitPhase
+ │         ├── 1 element transitioning toward PUBLIC
+ │         │    └── ABSENT → WRITE_ONLY CheckConstraint:{DescID: 104, IndexID: 0, ConstraintID: 2}
+ │         └── 5 Mutation operations
+ │              ├── AddCheckConstraint {"CheckExpr":"[FUNCTION 100105...","ConstraintID":2,"TableID":104,"Validity":2}
+ │              ├── AddTableConstraintBackReferencesInFunctions {"BackReferencedConstraintID":2,"BackReferencedTableID":104}
+ │              ├── SetJobStateOnDescriptor {"DescriptorID":104,"Initialize":true}
+ │              ├── SetJobStateOnDescriptor {"DescriptorID":105,"Initialize":true}
+ │              └── CreateSchemaChangerJob {"RunningStatus":"PostCommitPhase ..."}
+ └── PostCommitPhase
+      ├── Stage 1 of 2 in PostCommitPhase
+      │    ├── 1 element transitioning toward PUBLIC
+      │    │    └── WRITE_ONLY → VALIDATED CheckConstraint:{DescID: 104, IndexID: 0, ConstraintID: 2}
+      │    └── 1 Validation operation
+      │         └── ValidateConstraint {"ConstraintID":2,"TableID":104}
+      └── Stage 2 of 2 in PostCommitPhase
+           ├── 2 elements transitioning toward PUBLIC
+           │    ├── VALIDATED → PUBLIC CheckConstraint:{DescID: 104, IndexID: 0, ConstraintID: 2}
+           │    └── ABSENT    → PUBLIC ConstraintWithoutIndexName:{DescID: 104, Name: check_b, ConstraintID: 2}
+           └── 5 Mutation operations
+                ├── SetConstraintName {"ConstraintID":2,"Name":"check_b","TableID":104}
+                ├── MakeValidatedCheckConstraintPublic {"ConstraintID":2,"TableID":104}
+                ├── RemoveJobStateFromDescriptor {"DescriptorID":104}
+                ├── RemoveJobStateFromDescriptor {"DescriptorID":105}
+                └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"all stages compl..."}

--- a/pkg/sql/schemachanger/testdata/explain/alter_table_add_check_udf.rollback_1_of_2
+++ b/pkg/sql/schemachanger/testdata/explain/alter_table_add_check_udf.rollback_1_of_2
@@ -1,0 +1,19 @@
+/* setup */
+CREATE TABLE t (i INT PRIMARY KEY, b INT);
+CREATE FUNCTION f(b INT) RETURNS INT LANGUAGE SQL AS $$ SELECT b + 1 $$;
+
+/* test */
+ALTER TABLE t ADD CONSTRAINT check_b CHECK (f(b) > 1);
+EXPLAIN (ddl) rollback at post-commit stage 1 of 2;
+----
+Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› ADD CONSTRAINT ‹check_b› CHECK (f(‹b›) > ‹1›);
+ └── PostCommitNonRevertiblePhase
+      └── Stage 1 of 1 in PostCommitNonRevertiblePhase
+           ├── 1 element transitioning toward ABSENT
+           │    └── WRITE_ONLY → ABSENT CheckConstraint:{DescID: 104, IndexID: 0, ConstraintID: 2}
+           └── 5 Mutation operations
+                ├── RemoveCheckConstraint {"ConstraintID":2,"TableID":104}
+                ├── RemoveTableConstraintBackReferencesFromFunctions {"BackReferencedConstraintID":2,"BackReferencedTableID":104}
+                ├── RemoveJobStateFromDescriptor {"DescriptorID":104}
+                ├── RemoveJobStateFromDescriptor {"DescriptorID":105}
+                └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"all stages compl..."}

--- a/pkg/sql/schemachanger/testdata/explain/alter_table_add_check_udf.rollback_2_of_2
+++ b/pkg/sql/schemachanger/testdata/explain/alter_table_add_check_udf.rollback_2_of_2
@@ -1,0 +1,19 @@
+/* setup */
+CREATE TABLE t (i INT PRIMARY KEY, b INT);
+CREATE FUNCTION f(b INT) RETURNS INT LANGUAGE SQL AS $$ SELECT b + 1 $$;
+
+/* test */
+ALTER TABLE t ADD CONSTRAINT check_b CHECK (f(b) > 1);
+EXPLAIN (ddl) rollback at post-commit stage 2 of 2;
+----
+Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› ADD CONSTRAINT ‹check_b› CHECK (f(‹b›) > ‹1›);
+ └── PostCommitNonRevertiblePhase
+      └── Stage 1 of 1 in PostCommitNonRevertiblePhase
+           ├── 1 element transitioning toward ABSENT
+           │    └── WRITE_ONLY → ABSENT CheckConstraint:{DescID: 104, IndexID: 0, ConstraintID: 2}
+           └── 5 Mutation operations
+                ├── RemoveCheckConstraint {"ConstraintID":2,"TableID":104}
+                ├── RemoveTableConstraintBackReferencesFromFunctions {"BackReferencedConstraintID":2,"BackReferencedTableID":104}
+                ├── RemoveJobStateFromDescriptor {"DescriptorID":104}
+                ├── RemoveJobStateFromDescriptor {"DescriptorID":105}
+                └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"all stages compl..."}

--- a/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_add_check_udf
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_add_check_udf
@@ -1,0 +1,159 @@
+/* setup */
+CREATE TABLE t (i INT PRIMARY KEY, b INT);
+CREATE FUNCTION f(b INT) RETURNS INT LANGUAGE SQL AS $$ SELECT b + 1 $$;
+
+/* test */
+EXPLAIN (ddl, verbose) ALTER TABLE t ADD CONSTRAINT check_b CHECK (f(b) > 1);
+----
+• Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› ADD CONSTRAINT ‹check_b› CHECK (f(‹b›) > ‹1›);
+│
+├── • StatementPhase
+│   │
+│   └── • Stage 1 of 1 in StatementPhase
+│       │
+│       ├── • 1 element transitioning toward PUBLIC
+│       │   │
+│       │   └── • CheckConstraint:{DescID: 104, IndexID: 0, ConstraintID: 2}
+│       │       │ ABSENT → WRITE_ONLY
+│       │       │
+│       │       └── • PreviousStagePrecedence dependency from ABSENT CheckConstraint:{DescID: 104, IndexID: 0, ConstraintID: 2}
+│       │             rule: "CheckConstraint transitions to PUBLIC uphold 2-version invariant: ABSENT->WRITE_ONLY"
+│       │
+│       └── • 2 Mutation operations
+│           │
+│           ├── • AddCheckConstraint
+│           │     CheckExpr: '[FUNCTION 100105](b) > 1:::INT8'
+│           │     ColumnIDs:
+│           │     - 2
+│           │     ConstraintID: 2
+│           │     TableID: 104
+│           │     Validity: 2
+│           │
+│           └── • AddTableConstraintBackReferencesInFunctions
+│                 BackReferencedConstraintID: 2
+│                 BackReferencedTableID: 104
+│                 FunctionIDs:
+│                 - 105
+│
+├── • PreCommitPhase
+│   │
+│   ├── • Stage 1 of 2 in PreCommitPhase
+│   │   │
+│   │   ├── • 1 element transitioning toward PUBLIC
+│   │   │   │
+│   │   │   └── • CheckConstraint:{DescID: 104, IndexID: 0, ConstraintID: 2}
+│   │   │         WRITE_ONLY → ABSENT
+│   │   │
+│   │   └── • 1 Mutation operation
+│   │       │
+│   │       └── • UndoAllInTxnImmediateMutationOpSideEffects
+│   │             {}
+│   │
+│   └── • Stage 2 of 2 in PreCommitPhase
+│       │
+│       ├── • 1 element transitioning toward PUBLIC
+│       │   │
+│       │   └── • CheckConstraint:{DescID: 104, IndexID: 0, ConstraintID: 2}
+│       │       │ ABSENT → WRITE_ONLY
+│       │       │
+│       │       └── • PreviousStagePrecedence dependency from ABSENT CheckConstraint:{DescID: 104, IndexID: 0, ConstraintID: 2}
+│       │             rule: "CheckConstraint transitions to PUBLIC uphold 2-version invariant: ABSENT->WRITE_ONLY"
+│       │
+│       └── • 5 Mutation operations
+│           │
+│           ├── • AddCheckConstraint
+│           │     CheckExpr: '[FUNCTION 100105](b) > 1:::INT8'
+│           │     ColumnIDs:
+│           │     - 2
+│           │     ConstraintID: 2
+│           │     TableID: 104
+│           │     Validity: 2
+│           │
+│           ├── • AddTableConstraintBackReferencesInFunctions
+│           │     BackReferencedConstraintID: 2
+│           │     BackReferencedTableID: 104
+│           │     FunctionIDs:
+│           │     - 105
+│           │
+│           ├── • SetJobStateOnDescriptor
+│           │     DescriptorID: 104
+│           │     Initialize: true
+│           │
+│           ├── • SetJobStateOnDescriptor
+│           │     DescriptorID: 105
+│           │     Initialize: true
+│           │
+│           └── • CreateSchemaChangerJob
+│                 Authorization:
+│                   UserName: root
+│                 DescriptorIDs:
+│                 - 104
+│                 - 105
+│                 JobID: 1
+│                 RunningStatus: PostCommitPhase stage 1 of 2 with 1 ValidationType op pending
+│                 Statements:
+│                 - statement: ALTER TABLE t ADD CONSTRAINT check_b CHECK (f(b) > 1)
+│                   redactedstatement: ALTER TABLE ‹defaultdb›.‹public›.‹t› ADD CONSTRAINT ‹check_b›
+│                     CHECK (f(‹b›) > ‹1›)
+│                   statementtag: ALTER TABLE
+│
+└── • PostCommitPhase
+    │
+    ├── • Stage 1 of 2 in PostCommitPhase
+    │   │
+    │   ├── • 1 element transitioning toward PUBLIC
+    │   │   │
+    │   │   └── • CheckConstraint:{DescID: 104, IndexID: 0, ConstraintID: 2}
+    │   │       │ WRITE_ONLY → VALIDATED
+    │   │       │
+    │   │       └── • PreviousStagePrecedence dependency from WRITE_ONLY CheckConstraint:{DescID: 104, IndexID: 0, ConstraintID: 2}
+    │   │             rule: "CheckConstraint transitions to PUBLIC uphold 2-version invariant: WRITE_ONLY->VALIDATED"
+    │   │
+    │   └── • 1 Validation operation
+    │       │
+    │       └── • ValidateConstraint
+    │             ConstraintID: 2
+    │             TableID: 104
+    │
+    └── • Stage 2 of 2 in PostCommitPhase
+        │
+        ├── • 2 elements transitioning toward PUBLIC
+        │   │
+        │   ├── • CheckConstraint:{DescID: 104, IndexID: 0, ConstraintID: 2}
+        │   │   │ VALIDATED → PUBLIC
+        │   │   │
+        │   │   ├── • PreviousStagePrecedence dependency from VALIDATED CheckConstraint:{DescID: 104, IndexID: 0, ConstraintID: 2}
+        │   │   │     rule: "CheckConstraint transitions to PUBLIC uphold 2-version invariant: VALIDATED->PUBLIC"
+        │   │   │
+        │   │   └── • SameStagePrecedence dependency from PUBLIC ConstraintWithoutIndexName:{DescID: 104, Name: check_b, ConstraintID: 2}
+        │   │         rule: "constraint dependent public right before complex constraint"
+        │   │
+        │   └── • ConstraintWithoutIndexName:{DescID: 104, Name: check_b, ConstraintID: 2}
+        │         ABSENT → PUBLIC
+        │
+        └── • 5 Mutation operations
+            │
+            ├── • SetConstraintName
+            │     ConstraintID: 2
+            │     Name: check_b
+            │     TableID: 104
+            │
+            ├── • MakeValidatedCheckConstraintPublic
+            │     ConstraintID: 2
+            │     TableID: 104
+            │
+            ├── • RemoveJobStateFromDescriptor
+            │     DescriptorID: 104
+            │     JobID: 1
+            │
+            ├── • RemoveJobStateFromDescriptor
+            │     DescriptorID: 105
+            │     JobID: 1
+            │
+            └── • UpdateSchemaChangerJob
+                  DescriptorIDsToRemove:
+                  - 104
+                  - 105
+                  IsNonCancelable: true
+                  JobID: 1
+                  RunningStatus: all stages completed

--- a/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_add_check_udf.rollback_1_of_2
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_add_check_udf.rollback_1_of_2
@@ -1,0 +1,52 @@
+/* setup */
+CREATE TABLE t (i INT PRIMARY KEY, b INT);
+CREATE FUNCTION f(b INT) RETURNS INT LANGUAGE SQL AS $$ SELECT b + 1 $$;
+
+/* test */
+ALTER TABLE t ADD CONSTRAINT check_b CHECK (f(b) > 1);
+EXPLAIN (ddl, verbose) rollback at post-commit stage 1 of 2;
+----
+• Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› ADD CONSTRAINT ‹check_b› CHECK (f(‹b›) > ‹1›);
+│
+└── • PostCommitNonRevertiblePhase
+    │
+    └── • Stage 1 of 1 in PostCommitNonRevertiblePhase
+        │
+        ├── • 1 element transitioning toward ABSENT
+        │   │
+        │   └── • CheckConstraint:{DescID: 104, IndexID: 0, ConstraintID: 2}
+        │       │ WRITE_ONLY → ABSENT
+        │       │
+        │       ├── • PreviousStagePrecedence dependency from WRITE_ONLY CheckConstraint:{DescID: 104, IndexID: 0, ConstraintID: 2}
+        │       │     rule: "CheckConstraint transitions to ABSENT uphold 2-version invariant: WRITE_ONLY->VALIDATED"
+        │       │
+        │       └── • Precedence dependency from ABSENT ConstraintWithoutIndexName:{DescID: 104, Name: check_b, ConstraintID: 2}
+        │             rule: "dependents removed before constraint"
+        │
+        └── • 5 Mutation operations
+            │
+            ├── • RemoveCheckConstraint
+            │     ConstraintID: 2
+            │     TableID: 104
+            │
+            ├── • RemoveTableConstraintBackReferencesFromFunctions
+            │     BackReferencedConstraintID: 2
+            │     BackReferencedTableID: 104
+            │     FunctionIDs:
+            │     - 105
+            │
+            ├── • RemoveJobStateFromDescriptor
+            │     DescriptorID: 104
+            │     JobID: 1
+            │
+            ├── • RemoveJobStateFromDescriptor
+            │     DescriptorID: 105
+            │     JobID: 1
+            │
+            └── • UpdateSchemaChangerJob
+                  DescriptorIDsToRemove:
+                  - 104
+                  - 105
+                  IsNonCancelable: true
+                  JobID: 1
+                  RunningStatus: all stages completed

--- a/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_add_check_udf.rollback_2_of_2
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_add_check_udf.rollback_2_of_2
@@ -1,0 +1,52 @@
+/* setup */
+CREATE TABLE t (i INT PRIMARY KEY, b INT);
+CREATE FUNCTION f(b INT) RETURNS INT LANGUAGE SQL AS $$ SELECT b + 1 $$;
+
+/* test */
+ALTER TABLE t ADD CONSTRAINT check_b CHECK (f(b) > 1);
+EXPLAIN (ddl, verbose) rollback at post-commit stage 2 of 2;
+----
+• Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› ADD CONSTRAINT ‹check_b› CHECK (f(‹b›) > ‹1›);
+│
+└── • PostCommitNonRevertiblePhase
+    │
+    └── • Stage 1 of 1 in PostCommitNonRevertiblePhase
+        │
+        ├── • 1 element transitioning toward ABSENT
+        │   │
+        │   └── • CheckConstraint:{DescID: 104, IndexID: 0, ConstraintID: 2}
+        │       │ WRITE_ONLY → ABSENT
+        │       │
+        │       ├── • PreviousStagePrecedence dependency from WRITE_ONLY CheckConstraint:{DescID: 104, IndexID: 0, ConstraintID: 2}
+        │       │     rule: "CheckConstraint transitions to ABSENT uphold 2-version invariant: WRITE_ONLY->VALIDATED"
+        │       │
+        │       └── • Precedence dependency from ABSENT ConstraintWithoutIndexName:{DescID: 104, Name: check_b, ConstraintID: 2}
+        │             rule: "dependents removed before constraint"
+        │
+        └── • 5 Mutation operations
+            │
+            ├── • RemoveCheckConstraint
+            │     ConstraintID: 2
+            │     TableID: 104
+            │
+            ├── • RemoveTableConstraintBackReferencesFromFunctions
+            │     BackReferencedConstraintID: 2
+            │     BackReferencedTableID: 104
+            │     FunctionIDs:
+            │     - 105
+            │
+            ├── • RemoveJobStateFromDescriptor
+            │     DescriptorID: 104
+            │     JobID: 1
+            │
+            ├── • RemoveJobStateFromDescriptor
+            │     DescriptorID: 105
+            │     JobID: 1
+            │
+            └── • UpdateSchemaChangerJob
+                  DescriptorIDsToRemove:
+                  - 104
+                  - 105
+                  IsNonCancelable: true
+                  JobID: 1
+                  RunningStatus: all stages completed

--- a/pkg/sql/sem/tree/backup.go
+++ b/pkg/sql/sem/tree/backup.go
@@ -132,6 +132,7 @@ type RestoreOptions struct {
 	SkipMissingSequences      bool
 	SkipMissingSequenceOwners bool
 	SkipMissingViews          bool
+	SkipMissingUDFs           bool
 	Detached                  bool
 	SkipLocalitiesCheck       bool
 	DebugPauseOn              Expr
@@ -416,6 +417,11 @@ func (o *RestoreOptions) Format(ctx *FmtCtx) {
 		ctx.WriteString("skip_missing_views")
 	}
 
+	if o.SkipMissingUDFs {
+		maybeAddSep()
+		ctx.WriteString("skip_missing_udfs")
+	}
+
 	if o.Detached {
 		maybeAddSep()
 		ctx.WriteString("detached")
@@ -513,6 +519,14 @@ func (o *RestoreOptions) CombineWith(other *RestoreOptions) error {
 		o.SkipMissingViews = other.SkipMissingViews
 	}
 
+	if o.SkipMissingUDFs {
+		if other.SkipMissingUDFs {
+			return errors.New("skip_missing_udfs specified multiple times")
+		}
+	} else {
+		o.SkipMissingUDFs = other.SkipMissingUDFs
+	}
+
 	if o.Detached {
 		if other.Detached {
 			return errors.New("detached option specified multiple times")
@@ -583,6 +597,7 @@ func (o RestoreOptions) IsDefault() bool {
 		o.SkipMissingSequences == options.SkipMissingSequences &&
 		o.SkipMissingSequenceOwners == options.SkipMissingSequenceOwners &&
 		o.SkipMissingViews == options.SkipMissingViews &&
+		o.SkipMissingUDFs == options.SkipMissingUDFs &&
 		cmp.Equal(o.DecryptionKMSURI, options.DecryptionKMSURI) &&
 		o.EncryptionPassphrase == options.EncryptionPassphrase &&
 		o.IntoDB == options.IntoDB &&

--- a/pkg/sql/sem/tree/name_resolution.go
+++ b/pkg/sql/sem/tree/name_resolution.go
@@ -123,6 +123,7 @@ const (
 // database in the qualification.
 type QualifiedNameResolver interface {
 	GetQualifiedTableNameByID(ctx context.Context, id int64, requiredType RequiredTableKind) (*TableName, error)
+	GetQualifiedFunctionNameByID(ctx context.Context, id int64) (*FunctionName, error)
 	CurrentDatabase() string
 }
 

--- a/pkg/sql/sem/tree/type_check.go
+++ b/pkg/sql/sem/tree/type_check.go
@@ -65,9 +65,9 @@ type SemaContext struct {
 	// *FunctionDefinitons.
 	FunctionResolver FunctionReferenceResolver
 
-	// TableNameResolver is used to resolve the fully qualified
+	// NameResolver is used to resolve the fully qualified
 	// name of a table given its ID.
-	TableNameResolver QualifiedNameResolver
+	NameResolver QualifiedNameResolver
 
 	Properties SemaProperties
 
@@ -1224,6 +1224,8 @@ func (expr *FuncExpr) TypeCheck(
 	for i, subExpr := range s.typedExprs {
 		expr.Exprs[i] = subExpr
 	}
+
+	expr.Func.FunctionReference = def
 	expr.fn = overloadImpl
 	expr.fnProps = &overloadImpl.FunctionProperties
 	expr.typ = overloadImpl.returnType()(s.typedExprs)

--- a/pkg/sql/sem/tree/udf.go
+++ b/pkg/sql/sem/tree/udf.go
@@ -530,15 +530,50 @@ func (v *UDFDisallowanceVisitor) VisitPost(expr Expr) (newNode Expr) {
 }
 
 // MaybeFailOnUDFUsage returns an error if the given expression or any
-// sub-expression used a UDF.
+// sub-expression used a UDF unless it's explicitly listed as an allowed use
+// case.
 // TODO(chengxiong): remove this function when we start allowing UDF references.
-func MaybeFailOnUDFUsage(expr TypedExpr) error {
+func MaybeFailOnUDFUsage(expr TypedExpr, exprContext SchemaExprContext) error {
+	if _, ok := schemaExprContextAllowingUDF[exprContext]; ok {
+		return nil
+	}
 	visitor := &UDFDisallowanceVisitor{}
 	WalkExpr(visitor, expr)
 	if visitor.FoundUDF {
 		return unimplemented.NewWithIssue(83234, "usage of user-defined function from relations not supported")
 	}
 	return nil
+}
+
+// SchemaExprContext indicates in which schema change context an expression is being
+// used in. For example, DEFAULT VALUE of a column, CHECK CONSTRAINT's
+// expression, etc.
+type SchemaExprContext string
+
+const (
+	AlterColumnTypeUsingExpr        SchemaExprContext = "ALTER COLUMN TYPE USING EXPRESSION"
+	StoredComputedColumnExpr        SchemaExprContext = "STORED COMPUTED COLUMN"
+	VirtualComputedColumnExpr       SchemaExprContext = "VIRTUAL COMPUTED COLUMN"
+	ColumnOnUpdateExpr              SchemaExprContext = "ON UPDATE"
+	ColumnDefaultExpr               SchemaExprContext = "DEFAULT"
+	CheckConstraintExpr             SchemaExprContext = "CHECK"
+	UniqueWithoutIndexPredicateExpr SchemaExprContext = "UNIQUE WITHOUT INDEX PREDICATE"
+	IndexPredicateExpr              SchemaExprContext = "INDEX PREDICATE"
+	ExpressionIndexElementExpr      SchemaExprContext = "EXPRESSION INDEX ELEMENT"
+	TTLExpirationExpr               SchemaExprContext = "TTL EXPIRATION EXPRESSION"
+	TTLDefaultExpr                  SchemaExprContext = "TTL DEFAULT"
+	TTLUpdateExpr                   SchemaExprContext = "TTL UPDATE"
+)
+
+var schemaExprContextAllowingUDF = map[SchemaExprContext]struct{}{
+	CheckConstraintExpr: {},
+}
+
+func ComputedColumnExprContext(isVirtual bool) SchemaExprContext {
+	if isVirtual {
+		return VirtualComputedColumnExpr
+	}
+	return StoredComputedColumnExpr
 }
 
 // ValidateFuncOptions checks whether there are conflicting or redundant

--- a/pkg/sql/show_create_clauses.go
+++ b/pkg/sql/show_create_clauses.go
@@ -190,7 +190,7 @@ func formatQuerySequencesForDisplay(
 	ctx context.Context, semaCtx *tree.SemaContext, queries string, multiStmt bool,
 ) (string, error) {
 	replaceFunc := func(expr tree.Expr) (recurse bool, newExpr tree.Expr, err error) {
-		newExpr, err = schemaexpr.ReplaceIDsWithFQNames(ctx, expr, semaCtx)
+		newExpr, err = schemaexpr.ReplaceSequenceIDsWithFQNames(ctx, expr, semaCtx)
 		if err != nil {
 			return false, expr, err
 		}


### PR DESCRIPTION
Informs #87699

**sql: use UDFs in check constraints**

This commit turns on UDF usages in CHECK constraints.
It does a few things:
1. Add a concept of `SchemaExprContext`, which used to be a
pure string. This commit makes it a type so that we can
switch on different context of a expression. This allow fine
grain control over in which circumstance that a UDF is allowed.
2. Serialize Function Expression to use OID reference to UDF.
This allows objects reference UDFs by ID so that functions can
be renamed.
3. Refine cross reference validation in function descriptor
and table descriptor for more safety.
4. Fix legacy schema changer, so that cross references between
UDF and tables are properly tracked when CHECK constraints are
added and dropped.
5. Fix declarative schema changer, so that UDFs are recognized
in check constraint elements, and ops are added to add and remove
UDF back references.

Release note (sql change): previously UDFs are not allowed in
tables and any other object. This patch enables UDF usage in
CHECK constraints of tables in both legacy schema changer and
delcarative schema changer. Dependency circles are not allowed,
namely if a UDF depends on a table, then the table can't use that
UDF.


**sql: version gate udf usage check**

This commit adds version gate for udf usage check, so that
cross reference won't be broken because there won't be cases
like a constraint is added in new version, but dropped in
an old version.

Release note (sql change): This patch adds version gate so the
UDF usage in CHECK constraints are not allowed until cluster is
fully upgraded to 23.1.


**backupccl: fix backup and restore to work with objects referencing UDFs**

Release note (enterprise change): Previously UDFs can't be referenced
from other objects, so backup and restore oly needs to read and
write UDF descriptors without worrying about missing UDFs when
doing `RESTORE TABLE`. Now that we turned UDF's usage in table
CHECK constraints. We need to be able to handle all function ID
rewrites in CHECK constraint expressions during `RESTORE`. A new
`RSTORE` command option `skip_missing_udfs` is added, so that
when the option is given, UDF dependencies will be skipped if UDF
descriptors are missing. The main use case, as of this patch is that
 currently when doing `RESTORE TABLE`, we don't restore referenced
UDFs together, so UDFs are consider missing, which blocks the table
restore unless the `skip_missing_udfs` option is specified, so that
those check constraints are dropped to remove the dependency to
unblock `RESTORE TABLE`.
