### PR TITLE
release-22.2: sql: dedupe on search path schema when resolving functions

### DIFF
--- a/pkg/ccl/logictestccl/tests/3node-tenant/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/3node-tenant/generated_test.go
@@ -1716,6 +1716,13 @@ func TestTenantLogic_show_indexes(
 	runLogicTest(t, "show_indexes")
 }
 
+func TestTenantLogic_show_var(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "show_var")
+}
+
 func TestTenantLogic_span_builtins(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/testdata/logic_test/show_var
+++ b/pkg/sql/logictest/testdata/logic_test/show_var
@@ -1,0 +1,8 @@
+# Make sure that user get duplicate search paths as they set.
+statement ok
+SET search_path = public, public, a, b, c
+
+query T
+SHOW search_path;
+----
+public, public, a, b, c

--- a/pkg/sql/logictest/testdata/logic_test/udf
+++ b/pkg/sql/logictest/testdata/logic_test/udf
@@ -2703,3 +2703,20 @@ distribution: local
 vectorized: true
 ·
 • create function
+
+subtest regression_97130
+
+statement ok
+CREATE FUNCTION f_97130() RETURNS INT LANGUAGE SQL AS $$ SELECT 1 $$;
+
+let $pre_search_path
+SHOW search_path
+
+statement ok
+SET search_path = public,public
+
+statement ok
+SELECT f_97130();
+
+statement ok
+SET search_path = $pre_search_path

--- a/pkg/sql/logictest/tests/fakedist-disk/generated_test.go
+++ b/pkg/sql/logictest/tests/fakedist-disk/generated_test.go
@@ -1696,6 +1696,13 @@ func TestLogic_show_transfer_state(
 	runLogicTest(t, "show_transfer_state")
 }
 
+func TestLogic_show_var(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "show_var")
+}
+
 func TestLogic_span_builtins(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/fakedist-vec-off/generated_test.go
+++ b/pkg/sql/logictest/tests/fakedist-vec-off/generated_test.go
@@ -1696,6 +1696,13 @@ func TestLogic_show_transfer_state(
 	runLogicTest(t, "show_transfer_state")
 }
 
+func TestLogic_show_var(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "show_var")
+}
+
 func TestLogic_span_builtins(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/fakedist/generated_test.go
+++ b/pkg/sql/logictest/tests/fakedist/generated_test.go
@@ -1710,6 +1710,13 @@ func TestLogic_show_transfer_state(
 	runLogicTest(t, "show_transfer_state")
 }
 
+func TestLogic_show_var(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "show_var")
+}
+
 func TestLogic_span_builtins(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/local-legacy-schema-changer/generated_test.go
+++ b/pkg/sql/logictest/tests/local-legacy-schema-changer/generated_test.go
@@ -1675,6 +1675,13 @@ func TestLogic_show_transfer_state(
 	runLogicTest(t, "show_transfer_state")
 }
 
+func TestLogic_show_var(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "show_var")
+}
+
 func TestLogic_span_builtins(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/local-vec-off/generated_test.go
+++ b/pkg/sql/logictest/tests/local-vec-off/generated_test.go
@@ -1703,6 +1703,13 @@ func TestLogic_show_transfer_state(
 	runLogicTest(t, "show_transfer_state")
 }
 
+func TestLogic_show_var(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "show_var")
+}
+
 func TestLogic_span_builtins(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/local/generated_test.go
+++ b/pkg/sql/logictest/tests/local/generated_test.go
@@ -1843,6 +1843,13 @@ func TestLogic_show_transfer_state(
 	runLogicTest(t, "show_transfer_state")
 }
 
+func TestLogic_show_var(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "show_var")
+}
+
 func TestLogic_skip_on_retry(
 	t *testing.T,
 ) {

--- a/pkg/sql/sessiondata/BUILD.bazel
+++ b/pkg/sql/sessiondata/BUILD.bazel
@@ -18,6 +18,7 @@ go_library(
         "//pkg/sql/pgwire/pgerror",
         "//pkg/sql/sem/catconstants",
         "//pkg/sql/sessiondatapb",
+        "//pkg/util",
         "//pkg/util/duration",
         "//pkg/util/syncutil",
         "//pkg/util/timeutil",

--- a/pkg/sql/sessiondata/search_path.go
+++ b/pkg/sql/sessiondata/search_path.go
@@ -19,6 +19,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/catconstants"
+	"github.com/cockroachdb/cockroach/pkg/util"
 )
 
 // DefaultSearchPath is the search path used by virgin sessions.
@@ -35,6 +36,7 @@ type SearchPath struct {
 	containsPgTempSchema bool
 	tempSchemaName       string
 	userSchemaName       string
+	duplicatedIndexes    util.FastIntSet
 }
 
 // EmptySearchPath is a SearchPath with no schema names in it.
@@ -49,25 +51,31 @@ func DefaultSearchPathForUser(userName username.SQLUsername) SearchPath {
 // MakeSearchPath returns a new immutable SearchPath struct. The paths slice
 // must not be modified after hand-off to MakeSearchPath.
 func MakeSearchPath(paths []string) SearchPath {
-	containsPgCatalog := false
-	containsPgExtension := false
-	containsPgTempSchema := false
-	for _, e := range paths {
+	exists := func(p []string, e string) bool {
+		for i := range p {
+			if p[i] == e {
+				return true
+			}
+		}
+		return false
+	}
+
+	sp := SearchPath{paths: paths}
+
+	for i, e := range paths {
 		switch e {
 		case catconstants.PgCatalogName:
-			containsPgCatalog = true
+			sp.containsPgCatalog = true
 		case catconstants.PgTempSchemaName:
-			containsPgTempSchema = true
+			sp.containsPgTempSchema = true
 		case catconstants.PgExtensionSchemaName:
-			containsPgExtension = true
+			sp.containsPgExtension = true
+		}
+		if exists(paths[:i], e) {
+			sp.duplicatedIndexes.Add(i)
 		}
 	}
-	return SearchPath{
-		paths:                paths,
-		containsPgCatalog:    containsPgCatalog,
-		containsPgExtension:  containsPgExtension,
-		containsPgTempSchema: containsPgTempSchema,
-	}
+	return sp
 }
 
 // WithTemporarySchemaName returns a new immutable SearchPath struct with
@@ -82,6 +90,7 @@ func (s SearchPath) WithTemporarySchemaName(tempSchemaName string) SearchPath {
 		containsPgExtension:  s.containsPgExtension,
 		userSchemaName:       s.userSchemaName,
 		tempSchemaName:       tempSchemaName,
+		duplicatedIndexes:    s.duplicatedIndexes,
 	}
 }
 
@@ -95,6 +104,7 @@ func (s SearchPath) WithUserSchemaName(userSchemaName string) SearchPath {
 		containsPgExtension:  s.containsPgExtension,
 		userSchemaName:       userSchemaName,
 		tempSchemaName:       s.tempSchemaName,
+		duplicatedIndexes:    s.duplicatedIndexes,
 	}
 }
 
@@ -143,6 +153,7 @@ func (s SearchPath) Iter() SearchPathIter {
 		implicitPgTempSchema: implicitPgTempSchema,
 		tempSchemaName:       s.tempSchemaName,
 		userSchemaName:       s.userSchemaName,
+		duplicatedIndexes:    s.duplicatedIndexes,
 	}
 	return sp
 }
