### PR TITLE
kvserver: add TestSeparateRaftLog

### DIFF
--- a/pkg/base/store_spec.go
+++ b/pkg/base/store_spec.go
@@ -273,6 +273,11 @@ type StoreSpec struct {
 	EncryptionOptions []byte
 	// ProvisionedRateSpec is optional.
 	ProvisionedRateSpec ProvisionedRateSpec
+	// ExperimentalSeparateRaftLogPath, if set, enables a split between the state
+	// and log engines: two engines will be created for this store. This is highly
+	// experimental and not for production use. Data loss and inconsistencies are
+	// likely.
+	ExperimentalSeparateRaftLogPath string
 }
 
 // String returns a fully parsable version of the store spec.

--- a/pkg/kv/kvserver/BUILD.bazel
+++ b/pkg/kv/kvserver/BUILD.bazel
@@ -248,6 +248,7 @@ go_test(
         "client_replica_gc_test.go",
         "client_replica_raft_overload_test.go",
         "client_replica_test.go",
+        "client_separate_raft_log_test.go",
         "client_spanconfigs_test.go",
         "client_split_burst_test.go",
         "client_split_test.go",

--- a/pkg/kv/kvserver/client_merge_test.go
+++ b/pkg/kv/kvserver/client_merge_test.go
@@ -5351,7 +5351,7 @@ func TestStoreMergeGCHint(t *testing.T) {
 				require.Greater(t, gcHint.LatestRangeDeleteTimestamp.WallTime, beforeSecondDel,
 					"highest timestamp wasn't picked up")
 			}
-			repl.AssertState(ctx, store.TODOEngine())
+			repl.AssertState(ctx)
 		})
 	}
 }

--- a/pkg/kv/kvserver/client_separate_raft_log_test.go
+++ b/pkg/kv/kvserver/client_separate_raft_log_test.go
@@ -1,0 +1,80 @@
+// Copyright 2023 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package kvserver_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver"
+	"github.com/cockroachdb/cockroach/pkg/testutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
+	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/stretchr/testify/require"
+)
+
+// TestSeparateRaftLog is a very basic test for the separate raft log.
+// It sets up a three node cluster with two stores each (each store with
+// a separate raft log), and waits for rebalancing. This requires both
+// raft handling, distributed txns, and snapshot application, so it's
+// a reasonably good sanity check.
+func TestSeparateRaftLog(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	ctx := context.Background()
+
+	skip.IgnoreLint(t, "TODO(this PR): unskip in last commit")
+
+	// Six stores, each of which with a separate log engine, makes twelve pebble
+	// instances - likely too heavyweight for stressing.
+	skip.UnderStress(t, "not a useful test to stress")
+
+	const numNodes = 3
+
+	testutils.RunTrueAndFalse(t, "mem", func(t *testing.T, inMem bool) {
+		if !inMem {
+			// The test is very slow with real disks, at least on OSX.
+			// Six disks + rebalancing = lots of fsyncs. But the code
+			// in CreateEngines for the disk path is very different
+			// so it makes sense to be able to run it manually at least.
+			skip.IgnoreLint(t, "only for manual testing")
+		}
+		var args base.TestClusterArgs
+		// Two in-mem stores per node, with sep raft log enabled.
+		args.ServerArgsPerNode = map[int]base.TestServerArgs{}
+		for i := 0; i < numNodes; i++ {
+			var serverArgs base.TestServerArgs
+			for j := 0; j < 2; j++ {
+				spec := base.DefaultTestStoreSpec
+				spec.InMemory = inMem
+				spec.ExperimentalSeparateRaftLogPath = "mem"
+				if !inMem {
+					spec.Path = t.TempDir()
+					spec.ExperimentalSeparateRaftLogPath = t.TempDir()
+				}
+				serverArgs.StoreSpecs = append(serverArgs.StoreSpecs, spec)
+			}
+			args.ServerArgsPerNode[i] = serverArgs
+		}
+		tc := testcluster.StartTestCluster(t, numNodes, args)
+		defer tc.Stopper().Stop(ctx)
+
+		for _, srv := range tc.Servers {
+			require.NoError(t, srv.GetStores().(*kvserver.Stores).VisitStores(func(s *kvserver.Store) error {
+				require.True(t, s.StateEngine() != s.LogEngine())
+				return nil
+			}))
+		}
+	})
+}

