### PR TITLE
server: Fix ballast size calculation when opening pebble

### DIFF
--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -803,7 +803,7 @@ func (cfg *Config) CreateEngines(ctx context.Context) (Engines, error) {
 			detail(redact.Sprintf("store %d: max size %s, max open file limit %d", i, humanizeutil.IBytes(sizeInBytes), openFileLimitPerStore))
 
 			addCfgOpt(storage.MaxSize(sizeInBytes))
-			addCfgOpt(storage.BallastSize(sizeInBytes))
+			addCfgOpt(storage.BallastSize(storage.BallastSizeBytes(spec, du)))
 			addCfgOpt(storage.Caches(pebbleCache, tableCache))
 			// TODO(radu): move up all remaining settings below so they apply to in-memory stores as well.
 			addCfgOpt(storage.MaxOpenFiles(int(openFileLimitPerStore)))


### PR DESCRIPTION
As part of #97332, we unintentionally started setting the ballast size to be the same as the max size of the store, if one was specified. This meant that we wouldn't create the default 1GB ballast file if no store max size was specified.

Fixes #97449.

Epic: none

Release note: None