### PR TITLE
release-22.1: sql: add is_grantable to SHOW DEFAULT PRIVILEGES

### DIFF
--- a/pkg/migration/migrations/remove_invalid_database_privileges_external_test.go
+++ b/pkg/migration/migrations/remove_invalid_database_privileges_external_test.go
@@ -131,14 +131,14 @@ func TestConvertIncompatibleDatabasePrivilegesToDefaultPrivileges(t *testing.T) 
 	// Check that the incompatible privileges have turned into default privileges.
 	tdb.CheckQueryResults(t, "SHOW DEFAULT PRIVILEGES FOR ALL ROLES",
 		[][]string{
-			{"NULL", "true", "tables", "testuser", "DELETE"},
-			{"NULL", "true", "tables", "testuser", "INSERT"},
-			{"NULL", "true", "tables", "testuser", "SELECT"},
-			{"NULL", "true", "tables", "testuser", "UPDATE"},
-			{"NULL", "true", "tables", "testuser2", "DELETE"},
-			{"NULL", "true", "tables", "testuser2", "INSERT"},
-			{"NULL", "true", "tables", "testuser2", "SELECT"},
-			{"NULL", "true", "tables", "testuser2", "UPDATE"},
-			{"NULL", "true", "types", "public", "USAGE"},
+			{"NULL", "true", "tables", "testuser", "DELETE", "false"},
+			{"NULL", "true", "tables", "testuser", "INSERT", "false"},
+			{"NULL", "true", "tables", "testuser", "SELECT", "false"},
+			{"NULL", "true", "tables", "testuser", "UPDATE", "false"},
+			{"NULL", "true", "tables", "testuser2", "DELETE", "false"},
+			{"NULL", "true", "tables", "testuser2", "INSERT", "false"},
+			{"NULL", "true", "tables", "testuser2", "SELECT", "false"},
+			{"NULL", "true", "tables", "testuser2", "UPDATE", "false"},
+			{"NULL", "true", "types", "public", "USAGE", "false"},
 		})
 }

--- a/pkg/sql/delegate/BUILD.bazel
+++ b/pkg/sql/delegate/BUILD.bazel
@@ -38,6 +38,7 @@ go_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/sql/delegate",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/clusterversion",
         "//pkg/jobs",
         "//pkg/jobs/jobspb",
         "//pkg/keys",

--- a/pkg/sql/logictest/testdata/logic_test/alter_default_privileges_in_schema
+++ b/pkg/sql/logictest/testdata/logic_test/alter_default_privileges_in_schema
@@ -212,77 +212,77 @@ test           s2           t12         admin     ALL             true
 test           s2           t12         root      ALL             true
 test           s2           t12         testuser  ALL             true
 
-query TTTBTTT colnames,rowsort
+query TTTBTTTB colnames,rowsort
 SELECT * FROM crdb_internal.default_privileges WHERE schema_name IS NOT NULL
 ----
-database_name  schema_name  role  for_all_roles  object_type  grantee    privilege_type
-test           public       NULL  true           tables       testuser2  SELECT
-test           s            NULL  true           tables       testuser2  SELECT
+database_name  schema_name  role  for_all_roles  object_type  grantee    privilege_type  is_grantable
+test           public       NULL  true           tables       testuser2  SELECT          false
+test           s            NULL  true           tables       testuser2  SELECT          false
 
-query TBTTT colnames
+query TBTTTB colnames
 SHOW DEFAULT PRIVILEGES IN SCHEMA public
 ----
-role  for_all_roles  object_type  grantee  privilege_type
+role  for_all_roles  object_type  grantee  privilege_type  is_grantable
 
-query TBTTT colnames
+query TBTTTB colnames
 SHOW DEFAULT PRIVILEGES IN SCHEMA s
 ----
-role  for_all_roles  object_type  grantee  privilege_type
+role  for_all_roles  object_type  grantee  privilege_type  is_grantable
 
-query TBTTT colnames
+query TBTTTB colnames
 SHOW DEFAULT PRIVILEGES IN SCHEMA s2
 ----
-role  for_all_roles  object_type  grantee  privilege_type
+role  for_all_roles  object_type  grantee  privilege_type  is_grantable
 
 statement ok
 ALTER DEFAULT PRIVILEGES FOR ROLE testuser IN SCHEMA public GRANT ALL ON TABLES TO testuser;
 ALTER DEFAULT PRIVILEGES FOR ROLE testuser IN SCHEMA s GRANT USAGE ON TYPES TO testuser2;
 ALTER DEFAULT PRIVILEGES FOR ROLE testuser IN SCHEMA s2 GRANT SELECT, UPDATE, DROP ON TABLES TO testuser2
 
-query TTTBTTT colnames,rowsort
+query TTTBTTTB colnames,rowsort
 SELECT * FROM crdb_internal.default_privileges WHERE schema_name IS NOT NULL
 ----
-database_name  schema_name  role      for_all_roles  object_type  grantee    privilege_type
-test           public       testuser  false          tables       testuser   ALL
-test           public       NULL      true           tables       testuser2  SELECT
-test           s            testuser  false          types        testuser2  USAGE
-test           s            NULL      true           tables       testuser2  SELECT
-test           s2           testuser  false          tables       testuser2  DROP
-test           s2           testuser  false          tables       testuser2  SELECT
-test           s2           testuser  false          tables       testuser2  UPDATE
+database_name  schema_name  role      for_all_roles  object_type  grantee    privilege_type  is_grantable
+test           public       testuser  false          tables       testuser   ALL             true
+test           public       NULL      true           tables       testuser2  SELECT          false
+test           s            testuser  false          types        testuser2  USAGE           false
+test           s            NULL      true           tables       testuser2  SELECT          false
+test           s2           testuser  false          tables       testuser2  DROP            false
+test           s2           testuser  false          tables       testuser2  SELECT          false
+test           s2           testuser  false          tables       testuser2  UPDATE          false
 
 
-query TBTTT colnames
+query TBTTTB colnames
 SHOW DEFAULT PRIVILEGES IN SCHEMA public
 ----
-role      for_all_roles  object_type  grantee   privilege_type
-testuser  false          tables       testuser  ALL
+role      for_all_roles  object_type  grantee   privilege_type  is_grantable
+testuser  false          tables       testuser  ALL             true
 
-query TBTTT colnames
+query TBTTTB colnames
 SHOW DEFAULT PRIVILEGES IN SCHEMA s
 ----
-role      for_all_roles  object_type  grantee    privilege_type
-testuser  false          types        testuser2  USAGE
+role      for_all_roles  object_type  grantee    privilege_type  is_grantable
+testuser  false          types        testuser2  USAGE           false
 
-query TBTTT colnames
+query TBTTTB colnames
 SHOW DEFAULT PRIVILEGES IN SCHEMA s2
 ----
-role      for_all_roles  object_type  grantee    privilege_type
-testuser  false          tables       testuser2  DROP
-testuser  false          tables       testuser2  SELECT
-testuser  false          tables       testuser2  UPDATE
+role      for_all_roles  object_type  grantee    privilege_type  is_grantable
+testuser  false          tables       testuser2  DROP            false
+testuser  false          tables       testuser2  SELECT          false
+testuser  false          tables       testuser2  UPDATE          false
 
 user root
 
-query TBTTT colnames
+query TBTTTB colnames
 SHOW DEFAULT PRIVILEGES FOR ROLE testuser IN SCHEMA s2
 ----
-role      for_all_roles  object_type  grantee    privilege_type
-testuser  false          tables       testuser2  DROP
-testuser  false          tables       testuser2  SELECT
-testuser  false          tables       testuser2  UPDATE
+role      for_all_roles  object_type  grantee    privilege_type  is_grantable
+testuser  false          tables       testuser2  DROP            false
+testuser  false          tables       testuser2  SELECT          false
+testuser  false          tables       testuser2  UPDATE          false
 
-query TBTTT colnames
+query TBTTTB colnames
 SHOW DEFAULT PRIVILEGES IN SCHEMA "'; drop database test; SELECT '";
 ----
-role  for_all_roles  object_type  grantee  privilege_type
+role  for_all_roles  object_type  grantee  privilege_type  is_grantable

--- a/pkg/sql/logictest/testdata/logic_test/crdb_internal_default_privileges
+++ b/pkg/sql/logictest/testdata/logic_test/crdb_internal_default_privileges
@@ -4,77 +4,77 @@ ALTER DEFAULT PRIVILEGES GRANT USAGE ON TYPES TO PUBLIC;
 ALTER DEFAULT PRIVILEGES GRANT USAGE ON SCHEMAS TO PUBLIC;
 ALTER DEFAULT PRIVILEGES GRANT SELECT ON SEQUENCES TO PUBLIC;
 
-query TTTBTTT colnames,rowsort
+query TTTBTTTB colnames,rowsort
 SELECT * FROM crdb_internal.default_privileges
 ----
-database_name  schema_name  role      for_all_roles  object_type  grantee   privilege_type
-defaultdb      NULL         admin     false          tables       admin     ALL
-defaultdb      NULL         admin     false          sequences    admin     ALL
-defaultdb      NULL         admin     false          types        admin     ALL
-defaultdb      NULL         admin     false          schemas      admin     ALL
-defaultdb      NULL         admin     false          types        public    USAGE
-defaultdb      NULL         root      false          tables       root      ALL
-defaultdb      NULL         root      false          sequences    root      ALL
-defaultdb      NULL         root      false          types        root      ALL
-defaultdb      NULL         root      false          schemas      root      ALL
-defaultdb      NULL         root      false          types        public    USAGE
-defaultdb      NULL         testuser  false          tables       testuser  ALL
-defaultdb      NULL         testuser  false          sequences    testuser  ALL
-defaultdb      NULL         testuser  false          types        testuser  ALL
-defaultdb      NULL         testuser  false          schemas      testuser  ALL
-defaultdb      NULL         testuser  false          types        public    USAGE
-defaultdb      NULL         NULL      true           types        public    USAGE
-postgres       NULL         admin     false          tables       admin     ALL
-postgres       NULL         admin     false          sequences    admin     ALL
-postgres       NULL         admin     false          types        admin     ALL
-postgres       NULL         admin     false          schemas      admin     ALL
-postgres       NULL         admin     false          types        public    USAGE
-postgres       NULL         root      false          tables       root      ALL
-postgres       NULL         root      false          sequences    root      ALL
-postgres       NULL         root      false          types        root      ALL
-postgres       NULL         root      false          schemas      root      ALL
-postgres       NULL         root      false          types        public    USAGE
-postgres       NULL         testuser  false          tables       testuser  ALL
-postgres       NULL         testuser  false          sequences    testuser  ALL
-postgres       NULL         testuser  false          types        testuser  ALL
-postgres       NULL         testuser  false          schemas      testuser  ALL
-postgres       NULL         testuser  false          types        public    USAGE
-postgres       NULL         NULL      true           types        public    USAGE
-system         NULL         admin     false          tables       admin     ALL
-system         NULL         admin     false          sequences    admin     ALL
-system         NULL         admin     false          types        admin     ALL
-system         NULL         admin     false          schemas      admin     ALL
-system         NULL         admin     false          types        public    USAGE
-system         NULL         root      false          tables       root      ALL
-system         NULL         root      false          sequences    root      ALL
-system         NULL         root      false          types        root      ALL
-system         NULL         root      false          schemas      root      ALL
-system         NULL         root      false          types        public    USAGE
-system         NULL         testuser  false          tables       testuser  ALL
-system         NULL         testuser  false          sequences    testuser  ALL
-system         NULL         testuser  false          types        testuser  ALL
-system         NULL         testuser  false          schemas      testuser  ALL
-system         NULL         testuser  false          types        public    USAGE
-system         NULL         NULL      true           types        public    USAGE
-test           NULL         admin     false          tables       admin     ALL
-test           NULL         admin     false          sequences    admin     ALL
-test           NULL         admin     false          types        admin     ALL
-test           NULL         admin     false          schemas      admin     ALL
-test           NULL         admin     false          types        public    USAGE
-test           NULL         root      false          tables       public    SELECT
-test           NULL         root      false          sequences    public    SELECT
-test           NULL         root      false          schemas      public    USAGE
-test           NULL         root      false          tables       root      ALL
-test           NULL         root      false          sequences    root      ALL
-test           NULL         root      false          types        root      ALL
-test           NULL         root      false          schemas      root      ALL
-test           NULL         root      false          types        public    USAGE
-test           NULL         testuser  false          tables       testuser  ALL
-test           NULL         testuser  false          sequences    testuser  ALL
-test           NULL         testuser  false          types        testuser  ALL
-test           NULL         testuser  false          schemas      testuser  ALL
-test           NULL         testuser  false          types        public    USAGE
-test           NULL         NULL      true           types        public    USAGE
+database_name  schema_name  role      for_all_roles  object_type  grantee   privilege_type  is_grantable
+defaultdb      NULL         admin     false          tables       admin     ALL             true
+defaultdb      NULL         admin     false          sequences    admin     ALL             true
+defaultdb      NULL         admin     false          types        admin     ALL             true
+defaultdb      NULL         admin     false          schemas      admin     ALL             true
+defaultdb      NULL         admin     false          types        public    USAGE           false
+defaultdb      NULL         root      false          tables       root      ALL             true
+defaultdb      NULL         root      false          sequences    root      ALL             true
+defaultdb      NULL         root      false          types        root      ALL             true
+defaultdb      NULL         root      false          schemas      root      ALL             true
+defaultdb      NULL         root      false          types        public    USAGE           false
+defaultdb      NULL         testuser  false          tables       testuser  ALL             true
+defaultdb      NULL         testuser  false          sequences    testuser  ALL             true
+defaultdb      NULL         testuser  false          types        testuser  ALL             true
+defaultdb      NULL         testuser  false          schemas      testuser  ALL             true
+defaultdb      NULL         testuser  false          types        public    USAGE           false
+defaultdb      NULL         NULL      true           types        public    USAGE           false
+postgres       NULL         admin     false          tables       admin     ALL             true
+postgres       NULL         admin     false          sequences    admin     ALL             true
+postgres       NULL         admin     false          types        admin     ALL             true
+postgres       NULL         admin     false          schemas      admin     ALL             true
+postgres       NULL         admin     false          types        public    USAGE           false
+postgres       NULL         root      false          tables       root      ALL             true
+postgres       NULL         root      false          sequences    root      ALL             true
+postgres       NULL         root      false          types        root      ALL             true
+postgres       NULL         root      false          schemas      root      ALL             true
+postgres       NULL         root      false          types        public    USAGE           false
+postgres       NULL         testuser  false          tables       testuser  ALL             true
+postgres       NULL         testuser  false          sequences    testuser  ALL             true
+postgres       NULL         testuser  false          types        testuser  ALL             true
+postgres       NULL         testuser  false          schemas      testuser  ALL             true
+postgres       NULL         testuser  false          types        public    USAGE           false
+postgres       NULL         NULL      true           types        public    USAGE           false
+system         NULL         admin     false          tables       admin     ALL             true
+system         NULL         admin     false          sequences    admin     ALL             true
+system         NULL         admin     false          types        admin     ALL             true
+system         NULL         admin     false          schemas      admin     ALL             true
+system         NULL         admin     false          types        public    USAGE           false
+system         NULL         root      false          tables       root      ALL             true
+system         NULL         root      false          sequences    root      ALL             true
+system         NULL         root      false          types        root      ALL             true
+system         NULL         root      false          schemas      root      ALL             true
+system         NULL         root      false          types        public    USAGE           false
+system         NULL         testuser  false          tables       testuser  ALL             true
+system         NULL         testuser  false          sequences    testuser  ALL             true
+system         NULL         testuser  false          types        testuser  ALL             true
+system         NULL         testuser  false          schemas      testuser  ALL             true
+system         NULL         testuser  false          types        public    USAGE           false
+system         NULL         NULL      true           types        public    USAGE           false
+test           NULL         admin     false          tables       admin     ALL             true
+test           NULL         admin     false          sequences    admin     ALL             true
+test           NULL         admin     false          types        admin     ALL             true
+test           NULL         admin     false          schemas      admin     ALL             true
+test           NULL         admin     false          types        public    USAGE           false
+test           NULL         root      false          sequences    public    SELECT          false
+test           NULL         root      false          schemas      public    USAGE           false
+test           NULL         root      false          tables       public    SELECT          false
+test           NULL         root      false          tables       root      ALL             true
+test           NULL         root      false          sequences    root      ALL             true
+test           NULL         root      false          types        root      ALL             true
+test           NULL         root      false          schemas      root      ALL             true
+test           NULL         root      false          types        public    USAGE           false
+test           NULL         testuser  false          tables       testuser  ALL             true
+test           NULL         testuser  false          sequences    testuser  ALL             true
+test           NULL         testuser  false          types        testuser  ALL             true
+test           NULL         testuser  false          schemas      testuser  ALL             true
+test           NULL         testuser  false          types        public    USAGE           false
+test           NULL         NULL      true           types        public    USAGE           false
 
 statement ok
 CREATE USER foo
