### PR TITLE
sql: deflake mixed version user ID migration logic tests

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/mixed_version_external_connections_owner_id
+++ b/pkg/sql/logictest/testdata/logic_test/mixed_version_external_connections_owner_id
@@ -29,10 +29,13 @@ connection1  t
 connection2  t
 
 # Wait for migrations to run and verify that owner_id column is now present.
+# The sleep directive is needed to reduce flakiness.
 
 upgrade 0
 
 upgrade 2
+
+sleep 10s
 
 query B retry
 SELECT crdb_internal.is_at_least_version('1000022.2-76')

--- a/pkg/sql/logictest/testdata/logic_test/mixed_version_role_members_user_ids
+++ b/pkg/sql/logictest/testdata/logic_test/mixed_version_role_members_user_ids
@@ -110,6 +110,7 @@ SELECT crdb_internal.node_executable_version() SIMILAR TO '1000022.2-%'
 true
 
 # Wait for migrations to run.
+# The sleep directive is needed to reduce flakiness.
 
 sleep 10s
 


### PR DESCRIPTION
This patch adds a sleep directive into the mixed version user ID
migration logic tests to reduce the flakiness caused by the cluster
upgrades not finishing quickly enough.

Informs #92342

Release note: None