### PR TITLE
release-22.2: eval: fix evaluation of ALL, ANY, and SOME with NULLs on the left

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/array
+++ b/pkg/sql/logictest/testdata/logic_test/array
@@ -2294,3 +2294,21 @@ ORDER BY a;
 ----
 {09:20:35.19023}
 {09:20:35.19023,03:23:06.042923}
+
+# Regression tests for not checking whether the left argument of a comparison
+# operator with a sub-operator for being non-NULL (#95158).
+statement ok
+CREATE TABLE t95158 (c STRING);
+INSERT INTO t95158 VALUES (NULL);
+
+query I
+SELECT * FROM t95158 WHERE c !~ ALL (ARRAY['x']::STRING[])
+----
+
+query I
+SELECT * FROM t95158 WHERE c !~ ANY (ARRAY['x']::STRING[])
+----
+
+query I
+SELECT * FROM t95158 WHERE c !~ SOME (ARRAY['x']::STRING[])
+----

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -13312,9 +13312,16 @@ a_expr:
     subOp := $2.op()
     subOpCmp, ok := subOp.(treecmp.ComparisonOperator)
     if !ok {
-      sqllex.Error(fmt.Sprintf("%s %s <array> is invalid because %q is not a boolean operator",
-        subOp, op, subOp))
-      return 1
+      // It is possible that we found `~` operator which was incorrectly typed
+      // as "unary complement" math operator. Check whether that's the case and
+      // override it to the correct "reg match" comparison operator.
+      if tree.IsUnaryComplement(subOp) {
+        subOp = treecmp.MakeComparisonOperator(treecmp.RegMatch)
+      } else {
+        sqllex.Error(fmt.Sprintf("%s %s <array> is invalid because %q is not a boolean operator",
+          subOp, op, subOp))
+        return 1
+      }
     }
     $$.val = &tree.ComparisonExpr{
       Operator: op,

--- a/pkg/sql/parser/testdata/select_exprs
+++ b/pkg/sql/parser/testdata/select_exprs
@@ -1927,3 +1927,19 @@ OVERLAPS
 (DATE '2000-01-03')
                   ^
 HINT: try \h SELECT
+
+parse
+SELECT NOT ('a' ~ ANY (ARRAY['x']:::STRING[]))
+----
+SELECT NOT ('a' = ANY (ARRAY['x']:::STRING[])) -- normalized!
+SELECT (NOT (((('a') = ANY ((((ARRAY[('x')]):::STRING[]))))))) -- fully parenthesized
+SELECT NOT ('_' = ANY (ARRAY['_']:::STRING[])) -- literals removed
+SELECT NOT ('a' = ANY (ARRAY['x']:::STRING[])) -- identifiers removed
+
+parse
+SELECT ('a' !~ ANY (ARRAY['x']:::STRING[]))
+----
+SELECT ('a' !~ ANY (ARRAY['x']:::STRING[]))
+SELECT (((('a') !~ ANY ((((ARRAY[('x')]):::STRING[])))))) -- fully parenthesized
+SELECT ('_' !~ ANY (ARRAY['_']:::STRING[])) -- literals removed
+SELECT ('a' !~ ANY (ARRAY['x']:::STRING[])) -- identifiers removed

--- a/pkg/sql/sem/eval/comparison.go
+++ b/pkg/sql/sem/eval/comparison.go
@@ -19,7 +19,7 @@ import (
 )
 
 // ComparisonExprWithSubOperator evaluates a comparison expression that has
-// sub-operator.
+// sub-operator (which are ANY, SOME, and ALL).
 func ComparisonExprWithSubOperator(
 	ctx *Context, expr *tree.ComparisonExpr, left, right tree.Datum,
 ) (tree.Datum, error) {
@@ -81,7 +81,7 @@ func evalDatumsCmp(
 	any := !all
 	sawNull := false
 	for _, elem := range right {
-		if elem == tree.DNull {
+		if left == tree.DNull || elem == tree.DNull {
 			sawNull = true
 			continue
 		}

--- a/pkg/sql/sem/tree/expr.go
+++ b/pkg/sql/sem/tree/expr.go
@@ -1145,6 +1145,12 @@ func (o UnaryOperator) String() string {
 // Operator implements tree.Operator.
 func (UnaryOperator) Operator() {}
 
+// IsUnaryComplement returns whether op is a unary complement operator.
+func IsUnaryComplement(op Operator) bool {
+	u, ok := op.(UnaryOperator)
+	return ok && u.Symbol == UnaryComplement
+}
+
 // UnaryOperatorSymbol represents a unary operator.
 type UnaryOperatorSymbol uint8
 


### PR DESCRIPTION
Backport 2/2 commits from #95180.

/cc @cockroachdb/release

---

**parser: fix parsing ~ when used as comparison operator in some cases**

This commit fixes how we parse expressions like
```
NOT ('a' ~ ANY (ARRAY['x']:::STRING[]))
```
which is equivalent to
```
('a' !~ ANY (ARRAY['x']:::STRING[]))
```
which we parse correctly. The problem was that we parse `~` symbol as
"unary complement" math operator and not as "reg match" comparison
operator, and this is now fixed in a somewhat hacky way. Namely, we
still parse it as unary complement, but then when we're in the comparison
operator with sub-operator context, we retype it correctly. This seems
acceptable given that a more "proper" fix would probably require
non-trivial changes to the grammar.

Release note: None

**eval: fix evaluation of ALL, ANY, and SOME with NULL on the left**

Previously, we could run into an internal error (or a crash when the
vectorized engine is not used) when evaluating ALL, ANY, or SOME
comparison operators with some sub-operators (e.g. RegMatch). We forgot
to check whether the left argument is NULL, and this is now fixed. For
other sub-operators we seem to have done the right thing, so this bug
seems rather rare in practice, thus, I omitted the release note.

Fixes: #95158.

Release note: None

Fixes: #97011.

Release justification: bug fix.