### PR TITLE
release-22.2: logictest: disable statistics forecasts by default

### DIFF
--- a/pkg/sql/logictest/logic.go
+++ b/pkg/sql/logictest/logic.go
@@ -1550,6 +1550,14 @@ func (t *logicTest) newCluster(
 			t.Fatal(err)
 		}
 
+		// We also disable stats forecasts to have deterministic tests. See #97003
+		// for details.
+		if _, err := conn.Exec(
+			"SET CLUSTER SETTING sql.stats.forecasts.enabled = false",
+		); err != nil {
+			t.Fatal(err)
+		}
+
 		// Update the default AS OF time for querying the system.table_statistics
 		// table to create the crdb_internal.table_row_statistics table.
 		if _, err := conn.Exec(

--- a/pkg/sql/opt/exec/execbuilder/testdata/forecast
+++ b/pkg/sql/opt/exec/execbuilder/testdata/forecast
@@ -5,6 +5,13 @@
 # Verify that we create and use statistics forecasts for a simple table that
 # grows at a constant rate.
 
+let $forecastsEnabledPrev
+SHOW CLUSTER SETTING sql.stats.forecasts.enabled
+
+# First: enable statistics forecasts.
+statement ok
+SET CLUSTER SETTING sql.stats.forecasts.enabled = true
+
 statement ok
 CREATE TABLE g (a INT PRIMARY KEY) WITH (sql_stats_automatic_collection_enabled = false)
 
@@ -1596,3 +1603,7 @@ RESET enable_zigzag_join
 
 statement ok
 RESET optimizer_use_forecasts
+
+# Finally, restore forecasts setting to its previous value.
+statement ok
+SET CLUSTER SETTING sql.stats.forecasts.enabled = $forecastsEnabledPrev

--- a/pkg/sql/opt/exec/execbuilder/testdata/forecast1401
+++ b/pkg/sql/opt/exec/execbuilder/testdata/forecast1401
@@ -2,6 +2,13 @@
 
 # Test whether statistics forecasts help the query from case 1401.
 
+let $forecastsEnabledPrev
+SHOW CLUSTER SETTING sql.stats.forecasts.enabled
+
+# First: enable statistics forecasts.
+statement ok
+SET CLUSTER SETTING sql.stats.forecasts.enabled = true
+
 statement ok
 CREATE TABLE t1401 (
   a INT8 NOT NULL,
@@ -18481,3 +18488,7 @@ vectorized: true
               estimated row count: 101 - 632 (<0.01% of the table; stats collected <hidden> ago; using stats forecast)
               table: t1401@t1401_f_c_idx1 (partial index)
               spans: [/4458256 - /4458256/'2022-01-25 21:17:27.216095+00:00']
+
+# Finally, restore forecasts setting to its previous value.
+statement ok
+SET CLUSTER SETTING sql.stats.forecasts.enabled = $forecastsEnabledPrev


### PR DESCRIPTION
Backport 1/1 commits from #97510.

/cc @cockroachdb/release

---

Fixes: #97003

Epic: None

Release note: None

---

Release justification: test-only change.