### PR TITLE
storage: set shared storage creator ID

### DIFF
--- a/docs/generated/settings/settings-for-tenants.txt
+++ b/docs/generated/settings/settings-for-tenants.txt
@@ -297,4 +297,4 @@ trace.jaeger.agent	string		the address of a Jaeger agent to receive traces using
 trace.opentelemetry.collector	string		address of an OpenTelemetry trace collector to receive traces using the otel gRPC protocol, as <host>:<port>. If no port is specified, 4317 will be used.
 trace.span_registry.enabled	boolean	true	if set, ongoing traces can be seen at https://<ui>/#/debug/tracez
 trace.zipkin.collector	string		the address of a Zipkin instance to receive traces, as <host>:<port>. If no port is specified, 9411 will be used.
-version	version	1000022.2-62	set the active cluster version in the format '<major>.<minor>'
+version	version	1000022.2-64	set the active cluster version in the format '<major>.<minor>'

--- a/docs/generated/settings/settings.html
+++ b/docs/generated/settings/settings.html
@@ -238,6 +238,6 @@
 <tr><td><div id="setting-trace-opentelemetry-collector" class="anchored"><code>trace.opentelemetry.collector</code></div></td><td>string</td><td><code></code></td><td>address of an OpenTelemetry trace collector to receive traces using the otel gRPC protocol, as &lt;host&gt;:&lt;port&gt;. If no port is specified, 4317 will be used.</td></tr>
 <tr><td><div id="setting-trace-span-registry-enabled" class="anchored"><code>trace.span_registry.enabled</code></div></td><td>boolean</td><td><code>true</code></td><td>if set, ongoing traces can be seen at https://&lt;ui&gt;/#/debug/tracez</td></tr>
 <tr><td><div id="setting-trace-zipkin-collector" class="anchored"><code>trace.zipkin.collector</code></div></td><td>string</td><td><code></code></td><td>the address of a Zipkin instance to receive traces, as &lt;host&gt;:&lt;port&gt;. If no port is specified, 9411 will be used.</td></tr>
-<tr><td><div id="setting-version" class="anchored"><code>version</code></div></td><td>version</td><td><code>1000022.2-62</code></td><td>set the active cluster version in the format &#39;&lt;major&gt;.&lt;minor&gt;&#39;</td></tr>
+<tr><td><div id="setting-version" class="anchored"><code>version</code></div></td><td>version</td><td><code>1000022.2-64</code></td><td>set the active cluster version in the format &#39;&lt;major&gt;.&lt;minor&gt;&#39;</td></tr>
 </tbody>
 </table>

--- a/pkg/cli/testdata/declarative-rules/deprules
+++ b/pkg/cli/testdata/declarative-rules/deprules
@@ -1,6 +1,6 @@
 dep
 ----
-debug declarative-print-rules 1000022.2-62 dep
+debug declarative-print-rules 1000022.2-64 dep
 deprules
 ----
 - name: 'CheckConstraint transitions to ABSENT uphold 2-version invariant: PUBLIC->VALIDATED'

--- a/pkg/cli/testdata/declarative-rules/oprules
+++ b/pkg/cli/testdata/declarative-rules/oprules
@@ -1,6 +1,6 @@
 op
 ----
-debug declarative-print-rules 1000022.2-62 op
+debug declarative-print-rules 1000022.2-64 op
 rules
 ----
 []

