### PR TITLE
release-22.2: ui: fixes for console errors

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/filter/filterSearchOption.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/filter/filterSearchOption.tsx
@@ -27,7 +27,7 @@ export const FilterSearchOption = (
       <div className={filterLabel.margin}>{label}</div>
       <Search
         onChange={onChanged}
-        renderSuffix={false}
+        suffix={false}
         placeholder="Search"
         value={value}
       />

--- a/pkg/ui/workspaces/cluster-ui/src/search/search.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/search/search.tsx
@@ -28,7 +28,7 @@ interface ISearchProps {
   onClear?: () => void;
   defaultValue?: string;
   placeholder?: string;
-  renderSuffix?: boolean;
+  suffix?: boolean;
 }
 
 interface ISearchState {
@@ -45,7 +45,6 @@ const cx = classNames.bind(styles);
 export class Search extends React.Component<TSearchProps, ISearchState> {
   static defaultProps: Partial<ISearchProps> = {
     placeholder: "Search Statements",
-    renderSuffix: true,
     onSubmit: noop,
     onChange: noop,
     onClear: noop,
@@ -86,7 +85,7 @@ export class Search extends React.Component<TSearchProps, ISearchState> {
   };
 
   renderSuffix = (): React.ReactElement => {
-    if (!this.props.renderSuffix) {
+    if (this.props.suffix === false) {
       return null;
     }
     const { value, submitted } = this.state;

--- a/pkg/ui/workspaces/cluster-ui/src/store/insights/transactionInsights/transactionInsights.selectors.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/store/insights/transactionInsights/transactionInsights.selectors.ts
@@ -14,7 +14,7 @@ import { selectTxnInsightsCombiner } from "src/selectors/insightsCommon.selector
 import { localStorageSelector } from "src/store/utils/selectors";
 
 const selectTransactionInsightsData = (state: AppState) =>
-  state.adminUI.transactionInsights.data?.results;
+  state.adminUI?.transactionInsights.data?.results;
 
 export const selectTransactionInsights = createSelector(
   selectTransactionInsightsData,
@@ -22,11 +22,11 @@ export const selectTransactionInsights = createSelector(
 );
 
 export const selectTransactionInsightsError = (state: AppState) =>
-  state.adminUI.transactionInsights?.lastError;
+  state.adminUI?.transactionInsights?.lastError;
 
 export const selectTransactionInsightsMaxApiReached = (
   state: AppState,
-): boolean => !!state.adminUI.transactionInsights?.data?.maxSizeReached;
+): boolean => !!state.adminUI?.transactionInsights?.data?.maxSizeReached;
 
 export const selectSortSetting = createSelector(
   localStorageSelector,

--- a/pkg/ui/workspaces/cluster-ui/src/summaryCard/index.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/summaryCard/index.tsx
@@ -53,7 +53,7 @@ export const SummaryCardItem: React.FC<ISummaryCardItemProps> = ({
 }) => (
   <div className={cx("summary--card__item", className)}>
     <h4 className={cx("summary--card__item--label")}>{label}</h4>
-    <p className={cx("summary--card__item--value")}>{value}</p>
+    <span className={cx("summary--card__item--value")}>{value}</span>
   </div>
 );
 

--- a/pkg/ui/workspaces/db-console/src/views/hotRanges/hotRangesTable.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/hotRanges/hotRangesTable.tsx
@@ -110,7 +110,7 @@ const HotRangesTable = ({
         cell: val => (
           <>
             {val.replica_node_ids.map((nodeId, idx, arr) => (
-              <Link to={`/node/${nodeId}`}>
+              <Link to={`/node/${nodeId}`} key={nodeId}>
                 {nodeId}
                 {idx < arr.length - 1 && ", "}
               </Link>


### PR DESCRIPTION
Backport 1/1 commits from #98004.

/cc @cockroachdb/release

---

Fixes for problems causing warnings on console.
Those didn't cause any actual error, just warnings (but sending out as error on datadog):

- Change `<p>` to `<span` fixes `Warning: validateDOMNesting(...): <div> cannot appear as a descendant of <p>.`

- Change `renderSuffix` to `suffix` fixes `React does not recognize the renderSuffix prop on a DOM element. If you intentionally want it to appear in the DOM as a custom attribute, spell it as lowercase rendersuffix instead.`

- Add key attribute to list fixes `Warning: Each child in a list should have a unique "key" prop.`

- Adding checks that were causing some crashed the first time a page was open with no cache.
Fixes #97902

Release note: None

---

Release justification: bug fixes
