### PR TITLE
ui: add replace idx as idx recommendation type

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/insightsTable/insightsTable.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insightsTable/insightsTable.tsx
@@ -392,6 +392,7 @@ const isIndexRec = (rec: InsightRecommendation) => {
     case "AlterIndex":
     case "CreateIndex":
     case "DropIndex":
+    case "ReplaceIndex":
       return true;
     default:
       return false;


### PR DESCRIPTION
The Replace Index type was not added on the list
of index recommendation, making fingerprint
to not show on insights tables.
This commit adds to part of the case.

Before
<img width="1541" alt="Screenshot 2023-03-01 at 6 35 29 PM" src="https://user-images.githubusercontent.com/1017486/222301675-64080b3c-323c-4ce3-b0ab-491996c78de3.png">


After
<img width="1176" alt="Screenshot 2023-03-01 at 6 40 52 PM" src="https://user-images.githubusercontent.com/1017486/222301695-8445a11c-e96d-4e1d-b489-cca520eb7199.png">


Epic: None

Release note: None