### PR TITLE
pkg/server: make MT session cookies backwards compatible

### DIFF
--- a/pkg/ccl/serverccl/server_controller_test.go
+++ b/pkg/ccl/serverccl/server_controller_test.go
@@ -338,8 +338,8 @@ func TestServerControllerLoginLogout(t *testing.T) {
 		cookieNames[i] = c.Name
 		cookieValues[i] = c.Value
 	}
-	require.ElementsMatch(t, []string{"session", "multitenant-session", "tenant"}, cookieNames)
-	require.ElementsMatch(t, []string{"", "", ""}, cookieValues)
+	require.ElementsMatch(t, []string{"session", "tenant"}, cookieNames)
+	require.ElementsMatch(t, []string{"", ""}, cookieValues)
 
 	// Need a new server because the HTTP Client is memoized.
 	s2, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
@@ -359,8 +359,8 @@ func TestServerControllerLoginLogout(t *testing.T) {
 		cookieNames[i] = c.Name
 		cookieValues[i] = c.Value
 	}
-	require.ElementsMatch(t, []string{"session", "multitenant-session", "tenant"}, cookieNames)
-	require.ElementsMatch(t, []string{"", "", ""}, cookieValues)
+	require.ElementsMatch(t, []string{"session", "tenant"}, cookieNames)
+	require.ElementsMatch(t, []string{"", ""}, cookieValues)
 
 	// Now using manual clients to simulate states that might be invalid
 	url, err := url.Parse(s2.AdminURL())
@@ -386,6 +386,6 @@ func TestServerControllerLoginLogout(t *testing.T) {
 		cookieNames[i] = c.Name
 		cookieValues[i] = c.Value
 	}
-	require.ElementsMatch(t, []string{"session", "multitenant-session", "tenant"}, cookieNames)
-	require.ElementsMatch(t, []string{"", "", ""}, cookieValues)
+	require.ElementsMatch(t, []string{"session", "tenant"}, cookieNames)
+	require.ElementsMatch(t, []string{"", ""}, cookieValues)
 }

--- a/pkg/server/authentication_test.go
+++ b/pkg/server/authentication_test.go
@@ -595,7 +595,7 @@ func TestLogoutClearsCookies(t *testing.T) {
 		require.Equal(t, "", c.Value)
 		cNames[i] = c.Name
 	}
