### PR TITLE
sql: disallow dropping column referenced in partial index predicate

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/partial_index
+++ b/pkg/sql/logictest/testdata/logic_test/partial_index
@@ -186,7 +186,8 @@ CREATE TABLE t8 (
     FAMILY (a, b, c)
 )
 
-statement ok
+# TODO(mgartner): Lift this restriction. See #96924.
+statement error column "c" cannot be dropped because it is referenced by partial index "t8_a_idx1"
 ALTER TABLE t8 DROP COLUMN c
 
 query TT
@@ -195,10 +196,12 @@ SHOW CREATE TABLE t8
 t8  CREATE TABLE public.t8 (
       a INT8 NULL,
       b INT8 NULL,
+      c STRING NULL,
       rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
       CONSTRAINT t8_pkey PRIMARY KEY (rowid ASC),
       INDEX t8_a_idx (a ASC) WHERE b > 0:::INT8,
-      FAMILY fam_0_a_b_c_rowid (a, b, rowid)
+      INDEX t8_a_idx1 (a ASC) WHERE c = 'foo':::STRING,
+      FAMILY fam_0_a_b_c_rowid (a, b, c, rowid)
     )
 
 # CREATE TABLE LIKE ... INCLUDING INDEXES copies partial index predicate
@@ -1911,3 +1914,123 @@ BEGIN;
 COMMIT;
 SELECT * FROM t79613;
 DROP TABLE t79613;
+
+# Regression test for #96924 to disallow dropping a column that is referenced in
+# a partial index predicate.
+subtest column_dropped_referenced_in_partial_index
+
+statement ok
+SET experimental_enable_unique_without_index_constraints = true
+
+statement ok
+CREATE TABLE t96924 (
+  a INT,
+  b INT,
+  c INT,
+  d INT,
+  e INT,
+  f JSON,
+  g INT,
+  h INT,
+  i INT,
+  INDEX (a) WHERE (b > 0),
+  UNIQUE INDEX (b) WHERE (b > 0),
+  UNIQUE (c) WHERE (c > 0),
+  UNIQUE WITHOUT INDEX (d) WHERE (d > 0),
+  INVERTED INDEX (e, f) WHERE (e > 0),
+  INDEX (g) WHERE (h > 0),
+  UNIQUE WITHOUT INDEX (g) WHERE (i > 0)
+)
+
+# Column `a` can be dropped because it is not referenced in any partial index
+# predicates.
+statement ok
+ALTER TABLE t96924 DROP COLUMN a
+
+statement error pq: column "b" cannot be dropped because it is referenced by partial index "t96924_b_key"
+ALTER TABLE t96924 DROP COLUMN b
+
+statement ok
+DROP INDEX t96924_b_key CASCADE
+
+statement ok
+ALTER TABLE t96924 DROP COLUMN b
+
+statement error pq: column "c" cannot be dropped because it is referenced by partial index "t96924_c_key"
+ALTER TABLE t96924 DROP COLUMN c
+
+statement ok
+DROP INDEX t96924_c_key CASCADE
+
+statement ok
+ALTER TABLE t96924 DROP COLUMN c
+
+statement error pq: column "d" cannot be dropped because it is referenced by partial unique constraint "unique_d"
+ALTER TABLE t96924 DROP COLUMN d
+
+statement ok
+ALTER TABLE t96924 DROP CONSTRAINT unique_d
+
+statement ok
+ALTER TABLE t96924 DROP COLUMN d
+
+statement error pq: column "e" cannot be dropped because it is referenced by partial index "t96924_e_f_idx"
+ALTER TABLE t96924 DROP COLUMN e
+
+statement ok
+DROP INDEX t96924_e_f_idx CASCADE
+
+statement ok
+ALTER TABLE t96924 DROP COLUMN e
+
+# Column `f` can be dropped because it is not referenced in any partial index
+# predicates.
+statement ok
+ALTER TABLE t96924 DROP COLUMN f
+
+# Column `h` is used in the predicate of another index that does not key on `h`,
+# we will prevent dropping column `h` as well.
+statement error pq: column "h" cannot be dropped because it is referenced by partial index "t96924_g_idx"
+ALTER TABLE t96924 DROP COLUMN h
+
+statement ok
+DROP INDEX t96924_g_idx
+
+statement ok
+ALTER TABLE t96924 DROP COLUMN h
+
+# Similarly, column `i` cannot be dropped since it's used in the predicate of
+# of a UWI constraint.
+statement error pq: column "i" cannot be dropped because it is referenced by partial unique constraint "unique_g"
+ALTER TABLE t96924 DROP COLUMN i
+
+statement ok
+ALTER TABLE t96924 DROP CONSTRAINT unique_g
+
+statement ok
+ALTER TABLE t96924 DROP COLUMN i
+
+statement ok
+ALTER TABLE t96924 DROP COLUMN g
+
+# Another edge case where ALTER PRIMARY KEY implicit drops the `rowid` column
+# yet `rowid` is referenced in a partial index. Note that this behavior is
+# only in the declarative schema changer but not in the legacy schema changer.
+statement ok
+DROP TABLE t96924
+
+statement ok
+CREATE TABLE t96924 (a INT NOT NULL)
+
+statement ok
+CREATE INDEX t96924_idx_1 ON t96924(a) WHERE (rowid > 0);
+
+skipif config local-legacy-schema-changer
+statement error column "rowid" cannot be dropped because it is referenced by partial index "t96924_idx_1"
+ALTER TABLE t96924 ALTER PRIMARY KEY USING COLUMNS (a);
+
+statement ok
+DROP INDEX t96924_idx_1
+
+statement ok
+ALTER TABLE t96924 ALTER PRIMARY KEY USING COLUMNS (a);

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_table_alter_primary_key.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_table_alter_primary_key.go
@@ -508,6 +508,40 @@ func mustRetrieveKeyIndexColumns(
 	return indexColumns
 }
 
