### PR TITLE
changefeedccl: set external connection test rate to 50%

### DIFF
--- a/pkg/ccl/changefeedccl/helpers_test.go
+++ b/pkg/ccl/changefeedccl/helpers_test.go
@@ -1012,8 +1012,7 @@ func maybeUseExternalConnection(
 ) cdctest.TestFeedFactory {
 	// percentExternal is the chance of randomly running a test using an `external://` uri.
 	// Set to 1 to always do this.
-	// TODO (zinger): Set this to 0.5 before merging.
-	const percentExternal = 1
+	const percentExternal = 0.5
 	if sinkType == `sinkless` || sinkType == `enterprise` || strings.Contains(flakyWhenExternalConnection, sinkType) ||
 		options.forceNoExternalConnectionURI || rand.Float32() > percentExternal {
 		return factory


### PR DESCRIPTION
We briefly had the metamorphic tests for external connections set to 100% external connections to catch any failing tests. It's now more valuable to make them actually metamorphic so we can prove that external connections don't change the behavior.

Epic: none

Release note: None