@@ -156,6 +167,7 @@ func (s SearchPath) IterWithoutImplicitPGSchemas() SearchPathIter {
 		implicitPgTempSchema: false,
 		tempSchemaName:       s.tempSchemaName,
 		userSchemaName:       s.userSchemaName,
+		duplicatedIndexes:    s.duplicatedIndexes,
 	}
 	return sp
 }
@@ -242,6 +254,7 @@ type SearchPathIter struct {
 	implicitPgTempSchema bool
 	tempSchemaName       string
 	userSchemaName       string
+	duplicatedIndexes    util.FastIntSet
 	i                    int
 }
 
@@ -259,6 +272,7 @@ func (iter *SearchPathIter) Next() (path string, ok bool) {
 	}
 
 	if iter.i < len(iter.paths) {
+		var ret string
 		iter.i++
 		// If pg_temp is explicitly present in the paths, it must be resolved to the
 		// session specific temp schema (if one exists). tempSchemaName is set in the
@@ -269,7 +283,7 @@ func (iter *SearchPathIter) Next() (path string, ok bool) {
 			if iter.tempSchemaName == "" {
 				return iter.Next()
 			}
-			return iter.tempSchemaName, true
+			ret = iter.tempSchemaName
 		}
 		if iter.paths[iter.i-1] == catconstants.UserSchemaName {
 			// In case the user schema name is unset, we simply iterate to the next
@@ -277,16 +291,25 @@ func (iter *SearchPathIter) Next() (path string, ok bool) {
 			if iter.userSchemaName == "" {
 				return iter.Next()
 			}
-			return iter.userSchemaName, true
+			ret = iter.userSchemaName
 		}
 		// pg_extension should be read before delving into the schema.
 		if iter.paths[iter.i-1] == catconstants.PublicSchemaName && iter.implicitPgExtension {
 			iter.implicitPgExtension = false
 			// Go back one so `public` can be found again next.
 			iter.i--
-			return catconstants.PgExtensionSchemaName, true
+			ret = catconstants.PgExtensionSchemaName
 		}
-		return iter.paths[iter.i-1], true
+
+		if ret == "" {
+			ret = iter.paths[iter.i-1]
+		}
+
+		for iter.i < len(iter.paths) && iter.duplicatedIndexes.Contains(iter.i) {
+			iter.i++
+		}
+
+		return ret, true
 	}
 	return "", false
 }

