### PR TITLE
sql: add metrics for prepared statement memory usage

### DIFF
--- a/pkg/sql/conn_executor_prepare.go
+++ b/pkg/sql/conn_executor_prepare.go
@@ -157,7 +157,7 @@ func (ex *connExecutor) prepare(
 ) (_ *PreparedStatement, retErr error) {
 
 	prepared := &PreparedStatement{
-		memAcc:   ex.sessionMon.MakeBoundAccount(),
+		memAcc:   ex.sessionPreparedMon.MakeBoundAccount(),
 		refCount: 1,
 
 		createdAt: timeutil.Now(),

--- a/pkg/ts/catalog/chart_catalog.go
+++ b/pkg/ts/catalog/chart_catalog.go
@@ -2543,6 +2543,14 @@ var charts = []sectionDescription{
 				Metrics: []string{"sql.mem.internal.session.current"},
 			},
 			{
+				Title:   "Prepared Statements All",
+				Metrics: []string{"sql.mem.internal.session.prepared.max"},
+			},
+			{
+				Title:   "Prepared Statements Current",
+				Metrics: []string{"sql.mem.internal.session.prepared.current"},
+			},
+			{
 				Title:   "Txn All",
 				Metrics: []string{"sql.mem.internal.txn.max"},
 			},
@@ -2562,6 +2570,14 @@ var charts = []sectionDescription{
 			{
 				Title:   "Max",
 				Metrics: []string{"sql.mem.sql.session.max"},
+			},
+			{
+				Title:   "Prepared Statements Current",
+				Metrics: []string{"sql.mem.sql.session.prepared.current"},
+			},
+			{
+				Title:   "Prepared Statements Max",
+				Metrics: []string{"sql.mem.sql.session.prepared.max"},
 			},
 		},
 	},


### PR DESCRIPTION
Add node-level metrics for memory used by prepared statements across all sessions.

Assists: #72581

Epic: None

Release note (ui change): Add the following new metrics to track memory usage of prepared statements in sessions:
- sql.mem.internal.session.prepared.current
- sql.mem.internal.session.prepared.max-avg
- sql.mem.internal.session.prepared.max-count
- sql.mem.internal.session.prepared.max-max
- sql.mem.internal.session.prepared.max-p50
- sql.mem.internal.session.prepared.max-p75
- sql.mem.internal.session.prepared.max-p90
- sql.mem.internal.session.prepared.max-p99
- sql.mem.internal.session.prepared.max-p99.9
- sql.mem.internal.session.prepared.max-p99.99
- sql.mem.internal.session.prepared.max-p99.999
- sql.mem.sql.session.prepared.current
- sql.mem.sql.session.prepared.max-avg
- sql.mem.sql.session.prepared.max-count
- sql.mem.sql.session.prepared.max-max
- sql.mem.sql.session.prepared.max-p50
- sql.mem.sql.session.prepared.max-p75
- sql.mem.sql.session.prepared.max-p90
- sql.mem.sql.session.prepared.max-p99
- sql.mem.sql.session.prepared.max-p99.9
- sql.mem.sql.session.prepared.max-p99.99
- sql.mem.sql.session.prepared.max-p99.999