### PR TITLE
spanconfig: add basic rate limiter to calls to SpanConfigConformance

### DIFF
--- a/pkg/spanconfig/spanconfigreporter/BUILD.bazel
+++ b/pkg/spanconfig/spanconfigreporter/BUILD.bazel
@@ -16,6 +16,7 @@ go_library(
         "//pkg/settings",
         "//pkg/settings/cluster",
         "//pkg/spanconfig",
+        "//pkg/util/quotapool",
         "//pkg/util/rangedesc",
         "@com_github_cockroachdb_errors//:errors",
     ],


### PR DESCRIPTION
This commit introduces a basic rate limiter to prevent excessive resource usage. The current limit is 1 request per second. Future iterations may consider tenant-level fairness, or some integration with admission control.

Addresses: #96683
Epic: CRDB-10630
Release note: None

Results of `ab`:
`ab -m POST -n 20 -c 20 http://localhost:3000/_status/critical_nodes `

```
This is ApacheBench, Version 2.3 <$Revision: 1843412 $>
Copyright 1996 Adam Twiss, Zeus Technology Ltd, http://www.zeustech.net/
Licensed to The Apache Software Foundation, http://www.apache.org/

Benchmarking localhost (be patient).....done


Server Software:        
Server Hostname:        localhost
Server Port:            3000

Document Path:          /_status/critical_nodes
Document Length:        209 bytes

Concurrency Level:      20
Time taken for tests:   19.017 seconds
Complete requests:      20
Failed requests:        0
Total transferred:      9080 bytes
HTML transferred:       4180 bytes
Requests per second:    1.05 [#/sec] (mean)
Time per request:       19016.737 [ms] (mean)
Time per request:       950.837 [ms] (mean, across all concurrent requests)
Transfer rate:          0.47 [Kbytes/sec] received

Connection Times (ms)
              min  mean[+/-sd] median   max
Connect:        0    0   0.1      0       0
Processing:     7 9505 5918.0  10003   19009
Waiting:        6 9504 5918.1  10003   19009
Total:          8 9505 5918.0  10004   19009

Percentage of the requests served within a certain time (ms)
  50%  10004
  66%  13005
  75%  15007
  80%  16007
  90%  18008
  95%  19009
  98%  19009
  99%  19009
 100%  19009 (longest request)


```


