### PR TITLE
release-22.2: disable cross descriptor validation during lease renewal

### DIFF
--- a/pkg/base/config.go
+++ b/pkg/base/config.go
@@ -100,7 +100,7 @@ const (
 
 	// DefaultLeaseRenewalCrossValidate is the default setting for if
 	// we should validate descriptors on lease renewals.
-	DefaultLeaseRenewalCrossValidate = true
+	DefaultLeaseRenewalCrossValidate = false
 )
 
 // DefaultCertsDirectory is the default value for the cert directory flag.


### PR DESCRIPTION
Previously, we added support for disabling descriptor lease validation during lease renewal to avoid regressions due to the overhead on multi-region clusters, where in some cases schema change transactions would hit retry errors. This was inadequate because the default still exposed users to a regression in behaviour. To address this, this patch will disable cross-descriptor validation by default during lease renewal.

Informs: #95764

Release note: None
Release justification: low risk and eliminates a far more problematic regression