### PR TITLE
release-22.1: colexec: fix incorrect accounting when resetting datum-backed vectors

### DIFF
--- a/pkg/col/coldata/batch.go
+++ b/pkg/col/coldata/batch.go
@@ -16,7 +16,6 @@ import (
 	"strings"
 	"sync/atomic"
 
-	"github.com/cockroachdb/cockroach/pkg/col/typeconv"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/errors"
@@ -70,12 +69,7 @@ type Batch interface {
 	// batches that they reuse as not doing this could result in correctness
 	// or memory blowup issues. It unsets the selection and sets the length to
 	// 0.
-	//
-	// Notably, it deeply resets the datum-backed vectors and returns the number
-	// of bytes released as a result of the reset. Callers should update the
-	// allocator (which the batch was instantiated from) accordingly unless they
-	// guarantee that the batch doesn't have any datum-backed vectors.
-	ResetInternalBatch() int64
+	ResetInternalBatch()
 	// String returns a pretty representation of this batch.
 	String() string
 }
@@ -130,9 +124,6 @@ func NewMemBatchWithCapacity(typs []*types.T, capacity int, factory ColumnFactor
 		col := &cols[i]
 		col.init(t, capacity, factory)
 		b.b[i] = col
-		if col.CanonicalTypeFamily() == typeconv.DatumVecCanonicalTypeFamily {
-			b.datumVecIdxs.Add(i)
-		}
 	}
 	return b
 }
