### PR TITLE
upgrades: add ExecForCountInTxns helper function for testing

### DIFF
--- a/pkg/upgrade/upgrades/helpers_test.go
+++ b/pkg/upgrade/upgrades/helpers_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/systemschema"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/tabledesc"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -167,3 +168,31 @@ func GetTable(
 
 // WaitForJobStatement is exported so that it can be detected by a testing knob.
 const WaitForJobStatement = waitForJobStatement
+
+// ExecForCountInTxns allows statements to be repeatedly run on a database
+// in transactions of a specified size.
+func ExecForCountInTxns(
+	ctx context.Context,
+	t *testing.T,
+	db *gosql.DB,
+	count int,
+	txnSize int,
+	fn func(txRunner *sqlutils.SQLRunner, i int),
+) {
+	tx, err := db.BeginTx(ctx, nil /* opts */)
+	require.NoError(t, err)
+	txRunner := sqlutils.MakeSQLRunner(tx)
+	// Group statements into transactions of txnSize runs to speed up creation.
+	for i := 0; i < count; i++ {
+		if i != 0 && i%txnSize == 0 {
+			err := tx.Commit()
+			require.NoError(t, err)
+			tx, err = db.BeginTx(ctx, nil /* opts */)
+			require.NoError(t, err)
+			txRunner = sqlutils.MakeSQLRunner(tx)
+		}
+		fn(txRunner, i)
+	}
+	err = tx.Commit()
+	require.NoError(t, err)
+}

--- a/pkg/upgrade/upgrades/system_privileges_user_id_migration_test.go
+++ b/pkg/upgrade/upgrades/system_privileges_user_id_migration_test.go
@@ -84,27 +84,14 @@ func runTestSystemPrivilegesUserIDMigration(t *testing.T, numUsers int) {
 	upgrades.InjectLegacyTable(ctx, t, s, systemschema.SystemPrivilegeTable, getTableDescForSystemPrivilegesTableBeforeUserIDCol)
 
 	// Create test users.
-	tx, err := db.BeginTx(ctx, nil /* opts */)
-	require.NoError(t, err)
-	txRunner := sqlutils.MakeSQLRunner(tx)
-	for i := 0; i < numUsers; i++ {
-		// Group statements into transactions of 100 users to speed up creation.
-		if i != 0 && i%100 == 0 {
-			err := tx.Commit()
-			require.NoError(t, err)
-			tx, err = db.BeginTx(ctx, nil /* opts */)
-			require.NoError(t, err)
-			txRunner = sqlutils.MakeSQLRunner(tx)
-		}
+	upgrades.ExecForCountInTxns(ctx, t, db, numUsers, 100 /* txCount */, func(txRunner *sqlutils.SQLRunner, i int) {
 		txRunner.Exec(t, fmt.Sprintf("CREATE USER testuser%d", i))
 		txRunner.Exec(t, fmt.Sprintf("GRANT SYSTEM MODIFYCLUSTERSETTING TO testuser%d", i))
-	}
-	err = tx.Commit()
-	require.NoError(t, err)
+	})
 	tdb.CheckQueryResults(t, "SELECT count(*) FROM system.privileges", [][]string{{strconv.Itoa(numUsers)}})
 
 	// Run migrations.
-	_, err = tc.Conns[0].ExecContext(ctx, `SET CLUSTER SETTING version = $1`,
+	_, err := tc.Conns[0].ExecContext(ctx, `SET CLUSTER SETTING version = $1`,
 		clusterversion.ByKey(clusterversion.V23_1SystemPrivilegesTableHasUserIDColumn).String())
 	require.NoError(t, err)
 	_, err = tc.Conns[0].ExecContext(ctx, `SET CLUSTER SETTING version = $1`,


### PR DESCRIPTION
This patch adds a helper function called `ExecForCountInTxns`, which abstracts
out the logic to repeatedly run SQL statements on a database in transactions
of a specified size. It also refactors existing usages of this pattern to use
this new function.

Part of #87079

Release note: None