@@ -88,50 +88,50 @@ ALTER DEFAULT PRIVILEGES GRANT ALL ON TYPES TO foo, bar;
 ALTER DEFAULT PRIVILEGES GRANT ALL ON SCHEMAS TO foo, bar;
 ALTER DEFAULT PRIVILEGES GRANT ALL ON SEQUENCES TO foo, bar;
 
-query TTTBTTT colnames,rowsort
+query TTTBTTTB colnames,rowsort
 SELECT * FROM crdb_internal.default_privileges WHERE grantee='foo' OR grantee='bar'
 ----
-database_name  schema_name  role  for_all_roles  object_type  grantee  privilege_type
-defaultdb      NULL         bar   false          tables       bar      ALL
-defaultdb      NULL         bar   false          sequences    bar      ALL
-defaultdb      NULL         bar   false          types        bar      ALL
-defaultdb      NULL         bar   false          schemas      bar      ALL
-defaultdb      NULL         foo   false          tables       foo      ALL
-defaultdb      NULL         foo   false          sequences    foo      ALL
-defaultdb      NULL         foo   false          types        foo      ALL
-defaultdb      NULL         foo   false          schemas      foo      ALL
-postgres       NULL         bar   false          tables       bar      ALL
-postgres       NULL         bar   false          sequences    bar      ALL
-postgres       NULL         bar   false          types        bar      ALL
-postgres       NULL         bar   false          schemas      bar      ALL
-postgres       NULL         foo   false          tables       foo      ALL
-postgres       NULL         foo   false          sequences    foo      ALL
-postgres       NULL         foo   false          types        foo      ALL
-postgres       NULL         foo   false          schemas      foo      ALL
-system         NULL         bar   false          tables       bar      ALL
-system         NULL         bar   false          sequences    bar      ALL
-system         NULL         bar   false          types        bar      ALL
-system         NULL         bar   false          schemas      bar      ALL
-system         NULL         foo   false          tables       foo      ALL
-system         NULL         foo   false          sequences    foo      ALL
-system         NULL         foo   false          types        foo      ALL
-system         NULL         foo   false          schemas      foo      ALL
-test           NULL         bar   false          tables       bar      ALL
-test           NULL         bar   false          sequences    bar      ALL
-test           NULL         bar   false          types        bar      ALL
-test           NULL         bar   false          schemas      bar      ALL
-test           NULL         foo   false          tables       foo      ALL
-test           NULL         foo   false          sequences    foo      ALL
-test           NULL         foo   false          types        foo      ALL
-test           NULL         foo   false          schemas      foo      ALL
-test           NULL         root  false          sequences    bar      ALL
-test           NULL         root  false          sequences    foo      ALL
-test           NULL         root  false          types        bar      ALL
-test           NULL         root  false          types        foo      ALL
-test           NULL         root  false          schemas      bar      ALL
-test           NULL         root  false          schemas      foo      ALL
-test           NULL         root  false          tables       bar      ALL
-test           NULL         root  false          tables       foo      ALL
+database_name  schema_name  role  for_all_roles  object_type  grantee  privilege_type  is_grantable
+defaultdb      NULL         bar   false          tables       bar      ALL             true
+defaultdb      NULL         bar   false          sequences    bar      ALL             true
+defaultdb      NULL         bar   false          types        bar      ALL             true
+defaultdb      NULL         bar   false          schemas      bar      ALL             true
+defaultdb      NULL         foo   false          tables       foo      ALL             true
+defaultdb      NULL         foo   false          sequences    foo      ALL             true
+defaultdb      NULL         foo   false          types        foo      ALL             true
+defaultdb      NULL         foo   false          schemas      foo      ALL             true
+postgres       NULL         bar   false          tables       bar      ALL             true
+postgres       NULL         bar   false          sequences    bar      ALL             true
+postgres       NULL         bar   false          types        bar      ALL             true
+postgres       NULL         bar   false          schemas      bar      ALL             true
+postgres       NULL         foo   false          tables       foo      ALL             true
+postgres       NULL         foo   false          sequences    foo      ALL             true
+postgres       NULL         foo   false          types        foo      ALL             true
+postgres       NULL         foo   false          schemas      foo      ALL             true
+system         NULL         bar   false          tables       bar      ALL             true
+system         NULL         bar   false          sequences    bar      ALL             true
+system         NULL         bar   false          types        bar      ALL             true
+system         NULL         bar   false          schemas      bar      ALL             true
+system         NULL         foo   false          tables       foo      ALL             true
+system         NULL         foo   false          sequences    foo      ALL             true
+system         NULL         foo   false          types        foo      ALL             true
+system         NULL         foo   false          schemas      foo      ALL             true
+test           NULL         bar   false          tables       bar      ALL             true
+test           NULL         bar   false          sequences    bar      ALL             true
+test           NULL         bar   false          types        bar      ALL             true
+test           NULL         bar   false          schemas      bar      ALL             true
+test           NULL         foo   false          tables       foo      ALL             true
+test           NULL         foo   false          sequences    foo      ALL             true
+test           NULL         foo   false          types        foo      ALL             true
+test           NULL         foo   false          schemas      foo      ALL             true
+test           NULL         root  false          schemas      bar      ALL             true
+test           NULL         root  false          schemas      foo      ALL             true
+test           NULL         root  false          tables       bar      ALL             true
+test           NULL         root  false          tables       foo      ALL             true
+test           NULL         root  false          sequences    bar      ALL             true
+test           NULL         root  false          sequences    foo      ALL             true
+test           NULL         root  false          types        bar      ALL             true
+test           NULL         root  false          types        foo      ALL             true
 
 statement ok
 GRANT foo, bar TO root;
@@ -142,58 +142,58 @@ ALTER DEFAULT PRIVILEGES FOR ROLE foo, bar GRANT ALL ON TYPES TO foo, bar;
 ALTER DEFAULT PRIVILEGES FOR ROLE foo, bar GRANT ALL ON SCHEMAS TO foo, bar;
 ALTER DEFAULT PRIVILEGES FOR ROLE foo, bar GRANT ALL ON SEQUENCES TO foo, bar;
 
-query TTTBTTT colnames,rowsort
+query TTTBTTTB colnames,rowsort
 SELECT * FROM crdb_internal.default_privileges WHERE role='foo' OR role='bar'
 ----
-database_name  schema_name  role  for_all_roles  object_type  grantee  privilege_type
-defaultdb      NULL         bar   false          tables       bar      ALL
-defaultdb      NULL         bar   false          sequences    bar      ALL
-defaultdb      NULL         bar   false          types        bar      ALL
-defaultdb      NULL         bar   false          schemas      bar      ALL
-defaultdb      NULL         bar   false          types        public   USAGE
-defaultdb      NULL         foo   false          tables       foo      ALL
-defaultdb      NULL         foo   false          sequences    foo      ALL
-defaultdb      NULL         foo   false          types        foo      ALL
-defaultdb      NULL         foo   false          schemas      foo      ALL
-defaultdb      NULL         foo   false          types        public   USAGE
-postgres       NULL         bar   false          tables       bar      ALL
-postgres       NULL         bar   false          sequences    bar      ALL
-postgres       NULL         bar   false          types        bar      ALL
-postgres       NULL         bar   false          schemas      bar      ALL
-postgres       NULL         bar   false          types        public   USAGE
-postgres       NULL         foo   false          tables       foo      ALL
-postgres       NULL         foo   false          sequences    foo      ALL
-postgres       NULL         foo   false          types        foo      ALL
-postgres       NULL         foo   false          schemas      foo      ALL
-postgres       NULL         foo   false          types        public   USAGE
-system         NULL         bar   false          tables       bar      ALL
-system         NULL         bar   false          sequences    bar      ALL
-system         NULL         bar   false          types        bar      ALL
-system         NULL         bar   false          schemas      bar      ALL
-system         NULL         bar   false          types        public   USAGE
-system         NULL         foo   false          tables       foo      ALL
-system         NULL         foo   false          sequences    foo      ALL
-system         NULL         foo   false          types        foo      ALL
-system         NULL         foo   false          schemas      foo      ALL
-system         NULL         foo   false          types        public   USAGE
-test           NULL         bar   false          tables       bar      ALL
-test           NULL         bar   false          tables       foo      ALL
-test           NULL         bar   false          sequences    bar      ALL
-test           NULL         bar   false          sequences    foo      ALL
-test           NULL         bar   false          types        bar      ALL
-test           NULL         bar   false          types        foo      ALL
-test           NULL         bar   false          schemas      bar      ALL
-test           NULL         bar   false          schemas      foo      ALL
-test           NULL         bar   false          types        public   USAGE
-test           NULL         foo   false          sequences    bar      ALL
-test           NULL         foo   false          sequences    foo      ALL
-test           NULL         foo   false          types        bar      ALL
-test           NULL         foo   false          types        foo      ALL
-test           NULL         foo   false          schemas      bar      ALL
-test           NULL         foo   false          schemas      foo      ALL
-test           NULL         foo   false          tables       bar      ALL
-test           NULL         foo   false          tables       foo      ALL
-test           NULL         foo   false          types        public   USAGE
+database_name  schema_name  role  for_all_roles  object_type  grantee  privilege_type  is_grantable
+defaultdb      NULL         bar   false          tables       bar      ALL             true
+defaultdb      NULL         bar   false          sequences    bar      ALL             true
+defaultdb      NULL         bar   false          types        bar      ALL             true
+defaultdb      NULL         bar   false          schemas      bar      ALL             true
+defaultdb      NULL         bar   false          types        public   USAGE           false
+defaultdb      NULL         foo   false          tables       foo      ALL             true
+defaultdb      NULL         foo   false          sequences    foo      ALL             true
+defaultdb      NULL         foo   false          types        foo      ALL             true
+defaultdb      NULL         foo   false          schemas      foo      ALL             true
+defaultdb      NULL         foo   false          types        public   USAGE           false
+postgres       NULL         bar   false          tables       bar      ALL             true
+postgres       NULL         bar   false          sequences    bar      ALL             true
+postgres       NULL         bar   false          types        bar      ALL             true
+postgres       NULL         bar   false          schemas      bar      ALL             true
+postgres       NULL         bar   false          types        public   USAGE           false
+postgres       NULL         foo   false          tables       foo      ALL             true
+postgres       NULL         foo   false          sequences    foo      ALL             true
+postgres       NULL         foo   false          types        foo      ALL             true
+postgres       NULL         foo   false          schemas      foo      ALL             true
+postgres       NULL         foo   false          types        public   USAGE           false
+system         NULL         bar   false          tables       bar      ALL             true
+system         NULL         bar   false          sequences    bar      ALL             true
+system         NULL         bar   false          types        bar      ALL             true
+system         NULL         bar   false          schemas      bar      ALL             true
+system         NULL         bar   false          types        public   USAGE           false
+system         NULL         foo   false          tables       foo      ALL             true
+system         NULL         foo   false          sequences    foo      ALL             true
+system         NULL         foo   false          types        foo      ALL             true
+system         NULL         foo   false          schemas      foo      ALL             true
+system         NULL         foo   false          types        public   USAGE           false
+test           NULL         bar   false          tables       bar      ALL             true
+test           NULL         bar   false          tables       foo      ALL             true
+test           NULL         bar   false          sequences    bar      ALL             true
+test           NULL         bar   false          sequences    foo      ALL             true
+test           NULL         bar   false          types        bar      ALL             true
+test           NULL         bar   false          types        foo      ALL             true
+test           NULL         bar   false          schemas      bar      ALL             true
+test           NULL         bar   false          schemas      foo      ALL             true
+test           NULL         bar   false          types        public   USAGE           false
+test           NULL         foo   false          schemas      bar      ALL             true
+test           NULL         foo   false          schemas      foo      ALL             true
+test           NULL         foo   false          tables       bar      ALL             true
+test           NULL         foo   false          tables       foo      ALL             true
+test           NULL         foo   false          sequences    bar      ALL             true
+test           NULL         foo   false          sequences    foo      ALL             true
+test           NULL         foo   false          types        bar      ALL             true
+test           NULL         foo   false          types        foo      ALL             true
+test           NULL         foo   false          types        public   USAGE           false
 
 statement ok
 ALTER DEFAULT PRIVILEGES FOR ROLE foo, bar REVOKE ALL ON TABLES FROM foo, bar;
@@ -201,117 +201,117 @@ ALTER DEFAULT PRIVILEGES FOR ROLE foo, bar REVOKE ALL ON TYPES FROM foo, bar;
 ALTER DEFAULT PRIVILEGES FOR ROLE foo, bar REVOKE ALL ON SCHEMAS FROM foo, bar;
 ALTER DEFAULT PRIVILEGES FOR ROLE foo, bar REVOKE ALL ON SEQUENCES FROM foo, bar;
 
-query TTTBTTT colnames,rowsort
+query TTTBTTTB colnames,rowsort
 SELECT * FROM crdb_internal.default_privileges
 ----
