### PR TITLE
release-22.2: fix unstable sort in SSTSink

### DIFF
--- a/pkg/ccl/backupccl/backup_test.go
+++ b/pkg/ccl/backupccl/backup_test.go
@@ -26,6 +26,7 @@ import (
 	"reflect"
 	"regexp"
 	"runtime/pprof"
+	"sort"
 	"strconv"
 	"strings"
 	"sync/atomic"
@@ -10512,4 +10513,141 @@ $$;
 	require.Equal(t, "1", rows[0][0])
 	require.NoError(t, err)
 
+}
+
+// TestExportRevisionsWithTimestampPagination is a regression test for a bug
+// where in the presence of several revisions of the same key, an unstable sort
+// in the backup processor's sstSink would result in out-of-order keys being
+// written to the in-memory Pebble file. This would result in a failed backup.
+func TestExportRevisionsWithTimestampPagination(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+	dir, dirCleanupFn := testutils.TempDir(t)
+	defer dirCleanupFn()
+	tc := testcluster.StartTestCluster(t, 1, base.TestClusterArgs{ServerArgs: base.TestServerArgs{
+		ExternalIODir: dir,
+	}})
+	defer tc.Stopper().Stop(ctx)
+
+	db := sqlutils.MakeSQLRunner(tc.Conns[0])
+	db.Exec(t, `CREATE TABLE foo (id) AS (SELECT 1)`)
+	// Generate a thousand revisions.
+	for i := 2; i < 1002; i++ {
+		db.Exec(t, `UPDATE foo SET id = $1`, i)
+	}
+	db.Exec(t, `SET CLUSTER SETTING kv.bulk_sst.max_allowed_overage = '19b'`)
+	db.Exec(t, `SET CLUSTER SETTING kv.bulk_sst.target_size = '1b'`)
+
+	// Each response is roughly 940bytes large. 845100b ensures that we have ~900
+	// revisions in our file buffer that we then sort before writing to the
+	// underlying SSTWriter. This configuration was sufficient to result in an
+	// unstable sort when the test was run under stress.
+	db.Exec(t, `SET CLUSTER SETTING bulkio.backup.merge_file_buffer_size = '845100b'`)
+	db.Exec(t, `BACKUP TABLE foo INTO 'nodelocal://1/foo' WITH revision_history`)
+}
+
+// TestSSTQueueSort is a unit test for the sort algorithm of the `sstQueue`
+// type.
+func TestSSTQueueSort(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	for _, tc := range []struct {
+		name  string
+		elems sstQueue
+	}{
+		{
+			"simple",
+			sstQueue{
+				{
+					f: backuppb.BackupManifest_File{
+						Span: roachpb.Span{Key: roachpb.Key("a"), EndKey: roachpb.Key("b")},
+					},
+				},
+				{
+					f: backuppb.BackupManifest_File{
+						Span: roachpb.Span{Key: roachpb.Key("c"), EndKey: roachpb.Key("d")},
+					},
+				},
+			},
+		},
+		{
+			"start-key-equal-end-key-unequal",
+			sstQueue{
+				{
+					f: backuppb.BackupManifest_File{
+						Span: roachpb.Span{Key: roachpb.Key("a"), EndKey: roachpb.Key("a")},
+					},
+				},
+				{
+					f: backuppb.BackupManifest_File{
+						Span: roachpb.Span{Key: roachpb.Key("a"), EndKey: roachpb.Key("b")},
+					},
+				},
+			},
+		},
+		{
+			"start-key-equal-end-key-equal-walltime",
+			sstQueue{
+				{
+					f: backuppb.BackupManifest_File{
+						Span: roachpb.Span{Key: roachpb.Key("a"), EndKey: roachpb.Key("a")},
+					},
+					endKeyTS: hlc.Timestamp{WallTime: 2, Logical: 1},
+				},
+				{
+					f: backuppb.BackupManifest_File{
+						Span: roachpb.Span{Key: roachpb.Key("a"), EndKey: roachpb.Key("a")},
+					},
+					endKeyTS: hlc.Timestamp{WallTime: 1, Logical: 7},
+				},
+			},
+		},
+		{
+			"start-key-equal-end-key-equal-logical",
+			sstQueue{
+				{
+					f: backuppb.BackupManifest_File{
+						Span: roachpb.Span{Key: roachpb.Key("a"), EndKey: roachpb.Key("a")},
+					},
+					endKeyTS: hlc.Timestamp{WallTime: 1, Logical: 7},
+				},
+				{
+					f: backuppb.BackupManifest_File{
+						Span: roachpb.Span{Key: roachpb.Key("a"), EndKey: roachpb.Key("a")},
+					},
+					endKeyTS: hlc.Timestamp{WallTime: 1, Logical: 1},
+				},
+			},
+		},
+		{
+			"start-key-equal-end-key-equal-empty-endkeyTS",
+			sstQueue{
+				{
+					f: backuppb.BackupManifest_File{
+						Span: roachpb.Span{Key: roachpb.Key("a"), EndKey: roachpb.Key("a")},
+					},
+					endKeyTS: hlc.Timestamp{WallTime: 1, Logical: 7},
+				},
+				{
+					f: backuppb.BackupManifest_File{
+						Span: roachpb.Span{Key: roachpb.Key("a"), EndKey: roachpb.Key("a")},
+					},
+				},
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var queue sstQueue
+			queue = append(queue, tc.elems...)
+			rand.Seed(timeutil.Now().UnixNano())
+			rand.Shuffle(len(queue), func(i, j int) {
+				queue[i], queue[j] = queue[j], queue[i]
+			})
+			sort.Sort(queue)
+			require.Equal(t, tc.elems, queue)
+		})
+	}
 }

