### PR TITLE
release-22.2: cdc: copy request body when registering schemas

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_stmt.go
+++ b/pkg/ccl/changefeedccl/changefeed_stmt.go
@@ -497,11 +497,12 @@ func createChangefeedJobRecord(
 		return nil, err
 	}
 
+	// Validate the encoder. We can pass an empty slimetrics struct here since the encoder will not be used.
 	encodingOpts, err := opts.GetEncodingOptions()
 	if err != nil {
 		return nil, err
 	}
-	if _, err := getEncoder(encodingOpts, AllTargets(details)); err != nil {
+	if _, err := getEncoder(encodingOpts, AllTargets(details), nil); err != nil {
 		return nil, err
 	}
 

--- a/pkg/ccl/changefeedccl/encoder.go
+++ b/pkg/ccl/changefeedccl/encoder.go
@@ -42,13 +42,13 @@ type Encoder interface {
 }
 
 func getEncoder(
-	opts changefeedbase.EncodingOptions, targets changefeedbase.Targets,
+	opts changefeedbase.EncodingOptions, targets changefeedbase.Targets, sliMetrics *sliMetrics,
 ) (Encoder, error) {
 	switch opts.Format {
 	case changefeedbase.OptFormatJSON:
 		return makeJSONEncoder(opts)
 	case changefeedbase.OptFormatAvro, changefeedbase.DeprecatedOptFormatAvro:
-		return newConfluentAvroEncoder(opts, targets)
+		return newConfluentAvroEncoder(opts, targets, sliMetrics)
 	case changefeedbase.OptFormatCSV:
 		return newCSVEncoder(opts), nil
 	default:

--- a/pkg/ccl/changefeedccl/encoder_avro.go
+++ b/pkg/ccl/changefeedccl/encoder_avro.go
@@ -74,7 +74,7 @@ var encoderCacheConfig = cache.Config{
 }
 
 func newConfluentAvroEncoder(
-	opts changefeedbase.EncodingOptions, targets changefeedbase.Targets,
+	opts changefeedbase.EncodingOptions, targets changefeedbase.Targets, sliMetrics *sliMetrics,
 ) (*confluentAvroEncoder, error) {
 	e := &confluentAvroEncoder{
 		schemaPrefix:            opts.AvroSchemaPrefix,
@@ -102,7 +102,7 @@ func newConfluentAvroEncoder(
 			changefeedbase.OptConfluentSchemaRegistry, changefeedbase.OptFormat, changefeedbase.OptFormatAvro)
 	}
 
-	reg, err := newConfluentSchemaRegistry(opts.SchemaRegistryURI)
+	reg, err := newConfluentSchemaRegistry(opts.SchemaRegistryURI, sliMetrics)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/ccl/changefeedccl/encoder_test.go
+++ b/pkg/ccl/changefeedccl/encoder_test.go
@@ -236,7 +236,7 @@ func TestEncoders(t *testing.T) {
 				return
 			}
 			require.NoError(t, o.Validate())
-			e, err := getEncoder(o, targets)
+			e, err := getEncoder(o, targets, nil)
 			require.NoError(t, err)
 
 			rowInsert := cdcevent.TestingMakeEventRow(tableDesc, 0, row, false)
@@ -382,7 +382,7 @@ func TestAvroEncoderWithTLS(t *testing.T) {
 				StatementTimeName: changefeedbase.StatementTimeName(tableDesc.GetName()),
 			})
 
-			e, err := getEncoder(opts, targets)
+			e, err := getEncoder(opts, targets, nil)
 			require.NoError(t, err)
 
 			rowInsert := cdcevent.TestingMakeEventRow(tableDesc, 0, row, false)
@@ -414,7 +414,7 @@ func TestAvroEncoderWithTLS(t *testing.T) {
 			defer noCertReg.Close()
 			opts.SchemaRegistryURI = noCertReg.URL()
 
-			enc, err := getEncoder(opts, targets)
+			enc, err := getEncoder(opts, targets, nil)
 			require.NoError(t, err)
 			_, err = enc.EncodeKey(context.Background(), rowInsert)
 			require.Regexp(t, "x509", err)
@@ -427,7 +427,7 @@ func TestAvroEncoderWithTLS(t *testing.T) {
 			defer wrongCertReg.Close()
 			opts.SchemaRegistryURI = wrongCertReg.URL()
 
-			enc, err = getEncoder(opts, targets)
+			enc, err = getEncoder(opts, targets, nil)
 			require.NoError(t, err)
 			_, err = enc.EncodeKey(context.Background(), rowInsert)
 			require.Regexp(t, `contacting confluent schema registry.*: x509`, err)
@@ -916,7 +916,7 @@ func BenchmarkEncoders(b *testing.B) {
 	bench := func(b *testing.B, fn encodeFn, opts changefeedbase.EncodingOptions, updatedRows, prevRows []cdcevent.Row) {
 		b.ReportAllocs()
 		b.StopTimer()
-		encoder, err := getEncoder(opts, targets)
+		encoder, err := getEncoder(opts, targets, nil)
 		if err != nil {
 			b.Fatal(err)
 		}

--- a/pkg/ccl/changefeedccl/schema_registry_test.go
+++ b/pkg/ccl/changefeedccl/schema_registry_test.go
@@ -10,9 +10,12 @@ package changefeedccl
 
 import (
 	"context"
+	"errors"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/cdctest"
+	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/stretchr/testify/require"
@@ -23,12 +26,12 @@ func TestConfluentSchemaRegistry(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	t.Run("errors with no scheme", func(t *testing.T) {
-		_, err := newConfluentSchemaRegistry("justsomestring")
+		_, err := newConfluentSchemaRegistry("justsomestring", nil)
 		require.Error(t, err)
 	})
 	t.Run("errors with unsupported scheme", func(t *testing.T) {
 		url := "gopher://myhost"
-		_, err := newConfluentSchemaRegistry(url)
+		_, err := newConfluentSchemaRegistry(url, nil)
 		require.Error(t, err)
 	})
 }
@@ -41,18 +44,49 @@ func TestConfluentSchemaRegistryPing(t *testing.T) {
 	defer regServer.Close()
 
 	t.Run("ping works when all is well", func(t *testing.T) {
-		reg, err := newConfluentSchemaRegistry(regServer.URL())
+		reg, err := newConfluentSchemaRegistry(regServer.URL(), nil)
 		require.NoError(t, err)
 		require.NoError(t, reg.Ping(context.Background()))
 	})
 	t.Run("ping does not error from HTTP 404", func(t *testing.T) {
-		reg, err := newConfluentSchemaRegistry(regServer.URL() + "/path-does-not-exist-but-we-do-not-care")
+		reg, err := newConfluentSchemaRegistry(regServer.URL()+"/path-does-not-exist-but-we-do-not-care", nil)
 		require.NoError(t, err)
 		require.NoError(t, reg.Ping(context.Background()), "Ping")
 	})
 	t.Run("Ping errors with bad host", func(t *testing.T) {
-		reg, err := newConfluentSchemaRegistry("http://host-does-exist-and-we-care")
+		reg, err := newConfluentSchemaRegistry("http://host-does-exist-and-we-care", nil)
 		require.NoError(t, err)
 		require.Error(t, reg.Ping(context.Background()))
 	})
+}
+
+// TestConfluentSchemaRegistryRetryMetrics verifies that we retry request to the schema registry
+// at least 5 times.
+func TestConfluentSchemaRegistryRetryMetrics(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	regServer := cdctest.StartErrorTestSchemaRegistry(409)
+	defer regServer.Close()
+
+	sliMetrics, err := MakeMetrics(base.DefaultHistogramWindowInterval()).(*Metrics).AggMetrics.getOrCreateScope("")
+	require.NoError(t, err)
+
+	t.Run("retries increment metrics", func(t *testing.T) {
+		reg, err := newConfluentSchemaRegistry(regServer.URL(), sliMetrics)
+		require.NoError(t, err)
+		ctx, cancel := context.WithCancel(context.Background())
+		go func() {
+			_, err = reg.RegisterSchemaForSubject(ctx, "subject1", "schema1")
+		}()
+		require.NoError(t, err)
+		testutils.SucceedsSoon(t, func() error {
+			if sliMetrics.SchemaRegistryRetries.Value() < 5 {
+				return errors.New("insufficient retries detected")
+			}
+			return nil
+		})
+		cancel()
+	})
+
 }

--- a/pkg/ts/catalog/chart_catalog.go
+++ b/pkg/ts/catalog/chart_catalog.go
@@ -1531,6 +1531,12 @@ var charts = []sectionDescription{
 					"changefeed.internal_retry_message_count",
 				},
 			},
+			{
+				Title: "Schema Registry Retries",
+				Metrics: []string{
+					"changefeed.schema_registry.retry_count",
+				},
+			},
 		},
 	},
 	{


### PR DESCRIPTION
Backport 1/2 commits from https://github.com/cockroachdb/cockroach/pull/98338, with resolved merged conflicts

---
cdc: copy request body when registering schemas

Previously, when the schema registry encountered an error when registering a schema, it would retry the request. The problem is that upon hitting an error, we clean the body before retrying. Retrying with an empty body results in a obscure error message. With this change, we now retry with the original request body so the original error is sustained.

This change also adds the metric changefeed.schema_registry.retry_count which is a counter for the number of retries performed by the schema registry. Seeing nonzero values indicates that there is an issue with contacting the schema registry and/or registering schemas.

Release note (ops change): A new metric changefeed.schema_registry.retry_count is added. This measures the number of request retries performed when sending requests to the schema registry. Observing a nonzero value may indicate improper configuration of the schema registry or changefeed parameters.

Release justification: This change fixes a bug which has caused customer escalations.
It also adds better observability.

Epic: None

Informs: cockroachlabs/support#2131
Informs: cockroachlabs/support#2129