### PR TITLE
*: update to use full package name for `option go_package` in protos

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1359,15 +1359,15 @@ $(ERRORS_PROTO): bin/.submodules-initialized
 bin/.go_protobuf_sources: $(GO_PROTOS) $(GOGOPROTO_PROTO) $(ERRORS_PROTO) bin/.bootstrap bin/protoc-gen-gogoroach c-deps/proto-rebuild vendor/modules.txt
 	$(FIND_RELEVANT) -type f -name '*.pb.go' -exec rm {} +
 	set -e; for dir in $(sort $(dir $(GO_PROTOS))); do \
-	  buf protoc -Ipkg -I$(GOGO_PROTOBUF_PATH) -I$(COREOS_PATH) -I$(PROMETHEUS_PATH) -I$(GRPC_GATEWAY_GOOGLEAPIS_PATH) -I$(ERRORS_PATH) --gogoroach_out=$(PROTO_MAPPINGS)plugins=grpc,import_prefix=github.com/cockroachdb/cockroach/pkg/:./pkg $$dir/*.proto; \
+	  buf protoc -Ipkg -I$(GOGO_PROTOBUF_PATH) -I$(COREOS_PATH) -I$(PROMETHEUS_PATH) -I$(GRPC_GATEWAY_GOOGLEAPIS_PATH) -I$(ERRORS_PATH) --gogoroach_out=$(PROTO_MAPPINGS)plugins=grpc,import_prefix=github.com/cockroachdb/cockroach/pkg/,paths=source_relative:./pkg $$dir/*.proto; \
 	done
 	gofmt -s -w $(GO_SOURCES)
 	touch $@
 
 bin/.gw_protobuf_sources: $(GW_SERVER_PROTOS) $(GW_TS_PROTOS) $(GO_PROTOS) $(GOGOPROTO_PROTO) $(ERRORS_PROTO) bin/.bootstrap c-deps/proto-rebuild vendor/modules.txt
 	$(FIND_RELEVANT) -type f -name '*.pb.gw.go' -exec rm {} +
-		buf protoc -Ipkg -I$(GOGO_PROTOBUF_PATH) -I$(ERRORS_PATH) -I$(COREOS_PATH) -I$(PROMETHEUS_PATH) -I$(GRPC_GATEWAY_GOOGLEAPIS_PATH) --grpc-gateway_out=logtostderr=true,request_context=true:./pkg $(GW_SERVER_PROTOS)
-		buf protoc -Ipkg -I$(GOGO_PROTOBUF_PATH) -I$(ERRORS_PATH) -I$(COREOS_PATH) -I$(PROMETHEUS_PATH) -I$(GRPC_GATEWAY_GOOGLEAPIS_PATH) --grpc-gateway_out=logtostderr=true,request_context=true:./pkg $(GW_TS_PROTOS)
+		buf protoc -Ipkg -I$(GOGO_PROTOBUF_PATH) -I$(ERRORS_PATH) -I$(COREOS_PATH) -I$(PROMETHEUS_PATH) -I$(GRPC_GATEWAY_GOOGLEAPIS_PATH) --grpc-gateway_out=logtostderr=true,request_context=true,paths=source_relative:./pkg $(GW_SERVER_PROTOS)
+		buf protoc -Ipkg -I$(GOGO_PROTOBUF_PATH) -I$(ERRORS_PATH) -I$(COREOS_PATH) -I$(PROMETHEUS_PATH) -I$(GRPC_GATEWAY_GOOGLEAPIS_PATH) --grpc-gateway_out=logtostderr=true,request_context=true,paths=source_relative:./pkg $(GW_TS_PROTOS)
 	gofmt -s -w $(GW_SOURCES)
 	@# TODO(jordan,benesch) This can be removed along with the above TODO.
 	goimports -w $(GW_SOURCES)

--- a/pkg/acceptance/cluster/testconfig.proto
+++ b/pkg/acceptance/cluster/testconfig.proto
@@ -10,7 +10,7 @@
 
 syntax = "proto2";
 package cockroach.acceptance.cluster;
-option go_package = "cluster";
+option go_package = "github.com/cockroachdb/cockroach/pkg/acceptance/cluster";
 
 import "gogoproto/gogo.proto";
 

--- a/pkg/blobs/blobspb/blobs.proto
+++ b/pkg/blobs/blobspb/blobs.proto
@@ -10,7 +10,7 @@
 
 syntax = "proto3";
 package cockroach.blobs;
-option go_package = "blobspb";
+option go_package = "github.com/cockroachdb/cockroach/pkg/blobs/blobspb";
 
 // GetRequest is used to read a file from a remote node.
 // It's path is specified by `filename`, which can either

--- a/pkg/build/info.proto
+++ b/pkg/build/info.proto
@@ -10,7 +10,7 @@
 
 syntax = "proto2";
 package cockroach.build;
-option go_package = "build";
+option go_package = "github.com/cockroachdb/cockroach/pkg/build";
 
 import "gogoproto/gogo.proto";
 

--- a/pkg/ccl/backupccl/backuppb/backup.proto
+++ b/pkg/ccl/backupccl/backuppb/backup.proto
@@ -8,7 +8,7 @@
 
 syntax = "proto3";
 package cockroach.ccl.backupccl;
-option go_package = "backuppb";
+option go_package = "github.com/cockroachdb/cockroach/pkg/ccl/backupccl/backuppb";
 
 import "build/info.proto";
 import "cloud/cloudpb/external_storage.proto";

--- a/pkg/ccl/baseccl/encryption_options.proto
+++ b/pkg/ccl/baseccl/encryption_options.proto
@@ -8,7 +8,7 @@
 
 syntax = "proto3";
 package cockroach.ccl.baseccl;
-option go_package = "baseccl";
+option go_package = "github.com/cockroachdb/cockroach/pkg/ccl/baseccl";
 
 enum EncryptionKeySource {
   // Plain key files.

--- a/pkg/ccl/changefeedccl/changefeedpb/scheduled_changefeed.proto
+++ b/pkg/ccl/changefeedccl/changefeedpb/scheduled_changefeed.proto
@@ -8,7 +8,7 @@
 
 syntax = "proto3";
 package cockroach.ccl.changefeedccl;
-option go_package = "changefeedpb";
+option go_package = "github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/changefeedpb";
 
 // ScheduledExportExecutionArgs is the arguments to the scheduled backup executor.
 message ScheduledChangefeedExecutionArgs {

--- a/pkg/ccl/storageccl/engineccl/enginepbccl/key_registry.proto
+++ b/pkg/ccl/storageccl/engineccl/enginepbccl/key_registry.proto
@@ -8,7 +8,7 @@
 
 syntax = "proto3";
 package cockroach.ccl.storageccl.engineccl.enginepbccl;
-option go_package = "enginepbccl";
+option go_package = "github.com/cockroachdb/cockroach/pkg/ccl/storageccl/engineccl/enginepbccl";
 
 enum EncryptionType {
   // No encryption.

--- a/pkg/ccl/storageccl/engineccl/enginepbccl/stats.proto
+++ b/pkg/ccl/storageccl/engineccl/enginepbccl/stats.proto
@@ -8,7 +8,7 @@
 
 syntax = "proto3";
 package cockroach.ccl.storageccl.engineccl.enginepbccl;
-option go_package = "enginepbccl";
+option go_package = "github.com/cockroachdb/cockroach/pkg/ccl/storageccl/engineccl/enginepbccl";
 
 import "ccl/storageccl/engineccl/enginepbccl/key_registry.proto";
 

--- a/pkg/ccl/utilccl/licenseccl/license.proto
+++ b/pkg/ccl/utilccl/licenseccl/license.proto
@@ -8,7 +8,7 @@
 
 syntax = "proto3";
 package cockroach.ccl.utilccl.licenseccl;
-option go_package = "licenseccl";
+option go_package = "github.com/cockroachdb/cockroach/pkg/ccl/utilccl/licenseccl";
 
 import "gogoproto/gogo.proto";
 

--- a/pkg/cloud/cloudpb/external_storage.proto
+++ b/pkg/cloud/cloudpb/external_storage.proto
@@ -10,7 +10,7 @@
 
 syntax = "proto3";
 package cockroach.cloud.cloudpb;
-option go_package = "cloudpb";
+option go_package = "github.com/cockroachdb/cockroach/pkg/cloud/cloudpb";
 
 import "gogoproto/gogo.proto";
 

--- a/pkg/cloud/externalconn/connectionpb/connection.proto
+++ b/pkg/cloud/externalconn/connectionpb/connection.proto
@@ -10,7 +10,7 @@
 
 syntax = "proto3";
 package cockroach.cloud.externalconn.connectionpb;
-option go_package = "connectionpb";
+option go_package = "github.com/cockroachdb/cockroach/pkg/cloud/externalconn/connectionpb";
 
 import "gogoproto/gogo.proto";
 

--- a/pkg/clusterversion/cluster_version.proto
+++ b/pkg/clusterversion/cluster_version.proto
@@ -10,7 +10,7 @@
 
 syntax = "proto3";
 package cockroach.clusterversion;
-option go_package = "clusterversion";
+option go_package = "github.com/cockroachdb/cockroach/pkg/clusterversion";
 
 import "roachpb/metadata.proto";
 import "gogoproto/gogo.proto";

--- a/pkg/config/system.proto
+++ b/pkg/config/system.proto
@@ -10,7 +10,7 @@
 
 syntax = "proto2";
 package cockroach.config;
-option go_package = "config";
+option go_package = "github.com/cockroachdb/cockroach/pkg/config";
 
 import "gogoproto/gogo.proto";
 import "roachpb/data.proto";

--- a/pkg/config/zonepb/zone.proto
+++ b/pkg/config/zonepb/zone.proto
@@ -10,7 +10,7 @@
 
 syntax = "proto2";
 package cockroach.config.zonepb;
-option go_package = "zonepb";
+option go_package = "github.com/cockroachdb/cockroach/pkg/config/zonepb";
 
 import "gogoproto/gogo.proto";
 

--- a/pkg/geo/geoindex/config.proto
+++ b/pkg/geo/geoindex/config.proto
@@ -10,7 +10,7 @@
 
 syntax = "proto3";
 package cockroach.geo.geoindex;
-option go_package = "geoindex";
+option go_package = "github.com/cockroachdb/cockroach/pkg/geo/geoindex";
 
 import "gogoproto/gogo.proto";
 

--- a/pkg/geo/geopb/geopb.proto
+++ b/pkg/geo/geopb/geopb.proto
@@ -10,7 +10,7 @@
 
 syntax = "proto3";
 package cockroach.geopb;
-option go_package = "geopb";
+option go_package = "github.com/cockroachdb/cockroach/pkg/geo/geopb";
 
 import "gogoproto/gogo.proto";
 

--- a/pkg/gossip/gossip.proto
+++ b/pkg/gossip/gossip.proto
@@ -10,7 +10,7 @@
 
 syntax = "proto3";
 package cockroach.gossip;
-option go_package = "gossip";
+option go_package = "github.com/cockroachdb/cockroach/pkg/gossip";
 
 import "roachpb/data.proto";
 import "util/hlc/timestamp.proto";

--- a/pkg/jobs/jobspb/jobs.proto
+++ b/pkg/jobs/jobspb/jobs.proto
@@ -10,7 +10,7 @@
 
 syntax = "proto3";
 package cockroach.sql.jobs.jobspb;
-option go_package = "jobspb";
+option go_package = "github.com/cockroachdb/cockroach/pkg/jobs/jobspb";
 
 import "errorspb/errors.proto";
 import "gogoproto/gogo.proto";

--- a/pkg/jobs/jobspb/schedule.proto
+++ b/pkg/jobs/jobspb/schedule.proto
@@ -10,7 +10,7 @@
 
 syntax = "proto3";
 package cockroach.jobs.jobspb;
-option go_package = "jobspb";
+option go_package = "github.com/cockroachdb/cockroach/pkg/jobs/jobspb";
 
 import "google/protobuf/any.proto";
 

--- a/pkg/keyvisualizer/keyvispb/key_visualizer.proto
+++ b/pkg/keyvisualizer/keyvispb/key_visualizer.proto
@@ -11,7 +11,7 @@
 
 syntax = "proto3";
 package cockroach.keyvisualizer.keyvispb;
-option go_package = "keyvispb";
+option go_package = "github.com/cockroachdb/cockroach/pkg/keyvisualizer/keyvispb";
 
 import "roachpb/data.proto";
 import "gogoproto/gogo.proto";

--- a/pkg/kv/bulk/bulkpb/bulkpb.proto
+++ b/pkg/kv/bulk/bulkpb/bulkpb.proto
@@ -11,7 +11,7 @@
 
 syntax = "proto3";
 package cockroach.kv.bulk.bulkpb;
-option go_package = "bulkpb";
+option go_package = "github.com/cockroachdb/cockroach/pkg/kv/bulk/bulkpb";
 
 import "gogoproto/gogo.proto";
 import "util/hlc/timestamp.proto";

--- a/pkg/kv/kvnemesis/operations.proto
+++ b/pkg/kv/kvnemesis/operations.proto
@@ -10,7 +10,7 @@
 
 syntax = "proto3";
 package cockroach.kv.kvnemesis;
-option go_package = "kvnemesis";
+option go_package = "github.com/cockroachdb/cockroach/pkg/kv/kvnemesis";
 
 import "errorspb/errors.proto";
 import "gogoproto/gogo.proto";

--- a/pkg/kv/kvpb/api.proto
+++ b/pkg/kv/kvpb/api.proto
@@ -10,7 +10,7 @@
 
 syntax = "proto3";
 package cockroach.roachpb;
-option go_package = "kvpb";
+option go_package = "github.com/cockroachdb/cockroach/pkg/kv/kvpb";
 
 import "errorspb/errors.proto";
 import "kv/kvserver/concurrency/lock/locking.proto";

--- a/pkg/kv/kvpb/errors.proto
+++ b/pkg/kv/kvpb/errors.proto
@@ -24,7 +24,7 @@ syntax = "proto2";
 // correct name, the files can be moved into a newly created `kvpb` package
 // at leisure.
 package cockroach.kv.kvpb;
-option go_package = "kvpb";
+option go_package = "github.com/cockroachdb/cockroach/pkg/kv/kvpb";
 
 import "errorspb/errors.proto";
 import "roachpb/data.proto";

--- a/pkg/kv/kvserver/api.proto
+++ b/pkg/kv/kvserver/api.proto
@@ -10,7 +10,7 @@
 
 syntax = "proto3";
 package cockroach.kv.kvserver;
-option go_package = "kvserver";
+option go_package = "github.com/cockroachdb/cockroach/pkg/kv/kvserver";
 
 import "roachpb/data.proto";
 import "storage/enginepb/mvcc.proto";

--- a/pkg/kv/kvserver/closedts/ctpb/service.proto
+++ b/pkg/kv/kvserver/closedts/ctpb/service.proto
@@ -10,7 +10,7 @@
 
 syntax = "proto3";
 package cockroach.kv.kvserver.ctupdate;
-option go_package = "ctpb";
+option go_package = "github.com/cockroachdb/cockroach/pkg/kv/kvserver/closedts/ctpb";
 
 import "roachpb/data.proto";
 import "util/hlc/timestamp.proto";

--- a/pkg/kv/kvserver/concurrency/lock/lock_waiter.proto
+++ b/pkg/kv/kvserver/concurrency/lock/lock_waiter.proto
@@ -10,7 +10,7 @@
 
 syntax = "proto3";
 package cockroach.kv.kvserver.concurrency.lock;
-option go_package = "lock";
+option go_package = "github.com/cockroachdb/cockroach/pkg/kv/kvserver/concurrency/lock";
 
 import "kv/kvserver/concurrency/lock/locking.proto";
 import "storage/enginepb/mvcc3.proto";

--- a/pkg/kv/kvserver/concurrency/lock/locking.proto
+++ b/pkg/kv/kvserver/concurrency/lock/locking.proto
@@ -10,7 +10,7 @@
 
 syntax = "proto3";
 package cockroach.kv.kvserver.concurrency.lock;
-option go_package = "lock";
+option go_package = "github.com/cockroachdb/cockroach/pkg/kv/kvserver/concurrency/lock";
 
 import "gogoproto/gogo.proto";
 import "util/hlc/timestamp.proto";

--- a/pkg/kv/kvserver/concurrency/poison/error.proto
+++ b/pkg/kv/kvserver/concurrency/poison/error.proto
@@ -10,7 +10,7 @@
 
 syntax = "proto3";
 package cockroach.kv.kvserver.concurrency.poison;
-option go_package = "poison";
+option go_package = "github.com/cockroachdb/cockroach/pkg/kv/kvserver/concurrency/poison";
 
 import "util/hlc/timestamp.proto";
 import "roachpb/data.proto";

--- a/pkg/kv/kvserver/concurrency/poison/policy.proto
+++ b/pkg/kv/kvserver/concurrency/poison/policy.proto
@@ -10,7 +10,7 @@
 
 syntax = "proto3";
 package cockroach.kv.kvserver.concurrency.poison;
-option go_package = "poison";
+option go_package = "github.com/cockroachdb/cockroach/pkg/kv/kvserver/concurrency/poison";
 
 // Policy determines how a request will react to encountering a poisoned
 // latch. A poisoned latch is a latch for which the holder is unable to make

--- a/pkg/kv/kvserver/kvflowcontrol/kvflowcontrolpb/kvflowcontrol.proto
+++ b/pkg/kv/kvserver/kvflowcontrol/kvflowcontrolpb/kvflowcontrol.proto
@@ -10,7 +10,7 @@
 
 syntax = "proto3";
 package cockroach.kv.kvserver.kvflowcontrol.kvflowcontrolpb;
-option go_package = "kvflowcontrolpb";
+option go_package = "github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvflowcontrol/kvflowcontrolpb";
 
 import "gogoproto/gogo.proto";
 

--- a/pkg/kv/kvserver/kvserverpb/lease_status.proto
+++ b/pkg/kv/kvserver/kvserverpb/lease_status.proto
@@ -10,7 +10,7 @@
 
 syntax = "proto3";
 package cockroach.kv.kvserver.storagepb;
-option go_package = "kvserverpb";
+option go_package = "github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverpb";
 
 import "roachpb/data.proto";
 import "kv/kvserver/liveness/livenesspb/liveness.proto";

--- a/pkg/kv/kvserver/kvserverpb/proposer_kv.proto
+++ b/pkg/kv/kvserver/kvserverpb/proposer_kv.proto
@@ -10,7 +10,7 @@
 
 syntax = "proto3";
 package cockroach.kv.kvserver.storagepb;
-option go_package = "kvserverpb";
+option go_package = "github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverpb";
 
 import "kv/kvpb/api.proto";
 import "roachpb/data.proto";

--- a/pkg/kv/kvserver/kvserverpb/raft.proto
+++ b/pkg/kv/kvserver/kvserverpb/raft.proto
@@ -10,7 +10,7 @@
 
 syntax = "proto3";
 package cockroach.kv.kvserver.kvserverpb;
-option go_package = "kvserverpb";
+option go_package = "github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverpb";
 
 import "errorspb/errors.proto";
 import "kv/kvpb/errors.proto";

--- a/pkg/kv/kvserver/kvserverpb/range_log.proto
+++ b/pkg/kv/kvserver/kvserverpb/range_log.proto
@@ -10,7 +10,7 @@
 
 syntax = "proto3";
 package cockroach.kv.kvserver.storagepb;
-option go_package = "kvserverpb";
+option go_package = "github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverpb";
 
 import "roachpb/metadata.proto";
 import "gogoproto/gogo.proto";

--- a/pkg/kv/kvserver/kvserverpb/state.proto
+++ b/pkg/kv/kvserver/kvserverpb/state.proto
@@ -10,7 +10,7 @@
 
 syntax = "proto3";
 package cockroach.kv.kvserver.storagepb;
-option go_package = "kvserverpb";
+option go_package = "github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverpb";
 
 import "storage/enginepb/mvcc.proto";
 import "roachpb/internal_raft.proto";

--- a/pkg/kv/kvserver/liveness/livenesspb/liveness.proto
+++ b/pkg/kv/kvserver/liveness/livenesspb/liveness.proto
@@ -10,7 +10,7 @@
 
 syntax = "proto3";
 package cockroach.kv.kvserver.liveness.livenesspb;
-option go_package = "livenesspb";
+option go_package = "github.com/cockroachdb/cockroach/pkg/kv/kvserver/liveness/livenesspb";
 
 import "util/hlc/legacy_timestamp.proto";
 import "gogoproto/gogo.proto";

--- a/pkg/kv/kvserver/loqrecovery/loqrecoverypb/recovery.proto
+++ b/pkg/kv/kvserver/loqrecovery/loqrecoverypb/recovery.proto
@@ -10,7 +10,7 @@
 
 syntax = "proto3";
 package cockroach.kv.kvserver.loqrecovery.loqrecoverypb;
-option go_package = "loqrecoverypb";
+option go_package = "github.com/cockroachdb/cockroach/pkg/kv/kvserver/loqrecovery/loqrecoverypb";
 
 import "roachpb/data.proto";
 import "roachpb/metadata.proto";

--- a/pkg/kv/kvserver/protectedts/ptpb/protectedts.proto
+++ b/pkg/kv/kvserver/protectedts/ptpb/protectedts.proto
@@ -11,7 +11,7 @@
 
 syntax = "proto3";
 package cockroach.protectedts;
-option go_package = "ptpb";
+option go_package = "github.com/cockroachdb/cockroach/pkg/kv/kvserver/protectedts/ptpb";
 
 import "gogoproto/gogo.proto";
 import "roachpb/data.proto";

--- a/pkg/kv/kvserver/protectedts/ptstorage/storage.proto
+++ b/pkg/kv/kvserver/protectedts/ptstorage/storage.proto
@@ -10,7 +10,7 @@
 
 syntax = "proto3";
 package cockroach.protectedts;
-option go_package = "ptstorage";
+option go_package = "github.com/cockroachdb/cockroach/pkg/kv/kvserver/protectedts/ptstorage";
 
 import "gogoproto/gogo.proto";
 import "roachpb/data.proto";

--- a/pkg/kv/kvserver/rangelog/internal/rangelogtestpb/rangelogtest.proto
+++ b/pkg/kv/kvserver/rangelog/internal/rangelogtestpb/rangelogtest.proto
@@ -10,7 +10,7 @@
 
 syntax = "proto3";
 package cockroach.kv.kvserver.rangelog.rangelogtest;
-option go_package = "rangelogtestpb";
+option go_package = "github.com/cockroachdb/cockroach/pkg/kv/kvserver/rangelog/internal/rangelogtestpb";
 
 import "kv/kvserver/kvserverpb/range_log.proto";
 

--- a/pkg/kv/kvserver/readsummary/rspb/summary.proto
+++ b/pkg/kv/kvserver/readsummary/rspb/summary.proto
@@ -10,7 +10,7 @@
 
 syntax = "proto3";
 package cockroach.kv.kvserver.readsummary;
-option go_package = "rspb";
+option go_package = "github.com/cockroachdb/cockroach/pkg/kv/kvserver/readsummary/rspb";
 
 import "util/hlc/timestamp.proto";
 import "gogoproto/gogo.proto";

--- a/pkg/kv/kvserver/storage_services.proto
+++ b/pkg/kv/kvserver/storage_services.proto
@@ -10,7 +10,7 @@
 
 syntax = "proto3";
 package cockroach.storage; // HACK
-option go_package = "kvserver";
+option go_package = "github.com/cockroachdb/cockroach/pkg/kv/kvserver";
 
 import "kv/kvserver/kvserverpb/raft.proto";
 import "kv/kvserver/api.proto";

--- a/pkg/multitenant/mtinfopb/info.proto
+++ b/pkg/multitenant/mtinfopb/info.proto
@@ -10,7 +10,7 @@
 
 syntax = "proto2";
 package cockroach.multitenant;
-option go_package = "mtinfopb";
+option go_package = "github.com/cockroachdb/cockroach/pkg/multitenant/mtinfopb";
 
 import "gogoproto/gogo.proto";
 import "kv/kvpb/api.proto";

--- a/pkg/multitenant/tenantcapabilities/tenantcapabilitiespb/capabilities.proto
+++ b/pkg/multitenant/tenantcapabilities/tenantcapabilitiespb/capabilities.proto
@@ -10,7 +10,7 @@
 
 syntax = "proto3";
 package cockroach.multitenant.tenantcapabilitiespb;
-option go_package = "tenantcapabilitiespb";
+option go_package = "github.com/cockroachdb/cockroach/pkg/multitenant/tenantcapabilities/tenantcapabilitiespb";
 
 import "gogoproto/gogo.proto";
 

--- a/pkg/repstream/streampb/stream.proto
+++ b/pkg/repstream/streampb/stream.proto
@@ -11,7 +11,7 @@
 
 syntax = "proto3";
 package cockroach.repstream.streampb;
-option go_package = "streampb";
+option go_package = "github.com/cockroachdb/cockroach/pkg/repstream/streampb";
 
 
 import "kv/kvpb/api.proto";

--- a/pkg/roachpb/data.proto
+++ b/pkg/roachpb/data.proto
@@ -10,7 +10,7 @@
 
 syntax = "proto3";
 package cockroach.roachpb;
-option go_package = "roachpb";
+option go_package = "github.com/cockroachdb/cockroach/pkg/roachpb";
 
 import "kv/kvserver/concurrency/lock/lock_waiter.proto";
 import "kv/kvserver/concurrency/lock/locking.proto";

--- a/pkg/roachpb/index_usage_stats.proto
+++ b/pkg/roachpb/index_usage_stats.proto
@@ -10,7 +10,7 @@
 
 syntax = "proto2";
 package cockroach.sql;
-option go_package = "roachpb";
+option go_package = "github.com/cockroachdb/cockroach/pkg/roachpb";
 
 import "gogoproto/gogo.proto";
 import "google/protobuf/timestamp.proto";

--- a/pkg/roachpb/internal.proto
+++ b/pkg/roachpb/internal.proto
@@ -11,7 +11,7 @@
 // Cannot be proto3 because we depend on absent-vs-empty distinction.
 syntax = "proto2";
 package cockroach.roachpb;
-option go_package = "roachpb";
+option go_package = "github.com/cockroachdb/cockroach/pkg/roachpb";
 
 import "gogoproto/gogo.proto";
 

--- a/pkg/roachpb/internal_raft.proto
+++ b/pkg/roachpb/internal_raft.proto
@@ -10,7 +10,7 @@
 
 syntax = "proto2";
 package cockroach.roachpb;
-option go_package = "roachpb";
+option go_package = "github.com/cockroachdb/cockroach/pkg/roachpb";
 
 import "gogoproto/gogo.proto";
 

--- a/pkg/roachpb/io-formats.proto
+++ b/pkg/roachpb/io-formats.proto
@@ -10,7 +10,7 @@
 
 syntax = "proto2";
 package cockroach.roachpb;
-option go_package = "roachpb";
+option go_package = "github.com/cockroachdb/cockroach/pkg/roachpb";
 
 import "gogoproto/gogo.proto";
 

--- a/pkg/roachpb/metadata.proto
+++ b/pkg/roachpb/metadata.proto
@@ -10,7 +10,7 @@
 
 syntax = "proto2";
 package cockroach.roachpb;
-option go_package = "roachpb";
+option go_package = "github.com/cockroachdb/cockroach/pkg/roachpb";
 
 import "util/unresolved_addr.proto";
 import "util/hlc/timestamp.proto";

--- a/pkg/roachpb/span_config.proto
+++ b/pkg/roachpb/span_config.proto
@@ -10,7 +10,7 @@
 
 syntax = "proto3";
 package cockroach.roachpb;
-option go_package = "roachpb";
+option go_package = "github.com/cockroachdb/cockroach/pkg/roachpb";
 
 import "errorspb/errors.proto";
 import "roachpb/data.proto";

--- a/pkg/roachpb/span_stats.proto
+++ b/pkg/roachpb/span_stats.proto
@@ -10,7 +10,7 @@
 
 syntax = "proto3";
 package cockroach.roachpb;
-option go_package = "roachpb";
+option go_package = "github.com/cockroachdb/cockroach/pkg/roachpb";
 
 import "storage/enginepb/mvcc.proto";
 import "gogoproto/gogo.proto";

--- a/pkg/rpc/heartbeat.proto
+++ b/pkg/rpc/heartbeat.proto
@@ -10,7 +10,7 @@
 
 syntax = "proto2";
 package cockroach.rpc;
-option go_package = "rpc";
+option go_package = "github.com/cockroachdb/cockroach/pkg/rpc";
 
 import "roachpb/metadata.proto";
 import "gogoproto/gogo.proto";

--- a/pkg/server/diagnostics/diagnosticspb/diagnostics.proto
+++ b/pkg/server/diagnostics/diagnosticspb/diagnostics.proto
@@ -10,7 +10,7 @@
 
 syntax = "proto3";
 package cockroach.server.diagnostics.diagnosticspb;
-option go_package = "diagnosticspb";
+option go_package = "github.com/cockroachdb/cockroach/pkg/server/diagnostics/diagnosticspb";
 
 import "build/info.proto";
 import "config/zonepb/zone.proto";

--- a/pkg/server/serverpb/admin.proto
+++ b/pkg/server/serverpb/admin.proto
@@ -10,7 +10,7 @@
 
 syntax = "proto3";
 package cockroach.server.serverpb;
-option go_package = "serverpb";
+option go_package = "github.com/cockroachdb/cockroach/pkg/server/serverpb";
 
 import "config/zonepb/zone.proto";
 import "util/tracing/tracingpb/tracing.proto";

--- a/pkg/server/serverpb/authentication.proto
+++ b/pkg/server/serverpb/authentication.proto
@@ -10,7 +10,7 @@
 
 syntax = "proto3";
 package cockroach.server.serverpb;
-option go_package = "serverpb";
+option go_package = "github.com/cockroachdb/cockroach/pkg/server/serverpb";
 
 import "gogoproto/gogo.proto";
 import "google/api/annotations.proto";

--- a/pkg/server/serverpb/index_recommendations.proto
+++ b/pkg/server/serverpb/index_recommendations.proto
@@ -10,7 +10,7 @@
 
 syntax = "proto2";
 package cockroach.sql;
-option go_package = "serverpb";
+option go_package = "github.com/cockroachdb/cockroach/pkg/server/serverpb";
 
 import "gogoproto/gogo.proto";
 

--- a/pkg/server/serverpb/init.proto
+++ b/pkg/server/serverpb/init.proto
@@ -10,7 +10,7 @@
 
 syntax = "proto3";
 package cockroach.server.serverpb;
-option go_package = "serverpb";
+option go_package = "github.com/cockroachdb/cockroach/pkg/server/serverpb";
 
 message BootstrapRequest { }
 message BootstrapResponse { }

--- a/pkg/server/serverpb/migration.proto
+++ b/pkg/server/serverpb/migration.proto
@@ -10,7 +10,7 @@
 
 syntax = "proto3";
 package cockroach.server.serverpb;
-option go_package = "serverpb";
+option go_package = "github.com/cockroachdb/cockroach/pkg/server/serverpb";
 
 import "clusterversion/cluster_version.proto";
 import "roachpb/metadata.proto";

--- a/pkg/server/serverpb/status.proto
+++ b/pkg/server/serverpb/status.proto
@@ -10,7 +10,7 @@
 
 syntax = "proto3";
 package cockroach.server.serverpb;
-option go_package = "serverpb";
+option go_package = "github.com/cockroachdb/cockroach/pkg/server/serverpb";
 
 import "build/info.proto";
 import "errorspb/errors.proto";

--- a/pkg/server/status/statuspb/status.proto
+++ b/pkg/server/status/statuspb/status.proto
@@ -10,7 +10,7 @@
 
 syntax = "proto3";
 package cockroach.server.status.statuspb;
-option go_package = "statuspb";
+option go_package = "github.com/cockroachdb/cockroach/pkg/server/status/statuspb";
 
 import "roachpb/metadata.proto";
 import "build/info.proto";

--- a/pkg/settings/encoding.proto
+++ b/pkg/settings/encoding.proto
@@ -10,7 +10,7 @@
 
 syntax = "proto3";
 package cockroach.settings;
-option go_package = "settings";
+option go_package = "github.com/cockroachdb/cockroach/pkg/settings";
 
 import "gogoproto/gogo.proto";
 

--- a/pkg/sql/appstatspb/app_stats.proto
+++ b/pkg/sql/appstatspb/app_stats.proto
@@ -10,7 +10,7 @@
 
 syntax = "proto2";
 package cockroach.sql;
-option go_package = "appstatspb";
+option go_package = "github.com/cockroachdb/cockroach/pkg/sql/appstatspb";
 
 import "gogoproto/gogo.proto";
 import "google/protobuf/timestamp.proto";

--- a/pkg/sql/catalog/catenumpb/encoded_datum.proto
+++ b/pkg/sql/catalog/catenumpb/encoded_datum.proto
@@ -13,7 +13,7 @@
 
 syntax = "proto2";
 package cockroach.sql.sqlbase;
-option go_package = "catenumpb";
+option go_package = "github.com/cockroachdb/cockroach/pkg/sql/catalog/catenumpb";
 
 // DatumEncoding identifies the encoding used for an EncDatum.
 enum DatumEncoding {

--- a/pkg/sql/catalog/catenumpb/index.proto
+++ b/pkg/sql/catalog/catenumpb/index.proto
@@ -11,7 +11,7 @@
 syntax = "proto3";
 
 package cockroach.sql.catalog.catpb;
-option go_package = "catenumpb";
+option go_package = "github.com/cockroachdb/cockroach/pkg/sql/catalog/catenumpb";
 
 import "gogoproto/gogo.proto";
 

--- a/pkg/sql/catalog/catpb/catalog.proto
+++ b/pkg/sql/catalog/catpb/catalog.proto
@@ -14,7 +14,7 @@
 syntax = "proto2";
 
 package cockroach.sql.catalog.catpb;
-option go_package = "catpb";
+option go_package = "github.com/cockroachdb/cockroach/pkg/sql/catalog/catpb";
 
 import "gogoproto/gogo.proto";
 

--- a/pkg/sql/catalog/catpb/enum.proto
+++ b/pkg/sql/catalog/catpb/enum.proto
@@ -14,7 +14,7 @@
 // when needed.
 syntax = "proto3";
 package cockroach.sql.catalog.catpb;
-option go_package = "catpb";
+option go_package = "github.com/cockroachdb/cockroach/pkg/sql/catalog/catpb";
 
 import "gogoproto/gogo.proto";
 

--- a/pkg/sql/catalog/catpb/function.proto
+++ b/pkg/sql/catalog/catpb/function.proto
@@ -11,7 +11,7 @@
 syntax = "proto2";
 
 package cockroach.sql.catalog.catpb;
-option go_package = "catpb";
+option go_package = "github.com/cockroachdb/cockroach/pkg/sql/catalog/catpb";
 
 import "gogoproto/gogo.proto";
 

--- a/pkg/sql/catalog/catpb/privilege.proto
+++ b/pkg/sql/catalog/catpb/privilege.proto
@@ -10,7 +10,7 @@
 
 syntax = "proto2";
 package cockroach.sql.sqlbase;
-option go_package = "catpb";
+option go_package = "github.com/cockroachdb/cockroach/pkg/sql/catalog/catpb";
 
 import "gogoproto/gogo.proto";
 

--- a/pkg/sql/catalog/descpb/join_type.proto
+++ b/pkg/sql/catalog/descpb/join_type.proto
@@ -10,7 +10,7 @@
 
 syntax = "proto2";
 package cockroach.sql.sqlbase;
-option go_package = "descpb";
+option go_package = "github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb";
 
 // JoinType is the particular type of a join (or join-like) operation. Not all
 // values are used in all contexts.

--- a/pkg/sql/catalog/descpb/locking.proto
+++ b/pkg/sql/catalog/descpb/locking.proto
@@ -10,7 +10,7 @@
 
 syntax = "proto2";
 package cockroach.sql.sqlbase;
-option go_package = "descpb";
+option go_package = "github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb";
 
 // ScanLockingStrength controls the row-level locking mode used by scans.
 //

--- a/pkg/sql/catalog/descpb/structured.proto
+++ b/pkg/sql/catalog/descpb/structured.proto
@@ -11,7 +11,7 @@
 // Cannot be proto3 because we use nullable primitives.
 syntax = "proto2";
 package cockroach.sql.sqlbase;
-option go_package = "descpb";
+option go_package = "github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb";
 
 import "config/zonepb/zone.proto";
 import "util/hlc/timestamp.proto";

--- a/pkg/sql/catalog/fetchpb/index_fetch.proto
+++ b/pkg/sql/catalog/fetchpb/index_fetch.proto
@@ -11,7 +11,7 @@
 // Cannot be proto3 because we use nullable primitives.
 syntax = "proto2";
 package cockroach.sql.sqlbase;
-option go_package = "fetchpb";
+option go_package = "github.com/cockroachdb/cockroach/pkg/sql/catalog/fetchpb";
 
 import "gogoproto/gogo.proto";
 import "sql/types/types.proto";

--- a/pkg/sql/catalog/schematelemetry/schematelemetrycontroller/schema_telemetry.proto
+++ b/pkg/sql/catalog/schematelemetry/schematelemetrycontroller/schema_telemetry.proto
@@ -10,7 +10,7 @@
 
 syntax = "proto3";
 package cockroach.sql;
-option go_package = "schematelemetrycontroller";
+option go_package = "github.com/cockroachdb/cockroach/pkg/sql/catalog/schematelemetry/schematelemetrycontroller";
 
 // ScheduledSchemaTelemetryExecutionArgs is the arguments to the scheduled
 // schema telemetry job. This is required to support SHOW SCHEDULE queries.

--- a/pkg/sql/contentionpb/contention.proto
+++ b/pkg/sql/contentionpb/contention.proto
@@ -10,7 +10,7 @@
 
 syntax = "proto3";
 package cockroach.sql.contentionpb;
-option go_package = "contentionpb";
+option go_package = "github.com/cockroachdb/cockroach/pkg/sql/contentionpb";
 
 import "kv/kvpb/api.proto";
 import "gogoproto/gogo.proto";

--- a/pkg/sql/execinfrapb/api.proto
+++ b/pkg/sql/execinfrapb/api.proto
@@ -15,7 +15,7 @@ syntax = "proto2";
 // the Go package name, because it defines the Protobuf message names which
 // can't be changed without breaking backward compatibility.
 package cockroach.sql.distsqlrun;
-option go_package = "execinfrapb";
+option go_package = "github.com/cockroachdb/cockroach/pkg/sql/execinfrapb";
 
 import "gogoproto/gogo.proto";
 import "google/protobuf/timestamp.proto";

--- a/pkg/sql/execinfrapb/component_stats.proto
+++ b/pkg/sql/execinfrapb/component_stats.proto
@@ -10,7 +10,7 @@
 
 syntax = "proto2";
 package cockroach.sql.distsqlrun;
-option go_package = "execinfrapb";
+option go_package = "github.com/cockroachdb/cockroach/pkg/sql/execinfrapb";
 
 import "gogoproto/gogo.proto";
 

--- a/pkg/sql/execinfrapb/data.proto
+++ b/pkg/sql/execinfrapb/data.proto
@@ -17,7 +17,7 @@ syntax = "proto2";
 // the Go package name, because it defines the Protobuf message names which
 // can't be changed without breaking backward compatibility.
 package cockroach.sql.distsqlrun;
-option go_package = "execinfrapb";
+option go_package = "github.com/cockroachdb/cockroach/pkg/sql/execinfrapb";
 
 import "kv/kvpb/api.proto";
 import "roachpb/data.proto";

--- a/pkg/sql/execinfrapb/processors.proto
+++ b/pkg/sql/execinfrapb/processors.proto
@@ -17,7 +17,7 @@ syntax = "proto2";
 // the Go package name, because it defines the Protobuf message names which
 // can't be changed without breaking backward compatibility.
 package cockroach.sql.distsqlrun;
-option go_package = "execinfrapb";
+option go_package = "github.com/cockroachdb/cockroach/pkg/sql/execinfrapb";
 
 import "sql/execinfrapb/data.proto";
 import "sql/execinfrapb/processors_base.proto";

--- a/pkg/sql/execinfrapb/processors_base.proto
+++ b/pkg/sql/execinfrapb/processors_base.proto
@@ -17,7 +17,7 @@ syntax = "proto2";
 // the Go package name, because it defines the Protobuf message names which
 // can't be changed without breaking backward compatibility.
 package cockroach.sql.distsqlrun;
-option go_package = "execinfrapb";
+option go_package = "github.com/cockroachdb/cockroach/pkg/sql/execinfrapb";
 
 import "sql/execinfrapb/data.proto";
 import "gogoproto/gogo.proto";

--- a/pkg/sql/execinfrapb/processors_bulk_io.proto
+++ b/pkg/sql/execinfrapb/processors_bulk_io.proto
@@ -17,7 +17,7 @@ syntax = "proto2";
 // the Go package name, because it defines the Protobuf message names which
 // can't be changed without breaking backward compatibility.
 package cockroach.sql.distsqlrun;
-option go_package = "execinfrapb";
+option go_package = "github.com/cockroachdb/cockroach/pkg/sql/execinfrapb";
 
 import "jobs/jobspb/jobs.proto";
 import "roachpb/io-formats.proto";

--- a/pkg/sql/execinfrapb/processors_changefeeds.proto
+++ b/pkg/sql/execinfrapb/processors_changefeeds.proto
@@ -17,7 +17,7 @@ syntax = "proto2";
 // the Go package name, because it defines the Protobuf message names which
 // can't be changed without breaking backward compatibility.
 package cockroach.sql.distsqlrun;
-option go_package = "execinfrapb";
+option go_package = "github.com/cockroachdb/cockroach/pkg/sql/execinfrapb";
 
 import "jobs/jobspb/jobs.proto";
 import "roachpb/data.proto";

--- a/pkg/sql/execinfrapb/processors_sql.proto
+++ b/pkg/sql/execinfrapb/processors_sql.proto
@@ -17,7 +17,7 @@ syntax = "proto2";
 // the Go package name, because it defines the Protobuf message names which
 // can't be changed without breaking backward compatibility.
 package cockroach.sql.distsqlrun;
-option go_package = "execinfrapb";
+option go_package = "github.com/cockroachdb/cockroach/pkg/sql/execinfrapb";
 
 import "gogoproto/gogo.proto";
 import "roachpb/data.proto";

--- a/pkg/sql/execinfrapb/processors_table_stats.proto
+++ b/pkg/sql/execinfrapb/processors_table_stats.proto
@@ -17,7 +17,7 @@ syntax = "proto2";
 // the Go package name, because it defines the Protobuf message names which
 // can't be changed without breaking backward compatibility.
 package cockroach.sql.distsqlrun;
-option go_package = "execinfrapb";
+option go_package = "github.com/cockroachdb/cockroach/pkg/sql/execinfrapb";
 
 import "sql/catalog/descpb/structured.proto";
 import "gogoproto/gogo.proto";

--- a/pkg/sql/execinfrapb/processors_ttl.proto
+++ b/pkg/sql/execinfrapb/processors_ttl.proto
@@ -17,7 +17,7 @@ syntax = "proto2";
 // the Go package name, because it defines the Protobuf message names which
 // can't be changed without breaking backward compatibility.
 package cockroach.sql.distsqlrun;
-option go_package = "execinfrapb";
+option go_package = "github.com/cockroachdb/cockroach/pkg/sql/execinfrapb";
 
 import "gogoproto/gogo.proto";
 import "google/protobuf/duration.proto";

--- a/pkg/sql/inverted/span_expression.proto
+++ b/pkg/sql/inverted/span_expression.proto
@@ -10,7 +10,7 @@
 
 syntax = "proto3";
 package cockroach.sql.inverted;
-option go_package = "inverted";
+option go_package = "github.com/cockroachdb/cockroach/pkg/sql/inverted";
 
 import "gogoproto/gogo.proto";
 

--- a/pkg/sql/lex/encode.proto
+++ b/pkg/sql/lex/encode.proto
@@ -10,7 +10,7 @@
 
 syntax = "proto3";
 package cockroach.sql.sessiondatapb;
-option go_package = "lex";
+option go_package = "github.com/cockroachdb/cockroach/pkg/sql/lex";
 
 import "gogoproto/gogo.proto";
 

--- a/pkg/sql/pgwire/pgerror/errors.proto
+++ b/pkg/sql/pgwire/pgerror/errors.proto
@@ -10,7 +10,7 @@
 
 syntax = "proto3";
 package cockroach.pgerror;
-option go_package = "pgerror";
+option go_package = "github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror";
 
 // Error contains all Postgres wire protocol error fields.
 // See https://www.postgresql.org/docs/current/static/protocol-error-fields.html

--- a/pkg/sql/protoreflect/BUILD.bazel
+++ b/pkg/sql/protoreflect/BUILD.bazel
@@ -1,6 +1,8 @@
 load("//build/bazelutil/unused_checker:unused.bzl", "get_x_data")
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
+# gazelle:resolve go go github.com/cockroachdb/cockroach/pkg/sql/protoreflect/test //pkg/sql/protoreflect/test
+
 go_library(
     name = "protoreflect",
     srcs = [

--- a/pkg/sql/protoreflect/test/BUILD.bazel
+++ b/pkg/sql/protoreflect/test/BUILD.bazel
@@ -13,7 +13,7 @@ proto_library(
 go_proto_library(
     name = "protoreflecttest_go_proto",
     compilers = ["//pkg/cmd/protoc-gen-gogoroach:protoc-gen-gogoroach_compiler"],
-    importpath = "github.com/cockroachdb/cockroach/pkg/sql/protoreflect/test",
+    importpath = "github.com/cockroachdb/cockroach/pkg/sql/protoreflect/protoreflecttest",
     proto = ":protoreflecttest_proto",
     visibility = ["//visibility:public"],
 )
@@ -21,7 +21,7 @@ go_proto_library(
 go_library(
     name = "test",
     srcs = ["wrap.go"],
-    embed = [":protoreflecttest_go_proto"],
+    embed = [":protoreflecttest_go_proto"],  # keep
     importpath = "github.com/cockroachdb/cockroach/pkg/sql/protoreflect/test",
     visibility = ["//visibility:public"],
     deps = [

--- a/pkg/sql/protoreflect/test/test.proto
+++ b/pkg/sql/protoreflect/test/test.proto
@@ -10,7 +10,7 @@
 
 syntax = "proto3";
 package cockroach.sql.protoreflecttest;
-option go_package = "protoreflecttest";
+option go_package = "github.com/cockroachdb/cockroach/pkg/sql/protoreflect/protoreflecttest";
 
 message Inner {
   string value = 1;

--- a/pkg/sql/rowenc/rowencpb/index_encoding.proto
+++ b/pkg/sql/rowenc/rowencpb/index_encoding.proto
@@ -10,7 +10,7 @@
 
 syntax = "proto3";
 package cockroach.rowenc;
-option go_package = "rowencpb";
+option go_package = "github.com/cockroachdb/cockroach/pkg/sql/rowenc/rowencpb";
 
 // Wrapper for the bytes of the value of an index that also contains bit for
 // whether or not the value was deleted. A wrapper of arbitrary index values

--- a/pkg/sql/schemachanger/scpb/elements.proto
+++ b/pkg/sql/schemachanger/scpb/elements.proto
@@ -10,7 +10,7 @@
 
 syntax = "proto3";
 package cockroach.sql.schemachanger.scpb;
-option go_package = "scpb";
+option go_package = "github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scpb";
 
 import "sql/catalog/catenumpb/index.proto";
 import "sql/catalog/catpb/catalog.proto";

--- a/pkg/sql/schemachanger/scpb/scpb.proto
+++ b/pkg/sql/schemachanger/scpb/scpb.proto
@@ -10,7 +10,7 @@
 
 syntax = "proto3";
 package cockroach.sql.schemachanger.scpb;
-option go_package = "scpb";
+option go_package = "github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scpb";
 
 import "sql/schemachanger/scpb/elements.proto";
 import "gogoproto/gogo.proto";

--- a/pkg/sql/sem/semenumpb/constraint.proto
+++ b/pkg/sql/sem/semenumpb/constraint.proto
@@ -15,7 +15,7 @@
 // when needed.
 syntax = "proto3";
 package cockroach.sql.sem.semenumpb;
-option go_package = "semenumpb";
+option go_package = "github.com/cockroachdb/cockroach/pkg/sql/sem/semenumpb";
 
 import "gogoproto/gogo.proto";
 

--- a/pkg/sql/sessiondatapb/local_only_session_data.proto
+++ b/pkg/sql/sessiondatapb/local_only_session_data.proto
@@ -10,7 +10,7 @@
 
 syntax = "proto3";
 package cockroach.sql.sessiondatapb;
-option go_package = "sessiondatapb";
+option go_package = "github.com/cockroachdb/cockroach/pkg/sql/sessiondatapb";
 
 import "gogoproto/gogo.proto";
 

--- a/pkg/sql/sessiondatapb/session_data.proto
+++ b/pkg/sql/sessiondatapb/session_data.proto
@@ -10,7 +10,7 @@
 
 syntax = "proto3";
 package cockroach.sql.sessiondatapb;
-option go_package = "sessiondatapb";
+option go_package = "github.com/cockroachdb/cockroach/pkg/sql/sessiondatapb";
 
 import "sql/lex/encode.proto";
 import "util/duration/duration.proto";

--- a/pkg/sql/sessiondatapb/session_migration.proto
+++ b/pkg/sql/sessiondatapb/session_migration.proto
@@ -10,7 +10,7 @@
 
 syntax = "proto3";
 package cockroach.sql.sessiondatapb;
-option go_package = "sessiondatapb";
+option go_package = "github.com/cockroachdb/cockroach/pkg/sql/sessiondatapb";
 
 import "gogoproto/gogo.proto";
 import "sql/sessiondatapb/session_data.proto";

--- a/pkg/sql/sessiondatapb/session_revival_token.proto
+++ b/pkg/sql/sessiondatapb/session_revival_token.proto
@@ -10,7 +10,7 @@
 
 syntax = "proto3";
 package cockroach.sql.sessiondatapb;
-option go_package = "sessiondatapb";
+option go_package = "github.com/cockroachdb/cockroach/pkg/sql/sessiondatapb";
 
 import "google/protobuf/timestamp.proto";
 

--- a/pkg/sql/sqlstats/insights/insights.proto
+++ b/pkg/sql/sqlstats/insights/insights.proto
@@ -10,7 +10,7 @@
 
 syntax = "proto3";
 package cockroach.sql.insights;
-option go_package = "insights";
+option go_package = "github.com/cockroachdb/cockroach/pkg/sql/sqlstats/insights";
 
 import "gogoproto/gogo.proto";
 import "google/protobuf/timestamp.proto";

--- a/pkg/sql/sqlstats/persistedsqlstats/sql_stats_compact.proto
+++ b/pkg/sql/sqlstats/persistedsqlstats/sql_stats_compact.proto
@@ -10,7 +10,7 @@
 
 syntax = "proto3";
 package cockroach.sql;
-option go_package = "persistedsqlstats";
+option go_package = "github.com/cockroachdb/cockroach/pkg/sql/sqlstats/persistedsqlstats";
 
 // ScheduledSQLStatsCompactorExecutionArgs is the arguments to the scheduled
 // sql stats compactor. This is required to support SHOW SCHEDULE queries.

--- a/pkg/sql/stats/histogram.proto
+++ b/pkg/sql/stats/histogram.proto
@@ -14,7 +14,7 @@
 
 syntax = "proto3";
 package cockroach.sql.stats;
-option go_package = "stats";
+option go_package = "github.com/cockroachdb/cockroach/pkg/sql/stats";
 
 import "gogoproto/gogo.proto";
 import "sql/types/types.proto";

--- a/pkg/sql/stats/table_statistic.proto
+++ b/pkg/sql/stats/table_statistic.proto
@@ -14,7 +14,7 @@
 
 syntax = "proto3";
 package cockroach.sql.stats;
-option go_package = "stats";
+option go_package = "github.com/cockroachdb/cockroach/pkg/sql/stats";
 
 import "gogoproto/gogo.proto";
 import "google/protobuf/timestamp.proto";

--- a/pkg/sql/types/types.proto
+++ b/pkg/sql/types/types.proto
@@ -11,7 +11,7 @@
 // Cannot be proto3 because we use nullable primitives.
 syntax = "proto2";
 package cockroach.sql.sem.types;
-option go_package = "types";
+option go_package = "github.com/cockroachdb/cockroach/pkg/sql/types";
 
 import "gogoproto/gogo.proto";
 import "geo/geopb/geopb.proto";

--- a/pkg/storage/enginepb/engine.proto
+++ b/pkg/storage/enginepb/engine.proto
@@ -10,7 +10,7 @@
 
 syntax = "proto3";
 package cockroach.storage.enginepb;
-option go_package = "enginepb";
+option go_package = "github.com/cockroachdb/cockroach/pkg/storage/enginepb";
 
 import "gogoproto/gogo.proto";
 

--- a/pkg/storage/enginepb/file_registry.proto
+++ b/pkg/storage/enginepb/file_registry.proto
@@ -10,7 +10,7 @@
 
 syntax = "proto3";
 package cockroach.storage.enginepb;
-option go_package = "enginepb";
+option go_package = "github.com/cockroachdb/cockroach/pkg/storage/enginepb";
 
 // RegistryVersion defines the version of a registry. Newly added versions
 // should be larger than all currently and previously existing versions.

--- a/pkg/storage/enginepb/mvcc.proto
+++ b/pkg/storage/enginepb/mvcc.proto
@@ -11,7 +11,7 @@
 // Cannot be proto3 because we depend on absent-vs-empty distinction.
 syntax = "proto2";
 package cockroach.storage.enginepb;
-option go_package = "enginepb";
+option go_package = "github.com/cockroachdb/cockroach/pkg/storage/enginepb";
 
 import "storage/enginepb/mvcc3.proto";
 import "util/hlc/legacy_timestamp.proto";

--- a/pkg/storage/enginepb/mvcc3.proto
+++ b/pkg/storage/enginepb/mvcc3.proto
@@ -10,7 +10,7 @@
 
 syntax = "proto3";
 package cockroach.storage.enginepb;
-option go_package = "enginepb";
+option go_package = "github.com/cockroachdb/cockroach/pkg/storage/enginepb";
 
 import "util/hlc/timestamp.proto";
 import "gogoproto/gogo.proto";

--- a/pkg/storage/enginepb/rocksdb.proto
+++ b/pkg/storage/enginepb/rocksdb.proto
@@ -10,7 +10,7 @@
 
 syntax = "proto3";
 package cockroach.storage.enginepb;
-option go_package = "enginepb";
+option go_package = "github.com/cockroachdb/cockroach/pkg/storage/enginepb";
 
 import "util/hlc/timestamp.proto";
 import "gogoproto/gogo.proto";

--- a/pkg/testutils/grpcutils/testservice.proto
+++ b/pkg/testutils/grpcutils/testservice.proto
@@ -10,7 +10,7 @@
 
 syntax = "proto3";
 package cockroach.testutils.grpcutils;
-option go_package = "grpcutils";
+option go_package = "github.com/cockroachdb/cockroach/pkg/testutils/grpcutils";
 
 import "google/protobuf/any.proto";
 

--- a/pkg/ts/catalog/chart_catalog.proto
+++ b/pkg/ts/catalog/chart_catalog.proto
@@ -10,7 +10,7 @@
 
 syntax = "proto2";
 package cockroach.ts.catalog;
-option go_package = "catalog";
+option go_package = "github.com/cockroachdb/cockroach/pkg/ts/catalog";
 
 import "ts/tspb/timeseries.proto";
 

--- a/pkg/ts/tspb/timeseries.proto
+++ b/pkg/ts/tspb/timeseries.proto
@@ -10,7 +10,7 @@
 
 syntax = "proto2";
 package cockroach.ts.tspb;
-option go_package = "tspb";
+option go_package = "github.com/cockroachdb/cockroach/pkg/ts/tspb";
 
 import "roachpb/data.proto";
 import "gogoproto/gogo.proto";

--- a/pkg/util/admission/admissionpb/io_threshold.proto
+++ b/pkg/util/admission/admissionpb/io_threshold.proto
@@ -10,7 +10,7 @@
 
 syntax = "proto3";
 package cockroach.util.admission.admissionpb;
-option go_package = "admissionpb";
+option go_package = "github.com/cockroachdb/cockroach/pkg/util/admission/admissionpb";
 
 import "gogoproto/gogo.proto";
 

--- a/pkg/util/duration/duration.proto
+++ b/pkg/util/duration/duration.proto
@@ -10,7 +10,7 @@
 
 syntax = "proto3";
 package cockroach.util.duration;
-option go_package = "duration";
+option go_package = "github.com/cockroachdb/cockroach/pkg/util/duration";
 
 // IntervalStyle matches the PostgreSQL IntervalStyle session parameter.
 enum IntervalStyle {

--- a/pkg/util/hlc/legacy_timestamp.proto
+++ b/pkg/util/hlc/legacy_timestamp.proto
@@ -10,7 +10,7 @@
 
 syntax = "proto2";
 package cockroach.util.hlc;
-option go_package = "hlc";
+option go_package = "github.com/cockroachdb/cockroach/pkg/util/hlc";
 
 import "gogoproto/gogo.proto";
 

--- a/pkg/util/hlc/timestamp.proto
+++ b/pkg/util/hlc/timestamp.proto
@@ -10,7 +10,7 @@
 
 syntax = "proto3";
 package cockroach.util.hlc;
-option go_package = "hlc";
+option go_package = "github.com/cockroachdb/cockroach/pkg/util/hlc";
 
 import "gogoproto/gogo.proto";
 

--- a/pkg/util/log/eventpb/cluster_events.proto
+++ b/pkg/util/log/eventpb/cluster_events.proto
@@ -10,7 +10,7 @@
 
 syntax = "proto3";
 package cockroach.util.log.eventpb;
-option go_package = "eventpb";
+option go_package = "github.com/cockroachdb/cockroach/pkg/util/log/eventpb";
 
 import "gogoproto/gogo.proto";
 import "util/log/logpb/event.proto";

--- a/pkg/util/log/eventpb/ddl_events.proto
+++ b/pkg/util/log/eventpb/ddl_events.proto
@@ -10,7 +10,7 @@
 
 syntax = "proto3";
 package cockroach.util.log.eventpb;
-option go_package = "eventpb";
+option go_package = "github.com/cockroachdb/cockroach/pkg/util/log/eventpb";
 
 import "gogoproto/gogo.proto";
 import "util/log/eventpb/events.proto";

--- a/pkg/util/log/eventpb/debug_events.proto
+++ b/pkg/util/log/eventpb/debug_events.proto
@@ -10,7 +10,7 @@
 
 syntax = "proto3";
 package cockroach.util.log.eventpb;
-option go_package = "eventpb";
+option go_package = "github.com/cockroachdb/cockroach/pkg/util/log/eventpb";
 
 import "gogoproto/gogo.proto";
 import "util/log/logpb/event.proto";

--- a/pkg/util/log/eventpb/events.proto
+++ b/pkg/util/log/eventpb/events.proto
@@ -10,7 +10,7 @@
 
 syntax = "proto3";
 package cockroach.util.log.eventpb;
-option go_package = "eventpb";
+option go_package = "github.com/cockroachdb/cockroach/pkg/util/log/eventpb";
 
 import "gogoproto/gogo.proto";
 import "util/log/logpb/event.proto";

--- a/pkg/util/log/eventpb/health_events.proto
+++ b/pkg/util/log/eventpb/health_events.proto
@@ -10,7 +10,7 @@
 
 syntax = "proto3";
 package cockroach.util.log.eventpb;
-option go_package = "eventpb";
+option go_package = "github.com/cockroachdb/cockroach/pkg/util/log/eventpb";
 
 import "gogoproto/gogo.proto";
 import "util/log/logpb/event.proto";

--- a/pkg/util/log/eventpb/job_events.proto
+++ b/pkg/util/log/eventpb/job_events.proto
@@ -10,7 +10,7 @@
 
 syntax = "proto3";
 package cockroach.util.log.eventpb;
-option go_package = "eventpb";
+option go_package = "github.com/cockroachdb/cockroach/pkg/util/log/eventpb";
 
 import "gogoproto/gogo.proto";
 import "util/log/eventpb/events.proto";

--- a/pkg/util/log/eventpb/misc_sql_events.proto
+++ b/pkg/util/log/eventpb/misc_sql_events.proto
@@ -10,7 +10,7 @@
 
 syntax = "proto3";
 package cockroach.util.log.eventpb;
-option go_package = "eventpb";
+option go_package = "github.com/cockroachdb/cockroach/pkg/util/log/eventpb";
 
 import "gogoproto/gogo.proto";
 import "util/log/eventpb/events.proto";

--- a/pkg/util/log/eventpb/privilege_events.proto
+++ b/pkg/util/log/eventpb/privilege_events.proto
@@ -10,7 +10,7 @@
 
 syntax = "proto3";
 package cockroach.util.log.eventpb;
-option go_package = "eventpb";
+option go_package = "github.com/cockroachdb/cockroach/pkg/util/log/eventpb";
 
 import "gogoproto/gogo.proto";
 import "util/log/eventpb/events.proto";

--- a/pkg/util/log/eventpb/role_events.proto
+++ b/pkg/util/log/eventpb/role_events.proto
@@ -10,7 +10,7 @@
 
 syntax = "proto3";
 package cockroach.util.log.eventpb;
-option go_package = "eventpb";
+option go_package = "github.com/cockroachdb/cockroach/pkg/util/log/eventpb";
 
 import "gogoproto/gogo.proto";
 import "util/log/eventpb/events.proto";

--- a/pkg/util/log/eventpb/session_events.proto
+++ b/pkg/util/log/eventpb/session_events.proto
@@ -10,7 +10,7 @@
 
 syntax = "proto3";
 package cockroach.util.log.eventpb;
-option go_package = "eventpb";
+option go_package = "github.com/cockroachdb/cockroach/pkg/util/log/eventpb";
 
 import "gogoproto/gogo.proto";
 import "util/log/logpb/event.proto";

--- a/pkg/util/log/eventpb/sql_audit_events.proto
+++ b/pkg/util/log/eventpb/sql_audit_events.proto
@@ -10,7 +10,7 @@
 
 syntax = "proto3";
 package cockroach.util.log.eventpb;
-option go_package = "eventpb";
+option go_package = "github.com/cockroachdb/cockroach/pkg/util/log/eventpb";
 
 import "gogoproto/gogo.proto";
 import "util/log/eventpb/events.proto";

--- a/pkg/util/log/eventpb/storage_events.proto
+++ b/pkg/util/log/eventpb/storage_events.proto
@@ -10,7 +10,7 @@
 
 syntax = "proto3";
 package cockroach.util.log.eventpb;
-option go_package = "eventpb";
+option go_package = "github.com/cockroachdb/cockroach/pkg/util/log/eventpb";
 
 import "gogoproto/gogo.proto";
 import "util/log/logpb/event.proto";

--- a/pkg/util/log/eventpb/telemetry.proto
+++ b/pkg/util/log/eventpb/telemetry.proto
@@ -10,7 +10,7 @@
 
 syntax = "proto3";
 package cockroach.util.log.eventpb;
-option go_package = "eventpb";
+option go_package = "github.com/cockroachdb/cockroach/pkg/util/log/eventpb";
 
 import "gogoproto/gogo.proto";
 import "sql/catalog/descpb/structured.proto";

--- a/pkg/util/log/eventpb/zone_events.proto
+++ b/pkg/util/log/eventpb/zone_events.proto
@@ -10,7 +10,7 @@
 
 syntax = "proto3";
 package cockroach.util.log.eventpb;
-option go_package = "eventpb";
+option go_package = "github.com/cockroachdb/cockroach/pkg/util/log/eventpb";
 
 import "gogoproto/gogo.proto";
 import "util/log/eventpb/events.proto";

--- a/pkg/util/log/logpb/event.proto
+++ b/pkg/util/log/logpb/event.proto
@@ -10,7 +10,7 @@
 
 syntax = "proto3";
 package cockroach.util.log;
-option go_package = "logpb";
+option go_package = "github.com/cockroachdb/cockroach/pkg/util/log/logpb";
 
 import "gogoproto/gogo.proto";
 

--- a/pkg/util/log/logpb/log.proto
+++ b/pkg/util/log/logpb/log.proto
@@ -10,7 +10,7 @@
 
 syntax = "proto3";
 package cockroach.util.log;
-option go_package = "logpb";
+option go_package = "github.com/cockroachdb/cockroach/pkg/util/log/logpb";
 
 import "gogoproto/gogo.proto";
 

--- a/pkg/util/metric/metric.proto
+++ b/pkg/util/metric/metric.proto
@@ -11,7 +11,7 @@
 // metric.proto requires proto2 to import io.prometheus.client.MetricType.
 syntax = "proto2";
 package cockroach.util.metric;
-option go_package = "metric";
+option go_package = "github.com/cockroachdb/cockroach/pkg/util/metric";
 
 import "gogoproto/gogo.proto";
 import "io/prometheus/client/metrics.proto";

--- a/pkg/util/optional/optional.proto
+++ b/pkg/util/optional/optional.proto
@@ -14,7 +14,7 @@
 
 syntax = "proto3";
 package cockroach.util.optional;
-option go_package = "optional";
+option go_package = "github.com/cockroachdb/cockroach/pkg/util/optional";
 
 import "gogoproto/gogo.proto";
 import "google/protobuf/duration.proto";

--- a/pkg/util/protoutil/clone.proto
+++ b/pkg/util/protoutil/clone.proto
@@ -10,7 +10,7 @@
 
 syntax = "proto3";
 package cockroach.util.protoutil;
-option go_package = "protoutil";
+option go_package = "github.com/cockroachdb/cockroach/pkg/util/protoutil";
 
 import "gogoproto/gogo.proto";
 

--- a/pkg/util/timeutil/pgdate/pgdate.proto
+++ b/pkg/util/timeutil/pgdate/pgdate.proto
@@ -10,7 +10,7 @@
 
 syntax = "proto3";
 package cockroach.util.timeutil.pgdate;
-option go_package = "pgdate";
+option go_package = "github.com/cockroachdb/cockroach/pkg/util/timeutil/pgdate";
 
 // DateStyle refers to the PostgreSQL DateStyle allowed variables.
 message DateStyle {

--- a/pkg/util/tracing/tracingpb/recorded_span.proto
+++ b/pkg/util/tracing/tracingpb/recorded_span.proto
@@ -10,7 +10,7 @@
 
 syntax = "proto3";
 package cockroach.util.tracing.tracingpb;
-option go_package = "tracingpb";
+option go_package = "github.com/cockroachdb/cockroach/pkg/util/tracing/tracingpb";
 
 import "gogoproto/gogo.proto";
 import "google/protobuf/any.proto";

--- a/pkg/util/tracing/tracingpb/tracing.proto
+++ b/pkg/util/tracing/tracingpb/tracing.proto
@@ -10,7 +10,7 @@
 
 syntax = "proto3";
 package cockroach.util.tracing.tracingpb;
-option go_package = "tracingpb";
+option go_package = "github.com/cockroachdb/cockroach/pkg/util/tracing/tracingpb";
 
 import "gogoproto/gogo.proto";
 

--- a/pkg/util/tracing/tracingservicepb/tracing_service.proto
+++ b/pkg/util/tracing/tracingservicepb/tracing_service.proto
@@ -10,7 +10,7 @@
 
 syntax = "proto3";
 package cockroach.util.tracing;
-option go_package = "tracingservicepb";
+option go_package = "github.com/cockroachdb/cockroach/pkg/util/tracing/tracingservicepb";
 
 import "gogoproto/gogo.proto";
 import "util/tracing/tracingpb/recorded_span.proto";

--- a/pkg/util/unresolved_addr.proto
+++ b/pkg/util/unresolved_addr.proto
@@ -10,7 +10,7 @@
 
 syntax = "proto2";
 package cockroach.util;
-option go_package = "util";
+option go_package = "github.com/cockroachdb/cockroach/pkg/util";
 
 import "gogoproto/gogo.proto";
 


### PR DESCRIPTION
Everywhere in the entire tree we use `option go_package` statements like
the following:

```
option go_package = "build";
```

We do this *instead of* using the entire fully-qualified package name,
like:

```
option go_package = "github.com/cockroachdb/cockroach/pkg/build";
```

This is apparently just an error. All the documentation I have seen
(https://github.com/cockroachdb/gogoproto/blob/master/README) suggests
that the fully-qualified package name should be used here. Further, this
caused the `make` build to break after a refactor as the code generator
doesn't know how to import a package like `"roachpb"` (since it should
instead be importing `"github.com/cockroachdb/cockroach/pkg/roachpb"`).

Correct this problem *everywhere* and update the `Makefile` to set
`paths=source_relative` to tell `protoc` that output files should be
placed next to input files.

Epic: none
Release note: None