### PR TITLE
delegate: make actual number of annotations used by delegator

### DIFF
--- a/pkg/sql/delegate/delegate.go
+++ b/pkg/sql/delegate/delegate.go
@@ -194,7 +194,11 @@ type delegator struct {
 	evalCtx *eval.Context
 }
 
-func parse(sql string) (tree.Statement, error) {
+func (d *delegator) parse(sql string) (tree.Statement, error) {
 	s, err := parser.ParseOne(sql)
+	if err != nil {
+		return s.AST, err
+	}
+	d.evalCtx.Planner.MaybeReallocateAnnotations(s.NumAnnotations)
 	return s.AST, err
 }

--- a/pkg/sql/delegate/job_control.go
+++ b/pkg/sql/delegate/job_control.go
@@ -70,7 +70,7 @@ func (d *delegator) delegateJobControl(stmt ControlJobsDelegate) (tree.Statement
 	// nodes.
 
 	if stmt.Schedules != nil {
-		return parse(fmt.Sprintf(`%s JOBS SELECT id FROM system.jobs WHERE jobs.created_by_type = '%s' 
+		return d.parse(fmt.Sprintf(`%s JOBS SELECT id FROM system.jobs WHERE jobs.created_by_type = '%s' 
 AND jobs.status IN (%s) AND jobs.created_by_id IN (%s)`,
 			tree.JobCommandToStatement[stmt.Command], jobs.CreatedByScheduledJobs, filterClause,
 			stmt.Schedules))
@@ -96,7 +96,7 @@ AND jobs.status IN (%s) AND jobs.created_by_id IN (%s)`,
        )
   WHERE correct_type
 );`
-		return parse(fmt.Sprintf(queryStrFormat, tree.JobCommandToStatement[stmt.Command], protobufNameForType[stmt.Type], filterClause))
+		return d.parse(fmt.Sprintf(queryStrFormat, tree.JobCommandToStatement[stmt.Command], protobufNameForType[stmt.Type], filterClause))
 	}
 
 	return nil, errors.AssertionFailedf("Missing Schedules or Type clause in delegate parameters")

--- a/pkg/sql/delegate/show_all_cluster_settings.go
+++ b/pkg/sql/delegate/show_all_cluster_settings.go
@@ -76,12 +76,12 @@ func (d *delegator) delegateShowClusterSettingList(
 	}
 
 	if stmt.All {
-		return parse(
+		return d.parse(
 			`SELECT variable, value, type AS setting_type, public, description
        FROM   crdb_internal.cluster_settings`,
 		)
 	}
-	return parse(
+	return d.parse(
 		`SELECT variable, value, type AS setting_type, description
      FROM   crdb_internal.cluster_settings
      WHERE  public IS TRUE`,
@@ -117,7 +117,7 @@ func (d *delegator) delegateShowTenantClusterSettingList(
 	// Note: we do the validation in SQL (via CASE...END) because the
 	// TenantID expression may be complex (incl subqueries, etc) and we
 	// cannot evaluate it in the go code.
-	return parse(`
+	return d.parse(`
 WITH
   tenant_id AS (SELECT id AS tenant_id FROM [SHOW TENANT ` + stmt.TenantSpec.String() + `]),
   isvalid AS (

--- a/pkg/sql/delegate/show_changefeed_jobs.go
+++ b/pkg/sql/delegate/show_changefeed_jobs.go
@@ -86,5 +86,5 @@ FROM
 
 	sqlStmt := fmt.Sprintf("%s %s %s", selectClause, whereClause, orderbyClause)
 
-	return parse(sqlStmt)
+	return d.parse(sqlStmt)
 }

--- a/pkg/sql/delegate/show_database_indexes.go
+++ b/pkg/sql/delegate/show_database_indexes.go
@@ -66,5 +66,5 @@ FROM
 	getAllIndexesQuery += `
 ORDER BY 1, 2, 4`
 
-	return parse(fmt.Sprintf(getAllIndexesQuery, name.String()))
+	return d.parse(fmt.Sprintf(getAllIndexesQuery, name.String()))
 }

--- a/pkg/sql/delegate/show_databases.go
+++ b/pkg/sql/delegate/show_databases.go
@@ -48,5 +48,5 @@ ON
 ORDER BY
 	database_name`
 
-	return parse(query)
+	return d.parse(query)
 }

--- a/pkg/sql/delegate/show_default_privileges.go
+++ b/pkg/sql/delegate/show_default_privileges.go
@@ -66,5 +66,5 @@ func (d *delegator) delegateShowDefaultPrivileges(
 			query, d.evalCtx.SessionData().User())
 	}
 	query += " ORDER BY 1,2,3,4,5"
-	return parse(query)
+	return d.parse(query)
 }

--- a/pkg/sql/delegate/show_enums.go
+++ b/pkg/sql/delegate/show_enums.go
@@ -61,5 +61,5 @@ FROM
 WHERE types.typtype = 'e' %[2]s
 ORDER BY (nsp.nspname, types.typname)
 `, &name.CatalogName, schemaClause)
-	return parse(query)
+	return d.parse(query)
 }

--- a/pkg/sql/delegate/show_full_table_scans.go
+++ b/pkg/sql/delegate/show_full_table_scans.go
@@ -21,5 +21,5 @@ func (d *delegator) delegateShowFullTableScans() (tree.Statement, error) {
   SELECT 
     key AS query, count, rows_read_avg, bytes_read_avg, service_lat_avg, contention_time_avg, max_mem_usage_avg, network_bytes_avg, cpu_sql_nanos_avg, max_retries
   FROM crdb_internal.node_statement_statistics WHERE full_scan = TRUE ORDER BY count DESC`
-	return parse(query)
+	return d.parse(query)
 }