--- a/pkg/clusterversion/cockroach_versions.go
+++ b/pkg/clusterversion/cockroach_versions.go
@@ -442,12 +442,12 @@ const (
 	// backfilled.
 	V23_1DatabaseRoleSettingsRoleIDColumnBackfilled
 
-	// V23_1_MVCCRangeTombstonesUnconditionallyEnabled is a version gate at and
-	// after which Cockroach will always write MVCC Range Tombstones, regardless
-	// of the value of the storage.mvcc.range_tombstones.enabled cluster setting.
-	// Prior to this version, it was possible for a cluster to be writing MVCC
-	// Range Tombstones, but only if the cluster had been opted in manually, under
-	// a specific set of circumstances (i.e. appropriate 22.2.x version, Cockroach
+	// V23_1_MVCCRangeTombstonesUnconditionallyEnabled is a version gate after
+	// which Cockroach will always write MVCC Range Tombstones, regardless of the
+	// value of the storage.mvcc.range_tombstones.enabled cluster setting. Prior
+	// to this version, it was possible for a cluster to be writing MVCC Range
+	// Tombstones, but only if the cluster had been opted in manually, under a
+	// specific set of circumstances (i.e. appropriate 22.2.x version, Cockroach
 	// Cloud cluster, etc.).
 	V23_1_MVCCRangeTombstonesUnconditionallyEnabled
 
@@ -458,6 +458,10 @@ const (
 	// V23_1DeprecateClusterVersionKey is the version where we no longer write
 	// cluster version keys to engines.
 	V23_1DeprecateClusterVersionKey
+
+	// V23_1SetPebbleCreatorID is a version gate after which we set the Creator ID
+	// on Pebble stores that have shared storage configured.
+	V23_1SetPebbleCreatorID
 
 	// *************************************************
 	// Step (1): Add new versions here.
@@ -795,6 +799,10 @@ var rawVersionsSingleton = keyedVersions{
 	{
 		Key:     V23_1DeprecateClusterVersionKey,
 		Version: roachpb.Version{Major: 22, Minor: 2, Internal: 62},
+	},
+	{
+		Key:     V23_1SetPebbleCreatorID,
+		Version: roachpb.Version{Major: 22, Minor: 2, Internal: 64},
 	},
 
 	// *************************************************

--- a/pkg/kv/kvserver/kvstorage/init.go
+++ b/pkg/kv/kvserver/kvstorage/init.go
@@ -72,6 +72,12 @@ func InitEngine(ctx context.Context, eng storage.Engine, ident roachpb.StoreIden
 	if err := batch.Commit(true /* sync */); err != nil {
 		return errors.Wrap(err, "persisting engine initialization data")
 	}
+	// We will set the store ID during start, but we want to set it as quickly as
+	// possible after creating a store (to initialize the shared object creator
+	// ID).
+	if err := eng.SetStoreID(ctx, int32(ident.StoreID)); err != nil {
+		return errors.Wrap(err, "setting store ID")
+	}
 
 	return nil
 }

--- a/pkg/kv/kvserver/store.go
+++ b/pkg/kv/kvserver/store.go
@@ -1803,10 +1803,10 @@ func (s *Store) Start(ctx context.Context, stopper *stop.Stopper) error {
 	ctx = s.AnnotateCtx(ctx)
 	log.Event(ctx, "read store identity")
 
-	// Communicate store ID to engine, if it needs it.
+	// Communicate store ID to engine.
 	// TODO(sep-raft-log): do for both engines.
-	if logSetter, ok := s.TODOEngine().(storage.StoreIDSetter); ok {
-		logSetter.SetStoreID(ctx, int32(s.StoreID()))
+	if err := s.TODOEngine().SetStoreID(ctx, int32(s.StoreID())); err != nil {
+		return err
 	}
 
 	// Add the store ID to the scanner's AmbientContext before starting it, since

--- a/pkg/roachpb/version.go
+++ b/pkg/roachpb/version.go
@@ -49,6 +49,11 @@ func (v Version) LessEq(otherV Version) bool {
 	return v.Equal(otherV) || v.Less(otherV)
 }
 
+// AtLeast returns true if the receiver is greater than or requal to the parameter.
+func (v Version) AtLeast(otherV Version) bool {
+	return !otherV.Less(v)
+}
+
 // String implements the fmt.Stringer interface.
 func (v Version) String() string { return redact.StringWithoutMarkers(v) }
 

--- a/pkg/server/sticky_engine.go
+++ b/pkg/server/sticky_engine.go
@@ -88,10 +88,8 @@ func (e *stickyInMemEngine) Closed() bool {
 }
 
 // SetStoreID implements the StoreIDSetter interface.
-func (e *stickyInMemEngine) SetStoreID(ctx context.Context, storeID int32) {
-	if storeIDSetter, ok := e.Engine.(storage.StoreIDSetter); ok {
-		storeIDSetter.SetStoreID(ctx, storeID)
-	}
+func (e *stickyInMemEngine) SetStoreID(ctx context.Context, storeID int32) error {
+	return e.Engine.SetStoreID(ctx, storeID)
 }
 
 // stickyInMemEnginesRegistryImpl is the bookkeeper for all active

--- a/pkg/storage/engine.go
+++ b/pkg/storage/engine.go
@@ -963,6 +963,11 @@ type Engine interface {
 	// SetCompactionConcurrency is used to set the engine's compaction
 	// concurrency. It returns the previous compaction concurrency.
 	SetCompactionConcurrency(n uint64) uint64
+
+	// SetStoreID informs the engine of the store ID, once it is known.
+	// Used to show the store ID in logs and to initialize the shared object
+	// creator ID (if shared object storage is configured).
+	SetStoreID(ctx context.Context, storeID int32) error
 }
 
 // Batch is the interface for batch specific operations.

--- a/pkg/storage/pebble.go
+++ b/pkg/storage/pebble.go
@@ -755,7 +755,7 @@ type Pebble struct {
 	minVersion roachpb.Version
 
 	// closer is populated when the database is opened. The closer is associated
-	// with the filesyetem
+	// with the filesystem.
 	closer io.Closer
 
 	wrappedIntentWriter intentDemuxWriter
@@ -798,14 +798,6 @@ var WorkloadCollectorEnabled = envutil.EnvOrDefaultBool("COCKROACH_STORAGE_WORKL
 // code does not depend on CCL code.
 var NewEncryptedEnvFunc func(fs vfs.FS, fr *PebbleFileRegistry, dbDir string, readOnly bool, optionBytes []byte) (*EncryptionEnv, error)
 
-// StoreIDSetter is used to set the store id in the log.
-type StoreIDSetter interface {
-	// SetStoreID can be used to atomically set the store
-	// id as a tag in the pebble logs. Once set, the store id will be visible
-	// in pebble logs in cockroach.
-	SetStoreID(ctx context.Context, storeID int32)
-}
-
 // SetCompactionConcurrency will return the previous compaction concurrency.
 func (p *Pebble) SetCompactionConcurrency(n uint64) uint64 {
 	prevConcurrency := atomic.SwapUint64(&p.atomic.compactionConcurrency, n)
@@ -813,14 +805,24 @@ func (p *Pebble) SetCompactionConcurrency(n uint64) uint64 {
 }
 
 // SetStoreID adds the store id to pebble logs.
-func (p *Pebble) SetStoreID(ctx context.Context, storeID int32) {
+func (p *Pebble) SetStoreID(ctx context.Context, storeID int32) error {
 	if p == nil {
-		return
+		return nil
 	}
-	if p.storeIDPebbleLog == nil {
-		return
+	if p.storeIDPebbleLog != nil {
+		p.storeIDPebbleLog.Set(ctx, storeID)
 	}
-	p.storeIDPebbleLog.Set(ctx, storeID)
+	// Note that SetCreatorID only does something if shared storage is configured
+	// in the pebble options. The version gate protects against accidentally
+	// setting the creator ID on an older store.
+	// TODO(radu): we don't yet have a complete story about how we will transition
+	// an existing store to use shared storage.
+	if storeID != base.TempStoreID && p.minVersion.AtLeast(clusterversion.ByKey(clusterversion.V23_1SetPebbleCreatorID)) {
+		if err := p.db.SetCreatorID(uint64(storeID)); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // ResolveEncryptedEnvOptions creates the EncryptionEnv and associated file

--- a/pkg/storage/temp_engine.go
+++ b/pkg/storage/temp_engine.go
@@ -96,8 +96,9 @@ func newPebbleTempEngine(
 		return nil, nil, err
 	}
 
-	// Set store ID for the pebble engine.
-	p.SetStoreID(ctx, base.TempStoreID)
+	// Set store ID for the pebble engine. We are not using shared storage for
+	// temp stores so this cannot error out.
+	_ = p.SetStoreID(ctx, base.TempStoreID)
 	return &pebbleTempEngine{
 		db:     p.db,
 		closer: p.closer,


### PR DESCRIPTION
Set the Pebble shared object creator ID when initializing or starting
the store. The creator ID is only set if shared storage is configured
from the store (currently only the case with an experimental flag). We
also add a version gate to avoid accidentally setting the creator ID
on a 22.2 store.

Release note: none
Epic: none
