### PR TITLE
ui: add latency info to stmt pages

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/statementsTable/statementsTable.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsTable/statementsTable.tsx
@@ -20,8 +20,9 @@ import {
   TimestampToNumber,
   TimestampToMoment,
   unset,
+  DurationCheckSample,
 } from "src/util";
-import { DATE_FORMAT } from "src/util/format";
+import { DATE_FORMAT, Duration } from "src/util/format";
 import {
   countBarChart,
   bytesReadBarChart,
@@ -225,6 +226,49 @@ export function makeStatementsColumns(
       cell: cpuBar,
       sort: (stmt: AggregateStatistics) =>
         FixLong(Number(stmt.stats.exec_stats.cpu_sql_nanos?.mean)),
+    },
+    {
+      name: "latencyP50",
+      title: statisticsTableTitles.latencyP50(statType),
+      cell: (stmt: AggregateStatistics) =>
+        DurationCheckSample(stmt.stats.latency_info?.p50 * 1e9),
+      sort: (stmt: AggregateStatistics) =>
+        FixLong(Number(stmt.stats.latency_info?.p50)),
+      showByDefault: false,
+    },
+    {
+      name: "latencyP90",
+      title: statisticsTableTitles.latencyP90(statType),
+      cell: (stmt: AggregateStatistics) =>
+        DurationCheckSample(stmt.stats.latency_info?.p90 * 1e9),
+      sort: (stmt: AggregateStatistics) =>
+        FixLong(Number(stmt.stats.latency_info?.p90)),
+      showByDefault: false,
+    },
+    {
+      name: "latencyP99",
+      title: statisticsTableTitles.latencyP99(statType),
+      cell: (stmt: AggregateStatistics) =>
+        DurationCheckSample(stmt.stats.latency_info?.p99 * 1e9),
+      sort: (stmt: AggregateStatistics) =>
+        FixLong(Number(stmt.stats.latency_info?.p99)),
+    },
+    {
+      name: "latencyMin",
+      title: statisticsTableTitles.latencyMin(statType),
+      cell: (stmt: AggregateStatistics) =>
+        Duration(stmt.stats.latency_info?.min * 1e9),
+      sort: (stmt: AggregateStatistics) =>
+        FixLong(Number(stmt.stats.latency_info?.min)),
+      showByDefault: false,
+    },
+    {
+      name: "latencyMax",
+      title: statisticsTableTitles.latencyMax(statType),
+      cell: (stmt: AggregateStatistics) =>
+        Duration(stmt.stats.latency_info?.max * 1e9),
+      sort: (stmt: AggregateStatistics) =>
+        FixLong(Number(stmt.stats.latency_info?.max)),
     },
     {
       name: "maxMemUsage",

--- a/pkg/ui/workspaces/cluster-ui/src/statsTableUtil/statsTableUtil.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statsTableUtil/statsTableUtil.tsx
@@ -28,42 +28,47 @@ export type NodeNames = { [nodeId: string]: string };
 
 // Single place for column names. Used in table columns and in columns selector.
 export const statisticsColumnLabels = {
-  sessionStart: "Session Start Time (UTC)",
-  sessionDuration: "Session Duration",
-  sessionActiveDuration: "Session Active Duration",
-  sessionTxnCount: "Transaction Count",
-  mostRecentStatement: "Most Recent Statement",
-  status: "Status",
-  statementStartTime: "Statement Start Time (UTC)",
-  txnDuration: "Transaction Duration",
   actions: "Actions",
-  memUsage: "Memory Usage",
-  maxMemUsed: "Maximum Memory Usage",
-  numRetries: "Retries",
-  numStatements: "Statements Run",
-  clientAddress: "Client IP Address",
-  username: "User Name",
   applicationName: "Application Name",
   bytesRead: "Bytes Read",
+  clientAddress: "Client IP Address",
   contention: "Contention Time",
   cpu: "CPU Time",
   database: "Database",
   diagnostics: "Diagnostics",
   executionCount: "Execution Count",
+  lastExecTimestamp: "Last Execution Time (UTC)",
+  latencyMax: "Max Latency",
+  latencyMin: "Min Latency",
+  latencyP50: "P50 Latency",
+  latencyP90: "P90 Latency",
+  latencyP99: "P99 Latency",
   maxMemUsage: "Max Memory",
+  maxMemUsed: "Maximum Memory Usage",
+  memUsage: "Memory Usage",
+  mostRecentStatement: "Most Recent Statement",
   networkBytes: "Network",
+  numRetries: "Retries",
+  numStatements: "Statements Run",
   regions: "Regions",
   regionNodes: "Regions/Nodes",
   retries: "Retries",
   rowsProcessed: "Rows Processed",
+  sessionActiveDuration: "Session Active Duration",
+  sessionDuration: "Session Duration",
+  sessionStart: "Session Start Time (UTC)",
+  sessionTxnCount: "Transaction Count",
+  statementFingerprintId: "Statement Fingerprint ID",
+  statementStartTime: "Statement Start Time (UTC)",
   statements: "Statements",
   statementsCount: "Statements",
+  status: "Status",
   time: "Time",
-  transactions: "Transactions",
-  workloadPct: "% of All Runtime",
-  lastExecTimestamp: "Last Execution Time (UTC)",
-  statementFingerprintId: "Statement Fingerprint ID",
   transactionFingerprintId: "Transaction Fingerprint ID",
+  transactions: "Transactions",
+  txnDuration: "Transaction Duration",
+  username: "User Name",
+  workloadPct: "% of All Runtime",
 };
 
 export const contentModifiers = {
@@ -885,6 +890,136 @@ export const statisticsTableTitles: StatisticTableTitleType = {
         }
       >
         {getLabel("statementsCount")}
+      </Tooltip>
+    );
+  },
+  latencyMax: (statType: StatisticType) => {
+    let contentModifier = "";
+    switch (statType) {
+      case "transaction":
+        contentModifier = contentModifiers.transaction;
+        break;
+      case "statement":
+        contentModifier = contentModifiers.statement;
+        break;
+    }
+
+    return (
+      <Tooltip
+        placement="bottom"
+        style="tableTitle"
+        content={
+          <p>
+            The highest latency value in the sampled {contentModifier}
+            executions with this fingerprint.
+          </p>
+        }
+      >
+        {getLabel("latencyMax")}
+      </Tooltip>
+    );
+  },
+  latencyMin: (statType: StatisticType) => {
+    let contentModifier = "";
+    switch (statType) {
+      case "transaction":
+        contentModifier = contentModifiers.transaction;
+        break;
+      case "statement":
+        contentModifier = contentModifiers.statement;
+        break;
+    }
+
+    return (
+      <Tooltip
+        placement="bottom"
+        style="tableTitle"
+        content={
+          <p>
+            The lowest latency value in the sampled {contentModifier} executions
+            with this fingerprint.
+          </p>
+        }
+      >
+        {getLabel("latencyMin")}
+      </Tooltip>
+    );
+  },
+  latencyP50: (statType: StatisticType) => {
+    let contentModifier = "";
+    switch (statType) {
+      case "transaction":
+        contentModifier = contentModifiers.transaction;
+        break;
+      case "statement":
+        contentModifier = contentModifiers.statement;
+        break;
+    }
+
+    return (
+      <Tooltip
+        placement="bottom"
+        style="tableTitle"
+        content={
+          <p>
+            The 50th latency percentile for {contentModifier} executions with
+            this fingerprint.
+          </p>
+        }
+      >
+        {getLabel("latencyP50")}
+      </Tooltip>
+    );
+  },
+  latencyP90: (statType: StatisticType) => {
+    let contentModifier = "";
+    switch (statType) {
+      case "transaction":
+        contentModifier = contentModifiers.transaction;
+        break;
+      case "statement":
+        contentModifier = contentModifiers.statement;
+        break;
+    }
+
+    return (
+      <Tooltip
+        placement="bottom"
+        style="tableTitle"
+        content={
+          <p>
+            The 90th latency percentile for {contentModifier} executions with
+            this fingerprint.
+          </p>
+        }
+      >
+        {getLabel("latencyP90")}
+      </Tooltip>
+    );
+  },
+  latencyP99: (statType: StatisticType) => {
+    let contentModifier = "";
+    switch (statType) {
+      case "transaction":
+        contentModifier = contentModifiers.transaction;
+        break;
+      case "statement":
+        contentModifier = contentModifiers.statement;
+        break;
+    }
+
+    return (
+      <Tooltip
+        placement="bottom"
+        style="tableTitle"
+        content={
+          <p>
+            The 99th latency percentile for {contentModifier} executions with
+            this fingerprint.
+          </p>
+        }
+      >
+        {getLabel("latencyP99")}
       </Tooltip>
     );
   },

--- a/pkg/ui/workspaces/cluster-ui/src/util/format.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/util/format.ts
@@ -156,6 +156,19 @@ export function Duration(nanoseconds: number): string {
 }
 
 /**
+ * Duration creates a string representation for a duration. The expectation is
+ * that units are passed in nanoseconds; for larger durations, the value will
+ * be converted into larger units.
+ * If the value is 0, return "no samples".
+ */
+export function DurationCheckSample(nanoseconds: number): string {
+  if (nanoseconds == 0) {
+    return "no samples";
+  }
+  return Duration(nanoseconds);
+}
+
+/**
  * Cast nanoseconds to provided scale units
  */
 // tslint:disable-next-line: variable-name


### PR DESCRIPTION
Part Of: #72954

<img width="1373" alt="Screenshot 2023-02-13 at 5 53 57 PM" src="https://user-images.githubusercontent.com/1017486/218592825-922eed84-2559-4902-b291-852958a59ed6.png">

Add p50, p90, p99, max and min latency to
Statement table on SQL Activity page.

Release note (ui change): Add columns p50, p90, p99, max and min latency for Statement table on SQL Activity page.