### PR TITLE
opt: evaluate non-strict UDFs when arguments are NULL

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/udf
+++ b/pkg/sql/logictest/testdata/logic_test/udf
@@ -3163,3 +3163,49 @@ CREATE FUNCTION f_97854 (f FLOAT) RETURNS CHAR LANGUAGE SQL AS $$ SELECT 'f' $$;
 # TODO(#88318): In Postgres, the float overload is chosen.
 statement error pgcode 42725 ambiguous call: f_97854\(decimal\).*
 SELECT f_97854(1.0)
+
+# Regression test for #93861 - non-strict UDFs should be evaluated with NULL
+# arguments.
+subtest regression_93861
+
+statement ok
+CREATE TABLE t93861(x INT);
+INSERT INTO t93861 VALUES (1), (2), (NULL);
+CREATE FUNCTION f93861_scalar (i INT) RETURNS INT CALLED ON NULL INPUT
+  LANGUAGE SQL AS $$ SELECT 1 $$;
+CREATE FUNCTION f93861_strict_scalar (i INT) RETURNS INT STRICT
+  LANGUAGE SQL AS $$ SELECT 1 $$;
+CREATE FUNCTION f93861_setof (i INT) RETURNS SETOF INT CALLED ON NULL INPUT
+  LANGUAGE SQL AS $$ SELECT * FROM generate_series(1, 3) $$;
+CREATE FUNCTION f93861_strict_setof (i INT) RETURNS SETOF INT STRICT
+  LANGUAGE SQL AS $$ SELECT * FROM generate_series(1, 3) $$;
+
+query III rowsort
+SELECT x, f93861_scalar(x), f93861_strict_scalar(x) FROM t93861;
+----
+1     1  1
+2     1  1
+NULL  1  NULL
+
+query II rowsort
+SELECT x, f93861_setof(x) FROM t93861;
+----
+1     1
+1     2
+1     3
+2     1
+2     2
+2     3
+NULL  1
+NULL  2
+NULL  3
+
+query II rowsort
+SELECT x, f93861_strict_setof(x) FROM t93861;
+----
+1  1
+1  2
+1  3
+2  1
+2  2
+2  3

--- a/pkg/sql/opt/optbuilder/scalar.go
+++ b/pkg/sql/opt/optbuilder/scalar.go
@@ -769,15 +769,23 @@ func (b *Builder) buildUDF(
 		}
 	}
 
+	// For set-returning functions, we handle STRICT behavior in the routine
+	// execution logic. For scalar UDFs this is handled by a CASE statement - see
+	// below.
+	calledOnNullInput := true
+	if isSetReturning {
+		calledOnNullInput = o.CalledOnNullInput
+	}
 	out = b.factory.ConstructUDF(
 		args,
 		&memo.UDFPrivate{
-			Name:         def.Name,
-			Params:       params,
-			Body:         rels,
-			Typ:          f.ResolvedType(),
-			SetReturning: isSetReturning,
-			Volatility:   o.Volatility,
+			Name:              def.Name,
+			Params:            params,
+			Body:              rels,
+			Typ:               f.ResolvedType(),
+			SetReturning:      isSetReturning,
+			Volatility:        o.Volatility,
+			CalledOnNullInput: calledOnNullInput,
 		},
 	)
 


### PR DESCRIPTION
This patch ensures that the `CalledOnNullInput` field is correctly set for set-returning UDFs to ensure that the routine execution logic will handle `STRICT` and `CalledOnNullInput` behavior. The `CalledOnNullInput` field is now set to true for scalar UDFs to ensure they are unconditionally evaluated, since `STRICT` scalar UDFs are implemented using inlined `CASE` statements.

Fixes #98361

Release note: None