### PR TITLE
pg_catalog: handle temp tables in lookup joins

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/temp_table
+++ b/pkg/sql/logictest/testdata/logic_test/temp_table
@@ -397,3 +397,27 @@ SELECT * FROM pg_temp.t
 statement ok
 USE defaultdb;
 DROP DATABASE to_drop CASCADE;
+
+subtest end
+
+subtest temp_table_in_other_session
+
+user testuser
+
+statement ok
+USE defaultdb;
+CREATE TEMPORARY TABLE from_other_session(i INT PRIMARY KEY)
+
+user root
+
+statement ok
+USE defaultdb
+
+query TT
+SELECT c.relname, a.attname FROM pg_attribute a
+INNER LOOKUP JOIN pg_class c ON c.oid = a.attrelid
+WHERE c.relname = 'from_other_session'
+----
+from_other_session  i
+
+subtest end


### PR DESCRIPTION
The included test previously would have failed with an error like `unknown schema "[151]"`. In Postgres, temporary tables from other sessions are visible in pg_catalog, so we match that behavior.

Found in the npgsql nightly tests.
informs https://github.com/cockroachdb/cockroach/issues/97614

Release note (bug fix): Fixed an error that could occur when querying a pg_catalog table that included information about a temporary table created in another session.