### PR TITLE
opt: synthesize outlier histogram buckets

### DIFF
--- a/pkg/sql/opt/memo/testdata/stats/outliers
+++ b/pkg/sql/opt/memo/testdata/stats/outliers
@@ -1,0 +1,130 @@
+exec-ddl
+CREATE TABLE t (
+  k INT PRIMARY KEY,
+  a STRING,
+  b STRING,
+  c STRING,
+  d STRING,
+  UNIQUE INDEX (a, b),
+  INDEX (a, c)
+)
+----
+
+exec-ddl
+ALTER TABLE t INJECT STATISTICS '[
+  {
+    "columns": ["a"],
+    "created_at": "2018-01-01 1:00:00.00000+00:00",
+    "row_count": 1000,
+    "distinct_count": 40,
+    "avg_size": 10,
+    "histo_col_type": "string",
+    "histo_buckets": [
+      {"num_eq": 0, "num_range": 0, "distinct_range": 0, "upper_bound": "apple"},
+      {"num_eq": 100, "num_range": 100, "distinct_range": 9, "upper_bound": "banana"},
+      {"num_eq": 100, "num_range": 100, "distinct_range": 9, "upper_bound": "cherry"},
+      {"num_eq": 200, "num_range": 100, "distinct_range": 9, "upper_bound": "mango"},
+      {"num_eq": 200, "num_range": 100, "distinct_range": 9, "upper_bound": "pineapple"}
+    ]
+  },
+  {
+    "columns": ["b"],
+    "created_at": "2018-01-01 1:00:00.00000+00:00",
+    "row_count": 1000,
+    "distinct_count": 40,
+    "avg_size": 10,
+    "histo_col_type": "string",
+    "histo_buckets": [
+      {"num_eq": 0, "num_range": 0, "distinct_range": 0, "upper_bound": "apple"},
+      {"num_eq": 100, "num_range": 100, "distinct_range": 9, "upper_bound": "banana"},
+      {"num_eq": 100, "num_range": 100, "distinct_range": 9, "upper_bound": "cherry"},
+      {"num_eq": 200, "num_range": 100, "distinct_range": 9, "upper_bound": "mango"},
+      {"num_eq": 200, "num_range": 100, "distinct_range": 9, "upper_bound": "pineapple"}
+    ]
+  },
+  {
+    "columns": ["d"],
+    "created_at": "2018-01-01 1:00:00.00000+00:00",
+    "row_count": 1000,
+    "distinct_count": 40,
+    "avg_size": 1000,
+    "histo_col_type": "string"
+  }
+]'
+----
+
+# Because 'yuzu' is greater than the max value in the histogram, and the
+# avg_size of d is large, we would pick the suboptimal plan below.
+#
+# select
+#  ├── columns: k:1 a:2 b:3 c:4 d:5
+#  ├── stats: [rows=0.9625]
+#  ├── cost: 18.0600024
+#  ├── index-join t
+#  │    ├── columns: k:1 a:2 b:3 c:4 d:5
+#  │    ├── stats: [rows=2e-07]
+#  │    ├── cost: 18.0400024
+#  │    └── scan t@t_a_c_idx
+#  │         ├── columns: k:1 a:2 c:4
+#  │         ├── constraint: /2/4/1: [/'yuzu' - /'yuzu']
+#  │         ├── stats: [rows=2e-07]
+#  │         └── cost: 18.0200002
+#  └── filters
+#       └── b:3 = 'banana'
+#
+# By synthesizing a bucket that contains all values greater than 'pineapple', we
+# pick the optimal plan.
+opt
+SELECT * FROM t WHERE a = 'yuzu' AND b = 'banana'
+----
+index-join t
+ ├── columns: k:1(int!null) a:2(string!null) b:3(string!null) c:4(string) d:5(string)
+ ├── cardinality: [0 - 1]
+ ├── stats: [rows=0.9625, distinct(2)=0.9625, null(2)=0, distinct(3)=0.9625, null(3)=0, distinct(2,3)=0.9625, null(2,3)=0]
+ ├── key: ()
+ ├── fd: ()-->(1-5)
+ └── scan t@t_a_b_key
+      ├── columns: k:1(int!null) a:2(string!null) b:3(string!null)
+      ├── constraint: /2/3: [/'yuzu'/'banana' - /'yuzu'/'banana']
+      ├── cardinality: [0 - 1]
+      ├── stats: [rows=0.9625, distinct(2)=0.9625, null(2)=0, distinct(3)=0.9625, null(3)=0, distinct(2,3)=0.9625, null(2,3)=0]
+      ├── key: ()
+      └── fd: ()-->(1-3)
+
+# Because 'aardvark' is less than the max value in the histogram, and the
+# avg_size of d is large, we would pick the suboptimal plan below.
+#
+# select
+#  ├── columns: k:1 a:2 b:3 c:4 d:5
+#  ├── stats: [rows=0.9625]
+#  ├── cost: 18.0600024
+#  ├── index-join t
+#  │    ├── columns: k:1 a:2 b:3 c:4(string) d:5(string)
+#  │    ├── stats: [rows=2e-07]
+#  │    ├── cost: 18.0400024
+#  │    └── scan t@t_a_c_idx
+#  │         ├── columns: k:1 a:2 c:4
+#  │         ├── constraint: /2/4/1: [/'aardvark' - /'aardvark']
+#  │         ├── stats: [rows=2e-07]
+#  │         └── cost: 18.0200002
+#  └── filters
+#       └── b:3 = 'banana'
+#
+# By adding to the num_range and distinct_range of the minimum bucket, we pick
+# the optimal plan.
+opt
+SELECT * FROM t WHERE a = 'aardvark' AND b = 'banana'
+----
+index-join t
+ ├── columns: k:1(int!null) a:2(string!null) b:3(string!null) c:4(string) d:5(string)
+ ├── cardinality: [0 - 1]
+ ├── stats: [rows=0.9625, distinct(2)=0.9625, null(2)=0, distinct(3)=0.9625, null(3)=0, distinct(2,3)=0.9625, null(2,3)=0]
+ ├── key: ()
+ ├── fd: ()-->(1-5)
+ └── scan t@t_a_b_key
+      ├── columns: k:1(int!null) a:2(string!null) b:3(string!null)
+      ├── constraint: /2/3: [/'aardvark'/'banana' - /'aardvark'/'banana']
+      ├── cardinality: [0 - 1]
+      ├── stats: [rows=0.9625, distinct(2)=0.9625, null(2)=0, distinct(3)=0.9625, null(3)=0, distinct(2,3)=0.9625, null(2,3)=0]
+      ├── key: ()
+      └── fd: ()-->(1-3)

