### PR TITLE
release-22.2: logictest: remove added lines in crdb_internal

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/crdb_internal
+++ b/pkg/sql/logictest/testdata/logic_test/crdb_internal
@@ -792,12 +792,6 @@ SELECT start_pretty, end_pretty FROM crdb_internal.ranges
 WHERE split_enforced_until IS NOT NULL
 AND (start_pretty LIKE '/Table/112/1%' OR start_pretty LIKE '/Table/112/2%')
 ----
-/Table/112/1/1  /Table/112/1/2
-/Table/112/1/2  /Table/112/1/3
-/Table/112/1/3  /Table/112/2/1
-/Table/112/2/1  /Table/112/2/2
-/Table/112/2/2  /Table/112/2/3
-/Table/112/2/3  /Table/112/3/1
 
 statement ok
 ALTER TABLE foo SPLIT AT VALUES (1), (2), (3)


### PR DESCRIPTION
https://github.com/cockroachdb/cockroach/pull/96454 mistakenly added some extra lines to the crdb_internal logic test causing stress tests to fail.

Epic: none
Fixes: #96861

Release note: None
Release justification: test-only changes