### PR TITLE
sqlinstance: refactor sql instance reader

### DIFF
--- a/pkg/server/server_sql.go
+++ b/pkg/server/server_sql.go
@@ -558,12 +558,11 @@ func newSQLServer(ctx context.Context, cfg sqlServerArgs) (*SQLServer, error) {
 	)
 
 	cfg.sqlInstanceStorage = instancestorage.NewStorage(
-		cfg.db, codec, cfg.sqlLivenessProvider.CachedReader(), cfg.Settings)
+		cfg.db, codec, cfg.sqlLivenessProvider.CachedReader(), cfg.Settings, cfg.clock, cfg.rangeFeedFactory)
 	cfg.sqlInstanceReader = instancestorage.NewReader(
 		cfg.sqlInstanceStorage,
 		cfg.sqlLivenessProvider,
-		cfg.rangeFeedFactory,
-		codec, cfg.clock, cfg.stopper)
+		cfg.stopper)
 
 	// We can't use the nodeDailer as the podNodeDailer unless we
 	// are serving the system tenant despite the fact that we've

--- a/pkg/sql/sqlinstance/instancestorage/BUILD.bazel
+++ b/pkg/sql/sqlinstance/instancestorage/BUILD.bazel
@@ -4,6 +4,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 go_library(
     name = "instancestorage",
     srcs = [
+        "instancecache.go",
         "instancereader.go",
         "instancestorage.go",
         "row_codec.go",
@@ -50,6 +51,7 @@ go_test(
     name = "instancestorage_test",
     srcs = [
         "helpers_test.go",
+        "instancecache_test.go",
         "instancereader_test.go",
         "instancestorage_internal_test.go",
         "instancestorage_test.go",
@@ -60,6 +62,7 @@ go_test(
     embed = [":instancestorage"],
     deps = [
         "//pkg/base",
+        "//pkg/ccl/kvccl/kvtenantccl",
         "//pkg/keys",
         "//pkg/kv",
         "//pkg/kv/kvclient/rangefeed",
@@ -67,7 +70,6 @@ go_test(
         "//pkg/security/securityassets",
         "//pkg/security/securitytest",
         "//pkg/server",
-        "//pkg/settings/cluster",
         "//pkg/sql/catalog/descs",
         "//pkg/sql/catalog/desctestutils",
         "//pkg/sql/catalog/systemschema",
@@ -82,6 +84,7 @@ go_test(
         "//pkg/testutils/testcluster",
         "//pkg/util/encoding",
         "//pkg/util/envutil",
+        "//pkg/util/grpcutil",
         "//pkg/util/hlc",
         "//pkg/util/leaktest",
         "//pkg/util/log",

--- a/pkg/sql/sqlinstance/instancestorage/instancecache.go
+++ b/pkg/sql/sqlinstance/instancestorage/instancecache.go
@@ -1,0 +1,206 @@
+// Copyright 2023 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package instancestorage
+
+import (
+	"context"
+	"strings"
+
+	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvclient/rangefeed"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/util/grpcutil"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
+)
+
+// instanceCache represents a cache over the contents of sql_instances table.
+type instanceCache interface {
+	// getInstance returns a single instance by ID. If the instance is not
+	// found, ok is set to false.
+	getInstance(instanceID base.SQLInstanceID) (i instancerow, ok bool)
+
+	// listInstances returns a list containing all of the cached instance rows.
+	// listInstances returns all cached rows, including rows that are unclaimed
+	// or owned by an inactive session.
+	listInstances() []instancerow
+
+	// Close stops updates to the cache. getInstance and listInstances continue
+	// to work after Close, but will return stale results.
+	Close()
+}
+
+// emptyInstanceCache is used during initialization. It implements an instance
+// feed with no instances.
+type emptyInstanceCache struct {
+}
+
+// Close implements instanceCache
+func (*emptyInstanceCache) Close() {
+	// no-op
+}
+
+// getInstance implements instanceCache
+func (*emptyInstanceCache) getInstance(instanceID base.SQLInstanceID) (instancerow, bool) {
+	return instancerow{}, false
+}
+
+// listInstances implements instanceCache
+func (*emptyInstanceCache) listInstances() []instancerow {
+	return nil
+}
+
+var _ instanceCache = &emptyInstanceCache{}
+
+// singletonInstanceFeed is used during system start up. It only contains
+// server's own sql instance.
+type singletonInstanceFeed struct {
+	instance instancerow
+}
+
+var _ instanceCache = &singletonInstanceFeed{}
+
+func (s *singletonInstanceFeed) getInstance(instanceID base.SQLInstanceID) (instancerow, bool) {
+	if instanceID == s.instance.instanceID {
+		return s.instance, true
+	}
+	return instancerow{}, false
+}
+
+func (s *singletonInstanceFeed) listInstances() []instancerow {
+	return []instancerow{s.instance}
+}
+
+func (s *singletonInstanceFeed) Close() {}
+
+type rangeFeedCache struct {
+	feed *rangefeed.RangeFeed
+	mu   struct {
+		syncutil.Mutex
+		instances map[base.SQLInstanceID]instancerow
+	}
+}
+
+var _ instanceCache = &rangeFeedCache{}
+
+// newRangeFeedCache constructs an instanceCache backed by a range feed over the
+// sql_instances table. newRangeFeedCache will block until the initial scan is
+// complete.
+func newRangeFeedCache(
+	ctx context.Context, rowCodec rowCodec, clock *hlc.Clock, f *rangefeed.Factory,
+) (resultFeed instanceCache, err error) {
+	done := make(chan error, 1)
+
+	feed := &rangeFeedCache{}
+	feed.mu.instances = map[base.SQLInstanceID]instancerow{}
+
+	updateCacheFn := func(
+		ctx context.Context, keyVal *kvpb.RangeFeedValue,
+	) {
+		instance, err := rowCodec.decodeRow(keyVal.Key, &keyVal.Value)
+		if err != nil {
+			log.Ops.Warningf(ctx, "failed to decode settings row %v: %v", keyVal.Key, err)
+			return
+		}
+		feed.updateInstanceMap(instance, !keyVal.Value.IsPresent())
+	}
+	initialScanDoneFn := func(_ context.Context) {
+		select {
+		case done <- nil:
+			// success reported to the caller
+		default:
+			// something is already in the done channel
+		}
+	}
+	initialScanErrFn := func(_ context.Context, err error) (shouldFail bool) {
+		if grpcutil.IsAuthError(err) ||
+			// This is a hack around the fact that we do not get properly structured
+			// errors out of gRPC. See #56208.
+			strings.Contains(err.Error(), "rpc error: code = Unauthenticated") {
+			shouldFail = true
+			select {
+			case done <- err:
+				// err reported to the caller
+			default:
+				// something is already in the done channel
+			}
+		}
+		return shouldFail
+	}
+
+	instancesTablePrefix := rowCodec.makeIndexPrefix()
+	instancesTableSpan := roachpb.Span{
+		Key:    instancesTablePrefix,
+		EndKey: instancesTablePrefix.PrefixEnd(),
+	}
+	feed.feed, err = f.RangeFeed(ctx,
+		"sql_instances",
+		[]roachpb.Span{instancesTableSpan},
+		clock.Now(),
+		updateCacheFn,
+		rangefeed.WithSystemTablePriority(),
+		rangefeed.WithInitialScan(initialScanDoneFn),
+		rangefeed.WithOnInitialScanError(initialScanErrFn),
+		rangefeed.WithRowTimestampInInitialScan(true),
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		// Ensure the feed is cleaned up if there is an error
+		if resultFeed == nil {
+			feed.Close()
+		}
+	}()
+
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case err := <-done:
+		if err != nil {
+			return nil, err
+		}
+		return feed, nil
+	}
+}
+
+func (s *rangeFeedCache) getInstance(instanceID base.SQLInstanceID) (instancerow, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	row, ok := s.mu.instances[instanceID]
+	return row, ok
+}
+
+func (s *rangeFeedCache) listInstances() []instancerow {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	result := make([]instancerow, 0, len(s.mu.instances))
+	for _, row := range s.mu.instances {
+		result = append(result, row)
+	}
+	return result
+}
+
+func (r *rangeFeedCache) updateInstanceMap(instance instancerow, deletionEvent bool) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if deletionEvent {
+		delete(r.mu.instances, instance.instanceID)
+		return
+	}
+	r.mu.instances[instance.instanceID] = instance
+}
+
+func (s *rangeFeedCache) Close() {
+	s.feed.Close()
+}

--- a/pkg/sql/sqlinstance/instancestorage/instancecache_test.go
+++ b/pkg/sql/sqlinstance/instancestorage/instancecache_test.go
@@ -1,0 +1,120 @@
+// Copyright 2023 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package instancestorage
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/ccl/kvccl/kvtenantccl"
+	"github.com/cockroachdb/cockroach/pkg/keys"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvclient/rangefeed"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/desctestutils"
+	"github.com/cockroachdb/cockroach/pkg/sql/enum"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlliveness/slstorage"
+	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
+	"github.com/cockroachdb/cockroach/pkg/util/grpcutil"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEmptyInstanceFeed(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	var feed instanceCache = &emptyInstanceCache{}
+	require.Empty(t, feed.listInstances())
+
+	_, ok := feed.getInstance(base.SQLInstanceID(0))
+	require.False(t, ok)
+}
+
+func TestSingletonFeed(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	instance := instancerow{
+		instanceID: base.SQLInstanceID(10),
+		sqlAddr:    "something",
+	}
+	var feed instanceCache = &singletonInstanceFeed{instance: instance}
+
+	got, ok := feed.getInstance(10)
+	require.True(t, ok)
+	require.Equal(t, instance, got)
+
+	got, ok = feed.getInstance(11)
+	require.False(t, ok)
+	require.NotEqual(t, instance, got)
+
+	require.Equal(t, feed.listInstances(), []instancerow{instance})
+}
+
+func TestRangeFeed(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+	host, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	defer host.Stopper().Stop(ctx)
+
+	var _ = kvtenantccl.Connector{}
+	tenant, tenantSQL := serverutils.StartTenant(t, host, base.TestTenantArgs{
+		TenantID: serverutils.TestTenantID(),
+	})
+	tDB := sqlutils.MakeSQLRunner(tenantSQL)
+
+	newStorage := func(t *testing.T, codec keys.SQLCodec) *Storage {
+		tDB.Exec(t, `CREATE DATABASE "`+t.Name()+`"`)
+		tDB.Exec(t, GetTableSQLForDatabase(t.Name()))
+		tableDesc := desctestutils.TestingGetTableDescriptor(tenant.DB(), tenant.Codec(), t.Name(), "public", "sql_instances")
+		slStorage := slstorage.NewFakeStorage()
+		return NewTestingStorage(tenant.DB(), codec, tableDesc, slStorage,
+			tenant.ClusterSettings(), tenant.Clock(), tenant.RangeFeedFactory().(*rangefeed.Factory))
+	}
+
+	t.Run("success", func(t *testing.T) {
+		storage := newStorage(t, tenant.Codec())
+
+		require.NoError(t, storage.generateAvailableInstanceRows(ctx, [][]byte{enum.One}, tenant.Clock().Now().Add(int64(time.Minute), 0)))
+
+		feed, err := storage.newInstanceCache(ctx)
+		require.NoError(t, err)
+		require.NotNil(t, feed)
+		defer feed.Close()
+
+		// Check the entries in the feed to make sure it is constructed after
+		// the complete scan.
+		instances := feed.listInstances()
+		require.Len(t, instances, int(PreallocatedCount.Get(&tenant.ClusterSettings().SV)))
+	})
+
+	t.Run("auth_error", func(t *testing.T) {
+		storage := newStorage(t, keys.SystemSQLCodec)
+		_, err := storage.newInstanceCache(ctx)
+		require.True(t, grpcutil.IsAuthError(err), "expected %v to be an auth error", err)
+	})
+
+	t.Run("context_cancelled", func(t *testing.T) {
+		storage := newStorage(t, tenant.Codec())
+
+		ctx, cancel := context.WithCancel(ctx)
+		cancel()
+
+		_, err := storage.newInstanceCache(ctx)
+		require.Error(t, err)
+		require.ErrorIs(t, err, ctx.Err())
+	})
+}

--- a/pkg/sql/sqlinstance/instancestorage/instancereader.go
+++ b/pkg/sql/sqlinstance/instancestorage/instancereader.go
@@ -13,42 +13,31 @@ package instancestorage
 import (
 	"context"
 	"sort"
-	"strings"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
-	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv"
-	"github.com/cockroachdb/cockroach/pkg/kv/kvclient/rangefeed"
-	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
-	"github.com/cockroachdb/cockroach/pkg/roachpb"
-	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
-	"github.com/cockroachdb/cockroach/pkg/sql/catalog/systemschema"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/concurrency/lock"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlinstance"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlliveness"
-	"github.com/cockroachdb/cockroach/pkg/util/grpcutil"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
-	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/errors"
 )
 
-// Reader implements the sqlinstance.AddressResolver interface. It uses
-// caching backed by rangefeed to cache instance information.
+// Reader implements the sqlinstance.AddressResolver interface. It uses caching
+// backed by rangefeed to cache instance information.
 type Reader struct {
 	storage  *Storage
 	slReader sqlliveness.Reader
-	f        *rangefeed.Factory
-	codec    keys.SQLCodec
-	clock    *hlc.Clock
 	stopper  *stop.Stopper
-	rowcodec rowCodec
+
 	// Once initialScanDone is closed, the error (if any) while establishing the
 	// rangefeed can be found in initialScanErr.
 	initialScanDone chan struct{}
 	mu              struct {
 		syncutil.Mutex
-		instances      map[base.SQLInstanceID]instancerow
+		cache          instanceCache
 		initialScanErr error
 	}
 }
@@ -56,46 +45,30 @@ type Reader struct {
 // NewTestingReader constructs a new Reader with control for the database
 // in which the `sql_instances` table should exist.
 func NewTestingReader(
-	storage *Storage,
-	slReader sqlliveness.Reader,
-	f *rangefeed.Factory,
-	codec keys.SQLCodec,
-	table catalog.TableDescriptor,
-	clock *hlc.Clock,
-	stopper *stop.Stopper,
+	storage *Storage, slReader sqlliveness.Reader, stopper *stop.Stopper,
 ) *Reader {
 	r := &Reader{
 		storage:         storage,
 		slReader:        slReader,
-		f:               f,
-		codec:           codec,
-		clock:           clock,
-		rowcodec:        makeRowCodec(codec, table),
 		initialScanDone: make(chan struct{}),
 		stopper:         stopper,
 	}
-	r.mu.instances = make(map[base.SQLInstanceID]instancerow)
+	r.setCache(&emptyInstanceCache{})
 	return r
 }
 
 // NewReader constructs a new reader for SQL instance data.
-func NewReader(
-	storage *Storage,
-	slReader sqlliveness.Reader,
-	f *rangefeed.Factory,
-	codec keys.SQLCodec,
-	clock *hlc.Clock,
-	stopper *stop.Stopper,
-) *Reader {
-	return NewTestingReader(storage, slReader, f, codec, systemschema.SQLInstancesTable(), clock, stopper)
+func NewReader(storage *Storage, slReader sqlliveness.Reader, stopper *stop.Stopper) *Reader {
+	return NewTestingReader(storage, slReader, stopper)
 }
 
-// Start initializes the rangefeed for the Reader. The rangefeed will run until
-// the stopper stops. If self has a non-zero ID, it will be used to initialize
-// the set of instances before the rangefeed catches up.
+// Start initializes the instanceCache for the Reader. The range feed backing
+// the cache will run until the stopper stops. If self has a non-zero ID, it
+// will be used to initialize the set of instances before the rangefeed catches
+// up.
 func (r *Reader) Start(ctx context.Context, self sqlinstance.InstanceInfo) {
-	if self.InstanceID != 0 {
-		r.updateInstanceMap(instancerow{
+	r.setCache(&singletonInstanceFeed{
+		instance: instancerow{
 			region:     self.Region,
 			instanceID: self.InstanceID,
 			sqlAddr:    self.InstanceSQLAddr,
@@ -103,9 +76,21 @@ func (r *Reader) Start(ctx context.Context, self sqlinstance.InstanceInfo) {
 			sessionID:  self.SessionID,
 			locality:   self.Locality,
 			timestamp:  hlc.Timestamp{}, // intentionally zero
-		}, false /* deletionEvent */)
+		},
+	})
+	err := r.stopper.RunAsyncTask(ctx, "start-instance-reader", func(ctx context.Context) {
+		cache, err := r.storage.newInstanceCache(ctx)
+		if err != nil {
+			r.setInitialScanDone(err)
+			return
+		}
+		r.stopper.AddCloser(cache)
+		r.setCache(cache)
+		r.setInitialScanDone(nil)
+	})
+	if err != nil {
+		r.setInitialScanDone(err)
 	}
-	r.startRangeFeed(ctx)
 }
 
 // WaitForStarted will block until the Reader has an initial full snapshot of
@@ -122,6 +107,18 @@ func (r *Reader) WaitForStarted(ctx context.Context) error {
 		return errors.Wrap(ctx.Err(),
 			"failed to retrieve initial instance data")
 	}
+}
+
+func (r *Reader) getCache() instanceCache {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.mu.cache
+}
+
+func (r *Reader) setCache(feed instanceCache) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.mu.cache = feed
 }
 
 func makeInstanceInfo(row instancerow) sqlinstance.InstanceInfo {
@@ -147,71 +144,15 @@ func makeInstanceInfos(rows []instancerow) []sqlinstance.InstanceInfo {
 func (r *Reader) GetAllInstancesUsingTxn(
 	ctx context.Context, txn *kv.Txn,
 ) ([]sqlinstance.InstanceInfo, error) {
-	instancesTablePrefix := r.rowcodec.codec.TablePrefix(uint32(r.rowcodec.tableID))
-	rows, err := txn.Scan(ctx, instancesTablePrefix, instancesTablePrefix.PrefixEnd(), 0 /* maxRows */)
+	decodedRows, err := r.storage.getInstanceRows(ctx, nil /*all regions*/, txn, lock.WaitPolicy_Block)
 	if err != nil {
 		return nil, err
-	}
-	decodedRows := make([]instancerow, 0, len(rows))
-	for _, row := range rows {
-		decodedRow, err := r.rowcodec.decodeRow(row.Key, row.Value)
-		if err != nil {
-			return nil, err
-		}
-		decodedRows = append(decodedRows, decodedRow)
 	}
 	filteredRows, err := selectDistinctLiveRows(ctx, r.slReader, decodedRows)
 	if err != nil {
 		return nil, err
 	}
 	return makeInstanceInfos(filteredRows), nil
-}
-
-func (r *Reader) startRangeFeed(ctx context.Context) {
-	updateCacheFn := func(
-		ctx context.Context, keyVal *kvpb.RangeFeedValue,
-	) {
-		instance, err := r.rowcodec.decodeRow(keyVal.Key, &keyVal.Value)
-		if err != nil {
-			log.Ops.Warningf(ctx, "failed to decode settings row %v: %v", keyVal.Key, err)
-			return
-		}
-		r.updateInstanceMap(instance, !keyVal.Value.IsPresent())
-	}
-	initialScanDoneFn := func(_ context.Context) {
-		r.setInitialScanErr(nil)
-	}
-	initialScanErrFn := func(_ context.Context, err error) (shouldFail bool) {
-		if grpcutil.IsAuthError(err) ||
-			// This is a hack around the fact that we do not get properly structured
-			// errors out of gRPC. See #56208.
-			strings.Contains(err.Error(), "rpc error: code = Unauthenticated") {
-			shouldFail = true
-			r.setInitialScanErr(err)
-		}
-		return shouldFail
-	}
-
-	instancesTablePrefix := r.rowcodec.makeIndexPrefix()
-	instancesTableSpan := roachpb.Span{
-		Key:    instancesTablePrefix,
-		EndKey: instancesTablePrefix.PrefixEnd(),
-	}
-	rf, err := r.f.RangeFeed(ctx,
-		"sql_instances",
-		[]roachpb.Span{instancesTableSpan},
-		r.clock.Now(),
-		updateCacheFn,
-		rangefeed.WithSystemTablePriority(),
-		rangefeed.WithInitialScan(initialScanDoneFn),
-		rangefeed.WithOnInitialScanError(initialScanErrFn),
-		rangefeed.WithRowTimestampInInitialScan(true),
-	)
-	if err != nil {
-		r.setInitialScanErr(err)
-		return
-	}
-	r.stopper.AddCloser(rf)
 }
 
 // GetInstance implements sqlinstance.AddressResolver interface.
@@ -221,9 +162,7 @@ func (r *Reader) GetInstance(
 	if err := r.initialScanErr(); err != nil {
 		return sqlinstance.InstanceInfo{}, err
 	}
-	r.mu.Lock()
-	instance, ok := r.mu.instances[instanceID]
-	r.mu.Unlock()
+	instance, ok := r.getCache().getInstance(instanceID)
 	if !ok {
 		return sqlinstance.InstanceInfo{}, sqlinstance.NonExistentInstanceError
 	}
@@ -252,7 +191,8 @@ func (r *Reader) GetAllInstances(ctx context.Context) ([]sqlinstance.InstanceInf
 	if err := r.initialScanErr(); err != nil {
 		return nil, err
 	}
-	liveInstances, err := selectDistinctLiveRows(ctx, r.slReader, r.getAllInstanceRows())
+
+	liveInstances, err := selectDistinctLiveRows(ctx, r.slReader, r.getCache().listInstances())
 	if err != nil {
 		return nil, err
 	}
@@ -301,34 +241,13 @@ func selectDistinctLiveRows(
 	return rows, nil
 }
 
-// getAllInstanceRows returns all instancerow objects contained within the map,
-// in an arbitrary order.
-func (r *Reader) getAllInstanceRows() (instances []instancerow) {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-	for _, instance := range r.mu.instances {
-		instances = append(instances, instance)
-	}
-	return instances
-}
-
-func (r *Reader) updateInstanceMap(instance instancerow, deletionEvent bool) {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-	if deletionEvent {
-		delete(r.mu.instances, instance.instanceID)
-		return
-	}
-	r.mu.instances[instance.instanceID] = instance
-}
-
 func (r *Reader) initialScanErr() error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	return r.mu.initialScanErr
 }
 
-func (r *Reader) setInitialScanErr(err error) {
+func (r *Reader) setInitialScanDone(err error) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	// Set error before closing done channel.

--- a/pkg/sql/sqlinstance/instancestorage/instancereader_test.go
+++ b/pkg/sql/sqlinstance/instancestorage/instancereader_test.go
@@ -57,8 +57,8 @@ func TestReader(t *testing.T) {
 		tDB.Exec(t, schema)
 		table := desctestutils.TestingGetPublicTableDescriptor(s.DB(), s.Codec(), dbName, "sql_instances")
 		slStorage := slstorage.NewFakeStorage()
-		storage := instancestorage.NewTestingStorage(s.DB(), keys.SystemSQLCodec, table, slStorage, s.ClusterSettings())
-		reader := instancestorage.NewTestingReader(storage, slStorage, s.RangeFeedFactory().(*rangefeed.Factory), keys.SystemSQLCodec, table, s.Clock(), s.Stopper())
+		storage := instancestorage.NewTestingStorage(s.DB(), keys.SystemSQLCodec, table, slStorage, s.ClusterSettings(), s.Clock(), s.RangeFeedFactory().(*rangefeed.Factory))
+		reader := instancestorage.NewTestingReader(storage, slStorage, s.Stopper())
 		return storage, slStorage, s.Clock(), reader
 	}
 

--- a/pkg/sql/sqlinstance/instancestorage/instancestorage.go
+++ b/pkg/sql/sqlinstance/instancestorage/instancestorage.go
@@ -21,6 +21,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvclient/rangefeed"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/concurrency/lock"
 	"github.com/cockroachdb/cockroach/pkg/multitenant"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
@@ -86,6 +87,8 @@ type Storage struct {
 	slReader sqlliveness.Reader
 	rowcodec rowCodec
 	settings *cluster.Settings
+	clock    *hlc.Clock
+	f        *rangefeed.Factory
 	// TestingKnobs refers to knobs used for testing.
 	TestingKnobs struct {
 		// JitteredIntervalFn corresponds to the function used to jitter the
@@ -119,21 +122,30 @@ func NewTestingStorage(
 	table catalog.TableDescriptor,
 	slReader sqlliveness.Reader,
 	settings *cluster.Settings,
+	clock *hlc.Clock,
+	f *rangefeed.Factory,
 ) *Storage {
 	s := &Storage{
 		db:       db,
 		rowcodec: makeRowCodec(codec, table),
 		slReader: slReader,
 		settings: settings,
+		clock:    clock,
+		f:        f,
 	}
 	return s
 }
 
 // NewStorage creates a new storage struct.
 func NewStorage(
-	db *kv.DB, codec keys.SQLCodec, slReader sqlliveness.Reader, settings *cluster.Settings,
+	db *kv.DB,
+	codec keys.SQLCodec,
+	slReader sqlliveness.Reader,
+	settings *cluster.Settings,
+	clock *hlc.Clock,
+	f *rangefeed.Factory,
 ) *Storage {
-	return NewTestingStorage(db, codec, systemschema.SQLInstancesTable(), slReader, settings)
+	return NewTestingStorage(db, codec, systemschema.SQLInstancesTable(), slReader, settings, clock, f)
 }
 
 // CreateNodeInstance claims a unique instance identifier for the SQL pod, and
@@ -281,6 +293,13 @@ func (s *Storage) createInstanceRow(
 
 	// If we exit here, it has to be the case where the context has expired.
 	return sqlinstance.InstanceInfo{}, ctx.Err()
+}
+
+// newInstanceCache constructs an instanceCache backed by a range feed over the
+// sql_instances table. newInstanceCache blocks until the initial scan is
+// complete.
+func (s *Storage) newInstanceCache(ctx context.Context) (instanceCache, error) {
+	return newRangeFeedCache(ctx, s.rowcodec, s.clock, s.f)
 }
 
 // getAvailableInstanceIDForRegion retrieves an available instance ID for the


### PR DESCRIPTION
This change is intended to support the migration of sql_instances to a regional by row compatible index structure. There are two main goals of the change:

1. Remove the rowCodec from the instance reader so that it does not need to be involved in the migration protocol.
2. Encapsulate the feed into a sub object so that the implementation can be easily swapped when the index changes.

Part of #94843

Release note: None