### PR TITLE
release-22.2: test: remove no longer valid test

### DIFF
--- a/pkg/sql/sqlstats/persistedsqlstats/compaction_test.go
+++ b/pkg/sql/sqlstats/persistedsqlstats/compaction_test.go
@@ -14,7 +14,6 @@ import (
 	"context"
 	"fmt"
 	"regexp"
-	"strconv"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -266,81 +265,6 @@ func TestSQLStatsCompactor(t *testing.T) {
 			require.GreaterOrEqual(t, tc.maxPersistedRowLimit, txnStatsCnt)
 		})
 	}
-}
-
-// TestSQLStatsForegroundInterference ensures that the background SQL Stats
-// cleanup job does not delete any rows in the current aggregation window. Doing
-// so would cause contentions, which can potentially lead to long runtime of the
-// SQL Stats cleanup job. We test this behavior by generating some rows in the
-// stats system table that are in the current aggregation window and previous
-// aggregation window. Before running the SQL Stats compaction, we lower the
-// row limit in the stats table so that all the rows will be deleted by the
-// StatsCompactor, if all the generated rows live outside the current
-// aggregation window. This test asserts that, since some of generated rows live
-// in the current aggregation interval, those rows will not be deleted by the
-// StatsCompactor.
-func TestSQLStatsForegroundInterference(t *testing.T) {
-	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
-
-	var tm atomic.Value
-	// Initialize the time to 2 aggregation interval in the past.
-	tm.Store(timeutil.Now().Add(-2 * persistedsqlstats.SQLStatsAggregationInterval.Default()))
-
-	ctx := context.Background()
-	params, _ := tests.CreateTestServerParams()
-	params.Knobs.SQLStatsKnobs.(*sqlstats.TestingKnobs).StubTimeNow = func() time.Time {
-		return tm.Load().(time.Time)
-	}
-	s, conn, _ := serverutils.StartServer(t, params)
-	defer s.Stopper().Stop(ctx)
-
-	serverSQLStats :=
-		s.SQLServer().(*sql.Server).
-			GetSQLStatsProvider().(*persistedsqlstats.PersistedSQLStats)
-
-	sqlConn := sqlutils.MakeSQLRunner(conn)
-	sqlConn.Exec(t, "SET CLUSTER SETTING sql.stats.persisted_rows.max = 10")
-
-	// Generate some data that are older than the current aggregation window,
-	// and then generate some that are within the current aggregation window.
-	generateFingerprints(t, sqlConn, 10 /* distinctFingerprints */)
-	serverSQLStats.Flush(ctx)
-
-	tm.Store(timeutil.Now())
-	generateFingerprints(t, sqlConn, 10 /* distinctFingerprints */)
-	serverSQLStats.Flush(ctx)
-
-	statsCompactor := persistedsqlstats.NewStatsCompactor(
-		s.ClusterSettings(),
-		s.InternalExecutor().(sqlutil.InternalExecutor),
-		s.DB(),
-		metric.NewCounter(metric.Metadata{}),
-		params.Knobs.SQLStatsKnobs.(*sqlstats.TestingKnobs),
-	)
-
-	// Run the compactor.
-	require.NoError(t, statsCompactor.DeleteOldestEntries(ctx))
-
-	result := sqlConn.QueryStr(t, `
-	SELECT count(*)
-	FROM system.statement_statistics`)[0][0]
-
-	stmtStatsCount, err := strconv.Atoi(result)
-	require.NoError(t, err)
-	require.GreaterOrEqual(t, stmtStatsCount, 10,
-		"expected at least 10 fingerprints in statement statistics table, "+
-			"but only %d is present", stmtStatsCount)
-
-	result = sqlConn.QueryStr(t, `
-	SELECT count(*)
-	FROM system.transaction_statistics`)[0][0]
-
-	txnStatsCount, err := strconv.Atoi(result)
-	require.NoError(t, err)
-	require.GreaterOrEqual(t, txnStatsCount, 10,
-		"expected at least 10 fingerprints in transaction statistics table, "+
-			"but only %d is present", txnStatsCount)
 }
 
 func TestSQLStatsCompactionJobMarkedAsAutomatic(t *testing.T) {

--- a/pkg/sql/sqlstats/persistedsqlstats/flush_test.go
+++ b/pkg/sql/sqlstats/persistedsqlstats/flush_test.go
@@ -458,8 +458,7 @@ func TestSQLStatsGatewayNodeSetting(t *testing.T) {
 }
 
 func TestSQLStatsPersistedLimitReached(t *testing.T) {
-	skip.UnderStress(t, "During stress, several flushes can be done at the same time, and we don't"+
-		"want to test this case for now, because the limit could be more than 1.5 * maxMemory")
+	skip.WithIssue(t, 97488)
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 


### PR DESCRIPTION
Backport 1/1 commits from #97472.

/cc @cockroachdb/release

---

This test was checking for a behaviour that no longer is the case. With the limitation of how much data we can flush, we might not have the same fingerprints as expected on this test.
Removing the test completely.

Fixes #97458

Also skip test TestSQLStatsPersistedLimitReached while investigating.
Informs #97488

Release note: None

---

Release justification: test only changes
