### PR TITLE
sql: allow ALTER SCHEMA public OWNER TO new_owner

### DIFF
--- a/pkg/sql/alter_schema.go
+++ b/pkg/sql/alter_schema.go
@@ -60,9 +60,12 @@ func (p *planner) AlterSchema(ctx context.Context, n *tree.AlterSchema) (planNod
 	if err != nil {
 		return nil, err
 	}
-	// Explicitly disallow modifying Public schema in 22.1.
-	if schema.GetName() == tree.PublicSchema {
-		return nil, pgerror.Newf(pgcode.InvalidSchemaName, "cannot modify schema %q", n.Schema.String())
+	// Explicitly disallow renaming public schema. In the future, we may want
+	// to support this. In order to support it, we have to remove the logic that
+	// automatically re-creates the public schema if it doesn't exist.
+	_, isRename := n.Cmd.(*tree.AlterSchemaRename)
+	if schema.GetName() == tree.PublicSchema && isRename {
+		return nil, pgerror.Newf(pgcode.InvalidSchemaName, "cannot rename schema %q", n.Schema.String())
 	}
 	switch schema.SchemaKind() {
 	case catalog.SchemaPublic, catalog.SchemaVirtual, catalog.SchemaTemporary:

--- a/pkg/sql/logictest/testdata/logic_test/schema
+++ b/pkg/sql/logictest/testdata/logic_test/schema
@@ -106,20 +106,34 @@ SELECT * FROM myschema.tb2
 statement ok
 SET search_path TO public
 
+# We should be able to alter the public schema owner.
+statement ok
+ALTER SCHEMA public OWNER TO testuser
+
+query TT
+SELECT schema_name, owner FROM [SHOW SCHEMAS] WHERE schema_name = 'public'
+----
+public  testuser
+
 # Try to create a temp table in a user defined schema.
-statement error pq: cannot create temporary relation in non-temporary schema
+statement error pgcode 42P16 pq: cannot create temporary relation in non-temporary schema
 CREATE TEMP TABLE myschema.tmp (x int)
 
 # We should error out trying to modify any virtual schemas.
-statement error pq: schema cannot be modified: "pg_catalog"
+statement error pgcode 42501 pq: schema cannot be modified: "pg_catalog"
 CREATE TABLE pg_catalog.bad (x int)
 
-# We shouldn't be able to alter virtual or public schemas.
-statement error pq: cannot modify schema "public"
+# We shouldn't be able to rename the public schema. In the future, we may
+# want to support this.
+statement error pgcode 3F000 pq: cannot rename schema "public"
 ALTER SCHEMA public RENAME TO private
 
-statement error pq: cannot modify schema "pg_catalog"
+# We shouldn't be able to alter virtual schemas.
+statement error pgcode 3F000 pq: cannot modify schema "pg_catalog"
 ALTER SCHEMA pg_catalog RENAME TO mysql_catalog
+
+statement error pgcode 3F000 pq: cannot modify schema "pg_catalog"
+ALTER SCHEMA pg_catalog OWNER TO root
 
 # We can't rename a schema to a pg_temp prefixed name.
 statement error pq: unacceptable schema name "pg_temp_not_temp"


### PR DESCRIPTION
fixes https://github.com/cockroachdb/cockroach/issues/97994

Release note (bug fix): The owner of the public schema can now be changed. Use `ALTER SCHEMA public OWNER TO new_owner`.