+func mustRetrieveIndexNameElem(
+	b BuildCtx, tableID catid.DescID, indexID catid.IndexID,
+) (indexNameElem *scpb.IndexName) {
+	scpb.ForEachIndexName(b.QueryByID(tableID), func(
+		current scpb.Status, target scpb.TargetStatus, e *scpb.IndexName,
+	) {
+		if e.IndexID == indexID {
+			indexNameElem = e
+		}
+	})
+	if indexNameElem == nil {
+		panic(errors.AssertionFailedf("programming error: cannot find an index name element "+
+			"with ID %v from table %v", indexID, tableID))
+	}
+	return indexNameElem
+}
+
+func mustRetrieveConstraintWithoutIndexNameElem(
+	b BuildCtx, tableID catid.DescID, constraintID catid.ConstraintID,
+) (constraintWithoutIndexName *scpb.ConstraintWithoutIndexName) {
+	scpb.ForEachConstraintWithoutIndexName(b.QueryByID(tableID), func(
+		current scpb.Status, target scpb.TargetStatus, e *scpb.ConstraintWithoutIndexName,
+	) {
+		if e.ConstraintID == constraintID {
+			constraintWithoutIndexName = e
+		}
+	})
+	if constraintWithoutIndexName == nil {
+		panic(errors.AssertionFailedf("programming error: cannot find a constraint name "+
+			"element with ID %v from table %v", constraintID, tableID))
+	}
+	return constraintWithoutIndexName
+}
+
 func checkIfConstraintNameAlreadyExists(b BuildCtx, tbl *scpb.Table, t alterPrimaryKeySpec) {
 	if t.Name == "" {
 		return

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_table_drop_column.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_table_drop_column.go
@@ -304,6 +304,10 @@ func walkDropColumnDependencies(b BuildCtx, col *scpb.Column, fn func(e scpb.Ele
 	var indexesToDrop catid.IndexSet
 	var columnsToDrop catalog.TableColSet
 	tblElts := b.QueryByID(col.TableID).Filter(publicTargetFilter)
+	// Panic if `col` is referenced in a predicate of an index or
+	// unique without index constraint.
+	// TODO (xiang): Remove this restriction when #96924 is fixed.
+	panicIfColReferencedInPredicate(b, col, tblElts)
 	tblElts.
 		Filter(referencesColumnIDFilter(col.ColumnID)).
 		ForEachElementStatus(func(_ scpb.Status, _ scpb.TargetStatus, e scpb.Element) {
@@ -323,6 +327,8 @@ func walkDropColumnDependencies(b BuildCtx, col *scpb.Column, fn func(e scpb.Ele
 			case *scpb.SequenceOwner:
 				fn(e)
 				sequencesToDrop.Add(elt.SequenceID)
+			case *scpb.SecondaryIndex:
+				indexesToDrop.Add(elt.IndexID)
 			case *scpb.SecondaryIndexPartial:
 				indexesToDrop.Add(elt.IndexID)
 			case *scpb.IndexColumn:
@@ -350,14 +356,7 @@ func walkDropColumnDependencies(b BuildCtx, col *scpb.Column, fn func(e scpb.Ele
 		case *scpb.SecondaryIndex:
 			if indexesToDrop.Contains(elt.IndexID) {
 				fn(e)
-			} else if elt.EmbeddedExpr != nil {
-				for _, columnID := range elt.EmbeddedExpr.ReferencedColumnIDs {
-					if columnID == col.ColumnID {
-						fn(e)
-					}
-				}
 			}
-
 		}
 	})
 	sequencesToDrop.ForEach(func(id descpb.ID) {
@@ -389,6 +388,56 @@ func walkDropColumnDependencies(b BuildCtx, col *scpb.Column, fn func(e scpb.Ele
 			}
 		}
 	})
+}
+
+// panicIfColReferencedInPredicate is a temporary fix that disallow dropping a
+// column that is referenced in predicate of a partial index or unique without index.
+// This restriction shall be lifted once #96924 is fixed.
+func panicIfColReferencedInPredicate(b BuildCtx, col *scpb.Column, tblElts ElementResultSet) {
+	contains := func(container []catid.ColumnID, target catid.ColumnID) bool {
+		for _, elem := range container {
+			if elem == target {
+				return true
+			}
+		}
+		return false
+	}
+
+	var violatingIndex catid.IndexID
+	var violatingUWI catid.ConstraintID
+	tblElts.ForEachElementStatus(func(_ scpb.Status, _ scpb.TargetStatus, e scpb.Element) {
+		if violatingIndex != 0 || violatingUWI != 0 {
+			return
+		}
+		switch elt := e.(type) {
+		case *scpb.SecondaryIndex:
+			if elt.EmbeddedExpr != nil && contains(elt.EmbeddedExpr.ReferencedColumnIDs, col.ColumnID) {
+				violatingIndex = elt.IndexID
+			}
+		case *scpb.SecondaryIndexPartial:
+			if contains(elt.ReferencedColumnIDs, col.ColumnID) {
+				violatingIndex = elt.IndexID
+			}
+		case *scpb.UniqueWithoutIndexConstraint:
+			if elt.Predicate != nil && contains(elt.Predicate.ReferencedColumnIDs, col.ColumnID) {
+				violatingUWI = elt.ConstraintID
+			}
+		case *scpb.UniqueWithoutIndexConstraintUnvalidated:
+			if elt.Predicate != nil && contains(elt.Predicate.ReferencedColumnIDs, col.ColumnID) {
+				violatingUWI = elt.ConstraintID
+			}
+		}
+	})
+	if violatingIndex != 0 {
+		colNameElem := mustRetrieveColumnNameElem(b, col.TableID, col.ColumnID)
+		indexNameElem := mustRetrieveIndexNameElem(b, col.TableID, violatingIndex)
+		panic(sqlerrors.NewColumnReferencedByPartialIndex(colNameElem.Name, indexNameElem.Name))
+	}
+	if violatingUWI != 0 {
+		colNameElem := mustRetrieveColumnNameElem(b, col.TableID, col.ColumnID)
+		uwiNameElem := mustRetrieveConstraintWithoutIndexNameElem(b, col.TableID, violatingUWI)
+		panic(sqlerrors.NewColumnReferencedByPartialUniqueWithoutIndexConstraint(colNameElem.Name, uwiNameElem.Name))
+	}
 }
 
 func handleDropColumnPrimaryIndexes(

--- a/pkg/sql/schemachanger/scplan/internal/rules/current/dep_drop_column.go
+++ b/pkg/sql/schemachanger/scplan/internal/rules/current/dep_drop_column.go
@@ -158,7 +158,7 @@ func init() {
 		"secondary index partial no longer public before referenced column",
 		scgraph.Precedence,
 		"secondary-partial-index", "column",
-		scpb.Status_DELETE_ONLY, scpb.Status_WRITE_ONLY,
+		scpb.Status_ABSENT, scpb.Status_WRITE_ONLY,
 		func(from, to NodeVars) rel.Clauses {
 			return rel.Clauses{
 				from.Type((*scpb.SecondaryIndexPartial)(nil)),

--- a/pkg/sql/schemachanger/scplan/internal/rules/current/testdata/deprules
+++ b/pkg/sql/schemachanger/scplan/internal/rules/current/testdata/deprules
@@ -3128,7 +3128,7 @@ deprules
     - descriptorIsNotBeingDropped-23.1($secondary-partial-index)
     - secondaryIndexReferencesColumn(*scpb.SecondaryIndexPartial, *scpb.Column)($secondary-partial-index, $column)
     - toAbsent($secondary-partial-index-Target, $column-Target)
-    - $secondary-partial-index-Node[CurrentStatus] = DELETE_ONLY
+    - $secondary-partial-index-Node[CurrentStatus] = ABSENT
     - $column-Node[CurrentStatus] = WRITE_ONLY
     - joinTargetNode($secondary-partial-index, $secondary-partial-index-Target, $secondary-partial-index-Node)
     - joinTargetNode($column, $column-Target, $column-Node)
@@ -3143,7 +3143,7 @@ deprules
     - descriptorIsNotBeingDropped-23.1($secondary-partial-index)
     - secondaryIndexReferencesColumn(*scpb.SecondaryIndexPartial, *scpb.Column)($secondary-partial-index, $column)
     - transient($secondary-partial-index-Target, $column-Target)
-    - $secondary-partial-index-Node[CurrentStatus] = TRANSIENT_DELETE_ONLY
+    - $secondary-partial-index-Node[CurrentStatus] = TRANSIENT_ABSENT
     - $column-Node[CurrentStatus] = TRANSIENT_WRITE_ONLY
     - joinTargetNode($secondary-partial-index, $secondary-partial-index-Target, $secondary-partial-index-Node)
     - joinTargetNode($column, $column-Target, $column-Node)
@@ -3158,7 +3158,7 @@ deprules
     - descriptorIsNotBeingDropped-23.1($secondary-partial-index)
     - secondaryIndexReferencesColumn(*scpb.SecondaryIndexPartial, *scpb.Column)($secondary-partial-index, $column)
     - $secondary-partial-index-Target[TargetStatus] = TRANSIENT_ABSENT
-    - $secondary-partial-index-Node[CurrentStatus] = TRANSIENT_DELETE_ONLY
+    - $secondary-partial-index-Node[CurrentStatus] = TRANSIENT_ABSENT
     - $column-Target[TargetStatus] = ABSENT
     - $column-Node[CurrentStatus] = WRITE_ONLY
     - joinTargetNode($secondary-partial-index, $secondary-partial-index-Target, $secondary-partial-index-Node)
@@ -3174,7 +3174,7 @@ deprules
     - descriptorIsNotBeingDropped-23.1($secondary-partial-index)
     - secondaryIndexReferencesColumn(*scpb.SecondaryIndexPartial, *scpb.Column)($secondary-partial-index, $column)
     - $secondary-partial-index-Target[TargetStatus] = ABSENT
-    - $secondary-partial-index-Node[CurrentStatus] = DELETE_ONLY
+    - $secondary-partial-index-Node[CurrentStatus] = ABSENT
     - $column-Target[TargetStatus] = TRANSIENT_ABSENT
     - $column-Node[CurrentStatus] = TRANSIENT_WRITE_ONLY
     - joinTargetNode($secondary-partial-index, $secondary-partial-index-Target, $secondary-partial-index-Node)
@@ -6462,7 +6462,7 @@ deprules
     - descriptorIsNotBeingDropped-23.1($secondary-partial-index)
     - secondaryIndexReferencesColumn(*scpb.SecondaryIndexPartial, *scpb.Column)($secondary-partial-index, $column)
     - toAbsent($secondary-partial-index-Target, $column-Target)
-    - $secondary-partial-index-Node[CurrentStatus] = DELETE_ONLY
+    - $secondary-partial-index-Node[CurrentStatus] = ABSENT
     - $column-Node[CurrentStatus] = WRITE_ONLY
     - joinTargetNode($secondary-partial-index, $secondary-partial-index-Target, $secondary-partial-index-Node)
     - joinTargetNode($column, $column-Target, $column-Node)
@@ -6477,7 +6477,7 @@ deprules
     - descriptorIsNotBeingDropped-23.1($secondary-partial-index)
     - secondaryIndexReferencesColumn(*scpb.SecondaryIndexPartial, *scpb.Column)($secondary-partial-index, $column)
     - transient($secondary-partial-index-Target, $column-Target)
-    - $secondary-partial-index-Node[CurrentStatus] = TRANSIENT_DELETE_ONLY
+    - $secondary-partial-index-Node[CurrentStatus] = TRANSIENT_ABSENT
     - $column-Node[CurrentStatus] = TRANSIENT_WRITE_ONLY
     - joinTargetNode($secondary-partial-index, $secondary-partial-index-Target, $secondary-partial-index-Node)
     - joinTargetNode($column, $column-Target, $column-Node)
@@ -6492,7 +6492,7 @@ deprules
     - descriptorIsNotBeingDropped-23.1($secondary-partial-index)
     - secondaryIndexReferencesColumn(*scpb.SecondaryIndexPartial, *scpb.Column)($secondary-partial-index, $column)
     - $secondary-partial-index-Target[TargetStatus] = TRANSIENT_ABSENT
-    - $secondary-partial-index-Node[CurrentStatus] = TRANSIENT_DELETE_ONLY
+    - $secondary-partial-index-Node[CurrentStatus] = TRANSIENT_ABSENT
     - $column-Target[TargetStatus] = ABSENT
     - $column-Node[CurrentStatus] = WRITE_ONLY
     - joinTargetNode($secondary-partial-index, $secondary-partial-index-Target, $secondary-partial-index-Node)
@@ -6508,7 +6508,7 @@ deprules
     - descriptorIsNotBeingDropped-23.1($secondary-partial-index)
     - secondaryIndexReferencesColumn(*scpb.SecondaryIndexPartial, *scpb.Column)($secondary-partial-index, $column)
     - $secondary-partial-index-Target[TargetStatus] = ABSENT
-    - $secondary-partial-index-Node[CurrentStatus] = DELETE_ONLY
+    - $secondary-partial-index-Node[CurrentStatus] = ABSENT
     - $column-Target[TargetStatus] = TRANSIENT_ABSENT
     - $column-Node[CurrentStatus] = TRANSIENT_WRITE_ONLY
     - joinTargetNode($secondary-partial-index, $secondary-partial-index-Target, $secondary-partial-index-Node)

--- a/pkg/sql/schemachanger/testdata/end_to_end/drop_column_with_partial_index
+++ b/pkg/sql/schemachanger/testdata/end_to_end/drop_column_with_partial_index
@@ -1,5 +1,8 @@
+# Note that we changed the index's predicate to not contain `j` because we've
+# temporarily disabled dropping a column that's used in a index's predicate.
+# We'll lift this restriction once #96924 is fixed.
 setup
-CREATE TABLE t (i INT PRIMARY KEY, j INT, INDEX (j) WHERE j >=0)
+CREATE TABLE t (i INT PRIMARY KEY, j INT, INDEX (j) WHERE i >=0)
 ----
 ...
 +object {100 101 t} -> 104
@@ -46,9 +49,27 @@ write *eventpb.AlterTable to event log:
     tag: ALTER TABLE
     user: root
   tableName: defaultdb.public.t
-## StatementPhase stage 1 of 1 with 5 MutationType ops
+## StatementPhase stage 1 of 1 with 7 MutationType ops
 upsert descriptor #104
   ...
+         oid: 20
+         width: 64
+  -  - id: 2
+  -    name: j
+  -    nullable: true
+  -    type:
+  -      family: IntFamily
+  -      oid: 20
+  -      width: 64
+     createAsOfTime:
+       wallTime: "1640995200000000000"
+  ...
+       columnNames:
+       - i
+  -    - j
+  +    - crdb_internal_column_2_name_placeholder
+       defaultColumnId: 2
+       name: primary
      formatVersion: 3
      id: 104
   -  indexes:
@@ -67,7 +88,7 @@ upsert descriptor #104
   -    - 1
   -    name: t_j_idx
   -    partitioning: {}
-  -    predicate: j >= 0:::INT8
+  -    predicate: i >= 0:::INT8
   -    sharded: {}
   -    version: 3
   +  indexes: []
@@ -85,12 +106,12 @@ upsert descriptor #104
   +      keyColumnIds:
   +      - 2
   +      keyColumnNames:
-  +      - j
+  +      - crdb_internal_column_2_name_placeholder
   +      keySuffixColumnIds:
   +      - 1
   +      name: t_j_idx
   +      partitioning: {}
-  +      predicate: j >= 0:::INT8
+  +      predicate: i >= 0:::INT8
   +      sharded: {}
   +      version: 3
   +    mutationId: 1
@@ -142,6 +163,17 @@ upsert descriptor #104
   +      version: 4
   +    mutationId: 1
   +    state: DELETE_ONLY
+  +  - column:
+  +      id: 2
+  +      name: crdb_internal_column_2_name_placeholder
+  +      nullable: true
+  +      type:
+  +        family: IntFamily
+  +        oid: 20
+  +        width: 64
+  +    direction: DROP
+  +    mutationId: 1
+  +    state: WRITE_ONLY
      name: t
      nextColumnId: 3
   -  nextConstraintId: 2
@@ -152,6 +184,13 @@ upsert descriptor #104
      nextMutationId: 1
      parentId: 100
   ...
+       - 2
+       storeColumnNames:
+  -    - j
+  +    - crdb_internal_column_2_name_placeholder
+       unique: true
+       version: 4
+  ...
        time: {}
      unexposedParentSchemaId: 101
   -  version: "1"
@@ -161,9 +200,18 @@ upsert descriptor #104
 ## PreCommitPhase stage 1 of 2 with 1 MutationType op
 undo all catalog changes within txn #1
 persist all catalog changes to storage
-## PreCommitPhase stage 2 of 2 with 9 MutationType ops
+## PreCommitPhase stage 2 of 2 with 11 MutationType ops
 upsert descriptor #104
   ...
+         oid: 20
+         width: 64
+  -  - id: 2
+  -    name: j
+  -    nullable: true
+  -    type:
+  -      family: IntFamily
+  -      oid: 20
+  -      width: 64
      createAsOfTime:
        wallTime: "1640995200000000000"
   +  declarativeSchemaChangerState:
@@ -182,6 +230,12 @@ upsert descriptor #104
      families:
      - columnIds:
   ...
+       columnNames:
+       - i
+  -    - j
+  +    - crdb_internal_column_2_name_placeholder
+       defaultColumnId: 2
+       name: primary
      formatVersion: 3
      id: 104
   -  indexes:
@@ -200,7 +254,7 @@ upsert descriptor #104
   -    - 1
   -    name: t_j_idx
   -    partitioning: {}
-  -    predicate: j >= 0:::INT8
+  -    predicate: i >= 0:::INT8
   -    sharded: {}
   -    version: 3
   +  indexes: []
@@ -218,12 +272,12 @@ upsert descriptor #104
   +      keyColumnIds:
   +      - 2
   +      keyColumnNames:
-  +      - j
+  +      - crdb_internal_column_2_name_placeholder
   +      keySuffixColumnIds:
   +      - 1
   +      name: t_j_idx
   +      partitioning: {}
-  +      predicate: j >= 0:::INT8
+  +      predicate: i >= 0:::INT8
   +      sharded: {}
   +      version: 3
   +    mutationId: 1
@@ -275,6 +329,17 @@ upsert descriptor #104
   +      version: 4
   +    mutationId: 1
   +    state: DELETE_ONLY
+  +  - column:
+  +      id: 2
+  +      name: crdb_internal_column_2_name_placeholder
+  +      nullable: true
+  +      type:
+  +        family: IntFamily
+  +        oid: 20
+  +        width: 64
+  +    direction: DROP
+  +    mutationId: 1
+  +    state: WRITE_ONLY
      name: t
      nextColumnId: 3
   -  nextConstraintId: 2
@@ -284,6 +349,13 @@ upsert descriptor #104
   +  nextIndexId: 5
      nextMutationId: 1
      parentId: 100
+  ...
+       - 2
+       storeColumnNames:
+  -    - j
+  +    - crdb_internal_column_2_name_placeholder
+       unique: true
+       version: 4
   ...
        time: {}
      unexposedParentSchemaId: 101
@@ -306,8 +378,8 @@ upsert descriptor #104
        mutationId: 1
   -    state: DELETE_ONLY
   +    state: WRITE_ONLY
-     name: t
-     nextColumnId: 3
+     - column:
+         id: 2
   ...
        time: {}
      unexposedParentSchemaId: 101
@@ -383,20 +455,8 @@ begin transaction #9
 validate forward indexes [3] in table #104
 commit transaction #9
 begin transaction #10
-## PostCommitNonRevertiblePhase stage 1 of 3 with 15 MutationType ops
+## PostCommitNonRevertiblePhase stage 1 of 3 with 14 MutationType ops
 upsert descriptor #104
-  ...
-         oid: 20
-         width: 64
-  -  - id: 2
-  -    name: j
-  -    nullable: true
-  -    type:
-  -      family: IntFamily
-  -      oid: 20
-  -      width: 64
-     createAsOfTime:
-       wallTime: "1640995200000000000"
   ...
            statement: ALTER TABLE t DROP COLUMN j
            statementTag: ALTER TABLE
@@ -404,23 +464,12 @@ upsert descriptor #104
        targetRanks: <redacted>
        targets: <redacted>
   ...
-       columnNames:
-       - i
-  -    - j
-  +    - crdb_internal_column_2_name_placeholder
-       defaultColumnId: 2
-       name: primary
-  ...
-         - 2
-         keyColumnNames:
-  -      - j
-  +      - crdb_internal_column_2_name_placeholder
          keySuffixColumnIds:
          - 1
   -      name: t_j_idx
   +      name: crdb_internal_index_2_name_placeholder
          partitioning: {}
-  -      predicate: j >= 0:::INT8
+  -      predicate: i >= 0:::INT8
          sharded: {}
          version: 3
        mutationId: 1
@@ -454,6 +503,17 @@ upsert descriptor #104
   -    state: WRITE_ONLY
   -  - direction: ADD
   +    state: DELETE_ONLY
+  +  - column:
+  +      id: 2
+  +      name: crdb_internal_column_2_name_placeholder
+  +      nullable: true
+  +      type:
+  +        family: IntFamily
+  +        oid: 20
+  +        width: 64
+  +    direction: DROP
+  +    mutationId: 1
+  +    state: DELETE_ONLY
   +  - direction: DROP
        index:
   -      constraintId: 3
@@ -484,17 +544,17 @@ upsert descriptor #104
          version: 4
        mutationId: 1
        state: WRITE_ONLY
-  +  - column:
-  +      id: 2
-  +      name: crdb_internal_column_2_name_placeholder
-  +      nullable: true
-  +      type:
-  +        family: IntFamily
-  +        oid: 20
-  +        width: 64
-  +    direction: DROP
-  +    mutationId: 1
-  +    state: WRITE_ONLY
+  -  - column:
+  -      id: 2
+  -      name: crdb_internal_column_2_name_placeholder
+  -      nullable: true
+  -      type:
+  -        family: IntFamily
+  -        oid: 20
+  -        width: 64
+  -    direction: DROP
+  -    mutationId: 1
+  -    state: WRITE_ONLY
      name: t
      nextColumnId: 3
   ...
@@ -517,7 +577,7 @@ upsert descriptor #104
   -    storeColumnIds:
   -    - 2
   -    storeColumnNames:
-  -    - j
+  -    - crdb_internal_column_2_name_placeholder
   +    storeColumnNames: []
        unique: true
        version: 4
@@ -527,15 +587,17 @@ upsert descriptor #104
   -  version: "6"
   +  version: "7"
 persist all catalog changes to storage
-update progress of schema change job #1: "PostCommitNonRevertiblePhase stage 2 of 3 with 6 MutationType ops pending"
+update progress of schema change job #1: "PostCommitNonRevertiblePhase stage 2 of 3 with 5 MutationType ops pending"
 set schema change job #1 to non-cancellable
 commit transaction #10
 begin transaction #11
-## PostCommitNonRevertiblePhase stage 2 of 3 with 8 MutationType ops
+## PostCommitNonRevertiblePhase stage 2 of 3 with 7 MutationType ops
 upsert descriptor #104
   ...
-     - direction: DROP
-       index:
+     modificationTime: {}
+     mutations:
+  -  - direction: DROP
+  -    index:
   -      createdAtNanos: "1640995200000000000"
   -      foreignKey: {}
   -      geoConfig: {}
@@ -579,19 +641,10 @@ upsert descriptor #104
   -      version: 4
   -    mutationId: 1
   -    state: DELETE_ONLY
-  -  - direction: DROP
-  -    index:
-         constraintId: 1
-         createdAtNanos: "1640995200000000000"
-  ...
-         version: 4
-       mutationId: 1
-  -    state: WRITE_ONLY
-  +    state: DELETE_ONLY
      - column:
          id: 2
   ...
-       direction: DROP
+         version: 4
        mutationId: 1
   -    state: WRITE_ONLY
   +    state: DELETE_ONLY
@@ -636,6 +689,17 @@ upsert descriptor #104
      indexes: []
      modificationTime: {}
   -  mutations:
+  -  - column:
+  -      id: 2
+  -      name: crdb_internal_column_2_name_placeholder
+  -      nullable: true
+  -      type:
+  -        family: IntFamily
+  -        oid: 20
+  -        width: 64
+  -    direction: DROP
+  -    mutationId: 1
+  -    state: DELETE_ONLY
   -  - direction: DROP
   -    index:
   -      constraintId: 1
@@ -660,17 +724,6 @@ upsert descriptor #104
   -      - crdb_internal_column_2_name_placeholder
   -      unique: true
   -      version: 4
-  -    mutationId: 1
-  -    state: DELETE_ONLY
-  -  - column:
-  -      id: 2
-  -      name: crdb_internal_column_2_name_placeholder
-  -      nullable: true
-  -      type:
-  -        family: IntFamily
-  -        oid: 20
-  -        width: 64
-  -    direction: DROP
   -    mutationId: 1
   -    state: DELETE_ONLY
   +  mutations: []

--- a/pkg/sql/schemachanger/testdata/explain/drop_column_with_partial_index
+++ b/pkg/sql/schemachanger/testdata/explain/drop_column_with_partial_index
@@ -1,5 +1,5 @@
 /* setup */
-CREATE TABLE t (i INT PRIMARY KEY, j INT, INDEX (j) WHERE j >=0);
+CREATE TABLE t (i INT PRIMARY KEY, j INT, INDEX (j) WHERE i >=0);
 
 /* test */
 EXPLAIN (ddl) ALTER TABLE t DROP COLUMN j;
@@ -14,14 +14,18 @@ Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› DROP COL
  │         ├── 2 elements transitioning toward TRANSIENT_ABSENT
  │         │    ├── ABSENT → DELETE_ONLY   TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
  │         │    └── ABSENT → PUBLIC        IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
- │         ├── 1 element transitioning toward ABSENT
+ │         ├── 3 elements transitioning toward ABSENT
+ │         │    ├── PUBLIC → WRITE_ONLY    Column:{DescID: 104, ColumnID: 2}
+ │         │    ├── PUBLIC → ABSENT        ColumnName:{DescID: 104, Name: j, ColumnID: 2}
  │         │    └── PUBLIC → VALIDATED     SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 0}
- │         └── 5 Mutation operations
+ │         └── 7 Mutation operations
  │              ├── MakePublicSecondaryIndexWriteOnly {"IndexID":2,"TableID":104}
  │              ├── MakeAbsentIndexBackfilling {"Index":{"ConstraintID":2,"IndexID":3,"IsUnique":true,"SourceIndexID":1,"TableID":104,"TemporaryIndexID":4}}
  │              ├── AddColumnToIndex {"ColumnID":1,"IndexID":3,"TableID":104}
  │              ├── MakeAbsentTempIndexDeleteOnly {"Index":{"ConstraintID":3,"IndexID":4,"IsUnique":true,"SourceIndexID":1,"TableID":104}}
- │              └── AddColumnToIndex {"ColumnID":1,"IndexID":4,"TableID":104}
+ │              ├── AddColumnToIndex {"ColumnID":1,"IndexID":4,"TableID":104}
+ │              ├── MakePublicColumnWriteOnly {"ColumnID":2,"TableID":104}
+ │              └── SetColumnName {"ColumnID":2,"Name":"crdb_internal_co...","TableID":104}
  ├── PreCommitPhase
  │    ├── Stage 1 of 2 in PreCommitPhase
  │    │    ├── 3 elements transitioning toward PUBLIC
@@ -31,7 +35,9 @@ Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› DROP COL
  │    │    ├── 2 elements transitioning toward TRANSIENT_ABSENT
  │    │    │    ├── DELETE_ONLY   → ABSENT TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
  │    │    │    └── PUBLIC        → ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
- │    │    ├── 1 element transitioning toward ABSENT
+ │    │    ├── 3 elements transitioning toward ABSENT
+ │    │    │    ├── WRITE_ONLY    → PUBLIC Column:{DescID: 104, ColumnID: 2}
+ │    │    │    ├── ABSENT        → PUBLIC ColumnName:{DescID: 104, Name: j, ColumnID: 2}
  │    │    │    └── VALIDATED     → PUBLIC SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 0}
  │    │    └── 1 Mutation operation
  │    │         └── UndoAllInTxnImmediateMutationOpSideEffects
@@ -43,9 +49,11 @@ Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› DROP COL
  │         ├── 2 elements transitioning toward TRANSIENT_ABSENT
  │         │    ├── ABSENT → DELETE_ONLY   TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
  │         │    └── ABSENT → PUBLIC        IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
- │         ├── 1 element transitioning toward ABSENT
+ │         ├── 3 elements transitioning toward ABSENT
+ │         │    ├── PUBLIC → WRITE_ONLY    Column:{DescID: 104, ColumnID: 2}
+ │         │    ├── PUBLIC → ABSENT        ColumnName:{DescID: 104, Name: j, ColumnID: 2}
  │         │    └── PUBLIC → VALIDATED     SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 0}
- │         └── 9 Mutation operations
+ │         └── 11 Mutation operations
  │              ├── MakePublicSecondaryIndexWriteOnly {"IndexID":2,"TableID":104}
  │              ├── MakeAbsentIndexBackfilling {"Index":{"ConstraintID":2,"IndexID":3,"IsUnique":true,"SourceIndexID":1,"TableID":104,"TemporaryIndexID":4}}
  │              ├── MaybeAddSplitForIndex {"IndexID":3,"TableID":104}
@@ -53,6 +61,8 @@ Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› DROP COL
  │              ├── MakeAbsentTempIndexDeleteOnly {"Index":{"ConstraintID":3,"IndexID":4,"IsUnique":true,"SourceIndexID":1,"TableID":104}}
  │              ├── MaybeAddSplitForIndex {"IndexID":4,"TableID":104}
  │              ├── AddColumnToIndex {"ColumnID":1,"IndexID":4,"TableID":104}
+ │              ├── MakePublicColumnWriteOnly {"ColumnID":2,"TableID":104}
+ │              ├── SetColumnName {"ColumnID":2,"Name":"crdb_internal_co...","TableID":104}
  │              ├── SetJobStateOnDescriptor {"DescriptorID":104,"Initialize":true}
  │              └── CreateSchemaChangerJob {"RunningStatus":"PostCommitPhase ..."}
  ├── PostCommitPhase
@@ -108,16 +118,16 @@ Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› DROP COL
       │    ├── 2 elements transitioning toward TRANSIENT_ABSENT
       │    │    ├── WRITE_ONLY → TRANSIENT_DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
       │    │    └── PUBLIC     → TRANSIENT_ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
-      │    ├── 8 elements transitioning toward ABSENT
-      │    │    ├── PUBLIC     → WRITE_ONLY            Column:{DescID: 104, ColumnID: 2}
-      │    │    ├── PUBLIC     → ABSENT                ColumnName:{DescID: 104, Name: j, ColumnID: 2}
+      │    ├── 7 elements transitioning toward ABSENT
+      │    │    ├── WRITE_ONLY → DELETE_ONLY           Column:{DescID: 104, ColumnID: 2}
       │    │    ├── PUBLIC     → VALIDATED             PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}
       │    │    ├── PUBLIC     → ABSENT                IndexName:{DescID: 104, Name: t_pkey, IndexID: 1}
       │    │    ├── PUBLIC     → ABSENT                IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 2}
       │    │    ├── PUBLIC     → ABSENT                IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 2}
       │    │    ├── VALIDATED  → DELETE_ONLY           SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 0}
       │    │    └── PUBLIC     → ABSENT                IndexName:{DescID: 104, Name: t_j_idx, IndexID: 2}
-      │    └── 15 Mutation operations
+      │    └── 14 Mutation operations
+      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":2,"TableID":104}
       │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":1,"TableID":104}
       │         ├── SetIndexName {"IndexID":1,"Name":"crdb_internal_in...","TableID":104}
       │         ├── SetIndexName {"IndexID":3,"Name":"t_pkey","TableID":104}
@@ -127,8 +137,6 @@ Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› DROP COL
       │         ├── RemoveDroppedIndexPartialPredicate {"IndexID":2,"TableID":104}
       │         ├── SetIndexName {"IndexID":2,"Name":"crdb_internal_in...","TableID":104}
       │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":3,"TableID":104}
-      │         ├── MakePublicColumnWriteOnly {"ColumnID":2,"TableID":104}
-      │         ├── SetColumnName {"ColumnID":2,"Name":"crdb_internal_co...","TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":2,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":2,"Kind":1,"TableID":104}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
@@ -136,14 +144,12 @@ Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› DROP COL
       ├── Stage 2 of 3 in PostCommitNonRevertiblePhase
       │    ├── 1 element transitioning toward TRANSIENT_ABSENT
       │    │    └── TRANSIENT_DELETE_ONLY → TRANSIENT_ABSENT TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
-      │    ├── 5 elements transitioning toward ABSENT
-      │    │    ├── WRITE_ONLY            → DELETE_ONLY      Column:{DescID: 104, ColumnID: 2}
+      │    ├── 4 elements transitioning toward ABSENT
       │    │    ├── PUBLIC                → ABSENT           IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 1}
       │    │    ├── PUBLIC                → ABSENT           IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 1}
       │    │    ├── VALIDATED             → DELETE_ONLY      PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}
       │    │    └── DELETE_ONLY           → ABSENT           SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 0}
