### PR TITLE
kv: don't gossip node liveness on lease extensions

### DIFF
--- a/pkg/kv/kvserver/replica_proposal.go
+++ b/pkg/kv/kvserver/replica_proposal.go
@@ -435,7 +435,8 @@ func (r *Replica) leasePostApplyLocked(
 	// this gossip if we're taking over after a leaseholder failure. In both cases,
 	// incremental liveness updates may have been lost, so we want to make sure that
 	// the latest view of node liveness ends up in gossip.
-	if leaseChangingHands && iAmTheLeaseHolder {
+	nls := keys.NodeLivenessSpan
+	if leaseChangingHands && iAmTheLeaseHolder && kvserverbase.ContainsKeyRange(r.descRLocked(), nls.Key, nls.EndKey) {
 		// NB: run these in an async task to keep them out of the critical section
 		// (r.mu is held here).
 		_ = r.store.stopper.RunAsyncTask(r.AnnotateCtx(context.Background()), "lease-triggers", func(ctx context.Context) {

--- a/pkg/kv/kvserver/replica_proposal.go
+++ b/pkg/kv/kvserver/replica_proposal.go
@@ -430,14 +430,12 @@ func (r *Replica) leasePostApplyLocked(
 		}
 	}
 
-	// Potentially re-gossip if the range contains system data (e.g. system
-	// config or node liveness). We need to perform this gossip at startup as
-	// soon as possible. Trying to minimize how often we gossip is a fool's
-	// errand. The node liveness info will be gossiped frequently (every few
-	// seconds) in any case due to the liveness heartbeats. And the system config
-	// will be gossiped rarely because it falls on a range with an epoch-based
-	// range lease that is only reacquired extremely infrequently.
-	if iAmTheLeaseHolder {
+	// Potentially re-gossip if the range contains node liveness data. We need to
+	// perform this gossip at startup as soon as possible. We also need to perform
+	// this gossip if we're taking over after a leaseholder failure. In both cases,
+	// incremental liveness updates may have been lost, so we want to make sure that
+	// the latest view of node liveness ends up in gossip.
+	if leaseChangingHands && iAmTheLeaseHolder {
 		// NB: run these in an async task to keep them out of the critical section
 		// (r.mu is held here).
 		_ = r.store.stopper.RunAsyncTask(r.AnnotateCtx(context.Background()), "lease-triggers", func(ctx context.Context) {


### PR DESCRIPTION
Informs: #97966

Before this change, we would gossip the entire node liveness range on each liveness lease extension (every few seconds). In cases where the liveness range is full of garbage, we have seen that this can be expensive.

This change updates the post-lease change hook to only gossip all liveness records on lease changes, never on lease extensions. This is possible because there is no risk of lost incremental liveness updates on lease extensions.

Release note: None