### PR TITLE
roachtest: schemachange/mixed-versions: fix handling of tsquery/tsvector

### DIFF
--- a/pkg/workload/schemachange/operation_generator.go
+++ b/pkg/workload/schemachange/operation_generator.go
@@ -1249,6 +1249,7 @@ func (og *operationGenerator) createTable(ctx context.Context, tx pgx.Tx) (*opSt
 	// fully transaction aware.
 	codesWithConditions{
 		{code: pgcode.Syntax, condition: hasUnsupportedTSQuery},
+		{code: pgcode.FeatureNotSupported, condition: hasUnsupportedTSQuery},
 	}.add(opStmt.potentialExecErrors)
 	opStmt.sql = tree.Serialize(stmt)
 	return opStmt, nil


### PR DESCRIPTION
Previously, we attempted to fix mixed version handling of new types in tsquery/tsvector in the schema changer mixed version workload. This was inadequate because it could lead to either syntax errors or unsupported
feature errors (only one was handled). To address this, this patch expects both errors in this mixed version state.

Epic: none
Fixes: #97096
Release note: None