-      │    └── 8 Mutation operations
-      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":2,"TableID":104}
+      │    └── 7 Mutation operations
       │         ├── MakeIndexAbsent {"IndexID":2,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":4,"TableID":104}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":1,"TableID":104}

--- a/pkg/sql/schemachanger/testdata/explain/drop_column_with_partial_index.rollback_1_of_7
+++ b/pkg/sql/schemachanger/testdata/explain/drop_column_with_partial_index.rollback_1_of_7
@@ -1,5 +1,5 @@
 /* setup */
-CREATE TABLE t (i INT PRIMARY KEY, j INT, INDEX (j) WHERE j >=0);
+CREATE TABLE t (i INT PRIMARY KEY, j INT, INDEX (j) WHERE i >=0);
 
 /* test */
 ALTER TABLE t DROP COLUMN j;
@@ -8,7 +8,9 @@ EXPLAIN (ddl) rollback at post-commit stage 1 of 7;
 Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› DROP COLUMN ‹j›;
  └── PostCommitNonRevertiblePhase
       └── Stage 1 of 1 in PostCommitNonRevertiblePhase
-           ├── 1 element transitioning toward PUBLIC
+           ├── 3 elements transitioning toward PUBLIC
+           │    ├── WRITE_ONLY    → PUBLIC Column:{DescID: 104, ColumnID: 2}
+           │    ├── ABSENT        → PUBLIC ColumnName:{DescID: 104, Name: j, ColumnID: 2}
            │    └── VALIDATED     → PUBLIC SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 0}
            ├── 5 elements transitioning toward ABSENT
            │    ├── BACKFILL_ONLY → ABSENT PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
