### PR TITLE
sql/schemachanger: use force puts when writing to new primary indexes

### DIFF
--- a/pkg/sql/catalog/table_col_set.go
+++ b/pkg/sql/catalog/table_col_set.go
@@ -71,6 +71,11 @@ func (s TableColSet) Difference(other TableColSet) TableColSet {
 	return TableColSet{set: s.set.Difference(other.set)}
 }
 
+// Equals returns the column IDs in s are equal to the ones in other.
+func (s TableColSet) Equals(other TableColSet) bool {
+	return s.set.Equals(other.set)
+}
+
 // Ordered returns a slice with all the descpb.ColumnIDs in the set, in
 // increasing order.
 func (s TableColSet) Ordered() []descpb.ColumnID {

--- a/pkg/sql/catalog/tabledesc/index.go
+++ b/pkg/sql/catalog/tabledesc/index.go
@@ -391,15 +391,49 @@ func (w index) UseDeletePreservingEncoding() bool {
 	return w.desc.UseDeletePreservingEncoding && !w.maybeMutation.DeleteOnly()
 }
 
-// ForcePut returns true if writes to the index should only use Put (rather than
-// CPut or InitPut). This is used by:
+// ForcePut forces all writes to use Put rather than CPut or InitPut.
 //
-//   - indexes currently being built by the MVCC-compliant index backfiller, and
-//   - the temporary indexes that support that process, and
-//   - old primary indexes which are being dropped.
+// Users of this options should take great care as it
+// effectively mean unique constraints are not respected.
+//
+// Currently (2023-03-09) there are three users:
+//   - delete preserving indexes
+//   - merging indexes
+//   - dropping primary indexes
+//   - adding primary indexes with new columns (same key)
+//
+// Delete preserving encoding indexes are used only as a log of
+// index writes during backfill, thus we can blindly put values into
+// them.
+//
+// New indexes may miss updates during the backfilling process
+// that would lead to CPut failures until the missed updates
+// are merged into the index. Uniqueness for such indexes is
+// checked by the schema changer before they are brought back
+// online.
+//
+// In the case of dropping primary indexes, we always ensure that
+// there's a replacement primary index which has become public.
+// The reason we must not use cput is that the new primary index
+// may not store all the columns stored in this index.
+//
+// In the case of adding primary indexes with new columns, we don't
+// know the value of the new column when performing updates, so we can't
+// synthesize the expectation. This is okay because the uniqueness of
+// the key is being enforced by the existing primary index.
+//
+// When altering a primary key, we never simultaneously add new columns.
+// When adding a new primary index which has a new key, we always ensure that
+// the source primary index, which is the public primary index, has all
+// columns in that new primary index. In this case, it's unsafe to avoid the
+// ForcePut when that index is in WriteOnly because we need the write to be
+// upholding uniqueness. To re-iterate, when changing the primary key of a
+// table, we'll not be both adding new columns and creating the new primary
+// key at the same time; we have to materialize the new columns and make them
+// available as the public primary index on the table before proceeding to
+// populate the new primary index with the new key structure.
 func (w index) ForcePut() bool {
-	return w.Merging() || w.desc.UseDeletePreservingEncoding ||
-		w.Dropped() && w.IsUnique() && w.GetEncodingType() == catenumpb.PrimaryIndexEncoding
+	return w.mutationForcePutForIndexWrites
 }
 
 func (w index) CreatedAt() time.Time {

--- a/pkg/sql/schemachanger/testdata/end_to_end/add_column
+++ b/pkg/sql/schemachanger/testdata/end_to_end/add_column
@@ -1,6 +1,6 @@
 setup
 CREATE DATABASE db;
-CREATE TABLE db.public.tbl (i INT PRIMARY KEY);
+CREATE TABLE db.public.tbl (i INT PRIMARY KEY, k INT);
 CREATE SEQUENCE db.public.sq1;
 ----
 ...
@@ -12,12 +12,17 @@ CREATE SEQUENCE db.public.sq1;
 stage-exec phase=PostCommitPhase stage=:
 INSERT INTO db.public.tbl VALUES($stageKey);
 INSERT INTO db.public.tbl VALUES($stageKey + 1);
+UPDATE db.public.tbl SET k=$stageKey;
+UPDATE db.public.tbl SET k=i;
+DELETE FROM db.public.tbl WHERE i=-1;
+DELETE FROM db.public.tbl WHERE i=$stageKey;
+INSERT INTO db.public.tbl VALUES($stageKey);
+INSERT INTO db.public.tbl VALUES(-1);
 ----
 
-# Each insert will be injected twice per stage, so we should always,
-# see a count of 2.
+# Each insert will be injected twice per stage, plus 1 extra.
 stage-query phase=PostCommitPhase stage=:
-SELECT count(*)=$successfulStageCount*2 FROM db.public.tbl;
+SELECT count(*)=($successfulStageCount*2)+1 FROM db.public.tbl;
 ----
 true
 
@@ -25,12 +30,17 @@ true
 stage-exec phase=PostCommitNonRevertiblePhase stage=:
 INSERT INTO db.public.tbl VALUES($stageKey);
 INSERT INTO db.public.tbl VALUES($stageKey + 1);
+UPDATE db.public.tbl SET k=$stageKey;
+UPDATE db.public.tbl SET k=i;
+DELETE FROM db.public.tbl WHERE i=-1;
+DELETE FROM db.public.tbl WHERE i=$stageKey;
+INSERT INTO db.public.tbl VALUES($stageKey);
+INSERT INTO db.public.tbl VALUES(-1);
 ----
 
-# Each insert will be injected twice per stage, so we should always,
-# see a count of 2.
+# Each insert will be injected twice per stage, , plus 1 extra.
 stage-query phase=PostCommitNonRevertiblePhase stage=:
-SELECT count(*)=$successfulStageCount*2 FROM db.public.tbl;
+SELECT count(*)=($successfulStageCount*2)+1 FROM db.public.tbl;
 ----
 true
 
@@ -53,27 +63,28 @@ write *eventpb.AlterTable to event log:
     tag: ALTER TABLE
     user: root
   tableName: db.public.tbl
-## StatementPhase stage 1 of 1 with 10 MutationType ops
+## StatementPhase stage 1 of 1 with 12 MutationType ops
 upsert descriptor #106
   ...
-     - columnIds:
        - 1
-  +    - 2
+       - 2
+  +    - 3
        columnNames:
        - i
+       - k
   +    - j
-  +    defaultColumnId: 2
+       defaultColumnId: 2
        name: primary
-     formatVersion: 3
+  ...
      id: 106
      modificationTime: {}
   +  mutations:
   +  - column:
   +      defaultExpr: 42:::INT8
-  +      id: 2
+  +      id: 3
   +      name: j
   +      nullable: true
-  +      pgAttributeNum: 2
+  +      pgAttributeNum: 3
   +      type:
   +        family: IntFamily
   +        oid: 20
@@ -101,7 +112,9 @@ upsert descriptor #106
   +      sharded: {}
   +      storeColumnIds:
   +      - 2
+  +      - 3
   +      storeColumnNames:
+  +      - k
   +      - j
   +      unique: true
   +      version: 4
@@ -127,7 +140,9 @@ upsert descriptor #106
   +      sharded: {}
   +      storeColumnIds:
   +      - 2
+  +      - 3
   +      storeColumnNames:
+  +      - k
   +      - j
   +      unique: true
   +      useDeletePreservingEncoding: true
@@ -135,9 +150,9 @@ upsert descriptor #106
   +    mutationId: 1
   +    state: DELETE_ONLY
      name: tbl
-  -  nextColumnId: 2
+  -  nextColumnId: 3
   -  nextConstraintId: 2
-  +  nextColumnId: 3
+  +  nextColumnId: 4
   +  nextConstraintId: 4
      nextFamilyId: 1
   -  nextIndexId: 2
@@ -154,7 +169,7 @@ upsert descriptor #106
 ## PreCommitPhase stage 1 of 2 with 1 MutationType op
 undo all catalog changes within txn #1
 persist all catalog changes to storage
-## PreCommitPhase stage 2 of 2 with 14 MutationType ops
+## PreCommitPhase stage 2 of 2 with 16 MutationType ops
 upsert descriptor #106
   ...
      createAsOfTime:
@@ -176,22 +191,24 @@ upsert descriptor #106
      families:
      - columnIds:
        - 1
-  +    - 2
+       - 2
+  +    - 3
        columnNames:
        - i
+       - k
   +    - j
-  +    defaultColumnId: 2
+       defaultColumnId: 2
        name: primary
-     formatVersion: 3
+  ...
      id: 106
      modificationTime: {}
   +  mutations:
   +  - column:
   +      defaultExpr: 42:::INT8
-  +      id: 2
+  +      id: 3
   +      name: j
   +      nullable: true
-  +      pgAttributeNum: 2
+  +      pgAttributeNum: 3
   +      type:
   +        family: IntFamily
   +        oid: 20
@@ -219,7 +236,9 @@ upsert descriptor #106
   +      sharded: {}
   +      storeColumnIds:
   +      - 2
+  +      - 3
   +      storeColumnNames:
+  +      - k
   +      - j
   +      unique: true
   +      version: 4
@@ -245,7 +264,9 @@ upsert descriptor #106
   +      sharded: {}
   +      storeColumnIds:
   +      - 2
+  +      - 3
   +      storeColumnNames:
+  +      - k
   +      - j
   +      unique: true
   +      useDeletePreservingEncoding: true
@@ -253,9 +274,9 @@ upsert descriptor #106
   +    mutationId: 1
   +    state: DELETE_ONLY
      name: tbl
-  -  nextColumnId: 2
+  -  nextColumnId: 3
   -  nextConstraintId: 2
-  +  nextColumnId: 3
+  +  nextColumnId: 4
   +  nextConstraintId: 4
      nextFamilyId: 1
   -  nextIndexId: 2
@@ -282,7 +303,7 @@ upsert descriptor #106
    table:
   +  checks:
   +  - columnIds:
-  +    - 2
+  +    - 3
   +    expr: j IS NOT NULL
   +    isNonNullConstraint: true
   +    name: j_auto_not_null
@@ -304,7 +325,7 @@ upsert descriptor #106
   +  - constraint:
   +      check:
   +        columnIds:
-  +        - 2
+  +        - 3
   +        expr: j IS NOT NULL
   +        isNonNullConstraint: true
   +        name: j_auto_not_null
@@ -312,13 +333,13 @@ upsert descriptor #106
   +      constraintType: NOT_NULL
   +      foreignKey: {}
   +      name: j_auto_not_null
-  +      notNullColumn: 2
+  +      notNullColumn: 3
   +      uniqueWithoutIndexConstraint: {}
   +    direction: ADD
   +    mutationId: 1
   +    state: WRITE_ONLY
      name: tbl
-     nextColumnId: 3
+     nextColumnId: 4
   ...
        time: {}
      unexposedParentSchemaId: 105
@@ -395,12 +416,12 @@ validate forward indexes [2] in table #106
 validate CHECK constraint j_auto_not_null in table #106
 commit transaction #9
 begin transaction #10
-## PostCommitNonRevertiblePhase stage 1 of 3 with 12 MutationType ops
+## PostCommitNonRevertiblePhase stage 1 of 3 with 13 MutationType ops
 upsert descriptor #106
    table:
   -  checks:
   -  - columnIds:
-  -    - 2
+  -    - 3
   -    expr: j IS NOT NULL
   -    isNonNullConstraint: true
   -    name: j_auto_not_null
@@ -412,9 +433,9 @@ upsert descriptor #106
          oid: 20
          width: 64
   +  - defaultExpr: 42:::INT8
-  +    id: 2
+  +    id: 3
   +    name: j
-  +    pgAttributeNum: 2
+  +    pgAttributeNum: 3
   +    type:
   +      family: IntFamily
   +      oid: 20
@@ -432,10 +453,10 @@ upsert descriptor #106
      mutations:
   -  - column:
   -      defaultExpr: 42:::INT8
-  -      id: 2
+  -      id: 3
   -      name: j
   -      nullable: true
-  -      pgAttributeNum: 2
+  -      pgAttributeNum: 3
   -      type:
   -        family: IntFamily
   -        oid: 20
@@ -492,9 +513,11 @@ upsert descriptor #106
   +      name: crdb_internal_index_1_name_placeholder
          partitioning: {}
          sharded: {}
-  -      storeColumnIds:
-  -      - 2
-  -      storeColumnNames:
+         storeColumnIds:
+         - 2
+  -      - 3
+         storeColumnNames:
+         - k
   -      - j
          unique: true
   -      useDeletePreservingEncoding: true
@@ -504,7 +527,7 @@ upsert descriptor #106
   -  - constraint:
   -      check:
   -        columnIds:
-  -        - 2
+  -        - 3
   -        expr: j IS NOT NULL
   -        isNonNullConstraint: true
   -        name: j_auto_not_null
@@ -512,13 +535,13 @@ upsert descriptor #106
   -      constraintType: NOT_NULL
   -      foreignKey: {}
   -      name: j_auto_not_null
-  -      notNullColumn: 2
+  -      notNullColumn: 3
   -      uniqueWithoutIndexConstraint: {}
   -    direction: ADD
   -    mutationId: 1
   -    state: WRITE_ONLY
      name: tbl
-     nextColumnId: 3
+     nextColumnId: 4
   ...
      parentId: 104
      primaryIndex:
@@ -534,11 +557,11 @@ upsert descriptor #106
        interleave: {}
        keyColumnDirections:
   ...
-       partitioning: {}
-       sharded: {}
-  +    storeColumnIds:
-  +    - 2
-  +    storeColumnNames:
+       storeColumnIds:
+       - 2
+  +    - 3
+       storeColumnNames:
+       - k
   +    - j
        unique: true
        version: 4
@@ -549,11 +572,11 @@ upsert descriptor #106
   +  version: "7"
 persist all catalog changes to storage
 adding table for stats refresh: 106
-update progress of schema change job #1: "PostCommitNonRevertiblePhase stage 2 of 3 with 3 MutationType ops pending"
+update progress of schema change job #1: "PostCommitNonRevertiblePhase stage 2 of 3 with 4 MutationType ops pending"
 set schema change job #1 to non-cancellable
 commit transaction #10
 begin transaction #11
-## PostCommitNonRevertiblePhase stage 2 of 3 with 5 MutationType ops
+## PostCommitNonRevertiblePhase stage 2 of 3 with 6 MutationType ops
 upsert descriptor #106
   ...
      - direction: DROP
@@ -576,7 +599,9 @@ upsert descriptor #106
   -      sharded: {}
   -      storeColumnIds:
   -      - 2
+  -      - 3
   -      storeColumnNames:
+  -      - k
   -      - j
   -      unique: true
   -      useDeletePreservingEncoding: true
@@ -593,7 +618,7 @@ upsert descriptor #106
   -    state: WRITE_ONLY
   +    state: DELETE_ONLY
      name: tbl
-     nextColumnId: 3
+     nextColumnId: 4
   ...
        time: {}
      unexposedParentSchemaId: 105
@@ -645,13 +670,17 @@ upsert descriptor #106
   -      name: crdb_internal_index_1_name_placeholder
   -      partitioning: {}
   -      sharded: {}
+  -      storeColumnIds:
+  -      - 2
+  -      storeColumnNames:
+  -      - k
   -      unique: true
   -      version: 4
   -    mutationId: 1
   -    state: DELETE_ONLY
   +  mutations: []
      name: tbl
-     nextColumnId: 3
+     nextColumnId: 4
   ...
        time: {}
      unexposedParentSchemaId: 105

--- a/pkg/sql/schemachanger/testdata/end_to_end/drop_column_basic
+++ b/pkg/sql/schemachanger/testdata/end_to_end/drop_column_basic
@@ -1,5 +1,5 @@
 setup
-CREATE TABLE t (i INT PRIMARY KEY, j INT);
+CREATE TABLE t (i INT PRIMARY KEY, j INT, k int);
 COMMENT ON TABLE t IS 't has a comment';
 COMMENT ON COLUMN t.j IS 'j has a comment';
 ----
@@ -9,27 +9,38 @@ COMMENT ON COLUMN t.j IS 'j has a comment';
 stage-exec phase=PostCommitPhase stage=:
 INSERT INTO t VALUES($stageKey);
 INSERT INTO t VALUES($stageKey + 1);
+UPDATE t SET k=$stageKey;
+UPDATE t SET k=i;
+DELETE FROM t WHERE i=-1;
+DELETE FROM t WHERE i=$stageKey;
+INSERT INTO t VALUES($stageKey);
+INSERT INTO t VALUES(-1);
 ----
 
-# Each insert will be injected twice per stage, so we should always,
-# see a count of 2.
+# Each insert will be injected twice per stage, plus 3 injected
+# at the start.
 stage-query phase=PostCommitPhase stage=:
-SELECT count(*)=$successfulStageCount*2 FROM t;
+SELECT count(*)=($successfulStageCount*2) FROM t;
 ----
-true
-
+false
 
 stage-exec phase=PostCommitNonRevertiblePhase stage=:
 INSERT INTO t VALUES($stageKey);
 INSERT INTO t VALUES($stageKey + 1);
+UPDATE t SET k=$stageKey;
+UPDATE t SET k=i;
+DELETE FROM t WHERE i=-1;
+DELETE FROM t WHERE i=$stageKey;
+INSERT INTO t VALUES($stageKey);
+INSERT INTO t VALUES(-1);
 ----
 
-# Each insert will be injected twice per stage, so we should always,
-# see a count of 2.
+# Each insert will be injected twice per stage, plus 3 injected
+# at the start.
 stage-query phase=PostCommitNonRevertiblePhase stage=:
-SELECT count(*)=$successfulStageCount*2 FROM t;
+SELECT count(*)=($successfulStageCount*2) FROM t;
 ----
-true
+false
 
 test
 ALTER TABLE t DROP COLUMN j
@@ -47,7 +58,7 @@ write *eventpb.AlterTable to event log:
     tag: ALTER TABLE
     user: root
   tableName: defaultdb.public.t
-## StatementPhase stage 1 of 1 with 7 MutationType ops
+## StatementPhase stage 1 of 1 with 9 MutationType ops
 upsert descriptor #104
   ...
          oid: 20
@@ -59,14 +70,14 @@ upsert descriptor #104
   -      family: IntFamily
   -      oid: 20
   -      width: 64
-     createAsOfTime:
-       wallTime: "1640995200000000000"
+     - id: 3
+       name: k
   ...
        columnNames:
        - i
   -    - j
   +    - crdb_internal_column_2_name_placeholder
-       defaultColumnId: 2
+       - k
        name: primary
   ...
      id: 104
@@ -101,7 +112,10 @@ upsert descriptor #104
   +      name: crdb_internal_index_2_name_placeholder
   +      partitioning: {}
   +      sharded: {}
-  +      storeColumnNames: []
+  +      storeColumnIds:
+  +      - 3
+  +      storeColumnNames:
+  +      - k
   +      unique: true
   +      version: 4
   +    mutationId: 1
@@ -124,14 +138,17 @@ upsert descriptor #104
   +      name: crdb_internal_index_3_name_placeholder
   +      partitioning: {}
   +      sharded: {}
-  +      storeColumnNames: []
+  +      storeColumnIds:
+  +      - 3
+  +      storeColumnNames:
+  +      - k
   +      unique: true
   +      useDeletePreservingEncoding: true
   +      version: 4
   +    mutationId: 1
   +    state: DELETE_ONLY
      name: t
-     nextColumnId: 3
+     nextColumnId: 4
   -  nextConstraintId: 2
   +  nextConstraintId: 4
      nextFamilyId: 1
@@ -140,12 +157,12 @@ upsert descriptor #104
      nextMutationId: 1
      parentId: 100
   ...
-       - 2
+       - 3
        storeColumnNames:
   -    - j
   +    - crdb_internal_column_2_name_placeholder
+       - k
        unique: true
-       version: 4
   ...
        time: {}
      unexposedParentSchemaId: 101
@@ -157,7 +174,7 @@ delete comment ColumnCommentType(objID: 104, subID: 2)
 ## PreCommitPhase stage 1 of 2 with 1 MutationType op
 undo all catalog changes within txn #1
 persist all catalog changes to storage
-## PreCommitPhase stage 2 of 2 with 11 MutationType ops
+## PreCommitPhase stage 2 of 2 with 13 MutationType ops
 upsert descriptor #104
   ...
          oid: 20
@@ -169,6 +186,9 @@ upsert descriptor #104
   -      family: IntFamily
   -      oid: 20
   -      width: 64
+     - id: 3
+       name: k
+  ...
      createAsOfTime:
        wallTime: "1640995200000000000"
   +  declarativeSchemaChangerState:
@@ -191,7 +211,7 @@ upsert descriptor #104
        - i
   -    - j
   +    - crdb_internal_column_2_name_placeholder
-       defaultColumnId: 2
+       - k
        name: primary
   ...
      id: 104
@@ -226,7 +246,10 @@ upsert descriptor #104
   +      name: crdb_internal_index_2_name_placeholder
   +      partitioning: {}
   +      sharded: {}
-  +      storeColumnNames: []
+  +      storeColumnIds:
+  +      - 3
+  +      storeColumnNames:
+  +      - k
   +      unique: true
   +      version: 4
   +    mutationId: 1
@@ -249,14 +272,17 @@ upsert descriptor #104
   +      name: crdb_internal_index_3_name_placeholder
   +      partitioning: {}
   +      sharded: {}
-  +      storeColumnNames: []
+  +      storeColumnIds:
+  +      - 3
+  +      storeColumnNames:
+  +      - k
   +      unique: true
   +      useDeletePreservingEncoding: true
   +      version: 4
   +    mutationId: 1
   +    state: DELETE_ONLY
      name: t
-     nextColumnId: 3
+     nextColumnId: 4
   -  nextConstraintId: 2
   +  nextConstraintId: 4
      nextFamilyId: 1
@@ -265,12 +291,12 @@ upsert descriptor #104
      nextMutationId: 1
      parentId: 100
   ...
-       - 2
+       - 3
        storeColumnNames:
   -    - j
   +    - crdb_internal_column_2_name_placeholder
+       - k
        unique: true
-       version: 4
   ...
        time: {}
      unexposedParentSchemaId: 101
@@ -295,7 +321,7 @@ upsert descriptor #104
   -    state: DELETE_ONLY
   +    state: WRITE_ONLY
      name: t
-     nextColumnId: 3
+     nextColumnId: 4
   ...
        time: {}
      unexposedParentSchemaId: 101
@@ -371,7 +397,7 @@ begin transaction #9
 validate forward indexes [2] in table #104
 commit transaction #9
 begin transaction #10
-## PostCommitNonRevertiblePhase stage 1 of 3 with 9 MutationType ops
+## PostCommitNonRevertiblePhase stage 1 of 3 with 10 MutationType ops
 upsert descriptor #104
   ...
            statement: ALTER TABLE t DROP COLUMN j
@@ -404,7 +430,8 @@ upsert descriptor #104
   +      name: crdb_internal_index_3_name_placeholder
          partitioning: {}
          sharded: {}
-         storeColumnNames: []
+  ...
+         - k
          unique: true
   +      useDeletePreservingEncoding: true
          version: 4
@@ -432,11 +459,12 @@ upsert descriptor #104
   +      name: crdb_internal_index_1_name_placeholder
          partitioning: {}
          sharded: {}
-  -      storeColumnNames: []
-  +      storeColumnIds:
+         storeColumnIds:
   +      - 2
-  +      storeColumnNames:
+         - 3
+         storeColumnNames:
   +      - crdb_internal_column_2_name_placeholder
+         - k
          unique: true
   -      useDeletePreservingEncoding: true
          version: 4
@@ -456,26 +484,25 @@ upsert descriptor #104
        interleave: {}
        keyColumnDirections:
   ...
-       partitioning: {}
        sharded: {}
-  -    storeColumnIds:
+       storeColumnIds:
   -    - 2
-  -    storeColumnNames:
+       - 3
+       storeColumnNames:
   -    - crdb_internal_column_2_name_placeholder
-  +    storeColumnNames: []
+       - k
        unique: true
-       version: 4
   ...
        time: {}
      unexposedParentSchemaId: 101
   -  version: "6"
   +  version: "7"
 persist all catalog changes to storage
-update progress of schema change job #1: "PostCommitNonRevertiblePhase stage 2 of 3 with 4 MutationType ops pending"
+update progress of schema change job #1: "PostCommitNonRevertiblePhase stage 2 of 3 with 5 MutationType ops pending"
 set schema change job #1 to non-cancellable
 commit transaction #10
 begin transaction #11
-## PostCommitNonRevertiblePhase stage 2 of 3 with 6 MutationType ops
+## PostCommitNonRevertiblePhase stage 2 of 3 with 7 MutationType ops
 upsert descriptor #104
   ...
      - direction: DROP
@@ -496,7 +523,10 @@ upsert descriptor #104
   -      name: crdb_internal_index_3_name_placeholder
   -      partitioning: {}
   -      sharded: {}
-  -      storeColumnNames: []
+  -      storeColumnIds:
+  -      - 3
+  -      storeColumnNames:
+  -      - k
   -      unique: true
   -      useDeletePreservingEncoding: true
   -      version: 4
@@ -512,7 +542,7 @@ upsert descriptor #104
   -    state: WRITE_ONLY
   +    state: DELETE_ONLY
      name: t
-     nextColumnId: 3
+     nextColumnId: 4
   ...
        time: {}
      unexposedParentSchemaId: 101
@@ -543,10 +573,11 @@ upsert descriptor #104
      - columnIds:
        - 1
   -    - 2
+       - 3
        columnNames:
        - i
   -    - crdb_internal_column_2_name_placeholder
-       defaultColumnId: 2
+       - k
        name: primary
   ...
      id: 104
@@ -583,15 +614,17 @@ upsert descriptor #104
   -      sharded: {}
   -      storeColumnIds:
   -      - 2
+  -      - 3
   -      storeColumnNames:
   -      - crdb_internal_column_2_name_placeholder
+  -      - k
   -      unique: true
   -      version: 4
   -    mutationId: 1
   -    state: DELETE_ONLY
   +  mutations: []
      name: t
-     nextColumnId: 3
+     nextColumnId: 4
   ...
        time: {}
      unexposedParentSchemaId: 101

--- a/pkg/sql/schemachanger/testdata/explain/add_column
+++ b/pkg/sql/schemachanger/testdata/explain/add_column
@@ -1,6 +1,6 @@
 /* setup */
 CREATE DATABASE db;
-CREATE TABLE db.public.tbl (i INT PRIMARY KEY);
+CREATE TABLE db.public.tbl (i INT PRIMARY KEY, k INT);
 CREATE SEQUENCE db.public.sq1;
 
 /* test */
@@ -9,88 +9,98 @@ EXPLAIN (ddl) ALTER TABLE db.public.tbl ADD COLUMN j INT NOT NULL DEFAULT 42;
 Schema change plan for ALTER TABLE ‹db›.‹public›.‹tbl› ADD COLUMN ‹j› INT8 NOT NULL DEFAULT ‹42›;
  ├── StatementPhase
  │    └── Stage 1 of 1 in StatementPhase
- │         ├── 8 elements transitioning toward PUBLIC
- │         │    ├── ABSENT → DELETE_ONLY   Column:{DescID: 106, ColumnID: 2}
- │         │    ├── ABSENT → PUBLIC        ColumnName:{DescID: 106, Name: j, ColumnID: 2}
- │         │    ├── ABSENT → PUBLIC        ColumnType:{DescID: 106, ColumnFamilyID: 0, ColumnID: 2}
- │         │    ├── ABSENT → PUBLIC        ColumnDefaultExpression:{DescID: 106, ColumnID: 2}
+ │         ├── 9 elements transitioning toward PUBLIC
+ │         │    ├── ABSENT → DELETE_ONLY   Column:{DescID: 106, ColumnID: 3}
+ │         │    ├── ABSENT → PUBLIC        ColumnName:{DescID: 106, Name: j, ColumnID: 3}
+ │         │    ├── ABSENT → PUBLIC        ColumnType:{DescID: 106, ColumnFamilyID: 0, ColumnID: 3}
+ │         │    ├── ABSENT → PUBLIC        ColumnDefaultExpression:{DescID: 106, ColumnID: 3}
  │         │    ├── ABSENT → BACKFILL_ONLY PrimaryIndex:{DescID: 106, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
  │         │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 106, ColumnID: 1, IndexID: 2}
  │         │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 2}
+ │         │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 106, ColumnID: 3, IndexID: 2}
  │         │    └── ABSENT → PUBLIC        IndexData:{DescID: 106, IndexID: 2}
- │         ├── 3 elements transitioning toward TRANSIENT_ABSENT
+ │         ├── 4 elements transitioning toward TRANSIENT_ABSENT
  │         │    ├── ABSENT → DELETE_ONLY   TemporaryIndex:{DescID: 106, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
  │         │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 106, ColumnID: 1, IndexID: 3}
- │         │    └── ABSENT → PUBLIC        IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 3}
- │         └── 10 Mutation operations
- │              ├── MakeAbsentColumnDeleteOnly {"Column":{"ColumnID":2,"PgAttributeNum":2,"TableID":106}}
- │              ├── SetColumnName {"ColumnID":2,"Name":"j","TableID":106}
- │              ├── SetAddedColumnType {"ColumnType":{"ColumnID":2,"TableID":106}}
- │              ├── AddColumnDefaultExpression {"Default":{"ColumnID":2,"TableID":106}}
+ │         │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 3}
+ │         │    └── ABSENT → PUBLIC        IndexColumn:{DescID: 106, ColumnID: 3, IndexID: 3}
+ │         └── 12 Mutation operations
+ │              ├── MakeAbsentColumnDeleteOnly {"Column":{"ColumnID":3,"PgAttributeNum":3,"TableID":106}}
+ │              ├── SetColumnName {"ColumnID":3,"Name":"j","TableID":106}
+ │              ├── SetAddedColumnType {"ColumnType":{"ColumnID":3,"TableID":106}}
+ │              ├── AddColumnDefaultExpression {"Default":{"ColumnID":3,"TableID":106}}
  │              ├── MakeAbsentIndexBackfilling {"Index":{"ConstraintID":2,"IndexID":2,"IsUnique":true,"SourceIndexID":1,"TableID":106,"TemporaryIndexID":3}}
  │              ├── AddColumnToIndex {"ColumnID":1,"IndexID":2,"TableID":106}
  │              ├── AddColumnToIndex {"ColumnID":2,"IndexID":2,"Kind":2,"TableID":106}
+ │              ├── AddColumnToIndex {"ColumnID":3,"IndexID":2,"Kind":2,"Ordinal":1,"TableID":106}
  │              ├── MakeAbsentTempIndexDeleteOnly {"Index":{"ConstraintID":3,"IndexID":3,"IsUnique":true,"SourceIndexID":1,"TableID":106}}
  │              ├── AddColumnToIndex {"ColumnID":1,"IndexID":3,"TableID":106}
- │              └── AddColumnToIndex {"ColumnID":2,"IndexID":3,"Kind":2,"TableID":106}
+ │              ├── AddColumnToIndex {"ColumnID":2,"IndexID":3,"Kind":2,"TableID":106}
+ │              └── AddColumnToIndex {"ColumnID":3,"IndexID":3,"Kind":2,"Ordinal":1,"TableID":106}
  ├── PreCommitPhase
  │    ├── Stage 1 of 2 in PreCommitPhase
- │    │    ├── 8 elements transitioning toward PUBLIC
- │    │    │    ├── DELETE_ONLY   → ABSENT Column:{DescID: 106, ColumnID: 2}
- │    │    │    ├── PUBLIC        → ABSENT ColumnName:{DescID: 106, Name: j, ColumnID: 2}
- │    │    │    ├── PUBLIC        → ABSENT ColumnType:{DescID: 106, ColumnFamilyID: 0, ColumnID: 2}
- │    │    │    ├── PUBLIC        → ABSENT ColumnDefaultExpression:{DescID: 106, ColumnID: 2}
+ │    │    ├── 9 elements transitioning toward PUBLIC
+ │    │    │    ├── DELETE_ONLY   → ABSENT Column:{DescID: 106, ColumnID: 3}
+ │    │    │    ├── PUBLIC        → ABSENT ColumnName:{DescID: 106, Name: j, ColumnID: 3}
+ │    │    │    ├── PUBLIC        → ABSENT ColumnType:{DescID: 106, ColumnFamilyID: 0, ColumnID: 3}
+ │    │    │    ├── PUBLIC        → ABSENT ColumnDefaultExpression:{DescID: 106, ColumnID: 3}
  │    │    │    ├── BACKFILL_ONLY → ABSENT PrimaryIndex:{DescID: 106, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
  │    │    │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 106, ColumnID: 1, IndexID: 2}
  │    │    │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 2}
+ │    │    │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 106, ColumnID: 3, IndexID: 2}
  │    │    │    └── PUBLIC        → ABSENT IndexData:{DescID: 106, IndexID: 2}
- │    │    ├── 3 elements transitioning toward TRANSIENT_ABSENT
+ │    │    ├── 4 elements transitioning toward TRANSIENT_ABSENT
  │    │    │    ├── DELETE_ONLY   → ABSENT TemporaryIndex:{DescID: 106, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
  │    │    │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 106, ColumnID: 1, IndexID: 3}
- │    │    │    └── PUBLIC        → ABSENT IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 3}
+ │    │    │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 3}
+ │    │    │    └── PUBLIC        → ABSENT IndexColumn:{DescID: 106, ColumnID: 3, IndexID: 3}
  │    │    └── 1 Mutation operation
  │    │         └── UndoAllInTxnImmediateMutationOpSideEffects
  │    └── Stage 2 of 2 in PreCommitPhase
- │         ├── 8 elements transitioning toward PUBLIC
- │         │    ├── ABSENT → DELETE_ONLY   Column:{DescID: 106, ColumnID: 2}
- │         │    ├── ABSENT → PUBLIC        ColumnName:{DescID: 106, Name: j, ColumnID: 2}
- │         │    ├── ABSENT → PUBLIC        ColumnType:{DescID: 106, ColumnFamilyID: 0, ColumnID: 2}
- │         │    ├── ABSENT → PUBLIC        ColumnDefaultExpression:{DescID: 106, ColumnID: 2}
+ │         ├── 9 elements transitioning toward PUBLIC
+ │         │    ├── ABSENT → DELETE_ONLY   Column:{DescID: 106, ColumnID: 3}
+ │         │    ├── ABSENT → PUBLIC        ColumnName:{DescID: 106, Name: j, ColumnID: 3}
+ │         │    ├── ABSENT → PUBLIC        ColumnType:{DescID: 106, ColumnFamilyID: 0, ColumnID: 3}
+ │         │    ├── ABSENT → PUBLIC        ColumnDefaultExpression:{DescID: 106, ColumnID: 3}
  │         │    ├── ABSENT → BACKFILL_ONLY PrimaryIndex:{DescID: 106, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
  │         │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 106, ColumnID: 1, IndexID: 2}
  │         │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 2}
