### PR TITLE
kvserver: fix deadlock on rebalance obj change

### DIFF
--- a/pkg/kv/kvserver/merge_queue.go
+++ b/pkg/kv/kvserver/merge_queue.go
@@ -19,6 +19,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverbase"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/split"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/spanconfig"
@@ -185,7 +186,12 @@ var _ PurgatoryError = rangeMergePurgatoryError{}
 
 func (mq *mergeQueue) requestRangeStats(
 	ctx context.Context, key roachpb.Key,
-) (desc *roachpb.RangeDescriptor, stats enginepb.MVCCStats, ls loadSplitStat, err error) {
+) (
+	desc *roachpb.RangeDescriptor,
+	stats enginepb.MVCCStats,
+	lbSnap split.LoadSplitSnapshot,
+	err error,
+) {
 
 	ba := &kvpb.BatchRequest{}
 	ba.Add(&kvpb.RangeStatsRequest{
@@ -194,7 +200,7 @@ func (mq *mergeQueue) requestRangeStats(
 
 	br, pErr := mq.db.NonTransactionalSender().Send(ctx, ba)
 	if pErr != nil {
-		return nil, enginepb.MVCCStats{}, loadSplitStat{}, pErr.GoError()
+		return nil, enginepb.MVCCStats{}, lbSnap, pErr.GoError()
 	}
 	res := br.Responses[0].GetInner().(*kvpb.RangeStatsResponse)
 
@@ -202,23 +208,28 @@ func (mq *mergeQueue) requestRangeStats(
 	stats = res.MVCCStats
 
 	// The load based splitter will only track the max of at most one statistic
-	// at a time for load based splitting. This is either CPU or QPS. However
-	// we don't enforce that only one max stat is returned. If the split
-	// objective is currently CPU, it must be the case that every store in the
-	// cluster is running a version that populates MaxCPUPerSecond so we don't
-	// need to worry about it being 0 as default and passing the >= 0 check.
-	switch mq.store.splitConfig.SplitObjective() {
-	case SplitCPU:
-		ls.max = res.MaxCPUPerSecond
-		ls.ok = res.MaxCPUPerSecond >= 0
-		ls.typ = SplitCPU
-	case SplitQPS:
-		ls.max = res.MaxQueriesPerSecond
-		ls.ok = res.MaxQueriesPerSecond >= 0
-		ls.typ = SplitQPS
+	// at a time for load based splitting. This is either CPU or QPS. However we
+	// don't enforce that only one max stat is returned. We set QPS after CPU,
+	// possibly overwriting if both are set. A default value of 0 could be
+	// returned in the response if the rhs node is on a pre 23.1 version. To
+	// avoid merging the range due to low load (0 CPU), always overwrite the
+	// value if MaxQPS is set. If neither are >= 0, OK won't be set and the
+	// objective will be default value, QPS.
+	if res.MaxCPUPerSecond >= 0 {
+		lbSnap = split.LoadSplitSnapshot{
+			SplitObjective: split.SplitCPU,
+			Max:            res.MaxCPUPerSecond,
+			Ok:             true,
+		}
 	}
-
-	return desc, stats, ls, nil
+	if res.MaxQueriesPerSecond >= 0 {
+		lbSnap = split.LoadSplitSnapshot{
+			SplitObjective: split.SplitQPS,
+			Max:            res.MaxQueriesPerSecond,
+			Ok:             true,
+		}
+	}
+	return desc, stats, lbSnap, nil
 }
 
 func (mq *mergeQueue) process(
@@ -231,7 +242,6 @@ func (mq *mergeQueue) process(
 
 	lhsDesc := lhsRepl.Desc()
 	lhsStats := lhsRepl.GetMVCCStats()
-	lhsLoadSplitStat := lhsRepl.loadSplitStat(ctx)
 	minBytes := lhsRepl.GetMinBytes()
 	if lhsStats.Total() >= minBytes {
 		log.VEventf(ctx, 2, "skipping merge: LHS meets minimum size threshold %d with %d bytes",
@@ -239,7 +249,7 @@ func (mq *mergeQueue) process(
 		return false, nil
 	}
 
-	rhsDesc, rhsStats, rhsLoadSplitStat, err := mq.requestRangeStats(ctx, lhsDesc.EndKey.AsRawKey())
+	rhsDesc, rhsStats, rhsLoadSplitSnap, err := mq.requestRangeStats(ctx, lhsDesc.EndKey.AsRawKey())
 	if err != nil {
 		return false, err
 	}
@@ -265,11 +275,12 @@ func (mq *mergeQueue) process(
 	mergedStats := lhsStats
 	mergedStats.Add(rhsStats)
 
+	lhsLoadSplitSnap := lhsRepl.loadBasedSplitter.Snapshot(ctx, mq.store.Clock().PhysicalTime())
 	var loadMergeReason string
 	if lhsRepl.SplitByLoadEnabled() {
 		var canMergeLoad bool
 		if canMergeLoad, loadMergeReason = canMergeRangeLoad(
-			ctx, lhsLoadSplitStat, rhsLoadSplitStat, mq.store.splitConfig,
+			ctx, lhsLoadSplitSnap, rhsLoadSplitSnap,
 		); !canMergeLoad {
 			log.VEventf(ctx, 2, "skipping merge to avoid thrashing: merged range %s may split %s",
 				mergedDesc, loadMergeReason)
@@ -415,7 +426,7 @@ func (mq *mergeQueue) process(
 	// Adjust the splitter to account for the additional load from the RHS. We
 	// could just Reset the splitter, but then we'd need to wait out a full
 	// measurement period (default of 5m) before merging this range again.
-	if mergedLoadSplitStat := lhsLoadSplitStat.max + rhsLoadSplitStat.max; mergedLoadSplitStat != 0 {
+	if mergedLoadSplitStat := lhsLoadSplitSnap.Max + rhsLoadSplitSnap.Max; mergedLoadSplitStat != 0 {
 		lhsRepl.loadBasedSplitter.RecordMax(mq.store.Clock().PhysicalTime(), mergedLoadSplitStat)
 	}
 	return true, nil
@@ -439,7 +450,7 @@ func (mq *mergeQueue) updateChan() <-chan time.Time {
 }
 
 func canMergeRangeLoad(
-	ctx context.Context, lhs, rhs loadSplitStat, rsc *replicaSplitConfig,
+	ctx context.Context, lhs, rhs split.LoadSplitSnapshot,
 ) (can bool, reason string) {
 	// When load is a consideration for splits and, by extension, merges, the
 	// mergeQueue is fairly conservative. In an effort to avoid thrashing and to
@@ -451,10 +462,10 @@ func canMergeRangeLoad(
 	// maximum qps measurement from both sides to be sufficiently stable and
 	// reliable, meaning that it was a maximum measurement over some extended
 	// period of time.
-	if !lhs.ok {
+	if !lhs.Ok {
 		return false, "LHS load measurement not yet reliable"
 	}
-	if !rhs.ok {
+	if !rhs.Ok {
 		return false, "RHS load measurement not yet reliable"
 	}
 
@@ -462,36 +473,36 @@ func canMergeRangeLoad(
 	// the current split objective they cannot merge together. This could occur
 	// just after changing the split objective to a different value, where
 	// there is a mismatch.
-	splitObjective, splitThreshold := rsc.SplitObjective(), rsc.StatThreshold()
-	if lhs.typ != splitObjective {
-		return false, "LHS load measurement is a different type (%s) than current split objective (%s)"
-	}
-	if rhs.typ != splitObjective {
-		return false, "RHS load measurement is a different type (%s) than current split objective (%s)"
+	if lhs.SplitObjective != rhs.SplitObjective {
+		return false, fmt.Sprintf("LHS load measurement is a different type (%s) than the RHS (%s)",
+			lhs.SplitObjective,
+			rhs.SplitObjective,
+		)
 	}
 
+	obj := lhs.SplitObjective
 	// Check if the merged range would need to be split, if so, skip merge.
 	// Use a lower threshold for load based splitting so we don't find ourselves
 	// in a situation where we keep merging ranges that would be split soon after
 	// by a small increase in load.
-	merged := lhs.max + rhs.max
-	conservativeLoadBasedSplitThreshold := 0.5 * splitThreshold
+	merged := lhs.Max + rhs.Max
+	conservativeLoadBasedSplitThreshold := 0.5 * lhs.Threshold
 
 	if merged >= conservativeLoadBasedSplitThreshold {
 		return false, fmt.Sprintf("lhs+rhs %s (%s+%s=%s) above threshold (%s)",
-			splitObjective,
-			splitObjective.Format(lhs.max),
-			splitObjective.Format(lhs.max),
-			splitObjective.Format(merged),
-			splitObjective.Format(conservativeLoadBasedSplitThreshold),
+			obj,
+			obj.Format(lhs.Max),
+			obj.Format(rhs.Max),
+			obj.Format(merged),
+			obj.Format(conservativeLoadBasedSplitThreshold),
 		)
 	}
 
 	return true, fmt.Sprintf("lhs+rhs %s (%s+%s=%s) below threshold (%s)",
-		splitObjective,
-		splitObjective.Format(lhs.max),
-		splitObjective.Format(lhs.max),
-		splitObjective.Format(merged),
-		splitObjective.Format(conservativeLoadBasedSplitThreshold),
+		obj,
+		obj.Format(lhs.Max),
+		obj.Format(rhs.Max),
+		obj.Format(merged),
+		obj.Format(conservativeLoadBasedSplitThreshold),
 	)
 }

--- a/pkg/kv/kvserver/replica.go
+++ b/pkg/kv/kvserver/replica.go
@@ -1301,10 +1301,12 @@ func (r *Replica) SetMVCCStatsForTesting(stats *enginepb.MVCCStats) {
 //
 // Use LoadStats.QueriesPerSecond for all other purposes.
 func (r *Replica) GetMaxSplitQPS(ctx context.Context) (float64, bool) {
-	if r.store.splitConfig.SplitObjective() != SplitQPS {
+	snap := r.loadBasedSplitter.Snapshot(ctx, r.Clock().PhysicalTime())
+
+	if snap.SplitObjective != split.SplitQPS {
 		return 0, false
 	}
-	return r.loadBasedSplitter.MaxStat(ctx, r.Clock().PhysicalTime())
+	return snap.Max, snap.Ok
 }
 
 // GetMaxSplitCPU returns the Replica's maximum CPU/s rate over a configured
@@ -1317,10 +1319,12 @@ func (r *Replica) GetMaxSplitQPS(ctx context.Context) (float64, bool) {
 // Use LoadStats.RaftCPUNanosPerSecond and RequestCPUNanosPerSecond for current
 // CPU stats for all other purposes.
 func (r *Replica) GetMaxSplitCPU(ctx context.Context) (float64, bool) {
-	if r.store.splitConfig.SplitObjective() != SplitCPU {
+	snap := r.loadBasedSplitter.Snapshot(ctx, r.Clock().PhysicalTime())
+
+	if snap.SplitObjective != split.SplitCPU {
 		return 0, false
 	}
-	return r.loadBasedSplitter.MaxStat(ctx, r.Clock().PhysicalTime())
+	return snap.Max, snap.Ok
 }
 
 // ContainsKey returns whether this range contains the specified key.

--- a/pkg/kv/kvserver/replica_split_load.go
+++ b/pkg/kv/kvserver/replica_split_load.go
@@ -21,9 +21,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
-	"github.com/cockroachdb/cockroach/pkg/util/humanizeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
-	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/errors"
 )
 
@@ -61,80 +59,39 @@ var SplitByLoadCPUThreshold = settings.RegisterDurationSetting(
 	500*time.Millisecond,
 ).WithPublic()
 
-// SplitObjective is a type that specifies a load based splitting objective.
-type SplitObjective int
-
-const (
-	// SplitQPS will track and split QPS (queries-per-second) over a range.
-	SplitQPS SplitObjective = iota
-	// SplitCPU will track and split CPU (cpu-per-second) over a range.
-	SplitCPU
-)
-
-// String returns a human readable string representation of the dimension.
-func (d SplitObjective) String() string {
-	switch d {
-	case SplitQPS:
-		return "qps"
-	case SplitCPU:
-		return "cpu"
+func (obj LBRebalancingObjective) ToSplitObjective() split.SplitObjective {
+	switch obj {
+	case LBRebalancingQueries:
+		return split.SplitQPS
+	case LBRebalancingCPU:
+		return split.SplitCPU
 	default:
-		panic(fmt.Sprintf("cannot name: unknown objective with ordinal %d", d))
-	}
-}
-
-// Format returns a formatted string for a value.
-func (d SplitObjective) Format(value float64) string {
-	switch d {
-	case SplitQPS:
-		return fmt.Sprintf("%.1f", value)
-	case SplitCPU:
-		return string(humanizeutil.Duration(time.Duration(int64(value))))
-	default:
-		panic(fmt.Sprintf("cannot format value: unknown objective with ordinal %d", d))
+		panic(fmt.Sprintf("unknown objective %d", obj))
 	}
 }
 
 // replicaSplitConfig implements the split.SplitConfig interface.
 type replicaSplitConfig struct {
-	randSource                 split.RandSource
-	rebalanceObjectiveProvider RebalanceObjectiveProvider
-	st                         *cluster.Settings
+	randSource split.RandSource
+	st         *cluster.Settings
 }
 
-func newReplicaSplitConfig(
-	st *cluster.Settings, rebalanceObjectiveProvider RebalanceObjectiveProvider,
-) *replicaSplitConfig {
+func newReplicaSplitConfig(st *cluster.Settings) *replicaSplitConfig {
 	return &replicaSplitConfig{
-		randSource:                 split.GlobalRandSource(),
-		rebalanceObjectiveProvider: rebalanceObjectiveProvider,
-		st:                         st,
-	}
-}
-
-// SplitObjective returns the current split objective. Currently this tracks
-// 1:1 to the rebalance objective e.g. balancing QPS means also load based
-// splitting on QPS.
-func (c *replicaSplitConfig) SplitObjective() SplitObjective {
-	obj := c.rebalanceObjectiveProvider.Objective()
-	switch obj {
-	case LBRebalancingQueries:
-		return SplitQPS
-	case LBRebalancingCPU:
-		return SplitCPU
-	default:
-		panic(errors.AssertionFailedf("Unkown split objective %d", obj))
+		randSource: split.GlobalRandSource(),
+		st:         st,
 	}
 }
 
 // NewLoadBasedSplitter returns a new LoadBasedSplitter that may be used to
 // find the midpoint based on recorded load.
-func (c *replicaSplitConfig) NewLoadBasedSplitter(startTime time.Time) split.LoadBasedSplitter {
-	obj := c.SplitObjective()
+func (c *replicaSplitConfig) NewLoadBasedSplitter(
+	startTime time.Time, obj split.SplitObjective,
+) split.LoadBasedSplitter {
 	switch obj {
-	case SplitQPS:
+	case split.SplitQPS:
 		return split.NewUnweightedFinder(startTime, c.randSource)
-	case SplitCPU:
+	case split.SplitCPU:
 		return split.NewWeightedFinder(startTime, c.randSource)
 	default:
 		panic(errors.AssertionFailedf("Unkown rebalance objective %d", obj))
@@ -148,12 +105,11 @@ func (c *replicaSplitConfig) StatRetention() time.Duration {
 
 // StatThreshold returns the threshold for load above which the range should be
 // considered split.
-func (c *replicaSplitConfig) StatThreshold() float64 {
-	obj := c.SplitObjective()
+func (c *replicaSplitConfig) StatThreshold(obj split.SplitObjective) float64 {
 	switch obj {
-	case SplitQPS:
+	case split.SplitQPS:
 		return float64(SplitByLoadQPSThreshold.Get(&c.st.SV))
-	case SplitCPU:
+	case split.SplitCPU:
 		return float64(SplitByLoadCPUThreshold.Get(&c.st.SV))
 	default:
 		panic(errors.AssertionFailedf("Unkown rebalance objective %d", obj))
@@ -166,22 +122,6 @@ func (c *replicaSplitConfig) StatThreshold() float64 {
 func (r *Replica) SplitByLoadEnabled() bool {
 	return SplitByLoadEnabled.Get(&r.store.cfg.Settings.SV) &&
 		!r.store.TestingKnobs().DisableLoadBasedSplitting
-}
-
-type loadSplitStat struct {
-	max float64
-	ok  bool
-	typ SplitObjective
-}
-
-func (r *Replica) loadSplitStat(ctx context.Context) loadSplitStat {
-	max, ok := r.loadBasedSplitter.MaxStat(ctx, r.Clock().PhysicalTime())
-	lss := loadSplitStat{
-		max: max,
-		ok:  ok,
-		typ: r.store.splitConfig.SplitObjective(),
-	}
-	return lss
 }
 
 // getResponseBoundarySpan computes the union span of the true spans that were
@@ -260,7 +200,7 @@ func getResponseBoundarySpan(
 // recordBatchForLoadBasedSplitting records the batch's spans to be considered
 // for load based splitting.
 func (r *Replica) recordBatchForLoadBasedSplitting(
-	ctx context.Context, ba *kvpb.BatchRequest, br *kvpb.BatchResponse, stat int,
+	ctx context.Context, ba *kvpb.BatchRequest, br *kvpb.BatchResponse, cpu int,
 ) {
 	if !r.SplitByLoadEnabled() {
 		return
@@ -278,15 +218,20 @@ func (r *Replica) recordBatchForLoadBasedSplitting(
 			len(ba.Requests), len(br.Responses))
 	}
 
-	// When QPS splitting is enabled, use the number of requests rather than
-	// the given stat for recording load.
-	if r.store.splitConfig.SplitObjective() == SplitQPS {
-		stat = len(ba.Requests)
+	loadFn := func(obj split.SplitObjective) int {
+		switch obj {
+		case split.SplitCPU:
+			return cpu
+		default:
+			return len(ba.Requests)
+		}
 	}
 
-	shouldInitSplit := r.loadBasedSplitter.Record(ctx, timeutil.Now(), stat, func() roachpb.Span {
+	spanFn := func() roachpb.Span {
 		return getResponseBoundarySpan(ba, br)
-	})
+	}
+
+	shouldInitSplit := r.loadBasedSplitter.Record(ctx, r.Clock().PhysicalTime(), loadFn, spanFn)
 	if shouldInitSplit {
 		r.store.splitQueue.MaybeAddAsync(ctx, r, r.store.Clock().NowAsClockTimestamp())
 	}

--- a/pkg/kv/kvserver/split/BUILD.bazel
+++ b/pkg/kv/kvserver/split/BUILD.bazel
@@ -5,6 +5,7 @@ go_library(
     name = "split",
     srcs = [
         "decider.go",
+        "objective.go",
         "unweighted_finder.go",
         "weighted_finder.go",
     ],
@@ -13,6 +14,7 @@ go_library(
     deps = [
         "//pkg/keys",
         "//pkg/roachpb",
+        "//pkg/util/humanizeutil",
         "//pkg/util/log",
         "//pkg/util/metric",
         "//pkg/util/syncutil",

--- a/pkg/kv/kvserver/split/objective.go
+++ b/pkg/kv/kvserver/split/objective.go
@@ -1,0 +1,52 @@
+// Copyright 2023 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package split
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/util/humanizeutil"
+)
+
+// SplitObjective is a type that specifies a load based splitting objective.
+type SplitObjective int
+
+const (
+	// SplitQPS will track and split QPS (queries-per-second) over a range.
+	SplitQPS SplitObjective = iota
+	// SplitCPU will track and split CPU (cpu-per-second) over a range.
+	SplitCPU
+)
+
+// String returns a human readable string representation of the dimension.
+func (d SplitObjective) String() string {
+	switch d {
+	case SplitQPS:
+		return "qps"
+	case SplitCPU:
+		return "cpu"
+	default:
+		panic(fmt.Sprintf("cannot name: unknown objective with ordinal %d", d))
+	}
+}
+
+// Format returns a formatted string for a value.
+func (d SplitObjective) Format(value float64) string {
+	switch d {
+	case SplitQPS:
+		return fmt.Sprintf("%.1f", value)
+	case SplitCPU:
+		return string(humanizeutil.Duration(time.Duration(int64(value))))
+	default:
+		panic(fmt.Sprintf("cannot format value: unknown objective with ordinal %d", d))
+	}
+}

--- a/pkg/kv/kvserver/store.go
+++ b/pkg/kv/kvserver/store.go
@@ -775,7 +775,6 @@ type Store struct {
 	ctSender            *sidetransport.Sender
 	storeGossip         *StoreGossip
 	rebalanceObjManager *RebalanceObjectiveManager
-	splitConfig         *replicaSplitConfig
 
 	coalescedMu struct {
 		syncutil.Mutex
@@ -1234,14 +1233,16 @@ func NewStore(
 		s.rebalanceObjManager = newRebalanceObjectiveManager(ctx, s.cfg.Settings,
 			func(ctx context.Context, obj LBRebalancingObjective) {
 				s.VisitReplicas(func(r *Replica) (wantMore bool) {
-					r.loadBasedSplitter.Reset(s.Clock().PhysicalTime())
+					r.loadBasedSplitter.SetSplitObjective(
+						s.Clock().PhysicalTime(),
+						obj.ToSplitObjective(),
+					)
 					return true
 				})
 			},
 			allocatorStorePool, /* storeDescProvider */
 			allocatorStorePool, /* capacityChangeNotifier */
 		)
-		s.splitConfig = newReplicaSplitConfig(s.cfg.Settings, s.rebalanceObjManager)
 	}
 	if cfg.RPCContext != nil {
 		s.allocator = allocatorimpl.MakeAllocator(


### PR DESCRIPTION
Previously, changing the rebalance objective could lead to inconsistent
locking order between the load based splitter and rebalance objective.
When the objective was updated, the previous method also blocked
batch requests from completing until every replica lb splitter was
reset.

This commit moves the split objective to be a variable owned by the
decider, rather than inferred on each decider operation. The split
objective is updated on a rebalance objective change atomically over
each replica but not atomically over a store. This removes the need for
blocking batch requests until every replica is updated.

Resolves: https://github.com/cockroachdb/cockroach/issues/97000
Resolves: https://github.com/cockroachdb/cockroach/issues/97445
Resolves: https://github.com/cockroachdb/cockroach/issues/97450
Resolves: https://github.com/cockroachdb/cockroach/issues/97452
Resolves: https://github.com/cockroachdb/cockroach/issues/97457

Release note: None