### PR TITLE
status: skip TestTenantStatusAPI/.../test_tenant_ranges_pagination

### DIFF
--- a/pkg/ccl/serverccl/statusccl/tenant_status_test.go
+++ b/pkg/ccl/serverccl/statusccl/tenant_status_test.go
@@ -1312,6 +1312,8 @@ func testTenantRangesRPC(_ context.Context, t *testing.T, helper serverccl.Tenan
 	})
 
 	t.Run("test tenant ranges pagination", func(t *testing.T) {
+		skip.WithIssue(t, 92979,
+			"flaky test, difficult to reproduce locally. Skip until resolved.")
 		ctx := context.Background()
 		resp1, err := tenantA.TenantRanges(ctx, &serverpb.TenantRangesRequest{
 			Limit: 1,


### PR DESCRIPTION
Refs: https://github.com/cockroachdb/cockroach/issues/92979

Reason: flaky test, difficult to reproduce locally. Skip until resolved.

Release note: none

Informs: https://github.com/cockroachdb/cockroach/issues/92979