### PR TITLE
schemachanger: Support dropping column with referenced constraints

### DIFF
--- a/pkg/sql/alter_table.go
+++ b/pkg/sql/alter_table.go
@@ -508,6 +508,13 @@ func (n *alterTableNode) startExec(params runParams) error {
 				}
 				return sqlerrors.NewUndefinedConstraintError(string(t.Constraint), n.tableDesc.Name)
 			}
+			if uwoi := c.AsUniqueWithoutIndex(); uwoi != nil {
+				if err := params.p.tryRemoveFKBackReferences(
+					params.ctx, n.tableDesc, uwoi, t.DropBehavior, true,
+				); err != nil {
+					return err
+				}
+			}
 			if err := n.tableDesc.DropConstraint(
 				c,
 				func(backRef catalog.ForeignKeyConstraint) error {

--- a/pkg/sql/logictest/testdata/logic_test/alter_table
+++ b/pkg/sql/logictest/testdata/logic_test/alter_table
@@ -2940,3 +2940,60 @@ ALTER TABLE t_96648 DROP CONSTRAINT check_i, DROP CONSTRAINT check_i1;
 
 statement ok
 DROP TABLE t_96648
+
+# This subtests ensures that dropping unique and unique without index
+# constraints with dependent FKs works properly.
+subtest drop_constraint_with_dependent_FKs_97538
+
+statement ok
+CREATE TABLE t_97538_2 (i INT PRIMARY KEY, j INT);
+
+statement ok
+SET experimental_enable_unique_without_index_constraints = true
+
+statement ok
+ALTER TABLE t_97538_2 ADD UNIQUE WITHOUT INDEX (j);
+
+statement ok
+CREATE UNIQUE INDEX t_97538_2_j_key on t_97538_2(j);
+
+statement ok
+CREATE TABLE t_97538_1 (i INT PRIMARY KEY REFERENCES t_97538_2(j));
+
+statement ok
+DROP INDEX t_97538_2_j_key;
+
+# Ensure that only the unique index is dropped but not the FK
+# because we have replacement (the other unique without index constraint).
+query TTTTB colnames
+SHOW CONSTRAINTS FROM t_97538_1
+----
+table_name  constraint_name   constraint_type  details                                  validated
+t_97538_1   t_97538_1_i_fkey  FOREIGN KEY      FOREIGN KEY (i) REFERENCES t_97538_2(j)  true
+t_97538_1   t_97538_1_pkey    PRIMARY KEY      PRIMARY KEY (i ASC)                      true
+
+# Add back the unique index, and drop the unique without index constraint (without CASCADE) this time.
+statement ok
+CREATE UNIQUE INDEX t_97538_2_j_key on t_97538_2(j);
+
+statement ok
+ALTER TABLE t_97538_2 DROP CONSTRAINT unique_j;
+
+# Similarly, ensure that only the constraint is dropped but not the FK
+# because we have replacement (the other unique index).
+query TTTTB colnames
+SHOW CONSTRAINTS FROM t_97538_1
+----
+table_name  constraint_name   constraint_type  details                                  validated
+t_97538_1   t_97538_1_i_fkey  FOREIGN KEY      FOREIGN KEY (i) REFERENCES t_97538_2(j)  true
+t_97538_1   t_97538_1_pkey    PRIMARY KEY      PRIMARY KEY (i ASC)                      true
+
+statement ok
+DROP INDEX t_97538_2_j_key CASCADE;
+
+# Now ensure that the FK is dropped as a result of the cascade.
+query TTTTB colnames
+SHOW CONSTRAINTS FROM t_97538_1
+----
+table_name  constraint_name  constraint_type  details              validated
+t_97538_1   t_97538_1_pkey   PRIMARY KEY      PRIMARY KEY (i ASC)  true

--- a/pkg/sql/logictest/testdata/logic_test/alter_table
+++ b/pkg/sql/logictest/testdata/logic_test/alter_table
@@ -2997,3 +2997,70 @@ SHOW CONSTRAINTS FROM t_97538_1
 ----
 table_name  constraint_name  constraint_type  details              validated
 t_97538_1   t_97538_1_pkey   PRIMARY KEY      PRIMARY KEY (i ASC)  true
+
+# This subtest ensures that dropping a column that is referenced
+# by constraints works properly.
+subtest drop_column_with_dependent_FKs_96727
+
+statement ok
+CREATE TABLE t_96727_2 (i INT PRIMARY KEY, j INT UNIQUE, FAMILY (i, j));
+
+statement ok
+SET experimental_enable_unique_without_index_constraints = true
+
+statement ok
+ALTER TABLE t_96727_2 ADD UNIQUE WITHOUT INDEX (j);
+
+statement ok
+CREATE TABLE t_96727_1 (i INT PRIMARY KEY REFERENCES t_96727_2(j));
+
+# Here, either the unique index or the unique without index constraint
+# is used for the output of error message is okay, so we used ".*".
+statement error pq: ".*" is referenced by foreign key from table "t_96727_1"
+ALTER TABLE t_96727_2 DROP COLUMN j;
+
+statement ok
+ALTER TABLE t_96727_2 DROP COLUMN j CASCADE;
+
+# Ensure that the unique index, unique without index constraint, as well
+# as the FK constraint are all dropped as a result of dropping the column.
+query TT
+SHOW CREATE TABLE t_96727_2
+----
+t_96727_2  CREATE TABLE public.t_96727_2 (
+             i INT8 NOT NULL,
+             CONSTRAINT t_96727_2_pkey PRIMARY KEY (i ASC),
+             FAMILY fam_0_i_j (i)
+           )
+
+query TT
+SHOW CREATE TABLE t_96727_1
+----
+t_96727_1  CREATE TABLE public.t_96727_1 (
+             i INT8 NOT NULL,
+             CONSTRAINT t_96727_1_pkey PRIMARY KEY (i ASC)
+           )
+
+# More testing when the column is referenced in other constraints.
+statement ok
+ALTER TABLE t_96727_2 ADD COLUMN j INT;
+
+statement ok
+ALTER TABLE t_96727_2 ADD CHECK (j > 0), ADD CHECK (j < 10) NOT VALID, ADD UNIQUE WITHOUT INDEX (j);
+
+statement ok
+CREATE UNIQUE INDEX idx ON t_96727_2(j);
+
+statement ok
+ALTER TABLE t_96727_2 DROP COLUMN j;
+
+# Ensure dropping the column, even without CASCADE, will also
+# drop all the constraints.
+query TT
+SHOW CREATE TABLE t_96727_2
+----
+t_96727_2  CREATE TABLE public.t_96727_2 (
+             i INT8 NOT NULL,
+             CONSTRAINT t_96727_2_pkey PRIMARY KEY (i ASC),
+             FAMILY fam_0_i_j (i)
+           )

--- a/pkg/sql/pgwire/testdata/pgtest/notice
+++ b/pkg/sql/pgwire/testdata/pgtest/notice
@@ -55,7 +55,7 @@ Query {"String": "DROP INDEX t_x_idx"}
 until crdb_only
 CommandComplete
 ----
-{"Severity":"NOTICE","SeverityUnlocalized":"NOTICE","Code":"00000","Message":"the data for dropped indexes is reclaimed asynchronously","Detail":"","Hint":"The reclamation delay can be customized in the zone configuration for the table.","Position":0,"InternalPosition":0,"InternalQuery":"","Where":"","SchemaName":"","TableName":"","ColumnName":"","DataTypeName":"","ConstraintName":"","File":"drop_index.go","Line":65,"Routine":"DropIndex","UnknownFields":null}
+{"Severity":"NOTICE","SeverityUnlocalized":"NOTICE","Code":"00000","Message":"the data for dropped indexes is reclaimed asynchronously","Detail":"","Hint":"The reclamation delay can be customized in the zone configuration for the table.","Position":0,"InternalPosition":0,"InternalQuery":"","Where":"","SchemaName":"","TableName":"","ColumnName":"","DataTypeName":"","ConstraintName":"","File":"drop_index.go","Line":66,"Routine":"DropIndex","UnknownFields":null}
 {"Type":"CommandComplete","CommandTag":"DROP INDEX"}
 
 until noncrdb_only

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_table_validate_constraint.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_table_validate_constraint.go
@@ -80,6 +80,19 @@ func retrieveUniqueWithoutIndexConstraintUnvalidatedElem(
 	return UniqueWithoutIndexConstraintUnvalidatedElem
 }
 
+func retrieveUniqueWithoutIndexConstraintElem(
+	b BuildCtx, tableID catid.DescID, constraintID catid.ConstraintID,
+) (UniqueWithoutIndexConstraintElem *scpb.UniqueWithoutIndexConstraint) {
+	scpb.ForEachUniqueWithoutIndexConstraint(b.QueryByID(tableID), func(
+		current scpb.Status, target scpb.TargetStatus, e *scpb.UniqueWithoutIndexConstraint,
+	) {
+		if e.ConstraintID == constraintID {
+			UniqueWithoutIndexConstraintElem = e
+		}
+	})
+	return UniqueWithoutIndexConstraintElem
+}
+
 func retrieveForeignKeyConstraintUnvalidatedElem(
 	b BuildCtx, tableID catid.DescID, constraintID catid.ConstraintID,
 ) (ForeignKeyConstraintUnvalidatedElem *scpb.ForeignKeyConstraintUnvalidated) {

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/drop_index.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/drop_index.go
@@ -215,53 +215,63 @@ func maybeDropDependentFunctions(
 	})
 }
 
-// maybeDropDependentFKConstraints attempts to drop all FK constraints
-// that depend on the to be dropped index if CASCADE.
-// A FK constraint can only exist if there is `PRIMARY KEY`, `UNIQUE`,
-// or `UNIQUE WITHOUT INDEX` constraint on the referenced columns in the child table.
-// This is relevant if we're dropping a unique index whose `UNIQUE`
-// constraints serves some FK constraints from other tables. In this case,
-// we attempt to find a replacement constraint to serve this FK constraint.
-// If we can, then we can proceed to drop the index. Otherwise, we will need
-// to drop the FK constraint as well (if CASCADE of course).
-// Panic if there is a dependent FK constraint, no replacement is found
-// but drop behavior is not CASCADE.
+// maybeDropDependentFKConstraints attempts to drop all inbound, dependent FK constraints,
+// as a result of dropping a uniqueness-providing constraint.
+//
+// If we find a uniqueness-providing replacement, then we don't drop those FKs.
+// If we don't and `behavior` is not CASCADE, then we panic.
 func maybeDropDependentFKConstraints(
 	b BuildCtx,
-	toBeDroppedIndex *scpb.SecondaryIndex,
-	toBeDroppedIndexName *tree.TableIndexName,
-	dropBehavior tree.DropBehavior,
+	tableID catid.DescID,
+	toBeDroppedConstraintID catid.ConstraintID,
+	toBeDroppedConstraintName string,
+	behavior tree.DropBehavior,
+	canToBeDroppedConstraintServeFK func([]catid.ColumnID) bool,
 ) {
-	scpb.ForEachForeignKeyConstraint(b.BackReferences(toBeDroppedIndex.TableID), func(
-		current scpb.Status, target scpb.TargetStatus, e *scpb.ForeignKeyConstraint,
-	) {
-		if !isIndexUniqueAndCanServeFK(b, &toBeDroppedIndex.Index, e.ReferencedColumnIDs) ||
-			uniqueConstraintHasReplacementCandidate(b, toBeDroppedIndex.TableID,
-				toBeDroppedIndex, e.ReferencedColumnIDs) {
-			return
-		}
+	// shouldDropFK returns true if it is a dependent FK and no uniqueness-providing
+	// replacement can be found.
+	shouldDropFK := func(fkReferencedColIDs []catid.ColumnID) bool {
+		return canToBeDroppedConstraintServeFK(fkReferencedColIDs) &&
+			!hasColsUniquenessConstraintOtherThan(b, tableID, fkReferencedColIDs, toBeDroppedConstraintID)
+	}
 
-		// This foreign key constraint references the table that the
-		// to-be-dropped index belongs, and such a FK constraint is
-		// served by this to-be-dropped index (i.e. the to-be-dropped
-		// index is a unique index that provides a unique constraint on
-		// the FK referenced columns).
-		// We also tried but cannot find a "replacement" index to serve
-		// this dependent FK (i.e. the primary index or another unique
-		// secondary index that also covers the same columns this FK
-		// references), so, we will need to remove the dependent FK
-		// constraint as well.
-		if dropBehavior != tree.DropCascade {
-			_, _, ns := scpb.FindNamespace(b.QueryByID(e.TableID))
-			panic(fmt.Errorf("%q is referenced by foreign key from table %q", toBeDroppedIndexName.Index, ns.Name))
+	// ensureCascadeBehavior panics if behavior is not cascade.
+	ensureCascadeBehavior := func(fkOriginTableID catid.DescID) {
+		if behavior != tree.DropCascade {
+			_, _, fkOriginTableName := scpb.FindNamespace(b.QueryByID(fkOriginTableID))
+			panic(sqlerrors.NewUniqueConstraintReferencedByForeignKeyError(
+				toBeDroppedConstraintName, fkOriginTableName.Name))
 		}
+	}
 
-		b.BackReferences(toBeDroppedIndex.TableID).Filter(hasConstraintIDAttrFilter(e.ConstraintID)).
+	// dropDependentFKConstraint is a helper function that drops a dependent
+	// FK constraint with ID `fkConstraintID`.
+	dropDependentFKConstraint := func(fkConstraintID catid.ConstraintID) {
+		b.BackReferences(tableID).Filter(hasConstraintIDAttrFilter(fkConstraintID)).
 			ForEachElementStatus(func(
 				current scpb.Status, target scpb.TargetStatus, e scpb.Element,
 			) {
 				b.Drop(e)
 			})
+	}
+
+	b.BackReferences(tableID).ForEachElementStatus(func(
+		current scpb.Status, target scpb.TargetStatus, e scpb.Element,
+	) {
+		switch t := e.(type) {
+		case *scpb.ForeignKeyConstraint:
+			if !shouldDropFK(t.ReferencedColumnIDs) {
+				return
+			}
+			ensureCascadeBehavior(t.TableID)
+			dropDependentFKConstraint(t.ConstraintID)
+		case *scpb.ForeignKeyConstraintUnvalidated:
+			if !shouldDropFK(t.ReferencedColumnIDs) {
+				return
+			}
+			ensureCascadeBehavior(t.TableID)
+			dropDependentFKConstraint(t.ConstraintID)
+		}
 	})
 }
 
@@ -473,44 +483,39 @@ func isIndexUniqueAndCanServeFK(
 		allKeyColIDsWithoutShardCol.PermutationOf(fkReferencedColIDs)
 }
 
-// uniqueConstraintHasReplacementCandidate returns true if table ensures
-// uniqueness on columns `referencedColumnIDs` through something other
-// than the unique secondary index `sie`.
+// hasColsUniquenessConstraintOtherThan returns true if the table ensures
+// uniqueness on `columnIDs` through a constraint other than `otherThan`.
+// Uniqueness can be ensured through PK, UNIQUE, or UNIQUE WITHOUT INDEX.
 //
-// Uniqueness can be ensured through a unique primary index,
-// a unique secondary index, or a unique without index constraint.
-func uniqueConstraintHasReplacementCandidate(
-	b BuildCtx, tableID descpb.ID, sie *scpb.SecondaryIndex, referencedColumnIDs []descpb.ColumnID,
-) bool {
-	result := false
-
-	// Check all indexes (both primary and secondary) to see if we can find a replacement candidate.
-	// Also check all unique_without_indexes to see if we can find a replace
-	b.QueryByID(tableID).ForEachElementStatus(func(
-		current scpb.Status, target scpb.TargetStatus, e scpb.Element,
-	) {
-		if result {
-			return
-		}
-
-		switch t := e.(type) {
-		case *scpb.SecondaryIndex:
-			if t.IndexID != sie.IndexID && isIndexUniqueAndCanServeFK(b, &t.Index, referencedColumnIDs) {
-				result = true
+// This function can be used to determine, e.g., whether a certain
+// uniqueness-providing constraint has a replacement when we want to drop it;
+// If yes, we don't need to drop any dependent inbound FKs if not cascade.
+func hasColsUniquenessConstraintOtherThan(
+	b BuildCtx, tableID descpb.ID, columnIDs []descpb.ColumnID, otherThan descpb.ConstraintID,
+) (ret bool) {
+	b.QueryByID(tableID).Filter(publicTargetFilter).Filter(statusPublicFilter).
+		ForEachElementStatus(func(
+			current scpb.Status, target scpb.TargetStatus, e scpb.Element,
+		) {
+			if ret {
+				return
 			}
-		case *scpb.PrimaryIndex:
-			if isIndexUniqueAndCanServeFK(b, &t.Index, referencedColumnIDs) {
-				result = true
+			switch t := e.(type) {
+			case *scpb.PrimaryIndex:
+				if t.ConstraintID != otherThan && isIndexUniqueAndCanServeFK(b, &t.Index, columnIDs) {
+					ret = true
+				}
+			case *scpb.SecondaryIndex:
+				if t.ConstraintID != otherThan && isIndexUniqueAndCanServeFK(b, &t.Index, columnIDs) {
+					ret = true
+				}
+			case *scpb.UniqueWithoutIndexConstraint:
+				if t.ConstraintID != otherThan && descpb.ColumnIDs(t.ColumnIDs).PermutationOf(columnIDs) {
+					ret = true
+				}
 			}
-		case *scpb.UniqueWithoutIndexConstraint:
-			if descpb.ColumnIDs(t.ColumnIDs).PermutationOf(referencedColumnIDs) {
-				result = true
-			}
-
-		}
-	})
-
-	return result
+		})
+	return ret
 }
 
 func isExpressionIndexColumn(b BuildCtx, ce *scpb.Column) bool {

--- a/pkg/sql/schemachanger/scbuild/testdata/unimplemented_alter_table
+++ b/pkg/sql/schemachanger/scbuild/testdata/unimplemented_alter_table
@@ -21,22 +21,6 @@ ALTER TABLE defaultdb.foo ALTER COLUMN i SET DATA TYPE STRING
 ----
 
 unimplemented
-ALTER TABLE defaultdb.foo DROP COLUMN k
-----
-
-unimplemented
-ALTER TABLE defaultdb.foo DROP COLUMN l CASCADE;
-----
-
-unimplemented
-ALTER TABLE defaultdb.foo DROP COLUMN m
-----
-
-unimplemented
-ALTER TABLE defaultdb.foo DROP COLUMN n
-----
-
-unimplemented
 ALTER TABLE defaultdb.foo DROP COLUMN o, ADD COLUMN p INT
 ----
 

--- a/pkg/sql/schemachanger/scplan/internal/rules/current/dep_drop_column.go
+++ b/pkg/sql/schemachanger/scplan/internal/rules/current/dep_drop_column.go
@@ -116,7 +116,7 @@ func init() {
 		scpb.Status_ABSENT, scpb.Status_DELETE_ONLY,
 		func(from, to NodeVars) rel.Clauses {
 			return rel.Clauses{
-				from.Type((*scpb.ColumnNotNull)(nil)),
+				from.TypeFilter(rulesVersionKey, isNonIndexBackedConstraint, isSubjectTo2VersionInvariant),
 				to.Type((*scpb.Column)(nil)),
 				JoinOnColumnID(from, to, "table-id", "col-id"),
 			}

--- a/pkg/sql/schemachanger/scplan/internal/rules/current/testdata/deprules
+++ b/pkg/sql/schemachanger/scplan/internal/rules/current/testdata/deprules
@@ -1547,7 +1547,7 @@ deprules
   kind: SameStagePrecedence
   to: column-Node
   query:
-    - $column-constraint[Type] = '*scpb.ColumnNotNull'
+    - $column-constraint[Type] IN ['*scpb.UniqueWithoutIndexConstraint', '*scpb.CheckConstraint', '*scpb.ForeignKeyConstraint', '*scpb.ColumnNotNull']
     - $column[Type] = '*scpb.Column'
     - joinOnColumnID($column-constraint, $column, $table-id, $col-id)
     - toAbsent($column-constraint-Target, $column-Target)
@@ -1560,7 +1560,7 @@ deprules
   kind: SameStagePrecedence
   to: column-Node
   query:
-    - $column-constraint[Type] = '*scpb.ColumnNotNull'
+    - $column-constraint[Type] IN ['*scpb.UniqueWithoutIndexConstraint', '*scpb.CheckConstraint', '*scpb.ForeignKeyConstraint', '*scpb.ColumnNotNull']
     - $column[Type] = '*scpb.Column'
     - joinOnColumnID($column-constraint, $column, $table-id, $col-id)
     - transient($column-constraint-Target, $column-Target)
@@ -1573,7 +1573,7 @@ deprules
   kind: SameStagePrecedence
   to: column-Node
   query:
-    - $column-constraint[Type] = '*scpb.ColumnNotNull'
+    - $column-constraint[Type] IN ['*scpb.UniqueWithoutIndexConstraint', '*scpb.CheckConstraint', '*scpb.ForeignKeyConstraint', '*scpb.ColumnNotNull']
     - $column[Type] = '*scpb.Column'
     - joinOnColumnID($column-constraint, $column, $table-id, $col-id)
     - $column-constraint-Target[TargetStatus] = TRANSIENT_ABSENT
@@ -1587,7 +1587,7 @@ deprules
   kind: SameStagePrecedence
   to: column-Node
   query:
-    - $column-constraint[Type] = '*scpb.ColumnNotNull'
+    - $column-constraint[Type] IN ['*scpb.UniqueWithoutIndexConstraint', '*scpb.CheckConstraint', '*scpb.ForeignKeyConstraint', '*scpb.ColumnNotNull']
     - $column[Type] = '*scpb.Column'
     - joinOnColumnID($column-constraint, $column, $table-id, $col-id)
     - $column-constraint-Target[TargetStatus] = ABSENT
@@ -4895,7 +4895,7 @@ deprules
   kind: SameStagePrecedence
   to: column-Node
   query:
-    - $column-constraint[Type] = '*scpb.ColumnNotNull'
+    - $column-constraint[Type] IN ['*scpb.UniqueWithoutIndexConstraint', '*scpb.CheckConstraint', '*scpb.ForeignKeyConstraint', '*scpb.ColumnNotNull']
     - $column[Type] = '*scpb.Column'
     - joinOnColumnID($column-constraint, $column, $table-id, $col-id)
     - toAbsent($column-constraint-Target, $column-Target)
@@ -4908,7 +4908,7 @@ deprules
   kind: SameStagePrecedence
   to: column-Node
   query:
-    - $column-constraint[Type] = '*scpb.ColumnNotNull'
+    - $column-constraint[Type] IN ['*scpb.UniqueWithoutIndexConstraint', '*scpb.CheckConstraint', '*scpb.ForeignKeyConstraint', '*scpb.ColumnNotNull']
     - $column[Type] = '*scpb.Column'
     - joinOnColumnID($column-constraint, $column, $table-id, $col-id)
     - transient($column-constraint-Target, $column-Target)
@@ -4921,7 +4921,7 @@ deprules
   kind: SameStagePrecedence
   to: column-Node
   query:
-    - $column-constraint[Type] = '*scpb.ColumnNotNull'
+    - $column-constraint[Type] IN ['*scpb.UniqueWithoutIndexConstraint', '*scpb.CheckConstraint', '*scpb.ForeignKeyConstraint', '*scpb.ColumnNotNull']
     - $column[Type] = '*scpb.Column'
     - joinOnColumnID($column-constraint, $column, $table-id, $col-id)
     - $column-constraint-Target[TargetStatus] = TRANSIENT_ABSENT
@@ -4935,7 +4935,7 @@ deprules
   kind: SameStagePrecedence
   to: column-Node
   query:
-    - $column-constraint[Type] = '*scpb.ColumnNotNull'
+    - $column-constraint[Type] IN ['*scpb.UniqueWithoutIndexConstraint', '*scpb.CheckConstraint', '*scpb.ForeignKeyConstraint', '*scpb.ColumnNotNull']
     - $column[Type] = '*scpb.Column'
     - joinOnColumnID($column-constraint, $column, $table-id, $col-id)
     - $column-constraint-Target[TargetStatus] = ABSENT


### PR DESCRIPTION
This PR enables dropping columns with referenced constraints in the declarative schema changer.

As a prerequisite step, we also added support to dropping a UWI constraint when there is a dependent
FK constraint in both the legacy and declarative schema changer (commit 2).

Commit 2 Fixes: #96787, Fixes: #97538
Commit 3 Fixes: #96727

Epic: None