### PR TITLE
sql/schemachanger: suffix columns were not properly handled for indexes

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/alter_primary_key
+++ b/pkg/sql/logictest/testdata/logic_test/alter_primary_key
@@ -1845,3 +1845,18 @@ CREATE TABLE t_90836(a INT NOT NULL, b INT NOT NULL, CONSTRAINT "constraint" PRI
 
 statement ok
 ALTER TABLE t_90836 DROP CONSTRAINT "constraint"; ALTER TABLE t_90836 ADD CONSTRAINT "constraint" PRIMARY KEY (b);
+
+
+# The following sub test validates a primary key swap,
+# where the recreated secondary indexes will have suffix
+# columns.
+subtest regression_97296
+
+statement ok
+CREATE TABLE t_97296 (a DECIMAL PRIMARY KEY, b INT NOT NULL, c INT NOT NULL, INDEX i4(c));
+
+statement ok
+INSERT INTO t_97296 VALUES (0.0, 5, 32);
+
+statement ok
+ALTER TABLE t_97296 ALTER PRIMARY KEY USING COLUMNS (b, a);

--- a/pkg/sql/schemachanger/scexec/scmutationexec/index.go
+++ b/pkg/sql/schemachanger/scexec/scmutationexec/index.go
@@ -397,13 +397,12 @@ func (i *immediateVisitor) AddColumnToIndex(ctx context.Context, op scop.AddColu
 		// We don't need to track the composite column IDs for stored columns.
 		op.Kind != scpb.IndexColumn_STORED {
 
-		index.NumKeyColumns()
 		var colOrdMap catalog.TableColMap
 		for i := 0; i < index.NumKeyColumns(); i++ {
 			colOrdMap.Set(index.GetKeyColumnID(i), i)
 		}
 		for i := 0; i < index.NumKeySuffixColumns(); i++ {
-			colOrdMap.Set(index.GetKeyColumnID(i), i+index.NumKeyColumns())
+			colOrdMap.Set(index.GetKeySuffixColumnID(i), i+index.NumKeyColumns())
 		}
 		indexDesc.CompositeColumnIDs = append(indexDesc.CompositeColumnIDs, column.GetID())
 		cids := indexDesc.CompositeColumnIDs


### PR DESCRIPTION
Previously, the logic to determine composite column IDs, iterated over the key column count when dealing with suffix columns. This meant that when creating indexes with composite columns we could hit index out of
of range error, if the number of suffix columns was less than key columns. Additionally, the composite column IDs could be ordered incorrectly, since the ordinal mapping was incomplete. To address this, this patch loops over the correct length of the suffix columns

Fixes: #97296

Release note: None