### PR TITLE
tree: allow multiple UDFs with in-exact type parameters

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/udf
+++ b/pkg/sql/logictest/testdata/logic_test/udf
@@ -3043,3 +3043,24 @@ query I
 SELECT count(descriptor) FROM system.descriptor WHERE id = $dropped_fn_id;
 ----
 0
+
+# Regression test for #94146
+statement ok
+CREATE FUNCTION f_94146(i INT2) RETURNS INT STRICT LANGUAGE SQL AS 'SELECT 2';
+CREATE FUNCTION f_94146(i INT4) RETURNS INT STRICT LANGUAGE SQL AS 'SELECT 4';
+CREATE FUNCTION f_94146(i INT8) RETURNS INT STRICT LANGUAGE SQL AS 'SELECT 8';
+
+query I
+SELECT f_94146(1::INT8)
+----
+8
+
+query I
+SELECT f_94146(1::INT4)
+----
+4
+
+query I
+SELECT f_94146(1::INT2)
+----
+2

--- a/pkg/sql/sem/tree/function_definition.go
+++ b/pkg/sql/sem/tree/function_definition.go
@@ -244,6 +244,11 @@ func (fd *ResolvedFunctionDefinition) MatchOverload(
 	paramTypes []*types.T, explicitSchema string, searchPath SearchPath,
 ) (QualifiedOverload, error) {
 	matched := func(ol QualifiedOverload, schema string) bool {
+		if ol.IsUDF {
+			// TODO(mgartner/chengxiong-ruan): Differentiate between functions
+			// defined with `Body` and UDFs, now that we use `Body` for built-in functions.
+			return schema == ol.Schema && (paramTypes == nil || ol.params().MatchIdentical(paramTypes))
+		}
 		return schema == ol.Schema && (paramTypes == nil || ol.params().Match(paramTypes))
 	}
 	typeNames := func() string {

--- a/pkg/sql/sem/tree/function_definition_test.go
+++ b/pkg/sql/sem/tree/function_definition_test.go
@@ -111,6 +111,14 @@ func TestMatchOverload(t *testing.T) {
 				Schema:   "sc2",
 				Overload: &tree.Overload{Oid: 4, IsUDF: true, Types: tree.ParamTypes{tree.ParamType{Typ: types.Int}}},
 			},
+			{
+				Schema: "sc3",
+				Overload: &tree.Overload{Oid: 5, IsUDF: true,
+					Types: tree.ParamTypes{
+						tree.ParamType{Typ: types.Int2}, tree.ParamType{Typ: types.Int4},
+					},
+				},
+			},
 		},
 	}
 
@@ -190,6 +198,18 @@ func TestMatchOverload(t *testing.T) {
 			argTypes:    []*types.T{types.String},
 			path:        []string{"sc2", "sc1", "pg_catalog"},
 			expectedErr: `function f\(string\) does not exist`,
+		},
+		{
+			testName:    "multiple parameters exact match on same family type",
+			argTypes:    []*types.T{types.Int2, types.Int4},
+			path:        []string{"sc3", "sc3", "pg_catalog"},
+			expectedOid: 5,
+		},
+		{
+			testName:    "multiple parameters exact match on same family type not exists",
+			argTypes:    []*types.T{types.Int, types.Int4},
+			path:        []string{"sc3", "sc3", "pg_catalog"},
+			expectedErr: `function f\(int,int4\) does not exist: function undefined`,
 		},
 	}
 

