### PR TITLE
sql: fix internal error during execution of correlated EXISTS subquery

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/subquery
+++ b/pkg/sql/logictest/testdata/logic_test/subquery
@@ -756,6 +756,23 @@ WHERE
   NOT IN (SELECT (ARRAY[704, 11676, 10005, 3912, 11765, 59410, 11397])[i] FROM generate_series(1, 376) AS i)
 ----
 
+# Regression test for #96441.
+statement ok
+CREATE TABLE t96441 (
+  k INT PRIMARY KEY,
+  i INT,
+  CHECK (k IN (1, 2))
+);
+INSERT INTO t96441 VALUES (1, 10);
+
+query III
+SELECT * FROM (VALUES (0))
+FULL JOIN t96441 AS t1
+ON 1 IN (SELECT t1.i FROM t96441)
+----
+NULL  1     10
+0     NULL  NULL
+
 statement ok
 ALTER TABLE abc INJECT STATISTICS '[
   {

--- a/pkg/sql/opt/exec/execbuilder/scalar.go
+++ b/pkg/sql/opt/exec/execbuilder/scalar.go
@@ -982,13 +982,14 @@ func (b *Builder) buildRoutinePlanGenerator(
 					// Fall through.
 				}
 
-				replaced := f.CopyAndReplaceDefault(e, replaceFn)
-				if wrapRootExpr != nil && e == stmt.RelExpr {
-					replaced = wrapRootExpr(f, replaced.(memo.RelExpr))
-				}
-				return replaced
+				return f.CopyAndReplaceDefault(e, replaceFn)
 			}
-			f.CopyAndReplace(stmt, stmt.PhysProps, replaceFn)
+			f.CopyAndReplace(stmt.RelExpr, stmt.PhysProps, replaceFn)
+
+			if wrapRootExpr != nil {
+				wrapped := wrapRootExpr(f, f.Memo().RootExpr().(memo.RelExpr)).(memo.RelExpr)
+				f.Memo().SetRoot(wrapped, stmt.PhysProps)
+			}
 
 			// Optimize the memo.
 			optimizedExpr, err := o.Optimize()


### PR DESCRIPTION
#### sql: fix internal error during execution of correlated EXISTS subquery

During execution of a correlated EXISTS subquery, the subquery is
optimized. Before optimization, the subquery is wrapped in Project and
Limit expressions while `CopyAndReplace` is invoked to replace
correlated variables with constant values. Execbuilder determined which
expression was the root of the subquery, and therefore the expression to
wrap, using pointer equality. This was incorrect because
`CopyAndReplace` invokes the replace function on the first member of a
memo group. If the subquery's root expression was not the first member
of its memo group, the subquery would not be wrapped in a Project and
Limit, and an internal error would occur.

This commit fixes the issue by no longer relying on pointer equality to
determine the root expression of a subquery.

Fixes #96441

Release note: None
