### PR TITLE
sql, schemachanger: Properly support ALTER TABLE ADD UNIQUE

### DIFF
--- a/pkg/sql/alter_table.go
+++ b/pkg/sql/alter_table.go
@@ -251,6 +251,10 @@ func (n *alterTableNode) startExec(params runParams) error {
 					continue
 				}
 
+				if t.ValidationBehavior == tree.ValidationSkip {
+					return sqlerrors.NewUnsupportedUnvalidatedConstraintError(catconstants.ConstraintTypeUnique)
+				}
+
 				if err := validateColumnsAreAccessible(n.tableDesc, d.Columns); err != nil {
 					return err
 				}

--- a/pkg/sql/logictest/testdata/logic_test/alter_table
+++ b/pkg/sql/logictest/testdata/logic_test/alter_table
@@ -3153,3 +3153,22 @@ SHOW CONSTRAINTS FROM t_96729
 ----
 table_name  constraint_name  constraint_type  details              validated
 t_96729     t_96729_pkey     PRIMARY KEY      PRIMARY KEY (i ASC)  true
+
+# This subtests ensures adding UNIQUE constraint works properly.
+subtest alter_table_add_unique_96728
+
+statement ok
+CREATE TABLE t_96728 (i INT PRIMARY KEY, j INT, k INT);
+
+statement error pgcode 0A000 UNIQUE constraints cannot be marked NOT VALID
+ALTER TABLE t_96728 ADD UNIQUE (j) NOT VALID;
+
+statement ok
+ALTER TABLE t_96728 ADD UNIQUE (j, k) WHERE (i > 0);
+
+query TTTTB colnames
+SHOW CONSTRAINTS FROM t_96728
+----
+table_name  constraint_name  constraint_type  details                              validated
+t_96728     t_96728_j_k_key  UNIQUE           UNIQUE (j ASC, k ASC) WHERE (i > 0)  true
+t_96728     t_96728_pkey     PRIMARY KEY      PRIMARY KEY (i ASC)                  true

--- a/pkg/sql/logictest/testdata/logic_test/show_create
+++ b/pkg/sql/logictest/testdata/logic_test/show_create
@@ -43,13 +43,10 @@ c           CREATE TABLE public.c (
             COMMENT ON COLUMN public.c.a IS 'column';
             COMMENT ON INDEX public.c@c_a_b_idx IS 'index'
 
-# TODO(rytaft): adding a NOT VALID unique constraint in PostgreSQL returns
-# an error. We should consider doing the same unless the constraint is UNIQUE
-# WITHOUT INDEX.
 statement ok
 ALTER TABLE c ADD CONSTRAINT check_b CHECK (b IN (1, 2, 3)) NOT VALID;
 ALTER TABLE c ADD CONSTRAINT fk_a FOREIGN KEY (a) REFERENCES d (d) NOT VALID;
-ALTER TABLE c ADD CONSTRAINT unique_a UNIQUE (a) NOT VALID;
+ALTER TABLE c ADD CONSTRAINT unique_a UNIQUE (a);
 ALTER TABLE c ADD CONSTRAINT unique_b UNIQUE WITHOUT INDEX (b) NOT VALID;
 ALTER TABLE c ADD CONSTRAINT unique_b_partial UNIQUE WITHOUT INDEX (b) WHERE a > 0 NOT VALID;
 

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_table.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_table.go
@@ -52,11 +52,10 @@ var supportedAlterTableStatements = map[reflect.Type]supportedAlterTableCommand{
 	reflect.TypeOf((*tree.AlterTableAddConstraint)(nil)): {fn: alterTableAddConstraint, on: true, extraChecks: func(
 		t *tree.AlterTableAddConstraint,
 	) bool {
-		if d, ok := t.ConstraintDef.(*tree.UniqueConstraintTableDef); ok && d.PrimaryKey {
-			// Support ALTER TABLE ... ADD PRIMARY KEY
-			return true
-		} else if ok && d.WithoutIndex {
+		if _, ok := t.ConstraintDef.(*tree.UniqueConstraintTableDef); ok {
+			// Support ALTER TABLE ... ADD PRIMARY KEY [NOT VALID]
 			// Support ALTER TABLE ... ADD UNIQUE WITHOUT INDEX [NOT VALID]
+			// Support ALTER TABLE ... ADD UNIQUE [NOT VALID]
 			return true
 		}
 
@@ -82,10 +81,12 @@ var supportedAlterTableStatements = map[reflect.Type]supportedAlterTableCommand{
 // E.g. "ADD_PRIMARY_KEY_DEFAULT", "ADD_CHECK_SKIP", "ADD_FOREIGN_KEY_DEFAULT", etc.
 var alterTableAddConstraintMinSupportedClusterVersion = map[string]clusterversion.Key{
 	"ADD_PRIMARY_KEY_DEFAULT":          clusterversion.V22_2,
+	"ADD_UNIQUE_DEFAULT":               clusterversion.V23_1,
 	"ADD_CHECK_DEFAULT":                clusterversion.V23_1,
 	"ADD_FOREIGN_KEY_DEFAULT":          clusterversion.V23_1,
 	"ADD_UNIQUE_WITHOUT_INDEX_DEFAULT": clusterversion.V23_1,
 	"ADD_PRIMARY_KEY_SKIP":             clusterversion.V23_1,
+	"ADD_UNIQUE_SKIP":                  clusterversion.V23_1,
 	"ADD_CHECK_SKIP":                   clusterversion.V23_1,
 	"ADD_UNIQUE_WITHOUT_INDEX_SKIP":    clusterversion.V23_1,
 	"ADD_FOREIGN_KEY_SKIP":             clusterversion.V23_1,

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_table_add_constraint.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_table_add_constraint.go
@@ -45,6 +45,17 @@ func alterTableAddConstraint(
 			alterTableAddPrimaryKey(b, tn, tbl, t)
 		} else if d.WithoutIndex {
 			alterTableAddUniqueWithoutIndex(b, tn, tbl, t)
+		} else {
+			if t.ValidationBehavior == tree.ValidationSkip {
+				panic(sqlerrors.NewUnsupportedUnvalidatedConstraintError(catconstants.ConstraintTypeUnique))
+			}
+			CreateIndex(b, &tree.CreateIndex{
+				Name:      d.Name,
+				Table:     *tn,
+				Unique:    true,
+				Columns:   d.Columns,
+				Predicate: d.Predicate,
+			})
 		}
 	case *tree.CheckConstraintTableDef:
 		alterTableAddCheck(b, tn, tbl, t)


### PR DESCRIPTION
Fixes https://github.com/cockroachdb/cockroach/issues/96728
release note (sql change): Previously, `ALTER TABLE .. ADD UNIQUE .. NOT VALID` is process by ignoring the NOT VALID qualifier. This is not adequate because PG throws an error instead. This PR ensures that CRDB throws the same error, "UNIQUE constraints cannot be marked NOT VALID", for such statement.