### PR TITLE
server: rationalize tenant TestServers metrics registration

### DIFF
--- a/pkg/cli/mt_start_sql.go
+++ b/pkg/cli/mt_start_sql.go
@@ -92,7 +92,6 @@ func runStartSQL(cmd *cobra.Command, args []string) error {
 			stopper,
 			serverCfg.BaseConfig,
 			serverCfg.SQLConfig,
-			nil, /* parentRecorder */
 			nil, /* tenantNameContainer */
 		)
 		if err != nil {

--- a/pkg/server/status/recorder.go
+++ b/pkg/server/status/recorder.go
@@ -299,7 +299,8 @@ func (mr *MetricsRecorder) ExportToGraphite(
 }
 
 // GetTimeSeriesData serializes registered metrics for consumption by
-// CockroachDB's time series system.
+// CockroachDB's time series system. GetTimeSeriesData implements the DataSource
+// interface of the ts package.
 func (mr *MetricsRecorder) GetTimeSeriesData() []tspb.TimeSeriesData {
 	mr.mu.RLock()
 	defer mr.mu.RUnlock()

--- a/pkg/server/tenant.go
+++ b/pkg/server/tenant.go
@@ -162,11 +162,10 @@ func NewSeparateProcessTenantServer(
 	stopper *stop.Stopper,
 	baseCfg BaseConfig,
 	sqlCfg SQLConfig,
-	parentRecorder *status.MetricsRecorder,
 	tenantNameContainer *roachpb.TenantNameContainer,
 ) (*SQLServerWrapper, error) {
 	instanceIDContainer := baseCfg.IDContainer.SwitchToSQLIDContainerForStandaloneSQLInstance()
-	return newTenantServer(ctx, stopper, baseCfg, sqlCfg, parentRecorder, tenantNameContainer, instanceIDContainer)
+	return newTenantServer(ctx, stopper, baseCfg, sqlCfg, nil /* parentRecorder */, tenantNameContainer, instanceIDContainer)
 }
 
 // NewSeparateProcessTenantServer creates a tenant-specific, SQL-only
@@ -190,6 +189,9 @@ func NewSharedProcessTenantServer(
 	return newTenantServer(ctx, stopper, baseCfg, sqlCfg, parentRecorder, tenantNameContainer, instanceIDContainer)
 }
 
+// newTenantServer constructs a SQLServerWrapper.
+//
+// The tenant's metrics registry is registered with parentRecorder, if not nil.
 func newTenantServer(
 	ctx context.Context,
 	stopper *stop.Stopper,

--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -1120,7 +1120,6 @@ func (ts *TestServer) StartTenant(
 		stopper,
 		baseCfg,
 		sqlCfg,
-		ts.recorder,
 		roachpb.NewTenantNameContainer(params.TenantName),
 	)
 	if err != nil {


### PR DESCRIPTION
This patch makes tenant test servers started with StartTenant (as
opposed to StartSharedProcessTenant) not register their metrics in the
parent TestServer's MetricRecorder. I believe the fact that they were
previously registering themselves to have been a mistake. To better
simulate out-of-process tenants, we should not have references like this
from a TestServer to the "out-of-process" tenants.
StartSharedProcessTenants tenants continue to be registered with the
parent Server.

Background: when a tenant registers with a parent recorder, the tenant's
metrics are reported on _status/vars. Note that these tenant metrics are
not currently written to TSDB, although work on that is happening
elsewhere.

I believe the only practical thing that this patch affects is
`cockroach demo --multitenant=true --disable-server-controller=true`
(which is not the default). Before, regardless of
`--disable-server-controller`, the tenant's metrics were reported on the
system's status/vars. Now, they're no longer reported there with
`--disable-server-controller=true` - which I believe is a good
thing because it more accurately represents reality with out-of-process
tenants (I don't know if --disable-server-controller=true deserves to
exist at all, btw).

Release note: None
Epic: None