### PR TITLE
[DNM] sql: attempt to prevent livelock with concurrent schema changes

### DIFF
--- a/pkg/sql/catalog/descriptor_id_set.go
+++ b/pkg/sql/catalog/descriptor_id_set.go
@@ -83,6 +83,11 @@ func (d DescriptorIDSet) Union(o DescriptorIDSet) DescriptorIDSet {
 	return DescriptorIDSet{set: d.set.Union(o.set)}
 }
 
+// UnionWith adds the members of o to d.
+func (d *DescriptorIDSet) UnionWith(o DescriptorIDSet) {
+	d.set.UnionWith(o.set)
+}
+
 // ConstraintIDSet stores an unordered set of descriptor ids.
 type ConstraintIDSet struct {
 	set intsets.Fast

--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -1038,13 +1038,7 @@ func (ex *connExecutor) commitSQLTransactionInternal(ctx context.Context) error 
 		// By detecting restarts and locking descriptors, here, we may not prevent
 		// another restart, but we should prevent subsequent live-lock for future
 		// restarts.
-		if ex.hasRetried() {
-			if err := descsCol.LockDescriptorsForValidation(
-				ctx, ex.state.mu.txn,
-			); err != nil {
-				return err
-			}
-		}
+
 		if err := descsCol.ValidateUncommittedDescriptors(ctx, ex.state.mu.txn); err != nil {
 			return err
 		}

--- a/pkg/sql/schemachanger/scexec/exec_deferred_mutation.go
+++ b/pkg/sql/schemachanger/scexec/exec_deferred_mutation.go
@@ -193,20 +193,22 @@ func (s *deferredState) exec(
 			return err
 		}
 	}
-	for _, idx := range s.indexesToSplitAndScatter {
-		descs, err := c.MustReadImmutableDescriptors(ctx, idx.tableID)
-		if err != nil {
-			return err
+	/*
+		for _, idx := range s.indexesToSplitAndScatter {
+			descs, err := c.MustReadImmutableDescriptors(ctx, idx.tableID)
+			if err != nil {
+				return err
+			}
+			tableDesc := descs[0].(catalog.TableDescriptor)
+			idxDesc, err := catalog.MustFindIndexByID(tableDesc, idx.indexID)
+			if err != nil {
+				return err
+			}
+			if err := iss.MaybeSplitIndexSpans(ctx, tableDesc, idxDesc); err != nil {
+				return err
+			}
 		}
-		tableDesc := descs[0].(catalog.TableDescriptor)
-		idxDesc, err := catalog.MustFindIndexByID(tableDesc, idx.indexID)
-		if err != nil {
-			return err
-		}
-		if err := iss.MaybeSplitIndexSpans(ctx, tableDesc, idxDesc); err != nil {
-			return err
-		}
-	}
+	*/
 	s.statsToRefresh.ForEach(q.AddTableForStatsRefresh)
 	// Note that we perform the system.jobs writes last in order to acquire locks
 	// on the job rows in question as late as possible. If a restart is


### PR DESCRIPTION
Relates to #97846


Release note (bug fix): In some cases, concurrent schema changes to disjoint,
but related descriptors can result in livelock. A workaround has been introduced
to alleviate livelock in some such cases.