### PR TITLE
release-22.2: sql/opt/bench: fix invalid JSON in `INJECT STATISTICS`

### DIFF
--- a/pkg/sql/opt/bench/bench_test.go
+++ b/pkg/sql/opt/bench/bench_test.go
@@ -322,7 +322,7 @@ var schemas = []string{
 		      {"num_eq": 10, "num_range": 10, "distinct_range": 10, "upper_bound": "abcdefghijklmnopqrstuvwxyz___________________9600"},
 		      {"num_eq": 10, "num_range": 10, "distinct_range": 10, "upper_bound": "abcdefghijklmnopqrstuvwxyz___________________9700"},
 		      {"num_eq": 10, "num_range": 10, "distinct_range": 10, "upper_bound": "abcdefghijklmnopqrstuvwxyz___________________9800"},
-		      {"num_eq": 10, "num_range": 10, "distinct_range": 10, "upper_bound": "abcdefghijklmnopqrstuvwxyz___________________9900"},
+		      {"num_eq": 10, "num_range": 10, "distinct_range": 10, "upper_bound": "abcdefghijklmnopqrstuvwxyz___________________9900"}
 		    ]
 		  }
 		]'


### PR DESCRIPTION
Backport 1/1 commits from #93605.

/cc @cockroachdb/release

---

Fixes: #93565
Release note: None

Release justification: Test-only change.