### PR TITLE
server: configure nodelocal storage for shared-process tenant servers

### DIFF
--- a/pkg/blobs/client_test.go
+++ b/pkg/blobs/client_test.go
@@ -87,9 +87,10 @@ func setUpService(
 	localNodeIDContainer := &base.NodeIDContainer{}
 	localNodeIDContainer.Set(context.Background(), localNodeID)
 	return NewBlobClientFactory(
-		localNodeIDContainer,
+		base.NewSQLIDContainerForNode(localNodeIDContainer),
 		localDialer,
 		localExternalDir,
+		true, /* allowLocalFastpath */
 	)
 }
 

--- a/pkg/blobs/service.go
+++ b/pkg/blobs/service.go
@@ -70,6 +70,7 @@ func (s *Service) PutStream(stream blobspb.Blob_PutStreamServer) error {
 	if filename == "" {
 		return errors.New("invalid filename in metadata")
 	}
+
 	reader := newPutStreamReader(stream)
 	defer reader.Close(stream.Context())
 	ctx, cancel := context.WithCancel(stream.Context())
@@ -80,9 +81,10 @@ func (s *Service) PutStream(stream blobspb.Blob_PutStreamServer) error {
 		cancel()
 		return err
 	}
+
 	if _, err := io.Copy(w, ioctx.ReaderCtxAdapter(stream.Context(), reader)); err != nil {
 		cancel()
-		return errors.CombineErrors(w.Close(), err)
+		return errors.CombineErrors(err, w.Close())
 	}
 	err = w.Close()
 	cancel()

--- a/pkg/ccl/backupccl/alter_backup_schedule_test.go
+++ b/pkg/ccl/backupccl/alter_backup_schedule_test.go
@@ -105,7 +105,7 @@ INSERT INTO t1 values (1), (10), (100);
 `)
 
 	rows := th.sqlDB.Query(t,
-		`CREATE SCHEDULE FOR BACKUP t1 INTO 'nodelocal://0/backup/alter-schedule' RECURRING '@daily';`)
+		`CREATE SCHEDULE FOR BACKUP t1 INTO 'nodelocal://1/backup/alter-schedule' RECURRING '@daily';`)
 	require.NoError(t, rows.Err())
 
 	var scheduleID int64
@@ -136,8 +136,8 @@ INSERT INTO t1 values (1), (10), (100);
 	require.Equal(t, []string{"PAUSED: Waiting for initial backup to complete", "ACTIVE"}, statuses)
 	require.Equal(t, []string{"@daily", "@weekly"}, schedules)
 	require.Equal(t, []string{
-		"BACKUP TABLE mydb.public.t1 INTO LATEST IN 'nodelocal://0/backup/alter-schedule' WITH detached",
-		"BACKUP TABLE mydb.public.t1 INTO 'nodelocal://0/backup/alter-schedule' WITH detached",
+		"BACKUP TABLE mydb.public.t1 INTO LATEST IN 'nodelocal://1/backup/alter-schedule' WITH detached",
+		"BACKUP TABLE mydb.public.t1 INTO 'nodelocal://1/backup/alter-schedule' WITH detached",
 	},
 		backupStmts)
 

--- a/pkg/ccl/backupccl/backup_test.go
+++ b/pkg/ccl/backupccl/backup_test.go
@@ -640,8 +640,8 @@ func TestBackupRestoreAppend(t *testing.T) {
 			"nodelocal",
 			// for testing backup *into* collection, pick collection shards on each
 			// node.
-			makeCollections(`nodelocal://0/`, `nodelocal://1/`, `nodelocal://2/`),
-			makeCollectionsWithSubdir(`nodelocal://0`, `nodelocal://1`, `nodelocal://2`),
+			makeCollections(`nodelocal://1/`, `nodelocal://2/`, `nodelocal://3/`),
+			makeCollectionsWithSubdir(`nodelocal://1`, `nodelocal://2`, `nodelocal://3`),
 		},
 		{
 			"userfile",
@@ -764,8 +764,8 @@ func TestBackupAndRestoreJobDescription(t *testing.T) {
 	_, sqlDB, tmpDir, cleanupFn := backupRestoreTestSetup(t, multiNode, numAccounts, InitManualReplication)
 	defer cleanupFn()
 
-	const c1, c2, c3 = `nodelocal://0/full/`, `nodelocal://1/full/`, `nodelocal://2/full/`
-	const i1, i2, i3 = `nodelocal://0/inc/`, `nodelocal://1/inc/`, `nodelocal://2/inc/`
+	const c1, c2, c3 = `nodelocal://1/full/`, `nodelocal://2/full/`, `nodelocal://3/full/`
+	const i1, i2, i3 = `nodelocal://1/inc/`, `nodelocal://3/inc/`, `nodelocal://3/inc/`
 
 	const localFoo1, localFoo2, localFoo3 = localFoo + "/1", localFoo + "/2", localFoo + "/3"
 	backups := []interface{}{
@@ -1832,7 +1832,7 @@ func TestBackupRestoreResume(t *testing.T) {
 					t, sqlDB, []descpb.ID{backupTableDesc.GetID()},
 					jobspb.BackupDetails{
 						EndTime: tc.Servers[0].Clock().Now(),
-						URI:     "nodelocal://0/backup" + "-" + item.testName,
+						URI:     "nodelocal://1/backup" + "-" + item.testName,
 					},
 					jobspb.BackupProgress{},
 					roachpb.Version{},
@@ -1867,7 +1867,7 @@ func TestBackupRestoreResume(t *testing.T) {
 		// We backup into two different directories in the tests above so
 		// as to not intefere with each other. However, they should both be
 		// the same to RESTORE so we arbitrarily pick this directory.
-		restoreDir := "nodelocal://0/restore-backup-progress-directory"
+		restoreDir := "nodelocal://1/restore-backup-progress-directory"
 		sqlDB.Exec(t, `BACKUP DATABASE DATA TO $1`, restoreDir)
 		sqlDB.Exec(t, `CREATE DATABASE restoredb`)
 		restoreDatabaseID := sqlutils.QueryDatabaseID(t, sqlDB.DB, "restoredb")
@@ -1953,7 +1953,7 @@ func TestBackupRestoreUserDefinedSchemas(t *testing.T) {
 		sqlDB.Exec(t, `CREATE TABLE sc.t1 (a STRING);
 `)
 		sqlDB.QueryRow(t, `SELECT cluster_logical_timestamp()`).Scan(&ts4)
-		sqlDB.Exec(t, `BACKUP DATABASE d TO 'nodelocal://0/rev-history-backup' WITH revision_history`)
+		sqlDB.Exec(t, `BACKUP DATABASE d TO 'nodelocal://1/rev-history-backup' WITH revision_history`)
 
 		sqlDB.Exec(t, `DROP TABLE sc.t1;`)
 		sqlDB.Exec(t, `DROP SCHEMA sc;
@@ -1963,42 +1963,42 @@ func TestBackupRestoreUserDefinedSchemas(t *testing.T) {
 		sqlDB.Exec(t, `CREATE SCHEMA sc;`)
 		sqlDB.Exec(t, `CREATE TABLE sc.t1 (a FLOAT);`)
 		sqlDB.QueryRow(t, `SELECT cluster_logical_timestamp()`).Scan(&ts6)
-		sqlDB.Exec(t, `BACKUP DATABASE d TO 'nodelocal://0/rev-history-backup' WITH revision_history`)
+		sqlDB.Exec(t, `BACKUP DATABASE d TO 'nodelocal://1/rev-history-backup' WITH revision_history`)
 
 		t.Run("ts1", func(t *testing.T) {
 			sqlDB.Exec(t, "DROP DATABASE d;")
-			sqlDB.Exec(t, "RESTORE DATABASE d FROM 'nodelocal://0/rev-history-backup' AS OF SYSTEM TIME "+ts1)
+			sqlDB.Exec(t, "RESTORE DATABASE d FROM 'nodelocal://1/rev-history-backup' AS OF SYSTEM TIME "+ts1)
 			sqlDB.Exec(t, "INSERT INTO d.sc.t1 VALUES (1)")
 			sqlDB.Exec(t, "INSERT INTO d.sc2.t1 VALUES (true)")
 			sqlDB.Exec(t, "USE d; CREATE SCHEMA unused;")
 		})
 		t.Run("ts2", func(t *testing.T) {
 			sqlDB.Exec(t, "DROP DATABASE d;")
-			sqlDB.Exec(t, "RESTORE DATABASE d FROM 'nodelocal://0/rev-history-backup' AS OF SYSTEM TIME "+ts2)
+			sqlDB.Exec(t, "RESTORE DATABASE d FROM 'nodelocal://1/rev-history-backup' AS OF SYSTEM TIME "+ts2)
 			sqlDB.Exec(t, "INSERT INTO d.sc3.t1 VALUES (1)")
 			sqlDB.Exec(t, "INSERT INTO d.sc.t1 VALUES (true)")
 		})
 		t.Run("ts3", func(t *testing.T) {
 			sqlDB.Exec(t, "DROP DATABASE d;")
-			sqlDB.Exec(t, "RESTORE DATABASE d FROM 'nodelocal://0/rev-history-backup' AS OF SYSTEM TIME "+ts3)
+			sqlDB.Exec(t, "RESTORE DATABASE d FROM 'nodelocal://1/rev-history-backup' AS OF SYSTEM TIME "+ts3)
 			sqlDB.Exec(t, "USE d")
 			sqlDB.Exec(t, "CREATE SCHEMA sc")
 			sqlDB.Exec(t, "CREATE SCHEMA sc3;")
 		})
 		t.Run("ts4", func(t *testing.T) {
 			sqlDB.Exec(t, "DROP DATABASE d;")
-			sqlDB.Exec(t, "RESTORE DATABASE d FROM 'nodelocal://0/rev-history-backup' AS OF SYSTEM TIME "+ts4)
+			sqlDB.Exec(t, "RESTORE DATABASE d FROM 'nodelocal://1/rev-history-backup' AS OF SYSTEM TIME "+ts4)
 			sqlDB.Exec(t, "INSERT INTO d.sc.t1 VALUES ('hello')")
 		})
 		t.Run("ts5", func(t *testing.T) {
 			sqlDB.Exec(t, "DROP DATABASE d;")
-			sqlDB.Exec(t, "RESTORE DATABASE d FROM 'nodelocal://0/rev-history-backup' AS OF SYSTEM TIME "+ts5)
+			sqlDB.Exec(t, "RESTORE DATABASE d FROM 'nodelocal://1/rev-history-backup' AS OF SYSTEM TIME "+ts5)
 			sqlDB.Exec(t, "USE d")
 			sqlDB.Exec(t, "CREATE SCHEMA sc")
 		})
 		t.Run("ts6", func(t *testing.T) {
 			sqlDB.Exec(t, "DROP DATABASE d;")
-			sqlDB.Exec(t, "RESTORE DATABASE d FROM 'nodelocal://0/rev-history-backup' AS OF SYSTEM TIME "+ts6)
+			sqlDB.Exec(t, "RESTORE DATABASE d FROM 'nodelocal://1/rev-history-backup' AS OF SYSTEM TIME "+ts6)
 			sqlDB.Exec(t, `INSERT INTO d.sc.t1 VALUES (123.123)`)
 		})
 	})
@@ -2017,13 +2017,13 @@ func TestBackupRestoreUserDefinedSchemas(t *testing.T) {
 		sqlDB.Exec(t, `CREATE TABLE sc.tb2 (x sc.typ1);`)
 		sqlDB.Exec(t, `INSERT INTO sc.tb2 VALUES ('hello');`)
 		// Now backup the full cluster.
-		sqlDB.Exec(t, `BACKUP TO 'nodelocal://0/test/'`)
+		sqlDB.Exec(t, `BACKUP TO 'nodelocal://1/test/'`)
 		// Start a new server that shares the data directory.
 		_, sqlDBRestore, cleanupRestore := backupRestoreTestSetupEmpty(t, singleNode, dataDir, InitManualReplication, base.TestClusterArgs{})
 		defer cleanupRestore()
 
 		// Restore into the new cluster.
-		sqlDBRestore.Exec(t, `RESTORE FROM 'nodelocal://0/test/'`)
+		sqlDBRestore.Exec(t, `RESTORE FROM 'nodelocal://1/test/'`)
 
 		// Check that we can resolve all names through the user defined schema.
 		sqlDBRestore.CheckQueryResults(t, `SELECT * FROM d.sc.tb1`, [][]string{{"1"}})
@@ -2050,11 +2050,11 @@ func TestBackupRestoreUserDefinedSchemas(t *testing.T) {
 		sqlDB.Exec(t, `CREATE TABLE sc.tb2 (x sc.typ1);`)
 		sqlDB.Exec(t, `INSERT INTO sc.tb2 VALUES ('hello');`)
 		// Backup the database.
-		sqlDB.Exec(t, `BACKUP DATABASE d TO 'nodelocal://0/test/'`)
+		sqlDB.Exec(t, `BACKUP DATABASE d TO 'nodelocal://1/test/'`)
 
 		// Drop the database and restore into it.
 		sqlDB.Exec(t, `DROP DATABASE d`)
-		sqlDB.Exec(t, `RESTORE DATABASE d FROM 'nodelocal://0/test/'`)
+		sqlDB.Exec(t, `RESTORE DATABASE d FROM 'nodelocal://1/test/'`)
 
 		// Check that we can resolve all names through the user defined schema.
 		sqlDB.CheckQueryResults(t, `SELECT * FROM d.sc.tb1`, [][]string{{"1"}})
@@ -2121,9 +2121,9 @@ func TestBackupRestoreUserDefinedSchemas(t *testing.T) {
 				expectedTablesInBackup: [][]string{{"data", "tb1"}, {"public", "bank"}, {"public", "table_in_data"}},
 			},
 		} {
-			sqlDB.Exec(t, fmt.Sprintf(`BACKUP TABLE %s TO 'nodelocal://0/%s'`, tc.target, tc.name))
+			sqlDB.Exec(t, fmt.Sprintf(`BACKUP TABLE %s TO 'nodelocal://1/%s'`, tc.target, tc.name))
 			sqlDB.Exec(t, `CREATE DATABASE restore`)
-			sqlDB.Exec(t, fmt.Sprintf(`RESTORE TABLE %s FROM 'nodelocal://0/%s' WITH into_db='restore'`, tc.target, tc.name))
+			sqlDB.Exec(t, fmt.Sprintf(`RESTORE TABLE %s FROM 'nodelocal://1/%s' WITH into_db='restore'`, tc.target, tc.name))
 			sqlDB.CheckQueryResults(t, `SELECT schema_name,
 table_name from [SHOW TABLES FROM restore] ORDER BY schema_name, table_name`, tc.expectedTablesInBackup)
 			sqlDB.Exec(t, `DROP DATABASE restore CASCADE`)
@@ -2147,17 +2147,17 @@ table_name from [SHOW TABLES FROM restore] ORDER BY schema_name, table_name`, tc
 		{
 			// We have to qualify the table correctly to back it up. d.tb1 resolves
 			// to d.public.tb1.
-			sqlDB.ExpectErr(t, `pq: failed to resolve targets specified in the BACKUP stmt: table "d.tb1" does not exist`, `BACKUP TABLE d.tb1 TO 'nodelocal://0/test/'`)
+			sqlDB.ExpectErr(t, `pq: failed to resolve targets specified in the BACKUP stmt: table "d.tb1" does not exist`, `BACKUP TABLE d.tb1 TO 'nodelocal://1/test/'`)
 			// Backup tb1.
-			sqlDB.Exec(t, `BACKUP TABLE d.sc.tb1 TO 'nodelocal://0/test/'`)
+			sqlDB.Exec(t, `BACKUP TABLE d.sc.tb1 TO 'nodelocal://1/test/'`)
 			// Create a new database to restore into. This restore should restore the
 			// schema sc into the new database.
 			sqlDB.Exec(t, `CREATE DATABASE d2`)
 
 			// We must properly qualify the table name when restoring as well.
-			sqlDB.ExpectErr(t, `pq: failed to resolve targets in the BACKUP location specified by the RESTORE statement, use SHOW BACKUP to find correct targets: table "d.tb1" does not exist`, `RESTORE TABLE d.tb1 FROM 'nodelocal://0/test/' WITH into_db = 'd2'`)
+			sqlDB.ExpectErr(t, `pq: failed to resolve targets in the BACKUP location specified by the RESTORE statement, use SHOW BACKUP to find correct targets: table "d.tb1" does not exist`, `RESTORE TABLE d.tb1 FROM 'nodelocal://1/test/' WITH into_db = 'd2'`)
 
-			sqlDB.Exec(t, `RESTORE TABLE d.sc.tb1 FROM 'nodelocal://0/test/' WITH into_db = 'd2'`)
+			sqlDB.Exec(t, `RESTORE TABLE d.sc.tb1 FROM 'nodelocal://1/test/' WITH into_db = 'd2'`)
 
 			// Check that we can resolve all names through the user defined schema.
 			sqlDB.CheckQueryResults(t, `SELECT * FROM d2.sc.tb1`, [][]string{{"hello"}})
@@ -2170,10 +2170,10 @@ table_name from [SHOW TABLES FROM restore] ORDER BY schema_name, table_name`, tc
 		{
 			// Test that we can * expand schema prefixed names. Create a new backup
 			// with all the tables in d.sc.
-			sqlDB.Exec(t, `BACKUP TABLE d.sc.* TO 'nodelocal://0/test2/'`)
+			sqlDB.Exec(t, `BACKUP TABLE d.sc.* TO 'nodelocal://1/test2/'`)
 			// Create a new database to restore into.
 			sqlDB.Exec(t, `CREATE DATABASE d3`)
-			sqlDB.Exec(t, `RESTORE TABLE d.sc.* FROM 'nodelocal://0/test2/' WITH into_db = 'd3'`)
+			sqlDB.Exec(t, `RESTORE TABLE d.sc.* FROM 'nodelocal://1/test2/' WITH into_db = 'd3'`)
 
 			// Check that we can resolve all names through the user defined schema.
 			sqlDB.CheckQueryResults(t, `SELECT * FROM d3.sc.tb1`, [][]string{{"hello"}})
@@ -2211,7 +2211,7 @@ table_name from [SHOW TABLES FROM restore] ORDER BY schema_name, table_name`, tc
 		sqlDB.Exec(t, `INSERT INTO sc4.tb VALUES (4);`)
 		{
 			// Backup all databases.
-			sqlDB.Exec(t, `BACKUP DATABASE d1, d2 TO 'nodelocal://0/test/'`)
+			sqlDB.Exec(t, `BACKUP DATABASE d1, d2 TO 'nodelocal://1/test/'`)
 			// Create a new database to restore into. This restore should restore the
 			// schemas into the new database.
 			sqlDB.Exec(t, `CREATE DATABASE newdb`)
@@ -2222,7 +2222,7 @@ table_name from [SHOW TABLES FROM restore] ORDER BY schema_name, table_name`, tc
 			sqlDB.Exec(t, `CREATE TABLE existingschema.tb (x INT)`)
 			sqlDB.Exec(t, `INSERT INTO existingschema.tb VALUES (0)`)
 
-			sqlDB.Exec(t, `RESTORE TABLE d1.sc1.*, d1.sc2.*, d2.sc3.*, d2.sc4.* FROM 'nodelocal://0/test/' WITH into_db = 'newdb'`)
+			sqlDB.Exec(t, `RESTORE TABLE d1.sc1.*, d1.sc2.*, d2.sc3.*, d2.sc4.* FROM 'nodelocal://1/test/' WITH into_db = 'newdb'`)
 
 			// Check that we can resolve all names through the user defined schemas.
 			sqlDB.CheckQueryResults(t, `SELECT * FROM newdb.sc1.tb`, [][]string{{"1"}})
@@ -2255,11 +2255,11 @@ table_name from [SHOW TABLES FROM restore] ORDER BY schema_name, table_name`, tc
 		sqlDB.Exec(t, `CREATE TABLE sc.tb1 (x sc.typ1);`)
 		sqlDB.Exec(t, `INSERT INTO sc.tb1 VALUES ('hello');`)
 		// Take a backup.
-		sqlDB.Exec(t, `BACKUP TABLE d.sc.tb1 TO 'nodelocal://0/test/'`)
+		sqlDB.Exec(t, `BACKUP TABLE d.sc.tb1 TO 'nodelocal://1/test/'`)
 		// Now drop the table.
 		sqlDB.Exec(t, `DROP TABLE d.sc.tb1`)
 		// Restoring the table should restore into d.sc.
-		sqlDB.Exec(t, `RESTORE TABLE d.sc.tb1 FROM 'nodelocal://0/test/'`)
+		sqlDB.Exec(t, `RESTORE TABLE d.sc.tb1 FROM 'nodelocal://1/test/'`)
 		sqlDB.CheckQueryResults(t, `SELECT * FROM d.sc.tb1`, [][]string{{"hello"}})
 	})
 }
@@ -2304,7 +2304,7 @@ CREATE TABLE d.t1 (x d.farewell);
 `)
 		sqlDB.QueryRow(t, `SELECT cluster_logical_timestamp()`).Scan(&ts3)
 		// Make a full backup that includes ts1, ts2 and ts3.
-		sqlDB.Exec(t, `BACKUP DATABASE d TO 'nodelocal://0/rev-history-backup' WITH revision_history`)
+		sqlDB.Exec(t, `BACKUP DATABASE d TO 'nodelocal://1/rev-history-backup' WITH revision_history`)
 
 		sqlDB.Exec(t, `
 DROP TABLE d.t1;
@@ -2318,7 +2318,7 @@ CREATE TABLE d.t1 (x d.farewell);
 `)
 		sqlDB.QueryRow(t, `SELECT cluster_logical_timestamp()`).Scan(&ts5)
 		// Make an incremental backup that includes ts4 and ts5.
-		sqlDB.Exec(t, `BACKUP DATABASE d TO 'nodelocal://0/rev-history-backup' WITH revision_history`)
+		sqlDB.Exec(t, `BACKUP DATABASE d TO 'nodelocal://1/rev-history-backup' WITH revision_history`)
 
 		t.Run("ts1", func(t *testing.T) {
 			// Expect the farewell type ('bye', 'cya') to be restored - from the full
@@ -2326,7 +2326,7 @@ CREATE TABLE d.t1 (x d.farewell);
 			sqlDB.Exec(t, `DROP DATABASE d;`)
 			sqlDB.Exec(t,
 				fmt.Sprintf(`
-RESTORE DATABASE d FROM 'nodelocal://0/rev-history-backup'
+RESTORE DATABASE d FROM 'nodelocal://1/rev-history-backup'
   AS OF SYSTEM TIME %s
 `, ts1))
 			sqlDB.ExpectErr(t, `pq: type "d.public.farewell" already exists`,
@@ -2345,7 +2345,7 @@ RESTORE DATABASE d FROM 'nodelocal://0/rev-history-backup'
 			sqlDB.Exec(t, `DROP DATABASE d;`)
 			sqlDB.Exec(t,
 				fmt.Sprintf(`
-		RESTORE DATABASE d FROM 'nodelocal://0/rev-history-backup'
+		RESTORE DATABASE d FROM 'nodelocal://1/rev-history-backup'
 		 AS OF SYSTEM TIME %s
 		`, ts2))
 			sqlDB.Exec(t, `CREATE TYPE d.farewell AS ENUM ('bye', 'cya')`)
@@ -2357,7 +2357,7 @@ RESTORE DATABASE d FROM 'nodelocal://0/rev-history-backup'
 			sqlDB.Exec(t, `DROP DATABASE d;`)
 			sqlDB.Exec(t,
 				fmt.Sprintf(`
-		RESTORE DATABASE d FROM 'nodelocal://0/rev-history-backup'
+		RESTORE DATABASE d FROM 'nodelocal://1/rev-history-backup'
 		 AS OF SYSTEM TIME %s
 		`, ts3))
 			sqlDB.ExpectErr(t, `pq: type "d.public.farewell" already exists`,
@@ -2376,7 +2376,7 @@ RESTORE DATABASE d FROM 'nodelocal://0/rev-history-backup'
 			sqlDB.Exec(t, `DROP DATABASE d;`)
 			sqlDB.Exec(t,
 				fmt.Sprintf(`
-		RESTORE DATABASE d FROM 'nodelocal://0/rev-history-backup'
+		RESTORE DATABASE d FROM 'nodelocal://1/rev-history-backup'
 		 AS OF SYSTEM TIME %s
 		`, ts4))
 			sqlDB.Exec(t, `CREATE TYPE d.farewell AS ENUM ('bye', 'cya')`)
@@ -2388,7 +2388,7 @@ RESTORE DATABASE d FROM 'nodelocal://0/rev-history-backup'
 			sqlDB.Exec(t, `DROP DATABASE d;`)
 			sqlDB.Exec(t,
 				fmt.Sprintf(`
-		RESTORE DATABASE d FROM 'nodelocal://0/rev-history-backup'
+		RESTORE DATABASE d FROM 'nodelocal://1/rev-history-backup'
 		 AS OF SYSTEM TIME %s
 		`, ts5))
 			sqlDB.ExpectErr(t, `pq: type "d.public.farewell" already exists`,
@@ -2420,11 +2420,11 @@ INSERT INTO d.t3 VALUES ('hi');
 		// Test backups of t.
 		{
 			// Now backup t.
-			sqlDB.Exec(t, `BACKUP TABLE d.t TO 'nodelocal://0/test/'`)
+			sqlDB.Exec(t, `BACKUP TABLE d.t TO 'nodelocal://1/test/'`)
 			// Create a new database to restore the table into.
 			sqlDB.Exec(t, `CREATE DATABASE d2`)
 			// Restore t into d2.
-			sqlDB.Exec(t, `RESTORE TABLE d.t FROM 'nodelocal://0/test/' WITH into_db = 'd2'`)
+			sqlDB.Exec(t, `RESTORE TABLE d.t FROM 'nodelocal://1/test/' WITH into_db = 'd2'`)
 			// Ensure that greeting type has been restored into d2 as well.
 			sqlDB.Exec(t, `CREATE TABLE d2.t2 (x d2.greeting, y d2._greeting)`)
 			// Check that the table data is as expected.
@@ -2435,11 +2435,11 @@ INSERT INTO d.t3 VALUES ('hi');
 		// checking that the base type gets included as well.
 		{
 			// Now backup t2.
-			sqlDB.Exec(t, `BACKUP TABLE d.t2 TO 'nodelocal://0/test2/'`)
+			sqlDB.Exec(t, `BACKUP TABLE d.t2 TO 'nodelocal://1/test2/'`)
 			// Create a new database to restore the table into.
 			sqlDB.Exec(t, `CREATE DATABASE d3`)
 			// Restore t2 into d3.
-			sqlDB.Exec(t, `RESTORE TABLE d.t2 FROM 'nodelocal://0/test2/' WITH into_db = 'd3'`)
+			sqlDB.Exec(t, `RESTORE TABLE d.t2 FROM 'nodelocal://1/test2/' WITH into_db = 'd3'`)
 			// Ensure that the base type and array type have been restored into d3.
 			sqlDB.Exec(t, `CREATE TABLE d3.t (x d3.greeting, y d3._greeting)`)
 			// Check that the table data is as expected.
@@ -2449,11 +2449,11 @@ INSERT INTO d.t3 VALUES ('hi');
 		// Create a backup of all the tables in d.
 		{
 			// Backup all of the tables.
-			sqlDB.Exec(t, `BACKUP d.* TO 'nodelocal://0/test_all_tables/'`)
+			sqlDB.Exec(t, `BACKUP d.* TO 'nodelocal://1/test_all_tables/'`)
 			// Create a new database to restore all of the tables into.
 			sqlDB.Exec(t, `CREATE DATABASE d4`)
 			// Restore all of the tables.
-			sqlDB.Exec(t, `RESTORE TABLE d.* FROM 'nodelocal://0/test_all_tables/' WITH into_db = 'd4'`)
+			sqlDB.Exec(t, `RESTORE TABLE d.* FROM 'nodelocal://1/test_all_tables/' WITH into_db = 'd4'`)
 			// Check that all of the tables have expected data.
 			sqlDB.CheckQueryResults(t, `SELECT * FROM d4.t ORDER BY x`, [][]string{{"hello"}, {"howdy"}})
 			sqlDB.CheckQueryResults(t, `SELECT * FROM d4.t2 ORDER BY x`, [][]string{{"{hello}"}})
@@ -2479,9 +2479,9 @@ INSERT INTO d.t2 VALUES (ARRAY['hello']);
 `)
 		{
 			// Backup and restore t.
-			sqlDB.Exec(t, `BACKUP TABLE d.t TO 'nodelocal://0/test/'`)
+			sqlDB.Exec(t, `BACKUP TABLE d.t TO 'nodelocal://1/test/'`)
 			sqlDB.Exec(t, `DROP TABLE d.t`)
-			sqlDB.Exec(t, `RESTORE TABLE d.t FROM 'nodelocal://0/test/'`)
+			sqlDB.Exec(t, `RESTORE TABLE d.t FROM 'nodelocal://1/test/'`)
 
 			// Check that the table data is restored correctly and the types aren't touched.
 			sqlDB.CheckQueryResults(t, `SELECT 'hello'::d.greeting, ARRAY['hello']::d.greeting[]`, [][]string{{"hello", "{hello}"}})
@@ -2494,9 +2494,9 @@ INSERT INTO d.t2 VALUES (ARRAY['hello']);
 		{
 			// Test that backing up an restoring a table with just the array type
 			// will remap types appropriately.
-			sqlDB.Exec(t, `BACKUP TABLE d.t2 TO 'nodelocal://0/test2/'`)
+			sqlDB.Exec(t, `BACKUP TABLE d.t2 TO 'nodelocal://1/test2/'`)
 			sqlDB.Exec(t, `DROP TABLE d.t2`)
-			sqlDB.Exec(t, `RESTORE TABLE d.t2 FROM 'nodelocal://0/test2/'`)
+			sqlDB.Exec(t, `RESTORE TABLE d.t2 FROM 'nodelocal://1/test2/'`)
 			sqlDB.CheckQueryResults(t, `SELECT 'hello'::d.greeting, ARRAY['hello']::d.greeting[]`, [][]string{{"hello", "{hello}"}})
 			sqlDB.CheckQueryResults(t, `SELECT * FROM d.t2 ORDER BY x`, [][]string{{"{hello}"}})
 		}
@@ -2507,12 +2507,12 @@ INSERT INTO d.t2 VALUES (ARRAY['hello']);
 			sqlDB.Exec(t, `CREATE TYPE d2.greeting AS ENUM ('hello', 'howdy', 'hi')`)
 
 			// Now restore t into this database. It should remap d.greeting to d2.greeting.
-			sqlDB.Exec(t, `RESTORE TABLE d.t FROM 'nodelocal://0/test/' WITH into_db = 'd2'`)
+			sqlDB.Exec(t, `RESTORE TABLE d.t FROM 'nodelocal://1/test/' WITH into_db = 'd2'`)
 			sqlDB.CheckQueryResults(t, `SELECT * FROM d2.t ORDER BY x`, [][]string{{"hello"}, {"howdy"}})
 			sqlDB.Exec(t, `INSERT INTO d2.t VALUES ('hi'::d2.greeting)`)
 
 			// Restore t2 as well.
-			sqlDB.Exec(t, `RESTORE TABLE d.t2 FROM 'nodelocal://0/test2/' WITH into_db = 'd2'`)
+			sqlDB.Exec(t, `RESTORE TABLE d.t2 FROM 'nodelocal://1/test2/' WITH into_db = 'd2'`)
 			sqlDB.CheckQueryResults(t, `SELECT * FROM d2.t2 ORDER BY x`, [][]string{{"{hello}"}})
 			sqlDB.Exec(t, `INSERT INTO d2.t2 VALUES (ARRAY['hi'::d2.greeting])`)
 
@@ -2528,12 +2528,12 @@ INSERT INTO d.t2 VALUES (ARRAY['hello']);
 
 			// Now restore t into this database. We'll attempt to remap d.greeting to
 			// d3.greeting and fail because they aren't compatible.
-			sqlDB.ExpectErr(t, `could not find enum value "hi"`, `RESTORE TABLE d.t FROM 'nodelocal://0/test/' WITH into_db = 'd3'`)
+			sqlDB.ExpectErr(t, `could not find enum value "hi"`, `RESTORE TABLE d.t FROM 'nodelocal://1/test/' WITH into_db = 'd3'`)
 
 			// Test the same case, but with differing internal representations.
 			sqlDB.Exec(t, `CREATE DATABASE d4`)
 			sqlDB.Exec(t, `CREATE TYPE d4.greeting AS ENUM ('hello', 'howdy', 'hi', 'greetings')`)
-			sqlDB.ExpectErr(t, `has differing physical representation`, `RESTORE TABLE d.t FROM 'nodelocal://0/test/' WITH into_db = 'd4'`)
+			sqlDB.ExpectErr(t, `has differing physical representation`, `RESTORE TABLE d.t FROM 'nodelocal://1/test/' WITH into_db = 'd4'`)
 		}
 
 		{
@@ -2547,14 +2547,14 @@ INSERT INTO d.t2 VALUES (ARRAY['hello']);
 			// Create a table using these ___typ1.
 			sqlDB.Exec(t, `CREATE TABLE d5.tb1 (x d5.typ1[])`)
 			// Backup tb1.
-			sqlDB.Exec(t, `BACKUP TABLE d5.tb1 TO 'nodelocal://0/testd5/'`)
+			sqlDB.Exec(t, `BACKUP TABLE d5.tb1 TO 'nodelocal://1/testd5/'`)
 
 			// Create another database with a compatible type.
 			sqlDB.Exec(t, `CREATE DATABASE d6`)
 			sqlDB.Exec(t, `CREATE TYPE d6.typ1 AS ENUM ('v1', 'v2')`)
 			// Restoring tb1 into d6 will remap d5.typ1 to d6.typ1 and d5.___typ1
 			// to d6._typ1.
-			sqlDB.Exec(t, `RESTORE TABLE d5.tb1 FROM 'nodelocal://0/testd5/' WITH into_db = 'd6'`)
+			sqlDB.Exec(t, `RESTORE TABLE d5.tb1 FROM 'nodelocal://1/testd5/' WITH into_db = 'd6'`)
 			sqlDB.Exec(t, `INSERT INTO d6.tb1 VALUES (ARRAY['v1']::d6._typ1)`)
 		}
 
@@ -2568,7 +2568,7 @@ INSERT INTO d.t2 VALUES (ARRAY['hello']);
 			sqlDB.Exec(t, `ALTER TYPE d7.greeting ADD VALUE 'greetings' BEFORE 'howdy'`)
 
 			// We should be able to restore d.greeting using d7.greeting.
-			sqlDB.Exec(t, `RESTORE TABLE d.t FROM 'nodelocal://0/test/' WITH into_db = 'd7'`)
+			sqlDB.Exec(t, `RESTORE TABLE d.t FROM 'nodelocal://1/test/' WITH into_db = 'd7'`)
 			sqlDB.Exec(t, `INSERT INTO d7.t VALUES ('greetings')`)
 			sqlDB.CheckQueryResults(t, `SELECT * FROM d7.t ORDER BY x`, [][]string{{"hello"}, {"greetings"}, {"howdy"}})
 			// d7.t should have a back reference from d7.greeting.
@@ -2639,28 +2639,28 @@ INSERT INTO d.t VALUES ('hello'), ('howdy');
 `)
 		{
 			// Start out with backing up t.
-			sqlDB.Exec(t, `BACKUP TABLE d.t TO 'nodelocal://0/test/'`)
+			sqlDB.Exec(t, `BACKUP TABLE d.t TO 'nodelocal://1/test/'`)
 			// Alter d.greeting.
 			sqlDB.Exec(t, `ALTER TYPE d.greeting RENAME TO newname`)
 			// Now backup on top of the original back containing d.greeting.
-			sqlDB.Exec(t, `BACKUP TABLE d.t TO 'nodelocal://0/test/'`)
+			sqlDB.Exec(t, `BACKUP TABLE d.t TO 'nodelocal://1/test/'`)
 			// We should be able to restore this backup, and see that the type's
 			// name change is present.
 			sqlDB.Exec(t, `CREATE DATABASE d2`)
-			sqlDB.Exec(t, `RESTORE TABLE d.t FROM 'nodelocal://0/test/' WITH into_db = 'd2'`)
+			sqlDB.Exec(t, `RESTORE TABLE d.t FROM 'nodelocal://1/test/' WITH into_db = 'd2'`)
 			sqlDB.CheckQueryResults(t, `SELECT 'hello'::d2.newname`, [][]string{{"hello"}})
 		}
 
 		{
 			// Create a database with a type, and take a backup.
 			sqlDB.Exec(t, `CREATE DATABASE d3`)
-			sqlDB.Exec(t, `BACKUP DATABASE d3 TO 'nodelocal://0/testd3/'`)
+			sqlDB.Exec(t, `BACKUP DATABASE d3 TO 'nodelocal://1/testd3/'`)
 
 			// Now create a new type in that database.
 			sqlDB.Exec(t, `CREATE TYPE d3.farewell AS ENUM ('bye', 'cya')`)
 
 			// Perform an incremental backup, which should pick up the new type.
-			sqlDB.Exec(t, `BACKUP DATABASE d3 TO 'nodelocal://0/testd3/'`)
+			sqlDB.Exec(t, `BACKUP DATABASE d3 TO 'nodelocal://1/testd3/'`)
 
 			// Until #51362 lands we have to manually clean up this type before the
 			// DROP DATABASE statement otherwise we'll leave behind an orphaned desc.
@@ -2668,7 +2668,7 @@ INSERT INTO d.t VALUES ('hello'), ('howdy');
 
 			// Now restore it.
 			sqlDB.Exec(t, `DROP DATABASE d3`)
-			sqlDB.Exec(t, `RESTORE DATABASE d3 FROM 'nodelocal://0/testd3/'`)
+			sqlDB.Exec(t, `RESTORE DATABASE d3 FROM 'nodelocal://1/testd3/'`)
 
 			// Check that we are able to use the type.
 			sqlDB.Exec(t, `CREATE TABLE d3.t (x d3.farewell)`)
@@ -2677,9 +2677,9 @@ INSERT INTO d.t VALUES ('hello'), ('howdy');
 			// If we drop the type and back up again, it should be gone.
 			sqlDB.Exec(t, `DROP TYPE d3.farewell`)
 
-			sqlDB.Exec(t, `BACKUP DATABASE d3 TO 'nodelocal://0/testd3_2/'`)
+			sqlDB.Exec(t, `BACKUP DATABASE d3 TO 'nodelocal://1/testd3_2/'`)
 			sqlDB.Exec(t, `DROP DATABASE d3`)
-			sqlDB.Exec(t, `RESTORE DATABASE d3 FROM 'nodelocal://0/testd3_2/'`)
+			sqlDB.Exec(t, `RESTORE DATABASE d3 FROM 'nodelocal://1/testd3_2/'`)
 			sqlDB.ExpectErr(t, `pq: type "d3.farewell" does not exist`, `CREATE TABLE d3.t (x d3.farewell)`)
 		}
 	})
@@ -2798,7 +2798,7 @@ CREATE TYPE d.greeting AS ENUM ('hello', 'howdy', 'hi');
 
 				// Now create a backup while the type change job is blocked so that
 				// greeting is backed up with some enum members in READ_ONLY state.
-				sqlDB.Exec(t, `BACKUP DATABASE d TO 'nodelocal://0/test/'`)
+				sqlDB.Exec(t, `BACKUP DATABASE d TO 'nodelocal://1/test/'`)
 
 				// Let the type change finish.
 				close(waitForBackup)
@@ -2806,7 +2806,7 @@ CREATE TYPE d.greeting AS ENUM ('hello', 'howdy', 'hi');
 
 				// Now drop the database and restore.
 				sqlDB.Exec(t, `DROP DATABASE d`)
-				restoreQuery := `RESTORE DATABASE d FROM 'nodelocal://0/test/'`
+				restoreQuery := `RESTORE DATABASE d FROM 'nodelocal://1/test/'`
 				if isSchemaOnly {
 					restoreQuery = restoreQuery + " with schema_only"
 				}
@@ -3235,7 +3235,7 @@ func TestBackupRestoreIncremental(t *testing.T) {
 
 			checksums = append(checksums, checksumBankPayload(t, sqlDB))
 
-			backupDir := fmt.Sprintf("nodelocal://0/%d", backupNum)
+			backupDir := fmt.Sprintf("nodelocal://1/%d", backupNum)
 			var from string
 			if backupNum > 0 {
 				from = fmt.Sprintf(` INCREMENTAL FROM %s`, strings.Join(backupDirs, `,`))
@@ -3251,9 +3251,9 @@ func TestBackupRestoreIncremental(t *testing.T) {
 		sqlDB.Exec(t, `INSERT INTO data.bank VALUES (0, -1, 'final')`)
 		checksums = append(checksums, checksumBankPayload(t, sqlDB))
 		sqlDB.Exec(t, fmt.Sprintf(`BACKUP TABLE data.bank TO '%s' %s`,
-			"nodelocal://0/final", fmt.Sprintf(` INCREMENTAL FROM %s`, strings.Join(backupDirs, `,`)),
+			"nodelocal://1/final", fmt.Sprintf(` INCREMENTAL FROM %s`, strings.Join(backupDirs, `,`)),
 		))
-		backupDirs = append(backupDirs, `'nodelocal://0/final'`)
+		backupDirs = append(backupDirs, `'nodelocal://1/final'`)
 	}
 
 	// Start a new cluster to restore into.
@@ -3273,7 +3273,7 @@ func TestBackupRestoreIncremental(t *testing.T) {
 		sqlDBRestore.ExpectErr(
 			t, fmt.Sprintf("belongs to cluster %s", tc.Servers[0].RPCContext().LogicalClusterID.Get()),
 			`BACKUP TABLE data.bank TO $1 INCREMENTAL FROM $2`,
-			"nodelocal://0/some-other-table", "nodelocal://0/0",
+			"nodelocal://1/some-other-table", "nodelocal://1/0",
 		)
 
 		for i := len(backupDirs); i > 0; i-- {
@@ -3305,8 +3305,8 @@ func TestBackupRestorePartitionedIncremental(t *testing.T) {
 
 	// Each incremental backup is written to two different subdirectories in
 	// defaultDir and dc1Dir, respectively.
-	const defaultDir = "nodelocal://0/default"
-	const dc1Dir = "nodelocal://0/dc=dc1"
+	const defaultDir = "nodelocal://1/default"
+	const dc1Dir = "nodelocal://1/dc=dc1"
 	var defaultBackupDirs []string
 	var checksums []uint32
 	{
@@ -3496,7 +3496,7 @@ func TestConcurrentBackupRestores(t *testing.T) {
 		g.Go(func() error {
 			for j := 0; j < numIterations; j++ {
 				dbName := fmt.Sprintf("%s_%d", table, j)
-				backupDir := fmt.Sprintf("nodelocal://0/%s", dbName)
+				backupDir := fmt.Sprintf("nodelocal://1/%s", dbName)
 				backupQ := fmt.Sprintf(`BACKUP data.%s TO $1`, table)
 				if _, err := sqlDB.DB.ExecContext(gCtx, backupQ, backupDir); err != nil {
 					return err
@@ -3539,10 +3539,10 @@ func TestBackupTenantsWithRevisionHistory(t *testing.T) {
 
 	const msg = "can not backup tenants with revision history"
 
-	_, err = sqlDB.DB.ExecContext(ctx, `BACKUP TENANT 10 TO 'nodelocal://0/foo' WITH revision_history`)
+	_, err = sqlDB.DB.ExecContext(ctx, `BACKUP TENANT 10 TO 'nodelocal://1/foo' WITH revision_history`)
 	require.Contains(t, fmt.Sprint(err), msg)
 
-	_, err = sqlDB.DB.ExecContext(ctx, `BACKUP TO 'nodelocal://0/bar' WITH revision_history, include_all_secondary_tenants`)
+	_, err = sqlDB.DB.ExecContext(ctx, `BACKUP TO 'nodelocal://1/bar' WITH revision_history, include_all_secondary_tenants`)
 	require.Contains(t, fmt.Sprint(err), msg)
 }
 
@@ -3620,7 +3620,7 @@ func TestRestoreAsOfSystemTime(t *testing.T) {
 	ctx := context.Background()
 	_, sqlDB, _, cleanupFn := backupRestoreTestSetup(t, singleNode, numAccounts, InitManualReplication)
 	defer cleanupFn()
-	const dir = "nodelocal://0/"
+	const dir = "nodelocal://1/"
 
 	ts := make([]string, 9)
 
@@ -3843,7 +3843,7 @@ func TestRestoreAsOfSystemTime(t *testing.T) {
 
 	t.Run("create-backup-drop-backup", func(t *testing.T) {
 		var tsBefore string
-		backupPath := "nodelocal://0/drop_table_db"
+		backupPath := "nodelocal://1/drop_table_db"
 
 		sqlDB.Exec(t, "CREATE DATABASE drop_table_db")
 		sqlDB.Exec(t, "CREATE DATABASE drop_table_db_restore")
@@ -3864,7 +3864,7 @@ func TestRestoreAsOfSystemTime(t *testing.T) {
 
 	t.Run("backup-create-drop-backup", func(t *testing.T) {
 		var tsBefore string
-		backupPath := "nodelocal://0/create_and_drop"
+		backupPath := "nodelocal://1/create_and_drop"
 
 		sqlDB.Exec(t, "CREATE DATABASE create_and_drop")
 		sqlDB.Exec(t, "CREATE DATABASE create_and_drop_restore")
@@ -3885,7 +3885,7 @@ func TestRestoreAsOfSystemTime(t *testing.T) {
 
 	// This is a regression test for #49707.
 	t.Run("ignore-dropped-table", func(t *testing.T) {
-		backupPath := "nodelocal://0/ignore_dropped_table"
+		backupPath := "nodelocal://1/ignore_dropped_table"
 
 		sqlDB.Exec(t, "CREATE DATABASE ignore_dropped_table")
 		sqlDB.Exec(t, "CREATE TABLE ignore_dropped_table.a (k int, v string)")
@@ -3914,7 +3914,7 @@ func TestRestoreAsOfSystemTimeGCBounds(t *testing.T) {
 	ctx := context.Background()
 	tc, sqlDB, _, cleanupFn := backupRestoreTestSetup(t, singleNode, numAccounts, InitManualReplication)
 	defer cleanupFn()
-	const dir = "nodelocal://0/"
+	const dir = "nodelocal://1/"
 	preGC := eval.TimestampToDecimalDatum(tc.Server(0).Clock().Now()).String()
 
 	gcr := kvpb.GCRequest{
@@ -4724,9 +4724,9 @@ func TestRestoreDatabaseVersusTable(t *testing.T) {
 		origDB.Exec(t, q)
 	}
 
-	d4foo := "nodelocal://0/d4foo"
-	d4foobar := "nodelocal://0/d4foobar"
-	d4star := "nodelocal://0/d4star"
+	d4foo := "nodelocal://1/d4foo"
+	d4foobar := "nodelocal://1/d4foobar"
+	d4star := "nodelocal://1/d4star"
 
 	origDB.Exec(t, `BACKUP DATABASE data, d2, d3, d4 TO $1`, localFoo)
 	origDB.Exec(t, `BACKUP d4.foo TO $1`, d4foo)
@@ -5055,7 +5055,7 @@ func TestFileIOLimits(t *testing.T) {
 	_, sqlDB, _, cleanupFn := backupRestoreTestSetup(t, singleNode, numAccounts, InitManualReplication)
 	defer cleanupFn()
 
-	elsewhere := "nodelocal://0/../../blah"
+	elsewhere := "nodelocal://1/../../blah"
 
 	sqlDB.Exec(t, `BACKUP data.bank TO $1`, localFoo)
 	sqlDB.ExpectErr(
@@ -5318,11 +5318,11 @@ func TestBackupRestoreSequencesInViews(t *testing.T) {
 		sqlDB.Exec(t, `CREATE VIEW v AS SELECT k FROM (SELECT nextval('s') AS k)`)
 
 		// Backup the database.
-		sqlDB.Exec(t, `BACKUP DATABASE d TO 'nodelocal://0/test/'`)
+		sqlDB.Exec(t, `BACKUP DATABASE d TO 'nodelocal://1/test/'`)
 
 		// Drop the database and restore into it.
 		sqlDB.Exec(t, `DROP DATABASE d`)
-		sqlDB.Exec(t, `RESTORE DATABASE d FROM 'nodelocal://0/test/'`)
+		sqlDB.Exec(t, `RESTORE DATABASE d FROM 'nodelocal://1/test/'`)
 
 		// Check that the view is not corrupted.
 		sqlDB.CheckQueryResults(t, `SELECT * FROM d.v`, [][]string{{"1"}})
@@ -5352,12 +5352,12 @@ func TestBackupRestoreSequencesInViews(t *testing.T) {
 		sqlDB.Exec(t, `CREATE VIEW v AS (SELECT k FROM (SELECT nextval('s') AS k))`)
 
 		// Backup v and s.
-		sqlDB.Exec(t, `BACKUP TABLE v, s TO 'nodelocal://0/test/'`)
+		sqlDB.Exec(t, `BACKUP TABLE v, s TO 'nodelocal://1/test/'`)
 		// Drop v and s.
 		sqlDB.Exec(t, `DROP VIEW v`)
 		sqlDB.Exec(t, `DROP SEQUENCE s`)
 		// Restore v and s.
-		sqlDB.Exec(t, `RESTORE TABLE s, v FROM 'nodelocal://0/test/'`)
+		sqlDB.Exec(t, `RESTORE TABLE s, v FROM 'nodelocal://1/test/'`)
 		sqlDB.CheckQueryResults(t, `SHOW CREATE VIEW d.v`, [][]string{{
 			"d.public.v", "CREATE VIEW public.v (\n\tk\n) AS " +
 				"(SELECT k FROM (SELECT nextval('public.s'::REGCLASS) AS k) AS \"?subquery1?\")",
@@ -5389,12 +5389,12 @@ func TestBackupRestoreSequencesInViews(t *testing.T) {
 		sqlDB.Exec(t, `CREATE VIEW v AS (SELECT k FROM (SELECT nextval('s') AS k))`)
 
 		// Backup v and drop.
-		sqlDB.Exec(t, `BACKUP TABLE v TO 'nodelocal://0/test/'`)
+		sqlDB.Exec(t, `BACKUP TABLE v TO 'nodelocal://1/test/'`)
 		sqlDB.Exec(t, `DROP VIEW v`)
 		// Restore v.
 		sqlDB.ExpectErr(
 			t, "pq: cannot restore view \"v\" without restoring referenced table \\(or \"skip_missing_views\" option\\)",
-			`RESTORE TABLE v FROM 'nodelocal://0/test/'`,
+			`RESTORE TABLE v FROM 'nodelocal://1/test/'`,
 		)
 	})
 }
@@ -5677,8 +5677,8 @@ func TestBackupRestoreShowJob(t *testing.T) {
 	sqlDB.CheckQueryResults(
 		t, "SELECT description FROM [SHOW JOBS] WHERE job_type != 'MIGRATION' AND description != 'updating privileges' ORDER BY description",
 		[][]string{
-			{"BACKUP DATABASE data TO 'nodelocal://0/foo' WITH revision_history = true"},
-			{"RESTORE TABLE data.bank FROM 'nodelocal://0/foo' WITH into_db = 'data 2', skip_missing_foreign_keys"},
+			{"BACKUP DATABASE data TO 'nodelocal://1/foo' WITH revision_history = true"},
+			{"RESTORE TABLE data.bank FROM 'nodelocal://1/foo' WITH into_db = 'data 2', skip_missing_foreign_keys"},
 		},
 	)
 }
@@ -5921,8 +5921,8 @@ func TestBackupCreatedStatsFromIncrementalBackup(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	const incremental1Foo = "nodelocal://0/incremental1foo"
-	const incremental2Foo = "nodelocal://0/incremental2foo"
+	const incremental1Foo = "nodelocal://1/incremental1foo"
+	const incremental2Foo = "nodelocal://1/incremental2foo"
 	const numAccounts = 1
 	_, sqlDB, _, cleanupFn := backupRestoreTestSetup(t, singleNode, numAccounts, InitManualReplication)
 	defer cleanupFn()
@@ -6304,7 +6304,7 @@ func TestRestoreErrorPropagates(t *testing.T) {
 	runner.Exec(t, `SET CLUSTER SETTING sql.stats.system_tables_autostats.enabled = false`)
 	runner.Exec(t, "CREATE TABLE foo ()")
 	runner.Exec(t, "CREATE DATABASE into_db")
-	url := `nodelocal://0/foo`
+	url := `nodelocal://1/foo`
 	runner.Exec(t, `BACKUP TABLE foo to '`+url+`'`)
 	atomic.StoreInt64(&shouldFail, 1)
 	_, err := db.Exec(`RESTORE TABLE foo FROM '` + url + `' WITH into_db = 'into_db'`)
@@ -6333,7 +6333,7 @@ func TestProtectedTimestampsFailDueToLimits(t *testing.T) {
 
 	// Creating the protected timestamp record should fail because there are too
 	// many spans. Ensure that we get the appropriate error.
-	_, err := db.Exec(`BACKUP TABLE foo, bar TO 'nodelocal://0/foo/byte-limit'`)
+	_, err := db.Exec(`BACKUP TABLE foo, bar TO 'nodelocal://1/foo/byte-limit'`)
 	require.EqualError(t, err, "pq: protectedts: limit exceeded: 0+30 > 1 bytes")
 
 	// TODO(adityamaru): Remove in 22.2 once no records protect spans.
@@ -6354,7 +6354,7 @@ func TestProtectedTimestampsFailDueToLimits(t *testing.T) {
 
 		// Creating the protected timestamp record should fail because there are too
 		// many spans. Ensure that we get the appropriate error.
-		_, err := db.Exec(`BACKUP TABLE foo, bar TO 'nodelocal://0/foo/spans-limit'`)
+		_, err := db.Exec(`BACKUP TABLE foo, bar TO 'nodelocal://1/foo/spans-limit'`)
 		require.EqualError(t, err, "pq: protectedts: limit exceeded: 0+2 > 1 spans")
 	})
 }
@@ -6973,7 +6973,7 @@ func TestBackupRestoreTenant(t *testing.T) {
 					`10`, `true`, `tenant-10`,
 					strconv.Itoa(int(mtinfopb.DataStateReady)),
 					strconv.Itoa(int(mtinfopb.ServiceModeNone)),
-					`{"capabilities": {}, "deprecatedId": "10"}`,
+					`{"capabilities": {"canUseNodelocalStorage": true}, "deprecatedId": "10"}`,
 				},
 			},
 		)
@@ -7013,7 +7013,7 @@ func TestBackupRestoreTenant(t *testing.T) {
 					`10`, `false`, `NULL`,
 					strconv.Itoa(int(mtinfopb.DataStateDrop)),
 					strconv.Itoa(int(mtinfopb.ServiceModeNone)),
-					`{"capabilities": {}, "deprecatedDataState": "DROP", "deprecatedId": "10", "droppedName": "tenant-10"}`,
+					`{"capabilities": {"canUseNodelocalStorage": true}, "deprecatedDataState": "DROP", "deprecatedId": "10", "droppedName": "tenant-10"}`,
 				},
 			},
 		)
