### PR TITLE
sql/schemachanger: version gate dropping foreign keys

### DIFF
--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_table_drop_column.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_table_drop_column.go
@@ -13,6 +13,7 @@ package scbuildstmt
 import (
 	"sort"
 
+	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/colinfo"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
@@ -246,6 +247,12 @@ func dropColumn(
 				undroppedSeqBackrefsToCheck.Add(e.SequenceID)
 			}
 		case *scpb.FunctionBody:
+			// Until the appropriate version gate is hit, we still do not allow
+			// dropping function bodies.
+			if !b.ClusterSettings().Version.IsActive(b, clusterversion.V23_1) {
+				panic(scerrors.NotImplementedErrorf(nil, "dropping functions is"+
+					"not allowed yet."))
+			}
 			if behavior != tree.DropCascade {
 				_, _, fnName := scpb.FindFunctionName(b.QueryByID(e.FunctionID))
 				panic(sqlerrors.NewDependentObjectErrorf(
@@ -255,6 +262,12 @@ func dropColumn(
 			}
 			dropCascadeDescriptor(b, e.FunctionID)
 		case *scpb.UniqueWithoutIndexConstraint:
+			// Until the appropriate version gate is hit, we still do not allow
+			// dropping unique without index constraints.
+			if !b.ClusterSettings().Version.IsActive(b, clusterversion.V23_1) {
+				panic(scerrors.NotImplementedErrorf(nil, "dropping without"+
+					"index constraints is not allowed."))
+			}
 			constraintElems := b.QueryByID(e.TableID).Filter(hasConstraintIDAttrFilter(e.ConstraintID))
 			_, _, constraintName := scpb.FindConstraintWithoutIndexName(constraintElems.Filter(publicTargetFilter))
 			alterTableDropConstraint(b, tn, tbl, &tree.AlterTableDropConstraint{
@@ -263,6 +276,12 @@ func dropColumn(
 				DropBehavior: behavior,
 			})
 		case *scpb.UniqueWithoutIndexConstraintUnvalidated:
+			// Until the appropriate version gate is hit, we still do not allow
+			// dropping unique without index constraints.
+			if !b.ClusterSettings().Version.IsActive(b, clusterversion.V23_1) {
+				panic(scerrors.NotImplementedErrorf(nil, "dropping without"+
+					"index constraints is not allowed."))
+			}
 			constraintElems := b.QueryByID(e.TableID).Filter(hasConstraintIDAttrFilter(e.ConstraintID))
 			_, _, constraintName := scpb.FindConstraintWithoutIndexName(constraintElems.Filter(publicTargetFilter))
 			alterTableDropConstraint(b, tn, tbl, &tree.AlterTableDropConstraint{


### PR DESCRIPTION
Previously, it was possible in a mixed version state to clean up foreign keys when dropping columns (when cleaning up any secondary indexes). This was because DROP COLUMN and DROP INDEX share code for this cleanup, so it was possible to clean up foreign keys in unsupported scenarios. To address this, this patch adds a version gate to prevent dropping foreign keys when dropping secondary indexes (which could happen on a mixed version cluster due to a dropped column).

Fixes: #97576

Release note: None