@@ -202,10 +193,8 @@ type MemBatch struct {
 	// MemBatch.
 	capacity int
 	// b is the slice of columns in this batch.
-	b []Vec
-	// datumVecIdxs stores the indices of all datum-backed vectors in b.
-	datumVecIdxs util.FastIntSet
-	useSel       bool
+	b      []Vec
+	useSel bool
 	// sel is - if useSel is true - a selection vector from upstream. A
 	// selection vector is a list of selected tuple indices in this memBatch's
 	// columns (tuples for which indices are not in sel are considered to be
@@ -258,9 +247,6 @@ func (m *MemBatch) SetLength(length int) {
 
 // AppendCol implements the Batch interface.
 func (m *MemBatch) AppendCol(col Vec) {
-	if col.CanonicalTypeFamily() == typeconv.DatumVecCanonicalTypeFamily {
-		m.datumVecIdxs.Add(len(m.b))
-	}
 	m.b = append(m.b, col)
 }
 
@@ -299,17 +285,12 @@ func (m *MemBatch) Reset(typs []*types.T, length int, factory ColumnFactory) {
 	// since those will get reset in ResetInternalBatch anyway.
 	m.b = m.b[:len(typs)]
 	m.sel = m.sel[:length]
-	for i, ok := m.datumVecIdxs.Next(0); ok; i, ok = m.datumVecIdxs.Next(i + 1) {
-		if i >= len(typs) {
-			m.datumVecIdxs.Remove(i)
-		}
-	}
 	m.ResetInternalBatch()
 	m.SetLength(length)
 }
 
 // ResetInternalBatch implements the Batch interface.
-func (m *MemBatch) ResetInternalBatch() int64 {
+func (m *MemBatch) ResetInternalBatch() {
 	m.SetLength(0 /* length */)
 	m.SetSelection(false)
 	for _, v := range m.b {
@@ -318,11 +299,6 @@ func (m *MemBatch) ResetInternalBatch() int64 {
 			ResetIfBytesLike(v)
 		}
 	}
-	var released int64
-	for i, ok := m.datumVecIdxs.Next(0); ok; i, ok = m.datumVecIdxs.Next(i + 1) {
-		released += m.b[i].Datum().Reset()
-	}
-	return released
 }
 
 // String returns a pretty representation of this batch.

--- a/pkg/col/coldata/datum_vec.go
+++ b/pkg/col/coldata/datum_vec.go
@@ -36,6 +36,8 @@ type DatumVec interface {
 	AppendSlice(src DatumVec, destIdx, srcStartIdx, srcEndIdx int)
 	// AppendVal appends the given tree.Datum value to the end of the vector.
 	AppendVal(v Datum)
+	// SetLength sets the length of the vector.
+	SetLength(l int)
 	// Len returns the length of the vector.
 	Len() int
 	// Cap returns the underlying capacity of the vector.
@@ -53,7 +55,4 @@ type DatumVec interface {
 	// be used when elements before startIdx are guaranteed not to have been
 	// modified.
 	Size(startIdx int) int64
-	// Reset resets the vector for reuse. It returns the number of bytes
-	// released.
-	Reset() int64
 }

--- a/pkg/col/coldataext/datum_vec.go
+++ b/pkg/col/coldataext/datum_vec.go
@@ -124,6 +124,11 @@ func (dv *datumVec) AppendVal(v coldata.Datum) {
 	dv.data = append(dv.data, datum)
 }
 
+// SetLength implements coldata.DatumVec interface.
+func (dv *datumVec) SetLength(l int) {
+	dv.data = dv.data[:l]
+}
+
 // Len implements coldata.DatumVec interface.
 func (dv *datumVec) Len() int {
 	return len(dv.data)
@@ -149,24 +154,6 @@ func (dv *datumVec) UnmarshalTo(i int, b []byte) error {
 	return err
 }
 
-// valuesSize returns the footprint of actual datums (in bytes) with ordinals in
-// [startIdx:] range, ignoring the overhead of tree.Datum wrapper.
-func (dv *datumVec) valuesSize(startIdx int) int64 {
-	var size int64
-	// Only the elements up to the length are expected to be non-nil. Note that
-	// we cannot take a short-cut with fixed-length values here because they
-	// might not be set, so we could over-account if we did something like
-	//   size += (len-startIdx) * fixedSize.
-	if startIdx < dv.Len() {
-		for _, d := range dv.data[startIdx:dv.Len()] {
-			if d != nil {
-				size += int64(d.Size())
-			}
-		}
-	}
-	return size
-}
-
 // Size implements coldata.DatumVec interface.
 func (dv *datumVec) Size(startIdx int) int64 {
 	// Note that we don't account for the overhead of datumVec struct, and the
@@ -178,18 +165,24 @@ func (dv *datumVec) Size(startIdx int) int64 {
 	if startIdx < 0 {
 		startIdx = 0
 	}
-	// We have to account for the tree.Datum overhead for the whole capacity of
-	// the underlying slice.
-	return memsize.DatumOverhead*int64(dv.Cap()-startIdx) + dv.valuesSize(startIdx)
-}
-
-// Reset implements coldata.DatumVec interface.
-func (dv *datumVec) Reset() int64 {
-	released := dv.valuesSize(0 /* startIdx */)
-	for i := range dv.data {
-		dv.data[i] = nil
+	count := int64(dv.Cap() - startIdx)
+	size := memsize.DatumOverhead * count
+	if datumSize, variable := tree.DatumTypeSize(dv.t); variable {
+		// The elements in dv.data[max(startIdx,len):cap] range are accounted with
+		// the default datum size for the type. For those in the range
+		// [startIdx, len) we call Datum.Size().
+		idx := startIdx
+		for ; idx < len(dv.data); idx++ {
+			if dv.data[idx] != nil {
+				size += int64(dv.data[idx].Size())
+			}
+		}
+		// Pick up where the loop left off.
+		size += int64(dv.Cap()-idx) * int64(datumSize)
+	} else {
+		size += int64(datumSize) * count
 	}
-	return released
+	return size
 }
 
 // assertValidDatum asserts that the given datum is valid to be stored in this

--- a/pkg/sql/colexec/colexecutils/operator.go
+++ b/pkg/sql/colexec/colexecutils/operator.go
@@ -76,9 +76,7 @@ func (s *fixedNumTuplesNoInputOp) Next() coldata.Batch {
 	if s.numTuplesLeft == 0 {
 		return coldata.ZeroBatch
 	}
-	// The internal batch has no columns, so no memory is ever released on the
-	// ResetInternalBatch() call.
-	_ = s.batch.ResetInternalBatch()
+	s.batch.ResetInternalBatch()
 	length := s.numTuplesLeft
 	if length > coldata.BatchSize() {
 		length = coldata.BatchSize()

--- a/pkg/sql/colexec/colexecutils/utils.go
+++ b/pkg/sql/colexec/colexecutils/utils.go
@@ -183,12 +183,9 @@ func (b *AppendOnlyBufferedBatch) Reset([]*types.T, int, coldata.ColumnFactory) 
 }
 
 // ResetInternalBatch implements the coldata.Batch interface.
-// NB: any memory released during this call is automatically released from the
-// allocator that created the batch.
-func (b *AppendOnlyBufferedBatch) ResetInternalBatch() int64 {
+func (b *AppendOnlyBufferedBatch) ResetInternalBatch() {
 	b.SetLength(0 /* n */)
-	b.allocator.ReleaseMemory(b.batch.ResetInternalBatch())
-	return 0
+	b.batch.ResetInternalBatch()
 }
 
 // String implements the coldata.Batch interface.

--- a/pkg/sql/colexec/colexecwindow/relative_rank.eg.go
+++ b/pkg/sql/colexec/colexecwindow/relative_rank.eg.go
@@ -260,7 +260,7 @@ func (r *percentRankNoPartitionOp) Next() coldata.Batch {
 				continue
 			}
 
-			r.allocator.ResetBatch(r.output)
+			r.output.ResetInternalBatch()
 			// First, we copy over the buffered up columns.
 			r.allocator.PerformOperation(r.output.ColVecs()[:len(r.inputTypes)], func() {
 				for colIdx, vec := range r.output.ColVecs()[:len(r.inputTypes)] {
@@ -473,9 +473,7 @@ func (r *percentRankWithPartitionOp) Next() coldata.Batch {
 								r.partitionsState.runningSizes.SetLength(coldata.BatchSize())
 								r.partitionsState.Enqueue(r.Ctx, r.partitionsState.runningSizes)
 								r.partitionsState.idx = 0
-								// This batch has only a single INT column, so no memory is ever
-								// released on the ResetInternalBatch() call.
-								_ = r.partitionsState.runningSizes.ResetInternalBatch()
+								r.partitionsState.runningSizes.ResetInternalBatch()
 							}
 						}
 					}
@@ -498,9 +496,7 @@ func (r *percentRankWithPartitionOp) Next() coldata.Batch {
 								r.partitionsState.runningSizes.SetLength(coldata.BatchSize())
 								r.partitionsState.Enqueue(r.Ctx, r.partitionsState.runningSizes)
 								r.partitionsState.idx = 0
-								// This batch has only a single INT column, so no memory is ever
-								// released on the ResetInternalBatch() call.
-								_ = r.partitionsState.runningSizes.ResetInternalBatch()
+								r.partitionsState.runningSizes.ResetInternalBatch()
 							}
 						}
 					}
@@ -528,7 +524,7 @@ func (r *percentRankWithPartitionOp) Next() coldata.Batch {
 				r.numTuplesInPartition = 0
 			}
 
-			r.allocator.ResetBatch(r.output)
+			r.output.ResetInternalBatch()
 			// First, we copy over the buffered up columns.
 			r.allocator.PerformOperation(r.output.ColVecs()[:len(r.inputTypes)], func() {
 				for colIdx, vec := range r.output.ColVecs()[:len(r.inputTypes)] {
@@ -757,9 +753,7 @@ func (r *cumeDistNoPartitionOp) Next() coldata.Batch {
 								r.peerGroupsState.runningSizes.SetLength(coldata.BatchSize())
 								r.peerGroupsState.Enqueue(r.Ctx, r.peerGroupsState.runningSizes)
 								r.peerGroupsState.idx = 0
-								// This batch has only a single INT column, so no memory is ever
-								// released on the ResetInternalBatch() call.
-								_ = r.peerGroupsState.runningSizes.ResetInternalBatch()
+								r.peerGroupsState.runningSizes.ResetInternalBatch()
 							}
 						}
 					}
@@ -782,9 +776,7 @@ func (r *cumeDistNoPartitionOp) Next() coldata.Batch {
 								r.peerGroupsState.runningSizes.SetLength(coldata.BatchSize())
 								r.peerGroupsState.Enqueue(r.Ctx, r.peerGroupsState.runningSizes)
 								r.peerGroupsState.idx = 0
-								// This batch has only a single INT column, so no memory is ever
-								// released on the ResetInternalBatch() call.
-								_ = r.peerGroupsState.runningSizes.ResetInternalBatch()
+								r.peerGroupsState.runningSizes.ResetInternalBatch()
 							}
 						}
 					}
@@ -811,7 +803,7 @@ func (r *cumeDistNoPartitionOp) Next() coldata.Batch {
 				r.numPeers = 0
 			}
 
-			r.allocator.ResetBatch(r.output)
+			r.output.ResetInternalBatch()
 			// First, we copy over the buffered up columns.
 			r.allocator.PerformOperation(r.output.ColVecs()[:len(r.inputTypes)], func() {
 				for colIdx, vec := range r.output.ColVecs()[:len(r.inputTypes)] {
@@ -1047,9 +1039,7 @@ func (r *cumeDistWithPartitionOp) Next() coldata.Batch {
 								r.partitionsState.runningSizes.SetLength(coldata.BatchSize())
 								r.partitionsState.Enqueue(r.Ctx, r.partitionsState.runningSizes)
 								r.partitionsState.idx = 0
-								// This batch has only a single INT column, so no memory is ever
-								// released on the ResetInternalBatch() call.
-								_ = r.partitionsState.runningSizes.ResetInternalBatch()
+								r.partitionsState.runningSizes.ResetInternalBatch()
 							}
 						}
 					}
@@ -1072,9 +1062,7 @@ func (r *cumeDistWithPartitionOp) Next() coldata.Batch {
 								r.partitionsState.runningSizes.SetLength(coldata.BatchSize())
 								r.partitionsState.Enqueue(r.Ctx, r.partitionsState.runningSizes)
 								r.partitionsState.idx = 0
-								// This batch has only a single INT column, so no memory is ever
-								// released on the ResetInternalBatch() call.
-								_ = r.partitionsState.runningSizes.ResetInternalBatch()
+								r.partitionsState.runningSizes.ResetInternalBatch()
 							}
 						}
 					}
@@ -1103,9 +1091,7 @@ func (r *cumeDistWithPartitionOp) Next() coldata.Batch {
 								r.peerGroupsState.runningSizes.SetLength(coldata.BatchSize())
 								r.peerGroupsState.Enqueue(r.Ctx, r.peerGroupsState.runningSizes)
 								r.peerGroupsState.idx = 0
-								// This batch has only a single INT column, so no memory is ever
-								// released on the ResetInternalBatch() call.
-								_ = r.peerGroupsState.runningSizes.ResetInternalBatch()
+								r.peerGroupsState.runningSizes.ResetInternalBatch()
 							}
 						}
 					}
@@ -1128,9 +1114,7 @@ func (r *cumeDistWithPartitionOp) Next() coldata.Batch {
 								r.peerGroupsState.runningSizes.SetLength(coldata.BatchSize())
 								r.peerGroupsState.Enqueue(r.Ctx, r.peerGroupsState.runningSizes)
 								r.peerGroupsState.idx = 0
-								// This batch has only a single INT column, so no memory is ever
-								// released on the ResetInternalBatch() call.
-								_ = r.peerGroupsState.runningSizes.ResetInternalBatch()
+								r.peerGroupsState.runningSizes.ResetInternalBatch()
 							}
 						}
 					}
@@ -1165,7 +1149,7 @@ func (r *cumeDistWithPartitionOp) Next() coldata.Batch {
 				r.numPeers = 0
 			}
 
-			r.allocator.ResetBatch(r.output)
+			r.output.ResetInternalBatch()
 			// First, we copy over the buffered up columns.
 			r.allocator.PerformOperation(r.output.ColVecs()[:len(r.inputTypes)], func() {
 				for colIdx, vec := range r.output.ColVecs()[:len(r.inputTypes)] {

--- a/pkg/sql/colexec/colexecwindow/relative_rank_tmpl.go
+++ b/pkg/sql/colexec/colexecwindow/relative_rank_tmpl.go
@@ -155,9 +155,7 @@ func _COMPUTE_PARTITIONS_SIZES(_HAS_SEL bool) { // */}}
 				r.partitionsState.runningSizes.SetLength(coldata.BatchSize())
 				r.partitionsState.Enqueue(r.Ctx, r.partitionsState.runningSizes)
 				r.partitionsState.idx = 0
-				// This batch has only a single INT column, so no memory is ever
-				// released on the ResetInternalBatch() call.
-				_ = r.partitionsState.runningSizes.ResetInternalBatch()
+				r.partitionsState.runningSizes.ResetInternalBatch()
 			}
 		}
 	}
@@ -189,9 +187,7 @@ func _COMPUTE_PEER_GROUPS_SIZES(_HAS_SEL bool) { // */}}
 				r.peerGroupsState.runningSizes.SetLength(coldata.BatchSize())
 				r.peerGroupsState.Enqueue(r.Ctx, r.peerGroupsState.runningSizes)
 				r.peerGroupsState.idx = 0
-				// This batch has only a single INT column, so no memory is ever
-				// released on the ResetInternalBatch() call.
-				_ = r.peerGroupsState.runningSizes.ResetInternalBatch()
+				r.peerGroupsState.runningSizes.ResetInternalBatch()
 			}
 		}
 	}
@@ -478,7 +474,7 @@ func (r *_RELATIVE_RANK_STRINGOp) Next() coldata.Batch {
 			}
 			// {{end}}
 
-			r.allocator.ResetBatch(r.output)
+			r.output.ResetInternalBatch()
 			// First, we copy over the buffered up columns.
 			r.allocator.PerformOperation(r.output.ColVecs()[:len(r.inputTypes)], func() {
 				for colIdx, vec := range r.output.ColVecs()[:len(r.inputTypes)] {

--- a/pkg/sql/colexec/count.go
+++ b/pkg/sql/colexec/count.go
@@ -46,9 +46,7 @@ func (c *countOp) Next() coldata.Batch {
 	if c.done {
 		return coldata.ZeroBatch
 	}
-	// The internal batch has only a single INT column, so no memory is ever
-	// released on the ResetInternalBatch() call.
-	_ = c.internalBatch.ResetInternalBatch()
+	c.internalBatch.ResetInternalBatch()
 	for {
 		bat := c.Input.Next()
 		length := bat.Length()

--- a/pkg/sql/colexec/hash_based_partitioner.go
+++ b/pkg/sql/colexec/hash_based_partitioner.go
@@ -368,7 +368,7 @@ func (op *hashBasedPartitioner) partitionBatch(
 	for idx, sel := range selections {
 		partitionIdx := op.partitionIdxOffset + idx
 		if len(sel) > 0 {
-			op.unlimitedAllocator.ResetBatch(scratchBatch)
+			scratchBatch.ResetInternalBatch()
 			// The partitioner expects the batches without a selection vector,
 			// so we need to copy the tuples according to the selection vector
 			// into a scratch batch.

--- a/pkg/sql/colexec/ordered_aggregator.go
+++ b/pkg/sql/colexec/ordered_aggregator.go
@@ -190,7 +190,7 @@ func (a *orderedAggregator) Next() coldata.Batch {
 		switch a.state {
 		case orderedAggregatorAggregating:
 			if a.scratch.shouldResetInternalBatch {
-				a.allocator.ResetBatch(a.scratch)
+				a.scratch.ResetInternalBatch()
 				a.scratch.shouldResetInternalBatch = false
 			}
 			if a.scratch.resumeIdx >= coldata.BatchSize() {
@@ -325,7 +325,7 @@ func (a *orderedAggregator) Next() coldata.Batch {
 				if a.unsafeBatch == nil {
 					a.unsafeBatch = a.allocator.NewMemBatchWithFixedCapacity(a.outputTypes, coldata.BatchSize())
 				} else {
-					a.allocator.ResetBatch(a.unsafeBatch)
+					a.unsafeBatch.ResetInternalBatch()
 				}
 				a.allocator.PerformOperation(a.unsafeBatch.ColVecs(), func() {
 					for i := 0; i < len(a.outputTypes); i++ {
@@ -351,7 +351,7 @@ func (a *orderedAggregator) Next() coldata.Batch {
 				// the source and the destination would be the same, and
 				// resetting it would lead to the loss of data.
 				newResumeIdx := a.scratch.resumeIdx - coldata.BatchSize()
-				a.allocator.ResetBatch(a.scratch.tempBuffer)
+				a.scratch.tempBuffer.ResetInternalBatch()
 				a.allocator.PerformOperation(a.scratch.tempBuffer.ColVecs(), func() {
 					for i := 0; i < len(a.outputTypes); i++ {
 						a.scratch.tempBuffer.ColVec(i).Copy(
@@ -363,7 +363,7 @@ func (a *orderedAggregator) Next() coldata.Batch {
 						)
 					}
 				})
-				a.allocator.ResetBatch(a.scratch)
+				a.scratch.ResetInternalBatch()
 				a.allocator.PerformOperation(a.scratch.ColVecs(), func() {
 					for i := 0; i < len(a.outputTypes); i++ {
 						a.scratch.ColVec(i).Copy(

--- a/pkg/sql/colmem/BUILD.bazel
+++ b/pkg/sql/colmem/BUILD.bazel
@@ -31,6 +31,7 @@ go_test(
     deps = [
         "//pkg/col/coldata",
         "//pkg/col/coldataext",
+        "//pkg/col/typeconv",
         "//pkg/settings/cluster",
         "//pkg/sql/colconv",
         "//pkg/sql/colexec/colexecutils",

--- a/pkg/sql/colmem/allocator.go
+++ b/pkg/sql/colmem/allocator.go
@@ -182,11 +182,6 @@ func (a *Allocator) NewMemBatchNoCols(typs []*types.T, capacity int) coldata.Bat
 	return coldata.NewMemBatchNoCols(typs, capacity)
 }
 
-// ResetBatch resets the batch while keeping the memory accounting updated.
-func (a *Allocator) ResetBatch(batch coldata.Batch) {
-	a.ReleaseMemory(batch.ResetInternalBatch())
-}
-
 // truncateToMemoryLimit returns the largest batch capacity that is still within
 // the memory limit for the given type schema. The returned value is at most
 // minDesiredCapacity and at least 1.
@@ -310,7 +305,7 @@ func (a *Allocator) resetMaybeReallocate(
 		}
 		if useOldBatch {
 			reallocated = false
-			a.ResetBatch(oldBatch)
+			oldBatch.ResetInternalBatch()
 			newBatch = oldBatch
 		} else {
 			a.ReleaseMemory(oldBatchMemSize)
@@ -393,10 +388,9 @@ func (a *Allocator) MaybeAppendColumn(b coldata.Batch, t *types.T, colIdx int) {
 				b.ReplaceCol(a.NewMemColumn(t, desiredCapacity), colIdx)
 				return
 			}
-			if presentVec.CanonicalTypeFamily() == typeconv.DatumVecCanonicalTypeFamily {
-				a.ReleaseMemory(presentVec.Datum().Reset())
-			} else {
-				coldata.ResetIfBytesLike(presentVec)
+			coldata.ResetIfBytesLike(presentVec)
+			if presentVec.MaybeHasNulls() {
+				presentVec.Nulls().UnsetNulls()
 			}
 			return
 		}
@@ -576,11 +570,15 @@ func EstimateBatchSizeBytes(vecTypes []*types.T, batchLength int) int64 {
 			// use the flat struct size as an estimate.
 			acc += memsize.Decimal
 		case typeconv.DatumVecCanonicalTypeFamily:
-			// Initially, only []tree.Datum slice is allocated for the
-			// datum-backed vectors right away, so that's what we're including
-			// in the estimate. Later on, once the actual values are set, they
-			// will be accounted for properly.
-			acc += memsize.DatumOverhead
+			// In datum vec we need to account for memory underlying the struct
+			// that is the implementation of tree.Datum interface (for example,
+			// tree.DBoolFalse) as well as for the overhead of storing that
+			// implementation in the slice of tree.Datums. Note that if t is of
+			// variable size, the memory will be properly accounted in
+			// getVecMemoryFootprint.
+			// Note: keep the calculation here in line with datumVec.Size.
+			implementationSize, _ := tree.DatumTypeSize(t)
+			acc += int64(implementationSize) + memsize.DatumOverhead
 		case
 			types.BoolFamily,
 			types.IntFamily,
@@ -803,30 +801,29 @@ type SetAccountingHelper struct {
 	// that we have already accounted for.
 	prevBytesLikeTotalSize int64
 
-	// decimalVecIdxs stores the indices of all decimal vectors.
-	decimalVecIdxs util.FastIntSet
-	// decimalVecs stores all decimal vectors. They are updated every time a new
-	// batch is allocated.
+	// varSizeVecIdxs stores the indices of all vectors with variable sized
+	// values except for the bytes-like ones.
+	varSizeVecIdxs util.FastIntSet
+	// decimalVecs and datumVecs store all decimal and datum-backed vectors,
+	// respectively. They are updated every time a new batch is allocated.
 	decimalVecs []coldata.Decimals
-	// decimalSizes stores the amount of space we have accounted for for the
-	// corresponding decimal values in the corresponding row of the last batch
-	// that the helper has touched. This is necessary to track because when the
-	// batch is reset, the vectors still have references to the old decimals, so
-	// we need to adjust the accounting only by the delta. Similarly, once a new
-	// batch is allocated, we need to track the estimate that we have already
+	datumVecs   []coldata.DatumVec
+	// varSizeDatumSizes stores the amount of space we have accounted for for
+	// the corresponding "row" of variable length values in the last batch that
+	// the helper has touched. This is necessary to track because when the batch
+	// is reset, the vectors still have references to the old datums, so we need
+	// to adjust the accounting only by the delta. Similarly, once a new batch
+	// is allocated, we need to track the estimate that we have already
 	// accounted for.
 	//
 	// Note that because ResetMaybeReallocate caps the capacity of the batch at
 	// coldata.BatchSize(), this slice will never exceed coldata.BatchSize() in
 	// size, and we choose to ignore it for the purposes of memory accounting.
-	decimalSizes []int64
-
-	// varLenDatumVecIdxs stores the indices of all datum-backed vectors with
-	// variable-length values.
-	varLenDatumVecIdxs util.FastIntSet
-	// varLenDatumVecs stores all variable-sized datum-backed vectors. They are
-	// updated every time a new batch is allocated.
-	varLenDatumVecs []coldata.DatumVec
+	varSizeDatumSizes []int64
+	// varSizeEstimatePerRow is the total estimated size of single values from
+	// varSizeVecIdxs vectors which is accounted for by EstimateBatchSizeBytes.
+	// It serves as the initial value for varSizeDatumSizes values.
+	varSizeEstimatePerRow int64
 }
 
 // Init initializes the helper. The allocator must **not** be shared with any
@@ -834,21 +831,28 @@ type SetAccountingHelper struct {
 func (h *SetAccountingHelper) Init(allocator *Allocator, memoryLimit int64, typs []*types.T) {
 	h.helper.Init(allocator, memoryLimit)
 
+	numDecimalVecs := 0
 	for vecIdx, typ := range typs {
 		switch typeconv.TypeFamilyToCanonicalTypeFamily(typ.Family()) {
 		case types.BytesFamily, types.JsonFamily:
 			h.bytesLikeVecIdxs.Add(vecIdx)
 		case types.DecimalFamily:
-			h.decimalVecIdxs.Add(vecIdx)
+			h.varSizeVecIdxs.Add(vecIdx)
+			h.varSizeEstimatePerRow += memsize.Decimal
+			numDecimalVecs++
 		case typeconv.DatumVecCanonicalTypeFamily:
-			h.varLenDatumVecIdxs.Add(vecIdx)
+			estimate, isVarlen := tree.DatumTypeSize(typ)
+			if isVarlen {
+				h.varSizeVecIdxs.Add(vecIdx)
+				h.varSizeEstimatePerRow += int64(estimate) + memsize.DatumOverhead
+			}
 		}
 	}
 
-	h.allFixedLength = h.bytesLikeVecIdxs.Empty() && h.decimalVecIdxs.Empty() && h.varLenDatumVecIdxs.Empty()
+	h.allFixedLength = h.bytesLikeVecIdxs.Empty() && h.varSizeVecIdxs.Empty()
 	h.bytesLikeVectors = make([]*coldata.Bytes, h.bytesLikeVecIdxs.Len())
-	h.decimalVecs = make([]coldata.Decimals, h.decimalVecIdxs.Len())
-	h.varLenDatumVecs = make([]coldata.DatumVec, h.varLenDatumVecIdxs.Len())
+	h.decimalVecs = make([]coldata.Decimals, numDecimalVecs)
+	h.datumVecs = make([]coldata.DatumVec, h.varSizeVecIdxs.Len()-numDecimalVecs)
 }
 
 func (h *SetAccountingHelper) getBytesLikeTotalSize() int64 {
@@ -892,24 +896,23 @@ func (h *SetAccountingHelper) ResetMaybeReallocate(
 			}
 			h.prevBytesLikeTotalSize = h.getBytesLikeTotalSize()
 		}
-		if !h.decimalVecIdxs.Empty() {
+		if !h.varSizeVecIdxs.Empty() {
 			h.decimalVecs = h.decimalVecs[:0]
-			for vecIdx, ok := h.decimalVecIdxs.Next(0); ok; vecIdx, ok = h.decimalVecIdxs.Next(vecIdx + 1) {
-				h.decimalVecs = append(h.decimalVecs, vecs[vecIdx].Decimal())
+			h.datumVecs = h.datumVecs[:0]
+			for vecIdx, ok := h.varSizeVecIdxs.Next(0); ok; vecIdx, ok = h.varSizeVecIdxs.Next(vecIdx + 1) {
+				if vecs[vecIdx].CanonicalTypeFamily() == types.DecimalFamily {
+					h.decimalVecs = append(h.decimalVecs, vecs[vecIdx].Decimal())
+				} else {
+					h.datumVecs = append(h.datumVecs, vecs[vecIdx].Datum())
+				}
 			}
-			h.decimalSizes = make([]int64, newBatch.Capacity())
-			for i := range h.decimalSizes {
-				// In EstimateBatchSizeBytes, memsize.Decimal has already been
-				// accounted for for each decimal value, so we multiple that by
-				// the number of decimal vectors to get already included
-				// footprint of all decimal values in a single row.
-				h.decimalSizes[i] = int64(len(h.decimalVecs)) * memsize.Decimal
+			if cap(h.varSizeDatumSizes) < newBatch.Capacity() {
+				h.varSizeDatumSizes = make([]int64, newBatch.Capacity())
+			} else {
+				h.varSizeDatumSizes = h.varSizeDatumSizes[:newBatch.Capacity()]
 			}
-		}
-		if !h.varLenDatumVecIdxs.Empty() {
-			h.varLenDatumVecs = h.varLenDatumVecs[:0]
-			for vecIdx, ok := h.varLenDatumVecIdxs.Next(0); ok; vecIdx, ok = h.varLenDatumVecIdxs.Next(vecIdx + 1) {
-				h.varLenDatumVecs = append(h.varLenDatumVecs, vecs[vecIdx].Datum())
+			for i := range h.varSizeDatumSizes {
+				h.varSizeDatumSizes[i] = h.varSizeEstimatePerRow
 			}
 		}
 	}
@@ -937,25 +940,18 @@ func (h *SetAccountingHelper) AccountForSet(rowIdx int) (batchDone bool) {
 		h.prevBytesLikeTotalSize = newBytesLikeTotalSize
 	}
 
-	if !h.decimalVecIdxs.Empty() {
-		var newDecimalSizes int64
+	if !h.varSizeVecIdxs.Empty() {
+		var newVarLengthDatumSize int64
 		for _, decimalVec := range h.decimalVecs {
 			d := decimalVec.Get(rowIdx)
-			newDecimalSizes += int64(d.Size())
+			newVarLengthDatumSize += int64(d.Size())
 		}
-		h.helper.allocator.adjustMemoryUsageAfterAllocation(newDecimalSizes - h.decimalSizes[rowIdx])
-		h.decimalSizes[rowIdx] = newDecimalSizes
-	}
-
-	if !h.varLenDatumVecIdxs.Empty() {
-		var newVarLengthDatumSize int64
-		for _, datumVec := range h.varLenDatumVecs {
+		for _, datumVec := range h.datumVecs {
 			datumSize := datumVec.Get(rowIdx).(tree.Datum).Size()
-			// Note that we're ignoring the overhead of tree.Datum because it
-			// was already included in EstimateBatchSizeBytes.
-			newVarLengthDatumSize += int64(datumSize)
+			newVarLengthDatumSize += int64(datumSize) + memsize.DatumOverhead
 		}
-		h.helper.allocator.adjustMemoryUsageAfterAllocation(newVarLengthDatumSize)
+		h.helper.allocator.adjustMemoryUsageAfterAllocation(newVarLengthDatumSize - h.varSizeDatumSizes[rowIdx])
+		h.varSizeDatumSizes[rowIdx] = newVarLengthDatumSize
 	}
 
 	// The allocator is not shared with any other components, so we can just use

--- a/pkg/sql/colmem/allocator_test.go
+++ b/pkg/sql/colmem/allocator_test.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
 	"github.com/cockroachdb/cockroach/pkg/col/coldataext"
+	"github.com/cockroachdb/cockroach/pkg/col/typeconv"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/colconv"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexec/colexecutils"
@@ -527,7 +528,18 @@ func TestEstimateBatchSizeBytes(t *testing.T) {
 	numCols := rng.Intn(10) + 1
 	typs := make([]*types.T, numCols)
 	for i := range typs {
-		typs[i] = randgen.RandType(rng)
+		for {
+			typs[i] = randgen.RandType(rng)
+			// We ignore all datum-backed types. This is due to mismatch in how
+			// we account for unset elements in EstimateBatchSizeBytes (where we
+			// include the estimated implementation size) and datumVec.Size
+			// (where unset elements remain nil for which we only include the
+			// DatumOverhead). This exception is ok given that we still perform
+			// the correct accounting after the actual elements are set.
+			if typeconv.TypeFamilyToCanonicalTypeFamily(typs[i].Family()) != typeconv.DatumVecCanonicalTypeFamily {
+				break
+			}
+		}
 	}
 	const numRuns = 10
 	for run := 0; run < numRuns; run++ {

--- a/pkg/sql/logictest/testdata/logic_test/vectorize_agg
+++ b/pkg/sql/logictest/testdata/logic_test/vectorize_agg
@@ -55,3 +55,17 @@ NULL NULL
 1    1
 22   22
 33   33
+
+# Regression test for releasing the memory of datums in the datum-backed vector
+# from the incorrect memory account (#97603).
+statement ok
+CREATE TABLE t97603 (id PRIMARY KEY) AS SELECT generate_series(1, 50000);
+
+# The important bits are to use an aggregate function that is not supported
+# natively in the vectorized engine and to have a projection operator that is
+# producing a datum-backed vector (constant OID projection).
+statement ok
+SELECT
+     var_pop(crdb_internal_mvcc_timestamp::DECIMAL),
+     1:::OID
+FROM t97603 GROUP BY id HAVING bool_or(true)


### PR DESCRIPTION
Backport 1/1 commits from #97750.

/cc @cockroachdb/release

---

This commit reverts a couple of other commits:
- "colexec: fix a "fake" memory accounting leak for intra-query period"
(https://github.com/cockroachdb/cockroach/commit/72e83fee28f790420c2c96a707ee88eed58618fa)
- "colexec: deeply reset datum-backed vectors in ResetInternalBatch"
(https://github.com/cockroachdb/cockroach/commit/cb93c302de1bab49c8b3051ad96cf859bd91036f)

since they introduced incorrect memory accounting for the datum-backed
vectors.

Those two commits together solved another issue where we would keep
no-longer-needed datums live for longer than necessary (until they are
overwritten in the datum-backed vector) by eagerly nil-ing them out when
resetting the whole batch. This required introducing some careful
adjustment to the memory accounting in order to keep the accounting up
to date. However, that logic turned out to be faulty; in particular, it
became possible to register the allocations of the datum-backed vectors
with one account but then attempt to release some of those allocations
from another. If those releases happen enough times, it'd put the
account in debt which would trigger an internal error (or a crash in
test builds).

Such a scenario can occur because we have a couple of utility operators
that append a vector to a batch owned by another operator. When that
other operator resets its batch, the appended-by-utility-operator
vector is also reset, and the memory usage of the freed datum would be
deregistered from the wrong account. Tracking precisely which vector is
owned by the owner of the batch vs appended by another operator can be
cumbersome and error-prone, so this commit instead of introducing this
tracking removes the resetting behavior of the datum-backed vectors.
This should be bullet-proof while only increasing slightly the amount of
time references to datums are kept live.

Fixes: #97603.

Release note (bug fix): CockroachDB could previously encounter an
internal error "no bytes in account to release ..." in rare cases and
this is now fixed. The bug was introduced in 22.1.

Release justification: bug fix.