### PR TITLE
ui: remove polling from fingerprints pages, allow new stats requests while one is in flight

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/api/statementsApi.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/api/statementsApi.ts
@@ -19,10 +19,11 @@ import {
 } from "src/util";
 import Long from "long";
 import { AggregateStatistics } from "../statementsTable";
-const STATEMENTS_PATH = "/_status/statements";
+const STATEMENTS_PATH = "/_status/combinedstmts";
 const STATEMENT_DETAILS_PATH = "/_status/stmtdetails";
 
-export type StatementsRequest = cockroach.server.serverpb.StatementsRequest;
+export type StatementsRequest =
+  cockroach.server.serverpb.CombinedStatementsStatsRequest;
 export type StatementDetailsRequest =
   cockroach.server.serverpb.StatementDetailsRequest;
 export type StatementDetailsResponse =
@@ -42,7 +43,6 @@ export const getCombinedStatements = (
   const queryStr = propsToQueryString({
     start: req.start.toInt(),
     end: req.end.toInt(),
-    combined: req.combined,
   });
   return fetchData(
     cockroach.server.serverpb.StatementsResponse,

--- a/pkg/ui/workspaces/cluster-ui/src/sessions/sessionDetailsConnected.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/sessions/sessionDetailsConnected.tsx
@@ -44,8 +44,7 @@ export const SessionDetailsPageConnected = withRouter(
       refreshNodes: nodesActions.refresh,
       refreshNodesLiveness: nodesLivenessActions.refresh,
       setTimeScale: (ts: TimeScale) =>
-        localStorageActions.update({
-          key: "timeScale/SQLActivity",
+        localStorageActions.updateTimeScale({
           value: ts,
         }),
       onTerminateSessionClick: () =>

--- a/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.fixture.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.fixture.ts
@@ -583,6 +583,7 @@ const statementsPagePropsFixture: StatementsPageProps = {
   },
   lastUpdated,
   isDataValid: true,
+  isReqInFlight: false,
   // Aggregate key values in these statements will need to change if implementation
   // of 'statementKey' in appStats.ts changes.
   statementsError: null,

--- a/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.selectors.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.selectors.ts
@@ -127,6 +127,13 @@ export const selectStatementsDataValid = createSelector(
   },
 );
 
+export const selectStatementsDataInFlight = createSelector(
+  sqlStatsSelector,
+  (state: SQLStatsState): boolean => {
+    return state.inFlight;
+  },
+);
+
 export const selectStatements = createSelector(
   sqlStatsSelector,
   (_: AppState, props: RouteComponentProps) => props,

--- a/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.tsx
@@ -146,12 +146,9 @@ export type StatementsPageProps = StatementsPageDispatchProps &
   StatementsPageStateProps &
   RouteComponentProps<unknown>;
 
-function stmtsRequestFromTimeScale(
-  ts: TimeScale,
-): cockroach.server.serverpb.StatementsRequest {
+function stmtsRequestFromTimeScale(ts: TimeScale): StatementsRequest {
   const [start, end] = toRoundedDateRange(ts);
-  return new cockroach.server.serverpb.StatementsRequest({
-    combined: true,
+  return new cockroach.server.serverpb.CombinedStatementsStatsRequest({
     start: Long.fromNumber(start.unix()),
     end: Long.fromNumber(end.unix()),
   });

--- a/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.tsx
@@ -78,6 +78,7 @@ import {
   StatementDiagnosticsReport,
 } from "../api";
 import { filteredStatementsData } from "../sqlActivity/util";
+import { STATS_LONG_LOADING_DURATION } from "../util/constants";
 
 const cx = classNames.bind(styles);
 const sortableTableCx = classNames.bind(sortableTableStyles);
@@ -576,7 +577,7 @@ export class StatementsPage extends React.Component<
     const { filters, activeFilters } = this.state;
 
     const longLoadingMessage = (
-      <Delayed delay={moment.duration(2, "s")}>
+      <Delayed delay={STATS_LONG_LOADING_DURATION}>
         <InlineAlert
           intent="info"
           title="If the selected time interval contains a large amount of data, this page might take a few minutes to load."

--- a/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.tsx
@@ -10,7 +10,7 @@
 
 import React from "react";
 import { RouteComponentProps } from "react-router-dom";
-import { flatMap, isNil, merge } from "lodash";
+import { flatMap, merge } from "lodash";
 import classNames from "classnames/bind";
 import { getValidErrorsList, Loading } from "src/loading";
 import { Delayed } from "src/delayed";
@@ -82,8 +82,6 @@ import { filteredStatementsData } from "../sqlActivity/util";
 const cx = classNames.bind(styles);
 const sortableTableCx = classNames.bind(sortableTableStyles);
 
-const POLLING_INTERVAL_MILLIS = 300000;
-
 // Most of the props are supposed to be provided as connected props
 // from redux store.
 // StatementsPageDispatchProps, StatementsPageStateProps, and StatementsPageOuterProps interfaces
@@ -95,7 +93,7 @@ export interface StatementsPageDispatchProps {
   refreshStatementDiagnosticsRequests: () => void;
   refreshNodes: () => void;
   refreshUserSQLRoles: () => void;
-  resetSQLStats: (req: StatementsRequest) => void;
+  resetSQLStats: () => void;
   dismissAlertMessage: () => void;
   onActivateStatementDiagnostics: (
     insertStmtDiagnosticsRequest: InsertStmtDiagnosticRequest,
@@ -120,6 +118,7 @@ export interface StatementsPageDispatchProps {
 export interface StatementsPageStateProps {
   statements: AggregateStatistics[];
   isDataValid: boolean;
+  isReqInFlight: boolean;
   lastUpdated: moment.Moment | null;
   timeScale: TimeScale;
   statementsError: Error | null;
@@ -141,7 +140,6 @@ export interface StatementsPageState {
   pagination: ISortedTablePagination;
   filters?: Filters;
   activeFilters?: number;
-  startRequest?: Date;
 }
 
 export type StatementsPageProps = StatementsPageDispatchProps &
@@ -187,7 +185,6 @@ export class StatementsPage extends React.Component<
   StatementsPageState
 > {
   activateDiagnosticsRef: React.RefObject<ActivateDiagnosticsModalRef>;
-  refreshDataTimeout: NodeJS.Timeout;
 
   constructor(props: StatementsPageProps) {
     super(props);
@@ -196,19 +193,10 @@ export class StatementsPage extends React.Component<
         pageSize: 20,
         current: 1,
       },
-      startRequest: new Date(),
     };
     const stateFromHistory = this.getStateFromHistory();
     this.state = merge(defaultState, stateFromHistory);
     this.activateDiagnosticsRef = React.createRef();
-
-    // In case the user selected a option not available on this page,
-    // force a selection of a valid option. This is necessary for the case
-    // where the value 10/30 min is selected on the Metrics page.
-    const ts = getValidOption(this.props.timeScale, timeScale1hMinOptions);
-    if (ts !== this.props.timeScale) {
-      this.changeTimeScale(ts);
-    }
   }
 
   getStateFromHistory = (): Partial<StatementsPageState> => {
@@ -267,10 +255,6 @@ export class StatementsPage extends React.Component<
     if (this.props.onTimeScaleChange) {
       this.props.onTimeScaleChange(ts);
     }
-    this.refreshStatements(ts);
-    this.setState({
-      startRequest: new Date(),
-    });
   };
 
   resetPagination = (): void => {
@@ -284,29 +268,9 @@ export class StatementsPage extends React.Component<
     });
   };
 
-  clearRefreshDataTimeout(): void {
-    if (this.refreshDataTimeout != null) {
-      clearTimeout(this.refreshDataTimeout);
-    }
-  }
-
-  resetPolling(ts: TimeScale): void {
-    this.clearRefreshDataTimeout();
-    if (ts.key !== "Custom") {
-      this.refreshDataTimeout = setTimeout(
-        this.refreshStatements,
-        POLLING_INTERVAL_MILLIS, // 5 minutes
-        ts,
-      );
-    }
-  }
-
-  refreshStatements = (ts?: TimeScale): void => {
-    const time = ts ?? this.props.timeScale;
-    const req = stmtsRequestFromTimeScale(time);
+  refreshStatements = (): void => {
+    const req = stmtsRequestFromTimeScale(this.props.timeScale);
     this.props.refreshStatements(req);
-
-    this.resetPolling(time);
   };
 
   refreshDatabases = (): void => {
@@ -314,42 +278,24 @@ export class StatementsPage extends React.Component<
   };
 
   resetSQLStats = (): void => {
-    const req = stmtsRequestFromTimeScale(this.props.timeScale);
-    this.props.resetSQLStats(req);
-    this.setState({
-      startRequest: new Date(),
-    });
+    this.props.resetSQLStats();
   };
 
   componentDidMount(): void {
-    this.setState({
-      startRequest: new Date(),
-    });
-
-    // For the first data fetch for this page, we refresh immediately if:
-    // - Last updated is null (no statements fetched previously)
-    // - The data is not valid (time scale may have changed on other pages)
-    // - The time range selected is a moving window and the last udpated time
-    // is >= 5 minutes.
-    // Otherwise, we schedule a refresh at 5 mins from the lastUpdated time if
-    // the time range selected is a moving window (i.e. not custom).
-    const now = moment();
-    let nextRefresh = null;
-    if (this.props.lastUpdated == null || !this.props.isDataValid) {
-      nextRefresh = now;
-    } else if (this.props.timeScale.key !== "Custom") {
-      nextRefresh = this.props.lastUpdated
-        .clone()
-        .add(POLLING_INTERVAL_MILLIS, "milliseconds");
-    }
-    if (nextRefresh) {
-      this.refreshDataTimeout = setTimeout(
-        this.refreshStatements,
-        Math.max(0, nextRefresh.diff(now, "milliseconds")),
-      );
-    }
-
     this.refreshDatabases();
+    // In case the user selected a option not available on this page,
+    // force a selection of a valid option. This is necessary for the case
+    // where the value 10/30 min is selected on the Metrics page.
+    const ts = getValidOption(this.props.timeScale, timeScale1hMinOptions);
+    if (ts !== this.props.timeScale) {
+      this.changeTimeScale(ts);
+    } else if (
+      !this.props.isDataValid ||
+      !this.props.lastUpdated ||
+      !this.props.statements
+    ) {
+      this.refreshStatements();
+    }
 
     this.props.refreshUserSQLRoles();
     if (!this.props.isTenant) {
@@ -392,7 +338,7 @@ export class StatementsPage extends React.Component<
     );
   }
 
-  componentDidUpdate = (): void => {
+  componentDidUpdate = (prevProps: StatementsPageProps): void => {
     this.updateQueryParams();
     if (!this.props.isTenant) {
       this.props.refreshNodes();
@@ -400,11 +346,17 @@ export class StatementsPage extends React.Component<
         this.props.refreshStatementDiagnosticsRequests();
       }
     }
+
+    if (
+      prevProps.timeScale !== this.props.timeScale ||
+      (prevProps.isDataValid && !this.props.isDataValid)
+    ) {
+      this.refreshStatements();
+    }
   };
 
   componentWillUnmount(): void {
     this.props.dismissAlertMessage();
-    this.clearRefreshDataTimeout();
   }
 
   onChangePage = (current: number): void => {
@@ -493,7 +445,6 @@ export class StatementsPage extends React.Component<
   renderStatements = (regions: string[]): React.ReactElement => {
     const { pagination, filters, activeFilters } = this.state;
     const {
-      statements,
       onSelectDiagnosticsReportDropdownOption,
       onStatementClick,
       columns: userSelectedColumnsToShow,
@@ -504,6 +455,7 @@ export class StatementsPage extends React.Component<
       sortSetting,
       search,
     } = this.props;
+    const statements = this.props.statements ?? [];
     const data = filteredStatementsData(
       filters,
       search,
@@ -626,15 +578,14 @@ export class StatementsPage extends React.Component<
 
     const { filters, activeFilters } = this.state;
 
-    const longLoadingMessage = isNil(this.props.statements) &&
-      isNil(getValidErrorsList(this.props.statementsError)) && (
-        <Delayed delay={moment.duration(2, "s")}>
-          <InlineAlert
-            intent="info"
-            title="If the selected time interval contains a large amount of data, this page might take a few minutes to load."
-          />
-        </Delayed>
-      );
+    const longLoadingMessage = (
+      <Delayed delay={moment.duration(2, "s")}>
+        <InlineAlert
+          intent="info"
+          title="If the selected time interval contains a large amount of data, this page might take a few minutes to load."
+        />
+      </Delayed>
+    );
 
     return (
       <div className={cx("root")}>
@@ -684,7 +635,7 @@ export class StatementsPage extends React.Component<
         </PageConfig>
         <div className={cx("table-area")}>
           <Loading
-            loading={isNil(this.props.statements)}
+            loading={this.props.isReqInFlight}
             page={"statements"}
             error={this.props.statementsError}
             render={() => this.renderStatements(regions)}
@@ -697,7 +648,9 @@ export class StatementsPage extends React.Component<
               })
             }
           />
-          {longLoadingMessage}
+          {this.props.isReqInFlight &&
+            getValidErrorsList(this.props.statementsError) == null &&
+            longLoadingMessage}
           <ActivateStatementDiagnosticsModal
             ref={this.activateDiagnosticsRef}
             activate={onActivateStatementDiagnostics}

--- a/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPageConnected.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPageConnected.tsx
@@ -29,6 +29,7 @@ import {
   selectLastReset,
   selectStatements,
   selectStatementsDataValid,
+  selectStatementsDataInFlight,
   selectStatementsLastError,
   selectTotalFingerprints,
   selectColumns,
@@ -97,6 +98,7 @@ export const ConnectedStatementsPage = withRouter(
         sortSetting: selectSortSetting(state),
         statements: selectStatements(state, props),
         isDataValid: selectStatementsDataValid(state),
+        isReqInFlight: selectStatementsDataInFlight(state),
         lastUpdated: selectStatementsLastUpdated(state),
         statementsError: selectStatementsLastError(state),
         totalFingerprints: selectTotalFingerprints(state),
@@ -120,8 +122,7 @@ export const ConnectedStatementsPage = withRouter(
         refreshNodes: () => dispatch(nodesActions.refresh()),
         refreshUserSQLRoles: () =>
           dispatch(uiConfigActions.refreshUserSQLRoles()),
-        resetSQLStats: (req: StatementsRequest) =>
-          dispatch(sqlStatsActions.reset(req)),
+        resetSQLStats: () => dispatch(sqlStatsActions.reset()),
         dismissAlertMessage: () =>
           dispatch(
             localStorageActions.update({

--- a/pkg/ui/workspaces/cluster-ui/src/store/localStorage/localStorage.reducer.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/store/localStorage/localStorage.reducer.ts
@@ -19,6 +19,10 @@ type SortSetting = {
   columnTitle: string;
 };
 
+export enum LocalStorageKeys {
+  GLOBAL_TIME_SCALE = "timeScale/SQLActivity",
+}
+
 export type LocalStorageState = {
   "adminUi/showDiagnosticsModal": boolean;
   "showColumns/ActiveStatementsPage": string;
@@ -28,7 +32,7 @@ export type LocalStorageState = {
   "showColumns/SessionsPage": string;
   "showColumns/StatementInsightsPage": string;
   "showColumns/JobsPage": string;
-  "timeScale/SQLActivity": TimeScale;
+  [LocalStorageKeys.GLOBAL_TIME_SCALE]: TimeScale;
   "sortSetting/ActiveStatementsPage": SortSetting;
   "sortSetting/ActiveTransactionsPage": SortSetting;
   "sortSetting/StatementsPage": SortSetting;
@@ -56,6 +60,10 @@ export type LocalStorageState = {
 type Payload = {
   key: keyof LocalStorageState;
   value: any;
+};
+
+type TypedPayload<T> = {
+  value: T;
 };
 
 const defaultSortSetting: SortSetting = {
@@ -134,8 +142,8 @@ const initialState: LocalStorageState = {
   "showSetting/JobsPage":
     JSON.parse(localStorage.getItem("showSetting/JobsPage")) ||
     defaultJobShowSetting,
-  "timeScale/SQLActivity":
-    JSON.parse(localStorage.getItem("timeScale/SQLActivity")) ||
+  [LocalStorageKeys.GLOBAL_TIME_SCALE]:
+    JSON.parse(localStorage.getItem(LocalStorageKeys.GLOBAL_TIME_SCALE)) ||
     defaultTimeScaleSelected,
   "sortSetting/ActiveStatementsPage":
     JSON.parse(localStorage.getItem("sortSetting/ActiveStatementsPage")) ||
@@ -204,6 +212,12 @@ const localStorageSlice = createSlice({
   reducers: {
     update: (state: any, action: PayloadAction<Payload>) => {
       state[action.payload.key] = action.payload.value;
+    },
+    updateTimeScale: (
+      state,
+      action: PayloadAction<TypedPayload<TimeScale>>,
+    ) => {
+      state[LocalStorageKeys.GLOBAL_TIME_SCALE] = action.payload.value;
     },
   },
 });

--- a/pkg/ui/workspaces/cluster-ui/src/store/localStorage/localStorage.saga.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/store/localStorage/localStorage.saga.ts
@@ -9,8 +9,11 @@
 // licenses/APL.txt.
 
 import { AnyAction } from "redux";
-import { all, call, takeEvery } from "redux-saga/effects";
+import { all, call, takeEvery, takeLatest, put } from "redux-saga/effects";
 import { actions } from "./localStorage.reducer";
+import { actions as sqlStatsActions } from "src/store/sqlStats";
+import { actions as stmtInsightActions } from "src/store/insights/statementInsights";
+import { actions as txnInsightActions } from "src/store/insights/transactionInsights";
 
 export function* updateLocalStorageItemSaga(action: AnyAction) {
   const { key, value } = action.payload;
@@ -21,6 +24,17 @@ export function* updateLocalStorageItemSaga(action: AnyAction) {
   );
 }
 
+export function* updateTimeScale(action: AnyAction) {
+  yield all([
+    put(sqlStatsActions.invalidated()),
+    put(stmtInsightActions.invalidated()),
+    put(txnInsightActions.invalidated()),
+  ]);
+}
+
 export function* localStorageSaga() {
-  yield all([takeEvery(actions.update, updateLocalStorageItemSaga)]);
+  yield all([
+    takeEvery(actions.update, updateLocalStorageItemSaga),
+    takeLatest(actions.updateTimeScale, updateLocalStorageItemSaga),
+  ]);
 }

--- a/pkg/ui/workspaces/cluster-ui/src/store/sqlStats/sqlStats.reducer.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/store/sqlStats/sqlStats.reducer.ts
@@ -22,6 +22,7 @@ export type SQLStatsState = {
   lastError: Error;
   valid: boolean;
   lastUpdated: moment.Moment | null;
+  inFlight: boolean;
 };
 
 const initialState: SQLStatsState = {
@@ -29,6 +30,7 @@ const initialState: SQLStatsState = {
   lastError: null,
   valid: false,
   lastUpdated: null,
+  inFlight: false,
 };
 
 export type UpdateTimeScalePayload = {
@@ -44,19 +46,25 @@ const sqlStatsSlice = createSlice({
       state.valid = true;
       state.lastError = null;
       state.lastUpdated = moment.utc();
+      state.inFlight = false;
     },
     failed: (state, action: PayloadAction<Error>) => {
       state.valid = false;
       state.lastError = action.payload;
       state.lastUpdated = moment.utc();
+      state.inFlight = false;
     },
     invalidated: state => {
       state.valid = false;
     },
-    refresh: (_, action: PayloadAction<StatementsRequest>) => {},
-    request: (_, action: PayloadAction<StatementsRequest>) => {},
-    updateTimeScale: (_, action: PayloadAction<UpdateTimeScalePayload>) => {},
-    reset: (_, action: PayloadAction<StatementsRequest>) => {},
+    refresh: (state, action: PayloadAction<StatementsRequest>) => {
+      state.inFlight = true;
+    },
+    request: (state, action: PayloadAction<StatementsRequest>) => {
+      state.inFlight = true;
+    },
+    updateTimeScale: (_, _action: PayloadAction<UpdateTimeScalePayload>) => {},
+    reset: (_, _action: PayloadAction<StatementsRequest>) => {},
   },
 });
 

--- a/pkg/ui/workspaces/cluster-ui/src/store/sqlStats/sqlStats.sagas.spec.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/store/sqlStats/sqlStats.sagas.spec.ts
@@ -82,6 +82,7 @@ describe("SQLStats sagas", () => {
           lastError: null,
           valid: true,
           lastUpdated,
+          inFlight: false,
         })
         .run();
     });
@@ -97,6 +98,7 @@ describe("SQLStats sagas", () => {
           lastError: error,
           valid: false,
           lastUpdated,
+          inFlight: false,
         })
         .run();
     });
@@ -107,23 +109,24 @@ describe("SQLStats sagas", () => {
       new cockroach.server.serverpb.ResetSQLStatsResponse();
 
     it("successfully resets SQL stats", () => {
-      return expectSaga(resetSQLStatsSaga, payload)
+      return expectSaga(resetSQLStatsSaga)
         .provide([[matchers.call.fn(resetSQLStats), resetSQLStatsResponse]])
         .put(sqlDetailsStatsActions.invalidateAll())
-        .put(actions.refresh())
+        .put(actions.invalidated())
         .withReducer(reducer)
         .hasFinalState<SQLStatsState>({
           data: null,
           lastError: null,
           valid: false,
           lastUpdated: null,
+          inFlight: false,
         })
         .run();
     });
 
     it("returns error on failed reset", () => {
       const err = new Error("failed to reset");
-      return expectSaga(resetSQLStatsSaga, payload)
+      return expectSaga(resetSQLStatsSaga)
         .provide([[matchers.call.fn(resetSQLStats), throwError(err)]])
         .put(actions.failed(err))
         .withReducer(reducer)
@@ -132,6 +135,7 @@ describe("SQLStats sagas", () => {
           lastError: err,
           valid: false,
           lastUpdated,
+          inFlight: false,
         })
         .run();
     });

--- a/pkg/ui/workspaces/cluster-ui/src/store/sqlStats/sqlStats.sagas.spec.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/store/sqlStats/sqlStats.sagas.spec.ts
@@ -41,10 +41,9 @@ describe("SQLStats sagas", () => {
     spy.mockRestore();
   });
 
-  const payload = new cockroach.server.serverpb.StatementsRequest({
+  const payload = new cockroach.server.serverpb.CombinedStatementsStatsRequest({
     start: Long.fromNumber(1596816675),
     end: Long.fromNumber(1596820675),
-    combined: true,
   });
   const sqlStatsResponse = new cockroach.server.serverpb.StatementsResponse({
     statements: [

--- a/pkg/ui/workspaces/cluster-ui/src/store/sqlStats/sqlStats.sagas.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/store/sqlStats/sqlStats.sagas.ts
@@ -21,8 +21,6 @@ import {
   UpdateTimeScalePayload,
 } from "./sqlStats.reducer";
 import { actions as sqlDetailsStatsActions } from "../statementDetails/statementDetails.reducer";
-import { actions as stmtInsightActions } from "../insights/statementInsights";
-import { actions as txnInsightActions } from "../insights/transactionInsights";
 
 export function* refreshSQLStatsSaga(action: PayloadAction<StatementsRequest>) {
   yield put(sqlStatsActions.request(action.payload));
@@ -44,24 +42,19 @@ export function* updateSQLStatsTimeScaleSaga(
 ) {
   const { ts } = action.payload;
   yield put(
-    localStorageActions.update({
-      key: "timeScale/SQLActivity",
+    localStorageActions.updateTimeScale({
       value: ts,
     }),
   );
-  yield all([
-    put(sqlStatsActions.invalidated()),
-    put(stmtInsightActions.invalidated()),
-    put(txnInsightActions.invalidated()),
-  ]);
 }
 
-export function* resetSQLStatsSaga(action: PayloadAction<StatementsRequest>) {
+export function* resetSQLStatsSaga() {
   try {
     yield call(resetSQLStats);
-    yield put(sqlDetailsStatsActions.invalidateAll());
-    yield put(sqlStatsActions.invalidated());
-    yield put(sqlStatsActions.refresh(action.payload));
+    yield all([
+      put(sqlDetailsStatsActions.invalidateAll()),
+      put(sqlStatsActions.invalidated()),
+    ]);
   } catch (e) {
     yield put(sqlStatsActions.failed(e));
   }

--- a/pkg/ui/workspaces/cluster-ui/src/store/utils/selectors.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/store/utils/selectors.ts
@@ -9,6 +9,7 @@
 // licenses/APL.txt.
 
 import { createSelector } from "reselect";
+import { LocalStorageKeys } from "../localStorage";
 import { AppState } from "../reducers";
 
 export const adminUISelector = createSelector(
@@ -23,5 +24,5 @@ export const localStorageSelector = createSelector(
 
 export const selectTimeScale = createSelector(
   localStorageSelector,
-  localStorage => localStorage["timeScale/SQLActivity"],
+  localStorage => localStorage[LocalStorageKeys.GLOBAL_TIME_SCALE],
 );

--- a/pkg/ui/workspaces/cluster-ui/src/transactionDetails/transactionDetails.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionDetails/transactionDetails.tsx
@@ -137,8 +137,7 @@ function statementsRequestFromProps(
   props: TransactionDetailsProps,
 ): StatementsRequest {
   const [start, end] = toRoundedDateRange(props.timeScale);
-  return new protos.cockroach.server.serverpb.StatementsRequest({
-    combined: true,
+  return new protos.cockroach.server.serverpb.CombinedStatementsStatsRequest({
     start: Long.fromNumber(start.unix()),
     end: Long.fromNumber(end.unix()),
   });

--- a/pkg/ui/workspaces/cluster-ui/src/transactionDetails/transactionDetailsConnected.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionDetails/transactionDetailsConnected.tsx
@@ -50,8 +50,9 @@ export const selectTransaction = createSelector(
     const transactions = transactionState.data?.transactions;
     if (!transactions) {
       return {
-        isLoading: true,
+        isLoading: transactionState.inFlight,
         transaction: null,
+        isValid: transactionState.valid,
       };
     }
     const txnFingerprintId = getMatchParamByName(
@@ -65,9 +66,10 @@ export const selectTransaction = createSelector(
         txnFingerprintId,
     )[0];
     return {
-      isLoading: false,
+      isLoading: transactionState.inFlight,
       transaction: transaction,
       lastUpdated: transactionState.lastUpdated,
+      isValid: transactionState.valid,
     };
   },
 );
@@ -76,7 +78,7 @@ const mapStateToProps = (
   state: AppState,
   props: TransactionDetailsProps,
 ): TransactionDetailsStateProps => {
-  const { isLoading, transaction, lastUpdated } = selectTransaction(
+  const { isLoading, transaction, lastUpdated, isValid } = selectTransaction(
     state,
     props,
   );
@@ -96,6 +98,7 @@ const mapStateToProps = (
     hasViewActivityRedactedRole: selectHasViewActivityRedactedRole(state),
     transactionInsights: selectTxnInsightsByFingerprint(state, props),
     hasAdminRole: selectHasAdminRole(state),
+    isDataValid: isValid,
   };
 };
 

--- a/pkg/ui/workspaces/cluster-ui/src/transactionsPage/transactionsPage.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionsPage/transactionsPage.tsx
@@ -78,7 +78,6 @@ type IStatementsResponse = protos.cockroach.server.serverpb.IStatementsResponse;
 
 const cx = classNames.bind(styles);
 
-const POLLING_INTERVAL_MILLIS = 300000;
 interface TState {
   filters?: Filters;
   pagination: ISortedTablePagination;
@@ -88,6 +87,7 @@ export interface TransactionsPageStateProps {
   columns: string[];
   data: IStatementsResponse;
   isDataValid: boolean;
+  isReqInFlight: boolean;
   lastUpdated: moment.Moment | null;
   timeScale: TimeScale;
   error?: Error | null;
@@ -104,7 +104,7 @@ export interface TransactionsPageDispatchProps {
   refreshData: (req: StatementsRequest) => void;
   refreshNodes: () => void;
   refreshUserSQLRoles: () => void;
-  resetSQLStats: (req: StatementsRequest) => void;
+  resetSQLStats: () => void;
   onTimeScaleChange?: (ts: TimeScale) => void;
   onColumnsChange?: (selectedColumns: string[]) => void;
   onFilterChange?: (value: Filters) => void;
@@ -134,8 +134,6 @@ export class TransactionsPage extends React.Component<
   TransactionsPageProps,
   TState
 > {
-  refreshDataTimeout: NodeJS.Timeout;
-
   constructor(props: TransactionsPageProps) {
     super(props);
     this.state = {
@@ -146,14 +144,6 @@ export class TransactionsPage extends React.Component<
     };
     const stateFromHistory = this.getStateFromHistory();
     this.state = merge(this.state, stateFromHistory);
-
-    // In case the user selected a option not available on this page,
-    // force a selection of a valid option. This is necessary for the case
-    // where the value 10/30 min is selected on the Metrics page.
-    const ts = getValidOption(this.props.timeScale, timeScale1hMinOptions);
-    if (ts !== this.props.timeScale) {
-      this.changeTimeScale(ts);
-    }
   }
 
   getStateFromHistory = (): Partial<TState> => {
@@ -194,61 +184,28 @@ export class TransactionsPage extends React.Component<
     };
   };
 
-  clearRefreshDataTimeout(): void {
-    if (this.refreshDataTimeout != null) {
-      clearTimeout(this.refreshDataTimeout);
-    }
-  }
-
-  // Schedule the next data request depending on the time
-  // range key.
-  resetPolling(ts: TimeScale): void {
-    this.clearRefreshDataTimeout();
-    if (ts.key !== "Custom") {
-      this.refreshDataTimeout = setTimeout(
-        this.refreshData,
-        POLLING_INTERVAL_MILLIS, // 5 minutes
-        ts,
-      );
-    }
-  }
-
-  refreshData = (ts?: TimeScale): void => {
-    const time = ts ?? this.props.timeScale;
-    const req = stmtsRequestFromTimeScale(time);
+  refreshData = (): void => {
+    const req = stmtsRequestFromTimeScale(this.props.timeScale);
     this.props.refreshData(req);
-
-    this.resetPolling(time);
   };
 
   resetSQLStats = (): void => {
-    const req = stmtsRequestFromTimeScale(this.props.timeScale);
-    this.props.resetSQLStats(req);
-    this.resetPolling(this.props.timeScale);
+    this.props.resetSQLStats();
   };
 
   componentDidMount(): void {
-    // For the first data fetch for this page, we refresh immediately if:
-    // - Last updated is null (no statements fetched previously)
-    // - The data is not valid (time scale may have changed on other pages)
-    // - The time range selected is a moving window and the last udpated time
-    // is >= 5 minutes.
-    // Otherwise, we schedule a refresh at 5 mins from the lastUpdated time if
-    // the time range selected is a moving window (i.e. not custom).
-    const now = moment();
-    let nextRefresh = null;
-    if (this.props.lastUpdated == null || !this.props.isDataValid) {
-      nextRefresh = now;
-    } else if (this.props.timeScale.key !== "Custom") {
-      nextRefresh = this.props.lastUpdated
-        .clone()
-        .add(POLLING_INTERVAL_MILLIS, "milliseconds");
-    }
-    if (nextRefresh) {
-      this.refreshDataTimeout = setTimeout(
-        this.refreshData,
-        Math.max(0, nextRefresh.diff(now, "milliseconds")),
-      );
+    // In case the user selected a option not available on this page,
+    // force a selection of a valid option. This is necessary for the case
+    // where the value 10/30 min is selected on the Metrics page.
+    const ts = getValidOption(this.props.timeScale, timeScale1hMinOptions);
+    if (ts !== this.props.timeScale) {
+      this.changeTimeScale(ts);
+    } else if (
+      !this.props.isDataValid ||
+      !this.props.data ||
+      !this.props.lastUpdated
+    ) {
+      this.refreshData();
     }
 
     if (!this.props.isTenant) {
@@ -256,10 +213,6 @@ export class TransactionsPage extends React.Component<
     }
 
     this.props.refreshUserSQLRoles();
-  }
-
-  componentWillUnmount(): void {
-    this.clearRefreshDataTimeout();
   }
 
   updateQueryParams(): void {
@@ -294,10 +247,17 @@ export class TransactionsPage extends React.Component<
     );
   }
 
-  componentDidUpdate(): void {
+  componentDidUpdate(prevProps: TransactionsPageProps): void {
     this.updateQueryParams();
     if (!this.props.isTenant) {
       this.props.refreshNodes();
+    }
+
+    if (
+      prevProps.timeScale !== this.props.timeScale ||
+      (prevProps.isDataValid && !this.props.isDataValid)
+    ) {
+      this.refreshData();
     }
   }
 
@@ -407,7 +367,6 @@ export class TransactionsPage extends React.Component<
     if (this.props.onTimeScaleChange) {
       this.props.onTimeScaleChange(ts);
     }
-    this.refreshData(ts);
   };
 
   render(): React.ReactElement {
@@ -454,7 +413,8 @@ export class TransactionsPage extends React.Component<
       data?.transactions || [],
       internal_app_name_prefix,
     );
-    const longLoadingMessage = !this.props?.data && (
+
+    const longLoadingMessage = (
       <Delayed delay={moment.duration(2, "s")}>
         <InlineAlert
           intent="info"
@@ -505,7 +465,7 @@ export class TransactionsPage extends React.Component<
         </PageConfig>
         <div className={cx("table-area")}>
           <Loading
-            loading={!this.props?.data}
+            loading={this.props.isReqInFlight}
             page={"transactions"}
             error={this.props?.error}
             render={() => {
@@ -520,7 +480,7 @@ export class TransactionsPage extends React.Component<
                   }),
                 );
               const { current, pageSize } = pagination;
-              const hasData = data.transactions?.length > 0;
+              const hasData = data?.transactions?.length > 0;
               const isUsedFilter = search?.length > 0;
 
               // Creates a list of all possible columns,
@@ -607,7 +567,7 @@ export class TransactionsPage extends React.Component<
               })
             }
           />
-          {longLoadingMessage}
+          {this.props.isReqInFlight && longLoadingMessage}
         </div>
       </>
     );

--- a/pkg/ui/workspaces/cluster-ui/src/transactionsPage/transactionsPage.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionsPage/transactionsPage.tsx
@@ -73,6 +73,7 @@ import { InlineAlert } from "@cockroachlabs/ui-components";
 import { TransactionViewType } from "./transactionsPageTypes";
 import { isSelectedColumn } from "../columnsSelector/utils";
 import moment from "moment";
+import { STATS_LONG_LOADING_DURATION } from "../util/constants";
 
 type IStatementsResponse = protos.cockroach.server.serverpb.IStatementsResponse;
 
@@ -412,7 +413,7 @@ export class TransactionsPage extends React.Component<
     );
 
     const longLoadingMessage = (
-      <Delayed delay={moment.duration(2, "s")}>
+      <Delayed delay={STATS_LONG_LOADING_DURATION}>
         <InlineAlert
           intent="info"
           title="If the selected time interval contains a large amount of data, this page might take a few minutes to load."

--- a/pkg/ui/workspaces/cluster-ui/src/transactionsPage/transactionsPage.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionsPage/transactionsPage.tsx
@@ -120,12 +120,9 @@ export type TransactionsPageProps = TransactionsPageStateProps &
   TransactionsPageDispatchProps &
   RouteComponentProps;
 
-function stmtsRequestFromTimeScale(
-  ts: TimeScale,
-): protos.cockroach.server.serverpb.StatementsRequest {
+function stmtsRequestFromTimeScale(ts: TimeScale): StatementsRequest {
   const [start, end] = toRoundedDateRange(ts);
-  return new protos.cockroach.server.serverpb.StatementsRequest({
-    combined: true,
+  return new protos.cockroach.server.serverpb.CombinedStatementsStatsRequest({
     start: Long.fromNumber(start.unix()),
     end: Long.fromNumber(end.unix()),
   });

--- a/pkg/ui/workspaces/cluster-ui/src/transactionsPage/transactionsPageConnected.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionsPage/transactionsPageConnected.tsx
@@ -32,6 +32,7 @@ import { nodeRegionsByIDSelector } from "../store/nodes";
 import {
   selectStatementsLastUpdated,
   selectStatementsDataValid,
+  selectStatementsDataInFlight,
 } from "src/statementsPage/statementsPage.selectors";
 import { selectTimeScale } from "../store/utils/selectors";
 import { StatementsRequest } from "src/api/statementsApi";
@@ -75,6 +76,7 @@ export const TransactionsPageConnected = withRouter(
         columns: selectTxnColumns(state),
         data: selectTransactionsData(state),
         isDataValid: selectStatementsDataValid(state),
+        isReqInFlight: selectStatementsDataInFlight(state),
         lastUpdated: selectStatementsLastUpdated(state),
         timeScale: selectTimeScale(state),
         error: selectTransactionsLastError(state),
@@ -94,8 +96,7 @@ export const TransactionsPageConnected = withRouter(
         refreshNodes: () => dispatch(nodesActions.refresh()),
         refreshUserSQLRoles: () =>
           dispatch(uiConfigActions.refreshUserSQLRoles()),
-        resetSQLStats: (req: StatementsRequest) =>
-          dispatch(sqlStatsActions.reset(req)),
+        resetSQLStats: () => dispatch(sqlStatsActions.reset()),
         onTimeScaleChange: (ts: TimeScale) => {
           dispatch(
             sqlStatsActions.updateTimeScale({

--- a/pkg/ui/workspaces/cluster-ui/src/util/constants.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/util/constants.ts
@@ -8,6 +8,8 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
+import { duration } from "moment";
+
 export const aggregatedTsAttr = "aggregated_ts";
 export const appAttr = "app";
 export const appNamesAttr = "appNames";
@@ -45,3 +47,5 @@ export const serverToClientErrorMessageMap = new Map([
 ]);
 
 export const NO_SAMPLES_FOUND = "no samples";
+
+export const STATS_LONG_LOADING_DURATION = duration(2, "s");

--- a/pkg/ui/workspaces/db-console/src/redux/apiReducers.ts
+++ b/pkg/ui/workspaces/db-console/src/redux/apiReducers.ts
@@ -329,6 +329,7 @@ const queriesReducerObj = new CachedDataReducer(
   "statements",
   null,
   moment.duration(30, "m"),
+  true, // Allow new requests to replace in flight ones.
 );
 export const invalidateStatements = queriesReducerObj.invalidateData;
 export const refreshStatements = queriesReducerObj.refresh;

--- a/pkg/ui/workspaces/db-console/src/redux/cachedDataReducer.ts
+++ b/pkg/ui/workspaces/db-console/src/redux/cachedDataReducer.ts
@@ -95,6 +95,7 @@ export class CachedDataReducer<
   ERROR: string; // request encountered an error
   INVALIDATE: string; // invalidate data
   INVALIDATE_ALL: string; // invalidate all data on keyed cache
+  pendingRequestStarted: moment.Moment | null;
 
   /**
    * apiEndpoint - The API endpoint used to refresh data.
@@ -102,12 +103,15 @@ export class CachedDataReducer<
    * invalidationPeriod (optional) - The duration after
    *   data is received after which it will be invalidated.
    * requestTimeout (optional)
+   *  allowReplacementRequests (optional) - allows requests to be replaced
+   * while they are in flight.
    */
   constructor(
     protected apiEndpoint: APIRequestFn<TRequest, TResponseMessage>,
     public actionNamespace: TActionNamespace,
     protected invalidationPeriod?: moment.Duration,
     protected requestTimeout?: moment.Duration,
+    protected allowReplacementRequests = false,
   ) {
     // check actionNamespace
     assert(
@@ -119,6 +123,7 @@ export class CachedDataReducer<
     );
     CachedDataReducer.namespaces[actionNamespace] = true;
 
+    this.pendingRequestStarted = null;
     this.REQUEST = `cockroachui/CachedDataReducer/${actionNamespace}/REQUEST`;
     this.RECEIVE = `cockroachui/CachedDataReducer/${actionNamespace}/RECEIVE`;
     this.ERROR = `cockroachui/CachedDataReducer/${actionNamespace}/ERROR`;
@@ -241,6 +246,15 @@ export class CachedDataReducer<
     };
   };
 
+  cancelPendingRequest = (): void => {
+    this.pendingRequestStarted = null;
+  };
+
+  setPendingRequestTime = (): moment.Moment => {
+    this.pendingRequestStarted = moment.utc();
+    return this.pendingRequestStarted;
+  };
+
   /**
    * refresh is the primary action creator that should be used to refresh the
    * cached data. Dispatching it will attempt to asynchronously refresh the
@@ -267,12 +281,15 @@ export class CachedDataReducer<
 
       if (
         state &&
-        (state.inFlight ||
-          (this.invalidationPeriod && state.valid) ||
-          state.unauthorized)
+        ((state.inFlight && !this.allowReplacementRequests) ||
+          state.unauthorized ||
+          (this.invalidationPeriod && state.valid))
       ) {
         return;
       }
+
+      this.cancelPendingRequest();
+      const pendingRequestStarted = this.setPendingRequestTime();
 
       // Note that after dispatching requestData, state.inFlight is true
       dispatch(this.requestData(req));
@@ -281,9 +298,16 @@ export class CachedDataReducer<
         .then(
           data => {
             // Dispatch the results to the store.
+            if (this.pendingRequestStarted !== pendingRequestStarted) {
+              return;
+            }
             dispatch(this.receiveData(data, req));
           },
           (error: Error) => {
+            if (this.pendingRequestStarted !== pendingRequestStarted) {
+              return;
+            }
+
             // TODO(couchand): This is a really myopic way to check for HTTP
             // codes.  However, at the moment that's all that the underlying
             // timeoutFetch offers.  Major changes to this plumbing are warranted.
@@ -304,6 +328,9 @@ export class CachedDataReducer<
           },
         )
         .then(() => {
+          if (this.pendingRequestStarted !== pendingRequestStarted) {
+            return;
+          }
           // Invalidate data after the invalidation period if one exists.
           if (this.invalidationPeriod) {
             setTimeout(

--- a/pkg/ui/workspaces/db-console/src/redux/sqlStats/sqlStatsActions.ts
+++ b/pkg/ui/workspaces/db-console/src/redux/sqlStats/sqlStatsActions.ts
@@ -9,29 +9,14 @@
 // licenses/APL.txt.
 
 import { Action } from "redux";
-import { PayloadAction } from "@reduxjs/toolkit";
-import { cockroach } from "src/js/protos";
 
 export const RESET_SQL_STATS = "cockroachui/sqlStats/RESET_SQL_STATS";
-export const RESET_SQL_STATS_COMPLETE =
-  "cockroachui/sqlStats/RESET_SQL_STATS_COMPLETE";
 export const RESET_SQL_STATS_FAILED =
   "cockroachui/sqlStats/RESET_SQL_STATS_FAILED";
 
-import StatementsRequest = cockroach.server.serverpb.StatementsRequest;
-
-export function resetSQLStatsAction(
-  req: StatementsRequest,
-): PayloadAction<StatementsRequest> {
+export function resetSQLStatsAction(): Action {
   return {
     type: RESET_SQL_STATS,
-    payload: req,
-  };
-}
-
-export function resetSQLStatsCompleteAction(): Action {
-  return {
-    type: RESET_SQL_STATS_COMPLETE,
   };
 }
 

--- a/pkg/ui/workspaces/db-console/src/redux/sqlStats/sqlStatsSagas.spec.ts
+++ b/pkg/ui/workspaces/db-console/src/redux/sqlStats/sqlStatsSagas.spec.ts
@@ -11,11 +11,7 @@
 import { expectSaga } from "redux-saga-test-plan";
 import { call } from "redux-saga-test-plan/matchers";
 
-import {
-  resetSQLStatsFailedAction,
-  resetSQLStatsCompleteAction,
-  resetSQLStatsAction,
-} from "./sqlStatsActions";
+import { resetSQLStatsFailedAction } from "./sqlStatsActions";
 import { resetSQLStatsSaga } from "./sqlStatsSagas";
 import { resetSQLStats } from "src/util/api";
 import {
@@ -26,25 +22,18 @@ import {
 import { throwError } from "redux-saga-test-plan/providers";
 
 import { cockroach } from "src/js/protos";
-import Long from "long";
 
 describe("SQL Stats sagas", () => {
   describe("resetSQLStatsSaga", () => {
-    const payload = new cockroach.server.serverpb.StatementsRequest({
-      start: Long.fromNumber(1596816675),
-      end: Long.fromNumber(1596820675),
-      combined: false,
-    });
     const resetSQLStatsResponse =
       new cockroach.server.serverpb.ResetSQLStatsResponse();
 
     it("successfully resets SQL stats", () => {
       // TODO(azhng): validate refreshStatement() actions once we can figure out
       //  how to get ThunkAction to work with sagas.
-      return expectSaga(resetSQLStatsSaga, resetSQLStatsAction(payload))
+      return expectSaga(resetSQLStatsSaga)
         .withReducer(apiReducersReducer)
         .provide([[call.fn(resetSQLStats), resetSQLStatsResponse]])
-        .put(resetSQLStatsCompleteAction())
         .put(invalidateStatements())
         .put(invalidateAllStatementDetails())
         .run();
@@ -52,7 +41,7 @@ describe("SQL Stats sagas", () => {
 
     it("returns error on failed reset", () => {
       const err = new Error("failed to reset");
-      return expectSaga(resetSQLStatsSaga, resetSQLStatsAction(payload))
+      return expectSaga(resetSQLStatsSaga)
         .provide([[call.fn(resetSQLStats), throwError(err)]])
         .put(resetSQLStatsFailedAction())
         .run();

--- a/pkg/ui/workspaces/db-console/src/redux/statements/statementsSagas.ts
+++ b/pkg/ui/workspaces/db-console/src/redux/statements/statementsSagas.ts
@@ -23,9 +23,6 @@ import {
 import {
   invalidateStatementDiagnosticsRequests,
   refreshStatementDiagnosticsRequests,
-  invalidateStatements,
-  invalidateExecutionInsights,
-  invalidateTxnInsights,
 } from "src/redux/apiReducers";
 import {
   createStatementDiagnosticsAlertLocalSetting,
@@ -124,9 +121,6 @@ export function* setCombinedStatementsTimeScaleSaga(
   const ts = action.payload;
 
   yield put(setTimeScale(ts));
-  yield put(invalidateStatements());
-  yield put(invalidateExecutionInsights());
-  yield put(invalidateTxnInsights());
 }
 
 export function* statementsSaga() {

--- a/pkg/ui/workspaces/db-console/src/redux/timeScale.ts
+++ b/pkg/ui/workspaces/db-console/src/redux/timeScale.ts
@@ -14,7 +14,7 @@
  */
 
 import { Action } from "redux";
-import { put, takeEvery } from "redux-saga/effects";
+import { put, takeEvery, all } from "redux-saga/effects";
 import { PayloadAction } from "src/interfaces/action";
 import _ from "lodash";
 import { defaultTimeScaleOptions, TimeScale } from "@cockroachlabs/cluster-ui";
@@ -25,6 +25,11 @@ import {
   getValueFromSessionStorage,
   setLocalSetting,
 } from "src/redux/localsettings";
+import {
+  invalidateExecutionInsights,
+  invalidateTxnInsights,
+  invalidateStatements,
+} from "./apiReducers";
 
 export const SET_SCALE = "cockroachui/timewindow/SET_SCALE";
 export const SET_METRICS_MOVING_WINDOW =
@@ -110,14 +115,17 @@ export function timeScaleReducer(
     }
     case SET_METRICS_MOVING_WINDOW: {
       const { payload: tw } = action as PayloadAction<TimeWindow>;
-      state = _.cloneDeep(state);
+      // We don't want to deep clone the state here, because we're
+      // not changing the scale object here. For components observing
+      // timescale changes, we don't want to update them unnecessarily.
+      state = { ...state, metricsTime: _.cloneDeep(state.metricsTime) };
       state.metricsTime.currentWindow = tw;
       state.metricsTime.shouldUpdateMetricsWindowFromScale = false;
       return state;
     }
     case SET_METRICS_FIXED_WINDOW: {
       const { payload: data } = action as PayloadAction<TimeWindow>;
-      state = _.cloneDeep(state);
+      state = { ...state, metricsTime: _.cloneDeep(state.metricsTime) };
       state.metricsTime.currentWindow = data;
       state.metricsTime.isFixedWindow = true;
       state.metricsTime.shouldUpdateMetricsWindowFromScale = false;
@@ -222,5 +230,10 @@ export const adjustTimeScale = (
 export function* timeScaleSaga() {
   yield takeEvery(SET_SCALE, function* ({ payload }: PayloadAction<TimeScale>) {
     yield put(setLocalSetting(TIME_SCALE_SESSION_STORAGE_KEY, payload));
+    yield all([
+      put(invalidateStatements()),
+      put(invalidateExecutionInsights()),
+      put(invalidateTxnInsights()),
+    ]);
   });
 }

--- a/pkg/ui/workspaces/db-console/src/selectors/executionFingerprintsSelectors.tsx
+++ b/pkg/ui/workspaces/db-console/src/selectors/executionFingerprintsSelectors.tsx
@@ -15,3 +15,6 @@ export const selectStatementsLastUpdated = (state: AdminUIState) =>
 
 export const selectStatementsDataValid = (state: AdminUIState) =>
   state.cachedData.statements?.valid;
+
+export const selectStatementsDataInFlight = (state: AdminUIState) =>
+  state.cachedData.statements?.inFlight;

--- a/pkg/ui/workspaces/db-console/src/util/api.ts
+++ b/pkg/ui/workspaces/db-console/src/util/api.ts
@@ -176,7 +176,7 @@ export type MetricMetadataResponseMessage =
   protos.cockroach.server.serverpb.MetricMetadataResponse;
 
 export type StatementsRequestMessage =
-  protos.cockroach.server.serverpb.StatementsRequest;
+  protos.cockroach.server.serverpb.CombinedStatementsStatsRequest;
 export type StatementDetailsRequestMessage =
   protos.cockroach.server.serverpb.StatementDetailsRequest;
 
@@ -750,13 +750,12 @@ export function getCombinedStatements(
   timeout?: moment.Duration,
 ): Promise<StatementsResponseMessage> {
   const queryStr = propsToQueryString({
-    combined: req.combined,
     start: req.start.toInt(),
     end: req.end.toInt(),
   });
   return timeoutFetch(
     serverpb.StatementsResponse,
-    `${STATUS_PREFIX}/statements?${queryStr}`,
+    `${STATUS_PREFIX}/combinedstmts?${queryStr}`,
     null,
     timeout,
   );

--- a/pkg/ui/workspaces/db-console/src/views/statements/statements.spec.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/statements/statements.spec.tsx
@@ -614,7 +614,7 @@ function makeStateWithStatementsAndLastReset(
       },
     },
     localSettings: {
-      "timeScale/SQLActivity": timeScale,
+      [localStorage.GlOBAL_TIME_SCALE]: timeScale,
     },
     timeScale: {
       scale: timeScale,

--- a/pkg/ui/workspaces/db-console/src/views/statements/statementsPage.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/statements/statementsPage.tsx
@@ -70,6 +70,7 @@ import { selectTimeScale } from "src/redux/timeScale";
 import {
   selectStatementsLastUpdated,
   selectStatementsDataValid,
+  selectStatementsDataInFlight,
 } from "src/selectors/executionFingerprintsSelectors";
 import { api as clusterUiApi } from "@cockroachlabs/cluster-ui";
 
@@ -380,6 +381,7 @@ export default withRouter(
         sortSetting: sortSettingLocalSetting.selector(state),
         statements: selectStatements(state, props),
         isDataValid: selectStatementsDataValid(state),
+        isReqInFlight: selectStatementsDataInFlight(state),
         lastUpdated: selectStatementsLastUpdated(state),
         statementsError: state.cachedData.statements.lastError,
         totalFingerprints: selectTotalFingerprints(state),

--- a/pkg/ui/workspaces/db-console/src/views/transactions/transactionDetails.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/transactions/transactionDetails.tsx
@@ -43,9 +43,10 @@ export const selectTransaction = createSelector(
     const transactions = transactionState.data?.transactions;
     if (!transactions) {
       return {
-        isLoading: true,
+        isLoading: transactionState.inFlight,
         transaction: null,
         lastUpdated: null,
+        isValid: transactionState.valid,
       };
     }
     const txnFingerprintId = getMatchParamByName(
@@ -59,9 +60,10 @@ export const selectTransaction = createSelector(
         txnFingerprintId,
     )[0];
     return {
-      isLoading: false,
+      isLoading: transactionState.inFlight,
       transaction: transaction,
       lastUpdated: transactionState?.setAt?.utc(),
+      isValid: transactionState.valid,
     };
   },
 );
@@ -72,10 +74,8 @@ export default withRouter(
       state: AdminUIState,
       props: TransactionDetailsProps,
     ): TransactionDetailsStateProps => {
-      const { isLoading, transaction, lastUpdated } = selectTransaction(
-        state,
-        props,
-      );
+      const { isLoading, transaction, lastUpdated, isValid } =
+        selectTransaction(state, props);
       return {
         timeScale: selectTimeScale(state),
         error: selectLastError(state),
@@ -91,6 +91,7 @@ export default withRouter(
         lastUpdated: lastUpdated,
         transactionInsights: selectTxnInsightsByFingerprint(state, props),
         hasAdminRole: selectHasAdminRole(state),
+        isDataValid: isValid,
       };
     },
     {

--- a/pkg/ui/workspaces/db-console/src/views/transactions/transactionsPage.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/transactions/transactionsPage.tsx
@@ -47,6 +47,7 @@ import { selectTimeScale } from "src/redux/timeScale";
 import {
   selectStatementsLastUpdated,
   selectStatementsDataValid,
+  selectStatementsDataInFlight,
 } from "src/selectors/executionFingerprintsSelectors";
 
 // selectStatements returns the array of AggregateStatistics to show on the
@@ -151,6 +152,7 @@ const TransactionsPageConnected = withRouter(
         columns: transactionColumnsLocalSetting.selectorToArray(state),
         data: selectData(state),
         isDataValid: selectStatementsDataValid(state),
+        isReqInFlight: selectStatementsDataInFlight(state),
         lastUpdated: selectStatementsLastUpdated(state),
         timeScale: selectTimeScale(state),
         error: selectLastError(state),


### PR DESCRIPTION
See individual commits.

The changes here serve as a base for the performance improvements we'll be making.
Since they're not really related to those changes specifically (e.g. adding limit/sort and splitting the api calls), I've put them in their own PR here to make reviewing easier.

Loom verifying behaviour and showing new requests being dispatched while ones are pending
Pages shown:
- stmt fingerprints
- txn fingerprints
- txn fingerprint details
- stmt fingerprint details

https://www.loom.com/share/3448117bfecf404c8d698f4ad1240e8c

CC:
https://www.loom.com/share/bb30b51ebe5144528ab0c6fabdbfb2f1