### PR TITLE
storepool: consider stores suspect on join

### DIFF
--- a/pkg/kv/kvserver/allocator/allocatorimpl/allocator_test.go
+++ b/pkg/kv/kvserver/allocator/allocatorimpl/allocator_test.go
@@ -531,7 +531,6 @@ func mockStorePool(
 	for _, storeID := range suspectedStoreIDs {
 		liveNodeSet[roachpb.NodeID(storeID)] = livenesspb.NodeLivenessStatus_LIVE
 		detail := storePool.GetStoreDetailLocked(storeID)
-		detail.LastAvailable = storePool.Clock().Now().GoTime()
 		detail.LastUnavailable = storePool.Clock().Now().GoTime()
 		detail.Desc = &roachpb.StoreDescriptor{
 			StoreID: storeID,

--- a/pkg/kv/kvserver/allocator/storepool/override_store_pool_test.go
+++ b/pkg/kv/kvserver/allocator/storepool/override_store_pool_test.go
@@ -335,7 +335,6 @@ func TestOverrideStorePoolGetStoreList(t *testing.T) {
 
 	// Set suspectedStore as suspected.
 	testStorePool.DetailsMu.Lock()
-	testStorePool.DetailsMu.StoreDetails[suspectedStore.StoreID].LastAvailable = testStorePool.clock.Now().GoTime()
 	testStorePool.DetailsMu.StoreDetails[suspectedStore.StoreID].LastUnavailable = testStorePool.clock.Now().GoTime()
 	testStorePool.DetailsMu.Unlock()
 

--- a/pkg/kv/kvserver/allocator/storepool/store_pool.go
+++ b/pkg/kv/kvserver/allocator/storepool/store_pool.go
@@ -162,6 +162,15 @@ func MakeStorePoolNodeLivenessFunc(nodeLiveness *liveness.NodeLiveness) NodeLive
 func LivenessStatus(
 	l livenesspb.Liveness, now time.Time, deadThreshold time.Duration,
 ) livenesspb.NodeLivenessStatus {
+	// If we don't have a liveness expiration time, treat the status as unknown.
+	// This is different than unavailable as it doesn't transition through being
+	// marked as suspect. In unavailable we still won't transfer leases or
+	// replicas to it in this state. A node that is in UNKNOWN status can
+	// immediately transition to Available once it passes a liveness heartbeat.
+	if l.Expiration.WallTime == 0 {
+		return livenesspb.NodeLivenessStatus_UNKNOWN
+	}
+
 	if l.IsDead(now, deadThreshold) {
 		if !l.Membership.Active() {
 			return livenesspb.NodeLivenessStatus_DECOMMISSIONED
@@ -177,6 +186,7 @@ func LivenessStatus(
 		}
 		return livenesspb.NodeLivenessStatus_LIVE
 	}
+	// Not yet dead, but has not heartbeated recently enough to be alive either.
 	return livenesspb.NodeLivenessStatus_UNAVAILABLE
 }
 
@@ -195,21 +205,6 @@ type StoreDetail struct {
 	// LastUnavailable is set when it's detected that a store was unavailable,
 	// i.e. failed liveness.
 	LastUnavailable time.Time
-	// LastAvailable is set when it's detected that a store was available,
-	// i.e. we got a liveness heartbeat.
-	LastAvailable time.Time
-}
-
-// isThrottled returns whether the store is currently throttled.
-func (sd StoreDetail) isThrottled(now time.Time) bool {
-	return sd.ThrottledUntil.After(now)
-}
-
-// isSuspect returns whether the store is currently suspect. We measure that by
-// looking at the time it was last unavailable making sure we have not seen any
-// failures for a period of time defined by StoreSuspectDuration.
-func (sd StoreDetail) isSuspect(now time.Time, suspectDuration time.Duration) bool {
-	return sd.LastUnavailable.Add(suspectDuration).After(now)
 }
 
 // storeStatus is the current status of a store.
@@ -243,39 +238,28 @@ const (
 )
 
 func (sd *StoreDetail) status(
-	now time.Time, threshold time.Duration, nl NodeLivenessFunc, suspectDuration time.Duration,
+	now time.Time, deadThreshold time.Duration, nl NodeLivenessFunc, suspectDuration time.Duration,
 ) storeStatus {
 	// During normal operation, we expect the state transitions for stores to look like the following:
 	//
-	//                                           Successful heartbeats
-	//                                          throughout the suspect
-	//       +-----------------------+                 duration
-	//       | storeStatusAvailable  |<-+------------------------------------+
-	//       +-----------------------+  |                                    |
-	//                                  |                                    |
-	//                                  |                         +--------------------+
-	//                                  |                         | storeStatusSuspect |
-	//      +---------------------------+                         +--------------------+
-	//      |      Failed liveness                                           ^
-	//      |         heartbeat                                              |
-	//      |                                                                |
-	//      |                                                                |
-	//      |  +----------------------+                                      |
-	//      +->|  storeStatusUnknown  |--------------------------------------+
-	//         +----------------------+          Successful liveness
-	//                                                heartbeat
+	//      +-----------------------+
+	//   +- |  storeStatusUnknown   |
+	//   |  +-----------------------+             Successful heartbeats
+	//   |                                        throughout the suspect
+	//   |      +-----------------------+         duration
+	//   +----->| storeStatusAvailable  |<-+---------------------------+
+	//          +-----------------------+  |                           |
+	//                                     |                   +--------------------+
+	//                                     |                   | storeStatusSuspect |
+	//      +------------------------------+                   +--------------------+
+	//      |      Failed liveness                                     ^
+	//      |      heartbeat                                           |
+	//      |                                                          |
+	//      |  +-------------------------+                             |
+	//      +->|  storeStatusUnavailable |-----------------------------+
+	//         +-------------------------+    Successful liveness
+	//                                        heartbeat
 	//
-	// The store is considered dead if it hasn't been updated via gossip
-	// within the liveness threshold. Note that LastUpdatedTime is set
-	// when the store detail is created and will have a non-zero value
-	// even before the first gossip arrives for a store.
-	deadAsOf := sd.LastUpdatedTime.Add(threshold)
-	if now.After(deadAsOf) {
-		// Wipe out the lastAvailable timestamp, so that once a node comes back
-		// from the dead we dont consider it suspect.
-		sd.LastAvailable = time.Time{}
-		return storeStatusDead
-	}
 	// If there's no descriptor (meaning no gossip ever arrived for this
 	// store), return unavailable.
 	if sd.Desc == nil {
@@ -283,41 +267,39 @@ func (sd *StoreDetail) status(
 	}
 
 	// Even if the store has been updated via gossip, we still rely on
-	// the node liveness to determine whether it is considered live.
+	// the node liveness to determine whether it is considered available.
 	//
 	// Store statuses checked in the following order:
 	// dead -> decommissioning -> unknown -> draining -> suspect -> available.
-	switch nl(sd.Desc.Node.NodeID, now, threshold) {
+	switch nl(sd.Desc.Node.NodeID, now, deadThreshold) {
 	case livenesspb.NodeLivenessStatus_DEAD, livenesspb.NodeLivenessStatus_DECOMMISSIONED:
+		sd.LastUnavailable = now
 		return storeStatusDead
 	case livenesspb.NodeLivenessStatus_DECOMMISSIONING:
 		return storeStatusDecommissioning
 	case livenesspb.NodeLivenessStatus_UNAVAILABLE:
-		// We don't want to suspect a node on startup or when it's first added to a
-		// cluster, because we dont know its liveness yet.
-		if !sd.LastAvailable.IsZero() {
-			sd.LastUnavailable = now
-		}
+		sd.LastUnavailable = now
 		return storeStatusUnknown
 	case livenesspb.NodeLivenessStatus_UNKNOWN:
 		return storeStatusUnknown
 	case livenesspb.NodeLivenessStatus_DRAINING:
-		// Wipe out the lastAvailable timestamp, so if this node comes back after a
-		// graceful restart it will not be considered as suspect. This is best effort
-		// and we may not see a store in this state. To help with that we perform
-		// a similar clear of lastAvailable on a DEAD store.
-		sd.LastAvailable = time.Time{}
+		sd.LastUnavailable = now
 		return storeStatusDraining
 	}
 
-	if sd.isThrottled(now) {
+	// A store is throttled if it has missed receiving snapshots recently.
+	if sd.ThrottledUntil.After(now) {
 		return storeStatusThrottled
 	}
 
-	if sd.isSuspect(now, suspectDuration) {
+	// Check whether the store is currently suspect. We measure that by
+	// looking at the time it was last unavailable making sure we have not seen any
+	// failures for a period of time defined by StoreSuspectDuration.
+	if sd.LastUnavailable.Add(suspectDuration).After(now) {
 		return storeStatusSuspect
 	}
-	sd.LastAvailable = now
+
+	// Clear out the LastUnavailable once we return available status.
 	return storeStatusAvailable
 }
 

--- a/pkg/kv/kvserver/asim/gossip/exchange.go
+++ b/pkg/kv/kvserver/asim/gossip/exchange.go
@@ -59,6 +59,5 @@ func makeStoreDetail(desc *roachpb.StoreDescriptor, tick time.Time) *storepool.S
 	return &storepool.StoreDetail{
 		Desc:            desc,
 		LastUpdatedTime: tick,
-		LastAvailable:   tick,
 	}
 }

--- a/pkg/kv/kvserver/client_replica_test.go
+++ b/pkg/kv/kvserver/client_replica_test.go
@@ -1554,8 +1554,9 @@ func (l *leaseTransferTest) setFilter(setTo bool, extensionSem chan struct{}) {
 func (l *leaseTransferTest) forceLeaseExtension(
 	t *testing.T, storeIdx int, lease roachpb.Lease,
 ) error {
-	// Set the clock close to the lease's expiration.
-	l.manualClock.Increment(lease.Expiration.WallTime - l.manualClock.UnixNano() - 10)
+	// Set the clock far enough forward to cause a lease extension, but not far
+	// enough to make the node appear unhealthy.
+	l.manualClock.Increment((lease.Expiration.WallTime - l.manualClock.UnixNano()) / 2)
 	err := l.sendRead(t, storeIdx).GoError()
 	// We can sometimes receive an error from our renewal attempt because the
 	// lease transfer ends up causing the renewal to re-propose and second


### PR DESCRIPTION
Previously, stores would not be considered suspect when joining the cluster. This patch updates logic so that stores are now considered suspect on joining the cluster (rejoining or startup).

Release note (ops change): Stores will now be considered suspect when joining the cluster.

Epic: none