### PR TITLE
sql/opt: fix "no output column" internal error

### DIFF
--- a/pkg/sql/opt/ordering/ordering.go
+++ b/pkg/sql/opt/ordering/ordering.go
@@ -365,9 +365,14 @@ func remapProvided(provided opt.Ordering, fds *props.FuncDepSet, outCols opt.Col
 			}
 		} else {
 			equivCols := fds.ComputeEquivClosureNoCopy(opt.MakeColSet(col))
-			remappedCol, ok := equivCols.Intersection(outCols).Next(0)
+			remappedCol, ok := equivCols.Next(0)
 			if !ok {
 				panic(errors.AssertionFailedf("no output column equivalent to %d", redact.Safe(col)))
+			}
+			// If the column is in the output use that.
+			remappedColFromOutput, ok := equivCols.Intersection(outCols).Next(0)
+			if ok {
+				remappedCol = remappedColFromOutput
 			}
 			if result == nil {
 				result = make(opt.Ordering, i, len(provided))

--- a/pkg/sql/opt/xform/testdata/physprops/ordering
+++ b/pkg/sql/opt/xform/testdata/physprops/ordering
@@ -3078,3 +3078,35 @@ sort
       ├── cardinality: [0 - 0]
       ├── key: ()
       └── fd: ()-->(6,12,23)
+
+# Regression test for #96288
+exec-ddl
+CREATE TABLE v0 (c1 BYTES PRIMARY KEY, c2 TIMESTAMP, INDEX i3(c2))
+----
+
+opt
+SELECT * FROM v0 WHERE (c1 = c1 AND c2 = '01-31-2023 00:00:00'::TIMESTAMP) OR (c1 = b'00' AND c1 = b'0') OR (c1 IS NULL AND c2 IS NULL)
+----
+distinct-on
+ ├── columns: c1:1!null c2:2
+ ├── grouping columns: c1:1!null
+ ├── internal-ordering: +1
+ ├── key: (1)
+ ├── fd: (1)-->(2)
+ ├── project
+ │    ├── columns: c1:1!null c2:2
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2)
+ │    ├── ordering: +1 [actual: +2,+1]
+ │    ├── scan v0@i3
+ │    │    ├── columns: c1:5!null c2:6
+ │    │    ├── constraint: /6/5: [/'2023-01-31 00:00:00' - /'2023-01-31 00:00:00']
+ │    │    ├── key: (5)
+ │    │    ├── fd: (5)-->(6)
+ │    │    └── ordering: +5 [actual: +6,+5]
+ │    └── projections
+ │         ├── c1:5 [as=c1:1, outer=(5)]
+ │         └── c2:6 [as=c2:2, outer=(6)]
+ └── aggregations
+      └── const-agg [as=c2:2, outer=(2)]
+           └── c2:2


### PR DESCRIPTION
In PR #87735 we allowed extra cols that were constant constrained provide
orderings but the remapOrdering code couldn't handle these extra
columns and would panic. Fix it by allowing these extra columns to be
remapped.

Fixes: #96288