### PR TITLE
release-22.2: kvserver: record ScanStats once per BatchRequest

### DIFF
--- a/pkg/kv/kvserver/batcheval/cmd_get.go
+++ b/pkg/kv/kvserver/batcheval/cmd_get.go
@@ -57,6 +57,7 @@ func Get(
 		SkipLocked:       h.WaitPolicy == lock.WaitPolicy_SkipLocked,
 		Txn:              h.Txn,
 		FailOnMoreRecent: args.KeyLocking != lock.None,
+		ScanStats:        cArgs.ScanStats,
 		Uncertainty:      cArgs.Uncertainty,
 		MemoryAccount:    cArgs.EvalCtx.GetResponseMemoryAccount(),
 		LockTable:        cArgs.Concurrency,

--- a/pkg/kv/kvserver/batcheval/cmd_reverse_scan.go
+++ b/pkg/kv/kvserver/batcheval/cmd_reverse_scan.go
@@ -43,6 +43,7 @@ func ReverseScan(
 		Inconsistent:     h.ReadConsistency != roachpb.CONSISTENT,
 		SkipLocked:       h.WaitPolicy == lock.WaitPolicy_SkipLocked,
 		Txn:              h.Txn,
+		ScanStats:        cArgs.ScanStats,
 		Uncertainty:      cArgs.Uncertainty,
 		MaxKeys:          h.MaxSpanRequestKeys,
 		MaxIntents:       storage.MaxIntentsPerWriteIntentError.Get(&cArgs.EvalCtx.ClusterSettings().SV),

--- a/pkg/kv/kvserver/batcheval/cmd_scan.go
+++ b/pkg/kv/kvserver/batcheval/cmd_scan.go
@@ -43,6 +43,7 @@ func Scan(
 		Inconsistent:     h.ReadConsistency != roachpb.CONSISTENT,
 		SkipLocked:       h.WaitPolicy == lock.WaitPolicy_SkipLocked,
 		Txn:              h.Txn,
+		ScanStats:        cArgs.ScanStats,
 		Uncertainty:      cArgs.Uncertainty,
 		MaxKeys:          h.MaxSpanRequestKeys,
 		MaxIntents:       storage.MaxIntentsPerWriteIntentError.Get(&cArgs.EvalCtx.ClusterSettings().SV),

--- a/pkg/kv/kvserver/batcheval/declare.go
+++ b/pkg/kv/kvserver/batcheval/declare.go
@@ -121,7 +121,10 @@ type CommandArgs struct {
 	Args    roachpb.Request
 	Now     hlc.ClockTimestamp
 	// *Stats should be mutated to reflect any writes made by the command.
-	Stats       *enginepb.MVCCStats
+	Stats *enginepb.MVCCStats
+	// ScanStats should be mutated to reflect Get and Scan/ReverseScan reads
+	// made by the command.
+	ScanStats   *roachpb.ScanStats
 	Concurrency *concurrency.Guard
 	Uncertainty uncertainty.Interval
 }

--- a/pkg/roachpb/api.go
+++ b/pkg/roachpb/api.go
@@ -1823,7 +1823,8 @@ func (s *ScanStats) SafeFormat(w redact.SafePrinter, _ rune) {
 	w.Printf("scan stats: stepped %d times (%d internal); seeked %d times (%d internal); "+
 		"block-bytes: (total %s, cached %s); "+
 		"points: (count %s, key-bytes %s, value-bytes %s, tombstoned: %s) "+
-		"ranges: (count %s), (contained-points %s, skipped-points %s)",
+		"ranges: (count %s), (contained-points %s, skipped-points %s) "+
+		"evaluated requests: %d gets, %d scans, %d reverse scans",
 		s.NumInterfaceSteps, s.NumInternalSteps, s.NumInterfaceSeeks, s.NumInternalSeeks,
 		humanizeutil.IBytes(int64(s.BlockBytes)),
 		humanizeutil.IBytes(int64(s.BlockBytesInCache)),
@@ -1833,7 +1834,8 @@ func (s *ScanStats) SafeFormat(w redact.SafePrinter, _ rune) {
 		humanizePointCount(s.PointsCoveredByRangeTombstones),
 		humanizePointCount(s.RangeKeyCount),
 		humanizePointCount(s.RangeKeyContainedPoints),
-		humanizePointCount(s.RangeKeySkippedPoints))
+		humanizePointCount(s.RangeKeySkippedPoints),
+		s.NumGets, s.NumScans, s.NumReverseScans)
 }
 
 // String implements fmt.Stringer.

--- a/pkg/roachpb/api.proto
+++ b/pkg/roachpb/api.proto
@@ -3075,8 +3075,8 @@ message ContentionEvent {
                                          (gogoproto.stdduration) = true];
 }
 
-// ScanStats is a message that will be attached to BatchResponses containing
-// information about what happened during each scan and get in the request.
+// ScanStats is a message that tracks miscellaneous statistics of all Gets,
+// Scans, and ReverseScans in a single BatchResponse.
 message ScanStats {
   option (gogoproto.goproto_stringer) = false;
 
@@ -3095,4 +3095,12 @@ message ScanStats {
   uint64 range_key_count = 11;
   uint64 range_key_contained_points = 12;
   uint64 range_key_skipped_points = 13;
+
+  // NumGets, NumScans, and NumReverseScans tracks the number of Gets, Scans,
+  // and ReverseScans, respectively, that were actually evaluated as part of the
+  // BatchResponse. These don't include requests that were not evaluated due to
+  // reaching the BatchResponse's limits or an error.
+  uint64 num_gets = 17;
+  uint64 num_scans = 18;
+  uint64 num_reverse_scans = 19;
 }

--- a/pkg/sql/execinfrapb/component_stats.proto
+++ b/pkg/sql/execinfrapb/component_stats.proto
@@ -136,6 +136,10 @@ message KVStats {
   optional util.optional.Uint num_internal_steps = 6 [(gogoproto.nullable) = false];
   optional util.optional.Uint num_interface_seeks = 7 [(gogoproto.nullable) = false];
   optional util.optional.Uint num_internal_seeks = 8 [(gogoproto.nullable) = false];
+
+  optional util.optional.Uint num_gets = 21 [(gogoproto.nullable) = false];
+  optional util.optional.Uint num_scans = 22 [(gogoproto.nullable) = false];
+  optional util.optional.Uint num_reverse_scans = 23 [(gogoproto.nullable) = false];
 }
 
 // ExecStats contains statistics about the execution of a component.

--- a/pkg/sql/execstats/stats.go
+++ b/pkg/sql/execstats/stats.go
@@ -74,7 +74,10 @@ type ScanStats struct {
 	NumInternalSeeks uint64
 	// ConsumedRU is the number of RUs that were consumed during the course of a
 	// scan.
-	ConsumedRU uint64
+	ConsumedRU      uint64
+	NumGets         uint64
+	NumScans        uint64
+	NumReverseScans uint64
 }
 
 // PopulateKVMVCCStats adds data from the input ScanStats to the input KVStats.
@@ -83,6 +86,9 @@ func PopulateKVMVCCStats(kvStats *execinfrapb.KVStats, ss *ScanStats) {
 	kvStats.NumInternalSteps = optional.MakeUint(ss.NumInternalSteps)
 	kvStats.NumInterfaceSeeks = optional.MakeUint(ss.NumInterfaceSeeks)
 	kvStats.NumInternalSeeks = optional.MakeUint(ss.NumInternalSeeks)
+	kvStats.NumGets = optional.MakeUint(ss.NumGets)
+	kvStats.NumScans = optional.MakeUint(ss.NumScans)
+	kvStats.NumReverseScans = optional.MakeUint(ss.NumReverseScans)
 }
 
 // GetScanStats is a helper function to calculate scan stats from the given
@@ -104,6 +110,9 @@ func GetScanStats(ctx context.Context, recording tracingpb.Recording) (scanStats
 				scanStats.NumInternalSteps += ss.NumInternalSteps
 				scanStats.NumInterfaceSeeks += ss.NumInterfaceSeeks
 				scanStats.NumInternalSeeks += ss.NumInternalSeeks
+				scanStats.NumGets += ss.NumGets
+				scanStats.NumScans += ss.NumScans
+				scanStats.NumReverseScans += ss.NumReverseScans
 			} else if pbtypes.Is(any, &tc) {
 				if err := pbtypes.UnmarshalAny(any, &tc); err != nil {
 					return

--- a/pkg/storage/BUILD.bazel
+++ b/pkg/storage/BUILD.bazel
@@ -78,7 +78,6 @@ go_library(
         "//pkg/util/sysutil",
         "//pkg/util/timeutil",
         "//pkg/util/tracing",
-        "//pkg/util/tracing/tracingpb",
         "//pkg/util/uuid",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_cockroachdb_errors//oserror",


### PR DESCRIPTION
Backport 1/1 commits from #97442.

/cc @cockroachdb/release

---

Previously, we would record a `kvpb.ScanStats` object into the trace for
each evaluated Get, Scan, and ReverseScan command. This was suboptimal
for two reasons:
- this required an allocation of that `kvpb.ScanStats` object
- this required propagating all of these separate objects via the
tracing infrastructure which might make it so that the tracing limits
are reached resulting in some objects being dropped.

This commit, instead, changes the ScanStats to be tracked at the
BatchRequest level, thus, we only need to record a single object per
BatchRequest. This results in reduced granularity, but that is still
sufficient for the SQL needs which simply aggregates all
`kvpb.ScanStats` from a single SQL processor into one object. As
a result, the tpch_concurrency metric averaged over 20 runs increased
from 76.75 to 84.75.

Additionally, this commit makes it so that we track the number of Gets,
Scans, and ReverseScans actually evaluated as part of the BatchResponse.
This information is plumbed through a couple of protos but is not
exposed in any SQL Observability virtual tables. Still, due to having it
in the protos will include this information into the trace.

Informs: #64906.
Fixes: #71351.

Release note: None

Release justification: stability improvement.