### PR TITLE
ui: add error code to stmt and txn insights details pages

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/api/stmtInsightsApi.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/api/stmtInsightsApi.ts
@@ -22,6 +22,7 @@ import {
   ContentionDetails,
   getInsightsFromProblemsAndCauses,
   InsightExecEnum,
+  StatementStatus,
   StmtInsightEvent,
 } from "src/insights";
 import moment from "moment";
@@ -63,6 +64,8 @@ export type StmtInsightsResponseRow = {
   index_recommendations: string[];
   plan_gist: string;
   cpu_sql_nanos: number;
+  error_code: string;
+  status: StatementStatus;
 };
 
 const stmtColumns = `
@@ -90,7 +93,9 @@ causes,
 problem,
 index_recommendations,
 plan_gist,
-cpu_sql_nanos
+cpu_sql_nanos,
+error_code,
+status
 `;
 
 const stmtInsightsOverviewQuery = (filters?: StmtInsightsReq): string => {
@@ -232,6 +237,8 @@ export function formatStmtInsights(
       ),
       planGist: row.plan_gist,
       cpuSQLNanos: row.cpu_sql_nanos,
+      errorCode: row.error_code,
+      status: row.status,
     } as StmtInsightEvent;
   });
 }

--- a/pkg/ui/workspaces/cluster-ui/src/api/txnInsightsApi.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/api/txnInsightsApi.ts
@@ -26,6 +26,7 @@ import {
   getInsightsFromProblemsAndCauses,
   InsightExecEnum,
   InsightNameEnum,
+  TransactionStatus,
   TxnContentionInsightDetails,
   TxnInsightDetails,
   TxnInsightEvent,
@@ -293,6 +294,8 @@ type TxnInsightsResponseRow = {
   causes: string[];
   stmt_execution_ids: string[];
   cpu_sql_nanos: number;
+  last_error_code: string;
+  status: TransactionStatus;
 };
 
 type TxnQueryFilters = {
@@ -326,7 +329,9 @@ last_retry_reason,
 problems,
 causes,
 stmt_execution_ids,
-cpu_sql_nanos`;
+cpu_sql_nanos,
+last_error_code,
+status`;
 
   if (filters?.execID) {
     return `
@@ -394,6 +399,8 @@ function formatTxnInsightsRow(row: TxnInsightsResponseRow): TxnInsightEvent {
     insights,
     stmtExecutionIDs: row.stmt_execution_ids,
     cpuSQLNanos: row.cpu_sql_nanos,
+    errorCode: row.last_error_code,
+    status: row.status,
   };
 }
 

--- a/pkg/ui/workspaces/cluster-ui/src/insights/types.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/types.ts
@@ -26,6 +26,18 @@ export enum InsightExecEnum {
   STATEMENT = "statement",
 }
 
+export enum StatementStatus {
+  COMPLETED = "Completed",
+  FAILED = "Failed",
+}
+
+export enum TransactionStatus {
+  COMPLETED = "Completed",
+  FAILED = "Failed",
+  // Unimplemented, see https://github.com/cockroachdb/cockroach/issues/98219/.
+  CANCELLED = "Cancelled",
+}
+
 // Common fields for both txn and stmt insights.
 export type InsightEventBase = {
   application: string;
@@ -46,9 +58,11 @@ export type InsightEventBase = {
   transactionExecutionID: string;
   transactionFingerprintID: string;
   username: string;
+  errorCode: string;
 };
 
 export type TxnInsightEvent = InsightEventBase & {
+  status: TransactionStatus;
   stmtExecutionIDs: string[];
 };
 
@@ -99,6 +113,7 @@ export type StmtInsightEvent = InsightEventBase & {
   planGist: string;
   databaseName: string;
   execType?: InsightExecEnum;
+  status: StatementStatus;
 };
 
 export type Insight = {
@@ -327,6 +342,8 @@ export interface ExecutionDetails {
   statementExecutionID?: string;
   transactionExecutionID?: string;
   execType?: InsightExecEnum;
+  errorCode?: string;
+  status?: string;
 }
 
 export interface insightDetails {

--- a/pkg/ui/workspaces/cluster-ui/src/insights/utils.spec.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/utils.spec.ts
@@ -26,8 +26,10 @@ import {
   InsightNameEnum,
   planRegressionInsight,
   slowExecutionInsight,
+  StatementStatus,
   StmtInsightEvent,
   suboptimalPlanInsight,
+  TransactionStatus,
   TxnInsightDetails,
   TxnInsightEvent,
 } from "./types";
@@ -76,6 +78,8 @@ const statementInsightMock: StmtInsightEvent = {
   indexRecommendations: [],
   planGist: "gist",
   cpuSQLNanos: 50,
+  errorCode: "",
+  status: StatementStatus.COMPLETED,
 };
 
 function mockStmtInsightEvent(
@@ -116,6 +120,8 @@ const txnInsightEventMock: TxnInsightEvent = {
   elapsedTimeMillis: 1,
   stmtExecutionIDs: [statementInsightMock.statementExecutionID],
   cpuSQLNanos: 50,
+  errorCode: "",
+  status: TransactionStatus.COMPLETED,
 };
 
 function mockTxnInsightEvent(

--- a/pkg/ui/workspaces/cluster-ui/src/insights/utils.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/utils.ts
@@ -392,6 +392,8 @@ export function getStmtInsightRecommendations(
     statementExecutionID: insightDetails.statementExecutionID,
     transactionExecutionID: insightDetails.transactionExecutionID,
     execType: InsightExecEnum.STATEMENT,
+    errorCode: insightDetails.errorCode,
+    status: insightDetails.status,
   };
 
   const recs: InsightRecommendation[] = insightDetails.insights?.map(insight =>
@@ -412,6 +414,7 @@ export function getTxnInsightRecommendations(
     contentionTimeMs: insightDetails.contentionTime.asMilliseconds(),
     elapsedTimeMillis: insightDetails.elapsedTimeMillis,
     execType: InsightExecEnum.TRANSACTION,
+    errorCode: insightDetails.errorCode,
   };
   const recs: InsightRecommendation[] = [];
 

--- a/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsights/statementInsights/statementInsightsTable.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsights/statementInsights/statementInsightsTable.tsx
@@ -22,7 +22,11 @@ import {
   limitText,
   NO_SAMPLES_FOUND,
 } from "src/util";
-import { InsightExecEnum, StmtInsightEvent } from "src/insights";
+import {
+  InsightExecEnum,
+  StatementStatus,
+  StmtInsightEvent,
+} from "src/insights";
 import {
   InsightCell,
   insightsTableTitles,
@@ -33,8 +37,20 @@ import { Link } from "react-router-dom";
 import classNames from "classnames/bind";
 import styles from "../util/workloadInsights.module.scss";
 import { TimeScale } from "../../../timeScaleDropdown";
+import { Badge } from "src/badge";
 
 const cx = classNames.bind(styles);
+
+function stmtStatusToString(status: StatementStatus) {
+  switch (status) {
+    case StatementStatus.COMPLETED:
+      return "success";
+    case StatementStatus.FAILED:
+      return "danger";
+    default:
+      return "info";
+  }
+}
 
 interface StatementInsightsTable {
   data: StmtInsightEvent[];
@@ -75,6 +91,15 @@ export function makeStatementInsightsColumns(): ColumnDescriptor<StmtInsightEven
         </Tooltip>
       ),
       sort: (item: StmtInsightEvent) => item.query,
+      showByDefault: true,
+    },
+    {
+      name: "status",
+      title: insightsTableTitles.status(execType),
+      cell: (item: StmtInsightEvent) => (
+        <Badge text={item.status} status={stmtStatusToString(item.status)} />
+      ),
+      sort: (item: StmtInsightEvent) => item.status,
       showByDefault: true,
     },
     {

--- a/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsights/transactionInsights/transactionInsightsTable.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsights/transactionInsights/transactionInsightsTable.tsx
@@ -16,7 +16,11 @@ import {
   SortSetting,
 } from "src/sortedtable";
 import { DATE_WITH_SECONDS_AND_MILLISECONDS_FORMAT, Duration } from "src/util";
-import { InsightExecEnum, TxnInsightEvent } from "src/insights";
+import {
+  InsightExecEnum,
+  TransactionStatus,
+  TxnInsightEvent,
+} from "src/insights";
 import {
   InsightCell,
   insightsTableTitles,
@@ -25,6 +29,18 @@ import {
 } from "../util";
 import { Link } from "react-router-dom";
 import { TimeScale } from "../../../timeScaleDropdown";
+import { Badge } from "src/badge";
+
+function txnStatusToString(status: TransactionStatus) {
+  switch (status) {
+    case TransactionStatus.COMPLETED:
+      return "success";
+    case TransactionStatus.FAILED:
+      return "danger";
+    case TransactionStatus.CANCELLED:
+      return "info";
+  }
+}
 
 interface TransactionInsightsTable {
   data: TxnInsightEvent[];
@@ -59,6 +75,15 @@ export function makeTransactionInsightsColumns(): ColumnDescriptor<TxnInsightEve
       title: insightsTableTitles.query(execType),
       cell: item => QueriesCell([item.query], 50),
       sort: item => item.query,
+    },
+    {
+      name: "status",
+      title: insightsTableTitles.status(execType),
+      cell: item => (
+        <Badge text={item.status} status={txnStatusToString(item.status)} />
+      ),
+      sort: item => item.status,
+      showByDefault: true,
     },
     {
       name: "insights",

--- a/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsights/util/insightsColumns.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsights/util/insightsColumns.tsx
@@ -21,6 +21,7 @@ export const insightsColumnLabels = {
   waitingID: "Waiting Execution ID",
   waitingFingerprintID: "Waiting Fingerprint ID",
   query: "Execution",
+  status: "Status",
   insights: "Insights",
   startTime: "Start Time (UTC)",
   elapsedTime: "Elapsed Time",
@@ -122,6 +123,10 @@ export const insightsTableTitles: InsightsTableTitleType = {
       tooltipText = "The queries attempted in the transaction.";
     }
     return makeToolTip(<p>{tooltipText}</p>, "query", execType);
+  },
+  status: (execType: InsightExecEnum) => {
+    const tooltipText = `The ${execType} status`;
+    return makeToolTip(<p>{tooltipText}</p>, "status");
   },
   insights: (execType: InsightExecEnum) => {
     return makeToolTip(

--- a/pkg/ui/workspaces/cluster-ui/src/insightsTable/insightsTable.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/insightsTable/insightsTable.module.scss
@@ -5,6 +5,11 @@
   font-weight: $font-weight--bold;
 }
 
+.insights-type-failed {
+  color: $colors--functional-red-4;
+  font-weight: $font-weight--bold;
+}
+
 .label-bold {
   font-family: $font-family--semi-bold;
   font-size: $font-size--medium;

--- a/pkg/ui/workspaces/cluster-ui/src/insightsTable/insightsTable.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insightsTable/insightsTable.tsx
@@ -31,6 +31,7 @@ import { Link } from "react-router-dom";
 import {
   InsightExecEnum,
   InsightRecommendation,
+  InsightType,
   insightType,
 } from "../insights";
 
@@ -93,8 +94,12 @@ export const insightsTableTitles: InsightsTableTitleType = {
   },
 };
 
-function typeCell(value: string): React.ReactElement {
-  return <div className={cx("insight-type")}>{value}</div>;
+function TypeCell(value: InsightType): React.ReactElement {
+  const className =
+    insightType(value) === "FailedExecution"
+      ? "insight-type-failed"
+      : "insight-type";
+  return <div className={cx(className)}>{value}</div>;
 }
 
 const StatementExecution = ({
@@ -276,7 +281,8 @@ function descriptionCell(
       return (
         <>
           <div className={cx("description-item")}>
-            This execution has failed.
+            <span className={cx("label-bold")}>Error Code: </span>{" "}
+            {insightRec.execution.errorCode}
           </div>
         </>
       );
@@ -409,7 +415,7 @@ export function makeInsightsColumns(
     {
       name: "insights",
       title: insightsTableTitles.insights(),
-      cell: (item: InsightRecommendation) => typeCell(insightType(item.type)),
+      cell: (item: InsightRecommendation) => TypeCell(item.type),
       sort: (item: InsightRecommendation) => item.type,
     },
     {


### PR DESCRIPTION
Part of: #87785.

Previously, the stmt and txn insights details pages did not show any
further information for failed executions. This commit adds an "error
code" column to the insights table for a failed execution in the stmt
and txn insights details pages. Additionally, a "status" column was
added to the stmt and txn workload insights tables which is either
"Completed" or "Failed".

Future work involves adding the error message string in addition to the
error code but it needs to be redacted first. Additionally, the txn
status is missing the implementation of a "Cancelled" status.

Note to reviewers: only consider the second commit, as the first is 
required to get the txn status.

- Loom [demo](https://www.loom.com/share/e82b97ff9f034d82b98640170eb54408).

Release note (ui change): Adds error code column to the insights table
for a failed execution in the stmt and txn insights details page. Adds
status column to the stmt and txn workload insights tables.