### PR TITLE
kvserver: optimize check of required expiration leases

### DIFF
--- a/pkg/kv/kvserver/replica.go
+++ b/pkg/kv/kvserver/replica.go
@@ -400,6 +400,15 @@ type Replica struct {
 		// The state of the Raft state machine. Updated only when raftMu and mu are
 		// both held.
 		state kvserverpb.ReplicaState
+		// requiresExpirationLease specifies whether this range unconditionally
+		// requires an expiration-based lease. Ranges located before or including
+		// the node liveness table must always use expiration leases to avoid
+		// circular dependencies on the node liveness table. Other ranges may use
+		// expiration-based leases regardless of this value, e.g. during lease
+		// transfers.
+		//
+		// This field is updated whenever state.Desc changes.
+		requiresExpirationLease bool
 		// Last index/term written to the raft log (not necessarily durable locally
 		// or committed by the group). Note that lastTermNotDurable may be 0 (and
 		// thus invalid) even when lastIndexNotDurable is known, in which case the

--- a/pkg/kv/kvserver/replica_proposal.go
+++ b/pkg/kv/kvserver/replica_proposal.go
@@ -363,7 +363,7 @@ func (r *Replica) leasePostApplyLocked(
 	// lease but not the updated merge or timestamp cache state, which can result
 	// in serializability violations.
 	r.mu.state.Lease = newLease
-	requiresExpirationBasedLease := r.requiresExpiringLeaseRLocked()
+	requiresExpirationBasedLease := r.requiresExpirationLeaseRLocked()
 	hasExpirationBasedLease := newLease.Type() == roachpb.LeaseExpiration
 
 	now := r.store.Clock().NowAsClockTimestamp()

--- a/pkg/kv/kvserver/replica_proposal_buf.go
+++ b/pkg/kv/kvserver/replica_proposal_buf.go
@@ -1249,7 +1249,7 @@ func (rp *replicaProposer) shouldCampaignOnRedirect(raftGroup proposerRaft) bool
 		raftGroup.BasicStatus(),
 		livenessMap,
 		r.descRLocked(),
-		r.requiresExpiringLeaseRLocked(),
+		r.requiresExpirationLeaseRLocked(),
 		r.store.Clock().Now(),
 	)
 }

--- a/pkg/kv/kvserver/replica_raft.go
+++ b/pkg/kv/kvserver/replica_raft.go
@@ -2044,7 +2044,7 @@ func (r *Replica) maybeCampaignOnWakeLocked(ctx context.Context) {
 	leaseStatus := r.leaseStatusAtRLocked(ctx, r.store.Clock().NowAsClockTimestamp())
 	raftStatus := r.mu.internalRaftGroup.BasicStatus()
 	livenessMap, _ := r.store.livenessMap.Load().(livenesspb.IsLiveMap)
-	if shouldCampaignOnWake(leaseStatus, r.store.StoreID(), raftStatus, livenessMap, r.descRLocked(), r.requiresExpiringLeaseRLocked()) {
+	if shouldCampaignOnWake(leaseStatus, r.store.StoreID(), raftStatus, livenessMap, r.descRLocked(), r.requiresExpirationLeaseRLocked()) {
 		r.campaignLocked(ctx)
 	}
 }


### PR DESCRIPTION
Ranges located before or including the node liveness table must always use expiration leases to avoid circular dependencies on the node liveness table.

Previously, `requiresExpiringLeaseRLocked()` would determine whether this was the case for a given replica on-the-fly, by comparing the range descriptor start key with the node liveness table span. However, key comparisons are not cheap, which makes this method unsuitable for use in hot paths. This is already called for every RPC request via `checkRequestTimeRLocked()`, and further calls are planned with the introduction of `kv.expiration_leases_only.enabled`.

This patch instead makes this determination on range descriptor changes and stores the result in `Replica.mu.requiresExpirationLease`.

`requiresExpiringLeaseRLocked()` is also renamed to `requiresExpirationLeaseRLocked()`, which is the common name for such leases.

Touches #93903.

Epic: none
Release note: None