### PR TITLE
ui: fixes for console errors

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/filter/filterSearchOption.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/filter/filterSearchOption.tsx
@@ -27,7 +27,7 @@ export const FilterSearchOption = (
       <div className={filterLabel.margin}>{label}</div>
       <Search
         onChange={onChanged}
-        renderSuffix={false}
+        suffix={false}
         placeholder="Search"
         value={value}
       />

--- a/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsights/workloadInsightsPageConnected.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsights/workloadInsightsPageConnected.tsx
@@ -56,8 +56,8 @@ const transactionMapStateToProps = (
   state: AppState,
   _props: RouteComponentProps,
 ): TransactionInsightsViewStateProps => ({
-  isDataValid: state.adminUI.txnInsights?.valid,
-  lastUpdated: state.adminUI.txnInsights.lastUpdated,
+  isDataValid: state.adminUI?.txnInsights?.valid,
+  lastUpdated: state.adminUI?.txnInsights.lastUpdated,
   transactions: selectTransactionInsights(state),
   transactionsError: selectTransactionInsightsError(state),
   insightTypes: selectInsightTypes(),

--- a/pkg/ui/workspaces/cluster-ui/src/search/search.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/search/search.tsx
@@ -28,7 +28,7 @@ interface ISearchProps {
   onClear?: () => void;
   defaultValue?: string;
   placeholder?: string;
-  renderSuffix?: boolean;
+  suffix?: boolean;
 }
 
 interface ISearchState {
@@ -45,7 +45,6 @@ const cx = classNames.bind(styles);
 export class Search extends React.Component<TSearchProps, ISearchState> {
   static defaultProps: Partial<ISearchProps> = {
     placeholder: "Search Statements",
-    renderSuffix: true,
     onSubmit: noop,
     onChange: noop,
     onClear: noop,
@@ -86,7 +85,7 @@ export class Search extends React.Component<TSearchProps, ISearchState> {
   };
 
   renderSuffix = (): React.ReactElement => {
-    if (!this.props.renderSuffix) {
+    if (this.props.suffix === false) {
       return null;
     }
     const { value, submitted } = this.state;

--- a/pkg/ui/workspaces/cluster-ui/src/store/insightDetails/transactionInsightDetails/transactionInsightDetails.selectors.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/store/insightDetails/transactionInsightDetails/transactionInsightDetails.selectors.ts
@@ -24,7 +24,7 @@ const selectTxnContentionInsightsDetails = createSelector(
 );
 
 const selectTxnInsightFromExecInsight = createSelector(
-  (state: AppState) => state.adminUI.txnInsights?.data?.results,
+  (state: AppState) => state.adminUI?.txnInsights?.data?.results,
   selectID,
   (execInsights, execID): TxnInsightEvent => {
     return execInsights?.find(txn => txn.transactionExecutionID === execID);

--- a/pkg/ui/workspaces/cluster-ui/src/store/insights/transactionInsights/transactionInsights.selectors.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/store/insights/transactionInsights/transactionInsights.selectors.ts
@@ -16,14 +16,14 @@ import { selectTransactionFingerprintID } from "src/selectors/common";
 import { FixFingerprintHexValue } from "../../../util";
 
 export const selectTransactionInsights = (state: AppState): TxnInsightEvent[] =>
-  state.adminUI.txnInsights?.data?.results;
+  state.adminUI?.txnInsights?.data?.results;
 
 export const selectTransactionInsightsError = (state: AppState): Error | null =>
-  state.adminUI.txnInsights?.lastError;
+  state.adminUI?.txnInsights?.lastError;
 
 export const selectTransactionInsightsMaxApiReached = (
   state: AppState,
-): boolean => state.adminUI.stmtInsights?.data?.maxSizeReached;
+): boolean => state.adminUI?.stmtInsights?.data?.maxSizeReached;
 
 export const selectTxnInsightsByFingerprint = createSelector(
   selectTransactionInsights,
@@ -50,5 +50,5 @@ export const selectFilters = createSelector(
 // Show the data as 'Loading' when the request is in flight AND the
 // data is invalid or null.
 export const selectTransactionInsightsLoading = (state: AppState): boolean =>
-  state.adminUI.txnInsights?.inFlight &&
-  (!state.adminUI.txnInsights?.valid || !state.adminUI.txnInsights?.data);
+  state.adminUI?.txnInsights?.inFlight &&
+  (!state.adminUI?.txnInsights?.valid || !state.adminUI?.txnInsights?.data);

--- a/pkg/ui/workspaces/cluster-ui/src/summaryCard/index.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/summaryCard/index.tsx
@@ -53,7 +53,7 @@ export const SummaryCardItem: React.FC<ISummaryCardItemProps> = ({
 }) => (
   <div className={cx("summary--card__item", className)}>
     <h4 className={cx("summary--card__item--label")}>{label}</h4>
-    <p className={cx("summary--card__item--value")}>{value}</p>
+    <span className={cx("summary--card__item--value")}>{value}</span>
   </div>
 );
 

--- a/pkg/ui/workspaces/db-console/src/views/hotRanges/hotRangesTable.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/hotRanges/hotRangesTable.tsx
@@ -175,7 +175,7 @@ const HotRangesTable = ({
         cell: val => (
           <>
             {val.replica_node_ids.map((nodeId, idx, arr) => (
-              <Link to={`/node/${nodeId}`}>
+              <Link to={`/node/${nodeId}`} key={nodeId}>
                 {nodeId}
                 {idx < arr.length - 1 && ", "}
               </Link>


### PR DESCRIPTION
Fixes for problems causing warnings on console.
Those didn't cause any actual error, just warnings (but sending out as error on datadog):

- Change `<p>` to `<span` fixes `Warning: validateDOMNesting(...): <div> cannot appear as a descendant of <p>.`

- Change `renderSuffix` to `suffix` fixes `React does not recognize the renderSuffix prop on a DOM element. If you intentionally want it to appear in the DOM as a custom attribute, spell it as lowercase rendersuffix instead.`

- Add key attribute to list fixes `Warning: Each child in a list should have a unique "key" prop.`

- Adding checks that were causing some crashed the first time a page was open with no cache.
Fixes #97902

Release note: None