### PR TITLE
roachtest: upload cockroach binary and use it to collect artifacts

### DIFF
--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -98,6 +98,7 @@ var (
 
 const (
 	defaultEncryptionProbability = 1
+	defaultCockroachPath         = "./cockroach-default"
 )
 
 type errBinaryOrLibraryNotFound struct {
@@ -1156,7 +1157,7 @@ func (c *clusterImpl) FetchLogs(ctx context.Context, l *logger.Logger) error {
 			}
 		}
 
-		if err := c.RunE(ctx, c.All(), "mkdir -p logs/redacted && ./cockroach debug merge-logs --redact logs/*.log > logs/redacted/combined.log"); err != nil {
+		if err := c.RunE(ctx, c.All(), fmt.Sprintf("mkdir -p logs/redacted && %s debug merge-logs --redact logs/*.log > logs/redacted/combined.log", defaultCockroachPath)); err != nil {
 			l.Printf("failed to redact logs: %v", err)
 			if ctx.Err() != nil {
 				return err
@@ -1236,7 +1237,7 @@ func (c *clusterImpl) FetchTimeseriesData(ctx context.Context, l *logger.Logger)
 			sec = fmt.Sprintf("--certs-dir=%s", certs)
 		}
 		if err := c.RunE(
-			ctx, c.Node(node), fmt.Sprintf("./cockroach debug tsdump %s --format=raw > tsdump.gob", sec),
+			ctx, c.Node(node), fmt.Sprintf("%s debug tsdump %s --format=raw > tsdump.gob", defaultCockroachPath, sec),
 		); err != nil {
 			return err
 		}
@@ -1302,17 +1303,17 @@ func (c *clusterImpl) FetchDebugZip(ctx context.Context, l *logger.Logger) error
 		// assumption that a down node will refuse the connection, so it won't
 		// waste our time.
 		for i := 1; i <= c.spec.NodeCount; i++ {
-			// `./cockroach debug zip` is noisy. Suppress the output unless it fails.
+			// `cockroach debug zip` is noisy. Suppress the output unless it fails.
 			//
 			// Ignore the files in the the log directory; we pull the logs separately anyway
 			// so this would only cause duplication.
 			excludeFiles := "*.log,*.txt,*.pprof"
 			cmd := fmt.Sprintf(
-				"./cockroach debug zip --exclude-files='%s' --url {pgurl:%d} %s",
-				excludeFiles, i, zipName,
+				"%s debug zip --exclude-files='%s' --url {pgurl:%d} %s",
+				defaultCockroachPath, excludeFiles, i, zipName,
 			)
 			if err := c.RunE(ctx, c.Node(i), cmd); err != nil {
-				l.Printf("./cockroach debug zip failed on node %d: %v", i, err)
+				l.Printf("%s debug zip failed on node %d: %v", defaultCockroachPath, i, err)
 				if i < c.spec.NodeCount {
 					continue
 				}
@@ -1655,6 +1656,18 @@ func (c *clusterImpl) PutE(
 	c.status("uploading file")
 	defer c.status("")
 	return errors.Wrap(roachprod.Put(ctx, l, c.MakeNodes(nodes...), src, dest, true /* useTreeDist */), "cluster.PutE")
+}
+
+// PutDefaultCockroach uploads the cockroach binary passed in the
+// command line to `defaultCockroachPath` in every node in the
+// cluster. This binary is used by the test runner to collect failure
+// artifacts since tests are free to upload the cockroach binary they
+// use to any location they desire.
+func (c *clusterImpl) PutDefaultCockroach(
+	ctx context.Context, l *logger.Logger, cockroachPath string,
+) error {
+	c.status("uploading default cockroach binary to nodes")
+	return c.PutE(ctx, l, cockroachPath, defaultCockroachPath, c.All())
 }
 
 // PutLibraries inserts the specified libraries, by name, into all nodes on the cluster

--- a/pkg/cmd/roachtest/test_runner.go
+++ b/pkg/cmd/roachtest/test_runner.go
@@ -684,7 +684,12 @@ func (r *testRunner) runWorker(
 			}
 		} else {
 			c.setTest(t)
-			err = c.PutLibraries(ctx, "./lib", t.spec.NativeLibs)
+			if c.spec.NodeCount > 0 { // skip during tests
+				err = c.PutDefaultCockroach(ctx, l, t.Cockroach())
+			}
+			if err == nil {
+				err = c.PutLibraries(ctx, "./lib", t.spec.NativeLibs)
+			}
 
 			if err == nil {
 				// Tell the cluster that, from now on, it will be run "on behalf of this
@@ -1127,9 +1132,7 @@ func (r *testRunner) collectClusterArtifacts(
 	// We only save artifacts for failed tests in CI, so this
 	// duplication is acceptable.
 	// NB: fetch the logs *first* in case one of the other steps
-	// below has problems. For example, `debug zip` is known to
-	// hang sometimes at the time of writing, see:
-	// https://github.com/cockroachdb/cockroach/issues/39620
+	// below has problems.
 	l.PrintfCtx(ctx, "collecting cluster logs")
 	// Do this before collecting logs to make sure the file gets
 	// downloaded below.


### PR DESCRIPTION
This changes the roachtest test runner to always upload the cockroach binary passed in the command line to all nodes in the cluster before a test starts (under the `./cockroach-default` name). This binary is then used when collecting artifacts after a test failure.

Currently, tests are free to upload the cockroach binary under any name they desire, but they commonly use the `./cockroach` path. This practice became an assumption of the test runner, which uses the `./cockroach` path to (for example) generate debug.zip files. However, some tests do not upload a `./cockroach` binary immediately: one notable example is upgrade tests that start from a previous version. These binaries are generally downloaded to `{version}/cockroach`. If the test fails before the test uploaded a binary to `./cockroach`, the test runner would fail to generate a debug.zip, making the issue much harder to debug. Examples of this are #96923 and #97679.

Resolves: #97713.

Release note: None