### PR TITLE
colexecerror: catch panics from util/encoding

### DIFF
--- a/pkg/sql/colexecerror/error.go
+++ b/pkg/sql/colexecerror/error.go
@@ -101,6 +101,7 @@ func CatchVectorizedRuntimeError(operation func()) (retErr error) {
 // defined below, but all of such packages are allowed to be caught from.
 const (
 	colPackagesPrefix      = "github.com/cockroachdb/cockroach/pkg/col"
+	encodingPackagePrefix  = "github.com/cockroachdb/cockroach/pkg/util/encoding"
 	execinfraPackagePrefix = "github.com/cockroachdb/cockroach/pkg/sql/execinfra"
 	sqlColPackagesPrefix   = "github.com/cockroachdb/cockroach/pkg/sql/col"
 	sqlRowPackagesPrefix   = "github.com/cockroachdb/cockroach/pkg/sql/row"
@@ -130,6 +131,7 @@ func shouldCatchPanic(panicEmittedFrom string) bool {
 		return false
 	}
 	return strings.HasPrefix(panicEmittedFrom, colPackagesPrefix) ||
+		strings.HasPrefix(panicEmittedFrom, encodingPackagePrefix) ||
 		strings.HasPrefix(panicEmittedFrom, execinfraPackagePrefix) ||
 		strings.HasPrefix(panicEmittedFrom, sqlColPackagesPrefix) ||
 		strings.HasPrefix(panicEmittedFrom, sqlRowPackagesPrefix) ||


### PR DESCRIPTION
We recently saw a couple of cases where data corruption led to panics when decoding that data. It is safe to catch such panics from `util/encoding` package and convert them into internal errors since that package doesn't deal with any mutexes or whatnot, so this commit includes it into the allowlist for the vectorized panic catcher.

Informs: #97132.

Epic: None

Release note: None