### PR TITLE
cli: don't use multi-tenant demo for statement-bundle recreate

### DIFF
--- a/pkg/cli/statement_bundle.go
+++ b/pkg/cli/statement_bundle.go
@@ -124,6 +124,7 @@ func runBundleRecreate(cmd *cobra.Command, args []string) (resErr error) {
 	}
 
 	demoCtx.UseEmptyDatabase = true
+	demoCtx.Multitenant = false
 	return runDemoInternal(cmd, nil /* gen */, func(ctx context.Context, conn clisqlclient.Conn) error {
 		// Disable autostats collection, which will override the injected stats.
 		if err := conn.Exec(ctx,


### PR DESCRIPTION
I was just trying to recreate a stmt bundle using the latest master, and I got an unsupported error in multi-tenancy. It doesn't seem worth it to run `demo` for this in multi-tenant mode, so this commit turns that off.

Epic: None

Release note: None