--- a/pkg/sql/delegate/show_function.go
+++ b/pkg/sql/delegate/show_function.go
@@ -48,5 +48,5 @@ AND function_name = %[2]s
 	}
 
 	fullQuery := fmt.Sprintf(query, lexbase.EscapeSQLString(udfSchema), lexbase.EscapeSQLString(un.Parts[0]))
-	return parse(fullQuery)
+	return d.parse(fullQuery)
 }

--- a/pkg/sql/delegate/show_functions.go
+++ b/pkg/sql/delegate/show_functions.go
@@ -80,5 +80,5 @@ ORDER BY 1, 2, 4;
 		&name.CatalogName,
 		schemaClause,
 	)
-	return parse(query)
+	return d.parse(query)
 }

--- a/pkg/sql/delegate/show_grants.go
+++ b/pkg/sql/delegate/show_grants.go
@@ -393,5 +393,5 @@ SELECT database_name,
 		}
 	}
 
-	return parse(query)
+	return d.parse(query)
 }

--- a/pkg/sql/delegate/show_jobs.go
+++ b/pkg/sql/delegate/show_jobs.go
@@ -23,7 +23,7 @@ import (
 func (d *delegator) delegateShowJobs(n *tree.ShowJobs) (tree.Statement, error) {
 	if n.Schedules != nil {
 		// Limit the jobs displayed to the ones started by specified schedules.
-		return parse(fmt.Sprintf(`
+		return d.parse(fmt.Sprintf(`
 SHOW JOBS SELECT id FROM system.jobs WHERE created_by_type='%s' and created_by_id IN (%s)
 `, jobs.CreatedByScheduledJobs, n.Schedules.String()),
 		)
@@ -94,5 +94,5 @@ SELECT *
   FROM jobs
  WHERE NOT EXISTS(SELECT * FROM fail_if_slept_too_long)`, sqlStmt)
 	}
-	return parse(sqlStmt)
+	return d.parse(sqlStmt)
 }

--- a/pkg/sql/delegate/show_partitions.go
+++ b/pkg/sql/delegate/show_partitions.go
@@ -69,7 +69,7 @@ func (d *delegator) delegateShowPartitions(n *tree.ShowPartitions) (tree.Stateme
 		ORDER BY
 			1, 2, 3, 4, 5, 6, 7, 8, 9;
 		`
-		return parse(fmt.Sprintf(showTablePartitionsQuery,
+		return d.parse(fmt.Sprintf(showTablePartitionsQuery,
 			lexbase.EscapeSQLString(resName.Table()),
 			lexbase.EscapeSQLString(resName.Catalog()),
 			resName.CatalogName.String()))
@@ -105,7 +105,7 @@ func (d *delegator) delegateShowPartitions(n *tree.ShowPartitions) (tree.Stateme
 			tables.name, partitions.name, 1, 4, 5, 6, 7, 8, 9;
 		`
 		// Note: n.Database.String() != string(n.Database)
-		return parse(fmt.Sprintf(showDatabasePartitionsQuery, n.Database.String(), lexbase.EscapeSQLString(string(n.Database))))
+		return d.parse(fmt.Sprintf(showDatabasePartitionsQuery, n.Database.String(), lexbase.EscapeSQLString(string(n.Database))))
 	}
 
 	flags := cat.Flags{AvoidDescriptorCaches: true, NoTableStats: true}
@@ -164,7 +164,7 @@ func (d *delegator) delegateShowPartitions(n *tree.ShowPartitions) (tree.Stateme
 	ORDER BY
 		1, 2, 3, 4, 5, 6, 7, 8, 9;
 	`
-	return parse(fmt.Sprintf(showIndexPartitionsQuery,
+	return d.parse(fmt.Sprintf(showIndexPartitionsQuery,
 		lexbase.EscapeSQLString(n.Index.Index.String()),
 		lexbase.EscapeSQLString(resName.Table()),
 		resName.Table(),

--- a/pkg/sql/delegate/show_queries.go
+++ b/pkg/sql/delegate/show_queries.go
@@ -40,5 +40,5 @@ FROM crdb_internal.`
 	if !n.All {
 		filter = " WHERE application_name NOT LIKE '" + catconstants.InternalAppNamePrefix + "%'"
 	}
-	return parse(query + table + filter)
+	return d.parse(query + table + filter)
 }

--- a/pkg/sql/delegate/show_range_for_row.go
+++ b/pkg/sql/delegate/show_range_for_row.go
@@ -84,7 +84,7 @@ WHERE (r.start_key <= crdb_internal.encode_key(%[1]d, %[2]d, %[3]s))
   AND (r.end_key   >  crdb_internal.encode_key(%[1]d, %[2]d, %[3]s)) ORDER BY r.start_key
 	`
 	// note: CatalogName.String() != Catalog()
-	return parse(
+	return d.parse(
 		fmt.Sprintf(
 			query,
 			table.ID(),

--- a/pkg/sql/delegate/show_ranges.go
+++ b/pkg/sql/delegate/show_ranges.go
@@ -690,7 +690,7 @@ AND s.end_key > r.start_key`)
 		// debugging invalid syntax more difficult.
 		fullQuery = fmt.Sprintf(`SELECT %s AS query`, lexbase.EscapeSQLString(fullQuery))
 	}