+ │         │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 106, ColumnID: 3, IndexID: 2}
  │         │    └── ABSENT → PUBLIC        IndexData:{DescID: 106, IndexID: 2}
- │         ├── 3 elements transitioning toward TRANSIENT_ABSENT
+ │         ├── 4 elements transitioning toward TRANSIENT_ABSENT
  │         │    ├── ABSENT → DELETE_ONLY   TemporaryIndex:{DescID: 106, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
  │         │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 106, ColumnID: 1, IndexID: 3}
- │         │    └── ABSENT → PUBLIC        IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 3}
- │         └── 14 Mutation operations
- │              ├── MakeAbsentColumnDeleteOnly {"Column":{"ColumnID":2,"PgAttributeNum":2,"TableID":106}}
- │              ├── SetColumnName {"ColumnID":2,"Name":"j","TableID":106}
- │              ├── SetAddedColumnType {"ColumnType":{"ColumnID":2,"TableID":106}}
- │              ├── AddColumnDefaultExpression {"Default":{"ColumnID":2,"TableID":106}}
+ │         │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 3}
+ │         │    └── ABSENT → PUBLIC        IndexColumn:{DescID: 106, ColumnID: 3, IndexID: 3}
+ │         └── 16 Mutation operations
+ │              ├── MakeAbsentColumnDeleteOnly {"Column":{"ColumnID":3,"PgAttributeNum":3,"TableID":106}}
+ │              ├── SetColumnName {"ColumnID":3,"Name":"j","TableID":106}
+ │              ├── SetAddedColumnType {"ColumnType":{"ColumnID":3,"TableID":106}}
+ │              ├── AddColumnDefaultExpression {"Default":{"ColumnID":3,"TableID":106}}
  │              ├── MakeAbsentIndexBackfilling {"Index":{"ConstraintID":2,"IndexID":2,"IsUnique":true,"SourceIndexID":1,"TableID":106,"TemporaryIndexID":3}}
  │              ├── MaybeAddSplitForIndex {"IndexID":2,"TableID":106}
  │              ├── AddColumnToIndex {"ColumnID":1,"IndexID":2,"TableID":106}
  │              ├── AddColumnToIndex {"ColumnID":2,"IndexID":2,"Kind":2,"TableID":106}
+ │              ├── AddColumnToIndex {"ColumnID":3,"IndexID":2,"Kind":2,"Ordinal":1,"TableID":106}
  │              ├── MakeAbsentTempIndexDeleteOnly {"Index":{"ConstraintID":3,"IndexID":3,"IsUnique":true,"SourceIndexID":1,"TableID":106}}
  │              ├── MaybeAddSplitForIndex {"IndexID":3,"TableID":106}
  │              ├── AddColumnToIndex {"ColumnID":1,"IndexID":3,"TableID":106}
  │              ├── AddColumnToIndex {"ColumnID":2,"IndexID":3,"Kind":2,"TableID":106}
+ │              ├── AddColumnToIndex {"ColumnID":3,"IndexID":3,"Kind":2,"Ordinal":1,"TableID":106}
  │              ├── SetJobStateOnDescriptor {"DescriptorID":106,"Initialize":true}
  │              └── CreateSchemaChangerJob {"RunningStatus":"PostCommitPhase ..."}
  ├── PostCommitPhase
  │    ├── Stage 1 of 7 in PostCommitPhase
  │    │    ├── 2 elements transitioning toward PUBLIC
- │    │    │    ├── DELETE_ONLY → WRITE_ONLY Column:{DescID: 106, ColumnID: 2}
- │    │    │    └── ABSENT      → WRITE_ONLY ColumnNotNull:{DescID: 106, ColumnID: 2, IndexID: 2}
+ │    │    │    ├── DELETE_ONLY → WRITE_ONLY Column:{DescID: 106, ColumnID: 3}
+ │    │    │    └── ABSENT      → WRITE_ONLY ColumnNotNull:{DescID: 106, ColumnID: 3, IndexID: 2}
  │    │    ├── 2 elements transitioning toward TRANSIENT_ABSENT
  │    │    │    ├── DELETE_ONLY → WRITE_ONLY TemporaryIndex:{DescID: 106, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
  │    │    │    └── ABSENT      → PUBLIC     IndexData:{DescID: 106, IndexID: 3}
  │    │    └── 5 Mutation operations
- │    │         ├── MakeDeleteOnlyColumnWriteOnly {"ColumnID":2,"TableID":106}
+ │    │         ├── MakeDeleteOnlyColumnWriteOnly {"ColumnID":3,"TableID":106}
  │    │         ├── MakeDeleteOnlyIndexWriteOnly {"IndexID":3,"TableID":106}
- │    │         ├── MakeAbsentColumnNotNullWriteOnly {"ColumnID":2,"TableID":106}
+ │    │         ├── MakeAbsentColumnNotNullWriteOnly {"ColumnID":3,"TableID":106}
  │    │         ├── SetJobStateOnDescriptor {"DescriptorID":106}
  │    │         └── UpdateSchemaChangerJob {"RunningStatus":"PostCommitPhase ..."}
  │    ├── Stage 2 of 7 in PostCommitPhase
@@ -127,47 +137,51 @@ Schema change plan for ALTER TABLE ‹db›.‹public›.‹tbl› ADD COLUMN �
  │    └── Stage 7 of 7 in PostCommitPhase
  │         ├── 2 elements transitioning toward PUBLIC
  │         │    ├── WRITE_ONLY → VALIDATED PrimaryIndex:{DescID: 106, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
- │         │    └── WRITE_ONLY → VALIDATED ColumnNotNull:{DescID: 106, ColumnID: 2, IndexID: 2}
+ │         │    └── WRITE_ONLY → VALIDATED ColumnNotNull:{DescID: 106, ColumnID: 3, IndexID: 2}
  │         └── 2 Validation operations
  │              ├── ValidateIndex {"IndexID":2,"TableID":106}
- │              └── ValidateColumnNotNull {"ColumnID":2,"IndexIDForValidation":2,"TableID":106}
+ │              └── ValidateColumnNotNull {"ColumnID":3,"IndexIDForValidation":2,"TableID":106}
  └── PostCommitNonRevertiblePhase
       ├── Stage 1 of 3 in PostCommitNonRevertiblePhase
       │    ├── 4 elements transitioning toward PUBLIC
-      │    │    ├── WRITE_ONLY → PUBLIC                Column:{DescID: 106, ColumnID: 2}
+      │    │    ├── WRITE_ONLY → PUBLIC                Column:{DescID: 106, ColumnID: 3}
       │    │    ├── VALIDATED  → PUBLIC                PrimaryIndex:{DescID: 106, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
       │    │    ├── ABSENT     → PUBLIC                IndexName:{DescID: 106, Name: tbl_pkey, IndexID: 2}
-      │    │    └── VALIDATED  → PUBLIC                ColumnNotNull:{DescID: 106, ColumnID: 2, IndexID: 2}
-      │    ├── 3 elements transitioning toward TRANSIENT_ABSENT
+      │    │    └── VALIDATED  → PUBLIC                ColumnNotNull:{DescID: 106, ColumnID: 3, IndexID: 2}
+      │    ├── 4 elements transitioning toward TRANSIENT_ABSENT
       │    │    ├── WRITE_ONLY → TRANSIENT_DELETE_ONLY TemporaryIndex:{DescID: 106, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
       │    │    ├── PUBLIC     → TRANSIENT_ABSENT      IndexColumn:{DescID: 106, ColumnID: 1, IndexID: 3}
-      │    │    └── PUBLIC     → TRANSIENT_ABSENT      IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 3}
+      │    │    ├── PUBLIC     → TRANSIENT_ABSENT      IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 3}
+      │    │    └── PUBLIC     → TRANSIENT_ABSENT      IndexColumn:{DescID: 106, ColumnID: 3, IndexID: 3}
       │    ├── 2 elements transitioning toward ABSENT
       │    │    ├── PUBLIC     → VALIDATED             PrimaryIndex:{DescID: 106, IndexID: 1, ConstraintID: 1}
       │    │    └── PUBLIC     → ABSENT                IndexName:{DescID: 106, Name: tbl_pkey, IndexID: 1}
-      │    └── 12 Mutation operations
+      │    └── 13 Mutation operations
       │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":1,"TableID":106}
       │         ├── SetIndexName {"IndexID":1,"Name":"crdb_internal_in...","TableID":106}
       │         ├── SetIndexName {"IndexID":2,"Name":"tbl_pkey","TableID":106}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":3,"TableID":106}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":3,"TableID":106}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":3,"Kind":2,"TableID":106}
-      │         ├── MakeValidatedColumnNotNullPublic {"ColumnID":2,"TableID":106}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":3,"Kind":2,"Ordinal":1,"TableID":106}
+      │         ├── MakeValidatedColumnNotNullPublic {"ColumnID":3,"TableID":106}
       │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":2,"TableID":106}
-      │         ├── MakeWriteOnlyColumnPublic {"ColumnID":2,"TableID":106}
+      │         ├── MakeWriteOnlyColumnPublic {"ColumnID":3,"TableID":106}
       │         ├── RefreshStats {"TableID":106}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":106}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
       ├── Stage 2 of 3 in PostCommitNonRevertiblePhase
       │    ├── 1 element transitioning toward TRANSIENT_ABSENT
       │    │    └── TRANSIENT_DELETE_ONLY → TRANSIENT_ABSENT TemporaryIndex:{DescID: 106, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
-      │    ├── 2 elements transitioning toward ABSENT
+      │    ├── 3 elements transitioning toward ABSENT
       │    │    ├── PUBLIC                → ABSENT           IndexColumn:{DescID: 106, ColumnID: 1, IndexID: 1}
+      │    │    ├── PUBLIC                → ABSENT           IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 1}
       │    │    └── VALIDATED             → DELETE_ONLY      PrimaryIndex:{DescID: 106, IndexID: 1, ConstraintID: 1}
-      │    └── 5 Mutation operations
+      │    └── 6 Mutation operations
       │         ├── MakeIndexAbsent {"IndexID":3,"TableID":106}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":1,"TableID":106}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":1,"TableID":106}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":1,"Kind":2,"TableID":106}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":106}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
       └── Stage 3 of 3 in PostCommitNonRevertiblePhase

--- a/pkg/sql/schemachanger/testdata/explain/add_column.rollback_1_of_7
+++ b/pkg/sql/schemachanger/testdata/explain/add_column.rollback_1_of_7
@@ -1,6 +1,6 @@
 /* setup */
 CREATE DATABASE db;
-CREATE TABLE db.public.tbl (i INT PRIMARY KEY);
+CREATE TABLE db.public.tbl (i INT PRIMARY KEY, k INT);
 CREATE SEQUENCE db.public.sq1;
 
 /* test */
@@ -10,28 +10,32 @@ EXPLAIN (ddl) rollback at post-commit stage 1 of 7;
 Schema change plan for rolling back ALTER TABLE ‹db›.public.‹tbl› ADD COLUMN ‹j› INT8 NOT NULL DEFAULT ‹42›;
  └── PostCommitNonRevertiblePhase
       └── Stage 1 of 1 in PostCommitNonRevertiblePhase
-           ├── 11 elements transitioning toward ABSENT
-           │    ├── DELETE_ONLY   → ABSENT Column:{DescID: 106, ColumnID: 2}
-           │    ├── PUBLIC        → ABSENT ColumnName:{DescID: 106, Name: j, ColumnID: 2}
-           │    ├── PUBLIC        → ABSENT ColumnType:{DescID: 106, ColumnFamilyID: 0, ColumnID: 2}
-           │    ├── PUBLIC        → ABSENT ColumnDefaultExpression:{DescID: 106, ColumnID: 2}
+           ├── 13 elements transitioning toward ABSENT
+           │    ├── DELETE_ONLY   → ABSENT Column:{DescID: 106, ColumnID: 3}
+           │    ├── PUBLIC        → ABSENT ColumnName:{DescID: 106, Name: j, ColumnID: 3}
+           │    ├── PUBLIC        → ABSENT ColumnType:{DescID: 106, ColumnFamilyID: 0, ColumnID: 3}
+           │    ├── PUBLIC        → ABSENT ColumnDefaultExpression:{DescID: 106, ColumnID: 3}
            │    ├── BACKFILL_ONLY → ABSENT PrimaryIndex:{DescID: 106, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
            │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 106, ColumnID: 1, IndexID: 2}
            │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 2}
+           │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 106, ColumnID: 3, IndexID: 2}
            │    ├── PUBLIC        → ABSENT IndexData:{DescID: 106, IndexID: 2}
            │    ├── DELETE_ONLY   → ABSENT TemporaryIndex:{DescID: 106, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
            │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 106, ColumnID: 1, IndexID: 3}
-           │    └── PUBLIC        → ABSENT IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 3}
-           └── 12 Mutation operations
-                ├── SetColumnName {"ColumnID":2,"Name":"crdb_internal_co...","TableID":106}
+           │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 3}
+           │    └── PUBLIC        → ABSENT IndexColumn:{DescID: 106, ColumnID: 3, IndexID: 3}
+           └── 14 Mutation operations
+                ├── SetColumnName {"ColumnID":3,"Name":"crdb_internal_co...","TableID":106}
                 ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":2,"TableID":106}
                 ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":2,"Kind":2,"TableID":106}
+                ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":2,"Kind":2,"Ordinal":1,"TableID":106}
                 ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":3,"TableID":106}
                 ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":3,"Kind":2,"TableID":106}
-                ├── RemoveColumnDefaultExpression {"ColumnID":2,"TableID":106}
+                ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":3,"Kind":2,"Ordinal":1,"TableID":106}
+                ├── RemoveColumnDefaultExpression {"ColumnID":3,"TableID":106}
                 ├── MakeIndexAbsent {"IndexID":2,"TableID":106}
                 ├── CreateGCJobForIndex {"IndexID":2,"TableID":106}
                 ├── MakeIndexAbsent {"IndexID":3,"TableID":106}
-                ├── MakeDeleteOnlyColumnAbsent {"ColumnID":2,"TableID":106}
+                ├── MakeDeleteOnlyColumnAbsent {"ColumnID":3,"TableID":106}
                 ├── RemoveJobStateFromDescriptor {"DescriptorID":106}
                 └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"all stages compl..."}

--- a/pkg/sql/schemachanger/testdata/explain/add_column.rollback_2_of_7
+++ b/pkg/sql/schemachanger/testdata/explain/add_column.rollback_2_of_7
@@ -1,6 +1,6 @@
 /* setup */
 CREATE DATABASE db;
-CREATE TABLE db.public.tbl (i INT PRIMARY KEY);
+CREATE TABLE db.public.tbl (i INT PRIMARY KEY, k INT);
 CREATE SEQUENCE db.public.sq1;
 
 /* test */
@@ -10,41 +10,45 @@ EXPLAIN (ddl) rollback at post-commit stage 2 of 7;
 Schema change plan for rolling back ALTER TABLE ‹db›.public.‹tbl› ADD COLUMN ‹j› INT8 NOT NULL DEFAULT ‹42›;
  └── PostCommitNonRevertiblePhase
       ├── Stage 1 of 2 in PostCommitNonRevertiblePhase
-      │    ├── 9 elements transitioning toward ABSENT
-      │    │    ├── WRITE_ONLY    → DELETE_ONLY Column:{DescID: 106, ColumnID: 2}
-      │    │    ├── PUBLIC        → ABSENT      ColumnName:{DescID: 106, Name: j, ColumnID: 2}
+      │    ├── 11 elements transitioning toward ABSENT
+      │    │    ├── WRITE_ONLY    → DELETE_ONLY Column:{DescID: 106, ColumnID: 3}
+      │    │    ├── PUBLIC        → ABSENT      ColumnName:{DescID: 106, Name: j, ColumnID: 3}
       │    │    ├── BACKFILL_ONLY → ABSENT      PrimaryIndex:{DescID: 106, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
       │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 106, ColumnID: 1, IndexID: 2}
       │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 2}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 106, ColumnID: 3, IndexID: 2}
       │    │    ├── WRITE_ONLY    → DELETE_ONLY TemporaryIndex:{DescID: 106, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
       │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 106, ColumnID: 1, IndexID: 3}
       │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 3}
-      │    │    └── WRITE_ONLY    → ABSENT      ColumnNotNull:{DescID: 106, ColumnID: 2, IndexID: 2}
-      │    └── 11 Mutation operations
-      │         ├── SetColumnName {"ColumnID":2,"Name":"crdb_internal_co...","TableID":106}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 106, ColumnID: 3, IndexID: 3}
+      │    │    └── WRITE_ONLY    → ABSENT      ColumnNotNull:{DescID: 106, ColumnID: 3, IndexID: 2}
+      │    └── 13 Mutation operations
+      │         ├── SetColumnName {"ColumnID":3,"Name":"crdb_internal_co...","TableID":106}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":2,"TableID":106}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":2,"Kind":2,"TableID":106}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":2,"Kind":2,"Ordinal":1,"TableID":106}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":3,"TableID":106}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":3,"TableID":106}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":3,"Kind":2,"TableID":106}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":3,"Kind":2,"Ordinal":1,"TableID":106}
       │         ├── MakeIndexAbsent {"IndexID":2,"TableID":106}
-      │         ├── RemoveColumnNotNull {"ColumnID":2,"TableID":106}
-      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":2,"TableID":106}
+      │         ├── RemoveColumnNotNull {"ColumnID":3,"TableID":106}
+      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":3,"TableID":106}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":106}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
       └── Stage 2 of 2 in PostCommitNonRevertiblePhase
            ├── 6 elements transitioning toward ABSENT
-           │    ├── DELETE_ONLY → ABSENT Column:{DescID: 106, ColumnID: 2}
-           │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 106, ColumnFamilyID: 0, ColumnID: 2}
-           │    ├── PUBLIC      → ABSENT ColumnDefaultExpression:{DescID: 106, ColumnID: 2}
+           │    ├── DELETE_ONLY → ABSENT Column:{DescID: 106, ColumnID: 3}
+           │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 106, ColumnFamilyID: 0, ColumnID: 3}
+           │    ├── PUBLIC      → ABSENT ColumnDefaultExpression:{DescID: 106, ColumnID: 3}
            │    ├── PUBLIC      → ABSENT IndexData:{DescID: 106, IndexID: 2}
            │    ├── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 106, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
            │    └── PUBLIC      → ABSENT IndexData:{DescID: 106, IndexID: 3}
            └── 7 Mutation operations
-                ├── RemoveColumnDefaultExpression {"ColumnID":2,"TableID":106}
+                ├── RemoveColumnDefaultExpression {"ColumnID":3,"TableID":106}
                 ├── CreateGCJobForIndex {"IndexID":2,"TableID":106}
                 ├── MakeIndexAbsent {"IndexID":3,"TableID":106}
                 ├── CreateGCJobForIndex {"IndexID":3,"TableID":106}
-                ├── MakeDeleteOnlyColumnAbsent {"ColumnID":2,"TableID":106}
+                ├── MakeDeleteOnlyColumnAbsent {"ColumnID":3,"TableID":106}
                 ├── RemoveJobStateFromDescriptor {"DescriptorID":106}
                 └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"all stages compl..."}

--- a/pkg/sql/schemachanger/testdata/explain/add_column.rollback_3_of_7
+++ b/pkg/sql/schemachanger/testdata/explain/add_column.rollback_3_of_7
@@ -1,6 +1,6 @@
 /* setup */
 CREATE DATABASE db;
-CREATE TABLE db.public.tbl (i INT PRIMARY KEY);
+CREATE TABLE db.public.tbl (i INT PRIMARY KEY, k INT);
 CREATE SEQUENCE db.public.sq1;
 
 /* test */
@@ -10,41 +10,45 @@ EXPLAIN (ddl) rollback at post-commit stage 3 of 7;
 Schema change plan for rolling back ALTER TABLE ‹db›.public.‹tbl› ADD COLUMN ‹j› INT8 NOT NULL DEFAULT ‹42›;
  └── PostCommitNonRevertiblePhase
       ├── Stage 1 of 2 in PostCommitNonRevertiblePhase
-      │    ├── 9 elements transitioning toward ABSENT
-      │    │    ├── WRITE_ONLY    → DELETE_ONLY Column:{DescID: 106, ColumnID: 2}
-      │    │    ├── PUBLIC        → ABSENT      ColumnName:{DescID: 106, Name: j, ColumnID: 2}
+      │    ├── 11 elements transitioning toward ABSENT
+      │    │    ├── WRITE_ONLY    → DELETE_ONLY Column:{DescID: 106, ColumnID: 3}
+      │    │    ├── PUBLIC        → ABSENT      ColumnName:{DescID: 106, Name: j, ColumnID: 3}
       │    │    ├── BACKFILL_ONLY → ABSENT      PrimaryIndex:{DescID: 106, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
       │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 106, ColumnID: 1, IndexID: 2}
       │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 2}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 106, ColumnID: 3, IndexID: 2}
       │    │    ├── WRITE_ONLY    → DELETE_ONLY TemporaryIndex:{DescID: 106, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
       │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 106, ColumnID: 1, IndexID: 3}
       │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 3}
-      │    │    └── WRITE_ONLY    → ABSENT      ColumnNotNull:{DescID: 106, ColumnID: 2, IndexID: 2}
-      │    └── 11 Mutation operations
-      │         ├── SetColumnName {"ColumnID":2,"Name":"crdb_internal_co...","TableID":106}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 106, ColumnID: 3, IndexID: 3}
+      │    │    └── WRITE_ONLY    → ABSENT      ColumnNotNull:{DescID: 106, ColumnID: 3, IndexID: 2}
+      │    └── 13 Mutation operations
+      │         ├── SetColumnName {"ColumnID":3,"Name":"crdb_internal_co...","TableID":106}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":2,"TableID":106}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":2,"Kind":2,"TableID":106}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":2,"Kind":2,"Ordinal":1,"TableID":106}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":3,"TableID":106}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":3,"TableID":106}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":3,"Kind":2,"TableID":106}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":3,"Kind":2,"Ordinal":1,"TableID":106}
       │         ├── MakeIndexAbsent {"IndexID":2,"TableID":106}
-      │         ├── RemoveColumnNotNull {"ColumnID":2,"TableID":106}
-      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":2,"TableID":106}
+      │         ├── RemoveColumnNotNull {"ColumnID":3,"TableID":106}
+      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":3,"TableID":106}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":106}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
       └── Stage 2 of 2 in PostCommitNonRevertiblePhase
            ├── 6 elements transitioning toward ABSENT
-           │    ├── DELETE_ONLY → ABSENT Column:{DescID: 106, ColumnID: 2}
-           │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 106, ColumnFamilyID: 0, ColumnID: 2}
-           │    ├── PUBLIC      → ABSENT ColumnDefaultExpression:{DescID: 106, ColumnID: 2}
+           │    ├── DELETE_ONLY → ABSENT Column:{DescID: 106, ColumnID: 3}
+           │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 106, ColumnFamilyID: 0, ColumnID: 3}
+           │    ├── PUBLIC      → ABSENT ColumnDefaultExpression:{DescID: 106, ColumnID: 3}
            │    ├── PUBLIC      → ABSENT IndexData:{DescID: 106, IndexID: 2}
            │    ├── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 106, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
            │    └── PUBLIC      → ABSENT IndexData:{DescID: 106, IndexID: 3}
            └── 7 Mutation operations
-                ├── RemoveColumnDefaultExpression {"ColumnID":2,"TableID":106}
+                ├── RemoveColumnDefaultExpression {"ColumnID":3,"TableID":106}
                 ├── CreateGCJobForIndex {"IndexID":2,"TableID":106}
                 ├── MakeIndexAbsent {"IndexID":3,"TableID":106}
                 ├── CreateGCJobForIndex {"IndexID":3,"TableID":106}
-                ├── MakeDeleteOnlyColumnAbsent {"ColumnID":2,"TableID":106}
+                ├── MakeDeleteOnlyColumnAbsent {"ColumnID":3,"TableID":106}
                 ├── RemoveJobStateFromDescriptor {"DescriptorID":106}
                 └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"all stages compl..."}

--- a/pkg/sql/schemachanger/testdata/explain/add_column.rollback_4_of_7
+++ b/pkg/sql/schemachanger/testdata/explain/add_column.rollback_4_of_7
@@ -1,6 +1,6 @@
 /* setup */
 CREATE DATABASE db;
-CREATE TABLE db.public.tbl (i INT PRIMARY KEY);
+CREATE TABLE db.public.tbl (i INT PRIMARY KEY, k INT);
 CREATE SEQUENCE db.public.sq1;
 
 /* test */
@@ -10,41 +10,45 @@ EXPLAIN (ddl) rollback at post-commit stage 4 of 7;
 Schema change plan for rolling back ALTER TABLE ‹db›.public.‹tbl› ADD COLUMN ‹j› INT8 NOT NULL DEFAULT ‹42›;
  └── PostCommitNonRevertiblePhase
       ├── Stage 1 of 2 in PostCommitNonRevertiblePhase
-      │    ├── 9 elements transitioning toward ABSENT
-      │    │    ├── WRITE_ONLY  → DELETE_ONLY Column:{DescID: 106, ColumnID: 2}
-      │    │    ├── PUBLIC      → ABSENT      ColumnName:{DescID: 106, Name: j, ColumnID: 2}
+      │    ├── 11 elements transitioning toward ABSENT
+      │    │    ├── WRITE_ONLY  → DELETE_ONLY Column:{DescID: 106, ColumnID: 3}
+      │    │    ├── PUBLIC      → ABSENT      ColumnName:{DescID: 106, Name: j, ColumnID: 3}
       │    │    ├── DELETE_ONLY → ABSENT      PrimaryIndex:{DescID: 106, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
       │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 106, ColumnID: 1, IndexID: 2}
       │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 2}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 106, ColumnID: 3, IndexID: 2}
       │    │    ├── WRITE_ONLY  → DELETE_ONLY TemporaryIndex:{DescID: 106, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
       │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 106, ColumnID: 1, IndexID: 3}
       │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 3}
-      │    │    └── WRITE_ONLY  → ABSENT      ColumnNotNull:{DescID: 106, ColumnID: 2, IndexID: 2}
-      │    └── 11 Mutation operations
-      │         ├── SetColumnName {"ColumnID":2,"Name":"crdb_internal_co...","TableID":106}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 106, ColumnID: 3, IndexID: 3}
+      │    │    └── WRITE_ONLY  → ABSENT      ColumnNotNull:{DescID: 106, ColumnID: 3, IndexID: 2}
+      │    └── 13 Mutation operations
+      │         ├── SetColumnName {"ColumnID":3,"Name":"crdb_internal_co...","TableID":106}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":2,"TableID":106}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":2,"Kind":2,"TableID":106}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":2,"Kind":2,"Ordinal":1,"TableID":106}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":3,"TableID":106}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":3,"TableID":106}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":3,"Kind":2,"TableID":106}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":3,"Kind":2,"Ordinal":1,"TableID":106}
       │         ├── MakeIndexAbsent {"IndexID":2,"TableID":106}
-      │         ├── RemoveColumnNotNull {"ColumnID":2,"TableID":106}
-      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":2,"TableID":106}
+      │         ├── RemoveColumnNotNull {"ColumnID":3,"TableID":106}
+      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":3,"TableID":106}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":106}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
       └── Stage 2 of 2 in PostCommitNonRevertiblePhase
            ├── 6 elements transitioning toward ABSENT
-           │    ├── DELETE_ONLY → ABSENT Column:{DescID: 106, ColumnID: 2}
-           │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 106, ColumnFamilyID: 0, ColumnID: 2}
-           │    ├── PUBLIC      → ABSENT ColumnDefaultExpression:{DescID: 106, ColumnID: 2}
+           │    ├── DELETE_ONLY → ABSENT Column:{DescID: 106, ColumnID: 3}
+           │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 106, ColumnFamilyID: 0, ColumnID: 3}
+           │    ├── PUBLIC      → ABSENT ColumnDefaultExpression:{DescID: 106, ColumnID: 3}
            │    ├── PUBLIC      → ABSENT IndexData:{DescID: 106, IndexID: 2}
            │    ├── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 106, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
            │    └── PUBLIC      → ABSENT IndexData:{DescID: 106, IndexID: 3}
            └── 7 Mutation operations
-                ├── RemoveColumnDefaultExpression {"ColumnID":2,"TableID":106}
+                ├── RemoveColumnDefaultExpression {"ColumnID":3,"TableID":106}
                 ├── CreateGCJobForIndex {"IndexID":2,"TableID":106}
                 ├── MakeIndexAbsent {"IndexID":3,"TableID":106}
                 ├── CreateGCJobForIndex {"IndexID":3,"TableID":106}
-                ├── MakeDeleteOnlyColumnAbsent {"ColumnID":2,"TableID":106}
+                ├── MakeDeleteOnlyColumnAbsent {"ColumnID":3,"TableID":106}
                 ├── RemoveJobStateFromDescriptor {"DescriptorID":106}
                 └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"all stages compl..."}

--- a/pkg/sql/schemachanger/testdata/explain/add_column.rollback_5_of_7
+++ b/pkg/sql/schemachanger/testdata/explain/add_column.rollback_5_of_7
@@ -1,6 +1,6 @@
 /* setup */
 CREATE DATABASE db;
-CREATE TABLE db.public.tbl (i INT PRIMARY KEY);
+CREATE TABLE db.public.tbl (i INT PRIMARY KEY, k INT);
 CREATE SEQUENCE db.public.sq1;
 
 /* test */
@@ -10,43 +10,47 @@ EXPLAIN (ddl) rollback at post-commit stage 5 of 7;
 Schema change plan for rolling back ALTER TABLE ‹db›.public.‹tbl› ADD COLUMN ‹j› INT8 NOT NULL DEFAULT ‹42›;
  └── PostCommitNonRevertiblePhase
       ├── Stage 1 of 2 in PostCommitNonRevertiblePhase
-      │    ├── 9 elements transitioning toward ABSENT
-      │    │    ├── WRITE_ONLY → DELETE_ONLY Column:{DescID: 106, ColumnID: 2}
-      │    │    ├── PUBLIC     → ABSENT      ColumnName:{DescID: 106, Name: j, ColumnID: 2}
+      │    ├── 11 elements transitioning toward ABSENT
+      │    │    ├── WRITE_ONLY → DELETE_ONLY Column:{DescID: 106, ColumnID: 3}
+      │    │    ├── PUBLIC     → ABSENT      ColumnName:{DescID: 106, Name: j, ColumnID: 3}
       │    │    ├── MERGE_ONLY → DELETE_ONLY PrimaryIndex:{DescID: 106, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
       │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 106, ColumnID: 1, IndexID: 2}
       │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 2}
+      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 106, ColumnID: 3, IndexID: 2}
       │    │    ├── WRITE_ONLY → DELETE_ONLY TemporaryIndex:{DescID: 106, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
       │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 106, ColumnID: 1, IndexID: 3}
       │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 3}
-      │    │    └── WRITE_ONLY → ABSENT      ColumnNotNull:{DescID: 106, ColumnID: 2, IndexID: 2}
-      │    └── 11 Mutation operations
-      │         ├── SetColumnName {"ColumnID":2,"Name":"crdb_internal_co...","TableID":106}
+      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 106, ColumnID: 3, IndexID: 3}
+      │    │    └── WRITE_ONLY → ABSENT      ColumnNotNull:{DescID: 106, ColumnID: 3, IndexID: 2}
+      │    └── 13 Mutation operations
+      │         ├── SetColumnName {"ColumnID":3,"Name":"crdb_internal_co...","TableID":106}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":3,"TableID":106}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":3,"TableID":106}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":3,"Kind":2,"TableID":106}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":3,"Kind":2,"Ordinal":1,"TableID":106}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":2,"TableID":106}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":2,"TableID":106}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":2,"Kind":2,"TableID":106}
-      │         ├── RemoveColumnNotNull {"ColumnID":2,"TableID":106}
-      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":2,"TableID":106}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":2,"Kind":2,"Ordinal":1,"TableID":106}
+      │         ├── RemoveColumnNotNull {"ColumnID":3,"TableID":106}
+      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":3,"TableID":106}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":106}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
       └── Stage 2 of 2 in PostCommitNonRevertiblePhase
            ├── 7 elements transitioning toward ABSENT
-           │    ├── DELETE_ONLY → ABSENT Column:{DescID: 106, ColumnID: 2}
-           │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 106, ColumnFamilyID: 0, ColumnID: 2}
-           │    ├── PUBLIC      → ABSENT ColumnDefaultExpression:{DescID: 106, ColumnID: 2}
+           │    ├── DELETE_ONLY → ABSENT Column:{DescID: 106, ColumnID: 3}
+           │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 106, ColumnFamilyID: 0, ColumnID: 3}
+           │    ├── PUBLIC      → ABSENT ColumnDefaultExpression:{DescID: 106, ColumnID: 3}
            │    ├── DELETE_ONLY → ABSENT PrimaryIndex:{DescID: 106, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
            │    ├── PUBLIC      → ABSENT IndexData:{DescID: 106, IndexID: 2}
            │    ├── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 106, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
            │    └── PUBLIC      → ABSENT IndexData:{DescID: 106, IndexID: 3}
            └── 8 Mutation operations
-                ├── RemoveColumnDefaultExpression {"ColumnID":2,"TableID":106}
+                ├── RemoveColumnDefaultExpression {"ColumnID":3,"TableID":106}
                 ├── MakeIndexAbsent {"IndexID":2,"TableID":106}
                 ├── CreateGCJobForIndex {"IndexID":2,"TableID":106}
                 ├── MakeIndexAbsent {"IndexID":3,"TableID":106}
                 ├── CreateGCJobForIndex {"IndexID":3,"TableID":106}
-                ├── MakeDeleteOnlyColumnAbsent {"ColumnID":2,"TableID":106}
+                ├── MakeDeleteOnlyColumnAbsent {"ColumnID":3,"TableID":106}
                 ├── RemoveJobStateFromDescriptor {"DescriptorID":106}
                 └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"all stages compl..."}

--- a/pkg/sql/schemachanger/testdata/explain/add_column.rollback_6_of_7
+++ b/pkg/sql/schemachanger/testdata/explain/add_column.rollback_6_of_7
@@ -1,6 +1,6 @@
 /* setup */
 CREATE DATABASE db;
-CREATE TABLE db.public.tbl (i INT PRIMARY KEY);
+CREATE TABLE db.public.tbl (i INT PRIMARY KEY, k INT);
 CREATE SEQUENCE db.public.sq1;
 
 /* test */
