### PR TITLE
builtins: fix crdb_internal.hide_sql_constants array overload

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/builtin_function
+++ b/pkg/sql/logictest/testdata/logic_test/builtin_function
@@ -3732,9 +3732,9 @@ SELECT crdb_internal.hide_sql_constants('select _, _, _')
 SELECT _, _, _
 
 query T
-SELECT crdb_internal.hide_sql_constants(ARRAY('select 1', NULL, 'select ''hello''', ''))
+SELECT crdb_internal.hide_sql_constants(ARRAY('select 1', NULL, 'select ''hello''', '', 'not a sql stmt'))
 ----
-{"SELECT _",NULL,"SELECT '_'",""}
+{"SELECT _",NULL,"SELECT '_'","",""}
 
 query T
 SELECT crdb_internal.hide_sql_constants('SELECT ''yes'' IN (''no'', ''maybe'', ''yes'')')

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -7746,11 +7746,10 @@ expires until the statement bundle is collected`,
 
 					if len(sql) != 0 {
 						parsed, err := parser.ParseOne(sql)
-						if err != nil {
-							return tree.NewDString(sqlNoConstants), nil //nolint:returnerrcheck
+						// Leave result as empty string on parsing error.
+						if err == nil {
+							sqlNoConstants = tree.AsStringWithFlags(parsed.AST, tree.FmtHideConstants)
 						}
-
-						sqlNoConstants = tree.AsStringWithFlags(parsed.AST, tree.FmtHideConstants)
 					}
 
 					if err := result.Append(tree.NewDString(sqlNoConstants)); err != nil {


### PR DESCRIPTION
Previously, erroring on parsing a stmt provided in one of the array elements to crdb_internal.hide_sql_constants would result in an error. This commit ensures that the empty string is returned for an unparseable stmt.

Epic: none

Release note: None