### PR TITLE
server: initialize DBContext with correct instance ID

### DIFF
--- a/pkg/server/tenant.go
+++ b/pkg/server/tenant.go
@@ -1017,7 +1017,11 @@ func makeTenantSQLServerArgs(
 		},
 		ds,
 	)
-	db := kv.NewDB(baseCfg.AmbientCtx, tcsFactory, clock, stopper)
+
+	dbCtx := kv.DefaultDBContext(stopper)
+	dbCtx.NodeID = instanceIDContainer
+	db := kv.NewDBWithContext(baseCfg.AmbientCtx, tcsFactory, clock, dbCtx)
+
 	rangeFeedKnobs, _ := baseCfg.TestingKnobs.RangeFeed.(*rangefeed.TestingKnobs)
 	rangeFeedFactory, err := rangefeed.NewFactory(stopper, db, st, rangeFeedKnobs)
 	if err != nil {


### PR DESCRIPTION
Before this change the DBContext in a tenant would always have a zero'd SQLInstanceID.

Note that for SQL pods not co-located on an KV-node, OptionalNodeID() should still return 0 and anything that requires a NodeID rather than an InstanceID _should_ be using that method.

Informs: #96353

Epic: none

Release note: None