### PR TITLE
kv: configure transaction uncertainty interval for reverse scan

### DIFF
--- a/pkg/kv/kvserver/batcheval/cmd_reverse_scan.go
+++ b/pkg/kv/kvserver/batcheval/cmd_reverse_scan.go
@@ -43,6 +43,7 @@ func ReverseScan(
 		Inconsistent:          h.ReadConsistency != kvpb.CONSISTENT,
 		SkipLocked:            h.WaitPolicy == lock.WaitPolicy_SkipLocked,
 		Txn:                   h.Txn,
+		Uncertainty:           cArgs.Uncertainty,
 		MaxKeys:               h.MaxSpanRequestKeys,
 		MaxIntents:            storage.MaxIntentsPerWriteIntentError.Get(&cArgs.EvalCtx.ClusterSettings().SV),
 		TargetBytes:           h.TargetBytes,

--- a/pkg/kv/kvserver/client_test.go
+++ b/pkg/kv/kvserver/client_test.go
@@ -37,12 +37,31 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// getArgs returns a GetRequest and GetResponse pair addressed to
-// the default replica for the specified key.
+// getArgs returns a GetRequest for the specified key.
 func getArgs(key roachpb.Key) *kvpb.GetRequest {
 	return &kvpb.GetRequest{
 		RequestHeader: kvpb.RequestHeader{
 			Key: key,
+		},
+	}
+}
+
+// scanArgs returns a ScanRequest for the specified key and end key.
+func scanArgs(key, endKey roachpb.Key) *kvpb.ScanRequest {
+	return &kvpb.ScanRequest{
+		RequestHeader: kvpb.RequestHeader{
+			Key:    key,
+			EndKey: endKey,
+		},
+	}
+}
+
+// revScanArgs returns a ReverseScanRequest for the specified key and end key.
+func revScanArgs(key, endKey roachpb.Key) *kvpb.ReverseScanRequest {
+	return &kvpb.ReverseScanRequest{
+		RequestHeader: kvpb.RequestHeader{
+			Key:    key,
+			EndKey: endKey,
 		},
 	}
 }


### PR DESCRIPTION
This commit configures the transaction uncertainty intervals for reverse scans. This was initially missed in 261fc35, which broke the use of observed timestamps for reverse scans. In 0ee3bbd, we started using this new plumbing path for the entire uncertainty interval, so the pessimization became a correctness bug that could lead to a loss of real-time ordering between a write and a reverse scan in cases with moderate but bounded clock skew between nodes.

The commit adds testing for this case and the ScanRequest case. I should have exercised these cases back in 8445150 when I noticed there was a complete absence of end-to-end testing for uncertainty interval errors. Unfortunately, that commit only added testing for the GetRequest case, allowing the bug to slip in for ReverseScanRequest.

Release note (bug fix): Transaction uncertainty intervals are correctly configured for reverse scans again, ensuring that reverse scans cannot serve stale reads when clocks in a cluster are skewed.

Epic: None