### PR TITLE
logictest: disable workmem randomization with the --rewrite flag

### DIFF
--- a/pkg/sql/logictest/logic.go
+++ b/pkg/sql/logictest/logic.go
@@ -4138,7 +4138,10 @@ func RunLogicTest(
 		}()
 	}
 
-	if *defaultWorkmem {
+	// Testing sql.distsql.temp_storage.workmem metamorphically isn't needed
+	// when rewriting logic test files, so we disable workmem randomization if
+	// the --rewrite flag is present.
+	if *defaultWorkmem || *rewriteResultsInTestfiles {
 		serverArgs.DisableWorkmemRandomization = true
 	}
 


### PR DESCRIPTION
This commit makes a minor ergonomic improvement to logic tests that
randomization of the `sql.distsql.temp_storage.workmem` setting is
disabled if the `--rewrite` flag is present. This reduces painfully slow
tests during development when the `--rewrite` flag is commonly used,
without having to pass the `--default-workmem` flag.

Epic: None

Release note: None
