### PR TITLE
sql: dedupe on search path schema when resolving functions

### DIFF
--- a/pkg/ccl/logictestccl/tests/3node-tenant/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/3node-tenant/generated_test.go
@@ -1753,6 +1753,13 @@ func TestTenantLogic_show_indexes(
 	runLogicTest(t, "show_indexes")
 }
 
+func TestTenantLogic_show_var(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "show_var")
+}
+
 func TestTenantLogic_span_builtins(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/testdata/logic_test/show_var
+++ b/pkg/sql/logictest/testdata/logic_test/show_var
@@ -1,0 +1,8 @@
+# Make sure that user get duplicate search paths as they set.
+statement ok
+SET search_path = public, public, a, b, c
+
+query T
+SHOW search_path;
+----
+public, public, a, b, c

--- a/pkg/sql/logictest/testdata/logic_test/udf
+++ b/pkg/sql/logictest/testdata/logic_test/udf
@@ -3116,3 +3116,20 @@ query I
 SELECT f_94146(1::INT2)
 ----
 2
+
+subtest regression_97130
+
+statement ok
+CREATE FUNCTION f_97130() RETURNS INT LANGUAGE SQL AS $$ SELECT 1 $$;
+
+let $pre_search_path
+SHOW search_path
+
+statement ok
+SET search_path = public,public
+
+statement ok
+SELECT f_97130();
+
+statement ok
+SET search_path = $pre_search_path

--- a/pkg/sql/logictest/tests/fakedist-disk/generated_test.go
+++ b/pkg/sql/logictest/tests/fakedist-disk/generated_test.go
@@ -1738,6 +1738,13 @@ func TestLogic_show_transfer_state(
 	runLogicTest(t, "show_transfer_state")
 }
 
+func TestLogic_show_var(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "show_var")
+}
+
 func TestLogic_span_builtins(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/fakedist-vec-off/generated_test.go
+++ b/pkg/sql/logictest/tests/fakedist-vec-off/generated_test.go
@@ -1738,6 +1738,13 @@ func TestLogic_show_transfer_state(
 	runLogicTest(t, "show_transfer_state")
 }
 
+func TestLogic_show_var(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "show_var")
+}
+
 func TestLogic_span_builtins(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/fakedist/generated_test.go
+++ b/pkg/sql/logictest/tests/fakedist/generated_test.go
@@ -1752,6 +1752,13 @@ func TestLogic_show_transfer_state(
 	runLogicTest(t, "show_transfer_state")
 }
 
+func TestLogic_show_var(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "show_var")
+}
+
 func TestLogic_span_builtins(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/local-legacy-schema-changer/generated_test.go
+++ b/pkg/sql/logictest/tests/local-legacy-schema-changer/generated_test.go
@@ -1710,6 +1710,13 @@ func TestLogic_show_transfer_state(
 	runLogicTest(t, "show_transfer_state")
 }
 
+func TestLogic_show_var(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "show_var")
+}
+
 func TestLogic_span_builtins(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/local-vec-off/generated_test.go
+++ b/pkg/sql/logictest/tests/local-vec-off/generated_test.go
@@ -1745,6 +1745,13 @@ func TestLogic_show_transfer_state(
 	runLogicTest(t, "show_transfer_state")
 }
 
+func TestLogic_show_var(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "show_var")
+}
+
 func TestLogic_span_builtins(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/local/generated_test.go
+++ b/pkg/sql/logictest/tests/local/generated_test.go
@@ -1913,6 +1913,13 @@ func TestLogic_show_transfer_state(
 	runLogicTest(t, "show_transfer_state")
 }
 
+func TestLogic_show_var(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "show_var")
+}
+
 func TestLogic_skip_on_retry(
 	t *testing.T,
 ) {

--- a/pkg/sql/sessiondata/BUILD.bazel
+++ b/pkg/sql/sessiondata/BUILD.bazel
@@ -19,6 +19,7 @@ go_library(
         "//pkg/sql/sem/catconstants",
         "//pkg/sql/sessiondatapb",
         "//pkg/util/duration",
+        "//pkg/util/intsets",
         "//pkg/util/syncutil",
         "//pkg/util/timeutil",
         "//pkg/util/timeutil/pgdate",

--- a/pkg/sql/sessiondata/search_path_test.go
+++ b/pkg/sql/sessiondata/search_path_test.go
@@ -45,7 +45,28 @@ func TestImpliedSearchPath(t *testing.T) {
 			expectedSearchPathWithoutImplicitPgSchemasWhenTempSchemaExists: []string{`pg_catalog`},
 		},
 		{
+			explicitSearchPath:                                             []string{`pg_catalog`, `pg_catalog`},
+			expectedSearchPath:                                             []string{`pg_catalog`},
+			expectedSearchPathWithoutImplicitPgSchemas:                     []string{`pg_catalog`},
+			expectedSearchPathWhenTemporarySchemaExists:                    []string{testTempSchemaName, `pg_catalog`},
+			expectedSearchPathWithoutImplicitPgSchemasWhenTempSchemaExists: []string{`pg_catalog`},
+		},
+		{
 			explicitSearchPath:                                             []string{`pg_catalog`, `pg_temp`},
+			expectedSearchPath:                                             []string{`pg_catalog`},
+			expectedSearchPathWithoutImplicitPgSchemas:                     []string{`pg_catalog`},
+			expectedSearchPathWhenTemporarySchemaExists:                    []string{`pg_catalog`, testTempSchemaName},
+			expectedSearchPathWithoutImplicitPgSchemasWhenTempSchemaExists: []string{`pg_catalog`, testTempSchemaName},
+		},
+		{
+			explicitSearchPath:                                             []string{`pg_catalog`, `pg_catalog`, `pg_temp`},
+			expectedSearchPath:                                             []string{`pg_catalog`},
+			expectedSearchPathWithoutImplicitPgSchemas:                     []string{`pg_catalog`},
+			expectedSearchPathWhenTemporarySchemaExists:                    []string{`pg_catalog`, testTempSchemaName},
+			expectedSearchPathWithoutImplicitPgSchemasWhenTempSchemaExists: []string{`pg_catalog`, testTempSchemaName},
+		},
+		{
+			explicitSearchPath:                                             []string{`pg_catalog`, `pg_temp`, `pg_temp`},
 			expectedSearchPath:                                             []string{`pg_catalog`},
 			expectedSearchPathWithoutImplicitPgSchemas:                     []string{`pg_catalog`},
 			expectedSearchPathWhenTemporarySchemaExists:                    []string{`pg_catalog`, testTempSchemaName},
@@ -59,7 +80,35 @@ func TestImpliedSearchPath(t *testing.T) {
 			expectedSearchPathWithoutImplicitPgSchemasWhenTempSchemaExists: []string{testTempSchemaName, `pg_catalog`},
 		},
 		{
+			explicitSearchPath:                                             []string{`pg_temp`, `pg_temp`, `pg_catalog`},
+			expectedSearchPath:                                             []string{`pg_catalog`},
+			expectedSearchPathWithoutImplicitPgSchemas:                     []string{`pg_catalog`},
+			expectedSearchPathWhenTemporarySchemaExists:                    []string{testTempSchemaName, `pg_catalog`},
+			expectedSearchPathWithoutImplicitPgSchemasWhenTempSchemaExists: []string{testTempSchemaName, `pg_catalog`},
+		},
+		{
+			explicitSearchPath:                                             []string{`pg_temp`, `pg_catalog`, `pg_catalog`},
+			expectedSearchPath:                                             []string{`pg_catalog`},
+			expectedSearchPathWithoutImplicitPgSchemas:                     []string{`pg_catalog`},
+			expectedSearchPathWhenTemporarySchemaExists:                    []string{testTempSchemaName, `pg_catalog`},
+			expectedSearchPathWithoutImplicitPgSchemasWhenTempSchemaExists: []string{testTempSchemaName, `pg_catalog`},
+		},
+		{
 			explicitSearchPath:                                             []string{`foobar`, `pg_catalog`},
+			expectedSearchPath:                                             []string{`foobar`, `pg_catalog`},
+			expectedSearchPathWithoutImplicitPgSchemas:                     []string{`foobar`, `pg_catalog`},
+			expectedSearchPathWhenTemporarySchemaExists:                    []string{testTempSchemaName, `foobar`, `pg_catalog`},
+			expectedSearchPathWithoutImplicitPgSchemasWhenTempSchemaExists: []string{`foobar`, `pg_catalog`},
+		},
+		{
+			explicitSearchPath:                                             []string{`foobar`, `foobar`, `pg_catalog`},
+			expectedSearchPath:                                             []string{`foobar`, `pg_catalog`},
+			expectedSearchPathWithoutImplicitPgSchemas:                     []string{`foobar`, `pg_catalog`},
+			expectedSearchPathWhenTemporarySchemaExists:                    []string{testTempSchemaName, `foobar`, `pg_catalog`},
+			expectedSearchPathWithoutImplicitPgSchemasWhenTempSchemaExists: []string{`foobar`, `pg_catalog`},
+		},
+		{
+			explicitSearchPath:                                             []string{`foobar`, `pg_catalog`, `pg_catalog`},
 			expectedSearchPath:                                             []string{`foobar`, `pg_catalog`},
 			expectedSearchPathWithoutImplicitPgSchemas:                     []string{`foobar`, `pg_catalog`},
 			expectedSearchPathWhenTemporarySchemaExists:                    []string{testTempSchemaName, `foobar`, `pg_catalog`},
@@ -73,7 +122,28 @@ func TestImpliedSearchPath(t *testing.T) {
 			expectedSearchPathWithoutImplicitPgSchemasWhenTempSchemaExists: []string{`foobar`, testTempSchemaName},
 		},
 		{
+			explicitSearchPath:                                             []string{`foobar`, `foobar`, `pg_temp`},
+			expectedSearchPath:                                             []string{`pg_catalog`, `foobar`},
+			expectedSearchPathWithoutImplicitPgSchemas:                     []string{`foobar`},
+			expectedSearchPathWhenTemporarySchemaExists:                    []string{`pg_catalog`, `foobar`, testTempSchemaName},
+			expectedSearchPathWithoutImplicitPgSchemasWhenTempSchemaExists: []string{`foobar`, testTempSchemaName},
+		},
+		{
+			explicitSearchPath:                                             []string{`foobar`, `pg_temp`, `pg_temp`},
+			expectedSearchPath:                                             []string{`pg_catalog`, `foobar`},
+			expectedSearchPathWithoutImplicitPgSchemas:                     []string{`foobar`},
+			expectedSearchPathWhenTemporarySchemaExists:                    []string{`pg_catalog`, `foobar`, testTempSchemaName},
+			expectedSearchPathWithoutImplicitPgSchemasWhenTempSchemaExists: []string{`foobar`, testTempSchemaName},
+		},
+		{
 			explicitSearchPath:                                             []string{`foobar`},
+			expectedSearchPath:                                             []string{`pg_catalog`, `foobar`},
+			expectedSearchPathWithoutImplicitPgSchemas:                     []string{`foobar`},
+			expectedSearchPathWhenTemporarySchemaExists:                    []string{testTempSchemaName, `pg_catalog`, `foobar`},
+			expectedSearchPathWithoutImplicitPgSchemasWhenTempSchemaExists: []string{`foobar`},
+		},
+		{
+			explicitSearchPath:                                             []string{`foobar`, `foobar`},
 			expectedSearchPath:                                             []string{`pg_catalog`, `foobar`},
 			expectedSearchPathWithoutImplicitPgSchemas:                     []string{`foobar`},
 			expectedSearchPathWhenTemporarySchemaExists:                    []string{testTempSchemaName, `pg_catalog`, `foobar`},
@@ -87,7 +157,28 @@ func TestImpliedSearchPath(t *testing.T) {
 			expectedSearchPathWithoutImplicitPgSchemasWhenTempSchemaExists: []string{`public`},
 		},
 		{
+			explicitSearchPath:                                             []string{`public`, `public`},
+			expectedSearchPath:                                             []string{`pg_catalog`, `pg_extension`, `public`},
+			expectedSearchPathWithoutImplicitPgSchemas:                     []string{`public`},
+			expectedSearchPathWhenTemporarySchemaExists:                    []string{testTempSchemaName, `pg_catalog`, `pg_extension`, `public`},
+			expectedSearchPathWithoutImplicitPgSchemasWhenTempSchemaExists: []string{`public`},
+		},
+		{
 			explicitSearchPath:                                             []string{`public`, `pg_extension`},
+			expectedSearchPath:                                             []string{`pg_catalog`, `public`, `pg_extension`},
+			expectedSearchPathWithoutImplicitPgSchemas:                     []string{`public`, `pg_extension`},
+			expectedSearchPathWhenTemporarySchemaExists:                    []string{testTempSchemaName, `pg_catalog`, `public`, `pg_extension`},
+			expectedSearchPathWithoutImplicitPgSchemasWhenTempSchemaExists: []string{`public`, `pg_extension`},
+		},
+		{
+			explicitSearchPath:                                             []string{`public`, `public`, `pg_extension`},
+			expectedSearchPath:                                             []string{`pg_catalog`, `public`, `pg_extension`},
+			expectedSearchPathWithoutImplicitPgSchemas:                     []string{`public`, `pg_extension`},
+			expectedSearchPathWhenTemporarySchemaExists:                    []string{testTempSchemaName, `pg_catalog`, `public`, `pg_extension`},
+			expectedSearchPathWithoutImplicitPgSchemasWhenTempSchemaExists: []string{`public`, `pg_extension`},
+		},
+		{
+			explicitSearchPath:                                             []string{`public`, `pg_extension`, `pg_extension`},
 			expectedSearchPath:                                             []string{`pg_catalog`, `public`, `pg_extension`},
 			expectedSearchPathWithoutImplicitPgSchemas:                     []string{`public`, `pg_extension`},
 			expectedSearchPathWhenTemporarySchemaExists:                    []string{testTempSchemaName, `pg_catalog`, `public`, `pg_extension`},
@@ -102,6 +193,18 @@ func TestImpliedSearchPath(t *testing.T) {
 			iter := searchPath.Iter()
 			for p, ok := iter.Next(); ok; p, ok = iter.Next() {
 				actualSearchPath = append(actualSearchPath, p)
+			}
+			if !reflect.DeepEqual(tc.expectedSearchPath, actualSearchPath) {
+				t.Errorf(
+					`#%d: Expected search path to be %#v, but was %#v.`,
+					tcNum,
+					tc.expectedSearchPath,
+					actualSearchPath,
+				)
+			}
+			actualSearchPath = make([]string, 0)
+			for i, n := 0, searchPath.NumElements(); i < n; i++ {
+				actualSearchPath = append(actualSearchPath, searchPath.GetSchema(i))
 			}
 			if !reflect.DeepEqual(tc.expectedSearchPath, actualSearchPath) {
 				t.Errorf(


### PR DESCRIPTION
Fixes: #97130
Previously, if there are duplicate schemas in current searcth path function resolution would fail due to ambiguity because a UDF was seen twice. This commit adds logic to dedupe on the search path schema.

Release note: None