### PR TITLE
server: use Open instead of NewPebble

### DIFF
--- a/pkg/base/store_spec.go
+++ b/pkg/base/store_spec.go
@@ -262,8 +262,10 @@ type StoreSpec struct {
 	// separated key-value syntax ("key1=value1; key2=value2").
 	RocksDBOptions string
 	// PebbleOptions contains Pebble-specific options in the same format as a
-	// Pebble OPTIONS file but treating any whitespace as a newline:
-	// (Eg, "[Options] delete_range_flush_delay=2s flush_split_bytes=4096")
+	// Pebble OPTIONS file. For example:
+	// [Options]
+	// delete_range_flush_delay=2s
+	// flush_split_bytes=4096
 	PebbleOptions string
 	// EncryptionOptions is a serialized protobuf set by Go CCL code and passed
 	// through to C CCL code to set up encryption-at-rest.  Must be set if and

--- a/pkg/storage/open.go
+++ b/pkg/storage/open.go
@@ -14,6 +14,7 @@ import (
 	"context"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/cloud"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/pebble"
@@ -134,12 +135,50 @@ func CacheSize(size int64) ConfigOption {
 	}
 }
 
+// Caches sets the block and table caches. Useful when multiple stores share
+// the same caches.
+func Caches(cache *pebble.Cache, tableCache *pebble.TableCache) ConfigOption {
+	return func(cfg *engineConfig) error {
+		cfg.Opts.Cache = cache
+		cfg.Opts.TableCache = tableCache
+		return nil
+	}
+}
+
+// BallastSize sets the amount reserved by a ballast file for manual
+// out-of-disk recovery.
+func BallastSize(size int64) ConfigOption {
+	return func(cfg *engineConfig) error {
+		cfg.BallastSize = size
+		return nil
+	}
+}
+
+// SharedStorage enables use of shared storage (experimental).
+func SharedStorage(sharedStorage cloud.ExternalStorage) ConfigOption {
+	return func(cfg *engineConfig) error {
+		cfg.SharedStorage = sharedStorage
+		return nil
+	}
+}
+
 // MaxConcurrentCompactions configures the maximum number of concurrent
 // compactions an Engine will execute.
 func MaxConcurrentCompactions(n int) ConfigOption {
 	return func(cfg *engineConfig) error {
 		cfg.Opts.MaxConcurrentCompactions = func() int { return n }
 		return nil
+	}
+}
+
+// PebbleOptions contains Pebble-specific options in the same format as a
+// Pebble OPTIONS file. For example:
+// [Options]
+// delete_range_flush_delay=2s
+// flush_split_bytes=4096
+func PebbleOptions(pebbleOptions string, parseHooks *pebble.ParseHooks) ConfigOption {
+	return func(cfg *engineConfig) error {
+		return cfg.Opts.Parse(pebbleOptions, parseHooks)
 	}
 }
 
@@ -224,7 +263,7 @@ func Open(
 			return nil, err
 		}
 	}
-	if cfg.cacheSize != nil {
+	if cfg.cacheSize != nil && cfg.Opts.Cache == nil {
 		cfg.Opts.Cache = pebble.NewCache(*cfg.cacheSize)
 		defer cfg.Opts.Cache.Unref()
 	}

--- a/pkg/storage/pebble.go
+++ b/pkg/storage/pebble.go
@@ -867,6 +867,7 @@ func ResolveEncryptedEnvOptions(
 }
 
 // NewPebble creates a new Pebble instance, at the specified path.
+// Do not use directly (except in test); use Open instead.
 func NewPebble(ctx context.Context, cfg PebbleConfig) (p *Pebble, err error) {
 	if cfg.Settings == nil {
 		return nil, errors.AssertionFailedf("NewPebble requires cfg.Settings to be set")


### PR DESCRIPTION
Clean up `server.CreateEngines` to use `Open` instead of `NewPebble` in all cases.

Release note: none
Epic: none