### PR TITLE
sql: set name prefix before resolving a function

### DIFF
--- a/pkg/bench/bench_test.go
+++ b/pkg/bench/bench_test.go
@@ -1443,8 +1443,7 @@ func BenchmarkFuncExprTypeCheck(b *testing.B) {
 	sqlDB.ExecMultiple(b,
 		`CREATE SCHEMA sc1`,
 		`CREATE SCHEMA sc2`,
-		// TODO(chengxiong): uncomment this when #97400 is resolved.
-		//`CREATE FUNCTION abs(val INT) RETURNS INT CALLED ON NULL INPUT LANGUAGE SQL AS $$ SELECT val $$`,
+		`CREATE FUNCTION abs(val INT) RETURNS INT CALLED ON NULL INPUT LANGUAGE SQL AS $$ SELECT val $$`,
 		`CREATE FUNCTION sc1.udf(val INT) RETURNS INT CALLED ON NULL INPUT LANGUAGE SQL AS $$ SELECT val $$`,
 		`CREATE FUNCTION sc1.udf(val STRING) RETURNS STRING LANGUAGE SQL AS $$ SELECT val $$`,
 		`CREATE FUNCTION sc1.udf(val FLOAT) RETURNS FLOAT LANGUAGE SQL AS $$ SELECT val $$`,
@@ -1488,11 +1487,10 @@ func BenchmarkFuncExprTypeCheck(b *testing.B) {
 			name:    "builtin aggregate not called on null",
 			exprStr: "concat_agg(NULL)",
 		},
-		// TODO(chengxiong): uncomment this when #97400 is resolved.
-		//{
-		//	name:    "udf same name as builtin",
-		//	exprStr: "abs(123)",
-		//},
+		{
+			name:    "udf same name as builtin",
+			exprStr: "abs(123)",
+		},
 		{
 			name:    "udf across different schemas",
 			exprStr: "udf(123)",

--- a/pkg/sql/logictest/testdata/logic_test/udf
+++ b/pkg/sql/logictest/testdata/logic_test/udf
@@ -3133,3 +3133,22 @@ SELECT f_97130();
 
 statement ok
 SET search_path = $pre_search_path
+
+subtest regression_97400
+
+# Make sure that creating a UDF with builtin function name is ok.
+statement ok
+CREATE FUNCTION abs(val INT) RETURNS INT
+CALLED ON NULL INPUT
+LANGUAGE SQL
+AS $$ SELECT val+100 $$;
+
+query I
+SELECT abs(-1)
+----
+1
+
+query I
+SELECT public.abs(-1)
+----
+99


### PR DESCRIPTION
Fixes: #97400

Previously, in desclarative schema changer, we would run into a builtin function when we try to create a UDF with a same builtin function signature. This is because we didn't set the name prefixes properly. This commit fixes this by setting the name prefixes using the prefix re-resolution result.

Release note: None