### PR TITLE
sql: support record return type in udfs

### DIFF
--- a/pkg/ccl/logictestccl/tests/3node-tenant/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/3node-tenant/generated_test.go
@@ -2040,6 +2040,13 @@ func TestTenantLogic_udf_oid_ref(
 	runLogicTest(t, "udf_oid_ref")
 }
 
+func TestTenantLogic_udf_record(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "udf_record")
+}
+
 func TestTenantLogic_udf_setof(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/testdata/logic_test/udf_record
+++ b/pkg/sql/logictest/testdata/logic_test/udf_record
@@ -1,0 +1,134 @@
+statement ok
+CREATE TABLE t (a INT PRIMARY KEY, b INT);
+INSERT INTO t VALUES (1, 5), (2, 6), (3, 7);
+
+statement ok
+CREATE FUNCTION f_one() RETURNS RECORD AS
+$$
+  SELECT 1;
+$$ LANGUAGE SQL;
+
+query T
+SELECT f_one();
+----
+(1)
+
+# TODO(97059): The following query should require a column definition list.
+statement ok
+SELECT * FROM f_one();
+
+# TODO(97059): The following query should produce a row, not a tuple.
+query T
+SELECT * FROM f_one() AS foo (a INT);
+----
+(1)
+
+statement ok
+CREATE FUNCTION f_const() RETURNS RECORD AS
+$$
+  SELECT 1, 2.0, 'welcome roacher', '2021-07-12 09:02:10-08:00'::TIMESTAMPTZ;
+$$ LANGUAGE SQL;
+
+query T
+SELECT f_const();
+----
+(1,2.0,"welcome roacher","2021-07-12 17:02:10+00")
+
+statement ok
+CREATE FUNCTION f_arr() RETURNS RECORD AS
+$$
+  SELECT ARRAY[1, 2, 3];
+$$ LANGUAGE SQL;
+
+query T
+SELECT f_arr();
+----
+("{1,2,3}")
+
+statement ok
+CREATE FUNCTION f_tuple() RETURNS RECORD AS
+$$
+  SELECT (4, 5, (6, 7, 8));
+$$ LANGUAGE SQL;
+
+query T
+SELECT f_tuple();
+----
+(4,5,"(6,7,8)")
+
+statement ok
+CREATE FUNCTION f_multituple() RETURNS RECORD AS
+$$
+  SELECT (1, 2), (3, 4);
+$$ LANGUAGE SQL;
+
+query T
+SELECT f_multituple();
+----
+("(1,2)","(3,4)")
+
+statement ok
+CREATE FUNCTION f_table() RETURNS RECORD AS
+$$
+  SELECT * FROM t ORDER BY a LIMIT 1;
+$$ LANGUAGE SQL;
+
+query TT
+SHOW CREATE FUNCTION f_table;
+----
+f_table  CREATE FUNCTION public.f_table()
+           RETURNS RECORD
+           VOLATILE
+           NOT LEAKPROOF
+           CALLED ON NULL INPUT
+           LANGUAGE SQL
+           AS $$
+           SELECT t.a, t.b FROM test.public.t ORDER BY a LIMIT 1;
+         $$
+
+query T
+SELECT f_table();
+----
+(1,5)
+
+statement ok
+CREATE FUNCTION f_multitable() RETURNS RECORD AS
+$$
+  SELECT t1.*, t2.* FROM t as t1 JOIN t as t2 on t1.a = t2.a ORDER BY t1.a LIMIT 1;
+$$ LANGUAGE SQL;
+
+query T
+SELECT f_multitable();
+----
+(1,5,1,5)
+
+statement ok
+CREATE FUNCTION f_setof() RETURNS SETOF RECORD AS
+$$
+  SELECT * FROM t
+$$ LANGUAGE SQL;
+
+query T rowsort
+SELECT f_setof();
+----
+(1,5)
+(2,6)
+(3,7)
+
+statement ok
+CREATE FUNCTION f_row() RETURNS RECORD IMMUTABLE LEAKPROOF LANGUAGE SQL AS 'SELECT ROW(1.1)';
+
+query T
+SELECT f_row();
+----
+(1.1)
+
+statement ok
+ALTER TABLE t ADD COLUMN c INT DEFAULT 0;
+
+query T
+SELECT f_table();
+----
+(1,5)
+
+

--- a/pkg/sql/logictest/tests/fakedist-disk/generated_test.go
+++ b/pkg/sql/logictest/tests/fakedist-disk/generated_test.go
@@ -2011,6 +2011,13 @@ func TestLogic_udf_oid_ref(
 	runLogicTest(t, "udf_oid_ref")
 }
 
+func TestLogic_udf_record(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "udf_record")
+}
+
 func TestLogic_udf_setof(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/fakedist-vec-off/generated_test.go
+++ b/pkg/sql/logictest/tests/fakedist-vec-off/generated_test.go
@@ -2018,6 +2018,13 @@ func TestLogic_udf_oid_ref(
 	runLogicTest(t, "udf_oid_ref")
 }
 
+func TestLogic_udf_record(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "udf_record")
+}
+
 func TestLogic_udf_setof(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/fakedist/generated_test.go
+++ b/pkg/sql/logictest/tests/fakedist/generated_test.go
@@ -2032,6 +2032,13 @@ func TestLogic_udf_oid_ref(
 	runLogicTest(t, "udf_oid_ref")
 }
 
+func TestLogic_udf_record(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "udf_record")
+}
+
 func TestLogic_udf_setof(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/local-legacy-schema-changer/generated_test.go
+++ b/pkg/sql/logictest/tests/local-legacy-schema-changer/generated_test.go
@@ -1997,6 +1997,13 @@ func TestLogic_udf_oid_ref(
 	runLogicTest(t, "udf_oid_ref")
 }
 
+func TestLogic_udf_record(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "udf_record")
+}
+
 func TestLogic_udf_setof(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/local-vec-off/generated_test.go
+++ b/pkg/sql/logictest/tests/local-vec-off/generated_test.go
@@ -2032,6 +2032,13 @@ func TestLogic_udf_oid_ref(
 	runLogicTest(t, "udf_oid_ref")
 }
 
+func TestLogic_udf_record(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "udf_record")
+}
+
 func TestLogic_udf_setof(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/local/generated_test.go
+++ b/pkg/sql/logictest/tests/local/generated_test.go
@@ -2221,6 +2221,13 @@ func TestLogic_udf_oid_ref(
 	runLogicTest(t, "udf_oid_ref")
 }
 
+func TestLogic_udf_record(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "udf_record")
+}
+
 func TestLogic_udf_setof(
 	t *testing.T,
 ) {

--- a/pkg/sql/opt/optbuilder/create_function.go
+++ b/pkg/sql/opt/optbuilder/create_function.go
@@ -214,6 +214,10 @@ func validateReturnType(expected *types.T, cols []scopeColumn) error {
 	if expected.Equivalent(types.Void) {
 		return nil
 	}
+	// If return type is RECORD, any column types are valid.
+	if types.IsRecordType(expected) {
+		return nil
+	}
 
 	if len(cols) == 0 {
 		return pgerror.WithCandidateCode(

--- a/pkg/sql/types/types.go
+++ b/pkg/sql/types/types.go
@@ -2720,6 +2720,13 @@ func IsWildcardTupleType(t *T) bool {
 	return len(t.TupleContents()) == 1 && t.TupleContents()[0].Family() == AnyFamily
 }
 
+// IsRecordType returns true if this is a RECORD type. This should only be used
+// when processing UDFs. A record differs from AnyTuple in that the tuple
+// contents may contain types other than Any.
+func IsRecordType(typ *T) bool {
+	return typ.Family() == TupleFamily && typ.Oid() == oid.T_record
+}
+
 // collatedStringTypeSQL returns the string representation of a COLLATEDSTRING
 // or []COLLATEDSTRING type. This is tricky in the case of an array of collated
 // string, since brackets must precede the COLLATE identifier:


### PR DESCRIPTION
UDFs can now use a `RECORD` return type that can match any tuple.

Epic: CRDB-19496
Fixes: #95171
Release note: UDFs can now return the `RECORD` result type. `RECORD` represents any tuple. For example, `CREATE FUNCTION f() RETURNS RECORD AS 'SELECT * FROM t' LANGUAGE SQL;` is equivalent to `CREATE FUNCTION f() RETURNS t AS 'SELECT * FROM t' LANGUAGE SQL;