-database_name  schema_name  role      for_all_roles  object_type  grantee   privilege_type
-defaultdb      NULL         admin     false          tables       admin     ALL
-defaultdb      NULL         admin     false          sequences    admin     ALL
-defaultdb      NULL         admin     false          types        admin     ALL
-defaultdb      NULL         admin     false          schemas      admin     ALL
-defaultdb      NULL         admin     false          types        public    USAGE
-defaultdb      NULL         bar       false          tables       bar       ALL
-defaultdb      NULL         bar       false          sequences    bar       ALL
-defaultdb      NULL         bar       false          types        bar       ALL
-defaultdb      NULL         bar       false          schemas      bar       ALL
-defaultdb      NULL         bar       false          types        public    USAGE
-defaultdb      NULL         foo       false          tables       foo       ALL
-defaultdb      NULL         foo       false          sequences    foo       ALL
-defaultdb      NULL         foo       false          types        foo       ALL
-defaultdb      NULL         foo       false          schemas      foo       ALL
-defaultdb      NULL         foo       false          types        public    USAGE
-defaultdb      NULL         root      false          tables       root      ALL
-defaultdb      NULL         root      false          sequences    root      ALL
-defaultdb      NULL         root      false          types        root      ALL
-defaultdb      NULL         root      false          schemas      root      ALL
-defaultdb      NULL         root      false          types        public    USAGE
-defaultdb      NULL         testuser  false          tables       testuser  ALL
-defaultdb      NULL         testuser  false          sequences    testuser  ALL
-defaultdb      NULL         testuser  false          types        testuser  ALL
-defaultdb      NULL         testuser  false          schemas      testuser  ALL
-defaultdb      NULL         testuser  false          types        public    USAGE
-defaultdb      NULL         NULL      true           types        public    USAGE
-postgres       NULL         admin     false          tables       admin     ALL
-postgres       NULL         admin     false          sequences    admin     ALL
-postgres       NULL         admin     false          types        admin     ALL
-postgres       NULL         admin     false          schemas      admin     ALL
-postgres       NULL         admin     false          types        public    USAGE
-postgres       NULL         bar       false          tables       bar       ALL
-postgres       NULL         bar       false          sequences    bar       ALL
-postgres       NULL         bar       false          types        bar       ALL
-postgres       NULL         bar       false          schemas      bar       ALL
-postgres       NULL         bar       false          types        public    USAGE
-postgres       NULL         foo       false          tables       foo       ALL
-postgres       NULL         foo       false          sequences    foo       ALL
-postgres       NULL         foo       false          types        foo       ALL
-postgres       NULL         foo       false          schemas      foo       ALL
-postgres       NULL         foo       false          types        public    USAGE
-postgres       NULL         root      false          tables       root      ALL
-postgres       NULL         root      false          sequences    root      ALL
-postgres       NULL         root      false          types        root      ALL
-postgres       NULL         root      false          schemas      root      ALL
-postgres       NULL         root      false          types        public    USAGE
-postgres       NULL         testuser  false          tables       testuser  ALL
-postgres       NULL         testuser  false          sequences    testuser  ALL
-postgres       NULL         testuser  false          types        testuser  ALL
-postgres       NULL         testuser  false          schemas      testuser  ALL
-postgres       NULL         testuser  false          types        public    USAGE
-postgres       NULL         NULL      true           types        public    USAGE
-system         NULL         admin     false          tables       admin     ALL
-system         NULL         admin     false          sequences    admin     ALL
-system         NULL         admin     false          types        admin     ALL
-system         NULL         admin     false          schemas      admin     ALL
-system         NULL         admin     false          types        public    USAGE
-system         NULL         bar       false          tables       bar       ALL
-system         NULL         bar       false          sequences    bar       ALL
-system         NULL         bar       false          types        bar       ALL
-system         NULL         bar       false          schemas      bar       ALL
-system         NULL         bar       false          types        public    USAGE
-system         NULL         foo       false          tables       foo       ALL
-system         NULL         foo       false          sequences    foo       ALL
-system         NULL         foo       false          types        foo       ALL
-system         NULL         foo       false          schemas      foo       ALL
-system         NULL         foo       false          types        public    USAGE
-system         NULL         root      false          tables       root      ALL
-system         NULL         root      false          sequences    root      ALL
-system         NULL         root      false          types        root      ALL
-system         NULL         root      false          schemas      root      ALL
-system         NULL         root      false          types        public    USAGE
-system         NULL         testuser  false          tables       testuser  ALL
-system         NULL         testuser  false          sequences    testuser  ALL
-system         NULL         testuser  false          types        testuser  ALL
-system         NULL         testuser  false          schemas      testuser  ALL
-system         NULL         testuser  false          types        public    USAGE
-system         NULL         NULL      true           types        public    USAGE
-test           NULL         admin     false          tables       admin     ALL
-test           NULL         admin     false          sequences    admin     ALL
-test           NULL         admin     false          types        admin     ALL
-test           NULL         admin     false          schemas      admin     ALL
-test           NULL         admin     false          types        public    USAGE
-test           NULL         bar       false          types        public    USAGE
-test           NULL         foo       false          types        public    USAGE
-test           NULL         root      false          tables       bar       ALL
-test           NULL         root      false          tables       foo       ALL
-test           NULL         root      false          tables       public    SELECT
-test           NULL         root      false          sequences    bar       ALL
-test           NULL         root      false          sequences    foo       ALL
-test           NULL         root      false          sequences    public    SELECT
-test           NULL         root      false          types        bar       ALL
-test           NULL         root      false          types        foo       ALL
-test           NULL         root      false          schemas      bar       ALL
-test           NULL         root      false          schemas      foo       ALL
-test           NULL         root      false          schemas      public    USAGE
-test           NULL         root      false          tables       root      ALL
-test           NULL         root      false          sequences    root      ALL
-test           NULL         root      false          types        root      ALL
-test           NULL         root      false          schemas      root      ALL
-test           NULL         root      false          types        public    USAGE
-test           NULL         testuser  false          tables       testuser  ALL
-test           NULL         testuser  false          sequences    testuser  ALL
-test           NULL         testuser  false          types        testuser  ALL
-test           NULL         testuser  false          schemas      testuser  ALL
-test           NULL         testuser  false          types        public    USAGE
-test           NULL         NULL      true           types        public    USAGE
+database_name  schema_name  role      for_all_roles  object_type  grantee   privilege_type  is_grantable
+defaultdb      NULL         admin     false          tables       admin     ALL             true
+defaultdb      NULL         admin     false          sequences    admin     ALL             true
+defaultdb      NULL         admin     false          types        admin     ALL             true
+defaultdb      NULL         admin     false          schemas      admin     ALL             true
+defaultdb      NULL         admin     false          types        public    USAGE           false
+defaultdb      NULL         bar       false          tables       bar       ALL             true
+defaultdb      NULL         bar       false          sequences    bar       ALL             true
+defaultdb      NULL         bar       false          types        bar       ALL             true
+defaultdb      NULL         bar       false          schemas      bar       ALL             true
+defaultdb      NULL         bar       false          types        public    USAGE           false
+defaultdb      NULL         foo       false          tables       foo       ALL             true
+defaultdb      NULL         foo       false          sequences    foo       ALL             true
+defaultdb      NULL         foo       false          types        foo       ALL             true
+defaultdb      NULL         foo       false          schemas      foo       ALL             true
+defaultdb      NULL         foo       false          types        public    USAGE           false
+defaultdb      NULL         root      false          tables       root      ALL             true
+defaultdb      NULL         root      false          sequences    root      ALL             true
+defaultdb      NULL         root      false          types        root      ALL             true
+defaultdb      NULL         root      false          schemas      root      ALL             true
+defaultdb      NULL         root      false          types        public    USAGE           false
+defaultdb      NULL         testuser  false          tables       testuser  ALL             true
+defaultdb      NULL         testuser  false          sequences    testuser  ALL             true
+defaultdb      NULL         testuser  false          types        testuser  ALL             true
+defaultdb      NULL         testuser  false          schemas      testuser  ALL             true
+defaultdb      NULL         testuser  false          types        public    USAGE           false
+defaultdb      NULL         NULL      true           types        public    USAGE           false
+postgres       NULL         admin     false          tables       admin     ALL             true
+postgres       NULL         admin     false          sequences    admin     ALL             true
+postgres       NULL         admin     false          types        admin     ALL             true
+postgres       NULL         admin     false          schemas      admin     ALL             true
+postgres       NULL         admin     false          types        public    USAGE           false
+postgres       NULL         bar       false          tables       bar       ALL             true
+postgres       NULL         bar       false          sequences    bar       ALL             true
+postgres       NULL         bar       false          types        bar       ALL             true
+postgres       NULL         bar       false          schemas      bar       ALL             true
+postgres       NULL         bar       false          types        public    USAGE           false
+postgres       NULL         foo       false          tables       foo       ALL             true
+postgres       NULL         foo       false          sequences    foo       ALL             true
+postgres       NULL         foo       false          types        foo       ALL             true
+postgres       NULL         foo       false          schemas      foo       ALL             true
+postgres       NULL         foo       false          types        public    USAGE           false
+postgres       NULL         root      false          tables       root      ALL             true
+postgres       NULL         root      false          sequences    root      ALL             true
+postgres       NULL         root      false          types        root      ALL             true
+postgres       NULL         root      false          schemas      root      ALL             true
+postgres       NULL         root      false          types        public    USAGE           false
+postgres       NULL         testuser  false          tables       testuser  ALL             true
+postgres       NULL         testuser  false          sequences    testuser  ALL             true
+postgres       NULL         testuser  false          types        testuser  ALL             true
+postgres       NULL         testuser  false          schemas      testuser  ALL             true
+postgres       NULL         testuser  false          types        public    USAGE           false
+postgres       NULL         NULL      true           types        public    USAGE           false
+system         NULL         admin     false          tables       admin     ALL             true
+system         NULL         admin     false          sequences    admin     ALL             true
+system         NULL         admin     false          types        admin     ALL             true
+system         NULL         admin     false          schemas      admin     ALL             true
+system         NULL         admin     false          types        public    USAGE           false
+system         NULL         bar       false          tables       bar       ALL             true
+system         NULL         bar       false          sequences    bar       ALL             true
+system         NULL         bar       false          types        bar       ALL             true
+system         NULL         bar       false          schemas      bar       ALL             true
+system         NULL         bar       false          types        public    USAGE           false
+system         NULL         foo       false          tables       foo       ALL             true
+system         NULL         foo       false          sequences    foo       ALL             true
+system         NULL         foo       false          types        foo       ALL             true
+system         NULL         foo       false          schemas      foo       ALL             true
+system         NULL         foo       false          types        public    USAGE           false
+system         NULL         root      false          tables       root      ALL             true
+system         NULL         root      false          sequences    root      ALL             true
+system         NULL         root      false          types        root      ALL             true
+system         NULL         root      false          schemas      root      ALL             true
+system         NULL         root      false          types        public    USAGE           false
+system         NULL         testuser  false          tables       testuser  ALL             true
+system         NULL         testuser  false          sequences    testuser  ALL             true
+system         NULL         testuser  false          types        testuser  ALL             true
+system         NULL         testuser  false          schemas      testuser  ALL             true
+system         NULL         testuser  false          types        public    USAGE           false
+system         NULL         NULL      true           types        public    USAGE           false
+test           NULL         admin     false          tables       admin     ALL             true
+test           NULL         admin     false          sequences    admin     ALL             true
+test           NULL         admin     false          types        admin     ALL             true
+test           NULL         admin     false          schemas      admin     ALL             true
+test           NULL         admin     false          types        public    USAGE           false
+test           NULL         bar       false          types        public    USAGE           false
+test           NULL         foo       false          types        public    USAGE           false
+test           NULL         root      false          sequences    bar       ALL             true
+test           NULL         root      false          sequences    foo       ALL             true
+test           NULL         root      false          sequences    public    SELECT          false
+test           NULL         root      false          types        bar       ALL             true
+test           NULL         root      false          types        foo       ALL             true
+test           NULL         root      false          schemas      bar       ALL             true
+test           NULL         root      false          schemas      foo       ALL             true
+test           NULL         root      false          schemas      public    USAGE           false
+test           NULL         root      false          tables       bar       ALL             true
+test           NULL         root      false          tables       foo       ALL             true
+test           NULL         root      false          tables       public    SELECT          false
+test           NULL         root      false          tables       root      ALL             true
+test           NULL         root      false          sequences    root      ALL             true
+test           NULL         root      false          types        root      ALL             true
+test           NULL         root      false          schemas      root      ALL             true
+test           NULL         root      false          types        public    USAGE           false
+test           NULL         testuser  false          tables       testuser  ALL             true
+test           NULL         testuser  false          sequences    testuser  ALL             true
+test           NULL         testuser  false          types        testuser  ALL             true
+test           NULL         testuser  false          schemas      testuser  ALL             true
+test           NULL         testuser  false          types        public    USAGE           false
+test           NULL         NULL      true           types        public    USAGE           false
 
 statement ok
 ALTER DEFAULT PRIVILEGES REVOKE SELECT ON TABLES FROM foo, bar, public;
@@ -319,226 +319,226 @@ ALTER DEFAULT PRIVILEGES REVOKE ALL ON TYPES FROM foo, bar, public;
 ALTER DEFAULT PRIVILEGES REVOKE ALL ON SCHEMAS FROM foo, bar, public;
 ALTER DEFAULT PRIVILEGES REVOKE ALL ON SEQUENCES FROM foo, bar, public;
 
-query TTTBTTT colnames,rowsort
+query TTTBTTTB colnames,rowsort
 SELECT * FROM crdb_internal.default_privileges
 ----
