### PR TITLE
cloud: bump version to v22.2.4

### DIFF
--- a/cloud/kubernetes/bring-your-own-certs/client.yaml
+++ b/cloud/kubernetes/bring-your-own-certs/client.yaml
@@ -20,7 +20,7 @@ spec:
   serviceAccountName: cockroachdb
   containers:
   - name: cockroachdb-client
-    image: cockroachdb/cockroach:v22.2.3
+    image: cockroachdb/cockroach:v22.2.4
     # Keep a pod open indefinitely so kubectl exec can be used to get a shell to it
     # and run cockroach client commands, such as cockroach sql, cockroach node status, etc.
     command:

--- a/cloud/kubernetes/bring-your-own-certs/cockroachdb-statefulset.yaml
+++ b/cloud/kubernetes/bring-your-own-certs/cockroachdb-statefulset.yaml
@@ -153,7 +153,7 @@ spec:
               topologyKey: kubernetes.io/hostname
       containers:
       - name: cockroachdb
-        image: cockroachdb/cockroach:v22.2.3
+        image: cockroachdb/cockroach:v22.2.4
         imagePullPolicy: IfNotPresent
         # TODO: Change these to appropriate values for the hardware that you're running. You can see
         # the resources that can be allocated on each of your Kubernetes nodes by running:

--- a/cloud/kubernetes/client-secure.yaml
+++ b/cloud/kubernetes/client-secure.yaml
@@ -32,7 +32,7 @@ spec:
       mountPath: /cockroach-certs
   containers:
   - name: cockroachdb-client
-    image: cockroachdb/cockroach:v22.2.3
+    image: cockroachdb/cockroach:v22.2.4
     imagePullPolicy: IfNotPresent
     volumeMounts:
     - name: client-certs

--- a/cloud/kubernetes/cluster-init-secure.yaml
+++ b/cloud/kubernetes/cluster-init-secure.yaml
@@ -34,7 +34,7 @@ spec:
           mountPath: /cockroach-certs
       containers:
       - name: cluster-init
-        image: cockroachdb/cockroach:v22.2.3
+        image: cockroachdb/cockroach:v22.2.4
         imagePullPolicy: IfNotPresent
         volumeMounts:
         - name: client-certs

--- a/cloud/kubernetes/cluster-init.yaml
+++ b/cloud/kubernetes/cluster-init.yaml
@@ -10,7 +10,7 @@ spec:
     spec:
       containers:
       - name: cluster-init
-        image: cockroachdb/cockroach:v22.2.3
+        image: cockroachdb/cockroach:v22.2.4
         imagePullPolicy: IfNotPresent
         command:
           - "/cockroach/cockroach"

--- a/cloud/kubernetes/cockroachdb-statefulset-secure.yaml
+++ b/cloud/kubernetes/cockroachdb-statefulset-secure.yaml
@@ -195,7 +195,7 @@ spec:
               topologyKey: kubernetes.io/hostname
       containers:
       - name: cockroachdb
-        image: cockroachdb/cockroach:v22.2.3
+        image: cockroachdb/cockroach:v22.2.4
         imagePullPolicy: IfNotPresent
         # TODO: Change these to appropriate values for the hardware that you're running. You can see
         # the resources that can be allocated on each of your Kubernetes nodes by running:

--- a/cloud/kubernetes/cockroachdb-statefulset.yaml
+++ b/cloud/kubernetes/cockroachdb-statefulset.yaml
@@ -98,7 +98,7 @@ spec:
               topologyKey: kubernetes.io/hostname
       containers:
       - name: cockroachdb
-        image: cockroachdb/cockroach:v22.2.3
+        image: cockroachdb/cockroach:v22.2.4
         imagePullPolicy: IfNotPresent
         # TODO: Change these to appropriate values for the hardware that you're running. You can see
         # the resources that can be allocated on each of your Kubernetes nodes by running:

--- a/cloud/kubernetes/multiregion/client-secure.yaml
+++ b/cloud/kubernetes/multiregion/client-secure.yaml
@@ -9,7 +9,7 @@ spec:
   serviceAccountName: cockroachdb
   containers:
   - name: cockroachdb-client
-    image: cockroachdb/cockroach:v22.2.3
+    image: cockroachdb/cockroach:v22.2.4
     imagePullPolicy: IfNotPresent
     volumeMounts:
     - name: client-certs

