### PR TITLE
release-22.1: ui: fix stmt details reading null object

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetails.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetails.tsx
@@ -799,7 +799,7 @@ export class StatementDetails extends React.Component<
         onDownloadDiagnosticBundleClick={this.props.onDiagnosticBundleDownload}
         onDiagnosticCancelRequestClick={this.props.onDiagnosticCancelRequest}
         showDiagnosticsViewLink={
-          this.props.uiConfig.showStatementDiagnosticsLink
+          this.props.uiConfig?.showStatementDiagnosticsLink
         }
         onSortingChange={this.props.onSortingChange}
       />


### PR DESCRIPTION
This commit adds a null check when reading the uiconfig object in stmt details (which is provided in CC but not db-console) to prevent throwing an error, which made the page unusable.

Epic: none

Release note (bug fix): stmt details page is now able to render
Release justification: bug fix

<img width="1901" alt="image" src="https://user-images.githubusercontent.com/20136951/218541726-3229f03d-ee56-4b81-8726-8f743826e60d.png">

