### PR TITLE
cluster-ui: move table details endpoint to use sql-over-http

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/api/index.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/api/index.ts
@@ -24,3 +24,4 @@ export * from "./tracezApi";
 export * from "./databasesApi";
 export * from "./eventsApi";
 export * from "./databaseDetailsApi";
+export * from "./tableDetailsApi";

--- a/pkg/ui/workspaces/cluster-ui/src/api/tableDetailsApi.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/api/tableDetailsApi.ts
@@ -1,0 +1,607 @@
+// Copyright 2023 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import {
+  executeInternalSql,
+  formatApiResult,
+  LARGE_RESULT_SIZE,
+  LONG_TIMEOUT,
+  SqlApiQueryResponse,
+  SqlApiResponse,
+  SqlExecutionErrorMessage,
+  SqlExecutionRequest,
+  SqlStatement,
+  SqlTxnResult,
+  txnResultIsEmpty,
+} from "./sqlApi";
+import moment from "moment";
+import { fromHexString, withTimeout } from "./util";
+import { Format, Identifier, Join, SQL } from "./safesql";
+import { cockroach } from "@cockroachlabs/crdb-protobuf-client";
+import { IndexUsageStatistic, recommendDropUnusedIndex } from "../insights";
+
+const { ZoneConfig } = cockroach.config.zonepb;
+const { ZoneConfigurationLevel } = cockroach.server.serverpb;
+type ZoneConfigType = cockroach.config.zonepb.ZoneConfig;
+type ZoneConfigLevelType = cockroach.server.serverpb.ZoneConfigurationLevel;
+
+export function newTableDetailsResponse(): TableDetailsResponse {
+  return {
+    idResp: { table_id: "" },
+    createStmtResp: { statement: "" },
+    grantsResp: { grants: [] },
+    schemaDetails: { columns: [], indexes: [] },
+    zoneConfigResp: {
+      configure_zone_statement: "",
+      zone_config: new ZoneConfig({
+        inherited_constraints: true,
+        inherited_lease_preferences: true,
+      }),
+      zone_config_level: ZoneConfigurationLevel.CLUSTER,
+    },
+    heuristicsDetails: { stats_last_created_at: null },
+    stats: {
+      spanStats: {
+        approximate_disk_bytes: 0,
+        live_bytes: 0,
+        total_bytes: 0,
+        range_count: 0,
+        live_percentage: 0,
+      },
+      replicaData: {
+        nodeIDs: [],
+        nodeCount: 0,
+        replicaCount: 0,
+      },
+      indexStats: {
+        has_index_recommendations: false,
+      },
+    },
+  };
+}
+
+export type TableDetailsResponse = {
+  idResp: SqlApiQueryResponse<TableIdRow>;
+  createStmtResp: SqlApiQueryResponse<TableCreateStatementRow>;
+  grantsResp: SqlApiQueryResponse<TableGrantsResponse>;
+  schemaDetails: SqlApiQueryResponse<TableSchemaDetailsRow>;
+  zoneConfigResp: SqlApiQueryResponse<TableZoneConfigResponse>;
+  heuristicsDetails: SqlApiQueryResponse<TableHeuristicDetailsRow>;
+  stats: TableDetailsStats;
+  error?: SqlExecutionErrorMessage;
+};
+
+// Table ID.
+type TableIdRow = {
+  table_id: string;
+};
+
+const getTableId: TableDetailsQuery<TableIdRow> = {
+  createStmt: (dbName, tableName) => {
+    const escFullTableName = Join(
+      [new Identifier(dbName), new SQL(tableName)],
+      new SQL("."),
+    );
+    return {
+      sql: `SELECT $1::regclass::oid as table_id`,
+      arguments: [escFullTableName.SQLString()],
+    };
+  },
+  addToTableDetail: (
+    txn_result: SqlTxnResult<TableIdRow>,
+    resp: TableDetailsResponse,
+  ) => {
+    if (!txnResultIsEmpty(txn_result)) {
+      resp.idResp.table_id = txn_result.rows[0].table_id;
+    } else {
+      txn_result.error = new Error("fetchTableId: unexpected empty results");
+    }
+    if (txn_result.error) {
+      resp.idResp.error = txn_result.error;
+    }
+  },
+};
+
+// Table create statement.
+type TableCreateStatementRow = { statement: string };
+
+const getTableCreateStatement: TableDetailsQuery<TableCreateStatementRow> = {
+  createStmt: (dbName, tableName) => {
+    const escFullTableName = Join(
+      [new Identifier(dbName), new SQL(tableName)],
+      new SQL("."),
+    );
+    return {
+      sql: Format(`SELECT create_statement FROM [SHOW CREATE %1]`, [
+        escFullTableName,
+      ]),
+    };
+  },
+  addToTableDetail: (
+    txn_result: SqlTxnResult<TableCreateStatementRow>,
+    resp: TableDetailsResponse,
+  ) => {
+    if (!txnResultIsEmpty(txn_result)) {
+      resp.createStmtResp.statement = txn_result.rows[0].statement;
+    } else {
+      txn_result.error = new Error(
+        "getTableCreateStatement: unexpected empty results",
+      );
+    }
+    if (txn_result.error) {
+      resp.createStmtResp.error = txn_result.error;
+    }
+  },
+};
+
+// Table grants.
+type TableGrantsResponse = {
+  grants: TableGrantsRow[];
+};
+
+type TableGrantsRow = {
+  user: string;
+  privileges: string[];
+};
+
+const getTableGrants: TableDetailsQuery<TableGrantsRow> = {
+  createStmt: (dbName, tableName) => {
+    const escFullTableName = Join(
+      [new Identifier(dbName), new SQL(tableName)],
+      new SQL("."),
+    );
+    return {
+      sql: Format(
+        `SELECT grantee as user, array_agg(privilege_type) as privileges 
+         FROM [SHOW GRANTS ON TABLE %1] group by grantee`,
+        [escFullTableName],
+      ),
+    };
+  },
+  addToTableDetail: (
+    txn_result: SqlTxnResult<TableGrantsRow>,
+    resp: TableDetailsResponse,
+  ) => {
+    if (!txnResultIsEmpty(txn_result)) {
+      resp.grantsResp.grants = txn_result.rows;
+    }
+    if (txn_result.error) {
+      resp.grantsResp.error = txn_result.error;
+    }
+  },
+};
+
+// Table schema details.
+type TableSchemaDetailsRow = {
+  columns: string[];
+  indexes: string[];
+};
+
+const getTableSchemaDetails: TableDetailsQuery<TableSchemaDetailsRow> = {
+  createStmt: (dbName, tableName) => {
+    const escFullTableName = Join(
+      [new Identifier(dbName), new SQL(tableName)],
+      new SQL("."),
+    );
+    return {
+      sql: Format(
+        `WITH 
+     columns AS (SELECT array_agg(distinct(column_name)) as unique_columns FROM [SHOW COLUMNS FROM %1]),
+     indexes AS (SELECT array_agg(distinct(index_name)) as unique_indexes FROM [SHOW INDEX FROM %1])
+        SELECT 
+            unique_columns as columns, 
+            unique_indexes as indexes 
+        FROM columns CROSS JOIN indexes`,
+        [escFullTableName],
+      ),
+    };
+  },
+  addToTableDetail: (
+    txn_result: SqlTxnResult<TableSchemaDetailsRow>,
+    resp: TableDetailsResponse,
+  ) => {
+    if (!txnResultIsEmpty(txn_result)) {
+      resp.schemaDetails.columns = txn_result.rows[0].columns;
+      resp.schemaDetails.indexes = txn_result.rows[0].indexes;
+    }
+    if (txn_result.error) {
+      resp.schemaDetails.error = txn_result.error;
+    }
+  },
+};
+
+// Table zone config.
+type TableZoneConfigResponse = {
+  configure_zone_statement: string;
+  zone_config: ZoneConfigType;
+  zone_config_level: ZoneConfigLevelType;
+};
+
+type TableZoneConfigStatementRow = { raw_config_sql: string };
+
+const getTableZoneConfigStmt: TableDetailsQuery<TableZoneConfigStatementRow> = {
+  createStmt: (dbName, tableName) => {
+    const escFullTableName = Join(
+      [new Identifier(dbName), new SQL(tableName)],
+      new SQL("."),
+    );
+    return {
+      sql: Format(
+        `SELECT raw_config_sql FROM [SHOW ZONE CONFIGURATION FOR TABLE %1]`,
+        [escFullTableName],
+      ),
+    };
+  },
+  addToTableDetail: (
+    txn_result: SqlTxnResult<TableZoneConfigStatementRow>,
+    resp: TableDetailsResponse,
+  ) => {
+    if (!txnResultIsEmpty(txn_result)) {
+      resp.zoneConfigResp.configure_zone_statement =
+        txn_result.rows[0].raw_config_sql;
+    }
+    if (txn_result.error) {
+      resp.zoneConfigResp.error = txn_result.error;
+    }
+  },
+};
+
+type TableZoneConfigRow = {
+  database_zone_config_hex_string: string;
+  table_zone_config_hex_string: string;
+};
+
+const getTableZoneConfig: TableDetailsQuery<TableZoneConfigRow> = {
+  createStmt: (dbName, tableName) => {
+    const escFullTableName = Join(
+      [new Identifier(dbName), new SQL(tableName)],
+      new SQL("."),
+    );
+    return {
+      sql: `SELECT 
+      encode(crdb_internal.get_zone_config((SELECT crdb_internal.get_database_id($1))), 'hex') as database_zone_config_hex_string,
+      encode(crdb_internal.get_zone_config((SELECT $2::regclass::int)), 'hex') as table_zone_config_hex_string`,
+      arguments: [dbName, escFullTableName.SQLString()],
+    };
+  },
+  addToTableDetail: (
+    txn_result: SqlTxnResult<TableZoneConfigRow>,
+    resp: TableDetailsResponse,
+  ) => {
+    if (!txnResultIsEmpty(txn_result)) {
+      let hexString = "";
+      let configLevel = ZoneConfigurationLevel.CLUSTER;
+      const row = txn_result.rows[0];
+      // Check that database_zone_config_bytes is not null
+      // and not empty.
+      if (
+        row.database_zone_config_hex_string &&
+        row.database_zone_config_hex_string.length !== 0
+      ) {
+        hexString = row.database_zone_config_hex_string;
+        configLevel = ZoneConfigurationLevel.DATABASE;
+      }
+      // Fall back to table_zone_config_bytes if we don't have database_zone_config_bytes.
+      if (
+        hexString === "" &&
+        row.table_zone_config_hex_string &&
+        row.table_zone_config_hex_string.length !== 0
+      ) {
+        hexString = row.table_zone_config_hex_string;
+        configLevel = ZoneConfigurationLevel.TABLE;
+      }
+
+      // No zone configuration, return.
+      if (hexString === "") {
+        return;
+      }
+
+      // Try to decode the zone config bytes response.
+      try {
+        // Parse the bytes from the hex string.
+        const zoneConfigBytes = fromHexString(hexString);
+        // Decode the bytes using ZoneConfig protobuf.
+        resp.zoneConfigResp.zone_config = ZoneConfig.decode(
+          new Uint8Array(zoneConfigBytes),
+        );
+        resp.zoneConfigResp.zone_config_level = configLevel;
+      } catch (e) {
+        console.error(
+          `Table Details API - encountered an error decoding zone config string: ${hexString}`,
+        );
+        // Catch and assign the error if we encounter one decoding.
+        resp.zoneConfigResp.error = e;
+        resp.zoneConfigResp.zone_config_level = ZoneConfigurationLevel.UNKNOWN;
+      }
+    }
+    if (txn_result.error) {
+      resp.zoneConfigResp.error = txn_result.error;
+    }
+  },
+};
+
+// Table heuristics details.
+type TableHeuristicDetailsRow = {
+  stats_last_created_at: moment.Moment;
+};
+
+const getTableHeuristicsDetails: TableDetailsQuery<TableHeuristicDetailsRow> = {
+  createStmt: (dbName, tableName) => {
+    const escFullTableName = Join(
+      [new Identifier(dbName), new SQL(tableName)],
+      new SQL("."),
+    );
+    return {
+      sql: Format(
+        `SELECT max(created) AS created FROM [SHOW STATISTICS FOR TABLE %1]`,
+        [escFullTableName],
+      ),
+    };
+  },
+  addToTableDetail: (
+    txn_result: SqlTxnResult<TableHeuristicDetailsRow>,
+    resp: TableDetailsResponse,
+  ) => {
+    if (!txnResultIsEmpty(txn_result)) {
+      resp.heuristicsDetails.stats_last_created_at =
+        txn_result.rows[0].stats_last_created_at;
+    }
+    if (txn_result.error) {
+      resp.heuristicsDetails.error = txn_result.error;
+    }
+  },
+};
+
+// Table details stats.
+type TableDetailsStats = {
+  spanStats: SqlApiQueryResponse<TableSpanStatsRow>;
+  replicaData: SqlApiQueryResponse<TableReplicaData>;
+  indexStats: SqlApiQueryResponse<TableIndexUsageStats>;
+};
+
+// Table span stats.
+type TableSpanStatsRow = {
+  approximate_disk_bytes: number;
+  live_bytes: number;
+  total_bytes: number;
+  range_count: number;
+  live_percentage: number;
+};
+
+const getTableSpanStats: TableDetailsQuery<TableSpanStatsRow> = {
+  createStmt: (dbName, tableName) => {
+    const escFullTableName = Join(
+      [new Identifier(dbName), new SQL(tableName)],
+      new SQL("."),
+    );
+    return {
+      sql: `SELECT
+              range_count,
+              approximate_disk_bytes,
+              live_bytes,
+              total_bytes,
+              live_percentage
+            FROM crdb_internal.tenant_span_stats(
+                (SELECT crdb_internal.get_database_id($1)), 
+                (SELECT $2::regclass::int))`,
+      arguments: [dbName, escFullTableName.SQLString()],
+    };
+  },
+  addToTableDetail: (
+    txn_result: SqlTxnResult<TableSpanStatsRow>,
+    resp: TableDetailsResponse,
+  ) => {
+    if (txn_result && txn_result.error) {
+      resp.stats.spanStats.error = txn_result.error;
+    }
+    if (txnResultIsEmpty(txn_result)) {
+      return;
+    }
+    if (txn_result.rows.length === 1) {
+      resp.stats.spanStats = txn_result.rows[0];
+    } else {
+      resp.stats.spanStats.error = new Error(
+        `getTableSpanStats: unexpected number of rows (expected 1, got ${txn_result.rows.length})`,
+      );
+    }
+  },
+};
+
+type TableReplicaData = SqlApiQueryResponse<{
+  nodeIDs: number[];
+  nodeCount: number;
+  replicaCount: number;
+}>;
+
+// Table replicas.
+type TableReplicasRow = {
+  replicas: number[];
+};
+
+const getTableReplicas: TableDetailsQuery<TableReplicasRow> = {
+  createStmt: (dbName, tableName) => {
+    const escFullTableName = Join(
+      [new Identifier(dbName), new SQL(tableName)],
+      new SQL("."),
+    );
+    return {
+      sql: Format(
+        `WITH tableId AS (SELECT $1::regclass::int as table_id)
+        SELECT
+            r.replicas
+          FROM %1.crdb_internal.table_spans as ts
+          JOIN tableId ON ts.descriptor_id = tableId.table_id
+          JOIN crdb_internal.ranges_no_leases as r ON ts.start_key < r.end_key AND ts.end_key > r.start_key`,
+        [new Identifier(dbName)],
+      ),
+      arguments: [escFullTableName.SQLString()],
+    };
+  },
+  addToTableDetail: (
+    txn_result: SqlTxnResult<TableReplicasRow>,
+    resp: TableDetailsResponse,
+  ) => {
+    // Build set of unique replicas for this database.
+    const replicas = new Set<number>();
+    // If rows are not null or empty...
+    if (!txnResultIsEmpty(txn_result)) {
+      txn_result.rows.forEach(row => {
+        row.replicas.forEach(replicas.add, replicas);
+      });
+      // Currently we use replica ids as node ids.
+      resp.stats.replicaData.replicaCount = replicas.size;
+      resp.stats.replicaData.nodeCount = replicas.size;
+      resp.stats.replicaData.nodeIDs = Array.from(replicas.values());
+    }
+    if (txn_result.error) {
+      resp.stats.replicaData.error = txn_result.error;
+    }
+  },
+};
+
+// Table index usage stats.
+type TableIndexUsageStats = {
+  has_index_recommendations: boolean;
+};
+
+const getTableIndexUsageStats: TableDetailsQuery<IndexUsageStatistic> = {
+  createStmt: (dbName, tableName) => {
+    const escFullTableName = Join(
+      [new Identifier(dbName), new SQL(tableName)],
+      new SQL("."),
+    );
+    return {
+      sql: Format(
+        `WITH 
+     cs AS (SELECT value FROM crdb_internal.cluster_settings WHERE variable = 'sql.index_recommendation.drop_unused_duration'),
+     tableId AS (SELECT $1::regclass::int as table_id)
+          SELECT * FROM (SELECT
+                  ti.created_at,
+                  us.last_read,
+                  us.total_reads,
+                  cs.value as unused_threshold,
+                  cs.value::interval as interval_threshold,
+                  now() - COALESCE(us.last_read AT TIME ZONE 'UTC', COALESCE(ti.created_at, '0001-01-01')) as unused_interval
+                  FROM %1.crdb_internal.index_usage_statistics AS us
+                  JOIN tableId ON us.table_id = tableId.table_id
+                  JOIN %1.crdb_internal.table_indexes AS ti ON (
+                      us.index_id = ti.index_id AND 
+                      tableId.table_id = ti.descriptor_id AND 
+                      ti.index_type = 'secondary' 
+                  )
+                  CROSS JOIN cs
+                 WHERE $2 != 'system')
+               WHERE unused_interval > interval_threshold
+               ORDER BY total_reads DESC`,
+        [new Identifier(dbName)],
+      ),
+      arguments: [escFullTableName.SQLString(), dbName],
+    };
+  },
+  addToTableDetail: (
+    txn_result: SqlTxnResult<IndexUsageStatistic>,
+    resp: TableDetailsResponse,
+  ) => {
+    resp.stats.indexStats.has_index_recommendations = txn_result.rows?.some(
+      row => recommendDropUnusedIndex(row),
+    );
+    if (txn_result.error) {
+      resp.stats.indexStats.error = txn_result.error;
+    }
+  },
+};
+
+type TableDetailsQuery<RowType> = {
+  createStmt: (dbName: string, tableName: string) => SqlStatement;
+  addToTableDetail: (
+    response: SqlTxnResult<RowType>,
+    tableDetail: TableDetailsResponse,
+  ) => void;
+};
+
+export type TableDetailsRow =
+  | TableIdRow
+  | TableGrantsRow
+  | TableSchemaDetailsRow
+  | TableCreateStatementRow
+  | TableZoneConfigStatementRow
+  | TableHeuristicDetailsRow
+  | TableSpanStatsRow
+  | IndexUsageStatistic
+  | TableZoneConfigRow
+  | TableReplicasRow;
+
+const tableDetailQueries: TableDetailsQuery<TableDetailsRow>[] = [
+  getTableId,
+  getTableGrants,
+  getTableSchemaDetails,
+  getTableCreateStatement,
+  getTableZoneConfigStmt,
+  getTableHeuristicsDetails,
+  getTableSpanStats,
+  getTableIndexUsageStats,
+  getTableZoneConfig,
+  getTableReplicas,
+];
+
+export function createTableDetailsReq(
+  dbName: string,
+  tableName: string,
+): SqlExecutionRequest {
+  return {
+    execute: true,
+    statements: tableDetailQueries.map(query =>
+      query.createStmt(dbName, tableName),
+    ),
+    max_result_size: LARGE_RESULT_SIZE,
+    timeout: LONG_TIMEOUT,
+    database: dbName,
+  };
+}
+
+export type TableDetailsReqParams = {
+  database: string;
+  // Note: table name is expected in the following format: "schemaName"."tableName"
+  table: string;
+};
+
+export async function getTableDetails(
+  params: TableDetailsReqParams,
+  timeout?: moment.Duration,
+): Promise<SqlApiResponse<TableDetailsResponse>> {
+  return withTimeout(fetchTableDetails(params.database, params.table), timeout);
+}
+
+async function fetchTableDetails(
+  databaseName: string,
+  tableName: string,
+): Promise<SqlApiResponse<TableDetailsResponse>> {
+  const detailsResponse: TableDetailsResponse = newTableDetailsResponse();
+  const req: SqlExecutionRequest = createTableDetailsReq(
+    databaseName,
+    tableName,
+  );
+  const resp = await executeInternalSql<TableDetailsRow>(req);
+  resp.execution.txn_results.forEach(txn_result => {
+    if (txn_result.rows) {
+      const query: TableDetailsQuery<TableDetailsRow> =
+        tableDetailQueries[txn_result.statement - 1];
+      query.addToTableDetail(txn_result, detailsResponse);
+    }
+  });
+  if (resp.error) {
+    detailsResponse.error = resp.error;
+  }
+  return formatApiResult<TableDetailsResponse>(
+    detailsResponse,
+    detailsResponse.error,
+    "retrieving table details information",
+  );
+}

