### PR TITLE
sql: return droppedView instead of nil

### DIFF
--- a/pkg/sql/drop_index.go
+++ b/pkg/sql/drop_index.go
@@ -555,5 +555,5 @@ func (p *planner) removeDependents(
 			}
 		}
 	}
-	return nil, nil
+	return droppedViews, nil
 }

--- a/pkg/sql/logictest/testdata/logic_test/event_log_legacy
+++ b/pkg/sql/logictest/testdata/logic_test/event_log_legacy
@@ -1,6 +1,6 @@
-# Legacy schema changer is also skipped because mutation IDs throughout log
-# entries will differ. "event_log_legacy" file is for the legacy schema changer.
-# LogicTest: !local-legacy-schema-changer
+# Only legacy schema changer is run because mutation IDs throughout log entries
+# will differ. "event_log" test file is for normal settings.
+# LogicTest: local-legacy-schema-changer
 # knob-opt: sync-event-log
 
 # For some reason, some of the queries produce non-deterministic results if
@@ -120,7 +120,7 @@ query IT
 SELECT "reportingID", info::JSONB - 'Timestamp' - 'DescriptorID' FROM system.eventlog
 WHERE "eventType" = 'finish_schema_change'
 ----
-1  {"EventType": "finish_schema_change", "InstanceID": 1}
+1  {"EventType": "finish_schema_change", "InstanceID": 1, "MutationID": 1}
 
 query I
 SELECT "reportingID" FROM system.eventlog
@@ -153,27 +153,27 @@ WHERE "eventType" = 'alter_table'
 ORDER BY "timestamp", info
 ----
 1  {"EventType": "alter_table", "MutationID": 1, "Statement": "ALTER TABLE test.public.a ADD COLUMN val INT8", "TableName": "test.public.a", "Tag": "ALTER TABLE", "User": "root"}
-1  {"EventType": "alter_table", "MutationID": 1, "Statement": "ALTER TABLE test.public.a ADD CONSTRAINT foo UNIQUE (val)", "TableName": "test.public.a", "Tag": "ALTER TABLE", "User": "root"}
+1  {"EventType": "alter_table", "MutationID": 2, "Statement": "ALTER TABLE test.public.a ADD CONSTRAINT foo UNIQUE (val)", "TableName": "test.public.a", "Tag": "ALTER TABLE", "User": "root"}
 
 query IT
 SELECT "reportingID", info::JSONB - 'Timestamp' - 'DescriptorID'  FROM system.eventlog
 WHERE "eventType" = 'finish_schema_change'
 ----
-1  {"EventType": "finish_schema_change", "InstanceID": 1}
+1  {"EventType": "finish_schema_change", "InstanceID": 1, "MutationID": 1}
 
 query IT
 SELECT "reportingID", info::JSONB - 'Timestamp' - 'DescriptorID' - 'Error'
   FROM system.eventlog
 WHERE "eventType" = 'reverse_schema_change'
 ----
-1  {"EventType": "reverse_schema_change", "InstanceID": 1, "MutationID": 1, "SQLSTATE": "23505"}
+1  {"EventType": "reverse_schema_change", "InstanceID": 1, "MutationID": 2, "SQLSTATE": "23505"}
 
 
 query IT
 SELECT "reportingID", info::JSONB - 'Timestamp' - 'DescriptorID' FROM system.eventlog
 WHERE "eventType" = 'finish_schema_change_rollback'
 ----
-1  {"EventType": "finish_schema_change_rollback", "InstanceID": 1, "MutationID": 1}
+1  {"EventType": "finish_schema_change_rollback", "InstanceID": 1, "MutationID": 2}
 
 # Create an Index on the table
 #################
@@ -186,15 +186,15 @@ SELECT "reportingID", info::JSONB - 'Timestamp' - 'DescriptorID' FROM system.eve
 WHERE "eventType" = 'create_index'
   AND info::JSONB->>'Statement' LIKE 'CREATE INDEX %a_foo%'
 ----
-1  {"EventType": "create_index", "IndexName": "a_foo", "MutationID": 1, "Statement": "CREATE INDEX a_foo ON test.public.a (val)", "TableName": "test.public.a", "Tag": "CREATE INDEX", "User": "root"}
+1  {"EventType": "create_index", "IndexName": "a_foo", "MutationID": 3, "Statement": "CREATE INDEX a_foo ON test.public.a (val)", "TableName": "test.public.a", "Tag": "CREATE INDEX", "User": "root"}
 
 query IT
 SELECT "reportingID", info::JSONB - 'Timestamp' - 'DescriptorID' FROM system.eventlog
 WHERE "eventType" = 'finish_schema_change'
 ORDER BY "timestamp", info
 ----
-1  {"EventType": "finish_schema_change", "InstanceID": 1}
-1  {"EventType": "finish_schema_change", "InstanceID": 1}
+1  {"EventType": "finish_schema_change", "InstanceID": 1, "MutationID": 1}
+1  {"EventType": "finish_schema_change", "InstanceID": 1, "MutationID": 3}
 
 statement ok
 CREATE INDEX ON a (val)
