### PR TITLE
status: set codec from context in table stats requests

### DIFF
--- a/pkg/server/admin.go
+++ b/pkg/server/admin.go
@@ -670,7 +670,7 @@ func (s *adminServer) getDatabaseTableSpans(
 		if err != nil {
 			return nil, err
 		}
-		tableSpans[tableName] = generateTableSpan(tableID)
+		tableSpans[tableName] = generateTableSpan(tableID, s.sqlServer.execCfg.Codec)
 	}
 	return tableSpans, nil
 }
@@ -1161,7 +1161,7 @@ func (s *adminServer) tableDetailsHelper(
 	// Get the number of ranges in the table. We get the key span for the table
 	// data. Then, we count the number of ranges that make up that key span.
 	{
-		tableSpan := generateTableSpan(tableID)
+		tableSpan := generateTableSpan(tableID, s.sqlServer.execCfg.Codec)
 		tableRSpan, err := keys.SpanAddr(tableSpan)
 		if err != nil {
 			return nil, err
@@ -1190,8 +1190,8 @@ func (s *adminServer) tableDetailsHelper(
 //
 // NOTE: this doesn't make sense for interleaved (children) table. As of
 // 03/2018, callers around here use it anyway.
-func generateTableSpan(tableID descpb.ID) roachpb.Span {
-	tableStartKey := keys.TODOSQLCodec.TablePrefix(uint32(tableID))
+func generateTableSpan(tableID descpb.ID, codec keys.SQLCodec) roachpb.Span {
+	tableStartKey := codec.TablePrefix(uint32(tableID))
 	tableEndKey := tableStartKey.PrefixEnd()
 	return roachpb.Span{Key: tableStartKey, EndKey: tableEndKey}
 }
@@ -1223,7 +1223,7 @@ func (s *adminServer) TableStats(
 	if err != nil {
 		return nil, serverError(ctx, err)
 	}
-	tableSpan := generateTableSpan(tableID)
+	tableSpan := generateTableSpan(tableID, s.sqlServer.execCfg.Codec)
 
 	r, err := s.statsForSpan(ctx, tableSpan)
 	if err != nil {

--- a/pkg/testutils/serverutils/test_server_shim.go
+++ b/pkg/testutils/serverutils/test_server_shim.go
@@ -437,14 +437,14 @@ func TestTenantID3() roachpb.TenantID {
 
 // GetJSONProto uses the supplied client to GET the URL specified by the parameters
 // and unmarshals the result into response.
-func GetJSONProto(ts TestServerInterface, path string, response protoutil.Message) error {
+func GetJSONProto(ts TestTenantInterface, path string, response protoutil.Message) error {
 	return GetJSONProtoWithAdminOption(ts, path, response, true)
 }
 
 // GetJSONProtoWithAdminOption is like GetJSONProto but the caller can customize
 // whether the request is performed with admin privilege
 func GetJSONProtoWithAdminOption(
-	ts TestServerInterface, path string, response protoutil.Message, isAdmin bool,
+	ts TestTenantInterface, path string, response protoutil.Message, isAdmin bool,
 ) error {
 	httpClient, err := ts.GetAuthenticatedHTTPClient(isAdmin)
 	if err != nil {
@@ -455,7 +455,7 @@ func GetJSONProtoWithAdminOption(
 
 // PostJSONProto uses the supplied client to POST the URL specified by the parameters
 // and unmarshals the result into response.
-func PostJSONProto(ts TestServerInterface, path string, request, response protoutil.Message) error {
+func PostJSONProto(ts TestTenantInterface, path string, request, response protoutil.Message) error {
 	return PostJSONProtoWithAdminOption(ts, path, request, response, true)
 }
 
@@ -463,7 +463,7 @@ func PostJSONProto(ts TestServerInterface, path string, request, response protou
 // can customize whether the request is performed with admin
 // privilege.
 func PostJSONProtoWithAdminOption(
-	ts TestServerInterface, path string, request, response protoutil.Message, isAdmin bool,
+	ts TestTenantInterface, path string, request, response protoutil.Message, isAdmin bool,
 ) error {
 	httpClient, err := ts.GetAuthenticatedHTTPClient(isAdmin)
 	if err != nil {


### PR DESCRIPTION
Replaced usages of `TODOSQLCodec` with the codec from `sqlServer.execCfg`. This enables the DB and Table stats endpoints to work from tenants.

Resolves: #82879

Relates to: #90261, #90267, #90268, #90264, #89429

Epic: CRDB-12100

Release note: None