### PR TITLE
tracing: fix stack gathering null bytes bug

### DIFF
--- a/pkg/util/tracing/tracer_snapshots.go
+++ b/pkg/util/tracing/tracer_snapshots.go
@@ -161,6 +161,7 @@ func (t *Tracer) generateSnapshot() SpansSnapshot {
 		stacks = make([]byte, n)
 		nbytes := runtime.Stack(stacks, true /* all */)
 		if nbytes < len(stacks) {
+			stacks = stacks[:nbytes]
 			break
 		}
 	}

--- a/pkg/util/tracing/tracer_test.go
+++ b/pkg/util/tracing/tracer_test.go
@@ -898,3 +898,22 @@ func TestTracerClusterSettings(t *testing.T) {
 	require.False(t, sp.IsNoop())
 	sp.Finish()
 }
+
+func TestTracerSnapshots(t *testing.T) {
+	tr := NewTracer()
+
+	s1 := tr.SaveSnapshot()
+	require.Equal(t, SnapshotID(1), s1.ID)
+	_ = tr.SaveSnapshot()
+	s3 := tr.SaveSnapshot()
+	require.Equal(t, SnapshotID(3), s3.ID)
+	require.Equal(t, 3, len(tr.GetSnapshots()))
+
+	for _, i := range []SnapshotID{2, 1, 3} {
+		s, err := tr.GetSnapshot(i)
+		require.NoError(t, err)
+		for _, s := range s.Stacks {
+			require.Less(t, len(s), 5<<10, s)
+		}
+	}
+}


### PR DESCRIPTION
Previously one of the stacks in the captured stack map would often have potentially kilobytes of extra bytes included in it due to the entire scratch buffer, not just the part that runtime.Stack filled, being passed to parsing.

Release note: none.
Epic: none.