### PR TITLE
changefeedccl: Lower memory allowance per changefeed

### DIFF
--- a/pkg/cmd/roachtest/tests/admission_control_elastic_cdc.go
+++ b/pkg/cmd/roachtest/tests/admission_control_elastic_cdc.go
@@ -96,6 +96,13 @@ func registerElasticControlForCDC(r registry.Registry) {
 						if _, err := db.Exec("SET CLUSTER SETTING kv.rangefeed.enabled = true"); err != nil {
 							return err
 						}
+						// By default, each changefeed can use up to 512MB of memory from root monitor.
+						// We will start 10 changefeeds, and potentially, we can reserve 5GB from main
+						// memory monitor.  That's a bit too much when running this test on smaller, 8G
+						// machines.  Lower the memory allowance.
+						if _, err := db.Exec("SET CLUSTER SETTING changefeed.memory.per_changefeed_limit = '128MB'"); err != nil {
+							return err
+						}
 					}
 
 					stopFeeds(db) // stop stray feeds (from repeated runs against the same cluster for ex.)


### PR DESCRIPTION
Lower memory allowance to 128MB in `admission-control/elastic-cdc` since we start 10 changefeeds, and those could use up too much memory from the sql monitor, resulting in query failures.

Fixes #96542
Release note: None