### PR TITLE
sql,schemachanger: ADD PRIMARY KEY NOT VALID returns an error

### DIFF
--- a/pkg/sql/alter_table.go
+++ b/pkg/sql/alter_table.go
@@ -37,6 +37,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgnotice"
 	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
 	"github.com/cockroachdb/cockroach/pkg/sql/roleoption"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/catconstants"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/eval"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/semenumpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
@@ -229,6 +230,9 @@ func (n *alterTableNode) startExec(params runParams) error {
 				}
 
 				if d.PrimaryKey {
+					if t.ValidationBehavior == tree.ValidationSkip {
+						return sqlerrors.NewUnsupportedUnvalidatedConstraintError(catconstants.ConstraintTypePK)
+					}
 					// Translate this operation into an ALTER PRIMARY KEY command.
 					alterPK := &tree.AlterTableAlterPrimaryKey{
 						Columns:       d.Columns,

--- a/pkg/sql/logictest/testdata/logic_test/alter_table
+++ b/pkg/sql/logictest/testdata/logic_test/alter_table
@@ -3135,3 +3135,21 @@ CREATE TABLE public.t_twocol (
   CONSTRAINT t_twocol_pkey PRIMARY KEY (id ASC),
   FAMILY fam_0 (id, a)
 )
+
+# This subtests ensures we cannot add an unvalidated PK constraint
+subtest add_unvalidated_pk_96729
+
+statement ok
+CREATE TABLE t_96729 (i INT NOT NULL)
+
+statement error pgcode 0A000 PRIMARY KEY constraints cannot be marked NOT VALID
+ALTER TABLE t_96729 ADD PRIMARY KEY (i) NOT VALID;
+
+statement ok
+ALTER TABLE t_96729 ADD PRIMARY KEY (i);
+
+query TTTTB colnames
+SHOW CONSTRAINTS FROM t_96729
+----
+table_name  constraint_name  constraint_type  details              validated
+t_96729     t_96729_pkey     PRIMARY KEY      PRIMARY KEY (i ASC)  true

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/BUILD.bazel
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/BUILD.bazel
@@ -57,6 +57,7 @@ go_library(
         "//pkg/sql/schemachanger/scerrors",
         "//pkg/sql/schemachanger/scpb",
         "//pkg/sql/schemachanger/screl",
+        "//pkg/sql/sem/catconstants",
         "//pkg/sql/sem/catid",
         "//pkg/sql/sem/eval",
         "//pkg/sql/sem/tree",

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_table.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_table.go
@@ -52,7 +52,7 @@ var supportedAlterTableStatements = map[reflect.Type]supportedAlterTableCommand{
 	reflect.TypeOf((*tree.AlterTableAddConstraint)(nil)): {fn: alterTableAddConstraint, on: true, extraChecks: func(
 		t *tree.AlterTableAddConstraint,
 	) bool {
-		if d, ok := t.ConstraintDef.(*tree.UniqueConstraintTableDef); ok && d.PrimaryKey && t.ValidationBehavior == tree.ValidationDefault {
+		if d, ok := t.ConstraintDef.(*tree.UniqueConstraintTableDef); ok && d.PrimaryKey {
 			// Support ALTER TABLE ... ADD PRIMARY KEY
 			return true
 		} else if ok && d.WithoutIndex {
@@ -85,6 +85,7 @@ var alterTableAddConstraintMinSupportedClusterVersion = map[string]clusterversio
 	"ADD_CHECK_DEFAULT":                clusterversion.V23_1,
 	"ADD_FOREIGN_KEY_DEFAULT":          clusterversion.V23_1,
 	"ADD_UNIQUE_WITHOUT_INDEX_DEFAULT": clusterversion.V23_1,
+	"ADD_PRIMARY_KEY_SKIP":             clusterversion.V23_1,
 	"ADD_CHECK_SKIP":                   clusterversion.V23_1,
 	"ADD_UNIQUE_WITHOUT_INDEX_SKIP":    clusterversion.V23_1,
 	"ADD_FOREIGN_KEY_SKIP":             clusterversion.V23_1,

--- a/pkg/sql/sqlerrors/BUILD.bazel
+++ b/pkg/sql/sqlerrors/BUILD.bazel
@@ -12,6 +12,7 @@ go_library(
         "//pkg/sql/catalog/descpb",
         "//pkg/sql/pgwire/pgcode",
         "//pkg/sql/pgwire/pgerror",
+        "//pkg/sql/sem/catconstants",
         "//pkg/sql/sem/tree",
         "//pkg/sql/types",
         "@com_github_cockroachdb_errors//:errors",

--- a/pkg/sql/sqlerrors/errors.go
+++ b/pkg/sql/sqlerrors/errors.go
@@ -17,6 +17,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/catconstants"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/errors"
@@ -169,6 +170,11 @@ func NewDatabaseAlreadyExistsError(name string) error {
 // NewSchemaAlreadyExistsError creates an error for a preexisting schema.
 func NewSchemaAlreadyExistsError(name string) error {
 	return pgerror.Newf(pgcode.DuplicateSchema, "schema %q already exists", name)
+}
+
+func NewUnsupportedUnvalidatedConstraintError(constraintType catconstants.ConstraintType) error {
+	return pgerror.Newf(pgcode.FeatureNotSupported,
+		"%v constraints cannot be marked NOT VALID", constraintType)
 }
 
 // WrapErrorWhileConstructingObjectAlreadyExistsErr is used to wrap an error


### PR DESCRIPTION
Fixes https://github.com/cockroachdb/cockroach/issues/96729

Release note (sql change): When we add an unvalidated PK constraint to a table, assuming its PK was on the implicit "rowid" column, will return an error. This is compatible to what PG will do.