### PR TITLE
insights: remove unused proto import

### DIFF
--- a/pkg/sql/sqlstats/insights/BUILD.bazel
+++ b/pkg/sql/sqlstats/insights/BUILD.bazel
@@ -66,7 +66,6 @@ proto_library(
     strip_import_prefix = "/pkg",
     visibility = ["//visibility:public"],
     deps = [
-        "//pkg/roachpb:roachpb_proto",
         "@com_github_gogo_protobuf//gogoproto:gogo_proto",
         "@com_google_protobuf//:duration_proto",
         "@com_google_protobuf//:timestamp_proto",
@@ -80,7 +79,6 @@ go_proto_library(
     proto = ":insights_proto",
     visibility = ["//visibility:public"],
     deps = [
-        "//pkg/roachpb",
         "//pkg/util/uuid",  # keep
         "@com_github_gogo_protobuf//gogoproto",
     ],

--- a/pkg/sql/sqlstats/insights/insights.proto
+++ b/pkg/sql/sqlstats/insights/insights.proto
@@ -12,7 +12,6 @@ syntax = "proto3";
 package cockroach.sql.insights;
 option go_package = "insights";
 
-import "roachpb/api.proto";
 import "gogoproto/gogo.proto";
 import "google/protobuf/timestamp.proto";
 import "google/protobuf/duration.proto";


### PR DESCRIPTION
Just saw a warning when building with bazel about this, not sure though when `roachpb/api.proto` became unused here.

Epic: None

Release note: None