### PR TITLE
kvserver: fix false positive in 'outstanding reproposal' assertion

### DIFF
--- a/pkg/kv/kvserver/replica_application_state_machine.go
+++ b/pkg/kv/kvserver/replica_application_state_machine.go
@@ -265,7 +265,6 @@ func (sm *replicaStateMachine) ApplySideEffects(
 			//   [lease seq is 1]
 			//   idx 99: unrelated cmd at LAI 10000, lease seq = 1
 			//   idx 100: cmd X at LAI 10000, lease seq = 1
-			//   idx 100: cmd X at LAI 10000, lease seq = 1
 			//
 			// Command `X` at log position 100 will get reproposed with a new lease
 			// index (as idx 99 consumed the LAI). But now the lease might also change
@@ -278,12 +277,12 @@ func (sm *replicaStateMachine) ApplySideEffects(
 			//   idx 102: cmd X at LAI 10000, lease seq = 1
 			//   idx 103: cmd X at LAI 20000, lease seq = 1
 			//
-			// When we apply index 102, we will see a permanent rejection but the
-			// proposal is local (since we don't unlink it if it is already superseded
-			// initially, see `retrieveLocalProposals`) and superseded (by idx 103). A
-			// permanent rejection dooms all reproposals (including the superseding
-			// one) to the same fate, so idx 103 will get rejected just like idx 102
-			// is.
+			// When we apply index 102, we will see a permanent rejection (because of
+			// the lease seq bump) but the proposal is local (since we don't unlink it
+			// if it is already superseded initially, see `retrieveLocalProposals`)
+			// and superseded (by idx 103). A permanent rejection dooms all
+			// reproposals (including the superseding one) to the same fate, so idx
+			// 103 will get rejected just like idx 102 is.
 			//
 			// [^1]: see (*replicaDecoder).retrieveLocalProposals()
 			sm.r.mu.RLock()

--- a/pkg/kv/kvserver/replica_application_state_machine.go
+++ b/pkg/kv/kvserver/replica_application_state_machine.go
@@ -282,7 +282,7 @@ func (sm *replicaStateMachine) ApplySideEffects(
 			// proposal is local (since we don't unlink it if it is already superseded
 			// initially, see `retrieveLocalProposals`) and superseded (by idx 103). A
 			// permanent rejection dooms all reproposals (including the superseding
-			// one) to the same fate, so idx 103 will get rejected just like idx 102.
+			// one) to the same fate, so idx 103 will get rejected just like idx 102
 			// is.
 			//
 			// [^1]: see (*replicaDecoder).retrieveLocalProposals()


### PR DESCRIPTION
In #94633, I introduced an assertion that attempted to catch cases
in which we might otherwise accidentally end up applying a proposal
twice.

This assertion had a false positive, see the updated comment within.

I was able to reproduce the failure within ~minutes via
`./experiment.sh` in #97173 as of 33dcdef.

Better testing of these cases would be desirable. Unfortunately, while
there is an abstraction over command application (`apply.Task`), most
of the logic worth testing lives in `(*replicaAppBatch)` which is
essentially a `*Replica` with more moving parts attached. This does
not lend itself well to unit testing.

I had a run[^1][^2][^3] earlier this year to make log application
standalone[^4], but then didn't have enough time to follow through.
It would be desirable to do so at a later date, perhaps with
the explicit goals of having interactions like the one discussion
in this PR unit become testable.

No release note because unreleased (except perhaps in an alpha).

[^1]: #93239
[^2]: #93266
[^3]: #93309
[^4]: https://github.com/cockroachdb/cockroach/issues/75729

Closes #94633.

[^1]: https://github.com/cockroachdb/cockroach/pull/94633/files#diff-50e458584d176deae52b20a7c04461b3e4110795c8c9a307cf7ee6696ba6bc60R238

Epic: none
Release note: None
