### PR TITLE
server: validate removing node connections via nodeTombstoneStorage

### DIFF
--- a/pkg/rpc/BUILD.bazel
+++ b/pkg/rpc/BUILD.bazel
@@ -36,6 +36,7 @@ go_library(
         "//pkg/security/username",
         "//pkg/settings/cluster",
         "//pkg/util/buildutil",
+        "//pkg/util/circuit",
         "//pkg/util/contextutil",
         "//pkg/util/envutil",
         "//pkg/util/growstack",

--- a/pkg/rpc/context.go
+++ b/pkg/rpc/context.go
@@ -2137,7 +2137,7 @@ func (m *connMap) OnDisconnect(k connKey, conn *Connection) error {
 	defer m.mu.Unlock()
 	mConn, found := m.mu.m[k]
 	if !found {
-		return errors.AssertionFailedf("no conn found for %+v", k)
+		return nil
 	}
 	if mConn.c != conn {
 		return errors.AssertionFailedf("conn for %+v not identical to those for which removal was requested", k)
@@ -2281,7 +2281,7 @@ func (rpcCtx *Context) runHeartbeat(ctx context.Context, conn *Connection, k con
 		if retErr != nil {
 			conn.err.Store(retErr)
 			if ctx.Err() == nil {
-				// If the remote Peer is down, we'll get fail-fast errors and since we
+				// If the remote peer is down, we'll get fail-fast errors and since we
 				// don't have circuit breakers at the rpcCtx level, we need to avoid a
 				// busy loop of corresponding logging. We ask the EveryN only if we're
 				// looking at an InitialHeartbeatFailedError; if we did manage to
@@ -2292,7 +2292,7 @@ func (rpcCtx *Context) runHeartbeat(ctx context.Context, conn *Connection, k con
 				); !neverHealthy || rpcCtx.logClosingConnEvery.ShouldLog() {
 					var buf redact.StringBuilder
 					if neverHealthy {
-						buf.Printf("unable to connect (is the Peer up and reachable?): %v", retErr)
+						buf.Printf("unable to connect (is the peer up and reachable?): %v", retErr)
 					} else {
 						buf.Printf("closing connection after: %s", retErr)
 					}
@@ -2510,4 +2510,9 @@ func (rpcCtx *Context) NewHeartbeatService() *HeartbeatService {
 		onHandlePing:                          rpcCtx.OnIncomingPing,
 		testingAllowNamedRPCToAnonymousServer: rpcCtx.TestingAllowNamedRPCToAnonymousServer,
 	}
+}
+
+// RemoveNodeConnections removes all known connections to target node.
+func (rpcCtx *Context) RemoveNodeConnections(nodeID roachpb.NodeID) error {
+	return rpcCtx.m.RemoveNodeConnections(nodeID)
 }

--- a/pkg/rpc/context_test.go
+++ b/pkg/rpc/context_test.go
@@ -166,6 +166,74 @@ func TestHeartbeatCB(t *testing.T) {
 	})
 }
 
+func TestPeersReconnect(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	//testutils.RunTrueAndFalse(t, "compression", func(t *testing.T, compression bool) {
+	stopper := stop.NewStopper()
+	defer stopper.Stop(context.Background())
+
+	// Shared cluster ID by all RPC peers (this ensures that the peers
+	// don't talk to servers from unrelated tests by accident).
+	clusterID := uuid.MakeV4()
+
+	clock := timeutil.NewManualTime(timeutil.Unix(0, 20))
+	maxOffset := time.Duration(250)
+	serverCtx := newTestContext(clusterID, clock, maxOffset, stopper)
+	//serverCtx.rpcCompression = compression
+	const serverNodeID = 1
+	serverCtx.NodeID.Set(context.Background(), serverNodeID)
+	s := newTestServer(t, serverCtx)
+	RegisterHeartbeatServer(s, &HeartbeatService{
+		clock:              clock,
+		remoteClockMonitor: serverCtx.RemoteClocks,
+		clusterID:          serverCtx.StorageClusterID,
+		nodeID:             serverCtx.NodeID,
+		settings:           serverCtx.Settings,
+	})
+
+	ln, err := netutil.ListenAndServeGRPC(serverCtx.Stopper, s, util.TestAddr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	remoteAddr := ln.Addr().String()
+
+	// Clocks don't matter in this test.
+	clientCtx := newTestContext(clusterID, clock, maxOffset, stopper)
+
+	conn, err := clientCtx.GRPCDialNode(remoteAddr, serverNodeID, DefaultClass).Connect(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	clock.Advance(time.Second)
+	conn.Close()
+	clock.Advance(time.Second)
+	testutils.SucceedsSoon(t, func() error {
+		k := connKey{
+			targetAddr: remoteAddr,
+			nodeID:     serverNodeID,
+			class:      DefaultClass,
+		}
+		c, ok := clientCtx.m.Get(k)
+		if !ok {
+			return fmt.Errorf("cannot find connection")
+		}
+		if c.grpcConn == conn {
+			return fmt.Errorf("hmmm")
+		}
+		return nil
+	})
+
+	cc := clientCtx.GRPCDialNode(remoteAddr, serverNodeID, DefaultClass)
+
+	testutils.SucceedsSoon(t, func() error {
+		if err = cc.Health(); err != nil {
+			return err
+		}
+		return nil
+	})
+}
+
 // TestPingInterceptors checks that OnOutgoingPing and OnIncomingPing can inject errors.
 func TestPingInterceptors(t *testing.T) {
 	defer leaktest.AfterTest(t)()
@@ -2108,9 +2176,9 @@ func TestClusterNameMismatch(t *testing.T) {
 	}{
 		{"", false, "", false, ``},
 		// The name check is enabled if both the client and server want it.
-		{"a", false, "", false, `peer node expects cluster name "a", use --cluster-name to configure`},
-		{"", false, "a", false, `peer node does not have a cluster name configured, cannot use --cluster-name`},
-		{"a", false, "b", false, `local cluster name "b" does not match peer cluster name "a"`},
+		{"a", false, "", false, `Peer node expects cluster name "a", use --cluster-name to configure`},
+		{"", false, "a", false, `Peer node does not have a cluster name configured, cannot use --cluster-name`},
+		{"a", false, "b", false, `local cluster name "b" does not match Peer cluster name "a"`},
 		// It's disabled if either doesn't want it.
 		// However in any case if the name is not empty it has to match.
 		{"a", true, "", false, ``},

--- a/pkg/server/decommission.go
+++ b/pkg/server/decommission.go
@@ -424,3 +424,18 @@ func (s *Server) DecommissioningNodeMap() map[roachpb.NodeID]interface{} {
 	}
 	return nodes
 }
+
+// checkIsDecommissioned returns a boolean indicating when a node was decommissioned based
+// on nodeTomstoneStorage.
+// This is meant for internal usage only.
+func checkIsDecommissioned(
+	ctx context.Context, nodeID roachpb.NodeID, nodeTombstones *nodeTombstoneStorage,
+) bool {
+	ts, err := nodeTombstones.IsDecommissioned(ctx, nodeID)
+	if err != nil {
+		// An error here means something very basic is not working. Better to terminate
+		// than to limp along.
+		log.Fatalf(ctx, "unable to read decommissioned status for n%d: %v", nodeID, err)
+	}
+	return !ts.IsZero()
+}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -495,6 +495,7 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 			}
 
 			decomNodeMap.onNodeDecommissioned(liveness.NodeID)
+			rpcContext.RemoveNodeConnections(liveness.NodeID)
 		},
 	})
 	registry.AddMetricStruct(nodeLiveness.Metrics())

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -495,7 +495,7 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 			}
 
 			decomNodeMap.onNodeDecommissioned(liveness.NodeID)
-			rpcContext.RemoveNodeConnections(liveness.NodeID)
+			rpcContext.RemoveNodeConnections(liveness.NodeID, func() bool { return checkIsDecommissioned(ctx, liveness.NodeID, nodeTombStorage) })
 		},
 	})
 	registry.AddMetricStruct(nodeLiveness.Metrics())


### PR DESCRIPTION
This patch updates the work done in https://github.com/cockroachdb/cockroach/pull/96566 to validate whether to remove
node connections by indirectly checking the node status in
`nodeTombstoneStorage`.

Epic: None

Release note: None