### PR TITLE
loqrecovery: add version gate to quorum recovery service

### DIFF
--- a/pkg/kv/kvserver/loqrecovery/BUILD.bazel
+++ b/pkg/kv/kvserver/loqrecovery/BUILD.bazel
@@ -17,6 +17,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/base",
+        "//pkg/clusterversion",
         "//pkg/gossip",
         "//pkg/keys",
         "//pkg/kv",
@@ -30,6 +31,7 @@ go_library(
         "//pkg/roachpb",
         "//pkg/rpc",
         "//pkg/server/serverpb",
+        "//pkg/settings/cluster",
         "//pkg/storage",
         "//pkg/util/contextutil",
         "//pkg/util/grpcutil",

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -1101,6 +1101,7 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 
 	recoveryServer := loqrecovery.NewServer(
 		nodeIDContainer,
+		st,
 		stores,
 		planStore,
 		g,


### PR DESCRIPTION
Previously loss of quorum recovery service was serving requests regardless of effective cluster version. That could lead to already upgraded node trying to make calls to endpoints that didn't exist on previous version.
This commit adds a version gate that only enables methods requiring support when cluster is fully upgraded.

Release note: None

Touches https://github.com/cockroachdb/cockroach/issues/95344