--- a/pkg/kv/kvserver/client_separate_raft_log_test.go
+++ b/pkg/kv/kvserver/client_separate_raft_log_test.go
@@ -34,8 +34,6 @@ func TestSeparateRaftLog(t *testing.T) {
 	defer log.Scope(t).Close(t)
 	ctx := context.Background()
 
-	skip.IgnoreLint(t, "TODO(this PR): unskip in last commit")
-
 	// Six stores, each of which with a separate log engine, makes twelve pebble
 	// instances - likely too heavyweight for stressing.
 	skip.UnderStress(t, "not a useful test to stress")

--- a/pkg/kv/kvserver/client_split_test.go
+++ b/pkg/kv/kvserver/client_split_test.go
@@ -1954,7 +1954,7 @@ func TestStoreSplitGCThreshold(t *testing.T) {
 		t.Fatalf("expected RHS's GCThreshold is equal to %v, but got %v", specifiedGCThreshold, gcThreshold)
 	}
 
-	repl.AssertState(ctx, store.TODOEngine())
+	repl.AssertState(ctx)
 }
 
 func TestStoreSplitGCHint(t *testing.T) {
@@ -2016,7 +2016,7 @@ func TestStoreSplitGCHint(t *testing.T) {
 	gcHint = repl.GetGCHint()
 	require.False(t, gcHint.IsEmpty(), "GC hint is empty after range delete")
 
-	repl.AssertState(ctx, store.TODOEngine())
+	repl.AssertState(ctx)
 }
 
 // TestStoreRangeSplitRaceUninitializedRHS reproduces #7600 (before it was

--- a/pkg/kv/kvserver/helpers_test.go
+++ b/pkg/kv/kvserver/helpers_test.go
@@ -240,12 +240,12 @@ func (r *Replica) Breaker() *circuit2.Breaker {
 	return r.breaker.wrapped
 }
 
-func (r *Replica) AssertState(ctx context.Context, reader storage.Reader) {
+func (r *Replica) AssertState(ctx context.Context) {
 	r.raftMu.Lock()
 	defer r.raftMu.Unlock()
 	r.mu.RLock()
 	defer r.mu.RUnlock()
-	r.assertStateRaftMuLockedReplicaMuRLocked(ctx, reader)
+	r.assertStateRaftMuLockedReplicaMuRLocked(ctx)
 }
 
 func (r *Replica) RaftLock() {

--- a/pkg/kv/kvserver/kvserverpb/state.proto
+++ b/pkg/kv/kvserver/kvserverpb/state.proto
@@ -53,6 +53,10 @@ message ReplicaState {
   // as part of ReplicatedEvalResult.
   roachpb.Lease lease = 4;
   // The truncation state of the Raft log.
+  //
+  // TODO(sep-raft-log): the truncated state is no longer cleanly a part of the
+  // replicated state and so it should not be in this proto. Tracked in:
+  // https://github.com/cockroachdb/cockroach/issues/97613
   roachpb.RaftTruncatedState truncated_state = 5;
   // GCThreshold is the GC threshold of the Range, typically updated when keys
   // are garbage collected. Reads and writes at timestamps <= this time will

--- a/pkg/kv/kvserver/kvstorage/init.go
+++ b/pkg/kv/kvserver/kvstorage/init.go
@@ -314,7 +314,7 @@ func (r Replica) ID() storage.FullReplicaID {
 
 // Load loads the state necessary to instantiate a replica in memory.
 func (r Replica) Load(
-	ctx context.Context, eng storage.Reader, storeID roachpb.StoreID,
+	ctx context.Context, eng, logEng storage.Reader, storeID roachpb.StoreID,
 ) (LoadedReplicaState, error) {
 	ls := LoadedReplicaState{
 		ReplicaID: r.ReplicaID,
@@ -322,7 +322,7 @@ func (r Replica) Load(
 	}
 	sl := stateloader.Make(r.Desc.RangeID)
 	var err error
-	if ls.LastIndex, err = sl.LoadLastIndex(ctx, eng); err != nil {
+	if ls.LastIndex, err = sl.LoadLastIndex(ctx, logEng); err != nil {
 		return LoadedReplicaState{}, err
 	}
 	if ls.ReplState, err = sl.Load(ctx, eng, r.Desc); err != nil {

--- a/pkg/kv/kvserver/mvcc_gc_queue_test.go
+++ b/pkg/kv/kvserver/mvcc_gc_queue_test.go
@@ -1220,11 +1220,9 @@ func TestMVCCGCQueueTransactionTable(t *testing.T) {
 			"but only %d are left", exp, count)
 	}
 
-	batch := tc.engine.NewSnapshot()
-	defer batch.Close()
 	tc.repl.raftMu.Lock()
 	tc.repl.mu.RLock()
-	tc.repl.assertStateRaftMuLockedReplicaMuRLocked(ctx, batch) // check that in-mem and on-disk state were updated
+	tc.repl.assertStateRaftMuLockedReplicaMuRLocked(ctx) // check that in-mem and on-disk state were updated
 	tc.repl.mu.RUnlock()
 	tc.repl.raftMu.Unlock()
 }

--- a/pkg/kv/kvserver/replica.go
+++ b/pkg/kv/kvserver/replica.go
@@ -1498,10 +1498,8 @@ func (r *Replica) State(ctx context.Context) kvserverpb.RangeInfo {
 // assertStateRaftMuLockedReplicaMuRLocked can be called from the Raft goroutine
 // to check that the in-memory and on-disk states of the Replica are congruent.
 // Requires that r.raftMu is locked and r.mu is read locked.
-func (r *Replica) assertStateRaftMuLockedReplicaMuRLocked(
-	ctx context.Context, reader storage.Reader,
-) {
-	diskState, err := r.mu.stateLoader.Load(ctx, reader, r.mu.state.Desc)
+func (r *Replica) assertStateRaftMuLockedReplicaMuRLocked(ctx context.Context) {
+	diskState, err := r.mu.stateLoader.Load(ctx, r.store.StateEngine(), r.mu.state.Desc)
 	if err != nil {
 		log.Fatalf(ctx, "%v", err)
 	}
@@ -1557,7 +1555,7 @@ func (r *Replica) assertStateRaftMuLockedReplicaMuRLocked(
 			log.Fatalf(ctx, "replica's replicaID %d diverges from descriptor %+v", r.replicaID, r.mu.state.Desc)
 		}
 	}
-	diskReplID, err := r.mu.stateLoader.LoadRaftReplicaID(ctx, reader)
+	diskReplID, err := r.mu.stateLoader.LoadRaftReplicaID(ctx, r.store.LogEngine())
 	if err != nil {
 		log.Fatalf(ctx, "%s", err)
 	}

--- a/pkg/kv/kvserver/replica_application_state_machine.go
+++ b/pkg/kv/kvserver/replica_application_state_machine.go
@@ -221,7 +221,7 @@ func (sm *replicaStateMachine) ApplySideEffects(
 			sm.r.mu.RLock()
 			// TODO(sep-raft-log): either check only statemachine invariants or
 			// pass both engines in.
-			sm.r.assertStateRaftMuLockedReplicaMuRLocked(ctx, sm.r.store.TODOEngine())
+			sm.r.assertStateRaftMuLockedReplicaMuRLocked(ctx)
 			sm.r.mu.RUnlock()
 			sm.applyStats.stateAssertions++
 		}

--- a/pkg/kv/kvserver/replica_init.go
+++ b/pkg/kv/kvserver/replica_init.go
@@ -143,9 +143,9 @@ func newUninitializedReplica(
 	r.raftMu.sideloaded = logstore.NewDiskSideloadStorage(
 		store.cfg.Settings,
 		rangeID,
-		store.TODOEngine().GetAuxiliaryDir(),
+		store.LogEngine().GetAuxiliaryDir(),
 		store.limiters.BulkIOWriteRate,
-		store.TODOEngine(),
+		store.LogEngine(),
 	)
 
 	r.splitQueueThrottle = util.Every(splitQueueThrottleDuration)

--- a/pkg/kv/kvserver/replica_raft.go
+++ b/pkg/kv/kvserver/replica_raft.go
@@ -956,7 +956,7 @@ func (r *Replica) handleRaftReadyRaftMuLocked(
 			// ranges, so can be passed to LogStore methods instead of being stored in it.
 			s := logstore.LogStore{
 				RangeID:     r.RangeID,
-				Engine:      r.store.TODOEngine(),
+				Engine:      r.store.LogEngine(),
 				Sideload:    r.raftMu.sideloaded,
 				StateLoader: r.raftMu.stateLoader.StateLoader,
 				SyncWaiter:  r.store.syncWaiter,

--- a/pkg/kv/kvserver/replica_raftstorage.go
+++ b/pkg/kv/kvserver/replica_raftstorage.go
@@ -678,7 +678,7 @@ func (r *Replica) applySnapshot(
 	// operation can be expensive. This is safe, as we hold the Replica.raftMu
 	// across both Replica.mu critical sections.
 	r.mu.RLock()
-	r.assertStateRaftMuLockedReplicaMuRLocked(ctx, r.store.TODOEngine())
+	r.assertStateRaftMuLockedReplicaMuRLocked(ctx)
 	r.mu.RUnlock()
 
 	// The rangefeed processor is listening for the logical ops attached to

--- a/pkg/kv/kvserver/replica_raftstorage.go
+++ b/pkg/kv/kvserver/replica_raftstorage.go
@@ -31,7 +31,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 	"github.com/cockroachdb/errors"
-	"github.com/cockroachdb/pebble"
 	"github.com/cockroachdb/redact"
 	"go.etcd.io/raft/v3"
 	"go.etcd.io/raft/v3/raftpb"
@@ -545,12 +544,12 @@ func (r *Replica) applySnapshot(
 			return err
 		}
 	}
-	var ingestStats pebble.IngestOperationStats
-	if ingestStats, err =
-		// TODO: separate ingestions for log and statemachine engine. See:
-		//
-		// https://github.com/cockroachdb/cockroach/issues/93251
-		r.store.TODOEngine().IngestExternalFilesWithStats(ctx, inSnap.SSTStorageScratch.SSTs()); err != nil {
+
+	// TODO: separate ingestions for log and statemachine engine. See:
+	//
+	// https://github.com/cockroachdb/cockroach/issues/93251
+	ingestStats, err := r.store.TODOEngine().IngestExternalFilesWithStats(ctx, inSnap.SSTStorageScratch.SSTs())
+	if err != nil {
 		return errors.Wrapf(err, "while ingesting %s", inSnap.SSTStorageScratch.SSTs())
 	}
 	if r.store.cfg.KVAdmissionController != nil {

--- a/pkg/kv/kvserver/replica_raftstorage.go
+++ b/pkg/kv/kvserver/replica_raftstorage.go
@@ -62,7 +62,7 @@ var _ raft.Storage = (*replicaRaftStorage)(nil)
 // exclusive access to r.mu.stateLoader.
 func (r *replicaRaftStorage) InitialState() (raftpb.HardState, raftpb.ConfState, error) {
 	ctx := r.AnnotateCtx(context.TODO())
-	hs, err := r.mu.stateLoader.LoadHardState(ctx, r.store.TODOEngine())
+	hs, err := r.mu.stateLoader.LoadHardState(ctx, r.store.LogEngine())
 	// For uninitialized ranges, membership is unknown at this point.
 	if raft.IsEmptyHardState(hs) || err != nil {
 		return raftpb.HardState{}, raftpb.ConfState{}, err
@@ -82,7 +82,7 @@ func (r *replicaRaftStorage) Entries(lo, hi, maxBytes uint64) ([]raftpb.Entry, e
 	if r.raftMu.sideloaded == nil {
 		return nil, errors.New("sideloaded storage is uninitialized")
 	}
-	return logstore.LoadEntries(ctx, r.raftMu.stateLoader.StateLoader, r.store.TODOEngine(), r.RangeID,
+	return logstore.LoadEntries(ctx, r.raftMu.stateLoader.StateLoader, r.store.LogEngine(), r.RangeID,
 		r.store.raftEntryCache, r.raftMu.sideloaded, lo, hi, maxBytes)
 }
 
@@ -101,7 +101,7 @@ func (r *replicaRaftStorage) Term(i uint64) (uint64, error) {
 		return r.mu.lastTermNotDurable, nil
 	}
 	ctx := r.AnnotateCtx(context.TODO())
-	return logstore.LoadTerm(ctx, r.mu.stateLoader.StateLoader, r.store.TODOEngine(), r.RangeID,
+	return logstore.LoadTerm(ctx, r.mu.stateLoader.StateLoader, r.store.LogEngine(), r.RangeID,
 		r.store.raftEntryCache, i)
 }
 

--- a/pkg/kv/kvserver/replica_raftstorage.go
+++ b/pkg/kv/kvserver/replica_raftstorage.go
@@ -489,21 +489,16 @@ func (r *Replica) applySnapshot(
 		log.Infof(ctx, "applied %s (%s)", inSnap, logDetails)
 	}(timeutil.Now())
 
-	unreplicatedSSTFile, nonempty, err := writeUnreplicatedSST(
+	unreplicatedSSTFile, err := writeUnreplicatedSST(
 		ctx, r.ID(), r.ClusterSettings(), nonemptySnap.Metadata, hs, &r.raftMu.stateLoader.StateLoader,
 	)
 	if err != nil {
 		return err
 	}
-	if !nonempty {
-		log.Fatalf(ctx, "unreplicated SST was empty")
-	}
-	if nonempty {
-		// TODO(itsbilal): Write to SST directly in unreplicatedSST rather than
-		// buffering in a MemObject first.
-		if err := inSnap.SSTStorageScratch.WriteSST(ctx, unreplicatedSSTFile.Data()); err != nil {
-			return err
-		}
+	// TODO(itsbilal): Write to SST directly in unreplicatedSST rather than
+	// buffering in a MemObject first.
+	if err := inSnap.SSTStorageScratch.WriteSST(ctx, unreplicatedSSTFile.Data()); err != nil {
+		return err
 	}
 	// Update Raft entries.
 	r.store.raftEntryCache.Drop(r.RangeID)
@@ -708,9 +703,6 @@ func (r *Replica) applySnapshot(
 // covers the RangeID-unreplicated keyspace. A range tombstone is
 // laid down and the Raft state provided by the arguments is overlaid
 // onto it.
-//
-// TODO(sep-raft-log): when is `nonempty` ever false? We always
-// perform a number of writes to this SST.
 func writeUnreplicatedSST(
 	ctx context.Context,
 	id storage.FullReplicaID,
@@ -718,7 +710,7 @@ func writeUnreplicatedSST(
 	meta raftpb.SnapshotMetadata,
 	hs raftpb.HardState,
 	sl *logstore.StateLoader,
-) (_ *storage.MemObject, nonempty bool, _ error) {
+) (*storage.MemObject, error) {
 	unreplicatedSSTFile := &storage.MemObject{}
 	unreplicatedSST := storage.MakeIngestionSSTWriter(
 		ctx, st, unreplicatedSSTFile,
@@ -733,19 +725,19 @@ func writeUnreplicatedSST(
 		if err := unreplicatedSST.ClearRawRange(
 			sp.Key, sp.EndKey, true /* pointKeys */, false, /* rangeKeys */
 		); err != nil {
-			return nil, false, errors.Wrapf(err, "error clearing range of unreplicated SST writer")
+			return nil, errors.Wrapf(err, "error clearing range of unreplicated SST writer")
 		}
 	}
 
 	// Update HardState.
 	if err := sl.SetHardState(ctx, &unreplicatedSST, hs); err != nil {
-		return nil, false, errors.Wrapf(err, "unable to write HardState to unreplicated SST writer")
+		return nil, errors.Wrapf(err, "unable to write HardState to unreplicated SST writer")
 	}
 	// We've cleared all the raft state above, so we are forced to write the
 	// RaftReplicaID again here.
 	if err := sl.SetRaftReplicaID(
 		ctx, &unreplicatedSST, id.ReplicaID); err != nil {
-		return nil, false, errors.Wrapf(err, "unable to write RaftReplicaID to unreplicated SST writer")
+		return nil, errors.Wrapf(err, "unable to write RaftReplicaID to unreplicated SST writer")
 	}
 
 	if err := sl.SetRaftTruncatedState(
@@ -755,13 +747,13 @@ func writeUnreplicatedSST(
 			Term:  meta.Term,
 		},
 	); err != nil {
-		return nil, false, errors.Wrapf(err, "unable to write TruncatedState to unreplicated SST writer")
+		return nil, errors.Wrapf(err, "unable to write TruncatedState to unreplicated SST writer")
 	}
 
 	if err := unreplicatedSST.Finish(); err != nil {
-		return nil, false, err
+		return nil, err
 	}
-	return unreplicatedSSTFile, unreplicatedSST.DataSize > 0, nil
+	return unreplicatedSSTFile, nil
 }
 
 // clearSubsumedReplicaDiskData clears the on disk data of the subsumed

--- a/pkg/kv/kvserver/replica_raftstorage.go
+++ b/pkg/kv/kvserver/replica_raftstorage.go
@@ -74,8 +74,7 @@ func (r *replicaRaftStorage) InitialState() (raftpb.HardState, raftpb.ConfState,
 // Entries implements the raft.Storage interface. Note that maxBytes is advisory
 // and this method will always return at least one entry even if it exceeds
 // maxBytes. Sideloaded proposals count towards maxBytes with their payloads inlined.
-// Entries requires that r.mu is held for writing because it requires exclusive
-// access to r.mu.stateLoader.
+// Holding r.mu is not required.
 //
 // Entries can return log entries that are not yet stable in durable storage.
 func (r *replicaRaftStorage) Entries(lo, hi, maxBytes uint64) ([]raftpb.Entry, error) {
@@ -83,13 +82,8 @@ func (r *replicaRaftStorage) Entries(lo, hi, maxBytes uint64) ([]raftpb.Entry, e
 	if r.raftMu.sideloaded == nil {
 		return nil, errors.New("sideloaded storage is uninitialized")
 	}
-	return logstore.LoadEntries(ctx, r.mu.stateLoader.StateLoader, r.store.TODOEngine(), r.RangeID,
+	return logstore.LoadEntries(ctx, r.raftMu.stateLoader.StateLoader, r.store.TODOEngine(), r.RangeID,
 		r.store.raftEntryCache, r.raftMu.sideloaded, lo, hi, maxBytes)
-}
-
-// raftEntriesLocked requires that r.mu is held for writing.
-func (r *Replica) raftEntriesLocked(lo, hi, maxBytes uint64) ([]raftpb.Entry, error) {
-	return (*replicaRaftStorage)(r).Entries(lo, hi, maxBytes)
 }
 
 // invalidLastTerm is an out-of-band value for r.mu.lastTermNotDurable that

--- a/pkg/kv/kvserver/replica_raftstorage.go
+++ b/pkg/kv/kvserver/replica_raftstorage.go
@@ -495,6 +495,9 @@ func (r *Replica) applySnapshot(
 	if err != nil {
 		return err
 	}
+	if !nonempty {
+		log.Fatalf(ctx, "unreplicated SST was empty")
+	}
 	if nonempty {
 		// TODO(itsbilal): Write to SST directly in unreplicatedSST rather than
 		// buffering in a MemObject first.

--- a/pkg/kv/kvserver/replica_test.go
+++ b/pkg/kv/kvserver/replica_test.go
@@ -296,7 +296,7 @@ func (tc *testContext) addBogusReplicaToRangeDesc(
 	tc.repl.setDescRaftMuLocked(ctx, &newDesc)
 	tc.repl.raftMu.Lock()
 	tc.repl.mu.RLock()
-	tc.repl.assertStateRaftMuLockedReplicaMuRLocked(ctx, tc.engine)
+	tc.repl.assertStateRaftMuLockedReplicaMuRLocked(ctx)
 	tc.repl.mu.RUnlock()
 	tc.repl.raftMu.Unlock()
 	return secondReplica, nil
@@ -10366,7 +10366,7 @@ func TestReplicaRecomputeStats(t *testing.T) {
 	disturbMS.ContainsEstimates = 0
 	ms.Add(*disturbMS)
 	err := repl.raftMu.stateLoader.SetMVCCStats(ctx, tc.engine, ms)
-	repl.assertStateRaftMuLockedReplicaMuRLocked(ctx, tc.engine)
+	repl.assertStateRaftMuLockedReplicaMuRLocked(ctx)
 	repl.mu.Unlock()
 	repl.raftMu.Unlock()
 

--- a/pkg/kv/kvserver/replica_test.go
+++ b/pkg/kv/kvserver/replica_test.go
@@ -7231,9 +7231,7 @@ func TestEntries(t *testing.T) {
 			if len(cacheEntries) != tc.expCacheCount {
 				t.Errorf("%d: expected cache count %d, got %d", i, tc.expCacheCount, len(cacheEntries))
 			}
-			repl.mu.Lock()
-			ents, err := repl.raftEntriesLocked(tc.lo, tc.hi, tc.maxBytes)
-			repl.mu.Unlock()
+			ents, err := entries(repl, tc.lo, tc.hi, tc.maxBytes)
 			if tc.expError == nil && err != nil {
 				t.Errorf("%d: expected no error, got %s", i, err)
 				continue
@@ -7252,11 +7250,9 @@ func TestEntries(t *testing.T) {
 		}
 
 		// Case 23: Lo must be less than or equal to hi.
-		repl.mu.Lock()
-		if _, err := repl.raftEntriesLocked(indexes[9], indexes[5], math.MaxUint64); err == nil {
+		if _, err := entries(repl, indexes[9], indexes[5], math.MaxUint64); err == nil {
 			t.Errorf("23: error expected, got none")
 		}
-		repl.mu.Unlock()
 	})
 }
 

--- a/pkg/kv/kvserver/stateloader/initial.go
+++ b/pkg/kv/kvserver/stateloader/initial.go
@@ -96,6 +96,11 @@ func WriteInitialReplicaState(
 		return enginepb.MVCCStats{}, err
 	}
 
+	// TODO(sep-raft-log): should be going to the log engine.
+	if err := rsl.SetRaftTruncatedState(ctx, stateRW, s.TruncatedState); err != nil {
+		return enginepb.MVCCStats{}, err
+	}
+
 	return newMS, nil
 }
 

--- a/pkg/kv/kvserver/stateloader/stateloader.go
+++ b/pkg/kv/kvserver/stateloader/stateloader.go
@@ -126,11 +126,6 @@ func (rsl StateLoader) Save(
 	if _, err := rsl.SetGCHint(ctx, readWriter, ms, state.GCHint); err != nil {
 		return enginepb.MVCCStats{}, err
 	}
-	// TODO(sep-raft-log): SetRaftTruncatedState will be in a separate batch when
-	// the Raft log engine is separated. Figure out the ordering required here.
-	if err := rsl.SetRaftTruncatedState(ctx, readWriter, state.TruncatedState); err != nil {
-		return enginepb.MVCCStats{}, err
-	}
 	if state.Version != nil {
 		if err := rsl.SetVersion(ctx, readWriter, ms, state.Version); err != nil {
 			return enginepb.MVCCStats{}, err

--- a/pkg/kv/kvserver/stateloader/stateloader.go
+++ b/pkg/kv/kvserver/stateloader/stateloader.go
@@ -341,19 +341,19 @@ func UninitializedReplicaState(rangeID roachpb.RangeID) kvserverpb.ReplicaState 
 // WriteInitialReplicaState and, on a split, perhaps the activity of an
 // uninitialized Raft group)
 func (rsl StateLoader) SynthesizeRaftState(
-	ctx context.Context, readWriter storage.ReadWriter,
+	ctx context.Context, stateRW storage.Reader, logRW storage.ReadWriter,
 ) error {
-	hs, err := rsl.LoadHardState(ctx, readWriter)
+	hs, err := rsl.LoadHardState(ctx, logRW)
 	if err != nil {
 		return err
 	}
-	truncState, err := rsl.LoadRaftTruncatedState(ctx, readWriter)
+	truncState, err := rsl.LoadRaftTruncatedState(ctx, logRW)
 	if err != nil {
 		return err
 	}
-	as, err := rsl.LoadRangeAppliedState(ctx, readWriter)
+	as, err := rsl.LoadRangeAppliedState(ctx, stateRW)
 	if err != nil {
 		return err
 	}
-	return rsl.SynthesizeHardState(ctx, readWriter, hs, truncState, as.RaftAppliedIndex)
+	return rsl.SynthesizeHardState(ctx, logRW, hs, truncState, as.RaftAppliedIndex)
 }

--- a/pkg/kv/kvserver/store.go
+++ b/pkg/kv/kvserver/store.go
@@ -2561,10 +2561,10 @@ func (s *Store) StateEngine() storage.Engine {
 	return s.internalEngines.stateEngine
 }
 
-// TODOEngine is a placeholder for cases in which
-// the caller needs to be updated in order to use
-// only one engine, or a closer check is still
-// pending.
+// TODOEngine is a placeholder for cases in which the caller needs to be updated
+// in order to use only one engine, or a closer check is still pending.
+//
+// See: https://github.com/cockroachdb/cockroach/issues/97627
 func (s *Store) TODOEngine() storage.Engine {
 	return s.internalEngines.todoEngine
 }

--- a/pkg/kv/kvserver/store.go
+++ b/pkg/kv/kvserver/store.go
@@ -1937,7 +1937,7 @@ func (s *Store) Start(ctx context.Context, stopper *stop.Stopper) error {
 			continue
 		}
 		// TODO(pavelkalinnikov): integrate into kvstorage.LoadAndReconcileReplicas.
-		state, err := repl.Load(ctx, s.TODOEngine(), s.StoreID())
+		state, err := repl.Load(ctx, s.StateEngine(), s.LogEngine(), s.StoreID())
 		if err != nil {
 			return err
 		}

--- a/pkg/kv/kvserver/store_snapshot.go
+++ b/pkg/kv/kvserver/store_snapshot.go
@@ -1363,7 +1363,7 @@ func SendEmptySnapshot(
 
 	ms, err = stateloader.WriteInitialReplicaState(
 		ctx,
-		eng,
+		eng, eng,
 		ms,
 		desc,
 		roachpb.Lease{},

--- a/pkg/kv/kvserver/store_test.go
+++ b/pkg/kv/kvserver/store_test.go
@@ -278,7 +278,7 @@ func createTestStoreWithoutStart(
 
 	kvs, splits := opts.splits()
 	if err := WriteInitialClusterData(
-		ctx, eng, kvs /* initialValues */, cv.Version,
+		ctx, eng, eng, kvs /* initialValues */, cv.Version,
 		1 /* numStores */, splits, cfg.Clock.PhysicalNow(), cfg.TestingKnobs,
 	); err != nil {
 		t.Fatal(err)
@@ -538,7 +538,7 @@ func createReplica(s *Store, rangeID roachpb.RangeID, start, end roachpb.RKey) *
 	}
 	const replicaID = 1
 	if err := stateloader.WriteInitialRangeState(
-		ctx, s.TODOEngine(), *desc, replicaID, clusterversion.TestingClusterVersion.Version,
+		ctx, s.StateEngine(), s.LogEngine(), *desc, replicaID, clusterversion.TestingClusterVersion.Version,
 	); err != nil {
 		panic(err)
 	}

--- a/pkg/server/node.go
+++ b/pkg/server/node.go
@@ -370,8 +370,13 @@ func bootstrapCluster(
 			if kn, ok := initCfg.testingKnobs.Store.(*kvserver.StoreTestingKnobs); ok {
 				storeKnobs = *kn
 			}
+
+			logEng := eng
+			if se, ok := eng.(kvserver.SeparatedEngine); ok {
+				logEng = se.LogEngine()
+			}
 			if err := kvserver.WriteInitialClusterData(
-				ctx, eng, initialValues,
+				ctx, eng, logEng, initialValues,
 				bootstrapVersion.Version, len(engines), splits,
 				timeutil.Now().UnixNano(), storeKnobs,
 			); err != nil {

--- a/pkg/testutils/localtestcluster/local_test_cluster.go
+++ b/pkg/testutils/localtestcluster/local_test_cluster.go
@@ -148,6 +148,10 @@ func (ltc *LocalTestCluster) Start(t testing.TB, baseCtx *base.Config, initFacto
 	clusterID := cfg.RPCContext.StorageClusterID
 	ltc.Gossip = gossip.New(ambient, clusterID, nc, ltc.stopper, metric.NewRegistry(), roachpb.Locality{}, zonepb.DefaultZoneConfigRef())
 	var err error
+	// TODO(sep-raft-log): LocalTestCluster currently doesn't support separating the raft log.
+	// That's probably fine, but here's an issue anyway:
+	//
+	// https://github.com/cockroachdb/cockroach/issues/97629
 	ltc.Eng, err = storage.Open(
 		ctx,
 		storage.InMemory(),
@@ -258,6 +262,7 @@ func (ltc *LocalTestCluster) Start(t testing.TB, baseCtx *base.Config, initFacto
 
 	if err := kvserver.WriteInitialClusterData(
 		ctx,
+		ltc.Eng,
 		ltc.Eng,
 		initialValues,
 		clusterversion.TestingBinaryVersion,


### PR DESCRIPTION
This series of commits first introduces the ability to request a separate raft
log engine via a `StoreSpec` during Go unit tests, along with a test verifying
that a cluster can be started. This test is initially skipped, as it would fail
on the first commit - there isn't any caller of `(*Store).LogEngine()` at this
point, but the test verifies that two engines are being used per store.  Next,
use of the log engine is introduced in all vital code paths related to raft
processing and snapshots. This requires some refactors, which were generally
carried out "conservatively", i.e., preferring small diffs over holistic
solutions. Instead, issues were filed and are referenced from TODO comments.

The sequence of commits culimates in a commit that unskips the test.

Closes https://github.com/cockroachdb/cockroach/issues/97608.
Closes #93250.

Epic: CRDB-220
Release Note: none
