### PR TITLE
roachtest: use qps splitting for splits/load tests

### DIFF
--- a/pkg/cmd/roachtest/tests/split.go
+++ b/pkg/cmd/roachtest/tests/split.go
@@ -147,6 +147,13 @@ func runLoadSplits(ctx context.Context, t test.Test, c cluster.Cluster, params s
 			return err
 		}
 
+		// TODO(kvoli): Add load split tests which use CPU, similar to the current
+		// QPS ones. Tracked by #97540.
+		t.Status("setting split objective to QPS")
+		if err := setLoadBasedRebalancingObjective(ctx, db, "qps"); err != nil {
+			return err
+		}
+
 		t.Status("increasing range_max_bytes")
 		minBytes := 16 << 20 // 16 MB
 		setRangeMaxBytes := func(maxBytes int) {
@@ -438,4 +445,13 @@ func disableLoadBasedSplitting(ctx context.Context, db *gosql.DB) error {
 		}
 	}
 	return nil
+}
+
+func setLoadBasedRebalancingObjective(ctx context.Context, db *gosql.DB, obj string) error {
+	_, err := db.ExecContext(
+		ctx,
+		fmt.Sprintf(`SET CLUSTER SETTING kv.allocator.load_based_rebalancing.objective = '%s'`, obj),
+	)
+	return err
+
 }


### PR DESCRIPTION
This commit updates the clusters used in `splits/load` roachtests to use
QPS load based splitting, rather than CPU, which was enabled by default
in https://github.com/cockroachdb/cockroach/pull/97424.

These tests were failing as they assumed QPS load based splitting when
calculating the number of final ranges to assert against.

These tests should be run against all load based split objectives, this
is tracked in https://github.com/cockroachdb/cockroach/issues/97540.

Resolves: https://github.com/cockroachdb/cockroach/issues/97494
Resolves: https://github.com/cockroachdb/cockroach/issues/97455
Informs:  https://github.com/cockroachdb/cockroach/issues/97540