### PR TITLE
cli: remove current version from declarative-print-rules test

### DIFF
--- a/pkg/cli/declarative_print_rules_test.go
+++ b/pkg/cli/declarative_print_rules_test.go
@@ -12,6 +12,7 @@ package cli
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/clusterversion"
@@ -43,7 +44,13 @@ func TestDeclarativeRules(t *testing.T) {
 
 		// Using datadriven allows TESTFLAGS=-rewrite.
 		datadriven.RunTest(t, datapathutils.TestDataPath(t, "declarative-rules", "invalid_version"), func(t *testing.T, td *datadriven.TestData) string {
-			return invalidOut
+			// Do not display the present current version within the output,
+			// for testing purposes. This can change from build to build, and
+			// need changes for every version bump.
+			return strings.Replace(invalidOut,
+				" "+clusterversion.ByKey(clusterversion.V23_1).String()+"\n",
+				" latest\n",
+				-1)
 		})
 		datadriven.RunTest(t, datapathutils.TestDataPath(t, "declarative-rules", "oprules"), func(t *testing.T, td *datadriven.TestData) string {
 			return opOut

--- a/pkg/cli/testdata/declarative-rules/invalid_version
+++ b/pkg/cli/testdata/declarative-rules/invalid_version
@@ -3,5 +3,5 @@ invalid_version
 ----
 debug declarative-print-rules 1.1 op
 unsupported version number, the supported versions are: 
- 1000022.2-56
+ latest
  1000022.2


### PR DESCRIPTION
Previously, when the test for declarative-print-rules was added it displayed the current version. This could be annoying during development as the version gets bumped up during the development of a release. To address this, this patch masks out the version number with the word latest.

Epic: none

Release note: None