### PR TITLE
parser: support `SET search_path = none;`

### DIFF
--- a/docs/generated/sql/bnf/stmt_block.bnf
+++ b/docs/generated/sql/bnf/stmt_block.bnf
@@ -2665,6 +2665,7 @@ generic_set ::=
 
 extra_var_value ::=
 	'ON'
+	| 'NONE'
 	| cockroachdb_extra_reserved_keyword
 
 show_backup_options_list ::=

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -6658,12 +6658,14 @@ var_value:
 //
 // In addition, for compatibility with CockroachDB we need to support
 // the reserved keyword ON (to go along OFF, which is a valid column name).
+// Similarly, NONE is specially allowed here.
 //
 // Finally, in PostgreSQL the CockroachDB-reserved words "index",
 // "nothing", etc. are not special and are valid in SET. These need to
 // be allowed here too.
 extra_var_value:
   ON
+| NONE
 | cockroachdb_extra_reserved_keyword
 
 var_list:

--- a/pkg/sql/parser/testdata/set
+++ b/pkg/sql/parser/testdata/set
@@ -7,6 +7,14 @@ SET a = _ -- literals removed
 SET a = 3 -- identifiers removed
 
 parse
+SET search_path = none
+----
+SET search_path = "none" -- normalized!
+SET search_path = ("none") -- fully parenthesized
+SET search_path = "none" -- literals removed
+SET search_path = _ -- identifiers removed
+
+parse
 EXPLAIN SET a = 3
 ----
 EXPLAIN SET a = 3


### PR DESCRIPTION
The asyncpg tests were relying on this command.

Epic: None
Release note (bug fix): The unquoted value `none` is now allowed as the value in a SET statement.