### PR TITLE
server: cleanups around a tenant's metrics registry

### DIFF
--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -517,6 +517,10 @@ type SQLConfig struct {
 	// LocalKVServerInfo is set in configs for shared-process tenants. It contains
 	// info for making Batch requests to the local KV server without using gRPC.
 	LocalKVServerInfo *LocalKVServerInfo
+
+	// NodeMetricsRecorder is the node's MetricRecorder; the tenant's metrics will
+	// be recorded with it. Nil if this is not a shared-process tenant.
+	NodeMetricsRecorder *status.MetricsRecorder
 }
 
 // LocalKVServerInfo is used to group information about the local KV server

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -755,11 +755,12 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 	systemTenantNameContainer := roachpb.NewTenantNameContainer(catconstants.SystemTenantName)
 
 	recorder := status.NewMetricsRecorder(
-		clock,
-		nodeLiveness,
-		rpcContext,
-		st,
+		rpcContext.TenantID,
 		systemTenantNameContainer,
+		nodeLiveness,
+		rpcContext.RemoteClocks,
+		clock,
+		st,
 	)
 	registry.AddMetricStruct(rpcContext.RemoteClocks.Metrics())
 

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -759,7 +759,7 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 		systemTenantNameContainer,
 		nodeLiveness,
 		rpcContext.RemoteClocks,
-		clock,
+		clock.WallClock(),
 		st,
 	)
 	registry.AddMetricStruct(rpcContext.RemoteClocks.Metrics())

