### PR TITLE
cli,server: set GOMEMLIMIT by default

### DIFF
--- a/pkg/cli/cliflags/flags.go
+++ b/pkg/cli/cliflags/flags.go
@@ -159,6 +159,20 @@ percentage of physical memory (e.g. .25). If left unspecified, defaults to 25% o
 physical memory.`,
 	}
 
+	GoMemLimit = FlagInfo{
+		Name: "max-go-memory",
+		Description: `
+Soft memory limit set on the Go runtime (which is also configurable via the
+GOMEMLIMIT environment variable, but --max-go-memory has higher precedence if
+both are set). Notably, the pebble cache (as configured by --cache) is not under
+control of the Go runtime and should not be considered when determining this
+soft memory limit. Accepts numbers interpreted as bytes, size suffixes (e.g. 1GB
+and 1GiB) or a percentage of physical memory (e.g. .25). If left unspecified,
+defaults to 2.25x of --max-sql-memory (subject to max-go-memory + 1.15x --cache
+not exceeding 90% of available RAM). Set to 0 to disable the soft memory limit
+(not recommended).`,
+	}
+
 	TSDBMem = FlagInfo{
 		Name: "max-tsdb-memory",
 		Description: `

--- a/pkg/cli/context.go
+++ b/pkg/cli/context.go
@@ -490,6 +490,7 @@ var startCtx struct {
 	// humanized size value.
 	cacheSizeValue           bytesOrPercentageValue
 	sqlSizeValue             bytesOrPercentageValue
+	goMemLimitValue          bytesOrPercentageValue
 	diskTempStorageSizeValue bytesOrPercentageValue
 	tsdbSizeValue            bytesOrPercentageValue
 }
@@ -514,6 +515,7 @@ func setStartContextDefaults() {
 	startCtx.geoLibsDir = "/usr/local/lib/cockroach"
 	startCtx.cacheSizeValue = makeBytesOrPercentageValue(&serverCfg.CacheSize, memoryPercentResolver)
 	startCtx.sqlSizeValue = makeBytesOrPercentageValue(&serverCfg.MemoryPoolSize, memoryPercentResolver)
+	startCtx.goMemLimitValue = makeBytesOrPercentageValue(&goMemLimit, memoryPercentResolver)
 	startCtx.diskTempStorageSizeValue = makeBytesOrPercentageValue(nil /* v */, nil /* percentResolver */)
 	startCtx.tsdbSizeValue = makeBytesOrPercentageValue(&serverCfg.TimeSeriesServerConfig.QueryMemoryMax, memoryPercentResolver)
 }

--- a/pkg/cli/flags.go
+++ b/pkg/cli/flags.go
@@ -59,6 +59,7 @@ var serverHTTPAdvertiseAddr, serverHTTPAdvertisePort string
 var localityAdvertiseHosts localityList
 var startBackground bool
 var storeSpecs base.StoreSpecList
+var goMemLimit int64
 
 // initPreFlagsDefaults initializes the values of the global variables
 // defined above.
@@ -87,6 +88,8 @@ func initPreFlagsDefaults() {
 	startBackground = false
 
 	storeSpecs = base.StoreSpecList{}
+
+	goMemLimit = 0
 }
 
 // AddPersistentPreRunE add 'fn' as a persistent pre-run function to 'cmd'.
