### PR TITLE
pkg/jobs: remove un-needed check for `job_type` column existence

### DIFF
--- a/pkg/jobs/registry.go
+++ b/pkg/jobs/registry.go
@@ -651,18 +651,6 @@ func (r *Registry) CreateJobWithTxn(
 		override := sessiondata.RootUserSessionDataOverride
 		override.Database = catconstants.SystemDatabaseName
 		hasJobTypeColumn := r.settings.Version.IsActive(ctx, clusterversion.V23_1AddTypeColumnToJobsTable)
-		if hasJobTypeColumn {
-			// Relying on the version gate may not be sufficient.
-			const pgAttributeStmt = `
-			SELECT * FROM system.pg_catalog.pg_attribute
-			         WHERE attrelid = 'system.public.jobs'::REGCLASS
-			         AND attname = 'job_type'`
-			row, err := txn.QueryRowEx(ctx, "job-columns-get", txn.KV(), override, pgAttributeStmt)
-			if err != nil {
-				return err
-			}
-			hasJobTypeColumn = row != nil
-		}
 		if !hasJobTypeColumn {
 			numCols -= 1
 		}

--- a/pkg/sql/testdata/telemetry/schema
+++ b/pkg/sql/testdata/telemetry/schema
@@ -56,7 +56,6 @@ sql.schema.alter_table
 sql.schema.alter_table.add_column
 sql.schema.alter_table.add_column.references
 sql.schema.alter_table.add_constraint
-sql.schema.get_virtual_table.pg_catalog.pg_attribute
 sql.schema.new_column_type.int8
 sql.schema.schema_changer_mode.declarative
 
@@ -108,7 +107,6 @@ ALTER TABLE on_update_t ADD COLUMN c INT DEFAULT 1 ON UPDATE 2;
 ----
 sql.schema.alter_table
 sql.schema.alter_table.add_column
-sql.schema.get_virtual_table.pg_catalog.pg_attribute
 sql.schema.new_column.qualification.default_expr
 sql.schema.new_column.qualification.on_update
 sql.schema.new_column_type.int8
@@ -160,7 +158,6 @@ feature-usage
 CREATE INDEX ON t(b)
 ----
 sql.schema.create_index
-sql.schema.get_virtual_table.pg_catalog.pg_attribute
 sql.schema.schema_changer_mode.declarative
 
 feature-usage


### PR DESCRIPTION
This code change makes the job creation code depend solely
on the version gate to check if `V23_1AddTypeColumnToJobsTable`
migration ran.

`TestTelemetry/schema` was rewritten.

Release note: None
Epic: [CRDB-21741](https://cockroachlabs.atlassian.net/browse/CRDB-21741)