@@ -204,16 +204,16 @@ SELECT "reportingID", info::JSONB - 'Timestamp' - 'DescriptorID' FROM system.eve
 WHERE "eventType" = 'create_index'
   AND info::JSONB->>'Statement' LIKE 'CREATE INDEX ON%'
 ----
-1  {"EventType": "create_index", "IndexName": "a_val_idx", "MutationID": 1, "Statement": "CREATE INDEX ON test.public.a (val)", "TableName": "test.public.a", "Tag": "CREATE INDEX", "User": "root"}
+1  {"EventType": "create_index", "IndexName": "a_val_idx", "MutationID": 4, "Statement": "CREATE INDEX ON test.public.a (val)", "TableName": "test.public.a", "Tag": "CREATE INDEX", "User": "root"}
 
 query IT
 SELECT "reportingID", info::JSONB - 'Timestamp' - 'DescriptorID' FROM system.eventlog
 WHERE "eventType" = 'finish_schema_change'
 ORDER BY "timestamp", info
 ----
-1  {"EventType": "finish_schema_change", "InstanceID": 1}
-1  {"EventType": "finish_schema_change", "InstanceID": 1}
-1  {"EventType": "finish_schema_change", "InstanceID": 1}
+1  {"EventType": "finish_schema_change", "InstanceID": 1, "MutationID": 1}
+1  {"EventType": "finish_schema_change", "InstanceID": 1, "MutationID": 3}
+1  {"EventType": "finish_schema_change", "InstanceID": 1, "MutationID": 4}
 
 
 # Drop the index
@@ -226,17 +226,17 @@ SELECT "reportingID", info::JSONB - 'Timestamp' - 'DescriptorID' FROM system.eve
 WHERE "eventType" = 'drop_index'
   AND info::JSONB->>'Statement' LIKE 'DROP INDEX%a_foo'
 ----
-1  {"EventType": "drop_index", "IndexName": "a_foo", "MutationID": 1, "Statement": "DROP INDEX test.public.a@a_foo", "TableName": "test.public.a", "Tag": "DROP INDEX", "User": "root"}
+1  {"EventType": "drop_index", "IndexName": "a_foo", "MutationID": 5, "Statement": "DROP INDEX test.public.a@a_foo", "TableName": "test.public.a", "Tag": "DROP INDEX", "User": "root"}
 
 query IT
 SELECT "reportingID", info::JSONB - 'Timestamp' - 'DescriptorID' FROM system.eventlog
 WHERE "eventType" = 'finish_schema_change'
 ORDER BY "timestamp", info
 ----
-1  {"EventType": "finish_schema_change", "InstanceID": 1}
-1  {"EventType": "finish_schema_change", "InstanceID": 1}
-1  {"EventType": "finish_schema_change", "InstanceID": 1}
-1  {"EventType": "finish_schema_change", "InstanceID": 1}
+1  {"EventType": "finish_schema_change", "InstanceID": 1, "MutationID": 1}
+1  {"EventType": "finish_schema_change", "InstanceID": 1, "MutationID": 3}
+1  {"EventType": "finish_schema_change", "InstanceID": 1, "MutationID": 4}
+1  {"EventType": "finish_schema_change", "InstanceID": 1, "MutationID": 5}
 
 # Truncate a table
 ##################
@@ -960,6 +960,7 @@ SELECT "reportingID", "eventType", info::JSONB - 'Timestamp' - 'DescriptorID'
 ORDER BY "timestamp", info
 ----
 1  drop_type  {"EventType": "drop_type", "Statement": "DROP TYPE defaultdb.public.eventlog_renamed", "Tag": "DROP TYPE", "TypeName": "defaultdb.public.eventlog_renamed", "User": "root"}
+1  drop_type  {"EventType": "drop_type", "Statement": "DROP TYPE defaultdb.public.eventlog_renamed", "Tag": "DROP TYPE", "TypeName": "defaultdb.public._eventlog_renamed", "User": "root"}
 
 # Test the event logs generated by COMMENT ON ... commands.
 subtest eventlog_comments

--- a/pkg/sql/logictest/tests/local-legacy-schema-changer/generated_test.go
+++ b/pkg/sql/logictest/tests/local-legacy-schema-changer/generated_test.go
@@ -702,6 +702,13 @@ func TestLogic_errors(
 	runLogicTest(t, "errors")
 }
 
+func TestLogic_event_log_legacy(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "event_log_legacy")
+}
+
 func TestLogic_exclude_data_from_backup(
 	t *testing.T,
 ) {


### PR DESCRIPTION
In #97631 we refactor the method to drorp index and column cascade dependents. But we didn't return a correct droppedViews for event logging, instead, we returned a nil. This wasn't caught by the `event_log` logic test because we `local-legacy-schema-changer` test config. Though this was caught when backporting to v22.2 because there was a fallback.

Epic: None

Release note: None