### PR TITLE
ui: tenant-gate transaction insights, change selection order of workload insights

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/insights/types.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/types.ts
@@ -262,8 +262,8 @@ export const getInsightFromCause = (
 };
 
 export const InsightExecOptions = new Map<string, string>([
-  [InsightExecEnum.TRANSACTION.toString(), "Transaction Executions"],
   [InsightExecEnum.STATEMENT.toString(), "Statement Executions"],
+  [InsightExecEnum.TRANSACTION.toString(), "Transaction Executions"],
 ]);
 
 export const InsightEnumToLabel = new Map<string, string>([

--- a/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsights/statementInsights/statementInsightsView.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsights/statementInsights/statementInsightsView.tsx
@@ -76,6 +76,7 @@ export type StatementInsightsViewStateProps = {
   dropDownSelect?: React.ReactElement;
   timeScale?: TimeScale;
   maxSizeApiReached?: boolean;
+  isTenant?: boolean;
 };
 
 export type StatementInsightsViewDispatchProps = {
@@ -110,6 +111,7 @@ export const StatementInsightsView: React.FC<StatementInsightsViewProps> = ({
   selectedColumnNames,
   dropDownSelect,
   maxSizeApiReached,
+  isTenant,
 }: StatementInsightsViewProps) => {
   const [pagination, setPagination] = useState<ISortedTablePagination>({
     current: 1,
@@ -250,7 +252,7 @@ export const StatementInsightsView: React.FC<StatementInsightsViewProps> = ({
   return (
     <div className={cx("root")}>
       <PageConfig>
-        <PageConfigItem>{dropDownSelect}</PageConfigItem>
+        {!isTenant && <PageConfigItem>{dropDownSelect}</PageConfigItem>}
         <PageConfigItem>
           <Search
             placeholder="Search Statements"

--- a/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsights/workloadInsightRootControl.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsights/workloadInsightRootControl.tsx
@@ -36,12 +36,11 @@ export const WorkloadInsightsRootControl = ({
 }: WorkloadInsightsViewProps): React.ReactElement => {
   const location = useLocation();
   const history = useHistory();
-  let viewValue =
-    queryByName(location, viewAttr) || InsightExecEnum.TRANSACTION;
-  // Use the default Transaction page if an
+  let viewValue = queryByName(location, viewAttr) || InsightExecEnum.STATEMENT;
+  // Use the default Statement page if an
   // unrecognized string was passed in from the URL
   if (!InsightExecOptions.has(viewValue)) {
-    viewValue = InsightExecEnum.TRANSACTION;
+    viewValue = InsightExecEnum.STATEMENT;
   }
 
   const [selectedInsightView, setSelectedInsightView] = useState(viewValue);

--- a/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsights/workloadInsightsPageConnected.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsights/workloadInsightsPageConnected.tsx
@@ -50,6 +50,7 @@ import { TimeScale } from "../../timeScaleDropdown";
 import { StmtInsightsReq, TxnInsightsRequest } from "src/api";
 import { selectTimeScale } from "../../store/utils/selectors";
 import { actions as analyticsActions } from "../../store/analytics";
+import { selectIsTenant } from "../../store/uiConfig";
 
 const transactionMapStateToProps = (
   state: AppState,
@@ -82,6 +83,7 @@ const statementMapStateToProps = (
   timeScale: selectTimeScale(state),
   isLoading: selectStmtInsightsLoading(state),
   maxSizeApiReached: selectStmtInsightsMaxApiReached(state),
+  isTenant: selectIsTenant(state),
 });
 
 const TransactionDispatchProps = (


### PR DESCRIPTION
Related to #96353, #92936.

This commit hides the dropdown to switch workload insights from statement insights to transaction insights on tenants. When #96353 is resolved, we can re-enable transaction insights for tenant clusters.

The commit also switches the order of workload insights, to show statement insights first (see #92936).

@gemma-shay We should add a note on the [Insights docs](https://www.cockroachlabs.com/docs/stable/ui-insights-page.html) and/or the serverless docs that Transaction Insights aren't available on serverless.

Release note: None

Epic: None