### PR TITLE
ui: make upgrade error message encompass more tables

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/api/sqlApi.spec.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/api/sqlApi.spec.ts
@@ -95,7 +95,15 @@ describe("sqlApi", () => {
         expected: true,
       },
       {
+        msg: 'extra text____relation "my table that doesnt exist" does not exist++++ extra text',
+        expected: true,
+      },
+      {
         msg: 'column "hello" does not exist',
+        expected: true,
+      },
+      {
+        msg: 'blah blah blah column "my_new_column" does not exist obs-fun-times',
         expected: true,
       },
       {

--- a/pkg/ui/workspaces/cluster-ui/src/api/sqlApi.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/api/sqlApi.ts
@@ -135,7 +135,7 @@ export function sqlResultsAreEmpty(
 // different versions. For now we just try to give more info as to why
 // this page is unavailable for insights.
 const UPGRADE_RELATED_ERRORS = [
-  /relation "crdb_internal.txn_execution_insights" does not exist/i,
+  /relation "(.*)" does not exist/i,
   /column "(.*)" does not exist/i,
 ];
 


### PR DESCRIPTION
Previously, we only show the upgrade error message when querying using the sql api in the cases where the server error message says either a column does not exist or the specific table `crdb_internal.txn_cluster_insights`. This commit expands that to any table.

Epic: none

Release note (ui change): users will see the upgrade error message when a response from the sql api says that a relation or column does not exist