### PR TITLE
tree: fix DatumPrev for collated string

### DIFF
--- a/pkg/sql/sem/tree/datum.go
+++ b/pkg/sql/sem/tree/datum.go
@@ -6144,16 +6144,6 @@ func DatumPrev(
 			return nil, false
 		}
 		return NewDString(prev), true
-	case *DCollatedString:
-		prev, ok := prevString(d.Contents)
-		if !ok {
-			return nil, false
-		}
-		c, err := NewDCollatedString(prev, d.Locale, collationEnv)
-		if err != nil {
-			return nil, false
-		}
-		return c, true
 	case *DBytes:
 		prev, ok := prevString(string(*d))
 		if !ok {
@@ -6166,8 +6156,8 @@ func DatumPrev(
 		return NewDInterval(prev, types.DefaultIntervalTypeMetadata), true
 	default:
 		// TODO(yuzefovich): consider adding support for other datums that don't
-		// have Datum.Prev implementation (DBitArray, DGeography, DGeometry,
-		// DBox2D, DJSON, DArray).
+		// have Datum.Prev implementation (DCollatedString, DBitArray,
+		// DGeography, DGeometry, DBox2D, DJSON, DArray).
 		return datum.Prev(cmpCtx)
 	}
 }


### PR DESCRIPTION
This commit removes the support of collated strings from `DatumPrev`. As it turns out, the comparison of collated strings is done by comparing their collation keys, and the current method of generating the previous string (simply subtracting 1 from the last non-zero byte) doesn't work. Similar bug in `DatumNext` was fixed in
1902d3d919753e23a51f424054f5f92a173d3600 (which added the collated strings into randomly generated types), but I didn't stress the test to catch this bug. The impact of the bug is minor since it's only used in `debug statement-bundle recreate` command.

Epic: None

Release note: None