### PR TITLE
roachtest: decommission roachtests conform to new output

### DIFF
--- a/pkg/cmd/roachtest/tests/decommission.go
+++ b/pkg/cmd/roachtest/tests/decommission.go
@@ -316,7 +316,9 @@ func runDecommission(
 			run(fmt.Sprintf(`ALTER RANGE default CONFIGURE ZONE = 'constraints: {"-node%d"}'`, node))
 
 			targetNodeList := option.NodeListOption{nodeID}
-			if _, err := h.decommission(ctx, targetNodeList, pinnedNode, "--wait=all"); err != nil {
+			// TODO(sarkesian): Ensure updated span configs have been applied, so that
+			// checks can be reenabled.
+			if _, err := h.decommission(ctx, targetNodeList, pinnedNode, "--wait=all", "--checks=skip"); err != nil {
 				return err
 			}
 
@@ -405,7 +407,7 @@ func runDecommissionRandomized(ctx context.Context, t test.Test, c cluster.Clust
 
 		exp := [][]string{
 			decommissionHeader,
-			{strconv.Itoa(targetNode), "true", `\d+`, "true", "decommissioning", "false", "ready|allocation errors", `\d+`},
+			{strconv.Itoa(targetNode), "true", `\d+`, "true", "decommissioning", "false", "ready", "0"},
 		}
 		if err := cli.MatchCSV(o, exp); err != nil {
 			t.Fatal(err)
@@ -471,20 +473,36 @@ func runDecommissionRandomized(ctx context.Context, t test.Test, c cluster.Clust
 	{
 		// Attempt to decommission all the nodes.
 		{
+			// Validate that the decommission pre-checks prevent this.
+			runNode := h.getRandNode()
+			t.L().Printf("checking ability to decommission all nodes from n%d\n", runNode)
+			o, _ := h.decommission(ctx, c.All(), runNode,
+				"--wait=none", "--format=csv")
+
+			exp := [][]string{decommissionHeader}
+			for i := 1; i <= c.Spec().NodeCount; i++ {
+				rowRegex := []string{strconv.Itoa(i), "true", `\d+`, "true", "decommissioning", "false", "allocation errors", `\d+`}
+				exp = append(exp, rowRegex)
+			}
+			if err := cli.MatchCSV(o, exp); err != nil {
+				t.Fatalf("decommission failed: %v", err)
+			}
+		}
+		{
 			// NB: the retry loop here is mostly silly, but since some of the fields below
 			// are async, we may for example find an 'active' node instead of 'decommissioning'.
 			if err := retry.WithMaxAttempts(ctx, retryOpts, 50, func() error {
 				runNode := h.getRandNode()
 				t.L().Printf("attempting to decommission all nodes from n%d\n", runNode)
 				o, err := h.decommission(ctx, c.All(), runNode,
-					"--wait=none", "--format=csv")
+					"--wait=none", "--checks=skip", "--format=csv")
 				if err != nil {
 					t.Fatalf("decommission failed: %v", err)
 				}
 
-				exp := [][]string{decommissionHeader}
+				exp := [][]string{decommissionHeaderWithoutChecks}
 				for i := 1; i <= c.Spec().NodeCount; i++ {
-					rowRegex := []string{strconv.Itoa(i), "true", `\d+`, "true", "decommissioning", "false", "ready|allocation errors", `\d+`}
+					rowRegex := []string{strconv.Itoa(i), "true", `\d+`, "true", "decommissioning", "false"}
 					exp = append(exp, rowRegex)
 				}
 				if err := cli.MatchCSV(o, exp); err != nil {
@@ -692,6 +710,7 @@ func runDecommissionRandomized(ctx context.Context, t test.Test, c cluster.Clust
 				decommissionHeader,
 				// NB: the "false" is liveness. We waited above for these nodes to
 				// vanish from `node ls`, so definitely not live at this point.
+				// TODO(sarkesian): Validate that MatchCSV is working as expected.
 				{strconv.Itoa(targetNodeA), "false", "0", "true", "decommissioned", "false", "already decommissioned", "0"},
 				{strconv.Itoa(targetNodeB), "false", "0", "true", "decommissioned", "false", "already decommissioned", "0"},
 				decommissionFooter,
@@ -761,7 +780,7 @@ func runDecommissionRandomized(ctx context.Context, t test.Test, c cluster.Clust
 		runNode := h.getRandNode()
 		t.L().Printf("decommissioning n%d (from n%d) in absentia\n", targetNode, runNode)
 		if _, err := h.decommission(ctx, c.Node(targetNode), runNode,
-			"--wait=all", "--format=csv"); err != nil {
+			"--wait=all", "--checks=skip", "--format=csv"); err != nil {
 			t.Fatalf("decommission failed: %v", err)
 		}
 
@@ -777,15 +796,17 @@ func runDecommissionRandomized(ctx context.Context, t test.Test, c cluster.Clust
 		// all been GC'ed. Note that we specify "all" because even though
 		// the target node is now running, it may not be live by the time
 		// the command runs.
+		t.L().Printf("decommissioning n%d a second time using --wait=all\n", targetNode)
+		// TODO(sarkesian): Remove error on checking already decommissioned nodes.
 		o, err := h.decommission(ctx, c.Node(targetNode), runNode,
-			"--wait=all", "--format=csv")
+			"--wait=all", "--checks=skip", "--format=csv")
 		if err != nil {
 			t.Fatalf("decommission failed: %v", err)
 		}
 
 		exp := [][]string{
-			decommissionHeader,
-			{strconv.Itoa(targetNode), "true|false", "0", "true", "decommissioned", "false", "already decommissioned", "0"},
+			decommissionHeaderWithoutChecks,
+			{strconv.Itoa(targetNode), "true|false", "0", "true", "decommissioned", "false"},
 			decommissionFooter,
 		}
 		if err := cli.MatchCSV(cli.RemoveMatchingLines(o, warningFilter), exp); err != nil {
@@ -1121,6 +1142,11 @@ func runDecommissionSlow(ctx context.Context, t test.Test, c cluster.Cluster) {
 // Header from the output of `cockroach node decommission`.
 var decommissionHeader = []string{
 	"id", "is_live", "replicas", "is_decommissioning", "membership", "is_draining", "readiness", "blocking_ranges",
+}
+
+// Header from the output of `cockroach node decommission --checks=skip`.
+var decommissionHeaderWithoutChecks = []string{
+	"id", "is_live", "replicas", "is_decommissioning", "membership", "is_draining",
 }
 
 // Footer from the output of `cockroach node decommission`, after successful

--- a/pkg/cmd/roachtest/tests/mixed_version_decommission.go
+++ b/pkg/cmd/roachtest/tests/mixed_version_decommission.go
@@ -151,7 +151,7 @@ func fullyDecommissionStep(target, from int, binaryVersion string) versionStep {
 	return func(ctx context.Context, t test.Test, u *versionUpgradeTest) {
 		c := u.c
 		c.Run(ctx, c.Node(from), cockroachBinaryPath(binaryVersion), "node", "decommission",
-			"--wait=all", "--insecure", strconv.Itoa(target))
+			"--wait=all", "--checks=skip", "--insecure", strconv.Itoa(target))
 	}
 }
 


### PR DESCRIPTION
This change fixes decommission roachtests to properly be aware of the new output introduced by #96100, and to utilize the decommission pre-checks accordingly. In some places, the decommission pre-checks are skipped, especially because the decommission used in the test is not expected to be completeable.

Fixes: #98026, #98018, #98017.

Release note: None