--- a/pkg/ui/workspaces/db-console/src/redux/apiReducers.spec.ts
+++ b/pkg/ui/workspaces/db-console/src/redux/apiReducers.spec.ts
@@ -13,7 +13,7 @@ import {
   databaseRequestPayloadToID,
   tableRequestToID,
 } from "./apiReducers";
-import * as protos from "src/js/protos";
+import { api as clusterUiApi } from "@cockroachlabs/cluster-ui";
 
 describe("table id generator", function () {
   it("generates encoded db/table id", function () {
@@ -39,11 +39,10 @@ describe("request to string functions", function () {
   it("correctly generates a string from a table details request", function () {
     const database = "testDatabase";
     const table = "testTable";
-    const tableRequest =
-      new protos.cockroach.server.serverpb.TableDetailsRequest({
-        database,
-        table,
-      });
+    const tableRequest: clusterUiApi.TableDetailsReqParams = {
+      database,
+      table,
+    };
     expect(tableRequestToID(tableRequest)).toEqual(
       generateTableID(database, table),
     );

--- a/pkg/ui/workspaces/db-console/src/redux/apiReducers.ts
+++ b/pkg/ui/workspaces/db-console/src/redux/apiReducers.ts
@@ -136,28 +136,19 @@ export function generateTableID(db: string, table: string) {
 
 export const tableRequestToID = (
   req:
-    | api.TableDetailsRequestMessage
     | api.TableStatsRequestMessage
-    | api.IndexStatsRequestMessage,
+    | api.IndexStatsRequestMessage
+    | clusterUiApi.TableDetailsReqParams,
 ): string => generateTableID(req.database, req.table);
 
 const tableDetailsReducerObj = new KeyedCachedDataReducer(
-  api.getTableDetails,
+  clusterUiApi.getTableDetails,
   "tableDetails",
   tableRequestToID,
   null,
   moment.duration(10, "m"),
 );
 export const refreshTableDetails = tableDetailsReducerObj.refresh;
-
-const tableStatsReducerObj = new KeyedCachedDataReducer(
-  api.getTableStats,
-  "tableStats",
-  tableRequestToID,
-  null,
-  moment.duration(10, "m"),
-);
-export const refreshTableStats = tableStatsReducerObj.refresh;
 
 const indexStatsReducerObj = new KeyedCachedDataReducer(
   api.getIndexStats,
@@ -534,8 +525,9 @@ export interface APIReducersState {
   databaseDetails: KeyedCachedDataReducerState<
     clusterUiApi.SqlApiResponse<clusterUiApi.DatabaseDetailsResponse>
   >;
-  tableDetails: KeyedCachedDataReducerState<api.TableDetailsResponseMessage>;
-  tableStats: KeyedCachedDataReducerState<api.TableStatsResponseMessage>;
+  tableDetails: KeyedCachedDataReducerState<
+    clusterUiApi.SqlApiResponse<clusterUiApi.TableDetailsResponse>
+  >;
   indexStats: KeyedCachedDataReducerState<api.IndexStatsResponseMessage>;
   nonTableStats: CachedDataReducerState<api.NonTableStatsResponseMessage>;
   logs: CachedDataReducerState<api.LogEntriesResponseMessage>;
@@ -595,7 +587,6 @@ export const apiReducersReducer = combineReducers<APIReducersState>({
   [databaseDetailsReducerObj.actionNamespace]:
     databaseDetailsReducerObj.reducer,
   [tableDetailsReducerObj.actionNamespace]: tableDetailsReducerObj.reducer,
-  [tableStatsReducerObj.actionNamespace]: tableStatsReducerObj.reducer,
   [indexStatsReducerObj.actionNamespace]: indexStatsReducerObj.reducer,
   [nonTableStatsReducerObj.actionNamespace]: nonTableStatsReducerObj.reducer,
   [logsReducerObj.actionNamespace]: logsReducerObj.reducer,

--- a/pkg/ui/workspaces/db-console/src/util/api.spec.ts
+++ b/pkg/ui/workspaces/db-console/src/util/api.spec.ts
@@ -367,13 +367,11 @@ describe("rest api", function () {
             "mock zone config stmt",
           );
           expect(
-            moment(
-              resp.results.heuristicsDetails.stats_last_created_at,
-            ).isSame(mockStatsLastCreatedTimestamp),
+            moment(resp.results.heuristicsDetails.stats_last_created_at).isSame(
+              mockStatsLastCreatedTimestamp,
+            ),
           ).toBe(true);
-          expect(resp.results.stats.spanStats.approximate_disk_bytes).toBe(
-            100,
-          );
+          expect(resp.results.stats.spanStats.approximate_disk_bytes).toBe(100);
           expect(resp.results.stats.spanStats.live_bytes).toBe(200);
           expect(resp.results.stats.spanStats.total_bytes).toBe(400);
           expect(resp.results.stats.spanStats.range_count).toBe(400);

--- a/pkg/ui/workspaces/db-console/src/util/api.spec.ts
+++ b/pkg/ui/workspaces/db-console/src/util/api.spec.ts
@@ -191,7 +191,6 @@ describe("rest api", function () {
             ],
           },
         ],
-        1,
       );
 
       return clusterUiApi.getDatabaseDetails(dbName).then(result => {
@@ -275,63 +274,144 @@ describe("rest api", function () {
   describe("table details request", function () {
     const dbName = "testDB";
     const tableName = "testTable";
+    const mockOldDate = new Date(2023, 2, 3);
+    const mockZoneConfig = new ZoneConfig({
+      inherited_constraints: true,
+      inherited_lease_preferences: true,
+      null_voter_constraints_is_empty: true,
+      global_reads: true,
+      gc: {
+        ttl_seconds: 100,
+      },
+    });
+    const mockZoneConfigBytes = ZoneConfig.encode(mockZoneConfig).finish();
+    const mockZoneConfigHexString = Array.from(mockZoneConfigBytes)
+      .map(x => x.toString(16).padStart(2, "0"))
+      .join("");
+    const mockStatsLastCreatedTimestamp = moment();
 
     afterEach(fetchMock.restore);
 
     it("correctly requests info about a specific table", function () {
       // Mock out the fetch query
-      fetchMock.mock({
-        matcher: `${api.API_PREFIX}/databases/${dbName}/tables/${tableName}`,
-        method: "GET",
-        response: (_url: string, requestObj: RequestInit) => {
-          expect(requestObj.body).toBeUndefined();
-          const encodedResponse =
-            protos.cockroach.server.serverpb.TableDetailsResponse.encode(
-              {},
-            ).finish();
-          return {
-            body: encodedResponse,
-          };
-        },
-      });
+      stubSqlApiCall<clusterUiApi.TableDetailsRow>(
+        clusterUiApi.createTableDetailsReq(dbName, tableName),
+        [
+          // Table ID query
+          { rows: [{ table_id: "1" }] },
+          // Table grants query
+          {
+            rows: [{ user: "user", privileges: ["ALL", "NONE", "PRIVILEGE"] }],
+          },
+          // Table schema details query
+          { rows: [{ columns: ["a", "b", "c"], indexes: ["d", "e"] }] },
+          // Table create statement query
+          { rows: [{ statement: "mock create stmt" }] },
+          // Table zone config statement query
+          { rows: [{ raw_config_sql: "mock zone config stmt" }] },
+          // Table heuristics query
+          { rows: [{ stats_last_created_at: mockStatsLastCreatedTimestamp }] },
+          // Table span stats query
+          {
+            rows: [
+              {
+                approximate_disk_bytes: 100,
+                live_bytes: 200,
+                total_bytes: 400,
+                range_count: 400,
+                live_percentage: 0.5,
+              },
+            ],
+          },
+          // Table index usage statistics query
+          {
+            rows: [
+              {
+                last_read: mockOldDate.toISOString(),
+                created_at: mockOldDate.toISOString(),
+                unused_threshold: "1m",
+              },
+            ],
+          },
+          // Table zone config query
+          {
+            rows: [
+              {
+                database_zone_config_hex_string: mockZoneConfigHexString,
+                table_zone_config_hex_string: null,
+              },
+            ],
+          },
+          // Table replicas query
+          {
+            rows: [{ replicas: [1, 2, 3] }],
+          },
+        ],
+      );
 
-      return api
-        .getTableDetails(
-          new protos.cockroach.server.serverpb.TableDetailsRequest({
-            database: dbName,
-            table: tableName,
-          }),
-        )
-        .then(result => {
+      return clusterUiApi
+        .getTableDetails({
+          database: dbName,
+          table: tableName,
+        })
+        .then(resp => {
+          expect(fetchMock.calls(clusterUiApi.SQL_API_PATH).length).toBe(1);
+          expect(resp.results.idResp.table_id).toBe("1");
+          expect(resp.results.grantsResp.grants.length).toBe(1);
+          expect(resp.results.schemaDetails.columns.length).toBe(3);
+          expect(resp.results.schemaDetails.indexes.length).toBe(2);
+          expect(resp.results.createStmtResp.statement).toBe(
+            "mock create stmt",
+          );
+          expect(resp.results.zoneConfigResp.configure_zone_statement).toBe(
+            "mock zone config stmt",
+          );
           expect(
-            fetchMock.calls(
-              `${api.API_PREFIX}/databases/${dbName}/tables/${tableName}`,
-            ).length,
-          ).toBe(1);
-          expect(result.columns.length).toBe(0);
-          expect(result.indexes.length).toBe(0);
-          expect(result.grants.length).toBe(0);
+            moment(
+              resp.results.heuristicsDetails.stats_last_created_at,
+            ).isSame(mockStatsLastCreatedTimestamp),
+          ).toBe(true);
+          expect(resp.results.stats.spanStats.approximate_disk_bytes).toBe(
+            100,
+          );
+          expect(resp.results.stats.spanStats.live_bytes).toBe(200);
+          expect(resp.results.stats.spanStats.total_bytes).toBe(400);
+          expect(resp.results.stats.spanStats.range_count).toBe(400);
+          expect(resp.results.stats.spanStats.live_percentage).toBe(0.5);
+          expect(resp.results.stats.indexStats.has_index_recommendations).toBe(
+            true,
+          );
+          expect(resp.results.zoneConfigResp.zone_config).toEqual(
+            mockZoneConfig,
+          );
+          expect(resp.results.zoneConfigResp.zone_config_level).toBe(
+            ZoneConfigurationLevel.DATABASE,
+          );
+          expect(resp.results.stats.replicaData.replicaCount).toBe(3);
+          expect(resp.results.stats.replicaData.nodeCount).toBe(3);
+          expect(resp.results.stats.replicaData.nodeIDs).toEqual([1, 2, 3]);
         });
     });
 
     it("correctly handles an error", function (done) {
       // Mock out the fetch query, but return a 500 status code
       fetchMock.mock({
-        matcher: `${api.API_PREFIX}/databases/${dbName}/tables/${tableName}`,
-        method: "GET",
+        matcher: clusterUiApi.SQL_API_PATH,
+        method: "POST",
         response: (_url: string, requestObj: RequestInit) => {
-          expect(requestObj.body).toBeUndefined();
+          expect(JSON.parse(requestObj.body.toString())).toEqual({
+            ...clusterUiApi.createTableDetailsReq(dbName, tableName),
+            application_name: clusterUiApi.INTERNAL_SQL_API_APP,
+          });
           return { throws: new Error() };
         },
       });
 
-      api
-        .getTableDetails(
-          new protos.cockroach.server.serverpb.TableDetailsRequest({
-            database: dbName,
-            table: tableName,
-          }),
-        )
+      clusterUiApi
+        .getTableDetails({
+          database: dbName,
+          table: tableName,
+        })
         .then(_result => {
           done(new Error("Request unexpectedly succeeded."));
         })
@@ -344,20 +424,23 @@ describe("rest api", function () {
     it("correctly times out", function (done) {
       // Mock out the fetch query, but return a promise that's never resolved to test the timeout
       fetchMock.mock({
-        matcher: `${api.API_PREFIX}/databases/${dbName}/tables/${tableName}`,
-        method: "GET",
+        matcher: clusterUiApi.SQL_API_PATH,
+        method: "POST",
         response: (_url: string, requestObj: RequestInit) => {
-          expect(requestObj.body).toBeUndefined();
+          expect(JSON.parse(requestObj.body.toString())).toEqual({
+            ...clusterUiApi.createTableDetailsReq(dbName, tableName),
+            application_name: clusterUiApi.INTERNAL_SQL_API_APP,
+          });
           return new Promise<any>(() => {});
         },
       });
 
-      api
+      clusterUiApi
         .getTableDetails(
-          new protos.cockroach.server.serverpb.TableDetailsRequest({
+          {
             database: dbName,
             table: tableName,
-          }),
+          },
           moment.duration(0),
         )
         .then(_result => {

--- a/pkg/ui/workspaces/db-console/src/util/api.ts
+++ b/pkg/ui/workspaces/db-console/src/util/api.ts
@@ -19,11 +19,6 @@ import * as protos from "src/js/protos";
 import { FixLong } from "src/util/fixLong";
 import { propsToQueryString } from "src/util/query";
 
-export type TableDetailsRequestMessage =
-  protos.cockroach.server.serverpb.TableDetailsRequest;
-export type TableDetailsResponseMessage =
-  protos.cockroach.server.serverpb.TableDetailsResponse;
-
 export type LocationsRequestMessage =
   protos.cockroach.server.serverpb.LocationsRequest;
 export type LocationsResponseMessage =
@@ -344,26 +339,6 @@ export type APIRequestFn<TReq, TResponse> = (
 
 const serverpb = protos.cockroach.server.serverpb;
 const tspb = protos.cockroach.ts.tspb;
-
-// getTableDetails gets details for a specific table
-export function getTableDetails(
-  req: TableDetailsRequestMessage,
-  timeout?: moment.Duration,
-): Promise<TableDetailsResponseMessage> {
-  const promiseErr = IsValidateUriName(req.database, req.table);
-  if (promiseErr) {
-    return promiseErr;
-  }
-
-  return timeoutFetch(
-    serverpb.TableDetailsResponse,
-    `${API_PREFIX}/databases/${EncodeUriName(
-      req.database,
-    )}/tables/${EncodeUriName(req.table)}`,
-    null,
-    timeout,
-  );
-}
 
 // getUIData gets UI data
 export function getUIData(

--- a/pkg/ui/workspaces/db-console/src/util/fakeApi.ts
+++ b/pkg/ui/workspaces/db-console/src/util/fakeApi.ts
@@ -18,7 +18,6 @@ import moment from "moment";
 
 const {
   SettingsResponse,
-  TableDetailsResponse,
   TableStatsResponse,
   TableIndexStatsResponse,
   NodesResponse,
@@ -194,20 +193,6 @@ export function stubNodesUI(
   stubGet(`/nodes_ui`, NodesResponse.encode(response), STATUS_PREFIX);
 }
 
-export function stubTableDetails(
-  database: string,
-  table: string,
-  response: cockroach.server.serverpb.ITableDetailsResponse,
-) {
-  stubGet(
-    `/databases/${encodeURIComponent(database)}/tables/${encodeURIComponent(
-      table,
-    )}`,
-    TableDetailsResponse.encode(response),
-    API_PREFIX,
-  );
-}
-
 export function stubTableStats(
   database: string,
   table: string,
@@ -260,7 +245,7 @@ export function createMockDatabaseRangesForTable(
 export function stubSqlApiCall<T>(
   req: clusterUiApi.SqlExecutionRequest,
   mockTxnResults: mockSqlTxnResult<T>[],
-  times?: number,
+  times: number = 1,
 ) {
   const response = buildSqlExecutionResponse(mockTxnResults);
   fetchMock.mock({

--- a/pkg/ui/workspaces/db-console/src/views/databases/databaseDetailsPage/redux.ts
+++ b/pkg/ui/workspaces/db-console/src/views/databases/databaseDetailsPage/redux.ts
@@ -16,20 +16,16 @@ import {
   DatabaseDetailsPageData,
   defaultFilters,
   Filters,
-  util,
   ViewMode,
 } from "@cockroachlabs/cluster-ui";
 
-import { cockroach } from "src/js/protos";
 import {
   generateTableID,
   refreshDatabaseDetails,
   refreshTableDetails,
-  refreshTableStats,
 } from "src/redux/apiReducers";
 import { AdminUIState } from "src/redux/state";
 import { databaseNameAttr } from "src/util/constants";
-import { FixLong } from "src/util/fixLong";
 import { getMatchParamByName } from "src/util/query";
 import {
   nodeRegionsByIDSelector,
@@ -40,8 +36,6 @@ import {
   getNodesByRegionString,
   normalizePrivileges,
 } from "../utils";
-
-const { TableDetailsRequest, TableStatsRequest } = cockroach.server.serverpb;
 
 function normalizeRoles(raw: string[]): string[] {
   const rolePrecedence: Record<string, number> = {
@@ -97,7 +91,6 @@ export const mapStateToProps = createSelector(
 
   state => state.cachedData.databaseDetails,
   state => state.cachedData.tableDetails,
-  state => state.cachedData.tableStats,
   state => nodeRegionsByIDSelector(state),
   state => selectIsMoreThanOneNode(state),
   state => viewModeLocalSetting.selector(state),
@@ -110,7 +103,6 @@ export const mapStateToProps = createSelector(
     database,
     databaseDetails,
     tableDetails,
-    tableStats,
     nodeRegions,
     showNodeRegionsColumn,
     viewMode,
@@ -141,51 +133,47 @@ export const mapStateToProps = createSelector(
         databaseDetails[database]?.data?.results.tables_resp.tables,
         table => {
           const tableId = generateTableID(database, table);
-
           const details = tableDetails[tableId];
-          const stats = tableStats[tableId];
 
-          const roles = normalizeRoles(_.map(details?.data?.grants, "user"));
-          const grants = normalizePrivileges(
-            _.flatMap(details?.data?.grants, "privileges"),
+          const roles = normalizeRoles(
+            _.map(details?.data?.results.grantsResp.grants, "user"),
           );
-          const nodes = stats?.data?.node_ids || [];
+          const grants = normalizePrivileges(
+            _.flatMap(details?.data?.results.grantsResp.grants, "privileges"),
+          );
+          const nodes = details?.data?.results.stats.replicaData.nodeIDs || [];
           const numIndexes = _.uniq(
-            _.map(details?.data?.indexes, index => index.name),
+            details?.data?.results.schemaDetails.indexes,
           ).length;
           return {
             name: table,
+            loading: !!details?.inFlight,
+            loaded: !!details?.valid,
+            lastError: details?.lastError,
             details: {
-              loading: !!details?.inFlight,
-              loaded: !!details?.valid,
-              lastError: details?.lastError,
-              columnCount: details?.data?.columns?.length || 0,
+              columnCount:
+                details?.data?.results.schemaDetails.columns?.length || 0,
               indexCount: numIndexes,
               userCount: roles.length,
               roles: roles,
               grants: grants,
-              statsLastUpdated: details?.data?.stats_last_created_at
-                ? util.TimestampToMoment(details?.data?.stats_last_created_at)
-                : null,
+              statsLastUpdated:
+                details?.data?.results.heuristicsDetails
+                  .stats_last_created_at || null,
               hasIndexRecommendations:
-                details?.data?.has_index_recommendations || false,
-              totalBytes: FixLong(
-                details?.data?.data_total_bytes || 0,
-              ).toNumber(),
-              liveBytes: FixLong(
-                details?.data?.data_live_bytes || 0,
-              ).toNumber(),
-              livePercentage: details?.data?.data_live_percentage || 0,
-            },
-            stats: {
-              loading: !!stats?.inFlight,
-              loaded: !!stats?.valid,
-              lastError: stats?.lastError,
-              replicationSizeInBytes: FixLong(
-                stats?.data?.approximate_disk_bytes || 0,
-              ).toNumber(),
+                details?.data?.results.stats.indexStats
+                  .has_index_recommendations || false,
+              totalBytes:
+                details?.data?.results.stats.spanStats.total_bytes || 0,
+              liveBytes: details?.data?.results.stats.spanStats.live_bytes || 0,
+              livePercentage:
+                details?.data?.results.stats.spanStats.live_percentage || 0,
+              replicationSizeInBytes:
+                details?.data?.results.stats.spanStats.approximate_disk_bytes ||
+                0,
               nodes: nodes,
-              rangeCount: FixLong(stats?.data?.range_count || 0).toNumber(),
+              rangeCount:
+                details?.data?.results.stats.spanStats.range_count || 0,
               nodesByRegionString: getNodesByRegionString(
                 nodes,
                 nodeRegions,
@@ -202,10 +190,10 @@ export const mapStateToProps = createSelector(
 export const mapDispatchToProps = {
   refreshDatabaseDetails,
   refreshTableDetails: (database: string, table: string) => {
-    return refreshTableDetails(new TableDetailsRequest({ database, table }));
-  },
-  refreshTableStats: (database: string, table: string) => {
-    return refreshTableStats(new TableStatsRequest({ database, table }));
+    return refreshTableDetails({
+      database,
+      table,
+    });
   },
   onViewModeChange: (viewMode: ViewMode) => viewModeLocalSetting.set(viewMode),
   onSortingTablesChange: (columnName: string, ascending: boolean) =>

--- a/pkg/ui/workspaces/db-console/src/views/databases/databaseTablePage/redux.spec.ts
+++ b/pkg/ui/workspaces/db-console/src/views/databases/databaseTablePage/redux.spec.ts
@@ -16,9 +16,9 @@ import {
   DatabaseTablePageActions,
   DatabaseTablePageData,
   DatabaseTablePageDataDetails,
-  DatabaseTablePageDataStats,
   DatabaseTablePageIndexStats,
   util,
+  api as clusterUiApi,
 } from "@cockroachlabs/cluster-ui";
 
 import { AdminUIState, createAdminUIStore } from "src/redux/state";
@@ -26,6 +26,7 @@ import { databaseNameAttr, tableNameAttr } from "src/util/constants";
 import * as fakeApi from "src/util/fakeApi";
 import { mapStateToProps, mapDispatchToProps } from "./redux";
 import { makeTimestamp } from "src/views/databases/utils";
+import moment from "moment";
 
 function fakeRouteComponentProps(
   k1: string,
@@ -94,11 +95,20 @@ class TestDriver {
   }
 
   assertTableDetails(expected: DatabaseTablePageDataDetails) {
-    expect(this.properties().details).toEqual(expected);
-  }
-
-  assertTableStats(expected: DatabaseTablePageDataStats) {
-    expect(this.properties().stats).toEqual(expected);
+    // We destructure the expected and actual payloads to extract the field
+    // with Moment type. Moment types cannot be compared using toEqual or toBe,
+    // we need to use moment's isSame function.
+    const { statsLastUpdated, ...rest } = this.properties().details;
+    const { statsLastUpdated: expectedStatsLastUpdated, ...expectedRest } =
+      expected;
+    expect(rest).toEqual(expectedRest);
+    expect(
+      // Moments are the same
+      moment(statsLastUpdated).isSame(expectedStatsLastUpdated) ||
+        // Moments are null.
+        (statsLastUpdated === expectedStatsLastUpdated &&
+          statsLastUpdated === null),
+    ).toBe(true);
   }
 
   assertIndexStats(
@@ -126,10 +136,6 @@ class TestDriver {
   }
   async refreshTableDetails() {
     return this.actions.refreshTableDetails(this.database, this.table);
-  }
-
-  async refreshTableStats() {
-    return this.actions.refreshTableStats(this.database, this.table);
   }
 
   async refreshIndexStats() {
@@ -178,16 +184,11 @@ describe("Database Table Page", function () {
           livePercentage: 0,
           liveBytes: 0,
           totalBytes: 0,
-        },
-        automaticStatsCollectionEnabled: true,
-        stats: {
-          loading: false,
-          loaded: false,
-          lastError: undefined,
           sizeInBytes: 0,
           rangeCount: 0,
           nodesByRegionString: "",
         },
+        automaticStatsCollectionEnabled: true,
         indexStats: {
           loading: false,
           loaded: false,
@@ -201,25 +202,65 @@ describe("Database Table Page", function () {
   });
 
   it("loads table details", async function () {
-    fakeApi.stubTableDetails("DATABASE", "TABLE", {
-      grants: [
-        { user: "admin", privileges: ["CREATE", "DROP"] },
-        { user: "public", privileges: ["SELECT"] },
+    const mockStatsLastCreatedTimestamp = moment();
+
+    fakeApi.stubSqlApiCall<clusterUiApi.TableDetailsRow>(
+      clusterUiApi.createTableDetailsReq("DATABASE", "TABLE"),
+      [
+        // Table ID query
+        { rows: [{ table_id: "1" }] },
+        // Table grants query
+        {
+          rows: [
+            { user: "admin", privileges: ["CREATE", "DROP"] },
+            { user: "public", privileges: ["SELECT"] },
+          ],
+        },
+        // Table schema details query
+        {
+          rows: [
+            {
+              columns: ["colA", "colB", "c"],
+              indexes: ["primary", "anotha", "one"],
+            },
+          ],
+        },
+        // Table create statement query
+        { rows: [{ statement: "CREATE TABLE foo" }] },
+        // Table zone config statement query
+        {},
+        // Table heuristics query
+        { rows: [{ stats_last_created_at: mockStatsLastCreatedTimestamp }] },
+        // Table span stats query
+        {
+          rows: [
+            {
+              approximate_disk_bytes: 23,
+              live_bytes: 45,
+              total_bytes: 45,
+              range_count: 56,
+              live_percentage: 1,
+            },
+          ],
+        },
+        // Table index usage statistics query
+        {
+          rows: [
+            {
+              last_read: new Date().toISOString(),
+              created_at: new Date().toISOString(),
+              unused_threshold: "1m",
+            },
+          ],
+        },
+        // Table zone config query
+        {},
+        // Table replicas query
+        {
+          rows: [{ replicas: [1, 2, 3, 4, 5] }],
+        },
       ],
-      indexes: [
-        { name: "primary" },
-        { name: "another_index", seq: new Long(1) },
-        { name: "another_index", seq: new Long(2) },
-      ],
-      create_table_statement: "CREATE TABLE foo",
-      zone_config: {
-        num_replicas: 5,
-      },
-      stats_last_created_at: makeTimestamp("0001-01-01T00:00:00Z"),
-      data_total_bytes: new Long(456789),
-      data_live_bytes: new Long(12345),
-      data_live_percentage: 2.0,
-    });
+    );
 
     await driver.refreshTableDetails();
 
@@ -229,35 +270,18 @@ describe("Database Table Page", function () {
       lastError: null,
       createStatement: "CREATE TABLE foo",
       replicaCount: 5,
-      indexNames: ["primary", "another_index"],
+      indexNames: ["primary", "anotha", "one"],
       grants: [
         { user: "admin", privileges: ["CREATE", "DROP"] },
         { user: "public", privileges: ["SELECT"] },
       ],
-      statsLastUpdated: util.TimestampToMoment(
-        makeTimestamp("0001-01-01T00:00:00Z"),
-      ),
-      livePercentage: 2.0,
-      liveBytes: 12345,
-      totalBytes: 456789,
-    });
-  });
-
-  it("loads table stats", async function () {
-    fakeApi.stubTableStats("DATABASE", "TABLE", {
-      range_count: new Long(4200),
-      approximate_disk_bytes: new Long(44040192),
-    });
-
-    await driver.refreshTableStats();
-
-    driver.assertTableStats({
-      loading: false,
-      loaded: true,
-      lastError: null,
-      sizeInBytes: 44040192,
-      rangeCount: 4200,
-      nodesByRegionString: "",
+      statsLastUpdated: mockStatsLastCreatedTimestamp,
+      livePercentage: 1,
+      liveBytes: 45,
+      totalBytes: 45,
+      sizeInBytes: 23,
+      rangeCount: 56,
+      nodesByRegionString: "undefined(n1,n2,n3,n4,n5)",
     });
   });
 

--- a/pkg/ui/workspaces/db-console/src/views/databases/databasesPage/redux.spec.ts
+++ b/pkg/ui/workspaces/db-console/src/views/databases/databasesPage/redux.spec.ts
@@ -244,7 +244,6 @@ describe("Databases Page", function () {
           ],
         },
       ],
-      1,
     );
 
     await driver.refreshNodes();


### PR DESCRIPTION
Part of: https://github.com/cockroachdb/cockroach/issues/89429
Resolves: https://github.com/cockroachdb/cockroach/issues/90264, https://github.com/cockroachdb/cockroach/issues/90268

This PR migrates our existing admin API table details endpoint to
use sql-over-http in cluster-ui. We change the structure of the table
details response, allowing each field to be a self-contained query
response. The exception here is the `stats` field, which is comprised of
a couple query responses. Changing the structure scopes errors at the
query-level, instead of the response level. This is important as it
allows us to still make use of partial data on the UI when only a subset
of the queries succeed.

The commit also coalesces the former table stats and table details API
into a single table details API. The only difference/movement here is
that the table details endpoint now fetches span statistics.

The data for table details is populated using 10 queries, which fetch
the table's:
- ID
- grants
- schema details (columns & indexes)
- create statement
- zone configuration statement
- zone configuration
- heuristics details (specifically, the timestamp at which table
  heuristics were last updated)
- span statistics
- index usage statistics
- replicas

This largely reflects like for like how we fetch data from the existing
admin api endpoint. We can improve upon this (i.e. remove bloating) in
follow up PRs.

**Short Demo**
https://www.loom.com/share/698c10c5752e439a9edb0ec2301771c1

Release note: None