### PR TITLE
opt: prevent panic in FoldCast with typed NULLs

### DIFF
--- a/pkg/sql/opt/norm/fold_constants_funcs.go
+++ b/pkg/sql/opt/norm/fold_constants_funcs.go
@@ -348,14 +348,21 @@ func (c *CustomFuncs) foldOIDFamilyCast(
 			if err != nil {
 				return nil, false, err
 			}
-			dOid = tree.MustBeDOid(cDatum)
+			oid, ok := tree.AsDOid(cDatum)
+			if !ok {
+				return nil, false, nil
+			}
+			dOid = oid
 		default:
 			return nil, false, nil
 		}
 	case oid.T_regclass:
 		switch inputFamily {
 		case types.StringFamily:
-			s := tree.MustBeDString(datum)
+			s, ok := tree.AsDString(datum)
+			if !ok {
+				return nil, false, nil
+			}
 			tn, err := parser.ParseQualifiedTableName(string(s))
 			if err != nil {
 				return nil, true, err

--- a/pkg/sql/opt/norm/testdata/rules/fold_constants
+++ b/pkg/sql/opt/norm/testdata/rules/fold_constants
@@ -843,6 +843,24 @@ values
  ├── fd: ()-->(1)
  └── ('2017-05-10 00:00:00+00',)
 
+# Regression test for #96447. FoldCast should not panic when attempting to fold
+# a typed NULL when FoldNullCast is disabled.
+norm disable=FoldNullCast
+SELECT NULL::INT::OID,
+  NULL::INT::REGTYPE,
+  NULL::INT::REGPROC,
+  NULL::INT::REGPROCEDURE,
+  NULL::INT::REGNAMESPACE,
+  NULL::STRING::REGCLASS
+----
+values
+ ├── columns: oid:1 regtype:2 regproc:3 regprocedure:4 regnamespace:5 regclass:6
+ ├── cardinality: [1 - 1]
+ ├── stable
+ ├── key: ()
+ ├── fd: ()-->(1-6)
+ └── (CAST(NULL AS INT8)::OID, CAST(NULL AS INT8)::REGTYPE, CAST(NULL AS INT8)::REGPROC, CAST(NULL AS INT8)::REGPROCEDURE, CAST(NULL AS INT8)::REGNAMESPACE, CAST(NULL AS STRING)::REGCLASS)
+
 # --------------------------------------------------
 # FoldAssignmentCast
 # --------------------------------------------------


### PR DESCRIPTION
#### opt: prevent panic in FoldCast with typed NULLs

FoldCast no longer panics when attempting to cast a typed NULL to an
OID, REGTYPE, REGPROC, REGPROCEDURE, REGNAMESPACE, or REGCLASS. It was
not actually possible to hit this panic in production because NULL casts
would always be folded by FoldNullCast. It was only possible during
testing with FoldNullCast disabled.

Fixes #96447

Release note: None
