### PR TITLE
sql: allow replace udf with implicit return type

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/udf
+++ b/pkg/sql/logictest/testdata/logic_test/udf
@@ -3086,6 +3086,19 @@ SELECT f_rtbl();
 ----
 (1,2)
 
+statement ok
+ALTER TABLE t_alter ADD COLUMN c INT;
+
+statement error pq: return type mismatch in function declared to return record
+CREATE OR REPLACE FUNCTION f_rtbl() RETURNS t_alter LANGUAGE SQL AS 'SELECT 1, 2;'
+
+statement ok
+CREATE OR REPLACE FUNCTION f_rtbl() RETURNS t_alter LANGUAGE SQL AS 'SELECT 1, 2, 3;'
+
+query T
+SELECT f_rtbl();
+----
+(1,2,3)
 
 subtest regression_94146
 


### PR DESCRIPTION
Before this change, we would return a "cannot change return type of existing function" when the user tried to replace a UDF with a function referencing the same UDT return type if the UDT had been altered since the original UDF was created.

This PR relaxes this constraint to match postgres behavior. Since the optbuilder already checks that the UDT return type is consistent with the columns returned by the UDF body, all we needed to do here was update the UDF descriptor.

Fixes: #94124

Epic: none
Release note: Fixes an error when calling `CREATE OR REPLACE FUNCTION` with a user-defined return type if the UDT was modified since the original UDF was created. Now the command will succeed as long as the function body returns the correct output matching the modified UDT.