### PR TITLE
multitenant: add version gate to alter tenant capabilities

### DIFF
--- a/docs/generated/settings/settings-for-tenants.txt
+++ b/docs/generated/settings/settings-for-tenants.txt
@@ -297,4 +297,4 @@ trace.jaeger.agent	string		the address of a Jaeger agent to receive traces using
 trace.opentelemetry.collector	string		address of an OpenTelemetry trace collector to receive traces using the otel gRPC protocol, as <host>:<port>. If no port is specified, 4317 will be used.
 trace.span_registry.enabled	boolean	true	if set, ongoing traces can be seen at https://<ui>/#/debug/tracez
 trace.zipkin.collector	string		the address of a Zipkin instance to receive traces, as <host>:<port>. If no port is specified, 9411 will be used.
-version	version	1000022.2-58	set the active cluster version in the format '<major>.<minor>'
+version	version	1000022.2-60	set the active cluster version in the format '<major>.<minor>'

--- a/docs/generated/settings/settings.html
+++ b/docs/generated/settings/settings.html
@@ -238,6 +238,6 @@
 <tr><td><div id="setting-trace-opentelemetry-collector" class="anchored"><code>trace.opentelemetry.collector</code></div></td><td>string</td><td><code></code></td><td>address of an OpenTelemetry trace collector to receive traces using the otel gRPC protocol, as &lt;host&gt;:&lt;port&gt;. If no port is specified, 4317 will be used.</td></tr>
 <tr><td><div id="setting-trace-span-registry-enabled" class="anchored"><code>trace.span_registry.enabled</code></div></td><td>boolean</td><td><code>true</code></td><td>if set, ongoing traces can be seen at https://&lt;ui&gt;/#/debug/tracez</td></tr>
 <tr><td><div id="setting-trace-zipkin-collector" class="anchored"><code>trace.zipkin.collector</code></div></td><td>string</td><td><code></code></td><td>the address of a Zipkin instance to receive traces, as &lt;host&gt;:&lt;port&gt;. If no port is specified, 9411 will be used.</td></tr>
-<tr><td><div id="setting-version" class="anchored"><code>version</code></div></td><td>version</td><td><code>1000022.2-58</code></td><td>set the active cluster version in the format &#39;&lt;major&gt;.&lt;minor&gt;&#39;</td></tr>
+<tr><td><div id="setting-version" class="anchored"><code>version</code></div></td><td>version</td><td><code>1000022.2-60</code></td><td>set the active cluster version in the format &#39;&lt;major&gt;.&lt;minor&gt;&#39;</td></tr>
 </tbody>
 </table>

--- a/pkg/cli/testdata/declarative-rules/deprules
+++ b/pkg/cli/testdata/declarative-rules/deprules
@@ -1,6 +1,6 @@
 dep
 ----
-debug declarative-print-rules 1000022.2-58 dep
+debug declarative-print-rules 1000022.2-60 dep
 deprules
 ----
 - name: 'CheckConstraint transitions to ABSENT uphold 2-version invariant: PUBLIC->VALIDATED'

--- a/pkg/cli/testdata/declarative-rules/oprules
+++ b/pkg/cli/testdata/declarative-rules/oprules
@@ -1,6 +1,6 @@
 op
 ----
-debug declarative-print-rules 1000022.2-58 op
+debug declarative-print-rules 1000022.2-60 op
 rules
 ----
 []

--- a/pkg/clusterversion/cockroach_versions.go
+++ b/pkg/clusterversion/cockroach_versions.go
@@ -453,6 +453,10 @@ const (
 	// Cloud cluster, etc.).
 	V23_1_MVCCRangeTombstonesUnconditionallyEnabled
 
+	// V23_1TenantCapabilities is the version where tenant capabilities can be
+	// set.
+	V23_1TenantCapabilities
+
 	// *************************************************
 	// Step (1): Add new versions here.
 	// Do not add new versions to a patch release.
@@ -781,6 +785,10 @@ var rawVersionsSingleton = keyedVersions{
 	{
 		Key:     V23_1_MVCCRangeTombstonesUnconditionallyEnabled,
 		Version: roachpb.Version{Major: 22, Minor: 2, Internal: 58},
+	},
+	{
+		Key:     V23_1TenantCapabilities,
+		Version: roachpb.Version{Major: 22, Minor: 2, Internal: 60},
 	},
 
 	// *************************************************

--- a/pkg/sql/tenant_capability.go
+++ b/pkg/sql/tenant_capability.go
@@ -14,6 +14,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/multitenant/tenantcapabilities/tenantcapabilitiespb"
 	"github.com/cockroachdb/cockroach/pkg/sql/paramparse"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
@@ -46,6 +47,9 @@ func (p *planner) AlterTenantCapability(
 ) (planNode, error) {
 	if err := rejectIfCantCoordinateMultiTenancy(p.execCfg.Codec, "grant/revoke capabilities to"); err != nil {
 		return nil, err
+	}
+	if !p.ExecCfg().Settings.Version.IsActive(ctx, clusterversion.V23_1TenantCapabilities) {
+		return nil, errors.New("cannot alter tenant capabilities until version is finalized")
 	}
 
 	tSpec, err := p.planTenantSpec(ctx, n.TenantSpec, alterTenantCapabilityOp)

--- a/pkg/sql/tenant_test.go
+++ b/pkg/sql/tenant_test.go
@@ -13,6 +13,7 @@ package sql_test
 import (
 	"context"
 	gosql "database/sql"
+	"fmt"
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
@@ -131,4 +132,27 @@ func TestGetTenantIds(t *testing.T) {
 		roachpb.MustMakeTenantID(3),
 	}
 	require.Equal(t, expectedIds, ids)
+}
+
+func TestAlterTenantCapabilityMixedVersion22_2_23_1(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	tc := testcluster.StartTestCluster(t, 1, base.TestClusterArgs{
+		ServerArgs: base.TestServerArgs{
+			Knobs: base.TestingKnobs{
+				Server: &server.TestingKnobs{
+					DisableAutomaticVersionUpgrade: make(chan struct{}),
+					BinaryVersionOverride:          clusterversion.ByKey(clusterversion.V22_2),
+				},
+			},
+		},
+	})
+	defer tc.Stopper().Stop(ctx)
+
+	systemTenant := sqlutils.MakeSQLRunner(tc.ServerConn(0))
+
+	const tenantID = 5
+	systemTenant.Exec(t, fmt.Sprintf("SELECT crdb_internal.create_tenant(%d)", tenantID))
+	systemTenant.ExpectErr(t, "cannot alter tenant capabilities until version is finalized", "ALTER TENANT $1 GRANT CAPABILITY can_admin_split", tenantID)
 }


### PR DESCRIPTION
Fixes #97756

Tenant capabilities should not be modifiable in mixed 22.2/23.1 version clusters to prevent inconsistent behavior between nodes that obey capabilities (23.1) and ignore them (22.2).

Release note: None