### PR TITLE
settings: new notification API

### DIFF
--- a/pkg/settings/BUILD.bazel
+++ b/pkg/settings/BUILD.bazel
@@ -16,6 +16,7 @@ go_library(
         "float.go",
         "int.go",
         "masked.go",
+        "notifer.go",
         "protobuf.go",
         "registry.go",
         "setting.go",
@@ -47,6 +48,7 @@ go_test(
     srcs = [
         "encoding_test.go",
         "internal_test.go",
+        "notifier_test.go",
         "settings_test.go",
     ],
     args = ["-test.timeout=55s"],

--- a/pkg/settings/common.go
+++ b/pkg/settings/common.go
@@ -107,6 +107,10 @@ func (c *common) SetOnChange(sv *Values, fn func(ctx context.Context)) {
 	sv.setOnChange(c.slot, fn)
 }
 
+func (c *common) slotIdx() slotIdx {
+	return c.slot
+}
+
 type internalSetting interface {
 	NonMaskedSetting
 

--- a/pkg/settings/notifer.go
+++ b/pkg/settings/notifer.go
@@ -1,0 +1,76 @@
+// Copyright 2023 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package settings
+
+import (
+	"runtime"
+	"runtime/debug"
+
+	"github.com/cockroachdb/cockroach/pkg/util/buildutil"
+	"github.com/cockroachdb/errors"
+)
+
+// NewNotifier is used when a piece of code needs to get a signal when certain
+// settings change. It returns a Notifier associated with the given settings
+// settings; whenever any of these settings change, a non-blocking send on
+// Notifier.Ch() is performed.
+//
+// The Notifier must be Closed.
+func (sv *Values) NewNotifier(settings ...NonMaskedSetting) *Notifier {
+	slots := make([]slotIdx, len(settings))
+	for i := range settings {
+		slots[i] = settings[i].slotIdx()
+	}
+	ch := make(chan struct{}, 1)
+	sv.addOnChangeCh(ch, slots...)
+	n := &Notifier{
+		sv:    sv,
+		slots: slots,
+		ch:    ch,
+	}
+	if buildutil.CrdbTestBuild {
+		n.debugStack = string(debug.Stack())
+		runtime.SetFinalizer(n, func(obj interface{}) {
+			notifier := obj.(*Notifier)
+			if notifier.sv != nil {
+				panic(errors.AssertionFailedf("settings.Notifier not closed; created by\n%s", notifier.debugStack))
+			}
+		})
+	}
+	return n
+}
+
+// Notifier is used to listen for changes to a set of settings; see NewNotifier.
+type Notifier struct {
+	sv         *Values
+	slots      []slotIdx
+	ch         chan struct{}
+	debugStack string
+}
+
+// Ch returns a channel that can be listened to for changes to the relevant
+// settings.
+//
+// Note that it is safe to use Ch() while or after calling Close.
+func (n *Notifier) Ch() <-chan struct{} {
+	return n.ch
+}
+
+// Close cleans up the notifier.
+func (n *Notifier) Close() {
+	if n.sv != nil {
+		n.sv.removeOnChangeCh(n.ch, n.slots...)
+		n.sv = nil
+		n.slots = nil
+		// We don't reset n.ch to allow the caller to still have a running goroutine
+		// that might try to receive on Ch().
+	}
+}

--- a/pkg/settings/notifier_test.go
+++ b/pkg/settings/notifier_test.go
@@ -1,0 +1,88 @@
+// Copyright 2023 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package settings
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+var testVar1 = RegisterIntSetting(TenantWritable, "n1", "n1", 1)
+var testVar2 = RegisterIntSetting(TenantWritable, "n2", "n2", 2)
+var testVar3 = RegisterIntSetting(TenantWritable, "n3", "n3", 3)
+
+func TestNotifier(t *testing.T) {
+	ctx := context.Background()
+	sv := &Values{}
+	sv.Init(ctx, TestOpaque)
+
+	n1 := sv.NewNotifier(testVar1)
+	n23 := sv.NewNotifier(testVar2, testVar3)
+	n123 := sv.NewNotifier(testVar1, testVar2, testVar3)
+
+	var count1, count23, count123 atomic.Uint32
+
+	cancelCtx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go func(ctx context.Context) {
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-n1.Ch():
+				count1.Add(1)
+			case <-n23.Ch():
+				count23.Add(1)
+			case <-n123.Ch():
+				count123.Add(1)
+			}
+		}
+	}(cancelCtx)
+
+	expect := func(exp1, exp23, exp123 uint32) {
+		require.Equal(t, count1.Load(), exp1)
+		require.Equal(t, count23.Load(), exp23)
+		require.Equal(t, count123.Load(), exp123)
+	}
+	wait := func(exp1, exp23, exp123 uint32) {
+		require.Eventuallyf(
+			t,
+			func() bool {
+				return count1.Load() == exp1 && count23.Load() == exp23 && count123.Load() == exp123
+			},
+			10*time.Second,
+			10*time.Millisecond,
+			"expected %d/%d/%d, got %d/%d/%d",
+			exp1, exp23, exp123, count1.Load(), count23.Load(), count123.Load())
+	}
+
+	expect(0 /* exp1 */, 0 /* exp23 */, 0 /* exp123 */)
+	_ = testVar1.set(ctx, sv, 10)
+	wait(1 /* exp1 */, 0 /* exp23 */, 1 /* exp123 */)
+	_ = testVar2.set(ctx, sv, 20)
+	wait(1 /* exp1 */, 1 /* exp23 */, 2 /* exp123 */)
+	_ = testVar1.set(ctx, sv, 100)
+	wait(2 /* exp1 */, 1 /* exp23 */, 3 /* exp123 */)
+	_ = testVar3.set(ctx, sv, 300)
+	wait(2 /* exp1 */, 2 /* exp23 */, 4 /* exp123 */)
+	n1.Close()
+	n23.Close()
+	n123.Close()
+	// We should get no more notifications.
+	_ = testVar1.set(ctx, sv, 1000)
+	_ = testVar2.set(ctx, sv, 2000)
+	_ = testVar3.set(ctx, sv, 3000)
+	expect(2 /* exp1 */, 2 /* exp23 */, 4 /* exp123 */)
+}

--- a/pkg/settings/setting.go
+++ b/pkg/settings/setting.go
@@ -79,6 +79,10 @@ type NonMaskedSetting interface {
 	// ErrorHint returns a hint message to be displayed to the user when there's
 	// an error.
 	ErrorHint() (bool, string)
+
+	// slotIdx is an internal method to get the assigned slot for the Values
+	// container.
+	slotIdx() slotIdx
 }
 
 // Class describes the scope of a setting in multi-tenant scenarios. While all


### PR DESCRIPTION
This is a proposal for a new API for getting notifications for changes to cluster settings.

As discussed in more detail in #73830, the existing mechanism is fragile: it executes an arbitrary callback inside the updater, possibly blocking it.

The new API is to create a `Notifier` which has a buffer channel that the caller can listen on. The `Notifier` is associated with a set of settings, and a non-blocking send is performed on the channel whenever one of the settings changes.

Release note: None
Epic: none