### PR TITLE
sql/pgwire: add test for portal bug

### DIFF
--- a/pkg/sql/pgwire/testdata/pgtest/portals_crbugs
+++ b/pkg/sql/pgwire/testdata/pgtest/portals_crbugs
@@ -293,6 +293,7 @@ Sync
 until ignore=RowDescription
 ReadyForQuery
 ReadyForQuery
+ReadyForQuery
 ----
 {"Type":"DataRow","Values":[{"text":"10"}]}
 {"Type":"DataRow","Values":[{"text":"20"}]}
@@ -301,3 +302,86 @@ ReadyForQuery
 {"Type":"ReadyForQuery","TxStatus":"T"}
 {"Type":"CommandComplete","CommandTag":"COMMIT"}
 {"Type":"ReadyForQuery","TxStatus":"I"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+
+
+subtest bind_before_update
+# In pg13.3, for portal bind before the update, the execution of the portal gives
+# value before the update. While CRDB gives the updated value. This may means we
+# need to modify the how the bind statement's execution.
+
+send
+Query {"String": "BEGIN"}
+Query {"String": "CREATE TABLE mytable (x int)"}
+Query {"String": "INSERT INTO mytable VALUES (1),(2),(3)"}
+Parse {"Name": "q3", "Query": "SELECT * FROM mytable"}
+Bind {"DestinationPortal": "p3", "PreparedStatement": "q3"}
+Query {"String": "UPDATE mytable SET x = 10"}
+----
+
+until
+ReadyForQuery
+ReadyForQuery
+ReadyForQuery
+ReadyForQuery
+----
+{"Type":"CommandComplete","CommandTag":"BEGIN"}
+{"Type":"ReadyForQuery","TxStatus":"T"}
+{"Type":"CommandComplete","CommandTag":"CREATE TABLE"}
+{"Type":"ReadyForQuery","TxStatus":"T"}
+{"Type":"CommandComplete","CommandTag":"INSERT 0 3"}
+{"Type":"ReadyForQuery","TxStatus":"T"}
+{"Type":"ParseComplete"}
+{"Type":"BindComplete"}
+{"Type":"CommandComplete","CommandTag":"UPDATE 3"}
+{"Type":"ReadyForQuery","TxStatus":"T"}
+
+send
+Execute {"Portal": "p3", "MaxRows": 2}
+Close {"ObjectType": "P", "Name": "p3"}
+Sync
+----
+
+# PG shows DataRow 1 and 2 here.
+
+until
+ReadyForQuery
+----
+{"Type":"DataRow","Values":[{"text":"10"}]}
+{"Type":"DataRow","Values":[{"text":"10"}]}
+{"Type":"PortalSuspended"}
+{"Type":"CloseComplete"}
+{"Type":"ReadyForQuery","TxStatus":"T"}
+
+
+send
+Parse {"Name": "q4", "Query": "SELECT * FROM mytable"}
+Bind {"DestinationPortal": "p4", "PreparedStatement": "q4"}
+Execute {"Portal": "p4", "MaxRows": 2}
+Sync
+----
+
+
+until
+ReadyForQuery
+----
+{"Type":"ParseComplete"}
+{"Type":"BindComplete"}
+{"Type":"DataRow","Values":[{"text":"10"}]}
+{"Type":"DataRow","Values":[{"text":"10"}]}
+{"Type":"PortalSuspended"}
+{"Type":"ReadyForQuery","TxStatus":"T"}
+
+send
+Query {"String": "COMMIT"}
+Sync
+----
+
+until
+ReadyForQuery
+----
+{"Type":"CommandComplete","CommandTag":"COMMIT"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+
+
+subtest end


### PR DESCRIPTION
informs #98118

In PG, a portal created (via the bind stmt) before the update statement gives the value before update when it's executed. But cockroach's one gives the updated value. This is because the underlying statement is planned and run only when the portal is executed, not when it's declared.

This commit is to add this bug to the existing test.

Release note: None