### PR TITLE
kvserver: addMVCCStats with no check for inited replica

### DIFF
--- a/pkg/kv/kvserver/store_split.go
+++ b/pkg/kv/kvserver/store_split.go
@@ -189,14 +189,7 @@ func splitPostApply(
 
 	// Update store stats with difference in stats before and after split.
 	if rightReplOrNil != nil {
-		if _, ok := rightReplOrNil.TenantID(); ok {
-			// TODO(tbg): why this check to get here? Is this really checking if the RHS
-			// is already initialized? But isn't it always, at this point?
-			rightReplOrNil.store.metrics.addMVCCStats(ctx, rightReplOrNil.tenantMetricsRef, deltaMS)
-		} else {
-			log.Fatalf(ctx, "%s: found replica which is RHS of a split "+
-				"without a valid tenant ID", rightReplOrNil)
-		}
+		rightReplOrNil.store.metrics.addMVCCStats(ctx, rightReplOrNil.tenantMetricsRef, deltaMS)
 	}
 
 	now := r.store.Clock().NowAsClockTimestamp()


### PR DESCRIPTION
Remove the unnecessary check for tenant ID. The ID, and tenantMetricsRef is always set for an initialized Replica, so we can just use it.

Release note: none
Epic: none