### PR TITLE
ui: remove timeScale update from fingerprint details link from insight details

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsightDetails/insightDetailsTables.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsightDetails/insightDetailsTables.tsx
@@ -28,7 +28,6 @@ interface InsightDetailsTableProps {
 
 export function makeInsightDetailsColumns(
   execType: InsightExecEnum,
-  setTimeScale: (tw: TimeScale) => void,
 ): ColumnDescriptor<ContentionEvent>[] {
   return [
     {
@@ -41,11 +40,7 @@ export function makeInsightDetailsColumns(
       name: "fingerprintID",
       title: insightsTableTitles.fingerprintID(execType),
       cell: (item: ContentionEvent) =>
-        TransactionDetailsLink(
-          item.fingerprintID,
-          item.startTime,
-          setTimeScale,
-        ),
+        TransactionDetailsLink(item.fingerprintID),
       sort: (item: ContentionEvent) => item.fingerprintID,
     },
     {
@@ -61,7 +56,7 @@ export function makeInsightDetailsColumns(
       ),
       cell: (item: ContentionEvent) =>
         item.stmtInsightEvent
-          ? StatementDetailsLink(item.stmtInsightEvent, setTimeScale)
+          ? StatementDetailsLink(item.stmtInsightEvent)
           : item.waitingStmtFingerprintID,
       sort: (item: ContentionEvent) => item.waitingStmtFingerprintID,
     },
@@ -114,7 +109,7 @@ export function makeInsightDetailsColumns(
 export const WaitTimeDetailsTable: React.FC<
   InsightDetailsTableProps
 > = props => {
-  const columns = makeInsightDetailsColumns(props.execType, props.setTimeScale);
+  const columns = makeInsightDetailsColumns(props.execType);
   const [sortSetting, setSortSetting] = useState<SortSetting>({
     ascending: false,
     columnTitle: "contention",
@@ -130,9 +125,7 @@ export const WaitTimeDetailsTable: React.FC<
   );
 };
 
-export function makeInsightStatementContentionColumns(
-  setTimeScale: (ts: TimeScale) => void,
-): ColumnDescriptor<ContentionDetails>[] {
+export function makeInsightStatementContentionColumns(): ColumnDescriptor<ContentionDetails>[] {
   const execType = InsightExecEnum.STATEMENT;
   return [
     {
@@ -145,11 +138,7 @@ export function makeInsightStatementContentionColumns(
       name: "fingerprintId",
       title: insightsTableTitles.fingerprintID(InsightExecEnum.TRANSACTION),
       cell: (item: ContentionDetails) =>
-        TransactionDetailsLink(
-          item.blockingTxnFingerprintID,
-          item.collectionTimeStamp,
-          setTimeScale,
-        ),
+        TransactionDetailsLink(item.blockingTxnFingerprintID),
       sort: (item: ContentionDetails) => item.blockingTxnFingerprintID,
     },
     {
@@ -189,13 +178,12 @@ interface InsightContentionTableProps {
   data: ContentionDetails[];
   sortSetting?: SortSetting;
   onChangeSortSetting?: (ss: SortSetting) => void;
-  setTimeScale: (ts: TimeScale) => void;
 }
 
 export const ContentionStatementDetailsTable: React.FC<
   InsightContentionTableProps
 > = props => {
-  const columns = makeInsightStatementContentionColumns(props.setTimeScale);
+  const columns = makeInsightStatementContentionColumns();
   return (
     <SortedTable
       className="statements-table"

--- a/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsightDetails/statementInsightDetails.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsightDetails/statementInsightDetails.tsx
@@ -171,7 +171,6 @@ export const StatementInsightDetails: React.FC<
             <Tabs.TabPane tab="Overview" key={TabKeysEnum.OVERVIEW}>
               <StatementInsightDetailsOverviewTab
                 insightEventDetails={details}
-                setTimeScale={setTimeScale}
                 hasAdminRole={hasAdminRole}
               />
             </Tabs.TabPane>

--- a/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsightDetails/statementInsightDetailsOverviewTab.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsightDetails/statementInsightDetailsOverviewTab.tsx
@@ -46,13 +46,12 @@ const summaryCardStylesCx = classNames.bind(summaryCardStyles);
 
 export interface StatementInsightDetailsOverviewTabProps {
   insightEventDetails: StmtInsightEvent;
-  setTimeScale: (ts: TimeScale) => void;
   hasAdminRole: boolean;
 }
 
 export const StatementInsightDetailsOverviewTab: React.FC<
   StatementInsightDetailsOverviewTabProps
-> = ({ insightEventDetails, setTimeScale, hasAdminRole }) => {
+> = ({ insightEventDetails, hasAdminRole }) => {
   const isCockroachCloud = useContext(CockroachCloudContext);
 
   const insightsColumns = useMemo(
@@ -85,7 +84,6 @@ export const StatementInsightDetailsOverviewTab: React.FC<
             data={insightDetails.contentionEvents}
             sortSetting={insightsDetailsContentionSortSetting}
             onChangeSortSetting={setDetailsContentionSortSetting}
-            setTimeScale={setTimeScale}
           />
         </Col>
       </Row>
@@ -161,8 +159,6 @@ export const StatementInsightDetailsOverviewTab: React.FC<
               label="Transaction Fingerprint ID"
               value={TransactionDetailsLink(
                 insightDetails.transactionFingerprintID,
-                insightDetails.startTime,
-                setTimeScale,
               )}
             />
             <SummaryCardItem
@@ -171,7 +167,7 @@ export const StatementInsightDetailsOverviewTab: React.FC<
             />
             <SummaryCardItem
               label="Statement Fingerprint ID"
-              value={StatementDetailsLink(insightDetails, setTimeScale)}
+              value={StatementDetailsLink(insightDetails)}
             />
           </SummaryCard>
         </Col>

--- a/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsightDetails/transactionInsightDetailsOverviewTab.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsightDetails/transactionInsightDetailsOverviewTab.tsx
@@ -197,8 +197,6 @@ the maximum number of statements was reached in the console.`;
                       label="Transaction Fingerprint ID"
                       value={TransactionDetailsLink(
                         txnDetails.transactionFingerprintID,
-                        txnDetails.startTime,
-                        setTimeScale,
                       )}
                     />
                   </SummaryCard>

--- a/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsights/statementInsights/statementInsightsTable.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsights/statementInsights/statementInsightsTable.tsx
@@ -45,9 +45,7 @@ interface StatementInsightsTable {
   visibleColumns: ColumnDescriptor<StmtInsightEvent>[];
 }
 
-export function makeStatementInsightsColumns(
-  setTimeScale: (ts: TimeScale) => void,
-): ColumnDescriptor<StmtInsightEvent>[] {
+export function makeStatementInsightsColumns(): ColumnDescriptor<StmtInsightEvent>[] {
   const execType = InsightExecEnum.STATEMENT;
   return [
     {
@@ -64,8 +62,7 @@ export function makeStatementInsightsColumns(
     {
       name: "statementFingerprintID",
       title: insightsTableTitles.fingerprintID(execType),
-      cell: (item: StmtInsightEvent) =>
-        StatementDetailsLink(item, setTimeScale),
+      cell: (item: StmtInsightEvent) => StatementDetailsLink(item),
       sort: (item: StmtInsightEvent) => item.statementFingerprintID,
       showByDefault: true,
     },

--- a/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsights/statementInsights/statementInsightsView.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsights/statementInsights/statementInsightsView.tsx
@@ -207,7 +207,7 @@ export const StatementInsightsView: React.FC<StatementInsightsViewProps> = ({
     resetPagination();
   };
 
-  const defaultColumns = makeStatementInsightsColumns(setTimeScale);
+  const defaultColumns = makeStatementInsightsColumns();
 
   const onSetTimeScale = useCallback(
     (ts: TimeScale) => {

--- a/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsights/transactionInsights/transactionInsightsTable.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsights/transactionInsights/transactionInsightsTable.tsx
@@ -35,9 +35,7 @@ interface TransactionInsightsTable {
   setTimeScale: (ts: TimeScale) => void;
 }
 
-export function makeTransactionInsightsColumns(
-  setTimeScale: (ts: TimeScale) => void,
-): ColumnDescriptor<TxnInsightEvent>[] {
+export function makeTransactionInsightsColumns(): ColumnDescriptor<TxnInsightEvent>[] {
   const execType = InsightExecEnum.TRANSACTION;
   return [
     {
@@ -53,12 +51,7 @@ export function makeTransactionInsightsColumns(
     {
       name: "fingerprintID",
       title: insightsTableTitles.fingerprintID(execType),
-      cell: item =>
-        TransactionDetailsLink(
-          item.transactionFingerprintID,
-          item.startTime,
-          setTimeScale,
-        ),
+      cell: item => TransactionDetailsLink(item.transactionFingerprintID),
       sort: item => item.transactionFingerprintID,
     },
     {
@@ -110,7 +103,7 @@ export function makeTransactionInsightsColumns(
 export const TransactionInsightsTable: React.FC<
   TransactionInsightsTable
 > = props => {
-  const columns = makeTransactionInsightsColumns(props.setTimeScale);
+  const columns = makeTransactionInsightsColumns();
   return (
     <SortedTable columns={columns} className="statements-table" {...props} />
   );

--- a/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsights/util/detailsLinks.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsights/util/detailsLinks.tsx
@@ -13,27 +13,14 @@ import React from "react";
 import { HexStringToInt64String } from "../../../util";
 import { Link } from "react-router-dom";
 import { StatementLinkTarget } from "../../../statementsTable";
-import moment from "moment/moment";
-import { TimeScale } from "../../../timeScaleDropdown";
-import { Moment } from "moment";
 
 export function TransactionDetailsLink(
   transactionFingerprintID: string,
-  startTime: Moment | null,
-  setTimeScale: (tw: TimeScale) => void,
 ): React.ReactElement {
   const txnID = HexStringToInt64String(transactionFingerprintID);
   const path = `/transaction/${txnID}`;
-  const timeScale: TimeScale = startTime
-    ? {
-        windowSize: moment.duration(65, "minutes"),
-        fixedWindowEnd: moment(startTime).add(1, "hour"),
-        sampleSize: moment.duration(1, "hour"),
-        key: "Custom",
-      }
-    : null;
   return (
-    <Link to={path} onClick={() => timeScale && setTimeScale(timeScale)}>
+    <Link to={path}>
       <div>{String(transactionFingerprintID)}</div>
     </Link>
   );
@@ -41,7 +28,6 @@ export function TransactionDetailsLink(
 
 export function StatementDetailsLink(
   insightDetails: StmtInsightEvent,
-  setTimeScale: (tw: TimeScale) => void,
 ): React.ReactElement {
   const linkProps = {
     statementFingerprintID: HexStringToInt64String(
@@ -50,18 +36,9 @@ export function StatementDetailsLink(
     appNames: [insightDetails.application],
     implicitTxn: insightDetails.implicitTxn,
   };
-  const timeScale: TimeScale = {
-    windowSize: moment.duration(insightDetails.elapsedTimeMillis),
-    fixedWindowEnd: insightDetails.endTime,
-    sampleSize: moment.duration(1, "hour"),
-    key: "Custom",
-  };
 
   return (
-    <Link
-      to={StatementLinkTarget(linkProps)}
-      onClick={() => setTimeScale(timeScale)}
-    >
+    <Link to={StatementLinkTarget(linkProps)}>
       <div>{String(insightDetails.statementFingerprintID)}</div>
     </Link>
   );


### PR DESCRIPTION
Part of #97952.

This PR removes the setTimeScale call from the StatementDetailsLink
and TransactionDetailsLink functions. Navigating to the Fingerprint Details
pages from the Insights Details pages will no longer set the global time scale.

Loom (CC Console): https://www.loom.com/share/ca388c8c0068446d960f89cc6c1f6af5
Loom (DB Console): https://www.loom.com/share/209f2d21a1784d1d86adffabddb9b47f

Epic: none

Release note: None