### PR TITLE
release-22.2: ui: tenant-gate transaction insights, change selection order of workload insights

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsights/statementInsights/statementInsightsView.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsights/statementInsights/statementInsightsView.tsx
@@ -57,6 +57,7 @@ export type StatementInsightsViewStateProps = {
   sortSetting: SortSetting;
   selectedColumnNames: string[];
   dropDownSelect?: React.ReactElement;
+  isTenant?: boolean;
 };
 
 export type StatementInsightsViewDispatchProps = {
@@ -88,6 +89,7 @@ export const StatementInsightsView: React.FC<StatementInsightsViewProps> = (
     setTimeScale,
     selectedColumnNames,
     dropDownSelect,
+    isTenant,
   } = props;
 
   const [pagination, setPagination] = useState<ISortedTablePagination>({
@@ -219,7 +221,7 @@ export const StatementInsightsView: React.FC<StatementInsightsViewProps> = (
   return (
     <div className={cx("root")}>
       <PageConfig>
-        <PageConfigItem>{dropDownSelect}</PageConfigItem>
+        {!isTenant && <PageConfigItem>{dropDownSelect}</PageConfigItem>}
         <PageConfigItem>
           <Search
             placeholder="Search Statements"

--- a/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsights/workloadInsightsPageConnected.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsights/workloadInsightsPageConnected.tsx
@@ -43,6 +43,7 @@ import { Dispatch } from "redux";
 import { TimeScale } from "../../timeScaleDropdown";
 import { actions as sqlStatsActions } from "../../store/sqlStats";
 import { actions as analyticsActions } from "../../store/analytics";
+import { selectIsTenant } from "../../store/uiConfig";
 
 const transactionMapStateToProps = (
   state: AppState,
@@ -63,6 +64,7 @@ const statementMapStateToProps = (
   filters: selectFilters(state),
   sortSetting: selectSortSetting(state),
   selectedColumnNames: selectColumns(state),
+  isTenant: selectIsTenant(state),
 });
 
 const TransactionDispatchProps = (


### PR DESCRIPTION
Backport 1/1 commits from #97256.

/cc @cockroachdb/release

---

Related to #96353, #92936.

This commit hides the dropdown to switch workload insights from statement insights to transaction insights on tenants. When #96353 is resolved, we can re-enable transaction insights for tenant clusters.

The commit also switches the order of workload insights, to show statement insights first (see #92936).

@gemma-shay We should add a note on the [Insights docs](https://www.cockroachlabs.com/docs/stable/ui-insights-page.html) and/or the serverless docs that Transaction Insights aren't available on serverless.

Release note: None

Epic: None

Release justification: low-risk update