@@ -7048,7 +7048,7 @@ func TestBackupRestoreTenant(t *testing.T) {
 					`10`, `true`, `tenant-10`,
 					strconv.Itoa(int(mtinfopb.DataStateReady)),
 					strconv.Itoa(int(mtinfopb.ServiceModeNone)),
-					`{"capabilities": {}, "deprecatedId": "10"}`,
+					`{"capabilities": {"canUseNodelocalStorage": true}, "deprecatedId": "10"}`,
 				},
 			},
 		)
@@ -7094,7 +7094,7 @@ func TestBackupRestoreTenant(t *testing.T) {
 					`10`, `true`, `tenant-10`,
 					strconv.Itoa(int(mtinfopb.DataStateReady)),
 					strconv.Itoa(int(mtinfopb.ServiceModeNone)),
-					`{"capabilities": {}, "deprecatedId": "10"}`,
+					`{"capabilities": {"canUseNodelocalStorage": true}, "deprecatedId": "10"}`,
 				},
 			},
 		)
@@ -7138,7 +7138,7 @@ func TestBackupRestoreTenant(t *testing.T) {
 					`10`, `true`, `tenant-10`,
 					strconv.Itoa(int(mtinfopb.DataStateReady)),
 					strconv.Itoa(int(mtinfopb.ServiceModeNone)),
-					`{"capabilities": {}, "deprecatedId": "10"}`,
+					`{"capabilities": {"canUseNodelocalStorage": true}, "deprecatedId": "10"}`,
 				},
 			},
 		)
@@ -7193,19 +7193,19 @@ func TestBackupRestoreTenant(t *testing.T) {
 					`10`, `true`, `tenant-10`,
 					strconv.Itoa(int(mtinfopb.DataStateReady)),
 					strconv.Itoa(int(mtinfopb.ServiceModeNone)),
-					`{"capabilities": {}, "deprecatedId": "10"}`,
+					`{"capabilities": {"canUseNodelocalStorage": true}, "deprecatedId": "10"}`,
 				},
 				{
 					`11`, `true`, `tenant-11`,
 					strconv.Itoa(int(mtinfopb.DataStateReady)),
 					strconv.Itoa(int(mtinfopb.ServiceModeNone)),
-					`{"capabilities": {}, "deprecatedId": "11"}`,
+					`{"capabilities": {"canUseNodelocalStorage": true}, "deprecatedId": "11"}`,
 				},
 				{
 					`20`, `true`, `tenant-20`,
 					strconv.Itoa(int(mtinfopb.DataStateReady)),
 					strconv.Itoa(int(mtinfopb.ServiceModeNone)),
-					`{"capabilities": {}, "deprecatedId": "20"}`,
+					`{"capabilities": {"canUseNodelocalStorage": true}, "deprecatedId": "20"}`,
 				},
 			},
 		)
@@ -7478,7 +7478,7 @@ func TestBackupExportRequestTimeout(t *testing.T) {
 	// Backup should go through the motions of attempting to run a high priority
 	// export request but since the intent was laid by a high priority txn it
 	// should hang. The timeout should save us in this case.
-	_, err := sqlSessions[1].DB.ExecContext(ctx, "BACKUP data.bank TO 'nodelocal://0/timeout'")
+	_, err := sqlSessions[1].DB.ExecContext(ctx, "BACKUP data.bank TO 'nodelocal://1/timeout'")
 	require.Regexp(t,
 		`exporting .*/Table/\d+/.*\: context deadline exceeded`,
 		err.Error())
@@ -7514,7 +7514,7 @@ func TestBackupDoesNotHangOnIntent(t *testing.T) {
 	}
 
 	// backup the table in which we have our intent.
-	_, err = sqlDB.DB.ExecContext(ctx, "BACKUP data.bank TO 'nodelocal://0/intent'")
+	_, err = sqlDB.DB.ExecContext(ctx, "BACKUP data.bank TO 'nodelocal://1/intent'")
 	require.NoError(t, err)
 
 	// observe that the backup aborted our txn.
@@ -7549,9 +7549,9 @@ CREATE TABLE db.table (k INT PRIMARY KEY, v db.typ);
 `)
 
 	// Back up the database, drop it, and restore into it.
-	sqlDB.Exec(t, `BACKUP DATABASE db TO 'nodelocal://0/test/1'`)
+	sqlDB.Exec(t, `BACKUP DATABASE db TO 'nodelocal://1/test/1'`)
 	sqlDB.Exec(t, `DROP DATABASE db`)
-	sqlDB.ExpectErr(t, "boom", `RESTORE DATABASE db FROM 'nodelocal://0/test/1'`)
+	sqlDB.ExpectErr(t, "boom", `RESTORE DATABASE db FROM 'nodelocal://1/test/1'`)
 	sqlDB.CheckQueryResults(t, `SELECT count(*) FROM system.namespace WHERE name = 'typ'`, [][]string{{"0"}})
 
 	// Back up database with user defined schema.
@@ -7563,9 +7563,9 @@ CREATE TABLE db.s.table (k INT PRIMARY KEY, v db.s.typ);
 `)
 
 	// Back up the database, drop it, and restore into it.
-	sqlDB.Exec(t, `BACKUP DATABASE db TO 'nodelocal://0/test/2'`)
+	sqlDB.Exec(t, `BACKUP DATABASE db TO 'nodelocal://1/test/2'`)
 	sqlDB.Exec(t, `DROP DATABASE db`)
-	sqlDB.ExpectErr(t, "boom", `RESTORE DATABASE db FROM 'nodelocal://0/test/2'`)
+	sqlDB.ExpectErr(t, "boom", `RESTORE DATABASE db FROM 'nodelocal://1/test/2'`)
 	sqlDB.CheckQueryResults(t, `SELECT count(*) FROM system.namespace WHERE name = 'typ'`, [][]string{{"0"}})
 }
 
@@ -7598,11 +7598,11 @@ CREATE TYPE sc.typ AS ENUM ('hello');
 ALTER TYPE sc.typ ADD VALUE 'hi';
 `)
 	// Back up the database.
-	sqlDB.Exec(t, `BACKUP DATABASE d TO 'nodelocal://0/test/'`)
+	sqlDB.Exec(t, `BACKUP DATABASE d TO 'nodelocal://1/test/'`)
 
 	// Drop the database and restore into it.
 	sqlDB.Exec(t, `DROP DATABASE d`)
-	sqlDB.Exec(t, `RESTORE DATABASE d FROM 'nodelocal://0/test/'`)
+	sqlDB.Exec(t, `RESTORE DATABASE d FROM 'nodelocal://1/test/'`)
 
 	dbDesc := desctestutils.TestingGetDatabaseDescriptor(kvDB, keys.SystemSQLCodec, "d")
 	require.EqualValues(t, 2, dbDesc.GetVersion())
@@ -7682,7 +7682,7 @@ CREATE TYPE sc.typ AS ENUM ('hello');
 `)
 
 		// Back up the database.
-		sqlDB.Exec(t, `BACKUP DATABASE d TO 'nodelocal://0/test/'`)
+		sqlDB.Exec(t, `BACKUP DATABASE d TO 'nodelocal://1/test/'`)
 
 		// Drop the database and restore into it.
 		sqlDB.Exec(t, `DROP DATABASE d`)
