### PR TITLE
c2c: set replication_lag metric to 0 before high water mark is set

### DIFF
--- a/pkg/ccl/streamingccl/streamingest/stream_ingestion_frontier_processor.go
+++ b/pkg/ccl/streamingccl/streamingest/stream_ingestion_frontier_processor.go
@@ -467,7 +467,10 @@ func (sf *streamIngestionFrontier) maybeUpdatePartitionProgress() error {
 	sf.metrics.JobProgressUpdates.Inc(1)
 	sf.persistedHighWater = f.Frontier()
 	sf.metrics.FrontierCheckpointSpanCount.Update(int64(len(frontierResolvedSpans)))
-	sf.metrics.FrontierLagNanos.Update(timeutil.Since(sf.persistedHighWater.GoTime()).Nanoseconds())
-
+	if !sf.persistedHighWater.IsEmpty() {
+		// Only update the frontier lag if the high water mark has been updated,
+		// implying the initial scan has completed.
+		sf.metrics.FrontierLagNanos.Update(timeutil.Since(sf.persistedHighWater.GoTime()).Nanoseconds())
+	}
 	return nil
 }

--- a/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/crossClusterReplication.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/crossClusterReplication.tsx
@@ -24,7 +24,7 @@ export default function (props: GraphDashboardProps) {
       title="Replication Lag"
       sources={storeSources}
       tooltip={`The time between the wall clock and replicated time of the replication stream.
-          This metric tracks how far behind the replication stream is relative to now.`}
+          This metric tracks how far behind the replication stream is relative to now. This metric is set to 0 during the initial scan.`}
     >
       <Axis units={AxisUnits.Duration} label="time">
         <Metric


### PR DESCRIPTION
Fixes #97224

Release note: None