### PR TITLE
release-22.1: sql: switch from Compare to CompareError in some places

### DIFF
--- a/pkg/col/coldataext/datum_vec.go
+++ b/pkg/col/coldataext/datum_vec.go
@@ -55,7 +55,15 @@ func newDatumVec(t *types.T, n int, evalCtx *tree.EvalContext) coldata.DatumVec 
 // Note that the method is named differently from "Compare" so that we do not
 // overload tree.Datum.Compare method.
 func CompareDatum(d, dVec, other interface{}) int {
-	return d.(tree.Datum).Compare(dVec.(*datumVec).evalCtx, convertToDatum(other))
+	// Note that it's not strictly necessary to use CompareError here instead of
+	// just Compare since pkg/sql/sem/eval is in the allow-list of paths that
+	// colexecerror catches panics from. Still, it seems nicer to be explicit
+	// about this.
+	res, err := d.(tree.Datum).CompareError(dVec.(*datumVec).evalCtx, convertToDatum(other))
+	if err != nil {
+		colexecerror.InternalError(err)
+	}
+	return res
 }
 
 // Hash returns the hash of the datum as a byte slice.

--- a/pkg/sql/logictest/testdata/logic_test/tuple_local
+++ b/pkg/sql/logictest/testdata/logic_test/tuple_local
@@ -1,0 +1,13 @@
+# LogicTest: !fakedist !fakedist-vec-off !fakedist-disk !fakedist-metadata !fakedist-spec-planning !3node-tenant
+
+# At the moment, the query below results in an internal error when executed in
+# a distributed fashion. We should fix that and merge this file into 'tuple'
+# (tracked in #94970).
+
+# Regression test for not using CompareError when dealing with tuples (#93396).
+statement ok
+CREATE TABLE t93396 (c1 TIME PRIMARY KEY, c2 INT8);
+INSERT INTO t93396 VALUES ('0:0:0'::TIME, 0);
+
+query error unsupported comparison: time to decimal
+SELECT * FROM t93396 WHERE (c1, c2) = (SELECT 0.0, 0);

--- a/pkg/sql/rowenc/encoded_datum.go
+++ b/pkg/sql/rowenc/encoded_datum.go
@@ -370,7 +370,7 @@ func (ed *EncDatum) Compare(
 	if err := rhs.EnsureDecoded(typ, a); err != nil {
 		return 0, err
 	}
-	return ed.Datum.Compare(evalCtx, rhs.Datum), nil
+	return ed.Datum.CompareError(evalCtx, rhs.Datum)
 }
 
 // GetInt decodes an EncDatum that is known to be of integer type and returns
