### PR TITLE
allocator: replace read amp with io thresh

### DIFF
--- a/pkg/kv/kvserver/allocator/allocatorimpl/BUILD.bazel
+++ b/pkg/kv/kvserver/allocator/allocatorimpl/BUILD.bazel
@@ -22,6 +22,7 @@ go_library(
         "//pkg/roachpb",
         "//pkg/settings",
         "//pkg/settings/cluster",
+        "//pkg/util/admission/admissionpb",
         "//pkg/util/log",
         "//pkg/util/metric",
         "//pkg/util/stop",

--- a/pkg/kv/kvserver/allocator/allocatorimpl/allocator.go
+++ b/pkg/kv/kvserver/allocator/allocatorimpl/allocator.go
@@ -2085,16 +2085,16 @@ func (a *Allocator) leaseholderShouldMoveDueToPreferences(
 }
 
 // StoreHealthOptions returns the store health options, currently only
-// considering the threshold for L0 sub-levels. This threshold is not
+// considering the threshold for io overload. This threshold is not
 // considered in allocation or rebalancing decisions (excluding candidate
 // stores as targets) when enforcementLevel is set to storeHealthNoAction or
 // storeHealthLogOnly. By default storeHealthBlockRebalanceTo is the action taken. When
 // there is a mixed version cluster, storeHealthNoAction is set instead.
 func (a *Allocator) StoreHealthOptions(_ context.Context) StoreHealthOptions {
-	enforcementLevel := StoreHealthEnforcement(l0SublevelsThresholdEnforce.Get(&a.st.SV))
+	enforcementLevel := IOOverloadEnforcementLevel(IOOverloadThresholdEnforcement.Get(&a.st.SV))
 	return StoreHealthOptions{
 		EnforcementLevel:    enforcementLevel,
-		L0SublevelThreshold: l0SublevelsThreshold.Get(&a.st.SV),
+		IOOverloadThreshold: IOOverloadThreshold.Get(&a.st.SV),
 	}
 }
 

--- a/pkg/kv/kvserver/allocator/allocatorimpl/allocator_scorer.go
+++ b/pkg/kv/kvserver/allocator/allocatorimpl/allocator_scorer.go
@@ -24,6 +24,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/constraint"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings"
+	"github.com/cockroachdb/cockroach/pkg/util/admission/admissionpb"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 )
 
@@ -70,49 +71,44 @@ const (
 	// away from the mean.
 	minRangeRebalanceThreshold = 2
 
-	// MaxL0SublevelThreshold is the number of L0 sub-levels of a store
-	// descriptor, that when greater than this value and in excees of the
-	// average L0 sub-levels in the cluster - will have the action defined by
-	// l0SublevelsThresholdEnforce taken. This value does not affect the
-	// allocator in deciding to remove replicas from it's store, only
-	// potentially block adding or moving replicas to other stores.
-	MaxL0SublevelThreshold = 20
+	// DefaultIOOverloadThreshold is used to avoid allocating to stores with an
+	// IO overload score greater than what's set. This is typically used in
+	// conjunction with IOOverloadMeanThreshold below.
+	DefaultIOOverloadThreshold = 0.8
 
-	// L0SublevelInterval is the period over which to accumulate statistics on
-	// the number of L0 sublevels within a store.
-	L0SublevelInterval = time.Minute * 2
+	// IOOverloadMeanThreshold is the percentage above the mean after which a
+	// store could be conisdered unhealthy if also exceeding the threshold.
+	IOOverloadMeanThreshold = 1.1
 
-	// L0SublevelMaxSampled is maximum number of L0 sub-levels that may exist
-	// in a sample. This setting limits the extreme skew that could occur by
-	// capping the highest possible value considered.
-	L0SublevelMaxSampled = 500
-
-	// l0SubLevelWaterMark is the percentage above the mean after which a store
-	// could be conisdered unhealthy if also exceeding the threshold.
-	l0SubLevelWaterMark = 1.10
+	// L0SublevelTrackerRetention is the tracking period for statistics on the
+	// number of L0 sublevels within a store. The L0-sublevels are tracked by
+	// taking the maximum over this retention period.
+	L0SublevelTrackerRetention = time.Minute * 10
 )
 
-// StoreHealthEnforcement represents the level of action that may be taken or
+// IOOverloadEnforcementLevel represents the level of action that may be taken or
 // excluded when a candidate disk is considered unhealthy.
-type StoreHealthEnforcement int64
+type IOOverloadEnforcementLevel int64
 
 const (
-	// StoreHealthNoAction will take no action upon candidate stores when they
-	// exceed l0SublevelThreshold.
-	StoreHealthNoAction StoreHealthEnforcement = iota
-	// StoreHealthLogOnly will take no action upon candidate stores when they
-	// exceed l0SublevelThreshold except log an event.
-	StoreHealthLogOnly
-	// StoreHealthBlockRebalanceTo will take action to exclude candidate stores
-	// when they exceed l0SublevelThreshold and mean from being considered
-	// targets for rebalance actions only. Allocation actions such as adding
-	// upreplicaing an range will not be affected.
-	StoreHealthBlockRebalanceTo
-	// StoreHealthBlockAll will take action to exclude candidate stores when
-	// they exceed l0SublevelThreshold and mean from being candidates for all
-	// replica allocation and rebalancing. When enabled and stores exceed the
-	// threshold, they will not receive any new replicas.
-	StoreHealthBlockAll
+	// IOOverloadThresholdNoAction wil not exclude stores from being considered
+	// as targets for any action regardless of the store IO overload.
+	IOOverloadThresholdNoAction IOOverloadEnforcementLevel = iota
+	// IOOverloadThresholdLogOnly will not exclude stores from being considered
+	// as targets for any action regarldess of the store IO overload. When a
+	// store exceeds IOOverloadThreshold, an event is logged.
+	IOOverloadThresholdLogOnly
+	// IOOverloadThresholdBlockRebalanceTo excludes stores from being being
+	// considered as targets for rebalance actions if they exceed (a)
+	// kv.allocator.io_overload_threshold and (b) the mean IO overload among
+	// possible candidates. This does not affect upreplication.
+	IOOverloadThresholdBlockRebalanceTo
+	// IOOverloadThresholdBlockAll excludes stores from being considered as a
+	// target for allocation and rebalancing actions if they exceed (a)
+	// kv.allocator.io_overload_threshold and (b) the mean IO overload among
+	// possible candidates. In other words, the store will receive no new
+	// replicas.
+	IOOverloadThresholdBlockAll
 )
 
 // RangeRebalanceThreshold is the minimum ratio of a store's range count to
