### PR TITLE
cli,loqrecovery: improve command output formatting

### DIFF
--- a/pkg/cli/cliflags/flags.go
+++ b/pkg/cli/cliflags/flags.go
@@ -1877,4 +1877,11 @@ p - prompt interactively for a confirmation
 </PRE>
 `,
 	}
+
+	PrintKeyLength = FlagInfo{
+		Name: "print-key-max-length",
+		Description: `
+Maximum number of characters in printed keys and spans. If key representation
+exceeds this value, it is truncated. Set to 0 to disable truncation.`,
+	}
 )

--- a/pkg/cli/debug.go
+++ b/pkg/cli/debug.go
@@ -1441,11 +1441,15 @@ func init() {
 	f.BoolVar(&debugRecoverPlanOpts.force, "force", false,
 		"force creation of plan even when problems were encountered; applying this plan may "+
 			"result in additional problems and should be done only with care and as a last resort")
+	f.UintVar(&formatHelper.maxPrintedKeyLength, cliflags.PrintKeyLength.Name,
+		formatHelper.maxPrintedKeyLength, cliflags.PrintKeyLength.Usage())
 
 	f = debugRecoverExecuteCmd.Flags()
 	f.VarP(&debugRecoverExecuteOpts.Stores, cliflags.RecoverStore.Name, cliflags.RecoverStore.Shorthand, cliflags.RecoverStore.Usage())
 	f.VarP(&debugRecoverExecuteOpts.confirmAction, cliflags.ConfirmActions.Name, cliflags.ConfirmActions.Shorthand,
 		cliflags.ConfirmActions.Usage())
+	f.UintVar(&formatHelper.maxPrintedKeyLength, cliflags.PrintKeyLength.Name,
+		formatHelper.maxPrintedKeyLength, cliflags.PrintKeyLength.Usage())
 
 	f = debugMergeLogsCmd.Flags()
 	f.Var(flagutil.Time(&debugMergeLogsOpts.from), "from",


### PR DESCRIPTION
This PR beautifies command output to make it easier to use:
- quotes are removed from suggested commands to make it easier to copy&paste.
- flag --print-key-max-length is added to limit length of the string representation of keys when showing proposed changes (keys could span kilobytes or megabytes and will make tool unusable).

Release note: None

Fixes #97161