### PR TITLE
ci: run `go tool nm` against binaries in artifacts

### DIFF
--- a/build/teamcity/cockroach/ci/builds/build_impl.sh
+++ b/build/teamcity/cockroach/ci/builds/build_impl.sh
@@ -36,7 +36,7 @@ BAZEL_BIN=$(bazel info bazel-bin --config=ci)
 
 if [[ $CONFIG == "crosslinuxfips" ]]; then
     for bin in cockroach cockroach-short cockroach-sql cockroach-oss; do
-        if bazel run @go_sdk//:bin/go -- tool nm "$BAZEL_BIN/pkg/cmd/$bin/${bin}_/$bin" | grep -v golang-fips; then
+        if bazel run @go_sdk//:bin/go -- tool nm "artifacts/pkg/cmd/$bin/${bin}_/$bin" | grep -v golang-fips; then
             echo "cannot find golang-fips in $bin, exiting"
             exit 1
         fi
@@ -44,7 +44,7 @@ if [[ $CONFIG == "crosslinuxfips" ]]; then
 fi
 if [[ $CONFIG == "crosslinux" ]]; then
     for bin in cockroach cockroach-short cockroach-sql cockroach-oss; do
-        if bazel run @go_sdk//:bin/go -- tool nm "$BAZEL_BIN/pkg/cmd/$bin/${bin}_/$bin" | grep golang-fips; then
+        if bazel run @go_sdk//:bin/go -- tool nm "artifacts/pkg/cmd/$bin/${bin}_/$bin" | grep golang-fips; then
             echo "found golang-fips in $bin, exiting"
             exit 1
         fi


### PR DESCRIPTION
Previously, when `go tool nm` ran against binaries in `$BAZEL_BIN`, we could hit a condition when `$BAZEL_BIN` is different for `--config=ci` and the actual build, where we use `-c opt`. As a result, the `go tool nm` test could scan a binary from a previous build, which can have different parameters.

This PR fixes the issue by scanning the binaries under the "artifacts" directory.

Epic: DEVINF-478
Part of: DEVINF-633
Release note: None