### PR TITLE
sql: fix internal error with ambiguous overloads

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/udf
+++ b/pkg/sql/logictest/testdata/logic_test/udf
@@ -3152,3 +3152,14 @@ query I
 SELECT public.abs(-1)
 ----
 99
+
+subtest regression_97854
+
+# Regression test for #97854.
+statement ok
+CREATE FUNCTION f_97854 (i INT) RETURNS CHAR LANGUAGE SQL AS $$ SELECT 'i' $$;
+CREATE FUNCTION f_97854 (f FLOAT) RETURNS CHAR LANGUAGE SQL AS $$ SELECT 'f' $$;
+
+# TODO(#88318): In Postgres, the float overload is chosen.
+statement error pgcode 42725 ambiguous call: f_97854\(decimal\).*
+SELECT f_97854(1.0)

--- a/pkg/sql/opt/testutils/testcat/function.go
+++ b/pkg/sql/opt/testutils/testcat/function.go
@@ -62,6 +62,8 @@ func (tc *Catalog) CreateFunction(c *tree.CreateFunction) {
 		panic(fmt.Errorf("built-in function with name %q already exists", name))
 	}
 	if _, ok := tc.udfs[name]; ok {
+		// TODO(mgartner): The test catalog should support multiple overloads
+		// with the same name if their arguments are different.
 		panic(fmt.Errorf("user-defined function with name %q already exists", name))
 	}
 	if c.RoutineBody != nil {

--- a/pkg/sql/sem/tree/type_check.go
+++ b/pkg/sql/sem/tree/type_check.go
@@ -3110,6 +3110,9 @@ func getMostSignificantOverload(
 				matchIdx = k
 			}
 		}
+		if !foundMatch {
+			return QualifiedOverload{}, ambiguousError()
+		}
 		return qualifiedOverloads[oImpls[matchIdx]], nil
 	}
 


### PR DESCRIPTION
This commit fixes an internal error that occurs when a UDF reference is
ambiguous.

Fixes #97854

There is not release note because this bug is not present in any
released versions.

Release note: None
