### PR TITLE
testutils,grpcutil: fixing comments

### DIFF
--- a/pkg/util/grpcutil/grpc_util.go
+++ b/pkg/util/grpcutil/grpc_util.go
@@ -62,8 +62,10 @@ func IsTimeout(err error) bool {
 	return false
 }
 
-// IsConnectionUnavailable checks if grpc code is codes.Unavailable which is
-// set when we are not able to establish connection to remote node.
+// IsConnectionUnavailable checks if grpc code is either codes.Unavailable which
+// is set when we are not able to establish connection to remote node or
+// codes.FailedPrecondition when node itself blocked access to remote node
+// because it is marked as decommissioned in the local tombstone storage.
 func IsConnectionUnavailable(err error) bool {
 	if s, ok := status.FromError(errors.UnwrapAll(err)); ok {
 		return s.Code() == codes.Unavailable || s.Code() == codes.FailedPrecondition


### PR DESCRIPTION
This is follow up PR to loss of quorum recovery changes and it adds clarifying comments to the methods.
There are no functional changes.

Release note: None