### PR TITLE
privilege: don't error when retrieving an unknown privilege

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/synthetic_privileges
+++ b/pkg/sql/logictest/testdata/logic_test/synthetic_privileges
@@ -340,3 +340,38 @@ query B
 SELECT has_table_privilege('testuser4', 'crdb_internal.tables', 'SELECT')
 ----
 false
+
+# This subtest makes sure that an unknown privilege in the system.privileges
+# table does not break code that is trying to look up other privileges.
+# This situation can happen if a new synthetic privilege is backported to an
+# older branch.
+subtest unknown_privilege
+
+statement ok
+INSERT INTO system.users VALUES ('node', NULL, true, 0);
+GRANT node TO root;
+
+statement ok
+UPDATE system.privileges SET privileges = '{FAKE_PRIVILEGE}'
+WHERE username = 'testuser' AND path = '/global/'
+
+query TTTTO
+SELECT * FROM system.privileges
+WHERE username = 'testuser' AND path = '/global/'
+----
+testuser  /global/  {FAKE_PRIVILEGE}  {}  102
+
+user testuser
+
+# The error shouldn't be related to FAKE_PRIVILEGE.
+statement error only users with the MODIFYCLUSTERSETTING privilege are allowed to set cluster setting
+SET CLUSTER SETTING sql.defaults.default_int_size = 8
+
+user root
+
+statement ok
+REVOKE SYSTEM ALL FROM testuser;
+REVOKE node FROM root;
+DELETE FROM system.users WHERE username = 'node';
+
+subtest end

--- a/pkg/sql/privilege/privilege.go
+++ b/pkg/sql/privilege/privilege.go
@@ -283,13 +283,16 @@ func PrivilegesFromBitFields(kindBits, grantOptionBits uint64, objectType Object
 
 // ListFromStrings takes a list of strings and attempts to build a list of Kind.
 // We convert each string to uppercase and search for it in the ByName map.
-// If an entry is not found in ByName, an error is returned.
+// If an entry is not found in ByName, it is ignored.
 func ListFromStrings(strs []string) (List, error) {
 	ret := make(List, len(strs))
 	for i, s := range strs {
 		k, ok := ByName[strings.ToUpper(s)]
 		if !ok {
-			return nil, errors.Errorf("not a valid privilege: %q", s)
+			// Ignore an unknown privilege name. This is so that it is possible to
+			// backport new privileges onto older release branches, without causing
+			// mixed-version compatibility issues.
+			continue
 		}
 		ret[i] = k
 	}


### PR DESCRIPTION
This makes it so that we can backport new system privileges onto older release branches. NB: We still cannot backport new system privileges to v22.2, since it does not include this change.

fixes https://github.com/cockroachdb/cockroach/issues/98164
informs https://github.com/cockroachdb/cockroach/issues/98155
Release note: None