### PR TITLE
bazci: protect against null output group

### DIFF
--- a/pkg/cmd/bazci/bazci.go
+++ b/pkg/cmd/bazci/bazci.go
@@ -247,7 +247,7 @@ func (s *monitorBuildServer) Finalize() error {
 	if s.action == "build" {
 		for _, target := range s.builtTargets {
 			for _, outputGroup := range target.OutputGroup {
-				if outputGroup.Incomplete {
+				if outputGroup == nil || outputGroup.Incomplete {
 					continue
 				}
 				for _, set := range outputGroup.FileSets {


### PR DESCRIPTION
Epic: none
Release note: None