### PR TITLE
storepool: consider nodes dead after no gossip

### DIFF
--- a/pkg/kv/kvserver/allocator/storepool/store_pool.go
+++ b/pkg/kv/kvserver/allocator/storepool/store_pool.go
@@ -260,6 +260,15 @@ func (sd *StoreDetail) status(
 	//         +-------------------------+    Successful liveness
 	//                                        heartbeat
 	//
+
+	// The store is considered dead if it hasn't been updated via gossip
+	// within the liveness threshold. Note that LastUpdatedTime is set
+	// when the store detail is created and will have a non-zero value
+	// even before the first gossip arrives for a store.
+	deadAsOf := sd.LastUpdatedTime.Add(deadThreshold)
+	if now.After(deadAsOf) {
+		return storeStatusDead
+	}
 	// If there's no descriptor (meaning no gossip ever arrived for this
 	// store), return unavailable.
 	if sd.Desc == nil {


### PR DESCRIPTION
In https://github.com/cockroachdb/cockroach/pull/97532 we removed a check that would consider stores as dead if they
hadn't gossiped their store descriptor within the last
`server.time_until_store_dead` period.

This patch updates adds back in the dead check that was removed, so
that stores which have not updated their store descriptor in gossip, in
the last `server.time_until_store_dead` are considered dead.

This is a mostly redundant check with node liveness mirroring this
behavior, however necessary in some tests.

Resolves: https://github.com/cockroachdb/cockroach/issues/97794

Release note: None