### PR TITLE
sql: fix `destroy_tenant`

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/tenant_builtins
+++ b/pkg/sql/logictest/testdata/logic_test/tenant_builtins
@@ -12,6 +12,10 @@ SELECT crdb_internal.create_tenant(5)
 ----
 5
 
+# Verify that DROP TENANT is blocked when the service is not NONE.
+statement error cannot drop tenant.*in service mode external
+DROP TENANT [5]
+
 # create_tenant auto-sets the service for backward-compatibility.
 # Reset it here so the tests below don't get confused.
 statement ok
@@ -245,3 +249,19 @@ DROP TENANT [1]
 
 statement error only users with the admin role are allowed to gc tenant
 SELECT crdb_internal.gc_tenant(314)
+
+subtest regression_97873
+
+user root
+
+# Verify that destroy_tenant works even in the default service mode,
+# for compatibility with CC serverless.
+query I
+SELECT crdb_internal.create_tenant(97873)
+----
+97873
+
+query I
+SELECT crdb_internal.destroy_tenant(97873)
+----
+97873

--- a/pkg/sql/tenant_deletion.go
+++ b/pkg/sql/tenant_deletion.go
@@ -83,9 +83,16 @@ func dropTenantInternal(
 	}
 
 	if settings.Version.IsActive(ctx, clusterversion.V23_1TenantNamesStateAndServiceMode) {
+		if ignoreServiceMode {
+			// Compatibility with CC serverless use of
+			// crdb_internal.destroy_tenant(): we want to disable the check
+			// immediately below, as well as the additional check performed
+			// inside UpdateTenantRecord() (via validateTenantInfo).
+			info.ServiceMode = mtinfopb.ServiceModeNone
+		}
 		// We can only check the service mode after upgrading to a version
 		// that supports the service mode column.
-		if !ignoreServiceMode && info.ServiceMode != mtinfopb.ServiceModeNone {
+		if info.ServiceMode != mtinfopb.ServiceModeNone {
 			return errors.WithHint(pgerror.Newf(pgcode.ObjectNotInPrerequisiteState,
 				"cannot drop tenant %q (%d) in service mode %v", info.Name, tenID, info.ServiceMode),
 				"Use ALTER TENANT STOP SERVICE before DROP TENANT.")


### PR DESCRIPTION
Fixes #97873.

We aimed in #95691 to preserve compatibility with the previous semantics of `destroy_tenant()`, but we failed to do so and there was no test to tell us about the mistake.

This commit fixes both.

Release note: None