### PR TITLE
roachtest: fix fetching of debug zip and add dmesg flag

### DIFF
--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -1306,10 +1306,13 @@ func (c *clusterImpl) FetchDebugZip(ctx context.Context, l *logger.Logger) error
 			//
 			// Ignore the files in the the log directory; we pull the logs separately anyway
 			// so this would only cause duplication.
-			si := strconv.Itoa(i)
-			cmd := []string{"./cockroach", "debug", "zip", "--exclude-files='*.log,*.txt,*.pprof'", "--url", "{pgurl:" + si + "}", zipName}
-			if err := c.RunE(ctx, c.All(), cmd...); err != nil {
-				l.Printf("./cockroach debug zip failed: %v", err)
+			excludeFiles := "*.log,*.txt,*.pprof"
+			cmd := fmt.Sprintf(
+				"./cockroach debug zip --exclude-files='%s' --url {pgurl:%d} %s",
+				excludeFiles, i, zipName,
+			)
+			if err := c.RunE(ctx, c.Node(i), cmd); err != nil {
+				l.Printf("./cockroach debug zip failed on node %d: %v", i, err)
 				if i < c.spec.NodeCount {
 					continue
 				}

--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -1406,7 +1406,7 @@ func (c *clusterImpl) FetchDmesg(ctx context.Context, l *logger.Logger) error {
 		}
 
 		// Run dmesg on all nodes to redirect the kernel ring buffer content to a file.
-		cmd := []string{"/bin/bash", "-c", "'sudo dmesg > " + name + "'"}
+		cmd := []string{"/bin/bash", "-c", "'sudo dmesg -T > " + name + "'"}
 		var results []install.RunResultDetails
 		var combinedDmesgError error
 		if results, combinedDmesgError = c.RunWithDetails(ctx, nil, c.All(), cmd...); combinedDmesgError != nil {


### PR DESCRIPTION
**roachtest: fix fetching of debug zip**
The roachtest logic to fetch the debug zip after a failure iterates
over each node in the cluster spec for that test and attempts to run
the `debug zip` command, returning once it succeeds on any node. The
idea is that at that stage in the test, there's no way to know which
node is alive so every node is attempted.

However, the actual `Run` command executed used to use `c.All()`,
meaning that, in practice, it would fail if _any_ node failed to run
the `debug zip` command. One common scenario where this bug would come
to the surface is during tests that don't upload the `cockroach`
binary to every node, maybe because one of the nodes is there to run a
`./workload` command exclusively. In those cases, we would fail to
fetch the `debug.zip` just because the workload node didn't have the
cockroach binary (see #97100, for example).

This commit fixes the bug/typo by running the `./cockroach debug zip`
command on each node individually.

**roachtest: pass -T flag to dmesg**
By default, the timestamps displayed on the `dmesg` output are
relative to the kernel's boot time. This makes it harder to correlate
events in there with test events. This changes artifact collection to
run `dmesg -T` instead, which makes dmesg use human readable
timestamps.