--- a/pkg/sql/sem/tree/overload.go
+++ b/pkg/sql/sem/tree/overload.go
@@ -310,10 +310,16 @@ func GetParamsAndReturnType(impl overloadImpl) (TypeList, ReturnTyper) {
 type TypeList interface {
 	// Match checks if all types in the TypeList match the corresponding elements in types.
 	Match(types []*types.T) bool
+	// MatchIdentical is similar to match but checks that the types are identical matches,
+	//instead of equivalent matches. See types.T.Equivalent and types.T.Identical.
+	MatchIdentical(types []*types.T) bool
 	// MatchAt checks if the parameter type at index i of the TypeList matches type typ.
 	// In all implementations, types.Null will match with each parameter type, allowing
 	// NULL values to be used as arguments.
 	MatchAt(typ *types.T, i int) bool
+	// MatchAtIdentical is similar to MatchAt but checks that the type at index i of
+	// the Typelist is identical to typ.
+	MatchAtIdentical(typ *types.T, i int) bool
 	// MatchLen checks that the TypeList can support l parameters.
 	MatchLen(l int) bool
 	// GetAt returns the type at the given index in the TypeList, or nil if the TypeList
@@ -353,6 +359,19 @@ func (p ParamTypes) Match(types []*types.T) bool {
 	return true
 }
 
+// MatchIdentical is part of the TypeList interface.
+func (p ParamTypes) MatchIdentical(types []*types.T) bool {
+	if len(types) != len(p) {
+		return false
+	}
+	for i := range types {
+		if !p.MatchAtIdentical(types[i], i) {
+			return false
+		}
+	}
+	return true
+}
+
 // MatchAt is part of the TypeList interface.
 func (p ParamTypes) MatchAt(typ *types.T, i int) bool {
 	// The parameterized types for Tuples are checked in the type checking
@@ -364,6 +383,14 @@ func (p ParamTypes) MatchAt(typ *types.T, i int) bool {
 		typ = types.AnyTuple
 	}
 	return i < len(p) && (typ.Family() == types.UnknownFamily || p[i].Typ.Equivalent(typ))
+}
+
+// MatchAtIdentical is part of the TypeList interface.
+func (p ParamTypes) MatchAtIdentical(typ *types.T, i int) bool {
+	if typ.Family() == types.TupleFamily {
+		typ = types.AnyTuple
+	}
+	return i < len(p) && (typ.Family() == types.UnknownFamily || p[i].Typ.Identical(typ))
 }
 
 // MatchLen is part of the TypeList interface.
@@ -420,8 +447,18 @@ func (HomogeneousType) Match(types []*types.T) bool {
 	return true
 }
 
+// MatchIdentical is part of the TypeList interface.
+func (HomogeneousType) MatchIdentical(types []*types.T) bool {
+	return true
+}
+
 // MatchAt is part of the TypeList interface.
 func (HomogeneousType) MatchAt(typ *types.T, i int) bool {
+	return true
+}
+
+// MatchAtIdentical is part of the TypeList interface.
+func (HomogeneousType) MatchAtIdentical(typ *types.T, i int) bool {
 	return true
 }
 
@@ -467,6 +504,11 @@ func (v VariadicType) Match(types []*types.T) bool {
 	return true
 }
 
+// MatchIdentical is part of the TypeList interface.
+func (VariadicType) MatchIdentical(types []*types.T) bool {
+	return true
+}
+
 // MatchAt is part of the TypeList interface.
 func (v VariadicType) MatchAt(typ *types.T, i int) bool {
 	if i < len(v.FixedTypes) {
@@ -474,6 +516,13 @@ func (v VariadicType) MatchAt(typ *types.T, i int) bool {
 	}
 	return typ.Family() == types.UnknownFamily || v.VarType.Equivalent(typ)
 }
+
+// MatchAtIdentical is part of the TypeList interface.
+// TODO(mgartner) : This will be incorrect once we add support for variadic UDFs
+func (VariadicType) MatchAtIdentical(typ *types.T, i int) bool {
+	return true
+}
+
 
 // MatchLen is part of the TypeList interface.
 func (v VariadicType) MatchLen(l int) bool {

--- a/pkg/sql/sem/tree/overload_test.go
+++ b/pkg/sql/sem/tree/overload_test.go
@@ -488,7 +488,7 @@ func TestGetMostSignificantOverload(t *testing.T) {
 				filters[i] = uint8(i)
 			}
 			overload, err := getMostSignificantOverload(
-				tc.overloads, impls, filters, tc.searchPath, &expr,
+				tc.overloads, impls, filters, tc.searchPath, &expr, nil /* typedInputExprs */,
 				func() string { return "some signature" },
 			)
 			if tc.expectedErr != "" {

--- a/pkg/sql/sem/tree/type_check.go
+++ b/pkg/sql/sem/tree/type_check.go
@@ -1152,7 +1152,7 @@ func (expr *FuncExpr) TypeCheck(
 
 	// Get overloads from the most significant schema in search path.
 	favoredOverload, err := getMostSignificantOverload(
-		def.Overloads, s.overloads, s.overloadIdxs, searchPath, expr,
+		def.Overloads, s.overloads, s.overloadIdxs, searchPath, expr, s.typedExprs,
 		func() string { return getFuncSig(expr, s.typedExprs, desired) },
 	)
 	if err != nil {
@@ -3012,6 +3012,7 @@ func getMostSignificantOverload(
 	filter []uint8,
 	searchPath SearchPath,
 	expr *FuncExpr,
+	typedInputExprs []TypedExpr,
 	getFuncSig func() string,
 ) (QualifiedOverload, error) {
 	ambiguousError := func() error {
@@ -3026,9 +3027,29 @@ func getMostSignificantOverload(
 	}
 	checkAmbiguity := func(oImpls []uint8) (QualifiedOverload, error) {
 		if len(oImpls) != 1 {
-			// Throw ambiguity error if there are more than one candidate overloads from
-			// same schema.
-			return QualifiedOverload{}, ambiguousError()
+			// Since there are ambiguity errors when udf with the same family
+			// parameter types, function signature has to be sorted out
+			// to directly match specific udf function for execution, e2e tests added
+			var expTypes []*types.T
+			for _, exp := range typedInputExprs {
+				expTypes = append(expTypes, exp.ResolvedType())
+			}
+
+			matchIdx := -1
+			for k, idx := range oImpls {
+				candidate := overloads[idx]
+				srcParams := candidate.params()
+				if srcParams.MatchIdentical(expTypes) {
+					if matchIdx != -1 {
+						// Throw ambiguity error if there are more than one
+						// candidate overloads from same schema.
+						return QualifiedOverload{}, ambiguousError()
+					}
+					matchIdx = k
+				}
+			}
+
+			return qualifiedOverloads[oImpls[matchIdx]], nil
 		}
 		return qualifiedOverloads[oImpls[0]], nil
 	}


### PR DESCRIPTION
This patch makes it possible for udf to check
exact type matching for udf parameters
Added TypeList.MatchExact to apply udf parameter check only.

- Unit test for such family type parameter matching are provided
- e2e test are applied on udf logictest
- applied review comments in general
- check ambiguity logic extended for successful dml execution (i.e. see udf e2e test)
- update logic that compares parameters via matchIdentical, parameters as key to check duplication

Release note (bug fix): A bug has been fixed that caused errors when creating multiple user-defined functions with the same name and different argument types in the same type family. For example, it was impossible to create both function `f(INT2)` and `f(INT4)`.