### PR TITLE
roachtest: unskip kv/restart/nodes=12

### DIFF
--- a/pkg/cmd/roachtest/tests/kv.go
+++ b/pkg/cmd/roachtest/tests/kv.go
@@ -916,8 +916,9 @@ func measureQPS(ctx context.Context, t test.Test, db *gosql.DB, duration time.Du
 // transfers.
 func registerKVRestartImpact(r registry.Registry) {
 	r.Add(registry.TestSpec{
-		Skip:    "#95159",
-		Name:    "kv/restart/nodes=12",
+		Name: "kv/restart/nodes=12",
+		// This test is expensive (104vcpu), we run it weekly.
+		Tags:    []string{`weekly`},
 		Owner:   registry.OwnerKV,
 		Cluster: r.MakeClusterSpec(13, spec.CPU(8)),
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {


### PR DESCRIPTION
Previously, the `kv/restart/nodes=12` roachtest was unable to pass and
was skipped. Following the changes introduced for https://github.com/cockroachdb/cockroach/issues/96521, the test now
passes.

This commit enables the `kv/restart/nodes=12` roachtest as a weekly
test.

resolves: https://github.com/cockroachdb/cockroach/issues/98296

Release note: None