-database_name  schema_name  role      for_all_roles  object_type  grantee   privilege_type
-defaultdb      NULL         admin     false          tables       admin     ALL
-defaultdb      NULL         admin     false          sequences    admin     ALL
-defaultdb      NULL         admin     false          types        admin     ALL
-defaultdb      NULL         admin     false          schemas      admin     ALL
-defaultdb      NULL         admin     false          types        public    USAGE
-defaultdb      NULL         bar       false          tables       bar       ALL
-defaultdb      NULL         bar       false          sequences    bar       ALL
-defaultdb      NULL         bar       false          types        bar       ALL
-defaultdb      NULL         bar       false          schemas      bar       ALL
-defaultdb      NULL         bar       false          types        public    USAGE
-defaultdb      NULL         foo       false          tables       foo       ALL
-defaultdb      NULL         foo       false          sequences    foo       ALL
-defaultdb      NULL         foo       false          types        foo       ALL
-defaultdb      NULL         foo       false          schemas      foo       ALL
-defaultdb      NULL         foo       false          types        public    USAGE
-defaultdb      NULL         root      false          tables       root      ALL
-defaultdb      NULL         root      false          sequences    root      ALL
-defaultdb      NULL         root      false          types        root      ALL
-defaultdb      NULL         root      false          schemas      root      ALL
-defaultdb      NULL         root      false          types        public    USAGE
-defaultdb      NULL         testuser  false          tables       testuser  ALL
-defaultdb      NULL         testuser  false          sequences    testuser  ALL
-defaultdb      NULL         testuser  false          types        testuser  ALL
-defaultdb      NULL         testuser  false          schemas      testuser  ALL
-defaultdb      NULL         testuser  false          types        public    USAGE
-defaultdb      NULL         NULL      true           types        public    USAGE
-postgres       NULL         admin     false          tables       admin     ALL
-postgres       NULL         admin     false          sequences    admin     ALL
-postgres       NULL         admin     false          types        admin     ALL
-postgres       NULL         admin     false          schemas      admin     ALL
-postgres       NULL         admin     false          types        public    USAGE
-postgres       NULL         bar       false          tables       bar       ALL
-postgres       NULL         bar       false          sequences    bar       ALL
-postgres       NULL         bar       false          types        bar       ALL
-postgres       NULL         bar       false          schemas      bar       ALL
-postgres       NULL         bar       false          types        public    USAGE
-postgres       NULL         foo       false          tables       foo       ALL
-postgres       NULL         foo       false          sequences    foo       ALL
-postgres       NULL         foo       false          types        foo       ALL
-postgres       NULL         foo       false          schemas      foo       ALL
-postgres       NULL         foo       false          types        public    USAGE
-postgres       NULL         root      false          tables       root      ALL
-postgres       NULL         root      false          sequences    root      ALL
-postgres       NULL         root      false          types        root      ALL
-postgres       NULL         root      false          schemas      root      ALL
-postgres       NULL         root      false          types        public    USAGE
-postgres       NULL         testuser  false          tables       testuser  ALL
-postgres       NULL         testuser  false          sequences    testuser  ALL
-postgres       NULL         testuser  false          types        testuser  ALL
-postgres       NULL         testuser  false          schemas      testuser  ALL
-postgres       NULL         testuser  false          types        public    USAGE
-postgres       NULL         NULL      true           types        public    USAGE
-system         NULL         admin     false          tables       admin     ALL
-system         NULL         admin     false          sequences    admin     ALL
-system         NULL         admin     false          types        admin     ALL
-system         NULL         admin     false          schemas      admin     ALL
-system         NULL         admin     false          types        public    USAGE
-system         NULL         bar       false          tables       bar       ALL
-system         NULL         bar       false          sequences    bar       ALL
-system         NULL         bar       false          types        bar       ALL
-system         NULL         bar       false          schemas      bar       ALL
-system         NULL         bar       false          types        public    USAGE
-system         NULL         foo       false          tables       foo       ALL
-system         NULL         foo       false          sequences    foo       ALL
-system         NULL         foo       false          types        foo       ALL
-system         NULL         foo       false          schemas      foo       ALL
-system         NULL         foo       false          types        public    USAGE
-system         NULL         root      false          tables       root      ALL
-system         NULL         root      false          sequences    root      ALL
-system         NULL         root      false          types        root      ALL
-system         NULL         root      false          schemas      root      ALL
-system         NULL         root      false          types        public    USAGE
-system         NULL         testuser  false          tables       testuser  ALL
-system         NULL         testuser  false          sequences    testuser  ALL
-system         NULL         testuser  false          types        testuser  ALL
-system         NULL         testuser  false          schemas      testuser  ALL
-system         NULL         testuser  false          types        public    USAGE
-system         NULL         NULL      true           types        public    USAGE
-test           NULL         admin     false          tables       admin     ALL
-test           NULL         admin     false          sequences    admin     ALL
-test           NULL         admin     false          types        admin     ALL
-test           NULL         admin     false          schemas      admin     ALL
-test           NULL         admin     false          types        public    USAGE
-test           NULL         bar       false          types        public    USAGE
-test           NULL         foo       false          types        public    USAGE
-test           NULL         root      false          tables       bar       CREATE
-test           NULL         root      false          tables       bar       DROP
-test           NULL         root      false          tables       bar       GRANT
-test           NULL         root      false          tables       bar       INSERT
-test           NULL         root      false          tables       bar       DELETE
-test           NULL         root      false          tables       bar       UPDATE
-test           NULL         root      false          tables       bar       ZONECONFIG
-test           NULL         root      false          tables       foo       CREATE
-test           NULL         root      false          tables       foo       DROP
-test           NULL         root      false          tables       foo       GRANT
-test           NULL         root      false          tables       foo       INSERT
-test           NULL         root      false          tables       foo       DELETE
-test           NULL         root      false          tables       foo       UPDATE
-test           NULL         root      false          tables       foo       ZONECONFIG
-test           NULL         root      false          tables       root      ALL
-test           NULL         root      false          sequences    root      ALL
-test           NULL         root      false          types        root      ALL
-test           NULL         root      false          schemas      root      ALL
-test           NULL         testuser  false          tables       testuser  ALL
-test           NULL         testuser  false          sequences    testuser  ALL
-test           NULL         testuser  false          types        testuser  ALL
-test           NULL         testuser  false          schemas      testuser  ALL
-test           NULL         testuser  false          types        public    USAGE
-test           NULL         NULL      true           types        public    USAGE
+database_name  schema_name  role      for_all_roles  object_type  grantee   privilege_type  is_grantable
+defaultdb      NULL         admin     false          tables       admin     ALL             true
+defaultdb      NULL         admin     false          sequences    admin     ALL             true
+defaultdb      NULL         admin     false          types        admin     ALL             true
+defaultdb      NULL         admin     false          schemas      admin     ALL             true
+defaultdb      NULL         admin     false          types        public    USAGE           false
+defaultdb      NULL         bar       false          tables       bar       ALL             true
+defaultdb      NULL         bar       false          sequences    bar       ALL             true
+defaultdb      NULL         bar       false          types        bar       ALL             true
+defaultdb      NULL         bar       false          schemas      bar       ALL             true
+defaultdb      NULL         bar       false          types        public    USAGE           false
+defaultdb      NULL         foo       false          tables       foo       ALL             true
+defaultdb      NULL         foo       false          sequences    foo       ALL             true
+defaultdb      NULL         foo       false          types        foo       ALL             true
+defaultdb      NULL         foo       false          schemas      foo       ALL             true
+defaultdb      NULL         foo       false          types        public    USAGE           false
+defaultdb      NULL         root      false          tables       root      ALL             true
+defaultdb      NULL         root      false          sequences    root      ALL             true
+defaultdb      NULL         root      false          types        root      ALL             true
+defaultdb      NULL         root      false          schemas      root      ALL             true
+defaultdb      NULL         root      false          types        public    USAGE           false
+defaultdb      NULL         testuser  false          tables       testuser  ALL             true
+defaultdb      NULL         testuser  false          sequences    testuser  ALL             true
+defaultdb      NULL         testuser  false          types        testuser  ALL             true
+defaultdb      NULL         testuser  false          schemas      testuser  ALL             true
+defaultdb      NULL         testuser  false          types        public    USAGE           false
+defaultdb      NULL         NULL      true           types        public    USAGE           false
+postgres       NULL         admin     false          tables       admin     ALL             true
+postgres       NULL         admin     false          sequences    admin     ALL             true
+postgres       NULL         admin     false          types        admin     ALL             true
+postgres       NULL         admin     false          schemas      admin     ALL             true
+postgres       NULL         admin     false          types        public    USAGE           false
+postgres       NULL         bar       false          tables       bar       ALL             true
+postgres       NULL         bar       false          sequences    bar       ALL             true
+postgres       NULL         bar       false          types        bar       ALL             true
+postgres       NULL         bar       false          schemas      bar       ALL             true
+postgres       NULL         bar       false          types        public    USAGE           false
+postgres       NULL         foo       false          tables       foo       ALL             true
+postgres       NULL         foo       false          sequences    foo       ALL             true
+postgres       NULL         foo       false          types        foo       ALL             true
+postgres       NULL         foo       false          schemas      foo       ALL             true
+postgres       NULL         foo       false          types        public    USAGE           false
+postgres       NULL         root      false          tables       root      ALL             true
+postgres       NULL         root      false          sequences    root      ALL             true
+postgres       NULL         root      false          types        root      ALL             true
+postgres       NULL         root      false          schemas      root      ALL             true
+postgres       NULL         root      false          types        public    USAGE           false
+postgres       NULL         testuser  false          tables       testuser  ALL             true
+postgres       NULL         testuser  false          sequences    testuser  ALL             true
+postgres       NULL         testuser  false          types        testuser  ALL             true
+postgres       NULL         testuser  false          schemas      testuser  ALL             true
+postgres       NULL         testuser  false          types        public    USAGE           false
+postgres       NULL         NULL      true           types        public    USAGE           false
+system         NULL         admin     false          tables       admin     ALL             true
+system         NULL         admin     false          sequences    admin     ALL             true
+system         NULL         admin     false          types        admin     ALL             true
+system         NULL         admin     false          schemas      admin     ALL             true
+system         NULL         admin     false          types        public    USAGE           false
+system         NULL         bar       false          tables       bar       ALL             true
+system         NULL         bar       false          sequences    bar       ALL             true
+system         NULL         bar       false          types        bar       ALL             true
+system         NULL         bar       false          schemas      bar       ALL             true
+system         NULL         bar       false          types        public    USAGE           false
+system         NULL         foo       false          tables       foo       ALL             true
+system         NULL         foo       false          sequences    foo       ALL             true
+system         NULL         foo       false          types        foo       ALL             true
+system         NULL         foo       false          schemas      foo       ALL             true
+system         NULL         foo       false          types        public    USAGE           false
+system         NULL         root      false          tables       root      ALL             true
+system         NULL         root      false          sequences    root      ALL             true
+system         NULL         root      false          types        root      ALL             true
+system         NULL         root      false          schemas      root      ALL             true
+system         NULL         root      false          types        public    USAGE           false
+system         NULL         testuser  false          tables       testuser  ALL             true
+system         NULL         testuser  false          sequences    testuser  ALL             true
+system         NULL         testuser  false          types        testuser  ALL             true
+system         NULL         testuser  false          schemas      testuser  ALL             true
+system         NULL         testuser  false          types        public    USAGE           false
+system         NULL         NULL      true           types        public    USAGE           false
+test           NULL         admin     false          tables       admin     ALL             true
+test           NULL         admin     false          sequences    admin     ALL             true
+test           NULL         admin     false          types        admin     ALL             true
+test           NULL         admin     false          schemas      admin     ALL             true
+test           NULL         admin     false          types        public    USAGE           false
+test           NULL         bar       false          types        public    USAGE           false
+test           NULL         foo       false          types        public    USAGE           false
+test           NULL         root      false          tables       bar       CREATE          true
+test           NULL         root      false          tables       bar       DROP            true
+test           NULL         root      false          tables       bar       GRANT           true
+test           NULL         root      false          tables       bar       INSERT          true
+test           NULL         root      false          tables       bar       DELETE          true
+test           NULL         root      false          tables       bar       UPDATE          true
+test           NULL         root      false          tables       bar       ZONECONFIG      true
+test           NULL         root      false          tables       foo       CREATE          true
+test           NULL         root      false          tables       foo       DROP            true
+test           NULL         root      false          tables       foo       GRANT           true
+test           NULL         root      false          tables       foo       INSERT          true
+test           NULL         root      false          tables       foo       DELETE          true
+test           NULL         root      false          tables       foo       UPDATE          true
+test           NULL         root      false          tables       foo       ZONECONFIG      true
+test           NULL         root      false          tables       root      ALL             true
+test           NULL         root      false          sequences    root      ALL             true
+test           NULL         root      false          types        root      ALL             true
+test           NULL         root      false          schemas      root      ALL             true
+test           NULL         testuser  false          tables       testuser  ALL             true
+test           NULL         testuser  false          sequences    testuser  ALL             true
+test           NULL         testuser  false          types        testuser  ALL             true
+test           NULL         testuser  false          schemas      testuser  ALL             true
+test           NULL         testuser  false          types        public    USAGE           false
+test           NULL         NULL      true           types        public    USAGE           false
 
 statement ok
 ALTER DEFAULT PRIVILEGES REVOKE ALL ON TABLES FROM foo, bar, public;
 ALTER DEFAULT PRIVILEGES GRANT GRANT, DROP, ZONECONFIG ON TABLES TO foo;
 
-query TTTBTTT colnames,rowsort
+query TTTBTTTB colnames,rowsort
 SELECT * FROM crdb_internal.default_privileges
 ----
