### PR TITLE
metric: get child metric from aggregated metric

### DIFF
--- a/pkg/util/metric/aggmetric/agg_metric.go
+++ b/pkg/util/metric/aggmetric/agg_metric.go
@@ -118,6 +118,22 @@ func (cs *childSet) remove(metric childMetric) {
 	}
 }
 
+func (cs *childSet) get(metric childMetric) (childMetric, bool) {
+	lvs := metric.labelValues()
+	if len(lvs) != len(cs.labels) {
+		panic(errors.AssertionFailedf(
+			"cannot get child with %d label values %v from a metric with %d labels %v",
+			len(lvs), lvs, len(cs.labels), cs.labels))
+	}
+	cs.mu.Lock()
+	defer cs.mu.Unlock()
+	m := cs.mu.tree.Get(metric)
+	if m == nil {
+		return nil, false
+	}
+	return m.(childMetric), m != nil
+}
+
 type childMetric interface {
 	btree.Item
 	labelValuer

--- a/pkg/util/metric/aggmetric/agg_metric_test.go
+++ b/pkg/util/metric/aggmetric/agg_metric_test.go
@@ -158,6 +158,24 @@ func TestAggMetric(t *testing.T) {
 		require.Panics(t, func() { d.AddChild() })
 		require.Panics(t, func() { g.AddChild("", "") })
 	})
+
+	t.Run("get child metric", func(t *testing.T) {
+		// Counter
+		cm, exist := c.GetChild(tenant2.String())
+		require.True(t, exist)
+		require.True(t, cm == c2)
+		cm, exist = c.GetChild("unknown_label")
+		require.False(t, exist)
+		require.Nil(t, cm)
+
+		// CounterFloat64
+		cmf, exist := d.GetChild(tenant2.String())
+		require.True(t, exist)
+		require.True(t, cmf == d2)
+		cmf, exist = d.GetChild("unknown_label")
+		require.False(t, exist)
+		require.Nil(t, cmf)
+	})
 }
 
 type Eacher interface {

--- a/pkg/util/metric/aggmetric/counter.go
+++ b/pkg/util/metric/aggmetric/counter.go
@@ -87,6 +87,18 @@ func (c *AggCounter) AddChild(labelVals ...string) *Counter {
 	return child
 }
 
+func (c *AggCounter) GetChild(labelVals ...string) (*Counter, bool) {
+	child := &Counter{
+		parent:           c,
+		labelValuesSlice: labelValuesSlice(labelVals),
+	}
+	cm, exists := c.get(child)
+	if !exists {
+		return nil, exists
+	}
+	return cm.(*Counter), exists
+}
+
 // Counter is a child of a AggCounter. When it is incremented, so too is the
 // parent. When metrics are collected by prometheus, each of the children will
 // appear with a distinct label, however, when cockroach internally collects
@@ -194,6 +206,18 @@ func (c *AggCounterFloat64) AddChild(labelVals ...string) *CounterFloat64 {
 	}
 	c.add(child)
 	return child
+}
+
+func (c *AggCounterFloat64) GetChild(labelVals ...string) (*CounterFloat64, bool) {
+	child := &CounterFloat64{
+		parent:           c,
+		labelValuesSlice: labelValuesSlice(labelVals),
+	}
+	cm, exists := c.get(child)
+	if !exists {
+		return nil, exists
+	}
+	return cm.(*CounterFloat64), exists
 }
 
 // CounterFloat64 is a child of a AggCounter. When it is incremented, so too is the


### PR DESCRIPTION
Before, Aggregated metrics allowed to add child metrics but required to keep track of added ones externally without ability to lookup metrics by labels values. In cases when child metric can be added dynamically with arbitrary values (when label values aren't known on bootstrapping stage), then it is necessary to have ability to get already added metric by label values to avoid attempts adding the same metric multiple times (which causes panics).

Related to: https://cockroachlabs.atlassian.net/browse/CRDB-21710

The downside of this approach: lookup by tree isn't efficient.

**Alternative** approach: wrap `AggCounter` with struct that keeps map of added child items, ie:
In this case lookup is efficient but requires additionally track map
https://github.com/cockroachdb/cockroach/blob/master/pkg/util/metric/aggmetric/counter.go#L25
 
```go
type AggCounter struct {
	g metric.Counter
	childSet
         // extend with map to keep track of added child metrics
	mu struct {
		syncutil.Mutex
		c map[labelValuesSlice]*Counter
	}
}

// add new Get func to retrieve added child metrics
func (g *AggCounter) Get(labelVals ...string) (*Counter, bool) {
	g.mu.Lock()
	defer g.mu.Unlock()
	if g.mu.c == nil {
		return nil, false
	}
	c, ok := g.mu.c[labelVal]
	if !ok {
		return nil, false
	}
	return c, true
}

func (g *AggCounter) AddChild(labelVals ...string) *Counter {
	child := &Counter{
		parent:           c,
		labelValuesSlice: labelValuesSlice(labelVals),
	}
	g.add(child)
        // add child to map here
        g.mu.Lock()
        g.mu.c[labelVals] = child
        g.mu.Unlock()
	return child
}
```

Release note: None