### PR TITLE
sqlstats, crdb_internal: stop unecessary sorting in table generation 

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/api/statementsApi.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/api/statementsApi.ts
@@ -138,7 +138,6 @@ export function convertStatementRawFormatToAggregatedStatistics(
   s: StatementRawFormat,
 ): AggregateStatistics {
   return {
-    aggregationInterval: s.agg_interval,
     applicationName: s.app_name,
     database: s.metadata.db,
     fullScan: s.metadata.fullScan,

--- a/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.fixture.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.fixture.ts
@@ -268,7 +268,6 @@ const diagnosticsReportsInProgress: StatementDiagnosticsReport[] = [
 
 const aggregatedTs = Date.parse("Sep 15 2021 01:00:00 GMT") * 1e-3;
 const lastUpdated = moment("Sep 15 2021 01:30:00 GMT");
-const aggregationInterval = 3600; // 1 hour
 
 export const mockStmt = (
   partialStmt: Partial<Omit<AggregateStatistics, "aggregatedFingerprintHexID">>,
@@ -285,7 +284,6 @@ export const mockStmt = (
     label: "SELECT 1",
     summary: "SELECT 1",
     aggregatedTs,
-    aggregationInterval,
     implicitTxn: true,
     database: "defaultdb",
     applicationName: "app",

--- a/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.selectors.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.selectors.ts
@@ -42,7 +42,6 @@ export interface StatementsSummaryData {
   statement: string;
   statementSummary: string;
   aggregatedTs: number;
-  aggregationInterval: number;
   implicitTxn: boolean;
   fullScan: boolean;
   database: string;
@@ -182,7 +181,6 @@ export const selectStatements = createSelector(
           statement: stmt.statement,
           statementSummary: stmt.statement_summary,
           aggregatedTs: stmt.aggregated_ts,
-          aggregationInterval: stmt.aggregation_interval,
           implicitTxn: stmt.implicit_txn,
           fullScan: stmt.full_scan,
           database: stmt.database,
@@ -203,7 +201,6 @@ export const selectStatements = createSelector(
         label: stmt.statement,
         summary: stmt.statementSummary,
         aggregatedTs: stmt.aggregatedTs,
-        aggregationInterval: stmt.aggregationInterval,
         implicitTxn: stmt.implicitTxn,
         fullScan: stmt.fullScan,
         database: stmt.database,

--- a/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.spec.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.spec.tsx
@@ -56,7 +56,6 @@ describe("StatementsPage", () => {
       aggregatedFingerprintID: "",
       aggregatedFingerprintHexID: "",
       aggregatedTs: 0,
-      aggregationInterval: 0,
       database: "",
       applicationName: "",
       fullScan: false,

--- a/pkg/ui/workspaces/cluster-ui/src/statementsTable/statementsTable.spec.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsTable/statementsTable.spec.tsx
@@ -23,7 +23,6 @@ describe("populateRegionNodeForStatements", () => {
       label: "",
       summary: "",
       aggregatedTs: 0,
-      aggregationInterval: 0,
       implicitTxn: false,
       fullScan: false,
       database: "",

--- a/pkg/ui/workspaces/cluster-ui/src/statementsTable/statementsTable.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsTable/statementsTable.tsx
@@ -63,7 +63,6 @@ export interface AggregateStatistics {
   // replaced with shortStatement otherwise.
   summary: string;
   aggregatedTs: number;
-  aggregationInterval: number;
   implicitTxn: boolean;
   fullScan: boolean;
   database: string;

--- a/pkg/ui/workspaces/cluster-ui/src/statementsTable/statementsTableContent.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsTable/statementsTableContent.tsx
@@ -49,7 +49,6 @@ export const StatementTableCell = {
           statement={stmt.label}
           statementSummary={stmt.summary}
           aggregatedTs={stmt.aggregatedTs}
-          aggregationInterval={stmt.aggregationInterval}
           appNames={selectedApp}
           implicitTxn={stmt.implicitTxn}
           search={search}
@@ -187,7 +186,6 @@ export const StatementLinkTarget = (
 interface StatementLinkProps {
   statementFingerprintID: string;
   aggregatedTs?: number;
-  aggregationInterval?: number;
   appNames?: string[];
   implicitTxn: boolean;
   statement: string;
@@ -200,7 +198,6 @@ interface StatementLinkProps {
 
 export const StatementLink = ({
   statementFingerprintID,
-  aggregationInterval,
   appNames,
   implicitTxn,
   statement,
@@ -217,7 +214,6 @@ export const StatementLink = ({
 
   const linkProps = {
     statementFingerprintID,
-    aggregationInterval,
     appNames,
     implicitTxn,
   };

--- a/pkg/ui/workspaces/cluster-ui/src/statsTableUtil/statsTableUtil.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statsTableUtil/statsTableUtil.tsx
@@ -1024,18 +1024,3 @@ export const statisticsTableTitles: StatisticTableTitleType = {
     );
   },
 };
-
-export function formatAggregationIntervalColumn(
-  aggregatedTs: number,
-  interval: number,
-): string {
-  const formatStr = "MMM D, H:mm";
-  const formatStrWithoutDay = "H:mm";
-  const start = moment.unix(aggregatedTs).utc();
-  const end = moment.unix(aggregatedTs + interval).utc();
-  const isSameDay = start.isSame(end, "day");
-
-  return `${start.format(formatStr)} - ${end.format(
-    isSameDay ? formatStrWithoutDay : formatStr,
-  )}`;
-}

--- a/pkg/ui/workspaces/cluster-ui/src/transactionsPage/utils.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionsPage/utils.ts
@@ -106,7 +106,6 @@ export const aggregateStatements = (
         label: s.statement,
         summary: s.statement_summary,
         aggregatedTs: s.aggregated_ts,
-        aggregationInterval: s.aggregation_interval,
         implicitTxn: s.implicit_txn,
         database: s.database,
         applicationName: s.app,

--- a/pkg/ui/workspaces/cluster-ui/src/util/constants.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/util/constants.ts
@@ -8,7 +8,6 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
-export const aggregationIntervalAttr = "aggregation_interval";
 export const aggregatedTsAttr = "aggregated_ts";
 export const appAttr = "app";
 export const appNamesAttr = "appNames";

--- a/pkg/ui/workspaces/db-console/src/util/constants.ts
+++ b/pkg/ui/workspaces/db-console/src/util/constants.ts
@@ -13,7 +13,6 @@ import { util } from "@cockroachlabs/cluster-ui";
 export const indexNameAttr = "index_name";
 
 export const {
-  aggregationIntervalAttr,
   aggregatedTsAttr,
   appAttr,
   appNamesAttr,

--- a/pkg/ui/workspaces/db-console/src/views/statements/statementsPage.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/statements/statementsPage.tsx
@@ -92,7 +92,6 @@ interface StatementsSummaryData {
   statement: string;
   statementSummary: string;
   aggregatedTs: number;
-  aggregationInterval: number;
   implicitTxn: boolean;
   fullScan: boolean;
   database: string;
@@ -155,7 +154,6 @@ export const selectStatements = createSelector(
           statement: stmt.statement,
           statementSummary: stmt.statement_summary,
           aggregatedTs: stmt.aggregated_ts,
-          aggregationInterval: stmt.aggregation_interval,
           implicitTxn: stmt.implicit_txn,
           fullScan: stmt.full_scan,
           database: stmt.database,
@@ -176,7 +174,6 @@ export const selectStatements = createSelector(
         label: stmt.statement,
         summary: stmt.statementSummary,
         aggregatedTs: stmt.aggregatedTs,
-        aggregationInterval: stmt.aggregationInterval,
         implicitTxn: stmt.implicitTxn,
         fullScan: stmt.fullScan,
         database: stmt.database,


### PR DESCRIPTION
During the creation of `cluster_{transaciton_statement}_statistics`,
internal tables, which display the in-memory sql stats from all nodes
aggregated across node boundaries, we create a temporary sql stats
container in order to do the aggregation across nodes. Previously,
we were sorting each node response by application name when adding
stats to the temp container. This sort was unnecessary as we don't
actually care if the data is generated in a consistent way as we provide
the desired sort in the ORDER BY clause when querying the table.

This commit removes the unnecessary sorting logic to speed up table
generation.

Epic: none
Fixes: https://github.com/cockroachdb/cockroach/issues/97980

Release note: None