### PR TITLE
raftlog: don't embed raftpb.Entry in Entry

### DIFF
--- a/pkg/kv/kvserver/debug_print.go
+++ b/pkg/kv/kvserver/debug_print.go
@@ -348,7 +348,7 @@ func tryRaftLogEntry(kv storage.MVCCKeyValue) (string, error) {
 	defer e.Release()
 
 	if len(e.Data) == 0 {
-		return fmt.Sprintf("%s: EMPTY\n", &e.Entry), nil
+		return fmt.Sprintf("%s: EMPTY\n", (*raftpb.Entry)(&e.RaftEntry)), nil
 	}
 	e.Data = nil
 	cmd := e.Cmd
@@ -366,7 +366,7 @@ func tryRaftLogEntry(kv storage.MVCCKeyValue) (string, error) {
 	}
 	cmd.WriteBatch = nil
 
-	return fmt.Sprintf("%s (ID %s) by %s\n%s\nwrite batch:\n%s", &e.Entry, e.ID, leaseStr, &cmd, wbStr), nil
+	return fmt.Sprintf("%s (ID %s) by %s\n%s\nwrite batch:\n%s", (*raftpb.Entry)(&e.RaftEntry), e.ID, leaseStr, &cmd, wbStr), nil
 }
 
 func tryTxn(kv storage.MVCCKeyValue) (string, error) {

--- a/pkg/kv/kvserver/raftlog/BUILD.bazel
+++ b/pkg/kv/kvserver/raftlog/BUILD.bazel
@@ -30,6 +30,7 @@ go_library(
 go_test(
     name = "raftlog_test",
     srcs = [
+        "command_test.go",
         "encoding_test.go",
         "entry_bench_test.go",
         "entry_test.go",

--- a/pkg/kv/kvserver/raftlog/command_test.go
+++ b/pkg/kv/kvserver/raftlog/command_test.go
@@ -1,0 +1,28 @@
+// Copyright 2023 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package raftlog
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestReplicatedCmdString checks that ReplicatedCmd does not implement
+// fmt.Stringer. It is fine to implement this in the future, however previously
+// at one point it "accidentally" implemented fmt.Stringer via embedding, which
+// could hide information.
+func TestReplicatedCmdString(t *testing.T) {
+	var cmd interface{} = (*ReplicatedCmd)(nil)
+	_, ok := cmd.(fmt.Stringer)
+	require.False(t, ok)
+}

--- a/pkg/kv/kvserver/raftlog/encoding_test.go
+++ b/pkg/kv/kvserver/raftlog/encoding_test.go
@@ -62,7 +62,7 @@ func BenchmarkRaftAdmissionMetaOverhead(b *testing.B) {
 
 			encodingBuf := make([]byte, RaftCommandPrefixLen+raftAdmissionMeta.Size()+len(marshaledRaftCmd))
 			raftEnt := Entry{
-				Entry: raftpb.Entry{
+				RaftEntry: RaftEntry{
 					Term:  1,
 					Index: 1,
 					Type:  raftpb.EntryNormal,

--- a/pkg/kv/kvserver/replica_application_state_machine_test.go
+++ b/pkg/kv/kvserver/replica_application_state_machine_test.go
@@ -93,7 +93,7 @@ func TestReplicaStateMachineChangeReplicas(t *testing.T) {
 
 		// Stage a command with the ChangeReplicas trigger.
 		ent := &raftlog.Entry{
-			Entry: raftpb.Entry{
+			RaftEntry: raftlog.RaftEntry{
 				Index: r.mu.state.RaftAppliedIndex + 1,
 				Type:  raftpb.EntryConfChange,
 			},
@@ -197,7 +197,7 @@ func TestReplicaStateMachineRaftLogTruncationStronglyCoupled(t *testing.T) {
 		// Stage a command that truncates one raft log entry which we pretend has a
 		// byte size of 1.
 		ent := &raftlog.Entry{
-			Entry: raftpb.Entry{
+			RaftEntry: raftlog.RaftEntry{
 				Index: raftAppliedIndex + 1,
 				Type:  raftpb.EntryNormal,
 			},
@@ -316,7 +316,7 @@ func TestReplicaStateMachineRaftLogTruncationLooselyCoupled(t *testing.T) {
 			// Stage a command that truncates one raft log entry which we pretend has a
 			// byte size of 1.
 			ent := &raftlog.Entry{
-				Entry: raftpb.Entry{
+				RaftEntry: raftlog.RaftEntry{
 					Index: raftAppliedIndex + 1,
 					Type:  raftpb.EntryNormal,
 				},
@@ -447,7 +447,7 @@ func TestReplicaStateMachineEphemeralAppBatchRejection(t *testing.T) {
 	for _, s := range []string{"earlier", "later"} {
 		req, repr := descWriteRepr(s)
 		ent := &raftlog.Entry{
-			Entry: raftpb.Entry{
+			RaftEntry: raftlog.RaftEntry{
 				Index: raftAppliedIndex + 1,
 				Type:  raftpb.EntryNormal,
 			},


### PR DESCRIPTION
`raftpb.Entry` is a `fmt.Stringer`, so by embedding it we were making
the string representation of structs embedding it worse.

Concretely, in #97173 I noticed that `*replicatedCmd` ended up just
printing the `raftpb.Entry` that it wrapped, which was not helpful.

Epic: none
Release note: None
