### PR TITLE
release-22.2: sql: make sure that "inner" plans use the LeafTxn if the "outer" does

### DIFF
--- a/pkg/ccl/changefeedccl/BUILD.bazel
+++ b/pkg/ccl/changefeedccl/BUILD.bazel
@@ -81,6 +81,7 @@ go_library(
         "//pkg/sql/execinfra",
         "//pkg/sql/execinfrapb",
         "//pkg/sql/exprutil",
+        "//pkg/sql/flowinfra",
         "//pkg/sql/parser",
         "//pkg/sql/pgwire/pgcode",
         "//pkg/sql/pgwire/pgerror",

--- a/pkg/ccl/changefeedccl/changefeed_dist.go
+++ b/pkg/ccl/changefeedccl/changefeed_dist.go
@@ -25,6 +25,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descs"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
+	"github.com/cockroachdb/cockroach/pkg/sql/flowinfra"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/physicalplan"
@@ -285,7 +286,7 @@ func startDistChangefeed(
 		)
 		defer recv.Release()
 
-		var finishedSetupFn func()
+		var finishedSetupFn func(flowinfra.Flow)
 		if details.SinkURI != `` {
 			// We abuse the job's results channel to make CREATE CHANGEFEED wait for
 			// this before returning to the user to ensure the setup went okay. Job
@@ -294,7 +295,7 @@ func startDistChangefeed(
 			// meaningful so that if we start doing anything with the results
 			// returned by resumed jobs, then it breaks instead of returning
 			// nonsense.
-			finishedSetupFn = func() { resultsCh <- tree.Datums(nil) }
+			finishedSetupFn = func(flowinfra.Flow) { resultsCh <- tree.Datums(nil) }
 		}
 
 		// Copy the evalCtx, as dsp.Run() might change it.

--- a/pkg/sql/distsql/server.go
+++ b/pkg/sql/distsql/server.go
@@ -566,6 +566,11 @@ type LocalState struct {
 	// HasConcurrency indicates whether the local flow uses multiple goroutines.
 	HasConcurrency bool
 
+	// MustUseLeaf indicates whether the local flow must use the LeafTxn even if
+	// there is no concurrency in the flow on its own because there would be
+	// concurrency with other flows which prohibits the usage of the RootTxn.
+	MustUseLeaf bool
+
 	// Txn is filled in on the gateway only. It is the RootTxn that the query is running in.
 	// This will be used directly by the flow if the flow has no concurrency and IsLocal is set.
 	// If there is concurrency, a LeafTxn will be created.
@@ -579,7 +584,7 @@ type LocalState struct {
 // MustUseLeafTxn returns true if a LeafTxn must be used. It is valid to call
 // this method only after IsLocal and HasConcurrency have been set correctly.
 func (l LocalState) MustUseLeafTxn() bool {
-	return !l.IsLocal || l.HasConcurrency
+	return !l.IsLocal || l.HasConcurrency || l.MustUseLeaf
 }
 
 // SetupLocalSyncFlow sets up a synchronous flow on the current (planning) node,

--- a/pkg/sql/distsql_physical_planner.go
+++ b/pkg/sql/distsql_physical_planner.go
@@ -791,6 +791,12 @@ type PlanningCtx struct {
 	// are supported natively by the vectorized engine.
 	parallelizeScansIfLocal bool
 
+	// mustUseLeafTxn, if set, indicates that this PlanningCtx is used to handle
+	// one of the plans that will run in parallel with other plans. As such, the
+	// DistSQL planner will need to use the LeafTxn (even if it's not needed
+	// based on other "regular" factors).
+	mustUseLeafTxn bool
+
 	// onFlowCleanup contains non-nil functions that will be called after the
 	// local flow finished running and is being cleaned up. It allows us to
 	// release the resources that are acquired during the physical planning and

--- a/pkg/sql/distsql_plan_ctas.go
+++ b/pkg/sql/distsql_plan_ctas.go
@@ -55,5 +55,7 @@ func PlanAndRunCTAS(
 	// Make copy of evalCtx as Run might modify it.
 	evalCtxCopy := planner.ExtendedEvalContextCopy()
 	dsp.FinalizePlan(planCtx, physPlan)
-	dsp.Run(ctx, planCtx, txn, physPlan, recv, evalCtxCopy, nil /* finishedSetupFn */)()
+	finishedSetupFn, cleanup := getFinishedSetupFn(planner)
+	defer cleanup()
+	dsp.Run(ctx, planCtx, txn, physPlan, recv, evalCtxCopy, finishedSetupFn)()
 }

--- a/pkg/sql/distsql_running_test.go
+++ b/pkg/sql/distsql_running_test.go
@@ -180,7 +180,7 @@ func TestDistSQLRunningInAbortedTxn(t *testing.T) {
 		planCtx.stmtType = recv.stmtType
 
 		execCfg.DistSQLPlanner.PlanAndRun(
-			ctx, evalCtx, planCtx, txn, p.curPlan.main, recv,
+			ctx, evalCtx, planCtx, txn, p.curPlan.main, recv, nil, /* finishedSetupFn */
 		)()
 		return rw.Err()
 	})

--- a/pkg/sql/logictest/testdata/logic_test/apply_join
+++ b/pkg/sql/logictest/testdata/logic_test/apply_join
@@ -624,3 +624,44 @@ WHERE EXISTS(
      SELECT t4.i::INT8 FROM w
   )
 )
+
+# Regression test for incorrectly using the RootTxn in apply join iterations
+# when the main query is using the LeafTxn (#97989).
+statement ok
+CREATE TABLE t1 (said, smid) AS VALUES (1, 1);
+CREATE TABLE t2 (aid, said, mid, pid) AS VALUES (1, 1, 1, 1);
+CREATE TABLE t3 (mid, smid) AS VALUES (1, 1);
+CREATE TABLE t4 (pid PRIMARY KEY) AS VALUES (1);
+CREATE TABLE t5 (said, smid) AS VALUES (1, 1);
+
+statement ok
+CREATE MATERIALIZED VIEW v1 AS
+    WITH
+        cte1
+            AS (
+                SELECT
+                    aid, t4.pid
+                FROM
+                    t1
+                    INNER JOIN t2 ON t2.said = t1.said AND t2.mid = (SELECT mid FROM t3 WHERE smid = t1.smid)
+                    INNER JOIN t4 ON t4.pid = t2.pid
+                    INNER JOIN t3 ON t3.smid = t1.smid
+            ),
+        cte2
+            AS (
+                SELECT
+                    aid, t4.pid
+                FROM
+                    t5
+                    INNER JOIN t2 ON t2.said = t5.said AND t2.mid = (SELECT mid FROM t3 WHERE smid = t5.smid)
+                    INNER JOIN t4 ON t4.pid = t2.pid
+                    INNER JOIN t3 ON t3.smid = t5.smid
+            )
+    SELECT
+        aid, pid
+    FROM
+        (
+            SELECT aid, pid FROM cte1
+            UNION
+            SELECT aid, pid FROM cte2
+        );

--- a/pkg/sql/planner.go
+++ b/pkg/sql/planner.go
@@ -175,6 +175,24 @@ type planner struct {
 	// a SQL session.
 	isInternalPlanner bool
 
+	atomic struct {
+		// innerPlansMustUseLeafTxn is set to 1 if the "outer" plan is using
+		// the LeafTxn forcing the "inner" plans to use the LeafTxns too. An
+		// example of this is apply-join iterations when the main query has
+		// concurrency.
+		//
+		// Note that even though the planner is not safe for concurrent usage,
+		// the "outer" plan modifies this field _before_ the "inner" plans start
+		// or _after_ the "inner" plans finish, so we could have avoided the
+		// usage of an atomic here, but we choose to be defensive about it.
+		// TODO(yuzefovich): this is a bit hacky. The problem is that the
+		// incorrect txn on the planner has already been captured by the
+		// planNodeToRowSource adapter before the "outer" query figured out that
+		// it must use the LeafTxn. Solving that issue properly is not trivial
+		// and is tracked in #41992.
+		innerPlansMustUseLeafTxn uint32
+	}
+
 	// Corresponding Statement for this query.
 	stmt Statement
 

--- a/pkg/sql/schema_changer.go
+++ b/pkg/sql/schema_changer.go
@@ -355,6 +355,7 @@ func (sc *SchemaChanger) backfillQueryIntoTable(
 					ctx, localPlanner, localPlanner.ExtendedEvalContextCopy,
 					localPlanner.curPlan.subqueryPlans, recv, &subqueryResultMemAcc,
 					false, /* skipDistSQLDiagramGeneration */
+					false, /* mustUseLeafTxn */
 				) {
 					if planAndRunErr = rw.Err(); planAndRunErr != nil {
 						return

--- a/pkg/sql/testutils.go
+++ b/pkg/sql/testutils.go
@@ -157,7 +157,7 @@ func (dsp *DistSQLPlanner) Exec(
 		distributionType)
 	planCtx.stmtType = recv.stmtType
 
-	dsp.PlanAndRun(ctx, evalCtx, planCtx, p.txn, p.curPlan.main, recv)()
+	dsp.PlanAndRun(ctx, evalCtx, planCtx, p.txn, p.curPlan.main, recv, nil /* finishedSetupFn */)()
 	return rw.Err()
 }
 


### PR DESCRIPTION
Backport 1/1 commits from #98120.

/cc @cockroachdb/release

---

This commit fixes a bug where "inner" plans could incorrectly use
the RootTxn when the "outer" plan used the LeafTxn. One example of such
situation is when the "main" query is using the streamer (and thus is
using the LeafTxn) and also has an apply join, but the apply join
iteration plans would use the RootTxn. This could lead to "concurrent
txn usage" detected on the RootTxn. This problem is fixed by auditing
all code paths that might run plans that can spin up "inner" plans and
plumbing the information that the LeafTxn must be used by those "inner"
plans via the planner (we don't really have any other more convenient
place to do that plumbing).

Note that when create the flow for the main query we only know for sure
whether it'll use the LeafTxn or not only after the flow setup is
complete, so we adjust an existing `finishedSetupFn` callback to check
the type of the txn that the flow ends up using and update the planner
accordingly.

This bug reliably reproduces when creating a materialized view, but for
some (unknown to me) reason just running the query as is doesn't seem to
trigger the bug (I tried stressing the query with no luck and decided it
wasn't worth spending more time on it). I also believe that even though
the underlying mechanism for the bug has been present since forever, it
was really introduced only when we enabled the streamer by default in
22.2 (since without the streamer we always use the RootTxn for flows
with apply joins or UDFs - they must be local).

Fixes: #97989.

Release note (bug fix): CockroachDB previously could encounter
"concurrent txn use detected" internal error in some rare cases, and
this is now fixed. The bug was introduced in 22.2.0.

Release justification: bug fix.