### PR TITLE
ui: disable invalid options for tenant advanced debug

### DIFF
--- a/pkg/server/api_v2.go
+++ b/pkg/server/api_v2.go
@@ -204,7 +204,7 @@ func registerRoutes(
 		{"databases/{database_name:[\\w.]+}/grants/", a.databaseGrants, true, regularRole, noOption, false},
 		{"databases/{database_name:[\\w.]+}/tables/", a.databaseTables, true, regularRole, noOption, false},
 		{"databases/{database_name:[\\w.]+}/tables/{table_name:[\\w.]+}/", a.tableDetails, true, regularRole, noOption, false},
-		{"rules/", a.listRules, false, regularRole, noOption, false},
+		{"rules/", a.listRules, false, regularRole, noOption, true},
 
 		{"sql/", a.execSQL, true, regularRole, noOption, true},
 	}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -1864,8 +1864,9 @@ func (s *Server) PreStart(ctx context.Context) error {
 			db:               s.db,
 		}), /* apiServer */
 		serverpb.FeatureFlags{
-			CanViewKvMetricDashboards: s.rpcContext.TenantID.Equal(roachpb.SystemTenantID),
-		}, /* flags */
+			CanViewKvMetricDashboards:   s.rpcContext.TenantID.Equal(roachpb.SystemTenantID),
+			DisableKvLevelAdvancedDebug: false,
+		},
 	); err != nil {
 		return err
 	}

--- a/pkg/server/serverpb/admin.proto
+++ b/pkg/server/serverpb/admin.proto
@@ -1459,8 +1459,12 @@ message SetTraceRecordingTypeResponse{}
 
 // FeatureFlags within this struct are used within back-end/front-end code to show/hide features.
 message FeatureFlags {
-  // Whether the server is an instance of the Observability Service
+  // isObservabiliyService is true when the server is an instance of the Observability Service
   bool is_observability_service = 1;
-  // Whether the logged in user is able to view KV-level metric dashboards.
+  // CanViewKVMetricDashboards is true when the logged in user is able to view KV-level metric dashboards.
   bool can_view_kv_metric_dashboards = 2;
+  // DisableKVLevelAdvancedDebug is true when the UI should remove options to certain KV-level
+  // debug operations. This is helpful in application tenant contexsts, where these requests
+  // can only return errors since the tenant cannot perform the operations.
+  bool disable_kv_level_advanced_debug = 3;
 }

