### PR TITLE
logictest: add flag to disable workmem randomization

### DIFF
--- a/pkg/cmd/dev/testlogic.go
+++ b/pkg/cmd/dev/testlogic.go
@@ -30,6 +30,7 @@ const (
 	showSQLFlag   = "show-sql"
 	noGenFlag     = "no-gen"
 	flexTypesFlag = "flex-types"
+	workmemFlag   = "default-workmem"
 )
 
 func makeTestLogicCmd(runE func(cmd *cobra.Command, args []string) error) *cobra.Command {
@@ -63,6 +64,7 @@ func makeTestLogicCmd(runE func(cmd *cobra.Command, args []string) error) *cobra
 	testLogicCmd.Flags().String(testArgsFlag, "", "additional arguments to pass to go test binary")
 	testLogicCmd.Flags().Bool(showDiffFlag, false, "generate a diff for expectation mismatches when possible")
 	testLogicCmd.Flags().Bool(flexTypesFlag, false, "tolerate when a result column is produced with a different numeric type")
+	testLogicCmd.Flags().Bool(workmemFlag, false, "disable randomization of sql.distsql.temp_storage.workmem")
 
 	addCommonBuildFlags(testLogicCmd)
 	return testLogicCmd
@@ -73,24 +75,25 @@ func (d *dev) testlogic(cmd *cobra.Command, commandLine []string) error {
 	ctx := cmd.Context()
 
 	var (
-		bigtest       = mustGetFlagBool(cmd, bigtestFlag)
-		configs       = mustGetFlagStringSlice(cmd, configsFlag)
-		files         = mustGetFlagString(cmd, filesFlag)
-		ignoreCache   = mustGetFlagBool(cmd, ignoreCacheFlag)
-		rewrite       = mustGetFlagBool(cmd, rewriteFlag)
-		streamOutput  = mustGetFlagBool(cmd, streamOutputFlag)
-		showLogs      = mustGetFlagBool(cmd, showLogsFlag)
-		subtests      = mustGetFlagString(cmd, subtestsFlag)
-		timeout       = mustGetFlagDuration(cmd, timeoutFlag)
-		verbose       = mustGetFlagBool(cmd, vFlag)
-		noGen         = mustGetFlagBool(cmd, noGenFlag)
-		showSQL       = mustGetFlagBool(cmd, showSQLFlag)
-		count         = mustGetFlagInt(cmd, countFlag)
-		stress        = mustGetFlagBool(cmd, stressFlag)
-		stressCmdArgs = mustGetFlagString(cmd, stressArgsFlag)
-		testArgs      = mustGetFlagString(cmd, testArgsFlag)
-		showDiff      = mustGetFlagBool(cmd, showDiffFlag)
-		flexTypes     = mustGetFlagBool(cmd, flexTypesFlag)
+		bigtest        = mustGetFlagBool(cmd, bigtestFlag)
+		configs        = mustGetFlagStringSlice(cmd, configsFlag)
+		files          = mustGetFlagString(cmd, filesFlag)
+		ignoreCache    = mustGetFlagBool(cmd, ignoreCacheFlag)
+		rewrite        = mustGetFlagBool(cmd, rewriteFlag)
+		streamOutput   = mustGetFlagBool(cmd, streamOutputFlag)
+		showLogs       = mustGetFlagBool(cmd, showLogsFlag)
+		subtests       = mustGetFlagString(cmd, subtestsFlag)
+		timeout        = mustGetFlagDuration(cmd, timeoutFlag)
+		verbose        = mustGetFlagBool(cmd, vFlag)
+		noGen          = mustGetFlagBool(cmd, noGenFlag)
+		showSQL        = mustGetFlagBool(cmd, showSQLFlag)
+		count          = mustGetFlagInt(cmd, countFlag)
+		stress         = mustGetFlagBool(cmd, stressFlag)
+		stressCmdArgs  = mustGetFlagString(cmd, stressArgsFlag)
+		testArgs       = mustGetFlagString(cmd, testArgsFlag)
+		showDiff       = mustGetFlagBool(cmd, showDiffFlag)
+		flexTypes      = mustGetFlagBool(cmd, flexTypesFlag)
+		defaultWorkmem = mustGetFlagBool(cmd, workmemFlag)
 	)
 	if rewrite {
 		ignoreCache = true
@@ -230,6 +233,9 @@ func (d *dev) testlogic(cmd *cobra.Command, commandLine []string) error {
 	}
 	if flexTypes {
 		args = append(args, "--test_arg", "-flex-types")
+	}
+	if defaultWorkmem {
+		args = append(args, "--test_arg", "-default-workmem")
 	}
 
 	if rewrite {

--- a/pkg/sql/logictest/logic.go
+++ b/pkg/sql/logictest/logic.go
@@ -577,6 +577,9 @@ var (
 		"declarative-corpus", "",
 		"enables generation and storage of a declarative schema changer	corpus",
 	)
+	defaultWorkmem = flag.Bool("default-workmem", false,
+		"disable randomization of sql.distsql.temp_storage.workmem",
+	)
 	// globalMVCCRangeTombstone will write a global MVCC range tombstone across
 	// the entire user keyspace during cluster bootstrapping. This should not
 	// semantically affect the test data written above it, but will activate MVCC
@@ -4120,6 +4123,10 @@ func RunLogicTest(
 				t.Fatalf("failed writing decalarative schema changer corpus: %v", err)
 			}
 		}()
+	}
+
+	if *defaultWorkmem {
+		serverArgs.DisableWorkmemRandomization = true
 	}
 
 	rng, _ := randutil.NewTestRand()


### PR DESCRIPTION
Logic tests randomize the `sql.distsql.temp_storage.workmem` setting, which limits the number of bytes a SQL processor can use before spilling to disk. This can cause significant variation in runtimes for a logic test. For example, running the `udf` logic test with the local configuration on my machine ranges anywhere from 10s to >100s. This is painful when development requires adding to a large logic test.

This patch adds a flag, `default-workmem` to the `dev testlogic` command, which disables randomization of the workmem setting. On my machine, the local `udf` logic test consistently takes 10s when run with this flag. The flag can be used when manually running tests to speed development time.

Example usage with `dev testlogic`:
```
./dev testlogic base --files udf --ignore-cache --default-workmem
```

Example usage with `dev test`:
```
./dev test pkg/sql/logictest/tests/local -f TestLogic_udf --ignore-cache --test-args=-default-workmem
```

Epic: CRDB-20535

Release note: None