@@ -7690,7 +7690,7 @@ CREATE TYPE sc.typ AS ENUM ('hello');
 		beforePublishingNotif, continueNotif := initBackfillNotification()
 		g := ctxgroup.WithContext(ctx)
 		g.GoCtx(func(ctx context.Context) error {
-			if _, err := sqlDB.DB.ExecContext(ctx, `RESTORE DATABASE d FROM 'nodelocal://0/test/'`); err != nil {
+			if _, err := sqlDB.DB.ExecContext(ctx, `RESTORE DATABASE d FROM 'nodelocal://1/test/'`); err != nil {
 				t.Fatal(err)
 			}
 			return nil
@@ -7779,7 +7779,7 @@ CREATE TYPE sc.typ AS ENUM ('hello');
 `)
 
 		// Back up the database.
-		sqlDB.Exec(t, `BACKUP DATABASE d TO 'nodelocal://0/test/'`)
+		sqlDB.Exec(t, `BACKUP DATABASE d TO 'nodelocal://1/test/'`)
 
 		// Drop the database.
 		sqlDB.Exec(t, `DROP DATABASE d`)
@@ -7790,7 +7790,7 @@ CREATE TYPE sc.typ AS ENUM ('hello');
 		beforePublishingNotif, continueNotif := initBackfillNotification()
 		g := ctxgroup.WithContext(ctx)
 		g.GoCtx(func(ctx context.Context) error {
-			if _, err := sqlDB.DB.ExecContext(ctx, `RESTORE d.* FROM 'nodelocal://0/test/' WITH into_db='newdb'`); err != nil {
+			if _, err := sqlDB.DB.ExecContext(ctx, `RESTORE d.* FROM 'nodelocal://1/test/' WITH into_db='newdb'`); err != nil {
 				t.Fatal(err)
 			}
 			return nil
@@ -7886,7 +7886,7 @@ CREATE TABLE d.sc.tb (x d.sc.typ);
 `)
 
 		// Back up the table.
-		sqlDB.Exec(t, `BACKUP TABLE d.sc.tb TO 'nodelocal://0/test/'`)
+		sqlDB.Exec(t, `BACKUP TABLE d.sc.tb TO 'nodelocal://1/test/'`)
 
 		// Drop the table and the type.
 		sqlDB.Exec(t, `DROP TABLE d.sc.tb`)
@@ -7900,7 +7900,7 @@ CREATE TABLE d.sc.tb (x d.sc.typ);
 		beforePublishingNotif, continueNotif := initBackfillNotification()
 		g := ctxgroup.WithContext(ctx)
 		g.GoCtx(func(ctx context.Context) error {
-			if _, err := sqlDB.DB.ExecContext(ctx, `RESTORE TABLE d.sc.tb FROM 'nodelocal://0/test/' WITH into_db = 'newdb'`); err != nil {
+			if _, err := sqlDB.DB.ExecContext(ctx, `RESTORE TABLE d.sc.tb FROM 'nodelocal://1/test/' WITH into_db = 'newdb'`); err != nil {
 				t.Fatal(err)
 			}
 			return nil
@@ -8021,7 +8021,7 @@ func TestCleanupDoesNotDeleteParentsWithChildObjects(t *testing.T) {
 		`)
 
 		// Back up the database.
-		sqlDB.Exec(t, `BACKUP DATABASE d TO 'nodelocal://0/test/'`)
+		sqlDB.Exec(t, `BACKUP DATABASE d TO 'nodelocal://1/test/'`)
 
 		// Drop the database and restore into it.
 		sqlDB.Exec(t, `DROP DATABASE d`)
@@ -8029,7 +8029,7 @@ func TestCleanupDoesNotDeleteParentsWithChildObjects(t *testing.T) {
 		afterPublishNotif, continueNotif := notifyAfterPublishing()
 		g := ctxgroup.WithContext(ctx)
 		g.GoCtx(func(ctx context.Context) error {
-			_, err := sqlDB.DB.ExecContext(ctx, `RESTORE DATABASE d FROM 'nodelocal://0/test/'`)
+			_, err := sqlDB.DB.ExecContext(ctx, `RESTORE DATABASE d FROM 'nodelocal://1/test/'`)
 			require.Regexp(t, "injected error", err)
 			return nil
 		})
@@ -8084,7 +8084,7 @@ func TestCleanupDoesNotDeleteParentsWithChildObjects(t *testing.T) {
 		`)
 
 		// Back up the database.
-		sqlDB.Exec(t, `BACKUP DATABASE d TO 'nodelocal://0/test/'`)
+		sqlDB.Exec(t, `BACKUP DATABASE d TO 'nodelocal://1/test/'`)
 
 		// Drop the database and restore into it.
 		sqlDB.Exec(t, `DROP DATABASE d`)
@@ -8092,7 +8092,7 @@ func TestCleanupDoesNotDeleteParentsWithChildObjects(t *testing.T) {
 		afterPublishNotif, continueNotif := notifyAfterPublishing()
 		g := ctxgroup.WithContext(ctx)
 		g.GoCtx(func(ctx context.Context) error {
-			_, err := sqlDB.DB.ExecContext(ctx, `RESTORE DATABASE d FROM 'nodelocal://0/test/'`)
+			_, err := sqlDB.DB.ExecContext(ctx, `RESTORE DATABASE d FROM 'nodelocal://1/test/'`)
 			require.Regexp(t, "injected error", err)
 			return nil
 		})
@@ -8152,7 +8152,7 @@ func TestCleanupDoesNotDeleteParentsWithChildObjects(t *testing.T) {
 		`)
 
 		// Back up the database.
-		sqlDB.Exec(t, `BACKUP DATABASE olddb TO 'nodelocal://0/test/'`)
+		sqlDB.Exec(t, `BACKUP DATABASE olddb TO 'nodelocal://1/test/'`)
 
 		// Drop the database.
 		sqlDB.Exec(t, `DROP DATABASE olddb`)
@@ -8165,7 +8165,7 @@ func TestCleanupDoesNotDeleteParentsWithChildObjects(t *testing.T) {
 		g.GoCtx(func(ctx context.Context) error {
 			conn, err := tc.Conns[0].Conn(ctx)
 			require.NoError(t, err)
-			_, err = conn.ExecContext(ctx, `RESTORE olddb.* FROM 'nodelocal://0/test/' WITH into_db='newdb'`)
+			_, err = conn.ExecContext(ctx, `RESTORE olddb.* FROM 'nodelocal://1/test/' WITH into_db='newdb'`)
 			require.Regexp(t, "injected error", err)
 			return nil
 		})
@@ -8216,7 +8216,7 @@ func TestCleanupDoesNotDeleteParentsWithChildObjects(t *testing.T) {
 		`)
 
 		// Back up the database.
-		sqlDB.Exec(t, `BACKUP DATABASE d TO 'nodelocal://0/test/'`)
+		sqlDB.Exec(t, `BACKUP DATABASE d TO 'nodelocal://1/test/'`)
 
 		// Drop the database and restore into it.
 		sqlDB.Exec(t, `DROP DATABASE d`)
@@ -8224,7 +8224,7 @@ func TestCleanupDoesNotDeleteParentsWithChildObjects(t *testing.T) {
 		afterPublishNotif, continueNotif := notifyAfterPublishing()
 		g := ctxgroup.WithContext(ctx)
 		g.GoCtx(func(ctx context.Context) error {
-			_, err := sqlDB.DB.ExecContext(ctx, `RESTORE DATABASE d FROM 'nodelocal://0/test/'`)
+			_, err := sqlDB.DB.ExecContext(ctx, `RESTORE DATABASE d FROM 'nodelocal://1/test/'`)
 			require.Regexp(t, "injected error", err)
 			return nil
 		})
@@ -8263,7 +8263,7 @@ func TestReadBackupManifestMemoryMonitoring(t *testing.T) {
 
 	st := cluster.MakeTestingClusterSettings()
 	storage, err := cloud.ExternalStorageFromURI(ctx,
-		"nodelocal://0/test",
+		"nodelocal://1/test",
 		base.ExternalIODirConfig{},
 		st,
 		blobs.TestBlobServiceClient(dir),
@@ -8313,7 +8313,7 @@ func TestIncorrectAccessOfFilesInBackupMetadata(t *testing.T) {
 	sqlDB.Exec(t, `CREATE DATABASE r1`)
 	sqlDB.Exec(t, `CREATE TABLE r1.foo ( id INT PRIMARY KEY)`)
 	sqlDB.Exec(t, `INSERT INTO r1.foo VALUES (1)`)
-	sqlDB.Exec(t, `BACKUP DATABASE r1 INTO 'nodelocal://0/test'`)
+	sqlDB.Exec(t, `BACKUP DATABASE r1 INTO 'nodelocal://1/test'`)
 
 	// Load/deserialize the manifest so we can mess with it.
 	matches, err := filepath.Glob(filepath.Join(rawDir, "test", "*/*/*", backupbase.BackupMetadataName))
@@ -8343,7 +8343,7 @@ func TestIncorrectAccessOfFilesInBackupMetadata(t *testing.T) {
 	require.NoError(t, os.WriteFile(manifestPath+backupinfo.BackupManifestChecksumSuffix, checksum, 0644 /* perm */))
 
 	// Expect an error on restore.
-	sqlDB.ExpectErr(t, "assertion: this placeholder legacy Descriptor entry should never be used", `RESTORE DATABASE r1 FROM LATEST IN 'nodelocal://0/test' WITH new_db_name = 'r2'`)
+	sqlDB.ExpectErr(t, "assertion: this placeholder legacy Descriptor entry should never be used", `RESTORE DATABASE r1 FROM LATEST IN 'nodelocal://1/test' WITH new_db_name = 'r2'`)
 }
 
 // TestRestoringAcrossVersions test that users are only allowed to restore
@@ -8356,7 +8356,11 @@ func TestRestoringAcrossVersions(t *testing.T) {
 	defer cleanupFn()
 
 	sqlDB.Exec(t, `CREATE DATABASE r1`)
-	sqlDB.Exec(t, `BACKUP DATABASE r1 TO 'nodelocal://0/cross_version'`)
+
+	sqlDB.Exec(t, `BACKUP DATABASE r1 TO 'nodelocal://1/cross_version'`)
+	sqlDB.Exec(t, `DROP DATABASE r1`)
+	// Prove we can restore.
+	sqlDB.Exec(t, `RESTORE DATABASE r1 FROM 'nodelocal://1/cross_version'`)
 	sqlDB.Exec(t, `DROP DATABASE r1`)
 
 	// Load/deserialize the manifest so we can mess with it.
@@ -8381,7 +8385,7 @@ func TestRestoringAcrossVersions(t *testing.T) {
 
 	t.Run("restore-same-version", func(t *testing.T) {
 		// Prove we can restore a backup taken on our current version.
-		sqlDB.Exec(t, `RESTORE DATABASE r1 FROM 'nodelocal://0/cross_version'`)
+		sqlDB.Exec(t, `RESTORE DATABASE r1 FROM 'nodelocal://1/cross_version'`)
 		sqlDB.Exec(t, `DROP DATABASE r1`)
 	})
 
@@ -8391,7 +8395,7 @@ func TestRestoringAcrossVersions(t *testing.T) {
 
 		// Verify we reject it.
 		sqlDB.ExpectErr(t, "backup from version 2147483647.1 is newer than current version",
-			`RESTORE DATABASE r1 FROM 'nodelocal://0/cross_version'`)
+			`RESTORE DATABASE r1 FROM 'nodelocal://1/cross_version'`)
 	})
 
 	t.Run("restore-older-major-version", func(t *testing.T) {
@@ -8405,7 +8409,7 @@ func TestRestoringAcrossVersions(t *testing.T) {
 		// Verify we reject it.
 		sqlDB.ExpectErr(t,
 			fmt.Sprintf("backup from version %s is older than the minimum restoreable version", minSupportedVersion.String()),
-			`RESTORE DATABASE r1 FROM 'nodelocal://0/cross_version'`)
+			`RESTORE DATABASE r1 FROM 'nodelocal://1/cross_version'`)
 	})
 
 	t.Run("restore-min-binary-version", func(t *testing.T) {
@@ -8414,7 +8418,7 @@ func TestRestoringAcrossVersions(t *testing.T) {
 		// version policy.
 		minBinaryVersion := tc.Server(0).ClusterSettings().Version.BinaryMinSupportedVersion()
 		setManifestClusterVersion(minBinaryVersion)
-		sqlDB.Exec(t, `RESTORE DATABASE r1 FROM 'nodelocal://0/cross_version'`)
+		sqlDB.Exec(t, `RESTORE DATABASE r1 FROM 'nodelocal://1/cross_version'`)
 		sqlDB.Exec(t, `DROP DATABASE r1`)
 	})
 
@@ -8424,7 +8428,7 @@ func TestRestoringAcrossVersions(t *testing.T) {
 
 		// Verify we reject it.
 		sqlDB.ExpectErr(t, "the backup is from a version older than our minimum restoreable version",
-			`RESTORE DATABASE r1 FROM 'nodelocal://0/cross_version'`)
+			`RESTORE DATABASE r1 FROM 'nodelocal://1/cross_version'`)
 	})
 }
 
@@ -8438,17 +8442,17 @@ func TestManifestBitFlip(t *testing.T) {
 	sqlDB.Exec(t, `CREATE DATABASE r1; CREATE DATABASE r2; CREATE DATABASE r3;`)
 	const checksumError = "checksum mismatch"
 	t.Run("unencrypted", func(t *testing.T) {
-		sqlDB.Exec(t, `BACKUP DATABASE data TO 'nodelocal://0/bit_flip_unencrypted'`)
+		sqlDB.Exec(t, `BACKUP DATABASE data TO 'nodelocal://1/bit_flip_unencrypted'`)
 		flipBitInManifests(t, rawDir)
 		sqlDB.ExpectErr(t, checksumError,
-			`RESTORE data.* FROM 'nodelocal://0/bit_flip_unencrypted' WITH into_db='r1'`)
+			`RESTORE data.* FROM 'nodelocal://1/bit_flip_unencrypted' WITH into_db='r1'`)
 	})
 
 	t.Run("encrypted", func(t *testing.T) {
-		sqlDB.Exec(t, `BACKUP DATABASE data TO 'nodelocal://0/bit_flip_encrypted' WITH encryption_passphrase = 'abc'`)
+		sqlDB.Exec(t, `BACKUP DATABASE data TO 'nodelocal://1/bit_flip_encrypted' WITH encryption_passphrase = 'abc'`)
 		flipBitInManifests(t, rawDir)
 		sqlDB.ExpectErr(t, checksumError,
-			`RESTORE data.* FROM 'nodelocal://0/bit_flip_encrypted' WITH encryption_passphrase = 'abc', into_db = 'r3'`)
+			`RESTORE data.* FROM 'nodelocal://1/bit_flip_encrypted' WITH encryption_passphrase = 'abc', into_db = 'r3'`)
 	})
 }
 
@@ -8513,11 +8517,11 @@ func TestRestoreJobEventLogging(t *testing.T) {
 	sqlDB.Exec(t, `CREATE DATABASE r1`)
 	sqlDB.Exec(t, `CREATE TABLE r1.foo (id INT)`)
 	sqlDB.Exec(t, `INSERT INTO r1.foo VALUES (1), (2), (3)`)
-	sqlDB.Exec(t, `BACKUP DATABASE r1 TO 'nodelocal://0/eventlogging'`)
+	sqlDB.Exec(t, `BACKUP DATABASE r1 TO 'nodelocal://1/eventlogging'`)
 	sqlDB.Exec(t, `DROP DATABASE r1`)
 
 	beforeRestore := timeutil.Now()
-	restoreQuery := `RESTORE DATABASE r1 FROM 'nodelocal://0/eventlogging'`
+	restoreQuery := `RESTORE DATABASE r1 FROM 'nodelocal://1/eventlogging'`
 
 	var jobID int64
 	var unused interface{}
@@ -8969,10 +8973,10 @@ func TestRestorePauseOnError(t *testing.T) {
 
 	sqlDB.Exec(t, `CREATE DATABASE r1`)
 	sqlDB.Exec(t, `CREATE TABLE r1.foo (id INT)`)
-	sqlDB.Exec(t, `BACKUP DATABASE r1 TO 'nodelocal://0/eventlogging'`)
+	sqlDB.Exec(t, `BACKUP DATABASE r1 TO 'nodelocal://1/eventlogging'`)
 	sqlDB.Exec(t, `DROP DATABASE r1`)
 
-	restoreQuery := `RESTORE DATABASE r1 FROM 'nodelocal://0/eventlogging' WITH DEBUG_PAUSE_ON = 'error'`
+	restoreQuery := `RESTORE DATABASE r1 FROM 'nodelocal://1/eventlogging' WITH DEBUG_PAUSE_ON = 'error'`
 	findJobQuery := `SELECT job_id FROM [SHOW JOBS] WHERE description LIKE '%RESTORE DATABASE%' ORDER BY created DESC`
 
 	// Verify that a RESTORE job will self pause on an error, but can be resumed
@@ -9040,7 +9044,7 @@ func TestDroppedDescriptorRevisionAndSystemDBIDClash(t *testing.T) {
 	defer cleanupFn()
 
 	sqlDB.Exec(t, `CREATE TABLE foo (id INT);`)
-	sqlDB.Exec(t, `BACKUP TO 'nodelocal://0/foo' WITH revision_history;`)
+	sqlDB.Exec(t, `BACKUP TO 'nodelocal://1/foo' WITH revision_history;`)
 	sqlDB.Exec(t, `DROP TABLE foo;`)
 
 	var aost string
@@ -9119,11 +9123,11 @@ func TestRestoreRemappingOfExistingUDTInColExpr(t *testing.T) {
 
 	sqlDB.Exec(t, `CREATE TYPE status AS ENUM ('open', 'closed', 'inactive');`)
 	sqlDB.Exec(t, `CREATE TABLE foo (id INT PRIMARY KEY, what status default 'open');`)
-	sqlDB.Exec(t, `BACKUP DATABASE data to 'nodelocal://0/foo';`)
+	sqlDB.Exec(t, `BACKUP DATABASE data to 'nodelocal://1/foo';`)
 	sqlDB.Exec(t, `DROP TABLE foo CASCADE;`)
 	sqlDB.Exec(t, `DROP TYPE status;`)
 	sqlDB.Exec(t, `CREATE TYPE status AS ENUM ('open', 'closed', 'inactive');`)
-	sqlDB.Exec(t, `RESTORE TABLE foo FROM 'nodelocal://0/foo';`)
+	sqlDB.Exec(t, `RESTORE TABLE foo FROM 'nodelocal://1/foo';`)
 }
 
 // TestGCDropIndexSpanExpansion is a regression test for
@@ -9175,11 +9179,11 @@ func TestGCDropIndexSpanExpansion(t *testing.T) {
 
 	// Take a full backup with revision history so it includes the PUBLIC version
 	// of index `bar` in the backed up spans.
-	sqlRunner.Exec(t, `BACKUP INTO 'nodelocal://0/foo' WITH revision_history`)
+	sqlRunner.Exec(t, `BACKUP INTO 'nodelocal://1/foo' WITH revision_history`)
 
 	// Take an incremental backup with revision history. This backup will not
 	// include the dropped index span.
-	sqlRunner.Exec(t, `BACKUP INTO LATEST IN 'nodelocal://0/foo' WITH revision_history`)
+	sqlRunner.Exec(t, `BACKUP INTO LATEST IN 'nodelocal://1/foo' WITH revision_history`)
 
 	// Allow the GC to complete.
 	close(allowGC)
@@ -9190,7 +9194,7 @@ func TestGCDropIndexSpanExpansion(t *testing.T) {
 
 	// This backup should succeed since the spans being backed up have a default
 	// GC TTL of 25 hours.
-	sqlRunner.Exec(t, `BACKUP INTO LATEST IN 'nodelocal://0/foo' WITH revision_history`)
+	sqlRunner.Exec(t, `BACKUP INTO LATEST IN 'nodelocal://1/foo' WITH revision_history`)
 }
 
 // TestRestoreSchemaDescriptorsRollBack is a regression test that ensures that a
@@ -9224,16 +9228,16 @@ CREATE DATABASE db;
 CREATE SCHEMA db.s;
 `)
 
-	sqlDB.Exec(t, `BACKUP DATABASE db TO 'nodelocal://0/test/1'`)
+	sqlDB.Exec(t, `BACKUP DATABASE db TO 'nodelocal://1/test/1'`)
 	sqlDB.Exec(t, `DROP DATABASE db`)
-	sqlDB.ExpectErr(t, "boom", `RESTORE DATABASE db FROM 'nodelocal://0/test/1'`)
+	sqlDB.ExpectErr(t, "boom", `RESTORE DATABASE db FROM 'nodelocal://1/test/1'`)
 
 	sqlDB.Exec(t, `
 CREATE DATABASE db;
 CREATE SCHEMA db.s;
 `)
 
-	sqlDB.Exec(t, `BACKUP DATABASE db TO 'nodelocal://0/test/2'`)
+	sqlDB.Exec(t, `BACKUP DATABASE db TO 'nodelocal://1/test/2'`)
 }
 
 // TestBackupRestoreSeperateIncrementalPrefix tests that a backup/restore round
@@ -9247,8 +9251,8 @@ func TestBackupRestoreSeparateIncrementalPrefix(t *testing.T) {
 	_, sqlDB, _, cleanupFn := backupRestoreTestSetup(t, multiNode, numAccounts, InitManualReplication)
 	defer cleanupFn()
 
-	const c1, c2, c3 = `nodelocal://0/full/`, `nodelocal://1/full/`, `nodelocal://2/full/`
-	const i1, i2, i3 = `nodelocal://0/inc/`, `nodelocal://1/inc/`, `nodelocal://2/inc/`
+	const c1, c2, c3 = `nodelocal://1/full/`, `nodelocal://2/full/`, `nodelocal://3/full/`
+	const i1, i2, i3 = `nodelocal://1/inc/`, `nodelocal://2/inc/`, `nodelocal://3/inc/`
 
 	collections := []string{
 		fmt.Sprintf("'%s?COCKROACH_LOCALITY=%s'", c1, url.QueryEscape("default")),
@@ -9822,11 +9826,11 @@ func TestBackupRestoreOldIncrementalDefault(t *testing.T) {
 	_, sqlDB, _, cleanupFn := backupRestoreTestSetup(t, multiNode, numAccounts, InitManualReplication)
 	defer cleanupFn()
 
-	const c1, c2, c3 = `nodelocal://0/full/`, `nodelocal://1/full/`, `nodelocal://2/full/`
+	const c1, c2, c3 = `nodelocal://1/full/`, `nodelocal://1/full/`, `nodelocal://2/full/`
 
 	// Deliberately the same. We're simulating an incremental backup in the old
 	// default directory, i.e. the top-level collection directory.
-	const i1, i2, i3 = `nodelocal://0/full/`, `nodelocal://1/full/`, `nodelocal://2/full/`
+	const i1, i2, i3 = `nodelocal://1/full/`, `nodelocal://1/full/`, `nodelocal://2/full/`
 
 	collections := []string{
 		fmt.Sprintf("'%s?COCKROACH_LOCALITY=%s'", c1, url.QueryEscape("default")),
@@ -9886,9 +9890,9 @@ func TestBackupRestoreErrorsOnBothDefaultsPopulated(t *testing.T) {
 	_, sqlDB, _, cleanupFn := backupRestoreTestSetup(t, singleNode, numAccounts, InitManualReplication)
 	defer cleanupFn()
 
-	base := `'nodelocal://0/full/'`
+	base := `'nodelocal://1/full/'`
 	oldInc := base
-	newInc := `'nodelocal://0/full/incrementals'`
+	newInc := `'nodelocal://1/full/incrementals'`
 
 	// create db
 	sqlDB.Exec(t, `CREATE DATABASE fkdb`)
@@ -9932,8 +9936,8 @@ func TestBackupRestoreSeparateExplicitIsDefault(t *testing.T) {
 	_, sqlDB, _, cleanupFn := backupRestoreTestSetup(t, multiNode, numAccounts, InitManualReplication)
 	defer cleanupFn()
 
-	const c1, c2, c3 = `nodelocal://0/full/`, `nodelocal://1/full/`, `nodelocal://2/full/`
-	const i1, i2, i3 = `nodelocal://0/full/incrementals`, `nodelocal://1/full/incrementals`, `nodelocal://2/full/incrementals`
+	const c1, c2, c3 = `nodelocal://1/full/`, `nodelocal://2/full/`, `nodelocal://3/full/`
+	const i1, i2, i3 = `nodelocal://1/full/incrementals`, `nodelocal://2/full/incrementals`, `nodelocal://3/full/incrementals`
 
 	collections := []string{
 		fmt.Sprintf("'%s?COCKROACH_LOCALITY=%s'", c1, url.QueryEscape("default")),
@@ -10229,7 +10233,7 @@ func TestBackupTimestampedCheckpointsAreLexicographical(t *testing.T) {
 			case "fileTable":
 				uri = "userfile:///a"
 			case "localFile":
-				uri = "nodelocal://0/a"
+				uri = "nodelocal://1/a"
 			}
 			store, err := execCfg.DistSQLSrv.ExternalStorageFromURI(ctx, uri, username.RootUserName())
 			require.NoError(t, err)
@@ -10342,7 +10346,7 @@ func TestBackupRestoreTelemetryEvents(t *testing.T) {
 	// correctly logged in a telemetry event.
 	beforeBackup := timeutil.Now()
 	loc1 := "userfile:///eventlogging?COCKROACH_LOCALITY=default"
-	loc2 := "nodelocal://0/us-west-bucket?COCKROACH_LOCALITY=region%3Dus-west"
+	loc2 := "nodelocal://1/us-west-bucket?COCKROACH_LOCALITY=region%3Dus-west"
 	sqlDB.Exec(t, `BACKUP DATABASE r1, r2 INTO  ($1, $2) AS OF SYSTEM TIME '-1ms' WITH revision_history`, loc1, loc2)
 
 	expectedBackupEvent := eventpb.RecoveryEvent{

--- a/pkg/ccl/backupccl/backuprand/backup_rand_test.go
+++ b/pkg/ccl/backupccl/backuprand/backup_rand_test.go
@@ -54,7 +54,7 @@ func TestBackupRestoreRandomDataRoundtrips(t *testing.T) {
 			ExternalIODir:            dir,
 		},
 	}
-	const localFoo = "nodelocal://0/foo/"
+	const localFoo = "nodelocal://1/foo/"
 
 	ctx := context.Background()
 	tc := testcluster.StartTestCluster(t, 1, params)

--- a/pkg/ccl/backupccl/bench_test.go
+++ b/pkg/ccl/backupccl/bench_test.go
@@ -27,7 +27,7 @@ func BenchmarkDatabaseBackup(b *testing.B) {
 	sqlDB.Exec(b, `DROP TABLE data.bank`)
 
 	bankData := bank.FromRows(b.N).Tables()[0]
-	loadURI := "nodelocal://0/load"
+	loadURI := "nodelocal://1/load"
 	if _, err := sampledataccl.ToBackup(b, bankData, dir, "load"); err != nil {
 		b.Fatalf("%+v", err)
 	}
@@ -66,7 +66,7 @@ func BenchmarkDatabaseRestore(b *testing.B) {
 	}
 
 	b.ResetTimer()
-	sqlDB.Exec(b, `RESTORE data.* FROM 'nodelocal://0/foo'`)
+	sqlDB.Exec(b, `RESTORE data.* FROM 'nodelocal://1/foo'`)
 	b.StopTimer()
 }
 

--- a/pkg/ccl/backupccl/create_scheduled_backup_test.go
+++ b/pkg/ccl/backupccl/create_scheduled_backup_test.go
@@ -312,7 +312,7 @@ CREATE TABLE other_db.t1(a int);
 			defer th.clearSchedules(t)
 			defer utilccl.TestingDisableEnterprise()()
 
-			destination := "nodelocal://0/backup/" + tc.name
+			destination := "nodelocal://1/backup/" + tc.name
 			schedules, err := th.createBackupSchedule(t, tc.query, destination)
 			require.NoError(t, err)
 
@@ -356,56 +356,56 @@ func TestSerializesScheduledBackupExecutionArgs(t *testing.T) {
 	}{
 		{
 			name:  "full-cluster",
-			query: "CREATE SCHEDULE FOR BACKUP INTO 'nodelocal://0/backup?AWS_SECRET_ACCESS_KEY=neverappears' RECURRING '@hourly'",
+			query: "CREATE SCHEDULE FOR BACKUP INTO 'nodelocal://1/backup?AWS_SECRET_ACCESS_KEY=neverappears' RECURRING '@hourly'",
 			user:  freeUser,
 			expectedSchedules: []expectedSchedule{
 				{
 					nameRe:     "BACKUP .+",
-					backupStmt: "BACKUP INTO 'nodelocal://0/backup?AWS_SECRET_ACCESS_KEY=neverappears' WITH detached",
-					shownStmt:  "BACKUP INTO 'nodelocal://0/backup?AWS_SECRET_ACCESS_KEY=redacted' WITH detached",
+					backupStmt: "BACKUP INTO 'nodelocal://1/backup?AWS_SECRET_ACCESS_KEY=neverappears' WITH detached",
+					shownStmt:  "BACKUP INTO 'nodelocal://1/backup?AWS_SECRET_ACCESS_KEY=redacted' WITH detached",
 					period:     time.Hour,
 				},
 			},
 		},
 		{
 			name:  "full-cluster-with-name",
-			query: "CREATE SCHEDULE 'my-backup' FOR BACKUP INTO 'nodelocal://0/backup' RECURRING '@hourly'",
+			query: "CREATE SCHEDULE 'my-backup' FOR BACKUP INTO 'nodelocal://1/backup' RECURRING '@hourly'",
 			user:  freeUser,
 			expectedSchedules: []expectedSchedule{
 				{
 					nameRe:     "my-backup",
-					backupStmt: "BACKUP INTO 'nodelocal://0/backup' WITH detached",
+					backupStmt: "BACKUP INTO 'nodelocal://1/backup' WITH detached",
 					period:     time.Hour,
 				},
 			},
 		},
 		{
 			name:  "full-cluster-always",
-			query: "CREATE SCHEDULE FOR BACKUP INTO 'nodelocal://0/backup' RECURRING '@hourly' FULL BACKUP ALWAYS",
+			query: "CREATE SCHEDULE FOR BACKUP INTO 'nodelocal://1/backup' RECURRING '@hourly' FULL BACKUP ALWAYS",
 			user:  freeUser,
 			expectedSchedules: []expectedSchedule{
 				{
 					nameRe:     "BACKUP .+",
-					backupStmt: "BACKUP INTO 'nodelocal://0/backup' WITH detached",
+					backupStmt: "BACKUP INTO 'nodelocal://1/backup' WITH detached",
 					period:     time.Hour,
 				},
 			},
 		},
 		{
 			name:  "full-cluster",
-			query: "CREATE SCHEDULE FOR BACKUP INTO 'nodelocal://0/backup' RECURRING '@hourly'",
+			query: "CREATE SCHEDULE FOR BACKUP INTO 'nodelocal://1/backup' RECURRING '@hourly'",
 			user:  enterpriseUser,
 			expectedSchedules: []expectedSchedule{
 				{
 					nameRe:                        "BACKUP .*",
-					backupStmt:                    "BACKUP INTO LATEST IN 'nodelocal://0/backup' WITH detached",
+					backupStmt:                    "BACKUP INTO LATEST IN 'nodelocal://1/backup' WITH detached",
 					period:                        time.Hour,
 					paused:                        true,
 					chainProtectedTimestampRecord: true,
 				},
 				{
 					nameRe:                        "BACKUP .+",
-					backupStmt:                    "BACKUP INTO 'nodelocal://0/backup' WITH detached",
+					backupStmt:                    "BACKUP INTO 'nodelocal://1/backup' WITH detached",
 					period:                        24 * time.Hour,
 					runsNow:                       true,
 					chainProtectedTimestampRecord: true,
@@ -414,19 +414,19 @@ func TestSerializesScheduledBackupExecutionArgs(t *testing.T) {
 		},
 		{
 			name:  "full-cluster-with-name",
-			query: "CREATE SCHEDULE 'my-backup' FOR BACKUP INTO 'nodelocal://0/backup' RECURRING '@hourly'",
+			query: "CREATE SCHEDULE 'my-backup' FOR BACKUP INTO 'nodelocal://1/backup' RECURRING '@hourly'",
 			user:  enterpriseUser,
 			expectedSchedules: []expectedSchedule{
 				{
 					nameRe:                        "my-backup",
-					backupStmt:                    "BACKUP INTO LATEST IN 'nodelocal://0/backup' WITH detached",
+					backupStmt:                    "BACKUP INTO LATEST IN 'nodelocal://1/backup' WITH detached",
 					period:                        time.Hour,
 					paused:                        true,
 					chainProtectedTimestampRecord: true,
 				},
 				{
 					nameRe:                        "my-backup",
-					backupStmt:                    "BACKUP INTO 'nodelocal://0/backup' WITH detached",
+					backupStmt:                    "BACKUP INTO 'nodelocal://1/backup' WITH detached",
 					period:                        24 * time.Hour,
 					runsNow:                       true,
 					chainProtectedTimestampRecord: true,
@@ -435,31 +435,31 @@ func TestSerializesScheduledBackupExecutionArgs(t *testing.T) {
 		},
 		{
 			name:  "full-cluster-always",
-			query: "CREATE SCHEDULE FOR BACKUP INTO 'nodelocal://0/backup' WITH revision_history RECURRING '@hourly' FULL BACKUP ALWAYS",
+			query: "CREATE SCHEDULE FOR BACKUP INTO 'nodelocal://1/backup' WITH revision_history RECURRING '@hourly' FULL BACKUP ALWAYS",
 			user:  enterpriseUser,
 			expectedSchedules: []expectedSchedule{
 				{
 					nameRe:     "BACKUP .+",
-					backupStmt: "BACKUP INTO 'nodelocal://0/backup' WITH revision_history = true, detached",
+					backupStmt: "BACKUP INTO 'nodelocal://1/backup' WITH revision_history = true, detached",
 					period:     time.Hour,
 				},
 			},
 		},
 		{
 			name:  "full-cluster-remote-incremental-location",
-			query: "CREATE SCHEDULE FOR BACKUP INTO 'nodelocal://0/backup' WITH incremental_location = 'nodelocal://1/incremental' RECURRING '@hourly'",
+			query: "CREATE SCHEDULE FOR BACKUP INTO 'nodelocal://1/backup' WITH incremental_location = 'nodelocal://1/incremental' RECURRING '@hourly'",
 			user:  enterpriseUser,
 			expectedSchedules: []expectedSchedule{
 				{
 					nameRe:                        "BACKUP .*",
-					backupStmt:                    "BACKUP INTO LATEST IN 'nodelocal://0/backup' WITH detached, incremental_location = 'nodelocal://1/incremental'",
+					backupStmt:                    "BACKUP INTO LATEST IN 'nodelocal://1/backup' WITH detached, incremental_location = 'nodelocal://1/incremental'",
 					period:                        time.Hour,
 					paused:                        true,
 					chainProtectedTimestampRecord: true,
 				},
 				{
 					nameRe:                        "BACKUP .+",
-					backupStmt:                    "BACKUP INTO 'nodelocal://0/backup' WITH detached",
+					backupStmt:                    "BACKUP INTO 'nodelocal://1/backup' WITH detached",
 					period:                        24 * time.Hour,
 					runsNow:                       true,
 					chainProtectedTimestampRecord: true,
@@ -470,13 +470,13 @@ func TestSerializesScheduledBackupExecutionArgs(t *testing.T) {
 			name: "multiple-tables-with-revision-history",
 			user: enterpriseUser,
 			query: `
-		CREATE SCHEDULE FOR BACKUP TABLE system.jobs, system.scheduled_jobs INTO 'nodelocal://0/backup'
+		CREATE SCHEDULE FOR BACKUP TABLE system.jobs, system.scheduled_jobs INTO 'nodelocal://1/backup'
 		WITH revision_history RECURRING '@hourly'`,
 			expectedSchedules: []expectedSchedule{
 				{
 					nameRe: "BACKUP .*",
 					backupStmt: "BACKUP TABLE system.public.jobs, " +
-						"system.public.scheduled_jobs INTO LATEST IN 'nodelocal://0/backup' WITH" +
+						"system.public.scheduled_jobs INTO LATEST IN 'nodelocal://1/backup' WITH" +
 						" revision_history = true, detached",
 					period:                        time.Hour,
 					paused:                        true,
@@ -485,7 +485,7 @@ func TestSerializesScheduledBackupExecutionArgs(t *testing.T) {
 				{
 					nameRe: "BACKUP .+",
 					backupStmt: "BACKUP TABLE system.public.jobs, " +
-						"system.public.scheduled_jobs INTO 'nodelocal://0/backup' WITH revision_history = true, detached",
+						"system.public.scheduled_jobs INTO 'nodelocal://1/backup' WITH revision_history = true, detached",
 					period:                        24 * time.Hour,
 					runsNow:                       true,
 					chainProtectedTimestampRecord: true,
@@ -496,19 +496,19 @@ func TestSerializesScheduledBackupExecutionArgs(t *testing.T) {
 			name: "database-with-revision-history",
 			user: enterpriseUser,
 			query: `
-		CREATE SCHEDULE FOR BACKUP DATABASE system INTO 'nodelocal://0/backup'
+		CREATE SCHEDULE FOR BACKUP DATABASE system INTO 'nodelocal://1/backup'
 		WITH revision_history RECURRING '@hourly'`,
 			expectedSchedules: []expectedSchedule{
 				{
 					nameRe:                        "BACKUP .*",
-					backupStmt:                    "BACKUP DATABASE system INTO LATEST IN 'nodelocal://0/backup' WITH revision_history = true, detached",
+					backupStmt:                    "BACKUP DATABASE system INTO LATEST IN 'nodelocal://1/backup' WITH revision_history = true, detached",
 					period:                        time.Hour,
 					paused:                        true,
 					chainProtectedTimestampRecord: true,
 				},
 				{
 					nameRe:                        "BACKUP .+",
-					backupStmt:                    "BACKUP DATABASE system INTO 'nodelocal://0/backup' WITH revision_history = true, detached",
+					backupStmt:                    "BACKUP DATABASE system INTO 'nodelocal://1/backup' WITH revision_history = true, detached",
 					period:                        24 * time.Hour,
 					runsNow:                       true,
 					chainProtectedTimestampRecord: true,
@@ -519,19 +519,19 @@ func TestSerializesScheduledBackupExecutionArgs(t *testing.T) {
 			name: "wildcard-with-revision-history",
 			user: enterpriseUser,
 			query: `
-		CREATE SCHEDULE FOR BACKUP TABLE system.* INTO 'nodelocal://0/backup'
+		CREATE SCHEDULE FOR BACKUP TABLE system.* INTO 'nodelocal://1/backup'
 		WITH revision_history RECURRING '@hourly'`,
 			expectedSchedules: []expectedSchedule{
 				{
 					nameRe:                        "BACKUP .*",
-					backupStmt:                    "BACKUP TABLE system.public.* INTO LATEST IN 'nodelocal://0/backup' WITH revision_history = true, detached",
+					backupStmt:                    "BACKUP TABLE system.public.* INTO LATEST IN 'nodelocal://1/backup' WITH revision_history = true, detached",
 					period:                        time.Hour,
 					paused:                        true,
 					chainProtectedTimestampRecord: true,
 				},
 				{
 					nameRe:                        "BACKUP .+",
-					backupStmt:                    "BACKUP TABLE system.public.* INTO 'nodelocal://0/backup' WITH revision_history = true, detached",
+					backupStmt:                    "BACKUP TABLE system.public.* INTO 'nodelocal://1/backup' WITH revision_history = true, detached",
 					period:                        24 * time.Hour,
 					runsNow:                       true,
 					chainProtectedTimestampRecord: true,
@@ -540,38 +540,38 @@ func TestSerializesScheduledBackupExecutionArgs(t *testing.T) {
 		},
 		{
 			name:   "enterprise-license-required-for-incremental",
-			query:  "CREATE SCHEDULE FOR BACKUP INTO 'nodelocal://0/backup' RECURRING '@hourly' FULL BACKUP '@weekly'",
+			query:  "CREATE SCHEDULE FOR BACKUP INTO 'nodelocal://1/backup' RECURRING '@hourly' FULL BACKUP '@weekly'",
 			user:   freeUser,
 			errMsg: "use of BACKUP INTO LATEST requires an enterprise license",
 		},
 		{
 			name:   "enterprise-license-required-for-revision-history",
-			query:  "CREATE SCHEDULE FOR BACKUP INTO 'nodelocal://0/backup' WITH revision_history RECURRING '@hourly'",
+			query:  "CREATE SCHEDULE FOR BACKUP INTO 'nodelocal://1/backup' WITH revision_history RECURRING '@hourly'",
 			user:   freeUser,
 			errMsg: "use of BACKUP with revision_history requires an enterprise license",
 		},
 		{
 			name:   "enterprise-license-required-for-encryption",
-			query:  "CREATE SCHEDULE FOR BACKUP INTO 'nodelocal://0/backup'  WITH encryption_passphrase = 'secret' RECURRING '@hourly'",
+			query:  "CREATE SCHEDULE FOR BACKUP INTO 'nodelocal://1/backup'  WITH encryption_passphrase = 'secret' RECURRING '@hourly'",
 			user:   freeUser,
 			errMsg: "use of BACKUP with encryption requires an enterprise license",
 		},
 		{
 			name:      "full-cluster-with-name-arg",
-			query:     `CREATE SCHEDULE $1 FOR BACKUP INTO 'nodelocal://0/backup' WITH revision_history, detached RECURRING '@hourly'`,
+			query:     `CREATE SCHEDULE $1 FOR BACKUP INTO 'nodelocal://1/backup' WITH revision_history, detached RECURRING '@hourly'`,
 			queryArgs: []interface{}{"my_backup_name"},
 			user:      enterpriseUser,
 			expectedSchedules: []expectedSchedule{
 				{
 					nameRe:                        "my_backup_name",
-					backupStmt:                    "BACKUP INTO LATEST IN 'nodelocal://0/backup' WITH revision_history = true, detached",
+					backupStmt:                    "BACKUP INTO LATEST IN 'nodelocal://1/backup' WITH revision_history = true, detached",
 					period:                        time.Hour,
 					paused:                        true,
 					chainProtectedTimestampRecord: true,
 				},
 				{
 					nameRe:                        "my_backup_name",
-					backupStmt:                    "BACKUP INTO 'nodelocal://0/backup' WITH revision_history = true, detached",
+					backupStmt:                    "BACKUP INTO 'nodelocal://1/backup' WITH revision_history = true, detached",
 					period:                        24 * time.Hour,
 					runsNow:                       true,
 					chainProtectedTimestampRecord: true,
@@ -580,20 +580,20 @@ func TestSerializesScheduledBackupExecutionArgs(t *testing.T) {
 		},
 		{
 			name:      "full-cluster-with-revision-history-arg",
-			query:     `CREATE SCHEDULE my_backup_name FOR BACKUP INTO 'nodelocal://0/backup' WITH revision_history = $1 RECURRING '@hourly'`,
+			query:     `CREATE SCHEDULE my_backup_name FOR BACKUP INTO 'nodelocal://1/backup' WITH revision_history = $1 RECURRING '@hourly'`,
 			queryArgs: []interface{}{true},
 			user:      enterpriseUser,
 			expectedSchedules: []expectedSchedule{
 				{
 					nameRe:                        "my_backup_name",
-					backupStmt:                    "BACKUP INTO LATEST IN 'nodelocal://0/backup' WITH revision_history = true, detached",
+					backupStmt:                    "BACKUP INTO LATEST IN 'nodelocal://1/backup' WITH revision_history = true, detached",
 					period:                        time.Hour,
 					paused:                        true,
 					chainProtectedTimestampRecord: true,
 				},
 				{
 					nameRe:                        "my_backup_name",
-					backupStmt:                    "BACKUP INTO 'nodelocal://0/backup' WITH revision_history = true, detached",
+					backupStmt:                    "BACKUP INTO 'nodelocal://1/backup' WITH revision_history = true, detached",
 					period:                        24 * time.Hour,
 					runsNow:                       true,
 					chainProtectedTimestampRecord: true,
@@ -604,16 +604,16 @@ func TestSerializesScheduledBackupExecutionArgs(t *testing.T) {
 			name: "multiple-tables-with-encryption",
 			user: enterpriseUser,
 			query: `
-		CREATE SCHEDULE FOR BACKUP TABLE system.jobs, system.scheduled_jobs INTO 'nodelocal://0/backup'
+		CREATE SCHEDULE FOR BACKUP TABLE system.jobs, system.scheduled_jobs INTO 'nodelocal://1/backup'
 		WITH revision_history, encryption_passphrase = 'secret' RECURRING '@weekly'`,
 			expectedSchedules: []expectedSchedule{
 				{
 					nameRe: "BACKUP .*",
 					backupStmt: "BACKUP TABLE system.public.jobs, " +
-						"system.public.scheduled_jobs INTO 'nodelocal://0/backup' WITH" +
+						"system.public.scheduled_jobs INTO 'nodelocal://1/backup' WITH" +
 						" revision_history = true, encryption_passphrase = 'secret', detached",
 					shownStmt: "BACKUP TABLE system.public.jobs, " +
-						"system.public.scheduled_jobs INTO 'nodelocal://0/backup' WITH" +
+						"system.public.scheduled_jobs INTO 'nodelocal://1/backup' WITH" +
 						" revision_history = true, encryption_passphrase = '*****', detached",
 					period: 7 * 24 * time.Hour,
 				},
@@ -624,7 +624,7 @@ func TestSerializesScheduledBackupExecutionArgs(t *testing.T) {
 			user: enterpriseUser,
 			query: `
 		CREATE SCHEDULE FOR BACKUP DATABASE system
-    INTO ('nodelocal://0/backup?COCKROACH_LOCALITY=x%3Dy', 'nodelocal://0/backup2?COCKROACH_LOCALITY=default')
+    INTO ('nodelocal://1/backup?COCKROACH_LOCALITY=x%3Dy', 'nodelocal://1/backup2?COCKROACH_LOCALITY=default')
 		WITH revision_history
     RECURRING '1 2 * * *'
     FULL BACKUP ALWAYS
@@ -635,7 +635,7 @@ func TestSerializesScheduledBackupExecutionArgs(t *testing.T) {
 				{
 					nameRe: "BACKUP .+",
 					backupStmt: "BACKUP DATABASE system INTO " +
-						"('nodelocal://0/backup?COCKROACH_LOCALITY=x%3Dy', 'nodelocal://0/backup2?COCKROACH_LOCALITY=default') " +
+						"('nodelocal://1/backup?COCKROACH_LOCALITY=x%3Dy', 'nodelocal://1/backup2?COCKROACH_LOCALITY=default') " +
 						"WITH revision_history = true, detached",
 					period: 24 * time.Hour,
 				},
@@ -646,7 +646,7 @@ func TestSerializesScheduledBackupExecutionArgs(t *testing.T) {
 			user: enterpriseUser,
 			query: `
 		CREATE SCHEDULE FOR BACKUP DATABASE system
-    INTO 'nodelocal://0/backup'
+    INTO 'nodelocal://1/backup'
 		WITH revision_history, execution locality = 'region=of-france'
     RECURRING '1 2 * * *'
     FULL BACKUP ALWAYS
@@ -656,7 +656,7 @@ func TestSerializesScheduledBackupExecutionArgs(t *testing.T) {
 			expectedSchedules: []expectedSchedule{
 				{
 					nameRe: "BACKUP .+",
-					backupStmt: "BACKUP DATABASE system INTO 'nodelocal://0/backup' " +
+					backupStmt: "BACKUP DATABASE system INTO 'nodelocal://1/backup' " +
 						"WITH revision_history = true, detached, execution locality = 'region=of-france'",
 					period: 24 * time.Hour,
 				},
@@ -779,7 +779,7 @@ INSERT INTO t1 values (1), (10), (100);
 
 	t.Run("on_previous_running=start", func(t *testing.T) {
 		schedule := `CREATE SCHEDULE FOR BACKUP INTO $1 RECURRING '@hourly' WITH SCHEDULE OPTIONS on_previous_running = 'start'`
-		destination := "nodelocal://0/backup/"
+		destination := "nodelocal://1/backup/"
 		schedules, err := th.createBackupSchedule(t, schedule, destination)
 		require.NoError(t, err)
 		require.Len(t, schedules, 2)
@@ -788,7 +788,7 @@ INSERT INTO t1 values (1), (10), (100);
 
 	t.Run("on_previous_running=skip", func(t *testing.T) {
 		schedule := `CREATE SCHEDULE FOR BACKUP INTO $1 RECURRING '@hourly' WITH SCHEDULE OPTIONS on_previous_running = 'skip'`
-		destination := "nodelocal://0/backup/"
+		destination := "nodelocal://1/backup/"
 		schedules, err := th.createBackupSchedule(t, schedule, destination)
 		require.NoError(t, err)
 		require.Len(t, schedules, 2)
@@ -797,7 +797,7 @@ INSERT INTO t1 values (1), (10), (100);
 
 	t.Run("on_previous_running=wait", func(t *testing.T) {
 		schedule := `CREATE SCHEDULE FOR BACKUP INTO $1 RECURRING '@hourly' WITH SCHEDULE OPTIONS on_previous_running = 'wait'`
-		destination := "nodelocal://0/backup/"
+		destination := "nodelocal://1/backup/"
 		schedules, err := th.createBackupSchedule(t, schedule, destination)
 		require.NoError(t, err)
 		require.Len(t, schedules, 2)
@@ -896,7 +896,7 @@ INSERT INTO t1 values (-1), (10), (-100);
 			testName := fmt.Sprintf("%s_chaining=%t", tc.name, enabled)
 			t.Run(testName, func(t *testing.T) {
 				th.sqlDB.Exec(t, fmt.Sprintf(`SET CLUSTER SETTING schedules.backup.gc_protection.enabled = %t`, enabled))
-				destination := "nodelocal://0/backup/" + testName
+				destination := "nodelocal://1/backup/" + testName
 				schedules, err := th.createBackupSchedule(t, tc.schedule, destination)
 				require.NoError(t, err)
 				require.LessOrEqual(t, 1, len(schedules))
@@ -1114,7 +1114,7 @@ INSERT INTO t values (1), (10), (100);
 	createSchedules := func(t *testing.T, name string) (int64, int64, func()) {
 		schedules, err := th.createBackupSchedule(t,
 			"CREATE SCHEDULE FOR BACKUP INTO $1 RECURRING '*/5 * * * *'",
-			"nodelocal://0/backup/"+name)
+			"nodelocal://1/backup/"+name)
 		require.NoError(t, err)
 
 		// We expect full & incremental schedule to be created.
@@ -1368,7 +1368,7 @@ func TestShowCreateScheduleStatement(t *testing.T) {
 			defer utilccl.TestingEnableEnterprise()()
 			defer th.clearSchedules(t)
 
-			destination := "nodelocal://0/" + tc.name
+			destination := "nodelocal://1/" + tc.name
 			createScheduleQuery := fmt.Sprintf(tc.query, destination)
 			schedules, err := th.createBackupSchedule(t, createScheduleQuery)
 			require.NoError(t, err)

--- a/pkg/ccl/backupccl/full_cluster_backup_restore_test.go
+++ b/pkg/ccl/backupccl/full_cluster_backup_restore_test.go
@@ -146,7 +146,7 @@ CREATE TABLE data2.foo (a int);
 	// Note: this is not the backup under test, this just serves as a job which
 	// should appear in the restore.
 	// This job will eventually fail since it will run from a new cluster.
-	sqlDB.Exec(t, `BACKUP data.bank TO 'nodelocal://0/throwawayjob'`)
+	sqlDB.Exec(t, `BACKUP data.bank TO 'nodelocal://1/throwawayjob'`)
 	// Populate system.settings.
 	sqlDB.Exec(t, `SET CLUSTER SETTING kv.bulk_io_write.concurrent_addsstable_requests = 5`)
 	sqlDB.Exec(t, `INSERT INTO system.ui (key, value, "lastUpdated") VALUES ($1, $2, now())`, "some_key", "some_val")
@@ -398,7 +398,7 @@ func TestIncrementalFullClusterBackup(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	const numAccounts = 10
-	const incrementalBackupLocation = "nodelocal://0/inc-full-backup"
+	const incrementalBackupLocation = "nodelocal://1/inc-full-backup"
 	_, sqlDB, tempDir, cleanupFn := backupRestoreTestSetup(t, singleNode, numAccounts, InitManualReplication)
 	_, sqlDBRestore, cleanupEmptyCluster := backupRestoreTestSetupEmpty(t, singleNode, tempDir, InitManualReplication, base.TestClusterArgs{})
 	defer cleanupFn()
@@ -646,7 +646,7 @@ func TestClusterRestoreFailCleanup(t *testing.T) {
 	// Note: this is not the backup under test, this just serves as a job which
 	// should appear in the restore.
 	// This job will eventually fail since it will run from a new cluster.
-	sqlDB.Exec(t, `BACKUP data.bank TO 'nodelocal://0/throwawayjob'`)
+	sqlDB.Exec(t, `BACKUP data.bank TO 'nodelocal://1/throwawayjob'`)
 	sqlDB.Exec(t, `BACKUP TO $1`, localFoo)
 
 	t.Run("during restoration of data", func(t *testing.T) {
@@ -973,8 +973,8 @@ func TestReintroduceOfflineSpans(t *testing.T) {
 	_, srcDB, tempDir, cleanupSrc := backupRestoreTestSetupWithParams(t, singleNode, numAccounts, InitManualReplication, params)
 	defer cleanupSrc()
 
-	dbBackupLoc := "nodelocal://0/my_db_backup"
-	clusterBackupLoc := "nodelocal://0/my_cluster_backup"
+	dbBackupLoc := "nodelocal://1/my_db_backup"
+	clusterBackupLoc := "nodelocal://1/my_cluster_backup"
 
 	// the small test-case will get entirely buffered/merged by small-file merging
 	// and not report any progress in the meantime unless it is disabled.

--- a/pkg/ccl/backupccl/generative_split_and_scatter_processor_test.go
+++ b/pkg/ccl/backupccl/generative_split_and_scatter_processor_test.go
@@ -37,7 +37,7 @@ func TestRunGenerativeSplitAndScatterContextCancel(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	const numAccounts = 1000
-	const localFoo = "nodelocal://0/foo"
+	const localFoo = "nodelocal://1/foo"
 	ctx := context.Background()
 	ctx, cancel := context.WithCancel(ctx)
 	tc, sqlDB, _, cleanupFn := backupRestoreTestSetup(t, singleNode, numAccounts,

--- a/pkg/ccl/backupccl/restore_data_processor_test.go
+++ b/pkg/ccl/backupccl/restore_data_processor_test.go
@@ -272,7 +272,7 @@ func runTestIngest(t *testing.T, init func(*cluster.Settings)) {
 		},
 	}
 
-	storage, err := cloud.ExternalStorageConfFromURI("nodelocal://0/foo", username.RootUserName())
+	storage, err := cloud.ExternalStorageConfFromURI("nodelocal://1/foo", username.RootUserName())
 	if err != nil {
 		t.Fatalf("%+v", err)
 	}

--- a/pkg/ccl/backupccl/tenant_backup_nemesis_test.go
+++ b/pkg/ccl/backupccl/tenant_backup_nemesis_test.go
@@ -95,14 +95,14 @@ func TestTenantBackupWithCanceledImport(t *testing.T) {
 	importStmt := fmt.Sprintf(`IMPORT INTO "%s" CSV DATA ('workload:///csv/bank/bank?payload-bytes=100&row-end=1&row-start=0&rows=1000&seed=1&version=1.0.0')`, tableName)
 	tenant10DB.ExpectErr(t, "pause", importStmt)
 
-	hostSQLDB.Exec(t, "BACKUP TENANT 10 INTO 'nodelocal://0/tenant-backup'")
+	hostSQLDB.Exec(t, "BACKUP TENANT 10 INTO 'nodelocal://1/tenant-backup'")
 
 	tenant10DB.Exec(t, "SET CLUSTER SETTING jobs.debug.pausepoints = ''")
 	tenant10DB.Exec(t, "CANCEL JOB (SELECT job_id FROM [SHOW JOBS] WHERE job_type = 'IMPORT' AND status = 'paused')")
 	tenant10DB.Exec(t, "SHOW JOBS WHEN COMPLETE (SELECT job_id FROM [SHOW JOBS] WHERE job_type = 'IMPORT')")
 
-	hostSQLDB.Exec(t, "BACKUP TENANT 10 INTO LATEST IN 'nodelocal://0/tenant-backup'")
-	hostSQLDB.Exec(t, "RESTORE TENANT 10 FROM LATEST IN 'nodelocal://0/tenant-backup' WITH tenant_name = 'tenant-11'")
+	hostSQLDB.Exec(t, "BACKUP TENANT 10 INTO LATEST IN 'nodelocal://1/tenant-backup'")
+	hostSQLDB.Exec(t, "RESTORE TENANT 10 FROM LATEST IN 'nodelocal://1/tenant-backup' WITH tenant_name = 'tenant-11'")
 
 	tenant11, err := tc.Servers[0].StartTenant(ctx, base.TestTenantArgs{
 		TenantName:          "tenant-11",
@@ -178,7 +178,7 @@ func TestTenantBackupNemesis(t *testing.T) {
 	_, err = workloadsql.Setup(ctx, tenant10Conn, bankData, l)
 	require.NoError(t, err)
 
-	backupLoc := "nodelocal://0/tenant-backup"
+	backupLoc := "nodelocal://1/tenant-backup"
 
 	backupDone := make(chan struct{})
 	g := ctxgroup.WithContext(ctx)

--- a/pkg/ccl/backupccl/testdata/backup-restore/backup-dropped-descriptors
+++ b/pkg/ccl/backupccl/testdata/backup-restore/backup-dropped-descriptors
@@ -35,18 +35,18 @@ SELECT orig->'database'->'name', orig->'database'->'state' FROM tbls WHERE id = 
 # A database backup should fail since we are explicitly targeting a dropped
 # object.
 exec-sql
-BACKUP DATABASE d INTO 'nodelocal://0/dropped-database';
+BACKUP DATABASE d INTO 'nodelocal://1/dropped-database';
 ----
 pq: failed to resolve targets specified in the BACKUP stmt: database "d" does not exist, or invalid RESTORE timestamp: supplied backups do not cover requested time
 
 # A cluster backup should succeed but should ignore the dropped database
 # and table descriptors.
 exec-sql
-BACKUP INTO 'nodelocal://0/cluster/dropped-database';
+BACKUP INTO 'nodelocal://1/cluster/dropped-database';
 ----
 
 query-sql
-SELECT count(*) FROM [SHOW BACKUP LATEST IN 'nodelocal://0/cluster/dropped-database'] WHERE object_name = 'd' OR object_name = 'foo';
+SELECT count(*) FROM [SHOW BACKUP LATEST IN 'nodelocal://1/cluster/dropped-database'] WHERE object_name = 'd' OR object_name = 'foo';
 ----
 0
 
@@ -59,20 +59,20 @@ CREATE TABLE d.bar (id INT);
 # A database backup should succeed since we have a public database descriptor that matches the
 # target.
 exec-sql
-BACKUP DATABASE d INTO 'nodelocal://0/dropped-database';
+BACKUP DATABASE d INTO 'nodelocal://1/dropped-database';
 ----
 
 # A cluster backup should succeed and include the public database descriptor and
 # its table.
 exec-sql
-BACKUP INTO 'nodelocal://0/cluster/dropped-database';
+BACKUP INTO 'nodelocal://1/cluster/dropped-database';
 ----
 
 # Restore from the database backup to ensure it is valid.
 # Sanity check that we did not backup the table 'foo' that belonged to the
 # dropped database 'd'.
 exec-sql
-RESTORE DATABASE d FROM LATEST IN 'nodelocal://0/dropped-database' WITH new_db_name = 'd1';
+RESTORE DATABASE d FROM LATEST IN 'nodelocal://1/dropped-database' WITH new_db_name = 'd1';
 ----
 
 exec-sql
@@ -88,7 +88,7 @@ public bar
 # Sanity check that we did not backup the table 'foo' that belonged to the
 # dropped database 'd'.
 exec-sql
-RESTORE DATABASE d FROM LATEST IN 'nodelocal://0/cluster/dropped-database' WITH new_db_name = 'd2';
+RESTORE DATABASE d FROM LATEST IN 'nodelocal://1/cluster/dropped-database' WITH new_db_name = 'd2';
 ----
 
 exec-sql
@@ -165,11 +165,11 @@ SELECT orig->'type'->'name', orig->'type'->'state' FROM tbls WHERE id = 110 OR i
 # A database backup should succeed but should not include the dropped schema,
 # type, and table.
 exec-sql
-BACKUP DATABASE d2 INTO 'nodelocal://0/dropped-schema-in-database';
+BACKUP DATABASE d2 INTO 'nodelocal://1/dropped-schema-in-database';
 ----
 
 query-sql
-SELECT count(*) FROM [SHOW BACKUP LATEST IN 'nodelocal://0/dropped-schema-in-database'] WHERE
+SELECT count(*) FROM [SHOW BACKUP LATEST IN 'nodelocal://1/dropped-schema-in-database'] WHERE
 object_name = 's' OR object_name = 'typ';
 ----
 0
@@ -178,18 +178,18 @@ object_name = 's' OR object_name = 'typ';
 # A cluster backup should succeed but should not include the dropped schema,
 # type, and table.
 exec-sql
-BACKUP INTO 'nodelocal://0/cluster/dropped-schema-in-database';
+BACKUP INTO 'nodelocal://1/cluster/dropped-schema-in-database';
 ----
 
 query-sql
-SELECT count(*) FROM [SHOW BACKUP LATEST IN 'nodelocal://0/cluster/dropped-schema-in-database']
+SELECT count(*) FROM [SHOW BACKUP LATEST IN 'nodelocal://1/cluster/dropped-schema-in-database']
 WHERE object_name = 's' OR object_name = 'typ';
 ----
 0
 
 # Restore the backups to check they are valid.
 exec-sql
-RESTORE DATABASE d2 FROM LATEST IN 'nodelocal://0/dropped-schema-in-database' WITH new_db_name = 'd3';
+RESTORE DATABASE d2 FROM LATEST IN 'nodelocal://1/dropped-schema-in-database' WITH new_db_name = 'd3';
 ----
 
 exec-sql
@@ -213,7 +213,7 @@ public t2
 
 
 exec-sql
-RESTORE DATABASE d2 FROM LATEST IN 'nodelocal://0/cluster/dropped-schema-in-database' WITH new_db_name ='d4';
+RESTORE DATABASE d2 FROM LATEST IN 'nodelocal://1/cluster/dropped-schema-in-database' WITH new_db_name ='d4';
 ----
 
 exec-sql

--- a/pkg/ccl/backupccl/testdata/backup-restore/backup-dropped-descriptors-declarative
+++ b/pkg/ccl/backupccl/testdata/backup-restore/backup-dropped-descriptors-declarative
@@ -36,19 +36,19 @@ SELECT orig->'database'->'name', orig->'database'->'state' FROM tbls WHERE id = 
 # A database backup should fail since we are explicitly targeting a dropped
 # object.
 exec-sql
-BACKUP DATABASE dd INTO 'nodelocal://0/dropped-database';
+BACKUP DATABASE dd INTO 'nodelocal://1/dropped-database';
 ----
 pq: failed to resolve targets specified in the BACKUP stmt: database "dd" does not exist, or invalid RESTORE timestamp: supplied backups do not cover requested time
 
 # A cluster backup should succeed.
 exec-sql
-BACKUP INTO 'nodelocal://0/cluster/dropped-database';
+BACKUP INTO 'nodelocal://1/cluster/dropped-database';
 ----
 
 # The dropped descriptors should not end up in the cluster backup.
 query-sql
 SELECT count(*)
-  FROM [SHOW BACKUP LATEST IN 'nodelocal://0/cluster/dropped-database']
+  FROM [SHOW BACKUP LATEST IN 'nodelocal://1/cluster/dropped-database']
   WHERE object_name IN ('dd', 'foo', 's');
 ----
 0
@@ -113,12 +113,12 @@ SELECT orig->'type'->'name', orig->'type'->'state' FROM tbls WHERE id = 110 OR i
 # A database backup should succeed and should not include the dropped schema,
 # type, and table.
 exec-sql
-BACKUP DATABASE d2 INTO 'nodelocal://0/dropped-schema-in-database';
+BACKUP DATABASE d2 INTO 'nodelocal://1/dropped-schema-in-database';
 ----
 
 query-sql
 SELECT count(*)
-  FROM [SHOW BACKUP LATEST IN 'nodelocal://0/dropped-schema-in-database']
+  FROM [SHOW BACKUP LATEST IN 'nodelocal://1/dropped-schema-in-database']
   WHERE object_name IN ('s', 't', 'typ', '_typ');
 ----
 0
@@ -126,19 +126,19 @@ SELECT count(*)
 # A cluster backup should succeed but should not include the dropped schema,
 # type, and table.
 exec-sql
-BACKUP INTO 'nodelocal://0/cluster/dropped-schema-in-database';
+BACKUP INTO 'nodelocal://1/cluster/dropped-schema-in-database';
 ----
 
 query-sql
 SELECT count(*)
-  FROM [SHOW BACKUP LATEST IN 'nodelocal://0/cluster/dropped-schema-in-database']
+  FROM [SHOW BACKUP LATEST IN 'nodelocal://1/cluster/dropped-schema-in-database']
   WHERE object_name IN ('s', 't', 'typ', '_typ');
 ----
 0
 
 # Restore the backups to check they are valid.
 exec-sql
-RESTORE DATABASE d2 FROM LATEST IN 'nodelocal://0/dropped-schema-in-database' WITH new_db_name = 'd3';
+RESTORE DATABASE d2 FROM LATEST IN 'nodelocal://1/dropped-schema-in-database' WITH new_db_name = 'd3';
 ----
 
 exec-sql
@@ -162,7 +162,7 @@ SELECT schema_name, table_name FROM [SHOW TABLES];
 public t2
 
 exec-sql
-RESTORE DATABASE d2 FROM LATEST IN 'nodelocal://0/cluster/dropped-schema-in-database' WITH new_db_name ='d4';
+RESTORE DATABASE d2 FROM LATEST IN 'nodelocal://1/cluster/dropped-schema-in-database' WITH new_db_name ='d4';
 ----
 
 exec-sql

--- a/pkg/ccl/backupccl/testdata/backup-restore/backup-permissions-deprecated
+++ b/pkg/ccl/backupccl/testdata/backup-restore/backup-permissions-deprecated
@@ -11,14 +11,14 @@ INSERT INTO d.t VALUES (1), (2), (3);
 
 # BACKUP is not allowed in a batch-statement.
 exec-sql
-BACKUP INTO 'nodelocal://0/test-root/';
+BACKUP INTO 'nodelocal://1/test-root/';
 SELECT 1;
 ----
 pq: BACKUP cannot be used inside a multi-statement transaction without DETACHED option
 
 # Cluster backup should succeed as a root user.
 exec-sql
-BACKUP INTO 'nodelocal://0/test-root/'
+BACKUP INTO 'nodelocal://1/test-root/'
 ----
 
 # Backups should succeed as a non-root user with admin role.
@@ -28,15 +28,15 @@ GRANT ADMIN TO testuser;
 ----
 
 exec-sql user=testuser
-BACKUP INTO 'nodelocal://0/test-nonroot-cluster';
+BACKUP INTO 'nodelocal://1/test-nonroot-cluster';
 ----
 
 exec-sql user=testuser
-BACKUP DATABASE d INTO 'nodelocal://0/test-nonroot-db';
+BACKUP DATABASE d INTO 'nodelocal://1/test-nonroot-db';
 ----
 
 exec-sql user=testuser
-BACKUP TABLE d.t INTO 'nodelocal://0/test-nonroot-table';
+BACKUP TABLE d.t INTO 'nodelocal://1/test-nonroot-table';
 ----
 
 # Start a new cluster with the same IO dir.
@@ -59,13 +59,13 @@ CREATE USER testuser
 
 # Cluster backup as a non-admin user should fail.
 exec-sql user=testuser
-BACKUP INTO 'nodelocal://0/test2'
+BACKUP INTO 'nodelocal://1/test2'
 ----
 pq: only users with the admin role or the BACKUP system privilege are allowed to perform full cluster backups: user testuser does not have BACKUP privilege on global 
 
 # Database backup as a non-admin user should have CONNECT on database and SELECT on tables.
 exec-sql user=testuser
-BACKUP DATABASE d2 TO 'nodelocal://0/d2'
+BACKUP DATABASE d2 TO 'nodelocal://1/d2'
 ----
 pq: user testuser does not have CONNECT privilege on database d2
 HINT: The existing privileges are being deprecated in favour of a fine-grained privilege model explained here https://www.cockroachlabs.com/docs/stable/backup.html#required-privileges. In a future release, to run BACKUP DATABASE, user testuser will exclusively require the BACKUP privilege on database d2.
@@ -76,7 +76,7 @@ GRANT CONNECT ON DATABASE d2 TO testuser;
 
 # Table backup as a non-admin user should have SELECT privileges.
 exec-sql user=testuser
-BACKUP TABLE d2.t INTO 'nodelocal://0/d2-table'
+BACKUP TABLE d2.t INTO 'nodelocal://1/d2-table'
 ----
 pq: user testuser does not have SELECT privilege on relation t
 HINT: The existing privileges are being deprecated in favour of a fine-grained privilege model explained here https://www.cockroachlabs.com/docs/stable/backup.html#required-privileges. In a future release, to run BACKUP TABLE, user testuser will exclusively require the BACKUP privilege on tables: t.
@@ -92,7 +92,7 @@ CREATE SCHEMA sc2;
 
 # Schema backup as a non-admin user should have USAGE privileges.
 exec-sql user=testuser
-BACKUP DATABASE d2 INTO 'nodelocal://0/d2-schema';
+BACKUP DATABASE d2 INTO 'nodelocal://1/d2-schema';
 ----
 pq: user testuser does not have USAGE privilege on schema sc2
 HINT: The existing privileges are being deprecated in favour of a fine-grained privilege model explained here https://www.cockroachlabs.com/docs/stable/backup.html#required-privileges. In a future release, to run BACKUP DATABASE, user testuser will exclusively require the BACKUP privilege on database d2.
@@ -111,7 +111,7 @@ REVOKE USAGE ON TYPE d2.greeting FROM public;
 
 # Type backup as a non-admin user should have USAGE privileges.
 exec-sql user=testuser
-BACKUP DATABASE d2 INTO 'nodelocal://0/d2-schema';
+BACKUP DATABASE d2 INTO 'nodelocal://1/d2-schema';
 ----
 pq: user testuser does not have USAGE privilege on type greeting
 HINT: The existing privileges are being deprecated in favour of a fine-grained privilege model explained here https://www.cockroachlabs.com/docs/stable/backup.html#required-privileges. In a future release, to run BACKUP DATABASE, user testuser will exclusively require the BACKUP privilege on database d2.
@@ -122,12 +122,12 @@ GRANT USAGE ON TYPE d2.greeting TO testuser;
 
 # testuser should now have all the required privileges.
 exec-sql cluster=s2 user=testuser
-BACKUP DATABASE d2 INTO 'nodelocal://0/d2';
+BACKUP DATABASE d2 INTO 'nodelocal://1/d2';
 ----
 NOTICE: The existing privileges are being deprecated in favour of a fine-grained privilege model explained here https://www.cockroachlabs.com/docs/stable/backup.html#required-privileges. In a future release, to run BACKUP DATABASE, user testuser will exclusively require the BACKUP privilege on database d2.
 
 exec-sql cluster=s2 user=testuser
-BACKUP TABLE d2.t INTO 'nodelocal://0/d2-table';
+BACKUP TABLE d2.t INTO 'nodelocal://1/d2-table';
 ----
 NOTICE: The existing privileges are being deprecated in favour of a fine-grained privilege model explained here https://www.cockroachlabs.com/docs/stable/backup.html#required-privileges. In a future release, to run BACKUP TABLE, user testuser will exclusively require the BACKUP privilege on tables: t.
 
@@ -148,7 +148,7 @@ SHOW BACKUP 'http://COCKROACH_TEST_HTTP_SERVER/'
 pq: only users with the admin role or the EXTERNALIOIMPLICITACCESS system privilege are allowed to access the specified http URI
 
 exec-sql user=testuser
-BACKUP DATABASE d INTO 'nodelocal://0/test3'
+BACKUP DATABASE d INTO 'nodelocal://1/test3'
 ----
 pq: only users with the admin role or the EXTERNALIOIMPLICITACCESS system privilege are allowed to access the specified nodelocal URI
 

--- a/pkg/ccl/backupccl/testdata/backup-restore/descriptor-conflicts
+++ b/pkg/ccl/backupccl/testdata/backup-restore/descriptor-conflicts
@@ -23,7 +23,7 @@ ALTER ROLE hamburger IN DATABASE foo SET application_name='helper';
 ----
 
 exec-sql
-BACKUP INTO 'nodelocal://0/conflicting-descriptors';
+BACKUP INTO 'nodelocal://1/conflicting-descriptors';
 ----
 
 new-cluster name=s2 share-io-dir=s1 disable-tenant
@@ -61,7 +61,7 @@ INSERT INTO system.crdb_internal_copy_107 VALUES ('tab_107', true, now(), 'b')
 ----
 
 exec-sql
-RESTORE FROM LATEST IN 'nodelocal://0/conflicting-descriptors';
+RESTORE FROM LATEST IN 'nodelocal://1/conflicting-descriptors';
 ----
 
 query-sql

--- a/pkg/ccl/backupccl/testdata/backup-restore/feature-flags
+++ b/pkg/ccl/backupccl/testdata/backup-restore/feature-flags
@@ -17,7 +17,7 @@ SET CLUSTER SETTING feature.backup.enabled = FALSE;
 ----
 
 exec-sql
-BACKUP INTO 'nodelocal://0/test-root/';
+BACKUP INTO 'nodelocal://1/test-root/';
 ----
 pq: feature BACKUP was disabled by the database administrator
 
@@ -27,7 +27,7 @@ SET CLUSTER SETTING feature.backup.enabled = TRUE;
 ----
 
 exec-sql
-BACKUP INTO 'nodelocal://0/test-root/';
+BACKUP INTO 'nodelocal://1/test-root/';
 ----
 
 exec-sql
@@ -40,7 +40,7 @@ SET CLUSTER SETTING feature.restore.enabled = FALSE;
 ----
 
 exec-sql
-RESTORE TABLE d.t FROM LATEST IN 'nodelocal://0/test-root/';
+RESTORE TABLE d.t FROM LATEST IN 'nodelocal://1/test-root/';
 ----
 pq: feature RESTORE was disabled by the database administrator
 
@@ -50,7 +50,7 @@ SET CLUSTER SETTING feature.restore.enabled = TRUE;
 ----
 
 exec-sql
-RESTORE TABLE d.t FROM LATEST IN 'nodelocal://0/test-root/';
+RESTORE TABLE d.t FROM LATEST IN 'nodelocal://1/test-root/';
 ----
 
 subtest end

--- a/pkg/ccl/backupccl/testdata/backup-restore/import-start-time
+++ b/pkg/ccl/backupccl/testdata/backup-restore/import-start-time
@@ -28,7 +28,7 @@ ON sys.id = tbls.id;
 ----
 
 exec-sql
-EXPORT INTO CSV 'nodelocal://0/export1/' FROM SELECT * FROM baz WHERE i = 1;
+EXPORT INTO CSV 'nodelocal://1/export1/' FROM SELECT * FROM baz WHERE i = 1;
 ----
 
 exec-sql
@@ -36,7 +36,7 @@ SET CLUSTER SETTING jobs.debug.pausepoints = 'import.after_ingest';
 ----
 
 import expect-pausepoint tag=a
-IMPORT INTO foo (i,s) CSV DATA ('nodelocal://0/export1/export*-n*.0.csv')
+IMPORT INTO foo (i,s) CSV DATA ('nodelocal://1/export1/export*-n*.0.csv')
 ----
 job paused at pausepoint
 
@@ -49,7 +49,7 @@ true
 # attempting another import on the table should fail, as there's already an in-progress import
 # on the table.
 exec-sql
-IMPORT INTO foo (i,s) CSV DATA ('nodelocal://0/export1/export*-n*.0.csv')
+IMPORT INTO foo (i,s) CSV DATA ('nodelocal://1/export1/export*-n*.0.csv')
 ----
 pq: relation "foo" is offline: importing
 
@@ -68,7 +68,7 @@ SET CLUSTER SETTING jobs.debug.pausepoints = '';
 ----
 
 exec-sql
-IMPORT INTO foo (i,s) CSV DATA ('nodelocal://0/export1/export*-n*.0.csv')
+IMPORT INTO foo (i,s) CSV DATA ('nodelocal://1/export1/export*-n*.0.csv')
 ----
 
 query-sql
@@ -79,7 +79,7 @@ SELECT * FROM import_time
 
 # ensure importing into an existing table also modifies the descriptor properly
 exec-sql
-EXPORT INTO CSV 'nodelocal://0/export2/' FROM SELECT * FROM baz WHERE i = 2;
+EXPORT INTO CSV 'nodelocal://1/export2/' FROM SELECT * FROM baz WHERE i = 2;
 ----
 
 exec-sql
@@ -87,7 +87,7 @@ SET CLUSTER SETTING jobs.debug.pausepoints = 'import.after_ingest';
 ----
 
 import expect-pausepoint tag=b
-IMPORT INTO foo (i,s) CSV DATA ('nodelocal://0/export2/export*-n*.0.csv')
+IMPORT INTO foo (i,s) CSV DATA ('nodelocal://1/export2/export*-n*.0.csv')
 ----
 job paused at pausepoint
 

--- a/pkg/ccl/backupccl/testdata/backup-restore/in-progress-import-rollback
+++ b/pkg/ccl/backupccl/testdata/backup-restore/in-progress-import-rollback
@@ -43,35 +43,35 @@ SET CLUSTER SETTING storage.mvcc.range_tombstones.enabled = false;
 
 
 exec-sql
-EXPORT INTO CSV 'nodelocal://0/export1/' FROM SELECT * FROM baz;
+EXPORT INTO CSV 'nodelocal://1/export1/' FROM SELECT * FROM baz;
 ----
 
 
 # Pause the import job, in order to back up the importing data.
 import expect-pausepoint tag=a
-IMPORT INTO foo (i,s) CSV DATA ('nodelocal://0/export1/export*-n*.0.csv')
+IMPORT INTO foo (i,s) CSV DATA ('nodelocal://1/export1/export*-n*.0.csv')
 ----
 job paused at pausepoint
 
 
 import expect-pausepoint tag=aa
-IMPORT INTO foofoo (i,s) CSV DATA ('nodelocal://0/export1/export*-n*.0.csv')
+IMPORT INTO foofoo (i,s) CSV DATA ('nodelocal://1/export1/export*-n*.0.csv')
 ----
 job paused at pausepoint
 
 
 # Ensure table, database, and cluster full backups capture importing rows.
 exec-sql
-BACKUP INTO 'nodelocal://0/cluster/' with revision_history;
+BACKUP INTO 'nodelocal://1/cluster/' with revision_history;
 ----
 
 
 exec-sql
-BACKUP DATABASE d INTO 'nodelocal://0/database/' with revision_history;
+BACKUP DATABASE d INTO 'nodelocal://1/database/' with revision_history;
 ----
 
 exec-sql
-BACKUP TABLE d.* INTO 'nodelocal://0/table/' with revision_history;
+BACKUP TABLE d.* INTO 'nodelocal://1/table/' with revision_history;
 ----
 
 
@@ -117,7 +117,7 @@ CREATE TABLE foo_offline (i INT PRIMARY KEY, s STRING);
 ----
 
 import expect-pausepoint tag=never_unpause
-IMPORT INTO foo_offline (i,s) CSV DATA ('nodelocal://0/export1/export*-n*.0.csv')
+IMPORT INTO foo_offline (i,s) CSV DATA ('nodelocal://1/export1/export*-n*.0.csv')
 ----
 job paused at pausepoint
 
@@ -139,23 +139,23 @@ CREATE INDEX foo_new_idx ON foo (s);
 # import was rolled back via non-mvcc clear range. So, backup 0 rows from foo
 # (it was empty pre-import), and 1 row from foo (had 1 row pre-import);
 exec-sql
-BACKUP INTO LATEST IN 'nodelocal://0/cluster/' with revision_history;
+BACKUP INTO LATEST IN 'nodelocal://1/cluster/' with revision_history;
 ----
 
 exec-sql
-BACKUP DATABASE d INTO LATEST IN 'nodelocal://0/database/' with revision_history;
+BACKUP DATABASE d INTO LATEST IN 'nodelocal://1/database/' with revision_history;
 ----
 
 
 exec-sql
-BACKUP TABLE d.* INTO LATEST IN 'nodelocal://0/table/' with revision_history;
+BACKUP TABLE d.* INTO LATEST IN 'nodelocal://1/table/' with revision_history;
 ----
 
 query-sql
 SELECT
   database_name, object_name, object_type, rows, backup_type
 FROM
-  [SHOW BACKUP FROM LATEST IN 'nodelocal://0/cluster/']
+  [SHOW BACKUP FROM LATEST IN 'nodelocal://1/cluster/']
 WHERE
   object_name = 'foo' or object_name = 'foofoo'
 ORDER BY
@@ -170,7 +170,7 @@ query-sql
 SELECT
   database_name, object_name, object_type, rows, backup_type
 FROM
-  [SHOW BACKUP FROM LATEST IN 'nodelocal://0/database/']
+  [SHOW BACKUP FROM LATEST IN 'nodelocal://1/database/']
 WHERE
   object_name = 'foo' or object_name = 'foofoo'
 ORDER BY
@@ -186,7 +186,7 @@ query-sql
 SELECT
   database_name, object_name, object_type, rows, backup_type
 FROM
-  [SHOW BACKUP FROM LATEST IN 'nodelocal://0/table/']
+  [SHOW BACKUP FROM LATEST IN 'nodelocal://1/table/']
 WHERE
   object_name = 'foo' or object_name = 'foofoo'
 ORDER BY
@@ -202,7 +202,7 @@ d foofoo table 1 incremental
 # are in their pre-import state.
 
 exec-sql
-RESTORE DATABASE d FROM LATEST IN 'nodelocal://0/database/' with new_db_name=d2;
+RESTORE DATABASE d FROM LATEST IN 'nodelocal://1/database/' with new_db_name=d2;
 ----
 
 
@@ -253,29 +253,29 @@ SET CLUSTER SETTING kv.bulkio.write_metadata_sst.enabled = false;
 
 # Pause the import job, in order to back up the importing data.
 import expect-pausepoint tag=b
-IMPORT INTO foo2 (i,s) CSV DATA ('nodelocal://0/export1/export*-n*.0.csv')
+IMPORT INTO foo2 (i,s) CSV DATA ('nodelocal://1/export1/export*-n*.0.csv')
 ----
 job paused at pausepoint
 
 
 import expect-pausepoint tag=bb
-IMPORT INTO foofoo2 (i,s) CSV DATA ('nodelocal://0/export1/export*-n*.0.csv')
+IMPORT INTO foofoo2 (i,s) CSV DATA ('nodelocal://1/export1/export*-n*.0.csv')
 ----
 job paused at pausepoint
 
 
 # Ensure table, database, and cluster full backups capture importing rows.
 exec-sql
-BACKUP INTO 'nodelocal://0/cluster/';
+BACKUP INTO 'nodelocal://1/cluster/';
 ----
 
 
 exec-sql
-BACKUP DATABASE d INTO 'nodelocal://0/database/';
+BACKUP DATABASE d INTO 'nodelocal://1/database/';
 ----
 
 exec-sql
-BACKUP TABLE d.* INTO 'nodelocal://0/table/';
+BACKUP TABLE d.* INTO 'nodelocal://1/table/';
 ----
 
 
@@ -324,23 +324,23 @@ CREATE INDEX foo2_new_idx ON foo2 (s);
 #      not record this range as a "row" in the backup.
 
 exec-sql
-BACKUP INTO LATEST IN 'nodelocal://0/cluster/';
+BACKUP INTO LATEST IN 'nodelocal://1/cluster/';
 ----
 
 exec-sql
-BACKUP DATABASE d INTO LATEST IN 'nodelocal://0/database/';
+BACKUP DATABASE d INTO LATEST IN 'nodelocal://1/database/';
 ----
 
 
 exec-sql
-BACKUP TABLE d.* INTO LATEST IN 'nodelocal://0/table/';
+BACKUP TABLE d.* INTO LATEST IN 'nodelocal://1/table/';
 ----
 
 query-sql
 SELECT
   database_name, object_name, object_type, rows, backup_type
 FROM
-  [SHOW BACKUP FROM LATEST IN 'nodelocal://0/cluster/']
+  [SHOW BACKUP FROM LATEST IN 'nodelocal://1/cluster/']
 WHERE
   object_name = 'foo2' or object_name = 'foofoo2'
 ORDER BY
@@ -355,7 +355,7 @@ query-sql
 SELECT
   database_name, object_name, object_type, rows, backup_type
 FROM
-  [SHOW BACKUP FROM LATEST IN 'nodelocal://0/database/']
+  [SHOW BACKUP FROM LATEST IN 'nodelocal://1/database/']
 WHERE
   object_name = 'foo2' or object_name = 'foofoo2'
 ORDER BY
@@ -371,7 +371,7 @@ query-sql
 SELECT
   database_name, object_name, object_type, rows, backup_type
 FROM
-  [SHOW BACKUP FROM LATEST IN 'nodelocal://0/table/']
+  [SHOW BACKUP FROM LATEST IN 'nodelocal://1/table/']
 WHERE
   object_name = 'foo2' or object_name = 'foofoo2'
 ORDER BY
@@ -386,7 +386,7 @@ d foofoo2 table 7 incremental
 # are in their pre-import state.
 
 exec-sql
-RESTORE DATABASE d FROM LATEST IN 'nodelocal://0/database/' with new_db_name=d2;
+RESTORE DATABASE d FROM LATEST IN 'nodelocal://1/database/' with new_db_name=d2;
 ----
 
 

--- a/pkg/ccl/backupccl/testdata/backup-restore/in-progress-imports
+++ b/pkg/ccl/backupccl/testdata/backup-restore/in-progress-imports
@@ -26,49 +26,49 @@ SET CLUSTER SETTING jobs.debug.pausepoints = 'import.after_ingest';
 
 
 exec-sql
-EXPORT INTO CSV 'nodelocal://0/export1/' FROM SELECT * FROM baz WHERE i = 1;
+EXPORT INTO CSV 'nodelocal://1/export1/' FROM SELECT * FROM baz WHERE i = 1;
 ----
 
 
 # Pause the import job, in order to back up the importing data.
 import expect-pausepoint tag=a
-IMPORT INTO foo (i,s) CSV DATA ('nodelocal://0/export1/export*-n*.0.csv')
+IMPORT INTO foo (i,s) CSV DATA ('nodelocal://1/export1/export*-n*.0.csv')
 ----
 job paused at pausepoint
 
 
 import expect-pausepoint tag=aa
-IMPORT INTO foofoo (i,s) CSV DATA ('nodelocal://0/export1/export*-n*.0.csv')
+IMPORT INTO foofoo (i,s) CSV DATA ('nodelocal://1/export1/export*-n*.0.csv')
 ----
 job paused at pausepoint
 
 
 # Ensure table, database, and cluster full backups capture importing rows.
 exec-sql
-BACKUP INTO 'nodelocal://0/cluster/' WITH revision_history;
+BACKUP INTO 'nodelocal://1/cluster/' WITH revision_history;
 ----
 
 
 exec-sql
-BACKUP DATABASE d INTO 'nodelocal://0/database/' WITH revision_history;
+BACKUP DATABASE d INTO 'nodelocal://1/database/' WITH revision_history;
 ----
 
 exec-sql
-BACKUP TABLE d.* INTO 'nodelocal://0/table/' WITH revision_history;
+BACKUP TABLE d.* INTO 'nodelocal://1/table/' WITH revision_history;
 ----
 
 # Ensure incremental backups do NOT re-capture the importing rows while the tables are offline
 exec-sql
-BACKUP INTO LATEST IN 'nodelocal://0/cluster/' WITH revision_history;
+BACKUP INTO LATEST IN 'nodelocal://1/cluster/' WITH revision_history;
 ----
 
 exec-sql
-BACKUP DATABASE d INTO LATEST IN 'nodelocal://0/database/' WITH revision_history;
+BACKUP DATABASE d INTO LATEST IN 'nodelocal://1/database/' WITH revision_history;
 ----
 
 
 exec-sql
-BACKUP TABLE d.* INTO LATEST IN 'nodelocal://0/table/' WITH revision_history;
+BACKUP TABLE d.* INTO LATEST IN 'nodelocal://1/table/' WITH revision_history;
 ----
 
 
@@ -106,17 +106,17 @@ job tag=aa wait-for-state=succeeded
 
 
 exec-sql
-BACKUP INTO LATEST IN 'nodelocal://0/cluster/' WITH revision_history;
+BACKUP INTO LATEST IN 'nodelocal://1/cluster/' WITH revision_history;
 ----
 
 
 exec-sql
-BACKUP DATABASE d INTO LATEST IN 'nodelocal://0/database/' WITH revision_history;
+BACKUP DATABASE d INTO LATEST IN 'nodelocal://1/database/' WITH revision_history;
 ----
 
 
 exec-sql
-BACKUP TABLE d.* INTO LATEST IN 'nodelocal://0/table/' WITH revision_history;
+BACKUP TABLE d.* INTO LATEST IN 'nodelocal://1/table/' WITH revision_history;
 ----
 
 
@@ -132,7 +132,7 @@ query-sql
 SELECT
   database_name, object_name, object_type, rows, backup_type
 FROM
-  [SHOW BACKUP FROM LATEST IN 'nodelocal://0/cluster/']
+  [SHOW BACKUP FROM LATEST IN 'nodelocal://1/cluster/']
 WHERE
   object_name = 'foo' or object_name = 'foofoo'
 ORDER BY
@@ -149,7 +149,7 @@ query-sql
 SELECT
   database_name, object_name, object_type, rows, backup_type
 FROM
-  [SHOW BACKUP FROM LATEST IN 'nodelocal://0/database/']
+  [SHOW BACKUP FROM LATEST IN 'nodelocal://1/database/']
 WHERE
   object_name = 'foo' or object_name = 'foofoo'
 ORDER BY
@@ -167,7 +167,7 @@ query-sql
 SELECT
   database_name, object_name, object_type, rows, backup_type
 FROM
-  [SHOW BACKUP FROM LATEST IN 'nodelocal://0/table/']
+  [SHOW BACKUP FROM LATEST IN 'nodelocal://1/table/']
 WHERE
   object_name = 'foo' or object_name = 'foofoo'
 ORDER BY
@@ -187,7 +187,7 @@ new-cluster name=s2 share-io-dir=s1 allow-implicit-access
 
 
 restore aost=t0
-RESTORE FROM LATEST IN 'nodelocal://0/cluster/' AS OF SYSTEM TIME t0;
+RESTORE FROM LATEST IN 'nodelocal://1/cluster/' AS OF SYSTEM TIME t0;
 ----
 
 
@@ -208,7 +208,7 @@ DROP DATABASE d;
 
 
 restore aost=t0
-RESTORE DATABASE d FROM LATEST IN 'nodelocal://0/database/' AS OF SYSTEM TIME t0;
+RESTORE DATABASE d FROM LATEST IN 'nodelocal://1/database/' AS OF SYSTEM TIME t0;
 ----
 
 query-sql
@@ -230,7 +230,7 @@ DROP TABLE d.baz;
 
 
 restore aost=t0
-RESTORE TABLE d.* FROM LATEST IN 'nodelocal://0/table/' AS OF SYSTEM TIME t0 WITH into_db='d';
+RESTORE TABLE d.* FROM LATEST IN 'nodelocal://1/table/' AS OF SYSTEM TIME t0 WITH into_db='d';
 ----
 
 
@@ -251,7 +251,7 @@ new-cluster name=s3 share-io-dir=s1 allow-implicit-access
 
 
 exec-sql
-RESTORE FROM LATEST IN 'nodelocal://0/cluster/';
+RESTORE FROM LATEST IN 'nodelocal://1/cluster/';
 ----
 
 
@@ -274,7 +274,7 @@ DROP DATABASE d;
 
 
 exec-sql
-RESTORE DATABASE d FROM LATEST IN 'nodelocal://0/database/';
+RESTORE DATABASE d FROM LATEST IN 'nodelocal://1/database/';
 ----
 
 
@@ -299,7 +299,7 @@ DROP TABLE d.baz;
 
 
 exec-sql
-RESTORE TABLE d.* FROM LATEST IN 'nodelocal://0/table/' WITH into_db= d;
+RESTORE TABLE d.* FROM LATEST IN 'nodelocal://1/table/' WITH into_db= d;
 ----
 
 

--- a/pkg/ccl/backupccl/testdata/backup-restore/in-progress-restores
+++ b/pkg/ccl/backupccl/testdata/backup-restore/in-progress-restores
@@ -38,7 +38,7 @@ USE d;
 # Run a backup to then restore from and test that future backups capture the
 # in-progress restore data.
 exec-sql
-BACKUP INTO 'nodelocal://0/cluster/' WITH revision_history;
+BACKUP INTO 'nodelocal://1/cluster/' WITH revision_history;
 ----
 
 
@@ -52,14 +52,14 @@ SET CLUSTER SETTING jobs.debug.pausepoints = restore.before_publishing_descripto
 
 # Pause a RESTORE DATABASE job, so a cluster backup can back up the restoring data.
 restore expect-pausepoint tag=a
-RESTORE DATABASE b FROM LATEST IN 'nodelocal://0/cluster/' with new_db_name=b2;
+RESTORE DATABASE b FROM LATEST IN 'nodelocal://1/cluster/' with new_db_name=b2;
 ----
 job paused at pausepoint
 
 
 # This incremental cluster backup should capture the offline restoring database
 exec-sql
-BACKUP INTO LATEST IN 'nodelocal://0/cluster/' WITH revision_history;
+BACKUP INTO LATEST IN 'nodelocal://1/cluster/' WITH revision_history;
 ----
 
 save-cluster-ts tag=t0
@@ -85,7 +85,7 @@ job tag=a wait-for-state=succeeded
 
 # This backup should capture the online restored database
 exec-sql
-BACKUP INTO LATEST IN 'nodelocal://0/cluster/' WITH revision_history;
+BACKUP INTO LATEST IN 'nodelocal://1/cluster/' WITH revision_history;
 ----
 
 
@@ -99,7 +99,7 @@ query-sql
 SELECT
   database_name, object_name, object_type, rows, backup_type
 FROM
-  [SHOW BACKUP FROM LATEST IN 'nodelocal://0/cluster/']
+  [SHOW BACKUP FROM LATEST IN 'nodelocal://1/cluster/']
 WHERE
   database_name = 'b2'
 ORDER BY
@@ -124,7 +124,7 @@ new-cluster name=s2 share-io-dir=s1 allow-implicit-access
 
 
 restore aost=t0
-RESTORE FROM LATEST IN 'nodelocal://0/cluster/' AS OF SYSTEM TIME t0;
+RESTORE FROM LATEST IN 'nodelocal://1/cluster/' AS OF SYSTEM TIME t0;
 ----
 
 
@@ -139,7 +139,7 @@ new-cluster name=s3 share-io-dir=s1 allow-implicit-access
 
 
 exec-sql
-RESTORE FROM LATEST IN 'nodelocal://0/cluster/';
+RESTORE FROM LATEST IN 'nodelocal://1/cluster/';
 ----
 
 
@@ -181,7 +181,7 @@ SET CLUSTER SETTING jobs.debug.pausepoints = restore.before_publishing_descripto
 
 
 restore expect-pausepoint tag=b
-RESTORE TABLE b.me.baz FROM LATEST IN 'nodelocal://0/cluster/' WITH into_db='d';
+RESTORE TABLE b.me.baz FROM LATEST IN 'nodelocal://1/cluster/' WITH into_db='d';
 ----
 job paused at pausepoint
 
@@ -195,7 +195,7 @@ pq: schema "me" already exists
 
 # This backup should capture 3 rows from restoring table table baz
 exec-sql
-BACKUP DATABASE d INTO 'nodelocal://0/database/' WITH revision_history;
+BACKUP DATABASE d INTO 'nodelocal://1/database/' WITH revision_history;
 ----
 
 save-cluster-ts tag=m0
@@ -216,7 +216,7 @@ job tag=b wait-for-state=succeeded
 # This backup should capture 3 rows from restoring table table baz, since it just came online
 # (this will change once we more selectively reintroduce offline spans)
 exec-sql
-BACKUP DATABASE d INTO LATEST IN 'nodelocal://0/database/' WITH revision_history;
+BACKUP DATABASE d INTO LATEST IN 'nodelocal://1/database/' WITH revision_history;
 ----
 
 # Display the backed up objects from the restoring d database
@@ -228,7 +228,7 @@ query-sql
 SELECT
   database_name, object_name, object_type, rows, backup_type
 FROM
-  [SHOW BACKUP FROM LATEST IN 'nodelocal://0/database/']
+  [SHOW BACKUP FROM LATEST IN 'nodelocal://1/database/']
 WHERE
   database_name = 'd'
 ORDER BY
@@ -248,7 +248,7 @@ d baz table 3 incremental
 
 # Ensure that restoring the database, AOST the in-progress restore, elides the restoring descriptors
 restore aost=m0
-RESTORE DATABASE d FROM LATEST IN 'nodelocal://0/database/' AS OF SYSTEM TIME m0 with new_db_name = d_aost;
+RESTORE DATABASE d FROM LATEST IN 'nodelocal://1/database/' AS OF SYSTEM TIME m0 with new_db_name = d_aost;
 ----
 
 
@@ -263,7 +263,7 @@ SELECT schema_name FROM [SHOW SCHEMAS FROM d_aost] WHERE schema_name='me';
 
 # Restore AOST completed in-progress restore, implying baz is online.
 exec-sql
-RESTORE DATABASE d FROM LATEST IN 'nodelocal://0/database/' with new_db_name = d_latest
+RESTORE DATABASE d FROM LATEST IN 'nodelocal://1/database/' with new_db_name = d_latest
 ----
 
 
@@ -292,7 +292,7 @@ SET CLUSTER SETTING jobs.debug.pausepoints = restore.before_publishing_descripto
 
 
 restore expect-pausepoint tag=bb
-RESTORE TABLE b.me.baz FROM LATEST IN 'nodelocal://0/cluster/' WITH into_db='d_with_schema';
+RESTORE TABLE b.me.baz FROM LATEST IN 'nodelocal://1/cluster/' WITH into_db='d_with_schema';
 ----
 job paused at pausepoint
 
@@ -305,7 +305,7 @@ INSERT INTO d_with_schema.me.bar VALUES (1);
 
 # This backup should capture 3 rows from restoring table table baz
 exec-sql
-BACKUP DATABASE d_with_schema INTO 'nodelocal://0/database/' WITH revision_history;
+BACKUP DATABASE d_with_schema INTO 'nodelocal://1/database/' WITH revision_history;
 ----
 
 
@@ -324,13 +324,13 @@ job tag=bb wait-for-state=succeeded
 ----
 
 exec-sql
-BACKUP DATABASE d_with_schema INTO LATEST IN 'nodelocal://0/database/' WITH revision_history;
+BACKUP DATABASE d_with_schema INTO LATEST IN 'nodelocal://1/database/' WITH revision_history;
 ----
 
 
 # Ensure that restoring the tables, AOST the in-progress restore, elides the restoring descriptors.
 restore aost=n0
-RESTORE DATABASE d_with_schema FROM LATEST IN 'nodelocal://0/database/' AS OF SYSTEM TIME n0 with new_db_name = d_aost;
+RESTORE DATABASE d_with_schema FROM LATEST IN 'nodelocal://1/database/' AS OF SYSTEM TIME n0 with new_db_name = d_aost;
 ----
 
 
@@ -349,7 +349,7 @@ me
 
 
 exec-sql
-RESTORE DATABASE d_with_schema FROM LATEST IN 'nodelocal://0/database/' with new_db_name = d_latest
+RESTORE DATABASE d_with_schema FROM LATEST IN 'nodelocal://1/database/' with new_db_name = d_latest
 ----
 
 
@@ -380,13 +380,13 @@ SET CLUSTER SETTING jobs.debug.pausepoints = restore.before_publishing_descripto
 
 
 restore expect-pausepoint tag=bbb
-RESTORE TABLE b.me.baz FROM LATEST IN 'nodelocal://0/cluster/' WITH into_db='d';
+RESTORE TABLE b.me.baz FROM LATEST IN 'nodelocal://1/cluster/' WITH into_db='d';
 ----
 job paused at pausepoint
 
 
 exec-sql
-BACKUP TABLE d.* INTO 'nodelocal://0/table/' WITH revision_history;
+BACKUP TABLE d.* INTO 'nodelocal://1/table/' WITH revision_history;
 ----
 
 
@@ -407,13 +407,13 @@ job tag=bbb wait-for-state=succeeded
 
 
 exec-sql
-BACKUP TABLE d.* INTO LATEST IN 'nodelocal://0/table/' WITH revision_history;
+BACKUP TABLE d.* INTO LATEST IN 'nodelocal://1/table/' WITH revision_history;
 ----
 
 
 # Ensure that restoring the table, AOST the in-progress restore, elides the restoring descriptors.
 restore aost=o0
-RESTORE TABLE d.* FROM LATEST IN 'nodelocal://0/table/' AS OF SYSTEM TIME o0 with into_db = d_aost;
+RESTORE TABLE d.* FROM LATEST IN 'nodelocal://1/table/' AS OF SYSTEM TIME o0 with into_db = d_aost;
 ----
 
 
@@ -429,7 +429,7 @@ SELECT schema_name FROM [SHOW SCHEMAS FROM d_aost] WHERE schema_name='me';
 
 
 exec-sql
-RESTORE TABLE d.* FROM LATEST IN 'nodelocal://0/table/' with into_db = d_latest
+RESTORE TABLE d.* FROM LATEST IN 'nodelocal://1/table/' with into_db = d_latest
 ----
 
 

--- a/pkg/ccl/backupccl/testdata/backup-restore/metadata
+++ b/pkg/ccl/backupccl/testdata/backup-restore/metadata
@@ -54,7 +54,7 @@ SELECT count(1) FROM [ SHOW STATISTICS FOR TABLE tab WITH MERGE ] WHERE statisti
 1
 
 exec-sql
-BACKUP DATABASE db1 INTO 'nodelocal://0/test/'
+BACKUP DATABASE db1 INTO 'nodelocal://1/test/'
 ----
 
 query-sql
@@ -64,8 +64,8 @@ SELECT
             'cockroach.ccl.backupccl.StatsTable',
             crdb_internal.read_file(
                 concat(
-                    'nodelocal://0/test/',
-                    (SELECT PATH FROM [SHOW BACKUPS IN 'nodelocal://0/test/']),
+                    'nodelocal://1/test/',
+                    (SELECT PATH FROM [SHOW BACKUPS IN 'nodelocal://1/test/']),
                     '/BACKUP-STATISTICS'
                 )
             )

--- a/pkg/ccl/backupccl/testdata/backup-restore/multiregion
+++ b/pkg/ccl/backupccl/testdata/backup-restore/multiregion
@@ -29,7 +29,7 @@ new-cluster name=s2 share-io-dir=s1 allow-implicit-access disable-tenant localit
 ----
 
 exec-sql
-RESTORE FROM LATEST IN 'nodelocal://0/full_cluster_backup/';
+RESTORE FROM LATEST IN 'nodelocal://1/full_cluster_backup/';
 ----
 
 exec-sql
@@ -37,7 +37,7 @@ DROP DATABASE d;
 ----
 
 exec-sql
-RESTORE DATABASE d FROM LATEST IN 'nodelocal://0/database_backup/';
+RESTORE DATABASE d FROM LATEST IN 'nodelocal://1/database_backup/';
 ----
 
 query-sql
@@ -54,13 +54,13 @@ new-cluster name=s3 share-io-dir=s1 allow-implicit-access disable-tenant localit
 ----
 
 exec-sql
-RESTORE DATABASE d FROM LATEST IN 'nodelocal://0/database_backup/';
+RESTORE DATABASE d FROM LATEST IN 'nodelocal://1/database_backup/';
 ----
 pq: detected a mismatch in regions between the restore cluster and the backup cluster, missing regions detected: us-east-1, us-west-1.
 HINT: there are two ways you can resolve this issue: 1) update the cluster to which you're restoring to ensure that the regions present on the nodes' --locality flags match those present in the backup image, or 2) restore with the "skip_localities_check" option
 
 exec-sql
-RESTORE FROM LATEST IN 'nodelocal://0/full_cluster_backup/';
+RESTORE FROM LATEST IN 'nodelocal://1/full_cluster_backup/';
 ----
 pq: detected a mismatch in regions between the restore cluster and the backup cluster, missing regions detected: us-east-1, us-west-1.
 HINT: there are two ways you can resolve this issue: 1) update the cluster to which you're restoring to ensure that the regions present on the nodes' --locality flags match those present in the backup image, or 2) restore with the "skip_localities_check" option

--- a/pkg/ccl/backupccl/testdata/backup-restore/rangekeys
+++ b/pkg/ccl/backupccl/testdata/backup-restore/rangekeys
@@ -27,11 +27,11 @@ INSERT INTO foo VALUES (3,'z');
 ----
 
 exec-sql
-BACKUP INTO 'nodelocal://0/test-root/';
+BACKUP INTO 'nodelocal://1/test-root/';
 ----
 
 exec-sql
-RESTORE DATABASE orig FROM LATEST IN 'nodelocal://0/test-root/' with new_db_name='orig1';
+RESTORE DATABASE orig FROM LATEST IN 'nodelocal://1/test-root/' with new_db_name='orig1';
 ----
 
 query-sql
@@ -65,11 +65,11 @@ INSERT INTO baz VALUES (33,'zz');
 ----
 
 exec-sql
-BACKUP INTO LATEST IN 'nodelocal://0/test-root/';
+BACKUP INTO LATEST IN 'nodelocal://1/test-root/';
 ----
 
 exec-sql
-RESTORE DATABASE orig FROM LATEST IN 'nodelocal://0/test-root/' with new_db_name='orig1';
+RESTORE DATABASE orig FROM LATEST IN 'nodelocal://1/test-root/' with new_db_name='orig1';
 ----
 
 query-sql

--- a/pkg/ccl/backupccl/testdata/backup-restore/rangekeys-revision-history
+++ b/pkg/ccl/backupccl/testdata/backup-restore/rangekeys-revision-history
@@ -40,7 +40,7 @@ save-cluster-ts tag=t2
 ----
 
 exec-sql
-BACKUP INTO 'nodelocal://0/test-root/' with revision_history;
+BACKUP INTO 'nodelocal://1/test-root/' with revision_history;
 ----
 
 exec-sql
@@ -61,11 +61,11 @@ save-cluster-ts tag=t4
 ----
 
 exec-sql
-BACKUP INTO LATEST IN 'nodelocal://0/test-root/' with revision_history;
+BACKUP INTO LATEST IN 'nodelocal://1/test-root/' with revision_history;
 ----
 
 restore aost=t0
-RESTORE DATABASE orig FROM LATEST IN 'nodelocal://0/test-root/' AS OF SYSTEM TIME t0 WITH new_db_name='orig1';
+RESTORE DATABASE orig FROM LATEST IN 'nodelocal://1/test-root/' AS OF SYSTEM TIME t0 WITH new_db_name='orig1';
 ----
 
 query-sql
@@ -83,7 +83,7 @@ DROP DATABASE orig1 CASCADE
 ----
 
 restore aost=t1
-RESTORE DATABASE orig FROM LATEST IN 'nodelocal://0/test-root/' AS OF SYSTEM TIME t1 WITH new_db_name='orig1';
+RESTORE DATABASE orig FROM LATEST IN 'nodelocal://1/test-root/' AS OF SYSTEM TIME t1 WITH new_db_name='orig1';
 ----
 
 query-sql
@@ -101,7 +101,7 @@ DROP DATABASE orig1 CASCADE
 ----
 
 restore aost=t2
-RESTORE DATABASE orig FROM LATEST IN 'nodelocal://0/test-root/' AS OF SYSTEM TIME t2 WITH new_db_name='orig1';
+RESTORE DATABASE orig FROM LATEST IN 'nodelocal://1/test-root/' AS OF SYSTEM TIME t2 WITH new_db_name='orig1';
 ----
 
 query-sql
@@ -119,7 +119,7 @@ DROP DATABASE orig1 CASCADE
 ----
 
 restore aost=t3
-RESTORE DATABASE orig FROM LATEST IN 'nodelocal://0/test-root/' AS OF SYSTEM TIME t3 WITH new_db_name='orig1';
+RESTORE DATABASE orig FROM LATEST IN 'nodelocal://1/test-root/' AS OF SYSTEM TIME t3 WITH new_db_name='orig1';
 ----
 
 query-sql
@@ -137,7 +137,7 @@ DROP DATABASE orig1 CASCADE
 ----
 
 restore aost=t4
-RESTORE DATABASE orig FROM LATEST IN 'nodelocal://0/test-root/' AS OF SYSTEM TIME t4 WITH new_db_name='orig1';
+RESTORE DATABASE orig FROM LATEST IN 'nodelocal://1/test-root/' AS OF SYSTEM TIME t4 WITH new_db_name='orig1';
 ----
 
 query-sql

--- a/pkg/ccl/backupccl/testdata/backup-restore/restore-grants
+++ b/pkg/ccl/backupccl/testdata/backup-restore/restore-grants
@@ -156,7 +156,7 @@ testdb public testtable_greeting_owner testuser ALL true
 
 # Let's take a backup of this cluster.
 exec-sql
-BACKUP INTO 'nodelocal://0/test/'
+BACKUP INTO 'nodelocal://1/test/'
 ----
 
 # Let's try a cluster restore and expect all of the same privileges that we had
@@ -167,7 +167,7 @@ new-cluster name=s2 share-io-dir=s1 allow-implicit-access disable-tenant
 ----
 
 exec-sql
-RESTORE FROM LATEST IN 'nodelocal://0/test/';
+RESTORE FROM LATEST IN 'nodelocal://1/test/';
 ----
 
 exec-sql
@@ -433,7 +433,7 @@ DROP DATABASE testdb CASCADE;
 ----
 
 exec-sql
-RESTORE DATABASE testdb FROM LATEST IN 'nodelocal://0/test/';
+RESTORE DATABASE testdb FROM LATEST IN 'nodelocal://1/test/';
 ----
 
 exec-sql
@@ -522,7 +522,7 @@ ALTER USER testuser CREATEDB;
 subtest restore-database-as-non-admin
 
 exec-sql user=testuser
-RESTORE DATABASE testdb FROM LATEST IN 'nodelocal://0/test/';
+RESTORE DATABASE testdb FROM LATEST IN 'nodelocal://1/test/';
 ----
 NOTICE: The existing privileges are being deprecated in favour of a fine-grained privilege model explained here https://www.cockroachlabs.com/docs/stable/restore.html#required-privileges. In a future release, to run RESTORE DATABASE, user testuser will exclusively require the RESTORE system privilege.
 

--- a/pkg/ccl/backupccl/testdata/backup-restore/restore-on-fail-or-cancel-fast-drop
+++ b/pkg/ccl/backupccl/testdata/backup-restore/restore-on-fail-or-cancel-fast-drop
@@ -50,7 +50,7 @@ SET CLUSTER SETTING jobs.debug.pausepoints = 'restore.after_publishing_descripto
 ----
 
 restore expect-pausepoint tag=a
-RESTORE FROM LATEST IN 'nodelocal://0/cluster_backup';
+RESTORE FROM LATEST IN 'nodelocal://1/cluster_backup';
 ----
 job paused at pausepoint
 
@@ -82,7 +82,7 @@ SHOW JOBS WHEN COMPLETE (SELECT job_id FROM [SHOW JOBS] WHERE job_type = 'SCHEMA
 ----
 
 restore
-RESTORE FROM LATEST IN 'nodelocal://0/cluster_backup';
+RESTORE FROM LATEST IN 'nodelocal://1/cluster_backup';
 ----
 
 subtest end

--- a/pkg/ccl/backupccl/testdata/backup-restore/restore-on-fail-or-cancel-retry
+++ b/pkg/ccl/backupccl/testdata/backup-restore/restore-on-fail-or-cancel-retry
@@ -41,7 +41,7 @@ SET CLUSTER SETTING jobs.debug.pausepoints = 'restore.after_publishing_descripto
 ----
 
 restore expect-pausepoint tag=a
-RESTORE FROM LATEST IN 'nodelocal://0/cluster_backup';
+RESTORE FROM LATEST IN 'nodelocal://1/cluster_backup';
 ----
 job paused at pausepoint
 
@@ -59,7 +59,7 @@ sleep ms=2000
 ----
 
 restore
-RESTORE FROM LATEST IN 'nodelocal://0/cluster_backup';
+RESTORE FROM LATEST IN 'nodelocal://1/cluster_backup';
 ----
 
 subtest end

--- a/pkg/ccl/backupccl/testdata/backup-restore/restore-permissions-deprecated
+++ b/pkg/ccl/backupccl/testdata/backup-restore/restore-permissions-deprecated
@@ -9,7 +9,7 @@ INSERT INTO d.t VALUES (1), (2), (3);
 ----
 
 exec-sql
-BACKUP INTO 'nodelocal://0/test/'
+BACKUP INTO 'nodelocal://1/test/'
 ----
 
 # Restores should succeed as a non-root user with admin role.
@@ -23,7 +23,7 @@ DROP DATABASE d;
 ----
 
 exec-sql user=testuser
-RESTORE DATABASE d FROM LATEST IN 'nodelocal://0/test/';
+RESTORE DATABASE d FROM LATEST IN 'nodelocal://1/test/';
 ----
 
 # Start a new cluster with the same IO dir.
@@ -36,12 +36,12 @@ CREATE USER testuser
 
 # Restore into the new cluster.
 exec-sql cluster=s2 user=testuser
-RESTORE FROM LATEST IN 'nodelocal://0/test/'
+RESTORE FROM LATEST IN 'nodelocal://1/test/'
 ----
 pq: only users with the admin role or the RESTORE system privilege are allowed to perform a cluster restore: user testuser does not have RESTORE privilege on global 
 
 exec-sql cluster=s2 user=testuser
-RESTORE DATABASE d FROM LATEST IN 'nodelocal://0/test/'
+RESTORE DATABASE d FROM LATEST IN 'nodelocal://1/test/'
 ----
 pq: only users with the CREATEDB privilege can restore databases
 HINT: The existing privileges are being deprecated in favour of a fine-grained privilege model explained here https://www.cockroachlabs.com/docs/stable/restore.html#required-privileges. In a future release, to run RESTORE DATABASE, user testuser will exclusively require the RESTORE system privilege.
@@ -51,7 +51,7 @@ CREATE DATABASE d
 ----
 
 exec-sql cluster=s2 user=testuser
-RESTORE TABLE d.t FROM LATEST IN 'nodelocal://0/test/'
+RESTORE TABLE d.t FROM LATEST IN 'nodelocal://1/test/'
 ----
 pq: user testuser does not have CREATE privilege on database d
 HINT: The existing privileges are being deprecated in favour of a fine-grained privilege model explained here https://www.cockroachlabs.com/docs/stable/restore.html#required-privileges. In a future release, to run RESTORE TABLE, user testuser will exclusively require the RESTORE privilege on database d.
@@ -61,7 +61,7 @@ GRANT CREATE ON DATABASE d TO testuser
 ----
 
 exec-sql cluster=s2 user=testuser
-RESTORE TABLE d.t FROM LATEST IN 'nodelocal://0/test/'
+RESTORE TABLE d.t FROM LATEST IN 'nodelocal://1/test/'
 ----
 NOTICE: The existing privileges are being deprecated in favour of a fine-grained privilege model explained here https://www.cockroachlabs.com/docs/stable/restore.html#required-privileges. In a future release, to run RESTORE TABLE, user testuser will exclusively require the RESTORE privilege on databases d
 
@@ -81,7 +81,7 @@ ALTER USER testuser CREATEDB
 ----
 
 exec-sql cluster=s2 user=testuser
-RESTORE DATABASE d FROM LATEST IN 'nodelocal://0/test/'
+RESTORE DATABASE d FROM LATEST IN 'nodelocal://1/test/'
 ----
 NOTICE: The existing privileges are being deprecated in favour of a fine-grained privilege model explained here https://www.cockroachlabs.com/docs/stable/restore.html#required-privileges. In a future release, to run RESTORE DATABASE, user testuser will exclusively require the RESTORE system privilege.
 
@@ -101,6 +101,6 @@ CREATE USER testuser
 ----
 
 exec-sql cluster=s3 user=testuser
-RESTORE TABLE d.t FROM LATEST IN 'nodelocal://0/test/'
+RESTORE TABLE d.t FROM LATEST IN 'nodelocal://1/test/'
 ----
 pq: only users with the admin role or the EXTERNALIOIMPLICITACCESS system privilege are allowed to access the specified nodelocal URI

--- a/pkg/ccl/backupccl/testdata/backup-restore/restore-schema-only
+++ b/pkg/ccl/backupccl/testdata/backup-restore/restore-schema-only
@@ -58,7 +58,7 @@ new-cluster name=s2 share-io-dir=s1 allow-implicit-access
 #
 # Fail fast if the user passes new_db_name.
 exec-sql
-RESTORE FROM LATEST IN 'nodelocal://0/full_cluster_backup/' with schema_only, new_db_name='d2';
+RESTORE FROM LATEST IN 'nodelocal://1/full_cluster_backup/' with schema_only, new_db_name='d2';
 ----
 pq: new_db_name can only be used for RESTORE DATABASE with a single target database
 
@@ -69,18 +69,18 @@ CREATE USER testuser
 
 # Non admins cannot run schema_only cluster restore
 exec-sql user=testuser
-RESTORE FROM LATEST IN 'nodelocal://0/full_cluster_backup/' with schema_only
+RESTORE FROM LATEST IN 'nodelocal://1/full_cluster_backup/' with schema_only
 ----
 pq: only users with the admin role or the RESTORE system privilege are allowed to perform a cluster restore: user testuser does not have RESTORE privilege on global 
 
 # Fail fast using a database backup
 exec-sql
-RESTORE FROM LATEST IN 'nodelocal://0/full_database_backup/' with schema_only;
+RESTORE FROM LATEST IN 'nodelocal://1/full_database_backup/' with schema_only;
 ----
 pq: full cluster RESTORE can only be used on full cluster BACKUP files
 
 exec-sql
-RESTORE FROM LATEST IN 'nodelocal://0/full_cluster_backup/' with schema_only;
+RESTORE FROM LATEST IN 'nodelocal://1/full_cluster_backup/' with schema_only;
 ----
 
 # there should be no data in the restored tables
@@ -119,7 +119,7 @@ SELECT count(*) FROM system.namespace WHERE name = 'defaultdb' AND id > 100
 ############################################################
 
 exec-sql
-RESTORE DATABASE d FROM LATEST IN 'nodelocal://0/full_database_backup/' with schema_only, new_db_name='d2';
+RESTORE DATABASE d FROM LATEST IN 'nodelocal://1/full_database_backup/' with schema_only, new_db_name='d2';
 ----
 
 

--- a/pkg/ccl/backupccl/testdata/backup-restore/restore-schema-only-mixed-version
+++ b/pkg/ccl/backupccl/testdata/backup-restore/restore-schema-only-mixed-version
@@ -17,7 +17,7 @@ BACKUP Database d INTO 'nodelocal://1/full_database_backup/';
 ----
 
 exec-sql
-RESTORE DATABASE d FROM LATEST IN 'nodelocal://0/full_database_backup/' with schema_only, new_db_name='d2';
+RESTORE DATABASE d FROM LATEST IN 'nodelocal://1/full_database_backup/' with schema_only, new_db_name='d2';
 ----
 pq: cannot run RESTORE with schema_only until cluster has fully upgraded to 22.2
 
@@ -25,7 +25,7 @@ upgrade-cluster version=Start22_2
 ----
 
 exec-sql
-RESTORE DATABASE d FROM LATEST IN 'nodelocal://0/full_database_backup/' with schema_only, new_db_name='d2';
+RESTORE DATABASE d FROM LATEST IN 'nodelocal://1/full_database_backup/' with schema_only, new_db_name='d2';
 ----
 
 # There should be no data in the user tables.

--- a/pkg/ccl/backupccl/testdata/backup-restore/restore-schema-only-multiregion
+++ b/pkg/ccl/backupccl/testdata/backup-restore/restore-schema-only-multiregion
@@ -32,7 +32,7 @@ new-cluster name=s2 share-io-dir=s1 allow-implicit-access disable-tenant localit
 ----
 
 exec-sql
-RESTORE FROM LATEST IN 'nodelocal://0/full_cluster_backup/' with schema_only;
+RESTORE FROM LATEST IN 'nodelocal://1/full_cluster_backup/' with schema_only;
 ----
 
 exec-sql
@@ -40,7 +40,7 @@ DROP DATABASE d;
 ----
 
 exec-sql
-RESTORE DATABASE d FROM LATEST IN 'nodelocal://0/database_backup/' with schema_only;
+RESTORE DATABASE d FROM LATEST IN 'nodelocal://1/database_backup/' with schema_only;
 ----
 
 query-sql
@@ -57,13 +57,13 @@ new-cluster name=s3 share-io-dir=s1 allow-implicit-access disable-tenant localit
 ----
 
 exec-sql
-RESTORE DATABASE d FROM LATEST IN 'nodelocal://0/database_backup/' with schema_only;
+RESTORE DATABASE d FROM LATEST IN 'nodelocal://1/database_backup/' with schema_only;
 ----
 pq: detected a mismatch in regions between the restore cluster and the backup cluster, missing regions detected: us-east-1, us-west-1.
 HINT: there are two ways you can resolve this issue: 1) update the cluster to which you're restoring to ensure that the regions present on the nodes' --locality flags match those present in the backup image, or 2) restore with the "skip_localities_check" option
 
 exec-sql
-RESTORE FROM LATEST IN 'nodelocal://0/full_cluster_backup/' with schema_only;
+RESTORE FROM LATEST IN 'nodelocal://1/full_cluster_backup/' with schema_only;
 ----
 pq: detected a mismatch in regions between the restore cluster and the backup cluster, missing regions detected: us-east-1, us-west-1.
 HINT: there are two ways you can resolve this issue: 1) update the cluster to which you're restoring to ensure that the regions present on the nodes' --locality flags match those present in the backup image, or 2) restore with the "skip_localities_check" option

--- a/pkg/ccl/backupccl/testdata/backup-restore/restore-validation-only
+++ b/pkg/ccl/backupccl/testdata/backup-restore/restore-validation-only
@@ -64,7 +64,7 @@ new-cluster name=s2 share-io-dir=s1 allow-implicit-access
 #
 # Fail fast if the user passes new_db_name.
 exec-sql
-RESTORE FROM LATEST IN 'nodelocal://0/full_cluster_backup/' with schema_only, verify_backup_table_data, new_db_name='d2';
+RESTORE FROM LATEST IN 'nodelocal://1/full_cluster_backup/' with schema_only, verify_backup_table_data, new_db_name='d2';
 ----
 pq: new_db_name can only be used for RESTORE DATABASE with a single target database
 
@@ -75,18 +75,18 @@ CREATE USER testuser
 
 # Non admins cannot run schema_only cluster restore
 exec-sql user=testuser
-RESTORE FROM LATEST IN 'nodelocal://0/full_cluster_backup/' with schema_only, verify_backup_table_data
+RESTORE FROM LATEST IN 'nodelocal://1/full_cluster_backup/' with schema_only, verify_backup_table_data
 ----
 pq: only users with the admin role or the RESTORE system privilege are allowed to perform a cluster restore: user testuser does not have RESTORE privilege on global 
 
 # Fail fast using a database backup
 exec-sql
-RESTORE FROM LATEST IN 'nodelocal://0/full_database_backup/' with schema_only, verify_backup_table_data;
+RESTORE FROM LATEST IN 'nodelocal://1/full_database_backup/' with schema_only, verify_backup_table_data;
 ----
 pq: full cluster RESTORE can only be used on full cluster BACKUP files
 
 exec-sql
-RESTORE FROM LATEST IN 'nodelocal://0/full_cluster_backup/' with schema_only, verify_backup_table_data;
+RESTORE FROM LATEST IN 'nodelocal://1/full_cluster_backup/' with schema_only, verify_backup_table_data;
 ----
 
 # there should be no data in the restored tables
@@ -123,7 +123,7 @@ SELECT count(*) FROM system.namespace WHERE name = 'defaultdb' AND id > 100
 
 # Ensure Database Level schema_only restore logic is sound
 exec-sql
-RESTORE DATABASE d FROM LATEST IN 'nodelocal://0/full_database_backup/' with schema_only, new_db_name='d2';
+RESTORE DATABASE d FROM LATEST IN 'nodelocal://1/full_database_backup/' with schema_only, new_db_name='d2';
 ----
 
 
@@ -161,16 +161,16 @@ INSERT INTO d2.t2 VALUES ('hi');
 # Part 2: test this checks corrupt data
 ########
 
-corrupt-backup uri='nodelocal://0/full_database_backup/'
+corrupt-backup uri='nodelocal://1/full_database_backup/'
 ----
 
 # Schema only restore misses the data corruption
 exec-sql
-RESTORE DATABASE d FROM LATEST IN 'nodelocal://0/full_database_backup/' with schema_only, new_db_name='d3';
+RESTORE DATABASE d FROM LATEST IN 'nodelocal://1/full_database_backup/' with schema_only, new_db_name='d3';
 ----
 
 # But verify_backup_table_data catches the corrupt backup file
 exec-sql expect-error-regex=(pebble/table: invalid table 000000)
-RESTORE DATABASE d FROM LATEST IN 'nodelocal://0/full_database_backup/' with schema_only, verify_backup_table_data, new_db_name='d4';
+RESTORE DATABASE d FROM LATEST IN 'nodelocal://1/full_database_backup/' with schema_only, verify_backup_table_data, new_db_name='d4';
 ----
 regex matches error

--- a/pkg/ccl/backupccl/testdata/backup-restore/revision_history
+++ b/pkg/ccl/backupccl/testdata/backup-restore/revision_history
@@ -21,5 +21,5 @@ NOTICE: the data for dropped indexes is reclaimed asynchronously
 HINT: The reclamation delay can be customized in the zone configuration for the table.
 
 exec-sql
-BACKUP DATABASE d INTO 'nodelocal://0/my_backups' WITH revision_history;
+BACKUP DATABASE d INTO 'nodelocal://1/my_backups' WITH revision_history;
 ----

--- a/pkg/ccl/backupccl/testdata/backup-restore/row_level_ttl
+++ b/pkg/ccl/backupccl/testdata/backup-restore/row_level_ttl
@@ -25,7 +25,7 @@ WHERE label LIKE 'row-level-ttl-%'
 0
 
 exec-sql
-RESTORE FROM LATEST IN 'nodelocal://0/full_cluster_backup/'
+RESTORE FROM LATEST IN 'nodelocal://1/full_cluster_backup/'
 ----
 
 exec-sql
@@ -58,7 +58,7 @@ WHERE label LIKE 'row-level-ttl-%'
 0
 
 exec-sql
-RESTORE DATABASE d FROM LATEST IN 'nodelocal://0/database_backup/'
+RESTORE DATABASE d FROM LATEST IN 'nodelocal://1/database_backup/'
 ----
 
 exec-sql
@@ -95,7 +95,7 @@ CREATE DATABASE d
 ----
 
 exec-sql
-RESTORE TABLE d.public.t FROM LATEST IN 'nodelocal://0/database_backup/'
+RESTORE TABLE d.public.t FROM LATEST IN 'nodelocal://1/database_backup/'
 ----
 
 exec-sql

--- a/pkg/ccl/backupccl/testdata/backup-restore/show-backup-union
+++ b/pkg/ccl/backupccl/testdata/backup-restore/show-backup-union
@@ -10,10 +10,10 @@ GRANT admin TO bigboss
 ----
 
 exec-sql
-BACKUP INTO 'nodelocal://0/test/'
+BACKUP INTO 'nodelocal://1/test/'
 ----
 
 # Just verify that concurrent privilege checks don't panic.
 exec-sql
-SELECT * FROM [SHOW BACKUPS IN 'nodelocal://0/test'] UNION SELECT * FROM [SHOW BACKUPS IN 'nodelocal://0/test']
+SELECT * FROM [SHOW BACKUPS IN 'nodelocal://1/test'] UNION SELECT * FROM [SHOW BACKUPS IN 'nodelocal://1/test']
 ----

--- a/pkg/ccl/backupccl/testdata/backup-restore/show-schedules-old
+++ b/pkg/ccl/backupccl/testdata/backup-restore/show-schedules-old
@@ -13,7 +13,7 @@ CREATE TABLE scratch (LIKE system.scheduled_jobs);
 ----
 
 exec-sql
-IMPORT INTO scratch CSV DATA ('nodelocal://0/system_scheduled_jobs_22_1/rows/export*-n*.0.csv');
+IMPORT INTO scratch CSV DATA ('nodelocal://1/system_scheduled_jobs_22_1/rows/export*-n*.0.csv');
 ----
 
 query-sql

--- a/pkg/ccl/backupccl/testdata/backup-restore/show_backup
+++ b/pkg/ccl/backupccl/testdata/backup-restore/show_backup
@@ -1,7 +1,7 @@
 # These tests validate the SHOW BACKUP command (old and new stynax) with
 # backup images that contain both invalid and valid sets of descriptors.
 
-new-cluster name=s1 allow-implicit-access disable-tenant localities=eu-central-1,eu-north-1,us-east-1
+new-cluster name=s1 allow-implicit-access localities=eu-central-1,eu-north-1,us-east-1
 ----
 
 link-backup cluster=s1 src-path=show_backup_validate,invalidDependOnBy_21.1 dest-path=invalidDependOnBy_21.1
@@ -9,7 +9,7 @@ link-backup cluster=s1 src-path=show_backup_validate,invalidDependOnBy_21.1 dest
 
 # This backup intentionally has a dangling invalid depend on by reference.
 query-sql regex=invalid\sdepended-on-by
-SELECT * FROM [SHOW BACKUP VALIDATE FROM 'invalidDependOnBy_21.1' IN 'nodelocal://0/'];
+SELECT * FROM [SHOW BACKUP VALIDATE FROM 'invalidDependOnBy_21.1' IN 'nodelocal://1/'];
 ----
 true
 
@@ -18,7 +18,7 @@ link-backup cluster=s1 src-path=show_backup_validate,valid-22.2 dest-path=valid-
 
 # This backup is completely valid, but has no jobs.
 query-sql regex=No\sproblems\sfound!
-SELECT * FROM [SHOW BACKUP VALIDATE FROM 'valid-22.2' IN 'nodelocal://0/'];
+SELECT * FROM [SHOW BACKUP VALIDATE FROM 'valid-22.2' IN 'nodelocal://1/'];
 ----
 true
 
@@ -28,13 +28,13 @@ link-backup cluster=s1 src-path=show_backup_validate,valid-22.2-with-job dest-pa
 # This back up is valid, and taken when a job was actively working on the
 # descriptor.
 query-sql regex=No\sproblems\sfound!
-SELECT * FROM [SHOW BACKUP VALIDATE FROM 'valid-22.2-with-job' IN 'nodelocal://0/'];
+SELECT * FROM [SHOW BACKUP VALIDATE FROM 'valid-22.2-with-job' IN 'nodelocal://1/'];
 ----
 true
 
 # Validates the same backup with the old syntax.
 query-sql regex=No\sproblems\sfound!
-SELECT * FROM [SHOW BACKUP VALIDATE 'nodelocal://0/valid-22.2-with-job'];
+SELECT * FROM [SHOW BACKUP VALIDATE 'nodelocal://1/valid-22.2-with-job'];
 ----
 true
 

--- a/pkg/ccl/backupccl/testdata/backup-restore/system-privileges-table
+++ b/pkg/ccl/backupccl/testdata/backup-restore/system-privileges-table
@@ -6,7 +6,7 @@ CREATE USER testuser;
 CREATE USER testuser2;
 GRANT SYSTEM MODIFYCLUSTERSETTING, VIEWACTIVITY TO testuser;
 GRANT SELECT ON crdb_internal.tables TO testuser;
-CREATE EXTERNAL CONNECTION foo AS 'nodelocal://0/foo';
+CREATE EXTERNAL CONNECTION foo AS 'nodelocal://1/foo';
 GRANT USAGE ON EXTERNAL CONNECTION foo TO testuser2;
 GRANT SYSTEM VIEWACTIVITYREDACTED TO testuser2;
 GRANT SELECT ON crdb_internal.databases, crdb_internal.tables TO testuser2;
@@ -25,7 +25,7 @@ testuser2 /vtable/crdb_internal/databases {SELECT} {} 101
 testuser2 /vtable/crdb_internal/tables {SELECT} {} 101
 
 exec-sql
-BACKUP INTO 'nodelocal://0/test/'
+BACKUP INTO 'nodelocal://1/test/'
 ----
 
 # Start a new cluster with the same IO dir.
@@ -34,7 +34,7 @@ new-cluster name=s2 share-io-dir=s1
 
 # Restore into the new cluster.
 exec-sql cluster=s2
-RESTORE FROM LATEST IN 'nodelocal://0/test/'
+RESTORE FROM LATEST IN 'nodelocal://1/test/'
 ----
 
 query-sql cluster=s2

--- a/pkg/ccl/backupccl/testdata/backup-restore/system-users
+++ b/pkg/ccl/backupccl/testdata/backup-restore/system-users
@@ -25,7 +25,7 @@ SHOW GRANTS ON ROLE developer
 developer abbey false
 
 exec-sql
-BACKUP DATABASE system INTO 'nodelocal://0/test/'
+BACKUP DATABASE system INTO 'nodelocal://1/test/'
 ----
 
 # Start a new cluster with the same IO dir.
@@ -34,7 +34,7 @@ new-cluster name=s2 share-io-dir=s1
 
 # Restore into the new cluster.
 exec-sql cluster=s2
-RESTORE SYSTEM USERS FROM LATEST IN 'nodelocal://0/test/'
+RESTORE SYSTEM USERS FROM LATEST IN 'nodelocal://1/test/'
 ----
 
 query-sql cluster=s2

--- a/pkg/ccl/backupccl/testdata/backup-restore/temp-tables
+++ b/pkg/ccl/backupccl/testdata/backup-restore/temp-tables
@@ -33,16 +33,16 @@ pg_temp
 public
 
 exec-sql
-BACKUP TABLE temp_table INTO 'nodelocal://0/temp_table_backup'
+BACKUP TABLE temp_table INTO 'nodelocal://1/temp_table_backup'
 ----
 pq: failed to resolve targets specified in the BACKUP stmt: table "temp_table" does not exist, or invalid RESTORE timestamp: supplied backups do not cover requested time
 
 exec-sql
-BACKUP DATABASE d1 INTO 'nodelocal://0/d1_backup/'
+BACKUP DATABASE d1 INTO 'nodelocal://1/d1_backup/'
 ----
 
 exec-sql
-BACKUP d1.* INTO 'nodelocal://0/d1_star_backup/'
+BACKUP d1.* INTO 'nodelocal://1/d1_star_backup/'
 ----
 
 exec-sql
@@ -50,7 +50,7 @@ COMMENT ON TABLE temp_table IS 'should not show up in restore';
 ----
 
 exec-sql
-BACKUP INTO 'nodelocal://0/full_cluster_backup/';
+BACKUP INTO 'nodelocal://1/full_cluster_backup/';
 ----
 
 exec-sql
@@ -59,7 +59,7 @@ DROP DATABASE d1
 ----
 
 exec-sql
-RESTORE DATABASE d1 FROM LATEST IN 'nodelocal://0/d1_backup/'
+RESTORE DATABASE d1 FROM LATEST IN 'nodelocal://1/d1_backup/'
 ----
 
 exec-sql
@@ -88,7 +88,7 @@ DROP DATABASE d1
 ----
 
 exec-sql
-RESTORE DATABASE d1 FROM LATEST IN 'nodelocal://0/d1_star_backup/'
+RESTORE DATABASE d1 FROM LATEST IN 'nodelocal://1/d1_star_backup/'
 ----
 
 exec-sql
@@ -121,7 +121,7 @@ USE defaultdb;
 
 # On full cluster restore we do not restore temp tables
 exec-sql
-RESTORE FROM LATEST IN 'nodelocal://0/full_cluster_backup/';
+RESTORE FROM LATEST IN 'nodelocal://1/full_cluster_backup/';
 ----
 
 query-sql

--- a/pkg/ccl/backupccl/testdata/backup-restore/user-defined-functions
+++ b/pkg/ccl/backupccl/testdata/backup-restore/user-defined-functions
@@ -28,12 +28,12 @@ SELECT sc2.f2()
 123
 
 exec-sql
-BACKUP DATABASE db1 INTO 'nodelocal://0/test/'
+BACKUP DATABASE db1 INTO 'nodelocal://1/test/'
 ----
 
 query-sql
 WITH descs AS (
-  SHOW BACKUP LATEST IN 'nodelocal://0/test/'
+  SHOW BACKUP LATEST IN 'nodelocal://1/test/'
 )
 SELECT database_name, parent_schema_name, object_name, object_type, is_full_cluster FROM descs
 ----
@@ -73,7 +73,7 @@ DROP DATABASE db1
 ----
 
 exec-sql
-RESTORE DATABASE db1 FROM LATEST IN 'nodelocal://0/test/' WITH new_db_name = db1_new
+RESTORE DATABASE db1 FROM LATEST IN 'nodelocal://1/test/' WITH new_db_name = db1_new
 ----
 
 exec-sql
@@ -172,12 +172,12 @@ SELECT sc2.f2()
 123
 
 exec-sql
-BACKUP INTO 'nodelocal://0/test/'
+BACKUP INTO 'nodelocal://1/test/'
 ----
 
 query-sql
 WITH descs AS (
-  SHOW BACKUP LATEST IN 'nodelocal://0/test/'
+  SHOW BACKUP LATEST IN 'nodelocal://1/test/'
 )
 SELECT
   database_name, parent_schema_name, object_name, object_type, is_full_cluster
@@ -223,7 +223,7 @@ new-cluster name=s2 share-io-dir=s1
 
 # Restore into the new cluster.
 exec-sql cluster=s2
-RESTORE FROM LATEST IN 'nodelocal://0/test/'
+RESTORE FROM LATEST IN 'nodelocal://1/test/'
 ----
 
 exec-sql
@@ -337,11 +337,11 @@ SELECT d->'schema'->>'functions'::string FROM to_json;
 {"f": {"signatures": [{"id": 111, "returnType": {"family": "IntFamily", "oid": 20, "width": 64}}]}}
 
 exec-sql
-BACKUP TABLE sc1.t INTO 'nodelocal://0/test/'
+BACKUP TABLE sc1.t INTO 'nodelocal://1/test/'
 ----
 
 exec-sql
-RESTORE TABLE sc1.t FROM LATEST IN 'nodelocal://0/test/' WITH into_db = 'db1';
+RESTORE TABLE sc1.t FROM LATEST IN 'nodelocal://1/test/' WITH into_db = 'db1';
 ----
 
 exec-sql

--- a/pkg/ccl/backupccl/testdata/backup-restore/user-defined-functions-in-checks
+++ b/pkg/ccl/backupccl/testdata/backup-restore/user-defined-functions-in-checks
@@ -13,12 +13,12 @@ CREATE TABLE sc1.t1(a INT PRIMARY KEY, b INT CHECK(sc1.f1(b) > 1));
 ----
 
 exec-sql
-BACKUP DATABASE db1 INTO 'nodelocal://0/test/'
+BACKUP DATABASE db1 INTO 'nodelocal://1/test/'
 ----
 
 query-sql
 WITH descs AS (
-  SHOW BACKUP LATEST IN 'nodelocal://0/test/'
+  SHOW BACKUP LATEST IN 'nodelocal://1/test/'
 )
 SELECT database_name, parent_schema_name, object_name, object_type, is_full_cluster FROM descs
 ----
@@ -29,7 +29,7 @@ db1 sc1 f1 function false
 db1 sc1 t1 table false
 
 exec-sql
-RESTORE DATABASE db1 FROM LATEST IN 'nodelocal://0/test/' WITH new_db_name = db1_new
+RESTORE DATABASE db1 FROM LATEST IN 'nodelocal://1/test/' WITH new_db_name = db1_new
 ----
 
 exec-sql
@@ -77,12 +77,12 @@ CREATE TABLE sc1.t1(a INT PRIMARY KEY, b INT CHECK(sc1.f1(b) > 1));
 ----
 
 exec-sql
-BACKUP INTO 'nodelocal://0/test/'
+BACKUP INTO 'nodelocal://1/test/'
 ----
 
 query-sql
 WITH descs AS (
-  SHOW BACKUP LATEST IN 'nodelocal://0/test/'
+  SHOW BACKUP LATEST IN 'nodelocal://1/test/'
 )
 SELECT
   database_name, parent_schema_name, object_name, object_type, is_full_cluster
@@ -102,7 +102,7 @@ new-cluster name=s2 share-io-dir=s1
 
 # Restore into the new cluster.
 exec-sql cluster=s2
-RESTORE FROM LATEST IN 'nodelocal://0/test/'
+RESTORE FROM LATEST IN 'nodelocal://1/test/'
 ----
 
 exec-sql
@@ -153,12 +153,12 @@ CREATE TABLE sc1.t1(a INT PRIMARY KEY, b INT CHECK(sc1.f1(b) > 1));
 ----
 
 exec-sql
-BACKUP DATABASE db1 INTO 'nodelocal://0/test/'
+BACKUP DATABASE db1 INTO 'nodelocal://1/test/'
 ----
 
 query-sql
 WITH descs AS (
-  SHOW BACKUP LATEST IN 'nodelocal://0/test/'
+  SHOW BACKUP LATEST IN 'nodelocal://1/test/'
 )
 SELECT database_name, parent_schema_name, object_name, object_type, is_full_cluster FROM descs
 ----
@@ -169,12 +169,12 @@ db1 sc1 f1 function false
 db1 sc1 t1 table false
 
 exec-sql
-RESTORE TABLE sc1.t1 FROM LATEST IN 'nodelocal://0/test/' WITH into_db = 'db2';
+RESTORE TABLE sc1.t1 FROM LATEST IN 'nodelocal://1/test/' WITH into_db = 'db2';
 ----
 pq: cannot restore table "t1" without referenced function 114 (or "skip_missing_udfs" option)
 
 exec-sql
-RESTORE TABLE sc1.t1 FROM LATEST IN 'nodelocal://0/test/' WITH into_db = 'db2', skip_missing_udfs;
+RESTORE TABLE sc1.t1 FROM LATEST IN 'nodelocal://1/test/' WITH into_db = 'db2', skip_missing_udfs;
 ----
 
 exec-sql
@@ -196,12 +196,12 @@ USE db1
 ----
 
 exec-sql
-BACKUP TABLE sc1.t1 INTO 'nodelocal://0/test/'
+BACKUP TABLE sc1.t1 INTO 'nodelocal://1/test/'
 ----
 
 query-sql
 WITH descs AS (
-  SHOW BACKUP LATEST IN 'nodelocal://0/test/'
+  SHOW BACKUP LATEST IN 'nodelocal://1/test/'
 )
 SELECT database_name, parent_schema_name, object_name, object_type, is_full_cluster FROM descs
 ----
@@ -210,12 +210,12 @@ db1 <nil> sc1 schema false
 db1 sc1 t1 table false
 
 exec-sql
-RESTORE TABLE sc1.t1 FROM LATEST IN 'nodelocal://0/test/' WITH into_db = 'db3';
+RESTORE TABLE sc1.t1 FROM LATEST IN 'nodelocal://1/test/' WITH into_db = 'db3';
 ----
 pq: cannot restore table "t1" without referenced function 114 (or "skip_missing_udfs" option)
 
 exec-sql
-RESTORE TABLE sc1.t1 FROM LATEST IN 'nodelocal://0/test/' WITH into_db = 'db3', skip_missing_udfs;
+RESTORE TABLE sc1.t1 FROM LATEST IN 'nodelocal://1/test/' WITH into_db = 'db3', skip_missing_udfs;
 ----
 
 exec-sql

--- a/pkg/ccl/backupccl/testdata/backup-restore/user-defined-functions-in-defaults
+++ b/pkg/ccl/backupccl/testdata/backup-restore/user-defined-functions-in-defaults
@@ -11,12 +11,12 @@ CREATE TABLE sc1.t1(a INT PRIMARY KEY, b INT DEFAULT sc1.f1());
 ----
 
 exec-sql
-BACKUP DATABASE db1 INTO 'nodelocal://0/test/'
+BACKUP DATABASE db1 INTO 'nodelocal://1/test/'
 ----
 
 query-sql
 WITH descs AS (
-  SHOW BACKUP LATEST IN 'nodelocal://0/test/'
+  SHOW BACKUP LATEST IN 'nodelocal://1/test/'
 )
 SELECT database_name, parent_schema_name, object_name, object_type, is_full_cluster FROM descs
 ----
@@ -27,7 +27,7 @@ db1 sc1 f1 function false
 db1 sc1 t1 table false
 
 exec-sql
-RESTORE DATABASE db1 FROM LATEST IN 'nodelocal://0/test/' WITH new_db_name = db1_new
+RESTORE DATABASE db1 FROM LATEST IN 'nodelocal://1/test/' WITH new_db_name = db1_new
 ----
 
 exec-sql
@@ -77,12 +77,12 @@ CREATE TABLE sc1.t1(a INT PRIMARY KEY, b INT DEFAULT sc1.f1());
 ----
 
 exec-sql
-BACKUP INTO 'nodelocal://0/test/'
+BACKUP INTO 'nodelocal://1/test/'
 ----
 
 query-sql
 WITH descs AS (
-  SHOW BACKUP LATEST IN 'nodelocal://0/test/'
+  SHOW BACKUP LATEST IN 'nodelocal://1/test/'
 )
 SELECT
   database_name, parent_schema_name, object_name, object_type, is_full_cluster
@@ -102,7 +102,7 @@ new-cluster name=s2 share-io-dir=s1
 
 # Restore into the new cluster.
 exec-sql cluster=s2
-RESTORE FROM LATEST IN 'nodelocal://0/test/'
+RESTORE FROM LATEST IN 'nodelocal://1/test/'
 ----
 
 exec-sql
@@ -155,12 +155,12 @@ CREATE TABLE sc1.t1(a INT PRIMARY KEY, b INT DEFAULT sc1.f1());
 ----
 
 exec-sql
-BACKUP DATABASE db1 INTO 'nodelocal://0/test/'
+BACKUP DATABASE db1 INTO 'nodelocal://1/test/'
 ----
 
 query-sql
 WITH descs AS (
-  SHOW BACKUP LATEST IN 'nodelocal://0/test/'
+  SHOW BACKUP LATEST IN 'nodelocal://1/test/'
 )
 SELECT database_name, parent_schema_name, object_name, object_type, is_full_cluster FROM descs
 ----
@@ -171,12 +171,12 @@ db1 sc1 f1 function false
 db1 sc1 t1 table false
 
 exec-sql
-RESTORE TABLE sc1.t1 FROM LATEST IN 'nodelocal://0/test/' WITH into_db = 'db2';
+RESTORE TABLE sc1.t1 FROM LATEST IN 'nodelocal://1/test/' WITH into_db = 'db2';
 ----
 pq: cannot restore table "t1" without referenced function 114 (or "skip_missing_udfs" option)
 
 exec-sql
-RESTORE TABLE sc1.t1 FROM LATEST IN 'nodelocal://0/test/' WITH into_db = 'db2', skip_missing_udfs;
+RESTORE TABLE sc1.t1 FROM LATEST IN 'nodelocal://1/test/' WITH into_db = 'db2', skip_missing_udfs;
 ----
 
 exec-sql
@@ -198,12 +198,12 @@ USE db1
 ----
 
 exec-sql
-BACKUP TABLE sc1.t1 INTO 'nodelocal://0/test/'
+BACKUP TABLE sc1.t1 INTO 'nodelocal://1/test/'
 ----
 
 query-sql
 WITH descs AS (
-  SHOW BACKUP LATEST IN 'nodelocal://0/test/'
+  SHOW BACKUP LATEST IN 'nodelocal://1/test/'
 )
 SELECT database_name, parent_schema_name, object_name, object_type, is_full_cluster FROM descs
 ----
@@ -212,12 +212,12 @@ db1 <nil> sc1 schema false
 db1 sc1 t1 table false
 
 exec-sql
-RESTORE TABLE sc1.t1 FROM LATEST IN 'nodelocal://0/test/' WITH into_db = 'db3';
+RESTORE TABLE sc1.t1 FROM LATEST IN 'nodelocal://1/test/' WITH into_db = 'db3';
 ----
 pq: cannot restore table "t1" without referenced function 114 (or "skip_missing_udfs" option)
 
 exec-sql
-RESTORE TABLE sc1.t1 FROM LATEST IN 'nodelocal://0/test/' WITH into_db = 'db3', skip_missing_udfs;
+RESTORE TABLE sc1.t1 FROM LATEST IN 'nodelocal://1/test/' WITH into_db = 'db3', skip_missing_udfs;
 ----
 
 exec-sql

--- a/pkg/ccl/backupccl/testdata/backup-restore/user-defined-types
+++ b/pkg/ccl/backupccl/testdata/backup-restore/user-defined-types
@@ -20,7 +20,7 @@ INSERT INTO d2.t2 VALUES (ARRAY['bye']), (ARRAY['cya']);
 ----
 
 exec-sql
-BACKUP INTO 'nodelocal://0/test/'
+BACKUP INTO 'nodelocal://1/test/'
 ----
 
 # Start a new cluster with the same IO dir.
@@ -29,7 +29,7 @@ new-cluster name=s2 share-io-dir=s1
 
 # Restore into the new cluster.
 exec-sql cluster=s2
-RESTORE FROM LATEST IN 'nodelocal://0/test/'
+RESTORE FROM LATEST IN 'nodelocal://1/test/'
 ----
 
 # Check all of the tables have the right data.
@@ -129,7 +129,7 @@ CREATE TABLE d.expr (
 
 # Backup the database now.
 exec-sql
-BACKUP DATABASE d INTO 'nodelocal://0/test/'
+BACKUP DATABASE d INTO 'nodelocal://1/test/'
 ----
 
 exec-sql
@@ -137,7 +137,7 @@ DROP DATABASE d
 ----
 
 exec-sql
-RESTORE DATABASE d FROM LATEST IN 'nodelocal://0/test/';
+RESTORE DATABASE d FROM LATEST IN 'nodelocal://1/test/';
 ----
 
 # Check the table data.

--- a/pkg/ccl/backupccl/testdata/backup-restore/views
+++ b/pkg/ccl/backupccl/testdata/backup-restore/views
@@ -27,11 +27,11 @@ sc1.v1 CREATE VIEW sc1.v1 (
 ) AS SELECT a FROM db1.sc1.tbl1
 
 exec-sql
-BACKUP DATABASE db1 INTO 'nodelocal://0/test/'
+BACKUP DATABASE db1 INTO 'nodelocal://1/test/'
 ----
 
 exec-sql
-RESTORE DATABASE db1 FROM LATEST IN 'nodelocal://0/test/' WITH new_db_name = db1_new
+RESTORE DATABASE db1 FROM LATEST IN 'nodelocal://1/test/' WITH new_db_name = db1_new
 ----
 
 query-sql

--- a/pkg/ccl/backupccl/testdata/backup-restore/virtual-columns
+++ b/pkg/ccl/backupccl/testdata/backup-restore/virtual-columns
@@ -18,7 +18,7 @@ INSERT INTO tab VALUES (1,1,1), (2,2,2), (3,3,3)
 ----
 
 exec-sql
-BACKUP INTO 'nodelocal://0/test/'
+BACKUP INTO 'nodelocal://1/test/'
 ----
 
 # Start a new cluster with the same IO dir.
@@ -26,7 +26,7 @@ new-cluster name=s2 share-io-dir=s1
 ----
 
 exec-sql cluster=s2
-RESTORE FROM LATEST IN 'nodelocal://0/test/'
+RESTORE FROM LATEST IN 'nodelocal://1/test/'
 ----
 
 query-sql

--- a/pkg/ccl/backupccl/utils_test.go
+++ b/pkg/ccl/backupccl/utils_test.go
@@ -61,7 +61,7 @@ const (
 	multiNode                   = 3
 	backupRestoreDefaultRanges  = 10
 	backupRestoreRowPayloadSize = 100
-	localFoo                    = "nodelocal://0/foo"
+	localFoo                    = "nodelocal://1/foo"
 )
 
 // smallEngineBlocks configures Pebble with a block size of 1 byte, to provoke

--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -4692,12 +4692,12 @@ func TestChangefeedErrors(t *testing.T) {
 	sqlDB.ExpectErr(
 		t, `this sink is incompatible with option confluent_schema_registry`,
 		`CREATE CHANGEFEED FOR foo INTO $1 WITH format='avro', confluent_schema_registry=$2`,
-		`experimental-nodelocal://0/bar`, schemaReg.URL(),
+		`experimental-nodelocal://1/bar`, schemaReg.URL(),
 	)
 	sqlDB.ExpectErr(
 		t, `this sink is incompatible with envelope=key_only`,
 		`CREATE CHANGEFEED FOR foo INTO $1 WITH envelope='key_only'`,
-		`experimental-nodelocal://0/bar`,
+		`experimental-nodelocal://1/bar`,
 	)
 
 	// WITH key_in_value requires envelope=wrapped

--- a/pkg/ccl/changefeedccl/helpers_test.go
+++ b/pkg/ccl/changefeedccl/helpers_test.go
@@ -27,7 +27,6 @@ import (
 
 	apd "github.com/cockroachdb/apd/v3"
 	"github.com/cockroachdb/cockroach/pkg/base"
-	"github.com/cockroachdb/cockroach/pkg/blobs"
 	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/cdctest"
 	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/changefeedbase"
 	// Imported to allow locality-related table mutations
@@ -876,20 +875,6 @@ func randomSinkTypeWithOptions(options feedTestOptions) string {
 func addCloudStorageOptions(t *testing.T, options *feedTestOptions) (cleanup func()) {
 	dir, dirCleanupFn := testutils.TempDir(t)
 	options.externalIODir = dir
-	oldKnobsFn := options.knobsFn
-	options.knobsFn = func(knobs *base.TestingKnobs) {
-		if oldKnobsFn != nil {
-			oldKnobsFn(knobs)
-		}
-		blobClientFactory := blobs.NewLocalOnlyBlobClientFactory(options.externalIODir)
-		if serverKnobs, ok := knobs.Server.(*server.TestingKnobs); ok {
-			serverKnobs.BlobClientFactory = blobClientFactory
-		} else {
-			knobs.Server = &server.TestingKnobs{
-				BlobClientFactory: blobClientFactory,
-			}
-		}
-	}
 	return dirCleanupFn
 }
 

--- a/pkg/ccl/changefeedccl/sink_cloudstorage_test.go
+++ b/pkg/ccl/changefeedccl/sink_cloudstorage_test.go
@@ -184,7 +184,7 @@ func TestCloudStorageSink(t *testing.T) {
 	user := username.RootUserName()
 
 	sinkURI := func(t *testing.T, maxFileSize int64) sinkURL {
-		u, err := url.Parse(fmt.Sprintf("nodelocal://0/%s", testDir(t)))
+		u, err := url.Parse(fmt.Sprintf("nodelocal://1/%s", testDir(t)))
 		require.NoError(t, err)
 		sink := sinkURL{URL: u}
 		if maxFileSize != unlimitedFileSize {

--- a/pkg/ccl/changefeedccl/testfeed_test.go
+++ b/pkg/ccl/changefeedccl/testfeed_test.go
@@ -1087,7 +1087,7 @@ func (f *cloudFeedFactory) Feed(
 	}
 
 	feedDir := feedSubDir()
-	sinkURI := `nodelocal://0/` + feedDir
+	sinkURI := `nodelocal://1/` + feedDir
 	// TODO(dan): This is a pretty unsatisfying way to test that the uri passes
 	// through params it doesn't understand to ExternalStorage.
 	sinkURI += `?should_be=ignored`

--- a/pkg/ccl/logictestccl/testdata/logic_test/multi_region_backup
+++ b/pkg/ccl/logictestccl/testdata/logic_test/multi_region_backup
@@ -376,13 +376,13 @@ ALTER DATABASE "mr-backup-1" CONFIGURE ZONE USING gc.ttlseconds = 1;
 ALTER DATABASE "mr-backup-2" CONFIGURE ZONE USING gc.ttlseconds = 1
 
 statement ok
-BACKUP DATABASE "mr-backup-1" TO 'nodelocal://0/mr-backup-1/';
+BACKUP DATABASE "mr-backup-1" TO 'nodelocal://1/mr-backup-1/';
 
 statement ok
-BACKUP DATABASE "mr-backup-2" TO 'nodelocal://0/mr-backup-2/';
+BACKUP DATABASE "mr-backup-2" TO 'nodelocal://1/mr-backup-2/';
 
 statement ok
-BACKUP DATABASE "mr-backup-1", "mr-backup-2" TO 'nodelocal://0/mr-backup-combined/'
+BACKUP DATABASE "mr-backup-1", "mr-backup-2" TO 'nodelocal://1/mr-backup-combined/'
 
 query T
 select database_name from [show databases]
@@ -409,7 +409,7 @@ system
 test
 
 statement ok
-RESTORE DATABASE "mr-backup-1" FROM 'nodelocal://0/mr-backup-1/'
+RESTORE DATABASE "mr-backup-1" FROM 'nodelocal://1/mr-backup-1/'
 
 query T
 select database_name from [show databases]
@@ -563,7 +563,7 @@ TABLE regional_by_table_in_ca_central_1  ALTER TABLE regional_by_table_in_ca_cen
                                            lease_preferences = '[[+region=ca-central-1]]'
 
 statement ok
-RESTORE DATABASE "mr-backup-2" FROM 'nodelocal://0/mr-backup-2/'
+RESTORE DATABASE "mr-backup-2" FROM 'nodelocal://1/mr-backup-2/'
 
 query T
 select database_name from [show databases]
@@ -732,7 +732,7 @@ system
 test
 
 statement ok
-RESTORE DATABASE "mr-backup-1", "mr-backup-2" FROM 'nodelocal://0/mr-backup-combined/'
+RESTORE DATABASE "mr-backup-1", "mr-backup-2" FROM 'nodelocal://1/mr-backup-combined/'
 
 query T
 select database_name from [show databases]
@@ -1032,16 +1032,16 @@ TABLE regional_by_table_in_ca_central_1  ALTER TABLE regional_by_table_in_ca_cen
 subtest multiregion_table_backup_and_restore
 
 statement ok
-BACKUP TABLE regional_by_row_table TO 'nodelocal://0/rbr_table/';
+BACKUP TABLE regional_by_row_table TO 'nodelocal://1/rbr_table/';
 
 statement ok
-BACKUP TABLE regional_by_table_in_primary_region TO 'nodelocal://0/rbt_table_in_primary_region/';
+BACKUP TABLE regional_by_table_in_primary_region TO 'nodelocal://1/rbt_table_in_primary_region/';
 
 statement ok
-BACKUP TABLE regional_by_table_in_ca_central_1 TO 'nodelocal://0/rbt_table_in_ca_central_1/';
+BACKUP TABLE regional_by_table_in_ca_central_1 TO 'nodelocal://1/rbt_table_in_ca_central_1/';
 
 statement ok
-BACKUP TABLE global_table TO 'nodelocal://0/global_table/';
+BACKUP TABLE global_table TO 'nodelocal://1/global_table/';
 
 statement ok
 DROP TABLE regional_by_row_table;
@@ -1050,16 +1050,16 @@ DROP TABLE regional_by_table_in_ca_central_1;
 DROP TABLE global_table;
 
 statement ok
-RESTORE TABLE regional_by_row_table FROM 'nodelocal://0/rbr_table/';
+RESTORE TABLE regional_by_row_table FROM 'nodelocal://1/rbr_table/';
 
 statement ok
-RESTORE TABLE regional_by_table_in_primary_region FROM 'nodelocal://0/rbt_table_in_primary_region/';
+RESTORE TABLE regional_by_table_in_primary_region FROM 'nodelocal://1/rbt_table_in_primary_region/';
 
 statement ok
-RESTORE TABLE regional_by_table_in_ca_central_1 FROM 'nodelocal://0/rbt_table_in_ca_central_1/';
+RESTORE TABLE regional_by_table_in_ca_central_1 FROM 'nodelocal://1/rbt_table_in_ca_central_1/';
 
 statement ok
-RESTORE TABLE global_table FROM 'nodelocal://0/global_table/';
+RESTORE TABLE global_table FROM 'nodelocal://1/global_table/';
 
 query IIIIT
 SELECT * FROM regional_by_row_table;
@@ -1203,13 +1203,13 @@ RANGE default  ALTER RANGE default CONFIGURE ZONE USING
                  lease_preferences = '[]'
 
 statement ok
-BACKUP TABLE non_mr_table TO 'nodelocal://0/non_mr_table/'
+BACKUP TABLE non_mr_table TO 'nodelocal://1/non_mr_table/'
 
 statement ok
 DROP TABLE non_mr_table
 
 statement ok
-RESTORE TABLE non_mr_table FROM 'nodelocal://0/non_mr_table/'
+RESTORE TABLE non_mr_table FROM 'nodelocal://1/non_mr_table/'
 
 query TT
 SHOW ZONE CONFIGURATION FROM TABLE non_mr_table
@@ -1223,11 +1223,11 @@ RANGE default  ALTER RANGE default CONFIGURE ZONE USING
                  lease_preferences = '[]'
 
 statement ok
-RESTORE TABLE non_mr_table FROM 'nodelocal://0/non_mr_table/' WITH into_db = 'mr-backup-1'
+RESTORE TABLE non_mr_table FROM 'nodelocal://1/non_mr_table/' WITH into_db = 'mr-backup-1'
 
 # Verify that an MR table cannot be restored in a non-MR database.
 statement error cannot restore descriptor for multi-region table regional_by_row_table into non-multi-region database non_mr_backup
-RESTORE TABLE "mr-backup-2".regional_by_row_table FROM 'nodelocal://0/mr-backup-2/' WITH into_db = 'non_mr_backup'
+RESTORE TABLE "mr-backup-2".regional_by_row_table FROM 'nodelocal://1/mr-backup-2/' WITH into_db = 'non_mr_backup'
 
 statement ok
 USE 'mr-backup-1'
@@ -1269,7 +1269,7 @@ DROP TABLE global_table;
 subtest restore_tables_into_database_with_same_regions
 
 statement ok
-RESTORE TABLE regional_by_row_table FROM 'nodelocal://0/mr-backup-2/'
+RESTORE TABLE regional_by_row_table FROM 'nodelocal://1/mr-backup-2/'
 
 query TT
 SHOW CREATE TABLE regional_by_row_table
@@ -1289,7 +1289,7 @@ regional_by_row_table  CREATE TABLE public.regional_by_row_table (
                        ) LOCALITY REGIONAL BY ROW
 
 statement ok
-RESTORE TABLE regional_by_table_in_primary_region FROM 'nodelocal://0/mr-backup-2/'
+RESTORE TABLE regional_by_table_in_primary_region FROM 'nodelocal://1/mr-backup-2/'
 
 query TT
 SHOW CREATE TABLE regional_by_table_in_primary_region
@@ -1303,7 +1303,7 @@ regional_by_table_in_primary_region             CREATE TABLE public.regional_by_
 
 
 statement ok
-RESTORE TABLE regional_by_table_in_ca_central_1 FROM 'nodelocal://0/mr-backup-2/'
+RESTORE TABLE regional_by_table_in_ca_central_1 FROM 'nodelocal://1/mr-backup-2/'
 
 # REGIONAL BY TABLE tables with a specific region are permitted if that region
 # exists in the database.
@@ -1318,7 +1318,7 @@ regional_by_table_in_ca_central_1               CREATE TABLE public.regional_by_
 ) LOCALITY REGIONAL BY TABLE IN "ca-central-1"
 
 statement ok
-RESTORE TABLE global_table FROM 'nodelocal://0/mr-backup-2/'
+RESTORE TABLE global_table FROM 'nodelocal://1/mr-backup-2/'
 
 query TT
 SHOW CREATE TABLE global_table
@@ -1338,7 +1338,7 @@ statement ok
 CREATE DATABASE "mr-restore-1" primary region "ap-southeast-2" regions "us-east-1"
 
 statement ok
-RESTORE TABLE "mr-backup-2".global_table FROM 'nodelocal://0/mr-backup-2/' WITH into_db='mr-restore-1';
+RESTORE TABLE "mr-backup-2".global_table FROM 'nodelocal://1/mr-backup-2/' WITH into_db='mr-restore-1';
 
 statement ok
 USE "mr-restore-1";
@@ -1369,7 +1369,7 @@ TABLE global_table  ALTER TABLE global_table CONFIGURE ZONE USING
 
 
 statement ok
-RESTORE TABLE "mr-backup-2".regional_by_table_in_primary_region FROM 'nodelocal://0/mr-backup-2/' WITH into_db='mr-restore-1';
+RESTORE TABLE "mr-backup-2".regional_by_table_in_primary_region FROM 'nodelocal://1/mr-backup-2/' WITH into_db='mr-restore-1';
 
 query TT
 SHOW CREATE TABLE regional_by_table_in_primary_region
@@ -1403,11 +1403,11 @@ ca-central-1    {ca-az1,ca-az2,ca-az3}  {mr-backup-1,mr-backup-2}               
 us-east-1       {us-az1,us-az2,us-az3}  {mr-backup-1,mr-backup-2,mr-restore-1}  {}                          {}
 
 statement error "crdb_internal_region" is not compatible with type "crdb_internal_region" existing in cluster: could not find enum value "ca-central-1" in "crdb_internal_region"
-RESTORE TABLE "mr-backup-2".regional_by_table_in_ap_southeast_2 FROM 'nodelocal://0/mr-backup-2/' WITH into_db='mr-restore-1';
+RESTORE TABLE "mr-backup-2".regional_by_table_in_ap_southeast_2 FROM 'nodelocal://1/mr-backup-2/' WITH into_db='mr-restore-1';
 
 # Cannot restore a REGIONAL BY TABLE table that has different regions.
 statement error cannot restore REGIONAL BY TABLE regional_by_table_in_ca_central_1 IN REGION "ca-central-1" \(table ID: [0-9]+\) into database "mr-restore-1"; region "ca-central-1" not found in database regions "ap-southeast-2", "us-east-1"
-RESTORE TABLE "mr-backup-2".regional_by_table_in_ca_central_1 FROM 'nodelocal://0/mr-backup-2/' WITH into_db='mr-restore-1'
+RESTORE TABLE "mr-backup-2".regional_by_table_in_ca_central_1 FROM 'nodelocal://1/mr-backup-2/' WITH into_db='mr-restore-1'
 
 statement error "crdb_internal_region" is not compatible with type "crdb_internal_region" existing in cluster: could not find enum value "ca-central-1" in "crdb_internal_region"
-RESTORE TABLE "mr-backup-2".regional_by_row_table FROM 'nodelocal://0/mr-backup-2/' WITH into_db='mr-restore-1'
+RESTORE TABLE "mr-backup-2".regional_by_row_table FROM 'nodelocal://1/mr-backup-2/' WITH into_db='mr-restore-1'

--- a/pkg/ccl/logictestccl/testdata/logic_test/multi_region_import_export
+++ b/pkg/ccl/logictestccl/testdata/logic_test/multi_region_import_export
@@ -72,7 +72,7 @@ id  name        likes                           dislikes
 2   otan        {"Sydney suburbs",cricket,vim}  {"flaky tests",onboarding}
 
 statement ok
-EXPORT INTO CSV 'nodelocal://0/team_export/' WITH DELIMITER = '|' FROM TABLE team
+EXPORT INTO CSV 'nodelocal://1/team_export/' WITH DELIMITER = '|' FROM TABLE team
 
 statement ok
 use multi_region_test_db;
@@ -85,7 +85,7 @@ CREATE TABLE team (
 )
 
 statement ok
-IMPORT INTO team CSV DATA ('nodelocal://0/team_export/export*.csv') WITH DELIMITER = '|'
+IMPORT INTO team CSV DATA ('nodelocal://1/team_export/export*.csv') WITH DELIMITER = '|'
 
 query ITTT colnames
 SELECT * FROM team

--- a/pkg/ccl/logictestccl/testdata/logic_test/super_regions_backup
+++ b/pkg/ccl/logictestccl/testdata/logic_test/super_regions_backup
@@ -17,19 +17,19 @@ CREATE TABLE mr1.t(x INT) LOCALITY REGIONAL BY TABLE;
 CREATE TABLE mr1.t2(x INT) LOCALITY REGIONAL BY ROW;
 
 statement ok
-BACKUP TABLE mr1.t TO 'nodelocal://0/mr1_t/'
+BACKUP TABLE mr1.t TO 'nodelocal://1/mr1_t/'
 
 statement ok
-BACKUP TABLE mr1.t2 TO 'nodelocal://0/mr1_t2/'
+BACKUP TABLE mr1.t2 TO 'nodelocal://1/mr1_t2/'
 
 statement ok
-BACKUP DATABASE "mr1" TO 'nodelocal://0/mr-backup-1/';
+BACKUP DATABASE "mr1" TO 'nodelocal://1/mr-backup-1/';
 
 statement ok
 DROP DATABASE mr1;
 
 statement ok
-RESTORE DATABASE "mr1" FROM 'nodelocal://0/mr-backup-1/'
+RESTORE DATABASE "mr1" FROM 'nodelocal://1/mr-backup-1/'
 
 query TT
 SHOW ZONE CONFIGURATION FOR TABLE mr1.t;
@@ -77,10 +77,10 @@ DROP TABLE mr1.t2;
 # Restore table into database with super regions.
 
 statement ok
-RESTORE TABLE mr1.t FROM 'nodelocal://0/mr1_t/'
+RESTORE TABLE mr1.t FROM 'nodelocal://1/mr1_t/'
 
 statement ok
-RESTORE TABLE mr1.t2 FROM 'nodelocal://0/mr1_t2/'
+RESTORE TABLE mr1.t2 FROM 'nodelocal://1/mr1_t2/'
 
 query TT
 SHOW ZONE CONFIGURATION FOR TABLE mr1.t;

--- a/pkg/ccl/logictestccl/testdata/logic_test/tenant_capability
+++ b/pkg/ccl/logictestccl/testdata/logic_test/tenant_capability
@@ -35,6 +35,7 @@ can_admin_relocate_range   false
 can_admin_scatter          true
 can_admin_split            true
 can_admin_unsplit          false
+can_use_nodelocal_storage  false
 can_view_node_info         false
 can_view_tsdb_metrics      false
 exempt_from_rate_limiting  false
@@ -58,6 +59,7 @@ can_admin_relocate_range   false
 can_admin_scatter          true
 can_admin_split            true
 can_admin_unsplit          false
+can_use_nodelocal_storage  false
 can_view_node_info         false
 can_view_tsdb_metrics      false
 exempt_from_rate_limiting  false
@@ -74,6 +76,7 @@ can_admin_relocate_range   false
 can_admin_scatter          true
 can_admin_split            false
 can_admin_unsplit          false
+can_use_nodelocal_storage  false
 can_view_node_info         false
 can_view_tsdb_metrics      false
 exempt_from_rate_limiting  false
@@ -97,6 +100,7 @@ can_admin_relocate_range   false
 can_admin_scatter          true
 can_admin_split            true
 can_admin_unsplit          false
+can_use_nodelocal_storage  false
 can_view_node_info         false
 can_view_tsdb_metrics      false
 exempt_from_rate_limiting  false
@@ -120,6 +124,7 @@ can_admin_relocate_range   false
 can_admin_scatter          true
 can_admin_split            true
 can_admin_unsplit          false
+can_use_nodelocal_storage  false
 can_view_node_info         false
 can_view_tsdb_metrics      false
 exempt_from_rate_limiting  false
@@ -143,6 +148,7 @@ can_admin_relocate_range   false
 can_admin_scatter          true
 can_admin_split            true
 can_admin_unsplit          false
+can_use_nodelocal_storage  false
 can_view_node_info         true
 can_view_tsdb_metrics      false
 exempt_from_rate_limiting  false
@@ -159,6 +165,7 @@ can_admin_relocate_range   false
 can_admin_scatter          true
 can_admin_split            false
 can_admin_unsplit          false
+can_use_nodelocal_storage  false
 can_view_node_info         false
 can_view_tsdb_metrics      false
 exempt_from_rate_limiting  false
@@ -175,6 +182,7 @@ can_admin_relocate_range   false
 can_admin_scatter          true
 can_admin_split            false
 can_admin_unsplit          false
+can_use_nodelocal_storage  false
 can_view_node_info         false
 can_view_tsdb_metrics      false
 exempt_from_rate_limiting  true
@@ -191,6 +199,7 @@ can_admin_relocate_range   false
 can_admin_scatter          true
 can_admin_split            false
 can_admin_unsplit          false
+can_use_nodelocal_storage  false
 can_view_node_info         false
 can_view_tsdb_metrics      false
 exempt_from_rate_limiting  false

--- a/pkg/ccl/multiregionccl/region_test.go
+++ b/pkg/ccl/multiregionccl/region_test.go
@@ -904,8 +904,8 @@ func TestRegionAddDropWithConcurrentBackupOps(t *testing.T) {
 	}{
 		{
 			name:      "backup-database",
-			backupOp:  `BACKUP DATABASE db TO 'nodelocal://0/db_backup'`,
-			restoreOp: `RESTORE DATABASE db FROM 'nodelocal://0/db_backup'`,
+			backupOp:  `BACKUP DATABASE db TO 'nodelocal://1/db_backup'`,
+			restoreOp: `RESTORE DATABASE db FROM 'nodelocal://1/db_backup'`,
 		},
 	}
 

--- a/pkg/ccl/multitenantccl/tenantcostclient/BUILD.bazel
+++ b/pkg/ccl/multitenantccl/tenantcostclient/BUILD.bazel
@@ -49,7 +49,6 @@ go_test(
     tags = ["ccl_test"],
     deps = [
         "//pkg/base",
-        "//pkg/blobs",
         "//pkg/ccl",
         "//pkg/ccl/changefeedccl",
         "//pkg/ccl/kvccl/kvtenantccl",

--- a/pkg/ccl/serverccl/BUILD.bazel
+++ b/pkg/ccl/serverccl/BUILD.bazel
@@ -57,6 +57,7 @@ go_test(
         "//pkg/clusterversion",
         "//pkg/kv/kvserver/liveness",
         "//pkg/kv/kvserver/liveness/livenesspb",
+        "//pkg/multitenant/tenantcapabilities",
         "//pkg/roachpb",
         "//pkg/security",
         "//pkg/security/password",

--- a/pkg/ccl/serverccl/admin_test.go
+++ b/pkg/ccl/serverccl/admin_test.go
@@ -136,7 +136,7 @@ func TestAdminAPIJobs(t *testing.T) {
 	defer s.Stopper().Stop(context.Background())
 	sqlDB := sqlutils.MakeSQLRunner(conn)
 
-	sqlDB.Exec(t, `BACKUP INTO 'nodelocal://0/backup/1?AWS_SECRET_ACCESS_KEY=neverappears'`)
+	sqlDB.Exec(t, `BACKUP INTO 'nodelocal://1/backup/1?AWS_SECRET_ACCESS_KEY=neverappears'`)
 
 	var jobsRes serverpb.JobsResponse
 	err := getAdminJSONProto(s, "jobs", &jobsRes)

--- a/pkg/ccl/serverccl/server_controller_test.go
+++ b/pkg/ccl/serverccl/server_controller_test.go
@@ -11,6 +11,7 @@ package serverccl
 import (
 	"bytes"
 	"context"
+	gosql "database/sql"
 	"fmt"
 	"io"
 	"net/http"
@@ -20,6 +21,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/multitenant/tenantcapabilities"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/server"
 	"github.com/cockroachdb/cockroach/pkg/server/serverpb"
@@ -28,6 +30,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
+	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util/httputil"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -36,6 +39,88 @@ import (
 	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/require"
 )
+
+func TestSharedProcessTenantNodeLocalAccess(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+	nodeCount := 3
+
+	dirs := make([]string, nodeCount)
+	dirCleanups := make([]func(), nodeCount)
+	for i := 0; i < nodeCount; i++ {
+		dir, dirCleanupFn := testutils.TempDir(t)
+		dirs[i] = dir
+		dirCleanups[i] = dirCleanupFn
+	}
+
+	defer func() {
+		for _, fn := range dirCleanups {
+			fn()
+		}
+	}()
+
+	tc := serverutils.StartNewTestCluster(t, nodeCount, base.TestClusterArgs{
+		ServerArgs: base.TestServerArgs{DisableDefaultTestTenant: true},
+		ServerArgsPerNode: map[int]base.TestServerArgs{
+			0: {
+				DisableDefaultTestTenant: true,
+				ExternalIODir:            dirs[0],
+			},
+			1: {
+				DisableDefaultTestTenant: true,
+				ExternalIODir:            dirs[1],
+			},
+			2: {
+				DisableDefaultTestTenant: true,
+				ExternalIODir:            dirs[2],
+			},
+		},
+	})
+	defer tc.Stopper().Stop(ctx)
+
+	db := sqlutils.MakeSQLRunner(tc.ServerConn(0))
+	db.Exec(t, `CREATE TENANT application;
+ALTER TENANT application GRANT CAPABILITY can_use_nodelocal_storage;
+ALTER TENANT application START SERVICE SHARED`)
+
+	var tenantID uint64
+	db.QueryRow(t, "SELECT id FROM [SHOW TENANT application]").Scan(&tenantID)
+	tc.WaitForTenantCapabilities(t, roachpb.MustMakeTenantID(tenantID), map[tenantcapabilities.ID]string{
+		tenantcapabilities.CanUseNodelocalStorage: "true",
+	})
+
+	// Wait for tenant to start up on all nodes.
+	tenantConns := make([]*gosql.DB, nodeCount)
+	testutils.SucceedsSoon(t, func() error {
+		for i := 0; i < nodeCount; i++ {
+			if tenantConns[i] != nil {
+				continue
+			}
+
+			sqlAddr := tc.Server(i).ServingSQLAddr()
+			db, err := serverutils.OpenDBConnE(sqlAddr, "cluster:application", false, tc.Stopper())
+			if err != nil {
+				return err
+			}
+			if err := db.Ping(); err != nil {
+				return err
+			}
+			tenantConns[i] = db
+		}
+		return nil
+	})
+
+	for srcNodeIdx := 1; srcNodeIdx <= nodeCount; srcNodeIdx++ {
+		for destNodeIdx := 2; destNodeIdx <= nodeCount; destNodeIdx++ {
+			destURI := fmt.Sprintf("nodelocal://%d/from-%d-to-%d", destNodeIdx, srcNodeIdx, destNodeIdx)
+			query := fmt.Sprintf("SELECT crdb_internal.write_file('abc', '%s')", destURI)
+			_, err := tenantConns[srcNodeIdx-1].Exec(query)
+			require.NoError(t, err)
+		}
+	}
+}
 
 func TestServerControllerHTTP(t *testing.T) {
 	defer leaktest.AfterTest(t)()

--- a/pkg/ccl/telemetryccl/testdata/telemetry/multiregion
+++ b/pkg/ccl/telemetryccl/testdata/telemetry/multiregion
@@ -381,11 +381,11 @@ INSERT INTO t7 VALUES (1),(2),(3);
 ----
 
 exec
-EXPORT INTO CSV 'nodelocal://0/t7' FROM TABLE t7;
+EXPORT INTO CSV 'nodelocal://1/t7' FROM TABLE t7;
 ----
 
 feature-usage
-IMPORT INTO t7 CSV DATA ('nodelocal://0/t7/export*.csv')
+IMPORT INTO t7 CSV DATA ('nodelocal://1/t7/export*.csv')
 ----
 sql.multiregion.import
 

--- a/pkg/ccl/testccl/workload/schemachange/schema_change_external_test.go
+++ b/pkg/ccl/testccl/workload/schemachange/schema_change_external_test.go
@@ -76,7 +76,7 @@ func TestWorkload(t *testing.T) {
 		}
 		printRows(tdb.Query(t, "SELECT id, encode(descriptor, 'hex') FROM system.descriptor"))
 		printRows(tdb.Query(t, "SELECT * FROM system.namespace"))
-		tdb.Exec(t, "BACKUP DATABASE schemachange TO 'nodelocal://0/backup'")
+		tdb.Exec(t, "BACKUP DATABASE schemachange TO 'nodelocal://1/backup'")
 		t.Logf("backup in %s", dir)
 	}()
 

--- a/pkg/ccl/utilccl/sampledataccl/bankdata.go
+++ b/pkg/ccl/utilccl/sampledataccl/bankdata.go
@@ -53,7 +53,7 @@ func toBackup(
 		}
 	}
 
-	if _, err := db.Exec("BACKUP DATABASE data TO $1", "nodelocal://0/"+path); err != nil {
+	if _, err := db.Exec("BACKUP DATABASE data TO $1", "nodelocal://1/"+path); err != nil {
 		return nil, err
 	}
 	return &Backup{BaseDir: filepath.Join(externalIODir, path)}, nil

--- a/pkg/cloud/nodelocal/nodelocal_storage.go
+++ b/pkg/cloud/nodelocal/nodelocal_storage.go
@@ -104,7 +104,7 @@ var LocalRequiresExternalIOAccounting = false
 // MakeLocalStorageURI converts a local path (should always be relative) to a
 // valid nodelocal URI.
 func MakeLocalStorageURI(path string) string {
-	return fmt.Sprintf("nodelocal://0/%s", path)
+	return fmt.Sprintf("nodelocal://1/%s", path)
 }
 
 func makeLocalFileStorage(

--- a/pkg/cloud/nodelocal/nodelocal_storage_test.go
+++ b/pkg/cloud/nodelocal/nodelocal_storage_test.go
@@ -32,7 +32,7 @@ func TestPutLocal(t *testing.T) {
 
 	cloudtestutils.CheckExportStore(
 		t, dest, false, username.RootUserName(), nil /* db */, testSettings)
-	url := "nodelocal://0/listing-test/basepath"
+	url := "nodelocal://1/listing-test/basepath"
 	cloudtestutils.CheckListFiles(
 		t, url, username.RootUserName(), nil /*db */, testSettings,
 	)

--- a/pkg/cmd/roachtest/tests/versionupgrade.go
+++ b/pkg/cmd/roachtest/tests/versionupgrade.go
@@ -113,7 +113,7 @@ func runVersionUpgrade(ctx context.Context, t test.Test, c cluster.Cluster) {
 		// Verify that backups can be created in various configurations. This is
 		// important to test because changes in system tables might cause backups to
 		// fail in mixed-version clusters.
-		dest := fmt.Sprintf("nodelocal://0/%d", timeutil.Now().UnixNano())
+		dest := fmt.Sprintf("nodelocal://1/%d", timeutil.Now().UnixNano())
 		return h.Exec(rng, `BACKUP TO $1`, dest)
 	})
 	mvt.InMixedVersion(

--- a/pkg/kv/kvserver/tenantrate/limiter_test.go
+++ b/pkg/kv/kvserver/tenantrate/limiter_test.go
@@ -684,6 +684,16 @@ func (ts *testState) HasTSDBQueryCapability(_ context.Context, tenID roachpb.Ten
 	}
 }
 
+func (ts *testState) HasNodelocalStorageCapability(
+	_ context.Context, tenID roachpb.TenantID,
+) error {
+	if ts.capabilities[tenID].CanUseNodelocalStorage {
+		return nil
+	} else {
+		return errors.New("unauthorized")
+	}
+}
+
 func (ts *testState) IsExemptFromRateLimiting(_ context.Context, tenID roachpb.TenantID) bool {
 	return ts.capabilities[tenID].ExemptFromRateLimiting
 }

--- a/pkg/multitenant/tenantcapabilities/capabilities.go
+++ b/pkg/multitenant/tenantcapabilities/capabilities.go
@@ -54,6 +54,10 @@ const (
 	// cluster.
 	CanAdminUnsplit // can_admin_unsplit
 
+	// CanUseNodelocalStorage allows the tenant to access the
+	// nodelocal storage service on the KV nodes.
+	CanUseNodelocalStorage // can_use_nodelocal_storage
+
 	// CanViewNodeInfo describes the ability of a tenant to read the
 	// metadata for KV nodes. These operations need a capability because
 	// the KV node record contains sensitive operational data which we
@@ -112,6 +116,7 @@ var capabilities = [MaxCapabilityID + 1]Capability{
 	CanAdminScatter:        boolCapability(CanAdminScatter),
 	CanAdminSplit:          boolCapability(CanAdminSplit),
 	CanAdminUnsplit:        boolCapability(CanAdminUnsplit),
+	CanUseNodelocalStorage: boolCapability(CanUseNodelocalStorage),
 	CanViewNodeInfo:        boolCapability(CanViewNodeInfo),
 	CanViewTSDBMetrics:     boolCapability(CanViewTSDBMetrics),
 	ExemptFromRateLimiting: boolCapability(ExemptFromRateLimiting),

--- a/pkg/multitenant/tenantcapabilities/id_string.go
+++ b/pkg/multitenant/tenantcapabilities/id_string.go
@@ -12,16 +12,17 @@ func _() {
 	_ = x[CanAdminScatter-2]
 	_ = x[CanAdminSplit-3]
 	_ = x[CanAdminUnsplit-4]
-	_ = x[CanViewNodeInfo-5]
-	_ = x[CanViewTSDBMetrics-6]
-	_ = x[ExemptFromRateLimiting-7]
-	_ = x[TenantSpanConfigBounds-8]
-	_ = x[MaxCapabilityID-8]
+	_ = x[CanUseNodelocalStorage-5]
+	_ = x[CanViewNodeInfo-6]
+	_ = x[CanViewTSDBMetrics-7]
+	_ = x[ExemptFromRateLimiting-8]
+	_ = x[TenantSpanConfigBounds-9]
+	_ = x[MaxCapabilityID-9]
 }
 
-const _ID_name = "can_admin_relocate_rangecan_admin_scattercan_admin_splitcan_admin_unsplitcan_view_node_infocan_view_tsdb_metricsexempt_from_rate_limitingspan_config_bounds"
+const _ID_name = "can_admin_relocate_rangecan_admin_scattercan_admin_splitcan_admin_unsplitcan_use_nodelocal_storagecan_view_node_infocan_view_tsdb_metricsexempt_from_rate_limitingspan_config_bounds"
 
-var _ID_index = [...]uint8{0, 24, 41, 56, 73, 91, 112, 137, 155}
+var _ID_index = [...]uint8{0, 24, 41, 56, 73, 98, 116, 137, 162, 180}
 
 func (i ID) String() string {
 	i -= 1

--- a/pkg/multitenant/tenantcapabilities/interfaces.go
+++ b/pkg/multitenant/tenantcapabilities/interfaces.go
@@ -58,6 +58,11 @@ type Authorizer interface {
 	// is not allowed to access cluster-level node metadata and liveness.
 	HasNodeStatusCapability(ctx context.Context, tenID roachpb.TenantID) error
 
+	// HasNodelocalStorageCapability returns an error if a tenant,
+	// referenced by its ID, is not allowed to use the nodelocal
+	// storage service.
+	HasNodelocalStorageCapability(ctx context.Context, tenID roachpb.TenantID) error
+
 	// HasTSDBQueryCapability returns an error if a tenant, referenced by its ID,
 	// is not allowed to query the TSDB for metrics.
 	HasTSDBQueryCapability(ctx context.Context, tenID roachpb.TenantID) error

--- a/pkg/multitenant/tenantcapabilities/tenantcapabilitiesauthorizer/authorizer.go
+++ b/pkg/multitenant/tenantcapabilities/tenantcapabilitiesauthorizer/authorizer.go
@@ -226,6 +226,27 @@ func (a *Authorizer) HasTSDBQueryCapability(ctx context.Context, tenID roachpb.T
 	return nil
 }
 
+func (a *Authorizer) HasNodelocalStorageCapability(
+	ctx context.Context, tenID roachpb.TenantID,
+) error {
+	if a.elideCapabilityChecks(ctx, tenID) {
+		return nil
+	}
+	cp, found := a.capabilitiesReader.GetCapabilities(tenID)
+	if !found {
+		log.Infof(ctx,
+			"no capability information for tenant %s; requests that require capabilities may be denied",
+			tenID,
+		)
+	}
+	if !found || !tenantcapabilities.MustGetBoolByID(
+		cp, tenantcapabilities.CanUseNodelocalStorage,
+	) {
+		return errors.Newf("client tenant does not have capability to use nodelocal storage")
+	}
+	return nil
+}
+
 // elideCapabilityChecks returns true if capability checks should be skipped for
 // the supplied tenant.
 func (a *Authorizer) elideCapabilityChecks(ctx context.Context, tenID roachpb.TenantID) bool {

--- a/pkg/multitenant/tenantcapabilities/tenantcapabilitiesauthorizer/noop.go
+++ b/pkg/multitenant/tenantcapabilities/tenantcapabilitiesauthorizer/noop.go
@@ -51,6 +51,13 @@ func (n *NoopAuthorizer) HasTSDBQueryCapability(ctx context.Context, tenID roach
 	return nil
 }
 
+// HasNodelocalStorageCapability implements the tenantcapabilities.Authorizer interface
+func (n *NoopAuthorizer) HasNodelocalStorageCapability(
+	ctx context.Context, tenID roachpb.TenantID,
+) error {
+	return nil
+}
+
 // IsExemptFromRateLimiting implements the tenantcapabilities.Authorizer interface
 func (n *NoopAuthorizer) IsExemptFromRateLimiting(context.Context, roachpb.TenantID) bool {
 	return false

--- a/pkg/multitenant/tenantcapabilities/tenantcapabilitiespb/capabilities.proto
+++ b/pkg/multitenant/tenantcapabilities/tenantcapabilitiespb/capabilities.proto
@@ -84,6 +84,10 @@ message TenantCapabilities {
   // ExemptFromRateLimiting, if set to true, exempts the tenant from the KV-side tenant
   // rate limiter.
   bool exempt_from_rate_limiting = 8;
+
+  // CanUseNodelocalStorage if set to true, grants the tenant the ability
+  // to use nodelocal storage  on any KV node.
+  bool can_use_nodelocal_storage = 9;
 };
 
 // SpanConfigBound is used to constrain the possible values a SpanConfig may

--- a/pkg/multitenant/tenantcapabilities/values.go
+++ b/pkg/multitenant/tenantcapabilities/values.go
@@ -44,6 +44,8 @@ func GetValueByID(t *tenantcapabilitiespb.TenantCapabilities, id ID) (Value, err
 		return (*invertedBoolValue)(&t.DisableAdminSplit), nil
 	case CanAdminUnsplit:
 		return (*boolValue)(&t.CanAdminUnsplit), nil
+	case CanUseNodelocalStorage:
+		return (*boolValue)(&t.CanUseNodelocalStorage), nil
 	case CanViewNodeInfo:
 		return (*boolValue)(&t.CanViewNodeInfo), nil
 	case CanViewTSDBMetrics:

--- a/pkg/rpc/auth_tenant.go
+++ b/pkg/rpc/auth_tenant.go
@@ -158,6 +158,13 @@ func (a tenantAuthorizer) authorize(
 	case "/cockroach.ts.tspb.TimeSeries/Query":
 		return a.authTSDBQuery(ctx, tenID, req.(*tspb.TimeSeriesQueryRequest))
 
+	case "/cockroach.blobs.Blob/List",
+		"/cockroach.blobs.Blob/Delete",
+		"/cockroach.blobs.Blob/Stat",
+		"/cockroach.blobs.Blob/GetStream",
+		"/cockroach.blobs.Blob/PutStream":
+		return a.capabilitiesAuthorizer.HasNodelocalStorageCapability(ctx, tenID)
+
 	default:
 		return authErrorf("unknown method %q", fullMethod)
 	}

--- a/pkg/rpc/auth_test.go
+++ b/pkg/rpc/auth_test.go
@@ -950,6 +950,7 @@ type mockAuthorizer struct {
 	hasCapabilityForBatch              bool
 	hasNodestatusCapability            bool
 	hasTSDBQueryCapability             bool
+	hasNodelocalStorageCapability      bool
 	hasExemptFromRateLimiterCapability bool
 }
 
@@ -979,6 +980,15 @@ func (m mockAuthorizer) HasNodeStatusCapability(ctx context.Context, tenID roach
 
 func (m mockAuthorizer) HasTSDBQueryCapability(ctx context.Context, tenID roachpb.TenantID) error {
 	if m.hasTSDBQueryCapability {
+		return nil
+	}
+	return errors.New("tenant does not have capability")
+}
+
+func (m mockAuthorizer) HasNodelocalStorageCapability(
+	ctx context.Context, tenID roachpb.TenantID,
+) error {
+	if m.hasNodelocalStorageCapability {
 		return nil
 	}
 	return errors.New("tenant does not have capability")

--- a/pkg/server/BUILD.bazel
+++ b/pkg/server/BUILD.bazel
@@ -262,6 +262,7 @@ go_library(
         "//pkg/storage",
         "//pkg/storage/enginepb",
         "//pkg/storage/fs",
+        "//pkg/testutils",
         "//pkg/testutils/serverutils",
         "//pkg/ts",
         "//pkg/ts/catalog",

--- a/pkg/server/external_storage_builder.go
+++ b/pkg/server/external_storage_builder.go
@@ -47,9 +47,10 @@ func (e *externalStorageBuilder) init(
 	ctx context.Context,
 	conf base.ExternalIODirConfig,
 	settings *cluster.Settings,
-	nodeIDContainer *base.NodeIDContainer,
+	nodeIDContainer *base.SQLIDContainer,
 	nodeDialer *nodedialer.Dialer,
 	testingKnobs base.TestingKnobs,
+	allowLocalFastpath bool,
 	db isql.DB,
 	recorder multitenant.TenantSideExternalIORecorder,
 	registry *metric.Registry,
@@ -59,7 +60,7 @@ func (e *externalStorageBuilder) init(
 		blobClientFactory = p.BlobClientFactory
 	}
 	if blobClientFactory == nil {
-		blobClientFactory = blobs.NewBlobClientFactory(nodeIDContainer, nodeDialer, settings.ExternalIODir)
+		blobClientFactory = blobs.NewBlobClientFactory(nodeIDContainer, nodeDialer, settings.ExternalIODir, allowLocalFastpath)
 	}
 	e.conf = conf
 	e.settings = settings

--- a/pkg/server/server_controller_new_server.go
+++ b/pkg/server/server_controller_new_server.go
@@ -338,7 +338,7 @@ func makeSharedProcessTenantServerConfig(
 
 	sqlCfg = MakeSQLConfig(tenantID, tempStorageCfg)
 
-	// Split for each tenant, see https://github.com/cockroachdb/cockroach/issues/84588.
+	baseCfg.Settings.ExternalIODir = kvServerCfg.BaseConfig.Settings.ExternalIODir
 	sqlCfg.ExternalIODirConfig = kvServerCfg.SQLConfig.ExternalIODirConfig
 
 	// Use the internal connector instead of the network.

--- a/pkg/server/server_sql.go
+++ b/pkg/server/server_sql.go
@@ -21,8 +21,6 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
-	"github.com/cockroachdb/cockroach/pkg/blobs"
-	"github.com/cockroachdb/cockroach/pkg/blobs/blobspb"
 	"github.com/cockroachdb/cockroach/pkg/cloud"
 	"github.com/cockroachdb/cockroach/pkg/cloud/externalconn"
 	"github.com/cockroachdb/cockroach/pkg/clusterversion"
@@ -157,7 +155,6 @@ type SQLServer struct {
 	internalExecutor *sql.InternalExecutor
 	internalDB       descs.DB
 	leaseMgr         *lease.Manager
-	blobService      *blobs.Service
 	tracingService   *service.Service
 	tenantConnect    kvtenant.Connector
 	// sessionRegistry can be queried for info on running SQL sessions. It is
@@ -534,13 +531,6 @@ func newSQLServer(ctx context.Context, cfg sqlServerArgs) (*SQLServer, error) {
 		}
 	}
 
-	// Create blob service for inter-node file sharing.
-	blobService, err := blobs.NewBlobService(cfg.Settings.ExternalIODir)
-	if err != nil {
-		return nil, errors.Wrap(err, "creating blob service")
-	}
-	blobspb.RegisterBlobServer(cfg.grpcServer, blobService)
-
 	if err := cfg.stopper.RunAsyncTask(ctx, "tracer-snapshots", func(context.Context) {
 		cfg.Tracer.PeriodicSnapshotsLoop(&cfg.Settings.SV, cfg.stopper.ShouldQuiesce())
 	}); err != nil {
@@ -597,7 +587,7 @@ func newSQLServer(ctx context.Context, cfg sqlServerArgs) (*SQLServer, error) {
 		cfg.db,
 	)
 
-	// We can't use the nodeDailer as the podNodeDailer unless we
+	// We can't use the nodeDialer as the podNodeDialer unless we
 	// are serving the system tenant despite the fact that we've
 	// arranged for pod IDs and instance IDs to match since the
 	// secondary tenant gRPC servers currently live on a different
@@ -1368,7 +1358,6 @@ func newSQLServer(ctx context.Context, cfg sqlServerArgs) (*SQLServer, error) {
 		internalExecutor:               cfg.circularInternalExecutor,
 		internalDB:                     cfg.internalDB,
 		leaseMgr:                       leaseMgr,
-		blobService:                    blobService,
 		tracingService:                 tracingService,
 		tenantConnect:                  cfg.tenantConnect,
 		sessionRegistry:                cfg.sessionRegistry,

--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -25,7 +25,7 @@ import (
 	"github.com/cenkalti/backoff"
 	circuit "github.com/cockroachdb/circuitbreaker"
 	"github.com/cockroachdb/cockroach/pkg/base"
-	"github.com/cockroachdb/cockroach/pkg/blobs"
+	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/config"
 	"github.com/cockroachdb/cockroach/pkg/config/zonepb"
 	"github.com/cockroachdb/cockroach/pkg/gossip"
@@ -37,6 +37,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/liveness"
+	"github.com/cockroachdb/cockroach/pkg/multitenant/tenantcapabilities"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/rpc"
 	"github.com/cockroachdb/cockroach/pkg/security/certnames"
@@ -51,6 +52,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
 	"github.com/cockroachdb/cockroach/pkg/storage"
+	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/ts"
 	"github.com/cockroachdb/cockroach/pkg/upgrade/upgradebase"
@@ -566,7 +568,7 @@ func (ts *TestServer) maybeStartDefaultTestTenant(ctx context.Context) error {
 	// Since we're creating a tenant, it doesn't make sense to pass through the
 	// Server testing knobs, since the bulk of them only apply to the system
 	// tenant. Any remaining knobs which are required by the tenant should be
-	// setup in StartTenant below (like the BlobClientFactory).
+	// setup in StartTenant below.
 	params.TestingKnobs.Server = &TestingKnobs{}
 
 	tenant, err := ts.StartTenant(ctx, params)
@@ -924,8 +926,10 @@ func (ts *TestServer) StartTenant(
 	ctx context.Context, params base.TestTenantArgs,
 ) (serverutils.TestTenantInterface, error) {
 	// Determine if we need to create the tenant before starting it.
+
+	ie := ts.InternalExecutor().(*sql.InternalExecutor)
 	if !params.DisableCreateTenant {
-		rowCount, err := ts.InternalExecutor().(*sql.InternalExecutor).Exec(
+		rowCount, err := ie.Exec(
 			ctx, "testserver-check-tenant-active", nil,
 			"SELECT 1 FROM system.tenants WHERE id=$1 AND active=true",
 			params.TenantID.ToUint64(),
@@ -935,14 +939,14 @@ func (ts *TestServer) StartTenant(
 		}
 		if rowCount == 0 {
 			// Tenant doesn't exist. Create it.
-			if _, err := ts.InternalExecutor().(*sql.InternalExecutor).Exec(
+			if _, err := ie.Exec(
 				ctx, "testserver-create-tenant", nil /* txn */, "SELECT crdb_internal.create_tenant($1, $2)",
 				params.TenantID.ToUint64(), params.TenantName,
 			); err != nil {
 				return nil, err
 			}
 		} else if params.TenantName != "" {
-			_, err := ts.InternalExecutor().(*sql.InternalExecutor).Exec(ctx, "rename-test-tenant", nil,
+			_, err := ie.Exec(ctx, "rename-test-tenant", nil,
 				`ALTER TENANT [$1] RENAME TO $2`,
 				params.TenantID.ToUint64(), params.TenantName)
 			if err != nil {
@@ -954,7 +958,7 @@ func (ts *TestServer) StartTenant(
 		if params.TenantID.IsSet() {
 			requestedID = params.TenantID.ToUint64()
 		}
-		rows, err := ts.InternalExecutor().(*sql.InternalExecutor).QueryBuffered(
+		rows, err := ie.QueryBuffered(
 			ctx, "testserver-check-tenant-active", nil,
 			"SELECT id, name FROM system.tenants WHERE ($1 <> 0 AND id=$1) OR ($2 <> '' AND name = $2) AND active=true",
 			requestedID, string(params.TenantName),
@@ -1054,25 +1058,36 @@ func (ts *TestServer) StartTenant(
 	baseCfg.DisableTLSForHTTP = params.DisableTLSForHTTP
 	baseCfg.EnableDemoLoginEndpoint = params.EnableDemoLoginEndpoint
 
+	if st.Version.IsActive(ctx, clusterversion.V23_1TenantCapabilities) {
+		_, err := ie.Exec(ctx, "testserver-alter-tenant-cap", nil,
+			"ALTER TENANT [$1] GRANT CAPABILITY can_use_nodelocal_storage", params.TenantID.ToUint64())
+		if err != nil {
+			if params.SkipTenantCheck {
+				log.Infof(ctx, "ignoring error granting capability because SkipTenantCheck is true: %v", err)
+			} else {
+				return nil, err
+			}
+		} else {
+			if err := testutils.SucceedsSoonError(func() error {
+				capabilities, found := ts.TenantCapabilitiesReader().GetCapabilities(params.TenantID)
+				if !found {
+					return errors.Newf("capabilities not yet ready")
+				}
+				if !tenantcapabilities.MustGetBoolByID(
+					capabilities, tenantcapabilities.CanUseNodelocalStorage,
+				) {
+					return errors.Newf("capabilities not yet ready")
+				}
+				return nil
+			}); err != nil {
+				return nil, err
+			}
+		}
+	}
+
 	// For now, we don't support split RPC/SQL ports for secondary tenants
 	// in test servers.
 	baseCfg.SplitListenSQL = true
-
-	localNodeIDContainer := &base.NodeIDContainer{}
-	localNodeIDContainer.Set(ctx, ts.NodeID())
-	blobClientFactory := blobs.NewBlobClientFactory(
-		localNodeIDContainer,
-		ts.Server.nodeDialer,
-		params.ExternalIODir,
-	)
-	tk := &baseCfg.TestingKnobs
-	if serverKnobs, ok := tk.Server.(*TestingKnobs); ok {
-		serverKnobs.BlobClientFactory = blobClientFactory
-	} else {
-		tk.Server = &TestingKnobs{
-			BlobClientFactory: blobClientFactory,
-		}
-	}
 
 	if params.SSLCertsDir != "" {
 		baseCfg.SSLCertsDir = params.SSLCertsDir

--- a/pkg/sql/importer/csv_testdata_helpers_test.go
+++ b/pkg/sql/importer/csv_testdata_helpers_test.go
@@ -104,20 +104,20 @@ func getTestFiles(numFiles int) csvTestFiles {
 		suffix = "-race"
 	}
 	for i := 0; i < numFiles; i++ {
-		testFiles.files = append(testFiles.files, fmt.Sprintf(`'nodelocal://0/%s'`, fmt.Sprintf("data-%d%s", i, suffix)+"?nonsecret=nosecrets"))
-		testFiles.gzipFiles = append(testFiles.gzipFiles, fmt.Sprintf(`'nodelocal://0/%s'`, fmt.Sprintf("data-%d%s.gz", i, suffix)+"?AWS_SESSION_TOKEN=secrets"))
-		testFiles.bzipFiles = append(testFiles.bzipFiles, fmt.Sprintf(`'nodelocal://0/%s'`, fmt.Sprintf("data-%d%s.bz2", i, suffix)))
-		testFiles.filesWithOpts = append(testFiles.filesWithOpts, fmt.Sprintf(`'nodelocal://0/%s'`, fmt.Sprintf("data-%d-opts%s", i, suffix)))
-		testFiles.filesWithDups = append(testFiles.filesWithDups, fmt.Sprintf(`'nodelocal://0/%s'`, fmt.Sprintf("data-%d-dup%s", i, suffix)))
+		testFiles.files = append(testFiles.files, fmt.Sprintf(`'nodelocal://1/%s'`, fmt.Sprintf("data-%d%s", i, suffix)+"?nonsecret=nosecrets"))
+		testFiles.gzipFiles = append(testFiles.gzipFiles, fmt.Sprintf(`'nodelocal://1/%s'`, fmt.Sprintf("data-%d%s.gz", i, suffix)+"?AWS_SESSION_TOKEN=secrets"))
+		testFiles.bzipFiles = append(testFiles.bzipFiles, fmt.Sprintf(`'nodelocal://1/%s'`, fmt.Sprintf("data-%d%s.bz2", i, suffix)))
+		testFiles.filesWithOpts = append(testFiles.filesWithOpts, fmt.Sprintf(`'nodelocal://1/%s'`, fmt.Sprintf("data-%d-opts%s", i, suffix)))
+		testFiles.filesWithDups = append(testFiles.filesWithDups, fmt.Sprintf(`'nodelocal://1/%s'`, fmt.Sprintf("data-%d-dup%s", i, suffix)))
 	}
 
-	testFiles.fileWithDupKeySameValue = append(testFiles.fileWithDupKeySameValue, fmt.Sprintf(`'nodelocal://0/%s'`, fmt.Sprintf("dup-key-same-value%s", suffix)))
-	testFiles.fileWithShadowKeys = append(testFiles.fileWithShadowKeys, fmt.Sprintf(`'nodelocal://0/%s'`, fmt.Sprintf("shadow-data%s", suffix)))
+	testFiles.fileWithDupKeySameValue = append(testFiles.fileWithDupKeySameValue, fmt.Sprintf(`'nodelocal://1/%s'`, fmt.Sprintf("dup-key-same-value%s", suffix)))
+	testFiles.fileWithShadowKeys = append(testFiles.fileWithShadowKeys, fmt.Sprintf(`'nodelocal://1/%s'`, fmt.Sprintf("shadow-data%s", suffix)))
 
 	wildcardFileName := "data-[0-9]"
-	testFiles.filesUsingWildcard = append(testFiles.filesUsingWildcard, fmt.Sprintf(`'nodelocal://0/%s%s'`, wildcardFileName, suffix))
-	testFiles.gzipFilesUsingWildcard = append(testFiles.gzipFilesUsingWildcard, fmt.Sprintf(`'nodelocal://0/%s%s.gz'`, wildcardFileName, suffix))
-	testFiles.bzipFilesUsingWildcard = append(testFiles.gzipFilesUsingWildcard, fmt.Sprintf(`'nodelocal://0/%s%s.bz2'`, wildcardFileName, suffix))
+	testFiles.filesUsingWildcard = append(testFiles.filesUsingWildcard, fmt.Sprintf(`'nodelocal://1/%s%s'`, wildcardFileName, suffix))
+	testFiles.gzipFilesUsingWildcard = append(testFiles.gzipFilesUsingWildcard, fmt.Sprintf(`'nodelocal://1/%s%s.gz'`, wildcardFileName, suffix))
+	testFiles.bzipFilesUsingWildcard = append(testFiles.gzipFilesUsingWildcard, fmt.Sprintf(`'nodelocal://1/%s%s.bz2'`, wildcardFileName, suffix))
 
 	return testFiles
 }

--- a/pkg/sql/importer/exportparquet_test.go
+++ b/pkg/sql/importer/exportparquet_test.go
@@ -278,7 +278,7 @@ func TestRandomParquetExports(t *testing.T) {
 		filePrefix: "outputfile",
 		dbName:     dbName,
 		dir:        dir,
-		stmt: fmt.Sprintf("EXPORT INTO PARQUET 'nodelocal://0/outputfile' FROM SELECT * FROM %s",
+		stmt: fmt.Sprintf("EXPORT INTO PARQUET 'nodelocal://1/outputfile' FROM SELECT * FROM %s",
 			tree.NameString(tableName)),
 	}
 	sqlDB.Exec(t, test.stmt)
@@ -320,22 +320,22 @@ INDEX (y))`)
 	tests := []parquetTest{
 		{
 			filePrefix: "basic",
-			stmt: `EXPORT INTO PARQUET 'nodelocal://0/basic' FROM SELECT *
+			stmt: `EXPORT INTO PARQUET 'nodelocal://1/basic' FROM SELECT *
 							FROM foo WHERE y IS NOT NULL ORDER BY y ASC LIMIT 2 `,
 		},
 		{
 			filePrefix: "null_vals",
-			stmt: `EXPORT INTO PARQUET 'nodelocal://0/null_vals' FROM SELECT *
+			stmt: `EXPORT INTO PARQUET 'nodelocal://1/null_vals' FROM SELECT *
 							FROM foo ORDER BY x ASC LIMIT 2`,
 		},
 		{
 			filePrefix: "colname",
-			stmt: `EXPORT INTO PARQUET 'nodelocal://0/colname' FROM SELECT avg(z), min(y) AS baz
+			stmt: `EXPORT INTO PARQUET 'nodelocal://1/colname' FROM SELECT avg(z), min(y) AS baz
 							FROM foo`,
 		},
 		{
 			filePrefix: "nullable",
-			stmt: `EXPORT INTO PARQUET 'nodelocal://0/nullable' FROM SELECT y,z,x
+			stmt: `EXPORT INTO PARQUET 'nodelocal://1/nullable' FROM SELECT y,z,x
 							FROM foo`,
 			colFieldRepType: []parquet.FieldRepetitionType{
 				parquet.FieldRepetitionType_OPTIONAL,
@@ -353,7 +353,7 @@ INDEX (y))`)
 				"CREATE TABLE atable (i INT PRIMARY KEY, x INT[])",
 				"INSERT INTO atable VALUES (1, ARRAY[1,2]), (2, ARRAY[2]), (3,ARRAY[1,13,5]),(4, NULL),(5, ARRAY[])",
 			},
-			stmt: `EXPORT INTO PARQUET 'nodelocal://0/arrays' FROM SELECT * FROM atable`,
+			stmt: `EXPORT INTO PARQUET 'nodelocal://1/arrays' FROM SELECT * FROM atable`,
 		},
 		{
 			filePrefix: "user_types",
@@ -362,7 +362,7 @@ INDEX (y))`)
 				"CREATE TABLE greeting_table (x greeting, y greeting)",
 				"INSERT INTO greeting_table VALUES ('hello', 'hello'), ('hi', 'hi')",
 			},
-			stmt: `EXPORT INTO PARQUET 'nodelocal://0/user_types' FROM SELECT * FROM greeting_table`,
+			stmt: `EXPORT INTO PARQUET 'nodelocal://1/user_types' FROM SELECT * FROM greeting_table`,
 		},
 		{
 			filePrefix: "collate",
@@ -370,7 +370,7 @@ INDEX (y))`)
 				"CREATE TABLE de_names (name STRING COLLATE de PRIMARY KEY)",
 				"INSERT INTO de_names VALUES ('Backhaus' COLLATE de), ('Bär' COLLATE de), ('Baz' COLLATE de)",
 			},
-			stmt: `EXPORT INTO PARQUET 'nodelocal://0/collate' FROM SELECT * FROM de_names ORDER BY name`,
+			stmt: `EXPORT INTO PARQUET 'nodelocal://1/collate' FROM SELECT * FROM de_names ORDER BY name`,
 		},
 		{
 			filePrefix: "ints_floats",
@@ -378,23 +378,23 @@ INDEX (y))`)
 				"CREATE TABLE nums (int_2 INT2, int_4 INT4, int_8 INT8, real_0 FLOAT4, double_0 FLOAT8)",
 				"INSERT INTO nums VALUES (2, 2, 2, 2.107109308242798, 2.107109308242798)",
 			},
-			stmt: `EXPORT INTO PARQUET 'nodelocal://0/ints_floats' FROM SELECT * FROM nums`,
+			stmt: `EXPORT INTO PARQUET 'nodelocal://1/ints_floats' FROM SELECT * FROM nums`,
 		},
 		{
 			filePrefix: "compress_gzip",
 			fileSuffix: ".gz",
-			stmt: `EXPORT INTO PARQUET 'nodelocal://0/compress_gzip' WITH compression = gzip
+			stmt: `EXPORT INTO PARQUET 'nodelocal://1/compress_gzip' WITH compression = gzip
 							FROM SELECT * FROM foo`,
 		},
 		{
 			filePrefix: "compress_snappy",
 			fileSuffix: ".snappy",
-			stmt: `EXPORT INTO PARQUET 'nodelocal://0/compress_snappy' WITH compression = snappy
+			stmt: `EXPORT INTO PARQUET 'nodelocal://1/compress_snappy' WITH compression = snappy
 							FROM SELECT * FROM foo `,
 		},
 		{
 			filePrefix: "uncompress",
-			stmt: `EXPORT INTO PARQUET 'nodelocal://0/uncompress'
+			stmt: `EXPORT INTO PARQUET 'nodelocal://1/uncompress'
 							FROM SELECT * FROM foo `,
 		},
 	}

--- a/pkg/sql/importer/read_import_base_test.go
+++ b/pkg/sql/importer/read_import_base_test.go
@@ -43,8 +43,8 @@ func TestRejectedFilename(t *testing.T) {
 		},
 		{
 			name:     "nodelocal",
-			fname:    "nodelocal://0/file.csv",
-			rejected: "nodelocal://0/file.csv.rejected",
+			fname:    "nodelocal://1/file.csv",
+			rejected: "nodelocal://1/file.csv.rejected",
 		},
 	}
 	for _, tc := range tests {

--- a/pkg/util/grpcutil/fast_metadata.go
+++ b/pkg/util/grpcutil/fast_metadata.go
@@ -43,6 +43,21 @@ func ClearIncomingContext(ctx context.Context) context.Context {
 	return ctx
 }
 
+// ClearIncomingContextExcept removes the gRPC incoming metadata if
+// there is any, except for metadata items identified by the given
+// keys.
+func ClearIncomingContextExcept(ctx context.Context, keys ...string) context.Context {
+	oldMD, ok := metadata.FromIncomingContext(ctx)
+	if !ok {
+		return ClearIncomingContext(ctx)
+	}
+	newMD := metadata.New(nil)
+	for _, k := range keys {
+		newMD[k] = oldMD.Get(k)
+	}
+	return metadata.NewIncomingContext(ctx, newMD)
+}
+
 // FastFirstValueFromIncomingContext is a specialization of
 // metadata.ValueFromIncomingContext() which extracts the first string
 // from the given metadata key, if it exists. No extra objects are

--- a/pkg/util/grpcutil/fast_metadata_test.go
+++ b/pkg/util/grpcutil/fast_metadata_test.go
@@ -34,6 +34,28 @@ func TestFastFromIncomingContext(t *testing.T) {
 	require.Equal(t, v, "world")
 }
 
+func TestClearIncomingContextExcept(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	md := metadata.MD{
+		"hello":   []string{"world", "universe"},
+		"goodbye": []string{"sweet prince", "moon"},
+	}
+
+	ctx := metadata.NewIncomingContext(context.Background(), md)
+
+	ctx2 := ClearIncomingContextExcept(ctx, "goodbye")
+	md2, ok := FastFromIncomingContext(ctx2)
+	require.True(t, ok)
+
+	_, ok = md2["hello"]
+	require.False(t, ok)
+
+	_, ok = md2["goodbye"]
+	require.True(t, ok)
+	require.Equal(t, md["goodbye"], md2["goodbye"])
+}
+
 func BenchmarkFromIncomingContext(b *testing.B) {
 	md := metadata.MD{"hello": []string{"world", "universe"}}
 	ctx := metadata.NewIncomingContext(context.Background(), md)


### PR DESCRIPTION
This allows shared-process tenant servers to use node local storage.

In the future, we likely want to put this behind a tenant capability.

Fixes #77986
Fixes #84588.

Release note: None