### PR TITLE
multi-region: Long-term owners for multi-region tests

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -84,7 +84,7 @@
 
 /pkg/ccl/schemachangerccl/   @cockroachdb/sql-schema
 /pkg/sql/catalog/            @cockroachdb/sql-schema
-/pkg/sql/catalog/multiregion @cockroachdb/multiregion
+/pkg/sql/catalog/multiregion @cockroachdb/sql-schema
 /pkg/sql/doctor/             @cockroachdb/sql-schema
 /pkg/sql/gcjob/              @cockroachdb/sql-schema
 /pkg/sql/gcjob_test/         @cockroachdb/sql-schema
@@ -288,10 +288,10 @@
 #!/pkg/ccl/upgradeccl/       @cockroachdb/unowned
 #!/pkg/ccl/logictestccl/       @cockroachdb/sql-queries-noreview
 #!/pkg/ccl/sqlitelogictestccl/ @cockroachdb/sql-queries-noreview
-/pkg/ccl/multiregionccl/     @cockroachdb/multiregion
+/pkg/ccl/multiregionccl/     @cockroachdb/sql-schema
 /pkg/ccl/multitenantccl/     @cockroachdb/multi-tenant
 #!/pkg/ccl/oidcccl/          @cockroachdb/unowned
-/pkg/ccl/partitionccl/       @cockroachdb/sql-schema @cockroachdb/multiregion
+/pkg/ccl/partitionccl/       @cockroachdb/sql-schema
 /pkg/ccl/serverccl/          @cockroachdb/server-prs
 /pkg/ccl/serverccl/server_sql* @cockroachdb/multi-tenant @cockroachdb/server-prs
 /pkg/ccl/serverccl/tenant_*  @cockroachdb/multi-tenant @cockroachdb/server-prs

--- a/pkg/cmd/roachtest/registry/owners.go
+++ b/pkg/cmd/roachtest/registry/owners.go
@@ -22,7 +22,6 @@ const (
 	OwnerKV               Owner = `kv`
 	OwnerReplication      Owner = `replication`
 	OwnerAdmissionControl Owner = `admission-control`
-	OwnerMultiRegion      Owner = `multiregion`
 	OwnerObsInf           Owner = `obs-inf-prs`
 	OwnerServer           Owner = `server` // not currently staffed
 	OwnerSQLQueries       Owner = `sql-queries`

--- a/pkg/cmd/roachtest/tests/tpcc.go
+++ b/pkg/cmd/roachtest/tests/tpcc.go
@@ -679,7 +679,7 @@ func registerTPCC(r registry.Registry) {
 			tc := multiRegionTests[i]
 			r.Add(registry.TestSpec{
 				Name:  tc.name,
-				Owner: registry.OwnerMultiRegion,
+				Owner: registry.OwnerSQLSchema,
 				// Add an extra node which serves as the workload nodes.
 				Cluster:           r.MakeClusterSpec(len(regions)*nodesPerRegion+1, spec.Geo(), spec.Zones(strings.Join(zs, ","))),
 				EncryptionSupport: registry.EncryptionMetamorphic,


### PR DESCRIPTION
When we were actively doing work on the multi-region syntax, we had a virtual team which was regularly triaging MR test cases. With the v-team disbanded, these tests need long-term owners which can regularly triage any test case failures. I took a stab at the right long-term owners, but may have not gotten it entirely correct. Specifically, we may want schema to own multiregionccl.

Epic: none
Release note: none