@@ -16,11 +18,14 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› D
            │    ├── PUBLIC        → ABSENT IndexData:{DescID: 104, IndexID: 3}
            │    ├── DELETE_ONLY   → ABSENT TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
            │    └── PUBLIC        → ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
-           └── 9 Mutation operations
+           └── 12 Mutation operations
+                ├── SetColumnName {"ColumnID":2,"Name":"j","TableID":104}
                 ├── MakeValidatedSecondaryIndexPublic {"IndexID":2,"TableID":104}
                 ├── RefreshStats {"TableID":104}
                 ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":3,"TableID":104}
                 ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":4,"TableID":104}
+                ├── MakeWriteOnlyColumnPublic {"ColumnID":2,"TableID":104}
+                ├── RefreshStats {"TableID":104}
                 ├── MakeIndexAbsent {"IndexID":3,"TableID":104}
                 ├── CreateGCJobForIndex {"IndexID":3,"TableID":104}
                 ├── MakeIndexAbsent {"IndexID":4,"TableID":104}

--- a/pkg/sql/schemachanger/testdata/explain/drop_column_with_partial_index.rollback_2_of_7
+++ b/pkg/sql/schemachanger/testdata/explain/drop_column_with_partial_index.rollback_2_of_7
@@ -1,5 +1,5 @@
 /* setup */
-CREATE TABLE t (i INT PRIMARY KEY, j INT, INDEX (j) WHERE j >=0);
+CREATE TABLE t (i INT PRIMARY KEY, j INT, INDEX (j) WHERE i >=0);
 
 /* test */
 ALTER TABLE t DROP COLUMN j;
@@ -8,19 +8,24 @@ EXPLAIN (ddl) rollback at post-commit stage 2 of 7;
 Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› DROP COLUMN ‹j›;
  └── PostCommitNonRevertiblePhase
       ├── Stage 1 of 2 in PostCommitNonRevertiblePhase
-      │    ├── 1 element transitioning toward PUBLIC
+      │    ├── 3 elements transitioning toward PUBLIC
+      │    │    ├── WRITE_ONLY    → PUBLIC      Column:{DescID: 104, ColumnID: 2}
+      │    │    ├── ABSENT        → PUBLIC      ColumnName:{DescID: 104, Name: j, ColumnID: 2}
       │    │    └── VALIDATED     → PUBLIC      SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 0}
       │    ├── 4 elements transitioning toward ABSENT
       │    │    ├── BACKFILL_ONLY → ABSENT      PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
       │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
       │    │    ├── WRITE_ONLY    → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
       │    │    └── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
-      │    └── 8 Mutation operations
+      │    └── 11 Mutation operations
+      │         ├── SetColumnName {"ColumnID":2,"Name":"j","TableID":104}
       │         ├── MakeValidatedSecondaryIndexPublic {"IndexID":2,"TableID":104}
       │         ├── RefreshStats {"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":3,"TableID":104}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":4,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":4,"TableID":104}
+      │         ├── MakeWriteOnlyColumnPublic {"ColumnID":2,"TableID":104}
+      │         ├── RefreshStats {"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":3,"TableID":104}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}

--- a/pkg/sql/schemachanger/testdata/explain/drop_column_with_partial_index.rollback_3_of_7
+++ b/pkg/sql/schemachanger/testdata/explain/drop_column_with_partial_index.rollback_3_of_7
@@ -1,5 +1,5 @@
 /* setup */
-CREATE TABLE t (i INT PRIMARY KEY, j INT, INDEX (j) WHERE j >=0);
+CREATE TABLE t (i INT PRIMARY KEY, j INT, INDEX (j) WHERE i >=0);
 
 /* test */
 ALTER TABLE t DROP COLUMN j;
