### PR TITLE
kv, util: add mvcc stats to telemetry logging channel

### DIFF
--- a/docs/generated/eventlog.md
+++ b/docs/generated/eventlog.md
@@ -2643,6 +2643,38 @@ An event of type `level_stats` contains per-level statistics for an LSM.
 
 
 
+### `replica_stats`
+
+An event of type `replica_stats` contains stats about the replicas in a store.
+These stats are also known as MVCCStats.
+
+
+| Field | Description | Sensitive |
+|--|--|--|
+| `RangeId` | The range_id associated with the replica. | no |
+| `ReplicaId` | replica_id is the id of the replica | no |
+| `ContainsEstimates` | contains_estimates indicates whether stats in the object are estimated or not. See pkg/storage/enginepb/mvcc.pb.go for more details. | no |
+| `LastUpdatedNanos` | last_update_nanos is a timestamp at which the ages were last updated. | no |
+| `IntentAge` | intent_age is the cumulative age of the tracked intents. | no |
+| `GcBytesAge` | gc_bytes_age is the cumulative age of the non-live data | no |
+| `LiveBytes` | live_bytes is the number of bytes stored in keys and values which can in principle be read by means of a Scan or Get in the far future, including intents but not deletion tombstones (or their intents). | no |
+| `LiveCount` | live_count is the number of meta keys tracked under live_bytes. | no |
+| `KeyBytes` | key_bytes is the number of bytes stored in all non-system point keys, including live, meta, old, and deleted keys. | no |
+| `KeyCount` | key_count is the number of meta keys tracked under key_bytes. | no |
+| `ValueBytes` | value_bytes is the number of bytes in all non-system version values, including meta values. | no |
+| `ValueCount` | val_count is the number of meta values tracked under val_bytes. | no |
+| `IntentCount` | intent_count is the number of keys tracked under intent_bytes. It is equal to the number of meta keys in the system with a non-empty Transaction proto. | no |
+| `SeparatedIntentCount` | separated_intent_count is the number of intents that are in the separated lock table. It is <= intent_count. | no |
+| `RangeKeyCount` | range_key_count is the number of range keys tracked under range_key_bytes. | no |
+| `RangeKeyBytes` | range_key_bytes is the encoded size of range keys. | no |
+| `RangeValCount` | range_val_count is the number of range key values tracked under range_val_bytes, i.e. the number of range key versions. | no |
+| `RangeValBytes` | range_val_bytes is the number of bytes stored in range keys. | no |
+| `SysBytes` | sys_bytes is the number of bytes stored in system-local kv-pairs. | no |
+| `SysCount` | sys_count is the number of meta keys tracked under sys_bytes. | no |
+| `AbortSpanBytes` | abort_span_bytes is the number of bytes stored in a range's abort span. These bytes are a subset of sys_bytes. | no |
+
+
+
 ### `store_stats`
 
 An event of type `store_stats` contains per store stats.
@@ -2685,6 +2717,7 @@ Note that because stats are scoped to the lifetime of the process, counters
 | `TableZombieCount` | table_zombie_count is the number of tables no longer referenced by the current DB state, but are still in use by an open iterator (gauge). | no |
 | `TableZombieSize` | table_zombie_size is the size, in bytes, of zombie tables (gauge). | no |
 | `RangeKeySetsCount` | range_key_sets_count is the approximate count of internal range key sets in the store. | no |
+| `Replicas` | replicas is a nested message containing containing statistics about the store's replicas. | yes |
 
 
 #### Common fields

