### PR TITLE
systemschema: switch session_uuid back to session_id

### DIFF
--- a/pkg/sql/catalog/systemschema/system.go
+++ b/pkg/sql/catalog/systemschema/system.go
@@ -492,11 +492,11 @@ CREATE TABLE system.sqlliveness (
 
 	MrSqllivenessTableSchema = `
 CREATE TABLE system.sqlliveness (
-    session_uuid         BYTES NOT NULL,
+    session_id           BYTES NOT NULL,
     expiration           DECIMAL NOT NULL,
     crdb_region          BYTES NOT NULL,
-    CONSTRAINT "primary" PRIMARY KEY (crdb_region, session_uuid),
-    FAMILY "primary" (crdb_region, session_uuid, expiration)
+    CONSTRAINT "primary" PRIMARY KEY (crdb_region, session_id),
+    FAMILY "primary" (crdb_region, session_id, expiration)
 )`
 
 	// system.migrations stores completion records for upgrades performed by the
@@ -2309,16 +2309,16 @@ var (
 					catconstants.SqllivenessTableName,
 					keys.SqllivenessID,
 					[]descpb.ColumnDescriptor{
-						{Name: "crdb_region", ID: 4, Type: types.Bytes, Nullable: false},
-						{Name: "session_uuid", ID: 3, Type: types.Bytes, Nullable: false},
+						{Name: "session_id", ID: 1, Type: types.Bytes, Nullable: false},
 						{Name: "expiration", ID: 2, Type: types.Decimal, Nullable: false},
+						{Name: "crdb_region", ID: 3, Type: types.Bytes, Nullable: false},
 					},
 					[]descpb.ColumnFamilyDescriptor{
 						{
 							Name:            "primary",
 							ID:              0,
-							ColumnNames:     []string{"crdb_region", "session_uuid", "expiration"},
-							ColumnIDs:       []descpb.ColumnID{4, 3, 2},
+							ColumnNames:     []string{"session_id", "expiration", "crdb_region"},
+							ColumnIDs:       []descpb.ColumnID{1, 2, 3},
 							DefaultColumnID: 2,
 						},
 					},
@@ -2326,9 +2326,9 @@ var (
 						Name:                "primary",
 						ID:                  2,
 						Unique:              true,
-						KeyColumnNames:      []string{"crdb_region", "session_uuid"},
+						KeyColumnNames:      []string{"crdb_region", "session_id"},
 						KeyColumnDirections: []catenumpb.IndexColumn_Direction{catenumpb.IndexColumn_ASC, catenumpb.IndexColumn_ASC},
-						KeyColumnIDs:        []descpb.ColumnID{4, 3},
+						KeyColumnIDs:        []descpb.ColumnID{3, 1},
 					},
 				))
 		}


### PR DESCRIPTION
The SessionID encodes a region prefix and a UUID. The initial implementation of RBR sqlliveness stored the crdb_region and the session_uuid. Now, sqlliveness stores the crdb_region and value of the SessionID.

```
SELECT * FROM system.sqlliveness;
                 session_id                |           expiration           | crdb_region
-------------------------------------------+--------------------------------+--------------
  \x01018028b91818a7584268992bb246f9755b37 | 1676502803528637593.0000000000 | \x80
(1 row)
```

Storing the complete SessionID takes an extra 3 bytes of storage but it makes it simpler to inspect the state of the system and join with tables that refer to the session_id. For example, it's possible to write this query:

```
SELECT *
FROM system.sqlliveness AS s
LEFT JOIN ON system.jobs AS j
WHERE s.session_id = j.session_id
AND s.crdb_region = 'us-central-1';
```

Release note: None