### PR TITLE
roachtest: remove lease metrics for `failover/liveness`

### DIFF
--- a/pkg/cmd/roachtest/tests/failover.go
+++ b/pkg/cmd/roachtest/tests/failover.go
@@ -19,15 +19,12 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
-	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/clusterstats"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/registry"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/spec"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/test"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/install"
-	"github.com/cockroachdb/cockroach/pkg/roachprod/prometheus"
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
-	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/stretchr/testify/require"
 )
 
@@ -272,27 +269,9 @@ func runFailoverLiveness(
 	conn := c.Conn(ctx, t.L(), 1)
 	defer conn.Close()
 
-	// Setup the prometheus instance and client. We don't collect metrics from n4
-	// (the failing node) because it's occasionally offline, and StatsCollector
-	// doesn't like it when the time series are missing data points.
-	promCfg := (&prometheus.Config{}).
-		WithCluster(c.Range(1, 3).InstallNodes()).
-		WithPrometheusNode(5)
-
-	require.NoError(t, c.StartGrafana(ctx, t.L(), promCfg))
-	defer func() {
-		if err := c.StopGrafana(ctx, t.L(), t.ArtifactsDir()); err != nil {
-			t.L().ErrorfCtx(ctx, "Error(s) shutting down prom/grafana %s", err)
-		}
-	}()
-
-	promClient, err := clusterstats.SetupCollectorPromClient(ctx, c, t.L(), promCfg)
-	require.NoError(t, err)
-	statsCollector := clusterstats.NewStatsCollector(ctx, promClient)
-
 	// Configure cluster. This test controls the ranges manually.
 	t.Status("configuring cluster")
-	_, err = conn.ExecContext(ctx, `SET CLUSTER SETTING kv.range_split.by_load_enabled = 'false'`)
+	_, err := conn.ExecContext(ctx, `SET CLUSTER SETTING kv.range_split.by_load_enabled = 'false'`)
 	require.NoError(t, err)
 
 	// Constrain all existing zone configs to n1-n3.
@@ -346,7 +325,6 @@ func runFailoverLiveness(
 			`{pgurl:1-3}`)
 		return nil
 	})
-	startTime := timeutil.Now()
 
 	// Start a worker to fail and recover n4.
 	failer.Ready(ctx, m)
@@ -395,33 +373,6 @@ func runFailoverLiveness(
 		return nil
 	})
 	m.Wait()
-
-	// Export roachperf metrics from Prometheus.
-	_, err = statsCollector.Exporter().Export(ctx, c, t, false /* dryRun */, startTime, timeutil.Now(),
-		[]clusterstats.AggQuery{
-			{
-				Stat: clusterstats.ClusterStat{
-					LabelName: "node",
-					Query:     "replicas_leaders_invalid_lease",
-				},
-				Query: "sum(replicas_leaders_invalid_lease)",
-				Tag:   "Invalid Leases",
-			},
-		},
-		func(stats map[string]clusterstats.StatSummary) (string, float64) {
-			summary, ok := stats["replicas_leaders_invalid_lease"]
-			require.True(t, ok, "stat summary for replicas_leaders_invalid_lease not found")
-			var max float64
-			for _, v := range summary.Value {
-				if v > max {
-					max = v
-				}
-			}
-			t.Status(fmt.Sprintf("Max invalid leases: %d", int64(max)))
-			return "Max invalid leases", max
-		},
-	)
-	require.NoError(t, err)
 }
 
 // runFailoverSystemNonLiveness benchmarks the maximum duration of range


### PR DESCRIPTION
The `failover/liveness` metric attempted to measure the number of leases that were affected by liveness leaseholder loss. However, the resolution of these metrics is only 10 seconds, which means that many leases can already have been reacquired by the time the metric is recorded, so we can't really use this metric for anything. This patch therefore removes this metric tracking.

Epic: none
Release note: None