### PR TITLE
sql: support read-only `ssl` session var

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/information_schema
+++ b/pkg/sql/logictest/testdata/logic_test/information_schema
@@ -5019,6 +5019,7 @@ session_authorization                                 root
 session_user                                          root
 show_primary_key_constraint_on_not_visible_columns    on
 sql_safe_updates                                      off
+ssl                                                   on
 ssl_renegotiation_limit                               0
 standard_conforming_strings                           on
 statement_timeout                                     0

--- a/pkg/sql/logictest/testdata/logic_test/set
+++ b/pkg/sql/logictest/testdata/logic_test/set
@@ -141,6 +141,14 @@ SET server_encoding = 'UTF8'
 statement error parameter "server_encoding" cannot be changed
 SET server_encoding = 'other'
 
+query T
+SHOW ssl
+----
+on
+
+statement error parameter "ssl" cannot be changed
+SET ssl = 'off'
+
 statement ok
 SET escape_string_warning = 'ON'
 

--- a/pkg/sql/vars.go
+++ b/pkg/sql/vars.go
@@ -1308,6 +1308,15 @@ var varGen = map[string]sessionVar{
 		},
 	},
 
+	// See https://www.postgresql.org/docs/9.4/runtime-config-connection.html
+	`ssl`: {
+		Hidden: true,
+		Get: func(evalCtx *extendedEvalContext, _ *kv.Txn) (string, error) {
+			insecure := evalCtx.ExecCfg.RPCContext.Config.Insecure || evalCtx.ExecCfg.RPCContext.Config.AcceptSQLWithoutTLS
+			return formatBoolAsPostgresSetting(!insecure), nil
+		},
+	},
+
 	// CockroachDB extension.
 	`crdb_version`: makeReadOnlyVarWithFn(func() string {
 		return build.GetInfo().Short()


### PR DESCRIPTION
I discovered this by running npgsql nightlies.

Epic: None

Release note (sql change): Added the read-only "ssl" session variable. It returns "off" if the server was started in insecure mode (which disables TLS), or "on" otherwise. This is based on the Postgres variable of the same name.