### PR TITLE
roachtest/awsdms: upgrade parameter group

### DIFF
--- a/pkg/cmd/roachtest/tests/awsdms.go
+++ b/pkg/cmd/roachtest/tests/awsdms.go
@@ -612,7 +612,7 @@ func setupRDSCluster(
 		rdsGroup, err := rdsCli.CreateDBClusterParameterGroup(
 			ctx,
 			&rds.CreateDBClusterParameterGroupInput{
-				DBParameterGroupFamily:      proto.String("aurora-postgresql13"),
+				DBParameterGroupFamily:      proto.String("aurora-postgresql14"),
 				DBClusterParameterGroupName: proto.String(awsdmsRoachtestDMSParameterGroup(t.BuildVersion())),
 				Description:                 proto.String("roachtest awsdms parameter groups"),
 			},


### PR DESCRIPTION
This commit updates the parameter group we use for the rds from postgresql13 to postgresql14.

Fixes: #98121
Release note: None