### PR TITLE
builtins: add crdb_internal.redact function

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/builtin_function
+++ b/pkg/sql/logictest/testdata/logic_test/builtin_function
@@ -3901,3 +3901,70 @@ CREATE TABLE public.redactable_sql_constants_table (a INT8 NOT NULL, b STRING NU
 
 statement ok
 DROP TABLE redactable_sql_constants_table
+
+subtest crdb_internal.redact
+
+query T
+SELECT crdb_internal.redact(NULL)
+----
+NULL
+
+query T
+SELECT crdb_internal.redact('')
+----
+·
+
+query T
+SELECT crdb_internal.redact('0')
+----
+0
+
+query T
+SELECT crdb_internal.redact('‹0›')
+----
+‹×›
+
+query T
+SELECT crdb_internal.redact('‹‹0››')
+----
+‹‹×››
+
+query T
+SELECT crdb_internal.redact('‹0› ‹0›')
+----
+‹×› ‹×›
+
+query T
+SELECT crdb_internal.redact('‹‹0›')
+----
+‹‹×›
+
+query T
+SELECT crdb_internal.redact(ARRAY[]::string[])
+----
+{}
+
+query T
+SELECT crdb_internal.redact(ARRAY[NULL])
+----
+{NULL}
+
+query T
+SELECT crdb_internal.redact(ARRAY[''])
+----
+{""}
+
+query T
+SELECT crdb_internal.redact(ARRAY['‹0›', '', NULL, '‹0› ‹0›', '‹0'])
+----
+{‹×›,"",NULL,"‹×› ‹×›",‹0}
+
+query T
+SELECT crdb_internal.redact(crdb_internal.redactable_sql_constants('SELECT 1, 2, 3'))
+----
+SELECT ‹×›, ‹×›, ‹×›
+
+query T
+SELECT crdb_internal.redact(crdb_internal.redactable_sql_constants(ARRAY['SELECT 1', NULL, 'SELECT ''hello''', '']))
+----
+{"SELECT ‹×›",NULL,"SELECT ‹×›",‹×›}

--- a/pkg/sql/sem/builtins/fixed_oids.go
+++ b/pkg/sql/sem/builtins/fixed_oids.go
@@ -2344,6 +2344,8 @@ var builtinOidsArray = []string{
 	2370: `pg_advisory_unlock_all() -> void`,
 	2371: `crdb_internal.redactable_sql_constants(val: string) -> string`,
 	2372: `crdb_internal.redactable_sql_constants(val: string[]) -> string[]`,
+	2373: `crdb_internal.redact(val: string) -> string`,
+	2374: `crdb_internal.redact(val: string[]) -> string[]`,
 }
 
 var builtinOidsBySignature map[string]oid.Oid


### PR DESCRIPTION
Add a new `crdb_internal.redact` function which calls `redact.RedactableString.Redact()` on the input string. This will be used to turn redactable `CREATE TABLE` statements into redacted `CREATE TABLE` statements.

Part of: #68570

Epic: CRDB-19756

Release note (sql change): Add a new internal built-in function, `crdb_internal.redact`, which replaces substrings surrounded by redaction markers with the redacted marker.