### PR TITLE
cli: fix statement-bundle recreate for table names with quotes

### DIFF
--- a/pkg/cli/statement_bundle.go
+++ b/pkg/cli/statement_bundle.go
@@ -182,7 +182,8 @@ func runBundleRecreate(cmd *cobra.Command, args []string) (resErr error) {
 // $2: 1
 var placeholderRe = regexp.MustCompile(`\$(\d+): .*`)
 
-var statsRe = regexp.MustCompile(`ALTER TABLE ([\w.]+) INJECT STATISTICS '`)
+// The double quotes are needed for table names that are reserved keywords.
+var statsRe = regexp.MustCompile(`ALTER TABLE ([\w".]+) INJECT STATISTICS '`)
 
 type bucketKey struct {
 	NumEq         float64

--- a/pkg/cli/testdata/explain-bundle/bundle/schema.sql
+++ b/pkg/cli/testdata/explain-bundle/bundle/schema.sql
@@ -4,3 +4,7 @@ CREATE TABLE public.a (
 	CONSTRAINT "primary" PRIMARY KEY (a ASC),
 	FAMILY "primary" (a, b)
 );
+
+CREATE TABLE public."order" (
+    id INT8 PRIMARY KEY
+);

--- a/pkg/cli/testdata/explain-bundle/bundle/stats-defaultdb.public."order".sql
+++ b/pkg/cli/testdata/explain-bundle/bundle/stats-defaultdb.public."order".sql
@@ -1,0 +1,13 @@
+ALTER TABLE public."order" INJECT STATISTICS '[
+    {
+        "columns": [
+            "id"
+        ],
+        "created_at": "2021-06-23 21:17:16.83267",
+        "distinct_count": 0,
+        "histo_col_type": "INT8",
+        "name": "__auto__",
+        "null_count": 0,
+        "row_count": 0
+    }
+]';


### PR DESCRIPTION
If a table name uses a reserved keyword, then its name must be enclosed in double quotes. Previously, for such tables `debug statement-bundle recreate` command would fail since it wouldn't match the regex, and now it is fixed.

Epic: None

Release note: None