### PR TITLE
sql: use temps schema name for temp table instead of a descriptor lookup

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/alter_type
+++ b/pkg/sql/logictest/testdata/logic_test/alter_type
@@ -666,3 +666,32 @@ CREATE VIEW bar_view AS (SELECT ARRAY['b'::bar])
 
 statement error pq: could not remove enum value "b" as it is being used in view "bar_view"
 ALTER TYPE bar DROP VALUE 'b'
+
+subtest regression_97975
+
+statement ok
+CREATE DATABASE db97975;
+USE db97975;
+
+statement ok
+CREATE TYPE enum_97975 as ENUM ('value1', 'value2');
+
+query T
+SHOW CREATE ALL TYPES;
+----
+CREATE TYPE public.enum_97975 AS ENUM ('value1', 'value2');
+
+statement ok
+SET experimental_enable_temp_tables = on;
+CREATE TEMPORARY TABLE tmp_table_97975 (id INT PRIMARY KEY);
+
+statement ok
+ALTER TYPE enum_97975 ADD VALUE 'value3';
+
+query T
+SHOW CREATE ALL TYPES;
+----
+CREATE TYPE public.enum_97975 AS ENUM ('value1', 'value2', 'value3');
+
+statement ok
+USE test;


### PR DESCRIPTION
Fixes: #97975

Previously, in method `planner.forEachMutableTableInDatabase`, when we loop through all table descriptors in a db, we also check parent schema name for each table by looking at descriptor informations. This doesn't work with temp tables because there is not descriptor for temp schemas. This caused `ALTER TYPE...ADD VALUE` statement to hang in the same session.

This commit changes it to use temp schema name of
current session directly instead of looking up from descriptors.

Release note (sql change): this commit fixed a bug where statement `ALTER TYPE...ADD VALUE` statement hangs whenever there is a temp schema in the same session.