### PR TITLE
sql: fix redact_descriptor test

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/redact_descriptor
+++ b/pkg/ccl/logictestccl/testdata/logic_test/redact_descriptor
@@ -16,20 +16,24 @@ CREATE VIEW redacted_descriptors AS
         jsonb_pretty(
             regexp_replace(
                 regexp_replace(
-                    (
-                        crdb_internal.pb_to_json(
-                            'desc',
-                            crdb_internal.redact_descriptor(
-                                descriptor
+                    regexp_replace(
+                        (
+                            crdb_internal.pb_to_json(
+                                'desc',
+                                crdb_internal.redact_descriptor(
+                                    descriptor
+                                )
                             )
-                        )
-                    )::STRING,
-                    '"createdAtNanos": "[0-9]+"',
-                    '"createdAtNanos": "0"',
-                    'g'
+                        )::STRING,
+                        '"createdAtNanos": "[0-9]+"',
+                        '"createdAtNanos": "0"',
+                        'g'
+                    ),
+                    '"wallTime": "[0-9]+"',
+                    '"wallTime": "0"'
                 ),
-                '"wallTime": "[0-9]+"',
-                '"wallTime": "0"'
+               '"logical": [0-9]+[,]*',
+               ''
             )::JSONB
         )
             AS descriptor

--- a/pkg/sql/logictest/testdata/logic_test/redact_descriptor
+++ b/pkg/sql/logictest/testdata/logic_test/redact_descriptor
@@ -5,20 +5,24 @@ CREATE VIEW redacted_descriptors AS
         jsonb_pretty(
             regexp_replace(
                 regexp_replace(
-                    (
-                        crdb_internal.pb_to_json(
-                            'desc',
-                            crdb_internal.redact_descriptor(
-                                descriptor
+                    regexp_replace(
+                        (
+                            crdb_internal.pb_to_json(
+                                'desc',
+                                crdb_internal.redact_descriptor(
+                                    descriptor
+                                )
                             )
-                        )
-                    )::STRING,
-                    '"createdAtNanos": "[0-9]+"',
-                    '"createdAtNanos": "0"',
-                    'g'
+                        )::STRING,
+                        '"createdAtNanos": "[0-9]+"',
+                        '"createdAtNanos": "0"',
+                        'g'
+                    ),
+                    '"wallTime": "[0-9]+"',
+                    '"wallTime": "0"'
                 ),
-                '"wallTime": "[0-9]+"',
-                '"wallTime": "0"'
+               '"logical": [0-9]+[,]*',
+               ''
             )::JSONB
         )
             AS descriptor


### PR DESCRIPTION
Fixes: #96928
Previously, we kept `logical` field in the descriptor to when validating result in `redact_descriptor` test. The test failed randomly because of the flaky timestamp. This patch removes `logical` field from the out as well to make the test stable.

Release note: None