-database_name  schema_name  role      for_all_roles  object_type  grantee   privilege_type
-defaultdb      NULL         admin     false          tables       admin     ALL
-defaultdb      NULL         admin     false          sequences    admin     ALL
-defaultdb      NULL         admin     false          types        admin     ALL
-defaultdb      NULL         admin     false          schemas      admin     ALL
-defaultdb      NULL         admin     false          types        public    USAGE
-defaultdb      NULL         bar       false          tables       bar       ALL
-defaultdb      NULL         bar       false          sequences    bar       ALL
-defaultdb      NULL         bar       false          types        bar       ALL
-defaultdb      NULL         bar       false          schemas      bar       ALL
-defaultdb      NULL         bar       false          types        public    USAGE
-defaultdb      NULL         foo       false          tables       foo       ALL
-defaultdb      NULL         foo       false          sequences    foo       ALL
-defaultdb      NULL         foo       false          types        foo       ALL
-defaultdb      NULL         foo       false          schemas      foo       ALL
-defaultdb      NULL         foo       false          types        public    USAGE
-defaultdb      NULL         root      false          tables       root      ALL
-defaultdb      NULL         root      false          sequences    root      ALL
-defaultdb      NULL         root      false          types        root      ALL
-defaultdb      NULL         root      false          schemas      root      ALL
-defaultdb      NULL         root      false          types        public    USAGE
-defaultdb      NULL         testuser  false          tables       testuser  ALL
-defaultdb      NULL         testuser  false          sequences    testuser  ALL
-defaultdb      NULL         testuser  false          types        testuser  ALL
-defaultdb      NULL         testuser  false          schemas      testuser  ALL
-defaultdb      NULL         testuser  false          types        public    USAGE
-defaultdb      NULL         NULL      true           types        public    USAGE
-postgres       NULL         admin     false          tables       admin     ALL
-postgres       NULL         admin     false          sequences    admin     ALL
-postgres       NULL         admin     false          types        admin     ALL
-postgres       NULL         admin     false          schemas      admin     ALL
-postgres       NULL         admin     false          types        public    USAGE
-postgres       NULL         bar       false          tables       bar       ALL
-postgres       NULL         bar       false          sequences    bar       ALL
-postgres       NULL         bar       false          types        bar       ALL
-postgres       NULL         bar       false          schemas      bar       ALL
-postgres       NULL         bar       false          types        public    USAGE
-postgres       NULL         foo       false          tables       foo       ALL
-postgres       NULL         foo       false          sequences    foo       ALL
-postgres       NULL         foo       false          types        foo       ALL
-postgres       NULL         foo       false          schemas      foo       ALL
-postgres       NULL         foo       false          types        public    USAGE
-postgres       NULL         root      false          tables       root      ALL
-postgres       NULL         root      false          sequences    root      ALL
-postgres       NULL         root      false          types        root      ALL
-postgres       NULL         root      false          schemas      root      ALL
-postgres       NULL         root      false          types        public    USAGE
-postgres       NULL         testuser  false          tables       testuser  ALL
-postgres       NULL         testuser  false          sequences    testuser  ALL
-postgres       NULL         testuser  false          types        testuser  ALL
-postgres       NULL         testuser  false          schemas      testuser  ALL
-postgres       NULL         testuser  false          types        public    USAGE
-postgres       NULL         NULL      true           types        public    USAGE
-system         NULL         admin     false          tables       admin     ALL
-system         NULL         admin     false          sequences    admin     ALL
-system         NULL         admin     false          types        admin     ALL
-system         NULL         admin     false          schemas      admin     ALL
-system         NULL         admin     false          types        public    USAGE
-system         NULL         bar       false          tables       bar       ALL
-system         NULL         bar       false          sequences    bar       ALL
-system         NULL         bar       false          types        bar       ALL
-system         NULL         bar       false          schemas      bar       ALL
-system         NULL         bar       false          types        public    USAGE
-system         NULL         foo       false          tables       foo       ALL
-system         NULL         foo       false          sequences    foo       ALL
-system         NULL         foo       false          types        foo       ALL
-system         NULL         foo       false          schemas      foo       ALL
-system         NULL         foo       false          types        public    USAGE
-system         NULL         root      false          tables       root      ALL
-system         NULL         root      false          sequences    root      ALL
-system         NULL         root      false          types        root      ALL
-system         NULL         root      false          schemas      root      ALL
-system         NULL         root      false          types        public    USAGE
-system         NULL         testuser  false          tables       testuser  ALL
-system         NULL         testuser  false          sequences    testuser  ALL
-system         NULL         testuser  false          types        testuser  ALL
-system         NULL         testuser  false          schemas      testuser  ALL
-system         NULL         testuser  false          types        public    USAGE
-system         NULL         NULL      true           types        public    USAGE
-test           NULL         admin     false          tables       admin     ALL
-test           NULL         admin     false          sequences    admin     ALL
-test           NULL         admin     false          types        admin     ALL
-test           NULL         admin     false          schemas      admin     ALL
-test           NULL         admin     false          types        public    USAGE
-test           NULL         bar       false          types        public    USAGE
-test           NULL         foo       false          types        public    USAGE
-test           NULL         root      false          tables       foo       DROP
-test           NULL         root      false          tables       foo       GRANT
-test           NULL         root      false          tables       foo       ZONECONFIG
-test           NULL         root      false          tables       root      ALL
-test           NULL         root      false          sequences    root      ALL
-test           NULL         root      false          types        root      ALL
-test           NULL         root      false          schemas      root      ALL
-test           NULL         testuser  false          tables       testuser  ALL
-test           NULL         testuser  false          sequences    testuser  ALL
-test           NULL         testuser  false          types        testuser  ALL
-test           NULL         testuser  false          schemas      testuser  ALL
-test           NULL         testuser  false          types        public    USAGE
-test           NULL         NULL      true           types        public    USAGE
+database_name  schema_name  role      for_all_roles  object_type  grantee   privilege_type  is_grantable
+defaultdb      NULL         admin     false          tables       admin     ALL             true
+defaultdb      NULL         admin     false          sequences    admin     ALL             true
+defaultdb      NULL         admin     false          types        admin     ALL             true
+defaultdb      NULL         admin     false          schemas      admin     ALL             true
+defaultdb      NULL         admin     false          types        public    USAGE           false
+defaultdb      NULL         bar       false          tables       bar       ALL             true
+defaultdb      NULL         bar       false          sequences    bar       ALL             true
+defaultdb      NULL         bar       false          types        bar       ALL             true
+defaultdb      NULL         bar       false          schemas      bar       ALL             true
+defaultdb      NULL         bar       false          types        public    USAGE           false
+defaultdb      NULL         foo       false          tables       foo       ALL             true
+defaultdb      NULL         foo       false          sequences    foo       ALL             true
+defaultdb      NULL         foo       false          types        foo       ALL             true
+defaultdb      NULL         foo       false          schemas      foo       ALL             true
+defaultdb      NULL         foo       false          types        public    USAGE           false
+defaultdb      NULL         root      false          tables       root      ALL             true
+defaultdb      NULL         root      false          sequences    root      ALL             true
+defaultdb      NULL         root      false          types        root      ALL             true
+defaultdb      NULL         root      false          schemas      root      ALL             true
+defaultdb      NULL         root      false          types        public    USAGE           false
+defaultdb      NULL         testuser  false          tables       testuser  ALL             true
+defaultdb      NULL         testuser  false          sequences    testuser  ALL             true
+defaultdb      NULL         testuser  false          types        testuser  ALL             true
+defaultdb      NULL         testuser  false          schemas      testuser  ALL             true
+defaultdb      NULL         testuser  false          types        public    USAGE           false
+defaultdb      NULL         NULL      true           types        public    USAGE           false
+postgres       NULL         admin     false          tables       admin     ALL             true
+postgres       NULL         admin     false          sequences    admin     ALL             true
+postgres       NULL         admin     false          types        admin     ALL             true
+postgres       NULL         admin     false          schemas      admin     ALL             true
+postgres       NULL         admin     false          types        public    USAGE           false
+postgres       NULL         bar       false          tables       bar       ALL             true
+postgres       NULL         bar       false          sequences    bar       ALL             true
+postgres       NULL         bar       false          types        bar       ALL             true
+postgres       NULL         bar       false          schemas      bar       ALL             true
+postgres       NULL         bar       false          types        public    USAGE           false
+postgres       NULL         foo       false          tables       foo       ALL             true
+postgres       NULL         foo       false          sequences    foo       ALL             true
+postgres       NULL         foo       false          types        foo       ALL             true
+postgres       NULL         foo       false          schemas      foo       ALL             true
+postgres       NULL         foo       false          types        public    USAGE           false
+postgres       NULL         root      false          tables       root      ALL             true
+postgres       NULL         root      false          sequences    root      ALL             true
+postgres       NULL         root      false          types        root      ALL             true
+postgres       NULL         root      false          schemas      root      ALL             true
+postgres       NULL         root      false          types        public    USAGE           false
+postgres       NULL         testuser  false          tables       testuser  ALL             true
+postgres       NULL         testuser  false          sequences    testuser  ALL             true
+postgres       NULL         testuser  false          types        testuser  ALL             true
+postgres       NULL         testuser  false          schemas      testuser  ALL             true
+postgres       NULL         testuser  false          types        public    USAGE           false
+postgres       NULL         NULL      true           types        public    USAGE           false
+system         NULL         admin     false          tables       admin     ALL             true
+system         NULL         admin     false          sequences    admin     ALL             true
+system         NULL         admin     false          types        admin     ALL             true
+system         NULL         admin     false          schemas      admin     ALL             true
+system         NULL         admin     false          types        public    USAGE           false
+system         NULL         bar       false          tables       bar       ALL             true
+system         NULL         bar       false          sequences    bar       ALL             true
+system         NULL         bar       false          types        bar       ALL             true
+system         NULL         bar       false          schemas      bar       ALL             true
+system         NULL         bar       false          types        public    USAGE           false
+system         NULL         foo       false          tables       foo       ALL             true
+system         NULL         foo       false          sequences    foo       ALL             true
+system         NULL         foo       false          types        foo       ALL             true
+system         NULL         foo       false          schemas      foo       ALL             true
+system         NULL         foo       false          types        public    USAGE           false
+system         NULL         root      false          tables       root      ALL             true
+system         NULL         root      false          sequences    root      ALL             true
+system         NULL         root      false          types        root      ALL             true
+system         NULL         root      false          schemas      root      ALL             true
+system         NULL         root      false          types        public    USAGE           false
+system         NULL         testuser  false          tables       testuser  ALL             true
+system         NULL         testuser  false          sequences    testuser  ALL             true
+system         NULL         testuser  false          types        testuser  ALL             true
+system         NULL         testuser  false          schemas      testuser  ALL             true
+system         NULL         testuser  false          types        public    USAGE           false
+system         NULL         NULL      true           types        public    USAGE           false
+test           NULL         admin     false          tables       admin     ALL             true
+test           NULL         admin     false          sequences    admin     ALL             true
+test           NULL         admin     false          types        admin     ALL             true
+test           NULL         admin     false          schemas      admin     ALL             true
+test           NULL         admin     false          types        public    USAGE           false
+test           NULL         bar       false          types        public    USAGE           false
+test           NULL         foo       false          types        public    USAGE           false
+test           NULL         root      false          tables       foo       DROP            true
+test           NULL         root      false          tables       foo       GRANT           true
+test           NULL         root      false          tables       foo       ZONECONFIG      true
+test           NULL         root      false          tables       root      ALL             true
+test           NULL         root      false          sequences    root      ALL             true
+test           NULL         root      false          types        root      ALL             true
+test           NULL         root      false          schemas      root      ALL             true
+test           NULL         testuser  false          tables       testuser  ALL             true
+test           NULL         testuser  false          sequences    testuser  ALL             true
+test           NULL         testuser  false          types        testuser  ALL             true
+test           NULL         testuser  false          schemas      testuser  ALL             true
+test           NULL         testuser  false          types        public    USAGE           false
+test           NULL         NULL      true           types        public    USAGE           false
 
 # Create a second database.
 statement ok
@@ -548,270 +548,270 @@ use test2;
 statement ok
 ALTER DEFAULT PRIVILEGES GRANT GRANT, DROP, ZONECONFIG ON TABLES TO foo;
 
-query TTTBTTT colnames,rowsort
+query TTTBTTTB colnames,rowsort
 SELECT * FROM crdb_internal.default_privileges
 ----
