### PR TITLE
ui: refine hook to schedule data refreshes

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsights/statementInsights/statementInsightsView.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsights/statementInsights/statementInsightsView.tsx
@@ -56,7 +56,7 @@ import moment from "moment";
 import styles from "src/statementsPage/statementsPage.module.scss";
 import sortableTableStyles from "src/sortedtable/sortedtable.module.scss";
 import { commonStyles } from "../../../common";
-import { useFetchDataWithPolling } from "src/util/hooks";
+import { useScheduleFunction } from "src/util/hooks";
 import { InlineAlert } from "@cockroachlabs/ui-components";
 import { insights } from "src/util";
 import { Anchor } from "src/anchor";
@@ -129,13 +129,16 @@ export const StatementInsightsView: React.FC<StatementInsightsViewProps> = ({
   }, [refreshStatementInsights, timeScale]);
 
   const shouldPoll = timeScale.key !== "Custom";
-  const clearPolling = useFetchDataWithPolling(
+  const [refetch, clearPolling] = useScheduleFunction(
     refresh,
-    isDataValid,
-    lastUpdated,
-    shouldPoll,
+    shouldPoll, // Don't reschedule refresh if we have a custom time interval.
     10 * 1000, // 10s polling interval
+    lastUpdated,
   );
+
+  useEffect(() => {
+    if (!isDataValid) refetch();
+  }, [isDataValid, refetch]);
 
   useEffect(() => {
     // We use this effect to sync settings defined on the URL (sort, filters),

--- a/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsights/transactionInsights/transactionInsightsView.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsights/transactionInsights/transactionInsightsView.tsx
@@ -51,7 +51,7 @@ import { TxnInsightsRequest } from "src/api";
 import styles from "src/statementsPage/statementsPage.module.scss";
 import sortableTableStyles from "src/sortedtable/sortedtable.module.scss";
 import { commonStyles } from "../../../common";
-import { useFetchDataWithPolling } from "src/util/hooks";
+import { useScheduleFunction } from "src/util/hooks";
 import { InlineAlert } from "@cockroachlabs/ui-components";
 import { insights } from "src/util";
 import { Anchor } from "src/anchor";
@@ -122,13 +122,16 @@ export const TransactionInsightsView: React.FC<TransactionInsightsViewProps> = (
   }, [refreshTransactionInsights, timeScale]);
 
   const shouldPoll = timeScale.key !== "Custom";
-  const clearPolling = useFetchDataWithPolling(
+  const [refetch, clearPolling] = useScheduleFunction(
     refresh,
-    isDataValid,
-    lastUpdated,
-    shouldPoll,
+    shouldPoll, // Don't reschedule refresh if we have a custom time interval.
     10 * 1000, // 10s polling interval
+    lastUpdated,
   );
+
+  useEffect(() => {
+    if (!isDataValid) refetch();
+  }, [isDataValid, refetch]);
 
   useEffect(() => {
     // We use this effect to sync settings defined on the URL (sort, filters),

--- a/pkg/ui/workspaces/cluster-ui/src/util/hooks.spec.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/util/hooks.spec.tsx
@@ -1,0 +1,142 @@
+// Copyright 2023 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import React from "react";
+import { useScheduleFunction } from "./hooks";
+import {
+  render,
+  cleanup,
+  screen,
+  fireEvent,
+  waitFor,
+} from "@testing-library/react";
+import moment from "moment";
+
+describe("useScheduleFunction", () => {
+  let mockFn: jest.Mock;
+
+  beforeEach(() => {
+    mockFn = jest.fn();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("should schedule the function according to the lastCompleted time and interval provided", async () => {
+    const timeoutMs = 1500;
+    const TestScheduleHook = () => {
+      const [lastUpdated, setLastUpdated] = React.useState<moment.Moment>(null);
+
+      const setLastUpdatedToNow = () => {
+        mockFn();
+        setLastUpdated(moment.utc());
+      };
+
+      useScheduleFunction(setLastUpdatedToNow, true, timeoutMs, lastUpdated);
+      return <div />;
+    };
+
+    const { unmount } = render(<TestScheduleHook />);
+    await waitFor(
+      () => new Promise(res => setTimeout(res, timeoutMs * 3 + 1000)), // Add 0.5s of buffer.
+      { timeout: timeoutMs * 3 + 1500 },
+    );
+    // 3 intervals and the initial call on mount, since last completed was initially null.
+    expect(mockFn).toBeCalledTimes(4);
+
+    unmount();
+    // Verify scheduling is stopped on unmount.
+    await waitFor(
+      () => new Promise(res => setTimeout(res, timeoutMs + 500)), // Add 0.5s of buffer.
+      { timeout: timeoutMs + 550 },
+    );
+    expect(mockFn).toBeCalledTimes(4);
+    // });
+  }, 20000);
+
+  it("should schedule the function immediately if returned scheduleNow is used", async () => {
+    const TestScheduleHook = () => {
+      const [lastUpdated, setLastUpdated] = React.useState<moment.Moment>(
+        moment.utc(),
+      );
+
+      const setLastUpdatedToNow = () => {
+        mockFn();
+        setLastUpdated(moment.utc());
+      };
+
+      const [scheduleNow] = useScheduleFunction(
+        setLastUpdatedToNow,
+        true,
+        3000, // Longer timeout.
+        lastUpdated,
+      );
+
+      const onClick = () => {
+        scheduleNow();
+      };
+
+      return (
+        <div>
+          <button onClick={onClick}></button>
+        </div>
+      );
+    };
+
+    render(<TestScheduleHook />);
+    const button = await screen.getByRole("button");
+
+    fireEvent.click(button);
+    await waitFor(() => expect(mockFn).toBeCalledTimes(1), { timeout: 1500 });
+
+    fireEvent.click(button);
+    await waitFor(() => expect(mockFn).toBeCalledTimes(2), { timeout: 1500 });
+
+    // Verify that the schedule is set up correctly after by waiting the interval length.
+    await waitFor(() => new Promise(res => setTimeout(res, 3100)), {
+      timeout: 4000,
+    });
+    expect(mockFn).toBeCalledTimes(3);
+  }, 10000);
+
+  it("should clear the scheduled func immediately if clear is used", async () => {
+    const TestScheduleHook = () => {
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      const [_, clear] = useScheduleFunction(mockFn, true, 1000, moment.utc());
+
+      React.useEffect(() => {
+        clear();
+      });
+
+      return <div />;
+    };
+
+    render(<TestScheduleHook />);
+    await waitFor(() => new Promise(res => setTimeout(res, 5000)), {
+      timeout: 5500,
+    });
+    expect(mockFn).toBeCalledTimes(0);
+  }, 10000);
+
+  it("should not reschedule the func if shouldReschedule=false", async () => {
+    const TestScheduleHook = () => {
+      // Since we pass in a last completed time here, we should expect no calls.
+      useScheduleFunction(mockFn, false, 100, moment.utc());
+      return <div />;
+    };
+
+    render(<TestScheduleHook />);
+    await waitFor(() => new Promise(res => setTimeout(res, 3000)), {
+      timeout: 3500,
+    });
+    expect(mockFn).toBeCalledTimes(0);
+  });
+});


### PR DESCRIPTION
This commit refines the logic in the `useFetchDataWithPolling` hook. Namely, it has been renamed to `useScheduleFunction` to be more generic. It also fixes a bug where the first call would not occur if `shouldPoll` was false. This mainly affects the insights pages where if the page was loaded with a custom time interval, the request would not be made.

Epic: none

Release note: None