### PR TITLE
kv: temporarily disable SST rewrite concurrency

### DIFF
--- a/pkg/kv/kvserver/batcheval/cmd_add_sstable.go
+++ b/pkg/kv/kvserver/batcheval/cmd_add_sstable.go
@@ -77,7 +77,8 @@ var AddSSTableRewriteConcurrency = settings.RegisterIntSetting(
 	settings.SystemOnly,
 	"kv.bulk_io_write.sst_rewrite_concurrency.per_call",
 	"concurrency to use when rewriting sstable timestamps by block, or 0 to use a loop",
-	int64(util.ConstantWithMetamorphicTestRange("addsst-rewrite-concurrency", 4, 0, 16)),
+	// TODO(radu): temporarily disabled because of #97076.
+	0, // int64(util.ConstantWithMetamorphicTestRange("addsst-rewrite-concurrency", 4, 0, 16)),
 	settings.NonNegativeInt,
 )
 


### PR DESCRIPTION
When SST rewrite concurrency is not zero, we use the Pebble SST rewrite code which appears to be broken when value blocks are enabled.

This change temporarily sets the concurrency to 0 until the problem is fixed.

Informs #97076.

Epic: none
Release note: None