### PR TITLE
bazel: rebuild db-console when relevant files change

### DIFF
--- a/pkg/ui/workspaces/db-console/BUILD.bazel
+++ b/pkg/ui/workspaces/db-console/BUILD.bazel
@@ -163,15 +163,24 @@ DEPENDENCIES = [
     "@npm_db_console//whatwg-fetch",
 ] + DEV_DEPENDENCIES
 
-WEBPACK_DATA_COMMON = [
+WEBPACK_DATA_COMMON = glob(
+    include = [
+        "assets/**",
+        "fonts/**",
+        "src/**",
+        "styl/**",
+    ],
+    exclude = [
+        "src/js/**",
+        "src/**/*.stories.tsx",
+        "src/**/*.spec.tsx",
+        "src/**/*.spec.ts",
+    ],
+) + [
     "babel.config.js",
     ".eslintrc.json",
     ".stylintrc",
-    "assets",
     "favicon.ico",
-    "fonts",
-    "src",
-    "styl",
     "tsconfig.json",
     "webpack.config.js",
     "//pkg/ui/workspaces/cluster-ui:cluster-ui",


### PR DESCRIPTION
Previously, Bazel would ignore changes to files in ./pkg/ui/workspaces/db-console/src (or '.../assets/', '.../fonts', or '.../styl') after an initial build completes and is cached. Since only those directories were listed and not the files within them via a `glob`, Bazel simply never looked for changes in those files. In fact, a bazel query confirms this:

    bazel query 'somepath(//pkg/cmd/cockroach:cockroach, //pkg/ui/workspaces/db-console:src/index.tsx)'
    INFO: empty results

Use a `glob` to force Bazel to depend on individual source files in db-console. That same query should now result in a valid dependency path:

    bazel query 'somepath(//pkg/cmd/cockroach:cockroach, //pkg/ui/workspaces/db-console:src/index.tsx)'
    //pkg/cmd/cockroach:cockroach
    //pkg/cmd/cockroach:cockroach_lib
    //pkg/ui/distccl:distccl
    //pkg/ui/distccl:genassets
    //pkg/ui/workspaces/db-console:db-console-ccl
    //pkg/ui/workspaces/db-console:src/index.tsx

Fixes: #97954

Release note (build change): Changes to source files in pkg/ui/workspaces/db-console now properly bust the build cache, and are consistently included in local builds.