### PR TITLE
multitenant: add AdminUnsplitRequest capability

### DIFF
--- a/pkg/ccl/backupccl/testdata/backup-restore/restore-tenants
+++ b/pkg/ccl/backupccl/testdata/backup-restore/restore-tenants
@@ -29,9 +29,9 @@ CREATE DATABASE db1;
 query-sql
 SELECT id,name,data_state,service_mode,active,crdb_internal.pb_to_json('cockroach.multitenant.ProtoInfo', info, true) FROM system.tenants;
 ----
-1 system 1 2 true {"capabilities": {"canAdminSplit": false, "canViewNodeInfo": false, "canViewTsdbMetrics": false, "spanConfigBounds": null}, "deprecatedDataState": "READY", "deprecatedId": "1", "droppedName": "", "tenantReplicationJobId": "0"}
-5 <nil> 2 0 false {"capabilities": {"canAdminSplit": false, "canViewNodeInfo": false, "canViewTsdbMetrics": false, "spanConfigBounds": null}, "deprecatedDataState": "DROP", "deprecatedId": "5", "droppedName": "tenant-5", "tenantReplicationJobId": "0"}
-6 tenant-6 1 1 true {"capabilities": {"canAdminSplit": false, "canViewNodeInfo": false, "canViewTsdbMetrics": false, "spanConfigBounds": null}, "deprecatedDataState": "READY", "deprecatedId": "6", "droppedName": "", "tenantReplicationJobId": "0"}
+1 system 1 2 true {"capabilities": {"canAdminSplit": false, "canAdminUnsplit": false, "canViewNodeInfo": false, "canViewTsdbMetrics": false, "spanConfigBounds": null}, "deprecatedDataState": "READY", "deprecatedId": "1", "droppedName": "", "tenantReplicationJobId": "0"}
+5 <nil> 2 0 false {"capabilities": {"canAdminSplit": false, "canAdminUnsplit": false, "canViewNodeInfo": false, "canViewTsdbMetrics": false, "spanConfigBounds": null}, "deprecatedDataState": "DROP", "deprecatedId": "5", "droppedName": "tenant-5", "tenantReplicationJobId": "0"}
+6 tenant-6 1 1 true {"capabilities": {"canAdminSplit": false, "canAdminUnsplit": false, "canViewNodeInfo": false, "canViewTsdbMetrics": false, "spanConfigBounds": null}, "deprecatedDataState": "READY", "deprecatedId": "6", "droppedName": "", "tenantReplicationJobId": "0"}
 
 exec-sql
 BACKUP INTO 'nodelocal://1/cluster_without_tenants'
@@ -81,8 +81,8 @@ job paused at pausepoint
 query-sql
 SELECT id,active,crdb_internal.pb_to_json('cockroach.multitenant.ProtoInfo', info, true) FROM system.tenants;
 ----
-1 true {"capabilities": {"canAdminSplit": false, "canViewNodeInfo": false, "canViewTsdbMetrics": false, "spanConfigBounds": null}, "deprecatedDataState": "READY", "deprecatedId": "1", "droppedName": "", "tenantReplicationJobId": "0"}
-6 false {"capabilities": {"canAdminSplit": false, "canViewNodeInfo": false, "canViewTsdbMetrics": false, "spanConfigBounds": null}, "deprecatedDataState": "ADD", "deprecatedId": "6", "droppedName": "", "tenantReplicationJobId": "0"}
+1 true {"capabilities": {"canAdminSplit": false, "canAdminUnsplit": false, "canViewNodeInfo": false, "canViewTsdbMetrics": false, "spanConfigBounds": null}, "deprecatedDataState": "READY", "deprecatedId": "1", "droppedName": "", "tenantReplicationJobId": "0"}
+6 false {"capabilities": {"canAdminSplit": false, "canAdminUnsplit": false, "canViewNodeInfo": false, "canViewTsdbMetrics": false, "spanConfigBounds": null}, "deprecatedDataState": "ADD", "deprecatedId": "6", "droppedName": "", "tenantReplicationJobId": "0"}
 
 exec-sql
 SET CLUSTER SETTING jobs.debug.pausepoints = ''
@@ -102,8 +102,8 @@ USE defaultdb;
 query-sql
 SELECT id,name,data_state,service_mode,active,crdb_internal.pb_to_json('cockroach.multitenant.ProtoInfo', info, true) FROM system.tenants;
 ----
-1 system 1 2 true {"capabilities": {"canAdminSplit": false, "canViewNodeInfo": false, "canViewTsdbMetrics": false, "spanConfigBounds": null}, "deprecatedDataState": "READY", "deprecatedId": "1", "droppedName": "", "tenantReplicationJobId": "0"}
-6 tenant-6 1 1 true {"capabilities": {"canAdminSplit": false, "canViewNodeInfo": false, "canViewTsdbMetrics": false, "spanConfigBounds": null}, "deprecatedDataState": "READY", "deprecatedId": "6", "droppedName": "", "tenantReplicationJobId": "0"}
+1 system 1 2 true {"capabilities": {"canAdminSplit": false, "canAdminUnsplit": false, "canViewNodeInfo": false, "canViewTsdbMetrics": false, "spanConfigBounds": null}, "deprecatedDataState": "READY", "deprecatedId": "1", "droppedName": "", "tenantReplicationJobId": "0"}
+6 tenant-6 1 1 true {"capabilities": {"canAdminSplit": false, "canAdminUnsplit": false, "canViewNodeInfo": false, "canViewTsdbMetrics": false, "spanConfigBounds": null}, "deprecatedDataState": "READY", "deprecatedId": "6", "droppedName": "", "tenantReplicationJobId": "0"}
 
 
 exec-sql expect-error-regex=(tenant 6 not in backup)
@@ -133,9 +133,9 @@ RESTORE TENANT 6 FROM LATEST IN 'nodelocal://1/tenant6' WITH tenant_name = 'newn
 query-sql
 SELECT id,name,data_state,service_mode,active,crdb_internal.pb_to_json('cockroach.multitenant.ProtoInfo', info, true) FROM system.tenants;
 ----
-1 system 1 2 true {"capabilities": {"canAdminSplit": false, "canViewNodeInfo": false, "canViewTsdbMetrics": false, "spanConfigBounds": null}, "deprecatedDataState": "READY", "deprecatedId": "1", "droppedName": "", "tenantReplicationJobId": "0"}
-2 newname 1 1 true {"capabilities": {"canAdminSplit": false, "canViewNodeInfo": false, "canViewTsdbMetrics": false, "spanConfigBounds": null}, "deprecatedDataState": "READY", "deprecatedId": "2", "droppedName": "", "tenantReplicationJobId": "0"}
-6 tenant-6 1 1 true {"capabilities": {"canAdminSplit": false, "canViewNodeInfo": false, "canViewTsdbMetrics": false, "spanConfigBounds": null}, "deprecatedDataState": "READY", "deprecatedId": "6", "droppedName": "", "tenantReplicationJobId": "0"}
+1 system 1 2 true {"capabilities": {"canAdminSplit": false, "canAdminUnsplit": false, "canViewNodeInfo": false, "canViewTsdbMetrics": false, "spanConfigBounds": null}, "deprecatedDataState": "READY", "deprecatedId": "1", "droppedName": "", "tenantReplicationJobId": "0"}
+2 newname 1 1 true {"capabilities": {"canAdminSplit": false, "canAdminUnsplit": false, "canViewNodeInfo": false, "canViewTsdbMetrics": false, "spanConfigBounds": null}, "deprecatedDataState": "READY", "deprecatedId": "2", "droppedName": "", "tenantReplicationJobId": "0"}
+6 tenant-6 1 1 true {"capabilities": {"canAdminSplit": false, "canAdminUnsplit": false, "canViewNodeInfo": false, "canViewTsdbMetrics": false, "spanConfigBounds": null}, "deprecatedDataState": "READY", "deprecatedId": "6", "droppedName": "", "tenantReplicationJobId": "0"}
 
 # Check that another service mode is also preserved.
 exec-sql