@@ -8,19 +8,24 @@ EXPLAIN (ddl) rollback at post-commit stage 3 of 7;
 Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› DROP COLUMN ‹j›;
  └── PostCommitNonRevertiblePhase
       ├── Stage 1 of 2 in PostCommitNonRevertiblePhase
-      │    ├── 1 element transitioning toward PUBLIC
+      │    ├── 3 elements transitioning toward PUBLIC
+      │    │    ├── WRITE_ONLY    → PUBLIC      Column:{DescID: 104, ColumnID: 2}
+      │    │    ├── ABSENT        → PUBLIC      ColumnName:{DescID: 104, Name: j, ColumnID: 2}
       │    │    └── VALIDATED     → PUBLIC      SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 0}
       │    ├── 4 elements transitioning toward ABSENT
       │    │    ├── BACKFILL_ONLY → ABSENT      PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
       │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
       │    │    ├── WRITE_ONLY    → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
       │    │    └── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
-      │    └── 8 Mutation operations
+      │    └── 11 Mutation operations
+      │         ├── SetColumnName {"ColumnID":2,"Name":"j","TableID":104}
       │         ├── MakeValidatedSecondaryIndexPublic {"IndexID":2,"TableID":104}
       │         ├── RefreshStats {"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":3,"TableID":104}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":4,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":4,"TableID":104}
+      │         ├── MakeWriteOnlyColumnPublic {"ColumnID":2,"TableID":104}
+      │         ├── RefreshStats {"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":3,"TableID":104}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}

--- a/pkg/sql/schemachanger/testdata/explain/drop_column_with_partial_index.rollback_4_of_7
+++ b/pkg/sql/schemachanger/testdata/explain/drop_column_with_partial_index.rollback_4_of_7
@@ -1,5 +1,5 @@
 /* setup */
-CREATE TABLE t (i INT PRIMARY KEY, j INT, INDEX (j) WHERE j >=0);
+CREATE TABLE t (i INT PRIMARY KEY, j INT, INDEX (j) WHERE i >=0);
 
 /* test */
 ALTER TABLE t DROP COLUMN j;
@@ -8,19 +8,24 @@ EXPLAIN (ddl) rollback at post-commit stage 4 of 7;
 Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› DROP COLUMN ‹j›;
  └── PostCommitNonRevertiblePhase
       ├── Stage 1 of 2 in PostCommitNonRevertiblePhase
-      │    ├── 1 element transitioning toward PUBLIC
+      │    ├── 3 elements transitioning toward PUBLIC
+      │    │    ├── WRITE_ONLY  → PUBLIC      Column:{DescID: 104, ColumnID: 2}
+      │    │    ├── ABSENT      → PUBLIC      ColumnName:{DescID: 104, Name: j, ColumnID: 2}
       │    │    └── VALIDATED   → PUBLIC      SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 0}
       │    ├── 4 elements transitioning toward ABSENT
       │    │    ├── DELETE_ONLY → ABSENT      PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
       │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
       │    │    ├── WRITE_ONLY  → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
       │    │    └── PUBLIC      → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
-      │    └── 8 Mutation operations
+      │    └── 11 Mutation operations
+      │         ├── SetColumnName {"ColumnID":2,"Name":"j","TableID":104}
       │         ├── MakeValidatedSecondaryIndexPublic {"IndexID":2,"TableID":104}
       │         ├── RefreshStats {"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":3,"TableID":104}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":4,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":4,"TableID":104}
+      │         ├── MakeWriteOnlyColumnPublic {"ColumnID":2,"TableID":104}
+      │         ├── RefreshStats {"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":3,"TableID":104}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}

--- a/pkg/sql/schemachanger/testdata/explain/drop_column_with_partial_index.rollback_5_of_7
+++ b/pkg/sql/schemachanger/testdata/explain/drop_column_with_partial_index.rollback_5_of_7
@@ -1,5 +1,5 @@
 /* setup */
-CREATE TABLE t (i INT PRIMARY KEY, j INT, INDEX (j) WHERE j >=0);
+CREATE TABLE t (i INT PRIMARY KEY, j INT, INDEX (j) WHERE i >=0);
 
 /* test */
 ALTER TABLE t DROP COLUMN j;
@@ -8,18 +8,23 @@ EXPLAIN (ddl) rollback at post-commit stage 5 of 7;
 Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› DROP COLUMN ‹j›;
  └── PostCommitNonRevertiblePhase
       ├── Stage 1 of 2 in PostCommitNonRevertiblePhase
-      │    ├── 1 element transitioning toward PUBLIC
+      │    ├── 3 elements transitioning toward PUBLIC
+      │    │    ├── WRITE_ONLY → PUBLIC      Column:{DescID: 104, ColumnID: 2}
+      │    │    ├── ABSENT     → PUBLIC      ColumnName:{DescID: 104, Name: j, ColumnID: 2}
       │    │    └── VALIDATED  → PUBLIC      SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 0}
       │    ├── 4 elements transitioning toward ABSENT
       │    │    ├── MERGE_ONLY → DELETE_ONLY PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
       │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
       │    │    ├── WRITE_ONLY → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
       │    │    └── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
-      │    └── 8 Mutation operations
+      │    └── 11 Mutation operations
+      │         ├── SetColumnName {"ColumnID":2,"Name":"j","TableID":104}
       │         ├── MakeValidatedSecondaryIndexPublic {"IndexID":2,"TableID":104}
       │         ├── RefreshStats {"TableID":104}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":4,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":4,"TableID":104}
+      │         ├── MakeWriteOnlyColumnPublic {"ColumnID":2,"TableID":104}
+      │         ├── RefreshStats {"TableID":104}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":3,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":3,"TableID":104}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}

--- a/pkg/sql/schemachanger/testdata/explain/drop_column_with_partial_index.rollback_6_of_7
+++ b/pkg/sql/schemachanger/testdata/explain/drop_column_with_partial_index.rollback_6_of_7
@@ -1,5 +1,5 @@
 /* setup */
-CREATE TABLE t (i INT PRIMARY KEY, j INT, INDEX (j) WHERE j >=0);
+CREATE TABLE t (i INT PRIMARY KEY, j INT, INDEX (j) WHERE i >=0);
 
 /* test */
 ALTER TABLE t DROP COLUMN j;
@@ -8,18 +8,23 @@ EXPLAIN (ddl) rollback at post-commit stage 6 of 7;
 Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› DROP COLUMN ‹j›;
  └── PostCommitNonRevertiblePhase
       ├── Stage 1 of 2 in PostCommitNonRevertiblePhase
-      │    ├── 1 element transitioning toward PUBLIC
+      │    ├── 3 elements transitioning toward PUBLIC
+      │    │    ├── WRITE_ONLY → PUBLIC      Column:{DescID: 104, ColumnID: 2}
+      │    │    ├── ABSENT     → PUBLIC      ColumnName:{DescID: 104, Name: j, ColumnID: 2}
       │    │    └── VALIDATED  → PUBLIC      SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 0}
       │    ├── 4 elements transitioning toward ABSENT
       │    │    ├── MERGE_ONLY → DELETE_ONLY PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
       │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
       │    │    ├── WRITE_ONLY → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
       │    │    └── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
-      │    └── 8 Mutation operations
+      │    └── 11 Mutation operations
+      │         ├── SetColumnName {"ColumnID":2,"Name":"j","TableID":104}
       │         ├── MakeValidatedSecondaryIndexPublic {"IndexID":2,"TableID":104}
       │         ├── RefreshStats {"TableID":104}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":4,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":4,"TableID":104}
+      │         ├── MakeWriteOnlyColumnPublic {"ColumnID":2,"TableID":104}
+      │         ├── RefreshStats {"TableID":104}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":3,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":3,"TableID":104}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}

--- a/pkg/sql/schemachanger/testdata/explain/drop_column_with_partial_index.rollback_7_of_7
+++ b/pkg/sql/schemachanger/testdata/explain/drop_column_with_partial_index.rollback_7_of_7
@@ -1,5 +1,5 @@
 /* setup */
-CREATE TABLE t (i INT PRIMARY KEY, j INT, INDEX (j) WHERE j >=0);
+CREATE TABLE t (i INT PRIMARY KEY, j INT, INDEX (j) WHERE i >=0);
 
 /* test */
 ALTER TABLE t DROP COLUMN j;
@@ -8,20 +8,25 @@ EXPLAIN (ddl) rollback at post-commit stage 7 of 7;
 Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› DROP COLUMN ‹j›;
  └── PostCommitNonRevertiblePhase
       ├── Stage 1 of 2 in PostCommitNonRevertiblePhase
-      │    ├── 1 element transitioning toward PUBLIC
+      │    ├── 3 elements transitioning toward PUBLIC
+      │    │    ├── WRITE_ONLY → PUBLIC      Column:{DescID: 104, ColumnID: 2}
+      │    │    ├── ABSENT     → PUBLIC      ColumnName:{DescID: 104, Name: j, ColumnID: 2}
       │    │    └── VALIDATED  → PUBLIC      SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 0}
       │    ├── 4 elements transitioning toward ABSENT
       │    │    ├── WRITE_ONLY → DELETE_ONLY PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
       │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
       │    │    ├── WRITE_ONLY → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
       │    │    └── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
-      │    └── 8 Mutation operations
+      │    └── 11 Mutation operations
+      │         ├── SetColumnName {"ColumnID":2,"Name":"j","TableID":104}
       │         ├── MakeValidatedSecondaryIndexPublic {"IndexID":2,"TableID":104}
       │         ├── RefreshStats {"TableID":104}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":3,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":3,"TableID":104}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":4,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":4,"TableID":104}
+      │         ├── MakeWriteOnlyColumnPublic {"ColumnID":2,"TableID":104}
+      │         ├── RefreshStats {"TableID":104}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
       └── Stage 2 of 2 in PostCommitNonRevertiblePhase

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_with_partial_index
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_with_partial_index
@@ -1,5 +1,5 @@
 /* setup */
-CREATE TABLE t (i INT PRIMARY KEY, j INT, INDEX (j) WHERE j >=0);
+CREATE TABLE t (i INT PRIMARY KEY, j INT, INDEX (j) WHERE i >=0);
 
 /* test */
 EXPLAIN (ddl, verbose) ALTER TABLE t DROP COLUMN j;
@@ -44,7 +44,22 @@ EXPLAIN (ddl, verbose) ALTER TABLE t DROP COLUMN j;
 │       │       └── • Precedence dependency from DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
 │       │             rule: "temp index existence precedes index dependents"
 │       │
-│       ├── • 1 element transitioning toward ABSENT
+│       ├── • 3 elements transitioning toward ABSENT
+│       │   │
+│       │   ├── • Column:{DescID: 104, ColumnID: 2}
+│       │   │   │ PUBLIC → WRITE_ONLY
+│       │   │   │
+│       │   │   ├── • PreviousStagePrecedence dependency from PUBLIC Column:{DescID: 104, ColumnID: 2}
+│       │   │   │     rule: "Column transitions to ABSENT uphold 2-version invariant: PUBLIC->WRITE_ONLY"
+│       │   │   │
+│       │   │   └── • Precedence dependency from VALIDATED SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 0}
+│       │   │         rule: "secondary indexes containing column as key reach write-only before column"
+│       │   │
+│       │   ├── • ColumnName:{DescID: 104, Name: j, ColumnID: 2}
+│       │   │   │ PUBLIC → ABSENT
+│       │   │   │
+│       │   │   └── • Precedence dependency from WRITE_ONLY Column:{DescID: 104, ColumnID: 2}
+│       │   │         rule: "column no longer public before dependents"
 │       │   │
 │       │   └── • SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 0}
 │       │       │ PUBLIC → VALIDATED
