### PR TITLE
sql: enable TestSQLStatsDataDriven

### DIFF
--- a/pkg/sql/sqlstats/persistedsqlstats/testdata/logical_plan_sampling_for_explicit_txn
+++ b/pkg/sql/sqlstats/persistedsqlstats/testdata/logical_plan_sampling_for_explicit_txn
@@ -1,12 +1,8 @@
-skip issue-num=89861
-----
-
 # This test checks the expected behavior of logical plan sampling.
 # Given a tuple of (db_name, implicitTxn, fingerprint string), the logical plan
 # is only sampled if and only if no logical plan has been sampled for the given
 # tuple in the last 5 minutes. (This is controlled via
 # sql.metrics.statement_details.plan_collection.period cluster setting).
-
 exec-sql
 SET application_name = 'app1'
 ----


### PR DESCRIPTION
Adding retry logic to the execute command, and
enabling the test. All previous builds with failures 
are no longer available. No failures on testing
locally with stress.

Epic: none
Closes: #89861

Release note: none