### PR TITLE
logictest: disable auto stats collection on system tables

### DIFF
--- a/pkg/sql/logictest/logic.go
+++ b/pkg/sql/logictest/logic.go
@@ -1676,6 +1676,11 @@ func (t *logicTest) newCluster(
 		); err != nil {
 			t.Fatal(err)
 		}
+		if _, err := conn.Exec(
+			"SET CLUSTER SETTING sql.stats.system_tables_autostats.enabled = false",
+		); err != nil {
+			t.Fatal(err)
+		}
 
 		// We also disable stats forecasts to have deterministic tests. See #97003
 		// for details.


### PR DESCRIPTION
This commit makes it so that we disable auto stats collection on the system tables in all logic tests in order to make them deterministic. We already do this for all non-system tables.

Fixes: #97704.

Release note: None