--- a/pkg/ccl/backupccl/file_sst_sink.go
+++ b/pkg/ccl/backupccl/file_sst_sink.go
@@ -33,6 +33,50 @@ import (
 	"github.com/kr/pretty"
 )
 
+type sstQueue []returnedSST
+
+// Len implements the sort.Interface.
+func (s sstQueue) Len() int {
+	return len(s)
+}
+
+// Less implements the sort.Interface.
+func (s sstQueue) Less(i, j int) bool {
+	cmp := s[i].f.Span.Key.Compare(s[j].f.Span.Key)
+	// If two backup files have the same start key, it implies we have
+	// paginated in the middle of a key's revisions and those revisions
+	// straddle the file boundary. We must ensure that these files are sorted
+	// in decreasing order of the key's revision timestamps so that they are
+	// added in-order to the underlying SSTWriter.
+	if cmp == 0 {
+		// Since the start key of the files are equal we compare the EndKeys.
+		endKeyCmp := s[i].f.Span.EndKey.Compare(s[j].f.Span.EndKey)
+		// If the end keys are also equal, we know that both files only contain
+		// revisions of the same key, and so it is safe to sort in descending
+		// order of the timestamp of the last revision in each file.
+		if endKeyCmp == 0 {
+			return s[j].endKeyTS.Less(s[i].endKeyTS)
+		}
+		// Otherwise, we want to sort the files in increasing order of their
+		// EndKeys.
+		// This ensures that a queue such as
+		// `{[a@3, a@2, b@6] , [a@6, a@5, a@4]}`
+		// will have its files in an order that will write to the underlying
+		// SSTWriter in-order.
+		// `{[a@6, a@5, a@4], [a@3, a@2, b@6]}`
+		return endKeyCmp < 0
+	}
+
+	return cmp < 0
+}
+
+// Swap implements the sort.Interface.
+func (s sstQueue) Swap(i, j int) {
+	s[i], s[j] = s[j], s[i]
+}
+
+var _ sort.Interface = &sstQueue{}
+
 type sstSinkConf struct {
 	progCh   chan execinfrapb.RemoteProducerMetadata_BulkProcessorProgress
 	enc      *roachpb.FileEncryptionOptions
@@ -44,7 +88,7 @@ type fileSSTSink struct {
 	dest cloud.ExternalStorage
 	conf sstSinkConf
 
-	queue []exportedSpan
+	queue sstQueue
 	// queueCap is the maximum byte size that the queue can grow to.
 	queueCap int64
 	// queueSize is the current byte size of the queue.
@@ -128,24 +172,18 @@ func (s *fileSSTSink) Close() error {
 	return nil
 }
 
-func (s *fileSSTSink) sortQueue() {
-	sort.Slice(s.queue, func(i, j int) bool {
-		return s.queue[i].metadata.Span.Key.Compare(s.queue[j].metadata.Span.Key) < 0
-	})
-}
-
 // push pushes one returned backup file into the sink. Returned files can arrive
 // out of order, but must be written to an underlying file in-order or else a
 // new underlying file has to be opened. The queue allows buffering up files and
 // sorting them before pushing them to the underlying file to try to avoid this.
 // When the queue length or sum of the data sizes in it exceeds thresholds the
 // queue is sorted and the first half is flushed.
-func (s *fileSSTSink) push(ctx context.Context, resp exportedSpan) error {
+func (s *fileSSTSink) push(ctx context.Context, resp returnedSST) error {
 	s.queue = append(s.queue, resp)
 	s.queueSize += len(resp.dataSST)
 
 	if s.queueSize >= int(s.queueCap) {
-		s.sortQueue()
+		sort.Sort(s.queue)
 		// Drain the first half.
 		drain := len(s.queue) / 2
 		if drain < 1 {
@@ -166,7 +204,7 @@ func (s *fileSSTSink) push(ctx context.Context, resp exportedSpan) error {
 }
 
 func (s *fileSSTSink) flush(ctx context.Context) error {
-	s.sortQueue()
+	sort.Sort(s.queue)
 	for i := range s.queue {
 		if err := s.write(ctx, s.queue[i]); err != nil {
 			return err
@@ -239,10 +277,10 @@ func (s *fileSSTSink) open(ctx context.Context) error {
 	return nil
 }
 
-func (s *fileSSTSink) write(ctx context.Context, resp exportedSpan) error {
+func (s *fileSSTSink) write(ctx context.Context, resp returnedSST) error {
 	s.stats.files++
 
-	span := resp.metadata.Span
+	span := resp.f.Span
 
 	// If this span starts before the last buffered span ended, we need to flush
 	// since it overlaps but SSTWriter demands writes in-order.
@@ -284,13 +322,13 @@ func (s *fileSSTSink) write(ctx context.Context, resp exportedSpan) error {
 	// ended and has the same time-bounds -- then we can simply extend that span
 	// and add to its entry counts. Otherwise we need to record it separately.
 	if l := len(s.flushedFiles) - 1; l > 0 && s.flushedFiles[l].Span.EndKey.Equal(span.Key) &&
-		s.flushedFiles[l].EndTime.EqOrdering(resp.metadata.EndTime) &&
-		s.flushedFiles[l].StartTime.EqOrdering(resp.metadata.StartTime) {
+		s.flushedFiles[l].EndTime.EqOrdering(resp.f.EndTime) &&
+		s.flushedFiles[l].StartTime.EqOrdering(resp.f.StartTime) {
 		s.flushedFiles[l].Span.EndKey = span.EndKey
-		s.flushedFiles[l].EntryCounts.Add(resp.metadata.EntryCounts)
+		s.flushedFiles[l].EntryCounts.Add(resp.f.EntryCounts)
 		s.stats.spanGrows++
 	} else {
-		f := resp.metadata
+		f := resp.f
 		f.Path = s.outName
 		s.flushedFiles = append(s.flushedFiles, f)
 	}


### PR DESCRIPTION
This is a forward port of #95446.

The focus of this patch is fixing the unstable sort described in #95445. Previously, we would sort only on the basis of the start key of two backup files returned as part of an ExportResponse. This could result in older revisions of a key getting sorted and flushed to the underlying SSTWriter before new revisions, resulting in out-of-order writes, causing the backup to fail. We saw this in the support issue cockroachlabs/support#1998 and have a test TestExportRevisionsWithTimestampPagination that failed under stress.

To fix this unstable sort we now use the following algorithm:

Sort on start key of the backup files.
If start key is the same, sort on end key of the backup files. If end key is the same, sort in descending order on the end key timestamp of the files as both files are guaranteed to only contain revisions of the same key.

Fixes: #95445

Release note (bug fix): Fixes a bug where a backup of keys with many revisions would fail with "pebble: keys must be added in order".

Release justification: high impact bug fix to prevent failing backups