### PR TITLE
Fix partial idx deletable

### DIFF
--- a/pkg/sql/opt/norm/testdata/rules/mutation
+++ b/pkg/sql/opt/norm/testdata/rules/mutation
@@ -214,8 +214,6 @@ update t
            ├── (f:18 > 1) AND (g:19 > 1) [as=partial_index_del2:28, outer=(18,19)]
            └── c:15 > 1 [as=partial_index_put3:29, outer=(15)]
 
-# Do not simplify partial index put/del column to false when it is also an
-# update column (h_new).
 norm
 UPDATE t SET h = d > 1 WHERE k = 1
 ----
@@ -224,15 +222,15 @@ update t
  ├── fetch columns: k:12 a:13 b:14 c:15 d:16 e:17 f:18 g:19 h:20
  ├── update-mapping:
  │    └── h_new:23 => h:9
- ├── partial index put columns: h_new:23 partial_index_put2:24 partial_index_put3:25
- ├── partial index del columns: h_new:23 partial_index_put2:24 partial_index_put3:25
+ ├── partial index put columns: partial_index_put1:24 partial_index_put2:25 partial_index_put3:26
+ ├── partial index del columns: partial_index_put1:24 partial_index_put2:25 partial_index_put3:26
  ├── cardinality: [0 - 0]
  ├── volatile, mutations
  └── project
-      ├── columns: partial_index_put2:24!null partial_index_put3:25!null h_new:23 k:12!null a:13 b:14 c:15 d:16 e:17 f:18 g:19 h:20
+      ├── columns: partial_index_put1:24!null partial_index_put2:25!null partial_index_put3:26!null h_new:23 k:12!null a:13 b:14 c:15 d:16 e:17 f:18 g:19 h:20
       ├── cardinality: [0 - 1]
       ├── key: ()
-      ├── fd: ()-->(12-20,23-25)
+      ├── fd: ()-->(12-20,23-26)
       ├── select
       │    ├── columns: k:12!null a:13 b:14 c:15 d:16 e:17 f:18 g:19 h:20
       │    ├── cardinality: [0 - 1]
@@ -253,8 +251,9 @@ update t
       │    └── filters
       │         └── k:12 = 1 [outer=(12), constraints=(/12: [/1 - /1]; tight), fd=()-->(12)]
       └── projections
-           ├── false [as=partial_index_put2:24]
-           ├── false [as=partial_index_put3:25]
+           ├── false [as=partial_index_put1:24]
+           ├── false [as=partial_index_put2:25]
+           ├── false [as=partial_index_put3:26]
            └── d:16 > 1 [as=h_new:23, outer=(16)]
 
 # Regression for #74385. Do not simplify partial index put/del columns to false

