### PR TITLE
ui: show normalized CPU Usage metric on Node Map

### DIFF
--- a/pkg/ui/workspaces/db-console/ccl/src/views/clusterviz/containers/map/cpuSparkline.tsx
+++ b/pkg/ui/workspaces/db-console/ccl/src/views/clusterviz/containers/map/cpuSparkline.tsx
@@ -23,8 +23,10 @@ export function CpuSparkline(props: CpuSparklineProps) {
   return (
     <MetricsDataProvider id={key}>
       <SparklineMetricsDataComponent formatCurrentValue={d3.format(".1%")}>
-        <Metric name="cr.node.sys.cpu.sys.percent" sources={props.nodes} />
-        <Metric name="cr.node.sys.cpu.user.percent" sources={props.nodes} />
+        <Metric
+          name="cr.node.sys.cpu.combined.percent-normalized"
+          sources={props.nodes}
+        />
       </SparklineMetricsDataComponent>
     </MetricsDataProvider>
   );


### PR DESCRIPTION
Before, Node map (on Overview page) displayed current system and user CPU usage 
that didn't represent the same data as CPU Percent metric on Metrics page.
Now, Node Map displays the same metric to provide users consistent information.

Release note (admin ui, bug fix): show normalized CPU usage on Node Map.
Resolve: #87664