@@ -10,43 +10,47 @@ EXPLAIN (ddl) rollback at post-commit stage 6 of 7;
 Schema change plan for rolling back ALTER TABLE ‹db›.public.‹tbl› ADD COLUMN ‹j› INT8 NOT NULL DEFAULT ‹42›;
  └── PostCommitNonRevertiblePhase
       ├── Stage 1 of 2 in PostCommitNonRevertiblePhase
-      │    ├── 9 elements transitioning toward ABSENT
-      │    │    ├── WRITE_ONLY → DELETE_ONLY Column:{DescID: 106, ColumnID: 2}
-      │    │    ├── PUBLIC     → ABSENT      ColumnName:{DescID: 106, Name: j, ColumnID: 2}
+      │    ├── 11 elements transitioning toward ABSENT
+      │    │    ├── WRITE_ONLY → DELETE_ONLY Column:{DescID: 106, ColumnID: 3}
+      │    │    ├── PUBLIC     → ABSENT      ColumnName:{DescID: 106, Name: j, ColumnID: 3}
       │    │    ├── MERGE_ONLY → DELETE_ONLY PrimaryIndex:{DescID: 106, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
       │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 106, ColumnID: 1, IndexID: 2}
       │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 2}
+      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 106, ColumnID: 3, IndexID: 2}
       │    │    ├── WRITE_ONLY → DELETE_ONLY TemporaryIndex:{DescID: 106, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
       │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 106, ColumnID: 1, IndexID: 3}
       │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 3}
-      │    │    └── WRITE_ONLY → ABSENT      ColumnNotNull:{DescID: 106, ColumnID: 2, IndexID: 2}
-      │    └── 11 Mutation operations
-      │         ├── SetColumnName {"ColumnID":2,"Name":"crdb_internal_co...","TableID":106}
+      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 106, ColumnID: 3, IndexID: 3}
+      │    │    └── WRITE_ONLY → ABSENT      ColumnNotNull:{DescID: 106, ColumnID: 3, IndexID: 2}
+      │    └── 13 Mutation operations
+      │         ├── SetColumnName {"ColumnID":3,"Name":"crdb_internal_co...","TableID":106}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":3,"TableID":106}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":3,"TableID":106}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":3,"Kind":2,"TableID":106}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":3,"Kind":2,"Ordinal":1,"TableID":106}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":2,"TableID":106}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":2,"TableID":106}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":2,"Kind":2,"TableID":106}
-      │         ├── RemoveColumnNotNull {"ColumnID":2,"TableID":106}
-      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":2,"TableID":106}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":2,"Kind":2,"Ordinal":1,"TableID":106}
+      │         ├── RemoveColumnNotNull {"ColumnID":3,"TableID":106}
+      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":3,"TableID":106}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":106}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
       └── Stage 2 of 2 in PostCommitNonRevertiblePhase
            ├── 7 elements transitioning toward ABSENT
-           │    ├── DELETE_ONLY → ABSENT Column:{DescID: 106, ColumnID: 2}
-           │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 106, ColumnFamilyID: 0, ColumnID: 2}
-           │    ├── PUBLIC      → ABSENT ColumnDefaultExpression:{DescID: 106, ColumnID: 2}
+           │    ├── DELETE_ONLY → ABSENT Column:{DescID: 106, ColumnID: 3}
+           │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 106, ColumnFamilyID: 0, ColumnID: 3}
+           │    ├── PUBLIC      → ABSENT ColumnDefaultExpression:{DescID: 106, ColumnID: 3}
            │    ├── DELETE_ONLY → ABSENT PrimaryIndex:{DescID: 106, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
            │    ├── PUBLIC      → ABSENT IndexData:{DescID: 106, IndexID: 2}
            │    ├── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 106, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
            │    └── PUBLIC      → ABSENT IndexData:{DescID: 106, IndexID: 3}
            └── 8 Mutation operations
-                ├── RemoveColumnDefaultExpression {"ColumnID":2,"TableID":106}
+                ├── RemoveColumnDefaultExpression {"ColumnID":3,"TableID":106}
                 ├── MakeIndexAbsent {"IndexID":2,"TableID":106}
                 ├── CreateGCJobForIndex {"IndexID":2,"TableID":106}
                 ├── MakeIndexAbsent {"IndexID":3,"TableID":106}
                 ├── CreateGCJobForIndex {"IndexID":3,"TableID":106}
-                ├── MakeDeleteOnlyColumnAbsent {"ColumnID":2,"TableID":106}
+                ├── MakeDeleteOnlyColumnAbsent {"ColumnID":3,"TableID":106}
                 ├── RemoveJobStateFromDescriptor {"DescriptorID":106}
                 └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"all stages compl..."}

--- a/pkg/sql/schemachanger/testdata/explain/add_column.rollback_7_of_7
+++ b/pkg/sql/schemachanger/testdata/explain/add_column.rollback_7_of_7
@@ -1,6 +1,6 @@
 /* setup */
 CREATE DATABASE db;
-CREATE TABLE db.public.tbl (i INT PRIMARY KEY);
+CREATE TABLE db.public.tbl (i INT PRIMARY KEY, k INT);
 CREATE SEQUENCE db.public.sq1;
 
 /* test */
@@ -10,43 +10,47 @@ EXPLAIN (ddl) rollback at post-commit stage 7 of 7;
 Schema change plan for rolling back ALTER TABLE ‹db›.public.‹tbl› ADD COLUMN ‹j› INT8 NOT NULL DEFAULT ‹42›;
  └── PostCommitNonRevertiblePhase
       ├── Stage 1 of 2 in PostCommitNonRevertiblePhase
-      │    ├── 9 elements transitioning toward ABSENT
-      │    │    ├── WRITE_ONLY → DELETE_ONLY Column:{DescID: 106, ColumnID: 2}
-      │    │    ├── PUBLIC     → ABSENT      ColumnName:{DescID: 106, Name: j, ColumnID: 2}
+      │    ├── 11 elements transitioning toward ABSENT
+      │    │    ├── WRITE_ONLY → DELETE_ONLY Column:{DescID: 106, ColumnID: 3}
+      │    │    ├── PUBLIC     → ABSENT      ColumnName:{DescID: 106, Name: j, ColumnID: 3}
       │    │    ├── WRITE_ONLY → DELETE_ONLY PrimaryIndex:{DescID: 106, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
       │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 106, ColumnID: 1, IndexID: 2}
       │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 2}
+      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 106, ColumnID: 3, IndexID: 2}
       │    │    ├── WRITE_ONLY → DELETE_ONLY TemporaryIndex:{DescID: 106, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
       │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 106, ColumnID: 1, IndexID: 3}
       │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 3}
-      │    │    └── WRITE_ONLY → ABSENT      ColumnNotNull:{DescID: 106, ColumnID: 2, IndexID: 2}
-      │    └── 11 Mutation operations
-      │         ├── SetColumnName {"ColumnID":2,"Name":"crdb_internal_co...","TableID":106}
+      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 106, ColumnID: 3, IndexID: 3}
+      │    │    └── WRITE_ONLY → ABSENT      ColumnNotNull:{DescID: 106, ColumnID: 3, IndexID: 2}
+      │    └── 13 Mutation operations
+      │         ├── SetColumnName {"ColumnID":3,"Name":"crdb_internal_co...","TableID":106}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":2,"TableID":106}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":2,"TableID":106}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":2,"Kind":2,"TableID":106}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":2,"Kind":2,"Ordinal":1,"TableID":106}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":3,"TableID":106}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":3,"TableID":106}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":3,"Kind":2,"TableID":106}
-      │         ├── RemoveColumnNotNull {"ColumnID":2,"TableID":106}
-      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":2,"TableID":106}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":3,"Kind":2,"Ordinal":1,"TableID":106}
+      │         ├── RemoveColumnNotNull {"ColumnID":3,"TableID":106}
+      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":3,"TableID":106}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":106}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
       └── Stage 2 of 2 in PostCommitNonRevertiblePhase
            ├── 7 elements transitioning toward ABSENT
-           │    ├── DELETE_ONLY → ABSENT Column:{DescID: 106, ColumnID: 2}
-           │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 106, ColumnFamilyID: 0, ColumnID: 2}
-           │    ├── PUBLIC      → ABSENT ColumnDefaultExpression:{DescID: 106, ColumnID: 2}
+           │    ├── DELETE_ONLY → ABSENT Column:{DescID: 106, ColumnID: 3}
+           │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 106, ColumnFamilyID: 0, ColumnID: 3}
+           │    ├── PUBLIC      → ABSENT ColumnDefaultExpression:{DescID: 106, ColumnID: 3}
            │    ├── DELETE_ONLY → ABSENT PrimaryIndex:{DescID: 106, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
            │    ├── PUBLIC      → ABSENT IndexData:{DescID: 106, IndexID: 2}
            │    ├── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 106, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
            │    └── PUBLIC      → ABSENT IndexData:{DescID: 106, IndexID: 3}
            └── 8 Mutation operations
-                ├── RemoveColumnDefaultExpression {"ColumnID":2,"TableID":106}
+                ├── RemoveColumnDefaultExpression {"ColumnID":3,"TableID":106}
                 ├── MakeIndexAbsent {"IndexID":2,"TableID":106}
                 ├── CreateGCJobForIndex {"IndexID":2,"TableID":106}
                 ├── MakeIndexAbsent {"IndexID":3,"TableID":106}
                 ├── CreateGCJobForIndex {"IndexID":3,"TableID":106}
-                ├── MakeDeleteOnlyColumnAbsent {"ColumnID":2,"TableID":106}
+                ├── MakeDeleteOnlyColumnAbsent {"ColumnID":3,"TableID":106}
                 ├── RemoveJobStateFromDescriptor {"DescriptorID":106}
                 └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"all stages compl..."}

--- a/pkg/sql/schemachanger/testdata/explain/drop_column_basic
+++ b/pkg/sql/schemachanger/testdata/explain/drop_column_basic
@@ -1,5 +1,5 @@
 /* setup */
-CREATE TABLE t (i INT PRIMARY KEY, j INT);
+CREATE TABLE t (i INT PRIMARY KEY, j INT, k int);
 COMMENT ON TABLE t IS 't has a comment';
 COMMENT ON COLUMN t.j IS 'j has a comment';
 
@@ -9,34 +9,40 @@ EXPLAIN (ddl) ALTER TABLE t DROP COLUMN j;
 Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› DROP COLUMN ‹j›;
  ├── StatementPhase
  │    └── Stage 1 of 1 in StatementPhase
- │         ├── 3 elements transitioning toward PUBLIC
+ │         ├── 4 elements transitioning toward PUBLIC
  │         │    ├── ABSENT → BACKFILL_ONLY PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
  │         │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 2}
+ │         │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 2}
  │         │    └── ABSENT → PUBLIC        IndexData:{DescID: 104, IndexID: 2}
- │         ├── 2 elements transitioning toward TRANSIENT_ABSENT
+ │         ├── 3 elements transitioning toward TRANSIENT_ABSENT
  │         │    ├── ABSENT → DELETE_ONLY   TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
- │         │    └── ABSENT → PUBLIC        IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
+ │         │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
+ │         │    └── ABSENT → PUBLIC        IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 3}
  │         ├── 3 elements transitioning toward ABSENT
  │         │    ├── PUBLIC → WRITE_ONLY    Column:{DescID: 104, ColumnID: 2}
  │         │    ├── PUBLIC → ABSENT        ColumnName:{DescID: 104, Name: j, ColumnID: 2}
  │         │    └── PUBLIC → ABSENT        ColumnComment:{DescID: 104, ColumnID: 2, Comment: j has a comment}
- │         └── 7 Mutation operations
+ │         └── 9 Mutation operations
  │              ├── MakePublicColumnWriteOnly {"ColumnID":2,"TableID":104}
  │              ├── SetColumnName {"ColumnID":2,"Name":"crdb_internal_co...","TableID":104}
  │              ├── RemoveColumnComment {"ColumnID":2,"PgAttributeNum":2,"TableID":104}
  │              ├── MakeAbsentIndexBackfilling {"Index":{"ConstraintID":2,"IndexID":2,"IsUnique":true,"SourceIndexID":1,"TableID":104,"TemporaryIndexID":3}}
  │              ├── AddColumnToIndex {"ColumnID":1,"IndexID":2,"TableID":104}
+ │              ├── AddColumnToIndex {"ColumnID":3,"IndexID":2,"Kind":2,"TableID":104}
  │              ├── MakeAbsentTempIndexDeleteOnly {"Index":{"ConstraintID":3,"IndexID":3,"IsUnique":true,"SourceIndexID":1,"TableID":104}}
- │              └── AddColumnToIndex {"ColumnID":1,"IndexID":3,"TableID":104}
+ │              ├── AddColumnToIndex {"ColumnID":1,"IndexID":3,"TableID":104}
+ │              └── AddColumnToIndex {"ColumnID":3,"IndexID":3,"Kind":2,"TableID":104}
  ├── PreCommitPhase
  │    ├── Stage 1 of 2 in PreCommitPhase
- │    │    ├── 3 elements transitioning toward PUBLIC
+ │    │    ├── 4 elements transitioning toward PUBLIC
  │    │    │    ├── BACKFILL_ONLY → ABSENT PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
  │    │    │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 2}
+ │    │    │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 2}
  │    │    │    └── PUBLIC        → ABSENT IndexData:{DescID: 104, IndexID: 2}
- │    │    ├── 2 elements transitioning toward TRANSIENT_ABSENT
+ │    │    ├── 3 elements transitioning toward TRANSIENT_ABSENT
  │    │    │    ├── DELETE_ONLY   → ABSENT TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
- │    │    │    └── PUBLIC        → ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
+ │    │    │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
+ │    │    │    └── PUBLIC        → ABSENT IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 3}
  │    │    ├── 3 elements transitioning toward ABSENT
  │    │    │    ├── WRITE_ONLY    → PUBLIC Column:{DescID: 104, ColumnID: 2}
  │    │    │    ├── ABSENT        → PUBLIC ColumnName:{DescID: 104, Name: j, ColumnID: 2}
@@ -44,27 +50,31 @@ Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› DROP COL
  │    │    └── 1 Mutation operation
  │    │         └── UndoAllInTxnImmediateMutationOpSideEffects
  │    └── Stage 2 of 2 in PreCommitPhase
- │         ├── 3 elements transitioning toward PUBLIC
+ │         ├── 4 elements transitioning toward PUBLIC
  │         │    ├── ABSENT → BACKFILL_ONLY PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
  │         │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 2}
+ │         │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 2}
  │         │    └── ABSENT → PUBLIC        IndexData:{DescID: 104, IndexID: 2}
- │         ├── 2 elements transitioning toward TRANSIENT_ABSENT
+ │         ├── 3 elements transitioning toward TRANSIENT_ABSENT
  │         │    ├── ABSENT → DELETE_ONLY   TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
- │         │    └── ABSENT → PUBLIC        IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
+ │         │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
+ │         │    └── ABSENT → PUBLIC        IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 3}
  │         ├── 3 elements transitioning toward ABSENT
  │         │    ├── PUBLIC → WRITE_ONLY    Column:{DescID: 104, ColumnID: 2}
  │         │    ├── PUBLIC → ABSENT        ColumnName:{DescID: 104, Name: j, ColumnID: 2}
  │         │    └── PUBLIC → ABSENT        ColumnComment:{DescID: 104, ColumnID: 2, Comment: j has a comment}
- │         └── 11 Mutation operations
+ │         └── 13 Mutation operations
  │              ├── MakePublicColumnWriteOnly {"ColumnID":2,"TableID":104}
  │              ├── SetColumnName {"ColumnID":2,"Name":"crdb_internal_co...","TableID":104}
  │              ├── RemoveColumnComment {"ColumnID":2,"PgAttributeNum":2,"TableID":104}
  │              ├── MakeAbsentIndexBackfilling {"Index":{"ConstraintID":2,"IndexID":2,"IsUnique":true,"SourceIndexID":1,"TableID":104,"TemporaryIndexID":3}}
  │              ├── MaybeAddSplitForIndex {"IndexID":2,"TableID":104}
  │              ├── AddColumnToIndex {"ColumnID":1,"IndexID":2,"TableID":104}
+ │              ├── AddColumnToIndex {"ColumnID":3,"IndexID":2,"Kind":2,"TableID":104}
  │              ├── MakeAbsentTempIndexDeleteOnly {"Index":{"ConstraintID":3,"IndexID":3,"IsUnique":true,"SourceIndexID":1,"TableID":104}}
  │              ├── MaybeAddSplitForIndex {"IndexID":3,"TableID":104}
  │              ├── AddColumnToIndex {"ColumnID":1,"IndexID":3,"TableID":104}
+ │              ├── AddColumnToIndex {"ColumnID":3,"IndexID":3,"Kind":2,"TableID":104}
  │              ├── SetJobStateOnDescriptor {"DescriptorID":104,"Initialize":true}
  │              └── CreateSchemaChangerJob {"RunningStatus":"PostCommitPhase ..."}
  ├── PostCommitPhase
@@ -117,35 +127,39 @@ Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› DROP COL
       │    ├── 2 elements transitioning toward PUBLIC
       │    │    ├── VALIDATED  → PUBLIC                PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
       │    │    └── ABSENT     → PUBLIC                IndexName:{DescID: 104, Name: t_pkey, IndexID: 2}
-      │    ├── 2 elements transitioning toward TRANSIENT_ABSENT
+      │    ├── 3 elements transitioning toward TRANSIENT_ABSENT
       │    │    ├── WRITE_ONLY → TRANSIENT_DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
-      │    │    └── PUBLIC     → TRANSIENT_ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
+      │    │    ├── PUBLIC     → TRANSIENT_ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
+      │    │    └── PUBLIC     → TRANSIENT_ABSENT      IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 3}
       │    ├── 3 elements transitioning toward ABSENT
       │    │    ├── WRITE_ONLY → DELETE_ONLY           Column:{DescID: 104, ColumnID: 2}
       │    │    ├── PUBLIC     → VALIDATED             PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}
       │    │    └── PUBLIC     → ABSENT                IndexName:{DescID: 104, Name: t_pkey, IndexID: 1}
-      │    └── 9 Mutation operations
+      │    └── 10 Mutation operations
       │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":2,"TableID":104}
       │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":1,"TableID":104}
       │         ├── SetIndexName {"IndexID":1,"Name":"crdb_internal_in...","TableID":104}
       │         ├── SetIndexName {"IndexID":2,"Name":"t_pkey","TableID":104}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":3,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":3,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":3,"Kind":2,"TableID":104}
       │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":2,"TableID":104}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
       ├── Stage 2 of 3 in PostCommitNonRevertiblePhase
       │    ├── 1 element transitioning toward TRANSIENT_ABSENT
       │    │    └── TRANSIENT_DELETE_ONLY → TRANSIENT_ABSENT TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
-      │    ├── 3 elements transitioning toward ABSENT
+      │    ├── 4 elements transitioning toward ABSENT
       │    │    ├── PUBLIC                → ABSENT           IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 1}
       │    │    ├── PUBLIC                → ABSENT           IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 1}
+      │    │    ├── PUBLIC                → ABSENT           IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 1}
       │    │    └── VALIDATED             → DELETE_ONLY      PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}
-      │    └── 6 Mutation operations
+      │    └── 7 Mutation operations
       │         ├── MakeIndexAbsent {"IndexID":3,"TableID":104}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":1,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":1,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":1,"Kind":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":1,"Kind":2,"Ordinal":1,"TableID":104}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
       └── Stage 3 of 3 in PostCommitNonRevertiblePhase

--- a/pkg/sql/schemachanger/testdata/explain/drop_column_basic.rollback_1_of_7
+++ b/pkg/sql/schemachanger/testdata/explain/drop_column_basic.rollback_1_of_7
@@ -1,5 +1,5 @@
 /* setup */
-CREATE TABLE t (i INT PRIMARY KEY, j INT);
+CREATE TABLE t (i INT PRIMARY KEY, j INT, k int);
 COMMENT ON TABLE t IS 't has a comment';
 COMMENT ON COLUMN t.j IS 'j has a comment';
 
@@ -14,17 +14,21 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› D
            │    ├── WRITE_ONLY    → PUBLIC Column:{DescID: 104, ColumnID: 2}
            │    ├── ABSENT        → PUBLIC ColumnName:{DescID: 104, Name: j, ColumnID: 2}
            │    └── ABSENT        → PUBLIC ColumnComment:{DescID: 104, ColumnID: 2, Comment: j has a comment}
-           ├── 5 elements transitioning toward ABSENT
+           ├── 7 elements transitioning toward ABSENT
            │    ├── BACKFILL_ONLY → ABSENT PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
            │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 2}
+           │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 2}
            │    ├── PUBLIC        → ABSENT IndexData:{DescID: 104, IndexID: 2}
            │    ├── DELETE_ONLY   → ABSENT TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
-           │    └── PUBLIC        → ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
-           └── 11 Mutation operations
+           │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
+           │    └── PUBLIC        → ABSENT IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 3}
+           └── 13 Mutation operations
                 ├── SetColumnName {"ColumnID":2,"Name":"j","TableID":104}
                 ├── UpsertColumnComment {"ColumnID":2,"Comment":"j has a comment","PGAttributeNum":2,"TableID":104}
                 ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":2,"TableID":104}
+                ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":2,"Kind":2,"TableID":104}
                 ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":3,"TableID":104}
+                ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":3,"Kind":2,"TableID":104}
                 ├── MakeWriteOnlyColumnPublic {"ColumnID":2,"TableID":104}
                 ├── RefreshStats {"TableID":104}
                 ├── MakeIndexAbsent {"IndexID":2,"TableID":104}

--- a/pkg/sql/schemachanger/testdata/explain/drop_column_basic.rollback_2_of_7
+++ b/pkg/sql/schemachanger/testdata/explain/drop_column_basic.rollback_2_of_7
@@ -1,5 +1,5 @@
 /* setup */
-CREATE TABLE t (i INT PRIMARY KEY, j INT);
+CREATE TABLE t (i INT PRIMARY KEY, j INT, k int);
 COMMENT ON TABLE t IS 't has a comment';
 COMMENT ON COLUMN t.j IS 'j has a comment';
 
@@ -14,17 +14,21 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› D
       │    │    ├── WRITE_ONLY    → PUBLIC      Column:{DescID: 104, ColumnID: 2}
       │    │    ├── ABSENT        → PUBLIC      ColumnName:{DescID: 104, Name: j, ColumnID: 2}
       │    │    └── ABSENT        → PUBLIC      ColumnComment:{DescID: 104, ColumnID: 2, Comment: j has a comment}
-      │    ├── 4 elements transitioning toward ABSENT
+      │    ├── 6 elements transitioning toward ABSENT
       │    │    ├── BACKFILL_ONLY → ABSENT      PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
       │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 2}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 2}
       │    │    ├── WRITE_ONLY    → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
-      │    │    └── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
-      │    └── 10 Mutation operations
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
+      │    │    └── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 3}
+      │    └── 12 Mutation operations
       │         ├── SetColumnName {"ColumnID":2,"Name":"j","TableID":104}
       │         ├── UpsertColumnComment {"ColumnID":2,"Comment":"j has a comment","PGAttributeNum":2,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":2,"Kind":2,"TableID":104}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":3,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":3,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":3,"Kind":2,"TableID":104}
       │         ├── MakeWriteOnlyColumnPublic {"ColumnID":2,"TableID":104}
       │         ├── RefreshStats {"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":2,"TableID":104}

--- a/pkg/sql/schemachanger/testdata/explain/drop_column_basic.rollback_3_of_7
+++ b/pkg/sql/schemachanger/testdata/explain/drop_column_basic.rollback_3_of_7
@@ -1,5 +1,5 @@
 /* setup */
-CREATE TABLE t (i INT PRIMARY KEY, j INT);
+CREATE TABLE t (i INT PRIMARY KEY, j INT, k int);
 COMMENT ON TABLE t IS 't has a comment';
 COMMENT ON COLUMN t.j IS 'j has a comment';
 
@@ -14,17 +14,21 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› D
       │    │    ├── WRITE_ONLY    → PUBLIC      Column:{DescID: 104, ColumnID: 2}
       │    │    ├── ABSENT        → PUBLIC      ColumnName:{DescID: 104, Name: j, ColumnID: 2}
       │    │    └── ABSENT        → PUBLIC      ColumnComment:{DescID: 104, ColumnID: 2, Comment: j has a comment}
-      │    ├── 4 elements transitioning toward ABSENT
+      │    ├── 6 elements transitioning toward ABSENT
       │    │    ├── BACKFILL_ONLY → ABSENT      PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
       │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 2}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 2}
       │    │    ├── WRITE_ONLY    → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
-      │    │    └── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
-      │    └── 10 Mutation operations
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
+      │    │    └── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 3}
+      │    └── 12 Mutation operations
       │         ├── SetColumnName {"ColumnID":2,"Name":"j","TableID":104}
       │         ├── UpsertColumnComment {"ColumnID":2,"Comment":"j has a comment","PGAttributeNum":2,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":2,"Kind":2,"TableID":104}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":3,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":3,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":3,"Kind":2,"TableID":104}
       │         ├── MakeWriteOnlyColumnPublic {"ColumnID":2,"TableID":104}
       │         ├── RefreshStats {"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":2,"TableID":104}

--- a/pkg/sql/schemachanger/testdata/explain/drop_column_basic.rollback_4_of_7
+++ b/pkg/sql/schemachanger/testdata/explain/drop_column_basic.rollback_4_of_7
@@ -1,5 +1,5 @@
 /* setup */
-CREATE TABLE t (i INT PRIMARY KEY, j INT);
+CREATE TABLE t (i INT PRIMARY KEY, j INT, k int);
 COMMENT ON TABLE t IS 't has a comment';
 COMMENT ON COLUMN t.j IS 'j has a comment';
 
@@ -14,17 +14,21 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› D
       │    │    ├── WRITE_ONLY  → PUBLIC      Column:{DescID: 104, ColumnID: 2}
       │    │    ├── ABSENT      → PUBLIC      ColumnName:{DescID: 104, Name: j, ColumnID: 2}
       │    │    └── ABSENT      → PUBLIC      ColumnComment:{DescID: 104, ColumnID: 2, Comment: j has a comment}
-      │    ├── 4 elements transitioning toward ABSENT
+      │    ├── 6 elements transitioning toward ABSENT
       │    │    ├── DELETE_ONLY → ABSENT      PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
       │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 2}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 2}
       │    │    ├── WRITE_ONLY  → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
-      │    │    └── PUBLIC      → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
-      │    └── 10 Mutation operations
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
+      │    │    └── PUBLIC      → ABSENT      IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 3}
+      │    └── 12 Mutation operations
       │         ├── SetColumnName {"ColumnID":2,"Name":"j","TableID":104}
       │         ├── UpsertColumnComment {"ColumnID":2,"Comment":"j has a comment","PGAttributeNum":2,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":2,"Kind":2,"TableID":104}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":3,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":3,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":3,"Kind":2,"TableID":104}
       │         ├── MakeWriteOnlyColumnPublic {"ColumnID":2,"TableID":104}
       │         ├── RefreshStats {"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":2,"TableID":104}

--- a/pkg/sql/schemachanger/testdata/explain/drop_column_basic.rollback_5_of_7
+++ b/pkg/sql/schemachanger/testdata/explain/drop_column_basic.rollback_5_of_7
@@ -1,5 +1,5 @@
 /* setup */
-CREATE TABLE t (i INT PRIMARY KEY, j INT);
+CREATE TABLE t (i INT PRIMARY KEY, j INT, k int);
 COMMENT ON TABLE t IS 't has a comment';
 COMMENT ON COLUMN t.j IS 'j has a comment';
 
@@ -14,20 +14,24 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› D
       │    │    ├── WRITE_ONLY → PUBLIC      Column:{DescID: 104, ColumnID: 2}
       │    │    ├── ABSENT     → PUBLIC      ColumnName:{DescID: 104, Name: j, ColumnID: 2}
       │    │    └── ABSENT     → PUBLIC      ColumnComment:{DescID: 104, ColumnID: 2, Comment: j has a comment}
-      │    ├── 4 elements transitioning toward ABSENT
+      │    ├── 6 elements transitioning toward ABSENT
       │    │    ├── MERGE_ONLY → DELETE_ONLY PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
       │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 2}
+      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 2}
       │    │    ├── WRITE_ONLY → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
-      │    │    └── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
-      │    └── 10 Mutation operations
+      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
+      │    │    └── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 3}
+      │    └── 12 Mutation operations
       │         ├── SetColumnName {"ColumnID":2,"Name":"j","TableID":104}
       │         ├── UpsertColumnComment {"ColumnID":2,"Comment":"j has a comment","PGAttributeNum":2,"TableID":104}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":3,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":3,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":3,"Kind":2,"TableID":104}
       │         ├── MakeWriteOnlyColumnPublic {"ColumnID":2,"TableID":104}
       │         ├── RefreshStats {"TableID":104}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":2,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":2,"Kind":2,"TableID":104}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
       └── Stage 2 of 2 in PostCommitNonRevertiblePhase

--- a/pkg/sql/schemachanger/testdata/explain/drop_column_basic.rollback_6_of_7
+++ b/pkg/sql/schemachanger/testdata/explain/drop_column_basic.rollback_6_of_7
@@ -1,5 +1,5 @@
 /* setup */
-CREATE TABLE t (i INT PRIMARY KEY, j INT);
+CREATE TABLE t (i INT PRIMARY KEY, j INT, k int);
 COMMENT ON TABLE t IS 't has a comment';
 COMMENT ON COLUMN t.j IS 'j has a comment';
 
@@ -14,20 +14,24 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› D
       │    │    ├── WRITE_ONLY → PUBLIC      Column:{DescID: 104, ColumnID: 2}
       │    │    ├── ABSENT     → PUBLIC      ColumnName:{DescID: 104, Name: j, ColumnID: 2}
       │    │    └── ABSENT     → PUBLIC      ColumnComment:{DescID: 104, ColumnID: 2, Comment: j has a comment}
-      │    ├── 4 elements transitioning toward ABSENT
+      │    ├── 6 elements transitioning toward ABSENT
       │    │    ├── MERGE_ONLY → DELETE_ONLY PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
       │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 2}
+      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 2}
       │    │    ├── WRITE_ONLY → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
-      │    │    └── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
-      │    └── 10 Mutation operations
+      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
+      │    │    └── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 3}
+      │    └── 12 Mutation operations
       │         ├── SetColumnName {"ColumnID":2,"Name":"j","TableID":104}
       │         ├── UpsertColumnComment {"ColumnID":2,"Comment":"j has a comment","PGAttributeNum":2,"TableID":104}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":3,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":3,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":3,"Kind":2,"TableID":104}
       │         ├── MakeWriteOnlyColumnPublic {"ColumnID":2,"TableID":104}
       │         ├── RefreshStats {"TableID":104}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":2,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":2,"Kind":2,"TableID":104}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
       └── Stage 2 of 2 in PostCommitNonRevertiblePhase

--- a/pkg/sql/schemachanger/testdata/explain/drop_column_basic.rollback_7_of_7
+++ b/pkg/sql/schemachanger/testdata/explain/drop_column_basic.rollback_7_of_7
@@ -1,5 +1,5 @@
 /* setup */
-CREATE TABLE t (i INT PRIMARY KEY, j INT);
+CREATE TABLE t (i INT PRIMARY KEY, j INT, k int);
 COMMENT ON TABLE t IS 't has a comment';
 COMMENT ON COLUMN t.j IS 'j has a comment';
 
@@ -14,18 +14,22 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› D
       │    │    ├── WRITE_ONLY → PUBLIC      Column:{DescID: 104, ColumnID: 2}
       │    │    ├── ABSENT     → PUBLIC      ColumnName:{DescID: 104, Name: j, ColumnID: 2}
       │    │    └── ABSENT     → PUBLIC      ColumnComment:{DescID: 104, ColumnID: 2, Comment: j has a comment}
-      │    ├── 4 elements transitioning toward ABSENT
+      │    ├── 6 elements transitioning toward ABSENT
       │    │    ├── WRITE_ONLY → DELETE_ONLY PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
       │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 2}
+      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 2}
       │    │    ├── WRITE_ONLY → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
-      │    │    └── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
-      │    └── 10 Mutation operations
+      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
+      │    │    └── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 3}
+      │    └── 12 Mutation operations
       │         ├── SetColumnName {"ColumnID":2,"Name":"j","TableID":104}
       │         ├── UpsertColumnComment {"ColumnID":2,"Comment":"j has a comment","PGAttributeNum":2,"TableID":104}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":2,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":2,"Kind":2,"TableID":104}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":3,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":3,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":3,"Kind":2,"TableID":104}
       │         ├── MakeWriteOnlyColumnPublic {"ColumnID":2,"TableID":104}
       │         ├── RefreshStats {"TableID":104}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}

--- a/pkg/sql/schemachanger/testdata/explain_verbose/add_column
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/add_column
@@ -1,6 +1,6 @@
 /* setup */
 CREATE DATABASE db;
-CREATE TABLE db.public.tbl (i INT PRIMARY KEY);
+CREATE TABLE db.public.tbl (i INT PRIMARY KEY, k INT);
 CREATE SEQUENCE db.public.sq1;
 
 /* test */
@@ -12,38 +12,38 @@ EXPLAIN (ddl, verbose) ALTER TABLE db.public.tbl ADD COLUMN j INT NOT NULL DEFAU
 │   │
 │   └── • Stage 1 of 1 in StatementPhase
 │       │
-│       ├── • 8 elements transitioning toward PUBLIC
+│       ├── • 9 elements transitioning toward PUBLIC
 │       │   │
-│       │   ├── • Column:{DescID: 106, ColumnID: 2}
+│       │   ├── • Column:{DescID: 106, ColumnID: 3}
 │       │   │   │ ABSENT → DELETE_ONLY
 │       │   │   │
-│       │   │   └── • PreviousStagePrecedence dependency from ABSENT Column:{DescID: 106, ColumnID: 2}
+│       │   │   └── • PreviousStagePrecedence dependency from ABSENT Column:{DescID: 106, ColumnID: 3}
 │       │   │         rule: "Column transitions to PUBLIC uphold 2-version invariant: ABSENT->DELETE_ONLY"
 │       │   │
-│       │   ├── • ColumnName:{DescID: 106, Name: j, ColumnID: 2}
+│       │   ├── • ColumnName:{DescID: 106, Name: j, ColumnID: 3}
 │       │   │   │ ABSENT → PUBLIC
 │       │   │   │
