### PR TITLE
sql, util: update CapturedIndexUsageStats payload

### DIFF
--- a/docs/generated/eventlog.md
+++ b/docs/generated/eventlog.md
@@ -2720,6 +2720,15 @@ An event of type `captured_index_usage_stats`
 | `IsInverted` | IsInverted indicates if the index is an inverted index. | no |
 | `CreatedAt` | CreatedAt is the timestamp at which the index was created. | no |
 | `SchemaName` | SchemaName is the name of the schema in which the index was created. | no |
+| `IsVisible` | IsVisible indicates whether the index is visible or not. | no |
+| `IsSharded` | IsSharded indicates whether the index is sharded or not. | no |
+| `ShardBucketCount` | ShardBucketCount indicates the number of shards the index is divided into. | no |
+| `TableDropTime` | DropTime is the timestamp at which the table was dropped. | no |
+| `TableModTime` | ModTime is the timestamp at which the table was last modified. | no |
+| `TableModTimeLogical` | ModTimeLogical is the unix nanos at which the table was last modified. | no |
+| `TableAuditMode` | AuditMode indicates if the table has audit logging set. | no |
+| `TableLocality` | Locality is the location associated with the table. | no |
+| `MVCCStats` | MVCCStats is a message containing replica stats related to a given table name. | yes |
 
 
 #### Common fields

--- a/pkg/server/server_sql.go
+++ b/pkg/server/server_sql.go
@@ -1579,7 +1579,7 @@ func (s *SQLServer) preStart(
 
 	scheduledlogging.Start(
 		ctx, stopper, s.execCfg.InternalDB, s.execCfg.Settings,
-		s.execCfg.CaptureIndexUsageStatsKnobs,
+		s.execCfg.CaptureIndexUsageStatsKnobs, s.execCfg.Codec, s.execCfg.TenantStatusServer.SpanStats,
 	)
 	s.execCfg.SyntheticPrivilegeCache.Start(ctx)
 	return nil

--- a/pkg/sql/scheduledlogging/BUILD.bazel
+++ b/pkg/sql/scheduledlogging/BUILD.bazel
@@ -7,6 +7,7 @@ go_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/sql/scheduledlogging",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/keys",
         "//pkg/roachpb",
         "//pkg/security/username",
         "//pkg/settings",
@@ -14,6 +15,7 @@ go_library(
         "//pkg/sql/isql",
         "//pkg/sql/sem/tree",
         "//pkg/sql/sessiondata",
+        "//pkg/storage/enginepb",
         "//pkg/util/log",
         "//pkg/util/log/eventpb",
         "//pkg/util/log/logpb",

--- a/pkg/util/log/eventpb/BUILD.bazel
+++ b/pkg/util/log/eventpb/BUILD.bazel
@@ -39,6 +39,7 @@ go_test(
     args = ["-test.timeout=55s"],
     embed = [":eventpb"],
     deps = [
+        "//pkg/storage/enginepb",
         "//pkg/util/log/logpb",
         "@com_github_cockroachdb_redact//:redact",
         "@com_github_stretchr_testify//assert",
@@ -67,6 +68,7 @@ proto_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/sql/catalog/descpb:descpb_proto",
+        "//pkg/storage/enginepb:enginepb_proto",
         "//pkg/util/log/logpb:logpb_proto",
         "@com_github_gogo_protobuf//gogoproto:gogo_proto",
     ],
@@ -80,6 +82,7 @@ go_proto_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/sql/catalog/descpb",
+        "//pkg/storage/enginepb",
         "//pkg/util/log/logpb",
         "@com_github_gogo_protobuf//gogoproto",
     ],

--- a/pkg/util/log/eventpb/event_test.go
+++ b/pkg/util/log/eventpb/event_test.go
@@ -13,6 +13,7 @@ package eventpb
 import (
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
 	"github.com/cockroachdb/cockroach/pkg/util/log/logpb"
 	"github.com/cockroachdb/redact"
 	"github.com/stretchr/testify/assert"
@@ -64,6 +65,10 @@ func TestEventJSON(t *testing.T) {
 		{
 			&StoreStats{Levels: []LevelStats{{Level: 0, NumFiles: 1}, {Level: 6, NumFiles: 2}}},
 			`"Levels":[{"Level":0,"NumFiles":1},{"Level":6,"NumFiles":2}]`,
+		},
+		{
+			&CapturedIndexUsageStats{TotalReadCount: 1, MVCCStats: &enginepb.MVCCStats{LiveBytes: 1, LiveCount: 1}},
+			`"TotalReadCount":1,"MVCCStats":{"liveBytes":"1","liveCount":"1"}`,
 		},
 	}
 

--- a/pkg/util/log/eventpb/eventpbgen/gen.go
+++ b/pkg/util/log/eventpb/eventpbgen/gen.go
@@ -387,7 +387,7 @@ func readInput(
 			switch typ {
 			case "google.protobuf.Timestamp":
 				typ = "timestamp"
-			case "cockroach.sql.sqlbase.Descriptor":
+			case "cockroach.sql.sqlbase.Descriptor", "cockroach.storage.enginepb.MVCCStats":
 				typ = "protobuf"
 			}
 

--- a/pkg/util/log/eventpb/json_encode_generated.go
+++ b/pkg/util/log/eventpb/json_encode_generated.go
@@ -810,6 +810,92 @@ func (m *CapturedIndexUsageStats) AppendJSONFields(printComma bool, b redact.Red
 		b = append(b, '"')
 	}
 
+	if m.IsVisible {
+		if printComma {
+			b = append(b, ',')
+		}
+		printComma = true
+		b = append(b, "\"IsVisible\":true"...)
+	}
+
+	if m.IsSharded {
+		if printComma {
+			b = append(b, ',')
+		}
+		printComma = true
+		b = append(b, "\"IsSharded\":true"...)
+	}
+
+	if m.ShardBucketCount != 0 {
+		if printComma {
+			b = append(b, ',')
+		}
+		printComma = true
+		b = append(b, "\"ShardBucketCount\":"...)
+		b = strconv.AppendInt(b, int64(m.ShardBucketCount), 10)
+	}
+
+	if m.TableDropTime != "" {
+		if printComma {
+			b = append(b, ',')
+		}
+		printComma = true
+		b = append(b, "\"TableDropTime\":\""...)
+		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(m.TableDropTime)))
+		b = append(b, '"')
+	}
+
+	if m.TableModTime != "" {
+		if printComma {
+			b = append(b, ',')
+		}
+		printComma = true
+		b = append(b, "\"TableModTime\":\""...)
+		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(m.TableModTime)))
+		b = append(b, '"')
+	}
+
+	if m.TableModTimeLogical != 0 {
+		if printComma {
+			b = append(b, ',')
+		}
+		printComma = true
+		b = append(b, "\"TableModTimeLogical\":"...)
+		b = strconv.AppendFloat(b, float64(m.TableModTimeLogical), 'f', -1, 32)
+	}
+
+	if m.TableAuditMode != "" {
+		if printComma {
+			b = append(b, ',')
+		}
+		printComma = true
+		b = append(b, "\"TableAuditMode\":\""...)
+		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(m.TableAuditMode)))
+		b = append(b, '"')
+	}
+
+	if m.TableLocality != "" {
+		if printComma {
+			b = append(b, ',')
+		}
+		printComma = true
+		b = append(b, "\"TableLocality\":\""...)
+		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(m.TableLocality)))
+		b = append(b, '"')
+	}
+
+	if m.MVCCStats != nil {
+		if printComma {
+			b = append(b, ',')
+		}
+		printComma = true
+		jsonEncoder := jsonpb.Marshaler{}
+		if str, err := jsonEncoder.MarshalToString(m.MVCCStats); err == nil {
+			b = append(b, "\"MVCCStats\":"...)
+			b = append(b, []byte(str)...)
+		}
+	}
+
 	return printComma, b
 }
 

