### PR TITLE
release-22.2: sql: switch from Compare to CompareError in some places

### DIFF
--- a/pkg/col/coldataext/datum_vec.go
+++ b/pkg/col/coldataext/datum_vec.go
@@ -56,7 +56,15 @@ func newDatumVec(t *types.T, n int, evalCtx *eval.Context) coldata.DatumVec {
 // Note that the method is named differently from "Compare" so that we do not
 // overload tree.Datum.Compare method.
 func CompareDatum(d, dVec, other interface{}) int {
-	return d.(tree.Datum).Compare(dVec.(*datumVec).evalCtx, convertToDatum(other))
+	// Note that it's not strictly necessary to use CompareError here instead of
+	// just Compare since pkg/sql/sem/eval is in the allow-list of paths that
+	// colexecerror catches panics from. Still, it seems nicer to be explicit
+	// about this.
+	res, err := d.(tree.Datum).CompareError(dVec.(*datumVec).evalCtx, convertToDatum(other))
+	if err != nil {
+		colexecerror.InternalError(err)
+	}
+	return res
 }
 
 // Hash returns the hash of the datum as a byte slice.

--- a/pkg/sql/logictest/testdata/logic_test/tuple_local
+++ b/pkg/sql/logictest/testdata/logic_test/tuple_local
@@ -1,0 +1,13 @@
+# LogicTest: !fakedist !fakedist-vec-off !fakedist-disk !3node-tenant
+
+# At the moment, the query below results in an internal error when executed in
+# a distributed fashion. We should fix that and merge this file into 'tuple'
+# (tracked in #94970).
+
+# Regression test for not using CompareError when dealing with tuples (#93396).
+statement ok
+CREATE TABLE t93396 (c1 TIME PRIMARY KEY, c2 INT8);
+INSERT INTO t93396 VALUES ('0:0:0'::TIME, 0);
+
+query error unsupported comparison: time to decimal
+SELECT * FROM t93396 WHERE (c1, c2) = (SELECT 0.0, 0);

--- a/pkg/sql/logictest/tests/local-legacy-schema-changer/generated_test.go
+++ b/pkg/sql/logictest/tests/local-legacy-schema-changer/generated_test.go
@@ -1878,6 +1878,13 @@ func TestLogic_tuple(
 	runLogicTest(t, "tuple")
 }
 
+func TestLogic_tuple_local(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "tuple_local")
+}
+
 func TestLogic_txn(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/local-vec-off/generated_test.go
+++ b/pkg/sql/logictest/tests/local-vec-off/generated_test.go
@@ -1906,6 +1906,13 @@ func TestLogic_tuple(
 	runLogicTest(t, "tuple")
 }
 
+func TestLogic_tuple_local(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "tuple_local")
+}
+
 func TestLogic_txn(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/local/generated_test.go
+++ b/pkg/sql/logictest/tests/local/generated_test.go
@@ -2067,6 +2067,13 @@ func TestLogic_tuple(
 	runLogicTest(t, "tuple")
 }
 
+func TestLogic_tuple_local(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "tuple_local")
+}
+
 func TestLogic_txn(
 	t *testing.T,
 ) {

--- a/pkg/sql/rowenc/encoded_datum.go
+++ b/pkg/sql/rowenc/encoded_datum.go
@@ -372,7 +372,7 @@ func (ed *EncDatum) Compare(
 	if err := rhs.EnsureDecoded(typ, a); err != nil {
 		return 0, err
 	}
-	return ed.Datum.Compare(evalCtx, rhs.Datum), nil
+	return ed.Datum.CompareError(evalCtx, rhs.Datum)
 }
 
 // GetInt decodes an EncDatum that is known to be of integer type and returns
@@ -541,7 +541,10 @@ func (r EncDatumRow) CompareToDatums(
 		if err := r[c.ColIdx].EnsureDecoded(types[c.ColIdx], a); err != nil {
 			return 0, err
 		}
-		cmp := r[c.ColIdx].Datum.Compare(evalCtx, rhs[c.ColIdx])
+		cmp, err := r[c.ColIdx].Datum.CompareError(evalCtx, rhs[c.ColIdx])
+		if err != nil {
+			return 0, err
+		}
 		if cmp != 0 {
 			if c.Direction == encoding.Descending {
 				cmp = -cmp

--- a/pkg/sql/rowexec/windower.go
+++ b/pkg/sql/rowexec/windower.go
@@ -789,7 +789,10 @@ func (n *partitionPeerGrouper) InSameGroup(i, j int) (bool, error) {
 			n.err = err
 			return false, n.err
 		}
-		if c := da.Compare(n.evalCtx, db); c != 0 {
+		if c, err := da.CompareError(n.evalCtx, db); err != nil {
+			n.err = err
+			return false, n.err
+		} else if c != 0 {
 			if o.Direction != execinfrapb.Ordering_Column_ASC {
 				return false, nil
 			}

--- a/pkg/sql/sem/builtins/aggregate_builtins.go
+++ b/pkg/sql/sem/builtins/aggregate_builtins.go
@@ -3024,7 +3024,10 @@ func (a *maxAggregate) Add(ctx context.Context, datum tree.Datum, _ ...tree.Datu
 		a.max = datum
 		return nil
 	}
-	c := a.max.Compare(a.evalCtx, datum)
+	c, err := a.max.CompareError(a.evalCtx, datum)
+	if err != nil {
+		return err
+	}
 	if c < 0 {
 		a.max = datum
 		if a.variableDatumSize {
@@ -3094,7 +3097,10 @@ func (a *minAggregate) Add(ctx context.Context, datum tree.Datum, _ ...tree.Datu
 		a.min = datum
 		return nil
 	}
-	c := a.min.Compare(a.evalCtx, datum)
+	c, err := a.min.CompareError(a.evalCtx, datum)
+	if err != nil {
+		return err
+	}
 	if c > 0 {
 		a.min = datum
 		if a.variableDatumSize {

--- a/pkg/sql/sem/builtins/math_builtins.go
+++ b/pkg/sql/sem/builtins/math_builtins.go
@@ -610,7 +610,9 @@ var mathBuiltins = map[string]builtinDefinition{
 				}
 
 				for i, v := range thresholds.Array {
-					if operand.Compare(ctx, v) < 0 {
+					if cmp, err := operand.CompareError(ctx, v); err != nil {
+						return tree.NewDInt(0), err
+					} else if cmp < 0 {
 						return tree.NewDInt(tree.DInt(i)), nil
 					}
 				}

--- a/pkg/sql/sem/builtins/pg_builtins.go
+++ b/pkg/sql/sem/builtins/pg_builtins.go
@@ -551,7 +551,9 @@ var pgBuiltins = map[string]builtinDefinition{
 			},
 			ReturnType: tree.FixedReturnType(types.String),
 			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
-				if args[0].Compare(ctx, DatEncodingUTFId) == 0 {
+				if cmp, err := args[0].CompareError(ctx, DatEncodingUTFId); err != nil {
+					return tree.DNull, err
+				} else if cmp == 0 {
 					return datEncodingUTF8ShortName, nil
 				}
 				return tree.DNull, nil

--- a/pkg/sql/sem/eval/binary_op.go
+++ b/pkg/sql/sem/eval/binary_op.go
@@ -182,7 +182,11 @@ func (e *evaluator) EvalCompareTupleOp(
 				return tree.DNull, nil
 			}
 		} else {
-			cmp = leftElem.Compare(e.ctx(), rightElem)
+			var err error
+			cmp, err = leftElem.CompareError(e.ctx(), rightElem)
+			if err != nil {
+				return tree.DNull, err
+			}
 			if cmp != 0 {
 				break
 			}
@@ -478,7 +482,9 @@ func (e *evaluator) EvalInTupleOp(_ *tree.InTupleOp, arg, values tree.Datum) (tr
 		for _, val := range vtuple.D {
 			if val == tree.DNull {
 				sawNull = true
-			} else if val.Compare(e.ctx(), arg) == 0 {
+			} else if cmp, err := val.CompareError(e.ctx(), arg); err != nil {
+				return tree.DNull, err
+			} else if cmp == 0 {
 				return tree.DBoolTrue, nil
 			}
 		}
@@ -491,10 +497,12 @@ func (e *evaluator) EvalInTupleOp(_ *tree.InTupleOp, arg, values tree.Datum) (tr
 				sawNull = true
 			} else {
 				// Use the EQ function which properly handles NULLs.
-				if res := cmpOpTupleFn(
+				if res, err := cmpOpTupleFn(
 					e.ctx(), *argTuple, *val.(*tree.DTuple),
 					treecmp.MakeComparisonOperator(treecmp.EQ),
-				); res == tree.DNull {
+				); err != nil {
+					return tree.DNull, err
+				} else if res == tree.DNull {
 					sawNull = true
 				} else if res == tree.DBoolTrue {
 					return tree.DBoolTrue, nil

--- a/pkg/sql/sem/eval/comparison.go
+++ b/pkg/sql/sem/eval/comparison.go
@@ -134,7 +134,7 @@ func boolFromCmp(cmp int, op treecmp.ComparisonOperator) *tree.DBool {
 
 func cmpOpTupleFn(
 	ctx tree.CompareContext, left, right tree.DTuple, op treecmp.ComparisonOperator,
-) tree.Datum {
+) (tree.Datum, error) {
 	cmp := 0
 	sawNull := false
 	for i, leftElem := range left.D {
@@ -154,7 +154,7 @@ func cmpOpTupleFn(
 			case treecmp.IsNotDistinctFrom:
 				// For IS NOT DISTINCT FROM, NULLs are "equal".
 				if leftElem != tree.DNull || rightElem != tree.DNull {
-					return tree.DBoolFalse
+					return tree.DBoolFalse, nil
 				}
 
 			default:
@@ -163,10 +163,14 @@ func cmpOpTupleFn(
 				// NULL. This is because NULL is thought of as "unknown" and tuple
 				// inequality is defined lexicographically, so once a NULL comparison is
 				// seen, the result of the entire tuple comparison is unknown.
-				return tree.DNull
+				return tree.DNull, nil
 			}
 		} else {
-			cmp = leftElem.Compare(ctx, rightElem)
+			var err error
+			cmp, err = leftElem.CompareError(ctx, rightElem)
+			if err != nil {
+				return tree.DNull, err
+			}
 			if cmp != 0 {
 				break
 			}
@@ -177,7 +181,7 @@ func cmpOpTupleFn(
 		// The op is EQ and all non-NULL elements are equal, but we saw at least
 		// one NULL element. Since NULL comparisons are treated as unknown, the
 		// result of the comparison becomes unknown (NULL).
-		return tree.DNull
+		return tree.DNull, nil
 	}
-	return b
+	return b, nil
 }

--- a/pkg/sql/sem/eval/window_funcs.go
+++ b/pkg/sql/sem/eval/window_funcs.go
@@ -698,5 +698,5 @@ func compareForWindow(evalCtx *Context, left, right tree.Datum) (int, error) {
 			return 0, err
 		}
 	}
-	return left.Compare(evalCtx, right), nil
+	return left.CompareError(evalCtx, right)
 }

--- a/pkg/sql/sem/tree/eval.go
+++ b/pkg/sql/sem/tree/eval.go
@@ -337,7 +337,9 @@ func ArrayContains(ctx CompareContext, haystack *DArray, needles *DArray) (*DBoo
 		}
 		var found bool
 		for _, hay := range haystack.Array {
-			if needle.Compare(ctx, hay) == 0 {
+			if cmp, err := needle.CompareError(ctx, hay); err != nil {
+				return DBoolFalse, err
+			} else if cmp == 0 {
 				found = true
 				break
 			}
@@ -361,7 +363,9 @@ func ArrayOverlaps(ctx CompareContext, array, other *DArray) (*DBool, error) {
 			continue
 		}
 		for _, hay := range other.Array {
-			if needle.Compare(ctx, hay) == 0 {
+			if cmp, err := needle.CompareError(ctx, hay); err != nil {
+				return DBoolFalse, err
+			} else if cmp == 0 {
 				return DBoolTrue, nil
 			}
 		}

--- a/pkg/sql/stats/histogram.go
+++ b/pkg/sql/stats/histogram.go
@@ -136,7 +136,9 @@ func EquiDepthHistogram(
 		// numLess is the number of samples less than upper (in this bucket).
 		numLess := 0
 		for ; numLess < numSamplesInBucket-1; numLess++ {
-			if c := samples[i+numLess].Compare(compareCtx, upper); c == 0 {
+			if c, err := samples[i+numLess].CompareError(compareCtx, upper); err != nil {
+				return HistogramData{}, nil, err
+			} else if c == 0 {
 				break
 			} else if c > 0 {
 				return HistogramData{}, nil, errors.AssertionFailedf("%+v", "samples not sorted")
@@ -144,7 +146,9 @@ func EquiDepthHistogram(
 		}
 		// Advance the boundary of the bucket to cover all samples equal to upper.
 		for ; i+numSamplesInBucket < numSamples; numSamplesInBucket++ {
-			if samples[i+numSamplesInBucket].Compare(compareCtx, upper) != 0 {
+			if c, err := samples[i+numSamplesInBucket].CompareError(compareCtx, upper); err != nil {
+				return HistogramData{}, nil, err
+			} else if c != 0 {
 				break
 			}
 		}


### PR DESCRIPTION
Backport 1/1 commits from #94971.

/cc @cockroachdb/release

---

This commit switches some of the production usages of `tree.Datum.Compare` method to `CompareError` in order to not crash the server (when the vectorized engine is not used). With the vectorized engine there was no user-visible impact we were catching the panic and propagating it as a regular error already. Thus, I decided to not include a release note.

Fixes: #93396.
Fixes: #94187.

Release note: None

Release justification: bug fix.