### PR TITLE
roachtest: wire up additional tpcc benchmarks

### DIFF
--- a/pkg/cmd/roachtest/tests/tpcc.go
+++ b/pkg/cmd/roachtest/tests/tpcc.go
@@ -872,6 +872,35 @@ func registerTPCC(r registry.Registry) {
 		LoadWarehouses: 2000,
 		EstimatedMax:   900,
 	})
+
+	// Encryption-At-Rest benchmarks. These are duplicates of variants above,
+	// using encrypted stores.
+	registerTPCCBenchSpec(r, tpccBenchSpec{
+		Nodes: 3,
+		CPUs:  4,
+
+		LoadWarehouses:    1000,
+		EstimatedMax:      gceOrAws(cloud, 750, 900),
+		EncryptionEnabled: true,
+	})
+	registerTPCCBenchSpec(r, tpccBenchSpec{
+		Nodes: 3,
+		CPUs:  16,
+
+		LoadWarehouses:    gceOrAws(cloud, 3500, 3900),
+		EstimatedMax:      gceOrAws(cloud, 2900, 3500),
+		EncryptionEnabled: true,
+	})
+	registerTPCCBenchSpec(r, tpccBenchSpec{
+		Nodes: 12,
+		CPUs:  16,
+
+		LoadWarehouses:    gceOrAws(cloud, 11500, 11500),
+		EstimatedMax:      gceOrAws(cloud, 10000, 10000),
+		EncryptionEnabled: true,
+
+		Tags: []string{`weekly`},
+	})
 }
 
 func gceOrAws(cloud string, gce, aws int) int {
@@ -1507,34 +1536,6 @@ func registerTPCCBench(r registry.Registry) {
 
 			LoadWarehouses: 10000,
 			EstimatedMax:   8000,
-		},
-
-		// Encryption-At-Rest benchmarks. These are duplicates of variants above,
-		// using encrypted stores.
-		{
-			Nodes: 3,
-			CPUs:  4,
-
-			LoadWarehouses:    1000,
-			EstimatedMax:      325,
-			EncryptionEnabled: true,
-		},
-		{
-			Nodes: 3,
-			CPUs:  16,
-
-			LoadWarehouses:    2000,
-			EstimatedMax:      1300,
-			EncryptionEnabled: true,
-		},
-		{
-			Nodes: 12,
-			CPUs:  16,
-
-			LoadWarehouses:    10000,
-			EstimatedMax:      6000,
-			LoadConfig:        singlePartitionedLoadgen,
-			EncryptionEnabled: true,
 		},
 	}
 


### PR DESCRIPTION
This is a follow up to #97923, adding the roachperf variants as tests, rather than benchmarks.

Release note: None.

Epic: CRDB-20293