-│       │   │   └── • SameStagePrecedence dependency from DELETE_ONLY Column:{DescID: 106, ColumnID: 2}
+│       │   │   └── • SameStagePrecedence dependency from DELETE_ONLY Column:{DescID: 106, ColumnID: 3}
 │       │   │         rule: "column existence precedes column dependents"
 │       │   │         rule: "column name and type set right after column existence"
 │       │   │
-│       │   ├── • ColumnType:{DescID: 106, ColumnFamilyID: 0, ColumnID: 2}
+│       │   ├── • ColumnType:{DescID: 106, ColumnFamilyID: 0, ColumnID: 3}
 │       │   │   │ ABSENT → PUBLIC
 │       │   │   │
-│       │   │   └── • SameStagePrecedence dependency from DELETE_ONLY Column:{DescID: 106, ColumnID: 2}
+│       │   │   └── • SameStagePrecedence dependency from DELETE_ONLY Column:{DescID: 106, ColumnID: 3}
 │       │   │         rule: "column existence precedes column dependents"
 │       │   │         rule: "column name and type set right after column existence"
 │       │   │
-│       │   ├── • ColumnDefaultExpression:{DescID: 106, ColumnID: 2}
+│       │   ├── • ColumnDefaultExpression:{DescID: 106, ColumnID: 3}
 │       │   │   │ ABSENT → PUBLIC
 │       │   │   │
-│       │   │   └── • Precedence dependency from DELETE_ONLY Column:{DescID: 106, ColumnID: 2}
+│       │   │   └── • Precedence dependency from DELETE_ONLY Column:{DescID: 106, ColumnID: 3}
 │       │   │         rule: "column existence precedes column dependents"
 │       │   │
 │       │   ├── • PrimaryIndex:{DescID: 106, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
 │       │   │   │ ABSENT → BACKFILL_ONLY
 │       │   │   │
-│       │   │   ├── • Precedence dependency from DELETE_ONLY Column:{DescID: 106, ColumnID: 2}
+│       │   │   ├── • Precedence dependency from DELETE_ONLY Column:{DescID: 106, ColumnID: 3}
 │       │   │   │     rule: "column existence precedes index existence"
 │       │   │   │
 │       │   │   └── • PreviousStagePrecedence dependency from ABSENT PrimaryIndex:{DescID: 106, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
@@ -58,7 +58,13 @@ EXPLAIN (ddl, verbose) ALTER TABLE db.public.tbl ADD COLUMN j INT NOT NULL DEFAU
 │       │   ├── • IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 2}
 │       │   │   │ ABSENT → PUBLIC
 │       │   │   │
-│       │   │   ├── • Precedence dependency from DELETE_ONLY Column:{DescID: 106, ColumnID: 2}
+│       │   │   └── • Precedence dependency from BACKFILL_ONLY PrimaryIndex:{DescID: 106, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
+│       │   │         rule: "index existence precedes index dependents"
+│       │   │
+│       │   ├── • IndexColumn:{DescID: 106, ColumnID: 3, IndexID: 2}
+│       │   │   │ ABSENT → PUBLIC
+│       │   │   │
+│       │   │   ├── • Precedence dependency from DELETE_ONLY Column:{DescID: 106, ColumnID: 3}
 │       │   │   │     rule: "column existence precedes column dependents"
 │       │   │   │
 │       │   │   └── • Precedence dependency from BACKFILL_ONLY PrimaryIndex:{DescID: 106, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
@@ -70,12 +76,12 @@ EXPLAIN (ddl, verbose) ALTER TABLE db.public.tbl ADD COLUMN j INT NOT NULL DEFAU
 │       │       └── • SameStagePrecedence dependency from BACKFILL_ONLY PrimaryIndex:{DescID: 106, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
 │       │             rule: "index data exists as soon as index accepts backfills"
 │       │
-│       ├── • 3 elements transitioning toward TRANSIENT_ABSENT
+│       ├── • 4 elements transitioning toward TRANSIENT_ABSENT
 │       │   │
 │       │   ├── • TemporaryIndex:{DescID: 106, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
 │       │   │   │ ABSENT → DELETE_ONLY
 │       │   │   │
-│       │   │   ├── • Precedence dependency from DELETE_ONLY Column:{DescID: 106, ColumnID: 2}
+│       │   │   ├── • Precedence dependency from DELETE_ONLY Column:{DescID: 106, ColumnID: 3}
 │       │   │   │     rule: "column existence precedes temp index existence"
 │       │   │   │
 │       │   │   └── • PreviousStagePrecedence dependency from ABSENT TemporaryIndex:{DescID: 106, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
@@ -87,31 +93,37 @@ EXPLAIN (ddl, verbose) ALTER TABLE db.public.tbl ADD COLUMN j INT NOT NULL DEFAU
 │       │   │   └── • Precedence dependency from DELETE_ONLY TemporaryIndex:{DescID: 106, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
 │       │   │         rule: "temp index existence precedes index dependents"
 │       │   │
-│       │   └── • IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 3}
+│       │   ├── • IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 3}
+│       │   │   │ ABSENT → PUBLIC
+│       │   │   │
+│       │   │   └── • Precedence dependency from DELETE_ONLY TemporaryIndex:{DescID: 106, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
+│       │   │         rule: "temp index existence precedes index dependents"
+│       │   │
+│       │   └── • IndexColumn:{DescID: 106, ColumnID: 3, IndexID: 3}
 │       │       │ ABSENT → PUBLIC
 │       │       │
-│       │       ├── • Precedence dependency from DELETE_ONLY Column:{DescID: 106, ColumnID: 2}
+│       │       ├── • Precedence dependency from DELETE_ONLY Column:{DescID: 106, ColumnID: 3}
 │       │       │     rule: "column existence precedes column dependents"
 │       │       │
 │       │       └── • Precedence dependency from DELETE_ONLY TemporaryIndex:{DescID: 106, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
 │       │             rule: "temp index existence precedes index dependents"
 │       │
-│       └── • 10 Mutation operations
+│       └── • 12 Mutation operations
 │           │
 │           ├── • MakeAbsentColumnDeleteOnly
 │           │     Column:
-│           │       ColumnID: 2
-│           │       PgAttributeNum: 2
+│           │       ColumnID: 3
+│           │       PgAttributeNum: 3
 │           │       TableID: 106
 │           │
 │           ├── • SetColumnName
-│           │     ColumnID: 2
+│           │     ColumnID: 3
 │           │     Name: j
 │           │     TableID: 106
 │           │
 │           ├── • SetAddedColumnType
 │           │     ColumnType:
-│           │       ColumnID: 2
+│           │       ColumnID: 3
 │           │       ElementCreationMetadata:
 │           │         in231OrLater: true
 │           │       TableID: 106
@@ -123,7 +135,7 @@ EXPLAIN (ddl, verbose) ALTER TABLE db.public.tbl ADD COLUMN j INT NOT NULL DEFAU
 │           │
 │           ├── • AddColumnDefaultExpression
 │           │     Default:
-│           │       ColumnID: 2
+│           │       ColumnID: 3
 │           │       Expression:
 │           │         Expr: 42:::INT8
 │           │       TableID: 106
@@ -148,6 +160,13 @@ EXPLAIN (ddl, verbose) ALTER TABLE db.public.tbl ADD COLUMN j INT NOT NULL DEFAU
 │           │     Kind: 2
 │           │     TableID: 106
 │           │
+│           ├── • AddColumnToIndex
+│           │     ColumnID: 3
+│           │     IndexID: 2
+│           │     Kind: 2
+│           │     Ordinal: 1
+│           │     TableID: 106
+│           │
 │           ├── • MakeAbsentTempIndexDeleteOnly
 │           │     Index:
 │           │       ConstraintID: 3
@@ -161,28 +180,35 @@ EXPLAIN (ddl, verbose) ALTER TABLE db.public.tbl ADD COLUMN j INT NOT NULL DEFAU
 │           │     IndexID: 3
 │           │     TableID: 106
 │           │
+│           ├── • AddColumnToIndex
+│           │     ColumnID: 2
+│           │     IndexID: 3
+│           │     Kind: 2
+│           │     TableID: 106
+│           │
 │           └── • AddColumnToIndex
-│                 ColumnID: 2
+│                 ColumnID: 3
 │                 IndexID: 3
 │                 Kind: 2
+│                 Ordinal: 1
 │                 TableID: 106
 │
 ├── • PreCommitPhase
 │   │
 │   ├── • Stage 1 of 2 in PreCommitPhase
 │   │   │
-│   │   ├── • 8 elements transitioning toward PUBLIC
+│   │   ├── • 9 elements transitioning toward PUBLIC
 │   │   │   │
-│   │   │   ├── • Column:{DescID: 106, ColumnID: 2}
+│   │   │   ├── • Column:{DescID: 106, ColumnID: 3}
 │   │   │   │     DELETE_ONLY → ABSENT
 │   │   │   │
-│   │   │   ├── • ColumnName:{DescID: 106, Name: j, ColumnID: 2}
+│   │   │   ├── • ColumnName:{DescID: 106, Name: j, ColumnID: 3}
 │   │   │   │     PUBLIC → ABSENT
 │   │   │   │
-│   │   │   ├── • ColumnType:{DescID: 106, ColumnFamilyID: 0, ColumnID: 2}
+│   │   │   ├── • ColumnType:{DescID: 106, ColumnFamilyID: 0, ColumnID: 3}
 │   │   │   │     PUBLIC → ABSENT
 │   │   │   │
-│   │   │   ├── • ColumnDefaultExpression:{DescID: 106, ColumnID: 2}
+│   │   │   ├── • ColumnDefaultExpression:{DescID: 106, ColumnID: 3}
 │   │   │   │     PUBLIC → ABSENT
 │   │   │   │
 │   │   │   ├── • PrimaryIndex:{DescID: 106, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
@@ -194,10 +220,13 @@ EXPLAIN (ddl, verbose) ALTER TABLE db.public.tbl ADD COLUMN j INT NOT NULL DEFAU
 │   │   │   ├── • IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 2}
 │   │   │   │     PUBLIC → ABSENT
 │   │   │   │
+│   │   │   ├── • IndexColumn:{DescID: 106, ColumnID: 3, IndexID: 2}
+│   │   │   │     PUBLIC → ABSENT
+│   │   │   │
 │   │   │   └── • IndexData:{DescID: 106, IndexID: 2}
 │   │   │         PUBLIC → ABSENT
 │   │   │
-│   │   ├── • 3 elements transitioning toward TRANSIENT_ABSENT
+│   │   ├── • 4 elements transitioning toward TRANSIENT_ABSENT
 │   │   │   │
 │   │   │   ├── • TemporaryIndex:{DescID: 106, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
 │   │   │   │     DELETE_ONLY → ABSENT
@@ -205,7 +234,10 @@ EXPLAIN (ddl, verbose) ALTER TABLE db.public.tbl ADD COLUMN j INT NOT NULL DEFAU
 │   │   │   ├── • IndexColumn:{DescID: 106, ColumnID: 1, IndexID: 3}
 │   │   │   │     PUBLIC → ABSENT
 │   │   │   │
-│   │   │   └── • IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 3}
+│   │   │   ├── • IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 3}
+│   │   │   │     PUBLIC → ABSENT
+│   │   │   │
+│   │   │   └── • IndexColumn:{DescID: 106, ColumnID: 3, IndexID: 3}
 │   │   │         PUBLIC → ABSENT
 │   │   │
 │   │   └── • 1 Mutation operation
@@ -215,38 +247,38 @@ EXPLAIN (ddl, verbose) ALTER TABLE db.public.tbl ADD COLUMN j INT NOT NULL DEFAU
 │   │
 │   └── • Stage 2 of 2 in PreCommitPhase
 │       │
-│       ├── • 8 elements transitioning toward PUBLIC
+│       ├── • 9 elements transitioning toward PUBLIC
 │       │   │
-│       │   ├── • Column:{DescID: 106, ColumnID: 2}
+│       │   ├── • Column:{DescID: 106, ColumnID: 3}
 │       │   │   │ ABSENT → DELETE_ONLY
 │       │   │   │
-│       │   │   └── • PreviousStagePrecedence dependency from ABSENT Column:{DescID: 106, ColumnID: 2}
+│       │   │   └── • PreviousStagePrecedence dependency from ABSENT Column:{DescID: 106, ColumnID: 3}
 │       │   │         rule: "Column transitions to PUBLIC uphold 2-version invariant: ABSENT->DELETE_ONLY"
 │       │   │
-│       │   ├── • ColumnName:{DescID: 106, Name: j, ColumnID: 2}
+│       │   ├── • ColumnName:{DescID: 106, Name: j, ColumnID: 3}
 │       │   │   │ ABSENT → PUBLIC
 │       │   │   │
-│       │   │   └── • SameStagePrecedence dependency from DELETE_ONLY Column:{DescID: 106, ColumnID: 2}
+│       │   │   └── • SameStagePrecedence dependency from DELETE_ONLY Column:{DescID: 106, ColumnID: 3}
 │       │   │         rule: "column existence precedes column dependents"
 │       │   │         rule: "column name and type set right after column existence"
 │       │   │
-│       │   ├── • ColumnType:{DescID: 106, ColumnFamilyID: 0, ColumnID: 2}
+│       │   ├── • ColumnType:{DescID: 106, ColumnFamilyID: 0, ColumnID: 3}
 │       │   │   │ ABSENT → PUBLIC
 │       │   │   │
-│       │   │   └── • SameStagePrecedence dependency from DELETE_ONLY Column:{DescID: 106, ColumnID: 2}
+│       │   │   └── • SameStagePrecedence dependency from DELETE_ONLY Column:{DescID: 106, ColumnID: 3}
 │       │   │         rule: "column existence precedes column dependents"
 │       │   │         rule: "column name and type set right after column existence"
 │       │   │
-│       │   ├── • ColumnDefaultExpression:{DescID: 106, ColumnID: 2}
+│       │   ├── • ColumnDefaultExpression:{DescID: 106, ColumnID: 3}
 │       │   │   │ ABSENT → PUBLIC
 │       │   │   │
-│       │   │   └── • Precedence dependency from DELETE_ONLY Column:{DescID: 106, ColumnID: 2}
+│       │   │   └── • Precedence dependency from DELETE_ONLY Column:{DescID: 106, ColumnID: 3}
 │       │   │         rule: "column existence precedes column dependents"
 │       │   │
 │       │   ├── • PrimaryIndex:{DescID: 106, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
 │       │   │   │ ABSENT → BACKFILL_ONLY
 │       │   │   │
-│       │   │   ├── • Precedence dependency from DELETE_ONLY Column:{DescID: 106, ColumnID: 2}
+│       │   │   ├── • Precedence dependency from DELETE_ONLY Column:{DescID: 106, ColumnID: 3}
 │       │   │   │     rule: "column existence precedes index existence"
 │       │   │   │
 │       │   │   └── • PreviousStagePrecedence dependency from ABSENT PrimaryIndex:{DescID: 106, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
@@ -261,7 +293,13 @@ EXPLAIN (ddl, verbose) ALTER TABLE db.public.tbl ADD COLUMN j INT NOT NULL DEFAU
 │       │   ├── • IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 2}
 │       │   │   │ ABSENT → PUBLIC
 │       │   │   │
-│       │   │   ├── • Precedence dependency from DELETE_ONLY Column:{DescID: 106, ColumnID: 2}
+│       │   │   └── • Precedence dependency from BACKFILL_ONLY PrimaryIndex:{DescID: 106, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
+│       │   │         rule: "index existence precedes index dependents"
+│       │   │
+│       │   ├── • IndexColumn:{DescID: 106, ColumnID: 3, IndexID: 2}
+│       │   │   │ ABSENT → PUBLIC
+│       │   │   │
+│       │   │   ├── • Precedence dependency from DELETE_ONLY Column:{DescID: 106, ColumnID: 3}
 │       │   │   │     rule: "column existence precedes column dependents"
 │       │   │   │
 │       │   │   └── • Precedence dependency from BACKFILL_ONLY PrimaryIndex:{DescID: 106, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
@@ -273,12 +311,12 @@ EXPLAIN (ddl, verbose) ALTER TABLE db.public.tbl ADD COLUMN j INT NOT NULL DEFAU
 │       │       └── • SameStagePrecedence dependency from BACKFILL_ONLY PrimaryIndex:{DescID: 106, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
 │       │             rule: "index data exists as soon as index accepts backfills"
 │       │
-│       ├── • 3 elements transitioning toward TRANSIENT_ABSENT
+│       ├── • 4 elements transitioning toward TRANSIENT_ABSENT
 │       │   │
 │       │   ├── • TemporaryIndex:{DescID: 106, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
 │       │   │   │ ABSENT → DELETE_ONLY
 │       │   │   │
-│       │   │   ├── • Precedence dependency from DELETE_ONLY Column:{DescID: 106, ColumnID: 2}
+│       │   │   ├── • Precedence dependency from DELETE_ONLY Column:{DescID: 106, ColumnID: 3}
 │       │   │   │     rule: "column existence precedes temp index existence"
 │       │   │   │
 │       │   │   └── • PreviousStagePrecedence dependency from ABSENT TemporaryIndex:{DescID: 106, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
@@ -290,31 +328,37 @@ EXPLAIN (ddl, verbose) ALTER TABLE db.public.tbl ADD COLUMN j INT NOT NULL DEFAU
 │       │   │   └── • Precedence dependency from DELETE_ONLY TemporaryIndex:{DescID: 106, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
 │       │   │         rule: "temp index existence precedes index dependents"
 │       │   │
-│       │   └── • IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 3}
+│       │   ├── • IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 3}
+│       │   │   │ ABSENT → PUBLIC
+│       │   │   │
+│       │   │   └── • Precedence dependency from DELETE_ONLY TemporaryIndex:{DescID: 106, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
+│       │   │         rule: "temp index existence precedes index dependents"
+│       │   │
+│       │   └── • IndexColumn:{DescID: 106, ColumnID: 3, IndexID: 3}
 │       │       │ ABSENT → PUBLIC
 │       │       │
-│       │       ├── • Precedence dependency from DELETE_ONLY Column:{DescID: 106, ColumnID: 2}
+│       │       ├── • Precedence dependency from DELETE_ONLY Column:{DescID: 106, ColumnID: 3}
 │       │       │     rule: "column existence precedes column dependents"
 │       │       │
 │       │       └── • Precedence dependency from DELETE_ONLY TemporaryIndex:{DescID: 106, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
 │       │             rule: "temp index existence precedes index dependents"
 │       │
-│       └── • 14 Mutation operations
+│       └── • 16 Mutation operations
 │           │
 │           ├── • MakeAbsentColumnDeleteOnly
 │           │     Column:
-│           │       ColumnID: 2
-│           │       PgAttributeNum: 2
+│           │       ColumnID: 3
+│           │       PgAttributeNum: 3
 │           │       TableID: 106
 │           │
 │           ├── • SetColumnName
-│           │     ColumnID: 2
+│           │     ColumnID: 3
 │           │     Name: j
 │           │     TableID: 106
 │           │
 │           ├── • SetAddedColumnType
 │           │     ColumnType:
-│           │       ColumnID: 2
+│           │       ColumnID: 3
 │           │       ElementCreationMetadata:
 │           │         in231OrLater: true
 │           │       TableID: 106
@@ -326,7 +370,7 @@ EXPLAIN (ddl, verbose) ALTER TABLE db.public.tbl ADD COLUMN j INT NOT NULL DEFAU
 │           │
 │           ├── • AddColumnDefaultExpression
 │           │     Default:
-│           │       ColumnID: 2
+│           │       ColumnID: 3
 │           │       Expression:
 │           │         Expr: 42:::INT8
 │           │       TableID: 106
@@ -355,6 +399,13 @@ EXPLAIN (ddl, verbose) ALTER TABLE db.public.tbl ADD COLUMN j INT NOT NULL DEFAU
 │           │     Kind: 2
 │           │     TableID: 106
 │           │
+│           ├── • AddColumnToIndex
+│           │     ColumnID: 3
+│           │     IndexID: 2
+│           │     Kind: 2
+│           │     Ordinal: 1
+│           │     TableID: 106
+│           │
 │           ├── • MakeAbsentTempIndexDeleteOnly
 │           │     Index:
 │           │       ConstraintID: 3
@@ -376,6 +427,13 @@ EXPLAIN (ddl, verbose) ALTER TABLE db.public.tbl ADD COLUMN j INT NOT NULL DEFAU
 │           │     ColumnID: 2
 │           │     IndexID: 3
 │           │     Kind: 2
+│           │     TableID: 106
+│           │
+│           ├── • AddColumnToIndex
+│           │     ColumnID: 3
+│           │     IndexID: 3
+│           │     Kind: 2
+│           │     Ordinal: 1
 │           │     TableID: 106
 │           │
 │           ├── • SetJobStateOnDescriptor
@@ -401,22 +459,22 @@ EXPLAIN (ddl, verbose) ALTER TABLE db.public.tbl ADD COLUMN j INT NOT NULL DEFAU
 │   │   │
 │   │   ├── • 2 elements transitioning toward PUBLIC
 │   │   │   │
-│   │   │   ├── • Column:{DescID: 106, ColumnID: 2}
+│   │   │   ├── • Column:{DescID: 106, ColumnID: 3}
 │   │   │   │   │ DELETE_ONLY → WRITE_ONLY
 │   │   │   │   │
-│   │   │   │   ├── • PreviousStagePrecedence dependency from DELETE_ONLY Column:{DescID: 106, ColumnID: 2}
+│   │   │   │   ├── • PreviousStagePrecedence dependency from DELETE_ONLY Column:{DescID: 106, ColumnID: 3}
 │   │   │   │   │     rule: "Column transitions to PUBLIC uphold 2-version invariant: DELETE_ONLY->WRITE_ONLY"
 │   │   │   │   │
-│   │   │   │   └── • Precedence dependency from PUBLIC ColumnDefaultExpression:{DescID: 106, ColumnID: 2}
+│   │   │   │   └── • Precedence dependency from PUBLIC ColumnDefaultExpression:{DescID: 106, ColumnID: 3}
 │   │   │   │         rule: "DEFAULT or ON UPDATE existence precedes writes to column"
 │   │   │   │
-│   │   │   └── • ColumnNotNull:{DescID: 106, ColumnID: 2, IndexID: 2}
+│   │   │   └── • ColumnNotNull:{DescID: 106, ColumnID: 3, IndexID: 2}
 │   │   │       │ ABSENT → WRITE_ONLY
 │   │   │       │
-│   │   │       ├── • SameStagePrecedence dependency from WRITE_ONLY Column:{DescID: 106, ColumnID: 2}
+│   │   │       ├── • SameStagePrecedence dependency from WRITE_ONLY Column:{DescID: 106, ColumnID: 3}
 │   │   │       │     rule: "column writable right before column constraint is enforced."
 │   │   │       │
-│   │   │       └── • PreviousStagePrecedence dependency from ABSENT ColumnNotNull:{DescID: 106, ColumnID: 2, IndexID: 2}
+│   │   │       └── • PreviousStagePrecedence dependency from ABSENT ColumnNotNull:{DescID: 106, ColumnID: 3, IndexID: 2}
 │   │   │             rule: "ColumnNotNull transitions to PUBLIC uphold 2-version invariant: ABSENT->WRITE_ONLY"
 │   │   │
 │   │   ├── • 2 elements transitioning toward TRANSIENT_ABSENT
@@ -424,7 +482,7 @@ EXPLAIN (ddl, verbose) ALTER TABLE db.public.tbl ADD COLUMN j INT NOT NULL DEFAU
 │   │   │   ├── • TemporaryIndex:{DescID: 106, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
 │   │   │   │   │ DELETE_ONLY → WRITE_ONLY
 │   │   │   │   │
-│   │   │   │   ├── • Precedence dependency from WRITE_ONLY Column:{DescID: 106, ColumnID: 2}
+│   │   │   │   ├── • Precedence dependency from WRITE_ONLY Column:{DescID: 106, ColumnID: 3}
 │   │   │   │   │     rule: "column is WRITE_ONLY before temporary index is WRITE_ONLY"
 │   │   │   │   │
 │   │   │   │   ├── • PreviousStagePrecedence dependency from DELETE_ONLY TemporaryIndex:{DescID: 106, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
@@ -433,7 +491,10 @@ EXPLAIN (ddl, verbose) ALTER TABLE db.public.tbl ADD COLUMN j INT NOT NULL DEFAU
 │   │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 106, ColumnID: 1, IndexID: 3}
 │   │   │   │   │     rule: "index-column added to index before temp index receives writes"
 │   │   │   │   │
-│   │   │   │   └── • Precedence dependency from PUBLIC IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 3}
+│   │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 3}
+│   │   │   │   │     rule: "index-column added to index before temp index receives writes"
+│   │   │   │   │
+│   │   │   │   └── • Precedence dependency from PUBLIC IndexColumn:{DescID: 106, ColumnID: 3, IndexID: 3}
 │   │   │   │         rule: "index-column added to index before temp index receives writes"
 │   │   │   │
 │   │   │   └── • IndexData:{DescID: 106, IndexID: 3}
@@ -445,7 +506,7 @@ EXPLAIN (ddl, verbose) ALTER TABLE db.public.tbl ADD COLUMN j INT NOT NULL DEFAU
 │   │   └── • 5 Mutation operations
 │   │       │
 │   │       ├── • MakeDeleteOnlyColumnWriteOnly
-│   │       │     ColumnID: 2
+│   │       │     ColumnID: 3
 │   │       │     TableID: 106
 │   │       │
 │   │       ├── • MakeDeleteOnlyIndexWriteOnly
@@ -453,7 +514,7 @@ EXPLAIN (ddl, verbose) ALTER TABLE db.public.tbl ADD COLUMN j INT NOT NULL DEFAU
 │   │       │     TableID: 106
 │   │       │
 │   │       ├── • MakeAbsentColumnNotNullWriteOnly
-│   │       │     ColumnID: 2
+│   │       │     ColumnID: 3
 │   │       │     TableID: 106
 │   │       │
 │   │       ├── • SetJobStateOnDescriptor
@@ -477,6 +538,9 @@ EXPLAIN (ddl, verbose) ALTER TABLE db.public.tbl ADD COLUMN j INT NOT NULL DEFAU
 │   │   │       │     rule: "index-column added to index before index is backfilled"
 │   │   │       │
 │   │   │       ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 2}
+│   │   │       │     rule: "index-column added to index before index is backfilled"
+│   │   │       │
+│   │   │       ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 106, ColumnID: 3, IndexID: 2}
 │   │   │       │     rule: "index-column added to index before index is backfilled"
 │   │   │       │
 │   │   │       └── • Precedence dependency from WRITE_ONLY TemporaryIndex:{DescID: 106, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
@@ -585,13 +649,13 @@ EXPLAIN (ddl, verbose) ALTER TABLE db.public.tbl ADD COLUMN j INT NOT NULL DEFAU
 │       │   │   └── • PreviousStagePrecedence dependency from WRITE_ONLY PrimaryIndex:{DescID: 106, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
 │       │   │         rule: "PrimaryIndex transitions to PUBLIC uphold 2-version invariant: WRITE_ONLY->VALIDATED"
 │       │   │
-│       │   └── • ColumnNotNull:{DescID: 106, ColumnID: 2, IndexID: 2}
+│       │   └── • ColumnNotNull:{DescID: 106, ColumnID: 3, IndexID: 2}
 │       │       │ WRITE_ONLY → VALIDATED
 │       │       │
 │       │       ├── • Precedence dependency from VALIDATED PrimaryIndex:{DescID: 106, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
 │       │       │     rule: "index is ready to be validated before we validate constraint on it"
 │       │       │
-│       │       └── • PreviousStagePrecedence dependency from WRITE_ONLY ColumnNotNull:{DescID: 106, ColumnID: 2, IndexID: 2}
+│       │       └── • PreviousStagePrecedence dependency from WRITE_ONLY ColumnNotNull:{DescID: 106, ColumnID: 3, IndexID: 2}
 │       │             rule: "ColumnNotNull transitions to PUBLIC uphold 2-version invariant: WRITE_ONLY->VALIDATED"
 │       │
 │       └── • 2 Validation operations
@@ -601,7 +665,7 @@ EXPLAIN (ddl, verbose) ALTER TABLE db.public.tbl ADD COLUMN j INT NOT NULL DEFAU
 │           │     TableID: 106
 │           │
 │           └── • ValidateColumnNotNull
-│                 ColumnID: 2
+│                 ColumnID: 3
 │                 IndexIDForValidation: 2
 │                 TableID: 106
 │
@@ -611,31 +675,31 @@ EXPLAIN (ddl, verbose) ALTER TABLE db.public.tbl ADD COLUMN j INT NOT NULL DEFAU
     │   │
     │   ├── • 4 elements transitioning toward PUBLIC
     │   │   │
-    │   │   ├── • Column:{DescID: 106, ColumnID: 2}
+    │   │   ├── • Column:{DescID: 106, ColumnID: 3}
     │   │   │   │ WRITE_ONLY → PUBLIC
     │   │   │   │
-    │   │   │   ├── • PreviousStagePrecedence dependency from WRITE_ONLY Column:{DescID: 106, ColumnID: 2}
+    │   │   │   ├── • PreviousStagePrecedence dependency from WRITE_ONLY Column:{DescID: 106, ColumnID: 3}
     │   │   │   │     rule: "Column transitions to PUBLIC uphold 2-version invariant: WRITE_ONLY->PUBLIC"
     │   │   │   │
-    │   │   │   ├── • Precedence dependency from PUBLIC ColumnName:{DescID: 106, Name: j, ColumnID: 2}
+    │   │   │   ├── • Precedence dependency from PUBLIC ColumnName:{DescID: 106, Name: j, ColumnID: 3}
     │   │   │   │     rule: "column dependents exist before column becomes public"
     │   │   │   │
-    │   │   │   ├── • Precedence dependency from PUBLIC ColumnType:{DescID: 106, ColumnFamilyID: 0, ColumnID: 2}
+    │   │   │   ├── • Precedence dependency from PUBLIC ColumnType:{DescID: 106, ColumnFamilyID: 0, ColumnID: 3}
     │   │   │   │     rule: "column dependents exist before column becomes public"
     │   │   │   │
-    │   │   │   ├── • Precedence dependency from PUBLIC ColumnDefaultExpression:{DescID: 106, ColumnID: 2}
+    │   │   │   ├── • Precedence dependency from PUBLIC ColumnDefaultExpression:{DescID: 106, ColumnID: 3}
     │   │   │   │     rule: "column dependents exist before column becomes public"
     │   │   │   │
     │   │   │   ├── • Precedence dependency from PUBLIC PrimaryIndex:{DescID: 106, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
     │   │   │   │     rule: "swapped primary index public before column"
     │   │   │   │
-    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 2}
+    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 106, ColumnID: 3, IndexID: 2}
     │   │   │   │     rule: "column dependents exist before column becomes public"
     │   │   │   │
-    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 3}
+    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 106, ColumnID: 3, IndexID: 3}
     │   │   │   │     rule: "column dependents exist before column becomes public"
     │   │   │   │
-    │   │   │   └── • Precedence dependency from PUBLIC ColumnNotNull:{DescID: 106, ColumnID: 2, IndexID: 2}
+    │   │   │   └── • Precedence dependency from PUBLIC ColumnNotNull:{DescID: 106, ColumnID: 3, IndexID: 2}
     │   │   │         rule: "column dependents exist before column becomes public"
     │   │   │
     │   │   ├── • PrimaryIndex:{DescID: 106, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
@@ -654,7 +718,10 @@ EXPLAIN (ddl, verbose) ALTER TABLE db.public.tbl ADD COLUMN j INT NOT NULL DEFAU
     │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 106, ColumnID: 1, IndexID: 2}
     │   │   │   │     rule: "index dependents exist before index becomes public"
     │   │   │   │
-    │   │   │   └── • Precedence dependency from PUBLIC IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 2}
+    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 2}
+    │   │   │   │     rule: "index dependents exist before index becomes public"
+    │   │   │   │
+    │   │   │   └── • Precedence dependency from PUBLIC IndexColumn:{DescID: 106, ColumnID: 3, IndexID: 2}
     │   │   │         rule: "index dependents exist before index becomes public"
     │   │   │
     │   │   ├── • IndexName:{DescID: 106, Name: tbl_pkey, IndexID: 2}
@@ -663,16 +730,16 @@ EXPLAIN (ddl, verbose) ALTER TABLE db.public.tbl ADD COLUMN j INT NOT NULL DEFAU
     │   │   │   └── • Precedence dependency from BACKFILL_ONLY PrimaryIndex:{DescID: 106, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
     │   │   │         rule: "index existence precedes index dependents"
     │   │   │
-    │   │   └── • ColumnNotNull:{DescID: 106, ColumnID: 2, IndexID: 2}
+    │   │   └── • ColumnNotNull:{DescID: 106, ColumnID: 3, IndexID: 2}
     │   │       │ VALIDATED → PUBLIC
     │   │       │
-    │   │       ├── • Precedence dependency from DELETE_ONLY Column:{DescID: 106, ColumnID: 2}
+    │   │       ├── • Precedence dependency from DELETE_ONLY Column:{DescID: 106, ColumnID: 3}
     │   │       │     rule: "column existence precedes column dependents"
     │   │       │
-    │   │       └── • PreviousStagePrecedence dependency from VALIDATED ColumnNotNull:{DescID: 106, ColumnID: 2, IndexID: 2}
+    │   │       └── • PreviousStagePrecedence dependency from VALIDATED ColumnNotNull:{DescID: 106, ColumnID: 3, IndexID: 2}
     │   │             rule: "ColumnNotNull transitions to PUBLIC uphold 2-version invariant: VALIDATED->PUBLIC"
     │   │
-    │   ├── • 3 elements transitioning toward TRANSIENT_ABSENT
+    │   ├── • 4 elements transitioning toward TRANSIENT_ABSENT
     │   │   │
     │   │   ├── • TemporaryIndex:{DescID: 106, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
     │   │   │   │ WRITE_ONLY → TRANSIENT_DELETE_ONLY
@@ -686,7 +753,13 @@ EXPLAIN (ddl, verbose) ALTER TABLE db.public.tbl ADD COLUMN j INT NOT NULL DEFAU
     │   │   │   └── • Precedence dependency from TRANSIENT_DELETE_ONLY TemporaryIndex:{DescID: 106, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
     │   │   │         rule: "index drop mutation visible before cleaning up index columns"
     │   │   │
-    │   │   └── • IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 3}
+    │   │   ├── • IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 3}
+    │   │   │   │ PUBLIC → TRANSIENT_ABSENT
+    │   │   │   │
+    │   │   │   └── • Precedence dependency from TRANSIENT_DELETE_ONLY TemporaryIndex:{DescID: 106, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
+    │   │   │         rule: "index drop mutation visible before cleaning up index columns"
+    │   │   │
+    │   │   └── • IndexColumn:{DescID: 106, ColumnID: 3, IndexID: 3}
     │   │       │ PUBLIC → TRANSIENT_ABSENT
     │   │       │
     │   │       └── • Precedence dependency from TRANSIENT_DELETE_ONLY TemporaryIndex:{DescID: 106, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
@@ -706,7 +779,7 @@ EXPLAIN (ddl, verbose) ALTER TABLE db.public.tbl ADD COLUMN j INT NOT NULL DEFAU
     │   │       └── • Precedence dependency from VALIDATED PrimaryIndex:{DescID: 106, IndexID: 1, ConstraintID: 1}
     │   │             rule: "index no longer public before dependents, excluding columns"
     │   │
-    │   └── • 12 Mutation operations
+    │   └── • 13 Mutation operations
     │       │
     │       ├── • MakePublicPrimaryIndexWriteOnly
     │       │     IndexID: 1
@@ -737,8 +810,15 @@ EXPLAIN (ddl, verbose) ALTER TABLE db.public.tbl ADD COLUMN j INT NOT NULL DEFAU
     │       │     Kind: 2
     │       │     TableID: 106
     │       │
+    │       ├── • RemoveColumnFromIndex
+    │       │     ColumnID: 3
+    │       │     IndexID: 3
+    │       │     Kind: 2
+    │       │     Ordinal: 1
+    │       │     TableID: 106
+    │       │
     │       ├── • MakeValidatedColumnNotNullPublic
-    │       │     ColumnID: 2
+    │       │     ColumnID: 3
     │       │     TableID: 106
     │       │
     │       ├── • MakeValidatedPrimaryIndexPublic
@@ -746,7 +826,7 @@ EXPLAIN (ddl, verbose) ALTER TABLE db.public.tbl ADD COLUMN j INT NOT NULL DEFAU
     │       │     TableID: 106
     │       │
     │       ├── • MakeWriteOnlyColumnPublic
-    │       │     ColumnID: 2
+    │       │     ColumnID: 3
     │       │     TableID: 106
     │       │
     │       ├── • RefreshStats
@@ -758,7 +838,7 @@ EXPLAIN (ddl, verbose) ALTER TABLE db.public.tbl ADD COLUMN j INT NOT NULL DEFAU
     │       └── • UpdateSchemaChangerJob
     │             IsNonCancelable: true
     │             JobID: 1
-    │             RunningStatus: PostCommitNonRevertiblePhase stage 2 of 3 with 3 MutationType ops pending
+    │             RunningStatus: PostCommitNonRevertiblePhase stage 2 of 3 with 4 MutationType ops pending
     │
     ├── • Stage 2 of 3 in PostCommitNonRevertiblePhase
     │   │
@@ -773,12 +853,21 @@ EXPLAIN (ddl, verbose) ALTER TABLE db.public.tbl ADD COLUMN j INT NOT NULL DEFAU
     │   │       ├── • Precedence dependency from TRANSIENT_ABSENT IndexColumn:{DescID: 106, ColumnID: 1, IndexID: 3}
     │   │       │     rule: "dependents removed before index"
     │   │       │
-    │   │       └── • Precedence dependency from TRANSIENT_ABSENT IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 3}
+    │   │       ├── • Precedence dependency from TRANSIENT_ABSENT IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 3}
+    │   │       │     rule: "dependents removed before index"
+    │   │       │
+    │   │       └── • Precedence dependency from TRANSIENT_ABSENT IndexColumn:{DescID: 106, ColumnID: 3, IndexID: 3}
     │   │             rule: "dependents removed before index"
     │   │
-    │   ├── • 2 elements transitioning toward ABSENT
+    │   ├── • 3 elements transitioning toward ABSENT
     │   │   │
     │   │   ├── • IndexColumn:{DescID: 106, ColumnID: 1, IndexID: 1}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   └── • Precedence dependency from DELETE_ONLY PrimaryIndex:{DescID: 106, IndexID: 1, ConstraintID: 1}
+    │   │   │         rule: "index drop mutation visible before cleaning up index columns"
+    │   │   │
+    │   │   ├── • IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 1}
     │   │   │   │ PUBLIC → ABSENT
     │   │   │   │
     │   │   │   └── • Precedence dependency from DELETE_ONLY PrimaryIndex:{DescID: 106, IndexID: 1, ConstraintID: 1}
@@ -790,7 +879,7 @@ EXPLAIN (ddl, verbose) ALTER TABLE db.public.tbl ADD COLUMN j INT NOT NULL DEFAU
     │   │       └── • PreviousStagePrecedence dependency from VALIDATED PrimaryIndex:{DescID: 106, IndexID: 1, ConstraintID: 1}
     │   │             rule: "PrimaryIndex transitions to ABSENT uphold 2-version invariant: VALIDATED->WRITE_ONLY"
     │   │
-    │   └── • 5 Mutation operations
+    │   └── • 6 Mutation operations
     │       │
     │       ├── • MakeIndexAbsent
     │       │     IndexID: 3
@@ -803,6 +892,12 @@ EXPLAIN (ddl, verbose) ALTER TABLE db.public.tbl ADD COLUMN j INT NOT NULL DEFAU
     │       ├── • RemoveColumnFromIndex
     │       │     ColumnID: 1
     │       │     IndexID: 1
+    │       │     TableID: 106
+    │       │
+    │       ├── • RemoveColumnFromIndex
+    │       │     ColumnID: 2
+    │       │     IndexID: 1
+    │       │     Kind: 2
     │       │     TableID: 106
     │       │
     │       ├── • SetJobStateOnDescriptor
@@ -832,6 +927,9 @@ EXPLAIN (ddl, verbose) ALTER TABLE db.public.tbl ADD COLUMN j INT NOT NULL DEFAU
         │   │   │ DELETE_ONLY → ABSENT
         │   │   │
         │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 106, ColumnID: 1, IndexID: 1}
+        │   │   │     rule: "dependents removed before index"
+        │   │   │
+        │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 1}
         │   │   │     rule: "dependents removed before index"
         │   │   │
         │   │   ├── • PreviousStagePrecedence dependency from DELETE_ONLY PrimaryIndex:{DescID: 106, IndexID: 1, ConstraintID: 1}

--- a/pkg/sql/schemachanger/testdata/explain_verbose/add_column.rollback_1_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/add_column.rollback_1_of_7
@@ -1,6 +1,6 @@
 /* setup */
 CREATE DATABASE db;
-CREATE TABLE db.public.tbl (i INT PRIMARY KEY);
+CREATE TABLE db.public.tbl (i INT PRIMARY KEY, k INT);
 CREATE SEQUENCE db.public.sq1;
 
 /* test */
@@ -13,46 +13,46 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 1 of 7;
     │
     └── • Stage 1 of 1 in PostCommitNonRevertiblePhase
         │
-        ├── • 11 elements transitioning toward ABSENT
+        ├── • 13 elements transitioning toward ABSENT
         │   │
-        │   ├── • Column:{DescID: 106, ColumnID: 2}
+        │   ├── • Column:{DescID: 106, ColumnID: 3}
         │   │   │ DELETE_ONLY → ABSENT
         │   │   │
-        │   │   ├── • PreviousStagePrecedence dependency from DELETE_ONLY Column:{DescID: 106, ColumnID: 2}
+        │   │   ├── • PreviousStagePrecedence dependency from DELETE_ONLY Column:{DescID: 106, ColumnID: 3}
         │   │   │     rule: "Column transitions to ABSENT uphold 2-version invariant: DELETE_ONLY->ABSENT"
         │   │   │
-        │   │   ├── • Precedence dependency from ABSENT ColumnName:{DescID: 106, Name: j, ColumnID: 2}
+        │   │   ├── • Precedence dependency from ABSENT ColumnName:{DescID: 106, Name: j, ColumnID: 3}
         │   │   │     rule: "dependents removed before column"
         │   │   │
-        │   │   ├── • SameStagePrecedence dependency from ABSENT ColumnType:{DescID: 106, ColumnFamilyID: 0, ColumnID: 2}
+        │   │   ├── • SameStagePrecedence dependency from ABSENT ColumnType:{DescID: 106, ColumnFamilyID: 0, ColumnID: 3}
         │   │   │     rule: "dependents removed before column"
         │   │   │     rule: "column type removed right before column when not dropping relation"
         │   │   │
-        │   │   ├── • Precedence dependency from ABSENT ColumnDefaultExpression:{DescID: 106, ColumnID: 2}
+        │   │   ├── • Precedence dependency from ABSENT ColumnDefaultExpression:{DescID: 106, ColumnID: 3}
         │   │   │     rule: "dependents removed before column"
         │   │   │
         │   │   ├── • Precedence dependency from ABSENT PrimaryIndex:{DescID: 106, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
         │   │   │     rule: "indexes containing column reach absent before column"
         │   │   │
-        │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 2}
+        │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 106, ColumnID: 3, IndexID: 2}
         │   │   │     rule: "dependents removed before column"
         │   │   │
-        │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 3}
+        │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 106, ColumnID: 3, IndexID: 3}
         │   │   │     rule: "dependents removed before column"
         │   │   │
-        │   │   └── • Precedence dependency from ABSENT ColumnNotNull:{DescID: 106, ColumnID: 2, IndexID: 2}
+        │   │   └── • Precedence dependency from ABSENT ColumnNotNull:{DescID: 106, ColumnID: 3, IndexID: 2}
         │   │         rule: "dependents removed before column"
         │   │
-        │   ├── • ColumnName:{DescID: 106, Name: j, ColumnID: 2}
+        │   ├── • ColumnName:{DescID: 106, Name: j, ColumnID: 3}
         │   │     PUBLIC → ABSENT
         │   │
-        │   ├── • ColumnType:{DescID: 106, ColumnFamilyID: 0, ColumnID: 2}
+        │   ├── • ColumnType:{DescID: 106, ColumnFamilyID: 0, ColumnID: 3}
         │   │   │ PUBLIC → ABSENT
         │   │   │
-        │   │   └── • SameStagePrecedence dependency from ABSENT ColumnDefaultExpression:{DescID: 106, ColumnID: 2}
+        │   │   └── • SameStagePrecedence dependency from ABSENT ColumnDefaultExpression:{DescID: 106, ColumnID: 3}
         │   │         rule: "column type dependents removed right before column type"
         │   │
-        │   ├── • ColumnDefaultExpression:{DescID: 106, ColumnID: 2}
+        │   ├── • ColumnDefaultExpression:{DescID: 106, ColumnID: 3}
         │   │     PUBLIC → ABSENT
         │   │
         │   ├── • PrimaryIndex:{DescID: 106, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
@@ -67,7 +67,10 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 1 of 7;
         │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 106, ColumnID: 1, IndexID: 2}
         │   │   │     rule: "dependents removed before index"
         │   │   │
-        │   │   └── • Precedence dependency from ABSENT IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 2}
+        │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 2}
+        │   │   │     rule: "dependents removed before index"
+        │   │   │
+        │   │   └── • Precedence dependency from ABSENT IndexColumn:{DescID: 106, ColumnID: 3, IndexID: 2}
         │   │         rule: "dependents removed before index"
         │   │
         │   ├── • IndexColumn:{DescID: 106, ColumnID: 1, IndexID: 2}
@@ -77,6 +80,12 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 1 of 7;
         │   │         rule: "index drop mutation visible before cleaning up index columns"
         │   │
         │   ├── • IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 2}