--- a/cloud/kubernetes/multiregion/cluster-init-secure.yaml
+++ b/cloud/kubernetes/multiregion/cluster-init-secure.yaml
@@ -11,7 +11,7 @@ spec:
       serviceAccountName: cockroachdb
       containers:
       - name: cluster-init
-        image: cockroachdb/cockroach:v22.2.3
+        image: cockroachdb/cockroach:v22.2.4
         imagePullPolicy: IfNotPresent
         volumeMounts:
         - name: client-certs

--- a/cloud/kubernetes/multiregion/cockroachdb-statefulset-secure.yaml
+++ b/cloud/kubernetes/multiregion/cockroachdb-statefulset-secure.yaml
@@ -167,7 +167,7 @@ spec:
               topologyKey: kubernetes.io/hostname
       containers:
       - name: cockroachdb
-        image: cockroachdb/cockroach:v22.2.3
+        image: cockroachdb/cockroach:v22.2.4
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 26257

--- a/cloud/kubernetes/multiregion/eks/cockroachdb-statefulset-secure-eks.yaml
+++ b/cloud/kubernetes/multiregion/eks/cockroachdb-statefulset-secure-eks.yaml
@@ -185,7 +185,7 @@ spec:
           name: cockroach-env
       containers:
       - name: cockroachdb
-        image: cockroachdb/cockroach:v22.2.3
+        image: cockroachdb/cockroach:v22.2.4
         imagePullPolicy: IfNotPresent
         # TODO: Change these to appropriate values for the hardware that you're running. You can see
         # the resources that can be allocated on each of your Kubernetes nodes by running:

--- a/cloud/kubernetes/performance/cockroachdb-daemonset-insecure.yaml
+++ b/cloud/kubernetes/performance/cockroachdb-daemonset-insecure.yaml
@@ -82,7 +82,7 @@ spec:
       hostNetwork: true
       containers:
       - name: cockroachdb
-        image: cockroachdb/cockroach:v22.2.3
+        image: cockroachdb/cockroach:v22.2.4
         imagePullPolicy: IfNotPresent
         # TODO: If you configured taints to give CockroachDB exclusive access to nodes, feel free
         # to remove the requests and limits sections. If you didn't, you'll need to change these to

--- a/cloud/kubernetes/performance/cockroachdb-daemonset-secure.yaml
+++ b/cloud/kubernetes/performance/cockroachdb-daemonset-secure.yaml
@@ -198,7 +198,7 @@ spec:
               topologyKey: kubernetes.io/hostname
       containers:
       - name: cockroachdb
-        image: cockroachdb/cockroach:v22.2.3
+        image: cockroachdb/cockroach:v22.2.4
         imagePullPolicy: IfNotPresent
         # TODO: If you configured taints to give CockroachDB exclusive access to nodes, feel free
         # to remove the requests and limits sections. If you didn't, you'll need to change these to

--- a/cloud/kubernetes/performance/cockroachdb-statefulset-insecure.yaml
+++ b/cloud/kubernetes/performance/cockroachdb-statefulset-insecure.yaml
@@ -141,7 +141,7 @@ spec:
       - name: cockroachdb
         # NOTE: Always use the most recent version of CockroachDB for the best
         # performance and reliability.
-        image: cockroachdb/cockroach:v22.2.3
+        image: cockroachdb/cockroach:v22.2.4
         imagePullPolicy: IfNotPresent
         # TODO: Change these to appropriate values for the hardware that you're running. You can see
         # the resources that can be allocated on each of your Kubernetes nodes by running:

--- a/cloud/kubernetes/performance/cockroachdb-statefulset-secure.yaml
+++ b/cloud/kubernetes/performance/cockroachdb-statefulset-secure.yaml
@@ -232,7 +232,7 @@ spec:
       - name: cockroachdb
         # NOTE: Always use the most recent version of CockroachDB for the best
         # performance and reliability.
-        image: cockroachdb/cockroach:v22.2.3
+        image: cockroachdb/cockroach:v22.2.4
         imagePullPolicy: IfNotPresent
         # TODO: Change these to appropriate values for the hardware that you're running. You can see
         # the resources that can be allocated on each of your Kubernetes nodes by running:

--- a/cloud/kubernetes/v1.6/client-secure.yaml
+++ b/cloud/kubernetes/v1.6/client-secure.yaml
@@ -32,7 +32,7 @@ spec:
       mountPath: /cockroach-certs
   containers:
   - name: cockroachdb-client
