### PR TITLE
release-22.2: sql/schemachanger: ensure version gates at 22.2 final

### DIFF
--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_table.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_table.go
@@ -47,15 +47,15 @@ type supportedAlterTableCommand struct {
 // declarative schema  changer. Operations marked as non-fully supported can
 // only be with the use_declarative_schema_changer session variable.
 var supportedAlterTableStatements = map[reflect.Type]supportedAlterTableCommand{
-	reflect.TypeOf((*tree.AlterTableAddColumn)(nil)):       {fn: alterTableAddColumn, on: true, minSupportedClusterVersion: clusterversion.Start22_2},
-	reflect.TypeOf((*tree.AlterTableDropColumn)(nil)):      {fn: alterTableDropColumn, on: true, minSupportedClusterVersion: clusterversion.Start22_2},
-	reflect.TypeOf((*tree.AlterTableAlterPrimaryKey)(nil)): {fn: alterTableAlterPrimaryKey, on: true, minSupportedClusterVersion: clusterversion.Start22_2},
+	reflect.TypeOf((*tree.AlterTableAddColumn)(nil)):       {fn: alterTableAddColumn, on: true, minSupportedClusterVersion: clusterversion.V22_2},
+	reflect.TypeOf((*tree.AlterTableDropColumn)(nil)):      {fn: alterTableDropColumn, on: true, minSupportedClusterVersion: clusterversion.V22_2},
+	reflect.TypeOf((*tree.AlterTableAlterPrimaryKey)(nil)): {fn: alterTableAlterPrimaryKey, on: true, minSupportedClusterVersion: clusterversion.V22_2},
 	reflect.TypeOf((*tree.AlterTableAddConstraint)(nil)): {fn: alterTableAddConstraint, on: true, extraChecks: func(
 		t *tree.AlterTableAddConstraint,
 	) bool {
 		d, ok := t.ConstraintDef.(*tree.UniqueConstraintTableDef)
 		return ok && d.PrimaryKey && t.ValidationBehavior == tree.ValidationDefault
-	}, minSupportedClusterVersion: clusterversion.Start22_2},
+	}, minSupportedClusterVersion: clusterversion.V22_2},
 }
 
 func init() {

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/process.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/process.go
@@ -69,22 +69,22 @@ var supportedStatements = map[reflect.Type]supportedStatement{
 	// supportedAlterTableStatements list, so wwe will consider it fully supported
 	// here.
 	reflect.TypeOf((*tree.AlterTable)(nil)):          {fn: AlterTable, on: true, extraChecks: alterTableIsSupported},
-	reflect.TypeOf((*tree.CreateIndex)(nil)):         {fn: CreateIndex, on: false, minSupportedClusterVersion: clusterversion.Start22_2},
+	reflect.TypeOf((*tree.CreateIndex)(nil)):         {fn: CreateIndex, on: false, minSupportedClusterVersion: clusterversion.V22_2},
 	reflect.TypeOf((*tree.DropDatabase)(nil)):        {fn: DropDatabase, on: true, minSupportedClusterVersion: clusterversion.V22_1},
-	reflect.TypeOf((*tree.DropOwnedBy)(nil)):         {fn: DropOwnedBy, on: true, minSupportedClusterVersion: clusterversion.Start22_2},
+	reflect.TypeOf((*tree.DropOwnedBy)(nil)):         {fn: DropOwnedBy, on: true, minSupportedClusterVersion: clusterversion.V22_2},
 	reflect.TypeOf((*tree.DropSchema)(nil)):          {fn: DropSchema, on: true, minSupportedClusterVersion: clusterversion.V22_1},
 	reflect.TypeOf((*tree.DropSequence)(nil)):        {fn: DropSequence, on: true, minSupportedClusterVersion: clusterversion.V22_1},
 	reflect.TypeOf((*tree.DropTable)(nil)):           {fn: DropTable, on: true, minSupportedClusterVersion: clusterversion.V22_1},
 	reflect.TypeOf((*tree.DropType)(nil)):            {fn: DropType, on: true, minSupportedClusterVersion: clusterversion.V22_1},
 	reflect.TypeOf((*tree.DropView)(nil)):            {fn: DropView, on: true, minSupportedClusterVersion: clusterversion.V22_1},
-	reflect.TypeOf((*tree.CommentOnDatabase)(nil)):   {fn: CommentOnDatabase, on: true, minSupportedClusterVersion: clusterversion.Start22_2},
-	reflect.TypeOf((*tree.CommentOnSchema)(nil)):     {fn: CommentOnSchema, on: true, minSupportedClusterVersion: clusterversion.Start22_2},
-	reflect.TypeOf((*tree.CommentOnTable)(nil)):      {fn: CommentOnTable, on: true, minSupportedClusterVersion: clusterversion.Start22_2},
-	reflect.TypeOf((*tree.CommentOnColumn)(nil)):     {fn: CommentOnColumn, on: true, minSupportedClusterVersion: clusterversion.Start22_2},
-	reflect.TypeOf((*tree.CommentOnIndex)(nil)):      {fn: CommentOnIndex, on: true, minSupportedClusterVersion: clusterversion.Start22_2},
-	reflect.TypeOf((*tree.CommentOnConstraint)(nil)): {fn: CommentOnConstraint, on: true, minSupportedClusterVersion: clusterversion.Start22_2},
+	reflect.TypeOf((*tree.CommentOnDatabase)(nil)):   {fn: CommentOnDatabase, on: true, minSupportedClusterVersion: clusterversion.V22_2},
+	reflect.TypeOf((*tree.CommentOnSchema)(nil)):     {fn: CommentOnSchema, on: true, minSupportedClusterVersion: clusterversion.V22_2},
+	reflect.TypeOf((*tree.CommentOnTable)(nil)):      {fn: CommentOnTable, on: true, minSupportedClusterVersion: clusterversion.V22_2},
+	reflect.TypeOf((*tree.CommentOnColumn)(nil)):     {fn: CommentOnColumn, on: true, minSupportedClusterVersion: clusterversion.V22_2},
+	reflect.TypeOf((*tree.CommentOnIndex)(nil)):      {fn: CommentOnIndex, on: true, minSupportedClusterVersion: clusterversion.V22_2},
+	reflect.TypeOf((*tree.CommentOnConstraint)(nil)): {fn: CommentOnConstraint, on: true, minSupportedClusterVersion: clusterversion.V22_2},
 	// TODO (Xiang): turn on `DROP INDEX` as fully supported.
-	reflect.TypeOf((*tree.DropIndex)(nil)): {fn: DropIndex, on: false, minSupportedClusterVersion: clusterversion.Start22_2},
+	reflect.TypeOf((*tree.DropIndex)(nil)): {fn: DropIndex, on: false, minSupportedClusterVersion: clusterversion.V22_2},
 }
 
 func init() {


### PR DESCRIPTION
Previously, the versions gates were incorrectly set to the final version of the previous release, which could lead to broken schema changes for ALTER TABLE ADD/DROP column (among other new decalrative schema changes). This patch, sets the version gates correctly to the final version of the 22.2 release.

Fixes: #98372

Release note (bug fix): Schema changes which use
the declarative schema changer in a mixed version
state upgrading from 22.1 does not execute properly.

Release justification: low risk only and avoids a bug that can lead tables in a bad state.