+        │   │   │ PUBLIC → ABSENT
+        │   │   │
+        │   │   └── • Precedence dependency from DELETE_ONLY PrimaryIndex:{DescID: 106, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
+        │   │         rule: "index drop mutation visible before cleaning up index columns"
+        │   │
+        │   ├── • IndexColumn:{DescID: 106, ColumnID: 3, IndexID: 2}
         │   │   │ PUBLIC → ABSENT
         │   │   │
         │   │   └── • Precedence dependency from DELETE_ONLY PrimaryIndex:{DescID: 106, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
@@ -97,7 +106,10 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 1 of 7;
         │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 106, ColumnID: 1, IndexID: 3}
         │   │   │     rule: "dependents removed before index"
         │   │   │
-        │   │   └── • Precedence dependency from ABSENT IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 3}
+        │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 3}
+        │   │   │     rule: "dependents removed before index"
+        │   │   │
+        │   │   └── • Precedence dependency from ABSENT IndexColumn:{DescID: 106, ColumnID: 3, IndexID: 3}
         │   │         rule: "dependents removed before index"
         │   │
         │   ├── • IndexColumn:{DescID: 106, ColumnID: 1, IndexID: 3}
@@ -106,17 +118,23 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 1 of 7;
         │   │   └── • Precedence dependency from DELETE_ONLY TemporaryIndex:{DescID: 106, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
         │   │         rule: "index drop mutation visible before cleaning up index columns"
         │   │
-        │   └── • IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 3}
+        │   ├── • IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 3}
+        │   │   │ PUBLIC → ABSENT
+        │   │   │
+        │   │   └── • Precedence dependency from DELETE_ONLY TemporaryIndex:{DescID: 106, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
+        │   │         rule: "index drop mutation visible before cleaning up index columns"
+        │   │
+        │   └── • IndexColumn:{DescID: 106, ColumnID: 3, IndexID: 3}
         │       │ PUBLIC → ABSENT
         │       │
         │       └── • Precedence dependency from DELETE_ONLY TemporaryIndex:{DescID: 106, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
         │             rule: "index drop mutation visible before cleaning up index columns"
         │
-        └── • 12 Mutation operations
+        └── • 14 Mutation operations
             │
             ├── • SetColumnName
-            │     ColumnID: 2
-            │     Name: crdb_internal_column_2_name_placeholder
+            │     ColumnID: 3
+            │     Name: crdb_internal_column_3_name_placeholder
             │     TableID: 106
             │
             ├── • RemoveColumnFromIndex
@@ -131,6 +149,13 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 1 of 7;
             │     TableID: 106
             │
             ├── • RemoveColumnFromIndex
+            │     ColumnID: 3
+            │     IndexID: 2
+            │     Kind: 2
+            │     Ordinal: 1
+            │     TableID: 106
+            │
+            ├── • RemoveColumnFromIndex
             │     ColumnID: 1
             │     IndexID: 3
             │     TableID: 106
@@ -139,10 +164,17 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 1 of 7;
             │     ColumnID: 2
             │     IndexID: 3
             │     Kind: 2
+            │     TableID: 106
+            │
+            ├── • RemoveColumnFromIndex
+            │     ColumnID: 3
+            │     IndexID: 3
+            │     Kind: 2
+            │     Ordinal: 1
             │     TableID: 106
             │
             ├── • RemoveColumnDefaultExpression
-            │     ColumnID: 2
+            │     ColumnID: 3
             │     TableID: 106
             │
             ├── • MakeIndexAbsent
@@ -161,7 +193,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 1 of 7;
             │     TableID: 106
             │
             ├── • MakeDeleteOnlyColumnAbsent
-            │     ColumnID: 2
+            │     ColumnID: 3
             │     TableID: 106
             │
             ├── • RemoveJobStateFromDescriptor

--- a/pkg/sql/schemachanger/testdata/explain_verbose/add_column.rollback_2_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/add_column.rollback_2_of_7
@@ -1,6 +1,6 @@
 /* setup */
 CREATE DATABASE db;
-CREATE TABLE db.public.tbl (i INT PRIMARY KEY);
+CREATE TABLE db.public.tbl (i INT PRIMARY KEY, k INT);
 CREATE SEQUENCE db.public.sq1;
 
 /* test */
@@ -13,21 +13,21 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 2 of 7;
     │
     ├── • Stage 1 of 2 in PostCommitNonRevertiblePhase
     │   │
-    │   ├── • 9 elements transitioning toward ABSENT
+    │   ├── • 11 elements transitioning toward ABSENT
     │   │   │
-    │   │   ├── • Column:{DescID: 106, ColumnID: 2}
+    │   │   ├── • Column:{DescID: 106, ColumnID: 3}
     │   │   │   │ WRITE_ONLY → DELETE_ONLY
     │   │   │   │
-    │   │   │   ├── • PreviousStagePrecedence dependency from WRITE_ONLY Column:{DescID: 106, ColumnID: 2}
+    │   │   │   ├── • PreviousStagePrecedence dependency from WRITE_ONLY Column:{DescID: 106, ColumnID: 3}
     │   │   │   │     rule: "Column transitions to ABSENT uphold 2-version invariant: WRITE_ONLY->DELETE_ONLY"
     │   │   │   │
-    │   │   │   └── • SameStagePrecedence dependency from ABSENT ColumnNotNull:{DescID: 106, ColumnID: 2, IndexID: 2}
+    │   │   │   └── • SameStagePrecedence dependency from ABSENT ColumnNotNull:{DescID: 106, ColumnID: 3, IndexID: 2}
     │   │   │         rule: "column constraint removed right before column reaches delete only"
     │   │   │
-    │   │   ├── • ColumnName:{DescID: 106, Name: j, ColumnID: 2}
+    │   │   ├── • ColumnName:{DescID: 106, Name: j, ColumnID: 3}
     │   │   │   │ PUBLIC → ABSENT
     │   │   │   │
-    │   │   │   └── • Precedence dependency from WRITE_ONLY Column:{DescID: 106, ColumnID: 2}
+    │   │   │   └── • Precedence dependency from WRITE_ONLY Column:{DescID: 106, ColumnID: 3}
     │   │   │         rule: "column no longer public before dependents"
     │   │   │
     │   │   ├── • PrimaryIndex:{DescID: 106, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
@@ -42,7 +42,10 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 2 of 7;
     │   │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 106, ColumnID: 1, IndexID: 2}
     │   │   │   │     rule: "dependents removed before index"
     │   │   │   │
-    │   │   │   └── • Precedence dependency from ABSENT IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 2}
+    │   │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 2}
+    │   │   │   │     rule: "dependents removed before index"
+    │   │   │   │
+    │   │   │   └── • Precedence dependency from ABSENT IndexColumn:{DescID: 106, ColumnID: 3, IndexID: 2}
     │   │   │         rule: "dependents removed before index"
     │   │   │
     │   │   ├── • IndexColumn:{DescID: 106, ColumnID: 1, IndexID: 2}
@@ -54,7 +57,13 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 2 of 7;
     │   │   ├── • IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 2}
     │   │   │   │ PUBLIC → ABSENT
     │   │   │   │
-    │   │   │   ├── • Precedence dependency from WRITE_ONLY Column:{DescID: 106, ColumnID: 2}
+    │   │   │   └── • Precedence dependency from DELETE_ONLY PrimaryIndex:{DescID: 106, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
+    │   │   │         rule: "index drop mutation visible before cleaning up index columns"
+    │   │   │
+    │   │   ├── • IndexColumn:{DescID: 106, ColumnID: 3, IndexID: 2}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from WRITE_ONLY Column:{DescID: 106, ColumnID: 3}
     │   │   │   │     rule: "column no longer public before dependents"
     │   │   │   │
     │   │   │   └── • Precedence dependency from DELETE_ONLY PrimaryIndex:{DescID: 106, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
@@ -75,26 +84,32 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 2 of 7;
     │   │   ├── • IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 3}
     │   │   │   │ PUBLIC → ABSENT
     │   │   │   │
-    │   │   │   ├── • Precedence dependency from WRITE_ONLY Column:{DescID: 106, ColumnID: 2}
+    │   │   │   └── • Precedence dependency from DELETE_ONLY TemporaryIndex:{DescID: 106, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
+    │   │   │         rule: "index drop mutation visible before cleaning up index columns"
+    │   │   │
+    │   │   ├── • IndexColumn:{DescID: 106, ColumnID: 3, IndexID: 3}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from WRITE_ONLY Column:{DescID: 106, ColumnID: 3}
     │   │   │   │     rule: "column no longer public before dependents"
     │   │   │   │
     │   │   │   └── • Precedence dependency from DELETE_ONLY TemporaryIndex:{DescID: 106, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
     │   │   │         rule: "index drop mutation visible before cleaning up index columns"
     │   │   │
-    │   │   └── • ColumnNotNull:{DescID: 106, ColumnID: 2, IndexID: 2}
+    │   │   └── • ColumnNotNull:{DescID: 106, ColumnID: 3, IndexID: 2}
     │   │       │ WRITE_ONLY → ABSENT
     │   │       │
-    │   │       ├── • PreviousStagePrecedence dependency from WRITE_ONLY ColumnNotNull:{DescID: 106, ColumnID: 2, IndexID: 2}
+    │   │       ├── • PreviousStagePrecedence dependency from WRITE_ONLY ColumnNotNull:{DescID: 106, ColumnID: 3, IndexID: 2}
     │   │       │     rule: "ColumnNotNull transitions to ABSENT uphold 2-version invariant: WRITE_ONLY->VALIDATED"
     │   │       │
-    │   │       └── • Precedence dependency from WRITE_ONLY Column:{DescID: 106, ColumnID: 2}
+    │   │       └── • Precedence dependency from WRITE_ONLY Column:{DescID: 106, ColumnID: 3}
     │   │             rule: "column no longer public before dependents"
     │   │
-    │   └── • 11 Mutation operations
+    │   └── • 13 Mutation operations
     │       │
     │       ├── • SetColumnName
-    │       │     ColumnID: 2
-    │       │     Name: crdb_internal_column_2_name_placeholder
+    │       │     ColumnID: 3
+    │       │     Name: crdb_internal_column_3_name_placeholder
     │       │     TableID: 106
     │       │
     │       ├── • RemoveColumnFromIndex
@@ -106,6 +121,13 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 2 of 7;
     │       │     ColumnID: 2
     │       │     IndexID: 2
     │       │     Kind: 2
+    │       │     TableID: 106
+    │       │
+    │       ├── • RemoveColumnFromIndex
+    │       │     ColumnID: 3
+    │       │     IndexID: 2
+    │       │     Kind: 2
+    │       │     Ordinal: 1
     │       │     TableID: 106
     │       │
     │       ├── • MakeWriteOnlyIndexDeleteOnly
@@ -123,16 +145,23 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 2 of 7;
     │       │     Kind: 2
     │       │     TableID: 106
     │       │
+    │       ├── • RemoveColumnFromIndex
+    │       │     ColumnID: 3
+    │       │     IndexID: 3
+    │       │     Kind: 2
+    │       │     Ordinal: 1
+    │       │     TableID: 106
+    │       │
     │       ├── • MakeIndexAbsent
     │       │     IndexID: 2
     │       │     TableID: 106
     │       │
     │       ├── • RemoveColumnNotNull
-    │       │     ColumnID: 2
+    │       │     ColumnID: 3
     │       │     TableID: 106
     │       │
     │       ├── • MakeWriteOnlyColumnDeleteOnly
-    │       │     ColumnID: 2
+    │       │     ColumnID: 3
     │       │     TableID: 106
     │       │
     │       ├── • SetJobStateOnDescriptor
@@ -147,47 +176,47 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 2 of 7;
         │
         ├── • 6 elements transitioning toward ABSENT
         │   │
-        │   ├── • Column:{DescID: 106, ColumnID: 2}
+        │   ├── • Column:{DescID: 106, ColumnID: 3}
         │   │   │ DELETE_ONLY → ABSENT
         │   │   │
-        │   │   ├── • PreviousStagePrecedence dependency from DELETE_ONLY Column:{DescID: 106, ColumnID: 2}
+        │   │   ├── • PreviousStagePrecedence dependency from DELETE_ONLY Column:{DescID: 106, ColumnID: 3}
         │   │   │     rule: "Column transitions to ABSENT uphold 2-version invariant: DELETE_ONLY->ABSENT"
         │   │   │
-        │   │   ├── • Precedence dependency from ABSENT ColumnName:{DescID: 106, Name: j, ColumnID: 2}
+        │   │   ├── • Precedence dependency from ABSENT ColumnName:{DescID: 106, Name: j, ColumnID: 3}
         │   │   │     rule: "dependents removed before column"
         │   │   │
-        │   │   ├── • SameStagePrecedence dependency from ABSENT ColumnType:{DescID: 106, ColumnFamilyID: 0, ColumnID: 2}
+        │   │   ├── • SameStagePrecedence dependency from ABSENT ColumnType:{DescID: 106, ColumnFamilyID: 0, ColumnID: 3}
         │   │   │     rule: "dependents removed before column"
         │   │   │     rule: "column type removed right before column when not dropping relation"
         │   │   │
-        │   │   ├── • Precedence dependency from ABSENT ColumnDefaultExpression:{DescID: 106, ColumnID: 2}
+        │   │   ├── • Precedence dependency from ABSENT ColumnDefaultExpression:{DescID: 106, ColumnID: 3}
         │   │   │     rule: "dependents removed before column"
         │   │   │
         │   │   ├── • Precedence dependency from ABSENT PrimaryIndex:{DescID: 106, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
         │   │   │     rule: "indexes containing column reach absent before column"
         │   │   │
-        │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 2}
+        │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 106, ColumnID: 3, IndexID: 2}
         │   │   │     rule: "dependents removed before column"
         │   │   │
-        │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 3}
+        │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 106, ColumnID: 3, IndexID: 3}
         │   │   │     rule: "dependents removed before column"
         │   │   │
-        │   │   └── • Precedence dependency from ABSENT ColumnNotNull:{DescID: 106, ColumnID: 2, IndexID: 2}
+        │   │   └── • Precedence dependency from ABSENT ColumnNotNull:{DescID: 106, ColumnID: 3, IndexID: 2}
         │   │         rule: "dependents removed before column"
         │   │
-        │   ├── • ColumnType:{DescID: 106, ColumnFamilyID: 0, ColumnID: 2}
+        │   ├── • ColumnType:{DescID: 106, ColumnFamilyID: 0, ColumnID: 3}
         │   │   │ PUBLIC → ABSENT
         │   │   │
-        │   │   ├── • Precedence dependency from WRITE_ONLY Column:{DescID: 106, ColumnID: 2}
+        │   │   ├── • Precedence dependency from WRITE_ONLY Column:{DescID: 106, ColumnID: 3}
         │   │   │     rule: "column no longer public before dependents"
         │   │   │
-        │   │   └── • SameStagePrecedence dependency from ABSENT ColumnDefaultExpression:{DescID: 106, ColumnID: 2}
+        │   │   └── • SameStagePrecedence dependency from ABSENT ColumnDefaultExpression:{DescID: 106, ColumnID: 3}
         │   │         rule: "column type dependents removed right before column type"
         │   │
-        │   ├── • ColumnDefaultExpression:{DescID: 106, ColumnID: 2}
+        │   ├── • ColumnDefaultExpression:{DescID: 106, ColumnID: 3}
         │   │   │ PUBLIC → ABSENT
         │   │   │
-        │   │   └── • Precedence dependency from WRITE_ONLY Column:{DescID: 106, ColumnID: 2}
+        │   │   └── • Precedence dependency from WRITE_ONLY Column:{DescID: 106, ColumnID: 3}
         │   │         rule: "column no longer public before dependents"
         │   │
         │   ├── • IndexData:{DescID: 106, IndexID: 2}
@@ -205,7 +234,10 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 2 of 7;
         │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 106, ColumnID: 1, IndexID: 3}
         │   │   │     rule: "dependents removed before index"
         │   │   │
-        │   │   └── • Precedence dependency from ABSENT IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 3}
+        │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 3}
+        │   │   │     rule: "dependents removed before index"
+        │   │   │
+        │   │   └── • Precedence dependency from ABSENT IndexColumn:{DescID: 106, ColumnID: 3, IndexID: 3}
         │   │         rule: "dependents removed before index"
         │   │
         │   └── • IndexData:{DescID: 106, IndexID: 3}
@@ -220,7 +252,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 2 of 7;
         └── • 7 Mutation operations
             │
             ├── • RemoveColumnDefaultExpression
-            │     ColumnID: 2
+            │     ColumnID: 3
             │     TableID: 106
             │
             ├── • CreateGCJobForIndex
@@ -242,7 +274,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 2 of 7;
             │     TableID: 106
             │
             ├── • MakeDeleteOnlyColumnAbsent
-            │     ColumnID: 2
+            │     ColumnID: 3
             │     TableID: 106
             │
             ├── • RemoveJobStateFromDescriptor

--- a/pkg/sql/schemachanger/testdata/explain_verbose/add_column.rollback_3_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/add_column.rollback_3_of_7
@@ -1,6 +1,6 @@
 /* setup */
 CREATE DATABASE db;
-CREATE TABLE db.public.tbl (i INT PRIMARY KEY);
+CREATE TABLE db.public.tbl (i INT PRIMARY KEY, k INT);
 CREATE SEQUENCE db.public.sq1;
 
 /* test */
@@ -13,21 +13,21 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 3 of 7;
     │
     ├── • Stage 1 of 2 in PostCommitNonRevertiblePhase
     │   │
-    │   ├── • 9 elements transitioning toward ABSENT
+    │   ├── • 11 elements transitioning toward ABSENT
     │   │   │
-    │   │   ├── • Column:{DescID: 106, ColumnID: 2}
+    │   │   ├── • Column:{DescID: 106, ColumnID: 3}
     │   │   │   │ WRITE_ONLY → DELETE_ONLY
     │   │   │   │
-    │   │   │   ├── • PreviousStagePrecedence dependency from WRITE_ONLY Column:{DescID: 106, ColumnID: 2}
+    │   │   │   ├── • PreviousStagePrecedence dependency from WRITE_ONLY Column:{DescID: 106, ColumnID: 3}
     │   │   │   │     rule: "Column transitions to ABSENT uphold 2-version invariant: WRITE_ONLY->DELETE_ONLY"
     │   │   │   │
-    │   │   │   └── • SameStagePrecedence dependency from ABSENT ColumnNotNull:{DescID: 106, ColumnID: 2, IndexID: 2}
+    │   │   │   └── • SameStagePrecedence dependency from ABSENT ColumnNotNull:{DescID: 106, ColumnID: 3, IndexID: 2}
     │   │   │         rule: "column constraint removed right before column reaches delete only"
     │   │   │
-    │   │   ├── • ColumnName:{DescID: 106, Name: j, ColumnID: 2}
+    │   │   ├── • ColumnName:{DescID: 106, Name: j, ColumnID: 3}
     │   │   │   │ PUBLIC → ABSENT
     │   │   │   │
-    │   │   │   └── • Precedence dependency from WRITE_ONLY Column:{DescID: 106, ColumnID: 2}
+    │   │   │   └── • Precedence dependency from WRITE_ONLY Column:{DescID: 106, ColumnID: 3}
     │   │   │         rule: "column no longer public before dependents"
     │   │   │
     │   │   ├── • PrimaryIndex:{DescID: 106, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
@@ -42,7 +42,10 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 3 of 7;
     │   │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 106, ColumnID: 1, IndexID: 2}
     │   │   │   │     rule: "dependents removed before index"
     │   │   │   │
-    │   │   │   └── • Precedence dependency from ABSENT IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 2}
+    │   │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 2}
+    │   │   │   │     rule: "dependents removed before index"
+    │   │   │   │
+    │   │   │   └── • Precedence dependency from ABSENT IndexColumn:{DescID: 106, ColumnID: 3, IndexID: 2}
     │   │   │         rule: "dependents removed before index"
     │   │   │
     │   │   ├── • IndexColumn:{DescID: 106, ColumnID: 1, IndexID: 2}
@@ -54,7 +57,13 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 3 of 7;
     │   │   ├── • IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 2}
     │   │   │   │ PUBLIC → ABSENT
     │   │   │   │
