### PR TITLE
release-22.1: sql: add metrics for prepared statement memory usage

### DIFF
--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -850,6 +850,13 @@ func (s *Server) newConnExecutor(
 		memMetrics.SessionMaxBytesHist,
 		-1 /* increment */, noteworthyMemoryUsageBytes, s.cfg.Settings,
 	)
+	sessionPreparedMon := mon.NewMonitor(
+		"session prepared statements",
+		mon.MemoryResource,
+		memMetrics.SessionPreparedCurBytesCount,
+		memMetrics.SessionPreparedMaxBytesHist,
+		-1 /* increment */, noteworthyMemoryUsageBytes, s.cfg.Settings,
+	)
 	// The txn monitor is started in txnState.resetForNewSQLTxn().
 	txnMon := mon.NewMonitor(
 		"txn",
@@ -867,6 +874,7 @@ func (s *Server) newConnExecutor(
 		clientComm:          clientComm,
 		mon:                 sessionRootMon,
 		sessionMon:          sessionMon,
+		sessionPreparedMon:  sessionPreparedMon,
 		sessionDataStack:    sdMutIterator.sds,
 		dataMutatorIterator: sdMutIterator,
 		state: txnState{
@@ -1164,10 +1172,12 @@ func (ex *connExecutor) close(ctx context.Context, closeType closeType) {
 
 	if closeType != panicClose {
 		ex.state.mon.Stop(ctx)
+		ex.sessionPreparedMon.Stop(ctx)
 		ex.sessionMon.Stop(ctx)
 		ex.mon.Stop(ctx)
 	} else {
 		ex.state.mon.EmergencyStop(ctx)
+		ex.sessionPreparedMon.EmergencyStop(ctx)
 		ex.sessionMon.EmergencyStop(ctx)
 		ex.mon.EmergencyStop(ctx)
 	}
@@ -1213,6 +1223,9 @@ type connExecutor struct {
 	// statistics for result sets (which escape transactions).
 	mon        *mon.BytesMonitor
 	sessionMon *mon.BytesMonitor
+
+	// sessionPreparedMon tracks memory usage by prepared statements.
+	sessionPreparedMon *mon.BytesMonitor
 	// memMetrics contains the metrics that statements executed on this connection
 	// will contribute to.
 	memMetrics MemoryMetrics
@@ -1740,6 +1753,7 @@ func (ex *connExecutor) activate(
 	// single threaded, and the point of buffering is just to avoid contention.
 	ex.mon.Start(ctx, parentMon, reserved)
 	ex.sessionMon.Start(ctx, ex.mon, mon.BoundAccount{})
+	ex.sessionPreparedMon.Start(ctx, ex.sessionMon, mon.BoundAccount{})
 
 	// Enable the trace if configured.
 	if traceSessionEventLogEnabled.Get(&ex.server.cfg.Settings.SV) {

--- a/pkg/sql/conn_executor_prepare.go
+++ b/pkg/sql/conn_executor_prepare.go
@@ -151,7 +151,7 @@ func (ex *connExecutor) prepare(
 ) (_ *PreparedStatement, retErr error) {
 
 	prepared := &PreparedStatement{
-		memAcc:   ex.sessionMon.MakeBoundAccount(),
+		memAcc:   ex.sessionPreparedMon.MakeBoundAccount(),
 		refCount: 1,
 
 		createdAt: timeutil.Now(),

--- a/pkg/ts/catalog/chart_catalog.go
+++ b/pkg/ts/catalog/chart_catalog.go
@@ -2205,6 +2205,14 @@ var charts = []sectionDescription{
 				Metrics: []string{"sql.mem.internal.session.current"},
 			},
 			{
+				Title:   "Prepared Statements All",
+				Metrics: []string{"sql.mem.internal.session.prepared.max"},
+			},
+			{
+				Title:   "Prepared Statements Current",
+				Metrics: []string{"sql.mem.internal.session.prepared.current"},
+			},
+			{
 				Title:   "Txn All",
 				Metrics: []string{"sql.mem.internal.txn.max"},
 			},
@@ -2224,6 +2232,14 @@ var charts = []sectionDescription{
 			{
 				Title:   "Max",
 				Metrics: []string{"sql.mem.sql.session.max"},
+			},
+			{
+				Title:   "Prepared Statements Current",
+				Metrics: []string{"sql.mem.sql.session.prepared.current"},
+			},
+			{
+				Title:   "Prepared Statements Max",
+				Metrics: []string{"sql.mem.sql.session.prepared.max"},
 			},
 		},
 	},


### PR DESCRIPTION
Backport 1/1 commits from #97590.

/cc @cockroachdb/release

---

Add node-level metrics for memory used by prepared statements across all sessions.

Assists: #72581

Epic: None

Release note (ui change): Add the following new metrics to track memory usage of prepared statements in sessions:
- sql.mem.internal.session.prepared.current
- sql.mem.internal.session.prepared.max-avg
- sql.mem.internal.session.prepared.max-count
- sql.mem.internal.session.prepared.max-max
- sql.mem.internal.session.prepared.max-p50
- sql.mem.internal.session.prepared.max-p75
- sql.mem.internal.session.prepared.max-p90
- sql.mem.internal.session.prepared.max-p99
- sql.mem.internal.session.prepared.max-p99.9
- sql.mem.internal.session.prepared.max-p99.99
- sql.mem.internal.session.prepared.max-p99.999
- sql.mem.sql.session.prepared.current
- sql.mem.sql.session.prepared.max-avg
- sql.mem.sql.session.prepared.max-count
- sql.mem.sql.session.prepared.max-max
- sql.mem.sql.session.prepared.max-p50
- sql.mem.sql.session.prepared.max-p75
- sql.mem.sql.session.prepared.max-p90
- sql.mem.sql.session.prepared.max-p99
- sql.mem.sql.session.prepared.max-p99.9
- sql.mem.sql.session.prepared.max-p99.99
- sql.mem.sql.session.prepared.max-p99.999

----

Release justification: small change to metrics to improve observability.