### PR TITLE
sqlstats: flush stmt and txns in parallel

### DIFF
--- a/pkg/sql/sqlstats/persistedsqlstats/flush.go
+++ b/pkg/sql/sqlstats/persistedsqlstats/flush.go
@@ -13,6 +13,7 @@ package persistedsqlstats
 import (
 	"context"
 	"fmt"
+	"sync"
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/appstatspb"
@@ -74,8 +75,20 @@ func (s *PersistedSQLStats) Flush(ctx context.Context) {
 	if s.stmtsLimitSizeReached(ctx) || s.txnsLimitSizeReached(ctx) {
 		log.Infof(ctx, "unable to flush fingerprints because table limit was reached.")
 	} else {
-		s.flushStmtStats(ctx, aggregatedTs)
-		s.flushTxnStats(ctx, aggregatedTs)
+		var wg sync.WaitGroup
+		wg.Add(2)
+
+		go func() {
+			defer wg.Done()
+			s.flushStmtStats(ctx, aggregatedTs)
+		}()
+
+		go func() {
+			defer wg.Done()
+			s.flushTxnStats(ctx, aggregatedTs)
+		}()
+
+		wg.Wait()
 	}
 }
 


### PR DESCRIPTION
When we have a lot of in-memory data, the flush
can take some time to complete. WHy not flush
stmt and txns in parallel, so that we at least
get some data to both system tables while flushing instead of wiating for the stmt flush to complete
to start flushing tot txns, which can delay data
being shown in the app.

Epic: none

Release note: None