@@ -513,10 +516,11 @@ func init() {
 			// Engine flags.
 			cliflagcfg.VarFlag(f, &startCtx.cacheSizeValue, cliflags.Cache)
 			cliflagcfg.VarFlag(f, &startCtx.sqlSizeValue, cliflags.SQLMem)
+			cliflagcfg.VarFlag(f, &startCtx.goMemLimitValue, cliflags.GoMemLimit)
 			cliflagcfg.VarFlag(f, &startCtx.tsdbSizeValue, cliflags.TSDBMem)
-			// N.B. diskTempStorageSizeValue.ResolvePercentage() will be called after
-			// the stores flag has been parsed and the storage device that a percentage
-			// refers to becomes known.
+			// N.B. diskTempStorageSizeValue.Resolve() will be called after the
+			// stores flag has been parsed and the storage device that a
+			// percentage refers to becomes known.
 			cliflagcfg.VarFlag(f, &startCtx.diskTempStorageSizeValue, cliflags.SQLTempStorage)
 			cliflagcfg.StringFlag(f, &startCtx.tempDir, cliflags.TempDir)
 			cliflagcfg.StringFlag(f, &startCtx.externalIODir, cliflags.ExternalIODir)

--- a/pkg/cli/flags_test.go
+++ b/pkg/cli/flags_test.go
@@ -21,6 +21,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"regexp"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -189,6 +190,73 @@ func TestMemoryPoolFlagValues(t *testing.T) {
 				if *tc.config < expectedLow || *tc.config > expectedHigh {
 					t.Errorf("expected %d-%d, but got %d", expectedLow, expectedHigh, *tc.config)
 				}
+			}
+		})
+	}
+}
+
+func TestGetDefaultGoMemLimitValue(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	maxMem, err := status.GetTotalMemory(context.Background())
+	if err != nil {
+		t.Logf("total memory unknown: %v", err)
+		return
+	}
+	if maxMem < 1<<30 /* 1GiB */ {
+		// The test assumes that it is running on a machine with at least 1GiB
+		// of RAM.
+		skip.IgnoreLint(t)
+	}
+
+	// highCachePercentage is such that --cache would be set too high resulting
+	// in the upper bound on the goMemLimit becoming negative, so we'd use the
+	// lower bound.
+	highCachePercentage := defaultGoMemLimitMaxTotalSystemMemUsage/defaultGoMemLimitCacheSlopMultiple + 0.02
+
+	for i, tc := range []struct {
+		maxSQLMemory string
+		cache        string
+		expected     int64
+	}{
+		{
+			maxSQLMemory: "100MiB",
+			cache:        "100MiB",
+			// The default calculation says 225MiB which is smaller than the
+			// lower bound, so we use the latter.
+			expected: defaultGoMemLimitMinValue,
+		},
+		{
+			maxSQLMemory: "200MiB",
+			cache:        "100MiB",
+			// The default 2.25x of --max-sql-memory.
+			expected: defaultGoMemLimitSQLMultiple * 200 << 20, /* 450MiB */
+		},
+		{
+			maxSQLMemory: "200MiB",
+			cache:        fmt.Sprintf("%.2f", highCachePercentage),
+			expected:     defaultGoMemLimitMinValue,
+		},
+	} {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			// Avoid leaking configuration changes after the test ends.
+			defer initCLIDefaults()
+
+			f := startCmd.Flags()
+
+			args := []string{
+				"--max-sql-memory", tc.maxSQLMemory,
+				"--cache", tc.cache,
+			}
+			if err := f.Parse(args); err != nil {
+				t.Fatal(err)
+			}
+			limit := getDefaultGoMemLimit(context.Background())
+			// Allow for some imprecision since we're dealing with float
+			// arithmetic but the result is converted to integer.
+			if diff := tc.expected - limit; diff > 1 || diff < -1 {
+				t.Errorf("expected %d, but got %d", tc.expected, limit)
 			}
 		})
 	}