--- a/pkg/server/status/BUILD.bazel
+++ b/pkg/server/status/BUILD.bazel
@@ -132,7 +132,6 @@ go_test(
         "//pkg/base",
         "//pkg/build",
         "//pkg/roachpb",
-        "//pkg/rpc",
         "//pkg/security/securityassets",
         "//pkg/security/securitytest",
         "//pkg/server",

--- a/pkg/server/status/BUILD.bazel
+++ b/pkg/server/status/BUILD.bazel
@@ -140,7 +140,6 @@ go_test(
         "//pkg/sql/sem/catconstants",
         "//pkg/testutils/serverutils",
         "//pkg/ts/tspb",
-        "//pkg/util/hlc",
         "//pkg/util/leaktest",
         "//pkg/util/log",
         "//pkg/util/log/eventpb",

--- a/pkg/server/status/recorder_test.go
+++ b/pkg/server/status/recorder_test.go
@@ -28,7 +28,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/catconstants"
 	"github.com/cockroachdb/cockroach/pkg/ts/tspb"
-	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/metric"
 	"github.com/cockroachdb/cockroach/pkg/util/metric/aggmetric"
@@ -113,7 +112,7 @@ func TestMetricsRecorderTenants(t *testing.T) {
 		roachpb.NewTenantNameContainer(catconstants.SystemTenantName),
 		nil, /* nodeLiveness */
 		nil, /* remoteClocks */
-		hlc.NewClockForTesting(manual),
+		manual,
 		st,
 	)
 	recorder.AddNode(reg1, nodeDesc, 50, "foo:26257", "foo:26258", "foo:5432")
@@ -132,7 +131,7 @@ func TestMetricsRecorderTenants(t *testing.T) {
 		appNameContainer,
 		nil, /* nodeLiveness */
 		nil, /* remoteClocks */
-		hlc.NewClockForTesting(manual),
+		manual,
 		stTenant,
 	)
 	recorderTenant.AddNode(reg2, nodeDescTenant, 50, "foo:26257", "foo:26258", "foo:5432")
@@ -227,7 +226,7 @@ func TestMetricsRecorder(t *testing.T) {
 	}
 	manual := timeutil.NewManualTime(timeutil.Unix(0, 100))
 	st := cluster.MakeTestingClusterSettings()
-	recorder := NewMetricsRecorder(roachpb.SystemTenantID, roachpb.NewTenantNameContainer(""), nil, nil, hlc.NewClockForTesting(manual), st)
+	recorder := NewMetricsRecorder(roachpb.SystemTenantID, roachpb.NewTenantNameContainer(""), nil, nil, manual, st)
 	recorder.AddStore(store1)
 	recorder.AddStore(store2)
 	recorder.AddNode(reg1, nodeDesc, 50, "foo:26257", "foo:26258", "foo:5432")

--- a/pkg/server/status/recorder_test.go
+++ b/pkg/server/status/recorder_test.go
@@ -120,31 +120,31 @@ func TestMetricsRecorderTenants(t *testing.T) {
 	nodeDescTenant := roachpb.NodeDescriptor{
 		NodeID: roachpb.NodeID(1),
 	}
-	reg2 := metric.NewRegistry()
+	regTenant := metric.NewRegistry()
 	stTenant := cluster.MakeTestingClusterSettings()
-	id, err := roachpb.MakeTenantID(123)
+	tenantID, err := roachpb.MakeTenantID(123)
 	require.NoError(t, err)
 
 	appNameContainer := roachpb.NewTenantNameContainer("application")
 	recorderTenant := NewMetricsRecorder(
-		id,
+		tenantID,
 		appNameContainer,
 		nil, /* nodeLiveness */
 		nil, /* remoteClocks */
 		manual,
 		stTenant,
 	)
-	recorderTenant.AddNode(reg2, nodeDescTenant, 50, "foo:26257", "foo:26258", "foo:5432")
+	recorderTenant.AddNode(regTenant, nodeDescTenant, 50, "foo:26257", "foo:26258", "foo:5432")
 
 	g := metric.NewGauge(metric.Metadata{Name: "some_metric"})
 	reg1.AddMetric(g)
 	g.Update(123)
 
 	g2 := metric.NewGauge(metric.Metadata{Name: "some_metric"})
-	reg2.AddMetric(g2)
+	regTenant.AddMetric(g2)
 	g2.Update(456)
 
-	recorder.AddTenantRecorder(recorderTenant)
+	recorder.AddTenantRegistry(tenantID, regTenant)
 
 	buf := bytes.NewBuffer([]byte{})
 	err = recorder.PrintAsText(buf)

--- a/pkg/server/tenant.go
+++ b/pkg/server/tenant.go
@@ -1068,7 +1068,8 @@ func makeTenantSQLServerArgs(
 	protectedTSProvider = pp
 
 	recorder := status.NewMetricsRecorder(
-		sqlCfg.TenantID, tenantNameContainer, nil /* nodeLiveness */, nil /* remoteClocks */, clock, st)
+		sqlCfg.TenantID, tenantNameContainer, nil /* nodeLiveness */, nil, /* remoteClocks */
+		clock.WallClock(), st)
 	// Note: If the tenant is in-process, we attach this tenant's metric
 	// recorder to the parentRecorder held by the system tenant. This
 	// ensures that generated Prometheus metrics from the system tenant

--- a/pkg/server/tenant.go
+++ b/pkg/server/tenant.go
@@ -1067,7 +1067,8 @@ func makeTenantSQLServerArgs(
 	registry.AddMetricStruct(pp.Metrics())
 	protectedTSProvider = pp
 
-	recorder := status.NewMetricsRecorder(clock, nil, rpcContext, st, tenantNameContainer)
+	recorder := status.NewMetricsRecorder(
+		sqlCfg.TenantID, tenantNameContainer, nil /* nodeLiveness */, nil /* remoteClocks */, clock, st)
 	// Note: If the tenant is in-process, we attach this tenant's metric
 	// recorder to the parentRecorder held by the system tenant. This
 	// ensures that generated Prometheus metrics from the system tenant

--- a/pkg/server/tenant.go
+++ b/pkg/server/tenant.go
@@ -169,7 +169,7 @@ func NewSeparateProcessTenantServer(
 	return newTenantServer(ctx, stopper, baseCfg, sqlCfg, nil /* parentRecorder */, tenantNameContainer, instanceIDContainer)
 }
 
-// NewSeparateProcessTenantServer creates a tenant-specific, SQL-only
+// NewSharedProcessTenantServer creates a tenant-specific, SQL-only
 // server against a KV backend, with defaults appropriate for a
 // SQLServer that is not located in the same process as a KVServer.
 //

--- a/pkg/server/tenant.go
+++ b/pkg/server/tenant.go
@@ -1071,11 +1071,11 @@ func makeTenantSQLServerArgs(
 		sqlCfg.TenantID, tenantNameContainer, nil /* nodeLiveness */, nil, /* remoteClocks */
 		clock.WallClock(), st)
 	// Note: If the tenant is in-process, we attach this tenant's metric
-	// recorder to the parentRecorder held by the system tenant. This
+	// registry to the parentRecorder held by the system tenant. This
 	// ensures that generated Prometheus metrics from the system tenant
 	// include metrics from this in-process tenant.
 	if parentRecorder != nil {
-		parentRecorder.AddTenantRecorder(recorder)
+		parentRecorder.AddTenantRegistry(sqlCfg.TenantID, registry)
 	}
 
 	var runtime *status.RuntimeStatSampler


### PR DESCRIPTION
Please see individual commits.

Release note: None
Epic: None