### PR TITLE
ui: update cluster-ui to 23.1.0-prerelease.4

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/package.json
+++ b/pkg/ui/workspaces/cluster-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cockroachlabs/cluster-ui",
-  "version": "23.1.0-prerelease.3",
+  "version": "23.1.0-prerelease.4",
   "description": "Cluster UI is a library of large features shared between CockroachDB and CockroachCloud",
   "repository": {
     "type": "git",


### PR DESCRIPTION
This commit updates the cluster-ui version to 23.1.0-prerelease.4.

Release note: None

Epic: None