### PR TITLE
builtins: fix errors with database names with hyphens and/or quotes

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/show_create_all_schemas
+++ b/pkg/sql/logictest/testdata/logic_test/show_create_all_schemas
@@ -40,3 +40,15 @@ SHOW CREATE ALL SCHEMAS
 create_statement
 CREATE SCHEMA public;
 CREATE SCHEMA test2;
+
+# Make sure database names with hyphens work well.
+statement ok
+CREATE DATABASE "d-d";
+USE "d-d";
+SHOW CREATE ALL SCHEMAS;
+
+# Make sure database names with quotes work well.
+statement ok
+CREATE DATABASE "a""bc";
+USE "a""bc";
+SHOW CREATE ALL SCHEMAS;

--- a/pkg/sql/logictest/testdata/logic_test/show_create_all_tables
+++ b/pkg/sql/logictest/testdata/logic_test/show_create_all_tables
@@ -434,3 +434,17 @@ CREATE TABLE public.t (
   FAMILY f2 (z),
   FAMILY f3 (h)
 );
+
+# Make sure database names with hyphens work well.
+statement ok
+CREATE DATABASE "d-d";
+USE "d-d";
+CREATE TABLE t();
+SHOW CREATE ALL TABLES;
+
+# Make sure database names with quotes work well.
+statement ok
+CREATE DATABASE "a""bc";
+USE "a""bc";
+CREATE TABLE t();
+SHOW CREATE ALL SCHEMAS;

--- a/pkg/sql/logictest/testdata/logic_test/show_create_all_tables_builtin
+++ b/pkg/sql/logictest/testdata/logic_test/show_create_all_tables_builtin
@@ -427,3 +427,17 @@ CREATE TABLE t_85418_2();
 CREATE TABLE dbs_85418(db STRING);
 INSERT INTO dbs_85418 VALUES ('db_85418_1'), ('db_85418_2');
 SELECT crdb_internal.show_create_all_tables(db) FROM dbs_85418;
+
+# Make sure database names with hyphens work well.
+statement ok
+CREATE DATABASE "d-d";
+USE "d-d";
+CREATE TABLE t();
+SELECT crdb_internal.show_create_all_tables('d-d');
+
+# Make sure database names with quotes work well.
+statement ok
+CREATE DATABASE "a""bc";
+USE "a""bc";
+CREATE TABLE t();
+SELECT crdb_internal.show_create_all_tables('a"bc');

--- a/pkg/sql/logictest/testdata/logic_test/show_create_all_types
+++ b/pkg/sql/logictest/testdata/logic_test/show_create_all_types
@@ -50,3 +50,15 @@ SHOW CREATE ALL TYPES
 create_statement
 CREATE TYPE public.tableobj AS ENUM ('row', 'col');
 CREATE TYPE s.status AS ENUM ('a', 'b', 'c');
+
+# Make sure database names with hyphens work well.
+statement ok
+CREATE DATABASE "d-d";
+USE "d-d";
+SHOW CREATE ALL TYPES;
+
+# Make sure database names with quotes work well.
+statement ok
+CREATE DATABASE "a""bc";
+USE "a""bc";
+SHOW CREATE ALL TYPES;

