### PR TITLE
storage: include version in benchmark fixture directory

### DIFF
--- a/pkg/ccl/storageccl/engineccl/.gitignore
+++ b/pkg/ccl/storageccl/engineccl/.gitignore
@@ -1,3 +1,7 @@
 # Do not add environment-specific entries here (see the top-level .gitignore
 # for reasoning and alternatives).
+
+# Old benchmark data.
 mvcc_data
+# New benchmark data.
+mvcc_data_*

--- a/pkg/ccl/storageccl/engineccl/BUILD.bazel
+++ b/pkg/ccl/storageccl/engineccl/BUILD.bazel
@@ -43,6 +43,7 @@ go_test(
         "//pkg/base",
         "//pkg/ccl/baseccl",
         "//pkg/ccl/storageccl/engineccl/enginepbccl",
+        "//pkg/clusterversion",
         "//pkg/keys",
         "//pkg/roachpb",
         "//pkg/settings/cluster",

--- a/pkg/ccl/storageccl/engineccl/bench_test.go
+++ b/pkg/ccl/storageccl/engineccl/bench_test.go
@@ -16,6 +16,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
@@ -43,9 +44,12 @@ import (
 // The creation of the database is time consuming, so the caller can choose
 // whether to use a temporary or permanent location.
 func loadTestData(
-	dir string, numKeys, numBatches, batchTimeSpan, valueBytes int,
+	dirPrefix string, numKeys, numBatches, batchTimeSpan, valueBytes int,
 ) (storage.Engine, error) {
 	ctx := context.Background()
+
+	verStr := fmt.Sprintf("v%s", clusterversion.TestingBinaryVersion.String())
+	dir := fmt.Sprintf("%s_v%s_%d_%d_%d_%d", dirPrefix, verStr, numKeys, numBatches, batchTimeSpan, valueBytes)
 
 	exists := true
 	if _, err := os.Stat(dir); oserror.IsNotExist(err) {
@@ -60,12 +64,18 @@ func loadTestData(
 		return nil, err
 	}
 
+	absPath, err := filepath.Abs(dir)
+	if err != nil {
+		absPath = dir
+	}
+
 	if exists {
+		log.Infof(context.Background(), "using existing test data: %s", absPath)
 		testutils.ReadAllFiles(filepath.Join(dir, "*"))
 		return eng, nil
 	}
 
-	log.Infof(context.Background(), "creating test data: %s", dir)
+	log.Infof(context.Background(), "creating test data: %s", absPath)
 
 	// Generate the same data every time.
 	rng := rand.New(rand.NewSource(1449168817))

--- a/pkg/kv/kvserver/batcheval/cmd_refresh_range_bench_test.go
+++ b/pkg/kv/kvserver/batcheval/cmd_refresh_range_bench_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/batcheval"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
@@ -210,6 +211,9 @@ func setupMVCCPebble(b testing.TB, dir string, lBaseMaxBytes int64, readOnly boo
 func setupData(
 	ctx context.Context, b *testing.B, emk engineMaker, opts benchDataOptions,
 ) (storage.Engine, string) {
+	// Include the current version in the fixture name, or we may inadvertently
+	// run against a left-over fixture that is no longer supported.
+	verStr := fmt.Sprintf("v%s", clusterversion.TestingBinaryVersion.String())
 	orderStr := "linear"
 	if opts.randomKeyOrder {
 		orderStr = "random"
@@ -218,8 +222,9 @@ func setupData(
 	if opts.readOnlyEngine {
 		readOnlyStr = "_readonly"
 	}
-	loc := fmt.Sprintf("refresh_range_bench_data_%s%s_%d_%d_%d",
-		orderStr, readOnlyStr, opts.numKeys, opts.valueBytes, opts.lBaseMaxBytes)
+	loc := fmt.Sprintf("refresh_range_bench_data_%s_%s%s_%d_%d_%d",
+		verStr, orderStr, readOnlyStr, opts.numKeys, opts.valueBytes, opts.lBaseMaxBytes)
+
 	exists := true
 	if _, err := os.Stat(loc); oserror.IsNotExist(err) {
 		exists = false
@@ -227,13 +232,19 @@ func setupData(
 		b.Fatal(err)
 	}
 
+	absPath, err := filepath.Abs(loc)
+	if err != nil {
+		absPath = loc
+	}
+
 	if exists {
+		log.Infof(ctx, "using existing refresh range benchmark data: %s", absPath)
 		testutils.ReadAllFiles(filepath.Join(loc, "*"))
 		return emk(b, loc, opts.lBaseMaxBytes, opts.readOnlyEngine), loc
 	}
 
 	eng := emk(b, loc, opts.lBaseMaxBytes, false)
-	log.Infof(ctx, "creating refresh range benchmark data: %s", loc)
+	log.Infof(ctx, "creating refresh range benchmark data: %s", absPath)
 
 	// Generate the same data every time.
 	rng := rand.New(rand.NewSource(1449168817))

--- a/pkg/kv/kvserver/rangefeed/BUILD.bazel
+++ b/pkg/kv/kvserver/rangefeed/BUILD.bazel
@@ -55,6 +55,7 @@ go_test(
     embed = [":rangefeed"],
     deps = [
         "//pkg/base",
+        "//pkg/clusterversion",
         "//pkg/keys",
         "//pkg/roachpb",
         "//pkg/settings/cluster",

--- a/pkg/kv/kvserver/rangefeed/catchup_scan_bench_test.go
+++ b/pkg/kv/kvserver/rangefeed/catchup_scan_bench_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/rangefeed"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
@@ -229,6 +230,7 @@ func setupMVCCPebble(b testing.TB, dir string, lBaseMaxBytes int64, readOnly boo
 func setupData(
 	ctx context.Context, b *testing.B, emk engineMaker, opts benchDataOptions,
 ) (storage.Engine, string) {
+	verStr := fmt.Sprintf("v%s", clusterversion.TestingBinaryVersion.String())
 	orderStr := "linear"
 	if opts.randomKeyOrder {
 		orderStr = "random"
@@ -237,8 +239,8 @@ func setupData(
 	if opts.readOnlyEngine {
 		readOnlyStr = "_readonly"
 	}
-	loc := fmt.Sprintf("rangefeed_bench_data_%s%s_%d_%d_%d_%d",
-		orderStr, readOnlyStr, opts.numKeys, opts.valueBytes, opts.lBaseMaxBytes, opts.numRangeKeys)
+	loc := fmt.Sprintf("rangefeed_bench_data_%s_%s%s_%d_%d_%d_%d",
+		verStr, orderStr, readOnlyStr, opts.numKeys, opts.valueBytes, opts.lBaseMaxBytes, opts.numRangeKeys)
 	exists := true
 	if _, err := os.Stat(loc); oserror.IsNotExist(err) {
 		exists = false
@@ -246,13 +248,18 @@ func setupData(
 		b.Fatal(err)
 	}
 
+	absPath, err := filepath.Abs(loc)
+	if err != nil {
+		absPath = loc
+	}
 	if exists {
+		log.Infof(ctx, "using existing refresh range benchmark data: %s", absPath)
 		testutils.ReadAllFiles(filepath.Join(loc, "*"))
 		return emk(b, loc, opts.lBaseMaxBytes, opts.readOnlyEngine), loc
 	}
 
 	eng := emk(b, loc, opts.lBaseMaxBytes, false)
-	log.Infof(ctx, "creating rangefeed benchmark data: %s", loc)
+	log.Infof(ctx, "creating rangefeed benchmark data: %s", absPath)
 
 	// Generate the same data every time.
 	rng := rand.New(rand.NewSource(1449168817))

--- a/pkg/storage/open.go
+++ b/pkg/storage/open.go
@@ -167,14 +167,6 @@ func Hook(hookFunc func(*base.StorageConfig) error) ConfigOption {
 	}
 }
 
-// LatestReleaseFormatMajorVersion opens the database already upgraded to the
-// latest release's format major version.
-var LatestReleaseFormatMajorVersion ConfigOption = func(cfg *engineConfig) error {
-	// TODO(jackson): Tie the below to the mapping in SetMinVersion.
-	cfg.PebbleConfig.Opts.FormatMajorVersion = pebble.FormatPrePebblev1Marked // v22.2
-	return nil
-}
-
 // If enables the given option if enable is true.
 func If(enable bool, opt ConfigOption) ConfigOption {
 	if enable {


### PR DESCRIPTION
This benchmark is sometimes failing in CI and I cannot reproduce locally. The error is consistent with a leftover fixture from an older version (which shouldn't happen because CI should be cleaning up the repo).

This change adds the version to the fixture name so that this kind of cross-version problem cannot occur. This is a good idea regardless of the CI issue.

Informs #97061

Release note: None
Epic: none