### PR TITLE
sql/schemachanger/scbuild: properly rewrite exprs in partial predicates

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/partial_index
+++ b/pkg/sql/logictest/testdata/logic_test/partial_index
@@ -2034,3 +2034,48 @@ DROP INDEX t96924_idx_1
 
 statement ok
 ALTER TABLE t96924 ALTER PRIMARY KEY USING COLUMNS (a);
+
+subtest enum_cast_references
+
+statement ok
+CREATE TYPE enum97551 AS ENUM ('a', 'b', 'c');
+CREATE TABLE t97551 (i INT PRIMARY KEY, j STRING);
+
+# We shouldn't be allowed to create this index because the cast from string
+# to an enum is not immutable. However, we can because of  #68672, so we
+# exercise that here. There's another set of statements below which can
+# continue to exist after that bug is fixed and also protect against the
+# underlying regression.
+statement ok
+CREATE INDEX idx97551 ON t97551 (j) WHERE (j::enum97551 = 'a'::enum97551);
+
+statement error pgcode 2BP01 cannot drop type "enum97551" because other objects \(\[test\.public\.t97551\]\) still depend on it
+DROP TYPE enum97551;
+
+statement ok
+DROP INDEX idx97551;
+
+statement ok
+DROP TYPE enum97551;
+
+# Do the same dance but with an expression that is actually immutable.
+
+statement ok
+CREATE TYPE enum97551 AS ENUM ('a', 'b', 'c');
+
+statement ok
+ALTER TABLE t97551 ADD COLUMN e enum97551;
+
+statement ok
+CREATE INDEX idx97551 ON t97551 (e) WHERE (e = 'a'::enum97551);
+
+statement error pgcode 2BP01 cannot drop type "enum97551" because other objects \(\[test\.public\.t97551\]\) still depend on it
+DROP TYPE enum97551;
+
+statement ok
+DROP INDEX idx97551;
+
+statement ok
+DROP TABLE t97551;
+DROP TYPE enum97551;
+

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/create_index.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/create_index.go
@@ -930,7 +930,7 @@ func maybeAddIndexPredicate(b BuildCtx, n *tree.CreateIndex, idxSpec *indexSpec)
 		return
 	}
 	expr := b.PartialIndexPredicateExpression(idxSpec.secondary.TableID, n.Predicate)
-	idxSpec.secondary.EmbeddedExpr = expr
+	idxSpec.secondary.EmbeddedExpr = b.WrapExpression(idxSpec.secondary.TableID, expr)
 	b.IncrementSchemaChangeIndexCounter("partial")
 	if n.Inverted {
 		b.IncrementSchemaChangeIndexCounter("partial_inverted")

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/dependencies.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/dependencies.go
@@ -254,7 +254,7 @@ type TableHelpers interface {
 	// wrapped expression
 	PartialIndexPredicateExpression(
 		tableID catid.DescID, expr tree.Expr,
-	) *scpb.Expression
+	) tree.Expr
 
 	// IsTableEmpty returns if the table is empty or not.
 	IsTableEmpty(tbl *scpb.Table) bool

--- a/pkg/sql/schemachanger/scbuild/testdata/drop_index
+++ b/pkg/sql/schemachanger/scbuild/testdata/drop_index
@@ -42,7 +42,7 @@ DROP INDEX idx2 CASCADE
 - [[IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 4}, ABSENT], PUBLIC]
   {columnId: 3, indexId: 4, kind: KEY_SUFFIX, tableId: 104}
 - [[SecondaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 0}, ABSENT], PUBLIC]
-  {expr: i > 0, indexId: 4, isCreatedExplicitly: true, referencedColumnIds: [1], tableId: 104}
+  {expr: 'i > 0:::INT8', indexId: 4, isCreatedExplicitly: true, referencedColumnIds: [1], tableId: 104}
 - [[IndexName:{DescID: 104, Name: idx2, IndexID: 4}, ABSENT], PUBLIC]
   {indexId: 4, name: idx2, tableId: 104}
 - [[IndexData:{DescID: 104, IndexID: 4}, ABSENT], PUBLIC]

--- a/pkg/sql/schemachanger/scplan/testdata/drop_table
+++ b/pkg/sql/schemachanger/scplan/testdata/drop_table
@@ -155,7 +155,7 @@ PreCommitPhase stage 1 of 2 with 1 MutationType op
   ops:
     *scop.UndoAllInTxnImmediateMutationOpSideEffects
       {}
-PreCommitPhase stage 2 of 2 with 119 MutationType ops
+PreCommitPhase stage 2 of 2 with 120 MutationType ops
   transitions:
     [[Namespace:{DescID: 109, Name: shipments, ReferencedDescID: 100}, ABSENT], PUBLIC] -> ABSENT
     [[Owner:{DescID: 109}, ABSENT], PUBLIC] -> ABSENT
@@ -542,6 +542,11 @@ PreCommitPhase stage 2 of 2 with 119 MutationType ops
     *scop.RemoveDroppedIndexPartialPredicate
       IndexID: 2
       TableID: 109
+    *scop.UpdateTableBackReferencesInTypes
+      BackReferencedTableID: 109
+      TypeIDs:
+      - 107
+      - 108
     *scop.SetIndexName
       IndexID: 2
       Name: crdb_internal_index_2_name_placeholder

--- a/pkg/sql/schemachanger/testdata/end_to_end/create_index
+++ b/pkg/sql/schemachanger/testdata/end_to_end/create_index
@@ -57,7 +57,19 @@ write *eventpb.CreateIndex to event log:
     tag: CREATE INDEX
     user: root
   tableName: defaultdb.public.t
-## StatementPhase stage 1 of 1 with 8 MutationType ops
+## StatementPhase stage 1 of 1 with 9 MutationType ops
+upsert descriptor #104
+  ...
+     referencingDescriptorIds:
+     - 106
+  -  version: "2"
+  +  version: "3"
+upsert descriptor #105
+  ...
+     referencingDescriptorIds:
+     - 106
+  -  version: "2"
+  +  version: "3"
 upsert descriptor #106
   ...
      id: 106
@@ -81,7 +93,7 @@ upsert descriptor #106
   +      - 1
   +      name: idx1
   +      partitioning: {}
-  +      predicate: (v = 'a')
+  +      predicate: v = b'@':::@100104
   +      sharded: {}
   +      storeColumnNames: []
   +      version: 4
@@ -129,7 +141,38 @@ upsert descriptor #106
 ## PreCommitPhase stage 1 of 2 with 1 MutationType op
 undo all catalog changes within txn #1
 persist all catalog changes to storage
-## PreCommitPhase stage 2 of 2 with 12 MutationType ops
+## PreCommitPhase stage 2 of 2 with 15 MutationType ops
+upsert descriptor #104
+   type:
+     arrayTypeId: 105
+  +  declarativeSchemaChangerState:
+  +    authorization:
+  +      userName: root
+  +    jobId: "1"
+  +    revertible: true
+     enumMembers:
+     - logicalRepresentation: a
+  ...
+     referencingDescriptorIds:
+     - 106
+  -  version: "2"
+  +  version: "3"
+upsert descriptor #105
+  ...
+       family: ArrayFamily
+       oid: 100105
+  +  declarativeSchemaChangerState:
+  +    authorization:
+  +      userName: root
+  +    jobId: "1"
+  +    revertible: true
+     id: 105
+     kind: ALIAS
+  ...
+     referencingDescriptorIds:
+     - 106
+  -  version: "2"
+  +  version: "3"
 upsert descriptor #106
   ...
      createAsOfTime:
@@ -172,7 +215,7 @@ upsert descriptor #106
   +      - 1
   +      name: idx1
   +      partitioning: {}
-  +      predicate: (v = 'a')
+  +      predicate: v = b'@':::@100104
   +      sharded: {}
   +      storeColumnNames: []
   +      version: 4
@@ -217,7 +260,7 @@ upsert descriptor #106
   +  version: "2"
 persist all catalog changes to storage
 create job #1 (non-cancelable: false): "CREATE INDEX idx1 ON defaultdb.public.t (v) WHERE (v = 'a')"
-  descriptor IDs: [106]
+  descriptor IDs: [104 105 106]
 # end PreCommitPhase
 commit transaction #1
 notified job registry to adopt jobs: [1]
@@ -225,7 +268,19 @@ notified job registry to adopt jobs: [1]
 begin transaction #2
 commit transaction #2
 begin transaction #3
