### PR TITLE
spanconfig: deflake spanconfigreconcilerccl/TestDataDriven

### DIFF
--- a/pkg/ccl/spanconfigccl/spanconfigreconcilerccl/testdata/protectedts
+++ b/pkg/ccl/spanconfigccl/spanconfigreconcilerccl/testdata/protectedts
@@ -130,6 +130,13 @@ state limit=2
 /System/NodeLiveness{-Max}                 ttl_seconds=600 num_replicas=5
 ...
 
+# Take another look at the remaining protected spans.
+state offset=57
+----
+...
+/Table/10{6-7}                             protection_policies=[{ts: 3} {ts: 4}]
+/Table/10{7-8}                             protection_policies=[{ts: 3} {ts: 4}]
+
 # Release the schema object records.
 release record-id=3
 ----
@@ -137,9 +144,9 @@ release record-id=3
 release record-id=4
 ----
 
-mutations
+# Observe that they're no longer protected.
+state offset=57
 ----
-delete /Table/10{6-7}
-upsert /Table/10{6-7}                      range default
-delete /Table/10{7-8}
-upsert /Table/10{7-8}                      range default
+...
+/Table/10{6-7}                             range default
+/Table/10{7-8}                             range default


### PR DESCRIPTION
Fixes #98038. This test set up two protection records over two schema objects at two timestamps ts=3 and ts=4.
```
   /Table/10{6-7}  protection_policies=[{ts: 3} {ts: 4}]
   /Table/10{7-8}  protection_policies=[{ts: 3} {ts: 4}]
```
When it later released those protection records:
```
   release record-id=3
   release record-id=4
   ----
```
It asserted that the span config mutations showed that we did infact get rid of the protected state:
```
   mutations
   ----
   delete /Table/10{6-7}
   upsert /Table/10{6-7}      range default
   delete /Table/10{7-8}
   upsert /Table/10{7-8}      range default
```
But since release of these protections was non-atomic, in #98038 we observed the following transition instead.
```
   delete /Table/10{6-7}
   upsert /Table/10{6-7}      protection_policies=[{ts: 4}]
   delete /Table/10{7-8}
   upsert /Table/10{7-8}      protection_policies=[{ts: 4}]
   delete /Table/10{6-7}
   upsert /Table/10{6-7}      range default
   delete /Table/10{7-8}
   upsert /Table/10{7-8}      range default
```
That is, we first got rid of the record with ts=3 and only then got rid of ts=4. We just rewrite the test to assert on the final state of the records that show no remaining protections, instead of trying to add synchronization for mutations.

Release note: None