-    image: cockroachdb/cockroach:v22.2.3
+    image: cockroachdb/cockroach:v22.2.4
     imagePullPolicy: IfNotPresent
     volumeMounts:
     - name: client-certs

--- a/cloud/kubernetes/v1.6/cluster-init-secure.yaml
+++ b/cloud/kubernetes/v1.6/cluster-init-secure.yaml
@@ -34,7 +34,7 @@ spec:
           mountPath: /cockroach-certs
       containers:
       - name: cluster-init
-        image: cockroachdb/cockroach:v22.2.3
+        image: cockroachdb/cockroach:v22.2.4
         imagePullPolicy: IfNotPresent
         volumeMounts:
         - name: client-certs

--- a/cloud/kubernetes/v1.6/cluster-init.yaml
+++ b/cloud/kubernetes/v1.6/cluster-init.yaml
@@ -10,7 +10,7 @@ spec:
     spec:
       containers:
       - name: cluster-init
-        image: cockroachdb/cockroach:v22.2.3
+        image: cockroachdb/cockroach:v22.2.4
         imagePullPolicy: IfNotPresent
         command:
           - "/cockroach/cockroach"

--- a/cloud/kubernetes/v1.6/cockroachdb-statefulset-secure.yaml
+++ b/cloud/kubernetes/v1.6/cockroachdb-statefulset-secure.yaml
@@ -178,7 +178,7 @@ spec:
               topologyKey: kubernetes.io/hostname
       containers:
       - name: cockroachdb
-        image: cockroachdb/cockroach:v22.2.3
+        image: cockroachdb/cockroach:v22.2.4
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 26257

--- a/cloud/kubernetes/v1.6/cockroachdb-statefulset.yaml
+++ b/cloud/kubernetes/v1.6/cockroachdb-statefulset.yaml
@@ -81,7 +81,7 @@ spec:
               topologyKey: kubernetes.io/hostname
       containers:
       - name: cockroachdb
-        image: cockroachdb/cockroach:v22.2.3
+        image: cockroachdb/cockroach:v22.2.4
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 26257

--- a/cloud/kubernetes/v1.7/client-secure.yaml
+++ b/cloud/kubernetes/v1.7/client-secure.yaml
@@ -32,7 +32,7 @@ spec:
       mountPath: /cockroach-certs
   containers:
   - name: cockroachdb-client
-    image: cockroachdb/cockroach:v22.2.3
+    image: cockroachdb/cockroach:v22.2.4
     imagePullPolicy: IfNotPresent
     volumeMounts:
     - name: client-certs

--- a/cloud/kubernetes/v1.7/cluster-init-secure.yaml
+++ b/cloud/kubernetes/v1.7/cluster-init-secure.yaml
@@ -34,7 +34,7 @@ spec:
           mountPath: /cockroach-certs
       containers:
       - name: cluster-init
-        image: cockroachdb/cockroach:v22.2.3
+        image: cockroachdb/cockroach:v22.2.4
         imagePullPolicy: IfNotPresent
         volumeMounts:
         - name: client-certs

--- a/cloud/kubernetes/v1.7/cluster-init.yaml
+++ b/cloud/kubernetes/v1.7/cluster-init.yaml
@@ -10,7 +10,7 @@ spec:
     spec:
       containers:
       - name: cluster-init
-        image: cockroachdb/cockroach:v22.2.3
+        image: cockroachdb/cockroach:v22.2.4
         imagePullPolicy: IfNotPresent
         command:
           - "/cockroach/cockroach"

--- a/cloud/kubernetes/v1.7/cockroachdb-statefulset-secure.yaml
+++ b/cloud/kubernetes/v1.7/cockroachdb-statefulset-secure.yaml
@@ -190,7 +190,7 @@ spec:
               topologyKey: kubernetes.io/hostname
       containers:
       - name: cockroachdb
-        image: cockroachdb/cockroach:v22.2.3
+        image: cockroachdb/cockroach:v22.2.4
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 26257

--- a/cloud/kubernetes/v1.7/cockroachdb-statefulset.yaml
+++ b/cloud/kubernetes/v1.7/cockroachdb-statefulset.yaml
@@ -93,7 +93,7 @@ spec:
               topologyKey: kubernetes.io/hostname
       containers:
       - name: cockroachdb
-        image: cockroachdb/cockroach:v22.2.3
+        image: cockroachdb/cockroach:v22.2.4
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 26257


### PR DESCRIPTION
Update the Docker image tag version in our Kubernetes config files to v22.2.4.

Epic: None
Release note: None