### PR TITLE
streamingccl: change frontier_lag_seconds to frontier_lag_nanos

### DIFF
--- a/pkg/ccl/streamingccl/streamingest/metrics.go
+++ b/pkg/ccl/streamingccl/streamingest/metrics.go
@@ -104,12 +104,12 @@ var (
 		Measurement: "Resolved Spans",
 		Unit:        metric.Unit_COUNT,
 	}
-	metaFrontierLagSeconds = metric.Metadata{
-		Name: "replication.frontier_lag_seconds",
+	metaFrontierLagNanos = metric.Metadata{
+		Name: "replication.frontier_lag_nanos",
 		Help: "Time between the wall clock and replicated time of the replication stream. " +
 			"This metric tracks how far behind the replication stream is relative to now",
-		Measurement: "Seconds",
-		Unit:        metric.Unit_SECONDS,
+		Measurement: "Nanoseconds",
+		Unit:        metric.Unit_NANOSECONDS,
 	}
 	metaJobProgressUpdates = metric.Metadata{
 		Name:        "replication.job_progress_updates",
@@ -146,7 +146,7 @@ type Metrics struct {
 	LatestDataCheckpointSpan    *metric.Gauge
 	DataCheckpointSpanCount     *metric.Gauge
 	FrontierCheckpointSpanCount *metric.Gauge
-	FrontierLagSeconds          *metric.GaugeFloat64
+	FrontierLagNanos            *metric.Gauge
 	ReplicationCutoverProgress  *metric.Gauge
 }
 
@@ -188,7 +188,7 @@ func MakeMetrics(histogramWindow time.Duration) metric.Struct {
 		LatestDataCheckpointSpan:    metric.NewGauge(metaLatestDataCheckpointSpan),
 		DataCheckpointSpanCount:     metric.NewGauge(metaDataCheckpointSpanCount),
 		FrontierCheckpointSpanCount: metric.NewGauge(metaFrontierCheckpointSpanCount),
-		FrontierLagSeconds:          metric.NewGaugeFloat64(metaFrontierLagSeconds),
+		FrontierLagNanos:            metric.NewGauge(metaFrontierLagNanos),
 		ReplicationCutoverProgress:  metric.NewGauge(metaReplicationCutoverProgress),
 	}
 	return m

--- a/pkg/ccl/streamingccl/streamingest/stream_ingestion_frontier_processor.go
+++ b/pkg/ccl/streamingccl/streamingest/stream_ingestion_frontier_processor.go
@@ -467,7 +467,7 @@ func (sf *streamIngestionFrontier) maybeUpdatePartitionProgress() error {
 	sf.metrics.JobProgressUpdates.Inc(1)
 	sf.persistedHighWater = f.Frontier()
 	sf.metrics.FrontierCheckpointSpanCount.Update(int64(len(frontierResolvedSpans)))
-	sf.metrics.FrontierLagSeconds.Update(timeutil.Since(sf.persistedHighWater.GoTime()).Seconds())
+	sf.metrics.FrontierLagNanos.Update(timeutil.Since(sf.persistedHighWater.GoTime()).Nanoseconds())
 
 	return nil
 }

--- a/pkg/ts/catalog/chart_catalog.go
+++ b/pkg/ts/catalog/chart_catalog.go
@@ -1643,7 +1643,7 @@ var charts = []sectionDescription{
 			},
 			{
 				Title:   "Frontier Lag",
-				Metrics: []string{"replication.frontier_lag_seconds"},
+				Metrics: []string{"replication.frontier_lag_nanos"},
 			},
 			{
 				Title:   "Job Progress Updates",

--- a/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/crossClusterReplication.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/crossClusterReplication.tsx
@@ -23,12 +23,12 @@ export default function (props: GraphDashboardProps) {
     <LineGraph
       title="Replication Lag"
       sources={storeSources}
-      tooltip={`The time between the wall clock and replicated time of the replication stream. 
+      tooltip={`The time between the wall clock and replicated time of the replication stream.
           This metric tracks how far behind the replication stream is relative to now.`}
     >
       <Axis units={AxisUnits.Duration} label="time">
         <Metric
-          name="cr.node.replication.frontier_lag_seconds"
+          name="cr.node.replication.frontier_lag_nanos"
           title="Replication Lag"
         />
       </Axis>


### PR DESCRIPTION
Our other time-related graphs all use nanoseconds, so AxisUnit.Duration is in nanoseconds, just like the underlying Go type. Thus, our graph was incorrectly reporting a 5s lag as a 5ns lag.

I've changed the units of the metric rather than the graph to match other time-related metrics.

Now, you may think nanoseconds are a level of precision that is mildly absurd here. And I agree.

Epic: none

Release note: None