### PR TITLE
allocator: make disk capacity threshold a setting

### DIFF
--- a/pkg/kv/kvserver/allocator/allocatorimpl/allocator.go
+++ b/pkg/kv/kvserver/allocator/allocatorimpl/allocator.go
@@ -1913,6 +1913,7 @@ func (a Allocator) RebalanceNonVoter(
 func (a *Allocator) ScorerOptions(ctx context.Context) *RangeCountScorerOptions {
 	return &RangeCountScorerOptions{
 		IOOverloadOptions:       a.IOOverloadOptions(),
+		DiskCapacityOptions:     a.DiskOptions(),
 		deterministic:           a.deterministic,
 		rangeRebalanceThreshold: RangeRebalanceThreshold.Get(&a.st.SV),
 	}
@@ -1923,6 +1924,7 @@ func (a *Allocator) ScorerOptionsForScatter(ctx context.Context) *ScatterScorerO
 	return &ScatterScorerOptions{
 		RangeCountScorerOptions: RangeCountScorerOptions{
 			IOOverloadOptions:       a.IOOverloadOptions(),
+			DiskCapacityOptions:     a.DiskOptions(),
 			deterministic:           a.deterministic,
 			rangeRebalanceThreshold: 0,
 		},
@@ -2172,6 +2174,13 @@ func (a *Allocator) leaseholderShouldMoveDueToPreferences(
 	return true
 }
 
+// DiskOptions returns the disk options. The disk options are used to determine
+// whether a store has disk capacity for additional replicas; or whether the
+// disk is over capacity and should shed replicas.
+func (a *Allocator) DiskOptions() DiskCapacityOptions {
+	return makeDiskCapacityOptions(&a.st.SV)
+}
+
 // IOOverloadOptions returns the store IO overload options. It is used to
 // filter and score candidates based on their level of IO overload and
 // enforcement level.
@@ -2352,6 +2361,7 @@ func (a *Allocator) TransferLeaseTarget(
 			storeDescMap,
 			&LoadScorerOptions{
 				IOOverloadOptions:            a.IOOverloadOptions(),
+				DiskOptions:                  a.DiskOptions(),
 				Deterministic:                a.deterministic,
 				LoadDims:                     opts.LoadDimensions,
 				LoadThreshold:                LoadThresholds(&a.st.SV, opts.LoadDimensions...),

--- a/pkg/kv/kvserver/allocator/allocatorimpl/allocator_scorer_test.go
+++ b/pkg/kv/kvserver/allocator/allocatorimpl/allocator_scorer_test.go
@@ -1096,7 +1096,9 @@ func TestShouldRebalanceDiversity(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	options := &RangeCountScorerOptions{}
+	options := &RangeCountScorerOptions{
+		DiskCapacityOptions: defaultDiskCapacityOptions(),
+	}
 	newStore := func(id int, locality roachpb.Locality) roachpb.StoreDescriptor {
 		return roachpb.StoreDescriptor{
 			StoreID: roachpb.StoreID(id),
@@ -1528,6 +1530,7 @@ func TestBalanceScoreByRangeCount(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	options := RangeCountScorerOptions{
+		DiskCapacityOptions:     defaultDiskCapacityOptions(),
 		rangeRebalanceThreshold: 0.1,
 	}
 	storeList := storepool.StoreList{
@@ -1612,7 +1615,9 @@ func TestRebalanceConvergesRangeCountOnMean(t *testing.T) {
 		{2000, false, true},
 	}
 
-	options := RangeCountScorerOptions{}
+	options := RangeCountScorerOptions{
+		DiskCapacityOptions: defaultDiskCapacityOptions(),
+	}
 	eqClass := equivalenceClass{
 		candidateSL: storeList,
 	}
@@ -1646,8 +1651,13 @@ func TestMaxCapacity(t *testing.T) {
 		testStoreEurope: true,
 	}
 
+	do := DiskCapacityOptions{
+		RebalanceToThreshold:     0.925,
+		ShedAndBlockAllThreshold: 0.95,
+	}
+
 	for _, s := range testStores {
-		if e, a := expectedCheck[s.StoreID], allocator.MaxCapacityCheck(s); e != a {
+		if e, a := expectedCheck[s.StoreID], do.maxCapacityCheck(s); e != a {
 			t.Errorf("store %d expected max capacity check: %t, actual %t", s.StoreID, e, a)
 		}
 	}

--- a/pkg/kv/kvserver/allocator/base.go
+++ b/pkg/kv/kvserver/allocator/base.go
@@ -23,12 +23,6 @@ import (
 )
 
 const (
-	// MaxFractionUsedThreshold controls the point at which the store cedes having
-	// room for new replicas. If the fraction used of a store descriptor capacity
-	// is greater than this value, it will never be used as a rebalance or
-	// allocate target and we will actively try to move replicas off of it.
-	MaxFractionUsedThreshold = 0.95
-
 	// MinQPSThresholdDifference is the minimum QPS difference from the cluster
 	// mean that this system should care about. In other words, we won't worry
 	// about rebalancing for QPS reasons if a store's QPS differs from the mean by
@@ -71,11 +65,6 @@ const (
 type AllocationError interface {
 	error
 	AllocationErrorMarker() // dummy method for unique interface
-}
-
-// MaxCapacityCheck returns true if the store has room for a new replica.
-func MaxCapacityCheck(store roachpb.StoreDescriptor) bool {
-	return store.Capacity.FractionUsed() < MaxFractionUsedThreshold
 }
 
 // IsStoreValid returns true iff the provided store would be a valid in a

--- a/pkg/kv/kvserver/allocator/storepool/store_pool.go
+++ b/pkg/kv/kvserver/allocator/storepool/store_pool.go
@@ -1071,9 +1071,7 @@ type StoreList struct {
 func MakeStoreList(descriptors []roachpb.StoreDescriptor) StoreList {
 	sl := StoreList{Stores: descriptors}
 	for _, desc := range descriptors {
-		if allocator.MaxCapacityCheck(desc) {
-			sl.CandidateRanges.update(float64(desc.Capacity.RangeCount))
-		}
+		sl.CandidateRanges.update(float64(desc.Capacity.RangeCount))
 		sl.CandidateLeases.update(float64(desc.Capacity.LeaseCount))
 		sl.candidateLogicalBytes.update(float64(desc.Capacity.LogicalBytes))
 		sl.CandidateQueriesPerSecond.update(desc.Capacity.QueriesPerSecond)

--- a/pkg/kv/kvserver/asim/storerebalancer/store_rebalancer.go
+++ b/pkg/kv/kvserver/asim/storerebalancer/store_rebalancer.go
@@ -135,6 +135,7 @@ func (s simRebalanceObjectiveProvider) Objective() kvserver.LBRebalancingObjecti
 func (src *storeRebalancerControl) scorerOptions() *allocatorimpl.LoadScorerOptions {
 	return &allocatorimpl.LoadScorerOptions{
 		IOOverloadOptions:            src.allocator.IOOverloadOptions(),
+		DiskOptions:                  src.allocator.DiskOptions(),
 		Deterministic:                true,
 		LoadDims:                     []load.Dimension{load.Queries},
 		LoadThreshold:                allocatorimpl.MakeQPSOnlyDim(src.settings.LBRebalanceQPSThreshold),

--- a/pkg/kv/kvserver/store_rebalancer.go
+++ b/pkg/kv/kvserver/store_rebalancer.go
@@ -285,6 +285,7 @@ func (sr *StoreRebalancer) scorerOptions(
 ) *allocatorimpl.LoadScorerOptions {
 	return &allocatorimpl.LoadScorerOptions{
 		IOOverloadOptions:            sr.allocator.IOOverloadOptions(),
+		DiskOptions:                  sr.allocator.DiskOptions(),
 		Deterministic:                sr.storePool.IsDeterministic(),
 		LoadDims:                     []load.Dimension{lbDimension},
 		LoadThreshold:                allocatorimpl.LoadThresholds(&sr.st.SV, lbDimension),


### PR DESCRIPTION
Previously, the store disk utilization was checked against a constant
threshold to determine if the store was a valid allocation target.

This commit adds two cluster settings to replace the constant.

`kv.allocator.max_disk_utilization_threshold`

Maximum disk utilization before a store will never be used as a
rebalance or allocation target and will actively have replicas moved off
of it.

`kv.allocator.rebalance_to_max_disk_utilization_threshold`

Maximum disk utilization before a store will never be used as a
rebalance target.

Resolves: https://github.com/cockroachdb/cockroach/issues/97392

Release note (ops change): Introduce two cluster settings to control disk
utilization thresholds for allocation.
`kv.allocator.rebalance_to_max_disk_utilization_threshold` Maximum disk
utilization before a store will never be used as a rebalance target.
`kv.allocator.max_disk_utilization_threshold` Maximum disk utilization
before a store will never be used as a rebalance or allocation target
and will actively have replicas moved off of it.