### PR TITLE
ui: show data for txn insights when max size reached

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/api/sqlApi.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/api/sqlApi.ts
@@ -60,9 +60,9 @@ export type SqlExecutionErrorMessage = {
   source: { file: string; line: number; function: "string" };
 };
 
-export type ApiResponse<ResultType> = {
+export type SqlApiResponse<ResultType> = {
   maxSizeReached: boolean;
-  results: Array<ResultType>;
+  results: ResultType;
 };
 
 export const SQL_API_PATH = "/api/v2/sql/";
@@ -165,7 +165,7 @@ export function sqlApiErrorMessage(message: string): string {
   return message;
 }
 
-function isMaxSizeError(message: string): boolean {
+export function isMaxSizeError(message: string): boolean {
   return !!message?.includes("max result size exceeded");
 }
 
@@ -173,7 +173,7 @@ export function formatApiResult(
   results: Array<any>,
   error: SqlExecutionErrorMessage,
   errorMessageContext: string,
-): ApiResponse<any> {
+): SqlApiResponse<any> {
   const maxSizeError = isMaxSizeError(error?.message);
 
   if (error && !maxSizeError) {

--- a/pkg/ui/workspaces/cluster-ui/src/api/stmtInsightsApi.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/api/stmtInsightsApi.ts
@@ -9,7 +9,7 @@
 // licenses/APL.txt.
 
 import {
-  ApiResponse,
+  SqlApiResponse,
   executeInternalSql,
   formatApiResult,
   LARGE_RESULT_SIZE,
@@ -138,7 +138,7 @@ export const stmtInsightsByTxnExecutionQuery = (id: string): string => `
 
 export async function getStmtInsightsApi(
   req?: StmtInsightsReq,
-): Promise<ApiResponse<StmtInsightEvent>> {
+): Promise<SqlApiResponse<StmtInsightEvent[]>> {
   const request: SqlExecutionRequest = {
     statements: [
       {

--- a/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsightDetails/transactionInsightDetails.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsightDetails/transactionInsightDetails.tsx
@@ -14,6 +14,7 @@ import { ArrowLeft } from "@cockroachlabs/icons";
 import { Tabs } from "antd";
 import "antd/lib/col/style";
 import "antd/lib/row/style";
+import "antd/lib/tabs/style";
 import { Button } from "src/button";
 import { getMatchParamByName } from "src/util/query";
 import { TxnInsightDetailsRequest, TxnInsightDetailsReqErrs } from "src/api";
@@ -25,14 +26,16 @@ import { idAttr } from "src/util";
 import { TransactionInsightDetailsOverviewTab } from "./transactionInsightDetailsOverviewTab";
 import { TransactionInsightsDetailsStmtsTab } from "./transactionInsightDetailsStmtsTab";
 import { timeScaleRangeToObj } from "src/timeScaleDropdown/utils";
-
-import "antd/lib/tabs/style";
+import { InlineAlert } from "@cockroachlabs/ui-components";
+import { insights } from "src/util";
+import { Anchor } from "src/anchor";
 
 export interface TransactionInsightDetailsStateProps {
   insightDetails: TxnInsightDetails;
   insightError: TxnInsightDetailsReqErrs | null;
   timeScale?: TimeScale;
   hasAdminRole: boolean;
+  maxSizeApiReached?: boolean;
 }
 
 export interface TransactionInsightDetailsDispatchProps {
@@ -65,6 +68,7 @@ export const TransactionInsightDetails: React.FC<
   match,
   hasAdminRole,
   refreshUserSQLRoles,
+  maxSizeApiReached,
 }) => {
   const fetches = useRef<number>(0);
   const executionID = getMatchParamByName(match, idAttr);
@@ -153,6 +157,7 @@ export const TransactionInsightDetails: React.FC<
               contentionDetails={insightDetails.blockingContentionDetails}
               setTimeScale={setTimeScale}
               hasAdminRole={hasAdminRole}
+              maxApiSizeReached={maxSizeApiReached}
             />
           </Tabs.TabPane>
           {(insightDetails.txnDetails?.stmtExecutionIDs?.length ||
@@ -169,6 +174,20 @@ export const TransactionInsightDetails: React.FC<
                 error={insightError?.statementsErr}
                 statements={insightDetails?.statements}
               />
+              {maxSizeApiReached && (
+                <InlineAlert
+                  intent="info"
+                  title={
+                    <>
+                      Not all statements are displayed because the maximum
+                      number of statements was reached in the console.&nbsp;
+                      <Anchor href={insights} target="_blank">
+                        Learn more
+                      </Anchor>
+                    </>
+                  }
+                />
+              )}
             </Tabs.TabPane>
           )}
         </Tabs>

--- a/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsightDetails/transactionInsightDetailsConnected.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsightDetails/transactionInsightDetailsConnected.tsx
@@ -19,6 +19,7 @@ import {
   selectTransactionInsightDetails,
   selectTransactionInsightDetailsError,
   actions,
+  selectTransactionInsightDetailsMaxSizeReached,
 } from "src/store/insightDetails/transactionInsightDetails";
 import { TimeScale } from "../../timeScaleDropdown";
 import { actions as sqlStatsActions } from "../../store/sqlStats";
@@ -39,6 +40,10 @@ const mapStateToProps = (
     insightError: insightError,
     timeScale: selectTimeScale(state),
     hasAdminRole: selectHasAdminRole(state),
+    maxSizeApiReached: selectTransactionInsightDetailsMaxSizeReached(
+      state,
+      props,
+    ),
   };
 };
 

--- a/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsightDetails/transactionInsightDetailsOverviewTab.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsightDetails/transactionInsightDetailsOverviewTab.tsx
@@ -60,6 +60,7 @@ type Props = {
   hasAdminRole: boolean;
   errors: TxnInsightDetailsReqErrs | null;
   maxRequestsReached: boolean;
+  maxApiSizeReached: boolean;
 };
 
 export const TransactionInsightDetailsOverviewTab: React.FC<Props> = ({
@@ -78,9 +79,13 @@ export const TransactionInsightDetailsOverviewTab: React.FC<Props> = ({
   const isCockroachCloud = useContext(CockroachCloudContext);
 
   const queryFromStmts = statements?.map(s => s.query)?.join("\n");
-  const insightQueries = queryFromStmts?.length
+  let insightQueries = queryFromStmts?.length
     ? queryFromStmts
     : txnDetails?.query ?? "Insight not found.";
+  if (maxRequestsReached) {
+    insightQueries = `${insightQueries} \n\nNot all statements are displayed because 
+the maximum number of statements was reached in the console.`;
+  }
   const insightsColumns = makeInsightsColumns(
     isCockroachCloud,
     hasAdminRole,

--- a/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsights/transactionInsights/transactionInsightsView.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsights/transactionInsights/transactionInsightsView.tsx
@@ -51,6 +51,9 @@ import styles from "src/statementsPage/statementsPage.module.scss";
 import sortableTableStyles from "src/sortedtable/sortedtable.module.scss";
 import { commonStyles } from "../../../common";
 import { useFetchDataWithPolling } from "src/util/hooks";
+import { InlineAlert } from "@cockroachlabs/ui-components";
+import { insights } from "src/util";
+import { Anchor } from "src/anchor";
 
 const cx = classNames.bind(styles);
 const sortableTableCx = classNames.bind(sortableTableStyles);
@@ -66,6 +69,7 @@ export type TransactionInsightsViewStateProps = {
   isLoading?: boolean;
   dropDownSelect?: React.ReactElement;
   timeScale?: TimeScale;
+  maxSizeApiReached?: boolean;
 };
 
 export type TransactionInsightsViewDispatchProps = {
@@ -99,6 +103,7 @@ export const TransactionInsightsView: React.FC<TransactionInsightsViewProps> = (
     onSortChange,
     setTimeScale,
     dropDownSelect,
+    maxSizeApiReached,
   } = props;
 
   const [pagination, setPagination] = useState<ISortedTablePagination>({
@@ -293,6 +298,20 @@ export const TransactionInsightsView: React.FC<TransactionInsightsViewProps> = (
               total={filteredTransactions?.length}
               onChange={onChangePage}
             />
+            {maxSizeApiReached && (
+              <InlineAlert
+                intent="info"
+                title={
+                  <>
+                    Not all insights are displayed because the maximum number of
+                    insights was reached in the console.&nbsp;
+                    <Anchor href={insights} target="_blank">
+                      Learn more
+                    </Anchor>
+                  </>
+                }
+              />
+            )}
           </div>
         </Loading>
       </div>

--- a/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsights/workloadInsightsPageConnected.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsights/workloadInsightsPageConnected.tsx
@@ -43,6 +43,7 @@ import {
   selectFilters,
   selectSortSetting,
   selectTransactionInsightsLoading,
+  selectTransactionInsightsMaxApiReached,
 } from "src/store/insights/transactionInsights";
 import { Dispatch } from "redux";
 import { TimeScale } from "../../timeScaleDropdown";
@@ -63,6 +64,7 @@ const transactionMapStateToProps = (
   sortSetting: selectSortSetting(state),
   timeScale: selectTimeScale(state),
   isLoading: selectTransactionInsightsLoading(state),
+  maxSizeApiReached: selectTransactionInsightsMaxApiReached(state),
 });
 
 const statementMapStateToProps = (

--- a/pkg/ui/workspaces/cluster-ui/src/store/insightDetails/transactionInsightDetails/transactionInsightDetails.reducer.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/store/insightDetails/transactionInsightDetails/transactionInsightDetails.reducer.ts
@@ -17,13 +17,14 @@ import {
   TxnInsightDetailsResponse,
 } from "src/api/txnInsightsApi";
 import { TxnInsightDetails } from "src/insights";
-import { TxnInsightDetailsReqErrs } from "src/api";
+import { SqlApiResponse, TxnInsightDetailsReqErrs } from "src/api";
 
 export type TxnInsightDetailsState = {
   data: TxnInsightDetails | null;
   lastUpdated: Moment | null;
   errors: TxnInsightDetailsReqErrs | null;
   valid: boolean;
+  maxSizeReached: boolean;
 };
 
 export type TxnInsightDetailsCachedState = {
@@ -38,12 +39,16 @@ const transactionInsightDetailsSlice = createSlice({
   name: `${DOMAIN_NAME}/transactionInsightDetailsSlice`,
   initialState,
   reducers: {
-    received: (state, action: PayloadAction<TxnInsightDetailsResponse>) => {
-      state.cachedData[action.payload.txnExecutionID] = {
-        data: action.payload.result,
+    received: (
+      state,
+      action: PayloadAction<SqlApiResponse<TxnInsightDetailsResponse>>,
+    ) => {
+      state.cachedData[action.payload.results.txnExecutionID] = {
+        data: action.payload.results.result,
         valid: true,
-        errors: action.payload.errors,
+        errors: action.payload.results.errors,
         lastUpdated: moment.utc(),
+        maxSizeReached: action.payload.maxSizeReached,
       };
     },
     failed: (state, action: PayloadAction<ErrorWithKey>) => {
@@ -56,6 +61,7 @@ const transactionInsightDetailsSlice = createSlice({
           statementsErr: action.payload.err,
         },
         lastUpdated: null,
+        maxSizeReached: false,
       };
     },
     invalidated: (state, action: PayloadAction<{ key: string }>) => {

--- a/pkg/ui/workspaces/cluster-ui/src/store/insightDetails/transactionInsightDetails/transactionInsightDetails.sagas.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/store/insightDetails/transactionInsightDetails/transactionInsightDetails.sagas.ts
@@ -17,7 +17,7 @@ import {
   TxnInsightDetailsResponse,
 } from "src/api/txnInsightsApi";
 import { PayloadAction } from "@reduxjs/toolkit";
-import { ErrorWithKey } from "src/api";
+import { ErrorWithKey, SqlApiResponse } from "src/api";
 
 export function* refreshTransactionInsightDetailsSaga(
   action: PayloadAction<TxnInsightDetailsRequest>,
@@ -45,9 +45,9 @@ const CACHE_INVALIDATION_PERIOD = 5 * 60 * 1000; // 5 minutes in ms
 const timeoutsByExecID = new Map<string, NodeJS.Timeout>();
 
 export function receivedTxnInsightsDetailsSaga(
-  action: PayloadAction<TxnInsightDetailsResponse>,
+  action: PayloadAction<SqlApiResponse<TxnInsightDetailsResponse>>,
 ) {
-  const execID = action.payload.txnExecutionID;
+  const execID = action.payload.results.txnExecutionID;
   clearTimeout(timeoutsByExecID.get(execID));
   const id = setTimeout(() => {
     actions.invalidated({ key: execID });

--- a/pkg/ui/workspaces/cluster-ui/src/store/insightDetails/transactionInsightDetails/transactionInsightDetails.selectors.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/store/insightDetails/transactionInsightDetails/transactionInsightDetails.selectors.ts
@@ -24,7 +24,7 @@ const selectTxnContentionInsightsDetails = createSelector(
 );
 
 const selectTxnInsightFromExecInsight = createSelector(
-  (state: AppState) => state.adminUI.txnInsights?.data,
+  (state: AppState) => state.adminUI.txnInsights?.data?.results,
   selectID,
   (execInsights, execID): TxnInsightEvent => {
     return execInsights?.find(txn => txn.transactionExecutionID === execID);
@@ -46,4 +46,9 @@ export const selectTransactionInsightDetails = createSelector(
 export const selectTransactionInsightDetailsError = createSelector(
   selectTxnContentionInsightsDetails,
   state => state?.errors,
+);
+
+export const selectTransactionInsightDetailsMaxSizeReached = createSelector(
+  selectTxnContentionInsightsDetails,
+  state => state?.maxSizeReached,
 );

--- a/pkg/ui/workspaces/cluster-ui/src/store/insights/statementFingerprintInsights/statementFingerprintInsights.reducer.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/store/insights/statementFingerprintInsights/statementFingerprintInsights.reducer.ts
@@ -11,11 +11,11 @@
 import { createSlice, PayloadAction } from "@reduxjs/toolkit";
 import { DOMAIN_NAME } from "../../utils";
 import moment, { Moment } from "moment";
-import { ApiResponse, ErrorWithKey, StmtInsightsReq } from "src/api";
+import { SqlApiResponse, ErrorWithKey, StmtInsightsReq } from "src/api";
 import { StmtInsightEvent } from "../../../insights";
 
 export type StatementFingerprintInsightsState = {
-  data: ApiResponse<StmtInsightEvent> | null;
+  data: SqlApiResponse<StmtInsightEvent[]> | null;
   lastUpdated: Moment | null;
   lastError: Error;
   valid: boolean;
@@ -26,7 +26,7 @@ export type StatementFingerprintInsightsCachedState = {
 };
 
 export type FingerprintInsightResponseWithKey = {
-  response: ApiResponse<StmtInsightEvent>;
+  response: SqlApiResponse<StmtInsightEvent[]>;
   key: string;
 };
 

--- a/pkg/ui/workspaces/cluster-ui/src/store/insights/statementInsights/statementInsights.reducer.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/store/insights/statementInsights/statementInsights.reducer.ts
@@ -11,11 +11,11 @@
 import { createSlice, PayloadAction } from "@reduxjs/toolkit";
 import { DOMAIN_NAME } from "../../utils";
 import { StmtInsightEvent } from "src/insights";
-import { ApiResponse, StmtInsightsReq } from "src/api";
+import { SqlApiResponse, StmtInsightsReq } from "src/api";
 import moment from "moment";
 
 export type StmtInsightsState = {
-  data: ApiResponse<StmtInsightEvent>;
+  data: SqlApiResponse<StmtInsightEvent[]>;
   lastError: Error;
   valid: boolean;
   inFlight: boolean;
@@ -34,7 +34,10 @@ const statementInsightsSlice = createSlice({
   name: `${DOMAIN_NAME}/statementInsightsSlice`,
   initialState,
   reducers: {
-    received: (state, action: PayloadAction<ApiResponse<StmtInsightEvent>>) => {
+    received: (
+      state,
+      action: PayloadAction<SqlApiResponse<StmtInsightEvent[]>>,
+    ) => {
       state.data = action.payload;
       state.valid = true;
       state.lastError = null;

--- a/pkg/ui/workspaces/cluster-ui/src/store/insights/statementInsights/statementInsights.selectors.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/store/insights/statementInsights/statementInsights.selectors.ts
@@ -26,7 +26,7 @@ export const selectStmtInsightsError = (state: AppState): Error | null =>
   state.adminUI.stmtInsights?.lastError;
 
 export const selectStmtInsightsMaxApiReached = (state: AppState): boolean =>
-  state.adminUI.stmtInsights?.data?.maxSizeReached;
+  !!state.adminUI.stmtInsights?.data?.maxSizeReached;
 
 export const selectStmtInsightDetails = createSelector(
   selectStmtInsights,

--- a/pkg/ui/workspaces/cluster-ui/src/store/insights/transactionInsights/transactionInsights.reducer.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/store/insights/transactionInsights/transactionInsights.reducer.ts
@@ -12,10 +12,10 @@ import { createSlice, PayloadAction } from "@reduxjs/toolkit";
 import { DOMAIN_NAME } from "../../utils";
 import { TxnInsightEvent } from "src/insights";
 import moment, { Moment } from "moment";
-import { TxnInsightsRequest } from "src/api";
+import { SqlApiResponse, TxnInsightsRequest } from "src/api";
 
 export type TxnInsightsState = {
-  data: TxnInsightEvent[];
+  data: SqlApiResponse<TxnInsightEvent[]>;
   lastError: Error;
   valid: boolean;
   inFlight: boolean;
@@ -34,7 +34,10 @@ const txnInsightsSlice = createSlice({
   name: `${DOMAIN_NAME}/txnInsightsSlice`,
   initialState,
   reducers: {
-    received: (state, action: PayloadAction<TxnInsightEvent[]>) => {
+    received: (
+      state,
+      action: PayloadAction<SqlApiResponse<TxnInsightEvent[]>>,
+    ) => {
       state.data = action.payload;
       state.valid = true;
       state.lastError = null;

--- a/pkg/ui/workspaces/cluster-ui/src/store/insights/transactionInsights/transactionInsights.selectors.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/store/insights/transactionInsights/transactionInsights.selectors.ts
@@ -16,10 +16,14 @@ import { selectTransactionFingerprintID } from "src/selectors/common";
 import { FixFingerprintHexValue } from "../../../util";
 
 export const selectTransactionInsights = (state: AppState): TxnInsightEvent[] =>
-  state.adminUI.txnInsights?.data;
+  state.adminUI.txnInsights?.data?.results;
 
 export const selectTransactionInsightsError = (state: AppState): Error | null =>
   state.adminUI.txnInsights?.lastError;
+
+export const selectTransactionInsightsMaxApiReached = (
+  state: AppState,
+): boolean => state.adminUI.stmtInsights?.data?.maxSizeReached;
 
 export const selectTxnInsightsByFingerprint = createSelector(
   selectTransactionInsights,

--- a/pkg/ui/workspaces/db-console/src/redux/apiReducers.ts
+++ b/pkg/ui/workspaces/db-console/src/redux/apiReducers.ts
@@ -558,13 +558,17 @@ export interface APIReducersState {
   hotRanges: PaginatedCachedDataReducerState<api.HotRangesV2ResponseMessage>;
   clusterLocks: CachedDataReducerState<clusterUiApi.ClusterLocksResponse>;
   stmtInsights: CachedDataReducerState<
-    clusterUiApi.ApiResponse<StmtInsightEvent>
+    clusterUiApi.SqlApiResponse<StmtInsightEvent[]>
   >;
-  txnInsightDetails: KeyedCachedDataReducerState<clusterUiApi.TxnInsightDetailsResponse>;
-  txnInsights: CachedDataReducerState<TxnInsightEvent[]>;
+  txnInsightDetails: KeyedCachedDataReducerState<
+    clusterUiApi.SqlApiResponse<clusterUiApi.TxnInsightDetailsResponse>
+  >;
+  txnInsights: CachedDataReducerState<
+    clusterUiApi.SqlApiResponse<TxnInsightEvent[]>
+  >;
   schemaInsights: CachedDataReducerState<clusterUiApi.InsightRecommendation[]>;
   statementFingerprintInsights: KeyedCachedDataReducerState<
-    clusterUiApi.ApiResponse<StmtInsightEvent>
+    clusterUiApi.SqlApiResponse<StmtInsightEvent[]>
   >;
   schedules: KeyedCachedDataReducerState<clusterUiApi.Schedules>;
   schedule: KeyedCachedDataReducerState<clusterUiApi.Schedule>;

--- a/pkg/ui/workspaces/db-console/src/views/insights/insightsSelectors.ts
+++ b/pkg/ui/workspaces/db-console/src/views/insights/insightsSelectors.ts
@@ -45,11 +45,12 @@ export const sortSettingLocalSetting = new LocalSetting<
 
 export const selectTransactionInsightsLoading = (state: AdminUIState) =>
   state.cachedData.txnInsights?.inFlight &&
-  (!state.cachedData.txnInsights?.valid || !state.cachedData.txnInsights?.data);
+  (!state.cachedData.txnInsights?.valid ||
+    !state.cachedData.txnInsights?.data?.results);
 
 export const selectTransactionInsights = (state: AdminUIState) =>
   state.cachedData.txnInsights?.valid
-    ? state.cachedData.txnInsights?.data
+    ? state.cachedData.txnInsights?.data?.results
     : null;
 
 const selectCachedTxnInsightDetails = createSelector(
@@ -58,30 +59,32 @@ const selectCachedTxnInsightDetails = createSelector(
     if (!insight) {
       return null;
     }
-    return insight[insightId]?.data?.result;
+    return insight[insightId]?.data?.results.result;
   },
 );
 
 const selectTxnInsight = createSelector(
-  (state: AdminUIState) => state.cachedData.txnInsights?.data,
+  (state: AdminUIState) => state.cachedData.txnInsights?.data?.results,
   selectID,
   (insights, execID) => {
     return insights?.find(txn => txn.transactionExecutionID === execID);
   },
 );
 
+export const selectTxnInsightsMaxApiReached = (
+  state: AdminUIState,
+): boolean => {
+  return !!state.cachedData.txnInsights?.data?.maxSizeReached;
+};
+
 export const selectStmtInsights = (state: AdminUIState) => {
-  return state.cachedData.stmtInsights?.data
-    ? state.cachedData.stmtInsights.data["results"]
-    : null;
+  return state.cachedData.stmtInsights?.data?.results;
 };
 
 export const selectStmtInsightsMaxApiReached = (
   state: AdminUIState,
 ): boolean => {
-  return state.cachedData.stmtInsights?.data
-    ? state.cachedData.stmtInsights?.data["maxSizeReached"]
-    : false;
+  return !!state.cachedData.stmtInsights?.data?.maxSizeReached;
 };
 
 export const selectTxnInsightDetails = createSelector(
@@ -98,7 +101,7 @@ export const selectTransactionInsightDetailsError = createSelector(
     if (!insights) {
       return null;
     }
-    const reqErrors = insights[insightId]?.data?.errors;
+    const reqErrors = insights[insightId]?.data?.results.errors;
     if (insights[insightId]?.lastError) {
       Object.keys(reqErrors).forEach(
         (key: keyof api.TxnInsightDetailsReqErrs) => {
@@ -107,8 +110,15 @@ export const selectTransactionInsightDetailsError = createSelector(
       );
     }
 
-    return insights[insightId]?.data?.errors;
+    return insights[insightId]?.data?.results.errors;
   },
+);
+
+export const selectTransactionInsightDetailsMaxSizeReached = createSelector(
+  (state: AdminUIState) => state.cachedData.txnInsightDetails,
+  selectID,
+  (insights, insightId: string): boolean =>
+    insights[insightId]?.data?.maxSizeReached,
 );
 
 // Data is showed as loading when the request is in flight AND we have

--- a/pkg/ui/workspaces/db-console/src/views/insights/transactionInsightDetailsPage.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/insights/transactionInsightDetailsPage.tsx
@@ -22,6 +22,7 @@ import { AdminUIState } from "src/redux/state";
 import {
   selectTxnInsightDetails,
   selectTransactionInsightDetailsError,
+  selectTransactionInsightDetailsMaxSizeReached,
 } from "src/views/insights/insightsSelectors";
 import { setGlobalTimeScaleAction } from "src/redux/statements";
 import { selectTimeScale } from "src/redux/timeScale";
@@ -36,6 +37,10 @@ const mapStateToProps = (
     insightError: selectTransactionInsightDetailsError(state, props),
     timeScale: selectTimeScale(state),
     hasAdminRole: selectHasAdminRole(state),
+    maxSizeApiReached: selectTransactionInsightDetailsMaxSizeReached(
+      state,
+      props,
+    ),
   };
 };
 

--- a/pkg/ui/workspaces/db-console/src/views/insights/workloadInsightsPage.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/insights/workloadInsightsPage.tsx
@@ -31,6 +31,7 @@ import {
   selectTransactionInsightsLoading,
   selectInsightTypes,
   selectStmtInsightsMaxApiReached,
+  selectTxnInsightsMaxApiReached,
 } from "src/views/insights/insightsSelectors";
 import { bindActionCreators } from "redux";
 import { LocalSetting } from "src/redux/localsettings";
@@ -59,6 +60,7 @@ const transactionMapStateToProps = (
   sortSetting: sortSettingLocalSetting.selector(state),
   timeScale: selectTimeScale(state),
   isLoading: selectTransactionInsightsLoading(state),
+  maxSizeApiReached: selectTxnInsightsMaxApiReached(state),
 });
 
 const statementMapStateToProps = (


### PR DESCRIPTION
Previously, when the sql api returned a max size reached error, we were just showing the error, but not the data that was also being returned.

This commit updates the Insights Workload > Transaction page with the new behaviour.

https://www.loom.com/share/73ea263ab31f43d89b9412b7ba9d8710

<img width="1521" alt="Screenshot 2023-02-16 at 7 32 09 PM" src="https://user-images.githubusercontent.com/1017486/219519311-64bf85a0-cdb3-483d-a1dd-e1772cad4472.png">

<img width="1363" alt="Screenshot 2023-02-16 at 7 31 47 PM" src="https://user-images.githubusercontent.com/1017486/219519308-4f0b4215-fd94-4153-9f41-2d1f2ed1f00a.png">

<img width="1187" alt="Screenshot 2023-02-16 at 7 31 39 PM" src="https://user-images.githubusercontent.com/1017486/219519303-d28dc7d7-5867-496a-add6-405b7f53b312.png">

Part Of: #96184
Release note (ui change): Still show data on the console (with a warning) for Transaction Insights when we reach a "max size exceed" error from the sql api.