### PR TITLE
sqlstats: fix data race on get percentile values

### DIFF
--- a/pkg/sql/sqlstats/insights/detector.go
+++ b/pkg/sql/sqlstats/insights/detector.go
@@ -91,8 +91,9 @@ func (d *anomalyDetector) isSlow(stmt *Statement) (decision bool) {
 }
 
 func (d *anomalyDetector) GetPercentileValues(id appstatspb.StmtFingerprintID) PercentileValues {
-	d.mu.RLock()
-	defer d.mu.RUnlock()
+	// latencySummary.Query might modify its own state (Stream.flush), so a read-write lock is necessary.
+	d.mu.Lock()
+	defer d.mu.Unlock()
 	latencies := PercentileValues{}
 	if entry, ok := d.mu.index[id]; ok {
 		latencySummary := entry.Value.(latencySummaryEntry).value


### PR DESCRIPTION
The function `GetPercentileValues` was using a read lock, since it was only reading the values from `latencySummary`, but the `Stream.flush` used by the `latencySummary` modifies the value, so a read and write lock is necessary.

Issue was reproduced and then tested using:
`./dev test pkg/sql -f=TestQueryCache --race --stress -v --stream-output -- cpus=1`

Fixes #97273
Release note: None