### PR TITLE
release-22.2: ui: add check for adminUI

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/package.json
+++ b/pkg/ui/workspaces/cluster-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cockroachlabs/cluster-ui",
-  "version": "22.2.8",
+  "version": "22.2.9",
   "description": "Cluster UI is a library of large features shared between CockroachDB and CockroachCloud",
   "repository": {
     "type": "git",

--- a/pkg/ui/workspaces/cluster-ui/src/indexDetailsPage/indexDetails.selectors.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/indexDetailsPage/indexDetails.selectors.ts
@@ -37,7 +37,7 @@ export const selectIndexDetails = createSelector(
     getMatchParamByName(props.match, tableNameAttr),
   (_state: AppState, props: RouteComponentProps): string =>
     getMatchParamByName(props.match, indexNameAttr),
-  (state: AppState) => state.adminUI.indexStats.cachedData,
+  (state: AppState) => state.adminUI?.indexStats.cachedData,
   (state: AppState) => selectIsTenant(state),
   (state: AppState) => selectHasAdminRole(state),
   (

--- a/pkg/ui/workspaces/cluster-ui/src/selectors/activeExecutions.selectors.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/selectors/activeExecutions.selectors.ts
@@ -24,10 +24,10 @@ import {
 // pages that are specific to cluster-ui.
 // They should NOT be exported with the cluster-ui package.
 
-const selectSessions = (state: AppState) => state.adminUI.sessions?.data;
+const selectSessions = (state: AppState) => state.adminUI?.sessions?.data;
 
 const selectClusterLocks = (state: AppState) =>
-  state.adminUI.clusterLocks?.data;
+  state.adminUI?.clusterLocks?.data;
 
 export const selectActiveExecutions = createSelector(
   selectSessions,
@@ -80,7 +80,7 @@ export const selectContentionDetailsForStatement = createSelector(
 );
 
 export const selectAppName = createSelector(
-  (state: AppState) => state.adminUI.sessions,
+  (state: AppState) => state.adminUI?.sessions,
   response => {
     if (!response.data) return null;
     return response.data.internal_app_name_prefix;

--- a/pkg/ui/workspaces/cluster-ui/src/sessions/sessionDetailsConnected.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/sessions/sessionDetailsConnected.tsx
@@ -31,7 +31,7 @@ export const SessionDetailsPageConnected = withRouter(
     (state: AppState, props: RouteComponentProps) => ({
       nodeNames: nodeDisplayNameByIDSelector(state),
       session: selectSession(state, props),
-      sessionError: state.adminUI.sessions.lastError,
+      sessionError: state.adminUI?.sessions.lastError,
       uiConfig: selectSessionDetailsUiConfig(state),
       isTenant: selectIsTenant(state),
     }),

--- a/pkg/ui/workspaces/cluster-ui/src/sessions/sessionsPageConnected.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/sessions/sessionsPageConnected.tsx
@@ -34,7 +34,7 @@ export const selectSessionsData = createSelector(
 );
 
 export const selectSessions = createSelector(
-  (state: AppState) => state.adminUI.sessions,
+  (state: AppState) => state.adminUI?.sessions,
   (state: SessionsState) => {
     if (!state.data) {
       return null;
@@ -46,7 +46,7 @@ export const selectSessions = createSelector(
 );
 
 export const selectAppName = createSelector(
-  (state: AppState) => state.adminUI.sessions,
+  (state: AppState) => state.adminUI?.sessions,
   (state: SessionsState) => {
     if (!state.data) {
       return null;
@@ -56,7 +56,7 @@ export const selectAppName = createSelector(
 );
 
 export const selectSortSetting = createSelector(
-  (state: AppState) => state.adminUI.localStorage,
+  (state: AppState) => state.adminUI?.localStorage,
   localStorage => localStorage["sortSetting/SessionsPage"],
 );
 
@@ -78,7 +78,7 @@ export const SessionsPageConnected = withRouter(
     (state: AppState, props: RouteComponentProps) => ({
       sessions: selectSessions(state),
       internalAppNamePrefix: selectAppName(state),
-      sessionsError: state.adminUI.sessions.lastError,
+      sessionsError: state.adminUI?.sessions.lastError,
       sortSetting: selectSortSetting(state),
       columns: selectColumns(state),
       filters: selectFilters(state),

--- a/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetails.selectors.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetails.selectors.ts
@@ -33,7 +33,7 @@ export const selectStatementDetails = createSelector(
   (_state: AppState, props: RouteComponentProps): string =>
     queryByName(props.location, appNamesAttr),
   (state: AppState): TimeScale => selectTimeScale(state),
-  (state: AppState) => state.adminUI.sqlDetailsStats.cachedData,
+  (state: AppState) => state.adminUI?.sqlDetailsStats.cachedData,
   (
     fingerprintID,
     appNames,
@@ -75,6 +75,6 @@ export const selectStatementDetails = createSelector(
 );
 
 export const selectStatementDetailsUiConfig = createSelector(
-  (state: AppState) => state.adminUI.uiConfig.pages.statementDetails,
+  (state: AppState) => state.adminUI?.uiConfig.pages.statementDetails,
   statementDetailsUiConfig => statementDetailsUiConfig,
 );

--- a/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetailsConnected.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetailsConnected.ts
@@ -64,8 +64,8 @@ const mapStateToProps = (state: AppState, props: RouteComponentProps) => {
     statementFingerprintID: getMatchParamByName(props.match, statementAttr),
     statementDetails,
     isLoading: isLoading,
-    latestQuery: state.adminUI.sqlDetailsStats.latestQuery,
-    latestFormattedQuery: state.adminUI.sqlDetailsStats.latestFormattedQuery,
+    latestQuery: state.adminUI?.sqlDetailsStats.latestQuery,
+    latestFormattedQuery: state.adminUI?.sqlDetailsStats.latestFormattedQuery,
     statementsError: lastError,
     lastUpdated: lastUpdated,
     timeScale: selectTimeScale(state),
@@ -76,7 +76,7 @@ const mapStateToProps = (state: AppState, props: RouteComponentProps) => {
         ? []
         : selectDiagnosticsReportsByStatementFingerprint(
             state,
-            state.adminUI.sqlDetailsStats.latestQuery,
+            state.adminUI?.sqlDetailsStats.latestQuery,
           ),
     uiConfig: selectStatementDetailsUiConfig(state),
     isTenant: selectIsTenant(state),

--- a/pkg/ui/workspaces/cluster-ui/src/statementsPage/activeStatementsPage.selectors.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsPage/activeStatementsPage.selectors.ts
@@ -50,7 +50,7 @@ export const mapStateToActiveStatementsPageProps = (
   state: AppState,
 ): ActiveStatementsViewStateProps => ({
   statements: selectActiveStatements(state),
-  sessionsError: state.adminUI.sessions.lastError,
+  sessionsError: state.adminUI?.sessions.lastError,
   selectedColumns: selectColumns(state),
   sortSetting: selectSortSetting(state),
   filters: selectFilters(state),

--- a/pkg/ui/workspaces/cluster-ui/src/store/insightDetails/transactionInsightDetails/transactionInsightDetails.selectors.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/store/insightDetails/transactionInsightDetails/transactionInsightDetails.selectors.ts
@@ -13,7 +13,7 @@ import { AppState } from "src/store/reducers";
 import { selectID } from "src/selectors/common";
 
 const selectTransactionInsightDetailsState = createSelector(
-  (state: AppState) => state.adminUI.transactionInsightDetails.cachedData,
+  (state: AppState) => state.adminUI?.transactionInsightDetails.cachedData,
   selectID,
   (cachedTxnInsightDetails, execId) => {
     return cachedTxnInsightDetails[execId];

--- a/pkg/ui/workspaces/cluster-ui/src/store/insights/statementInsights/statementInsights.selectors.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/store/insights/statementInsights/statementInsights.selectors.ts
@@ -18,15 +18,15 @@ import {
 } from "src/selectors/insightsCommon.selectors";
 import { selectID } from "src/selectors/common";
 export const selectStatementInsights = createSelector(
-  (state: AppState) => state.adminUI.statementInsights?.data?.results,
+  (state: AppState) => state.adminUI?.statementInsights?.data?.results,
   selectStatementInsightsCombiner,
 );
 
 export const selectStatementInsightsError = (state: AppState) =>
-  state.adminUI.statementInsights?.lastError;
+  state.adminUI?.statementInsights?.lastError;
 
 export const selectStmtInsightsMaxApiReached = (state: AppState): boolean =>
-  !!state.adminUI.statementInsights?.data?.maxSizeReached;
+  !!state.adminUI?.statementInsights?.data?.maxSizeReached;
 
 export const selectStatementInsightDetails = createSelector(
   selectStatementInsights,

--- a/pkg/ui/workspaces/cluster-ui/src/store/liveness/liveness.selectors.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/store/liveness/liveness.selectors.ts
@@ -11,7 +11,7 @@
 import { createSelector } from "@reduxjs/toolkit";
 import { AppState } from "../reducers";
 
-const livenessesSelector = (state: AppState) => state.adminUI.liveness.data;
+const livenessesSelector = (state: AppState) => state.adminUI?.liveness.data;
 
 export const livenessStatusByNodeIDSelector = createSelector(
   livenessesSelector,

--- a/pkg/ui/workspaces/cluster-ui/src/store/nodes/nodes.selectors.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/store/nodes/nodes.selectors.ts
@@ -18,7 +18,7 @@ import { cockroach } from "@cockroachlabs/crdb-protobuf-client";
 type ILocality = cockroach.roachpb.ILocality;
 
 export const nodeStatusesSelector = (state: AppState) =>
-  state.adminUI.nodes.data || [];
+  state.adminUI?.nodes.data || [];
 
 export const nodesSelector = createSelector(
   nodeStatusesSelector,

--- a/pkg/ui/workspaces/cluster-ui/src/store/sessions/sessions.selectors.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/store/sessions/sessions.selectors.ts
@@ -17,7 +17,7 @@ import { getMatchParamByName } from "src/util/query";
 import { byteArrayToUuid } from "src/sessions/sessionsTable";
 
 export const selectSession = createSelector(
-  (state: AppState) => state.adminUI.sessions,
+  (state: AppState) => state.adminUI?.sessions,
   (_state: AppState, props: RouteComponentProps) => props,
   (state: SessionsState, props: RouteComponentProps<any>) => {
     if (!state.data) {
@@ -33,6 +33,6 @@ export const selectSession = createSelector(
 );
 
 export const selectSessionDetailsUiConfig = createSelector(
-  (state: AppState) => state.adminUI.uiConfig.pages.sessionDetails,
+  (state: AppState) => state.adminUI?.uiConfig.pages.sessionDetails,
   statementDetailsUiConfig => statementDetailsUiConfig,
 );

--- a/pkg/ui/workspaces/cluster-ui/src/store/uiConfig/uiConfig.selector.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/store/uiConfig/uiConfig.selector.ts
@@ -12,7 +12,7 @@ import { createSelector } from "reselect";
 import { AppState } from "../reducers";
 
 export const selectUIConfig = createSelector(
-  (state: AppState) => state.adminUI.uiConfig,
+  (state: AppState) => state.adminUI?.uiConfig,
   uiConfig => uiConfig,
 );
 

--- a/pkg/ui/workspaces/cluster-ui/src/store/utils/selectors.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/store/utils/selectors.ts
@@ -18,5 +18,5 @@ export const adminUISelector = createSelector(
 
 export const localStorageSelector = createSelector(
   adminUISelector,
-  adminUiState => adminUiState.localStorage,
+  adminUiState => adminUiState?.localStorage,
 );

--- a/pkg/ui/workspaces/cluster-ui/src/transactionsPage/activeTransactionsPage.selectors.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionsPage/activeTransactionsPage.selectors.tsx
@@ -50,7 +50,7 @@ export const mapStateToActiveTransactionsPageProps = (
   state: AppState,
 ): ActiveTransactionsViewStateProps => ({
   transactions: selectActiveTransactions(state),
-  sessionsError: state.adminUI.sessions.lastError,
+  sessionsError: state.adminUI?.sessions.lastError,
   selectedColumns: selectColumns(state),
   sortSetting: selectSortSetting(state),
   filters: selectFilters(state),


### PR DESCRIPTION
Backport 1/1 commits from #98189.

/cc @cockroachdb/release

---

If is the first time the user opens the console,
the `adminUI` might not yet be created, so we need to add a check to all its usages so the page doesn't crash.

Epic: None

Release note: None

---
Release justification: bug fix
