### PR TITLE
release-22.1: roachprod: guard calls to SetupSSH

### DIFF
--- a/pkg/roachprod/roachprod.go
+++ b/pkg/roachprod/roachprod.go
@@ -219,8 +219,9 @@ func CachedClusters(l *logger.Logger, fn func(clusterName string, numVMs int)) {
 	}
 }
 
-// acquireFilesystemLock acquires a filesystem lock so that two concurrent
-// synchronizations of roachprod state don't clobber each other.
+// acquireFilesystemLock acquires a filesystem lock in order that concurrent
+// operations or roachprod processes that access shared system resources do
+// not conflict.
 func acquireFilesystemLock() (unlockFn func(), _ error) {
 	lockFile := os.ExpandEnv("$HOME/.roachprod/LOCK")
 	f, err := os.Create(lockFile)
@@ -555,6 +556,11 @@ func SetupSSH(ctx context.Context, l *logger.Logger, clusterName string) error {
 
 	// Configure SSH for machines in the zones we operate on.
 	if err := vm.ProvidersSequential(providers, func(p vm.Provider) error {
+		unlock, lockErr := acquireFilesystemLock()
+		if lockErr != nil {
+			return lockErr
+		}
+		defer unlock()
 		return p.ConfigSSH(zones[p.Name()])
 	}); err != nil {
 		return err


### PR DESCRIPTION
Backport 1/1 commits from #96794.

/cc @cockroachdb/release

---

This change ensures that calls to `SetupSSH` do not run concurrently across
processes or threads. Overlapping calls are not safe and can lead to invalid SSH
configurations. The scenario takes place when multiple clusters are created
simultaneously from the same or multiple processes.

Resolves:  #90092

Release justification: Improve roachprod stability