-	return parse(fullQuery)
+	return d.parse(fullQuery)
 }
 
 // In the shared logic above, we propagate the set of columns

--- a/pkg/sql/delegate/show_regions.go
+++ b/pkg/sql/delegate/show_regions.go
@@ -30,7 +30,7 @@ func (d *delegator) delegateShowRegions(n *tree.ShowRegions) (tree.Statement, er
 	switch n.ShowRegionsFrom {
 	case tree.ShowRegionsFromAllDatabases:
 		sqltelemetry.IncrementShowCounter(sqltelemetry.RegionsFromAllDatabases)
-		return parse(`
+		return d.parse(`
 SELECT
 	name as database_name,
 	regions,
@@ -76,7 +76,7 @@ ORDER BY "primary" DESC, "secondary" DESC, "region"`,
 			lexbase.EscapeSQLString(dbName),
 		)
 
-		return parse(query)
+		return d.parse(query)
 
 	case tree.ShowRegionsFromCluster:
 		sqltelemetry.IncrementShowCounter(sqltelemetry.RegionsFromCluster)
@@ -94,7 +94,7 @@ ORDER BY
 			zonesClause,
 		)
 
-		return parse(query)
+		return d.parse(query)
 	case tree.ShowRegionsFromDefault:
 		sqltelemetry.IncrementShowCounter(sqltelemetry.Regions)
 
@@ -140,7 +140,7 @@ ORDER BY zones_table.region
 `,
 			zonesClause,
 		)
-		return parse(query)
+		return d.parse(query)
 	case tree.ShowSuperRegionsFromDatabase:
 		sqltelemetry.IncrementShowCounter(sqltelemetry.SuperRegions)
 
@@ -150,7 +150,7 @@ SELECT database_name, super_region_name, regions
   FROM crdb_internal.super_regions
  WHERE database_name = '%s'`, n.DatabaseName)
 
-		return parse(query)
+		return d.parse(query)
 	}
 	return nil, errors.Newf("unhandled ShowRegionsFrom: %v", n.ShowRegionsFrom)
 }

--- a/pkg/sql/delegate/show_role_grants.go
+++ b/pkg/sql/delegate/show_role_grants.go
@@ -72,5 +72,5 @@ SELECT role AS role_name,
 
 	}
 
-	return parse(query.String())
+	return d.parse(query.String())
 }

--- a/pkg/sql/delegate/show_roles.go
+++ b/pkg/sql/delegate/show_roles.go
@@ -19,7 +19,7 @@ import (
 // Privileges: SELECT on system.users.
 func (d *delegator) delegateShowRoles() (tree.Statement, error) {
 	sqltelemetry.IncrementShowCounter(sqltelemetry.Roles)
-	return parse(`
+	return d.parse(`
 SELECT
 	u.username,
 	IFNULL(string_agg(o.option || COALESCE('=' || o.value, ''), ', ' ORDER BY o.option), '') AS options,

--- a/pkg/sql/delegate/show_schedules.go
+++ b/pkg/sql/delegate/show_schedules.go
@@ -77,7 +77,7 @@ WHERE status='%s' AND created_by_type='%s' AND created_by_id=schedule_id
 	if len(whereExprs) > 0 {
 		whereClause = fmt.Sprintf("WHERE (%s)", strings.Join(whereExprs, " AND "))
 	}
-	return parse(fmt.Sprintf(
+	return d.parse(fmt.Sprintf(
 		"SELECT %s FROM system.scheduled_jobs %s",
 		strings.Join(columnExprs, ","),
 		whereClause,

--- a/pkg/sql/delegate/show_schemas.go
+++ b/pkg/sql/delegate/show_schemas.go
@@ -38,7 +38,7 @@ func (d *delegator) delegateShowSchemas(n *tree.ShowSchemas) (tree.Statement, er
 		lexbase.EscapeSQLString(string(name)),
 	)
 
-	return parse(getSchemasQuery)
+	return d.parse(getSchemasQuery)
 }
 
 func (d *delegator) delegateShowCreateAllSchemas() (tree.Statement, error) {
@@ -53,7 +53,7 @@ func (d *delegator) delegateShowCreateAllSchemas() (tree.Statement, error) {
 		lexbase.EscapeSQLString(databaseLiteral),
 	)
 
-	return parse(query)
+	return d.parse(query)
 }
 
 // getSpecifiedOrCurrentDatabase returns the name of the specified database, or

--- a/pkg/sql/delegate/show_sequences.go
+++ b/pkg/sql/delegate/show_sequences.go
@@ -35,5 +35,5 @@ func (d *delegator) delegateShowSequences(n *tree.ShowSequences) (tree.Statement
 		name.String(), // note: (tree.Name).String() != string(name)
 		lexbase.EscapeSQLString(string(name)),
 	)
-	return parse(getSequencesQuery)
+	return d.parse(getSequencesQuery)
 }

--- a/pkg/sql/delegate/show_sessions.go
+++ b/pkg/sql/delegate/show_sessions.go
@@ -25,5 +25,5 @@ func (d *delegator) delegateShowSessions(n *tree.ShowSessions) (tree.Statement, 
 	if !n.All {
 		filter = " WHERE application_name NOT LIKE '" + catconstants.InternalAppNamePrefix + "%'"
 	}
-	return parse(query + table + filter)
+	return d.parse(query + table + filter)
 }

--- a/pkg/sql/delegate/show_survival_goal.go
+++ b/pkg/sql/delegate/show_survival_goal.go
@@ -33,5 +33,5 @@ FROM crdb_internal.databases
 WHERE name = %s`,
 		lexbase.EscapeSQLString(dbName),
 	)
-	return parse(query)
+	return d.parse(query)
 }

--- a/pkg/sql/delegate/show_syntax.go
+++ b/pkg/sql/delegate/show_syntax.go
@@ -66,5 +66,5 @@ func (d *delegator) delegateShowSyntax(n *tree.ShowSyntax) (tree.Statement, erro
 	)
 	query.WriteString(") v(f, m)")
 
-	return parse(query.String())
+	return d.parse(query.String())
 }

