### PR TITLE
sql,multitenant: add support for granting span_config_bounds

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/tenant_capability
+++ b/pkg/ccl/logictestccl/testdata/logic_test/tenant_capability
@@ -5,19 +5,19 @@ subtest grant_revoke_error
 statement ok
 CREATE TENANT "grant-revoke-error-tenant";
 
-statement error unknown capability: "not_a_capability"
+statement error pgcode 42601 unknown capability: "not_a_capability"
 ALTER TENANT "grant-revoke-error-tenant" GRANT CAPABILITY not_a_capability=true
 
-statement error argument of ALTER TENANT CAPABILITY can_admin_split must be type bool, not type int
+statement error pgcode 42804 argument of ALTER TENANT CAPABILITY can_admin_split must be type bool, not type int
 ALTER TENANT "grant-revoke-error-tenant" GRANT CAPABILITY can_admin_split=1
 
-statement error parameter "can_admin_split" requires a Boolean value
+statement error pgcode 22023 parameter "can_admin_split" requires a Boolean value
 ALTER TENANT "grant-revoke-error-tenant" GRANT CAPABILITY can_admin_split=NULL
 
-statement error unknown capability: "not_a_capability"
+statement error pgcode 42601 unknown capability: "not_a_capability"
 ALTER TENANT "grant-revoke-error-tenant" REVOKE CAPABILITY not_a_capability
 
-statement error no value allowed in revoke: "can_admin_split"
+statement error pgcode 42601 no value allowed in revoke: "can_admin_split"
 ALTER TENANT "grant-revoke-error-tenant" REVOKE CAPABILITY can_admin_split=false
 
 subtest end
@@ -128,5 +128,68 @@ capability_name        capability_value
 can_admin_split        false
 can_view_node_info     false
 can_view_tsdb_metrics  false
+
+subtest end
+
+subtest span_config_bounds
+
+statement ok
+CREATE TENANT scb;
+
+# Test that you can't REVOKE span_config_bounds. The reason is that it'd be
+# confusing; removing the bounds is like setting the capability to be a
+# wildcard. That's hardly REVOKE-ing anything.
+
+statement error pgcode 22023 cannot REVOKE CAPABILITY "span_config_bounds"
+ALTER TENANT scb REVOKE CAPABILITY span_config_bounds;
+
+statement ok
+ALTER TENANT scb GRANT CAPABILITY span_config_bounds = crdb_internal.json_to_pb(
+    'cockroach.multitenant.tenantcapabilitiespb.SpanConfigBounds',
+    '{"gcTtlSeconds": {"start": 60, "end":600}, "rangeMaxBytes": {"start": 100, "end":200}}'
+)
+
+# Observe the side-effect.
+
+query TT colnames
+SELECT capability_name, capability_value FROM [SHOW TENANT scb WITH CAPABILITIES]
+----
+capability_name        capability_value
+can_admin_split        false
+can_view_node_info     false
+can_view_tsdb_metrics  false
+span_config_bounds     {
+                           "gcTtlSeconds": {
+                               "end": 600,
+                               "start": 60
+                           },
+                           "rangeMaxBytes": {
+                               "end": "200",
+                               "start": "100"
+                           }
+                       }
+
+# Ensure that you can set the bounds to NULL, which means there now are no
+# bounds.
+
+statement ok
+ALTER TENANT scb GRANT CAPABILITY span_config_bounds = NULL;
+
+query TT colnames
+SELECT capability_name, capability_value FROM [SHOW TENANT scb WITH CAPABILITIES]
+----
+capability_name        capability_value
+can_admin_split        false
+can_view_node_info     false
+can_view_tsdb_metrics  false
+
+# Check that there are appropriate errors for invalid types, malformed and
+# malformed data.
+
+statement error pgcode 22023 invalid "span_config_bounds" value
+ALTER TENANT scb GRANT CAPABILITY span_config_bounds = x'01ab';
+
+statement error pgcode 42804 argument of ALTER TENANT CAPABILITY span_config_bounds must be type bytes, not type bool
+ALTER TENANT scb GRANT CAPABILITY span_config_bounds = false;
 
 subtest end

