### PR TITLE
grunning: support darwin+arm64

### DIFF
--- a/pkg/util/grunning/BUILD.bazel
+++ b/pkg/util/grunning/BUILD.bazel
@@ -70,6 +70,8 @@ go_test(
         ],
         "@io_bazel_rules_go//go/platform:darwin_arm64": [
             ":grunning",
+            "//pkg/testutils/skip",
+            "//pkg/util/syncutil",
             "@com_github_stretchr_testify//require",
         ],
         "@io_bazel_rules_go//go/platform:dragonfly_amd64": [
@@ -108,6 +110,8 @@ go_test(
         ],
         "@io_bazel_rules_go//go/platform:ios_arm64": [
             ":grunning",
+            "//pkg/testutils/skip",
+            "//pkg/util/syncutil",
             "@com_github_stretchr_testify//require",
         ],
         "@io_bazel_rules_go//go/platform:js_wasm": [

--- a/pkg/util/grunning/disabled.go
+++ b/pkg/util/grunning/disabled.go
@@ -10,8 +10,8 @@
 
 // See grunning.Supported() for an explanation behind this build tag.
 //
-//go:build (darwin && arm64) || freebsd || (linux && s390x) || !bazel
-// +build darwin,arm64 freebsd linux,s390x !bazel
+//go:build freebsd || (linux && s390x) || !bazel
+// +build freebsd linux,s390x !bazel
 
 package grunning
 

--- a/pkg/util/grunning/disabled_test.go
+++ b/pkg/util/grunning/disabled_test.go
@@ -10,8 +10,8 @@
 
 // See grunning.Supported() for an explanation behind this build tag.
 //
-//go:build (darwin && arm64) || freebsd || (linux && s390x) || !bazel
-// +build darwin,arm64 freebsd linux,s390x !bazel
+//go:build freebsd || (linux && s390x) || !bazel
+// +build freebsd linux,s390x !bazel
 
 package grunning_test
 

--- a/pkg/util/grunning/enabled.go
+++ b/pkg/util/grunning/enabled.go
@@ -10,8 +10,7 @@
 
 // See grunning.Supported() for an explanation behind this build tag.
 //
-//go:build !((darwin && arm64) || freebsd || (linux && s390x) || !bazel)
-// +build !darwin !arm64
+//go:build !(freebsd || (linux && s390x) || !bazel)
 // +build !freebsd
 // +build !linux !s390x
 // +build bazel

--- a/pkg/util/grunning/enabled_test.go
+++ b/pkg/util/grunning/enabled_test.go
@@ -10,8 +10,7 @@
 
 // See grunning.Supported() for an explanation behind this build tag.
 //
-//go:build !((darwin && arm64) || freebsd || (linux && s390x) || !bazel)
-// +build !darwin !arm64
+//go:build !(freebsd || (linux && s390x) || !bazel)
 // +build !freebsd
 // +build !linux !s390x
 // +build bazel

--- a/pkg/util/grunning/grunning.go
+++ b/pkg/util/grunning/grunning.go
@@ -50,12 +50,10 @@ func Elapsed(start, end time.Duration) time.Duration {
 
 // Supported returns true iff per-goroutine running time is available in this
 // build. We use a patched Go runtime for all platforms officially supported for
-// CRDB when built using Bazel. Engineers commonly building CRDB also use happen
-// to use two platforms we don't use a patched Go for:
-// - FreeBSD (we don't have cross-compilers setup), and
-// - M1/M2 Macs (we don't have a code-signing pipeline, yet).
-// We use '(darwin && arm64) || freebsd || !bazel' as the build tag to exclude
-// unsupported platforms.
+// CRDB when built using Bazel. Some engineers commonly building CRDB also
+// happen to use FreeBSD, which we don't use a patched Go for (we don't have
+// cross-compilers setup, yet). We use 'freebsd || !bazel' as the build tag to
+// exclude unsupported platforms.
 func Supported() bool {
 	return supported()
 }


### PR DESCRIPTION
We now have a code-signing pipeline for M1/M2 Macs (#97078), so we can support the patched Go runtime.

Release note: None