### PR TITLE
sql: add RevertSpans and RevertSpansFanout

### DIFF
--- a/pkg/ccl/streamingccl/streamingest/stream_ingestion_job.go
+++ b/pkg/ccl/streamingccl/streamingest/stream_ingestion_job.go
@@ -19,8 +19,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/jobs"
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobsprotectedts"
-	"github.com/cockroachdb/cockroach/pkg/kv"
-	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/protectedts"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/protectedts/ptpb"
 	"github.com/cockroachdb/cockroach/pkg/multitenant/mtinfopb"
@@ -31,7 +29,9 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/isql"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/metric"
 	"github.com/cockroachdb/cockroach/pkg/util/retry"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 	"github.com/cockroachdb/errors"
@@ -192,7 +192,7 @@ func updateRunningStatusInternal(
 func ingest(ctx context.Context, execCtx sql.JobExecContext, ingestionJob *jobs.Job) error {
 	// Cutover should be the *first* thing checked upon resumption as it is the
 	// most critical task in disaster recovery.
-	reverted, err := maybeRevertToCutoverTimestamp(ctx, execCtx, ingestionJob.ID())
+	reverted, err := maybeRevertToCutoverTimestamp(ctx, execCtx, ingestionJob)
 	if err != nil {
 		return err
 	}
@@ -299,7 +299,7 @@ func ingest(ctx context.Context, execCtx sql.JobExecContext, ingestionJob *jobs.
 		log.Infof(ctx,
 			"starting to revert to the specified cutover timestamp for stream ingestion job %d",
 			ingestionJob.ID())
-		if err = revertToCutoverTimestamp(ctx, execCtx, ingestionJob.ID()); err != nil {
+		if err = revertToCutoverTimestamp(ctx, execCtx, ingestionJob); err != nil {
 			return err
 		}
 
@@ -481,9 +481,9 @@ func (s *streamIngestionResumer) protectDestinationTenant(
 // revertToCutoverTimestamp attempts a cutover and errors out if one was not
 // executed.
 func revertToCutoverTimestamp(
-	ctx context.Context, execCtx interface{}, ingestionJobID jobspb.JobID,
+	ctx context.Context, execCtx sql.JobExecContext, ingestionJob *jobs.Job,
 ) error {
-	reverted, err := maybeRevertToCutoverTimestamp(ctx, execCtx, ingestionJobID)
+	reverted, err := maybeRevertToCutoverTimestamp(ctx, execCtx, ingestionJob)
 	if err != nil {
 		return err
 	}
@@ -494,56 +494,70 @@ func revertToCutoverTimestamp(
 	return nil
 }
 
+func cutoverTimeIsEligibleForCutover(
+	ctx context.Context, cutoverTime hlc.Timestamp, progress *jobspb.Progress,
+) bool {
+	if cutoverTime.IsEmpty() {
+		log.Infof(ctx, "empty cutover time, no revert required")
+		return false
+	}
+	if progress.GetHighWater() == nil || progress.GetHighWater().Less(cutoverTime) {
+		log.Infof(ctx, "job with highwater %s not yet ready to revert to cutover at %s",
+			progress.GetHighWater(), cutoverTime.String())
+		return false
+	}
+	return true
+}
+
 // maybeRevertToCutoverTimestamp reads the job progress for the cutover time and
 // if the job has progressed passed the cutover time issues a RevertRangeRequest
 // with the target time set to that cutover time, to bring the ingesting cluster
 // to a consistent state.
 func maybeRevertToCutoverTimestamp(
-	ctx context.Context, execCtx interface{}, ingestionJobID jobspb.JobID,
+	ctx context.Context, p sql.JobExecContext, ingestionJob *jobs.Job,
 ) (bool, error) {
 	ctx, span := tracing.ChildSpan(ctx, "streamingest.revertToCutoverTimestamp")
 	defer span.Finish()
 
-	p := execCtx.(sql.JobExecContext)
-	db := p.ExecCfg().DB
-	jobRegistry := p.ExecCfg().JobRegistry
-	ingestionJob, err := jobRegistry.LoadJob(ctx, ingestionJobID)
-	if err != nil {
-		return false, err
-	}
-
-	var shouldRevertToCutover bool
-	if err := p.ExecCfg().InternalDB.Txn(ctx, func(
-		ctx context.Context, txn isql.Txn,
-	) error {
-		return ingestionJob.WithTxn(txn).Update(ctx, func(txn isql.Txn, md jobs.JobMetadata, ju *jobs.JobUpdater) error {
-			payload := md.Payload.GetStreamIngestion()
-			if payload == nil {
-				return errors.Newf("unknown payload type %T in stream ingestion job %d",
-					md.Payload, ingestionJobID)
-			}
-			streamIngest := md.Progress.GetStreamIngest()
-			if streamIngest == nil {
-				return errors.Newf("unknown progress type %T in stream ingestion job %d",
-					md.Progress, ingestionJobID)
-			}
-			cutoverTime := streamIngest.CutoverTime
-			if cutoverTime.IsEmpty() {
-				log.Infof(ctx, "empty cutover time, no revert required")
-				return nil
-			}
-			if md.Progress.GetHighWater() == nil || md.Progress.GetHighWater().Less(cutoverTime) {
-				log.Infof(ctx, "job with highwater %s not yet ready to revert to cutover at %s",
-					md.Progress.GetHighWater(), cutoverTime.String())
-				return nil
+	// The update below sets the ReplicationStatus to
+	// CuttingOver. Once set, the cutoverTimestamp cannot be
+	// changed. We want to be sure to read the timestamp that
+	// existed in the record at the point of the update rather the
+	// value that may be in the job record before the update.
+	var (
+		shouldRevertToCutover bool
+		cutoverTimestamp      hlc.Timestamp
+		spanToRevert          roachpb.Span
+	)
+	if err := ingestionJob.NoTxn().Update(ctx,
+		func(txn isql.Txn, md jobs.JobMetadata, ju *jobs.JobUpdater) error {
+			streamIngestionDetails := md.Payload.GetStreamIngestion()
+			if streamIngestionDetails == nil {
+				return errors.AssertionFailedf("unknown payload %v in stream ingestion job %d",
+					md.Payload, ingestionJob.ID())
 			}
 
-			shouldRevertToCutover = true
-			updateRunningStatusInternal(md, ju, jobspb.ReplicationCuttingOver,
-				fmt.Sprintf("starting to cut over to the given timestamp %s", cutoverTime))
+			streamIngestionProgress := md.Progress.GetStreamIngest()
+			if streamIngestionProgress == nil {
+				return errors.AssertionFailedf("unknown progress %v in stream ingestion job %d",
+					md.Progress, ingestionJob.ID())
+			}
+
+			cutoverTimestamp = streamIngestionProgress.CutoverTime
+			spanToRevert = streamIngestionDetails.Span
+			shouldRevertToCutover = cutoverTimeIsEligibleForCutover(ctx, cutoverTimestamp, md.Progress)
+
+			if shouldRevertToCutover {
+				updateRunningStatusInternal(md, ju, jobspb.ReplicationCuttingOver,
+					fmt.Sprintf("starting to cut over to the given timestamp %s", cutoverTimestamp))
+			} else {
+				if streamIngestionProgress.ReplicationStatus == jobspb.ReplicationCuttingOver {
+					return errors.AssertionFailedf("cutover already started but cutover time %s is not eligible for cutover",
+						cutoverTimestamp)
+				}
+			}
 			return nil
-		})
-	}); err != nil {
+		}); err != nil {
 		return false, err
 	}
 	if !shouldRevertToCutover {
@@ -554,71 +568,30 @@ func maybeRevertToCutoverTimestamp(
 		p.ExecCfg().StreamingTestingKnobs.AfterCutoverStarted()
 	}
 
-	origNRanges := -1
-	payload := ingestionJob.Payload()
-	progress := ingestionJob.Progress()
-	spans := []roachpb.Span{payload.GetStreamIngestion().Span}
-	updateJobProgress := func() error {
-		if spans == nil {
-			return nil
-		}
-		nRanges, err := sql.NumRangesInSpans(ctx, p.ExecCfg().DB, p.DistSQLPlanner(), spans)
-		if err != nil {
-			return err
-		}
-		m := jobRegistry.MetricsStruct().StreamIngest.(*Metrics)
-		m.ReplicationCutoverProgress.Update(int64(nRanges))
-		if origNRanges == -1 {
-			origNRanges = nRanges
-		}
-		return p.ExecCfg().InternalDB.Txn(ctx, func(ctx context.Context, txn isql.Txn) error {
-			if nRanges < origNRanges {
-				fractionRangesFinished := float32(origNRanges-nRanges) / float32(origNRanges)
-				if err := ingestionJob.WithTxn(txn).FractionProgressed(
-					ctx, jobs.FractionUpdater(fractionRangesFinished),
-				); err != nil {
-					return jobs.SimplifyInvalidStatusError(err)
-				}
-			}
-			return nil
-		})
+	minProgressUpdateInterval := 15 * time.Second
+	progMetric := p.ExecCfg().JobRegistry.MetricsStruct().StreamIngest.(*Metrics).ReplicationCutoverProgress
+	progUpdater, err := newCutoverProgressTracker(ctx, p, spanToRevert, ingestionJob, progMetric, minProgressUpdateInterval)
+	if err != nil {
+		return false, err
 	}
 
-	cutoverTime := progress.GetStreamIngest().CutoverTime
-	for len(spans) != 0 {
-		if err := updateJobProgress(); err != nil {
-			log.Warningf(ctx, "failed to update replication job progress: %+v", err)
-		}
-		var b kv.Batch
-		for _, span := range spans {
-			b.AddRawRequest(&kvpb.RevertRangeRequest{
-				RequestHeader: kvpb.RequestHeader{
-					Key:    span.Key,
-					EndKey: span.EndKey,
-				},
-				TargetTime: cutoverTime,
-			})
-		}
-		b.Header.MaxSpanRequestKeys = sql.RevertTableDefaultBatchSize
-		if p.ExecCfg().StreamingTestingKnobs != nil && p.ExecCfg().StreamingTestingKnobs.OverrideRevertRangeBatchSize != 0 {
-			b.Header.MaxSpanRequestKeys = p.ExecCfg().StreamingTestingKnobs.OverrideRevertRangeBatchSize
-		}
-		if err := db.Run(ctx, &b); err != nil {
-			return false, err
-		}
-
-		spans = spans[:0]
-		for _, raw := range b.RawResponse().Responses {
-			r := raw.GetRevertRange()
-			if r.ResumeSpan != nil {
-				if !r.ResumeSpan.Valid() {
-					return false, errors.Errorf("invalid resume span: %s", r.ResumeSpan)
-				}
-				spans = append(spans, *r.ResumeSpan)
-			}
-		}
+	batchSize := int64(sql.RevertTableDefaultBatchSize)
+	if p.ExecCfg().StreamingTestingKnobs != nil && p.ExecCfg().StreamingTestingKnobs.OverrideRevertRangeBatchSize != 0 {
+		batchSize = p.ExecCfg().StreamingTestingKnobs.OverrideRevertRangeBatchSize
 	}
-	return true, updateJobProgress()
+	if err := sql.RevertSpansFanout(ctx,
+		p.ExecCfg().DB,
+		p,
+		[]roachpb.Span{spanToRevert},
+		cutoverTimestamp,
+		// TODO(ssd): It should be safe for us to ingore the
+		// GC threshold. Why aren't we?
+		false, /* ignoreGCThreshold */
+		batchSize,
+		progUpdater.onCompletedCallback); err != nil {
+		return false, err
+	}
+	return true, nil
 }
 
 func activateTenant(ctx context.Context, execCtx interface{}, newTenantID roachpb.TenantID) error {
@@ -699,6 +672,108 @@ func (s *streamIngestionResumer) OnFailOrCancel(
 
 		return nil
 	})
+}
+
+// cutoverProgressTracker updates the job progress and the given
+// metric with the number of ranges still remainng to revert during
+// the cutover process.
+type cutoverProgressTracker struct {
+	minProgressUpdateInterval time.Duration
+	progMetric                *metric.Gauge
+	job                       *jobs.Job
+
+	remainingSpans     roachpb.SpanGroup
+	lastUpdatedAt      time.Time
+	originalRangeCount int
+
+	getRangeCount                   func(context.Context, roachpb.Spans) (int, error)
+	onJobProgressUpdate             func()
+	overrideShouldUpdateJobProgress func() bool
+}
+
+func newCutoverProgressTracker(
+	ctx context.Context,
+	p sql.JobExecContext,
+	spanToRevert roachpb.Span,
+	job *jobs.Job,
+	progMetric *metric.Gauge,
+	minProgressUpdateInterval time.Duration,
+) (*cutoverProgressTracker, error) {
+	var sg roachpb.SpanGroup
+	sg.Add(spanToRevert)
+
+	nRanges, err := sql.NumRangesInSpans(ctx, p.ExecCfg().DB, p.DistSQLPlanner(), sg.Slice())
+	if err != nil {
+		return nil, err
+	}
+	c := &cutoverProgressTracker{
+		job:                       job,
+		progMetric:                progMetric,
+		minProgressUpdateInterval: minProgressUpdateInterval,
+
+		remainingSpans:     sg,
+		originalRangeCount: nRanges,
+
+		getRangeCount: func(ctx context.Context, sps roachpb.Spans) (int, error) {
+			return sql.NumRangesInSpans(ctx, p.ExecCfg().DB, p.DistSQLPlanner(), sg.Slice())
+		},
+	}
+	if testingKnobs := p.ExecCfg().StreamingTestingKnobs; testingKnobs != nil {
+		c.overrideShouldUpdateJobProgress = testingKnobs.CutoverProgressShouldUpdate
+		c.onJobProgressUpdate = testingKnobs.OnCutoverProgressUpdate
+	}
+	return c, nil
+
+}
+
+func (c *cutoverProgressTracker) shouldUpdateJobProgress() bool {
+	if c.overrideShouldUpdateJobProgress != nil {
+		return c.overrideShouldUpdateJobProgress()
+	}
+	return timeutil.Since(c.lastUpdatedAt) >= c.minProgressUpdateInterval
+}
+
+func (c *cutoverProgressTracker) updateJobProgress(ctx context.Context, sp []roachpb.Span) error {
+	nRanges, err := c.getRangeCount(ctx, sp)
+	if err != nil {
+		return err
+	}
+
+	c.progMetric.Update(int64(nRanges))
+
+	// We set lastUpdatedAt even though we might not actually
+	// update the job record below. We do this to avoid asking for
+	// the range count too often.
+	c.lastUpdatedAt = timeutil.Now()
+
+	// If our fraction is going to actually move, avoid touching
+	// the job record.
+	if nRanges >= c.originalRangeCount {
+		return nil
+	}
+
+	fractionRangesFinished := float32(c.originalRangeCount-nRanges) / float32(c.originalRangeCount)
+	if err := c.job.NoTxn().FractionProgressed(ctx, jobs.FractionUpdater(fractionRangesFinished)); err != nil {
+		return jobs.SimplifyInvalidStatusError(err)
+	}
+	if c.onJobProgressUpdate != nil {
+		c.onJobProgressUpdate()
+	}
+	return nil
+}
+
+func (c *cutoverProgressTracker) onCompletedCallback(
+	ctx context.Context, completed roachpb.Span,
+) error {
+	c.remainingSpans.Sub(completed)
+	if !c.shouldUpdateJobProgress() {
+		return nil
+	}
+
+	if err := c.updateJobProgress(ctx, c.remainingSpans.Slice()); err != nil {
+		log.Warningf(ctx, "failed to update job progress: %v", err)
+	}
+	return nil
 }
 
 func (s *streamIngestionResumer) ForceRealSpan() bool { return true }

--- a/pkg/ccl/streamingccl/streamingest/stream_ingestion_job_test.go
+++ b/pkg/ccl/streamingccl/streamingest/stream_ingestion_job_test.go
@@ -25,8 +25,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/jobs"
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
 	"github.com/cockroachdb/cockroach/pkg/keys"
-	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
-	"github.com/cockroachdb/cockroach/pkg/kv/kvserver"
 	"github.com/cockroachdb/cockroach/pkg/repstream/streampb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/security/username"
@@ -43,6 +41,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/require"
 )
 
@@ -403,25 +402,15 @@ func TestCutoverFractionProgressed(t *testing.T) {
 
 	ctx := context.Background()
 
-	respRecvd := make(chan struct{})
-	continueRevert := make(chan struct{})
-	defer close(continueRevert)
+	progressUpdated := make(chan struct{})
 	s, sqlDB, _ := serverutils.StartServer(t, base.TestServerArgs{
 		Knobs: base.TestingKnobs{
-			Store: &kvserver.StoreTestingKnobs{
-				TestingResponseFilter: func(ctx context.Context, ba *kvpb.BatchRequest, br *kvpb.BatchResponse) *kvpb.Error {
-					for _, ru := range br.Responses {
-						switch ru.GetInner().(type) {
-						case *kvpb.RevertRangeResponse:
-							respRecvd <- struct{}{}
-							<-continueRevert
-						}
-					}
-					return nil
-				},
-			},
 			Streaming: &sql.StreamingTestingKnobs{
 				OverrideRevertRangeBatchSize: 1,
+				CutoverProgressShouldUpdate:  func() bool { return true },
+				OnCutoverProgressUpdate: func() {
+					progressUpdated <- struct{}{}
+				},
 			},
 		},
 		DisableDefaultTestTenant: true,
@@ -454,7 +443,9 @@ func TestCutoverFractionProgressed(t *testing.T) {
 	// Create a mock replication job with the `foo` table span so that on cut over
 	// we can revert the table's ranges.
 	execCfg := s.ExecutorConfig().(sql.ExecutorConfig)
-	jobExecCtx := &sql.FakeJobExecContext{ExecutorConfig: &execCfg}
+	jobExecCtx, ctxClose := sql.MakeJobExecContext("test-cutover-fraction-progressed", username.RootUserName(), &sql.MemoryMetrics{}, &execCfg)
+	defer ctxClose()
+
 	mockReplicationJobDetails := jobspb.StreamIngestionDetails{
 		Span: makeTableSpan(execCfg.Codec, uint32(id)),
 	}
@@ -476,66 +467,43 @@ func TestCutoverFractionProgressed(t *testing.T) {
 	metrics := registry.MetricsStruct().StreamIngest.(*Metrics)
 	require.Equal(t, int64(0), metrics.ReplicationCutoverProgress.Value())
 
-	g := ctxgroup.WithContext(ctx)
-	g.GoCtx(func(ctx context.Context) error {
-		defer close(respRecvd)
-		revert, err := maybeRevertToCutoverTimestamp(ctx, jobExecCtx, jobID)
-		require.NoError(t, err)
-		require.True(t, revert)
-		return nil
-	})
-
 	loadProgress := func() jobspb.Progress {
 		j, err := execCfg.JobRegistry.LoadJob(ctx, jobID)
 		require.NoError(t, err)
 		return j.Progress()
 	}
-	progressMap := map[string]bool{
-		"0.00": false,
-		"0.17": false,
-		"0.33": false,
-		"0.50": false,
-		"0.67": false,
-		"0.83": false,
-	}
-	var expectedRanges int64 = 6
-	g.GoCtx(func(ctx context.Context) error {
-		for {
-			select {
-			case <-ctx.Done():
-				return ctx.Err()
-			case _, ok := <-respRecvd:
-				if !ok {
-					return nil
-				}
-				sip := loadProgress()
-				curProgress := sip.GetFractionCompleted()
-				s := fmt.Sprintf("%.2f", curProgress)
-				if _, ok := progressMap[s]; !ok {
-					t.Fatalf("unexpected progress fraction %s", s)
-				}
-				// We sometimes see the same progress, which is valid, no need to update
-				// the expected range count.
-				if expectedRanges != metrics.ReplicationCutoverProgress.Value() {
-					// There is progress, which means that another range was reverted,
-					// updated the expected range count.
-					expectedRanges--
-				}
-				require.Equal(t, expectedRanges, metrics.ReplicationCutoverProgress.Value())
-				progressMap[s] = true
-				continueRevert <- struct{}{}
-			}
-		}
-	})
-	require.NoError(t, g.Wait())
-	sip := loadProgress()
-	require.Equal(t, sip.GetFractionCompleted(), float32(1))
-	require.Equal(t, int64(0), metrics.ReplicationCutoverProgress.Value())
 
-	// Ensure we have hit all our expected progress fractions.
-	for k, v := range progressMap {
-		if !v {
-			t.Fatalf("failed to see progress fraction %s", k)
+	var lastRangesLeft int64 = 6
+	var lastFraction float32 = 0
+	var progressUpdates = 0
+	g := ctxgroup.WithContext(ctx)
+	g.GoCtx(func(ctx context.Context) error {
+		for range progressUpdated {
+			sip := loadProgress()
+			curProgress := sip.GetFractionCompleted()
+			progressUpdates++
+			if lastFraction > curProgress {
+				return errors.Newf("unexpected progress fraction: %f > %f", lastFraction, curProgress)
+			}
+			rangesLeft := metrics.ReplicationCutoverProgress.Value()
+			if lastRangesLeft < rangesLeft {
+				return errors.Newf("unexpected range count from metric: %d > %d", rangesLeft, lastRangesLeft)
+			}
+			lastRangesLeft = rangesLeft
+			lastFraction = curProgress
 		}
-	}
+		return nil
+	})
+
+	revert, err := maybeRevertToCutoverTimestamp(ctx, jobExecCtx, replicationJob)
+	require.NoError(t, err)
+	require.True(t, revert)
+
+	close(progressUpdated)
+	require.NoError(t, g.Wait())
+
+	sip := loadProgress()
+	require.Equal(t, float32(1), sip.GetFractionCompleted())
+	require.Equal(t, int64(0), metrics.ReplicationCutoverProgress.Value())
+	require.True(t, progressUpdates > 1)
 }

--- a/pkg/cmd/roachtest/tests/multitenant_utils.go
+++ b/pkg/cmd/roachtest/tests/multitenant_utils.go
@@ -341,15 +341,7 @@ func createInMemoryTenant(
 
 // removeTenantRateLimiters ensures the tenant is not throttled by limiters.
 func removeTenantRateLimiters(t test.Test, systemSQL *sqlutils.SQLRunner, tenantName string) {
-	var tenantID int
-	systemSQL.QueryRow(t, `SELECT id FROM [SHOW TENANT $1]`, tenantName).Scan(&tenantID)
-	systemSQL.Exec(t, `SELECT crdb_internal.update_tenant_resource_limits($1::INT, 10000000000, 0,
-10000000000, now(), 0);`, tenantID)
-	systemSQL.ExecMultiple(t,
-		`SET CLUSTER SETTING kv.tenant_rate_limiter.burst_limit_seconds = 10000;`,
-		`SET CLUSTER SETTING kv.tenant_rate_limiter.rate_limit = -1000; `,
-		`SET CLUSTER SETTING kv.tenant_rate_limiter.read_batch_cost = 0;`,
-		`SET CLUSTER SETTING kv.tenant_rate_limiter.read_cost_per_mebibyte = 0;`,
-		`SET CLUSTER SETTING kv.tenant_rate_limiter.write_cost_per_megabyte = 0;`,
-		`SET CLUSTER SETTING kv.tenant_rate_limiter.write_request_cost = 0;`)
+	systemSQL.Exec(t, `SELECT crdb_internal.update_tenant_resource_limits($1::STRING, 10000000000, 0,
+10000000000, now(), 0);`, tenantName)
+	systemSQL.Exec(t, `ALTER TENANT $1 GRANT CAPABILITY exempt_from_rate_limiting=true`, tenantName)
 }

--- a/pkg/sql/BUILD.bazel
+++ b/pkg/sql/BUILD.bazel
@@ -559,6 +559,7 @@ go_library(
         "@in_gopkg_yaml_v2//:yaml_v2",
         "@io_opentelemetry_go_otel//attribute",
         "@org_golang_x_net//trace",
+        "@org_golang_x_sync//errgroup",
     ],
 )
 

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -1718,6 +1718,14 @@ type StreamingTestingKnobs struct {
 
 	// AfterCutoverStarted allows blocking after the cutover has started.
 	AfterCutoverStarted func()
+
+	// OnCutoverProgressUpdate is called on every progress update
+	// call during the cutover process.
+	OnCutoverProgressUpdate func()
+
+	// CutoverProgressShouldUpdate overrides the standard logic
+	// for whether the job record is updated on a progress update.
+	CutoverProgressShouldUpdate func() bool
 }
 
 var _ base.ModuleTestingKnobs = &StreamingTestingKnobs{}

--- a/pkg/sql/revert.go
+++ b/pkg/sql/revert.go
@@ -26,7 +26,9 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 	"github.com/cockroachdb/errors"
+	"golang.org/x/sync/errgroup"
 )
 
 // TODO (msbutler): tune these
@@ -42,13 +44,21 @@ var predicateDeleteRangeNumWorkers = settings.RegisterIntSetting(
 	"the number of workers used to issue Predicate Based DeleteRange request",
 	4)
 
+var maxRevertSpanNumWorkers = settings.RegisterIntSetting(
+	settings.TenantWritable,
+	"sql.revert.max_span_parallelism",
+	"the maximum number of workers used to issue RevertRange request",
+	8,
+	settings.PositiveInt,
+)
+
 // RevertTableDefaultBatchSize is the default batch size for reverting tables.
 // This only needs to be small enough to keep raft/rocks happy -- there is no
 // reply size to worry about.
 // TODO(dt): tune this via experimentation.
 const RevertTableDefaultBatchSize = 500000
 
-// RevertTables reverts the passed table to the target time, which much be above
+// RevertTables reverts the passed table to the target time, which must be above
 // the GC threshold for every range (unless the flag ignoreGCThreshold is passed
 // which should be done with care -- see RevertRangeRequest.IgnoreGCThreshold).
 func RevertTables(
@@ -80,12 +90,127 @@ func RevertTables(
 		log.Infof(ctx, "reverting table %s (%d) to time %v", tables[i].GetName(), tables[i].GetID(), targetTime)
 	}
 
-	// TODO(dt): pre-split requests up using a rangedesc cache and run batches in
-	// parallel (since we're passing a key limit, distsender won't do its usual
-	// splitting/parallel sending to separate ranges).
-	for len(spans) != 0 {
-		var b kv.Batch
-		for _, span := range spans {
+	return RevertSpans(ctx, db, spans, targetTime, ignoreGCThreshold, batchSize, nil)
+}
+
+// RevertSpansContext provides the execution environment for a call to
+// RevertSpansFanout.
+type RevertSpansContext interface {
+	ExtendedEvalContext() *extendedEvalContext
+	ExecCfg() *ExecutorConfig
+	DistSQLPlanner() *DistSQLPlanner
+}
+
+// RevertSpansFanout calls RevertSpans in parallel. The span is
+// divided using DistSQL's PartitionSpans.
+//
+// We do this to get parallel execution of RevertRange even in the
+// case of a non-zero batch size. DistSender will not parallelize
+// requests with non-zero MaxSpanRequestKeys set.
+func RevertSpansFanout(
+	ctx context.Context,
+	db *kv.DB,
+	rsCtx RevertSpansContext,
+	spans []roachpb.Span,
+	targetTime hlc.Timestamp,
+	ignoreGCThreshold bool,
+	batchSize int64,
+	onCompletedCallback func(context.Context, roachpb.Span) error,
+) error {
+	ctx, sp := tracing.ChildSpan(ctx, "sql.RevertSpansFanout")
+	defer sp.Finish()
+
+	execCfg := rsCtx.ExecCfg()
+	maxWorkerCount := int(maxRevertSpanNumWorkers.Get(execCfg.SV()))
+	if maxWorkerCount == 1 {
+		return RevertSpans(ctx, db, spans, targetTime, ignoreGCThreshold, batchSize, onCompletedCallback)
+	}
+
+	dsp := rsCtx.DistSQLPlanner()
+	planCtx, _, err := dsp.SetupAllNodesPlanning(ctx, rsCtx.ExtendedEvalContext(), execCfg)
+	if err != nil {
+		return err
+	}
+
+	spanPartitions, err := dsp.PartitionSpans(ctx, planCtx, spans)
+	if err != nil {
+		return err
+	}
+
+	var workerPartitions []SpanPartition
+	if len(spanPartitions) <= maxWorkerCount {
+		workerPartitions = spanPartitions
+	} else {
+		workerPartitions = make([]SpanPartition, maxWorkerCount)
+		for i, sp := range spanPartitions {
+			idx := i % maxWorkerCount
+			workerPartitions[idx].Spans = append(workerPartitions[idx].Spans, sp.Spans...)
+		}
+	}
+
+	runRevertSpanWorkers := func(callback func(context.Context, roachpb.Span) error) error {
+		errGroup, workerCtx := errgroup.WithContext(ctx)
+		for i := range workerPartitions {
+			workerIdx := i
+			errGroup.Go(func() error {
+				spans := workerPartitions[workerIdx].Spans
+				return RevertSpans(workerCtx, db, spans,
+					targetTime, ignoreGCThreshold, batchSize, callback)
+			})
+		}
+		return errGroup.Wait()
+	}
+
+	if onCompletedCallback != nil {
+		// If we have an onCompletedCallback and are using multiple
+		// workers, arrange for it to be called serially so that callers
+		// don't need to worry about making it concurrency safe.
+		g := ctxgroup.WithContext(ctx)
+		completedSpanCh := make(chan roachpb.Span)
+		errCh := make(chan error)
+		g.GoCtx(func(ctx context.Context) error {
+			defer close(errCh)
+			for sp := range completedSpanCh {
+				errCh <- onCompletedCallback(ctx, sp)
+			}
+			return nil
+		})
+		g.GoCtx(func(ctx context.Context) error {
+			defer close(completedSpanCh)
+			return runRevertSpanWorkers(func(_ context.Context, completed roachpb.Span) error {
+				completedSpanCh <- completed
+				return <-errCh
+			})
+		})
+		return g.Wait()
+	} else {
+		// Otherwise, just run the workers directly.
+		return runRevertSpanWorkers(onCompletedCallback)
+	}
+}
+
+// RevertSpans reverts the passed span to the target time, which must be above
+// the GC threshold for every range (unless the flag ignoreGCThreshold is passed
+// which should be done with care -- see RevertRangeRequest.IgnoreGCThreshold).
+//
+// The onCompletedSpan is called after each response to a RevertRange
+// request.
+func RevertSpans(
+	ctx context.Context,
+	db *kv.DB,
+	spans []roachpb.Span,
+	targetTime hlc.Timestamp,
+	ignoreGCThreshold bool,
+	batchSize int64,
+	onCompletedSpan func(ctx context.Context, completed roachpb.Span) error,
+) error {
+	ctx, sp := tracing.ChildSpan(ctx, "sql.RevertSpans")
+	defer sp.Finish()
+
+	for _, sp := range spans {
+		span := &sp
+		for span != nil {
+			var b kv.Batch
 			b.AddRawRequest(&kvpb.RevertRangeRequest{
 				RequestHeader: kvpb.RequestHeader{
 					Key:    span.Key,
@@ -94,21 +219,38 @@ func RevertTables(
 				TargetTime:        targetTime,
 				IgnoreGcThreshold: ignoreGCThreshold,
 			})
-		}
-		b.Header.MaxSpanRequestKeys = batchSize
+			// TODO(ssd): We should probably be setting an
+			// admission header here has well.
+			b.Header.MaxSpanRequestKeys = batchSize
 
-		if err := db.Run(ctx, &b); err != nil {
-			return err
-		}
+			log.VEventf(ctx, 2, "RevertRange %s %s", span, targetTime)
+			if err := db.Run(ctx, &b); err != nil {
+				return err
+			}
 
-		spans = spans[:0]
-		for _, raw := range b.RawResponse().Responses {
-			r := raw.GetRevertRange()
-			if r.ResumeSpan != nil {
-				if !r.ResumeSpan.Valid() {
-					return errors.Errorf("invalid resume span: %s", r.ResumeSpan)
+			if l := len(b.RawResponse().Responses); l != 1 {
+				return errors.AssertionFailedf("expected single response, got %d", l)
+			}
+
+			resp := b.RawResponse().Responses[0].GetRevertRange()
+			if resp == nil {
+				return errors.AssertionFailedf("expected RevertRangeResponse, got: %v", resp)
+			}
+
+			completed := *span
+			span = resp.ResumeSpan
+
+			if resp.ResumeSpan != nil {
+				if !resp.ResumeSpan.Valid() {
+					return errors.Errorf("invalid resume span: %s", resp.ResumeSpan)
 				}
-				spans = append(spans, *r.ResumeSpan)
+				completed.EndKey = resp.ResumeSpan.Key
+			}
+
+			if onCompletedSpan != nil {
+				if err := onCompletedSpan(ctx, completed); err != nil {
+					return err
+				}
 			}
 		}
 	}

--- a/pkg/sql/revert_test.go
+++ b/pkg/sql/revert_test.go
@@ -12,18 +12,23 @@ package sql_test
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/security/username"
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/bootstrap"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/desctestutils"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/catid"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
@@ -104,6 +109,206 @@ func TestTableRollback(t *testing.T) {
 
 		db.CheckQueryResults(t, `SELECT count(*) FROM test`, beforeNumRows)
 	})
+}
+
+// TestTableRollbackMultiTable is a regression test for a previous bug
+// in RevertTables in which passing two tables to the function would
+// cause a log.Fatal error from KV.
+func TestTableRollbackMultiTable(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	s, sqlDB, kv := serverutils.StartServer(
+		t, base.TestServerArgs{UseDatabase: "test"})
+	defer s.Stopper().Stop(context.Background())
+	execCfg := s.ExecutorConfig().(sql.ExecutorConfig)
+
+	db := sqlutils.MakeSQLRunner(sqlDB)
+	db.Exec(t, "CREATE DATABASE IF NOT EXISTS test")
+	db.Exec(t, "CREATE TABLE test (k INT PRIMARY KEY)")
+	db.Exec(t, "CREATE TABLE test2 (k INT PRIMARY KEY)")
+
+	kvDB := s.DB()
+	desc1 := desctestutils.TestingGetPublicTableDescriptor(kvDB, execCfg.Codec, "test", "test")
+	desc2 := desctestutils.TestingGetPublicTableDescriptor(kv, keys.SystemSQLCodec, "test", "test2")
+
+	tableID1 := desc1.GetID()
+	tableID2 := desc2.GetID()
+
+	const numRows = 1000
+	db.Exec(t, `INSERT INTO test (k) SELECT generate_series(1, $1)`, numRows)
+	db.Exec(t, `INSERT INTO test2 (k) SELECT generate_series(1, $1)`, numRows)
+
+	before1, ts := fingerprintTableNoHistory(t, db, tableID1, "")
+	before2, _ := fingerprintTableNoHistory(t, db, tableID2, ts)
+
+	targetTime, err := hlc.ParseHLC(ts)
+	require.NoError(t, err)
+
+	// Delete some rows
+	db.Exec(t, `DELETE FROM test WHERE k % 5 = 2`)
+	db.Exec(t, `DELETE FROM test2 WHERE k % 5 = 2`)
+
+	afterDelete1, _ := fingerprintTableNoHistory(t, db, tableID1, "")
+	afterDelete2, _ := fingerprintTableNoHistory(t, db, tableID2, "")
+	require.NotEqual(t, before1, afterDelete1)
+	require.NotEqual(t, before2, afterDelete2)
+
+	aost1, _ := fingerprintTableNoHistory(t, db, tableID1, ts)
+	aost2, _ := fingerprintTableNoHistory(t, db, tableID2, ts)
+	require.Equal(t, before1, aost1)
+	require.Equal(t, before2, aost2)
+
+	const ignoreGC = false
+
+	// Bypass the offline check.
+	desc1.TableDesc().State = descpb.DescriptorState_OFFLINE
+	desc2.TableDesc().State = descpb.DescriptorState_OFFLINE
+
+	require.NoError(t, sql.RevertTables(context.Background(), kv, &execCfg, []catalog.TableDescriptor{desc1, desc2}, targetTime, ignoreGC, 10))
+
+	reverted1, _ := fingerprintTableNoHistory(t, db, tableID1, "")
+	reverted2, _ := fingerprintTableNoHistory(t, db, tableID2, "")
+	require.Equal(t, before1, reverted1, "expected reverted table after edits to match before")
+	require.Equal(t, before2, reverted2, "expected reverted table after edits to match before")
+}
+
+// TestRevertSpansFanout tests RevertSpansFanout using the same
+// sequence of modifications used in TestTableRollback.
+//
+// We use more splits and scatter the ranges.
+func TestRevertSpansFanout(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+
+	tc := testcluster.StartTestCluster(t, 3, base.TestClusterArgs{
+		ServerArgs: base.TestServerArgs{UseDatabase: "test"},
+	})
+	defer tc.Stopper().Stop(context.Background())
+	s := tc.TenantOrServer(0)
+	sqlDB := tc.Conns[0]
+
+	execCfg := s.ExecutorConfig().(sql.ExecutorConfig)
+
+	db := sqlutils.MakeSQLRunner(sqlDB)
+	db.Exec(t, "CREATE DATABASE IF NOT EXISTS test")
+	db.Exec(t, "CREATE TABLE test (k INT PRIMARY KEY, rev INT DEFAULT 0, INDEX (rev))")
+
+	kvDB := s.DB()
+	desc := desctestutils.TestingGetPublicTableDescriptor(kvDB, execCfg.Codec, "test", "test")
+	span := desc.TableSpan(execCfg.Codec)
+	tableID := desc.GetID()
+
+	// Fill a table with some rows plus some revisions to those rows.
+	const (
+		initRows  = 1000
+		extraRows = 500
+		splits    = 100
+	)
+
+	db.Exec(t, "INSERT INTO test (k) SELECT generate_series(1, $1)", initRows)
+	db.Exec(t, "UPDATE test SET rev = 1 WHERE k % 3 = 0")
+	db.Exec(t, "DELETE FROM test WHERE k % 10 = 0")
+	before, ts := fingerprintTableNoHistory(t, db, tableID, "")
+	targetTime, err := hlc.ParseHLC(ts)
+	require.NoError(t, err)
+
+	beforeNumRows := db.QueryStr(t, "SELECT count(*) FROM test")
+
+	// Make some more edits: delete some rows and edit others, insert into some of
+	// the gaps made between previous rows, edit a large swath of rows and add a
+	// large swath of new rows as well.
+	db.Exec(t, "DELETE FROM test WHERE k % 5 = 2")
+	db.Exec(t, "INSERT INTO test (k, rev) SELECT generate_series(10, $1, 10), 10", initRows)
+	db.Exec(t, "INSERT INTO test (k, rev) SELECT generate_series($1+1, $1+$2, 1), $2", initRows, extraRows)
+	db.Exec(t, "UPDATE test SET rev = 2 WHERE k % 4 = 0")
+	db.Exec(t, "UPDATE test SET rev = 4 WHERE k > 150 and k < 350")
+
+	var splitPointsBuf strings.Builder
+	splitIncrement := (initRows + extraRows) / splits
+	for i := 0; i < 100; i++ {
+		splitPoint := splitIncrement * i
+		if i == 0 {
+			fmt.Fprintf(&splitPointsBuf, "(%d)", splitPoint)
+		} else {
+			fmt.Fprintf(&splitPointsBuf, ", (%d)", splitPoint)
+		}
+	}
+
+	// Split and scatter the table.
+	db.Exec(t, fmt.Sprintf("ALTER TABLE test SPLIT AT VALUES %s", splitPointsBuf.String()))
+	db.Exec(t, "ALTER TABLE test SCATTER")
+
+	rsCtx, close := sql.MakeJobExecContext("revert-spans", username.RootUserName(), &sql.MemoryMetrics{}, &execCfg)
+	defer close()
+
+	verifyRevert := func() {
+		reverted, _ := fingerprintTableNoHistory(t, db, tableID, "")
+		require.Equal(t, before, reverted, "expected reverted table after edits to match before")
+		db.CheckQueryResults(t, "SELECT count(*) FROM test", beforeNumRows)
+	}
+
+	t.Run("revert-fanout-with-callback", func(t *testing.T) {
+		require.NoError(t,
+			sql.RevertSpansFanout(ctx,
+				kvDB, rsCtx, []roachpb.Span{span}, targetTime, false, 10,
+				func(context.Context, roachpb.Span) error {
+					return nil
+				}))
+		verifyRevert()
+	})
+	t.Run("revert-without-callback", func(t *testing.T) {
+		db.Exec(t, "DELETE FROM test WHERE k % 5 = 2")
+		require.NoError(t,
+			sql.RevertSpansFanout(ctx,
+				kvDB, rsCtx, []roachpb.Span{span}, targetTime, false, 10, nil))
+		verifyRevert()
+	})
+	t.Run("revert-with-1-worker", func(t *testing.T) {
+		db.Exec(t, "DELETE FROM test WHERE k % 5 = 2")
+		db.Exec(t, "SET CLUSTER SETTING sql.revert.max_span_parallelism = 1")
+		defer db.Exec(t, "RESET CLUSTER SETTING sql.revert.max_span_parallelism")
+		require.NoError(t,
+			sql.RevertSpansFanout(ctx,
+				kvDB, rsCtx, []roachpb.Span{span}, targetTime, false, 10,
+				func(context.Context, roachpb.Span) error {
+					return nil
+				}))
+		verifyRevert()
+
+	})
+	t.Run("revert-with-failing-callback", func(t *testing.T) {
+		require.Error(t,
+			sql.RevertSpansFanout(ctx,
+				kvDB, rsCtx, []roachpb.Span{span}, targetTime, false, 10,
+				func(context.Context, roachpb.Span) error {
+					return errors.New("callback failed")
+				}), "callbackFailed")
+		// No use verifying, the revert failed and we didn't
+		// make any changes anyway.
+	})
+}
+
+// fingerprintTableNoHistory returns the fingerprint of the given
+// table as well as the time the fingerprint was taken at.
+//
+// If a non-empty ts string is specified, the fingerprint will be
+// taken at that timestamp.
+func fingerprintTableNoHistory(
+	t *testing.T, db *sqlutils.SQLRunner, tableID catid.DescID, ts string,
+) (int, string) {
+	t.Helper()
+	query := "SELECT cluster_logical_timestamp(), * FROM crdb_internal.fingerprint(crdb_internal.table_span($1), 0::timestamptz, false)"
+	if ts != "" {
+		query = fmt.Sprintf("%s AS OF SYSTEM TIME %s", query, ts)
+	}
+
+	var fingerprint int
+	var timestamp string
+	db.QueryRow(t, query, tableID).Scan(&timestamp, &fingerprint)
+	return fingerprint, timestamp
 }
 
 func TestRevertGCThreshold(t *testing.T) {


### PR DESCRIPTION
This PR adds RevertSpans and RevertSpansFanout.

RevertSpans de-duplicates some code between import rollback and streaming cutover.

Along the way, it fixes a small bug that existed in RevertTables: Only a single RevertRangeRequest is permitted in a batch since RevertRangeRequest has the isAlone flag set. As a result, a future caller of RevertTables would have encountered a fatal error from KV.

RevertSpansFanout uses DistSQL's PartitionSpans to manually fan out multiple RevertRange requests. Since all users of revert range request currently set a limit on the number of keys touched, dist sender doesn't fanout such request.

Epic: none

Release note: None