### PR TITLE
pkg/server: fix `/demologin` to properly redirect to home page

### DIFF
--- a/pkg/server/authentication.go
+++ b/pkg/server/authentication.go
@@ -240,7 +240,7 @@ func (s *authenticationServer) demoLogin(w http.ResponseWriter, req *http.Reques
 
 	w.Header()["Set-Cookie"] = []string{cookie.String()}
 	w.Header()["Location"] = []string{"/"}
-	w.WriteHeader(302)
+	w.WriteHeader(http.StatusTemporaryRedirect)
 	_, _ = w.Write([]byte("you can use the UI now"))
 }
 


### PR DESCRIPTION
With the introduction of the server controller, we introduced a layer between the HTTP handler and the HTTP server. When this was introduced, the logic to attempt a login to all tenants forgot to handle a specific case for `/demologin`, where the status code is set to a 302 redirect, instead of a 200 status OK.

This broke the redirect piece of the `/demologin` endpoint.

This patch updates the `attemptLoginToAllTenants` HTTP handler to properly set the 302 response code in the case where the underlying login function does so on the sessionWriter.

Release note: none

Epic: CRDB-12100

Fixes: https://github.com/cockroachdb/cockroach/issues/98253