-## PostCommitPhase stage 1 of 7 with 3 MutationType ops
+## PostCommitPhase stage 1 of 7 with 5 MutationType ops
+upsert descriptor #104
+  ...
+     referencingDescriptorIds:
+     - 106
+  -  version: "3"
+  +  version: "4"
+upsert descriptor #105
+  ...
+     referencingDescriptorIds:
+     - 106
+  -  version: "3"
+  +  version: "4"
 upsert descriptor #106
   ...
          version: 4
@@ -247,7 +302,19 @@ begin transaction #4
 backfill indexes [2] from index #1 in table #106
 commit transaction #4
 begin transaction #5
-## PostCommitPhase stage 3 of 7 with 3 MutationType ops
+## PostCommitPhase stage 3 of 7 with 5 MutationType ops
+upsert descriptor #104
+  ...
+     referencingDescriptorIds:
+     - 106
+  -  version: "4"
+  +  version: "5"
+upsert descriptor #105
+  ...
+     referencingDescriptorIds:
+     - 106
+  -  version: "4"
+  +  version: "5"
 upsert descriptor #106
   ...
          version: 4
@@ -265,7 +332,19 @@ persist all catalog changes to storage
 update progress of schema change job #1: "PostCommitPhase stage 4 of 7 with 1 MutationType op pending"
 commit transaction #5
 begin transaction #6
-## PostCommitPhase stage 4 of 7 with 3 MutationType ops
+## PostCommitPhase stage 4 of 7 with 5 MutationType ops
+upsert descriptor #104
+  ...
+     referencingDescriptorIds:
+     - 106
+  -  version: "5"
+  +  version: "6"
+upsert descriptor #105
+  ...
+     referencingDescriptorIds:
+     - 106
+  -  version: "5"
+  +  version: "6"
 upsert descriptor #106
   ...
          version: 4
@@ -287,7 +366,19 @@ begin transaction #7
 merge temporary indexes [3] into backfilled indexes [2] in table #106
 commit transaction #7
 begin transaction #8
-## PostCommitPhase stage 6 of 7 with 3 MutationType ops
+## PostCommitPhase stage 6 of 7 with 5 MutationType ops
+upsert descriptor #104
+  ...
+     referencingDescriptorIds:
+     - 106
+  -  version: "6"
+  +  version: "7"
+upsert descriptor #105
+  ...
+     referencingDescriptorIds:
+     - 106
+  -  version: "6"
+  +  version: "7"
 upsert descriptor #106
   ...
          version: 4
@@ -309,7 +400,31 @@ begin transaction #9
 validate forward indexes [2] in table #106
 commit transaction #9
 begin transaction #10
-## PostCommitNonRevertiblePhase stage 1 of 2 with 7 MutationType ops
+## PostCommitNonRevertiblePhase stage 1 of 2 with 9 MutationType ops
+upsert descriptor #104
+  ...
+         userName: root
+       jobId: "1"
+  -    revertible: true
+     enumMembers:
+     - logicalRepresentation: a
+  ...
+     referencingDescriptorIds:
+     - 106
+  -  version: "7"
+  +  version: "8"
+upsert descriptor #105
+  ...
+         userName: root
+       jobId: "1"
+  -    revertible: true
+     id: 105
+     kind: ALIAS
+  ...
+     referencingDescriptorIds:
+     - 106
+  -  version: "7"
+  +  version: "8"
 upsert descriptor #106
   ...
            statement: CREATE INDEX idx1 ON t (v) WHERE (v = 'a')
@@ -337,7 +452,7 @@ upsert descriptor #106
   +    - 1
   +    name: idx1
   +    partitioning: {}
-  +    predicate: (v = 'a')
+  +    predicate: v = b'@':::@100104
   +    sharded: {}
   +    storeColumnNames: []
   +    version: 4
@@ -362,7 +477,7 @@ upsert descriptor #106
   -      - 1
   -      name: idx1
   -      partitioning: {}
-  -      predicate: (v = 'a')
+  -      predicate: v = b'@':::@100104
   -      sharded: {}
   -      storeColumnNames: []
   -      version: 4
@@ -390,7 +505,36 @@ update progress of schema change job #1: "PostCommitNonRevertiblePhase stage 2 o
 set schema change job #1 to non-cancellable
 commit transaction #10
 begin transaction #11
-## PostCommitNonRevertiblePhase stage 2 of 2 with 4 MutationType ops
+## PostCommitNonRevertiblePhase stage 2 of 2 with 6 MutationType ops
+upsert descriptor #104
+   type:
+     arrayTypeId: 105
+  -  declarativeSchemaChangerState:
+  -    authorization:
+  -      userName: root
+  -    jobId: "1"
+     enumMembers:
+     - logicalRepresentation: a
+  ...
+     referencingDescriptorIds:
+     - 106
+  -  version: "8"
+  +  version: "9"
+upsert descriptor #105
+  ...
+       family: ArrayFamily
+       oid: 100105
+  -  declarativeSchemaChangerState:
+  -    authorization:
+  -      userName: root
+  -    jobId: "1"
+     id: 105
+     kind: ALIAS
+  ...
+     referencingDescriptorIds:
+     - 106
+  -  version: "8"
+  +  version: "9"
 upsert descriptor #106
   ...
      createAsOfTime:

--- a/pkg/sql/schemachanger/testdata/end_to_end/drop_index_partial_expression_index
+++ b/pkg/sql/schemachanger/testdata/end_to_end/drop_index_partial_expression_index
@@ -62,7 +62,7 @@ upsert descriptor #104
   -    - 1
   -    name: idx
   -    partitioning: {}
-  -    predicate: i > 0
+  -    predicate: i > 0:::INT8
   -    sharded: {}
   -    version: 4
   +  indexes: []
@@ -86,7 +86,7 @@ upsert descriptor #104
   +      - 1
   +      name: idx
   +      partitioning: {}
-  +      predicate: i > 0
+  +      predicate: i > 0:::INT8
   +      sharded: {}
   +      version: 4
   +    mutationId: 1
@@ -168,7 +168,7 @@ upsert descriptor #104
   -    - 1
   -    name: idx
   -    partitioning: {}
-  -    predicate: i > 0
+  -    predicate: i > 0:::INT8
   -    sharded: {}
   -    version: 4
   +  indexes: []
@@ -192,7 +192,7 @@ upsert descriptor #104
   +      - 1
   +      name: idx
   +      partitioning: {}
-  +      predicate: i > 0
+  +      predicate: i > 0:::INT8
   +      sharded: {}
   +      version: 4
   +    mutationId: 1
@@ -236,7 +236,7 @@ upsert descriptor #104
   -      name: idx
   +      name: crdb_internal_index_2_name_placeholder
          partitioning: {}
-  -      predicate: i > 0
+  -      predicate: i > 0:::INT8
          sharded: {}
          version: 4
        mutationId: 1

--- a/pkg/sql/schemachanger/testdata/explain/create_index
+++ b/pkg/sql/schemachanger/testdata/explain/create_index
@@ -18,9 +18,10 @@ Schema change plan for CREATE INDEX ‹idx1› ON ‹defaultdb›.‹public›.�
  │         │    ├── ABSENT → DELETE_ONLY   TemporaryIndex:{DescID: 106, IndexID: 3, ConstraintID: 1, SourceIndexID: 1}
  │         │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 3}
  │         │    └── ABSENT → PUBLIC        IndexColumn:{DescID: 106, ColumnID: 1, IndexID: 3}
- │         └── 8 Mutation operations
+ │         └── 9 Mutation operations
  │              ├── MakeAbsentIndexBackfilling {"IsSecondaryIndex":true}
- │              ├── SetAddedIndexPartialPredicate {"Expr":"(v = 'a')","IndexID":2,"TableID":106}
+ │              ├── SetAddedIndexPartialPredicate {"Expr":"v = b'@':::@1001...","IndexID":2,"TableID":106}
+ │              ├── UpdateTableBackReferencesInTypes {"BackReferencedTableID":106}
  │              ├── AddColumnToIndex {"ColumnID":2,"IndexID":2,"TableID":106}
  │              ├── AddColumnToIndex {"ColumnID":1,"IndexID":2,"Kind":1,"TableID":106}
  │              ├── SetIndexName {"IndexID":2,"Name":"idx1","TableID":106}
@@ -52,10 +53,11 @@ Schema change plan for CREATE INDEX ‹idx1› ON ‹defaultdb›.‹public›.�
  │         │    ├── ABSENT → DELETE_ONLY   TemporaryIndex:{DescID: 106, IndexID: 3, ConstraintID: 1, SourceIndexID: 1}
  │         │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 3}
  │         │    └── ABSENT → PUBLIC        IndexColumn:{DescID: 106, ColumnID: 1, IndexID: 3}
