### PR TITLE
ui: remove redundant test, add mock stmt util

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.spec.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.spec.tsx
@@ -8,46 +8,14 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
-import React from "react";
 import { assert } from "chai";
-import { ReactWrapper, mount } from "enzyme";
-import { MemoryRouter } from "react-router-dom";
 
-import {
-  filterBySearchQuery,
-  StatementsPage,
-  StatementsPageProps,
-  StatementsPageState,
-} from "src/statementsPage";
-import statementsPagePropsFixture from "./statementsPage.fixture";
+import { filterBySearchQuery } from "src/statementsPage";
 import { AggregateStatistics } from "../statementsTable";
 import { FlatPlanNode } from "../statementDetails";
 
 describe("StatementsPage", () => {
-  describe("Statements table", () => {
-    it("sorts data by Execution Count DESC as default option", () => {
-      const rootWrapper = mount(
-        <MemoryRouter>
-          <StatementsPage {...statementsPagePropsFixture} />
-        </MemoryRouter>,
-      );
-
-      const statementsPageWrapper: ReactWrapper<
-        StatementsPageProps,
-        StatementsPageState,
-        React.Component<any, any>
-      > = rootWrapper.find(StatementsPage).first();
-      const statementsPageInstance = statementsPageWrapper.instance();
-
-      assert.equal(
-        statementsPageInstance.props.sortSetting.columnTitle,
-        "executionCount",
-      );
-      assert.equal(statementsPageInstance.props.sortSetting.ascending, false);
-    });
-  });
-
-  describe("filterBySearchQuery", () => {
+  test("filterBySearchQuery", () => {
     const testPlanNode: FlatPlanNode = {
       name: "render",
       attrs: [],


### PR DESCRIPTION
This commit removes a redundant test. The test aimed to verify that the default sort for the statements table in the stmts page was descending 'Execution Count', however, the test was reading the props passed to the test case, which we get from hard coded fixtures. The test was also extremely slow.

The util funciton 'mockStmt' was also added to help mock stmts provided to the stmts page for future testing.

Epic: none

Release note: None