### PR TITLE
release-22.2: opt: don't panic when recommending index with local and remote partitions

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/testdata/distsql_tenant_locality
+++ b/pkg/sql/opt/exec/execbuilder/testdata/distsql_tenant_locality
@@ -98,3 +98,42 @@ vectorized: true
   limit: 10
 ·
 Diagram: https://cockroachdb.github.io/distsqlplan/decode.html#eJyMUF9LvEAUff99iuE8_YpZnDHoYSAoNiPB_ZMKBSVhellkXcecMQrxu4f60G7Q1tucc-85c87tYF5LKHgP6-DKX7L_134UR3fBCYu8wJvH7JTdhKsFs-z-1gs9tmVPrRBndMEkC_yFHzMpwFHpnJbpjgzUIyQ4XCQcdaMzMkY3A92NS37-DiU4iqpu7UAnHJluCKqDLWxJUFjqma6dwSUnmxbluNZz6NZ-iYxNNwTl9nzPWB43jtOXkkJKc2occWAPe2mf6y19gGOuy3ZXGcW2nL2BI6rTATlSnDvSkbPx4YIjKHaFHfr_FE4ehPuldUim1pWhP9UWfcJB-YamyxrdNhmtG52N30xwNepGIidjp6k7Ab-aRkPAfbE8KhbfxEn_7zMAAP__RR61bw==
+
+
+# Regression test for #93887 - don't panic when generating index recommendations
+# with a mix of local and remote partitions.
+statement ok
+CREATE TABLE t93887 (x INT PRIMARY KEY, y INT) PARTITION BY LIST (x) (
+    PARTITION p1 VALUES IN (1),
+    PARTITION p2 VALUES IN (2),
+    PARTITION p3 VALUES IN (3)
+)
+
+statement ok
+ALTER PARTITION p1 OF TABLE t93887 CONFIGURE ZONE USING constraints='[+region=test]';
+ALTER PARTITION p2 OF TABLE t93887 CONFIGURE ZONE USING constraints='[+region=test1]';
+ALTER PARTITION p3 OF TABLE t93887 CONFIGURE ZONE USING constraints='[+region=test2]'
+
+statement ok
+SET index_recommendations_enabled = true;
+
+query T retry
+EXPLAIN SELECT * FROM t93887 WHERE y = 1
+----
+distribution: local
+vectorized: true
+·
+• filter
+│ filter: y = 1
+│
+└── • scan
+      missing stats
+      table: t93887@t93887_pkey
+      spans: FULL SCAN
+·
+index recommendations: 1
+1. type: index creation
+   SQL command: CREATE INDEX ON t93887 (y);
+
+statement ok
+RESET index_recommendations_enabled;

