### PR TITLE
scripts: update bump-pebble.sh to pull from crl-release-23.1

### DIFF
--- a/scripts/bump-pebble.sh
+++ b/scripts/bump-pebble.sh
@@ -21,7 +21,7 @@ popd() { builtin popd "$@" > /dev/null; }
 # Cockroach branch name (i.e. release-22.2, etc.), and corresponding Pebble
 # branch name (e.g. crl-release-21.2, etc.).
 BRANCH=master
-PEBBLE_BRANCH=master
+PEBBLE_BRANCH=crl-release-23.1
 
 # The script can only be run from a specific branch.
 if [ "$(git rev-parse --abbrev-ref HEAD)" != "$BRANCH" ]; then


### PR DESCRIPTION
Pebble's 23.1 release branch was cut a little early. All pebble bumps should pull from the release branch until the Cockroach release branch is cut, at which point we'll update master back to Pebble master.

Epic: None
Release note: None