--- a/pkg/kv/kvserver/BUILD.bazel
+++ b/pkg/kv/kvserver/BUILD.bazel
@@ -189,6 +189,7 @@ go_library(
         "//pkg/util/iterutil",
         "//pkg/util/limit",
         "//pkg/util/log",
+        "//pkg/util/log/eventpb",
         "//pkg/util/log/logcrash",
         "//pkg/util/metric",
         "//pkg/util/metric/aggmetric",

--- a/pkg/util/log/eventpb/event_test.go
+++ b/pkg/util/log/eventpb/event_test.go
@@ -62,8 +62,8 @@ func TestEventJSON(t *testing.T) {
 		// Primitive fields with an `includeempty` annotation will emit their zero
 		// value.
 		{
-			&StoreStats{Levels: []LevelStats{{Level: 0, NumFiles: 1}, {Level: 6, NumFiles: 2}}},
-			`"Levels":[{"Level":0,"NumFiles":1},{"Level":6,"NumFiles":2}]`,
+			&StoreStats{Levels: []LevelStats{{Level: 0, NumFiles: 1}, {Level: 6, NumFiles: 2}}, Replicas: []ReplicaStats{{RangeId: 1, ReplicaId: 1}, {RangeId: 2, ReplicaId: 1}}},
+			`"Levels":[{"Level":0,"NumFiles":1},{"Level":6,"NumFiles":2}],"Replicas":[{"RangeId":1,"ReplicaId":1},{"RangeId":2,"ReplicaId":1}]`,
 		},
 	}
 

--- a/pkg/util/log/eventpb/eventlog_channels_generated.go
+++ b/pkg/util/log/eventpb/eventlog_channels_generated.go
@@ -311,6 +311,9 @@ func (m *PasswordHashConverted) LoggingChannel() logpb.Channel { return logpb.Ch
 func (m *LevelStats) LoggingChannel() logpb.Channel { return logpb.Channel_TELEMETRY }
 
 // LoggingChannel implements the EventPayload interface.
+func (m *ReplicaStats) LoggingChannel() logpb.Channel { return logpb.Channel_TELEMETRY }
+
+// LoggingChannel implements the EventPayload interface.
 func (m *StoreStats) LoggingChannel() logpb.Channel { return logpb.Channel_TELEMETRY }
 
 // LoggingChannel implements the EventPayload interface.

--- a/pkg/util/log/eventpb/eventpbgen/gen.go
+++ b/pkg/util/log/eventpb/eventpbgen/gen.go
@@ -671,6 +671,18 @@ func (m *{{.GoType}}) AppendJSONFields(printComma bool, b redact.RedactableBytes
      }
      b = append(b, ']')
    }
+   {{- else if eq .FieldType "array_of_ReplicaStats"}}
+   if len(m.{{.FieldName}}) > 0 {
+     if printComma { b = append(b, ',')}; printComma = true
+     b = append(b, "\"{{.FieldName}}\":["...)
+     for i, l := range m.{{.FieldName}} {
+       if i > 0 { b = append(b, ',') }
+       b = append(b, '{')
+			 printComma, b = l.AppendJSONFields(false, b)
+       b = append(b, '}')
+     }
+     b = append(b, ']')
+   }
    {{- else if eq .FieldType "protobuf"}}
    if m.{{.FieldName}} != nil {
      if printComma { b = append(b, ',')}; printComma = true

--- a/pkg/util/log/eventpb/json_encode_generated.go
+++ b/pkg/util/log/eventpb/json_encode_generated.go
@@ -3772,6 +3772,201 @@ func (m *RenameType) AppendJSONFields(printComma bool, b redact.RedactableBytes)
 }
 
 // AppendJSONFields implements the EventPayload interface.
+func (m *ReplicaStats) AppendJSONFields(printComma bool, b redact.RedactableBytes) (bool, redact.RedactableBytes) {
+
+	if m.RangeId != 0 {
+		if printComma {
+			b = append(b, ',')
+		}
+		printComma = true
+		b = append(b, "\"RangeId\":"...)
+		b = strconv.AppendInt(b, int64(m.RangeId), 10)
+	}
+
+	if m.ReplicaId != 0 {
+		if printComma {
+			b = append(b, ',')
+		}
+		printComma = true
+		b = append(b, "\"ReplicaId\":"...)
+		b = strconv.AppendInt(b, int64(m.ReplicaId), 10)
+	}
+
+	if m.ContainsEstimates != 0 {
+		if printComma {
+			b = append(b, ',')
+		}
+		printComma = true
+		b = append(b, "\"ContainsEstimates\":"...)
+		b = strconv.AppendInt(b, int64(m.ContainsEstimates), 10)
+	}
+
+	if m.LastUpdatedNanos != 0 {
+		if printComma {
+			b = append(b, ',')
+		}
+		printComma = true
+		b = append(b, "\"LastUpdatedNanos\":"...)
+		b = strconv.AppendInt(b, int64(m.LastUpdatedNanos), 10)
+	}
+
+	if m.IntentAge != 0 {
+		if printComma {
+			b = append(b, ',')
+		}
+		printComma = true
+		b = append(b, "\"IntentAge\":"...)
+		b = strconv.AppendInt(b, int64(m.IntentAge), 10)
+	}
+
+	if m.GcBytesAge != 0 {
+		if printComma {
+			b = append(b, ',')
+		}
+		printComma = true
+		b = append(b, "\"GcBytesAge\":"...)
+		b = strconv.AppendInt(b, int64(m.GcBytesAge), 10)
+	}
+
+	if m.LiveBytes != 0 {
+		if printComma {
+			b = append(b, ',')
+		}
+		printComma = true
+		b = append(b, "\"LiveBytes\":"...)
+		b = strconv.AppendInt(b, int64(m.LiveBytes), 10)
+	}
+
+	if m.LiveCount != 0 {
+		if printComma {
+			b = append(b, ',')
+		}
+		printComma = true
+		b = append(b, "\"LiveCount\":"...)
+		b = strconv.AppendInt(b, int64(m.LiveCount), 10)
+	}
+
+	if m.KeyBytes != 0 {
+		if printComma {
+			b = append(b, ',')
+		}
+		printComma = true
+		b = append(b, "\"KeyBytes\":"...)
+		b = strconv.AppendInt(b, int64(m.KeyBytes), 10)
+	}
+
+	if m.KeyCount != 0 {
+		if printComma {
+			b = append(b, ',')
+		}
+		printComma = true
+		b = append(b, "\"KeyCount\":"...)
+		b = strconv.AppendInt(b, int64(m.KeyCount), 10)
+	}
+
+	if m.ValueBytes != 0 {
+		if printComma {
+			b = append(b, ',')
+		}
+		printComma = true
+		b = append(b, "\"ValueBytes\":"...)
+		b = strconv.AppendInt(b, int64(m.ValueBytes), 10)
+	}
+
+	if m.ValueCount != 0 {
+		if printComma {
+			b = append(b, ',')
+		}
+		printComma = true
+		b = append(b, "\"ValueCount\":"...)
+		b = strconv.AppendInt(b, int64(m.ValueCount), 10)
+	}
+
+	if m.IntentCount != 0 {
+		if printComma {
+			b = append(b, ',')
+		}
+		printComma = true
+		b = append(b, "\"IntentCount\":"...)
+		b = strconv.AppendInt(b, int64(m.IntentCount), 10)
+	}
+
+	if m.SeparatedIntentCount != 0 {
+		if printComma {
+			b = append(b, ',')
+		}
+		printComma = true
+		b = append(b, "\"SeparatedIntentCount\":"...)
+		b = strconv.AppendInt(b, int64(m.SeparatedIntentCount), 10)
+	}
+
+	if m.RangeKeyCount != 0 {
+		if printComma {
+			b = append(b, ',')
+		}
+		printComma = true
+		b = append(b, "\"RangeKeyCount\":"...)
+		b = strconv.AppendInt(b, int64(m.RangeKeyCount), 10)
+	}
+
+	if m.RangeKeyBytes != 0 {
+		if printComma {
+			b = append(b, ',')
+		}
+		printComma = true
+		b = append(b, "\"RangeKeyBytes\":"...)
+		b = strconv.AppendInt(b, int64(m.RangeKeyBytes), 10)
+	}
+
+	if m.RangeValCount != 0 {
+		if printComma {
+			b = append(b, ',')
+		}
+		printComma = true
+		b = append(b, "\"RangeValCount\":"...)
+		b = strconv.AppendInt(b, int64(m.RangeValCount), 10)
+	}
+
+	if m.RangeValBytes != 0 {
+		if printComma {
+			b = append(b, ',')
+		}
+		printComma = true
+		b = append(b, "\"RangeValBytes\":"...)
+		b = strconv.AppendInt(b, int64(m.RangeValBytes), 10)
+	}
+
+	if m.SysBytes != 0 {
+		if printComma {
+			b = append(b, ',')
+		}
+		printComma = true
+		b = append(b, "\"SysBytes\":"...)
+		b = strconv.AppendInt(b, int64(m.SysBytes), 10)
+	}
+
+	if m.SysCount != 0 {
+		if printComma {
+			b = append(b, ',')
+		}
+		printComma = true
+		b = append(b, "\"SysCount\":"...)
+		b = strconv.AppendInt(b, int64(m.SysCount), 10)
+	}
+
+	if m.AbortSpanBytes != 0 {
+		if printComma {
+			b = append(b, ',')
+		}
+		printComma = true
+		b = append(b, "\"AbortSpanBytes\":"...)
+		b = strconv.AppendInt(b, int64(m.AbortSpanBytes), 10)
+	}
+
+	return printComma, b
+}
+
+// AppendJSONFields implements the EventPayload interface.
 func (m *Restore) AppendJSONFields(printComma bool, b redact.RedactableBytes) (bool, redact.RedactableBytes) {
 
 	printComma, b = m.CommonEventDetails.AppendJSONFields(printComma, b)
@@ -5065,6 +5260,23 @@ func (m *StoreStats) AppendJSONFields(printComma bool, b redact.RedactableBytes)
 		printComma = true
 		b = append(b, "\"RangeKeySetsCount\":"...)
 		b = strconv.AppendUint(b, uint64(m.RangeKeySetsCount), 10)
+	}
+
+	if len(m.Replicas) > 0 {
+		if printComma {
+			b = append(b, ',')
+		}
+		printComma = true
+		b = append(b, "\"Replicas\":["...)
+		for i, l := range m.Replicas {
+			if i > 0 {
+				b = append(b, ',')
+			}
+			b = append(b, '{')
+			printComma, b = l.AppendJSONFields(false, b)
+			b = append(b, '}')
+		}
+		b = append(b, ']')
 	}
 
 	return printComma, b

--- a/pkg/util/log/eventpb/storage_events.proto
+++ b/pkg/util/log/eventpb/storage_events.proto
@@ -123,6 +123,10 @@ message StoreStats {
   // range_key_sets_count is the approximate count of internal range key sets in
   // the store.
   uint64 range_key_sets_count = 33 [(gogoproto.jsontag) = ",omitempty"];
+
+  // replicas is a nested message containing containing statistics about
+  // the store's replicas. 
+  repeated ReplicaStats replicas = 34 [(gogoproto.nullable) = false, (gogoproto.jsontag) = ""];
 }
 
 // LevelStats contains per-level statistics for an LSM.
@@ -164,4 +168,62 @@ message LevelStats {
   // num_sublevel is the count of sublevels for the level. This value is always
   // zero for levels other than L0 (gauge).
   int32 num_sublevels = 15 [(gogoproto.jsontag) = ",omitempty"];
+}
+
+// ReplicaStats contains stats about the replicas in a store.
+// These stats are also known as MVCCStats.
+message ReplicaStats {
+  // The range_id associated with the replica.
+  int32 range_id = 1 [(gogoproto.jsontag) = ",omitempty"];
+  // replica_id is the id of the replica
+  int32 replica_id = 2 [(gogoproto.jsontag) = ",omitempty"];
+  // contains_estimates indicates whether stats in the object are
+  // estimated or not. See pkg/storage/enginepb/mvcc.pb.go for more details.
+  int64 contains_estimates = 3 [(gogoproto.jsontag) = ",omitempty"];
+  // last_update_nanos is a timestamp at which the ages were last
+	// updated.
+  int64 last_updated_nanos = 4 [(gogoproto.jsontag) = ",omitempty"];
+  // intent_age is the cumulative age of the tracked intents.
+  int64 intent_age = 5 [(gogoproto.jsontag) = ",omitempty"];
+  // gc_bytes_age is the cumulative age of the non-live data
+  int64 gc_bytes_age = 6 [(gogoproto.jsontag) = ",omitempty"];
+  // live_bytes is the number of bytes stored in keys and values which can in
+	// principle be read by means of a Scan or Get in the far future, including
+	// intents but not deletion tombstones (or their intents).
+  int64 live_bytes = 7 [(gogoproto.jsontag) = ",omitempty"];
+  // live_count is the number of meta keys tracked under live_bytes.
+  int64 live_count = 8 [(gogoproto.jsontag) = ",omitempty"];
+  // key_bytes is the number of bytes stored in all non-system
+	// point keys, including live, meta, old, and deleted keys.
+	int64 key_bytes = 9 [(gogoproto.jsontag) = ",omitempty"];
+  // key_count is the number of meta keys tracked under key_bytes.
+  int64 key_count = 10 [(gogoproto.jsontag) = ",omitempty"];
+  // value_bytes is the number of bytes in all non-system version
+	// values, including meta values.
+  int64 value_bytes = 11 [(gogoproto.jsontag) = ",omitempty"];
+  // val_count is the number of meta values tracked under val_bytes.
+  int64 value_count = 12 [(gogoproto.jsontag) = ",omitempty"];
+  // intent_count is the number of keys tracked under intent_bytes.
+	// It is equal to the number of meta keys in the system with
+	// a non-empty Transaction proto.
+  int64 intent_count = 13 [(gogoproto.jsontag) = ",omitempty"];
+  // separated_intent_count is the number of intents that are in the separated
+	// lock table. It is <= intent_count.
+  int64 separated_intent_count = 14 [(gogoproto.jsontag) = ",omitempty"];
+  // range_key_count is the number of range keys tracked under range_key_bytes.
+	int64 range_key_count = 15 [(gogoproto.jsontag) = ",omitempty"];
+  // range_key_bytes is the encoded size of range keys. 
+  int64 range_key_bytes = 16 [(gogoproto.jsontag) = ",omitempty"];
+  // range_val_count is the number of range key values tracked under
+	// range_val_bytes, i.e. the number of range key versions.
+  int64 range_val_count = 17 [(gogoproto.jsontag) = ",omitempty"];
+  // range_val_bytes is the number of bytes stored in range keys. 
+  int64 range_val_bytes = 18 [(gogoproto.jsontag) = ",omitempty"];
+  // sys_bytes is the number of bytes stored in system-local kv-pairs.
+  int64 sys_bytes = 19 [(gogoproto.jsontag) = ",omitempty"];
+  // sys_count is the number of meta keys tracked under sys_bytes.
+  int64 sys_count = 20 [(gogoproto.jsontag) = ",omitempty"];
+  // abort_span_bytes is the number of bytes stored in a range's
+	// abort span. These bytes are a subset of sys_bytes.
+  int64 abort_span_bytes = 21 [(gogoproto.jsontag) = ",omitempty"];
 }


### PR DESCRIPTION
This change add a replicas field to the store stats payload for the telemetry logging channel. The replica stats that are logged are: contains_estimates, last_updated_nanos, intent_age, gc_bytes_age, live_bytes, live_count, key_bytes, key_count, value_bytes, value_count, intent_count, separated_intent_count, range_key_count, range_key_bytes, range_val_count, range_val_bytes, sys_bytes, sys_count, abort_span_bytes.

Fixes: #85411

Release note: None