### PR TITLE
kvserver: assert uniqueness in registerProposalLocked

### DIFF
--- a/pkg/kv/kvserver/replica_proposal_buf.go
+++ b/pkg/kv/kvserver/replica_proposal_buf.go
@@ -1192,6 +1192,9 @@ func (rp *replicaProposer) registerProposalLocked(p *ProposalData) {
 	if buildutil.CrdbTestBuild && (p.ec.repl == nil || p.ec.g == nil) {
 		log.Fatalf(rp.store.AnnotateCtx(context.Background()), "finished proposal inserted into map: %+v", p)
 	}
+	if prev := rp.mu.proposals[p.idKey]; prev != nil && prev != p {
+		log.Fatalf(rp.store.AnnotateCtx(context.Background()), "two proposals under same ID:\n%+v,\n%+v", prev, p)
+	}
 	rp.mu.proposals[p.idKey] = p
 }
 


### PR DESCRIPTION
We routinely overwrite entries in the `r.mu.proposals` map. That is
"fine" (better if we didn't, but currently it is by design - it
happens in refreshProposalsLocked and during
tryReproposeWithNewLeaseIndex) but our overwrites should be no-ops, i.e.
reference the exact same `*ProposalData`.

This is now asserted.

One way this would trip is a CmdID collision.

Epic: none
Release note: None