@@ -538,7 +538,10 @@ func (r EncDatumRow) CompareToDatums(
 		if err := r[c.ColIdx].EnsureDecoded(types[c.ColIdx], a); err != nil {
 			return 0, err
 		}
-		cmp := r[c.ColIdx].Datum.Compare(evalCtx, rhs[c.ColIdx])
+		cmp, err := r[c.ColIdx].Datum.CompareError(evalCtx, rhs[c.ColIdx])
+		if err != nil {
+			return 0, err
+		}
 		if cmp != 0 {
 			if c.Direction == encoding.Descending {
 				cmp = -cmp

--- a/pkg/sql/rowexec/windower.go
+++ b/pkg/sql/rowexec/windower.go
@@ -788,7 +788,10 @@ func (n *partitionPeerGrouper) InSameGroup(i, j int) (bool, error) {
 			n.err = err
 			return false, n.err
 		}
-		if c := da.Compare(n.evalCtx, db); c != 0 {
+		if c, err := da.CompareError(n.evalCtx, db); err != nil {
+			n.err = err
+			return false, n.err
+		} else if c != 0 {
 			if o.Direction != execinfrapb.Ordering_Column_ASC {
 				return false, nil
 			}

--- a/pkg/sql/sem/builtins/aggregate_builtins.go
+++ b/pkg/sql/sem/builtins/aggregate_builtins.go
@@ -3083,7 +3083,10 @@ func (a *maxAggregate) Add(ctx context.Context, datum tree.Datum, _ ...tree.Datu
 		a.max = datum
 		return nil
 	}
-	c := a.max.Compare(a.evalCtx, datum)
+	c, err := a.max.CompareError(a.evalCtx, datum)
+	if err != nil {
+		return err
+	}
 	if c < 0 {
 		a.max = datum
 		if a.variableDatumSize {
@@ -3155,7 +3158,10 @@ func (a *minAggregate) Add(ctx context.Context, datum tree.Datum, _ ...tree.Datu
 		a.min = datum
 		return nil
 	}
-	c := a.min.Compare(a.evalCtx, datum)
+	c, err := a.min.CompareError(a.evalCtx, datum)
+	if err != nil {
+		return err
+	}
 	if c > 0 {
 		a.min = datum
 		if a.variableDatumSize {

--- a/pkg/sql/sem/builtins/math_builtins.go
+++ b/pkg/sql/sem/builtins/math_builtins.go
@@ -573,7 +573,9 @@ var mathBuiltins = map[string]builtinDefinition{
 				}
 
 				for i, v := range thresholds.Array {
-					if operand.Compare(ctx, v) < 0 {
+					if cmp, err := operand.CompareError(ctx, v); err != nil {
+						return tree.NewDInt(0), err
+					} else if cmp < 0 {
 						return tree.NewDInt(tree.DInt(i)), nil
 					}
 				}

--- a/pkg/sql/sem/builtins/pg_builtins.go
+++ b/pkg/sql/sem/builtins/pg_builtins.go
@@ -532,7 +532,9 @@ var pgBuiltins = map[string]builtinDefinition{
 			},
 			ReturnType: tree.FixedReturnType(types.String),
 			Fn: func(ctx *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
-				if args[0].Compare(ctx, DatEncodingUTFId) == 0 {
+				if cmp, err := args[0].CompareError(ctx, DatEncodingUTFId); err != nil {
+					return tree.DNull, err
+				} else if cmp == 0 {
 					return datEncodingUTF8ShortName, nil
 				}
 				return tree.DNull, nil

--- a/pkg/sql/sem/tree/window_funcs.go
+++ b/pkg/sql/sem/tree/window_funcs.go
@@ -694,7 +694,7 @@ func compareForWindow(evalCtx *EvalContext, left, right Datum) (int, error) {
 			return 0, err
 		}
 	}
-	return left.Compare(evalCtx, right), nil
+	return left.CompareError(evalCtx, right)
 }
 
 // WindowFunc performs a computation on each row using data from a provided *WindowFrameRun.

--- a/pkg/sql/stats/histogram.go
+++ b/pkg/sql/stats/histogram.go
@@ -127,7 +127,9 @@ func EquiDepthHistogram(
 		// numLess is the number of samples less than upper (in this bucket).
 		numLess := 0
 		for ; numLess < numSamplesInBucket-1; numLess++ {
-			if c := samples[i+numLess].Compare(evalCtx, upper); c == 0 {
+			if c, err := samples[i+numLess].CompareError(evalCtx, upper); err != nil {
+				return HistogramData{}, nil, err
+			} else if c == 0 {
 				break
 			} else if c > 0 {
 				return HistogramData{}, nil, errors.AssertionFailedf("%+v", "samples not sorted")
@@ -135,7 +137,9 @@ func EquiDepthHistogram(
 		}
 		// Advance the boundary of the bucket to cover all samples equal to upper.
 		for ; i+numSamplesInBucket < numSamples; numSamplesInBucket++ {
-			if samples[i+numSamplesInBucket].Compare(evalCtx, upper) != 0 {
+			if c, err := samples[i+numSamplesInBucket].CompareError(evalCtx, upper); err != nil {
+				return HistogramData{}, nil, err
+			} else if c != 0 {
 				break
 			}
 		}


### PR DESCRIPTION
Backport 1/1 commits from #94971.

/cc @cockroachdb/release

---

This commit switches some of the production usages of `tree.Datum.Compare` method to `CompareError` in order to not crash the server (when the vectorized engine is not used). With the vectorized engine there was no user-visible impact we were catching the panic and propagating it as a regular error already. Thus, I decided to not include a release note.

Fixes: #93396.
Fixes: #94187.

Release note: None

Release justification: bug fix.