### PR TITLE
release-22.2: server: reduce logs from pgwire cancel

### DIFF
--- a/pkg/sql/pgwire/server.go
+++ b/pkg/sql/pgwire/server.go
@@ -936,8 +936,8 @@ func (s *Server) handleCancel(ctx context.Context, conn net.Conn, buf *pgwirebas
 	} else if err != nil {
 		if respStatus := status.Convert(err); respStatus.Code() == codes.ResourceExhausted {
 			s.metrics.PGWireCancelIgnoredCount.Inc(1)
+			log.Sessions.Warningf(ctx, "unexpected while handling pgwire cancellation request: %v", err)
 		}
-		log.Sessions.Warningf(ctx, "unexpected while handling pgwire cancellation request: %v", err)
 	}
 }
 


### PR DESCRIPTION
Backport 1/1 commits from #97186.
NB: This code was refactored quite a bit between releases, so the backport is different (and simpler).

/cc @cockroachdb/release

Release justification: logging change

---

fixes https://github.com/cockroachdb/cockroach/issues/91386

Now we only log if the rate limit was exceeded. This is an indication that someone may be maliciously spamming the query cancel protocol.

Release note: None
