### PR TITLE
ui: update suboptimal tooltip for txn

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/insights/types.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/types.ts
@@ -195,9 +195,9 @@ export const suboptimalPlanInsight = (execType: InsightExecEnum): Insight => {
       break;
     case InsightExecEnum.TRANSACTION:
       description =
-        "This transaction was slow because a good plan was not available for some " +
-        "statement(s) in this transaction, whether due to outdated statistics or " +
-        "missing indexes.";
+        "This transaction was slow because a good plan was unavailable for some " +
+        "statement(s) in this transaction; possible reasons include outdated " +
+        "statistics or missing indexes.";
       break;
   }
   return {


### PR DESCRIPTION
On #97656, I updated the tooltip of suboptimal plans for statements, but there is a similar message for transactions. This commit updates that tooltip to align the message.

Part Of #97266

Release note (ui change): Update description for the Suboptimal Insight for Transactions.