--- a/pkg/sql/opt/optbuilder/delete.go
+++ b/pkg/sql/opt/optbuilder/delete.go
@@ -79,8 +79,11 @@ func (b *Builder) buildDelete(del *tree.Delete, inScope *scope) (outScope *scope
 func (mb *mutationBuilder) buildDelete(returning *tree.ReturningExprs) {
 	mb.buildFKChecksAndCascadesForDelete()
 
+	// Add the partial index predicate expressions to the table metadata.
+	mb.b.addPartialIndexPredicatesForTable(mb.md.TableMeta(mb.tabID), nil /* scan */)
+
 	// Project partial index DEL boolean columns.
-	mb.projectPartialIndexDelCols()
+	mb.projectPartialIndexCols(false /* includePutCols */, true /* includeDelCols */)
 
 	private := mb.makeMutationPrivate(returning != nil)
 	for _, col := range mb.extraAccessibleCols {

--- a/pkg/sql/opt/optbuilder/insert.go
+++ b/pkg/sql/opt/optbuilder/insert.go
@@ -677,8 +677,11 @@ func (mb *mutationBuilder) buildInsert(returning *tree.ReturningExprs) {
 	// Add any check constraint boolean columns to the input.
 	mb.addCheckConstraintCols(false /* isUpdate */)
 
+	// Add the partial index predicate expressions to the table metadata.
+	mb.b.addPartialIndexPredicatesForTable(mb.md.TableMeta(mb.tabID), nil /* scan */)
+
 	// Project partial index PUT boolean columns.
-	mb.projectPartialIndexPutCols()
+	mb.projectPartialIndexCols(true /* includePutCols */, false /* includeDelCols */)
 
 	mb.buildUniqueChecksForInsert()
 
@@ -893,14 +896,14 @@ func (mb *mutationBuilder) buildUpsert(returning *tree.ReturningExprs) {
 	// Project partial index PUT and DEL boolean columns.
 	//
 	// In some cases existing rows may not be fetched for an UPSERT (see
-	// mutationBuilder.needExistingRows for more details). In theses cases
+	// mutationBuilder.needExistingRows for more details). In these cases
 	// there is no need to project partial index DEL columns and
 	// mb.fetchScope will be nil. Therefore, we only project partial index
 	// PUT columns.
 	if mb.needExistingRows() {
-		mb.projectPartialIndexPutAndDelCols()
+		mb.projectPartialIndexCols(true /* includePutCols */, true /* includeDelCols */)
 	} else {
-		mb.projectPartialIndexPutCols()
+		mb.projectPartialIndexCols(true /* includePutCols */, false /* includeDelCols */)
 	}
 
 	mb.buildUniqueChecksForUpsert()

--- a/pkg/sql/opt/optbuilder/mutation_builder.go
+++ b/pkg/sql/opt/optbuilder/mutation_builder.go
@@ -59,6 +59,9 @@ type mutationBuilder struct {
 	outScope *scope
 
 	// fetchScope contains the set of columns fetched from the target table.
+	// TODO(mgartner): Get rid of fetchScope once we stop building partial index
+	// predicate expressions with a fetchScope, and reuse the predicate in the
+	// table metadata instead.
 	fetchScope *scope
 
 	// insertExpr is the expression that produces the values which will be

--- a/pkg/sql/opt/optbuilder/mutation_builder_arbiter.go
+++ b/pkg/sql/opt/optbuilder/mutation_builder_arbiter.go
@@ -300,6 +300,9 @@ func (mb *mutationBuilder) buildAntiJoinForDoNothingArbiter(
 	// wraps the scan on the right side of the anti-join with the partial
 	// index predicate expression as the filter.
 	if pred != nil {
+		// TODO(mgartner): Use the predicate expression in the table metadata here,
+		// replacing column references with fetch column references, rather than
+		// re-building the expression.
 		texpr := fetchScope.resolveAndRequireType(pred, types.Bool)
 		predScalar := mb.b.buildScalar(texpr, fetchScope, nil, nil, nil)
 		fetchScope.expr = mb.b.factory.ConstructSelect(
@@ -387,6 +390,9 @@ func (mb *mutationBuilder) buildLeftJoinForUpsertArbiter(
 	// the scan on the right side of the left outer join with the partial index
 	// predicate expression as the filter.
 	if pred != nil {
+		// TODO(mgartner): Use the predicate expression in the table metadata here,
+		// replacing column references with fetch column references, rather than
+		// re-building the expression.
 		texpr := mb.fetchScope.resolveAndRequireType(pred, types.Bool)
 		predScalar := mb.b.buildScalar(texpr, mb.fetchScope, nil, nil, nil)
 		mb.fetchScope.expr = mb.b.factory.ConstructSelect(
@@ -521,6 +527,9 @@ func (mb *mutationBuilder) projectPartialArbiterDistinctColumn(
 		Left:  pred,
 		Right: tree.DNull,
 	}
+	// TODO(mgartner): Use the predicate expression in the table metadata here,
+	// replacing column references with fetch column references, rather than
+	// re-building the expression.
 	texpr := insertScope.resolveAndRequireType(expr, types.Bool)
 
 	// Use an anonymous name because the column cannot be referenced

--- a/pkg/sql/opt/optbuilder/mutation_builder_arbiter.go
+++ b/pkg/sql/opt/optbuilder/mutation_builder_arbiter.go
@@ -390,9 +390,9 @@ func (mb *mutationBuilder) buildLeftJoinForUpsertArbiter(
 	// the scan on the right side of the left outer join with the partial index
 	// predicate expression as the filter.
 	if pred != nil {
-		// TODO(mgartner): Use the predicate expression in the table metadata here,
-		// replacing column references with fetch column references, rather than
-		// re-building the expression.
+		// TODO(mgartner): Use the predicate expression in the table metadata
+		// here, replacing column references with fetch column references,
+		// rather than re-building the expression.
 		texpr := mb.fetchScope.resolveAndRequireType(pred, types.Bool)
 		predScalar := mb.b.buildScalar(texpr, mb.fetchScope, nil, nil, nil)
 		mb.fetchScope.expr = mb.b.factory.ConstructSelect(
@@ -423,6 +423,9 @@ func (mb *mutationBuilder) buildLeftJoinForUpsertArbiter(
 	// the unique partial index. Therefore, the partial index predicate
 	// expression is added to the ON filters.
 	if pred != nil {
+		// TODO(mgartner): Use the predicate expression in the table metadata
+		// here, replacing column references with fetch column references,
+		// rather than re-building the expression.
 		texpr := mb.outScope.resolveAndRequireType(pred, types.Bool)
 		predScalar := mb.b.buildScalar(texpr, mb.outScope, nil, nil, nil)
 		on = append(on, mb.b.factory.ConstructFiltersItem(predScalar))

--- a/pkg/sql/opt/optbuilder/mutation_builder_unique.go
+++ b/pkg/sql/opt/optbuilder/mutation_builder_unique.go
@@ -166,6 +166,9 @@ func (mb *mutationBuilder) uniqueColsUpdated(uniqueOrdinal cat.UniqueOrdinal) bo
 
 		var predCols opt.ColSet
 		mb.b.buildScalar(typedPred, mb.fetchScope, nil, nil, &predCols)
+		// TODO(mgartner): Use the predicate expression in the table metadata
+		// here, replacing column references with fetch column references,
+		// rather than re-building the expression.
 		for colID, ok := predCols.Next(0); ok; colID, ok = predCols.Next(colID + 1) {
 			ord := mb.md.ColumnMeta(colID).Table.ColumnOrdinal(colID)
 			if mb.updateColIDs[ord] != 0 {
@@ -343,6 +346,9 @@ func (h *uniqueCheckHelper) buildInsertionCheck() memo.UniqueChecksItem {
 	if isPartial {
 		pred := h.mb.parseUniqueConstraintPredicateExpr(h.uniqueOrdinal)
 
+		// TODO(mgartner): Use the predicate expression in the table metadata
+		// here, replacing column references with fetch column references,
+		// rather than re-building the expression.
 		typedPred := withScanScope.resolveAndRequireType(pred, types.Bool)
 		withScanPred := h.mb.b.buildScalar(typedPred, withScanScope, nil, nil, nil)
 		semiJoinFilters = append(semiJoinFilters, f.ConstructFiltersItem(withScanPred))

--- a/pkg/sql/opt/optbuilder/testdata/partial-indexes
+++ b/pkg/sql/opt/optbuilder/testdata/partial-indexes
@@ -61,9 +61,9 @@ project
            ├── partial_indexes_c_idx: filters
            │    └── (a:1 > b:2) AND (c:3 = 'bar')
            ├── b: filters
-           │    └── c:3 = 'delete-only'
+           │    └── c:3 = 'write-only'
            └── b: filters
-                └── c:3 = 'write-only'
+                └── c:3 = 'delete-only'
 
 # Inline virtual computed column expressions in partial index predicates in
 # table metadata. Do not inline stored computed column expressions.
@@ -109,8 +109,8 @@ insert partial_indexes
       └── projections
            ├── column3:8 = 'foo' [as=partial_index_put1:9]
            ├── (column1:6 > column2:7) AND (column3:8 = 'bar') [as=partial_index_put2:10]
-           ├── column3:8 = 'delete-only' [as=partial_index_put3:11]
-           └── column3:8 = 'write-only' [as=partial_index_put4:12]
+           ├── column3:8 = 'write-only' [as=partial_index_put3:11]
+           └── column3:8 = 'delete-only' [as=partial_index_put4:12]
 
 # Do not error with "column reference is ambiguous" when table column names
 # match synthesized column names.
@@ -214,14 +214,14 @@ delete partial_indexes
       │         ├── partial_indexes_c_idx: filters
       │         │    └── (a:6 > b:7) AND (c:8 = 'bar')
       │         ├── b: filters
-      │         │    └── c:8 = 'delete-only'
+      │         │    └── c:8 = 'write-only'
       │         └── b: filters
-      │              └── c:8 = 'write-only'
+      │              └── c:8 = 'delete-only'
       └── projections
            ├── c:8 = 'foo' [as=partial_index_del1:11]
            ├── (a:6 > b:7) AND (c:8 = 'bar') [as=partial_index_del2:12]
-           ├── c:8 = 'delete-only' [as=partial_index_del3:13]
-           └── c:8 = 'write-only' [as=partial_index_del4:14]
+           ├── c:8 = 'write-only' [as=partial_index_del3:13]
+           └── c:8 = 'delete-only' [as=partial_index_del4:14]
 
 # Do not error with "column reference is ambiguous" when table column names
 # match synthesized column names.
@@ -305,17 +305,17 @@ update partial_indexes
       │    │         ├── partial_indexes_c_idx: filters
       │    │         │    └── (a:6 > b:7) AND (c:8 = 'bar')
       │    │         ├── b: filters
-      │    │         │    └── c:8 = 'delete-only'
+      │    │         │    └── c:8 = 'write-only'
       │    │         └── b: filters
-      │    │              └── c:8 = 'write-only'
+      │    │              └── c:8 = 'delete-only'
       │    └── projections
       │         └── 1 [as=a_new:11]
       └── projections
            ├── c:8 = 'foo' [as=partial_index_put1:12]
            ├── (a_new:11 > b:7) AND (c:8 = 'bar') [as=partial_index_put2:13]
            ├── (a:6 > b:7) AND (c:8 = 'bar') [as=partial_index_del2:14]
-           ├── c:8 = 'delete-only' [as=partial_index_put3:15]
-           └── c:8 = 'write-only' [as=partial_index_put4:16]
+           ├── c:8 = 'write-only' [as=partial_index_put3:15]
+           └── c:8 = 'delete-only' [as=partial_index_put4:16]
 
 build
 UPDATE partial_indexes SET a = a + 5 RETURNING *
@@ -343,17 +343,17 @@ update partial_indexes
       │    │         ├── partial_indexes_c_idx: filters
       │    │         │    └── (a:6 > b:7) AND (c:8 = 'bar')
       │    │         ├── b: filters
-      │    │         │    └── c:8 = 'delete-only'
+      │    │         │    └── c:8 = 'write-only'
       │    │         └── b: filters
-      │    │              └── c:8 = 'write-only'
+      │    │              └── c:8 = 'delete-only'
       │    └── projections
       │         └── a:6 + 5 [as=a_new:11]
       └── projections
            ├── c:8 = 'foo' [as=partial_index_put1:12]
            ├── (a_new:11 > b:7) AND (c:8 = 'bar') [as=partial_index_put2:13]
            ├── (a:6 > b:7) AND (c:8 = 'bar') [as=partial_index_del2:14]
-           ├── c:8 = 'delete-only' [as=partial_index_put3:15]
-           └── c:8 = 'write-only' [as=partial_index_put4:16]
+           ├── c:8 = 'write-only' [as=partial_index_put3:15]
+           └── c:8 = 'delete-only' [as=partial_index_put4:16]
 
 build
 UPDATE partial_indexes SET a = v.a FROM (VALUES (1), (2)) AS v(a) WHERE partial_indexes.a = v.a
@@ -383,9 +383,9 @@ update partial_indexes
       │    │    │    │         ├── partial_indexes_c_idx: filters
       │    │    │    │         │    └── (a:6 > b:7) AND (c:8 = 'bar')
       │    │    │    │         ├── b: filters
-      │    │    │    │         │    └── c:8 = 'delete-only'
+      │    │    │    │         │    └── c:8 = 'write-only'
       │    │    │    │         └── b: filters
-      │    │    │    │              └── c:8 = 'write-only'
+      │    │    │    │              └── c:8 = 'delete-only'
       │    │    │    ├── values
       │    │    │    │    ├── columns: column1:11!null
       │    │    │    │    ├── (1,)
@@ -408,8 +408,8 @@ update partial_indexes
            ├── c:8 = 'foo' [as=partial_index_put1:12]
            ├── (column1:11 > b:7) AND (c:8 = 'bar') [as=partial_index_put2:13]
            ├── (a:6 > b:7) AND (c:8 = 'bar') [as=partial_index_del2:14]
-           ├── c:8 = 'delete-only' [as=partial_index_put3:15]
-           └── c:8 = 'write-only' [as=partial_index_put4:16]
+           ├── c:8 = 'write-only' [as=partial_index_put3:15]
+           └── c:8 = 'delete-only' [as=partial_index_put4:16]
 
 # Do not error with "column reference is ambiguous" when table column names
 # match synthesized column names.
@@ -643,9 +643,9 @@ insert partial_indexes
       │    │    │    │    │    │    ├── partial_indexes_c_idx: filters
       │    │    │    │    │    │    │    └── (a:9 > b:10) AND (c:11 = 'bar')
       │    │    │    │    │    │    ├── b: filters
-      │    │    │    │    │    │    │    └── c:11 = 'delete-only'
+      │    │    │    │    │    │    │    └── c:11 = 'write-only'
       │    │    │    │    │    │    └── b: filters
-      │    │    │    │    │    │         └── c:11 = 'write-only'
+      │    │    │    │    │    │         └── c:11 = 'delete-only'
       │    │    │    │    │    └── flags: disabled not visible index feature
       │    │    │    │    └── filters
       │    │    │    │         └── column1:6 = a:9
@@ -657,9 +657,9 @@ insert partial_indexes
       │    │    │    │    │    ├── partial_indexes_c_idx: filters
       │    │    │    │    │    │    └── (a:14 > b:15) AND (c:16 = 'bar')
       │    │    │    │    │    ├── b: filters
-      │    │    │    │    │    │    └── c:16 = 'delete-only'
+      │    │    │    │    │    │    └── c:16 = 'write-only'
       │    │    │    │    │    └── b: filters
-      │    │    │    │    │         └── c:16 = 'write-only'
+      │    │    │    │    │         └── c:16 = 'delete-only'
       │    │    │    │    └── flags: disabled not visible index feature
       │    │    │    └── filters
       │    │    │         ├── column2:7 = b:15
@@ -675,8 +675,8 @@ insert partial_indexes
       └── projections
            ├── column3:8 = 'foo' [as=partial_index_put1:19]
            ├── (column1:6 > column2:7) AND (column3:8 = 'bar') [as=partial_index_put2:20]
-           ├── column3:8 = 'delete-only' [as=partial_index_put3:21]
-           └── column3:8 = 'write-only' [as=partial_index_put4:22]
+           ├── column3:8 = 'write-only' [as=partial_index_put3:21]
+           └── column3:8 = 'delete-only' [as=partial_index_put4:22]
 
 build
 INSERT INTO partial_indexes VALUES (2, 1, 'bar') ON CONFLICT (b, c) DO UPDATE SET b = partial_indexes.b + 1, c = 'baz'
@@ -720,9 +720,9 @@ upsert partial_indexes
       │    │    │    │    │    ├── partial_indexes_c_idx: filters
       │    │    │    │    │    │    └── (a:9 > b:10) AND (c:11 = 'bar')
       │    │    │    │    │    ├── b: filters
-      │    │    │    │    │    │    └── c:11 = 'delete-only'
+      │    │    │    │    │    │    └── c:11 = 'write-only'
       │    │    │    │    │    └── b: filters
-      │    │    │    │    │         └── c:11 = 'write-only'
+      │    │    │    │    │         └── c:11 = 'delete-only'
       │    │    │    │    └── flags: disabled not visible index feature
       │    │    │    └── filters
       │    │    │         ├── column2:7 = b:10
@@ -739,10 +739,10 @@ upsert partial_indexes
            ├── c:11 = 'foo' [as=partial_index_del1:20]
            ├── (upsert_a:16 > upsert_b:17) AND (upsert_c:18 = 'bar') [as=partial_index_put2:21]
            ├── (a:9 > b:10) AND (c:11 = 'bar') [as=partial_index_del2:22]
-           ├── upsert_c:18 = 'delete-only' [as=partial_index_put3:23]
-           ├── c:11 = 'delete-only' [as=partial_index_del3:24]
-           ├── upsert_c:18 = 'write-only' [as=partial_index_put4:25]
-           └── c:11 = 'write-only' [as=partial_index_del4:26]
+           ├── upsert_c:18 = 'write-only' [as=partial_index_put3:23]
+           ├── c:11 = 'write-only' [as=partial_index_del3:24]
+           ├── upsert_c:18 = 'delete-only' [as=partial_index_put4:25]
+           └── c:11 = 'delete-only' [as=partial_index_del4:26]
 
 build
 UPSERT INTO partial_indexes VALUES (2, 1, 'bar')
@@ -786,9 +786,9 @@ upsert partial_indexes
       │    │    │    │    ├── partial_indexes_c_idx: filters
       │    │    │    │    │    └── (a:9 > b:10) AND (c:11 = 'bar')
       │    │    │    │    ├── b: filters
-      │    │    │    │    │    └── c:11 = 'delete-only'
+      │    │    │    │    │    └── c:11 = 'write-only'
       │    │    │    │    └── b: filters
-      │    │    │    │         └── c:11 = 'write-only'
+      │    │    │    │         └── c:11 = 'delete-only'
       │    │    │    └── flags: disabled not visible index feature
       │    │    └── filters
       │    │         └── column1:6 = a:9
@@ -799,10 +799,10 @@ upsert partial_indexes
            ├── c:11 = 'foo' [as=partial_index_del1:16]
            ├── (upsert_a:14 > column2:7) AND (column3:8 = 'bar') [as=partial_index_put2:17]
            ├── (a:9 > b:10) AND (c:11 = 'bar') [as=partial_index_del2:18]
-           ├── column3:8 = 'delete-only' [as=partial_index_put3:19]
-           ├── c:11 = 'delete-only' [as=partial_index_del3:20]
-           ├── column3:8 = 'write-only' [as=partial_index_put4:21]
-           └── c:11 = 'write-only' [as=partial_index_del4:22]
+           ├── column3:8 = 'write-only' [as=partial_index_put3:19]
+           ├── c:11 = 'write-only' [as=partial_index_del3:20]
+           ├── column3:8 = 'delete-only' [as=partial_index_put4:21]
+           └── c:11 = 'delete-only' [as=partial_index_del4:22]
 
 # Columns referenced in the SET expression are ambiguous without a table name.
 # Is it the value of the column being inserted or the value of the column

--- a/pkg/sql/opt/optbuilder/testdata/partial-indexes
+++ b/pkg/sql/opt/optbuilder/testdata/partial-indexes
@@ -45,6 +45,20 @@ CREATE TABLE ambig (
 )
 ----
 
+exec-ddl
+CREATE TABLE mut (
+  a INT PRIMARY KEY,
+  b INT,
+  c INT UNIQUE,
+  "w:write-only" INT,
+  "d:delete-only" INT,
+  UNIQUE INDEX "w_idx:write-only" (w) WHERE w > 1,
+  UNIQUE INDEX "d_idx:delete-only" (d) WHERE d > 2,
+  UNIQUE INDEX "b_w_idx:write-only" (b) WHERE w > 3,
+  UNIQUE INDEX "b_d_idx:delete-only" (b) WHERE d > 4
+)
+----
+
 # -- SELECT tests --
 
 # Populate table metadata with partial index predicates.
@@ -88,6 +102,23 @@ project
       │              └── e:5 = 'FOO'
       └── projections
            └── lower(c:3) [as=d:4]
+
+build
+SELECT a FROM mut
+----
+project
+ ├── columns: a:1!null
+ └── scan mut
+      ├── columns: a:1!null b:2 c:3 crdb_internal_mvcc_timestamp:6 tableoid:7
+      └── partial index predicates
+           ├── w_idx: filters
+           │    └── w:4 > 1
+           ├── b_w_idx: filters
+           │    └── w:4 > 3
+           ├── d_idx: filters
+           │    └── d:5 > 2
+           └── b_d_idx: filters
+                └── d:5 > 4
 
 # -- INSERT tests --
 
@@ -169,6 +200,31 @@ insert comp
       └── projections
            ├── d_comp:11 = 'foo' [as=partial_index_put1:13]
            └── e_comp:12 = 'FOO' [as=partial_index_put2:14]
+
+build
+INSERT INTO mut (a, b, c) VALUES (1, 2, 3)
+----
+insert mut
+ ├── columns: <none>
+ ├── insert-mapping:
+ │    ├── column1:8 => a:1
+ │    ├── column2:9 => b:2
+ │    ├── column3:10 => c:3
+ │    └── w_default:11 => w:4
+ ├── partial index put columns: partial_index_put1:12 partial_index_put2:13 partial_index_put3:14 partial_index_put3:14
+ └── project
+      ├── columns: partial_index_put1:12 partial_index_put2:13 partial_index_put3:14!null column1:8!null column2:9!null column3:10!null w_default:11
+      ├── project
+      │    ├── columns: w_default:11 column1:8!null column2:9!null column3:10!null
+      │    ├── values
+      │    │    ├── columns: column1:8!null column2:9!null column3:10!null
+      │    │    └── (1, 2, 3)
+      │    └── projections
+      │         └── NULL::INT8 [as=w_default:11]
+      └── projections
+           ├── w_default:11 > 1 [as=partial_index_put1:12]
+           ├── w_default:11 > 3 [as=partial_index_put2:13]
+           └── false [as=partial_index_put3:14]
 
 # Regression test for issue #52546. Building partial index predicate expressions
 # that are only a single column reference should not panic.
@@ -280,6 +336,32 @@ delete comp
       └── projections
            ├── d:11 = 'foo' [as=partial_index_del1:15]
            └── e:12 = 'FOO' [as=partial_index_del2:16]
+
+build
+DELETE FROM mut
+----
+delete mut
+ ├── columns: <none>
+ ├── fetch columns: a:8 b:9 c:10 w:11 d:12
+ ├── partial index del columns: partial_index_del1:15 partial_index_del2:16 partial_index_del3:17 partial_index_del4:18
+ └── project
+      ├── columns: partial_index_del1:15 partial_index_del2:16 partial_index_del3:17 partial_index_del4:18 a:8!null b:9 c:10 w:11 d:12 crdb_internal_mvcc_timestamp:13 tableoid:14
+      ├── scan mut
+      │    ├── columns: a:8!null b:9 c:10 w:11 d:12 crdb_internal_mvcc_timestamp:13 tableoid:14
+      │    └── partial index predicates
+      │         ├── w_idx: filters
+      │         │    └── w:11 > 1
+      │         ├── b_w_idx: filters
+      │         │    └── w:11 > 3
+      │         ├── d_idx: filters
+      │         │    └── d:12 > 2
+      │         └── b_d_idx: filters
+      │              └── d:12 > 4
+      └── projections
+           ├── w:11 > 1 [as=partial_index_del1:15]
+           ├── w:11 > 3 [as=partial_index_del2:16]
+           ├── d:12 > 2 [as=partial_index_del3:17]
+           └── d:12 > 4 [as=partial_index_del4:18]
 
 # -- UPDATE tests --
 
@@ -544,6 +626,47 @@ update comp
            ├── d:11 = 'foo' [as=partial_index_del1:19]
            ├── e_comp:17 = 'FOO' [as=partial_index_put2:20]
            └── e:12 = 'FOO' [as=partial_index_del2:21]
+
+build
+UPDATE mut SET b = 1
+----
+update mut
+ ├── columns: <none>
+ ├── fetch columns: a:8 b:9 c:10 w:11 d:12
+ ├── update-mapping:
+ │    ├── b_new:15 => b:2
+ │    └── w_default:16 => w:4
+ ├── partial index put columns: partial_index_put1:17 partial_index_put2:19 partial_index_put3:21 partial_index_put3:21
+ ├── partial index del columns: partial_index_del1:18 partial_index_del2:20 partial_index_del3:22 partial_index_del4:23
+ └── project
+      ├── columns: partial_index_put1:17 partial_index_del1:18 partial_index_put2:19 partial_index_del2:20 partial_index_put3:21!null partial_index_del3:22 partial_index_del4:23 a:8!null b:9 c:10 w:11 d:12 crdb_internal_mvcc_timestamp:13 tableoid:14 b_new:15!null w_default:16
+      ├── project
+      │    ├── columns: w_default:16 a:8!null b:9 c:10 w:11 d:12 crdb_internal_mvcc_timestamp:13 tableoid:14 b_new:15!null
+      │    ├── project
+      │    │    ├── columns: b_new:15!null a:8!null b:9 c:10 w:11 d:12 crdb_internal_mvcc_timestamp:13 tableoid:14
+      │    │    ├── scan mut
+      │    │    │    ├── columns: a:8!null b:9 c:10 w:11 d:12 crdb_internal_mvcc_timestamp:13 tableoid:14
+      │    │    │    └── partial index predicates
+      │    │    │         ├── w_idx: filters
+      │    │    │         │    └── w:11 > 1
+      │    │    │         ├── b_w_idx: filters
+      │    │    │         │    └── w:11 > 3
+      │    │    │         ├── d_idx: filters
+      │    │    │         │    └── d:12 > 2
+      │    │    │         └── b_d_idx: filters
+      │    │    │              └── d:12 > 4
+      │    │    └── projections
+      │    │         └── 1 [as=b_new:15]
+      │    └── projections
+      │         └── NULL::INT8 [as=w_default:16]
+      └── projections
+           ├── w_default:16 > 1 [as=partial_index_put1:17]
+           ├── w:11 > 1 [as=partial_index_del1:18]
+           ├── w_default:16 > 3 [as=partial_index_put2:19]
+           ├── w:11 > 3 [as=partial_index_del2:20]
+           ├── false [as=partial_index_put3:21]
+           ├── d:12 > 2 [as=partial_index_del3:22]
+           └── d:12 > 4 [as=partial_index_del4:23]
 
 # Regression test for #61520. The new value for column a should be in-scope when
 # building the partial index PUT expression when the value in the FROM clause
@@ -1898,3 +2021,220 @@ upsert comp
            ├── e:18 = 'FOO' [as=partial_index_del2:32]
            ├── upsert_e:28 = 'bar' [as=partial_index_put4:33]
            └── e:18 = 'bar' [as=partial_index_del4:34]
+
+build
+INSERT INTO mut VALUES (1, 2, 3) ON CONFLICT DO NOTHING
+----
+insert mut
+ ├── arbiter indexes: mut_pkey mut_c_key
+ ├── columns: <none>
+ ├── insert-mapping:
+ │    ├── column1:8 => a:1
+ │    ├── column2:9 => b:2
+ │    ├── column3:10 => c:3
+ │    └── w_default:11 => w:4
+ ├── partial index put columns: partial_index_put1:26 partial_index_put2:27 partial_index_put3:28 partial_index_put3:28
+ └── project
+      ├── columns: partial_index_put1:26 partial_index_put2:27 partial_index_put3:28!null column1:8!null column2:9!null column3:10!null w_default:11
+      ├── upsert-distinct-on
+      │    ├── columns: column1:8!null column2:9!null column3:10!null w_default:11
+      │    ├── grouping columns: column3:10!null
+      │    ├── upsert-distinct-on
+      │    │    ├── columns: column1:8!null column2:9!null column3:10!null w_default:11
+      │    │    ├── grouping columns: column1:8!null
+      │    │    ├── anti-join (hash)
+      │    │    │    ├── columns: column1:8!null column2:9!null column3:10!null w_default:11
+      │    │    │    ├── anti-join (hash)
+      │    │    │    │    ├── columns: column1:8!null column2:9!null column3:10!null w_default:11
+      │    │    │    │    ├── project
+      │    │    │    │    │    ├── columns: w_default:11 column1:8!null column2:9!null column3:10!null
+      │    │    │    │    │    ├── values
+      │    │    │    │    │    │    ├── columns: column1:8!null column2:9!null column3:10!null
+      │    │    │    │    │    │    └── (1, 2, 3)
+      │    │    │    │    │    └── projections
+      │    │    │    │    │         └── NULL::INT8 [as=w_default:11]
+      │    │    │    │    ├── scan mut
+      │    │    │    │    │    ├── columns: a:12!null b:13 c:14
+      │    │    │    │    │    ├── partial index predicates
+      │    │    │    │    │    │    ├── w_idx: filters
+      │    │    │    │    │    │    │    └── w:15 > 1
+      │    │    │    │    │    │    ├── b_w_idx: filters
+      │    │    │    │    │    │    │    └── w:15 > 3
+      │    │    │    │    │    │    ├── d_idx: filters
+      │    │    │    │    │    │    │    └── d:16 > 2
+      │    │    │    │    │    │    └── b_d_idx: filters
+      │    │    │    │    │    │         └── d:16 > 4
+      │    │    │    │    │    └── flags: disabled not visible index feature
+      │    │    │    │    └── filters
+      │    │    │    │         └── column1:8 = a:12
+      │    │    │    ├── scan mut
+      │    │    │    │    ├── columns: a:19!null b:20 c:21
+      │    │    │    │    ├── partial index predicates
+      │    │    │    │    │    ├── w_idx: filters
+      │    │    │    │    │    │    └── w:22 > 1
+      │    │    │    │    │    ├── b_w_idx: filters
+      │    │    │    │    │    │    └── w:22 > 3
+      │    │    │    │    │    ├── d_idx: filters
+      │    │    │    │    │    │    └── d:23 > 2
+      │    │    │    │    │    └── b_d_idx: filters
+      │    │    │    │    │         └── d:23 > 4
+      │    │    │    │    └── flags: disabled not visible index feature
+      │    │    │    └── filters
+      │    │    │         └── column3:10 = c:21
+      │    │    └── aggregations
+      │    │         ├── first-agg [as=column2:9]
+      │    │         │    └── column2:9
+      │    │         ├── first-agg [as=column3:10]
+      │    │         │    └── column3:10
+      │    │         └── first-agg [as=w_default:11]
+      │    │              └── w_default:11
+      │    └── aggregations
+      │         ├── first-agg [as=column1:8]
+      │         │    └── column1:8
+      │         ├── first-agg [as=column2:9]
+      │         │    └── column2:9
+      │         └── first-agg [as=w_default:11]
+      │              └── w_default:11
+      └── projections
+           ├── w_default:11 > 1 [as=partial_index_put1:26]
+           ├── w_default:11 > 3 [as=partial_index_put2:27]
+           └── false [as=partial_index_put3:28]
+
+build
+INSERT INTO mut VALUES (1, 2, 3) ON CONFLICT (c) DO UPDATE SET b = 3
+----
+upsert mut
+ ├── arbiter indexes: mut_c_key
+ ├── columns: <none>
+ ├── canary column: a:12
+ ├── fetch columns: a:12 b:13 c:14 w:15 d:16
+ ├── insert-mapping:
+ │    ├── column1:8 => a:1
+ │    ├── column2:9 => b:2
+ │    ├── column3:10 => c:3
+ │    └── w_default:11 => w:4
+ ├── update-mapping:
+ │    ├── upsert_b:21 => b:2
+ │    └── w_default:11 => w:4
+ ├── partial index put columns: partial_index_put1:23 partial_index_put2:25 partial_index_put3:27 partial_index_put3:27
+ ├── partial index del columns: partial_index_del1:24 partial_index_del2:26 partial_index_del3:28 partial_index_del4:29
+ └── project
+      ├── columns: partial_index_put1:23 partial_index_del1:24 partial_index_put2:25 partial_index_del2:26 partial_index_put3:27!null partial_index_del3:28 partial_index_del4:29 column1:8!null column2:9!null column3:10!null w_default:11 a:12 b:13 c:14 w:15 d:16 crdb_internal_mvcc_timestamp:17 tableoid:18 b_new:19!null upsert_a:20 upsert_b:21!null upsert_c:22
+      ├── project
+      │    ├── columns: upsert_a:20 upsert_b:21!null upsert_c:22 column1:8!null column2:9!null column3:10!null w_default:11 a:12 b:13 c:14 w:15 d:16 crdb_internal_mvcc_timestamp:17 tableoid:18 b_new:19!null
+      │    ├── project
+      │    │    ├── columns: b_new:19!null column1:8!null column2:9!null column3:10!null w_default:11 a:12 b:13 c:14 w:15 d:16 crdb_internal_mvcc_timestamp:17 tableoid:18
+      │    │    ├── left-join (hash)
+      │    │    │    ├── columns: column1:8!null column2:9!null column3:10!null w_default:11 a:12 b:13 c:14 w:15 d:16 crdb_internal_mvcc_timestamp:17 tableoid:18
+      │    │    │    ├── ensure-upsert-distinct-on
+      │    │    │    │    ├── columns: column1:8!null column2:9!null column3:10!null w_default:11
+      │    │    │    │    ├── grouping columns: column3:10!null
+      │    │    │    │    ├── project
+      │    │    │    │    │    ├── columns: w_default:11 column1:8!null column2:9!null column3:10!null
+      │    │    │    │    │    ├── values
+      │    │    │    │    │    │    ├── columns: column1:8!null column2:9!null column3:10!null
+      │    │    │    │    │    │    └── (1, 2, 3)
+      │    │    │    │    │    └── projections
+      │    │    │    │    │         └── NULL::INT8 [as=w_default:11]
+      │    │    │    │    └── aggregations
+      │    │    │    │         ├── first-agg [as=column1:8]
+      │    │    │    │         │    └── column1:8
+      │    │    │    │         ├── first-agg [as=column2:9]
+      │    │    │    │         │    └── column2:9
+      │    │    │    │         └── first-agg [as=w_default:11]
+      │    │    │    │              └── w_default:11
+      │    │    │    ├── scan mut
+      │    │    │    │    ├── columns: a:12!null b:13 c:14 w:15 d:16 crdb_internal_mvcc_timestamp:17 tableoid:18
+      │    │    │    │    ├── partial index predicates
+      │    │    │    │    │    ├── w_idx: filters
+      │    │    │    │    │    │    └── w:15 > 1
+      │    │    │    │    │    ├── b_w_idx: filters
+      │    │    │    │    │    │    └── w:15 > 3
+      │    │    │    │    │    ├── d_idx: filters
+      │    │    │    │    │    │    └── d:16 > 2
+      │    │    │    │    │    └── b_d_idx: filters
+      │    │    │    │    │         └── d:16 > 4
+      │    │    │    │    └── flags: disabled not visible index feature
+      │    │    │    └── filters
+      │    │    │         └── column3:10 = c:14
+      │    │    └── projections
+      │    │         └── 3 [as=b_new:19]
+      │    └── projections
+      │         ├── CASE WHEN a:12 IS NULL THEN column1:8 ELSE a:12 END [as=upsert_a:20]
+      │         ├── CASE WHEN a:12 IS NULL THEN column2:9 ELSE b_new:19 END [as=upsert_b:21]
+      │         └── CASE WHEN a:12 IS NULL THEN column3:10 ELSE c:14 END [as=upsert_c:22]
+      └── projections
+           ├── w_default:11 > 1 [as=partial_index_put1:23]
+           ├── w:15 > 1 [as=partial_index_del1:24]
+           ├── w_default:11 > 3 [as=partial_index_put2:25]
+           ├── w:15 > 3 [as=partial_index_del2:26]
+           ├── false [as=partial_index_put3:27]
+           ├── d:16 > 2 [as=partial_index_del3:28]
+           └── d:16 > 4 [as=partial_index_del4:29]
+
+build
+UPSERT INTO mut VALUES (1, 2, 3)
+----
+upsert mut
+ ├── arbiter indexes: mut_pkey
+ ├── columns: <none>
+ ├── canary column: a:12
+ ├── fetch columns: a:12 b:13 c:14 w:15 d:16
+ ├── insert-mapping:
+ │    ├── column1:8 => a:1
+ │    ├── column2:9 => b:2
+ │    ├── column3:10 => c:3
+ │    └── w_default:11 => w:4
+ ├── update-mapping:
+ │    ├── column2:9 => b:2
+ │    ├── column3:10 => c:3
+ │    └── w_default:11 => w:4
+ ├── partial index put columns: partial_index_put1:20 partial_index_put2:22 partial_index_put3:24 partial_index_put3:24
+ ├── partial index del columns: partial_index_del1:21 partial_index_del2:23 partial_index_del3:25 partial_index_del4:26
+ └── project
+      ├── columns: partial_index_put1:20 partial_index_del1:21 partial_index_put2:22 partial_index_del2:23 partial_index_put3:24!null partial_index_del3:25 partial_index_del4:26 column1:8!null column2:9!null column3:10!null w_default:11 a:12 b:13 c:14 w:15 d:16 crdb_internal_mvcc_timestamp:17 tableoid:18 upsert_a:19
+      ├── project
+      │    ├── columns: upsert_a:19 column1:8!null column2:9!null column3:10!null w_default:11 a:12 b:13 c:14 w:15 d:16 crdb_internal_mvcc_timestamp:17 tableoid:18
+      │    ├── left-join (hash)
+      │    │    ├── columns: column1:8!null column2:9!null column3:10!null w_default:11 a:12 b:13 c:14 w:15 d:16 crdb_internal_mvcc_timestamp:17 tableoid:18
+      │    │    ├── ensure-upsert-distinct-on
+      │    │    │    ├── columns: column1:8!null column2:9!null column3:10!null w_default:11
+      │    │    │    ├── grouping columns: column1:8!null
+      │    │    │    ├── project
+      │    │    │    │    ├── columns: w_default:11 column1:8!null column2:9!null column3:10!null
+      │    │    │    │    ├── values
+      │    │    │    │    │    ├── columns: column1:8!null column2:9!null column3:10!null
+      │    │    │    │    │    └── (1, 2, 3)
+      │    │    │    │    └── projections
+      │    │    │    │         └── NULL::INT8 [as=w_default:11]
+      │    │    │    └── aggregations
+      │    │    │         ├── first-agg [as=column2:9]
+      │    │    │         │    └── column2:9
+      │    │    │         ├── first-agg [as=column3:10]
+      │    │    │         │    └── column3:10
+      │    │    │         └── first-agg [as=w_default:11]
+      │    │    │              └── w_default:11
+      │    │    ├── scan mut
+      │    │    │    ├── columns: a:12!null b:13 c:14 w:15 d:16 crdb_internal_mvcc_timestamp:17 tableoid:18
+      │    │    │    ├── partial index predicates
+      │    │    │    │    ├── w_idx: filters
+      │    │    │    │    │    └── w:15 > 1
+      │    │    │    │    ├── b_w_idx: filters
+      │    │    │    │    │    └── w:15 > 3
+      │    │    │    │    ├── d_idx: filters
+      │    │    │    │    │    └── d:16 > 2
+      │    │    │    │    └── b_d_idx: filters
+      │    │    │    │         └── d:16 > 4
+      │    │    │    └── flags: disabled not visible index feature
+      │    │    └── filters
+      │    │         └── column1:8 = a:12
+      │    └── projections
+      │         └── CASE WHEN a:12 IS NULL THEN column1:8 ELSE a:12 END [as=upsert_a:19]
+      └── projections
+           ├── w_default:11 > 1 [as=partial_index_put1:20]
+           ├── w:15 > 1 [as=partial_index_del1:21]
+           ├── w_default:11 > 3 [as=partial_index_put2:22]
+           ├── w:15 > 3 [as=partial_index_del2:23]
+           ├── false [as=partial_index_put3:24]
+           ├── d:16 > 2 [as=partial_index_del3:25]
+           └── d:16 > 4 [as=partial_index_del4:26]

--- a/pkg/sql/opt/optbuilder/testdata/partial-indexes
+++ b/pkg/sql/opt/optbuilder/testdata/partial-indexes
@@ -110,7 +110,7 @@ insert partial_indexes
            ├── column3:8 = 'foo' [as=partial_index_put1:9]
            ├── (column1:6 > column2:7) AND (column3:8 = 'bar') [as=partial_index_put2:10]
            ├── column3:8 = 'write-only' [as=partial_index_put3:11]
-           └── column3:8 = 'delete-only' [as=partial_index_put4:12]
+           └── false [as=partial_index_put4:12]
 
 # Do not error with "column reference is ambiguous" when table column names
 # match synthesized column names.
@@ -292,9 +292,9 @@ update partial_indexes
  ├── update-mapping:
  │    └── a_new:11 => a:1
  ├── partial index put columns: partial_index_put1:12 partial_index_put2:13 partial_index_put3:15 partial_index_put4:16
- ├── partial index del columns: partial_index_put1:12 partial_index_del2:14 partial_index_put3:15 partial_index_put4:16
+ ├── partial index del columns: partial_index_put1:12 partial_index_del2:14 partial_index_put3:15 partial_index_del4:17
  └── project
-      ├── columns: partial_index_put1:12 partial_index_put2:13 partial_index_del2:14 partial_index_put3:15 partial_index_put4:16 a:6!null b:7 c:8 crdb_internal_mvcc_timestamp:9 tableoid:10 a_new:11!null
+      ├── columns: partial_index_put1:12 partial_index_put2:13 partial_index_del2:14 partial_index_put3:15 partial_index_put4:16!null partial_index_del4:17 a:6!null b:7 c:8 crdb_internal_mvcc_timestamp:9 tableoid:10 a_new:11!null
       ├── project
       │    ├── columns: a_new:11!null a:6!null b:7 c:8 crdb_internal_mvcc_timestamp:9 tableoid:10
       │    ├── scan partial_indexes
@@ -315,7 +315,8 @@ update partial_indexes
            ├── (a_new:11 > b:7) AND (c:8 = 'bar') [as=partial_index_put2:13]
            ├── (a:6 > b:7) AND (c:8 = 'bar') [as=partial_index_del2:14]
            ├── c:8 = 'write-only' [as=partial_index_put3:15]
-           └── c:8 = 'delete-only' [as=partial_index_put4:16]
+           ├── false [as=partial_index_put4:16]
+           └── c:8 = 'delete-only' [as=partial_index_del4:17]
 
 build
 UPDATE partial_indexes SET a = a + 5 RETURNING *
@@ -330,9 +331,9 @@ update partial_indexes
  │    ├── b:7 => b:2
  │    └── c:8 => c:3
  ├── partial index put columns: partial_index_put1:12 partial_index_put2:13 partial_index_put3:15 partial_index_put4:16
- ├── partial index del columns: partial_index_put1:12 partial_index_del2:14 partial_index_put3:15 partial_index_put4:16
+ ├── partial index del columns: partial_index_put1:12 partial_index_del2:14 partial_index_put3:15 partial_index_del4:17
  └── project
-      ├── columns: partial_index_put1:12 partial_index_put2:13 partial_index_del2:14 partial_index_put3:15 partial_index_put4:16 a:6!null b:7 c:8 crdb_internal_mvcc_timestamp:9 tableoid:10 a_new:11!null
+      ├── columns: partial_index_put1:12 partial_index_put2:13 partial_index_del2:14 partial_index_put3:15 partial_index_put4:16!null partial_index_del4:17 a:6!null b:7 c:8 crdb_internal_mvcc_timestamp:9 tableoid:10 a_new:11!null
       ├── project
       │    ├── columns: a_new:11!null a:6!null b:7 c:8 crdb_internal_mvcc_timestamp:9 tableoid:10
       │    ├── scan partial_indexes
@@ -353,7 +354,8 @@ update partial_indexes
            ├── (a_new:11 > b:7) AND (c:8 = 'bar') [as=partial_index_put2:13]
            ├── (a:6 > b:7) AND (c:8 = 'bar') [as=partial_index_del2:14]
            ├── c:8 = 'write-only' [as=partial_index_put3:15]
-           └── c:8 = 'delete-only' [as=partial_index_put4:16]
+           ├── false [as=partial_index_put4:16]
+           └── c:8 = 'delete-only' [as=partial_index_del4:17]
 
 build
 UPDATE partial_indexes SET a = v.a FROM (VALUES (1), (2)) AS v(a) WHERE partial_indexes.a = v.a
@@ -365,9 +367,9 @@ update partial_indexes
  ├── update-mapping:
  │    └── column1:11 => a:1
  ├── partial index put columns: partial_index_put1:12 partial_index_put2:13 partial_index_put3:15 partial_index_put4:16
- ├── partial index del columns: partial_index_put1:12 partial_index_del2:14 partial_index_put3:15 partial_index_put4:16
+ ├── partial index del columns: partial_index_put1:12 partial_index_del2:14 partial_index_put3:15 partial_index_del4:17
  └── project
-      ├── columns: partial_index_put1:12 partial_index_put2:13 partial_index_del2:14 partial_index_put3:15 partial_index_put4:16 a:6!null b:7 c:8 crdb_internal_mvcc_timestamp:9 tableoid:10 column1:11!null
+      ├── columns: partial_index_put1:12 partial_index_put2:13 partial_index_del2:14 partial_index_put3:15 partial_index_put4:16!null partial_index_del4:17 a:6!null b:7 c:8 crdb_internal_mvcc_timestamp:9 tableoid:10 column1:11!null
       ├── distinct-on
       │    ├── columns: a:6!null b:7 c:8 crdb_internal_mvcc_timestamp:9 tableoid:10 column1:11!null
       │    ├── grouping columns: a:6!null
@@ -409,7 +411,8 @@ update partial_indexes
            ├── (column1:11 > b:7) AND (c:8 = 'bar') [as=partial_index_put2:13]
            ├── (a:6 > b:7) AND (c:8 = 'bar') [as=partial_index_del2:14]
            ├── c:8 = 'write-only' [as=partial_index_put3:15]
-           └── c:8 = 'delete-only' [as=partial_index_put4:16]
+           ├── false [as=partial_index_put4:16]
+           └── c:8 = 'delete-only' [as=partial_index_del4:17]
 
 # Do not error with "column reference is ambiguous" when table column names
 # match synthesized column names.
@@ -676,7 +679,7 @@ insert partial_indexes
            ├── column3:8 = 'foo' [as=partial_index_put1:19]
            ├── (column1:6 > column2:7) AND (column3:8 = 'bar') [as=partial_index_put2:20]
            ├── column3:8 = 'write-only' [as=partial_index_put3:21]
-           └── column3:8 = 'delete-only' [as=partial_index_put4:22]
+           └── false [as=partial_index_put4:22]
 
 build
 INSERT INTO partial_indexes VALUES (2, 1, 'bar') ON CONFLICT (b, c) DO UPDATE SET b = partial_indexes.b + 1, c = 'baz'
@@ -741,7 +744,7 @@ upsert partial_indexes
            ├── (a:9 > b:10) AND (c:11 = 'bar') [as=partial_index_del2:22]
            ├── upsert_c:18 = 'write-only' [as=partial_index_put3:23]
            ├── c:11 = 'write-only' [as=partial_index_del3:24]
-           ├── upsert_c:18 = 'delete-only' [as=partial_index_put4:25]
+           ├── false [as=partial_index_put4:25]
            └── c:11 = 'delete-only' [as=partial_index_del4:26]
 
 build
@@ -801,7 +804,7 @@ upsert partial_indexes
            ├── (a:9 > b:10) AND (c:11 = 'bar') [as=partial_index_del2:18]
            ├── column3:8 = 'write-only' [as=partial_index_put3:19]
            ├── c:11 = 'write-only' [as=partial_index_del3:20]
-           ├── column3:8 = 'delete-only' [as=partial_index_put4:21]
+           ├── false [as=partial_index_put4:21]
            └── c:11 = 'delete-only' [as=partial_index_del4:22]
 
 # Columns referenced in the SET expression are ambiguous without a table name.
@@ -1695,7 +1698,7 @@ insert comp
       │              └── first-agg [as=e_comp:12]
       │                   └── e_comp:12
       └── projections
-           ├── d_comp:11 = 'foo' [as=partial_index_put1:29]
+           ├── lower(column3:10) = 'foo' [as=partial_index_put1:29]
            ├── e_comp:12 = 'FOO' [as=partial_index_put2:30]
            └── e_comp:12 = 'bar' [as=partial_index_put4:31]
 
@@ -1775,7 +1778,7 @@ insert comp
       │         └── first-agg [as=e_comp:12]
       │              └── e_comp:12
       └── projections
-           ├── d_comp:11 = 'foo' [as=partial_index_put1:20]
+           ├── lower(column3:10) = 'foo' [as=partial_index_put1:20]
            ├── e_comp:12 = 'FOO' [as=partial_index_put2:21]
            └── e_comp:12 = 'bar' [as=partial_index_put4:22]
 
@@ -1889,8 +1892,8 @@ upsert comp
       │         ├── CASE WHEN a:14 IS NULL THEN d_comp:11 ELSE d:17 END [as=upsert_d:27]
       │         └── CASE WHEN a:14 IS NULL THEN e_comp:12 ELSE e:18 END [as=upsert_e:28]
       └── projections
-           ├── upsert_d:27 = 'foo' [as=partial_index_put1:29]
-           ├── d:17 = 'foo' [as=partial_index_del1:30]
+           ├── lower(upsert_c:26) = 'foo' [as=partial_index_put1:29]
+           ├── lower(c:16) = 'foo' [as=partial_index_del1:30]
            ├── upsert_e:28 = 'FOO' [as=partial_index_put2:31]
            ├── e:18 = 'FOO' [as=partial_index_del2:32]
            ├── upsert_e:28 = 'bar' [as=partial_index_put4:33]

--- a/pkg/sql/opt/optbuilder/update.go
+++ b/pkg/sql/opt/optbuilder/update.go
@@ -340,7 +340,7 @@ func (mb *mutationBuilder) buildUpdate(returning *tree.ReturningExprs) {
 	mb.b.addPartialIndexPredicatesForTable(mb.md.TableMeta(mb.tabID), nil /* scan */)
 
 	// Project partial index PUT and DEL boolean columns.
-	mb.projectPartialIndexPutAndDelCols()
+	mb.projectPartialIndexCols(true /* includePutCols */, true /* includeDelCols */)
 
 	mb.buildUniqueChecksForUpdate()
 

--- a/pkg/sql/opt/table_meta.go
+++ b/pkg/sql/opt/table_meta.go
@@ -437,6 +437,12 @@ func (tm *TableMeta) PartialIndexPredicate(ord cat.IndexOrdinal) (pred ScalarExp
 	return pred, true
 }
 
+// PartialIndexPredicatesAdded returns true if partial index predicates have
+// already been added to the table metadata.
+func (tm *TableMeta) PartialIndexPredicatesAdded() bool {
+	return tm.partialIndexPredicates != nil
+}
+
 // PartialIndexPredicatesUnsafe returns the partialIndexPredicates map.
 //
 // WARNING: The returned map is NOT a source-of-truth for determining if an

--- a/pkg/sql/opt/testutils/testcat/create_index.go
+++ b/pkg/sql/opt/testutils/testcat/create_index.go
@@ -23,10 +23,10 @@ func (tc *Catalog) CreateIndex(stmt *tree.CreateIndex, version descpb.IndexDescr
 	tc.qualifyTableName(&tn)
 	tab := tc.Table(&tn)
 
-	for _, idx := range tab.Indexes {
-		in := stmt.Name.String()
-		if idx.IdxName == in {
-			panic(errors.Newf(`relation "%s" already exists`, in))
+	for i, n := 0, tab.DeletableIndexCount(); i < n; i++ {
+		idx := tab.Index(i)
+		if idx.Name() == stmt.Name {
+			panic(errors.Newf(`relation "%s" already exists`, stmt.Name))
 		}
 	}
 

--- a/pkg/sql/opt/testutils/testcat/set_zone_config.go
+++ b/pkg/sql/opt/testutils/testcat/set_zone_config.go
@@ -33,10 +33,10 @@ func (tc *Catalog) SetZoneConfig(stmt *tree.SetZoneConfig) cat.Zone {
 		var index *Index
 		if stmt.TableOrIndex.Index == "" {
 			// This partition is in the primary index.
-			index = tab.Indexes[0]
+			index = tab.indexes[0]
 		} else {
 			// This partition is in a secondary index.
-			for _, idx := range tab.Indexes {
+			for _, idx := range tab.indexes {
 				if idx.IdxName == string(stmt.TableOrIndex.Index) {
 					index = idx
 					break
@@ -60,11 +60,11 @@ func (tc *Catalog) SetZoneConfig(stmt *tree.SetZoneConfig) cat.Zone {
 
 	// Handle special case of primary index.
 	if stmt.TableOrIndex.Index == "" {
-		tab.Indexes[0].IdxZone = makeZoneConfig(stmt.Options)
-		return tab.Indexes[0].IdxZone
+		tab.indexes[0].IdxZone = makeZoneConfig(stmt.Options)
+		return tab.indexes[0].IdxZone
 	}
 
-	for _, idx := range tab.Indexes {
+	for _, idx := range tab.indexes {
 		if idx.IdxName == string(stmt.TableOrIndex.Index) {
 			idx.IdxZone = makeZoneConfig(stmt.Options)
 			return idx.IdxZone

--- a/pkg/sql/opt/testutils/testcat/testdata/index
+++ b/pkg/sql/opt/testutils/testcat/testdata/index
@@ -198,3 +198,107 @@ TABLE t_invisible
  └── INDEX idx_v_invisible NOT VISIBLE
       ├── v int
       └── k int not null
+
+exec-ddl
+CREATE TABLE mutations (
+  p INT,
+  w INT,
+  d INT,
+  INDEX "w1:write-only" (w),
+  INDEX "d1:delete-only" (d),
+  INDEX "w2:write-only" (w),
+  INDEX "d2:delete-only" (d),
+  INDEX p1 (p)
+)
+----
+
+exec-ddl
+CREATE INDEX "w3:write-only" ON mutations(w)
+----
+
+exec-ddl
+CREATE INDEX "d3:delete-only" ON mutations(d)
+----
+
+exec-ddl
+CREATE INDEX p2 ON mutations(p)
+----
+
+# Indexes should be ordered canonically: public, then write-only, then
+# delete-only.
+exec-ddl
+SHOW CREATE mutations
+----
+TABLE mutations
+ ├── p int
+ ├── w int
+ ├── d int
+ ├── rowid int not null default (unique_rowid()) [hidden]
+ ├── crdb_internal_mvcc_timestamp decimal [hidden] [system]
+ ├── tableoid oid [hidden] [system]
+ ├── PRIMARY INDEX mutations_pkey
+ │    └── rowid int not null default (unique_rowid()) [hidden]
+ ├── INDEX p1
+ │    ├── p int
+ │    └── rowid int not null default (unique_rowid()) [hidden]
+ ├── INDEX p2
+ │    ├── p int
+ │    └── rowid int not null default (unique_rowid()) [hidden]
+ ├── INDEX w1 (mutation)
+ │    ├── w int
+ │    └── rowid int not null default (unique_rowid()) [hidden]
+ ├── INDEX w2 (mutation)
+ │    ├── w int
+ │    └── rowid int not null default (unique_rowid()) [hidden]
+ ├── INDEX w3 (mutation)
+ │    ├── w int
+ │    └── rowid int not null default (unique_rowid()) [hidden]
+ ├── INDEX d1 (mutation)
+ │    ├── d int
+ │    └── rowid int not null default (unique_rowid()) [hidden]
+ ├── INDEX d2 (mutation)
+ │    ├── d int
+ │    └── rowid int not null default (unique_rowid()) [hidden]
+ └── INDEX d3 (mutation)
+      ├── d int
+      └── rowid int not null default (unique_rowid()) [hidden]
+
+exec-ddl
+DROP INDEX p2
+----
+
+exec-ddl
+DROP INDEX w2
+----
+
+exec-ddl
+DROP INDEX d2
+----
+
+exec-ddl
+SHOW CREATE mutations
+----
+TABLE mutations
+ ├── p int
+ ├── w int
+ ├── d int
+ ├── rowid int not null default (unique_rowid()) [hidden]
+ ├── crdb_internal_mvcc_timestamp decimal [hidden] [system]
+ ├── tableoid oid [hidden] [system]
+ ├── PRIMARY INDEX mutations_pkey
+ │    └── rowid int not null default (unique_rowid()) [hidden]
+ ├── INDEX p1
+ │    ├── p int
+ │    └── rowid int not null default (unique_rowid()) [hidden]
+ ├── INDEX w1 (mutation)
+ │    ├── w int
+ │    └── rowid int not null default (unique_rowid()) [hidden]
+ ├── INDEX w3 (mutation)
+ │    ├── w int
+ │    └── rowid int not null default (unique_rowid()) [hidden]
+ ├── INDEX d1 (mutation)
+ │    ├── d int
+ │    └── rowid int not null default (unique_rowid()) [hidden]
+ └── INDEX d3 (mutation)
+      ├── d int
+      └── rowid int not null default (unique_rowid()) [hidden]

--- a/pkg/sql/opt/xform/testdata/rules/select
+++ b/pkg/sql/opt/xform/testdata/rules/select
@@ -5862,7 +5862,7 @@ CREATE INVERTED INDEX idx2 ON pi (j) WHERE s = 'bar'
 memo expect=GenerateInvertedIndexScans
 SELECT * FROM pi WHERE j @> '{"a": "b"}' AND s = 'bar'
 ----
-memo (optimized, ~13KB, required=[presentation: k:1,s:2,j:3])
+memo (optimized, ~15KB, required=[presentation: k:1,s:2,j:3])
  ├── G1: (select G2 G3) (select G4 G5) (index-join G6 pi,cols=(1-3))
  │    └── [presentation: k:1,s:2,j:3]
  │         ├── best: (index-join G6 pi,cols=(1-3))
@@ -5910,7 +5910,7 @@ CREATE INVERTED INDEX idx ON pi (j) WHERE s IN ('foo', 'bar')
 memo expect-not=GenerateInvertedIndexScans
 SELECT * FROM pi WHERE j @> '{"a": "b"}' AND s = 'baz'
 ----
-memo (optimized, ~8KB, required=[presentation: k:1,s:2,j:3])
+memo (optimized, ~9KB, required=[presentation: k:1,s:2,j:3])
  ├── G1: (select G2 G3)
  │    └── [presentation: k:1,s:2,j:3]
  │         ├── best: (select G2 G3)


### PR DESCRIPTION
#### testcat: order indexes canonically

This commit fixes a minor inconsistency in the test catalog where
indexes were not canonically ordered, i.e., public indexes before
write-only indexes before delete-only indexes.

Release note: None

#### opt: build partial index PUT and DEL columns from table metadata predicates

Mutations on tables with partial indexes use two synthesized boolean
columns per partial index, known as PUT and DEL columns, to indicate to
the execution machinery when a row mutation must insert or delete an
entry in a partial index (see `mutationBuilder.partialIndexPutColIDs`
and `mutationBuilder.partialIndexDelColIDs` for more details). In order
to build partial index PUT and DEL columns, the optbuilder must resolve
columns in partial index predicates to the correct versions of those
columns within an optimizer expression. For example, consider the
schema, query, and query plan:

    CREATE TABLE t (a INT, INDEX (a) WHERE a > 0);

    UPDATE t SET a = 10;

    update t
     ├── fetch columns: a:5 rowid:6
     ├── update-mapping:
     │    └── a_new:9 => a:1
     ├── partial index put columns: partial_index_put1:10
     ├── partial index del columns: partial_index_del1:11
     └── project
          ├── columns: partial_index_put1:10 partial_index_del1:11 a_new:9 a:5 rowid:6
          ├── scan t
          │    └── columns: a:5 rowid:6
          └── projections
               ├── true [as=partial_index_put1:10]
               ├── a:5 > 0 [as=partial_index_del1:11]
               └── 10 [as=a_new:9]

The column `a` in the partial index predicate `a > 0` has to be resolved
to a column representing the old value of `a`, `a:5`, for the DEL column
projection. Separately, it has to be resolved to a column representing
the new value of `a`, `a_new:9`, for the PUT column projection.

Previously, the optbuilder relied on different scopes to resolve these
columns correctly. This was fragile and it did not support resolving
columns to mutation columns (e.g., delete-only columns), causing bugs
(see #96924).

Now, the optbuilder builds partial index predicates by resolving columns
to the target table's column IDs. These predicates are stored in the
table metadata, and reused for building PUT and DEL column projections
by replacing the target table column IDs in the expression with columns
representing the new and old values of those columns in the optimizer
expression.

Fixes #61298

Release note: None

#### opt: resolve delete-only columns in partial index predicates

When a column is dropped, any indexes referencing the column are
simultaneously dropped. Thus, it's possible for a delete-only index to
reference a delete-only column. Prior to this commit, the optimizer
would panic in this case, because it did not resolve delete-only columns
while building partial indexes predicates (which must be built for
delete-only indexes). Now, the optimizer can resolve any columns of the
table while building predicates, and an error not longer occurs.

Informs #79613
Fixes #96924

Release note (bug fix): A bug has been fixed that caused internal errors
when querying a table after dropping a column. The bug was only present
if the table included a partial index with a predicate referencing the
dropped column. The bug was present since partial indexes were added in
version 20.2.
