### PR TITLE
roachtest: add `pause` failure for `failover` tests

### DIFF
--- a/pkg/cmd/roachprod/main.go
+++ b/pkg/cmd/roachprod/main.go
@@ -19,6 +19,7 @@ import (
 	"os/user"
 	"path"
 	"sort"
+	"strconv"
 	"strings"
 	"text/tabwriter"
 	"time"
@@ -649,6 +650,20 @@ of nodes, outputting a line whenever a change is detected:
 	}),
 }
 
+var signalCmd = &cobra.Command{
+	Use:   "signal <cluster> <signal>",
+	Short: "send signal to cluster",
+	Long:  "Send a POSIX signal to the nodes in a cluster, specified by its integer code.",
+	Args:  cobra.ExactArgs(2),
+	Run: wrap(func(cmd *cobra.Command, args []string) error {
+		sig, err := strconv.ParseInt(args[1], 10, 8)
+		if err != nil {
+			return errors.Wrapf(err, "invalid signal argument")
+		}
+		return roachprod.Signal(context.Background(), config.Logger, args[0], int(sig))
+	}),
+}
+
 var wipeCmd = &cobra.Command{
 	Use:   "wipe <cluster>",
 	Short: "wipe a cluster",
@@ -1149,6 +1164,7 @@ func main() {
 		startTenantCmd,
 		initCmd,
 		runCmd,
+		signalCmd,
 		wipeCmd,
 		reformatCmd,
 		installCmd,
@@ -1178,7 +1194,7 @@ func main() {
 
 	// Add help about specifying nodes
 	for _, cmd := range []*cobra.Command{
-		getCmd, putCmd, runCmd, startCmd, statusCmd, stopCmd,
+		getCmd, putCmd, runCmd, startCmd, statusCmd, stopCmd, signalCmd,
 		wipeCmd, pgurlCmd, adminurlCmd, sqlCmd, installCmd,
 	} {
 		if cmd.Long == "" {

--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -1948,6 +1948,33 @@ func (c *clusterImpl) Stop(
 	}
 }
 
+// SignalE sends a signal to the given nodes.
+func (c *clusterImpl) SignalE(
+	ctx context.Context, l *logger.Logger, sig int, nodes ...option.Option,
+) error {
+	if ctx.Err() != nil {
+		return errors.Wrap(ctx.Err(), "cluster.Signal")
+	}
+	if c.spec.NodeCount == 0 {
+		return nil // unit tests
+	}
+	return errors.Wrap(roachprod.Signal(ctx, l, c.MakeNodes(nodes...), sig), "cluster.Signal")
+}
+
+// Signal is like SignalE, except instead of returning an error, it does
+// c.t.Fatal(). c.t needs to be set.
+func (c *clusterImpl) Signal(
+	ctx context.Context, l *logger.Logger, sig int, nodes ...option.Option,
+) {
+	if c.t.Failed() {
+		// If the test has failed, don't try to limp along.
+		return
+	}
+	if err := c.SignalE(ctx, l, sig, nodes...); err != nil {
+		c.t.Fatal(err)
+	}
+}
+
 // WipeE wipes a subset of the nodes in a cluster. See cluster.Start() for a
 // description of the nodes parameter.
 func (c *clusterImpl) WipeE(ctx context.Context, l *logger.Logger, nodes ...option.Option) error {

--- a/pkg/cmd/roachtest/cluster/cluster_interface.go
+++ b/pkg/cmd/roachtest/cluster/cluster_interface.go
@@ -54,6 +54,8 @@ type Cluster interface {
 	Start(ctx context.Context, l *logger.Logger, startOpts option.StartOpts, settings install.ClusterSettings, opts ...option.Option)
 	StopE(ctx context.Context, l *logger.Logger, stopOpts option.StopOpts, opts ...option.Option) error
 	Stop(ctx context.Context, l *logger.Logger, stopOpts option.StopOpts, opts ...option.Option)
+	SignalE(ctx context.Context, l *logger.Logger, sig int, opts ...option.Option) error
+	Signal(ctx context.Context, l *logger.Logger, sig int, opts ...option.Option)
 	StopCockroachGracefullyOnNode(ctx context.Context, l *logger.Logger, node int) error
 	NewMonitor(context.Context, ...option.Option) Monitor
 

--- a/pkg/roachprod/roachprod.go
+++ b/pkg/roachprod/roachprod.go
@@ -740,6 +740,18 @@ func Stop(ctx context.Context, l *logger.Logger, clusterName string, opts StopOp
 	return c.Stop(ctx, l, opts.Sig, opts.Wait, opts.MaxWait)
 }
 
+// Signal sends a signal to nodes in the cluster.
+func Signal(ctx context.Context, l *logger.Logger, clusterName string, sig int) error {
+	if err := LoadClusters(); err != nil {
+		return err
+	}
+	c, err := newCluster(l, clusterName)
+	if err != nil {
+		return err
+	}
+	return c.Signal(ctx, l, sig)
+}
+
 // Init initializes the cluster.
 func Init(ctx context.Context, l *logger.Logger, clusterName string, opts install.StartOpts) error {
 	if err := LoadClusters(); err != nil {


### PR DESCRIPTION
**roachprod: add `signal` command**

This patch adds a `signal` command and API that can be used to send UNIX signals to roachprod nodes. This is useful e.g. for pausing nodes via `SIGSTOP` and `SIGCONT` in chaos tests.

Epic: none
Release note: None
  
**roachtest: add `pause` failure for `failover` tests**

This patch adds a `pause` failure mode which pauses the process via `SIGSTOP`, while keeping the network connections and such alive. We expect this to fail in much the same way as the `blackhole` variant, where RPC heartbeats fail and the connections are closed, but the OS will still be alive to manage the connections.

Resolves #96276.
Epic: none
Release note: None