### PR TITLE
pkg/ui: filter metric dashboard options for tenants

### DIFF
--- a/pkg/obsservice/obslib/httpproxy/reverseproxy.go
+++ b/pkg/obsservice/obslib/httpproxy/reverseproxy.go
@@ -143,6 +143,8 @@ func (p *ReverseHTTPProxy) Start(ctx context.Context, stop *stop.Stopper) {
 		OIDC: &noOIDCConfigured{},
 		Flags: serverpb.FeatureFlags{
 			IsObservabilityService: true,
+			// TODO(obs-infra): make conditional once obsservice becomes tenant-aware.
+			CanViewKvMetricDashboards: true,
 		},
 	}))
 	for _, path := range CRDBProxyPaths {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -1862,6 +1862,9 @@ func (s *Server) PreStart(ctx context.Context) error {
 			sqlServer:        s.sqlServer,
 			db:               s.db,
 		}), /* apiServer */
+		serverpb.FeatureFlags{
+			CanViewKvMetricDashboards: s.rpcContext.TenantID.Equal(roachpb.SystemTenantID),
+		}, /* flags */
 	); err != nil {
 		return err
 	}

--- a/pkg/server/server_http.go
+++ b/pkg/server/server_http.go
@@ -19,6 +19,7 @@ import (
 	"github.com/cockroachdb/cmux"
 	"github.com/cockroachdb/cockroach/pkg/rpc"
 	"github.com/cockroachdb/cockroach/pkg/server/debug"
+	"github.com/cockroachdb/cockroach/pkg/server/serverpb"
 	"github.com/cockroachdb/cockroach/pkg/server/status"
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/ts"
@@ -94,6 +95,7 @@ func (s *httpServer) setupRoutes(
 	handleRequestsUnauthenticated http.Handler,
 	handleDebugUnauthenticated http.Handler,
 	apiServer http.Handler,
+	flags serverpb.FeatureFlags,
 ) error {
 	// OIDC Configuration must happen prior to the UI Handler being defined below so that we have
 	// the system settings initialized for it to pick up from the oidcAuthenticationServer.
@@ -117,6 +119,7 @@ func (s *httpServer) setupRoutes(
 			}
 			return nil
 		},
+		Flags: flags,
 	})
 
 	// The authentication mux used here is created in "allow anonymous" mode so that the UI

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -804,7 +804,7 @@ Binary built without web UI.
 			respBytes, err = io.ReadAll(resp.Body)
 			require.NoError(t, err)
 			expected := fmt.Sprintf(
-				`{"Insecure":true,"LoggedInUser":null,"Tag":"%s","Version":"%s","NodeID":"%d","OIDCAutoLogin":false,"OIDCLoginEnabled":false,"OIDCButtonText":"","FeatureFlags":{}}`,
+				`{"Insecure":true,"LoggedInUser":null,"Tag":"%s","Version":"%s","NodeID":"%d","OIDCAutoLogin":false,"OIDCLoginEnabled":false,"OIDCButtonText":"","FeatureFlags":{"can_view_kv_metric_dashboards":true}}`,
 				build.GetInfo().Tag,
 				build.BinaryVersionPrefix(),
 				1,
@@ -832,7 +832,7 @@ Binary built without web UI.
 			{
 				loggedInClient,
 				fmt.Sprintf(
-					`{"Insecure":false,"LoggedInUser":"authentic_user","Tag":"%s","Version":"%s","NodeID":"%d","OIDCAutoLogin":false,"OIDCLoginEnabled":false,"OIDCButtonText":"","FeatureFlags":{}}`,
+					`{"Insecure":false,"LoggedInUser":"authentic_user","Tag":"%s","Version":"%s","NodeID":"%d","OIDCAutoLogin":false,"OIDCLoginEnabled":false,"OIDCButtonText":"","FeatureFlags":{"can_view_kv_metric_dashboards":true}}`,
 					build.GetInfo().Tag,
 					build.BinaryVersionPrefix(),
 					1,
@@ -841,7 +841,7 @@ Binary built without web UI.
 			{
 				loggedOutClient,
 				fmt.Sprintf(
-					`{"Insecure":false,"LoggedInUser":null,"Tag":"%s","Version":"%s","NodeID":"%d","OIDCAutoLogin":false,"OIDCLoginEnabled":false,"OIDCButtonText":"","FeatureFlags":{}}`,
+					`{"Insecure":false,"LoggedInUser":null,"Tag":"%s","Version":"%s","NodeID":"%d","OIDCAutoLogin":false,"OIDCLoginEnabled":false,"OIDCButtonText":"","FeatureFlags":{"can_view_kv_metric_dashboards":true}}`,
 					build.GetInfo().Tag,
 					build.BinaryVersionPrefix(),
 					1,

--- a/pkg/server/serverpb/admin.proto
+++ b/pkg/server/serverpb/admin.proto
@@ -1457,4 +1457,6 @@ message SetTraceRecordingTypeResponse{}
 message FeatureFlags {
   // Whether the server is an instance of the Observability Service
   bool is_observability_service = 1;
+  // Whether the logged in user is able to view KV-level metric dashboards.
+  bool can_view_kv_metric_dashboards = 2;
 }

--- a/pkg/server/tenant.go
+++ b/pkg/server/tenant.go
@@ -687,6 +687,9 @@ func (s *SQLServerWrapper) PreStart(ctx context.Context) error {
 			sqlServer:        s.sqlServer,
 			db:               s.db,
 		}), /* apiServer */
+		serverpb.FeatureFlags{
+			CanViewKvMetricDashboards: s.rpcContext.TenantID.Equal(roachpb.SystemTenantID),
+		},
 	); err != nil {
 		return err
 	}

--- a/pkg/ui/workspaces/cluster-ui/src/util/dataFromServer.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/util/dataFromServer.ts
@@ -9,7 +9,7 @@
 // licenses/APL.txt.
 
 import { cockroach } from "@cockroachlabs/crdb-protobuf-client";
-import IFeatureFlags = cockroach.server.serverpb.IFeatureFlags;
+import FeatureFlags = cockroach.server.serverpb.FeatureFlags;
 
 export interface DataFromServer {
   Insecure: boolean;
@@ -20,7 +20,7 @@ export interface DataFromServer {
   OIDCAutoLogin: boolean;
   OIDCLoginEnabled: boolean;
   OIDCButtonText: string;
-  FeatureFlags: IFeatureFlags;
+  FeatureFlags: FeatureFlags;
 }
 
 // Tell TypeScript about `window.dataFromServer`, which is set in a script

--- a/pkg/ui/workspaces/db-console/src/redux/state.ts
+++ b/pkg/ui/workspaces/db-console/src/redux/state.ts
@@ -37,6 +37,8 @@ import { loginReducer, LoginAPIState } from "./login";
 import rootSaga from "./sagas";
 import { initializeAnalytics } from "./analytics";
 import { DataFromServer } from "src/util/dataFromServer";
+import { cockroach } from "@cockroachlabs/crdb-protobuf-client";
+import FeatureFlags = cockroach.server.serverpb.FeatureFlags;
 
 export interface AdminUIState {
   cachedData: APIReducersState;
@@ -53,7 +55,7 @@ export interface AdminUIState {
 
 const emptyDataFromServer: DataFromServer = {
   Insecure: true,
-  FeatureFlags: {},
+  FeatureFlags: new FeatureFlags(),
   LoggedInUser: "",
   NodeID: "",
   OIDCAutoLogin: false,

--- a/pkg/ui/workspaces/db-console/src/util/dataFromServer.ts
+++ b/pkg/ui/workspaces/db-console/src/util/dataFromServer.ts
@@ -9,7 +9,7 @@
 // licenses/APL.txt.
 
 import { cockroach } from "@cockroachlabs/crdb-protobuf-client";
-import IFeatureFlags = cockroach.server.serverpb.IFeatureFlags;
+import FeatureFlags = cockroach.server.serverpb.FeatureFlags;
 
 export interface DataFromServer {
   Insecure: boolean;
@@ -20,7 +20,7 @@ export interface DataFromServer {
   OIDCAutoLogin: boolean;
   OIDCLoginEnabled: boolean;
   OIDCButtonText: string;
-  FeatureFlags: IFeatureFlags;
+  FeatureFlags: FeatureFlags;
 }
 // Tell TypeScript about `window.dataFromServer`, which is set in a script
 // tag in index.html, the contents of which are generated in a Go template

--- a/pkg/ui/workspaces/db-console/src/views/cluster/components/linegraph/index.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/cluster/components/linegraph/index.tsx
@@ -47,6 +47,7 @@ import {
 import _ from "lodash";
 
 export interface LineGraphProps extends MetricsDataComponentProps {
+  isKvGraph?: boolean;
   title?: string;
   subtitle?: string;
   legend?: boolean;
@@ -158,6 +159,11 @@ export class LineGraph extends React.Component<LineGraphProps, {}> {
 
     this.setNewTimeRange = this.setNewTimeRange.bind(this);
   }
+
+  static defaultProps: Partial<LineGraphProps> = {
+    // Marking a graph as not being KV-related is opt-in.
+    isKvGraph: true,
+  };
 
   // axis is copied from the nvd3 LineGraph component above
   axis = createSelector(

--- a/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/changefeeds.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/changefeeds.tsx
@@ -20,7 +20,11 @@ export default function (props: GraphDashboardProps) {
   const { storeSources } = props;
 
   return [
-    <LineGraph title="Max Changefeed Latency" sources={storeSources}>
+    <LineGraph
+      title="Max Changefeed Latency"
+      isKvGraph={false}
+      sources={storeSources}
+    >
       <Axis units={AxisUnits.Duration} label="time">
         <Metric
           name="cr.node.changefeed.max_behind_nanos"
@@ -31,7 +35,11 @@ export default function (props: GraphDashboardProps) {
       </Axis>
     </LineGraph>,
 
-    <LineGraph title="Sink Byte Traffic" sources={storeSources}>
+    <LineGraph
+      title="Sink Byte Traffic"
+      isKvGraph={false}
+      sources={storeSources}
+    >
       <Axis units={AxisUnits.Bytes} label="bytes">
         <Metric
           name="cr.node.changefeed.emitted_bytes"
@@ -41,7 +49,7 @@ export default function (props: GraphDashboardProps) {
       </Axis>
     </LineGraph>,
 
-    <LineGraph title="Sink Counts" sources={storeSources}>
+    <LineGraph title="Sink Counts" isKvGraph={false} sources={storeSources}>
       <Axis units={AxisUnits.Count} label="actions">
         <Metric
           name="cr.node.changefeed.emitted_messages"
@@ -56,7 +64,7 @@ export default function (props: GraphDashboardProps) {
       </Axis>
     </LineGraph>,
 
-    <LineGraph title="Sink Timings" sources={storeSources}>
+    <LineGraph title="Sink Timings" isKvGraph={false} sources={storeSources}>
       <Axis units={AxisUnits.Duration} label="time">
         <Metric
           name="cr.node.changefeed.emit_nanos"
@@ -71,7 +79,11 @@ export default function (props: GraphDashboardProps) {
       </Axis>
     </LineGraph>,
 
-    <LineGraph title="Changefeed Restarts" sources={storeSources}>
+    <LineGraph
+      title="Changefeed Restarts"
+      isKvGraph={false}
+      sources={storeSources}
+    >
       <Axis units={AxisUnits.Count} label="actions">
         <Metric
           name="cr.node.changefeed.error_retries"

--- a/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/overview.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/overview.tsx
@@ -35,6 +35,7 @@ export default function (props: GraphDashboardProps) {
   return [
     <LineGraph
       title="SQL Statements"
+      isKvGraph={false}
       sources={nodeSources}
       tooltip={`A moving average of the number of SELECT, INSERT, UPDATE, and DELETE statements
         successfully executed per second ${tooltipSelection}.`}
@@ -66,6 +67,7 @@ export default function (props: GraphDashboardProps) {
 
     <LineGraph
       title="Service Latency: SQL Statements, 99th percentile"
+      isKvGraph={false}
       tooltip={
         <div>
           Over the last minute, this node executed 99% of SQL statements within
@@ -92,6 +94,7 @@ export default function (props: GraphDashboardProps) {
     </LineGraph>,
     <LineGraph
       title="SQL Statement Contention"
+      isKvGraph={false}
       sources={nodeSources}
       tooltip={`A moving average of the number of SQL statements executed per second that experienced contention ${tooltipSelection}.`}
       preCalcGraphSize={true}
@@ -132,6 +135,7 @@ export default function (props: GraphDashboardProps) {
 
     <LineGraph
       title="Capacity"
+      isKvGraph={false}
       sources={storeSources}
       tooltip={<CapacityGraphTooltip tooltipSelection={tooltipSelection} />}
       preCalcGraphSize={true}

--- a/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/sql.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/sql.tsx
@@ -27,6 +27,7 @@ export default function (props: GraphDashboardProps) {
   return [
     <LineGraph
       title="Open SQL Sessions"
+      isKvGraph={false}
       sources={nodeSources}
       tooltip={`The total number of open SQL Sessions ${tooltipSelection}.`}
     >
@@ -45,6 +46,7 @@ export default function (props: GraphDashboardProps) {
 
     <LineGraph
       title="Open SQL Transactions"
+      isKvGraph={false}
       sources={nodeSources}
       tooltip={`The total number of open SQL transactions  ${tooltipSelection}.`}
     >
@@ -59,6 +61,7 @@ export default function (props: GraphDashboardProps) {
 
     <LineGraph
       title="Active SQL Statements"
+      isKvGraph={false}
       sources={nodeSources}
       tooltip={`The total number of running SQL statements ${tooltipSelection}.`}
     >
@@ -73,6 +76,7 @@ export default function (props: GraphDashboardProps) {
 
     <LineGraph
       title="SQL Byte Traffic"
+      isKvGraph={false}
       sources={nodeSources}
       tooltip={`The total amount of SQL client network traffic in bytes per second ${tooltipSelection}.`}
     >
@@ -84,6 +88,7 @@ export default function (props: GraphDashboardProps) {
 
     <LineGraph
       title="SQL Statements"
+      isKvGraph={false}
       sources={nodeSources}
       tooltip={`A ten-second moving average of the # of SELECT, INSERT, UPDATE, and DELETE statements
         successfully executed per second ${tooltipSelection}.`}
@@ -114,6 +119,7 @@ export default function (props: GraphDashboardProps) {
 
     <LineGraph
       title="SQL Statement Errors"
+      isKvGraph={false}
       sources={nodeSources}
       tooltip={
         "The number of statements which returned a planning, runtime, or client-side retry error."
@@ -130,6 +136,7 @@ export default function (props: GraphDashboardProps) {
 
     <LineGraph
       title="SQL Statement Contention"
+      isKvGraph={false}
       sources={nodeSources}
       tooltip={`The total number of SQL statements that experienced contention ${tooltipSelection}.`}
     >
@@ -144,6 +151,7 @@ export default function (props: GraphDashboardProps) {
 
     <LineGraph
       title="Full Table/Index Scans"
+      isKvGraph={false}
       sources={nodeSources}
       tooltip={`The total number of full table/index scans ${tooltipSelection}.`}
     >
@@ -162,6 +170,7 @@ export default function (props: GraphDashboardProps) {
 
     <LineGraph
       title="Active Flows for Distributed SQL Statements"
+      isKvGraph={false}
       tooltip="The number of flows on each node contributing to currently running distributed SQL statements."
     >
       <Axis label="flows">
@@ -178,6 +187,7 @@ export default function (props: GraphDashboardProps) {
 
     <LineGraph
       title="Connection Latency: 99th percentile"
+      isKvGraph={false}
       tooltip={`Over the last minute, this node established and authenticated 99% of connections within this time.`}
     >
       <Axis units={AxisUnits.Duration} label="latency">
@@ -195,6 +205,7 @@ export default function (props: GraphDashboardProps) {
 
     <LineGraph
       title="Connection Latency: 90th percentile"
+      isKvGraph={false}
       tooltip={`Over the last minute, this node established and authenticated 90% of connections within this time.`}
     >
       <Axis units={AxisUnits.Duration} label="latency">
@@ -212,6 +223,7 @@ export default function (props: GraphDashboardProps) {
 
     <LineGraph
       title="Service Latency: SQL Statements, 99.99th percentile"
+      isKvGraph={false}
       tooltip={
         <div>
           Over the last minute, this node executed 99.99% of SQL statements
@@ -238,6 +250,7 @@ export default function (props: GraphDashboardProps) {
 
     <LineGraph
       title="Service Latency: SQL Statements, 99.9th percentile"
+      isKvGraph={false}
       tooltip={
         <div>
           Over the last minute, this node executed 99.9% of SQL statements
@@ -264,6 +277,7 @@ export default function (props: GraphDashboardProps) {
 
     <LineGraph
       title="Service Latency: SQL Statements, 99th percentile"
+      isKvGraph={false}
       tooltip={
         <div>
           Over the last minute, this node executed 99% of SQL statements within
@@ -290,6 +304,7 @@ export default function (props: GraphDashboardProps) {
 
     <LineGraph
       title="Service Latency: SQL Statements, 90th percentile"
+      isKvGraph={false}
       tooltip={
         <div>
           Over the last minute, this node executed 90% of SQL statements within
@@ -316,6 +331,7 @@ export default function (props: GraphDashboardProps) {
 
     <LineGraph
       title="KV Execution Latency: 99th percentile"
+      isKvGraph={false}
       tooltip={`The 99th percentile of latency between query requests and responses over a
           1 minute period. Values are displayed individually for each node.`}
     >
@@ -334,6 +350,7 @@ export default function (props: GraphDashboardProps) {
 
     <LineGraph
       title="KV Execution Latency: 90th percentile"
+      isKvGraph={false}
       tooltip={`The 90th percentile of latency between query requests and responses over a
            1 minute period. Values are displayed individually for each node.`}
     >
@@ -352,6 +369,7 @@ export default function (props: GraphDashboardProps) {
 
     <LineGraph
       title="Transactions"
+      isKvGraph={false}
       sources={nodeSources}
       tooltip={`The total number of transactions initiated, committed, rolled back,
            or aborted per second ${tooltipSelection}.`}
@@ -382,6 +400,7 @@ export default function (props: GraphDashboardProps) {
 
     <LineGraph
       title="Transaction Restarts"
+      isKvGraph={false}
       sources={nodeSources}
       tooltip={
         <TransactionRestartsToolTip tooltipSelection={tooltipSelection} />
@@ -433,6 +452,7 @@ export default function (props: GraphDashboardProps) {
 
     <LineGraph
       title="Transaction Latency: 99th percentile"
+      isKvGraph={false}
       tooltip={
         <div>
           Over the last minute, this node executed 99% of transactions within
@@ -459,6 +479,7 @@ export default function (props: GraphDashboardProps) {
 
     <LineGraph
       title="Transaction Latency: 90th percentile"
+      isKvGraph={false}
       tooltip={
         <div>
           Over the last minute, this node executed 90% of transactions within
@@ -485,6 +506,7 @@ export default function (props: GraphDashboardProps) {
 
     <LineGraph
       title="SQL Memory"
+      isKvGraph={false}
       tooltip={`The current amount of allocated SQL memory. This amount is
          compared against the node's --max-sql-memory flag.`}
     >
@@ -503,6 +525,7 @@ export default function (props: GraphDashboardProps) {
 
     <LineGraph
       title="Schema Changes"
+      isKvGraph={false}
       sources={nodeSources}
       tooltip={`The total number of DDL statements per second ${tooltipSelection}.`}
     >
@@ -517,6 +540,7 @@ export default function (props: GraphDashboardProps) {
 
     <LineGraph
       title="Statement Denials: Cluster Settings"
+      isKvGraph={false}
       sources={nodeSources}
       tooltip={
         <StatementDenialsClusterSettingsTooltip

--- a/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/ttl.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/ttl.tsx
@@ -23,7 +23,7 @@ export default function (props: GraphDashboardProps) {
   const percentiles = ["p50", "p75", "p90", "p95", "p99"];
 
   return [
-    <LineGraph title="Processing Rate" sources={nodeSources}>
+    <LineGraph title="Processing Rate" isKvGraph={false} sources={nodeSources}>
       <Axis label="rows per second" units={AxisUnits.Count}>
         <Metric
           name="cr.node.jobs.row_level_ttl.rows_selected"
@@ -37,7 +37,7 @@ export default function (props: GraphDashboardProps) {
         />
       </Axis>
     </LineGraph>,
-    <LineGraph title="Estimated Rows" sources={nodeSources}>
+    <LineGraph title="Estimated Rows" isKvGraph={false} sources={nodeSources}>
       <Axis label="row count" units={AxisUnits.Count}>
         <Metric
           name="cr.node.jobs.row_level_ttl.total_rows"
@@ -53,6 +53,7 @@ export default function (props: GraphDashboardProps) {
     </LineGraph>,
     <LineGraph
       title="Job Latency"
+      isKvGraph={false}
       sources={nodeSources}
       tooltip={`Latency of scanning and deleting within the job.`}
     >
@@ -75,6 +76,7 @@ export default function (props: GraphDashboardProps) {
     </LineGraph>,
     <LineGraph
       title="Spans in Progress"
+      isKvGraph={false}
       sources={nodeSources}
       tooltip={`Number of active spans being processed by TTL.`}
     >

--- a/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/index.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/index.tsx
@@ -87,28 +87,67 @@ import {
   selectResolution30mStorageTTL,
   selectCrossClusterReplicationEnabled,
 } from "src/redux/clusterSettings";
+import { getDataFromServer } from "src/util/dataFromServer";
 
 interface GraphDashboard {
   label: string;
   component: (props: GraphDashboardProps) => React.ReactElement<any>[];
+  isKvDashboard: boolean;
 }
 
 const dashboards: { [key: string]: GraphDashboard } = {
-  overview: { label: "Overview", component: overviewDashboard },
-  hardware: { label: "Hardware", component: hardwareDashboard },
-  runtime: { label: "Runtime", component: runtimeDashboard },
-  sql: { label: "SQL", component: sqlDashboard },
-  storage: { label: "Storage", component: storageDashboard },
-  replication: { label: "Replication", component: replicationDashboard },
-  distributed: { label: "Distributed", component: distributedDashboard },
-  queues: { label: "Queues", component: queuesDashboard },
-  requests: { label: "Slow Requests", component: requestsDashboard },
-  changefeeds: { label: "Changefeeds", component: changefeedsDashboard },
-  overload: { label: "Overload", component: overloadDashboard },
-  ttl: { label: "TTL", component: ttlDashboard },
+  overview: {
+    label: "Overview",
+    component: overviewDashboard,
+    isKvDashboard: false,
+  },
+  hardware: {
+    label: "Hardware",
+    component: hardwareDashboard,
+    isKvDashboard: true,
+  },
+  runtime: {
+    label: "Runtime",
+    component: runtimeDashboard,
+    isKvDashboard: true,
+  },
+  sql: { label: "SQL", component: sqlDashboard, isKvDashboard: false },
+  storage: {
+    label: "Storage",
+    component: storageDashboard,
+    isKvDashboard: true,
+  },
+  replication: {
+    label: "Replication",
+    component: replicationDashboard,
+    isKvDashboard: true,
+  },
+  distributed: {
+    label: "Distributed",
+    component: distributedDashboard,
+    isKvDashboard: true,
+  },
+  queues: { label: "Queues", component: queuesDashboard, isKvDashboard: true },
+  requests: {
+    label: "Slow Requests",
+    component: requestsDashboard,
+    isKvDashboard: true,
+  },
+  changefeeds: {
+    label: "Changefeeds",
+    component: changefeedsDashboard,
+    isKvDashboard: false,
+  },
+  overload: {
+    label: "Overload",
+    component: overloadDashboard,
+    isKvDashboard: true,
+  },
+  ttl: { label: "TTL", component: ttlDashboard, isKvDashboard: false },
   crossClusterReplication: {
     label: "Cross-Cluster Replication",
     component: crossClusterReplicationDashboard,
+    isKvDashboard: true,
   },
 };
 
@@ -118,6 +157,7 @@ const dashboardDropdownOptions = _.map(dashboards, (dashboard, key) => {
   return {
     value: key,
     label: dashboard.label,
+    isKvDashboard: dashboard.isKvDashboard,
   };
 });
 
@@ -253,8 +293,13 @@ export class NodeGraphs extends React.Component<
       nodeDisplayNameByID,
       nodeIds,
     } = this.props;
+    const canViewKvGraphs =
+      getDataFromServer().FeatureFlags.can_view_kv_metric_dashboards;
     const { showLowResolutionAlert, showDeletedDataAlert } = this.state;
-    const selectedDashboard = getMatchParamByName(match, dashboardNameAttr);
+    let selectedDashboard = getMatchParamByName(match, dashboardNameAttr);
+    if (dashboards[selectedDashboard].isKvDashboard && !canViewKvGraphs) {
+      selectedDashboard = defaultDashboard;
+    }
     const dashboard = _.has(dashboards, selectedDashboard)
       ? selectedDashboard
       : defaultDashboard;
@@ -300,7 +345,9 @@ export class NodeGraphs extends React.Component<
 
     // Generate graphs for the current dashboard, wrapping each one in a
     // MetricsDataProvider with a unique key.
-    const graphs = dashboards[dashboard].component(dashboardProps);
+    const graphs = dashboards[dashboard]
+      .component(dashboardProps)
+      .filter(d => canViewKvGraphs || !d.props.isKvGraph);
     const graphComponents = _.map(graphs, (graph, idx) => {
       const key = `nodes.${dashboard}.${idx}`;
       return (
@@ -325,12 +372,15 @@ export class NodeGraphs extends React.Component<
     // as we have 3 columns, we divide node amount on 3
     const paddingBottom =
       nodeIDs.length > 8 ? 90 + Math.ceil(nodeIDs.length / 3) * 10 : 50;
-
-    const filteredDropdownOptions = this.props.crossClusterReplicationEnabled
-      ? dashboardDropdownOptions // Already in the list, no need to filter
-      : dashboardDropdownOptions.filter(
-          option => option.label !== "Cross-Cluster Replication",
-        );
+    const filteredDropdownOptions = dashboardDropdownOptions
+      // Don't show KV dashboards if the logged-in user doesn't have permission to view them.
+      .filter(option => canViewKvGraphs || !option.isKvDashboard)
+      // Don't show the replication dashboard if not enabled.
+      .filter(
+        option =>
+          this.props.crossClusterReplicationEnabled ||
+          option.label !== "Cross-Cluster Replication",
+      );
 
     return (
       <div style={{ paddingBottom }}>


### PR DESCRIPTION
This patch uses the ui.Config feature flags to communicate
to the UI whether or not the currently logged in tenant
is able to view KV metric dashboards in DB Console.

The patch filters the list of dashboard options as well
as guards against users using URL params to try to view
KV dashboards as a tenant without the appropriate permissions.

Filtering is also made possible within the dashboards
for specific charts, depending on whether they display
KV-level information.

Release note (ui change): secondary tenants using DB Console
will no longer be able to view metrics dashboards that display
KV-level information.

Epic: CRDB-12100

Addresses: https://github.com/cockroachdb/cockroach/issues/97736