@@ -52,7 +67,7 @@ EXPLAIN (ddl, verbose) ALTER TABLE t DROP COLUMN j;
 │       │       └── • PreviousStagePrecedence dependency from PUBLIC SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 0}
 │       │             rule: "SecondaryIndex transitions to ABSENT uphold 2-version invariant: PUBLIC->VALIDATED"
 │       │
-│       └── • 5 Mutation operations
+│       └── • 7 Mutation operations
 │           │
 │           ├── • MakePublicSecondaryIndexWriteOnly
 │           │     IndexID: 2
@@ -80,9 +95,18 @@ EXPLAIN (ddl, verbose) ALTER TABLE t DROP COLUMN j;
 │           │       SourceIndexID: 1
 │           │       TableID: 104
 │           │
-│           └── • AddColumnToIndex
-│                 ColumnID: 1
-│                 IndexID: 4
+│           ├── • AddColumnToIndex
+│           │     ColumnID: 1
+│           │     IndexID: 4
+│           │     TableID: 104
+│           │
+│           ├── • MakePublicColumnWriteOnly
+│           │     ColumnID: 2
+│           │     TableID: 104
+│           │
+│           └── • SetColumnName
+│                 ColumnID: 2
+│                 Name: crdb_internal_column_2_name_placeholder
 │                 TableID: 104
 │
 ├── • PreCommitPhase
@@ -108,7 +132,13 @@ EXPLAIN (ddl, verbose) ALTER TABLE t DROP COLUMN j;
 │   │   │   └── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
 │   │   │         PUBLIC → ABSENT
 │   │   │
-│   │   ├── • 1 element transitioning toward ABSENT
+│   │   ├── • 3 elements transitioning toward ABSENT
+│   │   │   │
+│   │   │   ├── • Column:{DescID: 104, ColumnID: 2}
+│   │   │   │     WRITE_ONLY → PUBLIC
+│   │   │   │
+│   │   │   ├── • ColumnName:{DescID: 104, Name: j, ColumnID: 2}
+│   │   │   │     ABSENT → PUBLIC
 │   │   │   │
 │   │   │   └── • SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 0}
 │   │   │         VALIDATED → PUBLIC
@@ -154,7 +184,22 @@ EXPLAIN (ddl, verbose) ALTER TABLE t DROP COLUMN j;
 │       │       └── • Precedence dependency from DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
 │       │             rule: "temp index existence precedes index dependents"
 │       │
-│       ├── • 1 element transitioning toward ABSENT
+│       ├── • 3 elements transitioning toward ABSENT
+│       │   │
+│       │   ├── • Column:{DescID: 104, ColumnID: 2}
+│       │   │   │ PUBLIC → WRITE_ONLY
+│       │   │   │
+│       │   │   ├── • PreviousStagePrecedence dependency from PUBLIC Column:{DescID: 104, ColumnID: 2}
+│       │   │   │     rule: "Column transitions to ABSENT uphold 2-version invariant: PUBLIC->WRITE_ONLY"
+│       │   │   │
+│       │   │   └── • Precedence dependency from VALIDATED SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 0}
+│       │   │         rule: "secondary indexes containing column as key reach write-only before column"
+│       │   │
+│       │   ├── • ColumnName:{DescID: 104, Name: j, ColumnID: 2}
+│       │   │   │ PUBLIC → ABSENT
+│       │   │   │
+│       │   │   └── • Precedence dependency from WRITE_ONLY Column:{DescID: 104, ColumnID: 2}
+│       │   │         rule: "column no longer public before dependents"
 │       │   │
 │       │   └── • SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 0}
 │       │       │ PUBLIC → VALIDATED
@@ -162,7 +207,7 @@ EXPLAIN (ddl, verbose) ALTER TABLE t DROP COLUMN j;
 │       │       └── • PreviousStagePrecedence dependency from PUBLIC SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 0}
 │       │             rule: "SecondaryIndex transitions to ABSENT uphold 2-version invariant: PUBLIC->VALIDATED"
 │       │
-│       └── • 9 Mutation operations
+│       └── • 11 Mutation operations
 │           │
 │           ├── • MakePublicSecondaryIndexWriteOnly
 │           │     IndexID: 2
@@ -201,6 +246,15 @@ EXPLAIN (ddl, verbose) ALTER TABLE t DROP COLUMN j;
 │           ├── • AddColumnToIndex
 │           │     ColumnID: 1
 │           │     IndexID: 4
+│           │     TableID: 104
+│           │
+│           ├── • MakePublicColumnWriteOnly
+│           │     ColumnID: 2
+│           │     TableID: 104
+│           │
+│           ├── • SetColumnName
+│           │     ColumnID: 2
+│           │     Name: crdb_internal_column_2_name_placeholder
 │           │     TableID: 104
 │           │
 │           ├── • SetJobStateOnDescriptor
@@ -420,25 +474,13 @@ EXPLAIN (ddl, verbose) ALTER TABLE t DROP COLUMN j;
     │   │       └── • Precedence dependency from TRANSIENT_DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
     │   │             rule: "index drop mutation visible before cleaning up index columns"
     │   │
-    │   ├── • 8 elements transitioning toward ABSENT
+    │   ├── • 7 elements transitioning toward ABSENT
     │   │   │
     │   │   ├── • Column:{DescID: 104, ColumnID: 2}
-    │   │   │   │ PUBLIC → WRITE_ONLY
+    │   │   │   │ WRITE_ONLY → DELETE_ONLY
     │   │   │   │
-    │   │   │   ├── • PreviousStagePrecedence dependency from PUBLIC Column:{DescID: 104, ColumnID: 2}
-    │   │   │   │     rule: "Column transitions to ABSENT uphold 2-version invariant: PUBLIC->WRITE_ONLY"
-    │   │   │   │
-    │   │   │   ├── • Precedence dependency from DELETE_ONLY SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 0}
-    │   │   │   │     rule: "secondary index partial no longer public before referenced column"
-    │   │   │   │
-    │   │   │   └── • Precedence dependency from VALIDATED SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 0}
-    │   │   │         rule: "secondary indexes containing column as key reach write-only before column"
-    │   │   │
-    │   │   ├── • ColumnName:{DescID: 104, Name: j, ColumnID: 2}
-    │   │   │   │ PUBLIC → ABSENT
-    │   │   │   │
-    │   │   │   └── • Precedence dependency from WRITE_ONLY Column:{DescID: 104, ColumnID: 2}
-    │   │   │         rule: "column no longer public before dependents"
+    │   │   │   └── • PreviousStagePrecedence dependency from WRITE_ONLY Column:{DescID: 104, ColumnID: 2}
+    │   │   │         rule: "Column transitions to ABSENT uphold 2-version invariant: WRITE_ONLY->DELETE_ONLY"
     │   │   │
     │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}
     │   │   │   │ PUBLIC → VALIDATED
@@ -482,7 +524,11 @@ EXPLAIN (ddl, verbose) ALTER TABLE t DROP COLUMN j;
     │   │       └── • Precedence dependency from VALIDATED SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 0}
     │   │             rule: "index no longer public before dependents, excluding columns"
     │   │
-    │   └── • 15 Mutation operations
+    │   └── • 14 Mutation operations
+    │       │
+    │       ├── • MakeWriteOnlyColumnDeleteOnly
+    │       │     ColumnID: 2
+    │       │     TableID: 104
     │       │
     │       ├── • MakePublicPrimaryIndexWriteOnly
     │       │     IndexID: 1
@@ -524,15 +570,6 @@ EXPLAIN (ddl, verbose) ALTER TABLE t DROP COLUMN j;
     │       │     IndexID: 3
     │       │     TableID: 104
     │       │
-    │       ├── • MakePublicColumnWriteOnly
-    │       │     ColumnID: 2
-    │       │     TableID: 104
-    │       │
-    │       ├── • SetColumnName
-    │       │     ColumnID: 2
-    │       │     Name: crdb_internal_column_2_name_placeholder
-    │       │     TableID: 104
-    │       │
     │       ├── • RemoveColumnFromIndex
     │       │     ColumnID: 2
     │       │     IndexID: 2
@@ -550,7 +587,7 @@ EXPLAIN (ddl, verbose) ALTER TABLE t DROP COLUMN j;
     │       └── • UpdateSchemaChangerJob
     │             IsNonCancelable: true
     │             JobID: 1
-    │             RunningStatus: PostCommitNonRevertiblePhase stage 2 of 3 with 6 MutationType ops pending
+    │             RunningStatus: PostCommitNonRevertiblePhase stage 2 of 3 with 5 MutationType ops pending
     │
     ├── • Stage 2 of 3 in PostCommitNonRevertiblePhase
     │   │
@@ -565,13 +602,7 @@ EXPLAIN (ddl, verbose) ALTER TABLE t DROP COLUMN j;
     │   │       └── • Precedence dependency from TRANSIENT_ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
     │   │             rule: "dependents removed before index"
     │   │
-    │   ├── • 5 elements transitioning toward ABSENT
-    │   │   │
-    │   │   ├── • Column:{DescID: 104, ColumnID: 2}
-    │   │   │   │ WRITE_ONLY → DELETE_ONLY
-    │   │   │   │
-    │   │   │   └── • PreviousStagePrecedence dependency from WRITE_ONLY Column:{DescID: 104, ColumnID: 2}
-    │   │   │         rule: "Column transitions to ABSENT uphold 2-version invariant: WRITE_ONLY->DELETE_ONLY"
+    │   ├── • 4 elements transitioning toward ABSENT
     │   │   │
     │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 1}
     │   │   │   │ PUBLIC → ABSENT
@@ -609,11 +640,7 @@ EXPLAIN (ddl, verbose) ALTER TABLE t DROP COLUMN j;
     │   │       └── • Precedence dependency from ABSENT IndexName:{DescID: 104, Name: t_j_idx, IndexID: 2}
     │   │             rule: "dependents removed before index"
     │   │
-    │   └── • 8 Mutation operations
-    │       │
-    │       ├── • MakeWriteOnlyColumnDeleteOnly
-    │       │     ColumnID: 2
-    │       │     TableID: 104
+    │   └── • 7 Mutation operations
     │       │
     │       ├── • MakeIndexAbsent
     │       │     IndexID: 2

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_with_partial_index.rollback_1_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_with_partial_index.rollback_1_of_7
@@ -1,5 +1,5 @@
 /* setup */
-CREATE TABLE t (i INT PRIMARY KEY, j INT, INDEX (j) WHERE j >=0);
+CREATE TABLE t (i INT PRIMARY KEY, j INT, INDEX (j) WHERE i >=0);
 
 /* test */
 ALTER TABLE t DROP COLUMN j;
@@ -11,7 +11,28 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 1 of 7;
     │
     └── • Stage 1 of 1 in PostCommitNonRevertiblePhase
         │