-    │   │   │   ├── • Precedence dependency from WRITE_ONLY Column:{DescID: 106, ColumnID: 2}
+    │   │   │   └── • Precedence dependency from DELETE_ONLY PrimaryIndex:{DescID: 106, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
+    │   │   │         rule: "index drop mutation visible before cleaning up index columns"
+    │   │   │
+    │   │   ├── • IndexColumn:{DescID: 106, ColumnID: 3, IndexID: 2}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from WRITE_ONLY Column:{DescID: 106, ColumnID: 3}
     │   │   │   │     rule: "column no longer public before dependents"
     │   │   │   │
     │   │   │   └── • Precedence dependency from DELETE_ONLY PrimaryIndex:{DescID: 106, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
@@ -75,26 +84,32 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 3 of 7;
     │   │   ├── • IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 3}
     │   │   │   │ PUBLIC → ABSENT
     │   │   │   │
-    │   │   │   ├── • Precedence dependency from WRITE_ONLY Column:{DescID: 106, ColumnID: 2}
+    │   │   │   └── • Precedence dependency from DELETE_ONLY TemporaryIndex:{DescID: 106, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
+    │   │   │         rule: "index drop mutation visible before cleaning up index columns"
+    │   │   │
+    │   │   ├── • IndexColumn:{DescID: 106, ColumnID: 3, IndexID: 3}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from WRITE_ONLY Column:{DescID: 106, ColumnID: 3}
     │   │   │   │     rule: "column no longer public before dependents"
     │   │   │   │
     │   │   │   └── • Precedence dependency from DELETE_ONLY TemporaryIndex:{DescID: 106, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
     │   │   │         rule: "index drop mutation visible before cleaning up index columns"
     │   │   │
-    │   │   └── • ColumnNotNull:{DescID: 106, ColumnID: 2, IndexID: 2}
+    │   │   └── • ColumnNotNull:{DescID: 106, ColumnID: 3, IndexID: 2}
     │   │       │ WRITE_ONLY → ABSENT
     │   │       │
-    │   │       ├── • PreviousStagePrecedence dependency from WRITE_ONLY ColumnNotNull:{DescID: 106, ColumnID: 2, IndexID: 2}
+    │   │       ├── • PreviousStagePrecedence dependency from WRITE_ONLY ColumnNotNull:{DescID: 106, ColumnID: 3, IndexID: 2}
     │   │       │     rule: "ColumnNotNull transitions to ABSENT uphold 2-version invariant: WRITE_ONLY->VALIDATED"
     │   │       │
-    │   │       └── • Precedence dependency from WRITE_ONLY Column:{DescID: 106, ColumnID: 2}
+    │   │       └── • Precedence dependency from WRITE_ONLY Column:{DescID: 106, ColumnID: 3}
     │   │             rule: "column no longer public before dependents"
     │   │
-    │   └── • 11 Mutation operations
+    │   └── • 13 Mutation operations
     │       │
     │       ├── • SetColumnName
-    │       │     ColumnID: 2
-    │       │     Name: crdb_internal_column_2_name_placeholder
+    │       │     ColumnID: 3
+    │       │     Name: crdb_internal_column_3_name_placeholder
     │       │     TableID: 106
     │       │
     │       ├── • RemoveColumnFromIndex
@@ -106,6 +121,13 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 3 of 7;
     │       │     ColumnID: 2
     │       │     IndexID: 2
     │       │     Kind: 2
+    │       │     TableID: 106
+    │       │
+    │       ├── • RemoveColumnFromIndex
+    │       │     ColumnID: 3
+    │       │     IndexID: 2
+    │       │     Kind: 2
+    │       │     Ordinal: 1
     │       │     TableID: 106
     │       │
     │       ├── • MakeWriteOnlyIndexDeleteOnly
@@ -123,16 +145,23 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 3 of 7;
     │       │     Kind: 2
     │       │     TableID: 106
     │       │
+    │       ├── • RemoveColumnFromIndex
+    │       │     ColumnID: 3
+    │       │     IndexID: 3
+    │       │     Kind: 2
+    │       │     Ordinal: 1
+    │       │     TableID: 106
+    │       │
     │       ├── • MakeIndexAbsent
     │       │     IndexID: 2
     │       │     TableID: 106
     │       │
     │       ├── • RemoveColumnNotNull
-    │       │     ColumnID: 2
+    │       │     ColumnID: 3
     │       │     TableID: 106
     │       │
     │       ├── • MakeWriteOnlyColumnDeleteOnly
-    │       │     ColumnID: 2
+    │       │     ColumnID: 3
     │       │     TableID: 106
     │       │
     │       ├── • SetJobStateOnDescriptor
@@ -147,47 +176,47 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 3 of 7;
         │
         ├── • 6 elements transitioning toward ABSENT
         │   │
-        │   ├── • Column:{DescID: 106, ColumnID: 2}
+        │   ├── • Column:{DescID: 106, ColumnID: 3}
         │   │   │ DELETE_ONLY → ABSENT
         │   │   │
-        │   │   ├── • PreviousStagePrecedence dependency from DELETE_ONLY Column:{DescID: 106, ColumnID: 2}
+        │   │   ├── • PreviousStagePrecedence dependency from DELETE_ONLY Column:{DescID: 106, ColumnID: 3}
         │   │   │     rule: "Column transitions to ABSENT uphold 2-version invariant: DELETE_ONLY->ABSENT"
         │   │   │
-        │   │   ├── • Precedence dependency from ABSENT ColumnName:{DescID: 106, Name: j, ColumnID: 2}
+        │   │   ├── • Precedence dependency from ABSENT ColumnName:{DescID: 106, Name: j, ColumnID: 3}
         │   │   │     rule: "dependents removed before column"
         │   │   │
-        │   │   ├── • SameStagePrecedence dependency from ABSENT ColumnType:{DescID: 106, ColumnFamilyID: 0, ColumnID: 2}
+        │   │   ├── • SameStagePrecedence dependency from ABSENT ColumnType:{DescID: 106, ColumnFamilyID: 0, ColumnID: 3}
         │   │   │     rule: "dependents removed before column"
         │   │   │     rule: "column type removed right before column when not dropping relation"
         │   │   │
-        │   │   ├── • Precedence dependency from ABSENT ColumnDefaultExpression:{DescID: 106, ColumnID: 2}
+        │   │   ├── • Precedence dependency from ABSENT ColumnDefaultExpression:{DescID: 106, ColumnID: 3}
         │   │   │     rule: "dependents removed before column"
         │   │   │
         │   │   ├── • Precedence dependency from ABSENT PrimaryIndex:{DescID: 106, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
         │   │   │     rule: "indexes containing column reach absent before column"
         │   │   │
-        │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 2}
+        │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 106, ColumnID: 3, IndexID: 2}
         │   │   │     rule: "dependents removed before column"
         │   │   │
-        │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 3}
+        │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 106, ColumnID: 3, IndexID: 3}
         │   │   │     rule: "dependents removed before column"
         │   │   │
-        │   │   └── • Precedence dependency from ABSENT ColumnNotNull:{DescID: 106, ColumnID: 2, IndexID: 2}
+        │   │   └── • Precedence dependency from ABSENT ColumnNotNull:{DescID: 106, ColumnID: 3, IndexID: 2}
         │   │         rule: "dependents removed before column"
         │   │
-        │   ├── • ColumnType:{DescID: 106, ColumnFamilyID: 0, ColumnID: 2}
+        │   ├── • ColumnType:{DescID: 106, ColumnFamilyID: 0, ColumnID: 3}
         │   │   │ PUBLIC → ABSENT
         │   │   │
-        │   │   ├── • Precedence dependency from WRITE_ONLY Column:{DescID: 106, ColumnID: 2}
+        │   │   ├── • Precedence dependency from WRITE_ONLY Column:{DescID: 106, ColumnID: 3}
         │   │   │     rule: "column no longer public before dependents"
         │   │   │
-        │   │   └── • SameStagePrecedence dependency from ABSENT ColumnDefaultExpression:{DescID: 106, ColumnID: 2}
+        │   │   └── • SameStagePrecedence dependency from ABSENT ColumnDefaultExpression:{DescID: 106, ColumnID: 3}
         │   │         rule: "column type dependents removed right before column type"
         │   │
-        │   ├── • ColumnDefaultExpression:{DescID: 106, ColumnID: 2}
+        │   ├── • ColumnDefaultExpression:{DescID: 106, ColumnID: 3}
         │   │   │ PUBLIC → ABSENT
         │   │   │
-        │   │   └── • Precedence dependency from WRITE_ONLY Column:{DescID: 106, ColumnID: 2}
+        │   │   └── • Precedence dependency from WRITE_ONLY Column:{DescID: 106, ColumnID: 3}
         │   │         rule: "column no longer public before dependents"
         │   │
         │   ├── • IndexData:{DescID: 106, IndexID: 2}
@@ -205,7 +234,10 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 3 of 7;
         │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 106, ColumnID: 1, IndexID: 3}
         │   │   │     rule: "dependents removed before index"
         │   │   │
-        │   │   └── • Precedence dependency from ABSENT IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 3}
+        │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 3}
+        │   │   │     rule: "dependents removed before index"
+        │   │   │
+        │   │   └── • Precedence dependency from ABSENT IndexColumn:{DescID: 106, ColumnID: 3, IndexID: 3}
         │   │         rule: "dependents removed before index"
         │   │
         │   └── • IndexData:{DescID: 106, IndexID: 3}
@@ -220,7 +252,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 3 of 7;
         └── • 7 Mutation operations
             │
             ├── • RemoveColumnDefaultExpression
-            │     ColumnID: 2
+            │     ColumnID: 3
             │     TableID: 106
             │
             ├── • CreateGCJobForIndex
@@ -242,7 +274,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 3 of 7;
             │     TableID: 106
             │
             ├── • MakeDeleteOnlyColumnAbsent
-            │     ColumnID: 2
+            │     ColumnID: 3
             │     TableID: 106
             │
             ├── • RemoveJobStateFromDescriptor

--- a/pkg/sql/schemachanger/testdata/explain_verbose/add_column.rollback_4_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/add_column.rollback_4_of_7
@@ -1,6 +1,6 @@
 /* setup */
 CREATE DATABASE db;
-CREATE TABLE db.public.tbl (i INT PRIMARY KEY);
+CREATE TABLE db.public.tbl (i INT PRIMARY KEY, k INT);
 CREATE SEQUENCE db.public.sq1;
 
 /* test */
@@ -13,21 +13,21 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 4 of 7;
     │
     ├── • Stage 1 of 2 in PostCommitNonRevertiblePhase
     │   │
-    │   ├── • 9 elements transitioning toward ABSENT
+    │   ├── • 11 elements transitioning toward ABSENT
     │   │   │
-    │   │   ├── • Column:{DescID: 106, ColumnID: 2}
+    │   │   ├── • Column:{DescID: 106, ColumnID: 3}
     │   │   │   │ WRITE_ONLY → DELETE_ONLY
     │   │   │   │
-    │   │   │   ├── • PreviousStagePrecedence dependency from WRITE_ONLY Column:{DescID: 106, ColumnID: 2}
+    │   │   │   ├── • PreviousStagePrecedence dependency from WRITE_ONLY Column:{DescID: 106, ColumnID: 3}
     │   │   │   │     rule: "Column transitions to ABSENT uphold 2-version invariant: WRITE_ONLY->DELETE_ONLY"
     │   │   │   │
-    │   │   │   └── • SameStagePrecedence dependency from ABSENT ColumnNotNull:{DescID: 106, ColumnID: 2, IndexID: 2}
+    │   │   │   └── • SameStagePrecedence dependency from ABSENT ColumnNotNull:{DescID: 106, ColumnID: 3, IndexID: 2}
     │   │   │         rule: "column constraint removed right before column reaches delete only"
     │   │   │
-    │   │   ├── • ColumnName:{DescID: 106, Name: j, ColumnID: 2}
+    │   │   ├── • ColumnName:{DescID: 106, Name: j, ColumnID: 3}
     │   │   │   │ PUBLIC → ABSENT
     │   │   │   │
-    │   │   │   └── • Precedence dependency from WRITE_ONLY Column:{DescID: 106, ColumnID: 2}
+    │   │   │   └── • Precedence dependency from WRITE_ONLY Column:{DescID: 106, ColumnID: 3}
     │   │   │         rule: "column no longer public before dependents"
     │   │   │
     │   │   ├── • PrimaryIndex:{DescID: 106, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
@@ -42,7 +42,10 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 4 of 7;
     │   │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 106, ColumnID: 1, IndexID: 2}
     │   │   │   │     rule: "dependents removed before index"
     │   │   │   │
-    │   │   │   └── • Precedence dependency from ABSENT IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 2}
+    │   │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 2}
+    │   │   │   │     rule: "dependents removed before index"
+    │   │   │   │
+    │   │   │   └── • Precedence dependency from ABSENT IndexColumn:{DescID: 106, ColumnID: 3, IndexID: 2}
     │   │   │         rule: "dependents removed before index"
     │   │   │
     │   │   ├── • IndexColumn:{DescID: 106, ColumnID: 1, IndexID: 2}
@@ -54,7 +57,13 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 4 of 7;
     │   │   ├── • IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 2}
     │   │   │   │ PUBLIC → ABSENT
     │   │   │   │
-    │   │   │   ├── • Precedence dependency from WRITE_ONLY Column:{DescID: 106, ColumnID: 2}
+    │   │   │   └── • Precedence dependency from DELETE_ONLY PrimaryIndex:{DescID: 106, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
+    │   │   │         rule: "index drop mutation visible before cleaning up index columns"
+    │   │   │
+    │   │   ├── • IndexColumn:{DescID: 106, ColumnID: 3, IndexID: 2}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from WRITE_ONLY Column:{DescID: 106, ColumnID: 3}
     │   │   │   │     rule: "column no longer public before dependents"
     │   │   │   │
     │   │   │   └── • Precedence dependency from DELETE_ONLY PrimaryIndex:{DescID: 106, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
@@ -75,26 +84,32 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 4 of 7;
     │   │   ├── • IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 3}
     │   │   │   │ PUBLIC → ABSENT
     │   │   │   │
-    │   │   │   ├── • Precedence dependency from WRITE_ONLY Column:{DescID: 106, ColumnID: 2}
+    │   │   │   └── • Precedence dependency from DELETE_ONLY TemporaryIndex:{DescID: 106, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
+    │   │   │         rule: "index drop mutation visible before cleaning up index columns"
+    │   │   │
+    │   │   ├── • IndexColumn:{DescID: 106, ColumnID: 3, IndexID: 3}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from WRITE_ONLY Column:{DescID: 106, ColumnID: 3}
     │   │   │   │     rule: "column no longer public before dependents"
     │   │   │   │
     │   │   │   └── • Precedence dependency from DELETE_ONLY TemporaryIndex:{DescID: 106, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
     │   │   │         rule: "index drop mutation visible before cleaning up index columns"
     │   │   │
-    │   │   └── • ColumnNotNull:{DescID: 106, ColumnID: 2, IndexID: 2}
+    │   │   └── • ColumnNotNull:{DescID: 106, ColumnID: 3, IndexID: 2}
     │   │       │ WRITE_ONLY → ABSENT
     │   │       │
-    │   │       ├── • PreviousStagePrecedence dependency from WRITE_ONLY ColumnNotNull:{DescID: 106, ColumnID: 2, IndexID: 2}
+    │   │       ├── • PreviousStagePrecedence dependency from WRITE_ONLY ColumnNotNull:{DescID: 106, ColumnID: 3, IndexID: 2}
     │   │       │     rule: "ColumnNotNull transitions to ABSENT uphold 2-version invariant: WRITE_ONLY->VALIDATED"
     │   │       │
-    │   │       └── • Precedence dependency from WRITE_ONLY Column:{DescID: 106, ColumnID: 2}
+    │   │       └── • Precedence dependency from WRITE_ONLY Column:{DescID: 106, ColumnID: 3}
     │   │             rule: "column no longer public before dependents"
     │   │
-    │   └── • 11 Mutation operations
+    │   └── • 13 Mutation operations
     │       │
     │       ├── • SetColumnName
-    │       │     ColumnID: 2
-    │       │     Name: crdb_internal_column_2_name_placeholder
+    │       │     ColumnID: 3
+    │       │     Name: crdb_internal_column_3_name_placeholder
     │       │     TableID: 106
     │       │
     │       ├── • RemoveColumnFromIndex
@@ -106,6 +121,13 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 4 of 7;
     │       │     ColumnID: 2
     │       │     IndexID: 2
     │       │     Kind: 2
+    │       │     TableID: 106
+    │       │
+    │       ├── • RemoveColumnFromIndex
+    │       │     ColumnID: 3
+    │       │     IndexID: 2
+    │       │     Kind: 2
+    │       │     Ordinal: 1
     │       │     TableID: 106
     │       │
     │       ├── • MakeWriteOnlyIndexDeleteOnly
@@ -123,16 +145,23 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 4 of 7;
     │       │     Kind: 2
     │       │     TableID: 106
     │       │
+    │       ├── • RemoveColumnFromIndex
+    │       │     ColumnID: 3
+    │       │     IndexID: 3
+    │       │     Kind: 2
+    │       │     Ordinal: 1
+    │       │     TableID: 106
+    │       │
     │       ├── • MakeIndexAbsent
     │       │     IndexID: 2
     │       │     TableID: 106
     │       │
     │       ├── • RemoveColumnNotNull
-    │       │     ColumnID: 2
+    │       │     ColumnID: 3
     │       │     TableID: 106
     │       │
     │       ├── • MakeWriteOnlyColumnDeleteOnly
-    │       │     ColumnID: 2
+    │       │     ColumnID: 3
     │       │     TableID: 106
     │       │
     │       ├── • SetJobStateOnDescriptor
@@ -147,47 +176,47 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 4 of 7;
         │
         ├── • 6 elements transitioning toward ABSENT
         │   │
-        │   ├── • Column:{DescID: 106, ColumnID: 2}
+        │   ├── • Column:{DescID: 106, ColumnID: 3}
         │   │   │ DELETE_ONLY → ABSENT
         │   │   │
-        │   │   ├── • PreviousStagePrecedence dependency from DELETE_ONLY Column:{DescID: 106, ColumnID: 2}
+        │   │   ├── • PreviousStagePrecedence dependency from DELETE_ONLY Column:{DescID: 106, ColumnID: 3}
         │   │   │     rule: "Column transitions to ABSENT uphold 2-version invariant: DELETE_ONLY->ABSENT"
         │   │   │
-        │   │   ├── • Precedence dependency from ABSENT ColumnName:{DescID: 106, Name: j, ColumnID: 2}
+        │   │   ├── • Precedence dependency from ABSENT ColumnName:{DescID: 106, Name: j, ColumnID: 3}
         │   │   │     rule: "dependents removed before column"
         │   │   │
-        │   │   ├── • SameStagePrecedence dependency from ABSENT ColumnType:{DescID: 106, ColumnFamilyID: 0, ColumnID: 2}
+        │   │   ├── • SameStagePrecedence dependency from ABSENT ColumnType:{DescID: 106, ColumnFamilyID: 0, ColumnID: 3}
         │   │   │     rule: "dependents removed before column"
         │   │   │     rule: "column type removed right before column when not dropping relation"
         │   │   │
-        │   │   ├── • Precedence dependency from ABSENT ColumnDefaultExpression:{DescID: 106, ColumnID: 2}
+        │   │   ├── • Precedence dependency from ABSENT ColumnDefaultExpression:{DescID: 106, ColumnID: 3}
         │   │   │     rule: "dependents removed before column"
         │   │   │
         │   │   ├── • Precedence dependency from ABSENT PrimaryIndex:{DescID: 106, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
         │   │   │     rule: "indexes containing column reach absent before column"
         │   │   │
-        │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 2}
+        │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 106, ColumnID: 3, IndexID: 2}
         │   │   │     rule: "dependents removed before column"
         │   │   │
-        │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 3}
+        │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 106, ColumnID: 3, IndexID: 3}
         │   │   │     rule: "dependents removed before column"
         │   │   │
-        │   │   └── • Precedence dependency from ABSENT ColumnNotNull:{DescID: 106, ColumnID: 2, IndexID: 2}
+        │   │   └── • Precedence dependency from ABSENT ColumnNotNull:{DescID: 106, ColumnID: 3, IndexID: 2}
         │   │         rule: "dependents removed before column"
         │   │
-        │   ├── • ColumnType:{DescID: 106, ColumnFamilyID: 0, ColumnID: 2}
+        │   ├── • ColumnType:{DescID: 106, ColumnFamilyID: 0, ColumnID: 3}
         │   │   │ PUBLIC → ABSENT
         │   │   │
-        │   │   ├── • Precedence dependency from WRITE_ONLY Column:{DescID: 106, ColumnID: 2}
+        │   │   ├── • Precedence dependency from WRITE_ONLY Column:{DescID: 106, ColumnID: 3}
         │   │   │     rule: "column no longer public before dependents"
         │   │   │
-        │   │   └── • SameStagePrecedence dependency from ABSENT ColumnDefaultExpression:{DescID: 106, ColumnID: 2}
+        │   │   └── • SameStagePrecedence dependency from ABSENT ColumnDefaultExpression:{DescID: 106, ColumnID: 3}
         │   │         rule: "column type dependents removed right before column type"
         │   │
-        │   ├── • ColumnDefaultExpression:{DescID: 106, ColumnID: 2}
+        │   ├── • ColumnDefaultExpression:{DescID: 106, ColumnID: 3}
         │   │   │ PUBLIC → ABSENT
         │   │   │
-        │   │   └── • Precedence dependency from WRITE_ONLY Column:{DescID: 106, ColumnID: 2}
+        │   │   └── • Precedence dependency from WRITE_ONLY Column:{DescID: 106, ColumnID: 3}
         │   │         rule: "column no longer public before dependents"
         │   │
         │   ├── • IndexData:{DescID: 106, IndexID: 2}
@@ -205,7 +234,10 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 4 of 7;
         │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 106, ColumnID: 1, IndexID: 3}
         │   │   │     rule: "dependents removed before index"
         │   │   │
-        │   │   └── • Precedence dependency from ABSENT IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 3}
+        │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 3}
+        │   │   │     rule: "dependents removed before index"
+        │   │   │
+        │   │   └── • Precedence dependency from ABSENT IndexColumn:{DescID: 106, ColumnID: 3, IndexID: 3}
         │   │         rule: "dependents removed before index"
         │   │
         │   └── • IndexData:{DescID: 106, IndexID: 3}
@@ -220,7 +252,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 4 of 7;
         └── • 7 Mutation operations
             │
             ├── • RemoveColumnDefaultExpression
-            │     ColumnID: 2
+            │     ColumnID: 3
             │     TableID: 106
             │
             ├── • CreateGCJobForIndex
@@ -242,7 +274,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 4 of 7;
             │     TableID: 106
             │
             ├── • MakeDeleteOnlyColumnAbsent
-            │     ColumnID: 2
+            │     ColumnID: 3
             │     TableID: 106
             │
             ├── • RemoveJobStateFromDescriptor

--- a/pkg/sql/schemachanger/testdata/explain_verbose/add_column.rollback_5_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/add_column.rollback_5_of_7
@@ -1,6 +1,6 @@
 /* setup */
 CREATE DATABASE db;
-CREATE TABLE db.public.tbl (i INT PRIMARY KEY);
+CREATE TABLE db.public.tbl (i INT PRIMARY KEY, k INT);
 CREATE SEQUENCE db.public.sq1;
 
 /* test */
@@ -13,21 +13,21 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 5 of 7;
     │
     ├── • Stage 1 of 2 in PostCommitNonRevertiblePhase
     │   │
-    │   ├── • 9 elements transitioning toward ABSENT
+    │   ├── • 11 elements transitioning toward ABSENT
     │   │   │
-    │   │   ├── • Column:{DescID: 106, ColumnID: 2}
+    │   │   ├── • Column:{DescID: 106, ColumnID: 3}
     │   │   │   │ WRITE_ONLY → DELETE_ONLY
     │   │   │   │
-    │   │   │   ├── • PreviousStagePrecedence dependency from WRITE_ONLY Column:{DescID: 106, ColumnID: 2}
+    │   │   │   ├── • PreviousStagePrecedence dependency from WRITE_ONLY Column:{DescID: 106, ColumnID: 3}
     │   │   │   │     rule: "Column transitions to ABSENT uphold 2-version invariant: WRITE_ONLY->DELETE_ONLY"
     │   │   │   │
-    │   │   │   └── • SameStagePrecedence dependency from ABSENT ColumnNotNull:{DescID: 106, ColumnID: 2, IndexID: 2}
+    │   │   │   └── • SameStagePrecedence dependency from ABSENT ColumnNotNull:{DescID: 106, ColumnID: 3, IndexID: 2}
     │   │   │         rule: "column constraint removed right before column reaches delete only"
     │   │   │
-    │   │   ├── • ColumnName:{DescID: 106, Name: j, ColumnID: 2}
+    │   │   ├── • ColumnName:{DescID: 106, Name: j, ColumnID: 3}
     │   │   │   │ PUBLIC → ABSENT
     │   │   │   │
-    │   │   │   └── • Precedence dependency from WRITE_ONLY Column:{DescID: 106, ColumnID: 2}
+    │   │   │   └── • Precedence dependency from WRITE_ONLY Column:{DescID: 106, ColumnID: 3}
     │   │   │         rule: "column no longer public before dependents"
     │   │   │
     │   │   ├── • PrimaryIndex:{DescID: 106, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
@@ -45,7 +45,13 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 5 of 7;
     │   │   ├── • IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 2}
     │   │   │   │ PUBLIC → ABSENT
     │   │   │   │
-    │   │   │   ├── • Precedence dependency from WRITE_ONLY Column:{DescID: 106, ColumnID: 2}
+    │   │   │   └── • Precedence dependency from DELETE_ONLY PrimaryIndex:{DescID: 106, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
+    │   │   │         rule: "index drop mutation visible before cleaning up index columns"
+    │   │   │
+    │   │   ├── • IndexColumn:{DescID: 106, ColumnID: 3, IndexID: 2}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from WRITE_ONLY Column:{DescID: 106, ColumnID: 3}
     │   │   │   │     rule: "column no longer public before dependents"
     │   │   │   │
     │   │   │   └── • Precedence dependency from DELETE_ONLY PrimaryIndex:{DescID: 106, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
@@ -66,26 +72,32 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 5 of 7;
     │   │   ├── • IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 3}
     │   │   │   │ PUBLIC → ABSENT
     │   │   │   │
-    │   │   │   ├── • Precedence dependency from WRITE_ONLY Column:{DescID: 106, ColumnID: 2}
+    │   │   │   └── • Precedence dependency from DELETE_ONLY TemporaryIndex:{DescID: 106, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
+    │   │   │         rule: "index drop mutation visible before cleaning up index columns"
+    │   │   │
+    │   │   ├── • IndexColumn:{DescID: 106, ColumnID: 3, IndexID: 3}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from WRITE_ONLY Column:{DescID: 106, ColumnID: 3}
     │   │   │   │     rule: "column no longer public before dependents"
     │   │   │   │
     │   │   │   └── • Precedence dependency from DELETE_ONLY TemporaryIndex:{DescID: 106, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
     │   │   │         rule: "index drop mutation visible before cleaning up index columns"
     │   │   │
-    │   │   └── • ColumnNotNull:{DescID: 106, ColumnID: 2, IndexID: 2}
+    │   │   └── • ColumnNotNull:{DescID: 106, ColumnID: 3, IndexID: 2}
     │   │       │ WRITE_ONLY → ABSENT
     │   │       │
-    │   │       ├── • PreviousStagePrecedence dependency from WRITE_ONLY ColumnNotNull:{DescID: 106, ColumnID: 2, IndexID: 2}
+    │   │       ├── • PreviousStagePrecedence dependency from WRITE_ONLY ColumnNotNull:{DescID: 106, ColumnID: 3, IndexID: 2}
     │   │       │     rule: "ColumnNotNull transitions to ABSENT uphold 2-version invariant: WRITE_ONLY->VALIDATED"
     │   │       │
-    │   │       └── • Precedence dependency from WRITE_ONLY Column:{DescID: 106, ColumnID: 2}
+    │   │       └── • Precedence dependency from WRITE_ONLY Column:{DescID: 106, ColumnID: 3}
     │   │             rule: "column no longer public before dependents"
     │   │
-    │   └── • 11 Mutation operations
+    │   └── • 13 Mutation operations
     │       │
     │       ├── • SetColumnName
-    │       │     ColumnID: 2
-    │       │     Name: crdb_internal_column_2_name_placeholder
+    │       │     ColumnID: 3
+    │       │     Name: crdb_internal_column_3_name_placeholder
     │       │     TableID: 106
     │       │
     │       ├── • MakeWriteOnlyIndexDeleteOnly
@@ -103,6 +115,13 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 5 of 7;
     │       │     Kind: 2
     │       │     TableID: 106
     │       │
+    │       ├── • RemoveColumnFromIndex
+    │       │     ColumnID: 3
+    │       │     IndexID: 3
+    │       │     Kind: 2
+    │       │     Ordinal: 1
+    │       │     TableID: 106
+    │       │
     │       ├── • MakeWriteOnlyIndexDeleteOnly
     │       │     IndexID: 2
     │       │     TableID: 106
@@ -116,14 +135,21 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 5 of 7;
     │       │     ColumnID: 2
     │       │     IndexID: 2
     │       │     Kind: 2
+    │       │     TableID: 106
+    │       │
+    │       ├── • RemoveColumnFromIndex
+    │       │     ColumnID: 3
+    │       │     IndexID: 2
+    │       │     Kind: 2
+    │       │     Ordinal: 1
     │       │     TableID: 106
     │       │
     │       ├── • RemoveColumnNotNull
-    │       │     ColumnID: 2
+    │       │     ColumnID: 3
     │       │     TableID: 106
     │       │
     │       ├── • MakeWriteOnlyColumnDeleteOnly
-    │       │     ColumnID: 2
+    │       │     ColumnID: 3
     │       │     TableID: 106
     │       │
     │       ├── • SetJobStateOnDescriptor
@@ -138,47 +164,47 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 5 of 7;
         │
         ├── • 7 elements transitioning toward ABSENT
         │   │
-        │   ├── • Column:{DescID: 106, ColumnID: 2}
+        │   ├── • Column:{DescID: 106, ColumnID: 3}
         │   │   │ DELETE_ONLY → ABSENT
         │   │   │
-        │   │   ├── • PreviousStagePrecedence dependency from DELETE_ONLY Column:{DescID: 106, ColumnID: 2}
+        │   │   ├── • PreviousStagePrecedence dependency from DELETE_ONLY Column:{DescID: 106, ColumnID: 3}
         │   │   │     rule: "Column transitions to ABSENT uphold 2-version invariant: DELETE_ONLY->ABSENT"
         │   │   │
-        │   │   ├── • Precedence dependency from ABSENT ColumnName:{DescID: 106, Name: j, ColumnID: 2}
+        │   │   ├── • Precedence dependency from ABSENT ColumnName:{DescID: 106, Name: j, ColumnID: 3}
         │   │   │     rule: "dependents removed before column"
         │   │   │
-        │   │   ├── • SameStagePrecedence dependency from ABSENT ColumnType:{DescID: 106, ColumnFamilyID: 0, ColumnID: 2}
+        │   │   ├── • SameStagePrecedence dependency from ABSENT ColumnType:{DescID: 106, ColumnFamilyID: 0, ColumnID: 3}
         │   │   │     rule: "dependents removed before column"
         │   │   │     rule: "column type removed right before column when not dropping relation"
         │   │   │
-        │   │   ├── • Precedence dependency from ABSENT ColumnDefaultExpression:{DescID: 106, ColumnID: 2}
+        │   │   ├── • Precedence dependency from ABSENT ColumnDefaultExpression:{DescID: 106, ColumnID: 3}
         │   │   │     rule: "dependents removed before column"
         │   │   │
         │   │   ├── • Precedence dependency from ABSENT PrimaryIndex:{DescID: 106, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
         │   │   │     rule: "indexes containing column reach absent before column"
         │   │   │
-        │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 2}
+        │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 106, ColumnID: 3, IndexID: 2}
         │   │   │     rule: "dependents removed before column"
         │   │   │
-        │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 3}
+        │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 106, ColumnID: 3, IndexID: 3}
         │   │   │     rule: "dependents removed before column"
         │   │   │
-        │   │   └── • Precedence dependency from ABSENT ColumnNotNull:{DescID: 106, ColumnID: 2, IndexID: 2}
+        │   │   └── • Precedence dependency from ABSENT ColumnNotNull:{DescID: 106, ColumnID: 3, IndexID: 2}
         │   │         rule: "dependents removed before column"
         │   │
-        │   ├── • ColumnType:{DescID: 106, ColumnFamilyID: 0, ColumnID: 2}
+        │   ├── • ColumnType:{DescID: 106, ColumnFamilyID: 0, ColumnID: 3}
         │   │   │ PUBLIC → ABSENT
         │   │   │
-        │   │   ├── • Precedence dependency from WRITE_ONLY Column:{DescID: 106, ColumnID: 2}
+        │   │   ├── • Precedence dependency from WRITE_ONLY Column:{DescID: 106, ColumnID: 3}
         │   │   │     rule: "column no longer public before dependents"
         │   │   │
-        │   │   └── • SameStagePrecedence dependency from ABSENT ColumnDefaultExpression:{DescID: 106, ColumnID: 2}
+        │   │   └── • SameStagePrecedence dependency from ABSENT ColumnDefaultExpression:{DescID: 106, ColumnID: 3}
         │   │         rule: "column type dependents removed right before column type"
         │   │
-        │   ├── • ColumnDefaultExpression:{DescID: 106, ColumnID: 2}
+        │   ├── • ColumnDefaultExpression:{DescID: 106, ColumnID: 3}
         │   │   │ PUBLIC → ABSENT
         │   │   │
-        │   │   └── • Precedence dependency from WRITE_ONLY Column:{DescID: 106, ColumnID: 2}
+        │   │   └── • Precedence dependency from WRITE_ONLY Column:{DescID: 106, ColumnID: 3}
         │   │         rule: "column no longer public before dependents"
         │   │
         │   ├── • PrimaryIndex:{DescID: 106, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
@@ -193,7 +219,10 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 5 of 7;
         │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 106, ColumnID: 1, IndexID: 2}
         │   │   │     rule: "dependents removed before index"
         │   │   │
-        │   │   └── • Precedence dependency from ABSENT IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 2}
+        │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 2}
+        │   │   │     rule: "dependents removed before index"
+        │   │   │
+        │   │   └── • Precedence dependency from ABSENT IndexColumn:{DescID: 106, ColumnID: 3, IndexID: 2}
         │   │         rule: "dependents removed before index"
         │   │
         │   ├── • IndexData:{DescID: 106, IndexID: 2}
@@ -211,7 +240,10 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 5 of 7;
         │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 106, ColumnID: 1, IndexID: 3}
         │   │   │     rule: "dependents removed before index"
         │   │   │
-        │   │   └── • Precedence dependency from ABSENT IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 3}
+        │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 3}
+        │   │   │     rule: "dependents removed before index"
+        │   │   │
+        │   │   └── • Precedence dependency from ABSENT IndexColumn:{DescID: 106, ColumnID: 3, IndexID: 3}
         │   │         rule: "dependents removed before index"
         │   │
         │   └── • IndexData:{DescID: 106, IndexID: 3}
@@ -226,7 +258,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 5 of 7;
         └── • 8 Mutation operations
             │
             ├── • RemoveColumnDefaultExpression
-            │     ColumnID: 2
+            │     ColumnID: 3
             │     TableID: 106
             │
             ├── • MakeIndexAbsent
@@ -252,7 +284,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 5 of 7;
             │     TableID: 106
             │
             ├── • MakeDeleteOnlyColumnAbsent
-            │     ColumnID: 2
+            │     ColumnID: 3
             │     TableID: 106
             │
             ├── • RemoveJobStateFromDescriptor

--- a/pkg/sql/schemachanger/testdata/explain_verbose/add_column.rollback_6_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/add_column.rollback_6_of_7
@@ -1,6 +1,6 @@
 /* setup */
 CREATE DATABASE db;
-CREATE TABLE db.public.tbl (i INT PRIMARY KEY);
+CREATE TABLE db.public.tbl (i INT PRIMARY KEY, k INT);
 CREATE SEQUENCE db.public.sq1;
 
 /* test */
@@ -13,21 +13,21 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 6 of 7;
     │
     ├── • Stage 1 of 2 in PostCommitNonRevertiblePhase
     │   │
-    │   ├── • 9 elements transitioning toward ABSENT
+    │   ├── • 11 elements transitioning toward ABSENT
     │   │   │
-    │   │   ├── • Column:{DescID: 106, ColumnID: 2}
+    │   │   ├── • Column:{DescID: 106, ColumnID: 3}
     │   │   │   │ WRITE_ONLY → DELETE_ONLY
     │   │   │   │
-    │   │   │   ├── • PreviousStagePrecedence dependency from WRITE_ONLY Column:{DescID: 106, ColumnID: 2}
+    │   │   │   ├── • PreviousStagePrecedence dependency from WRITE_ONLY Column:{DescID: 106, ColumnID: 3}
     │   │   │   │     rule: "Column transitions to ABSENT uphold 2-version invariant: WRITE_ONLY->DELETE_ONLY"
     │   │   │   │
-    │   │   │   └── • SameStagePrecedence dependency from ABSENT ColumnNotNull:{DescID: 106, ColumnID: 2, IndexID: 2}
+    │   │   │   └── • SameStagePrecedence dependency from ABSENT ColumnNotNull:{DescID: 106, ColumnID: 3, IndexID: 2}
     │   │   │         rule: "column constraint removed right before column reaches delete only"
     │   │   │
-    │   │   ├── • ColumnName:{DescID: 106, Name: j, ColumnID: 2}
+    │   │   ├── • ColumnName:{DescID: 106, Name: j, ColumnID: 3}
     │   │   │   │ PUBLIC → ABSENT
     │   │   │   │
