### PR TITLE
keyvisualizer: set a minimum bound on the keyvisualizer.sample_interval cluster setting

### DIFF
--- a/pkg/keyvisualizer/keyvissettings/settings.go
+++ b/pkg/keyvisualizer/keyvissettings/settings.go
@@ -27,8 +27,8 @@ var SampleInterval = settings.RegisterDurationSetting(
 	settings.SystemOnly,
 	"keyvisualizer.sample_interval",
 	"the frequency at which the key visualizer samples are collected",
-	1*time.Minute,
-	settings.NonNegativeDuration,
+	5*time.Minute,
+	settings.NonNegativeDurationWithMinimum(1*time.Minute),
 )
 
 // MaxBuckets defines the maximum buckets allowed in a sample.

--- a/pkg/settings/duration.go
+++ b/pkg/settings/duration.go
@@ -212,6 +212,21 @@ func NonNegativeDurationWithMaximum(maxValue time.Duration) func(time.Duration) 
 	}
 }
 
+// NonNegativeDurationWithMinimum returns a validation function can be passed
+// to RegisterDurationSetting.
+func NonNegativeDurationWithMinimum(minValue time.Duration) func(time.Duration) error {
+	return func(v time.Duration) error {
+		if err := NonNegativeDuration(v); err != nil {
+			return err
+		}
+		if v < minValue {
+			return errors.Errorf("cannot be set to a value smaller than %s",
+				minValue)
+		}
+		return nil
+	}
+}
+
 // PositiveDuration can be passed to RegisterDurationSetting.
 func PositiveDuration(v time.Duration) error {
 	if v <= 0 {

--- a/pkg/settings/settings_test.go
+++ b/pkg/settings/settings_test.go
@@ -190,6 +190,14 @@ var iVal = settings.RegisterIntSetting(settings.SystemOnly,
 		return nil
 	})
 
+func TestNonNegativeDurationWithMinimum(t *testing.T) {
+	validator := settings.NonNegativeDurationWithMinimum(time.Minute)
+	require.NoError(t, validator(time.Minute))
+	require.NoError(t, validator(2*time.Minute))
+	require.Error(t, validator(59*time.Second))
+	require.Error(t, validator(-1*time.Second))
+}
+
 func TestValidation(t *testing.T) {
 	ctx := context.Background()
 	sv := &settings.Values{}


### PR DESCRIPTION
Resolves: https://github.com/cockroachdb/cockroach/issues/97525
Release note: None