### PR TITLE
release: fetch all tags for pick sha

### DIFF
--- a/build/teamcity/internal/cockroach/release/process/cancel_release_date_impl.sh
+++ b/build/teamcity/internal/cockroach/release/process/cancel_release_date_impl.sh
@@ -11,7 +11,7 @@ if [[ -z "${DRY_RUN}" ]] ; then
 fi
 
 # run git fetch in order to get all remote branches
-git fetch -q origin
+git fetch --tags -q origin
 bazel build --config=crosslinux //pkg/cmd/release
 
 $(bazel info --config=crosslinux bazel-bin)/pkg/cmd/release/release_/release \

--- a/build/teamcity/internal/cockroach/release/process/pick_sha_impl.sh
+++ b/build/teamcity/internal/cockroach/release/process/pick_sha_impl.sh
@@ -23,7 +23,7 @@ log_into_gcloud
 export GOOGLE_APPLICATION_CREDENTIALS="$PWD/.google-credentials.json"
 
 # run git fetch in order to get all remote branches
-git fetch -q origin
+git fetch --tags -q origin
 bazel build --config=crosslinux //pkg/cmd/release
 
 $(bazel info --config=crosslinux bazel-bin)/pkg/cmd/release/release_/release \

--- a/build/teamcity/internal/cockroach/release/process/post_blockers_impl.sh
+++ b/build/teamcity/internal/cockroach/release/process/post_blockers_impl.sh
@@ -11,7 +11,7 @@ if [[ -z "${DRY_RUN}" ]] ; then
 fi
 
 # run git fetch in order to get all remote branches
-git fetch -q origin
+git fetch --tags -q origin
 bazel build --config=crosslinux //pkg/cmd/release
 
 $(bazel info --config=crosslinux bazel-bin)/pkg/cmd/release/release_/release \

--- a/build/teamcity/internal/cockroach/release/process/update_versions_impl.sh
+++ b/build/teamcity/internal/cockroach/release/process/update_versions_impl.sh
@@ -10,7 +10,7 @@ if [[ -z "${DRY_RUN}" ]] ; then
 fi
 
 # run git fetch in order to get all remote branches
-git fetch -q origin
+git fetch --tags -q origin
 
 # install gh
 wget -O /tmp/gh.tar.gz https://github.com/cli/cli/releases/download/v2.13.0/gh_2.13.0_linux_amd64.tar.gz


### PR DESCRIPTION
Previously, the pick sha step relies on querying existing tags, but when a release is created on cherry-pick branch (staging-*), we don't have those tags in the local git checkout.

This PR explicitly fetches all tags to have the cherry-pick release tags available locally.

Fixes: RE-386
Epic: none
Release note: None