### PR TITLE
server: simplify logic for logging failed pgwire cancel

### DIFF
--- a/pkg/server/server_controller.go
+++ b/pkg/server/server_controller.go
@@ -35,7 +35,7 @@ type onDemandServer interface {
 	getHTTPHandlerFn() http.HandlerFunc
 
 	// handleCancel processes a SQL async cancel query.
-	handleCancel(ctx context.Context, cancelKey pgwirecancel.BackendKeyData) error
+	handleCancel(ctx context.Context, cancelKey pgwirecancel.BackendKeyData)
 
 	// serveConn handles an incoming SQL connection.
 	serveConn(ctx context.Context, conn net.Conn, status pgwire.PreServeStatus) error

--- a/pkg/sql/pgwire/server.go
+++ b/pkg/sql/pgwire/server.go
@@ -825,7 +825,7 @@ func readCancelKeyAndCloseConn(
 // - (*server/statusServer).cancelSemaphore
 // - (*server/statusServer).CancelRequestByKey
 // - (*server/serverController).sqlMux
-func (s *Server) HandleCancel(ctx context.Context, cancelKey pgwirecancel.BackendKeyData) error {
+func (s *Server) HandleCancel(ctx context.Context, cancelKey pgwirecancel.BackendKeyData) {
 	s.tenantMetrics.PGWireCancelTotalCount.Inc(1)
 
 	resp, err := func() (*serverpb.CancelQueryByKeyResponse, error) {
@@ -846,9 +846,9 @@ func (s *Server) HandleCancel(ctx context.Context, cancelKey pgwirecancel.Backen
 	} else if err != nil {
 		if respStatus := status.Convert(err); respStatus.Code() == codes.ResourceExhausted {
 			s.tenantMetrics.PGWireCancelIgnoredCount.Inc(1)
+			log.Sessions.Warningf(ctx, "unexpected while handling pgwire cancellation request: %v", err)
 		}
 	}
-	return err
 }
 
 // finalizeClientParameters "fills in" the session arguments with


### PR DESCRIPTION
Now that we only log when the rate limit is exceeded, it is simpler to move the log statement inside of the pgwire function that does the cancellation. This also removed the need for the server router to wait for all servers to respond to the request.

Informs #91386
Release note: None