### PR TITLE
storage,sql: add separated value iteration stats to ScanStats

### DIFF
--- a/pkg/roachpb/api.go
+++ b/pkg/roachpb/api.go
@@ -1794,6 +1794,12 @@ func (s *ScanStats) SafeFormat(w redact.SafePrinter, _ rune) {
 		humanizePointCount(s.RangeKeyCount),
 		humanizePointCount(s.RangeKeyContainedPoints),
 		humanizePointCount(s.RangeKeySkippedPoints))
+	if s.SeparatedPointCount != 0 {
+		w.Printf(" separated: (count: %s, bytes: %s, bytes-fetched: %s)",
+			humanizePointCount(s.SeparatedPointCount),
+			humanizeutil.IBytes(int64(s.SeparatedPointValueBytes)),
+			humanizeutil.IBytes(int64(s.SeparatedPointValueBytesFetched)))
+	}
 }
 
 // String implements fmt.Stringer.

--- a/pkg/roachpb/api.proto
+++ b/pkg/roachpb/api.proto
@@ -3223,4 +3223,7 @@ message ScanStats {
   uint64 range_key_count = 11;
   uint64 range_key_contained_points = 12;
   uint64 range_key_skipped_points = 13;
+  uint64 separated_point_count = 14;
+  uint64 separated_point_value_bytes = 15;
+  uint64 separated_point_value_bytes_fetched = 16;
 }

--- a/pkg/sql/execstats/stats.go
+++ b/pkg/sql/execstats/stats.go
@@ -77,16 +77,19 @@ type ScanStats struct {
 	NumInterfaceSeeks uint64
 	// NumInternalSeeks is the number of times that MVCC seek was invoked
 	// internally, including to step over internal, uncompacted Pebble versions.
-	NumInternalSeeks               uint64
-	BlockBytes                     uint64
-	BlockBytesInCache              uint64
-	KeyBytes                       uint64
-	ValueBytes                     uint64
-	PointCount                     uint64
-	PointsCoveredByRangeTombstones uint64
-	RangeKeyCount                  uint64
-	RangeKeyContainedPoints        uint64
-	RangeKeySkippedPoints          uint64
+	NumInternalSeeks                uint64
+	BlockBytes                      uint64
+	BlockBytesInCache               uint64
+	KeyBytes                        uint64
+	ValueBytes                      uint64
+	PointCount                      uint64
+	PointsCoveredByRangeTombstones  uint64
+	RangeKeyCount                   uint64
+	RangeKeyContainedPoints         uint64
+	RangeKeySkippedPoints           uint64
+	SeparatedPointCount             uint64
+	SeparatedPointValueBytes        uint64
+	SeparatedPointValueBytesFetched uint64
 	// ConsumedRU is the number of RUs that were consumed during the course of a
 	// scan.
 	ConsumedRU uint64
@@ -137,6 +140,9 @@ func GetScanStats(ctx context.Context, recording tracingpb.Recording) (scanStats
 				scanStats.RangeKeyCount += ss.RangeKeyCount
 				scanStats.RangeKeyContainedPoints += ss.RangeKeyContainedPoints
 				scanStats.RangeKeySkippedPoints += ss.RangeKeySkippedPoints
+				scanStats.SeparatedPointCount += ss.SeparatedPointCount
+				scanStats.SeparatedPointValueBytes += ss.SeparatedPointValueBytes
+				scanStats.SeparatedPointValueBytesFetched += ss.SeparatedPointValueBytesFetched
 			} else if pbtypes.Is(any, &tc) {
 				if err := pbtypes.UnmarshalAny(any, &tc); err != nil {
 					return

--- a/pkg/storage/mvcc.go
+++ b/pkg/storage/mvcc.go
@@ -3627,19 +3627,22 @@ func recordIteratorStats(ctx context.Context, iter MVCCIterator) {
 	internalSteps := stats.ReverseStepCount[pebble.InternalIterCall] + stats.ForwardStepCount[pebble.InternalIterCall]
 	internalSeeks := stats.ReverseSeekCount[pebble.InternalIterCall] + stats.ForwardSeekCount[pebble.InternalIterCall]
 	sp.RecordStructured(&roachpb.ScanStats{
-		NumInterfaceSeeks:              uint64(seeks),
-		NumInternalSeeks:               uint64(internalSeeks),
-		NumInterfaceSteps:              uint64(steps),
-		NumInternalSteps:               uint64(internalSteps),
-		BlockBytes:                     stats.InternalStats.BlockBytes,
-		BlockBytesInCache:              stats.InternalStats.BlockBytesInCache,
-		KeyBytes:                       stats.InternalStats.KeyBytes,
-		ValueBytes:                     stats.InternalStats.ValueBytes,
-		PointCount:                     stats.InternalStats.PointCount,
-		PointsCoveredByRangeTombstones: stats.InternalStats.PointsCoveredByRangeTombstones,
-		RangeKeyCount:                  uint64(stats.RangeKeyStats.Count),
-		RangeKeyContainedPoints:        uint64(stats.RangeKeyStats.ContainedPoints),
-		RangeKeySkippedPoints:          uint64(stats.RangeKeyStats.SkippedPoints),
+		NumInterfaceSeeks:               uint64(seeks),
+		NumInternalSeeks:                uint64(internalSeeks),
+		NumInterfaceSteps:               uint64(steps),
+		NumInternalSteps:                uint64(internalSteps),
+		BlockBytes:                      stats.InternalStats.BlockBytes,
+		BlockBytesInCache:               stats.InternalStats.BlockBytesInCache,
+		KeyBytes:                        stats.InternalStats.KeyBytes,
+		ValueBytes:                      stats.InternalStats.ValueBytes,
+		PointCount:                      stats.InternalStats.PointCount,
+		PointsCoveredByRangeTombstones:  stats.InternalStats.PointsCoveredByRangeTombstones,
+		RangeKeyCount:                   uint64(stats.RangeKeyStats.Count),
+		RangeKeyContainedPoints:         uint64(stats.RangeKeyStats.ContainedPoints),
+		RangeKeySkippedPoints:           uint64(stats.RangeKeyStats.SkippedPoints),
+		SeparatedPointCount:             stats.InternalStats.SeparatedPointValue.Count,
+		SeparatedPointValueBytes:        stats.InternalStats.SeparatedPointValue.ValueBytes,
+		SeparatedPointValueBytesFetched: stats.InternalStats.SeparatedPointValue.ValueBytesFetched,
 	})
 }
 


### PR DESCRIPTION
execinfrapb.ScanStats and execstats.ScanStats have these new fields. The intention here is for traces to show these stats and not to complete the plumbing to expose these in the fingerprint stats table.

Informs https://github.com/cockroachdb/pebble/issues/1170

Epic: CRDB-20378

Release note: None