### PR TITLE
sql/sqlstats/persistedsqlstats: ignore flakey TestSQLStatsScheduleOperations

### DIFF
--- a/pkg/sql/sqlstats/persistedsqlstats/scheduled_sql_stats_compaction_test.go
+++ b/pkg/sql/sqlstats/persistedsqlstats/scheduled_sql_stats_compaction_test.go
@@ -170,6 +170,7 @@ func TestScheduledSQLStatsCompaction(t *testing.T) {
 }
 
 func TestSQLStatsScheduleOperations(t *testing.T) {
+	skip.WithIssue(t, 93601)
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	skip.UnderStressRace(t, "test is too slow to run under race")


### PR DESCRIPTION
Informs #93601

Epic: None

Release note: None