### PR TITLE
roachtest: add tpcc roachperf test variants to stress encryption

### DIFF
--- a/pkg/cmd/roachtest/tests/tpcc.go
+++ b/pkg/cmd/roachtest/tests/tpcc.go
@@ -961,6 +961,9 @@ type tpccBenchSpec struct {
 	MinVersion string
 	// Tags to pass to testRegistryImpl.Add.
 	Tags []string
+	// EncryptionEnabled determines if the benchmark uses encrypted stores (i.e.
+	// Encryption-At-Rest / EAR).
+	EncryptionEnabled bool
 }
 
 // partitions returns the number of partitions specified to the load generator.
@@ -1029,6 +1032,12 @@ func registerTPCCBenchSpec(r registry.Registry, b tpccBenchSpec) {
 		panic("unexpected")
 	}
 
+	encryptionSupport := registry.EncryptionAlwaysDisabled
+	if b.EncryptionEnabled {
+		encryptionSupport = registry.EncryptionAlwaysEnabled
+		nameParts = append(nameParts, "enc=true")
+	}
+
 	name := strings.Join(nameParts, "/")
 
 	numNodes := b.Nodes + b.LoadConfig.numLoadNodes(b.Distribution)
@@ -1040,13 +1049,11 @@ func registerTPCCBenchSpec(r registry.Registry, b tpccBenchSpec) {
 	}
 
 	r.Add(registry.TestSpec{
-		Name:    name,
-		Owner:   owner,
-		Cluster: nodes,
-		Tags:    b.Tags,
-		// NB: intentionally not enabling encryption-at-rest to produce
-		// consistent results.
-		EncryptionSupport: registry.EncryptionAlwaysDisabled,
+		Name:              name,
+		Owner:             owner,
+		Cluster:           nodes,
+		Tags:              b.Tags,
+		EncryptionSupport: encryptionSupport,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			runTPCCBench(ctx, t, c, b)
 		},
@@ -1500,6 +1507,34 @@ func registerTPCCBench(r registry.Registry) {
 
 			LoadWarehouses: 10000,
 			EstimatedMax:   8000,
+		},
+
+		// Encryption-At-Rest benchmarks. These are duplicates of variants above,
+		// using encrypted stores.
+		{
+			Nodes: 3,
+			CPUs:  4,
+
+			LoadWarehouses:    1000,
+			EstimatedMax:      325,
+			EncryptionEnabled: true,
+		},
+		{
+			Nodes: 3,
+			CPUs:  16,
+
+			LoadWarehouses:    2000,
+			EstimatedMax:      1300,
+			EncryptionEnabled: true,
+		},
+		{
+			Nodes: 12,
+			CPUs:  16,
+
+			LoadWarehouses:    10000,
+			EstimatedMax:      6000,
+			LoadConfig:        singlePartitionedLoadgen,
+			EncryptionEnabled: true,
 		},
 	}
 


### PR DESCRIPTION
Currently, certain KV roachperf variants run with Encryption-At-Rest (EAR) support (i.e. `enc=true`). Expand the test variants to include three basic TPC-C configurations with EAR enabled:
- 3 nodes, 4 vCPU
- 3 nodes, 16 vCPU
- 12 nodes, 16 vCPU

Release note: None.

Epic: CRDB-20293.