### PR TITLE
sql: fix internal queries in SHOW QUERIES

### DIFF
--- a/pkg/server/server_internal_executor_factory_test.go
+++ b/pkg/server/server_internal_executor_factory_test.go
@@ -33,7 +33,7 @@ func TestInternalExecutorClearsMonitorMemory(t *testing.T) {
 
 	mon := s.(*TestServer).sqlServer.internalDBMemMonitor
 	ief := s.ExecutorConfig().(sql.ExecutorConfig).InternalDB
-	sessionData := sql.NewFakeSessionData(&s.ClusterSettings().SV)
+	sessionData := sql.NewFakeSessionData(&s.ClusterSettings().SV, "TestInternalExecutorClearsMonitorMemory")
 	ie := ief.NewInternalExecutor(sessionData)
 	rows, err := ie.QueryIteratorEx(ctx, "test", nil, sessiondata.NodeUserSessionDataOverride, `SELECT 1`)
 	require.NoError(t, err)

--- a/pkg/sql/backfill.go
+++ b/pkg/sql/backfill.go
@@ -1049,7 +1049,7 @@ func (sc *SchemaChanger) distIndexBackfill(
 		if err != nil {
 			return err
 		}
-		sd := NewFakeSessionData(sc.execCfg.SV())
+		sd := NewFakeSessionData(sc.execCfg.SV(), "dist-index-backfill")
 		evalCtx = createSchemaChangeEvalCtx(ctx, sc.execCfg, sd, txn.KV().ReadTimestamp(), txn.Descriptors())
 		planCtx = sc.distSQLPlanner.NewPlanningCtx(ctx, &evalCtx, nil, /* planner */
 			txn.KV(), DistributionTypeSystemTenantOnly)
@@ -1345,7 +1345,7 @@ func (sc *SchemaChanger) distColumnBackfill(
 				return nil
 			}
 			cbw := MetadataCallbackWriter{rowResultWriter: &errOnlyResultWriter{}, fn: metaFn}
-			sd := NewFakeSessionData(sc.execCfg.SV())
+			sd := NewFakeSessionData(sc.execCfg.SV(), "dist-column-backfill")
 			evalCtx := createSchemaChangeEvalCtx(ctx, sc.execCfg, sd, txn.KV().ReadTimestamp(), txn.Descriptors())
 			recv := MakeDistSQLReceiver(
 				ctx,

--- a/pkg/sql/catalog/descs/collection_test.go
+++ b/pkg/sql/catalog/descs/collection_test.go
@@ -856,7 +856,7 @@ parent schema name   id  kind     version dropped public
 `, formatCatalog(allDescs.OrderedDescriptors()))
 		return nil
 	}
-	sd := sql.NewFakeSessionData(&s0.ClusterSettings().SV)
+	sd := sql.NewFakeSessionData(&s0.ClusterSettings().SV, "TestGetAllDescriptorsInDatabase")
 	sd.Database = "db"
 	require.NoError(t, tm.DescsTxn(ctx, run, isql.WithSessionData(sd)))
 }

--- a/pkg/sql/index_backfiller.go
+++ b/pkg/sql/index_backfiller.go
@@ -167,7 +167,7 @@ func (ib *IndexBackfillPlanner) plan(
 	if err := DescsTxn(ctx, ib.execCfg, func(
 		ctx context.Context, txn isql.Txn, descriptors *descs.Collection,
 	) error {
-		sd := NewFakeSessionData(ib.execCfg.SV())
+		sd := NewFakeSessionData(ib.execCfg.SV(), "plan-index-backfill")
 		evalCtx = createSchemaChangeEvalCtx(ctx, ib.execCfg, sd, nowTimestamp, descriptors)
 		planCtx = ib.execCfg.DistSQLPlanner.NewPlanningCtx(ctx, &evalCtx,
 			nil /* planner */, txn.KV(), DistributionTypeSystemTenantOnly)

--- a/pkg/sql/internal_test.go
+++ b/pkg/sql/internal_test.go
@@ -375,10 +375,10 @@ func TestInternalExecAppNameInitialization(t *testing.T) {
 		s, _, _ := serverutils.StartServer(t, params)
 		defer s.Stopper().Stop(context.Background())
 
-		testInternalExecutorAppNameInitialization(t, sem,
-			catconstants.InternalAppNamePrefix+"-test-query", // app name in SHOW
-			catconstants.InternalAppNamePrefix+"-test-query", // app name in stats
-			s.InternalExecutor().(*sql.InternalExecutor))
+		testInternalExecutorAppNameInitialization(
+			t, sem, catconstants.InternalAppNamePrefix+"-test-query",
+			s.InternalExecutor().(*sql.InternalExecutor),
+		)
 	})
 
 	// We are running the second test with a new server so
@@ -402,10 +402,7 @@ func TestInternalExecAppNameInitialization(t *testing.T) {
 				SequenceState: &sessiondata.SequenceState{},
 			})
 		testInternalExecutorAppNameInitialization(
-			t, sem,
-			"appname_findme", // app name in SHOW
-			catconstants.DelegatedAppNamePrefix+"appname_findme", // app name in stats
-			&ie,
+			t, sem, catconstants.DelegatedAppNamePrefix+"appname_findme", &ie,
 		)
 	})
 }
@@ -420,10 +417,7 @@ type testInternalExecutor interface {
 }
 
 func testInternalExecutorAppNameInitialization(
-	t *testing.T,
-	sem chan struct{},
-	expectedAppName, expectedAppNameInStats string,
-	ie testInternalExecutor,
+	t *testing.T, sem chan struct{}, expectedAppName string, ie testInternalExecutor,
 ) {
 	// Check that the application_name is set properly in the executor.
 	if row, err := ie.QueryRow(context.Background(), "test-query", nil,
@@ -511,8 +505,8 @@ func testInternalExecutorAppNameInitialization(
 		t.Fatal(err)
 	} else if row == nil {
 		t.Fatalf("expected 1 query, got 0")
-	} else if appName := string(*row[0].(*tree.DString)); appName != expectedAppNameInStats {
-		t.Fatalf("unexpected app name: expected %q, got %q", expectedAppNameInStats, appName)
+	} else if appName := string(*row[0].(*tree.DString)); appName != expectedAppName {
+		t.Fatalf("unexpected app name: expected %q, got %q", expectedAppName, appName)
 	}
 }
 

--- a/pkg/sql/mvcc_backfiller.go
+++ b/pkg/sql/mvcc_backfiller.go
@@ -126,7 +126,7 @@ func (im *IndexBackfillerMergePlanner) plan(
 	if err := DescsTxn(ctx, im.execCfg, func(
 		ctx context.Context, txn isql.Txn, descriptors *descs.Collection,
 	) error {
-		sd := NewFakeSessionData(im.execCfg.SV())
+		sd := NewFakeSessionData(im.execCfg.SV(), "plan-index-backfill-merge")
 		evalCtx = createSchemaChangeEvalCtx(ctx, im.execCfg, sd, txn.KV().ReadTimestamp(), descriptors)
 		planCtx = im.execCfg.DistSQLPlanner.NewPlanningCtx(ctx, &evalCtx, nil /* planner */, txn.KV(),
 			DistributionTypeSystemTenantOnly)

--- a/pkg/sql/schema_changer.go
+++ b/pkg/sql/schema_changer.go
@@ -48,6 +48,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/catconstants"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/eval"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
@@ -2522,7 +2523,7 @@ func createSchemaChangeEvalCtx(
 // NewFakeSessionData returns "fake" session data for use in internal queries
 // that are not run on behalf of a user session, such as those run during the
 // steps of background jobs and schema changes.
-func NewFakeSessionData(sv *settings.Values) *sessiondata.SessionData {
+func NewFakeSessionData(sv *settings.Values, opName string) *sessiondata.SessionData {
 	sd := &sessiondata.SessionData{
 		SessionData: sessiondatapb.SessionData{
 			// The database is not supposed to be needed in schema changes, as there
@@ -2544,6 +2545,11 @@ func NewFakeSessionData(sv *settings.Values) *sessiondata.SessionData {
 		SearchPath:    sessiondata.DefaultSearchPathForUser(username.NodeUserName()),
 		SequenceState: sessiondata.NewSequenceState(),
 		Location:      time.UTC,
+	}
+
+	sd.ApplicationName = catconstants.InternalAppNamePrefix
+	if opName != "" {
+		sd.ApplicationName = catconstants.InternalAppNamePrefix + "-" + opName
 	}
 
 	return sd

--- a/pkg/sql/schemachanger/scdeps/validator.go
+++ b/pkg/sql/schemachanger/scdeps/validator.go
@@ -66,7 +66,7 @@ type ValidateConstraintFn func(
 
 // NewFakeSessionDataFn callback function used to create session data
 // for the internal executor.
-type NewFakeSessionDataFn func(sv *settings.Values) *sessiondata.SessionData
+type NewFakeSessionDataFn func(sv *settings.Values, opName string) *sessiondata.SessionData
 
 type validator struct {
 	db                         *kv.DB
@@ -120,7 +120,7 @@ func (vd validator) ValidateConstraint(
 	indexIDForValidation descpb.IndexID,
 	override sessiondata.InternalExecutorOverride,
 ) error {
-	return vd.validateConstraint(ctx, tbl, constraint, indexIDForValidation, vd.newFakeSessionData(&vd.settings.SV),
+	return vd.validateConstraint(ctx, tbl, constraint, indexIDForValidation, vd.newFakeSessionData(&vd.settings.SV, "validate-constraint"),
 		vd.makeHistoricalInternalExecTxnRunner(), override)
 }
 

--- a/pkg/sql/show_test.go
+++ b/pkg/sql/show_test.go
@@ -21,6 +21,7 @@ import (
 	"unicode/utf8"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/security/username"
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/lexbase"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
@@ -28,12 +29,15 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqltestutils"
 	"github.com/cockroachdb/cockroach/pkg/sql/tests"
+	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
+	"github.com/cockroachdb/cockroach/pkg/util/ctxgroup"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/errors"
+	"github.com/jackc/pgx/v4"
 	"github.com/stretchr/testify/require"
 )
 
@@ -655,6 +659,75 @@ func TestShowQueries(t *testing.T) {
 	if errcount != 1 {
 		t.Fatalf("expected 1 error row, got %d", errcount)
 	}
+}
+
+func TestShowQueriesDelegatesInternal(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	ctx := context.Background()
+
+	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	defer s.Stopper().Stop(ctx)
+
+	pgURL, cleanup := sqlutils.PGUrl(
+		t,
+		s.ServingSQLAddr(),
+		"TestShowQueriesDelegatesInternal",
+		url.User(username.RootUser),
+	)
+	defer cleanup()
+
+	q := pgURL.Query()
+	q.Add("application_name", "app_name")
+	pgURL.RawQuery = q.Encode()
+	copyConn, err := pgx.Connect(ctx, pgURL.String())
+	require.NoError(t, err)
+
+	g := ctxgroup.WithContext(ctx)
+	g.GoCtx(func(ctx context.Context) error {
+		// COPY TO uses the internal executor to run the source query.
+		_, err := copyConn.Exec(ctx, "COPY (SELECT pg_sleep(1) FROM ROWS FROM (generate_series(1, 60)) AS i) TO STDOUT")
+		return err
+	})
+
+	showConn, err := pgx.Connect(ctx, pgURL.String())
+	require.NoError(t, err)
+
+	// SucceedsSoon is used since COPY is being executed concurrently.
+	var appName string
+	testutils.SucceedsSoon(t, func() error {
+		// The COPY query should use the specified app name.
+		err = showConn.QueryRow(ctx, "SELECT application_name FROM [SHOW QUERIES] WHERE query LIKE 'COPY (SELECT pg_sleep(1) %'").Scan(&appName)
+		if err != nil {
+			return err
+		}
+		if appName != "app_name" {
+			return errors.New("expected COPY to appear in SHOW QUERIES")
+		}
+
+		// The internal query should use the delegated app name.
+		err = showConn.QueryRow(ctx, "SELECT application_name FROM [SHOW QUERIES] WHERE query LIKE 'SELECT pg_sleep(1) %'").Scan(&appName)
+		if err != nil {
+			return err
+		}
+		if appName != catconstants.DelegatedAppNamePrefix+"app_name" {
+			return errors.New("expected delegated query to appear in SHOW QUERIES")
+		}
+
+		return nil
+	})
+
+	err = copyConn.PgConn().CancelRequest(ctx)
+	require.NoError(t, err)
+
+	// An error is allowed here, since the query was canceled.
+	_ = g.Wait()
+
+	err = showConn.Close(ctx)
+	require.NoError(t, err)
+	err = copyConn.Close(ctx)
+	require.NoError(t, err)
+
 }
 
 func TestShowQueriesFillsInValuesForPlaceholders(t *testing.T) {


### PR DESCRIPTION
Epic: None

Release note (bug fix): Internal queries that are executed in order to
serve a client-initiated query already appeared in stats with an
application_name prefixed by `$$`. But this name was not used in the
output of SHOW QUERIES. Now, SHOW QUERIES also shows the `$$` prefix for
these types of queries.