### PR TITLE
release-22.2: sql: disallow dropping column referenced in partial index predicate

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/partial_index
+++ b/pkg/sql/logictest/testdata/logic_test/partial_index
@@ -186,7 +186,8 @@ CREATE TABLE t8 (
     FAMILY (a, b, c)
 )
 
-statement ok
+# TODO(mgartner): Lift this restriction. See #96924.
+statement error column "c" cannot be dropped because it is referenced by partial index "t8_a_idx1"
 ALTER TABLE t8 DROP COLUMN c
 
 query TT
@@ -195,10 +196,12 @@ SHOW CREATE TABLE t8
 t8  CREATE TABLE public.t8 (
       a INT8 NULL,
       b INT8 NULL,
+      c STRING NULL,
       rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
       CONSTRAINT t8_pkey PRIMARY KEY (rowid ASC),
       INDEX t8_a_idx (a ASC) WHERE b > 0:::INT8,
-      FAMILY fam_0_a_b_c_rowid (a, b, rowid)
+      INDEX t8_a_idx1 (a ASC) WHERE c = 'foo':::STRING,
+      FAMILY fam_0_a_b_c_rowid (a, b, c, rowid)
     )
 
 # CREATE TABLE LIKE ... INCLUDING INDEXES copies partial index predicate
@@ -1911,3 +1914,102 @@ BEGIN;
 COMMIT;
 SELECT * FROM t79613;
 DROP TABLE t79613;
+
+
+# Regression test for #96924 to disallow dropping a column that is referenced in
+# a partial index predicate.
+subtest column_dropped_referenced_in_partial_index
+
+statement ok
+SET experimental_enable_unique_without_index_constraints = true
+
+statement ok
+CREATE TABLE t96924 (
+  a INT,
+  b INT,
+  c INT,
+  d INT,
+  e INT,
+  f JSON,
+  g INT,
+  h INT,
+  i INT,
+  INDEX (a) WHERE (b > 0),
+  UNIQUE INDEX (b) WHERE (b > 0),
+  UNIQUE (c) WHERE (c > 0),
+  UNIQUE WITHOUT INDEX (d) WHERE (d > 0),
+  INVERTED INDEX (e, f) WHERE (e > 0),
+  INDEX (g) WHERE (h > 0),
+  UNIQUE WITHOUT INDEX (g) WHERE (i > 0)
+)
+
+# Column `a` can be dropped because it is not referenced in any partial index
+# predicates.
+statement ok
+ALTER TABLE t96924 DROP COLUMN a
+
+statement error pq: column "b" cannot be dropped because it is referenced by partial index "t96924_b_key"
+ALTER TABLE t96924 DROP COLUMN b
+
+statement ok
+DROP INDEX t96924_b_key CASCADE
+
+statement ok
+ALTER TABLE t96924 DROP COLUMN b
+
+statement error pq: column "c" cannot be dropped because it is referenced by partial index "t96924_c_key"
+ALTER TABLE t96924 DROP COLUMN c
+
+statement ok
+DROP INDEX t96924_c_key CASCADE
+
+statement ok
+ALTER TABLE t96924 DROP COLUMN c
+
+statement error pq: column "d" cannot be dropped because it is referenced by partial unique constraint "unique_d"
+ALTER TABLE t96924 DROP COLUMN d
+
+statement ok
+ALTER TABLE t96924 DROP CONSTRAINT unique_d
+
+statement ok
+ALTER TABLE t96924 DROP COLUMN d
+
+statement error pq: column "e" cannot be dropped because it is referenced by partial index "t96924_e_f_idx"
+ALTER TABLE t96924 DROP COLUMN e
+
+statement ok
+DROP INDEX t96924_e_f_idx CASCADE
+
+statement ok
+ALTER TABLE t96924 DROP COLUMN e
+
+# Column `f` can be dropped because it is not referenced in any partial index
+# predicates.
+statement ok
+ALTER TABLE t96924 DROP COLUMN f
+
+# Column `h` is used in the predicate of another index that does not key on `h`,
+# we will prevent dropping column `h` as well.
+statement error pq: column "h" cannot be dropped because it is referenced by partial index "t96924_g_idx"
+ALTER TABLE t96924 DROP COLUMN h
+
+statement ok
+DROP INDEX t96924_g_idx
+
+statement ok
+ALTER TABLE t96924 DROP COLUMN h
+
+# Similarly, column `i` cannot be dropped since it's used in the predicate of
+# of a UWI constraint.
+statement error pq: column "i" cannot be dropped because it is referenced by partial unique constraint "unique_g"
+ALTER TABLE t96924 DROP COLUMN i
+
+statement ok
+ALTER TABLE t96924 DROP CONSTRAINT unique_g
+
+statement ok
+ALTER TABLE t96924 DROP COLUMN i
+
+statement ok
+ALTER TABLE t96924 DROP COLUMN g

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_table_alter_primary_key.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_table_alter_primary_key.go
@@ -506,6 +506,40 @@ func mustRetrieveKeyIndexColumns(
 	return indexColumns
 }
 
