### PR TITLE
server: minor cleanup

### DIFF
--- a/pkg/server/server_controller_new_server.go
+++ b/pkg/server/server_controller_new_server.go
@@ -200,7 +200,7 @@ func makeSharedProcessTenantServerConfig(
 	if err := clusterversion.Initialize(
 		ctx, st.Version.BinaryMinSupportedVersion(), &st.SV,
 	); err != nil {
-		return baseCfg, sqlCfg, err
+		return BaseConfig{}, SQLConfig{}, err
 	}
 
 	tr := tracing.NewTracerWithOpt(ctx, tracing.WithClusterSettings(&st.SV))
@@ -226,7 +226,7 @@ func makeSharedProcessTenantServerConfig(
 	if !storeSpec.InMemory {
 		storeDir := filepath.Join(storeSpec.Path, "tenant-"+tenantID.String())
 		if err := os.MkdirAll(storeDir, 0755); err != nil {
-			return baseCfg, sqlCfg, err
+			return BaseConfig{}, SQLConfig{}, err
 		}
 		stopper.AddCloser(stop.CloserFn(func() {
 			if err := os.RemoveAll(storeDir); err != nil {
@@ -262,7 +262,7 @@ func makeSharedProcessTenantServerConfig(
 	baseCfg.Addr, err1 = rederivePort(index, kvServerCfg.Config.Addr, "", portOffset)
 	baseCfg.AdvertiseAddr, err2 = rederivePort(index, kvServerCfg.Config.AdvertiseAddr, baseCfg.Addr, portOffset)
 	if err := errors.CombineErrors(err1, err2); err != nil {
-		return baseCfg, sqlCfg, err
+		return BaseConfig{}, SQLConfig{}, err
 	}
 
 	// The parent server will route HTTP requests to us.
@@ -312,7 +312,7 @@ func makeSharedProcessTenantServerConfig(
 	if kvServerCfg.BaseConfig.InflightTraceDirName != "" {
 		traceDir := filepath.Join(kvServerCfg.BaseConfig.InflightTraceDirName, "tenant-"+tenantID.String())
 		if err := os.MkdirAll(traceDir, 0755); err != nil {
-			return baseCfg, sqlCfg, err
+			return BaseConfig{}, SQLConfig{}, err
 		}
 		baseCfg.InflightTraceDirName = traceDir
 	}
@@ -325,12 +325,12 @@ func makeSharedProcessTenantServerConfig(
 	// TODO(knz): Make tempDir configurable.
 	tempDir := useStore.Path
 	if tempStorageCfg.Path, err = fs.CreateTempDir(tempDir, TempDirPrefix, stopper); err != nil {
-		return baseCfg, sqlCfg, errors.Wrap(err, "could not create temporary directory for temp storage")
+		return BaseConfig{}, SQLConfig{}, errors.Wrap(err, "could not create temporary directory for temp storage")
 	}
 	if useStore.Path != "" {
 		recordPath := filepath.Join(useStore.Path, TempDirsRecordFilename)
 		if err := fs.RecordTempDir(recordPath, tempStorageCfg.Path); err != nil {
-			return baseCfg, sqlCfg, errors.Wrap(err, "could not record temp dir")
+			return BaseConfig{}, SQLConfig{}, errors.Wrap(err, "could not record temp dir")
 		}
 	}
 


### PR DESCRIPTION
This method was returning both values and an error in multiple places. This was unusual and misleading. The caller ignores the returned values on error. This patch makes it return empty values.

Release note: None
Epic: None