### PR TITLE
ui: fix jobs page error state

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/jobs/jobsPage/jobsPage.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/jobs/jobsPage/jobsPage.tsx
@@ -243,7 +243,6 @@ export class JobsPage extends React.Component<JobsPageProps, PageState> {
       onColumnsChange,
     } = this.props;
     const isLoading = reqInFlight && (!isDataValid || !jobs);
-    const error = jobs && jobsError;
     const { pagination } = this.state;
     const filteredJobs = jobs?.jobs ?? [];
     const columns = makeJobsColumns();
@@ -300,7 +299,14 @@ export class JobsPage extends React.Component<JobsPageProps, PageState> {
           </PageConfig>
         </div>
         <div className={cx("table-area")}>
-          <Loading loading={isLoading} page={"jobs"} error={error}>
+          {jobsError && jobs && (
+            <InlineAlert intent="danger" title={jobsError.message} />
+          )}
+          <Loading
+            loading={isLoading}
+            page={"jobs"}
+            error={!jobs ? jobsError : null}
+          >
             <div>
               <section className={sortableTableCx("cl-table-container")}>
                 <div className={sortableTableCx("cl-table-statistic")}>
@@ -350,7 +356,7 @@ export class JobsPage extends React.Component<JobsPageProps, PageState> {
               />
             </div>
           </Loading>
-          {isLoading && !error && (
+          {isLoading && !jobsError && (
             <Delayed delay={moment.duration(2, "s")}>
               <InlineAlert
                 intent="info"


### PR DESCRIPTION
Previously, the error state for the jobs page was
only displayed if there were previously jobs
returned. We should show the api error even when
we have never received a successful jobs payload
(e.g. error on first request). This commit changes 
error displaying in the jobs page  such that we will 
show the request error  regardless of whether or 
not we have previously received data. If we have 
previous data when we receive an unsuccessful request 
response, we will show the error along with the existing data.

Epic: none

Release note (bug fix): Jobs page properly shows error state when we receive an error during data fetching.