### PR TITLE
release-22.2: ui: fix link encoding for database/table/index

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/package.json
+++ b/pkg/ui/workspaces/cluster-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cockroachlabs/cluster-ui",
-  "version": "22.2.6",
+  "version": "22.2.7",
   "description": "Cluster UI is a library of large features shared between CockroachDB and CockroachCloud",
   "repository": {
     "type": "git",

--- a/pkg/ui/workspaces/cluster-ui/src/databaseTablePage/databaseTablePage.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/databaseTablePage/databaseTablePage.tsx
@@ -31,7 +31,11 @@ import {
   SummaryCardItemBoolSetting,
 } from "src/summaryCard";
 import * as format from "src/util/format";
-import { DATE_FORMAT, DATE_FORMAT_24_UTC } from "src/util/format";
+import {
+  DATE_FORMAT,
+  DATE_FORMAT_24_UTC,
+  EncodeUriName,
+} from "src/util/format";
 import {
   ascendingAttr,
   columnTitleAttr,
@@ -412,7 +416,7 @@ export class DatabaseTablePage extends React.Component<
       className: cx("index-stats-table__col-indexes"),
       cell: indexStat => (
         <Link
-          to={`${this.props.name}/index/${indexStat.indexName}`}
+          to={`${this.props.name}/index/${EncodeUriName(indexStat.indexName)}`}
           className={cx("icon__container")}
         >
           <IndexIcon className={cx("icon--s", "icon--primary")} />

--- a/pkg/ui/workspaces/cluster-ui/src/indexDetailsPage/indexDetails.selectors.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/indexDetailsPage/indexDetails.selectors.ts
@@ -55,7 +55,7 @@ export const selectIndexDetails = createSelector(
     )[0];
     const filteredIndexRecommendations =
       stats?.data?.index_recommendations.filter(
-        indexRec => indexRec.index_id === details.statistics.key.index_id,
+        indexRec => indexRec.index_id === details?.statistics.key.index_id,
       ) || [];
     const indexRecommendations = filteredIndexRecommendations.map(indexRec => {
       let type: RecType = "Unknown";

--- a/pkg/ui/workspaces/cluster-ui/src/queryFilter/filter.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/queryFilter/filter.tsx
@@ -463,7 +463,7 @@ export class Filter extends React.Component<QueryFilter, FilterState> {
         }))
       : [];
     const databaseValue = databasesOptions.filter(option => {
-      return filters.database.split(",").includes(option.label);
+      return filters.database?.split(",").includes(option.label);
     });
     const dbFilter = (
       <div>

--- a/pkg/ui/workspaces/cluster-ui/src/util/format.spec.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/util/format.spec.ts
@@ -16,6 +16,7 @@ import {
   byteUnits,
   HexStringToInt64String,
   FixFingerprintHexValue,
+  EncodeUriName,
 } from "./format";
 
 describe("Format utils", () => {
@@ -72,6 +73,20 @@ describe("Format utils", () => {
         "0b9111f22f2213b7",
       );
       expect(FixFingerprintHexValue("9111f22f2213b7")).toBe("009111f22f2213b7");
+    });
+  });
+
+  describe.only("EncodeUriName", () => {
+    it("decode simple string no special characters", () => {
+      expect(EncodeUriName("123abc")).toBe("123abc");
+    });
+
+    it("decode string with special characters", () => {
+      expect(EncodeUriName("12#_ab")).toBe("12%23_ab");
+    });
+
+    it("decode string with %", () => {
+      expect(EncodeUriName("12%abc")).toBe("12%252525abc");
     });
   });
 });

--- a/pkg/ui/workspaces/cluster-ui/src/util/format.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/util/format.ts
@@ -280,3 +280,43 @@ export function capitalize(str: string): string {
   if (!str) return str;
   return str[0].toUpperCase() + str.substring(1);
 }
+
+export function EncodeUriName(name: string): string {
+  // When a string has a '%' on it, the URI needs to have '%2525' instead, so this
+  // function replaces '%25' with '%252525' because when the link is created
+  // we have [%25]2525 -> %2525 (which is then used as the URI)
+  return encodeURIComponent(name).replace(/%25/g, "%252525");
+}
+
+export function EncodeDatabasesUri(db: string): string {
+  return `/databases/${EncodeUriName(db)}`;
+}
+
+export function EncodeDatabasesToIndexUri(
+  db: string,
+  schema: string,
+  table: string,
+  indexName: string,
+): string {
+  return `${EncodeDatabasesUri(db)}/${EncodeUriName(schema)}/${EncodeUriName(
+    table,
+  )}/${EncodeUriName(indexName)}`;
+}
+
+export function EncodeDatabaseTableUri(db: string, table: string): string {
+  return `${EncodeDatabaseUri(db)}/table/${EncodeUriName(table)}`;
+}
+
+export function EncodeDatabaseTableIndexUri(
+  db: string,
+  table: string,
+  indexName: string,
+): string {
+  return `${EncodeDatabaseTableUri(db, table)}/index/${EncodeUriName(
+    indexName,
+  )}`;
+}
+
+export function EncodeDatabaseUri(db: string): string {
+  return `/database/${EncodeUriName(db)}`;
+}

--- a/pkg/ui/workspaces/db-console/src/views/databases/indexDetailsPage/redux.ts
+++ b/pkg/ui/workspaces/db-console/src/views/databases/indexDetailsPage/redux.ts
@@ -51,7 +51,7 @@ export const mapStateToProps = createSelector(
     )[0];
     const filteredIndexRecommendations =
       stats?.data?.index_recommendations.filter(
-        indexRec => indexRec.index_id === details.statistics.key.index_id,
+        indexRec => indexRec.index_id === details?.statistics.key.index_id,
       ) || [];
     const indexRecommendations = filteredIndexRecommendations.map(indexRec => {
       let type: RecType = "Unknown";

--- a/pkg/ui/workspaces/db-console/src/views/hotRanges/hotRangesTable.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/hotRanges/hotRangesTable.tsx
@@ -25,6 +25,7 @@ import classNames from "classnames/bind";
 import { round } from "lodash";
 import styles from "./hotRanges.module.styl";
 import { cockroach } from "src/js/protos";
+import { util } from "@cockroachlabs/cluster-ui";
 import {
   performanceBestPracticesHotSpots,
   readsAndWritesOverviewPage,
@@ -186,7 +187,12 @@ const HotRangesTable = ({
           val.table_name.startsWith("/") ? (
             val.table_name
           ) : (
-            <Link to={`/database/${val.database_name}/table/${val.table_name}`}>
+            <Link
+              to={util.EncodeDatabaseTableUri(
+                val.database_name,
+                val.table_name,
+              )}
+            >
               {val.table_name}
             </Link>
           ),


### PR DESCRIPTION
Backport 1/1 commits from #97893.

/cc @cockroachdb/release

---

Fixes: https://github.com/cockroachdb/cockroach/issues/97621

Adds proper encoding to links created to database,
table and index pages.
When a link has `%` browsers need to have it as
`%2525`, because it will replace the first `%25`
with `%` and then try to use the decode with the next
two characters. So this commit also updates the format
function to handle this case.
This commit also adds a few checks that were missing
for parameters that could be causing crashed on pages.

https://www.loom.com/share/80659412f6fb45df9507ef94ee824e4d

Release note (bug fix): Fix link encoding on links to
database/table/index pages.

---

Release justification: bug fix