### PR TITLE
sql: remove redundant re-enabling of stepping for cascades and checks

### DIFF
--- a/pkg/sql/distsql_running.go
+++ b/pkg/sql/distsql_running.go
@@ -1852,10 +1852,6 @@ func (dsp *DistSQLPlanner) PlanAndRunCascadesAndChecks(
 		// We place a sequence point before every cascade, so
 		// that each subsequent cascade can observe the writes
 		// by the previous step.
-		// TODO(radu): the cascades themselves can have more cascades; if any of
-		// those fall back to legacy cascades code, it will disable stepping. So we
-		// have to reenable stepping each time.
-		_ = planner.Txn().ConfigureStepping(ctx, kv.SteppingEnabled)
 		if err := planner.Txn().Step(ctx); err != nil {
 			recv.SetError(err)
 			return false
@@ -1926,10 +1922,6 @@ func (dsp *DistSQLPlanner) PlanAndRunCascadesAndChecks(
 
 	// We place a sequence point before the checks, so that they observe the
 	// writes of the main query and/or any cascades.
-	// TODO(radu): the cascades themselves can have more cascades; if any of
-	// those fall back to legacy cascades code, it will disable stepping. So we
-	// have to reenable stepping each time.
-	_ = planner.Txn().ConfigureStepping(ctx, kv.SteppingEnabled)
 	if err := planner.Txn().Step(ctx); err != nil {
 		recv.SetError(err)
 		return false


### PR DESCRIPTION
This commit removes a couple of places where we enable the stepping for cascades and checks. This was introduced several years ago in 3feb82a3caf8f15ac9abcf72e7fb1a7402014713 since at the time we could have fallen back to the "legacy" cascade code which would have disabled the stepping. I believe that legacy code has been long gone, so it's now safe to remove the redundant re-enablement of stepping.

Epic: None

Release note: None