--- a/pkg/util/log/eventpb/telemetry.proto
+++ b/pkg/util/log/eventpb/telemetry.proto
@@ -14,6 +14,7 @@ option go_package = "github.com/cockroachdb/cockroach/pkg/util/log/eventpb";
 
 import "gogoproto/gogo.proto";
 import "sql/catalog/descpb/structured.proto";
+import "storage/enginepb/mvcc.proto";
 import "util/log/eventpb/events.proto";
 import "util/log/eventpb/sql_audit_events.proto";
 import "util/log/logpb/event.proto";
@@ -232,6 +233,33 @@ message CapturedIndexUsageStats {
 
   // SchemaName is the name of the schema in which the index was created.
   string schema_name = 13 [(gogoproto.jsontag) = ",omitempty", (gogoproto.moretags) = "redact:\"nonsensitive\""];
+
+  // IsVisible indicates whether the index is visible or not.
+  bool is_visible = 14 [(gogoproto.jsontag) = ",omitempty"];
+
+  // IsSharded indicates whether the index is sharded or not.
+  bool is_sharded = 15 [(gogoproto.jsontag) = ",omitempty"];
+
+  // ShardBucketCount indicates the number of shards the index is divided into.
+  int32 shard_bucket_count = 16 [(gogoproto.jsontag) = ",omitempty"];
+
+  // DropTime is the timestamp at which the table was dropped.
+  string table_drop_time = 17 [(gogoproto.jsontag) = ",omitempty", (gogoproto.moretags) = "redact:\"nonsensitive\""];
+
+  // ModTime is the timestamp at which the table was last modified.
+  string table_mod_time = 18 [(gogoproto.jsontag) = ",omitempty", (gogoproto.moretags) = "redact:\"nonsensitive\""];
+
+  // ModTimeLogical is the unix nanos at which the table was last modified.
+  float table_mod_time_logical = 19 [(gogoproto.jsontag) = ",omitempty"];
+
+  // AuditMode indicates if the table has audit logging set.
+  string table_audit_mode = 20 [(gogoproto.jsontag) = ",omitempty", (gogoproto.moretags) = "redact:\"nonsensitive\""];
+
+  // Locality is the location associated with the table.
+  string table_locality = 21 [(gogoproto.jsontag) = ",omitempty", (gogoproto.moretags) = "redact:\"nonsensitive\""];
+  
+  // MVCCStats is a message containing replica stats related to a given table name.
+  cockroach.storage.enginepb.MVCCStats mvcc_stats = 22 [(gogoproto.customname) = "MVCCStats", (gogoproto.jsontag) = ",omitempty"];
 }
 
 // CreateChangefeed is an event for any CREATE CHANGEFEED query that


### PR DESCRIPTION
This PR adds the following fields to CapturedIndexUsageStats in order to be logged to the telemetry channel:
- is_visible
- is_sharded
- shard_bucket_count
- drop_time
- mod_time
- mod_time_logical
- audit_mode
- locality
- mvcc_stats

mvcc_stats defines mvcc stats related to each table name retrieved in the
CapturedIndexUsageStats query. The stats are the ones defined in storage/enginepb/mvcc.proto.

Fixes: #85411, #92170

Release note: None