### PR TITLE
rangefeed: Metamorphically use mux rangefeed in tests

### DIFF
--- a/pkg/kv/kvclient/rangefeed/BUILD.bazel
+++ b/pkg/kv/kvclient/rangefeed/BUILD.bazel
@@ -22,6 +22,7 @@ go_library(
         "//pkg/roachpb",
         "//pkg/settings",
         "//pkg/settings/cluster",
+        "//pkg/util",
         "//pkg/util/admission/admissionpb",
         "//pkg/util/ctxgroup",
         "//pkg/util/hlc",


### PR DESCRIPTION
Enable mux rangefeed in tests using rangefeed library.

Epic: None
Release note: None