### PR TITLE
release-22.2: server: update default db to system on sql-api

### DIFF
--- a/pkg/server/api_v2_sql.go
+++ b/pkg/server/api_v2_sql.go
@@ -313,8 +313,7 @@ func (a *apiV2Server) execSQL(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if requestPayload.Database == "" {
-		// TODO(knz): maybe derive the default value off the username?
-		requestPayload.Database = "defaultdb"
+		requestPayload.Database = "system"
 	}
 	if requestPayload.ApplicationName == "" {
 		requestPayload.ApplicationName = "$ api-v2-sql"

--- a/pkg/server/testdata/api_v2_sql
+++ b/pkg/server/testdata/api_v2_sql
@@ -424,6 +424,98 @@ sql admin
 }
 
 
+# Delete defaultdb for the following two tests.
+sql admin
+{
+  "database": "mydb",
+  "execute": true,
+  "statements": [
+    {"sql": "DROP DATABASE defaultdb CASCADE"}
+  ]
+}
+----
+{
+ "execution": {
+  "txn_results": [
+   {
+    "columns": [
+     {
+      "name": "rows_affected",
+      "oid": 20,
+      "type": "INT8"
+     }
+    ],
+    "end": "1970-01-01T00:00:00Z",
+    "rows_affected": 0,
+    "start": "1970-01-01T00:00:00Z",
+    "statement": 1,
+    "tag": "DROP DATABASE"
+   }
+  ]
+ },
+ "num_statements": 1
+}
+
+
+# Not passing any database, should still work for admin with defaultdb deleted.
+sql admin
+{
+  "execute": true,
+  "statements": [
+    {"sql": "SELECT * FROM mydb.bar"}
+  ]
+}
+----
+{
+ "execution": {
+  "txn_results": [
+   {
+    "columns": [
+     {
+      "name": "i",
+      "oid": 20,
+      "type": "INT8"
+     },
+     {
+      "name": "k",
+      "oid": 20,
+      "type": "INT8"
+     }
+    ],
+    "end": "1970-01-01T00:00:00Z",
+    "rows": [
+     {
+      "i": 1,
+      "k": 42
+     },
+     {
+      "i": 2,
+      "k": 42
+     }
+    ],
+    "rows_affected": 0,
+    "start": "1970-01-01T00:00:00Z",
+    "statement": 1,
+    "tag": "SELECT"
+   }
+  ]
+ },
+ "num_statements": 1
+}
+
+
+
+# Not passing any database, should still work for non-admin with defaultdb deleted.
+# The error should be about permission on the table, not permission about executing the query.
+sql non-admin expect-error
+{
+  "execute": true,
+  "statements": [{"sql": "SELECT username FROM users where username = 'admin'"}]
+}
+----
+42501|executing stmt 1: run-query-via-api: user authentic_user_noadmin does not have SELECT privilege on relation users
+
+
 sql admin
 {
   "database": "mydb",

--- a/pkg/ui/workspaces/cluster-ui/package.json
+++ b/pkg/ui/workspaces/cluster-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cockroachlabs/cluster-ui",
-  "version": "22.2.7",
+  "version": "22.2.8",
   "description": "Cluster UI is a library of large features shared between CockroachDB and CockroachCloud",
   "repository": {
     "type": "git",

--- a/pkg/ui/workspaces/cluster-ui/src/api/sqlApi.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/api/sqlApi.ts
@@ -15,7 +15,7 @@ export type SqlExecutionRequest = {
   execute?: boolean;
   timeout?: string; // Default 5s
   application_name?: string; // Defaults to '$ api-v2-sql'
-  database?: string; // Defaults to defaultDb
+  database?: string; // Defaults to system
   max_result_size?: number; // Default 10kib
 };
 
@@ -76,6 +76,11 @@ export const SQL_API_PATH = "/api/v2/sql/";
 export function executeSql<RowType>(
   req: SqlExecutionRequest,
 ): Promise<SqlExecutionResponse<RowType>> {
+  // TODO(maryliag) remove this part of code when cloud is updated with
+  // a new CRDB release.
+  if (!req.database) {
+    req.database = "system";
+  }
   return fetchDataJSON<SqlExecutionResponse<RowType>, SqlExecutionRequest>(
     SQL_API_PATH,
     req,


### PR DESCRIPTION
Backport 1/1 commits from #97990.

/cc @cockroachdb/release

---

Currently the default database used by the sqlApi is `defaultdb`, but that database can be deleted and also is not available during restores.
The safe option is using system because it will always exist.

Changing just the server file should be enough to make this work, but this commit also updates the frontend code so a new version can be updates faster than waiting for a CRDB release. Once a release is updated to Cloud, those lines of code can be removed.

Fixes #97950

Release note (bug fix): Change database used for sql api calls, to no longer use "defaultdb", which was causing error messages on some pages when that database didn't exist anymore.

---

Release justification: bug fix
