### PR TITLE
ccl/kvccl/kvtenantccl: skip TestTenantUpgrade

### DIFF
--- a/pkg/ccl/kvccl/kvtenantccl/BUILD.bazel
+++ b/pkg/ccl/kvccl/kvtenantccl/BUILD.bazel
@@ -85,6 +85,7 @@ go_test(
         "//pkg/sql/sqlliveness/slinstance",
         "//pkg/testutils",
         "//pkg/testutils/serverutils",
+        "//pkg/testutils/skip",
         "//pkg/testutils/sqlutils",
         "//pkg/testutils/testcluster",
         "//pkg/upgrade",

--- a/pkg/ccl/kvccl/kvtenantccl/tenant_upgrade_test.go
+++ b/pkg/ccl/kvccl/kvtenantccl/tenant_upgrade_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/server"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlliveness/slinstance"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
 	"github.com/cockroachdb/cockroach/pkg/upgrade"
@@ -47,6 +48,7 @@ import (
 // also verifies that the version is correct after a restart
 func TestTenantUpgrade(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	skip.WithIssue(t, 97076, "flaky test")
 	defer log.Scope(t).Close(t)
 	ctx := context.Background()
 	settings := cluster.MakeTestingClusterSettingsWithVersions(


### PR DESCRIPTION
Refs: #97076

Reason: flaky test

Generated by bin/skip-test.

Release justification: non-production code changes
Release note: None
Epic: None