- │         └── 12 Mutation operations
+ │         └── 15 Mutation operations
  │              ├── MakeAbsentIndexBackfilling {"IsSecondaryIndex":true}
  │              ├── MaybeAddSplitForIndex {"IndexID":2,"TableID":106}
- │              ├── SetAddedIndexPartialPredicate {"Expr":"(v = 'a')","IndexID":2,"TableID":106}
+ │              ├── SetAddedIndexPartialPredicate {"Expr":"v = b'@':::@1001...","IndexID":2,"TableID":106}
+ │              ├── UpdateTableBackReferencesInTypes {"BackReferencedTableID":106}
  │              ├── AddColumnToIndex {"ColumnID":2,"IndexID":2,"TableID":106}
  │              ├── AddColumnToIndex {"ColumnID":1,"IndexID":2,"Kind":1,"TableID":106}
  │              ├── SetIndexName {"IndexID":2,"Name":"idx1","TableID":106}
@@ -63,6 +65,8 @@ Schema change plan for CREATE INDEX ‹idx1› ON ‹defaultdb›.‹public›.�
  │              ├── MaybeAddSplitForIndex {"IndexID":3,"TableID":106}
  │              ├── AddColumnToIndex {"ColumnID":2,"IndexID":3,"TableID":106}
  │              ├── AddColumnToIndex {"ColumnID":1,"IndexID":3,"Kind":1,"TableID":106}
+ │              ├── SetJobStateOnDescriptor {"DescriptorID":104,"Initialize":true}
+ │              ├── SetJobStateOnDescriptor {"DescriptorID":105,"Initialize":true}
  │              ├── SetJobStateOnDescriptor {"DescriptorID":106,"Initialize":true}
  │              └── CreateSchemaChangerJob {"RunningStatus":"PostCommitPhase ..."}
  ├── PostCommitPhase
@@ -70,8 +74,10 @@ Schema change plan for CREATE INDEX ‹idx1› ON ‹defaultdb›.‹public›.�
  │    │    ├── 2 elements transitioning toward TRANSIENT_ABSENT
  │    │    │    ├── DELETE_ONLY → WRITE_ONLY TemporaryIndex:{DescID: 106, IndexID: 3, ConstraintID: 1, SourceIndexID: 1}
  │    │    │    └── ABSENT      → PUBLIC     IndexData:{DescID: 106, IndexID: 3}
- │    │    └── 3 Mutation operations
+ │    │    └── 5 Mutation operations
  │    │         ├── MakeDeleteOnlyIndexWriteOnly {"IndexID":3,"TableID":106}
+ │    │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
+ │    │         ├── SetJobStateOnDescriptor {"DescriptorID":105}
  │    │         ├── SetJobStateOnDescriptor {"DescriptorID":106}
  │    │         └── UpdateSchemaChangerJob {"RunningStatus":"PostCommitPhase ..."}
  │    ├── Stage 2 of 7 in PostCommitPhase
@@ -82,15 +88,19 @@ Schema change plan for CREATE INDEX ‹idx1› ON ‹defaultdb›.‹public›.�
  │    ├── Stage 3 of 7 in PostCommitPhase
  │    │    ├── 1 element transitioning toward PUBLIC
  │    │    │    └── BACKFILLED → DELETE_ONLY SecondaryIndex:{DescID: 106, IndexID: 2, ConstraintID: 0, TemporaryIndexID: 3, SourceIndexID: 1}
- │    │    └── 3 Mutation operations
+ │    │    └── 5 Mutation operations
  │    │         ├── MakeBackfillingIndexDeleteOnly {"IndexID":2,"TableID":106}
+ │    │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
+ │    │         ├── SetJobStateOnDescriptor {"DescriptorID":105}
  │    │         ├── SetJobStateOnDescriptor {"DescriptorID":106}
  │    │         └── UpdateSchemaChangerJob {"RunningStatus":"PostCommitPhase ..."}
  │    ├── Stage 4 of 7 in PostCommitPhase
  │    │    ├── 1 element transitioning toward PUBLIC
  │    │    │    └── DELETE_ONLY → MERGE_ONLY SecondaryIndex:{DescID: 106, IndexID: 2, ConstraintID: 0, TemporaryIndexID: 3, SourceIndexID: 1}
- │    │    └── 3 Mutation operations
+ │    │    └── 5 Mutation operations
  │    │         ├── MakeBackfilledIndexMerging {"IndexID":2,"TableID":106}
+ │    │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
+ │    │         ├── SetJobStateOnDescriptor {"DescriptorID":105}
  │    │         ├── SetJobStateOnDescriptor {"DescriptorID":106}
  │    │         └── UpdateSchemaChangerJob {"RunningStatus":"PostCommitPhase ..."}
  │    ├── Stage 5 of 7 in PostCommitPhase
@@ -101,8 +111,10 @@ Schema change plan for CREATE INDEX ‹idx1› ON ‹defaultdb›.‹public›.�
  │    ├── Stage 6 of 7 in PostCommitPhase
  │    │    ├── 1 element transitioning toward PUBLIC
  │    │    │    └── MERGED → WRITE_ONLY SecondaryIndex:{DescID: 106, IndexID: 2, ConstraintID: 0, TemporaryIndexID: 3, SourceIndexID: 1}
- │    │    └── 3 Mutation operations
+ │    │    └── 5 Mutation operations
  │    │         ├── MakeMergedIndexWriteOnly {"IndexID":2,"TableID":106}
+ │    │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
+ │    │         ├── SetJobStateOnDescriptor {"DescriptorID":105}
  │    │         ├── SetJobStateOnDescriptor {"DescriptorID":106}
  │    │         └── UpdateSchemaChangerJob {"RunningStatus":"PostCommitPhase ..."}
  │    └── Stage 7 of 7 in PostCommitPhase
@@ -118,20 +130,24 @@ Schema change plan for CREATE INDEX ‹idx1› ON ‹defaultdb›.‹public›.�
       │    │    ├── WRITE_ONLY → TRANSIENT_DELETE_ONLY TemporaryIndex:{DescID: 106, IndexID: 3, ConstraintID: 1, SourceIndexID: 1}
       │    │    ├── PUBLIC     → TRANSIENT_ABSENT      IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 3}
       │    │    └── PUBLIC     → TRANSIENT_ABSENT      IndexColumn:{DescID: 106, ColumnID: 1, IndexID: 3}
-      │    └── 7 Mutation operations
+      │    └── 9 Mutation operations
       │         ├── MakeValidatedSecondaryIndexPublic {"IndexID":2,"TableID":106}
       │         ├── RefreshStats {"TableID":106}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":3,"TableID":106}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":3,"TableID":106}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":3,"Kind":1,"TableID":106}
+      │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
+      │         ├── SetJobStateOnDescriptor {"DescriptorID":105}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":106}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
       └── Stage 2 of 2 in PostCommitNonRevertiblePhase
            ├── 2 elements transitioning toward TRANSIENT_ABSENT
            │    ├── TRANSIENT_DELETE_ONLY → TRANSIENT_ABSENT TemporaryIndex:{DescID: 106, IndexID: 3, ConstraintID: 1, SourceIndexID: 1}
            │    └── PUBLIC                → TRANSIENT_ABSENT IndexData:{DescID: 106, IndexID: 3}
-           └── 4 Mutation operations
+           └── 6 Mutation operations
                 ├── MakeIndexAbsent {"IndexID":3,"TableID":106}
                 ├── CreateGCJobForIndex {"IndexID":3,"TableID":106}
+                ├── RemoveJobStateFromDescriptor {"DescriptorID":104}
+                ├── RemoveJobStateFromDescriptor {"DescriptorID":105}
                 ├── RemoveJobStateFromDescriptor {"DescriptorID":106}
                 └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"all stages compl..."}

--- a/pkg/sql/schemachanger/testdata/explain/create_index.rollback_1_of_7
+++ b/pkg/sql/schemachanger/testdata/explain/create_index.rollback_1_of_7
@@ -18,7 +18,7 @@ Schema change plan for rolling back CREATE INDEX ‹idx1› ON ‹defaultdb›.p
            │    ├── DELETE_ONLY   → ABSENT TemporaryIndex:{DescID: 106, IndexID: 3, ConstraintID: 1, SourceIndexID: 1}
            │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 3}
            │    └── PUBLIC        → ABSENT IndexColumn:{DescID: 106, ColumnID: 1, IndexID: 3}
