### PR TITLE
sql/schmachanger: use more friendly language for fallback

### DIFF
--- a/pkg/sql/schemachanger/scerrors/errors.go
+++ b/pkg/sql/schemachanger/scerrors/errors.go
@@ -75,7 +75,7 @@ func (el EventLogger) HandlePanicAndLogError(ctx context.Context, err *error) {
 			log.InfofDepth(ctx, depth, "done %s in %s", el.msg, redact.Safe(timeutil.Since(el.start)))
 		}
 	case HasNotImplemented(*err):
-		log.InfofDepth(ctx, depth, "failed %s with error: %v", el.msg, *err)
+		log.VEventfDepth(ctx, depth, 1, "declarative schema changer does not support %s: %v", el.msg, *err)
 	case errors.HasAssertionFailure(*err):
 		*err = errors.Wrapf(*err, "%s", el.msg)
 		fallthrough


### PR DESCRIPTION
Previously, the declarative schema changer used slightly
alarming language when falling back. To address this,
this patch removes the word failure and uses softer
language. Also, the logging level is reduced to remove
this message by default.

Fixes: #97922

Release note: None