-    │   │   │   └── • Precedence dependency from WRITE_ONLY Column:{DescID: 106, ColumnID: 2}
+    │   │   │   └── • Precedence dependency from WRITE_ONLY Column:{DescID: 106, ColumnID: 3}
     │   │   │         rule: "column no longer public before dependents"
     │   │   │
     │   │   ├── • PrimaryIndex:{DescID: 106, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
@@ -45,7 +45,13 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 6 of 7;
     │   │   ├── • IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 2}
     │   │   │   │ PUBLIC → ABSENT
     │   │   │   │
-    │   │   │   ├── • Precedence dependency from WRITE_ONLY Column:{DescID: 106, ColumnID: 2}
+    │   │   │   └── • Precedence dependency from DELETE_ONLY PrimaryIndex:{DescID: 106, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
+    │   │   │         rule: "index drop mutation visible before cleaning up index columns"
+    │   │   │
+    │   │   ├── • IndexColumn:{DescID: 106, ColumnID: 3, IndexID: 2}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from WRITE_ONLY Column:{DescID: 106, ColumnID: 3}
     │   │   │   │     rule: "column no longer public before dependents"
     │   │   │   │
     │   │   │   └── • Precedence dependency from DELETE_ONLY PrimaryIndex:{DescID: 106, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
@@ -66,26 +72,32 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 6 of 7;
     │   │   ├── • IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 3}
     │   │   │   │ PUBLIC → ABSENT
     │   │   │   │
-    │   │   │   ├── • Precedence dependency from WRITE_ONLY Column:{DescID: 106, ColumnID: 2}
+    │   │   │   └── • Precedence dependency from DELETE_ONLY TemporaryIndex:{DescID: 106, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
+    │   │   │         rule: "index drop mutation visible before cleaning up index columns"
+    │   │   │
+    │   │   ├── • IndexColumn:{DescID: 106, ColumnID: 3, IndexID: 3}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from WRITE_ONLY Column:{DescID: 106, ColumnID: 3}
     │   │   │   │     rule: "column no longer public before dependents"
     │   │   │   │
     │   │   │   └── • Precedence dependency from DELETE_ONLY TemporaryIndex:{DescID: 106, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
     │   │   │         rule: "index drop mutation visible before cleaning up index columns"
     │   │   │
-    │   │   └── • ColumnNotNull:{DescID: 106, ColumnID: 2, IndexID: 2}
+    │   │   └── • ColumnNotNull:{DescID: 106, ColumnID: 3, IndexID: 2}
     │   │       │ WRITE_ONLY → ABSENT
     │   │       │
-    │   │       ├── • PreviousStagePrecedence dependency from WRITE_ONLY ColumnNotNull:{DescID: 106, ColumnID: 2, IndexID: 2}
+    │   │       ├── • PreviousStagePrecedence dependency from WRITE_ONLY ColumnNotNull:{DescID: 106, ColumnID: 3, IndexID: 2}
     │   │       │     rule: "ColumnNotNull transitions to ABSENT uphold 2-version invariant: WRITE_ONLY->VALIDATED"
     │   │       │
-    │   │       └── • Precedence dependency from WRITE_ONLY Column:{DescID: 106, ColumnID: 2}
+    │   │       └── • Precedence dependency from WRITE_ONLY Column:{DescID: 106, ColumnID: 3}
     │   │             rule: "column no longer public before dependents"
     │   │
-    │   └── • 11 Mutation operations
+    │   └── • 13 Mutation operations
     │       │
     │       ├── • SetColumnName
-    │       │     ColumnID: 2
-    │       │     Name: crdb_internal_column_2_name_placeholder
+    │       │     ColumnID: 3
+    │       │     Name: crdb_internal_column_3_name_placeholder
     │       │     TableID: 106
     │       │
     │       ├── • MakeWriteOnlyIndexDeleteOnly
@@ -103,6 +115,13 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 6 of 7;
     │       │     Kind: 2
     │       │     TableID: 106
     │       │
+    │       ├── • RemoveColumnFromIndex
+    │       │     ColumnID: 3
+    │       │     IndexID: 3
+    │       │     Kind: 2
+    │       │     Ordinal: 1
+    │       │     TableID: 106
+    │       │
     │       ├── • MakeWriteOnlyIndexDeleteOnly
     │       │     IndexID: 2
     │       │     TableID: 106
@@ -116,14 +135,21 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 6 of 7;
     │       │     ColumnID: 2
     │       │     IndexID: 2
     │       │     Kind: 2
+    │       │     TableID: 106
+    │       │
+    │       ├── • RemoveColumnFromIndex
+    │       │     ColumnID: 3
+    │       │     IndexID: 2
+    │       │     Kind: 2
+    │       │     Ordinal: 1
     │       │     TableID: 106
     │       │
     │       ├── • RemoveColumnNotNull
-    │       │     ColumnID: 2
+    │       │     ColumnID: 3
     │       │     TableID: 106
     │       │
     │       ├── • MakeWriteOnlyColumnDeleteOnly
-    │       │     ColumnID: 2
+    │       │     ColumnID: 3
     │       │     TableID: 106
     │       │
     │       ├── • SetJobStateOnDescriptor
@@ -138,47 +164,47 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 6 of 7;
         │
         ├── • 7 elements transitioning toward ABSENT
         │   │
-        │   ├── • Column:{DescID: 106, ColumnID: 2}
+        │   ├── • Column:{DescID: 106, ColumnID: 3}
         │   │   │ DELETE_ONLY → ABSENT
         │   │   │
-        │   │   ├── • PreviousStagePrecedence dependency from DELETE_ONLY Column:{DescID: 106, ColumnID: 2}
+        │   │   ├── • PreviousStagePrecedence dependency from DELETE_ONLY Column:{DescID: 106, ColumnID: 3}
         │   │   │     rule: "Column transitions to ABSENT uphold 2-version invariant: DELETE_ONLY->ABSENT"
         │   │   │
-        │   │   ├── • Precedence dependency from ABSENT ColumnName:{DescID: 106, Name: j, ColumnID: 2}
+        │   │   ├── • Precedence dependency from ABSENT ColumnName:{DescID: 106, Name: j, ColumnID: 3}
         │   │   │     rule: "dependents removed before column"
         │   │   │
-        │   │   ├── • SameStagePrecedence dependency from ABSENT ColumnType:{DescID: 106, ColumnFamilyID: 0, ColumnID: 2}
+        │   │   ├── • SameStagePrecedence dependency from ABSENT ColumnType:{DescID: 106, ColumnFamilyID: 0, ColumnID: 3}
         │   │   │     rule: "dependents removed before column"
         │   │   │     rule: "column type removed right before column when not dropping relation"
         │   │   │
-        │   │   ├── • Precedence dependency from ABSENT ColumnDefaultExpression:{DescID: 106, ColumnID: 2}
+        │   │   ├── • Precedence dependency from ABSENT ColumnDefaultExpression:{DescID: 106, ColumnID: 3}
         │   │   │     rule: "dependents removed before column"
         │   │   │
         │   │   ├── • Precedence dependency from ABSENT PrimaryIndex:{DescID: 106, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
         │   │   │     rule: "indexes containing column reach absent before column"
         │   │   │
-        │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 2}
+        │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 106, ColumnID: 3, IndexID: 2}
         │   │   │     rule: "dependents removed before column"
         │   │   │
-        │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 3}
+        │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 106, ColumnID: 3, IndexID: 3}
         │   │   │     rule: "dependents removed before column"
         │   │   │
-        │   │   └── • Precedence dependency from ABSENT ColumnNotNull:{DescID: 106, ColumnID: 2, IndexID: 2}
+        │   │   └── • Precedence dependency from ABSENT ColumnNotNull:{DescID: 106, ColumnID: 3, IndexID: 2}
         │   │         rule: "dependents removed before column"
         │   │
-        │   ├── • ColumnType:{DescID: 106, ColumnFamilyID: 0, ColumnID: 2}
+        │   ├── • ColumnType:{DescID: 106, ColumnFamilyID: 0, ColumnID: 3}
         │   │   │ PUBLIC → ABSENT
         │   │   │
-        │   │   ├── • Precedence dependency from WRITE_ONLY Column:{DescID: 106, ColumnID: 2}
+        │   │   ├── • Precedence dependency from WRITE_ONLY Column:{DescID: 106, ColumnID: 3}
         │   │   │     rule: "column no longer public before dependents"
         │   │   │
-        │   │   └── • SameStagePrecedence dependency from ABSENT ColumnDefaultExpression:{DescID: 106, ColumnID: 2}
+        │   │   └── • SameStagePrecedence dependency from ABSENT ColumnDefaultExpression:{DescID: 106, ColumnID: 3}
         │   │         rule: "column type dependents removed right before column type"
         │   │
-        │   ├── • ColumnDefaultExpression:{DescID: 106, ColumnID: 2}
+        │   ├── • ColumnDefaultExpression:{DescID: 106, ColumnID: 3}
         │   │   │ PUBLIC → ABSENT
         │   │   │
-        │   │   └── • Precedence dependency from WRITE_ONLY Column:{DescID: 106, ColumnID: 2}
+        │   │   └── • Precedence dependency from WRITE_ONLY Column:{DescID: 106, ColumnID: 3}
         │   │         rule: "column no longer public before dependents"
         │   │
         │   ├── • PrimaryIndex:{DescID: 106, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
@@ -193,7 +219,10 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 6 of 7;
         │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 106, ColumnID: 1, IndexID: 2}
         │   │   │     rule: "dependents removed before index"
         │   │   │
-        │   │   └── • Precedence dependency from ABSENT IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 2}
+        │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 2}
+        │   │   │     rule: "dependents removed before index"
+        │   │   │
+        │   │   └── • Precedence dependency from ABSENT IndexColumn:{DescID: 106, ColumnID: 3, IndexID: 2}
         │   │         rule: "dependents removed before index"
         │   │
         │   ├── • IndexData:{DescID: 106, IndexID: 2}
@@ -211,7 +240,10 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 6 of 7;
         │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 106, ColumnID: 1, IndexID: 3}
         │   │   │     rule: "dependents removed before index"
         │   │   │
-        │   │   └── • Precedence dependency from ABSENT IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 3}
+        │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 3}
+        │   │   │     rule: "dependents removed before index"
+        │   │   │
+        │   │   └── • Precedence dependency from ABSENT IndexColumn:{DescID: 106, ColumnID: 3, IndexID: 3}
         │   │         rule: "dependents removed before index"
         │   │
         │   └── • IndexData:{DescID: 106, IndexID: 3}
@@ -226,7 +258,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 6 of 7;
         └── • 8 Mutation operations
             │
             ├── • RemoveColumnDefaultExpression
-            │     ColumnID: 2
+            │     ColumnID: 3
             │     TableID: 106
             │
             ├── • MakeIndexAbsent
@@ -252,7 +284,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 6 of 7;
             │     TableID: 106
             │
             ├── • MakeDeleteOnlyColumnAbsent
-            │     ColumnID: 2
+            │     ColumnID: 3
             │     TableID: 106
             │
             ├── • RemoveJobStateFromDescriptor

--- a/pkg/sql/schemachanger/testdata/explain_verbose/add_column.rollback_7_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/add_column.rollback_7_of_7
@@ -1,6 +1,6 @@
 /* setup */
 CREATE DATABASE db;
-CREATE TABLE db.public.tbl (i INT PRIMARY KEY);
+CREATE TABLE db.public.tbl (i INT PRIMARY KEY, k INT);
 CREATE SEQUENCE db.public.sq1;
 
 /* test */
@@ -13,21 +13,21 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 7 of 7;
     │
     ├── • Stage 1 of 2 in PostCommitNonRevertiblePhase
     │   │
-    │   ├── • 9 elements transitioning toward ABSENT
+    │   ├── • 11 elements transitioning toward ABSENT
     │   │   │
-    │   │   ├── • Column:{DescID: 106, ColumnID: 2}
+    │   │   ├── • Column:{DescID: 106, ColumnID: 3}
     │   │   │   │ WRITE_ONLY → DELETE_ONLY
     │   │   │   │
-    │   │   │   ├── • PreviousStagePrecedence dependency from WRITE_ONLY Column:{DescID: 106, ColumnID: 2}
+    │   │   │   ├── • PreviousStagePrecedence dependency from WRITE_ONLY Column:{DescID: 106, ColumnID: 3}
     │   │   │   │     rule: "Column transitions to ABSENT uphold 2-version invariant: WRITE_ONLY->DELETE_ONLY"
     │   │   │   │
-    │   │   │   └── • SameStagePrecedence dependency from ABSENT ColumnNotNull:{DescID: 106, ColumnID: 2, IndexID: 2}
+    │   │   │   └── • SameStagePrecedence dependency from ABSENT ColumnNotNull:{DescID: 106, ColumnID: 3, IndexID: 2}
     │   │   │         rule: "column constraint removed right before column reaches delete only"
     │   │   │
-    │   │   ├── • ColumnName:{DescID: 106, Name: j, ColumnID: 2}
+    │   │   ├── • ColumnName:{DescID: 106, Name: j, ColumnID: 3}
     │   │   │   │ PUBLIC → ABSENT
     │   │   │   │
-    │   │   │   └── • Precedence dependency from WRITE_ONLY Column:{DescID: 106, ColumnID: 2}
+    │   │   │   └── • Precedence dependency from WRITE_ONLY Column:{DescID: 106, ColumnID: 3}
     │   │   │         rule: "column no longer public before dependents"
     │   │   │
     │   │   ├── • PrimaryIndex:{DescID: 106, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
@@ -45,7 +45,13 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 7 of 7;
     │   │   ├── • IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 2}
     │   │   │   │ PUBLIC → ABSENT
     │   │   │   │
-    │   │   │   ├── • Precedence dependency from WRITE_ONLY Column:{DescID: 106, ColumnID: 2}
+    │   │   │   └── • Precedence dependency from DELETE_ONLY PrimaryIndex:{DescID: 106, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
+    │   │   │         rule: "index drop mutation visible before cleaning up index columns"
+    │   │   │
+    │   │   ├── • IndexColumn:{DescID: 106, ColumnID: 3, IndexID: 2}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from WRITE_ONLY Column:{DescID: 106, ColumnID: 3}
     │   │   │   │     rule: "column no longer public before dependents"
     │   │   │   │
     │   │   │   └── • Precedence dependency from DELETE_ONLY PrimaryIndex:{DescID: 106, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
@@ -66,26 +72,32 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 7 of 7;
     │   │   ├── • IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 3}
     │   │   │   │ PUBLIC → ABSENT
     │   │   │   │
-    │   │   │   ├── • Precedence dependency from WRITE_ONLY Column:{DescID: 106, ColumnID: 2}
+    │   │   │   └── • Precedence dependency from DELETE_ONLY TemporaryIndex:{DescID: 106, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
+    │   │   │         rule: "index drop mutation visible before cleaning up index columns"
+    │   │   │
+    │   │   ├── • IndexColumn:{DescID: 106, ColumnID: 3, IndexID: 3}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from WRITE_ONLY Column:{DescID: 106, ColumnID: 3}
     │   │   │   │     rule: "column no longer public before dependents"
     │   │   │   │
     │   │   │   └── • Precedence dependency from DELETE_ONLY TemporaryIndex:{DescID: 106, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
     │   │   │         rule: "index drop mutation visible before cleaning up index columns"
     │   │   │
-    │   │   └── • ColumnNotNull:{DescID: 106, ColumnID: 2, IndexID: 2}
+    │   │   └── • ColumnNotNull:{DescID: 106, ColumnID: 3, IndexID: 2}
     │   │       │ WRITE_ONLY → ABSENT
     │   │       │
-    │   │       ├── • PreviousStagePrecedence dependency from WRITE_ONLY ColumnNotNull:{DescID: 106, ColumnID: 2, IndexID: 2}
+    │   │       ├── • PreviousStagePrecedence dependency from WRITE_ONLY ColumnNotNull:{DescID: 106, ColumnID: 3, IndexID: 2}
     │   │       │     rule: "ColumnNotNull transitions to ABSENT uphold 2-version invariant: WRITE_ONLY->VALIDATED"
     │   │       │
-    │   │       └── • Precedence dependency from WRITE_ONLY Column:{DescID: 106, ColumnID: 2}
+    │   │       └── • Precedence dependency from WRITE_ONLY Column:{DescID: 106, ColumnID: 3}
     │   │             rule: "column no longer public before dependents"
     │   │
-    │   └── • 11 Mutation operations
+    │   └── • 13 Mutation operations
     │       │
     │       ├── • SetColumnName
-    │       │     ColumnID: 2
-    │       │     Name: crdb_internal_column_2_name_placeholder
+    │       │     ColumnID: 3
+    │       │     Name: crdb_internal_column_3_name_placeholder
     │       │     TableID: 106
     │       │
     │       ├── • MakeWriteOnlyIndexDeleteOnly
@@ -103,6 +115,13 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 7 of 7;
     │       │     Kind: 2
     │       │     TableID: 106
     │       │
+    │       ├── • RemoveColumnFromIndex
+    │       │     ColumnID: 3
+    │       │     IndexID: 2
+    │       │     Kind: 2
+    │       │     Ordinal: 1
+    │       │     TableID: 106
+    │       │
     │       ├── • MakeWriteOnlyIndexDeleteOnly
     │       │     IndexID: 3
     │       │     TableID: 106
@@ -116,14 +135,21 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 7 of 7;
     │       │     ColumnID: 2
     │       │     IndexID: 3
     │       │     Kind: 2
+    │       │     TableID: 106
+    │       │
+    │       ├── • RemoveColumnFromIndex
+    │       │     ColumnID: 3
+    │       │     IndexID: 3
+    │       │     Kind: 2
+    │       │     Ordinal: 1
     │       │     TableID: 106
     │       │
     │       ├── • RemoveColumnNotNull
-    │       │     ColumnID: 2
+    │       │     ColumnID: 3
     │       │     TableID: 106
     │       │
     │       ├── • MakeWriteOnlyColumnDeleteOnly
-    │       │     ColumnID: 2
+    │       │     ColumnID: 3
     │       │     TableID: 106
     │       │
     │       ├── • SetJobStateOnDescriptor
@@ -138,47 +164,47 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 7 of 7;
         │
         ├── • 7 elements transitioning toward ABSENT
         │   │
-        │   ├── • Column:{DescID: 106, ColumnID: 2}
+        │   ├── • Column:{DescID: 106, ColumnID: 3}
         │   │   │ DELETE_ONLY → ABSENT
         │   │   │
-        │   │   ├── • PreviousStagePrecedence dependency from DELETE_ONLY Column:{DescID: 106, ColumnID: 2}
+        │   │   ├── • PreviousStagePrecedence dependency from DELETE_ONLY Column:{DescID: 106, ColumnID: 3}
         │   │   │     rule: "Column transitions to ABSENT uphold 2-version invariant: DELETE_ONLY->ABSENT"
         │   │   │
-        │   │   ├── • Precedence dependency from ABSENT ColumnName:{DescID: 106, Name: j, ColumnID: 2}
+        │   │   ├── • Precedence dependency from ABSENT ColumnName:{DescID: 106, Name: j, ColumnID: 3}
         │   │   │     rule: "dependents removed before column"
         │   │   │
-        │   │   ├── • SameStagePrecedence dependency from ABSENT ColumnType:{DescID: 106, ColumnFamilyID: 0, ColumnID: 2}
+        │   │   ├── • SameStagePrecedence dependency from ABSENT ColumnType:{DescID: 106, ColumnFamilyID: 0, ColumnID: 3}
         │   │   │     rule: "dependents removed before column"
         │   │   │     rule: "column type removed right before column when not dropping relation"
         │   │   │
-        │   │   ├── • Precedence dependency from ABSENT ColumnDefaultExpression:{DescID: 106, ColumnID: 2}
+        │   │   ├── • Precedence dependency from ABSENT ColumnDefaultExpression:{DescID: 106, ColumnID: 3}
         │   │   │     rule: "dependents removed before column"
         │   │   │
         │   │   ├── • Precedence dependency from ABSENT PrimaryIndex:{DescID: 106, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
         │   │   │     rule: "indexes containing column reach absent before column"
         │   │   │
-        │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 2}
+        │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 106, ColumnID: 3, IndexID: 2}
         │   │   │     rule: "dependents removed before column"
         │   │   │
-        │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 3}
+        │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 106, ColumnID: 3, IndexID: 3}
         │   │   │     rule: "dependents removed before column"
         │   │   │
-        │   │   └── • Precedence dependency from ABSENT ColumnNotNull:{DescID: 106, ColumnID: 2, IndexID: 2}
+        │   │   └── • Precedence dependency from ABSENT ColumnNotNull:{DescID: 106, ColumnID: 3, IndexID: 2}
         │   │         rule: "dependents removed before column"
         │   │
-        │   ├── • ColumnType:{DescID: 106, ColumnFamilyID: 0, ColumnID: 2}
+        │   ├── • ColumnType:{DescID: 106, ColumnFamilyID: 0, ColumnID: 3}
         │   │   │ PUBLIC → ABSENT
         │   │   │
-        │   │   ├── • Precedence dependency from WRITE_ONLY Column:{DescID: 106, ColumnID: 2}
+        │   │   ├── • Precedence dependency from WRITE_ONLY Column:{DescID: 106, ColumnID: 3}
         │   │   │     rule: "column no longer public before dependents"
         │   │   │
-        │   │   └── • SameStagePrecedence dependency from ABSENT ColumnDefaultExpression:{DescID: 106, ColumnID: 2}
+        │   │   └── • SameStagePrecedence dependency from ABSENT ColumnDefaultExpression:{DescID: 106, ColumnID: 3}
         │   │         rule: "column type dependents removed right before column type"
         │   │
-        │   ├── • ColumnDefaultExpression:{DescID: 106, ColumnID: 2}
+        │   ├── • ColumnDefaultExpression:{DescID: 106, ColumnID: 3}
         │   │   │ PUBLIC → ABSENT
         │   │   │
-        │   │   └── • Precedence dependency from WRITE_ONLY Column:{DescID: 106, ColumnID: 2}
+        │   │   └── • Precedence dependency from WRITE_ONLY Column:{DescID: 106, ColumnID: 3}
         │   │         rule: "column no longer public before dependents"
         │   │
         │   ├── • PrimaryIndex:{DescID: 106, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
@@ -193,7 +219,10 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 7 of 7;
         │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 106, ColumnID: 1, IndexID: 2}
         │   │   │     rule: "dependents removed before index"
         │   │   │
-        │   │   └── • Precedence dependency from ABSENT IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 2}
+        │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 2}
+        │   │   │     rule: "dependents removed before index"
+        │   │   │
+        │   │   └── • Precedence dependency from ABSENT IndexColumn:{DescID: 106, ColumnID: 3, IndexID: 2}
         │   │         rule: "dependents removed before index"
         │   │
         │   ├── • IndexData:{DescID: 106, IndexID: 2}
@@ -211,7 +240,10 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 7 of 7;
         │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 106, ColumnID: 1, IndexID: 3}
         │   │   │     rule: "dependents removed before index"
         │   │   │
-        │   │   └── • Precedence dependency from ABSENT IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 3}
+        │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 3}
+        │   │   │     rule: "dependents removed before index"
+        │   │   │
+        │   │   └── • Precedence dependency from ABSENT IndexColumn:{DescID: 106, ColumnID: 3, IndexID: 3}
         │   │         rule: "dependents removed before index"
         │   │
         │   └── • IndexData:{DescID: 106, IndexID: 3}
@@ -226,7 +258,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 7 of 7;
         └── • 8 Mutation operations
             │
             ├── • RemoveColumnDefaultExpression
-            │     ColumnID: 2
+            │     ColumnID: 3
             │     TableID: 106
             │
             ├── • MakeIndexAbsent
@@ -252,7 +284,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 7 of 7;
             │     TableID: 106
             │
             ├── • MakeDeleteOnlyColumnAbsent
-            │     ColumnID: 2
+            │     ColumnID: 3
             │     TableID: 106
             │
             ├── • RemoveJobStateFromDescriptor

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_basic
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_basic
@@ -1,5 +1,5 @@
 /* setup */
-CREATE TABLE t (i INT PRIMARY KEY, j INT);
+CREATE TABLE t (i INT PRIMARY KEY, j INT, k int);
 COMMENT ON TABLE t IS 't has a comment';
 COMMENT ON COLUMN t.j IS 'j has a comment';
 
@@ -12,7 +12,7 @@ EXPLAIN (ddl, verbose) ALTER TABLE t DROP COLUMN j;
 │   │
 │   └── • Stage 1 of 1 in StatementPhase
 │       │
-│       ├── • 3 elements transitioning toward PUBLIC
+│       ├── • 4 elements transitioning toward PUBLIC
 │       │   │
 │       │   ├── • PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
 │       │   │   │ ABSENT → BACKFILL_ONLY
@@ -26,13 +26,19 @@ EXPLAIN (ddl, verbose) ALTER TABLE t DROP COLUMN j;
 │       │   │   └── • Precedence dependency from BACKFILL_ONLY PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
 │       │   │         rule: "index existence precedes index dependents"
 │       │   │
+│       │   ├── • IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 2}
+│       │   │   │ ABSENT → PUBLIC
+│       │   │   │
+│       │   │   └── • Precedence dependency from BACKFILL_ONLY PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
+│       │   │         rule: "index existence precedes index dependents"
+│       │   │
 │       │   └── • IndexData:{DescID: 104, IndexID: 2}
 │       │       │ ABSENT → PUBLIC
 │       │       │
 │       │       └── • SameStagePrecedence dependency from BACKFILL_ONLY PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
 │       │             rule: "index data exists as soon as index accepts backfills"
 │       │
-│       ├── • 2 elements transitioning toward TRANSIENT_ABSENT
+│       ├── • 3 elements transitioning toward TRANSIENT_ABSENT
 │       │   │
 │       │   ├── • TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
 │       │   │   │ ABSENT → DELETE_ONLY
@@ -40,7 +46,13 @@ EXPLAIN (ddl, verbose) ALTER TABLE t DROP COLUMN j;
 │       │   │   └── • PreviousStagePrecedence dependency from ABSENT TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
 │       │   │         rule: "TemporaryIndex transitions to TRANSIENT_ABSENT uphold 2-version invariant: ABSENT->DELETE_ONLY"
 │       │   │
-│       │   └── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
+│       │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
+│       │   │   │ ABSENT → PUBLIC
+│       │   │   │
+│       │   │   └── • Precedence dependency from DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
+│       │   │         rule: "temp index existence precedes index dependents"
+│       │   │
+│       │   └── • IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 3}
 │       │       │ ABSENT → PUBLIC
 │       │       │
 │       │       └── • Precedence dependency from DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
@@ -66,7 +78,7 @@ EXPLAIN (ddl, verbose) ALTER TABLE t DROP COLUMN j;
 │       │       └── • Precedence dependency from WRITE_ONLY Column:{DescID: 104, ColumnID: 2}
 │       │             rule: "column no longer public before dependents"
 │       │
-│       └── • 7 Mutation operations
+│       └── • 9 Mutation operations
 │           │
 │           ├── • MakePublicColumnWriteOnly
 │           │     ColumnID: 2
@@ -96,6 +108,12 @@ EXPLAIN (ddl, verbose) ALTER TABLE t DROP COLUMN j;
 │           │     IndexID: 2
 │           │     TableID: 104
 │           │
+│           ├── • AddColumnToIndex
+│           │     ColumnID: 3
+│           │     IndexID: 2
+│           │     Kind: 2
+│           │     TableID: 104
+│           │
 │           ├── • MakeAbsentTempIndexDeleteOnly
 │           │     Index:
 │           │       ConstraintID: 3
@@ -104,16 +122,22 @@ EXPLAIN (ddl, verbose) ALTER TABLE t DROP COLUMN j;
 │           │       SourceIndexID: 1
 │           │       TableID: 104
 │           │
+│           ├── • AddColumnToIndex
+│           │     ColumnID: 1
+│           │     IndexID: 3
+│           │     TableID: 104
+│           │
 │           └── • AddColumnToIndex
-│                 ColumnID: 1
+│                 ColumnID: 3
 │                 IndexID: 3
+│                 Kind: 2
 │                 TableID: 104
 │
 ├── • PreCommitPhase
 │   │
 │   ├── • Stage 1 of 2 in PreCommitPhase
 │   │   │
-│   │   ├── • 3 elements transitioning toward PUBLIC
+│   │   ├── • 4 elements transitioning toward PUBLIC
 │   │   │   │
 │   │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
 │   │   │   │     BACKFILL_ONLY → ABSENT
@@ -121,15 +145,21 @@ EXPLAIN (ddl, verbose) ALTER TABLE t DROP COLUMN j;
 │   │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 2}
 │   │   │   │     PUBLIC → ABSENT
 │   │   │   │
+│   │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 2}
+│   │   │   │     PUBLIC → ABSENT
+│   │   │   │
 │   │   │   └── • IndexData:{DescID: 104, IndexID: 2}
 │   │   │         PUBLIC → ABSENT
 │   │   │
-│   │   ├── • 2 elements transitioning toward TRANSIENT_ABSENT
+│   │   ├── • 3 elements transitioning toward TRANSIENT_ABSENT
 │   │   │   │
 │   │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
 │   │   │   │     DELETE_ONLY → ABSENT
 │   │   │   │
-│   │   │   └── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
+│   │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
+│   │   │   │     PUBLIC → ABSENT
+│   │   │   │
+│   │   │   └── • IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 3}
 │   │   │         PUBLIC → ABSENT
 │   │   │
 │   │   ├── • 3 elements transitioning toward ABSENT
@@ -150,7 +180,7 @@ EXPLAIN (ddl, verbose) ALTER TABLE t DROP COLUMN j;
 │   │
 │   └── • Stage 2 of 2 in PreCommitPhase
 │       │
-│       ├── • 3 elements transitioning toward PUBLIC
+│       ├── • 4 elements transitioning toward PUBLIC
 │       │   │
 │       │   ├── • PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
 │       │   │   │ ABSENT → BACKFILL_ONLY
@@ -164,13 +194,19 @@ EXPLAIN (ddl, verbose) ALTER TABLE t DROP COLUMN j;
 │       │   │   └── • Precedence dependency from BACKFILL_ONLY PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
 │       │   │         rule: "index existence precedes index dependents"
 │       │   │
+│       │   ├── • IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 2}
+│       │   │   │ ABSENT → PUBLIC
+│       │   │   │
+│       │   │   └── • Precedence dependency from BACKFILL_ONLY PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
+│       │   │         rule: "index existence precedes index dependents"
+│       │   │
 │       │   └── • IndexData:{DescID: 104, IndexID: 2}
 │       │       │ ABSENT → PUBLIC
 │       │       │
 │       │       └── • SameStagePrecedence dependency from BACKFILL_ONLY PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
 │       │             rule: "index data exists as soon as index accepts backfills"
 │       │
-│       ├── • 2 elements transitioning toward TRANSIENT_ABSENT
+│       ├── • 3 elements transitioning toward TRANSIENT_ABSENT
 │       │   │
 │       │   ├── • TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
 │       │   │   │ ABSENT → DELETE_ONLY
@@ -178,7 +214,13 @@ EXPLAIN (ddl, verbose) ALTER TABLE t DROP COLUMN j;
 │       │   │   └── • PreviousStagePrecedence dependency from ABSENT TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
 │       │   │         rule: "TemporaryIndex transitions to TRANSIENT_ABSENT uphold 2-version invariant: ABSENT->DELETE_ONLY"
 │       │   │
-│       │   └── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
+│       │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
+│       │   │   │ ABSENT → PUBLIC
+│       │   │   │
+│       │   │   └── • Precedence dependency from DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
+│       │   │         rule: "temp index existence precedes index dependents"
+│       │   │
+│       │   └── • IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 3}
 │       │       │ ABSENT → PUBLIC
 │       │       │
 │       │       └── • Precedence dependency from DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
@@ -204,7 +246,7 @@ EXPLAIN (ddl, verbose) ALTER TABLE t DROP COLUMN j;
 │       │       └── • Precedence dependency from WRITE_ONLY Column:{DescID: 104, ColumnID: 2}
 │       │             rule: "column no longer public before dependents"
 │       │
-│       └── • 11 Mutation operations
+│       └── • 13 Mutation operations
 │           │
 │           ├── • MakePublicColumnWriteOnly
 │           │     ColumnID: 2
@@ -238,6 +280,12 @@ EXPLAIN (ddl, verbose) ALTER TABLE t DROP COLUMN j;
 │           │     IndexID: 2
 │           │     TableID: 104
 │           │
+│           ├── • AddColumnToIndex
+│           │     ColumnID: 3
+│           │     IndexID: 2
+│           │     Kind: 2
+│           │     TableID: 104
+│           │
 │           ├── • MakeAbsentTempIndexDeleteOnly
 │           │     Index:
 │           │       ConstraintID: 3
@@ -253,6 +301,12 @@ EXPLAIN (ddl, verbose) ALTER TABLE t DROP COLUMN j;
 │           ├── • AddColumnToIndex
 │           │     ColumnID: 1
 │           │     IndexID: 3
+│           │     TableID: 104
+│           │
+│           ├── • AddColumnToIndex
+│           │     ColumnID: 3
+│           │     IndexID: 3
+│           │     Kind: 2
 │           │     TableID: 104
 │           │
 │           ├── • SetJobStateOnDescriptor
@@ -283,7 +337,10 @@ EXPLAIN (ddl, verbose) ALTER TABLE t DROP COLUMN j;
 │   │   │   │   ├── • PreviousStagePrecedence dependency from DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
 │   │   │   │   │     rule: "TemporaryIndex transitions to TRANSIENT_ABSENT uphold 2-version invariant: DELETE_ONLY->WRITE_ONLY"
 │   │   │   │   │
-│   │   │   │   └── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
+│   │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
+│   │   │   │   │     rule: "index-column added to index before temp index receives writes"
+│   │   │   │   │
+│   │   │   │   └── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 3}
 │   │   │   │         rule: "index-column added to index before temp index receives writes"
 │   │   │   │
 │   │   │   └── • IndexData:{DescID: 104, IndexID: 3}
@@ -316,6 +373,9 @@ EXPLAIN (ddl, verbose) ALTER TABLE t DROP COLUMN j;
 │   │   │       │     rule: "PrimaryIndex transitions to PUBLIC uphold 2-version invariant: BACKFILL_ONLY->BACKFILLED"
 │   │   │       │
 │   │   │       ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 2}