-        ├── • 1 element transitioning toward PUBLIC
+        ├── • 3 elements transitioning toward PUBLIC
+        │   │
+        │   ├── • Column:{DescID: 104, ColumnID: 2}
+        │   │   │ WRITE_ONLY → PUBLIC
+        │   │   │
+        │   │   ├── • PreviousStagePrecedence dependency from WRITE_ONLY Column:{DescID: 104, ColumnID: 2}
+        │   │   │     rule: "Column transitions to PUBLIC uphold 2-version invariant: WRITE_ONLY->PUBLIC"
+        │   │   │
+        │   │   ├── • Precedence dependency from PUBLIC ColumnName:{DescID: 104, Name: j, ColumnID: 2}
+        │   │   │     rule: "column dependents exist before column becomes public"
+        │   │   │
+        │   │   ├── • Precedence dependency from PUBLIC ColumnType:{DescID: 104, ColumnFamilyID: 0, ColumnID: 2}
+        │   │   │     rule: "column dependents exist before column becomes public"
+        │   │   │
+        │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 1}
+        │   │   │     rule: "column dependents exist before column becomes public"
+        │   │   │
+        │   │   └── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 2}
+        │   │         rule: "column dependents exist before column becomes public"
+        │   │
+        │   ├── • ColumnName:{DescID: 104, Name: j, ColumnID: 2}
+        │   │     ABSENT → PUBLIC
         │   │
         │   └── • SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 0}
         │       │ VALIDATED → PUBLIC
@@ -69,7 +90,12 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 1 of 7;
         │       └── • Precedence dependency from DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
         │             rule: "index drop mutation visible before cleaning up index columns"
         │
-        └── • 9 Mutation operations
+        └── • 12 Mutation operations
+            │
+            ├── • SetColumnName
+            │     ColumnID: 2
+            │     Name: j
+            │     TableID: 104
             │
             ├── • MakeValidatedSecondaryIndexPublic
             │     IndexID: 2
@@ -86,6 +112,13 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 1 of 7;
             ├── • RemoveColumnFromIndex
             │     ColumnID: 1
             │     IndexID: 4
+            │     TableID: 104
+            │
+            ├── • MakeWriteOnlyColumnPublic
+            │     ColumnID: 2
+            │     TableID: 104
+            │
+            ├── • RefreshStats
             │     TableID: 104
             │
             ├── • MakeIndexAbsent

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_with_partial_index.rollback_2_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_with_partial_index.rollback_2_of_7
@@ -1,5 +1,5 @@
 /* setup */
-CREATE TABLE t (i INT PRIMARY KEY, j INT, INDEX (j) WHERE j >=0);
+CREATE TABLE t (i INT PRIMARY KEY, j INT, INDEX (j) WHERE i >=0);
 
 /* test */
 ALTER TABLE t DROP COLUMN j;
@@ -11,7 +11,28 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 2 of 7;
     │
     ├── • Stage 1 of 2 in PostCommitNonRevertiblePhase
     │   │
-    │   ├── • 1 element transitioning toward PUBLIC
+    │   ├── • 3 elements transitioning toward PUBLIC
+    │   │   │
+    │   │   ├── • Column:{DescID: 104, ColumnID: 2}
+    │   │   │   │ WRITE_ONLY → PUBLIC
+    │   │   │   │
+    │   │   │   ├── • PreviousStagePrecedence dependency from WRITE_ONLY Column:{DescID: 104, ColumnID: 2}
+    │   │   │   │     rule: "Column transitions to PUBLIC uphold 2-version invariant: WRITE_ONLY->PUBLIC"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC ColumnName:{DescID: 104, Name: j, ColumnID: 2}
+    │   │   │   │     rule: "column dependents exist before column becomes public"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC ColumnType:{DescID: 104, ColumnFamilyID: 0, ColumnID: 2}
+    │   │   │   │     rule: "column dependents exist before column becomes public"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 1}
+    │   │   │   │     rule: "column dependents exist before column becomes public"
+    │   │   │   │
+    │   │   │   └── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 2}
+    │   │   │         rule: "column dependents exist before column becomes public"
+    │   │   │
+    │   │   ├── • ColumnName:{DescID: 104, Name: j, ColumnID: 2}
+    │   │   │     ABSENT → PUBLIC
     │   │   │
     │   │   └── • SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 0}
     │   │       │ VALIDATED → PUBLIC
@@ -60,7 +81,12 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 2 of 7;
     │   │       └── • Precedence dependency from DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
     │   │             rule: "index drop mutation visible before cleaning up index columns"
     │   │
-    │   └── • 8 Mutation operations
+    │   └── • 11 Mutation operations
+    │       │
+    │       ├── • SetColumnName
+    │       │     ColumnID: 2
+    │       │     Name: j
+    │       │     TableID: 104
     │       │
     │       ├── • MakeValidatedSecondaryIndexPublic
     │       │     IndexID: 2
@@ -81,6 +107,13 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 2 of 7;
     │       ├── • RemoveColumnFromIndex
     │       │     ColumnID: 1
     │       │     IndexID: 4
+    │       │     TableID: 104
+    │       │
+    │       ├── • MakeWriteOnlyColumnPublic
+    │       │     ColumnID: 2
+    │       │     TableID: 104
+    │       │
+    │       ├── • RefreshStats
     │       │     TableID: 104
     │       │
     │       ├── • MakeIndexAbsent

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_with_partial_index.rollback_3_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_with_partial_index.rollback_3_of_7
@@ -1,5 +1,5 @@
 /* setup */
-CREATE TABLE t (i INT PRIMARY KEY, j INT, INDEX (j) WHERE j >=0);
+CREATE TABLE t (i INT PRIMARY KEY, j INT, INDEX (j) WHERE i >=0);
 
 /* test */
 ALTER TABLE t DROP COLUMN j;
@@ -11,7 +11,28 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 3 of 7;
     │
     ├── • Stage 1 of 2 in PostCommitNonRevertiblePhase
     │   │
-    │   ├── • 1 element transitioning toward PUBLIC
+    │   ├── • 3 elements transitioning toward PUBLIC
+    │   │   │
+    │   │   ├── • Column:{DescID: 104, ColumnID: 2}
+    │   │   │   │ WRITE_ONLY → PUBLIC
+    │   │   │   │
+    │   │   │   ├── • PreviousStagePrecedence dependency from WRITE_ONLY Column:{DescID: 104, ColumnID: 2}
+    │   │   │   │     rule: "Column transitions to PUBLIC uphold 2-version invariant: WRITE_ONLY->PUBLIC"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC ColumnName:{DescID: 104, Name: j, ColumnID: 2}
+    │   │   │   │     rule: "column dependents exist before column becomes public"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC ColumnType:{DescID: 104, ColumnFamilyID: 0, ColumnID: 2}
+    │   │   │   │     rule: "column dependents exist before column becomes public"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 1}
+    │   │   │   │     rule: "column dependents exist before column becomes public"
+    │   │   │   │
+    │   │   │   └── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 2}
+    │   │   │         rule: "column dependents exist before column becomes public"
+    │   │   │
+    │   │   ├── • ColumnName:{DescID: 104, Name: j, ColumnID: 2}
+    │   │   │     ABSENT → PUBLIC
     │   │   │
     │   │   └── • SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 0}
     │   │       │ VALIDATED → PUBLIC
@@ -60,7 +81,12 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 3 of 7;
     │   │       └── • Precedence dependency from DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
     │   │             rule: "index drop mutation visible before cleaning up index columns"
     │   │
-    │   └── • 8 Mutation operations
+    │   └── • 11 Mutation operations
+    │       │
+    │       ├── • SetColumnName
+    │       │     ColumnID: 2
+    │       │     Name: j
+    │       │     TableID: 104
     │       │
     │       ├── • MakeValidatedSecondaryIndexPublic
     │       │     IndexID: 2
@@ -81,6 +107,13 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 3 of 7;
     │       ├── • RemoveColumnFromIndex
     │       │     ColumnID: 1
     │       │     IndexID: 4
+    │       │     TableID: 104
+    │       │
+    │       ├── • MakeWriteOnlyColumnPublic
+    │       │     ColumnID: 2
+    │       │     TableID: 104
+    │       │
+    │       ├── • RefreshStats
     │       │     TableID: 104
     │       │
     │       ├── • MakeIndexAbsent

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_with_partial_index.rollback_4_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_with_partial_index.rollback_4_of_7
@@ -1,5 +1,5 @@
 /* setup */
-CREATE TABLE t (i INT PRIMARY KEY, j INT, INDEX (j) WHERE j >=0);
+CREATE TABLE t (i INT PRIMARY KEY, j INT, INDEX (j) WHERE i >=0);
 
 /* test */
 ALTER TABLE t DROP COLUMN j;
@@ -11,7 +11,28 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 4 of 7;
     │
     ├── • Stage 1 of 2 in PostCommitNonRevertiblePhase
     │   │
-    │   ├── • 1 element transitioning toward PUBLIC
+    │   ├── • 3 elements transitioning toward PUBLIC
+    │   │   │
+    │   │   ├── • Column:{DescID: 104, ColumnID: 2}
+    │   │   │   │ WRITE_ONLY → PUBLIC
+    │   │   │   │
+    │   │   │   ├── • PreviousStagePrecedence dependency from WRITE_ONLY Column:{DescID: 104, ColumnID: 2}
+    │   │   │   │     rule: "Column transitions to PUBLIC uphold 2-version invariant: WRITE_ONLY->PUBLIC"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC ColumnName:{DescID: 104, Name: j, ColumnID: 2}
+    │   │   │   │     rule: "column dependents exist before column becomes public"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC ColumnType:{DescID: 104, ColumnFamilyID: 0, ColumnID: 2}
+    │   │   │   │     rule: "column dependents exist before column becomes public"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 1}
+    │   │   │   │     rule: "column dependents exist before column becomes public"
+    │   │   │   │
+    │   │   │   └── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 2}
+    │   │   │         rule: "column dependents exist before column becomes public"
+    │   │   │
+    │   │   ├── • ColumnName:{DescID: 104, Name: j, ColumnID: 2}
+    │   │   │     ABSENT → PUBLIC
     │   │   │
     │   │   └── • SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 0}
     │   │       │ VALIDATED → PUBLIC
@@ -60,7 +81,12 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 4 of 7;
     │   │       └── • Precedence dependency from DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
     │   │             rule: "index drop mutation visible before cleaning up index columns"
     │   │
-    │   └── • 8 Mutation operations
+    │   └── • 11 Mutation operations
+    │       │
+    │       ├── • SetColumnName
+    │       │     ColumnID: 2
+    │       │     Name: j
+    │       │     TableID: 104
     │       │
     │       ├── • MakeValidatedSecondaryIndexPublic
     │       │     IndexID: 2
@@ -81,6 +107,13 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 4 of 7;
     │       ├── • RemoveColumnFromIndex
     │       │     ColumnID: 1
     │       │     IndexID: 4
+    │       │     TableID: 104
+    │       │
+    │       ├── • MakeWriteOnlyColumnPublic
+    │       │     ColumnID: 2
+    │       │     TableID: 104
+    │       │
+    │       ├── • RefreshStats
     │       │     TableID: 104
     │       │
     │       ├── • MakeIndexAbsent

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_with_partial_index.rollback_5_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_with_partial_index.rollback_5_of_7
@@ -1,5 +1,5 @@
 /* setup */
