### PR TITLE
sql: dynamically detect a query's home region with enforce_home_region

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/multi_region_remote_access_error
+++ b/pkg/ccl/logictestccl/testdata/logic_test/multi_region_remote_access_error
@@ -200,6 +200,9 @@ CREATE TABLE json_arr2_rbt (
 statement ok
 SET enforce_home_region = true
 
+statement ok
+SET enforce_home_region_follower_reads_enabled = true
+
 ### Regression tests for issue #89875
 
 # Non-DML statements should not error out due to enforce_home_region.
@@ -652,6 +655,9 @@ CREATE TABLE messages (
 statement ok
 SET enforce_home_region = true
 
+statement ok
+SET enforce_home_region_follower_reads_enabled = true
+
 # Tables in non-multiregion databases have no home region.
 retry
 statement error pq: Query has no home region. Try accessing only tables in multi-region databases with ZONE survivability\. For more information, see https://www.cockroachlabs.com/docs/stable/cost-based-optimizer.html#control-whether-queries-are-limited-to-a-single-region
@@ -862,6 +868,9 @@ INSERT INTO messages_global SELECT * FROM messages_rbr WHERE crdb_region != 'ap-
 
 statement ok
 SET enforce_home_region = true;
+
+statement ok
+SET enforce_home_region_follower_reads_enabled = true
 
 # Querying the row in the local region succeeds.
 query III retry

--- a/pkg/ccl/logictestccl/testdata/logic_test/multi_region_remote_access_error
+++ b/pkg/ccl/logictestccl/testdata/logic_test/multi_region_remote_access_error
@@ -34,8 +34,9 @@ statement ok
 CREATE TABLE t1 (a INT, b INT, c INT, primary key(a)) LOCALITY REGIONAL BY ROW;
 
 statement ok
-INSERT INTO t1 (crdb_region, a, b, c) VALUES ('ap-southeast-2', 1, 1, 1);
+INSERT INTO t1 (crdb_region, a, b, c) VALUES ('us-east-1', 1, 1, 1);
 INSERT INTO t1 (crdb_region, a, b, c) VALUES ('ca-central-1', 2, 1, 1);
+INSERT INTO t1 (crdb_region, a, b, c) VALUES ('ap-southeast-2', 3, 1, 1);
 
 statement ok
 CREATE TABLE parent (
@@ -74,6 +75,10 @@ CREATE TABLE messages_rbt (
     PRIMARY KEY (account_id),
     INDEX msg_idx(message)
 ) LOCALITY REGIONAL BY TABLE
+
+# Sleep so that the follow_read_timestamp() used by phase 3 dynamic checking
+# of a query's home region isn't executing before the tables existed.
+sleep 5s
 
 statement ok
 CREATE TABLE messages_rbr (
@@ -844,21 +849,68 @@ INSERT INTO parent (crdb_region, p_id) VALUES('ca-central-1', 2);
 statement ok
 INSERT INTO child (crdb_region, c_id, c_p_id) VALUES('ap-southeast-2', 11, 2);
 
-subtest enforce_home_region_phase_2
+subtest enforce_home_region_phase_2_3
+
+retry
+statement ok
+INSERT INTO messages_rbr (crdb_region, account_id, message) VALUES ('us-east-1', 2, 'Hola, Region!');
+INSERT INTO messages_rbr (crdb_region, account_id, message) VALUES ('ca-central-1', 3, 'Guten Tag, Region!');
+
+retry
+statement ok
+INSERT INTO messages_global SELECT * FROM messages_rbr WHERE crdb_region != 'ap-southeast-2'
 
 statement ok
 SET enforce_home_region = true;
 
 # Querying the row in the local region succeeds.
 query III retry
-SELECT * FROM t1 WHERE a=1;
+SELECT * FROM t1 WHERE a=3;
 ----
-1  1  1
+3  1  1
 
-# Querying the row in the remote region errors out.
+## Phase 3, dynamically detect a query's home region.
+# Querying a row in a remote region errors out, and indicates the home region.
 retry
-statement error pq: Query has no home region\. Try using a lower LIMIT value or running the query from a different region\.
+statement error pq: Query is not running in its home region\. Try running the query from region 'us-east-1'\.
+SELECT * FROM t1 WHERE a=1;
+
+# Phase 3, dynamically detect a query's home region.
+# Querying a row in a remote region errors out, and indicates the home region.
+retry
+statement error pq: Query is not running in its home region\. Try running the query from region 'ca-central-1'\.
 SELECT * FROM t1 WHERE a=2;
+
+retry
+statement ok
+PREPARE s1 AS SELECT * FROM t1 WHERE a=$1
+
+# Phase 3, dynamically detect a query's home region.
+# Prepared statement accessing a row in a remote region errors out,
+# and indicates the home region.
+retry
+statement error pq: Query is not running in its home region\. Try running the query from region 'ca-central-1'\.
+EXECUTE s1('2')
+
+statement ok
+BEGIN
+
+statement ok
+SAVEPOINT foo
+
+# Phase 3, dynamically detect a query's home region.
+# An explicit transaction accessing a remote region errors out,
+# and indicates the home region.
+retry
+statement error pq: Query is not running in its home region\. Try running the query from region 'ca-central-1'\.
+SELECT * FROM t1 WHERE a=2;
+
+# Verify we can still roll back to the savepoint.
+statement ok
+ROLLBACK TO SAVEPOINT foo
+
+statement ok
+COMMIT
 
 # Locality-optimized join in the local region succeeds.
 query III retry
@@ -886,6 +938,14 @@ SELECT rbr.message FROM messages_rbr rbr, (SELECT * FROM messages_rbt ORDER BY a
 ----
 Hello, Region!
 
+# Phase 3, dynamically detect a query's home region.
+# Locality-optimized lookup join should report a query's home region.
+retry
+statement error pq: Query is not running in its home region\. Try running the query from region 'us-east-1'\.
+SELECT rbr.message FROM messages_rbr rbr, (SELECT * FROM messages_global ORDER BY account_id LIMIT 1) rbg
+       WHERE rbr.account_id = rbg.account_id LIMIT 1
+
+
 # Locality-optimized semijoin in the local region succeeds.
 query T retry
 SELECT message FROM (SELECT * FROM messages_rbt ORDER BY account_id LIMIT 1) rbt WHERE account_id IN
@@ -903,7 +963,7 @@ SELECT message FROM (SELECT * FROM messages_rbt ORDER BY account_id LIMIT 2) rbt
 
 # Locality-optimized semijoin in the local region with an ordered join reader
 # succeeds.
-query I
+query I retry
 SELECT account_id FROM (SELECT * FROM messages_rbt ORDER BY account_id LIMIT 1) rbt WHERE account_id IN
                      (SELECT account_id FROM messages_rbr rbr) ORDER BY 1 LIMIT 1;
 ----
@@ -935,6 +995,13 @@ SELECT message FROM (SELECT * FROM messages_rbt ORDER BY account_id LIMIT 1) rbt
                      (SELECT account_id FROM messages_rbr rbr) LIMIT 1
 ----
 
+# Phase 3, dynamically detect a query's home region.
+# Locality-optimized lookup antijoin should report a query's home region.
+retry
+statement error pq: Query is not running in its home region\. Try running the query from region 'us-east-1'\.
+SELECT message FROM (SELECT * FROM messages_global ORDER BY account_id LIMIT 1) rbg WHERE account_id NOT IN
+                     (SELECT account_id FROM messages_rbr rbr) LIMIT 1
+
 # Locality-optimized antijoin reading into a remote region fails.
 retry
 statement error pq: Query has no home region\. Try using a lower LIMIT value or running the query from a different region\.
@@ -959,6 +1026,118 @@ retry
 statement error pq: Query has no home region\. Try using a lower LIMIT value or running the query from a different region\.
 SELECT rbr.message FROM messages_rbr rbr INNER LOOKUP JOIN messages_rbt rbt
        ON rbr.account_id = rbt.account_id LIMIT 2
+
+# Run a locality-optimized scan that dynamically detects the home region with
+# tracing.
+retry
+statement error pq: Query is not running in its home region\. Try running the query from region 'ca-central-1'\.
+SET TRACING = "on", kv, results;
+SELECT * FROM t1 WHERE a=2;
+SET TRACING = off
+
+# All of the batch requests should be sent to (n1,s1) only.
+query T
+SELECT
+    CASE WHEN message LIKE '%sending%'
+      THEN SUBSTRING(message FOR 14 FROM 6) || SUBSTRING(message FOR 20 FROM POSITION('to' IN message))
+      ELSE message END
+FROM
+    [SHOW KV TRACE FOR SESSION] WITH ORDINALITY
+WHERE
+    message LIKE 'output row%' OR message LIKE '%sending%' OR message LIKE 'execution%'
+ORDER BY
+    "ordinality" ASC
+----
+sending batch to (n1,s1):1
+execution failed after 0 rows: Query has no home region. Try using a lower LIMIT value or running the query from a different region.
+sending batch to (n1,s1):1
+output row: [2 1 1]
+
+# Run a locality-optimized join that dynamically detects the home region with
+# tracing.
+retry
+statement error pq: Query is not running in its home region\. Try running the query from region 'us-east-1'\.
+SET TRACING = "on", kv, results;
+SELECT rbr.message FROM messages_rbr rbr, (SELECT * FROM messages_global ORDER BY account_id LIMIT 1) rbg
+       WHERE rbr.account_id = rbg.account_id LIMIT 1;
+SET TRACING = off
+
+# All of the batch requests should be sent to (n1,s1) only.
+query T
+SELECT
+    CASE WHEN message LIKE '%sending%'
+      THEN SUBSTRING(message FOR 14 FROM POSITION('sending' IN message)) || SUBSTRING(message FOR 12 FROM POSITION('to' IN message))
+      ELSE message END
+FROM
+    [SHOW KV TRACE FOR SESSION] WITH ORDINALITY
+WHERE
+    message LIKE 'output row%' OR message LIKE '%sending%' OR message LIKE 'execution%'
+ORDER BY
+    "ordinality" ASC
+----
+sending batch to (n1,s1):1
+execution failed after 0 rows: Query has no home region. Try using a lower LIMIT value or running the query from a different region.
+sending batch to (n1,s1):1
+output row: [2 1 1]
+sending batch to (n1,s1):1
+output row: ['execution failed after 0 rows: Query has no home region. Try using a lower LIMIT value or running the query from a different region.']
+sending batch to (n1,s1):1
+output row: ['output row: [2 1 1]']
+sending batch to (n1,s1):1
+sending batch to (n1,s1):1
+execution failed after 0 rows: Query has no home region. Try using a lower LIMIT value or running the query from a different region.
+sending batch to (n1,s1):1
+sending batch to (n1,s1):1
+execution failed after 0 rows: Query has no home region. Try using a lower LIMIT value or running the query from a different region.
+sending batch to (n1,s1):1
+sending batch to (n1,s1):1
+output row: ['Hola, Region!']
+
+statement ok
+BEGIN
+
+statement ok
+SAVEPOINT foo
+
+# Phase 3, dynamically detect a query's home region.
+# An explicit transaction accessing a remote region errors out,
+# and indicates the home region.
+statement error pq: Query is not running in its home region. Try running the query from region 'ca-central-1'\.
+SELECT * FROM t1 WHERE a=2;
+
+# Verify we can still roll back to the savepoint.
+statement ok
+ROLLBACK TO SAVEPOINT foo
+
+statement ok
+COMMIT
+
+statement ok
+BEGIN
+
+statement ok
+SAVEPOINT foo
+
+# Read some rows in an explicit transaction, which invalidates use of
+# switching to AOST follower_read_timestamp() internally in the next statement.
+query III
+SELECT * FROM t1 WHERE a=3;
+----
+3  1  1
+
+# Phase 3, dynamically detect a query's home region.
+# An explicit transaction accessing a remote region errors out,
+# and indicates "Query has no home region" if any rows were read
+# in the transaction already.
+statement error pq: Query has no home region\. Try using a lower LIMIT value or running the query from a different region\.
+SELECT * FROM t1 WHERE a=2;
+
+# Verify we can still roll back to the savepoint.
+statement ok
+ROLLBACK TO SAVEPOINT foo
+
+statement ok
+COMMIT
 
 statement ok
 RESET enforce_home_region

--- a/pkg/ccl/logictestccl/testdata/logic_test/multi_region_remote_access_error
+++ b/pkg/ccl/logictestccl/testdata/logic_test/multi_region_remote_access_error
@@ -223,12 +223,12 @@ UPDATE messages_rbt SET account_id = -account_id WHERE account_id NOT IN (SELECT
 
 # Update should fail accessing all rows in messages_rbr.
 retry
-statement error pq: Query has no home region\. Try adding a filter on messages_rbr\.crdb_region and/or on key column \(messages_rbr\.account_id\)\.
+statement error pq: Query has no home region\. Try adding a filter on messages_rbr\.crdb_region and/or on key column \(messages_rbr\.account_id\)\. For more information, see https://www.cockroachlabs.com/docs/stable/cost-based-optimizer.html#control-whether-queries-are-limited-to-a-single-region
 UPDATE messages_rbt SET account_id = -account_id WHERE message_id NOT IN (SELECT message_id FROM messages_rbr)
 
 # Update should fail accessing all rows in messages_rbr.
 retry
-statement error pq: Query has no home region\. Try adding a filter on messages_rbr\.crdb_region and/or on key column \(messages_rbr\.account_id\)\.
+statement error pq: Query has no home region\. Try adding a filter on messages_rbr\.crdb_region and/or on key column \(messages_rbr\.account_id\)\. For more information, see https://www.cockroachlabs.com/docs/stable/cost-based-optimizer.html#control-whether-queries-are-limited-to-a-single-region
 UPDATE messages_rbr SET account_id = -account_id WHERE account_id NOT IN (SELECT account_id FROM messages_rbt)
 
 # Delete does not fail when accessing all rows in messages_rbr because lookup
@@ -240,22 +240,22 @@ DELETE FROM messages_rbt WHERE account_id NOT IN (SELECT account_id FROM message
 # Delete should fail accessing all rows in messages_rbr.
 # join does not error out the lookup table in phase 1.
 retry
-statement error pq: Query has no home region\. Try adding a filter on messages_rbr\.crdb_region and/or on key column \(messages_rbr\.account_id\)\.
+statement error pq: Query has no home region\. Try adding a filter on messages_rbr\.crdb_region and/or on key column \(messages_rbr\.account_id\)\. For more information, see https://www.cockroachlabs.com/docs/stable/cost-based-optimizer.html#control-whether-queries-are-limited-to-a-single-region
 DELETE FROM messages_rbt WHERE message_id NOT IN (SELECT message_id FROM messages_rbr)
 
 # Delete of potentially all rows in messages_rbr should fail.
 retry
-statement error pq: Query has no home region\. Try adding a filter on messages_rbr\.crdb_region and/or on key column \(messages_rbr\.account_id\)\.
+statement error pq: Query has no home region\. Try adding a filter on messages_rbr\.crdb_region and/or on key column \(messages_rbr\.account_id\)\. For more information, see https://www.cockroachlabs.com/docs/stable/cost-based-optimizer.html#control-whether-queries-are-limited-to-a-single-region
 DELETE FROM messages_rbr WHERE account_id NOT IN (SELECT account_id FROM messages_rbt)
 
 # Delete accessing all regions should fail.
 retry
-statement error pq: Query has no home region\. Try adding a filter on messages_rbr\.crdb_region and/or on key column \(messages_rbr\.account_id\)\.
+statement error pq: Query has no home region\. Try adding a filter on messages_rbr\.crdb_region and/or on key column \(messages_rbr\.account_id\)\. For more information, see https://www.cockroachlabs.com/docs/stable/cost-based-optimizer.html#control-whether-queries-are-limited-to-a-single-region
 DELETE FROM messages_rbr WHERE message = 'Hello World!'
 
 # Insert should fail accessing all rows in messages_rbr.
 retry
-statement error pq: Query has no home region\. Try adding a filter on messages_rbr\.crdb_region and/or on key column \(messages_rbr\.account_id\)\.
+statement error pq: Query has no home region\. Try adding a filter on messages_rbr\.crdb_region and/or on key column \(messages_rbr\.account_id\)\. For more information, see https://www.cockroachlabs.com/docs/stable/cost-based-optimizer.html#control-whether-queries-are-limited-to-a-single-region
 INSERT INTO messages_rbt SELECT * FROM messages_rbr
 
 # Insert into an RBR table should succeed. New rows are placed in the gateway region.
@@ -270,7 +270,7 @@ UPSERT INTO messages_rbr SELECT * FROM messages_rbt
 
 # Upsert should fail accessing all rows in messages_rbr.
 retry
-statement error pq: Query has no home region\. Try adding a filter on messages_rbr\.crdb_region and/or on key column \(messages_rbr\.account_id\)\.
+statement error pq: Query has no home region\. Try adding a filter on messages_rbr\.crdb_region and/or on key column \(messages_rbr\.account_id\)\. For more information, see https://www.cockroachlabs.com/docs/stable/cost-based-optimizer.html#control-whether-queries-are-limited-to-a-single-region
 UPSERT INTO messages_rbt SELECT * FROM messages_rbr
 
 # Upsert into an RBR table uses locality-optimized lookup join and should
@@ -281,7 +281,7 @@ UPSERT INTO messages_rbr SELECT * FROM messages_rbt
 
 # UNION ALL where one branch scans all rows of an RBR table should fail.
 retry
-statement error pq: Query has no home region\. Try adding a filter on messages_rbr\.crdb_region and/or on key column \(messages_rbr\.account_id\)\.
+statement error pq: Query has no home region\. Try adding a filter on messages_rbr\.crdb_region and/or on key column \(messages_rbr\.account_id\)\. For more information, see https://www.cockroachlabs.com/docs/stable/cost-based-optimizer.html#control-whether-queries-are-limited-to-a-single-region
 SELECT * FROM messages_rbr UNION ALL SELECT * FROM messages_rbt
 
 # UNION ALL where one branch scans 1 row of an RBR table should succeed.
@@ -295,7 +295,7 @@ Hello, Region!
 # A join relation with no home region as the left input of lookup join should
 # not be allowed.
 retry
-statement error pq: Query has no home region\. Try adding a filter on rbr\.crdb_region and/or on key column \(rbr\.account_id\)\.
+statement error pq: Query has no home region\. Try adding a filter on rbr\.crdb_region and/or on key column \(rbr\.account_id\)\. For more information, see https://www.cockroachlabs.com/docs/stable/cost-based-optimizer.html#control-whether-queries-are-limited-to-a-single-region
 SELECT * FROM messages_rbr rbr INNER LOOKUP JOIN messages_global g2 ON rbr.account_id = g2.account_id
   INNER LOOKUP JOIN messages_global g3 ON g2.account_id = g3.account_id
 
@@ -307,7 +307,7 @@ SELECT c_id FROM child, (SELECT * FROM [VALUES (1)]) v WHERE crdb_region = 'ap-s
 
 # Joins which may access all regions should error out in phase 1.
 retry
-statement error pq: Query has no home region\. Try adding a filter on p\.crdb_region and/or on key column \(p\.p_id\)\. Try adding a filter on c\.crdb_region and/or on key column \(c\.c_id\)\.
+statement error pq: Query has no home region\. Try adding a filter on p\.crdb_region and/or on key column \(p\.p_id\)\. Try adding a filter on c\.crdb_region and/or on key column \(c\.c_id\)\. For more information, see https://www.cockroachlabs.com/docs/stable/cost-based-optimizer.html#control-whether-queries-are-limited-to-a-single-region
 SELECT * FROM parent p, child c WHERE p_id = c_p_id AND
 p.crdb_region = c.crdb_region LIMIT 1
 
@@ -355,7 +355,7 @@ SET locality_optimized_partitioned_index_scan = false
 
 # This query should error out because it is not locality optimized.
 retry
-statement error pq: Query has no home region\. Try adding a filter on parent\.crdb_region and/or on key column \(parent\.p_id\)\. Try adding a filter on child\.crdb_region and/or on key column \(child\.c_id\)\.
+statement error pq: Query has no home region\. Try adding a filter on parent\.crdb_region and/or on key column \(parent\.p_id\)\. Try adding a filter on child\.crdb_region and/or on key column \(child\.c_id\)\. For more information, see https://www.cockroachlabs.com/docs/stable/cost-based-optimizer.html#control-whether-queries-are-limited-to-a-single-region
 SELECT * FROM child WHERE NOT EXISTS (SELECT * FROM parent WHERE p_id = c_p_id) AND c_id = 10
 
 statement ok
@@ -381,7 +381,7 @@ locality-optimized-search
 # Locality optimized search with lookup join will be supported in phase 2 or 3
 # when we can dynamically determine if the lookup will access a remote region.
 retry
-statement error pq: Query has no home region\. Try adding a filter on o\.crdb_region and/or on key column \(o\.id\)\.
+statement error pq: Query has no home region\. Try adding a filter on o\.crdb_region and/or on key column \(o\.id\)\. For more information, see https://www.cockroachlabs.com/docs/stable/cost-based-optimizer.html#control-whether-queries-are-limited-to-a-single-region
 SELECT * FROM customers c JOIN orders o ON c.id = o.cust_id AND
   (c.crdb_region = o.crdb_region) WHERE c.id = '69a1c2c2-5b18-459e-94d2-079dc53a4dd0'
 
@@ -517,14 +517,14 @@ inner-join (lookup messages_global [as=g3])
 # A join relation with no home region as the left input of lookup join should
 # not be allowed.
 retry
-statement error pq: Query has no home region\. Try adding a filter on rbr\.crdb_region and/or on key column \(rbr\.account_id\)\.
+statement error pq: Query has no home region\. Try adding a filter on rbr\.crdb_region and/or on key column \(rbr\.account_id\)\. For more information, see https://www.cockroachlabs.com/docs/stable/cost-based-optimizer.html#control-whether-queries-are-limited-to-a-single-region
 SELECT * FROM messages_rbr rbr INNER LOOKUP JOIN messages_global g2 ON rbr.account_id = g2.account_id
   INNER LOOKUP JOIN messages_global g3 ON g2.account_id = g3.account_id
 
 # The explicit REGIONAL BY ROW AS column name should be used in the error
 # message if it differs from the default crdb_region.
 retry
-statement error pq: Query has no home region\. Try adding a filter on rbr\.crdb_region_alt and/or on key column \(rbr\.account_id\)\.
+statement error pq: Query has no home region\. Try adding a filter on rbr\.crdb_region_alt and/or on key column \(rbr\.account_id\)\. For more information, see https://www.cockroachlabs.com/docs/stable/cost-based-optimizer.html#control-whether-queries-are-limited-to-a-single-region
 SELECT * FROM messages_rbr_alt rbr INNER LOOKUP JOIN messages_global g2 ON rbr.account_id = g2.account_id
   INNER LOOKUP JOIN messages_global g3 ON g2.account_id = g3.account_id
 
@@ -564,12 +564,12 @@ ALTER TABLE messages_rbt SET LOCALITY REGIONAL BY TABLE IN "us-east-1";
 # Regression test for issue #88788
 # A full scan on an RBT table should error out lookup join.
 retry
-statement error pq: Query has no home region\. Try adding a filter on rbr\.crdb_region and/or on key column \(rbr\.account_id\)\.
+statement error pq: Query has no home region\. Try adding a filter on rbr\.crdb_region and/or on key column \(rbr\.account_id\)\. For more information, see https://www.cockroachlabs.com/docs/stable/cost-based-optimizer.html#control-whether-queries-are-limited-to-a-single-region
 SELECT * FROM messages_rbr rbr, messages_rbt rbt WHERE rbr.account_id = rbt.account_id LIMIT 1
 
 # Select from REGIONAL BY TABLE should indicate the gateway region to use.
 retry
-statement error pq: Query is not running in its home region. Try running the query from region 'us-east-1'.
+statement error pq: Query is not running in its home region\. Try running the query from region 'us-east-1'\. For more information, see https://www.cockroachlabs.com/docs/stable/cost-based-optimizer.html#control-whether-queries-are-limited-to-a-single-region
 SELECT message from messages_rbt@messages_rbt_pkey
 
 # Logging in through the appropriate gateway region allows reading from an RBR
@@ -592,13 +592,13 @@ project
 
 # Lookup join should detect REGIONAL BY TABLE in the wrong region.
 retry
-statement error pq: Query has no home region\. The home region \('us-east-1'\) of table 'messages_rbt' does not match the home region \('ap-southeast-2'\) of lookup table 'messages_rbr'\.
+statement error pq: Query has no home region\. The home region \('us-east-1'\) of table 'messages_rbt' does not match the home region \('ap-southeast-2'\) of lookup table 'messages_rbr'\. For more information, see https://www.cockroachlabs.com/docs/stable/cost-based-optimizer.html#control-whether-queries-are-limited-to-a-single-region
 SELECT * FROM  messages_rbt rbt inner lookup join messages_rbr rbr ON rbr.account_id = rbt.account_id
 AND rbr.crdb_region = 'ap-southeast-2'
 
 # Lookup join should detect REGIONAL BY TABLE in the wrong region.
 retry
-statement error pq: Query has no home region\. The home region \('ap-southeast-2'\) of table 'messages_rbr' does not match the home region \('us-east-1'\) of lookup table 'messages_rbt'\.
+statement error pq: Query has no home region\. The home region \('ap-southeast-2'\) of table 'messages_rbr' does not match the home region \('us-east-1'\) of lookup table 'messages_rbt'\. For more information, see https://www.cockroachlabs.com/docs/stable/cost-based-optimizer.html#control-whether-queries-are-limited-to-a-single-region
 SELECT * FROM messages_rbr rbr inner lookup join messages_rbt rbt ON rbr.account_id = rbt.account_id
 AND rbr.crdb_region = 'ap-southeast-2'
 
@@ -628,7 +628,7 @@ Hello, Region!
 
 # Prepared statement accessing a remote span is disallowed.
 retry
-statement error pq: Query is not running in its home region. Try running the query from region 'us-east-1'.
+statement error pq: Query is not running in its home region. Try running the query from region 'us-east-1'\. For more information, see https://www.cockroachlabs.com/docs/stable/cost-based-optimizer.html#control-whether-queries-are-limited-to-a-single-region
 EXECUTE s('us-east-1')
 
 statement ok
@@ -654,24 +654,24 @@ SET enforce_home_region = true
 
 # Tables in non-multiregion databases have no home region.
 retry
-statement error pq: Query has no home region. Try accessing only tables in multi-region databases with ZONE survivability.
+statement error pq: Query has no home region. Try accessing only tables in multi-region databases with ZONE survivability\. For more information, see https://www.cockroachlabs.com/docs/stable/cost-based-optimizer.html#control-whether-queries-are-limited-to-a-single-region
 SELECT * FROM messages
 
 # If any table in a query has no home region, error out.
 retry
-statement error pq: Query has no home region. Try accessing only tables in multi-region databases with ZONE survivability.
+statement error pq: Query has no home region. Try accessing only tables in multi-region databases with ZONE survivability\. For more information, see https://www.cockroachlabs.com/docs/stable/cost-based-optimizer.html#control-whether-queries-are-limited-to-a-single-region
 SELECT * FROM non_multiregion_test_db.messages, multi_region_test_db.messages_global
 
 # Scans from tables in non-multiregion databases with contradictions in
 # predicates are not allowed.
 retry
-statement error pq: Query has no home region. Try accessing only tables in multi-region databases with ZONE survivability.
+statement error pq: Query has no home region. Try accessing only tables in multi-region databases with ZONE survivability\. For more information, see https://www.cockroachlabs.com/docs/stable/cost-based-optimizer.html#control-whether-queries-are-limited-to-a-single-region
 SELECT * FROM messages WHERE account_id = 1 AND account_id = 2
 
 # A lookup join from a multiregion table to non-multiregion table is not
 # allowed.
 retry
-statement error pq: Query has no home region. Try accessing only tables in multi-region databases with ZONE survivability.
+statement error pq: Query has no home region. Try accessing only tables in multi-region databases with ZONE survivability\. For more information, see https://www.cockroachlabs.com/docs/stable/cost-based-optimizer.html#control-whether-queries-are-limited-to-a-single-region
 SELECT * FROM multi_region_test_db.messages_global mr INNER LOOKUP JOIN non_multiregion_test_db.messages nmr
   ON mr.account_id = nmr.account_id
 
@@ -747,7 +747,7 @@ project
 
 # Inverted join doing lookup into a REGIONAL BY ROW table is not allowed.
 retry
-statement error pq: Query has no home region\. Try adding a filter on t1\.crdb_region and/or on key column \(t1\.j_inverted_key\)\.
+statement error pq: Query has no home region\. Try adding a filter on t1\.crdb_region and/or on key column \(t1\.j_inverted_key\)\. For more information, see https://www.cockroachlabs.com/docs/stable/cost-based-optimizer.html#control-whether-queries-are-limited-to-a-single-region
 SELECT t1.k FROM json_arr2_rbt AS t2 INNER INVERTED JOIN json_arr1_rbr AS t1 ON t1.j @> t2.j
 
 # Inverted join with lookup into a REGIONAL BY ROW table in local region is allowed.
@@ -872,13 +872,13 @@ SELECT * FROM t1 WHERE a=3;
 ## Phase 3, dynamically detect a query's home region.
 # Querying a row in a remote region errors out, and indicates the home region.
 retry
-statement error pq: Query is not running in its home region\. Try running the query from region 'us-east-1'\.
+statement error pq: Query is not running in its home region\. Try running the query from region 'us-east-1'\. For more information, see https://www.cockroachlabs.com/docs/stable/cost-based-optimizer.html#control-whether-queries-are-limited-to-a-single-region
 SELECT * FROM t1 WHERE a=1;
 
 # Phase 3, dynamically detect a query's home region.
 # Querying a row in a remote region errors out, and indicates the home region.
 retry
-statement error pq: Query is not running in its home region\. Try running the query from region 'ca-central-1'\.
+statement error pq: Query is not running in its home region\. Try running the query from region 'ca-central-1'\. For more information, see https://www.cockroachlabs.com/docs/stable/cost-based-optimizer.html#control-whether-queries-are-limited-to-a-single-region
 SELECT * FROM t1 WHERE a=2;
 
 retry
@@ -889,7 +889,7 @@ PREPARE s1 AS SELECT * FROM t1 WHERE a=$1
 # Prepared statement accessing a row in a remote region errors out,
 # and indicates the home region.
 retry
-statement error pq: Query is not running in its home region\. Try running the query from region 'ca-central-1'\.
+statement error pq: Query is not running in its home region\. Try running the query from region 'ca-central-1'\. For more information, see https://www.cockroachlabs.com/docs/stable/cost-based-optimizer.html#control-whether-queries-are-limited-to-a-single-region
 EXECUTE s1('2')
 
 statement ok
@@ -902,7 +902,7 @@ SAVEPOINT foo
 # An explicit transaction accessing a remote region errors out,
 # and indicates the home region.
 retry
-statement error pq: Query is not running in its home region\. Try running the query from region 'ca-central-1'\.
+statement error pq: Query is not running in its home region\. Try running the query from region 'ca-central-1'\. For more information, see https://www.cockroachlabs.com/docs/stable/cost-based-optimizer.html#control-whether-queries-are-limited-to-a-single-region
 SELECT * FROM t1 WHERE a=2;
 
 # Verify we can still roll back to the savepoint.
@@ -941,7 +941,7 @@ Hello, Region!
 # Phase 3, dynamically detect a query's home region.
 # Locality-optimized lookup join should report a query's home region.
 retry
-statement error pq: Query is not running in its home region\. Try running the query from region 'us-east-1'\.
+statement error pq: Query is not running in its home region\. Try running the query from region 'us-east-1'\. For more information, see https://www.cockroachlabs.com/docs/stable/cost-based-optimizer.html#control-whether-queries-are-limited-to-a-single-region
 SELECT rbr.message FROM messages_rbr rbr, (SELECT * FROM messages_global ORDER BY account_id LIMIT 1) rbg
        WHERE rbr.account_id = rbg.account_id LIMIT 1
 
@@ -957,7 +957,7 @@ Hello, Zone!
 # Prior to fixing a bug in `DistributeExpr.GetDistributions`, this query would
 # return a different error message.
 retry
-statement error pq: Query has no home region\. Try using a lower LIMIT value or running the query from a different region\.
+statement error pq: Query has no home region\. Try using a lower LIMIT value or running the query from a different region\. For more information, see https://www.cockroachlabs.com/docs/stable/cost-based-optimizer.html#control-whether-queries-are-limited-to-a-single-region
 SELECT message FROM (SELECT * FROM messages_rbt ORDER BY account_id LIMIT 2) rbt WHERE account_id IN
                      (SELECT account_id FROM messages_rbr rbr) ORDER BY 1 LIMIT 2;
 
@@ -972,7 +972,7 @@ SELECT account_id FROM (SELECT * FROM messages_rbt ORDER BY account_id LIMIT 1) 
 # Locality-optimized semijoin reading into a remote region with an ordered join
 # reader fails.
 retry
-statement error pq: Query has no home region\. Try using a lower LIMIT value or running the query from a different region\.
+statement error pq: Query has no home region\. Try using a lower LIMIT value or running the query from a different region\. For more information, see https://www.cockroachlabs.com/docs/stable/cost-based-optimizer.html#control-whether-queries-are-limited-to-a-single-region
 SELECT account_id FROM (SELECT * FROM messages_rbt ORDER BY account_id LIMIT 2) rbt WHERE account_id IN
                      (SELECT account_id FROM messages_rbr rbr) ORDER BY 1 LIMIT 2;
 
@@ -985,7 +985,7 @@ Hello, Zone!  Hello, Region!
 
 # Locality-optimized left outer join reading into a remote region fails.
 retry
-statement error pq: Query has no home region\. Try using a lower LIMIT value or running the query from a different region\.
+statement error pq: Query has no home region\. Try using a lower LIMIT value or running the query from a different region\. For more information, see https://www.cockroachlabs.com/docs/stable/cost-based-optimizer.html#control-whether-queries-are-limited-to-a-single-region
 SELECT rbt.message, rbr.message FROM (SELECT * FROM messages_rbt ORDER BY account_id LIMIT 2) rbt LEFT OUTER LOOKUP JOIN
                     messages_rbr rbr ON rbr.account_id = rbt.account_id LIMIT 2;
 
@@ -998,20 +998,20 @@ SELECT message FROM (SELECT * FROM messages_rbt ORDER BY account_id LIMIT 1) rbt
 # Phase 3, dynamically detect a query's home region.
 # Locality-optimized lookup antijoin should report a query's home region.
 retry
-statement error pq: Query is not running in its home region\. Try running the query from region 'us-east-1'\.
+statement error pq: Query is not running in its home region\. Try running the query from region 'us-east-1'\. For more information, see https://www.cockroachlabs.com/docs/stable/cost-based-optimizer.html#control-whether-queries-are-limited-to-a-single-region
 SELECT message FROM (SELECT * FROM messages_global ORDER BY account_id LIMIT 1) rbg WHERE account_id NOT IN
                      (SELECT account_id FROM messages_rbr rbr) LIMIT 1
 
 # Locality-optimized antijoin reading into a remote region fails.
 retry
-statement error pq: Query has no home region\. Try using a lower LIMIT value or running the query from a different region\.
+statement error pq: Query has no home region\. Try using a lower LIMIT value or running the query from a different region\. For more information, see https://www.cockroachlabs.com/docs/stable/cost-based-optimizer.html#control-whether-queries-are-limited-to-a-single-region
 SELECT message from (SELECT * FROM messages_rbt ORDER BY account_id LIMIT 2) rbt WHERE account_id NOT IN
                      (SELECT account_id FROM messages_rbr rbr) LIMIT 2
 
 # Locality-optimized lookup join with less local rows than the LIMIT errors
 # out.
 retry
-statement error pq: Query has no home region\. Try using a lower LIMIT value or running the query from a different region\.
+statement error pq: Query has no home region\. Try using a lower LIMIT value or running the query from a different region\. For more information, see https://www.cockroachlabs.com/docs/stable/cost-based-optimizer.html#control-whether-queries-are-limited-to-a-single-region
 SELECT rbr.message FROM messages_rbr rbr, messages_rbt rbt WHERE rbr.account_id = rbt.account_id LIMIT 4
 
 # A locality-optimized search of lookup joins reading local rows succeeds.
@@ -1023,14 +1023,14 @@ Hello, Region!
 
 # A locality-optimized search of lookup joins attempting a remote read fails.
 retry
-statement error pq: Query has no home region\. Try using a lower LIMIT value or running the query from a different region\.
+statement error pq: Query has no home region\. Try using a lower LIMIT value or running the query from a different region\. For more information, see https://www.cockroachlabs.com/docs/stable/cost-based-optimizer.html#control-whether-queries-are-limited-to-a-single-region
 SELECT rbr.message FROM messages_rbr rbr INNER LOOKUP JOIN messages_rbt rbt
        ON rbr.account_id = rbt.account_id LIMIT 2
 
 # Run a locality-optimized scan that dynamically detects the home region with
 # tracing.
 retry
-statement error pq: Query is not running in its home region\. Try running the query from region 'ca-central-1'\.
+statement error pq: Query is not running in its home region\. Try running the query from region 'ca-central-1'\. For more information, see https://www.cockroachlabs.com/docs/stable/cost-based-optimizer.html#control-whether-queries-are-limited-to-a-single-region
 SET TRACING = "on", kv, results;
 SELECT * FROM t1 WHERE a=2;
 SET TRACING = off
@@ -1049,14 +1049,14 @@ ORDER BY
     "ordinality" ASC
 ----
 sending batch to (n1,s1):1
-execution failed after 0 rows: Query has no home region. Try using a lower LIMIT value or running the query from a different region.
+execution failed after 0 rows: Query has no home region. Try using a lower LIMIT value or running the query from a different region. For more information, see https://www.cockroachlabs.com/docs/stable/cost-based-optimizer.html#control-whether-queries-are-limited-to-a-single-region
 sending batch to (n1,s1):1
 output row: [2 1 1]
 
 # Run a locality-optimized join that dynamically detects the home region with
 # tracing.
 retry
-statement error pq: Query is not running in its home region\. Try running the query from region 'us-east-1'\.
+statement error pq: Query is not running in its home region\. Try running the query from region 'us-east-1'\. For more information, see https://www.cockroachlabs.com/docs/stable/cost-based-optimizer.html#control-whether-queries-are-limited-to-a-single-region
 SET TRACING = "on", kv, results;
 SELECT rbr.message FROM messages_rbr rbr, (SELECT * FROM messages_global ORDER BY account_id LIMIT 1) rbg
        WHERE rbr.account_id = rbg.account_id LIMIT 1;
@@ -1076,19 +1076,19 @@ ORDER BY
     "ordinality" ASC
 ----
 sending batch to (n1,s1):1
-execution failed after 0 rows: Query has no home region. Try using a lower LIMIT value or running the query from a different region.
+execution failed after 0 rows: Query has no home region. Try using a lower LIMIT value or running the query from a different region. For more information, see https://www.cockroachlabs.com/docs/stable/cost-based-optimizer.html#control-whether-queries-are-limited-to-a-single-region
 sending batch to (n1,s1):1
 output row: [2 1 1]
 sending batch to (n1,s1):1
-output row: ['execution failed after 0 rows: Query has no home region. Try using a lower LIMIT value or running the query from a different region.']
+output row: ['execution failed after 0 rows: Query has no home region. Try using a lower LIMIT value or running the query from a different region. For more information, see https://www.cockroachlabs.com/docs/stable/cost-based-optimizer.html#control-whether-queries-are-limited-to-a-single-region']
 sending batch to (n1,s1):1
 output row: ['output row: [2 1 1]']
 sending batch to (n1,s1):1
 sending batch to (n1,s1):1
-execution failed after 0 rows: Query has no home region. Try using a lower LIMIT value or running the query from a different region.
+execution failed after 0 rows: Query has no home region. Try using a lower LIMIT value or running the query from a different region. For more information, see https://www.cockroachlabs.com/docs/stable/cost-based-optimizer.html#control-whether-queries-are-limited-to-a-single-region
 sending batch to (n1,s1):1
 sending batch to (n1,s1):1
-execution failed after 0 rows: Query has no home region. Try using a lower LIMIT value or running the query from a different region.
+execution failed after 0 rows: Query has no home region. Try using a lower LIMIT value or running the query from a different region. For more information, see https://www.cockroachlabs.com/docs/stable/cost-based-optimizer.html#control-whether-queries-are-limited-to-a-single-region
 sending batch to (n1,s1):1
 sending batch to (n1,s1):1
 output row: ['Hola, Region!']
@@ -1102,7 +1102,7 @@ SAVEPOINT foo
 # Phase 3, dynamically detect a query's home region.
 # An explicit transaction accessing a remote region errors out,
 # and indicates the home region.
-statement error pq: Query is not running in its home region. Try running the query from region 'ca-central-1'\.
+statement error pq: Query is not running in its home region. Try running the query from region 'ca-central-1'\. For more information, see https://www.cockroachlabs.com/docs/stable/cost-based-optimizer.html#control-whether-queries-are-limited-to-a-single-region
 SELECT * FROM t1 WHERE a=2;
 
 # Verify we can still roll back to the savepoint.
@@ -1129,7 +1129,7 @@ SELECT * FROM t1 WHERE a=3;
 # An explicit transaction accessing a remote region errors out,
 # and indicates "Query has no home region" if any rows were read
 # in the transaction already.
-statement error pq: Query has no home region\. Try using a lower LIMIT value or running the query from a different region\.
+statement error pq: Query has no home region\. Try using a lower LIMIT value or running the query from a different region\. For more information, see https://www.cockroachlabs.com/docs/stable/cost-based-optimizer.html#control-whether-queries-are-limited-to-a-single-region
 SELECT * FROM t1 WHERE a=2;
 
 # Verify we can still roll back to the savepoint.

--- a/pkg/roachpb/metadata.go
+++ b/pkg/roachpb/metadata.go
@@ -706,6 +706,19 @@ func (l *Locality) Set(value string) error {
 	return nil
 }
 
+// CopyReplaceKeyValue makes a copy of this locality, replacing any tier in the
+// copy having the specified `key` with the new specified `value`.
+func (l *Locality) CopyReplaceKeyValue(key, value string) Locality {
+	tiers := make([]Tier, len(l.Tiers))
+	for i := range l.Tiers {
+		tiers[i] = l.Tiers[i]
+		if tiers[i].Key == key {
+			tiers[i].Value = value
+		}
+	}
+	return Locality{Tiers: tiers}
+}
+
 // Find searches the locality's tiers for the input key, returning its value if
 // present.
 func (l *Locality) Find(key string) (value string, ok bool) {

--- a/pkg/sql/colflow/vectorized_flow.go
+++ b/pkg/sql/colflow/vectorized_flow.go
@@ -968,6 +968,9 @@ func (s *vectorizedFlowCreator) setupInput(
 			var err error
 			if input.EnforceHomeRegionError != nil {
 				err = input.EnforceHomeRegionError.ErrorDetail(ctx)
+				if flowCtx.EvalCtx.SessionData().EnforceHomeRegionFollowerReadsEnabled {
+					err = execinfra.NewDynamicQueryHasNoHomeRegionError(err)
+				}
 			}
 			sync := colexec.NewSerialUnorderedSynchronizer(inputStreamOps, input.EnforceHomeRegionStreamExclusiveUpperBound, err)
 			opWithMetaInfo = colexecargs.OpWithMetaInfo{

--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -31,6 +31,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descs"
 	"github.com/cockroachdb/cockroach/pkg/sql/clusterunique"
 	"github.com/cockroachdb/cockroach/pkg/sql/contentionpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
 	"github.com/cockroachdb/cockroach/pkg/sql/execstats"
 	"github.com/cockroachdb/cockroach/pkg/sql/isql"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/exec/explain"
@@ -39,6 +40,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/physicalplan"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/asof"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/eval"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
@@ -745,7 +747,42 @@ func (ex *connExecutor) execStmtInOpenState(
 		stmtCtx = ctx
 	}
 
-	if err := ex.dispatchToExecutionEngine(stmtCtx, p, res); err != nil {
+	var rollbackSP *tree.RollbackToSavepoint
+	var r *tree.ReleaseSavepoint
+	enforceHomeRegion := p.EnforceHomeRegion()
+	_, isSelectStmt := stmt.AST.(*tree.Select)
+	if enforceHomeRegion && ex.state.mu.txn.IsOpen() && isSelectStmt {
+		// Create a savepoint at a point before which rows were read so that we can
+		// roll back to it, which will allow the txn to be modified with a
+		// historical timestamp (so that the locality-optimized ops used for error
+		// reporting can run locally and not incur latency). This is currently only
+		// supported for SELECT statements.
+		var b strings.Builder
+		b.WriteString("enforce_home_region_sp")
+		// Add some unprintable ASCII characters to the name of the savepoint to
+		// decrease the likelihood of collision with a user-created savepoint.
+		b.WriteRune(rune(0x11))
+		b.WriteRune(rune(0x12))
+		b.WriteRune(rune(0x13))
+		enforceHomeRegionSavepointName := tree.Name(b.String())
+		s := &tree.Savepoint{Name: enforceHomeRegionSavepointName}
+		var event fsm.Event
+		var eventPayload fsm.EventPayload
+		if event, eventPayload, err = ex.execSavepointInOpenState(ctx, s, res); err != nil {
+			return event, eventPayload, err
+		}
+
+		r = &tree.ReleaseSavepoint{Savepoint: enforceHomeRegionSavepointName}
+		rollbackSP = &tree.RollbackToSavepoint{Savepoint: enforceHomeRegionSavepointName}
+		defer func() {
+			// The default case is to roll back the internally-generated savepoint
+			// after every request. We only need it if a retryable "query has no home
+			// region" error occurs.
+			ex.execRelease(ctx, r, res)
+		}()
+	}
+
+	if err = ex.dispatchToExecutionEngine(stmtCtx, p, res); err != nil {
 		stmtThresholdSpan.Finish()
 		return nil, nil, err
 	}
@@ -769,7 +806,55 @@ func (ex *connExecutor) execStmtInOpenState(
 		}
 	}
 
-	if err := res.Err(); err != nil {
+	if err = res.Err(); err != nil {
+		setErrorAndRestoreLocality := func(err error) {
+			res.SetError(err)
+			// We won't be faking the gateway region any more. Restore the original
+			// locality.
+			p.EvalContext().Locality = p.EvalContext().OriginalLocality
+		}
+		if execinfra.IsDynamicQueryHasNoHomeRegionError(err) {
+			if rollbackSP != nil {
+				// A retryable "query has no home region" error has occurred.
+				// Roll back to the internal savepoint in preparation for the next
+				// planning and execution of this query with a different gateway region
+				// (as considered by the optimizer).
+				p.StmtNoConstantsWithHomeRegionEnforced = p.stmt.StmtNoConstants
+				event, eventPayload := ex.execRollbackToSavepointInOpenState(
+					ctx, rollbackSP, res,
+				)
+				_, isTxnRestart := event.(eventTxnRestart)
+				rollbackToSavepointFailed := !isTxnRestart || eventPayload != nil
+				if ex.implicitTxn() && rollbackToSavepointFailed {
+					err = errors.AssertionFailedf(
+						"unable to roll back to internal savepoint for enforce_home_region",
+					)
+					setErrorAndRestoreLocality(err)
+				} else if rollbackToSavepointFailed || int(ex.state.mu.autoRetryCounter) == len(ex.planner.EvalContext().RemoteRegions) {
+					// If rollback to savepoint in the transaction failed (perhaps because
+					// the txn was aborted) and we're in an explicit transaction, or we
+					// have retried the statement using each remote region as a fake
+					// gateway region, then give up and return the generic "query has no
+					// home region" error message.
+					err = execinfra.MaybeGetNonRetryableDynamicQueryHasNoHomeRegionError(err)
+					setErrorAndRestoreLocality(err)
+				}
+			} else {
+				err = execinfra.MaybeGetNonRetryableDynamicQueryHasNoHomeRegionError(err)
+				setErrorAndRestoreLocality(err)
+			}
+		} else if execinfra.IsDynamicQueryHasNoHomeRegionError(ex.state.mu.autoRetryReason) {
+			// If we are retrying a dynamic "query has no home region" error and
+			// we get a different error message when executing with locality-optimized
+			// ops using a different local region (for example, relation does not
+			// exist, due to the AOST read), return the original error message in
+			// non-retryable form.
+			errorMessage := err.Error()
+			if !strings.HasPrefix(errorMessage, execinfra.QueryNotRunningInHomeRegionMessagePrefix) {
+				err = execinfra.MaybeGetNonRetryableDynamicQueryHasNoHomeRegionError(ex.state.mu.autoRetryReason)
+				setErrorAndRestoreLocality(err)
+			}
+		}
 		return makeErrEvent(err)
 	}
 
@@ -798,6 +883,7 @@ func (ex *connExecutor) execStmtInOpenState(
 // handleAOST gets the AsOfSystemTime clause from the statement, and sets
 // the timestamps of the transaction accordingly.
 func (ex *connExecutor) handleAOST(ctx context.Context, stmt tree.Statement) error {
+	p := &ex.planner
 	if _, isNoTxn := ex.machine.CurState().(stateNoTxn); isNoTxn {
 		if _, ok := stmt.(*tree.ShowCommitTimestamp); ok {
 			return nil
@@ -805,8 +891,24 @@ func (ex *connExecutor) handleAOST(ctx context.Context, stmt tree.Statement) err
 		return errors.AssertionFailedf(
 			"cannot handle AOST clause without a transaction",
 		)
+	} else if execinfra.IsDynamicQueryHasNoHomeRegionError(ex.state.mu.autoRetryReason) {
+		asOfClause := tree.AsOfClause{Expr: followerReadTimestampExpr}
+		// Set the timestamp used by current_timestamp().
+		asOf, err := p.EvalAsOfTimestamp(ctx, asOfClause, asof.OptionAllowBoundedStaleness)
+		if err != nil {
+			return errors.AssertionFailedf(
+				"problem evaluating follower read timestamp for enforce_home_region dynamic error checking",
+			)
+		}
+		// Set up AOST in the txn so re-running of the query with different possible
+		// home regions does not have to read rows from remote regions.
+		p.extendedEvalCtx.SetTxnTimestamp(asOf.Timestamp.GoTime())
+		if err := ex.state.setHistoricalTimestamp(ctx, asOf.Timestamp); err != nil {
+			return errors.AssertionFailedf(
+				"problem setting follower read timestamp for enforce_home_region dynamic error checking",
+			)
+		}
 	}
-	p := &ex.planner
 	asOf, err := p.isAsOf(ctx, stmt)
 	if err != nil {
 		return err
@@ -1321,6 +1423,35 @@ func (ex *connExecutor) dispatchToExecutionEngine(
 
 	if limitsErr := ex.handleTxnRowsWrittenReadLimits(ctx); limitsErr != nil && res.Err() == nil {
 		res.SetError(limitsErr)
+	}
+	if res.Err() == nil && err == nil {
+		autoRetryReason := ex.state.mu.autoRetryReason
+		if execinfra.IsDynamicQueryHasNoHomeRegionError(autoRetryReason) {
+			if homeRegion, ok := planner.EvalContext().Locality.Find("region"); ok &&
+				planner.StmtNoConstantsWithHomeRegionEnforced == planner.stmt.StmtNoConstants {
+				// If this is the same query as ran when the dynamic "query has no home
+				// region" error occurred, but this time it didn't error out, report
+				// back the query's home region.
+				err = pgerror.Newf(pgcode.QueryNotRunningInHomeRegion,
+					`%s. Try running the query from region '%s'.`,
+					execinfra.QueryNotRunningInHomeRegionMessagePrefix,
+					homeRegion,
+				)
+				res.SetError(err)
+				// We won't be faking the gateway region any more. Restore the original
+				// locality.
+				planner.EvalContext().Locality = planner.EvalContext().OriginalLocality
+				return nil
+			}
+			// If for some reason we're not running the same query as before, report
+			// the original "query has no home region" error in non-retryable form.
+			err = execinfra.MaybeGetNonRetryableDynamicQueryHasNoHomeRegionError(autoRetryReason)
+			res.SetError(err)
+			// We won't be faking the gateway region any more. Restore the original
+			// locality.
+			planner.EvalContext().Locality = planner.EvalContext().OriginalLocality
+			return nil
+		}
 	}
 
 	return err

--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -1433,9 +1433,10 @@ func (ex *connExecutor) dispatchToExecutionEngine(
 				// region" error occurred, but this time it didn't error out, report
 				// back the query's home region.
 				err = pgerror.Newf(pgcode.QueryNotRunningInHomeRegion,
-					`%s. Try running the query from region '%s'.`,
+					`%s. Try running the query from region '%s'. %s`,
 					execinfra.QueryNotRunningInHomeRegionMessagePrefix,
 					homeRegion,
+					sqlerrors.EnforceHomeRegionFurtherInfo,
 				)
 				res.SetError(err)
 				// We won't be faking the gateway region any more. Restore the original

--- a/pkg/sql/distsql/server.go
+++ b/pkg/sql/distsql/server.go
@@ -352,6 +352,7 @@ func (ds *ServerImpl) setupFlow(
 			ReCache:                   ds.regexpCache,
 			ToCharFormatCache:         ds.toCharFormatCache,
 			Locality:                  ds.ServerConfig.Locality,
+			OriginalLocality:          ds.ServerConfig.Locality,
 			Tracer:                    ds.ServerConfig.Tracer,
 			Planner:                   &faketreeeval.DummyEvalPlanner{Monitor: monitor},
 			StreamManagerFactory:      &faketreeeval.DummyStreamManagerFactory{},

--- a/pkg/sql/distsql_physical_planner.go
+++ b/pkg/sql/distsql_physical_planner.go
@@ -49,6 +49,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondatapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/span"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlerrors"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlinstance"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util/buildutil"
@@ -4026,7 +4027,9 @@ func (dsp *DistSQLPlanner) createPlanForSetOp(
 				serialStreamErrorSpec.SerialInputIdxExclusiveUpperBound = 1
 				serialStreamErrorSpec.ExceedsInputIdxExclusiveUpperBoundError =
 					pgerror.Newf(pgcode.QueryHasNoHomeRegion,
-						"Query has no home region. Try using a lower LIMIT value or running the query from a different region.")
+						"Query has no home region. Try using a lower LIMIT value or running the query from a different region. %s",
+						sqlerrors.EnforceHomeRegionFurtherInfo,
+					)
 			}
 			// With UNION ALL, we can end up with multiple streams on the same node.
 			// We don't want to have unnecessary routers and cross-node streams, so

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -3462,6 +3462,10 @@ func (m *sessionDataMutator) SetInjectRetryErrorsOnCommitEnabled(val bool) {
 	m.data.InjectRetryErrorsOnCommitEnabled = val
 }
 
+func (m *sessionDataMutator) SetEnforceHomeRegionFollowerReadsEnabled(val bool) {
+	m.data.EnforceHomeRegionFollowerReadsEnabled = val
+}
+
 // Utility functions related to scrubbing sensitive information on SQL Stats.
 
 // quantizeCounts ensures that the Count field in the

--- a/pkg/sql/execinfra/BUILD.bazel
+++ b/pkg/sql/execinfra/BUILD.bazel
@@ -7,6 +7,7 @@ go_library(
     name = "execinfra",
     srcs = [
         "base.go",
+        "errors.go",
         "flow_context.go",
         "metrics.go",
         "outboxbase.go",

--- a/pkg/sql/execinfra/errors.go
+++ b/pkg/sql/execinfra/errors.go
@@ -1,0 +1,92 @@
+// Copyright 2023 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package execinfra
+
+import "github.com/cockroachdb/errors"
+
+// QueryNotRunningInHomeRegionMessagePrefix is the common message prefix for
+// erroring out queries with no home region when the enforce_home_region session
+// flag is set.
+const QueryNotRunningInHomeRegionMessagePrefix = "Query is not running in its home region"
+
+// dynamicQueryHasNoHomeRegionError is a wrapper for a
+// "query has no home region" error to flag the query as retryable.
+type dynamicQueryHasNoHomeRegionError struct {
+	err error
+}
+
+// NewDynamicQueryHasNoHomeRegionError returns a dynamic no home region error
+// wrapping the original error. This error triggers a transaction retry.
+func NewDynamicQueryHasNoHomeRegionError(err error) error {
+	return &dynamicQueryHasNoHomeRegionError{err: err}
+}
+
+// dynamicQueryHasNoHomeRegionError implements the error interface.
+func (e *dynamicQueryHasNoHomeRegionError) Error() string {
+	return e.err.Error()
+}
+
+// Cause returns the wrapped error inside this error.
+func (e *dynamicQueryHasNoHomeRegionError) Cause() error {
+	return e.err
+}
+
+// ClientVisibleRetryError is detected by the pgwire layer and will convert
+// this error into an error to be retried. See pgcode.ClientVisibleRetryError.
+func (e *dynamicQueryHasNoHomeRegionError) ClientVisibleRetryError() {}
+
+// IsDynamicQueryHasNoHomeRegionError tests if `err` is a
+// dynamicQueryHasNoHomeRegionError.
+func IsDynamicQueryHasNoHomeRegionError(err error) bool {
+	if err == nil {
+		return false
+	}
+	for {
+		// If the error is not a `dynamicQueryHasNoHomeRegionError`, unwrap the
+		// root cause.
+		if !errors.HasType(err, (*dynamicQueryHasNoHomeRegionError)(nil)) {
+			err = errors.UnwrapOnce(err)
+			if err == nil {
+				break
+			}
+			continue
+		}
+		break
+	}
+	nhrErr := (*dynamicQueryHasNoHomeRegionError)(nil)
+	return errors.As(err, &nhrErr)
+}
+
+// MaybeGetNonRetryableDynamicQueryHasNoHomeRegionError tests if `err` is a
+// dynamicQueryHasNoHomeRegionError. If it is, it returns the error embedded
+// in this structure (which should be a non-retryable error), otherwise returns
+// the original error.
+func MaybeGetNonRetryableDynamicQueryHasNoHomeRegionError(err error) error {
+	if err == nil {
+		return nil
+	}
+	for {
+		// If the error is not a `dynamicQueryHasNoHomeRegionError`, unwrap the
+		// root cause.
+		if !errors.HasType(err, (*dynamicQueryHasNoHomeRegionError)(nil)) {
+			err = errors.UnwrapOnce(err)
+			if err == nil {
+				break
+			}
+			continue
+		}
+		break
+	}
+	if errors.HasType(err, (*dynamicQueryHasNoHomeRegionError)(nil)) {
+		return errors.UnwrapOnce(err)
+	}
+	return err
+}

--- a/pkg/sql/faketreeeval/evalctx.go
+++ b/pkg/sql/faketreeeval/evalctx.go
@@ -469,6 +469,11 @@ func (ep *DummyEvalPlanner) IsANSIDML() bool {
 	return false
 }
 
+// EnforceHomeRegion is part of the eval.Planner interface.
+func (ep *DummyEvalPlanner) EnforceHomeRegion() bool {
+	return false
+}
+
 // GetRangeDescByID is part of the eval.Planner interface.
 func (ep *DummyEvalPlanner) GetRangeDescByID(
 	context.Context, roachpb.RangeID,

--- a/pkg/sql/logictest/testdata/logic_test/information_schema
+++ b/pkg/sql/logictest/testdata/logic_test/information_schema
@@ -4971,6 +4971,7 @@ enable_seqscan                                        on
 enable_super_regions                                  off
 enable_zigzag_join                                    on
 enforce_home_region                                   off
+enforce_home_region_follower_reads_enabled            off
 escape_string_warning                                 on
 expect_and_ignore_not_visible_columns_in_copy         off
 experimental_computed_column_rewrites                 ·

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -2605,6 +2605,7 @@ enable_seqscan                                        on                  NULL  
 enable_super_regions                                  off                 NULL      NULL        NULL        string
 enable_zigzag_join                                    on                  NULL      NULL        NULL        string
 enforce_home_region                                   off                 NULL      NULL        NULL        string
+enforce_home_region_follower_reads_enabled            off                 NULL      NULL        NULL        string
 escape_string_warning                                 on                  NULL      NULL        NULL        string
 expect_and_ignore_not_visible_columns_in_copy         off                 NULL      NULL        NULL        string
 experimental_distsql_planning                         off                 NULL      NULL        NULL        string
@@ -2751,6 +2752,7 @@ enable_seqscan                                        on                  NULL  
 enable_super_regions                                  off                 NULL  user     NULL      off                 off
 enable_zigzag_join                                    on                  NULL  user     NULL      on                  on
 enforce_home_region                                   off                 NULL  user     NULL      off                 off
+enforce_home_region_follower_reads_enabled            off                 NULL  user     NULL      off                 off
 escape_string_warning                                 on                  NULL  user     NULL      on                  on
 expect_and_ignore_not_visible_columns_in_copy         off                 NULL  user     NULL      off                 off
 experimental_distsql_planning                         off                 NULL  user     NULL      off                 off
@@ -2895,6 +2897,7 @@ enable_seqscan                                        NULL    NULL     NULL     
 enable_super_regions                                  NULL    NULL     NULL     NULL        NULL
 enable_zigzag_join                                    NULL    NULL     NULL     NULL        NULL
 enforce_home_region                                   NULL    NULL     NULL     NULL        NULL
+enforce_home_region_follower_reads_enabled            NULL    NULL     NULL     NULL        NULL
 escape_string_warning                                 NULL    NULL     NULL     NULL        NULL
 expect_and_ignore_not_visible_columns_in_copy         NULL    NULL     NULL     NULL        NULL
 experimental_distsql_planning                         NULL    NULL     NULL     NULL        NULL

--- a/pkg/sql/logictest/testdata/logic_test/show_source
+++ b/pkg/sql/logictest/testdata/logic_test/show_source
@@ -67,6 +67,7 @@ enable_seqscan                                        on
 enable_super_regions                                  off
 enable_zigzag_join                                    on
 enforce_home_region                                   off
+enforce_home_region_follower_reads_enabled            off
 escape_string_warning                                 on
 expect_and_ignore_not_visible_columns_in_copy         off
 experimental_distsql_planning                         off

--- a/pkg/sql/opt/exec/execbuilder/BUILD.bazel
+++ b/pkg/sql/opt/exec/execbuilder/BUILD.bazel
@@ -43,6 +43,7 @@ go_library(
         "//pkg/sql/sem/tree/treecmp",
         "//pkg/sql/sem/tree/treewindow",
         "//pkg/sql/sem/volatility",
+        "//pkg/sql/sqlerrors",
         "//pkg/sql/sqltelemetry",
         "//pkg/sql/types",
         "//pkg/util",

--- a/pkg/sql/opt/exec/execbuilder/BUILD.bazel
+++ b/pkg/sql/opt/exec/execbuilder/BUILD.bazel
@@ -18,6 +18,7 @@ go_library(
         "//pkg/server/telemetry",
         "//pkg/sql/catalog/colinfo",
         "//pkg/sql/catalog/descpb",
+        "//pkg/sql/execinfra",
         "//pkg/sql/lexbase",
         "//pkg/sql/mutations",
         "//pkg/sql/opt",

--- a/pkg/sql/opt/exec/execbuilder/relational.go
+++ b/pkg/sql/opt/exec/execbuilder/relational.go
@@ -20,6 +20,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/server/telemetry"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/colinfo"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/cat"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/constraint"
@@ -1913,7 +1914,8 @@ func (b *Builder) enforceScanWithHomeRegion(skipID cat.StableID) error {
 					firstTable)
 			} else if gatewayRegion != homeRegion {
 				return pgerror.Newf(pgcode.QueryNotRunningInHomeRegion,
-					`Query is not running in its home region. Try running the query from region '%s'.`,
+					`%s. Try running the query from region '%s'.`,
+					execinfra.QueryNotRunningInHomeRegionMessagePrefix,
 					homeRegion,
 				)
 			}
@@ -1978,8 +1980,8 @@ func (b *Builder) buildDistribute(distribute *memo.DistributeExpr) (input execPl
 		var errCode pgcode.Code
 		if ok {
 			errCode = pgcode.QueryNotRunningInHomeRegion
-			errorStringBuilder.WriteString("Query is not running in its home region.")
-			errorStringBuilder.WriteString(fmt.Sprintf(` Try running the query from region '%s'.`, homeRegion))
+			errorStringBuilder.WriteString(execinfra.QueryNotRunningInHomeRegionMessagePrefix)
+			errorStringBuilder.WriteString(fmt.Sprintf(`. Try running the query from region '%s'.`, homeRegion))
 		} else if distribute.Input.Op() != opt.LookupJoinOp {
 			// More detailed error message handling for lookup join occurs in the
 			// execbuilder.
@@ -2214,7 +2216,8 @@ func (b *Builder) handleRemoteLookupJoinError(join *memo.LookupJoinExpr) (err er
 					)
 				} else if gatewayRegion != homeRegion {
 					return pgerror.Newf(pgcode.QueryNotRunningInHomeRegion,
-						`Query is not running in its home region. Try running the query from region '%s'.`,
+						`%s. Try running the query from region '%s'.`,
+						execinfra.QueryNotRunningInHomeRegionMessagePrefix,
 						homeRegion,
 					)
 				}
@@ -2445,7 +2448,8 @@ func (b *Builder) handleRemoteInvertedJoinError(join *memo.InvertedJoinExpr) (er
 					)
 				} else if gatewayRegion != homeRegion {
 					return pgerror.Newf(pgcode.QueryNotRunningInHomeRegion,
-						`Query is not running in its home region. Try running the query from region '%s'.`,
+						`%s. Try running the query from region '%s'.`,
+						execinfra.QueryNotRunningInHomeRegionMessagePrefix,
 						homeRegion,
 					)
 				}

--- a/pkg/sql/opt/exec/execbuilder/relational.go
+++ b/pkg/sql/opt/exec/execbuilder/relational.go
@@ -38,6 +38,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/eval"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree/treewindow"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlerrors"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqltelemetry"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util"
@@ -1856,12 +1857,14 @@ func (b *Builder) enforceScanWithHomeRegion(skipID cat.StableID) error {
 	for _, scan := range b.builtScans {
 		if scan.Distribution.Any() {
 			return pgerror.Newf(pgcode.QueryHasNoHomeRegion,
-				"Query has no home region. Try accessing only tables defined in multi-region databases.")
+				"Query has no home region. Try accessing only tables defined in multi-region databases. %s",
+				sqlerrors.EnforceHomeRegionFurtherInfo)
 		}
 		if len(scan.Distribution.Regions) > 1 {
 			if scan.Table == opt.TableID(0) {
 				return pgerror.Newf(pgcode.QueryHasNoHomeRegion,
-					"Query has no home region. Try adding a LIMIT clause.")
+					"Query has no home region. Try adding a LIMIT clause. %s",
+					sqlerrors.EnforceHomeRegionFurtherInfo)
 			}
 			moreThanOneRegionScans = append(moreThanOneRegionScans, scan)
 		} else {
@@ -1884,7 +1887,8 @@ func (b *Builder) enforceScanWithHomeRegion(skipID cat.StableID) error {
 	}
 	if len(regionSet) > 2 {
 		return pgerror.Newf(pgcode.QueryHasNoHomeRegion,
-			"Query has no home region. Try adding a LIMIT clause.")
+			"Query has no home region. Try adding a LIMIT clause. %s",
+			sqlerrors.EnforceHomeRegionFurtherInfo)
 	}
 	for i, scan := range b.builtScans {
 		inputTableMeta := scan.Memo().Metadata().TableMeta(scan.Table)
@@ -1907,16 +1911,18 @@ func (b *Builder) enforceScanWithHomeRegion(skipID cat.StableID) error {
 		if queryHasHomeRegion {
 			if homeRegion != queryHomeRegion {
 				return pgerror.Newf(pgcode.QueryHasNoHomeRegion,
-					`Query has no home region. The home region ('%s') of operation on table '%s' does not match the home region ('%s') of operation on table '%s'.`,
+					`Query has no home region. The home region ('%s') of operation on table '%s' does not match the home region ('%s') of operation on table '%s'. %s`,
 					queryHomeRegion,
 					inputTableName,
 					homeRegion,
-					firstTable)
+					firstTable,
+					sqlerrors.EnforceHomeRegionFurtherInfo)
 			} else if gatewayRegion != homeRegion {
 				return pgerror.Newf(pgcode.QueryNotRunningInHomeRegion,
-					`%s. Try running the query from region '%s'.`,
+					`%s. Try running the query from region '%s'. %s`,
 					execinfra.QueryNotRunningInHomeRegionMessagePrefix,
 					homeRegion,
+					sqlerrors.EnforceHomeRegionFurtherInfo,
 				)
 			}
 		} else {
@@ -1981,7 +1987,7 @@ func (b *Builder) buildDistribute(distribute *memo.DistributeExpr) (input execPl
 		if ok {
 			errCode = pgcode.QueryNotRunningInHomeRegion
 			errorStringBuilder.WriteString(execinfra.QueryNotRunningInHomeRegionMessagePrefix)
-			errorStringBuilder.WriteString(fmt.Sprintf(`. Try running the query from region '%s'.`, homeRegion))
+			errorStringBuilder.WriteString(fmt.Sprintf(`. Try running the query from region '%s'. %s`, homeRegion, sqlerrors.EnforceHomeRegionFurtherInfo))
 		} else if distribute.Input.Op() != opt.LookupJoinOp {
 			// More detailed error message handling for lookup join occurs in the
 			// execbuilder.
@@ -1990,7 +1996,8 @@ func (b *Builder) buildDistribute(distribute *memo.DistributeExpr) (input execPl
 			} else {
 				errCode = pgcode.QueryHasNoHomeRegion
 				errorStringBuilder.WriteString("Query has no home region.")
-				errorStringBuilder.WriteString(` Try adding a LIMIT clause.`)
+				errorStringBuilder.WriteString(` Try adding a LIMIT clause. `)
+				errorStringBuilder.WriteString(sqlerrors.EnforceHomeRegionFurtherInfo)
 			}
 		}
 		if err == nil {
@@ -2106,14 +2113,15 @@ func (b *Builder) filterSuggestionError(
 				plural = "s"
 			}
 			tableName := tableMeta.Alias.Table()
-			args := make([]interface{}, 0, 8)
+			args := make([]interface{}, 0, 9)
 			args = append(args, tableName)
 			args = append(args, crdbRegionColName)
 			args = append(args, plural)
 			args = append(args, b.indexColumnNames(tableMeta, index, 1))
-			if table2 == nil {
+			if table2 == nil || table2Meta.Alias.Table() == tableName {
+				args = append(args, sqlerrors.EnforceHomeRegionFurtherInfo)
 				err = pgerror.Newf(pgcode.QueryHasNoHomeRegion,
-					"Query has no home region. Try adding a filter on %s.%s and/or on key column%s (%s).", args...)
+					"Query has no home region. Try adding a filter on %s.%s and/or on key column%s (%s). %s", args...)
 			} else if crdbRegionColName2, ok := table2.HomeRegionColName(); ok {
 				index = table2.Index(indexOrdinal2)
 				plural = ""
@@ -2125,8 +2133,9 @@ func (b *Builder) filterSuggestionError(
 				args = append(args, crdbRegionColName2)
 				args = append(args, plural)
 				args = append(args, b.indexColumnNames(table2Meta, index, 1))
+				args = append(args, sqlerrors.EnforceHomeRegionFurtherInfo)
 				err = pgerror.Newf(pgcode.QueryHasNoHomeRegion,
-					"Query has no home region. Try adding a filter on %s.%s and/or on key column%s (%s). Try adding a filter on %s.%s and/or on key column%s (%s).", args...)
+					"Query has no home region. Try adding a filter on %s.%s and/or on key column%s (%s). Try adding a filter on %s.%s and/or on key column%s (%s). %s", args...)
 			}
 		}
 	}
@@ -2201,24 +2210,27 @@ func (b *Builder) handleRemoteLookupJoinError(join *memo.LookupJoinExpr) (err er
 				if homeRegion != queryHomeRegion {
 					if inputTableName == "" {
 						return pgerror.Newf(pgcode.QueryHasNoHomeRegion,
-							`Query has no home region. The home region ('%s') of lookup table '%s' does not match the home region ('%s') of the other relation in the join.'`,
+							`Query has no home region. The home region ('%s') of lookup table '%s' does not match the home region ('%s') of the other relation in the join. %s'`,
 							homeRegion,
 							lookupTable.Name(),
 							queryHomeRegion,
+							sqlerrors.EnforceHomeRegionFurtherInfo,
 						)
 					}
 					return pgerror.Newf(pgcode.QueryHasNoHomeRegion,
-						`Query has no home region. The home region ('%s') of table '%s' does not match the home region ('%s') of lookup table '%s'.`,
+						`Query has no home region. The home region ('%s') of table '%s' does not match the home region ('%s') of lookup table '%s'. %s`,
 						queryHomeRegion,
 						inputTableName,
 						homeRegion,
 						string(lookupTable.Name()),
+						sqlerrors.EnforceHomeRegionFurtherInfo,
 					)
 				} else if gatewayRegion != homeRegion {
 					return pgerror.Newf(pgcode.QueryNotRunningInHomeRegion,
-						`%s. Try running the query from region '%s'.`,
+						`%s. Try running the query from region '%s'. %s`,
 						execinfra.QueryNotRunningInHomeRegionMessagePrefix,
 						homeRegion,
+						sqlerrors.EnforceHomeRegionFurtherInfo,
 					)
 				}
 			} else {
@@ -2433,24 +2445,27 @@ func (b *Builder) handleRemoteInvertedJoinError(join *memo.InvertedJoinExpr) (er
 				if homeRegion != queryHomeRegion {
 					if inputTableName == "" {
 						return pgerror.Newf(pgcode.QueryHasNoHomeRegion,
-							`Query has no home region. The home region ('%s') of lookup table '%s' does not match the home region ('%s') of the other relation in the join.'`,
+							`Query has no home region. The home region ('%s') of lookup table '%s' does not match the home region ('%s') of the other relation in the join. %s`,
 							homeRegion,
 							lookupTable.Name(),
 							queryHomeRegion,
+							sqlerrors.EnforceHomeRegionFurtherInfo,
 						)
 					}
 					return pgerror.Newf(pgcode.QueryHasNoHomeRegion,
-						`Query has no home region. The home region ('%s') of table '%s' does not match the home region ('%s') of lookup table '%s'.`,
+						`Query has no home region. The home region ('%s') of table '%s' does not match the home region ('%s') of lookup table '%s'. %s`,
 						queryHomeRegion,
 						inputTableName,
 						homeRegion,
 						string(lookupTable.Name()),
+						sqlerrors.EnforceHomeRegionFurtherInfo,
 					)
 				} else if gatewayRegion != homeRegion {
 					return pgerror.Newf(pgcode.QueryNotRunningInHomeRegion,
-						`%s. Try running the query from region '%s'.`,
+						`%s. Try running the query from region '%s'. %s`,
 						execinfra.QueryNotRunningInHomeRegionMessagePrefix,
 						homeRegion,
+						sqlerrors.EnforceHomeRegionFurtherInfo,
 					)
 				}
 			} else {

--- a/pkg/sql/opt/metadata_test.go
+++ b/pkg/sql/opt/metadata_test.go
@@ -463,6 +463,11 @@ func (f *fakeGetMultiregionConfigPlanner) IsANSIDML() bool {
 	return false
 }
 
+// EnforceHomeRegion is part of the eval.Planner interface.
+func (f *fakeGetMultiregionConfigPlanner) EnforceHomeRegion() bool {
+	return false
+}
+
 // GetRangeDescByID is part of the eval.Planner interface.
 func (ep *fakeGetMultiregionConfigPlanner) GetRangeDescByID(
 	context.Context, roachpb.RangeID,

--- a/pkg/sql/opt/optbuilder/BUILD.bazel
+++ b/pkg/sql/opt/optbuilder/BUILD.bazel
@@ -50,6 +50,7 @@ go_library(
     deps = [
         "//pkg/server/telemetry",
         "//pkg/settings",
+        "//pkg/sql/catalog/catpb",
         "//pkg/sql/catalog/colinfo",
         "//pkg/sql/catalog/descpb",
         "//pkg/sql/catalog/funcinfo",

--- a/pkg/sql/opt/optbuilder/select.go
+++ b/pkg/sql/opt/optbuilder/select.go
@@ -30,6 +30,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/asof"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/eval"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlerrors"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqltelemetry"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util/errorutil/unimplemented"
@@ -463,12 +464,14 @@ func errorOnInvalidMultiregionDB(
 	survivalGoal, ok := tabMeta.GetDatabaseSurvivalGoal(ctx, evalCtx.Planner)
 	// non-multiregional database or SURVIVE REGION FAILURE option
 	if !ok {
-		err := pgerror.New(pgcode.QueryHasNoHomeRegion,
-			"Query has no home region. Try accessing only tables in multi-region databases with ZONE survivability.")
+		err := pgerror.Newf(pgcode.QueryHasNoHomeRegion,
+			"Query has no home region. Try accessing only tables in multi-region databases with ZONE survivability. %s",
+			sqlerrors.EnforceHomeRegionFurtherInfo)
 		panic(err)
 	} else if survivalGoal == descpb.SurvivalGoal_REGION_FAILURE {
-		err := pgerror.New(pgcode.QueryHasNoHomeRegion,
-			"The enforce_home_region setting cannot be combined with REGION survivability. Try accessing only tables in multi-region databases with ZONE survivability.")
+		err := pgerror.Newf(pgcode.QueryHasNoHomeRegion,
+			"The enforce_home_region setting cannot be combined with REGION survivability. Try accessing only tables in multi-region databases with ZONE survivability. %s",
+			sqlerrors.EnforceHomeRegionFurtherInfo)
 		panic(err)
 	}
 }

--- a/pkg/sql/opt/props/physical/BUILD.bazel
+++ b/pkg/sql/opt/props/physical/BUILD.bazel
@@ -19,6 +19,7 @@ go_library(
         "//pkg/sql/pgwire/pgcode",
         "//pkg/sql/pgwire/pgerror",
         "//pkg/sql/sem/eval",
+        "//pkg/sql/sqlerrors",
     ],
 )
 

--- a/pkg/sql/opt/props/physical/distribution.go
+++ b/pkg/sql/opt/props/physical/distribution.go
@@ -22,6 +22,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/eval"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlerrors"
 )
 
 // Distribution represents the physical distribution of data for a relational
@@ -190,8 +191,9 @@ func (d *Distribution) FromIndexScan(
 			// distribution is all regions in the database.
 			regionsNames, ok := tabMeta.GetRegionsInDatabase(ctx, evalCtx.Planner)
 			if !ok && evalCtx.Planner != nil && evalCtx.Planner.EnforceHomeRegion() {
-				err := pgerror.New(pgcode.QueryHasNoHomeRegion,
-					"Query has no home region. Try accessing only tables defined in multi-region databases.")
+				err := pgerror.Newf(pgcode.QueryHasNoHomeRegion,
+					"Query has no home region. Try accessing only tables defined in multi-region databases. %s",
+					sqlerrors.EnforceHomeRegionFurtherInfo)
 				panic(err)
 			}
 			if ok {

--- a/pkg/sql/opt/props/physical/distribution.go
+++ b/pkg/sql/opt/props/physical/distribution.go
@@ -189,7 +189,7 @@ func (d *Distribution) FromIndexScan(
 			// If the above methods failed to find a distribution, then the
 			// distribution is all regions in the database.
 			regionsNames, ok := tabMeta.GetRegionsInDatabase(ctx, evalCtx.Planner)
-			if !ok && evalCtx.SessionData().EnforceHomeRegion && evalCtx.Planner != nil && evalCtx.Planner.IsANSIDML() {
+			if !ok && evalCtx.Planner != nil && evalCtx.Planner.EnforceHomeRegion() {
 				err := pgerror.New(pgcode.QueryHasNoHomeRegion,
 					"Query has no home region. Try accessing only tables defined in multi-region databases.")
 				panic(err)

--- a/pkg/sql/opt/testutils/opttester/opt_tester.go
+++ b/pkg/sql/opt/testutils/opttester/opt_tester.go
@@ -568,6 +568,7 @@ func (ot *OptTester) RunCommand(tb testing.TB, d *datadriven.TestData) string {
 
 	ot.evalCtx.TestingKnobs.OptimizerCostPerturbation = ot.Flags.PerturbCost
 	ot.evalCtx.Locality = ot.Flags.Locality
+	ot.evalCtx.OriginalLocality = ot.Flags.Locality
 	ot.evalCtx.Placeholders = nil
 
 	switch d.Cmd {

--- a/pkg/sql/opt/xform/coster.go
+++ b/pkg/sql/opt/xform/coster.go
@@ -731,7 +731,7 @@ func (c *coster) computeDistributeCost(
 			return c.distributionCost(source)
 		}
 	}
-	if c.evalCtx != nil && c.evalCtx.SessionData().EnforceHomeRegion && c.evalCtx.Planner.IsANSIDML() {
+	if c.evalCtx != nil && c.evalCtx.Planner.EnforceHomeRegion() {
 		if distribute.HasHomeRegion() {
 			// Query plans with a home region are favored over those without one.
 			return LargeDistributeCostWithHomeRegion
@@ -882,7 +882,7 @@ func (c *coster) distributionCost(regionsAccessed physical.Distribution) (cost m
 		// that case to try and avoid the distribution anyway.
 		extraCost = memo.Cost(SmallDistributeCost)
 	} else if !regionsAccessed.Any() && c.evalCtx != nil &&
-		c.evalCtx.SessionData().EnforceHomeRegion && c.evalCtx.Planner.IsANSIDML() {
+		c.evalCtx.Planner.EnforceHomeRegion() {
 		if len(regionsAccessed.Regions) == 1 {
 			// Query plans with a home region are favored over those without one.
 			extraCost = LargeDistributeCostWithHomeRegion

--- a/pkg/sql/plan_opt.go
+++ b/pkg/sql/plan_opt.go
@@ -363,8 +363,11 @@ func (opc *optPlanningCtx) reset(ctx context.Context) {
 		// descriptor versions are bumped at most once per transaction, even if there
 		// are multiple DDL operations; and transactions can be aborted leading to
 		// potential reuse of versions. To avoid these issues, we prevent saving a
-		// memo (for prepare) or reusing a saved memo (for execute).
-		opc.allowMemoReuse = !p.Descriptors().HasUncommittedTables()
+		// memo (for prepare) or reusing a saved memo (for execute). If
+		// RemoteRegions is set in the eval context we're building a memo for the
+		// purposes of generating the proper error message, and memo reuse or
+		// caching should not be done.
+		opc.allowMemoReuse = !p.Descriptors().HasUncommittedTables() && len(p.EvalContext().RemoteRegions) == 0
 		opc.useCache = opc.allowMemoReuse && queryCacheEnabled.Get(&p.execCfg.Settings.SV)
 
 		if _, isCanned := p.stmt.AST.(*tree.CannedOptPlan); isCanned {

--- a/pkg/sql/planner.go
+++ b/pkg/sql/planner.go
@@ -122,6 +122,7 @@ func (evalCtx *extendedEvalContext) copyFromExecCfg(execCfg *ExecutorConfig) {
 	evalCtx.ClusterName = execCfg.RPCContext.ClusterName()
 	evalCtx.NodeID = execCfg.NodeInfo.NodeID
 	evalCtx.Locality = execCfg.Locality
+	evalCtx.OriginalLocality = execCfg.Locality
 	evalCtx.NodesStatusServer = execCfg.NodesStatusServer
 	evalCtx.TenantStatusServer = execCfg.TenantStatusServer
 	evalCtx.SQLStatusServer = execCfg.SQLStatusServer
@@ -175,6 +176,10 @@ type planner struct {
 
 	// Corresponding Statement for this query.
 	stmt Statement
+
+	// StmtWithHomeRegionEnforced, if non-nil is the SQL statement for which a
+	// home region is being enforced.
+	StmtNoConstantsWithHomeRegionEnforced string
 
 	instrumentation instrumentationHelper
 
@@ -388,6 +393,7 @@ func newInternalPlanner(
 	p.extendedEvalCtx.ClusterName = execCfg.RPCContext.ClusterName()
 	p.extendedEvalCtx.NodeID = execCfg.NodeInfo.NodeID
 	p.extendedEvalCtx.Locality = execCfg.Locality
+	p.extendedEvalCtx.OriginalLocality = execCfg.Locality
 
 	p.sessionDataMutatorIterator = smi
 	p.autoCommit = false

--- a/pkg/sql/region_util.go
+++ b/pkg/sql/region_util.go
@@ -2394,6 +2394,11 @@ func (p *planner) IsANSIDML() bool {
 	return p.stmt.IsANSIDML()
 }
 
+// EnforceHomeRegion is part of the eval.Planner interface.
+func (p *planner) EnforceHomeRegion() bool {
+	return p.EvalContext().SessionData().EnforceHomeRegion && p.stmt.IsANSIDML()
+}
+
 // GetRangeDescByID is part of the eval.Planner interface.
 func (p *planner) GetRangeDescByID(
 	ctx context.Context, rangeID roachpb.RangeID,

--- a/pkg/sql/rowexec/joinreader.go
+++ b/pkg/sql/rowexec/joinreader.go
@@ -249,6 +249,11 @@ type joinReader struct {
 	// only lookups to rows in remote regions and remote accesses are set to
 	// error out via a session setting.
 	errorOnLookup bool
+
+	// allowEnforceHomeRegionFollowerReads, if true, causes errors produced by the
+	// above `errorOnLookup` flag to be retryable, and use follower reads to find
+	// the query's home region during the retries.
+	allowEnforceHomeRegionFollowerReads bool
 }
 
 var _ execinfra.Processor = &joinReader{}
@@ -346,19 +351,20 @@ func newJoinReader(
 		flowCtx.EvalCtx.Planner != nil && flowCtx.EvalCtx.Planner.EnforceHomeRegion()
 
 	jr := &joinReader{
-		fetchSpec:                         spec.FetchSpec,
-		splitFamilyIDs:                    spec.SplitFamilyIDs,
-		maintainOrdering:                  spec.MaintainOrdering,
-		input:                             input,
-		lookupCols:                        lookupCols,
-		outputGroupContinuationForLeftRow: spec.OutputGroupContinuationForLeftRow,
-		shouldLimitBatches:                shouldLimitBatches,
-		readerType:                        readerType,
-		txn:                               txn,
-		usesStreamer:                      useStreamer,
-		lookupBatchBytesLimit:             rowinfra.BytesLimit(spec.LookupBatchBytesLimit),
-		limitHintHelper:                   execinfra.MakeLimitHintHelper(spec.LimitHint, post),
-		errorOnLookup:                     errorOnLookup,
+		fetchSpec:                           spec.FetchSpec,
+		splitFamilyIDs:                      spec.SplitFamilyIDs,
+		maintainOrdering:                    spec.MaintainOrdering,
+		input:                               input,
+		lookupCols:                          lookupCols,
+		outputGroupContinuationForLeftRow:   spec.OutputGroupContinuationForLeftRow,
+		shouldLimitBatches:                  shouldLimitBatches,
+		readerType:                          readerType,
+		txn:                                 txn,
+		usesStreamer:                        useStreamer,
+		lookupBatchBytesLimit:               rowinfra.BytesLimit(spec.LookupBatchBytesLimit),
+		limitHintHelper:                     execinfra.MakeLimitHintHelper(spec.LimitHint, post),
+		errorOnLookup:                       errorOnLookup,
+		allowEnforceHomeRegionFollowerReads: flowCtx.EvalCtx.SessionData().EnforceHomeRegionFollowerReadsEnabled,
 	}
 	if readerType != indexJoinReaderType {
 		jr.groupingState = &inputBatchGroupingState{doGrouping: spec.LeftJoinWithPairedJoiner}
@@ -1021,14 +1027,18 @@ func (jr *joinReader) readInput() (
 	return jrPerformingLookup, outRow, nil
 }
 
-var noHomeRegionError = execinfra.NewDynamicQueryHasNoHomeRegionError(pgerror.Newf(pgcode.QueryHasNoHomeRegion,
+var noHomeRegionError = pgerror.Newf(pgcode.QueryHasNoHomeRegion,
 	"Query has no home region. Try using a lower LIMIT value or running the query from a different region. %s",
-	sqlerrors.EnforceHomeRegionFurtherInfo))
+	sqlerrors.EnforceHomeRegionFurtherInfo)
 
 // performLookup reads the next batch of index rows.
 func (jr *joinReader) performLookup() (joinReaderState, *execinfrapb.ProducerMetadata) {
 	if jr.errorOnLookup {
-		jr.MoveToDraining(noHomeRegionError)
+		err := noHomeRegionError
+		if jr.allowEnforceHomeRegionFollowerReads {
+			err = execinfra.NewDynamicQueryHasNoHomeRegionError(err)
+		}
+		jr.MoveToDraining(err)
 		return jrStateUnknown, jr.DrainHelper()
 	}
 	for {

--- a/pkg/sql/rowexec/joinreader.go
+++ b/pkg/sql/rowexec/joinreader.go
@@ -36,6 +36,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/rowinfra"
 	"github.com/cockroachdb/cockroach/pkg/sql/scrub"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlerrors"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -1021,7 +1022,8 @@ func (jr *joinReader) readInput() (
 }
 
 var noHomeRegionError = execinfra.NewDynamicQueryHasNoHomeRegionError(pgerror.Newf(pgcode.QueryHasNoHomeRegion,
-	"Query has no home region. Try using a lower LIMIT value or running the query from a different region."))
+	"Query has no home region. Try using a lower LIMIT value or running the query from a different region. %s",
+	sqlerrors.EnforceHomeRegionFurtherInfo))
 
 // performLookup reads the next batch of index rows.
 func (jr *joinReader) performLookup() (joinReaderState, *execinfrapb.ProducerMetadata) {

--- a/pkg/sql/rowexec/joinreader.go
+++ b/pkg/sql/rowexec/joinreader.go
@@ -341,8 +341,8 @@ func newJoinReader(
 		return nil, err
 	}
 
-	errorOnLookup := spec.RemoteOnlyLookups && flowCtx.EvalCtx.SessionData().EnforceHomeRegion &&
-		flowCtx.EvalCtx.Planner != nil && flowCtx.EvalCtx.Planner.IsANSIDML()
+	errorOnLookup := spec.RemoteOnlyLookups &&
+		flowCtx.EvalCtx.Planner != nil && flowCtx.EvalCtx.Planner.EnforceHomeRegion()
 
 	jr := &joinReader{
 		fetchSpec:                         spec.FetchSpec,
@@ -1020,8 +1020,8 @@ func (jr *joinReader) readInput() (
 	return jrPerformingLookup, outRow, nil
 }
 
-var noHomeRegionError = pgerror.Newf(pgcode.QueryHasNoHomeRegion,
-	"Query has no home region. Try using a lower LIMIT value or running the query from a different region.")
+var noHomeRegionError = execinfra.NewDynamicQueryHasNoHomeRegionError(pgerror.Newf(pgcode.QueryHasNoHomeRegion,
+	"Query has no home region. Try using a lower LIMIT value or running the query from a different region."))
 
 // performLookup reads the next batch of index rows.
 func (jr *joinReader) performLookup() (joinReaderState, *execinfrapb.ProducerMetadata) {

--- a/pkg/sql/rowexec/joinreader_strategies.go
+++ b/pkg/sql/rowexec/joinreader_strategies.go
@@ -187,7 +187,7 @@ func (s *joinReaderNoOrderingStrategy) generateRemoteSpans() (roachpb.Spans, []i
 		return nil, nil, errors.AssertionFailedf("generateRemoteSpans can only be called for locality optimized lookup joins")
 	}
 
-	if s.EvalCtx.SessionData().EnforceHomeRegion && s.EvalCtx.Planner.IsANSIDML() {
+	if s.EvalCtx.Planner.EnforceHomeRegion() {
 		return nil, nil, noHomeRegionError
 	}
 	s.remoteSpansGenerated = true
@@ -595,7 +595,7 @@ func (s *joinReaderOrderingStrategy) generateRemoteSpans() (roachpb.Spans, []int
 	if !ok {
 		return nil, nil, errors.AssertionFailedf("generateRemoteSpans can only be called for locality optimized lookup joins")
 	}
-	if s.EvalCtx.SessionData().EnforceHomeRegion && s.EvalCtx.Planner.IsANSIDML() {
+	if s.EvalCtx.Planner.EnforceHomeRegion() {
 		return nil, nil, noHomeRegionError
 	}
 	s.remoteSpansGenerated = true

--- a/pkg/sql/rowexec/joinreader_strategies.go
+++ b/pkg/sql/rowexec/joinreader_strategies.go
@@ -188,7 +188,11 @@ func (s *joinReaderNoOrderingStrategy) generateRemoteSpans() (roachpb.Spans, []i
 	}
 
 	if s.EvalCtx.Planner.EnforceHomeRegion() {
-		return nil, nil, noHomeRegionError
+		err := noHomeRegionError
+		if s.EvalCtx.SessionData().EnforceHomeRegionFollowerReadsEnabled {
+			err = execinfra.NewDynamicQueryHasNoHomeRegionError(err)
+		}
+		return nil, nil, err
 	}
 	s.remoteSpansGenerated = true
 	return gen.generateRemoteSpans(s.Ctx(), s.inputRows)
@@ -596,7 +600,11 @@ func (s *joinReaderOrderingStrategy) generateRemoteSpans() (roachpb.Spans, []int
 		return nil, nil, errors.AssertionFailedf("generateRemoteSpans can only be called for locality optimized lookup joins")
 	}
 	if s.EvalCtx.Planner.EnforceHomeRegion() {
-		return nil, nil, noHomeRegionError
+		err := noHomeRegionError
+		if s.EvalCtx.SessionData().EnforceHomeRegionFollowerReadsEnabled {
+			err = execinfra.NewDynamicQueryHasNoHomeRegionError(err)
+		}
+		return nil, nil, err
 	}
 	s.remoteSpansGenerated = true
 	return gen.generateRemoteSpans(s.Ctx(), s.inputRows)

--- a/pkg/sql/rowflow/row_based_flow.go
+++ b/pkg/sql/rowflow/row_based_flow.go
@@ -331,7 +331,7 @@ func (f *rowBasedFlow) setupInputSyncs(
 				var returnErrorFunc func() error
 				if is.EnforceHomeRegionError != nil {
 					returnErrorFunc = func() error {
-						return is.EnforceHomeRegionError.ErrorDetail(ctx)
+						return execinfra.NewDynamicQueryHasNoHomeRegionError(is.EnforceHomeRegionError.ErrorDetail(ctx))
 					}
 				}
 				sync, err = makeSerialSync(ordering, f.EvalCtx, streams,

--- a/pkg/sql/rowflow/row_based_flow.go
+++ b/pkg/sql/rowflow/row_based_flow.go
@@ -331,7 +331,11 @@ func (f *rowBasedFlow) setupInputSyncs(
 				var returnErrorFunc func() error
 				if is.EnforceHomeRegionError != nil {
 					returnErrorFunc = func() error {
-						return execinfra.NewDynamicQueryHasNoHomeRegionError(is.EnforceHomeRegionError.ErrorDetail(ctx))
+						enforceHomeRegionError := is.EnforceHomeRegionError.ErrorDetail(ctx)
+						if f.FlowCtx.EvalCtx.SessionData().EnforceHomeRegionFollowerReadsEnabled {
+							enforceHomeRegionError = execinfra.NewDynamicQueryHasNoHomeRegionError(enforceHomeRegionError)
+						}
+						return enforceHomeRegionError
 					}
 				}
 				sync, err = makeSerialSync(ordering, f.EvalCtx, streams,

--- a/pkg/sql/schema_changer.go
+++ b/pkg/sql/schema_changer.go
@@ -2499,6 +2499,7 @@ func createSchemaChangeEvalCtx(
 			NodeID:               execCfg.NodeInfo.NodeID,
 			Codec:                execCfg.Codec,
 			Locality:             execCfg.Locality,
+			OriginalLocality:     execCfg.Locality,
 			Tracer:               execCfg.AmbientCtx.Tracer,
 		},
 	}

--- a/pkg/sql/sem/eval/BUILD.bazel
+++ b/pkg/sql/sem/eval/BUILD.bazel
@@ -51,6 +51,7 @@ go_library(
         "//pkg/server/telemetry",
         "//pkg/settings",
         "//pkg/settings/cluster",
+        "//pkg/sql/catalog/catpb",
         "//pkg/sql/catalog/descpb",
         "//pkg/sql/lex",
         "//pkg/sql/parser",

--- a/pkg/sql/sem/eval/context.go
+++ b/pkg/sql/sem/eval/context.go
@@ -25,6 +25,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/repstream/streampb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgwirecancel"
@@ -92,8 +93,13 @@ type Context struct {
 	// are no tiers, then the node's location is not known. Example:
 	//
 	//   [region=us,dc=east]
-	//
+	// The region entry in this variable is the gateway region.
 	Locality roachpb.Locality
+
+	// OriginalLocality is the initial Locality at the time the connection was
+	// established. Since Locality may be overridden in some paths, this provides
+	// a means of restoring the original Locality.
+	OriginalLocality roachpb.Locality
 
 	Tracer *tracing.Tracer
 
@@ -250,6 +256,11 @@ type Context struct {
 
 	// ParseHelper makes date parsing more efficient.
 	ParseHelper pgdate.ParseHelper
+
+	// RemoteRegions contains the slice of remote regions in a multiregion
+	// database which owns a table accessed by the current SQL request.
+	// This slice is only populated during the optbuild stage.
+	RemoteRegions catpb.RegionNames
 }
 
 // DescIDGenerator generates unique descriptor IDs.
@@ -373,6 +384,16 @@ type fakePlannerWithMonitor struct {
 // Mon is part of the Planner interface.
 func (p *fakePlannerWithMonitor) Mon() *mon.BytesMonitor {
 	return p.monitor
+}
+
+// IsANSIDML is part of the eval.Planner interface.
+func (p *fakePlannerWithMonitor) IsANSIDML() bool {
+	return false
+}
+
+// EnforceHomeRegion is part of the eval.Planner interface.
+func (p *fakePlannerWithMonitor) EnforceHomeRegion() bool {
+	return false
 }
 
 type fakeStreamManagerFactory struct {

--- a/pkg/sql/sem/eval/deps.go
+++ b/pkg/sql/sem/eval/deps.go
@@ -369,6 +369,10 @@ type Planner interface {
 	// statements.
 	IsANSIDML() bool
 
+	// EnforceHomeRegion returns true if the statement being planned is an ANSI
+	// DML statement and the enforce_home_region session setting is true.
+	EnforceHomeRegion() bool
+
 	// GetRangeDescByID gets the RangeDescriptor by the specified RangeID.
 	GetRangeDescByID(context.Context, roachpb.RangeID) (roachpb.RangeDescriptor, error)
 

--- a/pkg/sql/sessiondatapb/local_only_session_data.proto
+++ b/pkg/sql/sessiondatapb/local_only_session_data.proto
@@ -339,6 +339,10 @@ message LocalOnlySessionData {
   // transaction to return a transaction retry error just before transcation commit.
   // It is intended for developers to test their app's retry logic.
   bool inject_retry_errors_on_commit_enabled = 92;
+  // EnforceHomeRegionFollowerReadsEnabled, when true, allows the use of
+  // follower reads to dynamically detect and report a query's home region
+  // when the enforce_home_region session setting is also true.
+  bool enforce_home_region_follower_reads_enabled = 93;
 
   ///////////////////////////////////////////////////////////////////////////
   // WARNING: consider whether a session parameter you're adding needs to  //

--- a/pkg/sql/sqlerrors/errors.go
+++ b/pkg/sql/sqlerrors/errors.go
@@ -30,6 +30,11 @@ const (
 		"until end of transaction block"
 )
 
+// EnforceHomeRegionFurtherInfo is the suffix to append to every error returned
+// due to turning on the enforce_home_region session setting, and provides some
+// information for users or app developers.
+const EnforceHomeRegionFurtherInfo = "For more information, see https://www.cockroachlabs.com/docs/stable/cost-based-optimizer.html#control-whether-queries-are-limited-to-a-single-region"
+
 // NewTransactionAbortedError creates an error for trying to run a command in
 // the context of transaction that's in the aborted state. Any statement other
 // than ROLLBACK TO SAVEPOINT will return this error.

--- a/pkg/sql/vars.go
+++ b/pkg/sql/vars.go
@@ -2498,6 +2498,23 @@ var varGen = map[string]sessionVar{
 		},
 		GlobalDefault: globalTrue,
 	},
+
+	// CockroachDB extension.
+	`enforce_home_region_follower_reads_enabled`: {
+		GetStringVal: makePostgresBoolGetStringValFn(`enforce_home_region_follower_reads_enabled`),
+		Set: func(_ context.Context, m sessionDataMutator, s string) error {
+			b, err := paramparse.ParseBoolVar("enforce_home_region_follower_reads_enabled", s)
+			if err != nil {
+				return err
+			}
+			m.SetEnforceHomeRegionFollowerReadsEnabled(b)
+			return nil
+		},
+		Get: func(evalCtx *extendedEvalContext, _ *kv.Txn) (string, error) {
+			return formatBoolAsPostgresSetting(evalCtx.SessionData().EnforceHomeRegionFollowerReadsEnabled), nil
+		},
+		GlobalDefault: globalFalse,
+	},
 }
 
 // We want test coverage for this on and off so make it metamorphic.


### PR DESCRIPTION
enforce_home_region phase 3
----

This extends the `enforce_home_region` session setting to not error out
right away when executing a locality-optimized search or join operation,
and the operation must read rows from a remote region. Instead, it will
retry the transaction, but with the local region, as marked in `evalCtx`,
updated to indicate one of the remote regions in the cluster. This causes
the locality-optimized Scan or Join operation to read from that remote
region first. A follower_read_timestamp() is used when re-running the
query with AOST, so no remote reads actually occur. If the query succeeds,
the current fake local region is reported back to the user in an error,
for example:
```
Query is not running in its home region.
Try running the query from region 'us-east-1'.
```
All of the remote regions in the cluster are tried until the home region
is found, or all remote regions are exhausted, in which case the original
"Query has no home region" error is returned.

This preview feature is only supported for SELECT queries.

Epic: CRDB-18645
Fixes: #83819

Release note (sql change): The enforce_home_region session setting was
extended with a new optional preview feature and session setting, which is
disabled by default, to dynamically detect and report the home region for
SELECT queries based on the locality of the queried rows, if different
from the gateway region.

---- 
execbuilder: add docs link to enforce_home_region errors

This commit adds a web URL to the text of "Query has no home region"
and "Query is not running in its home region" errors, with more
information about the errors.

Epic: CRDB-18645
Fixes: #86178

Release note (sql change): This adds a URL to errors related to the
enforce_home_region session setting, providing additional information
about the error.

----
sql: session setting enforce_home_region_follower_reads_enabled

This commit adds session setting `enforce_home_region_follower_reads_enabled`
which defaults to false. If enabled, it allows the `enforce_home_region` setting to perform
AOST follower reads to determine a query's home region, if any.

Epic: CRDB-18645
Informs: #83819

Epic: CRDB-18645
Informs: #83819

Release note (sql change): A new session setting was added as a preview feature to allow
errors triggered by session setting enforce_home_region to perform AS OF SYSTEM TIME
follower_read_timestamp() reads in order to find and report a query's home region.
The session setting name is enforce_home_region_follower_reads_enabled.