### PR TITLE
insights transactions: undefined (reading 'length')

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsights/util/queriesCell.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsights/util/queriesCell.tsx
@@ -20,6 +20,10 @@ export function QueriesCell(
   transactionQueries: string[],
   textLimit: number,
 ): React.ReactElement {
+  // Filter out null or undefined values from array
+  if (transactionQueries) {
+    transactionQueries = transactionQueries.filter(x => x);
+  }
   if (
     !transactionQueries?.length ||
     (transactionQueries.length === 1 &&

--- a/pkg/ui/workspaces/cluster-ui/src/util/format.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/util/format.ts
@@ -229,6 +229,9 @@ export function Count(count: number): string {
 
 // limitText returns a shortened form of text that surpasses a given limit
 export const limitText = (text: string, limit: number): string => {
+  if (!text) {
+    return "";
+  }
   return text?.length > limit ? text.slice(0, limit - 3).concat("...") : text;
 };
 
@@ -238,7 +241,13 @@ export const limitStringArray = (arr: string[], limit: number): string => {
     return "";
   }
 
-  if (arr.length == 1 || arr[0].length > limit) {
+  // Remove null and undefined entries in the array.
+  arr = arr.filter(n => n);
+  if (arr.length == 0) {
+    return "";
+  }
+
+  if (arr.length == 1 || arr[0]?.length > limit) {
     return limitText(arr[0], limit);
   }
 


### PR DESCRIPTION
Fixes an issue where if the first query string is null or undefined it will cause the page to fail.

Error:
ErrorBoundary::componentDidCatch] error =  TypeError: Cannot read properties of undefined (reading 'length')

Epic: none
Closes: #98188

Release note (ui change): Fixes the `Cannot read properties of undefined (reading 'length')`` error which can cause pages to fail to load.

Release justification: bug fix