### PR TITLE
parser: add `QUERY` to `bare_label_keyword`

### DIFF
--- a/docs/generated/sql/bnf/stmt_block.bnf
+++ b/docs/generated/sql/bnf/stmt_block.bnf
@@ -3426,6 +3426,7 @@ bare_label_keywords ::=
 	| 'INVOKER'
 	| 'LEAKPROOF'
 	| 'PARALLEL'
+	| 'QUERY'
 	| 'RETURN'
 	| 'RETURNS'
 	| 'SECURITY'

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -15904,13 +15904,13 @@ unrestricted_name:
 | reserved_keyword
 
 // Keyword category lists. Generally, every keyword present in the Postgres
-// grammar should appear in exactly one of these lists.
+// grammar should appear in exactly one of these "x_keyword" lists.
 //
 // Put a new keyword into the first list that it can go into without causing
 // shift or reduce conflicts. The earlier lists define "less reserved"
 // categories of keywords.
 //
-// Note: also add the new keyword to `bare_label` list to not break
+// Note: also add the **new** keyword to `bare_label_keywords` list to not break
 // user queries using column label without `AS`.
 // "Unreserved" keywords --- available for use as any kind of name.
 unreserved_keyword:
@@ -16374,6 +16374,7 @@ bare_label_keywords:
 | INVOKER
 | LEAKPROOF
 | PARALLEL
+| QUERY
 | RETURN
 | RETURNS
 | SECURITY

--- a/pkg/sql/parser/testdata/select_clauses
+++ b/pkg/sql/parser/testdata/select_clauses
@@ -3051,3 +3051,11 @@ SELECT * FROM ROWS FROM (json_to_record('')) AS t (a INT8, b STRING, c foo) -- n
 SELECT (*) FROM ROWS FROM ((json_to_record(('')))) AS t (a INT8, b STRING, c foo) -- fully parenthesized
 SELECT * FROM ROWS FROM (json_to_record('_')) AS t (a INT8, b STRING, c foo) -- literals removed
 SELECT * FROM ROWS FROM (json_to_record('')) AS _ (_ INT8, _ STRING, _ foo) -- identifiers removed
+
+parse
+SELECT substring('stringstringstring',1,10) QUERY
+----
+SELECT substring('stringstringstring', 1, 10) AS query -- normalized!
+SELECT (substring(('stringstringstring'), (1), (10))) AS query -- fully parenthesized
+SELECT substring('_', _, _) AS query -- literals removed
+SELECT substring('stringstringstring', 1, 10) AS _ -- identifiers removed


### PR DESCRIPTION
As revealed by #84309, some keywords not added to `bare_label_keywords` in `sql.y` make the `SELECT ... <keyword>` statement error out, which is not compatible with postgres. This commit is to add the `QUERY` keyword per a support ticket. We're not adding the whole `unreserved_keyword` list here as having some of them in `bare_label_keyword`, such as `DAY`, brings `reduce` errors.

Postgres:

```
postgres=# select substring('stringstringstring',1,10) query;
   query
------------
 stringstri
(1 row)
```

CRDB:

```
root@localhost:26257/defaultdb> select substring('stringstringstring',1,10)  query;
invalid syntax: statement ignored: at or near "query": syntax error
SQLSTATE: 42601
DETAIL: source SQL:
select substring('stringstringstring',1,10)  query
                                             ^
```

informs #84309

Release Note(bug fix): fixed the syntax error for `SELECT ... QUERY` (without AS) statement.