### PR TITLE
ui: add missing props to storybook files

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/indexDetailsPage/indexDetailsPage.stories.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/indexDetailsPage/indexDetailsPage.stories.tsx
@@ -22,6 +22,7 @@ const withData: IndexDetailsPageProps = {
   indexName: randomName(),
   isTenant: false,
   nodeRegions: {},
+  timeScale: null,
   details: {
     loading: false,
     loaded: true,
@@ -60,6 +61,7 @@ const withData: IndexDetailsPageProps = {
   resetIndexUsageStats: () => {},
   refreshNodes: () => {},
   refreshUserSQLRoles: () => {},
+  onTimeScaleChange: () => {},
 };
 
 storiesOf("Index Details Page", module)

--- a/pkg/ui/workspaces/cluster-ui/src/transactionDetails/transactionDetails.stories.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionDetails/transactionDetails.stories.tsx
@@ -41,11 +41,13 @@ storiesOf("Transactions Details", module)
       nodeRegions={nodeRegions}
       isTenant={false}
       hasViewActivityRedactedRole={false}
+      transactionInsights={undefined}
       refreshData={noop}
       refreshUserSQLRoles={noop}
       onTimeScaleChange={noop}
       refreshNodes={noop}
       lastUpdated={moment("0001-01-01T00:00:00Z")}
+      refreshTransactionInsights={noop}
     />
   ))
   .add("with loading indicator", () => (
@@ -59,11 +61,13 @@ storiesOf("Transactions Details", module)
       nodeRegions={nodeRegions}
       isTenant={false}
       hasViewActivityRedactedRole={false}
+      transactionInsights={undefined}
       refreshData={noop}
       refreshUserSQLRoles={noop}
       onTimeScaleChange={noop}
       refreshNodes={noop}
       lastUpdated={moment("0001-01-01T00:00:00Z")}
+      refreshTransactionInsights={noop}
     />
   ))
   .add("with error alert", () => (
@@ -78,11 +82,13 @@ storiesOf("Transactions Details", module)
       error={error}
       isTenant={false}
       hasViewActivityRedactedRole={false}
+      transactionInsights={undefined}
       refreshData={noop}
       refreshUserSQLRoles={noop}
       onTimeScaleChange={noop}
       refreshNodes={noop}
       lastUpdated={moment("0001-01-01T00:00:00Z")}
+      refreshTransactionInsights={noop}
     />
   ))
   .add("No data for this time frame; no cached transaction text", () => {
@@ -97,11 +103,13 @@ storiesOf("Transactions Details", module)
         nodeRegions={nodeRegions}
         isTenant={false}
         hasViewActivityRedactedRole={false}
+        transactionInsights={undefined}
         refreshData={noop}
         refreshUserSQLRoles={noop}
         onTimeScaleChange={noop}
         refreshNodes={noop}
         lastUpdated={moment("0001-01-01T00:00:00Z")}
+        refreshTransactionInsights={noop}
       />
     );
   });


### PR DESCRIPTION
This commit adds missing props to storybook files in cluster-ui. These missing props are causing the publish_cluster_ui GH action to fail. See https://github.com/cockroachdb/cockroach/actions/runs/4236959074/jobs/7362369310.

Interestingly, these missing props weren't caught by any essential CI tests...

Epic: none

Release note: None