### PR TITLE
kvserver: fix deadlock on rebalance obj change

### DIFF
--- a/pkg/kv/kvserver/helpers_test.go
+++ b/pkg/kv/kvserver/helpers_test.go
@@ -388,7 +388,7 @@ func (r *Replica) LargestPreviousMaxRangeSizeBytes() int64 {
 // LoadBasedSplitter returns the replica's split.Decider, which is used to
 // assist load-based split (and merge) decisions.
 func (r *Replica) LoadBasedSplitter() *split.Decider {
-	return &r.loadBasedSplitter
+	return &r.loadBasedSplitterMu.loadBasedSplitter
 }
 
 func MakeSSTable(

--- a/pkg/kv/kvserver/replica.go
+++ b/pkg/kv/kvserver/replica.go
@@ -819,8 +819,13 @@ type Replica struct {
 	// semaphores.
 	splitQueueThrottle, mergeQueueThrottle util.EveryN
 
-	// loadBasedSplitter keeps information about load-based splitting.
-	loadBasedSplitter split.Decider
+	// loadBasedSplitterMu protects access to the load based split decider and
+	// configuration.
+	loadBasedSplitterMu struct {
+		syncutil.Mutex
+		loadBasedSplitter split.Decider
+		splitConfig       *replicaSplitConfig
+	}
 
 	// unreachablesMu contains a set of remote ReplicaIDs that are to be reported
 	// as unreachable on the next raft tick.
@@ -1301,10 +1306,13 @@ func (r *Replica) SetMVCCStatsForTesting(stats *enginepb.MVCCStats) {
 //
 // Use LoadStats.QueriesPerSecond for all other purposes.
 func (r *Replica) GetMaxSplitQPS(ctx context.Context) (float64, bool) {
-	if r.store.splitConfig.SplitObjective() != SplitQPS {
+	r.loadBasedSplitterMu.Lock()
+	defer r.loadBasedSplitterMu.Unlock()
+
+	if r.loadBasedSplitterMu.splitConfig.SplitObjective() != SplitQPS {
 		return 0, false
 	}
-	return r.loadBasedSplitter.MaxStat(ctx, r.Clock().PhysicalTime())
+	return r.loadBasedSplitterMu.loadBasedSplitter.MaxStat(ctx, r.Clock().PhysicalTime())
 }
 
 // GetMaxSplitCPU returns the Replica's maximum CPU/s rate over a configured
@@ -1317,10 +1325,13 @@ func (r *Replica) GetMaxSplitQPS(ctx context.Context) (float64, bool) {
 // Use LoadStats.RaftCPUNanosPerSecond and RequestCPUNanosPerSecond for current
 // CPU stats for all other purposes.
 func (r *Replica) GetMaxSplitCPU(ctx context.Context) (float64, bool) {
-	if r.store.splitConfig.SplitObjective() != SplitCPU {
+	r.loadBasedSplitterMu.Lock()
+	defer r.loadBasedSplitterMu.Unlock()
+
+	if r.loadBasedSplitterMu.splitConfig.SplitObjective() != SplitCPU {
 		return 0, false
 	}
-	return r.loadBasedSplitter.MaxStat(ctx, r.Clock().PhysicalTime())
+	return r.loadBasedSplitterMu.loadBasedSplitter.MaxStat(ctx, r.Clock().PhysicalTime())
 }
 
 // ContainsKey returns whether this range contains the specified key.

--- a/pkg/kv/kvserver/replica_proposal.go
+++ b/pkg/kv/kvserver/replica_proposal.go
@@ -343,7 +343,10 @@ func (r *Replica) leasePostApplyLocked(
 		if r.loadStats != nil {
 			r.loadStats.Reset()
 		}
-		r.loadBasedSplitter.Reset(r.Clock().PhysicalTime())
+		r.loadBasedSplitterMu.Lock()
+		r.loadBasedSplitterMu.loadBasedSplitter.Reset(r.Clock().PhysicalTime())
+		r.loadBasedSplitterMu.Unlock()
+
 	}
 
 	// Inform the concurrency manager that the lease holder has been updated.


### PR DESCRIPTION
Previously, changing the rebalance objective could lead to inconsistent
locking order between the load based splitter and rebalance objective.

The split config is created per replica, rather than per store as it was
previously. The split config and split decider are bundled underneath a
new mutex which ensures consistent access.

Resolves: https://github.com/cockroachdb/cockroach/issues/97000