### PR TITLE
copy: make sure to commit if autocommit during exec is off

### DIFF
--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -2725,12 +2725,6 @@ func (ex *connExecutor) execCopyIn(
 			ex.resetPlanner(ctx, p, txn, stmtTS)
 		},
 	}
-	// If COPY is not atomic, then each batch must manage the txn state.
-	if ex.implicitTxn() && !ex.sessionData().CopyFromAtomicEnabled {
-		txnOpt.resetExtraTxnState = func(ctx context.Context) {
-			ex.resetExtraTxnState(ctx, txnEvent{eventType: noEvent})
-		}
-	}
 
 	ex.setCopyLoggingFields(cmd.ParsedStmt)
 

--- a/pkg/sql/copy_from.go
+++ b/pkg/sql/copy_from.go
@@ -358,10 +358,6 @@ type copyTxnOpt struct {
 	stmtTimestamp time.Time
 	initPlanner   func(ctx context.Context, p *planner)
 	resetPlanner  func(ctx context.Context, p *planner, txn *kv.Txn, txnTS time.Time, stmtTS time.Time)
-
-	// resetExtraTxnState should be called upon completing a batch from the copy
-	// machine when the copy machine handles its own transaction.
-	resetExtraTxnState func(ctx context.Context)
 }
 
 func (c *copyMachine) Close(ctx context.Context) {
@@ -802,27 +798,20 @@ func (c *copyMachine) readBinarySignature() ([]byte, error) {
 func (p *planner) preparePlannerForCopy(
 	ctx context.Context, txnOpt *copyTxnOpt, finalBatch bool, implicitTxn bool,
 ) func(context.Context, error) error {
-	autoCommit := false
+	autoCommit := implicitTxn
 	txnOpt.resetPlanner(ctx, p, txnOpt.txn, txnOpt.txnTimestamp, txnOpt.stmtTimestamp)
 	if implicitTxn {
 		if p.SessionData().CopyFromAtomicEnabled {
 			// If the COPY should be atomic, only the final batch can commit.
 			autoCommit = finalBatch
-		} else {
-			// Otherwise we do the original behavior of committing each batch.
-			autoCommit = true
 		}
 	}
-	p.autoCommit = autoCommit
+	p.autoCommit = autoCommit && !p.execCfg.TestingKnobs.DisableAutoCommitDuringExec
 
 	return func(ctx context.Context, prevErr error) (err error) {
-		// Ensure that we clean up any accumulated extraTxnState state if we've
-		// been handed a mechanism to do so.
-		// If this is the finalBatch, then the connExecutor state machine takes
-		// care of this cleanup.
-		if implicitTxn && !p.SessionData().CopyFromAtomicEnabled && !finalBatch {
-			defer txnOpt.resetExtraTxnState(ctx)
-
+		// Ensure that we commit the transaction if atomic copy is off. If it's on,
+		// the conn executor will commit the transaction.
+		if implicitTxn && !p.SessionData().CopyFromAtomicEnabled {
 			if prevErr == nil {
 				// Ensure that the txn is committed if the copyMachine is in charge of
 				// committing its transactions and the execution didn't already commit it


### PR DESCRIPTION
This fixes two issues:
- The planner.autoCommit flag was ignoring the corresponding testing knob for COPY.
- If non-atomic COPY is being used, it needs to commit the final batch if the 1PC commit did not occur.

We can also simplify some of the management of the extra txn state.

No release note since this bug was not released.

fixes https://github.com/cockroachdb/cockroach/issues/98182
fixes https://github.com/cockroachdb/cockroach/issues/98185

Release note: None