-           └── 10 Mutation operations
+           └── 12 Mutation operations
                 ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":2,"TableID":106}
                 ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":2,"Kind":1,"TableID":106}
                 ├── SetIndexName {"IndexID":2,"Name":"crdb_internal_in...","TableID":106}
@@ -27,5 +27,7 @@ Schema change plan for rolling back CREATE INDEX ‹idx1› ON ‹defaultdb›.p
                 ├── MakeIndexAbsent {"IndexID":2,"TableID":106}
                 ├── CreateGCJobForIndex {"IndexID":2,"TableID":106}
                 ├── MakeIndexAbsent {"IndexID":3,"TableID":106}
+                ├── RemoveJobStateFromDescriptor {"DescriptorID":104}
+                ├── RemoveJobStateFromDescriptor {"DescriptorID":105}
                 ├── RemoveJobStateFromDescriptor {"DescriptorID":106}
                 └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"all stages compl..."}

--- a/pkg/sql/schemachanger/testdata/explain/create_index.rollback_2_of_7
+++ b/pkg/sql/schemachanger/testdata/explain/create_index.rollback_2_of_7
@@ -17,7 +17,7 @@ Schema change plan for rolling back CREATE INDEX ‹idx1› ON ‹defaultdb›.p
       │    │    ├── WRITE_ONLY    → DELETE_ONLY TemporaryIndex:{DescID: 106, IndexID: 3, ConstraintID: 1, SourceIndexID: 1}
       │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 3}
       │    │    └── PUBLIC        → ABSENT      IndexColumn:{DescID: 106, ColumnID: 1, IndexID: 3}
-      │    └── 9 Mutation operations
+      │    └── 11 Mutation operations
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":2,"TableID":106}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":2,"Kind":1,"TableID":106}
       │         ├── SetIndexName {"IndexID":2,"Name":"crdb_internal_in...","TableID":106}
@@ -25,6 +25,8 @@ Schema change plan for rolling back CREATE INDEX ‹idx1› ON ‹defaultdb›.p
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":3,"TableID":106}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":3,"Kind":1,"TableID":106}
       │         ├── MakeIndexAbsent {"IndexID":2,"TableID":106}
+      │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
+      │         ├── SetJobStateOnDescriptor {"DescriptorID":105}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":106}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
       └── Stage 2 of 2 in PostCommitNonRevertiblePhase
@@ -32,9 +34,11 @@ Schema change plan for rolling back CREATE INDEX ‹idx1› ON ‹defaultdb›.p
            │    ├── PUBLIC      → ABSENT IndexData:{DescID: 106, IndexID: 2}
            │    ├── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 106, IndexID: 3, ConstraintID: 1, SourceIndexID: 1}
            │    └── PUBLIC      → ABSENT IndexData:{DescID: 106, IndexID: 3}
-           └── 5 Mutation operations
+           └── 7 Mutation operations
                 ├── CreateGCJobForIndex {"IndexID":2,"TableID":106}
                 ├── MakeIndexAbsent {"IndexID":3,"TableID":106}
                 ├── CreateGCJobForIndex {"IndexID":3,"TableID":106}
+                ├── RemoveJobStateFromDescriptor {"DescriptorID":104}
+                ├── RemoveJobStateFromDescriptor {"DescriptorID":105}
                 ├── RemoveJobStateFromDescriptor {"DescriptorID":106}
                 └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"all stages compl..."}

--- a/pkg/sql/schemachanger/testdata/explain/create_index.rollback_3_of_7
+++ b/pkg/sql/schemachanger/testdata/explain/create_index.rollback_3_of_7
@@ -17,7 +17,7 @@ Schema change plan for rolling back CREATE INDEX ‹idx1› ON ‹defaultdb›.p
       │    │    ├── WRITE_ONLY    → DELETE_ONLY TemporaryIndex:{DescID: 106, IndexID: 3, ConstraintID: 1, SourceIndexID: 1}
       │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 3}
       │    │    └── PUBLIC        → ABSENT      IndexColumn:{DescID: 106, ColumnID: 1, IndexID: 3}
-      │    └── 9 Mutation operations
+      │    └── 11 Mutation operations
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":2,"TableID":106}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":2,"Kind":1,"TableID":106}
       │         ├── SetIndexName {"IndexID":2,"Name":"crdb_internal_in...","TableID":106}
@@ -25,6 +25,8 @@ Schema change plan for rolling back CREATE INDEX ‹idx1› ON ‹defaultdb›.p
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":3,"TableID":106}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":3,"Kind":1,"TableID":106}
       │         ├── MakeIndexAbsent {"IndexID":2,"TableID":106}
+      │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
+      │         ├── SetJobStateOnDescriptor {"DescriptorID":105}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":106}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
       └── Stage 2 of 2 in PostCommitNonRevertiblePhase
@@ -32,9 +34,11 @@ Schema change plan for rolling back CREATE INDEX ‹idx1› ON ‹defaultdb›.p
            │    ├── PUBLIC      → ABSENT IndexData:{DescID: 106, IndexID: 2}
            │    ├── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 106, IndexID: 3, ConstraintID: 1, SourceIndexID: 1}
            │    └── PUBLIC      → ABSENT IndexData:{DescID: 106, IndexID: 3}
-           └── 5 Mutation operations
+           └── 7 Mutation operations
                 ├── CreateGCJobForIndex {"IndexID":2,"TableID":106}
                 ├── MakeIndexAbsent {"IndexID":3,"TableID":106}
                 ├── CreateGCJobForIndex {"IndexID":3,"TableID":106}
+                ├── RemoveJobStateFromDescriptor {"DescriptorID":104}
+                ├── RemoveJobStateFromDescriptor {"DescriptorID":105}
                 ├── RemoveJobStateFromDescriptor {"DescriptorID":106}
                 └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"all stages compl..."}

--- a/pkg/sql/schemachanger/testdata/explain/create_index.rollback_4_of_7
+++ b/pkg/sql/schemachanger/testdata/explain/create_index.rollback_4_of_7
@@ -17,7 +17,7 @@ Schema change plan for rolling back CREATE INDEX ‹idx1› ON ‹defaultdb›.p
       │    │    ├── WRITE_ONLY  → DELETE_ONLY TemporaryIndex:{DescID: 106, IndexID: 3, ConstraintID: 1, SourceIndexID: 1}
       │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 3}
       │    │    └── PUBLIC      → ABSENT      IndexColumn:{DescID: 106, ColumnID: 1, IndexID: 3}
-      │    └── 9 Mutation operations
+      │    └── 11 Mutation operations
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":2,"TableID":106}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":2,"Kind":1,"TableID":106}
       │         ├── SetIndexName {"IndexID":2,"Name":"crdb_internal_in...","TableID":106}
@@ -25,6 +25,8 @@ Schema change plan for rolling back CREATE INDEX ‹idx1› ON ‹defaultdb›.p
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":3,"TableID":106}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":3,"Kind":1,"TableID":106}
       │         ├── MakeIndexAbsent {"IndexID":2,"TableID":106}
+      │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
+      │         ├── SetJobStateOnDescriptor {"DescriptorID":105}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":106}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
       └── Stage 2 of 2 in PostCommitNonRevertiblePhase
@@ -32,9 +34,11 @@ Schema change plan for rolling back CREATE INDEX ‹idx1› ON ‹defaultdb›.p
            │    ├── PUBLIC      → ABSENT IndexData:{DescID: 106, IndexID: 2}
            │    ├── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 106, IndexID: 3, ConstraintID: 1, SourceIndexID: 1}
            │    └── PUBLIC      → ABSENT IndexData:{DescID: 106, IndexID: 3}
-           └── 5 Mutation operations
+           └── 7 Mutation operations
                 ├── CreateGCJobForIndex {"IndexID":2,"TableID":106}
                 ├── MakeIndexAbsent {"IndexID":3,"TableID":106}
                 ├── CreateGCJobForIndex {"IndexID":3,"TableID":106}
+                ├── RemoveJobStateFromDescriptor {"DescriptorID":104}
+                ├── RemoveJobStateFromDescriptor {"DescriptorID":105}
                 ├── RemoveJobStateFromDescriptor {"DescriptorID":106}
                 └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"all stages compl..."}

