### PR TITLE
kvserver: disable overeager slow lease warning

### DIFF
--- a/pkg/kv/kvserver/replica_proposal.go
+++ b/pkg/kv/kvserver/replica_proposal.go
@@ -370,7 +370,8 @@ func (r *Replica) leasePostApplyLocked(
 
 	// NB: ProposedTS is non-nil in practice, but we never fully migrated it
 	// in so we need to assume that it can be nil.
-	if iAmTheLeaseHolder && leaseChangingHands && newLease.ProposedTS != nil {
+	const slowLeaseWarningEnabled = false // see https://github.com/cockroachdb/cockroach/issues/97209
+	if slowLeaseWarningEnabled && iAmTheLeaseHolder && leaseChangingHands && newLease.ProposedTS != nil {
 		maybeLogSlowLeaseApplyWarning(ctx, time.Duration(now.WallTime-newLease.ProposedTS.WallTime), prevLease, newLease)
 	}
 


### PR DESCRIPTION
Touches https://github.com/cockroachdb/cockroach/issues/97209.

Epic: none
Release note (bug fix): the following spammy log message was removed:
> lease [...] expired before being followed by lease [...]; foreground traffic may have been impacted
