### PR TITLE
ui: update suboptimal insight description

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/insights/types.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/types.ts
@@ -190,8 +190,8 @@ export const suboptimalPlanInsight = (execType: InsightExecEnum): Insight => {
   switch (execType) {
     case InsightExecEnum.STATEMENT:
       description =
-        `This statement was slow because a good plan was not available, whether ` +
-        `due to outdated statistics or missing indexes.`;
+        `This statement was slow because a good plan was unavailable; ` +
+        `possible reasons include outdated statistics or missing indexes.`;
       break;
     case InsightExecEnum.TRANSACTION:
       description =

--- a/pkg/ui/workspaces/cluster-ui/src/insightsTable/insightsTable.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insightsTable/insightsTable.tsx
@@ -24,6 +24,7 @@ import {
   performanceBestPractices,
   performanceTuningRecipes,
   statementsRetries,
+  stmtPerformanceRules,
 } from "../util";
 import { Anchor } from "../anchor";
 import { Link } from "react-router-dom";
@@ -152,6 +153,12 @@ function descriptionCell(
     </>
   );
 
+  const learnMoreSuboptimalPlan = (
+    <Anchor href={stmtPerformanceRules} target="_blank">
+      Learn more
+    </Anchor>
+  );
+
   const indexLink = isCockroachCloud
     ? EncodeDatabasesToIndexUri(
         insightRec.database,
@@ -243,7 +250,7 @@ function descriptionCell(
           {stmtLink}
           <div className={cx("description-item")}>
             <span className={cx("label-bold")}>Description: </span>{" "}
-            {insightRec.details.description}
+            {insightRec.details.description} {learnMoreSuboptimalPlan}
           </div>
           {insightRec.execution.indexRecommendations && (
             <div className={cx("description-item")}>

--- a/pkg/ui/workspaces/cluster-ui/src/util/docs.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/util/docs.ts
@@ -93,6 +93,9 @@ export const tableStatsClusterSetting = docsURL(
 export const performanceBestPractices = docsURL(
   "performance-best-practices-overview",
 );
+export const stmtPerformanceRules = docsURL(
+  "make-queries-fast.html#sql-statement-performance-rules",
+);
 // Note that these explicitly don't use the current version, since we want to
 // link to the most up-to-date documentation available.
 export const upgradeCockroachVersion =


### PR DESCRIPTION
Update Suboptimal description to:
This statement was slow because a good plan was unavailable; possible reasons include outdated statistics or missing indexes.

Fixes #97266

<img width="1341" alt="Screenshot 2023-02-24 at 4 34 42 PM" src="https://user-images.githubusercontent.com/1017486/221298107-b205becb-5137-405f-b8c4-cc4f9d2a6531.png">


Release note (ui change): Update description for the Suboptimal Insight and adds a Learn more link to it.