### PR TITLE
sqlsmith: skip crdb_internal.fingerprint

### DIFF
--- a/pkg/internal/sqlsmith/schema.go
+++ b/pkg/internal/sqlsmith/schema.go
@@ -516,6 +516,9 @@ var functions = func() map[tree.FunctionClass]map[oid.Oid][]function {
 			// TODO(96555): Temporarily disable crdb_internal.hide_sql_constants,
 			// which produces internal errors for some valid inputs.
 			"crdb_internal.hide_sql_constants",
+			// TODO(#97097): Temporarily disable crdb_internal.fingerprint
+			// which produces internal errors for some valid inputs.
+			"crdb_internal.fingerprint",
 		} {
 			skip = skip || strings.Contains(def.Name, substr)
 		}


### PR DESCRIPTION
`crdb_internal.fingerprint` is a recently added builtin function that
produces internal errors for some valid inputs. This commit adds it to
the sqlsmith skip list until it is fixed.

Informs #97097

Epic: None

Release note: None
