### PR TITLE
cdc: add hint to schedule changefeed on initial scan error

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -4593,11 +4593,11 @@ func TestChangefeedErrors(t *testing.T) {
 
 	// WITH only_initial_scan and no_initial_scan disallowed
 	sqlDB.ExpectErr(
-		t, `cannot specify both initial_scan_only and no_initial_scan`,
+		t, `cannot specify both initial_scan='only' and no_initial_scan`,
 		`CREATE CHANGEFEED FOR foo INTO $1 WITH initial_scan_only, no_initial_scan`, `kafka://nope`,
 	)
 	sqlDB.ExpectErr(
-		t, `cannot specify both initial_scan_only and no_initial_scan`,
+		t, `cannot specify both initial_scan='only' and no_initial_scan`,
 		`CREATE CHANGEFEED FOR foo INTO $1 WITH no_initial_scan, initial_scan_only`, `kafka://nope`,
 	)
 
@@ -4613,40 +4613,40 @@ func TestChangefeedErrors(t *testing.T) {
 
 	// WITH only_initial_scan and end_time disallowed
 	sqlDB.ExpectErr(
-		t, `cannot specify both initial_scan_only and end_time`,
+		t, `cannot specify both initial_scan='only' and end_time`,
 		`CREATE CHANGEFEED FOR foo INTO $1 WITH initial_scan_only, end_time = '1'`, `kafka://nope`,
 	)
 	sqlDB.ExpectErr(
-		t, `cannot specify both initial_scan_only and end_time`,
+		t, `cannot specify both initial_scan='only' and end_time`,
 		`CREATE CHANGEFEED FOR foo INTO $1 WITH end_time = '1', initial_scan_only`, `kafka://nope`,
 	)
 
 	sqlDB.ExpectErr(
-		t, `cannot specify both initial_scan_only and end_time`,
+		t, `cannot specify both initial_scan='only' and end_time`,
 		`CREATE CHANGEFEED FOR foo INTO $1 WITH end_time = '1', initial_scan = 'only'`, `kafka://nope`,
 	)
 	sqlDB.ExpectErr(
-		t, `cannot specify both initial_scan_only and end_time`,
+		t, `cannot specify both initial_scan='only' and end_time`,
 		`CREATE CHANGEFEED FOR foo INTO $1 WITH initial_scan = 'only', end_time = '1'`, `kafka://nope`,
 	)
 
 	sqlDB.ExpectErr(
-		t, `cannot specify both initial_scan_only and resolved`,
+		t, `cannot specify both initial_scan='only' and resolved`,
 		`CREATE CHANGEFEED FOR foo INTO $1 WITH resolved, initial_scan = 'only'`, `kafka://nope`,
 	)
 
 	sqlDB.ExpectErr(
-		t, `cannot specify both initial_scan_only and diff`,
+		t, `cannot specify both initial_scan='only' and diff`,
 		`CREATE CHANGEFEED FOR foo INTO $1 WITH diff, initial_scan = 'only'`, `kafka://nope`,
 	)
 
 	sqlDB.ExpectErr(
-		t, `cannot specify both initial_scan_only and mvcc_timestamp`,
+		t, `cannot specify both initial_scan='only' and mvcc_timestamp`,
 		`CREATE CHANGEFEED FOR foo INTO $1 WITH mvcc_timestamp, initial_scan = 'only'`, `kafka://nope`,
 	)
 
 	sqlDB.ExpectErr(
-		t, `cannot specify both initial_scan_only and updated`,
+		t, `cannot specify both initial_scan='only' and updated`,
 		`CREATE CHANGEFEED FOR foo INTO $1 WITH updated, initial_scan = 'only'`, `kafka://nope`,
 	)
 

--- a/pkg/ccl/changefeedccl/changefeedbase/BUILD.bazel
+++ b/pkg/ccl/changefeedccl/changefeedbase/BUILD.bazel
@@ -19,6 +19,8 @@ go_library(
         "//pkg/settings",
         "//pkg/sql/catalog/descpb",
         "//pkg/sql/catalog/lease",
+        "//pkg/sql/pgwire/pgcode",
+        "//pkg/sql/pgwire/pgerror",
         "//pkg/util",
         "@com_github_cockroachdb_errors//:errors",
     ],

--- a/pkg/ccl/changefeedccl/changefeedbase/options.go
+++ b/pkg/ccl/changefeedccl/changefeedbase/options.go
@@ -14,6 +14,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/errors"
 )
 
@@ -606,7 +608,7 @@ func (s StatementOptions) GetInitialScanType() (InitialScanType, error) {
 
 	if noInitialScanSet && initialScanOnlySet {
 		return InitialScan, errors.Errorf(
-			`cannot specify both %s and %s`, OptInitialScanOnly,
+			`cannot specify both %s='only' and %s`, OptInitialScan,
 			OptNoInitialScan)
 	}
 
@@ -962,7 +964,10 @@ func describeEnum(strs ...string) string {
 // ValidateForCreateChangefeed checks that the provided options are
 // valid for a CREATE CHANGEFEED statement using the type assertions
 // in ChangefeedOptionExpectValues.
-func (s StatementOptions) ValidateForCreateChangefeed(isPredicateChangefeed bool) error {
+func (s StatementOptions) ValidateForCreateChangefeed(isPredicateChangefeed bool) (e error) {
+	defer func() {
+		e = pgerror.Wrap(e, pgcode.InvalidParameterValue, "")
+	}()
 	err := s.validateAgainst(ChangefeedOptionExpectValues)
 	if err != nil {
 		return err
@@ -974,13 +979,13 @@ func (s StatementOptions) ValidateForCreateChangefeed(isPredicateChangefeed bool
 	validateInitialScanUnsupportedOptions := func(errMsg string) error {
 		for o := range InitialScanOnlyUnsupportedOptions {
 			if _, ok := s.m[o]; ok {
-				return errors.Newf(`cannot specify both %s and %s`, errMsg, o)
+				return errors.Newf(`cannot specify both %s='only' and %s`, OptInitialScan, o)
 			}
 		}
 		return nil
 	}
 	if scanType == OnlyInitialScan {
-		if err := validateInitialScanUnsupportedOptions(OptInitialScanOnly); err != nil {
+		if err := validateInitialScanUnsupportedOptions(fmt.Sprintf("%s='only'", OptInitialScan)); err != nil {
 			return err
 		}
 	} else {

--- a/pkg/ccl/changefeedccl/changefeedbase/options_test.go
+++ b/pkg/ccl/changefeedccl/changefeedbase/options_test.go
@@ -36,6 +36,9 @@ func TestOptionsValidations(t *testing.T) {
 		{map[string]string{"diff": "", "format": "parquet"}, false, "cannot specify both"},
 		{map[string]string{"format": "txt"}, true, "unknown format"},
 		{map[string]string{"initial_scan": "", "no_initial_scan": ""}, true, "cannot specify both"},
+		// Verify that the returned error uses the syntax initial_scan='yes' instead of initial_scan_only. See #97008.
+		{map[string]string{"initial_scan_only": "", "resolved": ""}, true, "cannot specify both initial_scan='only'"},
+		{map[string]string{"initial_scan_only": "", "resolved": ""}, true, "cannot specify both initial_scan='only'"},
 		{map[string]string{"diff": "", "format": "parquet"}, true, ""},
 	}
 

--- a/pkg/sql/crdb_internal_test.go
+++ b/pkg/sql/crdb_internal_test.go
@@ -1305,8 +1305,8 @@ func TestCorruptPayloadError(t *testing.T) {
 		1, jobs.StatusRunning, timeutil.Now(), []byte("invalid payload"),
 	)
 
-	tdb.ExpectErrWithHint(t, "could not decode the payload for job 1. consider deleting this job from system.jobs", "SELECT * FROM crdb_internal.system_jobs")
-	tdb.ExpectErrWithHint(t, "could not decode the payload for job 1. consider deleting this job from system.jobs", "SELECT * FROM crdb_internal.jobs")
+	tdb.ExpectErrWithHint(t, "proto", "could not decode the payload for job 1. consider deleting this job from system.jobs", "SELECT * FROM crdb_internal.system_jobs")
+	tdb.ExpectErrWithHint(t, "proto", "could not decode the payload for job 1. consider deleting this job from system.jobs", "SELECT * FROM crdb_internal.jobs")
 }
 
 // TestInternalSystemJobsAccess asserts which entries a user can query

--- a/pkg/testutils/sqlutils/sql_runner.go
+++ b/pkg/testutils/sqlutils/sql_runner.go
@@ -15,6 +15,7 @@ import (
 	gosql "database/sql"
 	"fmt"
 	"reflect"
+	"regexp"
 	"strings"
 	"time"
 
@@ -146,6 +147,11 @@ func (sr *SQLRunner) ExecRowsAffected(
 func (sr *SQLRunner) ExpectErr(t Fataler, errRE string, query string, args ...interface{}) {
 	helperOrNoop(t)()
 	_, err := sr.DB.ExecContext(context.Background(), query, args...)
+	sr.expectErr(t, err, errRE)
+}
+
+func (sr *SQLRunner) expectErr(t Fataler, err error, errRE string) {
+	helperOrNoop(t)()
 	if !testutils.IsError(err, errRE) {
 		s := "nil"
 		if err != nil {
@@ -157,15 +163,18 @@ func (sr *SQLRunner) ExpectErr(t Fataler, errRE string, query string, args ...in
 
 // ExpectErrWithHint runs the given statement and verifies that it returns an error
 // with a hint matching the expected hint.
-func (sr *SQLRunner) ExpectErrWithHint(t Fataler, hint string, query string, args ...interface{}) {
+func (sr *SQLRunner) ExpectErrWithHint(
+	t Fataler, errRE string, hintRE string, query string, args ...interface{},
+) {
 	helperOrNoop(t)()
 	_, err := sr.DB.ExecContext(context.Background(), query, args...)
-	if err == nil {
-		t.Fatalf("expected error with hint '%s', but got error 'nil'", hint)
-	}
+
+	sr.expectErr(t, err, errRE)
+
 	if pqErr := (*pq.Error)(nil); errors.As(err, &pqErr) {
-		if pqErr.Hint != hint {
-			t.Fatalf("expected error with hint '%s', but got error with hint '%s'", hint, pqErr.Hint)
+		matched, merr := regexp.MatchString(hintRE, pqErr.Hint)
+		if !matched || merr != nil {
+			t.Fatalf("expected error with hint '%s', but got error with hint '%s'", hintRE, pqErr.Hint)
 		}
 	} else {
 		t.Fatalf("could not parse pq error")


### PR DESCRIPTION
### testutils: add helper to check pq.Error hint regex

Previously, the helper to check for pq.Error hint messages would do a string comparison.
This change updates the helper to check the hint using regex.

Epic: None
Release note: None

###  cdc: add hint to schedule changefeed on initial scan error
    
Previously, starting a scheduled changefeed such as
```
CREATE SCHEDULE test_schedule FOR CHANGEFEED movr.vehicles
INTO 'webhook-https://<address>?insecure_tls_skip_verify=true'
WITH resolved RECURRING '@daily' WITH SCHEDULE OPTIONS first_run = 'now';
```
would return the error
```
ERROR: Failed to dry run create changefeed: cannot specify both initial_scan_only and resolved
```

With this change, the returned error will use the updated syntax `initial_scan='only'`
and also provide a hint to the user which says the `initial_scan='only'` option
was passed implicitly in the scheduled changefeed statement.

Additionally, all error messages related to `initial_scan_only` will now
say `initial_scan='only'` instead.

Fixes: https://github.com/cockroachdb/cockroach/issues/97008
Epic: None
Release note (enterprise change): Error messages related to `initial_scan_only`
(ex. "cannot specify both initial_scan_only and resolved") will now
substitute in "initial_scan='only'".

