### PR TITLE
cli,server: initial cluster configuration via job injection

### DIFF
--- a/pkg/base/test_server_args.go
+++ b/pkg/base/test_server_args.go
@@ -168,6 +168,12 @@ type TestServerArgs struct {
 	// ObsServiceAddr is the address to which events will be exported over OTLP.
 	// If empty, exporting events is inhibited.
 	ObsServiceAddr string
+
+	// InjectedSQL configures some configuration SQL to inject as
+	// one-off jobs into the SQL system. This is used when setting up
+	// clusters initially.
+	// The concrete type of this field must be []*jobspb.InjectedSQLDetails.
+	InjectedSQL interface{}
 }
 
 // TestClusterArgs contains the parameters one can set when creating a test

--- a/pkg/cli/BUILD.bazel
+++ b/pkg/cli/BUILD.bazel
@@ -46,6 +46,7 @@ go_library(
         "node.go",
         "nodelocal.go",
         "prefixer.go",
+        "profiles.go",
         "rpc_client.go",
         "rpc_node_shutdown.go",
         "sql_client.go",

--- a/pkg/cli/cliflags/flags.go
+++ b/pkg/cli/cliflags/flags.go
@@ -1449,6 +1449,12 @@ Disable the creation of a default dataset in the demo shell.
 This makes 'cockroach demo' faster to start.`,
 	}
 
+	InitProfile = FlagInfo{
+		Name:        "init-profile",
+		EnvVar:      "COCKROACH_INIT_PROFILE",
+		Description: `Configuration to use during cluster initialization.`,
+	}
+
 	GeoLibsDir = FlagInfo{
 		Name: "spatial-libs",
 		Description: `

--- a/pkg/cli/context.go
+++ b/pkg/cli/context.go
@@ -639,6 +639,7 @@ func setDemoContextDefaults() {
 	demoCtx.Multitenant = true
 	demoCtx.DisableServerController = false
 	demoCtx.DefaultEnableRangefeeds = true
+	demoCtx.InjectedSQL = nil
 
 	demoCtx.pidFile = ""
 	demoCtx.disableEnterpriseFeatures = false

--- a/pkg/cli/democluster/BUILD.bazel
+++ b/pkg/cli/democluster/BUILD.bazel
@@ -22,6 +22,7 @@ go_library(
         "//pkg/cli/cliflags",
         "//pkg/cli/democluster/api",
         "//pkg/jobs",
+        "//pkg/jobs/jobspb",
         "//pkg/kv/kvserver/liveness/livenesspb",
         "//pkg/roachpb",
         "//pkg/rpc",

--- a/pkg/cli/democluster/context.go
+++ b/pkg/cli/democluster/context.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/cli/clicfg"
+	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
 	"github.com/cockroachdb/cockroach/pkg/workload"
 )
 
@@ -110,6 +111,9 @@ type Context struct {
 	// DisableServerController is true if we want to avoid the server
 	// controller to instantiate tenant secondary servers.
 	DisableServerController bool
+
+	// InjectedSQL contains initial SQL to execute upon cluster creation.
+	InjectedSQL []*jobspb.InjectedSQLDetails
 }
 
 // IsInteractive returns true if the demo cluster configuration

--- a/pkg/cli/democluster/demo_cluster.go
+++ b/pkg/cli/democluster/demo_cluster.go
@@ -883,6 +883,7 @@ func (demoCtx *Context) testServerArgsForTransientCluster(
 		StoreSpecs:              []base.StoreSpec{storeSpec},
 		SQLMemoryPoolSize:       demoCtx.SQLPoolMemorySize,
 		CacheSize:               demoCtx.CacheSize,
+		InjectedSQL:             demoCtx.InjectedSQL,
 		NoAutoInitializeCluster: true,
 		EnableDemoLoginEndpoint: true,
 		// Demo clusters by default will create their own tenants, so we

--- a/pkg/cli/flags.go
+++ b/pkg/cli/flags.go
@@ -393,6 +393,11 @@ func init() {
 		// planning?
 		if cmd != connectInitCmd && cmd != connectJoinCmd {
 			cliflagcfg.StringFlag(f, &serverCfg.Attrs, cliflags.Attrs)
+
+			// Cluster initialization. We only do this for a regular start command;
+			// SQL-only servers get their initialization payload from their tenant
+			// configuration.
+			cliflagcfg.VarFlag(f, &profileSetter{profileName: "default", injected: &serverCfg.InjectedSQL}, cliflags.InitProfile)
 		}
 	}
 
@@ -828,6 +833,8 @@ func init() {
 		cliflagcfg.IntFlag(f, &demoCtx.HTTPPort, cliflags.DemoHTTPPort)
 		cliflagcfg.StringFlag(f, &demoCtx.ListeningURLFile, cliflags.ListeningURLFile)
 		cliflagcfg.StringFlag(f, &demoCtx.pidFile, cliflags.PIDFile)
+
+		cliflagcfg.VarFlag(f, &profileSetter{profileName: "default", injected: &demoCtx.InjectedSQL}, cliflags.InitProfile)
 	}
 
 	{

--- a/pkg/cli/profiles.go
+++ b/pkg/cli/profiles.go
@@ -1,0 +1,45 @@
+package cli
+
+import (
+	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
+	"github.com/cockroachdb/errors"
+)
+
+type profileSetter struct {
+	profileName string
+	injected    *[]*jobspb.InjectedSQLDetails
+}
+
+// String implements the pflag.Value interface.
+func (p *profileSetter) String() string {
+	return p.profileName
+}
+
+// Type implements the pflag.Value interface.
+func (p *profileSetter) Type() string { return "<config profile>" }
+
+// Set implements the pflag.Value interface.
+func (p *profileSetter) Set(v string) error {
+	ij, ok := initProfiles[v]
+	if !ok {
+		return errors.Newf("unknown profile: %q", v)
+	}
+	res := make([]*jobspb.InjectedSQLDetails, len(ij))
+	for i := range ij {
+		res[i] = &ij[i]
+	}
+	*p.injected = res
+	return nil
+}
+
+var initProfiles = map[string][]jobspb.InjectedSQLDetails{
+	"default": nil,
+	"foo": {
+		{
+			InjectionID: 123,
+			Statements: []string{
+				"CREATE TABLE IF NOT EXISTS system.foo(x INT)",
+			},
+		},
+	},
+}

--- a/pkg/jobs/jobspb/jobs.proto
+++ b/pkg/jobs/jobspb/jobs.proto
@@ -854,6 +854,21 @@ message SchemaChangeDetails {
   // Next id 13.
 }
 
+// InjectedSQLDetails represents a SQL payload injected from "outside"
+// the SQL layer, during initialization.
+message InjectedSQLDetails {
+  // InjectionID is the idempotency key for this injected job payload
+  // within the tenant. It ensures that if multiple SQL servers receive
+  // a job payload with that ID, only one job will be created.
+  int64 injection_id = 1 [(gogoproto.customname) = "InjectionID"];
+  // Statements represents the SQL statements to execute.
+  repeated string statements = 2;
+}
+
+message InjectedSQLProgress {
+
+}
+
 message SchemaChangeProgress {
 
 }
@@ -1221,6 +1236,8 @@ message Payload {
     // PollJobsStats jobs poll the jobs table for statistics metrics as the number of
     // paused jobs.
     PollJobsStatsDetails poll_jobs_stats = 39;
+
+    InjectedSQLDetails injectedSQL = 41;
   }
   reserved 26;
   // PauseReason is used to describe the reason that the job is currently paused
@@ -1248,7 +1265,7 @@ message Payload {
   // specifies how old such record could get before this job is canceled.
   int64 maximum_pts_age = 40 [(gogoproto.casttype) = "time.Duration",  (gogoproto.customname) = "MaximumPTSAge"];
 
-  // NEXT ID: 41
+  // NEXT ID: 42
 }
 
 message Progress {
@@ -1290,6 +1307,7 @@ message Progress {
     SchemaTelemetryProgress schema_telemetry = 26;
     KeyVisualizerProgress keyVisualizerProgress = 27;
     PollJobsStatsProgress pollJobsStats = 28;
+    InjectedSQLProgress injectedSQL = 29;
   }
 
   uint64 trace_id = 21 [(gogoproto.nullable) = false, (gogoproto.customname) = "TraceID", (gogoproto.customtype) = "github.com/cockroachdb/cockroach/pkg/util/tracing/tracingpb.TraceID"];
@@ -1321,6 +1339,7 @@ enum Type {
   AUTO_SCHEMA_TELEMETRY = 17 [(gogoproto.enumvalue_customname) = "TypeAutoSchemaTelemetry"];
   KEY_VISUALIZER = 18 [(gogoproto.enumvalue_customname) = "TypeKeyVisualizer"];
   POLL_JOBS_STATS = 19 [(gogoproto.enumvalue_customname) = "TypePollJobsStats"];
+  INJECTED_SQL = 20 [(gogoproto.enumvalue_customname) = "TypeInjectedSQL"];
 }
 
 message Job {

--- a/pkg/jobs/jobspb/wrap.go
+++ b/pkg/jobs/jobspb/wrap.go
@@ -48,6 +48,7 @@ var (
 	_ Details = RowLevelTTLDetails{}
 	_ Details = SchemaTelemetryDetails{}
 	_ Details = KeyVisualizerDetails{}
+	_ Details = InjectedSQLDetails{}
 )
 
 // ProgressDetails is a marker interface for job progress details proto structs.
@@ -68,6 +69,7 @@ var (
 	_ ProgressDetails = RowLevelTTLProgress{}
 	_ ProgressDetails = SchemaTelemetryProgress{}
 	_ ProgressDetails = KeyVisualizerProgress{}
+	_ ProgressDetails = InjectedSQLProgress{}
 )
 
 // Type returns the payload's job type and panics if the type is invalid.
@@ -146,6 +148,7 @@ var AutomaticJobTypes = [...]Type{
 	TypeAutoSQLStatsCompaction,
 	TypeAutoSchemaTelemetry,
 	TypePollJobsStats,
+	TypeInjectedSQL,
 }
 
 // DetailsType returns the type for a payload detail.
@@ -191,6 +194,8 @@ func DetailsType(d isPayload_Details) (Type, error) {
 		return TypeKeyVisualizer, nil
 	case *Payload_PollJobsStats:
 		return TypePollJobsStats, nil
+	case *Payload_InjectedSQL:
+		return TypeInjectedSQL, nil
 	default:
 		return TypeUnspecified, errors.Newf("Payload.Type called on a payload with an unknown details type: %T", d)
 	}
@@ -231,6 +236,7 @@ var JobDetailsForEveryJobType = map[Type]Details{
 	TypeAutoSchemaTelemetry:          SchemaTelemetryDetails{},
 	TypeKeyVisualizer:                KeyVisualizerDetails{},
 	TypePollJobsStats:                PollJobsStatsDetails{},
+	TypeInjectedSQL:                  InjectedSQLDetails{},
 }
 
 // WrapProgressDetails wraps a ProgressDetails object in the protobuf wrapper
@@ -278,6 +284,8 @@ func WrapProgressDetails(details ProgressDetails) interface {
 		return &Progress_KeyVisualizerProgress{KeyVisualizerProgress: &d}
 	case PollJobsStatsProgress:
 		return &Progress_PollJobsStats{PollJobsStats: &d}
+	case InjectedSQLProgress:
+		return &Progress_InjectedSQL{InjectedSQL: &d}
 	default:
 		panic(errors.AssertionFailedf("WrapProgressDetails: unknown progress type %T", d))
 	}
@@ -323,6 +331,8 @@ func (p *Payload) UnwrapDetails() Details {
 		return *d.KeyVisualizerDetails
 	case *Payload_PollJobsStats:
 		return *d.PollJobsStats
+	case *Payload_InjectedSQL:
+		return *d.InjectedSQL
 	default:
 		return nil
 	}
@@ -368,6 +378,8 @@ func (p *Progress) UnwrapDetails() ProgressDetails {
 		return *d.KeyVisualizerProgress
 	case *Progress_PollJobsStats:
 		return *d.PollJobsStats
+	case *Progress_InjectedSQL:
+		return *d.InjectedSQL
 	default:
 		return nil
 	}
@@ -437,6 +449,8 @@ func WrapPayloadDetails(details Details) interface {
 		return &Payload_KeyVisualizerDetails{KeyVisualizerDetails: &d}
 	case PollJobsStatsDetails:
 		return &Payload_PollJobsStats{PollJobsStats: &d}
+	case InjectedSQLDetails:
+		return &Payload_InjectedSQL{InjectedSQL: &d}
 	default:
 		panic(errors.AssertionFailedf("jobs.WrapPayloadDetails: unknown details type %T", d))
 	}
@@ -472,7 +486,7 @@ const (
 func (Type) SafeValue() {}
 
 // NumJobTypes is the number of jobs types.
-const NumJobTypes = 20
+const NumJobTypes = 21
 
 // ChangefeedDetailsMarshaler allows for dependency injection of
 // cloud.SanitizeExternalStorageURI to avoid the dependency from this

--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -27,6 +27,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/cloud"
 	"github.com/cockroachdb/cockroach/pkg/config/zonepb"
 	"github.com/cockroachdb/cockroach/pkg/docs"
+	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvclient/rangefeed"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver"
@@ -257,6 +258,11 @@ type BaseConfig struct {
 	// These events are meant for the Observability Service, but they might pass
 	// through an OpenTelemetry Collector.
 	ObsServiceAddr string
+
+	// InjectedSQL configures some configuration SQL to inject as
+	// one-off jobs into the SQL system. This is used when setting up
+	// clusters initially.
+	InjectedSQL []*jobspb.InjectedSQLDetails
 }
 
 // MakeBaseConfig returns a BaseConfig with default values.

--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -30,6 +30,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/config/zonepb"
 	"github.com/cockroachdb/cockroach/pkg/gossip"
 	"github.com/cockroachdb/cockroach/pkg/jobs"
+	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvclient/kvcoord"
@@ -246,6 +247,10 @@ func makeTestConfigFromParams(params base.TestServerArgs) Config {
 	}
 	if params.SnapshotSendLimit != 0 {
 		cfg.SnapshotSendLimit = params.SnapshotSendLimit
+	}
+	if params.InjectedSQL != nil {
+		is := params.InjectedSQL.([]*jobspb.InjectedSQLDetails)
+		cfg.InjectedSQL = is
 	}
 
 	// Ensure we have the correct number of engines. Add in-memory ones where


### PR DESCRIPTION
Informs #94856.

This change introduces two new mechanisms:

- a new way to inject SQL statements upon initialization of the SQL layer, with exactly-once semantics. The TLDR is that the SQL server initialization code obtains an "injected SQL" payload from its configuration and synthetizes a one-off job to execute that payload.

  Because the payload is executed as a job, it will execute exactly once and will be guaranteed to execute even if the server that created the job terminates before the job starts or completes. (Another server will pick it up.)

  This mechanism is intended for use both by secondary tenants and the system tenant.

- a "config profiles" mechanism for the system tenant's SQL service, whereby either a command-line flag (`--init-profile`) or an env var (`COCKROACH_INIT_PROFILE`) can be used to choose a pre-defined "injected SQL" payload to populate in the server configuration.

  This leverages the mechanism defined above.

Implementation detail: all job entries created by this mechanism have the job column`created_by_name` set to `injected`. The unicity of the job entry is enforced using unique values for the column `created_by_id`.

Release note: None