### PR TITLE
ui: check if onPageChanged prop exists before calling it

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.tsx
@@ -406,7 +406,7 @@ export class StatementsPage extends React.Component<
   onChangePage = (current: number): void => {
     const { pagination } = this.state;
     this.setState({ pagination: { ...pagination, current } });
-    this.props.onPageChanged(current);
+    this.props.onPageChanged != null && this.props.onPageChanged(current);
   };
 
   onSubmitSearchField = (search: string): void => {


### PR DESCRIPTION
Fixes #96180.

This commit checks if the onPageChanged dispatch prop exists before calling it.

Epic: none

Release note: None