--- a/pkg/sql/opt/props/histogram.go
+++ b/pkg/sql/opt/props/histogram.go
@@ -627,6 +627,15 @@ func (hi *histogramIter) inclusiveUpperBound() tree.Datum {
 func makeSpanFromBucket(iter *histogramIter, prefix []tree.Datum) (span constraint.Span) {
 	start, startBoundary := iter.lowerBound()
 	end, endBoundary := iter.upperBound()
+	if end == tree.DInf {
+		span.Init(
+			constraint.MakeCompositeKey(append(prefix[:len(prefix):len(prefix)], start)...),
+			constraint.IncludeBoundary,
+			constraint.EmptyKey,
+			constraint.IncludeBoundary,
+		)
+		return span
+	}
 	if start.Compare(iter.h.evalCtx, end) == 0 &&
 		(startBoundary == constraint.IncludeBoundary || endBoundary == constraint.IncludeBoundary) {
 		// If the start and ends are equal and one of the boundaries is

--- a/pkg/sql/sem/tree/datum.go
+++ b/pkg/sql/sem/tree/datum.go
@@ -66,6 +66,12 @@ var (
 	// DNull is the NULL Datum.
 	DNull Datum = dNull{}
 
+	// DInf represents a generic maximum value for any type. In theory, it is
+	// similar to DNull, but it is a maximum, not a minimum. It should never be
+	// used in an expression, and it cannot be created by a user. It is
+	// currently only during query optimization.
+	DInf Datum = dInf{}
+
 	// DZero is the zero-valued integer Datum.
 	DZero = NewDInt(0)
 
@@ -443,6 +449,10 @@ func (d *DBool) CompareError(ctx CompareContext, other Datum) (int, error) {
 		// NULL is less than any non-NULL value.
 		return 1, nil
 	}
+	if other == DInf {
+		// DInf is greater than any value.
+		return -1, nil
+	}
 	v, ok := ctx.UnwrapDatum(other).(*DBool)
 	if !ok {
 		return 0, makeUnsupportedComparisonMessage(d, other)
@@ -616,6 +626,10 @@ func (d *DBitArray) CompareError(ctx CompareContext, other Datum) (int, error) {
 		// NULL is less than any non-NULL value.
 		return 1, nil
 	}
+	if other == DInf {
+		// DInf is greater than any value.
+		return -1, nil
+	}
 	v, ok := ctx.UnwrapDatum(other).(*DBitArray)
 	if !ok {
 		return 0, makeUnsupportedComparisonMessage(d, other)
@@ -743,6 +757,10 @@ func (d *DInt) CompareError(ctx CompareContext, other Datum) (int, error) {
 	if other == DNull {
 		// NULL is less than any non-NULL value.
 		return 1, nil
+	}
+	if other == DInf {
+		// DInf is greater than any value.
+		return -1, nil
 	}
 	thisInt := *d
 	var v DInt
@@ -882,6 +900,10 @@ func (d *DFloat) CompareError(ctx CompareContext, other Datum) (int, error) {
 	if other == DNull {
 		// NULL is less than any non-NULL value.
 		return 1, nil
+	}
+	if other == DInf {
+		// DInf is greater than any value.
+		return -1, nil
 	}
 	var v DFloat
 	switch t := ctx.UnwrapDatum(other).(type) {
@@ -1094,6 +1116,10 @@ func (d *DDecimal) CompareError(ctx CompareContext, other Datum) (int, error) {
 		// NULL is less than any non-NULL value.
 		return 1, nil
 	}
+	if other == DInf {
+		// DInf is greater than any value.
+		return -1, nil
+	}
 	var v apd.Decimal
 	switch t := ctx.UnwrapDatum(other).(type) {
 	case *DDecimal:
@@ -1272,6 +1298,10 @@ func (d *DString) CompareError(ctx CompareContext, other Datum) (int, error) {
 		// NULL is less than any non-NULL value.
 		return 1, nil
 	}
+	if other == DInf {
+		// DInf is greater than any value.
+		return -1, nil
+	}
 	v, ok := ctx.UnwrapDatum(other).(*DString)
 	if !ok {
 		return 0, makeUnsupportedComparisonMessage(d, other)
@@ -1427,6 +1457,10 @@ func (d *DCollatedString) CompareError(ctx CompareContext, other Datum) (int, er
 		// NULL is less than any non-NULL value.
 		return 1, nil
 	}
+	if other == DInf {
+		// DInf is greater than any value.
+		return -1, nil
+	}
 	v, ok := ctx.UnwrapDatum(other).(*DCollatedString)
 	if !ok || !d.ResolvedType().Equivalent(other.ResolvedType()) {
 		return 0, makeUnsupportedComparisonMessage(d, other)
@@ -1523,6 +1557,10 @@ func (d *DBytes) CompareError(ctx CompareContext, other Datum) (int, error) {
 	if other == DNull {
 		// NULL is less than any non-NULL value.
 		return 1, nil
+	}
+	if other == DInf {
+		// DInf is greater than any value.
+		return -1, nil
 	}
 	v, ok := ctx.UnwrapDatum(other).(*DBytes)
 	if !ok {
@@ -1730,6 +1768,10 @@ func (d *DUuid) CompareError(ctx CompareContext, other Datum) (int, error) {
 		// NULL is less than any non-NULL value.
 		return 1, nil
 	}
+	if other == DInf {
+		// DInf is greater than any value.
+		return -1, nil
+	}
 	v, ok := ctx.UnwrapDatum(other).(*DUuid)
 	if !ok {
 		return 0, makeUnsupportedComparisonMessage(d, other)
@@ -1862,6 +1904,10 @@ func (d *DIPAddr) CompareError(ctx CompareContext, other Datum) (int, error) {
 	if other == DNull {
 		// NULL is less than any non-NULL value.
 		return 1, nil
+	}
+	if other == DInf {
+		// DInf is greater than any value.
+		return -1, nil
 	}
 	v, ok := ctx.UnwrapDatum(other).(*DIPAddr)
 	if !ok {
@@ -2165,6 +2211,10 @@ func (d *DDate) CompareError(ctx CompareContext, other Datum) (int, error) {
 		// NULL is less than any non-NULL value.
 		return 1, nil
 	}
+	if other == DInf {
+		// DInf is greater than any value.
+		return -1, nil
+	}
 	var v DDate
 	switch t := ctx.UnwrapDatum(other).(type) {
 	case *DDate:
@@ -2321,6 +2371,10 @@ func (d *DTime) CompareError(ctx CompareContext, other Datum) (int, error) {
 		// NULL is less than any non-NULL value.
 		return 1, nil
 	}
+	if other == DInf {
+		// DInf is greater than any value.
+		return -1, nil
+	}
 	return compareTimestamps(ctx, d, other)
 }
 
@@ -2459,6 +2513,10 @@ func (d *DTimeTZ) CompareError(ctx CompareContext, other Datum) (int, error) {
 	if other == DNull {
 		// NULL is less than any non-NULL value.
 		return 1, nil
+	}
+	if other == DInf {
+		// DInf is greater than any value.
+		return -1, nil
 	}
 	return compareTimestamps(ctx, d, other)
 }
@@ -2794,6 +2852,10 @@ func (d *DTimestamp) CompareError(ctx CompareContext, other Datum) (int, error) 
 		// NULL is less than any non-NULL value.
 		return 1, nil
 	}
+	if other == DInf {
+		// DInf is greater than any value.
+		return -1, nil
+	}
 	return compareTimestamps(ctx, d, other)
 }
 
@@ -2972,6 +3034,10 @@ func (d *DTimestampTZ) CompareError(ctx CompareContext, other Datum) (int, error
 	if other == DNull {
 		// NULL is less than any non-NULL value.
 		return 1, nil
+	}
+	if other == DInf {
+		// DInf is greater than any value.
+		return -1, nil
 	}
 	return compareTimestamps(ctx, d, other)
 }
@@ -3163,6 +3229,10 @@ func (d *DInterval) CompareError(ctx CompareContext, other Datum) (int, error) {
 		// NULL is less than any non-NULL value.
 		return 1, nil
 	}
+	if other == DInf {
+		// DInf is greater than any value.
+		return -1, nil
+	}
 	v, ok := ctx.UnwrapDatum(other).(*DInterval)
 	if !ok {
 		return 0, makeUnsupportedComparisonMessage(d, other)
@@ -3301,6 +3371,10 @@ func (d *DGeography) CompareError(ctx CompareContext, other Datum) (int, error) 
 		// NULL is less than any non-NULL value.
 		return 1, nil
 	}
+	if other == DInf {
+		// DInf is greater than any value.
+		return -1, nil
+	}
 	v, ok := ctx.UnwrapDatum(other).(*DGeography)
 	if !ok {
 		return 0, makeUnsupportedComparisonMessage(d, other)
@@ -3423,6 +3497,10 @@ func (d *DGeometry) CompareError(ctx CompareContext, other Datum) (int, error) {
 		// NULL is less than any non-NULL value.
 		return 1, nil
 	}
+	if other == DInf {
+		// DInf is greater than any value.
+		return -1, nil
+	}
 	v, ok := ctx.UnwrapDatum(other).(*DGeometry)
 	if !ok {
 		return 0, makeUnsupportedComparisonMessage(d, other)
@@ -3544,6 +3622,10 @@ func (d *DBox2D) CompareError(ctx CompareContext, other Datum) (int, error) {
 	if other == DNull {
 		// NULL is less than any non-NULL value.
 		return 1, nil
+	}
+	if other == DInf {
+		// DInf is greater than any value.
+		return -1, nil
 	}
 	v, ok := ctx.UnwrapDatum(other).(*DBox2D)
 	if !ok {
@@ -3775,6 +3857,10 @@ func (d *DJSON) CompareError(ctx CompareContext, other Datum) (int, error) {
 		// NULL is less than any non-NULL value.
 		return 1, nil
 	}
+	if other == DInf {
+		// DInf is greater than any value.
+		return -1, nil
+	}
 	v, ok := ctx.UnwrapDatum(other).(*DJSON)
 	if !ok {
 		return 0, makeUnsupportedComparisonMessage(d, other)
@@ -3882,6 +3968,10 @@ func (d *DTSQuery) CompareError(ctx CompareContext, other Datum) (int, error) {
 	if other == DNull {
 		// NULL is less than any non-NULL value.
 		return 1, nil
+	}
+	if other == DInf {
+		// DInf is greater than any value.
+		return -1, nil
 	}
 	v, ok := ctx.UnwrapDatum(other).(*DTSQuery)
 	if !ok {
@@ -4013,6 +4103,10 @@ func (d *DTSVector) CompareError(ctx CompareContext, other Datum) (int, error) {
 	if other == DNull {
 		// NULL is less than any non-NULL value.
 		return 1, nil
+	}
+	if other == DInf {
+		// DInf is greater than any value.
+		return -1, nil
 	}
 	v, ok := ctx.UnwrapDatum(other).(*DTSVector)
 	if !ok {
@@ -4193,6 +4287,10 @@ func (d *DTuple) CompareError(ctx CompareContext, other Datum) (int, error) {
 	if other == DNull {
 		// NULL is less than any non-NULL value.
 		return 1, nil
+	}
+	if other == DInf {
+		// DInf is greater than any value.
+		return -1, nil
 	}
 	v, ok := ctx.UnwrapDatum(other).(*DTuple)
 	if !ok {
@@ -4513,6 +4611,10 @@ func (d dNull) CompareError(ctx CompareContext, other Datum) (int, error) {
 	if other == DNull {
 		return 0, nil
 	}
+	if other == DInf {
+		// DInf is greater than any value.
+		return -1, nil
+	}
 	return -1, nil
 }
 
@@ -4561,6 +4663,72 @@ func (dNull) Format(ctx *FmtCtx) {
 
 // Size implements the Datum interface.
 func (d dNull) Size() uintptr {
+	return unsafe.Sizeof(d)
+}
+
+type dInf struct{}
+
+// ResolvedType implements the TypedExpr interface.
+func (dInf) ResolvedType() *types.T {
+	return types.Any
+}
+
+// Compare implements the Datum interface.
+func (d dInf) Compare(ctx CompareContext, other Datum) int {
+	return 1
+}
+
+// CompareError implements the Datum interface.
+func (d dInf) CompareError(ctx CompareContext, other Datum) (int, error) {
+	// DInf is greater than any value, except itself.
+	if other == DInf {
+		return 0, nil
+	}
+	return 1, nil
+}
+
+// Prev implements the Datum interface.
+func (d dInf) Prev(ctx CompareContext) (Datum, bool) {
+	return nil, false
+}
+
+// Next implements the Datum interface.
+func (d dInf) Next(ctx CompareContext) (Datum, bool) {
+	return nil, false
+}
+
+// IsMax implements the Datum interface.
+func (dInf) IsMax(ctx CompareContext) bool {
+	return true
+}
+
+// IsMin implements the Datum interface.
+func (dInf) IsMin(ctx CompareContext) bool {
+	// TODO: Should this be false?
+	return true
+}
+
+// Max implements the Datum interface.
+func (dInf) Max(ctx CompareContext) (Datum, bool) {
+	return nil, true
+}
+
+// Min implements the Datum interface.
+func (dInf) Min(ctx CompareContext) (Datum, bool) {
+	// TODO: represent a negative infinity
+	return nil, false
+}
+
+// AmbiguousFormat implements the Datum interface.
+func (dInf) AmbiguousFormat() bool { return false }
+
+// Format implements the NodeFormatter interface.
+func (dInf) Format(ctx *FmtCtx) {
+	panic(errors.AssertionFailedf("shold not be called"))
+}
+
+// Size implements the Datum interface.
+func (d dInf) Size() uintptr {
 	return unsafe.Sizeof(d)
 }
 
@@ -4672,6 +4840,10 @@ func (d *DArray) CompareError(ctx CompareContext, other Datum) (int, error) {
 	if other == DNull {
 		// NULL is less than any non-NULL value.
 		return 1, nil
+	}
+	if other == DInf {
+		// DInf is greater than any value.
+		return -1, nil
 	}
 	v, ok := ctx.UnwrapDatum(other).(*DArray)
 	if !ok {
@@ -4860,6 +5032,10 @@ func (d *DVoid) CompareError(ctx CompareContext, other Datum) (int, error) {
 	if other == DNull {
 		// NULL is less than any non-NULL value.
 		return 1, nil
+	}
+	if other == DInf {
+		// DInf is greater than any value.
+		return -1, nil
 	}
 
 	_, ok := ctx.UnwrapDatum(other).(*DVoid)
@@ -5064,6 +5240,10 @@ func (d *DEnum) Compare(ctx CompareContext, other Datum) int {
 func (d *DEnum) CompareError(ctx CompareContext, other Datum) (int, error) {
 	if other == DNull {
 		return 1, nil
+	}
+	if other == DInf {
+		// DInf is greater than any value.
+		return -1, nil
 	}
 	v, ok := ctx.UnwrapDatum(other).(*DEnum)
 	if !ok {
@@ -5308,6 +5488,10 @@ func (d *DOid) CompareError(ctx CompareContext, other Datum) (int, error) {
 		// NULL is less than any non-NULL value.
 		return 1, nil
 	}
+	if other == DInf {
+		// DInf is greater than any value.
+		return -1, nil
+	}
 	var v oid.Oid
 	switch t := ctx.UnwrapDatum(other).(type) {
 	case *DOid:
@@ -5478,6 +5662,10 @@ func (d *DOidWrapper) CompareError(ctx CompareContext, other Datum) (int, error)
 	if other == DNull {
 		// NULL is less than any non-NULL value.
 		return 1, nil
+	}
+	if other == DInf {
+		// DInf is greater than any value.
+		return -1, nil
 	}
 	if v, ok := other.(*DOidWrapper); ok {
 		return d.Wrapped.CompareError(ctx, v.Wrapped)

--- a/pkg/sql/sem/tree/eval_expr_generated.go
+++ b/pkg/sql/sem/tree/eval_expr_generated.go
@@ -382,6 +382,11 @@ func (node *UnresolvedName) Eval(ctx context.Context, v ExprEvaluator) (Datum, e
 }
 
 // Eval is part of the TypedExpr interface.
+func (node dInf) Eval(ctx context.Context, v ExprEvaluator) (Datum, error) {
+	return node, nil
+}
+
+// Eval is part of the TypedExpr interface.
 func (node dNull) Eval(ctx context.Context, v ExprEvaluator) (Datum, error) {
 	return node, nil
 }

--- a/pkg/sql/sem/tree/evalgen/expr.go
+++ b/pkg/sql/sem/tree/evalgen/expr.go
@@ -29,7 +29,7 @@ func generateExprEval(fileName string, files []*ast.File) (err error) {
 			},
 			"isPtr": func(name string) bool {
 				switch name {
-				case "dNull", "UnqualifiedStar":
+				case "dNull", "UnqualifiedStar", "dInf":
 					return false
 				default:
 					return true
@@ -44,7 +44,7 @@ func generateExprEval(fileName string, files []*ast.File) (err error) {
 	})
 }
 
-var isDatumRE = regexp.MustCompile("^D[A-Z]|^dNull$")
+var isDatumRE = regexp.MustCompile("^D[A-Z]|^dNull|^dInf$")
 
 const visitorTemplate = header +
 	`

--- a/pkg/sql/sem/tree/expr.go
+++ b/pkg/sql/sem/tree/expr.go
@@ -1768,4 +1768,5 @@ func (node PartitionMaxVal) String() string   { return AsString(node) }
 func (node PartitionMinVal) String() string   { return AsString(node) }
 func (node *Placeholder) String() string      { return AsString(node) }
 func (node dNull) String() string             { return AsString(node) }
+func (node dInf) String() string              { return AsString(node) }
 func (list *NameList) String() string         { return AsString(list) }

--- a/pkg/sql/sem/tree/type_check.go
+++ b/pkg/sql/sem/tree/type_check.go
@@ -1942,6 +1942,12 @@ func (d dNull) TypeCheck(_ context.Context, _ *SemaContext, desired *types.T) (T
 	return d, nil
 }
 
+// TypeCheck implements the Expr interface. It is implemented as an idempotent
+// identity function for Datum.
+func (d dInf) TypeCheck(_ context.Context, _ *SemaContext, desired *types.T) (TypedExpr, error) {
+	return nil, errors.AssertionFailedf("nope")
+}
+
 // typeCheckAndRequireTupleElems asserts that all elements in the Tuple are
 // comparable to the input Expr given the input comparison operator.
 func typeCheckAndRequireTupleElems(

--- a/pkg/sql/sem/tree/walk.go
+++ b/pkg/sql/sem/tree/walk.go
@@ -784,6 +784,9 @@ func (expr *DIPAddr) Walk(_ Visitor) Expr { return expr }
 func (expr dNull) Walk(_ Visitor) Expr { return expr }
 
 // Walk implements the Expr interface.
+func (expr dInf) Walk(_ Visitor) Expr { return expr }
+
+// Walk implements the Expr interface.
 func (expr *DString) Walk(_ Visitor) Expr { return expr }
 
 // Walk implements the Expr interface.


### PR DESCRIPTION
This is a proof-of-concept to solve the optimizer's poor query planning
when queries filter columns by values outside the range of values in the
collected histograms.

Release note: None
