### PR TITLE
execbuilder: de-flake a recently introduced test

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/testdata/explain_analyze
+++ b/pkg/sql/opt/exec/execbuilder/testdata/explain_analyze
@@ -124,14 +124,18 @@ regions: <hidden>
 statement ok
 GRANT SELECT ON crdb_internal.tables TO root;
 
+# For some reason, even though we explicitly disable the automatic stats
+# collection for both user and system tables, rarely we still see that the stats
+# on system.privileges were collected, so we filter out a single line from the
+# output to make the test deterministic.
 query T
-EXPLAIN (VERBOSE) SELECT * FROM system.privileges WHERE path = 'vtable/crdb_internal/tables';
+SELECT * FROM [EXPLAIN (VERBOSE) SELECT * FROM system.privileges WHERE path = 'vtable/crdb_internal/tables']
+  WHERE info NOT LIKE '%estimated row count%';
 ----
 distribution: local
 vectorized: true
 ·
 • scan
   columns: (username, path, privileges, grant_options, user_id)
-  estimated row count: 10 (missing stats)
   table: privileges@privileges_path_user_id_key
   spans: /"vtable/crdb_internal/tables"-/"vtable/crdb_internal/tables"/PrefixEnd


### PR DESCRIPTION
I'm not able to reproduce the flake under stress, but for some reason it appears that the stats on a system table are collected even though we disable the auto stats collection. Those stats rarely show a different `estimated row count`, so this commit skips that line from the output of the EXPLAIN. This is acceptable given the goal of the test is ensuring that a secondary index is used for the scan.

Fixes: #97771.

Release note: None