### PR TITLE
server: fix logout to always fanout to all tenants

### DIFF
--- a/pkg/server/authentication_test.go
+++ b/pkg/server/authentication_test.go
@@ -571,6 +571,31 @@ func TestAuthenticationAPIUserLogin(t *testing.T) {
 	}
 }
 
+func TestLogoutClearsCookies(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	defer s.Stopper().Stop(context.Background())
+	ts := s.(*TestServer)
+
+	// Log in.
+	authHTTPClient, _, err := ts.getAuthenticatedHTTPClientAndCookie(authenticatedUserName(), true)
+	require.NoError(t, err)
+
+	// Log out.
+	resp, err := authHTTPClient.Get(ts.AdminURL() + logoutPath)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	cookies := resp.Cookies()
+	cNames := make([]string, len(cookies))
+	for i, c := range cookies {
+		require.Equal(t, "", c.Value)
+		cNames[i] = c.Name
+	}
+	require.ElementsMatch(t, cNames, []string{SessionCookieName, MultitenantSessionCookieName, TenantSelectCookieName})
+}
+
 func TestLogout(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)


### PR DESCRIPTION
Previously, we added login fanout logic handled through an HTTP layer in `server_controller_http.go` which lets us fanout logins to multiple tenants. In the case of a single tenant cluster, this simply means that the `multitenant-session` cookie contains only a single session, and `tenant` is set to `system`. However, we run into problems during `/logout` calls because our routing assumes that if you have a `tenant` cookie set that it should *not* fanout and simply proxy the request to the correct tenant. In the special case of Logout, this causes a problem because the tenant's Logout handler only clears the `session` cookie and not the new `multitenant-session` and `tenant` cookies.

Since these new cookies are owned by the code in `server_controller_http.go` and because we don't claim to support per-tenant logout operations yet (#92855) this commit enforces a fanout on *all* HTTP calls to `/logout`. This ensures that sessions are cleared in the SQL layer. Then we also make sure to clear the `session` cookie as well in case this code runs with a legacy session.

Epic: CRDB-12100

Release note: None