### PR TITLE
roachtest: add an option to create nodes with low memory per core

### DIFF
--- a/pkg/cmd/roachtest/spec/machine_type.go
+++ b/pkg/cmd/roachtest/spec/machine_type.go
@@ -12,13 +12,16 @@ package spec
 
 import "fmt"
 
-// AWSMachineType selects a machine type given the desired number of CPUs.
-func AWSMachineType(cpus int, highmem bool) string {
+// AWSMachineType selects a machine type given the desired number of CPUs and
+// memory per CPU ratio.
+func AWSMachineType(cpus int, mem MemPerCPU) string {
 	// TODO(erikgrinaker): These have significantly less RAM than
 	// their GCE counterparts. Consider harmonizing them.
 	family := "c5d" // 2 GB RAM per CPU
-	if highmem {
+	if mem == High {
 		family = "m5d" // 4 GB RAM per CPU
+	} else if mem == Low {
+		panic("low memory per CPU not available for AWS")
 	}
 
 	var size string
@@ -49,26 +52,37 @@ func AWSMachineType(cpus int, highmem bool) string {
 	return fmt.Sprintf("%s.%s", family, size)
 }
 
-// GCEMachineType selects a machine type given the desired number of CPUs.
-func GCEMachineType(cpus int, highmem bool) string {
+// GCEMachineType selects a machine type given the desired number of CPUs and
+// memory per CPU ratio.
+func GCEMachineType(cpus int, mem MemPerCPU) string {
 	// TODO(peter): This is awkward: at or below 16 cpus, use n1-standard so that
 	// the machines have a decent amount of RAM. We could use custom machine
 	// configurations, but the rules for the amount of RAM per CPU need to be
 	// determined (you can't request any arbitrary amount of RAM).
 	series := "n1"
-	kind := "standard" // 3.75 GB RAM per CPU
-	if highmem {
+	var kind string
+	switch mem {
+	case Auto:
+		if cpus > 16 {
+			kind = "highcpu"
+		} else {
+			kind = "standard"
+		}
+	case Standard:
+		kind = "standard" // 3.75 GB RAM per CPU
+	case High:
 		kind = "highmem" // 6.5 GB RAM per CPU
-	} else if cpus > 16 {
+	case Low:
 		kind = "highcpu" // 0.9 GB RAM per CPU
 	}
 	return fmt.Sprintf("%s-%s-%d", series, kind, cpus)
 }
 
-// AzureMachineType selects a machine type given the desired number of CPUs.
-func AzureMachineType(cpus int, highmem bool) string {
-	if highmem {
-		panic("highmem not implemented for Azure")
+// AzureMachineType selects a machine type given the desired number of CPUs and
+// memory per CPU ratio.
+func AzureMachineType(cpus int, mem MemPerCPU) string {
+	if mem != Auto && mem != Standard {
+		panic(fmt.Sprintf("custom memory per CPU not implemented for Azure, memory ratio requested: %d", mem))
 	}
 	switch {
 	case cpus <= 2:

--- a/pkg/cmd/roachtest/spec/option.go
+++ b/pkg/cmd/roachtest/spec/option.go
@@ -28,15 +28,15 @@ func CPU(n int) Option {
 	return nodeCPUOption(n)
 }
 
-type nodeHighMemOption bool
+type nodeMemOption MemPerCPU
 
-func (o nodeHighMemOption) apply(spec *ClusterSpec) {
-	spec.HighMem = bool(o)
+func (o nodeMemOption) apply(spec *ClusterSpec) {
+	spec.Mem = MemPerCPU(o)
 }
 
-// HighMem requests nodes with additional memory per CPU.
-func HighMem(enabled bool) Option {
-	return nodeHighMemOption(enabled)
+// Mem requests nodes with low/standard/high ratio of memory per CPU.
+func Mem(level MemPerCPU) Option {
+	return nodeMemOption(level)
 }
 
 type volumeSizeOption int

--- a/pkg/cmd/roachtest/tests/restore.go
+++ b/pkg/cmd/roachtest/tests/restore.go
@@ -510,6 +510,13 @@ func registerRestore(r registry.Registry) {
 			timeout:  1 * time.Hour,
 		},
 		{
+			// Benchmarks using a low memory per core ratio - we don't expect ideal
+			// performance but nodes should not OOM.
+			hardware: makeHardwareSpecs(hardwareSpecs{mem: spec.Low}),
+			backup:   makeBackupSpecs(backupSpecs{cloud: spec.GCE}),
+			timeout:  1 * time.Hour,
+		},
+		{
 			// Benchmarks if per node throughput remains constant if the number of
 			// nodes doubles relative to default.
 			hardware: makeHardwareSpecs(hardwareSpecs{nodes: 8}),
@@ -617,6 +624,9 @@ type hardwareSpecs struct {
 	// volumeSize indicates the size of per node block storage (pd-ssd for gcs,
 	// ebs for aws). If zero, local ssd's are used.
 	volumeSize int
+
+	// mem is the memory per cpu.
+	mem spec.MemPerCPU
 }
 
 func (hw hardwareSpecs) makeClusterSpecs(r registry.Registry) spec.ClusterSpec {
@@ -624,6 +634,9 @@ func (hw hardwareSpecs) makeClusterSpecs(r registry.Registry) spec.ClusterSpec {
 	clusterOpts = append(clusterOpts, spec.CPU(hw.cpus))
 	if hw.volumeSize != 0 {
 		clusterOpts = append(clusterOpts, spec.VolumeSize(hw.volumeSize))
+	}
+	if hw.mem != spec.Auto {
+		clusterOpts = append(clusterOpts, spec.Mem(hw.mem))
 	}
 	return r.MakeClusterSpec(hw.nodes, clusterOpts...)
 }
@@ -633,6 +646,9 @@ func (hw hardwareSpecs) String(verbose bool) string {
 	var builder strings.Builder
 	builder.WriteString(fmt.Sprintf("/nodes=%d", hw.nodes))
 	builder.WriteString(fmt.Sprintf("/cpus=%d", hw.cpus))
+	if hw.mem != spec.Auto {
+		builder.WriteString(fmt.Sprintf("/%smem", hw.mem))
+	}
 	if verbose {
 		builder.WriteString(fmt.Sprintf("/volSize=%dGB", hw.volumeSize))
 	}
@@ -648,6 +664,9 @@ func makeHardwareSpecs(override hardwareSpecs) hardwareSpecs {
 	}
 	if override.nodes != 0 {
 		specs.nodes = override.nodes
+	}
+	if override.mem != spec.Auto {
+		specs.mem = override.mem
 	}
 	if override.volumeSize != 0 {
 		specs.volumeSize = override.volumeSize

--- a/pkg/cmd/roachtest/tests/tpcc.go
+++ b/pkg/cmd/roachtest/tests/tpcc.go
@@ -1036,7 +1036,10 @@ func registerTPCCBenchSpec(r registry.Registry, b tpccBenchSpec) {
 		nameParts = append(nameParts, "chaos")
 	}
 
-	opts := []spec.Option{spec.CPU(b.CPUs), spec.HighMem(b.HighMem)}
+	opts := []spec.Option{spec.CPU(b.CPUs)}
+	if b.HighMem {
+		opts = append(opts, spec.Mem(spec.High))
+	}
 	switch b.Distribution {
 	case singleZone:
 		// No specifier.


### PR DESCRIPTION
Currently in roachtest we can create VMs with a default RAM per core, or we can request for highmem machines. This patch is adding an option to ask for highcpu (lower RAM per core) machines.

Previously, on GCE:
- Creating <= 16 core VM created VMs with standard memory per core (~4GM).
- Creating a VM with more cores used 'highcpu' nodes (~1GB per core).
- Using the `HighMem` option created a VM with high memory per core (~6.5GB).
- There was no option to create, for example, a 32 core VM with standard memory (~4GB) - only low mem or high mem.

With this patch the test writer can pick any low/standard/high memory per core ratio.

The initial need is to run restore performance benchmarks with reduced memory to verify nodes don't OOM in that environment. Running with n1-highcpu-8 is not ideal but nodes should not OOM.

We can also, with this change, run with 32 cores and 'standard' RAM (n1-standard-32).

Epic: none

Release note: None