### PR TITLE
settings: add COCKROACH_IGNORE_CLUSTER_SETTINGS env var

### DIFF
--- a/pkg/settings/BUILD.bazel
+++ b/pkg/settings/BUILD.bazel
@@ -29,6 +29,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/util/buildutil",
+        "//pkg/util/envutil",
         "//pkg/util/humanizeutil",
         "//pkg/util/protoutil",
         "//pkg/util/syncutil",
@@ -45,6 +46,7 @@ go_test(
     size = "small",
     srcs = [
         "encoding_test.go",
+        "internal_test.go",
         "settings_test.go",
     ],
     args = ["-test.timeout=55s"],

--- a/pkg/settings/internal_test.go
+++ b/pkg/settings/internal_test.go
@@ -1,0 +1,37 @@
+// Copyright 2023 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package settings
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+var b = RegisterBoolSetting(SystemOnly, "b", "desc", true)
+
+func TesIgnoreDefaults(t *testing.T) {
+	ctx := context.Background()
+	sv := &Values{}
+	sv.Init(ctx, TestOpaque)
+
+	ignoreAllUpdates = true
+	defer func() { ignoreAllUpdates = false }()
+	u := NewUpdater(sv)
+	require.NoError(t, u.Set(ctx, b.Key(), EncodedValue{Value: EncodeBool(false), Type: "b"}))
+	require.Equal(t, true, b.Get(sv))
+
+	ignoreAllUpdates = false
+	u = NewUpdater(sv)
+	require.NoError(t, u.Set(ctx, b.Key(), EncodedValue{Value: EncodeBool(false), Type: "b"}))
+	require.Equal(t, false, b.Get(sv))
+}

--- a/pkg/settings/updater.go
+++ b/pkg/settings/updater.go
@@ -15,10 +15,19 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/cockroachdb/cockroach/pkg/util/envutil"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 	"github.com/cockroachdb/errors"
 	"github.com/gogo/protobuf/proto"
 )
+
+var ignoreAllUpdates = envutil.EnvOrDefaultBool("COCKROACH_IGNORE_CLUSTER_SETTINGS", false)
+
+// IsIgnoringAllUpdates returns true if Updaters returned by NewUpdater will
+// discard all updates due to the COCKROACH_IGNORE_CLUSTER_SETTINGS var.
+func IsIgnoringAllUpdates() bool {
+	return ignoreAllUpdates
+}
 
 // EncodeDuration encodes a duration in the format of EncodedValue.Value.
 func EncodeDuration(d time.Duration) string {
@@ -76,6 +85,9 @@ func (u NoopUpdater) ResetRemaining(context.Context) {}
 
 // NewUpdater makes an Updater.
 func NewUpdater(sv *Values) Updater {
+	if ignoreAllUpdates {
+		return NoopUpdater{}
+	}
 	return updater{
 		m:  make(map[string]struct{}, len(registry)),
 		sv: sv,

--- a/pkg/sql/set_cluster_setting.go
+++ b/pkg/sql/set_cluster_setting.go
@@ -316,7 +316,10 @@ func (n *setClusterSettingNode) startExec(params runParams) error {
 			telemetry.Inc(sqltelemetry.HashAggregationDiskSpillingDisabled)
 		}
 	}
-
+	// Don't bother waiting if we're ignoring the values; just say so now.
+	if settings.IsIgnoringAllUpdates() {
+		return errors.New("setting updated but will not take effect in this process due to manual override")
+	}
 	return waitForSettingUpdate(params.ctx, params.extendedEvalCtx.ExecCfg,
 		n.setting, n.value == nil /* reset */, n.name, expectedEncodedValue)
 }

--- a/pkg/testutils/lint/lint_test.go
+++ b/pkg/testutils/lint/lint_test.go
@@ -1580,6 +1580,7 @@ func TestLint(t *testing.T) {
 			// Test that the settings package does not import CRDB dependencies.
 			if importingPkg == settingsPkgPrefix && strings.HasPrefix(importedPkg, cockroachDB) {
 				switch {
+				case strings.HasSuffix(s, "envutil"):
 				case strings.HasSuffix(s, "humanizeutil"):
 				case strings.HasSuffix(s, "protoutil"):
 				case strings.HasSuffix(s, "testutils"):


### PR DESCRIPTION
This provides an override usable in siturations where the persisted values for cluster settings may be causing a problem such that one cannot even start and interact with the the cluster enough to update them, such as if a given persisted setting causes nodes to crash on start or reject all SQL connections. In such cases, this env var provides a mechanism to start a node which will ignore the persisted values for all cluster settings and operate with just the default values instead, allowing alterations of the persisted values (though those alterations will similarly be ignored).

Release note (ops change): The enviornment variable COCKROACH_IGNORE_CLUSTER_SETTINGS can be used to start a node that ignores all stored cluster setting values in emergencies.
Epic: none.