### PR TITLE
sql/lease: support skipping descriptor validation lease renewals

### DIFF
--- a/pkg/base/config.go
+++ b/pkg/base/config.go
@@ -143,6 +143,10 @@ const (
 	// DefaultDescriptorLeaseRenewalTimeout is the default time
 	// before a lease expires when acquisition to renew the lease begins.
 	DefaultDescriptorLeaseRenewalTimeout = time.Minute
+
+	// DefaultLeaseRenewalCrossValidate is the default setting for if
+	// we should validate descriptors on lease renewals.
+	DefaultLeaseRenewalCrossValidate = false
 )
 
 // DefaultCertsDirectory is the default value for the cert directory flag.

--- a/pkg/bench/rttanalysis/testdata/benchmark_expectations
+++ b/pkg/bench/rttanalysis/testdata/benchmark_expectations
@@ -99,5 +99,5 @@ exp,benchmark
 12,Truncate/truncate_2_column_2_rows
 1,VirtualTableQueries/select_crdb_internal.invalid_objects_with_1_fk
 1,VirtualTableQueries/select_crdb_internal.tables_with_1_fk
-11,VirtualTableQueries/virtual_table_cache_with_point_lookups
+9,VirtualTableQueries/virtual_table_cache_with_point_lookups
 7,VirtualTableQueries/virtual_table_cache_with_schema_change


### PR DESCRIPTION
Fixes: #95764

Previously, when renewing a lease we would fetch dependent
descriptors for cross-descriptor validation. This could
lead to perpetual transaction retries, in the schema where
there are tons of dependencies between descriptors since
lease renewals would happen in a high-priority transaction.
Additionally, this incurs additional latency for lease renewal.
To address this, this patch disables cross-validation by default for
lease renewals.

Epic: none
Release note (bug fix): Disable cross-descriptor validation on lease renewal,
which can be problematic when there are lots of descriptors with lots
of foreign key references, in which cases, the cross-reference validation could
starve schema changes.