### PR TITLE
changefeedccl: check enterprise license for core changefeeds with expressions

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_stmt.go
+++ b/pkg/ccl/changefeedccl/changefeed_stmt.go
@@ -590,7 +590,7 @@ func createChangefeedJobRecord(
 			p.ExecCfg().Settings, p.ExecCfg().NodeInfo.LogicalClusterID(), "CHANGEFEED",
 		); err != nil {
 			return nil, errors.Wrapf(err,
-				"use of %q option requires enterprise license.", changefeedbase.OptMetricsScope)
+				"use of %q option requires an enterprise license.", changefeedbase.OptMetricsScope)
 		}
 
 		if scope == defaultSLIScope {
@@ -613,6 +613,15 @@ func createChangefeedJobRecord(
 	}
 
 	if details.SinkURI == `` {
+
+		if details.Select != `` {
+			if err := utilccl.CheckEnterpriseEnabled(
+				p.ExecCfg().Settings, p.ExecCfg().NodeInfo.LogicalClusterID(), "CHANGEFEED",
+			); err != nil {
+				return nil, errors.Wrap(err, "use of AS SELECT requires an enterprise license.")
+			}
+		}
+
 		details.Opts = opts.AsMap()
 		// Jobs should not be created for sinkless changefeeds. However, note that
 		// we create and return a job record for sinkless changefeeds below. This is

--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -4371,6 +4371,10 @@ func TestChangefeedErrors(t *testing.T) {
 		t, `CHANGEFEED requires an enterprise license`,
 		`CREATE CHANGEFEED FOR foo INTO $1`, `kafka://nope`,
 	)
+	sqlDB.ExpectErr(
+		t, `use of AS SELECT requires an enterprise license`,
+		`CREATE CHANGEFEED AS SELECT * FROM foo`,
+	)
 	enableEnterprise()
 
 	// Watching system.jobs would create a cycle, since the resolved timestamp


### PR DESCRIPTION
This PR adds an enterprise license check when
running a sinkless changefeed with a SELECT clause, per a recent decision. To avoid running it twice,
we specifically check it in the sinkless branch.

Closes #97371.

Release note (enterprise change): Sinkless changefeeds that use the AS SELECT syntax now require an enterprise license.