--- a/pkg/sql/delegate/show_table.go
+++ b/pkg/sql/delegate/show_table.go
@@ -51,7 +51,7 @@ WHERE name = %s
 		return nil, err
 	}
 
-	return parse(fmt.Sprintf(showCreateQuery, lexbase.EscapeSQLString(n.Name.Object())))
+	return d.parse(fmt.Sprintf(showCreateQuery, lexbase.EscapeSQLString(n.Name.Object())))
 }
 
 func (d *delegator) delegateShowCreateTable(n *tree.ShowCreate) (tree.Statement, error) {
@@ -274,7 +274,7 @@ func (d *delegator) delegateShowCreateAllTables() (tree.Statement, error) {
 		lexbase.EscapeSQLString(databaseLiteral),
 	)
 
-	return parse(query)
+	return d.parse(query)
 }
 
 // showTableDetails returns the AST of a query which extracts information about
@@ -311,5 +311,5 @@ func (d *delegator) showTableDetails(
 		dataSource.PostgresDescriptorID(),
 	)
 
-	return parse(fullQuery)
+	return d.parse(fullQuery)
 }

--- a/pkg/sql/delegate/show_tables.go
+++ b/pkg/sql/delegate/show_tables.go
@@ -112,5 +112,5 @@ ORDER BY schema_name, table_name
 		estimatedRowCountJoin,
 		lexbase.EscapeSQLString(string(name.CatalogName)),
 	)
