### PR TITLE
makefile: hacky fix to grpc-gateway build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1364,10 +1364,15 @@ bin/.go_protobuf_sources: $(GO_PROTOS) $(GOGOPROTO_PROTO) $(ERRORS_PROTO) bin/.b
 	gofmt -s -w $(GO_SOURCES)
 	touch $@
 
+
+# NOTE(ssd): The grpc-gateway doesn't produce the correct import for roachpb without this.
+# Another fix would be to set go_package to the full package path in span_stats.proto.
+HACKY_MAP_ARG := Mroachpb/span_stats.proto=github.com/cockroachdb/cockroach/pkg/roachpb
+
 bin/.gw_protobuf_sources: $(GW_SERVER_PROTOS) $(GW_TS_PROTOS) $(GO_PROTOS) $(GOGOPROTO_PROTO) $(ERRORS_PROTO) bin/.bootstrap c-deps/proto-rebuild vendor/modules.txt
 	$(FIND_RELEVANT) -type f -name '*.pb.gw.go' -exec rm {} +
-		buf protoc -Ipkg -I$(GOGO_PROTOBUF_PATH) -I$(ERRORS_PATH) -I$(COREOS_PATH) -I$(PROMETHEUS_PATH) -I$(GRPC_GATEWAY_GOOGLEAPIS_PATH) --grpc-gateway_out=logtostderr=true,request_context=true:./pkg $(GW_SERVER_PROTOS)
-		buf protoc -Ipkg -I$(GOGO_PROTOBUF_PATH) -I$(ERRORS_PATH) -I$(COREOS_PATH) -I$(PROMETHEUS_PATH) -I$(GRPC_GATEWAY_GOOGLEAPIS_PATH) --grpc-gateway_out=logtostderr=true,request_context=true:./pkg $(GW_TS_PROTOS)
+		buf protoc -Ipkg -I$(GOGO_PROTOBUF_PATH) -I$(ERRORS_PATH) -I$(COREOS_PATH) -I$(PROMETHEUS_PATH) -I$(GRPC_GATEWAY_GOOGLEAPIS_PATH) --grpc-gateway_out=logtostderr=true,request_context=true,$(HACKY_MAP_ARG):./pkg $(GW_SERVER_PROTOS)
+		buf protoc -Ipkg -I$(GOGO_PROTOBUF_PATH) -I$(ERRORS_PATH) -I$(COREOS_PATH) -I$(PROMETHEUS_PATH) -I$(GRPC_GATEWAY_GOOGLEAPIS_PATH) --grpc-gateway_out=logtostderr=true,request_context=true,$(HACKY_MAP_ARG):./pkg $(GW_TS_PROTOS)
 	gofmt -s -w $(GW_SOURCES)
 	@# TODO(jordan,benesch) This can be removed along with the above TODO.
 	goimports -w $(GW_SOURCES)


### PR DESCRIPTION
During the make-based build, the grpc-gateway plugin produces a file that doesn't build.

```
pkg/server/serverpb/status.pb.gw.go:15:2: cannot find package "github.com/cockroachdb/cockroach/vendor/roachpb" in:
        /Users/ssd/go/src/github.com/cockroachdb/cockroach/vendor/roachpb
make: *** [Makefile:1229: lint] Error 1
```

It tries to import "roachpb" rather than
"github.com/cockroachdb/cockroach/pkg/roachpb".  There are a number of ways to fix this. But, I'm honestly not familiar enough with the state of our Make-based builds at the moment to choose the correct one.

Here, I put in an explicit mapping for the problematic import in question. The bazel-based builds uses some tooling which generates similar mappings for every single import.

Another approach would be to change the go_package directive in the relevant .proto file.

Epic: none

Release note: None