--- a/pkg/sql/schemachanger/testdata/explain/create_index.rollback_5_of_7
+++ b/pkg/sql/schemachanger/testdata/explain/create_index.rollback_5_of_7
@@ -17,15 +17,18 @@ Schema change plan for rolling back CREATE INDEX ‹idx1› ON ‹defaultdb›.p
       │    │    ├── WRITE_ONLY → DELETE_ONLY TemporaryIndex:{DescID: 106, IndexID: 3, ConstraintID: 1, SourceIndexID: 1}
       │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 3}
       │    │    └── PUBLIC     → ABSENT      IndexColumn:{DescID: 106, ColumnID: 1, IndexID: 3}
-      │    └── 10 Mutation operations
+      │    └── 13 Mutation operations
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":3,"TableID":106}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":3,"TableID":106}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":3,"Kind":1,"TableID":106}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":2,"TableID":106}
       │         ├── RemoveDroppedIndexPartialPredicate {"IndexID":2,"TableID":106}
+      │         ├── UpdateTableBackReferencesInTypes {"BackReferencedTableID":106}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":2,"TableID":106}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":2,"Kind":1,"TableID":106}
       │         ├── SetIndexName {"IndexID":2,"Name":"crdb_internal_in...","TableID":106}
+      │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
+      │         ├── SetJobStateOnDescriptor {"DescriptorID":105}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":106}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
       └── Stage 2 of 2 in PostCommitNonRevertiblePhase
@@ -34,10 +37,12 @@ Schema change plan for rolling back CREATE INDEX ‹idx1› ON ‹defaultdb›.p
            │    ├── PUBLIC      → ABSENT IndexData:{DescID: 106, IndexID: 2}
            │    ├── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 106, IndexID: 3, ConstraintID: 1, SourceIndexID: 1}
            │    └── PUBLIC      → ABSENT IndexData:{DescID: 106, IndexID: 3}
-           └── 6 Mutation operations
+           └── 8 Mutation operations
                 ├── MakeIndexAbsent {"IndexID":2,"TableID":106}
                 ├── CreateGCJobForIndex {"IndexID":2,"TableID":106}
                 ├── MakeIndexAbsent {"IndexID":3,"TableID":106}
                 ├── CreateGCJobForIndex {"IndexID":3,"TableID":106}
+                ├── RemoveJobStateFromDescriptor {"DescriptorID":104}
+                ├── RemoveJobStateFromDescriptor {"DescriptorID":105}
                 ├── RemoveJobStateFromDescriptor {"DescriptorID":106}
                 └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"all stages compl..."}

--- a/pkg/sql/schemachanger/testdata/explain/create_index.rollback_6_of_7
+++ b/pkg/sql/schemachanger/testdata/explain/create_index.rollback_6_of_7
@@ -17,15 +17,18 @@ Schema change plan for rolling back CREATE INDEX ‹idx1› ON ‹defaultdb›.p
       │    │    ├── WRITE_ONLY → DELETE_ONLY TemporaryIndex:{DescID: 106, IndexID: 3, ConstraintID: 1, SourceIndexID: 1}
       │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 3}
       │    │    └── PUBLIC     → ABSENT      IndexColumn:{DescID: 106, ColumnID: 1, IndexID: 3}
-      │    └── 10 Mutation operations
+      │    └── 13 Mutation operations
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":3,"TableID":106}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":3,"TableID":106}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":3,"Kind":1,"TableID":106}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":2,"TableID":106}
       │         ├── RemoveDroppedIndexPartialPredicate {"IndexID":2,"TableID":106}
+      │         ├── UpdateTableBackReferencesInTypes {"BackReferencedTableID":106}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":2,"TableID":106}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":2,"Kind":1,"TableID":106}
       │         ├── SetIndexName {"IndexID":2,"Name":"crdb_internal_in...","TableID":106}
+      │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
+      │         ├── SetJobStateOnDescriptor {"DescriptorID":105}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":106}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
       └── Stage 2 of 2 in PostCommitNonRevertiblePhase
@@ -34,10 +37,12 @@ Schema change plan for rolling back CREATE INDEX ‹idx1› ON ‹defaultdb›.p
            │    ├── PUBLIC      → ABSENT IndexData:{DescID: 106, IndexID: 2}
            │    ├── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 106, IndexID: 3, ConstraintID: 1, SourceIndexID: 1}
            │    └── PUBLIC      → ABSENT IndexData:{DescID: 106, IndexID: 3}
-           └── 6 Mutation operations
+           └── 8 Mutation operations
                 ├── MakeIndexAbsent {"IndexID":2,"TableID":106}
                 ├── CreateGCJobForIndex {"IndexID":2,"TableID":106}
                 ├── MakeIndexAbsent {"IndexID":3,"TableID":106}
                 ├── CreateGCJobForIndex {"IndexID":3,"TableID":106}
+                ├── RemoveJobStateFromDescriptor {"DescriptorID":104}
+                ├── RemoveJobStateFromDescriptor {"DescriptorID":105}
                 ├── RemoveJobStateFromDescriptor {"DescriptorID":106}
                 └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"all stages compl..."}

--- a/pkg/sql/schemachanger/testdata/explain/create_index.rollback_7_of_7
+++ b/pkg/sql/schemachanger/testdata/explain/create_index.rollback_7_of_7
@@ -17,15 +17,18 @@ Schema change plan for rolling back CREATE INDEX ‹idx1› ON ‹defaultdb›.p
       │    │    ├── WRITE_ONLY → DELETE_ONLY TemporaryIndex:{DescID: 106, IndexID: 3, ConstraintID: 1, SourceIndexID: 1}
       │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 3}
       │    │    └── PUBLIC     → ABSENT      IndexColumn:{DescID: 106, ColumnID: 1, IndexID: 3}
-      │    └── 10 Mutation operations
+      │    └── 13 Mutation operations
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":2,"TableID":106}
       │         ├── RemoveDroppedIndexPartialPredicate {"IndexID":2,"TableID":106}
+      │         ├── UpdateTableBackReferencesInTypes {"BackReferencedTableID":106}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":2,"TableID":106}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":2,"Kind":1,"TableID":106}
       │         ├── SetIndexName {"IndexID":2,"Name":"crdb_internal_in...","TableID":106}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":3,"TableID":106}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":3,"TableID":106}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":3,"Kind":1,"TableID":106}
+      │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
+      │         ├── SetJobStateOnDescriptor {"DescriptorID":105}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":106}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
       └── Stage 2 of 2 in PostCommitNonRevertiblePhase
@@ -34,10 +37,12 @@ Schema change plan for rolling back CREATE INDEX ‹idx1› ON ‹defaultdb›.p
            │    ├── PUBLIC      → ABSENT IndexData:{DescID: 106, IndexID: 2}
            │    ├── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 106, IndexID: 3, ConstraintID: 1, SourceIndexID: 1}
            │    └── PUBLIC      → ABSENT IndexData:{DescID: 106, IndexID: 3}
-           └── 6 Mutation operations
+           └── 8 Mutation operations
                 ├── MakeIndexAbsent {"IndexID":2,"TableID":106}
                 ├── CreateGCJobForIndex {"IndexID":2,"TableID":106}
                 ├── MakeIndexAbsent {"IndexID":3,"TableID":106}
                 ├── CreateGCJobForIndex {"IndexID":3,"TableID":106}
+                ├── RemoveJobStateFromDescriptor {"DescriptorID":104}
+                ├── RemoveJobStateFromDescriptor {"DescriptorID":105}
                 ├── RemoveJobStateFromDescriptor {"DescriptorID":106}
                 └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"all stages compl..."}

--- a/pkg/sql/schemachanger/testdata/explain_verbose/create_index
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/create_index
@@ -63,7 +63,7 @@ EXPLAIN (ddl, verbose) CREATE INDEX idx1 ON t (v) WHERE (v = 'a');
 │       │       └── • Precedence dependency from DELETE_ONLY TemporaryIndex:{DescID: 106, IndexID: 3, ConstraintID: 1, SourceIndexID: 1}
 │       │             rule: "temp index existence precedes index dependents"
 │       │
-│       └── • 8 Mutation operations
+│       └── • 9 Mutation operations
 │           │
 │           ├── • MakeAbsentIndexBackfilling
 │           │     Index:
@@ -74,9 +74,15 @@ EXPLAIN (ddl, verbose) CREATE INDEX idx1 ON t (v) WHERE (v = 'a');
 │           │     IsSecondaryIndex: true
 │           │
 │           ├── • SetAddedIndexPartialPredicate
-│           │     Expr: (v = 'a')
+│           │     Expr: v = b'@':::@100104
 │           │     IndexID: 2
 │           │     TableID: 106
