### PR TITLE
ui: add change page controls in recent execs overview

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/statementsPage/recentStatementsView.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsPage/recentStatementsView.tsx
@@ -32,14 +32,15 @@ import {
   getFullFiltersAsStringRecord,
 } from "../queryFilter/filter";
 import { RecentStatementsSection } from "../recentExecutions/recentStatementsSection";
-import { inactiveFiltersState } from "../queryFilter/filter";
 import { queryByName, syncHistory } from "src/util/query";
 import { getTableSortFromURL } from "../sortedtable/getTableSortFromURL";
 import { getRecentStatementFiltersFromURL } from "src/queryFilter/utils";
+import { Pagination } from "src/pagination";
 
 import styles from "./statementsPage.module.scss";
 
 const cx = classNames.bind(styles);
+const PAGE_SIZE = 20;
 
 export type RecentStatementsViewDispatchProps = {
   onColumnsSelect: (columns: string[]) => void;
@@ -78,7 +79,7 @@ export const RecentStatementsView: React.FC<RecentStatementsViewProps> = ({
 }: RecentStatementsViewProps) => {
   const [pagination, setPagination] = useState<ISortedTablePagination>({
     current: 1,
-    pageSize: 20,
+    pageSize: PAGE_SIZE,
   });
   const history = useHistory();
   const [search, setSearch] = useState<string>(
@@ -135,8 +136,8 @@ export const RecentStatementsView: React.FC<RecentStatementsViewProps> = ({
 
   const resetPagination = () => {
     setPagination({
+      pageSize: PAGE_SIZE,
       current: 1,
-      pageSize: 20,
     });
   };
 
@@ -172,6 +173,13 @@ export const RecentStatementsView: React.FC<RecentStatementsViewProps> = ({
     internalAppNamePrefix,
     search,
   );
+
+  const onChangePage = (page: number) => {
+    setPagination({
+      ...pagination,
+      current: page,
+    });
+  };
 
   return (
     <div className={cx("root")}>
@@ -216,6 +224,12 @@ export const RecentStatementsView: React.FC<RecentStatementsViewProps> = ({
             onChangeSortSetting={onSortClick}
             onColumnsSelect={onColumnsSelect}
             isTenant={isTenant}
+          />
+          <Pagination
+            pageSize={pagination.pageSize}
+            current={pagination.current}
+            total={filteredStatements?.length}
+            onChange={onChangePage}
           />
         </Loading>
       </div>

--- a/pkg/ui/workspaces/cluster-ui/src/transactionsPage/recentTransactionsView.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionsPage/recentTransactionsView.tsx
@@ -32,6 +32,7 @@ import {
 import { getAppsFromRecentExecutions } from "../recentExecutions/recentStatementUtils";
 import { inactiveFiltersState } from "../queryFilter/filter";
 import { RecentTransactionsSection } from "src/recentExecutions/recentTransactionsSection";
+import { Pagination } from "src/pagination";
 
 import styles from "../statementsPage/statementsPage.module.scss";
 import { queryByName, syncHistory } from "src/util/query";
@@ -62,6 +63,7 @@ export type RecentTransactionsViewProps = RecentTransactionsViewStateProps &
   RecentTransactionsViewDispatchProps;
 
 const RECENT_TXN_SEARCH_PARAM = "q";
+const PAGE_SIZE = 20;
 
 export const RecentTransactionsView: React.FC<RecentTransactionsViewProps> = ({
   onColumnsSelect,
@@ -79,7 +81,7 @@ export const RecentTransactionsView: React.FC<RecentTransactionsViewProps> = ({
 }: RecentTransactionsViewProps) => {
   const [pagination, setPagination] = useState<ISortedTablePagination>({
     current: 1,
-    pageSize: 20,
+    pageSize: PAGE_SIZE,
   });
 
   const history = useHistory();
@@ -137,7 +139,7 @@ export const RecentTransactionsView: React.FC<RecentTransactionsViewProps> = ({
   const resetPagination = () => {
     setPagination({
       current: 1,
-      pageSize: 20,
+      pageSize: PAGE_SIZE,
     });
   };
 
@@ -173,6 +175,14 @@ export const RecentTransactionsView: React.FC<RecentTransactionsViewProps> = ({
     internalAppNamePrefix,
     search,
   );
+
+  const onChangePage = (page: number) => {
+    setPagination({
+      ...pagination,
+      current: page,
+    });
+  };
+
   return (
     <div className={cx("root")}>
       <PageConfig>
@@ -217,6 +227,12 @@ export const RecentTransactionsView: React.FC<RecentTransactionsViewProps> = ({
             onChangeSortSetting={onChangeSortSetting}
             onColumnsSelect={onColumnsSelect}
             isTenant={isTenant}
+          />
+          <Pagination
+            pageSize={pagination.pageSize}
+            current={pagination.current}
+            total={filteredTransactions?.length}
+            onChange={onChangePage}
           />
         </Loading>
       </div>


### PR DESCRIPTION
Previously, the recent exec overview pages did not have the necessary component to go the next page of the table when the page limit was reached. Page controls are now present in both recent stmt and txn pages.

Epic: none
Fixes: #95699

Release note (bug fix): Users can now go to the next page of results when there are >20 active stmts or txns in the active exec pages.

https://www.loom.com/share/5e5b54a3cc8e402ca8b53ab16e920bf0