### PR TITLE
kv: add commentary to discourage use of (*kv.DB).NewTxn()

### DIFF
--- a/pkg/kv/db.go
+++ b/pkg/kv/db.go
@@ -855,6 +855,11 @@ func (db *DB) Run(ctx context.Context, b *Batch) error {
 }
 
 // NewTxn creates a new RootTxn.
+//
+// Note: this is a low-level constructor for users who intend to manage
+// the lifecycle of the transaction manually (read: the sql layer). For
+// ad-hoc transactions against the KV layer, prefer db.Txn() or
+// db.TxnWithAdmissionControl().
 func (db *DB) NewTxn(ctx context.Context, debugName string) *Txn {
 	// Observed timestamps don't work with multi-tenancy. See:
 	//


### PR DESCRIPTION
The `(*kv.DB).NewTxn()` method is rarely what folks want. This commit adds commentary to push programmers towards `(*kv.DB).Txn` and its friends.

Epic: none

Release note: None