### PR TITLE
sqlsmith: bring back hide_sql_constants

### DIFF
--- a/pkg/internal/sqlsmith/schema.go
+++ b/pkg/internal/sqlsmith/schema.go
@@ -521,9 +521,6 @@ var functions = func() map[tree.FunctionClass]map[oid.Oid][]function {
 			"crdb_internal.revalidate_unique_constraint",
 			"crdb_internal.request_statement_bundle",
 			"crdb_internal.set_compaction_concurrency",
-			// TODO(96555): Temporarily disable crdb_internal.hide_sql_constants,
-			// which produces internal errors for some valid inputs.
-			"crdb_internal.hide_sql_constants",
 			// TODO(#97097): Temporarily disable crdb_internal.fingerprint
 			// which produces internal errors for some valid inputs.
 			"crdb_internal.fingerprint",

--- a/pkg/sql/logictest/testdata/logic_test/builtin_function
+++ b/pkg/sql/logictest/testdata/logic_test/builtin_function
@@ -3737,6 +3737,11 @@ SELECT crdb_internal.hide_sql_constants(ARRAY('select 1', NULL, 'select ''hello'
 {"SELECT _",NULL,"SELECT '_'","",""}
 
 query T
+SELECT crdb_internal.hide_sql_constants(ARRAY['banana'])
+----
+{""}
+
+query T
 SELECT crdb_internal.hide_sql_constants('SELECT ''yes'' IN (''no'', ''maybe'', ''yes'')')
 ----
 SELECT '_' IN ('_', '_', __more1_10__)

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -7683,7 +7683,7 @@ expires until the statement bundle is collected`,
 				return tree.NewDString(sqlNoConstants), nil
 			},
 			types.String,
-			"Removes constants from a SQL statement. String provided must contain at most"+
+			"Removes constants from a SQL statement. String provided must contain at most "+
 				"1 statement.",
 			volatility.Immutable,
 		),
@@ -7720,7 +7720,7 @@ expires until the statement bundle is collected`,
 
 				return result, nil
 			},
-			Info: "Hide constants for each element in an array of SQL statements." +
+			Info: "Hide constants for each element in an array of SQL statements. " +
 				"Note that maximum 1 statement is permitted per string element.",
 			Volatility: volatility.Immutable,
 		},


### PR DESCRIPTION
Now that https://github.com/cockroachdb/cockroach/issues/96555 and https://github.com/cockroachdb/cockroach/issues/97830 are fixed, add `hide_sql_constants` back to sqlsmith. Also add some missing spaces to the info strings.

Epic: None

Release note: None