### PR TITLE
sql: add missing STORING clause in system.privileges user ID migration

### DIFF
--- a/pkg/upgrade/upgrades/system_privileges_user_id_migration.go
+++ b/pkg/upgrade/upgrades/system_privileges_user_id_migration.go
@@ -28,7 +28,7 @@ FAMILY "primary"
 `
 
 const createUniqueIndexOnUserIDAndPathOnSystemPrivilegesStmt = `
-CREATE UNIQUE INDEX IF NOT EXISTS privileges_path_user_id_key ON system.privileges (path ASC, user_id ASC)
+CREATE UNIQUE INDEX IF NOT EXISTS privileges_path_user_id_key ON system.privileges (path, user_id) STORING (privileges, grant_options)
 `
 
 func alterSystemPrivilegesAddUserIDColumn(

--- a/pkg/upgrade/upgrades/system_privileges_user_id_migration_test.go
+++ b/pkg/upgrade/upgrades/system_privileges_user_id_migration_test.go
@@ -119,7 +119,7 @@ func runTestSystemPrivilegesUserIDMigration(t *testing.T, numUsers int) {
 	grant_options STRING[] NOT NULL,
 	user_id OID NULL,
 	CONSTRAINT "primary" PRIMARY KEY (username ASC, path ASC),
-	UNIQUE INDEX privileges_path_user_id_key (path ASC, user_id ASC)
+	UNIQUE INDEX privileges_path_user_id_key (path ASC, user_id ASC) STORING (privileges, grant_options)
 )`
 	r := tdb.QueryRow(t, "SELECT create_statement FROM [SHOW CREATE TABLE system.privileges]")
 	var actualSchema string


### PR DESCRIPTION
This patch fixes a discrepancy between the bootstrap schema and user ID
migration for the system.privileges table.

Part of #87079

Release note: None