### PR TITLE
generate-bazel-extra: add instructions to update timeouts list

### DIFF
--- a/pkg/ccl/backupccl/BUILD.bazel
+++ b/pkg/ccl/backupccl/BUILD.bazel
@@ -189,7 +189,7 @@ go_test(
         "tenant_backup_nemesis_test.go",
         "utils_test.go",
     ],
-    args = ["-test.timeout=7195s"],
+    args = ["-test.timeout=3595s"],
     data = glob(["testdata/**"]) + ["//c-deps:libgeos"],
     embed = [":backupccl"],
     shard_count = 16,

--- a/pkg/cmd/generate-bazel-extra/main.go
+++ b/pkg/cmd/generate-bazel-extra/main.go
@@ -289,10 +289,20 @@ unused_checker(srcs = GET_X_DATA_TARGETS)`)
 func excludeReallyEnormousTargets(targets []string) []string {
 	for i := 0; i < len(targets); i++ {
 		var excluded bool
+		// Answer the following questions before adding a test target to this list:
+		//  1. Does this target run in Bazel Essential CI? If it does and you need
+		//     timeout to be > 1 hour then you need to talk to dev-inf. This is not
+		//	   expected.
+		//  2. Are you increasing the timeout for stress-testing purposes in CI? Make
+		// 	   your change in `pkg/cmd/teamcity-trigger` by updating `customTimeouts`.
+		//	3. You should only add a test target here if it's for stand-alone testing.
+		//	   For example: `/pkg/sql/sqlitelogictest` is only tested in a nightly in
+		//	   `build/teamcity/cockroach/nightlies/sqlite_logic_test_impl.sh`. If this is
+		//	   the case, you should tag your test as `integration`.
+		//  4. If you are not sure, please ask the dev-inf team for help.
 		for _, toExclude := range []string{
 			"//pkg/ccl/sqlitelogictestccl",
 			"//pkg/sql/sqlitelogictest",
-			"//pkg/ccl/backupccl",
 		} {
 			if strings.HasPrefix(targets[i], toExclude) {
 				excluded = true

--- a/pkg/cmd/generate-bazel-extra/main_test.go
+++ b/pkg/cmd/generate-bazel-extra/main_test.go
@@ -55,7 +55,6 @@ func TestExcludeReallyEnormousTests(t *testing.T) {
 		{
 			in: []string{
 				"//pkg/jobs:jobs_test",
-				"//pkg/ccl/backupccl:backupccl_test",
 				"//pkg/sql/sem/eval:eval_test",
 				"//pkg/sql/sqlitelogictest:sqlitelogictest_test",
 			},
@@ -84,7 +83,6 @@ func TestExcludeReallyEnormousTests(t *testing.T) {
 		{
 			in: []string{
 				"//pkg/ccl/sqlitelogictestccl:sqlitelogictestccl_test",
-				"//pkg/ccl/backupccl:backupccl_test",
 				"//pkg/jobs:jobs_test",
 				"//pkg/sql/colexec:colexec_test",
 				"//pkg/sql/sem/eval:eval_test",


### PR DESCRIPTION
This code change removes `pkg/ccl/backupccl` from the really enormous targets list because it's only there for CI stress purposes.

It also adds instructions to follow when adding a new test target to the list of really enormous timeouts.

Release note: None
Epic: none