### PR TITLE
kvserver: add storage.keys.tombstone.count metric

### DIFF
--- a/pkg/kv/kvserver/metrics.go
+++ b/pkg/kv/kvserver/metrics.go
@@ -531,6 +531,12 @@ var (
 		Measurement: "Keys",
 		Unit:        metric.Unit_COUNT,
 	}
+	metaRdbKeysTombstones = metric.Metadata{
+		Name:        "storage.keys.tombstone.count",
+		Help:        "Approximate count of DEL, SINGLEDEL and RANGEDEL internal keys across the storage engine.",
+		Measurement: "Keys",
+		Unit:        metric.Unit_COUNT,
+	}
 	// NB: bytes only ever get flushed into L0, so this metric does not
 	// exist for any other level.
 	metaRdbL0BytesFlushed = storageLevelMetricMetadata(
@@ -1811,6 +1817,7 @@ type StoreMetrics struct {
 	RdbPendingCompaction        *metric.Gauge
 	RdbMarkedForCompactionFiles *metric.Gauge
 	RdbKeysRangeKeySets         *metric.Gauge
+	RdbKeysTombstones           *metric.Gauge
 	RdbL0BytesFlushed           *metric.Gauge
 	RdbL0Sublevels              *metric.Gauge
 	RdbL0NumFiles               *metric.Gauge
@@ -2349,6 +2356,7 @@ func newStoreMetrics(histogramWindow time.Duration) *StoreMetrics {
 		RdbPendingCompaction:        metric.NewGauge(metaRdbPendingCompaction),
 		RdbMarkedForCompactionFiles: metric.NewGauge(metaRdbMarkedForCompactionFiles),
 		RdbKeysRangeKeySets:         metric.NewGauge(metaRdbKeysRangeKeySets),
+		RdbKeysTombstones:           metric.NewGauge(metaRdbKeysTombstones),
 		RdbL0BytesFlushed:           metric.NewGauge(metaRdbL0BytesFlushed),
 		RdbL0Sublevels:              metric.NewGauge(metaRdbL0Sublevels),
 		RdbL0NumFiles:               metric.NewGauge(metaRdbL0NumFiles),
@@ -2677,6 +2685,7 @@ func (sm *StoreMetrics) updateEngineMetrics(m storage.Metrics) {
 	sm.RdbPendingCompaction.Update(int64(m.Compact.EstimatedDebt))
 	sm.RdbMarkedForCompactionFiles.Update(int64(m.Compact.MarkedFiles))
 	sm.RdbKeysRangeKeySets.Update(int64(m.Keys.RangeKeySetsCount))
+	sm.RdbKeysTombstones.Update(int64(m.Keys.TombstoneCount))
 	sm.RdbNumSSTables.Update(m.NumSSTables())
 	sm.RdbWriteStalls.Update(m.WriteStallCount)
 	sm.RdbWriteStallNanos.Update(m.WriteStallDuration.Nanoseconds())

--- a/pkg/ts/catalog/chart_catalog.go
+++ b/pkg/ts/catalog/chart_catalog.go
@@ -3029,6 +3029,10 @@ var charts = []sectionDescription{
 				Title:   "Range Key Set Count",
 				Metrics: []string{"storage.keys.range-key-set.count"},
 			},
+			{
+				Title:   "Tombstone Count",
+				Metrics: []string{"storage.keys.tombstone.count"},
+			},
 		},
 	},
 	{


### PR DESCRIPTION
Expose the number of tombstones in the storage engine as a timeseries metric. This provides some additional visibility into garbage collection and would help in diagnosing issues like cockroachlabs/support#2084.

Epic: None
Release note (ops change): Adds a new timeseries metric `storage.keys.tombstone.count` that shows the current count of point and range deletion tombstones across the storage engine.