### PR TITLE
roachtest: always use active node in backup schedule injection

### DIFF
--- a/pkg/cmd/roachtest/tests/multitenant_upgrade.go
+++ b/pkg/cmd/roachtest/tests/multitenant_upgrade.go
@@ -130,7 +130,9 @@ func runMultiTenantUpgrade(ctx context.Context, t test.Test, c cluster.Cluster, 
 	t.Status("upgrading system tenant binary")
 	c.Stop(ctx, t.L(), option.DefaultStopOpts(), kvNodes)
 	settings.Binary = currentBinary
-	c.Start(ctx, t.L(), option.DefaultStartOpts(), settings, kvNodes)
+	// TODO (msbutler): investigate why the scheduled backup command fails due to a `Is the Server
+	// running?` error.
+	c.Start(ctx, t.L(), option.DefaultStartOptsNoBackups(), settings, kvNodes)
 	time.Sleep(time.Second)
 
 	t.Status("checking the pre-upgrade sql server still works after the system tenant binary upgrade")


### PR DESCRIPTION
Previously, the schedule backup cmd injection on Start() would always run on the first node on the cluster, but if that node were not available, the cmd would fail. This patch ensures the injection runs on a node that was just started.

Fixes #97558, #97582, #97548, https://github.com/cockroachdb/cockroach/issues/97562 #97565 #97561

Release note: None