-	require.ElementsMatch(t, cNames, []string{SessionCookieName, MultitenantSessionCookieName, TenantSelectCookieName})
+	require.ElementsMatch(t, cNames, []string{SessionCookieName, TenantSelectCookieName})
 }
 
 func TestLogout(t *testing.T) {
@@ -910,66 +910,78 @@ func TestFindSessionCookieValue(t *testing.T) {
 	defer log.Scope(t).Close(t)
 	normalSessionStr := "abcd1234,system,efgh5678,app"
 	tests := []struct {
-		name          string
-		cookieArg     []*http.Cookie
-		resExpected   string
-		errorExpected bool
+		name              string
+		sessionCookie     *http.Cookie
+		tenantSelectValue string
+		resExpected       string
+		errorExpected     bool
 	}{
-		{"standard args", []*http.Cookie{
-			{
-				Name:  MultitenantSessionCookieName,
+		{
+			name: "standard args",
+			sessionCookie: &http.Cookie{
+				Name:  SessionCookieName,
 				Value: normalSessionStr,
 				Path:  "/",
 			},
-			{
-				Name:  TenantSelectCookieName,
-				Value: "system",
-				Path:  "/",
-			},
-		}, "abcd1234", false},
-		{"no multitenant session cookie", []*http.Cookie{
-			{
-				Name:  TenantSelectCookieName,
-				Value: "system",
-				Path:  "/",
-			},
-		}, "", false},
-		{"no tenant cookie", []*http.Cookie{
-			{
-				Name:  MultitenantSessionCookieName,
+			tenantSelectValue: "system",
+			resExpected:       "abcd1234",
+			errorExpected:     false,
+		},
+		{
+			name:              "no multitenant session cookie",
+			sessionCookie:     nil,
+			tenantSelectValue: "system",
+			resExpected:       "",
+			errorExpected:     false,
+		},
+		{
+			name: "no tenant cookie",
+			sessionCookie: &http.Cookie{
+				Name:  SessionCookieName,
 				Value: normalSessionStr,
 				Path:  "/",
 			},
-		}, "abcd1234", false},
-		{"empty string tenant cookie", []*http.Cookie{
-			{
-				Name:  MultitenantSessionCookieName,
+			resExpected:   "abcd1234",
+			errorExpected: false,
+		},
+		{
+			name: "empty string tenant cookie",
+			sessionCookie: &http.Cookie{
+				Name:  SessionCookieName,
 				Value: normalSessionStr,
 				Path:  "/",
 			},
-			{
-				Name:  TenantSelectCookieName,
-				Value: "",
-				Path:  "/",
-			},
-		}, "abcd1234", false},
-		{"no tenant name match", []*http.Cookie{
-			{
-				Name:  MultitenantSessionCookieName,
+			tenantSelectValue: "",
+			resExpected:       "abcd1234",
+			errorExpected:     false,
+		},
+		{
+			name: "no tenant name match",
+			sessionCookie: &http.Cookie{
+				Name:  SessionCookieName,
 				Value: normalSessionStr,
 				Path:  "/",
 			},
-			{
-				Name:  TenantSelectCookieName,
-				Value: "app2",
+			tenantSelectValue: "app2",
+			resExpected:       "",
+			errorExpected:     true,
+		},
+		{
+			name: "legacy session cookie",
+			sessionCookie: &http.Cookie{
+				Name:  SessionCookieName,
+				Value: "aaskjhf218==",
 				Path:  "/",
 			},
-		}, "", true},
+			tenantSelectValue: "",
+			resExpected:       "aaskjhf218==",
+			errorExpected:     false,
+		},
 	}
 	for _, test := range tests {
 		t.Run(fmt.Sprintf("find-session-cookie/%s", test.name), func(t *testing.T) {
 			st := cluster.MakeClusterSettings()
-			res, err := findSessionCookieValue(st, test.cookieArg)
+			res, err := findSessionCookieValueForTenant(st, test.sessionCookie, test.tenantSelectValue)
 			require.Equal(t, test.resExpected, res)
 			require.Equal(t, test.errorExpected, err != nil)
 		})

--- a/pkg/server/server_controller_http.go
+++ b/pkg/server/server_controller_http.go
@@ -72,7 +72,7 @@ func (c *serverController) httpMux(w http.ResponseWriter, r *http.Request) {
 		log.Warningf(ctx, "unable to find server for tenant %q: %v", tenantName, err)
 		// Clear session and tenant cookies since it appears they reference invalid state.
 		http.SetCookie(w, &http.Cookie{
-			Name:     MultitenantSessionCookieName,
+			Name:     SessionCookieName,
 			Value:    "",
 			Path:     "/",
 			HttpOnly: true,
@@ -193,7 +193,7 @@ func (c *serverController) attemptLoginToAllTenants() http.Handler {
 		if len(tenantNameToSetCookieSlice) > 0 {
 			sessionsStr := createAggregatedSessionCookieValue(tenantNameToSetCookieSlice)
 			cookie := http.Cookie{
-				Name:     MultitenantSessionCookieName,
+				Name:     SessionCookieName,
 				Value:    sessionsStr,
 				Path:     "/",
 				HttpOnly: false,
@@ -238,7 +238,7 @@ func (c *serverController) attemptLogoutFromAllTenants() http.Handler {
 			w.WriteHeader(http.StatusInternalServerError)
 			return
 		}
-		sessionCookie, err := r.Cookie(MultitenantSessionCookieName)
+		sessionCookie, err := r.Cookie(SessionCookieName)
 		if errors.Is(err, http.ErrNoCookie) {
 			sessionCookie, err = r.Cookie(SessionCookieName)
 			if err != nil {
@@ -289,15 +289,7 @@ func (c *serverController) attemptLogoutFromAllTenants() http.Handler {
 		}
 		// Clear session and tenant cookies after all logouts have completed.
 		cookie := http.Cookie{
-			Name:     MultitenantSessionCookieName,
-			Value:    "",
-			Path:     "/",
-			HttpOnly: true,
-			Expires:  timeutil.Unix(0, 0),
-		}
-		http.SetCookie(w, &cookie)
-		cookie = http.Cookie{
-			Name:     TenantSelectCookieName,
+			Name:     SessionCookieName,
 			Value:    "",
 			Path:     "/",
 			HttpOnly: false,
@@ -305,7 +297,7 @@ func (c *serverController) attemptLogoutFromAllTenants() http.Handler {
 		}
 		http.SetCookie(w, &cookie)
 		cookie = http.Cookie{
-			Name:     SessionCookieName,
+			Name:     TenantSelectCookieName,
 			Value:    "",
 			Path:     "/",
 			HttpOnly: false,

--- a/pkg/server/testserver_http.go
+++ b/pkg/server/testserver_http.go
@@ -155,7 +155,7 @@ func (ts *httpTestServer) getAuthenticatedHTTPClientAndCookie(
 				return err
 			}
 			if session == serverutils.MultiTenantSession {
-				cookie.Name = MultitenantSessionCookieName
+				cookie.Name = SessionCookieName
 				cookie.Value = fmt.Sprintf("%s,%s", cookie.Value, ts.t.tenantName)
 			}
 			cookieJar.SetCookies(url, []*http.Cookie{cookie})

--- a/pkg/ui/workspaces/db-console/src/redux/cookies.ts
+++ b/pkg/ui/workspaces/db-console/src/redux/cookies.ts
@@ -8,7 +8,7 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
-export const MULTITENANT_SESSION_COOKIE_NAME = "multitenant-session";
+export const MULTITENANT_SESSION_COOKIE_NAME = "session";
 
 export const getAllCookies = (): Map<string, string> => {
   const cookieMap: Map<string, string> = new Map();
@@ -26,7 +26,7 @@ export const getCookieValue = (cookieName: string): string => {
   return cookies.get(cookieName) || null;
 };
 
-// selectTenantsFromMultitenantSessionCookie formats the multitenant-session
+// selectTenantsFromMultitenantSessionCookie formats the session
 // cookie value and returns only the tenant names.
 export const selectTenantsFromMultitenantSessionCookie = (): string[] => {
   const cookies = getAllCookies();

--- a/pkg/ui/workspaces/db-console/src/views/app/components/tenantDropdown/tenantDropdown.spec.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/app/components/tenantDropdown/tenantDropdown.spec.tsx
@@ -21,7 +21,7 @@ jest.mock("src/redux/cookies", () => ({
 }));
 
 describe("TenantDropdown", () => {
-  it("returns null if there are no tenants in the multitenant-session cookie", () => {
+  it("returns null if there are no tenants in the session cookie", () => {
     (
       selectTenantsFromMultitenantSessionCookie as jest.MockedFn<
         typeof selectTenantsFromMultitenantSessionCookie
@@ -30,7 +30,7 @@ describe("TenantDropdown", () => {
     const wrapper = shallow(<TenantDropdown />);
     expect(wrapper.isEmptyRender());
   });
-  it("returns a dropdown list of tenant options if there are tenant in the multitenant-session cookie", () => {
+  it("returns a dropdown list of tenant options if there are tenant in the session cookie", () => {
     (
       selectTenantsFromMultitenantSessionCookie as jest.MockedFn<
         typeof selectTenantsFromMultitenantSessionCookie


### PR DESCRIPTION
Previous work has been done to update the `session` cookie to instead be named `multitenant-session`, which encoded not only the session ID of the currently logged in tenant, but also the name of that tenant, as well as any *other* tenant (and their session) who was able to be logged in to using the same credentials.

This created backwards compatibility issues, since the cookie name changed, and the auth layer began requiring the tenant name to be encoded in the cookie value. This led to scenarios where upgrading from v22.2 to v23.1 effectively invalidated any existing `session` cookie.

To fix this, this patch reverts the session cookie name back to `session` (instead of `multitenant-session`). Furthermore, if the authorization layer doesn't find any tenant name to be encoded in the cookie's value, it defaults to the system tenant. This enables older sessions to still be usable in the DB Console and
apiV2.

Note that this does *not* mean that existing legacy session cookie will be multitenant capable, which is to say that the cookie will not be updated to encode the system tenant's name, or sessions for other
tenants. To gain this multitenant session cookie,
clients will need to go through the login flow
anew.

Release note: none

Epic: CRDB-12100

Fixes: https://github.com/cockroachdb/cockroach/issues/97786