### PR TITLE
sql: avoid panic by not applying AvoidBuffering to InternalExecutor

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/internal_executor
+++ b/pkg/sql/logictest/testdata/logic_test/internal_executor
@@ -5,3 +5,13 @@ SHOW JOBS WHEN COMPLETE SELECT job_id FROM [SHOW JOBS] WHERE job_type = 'SCHEMA 
 
 statement ok
 SELECT a.job_id, b.job_id FROM [SHOW JOBS] a, [SHOW JOBS] b;
+
+
+# Regression tests for panic when SET avoid_buffering = true has been called. (#98204)
+user testuser
+
+statement ok
+SET avoid_buffering = true;
+
+statement ok
+SELECT crdb_internal.has_role_option('VIEWACTIVITY')

--- a/pkg/sql/sessiondatapb/local_only_session_data.proto
+++ b/pkg/sql/sessiondatapb/local_only_session_data.proto
@@ -219,6 +219,8 @@ message LocalOnlySessionData {
   // AvoidBuffering indicates that the returned data should not be
   // buffered by conn executor.  This is currently used by replication primitives
   // to ensure the data is flushed to the consumer immediately.
+  //
+  // Does not apply to the InternalExecutor.
   bool avoid_buffering = 59;
   // CheckFunctionBodies indicates whether functions are validated during
   // creation.


### PR DESCRIPTION
The InternalExecutor creates a streamingCommandResult, which does not support DisableBuffering.

Here, we skip calling DisableBuffering() if the request is from an internal executor.

Fixes: #98204

Release note (bug fix): Fixes a bug in which `SET avoid_buffering = true` could produce a crash on subsequent operations.