### PR TITLE
storage: write min version file with checkpoint

### DIFF
--- a/pkg/storage/pebble.go
+++ b/pkg/storage/pebble.go
@@ -1067,8 +1067,14 @@ func NewPebble(ctx context.Context, cfg PebbleConfig) (p *Pebble, err error) {
 		}
 		opts.ErrorIfNotExists = true
 	} else {
-		if opts.ErrorIfNotExists {
-			return nil, errors.Errorf("pebble: database %q does not exist", cfg.StorageConfig.Dir)
+		if opts.ErrorIfNotExists || opts.ReadOnly {
+			// Make sure the message is not confusing if the store does exist but
+			// there is no min version file.
+			filename := unencryptedFS.PathJoin(cfg.Dir, MinVersionFilename)
+			return nil, errors.Errorf(
+				"pebble: database %q does not exist (missing required file %q)",
+				cfg.StorageConfig.Dir, filename,
+			)
 		}
 		// If there is no min version file, there should be no store. If there is
 		// one, it's either 1) a store from a very old version (which we don't want


### PR DESCRIPTION
#### storage: better error for missing min version file

We require the min version filename to open a store. If it doesn't
exist, we assume the store doesn't exist which can lead to a confusing
message if just the min version file is missing. This commit makes
this message more useful.

Informs #97337

Release note: none
Epic: none

#### storage: write min version file with checkpoint

We now write out the min version file with checkpoints generated
through the storage layer. This allows checkpoints to be opened with
the cockroach storage layer (not just with the low level pebble tool).

Fixes #97337

Release note: None
Epic: none
