### PR TITLE
logictest: add test for logging in as non-root in mixed-version cluster

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/testserver_upgrade_node
+++ b/pkg/sql/logictest/testdata/logic_test/testserver_upgrade_node
@@ -30,28 +30,37 @@ SELECT crdb_internal.node_executable_version()
 ----
 22.2
 
-# start of test that user cmd nodeidx opt works when used for a previously used user
-
-user root nodeidx=2
-
-query T
-SELECT crdb_internal.node_executable_version()
-----
-22.2
-
-query B
-SELECT crdb_internal.node_executable_version() SIMILAR TO '1000022.2-%'
-----
-false
-
-user root nodeidx=0
+# Verify that a non-root user can login on the upgraded node.
+user testuser nodeidx=0
 
 query B
 SELECT crdb_internal.node_executable_version() SIMILAR TO '1000022.2-%'
 ----
 true
 
-# end of test that user cmd nodeidx opt works when used for a previously used user
+# Verify that a root user can login on the upgraded node.
+user root nodeidx=1
+
+query B
+SELECT crdb_internal.node_executable_version() SIMILAR TO '1000022.2-%'
+----
+true
+
+# Verify that a non-root user can login on the non-upgraded node.
+user testuser nodeidx=2
+
+query T
+SELECT crdb_internal.node_executable_version()
+----
+22.2
+
+# Verify that a root user can login on the non-upgraded node.
+user root nodeidx=2
+
+query T
+SELECT crdb_internal.node_executable_version()
+----
+22.2
 
 upgrade 2
 


### PR DESCRIPTION
This type of test would have prevented the incident seen in https://cockroachlabs.atlassian.net/wiki/x/MgARrg.

Epic: None

Release note: None