+func mustRetrieveIndexNameElem(
+	b BuildCtx, tableID catid.DescID, indexID catid.IndexID,
+) (indexNameElem *scpb.IndexName) {
+	scpb.ForEachIndexName(b.QueryByID(tableID), func(
+		current scpb.Status, target scpb.TargetStatus, e *scpb.IndexName,
+	) {
+		if e.IndexID == indexID {
+			indexNameElem = e
+		}
+	})
+	if indexNameElem == nil {
+		panic(errors.AssertionFailedf("programming error: cannot find an index name element "+
+			"with ID %v from table %v", indexID, tableID))
+	}
+	return indexNameElem
+}
+
+func mustRetrieveConstraintWithoutIndexNameElem(
+	b BuildCtx, tableID catid.DescID, constraintID catid.ConstraintID,
+) (constraintWithoutIndexName *scpb.ConstraintName) {
+	scpb.ForEachConstraintName(b.QueryByID(tableID), func(
+		current scpb.Status, target scpb.TargetStatus, e *scpb.ConstraintName,
+	) {
+		if e.ConstraintID == constraintID {
+			constraintWithoutIndexName = e
+		}
+	})
+	if constraintWithoutIndexName == nil {
+		panic(errors.AssertionFailedf("programming error: cannot find a constraint name "+
+			"element with ID %v from table %v", constraintID, tableID))
+	}
+	return constraintWithoutIndexName
+}
+
 func checkIfConstraintNameAlreadyExists(b BuildCtx, tbl *scpb.Table, t alterPrimaryKeySpec) {
 	if t.Name == "" {
 		return

--- a/pkg/sql/schemachanger/scpb/elements.proto
+++ b/pkg/sql/schemachanger/scpb/elements.proto
@@ -323,6 +323,8 @@ message UniqueWithoutIndexConstraint {
   uint32 table_id = 1 [(gogoproto.customname) = "TableID", (gogoproto.casttype) = "github.com/cockroachdb/cockroach/pkg/sql/sem/catid.DescID"];
   uint32 constraint_id = 2 [(gogoproto.customname) = "ConstraintID", (gogoproto.casttype) = "github.com/cockroachdb/cockroach/pkg/sql/sem/catid.ConstraintID"];
   repeated uint32 column_ids = 3 [(gogoproto.customname) = "ColumnIDs", (gogoproto.casttype) = "github.com/cockroachdb/cockroach/pkg/sql/sem/catid.ColumnID"];
+  // Predicate, if non-nil, means a partial uniqueness constraint.
+  Expression predicate = 4 [(gogoproto.customname) = "Predicate"];
 }
 
 message CheckConstraint {

--- a/pkg/sql/schemachanger/scpb/uml/table.puml
+++ b/pkg/sql/schemachanger/scpb/uml/table.puml
@@ -75,6 +75,7 @@ object UniqueWithoutIndexConstraint
 UniqueWithoutIndexConstraint :  TableID
 UniqueWithoutIndexConstraint :  ConstraintID
 UniqueWithoutIndexConstraint : []ColumnIDs
+UniqueWithoutIndexConstraint :  Predicate
 
 object CheckConstraint
 

--- a/pkg/sql/sqlerrors/errors.go
+++ b/pkg/sql/sqlerrors/errors.go
@@ -265,6 +265,35 @@ func NewColumnReferencedByComputedColumnError(droppingColumn, computedColumn str
 	)
 }
 
+// NewColumnReferencedByPartialIndex is returned when we drop a column that is
+// referenced in a partial index's predicate.
+func NewColumnReferencedByPartialIndex(droppingColumn, partialIndex string) error {
+	return errors.WithIssueLink(errors.WithHint(
+		pgerror.Newf(
+			pgcode.InvalidColumnReference,
+			"column %q cannot be dropped because it is referenced by partial index %q",
+			droppingColumn, partialIndex,
+		),
+		"drop the partial index first, then drop the column",
+	), errors.IssueLink{IssueURL: "https://github.com/cockroachdb/cockroach/pull/97372"})
+}
+
+// NewColumnReferencedByPartialUniqueWithoutIndexConstraint is almost the same as
+// NewColumnReferencedByPartialIndex except it's used when dropping column that is
+// referenced in a partial unique without index constraint's predicate.
+func NewColumnReferencedByPartialUniqueWithoutIndexConstraint(
+	droppingColumn, partialUWIConstraint string,
+) error {
+	return errors.WithIssueLink(errors.WithHint(
+		pgerror.Newf(
+			pgcode.InvalidColumnReference,
+			"column %q cannot be dropped because it is referenced by partial unique constraint %q",
+			droppingColumn, partialUWIConstraint,
+		),
+		"drop the unique constraint first, then drop the column",
+	), errors.IssueLink{IssueURL: "https://github.com/cockroachdb/cockroach/pull/97372"})
+}
+
 // NewUniqueConstraintReferencedByForeignKeyError generates an error to be
 // returned when dropping a unique constraint that is relied upon by an
 // inbound foreign key constraint.


### PR DESCRIPTION
Backport 1/1 commits from https://github.com/cockroachdb/cockroach/pull/97372.

One major change I made to make the backport work is I need to introduce the `Predicate` field in the `UniqueWithoutIndex` element.

/cc https://github.com/orgs/cockroachdb/teams/release

---

Informs #96924

Release note (bug fix/sql change): Columns referenced in partial index predicates and partial unique constraint predicates can no longer be dropped. The `ALTER TABLE .. DROP COLUMN` statement now returns an error with a hint suggesting to drop the indexes and constraints first. This is a temporary safe-guard to prevent users from hitting #96924. This restriction will be lifted when that bug is fixed.

Release justification: bug fix