### PR TITLE
release-22.2: ui: extend stmt details link timescale window to match txn details link

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsights/util/detailsLinks.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsights/util/detailsLinks.tsx
@@ -49,7 +49,7 @@ export function StatementDetailsLink(
     implicitTxn: insightDetails.implicitTxn,
   };
   const timeScale: TimeScale = {
-    windowSize: moment.duration(insightDetails.elapsedTimeMillis),
+    windowSize: moment.duration(65, "minutes"),
     fixedWindowEnd: insightDetails.endTime,
     sampleSize: moment.duration(1, "hour"),
     key: "Custom",


### PR DESCRIPTION
Fixes #97952.

This PR extends the window of the timeScale set by clicking the statement details link from the Insight Overview and Statement Insight Details pages to 65 minutes, to match the behavior of the transaction details link.

Loom (CC Console): https://www.loom.com/share/7d3cf837f1b24ab29dc1294b1471899b
Loom (DB Console): https://www.loom.com/share/152b87c96e314b8392b555d63eeb5d60

Epic: none

Release note: None

Release justification: bug fix