### PR TITLE
roachtest/cdc: increase cloud storage assume role acceptable latency

### DIFF
--- a/pkg/cmd/roachtest/tests/cdc.go
+++ b/pkg/cmd/roachtest/tests/cdc.go
@@ -1175,7 +1175,7 @@ func registerCDC(r registry.Registry) {
 			})
 			ct.runFeedLatencyVerifier(feed, latencyTargets{
 				initialScanLatency: 30 * time.Minute,
-				steadyLatency:      time.Minute,
+				steadyLatency:      90 * time.Second,
 			})
 			ct.waitForWorkload()
 		},


### PR DESCRIPTION
Previously, we would observe failures due to the latency jumping to ~1m15s.
- https://teamcity.cockroachdb.com/buildConfiguration/Cockroach_Nightlies_RoachtestNightlyGceBazel/8757437
- https://teamcity.cockroachdb.com/buildConfiguration/Cockroach_Nightlies_RoachtestNightlyGceBazel/8534805

The most likely explanation for this is network blips. Previously, the maximum acceptable latency was 1 minute. This change bumps it to 90 seconds to reduce how often we see flakes.

Fixes: https://github.com/cockroachdb/cockroach/issues/96330
Epic: none

Release note: None