--- a/pkg/server/tenant.go
+++ b/pkg/server/tenant.go
@@ -692,7 +692,8 @@ func (s *SQLServerWrapper) PreStart(ctx context.Context) error {
 			db:               s.db,
 		}), /* apiServer */
 		serverpb.FeatureFlags{
-			CanViewKvMetricDashboards: s.rpcContext.TenantID.Equal(roachpb.SystemTenantID),
+			CanViewKvMetricDashboards:   s.rpcContext.TenantID.Equal(roachpb.SystemTenantID),
+			DisableKvLevelAdvancedDebug: true,
 		},
 	); err != nil {
 		return err

--- a/pkg/ui/workspaces/db-console/src/redux/state.ts
+++ b/pkg/ui/workspaces/db-console/src/redux/state.ts
@@ -39,6 +39,7 @@ import { initializeAnalytics } from "./analytics";
 import { DataFromServer } from "src/util/dataFromServer";
 import { cockroach } from "@cockroachlabs/crdb-protobuf-client";
 import FeatureFlags = cockroach.server.serverpb.FeatureFlags;
+import { createSelector } from "reselect";
 
 export interface AdminUIState {
   cachedData: APIReducersState;
@@ -51,6 +52,7 @@ export interface AdminUIState {
   timeScale: TimeScaleState;
   uiData: UIDataState;
   login: LoginAPIState;
+  flags: FeatureFlags;
 }
 
 const emptyDataFromServer: DataFromServer = {
@@ -64,6 +66,15 @@ const emptyDataFromServer: DataFromServer = {
   Tag: "",
   Version: "",
 };
+
+export const featureFlagSelector = createSelector(
+  (state: AdminUIState) => state.flags,
+  flags => flags,
+);
+
+export function flagsReducer(state = emptyDataFromServer.FeatureFlags) {
+  return state;
+}
 
 // createAdminUIStore is a function that returns a new store for the admin UI.
 // It's in a function so it can be recreated as necessary for testing.
@@ -86,6 +97,7 @@ export function createAdminUIStore(
       timeScale: timeScaleReducer,
       uiData: uiDataReducer,
       login: loginReducer,
+      flags: flagsReducer,
     }),
     {
       login: {
@@ -96,6 +108,7 @@ export function createAdminUIStore(
         oidcLoginEnabled: dataFromServer.OIDCLoginEnabled,
         oidcButtonText: dataFromServer.OIDCButtonText,
       },
+      flags: dataFromServer.FeatureFlags,
     },
     compose(
       applyMiddleware(thunk, sagaMiddleware, routerMiddleware(historyInst)),

--- a/pkg/ui/workspaces/db-console/src/test-utils/renderWithProviders.tsx
+++ b/pkg/ui/workspaces/db-console/src/test-utils/renderWithProviders.tsx
@@ -13,7 +13,7 @@ import { configureStore } from "@reduxjs/toolkit";
 import type { PreloadedState } from "@reduxjs/toolkit";
 import { Provider } from "react-redux";
 
-import { AdminUIState } from "src/redux/state";
+import { AdminUIState, flagsReducer } from "src/redux/state";
 import { createMemoryHistory } from "history";
 import { apiReducersReducer } from "src/redux/apiReducers";
 import { hoverReducer } from "src/redux/hover";
@@ -44,6 +44,7 @@ export function renderWithProviders(
       timeScale: timeScaleReducer,
       uiData: uiDataReducer,
       login: loginReducer,
+      flags: flagsReducer,
     },
     preloadedState,
   });

--- a/pkg/ui/workspaces/db-console/src/views/reports/containers/debug/index.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/reports/containers/debug/index.tsx
@@ -23,12 +23,13 @@ import {
   Panel,
 } from "src/views/shared/components/panelSection";
 import "./debug.styl";
-import { connect } from "react-redux";
-import { AdminUIState } from "src/redux/state";
+import { connect, useSelector } from "react-redux";
+import { AdminUIState, featureFlagSelector } from "src/redux/state";
 import { nodeIDsStringifiedSelector } from "src/redux/nodes";
 import { refreshNodes, refreshUserSQLRoles } from "src/redux/apiReducers";
 import { selectHasViewActivityRedactedRole } from "src/redux/user";
 import { getCookieValue, setCookie } from "src/redux/cookies";
+import { InlineAlert } from "src/components";
 
 const COMMUNITY_URL = "https://www.cockroachlabs.com/community/";
 
@@ -42,7 +43,12 @@ export function DebugTableLink(props: {
     si?: string;
     labels?: string;
   };
+  disabled?: boolean;
 }) {
+  if (props.disabled) {
+    return null;
+  }
+
   const params = new URLSearchParams(props.params);
   const urlWithParams = props.params
     ? `${props.url}?${params.toString()}`
@@ -61,7 +67,14 @@ export function DebugTableLink(props: {
   );
 }
 
-function DebugTableRow(props: { title: string; children?: React.ReactNode }) {
+function DebugTableRow(props: {
+  title: string;
+  children?: React.ReactNode;
+  disabled?: boolean;
+}) {
+  if (props.disabled) {
+    return null;
+  }
   return (
     <tr className="debug-table__row">
       <th className="debug-table__cell debug-table__cell--header">
@@ -90,7 +103,15 @@ function DebugTable(props: {
   );
 }
 
-function DebugPanelLink(props: { name: string; url: string; note: string }) {
+function DebugPanelLink(props: {
+  name: string;
+  url: string;
+  note: string;
+  disabled?: boolean;
+}) {
+  if (props.disabled) {
+    return null;
+  }
   return (
     <PanelPair>
       <Panel>
@@ -233,10 +254,27 @@ const StatementDiagnosticsConnected = connect(
 
 export default function Debug() {
   const [nodeID, setNodeID] = useState<string>(getDataFromServer().NodeID);
+
+  const { disable_kv_level_advanced_debug } = useSelector(featureFlagSelector);
+
   return (
     <div className="section">
       <Helmet title="Debug" />
       <h3 className="base-heading">Advanced Debugging</h3>
+      {disable_kv_level_advanced_debug && (
+        <section className="section">
+          <InlineAlert
+            title="Some advanced debug options are not available on secondary tenants."
+            intent="warning"
+            message={
+              <span>
+                To access additional advanced debug options, please login using
+                system tenant credentials.
+              </span>
+            }
+          />
+        </section>
+      )}
       <div className="debug-header">
         <InfoBox>
           <p>
@@ -266,11 +304,13 @@ export default function Debug() {
           name="Problem Ranges"
           url="#/reports/problemranges"
           note="View ranges in your cluster that are unavailable, underreplicated, slow, or have other problems."
+          disabled={disable_kv_level_advanced_debug}
         />
         <DebugPanelLink
           name="Data Distribution and Zone Configs"
           url="#/data-distribution"
           note="View the distribution of table data across nodes and verify zone configuration."
+          disabled={disable_kv_level_advanced_debug}
         />
         <StatementDiagnosticsConnected />
         <PanelTitle>Configuration</PanelTitle>
@@ -304,7 +344,10 @@ export default function Debug() {
             note="#/reports/nodes/history"
           />
         </DebugTableRow>
-        <DebugTableRow title="Stores">
+        <DebugTableRow
+          title="Stores"
+          disabled={disable_kv_level_advanced_debug}
+        >
           <DebugTableLink
             name="Stores on this node"
             url="#/reports/stores/local"
@@ -331,7 +374,10 @@ export default function Debug() {
             note="#/reports/certificates/[node_id]"
           />
         </DebugTableRow>
-        <DebugTableRow title="Problem Ranges">
+        <DebugTableRow
+          title="Problem Ranges"
+          disabled={disable_kv_level_advanced_debug}
+        >
           <DebugTableLink
             name="Problem Ranges on a specific node"
             url="#/reports/problemranges/local"
@@ -344,11 +390,26 @@ export default function Debug() {
             url="#/reports/range/1"
             note="#/reports/range/[range_id]"
           />
-          <DebugTableLink name="Raft Messages" url="#/raft/messages/all" />
-          <DebugTableLink name="Raft for all ranges" url="#/raft/ranges" />
-          <DebugTableLink name="Key Visualizer" url="#/keyvisualizer" />
+          <DebugTableLink
+            name="Raft Messages"
+            url="#/raft/messages/all"
+            disabled={disable_kv_level_advanced_debug}
+          />
+          <DebugTableLink
+            name="Raft for all ranges"
+            url="#/raft/ranges"
+            disabled={disable_kv_level_advanced_debug}
+          />
+          <DebugTableLink
+            name="Key Visualizer"
+            url="#/keyvisualizer"
+            disabled={disable_kv_level_advanced_debug}
+          />
         </DebugTableRow>
-        <DebugTableRow title="Closed timestamps">
+        <DebugTableRow
+          title="Closed timestamps"
+          disabled={disable_kv_level_advanced_debug}
+        >
           <DebugTableLink
             name="Sender on this node"
             url="debug/closedts-sender"
@@ -408,9 +469,21 @@ export default function Debug() {
       </DebugTable>
       <DebugTable heading="Tracing and Profiling Endpoints (local node only)">
         <DebugTableRow title="Tracing">
-          <DebugTableLink name="Active operations" url="#/debug/tracez" />
-          <DebugTableLink name="Requests" url="debug/requests" />
-          <DebugTableLink name="Events" url="debug/events" />
+          <DebugTableLink
+            name="Active operations"
+            url="#/debug/tracez"
+            disabled={disable_kv_level_advanced_debug}
+          />
+          <DebugTableLink
+            name="Requests"
+            url="debug/requests"
+            disabled={disable_kv_level_advanced_debug}
+          />
+          <DebugTableLink
+            name="Events"
+            url="debug/events"
+            disabled={disable_kv_level_advanced_debug}
+          />
           <DebugTableLink
             name="Logs (JSON)"
             url="debug/logspy?count=100&amp;duration=10s&amp;grep=.&flatten=0"
@@ -432,7 +505,10 @@ export default function Debug() {
             note="debug/vmodule?duration=[duration]&amp;vmodule=[vmodule]"
           />
         </DebugTableRow>
-        <DebugTableRow title="Enqueue Range">
+        <DebugTableRow
+          title="Enqueue Range"
+          disabled={disable_kv_level_advanced_debug}
+        >
           <DebugTableLink
             name="Run a range through an internal queue"
             url="#/debug/enqueue_range"
@@ -481,7 +557,10 @@ export default function Debug() {
           <DebugTableLink name="Prometheus" url="_status/vars" />
           <DebugTableLink name="Rules" url="api/v2/rules/" />
         </DebugTableRow>
-        <DebugTableRow title="Node Status">
+        <DebugTableRow
+          title="Node Status"
+          disabled={disable_kv_level_advanced_debug}
+        >
           <DebugTableLink
             name="All Nodes"
             url="_status/nodes"
@@ -503,9 +582,13 @@ export default function Debug() {
             name="Single node's ranges"
             url="#/debug/hotranges/local"
             note="#/debug/hotranges/[node_id]"
+            disabled={disable_kv_level_advanced_debug}
           />
         </DebugTableRow>
-        <DebugTableRow title="Hot Ranges (legacy)">
+        <DebugTableRow
+          title="Hot Ranges (legacy)"
+          disabled={disable_kv_level_advanced_debug}
+        >
           <DebugTableLink
             name="All Nodes"
             url="_status/hotranges"
@@ -517,7 +600,10 @@ export default function Debug() {
             note="_status/hotranges?node_id=[node_id]"
           />
         </DebugTableRow>
-        <DebugTableRow title="Single Node Specific">
+        <DebugTableRow
+          title="Single Node Specific"
+          disabled={disable_kv_level_advanced_debug}
+        >
           <DebugTableLink
             name="Stores"
             url="_status/stores/local"
@@ -558,7 +644,10 @@ export default function Debug() {
           <DebugTableLink name="Local Sessions" url="_status/local_sessions" />
           <DebugTableLink name="All Sessions" url="_status/sessions" />
         </DebugTableRow>
-        <DebugTableRow title="Cluster Wide">
+        <DebugTableRow
+          title="Cluster Wide"
+          disabled={disable_kv_level_advanced_debug}
+        >
           <DebugTableLink name="Raft" url="_status/raft" />
           <DebugTableLink
             name="Range"
@@ -572,7 +661,10 @@ export default function Debug() {
             note="_admin/v1/rangelog/[range_id]?limit=100"
           />
         </DebugTableRow>
-        <DebugTableRow title="Allocator">
+        <DebugTableRow
+          title="Allocator"
+          disabled={disable_kv_level_advanced_debug}
+        >
           <DebugTableLink
             name="Simulated Allocator Runs on a Specific Node"
             url="_status/allocator/node/local"


### PR DESCRIPTION
Prevously, the Advanced Debug page on the DB console would show a lot of options to the tenant that were either unsupported, unimplemented, or not valid in that context. This change hides those options for now to create a smoother Console experience for tenants.

The changes made are currently implemented via a server-controlled feature flag that is enabled by default on tenants, and not on the system tenant.

The summary of disabled items is as follows:
* Problem ranges: hidden since implementation depends on liveness 
  * Issue to fix: #97941
* Data distribution: hidden due to error on tenants
  * Issue to fix: #97942
* Stores section: not applicable to tenants
* Problem Ranges section: see above
* Raft and Key Visualizer links: not applicable to tenants
* Closed timestamps: not applicable to tenants
* Tracing active operations: ui impl proxies to nodes, needs changes
  * Issue to fix: #97943
* Debug requests/events: not applicable to tenants
* Enqueue range: not applicable to tenants
* Node status: not implemented on tenants
* Single node's ranges: not implemented on tenants
* Hot Ranges (legacy): not implemented on tenants
* Single Node Specific: not implemented on tenants
* Cluster wide: not applicable to tenants
* Allocator: not applicable to tenants

Resolves: #80595
Epic: CRDB-12100

Release note: None