### PR TITLE
ui: fixed insights table bug on insights

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsightDetails/statementInsightDetailsOverviewTab.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsightDetails/statementInsightDetailsOverviewTab.tsx
@@ -56,7 +56,7 @@ export const StatementInsightDetailsOverviewTab: React.FC<
   const isCockroachCloud = useContext(CockroachCloudContext);
 
   const insightsColumns = useMemo(
-    () => makeInsightsColumns(isCockroachCloud, hasAdminRole, true),
+    () => makeInsightsColumns(isCockroachCloud, hasAdminRole),
     [isCockroachCloud, hasAdminRole],
   );
 

--- a/pkg/ui/workspaces/cluster-ui/src/insightsTable/insightsTable.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insightsTable/insightsTable.tsx
@@ -131,11 +131,15 @@ const StatementExecution = ({
 
 function descriptionCell(
   insightRec: InsightRecommendation,
-  isExecution: boolean,
+  disableStmtLink: boolean,
   isCockroachCloud: boolean,
+  isFingerprint: boolean,
 ): React.ReactElement {
   const stmtLink = isIndexRec(insightRec) ? (
-    <StatementExecution rec={insightRec} disableLink={!isExecution} />
+    <StatementExecution
+      rec={insightRec}
+      disableLink={disableStmtLink || isFingerprint}
+    />
   ) : null;
 
   const clusterSettingsLink = (
@@ -201,7 +205,7 @@ function descriptionCell(
     case "HighContention":
       return (
         <>
-          {isExecution && (
+          {!isFingerprint && (
             <div className={cx("description-item")}>
               <span className={cx("label-bold")}>Time Spent Waiting: </span>{" "}
               {Duration(insightRec.details.duration * 1e6)}
@@ -209,7 +213,7 @@ function descriptionCell(
           )}
           {stmtLink}
           <div className={cx("description-item")}>
-            {isExecution && (
+            {!isFingerprint && (
               <span className={cx("label-bold")}>Description: </span>
             )}
             {insightRec.details.description} {clusterSettingsLink}
@@ -272,7 +276,7 @@ function descriptionCell(
     case "Unknown":
       return (
         <>
-          {isExecution && (
+          {!isFingerprint && (
             <div className={cx("description-item")}>
               <span className={cx("label-bold")}>Elapsed Time: </span>
               {Duration(insightRec.details.duration * 1e6)}
@@ -280,7 +284,7 @@ function descriptionCell(
           )}
           {stmtLink}
           <div className={cx("description-item")}>
-            {isExecution && (
+            {!isFingerprint && (
               <span className={cx("label-bold")}>Description: </span>
             )}
             {insightRec.details.description} {clusterSettingsLink}
@@ -390,7 +394,8 @@ const isIndexRec = (rec: InsightRecommendation) => {
 export function makeInsightsColumns(
   isCockroachCloud: boolean,
   hasAdminRole: boolean,
-  isExecution?: boolean,
+  disableStmtLink?: boolean,
+  isFingerprint?: boolean,
 ): ColumnDescriptor<InsightRecommendation>[] {
   const columns: ColumnDescriptor<InsightRecommendation>[] = [
     {
@@ -403,17 +408,17 @@ export function makeInsightsColumns(
       name: "details",
       title: insightsTableTitles.details(),
       cell: (item: InsightRecommendation) =>
-        descriptionCell(item, isExecution, isCockroachCloud),
+        descriptionCell(item, disableStmtLink, isCockroachCloud, isFingerprint),
       sort: (item: InsightRecommendation) => item.type,
     },
     {
       name: "action",
       title: insightsTableTitles.actions(),
       cell: (item: InsightRecommendation) =>
-        actionCell(item, isCockroachCloud || !hasAdminRole || !isExecution),
+        actionCell(item, isCockroachCloud || !hasAdminRole || isFingerprint),
     },
   ];
-  if (!isExecution) {
+  if (isFingerprint) {
     columns.push({
       name: "latestExecution",
       title: insightsTableTitles.latestExecution(),

--- a/pkg/ui/workspaces/cluster-ui/src/statementDetails/planDetails/planDetails.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementDetails/planDetails/planDetails.tsx
@@ -295,7 +295,7 @@ export function Insights({
   hasAdminRole,
 }: InsightsProps): React.ReactElement {
   const hideAction = useContext(CockroachCloudContext) || database?.length == 0;
-  const insightsColumns = makeInsightsColumns(hideAction, hasAdminRole, false);
+  const insightsColumns = makeInsightsColumns(hideAction, hasAdminRole, true);
   const data = formatIdxRecommendations(
     idxRecommendations,
     database,

--- a/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetails.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetails.tsx
@@ -665,7 +665,8 @@ export class StatementDetails extends React.Component<
     const insightsColumns = makeInsightsColumns(
       isCockroachCloud,
       this.props.hasAdminRole,
-      false,
+      true,
+      true,
     );
     const tableData: InsightRecommendation[] = [];
     if (statementFingerprintInsights) {

--- a/pkg/ui/workspaces/cluster-ui/src/transactionDetails/transactionDetails.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionDetails/transactionDetails.tsx
@@ -456,7 +456,8 @@ export class TransactionDetails extends React.Component<
             const insightsColumns = makeInsightsColumns(
               isCockroachCloud,
               this.props.hasAdminRole,
-              false,
+              true,
+              true,
             );
             const tableData: InsightRecommendation[] = [];
             if (transactionInsights) {


### PR DESCRIPTION
#96440 introduced a bug to the Insights Table on the Schema
Insights page. This commit fixes that bug.

Loom: https://www.loom.com/share/0f81bc55371f49418f7f0175bbc5dff4

Release note: None
Epic: None