### PR TITLE
colexec: always copy eval context in some places

### DIFF
--- a/pkg/sql/colexec/columnarizer.go
+++ b/pkg/sql/colexec/columnarizer.go
@@ -155,12 +155,9 @@ func newColumnarizer(
 	c.ProcessorBaseNoHelper.Init(
 		nil, /* self */
 		flowCtx,
-		// Similar to the materializer, the columnarizer will update the eval
-		// context when closed, so we give it a copy of the eval context to
-		// preserve the "global" eval context from being mutated. In practice,
-		// the columnarizer is closed only when DrainMeta() is called which
-		// occurs at the very end of the execution, yet we choose to be
-		// defensive here.
+		// The columnarizer will update the eval context when closed, so we give
+		// it a copy of the eval context to preserve the "global" eval context
+		// from being mutated.
 		flowCtx.NewEvalCtx(),
 		processorID,
 		nil, /* output */

--- a/pkg/sql/colflow/flow_coordinator.go
+++ b/pkg/sql/colflow/flow_coordinator.go
@@ -68,9 +68,10 @@ func NewFlowCoordinator(
 	f.Init(
 		f,
 		flowCtx,
-		// FlowCoordinator doesn't modify the eval context, so it is safe to
-		// reuse the one from the flow context.
-		flowCtx.EvalCtx,
+		// The FlowCoordinator will update the eval context when closed, so we
+		// give it a copy of the eval context to preserve the "global" eval
+		// context from being mutated.
+		flowCtx.NewEvalCtx(),
 		processorID,
 		output,
 		execinfra.ProcStateOpts{

--- a/pkg/sql/colflow/vectorized_flow.go
+++ b/pkg/sql/colflow/vectorized_flow.go
@@ -1080,7 +1080,7 @@ func (s *vectorizedFlowCreator) setupOutput(
 			// We need to use the row receiving output.
 			if input == nil {
 				// We couldn't remove the columnarizer.
-				input = colexec.NewMaterializerNoEvalCtxCopy(
+				input = colexec.NewMaterializer(
 					colmem.NewAllocator(ctx, s.monitorRegistry.NewStreamingMemAccount(flowCtx), factory),
 					flowCtx,
 					pspec.ProcessorID,

--- a/pkg/sql/execinfra/flow_context.go
+++ b/pkg/sql/execinfra/flow_context.go
@@ -114,6 +114,9 @@ type FlowCtx struct {
 // EvalContext, since it stores that EvalContext in its exprHelpers and mutates
 // them at runtime to ensure expressions are evaluated with the correct indexed
 // var context.
+// TODO(yuzefovich): once we remove eval.Context.deprecatedContext, re-evaluate
+// this since many processors don't modify the eval context except for that
+// field.
 func (flowCtx *FlowCtx) NewEvalCtx() *eval.Context {
 	evalCopy := flowCtx.EvalCtx.Copy()
 	return evalCopy


### PR DESCRIPTION
This commit makes it so that we always create a copy of the eval context in the materializer and the flow coordinator. This copy is needed since in `ProcessorBaseNoHelper.InternalClose` the eval context is mutated. Previously, we were assuming that the root components can avoid this, but this can lead to data races. In particular, the flow coordinator might be closed before a concurrent goroutine (for example, that was spun up for the virtual table generator) is done. This data race can occur on the deprecated context which ideally we'd remove altogether from the eval context, but we're not there yet, so for now we just avoid the data race.

Previous fix of a similar issue is in #73660, but that PR missed the fact that when closing the root, the concurrent goroutines might still be running.

Fixes: #94407.

Release note: None