### PR TITLE
release-22.1: kv: configure transaction uncertainty interval for reverse scan

### DIFF
--- a/pkg/kv/kvserver/batcheval/cmd_reverse_scan.go
+++ b/pkg/kv/kvserver/batcheval/cmd_reverse_scan.go
@@ -45,6 +45,7 @@ func ReverseScan(
 	opts := storage.MVCCScanOptions{
 		Inconsistent:           h.ReadConsistency != roachpb.CONSISTENT,
 		Txn:                    h.Txn,
+		Uncertainty:            cArgs.Uncertainty,
 		MaxKeys:                h.MaxSpanRequestKeys,
 		MaxIntents:             storage.MaxIntentsPerWriteIntentError.Get(&cArgs.EvalCtx.ClusterSettings().SV),
 		TargetBytes:            h.TargetBytes,

--- a/pkg/kv/kvserver/client_replica_test.go
+++ b/pkg/kv/kvserver/client_replica_test.go
@@ -430,67 +430,88 @@ func TestTxnPutOutOfOrder(t *testing.T) {
 // timestamp is below the committed value's timestamp. As a result, the
 // transaction observes the committed value in its certain future, allowing it
 // to avoid the ReadWithinUncertaintyIntervalError.
+//
+// Each test variant is run using the three different forms of transactional
+// read-only operations: Get, Scan, and ReverseScan.
 func TestTxnReadWithinUncertaintyInterval(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
 	testutils.RunTrueAndFalse(t, "observedTS", func(t *testing.T, observedTS bool) {
-		ctx := context.Background()
-		manual := hlc.NewHybridManualClock()
-		srv, _, _ := serverutils.StartServer(t, base.TestServerArgs{
-			Knobs: base.TestingKnobs{
-				Server: &server.TestingKnobs{
-					ClockSource: manual.UnixNano,
-				},
-			},
+		readOps := []interface{}{"get", "scan", "revScan"}
+		testutils.RunValues(t, "readOp", readOps, func(t *testing.T, readOp interface{}) {
+			testTxnReadWithinUncertaintyInterval(t, observedTS, readOp.(string))
 		})
-		s := srv.(*server.TestServer)
-		defer s.Stopper().Stop(ctx)
-		store, err := s.Stores().GetStore(s.GetFirstStoreID())
-		require.NoError(t, err)
-
-		// Split off a scratch range.
-		key, err := s.ScratchRange()
-		require.NoError(t, err)
-
-		// Pause the server's clocks going forward.
-		manual.Pause()
-
-		// Create a new transaction.
-		now := s.Clock().Now()
-		maxOffset := s.Clock().MaxOffset().Nanoseconds()
-		require.NotZero(t, maxOffset)
-		txn := roachpb.MakeTransaction("test", key, 1, now, maxOffset, int32(s.SQLInstanceID()))
-		require.True(t, txn.ReadTimestamp.Less(txn.GlobalUncertaintyLimit))
-		require.Len(t, txn.ObservedTimestamps, 0)
-
-		// If the test variant wants an observed timestamp from the server at a
-		// timestamp below the value, collect one now.
-		if observedTS {
-			get := getArgs(key)
-			resp, pErr := kv.SendWrappedWith(ctx, store.TestSender(), roachpb.Header{Txn: &txn}, get)
-			require.Nil(t, pErr)
-			txn.Update(resp.Header().Txn)
-			require.Len(t, txn.ObservedTimestamps, 1)
-		}
-
-		// Perform a non-txn write. This will grab a timestamp from the clock.
-		put := putArgs(key, []byte("val"))
-		_, pErr := kv.SendWrapped(ctx, store.TestSender(), put)
-		require.Nil(t, pErr)
-
-		// Perform another read on the same key. Depending on whether or not the txn
-		// had collected an observed timestamp, it may or may not observe the value
-		// in its uncertainty interval and throw an error.
-		get := getArgs(key)
-		_, pErr = kv.SendWrappedWith(ctx, store.TestSender(), roachpb.Header{Txn: &txn}, get)
-		if observedTS {
-			require.Nil(t, pErr)
-		} else {
-			require.NotNil(t, pErr)
-			require.IsType(t, &roachpb.ReadWithinUncertaintyIntervalError{}, pErr.GetDetail())
-		}
 	})
+}
+
+func testTxnReadWithinUncertaintyInterval(t *testing.T, observedTS bool, readOp string) {
+	ctx := context.Background()
+	manual := hlc.NewHybridManualClock()
+	srv, _, _ := serverutils.StartServer(t, base.TestServerArgs{
+		Knobs: base.TestingKnobs{
+			Server: &server.TestingKnobs{
+				ClockSource: manual.UnixNano,
+			},
+		},
+	})
+	s := srv.(*server.TestServer)
+	defer s.Stopper().Stop(ctx)
+	store, err := s.Stores().GetStore(s.GetFirstStoreID())
+	require.NoError(t, err)
+
+	// Split off a scratch range.
+	key, err := s.ScratchRange()
+	require.NoError(t, err)
+
+	// Pause the server's clocks going forward.
+	manual.Pause()
+
+	// Create a new transaction.
+	now := s.Clock().Now()
+	maxOffset := s.Clock().MaxOffset().Nanoseconds()
+	require.NotZero(t, maxOffset)
+	txn := roachpb.MakeTransaction("test", key, 1, now, maxOffset, int32(s.SQLInstanceID()))
+	require.True(t, txn.ReadTimestamp.Less(txn.GlobalUncertaintyLimit))
+	require.Len(t, txn.ObservedTimestamps, 0)
+
+	// If the test variant wants an observed timestamp from the server at a
+	// timestamp below the value, collect one now.
+	if observedTS {
+		get := getArgs(key)
+		resp, pErr := kv.SendWrappedWith(ctx, store.TestSender(), roachpb.Header{Txn: &txn}, get)
+		require.Nil(t, pErr)
+		txn.Update(resp.Header().Txn)
+		require.Len(t, txn.ObservedTimestamps, 1)
+	}
+
+	// Perform a non-txn write. This will grab a timestamp from the clock.
+	put := putArgs(key, []byte("val"))
+	_, pErr := kv.SendWrapped(ctx, store.TestSender(), put)
+	require.Nil(t, pErr)
+
+	// Perform another read on the same key. Depending on whether or not the txn
+	// had collected an observed timestamp, it may or may not observe the value
+	// in its uncertainty interval and throw an error.
+
+	var read roachpb.Request
+	switch readOp {
+	case "get":
+		read = getArgs(key)
+	case "scan":
+		read = scanArgs(key, key.Next())
+	case "revScan":
+		read = revScanArgs(key, key.Next())
+	default:
+		t.Fatalf("unknown op: %q", readOp)
+	}
+	_, pErr = kv.SendWrappedWith(ctx, store.TestSender(), roachpb.Header{Txn: &txn}, read)
+	if observedTS {
+		require.Nil(t, pErr)
+	} else {
+		require.NotNil(t, pErr)
+		require.IsType(t, &roachpb.ReadWithinUncertaintyIntervalError{}, pErr.GetDetail())
+	}
 }
 
 // TestTxnReadWithinUncertaintyIntervalAfterLeaseTransfer tests a case where a

--- a/pkg/kv/kvserver/client_test.go
+++ b/pkg/kv/kvserver/client_test.go
@@ -35,12 +35,31 @@ import (
 	"github.com/kr/pretty"
 )
 
-// getArgs returns a GetRequest and GetResponse pair addressed to
-// the default replica for the specified key.
+// getArgs returns a GetRequest for the specified key.
 func getArgs(key roachpb.Key) *roachpb.GetRequest {
 	return &roachpb.GetRequest{
 		RequestHeader: roachpb.RequestHeader{
 			Key: key,
+		},
+	}
+}
+
+// scanArgs returns a ScanRequest for the specified key and end key.
+func scanArgs(key, endKey roachpb.Key) *roachpb.ScanRequest {
+	return &roachpb.ScanRequest{
+		RequestHeader: roachpb.RequestHeader{
+			Key:    key,
+			EndKey: endKey,
+		},
+	}
+}
+
+// revScanArgs returns a ReverseScanRequest for the specified key and end key.
+func revScanArgs(key, endKey roachpb.Key) *roachpb.ReverseScanRequest {
+	return &roachpb.ReverseScanRequest{
+		RequestHeader: roachpb.RequestHeader{
+			Key:    key,
+			EndKey: endKey,
 		},
 	}
 }


### PR DESCRIPTION
Backport 1/1 commits from #97443.

/cc @cockroachdb/release

---

This commit configures the transaction uncertainty intervals for reverse scans. This was initially missed in 261fc35, which broke the use of observed timestamps for reverse scans. In 0ee3bbd, we started using this new plumbing path for the entire uncertainty interval, so the pessimization became a correctness bug that could lead to a loss of real-time ordering between a write and a reverse scan in cases with moderate but bounded clock skew between nodes.

The commit adds testing for this case and the ScanRequest case. I should have exercised these cases back in 8445150 when I noticed there was a complete absence of end-to-end testing for uncertainty interval errors. Unfortunately, that commit only added testing for the GetRequest case, allowing the bug to slip in for ReverseScanRequest.

Release note (bug fix): Transaction uncertainty intervals are correctly configured for reverse scans again, ensuring that reverse scans cannot serve stale reads when clocks in a cluster are skewed.

Epic: None

Release justification: small change that resolves bug.