### PR TITLE
roachtest: mark some hibernate/pgjdbc tests as flaky

### DIFF
--- a/pkg/cmd/roachtest/tests/canary.go
+++ b/pkg/cmd/roachtest/tests/canary.go
@@ -36,18 +36,20 @@ import (
 // blocklist is a lists of known test errors and failures.
 type blocklist map[string]string
 
-// blocklistWithName contains both a blocklist of known test errors and
-// failures but also an optional ignorelist for flaky tests.
-// When the test suite is run, the results are compared to this list.
+// listWithName contains both a blocklist of known test errors and
+// failures and also an optional ignorelist for flaky tests.
+// When the test suite is run, the results are compared to this blocklist.
 // Any passed test that is not on this blocklist is reported as PASS - expected
 // Any passed test that is on this blocklist is reported as PASS - unexpected
 // Any failed test that is on this blocklist is reported as FAIL - expected
-// Any failed test that is not on blocklist list is reported as FAIL - unexpected
+// Any failed test that is not on blocklist blocklist is reported as FAIL - unexpected
 // Any test on this blocklist that is not run is reported as FAIL - not run
-// Ant test in the ignorelist is reported as SKIP if it is run
-type blocklistWithName struct {
-	blocklistname string
-	blocklist     blocklist
+// Any test in the ignorelist is reported as SKIP if it is run
+type listWithName struct {
+	blocklistName  string
+	blocklist      blocklist
+	ignorelistName string
+	ignorelist     blocklist
 }
 
 func fetchCockroachVersion(

--- a/pkg/cmd/roachtest/tests/hibernate.go
+++ b/pkg/cmd/roachtest/tests/hibernate.go
@@ -30,8 +30,8 @@ type hibernateOptions struct {
 	testDir  string
 	buildCmd,
 	testCmd string
-	blocklistWithName blocklistWithName
-	dbSetupFunc       func(ctx context.Context, t test.Test, c cluster.Cluster)
+	listWithName listWithName
+	dbSetupFunc  func(ctx context.Context, t test.Test, c cluster.Cluster)
 }
 
 var (
@@ -40,9 +40,14 @@ var (
 		testDir:  "hibernate-core",
 		buildCmd: `cd /mnt/data1/hibernate/hibernate-core/ && ./../gradlew test -Pdb=cockroachdb ` +
 			`--tests org.hibernate.jdbc.util.BasicFormatterTest.*`,
-		testCmd:           "cd /mnt/data1/hibernate/hibernate-core/ && ./../gradlew test -Pdb=cockroachdb",
-		blocklistWithName: blocklistWithName{blocklistname: "hibernateBlockList", blocklist: hibernateBlockList},
-		dbSetupFunc:       nil,
+		testCmd: "cd /mnt/data1/hibernate/hibernate-core/ && ./../gradlew test -Pdb=cockroachdb",
+		listWithName: listWithName{
+			blocklistName:  "hibernateBlockList",
+			blocklist:      hibernateBlockList,
+			ignorelistName: "hibernateIgnoreList",
+			ignorelist:     hibernateIgnoreList,
+		},
+		dbSetupFunc: nil,
 	}
 	hibernateSpatialOpts = hibernateOptions{
 		testName: "hibernate-spatial",
@@ -51,7 +56,12 @@ var (
 			`--tests org.hibernate.spatial.dialect.postgis.*`,
 		testCmd: `cd /mnt/data1/hibernate/hibernate-spatial && ` +
 			`HIBERNATE_CONNECTION_LEAK_DETECTION=true ./../gradlew test -Pdb=cockroachdb_spatial`,
-		blocklistWithName: blocklistWithName{blocklistname: "hibernateSpatialBlockList", blocklist: hibernateSpatialBlockList},
+		listWithName: listWithName{
+			blocklistName:  "hibernateSpatialBlockList",
+			blocklist:      hibernateSpatialBlockList,
+			ignorelistName: "hibernateSpatialIgnoreList",
+			ignorelist:     hibernateSpatialIgnoreList,
+		},
 		dbSetupFunc: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			db := c.Conn(ctx, t.L(), 1)
 			defer db.Close()
@@ -169,8 +179,8 @@ func registerHibernate(r registry.Registry, opt hibernateOptions) {
 			t.Fatal(err)
 		}
 
-		blocklistName := opt.blocklistWithName.blocklistname
-		expectedFailures := opt.blocklistWithName.blocklist
+		blocklistName := opt.listWithName.blocklistName
+		expectedFailures := opt.listWithName.blocklist
 
 		t.L().Printf("Running cockroach version %s, using blocklist %s", version, blocklistName)
 
@@ -228,7 +238,7 @@ func registerHibernate(r registry.Registry, opt hibernateOptions) {
 
 		parseAndSummarizeJavaORMTestsResults(
 			ctx, t, c, node, "hibernate" /* ormName */, output,
-			blocklistName, expectedFailures, nil /* ignorelist */, version, supportedHibernateTag,
+			blocklistName, expectedFailures, opt.listWithName.ignorelist, version, supportedHibernateTag,
 		)
 	}
 

--- a/pkg/cmd/roachtest/tests/hibernate_blocklist.go
+++ b/pkg/cmd/roachtest/tests/hibernate_blocklist.go
@@ -33,3 +33,13 @@ var hibernateBlockList = blocklist{
 	"org.hibernate.test.bytecode.enhancement.lazy.proxy.inlinedirtychecking.DirtyCheckPrivateUnMappedCollectionTest.testIt": "unknown",
 	"org.hibernate.test.hql.BulkManipulationTest.testUpdateWithSubquery":                                                    "unknown",
 }
+
+var hibernateSpatialIgnoreList = blocklist{
+	"org.hibernate.serialization.SessionFactorySerializationTest.testUnNamedSessionFactorySerialization": "flaky",
+	"org.hibernate.serialization.SessionFactorySerializationTest.testNamedSessionFactorySerialization":   "flaky",
+}
+
+var hibernateIgnoreList = blocklist{
+	"org.hibernate.serialization.SessionFactorySerializationTest.testUnNamedSessionFactorySerialization": "flaky",
+	"org.hibernate.serialization.SessionFactorySerializationTest.testNamedSessionFactorySerialization":   "flaky",
+}

--- a/pkg/cmd/roachtest/tests/pgjdbc_blocklist.go
+++ b/pkg/cmd/roachtest/tests/pgjdbc_blocklist.go
@@ -926,6 +926,7 @@ var pgjdbcIgnoreList = blocklist{
 	"org.postgresql.test.jdbc2.BatchedInsertReWriteEnabledTest.testBatchWithReWrittenSpaceAfterValues[3: autoCommit=NO, binary=FORCE]":              "54477",
 	"org.postgresql.test.jdbc2.BatchedInsertReWriteEnabledTest.testReWriteDisabledForPlainBatch[2: autoCommit=NO, binary=REGULAR]":                  "54477",
 	"org.postgresql.test.jdbc2.BatchedInsertReWriteEnabledTest.testReWriteDisabledForPlainBatch[3: autoCommit=NO, binary=FORCE]":                    "54477",
+	"org.postgresql.test.jdbc2.CursorFetchTest.testBasicFetch[binary = FORCE]":                                                                      "flaky",
 	"org.postgresql.test.jdbc2.DatabaseEncodingTest.testBadUTF8Decode":                                                                              "54477",
 	"org.postgresql.test.jdbc2.DatabaseEncodingTest.testTruncatedUTF8Decode":                                                                        "54477",
 	"org.postgresql.test.jdbc2.DatabaseEncodingTest.testUTF8Decode":                                                                                 "54477",


### PR DESCRIPTION
I've noticed these ones coming up more.

fixes https://github.com/cockroachdb/cockroach/issues/98227
fixes https://github.com/cockroachdb/cockroach/issues/98288
Release note: None