### PR TITLE
sql/sqlstats/persistedsqlstats: fix flakey TestSQLStatsScheduleOperations

### DIFF
--- a/pkg/sql/sqlstats/persistedsqlstats/scheduled_sql_stats_compaction_test.go
+++ b/pkg/sql/sqlstats/persistedsqlstats/scheduled_sql_stats_compaction_test.go
@@ -228,6 +228,11 @@ func TestSQLStatsScheduleOperations(t *testing.T) {
 
 			helper.sqlDB.Exec(t, "RESET CLUSTER SETTING sql.stats.cleanup.recurrence")
 			helper.sqlDB.CheckQueryResultsRetry(t,
+				`SHOW CLUSTER SETTING sql.stats.cleanup.recurrence`,
+				[][]string{{"@hourly"}},
+			)
+
+			helper.sqlDB.CheckQueryResultsRetry(t,
 				fmt.Sprintf(`
 SELECT schedule_expr
 FROM system.scheduled_jobs WHERE schedule_id = %d`, schedID),


### PR DESCRIPTION
This fixes test failures that happen rarely during stress runs. The theory of what 
causes the failure is the following scenario.

1. Update the config to v1
2. Background monitor loops every 1 second in the test
3. Monitor sees the value is updated and runs `j.updateSchedule`.
4. After `j.updateSchedule` a new config value is set to v2
5. currentRecurrence is set to v2 even though job is set to v1
6. Monitor does not update because it thinks it's already set to v2

To fix this issue the config is read once and passed around to avoid any race 
condition. Additional checks were added to verify the setting was actually reset.

closes #93601

Epic: None

Release note: None