### PR TITLE
build: no longer stamp by default for dev scenarios

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -104,7 +104,6 @@ build:crosslinuxs390xbase --config=cross
 
 # devdarwinx86_64 is a legacy setting that implies `--config=dev`.
 build:devdarwinx86_64 --config=dev
-build:dev --config=simplestamp
 build:macos --action_env=PATH=/opt/homebrew/bin:/opt/local/bin:/usr/local/bin:/usr/bin:/bin
 build:macos --host_action_env=PATH=/opt/homebrew/bin:/opt/local/bin:/usr/local/bin:/usr/bin:/bin
 

--- a/build/bazelutil/BUILD.bazel
+++ b/build/bazelutil/BUILD.bazel
@@ -4,13 +4,6 @@ load("@bazel_skylib//rules:analysis_test.bzl", "analysis_test")
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 load(":lint.bzl", "lint_binary")
 
-genrule(
-    name = "test_stamping",
-    outs = ["test_stamping.txt"],
-    cmd = """cat bazel-out/stable-status.txt | grep STABLE_BUILD > $@""",
-    stamp = True,
-)
-
 analysis_test(
     name = "test_nogo_configured",
     targets = select(

--- a/build/teamcity/cockroach/ci/tests/testrace_impl.sh
+++ b/build/teamcity/cockroach/ci/tests/testrace_impl.sh
@@ -30,7 +30,7 @@ do
                 echo "Skipping test $test"
                 continue
             fi
-            $(bazel info bazel-bin --config=ci)/pkg/cmd/bazci/bazci_/bazci -- test --config=ci --config=race --config=simplestamp "$test" \
+            $(bazel info bazel-bin --config=ci)/pkg/cmd/bazci/bazci_/bazci -- test --config=ci --config=race "$test" \
                                 --test_env=COCKROACH_LOGIC_TESTS_SKIP=true \
                                 --test_env=GOMAXPROCS=8 \
                                 --test_arg=-test.timeout="${go_timeout}s"

--- a/build/teamcity/cockroach/ci/tests/unit_tests_impl.sh
+++ b/build/teamcity/cockroach/ci/tests/unit_tests_impl.sh
@@ -15,6 +15,6 @@ if tc_release_branch; then
   EXTRA_PARAMS=" --flaky_test_attempts=3" 
 fi
 
-$(bazel info bazel-bin --config=ci)/pkg/cmd/bazci/bazci_/bazci -- test --config=cinolint --config=simplestamp -c fastbuild \
+$(bazel info bazel-bin --config=ci)/pkg/cmd/bazci/bazci_/bazci -- test --config=cinolint -c fastbuild \
                                   //pkg:small_tests //pkg:medium_tests //pkg:large_tests //pkg:enormous_tests \
                                    --profile=/artifacts/profile.gz $EXTRA_PARAMS

--- a/build/teamcity/cockroach/ci/tests/unused_test_impl.sh
+++ b/build/teamcity/cockroach/ci/tests/unused_test_impl.sh
@@ -4,6 +4,6 @@ set -xeuo pipefail
 
 # Get all the .x archives for everything in bazel-bin.
 bazel query 'kind("go_test|go_binary|go_transition_binary|go_transition_test|go_library", //pkg/...)' | \
-    xargs bazel build --config=ci --config=simplestamp --config=test
+    xargs bazel build --config=ci --config=test
 
-bazel run //pkg:unused_checker --config=ci --config=simplestamp --config=test
+bazel run //pkg:unused_checker --config=ci --config=test

--- a/dev
+++ b/dev
@@ -8,7 +8,7 @@ fi
 set -euo pipefail
 
 # Bump this counter to force rebuilding `dev` on all machines.
-DEV_VERSION=69
+DEV_VERSION=70
 
 THIS_DIR=$(cd "$(dirname "$0")" && pwd)
 BINARY_DIR=$THIS_DIR/bin/dev-versions

--- a/pkg/build/info.go
+++ b/pkg/build/info.go
@@ -38,7 +38,7 @@ var (
 	// Distribution is changed by the CCL init-time hook in non-APL builds.
 	Distribution = "OSS"
 	typ          string // Type of this build: <empty>, "development", or "release"
-	channel      = "unknown"
+	channel      string
 	envChannel   = envutil.EnvOrDefaultString("COCKROACH_CHANNEL", "unknown")
 	//go:embed version.txt
 	cockroachVersion string
@@ -65,7 +65,10 @@ func computeBinaryVersion(versionTxt, revision string) string {
 	if IsRelease() {
 		return v.String()
 	}
-	return fmt.Sprintf("%s-dev-%s", v.String(), revision)
+	if revision != "" {
+		return fmt.Sprintf("%s-dev-%s", v.String(), revision)
+	}
+	return fmt.Sprintf("%s-dev", v.String())
 }
 
 // BinaryVersion returns the version prefix, patch number and metadata of the current build.
@@ -140,6 +143,10 @@ func (b Info) Timestamp() (int64, error) {
 
 // GetInfo returns an Info struct populated with the build information.
 func GetInfo() Info {
+	ch := channel
+	if ch == "" {
+		ch = "unknown"
+	}
 	return Info{
 		GoVersion:       runtime.Version(),
 		Tag:             binaryVersion,
@@ -150,7 +157,7 @@ func GetInfo() Info {
 		Platform:        platform,
 		Distribution:    Distribution,
 		Type:            typ,
-		Channel:         channel,
+		Channel:         ch,
 		EnvChannel:      envChannel,
 	}
 }

--- a/pkg/gen/genbzl/targets.go
+++ b/pkg/gen/genbzl/targets.go
@@ -85,7 +85,6 @@ in ($all ^ labels("out", kind("_gomock_prog_gen rule",  {{ .All }})))
   + filter(".*:.*(-gen|gen-).*", $all)
   + //pkg/testutils/lint/passes/errcheck:errcheck_excludes.txt
   + //build/bazelutil:test_force_build_cdeps.txt
-  + //build/bazelutil:test_stamping.txt
   + //pkg/cmd/mirror/npm:*
 `,
 		doNotGenerate: true,


### PR DESCRIPTION
No longer require stamping for dev builds.

We still turn on stamping for `--cross` builds. This could be refined
further: for example, we don't *always* need to stamp, we need to just
stamp when we are actually building `cockroach`. For now I have not
touched this but we could make stamping even less common in this way.

This change makes unit tests more cacheable by Bazel and speeds up
many builds as we don't have to shell out to `git` for stamping.

Epic: none
Release note: None
@rickystewart
