### PR TITLE
release-22.2: sql/lease: support skipping descriptor validation lease renewals

### DIFF
--- a/pkg/base/config.go
+++ b/pkg/base/config.go
@@ -97,6 +97,10 @@ const (
 	// DefaultDescriptorLeaseRenewalTimeout is the default time
 	// before a lease expires when acquisition to renew the lease begins.
 	DefaultDescriptorLeaseRenewalTimeout = time.Minute
+
+	// DefaultLeaseRenewalCrossValidate is the default setting for if
+	// we should validate descriptors on lease renewals.
+	DefaultLeaseRenewalCrossValidate = true
 )
 
 // DefaultCertsDirectory is the default value for the cert directory flag.

--- a/pkg/sql/catalog/lease/BUILD.bazel
+++ b/pkg/sql/catalog/lease/BUILD.bazel
@@ -31,6 +31,7 @@ go_library(
         "//pkg/sql/catalog/descbuilder",
         "//pkg/sql/catalog/descpb",
         "//pkg/sql/catalog/internal/catkv",
+        "//pkg/sql/catalog/internal/validate",
         "//pkg/sql/catalog/nstree",
         "//pkg/sql/pgwire/pgcode",
         "//pkg/sql/pgwire/pgerror",


### PR DESCRIPTION
Backport 1/1 commits from #97630.

/cc @cockroachdb/release

---

Fixes: #95764

Previously, when renewing a lease we would fetch dependent
descriptors for cross-descriptor validation. This could
lead to perpetual transaction retries, in the schema where
there are tons of dependencies between descriptors since
lease renewals would happen in a high-priority transaction.
Additionally, this incurs additional latency for lease renewal.
To address this, this patch disables cross-validation by default for
lease renewals.

Epic: none
Release note (bug fix): Add support for disabling cross-descriptor validation
on lease renewal, which can be problematic when there are lots of descriptors
with lots of foreign key references, in which cases, the cross-reference
validation could starve schema changes. This can be enabled with
sql.catalog.descriptor_lease_renewal_cross_validation.

Release justification: low-risk fix aimed at fairly pervasive issues in some clusters
