### PR TITLE
server, sql: move cluster version change metric to SQL

### DIFF
--- a/pkg/clusterversion/BUILD.bazel
+++ b/pkg/clusterversion/BUILD.bazel
@@ -36,14 +36,18 @@ go_test(
     srcs = [
         "clusterversion_test.go",
         "cockroach_versions_test.go",
+        "setting_test.go",
     ],
     args = ["-test.timeout=55s"],
     embed = [":clusterversion"],
     deps = [
         "//pkg/roachpb",
         "//pkg/settings",
+        "//pkg/settings/cluster",
+        "//pkg/testutils",
         "//pkg/util/leaktest",
         "//pkg/util/protoutil",
+        "@com_github_cockroachdb_errors//:errors",
         "@com_github_cockroachdb_redact//:redact",
         "@com_github_dustin_go_humanize//:go-humanize",
         "@com_github_stretchr_testify//require",

--- a/pkg/clusterversion/setting_test.go
+++ b/pkg/clusterversion/setting_test.go
@@ -1,0 +1,62 @@
+// Copyright 2023 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package clusterversion_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/clusterversion"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/testutils"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/errors"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMakeMetricsAndRegisterOnVersionChangeCallback(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	ctx := context.Background()
+	s1 := cluster.MakeTestingClusterSettingsWithVersions(clusterversion.TestingBinaryVersion, clusterversion.TestingBinaryMinSupportedVersion, true)
+	s2 := cluster.MakeTestingClusterSettingsWithVersions(clusterversion.TestingBinaryVersion, clusterversion.TestingBinaryMinSupportedVersion, true)
+
+	m1 := clusterversion.MakeMetricsAndRegisterOnVersionChangeCallback(&s1.SV)
+	m2 := clusterversion.MakeMetricsAndRegisterOnVersionChangeCallback(&s2.SV)
+
+	require.Equal(t, int64(0), m1.PreserveDowngradeLastUpdated.Value())
+	require.Equal(t, int64(0), m2.PreserveDowngradeLastUpdated.Value())
+
+	// Test that the metrics returned are independent.
+	clusterversion.PreserveDowngradeVersion.Override(ctx, &s1.SV, clusterversion.TestingBinaryVersion.String())
+	testutils.SucceedsSoon(t, func() error {
+		if int64(0) >= m1.PreserveDowngradeLastUpdated.Value() {
+			return errors.New("metric is zero. expected positive number.")
+		}
+		return nil
+	})
+	require.Equal(t, int64(0), m2.PreserveDowngradeLastUpdated.Value())
+
+	clusterversion.PreserveDowngradeVersion.Override(ctx, &s2.SV, clusterversion.TestingBinaryVersion.String())
+	testutils.SucceedsSoon(t, func() error {
+		if int64(0) >= m2.PreserveDowngradeLastUpdated.Value() {
+			return errors.New("metric is zero. expected positive number.")
+		}
+		return nil
+	})
+
+	clusterversion.PreserveDowngradeVersion.Override(ctx, &s1.SV, "")
+	testutils.SucceedsSoon(t, func() error {
+		if int64(0) != m1.PreserveDowngradeLastUpdated.Value() {
+			return errors.New("metric is non-zero. expected zero.")
+		}
+		return nil
+	})
+}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -389,11 +389,6 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 	cfg.RuntimeStatSampler = runtimeSampler
 
 	registry.AddMetric(base.LicenseTTL)
-
-	clusterVersionMetrics := clusterversion.MakeMetrics()
-	registry.AddMetricStruct(clusterVersionMetrics)
-	clusterversion.RegisterOnVersionChangeCallback(&st.SV)
-
 	err = base.UpdateMetricOnLicenseChange(ctx, cfg.Settings, base.LicenseTTL, timeutil.DefaultTimeSource{}, stopper)
 	if err != nil {
 		log.Errorf(ctx, "unable to initialize periodic license metric update: %v", err)

--- a/pkg/server/server_sql.go
+++ b/pkg/server/server_sql.go
@@ -1502,6 +1502,9 @@ func (s *SQLServer) preStart(
 		return errors.Wrap(err, "initializing settings")
 	}
 
+	clusterVersionMetrics := clusterversion.MakeMetricsAndRegisterOnVersionChangeCallback(&s.cfg.Settings.SV)
+	s.metricsRegistry.AddMetricStruct(clusterVersionMetrics)
+
 	// Run all the "permanent" upgrades that haven't already run in this cluster,
 	// until the currently active version. Upgrades for higher versions, if any,
 	// will be run in response to `SET CLUSTER SETTING version = <v>`, just like


### PR DESCRIPTION
Previously, we had a globally updated metric named `cluster.preserve-downgrade-option.last-updated` which was updated with a timestamp every time the `cluster.preserve_downgrade_option` cluster setting was set. This was to help alert users that they had left the option on for "too long".

This configuration was not multi-tenant friendly since the cluster setting is tenant writeable, but the metric was global on the node. This meant that tenants setting this setting would clobber each others metrics.

The metric generation and callback registration with the setting has now been moved to the SQL server preStart method in order to be set up on every tenant separately.

Resolves #96219
Epic: CRDB-12100
Release note: none