### PR TITLE
release-22.2: ui: fix schema insight pagination

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/package.json
+++ b/pkg/ui/workspaces/cluster-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cockroachlabs/cluster-ui",
-  "version": "22.2.5",
+  "version": "22.2.6",
   "description": "Cluster UI is a library of large features shared between CockroachDB and CockroachCloud",
   "repository": {
     "type": "git",

--- a/pkg/ui/workspaces/cluster-ui/src/insights/schemaInsights/schemaInsightsView.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/schemaInsights/schemaInsightsView.tsx
@@ -242,6 +242,7 @@ export const SchemaInsightsView: React.FC<SchemaInsightsViewProps> = ({
                 data={filteredSchemaInsights}
                 sortSetting={sortSetting}
                 onChangeSortSetting={onChangeSortSetting}
+                pagination={pagination}
                 renderNoResult={
                   <EmptySchemaInsightsTablePlaceholder
                     isEmptySearchResults={


### PR DESCRIPTION
Backport 1/1 commits from #97640.

/cc @cockroachdb/release

---

Previously, we were showing pagination components, but we were always loading all results in all pages. This commit fixes the issue by adding the proper
pagination to the table.

Fixes #97536

Release note (bug fix): Fix pagination on schema insights.

---
Release justification: bug fix
