### PR TITLE
opt: build ANY expressions as regular subqueries within UDFs

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/udf
+++ b/pkg/sql/logictest/testdata/logic_test/udf
@@ -2812,6 +2812,130 @@ SELECT a, sub_two() FROM sub_all
 5  2
 6  2
 
+subtest any_subquery
+
+statement ok
+CREATE TABLE any_tab (
+  a INT,
+  b INT
+)
+
+statement ok
+CREATE FUNCTION any_fn(i INT) RETURNS BOOL LANGUAGE SQL AS $$
+  SELECT i = ANY(SELECT a FROM any_tab)
+$$
+
+statement ok
+CREATE FUNCTION any_fn_lt(i INT) RETURNS BOOL LANGUAGE SQL AS $$
+  SELECT i < ANY(SELECT a FROM any_tab)
+$$
+
+statement ok
+CREATE FUNCTION any_fn_tuple(i INT, j INT) RETURNS BOOL LANGUAGE SQL AS $$
+  SELECT (i, j) = ANY(SELECT a, b FROM any_tab)
+$$
+
+# If the subquery returns no rows, the result should always be false.
+query BBB
+SELECT any_fn(1), any_fn(4), any_fn(NULL::INT)
+----
+false  false  false
+
+query BBB
+SELECT any_fn_lt(1), any_fn_lt(4), any_fn_lt(NULL::INT)
+----
+false  false  false
+
+query BBB
+SELECT any_fn_tuple(1, 10), any_fn_tuple(1, 20), any_fn_tuple(NULL::INT, NULL::INT)
+----
+false  false  false
+
+statement ok
+INSERT INTO any_tab VALUES (1, 10), (3, 30)
+
+query BBB
+SELECT any_fn(1), any_fn(4), any_fn(NULL::INT)
+----
+true  false  NULL
+
+query BBB
+SELECT any_fn_lt(1), any_fn_lt(4), any_fn_lt(NULL::INT)
+----
+true  false  NULL
+
+query BBB
+SELECT any_fn_tuple(1, 10), any_fn_tuple(1, 20), any_fn_tuple(NULL::INT, NULL::INT)
+----
+true  false  NULL
+
+statement ok
+INSERT INTO any_tab VALUES (NULL, NULL)
+
+query BBB
+SELECT any_fn(1), any_fn(4), any_fn(NULL::INT)
+----
+true  NULL  NULL
+
+query BBB
+SELECT any_fn_lt(1), any_fn_lt(4), any_fn_lt(NULL::INT)
+----
+true  NULL  NULL
+
+query BBB
+SELECT any_fn_tuple(1, 10), any_fn_tuple(1, 20), any_fn_tuple(NULL::INT, NULL::INT)
+----
+true  NULL  NULL
+
+statement ok
+CREATE FUNCTION any_fn2(i INT) RETURNS SETOF INT LANGUAGE SQL AS $$
+  SELECT b FROM (VALUES (1), (2), (3), (NULL)) v(b)
+  WHERE b = ANY (SELECT a FROM any_tab WHERE a <= i)
+$$
+
+query I
+SELECT any_fn2(2)
+----
+1
+
+query I rowsort
+SELECT any_fn2(3)
+----
+1
+3
+
+subtest all_subquery
+
+statement ok
+CREATE TABLE all_tab (a INT)
+
+statement ok
+CREATE FUNCTION all_fn(i INT) RETURNS BOOL LANGUAGE SQL AS $$
+  SELECT i = ALL(SELECT a FROM all_tab)
+$$
+
+# If the subquery returns no rows, the result should always be true.
+query BBB
+SELECT all_fn(1), all_fn(2), all_fn(NULL::INT)
+----
+true  true  true
+
+statement ok
+INSERT INTO all_tab VALUES (1), (1);
+
+query BBB
+SELECT all_fn(1), all_fn(2), all_fn(NULL::INT)
+----
+true  false  NULL
+
+statement ok
+INSERT INTO all_tab VALUES (NULL);
+
+query BBB
+SELECT all_fn(1), all_fn(2), all_fn(NULL::INT)
+----
+NULL  false  NULL
+
 
 subtest variadic
 
