### PR TITLE
changefeedccl: kafka sink oauth support

### DIFF
--- a/pkg/ccl/changefeedccl/BUILD.bazel
+++ b/pkg/ccl/changefeedccl/BUILD.bazel
@@ -160,6 +160,8 @@ go_library(
         "@org_golang_google_api//option",
         "@org_golang_google_grpc//codes",
         "@org_golang_google_grpc//status",
+        "@org_golang_x_oauth2//:oauth2",
+        "@org_golang_x_oauth2//clientcredentials",
         "@org_golang_x_oauth2//google",
     ],
 )

--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -4544,19 +4544,31 @@ func TestChangefeedErrors(t *testing.T) {
 		`CREATE CHANGEFEED FOR foo INTO $1`, `kafka://nope/?sasl_enabled=true&sasl_user=a`,
 	)
 	sqlDB.ExpectErr(
-		t, `sasl_enabled must be enabled if a SASL user is provided`,
+		t, `sasl_user must be provided when SASL is enabled using mechanism SCRAM-SHA-256`,
+		`CREATE CHANGEFEED FOR foo INTO $1`, `kafka://nope/?sasl_enabled=true&sasl_mechanism=SCRAM-SHA-256`,
+	)
+	sqlDB.ExpectErr(
+		t, `sasl_client_id must be provided when SASL is enabled using mechanism OAUTHBEARER`,
+		`CREATE CHANGEFEED FOR foo INTO $1`, `kafka://nope/?sasl_enabled=true&sasl_mechanism=OAUTHBEARER`,
+	)
+	sqlDB.ExpectErr(
+		t, `sasl_enabled must be enabled if sasl_user is provided`,
 		`CREATE CHANGEFEED FOR foo INTO $1`, `kafka://nope/?sasl_user=a`,
 	)
 	sqlDB.ExpectErr(
-		t, `sasl_enabled must be enabled if a SASL password is provided`,
+		t, `sasl_enabled must be enabled if sasl_password is provided`,
 		`CREATE CHANGEFEED FOR foo INTO $1`, `kafka://nope/?sasl_password=a`,
+	)
+	sqlDB.ExpectErr(
+		t, `sasl_client_id is only a valid parameter for sasl_mechanism=OAUTHBEARER`,
+		`CREATE CHANGEFEED FOR foo INTO $1`, `kafka://nope/?sasl_client_id=a`,
 	)
 	sqlDB.ExpectErr(
 		t, `sasl_enabled must be enabled to configure SASL mechanism`,
 		`CREATE CHANGEFEED FOR foo INTO $1`, `kafka://nope/?sasl_mechanism=SCRAM-SHA-256`,
 	)
 	sqlDB.ExpectErr(
-		t, `param sasl_mechanism must be one of SCRAM-SHA-256, SCRAM-SHA-512, or PLAIN`,
+		t, `param sasl_mechanism must be one of SCRAM-SHA-256, SCRAM-SHA-512, OAUTHBEARER, or PLAIN`,
 		`CREATE CHANGEFEED FOR foo INTO $1`, `kafka://nope/?sasl_enabled=true&sasl_mechanism=unsuppported`,
 	)
 	sqlDB.ExpectErr(
@@ -4917,7 +4929,6 @@ func TestChangefeedDescription(t *testing.T) {
 			require.Equal(t, tc.descr, description)
 		})
 	}
