### PR TITLE
storage: add guardrails to rocksdb.min_wal_sync_interval

### DIFF
--- a/pkg/storage/mvcc.go
+++ b/pkg/storage/mvcc.go
@@ -72,6 +72,7 @@ var minWALSyncInterval = settings.RegisterDurationSetting(
 	"rocksdb.min_wal_sync_interval",
 	"minimum duration between syncs of the RocksDB WAL",
 	0*time.Millisecond,
+	settings.NonNegativeDurationWithMaximum(1*time.Second),
 )
 
 // MVCCRangeTombstonesEnabled enables writing of MVCC range tombstones.


### PR DESCRIPTION
This commit prevents `rocksdb.min_wal_sync_interval` from being set to a negative value or from being set to a value above 1s. This prevents the cluster setting from being used to break node liveness and put a cluster into an unrecoverable state.

Release note: None
Epic: None