### PR TITLE
logictest: unskip 3node-tenant config in statement_statistics

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/statement_statistics
+++ b/pkg/sql/logictest/testdata/logic_test/statement_statistics
@@ -151,7 +151,6 @@ SET application_name = '';
 statement ok
 RESET distsql
 
-skipif config 3node-tenant-default-configs #52763
 query TT colnames
 SELECT key,flags
   FROM test.crdb_internal.node_statement_statistics


### PR DESCRIPTION
This test now passed (since we support DistSQL in multi-tenancy now).

Fixes: #52763.

Epic: None

Release note: None