--- a/pkg/sql/sem/builtins/show_create_all_schemas_builtin.go
+++ b/pkg/sql/sem/builtins/show_create_all_schemas_builtin.go
@@ -16,6 +16,7 @@ import (
 	"unsafe"
 
 	"github.com/cockroachdb/cockroach/pkg/kv"
+	"github.com/cockroachdb/cockroach/pkg/sql/lexbase"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/eval"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
@@ -32,7 +33,7 @@ func getSchemaIDs(
 		SELECT descriptor_id
 		FROM %s.crdb_internal.create_schema_statements
 		WHERE database_name = $1
-		`, dbName)
+		`, lexbase.EscapeSQLIdent(dbName))
 	it, err := evalPlanner.QueryIteratorEx(
 		ctx,
 		"crdb_internal.show_create_all_schemas",
@@ -73,7 +74,7 @@ func getSchemaCreateStatement(
 			create_statement
 		FROM %s.crdb_internal.create_schema_statements
 		WHERE descriptor_id = $1
-	`, dbName)
+	`, lexbase.EscapeSQLIdent(dbName))
 	row, err := evalPlanner.QueryRowEx(
 		ctx,
 		"crdb_internal.show_create_all_schemas",

--- a/pkg/sql/sem/builtins/show_create_all_tables_builtin.go
+++ b/pkg/sql/sem/builtins/show_create_all_tables_builtin.go
@@ -17,6 +17,7 @@ import (
 	"unsafe"
 
 	"github.com/cockroachdb/cockroach/pkg/kv"
+	"github.com/cockroachdb/cockroach/pkg/sql/lexbase"
 	"github.com/cockroachdb/cockroach/pkg/sql/memsize"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/eval"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
@@ -70,7 +71,7 @@ func getTopologicallySortedTableIDs(
 		SELECT dependson_id
 		FROM %s.crdb_internal.backward_dependencies
 		WHERE descriptor_id = $1
-		`, dbName)
+		`, lexbase.EscapeSQLIdent(dbName))
 		it, err := evalPlanner.QueryIteratorEx(
 			ctx,
 			"crdb_internal.show_create_all_tables",
@@ -159,7 +160,7 @@ func getTableIDs(
 		WHERE database_name = $1 
 		AND is_virtual = FALSE
 		AND is_temporary = FALSE
-		`, dbName)
+		`, lexbase.EscapeSQLIdent(dbName))
 	it, err := evalPlanner.QueryIteratorEx(
 		ctx,
 		"crdb_internal.show_create_all_tables",
@@ -248,7 +249,7 @@ func getCreateStatement(
 			create_nofks
 		FROM %s.crdb_internal.create_statements
 		WHERE descriptor_id = $1
-	`, dbName)
+	`, lexbase.EscapeSQLIdent(dbName))
 	row, err := evalPlanner.QueryRowEx(
 		ctx,
 		"crdb_internal.show_create_all_tables",
@@ -278,7 +279,7 @@ func getAlterStatements(
 			%s
 		FROM %s.crdb_internal.create_statements
 		WHERE descriptor_id = $1
-	`, statementType, dbName)
+	`, statementType, lexbase.EscapeSQLIdent(dbName))
 	row, err := evalPlanner.QueryRowEx(
 		ctx,
 		"crdb_internal.show_create_all_tables",

--- a/pkg/sql/sem/builtins/show_create_all_types_builtin.go
+++ b/pkg/sql/sem/builtins/show_create_all_types_builtin.go
@@ -16,6 +16,7 @@ import (
 	"unsafe"
 
 	"github.com/cockroachdb/cockroach/pkg/kv"
+	"github.com/cockroachdb/cockroach/pkg/sql/lexbase"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/eval"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
@@ -32,7 +33,7 @@ func getTypeIDs(
 		SELECT descriptor_id
 		FROM %s.crdb_internal.create_type_statements
 		WHERE database_name = $1
-		`, dbName)
+		`, lexbase.EscapeSQLIdent(dbName))
 	it, err := evalPlanner.QueryIteratorEx(
 		ctx,
 		"crdb_internal.show_create_all_types",
@@ -73,7 +74,7 @@ func getTypeCreateStatement(
 			create_statement
 		FROM %s.crdb_internal.create_type_statements
 		WHERE descriptor_id = $1
-	`, dbName)
+	`, lexbase.EscapeSQLIdent(dbName))
 	row, err := evalPlanner.QueryRowEx(
 		ctx,
 		"crdb_internal.show_create_all_types",


### PR DESCRIPTION
Using a database name with a hyphen or quotes is allowed,
but you have to escape it properly to make it work.
    
There was a problem with the builtins taking the current
database name as an implicit arg, specifically:
    
- show_create_all_schemas
- show_create_all_tables
- show_create_all_types
    
Escaping the database name using `lexbase.EscapeSQLIdent`
ensures the database name is always valid, allowing database names 
with hyphens or quotes to being used with the mentioned builtins
safely from now on.
    
Closes #97914
    
Release note (bug fix): Fixed the SHOW CREATE ALL {TYPES|SCHEMAS|TABLES} commands
so they handle database names that have mixed-case, hyphens, or quotes.