--- a/pkg/ccl/logictestccl/testdata/logic_test/crdb_internal
+++ b/pkg/ccl/logictestccl/testdata/logic_test/crdb_internal
@@ -195,9 +195,11 @@ SELECT * FROM crdb_internal.node_tenant_capabilities_cache
 ----
 tenant_id  capability_id          capability_value
 1          can_admin_split        false
+1          can_admin_unsplit      false
 1          can_view_node_info     false
 1          can_view_tsdb_metrics  false
 5          can_admin_split        false
+5          can_admin_unsplit      false
 5          can_view_node_info     false
 5          can_view_tsdb_metrics  false
 
@@ -210,9 +212,11 @@ SELECT * FROM crdb_internal.node_tenant_capabilities_cache
 ----
 tenant_id  capability_id          capability_value
 1          can_admin_split        false
+1          can_admin_unsplit      false
 1          can_view_node_info     false
 1          can_view_tsdb_metrics  false
 5          can_admin_split        true
+5          can_admin_unsplit      false
 5          can_view_node_info     false
 5          can_view_tsdb_metrics  false
 

--- a/pkg/ccl/logictestccl/testdata/logic_test/tenant_capability
+++ b/pkg/ccl/logictestccl/testdata/logic_test/tenant_capability
@@ -32,6 +32,7 @@ SELECT capability_id, capability_value FROM [SHOW TENANT "no-capabilities-tenant
 ----
 capability_id          capability_value
 can_admin_split        false
+can_admin_unsplit      false
 can_view_node_info     false
 can_view_tsdb_metrics  false
 
@@ -50,6 +51,7 @@ SELECT capability_id, capability_value FROM [SHOW TENANT "bool-capability-no-val
 ----
 capability_id          capability_value
 can_admin_split        true
+can_admin_unsplit      false
 can_view_node_info     false
 can_view_tsdb_metrics  false
 
@@ -61,6 +63,7 @@ SELECT capability_id, capability_value FROM [SHOW TENANT "bool-capability-no-val
 ----
 capability_id          capability_value
 can_admin_split        false
+can_admin_unsplit      false
 can_view_node_info     false
 can_view_tsdb_metrics  false
 
@@ -79,6 +82,7 @@ SELECT capability_id, capability_value FROM [SHOW TENANT "bool-capability-with-v
 ----
 capability_id          capability_value
 can_admin_split        true
+can_admin_unsplit      false
 can_view_node_info     false
 can_view_tsdb_metrics  false
 
@@ -97,6 +101,7 @@ SELECT capability_id, capability_value FROM [SHOW TENANT "bool-capability-with-e
 ----
 capability_id          capability_value
 can_admin_split        true
+can_admin_unsplit      false
 can_view_node_info     false
 can_view_tsdb_metrics  false
 
@@ -115,6 +120,7 @@ SELECT capability_id, capability_value FROM [SHOW TENANT "multiple-capability-te
 ----
 capability_id          capability_value
 can_admin_split        true
+can_admin_unsplit      false
 can_view_node_info     true
 can_view_tsdb_metrics  false
 
@@ -126,6 +132,7 @@ SELECT capability_id, capability_value FROM [SHOW TENANT "multiple-capability-te
 ----
 capability_id          capability_value
 can_admin_split        false
+can_admin_unsplit      false
 can_view_node_info     false
 can_view_tsdb_metrics  false
 

--- a/pkg/ccl/logictestccl/testdata/logic_test/tenant_unsupported
+++ b/pkg/ccl/logictestccl/testdata/logic_test/tenant_unsupported
@@ -45,12 +45,6 @@ SELECT * FROM crdb_internal.kv_node_status
 
 # Cannot perform operations that issue Admin requests.
 
-statement error operation is unsupported in multi-tenancy mode
-ALTER TABLE kv UNSPLIT AT VALUES ('foo')
-
-statement error operation is unsupported in multi-tenancy mode
-ALTER TABLE kv UNSPLIT ALL
-
 statement error tenant cluster setting sql.scatter.allow_for_secondary_tenant.enabled disabled
 ALTER TABLE kv SCATTER
 

--- a/pkg/ccl/multitenantccl/tenantcapabilitiesccl/testdata/can_admin_split
+++ b/pkg/ccl/multitenantccl/tenantcapabilitiesccl/testdata/can_admin_split
@@ -1,9 +1,7 @@
 query-sql-system
-SHOW TENANT [10] WITH CAPABILITIES
+SELECT * FROM [SHOW TENANT [10] WITH CAPABILITIES] WHERE capability_id = 'can_admin_split'
 ----
 10 tenant-10 ready none can_admin_split false
-10 tenant-10 ready none can_view_node_info false
-10 tenant-10 ready none can_view_tsdb_metrics false
 
 exec-sql-tenant
 CREATE TABLE t(a INT)

--- a/pkg/kv/kvpb/BUILD.bazel
+++ b/pkg/kv/kvpb/BUILD.bazel
@@ -36,6 +36,7 @@ go_library(
         "//pkg/util/humanizeutil",
         "//pkg/util/log",
         "//pkg/util/protoutil",
+        "//pkg/util/stringerutil",
         "//pkg/util/uuid",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_cockroachdb_errors//extgrpc",

--- a/pkg/kv/kvpb/method.go
+++ b/pkg/kv/kvpb/method.go
@@ -10,11 +10,20 @@
 
 package kvpb
 
+import "github.com/cockroachdb/cockroach/pkg/util/stringerutil"
+
 // Method is the enumerated type for methods.
 type Method int
 
 // SafeValue implements redact.SafeValue.
 func (Method) SafeValue() {}
+
+var StringToMethodMap = stringerutil.StringToEnumValueMap(
+	_Method_index[:],
+	_Method_name,
+	0,
+	MaxMethod,
+)
 
 //go:generate stringer -type=Method
 const (
@@ -174,6 +183,8 @@ const (
 	// IsSpanEmpty is a non-transaction read request used to determine whether
 	// a span contains any keys whatsoever (garbage or otherwise).
 	IsSpanEmpty
+	// MaxMethod is the maximum method.
+	MaxMethod Method = iota - 1
 	// NumMethods represents the total number of API methods.
 	NumMethods
 )

--- a/pkg/kv/kvpb/method_string.go
+++ b/pkg/kv/kvpb/method_string.go
@@ -57,6 +57,7 @@ func _() {
 	_ = x[Barrier-46]
 	_ = x[Probe-47]
 	_ = x[IsSpanEmpty-48]
+	_ = x[MaxMethod-48]
 	_ = x[NumMethods-49]
 }
 

--- a/pkg/multitenant/tenantcapabilities/capabilities.go
+++ b/pkg/multitenant/tenantcapabilities/capabilities.go
@@ -166,6 +166,12 @@ const (
 	// cluster.
 	CanAdminSplit // can_admin_split
 
+	// CanAdminUnsplit describes the ability of a tenant to perform manual
+	// KV range unsplit requests. These operations need a capability
+	// because excessive KV range unsplits can overwhelm the storage
+	// cluster.
+	CanAdminUnsplit // can_admin_unsplit
+
 	// CanViewNodeInfo describes the ability of a tenant to read the
 	// metadata for KV nodes. These operations need a capability because
 	// the KV node record contains sensitive operational data which we
@@ -215,10 +221,14 @@ const (
 // CapabilityType returns the type of a given capability.
 func (c CapabilityID) CapabilityType() Type {
 	switch c {
-	case CanAdminSplit, CanViewNodeInfo, CanViewTSDBMetrics:
+	case
+		CanAdminSplit,
+		CanAdminUnsplit,
+		CanViewNodeInfo,
+		CanViewTSDBMetrics:
 		return Bool
 
 	default:
-		panic(errors.AssertionFailedf("missing case: %d", c))
+		panic(errors.AssertionFailedf("missing case: %q", c))
 	}
 }

--- a/pkg/multitenant/tenantcapabilities/capabilityid_string.go
+++ b/pkg/multitenant/tenantcapabilities/capabilityid_string.go
@@ -9,15 +9,16 @@ func _() {
 	// Re-run the stringer command to generate them again.
 	var x [1]struct{}
 	_ = x[CanAdminSplit-1]
-	_ = x[CanViewNodeInfo-2]
-	_ = x[CanViewTSDBMetrics-3]
-	_ = x[TenantSpanConfigBounds-4]
-	_ = x[MaxCapabilityID-4]
+	_ = x[CanAdminUnsplit-2]
+	_ = x[CanViewNodeInfo-3]
+	_ = x[CanViewTSDBMetrics-4]
+	_ = x[TenantSpanConfigBounds-5]
+	_ = x[MaxCapabilityID-5]
 }
 
-const _CapabilityID_name = "can_admin_splitcan_view_node_infocan_view_tsdb_metricsspan_config_bounds"
+const _CapabilityID_name = "can_admin_splitcan_admin_unsplitcan_view_node_infocan_view_tsdb_metricsspan_config_bounds"
 
-var _CapabilityID_index = [...]uint8{0, 15, 33, 54, 72}
+var _CapabilityID_index = [...]uint8{0, 15, 32, 50, 71, 89}
 
 func (i CapabilityID) String() string {
 	i -= 1

--- a/pkg/multitenant/tenantcapabilities/tenantcapabilitiesauthorizer/authorizer.go
+++ b/pkg/multitenant/tenantcapabilities/tenantcapabilitiesauthorizer/authorizer.go
@@ -118,7 +118,8 @@ var reqMethodToCap = map[kvpb.Method]tenantcapabilities.CapabilityID{
 	kvpb.Scan:               noCapCheckNeeded,
 
 	// The following are authorized via specific capabilities.
-	kvpb.AdminSplit: tenantcapabilities.CanAdminSplit,
+	kvpb.AdminSplit:   tenantcapabilities.CanAdminSplit,
+	kvpb.AdminUnsplit: tenantcapabilities.CanAdminUnsplit,
 
 	// TODO(ecwall): The following should also be authorized via specific capabilities.
 	kvpb.AdminChangeReplicas: noCapCheckNeeded,
@@ -126,7 +127,6 @@ var reqMethodToCap = map[kvpb.Method]tenantcapabilities.CapabilityID{
 	kvpb.AdminRelocateRange:  noCapCheckNeeded,
 	kvpb.AdminScatter:        noCapCheckNeeded,
 	kvpb.AdminTransferLease:  noCapCheckNeeded,
-	kvpb.AdminUnsplit:        noCapCheckNeeded,
 
 	// TODO(knz,arul): Verify with the relevant teams whether secondary
 	// tenants have legitimate access to any of those.

--- a/pkg/multitenant/tenantcapabilities/tenantcapabilitiesauthorizer/authorizer.go
+++ b/pkg/multitenant/tenantcapabilities/tenantcapabilitiesauthorizer/authorizer.go
@@ -65,7 +65,8 @@ func (a *Authorizer) HasCapabilityForBatch(
 	}
 
 	for _, ru := range ba.Requests {
-		requiredCap, hasCap := reqMethodToCap[ru.GetInner().Method()]
+		request := ru.GetInner()
+		requiredCap, hasCap := reqMethodToCap[request.Method()]
 		if requiredCap == noCapCheckNeeded {
 			continue
 		}
@@ -79,7 +80,7 @@ func (a *Authorizer) HasCapabilityForBatch(
 			// disallowed. This prevents accidents where someone adds a new
 			// sensitive request type in KV and forgets to add an explicit
 			// authorization rule for it here.
-			return errors.Newf("client tenant does not have capability %q (%T)", requiredCap, ru.GetInner())
+			return errors.Newf("client tenant does not have capability %q (%T)", requiredCap, request)
 		}
 	}
 	return nil

--- a/pkg/multitenant/tenantcapabilities/tenantcapabilitiesauthorizer/testdata/basic
+++ b/pkg/multitenant/tenantcapabilities/tenantcapabilitiesauthorizer/testdata/basic
@@ -8,28 +8,28 @@ ok
 
 # Tenant 10 should be able to issue splits, given it has the capability to do
 # so.
-has-capability-for-batch ten=10 cmds=(split, scan, cput)
+has-capability-for-batch ten=10 cmds=(AdminSplit, Scan, ConditionalPut)
 ----
 ok
 
 # Tenant 11 shouldn't be able to issue splits.
-has-capability-for-batch  ten=11 cmds=(split, scan, cput)
+has-capability-for-batch  ten=11 cmds=(AdminSplit, Scan, ConditionalPut)
 ----
 client tenant does not have capability "can_admin_split" (*kvpb.AdminSplitRequest)
 
 # Test that the order of the split request doesn't have any effect.
-has-capability-for-batch ten=11 cmds=(scan, cput)
+has-capability-for-batch ten=11 cmds=(Scan, ConditionalPut)
 ----
 ok
 
 # However, a batch request which doesn't include a split (by tenant 11) should
 # work as you'd expect.
-has-capability-for-batch  ten=11 cmds=(scan, cput)
+has-capability-for-batch  ten=11 cmds=(Scan, ConditionalPut)
 ----
 ok
 
 # Ditto for tenant 10.
-has-capability-for-batch  ten=10 cmds=(scan, cput)
+has-capability-for-batch  ten=10 cmds=(Scan, ConditionalPut)
 ----
 ok
 
@@ -39,12 +39,12 @@ upsert ten=10 can_admin_split=false can_view_node_info=true can_view_tsdb_metric
 ----
 ok
 
-has-capability-for-batch  ten=10 cmds=(split, scan, cput)
+has-capability-for-batch  ten=10 cmds=(AdminSplit, Scan, ConditionalPut)
 ----
 client tenant does not have capability "can_admin_split" (*kvpb.AdminSplitRequest)
 
 # However, this has no effect on batch requests that don't contain splits.
-has-capability-for-batch ten=10 cmds=(scan, cput)
+has-capability-for-batch ten=10 cmds=(Scan, ConditionalPut)
 ----
 ok
 

--- a/pkg/multitenant/tenantcapabilities/tenantcapabilitiesauthorizer/testdata/basic
+++ b/pkg/multitenant/tenantcapabilities/tenantcapabilitiesauthorizer/testdata/basic
@@ -1,8 +1,8 @@
-upsert ten=10 can_admin_split=true can_view_node_info=true can_view_tsdb_metrics=true
+upsert ten=10 can_admin_split=true can_admin_unsplit=true can_view_node_info=true can_view_tsdb_metrics=true
 ----
 ok
 
-upsert ten=11 can_admin_split=false can_view_node_info=false can_view_tsdb_metrics=false
+upsert ten=11 can_admin_split=false can_admin_unsplit=false can_view_node_info=false can_view_tsdb_metrics=false
 ----
 ok
 
@@ -12,10 +12,18 @@ has-capability-for-batch ten=10 cmds=(AdminSplit, Scan, ConditionalPut)
 ----
 ok
 
+has-capability-for-batch ten=10 cmds=(AdminUnsplit, Scan, ConditionalPut)
+----
+ok
+
 # Tenant 11 shouldn't be able to issue splits.
-has-capability-for-batch  ten=11 cmds=(AdminSplit, Scan, ConditionalPut)
+has-capability-for-batch ten=11 cmds=(AdminSplit, Scan, ConditionalPut)
 ----
 client tenant does not have capability "can_admin_split" (*kvpb.AdminSplitRequest)
+
+has-capability-for-batch ten=11 cmds=(AdminUnsplit, Scan, ConditionalPut)
+----
+client tenant does not have capability "can_admin_unsplit" (*kvpb.AdminUnsplitRequest)
 
 # Test that the order of the split request doesn't have any effect.
 has-capability-for-batch ten=11 cmds=(Scan, ConditionalPut)
@@ -24,24 +32,28 @@ ok
 
 # However, a batch request which doesn't include a split (by tenant 11) should
 # work as you'd expect.
-has-capability-for-batch  ten=11 cmds=(Scan, ConditionalPut)
+has-capability-for-batch ten=11 cmds=(Scan, ConditionalPut)
 ----
 ok
 
 # Ditto for tenant 10.
-has-capability-for-batch  ten=10 cmds=(Scan, ConditionalPut)
+has-capability-for-batch ten=10 cmds=(Scan, ConditionalPut)
 ----
 ok
 
 # Lastly, flip tenant 10's capability for splits; ensure it can no longer issue
 # splits as a result.
-upsert ten=10 can_admin_split=false can_view_node_info=true can_view_tsdb_metrics=true
+upsert ten=10 can_admin_split=false can_admin_unsplit=false can_view_node_info=true can_view_tsdb_metrics=true
 ----
 ok
 
-has-capability-for-batch  ten=10 cmds=(AdminSplit, Scan, ConditionalPut)
+has-capability-for-batch ten=10 cmds=(AdminSplit, Scan, ConditionalPut)
 ----
 client tenant does not have capability "can_admin_split" (*kvpb.AdminSplitRequest)
+
+has-capability-for-batch ten=10 cmds=(AdminUnsplit, Scan, ConditionalPut)
+----
+client tenant does not have capability "can_admin_unsplit" (*kvpb.AdminUnsplitRequest)
 
 # However, this has no effect on batch requests that don't contain splits.
 has-capability-for-batch ten=10 cmds=(Scan, ConditionalPut)
@@ -55,7 +67,6 @@ ok
 has-node-status-capability ten=11
 ----
 client tenant does not have capability to query cluster node metadata
-
 
 has-tsdb-query-capability ten=10
 ----

--- a/pkg/multitenant/tenantcapabilities/tenantcapabilitiesauthorizer/testdata/no_capabilities
+++ b/pkg/multitenant/tenantcapabilities/tenantcapabilitiesauthorizer/testdata/no_capabilities
@@ -1,13 +1,13 @@
 # Ensure if no capability exists for a tenant (or if an entry existed, but is
 # deleted), split requests can't be issued.
 
-has-capability-for-batch ten=10 cmds=(split, scan, cput)
+has-capability-for-batch ten=10 cmds=(AdminSplit, Scan, ConditionalPut)
 ----
 client tenant does not have capability "can_admin_split" (*kvpb.AdminSplitRequest)
 
 # However, if there was no split in the batch, the batch should be allowed to
 # go through.
-has-capability-for-batch ten=10 cmds=(scan, cput)
+has-capability-for-batch ten=10 cmds=(Scan, ConditionalPut)
 ----
 ok
 
@@ -16,7 +16,7 @@ upsert ten=10 can_admin_split=true
 ----
 ok
 
-has-capability-for-batch ten=10 cmds=(split, scan, cput)
+has-capability-for-batch ten=10 cmds=(AdminSplit, Scan, ConditionalPut)
 ----
 ok
 
@@ -25,6 +25,6 @@ delete ten=10
 ----
 ok
 
-has-capability-for-batch ten=10 cmds=(split, scan, cput)
+has-capability-for-batch ten=10 cmds=(AdminSplit, Scan, ConditionalPut)
 ----
 client tenant does not have capability "can_admin_split" (*kvpb.AdminSplitRequest)

--- a/pkg/multitenant/tenantcapabilities/tenantcapabilitiesauthorizer/testdata/system_tenant
+++ b/pkg/multitenant/tenantcapabilities/tenantcapabilitiesauthorizer/testdata/system_tenant
@@ -1,14 +1,14 @@
 # Ensure the system tenant can issue any request, regardless of capabilities.
 
-has-capability-for-batch ten=system cmds=(split, scan, cput)
+has-capability-for-batch ten=system cmds=(AdminSplit, Scan, ConditionalPut)
 ----
 ok
 
-has-capability-for-batch ten=system cmds=(scan, cput)
+has-capability-for-batch ten=system cmds=(Scan, ConditionalPut)
 ----
 ok
 
-has-capability-for-batch ten=system cmds=(split)
+has-capability-for-batch ten=system cmds=(AdminSplit)
 ----
 ok
 
@@ -21,6 +21,6 @@ ok
 # things properly. For now, we test this case explicitly to ensure nothing
 # breaks.
 
-has-capability-for-batch ten=system cmds=(split)
+has-capability-for-batch ten=system cmds=(AdminSplit)
 ----
 ok

--- a/pkg/multitenant/tenantcapabilities/tenantcapabilitiespb/capabilities.go
+++ b/pkg/multitenant/tenantcapabilities/tenantcapabilitiespb/capabilities.go
@@ -54,6 +54,8 @@ func (t *TenantCapabilities) Cap(
 	switch capabilityID {
 	case tenantcapabilities.CanAdminSplit:
 		return boolCap{&t.CanAdminSplit}
+	case tenantcapabilities.CanAdminUnsplit:
+		return boolCap{&t.CanAdminUnsplit}
 	case tenantcapabilities.CanViewNodeInfo:
 		return boolCap{&t.CanViewNodeInfo}
 	case tenantcapabilities.CanViewTSDBMetrics:
@@ -69,6 +71,8 @@ func (t *TenantCapabilities) GetBool(capabilityID tenantcapabilities.CapabilityI
 	switch capabilityID {
 	case tenantcapabilities.CanAdminSplit:
 		return t.CanAdminSplit
+	case tenantcapabilities.CanAdminUnsplit:
+		return t.CanAdminUnsplit
 	case tenantcapabilities.CanViewNodeInfo:
 		return t.CanViewNodeInfo
 	case tenantcapabilities.CanViewTSDBMetrics:

--- a/pkg/multitenant/tenantcapabilities/tenantcapabilitiespb/capabilities.proto
+++ b/pkg/multitenant/tenantcapabilities/tenantcapabilitiespb/capabilities.proto
@@ -57,6 +57,10 @@ message TenantCapabilities {
   // Furthermore the span config reconciliation infrastructure is poorly
   // positioned to surface errors to the user.
   SpanConfigBounds span_config_bounds = 4;
+
+  // CanAdminUnsplit if set to true, grants the tenant the ability to
+  // successfully perform `AdminUnsplit` requests.
+  bool can_admin_unsplit = 5;
 };
 
 // SpanConfigBound is used to constrain the possible values a SpanConfig may

--- a/pkg/multitenant/tenantcapabilities/tenantcapabilitiestestutils/testutils.go
+++ b/pkg/multitenant/tenantcapabilities/tenantcapabilitiestestutils/testutils.go
@@ -32,16 +32,12 @@ func ParseBatchRequests(t *testing.T, d *datadriven.TestData) (ba kvpb.BatchRequ
 	for _, cmd := range d.CmdArgs {
 		if cmd.Key == "cmds" {
 			for _, z := range cmd.Vals {
-				switch z {
-				case "split":
-					ba.Add(&kvpb.AdminSplitRequest{})
-				case "scan":
-					ba.Add(&kvpb.ScanRequest{})
-				case "cput":
-					ba.Add(&kvpb.ConditionalPutRequest{})
-				default:
+				method, ok := kvpb.StringToMethodMap[z]
+				if !ok {
 					t.Fatalf("unsupported request type: %s", z)
 				}
+				request := kvpb.CreateRequest(method)
+				ba.Add(request)
 			}
 		}
 	}

--- a/pkg/multitenant/tenantcapabilities/tenantcapabilitieswatcher/testdata/basic
+++ b/pkg/multitenant/tenantcapabilities/tenantcapabilitieswatcher/testdata/basic
@@ -18,13 +18,13 @@ ok
 updates
 ----
 Incremental Update
-update: ten=10 cap={can_admin_split:true can_view_node_info:false can_view_tsdb_metrics:false}
-update: ten=11 cap={can_admin_split:false can_view_node_info:false can_view_tsdb_metrics:false}
+update: ten=10 cap={can_admin_split:true can_admin_unsplit:false can_view_node_info:false can_view_tsdb_metrics:false}
+update: ten=11 cap={can_admin_split:false can_admin_unsplit:false can_view_node_info:false can_view_tsdb_metrics:false}
 
 flush-state
 ----
-ten=10 cap={can_admin_split:true can_view_node_info:false can_view_tsdb_metrics:false}
-ten=11 cap={can_admin_split:false can_view_node_info:false can_view_tsdb_metrics:false}
+ten=10 cap={can_admin_split:true can_admin_unsplit:false can_view_node_info:false can_view_tsdb_metrics:false}
+ten=11 cap={can_admin_split:false can_admin_unsplit:false can_view_node_info:false can_view_tsdb_metrics:false}
 
 upsert ten=11 can_admin_split=true
 ----
@@ -33,11 +33,11 @@ ok
 updates
 ----
 Incremental Update
-update: ten=11 cap={can_admin_split:true can_view_node_info:false can_view_tsdb_metrics:false}
+update: ten=11 cap={can_admin_split:true can_admin_unsplit:false can_view_node_info:false can_view_tsdb_metrics:false}
 
 get-capabilities ten=11
 ----
-{can_admin_split:true can_view_node_info:false can_view_tsdb_metrics:false}
+{can_admin_split:true can_admin_unsplit:false can_view_node_info:false can_view_tsdb_metrics:false}
 
 delete ten=10
 ----
@@ -64,7 +64,7 @@ updates
 # what we'd expect.
 flush-state
 ----
-ten=11 cap={can_admin_split:true can_view_node_info:false can_view_tsdb_metrics:false}
+ten=11 cap={can_admin_split:true can_admin_unsplit:false can_view_node_info:false can_view_tsdb_metrics:false}
 
 upsert ten=15 can_admin_split=true
 ----
@@ -73,7 +73,7 @@ ok
 updates
 ----
 Incremental Update
-update: ten=15 cap={can_admin_split:true can_view_node_info:false can_view_tsdb_metrics:false}
+update: ten=15 cap={can_admin_split:true can_admin_unsplit:false can_view_node_info:false can_view_tsdb_metrics:false}
 
 # Ensure only the last update is applied, even when there are multiple updates
 # to a single key.
@@ -100,7 +100,7 @@ not-found
 
 flush-state
 ----
-ten=15 cap={can_admin_split:true can_view_node_info:false can_view_tsdb_metrics:false}
+ten=15 cap={can_admin_split:true can_admin_unsplit:false can_view_node_info:false can_view_tsdb_metrics:false}
 
 # Same thing, but this time instead of deleting the key, leave it behind.
 delete ten=15
@@ -118,12 +118,12 @@ ok
 updates
 ----
 Incremental Update
-update: ten=15 cap={can_admin_split:false can_view_node_info:false can_view_tsdb_metrics:false}
+update: ten=15 cap={can_admin_split:false can_admin_unsplit:false can_view_node_info:false can_view_tsdb_metrics:false}
 
 flush-state
 ----
-ten=15 cap={can_admin_split:false can_view_node_info:false can_view_tsdb_metrics:false}
+ten=15 cap={can_admin_split:false can_admin_unsplit:false can_view_node_info:false can_view_tsdb_metrics:false}
 
 get-capabilities ten=15
 ----
-{can_admin_split:false can_view_node_info:false can_view_tsdb_metrics:false}
+{can_admin_split:false can_admin_unsplit:false can_view_node_info:false can_view_tsdb_metrics:false}

--- a/pkg/multitenant/tenantcapabilities/tenantcapabilitieswatcher/testdata/initial_scan
+++ b/pkg/multitenant/tenantcapabilities/tenantcapabilitieswatcher/testdata/initial_scan
@@ -38,13 +38,13 @@ ok
 updates
 ----
 Complete Update
-update: ten=11 cap={can_admin_split:false can_view_node_info:false can_view_tsdb_metrics:false}
-update: ten=15 cap={can_admin_split:true can_view_node_info:false can_view_tsdb_metrics:false}
+update: ten=11 cap={can_admin_split:false can_admin_unsplit:false can_view_node_info:false can_view_tsdb_metrics:false}
+update: ten=15 cap={can_admin_split:true can_admin_unsplit:false can_view_node_info:false can_view_tsdb_metrics:false}
 
 flush-state
 ----
-ten=11 cap={can_admin_split:false can_view_node_info:false can_view_tsdb_metrics:false}
-ten=15 cap={can_admin_split:true can_view_node_info:false can_view_tsdb_metrics:false}
+ten=11 cap={can_admin_split:false can_admin_unsplit:false can_view_node_info:false can_view_tsdb_metrics:false}
+ten=15 cap={can_admin_split:true can_admin_unsplit:false can_view_node_info:false can_view_tsdb_metrics:false}
 
 get-capabilities ten=10
 ----
@@ -52,4 +52,4 @@ not-found
 
 get-capabilities ten=15
 ----
-{can_admin_split:true can_view_node_info:false can_view_tsdb_metrics:false}
+{can_admin_split:true can_admin_unsplit:false can_view_node_info:false can_view_tsdb_metrics:false}

--- a/pkg/multitenant/tenantcapabilities/tenantcapabilitieswatcher/testdata/rangefeed_errors
+++ b/pkg/multitenant/tenantcapabilities/tenantcapabilitieswatcher/testdata/rangefeed_errors
@@ -25,9 +25,9 @@ ok
 updates
 ----
 Incremental Update
-update: ten=10 cap={can_admin_split:true can_view_node_info:false can_view_tsdb_metrics:false}
-update: ten=11 cap={can_admin_split:false can_view_node_info:false can_view_tsdb_metrics:false}
-update: ten=12 cap={can_admin_split:false can_view_node_info:false can_view_tsdb_metrics:false}
+update: ten=10 cap={can_admin_split:true can_admin_unsplit:false can_view_node_info:false can_view_tsdb_metrics:false}
+update: ten=11 cap={can_admin_split:false can_admin_unsplit:false can_view_node_info:false can_view_tsdb_metrics:false}
+update: ten=12 cap={can_admin_split:false can_admin_unsplit:false can_view_node_info:false can_view_tsdb_metrics:false}
 
 inject-error
 ----
@@ -56,9 +56,9 @@ updates
 
 flush-state
 ----
-ten=10 cap={can_admin_split:true can_view_node_info:false can_view_tsdb_metrics:false}
-ten=11 cap={can_admin_split:false can_view_node_info:false can_view_tsdb_metrics:false}
-ten=12 cap={can_admin_split:false can_view_node_info:false can_view_tsdb_metrics:false}
+ten=10 cap={can_admin_split:true can_admin_unsplit:false can_view_node_info:false can_view_tsdb_metrics:false}
+ten=11 cap={can_admin_split:false can_admin_unsplit:false can_view_node_info:false can_view_tsdb_metrics:false}
+ten=12 cap={can_admin_split:false can_admin_unsplit:false can_view_node_info:false can_view_tsdb_metrics:false}
 
 get-capabilities ten=50
 ----
@@ -66,11 +66,11 @@ not-found
 
 get-capabilities ten=12
 ----
-{can_admin_split:false can_view_node_info:false can_view_tsdb_metrics:false}
+{can_admin_split:false can_admin_unsplit:false can_view_node_info:false can_view_tsdb_metrics:false}
 
 get-capabilities ten=10
 ----
-{can_admin_split:true can_view_node_info:false can_view_tsdb_metrics:false}
+{can_admin_split:true can_admin_unsplit:false can_view_node_info:false can_view_tsdb_metrics:false}
 
 # Let the Watcher attempt to restart.
 restart-after-injected-error
@@ -82,23 +82,23 @@ ok
 updates
 ----
 Complete Update
-update: ten=11 cap={can_admin_split:false can_view_node_info:false can_view_tsdb_metrics:false}
-update: ten=12 cap={can_admin_split:true can_view_node_info:false can_view_tsdb_metrics:false}
-update: ten=50 cap={can_admin_split:false can_view_node_info:false can_view_tsdb_metrics:false}
+update: ten=11 cap={can_admin_split:false can_admin_unsplit:false can_view_node_info:false can_view_tsdb_metrics:false}
+update: ten=12 cap={can_admin_split:true can_admin_unsplit:false can_view_node_info:false can_view_tsdb_metrics:false}
+update: ten=50 cap={can_admin_split:false can_admin_unsplit:false can_view_node_info:false can_view_tsdb_metrics:false}
 
 flush-state
 ----
-ten=11 cap={can_admin_split:false can_view_node_info:false can_view_tsdb_metrics:false}
-ten=12 cap={can_admin_split:true can_view_node_info:false can_view_tsdb_metrics:false}
-ten=50 cap={can_admin_split:false can_view_node_info:false can_view_tsdb_metrics:false}
+ten=11 cap={can_admin_split:false can_admin_unsplit:false can_view_node_info:false can_view_tsdb_metrics:false}
+ten=12 cap={can_admin_split:true can_admin_unsplit:false can_view_node_info:false can_view_tsdb_metrics:false}
+ten=50 cap={can_admin_split:false can_admin_unsplit:false can_view_node_info:false can_view_tsdb_metrics:false}
 
 get-capabilities ten=50
 ----
-{can_admin_split:false can_view_node_info:false can_view_tsdb_metrics:false}
+{can_admin_split:false can_admin_unsplit:false can_view_node_info:false can_view_tsdb_metrics:false}
 
 get-capabilities ten=12
 ----
-{can_admin_split:true can_view_node_info:false can_view_tsdb_metrics:false}
+{can_admin_split:true can_admin_unsplit:false can_view_node_info:false can_view_tsdb_metrics:false}
 
 get-capabilities ten=10
 ----

--- a/pkg/sql/gcjob_test/gc_job_test.go
+++ b/pkg/sql/gcjob_test/gc_job_test.go
@@ -487,13 +487,10 @@ func TestGCTenant(t *testing.T) {
 				Status: jobspb.SchemaChangeGCProgress_CLEARED,
 			},
 		}
-		require.EqualError(
+		require.ErrorContains(
 			t,
 			gcClosure(dropTenID, progress),
-			`GC state for tenant is DELETED yet the tenant row still exists: `+
-				`{ProtoInfo:{DeprecatedID:11 DeprecatedDataState:DROP DroppedName: TenantReplicationJobID:0 `+
-				`Capabilities:{CanAdminSplit:false CanViewNodeInfo:false CanViewTSDBMetrics:false SpanConfigBounds:<nil>}} `+
-				`SQLInfo:{ID:11 Name:tenant-11 DataState:drop ServiceMode:none}}`,
+			`GC state for tenant is DELETED yet the tenant row still exists`,
 		)
 	})
 

--- a/pkg/sql/logictest/testdata/logic_test/tenant
+++ b/pkg/sql/logictest/testdata/logic_test/tenant
@@ -38,10 +38,10 @@ FROM system.tenants
 ORDER BY id
 ----
 id  active  name        crdb_internal.pb_to_json
-1   true    system      {"capabilities": {"canAdminSplit": false, "canViewNodeInfo": false, "canViewTsdbMetrics": false, "spanConfigBounds": null}, "deprecatedDataState": "READY", "deprecatedId": "1", "droppedName": "", "tenantReplicationJobId": "0"}
-2   true    tenant-one  {"capabilities": {"canAdminSplit": false, "canViewNodeInfo": false, "canViewTsdbMetrics": false, "spanConfigBounds": null}, "deprecatedDataState": "READY", "deprecatedId": "2", "droppedName": "", "tenantReplicationJobId": "0"}
-3   true    two         {"capabilities": {"canAdminSplit": false, "canViewNodeInfo": false, "canViewTsdbMetrics": false, "spanConfigBounds": null}, "deprecatedDataState": "READY", "deprecatedId": "3", "droppedName": "", "tenantReplicationJobId": "0"}
-4   true    three       {"capabilities": {"canAdminSplit": false, "canViewNodeInfo": false, "canViewTsdbMetrics": false, "spanConfigBounds": null}, "deprecatedDataState": "READY", "deprecatedId": "4", "droppedName": "", "tenantReplicationJobId": "0"}
+1   true    system      {"capabilities": {"canAdminSplit": false, "canAdminUnsplit": false, "canViewNodeInfo": false, "canViewTsdbMetrics": false, "spanConfigBounds": null}, "deprecatedDataState": "READY", "deprecatedId": "1", "droppedName": "", "tenantReplicationJobId": "0"}
+2   true    tenant-one  {"capabilities": {"canAdminSplit": false, "canAdminUnsplit": false, "canViewNodeInfo": false, "canViewTsdbMetrics": false, "spanConfigBounds": null}, "deprecatedDataState": "READY", "deprecatedId": "2", "droppedName": "", "tenantReplicationJobId": "0"}
+3   true    two         {"capabilities": {"canAdminSplit": false, "canAdminUnsplit": false, "canViewNodeInfo": false, "canViewTsdbMetrics": false, "spanConfigBounds": null}, "deprecatedDataState": "READY", "deprecatedId": "3", "droppedName": "", "tenantReplicationJobId": "0"}
+4   true    three       {"capabilities": {"canAdminSplit": false, "canAdminUnsplit": false, "canViewNodeInfo": false, "canViewTsdbMetrics": false, "spanConfigBounds": null}, "deprecatedDataState": "READY", "deprecatedId": "4", "droppedName": "", "tenantReplicationJobId": "0"}
 
 query ITTT colnames
 SHOW TENANT system
@@ -158,7 +158,7 @@ FROM system.tenants WHERE name = 'four'
 ORDER BY id
 ----
 id  active  name  crdb_internal.pb_to_json
-5   true    four  {"capabilities": {"canAdminSplit": false, "canViewNodeInfo": false, "canViewTsdbMetrics": false, "spanConfigBounds": null}, "deprecatedDataState": "READY", "deprecatedId": "5", "droppedName": "", "tenantReplicationJobId": "0"}
+5   true    four  {"capabilities": {"canAdminSplit": false, "canAdminUnsplit": false, "canViewNodeInfo": false, "canViewTsdbMetrics": false, "spanConfigBounds": null}, "deprecatedDataState": "READY", "deprecatedId": "5", "droppedName": "", "tenantReplicationJobId": "0"}
 
 statement ok
 DROP TENANT four
@@ -232,14 +232,14 @@ FROM system.tenants
 ORDER BY id
 ----
 id  active  name             crdb_internal.pb_to_json
-1   true    system           {"capabilities": {"canAdminSplit": false, "canViewNodeInfo": false, "canViewTsdbMetrics": false, "spanConfigBounds": null}, "deprecatedDataState": "READY", "deprecatedId": "1", "droppedName": "", "tenantReplicationJobId": "0"}
-2   true    tenant-one       {"capabilities": {"canAdminSplit": false, "canViewNodeInfo": false, "canViewTsdbMetrics": false, "spanConfigBounds": null}, "deprecatedDataState": "READY", "deprecatedId": "2", "droppedName": "", "tenantReplicationJobId": "0"}
-3   true    two              {"capabilities": {"canAdminSplit": false, "canViewNodeInfo": false, "canViewTsdbMetrics": false, "spanConfigBounds": null}, "deprecatedDataState": "READY", "deprecatedId": "3", "droppedName": "", "tenantReplicationJobId": "0"}
-4   true    three            {"capabilities": {"canAdminSplit": false, "canViewNodeInfo": false, "canViewTsdbMetrics": false, "spanConfigBounds": null}, "deprecatedDataState": "READY", "deprecatedId": "4", "droppedName": "", "tenantReplicationJobId": "0"}
-5   false   NULL             {"capabilities": {"canAdminSplit": false, "canViewNodeInfo": false, "canViewTsdbMetrics": false, "spanConfigBounds": null}, "deprecatedDataState": "DROP", "deprecatedId": "5", "droppedName": "four", "tenantReplicationJobId": "0"}
-6   false   NULL             {"capabilities": {"canAdminSplit": false, "canViewNodeInfo": false, "canViewTsdbMetrics": false, "spanConfigBounds": null}, "deprecatedDataState": "DROP", "deprecatedId": "6", "droppedName": "five-requiring-quotes", "tenantReplicationJobId": "0"}
-7   false   NULL             {"capabilities": {"canAdminSplit": false, "canViewNodeInfo": false, "canViewTsdbMetrics": false, "spanConfigBounds": null}, "deprecatedDataState": "DROP", "deprecatedId": "7", "droppedName": "to-be-reclaimed", "tenantReplicationJobId": "0"}
-8   true    to-be-reclaimed  {"capabilities": {"canAdminSplit": false, "canViewNodeInfo": false, "canViewTsdbMetrics": false, "spanConfigBounds": null}, "deprecatedDataState": "READY", "deprecatedId": "8", "droppedName": "", "tenantReplicationJobId": "0"}
+1   true    system           {"capabilities": {"canAdminSplit": false, "canAdminUnsplit": false, "canViewNodeInfo": false, "canViewTsdbMetrics": false, "spanConfigBounds": null}, "deprecatedDataState": "READY", "deprecatedId": "1", "droppedName": "", "tenantReplicationJobId": "0"}
+2   true    tenant-one       {"capabilities": {"canAdminSplit": false, "canAdminUnsplit": false, "canViewNodeInfo": false, "canViewTsdbMetrics": false, "spanConfigBounds": null}, "deprecatedDataState": "READY", "deprecatedId": "2", "droppedName": "", "tenantReplicationJobId": "0"}
+3   true    two              {"capabilities": {"canAdminSplit": false, "canAdminUnsplit": false, "canViewNodeInfo": false, "canViewTsdbMetrics": false, "spanConfigBounds": null}, "deprecatedDataState": "READY", "deprecatedId": "3", "droppedName": "", "tenantReplicationJobId": "0"}
+4   true    three            {"capabilities": {"canAdminSplit": false, "canAdminUnsplit": false, "canViewNodeInfo": false, "canViewTsdbMetrics": false, "spanConfigBounds": null}, "deprecatedDataState": "READY", "deprecatedId": "4", "droppedName": "", "tenantReplicationJobId": "0"}
+5   false   NULL             {"capabilities": {"canAdminSplit": false, "canAdminUnsplit": false, "canViewNodeInfo": false, "canViewTsdbMetrics": false, "spanConfigBounds": null}, "deprecatedDataState": "DROP", "deprecatedId": "5", "droppedName": "four", "tenantReplicationJobId": "0"}
+6   false   NULL             {"capabilities": {"canAdminSplit": false, "canAdminUnsplit": false, "canViewNodeInfo": false, "canViewTsdbMetrics": false, "spanConfigBounds": null}, "deprecatedDataState": "DROP", "deprecatedId": "6", "droppedName": "five-requiring-quotes", "tenantReplicationJobId": "0"}
+7   false   NULL             {"capabilities": {"canAdminSplit": false, "canAdminUnsplit": false, "canViewNodeInfo": false, "canViewTsdbMetrics": false, "spanConfigBounds": null}, "deprecatedDataState": "DROP", "deprecatedId": "7", "droppedName": "to-be-reclaimed", "tenantReplicationJobId": "0"}
+8   true    to-be-reclaimed  {"capabilities": {"canAdminSplit": false, "canAdminUnsplit": false, "canViewNodeInfo": false, "canViewTsdbMetrics": false, "spanConfigBounds": null}, "deprecatedDataState": "READY", "deprecatedId": "8", "droppedName": "", "tenantReplicationJobId": "0"}
 
 # More valid tenant names.
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/tenant_builtins
+++ b/pkg/sql/logictest/testdata/logic_test/tenant_builtins
@@ -47,10 +47,10 @@ FROM system.tenants
 ORDER BY id
 ----
 id  active  name                  data_state  service_mode  crdb_internal.pb_to_json
-1   true    system                1           2             {"capabilities": {"canAdminSplit": false, "canViewNodeInfo": false, "canViewTsdbMetrics": false, "spanConfigBounds": null}, "deprecatedDataState": "READY", "deprecatedId": "1", "droppedName": "", "tenantReplicationJobId": "0"}
-2   true    tenant-number-eleven  1           0             {"capabilities": {"canAdminSplit": false, "canViewNodeInfo": false, "canViewTsdbMetrics": false, "spanConfigBounds": null}, "deprecatedDataState": "READY", "deprecatedId": "2", "droppedName": "", "tenantReplicationJobId": "0"}
-5   true    tenant-5              1           0             {"capabilities": {"canAdminSplit": false, "canViewNodeInfo": false, "canViewTsdbMetrics": false, "spanConfigBounds": null}, "deprecatedDataState": "READY", "deprecatedId": "5", "droppedName": "", "tenantReplicationJobId": "0"}
-10  true    tenant-number-ten     1           0             {"capabilities": {"canAdminSplit": false, "canViewNodeInfo": false, "canViewTsdbMetrics": false, "spanConfigBounds": null}, "deprecatedDataState": "READY", "deprecatedId": "10", "droppedName": "", "tenantReplicationJobId": "0"}
+1   true    system                1           2             {"capabilities": {"canAdminSplit": false, "canAdminUnsplit": false, "canViewNodeInfo": false, "canViewTsdbMetrics": false, "spanConfigBounds": null}, "deprecatedDataState": "READY", "deprecatedId": "1", "droppedName": "", "tenantReplicationJobId": "0"}
+2   true    tenant-number-eleven  1           0             {"capabilities": {"canAdminSplit": false, "canAdminUnsplit": false, "canViewNodeInfo": false, "canViewTsdbMetrics": false, "spanConfigBounds": null}, "deprecatedDataState": "READY", "deprecatedId": "2", "droppedName": "", "tenantReplicationJobId": "0"}
+5   true    tenant-5              1           0             {"capabilities": {"canAdminSplit": false, "canAdminUnsplit": false, "canViewNodeInfo": false, "canViewTsdbMetrics": false, "spanConfigBounds": null}, "deprecatedDataState": "READY", "deprecatedId": "5", "droppedName": "", "tenantReplicationJobId": "0"}
+10  true    tenant-number-ten     1           0             {"capabilities": {"canAdminSplit": false, "canAdminUnsplit": false, "canViewNodeInfo": false, "canViewTsdbMetrics": false, "spanConfigBounds": null}, "deprecatedDataState": "READY", "deprecatedId": "10", "droppedName": "", "tenantReplicationJobId": "0"}
 
 # Check we can add a name where none existed before.
 statement ok
@@ -118,10 +118,10 @@ FROM system.tenants
 ORDER BY id
 ----
 id  active  name                  data_state  service_mode  crdb_internal.pb_to_json
-1   true    system                1           2             {"capabilities": {"canAdminSplit": false, "canViewNodeInfo": false, "canViewTsdbMetrics": false, "spanConfigBounds": null}, "deprecatedDataState": "READY", "deprecatedId": "1", "droppedName": "", "tenantReplicationJobId": "0"}
-2   true    tenant-number-eleven  1           0             {"capabilities": {"canAdminSplit": false, "canViewNodeInfo": false, "canViewTsdbMetrics": false, "spanConfigBounds": null}, "deprecatedDataState": "READY", "deprecatedId": "2", "droppedName": "", "tenantReplicationJobId": "0"}
-5   false   NULL                  2           0             {"capabilities": {"canAdminSplit": false, "canViewNodeInfo": false, "canViewTsdbMetrics": false, "spanConfigBounds": null}, "deprecatedDataState": "DROP", "deprecatedId": "5", "droppedName": "my-new-tenant-name", "tenantReplicationJobId": "0"}
-10  true    tenant-number-ten     1           0             {"capabilities": {"canAdminSplit": false, "canViewNodeInfo": false, "canViewTsdbMetrics": false, "spanConfigBounds": null}, "deprecatedDataState": "READY", "deprecatedId": "10", "droppedName": "", "tenantReplicationJobId": "0"}
+1   true    system                1           2             {"capabilities": {"canAdminSplit": false, "canAdminUnsplit": false, "canViewNodeInfo": false, "canViewTsdbMetrics": false, "spanConfigBounds": null}, "deprecatedDataState": "READY", "deprecatedId": "1", "droppedName": "", "tenantReplicationJobId": "0"}
+2   true    tenant-number-eleven  1           0             {"capabilities": {"canAdminSplit": false, "canAdminUnsplit": false, "canViewNodeInfo": false, "canViewTsdbMetrics": false, "spanConfigBounds": null}, "deprecatedDataState": "READY", "deprecatedId": "2", "droppedName": "", "tenantReplicationJobId": "0"}
+5   false   NULL                  2           0             {"capabilities": {"canAdminSplit": false, "canAdminUnsplit": false, "canViewNodeInfo": false, "canViewTsdbMetrics": false, "spanConfigBounds": null}, "deprecatedDataState": "DROP", "deprecatedId": "5", "droppedName": "my-new-tenant-name", "tenantReplicationJobId": "0"}
+10  true    tenant-number-ten     1           0             {"capabilities": {"canAdminSplit": false, "canAdminUnsplit": false, "canViewNodeInfo": false, "canViewTsdbMetrics": false, "spanConfigBounds": null}, "deprecatedDataState": "READY", "deprecatedId": "10", "droppedName": "", "tenantReplicationJobId": "0"}
 
 
 # Try to recreate an existing tenant.
@@ -229,9 +229,9 @@ FROM system.tenants
 ORDER BY id
 ----
 id  active  name                  data_state  service_mode  crdb_internal.pb_to_json
-1   true    system                1           2             {"capabilities": {"canAdminSplit": false, "canViewNodeInfo": false, "canViewTsdbMetrics": false, "spanConfigBounds": null}, "deprecatedDataState": "READY", "deprecatedId": "1", "droppedName": "", "tenantReplicationJobId": "0"}
-2   true    tenant-number-eleven  1           0             {"capabilities": {"canAdminSplit": false, "canViewNodeInfo": false, "canViewTsdbMetrics": false, "spanConfigBounds": null}, "deprecatedDataState": "READY", "deprecatedId": "2", "droppedName": "", "tenantReplicationJobId": "0"}
-10  true    tenant-number-ten     1           0             {"capabilities": {"canAdminSplit": false, "canViewNodeInfo": false, "canViewTsdbMetrics": false, "spanConfigBounds": null}, "deprecatedDataState": "READY", "deprecatedId": "10", "droppedName": "", "tenantReplicationJobId": "0"}
+1   true    system                1           2             {"capabilities": {"canAdminSplit": false, "canAdminUnsplit": false, "canViewNodeInfo": false, "canViewTsdbMetrics": false, "spanConfigBounds": null}, "deprecatedDataState": "READY", "deprecatedId": "1", "droppedName": "", "tenantReplicationJobId": "0"}
+2   true    tenant-number-eleven  1           0             {"capabilities": {"canAdminSplit": false, "canAdminUnsplit": false, "canViewNodeInfo": false, "canViewTsdbMetrics": false, "spanConfigBounds": null}, "deprecatedDataState": "READY", "deprecatedId": "2", "droppedName": "", "tenantReplicationJobId": "0"}
+10  true    tenant-number-ten     1           0             {"capabilities": {"canAdminSplit": false, "canAdminUnsplit": false, "canViewNodeInfo": false, "canViewTsdbMetrics": false, "spanConfigBounds": null}, "deprecatedDataState": "READY", "deprecatedId": "10", "droppedName": "", "tenantReplicationJobId": "0"}
 
 query error tenant resource limits require a CCL binary
 SELECT crdb_internal.update_tenant_resource_limits(10, 1000, 100, 0, now(), 0)

--- a/pkg/sql/multitenant_admin_function_test.go
+++ b/pkg/sql/multitenant_admin_function_test.go
@@ -500,10 +500,11 @@ func TestMultiTenantAdminFunction(t *testing.T) {
 				result: [][]string{{"\xf0\x89\x89", "/Tenant/10/Table/104/1/1"}},
 			},
 			secondaryWithoutCapability: tenantExpected{
-				errorMessage: errorutil.UnsupportedWithMultiTenancyMessage,
+				errorMessage: `does not have capability "can_admin_unsplit"`,
 			},
 			setupClusterSetting: sql.SecondaryTenantSplitAtEnabled,
 			setupCapability:     tenantcapabilities.CanAdminSplit,
+			queryCapability:     tenantcapabilities.CanAdminUnsplit,
 		},
 		{
 			desc: "ALTER INDEX x UNSPLIT AT",
@@ -519,10 +520,11 @@ func TestMultiTenantAdminFunction(t *testing.T) {
 				result: [][]string{{"\xfe\x92\xf0\x8a\x89", "/Tenant/10/Table/104/2/1"}},
 			},
 			secondaryWithoutCapability: tenantExpected{
-				errorMessage: errorutil.UnsupportedWithMultiTenancyMessage,
+				errorMessage: `does not have capability "can_admin_unsplit"`,
 			},
 			setupClusterSetting: sql.SecondaryTenantSplitAtEnabled,
 			setupCapability:     tenantcapabilities.CanAdminSplit,
+			queryCapability:     tenantcapabilities.CanAdminUnsplit,
 		},
 		{
 			desc:  "ALTER TABLE x UNSPLIT ALL",
@@ -535,10 +537,11 @@ func TestMultiTenantAdminFunction(t *testing.T) {
 				result: [][]string{{"\xf0\x89\x89", "/Tenant/10/Table/104/1/1"}},
 			},
 			secondaryWithoutCapability: tenantExpected{
-				errorMessage: errorutil.UnsupportedWithMultiTenancyMessage,
+				errorMessage: `does not have capability "can_admin_unsplit"`,
 			},
 			setupClusterSetting: sql.SecondaryTenantSplitAtEnabled,
 			setupCapability:     tenantcapabilities.CanAdminSplit,
+			queryCapability:     tenantcapabilities.CanAdminUnsplit,
 		},
 		{
 			desc: "ALTER INDEX x UNSPLIT ALL",
@@ -554,10 +557,11 @@ func TestMultiTenantAdminFunction(t *testing.T) {
 				result: [][]string{{"\xfe\x92\xf0\x8a\x89", "/Tenant/10/Table/104/2/1"}},
 			},
 			secondaryWithoutCapability: tenantExpected{
-				errorMessage: errorutil.UnsupportedWithMultiTenancyMessage,
+				errorMessage: `does not have capability "can_admin_unsplit"`,
 			},
 			setupClusterSetting: sql.SecondaryTenantSplitAtEnabled,
 			setupCapability:     tenantcapabilities.CanAdminSplit,
+			queryCapability:     tenantcapabilities.CanAdminUnsplit,
 		},
 		{
 			desc:  "ALTER TABLE x SCATTER",

--- a/pkg/sql/opt_exec_factory.go
+++ b/pkg/sql/opt_exec_factory.go
@@ -1985,20 +1985,13 @@ func (ef *execFactory) ConstructAlterTableSplit(
 func (ef *execFactory) ConstructAlterTableUnsplit(
 	index cat.Index, input exec.Node,
 ) (exec.Node, error) {
-
-	execCfg := ef.planner.ExecCfg()
 	if err := checkSchemaChangeEnabled(
 		ef.ctx,
-		execCfg,
+		ef.planner.ExecCfg(),
 		"ALTER TABLE/INDEX UNSPLIT AT",
 	); err != nil {
 		return nil, err
 	}
-
-	if err := execCfg.RequireSystemTenant(); err != nil {
-		return nil, err
-	}
-
 	return &unsplitNode{
 		tableDesc: index.Table().(*optTable).desc,
 		index:     index.(*optIndex).idx,
@@ -2008,15 +2001,11 @@ func (ef *execFactory) ConstructAlterTableUnsplit(
 
 // ConstructAlterTableUnsplitAll is part of the exec.Factory interface.
 func (ef *execFactory) ConstructAlterTableUnsplitAll(index cat.Index) (exec.Node, error) {
-	execCfg := ef.planner.ExecCfg()
 	if err := checkSchemaChangeEnabled(
 		ef.ctx,
-		execCfg,
+		ef.planner.ExecCfg(),
 		"ALTER TABLE/INDEX UNSPLIT ALL",
 	); err != nil {
-		return nil, err
-	}
-	if err := execCfg.RequireSystemTenant(); err != nil {
 		return nil, err
 	}
 	return &unsplitAllNode{

--- a/pkg/util/stringerutil/stringerutil.go
+++ b/pkg/util/stringerutil/stringerutil.go
@@ -17,7 +17,7 @@ import (
 
 type enum interface {
 	fmt.Stringer
-	~int8 | ~int16 | ~int32 | ~int64 | ~uint8 | ~uint16 | ~uint32 | ~uint64
+	~int | ~int8 | ~int16 | ~int32 | ~int64 | ~uint | ~uint8 | ~uint16 | ~uint32 | ~uint64
 }
 
 type index interface {


### PR DESCRIPTION
Fixes #97716

1) Add a new `tenantcapabilitiespb.CanAdminUnsplit` capability.
2) Check capability in `Authorizer.HasCapabilityForBatch`.
3) Remove `ExecutorConfig.RequireSystemTenant` call from
   `execFactory.ConstructAlterTableUnsplit`,
   `execFactory.ConstructAlterTableUnsplitAll`.

Release note: None