--- a/pkg/sql/opt/metadata.go
+++ b/pkg/sql/opt/metadata.go
@@ -21,6 +21,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/eval"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util"
@@ -628,7 +629,7 @@ func (md *Metadata) QualifiedAlias(
 
 // UpdateTableMeta allows the caller to replace the cat.Table struct that a
 // TableMeta instance stores.
-func (md *Metadata) UpdateTableMeta(tables map[cat.StableID]cat.Table) {
+func (md *Metadata) UpdateTableMeta(evalCtx *eval.Context, tables map[cat.StableID]cat.Table) {
 	for i := range md.tables {
 		oldTable := md.tables[i].Table
 		if newTable, ok := tables[oldTable.ID()]; ok {
@@ -644,6 +645,7 @@ func (md *Metadata) UpdateTableMeta(tables map[cat.StableID]cat.Table) {
 				md.SetTableAnnotation(md.tables[i].MetaID, NotNullAnnID, nil)
 			}
 			md.tables[i].Table = newTable
+			md.tables[i].CacheIndexPartitionLocalities(evalCtx)
 		}
 	}
 }

--- a/pkg/sql/opt/optbuilder/BUILD.bazel
+++ b/pkg/sql/opt/optbuilder/BUILD.bazel
@@ -65,7 +65,6 @@ go_library(
         "//pkg/sql/opt/norm",
         "//pkg/sql/opt/optgen/exprgen",
         "//pkg/sql/opt/partialidx",
-        "//pkg/sql/opt/partition",
         "//pkg/sql/opt/props",
         "//pkg/sql/opt/props/physical",
         "//pkg/sql/parser",

--- a/pkg/sql/opt/optbuilder/select.go
+++ b/pkg/sql/opt/optbuilder/select.go
@@ -18,7 +18,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/cat"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
-	"github.com/cockroachdb/cockroach/pkg/sql/opt/partition"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/props"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
@@ -641,7 +640,7 @@ func (b *Builder) buildScan(
 
 	b.addCheckConstraintsForTable(tabMeta)
 	b.addComputedColsForTable(tabMeta)
-	b.addIndexPartitionLocalitiesForTable(tabMeta)
+	tabMeta.CacheIndexPartitionLocalities(b.evalCtx)
 
 	outScope.expr = b.factory.ConstructScan(&private)
 
@@ -814,19 +813,6 @@ func (b *Builder) addComputedColsForTable(tabMeta *opt.TableMeta) {
 			if !sharedProps.VolatilitySet.HasStable() && !sharedProps.VolatilitySet.HasVolatile() {
 				tabMeta.AddComputedCol(colID, scalar)
 			}
-		}
-	}
-}
-
-// addIndexPartitionLocalitiesForTable caches locality prefix sorters in the
-// table metadata for indexes that have a mix of local and remote partitions.
-func (b *Builder) addIndexPartitionLocalitiesForTable(tabMeta *opt.TableMeta) {
-	tab := tabMeta.Table
-	for indexOrd, n := 0, tab.IndexCount(); indexOrd < n; indexOrd++ {
-		index := tab.Index(indexOrd)
-		if localPartitions, ok := partition.HasMixOfLocalAndRemotePartitions(b.evalCtx, index); ok {
-			ps := partition.GetSortedPrefixes(index, localPartitions, b.evalCtx)
-			tabMeta.AddIndexPartitionLocality(indexOrd, ps)
 		}
 	}
 }

--- a/pkg/sql/opt/table_meta.go
+++ b/pkg/sql/opt/table_meta.go
@@ -376,13 +376,22 @@ func (tm *TableMeta) OrigCheckConstraintsStats(
 	return nil, false
 }
 
-// AddIndexPartitionLocality adds a PrefixSorter to the table's metadata for the
-// index with IndexOrdinal ord.
-func (tm *TableMeta) AddIndexPartitionLocality(ord cat.IndexOrdinal, ps partition.PrefixSorter) {
-	if tm.indexPartitionLocalities == nil {
-		tm.indexPartitionLocalities = make([]partition.PrefixSorter, tm.Table.IndexCount())
+// CacheIndexPartitionLocalities caches locality prefix sorters in the table
+// metadata for indexes that have a mix of local and remote partitions. It can
+// be called multiple times if necessary to update with new indexes.
+func (tm *TableMeta) CacheIndexPartitionLocalities(evalCtx *eval.Context) {
+	tab := tm.Table
+	if cap(tm.indexPartitionLocalities) < tab.IndexCount() {
+		tm.indexPartitionLocalities = make([]partition.PrefixSorter, tab.IndexCount())
 	}
-	tm.indexPartitionLocalities[ord] = ps
+	tm.indexPartitionLocalities = tm.indexPartitionLocalities[:tab.IndexCount()]
+	for indexOrd, n := 0, tab.IndexCount(); indexOrd < n; indexOrd++ {
+		index := tab.Index(indexOrd)
+		if localPartitions, ok := partition.HasMixOfLocalAndRemotePartitions(evalCtx, index); ok {
+			ps := partition.GetSortedPrefixes(index, localPartitions, evalCtx)
+			tm.indexPartitionLocalities[indexOrd] = ps
+		}
+	}
 }
 
 // IndexPartitionLocality returns the given index's PrefixSorter. An empty
@@ -390,6 +399,11 @@ func (tm *TableMeta) AddIndexPartitionLocality(ord cat.IndexOrdinal, ps partitio
 // partitions.
 func (tm *TableMeta) IndexPartitionLocality(ord cat.IndexOrdinal) (ps partition.PrefixSorter) {
 	if tm.indexPartitionLocalities != nil {
+		if ord >= len(tm.indexPartitionLocalities) {
+			panic(errors.AssertionFailedf(
+				"index ordinal %d greater than length of indexPartitionLocalities", ord,
+			))
+		}
 		ps := tm.indexPartitionLocalities[ord]
 		return ps
 	}

--- a/pkg/sql/opt/testutils/opttester/opt_tester.go
+++ b/pkg/sql/opt/testutils/opttester/opt_tester.go
@@ -2250,7 +2250,7 @@ func (ot *OptTester) optimizeExpr(
 		return nil, err
 	}
 	if tables != nil {
-		o.Memo().Metadata().UpdateTableMeta(tables)
+		o.Memo().Metadata().UpdateTableMeta(&ot.evalCtx, tables)
 	}
 	root, err := o.Optimize()
 	if err != nil {

--- a/pkg/sql/plan_opt.go
+++ b/pkg/sql/plan_opt.go
@@ -785,7 +785,7 @@ func (opc *optPlanningCtx) makeQueryIndexRecommendation(ctx context.Context) (er
 		savedMemo.RootProps(),
 		f.CopyWithoutAssigningPlaceholders,
 	)
-	opc.optimizer.Memo().Metadata().UpdateTableMeta(hypTables)
+	opc.optimizer.Memo().Metadata().UpdateTableMeta(f.EvalContext(), hypTables)
 	if _, err = opc.optimizer.Optimize(); err != nil {
 		return err
 	}
@@ -796,7 +796,7 @@ func (opc *optPlanningCtx) makeQueryIndexRecommendation(ctx context.Context) (er
 	// update the saved memo's metadata with the original table information.
 	// Prepare to re-optimize and create an executable plan.
 	opc.optimizer.Init(ctx, f.EvalContext(), &opc.catalog)
-	savedMemo.Metadata().UpdateTableMeta(optTables)
+	savedMemo.Metadata().UpdateTableMeta(f.EvalContext(), optTables)
 	f.CopyAndReplace(
 		savedMemo.RootExpr().(memo.RelExpr),
 		savedMemo.RootProps(),


### PR DESCRIPTION
Backport 1/1 commits from #94671.

/cc @cockroachdb/release

---

Previously, it was possible for the optimizer to panic when running a query with `EXPLAIN` if it attempted to generate an index recommendation with both local and remote partitions. This is because the metadata wasn't fully updated to reflect the hypothetical index in `indexPartitionLocalities`. A later attempt to call `IndexPartitionLocality` for the hypothetical index led to an out-of-bounds error.

This patch ensures that the metadata is updated to include hypothetical indexes during index recommendation generation. This will prevent the panic.

Fixes #93887

Release note: None

Release justification: fix panic bug in optimizer when running explain