### PR TITLE
kvserver: clean-ups around ProposalData

### DIFF
--- a/pkg/kv/kvserver/replica_evaluate.go
+++ b/pkg/kv/kvserver/replica_evaluate.go
@@ -148,6 +148,8 @@ func optimizePuts(
 // evaluateBatch evaluates a batch request by splitting it up into its
 // individual commands, passing them to evaluateCommand, and combining
 // the results.
+//
+// evaluateBatch is called both on the read-only and read-write path.
 func evaluateBatch(
 	ctx context.Context,
 	idKey kvserverbase.CmdIDKey,

--- a/pkg/kv/kvserver/replica_proposal.go
+++ b/pkg/kv/kvserver/replica_proposal.go
@@ -736,7 +736,7 @@ func (r *Replica) evaluateProposal(
 	// proposal is expensive.
 	//
 	// Note that, during evaluation, ba's read and write timestamps might get
-	// bumped (see evaluateWriteBatchWithServersideRefreshes).
+	// bumped (see evaluateReadWriteBatchWithServersideRefreshes).
 	//
 	// TODO(tschottdorf): absorb all returned values in `res` below this point
 	// in the call stack as well.

--- a/pkg/kv/kvserver/replica_raft.go
+++ b/pkg/kv/kvserver/replica_raft.go
@@ -189,7 +189,7 @@ func (r *Replica) evalAndPropose(
 	// return a proposal result immediately on the proposal's done channel.
 	// The channel's capacity will be large enough to accommodate this.
 	if ba.AsyncConsensus {
-		if ets := proposal.Local.DetachEndTxns(false /* alwaysOnly */); len(ets) != 0 {
+		if ets := proposal.Local.EndTxns; len(ets) != 0 {
 			// Disallow async consensus for commands with EndTxnIntents because
 			// any !Always EndTxnIntent can't be cleaned up until after the
 			// command succeeds.


### PR DESCRIPTION
See individual commits:

- kvserver: split requestToProposal
- kvserver: reorder fields in ProposalData
- kvserver: avoid mutation on an error path
- kvserver: `write` -> `readWrite` in a few methods

Epic: none
Release Note: none