+│   │   │       │     rule: "index-column added to index before index is backfilled"
+│   │   │       │
+│   │   │       ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 2}
 │   │   │       │     rule: "index-column added to index before index is backfilled"
 │   │   │       │
 │   │   │       └── • Precedence dependency from WRITE_ONLY TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
@@ -449,7 +509,10 @@ EXPLAIN (ddl, verbose) ALTER TABLE t DROP COLUMN j;
     │   │   │   │     rule: "index dependents exist before index becomes public"
     │   │   │   │     rule: "primary index named right before index becomes public"
     │   │   │   │
-    │   │   │   └── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 2}
+    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 2}
+    │   │   │   │     rule: "index dependents exist before index becomes public"
+    │   │   │   │
+    │   │   │   └── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 2}
     │   │   │         rule: "index dependents exist before index becomes public"
     │   │   │
     │   │   └── • IndexName:{DescID: 104, Name: t_pkey, IndexID: 2}
@@ -458,7 +521,7 @@ EXPLAIN (ddl, verbose) ALTER TABLE t DROP COLUMN j;
     │   │       └── • Precedence dependency from BACKFILL_ONLY PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
     │   │             rule: "index existence precedes index dependents"
     │   │
-    │   ├── • 2 elements transitioning toward TRANSIENT_ABSENT
+    │   ├── • 3 elements transitioning toward TRANSIENT_ABSENT
     │   │   │
     │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
     │   │   │   │ WRITE_ONLY → TRANSIENT_DELETE_ONLY
@@ -466,7 +529,13 @@ EXPLAIN (ddl, verbose) ALTER TABLE t DROP COLUMN j;
     │   │   │   └── • PreviousStagePrecedence dependency from WRITE_ONLY TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
     │   │   │         rule: "TemporaryIndex transitions to TRANSIENT_ABSENT uphold 2-version invariant: WRITE_ONLY->TRANSIENT_DELETE_ONLY"
     │   │   │
-    │   │   └── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
+    │   │   │   │ PUBLIC → TRANSIENT_ABSENT
+    │   │   │   │
+    │   │   │   └── • Precedence dependency from TRANSIENT_DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
+    │   │   │         rule: "index drop mutation visible before cleaning up index columns"
+    │   │   │
+    │   │   └── • IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 3}
     │   │       │ PUBLIC → TRANSIENT_ABSENT
     │   │       │
     │   │       └── • Precedence dependency from TRANSIENT_DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
@@ -492,7 +561,7 @@ EXPLAIN (ddl, verbose) ALTER TABLE t DROP COLUMN j;
     │   │       └── • Precedence dependency from VALIDATED PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}
     │   │             rule: "index no longer public before dependents, excluding columns"
     │   │
-    │   └── • 9 Mutation operations
+    │   └── • 10 Mutation operations
     │       │
     │       ├── • MakeWriteOnlyColumnDeleteOnly
     │       │     ColumnID: 2
@@ -521,6 +590,12 @@ EXPLAIN (ddl, verbose) ALTER TABLE t DROP COLUMN j;
     │       │     IndexID: 3
     │       │     TableID: 104
     │       │
+    │       ├── • RemoveColumnFromIndex
+    │       │     ColumnID: 3
+    │       │     IndexID: 3
+    │       │     Kind: 2
+    │       │     TableID: 104
+    │       │
     │       ├── • MakeValidatedPrimaryIndexPublic
     │       │     IndexID: 2
     │       │     TableID: 104
@@ -531,7 +606,7 @@ EXPLAIN (ddl, verbose) ALTER TABLE t DROP COLUMN j;
     │       └── • UpdateSchemaChangerJob
     │             IsNonCancelable: true
     │             JobID: 1
-    │             RunningStatus: PostCommitNonRevertiblePhase stage 2 of 3 with 4 MutationType ops pending
+    │             RunningStatus: PostCommitNonRevertiblePhase stage 2 of 3 with 5 MutationType ops pending
     │
     ├── • Stage 2 of 3 in PostCommitNonRevertiblePhase
     │   │
@@ -543,10 +618,13 @@ EXPLAIN (ddl, verbose) ALTER TABLE t DROP COLUMN j;
     │   │       ├── • PreviousStagePrecedence dependency from TRANSIENT_DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
     │   │       │     rule: "TemporaryIndex transitions to TRANSIENT_ABSENT uphold 2-version invariant: TRANSIENT_DELETE_ONLY->TRANSIENT_ABSENT"
     │   │       │
-    │   │       └── • Precedence dependency from TRANSIENT_ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
+    │   │       ├── • Precedence dependency from TRANSIENT_ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
+    │   │       │     rule: "dependents removed before index"
+    │   │       │
+    │   │       └── • Precedence dependency from TRANSIENT_ABSENT IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 3}
     │   │             rule: "dependents removed before index"
     │   │
-    │   ├── • 3 elements transitioning toward ABSENT
+    │   ├── • 4 elements transitioning toward ABSENT
     │   │   │
     │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 1}
     │   │   │   │ PUBLIC → ABSENT
@@ -563,13 +641,19 @@ EXPLAIN (ddl, verbose) ALTER TABLE t DROP COLUMN j;
     │   │   │   └── • Precedence dependency from DELETE_ONLY PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}
     │   │   │         rule: "index drop mutation visible before cleaning up index columns"
     │   │   │
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 1}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   └── • Precedence dependency from DELETE_ONLY PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}
+    │   │   │         rule: "index drop mutation visible before cleaning up index columns"
+    │   │   │
     │   │   └── • PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}
     │   │       │ VALIDATED → DELETE_ONLY
     │   │       │
     │   │       └── • PreviousStagePrecedence dependency from VALIDATED PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}
     │   │             rule: "PrimaryIndex transitions to ABSENT uphold 2-version invariant: VALIDATED->WRITE_ONLY"
     │   │
-    │   └── • 6 Mutation operations
+    │   └── • 7 Mutation operations
     │       │
     │       ├── • MakeIndexAbsent
     │       │     IndexID: 3
@@ -588,6 +672,13 @@ EXPLAIN (ddl, verbose) ALTER TABLE t DROP COLUMN j;
     │       │     ColumnID: 2
     │       │     IndexID: 1
     │       │     Kind: 2
+    │       │     TableID: 104
+    │       │
+    │       ├── • RemoveColumnFromIndex
+    │       │     ColumnID: 3
+    │       │     IndexID: 1
+    │       │     Kind: 2
+    │       │     Ordinal: 1
     │       │     TableID: 104
     │       │
     │       ├── • SetJobStateOnDescriptor
@@ -648,6 +739,9 @@ EXPLAIN (ddl, verbose) ALTER TABLE t DROP COLUMN j;
         │   │   │     rule: "dependents removed before index"
         │   │   │
         │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 1}
+        │   │   │     rule: "dependents removed before index"
+        │   │   │
+        │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 1}
         │   │   │     rule: "dependents removed before index"
         │   │   │
         │   │   ├── • PreviousStagePrecedence dependency from DELETE_ONLY PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_basic.rollback_1_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_basic.rollback_1_of_7
@@ -1,5 +1,5 @@
 /* setup */
-CREATE TABLE t (i INT PRIMARY KEY, j INT);
+CREATE TABLE t (i INT PRIMARY KEY, j INT, k int);
 COMMENT ON TABLE t IS 't has a comment';
 COMMENT ON COLUMN t.j IS 'j has a comment';
 
@@ -39,7 +39,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 1 of 7;
         │   └── • ColumnComment:{DescID: 104, ColumnID: 2, Comment: j has a comment}
         │         ABSENT → PUBLIC
         │
-        ├── • 5 elements transitioning toward ABSENT
+        ├── • 7 elements transitioning toward ABSENT
         │   │
         │   ├── • PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
         │   │   │ BACKFILL_ONLY → ABSENT
@@ -50,10 +50,19 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 1 of 7;
         │   │   ├── • Precedence dependency from ABSENT IndexName:{DescID: 104, Name: t_pkey, IndexID: 2}
         │   │   │     rule: "dependents removed before index"
         │   │   │
-        │   │   └── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 2}
+        │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 2}
+        │   │   │     rule: "dependents removed before index"
+        │   │   │
+        │   │   └── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 2}
         │   │         rule: "dependents removed before index"
         │   │
         │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 2}
+        │   │   │ PUBLIC → ABSENT
+        │   │   │
+        │   │   └── • Precedence dependency from DELETE_ONLY PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
+        │   │         rule: "index drop mutation visible before cleaning up index columns"
+        │   │
+        │   ├── • IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 2}
         │   │   │ PUBLIC → ABSENT
         │   │   │
         │   │   └── • Precedence dependency from DELETE_ONLY PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
@@ -71,16 +80,25 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 1 of 7;
         │   │   ├── • PreviousStagePrecedence dependency from DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
         │   │   │     rule: "TemporaryIndex transitions to ABSENT uphold 2-version invariant: DELETE_ONLY->ABSENT"
         │   │   │
-        │   │   └── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
+        │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
+        │   │   │     rule: "dependents removed before index"
+        │   │   │
+        │   │   └── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 3}
         │   │         rule: "dependents removed before index"
         │   │
-        │   └── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
+        │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
+        │   │   │ PUBLIC → ABSENT
+        │   │   │
+        │   │   └── • Precedence dependency from DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
+        │   │         rule: "index drop mutation visible before cleaning up index columns"
+        │   │
+        │   └── • IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 3}
         │       │ PUBLIC → ABSENT
         │       │
         │       └── • Precedence dependency from DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
         │             rule: "index drop mutation visible before cleaning up index columns"
         │
-        └── • 11 Mutation operations
+        └── • 13 Mutation operations
             │
             ├── • SetColumnName
             │     ColumnID: 2
@@ -99,8 +117,20 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 1 of 7;
             │     TableID: 104
             │
             ├── • RemoveColumnFromIndex
+            │     ColumnID: 3
+            │     IndexID: 2
+            │     Kind: 2
+            │     TableID: 104
+            │
+            ├── • RemoveColumnFromIndex
             │     ColumnID: 1
             │     IndexID: 3
+            │     TableID: 104
+            │
+            ├── • RemoveColumnFromIndex
+            │     ColumnID: 3
+            │     IndexID: 3
+            │     Kind: 2
             │     TableID: 104
             │
             ├── • MakeWriteOnlyColumnPublic

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_basic.rollback_2_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_basic.rollback_2_of_7
@@ -1,5 +1,5 @@
 /* setup */
-CREATE TABLE t (i INT PRIMARY KEY, j INT);
+CREATE TABLE t (i INT PRIMARY KEY, j INT, k int);
 COMMENT ON TABLE t IS 't has a comment';
 COMMENT ON COLUMN t.j IS 'j has a comment';
 
@@ -39,7 +39,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 2 of 7;
     │   │   └── • ColumnComment:{DescID: 104, ColumnID: 2, Comment: j has a comment}
     │   │         ABSENT → PUBLIC
     │   │
-    │   ├── • 4 elements transitioning toward ABSENT
+    │   ├── • 6 elements transitioning toward ABSENT
     │   │   │
     │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
     │   │   │   │ BACKFILL_ONLY → ABSENT
@@ -50,10 +50,19 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 2 of 7;
     │   │   │   ├── • Precedence dependency from ABSENT IndexName:{DescID: 104, Name: t_pkey, IndexID: 2}
     │   │   │   │     rule: "dependents removed before index"
     │   │   │   │
-    │   │   │   └── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 2}
+    │   │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 2}
+    │   │   │   │     rule: "dependents removed before index"
+    │   │   │   │
+    │   │   │   └── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 2}
     │   │   │         rule: "dependents removed before index"
     │   │   │
     │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 2}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   └── • Precedence dependency from DELETE_ONLY PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
+    │   │   │         rule: "index drop mutation visible before cleaning up index columns"
+    │   │   │
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 2}
     │   │   │   │ PUBLIC → ABSENT
     │   │   │   │
     │   │   │   └── • Precedence dependency from DELETE_ONLY PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
@@ -65,13 +74,19 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 2 of 7;
     │   │   │   └── • PreviousStagePrecedence dependency from WRITE_ONLY TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
     │   │   │         rule: "TemporaryIndex transitions to ABSENT uphold 2-version invariant: WRITE_ONLY->DELETE_ONLY"
     │   │   │
-    │   │   └── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   └── • Precedence dependency from DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
+    │   │   │         rule: "index drop mutation visible before cleaning up index columns"
+    │   │   │
+    │   │   └── • IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 3}
     │   │       │ PUBLIC → ABSENT
     │   │       │
     │   │       └── • Precedence dependency from DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
     │   │             rule: "index drop mutation visible before cleaning up index columns"
     │   │
-    │   └── • 10 Mutation operations
+    │   └── • 12 Mutation operations
     │       │
     │       ├── • SetColumnName
     │       │     ColumnID: 2
@@ -89,6 +104,12 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 2 of 7;
     │       │     IndexID: 2
     │       │     TableID: 104
     │       │
+    │       ├── • RemoveColumnFromIndex
+    │       │     ColumnID: 3
+    │       │     IndexID: 2
+    │       │     Kind: 2
+    │       │     TableID: 104
+    │       │
     │       ├── • MakeWriteOnlyIndexDeleteOnly
     │       │     IndexID: 3
     │       │     TableID: 104
@@ -96,6 +117,12 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 2 of 7;
     │       ├── • RemoveColumnFromIndex
     │       │     ColumnID: 1
     │       │     IndexID: 3
+    │       │     TableID: 104
+    │       │
+    │       ├── • RemoveColumnFromIndex
+    │       │     ColumnID: 3
+    │       │     IndexID: 3
+    │       │     Kind: 2
     │       │     TableID: 104
     │       │
     │       ├── • MakeWriteOnlyColumnPublic
@@ -133,7 +160,10 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 2 of 7;
         │   │   ├── • PreviousStagePrecedence dependency from DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
         │   │   │     rule: "TemporaryIndex transitions to ABSENT uphold 2-version invariant: DELETE_ONLY->ABSENT"
         │   │   │
-        │   │   └── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
+        │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
+        │   │   │     rule: "dependents removed before index"
+        │   │   │
+        │   │   └── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 3}
         │   │         rule: "dependents removed before index"
         │   │
         │   └── • IndexData:{DescID: 104, IndexID: 3}

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_basic.rollback_3_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_basic.rollback_3_of_7
@@ -1,5 +1,5 @@
 /* setup */
-CREATE TABLE t (i INT PRIMARY KEY, j INT);
+CREATE TABLE t (i INT PRIMARY KEY, j INT, k int);
 COMMENT ON TABLE t IS 't has a comment';
 COMMENT ON COLUMN t.j IS 'j has a comment';
 
@@ -39,7 +39,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 3 of 7;
     │   │   └── • ColumnComment:{DescID: 104, ColumnID: 2, Comment: j has a comment}
     │   │         ABSENT → PUBLIC
     │   │
-    │   ├── • 4 elements transitioning toward ABSENT
+    │   ├── • 6 elements transitioning toward ABSENT
     │   │   │
     │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
     │   │   │   │ BACKFILL_ONLY → ABSENT
@@ -50,10 +50,19 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 3 of 7;
     │   │   │   ├── • Precedence dependency from ABSENT IndexName:{DescID: 104, Name: t_pkey, IndexID: 2}
     │   │   │   │     rule: "dependents removed before index"
     │   │   │   │
-    │   │   │   └── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 2}
+    │   │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 2}
+    │   │   │   │     rule: "dependents removed before index"
+    │   │   │   │
+    │   │   │   └── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 2}
     │   │   │         rule: "dependents removed before index"
     │   │   │
     │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 2}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   └── • Precedence dependency from DELETE_ONLY PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
+    │   │   │         rule: "index drop mutation visible before cleaning up index columns"
+    │   │   │
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 2}
     │   │   │   │ PUBLIC → ABSENT
     │   │   │   │
     │   │   │   └── • Precedence dependency from DELETE_ONLY PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
@@ -65,13 +74,19 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 3 of 7;
     │   │   │   └── • PreviousStagePrecedence dependency from WRITE_ONLY TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
     │   │   │         rule: "TemporaryIndex transitions to ABSENT uphold 2-version invariant: WRITE_ONLY->DELETE_ONLY"
     │   │   │
-    │   │   └── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   └── • Precedence dependency from DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
+    │   │   │         rule: "index drop mutation visible before cleaning up index columns"
+    │   │   │
+    │   │   └── • IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 3}
     │   │       │ PUBLIC → ABSENT
     │   │       │
     │   │       └── • Precedence dependency from DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
     │   │             rule: "index drop mutation visible before cleaning up index columns"
     │   │
-    │   └── • 10 Mutation operations
+    │   └── • 12 Mutation operations
     │       │
     │       ├── • SetColumnName
     │       │     ColumnID: 2
@@ -89,6 +104,12 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 3 of 7;
     │       │     IndexID: 2
     │       │     TableID: 104
     │       │
+    │       ├── • RemoveColumnFromIndex
+    │       │     ColumnID: 3
+    │       │     IndexID: 2
+    │       │     Kind: 2
+    │       │     TableID: 104
+    │       │
     │       ├── • MakeWriteOnlyIndexDeleteOnly
     │       │     IndexID: 3
     │       │     TableID: 104
@@ -96,6 +117,12 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 3 of 7;
     │       ├── • RemoveColumnFromIndex
     │       │     ColumnID: 1
     │       │     IndexID: 3
+    │       │     TableID: 104
+    │       │
+    │       ├── • RemoveColumnFromIndex
+    │       │     ColumnID: 3
+    │       │     IndexID: 3
+    │       │     Kind: 2
     │       │     TableID: 104
     │       │
     │       ├── • MakeWriteOnlyColumnPublic
@@ -133,7 +160,10 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 3 of 7;
         │   │   ├── • PreviousStagePrecedence dependency from DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
         │   │   │     rule: "TemporaryIndex transitions to ABSENT uphold 2-version invariant: DELETE_ONLY->ABSENT"
         │   │   │
-        │   │   └── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
+        │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
+        │   │   │     rule: "dependents removed before index"
+        │   │   │
+        │   │   └── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 3}
         │   │         rule: "dependents removed before index"
         │   │
         │   └── • IndexData:{DescID: 104, IndexID: 3}

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_basic.rollback_4_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_basic.rollback_4_of_7
@@ -1,5 +1,5 @@
 /* setup */
-CREATE TABLE t (i INT PRIMARY KEY, j INT);
+CREATE TABLE t (i INT PRIMARY KEY, j INT, k int);
 COMMENT ON TABLE t IS 't has a comment';
 COMMENT ON COLUMN t.j IS 'j has a comment';
 
@@ -39,7 +39,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 4 of 7;
     │   │   └── • ColumnComment:{DescID: 104, ColumnID: 2, Comment: j has a comment}
     │   │         ABSENT → PUBLIC
     │   │
-    │   ├── • 4 elements transitioning toward ABSENT
+    │   ├── • 6 elements transitioning toward ABSENT
     │   │   │
     │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
     │   │   │   │ DELETE_ONLY → ABSENT
@@ -50,10 +50,19 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 4 of 7;
     │   │   │   ├── • Precedence dependency from ABSENT IndexName:{DescID: 104, Name: t_pkey, IndexID: 2}
     │   │   │   │     rule: "dependents removed before index"
     │   │   │   │
-    │   │   │   └── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 2}
+    │   │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 2}
+    │   │   │   │     rule: "dependents removed before index"
+    │   │   │   │
+    │   │   │   └── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 2}
     │   │   │         rule: "dependents removed before index"
     │   │   │
     │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 2}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   └── • Precedence dependency from DELETE_ONLY PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
+    │   │   │         rule: "index drop mutation visible before cleaning up index columns"
+    │   │   │
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 2}
     │   │   │   │ PUBLIC → ABSENT
     │   │   │   │
     │   │   │   └── • Precedence dependency from DELETE_ONLY PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
@@ -65,13 +74,19 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 4 of 7;
     │   │   │   └── • PreviousStagePrecedence dependency from WRITE_ONLY TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
     │   │   │         rule: "TemporaryIndex transitions to ABSENT uphold 2-version invariant: WRITE_ONLY->DELETE_ONLY"
     │   │   │
-    │   │   └── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   └── • Precedence dependency from DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
+    │   │   │         rule: "index drop mutation visible before cleaning up index columns"
+    │   │   │
+    │   │   └── • IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 3}
     │   │       │ PUBLIC → ABSENT
     │   │       │
     │   │       └── • Precedence dependency from DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
     │   │             rule: "index drop mutation visible before cleaning up index columns"
     │   │
-    │   └── • 10 Mutation operations
+    │   └── • 12 Mutation operations
     │       │
     │       ├── • SetColumnName
     │       │     ColumnID: 2
@@ -89,6 +104,12 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 4 of 7;
     │       │     IndexID: 2
     │       │     TableID: 104
     │       │
+    │       ├── • RemoveColumnFromIndex
+    │       │     ColumnID: 3
+    │       │     IndexID: 2
+    │       │     Kind: 2
+    │       │     TableID: 104
+    │       │
     │       ├── • MakeWriteOnlyIndexDeleteOnly
     │       │     IndexID: 3
     │       │     TableID: 104
@@ -96,6 +117,12 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 4 of 7;
     │       ├── • RemoveColumnFromIndex
     │       │     ColumnID: 1
     │       │     IndexID: 3
+    │       │     TableID: 104
+    │       │
+    │       ├── • RemoveColumnFromIndex
+    │       │     ColumnID: 3
+    │       │     IndexID: 3
+    │       │     Kind: 2
     │       │     TableID: 104
     │       │
     │       ├── • MakeWriteOnlyColumnPublic
@@ -133,7 +160,10 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 4 of 7;
         │   │   ├── • PreviousStagePrecedence dependency from DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
         │   │   │     rule: "TemporaryIndex transitions to ABSENT uphold 2-version invariant: DELETE_ONLY->ABSENT"
         │   │   │
-        │   │   └── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
+        │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
+        │   │   │     rule: "dependents removed before index"
+        │   │   │
+        │   │   └── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 3}
         │   │         rule: "dependents removed before index"
         │   │
         │   └── • IndexData:{DescID: 104, IndexID: 3}

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_basic.rollback_5_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_basic.rollback_5_of_7
@@ -1,5 +1,5 @@
 /* setup */
-CREATE TABLE t (i INT PRIMARY KEY, j INT);
+CREATE TABLE t (i INT PRIMARY KEY, j INT, k int);
 COMMENT ON TABLE t IS 't has a comment';
 COMMENT ON COLUMN t.j IS 'j has a comment';
 
@@ -39,7 +39,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 5 of 7;
     │   │   └── • ColumnComment:{DescID: 104, ColumnID: 2, Comment: j has a comment}
     │   │         ABSENT → PUBLIC
     │   │
-    │   ├── • 4 elements transitioning toward ABSENT
+    │   ├── • 6 elements transitioning toward ABSENT
     │   │   │
     │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
     │   │   │   │ MERGE_ONLY → DELETE_ONLY
@@ -53,19 +53,31 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 5 of 7;
     │   │   │   └── • Precedence dependency from DELETE_ONLY PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
     │   │   │         rule: "index drop mutation visible before cleaning up index columns"
     │   │   │
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 2}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   └── • Precedence dependency from DELETE_ONLY PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
+    │   │   │         rule: "index drop mutation visible before cleaning up index columns"
+    │   │   │
     │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
     │   │   │   │ WRITE_ONLY → DELETE_ONLY
     │   │   │   │
     │   │   │   └── • PreviousStagePrecedence dependency from WRITE_ONLY TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
     │   │   │         rule: "TemporaryIndex transitions to ABSENT uphold 2-version invariant: WRITE_ONLY->DELETE_ONLY"
     │   │   │
-    │   │   └── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   └── • Precedence dependency from DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
+    │   │   │         rule: "index drop mutation visible before cleaning up index columns"
+    │   │   │
+    │   │   └── • IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 3}
     │   │       │ PUBLIC → ABSENT
     │   │       │
     │   │       └── • Precedence dependency from DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
     │   │             rule: "index drop mutation visible before cleaning up index columns"
     │   │
-    │   └── • 10 Mutation operations
+    │   └── • 12 Mutation operations
     │       │
     │       ├── • SetColumnName
     │       │     ColumnID: 2
@@ -87,6 +99,12 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 5 of 7;
     │       │     IndexID: 3
     │       │     TableID: 104
     │       │
+    │       ├── • RemoveColumnFromIndex
+    │       │     ColumnID: 3
+    │       │     IndexID: 3
+    │       │     Kind: 2
+    │       │     TableID: 104
+    │       │
     │       ├── • MakeWriteOnlyColumnPublic
     │       │     ColumnID: 2
     │       │     TableID: 104
@@ -101,6 +119,12 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 5 of 7;
     │       ├── • RemoveColumnFromIndex
     │       │     ColumnID: 1
     │       │     IndexID: 2
+    │       │     TableID: 104
+    │       │
+    │       ├── • RemoveColumnFromIndex
+    │       │     ColumnID: 3
+    │       │     IndexID: 2
+    │       │     Kind: 2
     │       │     TableID: 104
     │       │
     │       ├── • SetJobStateOnDescriptor
@@ -124,7 +148,10 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 5 of 7;
         │   │   ├── • Precedence dependency from ABSENT IndexName:{DescID: 104, Name: t_pkey, IndexID: 2}
         │   │   │     rule: "dependents removed before index"
         │   │   │
-        │   │   └── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 2}
+        │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 2}
+        │   │   │     rule: "dependents removed before index"
+        │   │   │
+        │   │   └── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 2}
         │   │         rule: "dependents removed before index"
         │   │
         │   ├── • IndexData:{DescID: 104, IndexID: 2}
@@ -139,7 +166,10 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 5 of 7;
         │   │   ├── • PreviousStagePrecedence dependency from DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
         │   │   │     rule: "TemporaryIndex transitions to ABSENT uphold 2-version invariant: DELETE_ONLY->ABSENT"
         │   │   │
-        │   │   └── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
+        │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
+        │   │   │     rule: "dependents removed before index"
+        │   │   │
+        │   │   └── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 3}
         │   │         rule: "dependents removed before index"
         │   │
         │   └── • IndexData:{DescID: 104, IndexID: 3}

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_basic.rollback_6_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_basic.rollback_6_of_7
@@ -1,5 +1,5 @@
 /* setup */
-CREATE TABLE t (i INT PRIMARY KEY, j INT);
+CREATE TABLE t (i INT PRIMARY KEY, j INT, k int);
 COMMENT ON TABLE t IS 't has a comment';
 COMMENT ON COLUMN t.j IS 'j has a comment';
 
@@ -39,7 +39,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 6 of 7;
     │   │   └── • ColumnComment:{DescID: 104, ColumnID: 2, Comment: j has a comment}
     │   │         ABSENT → PUBLIC
     │   │
-    │   ├── • 4 elements transitioning toward ABSENT
+    │   ├── • 6 elements transitioning toward ABSENT
     │   │   │
     │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
     │   │   │   │ MERGE_ONLY → DELETE_ONLY
@@ -53,19 +53,31 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 6 of 7;
     │   │   │   └── • Precedence dependency from DELETE_ONLY PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
     │   │   │         rule: "index drop mutation visible before cleaning up index columns"
     │   │   │
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 2}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   └── • Precedence dependency from DELETE_ONLY PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
+    │   │   │         rule: "index drop mutation visible before cleaning up index columns"
+    │   │   │
     │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
     │   │   │   │ WRITE_ONLY → DELETE_ONLY
     │   │   │   │
     │   │   │   └── • PreviousStagePrecedence dependency from WRITE_ONLY TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
     │   │   │         rule: "TemporaryIndex transitions to ABSENT uphold 2-version invariant: WRITE_ONLY->DELETE_ONLY"
     │   │   │
-    │   │   └── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   └── • Precedence dependency from DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
+    │   │   │         rule: "index drop mutation visible before cleaning up index columns"
+    │   │   │
+    │   │   └── • IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 3}
     │   │       │ PUBLIC → ABSENT
     │   │       │
     │   │       └── • Precedence dependency from DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
     │   │             rule: "index drop mutation visible before cleaning up index columns"
     │   │
-    │   └── • 10 Mutation operations
+    │   └── • 12 Mutation operations
     │       │
     │       ├── • SetColumnName
     │       │     ColumnID: 2
@@ -87,6 +99,12 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 6 of 7;
     │       │     IndexID: 3
     │       │     TableID: 104
     │       │
+    │       ├── • RemoveColumnFromIndex
+    │       │     ColumnID: 3
+    │       │     IndexID: 3
+    │       │     Kind: 2
+    │       │     TableID: 104
+    │       │
     │       ├── • MakeWriteOnlyColumnPublic
     │       │     ColumnID: 2
     │       │     TableID: 104
@@ -101,6 +119,12 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 6 of 7;
     │       ├── • RemoveColumnFromIndex
     │       │     ColumnID: 1
     │       │     IndexID: 2
+    │       │     TableID: 104
+    │       │
+    │       ├── • RemoveColumnFromIndex
+    │       │     ColumnID: 3
+    │       │     IndexID: 2
+    │       │     Kind: 2
     │       │     TableID: 104
     │       │
     │       ├── • SetJobStateOnDescriptor
@@ -124,7 +148,10 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 6 of 7;
         │   │   ├── • Precedence dependency from ABSENT IndexName:{DescID: 104, Name: t_pkey, IndexID: 2}
         │   │   │     rule: "dependents removed before index"
         │   │   │
-        │   │   └── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 2}
+        │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 2}
+        │   │   │     rule: "dependents removed before index"
+        │   │   │
+        │   │   └── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 2}
         │   │         rule: "dependents removed before index"
         │   │
         │   ├── • IndexData:{DescID: 104, IndexID: 2}
@@ -139,7 +166,10 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 6 of 7;
         │   │   ├── • PreviousStagePrecedence dependency from DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
         │   │   │     rule: "TemporaryIndex transitions to ABSENT uphold 2-version invariant: DELETE_ONLY->ABSENT"
         │   │   │
-        │   │   └── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
+        │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
+        │   │   │     rule: "dependents removed before index"
+        │   │   │
+        │   │   └── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 3}
         │   │         rule: "dependents removed before index"
         │   │
         │   └── • IndexData:{DescID: 104, IndexID: 3}

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_basic.rollback_7_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_basic.rollback_7_of_7
@@ -1,5 +1,5 @@
 /* setup */
-CREATE TABLE t (i INT PRIMARY KEY, j INT);
+CREATE TABLE t (i INT PRIMARY KEY, j INT, k int);
 COMMENT ON TABLE t IS 't has a comment';
 COMMENT ON COLUMN t.j IS 'j has a comment';
 
@@ -39,7 +39,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 7 of 7;
     │   │   └── • ColumnComment:{DescID: 104, ColumnID: 2, Comment: j has a comment}
     │   │         ABSENT → PUBLIC
     │   │
-    │   ├── • 4 elements transitioning toward ABSENT
+    │   ├── • 6 elements transitioning toward ABSENT
     │   │   │
     │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
     │   │   │   │ WRITE_ONLY → DELETE_ONLY
@@ -53,19 +53,31 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 7 of 7;
     │   │   │   └── • Precedence dependency from DELETE_ONLY PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
     │   │   │         rule: "index drop mutation visible before cleaning up index columns"
     │   │   │
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 2}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   └── • Precedence dependency from DELETE_ONLY PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
+    │   │   │         rule: "index drop mutation visible before cleaning up index columns"
+    │   │   │
     │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
     │   │   │   │ WRITE_ONLY → DELETE_ONLY
     │   │   │   │
     │   │   │   └── • PreviousStagePrecedence dependency from WRITE_ONLY TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
     │   │   │         rule: "TemporaryIndex transitions to ABSENT uphold 2-version invariant: WRITE_ONLY->DELETE_ONLY"
     │   │   │
-    │   │   └── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   └── • Precedence dependency from DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
+    │   │   │         rule: "index drop mutation visible before cleaning up index columns"
+    │   │   │
+    │   │   └── • IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 3}
     │   │       │ PUBLIC → ABSENT
     │   │       │
     │   │       └── • Precedence dependency from DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
     │   │             rule: "index drop mutation visible before cleaning up index columns"
     │   │
-    │   └── • 10 Mutation operations
+    │   └── • 12 Mutation operations
     │       │
     │       ├── • SetColumnName
     │       │     ColumnID: 2
@@ -87,6 +99,12 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 7 of 7;
     │       │     IndexID: 2
     │       │     TableID: 104
     │       │
+    │       ├── • RemoveColumnFromIndex
+    │       │     ColumnID: 3
+    │       │     IndexID: 2
+    │       │     Kind: 2
+    │       │     TableID: 104
+    │       │
     │       ├── • MakeWriteOnlyIndexDeleteOnly
     │       │     IndexID: 3
     │       │     TableID: 104
@@ -94,6 +112,12 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 7 of 7;
     │       ├── • RemoveColumnFromIndex
     │       │     ColumnID: 1
     │       │     IndexID: 3
+    │       │     TableID: 104
+    │       │
+    │       ├── • RemoveColumnFromIndex
+    │       │     ColumnID: 3
+    │       │     IndexID: 3
+    │       │     Kind: 2
     │       │     TableID: 104
     │       │
     │       ├── • MakeWriteOnlyColumnPublic
@@ -124,7 +148,10 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 7 of 7;
         │   │   ├── • Precedence dependency from ABSENT IndexName:{DescID: 104, Name: t_pkey, IndexID: 2}
         │   │   │     rule: "dependents removed before index"
         │   │   │
-        │   │   └── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 2}
+        │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 2}
+        │   │   │     rule: "dependents removed before index"
+        │   │   │
+        │   │   └── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 2}
         │   │         rule: "dependents removed before index"
         │   │
         │   ├── • IndexData:{DescID: 104, IndexID: 2}
@@ -139,7 +166,10 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 7 of 7;
         │   │   ├── • PreviousStagePrecedence dependency from DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
         │   │   │     rule: "TemporaryIndex transitions to ABSENT uphold 2-version invariant: DELETE_ONLY->ABSENT"
         │   │   │
-        │   │   └── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
+        │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
+        │   │   │     rule: "dependents removed before index"
+        │   │   │
+        │   │   └── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 3}
         │   │         rule: "dependents removed before index"
         │   │
         │   └── • IndexData:{DescID: 104, IndexID: 3}


### PR DESCRIPTION
Previously, when primary indexes where swapped for adding new columns, we would use conditional puts for updates. This was problematic because when computing the expected values for the new primary index we didn't include the new column, since its not readable yet. To address this, this patch uses force puts updating new primary indexes as a result of added / dropped columns, since there is no risk of key duplication.

Additionally, extend our testing to cover IUD during ADD/DROP COLUMN.

Fixes: #98130

Release note (bug fix): If an UPDATE was performed during an on-going ADD/DROP column change on a table, the update could incorrectly fail due to a duplicate key error.