+│           │
+│           ├── • UpdateTableBackReferencesInTypes
+│           │     BackReferencedTableID: 106
+│           │     TypeIDs:
+│           │     - 104
+│           │     - 105
 │           │
 │           ├── • AddColumnToIndex
 │           │     ColumnID: 2
@@ -204,7 +210,7 @@ EXPLAIN (ddl, verbose) CREATE INDEX idx1 ON t (v) WHERE (v = 'a');
 │       │       └── • Precedence dependency from DELETE_ONLY TemporaryIndex:{DescID: 106, IndexID: 3, ConstraintID: 1, SourceIndexID: 1}
 │       │             rule: "temp index existence precedes index dependents"
 │       │
-│       └── • 12 Mutation operations
+│       └── • 15 Mutation operations
 │           │
 │           ├── • MakeAbsentIndexBackfilling
 │           │     Index:
@@ -219,9 +225,15 @@ EXPLAIN (ddl, verbose) CREATE INDEX idx1 ON t (v) WHERE (v = 'a');
 │           │     TableID: 106
 │           │
 │           ├── • SetAddedIndexPartialPredicate
-│           │     Expr: (v = 'a')
+│           │     Expr: v = b'@':::@100104
 │           │     IndexID: 2
 │           │     TableID: 106
+│           │
+│           ├── • UpdateTableBackReferencesInTypes
+│           │     BackReferencedTableID: 106
+│           │     TypeIDs:
+│           │     - 104
+│           │     - 105
 │           │
 │           ├── • AddColumnToIndex
 │           │     ColumnID: 2
@@ -263,6 +275,14 @@ EXPLAIN (ddl, verbose) CREATE INDEX idx1 ON t (v) WHERE (v = 'a');
 │           │     TableID: 106
 │           │
 │           ├── • SetJobStateOnDescriptor
+│           │     DescriptorID: 104
+│           │     Initialize: true
+│           │
+│           ├── • SetJobStateOnDescriptor
+│           │     DescriptorID: 105
+│           │     Initialize: true
+│           │
+│           ├── • SetJobStateOnDescriptor
 │           │     DescriptorID: 106
 │           │     Initialize: true
 │           │
@@ -270,6 +290,8 @@ EXPLAIN (ddl, verbose) CREATE INDEX idx1 ON t (v) WHERE (v = 'a');
 │                 Authorization:
 │                   UserName: root
 │                 DescriptorIDs:
+│                 - 104
+│                 - 105
 │                 - 106
 │                 JobID: 1
 │                 RunningStatus: PostCommitPhase stage 1 of 7 with 1 MutationType op pending
@@ -303,11 +325,17 @@ EXPLAIN (ddl, verbose) CREATE INDEX idx1 ON t (v) WHERE (v = 'a');
 │   │   │       └── • SameStagePrecedence dependency from WRITE_ONLY TemporaryIndex:{DescID: 106, IndexID: 3, ConstraintID: 1, SourceIndexID: 1}
 │   │   │             rule: "temp index data exists as soon as temp index accepts writes"
 │   │   │
-│   │   └── • 3 Mutation operations
+│   │   └── • 5 Mutation operations
 │   │       │
 │   │       ├── • MakeDeleteOnlyIndexWriteOnly
 │   │       │     IndexID: 3
 │   │       │     TableID: 106
+│   │       │
+│   │       ├── • SetJobStateOnDescriptor
+│   │       │     DescriptorID: 104
+│   │       │
+│   │       ├── • SetJobStateOnDescriptor
+│   │       │     DescriptorID: 105
 │   │       │
 │   │       ├── • SetJobStateOnDescriptor
 │   │       │     DescriptorID: 106
@@ -352,11 +380,17 @@ EXPLAIN (ddl, verbose) CREATE INDEX idx1 ON t (v) WHERE (v = 'a');
 │   │   │       └── • PreviousStagePrecedence dependency from BACKFILLED SecondaryIndex:{DescID: 106, IndexID: 2, ConstraintID: 0, TemporaryIndexID: 3, SourceIndexID: 1}
 │   │   │             rule: "SecondaryIndex transitions to PUBLIC uphold 2-version invariant: BACKFILLED->DELETE_ONLY"
 │   │   │
-│   │   └── • 3 Mutation operations
+│   │   └── • 5 Mutation operations
 │   │       │
 │   │       ├── • MakeBackfillingIndexDeleteOnly
 │   │       │     IndexID: 2
 │   │       │     TableID: 106
+│   │       │
+│   │       ├── • SetJobStateOnDescriptor
+│   │       │     DescriptorID: 104
+│   │       │
+│   │       ├── • SetJobStateOnDescriptor
+│   │       │     DescriptorID: 105
 │   │       │
 │   │       ├── • SetJobStateOnDescriptor
 │   │       │     DescriptorID: 106
@@ -375,11 +409,17 @@ EXPLAIN (ddl, verbose) CREATE INDEX idx1 ON t (v) WHERE (v = 'a');
 │   │   │       └── • PreviousStagePrecedence dependency from DELETE_ONLY SecondaryIndex:{DescID: 106, IndexID: 2, ConstraintID: 0, TemporaryIndexID: 3, SourceIndexID: 1}
 │   │   │             rule: "SecondaryIndex transitions to PUBLIC uphold 2-version invariant: DELETE_ONLY->MERGE_ONLY"
 │   │   │
-│   │   └── • 3 Mutation operations
+│   │   └── • 5 Mutation operations
 │   │       │
 │   │       ├── • MakeBackfilledIndexMerging
 │   │       │     IndexID: 2
 │   │       │     TableID: 106
+│   │       │
+│   │       ├── • SetJobStateOnDescriptor
+│   │       │     DescriptorID: 104
+│   │       │
+│   │       ├── • SetJobStateOnDescriptor
+│   │       │     DescriptorID: 105
 │   │       │
 │   │       ├── • SetJobStateOnDescriptor
 │   │       │     DescriptorID: 106
@@ -415,11 +455,17 @@ EXPLAIN (ddl, verbose) CREATE INDEX idx1 ON t (v) WHERE (v = 'a');
 │   │   │       └── • PreviousStagePrecedence dependency from MERGED SecondaryIndex:{DescID: 106, IndexID: 2, ConstraintID: 0, TemporaryIndexID: 3, SourceIndexID: 1}
 │   │   │             rule: "SecondaryIndex transitions to PUBLIC uphold 2-version invariant: MERGED->WRITE_ONLY"
 │   │   │
-│   │   └── • 3 Mutation operations
+│   │   └── • 5 Mutation operations
 │   │       │
 │   │       ├── • MakeMergedIndexWriteOnly
 │   │       │     IndexID: 2
 │   │       │     TableID: 106
+│   │       │
+│   │       ├── • SetJobStateOnDescriptor
+│   │       │     DescriptorID: 104
+│   │       │
+│   │       ├── • SetJobStateOnDescriptor
+│   │       │     DescriptorID: 105
 │   │       │
 │   │       ├── • SetJobStateOnDescriptor
 │   │       │     DescriptorID: 106
@@ -488,7 +534,7 @@ EXPLAIN (ddl, verbose) CREATE INDEX idx1 ON t (v) WHERE (v = 'a');
     │   │       └── • Precedence dependency from TRANSIENT_DELETE_ONLY TemporaryIndex:{DescID: 106, IndexID: 3, ConstraintID: 1, SourceIndexID: 1}
     │   │             rule: "index drop mutation visible before cleaning up index columns"
     │   │
-    │   └── • 7 Mutation operations
+    │   └── • 9 Mutation operations
     │       │
     │       ├── • MakeValidatedSecondaryIndexPublic
     │       │     IndexID: 2
@@ -511,6 +557,12 @@ EXPLAIN (ddl, verbose) CREATE INDEX idx1 ON t (v) WHERE (v = 'a');
     │       │     IndexID: 3
     │       │     Kind: 1
     │       │     TableID: 106
+    │       │
+    │       ├── • SetJobStateOnDescriptor
+    │       │     DescriptorID: 104
+    │       │
+    │       ├── • SetJobStateOnDescriptor
+    │       │     DescriptorID: 105
     │       │
     │       ├── • SetJobStateOnDescriptor
     │       │     DescriptorID: 106
@@ -542,7 +594,7 @@ EXPLAIN (ddl, verbose) CREATE INDEX idx1 ON t (v) WHERE (v = 'a');
         │       └── • Precedence dependency from TRANSIENT_ABSENT TemporaryIndex:{DescID: 106, IndexID: 3, ConstraintID: 1, SourceIndexID: 1}
         │             rule: "index removed before garbage collection"
         │
