### PR TITLE
kvserver: avoid reusing proposal in tryReproposeWithNewLeaseIndex

### DIFF
--- a/pkg/kv/kvserver/BUILD.bazel
+++ b/pkg/kv/kvserver/BUILD.bazel
@@ -297,6 +297,7 @@ go_test(
         "range_log_test.go",
         "rebalance_objective_test.go",
         "replica_application_cmd_buf_test.go",
+        "replica_application_result_test.go",
         "replica_application_state_machine_test.go",
         "replica_batch_updates_test.go",
         "replica_circuit_breaker_test.go",

--- a/pkg/kv/kvserver/replica_application_cmd.go
+++ b/pkg/kv/kvserver/replica_application_cmd.go
@@ -52,6 +52,9 @@ type replicatedCmd struct {
 	// finishTracingSpan. This span "follows from" the proposer's span (even
 	// when the proposer is remote; we marshall tracing info through the
 	// proposal).
+	//
+	// For local commands, we also have a `ProposalData` which may have a span
+	// as well, and if it does, this span will follow from it.
 	sp *tracing.Span
 
 	// splitMergeUnlock is acquired for splits and merges when they are staged

--- a/pkg/kv/kvserver/replica_application_result.go
+++ b/pkg/kv/kvserver/replica_application_result.go
@@ -287,7 +287,12 @@ func (r *Replica) tryReproposeWithNewLeaseIndex(
 		// succeeding in the Raft log for a given command.
 		return nil
 	}
+	return r.tryReproposeWithNewLeaseIndexShared(ctx, cmd.proposal)
+}
 
+func (r *Replica) tryReproposeWithNewLeaseIndexShared(
+	ctx context.Context, p *ProposalData,
+) *kvpb.Error {
 	// We need to track the request again in order to protect its timestamp until
 	// it gets reproposed.
 	// TODO(andrei): Only track if the request consults the ts cache. Some
@@ -319,7 +324,7 @@ func (r *Replica) tryReproposeWithNewLeaseIndex(
 	if pErr != nil {
 		return pErr
 	}
-	log.VEventf(ctx, 2, "reproposed command %x", cmd.ID)
+	log.VEventf(ctx, 2, "reproposed command %x", p.idKey)
 	return nil
 }
 

--- a/pkg/kv/kvserver/replica_application_result.go
+++ b/pkg/kv/kvserver/replica_application_result.go
@@ -19,12 +19,22 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/readsummary/rspb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
+	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
 	"github.com/cockroachdb/errors"
 	"go.etcd.io/raft/v3"
 )
+
+// useReproposalsV2 activates prototype code that instead of reproposing using a
+// modified lease index makes a new proposal (different CmdID), transfers the
+// waiting caller (if any) to it, and proposes that. With this strategy, the
+// *RaftCommand associated to a proposal becomes immutable, which simplifies the
+// mental model and allows various simplifications in the proposal pipeline. For
+// now, the old and new behavior coexist, and we want to keep exercising both.
+// Once we have confidence, we'll hard-code true and remove all old code paths.
+var useReproposalsV2 = util.ConstantWithMetamorphicTestBool("reproposals-v2", true)
 
 // replica_application_*.go files provide concrete implementations of
 // the interfaces defined in the storage/apply package:

--- a/pkg/kv/kvserver/replica_application_result_test.go
+++ b/pkg/kv/kvserver/replica_application_result_test.go
@@ -1,0 +1,80 @@
+// Copyright 2023 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package kvserver
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/batcheval/result"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvflowcontrol/kvflowcontrolpb"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverpb"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/quotapool"
+	"github.com/cockroachdb/cockroach/pkg/util/tracing"
+	"github.com/stretchr/testify/require"
+)
+
+func TestProposalDataAndRaftCommandAreConsideredWhenAddingFields(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	raftCommand := &kvserverpb.RaftCommand{
+		ProposerLeaseSequence:   1,
+		DeprecatedProposerLease: &roachpb.Lease{},
+		MaxLeaseIndex:           1,
+		ClosedTimestamp:         &hlc.Timestamp{},
+		ReplicatedEvalResult:    kvserverpb.ReplicatedEvalResult{IsProbe: true},
+		WriteBatch:              &kvserverpb.WriteBatch{},
+		LogicalOpLog:            &kvserverpb.LogicalOpLog{},
+		TraceData:               map[string]string{},
+		AdmissionPriority:       1,
+		AdmissionCreateTime:     1,
+		AdmissionOriginNode:     1,
+	}
+
+	prop := &ProposalData{
+		ctx:                     context.Background(),
+		sp:                      &tracing.Span{},
+		idKey:                   "deadbeef",
+		proposedAtTicks:         1,
+		createdAtTicks:          2,
+		command:                 raftCommand,
+		encodedCommand:          []byte("x"),
+		quotaAlloc:              &quotapool.IntAlloc{},
+		ec:                      endCmds{repl: &Replica{}},
+		applied:                 true,
+		doneCh:                  make(chan proposalResult),
+		Local:                   &result.LocalResult{},
+		Request:                 &kvpb.BatchRequest{},
+		leaseStatus:             kvserverpb.LeaseStatus{Lease: roachpb.Lease{Sequence: 1}},
+		tok:                     TrackedRequestToken{done: true},
+		raftAdmissionMeta:       &kvflowcontrolpb.RaftAdmissionMeta{},
+		v2SeenDuringApplication: true,
+	}
+
+	// If you are adding a field to ProposalData or RaftCommand, please consider the
+	// desired semantics of that field in `tryReproposeWithNewLeaseIndex{,v2}`. Once
+	// this has been done, adjust the expected number of fields below, and populate
+	// the field above, to let this test pass.
+	// test pass.
+	//
+	// NB: we can't use zerofields for two reasons: First, we have unexported fields
+	// here, and second, we don't want to check for recursively populated structs (but
+	// only for the top level fields).
+	require.Equal(t, 11, reflect.TypeOf(*raftCommand).NumField())
+	require.Equal(t, 17, reflect.TypeOf(*prop).NumField())
+}