@@ -2922,10 +3046,10 @@ SELECT oid, proname, pronamespace, proowner, prolang, proleakproof, proisstrict,
 FROM pg_catalog.pg_proc WHERE proname IN ('f_93314', 'f_93314_alias', 'f_93314_comp', 'f_93314_comp_t')
 ORDER BY oid;
 ----
-100264  f_93314         105  1546506610  14  false  false  false  v  0  100263  ·  {}  NULL  SELECT i, e FROM test.public.t_93314 ORDER BY i LIMIT 1;
-100266  f_93314_alias   105  1546506610  14  false  false  false  v  0  100265  ·  {}  NULL  SELECT i, e FROM test.public.t_93314_alias ORDER BY i LIMIT 1;
-100270  f_93314_comp    105  1546506610  14  false  false  false  v  0  100267  ·  {}  NULL  SELECT (1, 2);
-100271  f_93314_comp_t  105  1546506610  14  false  false  false  v  0  100269  ·  {}  NULL  SELECT a, c FROM test.public.t_93314_comp LIMIT 1;
+100271  f_93314         105  1546506610  14  false  false  false  v  0  100270  ·  {}  NULL  SELECT i, e FROM test.public.t_93314 ORDER BY i LIMIT 1;
+100273  f_93314_alias   105  1546506610  14  false  false  false  v  0  100272  ·  {}  NULL  SELECT i, e FROM test.public.t_93314_alias ORDER BY i LIMIT 1;
+100277  f_93314_comp    105  1546506610  14  false  false  false  v  0  100274  ·  {}  NULL  SELECT (1, 2);
+100278  f_93314_comp_t  105  1546506610  14  false  false  false  v  0  100276  ·  {}  NULL  SELECT a, c FROM test.public.t_93314_comp LIMIT 1;
 
 # Regression test for #95240. Strict UDFs that are inlined should result in NULL
 # when presented with NULL arguments.

