### PR TITLE
sql/backfill: consult the ResumeSpan when scanning in index merge

### DIFF
--- a/pkg/sql/BUILD.bazel
+++ b/pkg/sql/BUILD.bazel
@@ -784,6 +784,8 @@ go_test(
         "//pkg/sql/rowexec",
         "//pkg/sql/rowinfra",
         "//pkg/sql/schemachanger/scexec",
+        "//pkg/sql/schemachanger/scop",
+        "//pkg/sql/schemachanger/scplan",
         "//pkg/sql/scrub",
         "//pkg/sql/scrub/scrubtestutils",
         "//pkg/sql/sem/builtins",


### PR DESCRIPTION
The existing logic could construct an invalid batch request which would result in spurious errors.

Fixes #91977

Release note (bug fix): Fixed a bug which rarely could result in some CREATE INDEX statements to fail with an error `failed to verify keys for Scan`.