@@ -122,7 +118,8 @@ var RangeRebalanceThreshold = func() *settings.FloatSetting {
 	s := settings.RegisterFloatSetting(
 		settings.SystemOnly,
 		"kv.allocator.range_rebalance_threshold",
-		"minimum fraction away from the mean a store's range count can be before it is considered overfull or underfull",
+		"minimum fraction away from the mean a store's range count can be before "+
+			"it is considered overfull or underfull",
 		0.05,
 		settings.NonNegativeFloat,
 	)
@@ -130,52 +127,43 @@ var RangeRebalanceThreshold = func() *settings.FloatSetting {
 	return s
 }()
 
-// l0SublevelsThreshold is the maximum number of sub-levels within level 0 that
-// may exist on candidate store descriptors before they are considered
-// unhealthy. Once considered unhealthy, the action taken will be dictated by
-// l0SublevelsThresholdEnforce cluster setting defined below. The rationale for
-// using L0 sub-levels as opposed to read amplification is that it is more
-// generally the variable component that makes up read amplification. When
-// L0 sub-levels is high, it is an indicator of poor LSM health as L0 is usually
-// in memory and must be first visited before traversing any further level. See
-// this issue for additional information:
-// https://github.com/cockroachdb/pebble/issues/609
-var l0SublevelsThreshold = settings.RegisterIntSetting(
+// IOOverloadThreshold is the maximum IO overload score of a candidate store
+// before being considered unhealthy. Once considered unhealthy, the action
+// taken will be dictated by IOOverloadThresholdEnforcement cluster setting
+// defined below.
+var IOOverloadThreshold = settings.RegisterFloatSetting(
 	settings.SystemOnly,
-	"kv.allocator.l0_sublevels_threshold",
-	"the maximum number of l0 sublevels within a store that may exist "+
-		"before the action defined in "+
-		"`kv.allocator.l0_sublevels_threshold_enforce` will be taken "+
-		"if also exceeding the cluster average",
-	MaxL0SublevelThreshold,
+	"kv.allocator.io_overload_threshold",
+	"the maximum store io overload before the enforcement defined by "+
+		"`kv.allocator.io_overload_threshold_enforce` is taken on a store "+
+		"for allocation decisions",
+	DefaultIOOverloadThreshold,
 )
 
-// l0SublevelsThresholdEnforce is the level of enforcement taken upon candidate
-// stores when their L0-sublevels exceeds the threshold defined in
-// l0SublevelThreshold. Under disabled and log enforcement, no action is taken
-// to exclude the candidate store either as a potential allocation nor
-// rebalance target by the replicate queue and store rebalancer. When the
-// enforcement level is rebalance, candidate stores will be excluded as targets
-// for rebalancing when exceeding the threshold, however will remain candidates
-// for allocation of voters and non-voters.  When allocate is set, candidates
-// are excluded as targets for all rebalancing and also allocation of voters
-// and non-voters.
-var l0SublevelsThresholdEnforce = settings.RegisterEnumSetting(
+// IOOverloadThresholdEnforcement defines the level of enforcement when a candidate
+// stores' IO overload exceeds the threshold defined in IOOverloadThresold. No
+// action is taken when block_none and block_none_log are set. Rebalancing
+// towards the candidate store is blocked when block_rebalance_to is set.
+// Allocating and rebalancing towards the candidate store is blocked when
+// block_all is set.
+// NB: No matter the value of this setting, IOOverload will never cause
+// rebalancing away from a store (shedding), only block the store from being a target.
+var IOOverloadThresholdEnforcement = settings.RegisterEnumSetting(
 	settings.SystemOnly,
-	"kv.allocator.l0_sublevels_threshold_enforce",
-	"the level of enforcement when a candidate disk has L0 sub-levels "+
-		"exceeding `kv.allocator.l0_sublevels_threshold` and above the "+
-		"cluster average:`block_none` will exclude "+
+	"kv.allocator.io_overload_threshold_enforcement",
+	"the level of enforcement when a candidate store has an io overload score  "+
+		"exceeding `kv.allocator.io_overload_threshold` and above the "+
+		"average of comparable allocation candidates:`block_none` will exclude "+
 		"no candidate stores, `block_none_log` will exclude no candidates but log an "+
 		"event, `block_rebalance_to` will exclude candidates stores from being "+
 		"targets of rebalance actions, `block_all` will exclude candidate stores "+
 		"from being targets of both allocation and rebalancing",
 	"block_rebalance_to",
 	map[int64]string{
-		int64(StoreHealthNoAction):         "block_none",
-		int64(StoreHealthLogOnly):          "block_none_log",
-		int64(StoreHealthBlockRebalanceTo): "block_rebalance_to",
-		int64(StoreHealthBlockAll):         "block_all",
+		int64(IOOverloadThresholdNoAction):         "block_none",
+		int64(IOOverloadThresholdLogOnly):          "block_none_log",
+		int64(IOOverloadThresholdBlockRebalanceTo): "block_rebalance_to",
+		int64(IOOverloadThresholdBlockAll):         "block_all",
 	},
 )
 
@@ -571,24 +559,24 @@ func (o *LoadScorerOptions) removalMaximallyConvergesScore(
 
 // candidate store for allocation. These are ordered by importance.
 type candidate struct {
-	store          roachpb.StoreDescriptor
-	valid          bool
-	fullDisk       bool
-	necessary      bool
-	diversityScore float64
-	highReadAmp    bool
-	l0SubLevels    int
-	convergesScore int
-	balanceScore   balanceStatus
-	hasNonVoter    bool
-	rangeCount     int
-	details        string
+	store           roachpb.StoreDescriptor
+	valid           bool
+	fullDisk        bool
+	necessary       bool
+	diversityScore  float64
+	ioOverloaded    bool
+	ioOverloadScore float64
+	convergesScore  int
+	balanceScore    balanceStatus
+	hasNonVoter     bool
+	rangeCount      int
+	details         string
 }
 
 func (c candidate) String() string {
-	str := fmt.Sprintf("s%d, valid:%t, fulldisk:%t, necessary:%t, diversity:%.2f, highReadAmp: %t, l0SubLevels: %d, converges:%d, "+
+	str := fmt.Sprintf("s%d, valid:%t, fulldisk:%t, necessary:%t, diversity:%.2f, ioOverloaded: %t, ioOverload: %.2f, converges:%d, "+
 		"balance:%d, hasNonVoter:%t, rangeCount:%d, queriesPerSecond:%.2f",
-		c.store.StoreID, c.valid, c.fullDisk, c.necessary, c.diversityScore, c.highReadAmp, c.l0SubLevels, c.convergesScore,
+		c.store.StoreID, c.valid, c.fullDisk, c.necessary, c.diversityScore, c.ioOverloaded, c.ioOverloadScore, c.convergesScore,
 		c.balanceScore, c.hasNonVoter, c.rangeCount, c.store.Capacity.QueriesPerSecond)
 	if c.details != "" {
 		return fmt.Sprintf("%s, details:(%s)", str, c.details)
@@ -611,11 +599,11 @@ func (c candidate) compactString() string {
 	if c.diversityScore != 0 {
 		fmt.Fprintf(&buf, ", diversity:%.2f", c.diversityScore)
 	}
-	if c.highReadAmp {
-		fmt.Fprintf(&buf, ", highReadAmp:%t", c.highReadAmp)
+	if c.ioOverloaded {
+		fmt.Fprintf(&buf, ", ioOverloaded:%t", c.ioOverloaded)
 	}
-	if c.l0SubLevels > 0 {
-		fmt.Fprintf(&buf, ", l0SubLevels:%d", c.l0SubLevels)
+	if c.ioOverloadScore > 0 {
+		fmt.Fprintf(&buf, ", ioOverload:%.2fd", c.ioOverloadScore)
 	}
 	fmt.Fprintf(&buf, ", converges:%d, balance:%d, rangeCount:%d",
 		c.convergesScore, c.balanceScore, c.rangeCount)
@@ -660,17 +648,17 @@ func (c candidate) compare(o candidate) float64 {
 		}
 		return -300
 	}
-	// If both o and c have high read amplification, then we prefer the
-	// canidate with lower read amp.
-	if o.highReadAmp && c.highReadAmp {
-		if o.l0SubLevels > c.l0SubLevels {
+	// If both o and c are IO overloaded, then we prefer the
+	// candidate with the lower IO overload score.
+	if o.ioOverloaded && c.ioOverloaded {
+		if o.ioOverloadScore > c.ioOverloadScore {
 			return 250
 		}
 	}
-	if c.highReadAmp {
+	if c.ioOverloaded {
 		return -250
 	}
-	if o.highReadAmp {
+	if o.ioOverloaded {
 		return 250
 	}
 
@@ -743,7 +731,7 @@ func (c byScoreAndID) Less(i, j int) bool {
 		c[i].rangeCount == c[j].rangeCount &&
 		c[i].necessary == c[j].necessary &&
 		c[i].fullDisk == c[j].fullDisk &&
-		c[i].highReadAmp == c[j].highReadAmp &&
+		c[i].ioOverloaded == c[j].ioOverloaded &&
 		c[i].valid == c[j].valid {
 		return c[i].store.StoreID < c[j].store.StoreID
 	}
@@ -752,11 +740,11 @@ func (c byScoreAndID) Less(i, j int) bool {
 func (c byScoreAndID) Swap(i, j int) { c[i], c[j] = c[j], c[i] }
 
 // onlyValidAndHealthyDisk returns all the elements in a sorted (by score
-// reversed) candidate list that are valid and not nearly full or with high
-// read amplification.
+// reversed) candidate list that are valid and not nearly full or being IO
+// overloaded.
 func (cl candidateList) onlyValidAndHealthyDisk() candidateList {
 	for i := len(cl) - 1; i >= 0; i-- {
-		if cl[i].valid && !cl[i].fullDisk && !cl[i].highReadAmp {
+		if cl[i].valid && !cl[i].fullDisk && !cl[i].ioOverloaded {
 			return cl[:i+1]
 		}
 	}
@@ -826,10 +814,10 @@ func (cl candidateList) worst() candidateList {
 			}
 		}
 	}
-	// Are there candidates with high read amplification? If so, pick those.
-	if cl[len(cl)-1].highReadAmp {
+	// Are there candidates with high IO overload? If so, pick those.
+	if cl[len(cl)-1].ioOverloaded {
 		for i := len(cl) - 2; i >= 0; i-- {
-			if !cl[i].highReadAmp {
+			if !cl[i].ioOverloaded {
 				return cl[i+1:]
 			}
 		}
@@ -987,10 +975,10 @@ func rankedCandidateListForAllocation(
 			continue
 		}
 
-		if !allocator.MaxCapacityCheck(s) || !options.getStoreHealthOptions().readAmpIsHealthy(
+		if !allocator.MaxCapacityCheck(s) || !options.getStoreHealthOptions().storeIsHealthy(
 			ctx,
 			s,
-			candidateStores.CandidateL0Sublevels.Mean,
+			candidateStores.CandidateIOOverloadScores.Mean,
 		) {
 			continue
 		}
@@ -1058,10 +1046,10 @@ func candidateListForRemoval(
 			necessary: necessary,
 			fullDisk:  !allocator.MaxCapacityCheck(s),
 			// When removing a replica from a store, we do not want to include
-			// high amplification in ranking stores. This would submit already
-			// high read amplification stores to additional load of moving a
+			// IO overloaded in ranking stores. This would submit already
+			// overloaded amplification stores to additional load of moving a
 			// replica.
-			highReadAmp:    false,
+			ioOverloaded:   false,
 			diversityScore: diversityScore,
 		})
 	}
@@ -1375,10 +1363,10 @@ func rankedCandidateListForRebalancing(
 				necessary: necessary,
 				fullDisk:  fullDisk,
 				// When rebalancing a replica away from a store, we do not want
-				// to include high amplification in ranking stores. This would
-				// submit already high read amplification stores to additional
-				// load of moving a replica.
-				highReadAmp:    false,
+				// to include IO overload in ranking stores. This would
+				// submit already overloaded stores to additional load of
+				// moving a replica.
+				ioOverloaded:   false,
 				diversityScore: curDiversityScore,
 			}
 		}
@@ -1570,14 +1558,15 @@ func rankedCandidateListForRebalancing(
 			// above, but recompute fullDisk using special rebalanceTo logic for
 			// rebalance candidates.
 			s := cand.store
+			candIOOverloadScore, _ := s.Capacity.IOThreshold.Score()
 			cand.fullDisk = !rebalanceToMaxCapacityCheck(s)
-			cand.l0SubLevels = int(s.Capacity.L0Sublevels)
-			cand.highReadAmp = !options.getStoreHealthOptions().rebalanceToReadAmpIsHealthy(
+			cand.ioOverloadScore = candIOOverloadScore
+			cand.ioOverloaded = !options.getStoreHealthOptions().rebalanceToStoreIsHealthy(
 				ctx,
 				s,
-				// We only wish to compare the read amplification to the
+				// We only wish to compare the IO overload to the
 				// comparable stores average and not the cluster.
-				comparable.candidateSL.CandidateL0Sublevels.Mean,
+				comparable.candidateSL.CandidateIOOverloadScores.Mean,
 			)
 			cand.balanceScore = options.balanceScore(comparable.candidateSL, s.Capacity)
 			cand.convergesScore = options.rebalanceToConvergesScore(comparable, s)
@@ -2188,66 +2177,72 @@ func convergesOnMean(oldVal, newVal, mean float64) bool {
 // StoreHealthOptions is the scorer options for store health. It is
 // used to inform scoring based on the health of a store.
 type StoreHealthOptions struct {
-	EnforcementLevel    StoreHealthEnforcement
-	L0SublevelThreshold int64
+	EnforcementLevel    IOOverloadEnforcementLevel
+	IOOverloadThreshold float64
 }
 
-// readAmpIsHealthy returns true if the store read amplification does not exceed
+// storeIsHealthy returns true if the store IO overload does not exceed
 // the cluster threshold and mean, or the enforcement level does not include
 // excluding candidates from being allocation targets.
-func (o StoreHealthOptions) readAmpIsHealthy(
+func (o StoreHealthOptions) storeIsHealthy(
 	ctx context.Context, store roachpb.StoreDescriptor, avg float64,
 ) bool {
-	if o.EnforcementLevel == StoreHealthNoAction ||
-		store.Capacity.L0Sublevels < o.L0SublevelThreshold {
+	ioOverloadScore, _ := store.Capacity.IOThreshold.Score()
+	if o.EnforcementLevel == IOOverloadThresholdNoAction ||
+		ioOverloadScore < o.IOOverloadThreshold {
 		return true
 	}
 
-	// Still log an event when the L0 sub-levels exceeds the threshold, however
+	// Still log an event when the IO overload score exceeds the threshold, however
 	// does not exceed the cluster average. This is enabled to avoid confusion
 	// where candidate stores are still targets, despite exeeding the
 	// threshold.
-	if float64(store.Capacity.L0Sublevels) < avg*l0SubLevelWaterMark {
-		log.KvDistribution.VEventf(ctx, 5, "s%d, allocate check l0 sublevels %d exceeds threshold %d, but below average: %f, action enabled %d",
-			store.StoreID, store.Capacity.L0Sublevels,
-			o.L0SublevelThreshold, avg, o.EnforcementLevel)
+	if ioOverloadScore < avg*IOOverloadMeanThreshold {
+		log.KvDistribution.VEventf(ctx, 5, "s%d, allocate check io overload %.2f exceeds threshold %.2f, but below average: %.2f, action enabled %d",
+			store.StoreID, ioOverloadScore,
+			o.IOOverloadThreshold, avg, o.EnforcementLevel)
 		return true
 	}
 
-	log.KvDistribution.VEventf(ctx, 5, "s%d, allocate check l0 sublevels %d exceeds threshold %d, above average: %f, action enabled %d",
-		store.StoreID, store.Capacity.L0Sublevels,
-		o.L0SublevelThreshold, avg, o.EnforcementLevel)
+	log.KvDistribution.VEventf(ctx, 5, "s%d, allocate check io overload %.2f exceeds threshold %.2f, above average: %.2f, action enabled %d",
+		store.StoreID, ioOverloadScore,
+		o.IOOverloadThreshold, avg, o.EnforcementLevel)
 
 	// The store is only considered unhealthy when the enforcement level is
 	// storeHealthBlockAll.
-	return o.EnforcementLevel < StoreHealthBlockAll
+	return o.EnforcementLevel < IOOverloadThresholdBlockAll
 }
 
-// rebalanceToReadAmpIsHealthy returns true if the store read amplification does
-// not exceed the cluster threshold and mean, or the enforcement level does not
+// rebalanceToStoreIsHealthy returns true if the store IO overload does not
+// exceed the cluster threshold and mean, or the enforcement level does not
 // include excluding candidates from being rebalancing targets.
-func (o StoreHealthOptions) rebalanceToReadAmpIsHealthy(
+func (o StoreHealthOptions) rebalanceToStoreIsHealthy(
 	ctx context.Context, store roachpb.StoreDescriptor, avg float64,
 ) bool {
-	if o.EnforcementLevel == StoreHealthNoAction ||
-		store.Capacity.L0Sublevels < o.L0SublevelThreshold {
+	ioOverloadScore, _ := store.Capacity.IOThreshold.Score()
+	if o.EnforcementLevel == IOOverloadThresholdNoAction ||
+		ioOverloadScore < o.IOOverloadThreshold {
 		return true
 	}
 
-	if float64(store.Capacity.L0Sublevels) < avg*l0SubLevelWaterMark {
-		log.KvDistribution.VEventf(ctx, 5, "s%d, allocate check l0 sublevels %d exceeds threshold %d, but below average watermark: %f, action enabled %d",
-			store.StoreID, store.Capacity.L0Sublevels,
-			o.L0SublevelThreshold, avg*l0SubLevelWaterMark, o.EnforcementLevel)
+	if ioOverloadScore < avg*IOOverloadMeanThreshold {
+		log.KvDistribution.VEventf(ctx, 5,
+			"s%d, allocate check io overload %.2f exceeds threshold %.2f, but "+
+				"below average watermark: %.2f, action enabled %d",
+			store.StoreID, ioOverloadScore, o.IOOverloadThreshold,
+			avg*IOOverloadMeanThreshold, o.EnforcementLevel)
 		return true
 	}
 
-	log.KvDistribution.VEventf(ctx, 5, "s%d, allocate check l0 sublevels %d exceeds threshold %d, above average watermark: %f, action enabled %d",
-		store.StoreID, store.Capacity.L0Sublevels,
-		o.L0SublevelThreshold, avg*l0SubLevelWaterMark, o.EnforcementLevel)
+	log.KvDistribution.VEventf(ctx, 5,
+		"s%d, allocate check io overload %.2f exceeds threshold %.2f, above average "+
+			"watermark: %.2f, action enabled %d",
+		store.StoreID, ioOverloadScore, o.IOOverloadThreshold,
+		avg*IOOverloadMeanThreshold, o.EnforcementLevel)
 
 	// The store is only considered unhealthy when the enforcement level is
 	// storeHealthBlockRebalanceTo or storeHealthBlockAll.
-	return o.EnforcementLevel < StoreHealthBlockRebalanceTo
+	return o.EnforcementLevel < IOOverloadThresholdBlockRebalanceTo
 }
 
 // rebalanceToMaxCapacityCheck returns true if the store has enough room to
@@ -2259,4 +2254,15 @@ func rebalanceToMaxCapacityCheck(store roachpb.StoreDescriptor) bool {
 
 func scoresAlmostEqual(score1, score2 float64) bool {
 	return math.Abs(score1-score2) < epsilon
+}
+
+// TestingIOThresholdWithScore returns an IOThreshold where the score will be
+// equal to the value provided. This is suitable for testing only.
+func TestingIOThresholdWithScore(score float64) admissionpb.IOThreshold {
+	return admissionpb.IOThreshold{
+		L0NumSubLevels:          int64(20 * score),
+		L0NumSubLevelsThreshold: 20,
+		L0NumFiles:              int64(1000 * score),
+		L0NumFilesThreshold:     1000,
+	}
 }

--- a/pkg/kv/kvserver/allocator/allocatorimpl/allocator_scorer_test.go
+++ b/pkg/kv/kvserver/allocator/allocatorimpl/allocator_scorer_test.go
@@ -52,7 +52,7 @@ func TestOnlyValidAndHealthyDisk(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	testCases := []struct {
-		valid, invalid, full, readAmpHigh int
+		valid, invalid, full, ioOverloaded int
 	}{
 		{0, 0, 0, 0},
 		{1, 0, 0, 0},
@@ -80,8 +80,8 @@ func TestOnlyValidAndHealthyDisk(t *testing.T) {
 			for i := 0; i < tc.full; i++ {
 				cl = append(cl, candidate{fullDisk: true})
 			}
-			for i := 0; i < tc.readAmpHigh; i++ {
-				cl = append(cl, candidate{highReadAmp: true})
+			for i := 0; i < tc.ioOverloaded; i++ {
+				cl = append(cl, candidate{ioOverloaded: true})
 			}
 			sort.Sort(sort.Reverse(byScore(cl)))
 
@@ -89,7 +89,7 @@ func TestOnlyValidAndHealthyDisk(t *testing.T) {
 			if a, e := len(valid), tc.valid; a != e {
 				t.Errorf("expected %d valid, actual %d", e, a)
 			}
-			if a, e := len(cl)-len(valid), tc.invalid+tc.full+tc.readAmpHigh; a != e {
+			if a, e := len(cl)-len(valid), tc.invalid+tc.full+tc.ioOverloaded; a != e {
 				t.Errorf("expected %d invalid, actual %d", e, a)
 			}
 		})
@@ -1096,7 +1096,7 @@ func TestShouldRebalanceDiversity(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	options := &RangeCountScorerOptions{StoreHealthOptions: StoreHealthOptions{EnforcementLevel: StoreHealthNoAction}}
+	options := &RangeCountScorerOptions{StoreHealthOptions: StoreHealthOptions{EnforcementLevel: IOOverloadThresholdNoAction}}
 	newStore := func(id int, locality roachpb.Locality) roachpb.StoreDescriptor {
 		return roachpb.StoreDescriptor{
 			StoreID: roachpb.StoreID(id),

--- a/pkg/kv/kvserver/allocator/allocatorimpl/allocator_test.go
+++ b/pkg/kv/kvserver/allocator/allocatorimpl/allocator_test.go
@@ -344,90 +344,90 @@ var oneStoreWithFullDisk = []*roachpb.StoreDescriptor{
 	},
 }
 
-var oneStoreHighReadAmp = []*roachpb.StoreDescriptor{
+var oneStoreHighIOOverload = []*roachpb.StoreDescriptor{
 	{
 		StoreID:  1,
 		Node:     roachpb.NodeDescriptor{NodeID: 1},
-		Capacity: roachpb.StoreCapacity{Capacity: 200, Available: 200, RangeCount: 600, L0Sublevels: MaxL0SublevelThreshold - 5},
+		Capacity: roachpb.StoreCapacity{Capacity: 200, Available: 200, RangeCount: 600, IOThreshold: TestingIOThresholdWithScore(DefaultIOOverloadThreshold - 5)},
 	},
 	{
 		StoreID:  2,
 		Node:     roachpb.NodeDescriptor{NodeID: 2},
-		Capacity: roachpb.StoreCapacity{Capacity: 200, Available: 200, RangeCount: 1800, L0Sublevels: MaxL0SublevelThreshold - 5},
+		Capacity: roachpb.StoreCapacity{Capacity: 200, Available: 200, RangeCount: 1800, IOThreshold: TestingIOThresholdWithScore(DefaultIOOverloadThreshold - 5)},
 	},
 	{
 		StoreID:  3,
 		Node:     roachpb.NodeDescriptor{NodeID: 3},
-		Capacity: roachpb.StoreCapacity{Capacity: 200, Available: 200, RangeCount: 600, L0Sublevels: MaxL0SublevelThreshold + 5},
+		Capacity: roachpb.StoreCapacity{Capacity: 200, Available: 200, RangeCount: 600, IOThreshold: TestingIOThresholdWithScore(DefaultIOOverloadThreshold + 5)},
 	},
 	{
 		StoreID:  4,
 		Node:     roachpb.NodeDescriptor{NodeID: 4},
-		Capacity: roachpb.StoreCapacity{Capacity: 200, Available: 200, RangeCount: 1200, L0Sublevels: MaxL0SublevelThreshold - 5},
+		Capacity: roachpb.StoreCapacity{Capacity: 200, Available: 200, RangeCount: 1200, IOThreshold: TestingIOThresholdWithScore(DefaultIOOverloadThreshold - 5)},
 	},
 }
 
-var allStoresHighReadAmp = []*roachpb.StoreDescriptor{
+var allStoresHighIOOverload = []*roachpb.StoreDescriptor{
 	{
 		StoreID:  1,
 		Node:     roachpb.NodeDescriptor{NodeID: 1},
-		Capacity: roachpb.StoreCapacity{Capacity: 200, Available: 200, RangeCount: 1200, L0Sublevels: MaxL0SublevelThreshold + 1},
+		Capacity: roachpb.StoreCapacity{Capacity: 200, Available: 200, RangeCount: 1200, IOThreshold: TestingIOThresholdWithScore(DefaultIOOverloadThreshold + 1)},
 	},
 	{
 		StoreID:  2,
 		Node:     roachpb.NodeDescriptor{NodeID: 2},
-		Capacity: roachpb.StoreCapacity{Capacity: 200, Available: 200, RangeCount: 800, L0Sublevels: MaxL0SublevelThreshold + 1},
+		Capacity: roachpb.StoreCapacity{Capacity: 200, Available: 200, RangeCount: 800, IOThreshold: TestingIOThresholdWithScore(DefaultIOOverloadThreshold + 1)},
 	},
 	{
 		StoreID:  3,
 		Node:     roachpb.NodeDescriptor{NodeID: 3},
-		Capacity: roachpb.StoreCapacity{Capacity: 200, Available: 200, RangeCount: 600, L0Sublevels: MaxL0SublevelThreshold + 1},
+		Capacity: roachpb.StoreCapacity{Capacity: 200, Available: 200, RangeCount: 600, IOThreshold: TestingIOThresholdWithScore(DefaultIOOverloadThreshold + 1)},
 	},
 }
 
-var allStoresHighReadAmpSkewed = []*roachpb.StoreDescriptor{
+var allStoresHighIOOverloadSkewed = []*roachpb.StoreDescriptor{
 	{
 		StoreID:  1,
 		Node:     roachpb.NodeDescriptor{NodeID: 1},
-		Capacity: roachpb.StoreCapacity{Capacity: 200, Available: 200, RangeCount: 1200, L0Sublevels: MaxL0SublevelThreshold + 1},
+		Capacity: roachpb.StoreCapacity{Capacity: 200, Available: 200, RangeCount: 1200, IOThreshold: TestingIOThresholdWithScore(DefaultIOOverloadThreshold + 1)},
 	},
 	{
 		StoreID:  2,
 		Node:     roachpb.NodeDescriptor{NodeID: 2},
-		Capacity: roachpb.StoreCapacity{Capacity: 200, Available: 200, RangeCount: 800, L0Sublevels: MaxL0SublevelThreshold + 50},
+		Capacity: roachpb.StoreCapacity{Capacity: 200, Available: 200, RangeCount: 800, IOThreshold: TestingIOThresholdWithScore(DefaultIOOverloadThreshold + 50)},
 	},
 	{
 		StoreID:  3,
 		Node:     roachpb.NodeDescriptor{NodeID: 3},
-		Capacity: roachpb.StoreCapacity{Capacity: 200, Available: 200, RangeCount: 600, L0Sublevels: MaxL0SublevelThreshold + 55},
+		Capacity: roachpb.StoreCapacity{Capacity: 200, Available: 200, RangeCount: 600, IOThreshold: TestingIOThresholdWithScore(DefaultIOOverloadThreshold + 55)},
 	},
 }
 
-var threeStoresHighReadAmpAscRangeCount = []*roachpb.StoreDescriptor{
+var threeStoresHighIOOverloadAscRangeCount = []*roachpb.StoreDescriptor{
 	{
 		StoreID:  1,
 		Node:     roachpb.NodeDescriptor{NodeID: 1},
-		Capacity: roachpb.StoreCapacity{Capacity: 200, Available: 200, RangeCount: 100, L0Sublevels: MaxL0SublevelThreshold + 10},
+		Capacity: roachpb.StoreCapacity{Capacity: 200, Available: 200, RangeCount: 100, IOThreshold: TestingIOThresholdWithScore(DefaultIOOverloadThreshold + 10)},
 	},
 	{
 		StoreID:  2,
 		Node:     roachpb.NodeDescriptor{NodeID: 2},
-		Capacity: roachpb.StoreCapacity{Capacity: 200, Available: 200, RangeCount: 400, L0Sublevels: MaxL0SublevelThreshold + 10},
+		Capacity: roachpb.StoreCapacity{Capacity: 200, Available: 200, RangeCount: 400, IOThreshold: TestingIOThresholdWithScore(DefaultIOOverloadThreshold + 10)},
 	},
 	{
 		StoreID:  3,
 		Node:     roachpb.NodeDescriptor{NodeID: 3},
-		Capacity: roachpb.StoreCapacity{Capacity: 200, Available: 200, RangeCount: 1600, L0Sublevels: MaxL0SublevelThreshold + 10},
+		Capacity: roachpb.StoreCapacity{Capacity: 200, Available: 200, RangeCount: 1600, IOThreshold: TestingIOThresholdWithScore(DefaultIOOverloadThreshold + 10)},
 	},
 	{
 		StoreID:  4,
 		Node:     roachpb.NodeDescriptor{NodeID: 4},
-		Capacity: roachpb.StoreCapacity{Capacity: 200, Available: 200, RangeCount: 6400, L0Sublevels: MaxL0SublevelThreshold - 10},
+		Capacity: roachpb.StoreCapacity{Capacity: 200, Available: 200, RangeCount: 6400, IOThreshold: TestingIOThresholdWithScore(DefaultIOOverloadThreshold - 10)},
 	},
 	{
 		StoreID:  5,
 		Node:     roachpb.NodeDescriptor{NodeID: 5},
-		Capacity: roachpb.StoreCapacity{Capacity: 200, Available: 200, RangeCount: 25000, L0Sublevels: MaxL0SublevelThreshold - 10},
+		Capacity: roachpb.StoreCapacity{Capacity: 200, Available: 200, RangeCount: 25000, IOThreshold: TestingIOThresholdWithScore(DefaultIOOverloadThreshold - 10)},
 	},
 }
 
@@ -595,7 +595,7 @@ func TestAllocatorNoAvailableDisks(t *testing.T) {
 	}
 }
 
-func TestAllocatorReadAmpCheck(t *testing.T) {
+func TestAllocatorIOOverloadCheck(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
@@ -611,74 +611,74 @@ func TestAllocatorReadAmpCheck(t *testing.T) {
 		// allocator should pick a store that is good enough, ignoring the range
 		// count.
 		expectedTargetIfDead roachpb.StoreID
-		enforcement          StoreHealthEnforcement
+		enforcement          IOOverloadEnforcementLevel
 	}
 	tests := []testCase{
 		{
-			name:   "ignore read amp on allocation when StoreHealthNoAction enforcement",
-			stores: allStoresHighReadAmp,
+			name:   "ignore io overload on allocation when StoreHealthNoAction enforcement",
+			stores: allStoresHighIOOverload,
 			conf:   emptySpanConfig(),
-			// NB: All stores have high read amp, this should be ignored and
+			// NB: All stores have high io overload, this should be ignored and
 			// allocate to the store with the lowest range count.
 			expectedTargetIfAlive: roachpb.StoreID(3),
 			// Recovery of a dead node can pick any valid store, not necessarily the
 			// one with the lowest range count.
 			expectedTargetIfDead: roachpb.StoreID(2),
-			enforcement:          StoreHealthNoAction,
+			enforcement:          IOOverloadThresholdNoAction,
 		},
 		{
-			name: "ignore read amp on allocation when storeHealthLogOnly enforcement",
-			// NB: All stores have high read amp, this should be ignored and
+			name: "ignore io overload on allocation when storeHealthLogOnly enforcement",
+			// NB: All stores have high io overload, this should be ignored and
 			// allocate to the store with the lowest range count.
-			stores:                allStoresHighReadAmp,
+			stores:                allStoresHighIOOverload,
 			conf:                  emptySpanConfig(),
 			expectedTargetIfAlive: roachpb.StoreID(3),
 			// Recovery of a dead node can pick any valid store, not necessarily the
 			// one with the lowest range count.
 			expectedTargetIfDead: roachpb.StoreID(2),
-			enforcement:          StoreHealthLogOnly,
+			enforcement:          IOOverloadThresholdLogOnly,
 		},
 		{
-			name: "ignore read amp on allocation when StoreHealthBlockRebalanceTo enforcement",
-			// NB: All stores have high read amp, this should be ignored and
+			name: "ignore io overload on allocation when StoreHealthBlockRebalanceTo enforcement",
+			// NB: All stores have high io overload, this should be ignored and
 			// allocate to the store with the lowest range count.
-			stores:                allStoresHighReadAmp,
+			stores:                allStoresHighIOOverload,
 			conf:                  emptySpanConfig(),
 			expectedTargetIfAlive: roachpb.StoreID(3),
 			// Recovery of a dead node can pick any valid store, not necessarily the
 			// one with the lowest range count.
 			expectedTargetIfDead: roachpb.StoreID(2),
-			enforcement:          StoreHealthBlockRebalanceTo,
+			enforcement:          IOOverloadThresholdBlockRebalanceTo,
 		},
 		{
-			name: "don't allocate to stores when all have high read amp and StoreHealthBlockAll",
-			// NB: All stores have high read amp (limit + 1), none are above the watermark, select the lowest range count.
-			stores:                allStoresHighReadAmp,
+			name: "don't allocate to stores when all have high io overload and StoreHealthBlockAll",
+			// NB: All stores have high io overload (limit + 1), none are above the watermark, select the lowest range count.
+			stores:                allStoresHighIOOverload,
 			conf:                  emptySpanConfig(),
 			expectedTargetIfAlive: roachpb.StoreID(3),
 			// Recovery of a dead node can pick any valid store, not necessarily the
 			// one with the lowest range count.
 			expectedTargetIfDead: roachpb.StoreID(2),
-			enforcement:          StoreHealthBlockAll,
+			enforcement:          IOOverloadThresholdBlockAll,
 		},
 		{
-			name: "allocate to store below the mean when all have high read amp and StoreHealthBlockAll",
-			// NB: All stores have high read amp, however store 1 is below the watermark mean read amp.
-			stores:                allStoresHighReadAmpSkewed,
+			name: "allocate to store below the mean when all have high io overload and StoreHealthBlockAll",
+			// NB: All stores have high io overload, however store 1 is below the watermark mean io overload.
+			stores:                allStoresHighIOOverloadSkewed,
 			conf:                  emptySpanConfig(),
 			expectedTargetIfAlive: roachpb.StoreID(1),
 			expectedTargetIfDead:  roachpb.StoreID(1),
-			enforcement:           StoreHealthBlockAll,
+			enforcement:           IOOverloadThresholdBlockAll,
 		},
 		{
-			name: "allocate to lowest range count store without high read amp when StoreHealthBlockAll enforcement",
-			// NB: Store 1, 2 and 3 have high read amp and are above the watermark, the lowest range count (4)
+			name: "allocate to lowest range count store without high io overload when StoreHealthBlockAll enforcement",
+			// NB: Store 1, 2 and 3 have high io overload and are above the watermark, the lowest range count (4)
 			// should be selected.
-			stores:                threeStoresHighReadAmpAscRangeCount,
+			stores:                threeStoresHighIOOverloadAscRangeCount,
 			conf:                  emptySpanConfig(),
 			expectedTargetIfAlive: roachpb.StoreID(4),
 			expectedTargetIfDead:  roachpb.StoreID(4),
-			enforcement:           StoreHealthBlockAll,
+			enforcement:           IOOverloadThresholdBlockAll,
 		},
 	}
 
@@ -694,7 +694,7 @@ func TestAllocatorReadAmpCheck(t *testing.T) {
 			sg.GossipStores(test.stores, t)
 
 			// Enable read disk health checking in candidate exclusion.
-			l0SublevelsThresholdEnforce.Override(ctx, &a.st.SV, int64(test.enforcement))
+			IOOverloadThresholdEnforcement.Override(ctx, &a.st.SV, int64(test.enforcement))
 
 			// Allocate a voter where all replicas are alive (e.g. up-replicating a valid range).
 			add, _, err := a.AllocateVoter(
@@ -1654,7 +1654,7 @@ func TestAllocatorRebalanceByQPS(t *testing.T) {
 			gossiputil.NewStoreGossiper(g).GossipStores(subtest.testStores, t)
 			var rangeUsageInfo allocator.RangeUsageInfo
 			options := TestingQPSLoadScorerOptions(100, 0.2)
-			options.StoreHealthOptions = StoreHealthOptions{EnforcementLevel: StoreHealthNoAction}
+			options.StoreHealthOptions = StoreHealthOptions{EnforcementLevel: IOOverloadThresholdNoAction}
 			add, remove, _, ok := a.RebalanceVoter(
 				ctx,
 				sp,
@@ -1768,7 +1768,7 @@ func TestAllocatorRemoveBasedOnQPS(t *testing.T) {
 		defer stopper.Stop(ctx)
 		gossiputil.NewStoreGossiper(g).GossipStores(subtest.testStores, t)
 		options := TestingQPSLoadScorerOptions(0, 0.1)
-		options.StoreHealthOptions = StoreHealthOptions{EnforcementLevel: StoreHealthNoAction}
+		options.StoreHealthOptions = StoreHealthOptions{EnforcementLevel: IOOverloadThresholdNoAction}
 		remove, _, err := a.RemoveVoter(
 			ctx,
 			sp,
@@ -4346,19 +4346,14 @@ func TestAllocatorRebalanceNonVoters(t *testing.T) {
 	}
 }
 
-// TestAllocatorRebalanceReadAmpCheck ensures that rebalancing voters:
-// (1) Respects storeHealthEnforcement setting, by ignoring L0 Sublevels in
-//
-//	rebalancing decisions when disabled or set to log only.
-//
-// (2) Considers L0 sublevels when set to rebalanceOnly or allocate in
-//
-//	conjunction with the mean.
-//
-// (3) Does not attempt to rebalance off of the store when read amplification
-//
-//	is high, as this setting is only used for filtering candidates.
-func TestAllocatorRebalanceReadAmpCheck(t *testing.T) {
+// TestAllocatorRebalanceStoreHealthCheck ensures that rebalancing voters:
+// (1) Respects storeHealthEnforcement setting, by ignoring IO overload in
+// rebalancing decisions when disabled or set to log only.
+// (2) Considers IO overload when set to rebalanceOnly or allocate in
+// conjunction with the mean.
+// (3) Does not attempt to rebalance off of the store when io overload
+// is high, as this setting is only used for filtering candidates.
+func TestAllocatorRebalanceStoreHealthCheck(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	ctx := context.Background()
 
@@ -4369,67 +4364,67 @@ func TestAllocatorRebalanceReadAmpCheck(t *testing.T) {
 		existingVoters                            []roachpb.ReplicaDescriptor
 		expectNoAction                            bool
 		expectedRemoveTargets, expectedAddTargets []roachpb.StoreID
-		enforcement                               StoreHealthEnforcement
+		enforcement                               IOOverloadEnforcementLevel
 	}
 	tests := []testCase{
 		{
-			name: "don't move off of nodes with high read amp when StoreHealthBlockRebalanceTo",
-			// NB: Store 1,2, 4 have okay read amp. Store 3 has high read amp.
-			// We expect high read amplifaction to only be considered for
+			name: "don't move off of nodes with high io overload when StoreHealthBlockRebalanceTo",
+			// NB: Store 1,2, 4 have okay io overload. Store 3 has high io overload.
+			// We expect high io overload to only be considered for
 			// exlcuding targets, not for triggering rebalancing.
-			stores:         threeStoresHighReadAmpAscRangeCount,
+			stores:         threeStoresHighIOOverloadAscRangeCount,
 			conf:           emptySpanConfig(),
 			existingVoters: replicas(3, 1),
 			expectNoAction: true,
-			enforcement:    StoreHealthBlockRebalanceTo,
+			enforcement:    IOOverloadThresholdBlockRebalanceTo,
 		},
 		{
-			name: "don't move off of nodes with high read amp when StoreHealthBlockAll",
-			// NB: Store 1,2, 4 have okay read amp. Store 3 has high read amp.
-			// We expect high read amplifaction to only be considered for
+			name: "don't move off of nodes with high io overload when StoreHealthBlockAll",
+			// NB: Store 1,2, 4 have okay io overload. Store 3 has high io overload.
+			// We expect high io overload to only be considered for
 			// exlcuding targets, not for triggering rebalancing.
-			stores:         threeStoresHighReadAmpAscRangeCount,
+			stores:         threeStoresHighIOOverloadAscRangeCount,
 			conf:           emptySpanConfig(),
 			existingVoters: replicas(3, 1),
 			expectNoAction: true,
-			enforcement:    StoreHealthBlockAll,
+			enforcement:    IOOverloadThresholdBlockAll,
 		},
 		{
 			name: "don't take action when enforcement is not StoreHealthNoAction",
-			// NB: Store 3 has L0Sublevels > threshold. Store 2 has 3 x higher
+			// NB: Store 3 has IOOverload > threshold. Store 2 has 3 x higher
 			// ranges as other stores. Should move to candidate to 4, however
 			// enforcement for rebalancing is not enabled so will pick
 			// candidate 3 which has a lower range count.
-			stores:                oneStoreHighReadAmp,
+			stores:                oneStoreHighIOOverload,
 			conf:                  emptySpanConfig(),
 			existingVoters:        replicas(1, 2),
 			expectedRemoveTargets: []roachpb.StoreID{2},
 			expectedAddTargets:    []roachpb.StoreID{3},
-			enforcement:           StoreHealthNoAction,
+			enforcement:           IOOverloadThresholdNoAction,
 		},
 		{
-			name: "don't rebalance to nodes with high read amp when StoreHealthBlockRebalanceTo enforcement",
-			// NB: Store 3 has L0Sublevels > threshold. Store 2 has 3 x higher
+			name: "don't rebalance to nodes with high io overload when StoreHealthBlockRebalanceTo enforcement",
+			// NB: Store 3 has IOOverload > threshold. Store 2 has 3 x higher
 			// ranges as other stores. Should move to candidate to 4, which
-			// doesn't have high read amp.
-			stores:                oneStoreHighReadAmp,
+			// doesn't have high io overload.
+			stores:                oneStoreHighIOOverload,
 			conf:                  emptySpanConfig(),
 			existingVoters:        replicas(1, 2),
 			expectedRemoveTargets: []roachpb.StoreID{2},
 			expectedAddTargets:    []roachpb.StoreID{4},
-			enforcement:           StoreHealthBlockRebalanceTo,
+			enforcement:           IOOverloadThresholdBlockRebalanceTo,
 		},
 		{
-			name: "don't rebalance to nodes with high read amp when StoreHealthBlockAll enforcement",
-			// NB: Store 3 has L0Sublevels > threshold. Store 2 has 3 x higher
+			name: "don't rebalance to nodes with high io overload when StoreHealthBlockAll enforcement",
+			// NB: Store 3 has IOOverload > threshold. Store 2 has 3 x higher
 			// ranges as other stores. Should move to candidate to 4, which
-			// doesn't have high read amp.
-			stores:                oneStoreHighReadAmp,
+			// doesn't have high io overload.
+			stores:                oneStoreHighIOOverload,
 			conf:                  emptySpanConfig(),
 			existingVoters:        replicas(1, 2),
 			expectedRemoveTargets: []roachpb.StoreID{2},
 			expectedAddTargets:    []roachpb.StoreID{4},
-			enforcement:           StoreHealthBlockAll,
+			enforcement:           IOOverloadThresholdBlockAll,
 		},
 	}
 
@@ -4451,7 +4446,7 @@ func TestAllocatorRebalanceReadAmpCheck(t *testing.T) {
 			sg.GossipStores(test.stores, t)
 			// Enable read disk health checking in candidate exclusion.
 			options := a.ScorerOptions(ctx)
-			options.StoreHealthOptions = StoreHealthOptions{EnforcementLevel: test.enforcement, L0SublevelThreshold: 20}
+			options.StoreHealthOptions = StoreHealthOptions{EnforcementLevel: test.enforcement, IOOverloadThreshold: 1}
 			add, remove, _, ok := a.RebalanceVoter(
 				ctx,
 				sp,
@@ -8550,7 +8545,7 @@ func qpsBasedRebalanceFn(
 	jitteredQPS := avgQPS * (1 + alloc.randGen.Float64())
 
 	opts := TestingQPSLoadScorerOptions(jitteredQPS, 0.2)
-	opts.StoreHealthOptions = StoreHealthOptions{EnforcementLevel: StoreHealthNoAction}
+	opts.StoreHealthOptions = StoreHealthOptions{EnforcementLevel: IOOverloadThresholdNoAction}
 	opts.Deterministic = false
 	var rangeUsageInfo allocator.RangeUsageInfo
 	add, remove, details, ok := alloc.RebalanceVoter(

--- a/pkg/kv/kvserver/allocator/storepool/store_pool.go
+++ b/pkg/kv/kvserver/allocator/storepool/store_pool.go
@@ -558,18 +558,26 @@ func (sp *StorePool) statusString(nl NodeLivenessFunc) string {
 // storeGossipUpdate is the Gossip callback used to keep the StorePool up to date.
 func (sp *StorePool) storeGossipUpdate(_ string, content roachpb.Value) {
 	var storeDesc roachpb.StoreDescriptor
-	// We keep copies of the capacity and storeID to pass into the
-	// capacityChanged callback.
-	var oldCapacity, curCapacity roachpb.StoreCapacity
-	var storeID roachpb.StoreID
 
 	if err := content.GetProto(&storeDesc); err != nil {
 		ctx := sp.AnnotateCtx(context.TODO())
 		log.Errorf(ctx, "%v", err)
 		return
 	}
-	storeID = storeDesc.StoreID
-	curCapacity = storeDesc.Capacity
+
+	sp.storeDescriptorUpdate(storeDesc)
+}
+
+// storeDescriptorUpdate takes a store descriptor and updates the corresponding
+// details for the store in the storepool.
+func (sp *StorePool) storeDescriptorUpdate(storeDesc roachpb.StoreDescriptor) {
+	// We keep copies of the capacity and storeID to pass into the
+	// capacityChanged callback.
+	var oldCapacity roachpb.StoreCapacity
+	storeID := storeDesc.StoreID
+	curCapacity := storeDesc.Capacity
+
+	now := sp.clock.PhysicalTime()
 
 	sp.DetailsMu.Lock()
 	detail := sp.GetStoreDetailLocked(storeID)
@@ -577,7 +585,7 @@ func (sp *StorePool) storeGossipUpdate(_ string, content roachpb.Value) {
 		oldCapacity = detail.Desc.Capacity
 	}
 	detail.Desc = &storeDesc
-	detail.LastUpdatedTime = sp.clock.PhysicalTime()
+	detail.LastUpdatedTime = now
 	sp.DetailsMu.Unlock()
 
 	sp.localitiesMu.Lock()
@@ -749,8 +757,7 @@ func (sp *StorePool) UpdateLocalStoresAfterLeaseTransfer(
 	}
 }
 
-// newStoreDetail makes a new StoreDetail struct. It sets index to be -1 to
-// ensure that it will be processed by a queue immediately.
+// newStoreDetail makes a new StoreDetail struct.
 func newStoreDetail() *StoreDetail {
 	return &StoreDetail{}
 }
@@ -1063,9 +1070,9 @@ type StoreList struct {
 	// eligible to be rebalance targets.
 	candidateWritesPerSecond Stat
 
-	// candidateWritesPerSecond tracks L0 sub-level stats for Stores that are
-	// eligible to be rebalance targets.
-	CandidateL0Sublevels Stat
+	// CandidateIOOverloadScores tracks the IO overload stats for Stores that are
+	// eligible to be rebalance candidates.
+	CandidateIOOverloadScores Stat
 }
 
 // MakeStoreList constructs a new store list based on the passed in descriptors.
@@ -1080,8 +1087,9 @@ func MakeStoreList(descriptors []roachpb.StoreDescriptor) StoreList {
 		sl.candidateLogicalBytes.update(float64(desc.Capacity.LogicalBytes))
 		sl.CandidateQueriesPerSecond.update(desc.Capacity.QueriesPerSecond)
 		sl.candidateWritesPerSecond.update(desc.Capacity.WritesPerSecond)
-		sl.CandidateL0Sublevels.update(float64(desc.Capacity.L0Sublevels))
 		sl.CandidateCPU.update(desc.Capacity.CPUPerSecond)
+		score, _ := desc.Capacity.IOThreshold.Score()
+		sl.CandidateIOOverloadScores.update(score)
 	}
 	return sl
 }
@@ -1102,12 +1110,13 @@ func (sl StoreList) String() string {
 		fmt.Fprintf(&buf, " <no candidates>")
 	}
 	for _, desc := range sl.Stores {
-		fmt.Fprintf(&buf, "  %d: ranges=%d leases=%d disk-usage=%s queries-per-second=%.2f store-cpu-per-second=%s l0-sublevels=%d\n",
+		ioScore, _ := desc.Capacity.IOThreshold.Score()
+		fmt.Fprintf(&buf, "  %d: ranges=%d leases=%d disk-usage=%s queries-per-second=%.2f store-cpu-per-second=%s io-overload=%.2f\n",
 			desc.StoreID, desc.Capacity.RangeCount,
 			desc.Capacity.LeaseCount, humanizeutil.IBytes(desc.Capacity.LogicalBytes),
 			desc.Capacity.QueriesPerSecond,
 			humanizeutil.Duration(time.Duration(int64(desc.Capacity.CPUPerSecond))),
-			desc.Capacity.L0Sublevels,
+			ioScore,
 		)
 	}
 	return buf.String()

--- a/pkg/kv/kvserver/store_rebalancer_test.go
+++ b/pkg/kv/kvserver/store_rebalancer_test.go
@@ -59,7 +59,8 @@ var (
 			Capacity: roachpb.StoreCapacity{
 				QueriesPerSecond: 3000,
 				CPUPerSecond:     3000 * float64(time.Millisecond),
-				L0Sublevels:      allocatorimpl.MaxL0SublevelThreshold - 10,
+				IOThreshold: allocatorimpl.TestingIOThresholdWithScore(
+					allocatorimpl.DefaultIOOverloadThreshold - 10),
 			},
 		},
 		{
@@ -78,7 +79,8 @@ var (
 			Capacity: roachpb.StoreCapacity{
 				QueriesPerSecond: 2800,
 				CPUPerSecond:     2800 * float64(time.Millisecond),
-				L0Sublevels:      allocatorimpl.MaxL0SublevelThreshold - 5,
+				IOThreshold: allocatorimpl.TestingIOThresholdWithScore(
+					allocatorimpl.DefaultIOOverloadThreshold - 5),
 			},
 		},
 		{
@@ -97,7 +99,8 @@ var (
 			Capacity: roachpb.StoreCapacity{
 				QueriesPerSecond: 2600,
 				CPUPerSecond:     2600 * float64(time.Millisecond),
-				L0Sublevels:      allocatorimpl.MaxL0SublevelThreshold + 2,
+				IOThreshold: allocatorimpl.TestingIOThresholdWithScore(
+					allocatorimpl.DefaultIOOverloadThreshold + 2),
 			},
 		},
 		{
@@ -116,7 +119,8 @@ var (
 			Capacity: roachpb.StoreCapacity{
 				QueriesPerSecond: 2400,
 				CPUPerSecond:     2400 * float64(time.Millisecond),
-				L0Sublevels:      allocatorimpl.MaxL0SublevelThreshold - 10,
+				IOThreshold: allocatorimpl.TestingIOThresholdWithScore(
+					allocatorimpl.DefaultIOOverloadThreshold - 10),
 			},
 		},
 		{
@@ -135,7 +139,8 @@ var (
 			Capacity: roachpb.StoreCapacity{
 				QueriesPerSecond: 2200,
 				CPUPerSecond:     2200 * float64(time.Millisecond),
-				L0Sublevels:      allocatorimpl.MaxL0SublevelThreshold - 3,
+				IOThreshold: allocatorimpl.TestingIOThresholdWithScore(
+					allocatorimpl.DefaultIOOverloadThreshold - 3),
 			},
 		},
 		{
@@ -154,7 +159,8 @@ var (
 			Capacity: roachpb.StoreCapacity{
 				QueriesPerSecond: 2000,
 				CPUPerSecond:     2000 * float64(time.Millisecond),
-				L0Sublevels:      allocatorimpl.MaxL0SublevelThreshold + 2,
+				IOThreshold: allocatorimpl.TestingIOThresholdWithScore(
+					allocatorimpl.DefaultIOOverloadThreshold + 2),
 			},
 		},
 		{
@@ -173,7 +179,8 @@ var (
 			Capacity: roachpb.StoreCapacity{
 				QueriesPerSecond: 1800,
 				CPUPerSecond:     1800 * float64(time.Millisecond),
-				L0Sublevels:      allocatorimpl.MaxL0SublevelThreshold - 10,
+				IOThreshold: allocatorimpl.TestingIOThresholdWithScore(
+					allocatorimpl.DefaultIOOverloadThreshold - 10),
 			},
 		},
 		{
@@ -192,7 +199,8 @@ var (
 			Capacity: roachpb.StoreCapacity{
 				QueriesPerSecond: 1600,
 				CPUPerSecond:     1600 * float64(time.Millisecond),
-				L0Sublevels:      allocatorimpl.MaxL0SublevelThreshold - 5,
+				IOThreshold: allocatorimpl.TestingIOThresholdWithScore(
+					allocatorimpl.DefaultIOOverloadThreshold - 5),
 			},
 		},
 		{
@@ -211,7 +219,8 @@ var (
 			Capacity: roachpb.StoreCapacity{
 				QueriesPerSecond: 1400,
 				CPUPerSecond:     1400 * float64(time.Millisecond),
-				L0Sublevels:      allocatorimpl.MaxL0SublevelThreshold + 3,
+				IOThreshold: allocatorimpl.TestingIOThresholdWithScore(
+					allocatorimpl.DefaultIOOverloadThreshold + 3),
 			},
 		},
 	}
@@ -263,9 +272,9 @@ var (
 	}
 
 	// noLocalityAscendingReadAmpStores specifies a set of stores identical to
-	// noLocalityStores, however they have ascending read
-	// amplification. Where store 1, store 2 and store 3 are below the
-	// threshold, whilst store 4 and store 5 are above.
+	// noLocalityStores, however they have ascending IO overload threshold
+	// scores. Where store 1, store 2 and store 3 are below the threshold, whilst
+	// store 4 and store 5 are above.
 	noLocalityAscendingReadAmpStores = []*roachpb.StoreDescriptor{
 		{
 			StoreID: 1,
@@ -273,7 +282,8 @@ var (
 			Capacity: roachpb.StoreCapacity{
 				QueriesPerSecond: 1500,
 				CPUPerSecond:     1500 * float64(time.Millisecond),
-				L0Sublevels:      allocatorimpl.MaxL0SublevelThreshold - 15,
+				IOThreshold: allocatorimpl.TestingIOThresholdWithScore(
+					allocatorimpl.DefaultIOOverloadThreshold - 15),
 			},
 		},
 		{
@@ -282,7 +292,8 @@ var (
 			Capacity: roachpb.StoreCapacity{
 				QueriesPerSecond: 1300,
 				CPUPerSecond:     1300 * float64(time.Millisecond),
-				L0Sublevels:      allocatorimpl.MaxL0SublevelThreshold - 10,
+				IOThreshold: allocatorimpl.TestingIOThresholdWithScore(
+					allocatorimpl.DefaultIOOverloadThreshold - 10),
 			},
 		},
 		{
@@ -291,7 +302,8 @@ var (
 			Capacity: roachpb.StoreCapacity{
 				QueriesPerSecond: 1000,
 				CPUPerSecond:     1000 * float64(time.Millisecond),
-				L0Sublevels:      allocatorimpl.MaxL0SublevelThreshold - 5,
+				IOThreshold: allocatorimpl.TestingIOThresholdWithScore(
+					allocatorimpl.DefaultIOOverloadThreshold - 5),
 			},
 		},
 		{
@@ -300,7 +312,8 @@ var (
 			Capacity: roachpb.StoreCapacity{
 				QueriesPerSecond: 900,
 				CPUPerSecond:     900 * float64(time.Millisecond),
-				L0Sublevels:      allocatorimpl.MaxL0SublevelThreshold + 20,
+				IOThreshold: allocatorimpl.TestingIOThresholdWithScore(
+					allocatorimpl.DefaultIOOverloadThreshold + 20),
 			},
 		},
 		{
@@ -309,13 +322,14 @@ var (
 			Capacity: roachpb.StoreCapacity{
 				QueriesPerSecond: 500,
 				CPUPerSecond:     500 * float64(time.Millisecond),
-				L0Sublevels:      allocatorimpl.MaxL0SublevelThreshold + 25,
+				IOThreshold: allocatorimpl.TestingIOThresholdWithScore(
+					allocatorimpl.DefaultIOOverloadThreshold + 25),
 			},
 		},
 	}
 
 	// noLocalityUniformQPSHighReadAmp specifies a set of stores that are
-	// identical, except store 1 and 2 have high read amp.
+	// identical, except store 1 and 2 have a high IO overload score.
 	noLocalityUniformQPSHighReadAmp = []*roachpb.StoreDescriptor{
 		{
 			StoreID: 1,
@@ -323,7 +337,8 @@ var (
 			Capacity: roachpb.StoreCapacity{
 				QueriesPerSecond: 1000,
 				CPUPerSecond:     1000 * float64(time.Millisecond),
-				L0Sublevels:      allocatorimpl.MaxL0SublevelThreshold + 100,
+				IOThreshold: allocatorimpl.TestingIOThresholdWithScore(
+					allocatorimpl.DefaultIOOverloadThreshold + 100),
 			},
 		},
 		{
@@ -332,7 +347,8 @@ var (
 			Capacity: roachpb.StoreCapacity{
 				QueriesPerSecond: 1000,
 				CPUPerSecond:     1000 * float64(time.Millisecond),
-				L0Sublevels:      allocatorimpl.MaxL0SublevelThreshold - 15,
+				IOThreshold: allocatorimpl.TestingIOThresholdWithScore(
+					allocatorimpl.DefaultIOOverloadThreshold - 15),
 			},
 		},
 		{
@@ -341,7 +357,8 @@ var (
 			Capacity: roachpb.StoreCapacity{
 				QueriesPerSecond: 1000,
 				CPUPerSecond:     1000 * float64(time.Millisecond),
-				L0Sublevels:      allocatorimpl.MaxL0SublevelThreshold + 100,
+				IOThreshold: allocatorimpl.TestingIOThresholdWithScore(
+					allocatorimpl.DefaultIOOverloadThreshold + 100),
 			},
 		},
 		{
@@ -350,7 +367,8 @@ var (
 			Capacity: roachpb.StoreCapacity{
 				QueriesPerSecond: 1000,
 				CPUPerSecond:     1000 * float64(time.Millisecond),
-				L0Sublevels:      allocatorimpl.MaxL0SublevelThreshold - 15,
+				IOThreshold: allocatorimpl.TestingIOThresholdWithScore(
+					allocatorimpl.DefaultIOOverloadThreshold - 15),
 			},
 		},
 		{
@@ -359,12 +377,13 @@ var (
 			Capacity: roachpb.StoreCapacity{
 				QueriesPerSecond: 1000,
 				CPUPerSecond:     1000 * float64(time.Millisecond),
-				L0Sublevels:      allocatorimpl.MaxL0SublevelThreshold + 100,
+				IOThreshold: allocatorimpl.TestingIOThresholdWithScore(
+					allocatorimpl.DefaultIOOverloadThreshold + 100),
 			},
 		},
 	}
 	// noLocalityHighReadAmpStores specifies a set of stores identical to
-	// noLocalityStores, however they all have read amplification that exceeds
+	// noLocalityStores, however they all have an IO overload score that exceeds
 	// the threshold.
 	noLocalityHighReadAmpStores = []*roachpb.StoreDescriptor{
 		{
@@ -373,7 +392,8 @@ var (
 			Capacity: roachpb.StoreCapacity{
 				QueriesPerSecond: 1500,
 				CPUPerSecond:     1500 * float64(time.Millisecond),
-				L0Sublevels:      allocatorimpl.MaxL0SublevelThreshold + 1,
+				IOThreshold: allocatorimpl.TestingIOThresholdWithScore(
+					allocatorimpl.DefaultIOOverloadThreshold + 1),
 			},
 		},
 		{
@@ -382,7 +402,8 @@ var (
 			Capacity: roachpb.StoreCapacity{
 				QueriesPerSecond: 1300,
 				CPUPerSecond:     1300 * float64(time.Millisecond),
-				L0Sublevels:      allocatorimpl.MaxL0SublevelThreshold + 1,
+				IOThreshold: allocatorimpl.TestingIOThresholdWithScore(
+					allocatorimpl.DefaultIOOverloadThreshold + 1),
 			},
 		},
 		{
@@ -391,7 +412,8 @@ var (
 			Capacity: roachpb.StoreCapacity{
 				QueriesPerSecond: 1000,
 				CPUPerSecond:     1000 * float64(time.Millisecond),
-				L0Sublevels:      allocatorimpl.MaxL0SublevelThreshold + 1,
+				IOThreshold: allocatorimpl.TestingIOThresholdWithScore(
+					allocatorimpl.DefaultIOOverloadThreshold + 1),
 			},
 		},
 		{
@@ -400,7 +422,8 @@ var (
 			Capacity: roachpb.StoreCapacity{
 				QueriesPerSecond: 900,
 				CPUPerSecond:     900 * float64(time.Millisecond),
-				L0Sublevels:      allocatorimpl.MaxL0SublevelThreshold + 1,
+				IOThreshold: allocatorimpl.TestingIOThresholdWithScore(
+					allocatorimpl.DefaultIOOverloadThreshold + 1),
 			},
 		},
 		{
@@ -409,12 +432,13 @@ var (
 			Capacity: roachpb.StoreCapacity{
 				QueriesPerSecond: 500,
 				CPUPerSecond:     500 * float64(time.Millisecond),
-				L0Sublevels:      allocatorimpl.MaxL0SublevelThreshold + 1,
+				IOThreshold: allocatorimpl.TestingIOThresholdWithScore(
+					allocatorimpl.DefaultIOOverloadThreshold + 1),
 			},
 		},
 	}
 	// noLocalityHighReadAmpSkewedStores specifies a set of stores identical to
-	// noLocalityStores, however they all have read amplification that exceeds
+	// noLocalityStores, however they all have an IO overload score that exceeds
 	// the threshold in ascending order.
 	noLocalityHighReadAmpSkewedStores = []*roachpb.StoreDescriptor{
 		{
@@ -423,7 +447,8 @@ var (
 			Capacity: roachpb.StoreCapacity{
 				QueriesPerSecond: 1500,
 				CPUPerSecond:     1500 * float64(time.Millisecond),
-				L0Sublevels:      allocatorimpl.MaxL0SublevelThreshold + 1,
+				IOThreshold: allocatorimpl.TestingIOThresholdWithScore(
+					allocatorimpl.DefaultIOOverloadThreshold + 1),
 			},
 		},
 		{
@@ -432,7 +457,8 @@ var (
 			Capacity: roachpb.StoreCapacity{
 				QueriesPerSecond: 1300,
 				CPUPerSecond:     1300 * float64(time.Millisecond),
-				L0Sublevels:      allocatorimpl.MaxL0SublevelThreshold + 10,
+				IOThreshold: allocatorimpl.TestingIOThresholdWithScore(
+					allocatorimpl.DefaultIOOverloadThreshold + 10),
 			},
 		},
 		{
@@ -441,7 +467,8 @@ var (
 			Capacity: roachpb.StoreCapacity{
 				QueriesPerSecond: 1000,
 				CPUPerSecond:     1000 * float64(time.Millisecond),
-				L0Sublevels:      allocatorimpl.MaxL0SublevelThreshold + 50,
+				IOThreshold: allocatorimpl.TestingIOThresholdWithScore(
+					allocatorimpl.DefaultIOOverloadThreshold + 50),
 			},
 		},
 		{
@@ -450,7 +477,8 @@ var (
 			Capacity: roachpb.StoreCapacity{
 				QueriesPerSecond: 900,
 				CPUPerSecond:     900 * float64(time.Millisecond),
-				L0Sublevels:      allocatorimpl.MaxL0SublevelThreshold + 100,
+				IOThreshold: allocatorimpl.TestingIOThresholdWithScore(
+					allocatorimpl.DefaultIOOverloadThreshold + 100),
 			},
 		},
 		{
@@ -459,7 +487,8 @@ var (
 			Capacity: roachpb.StoreCapacity{
 				QueriesPerSecond: 500,
 				CPUPerSecond:     500 * float64(time.Millisecond),
-				L0Sublevels:      allocatorimpl.MaxL0SublevelThreshold + 100,
+				IOThreshold: allocatorimpl.TestingIOThresholdWithScore(
+					allocatorimpl.DefaultIOOverloadThreshold + 100),
 			},
 		},
 	}
@@ -906,7 +935,7 @@ func TestChooseRangeToRebalanceRandom(t *testing.T) {
 			hottestRanges := sr.replicaRankings.TopLoad()
 			options := sr.scorerOptions(ctx, lbRebalanceDimension)
 			rctx := sr.NewRebalanceContext(ctx, options, hottestRanges, sr.RebalanceMode())
-			rctx.options.StoreHealthOptions = allocatorimpl.StoreHealthOptions{EnforcementLevel: allocatorimpl.StoreHealthNoAction}
+			rctx.options.StoreHealthOptions = allocatorimpl.StoreHealthOptions{EnforcementLevel: allocatorimpl.IOOverloadThresholdNoAction}
 			rctx.options.LoadThreshold = allocatorimpl.WithAllDims(rebalanceThreshold)
 
 			_, voterTargets, nonVoterTargets := sr.chooseRangeToRebalance(ctx, rctx)
@@ -1014,10 +1043,10 @@ func TestChooseRangeToRebalanceAcrossHeterogeneousZones(t *testing.T) {
 		// the first listed voter target is expected to be the leaseholder.
 		expRebalancedVoters, expRebalancedNonVoters []roachpb.StoreID
 	}{
-		// All the replicas are already on the best possible stores. No
-		// rebalancing should be attempted, note here that the high read
-		// amp of the current stores is ignored as it is not considered in
-		// moving a replica away from a store.
+		// All the replicas are already on the best possible stores. No rebalancing
+		// should be attempted, note here that the high IO overload score of the
+		// current stores is ignored as it is not considered in moving a replica
+		// away from a store.
 		{
 			name:                "no rebalance",
 			voters:              []roachpb.StoreID{3, 6, 9},
@@ -1027,18 +1056,18 @@ func TestChooseRangeToRebalanceAcrossHeterogeneousZones(t *testing.T) {
 		// A replica is in a heavily loaded region, on a relatively heavily
 		// loaded store. We expect it to be moved to a less busy store
 		// within the same region. However, it cannot be the least busy
-		// store as it has high read amp (3).
+		// store as it has a high IO overload score (3).
 		{
 			name:                "rebalance one replica within heavy region",
 			voters:              []roachpb.StoreID{1, 6, 9},
 			constraints:         oneReplicaPerRegion,
 			expRebalancedVoters: []roachpb.StoreID{9, 6, 2},
 		},
-		// A replica is in a heavily loaded region, on a relatively heavily
-		// loaded store. We expect it to be moved to a less busy store
-		// within the same region. However, it cannot be the least busy
-		// store as it has high read amp (3). The new replica in the heavy
-		// region must also get the lease due to preferences.
+		// A replica is in a heavily loaded region, on a relatively heavily loaded
+		// store. We expect it to be moved to a less busy store within the same
+		// region. However, it cannot be the least busy store as it has a high IO
+		// overload score (3). The new replica in the heavy region must also get
+		// the lease due to preferences.
 		{
 			name:                "rebalance one replica within heavy region, prefer lease in heavy region",
 			voters:              []roachpb.StoreID{1, 6, 9},
@@ -1085,23 +1114,21 @@ func TestChooseRangeToRebalanceAcrossHeterogeneousZones(t *testing.T) {
 		// maximized, replicas on hot stores are rebalanced to cooler stores within
 		// the same region.
 		{
-			// Within the hottest region, expect rebalance from the hottest
-			// node (n1) to the coolest node (n3), however since n3 has
-			// high read amp it should instead rebalance to n2. Within the
-			// least hot region, we don't expect a rebalance from n8 to n9
-			// because the qps difference between the two
-			// stores is too small.
+			// Within the hottest region, expect rebalance from the hottest node (n1)
+			// to the coolest node (n3), however since n3 has a high IO overload
+			// score it should instead rebalance to n2. Within the least hot region,
+			// we don't expect a rebalance from n8 to n9 because the qps difference
+			// between the two stores is too small.
 			name:                "QPS balance without constraints",
 			voters:              []roachpb.StoreID{1, 5, 8},
 			expRebalancedVoters: []roachpb.StoreID{8, 5, 2},
 		},
 		{
-			// Within the second hottest region, expect rebalance from the
-			// hottest node (n4) to the coolest node (n6), however since n6
-			// has high read amp instead expect n5 to be selected. Within
-			// the lease hot region, we don't expect a rebalance from n8 to
-			// n9 because the qps difference between the two stores is too
-			// small.
+			// Within the second hottest region, expect rebalance from the hottest
+			// node (n4) to the coolest node (n6), however since n6 has a high IO
+			// overload score, instead expect n5 to be selected. Within the lease hot
+			// region, we don't expect a rebalance from n8 to n9 because the qps
+			// difference between the two stores is too small.
 			name:                "QPS balance without constraints",
 			voters:              []roachpb.StoreID{8, 4, 3},
 			expRebalancedVoters: []roachpb.StoreID{8, 5, 3},
@@ -1120,7 +1147,7 @@ func TestChooseRangeToRebalanceAcrossHeterogeneousZones(t *testing.T) {
 			expRebalancedVoters: []roachpb.StoreID{3, 2, 1},
 			// NB: Expect the non-voter on node 4 (hottest node in region B) to
 			// move to node 5 (least hot region in region B), the least hot
-			// node without high read amp.
+			// node without a high IO overload score.
 			expRebalancedNonVoters: []roachpb.StoreID{5, 9},
 		},
 		{
@@ -1167,13 +1194,12 @@ func TestChooseRangeToRebalanceAcrossHeterogeneousZones(t *testing.T) {
 			// constraints require at least one replica per each region.
 			voterConstraints: twoReplicasInHotRegion,
 			constraints:      oneReplicaPerRegion,
-			// NB: We've got 3 voters in the hottest region, but we only need
-			// 2. We expect that one of the voters from the hottest region
-			// will be moved to the least hot region. Additionally, in
-			// region B, we've got one replica on store 4 (which is the
-			// hottest store in that region). We expect that replica to be
-			// moved to store 5, which is the least hot node without high
-			// read amp.
+			// NB: We've got 3 voters in the hottest region, but we only need 2. We
+			// expect that one of the voters from the hottest region will be moved to
+			// the least hot region. Additionally, in region B, we've got one replica
+			// on store 4 (which is the hottest store in that region). We expect that
+			// replica to be moved to store 5, which is the least hot node without a
+			// high IO overload score.
 			expRebalancedVoters: []roachpb.StoreID{9, 2, 5, 8, 3},
 		},
 		{
@@ -1246,7 +1272,7 @@ func TestChooseRangeToRebalanceAcrossHeterogeneousZones(t *testing.T) {
 			options := sr.scorerOptions(ctx, lbRebalanceDimension)
 			rctx := sr.NewRebalanceContext(ctx, options, hottestRanges, LBRebalancingLeasesAndReplicas)
 			rctx.options.StoreHealthOptions = allocatorimpl.StoreHealthOptions{
-				EnforcementLevel: allocatorimpl.StoreHealthBlockRebalanceTo}
+				EnforcementLevel: allocatorimpl.IOOverloadThresholdBlockRebalanceTo}
 			rctx.options.LoadThreshold = allocatorimpl.WithAllDims(0.05)
 
 			_, voterTargets, nonVoterTargets := sr.chooseRangeToRebalance(
@@ -1335,7 +1361,7 @@ func TestChooseRangeToRebalanceIgnoresRangeOnBestStores(t *testing.T) {
 		options := sr.scorerOptions(ctx, lbRebalanceDimension)
 		rctx := sr.NewRebalanceContext(ctx, options, hottestRanges, sr.RebalanceMode())
 		rctx.options.StoreHealthOptions = allocatorimpl.StoreHealthOptions{
-			EnforcementLevel: allocatorimpl.StoreHealthNoAction}
+			EnforcementLevel: allocatorimpl.IOOverloadThresholdNoAction}
 		rctx.options.LoadThreshold = allocatorimpl.WithAllDims(0.05)
 
 		sr.chooseRangeToRebalance(ctx, rctx)
@@ -1503,7 +1529,7 @@ func TestChooseRangeToRebalanceOffHotNodes(t *testing.T) {
 			options := sr.scorerOptions(ctx, lbRebalanceDimension)
 			rctx := sr.NewRebalanceContext(ctx, options, hottestRanges, sr.RebalanceMode())
 			rctx.options.StoreHealthOptions = allocatorimpl.StoreHealthOptions{
-				EnforcementLevel: allocatorimpl.StoreHealthNoAction}
+				EnforcementLevel: allocatorimpl.IOOverloadThresholdNoAction}
 			rctx.options.LoadThreshold = allocatorimpl.WithAllDims(tc.rebalanceThreshold)
 
 			_, voterTargets, _ := sr.chooseRangeToRebalance(ctx, rctx)
@@ -1612,7 +1638,7 @@ func TestNoLeaseTransferToBehindReplicas(t *testing.T) {
 		options = sr.scorerOptions(ctx, lbRebalanceDimension)
 		rctx = sr.NewRebalanceContext(ctx, options, hottestRanges, sr.RebalanceMode())
 		rctx.options.StoreHealthOptions = allocatorimpl.StoreHealthOptions{
-			EnforcementLevel: allocatorimpl.StoreHealthNoAction}
+			EnforcementLevel: allocatorimpl.IOOverloadThresholdNoAction}
 		rctx.options.LoadThreshold = allocatorimpl.WithAllDims(0.05)
 		rctx.options.Deterministic = true
 
@@ -1629,12 +1655,12 @@ func TestNoLeaseTransferToBehindReplicas(t *testing.T) {
 	})
 }
 
-// TestStoreRebalancerReadAmpCheck checks that:
+// TestStoreRebalancerIOOverloadCheck checks that:
 //   - Under (1) disabled and (2) log that rebalancing decisions are unaffected
-//     by high read amplification.
-//   - Under (3) rebalanceOnly and (4) allocate that rebalance decisions exclude
-//     stores with high readamplification as candidate targets.
-func TestStoreRebalancerReadAmpCheck(t *testing.T) {
+//     by a high IO overload score.
+//   - Under (3) block rebalance to and (4) block all that rebalance decisions exclude
+//     stores with a high IO overload score as targets.
+func TestStoreRebalancerIOOverloadCheck(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
@@ -1645,113 +1671,114 @@ func TestStoreRebalancerReadAmpCheck(t *testing.T) {
 		stores          []*roachpb.StoreDescriptor
 		conf            roachpb.SpanConfig
 		expectedTargets []roachpb.ReplicationTarget
-		enforcement     allocatorimpl.StoreHealthEnforcement
+		enforcement     allocatorimpl.IOOverloadEnforcementLevel
 	}
 	tests := []testCase{
 		{
-			name: "ignore read amp on allocation when storeHealthNoAction enforcement",
-			// NB: All stores have high read amp, this should be ignored.
+			name: "ignore io overload on allocation when no action enforcement",
+			// NB: All stores have a high IO overload score, this should be ignored.
 			stores: noLocalityHighReadAmpStores,
 			conf:   roachpb.SpanConfig{},
 			expectedTargets: []roachpb.ReplicationTarget{
 				{NodeID: 4, StoreID: 4}, {NodeID: 3, StoreID: 3}, {NodeID: 5, StoreID: 5},
 			},
-			enforcement: allocatorimpl.StoreHealthNoAction,
+			enforcement: allocatorimpl.IOOverloadThresholdNoAction,
 		},
 		{
-			name: "ignore read amp on allocation when storeHealthLogOnly enforcement",
-			// NB: All stores have high read amp, this should be ignored.
+			name: "ignore io overload on allocation when log only enforcement",
+			// NB: All stores have high io overload, this should be ignored.
 			stores: noLocalityHighReadAmpStores,
 			conf:   roachpb.SpanConfig{},
 			expectedTargets: []roachpb.ReplicationTarget{
 				{NodeID: 4, StoreID: 4}, {NodeID: 3, StoreID: 3}, {NodeID: 5, StoreID: 5},
 			},
-			enforcement: allocatorimpl.StoreHealthLogOnly,
+			enforcement: allocatorimpl.IOOverloadThresholdLogOnly,
 		},
 		{
-			name: "don't stop rebalancing when read amp uniformly above threshold and storeHealthBlockRebalanceTo enforcement",
-			// NB: All stores have high uniformly high read  (threshold+1) this should be ignored.
+			name: "don't stop rebalancing when the io overload score uniformly above threshold and block rebalance to enforcement",
+			// NB: All stores have a high uniformly high IO overload score (threshold+1) this should be ignored.
 			stores: noLocalityHighReadAmpStores,
 			conf:   roachpb.SpanConfig{},
 			expectedTargets: []roachpb.ReplicationTarget{
 				{NodeID: 4, StoreID: 4}, {NodeID: 3, StoreID: 3}, {NodeID: 5, StoreID: 5},
 			},
-			enforcement: allocatorimpl.StoreHealthBlockRebalanceTo,
+			enforcement: allocatorimpl.IOOverloadThresholdBlockRebalanceTo,
 		},
 		{
-			name: "don't stop rebalancing when read amp uniformly above threshold and storeHealthBlockRebalanceTo enforcement",
-			// NB: All stores have high uniformly high read  (threshold+1) this should be ignored.
+			name: "don't stop rebalancing when the io overload score is uniformly above threshold and block rebalance to enforcement",
+			// NB: All stores have a high uniformly high IO overload score (threshold+1) this should be ignored.
 			stores: noLocalityHighReadAmpStores,
 			conf:   roachpb.SpanConfig{},
 			expectedTargets: []roachpb.ReplicationTarget{
 				{NodeID: 4, StoreID: 4}, {NodeID: 3, StoreID: 3}, {NodeID: 5, StoreID: 5},
 			},
-			enforcement: allocatorimpl.StoreHealthBlockAll,
+			enforcement: allocatorimpl.IOOverloadThresholdBlockAll,
 		},
 		{
-			name: "rebalance should ignore stores with high read amp that are also above the mean when storeHealthBlockAll enforcement",
-			// NB: All stores have high read amp, however store 2 is below the mean read amp so is a viable candidate.
+			name: "rebalance should ignore stores with a high io overload score that are also above the mean when storeHealthBlockAll enforcement",
+			// NB: All stores have a high IO overload score, however store 2 is below
+			// the mean IO overload score so is a viable candidate.
 			stores: noLocalityHighReadAmpSkewedStores,
 			conf:   roachpb.SpanConfig{},
 			expectedTargets: []roachpb.ReplicationTarget{
 				{NodeID: 2, StoreID: 2}, {NodeID: 3, StoreID: 3}, {NodeID: 5, StoreID: 5},
 			},
-			enforcement: allocatorimpl.StoreHealthBlockAll,
+			enforcement: allocatorimpl.IOOverloadThresholdBlockAll,
 		},
 		{
-			name: "rebalance should ignore stores with high read amp that are also above the mean when storeHealthBlockRebalanceTo enforcement",
-			// NB: All stores have high read amp, however store 2 is below the mean read amp so is a viable candidate.
+			name: "rebalance should ignore stores with high IO overload scores that are also above the mean when block rebalance to enforcement",
+			// NB: All stores have a high IO overload score, however store 2 is below
+			// the mean IO overload so is a viable candidate.
 			stores: noLocalityHighReadAmpSkewedStores,
 			conf:   roachpb.SpanConfig{},
 			expectedTargets: []roachpb.ReplicationTarget{
 				{NodeID: 2, StoreID: 2}, {NodeID: 3, StoreID: 3}, {NodeID: 5, StoreID: 5},
 			},
-			enforcement: allocatorimpl.StoreHealthBlockRebalanceTo,
+			enforcement: allocatorimpl.IOOverloadThresholdBlockRebalanceTo,
 		},
 		{
-			name: "rebalance should ignore stores with high read amp when storeHealthBlockRebalanceTo enforcement",
-			// NB: Store 4, 5 have high read amp, they should not be rebalance
-			// targets. Only 1,2,3 are valid targets, yet only 2 is not already
-			// a voter. 1 should transfer it's lease to 2. 5 could also have
-			// transferred its lease to 2, However, high read amp does not
-			// affect removing replicas from stores, only in blocking new
-			// replicas.
+			name: "rebalance should ignore stores with high IO overload when block rebalance to enforcement",
+			// NB: Store 4, 5 have a high IO overload score, they should not be
+			// rebalance targets. Only 1,2,3 are valid targets, yet only 2 is not
+			// already a voter. 1 should transfer it's lease to 2. 5 could also have
+			// transferred its lease to 2, However, high a IO overload score does not
+			// affect removing replicas from stores, only in blocking new replicas.
 			stores: noLocalityAscendingReadAmpStores,
 			conf:   roachpb.SpanConfig{},
 			expectedTargets: []roachpb.ReplicationTarget{
 				{NodeID: 2, StoreID: 2}, {NodeID: 3, StoreID: 3}, {NodeID: 5, StoreID: 5},
 			},
-			enforcement: allocatorimpl.StoreHealthBlockRebalanceTo,
+			enforcement: allocatorimpl.IOOverloadThresholdBlockRebalanceTo,
 		},
 		{
-			name: "rebalance should ignore stores with high read amp when storeHealthBlockAll enforcement",
-			// NB: This scenario and result should be identical to storeHealthBlockRebalanceTo.
+			name: "rebalance should ignore stores with high IO overload scores when block all enforcement level",
+			// NB: This scenario and result should be identical to block rebalance to enforcement level.
 			stores: noLocalityAscendingReadAmpStores,
 			conf:   roachpb.SpanConfig{},
 			expectedTargets: []roachpb.ReplicationTarget{
 				{NodeID: 2, StoreID: 2}, {NodeID: 3, StoreID: 3}, {NodeID: 5, StoreID: 5},
 			},
-			enforcement: allocatorimpl.StoreHealthBlockAll,
+			enforcement: allocatorimpl.IOOverloadThresholdBlockAll,
 		},
 		{
-			name: "rebalance should not rebalance away from stores with high read amp when storeHealthBlockAll enforcement",
-			// NB: Node 1,3,5 all have extremely high read amp. However, since
-			// read amp does not trigger rebalancing away, only blocking
+			name: "rebalance should not rebalance away from stores with high IO overload scores when block all enforcement level",
+			// NB: Node 1,3,5 all have an extremely high IO overload score. However,
+			// since IO overload does not trigger rebalancing away, only blocking
 			// rebalancing to this should be ignored and no action taken.
 			stores:          noLocalityUniformQPSHighReadAmp,
 			conf:            roachpb.SpanConfig{},
 			expectedTargets: nil,
-			enforcement:     allocatorimpl.StoreHealthBlockAll,
+			enforcement:     allocatorimpl.IOOverloadThresholdBlockAll,
 		},
 		{
-			name: "rebalance should not rebalance away from stores with high read amp when storeHealthBlockRebalanceTo enforcement",
-			// NB: Node 1,3,5 all have extremely high read amp. However, since
-			// read amp does not trigger rebalancing away, only blocking
+			name: "rebalance should not rebalance away from stores with high IO overload scores when block rebalance to enforcement level",
+			// NB: Node 1,3,5 all have an extremely high IO overload score. However,
+			// since IO overload does not trigger rebalancing away, only blocking
 			// rebalancing to this should be ignored and no action taken.
 			stores:          noLocalityUniformQPSHighReadAmp,
 			conf:            roachpb.SpanConfig{},
 			expectedTargets: nil,
-			enforcement:     allocatorimpl.StoreHealthBlockRebalanceTo,
+			enforcement:     allocatorimpl.IOOverloadThresholdBlockRebalanceTo,
 		},
 	}
 
@@ -1783,7 +1810,7 @@ func TestStoreRebalancerReadAmpCheck(t *testing.T) {
 			require.Greater(t, len(rctx.hottestRanges), 0)
 
 			rctx.options.StoreHealthOptions = allocatorimpl.StoreHealthOptions{
-				EnforcementLevel: test.enforcement, L0SublevelThreshold: allocatorimpl.MaxL0SublevelThreshold}
+				EnforcementLevel: test.enforcement, IOOverloadThreshold: allocatorimpl.DefaultIOOverloadThreshold}
 			rctx.options.LoadThreshold = allocatorimpl.WithAllDims(0.05)
 
 			_, targetVoters, _ := sr.chooseRangeToRebalance(ctx, rctx)

--- a/pkg/roachpb/metadata.go
+++ b/pkg/roachpb/metadata.go
@@ -515,11 +515,11 @@ func (sc StoreCapacity) String() string {
 func (sc StoreCapacity) SafeFormat(w redact.SafePrinter, _ rune) {
 	w.Printf("disk (capacity=%s, available=%s, used=%s, logicalBytes=%s), "+
 		"ranges=%d, leases=%d, queries=%.2f, writes=%.2f, "+
-		"l0Sublevels=%d, ioThreshold={%v} bytesPerReplica={%s}, writesPerReplica={%s}",
+		"ioThreshold={%v} bytesPerReplica={%s}, writesPerReplica={%s}",
 		humanizeutil.IBytes(sc.Capacity), humanizeutil.IBytes(sc.Available),
 		humanizeutil.IBytes(sc.Used), humanizeutil.IBytes(sc.LogicalBytes),
 		sc.RangeCount, sc.LeaseCount, sc.QueriesPerSecond, sc.WritesPerSecond,
-		sc.L0Sublevels, sc.IOThreshold, sc.BytesPerReplica, sc.WritesPerReplica)
+		sc.IOThreshold, sc.BytesPerReplica, sc.WritesPerReplica)
 }
 
 // FractionUsed computes the fraction of storage capacity that is in use.

--- a/pkg/roachpb/metadata.proto
+++ b/pkg/roachpb/metadata.proto
@@ -318,15 +318,14 @@ message StoreCapacity {
   // by ranges in the store. The stat is tracked over the time period defined
   // in storage/replica_stats.go, which as of July 2018 is 30 minutes.
   optional double writes_per_second = 5 [(gogoproto.nullable) = false];
-  // l0_sublevels tracks the current number of l0 sublevels in the store.
-  // TODO(kvoli): Use of this field will need to be version-gated, to avoid
-  // instances where overlapping node-binary versions within a cluster result
-  // in this this field missing.
-  optional int64 l0_sublevels = 12 [(gogoproto.nullable) = false];
   // cpu_per_second tracks the average store cpu use (ns) per second.
   // This is the sum of all the replica's cpu time on this store, which is
   // tracked in replica stats.
   optional double cpu_per_second = 14 [(gogoproto.nullable) = false, (gogoproto.customname) = "CPUPerSecond"];
+  // l0_sublevels tracks the current number of l0 sublevels in the store.
+  // TODO(kvoli): Remove this field in 23.2. The field is no longer consulted
+  // in 23.1
+  optional int64 l0_sublevels = 12 [(gogoproto.nullable) = false];
   optional cockroach.util.admission.admissionpb.IOThreshold io_threshold = 13 [(gogoproto.nullable) = false, (gogoproto.customname) = "IOThreshold" ];
   // bytes_per_replica and writes_per_replica contain percentiles for the
   // number of bytes and writes-per-second to each replica in the store.


### PR DESCRIPTION
We previously checked stores' L0-sublevels to exclude IO overloaded
stores from being allocation targets (https://github.com/cockroachdb/cockroach/pull/78608). This commit replaces the signal
with the normalized IO overload score instead, which also factors in the
L0-filecount. We started gossiping this value as of https://github.com/cockroachdb/cockroach/pull/83720. We continue
gossiping L0-sublevels for mixed-version compatibility; we can stop doing this
in 23.2.

Resolves: https://github.com/cockroachdb/cockroach/issues/85084

Release note (ops change): We've deprecated two cluster settings:
- kv.allocator.l0_sublevels_threshold
- kv.allocator.l0_sublevels_threshold_enforce.
The pair of them were used to control rebalancing and upreplication behavior in
the face of IO overloaded stores. This has been now been replaced by other
internal mechanisms.