### PR TITLE
insights: detect failed executions at the stmt and txn levels

### DIFF
--- a/pkg/sql/sqlstats/insights/detector.go
+++ b/pkg/sql/sqlstats/insights/detector.go
@@ -165,3 +165,7 @@ func (d *latencyThresholdDetector) enabled() bool {
 func (d *latencyThresholdDetector) isSlow(s *Statement) bool {
 	return d.enabled() && s.LatencyInSeconds >= LatencyThreshold.Get(&d.st.SV).Seconds()
 }
+
+func isFailed(s *Statement) bool {
+	return s.Status == Statement_Failed
+}

--- a/pkg/sql/sqlstats/insights/detector_test.go
+++ b/pkg/sql/sqlstats/insights/detector_test.go
@@ -119,6 +119,63 @@ func TestLatencyQuantileDetector(t *testing.T) {
 		}
 	})
 
+	// Testing the slow and failure detectors at the same time.
+	t.Run("isSlow and isFailed", func(t *testing.T) {
+		ctx := context.Background()
+		st := cluster.MakeTestingClusterSettings()
+		AnomalyDetectionEnabled.Override(ctx, &st.SV, true)
+		AnomalyDetectionLatencyThreshold.Override(ctx, &st.SV, 100*time.Millisecond)
+
+		tests := []struct {
+			name             string
+			seedLatency      time.Duration
+			candidateLatency time.Duration
+			status           Statement_Status
+			isSlow           bool
+			isFailed         bool
+		}{{
+			name:             "slow and failed statement",
+			seedLatency:      100 * time.Millisecond,
+			candidateLatency: 200 * time.Millisecond,
+			status:           Statement_Failed,
+			isSlow:           true,
+			isFailed:         true,
+		}, {
+			name:             "slow and non-failed statement",
+			seedLatency:      100 * time.Millisecond,
+			candidateLatency: 200 * time.Millisecond,
+			status:           Statement_Completed,
+			isSlow:           true,
+			isFailed:         false,
+		}, {
+			name:             "fast and non-failed statement",
+			seedLatency:      100 * time.Millisecond,
+			candidateLatency: 50 * time.Millisecond,
+			status:           Statement_Completed,
+			isSlow:           false,
+			isFailed:         false,
+		}, {
+			name:             "fast and failed statement",
+			seedLatency:      100 * time.Millisecond,
+			candidateLatency: 50 * time.Millisecond,
+			status:           Statement_Failed,
+			isSlow:           false,
+			isFailed:         true,
+		}}
+
+		for _, test := range tests {
+			t.Run(test.name, func(t *testing.T) {
+				d := newAnomalyDetector(st, NewMetrics())
+				for i := 0; i < 1000; i++ {
+					d.isSlow(&Statement{LatencyInSeconds: test.seedLatency.Seconds()})
+				}
+				stmt := &Statement{LatencyInSeconds: test.candidateLatency.Seconds(), Status: test.status}
+				require.Equal(t, test.isSlow, d.isSlow(stmt))
+				require.Equal(t, test.isFailed, isFailed(stmt))
+			})
+		}
+	})
+
 	t.Run("metrics", func(t *testing.T) {
 		ctx := context.Background()
 		st := cluster.MakeTestingClusterSettings()

--- a/pkg/sql/sqlstats/insights/registry.go
+++ b/pkg/sql/sqlstats/insights/registry.go
@@ -97,10 +97,11 @@ func (r *lockingRegistry) ObserveTransaction(sessionID clusterunique.ID, transac
 	delete(r.statements, sessionID)
 	defer statements.release()
 
-	var slowStatements intsets.Fast
+	// Mark statements which are detected as slow or have a failed status.
+	var slowOrFailedStatements intsets.Fast
 	for i, s := range *statements {
-		if r.detector.isSlow(s) {
-			slowStatements.Add(i)
+		if r.detector.isSlow(s) || isFailed(s) {
+			slowOrFailedStatements.Add(i)
 		}
 	}
 
@@ -112,8 +113,8 @@ func (r *lockingRegistry) ObserveTransaction(sessionID clusterunique.ID, transac
 		highContention = transaction.Contention.Seconds() >= LatencyThreshold.Get(&r.causes.st.SV).Seconds()
 	}
 
-	if slowStatements.Empty() && !highContention {
-		// We only record an insight if we have slow statements or high txn contention.
+	if slowOrFailedStatements.Empty() && !highContention {
+		// We only record an insight if we have slow or failed statements or high txn contention.
 		return
 	}
 
@@ -127,14 +128,12 @@ func (r *lockingRegistry) ObserveTransaction(sessionID clusterunique.ID, transac
 	}
 
 	for i, s := range *statements {
-		if slowStatements.Contains(i) {
+		if slowOrFailedStatements.Contains(i) {
 			switch s.Status {
 			case Statement_Completed:
 				s.Problem = Problem_SlowExecution
 				s.Causes = r.causes.examine(s.Causes, s)
 			case Statement_Failed:
-				// Note that we'll be building better failure support for 23.1.
-				// For now, we only mark failed statements that were also slow.
 				s.Problem = Problem_FailedExecution
 			}
 

--- a/pkg/sql/sqlstats/insights/registry_test.go
+++ b/pkg/sql/sqlstats/insights/registry_test.go
@@ -32,6 +32,13 @@ func newStmtWithProblemAndCauses(stmt *Statement, problem Problem, causes []Caus
 	return &newStmt
 }
 
+// Return a new failed statement.
+func newFailedStmt(stmt *Statement) *Statement {
+	newStmt := *stmt
+	newStmt.Problem = Problem_FailedExecution
+	return &newStmt
+}
+
 func TestRegistry(t *testing.T) {
 	ctx := context.Background()
 
@@ -72,9 +79,6 @@ func TestRegistry(t *testing.T) {
 	})
 
 	t.Run("failure detection", func(t *testing.T) {
-		// Note that we don't fully support detecting and reporting statement failures yet.
-		// We only report failures when the statement was also slow.
-		// We'll be coming back to build a better failure story for 23.1.
 		statement := &Statement{
 			ID:               clusterunique.IDFromBytes([]byte("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb")),
 			FingerprintID:    appstatspb.StmtFingerprintID(100),
@@ -93,7 +97,7 @@ func TestRegistry(t *testing.T) {
 			Session:     session,
 			Transaction: transaction,
 			Statements: []*Statement{
-				newStmtWithProblemAndCauses(statement, Problem_FailedExecution, nil),
+				newFailedStmt(statement),
 			},
 		}}
 		var actual []*Insight


### PR DESCRIPTION
Fixes: #94381.

Previously, the insights subsystem only kept track of failed executions
that were also slow executions. This commit enables the insights
subsystem to keep track of all failed executions, regardless if they were
slow or not.

Release note (sql change): The insights subsystem in `sqlstats` is able
to detect failed executions, regardless if they were slow or not.