-database_name  schema_name  role      for_all_roles  object_type  grantee   privilege_type
-defaultdb      NULL         admin     false          tables       admin     ALL
-defaultdb      NULL         admin     false          sequences    admin     ALL
-defaultdb      NULL         admin     false          types        admin     ALL
-defaultdb      NULL         admin     false          schemas      admin     ALL
-defaultdb      NULL         admin     false          types        public    USAGE
-defaultdb      NULL         bar       false          tables       bar       ALL
-defaultdb      NULL         bar       false          sequences    bar       ALL
-defaultdb      NULL         bar       false          types        bar       ALL
-defaultdb      NULL         bar       false          schemas      bar       ALL
-defaultdb      NULL         bar       false          types        public    USAGE
-defaultdb      NULL         foo       false          tables       foo       ALL
-defaultdb      NULL         foo       false          sequences    foo       ALL
-defaultdb      NULL         foo       false          types        foo       ALL
-defaultdb      NULL         foo       false          schemas      foo       ALL
-defaultdb      NULL         foo       false          types        public    USAGE
-defaultdb      NULL         root      false          tables       root      ALL
-defaultdb      NULL         root      false          sequences    root      ALL
-defaultdb      NULL         root      false          types        root      ALL
-defaultdb      NULL         root      false          schemas      root      ALL
-defaultdb      NULL         root      false          types        public    USAGE
-defaultdb      NULL         testuser  false          tables       testuser  ALL
-defaultdb      NULL         testuser  false          sequences    testuser  ALL
-defaultdb      NULL         testuser  false          types        testuser  ALL
-defaultdb      NULL         testuser  false          schemas      testuser  ALL
-defaultdb      NULL         testuser  false          types        public    USAGE
-defaultdb      NULL         NULL      true           types        public    USAGE
-postgres       NULL         admin     false          tables       admin     ALL
-postgres       NULL         admin     false          sequences    admin     ALL
-postgres       NULL         admin     false          types        admin     ALL
-postgres       NULL         admin     false          schemas      admin     ALL
-postgres       NULL         admin     false          types        public    USAGE
-postgres       NULL         bar       false          tables       bar       ALL
-postgres       NULL         bar       false          sequences    bar       ALL
-postgres       NULL         bar       false          types        bar       ALL
-postgres       NULL         bar       false          schemas      bar       ALL
-postgres       NULL         bar       false          types        public    USAGE
-postgres       NULL         foo       false          tables       foo       ALL
-postgres       NULL         foo       false          sequences    foo       ALL
-postgres       NULL         foo       false          types        foo       ALL
-postgres       NULL         foo       false          schemas      foo       ALL
-postgres       NULL         foo       false          types        public    USAGE
-postgres       NULL         root      false          tables       root      ALL
-postgres       NULL         root      false          sequences    root      ALL
-postgres       NULL         root      false          types        root      ALL
-postgres       NULL         root      false          schemas      root      ALL
-postgres       NULL         root      false          types        public    USAGE
-postgres       NULL         testuser  false          tables       testuser  ALL
-postgres       NULL         testuser  false          sequences    testuser  ALL
-postgres       NULL         testuser  false          types        testuser  ALL
-postgres       NULL         testuser  false          schemas      testuser  ALL
-postgres       NULL         testuser  false          types        public    USAGE
-postgres       NULL         NULL      true           types        public    USAGE
-system         NULL         admin     false          tables       admin     ALL
-system         NULL         admin     false          sequences    admin     ALL
-system         NULL         admin     false          types        admin     ALL
-system         NULL         admin     false          schemas      admin     ALL
-system         NULL         admin     false          types        public    USAGE
-system         NULL         bar       false          tables       bar       ALL
-system         NULL         bar       false          sequences    bar       ALL
-system         NULL         bar       false          types        bar       ALL
-system         NULL         bar       false          schemas      bar       ALL
-system         NULL         bar       false          types        public    USAGE
-system         NULL         foo       false          tables       foo       ALL
-system         NULL         foo       false          sequences    foo       ALL
-system         NULL         foo       false          types        foo       ALL
-system         NULL         foo       false          schemas      foo       ALL
-system         NULL         foo       false          types        public    USAGE
-system         NULL         root      false          tables       root      ALL
-system         NULL         root      false          sequences    root      ALL
-system         NULL         root      false          types        root      ALL
-system         NULL         root      false          schemas      root      ALL
-system         NULL         root      false          types        public    USAGE
-system         NULL         testuser  false          tables       testuser  ALL
-system         NULL         testuser  false          sequences    testuser  ALL
-system         NULL         testuser  false          types        testuser  ALL
-system         NULL         testuser  false          schemas      testuser  ALL
-system         NULL         testuser  false          types        public    USAGE
-system         NULL         NULL      true           types        public    USAGE
-test           NULL         admin     false          tables       admin     ALL
-test           NULL         admin     false          sequences    admin     ALL
-test           NULL         admin     false          types        admin     ALL
-test           NULL         admin     false          schemas      admin     ALL
-test           NULL         admin     false          types        public    USAGE
-test           NULL         bar       false          types        public    USAGE
-test           NULL         foo       false          types        public    USAGE
-test           NULL         root      false          tables       foo       DROP
-test           NULL         root      false          tables       foo       GRANT
-test           NULL         root      false          tables       foo       ZONECONFIG
-test           NULL         root      false          tables       root      ALL
-test           NULL         root      false          sequences    root      ALL
-test           NULL         root      false          types        root      ALL
-test           NULL         root      false          schemas      root      ALL
-test           NULL         testuser  false          tables       testuser  ALL
-test           NULL         testuser  false          sequences    testuser  ALL
-test           NULL         testuser  false          types        testuser  ALL
-test           NULL         testuser  false          schemas      testuser  ALL
-test           NULL         testuser  false          types        public    USAGE
-test           NULL         NULL      true           types        public    USAGE
-test2          NULL         admin     false          tables       admin     ALL
-test2          NULL         admin     false          sequences    admin     ALL
-test2          NULL         admin     false          types        admin     ALL
-test2          NULL         admin     false          schemas      admin     ALL
-test2          NULL         admin     false          types        public    USAGE
-test2          NULL         bar       false          tables       bar       ALL
-test2          NULL         bar       false          sequences    bar       ALL
-test2          NULL         bar       false          types        bar       ALL
-test2          NULL         bar       false          schemas      bar       ALL
-test2          NULL         bar       false          types        public    USAGE
-test2          NULL         foo       false          tables       foo       ALL
-test2          NULL         foo       false          sequences    foo       ALL
-test2          NULL         foo       false          types        foo       ALL
-test2          NULL         foo       false          schemas      foo       ALL
-test2          NULL         foo       false          types        public    USAGE
-test2          NULL         root      false          tables       foo       DROP
-test2          NULL         root      false          tables       foo       GRANT
-test2          NULL         root      false          tables       foo       ZONECONFIG
-test2          NULL         root      false          tables       root      ALL
-test2          NULL         root      false          sequences    root      ALL
-test2          NULL         root      false          types        root      ALL
-test2          NULL         root      false          schemas      root      ALL
-test2          NULL         root      false          types        public    USAGE
-test2          NULL         testuser  false          tables       testuser  ALL
-test2          NULL         testuser  false          sequences    testuser  ALL
-test2          NULL         testuser  false          types        testuser  ALL
-test2          NULL         testuser  false          schemas      testuser  ALL
-test2          NULL         testuser  false          types        public    USAGE
-test2          NULL         NULL      true           types        public    USAGE
+database_name  schema_name  role      for_all_roles  object_type  grantee   privilege_type  is_grantable
+defaultdb      NULL         admin     false          tables       admin     ALL             true
+defaultdb      NULL         admin     false          sequences    admin     ALL             true
+defaultdb      NULL         admin     false          types        admin     ALL             true
+defaultdb      NULL         admin     false          schemas      admin     ALL             true
+defaultdb      NULL         admin     false          types        public    USAGE           false
+defaultdb      NULL         bar       false          tables       bar       ALL             true
+defaultdb      NULL         bar       false          sequences    bar       ALL             true
+defaultdb      NULL         bar       false          types        bar       ALL             true
+defaultdb      NULL         bar       false          schemas      bar       ALL             true
+defaultdb      NULL         bar       false          types        public    USAGE           false
+defaultdb      NULL         foo       false          tables       foo       ALL             true
+defaultdb      NULL         foo       false          sequences    foo       ALL             true
+defaultdb      NULL         foo       false          types        foo       ALL             true
+defaultdb      NULL         foo       false          schemas      foo       ALL             true
+defaultdb      NULL         foo       false          types        public    USAGE           false
+defaultdb      NULL         root      false          tables       root      ALL             true
+defaultdb      NULL         root      false          sequences    root      ALL             true
+defaultdb      NULL         root      false          types        root      ALL             true
+defaultdb      NULL         root      false          schemas      root      ALL             true
+defaultdb      NULL         root      false          types        public    USAGE           false
+defaultdb      NULL         testuser  false          tables       testuser  ALL             true
+defaultdb      NULL         testuser  false          sequences    testuser  ALL             true
+defaultdb      NULL         testuser  false          types        testuser  ALL             true
+defaultdb      NULL         testuser  false          schemas      testuser  ALL             true
+defaultdb      NULL         testuser  false          types        public    USAGE           false
+defaultdb      NULL         NULL      true           types        public    USAGE           false
+postgres       NULL         admin     false          tables       admin     ALL             true
+postgres       NULL         admin     false          sequences    admin     ALL             true
+postgres       NULL         admin     false          types        admin     ALL             true
+postgres       NULL         admin     false          schemas      admin     ALL             true
+postgres       NULL         admin     false          types        public    USAGE           false
+postgres       NULL         bar       false          tables       bar       ALL             true
+postgres       NULL         bar       false          sequences    bar       ALL             true
+postgres       NULL         bar       false          types        bar       ALL             true
+postgres       NULL         bar       false          schemas      bar       ALL             true
+postgres       NULL         bar       false          types        public    USAGE           false
+postgres       NULL         foo       false          tables       foo       ALL             true
+postgres       NULL         foo       false          sequences    foo       ALL             true
+postgres       NULL         foo       false          types        foo       ALL             true
+postgres       NULL         foo       false          schemas      foo       ALL             true
+postgres       NULL         foo       false          types        public    USAGE           false
+postgres       NULL         root      false          tables       root      ALL             true
+postgres       NULL         root      false          sequences    root      ALL             true
+postgres       NULL         root      false          types        root      ALL             true
+postgres       NULL         root      false          schemas      root      ALL             true
+postgres       NULL         root      false          types        public    USAGE           false
+postgres       NULL         testuser  false          tables       testuser  ALL             true
+postgres       NULL         testuser  false          sequences    testuser  ALL             true
+postgres       NULL         testuser  false          types        testuser  ALL             true
+postgres       NULL         testuser  false          schemas      testuser  ALL             true
+postgres       NULL         testuser  false          types        public    USAGE           false
+postgres       NULL         NULL      true           types        public    USAGE           false
+system         NULL         admin     false          tables       admin     ALL             true
+system         NULL         admin     false          sequences    admin     ALL             true
+system         NULL         admin     false          types        admin     ALL             true
+system         NULL         admin     false          schemas      admin     ALL             true
+system         NULL         admin     false          types        public    USAGE           false
+system         NULL         bar       false          tables       bar       ALL             true
+system         NULL         bar       false          sequences    bar       ALL             true
+system         NULL         bar       false          types        bar       ALL             true
+system         NULL         bar       false          schemas      bar       ALL             true
+system         NULL         bar       false          types        public    USAGE           false
+system         NULL         foo       false          tables       foo       ALL             true
+system         NULL         foo       false          sequences    foo       ALL             true
+system         NULL         foo       false          types        foo       ALL             true
+system         NULL         foo       false          schemas      foo       ALL             true
+system         NULL         foo       false          types        public    USAGE           false
+system         NULL         root      false          tables       root      ALL             true
+system         NULL         root      false          sequences    root      ALL             true
+system         NULL         root      false          types        root      ALL             true
+system         NULL         root      false          schemas      root      ALL             true
+system         NULL         root      false          types        public    USAGE           false
+system         NULL         testuser  false          tables       testuser  ALL             true
+system         NULL         testuser  false          sequences    testuser  ALL             true
+system         NULL         testuser  false          types        testuser  ALL             true
+system         NULL         testuser  false          schemas      testuser  ALL             true
+system         NULL         testuser  false          types        public    USAGE           false
+system         NULL         NULL      true           types        public    USAGE           false
+test           NULL         admin     false          tables       admin     ALL             true
+test           NULL         admin     false          sequences    admin     ALL             true
+test           NULL         admin     false          types        admin     ALL             true
+test           NULL         admin     false          schemas      admin     ALL             true
+test           NULL         admin     false          types        public    USAGE           false
+test           NULL         bar       false          types        public    USAGE           false
+test           NULL         foo       false          types        public    USAGE           false
+test           NULL         root      false          tables       foo       DROP            true
+test           NULL         root      false          tables       foo       GRANT           true
+test           NULL         root      false          tables       foo       ZONECONFIG      true
+test           NULL         root      false          tables       root      ALL             true
+test           NULL         root      false          sequences    root      ALL             true
+test           NULL         root      false          types        root      ALL             true
+test           NULL         root      false          schemas      root      ALL             true
+test           NULL         testuser  false          tables       testuser  ALL             true
+test           NULL         testuser  false          sequences    testuser  ALL             true
+test           NULL         testuser  false          types        testuser  ALL             true
+test           NULL         testuser  false          schemas      testuser  ALL             true
+test           NULL         testuser  false          types        public    USAGE           false
+test           NULL         NULL      true           types        public    USAGE           false
+test2          NULL         admin     false          tables       admin     ALL             true
+test2          NULL         admin     false          sequences    admin     ALL             true
+test2          NULL         admin     false          types        admin     ALL             true
+test2          NULL         admin     false          schemas      admin     ALL             true
+test2          NULL         admin     false          types        public    USAGE           false
+test2          NULL         bar       false          tables       bar       ALL             true
+test2          NULL         bar       false          sequences    bar       ALL             true
+test2          NULL         bar       false          types        bar       ALL             true
+test2          NULL         bar       false          schemas      bar       ALL             true
+test2          NULL         bar       false          types        public    USAGE           false
+test2          NULL         foo       false          tables       foo       ALL             true
+test2          NULL         foo       false          sequences    foo       ALL             true
+test2          NULL         foo       false          types        foo       ALL             true
+test2          NULL         foo       false          schemas      foo       ALL             true
+test2          NULL         foo       false          types        public    USAGE           false
+test2          NULL         root      false          tables       foo       DROP            true
+test2          NULL         root      false          tables       foo       GRANT           true
+test2          NULL         root      false          tables       foo       ZONECONFIG      true
+test2          NULL         root      false          tables       root      ALL             true
+test2          NULL         root      false          sequences    root      ALL             true
+test2          NULL         root      false          types        root      ALL             true
+test2          NULL         root      false          schemas      root      ALL             true
+test2          NULL         root      false          types        public    USAGE           false
+test2          NULL         testuser  false          tables       testuser  ALL             true
+test2          NULL         testuser  false          sequences    testuser  ALL             true
+test2          NULL         testuser  false          types        testuser  ALL             true
+test2          NULL         testuser  false          schemas      testuser  ALL             true
+test2          NULL         testuser  false          types        public    USAGE           false
+test2          NULL         NULL      true           types        public    USAGE           false
 
 statement ok
 ALTER DEFAULT PRIVILEGES FOR ALL ROLES GRANT SELECT ON TABLES TO foo;
 
-query TTTBTTT colnames,rowsort
+query TTTBTTTB colnames,rowsort
 SELECT * FROM crdb_internal.default_privileges
 ----
