### PR TITLE
release-22.2: ui: update suboptimal insight description

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/insights/types.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/types.ts
@@ -176,8 +176,8 @@ const planRegressionInsight = (execType: InsightExecEnum): Insight => {
 
 const suboptimalPlanInsight = (execType: InsightExecEnum): Insight => {
   const description =
-    `This ${execType} was slow because a good plan was not available, whether ` +
-    `due to outdated statistics or missing indexes.`;
+    `This ${execType} was slow because a good plan was unavailable; ` +
+    `possible reasons include outdated statistics or missing indexes.`;
   return {
     name: InsightNameEnum.suboptimalPlan,
     label: "Suboptimal Plan",

--- a/pkg/ui/workspaces/cluster-ui/src/insightsTable/insightsTable.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insightsTable/insightsTable.tsx
@@ -21,6 +21,7 @@ import {
   Duration,
   performanceBestPractices,
   statementsRetries,
+  stmtPerformanceRules,
 } from "../util";
 import { Anchor } from "../anchor";
 import { Link } from "react-router-dom";
@@ -91,6 +92,12 @@ function descriptionCell(
   const summary = computeOrUseStmtSummary(
     insightRec.execution?.statement,
     insightRec.execution?.summary,
+  );
+
+  const learnMoreSuboptimalPlan = (
+    <Anchor href={stmtPerformanceRules} target="_blank">
+      Learn more
+    </Anchor>
   );
 
   const indexLink = isCockroachCloud
@@ -190,7 +197,7 @@ function descriptionCell(
         <>
           <div className={cx("description-item")}>
             <span className={cx("label-bold")}>Description: </span>{" "}
-            {insightRec.details.description}
+            {insightRec.details.description} {learnMoreSuboptimalPlan}
           </div>
           <div className={cx("description-item")}>
             <span className={cx("label-bold")}>Recommendation: </span>{" "}

--- a/pkg/ui/workspaces/cluster-ui/src/util/docs.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/util/docs.ts
@@ -93,6 +93,9 @@ export const tableStatsClusterSetting = docsURL(
 export const performanceBestPractices = docsURL(
   "performance-best-practices-overview",
 );
+export const stmtPerformanceRules = docsURL(
+  "make-queries-fast.html#sql-statement-performance-rules",
+);
 // Note that these explicitly don't use the current version, since we want to
 // link to the most up-to-date documentation available.
 export const upgradeCockroachVersion =


### PR DESCRIPTION
Backport 1/1 commits from #97656.

/cc @cockroachdb/release

---

Update Suboptimal description to:
This statement was slow because a good plan was unavailable; possible reasons include outdated statistics or missing indexes.

Fixes #97266

<img width="1341" alt="Screenshot 2023-02-24 at 4 34 42 PM" src="https://user-images.githubusercontent.com/1017486/221298107-b205becb-5137-405f-b8c4-cc4f9d2a6531.png">


Release note (ui change): Update description for the Suboptimal Insight and adds a Learn more link to it.

---
Release justification: small ui tooltip change
