### PR TITLE
cli: add "lite" debug zip shorthand

### DIFF
--- a/pkg/cli/cliflags/flags.go
+++ b/pkg/cli/cliflags/flags.go
@@ -1491,6 +1491,17 @@ list of node IDs or ranges of node IDs, for example: 5,10-20,23.
 The default is to not exclude any node.`,
 	}
 
+	ZipLite = FlagInfo{
+		Name: "lite",
+		Description: `If set, a small subset of the full zip is collected, excluding 
+		most files that are collection from disks such as logs or historical profiles
+		as well as range statuses or other classes of collected information that is 
+		known to become especially large in larger clusters. Such a "lite" zip is 
+		thus less comprehensive than a full zip, but may be able to be collected and
+		transferred more quickly to allow initial triage steps to begin while the 
+		larger full zip is being collected and transferred.`,
+	}
+
 	ZipIncludedFiles = FlagInfo{
 		Name: "include-files",
 		Description: `

--- a/pkg/cli/context.go
+++ b/pkg/cli/context.go
@@ -350,6 +350,12 @@ type zipContext struct {
 	// attempts to access multiple nodes concurrently by default.
 	concurrency int
 
+	// lite controls a collecting a pre-set minimal subset of data, excluding the
+	// disk-collected files like logs as well as per-range status, such that this
+	// subset remains small even for very large clusters, and can thus be quickly
+	// collected and shared for initial triage while a larger full zip is pending.
+	lite bool
+
 	// The log/heap/etc files to include.
 	files fileSelection
 }
@@ -365,6 +371,7 @@ func setZipContextDefaults() {
 	zipCtx.cpuProfDuration = 5 * time.Second
 	zipCtx.concurrency = 15
 
+	zipCtx.lite = false
 	// File selection covers the last 48 hours by default.
 	// We add 24 hours to now for the end timestamp to ensure
 	// that files created during the zip operation are

--- a/pkg/cli/flags.go
+++ b/pkg/cli/flags.go
@@ -691,6 +691,7 @@ func init() {
 		f := cmd.Flags()
 		cliflagcfg.VarFlag(f, &zipCtx.nodes.inclusive, cliflags.ZipNodes)
 		cliflagcfg.VarFlag(f, &zipCtx.nodes.exclusive, cliflags.ZipExcludeNodes)
+		cliflagcfg.BoolFlag(f, &zipCtx.lite, cliflags.ZipLite)
 		cliflagcfg.StringSliceFlag(f, &zipCtx.files.includePatterns, cliflags.ZipIncludedFiles)
 		cliflagcfg.StringSliceFlag(f, &zipCtx.files.excludePatterns, cliflags.ZipExcludedFiles)
 		cliflagcfg.VarFlag(f, &zipCtx.files.startTimestamp, cliflags.ZipFilesFrom)

--- a/pkg/cli/zip.go
+++ b/pkg/cli/zip.go
@@ -275,7 +275,7 @@ func runDebugZip(_ *cobra.Command, args []string) (retErr error) {
 
 			// Collect the per-node data.
 			if err := zc.forAllNodes(ctx, nodesList, func(ctx context.Context, nodeDetails serverpb.NodeDetails, nodesStatus *statuspb.NodeStatus) error {
-				return zc.collectPerNodeData(ctx, nodeDetails, nodesStatus, livenessByNodeID)
+				return zc.collectPerNodeData(ctx, nodeDetails, nodesStatus, livenessByNodeID, zipCtx.lite)
 			}); err != nil {
 				return err
 			}


### PR DESCRIPTION
WIP

Frequently when debugging issues we ask for a debug zip to be collected and uploaded to the support portal, then we download it, extract its content and analyze it. The debug zip has proved useful in automating the collection of various types of debugging information we know can be essential in debugging different classes of issues and bundling it together, eliminating repeated round-trips asking a customer to collect this or that and mistakes or hand-holding in the process. 

However, the comprehensiveness of the debug zip, while one of its major advantages, is also the cause of one of its significant drawbacks when used with large clusters: the inclusion of a range status report for every range, of large log files and large numbers of historical profiles, etc -- while all very useful in some classes of investigation -- can make the zip very large, and accordingly very time consuming to collect, to upload, to download and to extract and analyze.

Some tools have been added to assist with this already: the file inclusion/exclusion and time filters can allow making a relatively smaller zip when used correctly by significantly limiting which files are collected from disk. However these facilities require more nuanced operation and only apply to disk-collected files, with data such as range statuses that still scales with cluster size being unaffected by them. 

To mitigate these challenges, this change proposes a new "lite" shorthand that can be requested during collection of a debug zip, that can be used during collection to automatically elide classes of data that are known to scale with the cluster size and become large and expensive to collect, such as log files, range statuses, etc. While this is similar in effect to a very-recent file-time inclusion filter, it has value in being standalone both so that a) operators can easily see, recognize and remember "lite" zips (aka a shorthand) and b) there is a predictable, known content of a lite zip rather than being up to subtle flag combinations. 


As an example, here's a relatively small debug zip grabbed from a ~400GB roachprod cluster:

```
$ time cockroach debug zip --url 'postgres://...' --insecure debug.zip
...
user	1m0.263s

$ time roachprod get ... debug.zip
...
roachprod get ...:1 debug.zip  16.02s user 8.01s system 30% cpu 1:19.95 total

$ du -h debug.zip
1.2G	debug.zip

$ zipinfo -m debug.zip | wc -l
5984

$ time unzip debug.zip
... 
real	0m15.588s

$ du -sh debug
1.8G	debug
```

Just collecting the zip took a minute, then downloading it took a minute as well.  Here's the above sequence of operations on the same cluster, but now with a "lite" zip:

```
$ time cockroach debug zip --url 'postgres://...' --insecure --lite debug-lite.zip
...
user	0m3.896s

$ time roachprod get ... debug-lite.zip
roachprod get ...:1 debug-lite.zip  0.48s user 0.22s system 17% cpu 4.107 total

$ du -h debug-lite.zip
11M	debug-lite.zip

$ zipinfo -m debug-lite.zip | wc -l
289

$ time unzip debug.zip
... 
0m0.979s

$ du -sh debug
76M	debug
```
