### PR TITLE
ccl/kvccl/kvfollowerreadsccl: skip TestSecondaryTenantFollowerReadsRouting

### DIFF
--- a/pkg/ccl/kvccl/kvfollowerreadsccl/followerreads_test.go
+++ b/pkg/ccl/kvccl/kvfollowerreadsccl/followerreads_test.go
@@ -833,6 +833,7 @@ func TestFollowerReadsWithStaleDescriptor(t *testing.T) {
 // where it needs to be estimated using node localities.
 func TestSecondaryTenantFollowerReadsRouting(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	skip.WithIssue(t, 95338, "flaky test")
 	defer utilccl.TestingEnableEnterprise()()
 
 	skip.UnderStressRace(t, "times out")


### PR DESCRIPTION
Refs: #95338

Reason: flaky test

Generated by bin/skip-test.

Release justification: non-production code changes

Epic: None
Release note: None