--- a/pkg/sql/opt/optbuilder/builder.go
+++ b/pkg/sql/opt/optbuilder/builder.go
@@ -125,6 +125,14 @@ type Builder struct {
 	// are disabled and only statements whitelisted are allowed.
 	insideFuncDef bool
 
+	// insideUDF is true when the current expressions are being built within a
+	// UDF.
+	// TODO(mgartner): Once other UDFs can be referenced from within a UDF, a
+	// boolean will not be sufficient to track whether or not we are in a UDF.
+	// We'll need to track the depth of the UDFs we are building expressions
+	// within.
+	insideUDF bool
+
 	// If set, we are collecting view dependencies in schemaDeps. This can only
 	// happen inside view/function definitions.
 	//

--- a/pkg/sql/opt/optbuilder/scalar.go
+++ b/pkg/sql/opt/optbuilder/scalar.go
@@ -687,6 +687,11 @@ func (b *Builder) buildUDF(
 	// Build an expression for each statement in the function body.
 	rels := make(memo.RelListExpr, len(stmts))
 	isSetReturning := o.Class == tree.GeneratorClass
+	// TODO(mgartner): Once other UDFs can be referenced from within a UDF, a
+	// boolean will not be sufficient to track whether or not we are in a UDF.
+	// We'll need to track the depth of the UDFs we are building expressions
+	// within.
+	b.insideUDF = true
 	for i := range stmts {
 		stmtScope := b.buildStmt(stmts[i].AST, nil /* desiredTypes */, bodyScope)
 		expr := stmtScope.expr
@@ -768,6 +773,7 @@ func (b *Builder) buildUDF(
 			PhysProps: physProps,
 		}
 	}
+	b.insideUDF = false
 
 	// For set-returning functions, we handle STRICT behavior in the routine
 	// execution logic. For scalar UDFs this is handled by a CASE statement - see

--- a/pkg/sql/opt/optbuilder/testdata/udf
+++ b/pkg/sql/opt/optbuilder/testdata/udf
@@ -1329,3 +1329,228 @@ project
                                     └── gt
                                          ├── variable: a:7
                                          └── variable: i:6
+
+
+# --------------------------------------------------
+# UDFs with ANY/ALL expressions.
+# --------------------------------------------------
+
+exec-ddl
+CREATE FUNCTION any_fn(i INT) RETURNS BOOL LANGUAGE SQL AS 'SELECT i = ANY(SELECT a FROM abc)'
+----
+
+build format=show-scalars
+SELECT any_fn(10)
+----
+project
+ ├── columns: any_fn:11
+ ├── values
+ │    └── tuple
+ └── projections
+      └── udf: any_fn [as=any_fn:11]
+           ├── params: i:1
+           ├── args
+           │    └── const: 10
+           └── body
+                └── limit
+                     ├── columns: "?column?":10
+                     ├── project
+                     │    ├── columns: "?column?":10
+                     │    ├── values
+                     │    │    └── tuple
+                     │    └── projections
+                     │         └── subquery [as="?column?":10]
+                     │              └── project
+                     │                   ├── columns: case:9
+                     │                   ├── scalar-group-by
+                     │                   │    ├── columns: bool_or:8
+                     │                   │    ├── project
+                     │                   │    │    ├── columns: notnull:7!null
+                     │                   │    │    ├── select
+                     │                   │    │    │    ├── columns: a:2!null
+                     │                   │    │    │    ├── project
+                     │                   │    │    │    │    ├── columns: a:2!null
+                     │                   │    │    │    │    └── scan abc
+                     │                   │    │    │    │         └── columns: a:2!null b:3 c:4 crdb_internal_mvcc_timestamp:5 tableoid:6
+                     │                   │    │    │    └── filters
+                     │                   │    │    │         └── is-not
+                     │                   │    │    │              ├── eq
+                     │                   │    │    │              │    ├── variable: i:1
+                     │                   │    │    │              │    └── variable: a:2
+                     │                   │    │    │              └── false
+                     │                   │    │    └── projections
+                     │                   │    │         └── is-not [as=notnull:7]
+                     │                   │    │              ├── variable: a:2
+                     │                   │    │              └── null
+                     │                   │    └── aggregations
+                     │                   │         └── bool-or [as=bool_or:8]
+                     │                   │              └── variable: notnull:7
+                     │                   └── projections
+                     │                        └── case [as=case:9]
+                     │                             ├── true
+                     │                             ├── when
+                     │                             │    ├── and
+                     │                             │    │    ├── variable: bool_or:8
+                     │                             │    │    └── is-not
+                     │                             │    │         ├── variable: i:1
+                     │                             │    │         └── null
+                     │                             │    └── true
+                     │                             ├── when
+                     │                             │    ├── is
+                     │                             │    │    ├── variable: bool_or:8
+                     │                             │    │    └── null
+                     │                             │    └── false
+                     │                             └── null
+                     └── const: 1
+
+exec-ddl
+CREATE FUNCTION all_fn(i INT) RETURNS BOOL LANGUAGE SQL AS 'SELECT i < ALL(SELECT a FROM abc WHERE b > i)'
+----
+
+build format=show-scalars
+SELECT all_fn(10)
+----
+project
+ ├── columns: all_fn:11
+ ├── values
+ │    └── tuple
+ └── projections
+      └── udf: all_fn [as=all_fn:11]
+           ├── params: i:1
+           ├── args
+           │    └── const: 10
+           └── body
+                └── limit
+                     ├── columns: "?column?":10
+                     ├── project
+                     │    ├── columns: "?column?":10
+                     │    ├── values
+                     │    │    └── tuple
+                     │    └── projections
+                     │         └── not [as="?column?":10]
+                     │              └── subquery
+                     │                   └── project
+                     │                        ├── columns: case:9
+                     │                        ├── scalar-group-by
+                     │                        │    ├── columns: bool_or:8
+                     │                        │    ├── project
+                     │                        │    │    ├── columns: notnull:7!null
+                     │                        │    │    ├── select
+                     │                        │    │    │    ├── columns: a:2!null
+                     │                        │    │    │    ├── project
+                     │                        │    │    │    │    ├── columns: a:2!null
+                     │                        │    │    │    │    └── select
+                     │                        │    │    │    │         ├── columns: a:2!null b:3!null c:4 crdb_internal_mvcc_timestamp:5 tableoid:6
+                     │                        │    │    │    │         ├── scan abc
+                     │                        │    │    │    │         │    └── columns: a:2!null b:3 c:4 crdb_internal_mvcc_timestamp:5 tableoid:6
+                     │                        │    │    │    │         └── filters
+                     │                        │    │    │    │              └── gt
+                     │                        │    │    │    │                   ├── variable: b:3
+                     │                        │    │    │    │                   └── variable: i:1
+                     │                        │    │    │    └── filters
+                     │                        │    │    │         └── is-not
+                     │                        │    │    │              ├── ge
+                     │                        │    │    │              │    ├── variable: i:1
+                     │                        │    │    │              │    └── variable: a:2
+                     │                        │    │    │              └── false
+                     │                        │    │    └── projections
+                     │                        │    │         └── is-not [as=notnull:7]
+                     │                        │    │              ├── variable: a:2
+                     │                        │    │              └── null
+                     │                        │    └── aggregations
+                     │                        │         └── bool-or [as=bool_or:8]
+                     │                        │              └── variable: notnull:7
+                     │                        └── projections
+                     │                             └── case [as=case:9]
+                     │                                  ├── true
+                     │                                  ├── when
+                     │                                  │    ├── and
+                     │                                  │    │    ├── variable: bool_or:8
+                     │                                  │    │    └── is-not
+                     │                                  │    │         ├── variable: i:1
+                     │                                  │    │         └── null
+                     │                                  │    └── true
+                     │                                  ├── when
+                     │                                  │    ├── is
+                     │                                  │    │    ├── variable: bool_or:8
+                     │                                  │    │    └── null
+                     │                                  │    └── false
+                     │                                  └── null
+                     └── const: 1
+
+exec-ddl
+CREATE FUNCTION any_fn_tuple(i INT, j INT) RETURNS BOOL LANGUAGE SQL AS 'SELECT (i, j) = ANY(SELECT a, b FROM abc)'
+----
+
+build format=show-scalars
+SELECT any_fn_tuple(10, 20)
+----
+project
+ ├── columns: any_fn_tuple:13
+ ├── values
+ │    └── tuple
+ └── projections
+      └── udf: any_fn_tuple [as=any_fn_tuple:13]
+           ├── params: i:1 j:2
+           ├── args
+           │    ├── const: 10
+           │    └── const: 20
+           └── body
+                └── limit
+                     ├── columns: "?column?":12
+                     ├── project
+                     │    ├── columns: "?column?":12
+                     │    ├── values
+                     │    │    └── tuple
+                     │    └── projections
+                     │         └── subquery [as="?column?":12]
+                     │              └── project
+                     │                   ├── columns: case:11
+                     │                   ├── scalar-group-by
+                     │                   │    ├── columns: bool_or:10
+                     │                   │    ├── project
+                     │                   │    │    ├── columns: notnull:9!null
+                     │                   │    │    ├── select
+                     │                   │    │    │    ├── columns: column8:8
+                     │                   │    │    │    ├── project
+                     │                   │    │    │    │    ├── columns: column8:8
+                     │                   │    │    │    │    ├── project
+                     │                   │    │    │    │    │    ├── columns: a:3!null b:4
+                     │                   │    │    │    │    │    └── scan abc
+                     │                   │    │    │    │    │         └── columns: a:3!null b:4 c:5 crdb_internal_mvcc_timestamp:6 tableoid:7
+                     │                   │    │    │    │    └── projections
+                     │                   │    │    │    │         └── tuple [as=column8:8]
+                     │                   │    │    │    │              ├── variable: a:3
+                     │                   │    │    │    │              └── variable: b:4
+                     │                   │    │    │    └── filters
+                     │                   │    │    │         └── is-not
+                     │                   │    │    │              ├── eq
+                     │                   │    │    │              │    ├── tuple
+                     │                   │    │    │              │    │    ├── variable: i:1
+                     │                   │    │    │              │    │    └── variable: j:2
+                     │                   │    │    │              │    └── variable: column8:8
+                     │                   │    │    │              └── false
+                     │                   │    │    └── projections
+                     │                   │    │         └── is-tuple-not-null [as=notnull:9]
+                     │                   │    │              └── variable: column8:8
+                     │                   │    └── aggregations
+                     │                   │         └── bool-or [as=bool_or:10]
+                     │                   │              └── variable: notnull:9
+                     │                   └── projections
+                     │                        └── case [as=case:11]
+                     │                             ├── true
+                     │                             ├── when
+                     │                             │    ├── and
+                     │                             │    │    ├── variable: bool_or:10
+                     │                             │    │    └── is-tuple-not-null
+                     │                             │    │         └── tuple
+                     │                             │    │              ├── variable: i:1
+                     │                             │    │              └── variable: j:2
+                     │                             │    └── true
+                     │                             ├── when
+                     │                             │    ├── is
+                     │                             │    │    ├── variable: bool_or:10
+                     │                             │    │    └── null
+                     │                             │    └── false
+                     │                             └── null
+                     └── const: 1

--- a/pkg/sql/opt/xform/scan_funcs.go
+++ b/pkg/sql/opt/xform/scan_funcs.go
@@ -34,14 +34,13 @@ import (
 // in that it behaves the exactly the same as a non-partial secondary index.
 //
 // NOTE: This does not generate index joins for non-covering indexes (except in
-//
-//	case of ForceIndex). Index joins are usually only introduced "one level
-//	up", when the Scan operator is wrapped by an operator that constrains
-//	or limits scan output in some way (e.g. Select, Limit, InnerJoin).
-//	Index joins are only lower cost when their input does not include all
-//	rows from the table. See GenerateConstrainedScans,
-//	GenerateLimitedScans, and GenerateLimitedGroupByScans for cases where
-//	index joins are introduced into the memo.
+// case of ForceIndex). Index joins are usually only introduced "one level up",
+// when the Scan operator is wrapped by an operator that constrains or limits
+// scan output in some way (e.g. Select, Limit, InnerJoin). Index joins are only
+// lower cost when their input does not include all rows from the table. See
+// GenerateConstrainedScans, GenerateLimitedScans, and
+// GenerateLimitedGroupByScans for cases where index joins are introduced into
+// the memo.
 func (c *CustomFuncs) GenerateIndexScans(
 	grp memo.RelExpr, required *physical.Required, scanPrivate *memo.ScanPrivate,
 ) {


### PR DESCRIPTION
#### opt: build ANY expressions as regular subqueries within UDFs

To support execution of ANY expressions within UDFs, the optimizer
builds them as subqueries with GroupBy expressions instead. The
transformation simulates the peculiar behavior of ANY expressions. See
`CustomFuncs.ConstructGroupByAny` for more details on this
transformation.

By constructing ANY expressions within UDFs as subqueries, we avoid
adding complexity to the execution engine, which is not currently
capable of evaluating ANY expressions within the context of a UDF.

Fixes #87291

Release note: None

#### opt: fix GenerateIndexScans comment

Release note: None