--- a/pkg/multitenant/tenantcapabilities/tenantcapabilitiespb/BUILD.bazel
+++ b/pkg/multitenant/tenantcapabilities/tenantcapabilitiespb/BUILD.bazel
@@ -36,7 +36,10 @@ go_library(
     embed = [":tenantcapabilitiespb_go_proto"],
     importpath = "github.com/cockroachdb/cockroach/pkg/multitenant/tenantcapabilities/tenantcapabilitiespb",
     visibility = ["//visibility:public"],
-    deps = ["@com_github_cockroachdb_errors//:errors"],
+    deps = [
+        "@com_github_cockroachdb_errors//:errors",
+        "@com_github_cockroachdb_redact//:redact",
+    ],
 )
 
 stringer(

--- a/pkg/multitenant/tenantcapabilities/tenantcapabilitiespb/capabilities.go
+++ b/pkg/multitenant/tenantcapabilities/tenantcapabilitiespb/capabilities.go
@@ -10,10 +10,18 @@
 
 package tenantcapabilitiespb
 
-import "github.com/cockroachdb/errors"
+import (
+	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/redact"
+)
 
 // TenantCapabilityName is a pseudo-enum of valid capability names.
 type TenantCapabilityName int32
+
+var _ redact.SafeValue = TenantCapabilityName(0)
+
+// SafeValue makes TenantCapabilityName a redact.SafeValue.
+func (t TenantCapabilityName) SafeValue() {}
 
 // IsSet returns true if the capability name has a non-zero value.
 func (t TenantCapabilityName) IsSet() bool {

--- a/pkg/multitenant/tenantcapabilities/tenantcapabilitiespb/capabilities.proto
+++ b/pkg/multitenant/tenantcapabilities/tenantcapabilitiespb/capabilities.proto
@@ -64,8 +64,6 @@ message TenantCapabilities {
 message SpanConfigBounds {
   option (gogoproto.equal) = true;
 
-
-
   // GcTtlSeconds bounds the configuration of gc.ttl_seconds.
   Int32Range gc_ttl_seconds = 1 [(gogoproto.customname) = "GCTTLSeconds"];
 

--- a/pkg/sql/BUILD.bazel
+++ b/pkg/sql/BUILD.bazel
@@ -343,6 +343,7 @@ go_library(
         "//pkg/settings",
         "//pkg/settings/cluster",
         "//pkg/spanconfig",
+        "//pkg/spanconfig/spanconfigbounds",
         "//pkg/sql/appstatspb",
         "//pkg/sql/backfill",
         "//pkg/sql/catalog",

--- a/pkg/testutils/lint/passes/redactcheck/redactcheck.go
+++ b/pkg/testutils/lint/passes/redactcheck/redactcheck.go
@@ -92,6 +92,9 @@ func runAnalyzer(pass *analysis.Pass) (interface{}, error) {
 					"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverpb": {
 						"SnapshotRequest_Type": {},
 					},
+					"github.com/cockroachdb/cockroach/pkg/multitenant/tenantcapabilities/tenantcapabilitiespb": {
+						"TenantCapabilityName": {},
+					},
 					"github.com/cockroachdb/cockroach/pkg/repstream/streampb": {
 						"StreamID": {},
 					},


### PR DESCRIPTION
This commit adds SQL support for `ALTER TENANT ... GRANT CAPABILITY span_config_bounds`. The capability takes a bytes value which is an encoded protobuf. The existence of the `crdb_internal.json_to_pb` builtin makes interacting with this value more straightforward and valuable.

The PR also adds logic to display the capability in `SHOW TENANTS WITH CAPABILITIES`

Informs #99911.
Epic: CRDB-16706

Release note: None