--- a/pkg/sql/sessiondata/search_path_test.go
+++ b/pkg/sql/sessiondata/search_path_test.go
@@ -45,7 +45,28 @@ func TestImpliedSearchPath(t *testing.T) {
 			expectedSearchPathWithoutImplicitPgSchemasWhenTempSchemaExists: []string{`pg_catalog`},
 		},
 		{
+			explicitSearchPath:                                             []string{`pg_catalog`, `pg_catalog`},
+			expectedSearchPath:                                             []string{`pg_catalog`},
+			expectedSearchPathWithoutImplicitPgSchemas:                     []string{`pg_catalog`},
+			expectedSearchPathWhenTemporarySchemaExists:                    []string{testTempSchemaName, `pg_catalog`},
+			expectedSearchPathWithoutImplicitPgSchemasWhenTempSchemaExists: []string{`pg_catalog`},
+		},
+		{
 			explicitSearchPath:                                             []string{`pg_catalog`, `pg_temp`},
+			expectedSearchPath:                                             []string{`pg_catalog`},
+			expectedSearchPathWithoutImplicitPgSchemas:                     []string{`pg_catalog`},
+			expectedSearchPathWhenTemporarySchemaExists:                    []string{`pg_catalog`, testTempSchemaName},
+			expectedSearchPathWithoutImplicitPgSchemasWhenTempSchemaExists: []string{`pg_catalog`, testTempSchemaName},
+		},
+		{
+			explicitSearchPath:                                             []string{`pg_catalog`, `pg_catalog`, `pg_temp`},
+			expectedSearchPath:                                             []string{`pg_catalog`},
+			expectedSearchPathWithoutImplicitPgSchemas:                     []string{`pg_catalog`},
+			expectedSearchPathWhenTemporarySchemaExists:                    []string{`pg_catalog`, testTempSchemaName},
+			expectedSearchPathWithoutImplicitPgSchemasWhenTempSchemaExists: []string{`pg_catalog`, testTempSchemaName},
+		},
+		{
+			explicitSearchPath:                                             []string{`pg_catalog`, `pg_temp`, `pg_temp`},
 			expectedSearchPath:                                             []string{`pg_catalog`},
 			expectedSearchPathWithoutImplicitPgSchemas:                     []string{`pg_catalog`},
 			expectedSearchPathWhenTemporarySchemaExists:                    []string{`pg_catalog`, testTempSchemaName},
@@ -59,7 +80,35 @@ func TestImpliedSearchPath(t *testing.T) {
 			expectedSearchPathWithoutImplicitPgSchemasWhenTempSchemaExists: []string{testTempSchemaName, `pg_catalog`},
 		},
 		{
+			explicitSearchPath:                                             []string{`pg_temp`, `pg_temp`, `pg_catalog`},
+			expectedSearchPath:                                             []string{`pg_catalog`},
+			expectedSearchPathWithoutImplicitPgSchemas:                     []string{`pg_catalog`},
+			expectedSearchPathWhenTemporarySchemaExists:                    []string{testTempSchemaName, `pg_catalog`},
+			expectedSearchPathWithoutImplicitPgSchemasWhenTempSchemaExists: []string{testTempSchemaName, `pg_catalog`},
+		},
+		{
+			explicitSearchPath:                                             []string{`pg_temp`, `pg_catalog`, `pg_catalog`},
+			expectedSearchPath:                                             []string{`pg_catalog`},
+			expectedSearchPathWithoutImplicitPgSchemas:                     []string{`pg_catalog`},
+			expectedSearchPathWhenTemporarySchemaExists:                    []string{testTempSchemaName, `pg_catalog`},
+			expectedSearchPathWithoutImplicitPgSchemasWhenTempSchemaExists: []string{testTempSchemaName, `pg_catalog`},
+		},
+		{
 			explicitSearchPath:                                             []string{`foobar`, `pg_catalog`},
+			expectedSearchPath:                                             []string{`foobar`, `pg_catalog`},
+			expectedSearchPathWithoutImplicitPgSchemas:                     []string{`foobar`, `pg_catalog`},
+			expectedSearchPathWhenTemporarySchemaExists:                    []string{testTempSchemaName, `foobar`, `pg_catalog`},
+			expectedSearchPathWithoutImplicitPgSchemasWhenTempSchemaExists: []string{`foobar`, `pg_catalog`},
+		},
+		{
+			explicitSearchPath:                                             []string{`foobar`, `foobar`, `pg_catalog`},
+			expectedSearchPath:                                             []string{`foobar`, `pg_catalog`},
+			expectedSearchPathWithoutImplicitPgSchemas:                     []string{`foobar`, `pg_catalog`},
+			expectedSearchPathWhenTemporarySchemaExists:                    []string{testTempSchemaName, `foobar`, `pg_catalog`},
+			expectedSearchPathWithoutImplicitPgSchemasWhenTempSchemaExists: []string{`foobar`, `pg_catalog`},
+		},
+		{
+			explicitSearchPath:                                             []string{`foobar`, `pg_catalog`, `pg_catalog`},
 			expectedSearchPath:                                             []string{`foobar`, `pg_catalog`},
 			expectedSearchPathWithoutImplicitPgSchemas:                     []string{`foobar`, `pg_catalog`},
 			expectedSearchPathWhenTemporarySchemaExists:                    []string{testTempSchemaName, `foobar`, `pg_catalog`},
@@ -73,7 +122,28 @@ func TestImpliedSearchPath(t *testing.T) {
 			expectedSearchPathWithoutImplicitPgSchemasWhenTempSchemaExists: []string{`foobar`, testTempSchemaName},
 		},
 		{
+			explicitSearchPath:                                             []string{`foobar`, `foobar`, `pg_temp`},
+			expectedSearchPath:                                             []string{`pg_catalog`, `foobar`},
+			expectedSearchPathWithoutImplicitPgSchemas:                     []string{`foobar`},
+			expectedSearchPathWhenTemporarySchemaExists:                    []string{`pg_catalog`, `foobar`, testTempSchemaName},
+			expectedSearchPathWithoutImplicitPgSchemasWhenTempSchemaExists: []string{`foobar`, testTempSchemaName},
+		},
+		{
+			explicitSearchPath:                                             []string{`foobar`, `pg_temp`, `pg_temp`},
+			expectedSearchPath:                                             []string{`pg_catalog`, `foobar`},
+			expectedSearchPathWithoutImplicitPgSchemas:                     []string{`foobar`},
+			expectedSearchPathWhenTemporarySchemaExists:                    []string{`pg_catalog`, `foobar`, testTempSchemaName},
+			expectedSearchPathWithoutImplicitPgSchemasWhenTempSchemaExists: []string{`foobar`, testTempSchemaName},
+		},
+		{
 			explicitSearchPath:                                             []string{`foobar`},
+			expectedSearchPath:                                             []string{`pg_catalog`, `foobar`},
+			expectedSearchPathWithoutImplicitPgSchemas:                     []string{`foobar`},
+			expectedSearchPathWhenTemporarySchemaExists:                    []string{testTempSchemaName, `pg_catalog`, `foobar`},
+			expectedSearchPathWithoutImplicitPgSchemasWhenTempSchemaExists: []string{`foobar`},
+		},
+		{
+			explicitSearchPath:                                             []string{`foobar`, `foobar`},
 			expectedSearchPath:                                             []string{`pg_catalog`, `foobar`},
 			expectedSearchPathWithoutImplicitPgSchemas:                     []string{`foobar`},
 			expectedSearchPathWhenTemporarySchemaExists:                    []string{testTempSchemaName, `pg_catalog`, `foobar`},
@@ -87,7 +157,28 @@ func TestImpliedSearchPath(t *testing.T) {
 			expectedSearchPathWithoutImplicitPgSchemasWhenTempSchemaExists: []string{`public`},
 		},
 		{
+			explicitSearchPath:                                             []string{`public`, `public`},
+			expectedSearchPath:                                             []string{`pg_catalog`, `pg_extension`, `public`},
+			expectedSearchPathWithoutImplicitPgSchemas:                     []string{`public`},
+			expectedSearchPathWhenTemporarySchemaExists:                    []string{testTempSchemaName, `pg_catalog`, `pg_extension`, `public`},
+			expectedSearchPathWithoutImplicitPgSchemasWhenTempSchemaExists: []string{`public`},
+		},
+		{
 			explicitSearchPath:                                             []string{`public`, `pg_extension`},
+			expectedSearchPath:                                             []string{`pg_catalog`, `public`, `pg_extension`},
+			expectedSearchPathWithoutImplicitPgSchemas:                     []string{`public`, `pg_extension`},
+			expectedSearchPathWhenTemporarySchemaExists:                    []string{testTempSchemaName, `pg_catalog`, `public`, `pg_extension`},
+			expectedSearchPathWithoutImplicitPgSchemasWhenTempSchemaExists: []string{`public`, `pg_extension`},
+		},
+		{
+			explicitSearchPath:                                             []string{`public`, `public`, `pg_extension`},
+			expectedSearchPath:                                             []string{`pg_catalog`, `public`, `pg_extension`},
+			expectedSearchPathWithoutImplicitPgSchemas:                     []string{`public`, `pg_extension`},
+			expectedSearchPathWhenTemporarySchemaExists:                    []string{testTempSchemaName, `pg_catalog`, `public`, `pg_extension`},
+			expectedSearchPathWithoutImplicitPgSchemasWhenTempSchemaExists: []string{`public`, `pg_extension`},
+		},
+		{
+			explicitSearchPath:                                             []string{`public`, `pg_extension`, `pg_extension`},
 			expectedSearchPath:                                             []string{`pg_catalog`, `public`, `pg_extension`},
 			expectedSearchPathWithoutImplicitPgSchemas:                     []string{`public`, `pg_extension`},
 			expectedSearchPathWhenTemporarySchemaExists:                    []string{testTempSchemaName, `pg_catalog`, `public`, `pg_extension`},
@@ -102,6 +193,18 @@ func TestImpliedSearchPath(t *testing.T) {
 			iter := searchPath.Iter()
 			for p, ok := iter.Next(); ok; p, ok = iter.Next() {
 				actualSearchPath = append(actualSearchPath, p)
+			}
+			if !reflect.DeepEqual(tc.expectedSearchPath, actualSearchPath) {
+				t.Errorf(
+					`#%d: Expected search path to be %#v, but was %#v.`,
+					tcNum,
+					tc.expectedSearchPath,
+					actualSearchPath,
+				)
+			}
+			actualSearchPath = make([]string, 0)
+			for i, n := 0, searchPath.NumElements(); i < n; i++ {
+				actualSearchPath = append(actualSearchPath, searchPath.GetSchema(i))
 			}
 			if !reflect.DeepEqual(tc.expectedSearchPath, actualSearchPath) {
 				t.Errorf(


### PR DESCRIPTION
Backport 1/1 commits from #97634.

/cc @cockroachdb/release

---

Fixes: #97130
Previously, if there are duplicate schemas in current searcth path function resolution would fail due to ambiguity because a UDF was seen twice. This commit adds logic to dedupe on the search path schema.

Release note: None.
Release justification: low risk and necessary bug fix.
