### PR TITLE
dashboards: add replica cpu to repl dashboard

### DIFF
--- a/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/replication.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/replication.tsx
@@ -9,7 +9,6 @@
 // licenses/APL.txt.
 
 import React from "react";
-import _ from "lodash";
 
 import { LineGraph } from "src/views/cluster/components/linegraph";
 import { Axis, Metric } from "src/views/shared/components/metricQuery";
@@ -58,7 +57,7 @@ export default function (props: GraphDashboardProps) {
       tooltip={`The number of replicas on each node.`}
     >
       <Axis label="replicas">
-        {_.map(nodeIDs, nid => (
+        {nodeIDs.map(nid => (
           <Metric
             key={nid}
             name="cr.store.replicas"
@@ -75,7 +74,7 @@ export default function (props: GraphDashboardProps) {
           receives and coordinates all read and write requests for its range.`}
     >
       <Axis label="leaseholders">
-        {_.map(nodeIDs, nid => (
+        {nodeIDs.map(nid => (
           <Metric
             key={nid}
             name="cr.store.replicas.leaseholders"
@@ -91,7 +90,7 @@ export default function (props: GraphDashboardProps) {
       tooltip={`Exponentially weighted moving average of the number of KV batch requests processed by leaseholder replicas on each node per second. Tracks roughly the last 30 minutes of requests. Used for load-based rebalancing decisions.`}
     >
       <Axis label="queries">
-        {_.map(nodeIDs, nid => (
+        {nodeIDs.map(nid => (
           <Metric
             key={nid}
             name="cr.store.rebalancing.queriespersecond"
@@ -107,7 +106,7 @@ export default function (props: GraphDashboardProps) {
       tooltip={<LogicalBytesGraphTooltip />}
     >
       <Axis units={AxisUnits.Bytes} label="logical store size">
-        {_.map(nodeIDs, nid => (
+        {nodeIDs.map(nid => (
           <Metric
             key={nid}
             name="cr.store.totalbytes"
@@ -181,7 +180,7 @@ export default function (props: GraphDashboardProps) {
 
     <LineGraph title="Snapshot Data Received" sources={storeSources}>
       <Axis label="bytes" units={AxisUnits.Bytes}>
-        {_.map(nodeIDs, nid => (
+        {nodeIDs.map(nid => (
           <>
             <Metric
               key={nid}
@@ -207,7 +206,7 @@ export default function (props: GraphDashboardProps) {
       tooltip={ReceiverSnapshotsQueuedTooltip}
     >
       <Axis label="snapshots" units={AxisUnits.Count}>
-        {_.map(nodeIDs, nid => (
+        {nodeIDs.map(nid => (
           <Metric
             key={nid}
             name="cr.store.range.snapshots.recv-queue"
@@ -223,7 +222,7 @@ export default function (props: GraphDashboardProps) {
       tooltip={CircuitBreakerTrippedReplicasTooltip}
     >
       <Axis label="replicas">
-        {_.map(nodeIDs, nid => (
+        {nodeIDs.map(nid => (
           <Metric
             key={nid}
             name="cr.store.kv.replica_circuit_breaker.num_tripped_replicas"
@@ -240,7 +239,7 @@ export default function (props: GraphDashboardProps) {
       tooltip={CircuitBreakerTrippedEventsTooltip}
     >
       <Axis label="events">
-        {_.map(nodeIDs, nid => (
+        {nodeIDs.map(nid => (
           <Metric
             key={nid}
             name="cr.store.kv.replica_circuit_breaker.num_tripped_events"
@@ -257,7 +256,7 @@ export default function (props: GraphDashboardProps) {
       tooltip={PausedFollowersTooltip}
     >
       <Axis label="replicas">
-        {_.map(nodeIDs, nid => (
+        {nodeIDs.map(nid => (
           <Metric
             key={nid}
             name="cr.store.admission.raft.paused_replicas"
@@ -341,7 +340,7 @@ export default function (props: GraphDashboardProps) {
     </LineGraph>,
     <LineGraph title="Decommissioning Errors" sources={storeSources}>
       <Axis label="replicas" units={AxisUnits.Count}>
-        {_.map(nodeIDs, nid => (
+        {nodeIDs.map(nid => (
           <Metric
             key={nid}
             name="cr.store.queue.replicate.replacedecommissioningreplica.error"

--- a/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/replication.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/replication.tsx
@@ -104,6 +104,24 @@ export default function (props: GraphDashboardProps) {
     </LineGraph>,
 
     <LineGraph
+      title="Average Replica CPU per Node"
+      tooltip={`Moving average of all replica CPU usage on each node per second.
+         Tracks roughly the last 30 minutes of usage. Used for load-based
+         rebalancing decisions.`}
+    >
+      <Axis units={AxisUnits.Duration} label="CPU time">
+        {nodeIDs.map(nid => (
+          <Metric
+            key={nid}
+            name="cr.store.rebalancing.cpunanospersecond"
+            title={nodeDisplayName(nodeDisplayNameByID, nid)}
+            sources={storeIDsForNode(storeIDsByNodeID, nid)}
+          />
+        ))}
+      </Axis>
+    </LineGraph>,
+
+    <LineGraph
       title="Logical Bytes per Node"
       tooltip={<LogicalBytesGraphTooltip />}
     >

--- a/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/replication.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/replication.tsx
@@ -86,8 +86,10 @@ export default function (props: GraphDashboardProps) {
     </LineGraph>,
 
     <LineGraph
-      title="Average Queries per Node"
-      tooltip={`Exponentially weighted moving average of the number of KV batch requests processed by leaseholder replicas on each node per second. Tracks roughly the last 30 minutes of requests. Used for load-based rebalancing decisions.`}
+      title="Average Replica Queries per Node"
+      tooltip={`Moving average of the number of KV batch requests processed by
+         leaseholder replicas on each node per second. Tracks roughly the last
+         30 minutes of requests. Used for load-based rebalancing decisions.`}
     >
       <Axis label="queries">
         {nodeIDs.map(nid => (


### PR DESCRIPTION
In #96127 we added the option to load balance replica CPU instead of QPS across
stores in a cluster. It is desirable to view the signal being controlled for
rebalancing in the replication dashboard, similar to QPS.

This pr adds the `rebalancing.cpunanospersecond` metric to the replication
metrics dashboard.

The avg QPS graph on the replication graph previously described the metric as
"Exponentially weighted average", however this is not true.

This pr updates the description to just be "moving average" which is accurate.
Note that follow the workload does use an exponentially weighted value, however
the metric in the dashboard is not the same.

This pr also updates the graph header to include Replica in the title: "Average
Replica Queries per Node". QPS is specific to replicas. This is already
mentioned in the description.

Resolves: #98109
