### PR TITLE
release-22.2: ccl/multiregionccl: Skip stress testing flaky secondary region test

### DIFF
--- a/pkg/ccl/multiregionccl/datadriven_test.go
+++ b/pkg/ccl/multiregionccl/datadriven_test.go
@@ -113,9 +113,12 @@ func TestMultiRegionDataDriven(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	skip.UnderRace(t, "flaky test")
-
 	ctx := context.Background()
 	datadriven.Walk(t, testutils.TestDataPath(t), func(t *testing.T, path string) {
+		if strings.Contains(path, "secondary_region") {
+			skip.UnderStressWithIssue(t, 92235, "flaky test")
+		}
+
 		ds := datadrivenTestState{}
 		defer ds.cleanup(ctx)
 		var mu syncutil.Mutex


### PR DESCRIPTION
Backport 1/1 commits from #97473.

/cc @cockroachdb/release

---

Informs: #92235
Release note: None

Release Justification: Non-production changes