-CREATE TABLE t (i INT PRIMARY KEY, j INT, INDEX (j) WHERE j >=0);
+CREATE TABLE t (i INT PRIMARY KEY, j INT, INDEX (j) WHERE i >=0);
 
 /* test */
 ALTER TABLE t DROP COLUMN j;
@@ -11,7 +11,28 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 5 of 7;
     │
     ├── • Stage 1 of 2 in PostCommitNonRevertiblePhase
     │   │
-    │   ├── • 1 element transitioning toward PUBLIC
+    │   ├── • 3 elements transitioning toward PUBLIC
+    │   │   │
+    │   │   ├── • Column:{DescID: 104, ColumnID: 2}
+    │   │   │   │ WRITE_ONLY → PUBLIC
+    │   │   │   │
+    │   │   │   ├── • PreviousStagePrecedence dependency from WRITE_ONLY Column:{DescID: 104, ColumnID: 2}
+    │   │   │   │     rule: "Column transitions to PUBLIC uphold 2-version invariant: WRITE_ONLY->PUBLIC"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC ColumnName:{DescID: 104, Name: j, ColumnID: 2}
+    │   │   │   │     rule: "column dependents exist before column becomes public"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC ColumnType:{DescID: 104, ColumnFamilyID: 0, ColumnID: 2}
+    │   │   │   │     rule: "column dependents exist before column becomes public"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 1}
+    │   │   │   │     rule: "column dependents exist before column becomes public"
+    │   │   │   │
+    │   │   │   └── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 2}
+    │   │   │         rule: "column dependents exist before column becomes public"
+    │   │   │
+    │   │   ├── • ColumnName:{DescID: 104, Name: j, ColumnID: 2}
+    │   │   │     ABSENT → PUBLIC
     │   │   │
     │   │   └── • SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 0}
     │   │       │ VALIDATED → PUBLIC
@@ -54,7 +75,12 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 5 of 7;
     │   │       └── • Precedence dependency from DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
     │   │             rule: "index drop mutation visible before cleaning up index columns"
     │   │
-    │   └── • 8 Mutation operations
+    │   └── • 11 Mutation operations
+    │       │
+    │       ├── • SetColumnName
+    │       │     ColumnID: 2
+    │       │     Name: j
+    │       │     TableID: 104
     │       │
     │       ├── • MakeValidatedSecondaryIndexPublic
     │       │     IndexID: 2
@@ -70,6 +96,13 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 5 of 7;
     │       ├── • RemoveColumnFromIndex
     │       │     ColumnID: 1
     │       │     IndexID: 4
+    │       │     TableID: 104
+    │       │
+    │       ├── • MakeWriteOnlyColumnPublic
+    │       │     ColumnID: 2
+    │       │     TableID: 104
+    │       │
+    │       ├── • RefreshStats
     │       │     TableID: 104
     │       │
     │       ├── • MakeWriteOnlyIndexDeleteOnly

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_with_partial_index.rollback_6_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_with_partial_index.rollback_6_of_7
@@ -1,5 +1,5 @@
 /* setup */
-CREATE TABLE t (i INT PRIMARY KEY, j INT, INDEX (j) WHERE j >=0);
+CREATE TABLE t (i INT PRIMARY KEY, j INT, INDEX (j) WHERE i >=0);
 
 /* test */
 ALTER TABLE t DROP COLUMN j;
@@ -11,7 +11,28 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 6 of 7;
     │
     ├── • Stage 1 of 2 in PostCommitNonRevertiblePhase
     │   │
-    │   ├── • 1 element transitioning toward PUBLIC
+    │   ├── • 3 elements transitioning toward PUBLIC
+    │   │   │
+    │   │   ├── • Column:{DescID: 104, ColumnID: 2}
+    │   │   │   │ WRITE_ONLY → PUBLIC
+    │   │   │   │
+    │   │   │   ├── • PreviousStagePrecedence dependency from WRITE_ONLY Column:{DescID: 104, ColumnID: 2}
+    │   │   │   │     rule: "Column transitions to PUBLIC uphold 2-version invariant: WRITE_ONLY->PUBLIC"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC ColumnName:{DescID: 104, Name: j, ColumnID: 2}
+    │   │   │   │     rule: "column dependents exist before column becomes public"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC ColumnType:{DescID: 104, ColumnFamilyID: 0, ColumnID: 2}
+    │   │   │   │     rule: "column dependents exist before column becomes public"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 1}
+    │   │   │   │     rule: "column dependents exist before column becomes public"
+    │   │   │   │
+    │   │   │   └── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 2}
+    │   │   │         rule: "column dependents exist before column becomes public"
+    │   │   │
+    │   │   ├── • ColumnName:{DescID: 104, Name: j, ColumnID: 2}
+    │   │   │     ABSENT → PUBLIC
     │   │   │
     │   │   └── • SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 0}
     │   │       │ VALIDATED → PUBLIC
@@ -54,7 +75,12 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 6 of 7;
     │   │       └── • Precedence dependency from DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
     │   │             rule: "index drop mutation visible before cleaning up index columns"
     │   │
-    │   └── • 8 Mutation operations
+    │   └── • 11 Mutation operations
+    │       │
+    │       ├── • SetColumnName
+    │       │     ColumnID: 2
+    │       │     Name: j
+    │       │     TableID: 104
     │       │
     │       ├── • MakeValidatedSecondaryIndexPublic
     │       │     IndexID: 2
@@ -70,6 +96,13 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 6 of 7;
     │       ├── • RemoveColumnFromIndex
     │       │     ColumnID: 1
     │       │     IndexID: 4
+    │       │     TableID: 104
+    │       │
+    │       ├── • MakeWriteOnlyColumnPublic
+    │       │     ColumnID: 2
+    │       │     TableID: 104
+    │       │
+    │       ├── • RefreshStats
     │       │     TableID: 104
     │       │
     │       ├── • MakeWriteOnlyIndexDeleteOnly

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_with_partial_index.rollback_7_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_with_partial_index.rollback_7_of_7
@@ -1,5 +1,5 @@
 /* setup */
-CREATE TABLE t (i INT PRIMARY KEY, j INT, INDEX (j) WHERE j >=0);
+CREATE TABLE t (i INT PRIMARY KEY, j INT, INDEX (j) WHERE i >=0);
 
 /* test */
 ALTER TABLE t DROP COLUMN j;
@@ -11,7 +11,28 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 7 of 7;
     │
     ├── • Stage 1 of 2 in PostCommitNonRevertiblePhase
     │   │
-    │   ├── • 1 element transitioning toward PUBLIC
+    │   ├── • 3 elements transitioning toward PUBLIC
+    │   │   │
+    │   │   ├── • Column:{DescID: 104, ColumnID: 2}
+    │   │   │   │ WRITE_ONLY → PUBLIC
+    │   │   │   │
+    │   │   │   ├── • PreviousStagePrecedence dependency from WRITE_ONLY Column:{DescID: 104, ColumnID: 2}
+    │   │   │   │     rule: "Column transitions to PUBLIC uphold 2-version invariant: WRITE_ONLY->PUBLIC"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC ColumnName:{DescID: 104, Name: j, ColumnID: 2}
+    │   │   │   │     rule: "column dependents exist before column becomes public"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC ColumnType:{DescID: 104, ColumnFamilyID: 0, ColumnID: 2}
+    │   │   │   │     rule: "column dependents exist before column becomes public"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 1}
+    │   │   │   │     rule: "column dependents exist before column becomes public"
+    │   │   │   │
+    │   │   │   └── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 2}
+    │   │   │         rule: "column dependents exist before column becomes public"
+    │   │   │
+    │   │   ├── • ColumnName:{DescID: 104, Name: j, ColumnID: 2}
+    │   │   │     ABSENT → PUBLIC
     │   │   │
     │   │   └── • SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 0}
     │   │       │ VALIDATED → PUBLIC
@@ -54,7 +75,12 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 7 of 7;
     │   │       └── • Precedence dependency from DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
     │   │             rule: "index drop mutation visible before cleaning up index columns"
     │   │
-    │   └── • 8 Mutation operations
+    │   └── • 11 Mutation operations
+    │       │
+    │       ├── • SetColumnName
+    │       │     ColumnID: 2
+    │       │     Name: j
+    │       │     TableID: 104
     │       │
     │       ├── • MakeValidatedSecondaryIndexPublic
     │       │     IndexID: 2
@@ -79,6 +105,13 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 7 of 7;
     │       ├── • RemoveColumnFromIndex
     │       │     ColumnID: 1
     │       │     IndexID: 4
+    │       │     TableID: 104
+    │       │
+    │       ├── • MakeWriteOnlyColumnPublic
+    │       │     ColumnID: 2
+    │       │     TableID: 104
+    │       │
+    │       ├── • RefreshStats
     │       │     TableID: 104
     │       │
     │       ├── • SetJobStateOnDescriptor

--- a/pkg/sql/sqlerrors/errors.go
+++ b/pkg/sql/sqlerrors/errors.go
@@ -252,6 +252,35 @@ func NewColumnReferencedByComputedColumnError(droppingColumn, computedColumn str
 	)
 }
 
+// NewColumnReferencedByPartialIndex is returned when we drop a column that is
+// referenced in a partial index's predicate.
+func NewColumnReferencedByPartialIndex(droppingColumn, partialIndex string) error {
+	return errors.WithIssueLink(errors.WithHint(
+		pgerror.Newf(
+			pgcode.InvalidColumnReference,
+			"column %q cannot be dropped because it is referenced by partial index %q",
+			droppingColumn, partialIndex,
+		),
+		"drop the partial index first, then drop the column",
+	), errors.IssueLink{IssueURL: "https://github.com/cockroachdb/cockroach/pull/97372"})
+}
+
+// NewColumnReferencedByPartialUniqueWithoutIndexConstraint is almost the same as
+// NewColumnReferencedByPartialIndex except it's used when dropping column that is
+// referenced in a partial unique without index constraint's predicate.
+func NewColumnReferencedByPartialUniqueWithoutIndexConstraint(
+	droppingColumn, partialUWIConstraint string,
+) error {
+	return errors.WithIssueLink(errors.WithHint(
+		pgerror.Newf(
+			pgcode.InvalidColumnReference,
+			"column %q cannot be dropped because it is referenced by partial unique constraint %q",
+			droppingColumn, partialUWIConstraint,
+		),
+		"drop the unique constraint first, then drop the column",
+	), errors.IssueLink{IssueURL: "https://github.com/cockroachdb/cockroach/pull/97372"})
+}
+
 // NewUniqueConstraintReferencedByForeignKeyError generates an error to be
 // returned when dropping a unique constraint that is relied upon by an
 // inbound foreign key constraint.


### PR DESCRIPTION
Informs #96924

Release note (bug fix/sql change): Columns referenced in partial index
predicates and partial unique constraint predicates can no longer be
dropped. The `ALTER TABLE .. DROP COLUMN` statement now returns an error
with a hint suggesting to drop the indexes and constraints first. This
is a temporary safe-guard to prevent users from hitting #96924. This
restriction will be lifted when that bug is fixed.
