### PR TITLE
release-22.2: changefeedccl: Drop env gate for metrics label

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -3335,15 +3335,8 @@ func TestChangefeedMonitoring(t *testing.T) {
 			t.Errorf(`expected 0 got %d`, c)
 		}
 
-		enableSLIMetrics = false
 		foo := feed(t, f, `CREATE CHANGEFEED FOR foo WITH metrics_label='tier0'`)
 		_, err := foo.Next()
-		require.Regexp(t, "cannot create metrics scope", err)
-		require.NoError(t, foo.Close())
-
-		enableSLIMetrics = true
-		foo = feed(t, f, `CREATE CHANGEFEED FOR foo WITH metrics_label='tier0'`)
-		_, err = foo.Next()
 		require.NoError(t, err)
 
 		testutils.SucceedsSoon(t, func() error {

--- a/pkg/ccl/changefeedccl/metrics.go
+++ b/pkg/ccl/changefeedccl/metrics.go
@@ -15,25 +15,18 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/cdcutils"
-	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/changefeedbase"
 	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/kvevent"
 	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/schemafeed"
 	"github.com/cockroachdb/cockroach/pkg/jobs"
 	"github.com/cockroachdb/cockroach/pkg/multitenant"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
-	"github.com/cockroachdb/cockroach/pkg/util/envutil"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/metric"
 	"github.com/cockroachdb/cockroach/pkg/util/metric/aggmetric"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
-	"github.com/cockroachdb/errors"
 )
-
-// allow creation of per changefeed SLI metrics.
-var enableSLIMetrics = envutil.EnvOrDefaultBool(
-	"COCKROACH_EXPERIMENTAL_ENABLE_PER_CHANGEFEED_METRICS", false)
 
 const (
 	changefeedCheckpointHistMaxLatency = 30 * time.Second
@@ -572,13 +565,6 @@ func (a *AggMetrics) getOrCreateScope(scope string) (*sliMetrics, error) {
 	}
 
 	if scope != defaultSLIScope {
-		if !enableSLIMetrics {
-			return nil, changefeedbase.WithTerminalError(
-				errors.WithHint(
-					pgerror.Newf(pgcode.ConfigurationLimitExceeded, "cannot create metrics scope %q", scope),
-					"try restarting with COCKROACH_EXPERIMENTAL_ENABLE_PER_CHANGEFEED_METRICS=true",
-				))
-		}
 		const failSafeMax = 1024
 		if len(a.mu.sliMetrics) == failSafeMax {
 			return nil, pgerror.Newf(pgcode.ConfigurationLimitExceeded,


### PR DESCRIPTION
Backport 1/1 commits from #93423.

/cc @cockroachdb/release

---

Stop requiring `COCKROACH_EXPERIMENTAL_ENABLE_PER_CHANGEFEED_METRICS` in order to use changefeed metrics labels.

This env gate added unnecessary barriers for the feature use. There is still a fail safe limit of 1024 unique labels that will be allowed on the node.

Epic: None
Release note (enterprise change): changefeed no longer requires COCKROACH_EXPERIMENTAL_ENABLE_PER_CHANGEFEED_METRICS environment variable to be set in order to use metrics_label option.
Release justification: Env gate is an excessively cautious approach, preventing feature adaption.  Removing this env gate to improve usability of the feature. 