--- a/pkg/cli/start.go
+++ b/pkg/cli/start.go
@@ -21,6 +21,7 @@ import (
 	"os/signal"
 	"path/filepath"
 	"runtime"
+	"runtime/debug"
 	"strings"
 	"time"
 
@@ -537,6 +538,48 @@ func runStartInternal(
 	// Now perform additional configuration tweaks specific to the start
 	// command.
 
+	// Set the soft memory limit on the Go runtime.
+	if err = func() error {
+		if startCtx.goMemLimitValue.IsSet() {
+			if goMemLimit < 0 {
+				return errors.New("--max-go-memory must be non-negative")
+			} else if goMemLimit > 0 && goMemLimit < defaultGoMemLimitMinValue {
+				log.Ops.Shoutf(
+					ctx, severity.WARNING, "--max-go-memory (%s) is smaller "+
+						"than the recommended minimum (%s), consider increasing it",
+					humanizeutil.IBytes(goMemLimit), humanizeutil.IBytes(defaultGoMemLimitMinValue),
+				)
+			}
+		} else {
+			if _, envVarSet := os.LookupEnv("GOMEMLIMIT"); envVarSet {
+				// When --max-go-memory is not specified, but the env var is
+				// set, we don't change it.
+				if envVarLimit := envutil.EnvOrDefaultInt64("GOMEMLIMIT", -1); envVarLimit < defaultGoMemLimitMinValue {
+					log.Ops.Shoutf(
+						ctx, severity.WARNING, "GOMEMLIMIT (%s) is smaller "+
+							"than the recommended minimum (%s), consider increasing it",
+						humanizeutil.IBytes(envVarLimit), humanizeutil.IBytes(defaultGoMemLimitMinValue),
+					)
+				}
+				return nil
+			}
+			// If --max-go-memory wasn't specified, we set it to a reasonable
+			// default value.
+			goMemLimit = getDefaultGoMemLimit(ctx)
+		}
+		if goMemLimit == 0 {
+			// Value of 0 indicates that the soft memory limit should be
+			// disabled.
+			goMemLimit = math.MaxInt64
+		} else {
+			log.Ops.Infof(ctx, "soft memory limit of Go runtime is set to %s", humanizeutil.IBytes(goMemLimit))
+		}
+		debug.SetMemoryLimit(goMemLimit)
+		return nil
+	}(); err != nil {
+		return err
+	}
+
 	// Initialize the node's configuration from startup parameters.
 	// This also reads the part of the configuration that comes from
 	// environment variables.
@@ -608,6 +651,83 @@ If problems persist, please see %s.`
 		// asynchronously in a goroutine above.
 		stopper, serverShutdownReqC, signalCh,
 		srvStatus)
+}
+
+const (
+	// defaultGoMemLimitSQLMultiple determines the multiple of SQL memory pool
+	// size that we use in the calculation of the default value of the
+	// goMemLimit.
+	//
+	// Since not every memory allocation is registered with the memory
+	// accounting system of CRDB, we need to give it some room to prevent Go GC
+	// from being too aggressive to stay under the GOMEMLIMIT. The default
+	// multiple of 2.25x over the memory pool size should give enough room for
+	// those unaccounted for allocations.
+	defaultGoMemLimitSQLMultiple = 2.25
+
+	// Lower bound on the default value for goMemLimit. Lower bound has higher
+	// precedence that the upper bound when two bounds conflict with each other.
+
+	// defaultGoMemLimitMinValue determines the lower bound on the default value
+	// of the goMemLimit.
+	defaultGoMemLimitMinValue = 256 << 20 /* 256MiB */
+
+	// Upper bound on the default value for goMemLimit is computed as follows:
+	//
+	//   upper bound = 0.9 * SystemMemory - 1.15 * PebbleCache
+	//
+	// The rationale for this formula is as follows:
+	// - we don't want for the estimated max memory usage to exceed 90% of the
+	// available RAM to prevent the OOMs
+	// - Go runtime doesn't control the pebble cache, so we need to subtract it
+	// - anecdotally, the pebble cache can have some slop over its target size
+	// (perhaps, due to memory fragmentation), so we adjust the footprint of the
+	// cache by 15%.
+
+	// defaultGoMemLimitMaxTotalSystemMemUsage determines the maximum percentage
+	// of the system memory that goMemLimit and the pebble cache can use
+	// together.
+	defaultGoMemLimitMaxTotalSystemMemUsage = 0.9
+	// defaultGoMemLimitCacheSlopMultiple determines a "slop" multiple that we
+	// use on top of the pebble cache size when computing the upper bound.
+	defaultGoMemLimitCacheSlopMultiple = 1.15
+)
+
+// getDefaultGoMemLimit returns a reasonable default value for the soft memory
+// limit of the Go runtime based on SQL memory pool and the cache sizes (which
+// must be already set in serverCfg). It also warns the user in some cases when
+// suboptimal flags or hardware is detected.
+func getDefaultGoMemLimit(ctx context.Context) int64 {
+	sysMem, err := status.GetTotalMemory(ctx)
+	if err != nil {
+		return 0
+	}
+	maxGoMemLimit := int64(defaultGoMemLimitMaxTotalSystemMemUsage*float64(sysMem) -
+		defaultGoMemLimitCacheSlopMultiple*float64(serverCfg.CacheSize))
+	if maxGoMemLimit < defaultGoMemLimitMinValue {
+		// Most likely, --cache is set to at least 75% of available RAM which
+		// has already triggered a warning in maybeWarnMemorySizes(), so we
+		// don't shout here.
+		maxGoMemLimit = defaultGoMemLimitMinValue
+	}
+	limit := int64(defaultGoMemLimitSQLMultiple * float64(serverCfg.MemoryPoolSize))
+	if limit < defaultGoMemLimitMinValue {
+		log.Ops.Shoutf(
+			ctx, severity.WARNING, "--max-sql-memory (%s) is set too low, "+
+				"consider increasing it", humanizeutil.IBytes(serverCfg.MemoryPoolSize),
+		)
+		limit = defaultGoMemLimitMinValue
+	}
+	if limit > maxGoMemLimit {
+		log.Ops.Shoutf(
+			ctx, severity.WARNING, "recommended default value of "+
+				"--max-go-memory (%s) was truncated to %s, consider reducing "+
+				"--max-sql-memory and / or --cache",
+			humanizeutil.IBytes(limit), humanizeutil.IBytes(maxGoMemLimit),
+		)
+		limit = maxGoMemLimit
+	}
+	return limit
 }
 
 // createAndStartServerAsync starts an async goroutine which instantiates
@@ -1232,6 +1352,8 @@ func maybeWarnMemorySizes(ctx context.Context) {
 	// Check that the total suggested "max" memory is well below the available memory.
 	if maxMemory, err := status.GetTotalMemory(ctx); err == nil {
 		requestedMem := serverCfg.CacheSize + serverCfg.MemoryPoolSize + serverCfg.TimeSeriesServerConfig.QueryMemoryMax
+		// TODO(yuzefovich): we might want to adjust this warning higher now
+		// that GOMEMLIMIT is used.
 		maxRecommendedMem := int64(.75 * float64(maxMemory))
 		if requestedMem > maxRecommendedMem {
 			log.Ops.Shoutf(ctx, severity.WARNING,

--- a/pkg/testutils/lint/lint_test.go
+++ b/pkg/testutils/lint/lint_test.go
@@ -476,6 +476,7 @@ func TestLint(t *testing.T) {
 					":!util/grpcutil",                     // GRPC_GO_* variables
 					":!roachprod",                         // roachprod requires AWS environment variables
 					":!cli/env.go",                        // The CLI needs the PGHOST variable.
+					":!cli/start.go",                      // The CLI needs the GOMEMLIMIT variable.
 					":!internal/codeowners/codeowners.go", // For BAZEL_TEST.
 					":!internal/team/team.go",             // For BAZEL_TEST.
 				},


### PR DESCRIPTION
This commit introduces new `--max-go-memory` flag to CLI `start` command
which controls the soft memory limit set on the Go runtime. The default
value for this flag is computed as `2.25x --max-sql-memory` (which
should give enough room for allocations not registered with our memory
accounting system), subject to not exceeding `90% RAM - 1.15x pebble cache`.
The rationale for this upper bound is as follows:
- we don't want for the estimated max memory usage to exceed 90% of the
available RAM to prevent the OOMs
- Go runtime doesn't control the pebble cache, so we need to subtract it
- anecdotally, the pebble cache can have some slop over its target size
(perhaps, due to memory fragmentation), so we adjust the footprint of the
cache by 15%.

The lower bound on the default value is set to 256MiB.

Fixes: #95690.

Release note (cli change): New flag `--max-go-memory` is introduced to
`start` command. It controls the soft memory limit on the Go runtime
which adjusts the behavior of the Go garbage collector to try keeping the
memory usage under the soft memory limit (the limit is "soft" in a sense
that it is not enforced if live objects (RSS) exceed it). Similar to the
`--max-sql-memory` flag, the new flag `--max-go-memory` accepts numbers
interpreted as bytes, size suffixes (e.g. 1GB and 1GiB) or a percentage
of physical memory (e.g. .25). If left unspecified, the flag defaults to
2.25x of `--max-sql-memory` (subject to `--max-go-memory + 1.15x --cache`
not exceeding 90% of available RAM). Set to 0 to disable the soft memory
limit (not recommended). If GOMEMLIMIT env var is set and
`--max-go-memory` is not, then the value from the env var is used; if
both are set, then the flag takes precedence.

Here is a few examples of how the default value is calculated on
a machine with 16GiB of RAM:

| Command line flags | Computed max SQL memory | Computed cache size | Computed max Go memory |
| --- | --- | --- | --- |
| --max-sql-memory=.25 --cache=.25 | 4GiB | 4GiB | 9GiB |
| --max-sql-memory=.1 --cache=.5 | 1.6GiB | 8GiB | 3.6GiB |
| --max-sql-memory=.25 --cache=.4 | 4GiB | 6.4GiB | 7.04GiB |
| --max-sql-memory=100MiB | 100MiB | 128MiB | 256MiB |
| --max-sql-memory=.4 --cache=.2 --max-go-memory=100MiB | 6.4GiB | 3.2GiB | 100MiB |

Explanation:
- in the first two lines we just use the default formula `2.25x --max-sql-memory`
- in the third line, the default formula results in exceeding the upper
bound on total usage (including the cache), so we use the upper bound
determined as `0.9 * total RAM - 1.15 * cache size`
- in the fourth line, the default formula results in 225MiB which is
smaller than the lower bound of 256MiB, so we bump the value to that
lower bound
- in the fifth line, we use the value specified by the user (even though
it is smaller than the lower bound on the default value).

Release note (general change): CockroachDB now uses the soft memory
limit of Go runtime by default. This feature of Go has been available
since 22.2 version by setting GOMEMLIMIT environment variable and was
opt-in for 22.2. Now it is enabled by default which should reduce the
likelihood of CockroachDB process OOMing. This soft memory limit can be
disabled by specifying `--max-go-memory=0` in `cockroach start`.