-database_name  schema_name  role      for_all_roles  object_type  grantee   privilege_type
-defaultdb      NULL         admin     false          tables       admin     ALL
-defaultdb      NULL         admin     false          sequences    admin     ALL
-defaultdb      NULL         admin     false          types        admin     ALL
-defaultdb      NULL         admin     false          schemas      admin     ALL
-defaultdb      NULL         admin     false          types        public    USAGE
-defaultdb      NULL         bar       false          tables       bar       ALL
-defaultdb      NULL         bar       false          sequences    bar       ALL
-defaultdb      NULL         bar       false          types        bar       ALL
-defaultdb      NULL         bar       false          schemas      bar       ALL
-defaultdb      NULL         bar       false          types        public    USAGE
-defaultdb      NULL         foo       false          tables       foo       ALL
-defaultdb      NULL         foo       false          sequences    foo       ALL
-defaultdb      NULL         foo       false          types        foo       ALL
-defaultdb      NULL         foo       false          schemas      foo       ALL
-defaultdb      NULL         foo       false          types        public    USAGE
-defaultdb      NULL         root      false          tables       root      ALL
-defaultdb      NULL         root      false          sequences    root      ALL
-defaultdb      NULL         root      false          types        root      ALL
-defaultdb      NULL         root      false          schemas      root      ALL
-defaultdb      NULL         root      false          types        public    USAGE
-defaultdb      NULL         testuser  false          tables       testuser  ALL
-defaultdb      NULL         testuser  false          sequences    testuser  ALL
-defaultdb      NULL         testuser  false          types        testuser  ALL
-defaultdb      NULL         testuser  false          schemas      testuser  ALL
-defaultdb      NULL         testuser  false          types        public    USAGE
-defaultdb      NULL         NULL      true           types        public    USAGE
-postgres       NULL         admin     false          tables       admin     ALL
-postgres       NULL         admin     false          sequences    admin     ALL
-postgres       NULL         admin     false          types        admin     ALL
-postgres       NULL         admin     false          schemas      admin     ALL
-postgres       NULL         admin     false          types        public    USAGE
-postgres       NULL         bar       false          tables       bar       ALL
-postgres       NULL         bar       false          sequences    bar       ALL
-postgres       NULL         bar       false          types        bar       ALL
-postgres       NULL         bar       false          schemas      bar       ALL
-postgres       NULL         bar       false          types        public    USAGE
-postgres       NULL         foo       false          tables       foo       ALL
-postgres       NULL         foo       false          sequences    foo       ALL
-postgres       NULL         foo       false          types        foo       ALL
-postgres       NULL         foo       false          schemas      foo       ALL
-postgres       NULL         foo       false          types        public    USAGE
-postgres       NULL         root      false          tables       root      ALL
-postgres       NULL         root      false          sequences    root      ALL
-postgres       NULL         root      false          types        root      ALL
-postgres       NULL         root      false          schemas      root      ALL
-postgres       NULL         root      false          types        public    USAGE
-postgres       NULL         testuser  false          tables       testuser  ALL
-postgres       NULL         testuser  false          sequences    testuser  ALL
-postgres       NULL         testuser  false          types        testuser  ALL
-postgres       NULL         testuser  false          schemas      testuser  ALL
-postgres       NULL         testuser  false          types        public    USAGE
-postgres       NULL         NULL      true           types        public    USAGE
-system         NULL         admin     false          tables       admin     ALL
-system         NULL         admin     false          sequences    admin     ALL
-system         NULL         admin     false          types        admin     ALL
-system         NULL         admin     false          schemas      admin     ALL
-system         NULL         admin     false          types        public    USAGE
-system         NULL         bar       false          tables       bar       ALL
-system         NULL         bar       false          sequences    bar       ALL
-system         NULL         bar       false          types        bar       ALL
-system         NULL         bar       false          schemas      bar       ALL
-system         NULL         bar       false          types        public    USAGE
-system         NULL         foo       false          tables       foo       ALL
-system         NULL         foo       false          sequences    foo       ALL
-system         NULL         foo       false          types        foo       ALL
-system         NULL         foo       false          schemas      foo       ALL
-system         NULL         foo       false          types        public    USAGE
-system         NULL         root      false          tables       root      ALL
-system         NULL         root      false          sequences    root      ALL
-system         NULL         root      false          types        root      ALL
-system         NULL         root      false          schemas      root      ALL
-system         NULL         root      false          types        public    USAGE
-system         NULL         testuser  false          tables       testuser  ALL
-system         NULL         testuser  false          sequences    testuser  ALL
-system         NULL         testuser  false          types        testuser  ALL
-system         NULL         testuser  false          schemas      testuser  ALL
-system         NULL         testuser  false          types        public    USAGE
-system         NULL         NULL      true           types        public    USAGE
-test           NULL         admin     false          tables       admin     ALL
-test           NULL         admin     false          sequences    admin     ALL
-test           NULL         admin     false          types        admin     ALL
-test           NULL         admin     false          schemas      admin     ALL
-test           NULL         admin     false          types        public    USAGE
-test           NULL         bar       false          types        public    USAGE
-test           NULL         foo       false          types        public    USAGE
-test           NULL         root      false          tables       foo       DROP
-test           NULL         root      false          tables       foo       GRANT
-test           NULL         root      false          tables       foo       ZONECONFIG
-test           NULL         root      false          tables       root      ALL
-test           NULL         root      false          sequences    root      ALL
-test           NULL         root      false          types        root      ALL
-test           NULL         root      false          schemas      root      ALL
-test           NULL         testuser  false          tables       testuser  ALL
-test           NULL         testuser  false          sequences    testuser  ALL
-test           NULL         testuser  false          types        testuser  ALL
-test           NULL         testuser  false          schemas      testuser  ALL
-test           NULL         testuser  false          types        public    USAGE
-test           NULL         NULL      true           types        public    USAGE
-test2          NULL         admin     false          tables       admin     ALL
-test2          NULL         admin     false          sequences    admin     ALL
-test2          NULL         admin     false          types        admin     ALL
-test2          NULL         admin     false          schemas      admin     ALL
-test2          NULL         admin     false          types        public    USAGE
-test2          NULL         bar       false          tables       bar       ALL
-test2          NULL         bar       false          sequences    bar       ALL
-test2          NULL         bar       false          types        bar       ALL
-test2          NULL         bar       false          schemas      bar       ALL
-test2          NULL         bar       false          types        public    USAGE
-test2          NULL         foo       false          tables       foo       ALL
-test2          NULL         foo       false          sequences    foo       ALL
-test2          NULL         foo       false          types        foo       ALL
-test2          NULL         foo       false          schemas      foo       ALL
-test2          NULL         foo       false          types        public    USAGE
-test2          NULL         root      false          tables       foo       DROP
-test2          NULL         root      false          tables       foo       GRANT
-test2          NULL         root      false          tables       foo       ZONECONFIG
-test2          NULL         root      false          tables       root      ALL
-test2          NULL         root      false          sequences    root      ALL
-test2          NULL         root      false          types        root      ALL
-test2          NULL         root      false          schemas      root      ALL
-test2          NULL         root      false          types        public    USAGE
-test2          NULL         testuser  false          tables       testuser  ALL
-test2          NULL         testuser  false          sequences    testuser  ALL
-test2          NULL         testuser  false          types        testuser  ALL
-test2          NULL         testuser  false          schemas      testuser  ALL
-test2          NULL         testuser  false          types        public    USAGE
-test2          NULL         NULL      true           tables       foo       SELECT
-test2          NULL         NULL      true           types        public    USAGE
+database_name  schema_name  role      for_all_roles  object_type  grantee   privilege_type  is_grantable
+defaultdb      NULL         admin     false          tables       admin     ALL             true
+defaultdb      NULL         admin     false          sequences    admin     ALL             true
+defaultdb      NULL         admin     false          types        admin     ALL             true
+defaultdb      NULL         admin     false          schemas      admin     ALL             true
+defaultdb      NULL         admin     false          types        public    USAGE           false
+defaultdb      NULL         bar       false          tables       bar       ALL             true
+defaultdb      NULL         bar       false          sequences    bar       ALL             true
+defaultdb      NULL         bar       false          types        bar       ALL             true
+defaultdb      NULL         bar       false          schemas      bar       ALL             true
+defaultdb      NULL         bar       false          types        public    USAGE           false
+defaultdb      NULL         foo       false          tables       foo       ALL             true
+defaultdb      NULL         foo       false          sequences    foo       ALL             true
+defaultdb      NULL         foo       false          types        foo       ALL             true
+defaultdb      NULL         foo       false          schemas      foo       ALL             true
+defaultdb      NULL         foo       false          types        public    USAGE           false
+defaultdb      NULL         root      false          tables       root      ALL             true
+defaultdb      NULL         root      false          sequences    root      ALL             true
+defaultdb      NULL         root      false          types        root      ALL             true
+defaultdb      NULL         root      false          schemas      root      ALL             true
+defaultdb      NULL         root      false          types        public    USAGE           false
+defaultdb      NULL         testuser  false          tables       testuser  ALL             true
+defaultdb      NULL         testuser  false          sequences    testuser  ALL             true
+defaultdb      NULL         testuser  false          types        testuser  ALL             true
+defaultdb      NULL         testuser  false          schemas      testuser  ALL             true
+defaultdb      NULL         testuser  false          types        public    USAGE           false
+defaultdb      NULL         NULL      true           types        public    USAGE           false
+postgres       NULL         admin     false          tables       admin     ALL             true
+postgres       NULL         admin     false          sequences    admin     ALL             true
+postgres       NULL         admin     false          types        admin     ALL             true
+postgres       NULL         admin     false          schemas      admin     ALL             true
+postgres       NULL         admin     false          types        public    USAGE           false
+postgres       NULL         bar       false          tables       bar       ALL             true
+postgres       NULL         bar       false          sequences    bar       ALL             true
+postgres       NULL         bar       false          types        bar       ALL             true
+postgres       NULL         bar       false          schemas      bar       ALL             true
+postgres       NULL         bar       false          types        public    USAGE           false
+postgres       NULL         foo       false          tables       foo       ALL             true
+postgres       NULL         foo       false          sequences    foo       ALL             true
+postgres       NULL         foo       false          types        foo       ALL             true
+postgres       NULL         foo       false          schemas      foo       ALL             true
+postgres       NULL         foo       false          types        public    USAGE           false
+postgres       NULL         root      false          tables       root      ALL             true
+postgres       NULL         root      false          sequences    root      ALL             true
+postgres       NULL         root      false          types        root      ALL             true
+postgres       NULL         root      false          schemas      root      ALL             true
+postgres       NULL         root      false          types        public    USAGE           false
+postgres       NULL         testuser  false          tables       testuser  ALL             true
+postgres       NULL         testuser  false          sequences    testuser  ALL             true
+postgres       NULL         testuser  false          types        testuser  ALL             true
+postgres       NULL         testuser  false          schemas      testuser  ALL             true
+postgres       NULL         testuser  false          types        public    USAGE           false
+postgres       NULL         NULL      true           types        public    USAGE           false
+system         NULL         admin     false          tables       admin     ALL             true
+system         NULL         admin     false          sequences    admin     ALL             true
+system         NULL         admin     false          types        admin     ALL             true
+system         NULL         admin     false          schemas      admin     ALL             true
+system         NULL         admin     false          types        public    USAGE           false
+system         NULL         bar       false          tables       bar       ALL             true
+system         NULL         bar       false          sequences    bar       ALL             true
+system         NULL         bar       false          types        bar       ALL             true
+system         NULL         bar       false          schemas      bar       ALL             true
+system         NULL         bar       false          types        public    USAGE           false
+system         NULL         foo       false          tables       foo       ALL             true
+system         NULL         foo       false          sequences    foo       ALL             true
+system         NULL         foo       false          types        foo       ALL             true
+system         NULL         foo       false          schemas      foo       ALL             true
+system         NULL         foo       false          types        public    USAGE           false
+system         NULL         root      false          tables       root      ALL             true
+system         NULL         root      false          sequences    root      ALL             true
+system         NULL         root      false          types        root      ALL             true
+system         NULL         root      false          schemas      root      ALL             true
+system         NULL         root      false          types        public    USAGE           false
+system         NULL         testuser  false          tables       testuser  ALL             true
+system         NULL         testuser  false          sequences    testuser  ALL             true
+system         NULL         testuser  false          types        testuser  ALL             true
+system         NULL         testuser  false          schemas      testuser  ALL             true
+system         NULL         testuser  false          types        public    USAGE           false
+system         NULL         NULL      true           types        public    USAGE           false
+test           NULL         admin     false          tables       admin     ALL             true
+test           NULL         admin     false          sequences    admin     ALL             true
+test           NULL         admin     false          types        admin     ALL             true
+test           NULL         admin     false          schemas      admin     ALL             true
+test           NULL         admin     false          types        public    USAGE           false
+test           NULL         bar       false          types        public    USAGE           false
+test           NULL         foo       false          types        public    USAGE           false
+test           NULL         root      false          tables       foo       DROP            true
+test           NULL         root      false          tables       foo       GRANT           true
+test           NULL         root      false          tables       foo       ZONECONFIG      true
+test           NULL         root      false          tables       root      ALL             true
+test           NULL         root      false          sequences    root      ALL             true
+test           NULL         root      false          types        root      ALL             true
+test           NULL         root      false          schemas      root      ALL             true
+test           NULL         testuser  false          tables       testuser  ALL             true
+test           NULL         testuser  false          sequences    testuser  ALL             true
+test           NULL         testuser  false          types        testuser  ALL             true
+test           NULL         testuser  false          schemas      testuser  ALL             true
+test           NULL         testuser  false          types        public    USAGE           false
+test           NULL         NULL      true           types        public    USAGE           false
+test2          NULL         admin     false          tables       admin     ALL             true
+test2          NULL         admin     false          sequences    admin     ALL             true
+test2          NULL         admin     false          types        admin     ALL             true
+test2          NULL         admin     false          schemas      admin     ALL             true
+test2          NULL         admin     false          types        public    USAGE           false
+test2          NULL         bar       false          tables       bar       ALL             true
+test2          NULL         bar       false          sequences    bar       ALL             true
+test2          NULL         bar       false          types        bar       ALL             true
+test2          NULL         bar       false          schemas      bar       ALL             true
+test2          NULL         bar       false          types        public    USAGE           false
+test2          NULL         foo       false          tables       foo       ALL             true
+test2          NULL         foo       false          sequences    foo       ALL             true
+test2          NULL         foo       false          types        foo       ALL             true
+test2          NULL         foo       false          schemas      foo       ALL             true
+test2          NULL         foo       false          types        public    USAGE           false
+test2          NULL         root      false          tables       foo       DROP            true
+test2          NULL         root      false          tables       foo       GRANT           true
+test2          NULL         root      false          tables       foo       ZONECONFIG      true
+test2          NULL         root      false          tables       root      ALL             true
+test2          NULL         root      false          sequences    root      ALL             true
+test2          NULL         root      false          types        root      ALL             true
+test2          NULL         root      false          schemas      root      ALL             true
+test2          NULL         root      false          types        public    USAGE           false
+test2          NULL         testuser  false          tables       testuser  ALL             true
+test2          NULL         testuser  false          sequences    testuser  ALL             true
+test2          NULL         testuser  false          types        testuser  ALL             true
+test2          NULL         testuser  false          schemas      testuser  ALL             true
+test2          NULL         testuser  false          types        public    USAGE           false
+test2          NULL         NULL      true           tables       foo       SELECT          false
+test2          NULL         NULL      true           types        public    USAGE           false