-
 }
 
 func TestChangefeedPanicRecovery(t *testing.T) {

--- a/pkg/ccl/changefeedccl/changefeedbase/options.go
+++ b/pkg/ccl/changefeedccl/changefeedbase/options.go
@@ -198,6 +198,11 @@ const (
 	SinkParamSASLUser               = `sasl_user`
 	SinkParamSASLPassword           = `sasl_password`
 	SinkParamSASLMechanism          = `sasl_mechanism`
+	SinkParamSASLClientID           = `sasl_client_id`
+	SinkParamSASLClientSecret       = `sasl_client_secret`
+	SinkParamSASLTokenURL           = `sasl_token_url`
+	SinkParamSASLScopes             = `sasl_scopes`
+	SinkParamSASLGrantType          = `sasl_grant_type`
 
 	RegistryParamCACert     = `ca_cert`
 	RegistryParamClientCert = `client_cert`

--- a/pkg/ccl/changefeedccl/sink_kafka_connection_test.go
+++ b/pkg/ccl/changefeedccl/sink_kafka_connection_test.go
@@ -195,14 +195,14 @@ func TestChangefeedExternalConnections(t *testing.T) {
 			expectedError: "sasl_password must be provided when SASL is enabled",
 		},
 		{
-			name:          "sasl_enabled must be enabled if a SASL user is provided",
+			name:          "sasl_enabled must be enabled if sasl_user is provided",
 			uri:           "kafka://nope/?sasl_user=a",
-			expectedError: "sasl_enabled must be enabled if a SASL user is provided",
+			expectedError: "sasl_enabled must be enabled if sasl_user is provided",
 		},
 		{
-			name:          "sasl_enabled must be enabled if a SASL password is provided",
+			name:          "sasl_enabled must be enabled if sasl_password is provided",
 			uri:           "kafka://nope/?sasl_password=a",
-			expectedError: "sasl_enabled must be enabled if a SASL password is provided",
+			expectedError: "sasl_enabled must be enabled if sasl_password is provided",
 		},
 		{
 			name:          "sasl_enabled must be enabled to configure SASL mechanism",
@@ -210,9 +210,9 @@ func TestChangefeedExternalConnections(t *testing.T) {
 			expectedError: "sasl_enabled must be enabled to configure SASL mechanism",
 		},
 		{
-			name:          "param sasl_mechanism must be one of SCRAM-SHA-256, SCRAM-SHA-512, or PLAIN",
+			name:          "param sasl_mechanism must be one of SCRAM-SHA-256, SCRAM-SHA-512, OAUTHBEARER, or PLAIN",
 			uri:           "kafka://nope/?sasl_enabled=true&sasl_mechanism=unsuppported",
-			expectedError: "param sasl_mechanism must be one of SCRAM-SHA-256, SCRAM-SHA-512, or PLAIN",
+			expectedError: "param sasl_mechanism must be one of SCRAM-SHA-256, SCRAM-SHA-512, OAUTHBEARER, or PLAIN",
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {

--- a/pkg/cmd/roachtest/tests/BUILD.bazel
+++ b/pkg/cmd/roachtest/tests/BUILD.bazel
@@ -267,6 +267,7 @@ go_library(
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
         "@org_golang_google_protobuf//proto",
+        "@org_golang_x_oauth2//clientcredentials",
         "@org_golang_x_sync//errgroup",
     ],
 )


### PR DESCRIPTION
Epic: CRDB-9724

This change adds OAuth support for the Kafka sink via the Client Credentials flow, where the user provides credentials and a url to a token endpoint which CRDB sends requests to to obtain a token it can pass to Sarama to use in its requests to the Kafka broker.


The token endpoint should be standardized between all compliant OAuth servers.  The basic credentials needed to call a Token endpoint are simply a ClientID and ClientSecret, with some optional configuration being possible.  These are sent to a token endpoint either in the POST body or as an authorization Header (some OAuth configurations will accept only one of these formats).  The token endpoint then returns a Token object which contains the token itself as well as an expiry timestamp denoting for how long the token is valid for.  Requests to the Kafka broker are then provided the Token in order to be accepted.

The API for changefeeds is in the form of sink url query parameters just like the existing SASL parameters for kafka sinks:
- `sasl_mechanism=OAUTHBEARER`
- `sasl_client_id=<oauth client id>`
- `sasl_client_secret=<oauth client secret>`
- `sasl_token_url=<full url-encoded url to the token endpoint>`
- Optional: `sasl_scopes=<list of scopes that the token should have access for>` (see [this doc](https://cloud.google.com/apigee/docs/api-platform/security/oauth/working-scopes#:~:text=scopes%20on%20Apigee.-,What%20is%20OAuth2%20scope%3F,resources%2C%20or%20just%20READ%20access.) on scopes)
- Optional: `sasl_grant_type=<custom grant type>` by default this is just `client_credentials` and any compliant Oauth implementation should be using that.  I just added this since the `oauth2/clientcredentials` library allows overriding this value for non-compliant implementations and I figured we might as well support that.


Example CREATE statement for Okta: `CREATE CHANGEFEED FOR foo INTO 'kafka://localhost:9093?sasl_client_id=0oa858flcxdS48fCW5d7&sasl_client_secret=c19KaF9janVndl9JZFdMMFdReTFTbVRyNkdCNnNqdU4xZXZNa19oPQ%3D%3D&sasl_enabled=true&sasl_mechanism=OAUTHBEARER&sasl_token_url=https%3A%2F%2Fdev-13678656.okta.com%2Foauth2%2Fdefault%2Fv1%2Ftoken'`

The way this is done in this PR is the following:
- Credentials for Oauth are passed in as sink query parameters the same as the other forms of auth.  This way we remain consistent with existing methods and they can also be stored in an external connection.  The ClientSecret is expected to be base64 encoded, and the TokenURL must be url encoded.
- We set an AccessTokenProvider implementation for Sarama.  Sarama calls the Token() method on this whenever it attempts to connect to a broker, retrying when errors are observed.
- The Token() method we provide uses the [`oauth2/clientcredentials`](https://pkg.go.dev/golang.org/x/oauth2/clientcredentials#pkg-overview) library, which sends a request to the provided TokenURL, attempting both methods of encoding the credentials (POST body or Header), and caching the knowledge of which one was accepted for future requests. Upon receiving a Token the library also caches the token for future calls until the Expiry timestamp is reached, after which a new token is requested from the endpoint.
- This means that upon a changefeed starting, every node will independently hit the token url with the same credentials, obtain their own token, and then once the expiry timestamp has been reached they will re-request the url.


To verify this works, a roachtest is also added which uses the open source Hydra library to start an in-memory OAuth server.  Using Okta was manually verified with a dev account.


---

The vast majority of the difficulty in getting this working involved setting up OAuth with Kafka for verification purposes.  The main slowdown involved Kafka versions, where OAuth setup between Kafka 2 and Kafka 3 are different, and neither has good documentation around it.

The way it works in Kafka 2 is that a Broker needs to have custom implementations of a Login and a Verification interface that handle connecting to the OAuth provider.  The one used in this PR for the roachtest is from [this
repo](https://github.com/jairsjunior/kafka-oauth).  There were two implementations I found online and both of them were almost identical in source code.  Note that this roachtest setup does not work with Kafka 3. The custom implementation is loaded into Kafka by including the path of the compiled Jar file for it in the CLASSPATH environment variable used when starting Kafka.  The OAuth server parameters used in the custom implementation are also provided via environment variables.

From what I could find, the schema registry does not actually support an OAuth flow when it comes to external clients communicating with the schema registry itself.  The only thing that is supported is OAuth between the schema registry and the SASL-enabled kafka broker.

Release note (enterprise change): changefeeds to a kafka sink now support the OAUTHBEARER sasl_mechanism