### PR TITLE
asim: remove speed test

### DIFF
--- a/pkg/kv/kvserver/asim/BUILD.bazel
+++ b/pkg/kv/kvserver/asim/BUILD.bazel
@@ -28,8 +28,6 @@ go_test(
         "//pkg/kv/kvserver/asim/metrics",
         "//pkg/kv/kvserver/asim/state",
         "//pkg/kv/kvserver/asim/workload",
-        "//pkg/testutils/skip",
-        "//pkg/util/timeutil",
         "@com_github_stretchr_testify//require",
     ],
 )

--- a/pkg/kv/kvserver/asim/asim_test.go
+++ b/pkg/kv/kvserver/asim/asim_test.go
@@ -12,8 +12,6 @@ package asim_test
 
 import (
 	"context"
-	"fmt"
-	"math"
 	"os"
 	"testing"
 	"time"
@@ -23,8 +21,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/asim/metrics"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/asim/state"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/asim/workload"
-	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
-	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/stretchr/testify/require"
 )
 
@@ -40,83 +36,6 @@ func TestRunAllocatorSimulator(t *testing.T) {
 
 	sim := asim.NewSimulator(duration, rwg, s, settings, m)
 	sim.RunSim(ctx)
-}
-
-// TestAllocatorSimulatorSpeed tests that the simulation runs at a rate of at
-// least 1.67 simulated minutes per wall clock second (1:100) for a 32 node
-// cluster, with 32000 replicas. The workload is generating 16000 keys per
-// second with a uniform distribution.
-func TestAllocatorSimulatorSpeed(t *testing.T) {
-	ctx := context.Background()
-
-	skipString := "Skipping test under (?stress|?race) as it asserts on speed of the run."
-	skip.UnderStress(t, skipString)
-	skip.UnderStressRace(t, skipString)
-	skip.UnderRace(t, skipString)
-
-	settings := config.DefaultSimulationSettings()
-
-	// Run each simulation for 5 minutes.
-	duration := 5 * time.Minute
-	settings.TickInterval = 2 * time.Second
-
-	stores := 32
-	replsPerRange := 3
-	replicasPerStore := 1000
-	// NB: We want 1000 replicas per store, so the number of ranges required
-	// will be 1/3 of the total replicas.
-	ranges := (replicasPerStore * stores) / replsPerRange
-	// NB: In this test we are using a uniform workload and expect to see at
-	// most 3 splits occur due to range size, therefore the keyspace need not
-	// be larger than 3 keys per range.
-	keyspace := 3 * ranges
-
-	sample := func() int64 {
-		rwg := make([]workload.Generator, 1)
-		rwg[0] = workload.TestCreateWorkloadGenerator(settings.Seed, settings.StartTime, stores, int64(keyspace))
-		m := metrics.NewTracker(settings.MetricsInterval) // no output
-		replicaDistribution := make([]float64, stores)
-
-		// NB: Here create half of the stores with equal replica counts, the
-		// other half have no replicas. This will lead to a flurry of activity
-		// rebalancing towards these stores, based on the replica count
-		// imbalance.
-		for i := 0; i < stores/2; i++ {
-			replicaDistribution[i] = 1.0 / float64(stores/2)
-		}
-		for i := stores / 2; i < stores; i++ {
-			replicaDistribution[i] = 0
-		}
-
-		s := state.NewStateWithDistribution(replicaDistribution, ranges, replsPerRange, keyspace, settings)
-		sim := asim.NewSimulator(duration, rwg, s, settings, m)
-
-		startTime := timeutil.Now()
-		sim.RunSim(ctx)
-		return timeutil.Since(startTime).Nanoseconds()
-	}
-
-	// We sample 5 runs and take the minimum. The minimum is the cleanest
-	// estimate here of performance, as any additional time over the minimum is
-	// noise in a run.
-	minRunTime := int64(math.MaxInt64)
-	// TODO(kvoli): Hit perf wall again when running at a lower tick rate on
-	// selected operartions.
-	requiredRunTime := 30 * time.Second.Nanoseconds()
-	samples := 5
-	for i := 0; i < samples; i++ {
-		if sampledRun := sample(); sampledRun < minRunTime {
-			minRunTime = sampledRun
-		}
-		// NB: When we satisfy the test required runtime, exit early to avoid
-		// additional runs.
-		if minRunTime < requiredRunTime {
-			break
-		}
-	}
-
-	fmt.Println(time.Duration(minRunTime).Seconds())
-	require.Less(t, minRunTime, requiredRunTime)
 }
 
 func TestAllocatorSimulatorDeterministic(t *testing.T) {


### PR DESCRIPTION
A simulator speed test was added to notify on regressions in simulation speed. This test ended up needing several revisions and continues to flake.

This commit removes the speed test as other tests now exercise e2e simulation runs which give insight into speed.

Fixes: #97244

Release note: None