### PR TITLE
release-22.2: bazel: don't filter out `generics` lint failures

### DIFF
--- a/build/bazelutil/nogo_config.json
+++ b/build/bazelutil/nogo_config.json
@@ -78,11 +78,6 @@
             "cockroach/pkg/.*$": "first-party code"
         }
     },
-    "generics": {
-        "only_files": {
-            "cockroach/pkg/.*$": "first-party code"
-        }
-    },
     "grpcconnclose": {
         "exclude_files": {
             "cockroach/pkg/.*\\.eg\\.go$": "generated code",


### PR DESCRIPTION
The `generics` linter does not kick in on CRDB code for some reason. I think it's because the linter itself doesn't know how to point to the location of `generics` and just reports file names as `-`.

Delete the block where we configure the `generics` analyzer so it applies for all `.go` files that we compile with Bazel.

Epic: none
Release note: None
Release justification: Non-production code changes