-        └── • 4 Mutation operations
+        └── • 6 Mutation operations
             │
             ├── • MakeIndexAbsent
             │     IndexID: 3
@@ -555,11 +607,21 @@ EXPLAIN (ddl, verbose) CREATE INDEX idx1 ON t (v) WHERE (v = 'a');
             │     TableID: 106
             │
             ├── • RemoveJobStateFromDescriptor
+            │     DescriptorID: 104
+            │     JobID: 1
+            │
+            ├── • RemoveJobStateFromDescriptor
+            │     DescriptorID: 105
+            │     JobID: 1
+            │
+            ├── • RemoveJobStateFromDescriptor
             │     DescriptorID: 106
             │     JobID: 1
             │
             └── • UpdateSchemaChangerJob
                   DescriptorIDsToRemove:
+                  - 104
+                  - 105
                   - 106
                   IsNonCancelable: true
                   JobID: 1

--- a/pkg/sql/schemachanger/testdata/explain_verbose/create_index.rollback_1_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/create_index.rollback_1_of_7
@@ -77,7 +77,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 1 of 7;
         │       └── • Precedence dependency from DELETE_ONLY TemporaryIndex:{DescID: 106, IndexID: 3, ConstraintID: 1, SourceIndexID: 1}
         │             rule: "index drop mutation visible before cleaning up index columns"
         │
-        └── • 10 Mutation operations
+        └── • 12 Mutation operations
             │
             ├── • RemoveColumnFromIndex
             │     ColumnID: 2
@@ -122,11 +122,21 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 1 of 7;
             │     TableID: 106
             │
             ├── • RemoveJobStateFromDescriptor
+            │     DescriptorID: 104
+            │     JobID: 1
+            │
+            ├── • RemoveJobStateFromDescriptor
+            │     DescriptorID: 105
+            │     JobID: 1
+            │
+            ├── • RemoveJobStateFromDescriptor
             │     DescriptorID: 106
             │     JobID: 1
             │
             └── • UpdateSchemaChangerJob
                   DescriptorIDsToRemove:
+                  - 104
+                  - 105
                   - 106
                   IsNonCancelable: true
                   JobID: 1

--- a/pkg/sql/schemachanger/testdata/explain_verbose/create_index.rollback_2_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/create_index.rollback_2_of_7
@@ -65,7 +65,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 2 of 7;
     │   │       └── • Precedence dependency from DELETE_ONLY TemporaryIndex:{DescID: 106, IndexID: 3, ConstraintID: 1, SourceIndexID: 1}
     │   │             rule: "index drop mutation visible before cleaning up index columns"
     │   │
-    │   └── • 9 Mutation operations
+    │   └── • 11 Mutation operations
     │       │
     │       ├── • RemoveColumnFromIndex
     │       │     ColumnID: 2
@@ -101,6 +101,12 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 2 of 7;
     │       ├── • MakeIndexAbsent
     │       │     IndexID: 2
     │       │     TableID: 106
+    │       │
+    │       ├── • SetJobStateOnDescriptor
+    │       │     DescriptorID: 104
+    │       │
+    │       ├── • SetJobStateOnDescriptor
+    │       │     DescriptorID: 105
     │       │
     │       ├── • SetJobStateOnDescriptor
     │       │     DescriptorID: 106
@@ -141,7 +147,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 2 of 7;
         │       └── • Precedence dependency from ABSENT TemporaryIndex:{DescID: 106, IndexID: 3, ConstraintID: 1, SourceIndexID: 1}
         │             rule: "index removed before garbage collection"
         │
-        └── • 5 Mutation operations
+        └── • 7 Mutation operations
             │
             ├── • CreateGCJobForIndex
             │     IndexID: 2
@@ -162,11 +168,21 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 2 of 7;
             │     TableID: 106
             │
             ├── • RemoveJobStateFromDescriptor
+            │     DescriptorID: 104
+            │     JobID: 1
+            │
+            ├── • RemoveJobStateFromDescriptor
+            │     DescriptorID: 105
+            │     JobID: 1
+            │
+            ├── • RemoveJobStateFromDescriptor
             │     DescriptorID: 106
             │     JobID: 1
             │
             └── • UpdateSchemaChangerJob
                   DescriptorIDsToRemove:
+                  - 104
+                  - 105
                   - 106
                   IsNonCancelable: true
                   JobID: 1

--- a/pkg/sql/schemachanger/testdata/explain_verbose/create_index.rollback_3_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/create_index.rollback_3_of_7
@@ -65,7 +65,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 3 of 7;
     │   │       └── • Precedence dependency from DELETE_ONLY TemporaryIndex:{DescID: 106, IndexID: 3, ConstraintID: 1, SourceIndexID: 1}
     │   │             rule: "index drop mutation visible before cleaning up index columns"
     │   │
-    │   └── • 9 Mutation operations
+    │   └── • 11 Mutation operations
     │       │
     │       ├── • RemoveColumnFromIndex
     │       │     ColumnID: 2
@@ -101,6 +101,12 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 3 of 7;
     │       ├── • MakeIndexAbsent
     │       │     IndexID: 2
     │       │     TableID: 106
+    │       │
+    │       ├── • SetJobStateOnDescriptor
+    │       │     DescriptorID: 104
+    │       │
+    │       ├── • SetJobStateOnDescriptor
+    │       │     DescriptorID: 105
     │       │
     │       ├── • SetJobStateOnDescriptor
     │       │     DescriptorID: 106
@@ -141,7 +147,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 3 of 7;
         │       └── • Precedence dependency from ABSENT TemporaryIndex:{DescID: 106, IndexID: 3, ConstraintID: 1, SourceIndexID: 1}
         │             rule: "index removed before garbage collection"
         │
-        └── • 5 Mutation operations
+        └── • 7 Mutation operations
             │
             ├── • CreateGCJobForIndex
             │     IndexID: 2
@@ -162,11 +168,21 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 3 of 7;
             │     TableID: 106
             │
             ├── • RemoveJobStateFromDescriptor
+            │     DescriptorID: 104
+            │     JobID: 1
+            │
+            ├── • RemoveJobStateFromDescriptor
+            │     DescriptorID: 105
+            │     JobID: 1
+            │
+            ├── • RemoveJobStateFromDescriptor
             │     DescriptorID: 106
             │     JobID: 1
             │
             └── • UpdateSchemaChangerJob
                   DescriptorIDsToRemove:
+                  - 104
+                  - 105
                   - 106
                   IsNonCancelable: true
                   JobID: 1

--- a/pkg/sql/schemachanger/testdata/explain_verbose/create_index.rollback_4_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/create_index.rollback_4_of_7
@@ -65,7 +65,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 4 of 7;
     │   │       └── • Precedence dependency from DELETE_ONLY TemporaryIndex:{DescID: 106, IndexID: 3, ConstraintID: 1, SourceIndexID: 1}
     │   │             rule: "index drop mutation visible before cleaning up index columns"
     │   │
-    │   └── • 9 Mutation operations
+    │   └── • 11 Mutation operations
     │       │
     │       ├── • RemoveColumnFromIndex
     │       │     ColumnID: 2
@@ -101,6 +101,12 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 4 of 7;
     │       ├── • MakeIndexAbsent
     │       │     IndexID: 2
     │       │     TableID: 106
+    │       │
+    │       ├── • SetJobStateOnDescriptor
+    │       │     DescriptorID: 104
+    │       │
+    │       ├── • SetJobStateOnDescriptor
+    │       │     DescriptorID: 105
     │       │
     │       ├── • SetJobStateOnDescriptor
     │       │     DescriptorID: 106
@@ -141,7 +147,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 4 of 7;
         │       └── • Precedence dependency from ABSENT TemporaryIndex:{DescID: 106, IndexID: 3, ConstraintID: 1, SourceIndexID: 1}
         │             rule: "index removed before garbage collection"
         │
-        └── • 5 Mutation operations
+        └── • 7 Mutation operations
             │
             ├── • CreateGCJobForIndex
             │     IndexID: 2
@@ -162,11 +168,21 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 4 of 7;
             │     TableID: 106
             │
             ├── • RemoveJobStateFromDescriptor
+            │     DescriptorID: 104
+            │     JobID: 1
+            │
+            ├── • RemoveJobStateFromDescriptor
+            │     DescriptorID: 105
+            │     JobID: 1
+            │
+            ├── • RemoveJobStateFromDescriptor
             │     DescriptorID: 106
             │     JobID: 1
             │
             └── • UpdateSchemaChangerJob
                   DescriptorIDsToRemove:
