### PR TITLE
server: use workersCtx in cmux error handler

### DIFF
--- a/pkg/server/start_listen.go
+++ b/pkg/server/start_listen.go
@@ -100,7 +100,7 @@ func startListenRPCAndSQL(
 	m.HandleError(func(err error) bool {
 		select {
 		case <-stopper.ShouldQuiesce():
-			log.Infof(ctx, "server shutting down: instructing cmux to stop accepting")
+			log.Infof(workersCtx, "server shutting down: instructing cmux to stop accepting")
 			return false
 		default:
 			return true


### PR DESCRIPTION
Since the error handler outlives the startup, it should be using the workersCtx.

I suspect this is the cause of #97032 but I haven't been able to reproduce that locally in a unit test.

Fixes #93032

Epic: none

Release note: none