--- a/pkg/sql/logictest/testdata/logic_test/create_statements
+++ b/pkg/sql/logictest/testdata/logic_test/create_statements
@@ -535,7 +535,8 @@ CREATE TABLE crdb_internal.default_privileges (
    for_all_roles BOOL NULL,
    object_type STRING NOT NULL,
    grantee STRING NOT NULL,
-   privilege_type STRING NOT NULL
+   privilege_type STRING NOT NULL,
+   is_grantable BOOL NULL
 )  CREATE TABLE crdb_internal.default_privileges (
    database_name STRING NOT NULL,
    schema_name STRING NULL,
@@ -543,7 +544,8 @@ CREATE TABLE crdb_internal.default_privileges (
    for_all_roles BOOL NULL,
    object_type STRING NOT NULL,
    grantee STRING NOT NULL,
-   privilege_type STRING NOT NULL
+   privilege_type STRING NOT NULL,
+   is_grantable BOOL NULL
 )  {}  {}
 CREATE TABLE crdb_internal.feature_usage (
    feature_name STRING NOT NULL,

--- a/pkg/sql/logictest/testdata/logic_test/show_default_privileges
+++ b/pkg/sql/logictest/testdata/logic_test/show_default_privileges
@@ -1,13 +1,13 @@
 # Default privileges start with an implicit set, the creator role has ALL
 # and Public has usage.
-query TBTTT
+query TBTTTB
 SHOW DEFAULT PRIVILEGES
 ----
-root  false  schemas    root    ALL
-root  false  sequences  root    ALL
-root  false  tables     root    ALL
-root  false  types      public  USAGE
-root  false  types      root    ALL
+root  false  schemas    root    ALL    true
+root  false  sequences  root    ALL    true
+root  false  tables     root    ALL    true
+root  false  types      public  USAGE  false
+root  false  types      root    ALL    true
 
 # Ensure revoking "default" default privileges reflects in show default
 # privileges.
@@ -15,12 +15,12 @@ statement ok
 ALTER DEFAULT PRIVILEGES REVOKE ALL ON TABLES FROM root;
 ALTER DEFAULT PRIVILEGES REVOKE USAGE ON TYPES FROM public;
 
-query TBTTT
+query TBTTTB
 SHOW DEFAULT PRIVILEGES
 ----
-root  false  schemas    root  ALL
-root  false  sequences  root  ALL
-root  false  types      root  ALL
+root  false  schemas    root  ALL  true
+root  false  sequences  root  ALL  true
+root  false  types      root  ALL  true
 
 statement ok
 ALTER DEFAULT PRIVILEGES GRANT SELECT ON TABLES TO PUBLIC;
@@ -28,16 +28,16 @@ ALTER DEFAULT PRIVILEGES GRANT USAGE ON TYPES TO PUBLIC;
 ALTER DEFAULT PRIVILEGES GRANT USAGE ON SCHEMAS TO PUBLIC;
 ALTER DEFAULT PRIVILEGES GRANT SELECT ON SEQUENCES TO PUBLIC;
 
-query TBTTT
+query TBTTTB
 SHOW DEFAULT PRIVILEGES
 ----
-root  false  schemas    public  USAGE
-root  false  schemas    root    ALL
-root  false  sequences  public  SELECT
-root  false  sequences  root    ALL
-root  false  tables     public  SELECT
-root  false  types      public  USAGE
-root  false  types      root    ALL
+root  false  schemas    public  USAGE   false
+root  false  schemas    root    ALL     true
+root  false  sequences  public  SELECT  false
+root  false  sequences  root    ALL     true
+root  false  tables     public  SELECT  false
+root  false  types      public  USAGE   false
+root  false  types      root    ALL     true
 
 statement ok
 CREATE USER foo
@@ -45,16 +45,16 @@ CREATE USER foo
 statement ok
 CREATE USER bar
 
-query TBTTT
+query TBTTTB
 SHOW DEFAULT PRIVILEGES
 ----
-root  false  schemas    public  USAGE
-root  false  schemas    root    ALL
-root  false  sequences  public  SELECT
-root  false  sequences  root    ALL
-root  false  tables     public  SELECT
-root  false  types      public  USAGE
-root  false  types      root    ALL
+root  false  schemas    public  USAGE   false
+root  false  schemas    root    ALL     true
+root  false  sequences  public  SELECT  false
+root  false  sequences  root    ALL     true
+root  false  tables     public  SELECT  false
+root  false  types      public  USAGE   false
+root  false  types      root    ALL     true
 
 statement ok
 ALTER DEFAULT PRIVILEGES GRANT ALL ON TABLES TO foo, bar;
@@ -62,62 +62,62 @@ ALTER DEFAULT PRIVILEGES GRANT ALL ON TYPES TO foo, bar;
 ALTER DEFAULT PRIVILEGES GRANT ALL ON SCHEMAS TO foo, bar;
 ALTER DEFAULT PRIVILEGES GRANT ALL ON SEQUENCES TO foo, bar;
 
-query TBTTT
+query TBTTTB
 SHOW DEFAULT PRIVILEGES FOR ROLE foo, bar, root
 ----
-bar   false  schemas    bar     ALL
-bar   false  sequences  bar     ALL
-bar   false  tables     bar     ALL
-bar   false  types      bar     ALL
-bar   false  types      public  USAGE
-foo   false  schemas    foo     ALL
-foo   false  sequences  foo     ALL
-foo   false  tables     foo     ALL
-foo   false  types      foo     ALL
-foo   false  types      public  USAGE
-root  false  schemas    bar     ALL
-root  false  schemas    foo     ALL
-root  false  schemas    public  USAGE
-root  false  schemas    root    ALL
-root  false  sequences  bar     ALL
-root  false  sequences  foo     ALL
-root  false  sequences  public  SELECT
-root  false  sequences  root    ALL
-root  false  tables     bar     ALL
-root  false  tables     foo     ALL
-root  false  tables     public  SELECT
-root  false  types      bar     ALL
-root  false  types      foo     ALL
-root  false  types      public  USAGE
-root  false  types      root    ALL
+bar   false  schemas    bar     ALL     true
+bar   false  sequences  bar     ALL     true
+bar   false  tables     bar     ALL     true
+bar   false  types      bar     ALL     true
+bar   false  types      public  USAGE   false
+foo   false  schemas    foo     ALL     true
+foo   false  sequences  foo     ALL     true
+foo   false  tables     foo     ALL     true
+foo   false  types      foo     ALL     true
+foo   false  types      public  USAGE   false
+root  false  schemas    bar     ALL     true
+root  false  schemas    foo     ALL     true
+root  false  schemas    public  USAGE   false
+root  false  schemas    root    ALL     true
+root  false  sequences  bar     ALL     true
+root  false  sequences  foo     ALL     true
+root  false  sequences  public  SELECT  false
+root  false  sequences  root    ALL     true
+root  false  tables     bar     ALL     true
+root  false  tables     foo     ALL     true
+root  false  tables     public  SELECT  false
+root  false  types      bar     ALL     true
+root  false  types      foo     ALL     true
+root  false  types      public  USAGE   false
+root  false  types      root    ALL     true
 
 statement ok
 GRANT foo, bar TO root;
 
 statement ok
-ALTER DEFAULT PRIVILEGES FOR ROLE foo, bar GRANT ALL ON TABLES TO foo, bar;
+ALTER DEFAULT PRIVILEGES FOR ROLE foo, bar GRANT SELECT ON TABLES TO foo, bar;
 ALTER DEFAULT PRIVILEGES FOR ROLE foo, bar GRANT ALL ON TYPES TO foo, bar;
 ALTER DEFAULT PRIVILEGES FOR ROLE foo, bar GRANT ALL ON SCHEMAS TO foo, bar;
 ALTER DEFAULT PRIVILEGES FOR ROLE foo, bar GRANT ALL ON SEQUENCES TO foo, bar;
 
-query TBTTT
+query TBTTTB
 SHOW DEFAULT PRIVILEGES
 ----
-root  false  schemas    bar     ALL
-root  false  schemas    foo     ALL
-root  false  schemas    public  USAGE
-root  false  schemas    root    ALL
-root  false  sequences  bar     ALL
-root  false  sequences  foo     ALL
-root  false  sequences  public  SELECT
-root  false  sequences  root    ALL
-root  false  tables     bar     ALL
-root  false  tables     foo     ALL
-root  false  tables     public  SELECT
-root  false  types      bar     ALL
-root  false  types      foo     ALL
-root  false  types      public  USAGE
-root  false  types      root    ALL
+root  false  schemas    bar     ALL     true
+root  false  schemas    foo     ALL     true
+root  false  schemas    public  USAGE   false
+root  false  schemas    root    ALL     true
+root  false  sequences  bar     ALL     true
+root  false  sequences  foo     ALL     true
+root  false  sequences  public  SELECT  false
+root  false  sequences  root    ALL     true
+root  false  tables     bar     ALL     true
+root  false  tables     foo     ALL     true
+root  false  tables     public  SELECT  false
+root  false  types      bar     ALL     true
+root  false  types      foo     ALL     true
+root  false  types      public  USAGE   false
+root  false  types      root    ALL     true
 
 statement ok
 ALTER DEFAULT PRIVILEGES FOR ROLE foo, bar REVOKE ALL ON TABLES FROM foo, bar;
@@ -125,24 +125,24 @@ ALTER DEFAULT PRIVILEGES FOR ROLE foo, bar REVOKE ALL ON TYPES FROM foo, bar;
 ALTER DEFAULT PRIVILEGES FOR ROLE foo, bar REVOKE ALL ON SCHEMAS FROM foo, bar;
 ALTER DEFAULT PRIVILEGES FOR ROLE foo, bar REVOKE ALL ON SEQUENCES FROM foo, bar;
 
-query TBTTT
+query TBTTTB
 SHOW DEFAULT PRIVILEGES
 ----
-root  false  schemas    bar     ALL
-root  false  schemas    foo     ALL
-root  false  schemas    public  USAGE
-root  false  schemas    root    ALL
-root  false  sequences  bar     ALL
-root  false  sequences  foo     ALL
-root  false  sequences  public  SELECT
-root  false  sequences  root    ALL
-root  false  tables     bar     ALL
-root  false  tables     foo     ALL
-root  false  tables     public  SELECT
-root  false  types      bar     ALL
-root  false  types      foo     ALL
-root  false  types      public  USAGE
-root  false  types      root    ALL
+root  false  schemas    bar     ALL     true
+root  false  schemas    foo     ALL     true
+root  false  schemas    public  USAGE   false
+root  false  schemas    root    ALL     true
+root  false  sequences  bar     ALL     true
+root  false  sequences  foo     ALL     true
+root  false  sequences  public  SELECT  false
+root  false  sequences  root    ALL     true
+root  false  tables     bar     ALL     true
+root  false  tables     foo     ALL     true
+root  false  tables     public  SELECT  false
+root  false  types      bar     ALL     true
+root  false  types      foo     ALL     true
+root  false  types      public  USAGE   false
+root  false  types      root    ALL     true
 
 statement ok
 ALTER DEFAULT PRIVILEGES REVOKE SELECT ON TABLES FROM foo, bar, public;
@@ -150,40 +150,40 @@ ALTER DEFAULT PRIVILEGES REVOKE ALL ON TYPES FROM foo, bar, public;
 ALTER DEFAULT PRIVILEGES REVOKE ALL ON SCHEMAS FROM foo, bar, public;
 ALTER DEFAULT PRIVILEGES REVOKE ALL ON SEQUENCES FROM foo, bar, public;
 
-query TBTTT
+query TBTTTB
 SHOW DEFAULT PRIVILEGES
 ----
-root  false  schemas    root  ALL
-root  false  sequences  root  ALL
-root  false  tables     bar   CREATE
-root  false  tables     bar   DELETE
-root  false  tables     bar   DROP
-root  false  tables     bar   GRANT
-root  false  tables     bar   INSERT
-root  false  tables     bar   UPDATE
-root  false  tables     bar   ZONECONFIG
-root  false  tables     foo   CREATE
-root  false  tables     foo   DELETE
-root  false  tables     foo   DROP
-root  false  tables     foo   GRANT
-root  false  tables     foo   INSERT
-root  false  tables     foo   UPDATE
-root  false  tables     foo   ZONECONFIG
-root  false  types      root  ALL
+root  false  schemas    root  ALL         true
+root  false  sequences  root  ALL         true
+root  false  tables     bar   CREATE      true
+root  false  tables     bar   DELETE      true
+root  false  tables     bar   DROP        true
+root  false  tables     bar   GRANT       true
+root  false  tables     bar   INSERT      true
+root  false  tables     bar   UPDATE      true
+root  false  tables     bar   ZONECONFIG  true
+root  false  tables     foo   CREATE      true
+root  false  tables     foo   DELETE      true
+root  false  tables     foo   DROP        true
+root  false  tables     foo   GRANT       true
+root  false  tables     foo   INSERT      true
+root  false  tables     foo   UPDATE      true
+root  false  tables     foo   ZONECONFIG  true
+root  false  types      root  ALL         true
 
 statement ok
 ALTER DEFAULT PRIVILEGES REVOKE ALL ON TABLES FROM foo, bar, public;
 ALTER DEFAULT PRIVILEGES GRANT GRANT, DROP, ZONECONFIG ON TABLES TO foo;
 
-query TBTTT
+query TBTTTB
 SHOW DEFAULT PRIVILEGES
 ----
-root  false  schemas    root  ALL
-root  false  sequences  root  ALL
-root  false  tables     foo   DROP
-root  false  tables     foo   GRANT
-root  false  tables     foo   ZONECONFIG
-root  false  types      root  ALL
+root  false  schemas    root  ALL         true
+root  false  sequences  root  ALL         true
+root  false  tables     foo   DROP        true
+root  false  tables     foo   GRANT       true
+root  false  tables     foo   ZONECONFIG  true
+root  false  types      root  ALL         true
 
 # Create a second database.
 statement ok
@@ -195,74 +195,73 @@ statement ok
 GRANT testuser TO root;
 ALTER DEFAULT PRIVILEGES FOR ROLE testuser GRANT GRANT, DROP, ZONECONFIG ON TABLES TO foo;
 
-query TBTTT
+query TBTTTB
 SHOW DEFAULT PRIVILEGES FOR ROLE testuser
 ----
-testuser  false  schemas    testuser  ALL
-testuser  false  sequences  testuser  ALL
-testuser  false  tables     foo       DROP
-testuser  false  tables     foo       GRANT
-testuser  false  tables     foo       ZONECONFIG
-testuser  false  tables     testuser  ALL
-testuser  false  types      public    USAGE
-testuser  false  types      testuser  ALL
+testuser  false  schemas    testuser  ALL         true
+testuser  false  sequences  testuser  ALL         true
+testuser  false  tables     foo       DROP        true
+testuser  false  tables     foo       GRANT       true
+testuser  false  tables     foo       ZONECONFIG  true
+testuser  false  tables     testuser  ALL         true
+testuser  false  types      public    USAGE       false
+testuser  false  types      testuser  ALL         true
 
 # SHOW DEFAULT PRIVILEGES should show default privileges for the current role.
 user testuser
-query TBTTT
+query TBTTTB
 SHOW DEFAULT PRIVILEGES
 ----
-testuser  false  schemas    testuser  ALL
-testuser  false  sequences  testuser  ALL
-testuser  false  tables     testuser  ALL
-testuser  false  types      public    USAGE
-testuser  false  types      testuser  ALL
+testuser  false  schemas    testuser  ALL    true
+testuser  false  sequences  testuser  ALL    true
+testuser  false  tables     testuser  ALL    true
+testuser  false  types      public    USAGE  false
+testuser  false  types      testuser  ALL    true
 
 user root
 
-query TBTTT
+query TBTTTB
 SHOW DEFAULT PRIVILEGES FOR ROLE testuser
 ----
-testuser  false  schemas    testuser  ALL
-testuser  false  sequences  testuser  ALL
-testuser  false  tables     foo       DROP
-testuser  false  tables     foo       GRANT
-testuser  false  tables     foo       ZONECONFIG
-testuser  false  tables     testuser  ALL
-testuser  false  types      public    USAGE
-testuser  false  types      testuser  ALL
+testuser  false  schemas    testuser  ALL         true
+testuser  false  sequences  testuser  ALL         true
+testuser  false  tables     foo       DROP        true
+testuser  false  tables     foo       GRANT       true
+testuser  false  tables     foo       ZONECONFIG  true
+testuser  false  tables     testuser  ALL         true
+testuser  false  types      public    USAGE       false
+testuser  false  types      testuser  ALL         true
 
 statement ok
-ALTER DEFAULT PRIVILEGES FOR ROLE root GRANT GRANT, DROP, ZONECONFIG ON TABLES TO foo;
+ALTER DEFAULT PRIVILEGES FOR ROLE root GRANT DROP, ZONECONFIG ON TABLES TO foo;
 
-query TBTTT
+query TBTTTB
 SHOW DEFAULT PRIVILEGES FOR ROLE root, testuser
 ----
-root      false  schemas    root      ALL
-root      false  sequences  root      ALL
-root      false  tables     foo       DROP
-root      false  tables     foo       GRANT
-root      false  tables     foo       ZONECONFIG
-root      false  tables     root      ALL
-root      false  types      public    USAGE
-root      false  types      root      ALL
-testuser  false  schemas    testuser  ALL
-testuser  false  sequences  testuser  ALL
-testuser  false  tables     foo       DROP
-testuser  false  tables     foo       GRANT
-testuser  false  tables     foo       ZONECONFIG
-testuser  false  tables     testuser  ALL
-testuser  false  types      public    USAGE
-testuser  false  types      testuser  ALL
+root      false  schemas    root      ALL         true
+root      false  sequences  root      ALL         true
+root      false  tables     foo       DROP        false
+root      false  tables     foo       ZONECONFIG  false
+root      false  tables     root      ALL         true
+root      false  types      public    USAGE       false
+root      false  types      root      ALL         true
+testuser  false  schemas    testuser  ALL         true
+testuser  false  sequences  testuser  ALL         true
+testuser  false  tables     foo       DROP        true
+testuser  false  tables     foo       GRANT       true
+testuser  false  tables     foo       ZONECONFIG  true
+testuser  false  tables     testuser  ALL         true
+testuser  false  types      public    USAGE       false
+testuser  false  types      testuser  ALL         true
 
 statement ok
 ALTER DEFAULT PRIVILEGES FOR ALL ROLES GRANT GRANT, DROP, ZONECONFIG ON TABLES TO foo;
 
 # ForAllRoles is not a real role and thus is not the grantee for any privileges.
-query TBTTT
+query TBTTTB
 SHOW DEFAULT PRIVILEGES FOR ALL ROLES
 ----
-NULL  true  tables  foo     DROP
-NULL  true  tables  foo     GRANT
-NULL  true  tables  foo     ZONECONFIG
-NULL  true  types   public  USAGE
+NULL  true  tables  foo     DROP        true
+NULL  true  tables  foo     GRANT       true
+NULL  true  tables  foo     ZONECONFIG  true
+NULL  true  types   public  USAGE       false


### PR DESCRIPTION
Backport 1/2 commits from #85027.
Epic: None

/cc @cockroachdb/release

Release justification: only changes introspection; needed for making default privileges easy to use.

---

Release note (sql change): The SHOW DEFAULT PRIVILEGES command now has a
column that says if the default privilege will give the grant option to
the grantee.
