### PR TITLE
release-22.1: disable cross descriptor validation during lease renewal

### DIFF
--- a/pkg/base/config.go
+++ b/pkg/base/config.go
@@ -102,7 +102,7 @@ const (
 
 	// DefaultLeaseRenewalCrossValidate is the default setting for if
 	// we should validate descriptors on lease renewals.
-	DefaultLeaseRenewalCrossValidate = true
+	DefaultLeaseRenewalCrossValidate = false
 )
 
 // DefaultHistogramWindowInterval returns the default rotation window for

--- a/pkg/sql/testdata/telemetry/error
+++ b/pkg/sql/testdata/telemetry/error
@@ -13,6 +13,10 @@ ${1} (...)
 ----
 
 exec
+SET CLUSTER SETTING sql.catalog.descriptor_lease_renewal_cross_validation.enabled='on';
+----
+
+exec
 CREATE TABLE fktbl (id INT PRIMARY KEY);
 ----
 


### PR DESCRIPTION
Backport 1/1 commits from #98080.

/cc @cockroachdb/release

---

Previously, we added support for disabling descriptor lease validation during lease renewal to avoid regressions due to the overhead on multi-region clusters, where in some cases schema change transactions would hit retry errors. This was inadequate because the default still exposed users to a regression in behaviour. To address this, this patch will disable cross-descriptor validation by default during lease renewal.

Informs: #95764

Release note: None
Release justification: low risk and eliminates a far more problematic regression
