### PR TITLE
sql: skip mixed version test if setup stmt is unimplemented in old version

### DIFF
--- a/pkg/sql/schemachanger/sctest/BUILD.bazel
+++ b/pkg/sql/schemachanger/sctest/BUILD.bazel
@@ -23,6 +23,7 @@ go_library(
         "//pkg/sql",
         "//pkg/sql/catalog",
         "//pkg/sql/parser",
+        "//pkg/sql/pgwire/pgcode",
         "//pkg/sql/schemachanger/corpus",
         "//pkg/sql/schemachanger/scbuild",
         "//pkg/sql/schemachanger/scdecomp",


### PR DESCRIPTION
This patch add additional error checking so that we can skip a test if the any of the setup statement is unimplemented. This is useful to skip a mixed version schema changer test when implementing new features which are version gated.

Epic: None

Release note: None