### PR TITLE
kvserver: add stack history to trace of slow requests

### DIFF
--- a/pkg/util/tracing/BUILD.bazel
+++ b/pkg/util/tracing/BUILD.bazel
@@ -24,6 +24,7 @@ go_library(
         "//pkg/settings",
         "//pkg/util",
         "//pkg/util/buildutil",
+        "//pkg/util/caller",
         "//pkg/util/envutil",
         "//pkg/util/iterutil",
         "//pkg/util/netutil/addr",

--- a/pkg/util/tracing/BUILD.bazel
+++ b/pkg/util/tracing/BUILD.bazel
@@ -24,7 +24,6 @@ go_library(
         "//pkg/settings",
         "//pkg/util",
         "//pkg/util/buildutil",
-        "//pkg/util/caller",
         "//pkg/util/envutil",
         "//pkg/util/iterutil",
         "//pkg/util/netutil/addr",

--- a/pkg/util/tracing/tracer_snapshots.go
+++ b/pkg/util/tracing/tracer_snapshots.go
@@ -309,43 +309,27 @@ func (t *Tracer) runPeriodicSnapshotsLoop(
 // such automatic snapshots are available to be searched and if so at what
 // granularity.
 func (sp *Span) MaybeRecordStackHistory(since time.Time) {
-	if sp == nil {
-		return
-	}
-	t := sp.Tracer()
-	if !sp.IsVerbose() && !t.HasExternalSink() {
+	if sp == nil || !sp.i.hasVerboseSink() {
 		return
 	}
 
+	t := sp.Tracer()
 	id := int(goid.Get())
+
+	var prevStack string
+
 	t.snapshotsMu.Lock()
 	defer t.snapshotsMu.Unlock()
-
-	// In the loop below that moves backwards through time looking for stacks, if
-	// a matching stack is found, it is stored in `stack` until the next iteration
-	// when it is actually recorded, so that only the diff to older stack, if any,
-	// found on that next iteration is what is recorded.
-	var stack string
-	var stackTime time.Time
-
-	for i := t.snapshotsMu.autoSnapshots.Len() - 1; i >= 0; i-- {
+	for i := 0; i < t.snapshotsMu.autoSnapshots.Len(); i++ {
 		s := t.snapshotsMu.autoSnapshots.Get(i)
-		var prevStack string
-		if s.CapturedAt.After(since) {
-			prevStack = s.Stacks[id]
+		if s.CapturedAt.Before(since) {
+			continue
 		}
-
-		// If a previous iteration stored a newer stack in `stack`, record it now,
-		// using any older stack found this iteration as the basis for diffing.
-		if stack != "" {
-			sp.RecordStructured(stackDelta(prevStack, stack, timeutil.Since(stackTime)))
+		stack, ok := s.Stacks[id]
+		if ok {
+			sp.RecordStructured(stackDelta(prevStack, stack, timeutil.Since(s.CapturedAt)))
+			prevStack = stack
 		}
-
-		if prevStack == "" {
-			return
-		}
-		stack = prevStack
-		stackTime = s.CapturedAt
 	}
 }
 

--- a/pkg/util/tracing/tracer_test.go
+++ b/pkg/util/tracing/tracer_test.go
@@ -1008,12 +1008,13 @@ func TestTracerStackHistory(t *testing.T) {
 	sp.MaybeRecordStackHistory(started)
 
 	rec := sp.FinishAndGetRecording(tracingpb.RecordingVerbose)[0]
+	require.Len(t, rec.StructuredRecords, 3)
 	require.Len(t, rec.Logs, 3)
 	require.Len(t, rec.StructuredRecords, 3)
 	for i := range rec.Logs {
 		require.NotContains(t, rec.Logs[i].Message, "tracing.blockingFunc1")
 	}
-	require.Contains(t, rec.Logs[0].Message, "tracing.blockingCaller")
+	require.Contains(t, rec.Logs[0].Message, "tracing.blockingFunc2")
 	require.Contains(t, rec.Logs[1].Message, "tracing.blockingFunc3")
-	require.Contains(t, rec.Logs[2].Message, "tracing.blockingFunc2")
+	require.Contains(t, rec.Logs[2].Message, "tracing.blockingCaller")
 }

--- a/pkg/util/tracing/tracingpb/recorded_span.go
+++ b/pkg/util/tracing/tracingpb/recorded_span.go
@@ -198,3 +198,14 @@ func (m OperationMetadata) SafeFormat(s redact.SafePrinter, _ rune) {
 	}
 	s.Print("}")
 }
+
+func (c CapturedStack) String() string {
+	age := c.Age.Seconds()
+	if c.Stack == "" && c.SharedSuffix > 0 {
+		return fmt.Sprintf("stack as of %.1fs ago had not changed from previous stack", age)
+	}
+	if c.SharedLines > 0 {
+		return fmt.Sprintf("stack as of %.1fs ago: %s\n ...+%d lines matching previous stack", age, c.Stack, c.SharedLines)
+	}
+	return fmt.Sprintf("stack as of %.1fs ago: %s", age, c.Stack)
+}

--- a/pkg/util/tracing/tracingpb/recorded_span.proto
+++ b/pkg/util/tracing/tracingpb/recorded_span.proto
@@ -174,3 +174,12 @@ message NormalizedSpan {
   map<string, OperationMetadata> children_metadata = 9 [(gogoproto.nullable) = false];
   repeated NormalizedSpan children = 6 [(gogoproto.nullable) = false];
 }
+
+message CapturedStack {
+  option (gogoproto.goproto_stringer) = false;
+  string stack = 1;
+  int32 shared_suffix = 2;
+  int32 shared_lines = 3;
+  int64 age = 4 [(gogoproto.casttype) = "time.Duration"];
+  // NEXT ID: 5.
+}

--- a/pkg/util/tracing/tracingpb/recorded_span.proto
+++ b/pkg/util/tracing/tracingpb/recorded_span.proto
@@ -177,9 +177,15 @@ message NormalizedSpan {
 
 message CapturedStack {
   option (gogoproto.goproto_stringer) = false;
+  // Stack is the strack trace, or distinct prefix of the stack trace if a previous
+  // capture of this stack is also being recorded.
   string stack = 1;
+  // SharedSuffix indicates the length of the elided suffix of this stack that 
+  // was identical to the previous capture of this stack.
   int32 shared_suffix = 2;
+  // SharedLines indicated how many newlines were in the elided shared suffix.
   int32 shared_lines = 3;
+  // Age indicates the duration prior to being recorded that this stack was captured.
   int64 age = 4 [(gogoproto.casttype) = "time.Duration"];
   // NEXT ID: 5.
 }


### PR DESCRIPTION
First commit is #97829.

This uses the new tracing.MaybeRecordStackHistory helper to add any recorded history
of the request evaluation's stack to the trace before returning the result (success or
error) if the request is considered to have been 'slow'. A new setting controls how slow
a request must be to trigger a search for the history of its stack, and that history is only
available if and at the granularity controlled by trace.snapshot.rate setting.

A history of the stack can be particularly useful when a request returns an error caused
by a timeout or context cancellation, as often by the time such a request is returning, it
is no longer at the same point where it spent all the time that caused it to be so slow.
Instead, this patch in conjunction with the tracer's snapshotting facility allows asking
'what was i doing all that time?' and having the tracer answer, even if the code asking
was doing work that was not directly instrumented to make itself visible in traces.

Example statement bundle trace, after sprinkling some sleeps in pkg/storage code (trimmed for brevity):
<img width="1529" alt="Screenshot 2023-03-01 at 9 13 32 PM" src="https://user-images.githubusercontent.com/15615/222313217-af508bd0-67e4-4fe6-9fae-d18b924e74f5.png">

Fixes: #98304

Release note (ops change): the setting kv.slow_requests.trace_stack_history.threshold can be used to attach available stack history from tracer snapshots to the trace of slow requests.
Epic: none.