-	return parse(query)
+	return d.parse(query)
 }

--- a/pkg/sql/delegate/show_transactions.go
+++ b/pkg/sql/delegate/show_transactions.go
@@ -34,5 +34,5 @@ FROM `
 	if !n.All {
 		filter = " WHERE application_name NOT LIKE '" + catconstants.InternalAppNamePrefix + "%'"
 	}
-	return parse(query + table + filter)
+	return d.parse(query + table + filter)
 }

--- a/pkg/sql/delegate/show_types.go
+++ b/pkg/sql/delegate/show_types.go
@@ -21,7 +21,7 @@ import (
 func (d *delegator) delegateShowTypes() (tree.Statement, error) {
 	// TODO (SQL Features, SQL Exec): Once more user defined types are added
 	//  they should be added here.
-	return parse(`
+	return d.parse(`
 SELECT
   schema, name, owner
 FROM
@@ -42,5 +42,5 @@ func (d *delegator) delegateShowCreateAllTypes() (tree.Statement, error) {
 		lexbase.EscapeSQLString(databaseLiteral),
 	)
 
-	return parse(query)
+	return d.parse(query)
 }

--- a/pkg/sql/delegate/show_var.go
+++ b/pkg/sql/delegate/show_var.go
@@ -32,7 +32,7 @@ func (d *delegator) delegateShowVar(n *tree.ShowVar) (tree.Statement, error) {
 	}
 
 	if name == "all" {
-		return parse(
+		return d.parse(
 			"SELECT variable, value FROM crdb_internal.session_variables WHERE hidden = FALSE",
 		)
 	}
@@ -43,7 +43,7 @@ func (d *delegator) delegateShowVar(n *tree.ShowVar) (tree.Statement, error) {
 	// hit the database resolution path giving us a database is undefined
 	// error. The below query allows us to keep this behaviour.
 	if name == "database" {
-		return parse(
+		return d.parse(
 			"SELECT value as database FROM crdb_internal.session_variables WHERE variable = 'database'")
 	}
 

--- a/pkg/sql/delegate/show_zone_config.go
+++ b/pkg/sql/delegate/show_zone_config.go
@@ -18,5 +18,5 @@ func (d *delegator) delegateShowZoneConfig(n *tree.ShowZoneConfig) (tree.Stateme
 	if n.ZoneSpecifier != (tree.ZoneSpecifier{}) {
 		return nil, nil
 	}
-	return parse(`SELECT target, raw_config_sql FROM crdb_internal.zones`)
+	return d.parse(`SELECT target, raw_config_sql FROM crdb_internal.zones`)
 }

--- a/pkg/sql/faketreeeval/evalctx.go
+++ b/pkg/sql/faketreeeval/evalctx.go
@@ -495,6 +495,10 @@ func (ep *DummyEvalPlanner) GetDetailsForSpanStats(
 	return
 }
 
+// MaybeReallocateAnnotations is part of the eval.Planner interface.
+func (ep *DummyEvalPlanner) MaybeReallocateAnnotations(numAnnotations tree.AnnotationIdx) {
+}
+
 // DummyPrivilegedAccessor implements the tree.PrivilegedAccessor interface by returning errors.
 type DummyPrivilegedAccessor struct{}
 

--- a/pkg/sql/opt/exec/execbuilder/testdata/with
+++ b/pkg/sql/opt/exec/execbuilder/testdata/with
@@ -294,3 +294,22 @@ vectorized: true
           missing stats
           table: t93370@t93370_pkey
           spans: FULL SCAN
+
+statement ok
+CREATE TABLE t97362 (i INT, j INT)
+
+statement error pq: WITH clause "alias_0" does not return any columns
+SHOW CHANGEFEED JOBS WITH alias_0 AS MATERIALIZED (CREATE TYPE "int" AS ENUM ()) SELECT * FROM alias_0
+
+statement error pq: WITH clause "alias_0" does not return any columns
+WITH alias_0 AS MATERIALIZED (DELETE FROM t97362 WHERE i=1) SELECT * FROM alias_0
+
+query I
+WITH alias_0 AS MATERIALIZED (DELETE FROM t97362 WHERE i=1 RETURNING j) SELECT * FROM alias_0
+----
+
+statement error pq: WITH clause "alias_0" does not return any columns
+WITH alias_0 AS MATERIALIZED (CREATE TABLE t97362b ("i" INT, "j" INT)) SELECT * FROM alias_0
+
+statement error pq:
+WITH alias_0 AS MATERIALIZED (CREATE OR REPLACE FUNCTION sq(a INT) RETURNS INT AS 'SELECT a*a' LANGUAGE SQL) SELECT * FROM alias_0;

--- a/pkg/sql/planner.go
+++ b/pkg/sql/planner.go
@@ -902,3 +902,12 @@ func (p *planner) GetDetailsForSpanStats(
 		args...,
 	)
 }
+
+// MaybeReallocateAnnotations is part of the eval.Planner interface.
+func (p *planner) MaybeReallocateAnnotations(numAnnotations tree.AnnotationIdx) {
+	if len(p.SemaCtx().Annotations) > int(numAnnotations) {
+		return
+	}
+	p.SemaCtx().Annotations = tree.MakeAnnotations(numAnnotations)
+	p.ExtendedEvalContext().Annotations = &p.SemaCtx().Annotations
+}

--- a/pkg/sql/sem/eval/context.go
+++ b/pkg/sql/sem/eval/context.go
@@ -396,6 +396,10 @@ func (p *fakePlannerWithMonitor) EnforceHomeRegion() bool {
 	return false
 }
 
+// MaybeReallocateAnnotations is part of the eval.Planner interface.
+func (p *fakePlannerWithMonitor) MaybeReallocateAnnotations(numAnnotations tree.AnnotationIdx) {
+}
+
 type fakeStreamManagerFactory struct {
 	StreamManagerFactory
 }

--- a/pkg/sql/sem/eval/deps.go
+++ b/pkg/sql/sem/eval/deps.go
@@ -379,6 +379,12 @@ type Planner interface {
 	SpanStats(context.Context, roachpb.RKey, roachpb.RKey) (*roachpb.SpanStatsResponse, error)
 
 	GetDetailsForSpanStats(ctx context.Context, dbId int, tableId int) (InternalRows, error)
+
+	// MaybeReallocateAnnotations makes a new annotations slice of size
+	// numAnnotations if one is maintained by this Planner and the current one has
+	// less than numAnnotations entries. If updated, the annotations in the eval
+	// context held in the planner is also updated.
+	MaybeReallocateAnnotations(numAnnotations tree.AnnotationIdx)
 }
 
 // InternalRows is an iterator interface that's exposed by the internal


### PR DESCRIPTION
This updates the delegator, which parses textual SQL statements which
represent specific DDL statements, so that the `Annotations` slice
allocated in `planner.semaCtx` matches the actual number of annotations
built during parsing (if the delegator successfully built a statement).

Fixes: #97362

Release note (bug fix): Rare internal errors in SHOW JOBS
statements which have a WITH clause are fixed.