### PR TITLE
sem/tree: fix out-out-bounds exception in Tuple.formatHideConstants

### DIFF
--- a/pkg/sql/parser/testdata/select_exprs
+++ b/pkg/sql/parser/testdata/select_exprs
@@ -233,6 +233,14 @@ SELECT ((_,) AS a) -- literals removed
 SELECT ((1,) AS _) -- identifiers removed
 
 parse
+SELECT (ROW(1) AS a, b)
+----
+SELECT ((1,) AS a, b) -- normalized!
+SELECT ((((1),) AS a, b)) -- fully parenthesized
+SELECT ((_,) AS a, b) -- literals removed
+SELECT ((1,) AS _, _) -- identifiers removed
+
+parse
 SELECT (SELECT 1)
 ----
 SELECT (SELECT 1)
@@ -311,6 +319,38 @@ SELECT ((1, 2, 3) AS a, b, c)
 SELECT ((((1), (2), (3)) AS a, b, c)) -- fully parenthesized
 SELECT ((_, _, __more1_10__) AS a, b) -- literals removed
 SELECT ((1, 2, 3) AS _, _, _) -- identifiers removed
+
+parse
+SELECT ((1, 2, 3) AS a)
+----
+SELECT ((1, 2, 3) AS a)
+SELECT ((((1), (2), (3)) AS a)) -- fully parenthesized
+SELECT ((_, _, __more1_10__) AS a) -- literals removed
+SELECT ((1, 2, 3) AS _) -- identifiers removed
+
+parse
+SELECT ((1, 2, 3) AS a, b)
+----
+SELECT ((1, 2, 3) AS a, b)
+SELECT ((((1), (2), (3)) AS a, b)) -- fully parenthesized
+SELECT ((_, _, __more1_10__) AS a, b) -- literals removed
+SELECT ((1, 2, 3) AS _, _) -- identifiers removed
+
+parse
+SELECT ((1, 2) AS a, b, c)
+----
+SELECT ((1, 2) AS a, b, c)
+SELECT ((((1), (2)) AS a, b, c)) -- fully parenthesized
+SELECT ((_, _) AS a, b, c) -- literals removed
+SELECT ((1, 2) AS _, _, _) -- identifiers removed
+
+parse
+SELECT ((1, 2, 3) AS a, b, c, d)
+----
+SELECT ((1, 2, 3) AS a, b, c, d)
+SELECT ((((1), (2), (3)) AS a, b, c, d)) -- fully parenthesized
+SELECT ((_, _, __more1_10__) AS a, b) -- literals removed
+SELECT ((1, 2, 3) AS _, _, _, _) -- identifiers removed
 
 parse
 SELECT ((1, 2, 3))

--- a/pkg/sql/sem/tree/hide_constants.go
+++ b/pkg/sql/sem/tree/hide_constants.go
@@ -125,7 +125,7 @@ func (node *Tuple) formatHideConstants(ctx *FmtCtx) {
 		v2.Exprs = append(make(Exprs, 0, 3), v2.Exprs[:2]...)
 		if len(node.Exprs) > 2 {
 			v2.Exprs = append(v2.Exprs, arityIndicator(len(node.Exprs)-2))
-			if node.Labels != nil {
+			if len(node.Labels) > 2 {
 				v2.Labels = node.Labels[:2]
 			}
 		}


### PR DESCRIPTION
This commit fixes an out-of-bounds exception that occurred when
formatting a tuple with more than two elements and only a single label.

Fixes #95621

Release note (bug fix): A bug has been fixed that could crash the
process when a query contained a literal tuple expression with more than
two elements and only a single label, e.g., `((1, 2, 3) AS foo)`.