+                  - 104
+                  - 105
                   - 106
                   IsNonCancelable: true
                   JobID: 1

--- a/pkg/sql/schemachanger/testdata/explain_verbose/create_index.rollback_5_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/create_index.rollback_5_of_7
@@ -56,7 +56,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 5 of 7;
     │   │       └── • Precedence dependency from DELETE_ONLY TemporaryIndex:{DescID: 106, IndexID: 3, ConstraintID: 1, SourceIndexID: 1}
     │   │             rule: "index drop mutation visible before cleaning up index columns"
     │   │
-    │   └── • 10 Mutation operations
+    │   └── • 13 Mutation operations
     │       │
     │       ├── • MakeWriteOnlyIndexDeleteOnly
     │       │     IndexID: 3
@@ -81,6 +81,12 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 5 of 7;
     │       │     IndexID: 2
     │       │     TableID: 106
     │       │
+    │       ├── • UpdateTableBackReferencesInTypes
+    │       │     BackReferencedTableID: 106
+    │       │     TypeIDs:
+    │       │     - 104
+    │       │     - 105
+    │       │
     │       ├── • RemoveColumnFromIndex
     │       │     ColumnID: 2
     │       │     IndexID: 2
@@ -96,6 +102,12 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 5 of 7;
     │       │     IndexID: 2
     │       │     Name: crdb_internal_index_2_name_placeholder
     │       │     TableID: 106
+    │       │
+    │       ├── • SetJobStateOnDescriptor
+    │       │     DescriptorID: 104
+    │       │
+    │       ├── • SetJobStateOnDescriptor
+    │       │     DescriptorID: 105
     │       │
     │       ├── • SetJobStateOnDescriptor
     │       │     DescriptorID: 106
@@ -151,7 +163,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 5 of 7;
         │       └── • Precedence dependency from ABSENT TemporaryIndex:{DescID: 106, IndexID: 3, ConstraintID: 1, SourceIndexID: 1}
         │             rule: "index removed before garbage collection"
         │
-        └── • 6 Mutation operations
+        └── • 8 Mutation operations
             │
             ├── • MakeIndexAbsent
             │     IndexID: 2
@@ -176,11 +188,21 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 5 of 7;
             │     TableID: 106
             │
             ├── • RemoveJobStateFromDescriptor
+            │     DescriptorID: 104
+            │     JobID: 1
+            │
+            ├── • RemoveJobStateFromDescriptor
+            │     DescriptorID: 105
+            │     JobID: 1
+            │
+            ├── • RemoveJobStateFromDescriptor
             │     DescriptorID: 106
             │     JobID: 1
             │
             └── • UpdateSchemaChangerJob
                   DescriptorIDsToRemove:
+                  - 104
+                  - 105
                   - 106
                   IsNonCancelable: true
                   JobID: 1

--- a/pkg/sql/schemachanger/testdata/explain_verbose/create_index.rollback_6_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/create_index.rollback_6_of_7
@@ -56,7 +56,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 6 of 7;
     │   │       └── • Precedence dependency from DELETE_ONLY TemporaryIndex:{DescID: 106, IndexID: 3, ConstraintID: 1, SourceIndexID: 1}
     │   │             rule: "index drop mutation visible before cleaning up index columns"
     │   │
-    │   └── • 10 Mutation operations
+    │   └── • 13 Mutation operations
     │       │
     │       ├── • MakeWriteOnlyIndexDeleteOnly
     │       │     IndexID: 3
@@ -81,6 +81,12 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 6 of 7;
     │       │     IndexID: 2
     │       │     TableID: 106
     │       │
+    │       ├── • UpdateTableBackReferencesInTypes
+    │       │     BackReferencedTableID: 106
+    │       │     TypeIDs:
+    │       │     - 104
+    │       │     - 105
+    │       │
     │       ├── • RemoveColumnFromIndex
     │       │     ColumnID: 2
     │       │     IndexID: 2
@@ -96,6 +102,12 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 6 of 7;
     │       │     IndexID: 2
     │       │     Name: crdb_internal_index_2_name_placeholder
     │       │     TableID: 106
+    │       │
+    │       ├── • SetJobStateOnDescriptor
+    │       │     DescriptorID: 104
+    │       │
+    │       ├── • SetJobStateOnDescriptor
+    │       │     DescriptorID: 105
     │       │
     │       ├── • SetJobStateOnDescriptor
     │       │     DescriptorID: 106
@@ -151,7 +163,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 6 of 7;
         │       └── • Precedence dependency from ABSENT TemporaryIndex:{DescID: 106, IndexID: 3, ConstraintID: 1, SourceIndexID: 1}
         │             rule: "index removed before garbage collection"
         │
-        └── • 6 Mutation operations
+        └── • 8 Mutation operations
             │
             ├── • MakeIndexAbsent
             │     IndexID: 2
@@ -176,11 +188,21 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 6 of 7;
             │     TableID: 106
             │
             ├── • RemoveJobStateFromDescriptor
+            │     DescriptorID: 104
+            │     JobID: 1
+            │
+            ├── • RemoveJobStateFromDescriptor
+            │     DescriptorID: 105
+            │     JobID: 1
+            │
+            ├── • RemoveJobStateFromDescriptor
             │     DescriptorID: 106
             │     JobID: 1
             │
             └── • UpdateSchemaChangerJob
                   DescriptorIDsToRemove:
+                  - 104
+                  - 105
                   - 106
                   IsNonCancelable: true
                   JobID: 1

--- a/pkg/sql/schemachanger/testdata/explain_verbose/create_index.rollback_7_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/create_index.rollback_7_of_7
@@ -56,7 +56,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 7 of 7;
     │   │       └── • Precedence dependency from DELETE_ONLY TemporaryIndex:{DescID: 106, IndexID: 3, ConstraintID: 1, SourceIndexID: 1}
     │   │             rule: "index drop mutation visible before cleaning up index columns"
     │   │
-    │   └── • 10 Mutation operations
+    │   └── • 13 Mutation operations
     │       │
     │       ├── • MakeWriteOnlyIndexDeleteOnly
     │       │     IndexID: 2
@@ -65,6 +65,12 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 7 of 7;
     │       ├── • RemoveDroppedIndexPartialPredicate
     │       │     IndexID: 2
     │       │     TableID: 106
+    │       │
+    │       ├── • UpdateTableBackReferencesInTypes
+    │       │     BackReferencedTableID: 106
+    │       │     TypeIDs:
+    │       │     - 104
+    │       │     - 105
     │       │
     │       ├── • RemoveColumnFromIndex
     │       │     ColumnID: 2
@@ -96,6 +102,12 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 7 of 7;
     │       │     IndexID: 3
     │       │     Kind: 1
     │       │     TableID: 106
+    │       │
+    │       ├── • SetJobStateOnDescriptor
+    │       │     DescriptorID: 104
+    │       │
+    │       ├── • SetJobStateOnDescriptor
+    │       │     DescriptorID: 105
     │       │
     │       ├── • SetJobStateOnDescriptor
     │       │     DescriptorID: 106
@@ -151,7 +163,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 7 of 7;
         │       └── • Precedence dependency from ABSENT TemporaryIndex:{DescID: 106, IndexID: 3, ConstraintID: 1, SourceIndexID: 1}
         │             rule: "index removed before garbage collection"
         │
-        └── • 6 Mutation operations
+        └── • 8 Mutation operations
             │
             ├── • MakeIndexAbsent
             │     IndexID: 2
@@ -176,11 +188,21 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 7 of 7;
             │     TableID: 106
             │
             ├── • RemoveJobStateFromDescriptor
+            │     DescriptorID: 104
+            │     JobID: 1
+            │
+            ├── • RemoveJobStateFromDescriptor
+            │     DescriptorID: 105
+            │     JobID: 1
+            │
+            ├── • RemoveJobStateFromDescriptor
             │     DescriptorID: 106
             │     JobID: 1
             │
             └── • UpdateSchemaChangerJob
                   DescriptorIDsToRemove:
+                  - 104
+                  - 105
                   - 106
                   IsNonCancelable: true
                   JobID: 1


### PR DESCRIPTION
Before this change we were throwing away some standard rewriting we want to do to table expressions for the case of partial index predicates. This resulted in badness when attempting to backfill the index.

No release note because this feature is new in 23.1

Fixes: #97551

Release note: None