### PR TITLE
roachtest: use default env vars in `Run()`

### DIFF
--- a/pkg/cmd/roachtest/tests/gossip.go
+++ b/pkg/cmd/roachtest/tests/gossip.go
@@ -429,9 +429,8 @@ SELECT count(replicas)
 	// Restart node 1, but have it listen on a different port for internal
 	// connections. This will require node 1 to reach out to the other nodes in
 	// the cluster for gossip info.
-	defaultEnv := strings.Join(install.MakeClusterSettings().Env, " ")
 	err := c.RunE(ctx, c.Node(1),
-		defaultEnv+` ./cockroach start --insecure --background --store={store-dir} `+
+		` ./cockroach start --insecure --background --store={store-dir} `+
 			`--log-dir={log-dir} --cache=10% --max-sql-memory=10% `+
 			`--listen-addr=:$[{pgport:1}+10000] --http-port=$[{pgport:1}+1] `+
 			`--join={pghost:1}:{pgport:1}`+

--- a/pkg/roachprod/install/cluster_synced.go
+++ b/pkg/roachprod/install/cluster_synced.go
@@ -717,8 +717,11 @@ func (c *SyncedCluster) runCmdOnSingleNode(
 	//
 	// That command should return immediately. And a "roachprod status" should
 	// reveal that the sleep command is running on the cluster.
-	nodeCmd := fmt.Sprintf(`export ROACHPROD=%s GOTRACEBACK=crash && bash -c %s`,
-		c.roachprodEnvValue(node), ssh.Escape1(expandedCmd))
+	envVars := append([]string{
+		fmt.Sprintf("ROACHPROD=%s", c.roachprodEnvValue(node)), "GOTRACEBACK=crash",
+	}, config.DefaultEnvVars()...)
+	nodeCmd := fmt.Sprintf(`export %s && bash -c %s`,
+		strings.Join(envVars, " "), ssh.Escape1(expandedCmd))
 	if c.IsLocal() {
 		nodeCmd = fmt.Sprintf("cd %s; %s", c.localVMDir(node), nodeCmd)
 	}


### PR DESCRIPTION
In #97595, we added the `COCKROACH_TESTING_FORCE_RELEASE_BRANCH` environment variable to the list of roachprod's "default" environment variables. These variables are exported and accessible to the cockroach process when `cockroach` is started using `c.Start()`. However, nothing stops tests from invoking cockroach using `c.Run("./cockroach ...")`. In such cases, if a cluster had previously been created with `c.Start()`, the existing store would be deemed "too old" by the cockroach started with `c.Run()`, since that process (without the environment variable) would perform version offsetting.

To avoid these problems, we export roachprod's default environment variables to all commands run with `c.Run()`. The env vars available to cockroach are now consistent regardless of how the process is started, and the extra env vars should not affect unrelated commands run with `c.Run`.

Fixes #98025.
Fixes #98027.
Fixes #98029.
Fixes #98030.
Fixes #98031.

Epic: none

Release note: None