### PR TITLE
release-22.2: sql/sqlstats/persistedsqlstats: fix flakey TestSQLStatsScheduleOperations

### DIFF
--- a/pkg/sql/sqlstats/persistedsqlstats/scheduled_job_monitor.go
+++ b/pkg/sql/sqlstats/persistedsqlstats/scheduled_job_monitor.go
@@ -99,10 +99,14 @@ func (j *jobMonitor) start(ctx context.Context, stopper *stop.Stopper) {
 			case <-stopCtx.Done():
 				return
 			}
-			if SQLStatsCleanupRecurrence.Get(&j.st.SV) != currentRecurrence || nextJobScheduleCheck.Before(timeutil.Now()) {
-				j.updateSchedule(stopCtx, j.ie)
+
+			// Read the config once to avoid race condition if config is changed during
+			// the update process.
+			newRecurrence := SQLStatsCleanupRecurrence.Get(&j.st.SV)
+			if newRecurrence != currentRecurrence || nextJobScheduleCheck.Before(timeutil.Now()) {
+				j.updateSchedule(stopCtx, j.ie, newRecurrence)
 				nextJobScheduleCheck = timeutil.Now().Add(j.jitterFn(j.scanInterval))
-				currentRecurrence = SQLStatsCleanupRecurrence.Get(&j.st.SV)
+				currentRecurrence = newRecurrence
 			}
 
 			timer.Reset(updateCheckInterval)
@@ -141,7 +145,9 @@ func (j *jobMonitor) getSchedule(
 	return sj, nil
 }
 
-func (j *jobMonitor) updateSchedule(ctx context.Context, ie sqlutil.InternalExecutor) {
+func (j *jobMonitor) updateSchedule(
+	ctx context.Context, ie sqlutil.InternalExecutor, cronExpr string,
+) {
 	var sj *jobs.ScheduledJob
 	var err error
 	retryOptions := retry.Options{
@@ -162,8 +168,7 @@ func (j *jobMonitor) updateSchedule(ctx context.Context, ie sqlutil.InternalExec
 					return err
 				}
 			}
-			// Update schedule with new recurrence, if different.
-			cronExpr := SQLStatsCleanupRecurrence.Get(&j.st.SV)
+
 			if sj.ScheduleExpr() == cronExpr {
 				return nil
 			}

--- a/pkg/sql/sqlstats/persistedsqlstats/scheduled_sql_stats_compaction_test.go
+++ b/pkg/sql/sqlstats/persistedsqlstats/scheduled_sql_stats_compaction_test.go
@@ -234,6 +234,11 @@ func TestSQLStatsScheduleOperations(t *testing.T) {
 
 			helper.sqlDB.Exec(t, "RESET CLUSTER SETTING sql.stats.cleanup.recurrence")
 			helper.sqlDB.CheckQueryResultsRetry(t,
+				`SHOW CLUSTER SETTING sql.stats.cleanup.recurrence`,
+				[][]string{{"@hourly"}},
+			)
+
+			helper.sqlDB.CheckQueryResultsRetry(t,
 				fmt.Sprintf(`
 SELECT schedule_expr
 FROM system.scheduled_jobs WHERE schedule_id = %d`, schedID),


### PR DESCRIPTION
Backport 1/1 commits from #97126.

/cc @cockroachdb/release

---

This fixes test failures that happen rarely during stress runs. The theory of what 
causes the failure is the following scenario.

1. Update the config to v1
2. Background monitor loops every 1 second in the test
3. Monitor sees the value is updated and runs `j.updateSchedule`.
4. After `j.updateSchedule` a new config value is set to v2
5. currentRecurrence is set to v2 even though job is set to v1
6. Monitor does not update because it thinks it's already set to v2

To fix this issue the config is read once and passed around to avoid any race 
condition. Additional checks were added to verify the setting was actually reset.

closes #93601

Epic: None

Release note: None

Release justification: Fix flakey test and race condition
