### PR TITLE
release-22.2: ui: add change page controls in recent execs overview

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/statementsPage/activeStatementsView.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsPage/activeStatementsView.tsx
@@ -35,10 +35,12 @@ import { inactiveFiltersState } from "../queryFilter/filter";
 import { queryByName, syncHistory } from "src/util/query";
 import { getTableSortFromURL } from "../sortedtable/getTableSortFromURL";
 import { getActiveStatementFiltersFromURL } from "src/queryFilter/utils";
+import { Pagination } from "src/pagination";
 
 import styles from "./statementsPage.module.scss";
 
 const cx = classNames.bind(styles);
+const PAGE_SIZE = 20;
 
 export type ActiveStatementsViewDispatchProps = {
   onColumnsSelect: (columns: string[]) => void;
@@ -75,7 +77,7 @@ export const ActiveStatementsView: React.FC<ActiveStatementsViewProps> = ({
 }: ActiveStatementsViewProps) => {
   const [pagination, setPagination] = useState<ISortedTablePagination>({
     current: 1,
-    pageSize: 20,
+    pageSize: PAGE_SIZE,
   });
   const history = useHistory();
   const [search, setSearch] = useState<string>(
@@ -132,8 +134,8 @@ export const ActiveStatementsView: React.FC<ActiveStatementsViewProps> = ({
 
   const resetPagination = () => {
     setPagination({
+      pageSize: PAGE_SIZE,
       current: 1,
-      pageSize: 20,
     });
   };
 
@@ -165,6 +167,13 @@ export const ActiveStatementsView: React.FC<ActiveStatementsViewProps> = ({
     internalAppNamePrefix,
     search,
   );
+
+  const onChangePage = (page: number) => {
+    setPagination({
+      ...pagination,
+      current: page,
+    });
+  };
 
   return (
     <div className={cx("root")}>
@@ -207,6 +216,12 @@ export const ActiveStatementsView: React.FC<ActiveStatementsViewProps> = ({
             onChangeSortSetting={onSortClick}
             onColumnsSelect={onColumnsSelect}
             isTenant={isTenant}
+          />
+          <Pagination
+            pageSize={pagination.pageSize}
+            current={pagination.current}
+            total={filteredStatements?.length}
+            onChange={onChangePage}
           />
         </Loading>
       </div>

--- a/pkg/ui/workspaces/cluster-ui/src/transactionsPage/activeTransactionsView.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionsPage/activeTransactionsView.tsx
@@ -32,6 +32,7 @@ import {
 import { getAppsFromActiveExecutions } from "../activeExecutions/activeStatementUtils";
 import { inactiveFiltersState } from "../queryFilter/filter";
 import { ActiveTransactionsSection } from "src/activeExecutions/activeTransactionsSection";
+import { Pagination } from "src/pagination";
 
 import styles from "../statementsPage/statementsPage.module.scss";
 import { queryByName, syncHistory } from "src/util/query";
@@ -61,6 +62,7 @@ export type ActiveTransactionsViewProps = ActiveTransactionsViewStateProps &
   ActiveTransactionsViewDispatchProps;
 
 const ACTIVE_TXN_SEARCH_PARAM = "q";
+const PAGE_SIZE = 20;
 
 export const ActiveTransactionsView: React.FC<ActiveTransactionsViewProps> = ({
   onColumnsSelect,
@@ -77,7 +79,7 @@ export const ActiveTransactionsView: React.FC<ActiveTransactionsViewProps> = ({
 }: ActiveTransactionsViewProps) => {
   const [pagination, setPagination] = useState<ISortedTablePagination>({
     current: 1,
-    pageSize: 20,
+    pageSize: PAGE_SIZE,
   });
   const history = useHistory();
   const [search, setSearch] = useState<string>(
@@ -134,7 +136,7 @@ export const ActiveTransactionsView: React.FC<ActiveTransactionsViewProps> = ({
   const resetPagination = () => {
     setPagination({
       current: 1,
-      pageSize: 20,
+      pageSize: PAGE_SIZE,
     });
   };
 
@@ -166,6 +168,14 @@ export const ActiveTransactionsView: React.FC<ActiveTransactionsViewProps> = ({
     internalAppNamePrefix,
     search,
   );
+
+  const onChangePage = (page: number) => {
+    setPagination({
+      ...pagination,
+      current: page,
+    });
+  };
+
   return (
     <div className={cx("root")}>
       <PageConfig>
@@ -208,6 +218,12 @@ export const ActiveTransactionsView: React.FC<ActiveTransactionsViewProps> = ({
             onChangeSortSetting={onChangeSortSetting}
             onColumnsSelect={onColumnsSelect}
             isTenant={isTenant}
+          />
+          <Pagination
+            pageSize={pagination.pageSize}
+            current={pagination.current}
+            total={filteredTransactions?.length}
+            onChange={onChangePage}
           />
         </Loading>
       </div>


### PR DESCRIPTION
Backport 1/1 commits from #97122.

/cc @cockroachdb/release

---

Previously, the recent exec overview pages did not have the necessary component to go the next page of the table when the page limit was reached. Page controls are now present in both recent stmt and txn pages.

Epic: none
Fixes: #95699

Release note (bug fix): Users can now go to the next page of results when there are >20 active stmts or txns in the active exec pages.

https://www.loom.com/share/5e5b54a3cc8e402ca8b53ab16e920bf0

Release justification: big fix, low-risk update
