### PR TITLE
release 22.1: roachtest: fix lib/pq blocklist

### DIFF
--- a/pkg/cmd/roachtest/tests/libpq.go
+++ b/pkg/cmd/roachtest/tests/libpq.go
@@ -88,11 +88,10 @@ func registerLibPQ(r registry.Registry) {
 			t.Fatal(err)
 		}
 
-		blocklistName, expectedFailures, ignorelistName, ignoreList := libPQBlocklists.getLists(version)
-		if expectedFailures == nil {
+		if len(libPQBlocklist) == 0 {
 			t.Fatalf("No lib/pq blocklist defined for cockroach version %s", version)
 		}
-		t.L().Printf("Running cockroach version %s, using blocklist %s, using ignorelist %s", version, blocklistName, ignorelistName)
+		t.L().Printf("Running cockroach version %s, using blocklist %s, using ignorelist %s", version, "libPQBlocklist", "libPQIgnorelist")
 
 		t.Status("running lib/pq test suite and collecting results")
 
@@ -117,7 +116,7 @@ func registerLibPQ(r registry.Registry) {
 				continue
 			}
 			// If the test is part of ignoreList, do not run the test.
-			if _, ok := ignoreList[testName]; !ok {
+			if _, ok := libPQIgnorelist[testName]; !ok {
 				allowedTests = append(allowedTests, testName)
 			}
 		}
@@ -134,7 +133,7 @@ func registerLibPQ(r registry.Registry) {
 
 		parseAndSummarizeJavaORMTestsResults(
 			ctx, t, c, node, "lib/pq" /* ormName */, []byte(resultsPath),
-			blocklistName, expectedFailures, ignoreList, version, libPQSupportedTag,
+			"libPQBlocklist", libPQBlocklist, libPQIgnorelist, version, libPQSupportedTag,
 		)
 	}
 

--- a/pkg/cmd/roachtest/tests/libpq_blocklist.go
+++ b/pkg/cmd/roachtest/tests/libpq_blocklist.go
@@ -10,14 +10,7 @@
 
 package tests
 
-var libPQBlocklists = blocklistsForVersion{
-	{"v20.2", "libPQBlocklist20_2", libPQBlocklist20_2, "libPQIgnorelist20_2", libPQIgnorelist20_2},
-	{"v21.1", "libPQBlocklist21_1", libPQBlocklist21_1, "libPQIgnorelist21_1", libPQIgnorelist21_1},
-	{"v21.2", "libPQBlocklist21_2", libPQBlocklist21_2, "libPQIgnorelist21_2", libPQIgnorelist21_2},
-	{"v22.1", "libPQBlocklist22_1", libPQBlocklist22_1, "libPQIgnorelist22_1", libPQIgnorelist22_1},
-}
-
-var libPQBlocklist22_1 = blocklist{
+var libPQBlocklist = blocklist{
 	"pq.ExampleConnectorWithNoticeHandler":           "unknown",
 	"pq.TestBinaryByteSliceToInt":                    "41547",
 	"pq.TestBinaryByteSlicetoUUID":                   "41547",
@@ -48,91 +41,11 @@ var libPQBlocklist22_1 = blocklist{
 	"pq.TestRuntimeParameters":                       "12137",
 	"pq.TestStringWithNul":                           "26366",
 }
-
-var libPQBlocklist21_2 = blocklist{
-	"pq.ExampleConnectorWithNoticeHandler":           "unknown",
-	"pq.TestBinaryByteSliceToInt":                    "41547",
-	"pq.TestBinaryByteSlicetoUUID":                   "41547",
-	"pq.TestConnListen":                              "41522",
-	"pq.TestConnUnlisten":                            "41522",
-	"pq.TestConnUnlistenAll":                         "41522",
-	"pq.TestConnectorWithNoticeHandler_Simple":       "unknown",
-	"pq.TestConnectorWithNotificationHandler_Simple": "unknown",
-	"pq.TestContextCancelBegin":                      "41335",
-	"pq.TestContextCancelExec":                       "41335",
-	"pq.TestContextCancelQuery":                      "41335",
-	"pq.TestCopyFromError":                           "5807",
-	"pq.TestCopyInRaiseStmtTrigger":                  "5807",
-	"pq.TestCopyInTypes":                             "5807",
-	"pq.TestCopyRespLoopConnectionError":             "5807",
-	"pq.TestEncodeAndParseTs":                        "41563",
-	"pq.TestInfinityTimestamp":                       "41564",
-	"pq.TestIssue186":                                "41558",
-	"pq.TestIssue196":                                "41689",
-	"pq.TestIssue282":                                "12137",
-	"pq.TestListenerFailedQuery":                     "41522",
-	"pq.TestListenerListen":                          "41522",
-	"pq.TestListenerReconnect":                       "41522",
-	"pq.TestListenerUnlisten":                        "41522",
-	"pq.TestListenerUnlistenAll":                     "41522",
-	"pq.TestNotifyExtra":                             "41522",
-	"pq.TestPing":                                    "35897",
-	"pq.TestQueryRowBugWorkaround":                   "5807",
-	"pq.TestReconnect":                               "35897",
-	"pq.TestRowsColumnTypes":                         "41688",
-	"pq.TestRuntimeParameters":                       "12137",
-	"pq.TestStringWithNul":                           "26366",
-}
-
-var libPQBlocklist21_1 = libPQBlocklist20_2
-
-var libPQBlocklist20_2 = blocklist{
-	"pq.ExampleConnectorWithNoticeHandler":           "unknown",
-	"pq.TestBinaryByteSliceToInt":                    "41547",
-	"pq.TestBinaryByteSlicetoUUID":                   "41547",
-	"pq.TestByteaOutputFormats":                      "26947",
-	"pq.TestConnListen":                              "41522",
-	"pq.TestConnUnlisten":                            "41522",
-	"pq.TestConnUnlistenAll":                         "41522",
-	"pq.TestConnectorWithNoticeHandler_Simple":       "unknown",
-	"pq.TestConnectorWithNotificationHandler_Simple": "unknown",
-	"pq.TestContextCancelBegin":                      "41335",
-	"pq.TestContextCancelExec":                       "41335",
-	"pq.TestContextCancelQuery":                      "41335",
-	"pq.TestCopyFromError":                           "5807",
-	"pq.TestCopyInRaiseStmtTrigger":                  "5807",
-	"pq.TestCopyInTypes":                             "5807",
-	"pq.TestCopyRespLoopConnectionError":             "5807",
-	"pq.TestEncodeAndParseTs":                        "41563",
-	"pq.TestErrorDuringStartup":                      "41551",
-	"pq.TestInfinityTimestamp":                       "41564",
-	"pq.TestIssue186":                                "41558",
-	"pq.TestIssue196":                                "41689",
-	"pq.TestIssue282":                                "12137",
-	"pq.TestListenerFailedQuery":                     "41522",
-	"pq.TestListenerListen":                          "41522",
-	"pq.TestListenerReconnect":                       "41522",
-	"pq.TestListenerUnlisten":                        "41522",
-	"pq.TestListenerUnlistenAll":                     "41522",
-	"pq.TestNotifyExtra":                             "41522",
-	"pq.TestPing":                                    "35897",
-	"pq.TestQueryRowBugWorkaround":                   "5807",
-	"pq.TestReconnect":                               "35897",
-	"pq.TestRowsColumnTypes":                         "41688",
-	"pq.TestRuntimeParameters":                       "12137",
-	"pq.TestStringWithNul":                           "26366",
-}
-
-var libPQIgnorelist22_1 = libPQIgnorelist21_2
-
-var libPQIgnorelist21_2 = libPQIgnorelist21_1
-
-var libPQIgnorelist21_1 = libPQIgnorelist20_2
 
 // The test names here do not include "pq." since `go test -list` returns
 // the test name without "pq.". We use the name returned from `go test -list`
 // to ignore the test.
-var libPQIgnorelist20_2 = blocklist{
+var libPQIgnorelist = blocklist{
 	// TestFormatTsBacked fails due to not returning an error for accepting a
 	// timestamp format that postgres does not.
 	"TestFormatTsBackend": "41690",


### PR DESCRIPTION
Update the block list so that there's only one for each version.

Epic: None
Release note: None