### PR TITLE
ui: show events even with max size limit reached

### DIFF
--- a/pkg/ui/workspaces/db-console/src/redux/apiReducers.ts
+++ b/pkg/ui/workspaces/db-console/src/redux/apiReducers.ts
@@ -524,7 +524,9 @@ export const refreshRawTrace = rawTraceReducerObj.refresh;
 
 export interface APIReducersState {
   cluster: CachedDataReducerState<api.ClusterResponseMessage>;
-  events: CachedDataReducerState<clusterUiApi.EventsResponse>;
+  events: CachedDataReducerState<
+    clusterUiApi.SqlApiResponse<clusterUiApi.EventsResponse>
+  >;
   health: HealthState;
   nodes: CachedDataReducerState<INodeStatus[]>;
   raft: CachedDataReducerState<api.RaftDebugResponseMessage>;

--- a/pkg/ui/workspaces/db-console/src/redux/events.ts
+++ b/pkg/ui/workspaces/db-console/src/redux/events.ts
@@ -14,7 +14,7 @@ import { AdminUIState } from "src/redux/state";
  * eventsSelector selects the list of events from the store.
  */
 export function eventsSelector(state: AdminUIState) {
-  return state.cachedData.events.data;
+  return state.cachedData.events?.data?.results;
 }
 
 /**
@@ -27,3 +27,7 @@ export function eventsValidSelector(state: AdminUIState) {
 export function eventsLastErrorSelector(state: AdminUIState) {
   return state.cachedData.events.lastError;
 }
+
+export const eventsMaxApiReached = (state: AdminUIState): boolean => {
+  return !!state.cachedData.events?.data?.maxSizeReached;
+};

--- a/pkg/ui/workspaces/db-console/src/util/api.spec.ts
+++ b/pkg/ui/workspaces/db-console/src/util/api.spec.ts
@@ -330,7 +330,7 @@ describe("rest api", function () {
 
       return clusterUiApi.getNonRedactedEvents().then(result => {
         expect(fetchMock.calls(clusterUiApi.SQL_API_PATH).length).toBe(1);
-        expect(result.length).toBe(1);
+        expect(result.results.length).toBe(1);
       });
     });
 
@@ -364,7 +364,7 @@ describe("rest api", function () {
 
       return clusterUiApi.getNonRedactedEvents(req).then(result => {
         expect(fetchMock.calls(clusterUiApi.SQL_API_PATH).length).toBe(1);
-        expect(result.length).toBe(1);
+        expect(result.results.length).toBe(1);
       });
     });
 


### PR DESCRIPTION
Show events that were returned when we reach the max size limit of the sql-api.

Part Of #96184

https://www.loom.com/share/31e8c55f091c4e2ba4b4243710aa58a4

Release note: None