### PR TITLE
server: fix broken logout with multi-tenant cookie

### DIFF
--- a/pkg/ccl/oidcccl/authentication_oidc.go
+++ b/pkg/ccl/oidcccl/authentication_oidc.go
@@ -307,7 +307,7 @@ var ConfigureOIDC = func(
 			return
 		}
 		if !valid {
-			log.Error(ctx, "OIDC: invalid client cooke and state token pair")
+			log.Error(ctx, "OIDC: invalid client cookie and state token pair")
 			http.Error(w, genericCallbackHTTPError, http.StatusBadRequest)
 			return
 		}

--- a/pkg/ccl/serverccl/tenant_test_utils.go
+++ b/pkg/ccl/serverccl/tenant_test_utils.go
@@ -263,7 +263,7 @@ func (c tenantCluster) TenantHTTPClient(t *testing.T, idx serverIdx, isAdmin boo
 	if isAdmin {
 		client, err = c.Tenant(idx).GetTenant().GetAdminHTTPClient()
 	} else {
-		client, err = c.Tenant(idx).GetTenant().GetAuthenticatedHTTPClient(false)
+		client, err = c.Tenant(idx).GetTenant().GetAuthenticatedHTTPClient(false, serverutils.SingleTenantSession)
 	}
 	require.NoError(t, err)
 	return &httpClient{t: t, client: client, baseURL: c[idx].GetTenant().AdminURL()}

--- a/pkg/server/admin_test.go
+++ b/pkg/server/admin_test.go
@@ -264,7 +264,7 @@ func TestAdminDebugAuth(t *testing.T) {
 	}
 
 	// Authenticated as non-admin.
-	client, err = ts.GetAuthenticatedHTTPClient(false)
+	client, err = ts.GetAuthenticatedHTTPClient(false, serverutils.SingleTenantSession)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -278,7 +278,7 @@ func TestAdminDebugAuth(t *testing.T) {
 	}
 
 	// Authenticated as admin.
-	client, err = ts.GetAuthenticatedHTTPClient(true)
+	client, err = ts.GetAuthenticatedHTTPClient(true, serverutils.SingleTenantSession)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -390,7 +390,7 @@ func TestAdminAPIDatabases(t *testing.T) {
 	// We have to create the non-admin user before calling
 	// "GRANT ... TO authenticatedUserNameNoAdmin".
 	// This is done in "GetAuthenticatedHTTPClient".
-	if _, err := ts.GetAuthenticatedHTTPClient(false); err != nil {
+	if _, err := ts.GetAuthenticatedHTTPClient(false, serverutils.SingleTenantSession); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1613,7 +1613,7 @@ func TestAdminAPIJobs(t *testing.T) {
 	testutils.RunTrueAndFalse(t, "isAdmin", func(t *testing.T, isAdmin bool) {
 		// Creating this client causes a user to be created, which causes jobs
 		// to be created, so we do it up-front rather than inside the test.
-		_, err := s.GetAuthenticatedHTTPClient(isAdmin)
+		_, err := s.GetAuthenticatedHTTPClient(isAdmin, serverutils.SingleTenantSession)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/pkg/server/api_v2_sql_test.go
+++ b/pkg/server/api_v2_sql_test.go
@@ -44,7 +44,7 @@ func TestExecSQL(t *testing.T) {
 	adminClient, err := server.GetAdminHTTPClient()
 	require.NoError(t, err)
 
-	nonAdminClient, err := server.GetAuthenticatedHTTPClient(false)
+	nonAdminClient, err := server.GetAuthenticatedHTTPClient(false, serverutils.SingleTenantSession)
 	require.NoError(t, err)
 
 	datadriven.RunTest(t, "testdata/api_v2_sql",

--- a/pkg/server/api_v2_test.go
+++ b/pkg/server/api_v2_test.go
@@ -118,7 +118,7 @@ func TestListSessionsV2(t *testing.T) {
 	}
 
 	// A non-admin user cannot see sessions at all.
-	nonAdminClient, err := ts1.GetAuthenticatedHTTPClient(false)
+	nonAdminClient, err := ts1.GetAuthenticatedHTTPClient(false, serverutils.SingleTenantSession)
 	require.NoError(t, err)
 	req, err := http.NewRequest("GET", ts1.AdminURL()+apiV2Path+"sessions/", nil)
 	require.NoError(t, err)

--- a/pkg/server/authentication_test.go
+++ b/pkg/server/authentication_test.go
@@ -579,7 +579,9 @@ func TestLogoutClearsCookies(t *testing.T) {
 	ts := s.(*TestServer)
 
 	// Log in.
-	authHTTPClient, _, err := ts.getAuthenticatedHTTPClientAndCookie(authenticatedUserName(), true)
+	authHTTPClient, _, err := ts.getAuthenticatedHTTPClientAndCookie(
+		authenticatedUserName(), true, serverutils.SingleTenantSession,
+	)
 	require.NoError(t, err)
 
 	// Log out.
@@ -604,7 +606,9 @@ func TestLogout(t *testing.T) {
 	ts := s.(*TestServer)
 
 	// Log in.
-	authHTTPClient, cookie, err := ts.getAuthenticatedHTTPClientAndCookie(authenticatedUserName(), true)
+	authHTTPClient, cookie, err := ts.getAuthenticatedHTTPClientAndCookie(
+		authenticatedUserName(), true, serverutils.SingleTenantSession,
+	)
 	if err != nil {
 		t.Fatal("error opening HTTP client", err)
 	}

--- a/pkg/server/node_http_router_test.go
+++ b/pkg/server/node_http_router_test.go
@@ -145,7 +145,7 @@ func TestRouteToNode(t *testing.T) {
 			require.Equal(t, rt.sourceServerID+1, int(s.NodeID()))
 			client, err := s.GetUnauthenticatedHTTPClient()
 			if rt.requireAuth {
-				client, err = s.GetAuthenticatedHTTPClient(rt.requireAdmin)
+				client, err = s.GetAuthenticatedHTTPClient(rt.requireAdmin, serverutils.SingleTenantSession)
 			}
 			require.NoError(t, err)
 

--- a/pkg/server/server_controller_http.go
+++ b/pkg/server/server_controller_http.go
@@ -238,9 +238,17 @@ func (c *serverController) attemptLogoutFromAllTenants() http.Handler {
 			w.WriteHeader(http.StatusInternalServerError)
 			return
 		}
-		sessionCookie, err := r.Cookie(SessionCookieName)
+		sessionCookie, err := r.Cookie(MultitenantSessionCookieName)
+		if errors.Is(err, http.ErrNoCookie) {
+			sessionCookie, err = r.Cookie(SessionCookieName)
+			if err != nil {
+				log.Warningf(ctx, "unable to find session cookie: %v", err)
+				w.WriteHeader(http.StatusInternalServerError)
+				return
+			}
+		}
 		if err != nil {
-			log.Warning(ctx, "unable to find session cookie")
+			log.Warningf(ctx, "unable to find multi-tenant session cookie: %v", err)
 			w.WriteHeader(http.StatusInternalServerError)
 			return
 		}
@@ -277,7 +285,6 @@ func (c *serverController) attemptLogoutFromAllTenants() http.Handler {
 			// process of shutting down.
 			if sw.Header().Get("Set-Cookie") == "" {
 				log.Warningf(ctx, "logout for tenant %q failed: HTTP %d - %s", name, sw.code, &sw.buf)
-				return
 			}
 		}
 		// Clear session and tenant cookies after all logouts have completed.

--- a/pkg/server/server_http_test.go
+++ b/pkg/server/server_http_test.go
@@ -34,7 +34,7 @@ func TestHSTS(t *testing.T) {
 	require.NoError(t, err)
 	defer httpClient.CloseIdleConnections()
 
-	secureClient, err := s.GetAuthenticatedHTTPClient(false)
+	secureClient, err := s.GetAuthenticatedHTTPClient(false, serverutils.SingleTenantSession)
 	require.NoError(t, err)
 	defer secureClient.CloseIdleConnections()
 

--- a/pkg/testutils/serverutils/test_server_shim.go
+++ b/pkg/testutils/serverutils/test_server_shim.go
@@ -446,7 +446,7 @@ func GetJSONProto(ts TestServerInterface, path string, response protoutil.Messag
 func GetJSONProtoWithAdminOption(
 	ts TestServerInterface, path string, response protoutil.Message, isAdmin bool,
 ) error {
-	httpClient, err := ts.GetAuthenticatedHTTPClient(isAdmin)
+	httpClient, err := ts.GetAuthenticatedHTTPClient(isAdmin, SingleTenantSession)
 	if err != nil {
 		return err
 	}
@@ -465,7 +465,7 @@ func PostJSONProto(ts TestServerInterface, path string, request, response protou
 func PostJSONProtoWithAdminOption(
 	ts TestServerInterface, path string, request, response protoutil.Message, isAdmin bool,
 ) error {
-	httpClient, err := ts.GetAuthenticatedHTTPClient(isAdmin)
+	httpClient, err := ts.GetAuthenticatedHTTPClient(isAdmin, SingleTenantSession)
 	if err != nil {
 		return err
 	}

--- a/pkg/testutils/serverutils/test_tenant_shim.go
+++ b/pkg/testutils/serverutils/test_tenant_shim.go
@@ -30,6 +30,14 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 )
 
+type SessionType int
+
+const (
+	UnknownSession SessionType = iota
+	SingleTenantSession
+	MultiTenantSession
+)
+
 // TestTenantInterface defines SQL-only tenant functionality that tests need; it
 // is implemented by server.Test{Tenant,Server}. Tests written against this
 // interface are effectively agnostic to the type of tenant (host or secondary)
@@ -147,7 +155,7 @@ type TestTenantInterface interface {
 	GetAdminHTTPClient() (http.Client, error)
 	// GetAuthenticatedHTTPClient returns an http client which has been
 	// authenticated to access Admin API methods (via a cookie).
-	GetAuthenticatedHTTPClient(isAdmin bool) (http.Client, error)
+	GetAuthenticatedHTTPClient(isAdmin bool, sessionType SessionType) (http.Client, error)
 	// GetEncodedSession returns a byte array containing a valid auth
 	// session.
 	GetAuthSession(isAdmin bool) (*serverpb.SessionCookie, error)


### PR DESCRIPTION
Previously the logout code assumed that a session cookie would be present. This
was likely a bug in the original logout impl in the server controller since
code further down in logout expected to parse out individual sessions from the
first cookie. This cookie should be the multi-tenant session cookie.

The cookie lookup is changed in order to accept either a multi-tenant session
or a legacy session cookie for backwards compatibility.

Tests were added and a new parameter on `GetAuthenticatedHTTPClient` for the
test server can now set either a multi-tenant cookie or a session cookie
depending on your preferences.

A second bug was found and fixed which failed to continue through the logout
fanout loop if a failure was encountered. This caused the cleared cookies to
never be set which caused a broken logout loop. This could be encountered in
situations where a dev server was destroyed and a new one as created. The old
session from the old server would fail to clear (since it didn't exist in
`web_sessions`) and we'd be stuck without a valid logout response.

Epic: CRDB-12100

Release note: None