### PR TITLE
kvserverpb: remove `ReplicatedEvalResult.DeprecatedDelta`

### DIFF
--- a/pkg/kv/kvserver/app_batch.go
+++ b/pkg/kv/kvserver/app_batch.go
@@ -19,7 +19,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/raftlog"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/storage"
-	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/errors"
 	"golang.org/x/time/rate"
@@ -118,16 +117,6 @@ func (b *appBatch) toCheckedCmd(
 		cmd.Cmd.LogicalOpLog = nil
 		cmd.Cmd.ClosedTimestamp = nil
 	} else {
-		// If the command was using the deprecated version of the MVCCStats proto,
-		// migrate it to the new version and clear out the field.
-		res := cmd.ReplicatedResult()
-		if deprecatedDelta := res.DeprecatedDelta; deprecatedDelta != nil {
-			if res.Delta != (enginepb.MVCCStatsDelta{}) {
-				log.Fatalf(ctx, "stats delta not empty but deprecated delta provided: %+v", cmd)
-			}
-			res.Delta = deprecatedDelta.ToStatsDelta()
-			res.DeprecatedDelta = nil
-		}
 		log.Event(ctx, "applying command")
 	}
 }

--- a/pkg/kv/kvserver/kvserverpb/proposer_kv.go
+++ b/pkg/kv/kvserver/kvserverpb/proposer_kv.go
@@ -73,7 +73,6 @@ func (r *ReplicatedEvalResult) IsTrivial() bool {
 	allowlist := *r
 	allowlist.Delta = enginepb.MVCCStatsDelta{}
 	allowlist.WriteTimestamp = hlc.Timestamp{}
-	allowlist.DeprecatedDelta = nil
 	allowlist.PrevLeaseProposal = nil
 	allowlist.State = nil
 	return allowlist.IsZero()

--- a/pkg/kv/kvserver/kvserverpb/proposer_kv.proto
+++ b/pkg/kv/kvserver/kvserverpb/proposer_kv.proto
@@ -131,7 +131,6 @@ message ReplicatedEvalResult {
   util.hlc.Timestamp write_timestamp = 8 [(gogoproto.nullable) = false];
   // The stats delta corresponding to the data in this WriteBatch. On
   // a split, contains only the contributions to the left-hand side.
-  storage.enginepb.MVCCStats deprecated_delta = 10; // See #18828
   storage.enginepb.MVCCStatsDelta delta = 18 [(gogoproto.nullable) = false];
   ChangeReplicas change_replicas = 12;
 
@@ -230,7 +229,7 @@ message ReplicatedEvalResult {
   // is applied on the new leaseholder through a Raft snapshot.
   kv.kvserver.readsummary.ReadSummary prior_read_summary = 22;
 
-  reserved 1, 5, 7, 9, 14, 15, 16, 19, 10001 to 10013;
+  reserved 1, 5, 7, 9, 10, 14, 15, 16, 19, 10001 to 10013;
 }
 
 // WriteBatch is the serialized representation of a RocksDB write


### PR DESCRIPTION
This field was deprecated back in 2017 and is no longer used.

Resolves #94039.
Epic: none
Release note: None