### PR TITLE
roachprod: fix ssh-keyscan with multiple providers

### DIFF
--- a/pkg/roachprod/install/BUILD.bazel
+++ b/pkg/roachprod/install/BUILD.bazel
@@ -39,6 +39,7 @@ go_library(
         "//pkg/util/timeutil",
         "@com_github_alessio_shellescape//:shellescape",
         "@com_github_cockroachdb_errors//:errors",
+        "@org_golang_x_exp//maps",
         "@org_golang_x_sync//errgroup",
     ],
 )

--- a/pkg/roachprod/install/cluster_synced.go
+++ b/pkg/roachprod/install/cluster_synced.go
@@ -43,6 +43,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/errors"
+	"golang.org/x/exp/maps"
 	"golang.org/x/sync/errgroup"
 )
 
@@ -994,42 +995,67 @@ tar cf - .ssh/id_rsa .ssh/id_rsa.pub .ssh/authorized_keys
 	}
 
 	// Populate the known_hosts file with both internal and external IPs of all
-	// of the nodes in the cluster. Note that as a side effect, this creates the
-	// known hosts file in unhashed format, working around a limitation of jsch
-	// (which is used in jepsen tests).
-	ips := make([]string, len(c.Nodes), len(c.Nodes)*2)
+	// nodes in the cluster. Internal IPs are populated within its provider peers
+	// only, and external IPs are populated for all providers. Note that as a side
+	// effect, this creates the known hosts file in unhashed format, working
+	// around a limitation of jsch (which is used in jepsen tests).
+
+	mu := syncutil.Mutex{}
+	type nodeInfo struct {
+		node Node
+		ip   string
+	}
+	providerPrivateIPs := make(map[string][]nodeInfo)
+	// Build a list of internal IPs for each provider.
 	if err := c.Parallel(l, "retrieving hosts", len(c.Nodes), 0, func(i int) (*RunResultDetails, error) {
 		node := c.Nodes[i]
+		provider := c.VMs[node-1].Provider
 		res := &RunResultDetails{Node: node}
-		for j := 0; j < 20 && ips[i] == ""; j++ {
+		ip := ""
+		for j := 0; j < 20 && ip == ""; j++ {
 			var err error
-			ips[i], err = c.GetInternalIP(l, ctx, node)
+			ip, err = c.GetInternalIP(l, ctx, node)
 			if err != nil {
 				res.Err = errors.Wrapf(err, "pgurls")
 				return res, res.Err
 			}
 			time.Sleep(time.Second)
 		}
-		if ips[i] == "" {
+		if ip == "" {
 			res.Err = fmt.Errorf("retrieved empty IP address")
 			return res, res.Err
 		}
+		mu.Lock()
+		providerPrivateIPs[provider] = append(providerPrivateIPs[provider], nodeInfo{node: node, ip: ip})
+		mu.Unlock()
 		return res, nil
 	}, DefaultSSHRetryOpts); err != nil {
 		return err
 	}
 
+	// Get public IPs for all nodes.
+	publicIPs := make([]string, 0, len(c.Nodes))
 	for _, i := range c.Nodes {
-		ips = append(ips, c.Host(i))
+		publicIPs = append(publicIPs, c.Host(i))
 	}
-	var knownHostsData []byte
-	if err := c.Parallel(l, "scanning hosts", 1, 0, func(i int) (*RunResultDetails, error) {
-		node := c.Nodes[i]
+
+	providerKnownHostData := make(map[string][]byte)
+	providers := maps.Keys(providerPrivateIPs)
+	// Only need to scan on the first node of each provider.
+	if err := c.Parallel(l, "scanning hosts", len(providers), 0, func(i int) (*RunResultDetails, error) {
+		provider := providers[i]
+		node := providerPrivateIPs[provider][0].node
+		// Scan a combination of all remote IPs and local IPs pertaining to this
+		// node's cloud provider.
+		scanIPs := append([]string{}, publicIPs...)
+		for _, nodeInfo := range providerPrivateIPs[provider] {
+			scanIPs = append(scanIPs, nodeInfo.ip)
+		}
 
 		// ssh-keyscan may return fewer than the desired number of entries if the
 		// remote nodes are not responding yet, so we loop until we have a scan that
-		// found host keys for all of the IPs. Merge the newly scanned keys with the
-		// existing list to make this process idempotent.
+		// found host keys for all the public IPs. Merge the newly scanned keys
+		// with the existing list to make this process idempotent.
 		cmd := `
 set -e
 tmp="$(tempfile -d ~/.ssh -p 'roachprod' )"
@@ -1038,8 +1064,8 @@ on_exit() {
 }
 trap on_exit EXIT
 for i in {1..20}; do
-  ssh-keyscan -T 60 -t rsa ` + strings.Join(ips, " ") + ` > "${tmp}"
-  if [[ "$(wc < ${tmp} -l)" -eq "` + fmt.Sprint(len(ips)) + `" ]]; then
+  ssh-keyscan -T 60 -t rsa ` + strings.Join(scanIPs, " ") + ` > "${tmp}"
+  if [[ "$(wc < ${tmp} -l)" -eq "` + fmt.Sprint(len(scanIPs)) + `" ]]; then
     [[ -f .ssh/known_hosts ]] && cat .ssh/known_hosts >> "${tmp}"
     sort -u < "${tmp}"
     exit 0
@@ -1064,7 +1090,9 @@ exit 1
 		if res.Err != nil {
 			return res, errors.Wrapf(res.Err, "%s: stderr:\n%s", cmd, res.Stderr)
 		}
-		knownHostsData = stdout.Bytes()
+		mu.Lock()
+		providerKnownHostData[provider] = stdout.Bytes()
+		mu.Unlock()
 		return res, nil
 	}, DefaultSSHRetryOpts); err != nil {
 		return err
@@ -1072,6 +1100,7 @@ exit 1
 
 	if err := c.Parallel(l, "distributing known_hosts", len(c.Nodes), 0, func(i int) (*RunResultDetails, error) {
 		node := c.Nodes[i]
+		provider := c.VMs[node-1].Provider
 		const cmd = `
 known_hosts_data="$(cat)"
 set -e
@@ -1103,7 +1132,7 @@ fi
 		sess := c.newSession(l, node, cmd, withDebugName("ssh-dist-known-hosts"))
 		defer sess.Close()
 
-		sess.SetStdin(bytes.NewReader(knownHostsData))
+		sess.SetStdin(bytes.NewReader(providerKnownHostData[provider]))
 		out, cmdErr := sess.CombinedOutput(ctx)
 		res := newRunResultDetails(node, cmdErr)
 		res.CombinedOut = out


### PR DESCRIPTION
When multiple providers are passed during cluster creation (e.g., `--clouds="gce,aws"`) there is a step where the `known_hosts` get populated. This step requires a `ssh-keyscan`.

This PR patches the scan query to use the correct IPs. The previous implementation included all IPs from all nodes, internal and external, which resulted in trying to scan for internal IPs for all providers on one provider.

To amend this a list of internal IPs for each provider is gathered. The remote IPs for all nodes are appended. The final list is then used to complete a `ssh-keyscan` per provider, by selecting the first node for each provider.

Fixes: #97702
Epic: CRDB-10428