--- a/pkg/kv/kvserver/replica_proposal.go
+++ b/pkg/kv/kvserver/replica_proposal.go
@@ -256,6 +256,12 @@ func (proposal *ProposalData) finishApplication(ctx context.Context, pr proposal
 //
 // The method is safe to call more than once, but only the first result will be
 // returned to the client.
+//
+// TODO(tbg): a stricter invariant should hold: if a proposal is signaled
+// multiple times, at most one of them is not an AmbiguousResultError. In
+// other words, we get at most one result from log application, all other
+// results are from mechanisms that unblock the client despite not knowing
+// the outcome of the proposal.
 func (proposal *ProposalData) signalProposalResult(pr proposalResult) {
 	if proposal.doneCh != nil {
 		proposal.doneCh <- pr

--- a/pkg/kv/kvserver/replica_proposal.go
+++ b/pkg/kv/kvserver/replica_proposal.go
@@ -143,11 +143,6 @@ type ProposalData struct {
 	sp *tracing.Span
 
 	// idKey uniquely identifies this proposal.
-	// TODO(andrei): idKey is legacy at this point: We could easily key commands
-	// by their MaxLeaseIndex, and doing so should be ok with a stop- the-world
-	// migration. However, various test facilities depend on the command ID for
-	// e.g. replay protection. Later edit: the MaxLeaseIndex assignment has,
-	// however, moved to happen later, at proposal time.
 	idKey kvserverbase.CmdIDKey
 
 	// proposedAtTicks is the (logical) time at which this command was

--- a/pkg/kv/kvserver/replica_proposal.go
+++ b/pkg/kv/kvserver/replica_proposal.go
@@ -115,6 +115,12 @@ type ProposalData struct {
 	// sends, but not command application. In order to enable safely tracing events
 	// beneath, modifying this ctx field in *ProposalData requires holding the
 	// raftMu.
+	//
+	// TODO(tbg): under useReproposalsV2, the field can be modified safely as long
+	// as the ProposalData is still in `r.mu.proposals` and `r.mu` is held. If it's
+	// not in that map, we are log application and have exclusive access. Add a more
+	// general comment that explains what can be accessed where (I think I wrote one
+	// somewhere but it should live on ProposalData).
 	ctx context.Context
 
 	// An optional tracing span bound to the proposal. Will be cleaned
@@ -139,6 +145,9 @@ type ProposalData struct {
 
 	// command is serialized and proposed to raft. In the event of
 	// reproposals its MaxLeaseIndex field is mutated.
+	//
+	// TODO(tbg): when useReproposalsV2==true is baked in, the above comment
+	// is stale - MLI never gets mutated.
 	command *kvserverpb.RaftCommand
 
 	// encodedCommand is the encoded Raft command, with an optional prefix

--- a/pkg/kv/kvserver/replica_proposal.go
+++ b/pkg/kv/kvserver/replica_proposal.go
@@ -214,6 +214,29 @@ type ProposalData struct {
 	// raftAdmissionMeta captures the metadata we encode as part of the command
 	// when first proposed for replication admission control.
 	raftAdmissionMeta *kvflowcontrolpb.RaftAdmissionMeta
+
+	// v2SeenDuringApplication is set to true right at the very beginning of
+	// processing this proposal for application (regardless of what the outcome of
+	// application is). Under useReproposalsV2, a local proposal is bound to an
+	// entry only once and the proposals map entry removed. This flag makes sure
+	// that the proposal buffer won't accidentally reinsert the proposal into the
+	// map. In doing so, this field also addresses locking concerns. As long as
+	// the ProposalData is in the `proposals` map, replicaMu must be held. But
+	// command application unlinks the command from the map and wants to be able
+	// to access it without acquiring replicaMu. The only other actor that can
+	// access the proposal while it is being applied is the proposal buffer (which
+	// always holds replicaMu); since v2SeenDuringApplication is flipped while
+	// under the lock (which log application holds at that point in time) and is
+	// never mutated afterwards, the proposal buffer is allowed to access that
+	// particular field and use it to avoid touching the ProposalData. A similar
+	// strategy is not possible under !useReproposalsV2 because by "design",
+	// proposals may repeatedly leave and re-enter the map and ultimately still
+	// apply successfully.
+	//
+	// See: https://github.com/cockroachdb/cockroach/issues/97605
+	//
+	// Never set unless useReproposalsV2 is active.
+	v2SeenDuringApplication bool
 }
 
 // useReplicationAdmissionControl indicates whether this raft command should

--- a/pkg/kv/kvserver/replica_proposal.go
+++ b/pkg/kv/kvserver/replica_proposal.go
@@ -116,6 +116,19 @@ type ProposalData struct {
 	// beneath, modifying this ctx field in *ProposalData requires holding the
 	// raftMu.
 	//
+	// This is either the caller's context (if they are waiting for the result)
+	// or a "background" context, perhaps with a span in it (for async consensus
+	// or in case the caller has given up).
+	//
+	// Note that there is also replicatedCmd.{ctx,sp} and so confusion may arise
+	// about which one to log to. Generally if p.ctx has a span, replicatedCmd.ctx
+	// has a span that follows from it. However, if p.ctx has no span or the
+	// replicatedCmd is not associated to a local ProposalData, replicatedCmd.ctx
+	// may still have a span, if the remote proposer requested tracing. It follows
+	// that during command application one should always use `replicatedCmd.ctx`
+	// for best coverage. `p.ctx` should be used when a `replicatedCmd` is not in
+	// scope, i.e. outside of raft command application.
+	//
 	// TODO(tbg): under useReproposalsV2, the field can be modified safely as long
 	// as the ProposalData is still in `r.mu.proposals` and `r.mu` is held. If it's
 	// not in that map, we are log application and have exclusive access. Add a more
@@ -123,8 +136,10 @@ type ProposalData struct {
 	// somewhere but it should live on ProposalData).
 	ctx context.Context
 
-	// An optional tracing span bound to the proposal. Will be cleaned
-	// up when the proposal finishes.
+	// An optional tracing span bound to the proposal in the case of async
+	// consensus (it will be referenced by p.ctx). We need to finish this span
+	// after applying this proposal, since we created it. It is not used for
+	// anything else (all tracing goes through `p.ctx`).
 	sp *tracing.Span
 
 	// idKey uniquely identifies this proposal.

--- a/pkg/kv/kvserver/replica_proposal_buf.go
+++ b/pkg/kv/kvserver/replica_proposal_buf.go
@@ -261,6 +261,16 @@ func (b *propBuf) Insert(ctx context.Context, p *ProposalData, tok TrackedReques
 	b.p.rlocker().Lock()
 	defer b.p.rlocker().Unlock()
 
+	if p.v2SeenDuringApplication {
+		if useReproposalsV2 {
+			// We should never see a proposal that has already been on the apply loop
+			// passed to `Insert`. The only place where such proposals can be seen is
+			// `ReinsertLocked`.
+			return errors.AssertionFailedf("proposal that was already applied passed to propBuf.Insert: %+v", p)
+		}
+		return nil
+	}
+
 	if filter := b.testing.insertFilter; filter != nil {
 		if err := filter(p); err != nil {
 			return err
@@ -289,6 +299,9 @@ func (b *propBuf) Insert(ctx context.Context, p *ProposalData, tok TrackedReques
 // buffer back into the buffer to be reproposed at a new Raft log index. Unlike
 // Insert, it does not modify the command.
 func (b *propBuf) ReinsertLocked(ctx context.Context, p *ProposalData) error {
+	if p.v2SeenDuringApplication {
+		return nil
+	}
 	// Update the proposal buffer counter and determine which index we should
 	// insert at.
 	idx, err := b.allocateIndex(ctx, true /* wLocked */)

--- a/pkg/kv/kvserver/replica_proposal_buf.go
+++ b/pkg/kv/kvserver/replica_proposal_buf.go
@@ -587,6 +587,12 @@ func (b *propBuf) FlushLockedWithRaftGroup(
 
 			// We don't want deduct flow tokens for reproposed commands, and of
 			// course for proposals that didn't integrate with kvflowcontrol.
+			//
+			// TODO(tbg): with useReproposalsV2, we make new proposals in
+			// tryReproposeWithNewLeaseIndex that will have createdAtTicks ==
+			// proposedAtTicks. They will have !reproposal but raftAdmissionMeta=nil.
+			// What is createdAtTicks==proposedAtTicks even good for? The !reproposal
+			// condition already handles the case in which it isn't.
 			shouldAdmit := p.createdAtTicks == p.proposedAtTicks && !reproposal && p.raftAdmissionMeta != nil
 			if !shouldAdmit {
 				admitHandles = append(admitHandles, admitEntHandle{})

--- a/pkg/kv/kvserver/replica_raft.go
+++ b/pkg/kv/kvserver/replica_raft.go
@@ -363,15 +363,30 @@ func (r *Replica) propose(
 	// package is that proposals which are finished carry a raft command with a
 	// MaxLeaseIndex equal to the proposal command's max lease index.
 	defer func(prev kvpb.LeaseAppliedIndex) {
+		if useReproposalsV2 {
+			// The following poorly understood code is not necessary in V2 since
+			// we never mutate MaxLeaseIndex and don't hit propose() twice for
+			// the same *ProposalData.
+			return
+		}
 		if pErr != nil {
 			p.command.MaxLeaseIndex = prev
 		}
 	}(p.command.MaxLeaseIndex)
 
-	// Make sure the maximum lease index is unset. This field will be set in
-	// propBuf.Insert and its encoded bytes will be appended to the encoding
-	// buffer as a MaxLeaseFooter.
-	p.command.MaxLeaseIndex = 0
+	if !useReproposalsV2 {
+		// Make sure the maximum lease index is unset. This field will be set in
+		// propBuf.Insert and its encoded bytes will be appended to the encoding
+		// buffer as a MaxLeaseFooter.
+		p.command.MaxLeaseIndex = 0
+	} else {
+		if p.command.MaxLeaseIndex > 0 {
+			// TODO: there are a number of other fields that should still be unset.
+			// Verify them all. Some architectural improvements where we pass in a
+			// subset of ProposalData and then complete it here would be even better.
+			return kvpb.NewError(errors.AssertionFailedf("MaxLeaseIndex is set: %+v", p))
+		}
+	}
 
 	if crt := p.command.ReplicatedEvalResult.ChangeReplicas; crt != nil {
 		if err := checkReplicationChangeAllowed(p.command, r.Desc(), r.StoreID()); err != nil {

--- a/pkg/kv/kvserver/replica_test.go
+++ b/pkg/kv/kvserver/replica_test.go
@@ -8129,6 +8129,10 @@ func TestReplicaRefreshMultiple(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
+	if useReproposalsV2 {
+		skip.IgnoreLintf(t, "TODO(tbg)")
+	}
+
 	ctx := context.Background()
 
 	const incCmdID = "deadbeef"
@@ -8269,6 +8273,10 @@ func TestReplicaRefreshMultiple(t *testing.T) {
 func TestReplicaReproposalWithNewLeaseIndexError(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
+
+	if useReproposalsV2 {
+		skip.IgnoreLint(t, "TODO(tbg)")
+	}
 
 	ctx := context.Background()
 	var tc testContext


### PR DESCRIPTION
The previous reproposal mechanism is quite complex. We can side-step a
good amount of the complexity by not re-using proposals. Instead, when
the entry associated to a local proposal gets rejected by the
`LeaseAppliedIndex`, we mint a "new" proposal (identical to the old but
with a new command ID) which is now responsible for notifying the
caller.

This is introduced piecemeal, and the "old way" is preserved for continued
metamorphic testing (and a guaranteed way to be able to fall back, should
we see fallout over the next couple of weeks).

Phasing out the gating var `useReproposalsV2` is tracked separately[^1].

[^1]: https://github.com/cockroachdb/cockroach/issues/105625

Epic: CRDB-25287
Release note: None
