### PR TITLE
storage: add new CheckSSTConflicts randomized test

### DIFF
--- a/pkg/BUILD.bazel
+++ b/pkg/BUILD.bazel
@@ -2116,6 +2116,7 @@ GO_TARGETS = [
     "//pkg/storage/enginepb:enginepb_test",
     "//pkg/storage/fs:fs",
     "//pkg/storage/fs:fs_test",
+    "//pkg/storage/meta:meta",
     "//pkg/storage/metamorphic:metamorphic",
     "//pkg/storage/metamorphic:metamorphic_test",
     "//pkg/storage/pebbleiter:pebbleiter",

--- a/pkg/storage/BUILD.bazel
+++ b/pkg/storage/BUILD.bazel
@@ -161,6 +161,7 @@ go_test(
         "//pkg/sql/sem/tree",
         "//pkg/storage/enginepb",
         "//pkg/storage/fs",
+        "//pkg/storage/meta",
         "//pkg/testutils",
         "//pkg/testutils/datapathutils",
         "//pkg/testutils/echotest",

--- a/pkg/storage/meta/BUILD.bazel
+++ b/pkg/storage/meta/BUILD.bazel
@@ -1,0 +1,9 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "meta",
+    srcs = ["run.go"],
+    importpath = "github.com/cockroachdb/cockroach/pkg/storage/meta",
+    visibility = ["//visibility:public"],
+    deps = ["@com_github_stretchr_testify//require"],
+)

--- a/pkg/storage/meta/run.go
+++ b/pkg/storage/meta/run.go
@@ -1,0 +1,219 @@
+// Copyright 2023 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+// Package meta provides facilities for running metamorphic, property-based
+// testing. By running logically equivalent operations with different
+// conditions, metamorphic tests can identify bugs without requiring an oracle.
+//
+// Package meta will be moved to github.com/cockroachdb/metamorphic once it's
+// more stable.
+package meta
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"math/rand"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// ItemWeight holds an item and its corresponding weight.
+type ItemWeight[I any] struct {
+	Item   I
+	Weight int
+}
+
+// Weighted takes a slice of items and their weights, producing a function that
+// randomly picks items from the slice using the distribution indicated by the
+// weights.
+func Weighted[I any](items []ItemWeight[I]) func(rng *rand.Rand) I {
+	var total int
+	for i := 0; i < len(items); i++ {
+		total += items[i].Weight
+	}
+	return func(rng *rand.Rand) I {
+		w := rng.Intn(total)
+		for i := 0; i < len(items); i++ {
+			w -= items[i].Weight
+			if w < 0 {
+				return items[i].Item
+			}
+		}
+		panic("unreachable")
+	}
+}
+
+// Generate generates a sequence of n items, calling fn(rng)(rng) to produce
+// each item. It's intended to be used with a function returned by Weighted,
+// whhere the item itself is func(rng *rand.Rand).
+func Generate[I any](rng *rand.Rand, n int, fn func(*rand.Rand) func(*rand.Rand) I) []I {
+	items := make([]I, n)
+	for i := 0; i < n; i++ {
+		items[i] = fn(rng)(rng)
+	}
+	return items
+}
+
+// RunOne runs the provided operations, using the provided initial state.
+func RunOne[S any](t *testing.T, initial S, ops []Op[S]) {
+	l := &Logger{t: t}
+
+	// TODO(jackson): Support teeing to additional sink(s), eg, a file.
+	l.w = &l.history
+	l.wIndent = newlineIndentingWriter{Writer: l.w, indent: []byte("  ")}
+
+	// Ensure panics result in printing the history.
+	defer func() {
+		if r := recover(); r != nil {
+			l.Fatal(r)
+		}
+	}()
+
+	s := initial
+	for i := 0; i < len(ops); i++ {
+		// Set Logger's per-Op context.
+		l.opNumber = i
+		l.op = ops[i]
+		l.logged = false
+
+		fmt.Fprintf(l, "op %6d: %s = ", l.opNumber, l.op)
+		ops[i].Run(l, s)
+
+		if !l.logged {
+			fmt.Fprint(l, "-")
+		}
+		fmt.Fprintln(l)
+	}
+	fmt.Fprintln(l, "done")
+	if t.Failed() {
+		t.Logf("History:\n\n%s", l.history.String())
+	}
+}
+
+// Op represents a single operation within a metamorphic test.
+type Op[S any] interface {
+	fmt.Stringer
+
+	// Run runs the operation, logging its outcome to Logger.
+	Run(*Logger, S)
+}
+
+// Logger logs test operation's outputs and errors, maintaining a cumulative
+// history of the test. Logger may be used analogously to the standard library's
+// testing.TB.
+type Logger struct {
+	w        io.Writer
+	wIndent  newlineIndentingWriter
+	t        testing.TB
+	history  bytes.Buffer
+	lastByte byte
+
+	// op context; updated before each operation is run
+	opNumber int
+	op       fmt.Stringer
+	logged   bool
+}
+
+// Assert that *Logger implements require.TestingT.
+var _ require.TestingT = (*Logger)(nil)
+
+// Commentf writes a comment to the log file. Commentf always appends a newline
+// after the comment. Commentf may prepend a newline before the message if there
+// isn't already one.
+func (l *Logger) Commentf(format string, args ...any) {
+	if l.lastByte != '\n' {
+		fmt.Fprintln(&l.wIndent)
+	}
+	l.Logf("// "+format+"\n", args...)
+}
+
+// Error fails the test run, logging the provided error.
+func (l *Logger) Error(err error) {
+	l.Log("error: ", err)
+	l.t.Error(err)
+}
+
+// Errorf fails the test run, logging the provided message.
+func (l *Logger) Errorf(format string, args ...any) {
+	l.Logf("error: "+format, args...)
+	l.t.Errorf(format, args...)
+}
+
+// FailNow marks the function as having failed and stops its execution by
+// calling runtime.Goexit. FailNow is implemented by calling through to the
+// underlying *testing.T's FailNow.
+func (l *Logger) FailNow() {
+	l.t.Logf("History:\n\n%s", l.history.String())
+	l.t.FailNow()
+}
+
+// Fatal is equivalent to Log followed by FailNow.
+func (l *Logger) Fatal(args ...any) {
+	l.Errorf("%s", fmt.Sprint(args...))
+	l.FailNow()
+}
+
+// Log formats its arguments using default formatting, analogous to Print, and
+// records the text in the test's recorded history.
+func (l *Logger) Log(args ...any) {
+	l.logged = true
+	fmt.Fprint(&l.wIndent, args...)
+}
+
+// Logf formats its arguments according to the format, analogous to Printf, and
+// records the text in the test's recorded history.
+func (l *Logger) Logf(format string, args ...interface{}) {
+	l.logged = true
+	fmt.Fprintf(&l.wIndent, format, args...)
+}
+
+// Write implements io.Writer.
+func (l *Logger) Write(b []byte) (int, error) {
+	n, err := l.w.Write(b)
+	if n > 0 {
+		l.lastByte = b[n-1]
+	}
+	return n, err
+}
+
+// newlineIndentingWriter wraps a Writer. Whenever a '\n' is written, the
+// newlineIndentingWriter writes the '\n' and the configured `indent` byte slice
+// to the writer. All other bytes written are written to the underlying Writer
+// verbatim.
+type newlineIndentingWriter struct {
+	io.Writer
+	indent []byte
+}
+
+func (w *newlineIndentingWriter) Write(b []byte) (n int, err error) {
+	for len(b) > 0 {
+		if i := bytes.IndexByte(b, '\n'); i >= 0 {
+			n2, err := w.Writer.Write(b[:i+1])
+			n += n2
+			if err != nil {
+				return n, err
+			}
+			b = b[i+1:]
+			n2, err = w.Writer.Write(w.indent)
+			n += n2
+			if err != nil {
+				return n, err
+			}
+			continue
+		}
+
+		n2, err := w.Writer.Write(b)
+		n += n2
+		return n, err
+	}
+	return n, err
+}

--- a/pkg/storage/mvcc_history_test.go
+++ b/pkg/storage/mvcc_history_test.go
@@ -648,7 +648,7 @@ func TestMVCCHistories(t *testing.T) {
 						require.NoError(t, err)
 						msFinal.Add(ms)
 					}
-					buf.Printf("stats: %s\n", ms.Formatted(false /* delta */))
+					buf.Printf("stats: %s\n", msFinal.Formatted(false /* delta */))
 				}
 
 				signalError := e.t.Errorf

--- a/pkg/storage/mvcc_history_test.go
+++ b/pkg/storage/mvcc_history_test.go
@@ -15,7 +15,6 @@ import (
 	"context"
 	"fmt"
 	"math"
-	"regexp"
 	"sort"
 	"strconv"
 	"strings"
@@ -606,11 +605,11 @@ func TestMVCCHistories(t *testing.T) {
 						msEvalDiff := *e.ms
 						msEvalDiff.Subtract(msEvalBefore)
 						msEvalDiff.AgeTo(msEngineDiff.LastUpdateNanos)
-						buf.Printf("stats: %s\n", formatStats(msEvalDiff, true))
+						buf.Printf("stats: %s\n", msEvalDiff.Formatted(true /* delta */))
 
 						if msEvalDiff != msEngineDiff {
 							e.t.Errorf("MVCC stats mismatch for %q at %s\nReturned: %s\nExpected: %s",
-								d.Cmd, d.Pos, formatStats(msEvalDiff, true), formatStats(msEngineDiff, true))
+								d.Cmd, d.Pos, msEvalDiff.Formatted(true /* delta */), msEngineDiff.Formatted(true /* delta */))
 						}
 					}
 
@@ -649,7 +648,7 @@ func TestMVCCHistories(t *testing.T) {
 						require.NoError(t, err)
 						msFinal.Add(ms)
 					}
-					buf.Printf("stats: %s\n", formatStats(msFinal, false))
+					buf.Printf("stats: %s\n", ms.Formatted(false /* delta */))
 				}
 
 				signalError := e.t.Errorf
@@ -2068,55 +2067,6 @@ func checkAndUpdateRangeKeyChanged(e *evalCtx) bool {
 	}
 	rangeKeys.CloneInto(&e.iterRangeKeys)
 	return rangeKeyChanged
-}
-
-// formatStats formats MVCC stats.
-func formatStats(ms enginepb.MVCCStats, delta bool) string {
-	// Split stats into field pairs. Subindex 1 is key, 2 is value.
-	fields := regexp.MustCompile(`(\w+):(-?\d+)`).FindAllStringSubmatch(ms.String(), -1)
-
-	// Sort some fields in preferred order, keeping the rest as-is at the end.
-	//
-	// TODO(erikgrinaker): Consider just reordering the MVCCStats struct fields
-	// instead, which determines the order of MVCCStats.String().
-	order := []string{"key_count", "key_bytes", "val_count", "val_bytes",
-		"range_key_count", "range_key_bytes", "range_val_count", "range_val_bytes",
-		"live_count", "live_bytes", "gc_bytes_age",
-		"intent_count", "intent_bytes", "separated_intent_count", "intent_age"}
-	sort.SliceStable(fields, func(i, j int) bool {
-		for _, name := range order {
-			if fields[i][1] == name {
-				return true
-			} else if fields[j][1] == name {
-				return false
-			}
-		}
-		return false
-	})
-
-	// Format and output fields.
-	var s string
-	for _, field := range fields {
-		key, value := field[1], field[2]
-
-		// Always skip zero-valued fields and LastUpdateNanos.
-		if value == "0" || key == "last_update_nanos" {
-			continue
-		}
-
-		if len(s) > 0 {
-			s += " "
-		}
-		s += key + "="
-		if delta && value[0] != '-' {
-			s += "+" // prefix unsigned deltas with +
-		}
-		s += value
-	}
-	if len(s) == 0 && delta {
-		return "no change"
-	}
-	return s
 }
 
 // evalCtx stored the current state of the environment of a running

--- a/pkg/storage/sst.go
+++ b/pkg/storage/sst.go
@@ -101,7 +101,9 @@ func NewMultiMemSSTIterator(ssts [][]byte, verify bool, opts IterOptions) (MVCCI
 //
 // The given SST and reader cannot contain intents or inline values (i.e. zero
 // timestamps), but this is only checked for keys that exist in both sides, for
-// performance.
+// performance. The given SST must not contain multiple keys for the same user
+// key, even if at different timestamps, as its stats accounting does not
+// support it.
 //
 // The returned MVCC statistics is a delta between the SST-only statistics and
 // their effect when applied, which when added to the SST statistics will adjust

--- a/pkg/storage/sst.go
+++ b/pkg/storage/sst.go
@@ -80,6 +80,9 @@ func NewMultiMemSSTIterator(ssts [][]byte, verify bool, opts IterOptions) (MVCCI
 // out if it finds any conflicts. This includes intents and existing keys with a
 // timestamp at or above the SST key timestamp.
 //
+// The provided start and end boundaries describe the bounds of the sstable with
+// inclusive and exclusive bounds respectively.
+//
 // If disallowShadowingBelow is non-empty, it also errors for any existing live
 // key at the SST key timestamp, but allows shadowing an existing key if its
 // timestamp is above the given timestamp and the values are equal. See comment
@@ -107,7 +110,7 @@ func CheckSSTConflicts(
 	ctx context.Context,
 	sst []byte,
 	reader Reader,
-	start, end MVCCKey,
+	start, end roachpb.Key,
 	leftPeekBound, rightPeekBound roachpb.Key,
 	disallowShadowing bool,
 	disallowShadowingBelow hlc.Timestamp,
@@ -148,9 +151,9 @@ func CheckSSTConflicts(
 		// prefix one if there are engine keys in the span.
 		nonPrefixIter := reader.NewMVCCIterator(MVCCKeyAndIntentsIterKind, IterOptions{
 			KeyTypes:   IterKeyTypePointsAndRanges,
-			UpperBound: end.Key,
+			UpperBound: end,
 		})
-		nonPrefixIter.SeekGE(start)
+		nonPrefixIter.SeekGE(MVCCKey{Key: start})
 		valid, err := nonPrefixIter.Valid()
 		nonPrefixIter.Close()
 		if !valid {
@@ -187,7 +190,7 @@ func CheckSSTConflicts(
 		UpperBound: rightPeekBound,
 		KeyTypes:   IterKeyTypeRangesOnly,
 	})
-	rkIter.SeekGE(start)
+	rkIter.SeekGE(MVCCKey{Key: start})
 
 	var engineHasRangeKeys bool
 	if ok, err := rkIter.Valid(); err != nil {
@@ -232,7 +235,7 @@ func CheckSSTConflicts(
 
 	sstIter, err := NewMemSSTIterator(sst, false, IterOptions{
 		KeyTypes:   IterKeyTypePointsAndRanges,
-		UpperBound: end.Key,
+		UpperBound: end,
 	})
 	if err != nil {
 		return enginepb.MVCCStats{}, err
@@ -369,7 +372,7 @@ func CheckSSTConflicts(
 		return nil
 	}
 
-	sstIter.SeekGE(start)
+	sstIter.SeekGE(MVCCKey{Key: start})
 	sstOK, sstErr := sstIter.Valid()
 	var extOK bool
 	var extErr error

--- a/pkg/storage/sst_test.go
+++ b/pkg/storage/sst_test.go
@@ -16,16 +16,21 @@ import (
 	"encoding/binary"
 	"fmt"
 	"math/rand"
+	"sort"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
+	"github.com/cockroachdb/cockroach/pkg/storage/meta"
 	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/randutil"
+	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/require"
 )
 
@@ -166,4 +171,502 @@ func runUpdateSSTTimestamps(ctx context.Context, b *testing.B, numKeys int, conc
 		}
 	}
 	_ = res
+}
+
+func TestCheckSSTConflictsRandomized(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	const numOperations = 10_000
+	ctx := context.Background()
+	prng, seed := randutil.NewPseudoRand()
+	t.Logf("Using seed %d; to re-run set COCKROACH_RANDOM_SEED=%d", seed, seed)
+
+	// Generate a random set of operations.
+	g := &sstOpGenerator{
+		maxKeyLen:        6,
+		maxValLen:        10,
+		tsLow:            randutil.RandInt63InRange(prng, 1, 100),
+		tsHigh:           randutil.RandInt63InRange(prng, 100, 200),
+		pendingPointKeys: map[string]int64{},
+	}
+	ops := meta.Generate(prng, numOperations,
+		meta.Weighted([]meta.ItemWeight[func(*rand.Rand) meta.Op[*sstTestState]]{
+			{Weight: 100, Item: g.generateMVCCPut},
+			{Weight: 30, Item: g.generateMVCCDel},
+			{Weight: 5, Item: g.generateMVCCDelRangeTombstone},
+			{Weight: 10, Item: g.generateCheckSSTConflicts},
+			{Weight: 10, Item: g.generateAddSSTable},
+			{Weight: 10, Item: g.generateComputeStats},
+		}))
+
+	eng, err := Open(ctx, InMemory(), cluster.MakeTestingClusterSettings())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer eng.Close()
+	s := &sstTestState{engine: eng}
+	meta.RunOne[*sstTestState](t, s, ops)
+}
+
+type sstTestState struct {
+	engine      Engine
+	bufferedOps sstWriterOps
+}
+
+// sstWriterOp is an operation that writes to a sstable writer. The
+// CheckSSTConflicts randomized test buffers these operations and sorts them by
+// key before applying them to a sstable writer.
+type sstWriterOp interface {
+	fmt.Stringer
+	sortKey() MVCCKey
+	apply(*SSTWriter) error
+}
+
+// sstWriterOps implements sort.Interface, sorting ops by their sort key. It's
+// used to order ops before applying them to sstable writer which requires
+// writes to be ordered.
+type sstWriterOps []sstWriterOp
+
+func (s sstWriterOps) Len() int           { return len(s) }
+func (s sstWriterOps) Swap(i, j int)      { s[i], s[j] = s[j], s[i] }
+func (s sstWriterOps) Less(i, j int) bool { return s[i].sortKey().Compare(s[j].sortKey()) < 0 }
+
+type sstOpGenerator struct {
+	maxKeyLen int
+	maxValLen int
+	// rangeStart is the start key of the current KV range that the built
+	// sstable is targeting. It's a byte in a-z, except if unset in which case
+	// it's the zero byte.
+	rangeStart byte
+	// ts{Low,High} hold the inclusive (low) and exclusive (high) timestamp
+	// bounds for timestamps that should be generated.
+	tsLow, tsHigh int64
+	// pendingPointKeys contains a map of all MVCC user keys for which a key has
+	// been written since the last AddSSTable. The value is the MVCC timestamp
+	// at which it's written. It's used to prevent writing the same key twice in
+	// an sstable, which CheckSSTConflicts does not support.
+	pendingPointKeys map[string]int64
+	pendingRangeKeys []MVCCRangeKey
+}
+
+func (g *sstOpGenerator) generateTS(rng *rand.Rand) hlc.Timestamp {
+	g.tsLow += rng.Int63n(3)
+	g.tsHigh += rng.Int63n(3)
+	if g.tsHigh <= g.tsLow {
+		g.tsHigh = g.tsLow + 1
+	}
+	return hlc.Timestamp{WallTime: randutil.RandInt63InRange(rng, g.tsLow, g.tsHigh)}
+}
+
+// generateKey generates a new user key within the current range
+// (`g.rangeStart`). If `g.rangeStart` is unset, it'll set a random range.
+func (g *sstOpGenerator) generateKey(rng *rand.Rand) roachpb.Key {
+	if g.rangeStart == 0 {
+		g.rangeStart = randutil.LowercaseAlphabet[rng.Intn(len(randutil.LowercaseAlphabet))]
+	}
+	return append(roachpb.Key{g.rangeStart},
+		randutil.RandBytesInRange(rng, randutil.LowercaseAlphabet, 1, g.maxKeyLen-1)...)
+}
+
+func (g *sstOpGenerator) pointKeyConflicts(k MVCCKey) bool {
+	if _, ok := g.pendingPointKeys[string(k.Key)]; ok {
+		return true
+	}
+	for _, p := range g.pendingRangeKeys {
+		if p.Includes(k.Key) && p.Timestamp == k.Timestamp {
+			return true
+		}
+	}
+	return false
+}
+
+func (g *sstOpGenerator) rangeKeyConflicts(rk MVCCRangeKey) bool {
+	for _, p := range g.pendingRangeKeys {
+		if rk.Overlaps(p) && rk.Timestamp == p.Timestamp {
+			return true
+		}
+	}
+	for k, timestamp := range g.pendingPointKeys {
+		if rk.Timestamp.WallTime != timestamp {
+			continue
+		}
+		if rk.Includes(roachpb.Key(k)) {
+			return true
+		}
+	}
+	return false
+}
+
+// generateMVCCKey generates a new random MVCC key within the current KV range.
+// It avoids producing a MVCC key with the same user key and timestamp as
+// another key added since the last AddSSTable operation.
+func (g *sstOpGenerator) generateMVCCKey(rng *rand.Rand) MVCCKey {
+	k := MVCCKey{Key: g.generateKey(rng), Timestamp: g.generateTS(rng)}
+	// Avoid duplicates.
+	for g.pointKeyConflicts(k) {
+		k = MVCCKey{Key: g.generateKey(rng), Timestamp: g.generateTS(rng)}
+	}
+	g.pendingPointKeys[string(k.Key)] = k.Timestamp.WallTime
+	return k
+}
+
+func (g *sstOpGenerator) generateVal(rng *rand.Rand) []byte {
+	return randutil.RandBytesInRange(rng, randutil.LowercaseAlphabet, 0, g.maxValLen)
+}
+
+func (g *sstOpGenerator) rangeBounds() (start, end roachpb.Key) {
+	return roachpb.Key{g.rangeStart}, roachpb.Key{g.rangeStart + 1}
+}
+
+type putOp struct {
+	key       MVCCKey
+	userValue []byte
+}
+
+func (o *putOp) String() string {
+	return fmt.Sprintf("MVCCPut(%q@%d, %q)", o.key.Key, o.key.Timestamp.WallTime, o.userValue)
+}
+func (o *putOp) sortKey() MVCCKey { return o.key }
+func (o *putOp) apply(w *SSTWriter) error {
+	var v MVCCValue
+	v.Value.SetBytes(o.userValue)
+	v.Value.InitChecksum(o.key.Key)
+	return w.PutMVCC(o.key, v)
+}
+func (o *putOp) Run(l *meta.Logger, s *sstTestState) {
+	s.bufferedOps = append(s.bufferedOps, o)
+	l.Log("ok")
+}
+
+func (g *sstOpGenerator) generateMVCCPut(rng *rand.Rand) meta.Op[*sstTestState] {
+	return &putOp{
+		key:       g.generateMVCCKey(rng),
+		userValue: g.generateVal(rng),
+	}
+}
+
+type delOp struct {
+	key MVCCKey
+}
+
+func (o *delOp) String() string {
+	return fmt.Sprintf("MVCCDelete(%q@%d)", o.key.Key, o.key.Timestamp.WallTime)
+}
+func (o *delOp) sortKey() MVCCKey         { return o.key }
+func (o *delOp) apply(w *SSTWriter) error { return w.PutMVCC(o.key, MVCCValue{}) }
+func (o *delOp) Run(l *meta.Logger, s *sstTestState) {
+	s.bufferedOps = append(s.bufferedOps, o)
+	l.Log("ok")
+}
+
+func (g *sstOpGenerator) generateMVCCDel(rng *rand.Rand) meta.Op[*sstTestState] {
+	return &delOp{key: g.generateMVCCKey(rng)}
+}
+
+// Del range
+
+type sstDelRangeTombstoneOp struct {
+	key       MVCCRangeKey
+	peekLeft  roachpb.Key
+	peekRight roachpb.Key
+}
+
+func (o *sstDelRangeTombstoneOp) String() string {
+	return fmt.Sprintf("MVCCDeleteRangeUsingTombstone(%s, %s, %s)",
+		o.key.StartKey, o.key.EndKey, o.key.Timestamp)
+}
+func (o *sstDelRangeTombstoneOp) sortKey() MVCCKey {
+	return MVCCKey{Key: o.key.StartKey}
+}
+func (o *sstDelRangeTombstoneOp) apply(w *SSTWriter) error {
+	return w.PutMVCCRangeKey(o.key, MVCCValue{})
+}
+func (o *sstDelRangeTombstoneOp) Run(l *meta.Logger, s *sstTestState) {
+	s.bufferedOps = append(s.bufferedOps, o)
+	l.Log("ok")
+}
+
+func (g *sstOpGenerator) generateMVCCDelRangeTombstone(rng *rand.Rand) meta.Op[*sstTestState] {
+	if g.rangeStart == 0 {
+		g.rangeStart = randutil.LowercaseAlphabet[rng.Intn(len(randutil.LowercaseAlphabet))]
+	}
+	generateRangeKey := func() (rk MVCCRangeKey) {
+		rk.Timestamp = g.generateTS(rng)
+		if rng.Intn(3) == 0 {
+			rk.StartKey = roachpb.Key{g.rangeStart}
+		} else {
+			rk.StartKey = g.generateKey(rng)
+		}
+		if rng.Intn(3) == 0 {
+			rk.EndKey = roachpb.Key{rk.StartKey[0] + 1}
+		} else {
+			rk.EndKey = g.generateKey(rng)
+		}
+		// Ensure the bounds are properly ordered and nonequal.
+		if v := bytes.Compare(rk.StartKey, rk.EndKey); v > 0 {
+			rk.EndKey, rk.StartKey = rk.StartKey, rk.EndKey
+		} else if v == 0 {
+			rk.EndKey = append(append(rk.EndKey[:0], rk.StartKey...), 0x00)
+		}
+		return rk
+	}
+	rk := generateRangeKey()
+	for g.rangeKeyConflicts(rk) {
+		rk = generateRangeKey()
+	}
+
+	// TODO(jackson): Increase the probability of generating abutting
+	// range tombstones in neighboring ranges.
+	rangeStart, rangeEnd := g.rangeBounds()
+	return &sstDelRangeTombstoneOp{
+		key:       rk,
+		peekLeft:  rangeStart,
+		peekRight: rangeEnd,
+	}
+}
+
+type checkSSTConflictsOp struct {
+	// start and end hold the start and end keys of the sstable.
+	start, end roachpb.Key
+	// usePrefix determines whether or not the CheckSSTConflicts call should use
+	// prefix iteration if possible.
+	//
+	// TODO(jackson): This can be varied metamorphically at /execution/ time,
+	// but currently we don't have support for execution time metamorphism in
+	// the `meta` package.
+	usePrefix         bool
+	disallowShadowing *hlc.Timestamp
+}
+
+func (o *checkSSTConflictsOp) String() string {
+	return fmt.Sprintf("CheckSSTConflicts(disallowShadowing=%s, usePrefix=%t)", o.disallowShadowing, o.usePrefix)
+}
+func (o *checkSSTConflictsOp) Run(l *meta.Logger, s *sstTestState) {
+	if len(s.bufferedOps) == 0 {
+		l.Log("noop")
+		return
+	}
+
+	ctx := context.Background()
+	sort.Stable(s.bufferedOps)
+	f := new(MemObject)
+	w := MakeIngestionSSTWriter(ctx, cluster.MakeTestingClusterSettings(), f)
+	for i := 0; i < len(s.bufferedOps); i++ {
+		if err := s.bufferedOps[i].apply(&w); err != nil {
+			require.NoError(l, errors.Wrapf(err, "during op %d: %s", i, s.bufferedOps[i].String()))
+		}
+	}
+	require.NoError(l, w.Finish())
+
+	var disallowShadowingTS hlc.Timestamp
+	if o.disallowShadowing != nil {
+		disallowShadowingTS = *o.disallowShadowing
+	}
+
+	stats, err := CheckSSTConflicts(
+		ctx,
+		f.Bytes(),
+		s.engine,
+		s.bufferedOps[0].sortKey().Key,
+		s.bufferedOps[len(s.bufferedOps)-1].sortKey().Key.Next(),
+		o.start,
+		o.end,
+		o.disallowShadowing != nil,
+		disallowShadowingTS,
+		hlc.Timestamp{},
+		1000,
+		o.usePrefix)
+	l.Logf("\nStats: %s\nError: %v", stats.Formatted(false /* delta */), err)
+}
+
+func (g *sstOpGenerator) generateCheckSSTConflicts(rng *rand.Rand) meta.Op[*sstTestState] {
+	start, end := g.rangeBounds()
+	o := &checkSSTConflictsOp{
+		start:     start,
+		end:       end,
+		usePrefix: rng.Intn(2) == 1,
+	}
+	if rng.Intn(2) == 1 {
+		// Disallow shadowing.
+		o.disallowShadowing = new(hlc.Timestamp)
+		*o.disallowShadowing = g.generateTS(rng)
+	}
+	return o
+}
+
+type addSSTableOp struct {
+	// start and end hold the start and end keys of the sstable.
+	start, end roachpb.Key
+	// usePrefix determines whether or not the CheckSSTConflicts call should use
+	// prefix iteration if possible.
+	//
+	// TODO(jackson): This can be varied metamorphically at /execution/ time,
+	// but currently we don't have support for execution time metamorphism in
+	// the `meta` package.
+	usePrefix         bool
+	disallowShadowing *hlc.Timestamp
+	readAt            hlc.Timestamp
+}
+
+func (o *addSSTableOp) String() string {
+	return fmt.Sprintf("AddSSTable(disallowShadowing=%s, usePrefix=%t, readAt=%d)",
+		o.disallowShadowing, o.usePrefix, o.readAt.WallTime)
+}
+func (o *addSSTableOp) Run(l *meta.Logger, s *sstTestState) {
+	if len(s.bufferedOps) == 0 {
+		l.Log("noop")
+		return
+	}
+
+	ctx := context.Background()
+	sort.Sort(s.bufferedOps)
+	f := new(MemObject)
+	w := MakeIngestionSSTWriter(ctx, cluster.MakeTestingClusterSettings(), f)
+	for i := 0; i < len(s.bufferedOps); i++ {
+		if err := s.bufferedOps[i].apply(&w); err != nil {
+			require.NoError(l, errors.Wrapf(err, "apply op to writer %d: %s", i, s.bufferedOps[i].String()))
+		}
+	}
+	require.NoError(l, w.Finish())
+
+	var disallowShadowingTS hlc.Timestamp
+	if o.disallowShadowing != nil {
+		disallowShadowingTS = *o.disallowShadowing
+	}
+
+	sstIter, err := NewMemSSTIterator(f.Data(), true /* verify */, IterOptions{
+		KeyTypes:   IterKeyTypePointsAndRanges,
+		LowerBound: keys.MinKey,
+		UpperBound: keys.MaxKey,
+	})
+	require.NoError(l, err)
+	defer sstIter.Close()
+
+	sstIter.SeekGE(MVCCKey{Key: keys.MinKey})
+	_, err = sstIter.Valid()
+	require.NoError(l, err)
+
+	logKey := func(k MVCCKey, v []byte) error {
+		mv, err := DecodeMVCCValue(v)
+		if err != nil {
+			return err
+		}
+		l.Logf("  %s→%s\n", k, mv)
+		return nil
+	}
+	logRangeKey := func(rkv MVCCRangeKeyValue) error {
+		mv, err := DecodeMVCCValue(rkv.Value)
+		if err != nil {
+			return err
+		}
+		l.Logf("  %s→%s\n", rkv.RangeKey, mv)
+		return nil
+	}
+
+	l.Log("\nSST:\n")
+	sstStats, err := computeStatsForIterWithVisitors(
+		sstIter, o.readAt.WallTime, logKey, logRangeKey)
+	require.NoError(l, err)
+	l.Log("Before:\n")
+	beforeStats, err := ComputeStatsWithVisitors(
+		s.engine, o.start, o.end, o.readAt.WallTime, logKey, logRangeKey)
+	require.NoError(l, err)
+
+	conflictStats, err := CheckSSTConflicts(
+		ctx,
+		f.Bytes(),
+		s.engine,
+		s.bufferedOps[0].sortKey().Key,
+		o.end.Next(),
+		o.start,
+		o.end,
+		o.disallowShadowing != nil,
+		disallowShadowingTS,
+		hlc.Timestamp{},
+		1000,
+		o.usePrefix)
+	if err != nil {
+		l.Log("error ", err)
+		s.bufferedOps = nil
+		return
+	}
+
+	{
+		f2, err := s.engine.Create("op.sst")
+		require.NoError(l, err)
+		_, err = f2.Write(f.Data())
+		require.NoError(l, err)
+		require.NoError(l, f2.Sync())
+		require.NoError(l, f2.Close())
+		require.NoError(l, s.engine.IngestExternalFiles(ctx, []string{"op.sst"}))
+	}
+
+	ms := beforeStats
+	ms.Add(sstStats)
+	ms.Add(conflictStats)
+	l.Log("After:\n")
+	afterStats, err := ComputeStatsWithVisitors(
+		s.engine, o.start, o.end, o.readAt.WallTime, logKey, logRangeKey)
+	require.NoError(l, err)
+
+	if ms.ContainsEstimates == 0 && !ms.Equal(&afterStats) {
+		delta := afterStats
+		delta.Subtract(ms)
+		l.Fatal(errors.AssertionFailedf("range %s: stats calculated from CheckSSTConflicts differ:\n"+
+			"SST:\n  %s\nConflict:\n  %s\nBefore:\n  %s\nBefore+SST+Conflict:\n  %s\n"+
+			"ComputeStats:\n  %s\nDiff:\n  %s",
+			o.start,
+			sstStats.Formatted(true /* delta */),
+			conflictStats.Formatted(true /* delta */),
+			beforeStats.Formatted(false /* delta */),
+			ms.Formatted(false /* delta */),
+			afterStats.Formatted(false /* delta */),
+			delta.Formatted(true /* delta */)))
+	}
+	l.Commentf("%s: %s", o.start, afterStats.Formatted(false /* delta */))
+
+	// Next sstable starts anew.
+	s.bufferedOps = nil
+	l.Log("ok")
+}
+
+func (g *sstOpGenerator) generateAddSSTable(rng *rand.Rand) meta.Op[*sstTestState] {
+	start, end := g.rangeBounds()
+	o := &addSSTableOp{
+		start:     start,
+		end:       end,
+		usePrefix: rng.Intn(2) == 1,
+	}
+	if rng.Intn(2) == 1 {
+		// Disallow shadowing.
+		o.disallowShadowing = new(hlc.Timestamp)
+		*o.disallowShadowing = g.generateTS(rng)
+	}
+	o.readAt = hlc.Timestamp{WallTime: g.tsHigh}
+	// Next table starts anew.
+	g.pendingPointKeys = map[string]int64{}
+	g.pendingRangeKeys = nil
+	g.rangeStart = randutil.LowercaseAlphabet[rng.Intn(len(randutil.LowercaseAlphabet))]
+	return o
+}
+
+type sstComputeStatsOp struct {
+	timestamp int64
+}
+
+func (o *sstComputeStatsOp) String() string {
+	return fmt.Sprintf("ComputeStats(timestamp=%d)", o.timestamp)
+}
+func (o *sstComputeStatsOp) Run(l *meta.Logger, s *sstTestState) {
+	// Compute stats for every range, where ranges are [a,b),[b,c), ..., [z,A)
+	for start, end := byte('a'), byte('b'); start <= 'z'; start, end = start+1, end+1 {
+		stats, err := ComputeStats(s.engine, roachpb.Key{start}, roachpb.Key{end}, o.timestamp)
+		require.NoError(l, err)
+		l.Logf("\n%s: %s", string(start), stats.Formatted(false /* delta */))
+	}
+}
+
+func (g *sstOpGenerator) generateComputeStats(rng *rand.Rand) meta.Op[*sstTestState] {
+	return &sstComputeStatsOp{timestamp: g.generateTS(rng).WallTime}
 }

--- a/pkg/storage/sst_test.go
+++ b/pkg/storage/sst_test.go
@@ -90,8 +90,7 @@ func TestCheckSSTConflictsMaxIntents(t *testing.T) {
 			for _, usePrefixSeek := range []bool{false, true} {
 				t.Run(fmt.Sprintf("usePrefixSeek=%v", usePrefixSeek), func(t *testing.T) {
 					// Provoke and check WriteIntentErrors.
-					startKey, endKey := MVCCKey{Key: roachpb.Key(start)}, MVCCKey{Key: roachpb.Key(end)}
-					_, err := CheckSSTConflicts(ctx, sstFile.Bytes(), engine, startKey, endKey, startKey.Key, endKey.Key.Next(),
+					_, err := CheckSSTConflicts(ctx, sstFile.Bytes(), engine, roachpb.Key(start), roachpb.Key(end), roachpb.Key(start), roachpb.Key(end).Next(),
 						false /*disallowShadowing*/, hlc.Timestamp{} /*disallowShadowingBelow*/, hlc.Timestamp{} /* sstReqTS */, tc.maxIntents, usePrefixSeek)
 					require.Error(t, err)
 					writeIntentErr := &kvpb.WriteIntentError{}

--- a/pkg/util/randutil/rand.go
+++ b/pkg/util/randutil/rand.go
@@ -178,7 +178,18 @@ func RandDuration(r *rand.Rand, max time.Duration) time.Duration {
 	return time.Duration(r.Int63n(int64(max)))
 }
 
-var randLetters = []byte("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")
+const (
+	// MixedCaseAlphabet defines the alphabet of mixed-case letters for use when
+	// generating random bytes.
+	MixedCaseAlphabet = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
+	// LowercaseAlphabet defines the alphabet of lowercase letters for use when
+	// generating random bytes.
+	LowercaseAlphabet = "abcdefghijklmnopqrstuvwxyz"
+	// PrintableKeyAlphabet to use with random string generation to produce strings
+	// that doesn't need to be escaped when found as a part of a key and is
+	// generally human printable.
+	PrintableKeyAlphabet = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+)
 
 // RandBytes returns a byte slice of the given length with random
 // data.
@@ -186,12 +197,24 @@ func RandBytes(r *rand.Rand, size int) []byte {
 	if size <= 0 {
 		return nil
 	}
-
 	arr := make([]byte, size)
-	for i := 0; i < len(arr); i++ {
-		arr[i] = randLetters[r.Intn(len(randLetters))]
-	}
+	FillRandBytes(r, arr, MixedCaseAlphabet)
 	return arr
+}
+
+// FillRandBytes fills a bytes slice with random data.
+func FillRandBytes(r *rand.Rand, b []byte, alphabet string) {
+	for i := 0; i < len(b); i++ {
+		b[i] = alphabet[r.Intn(len(alphabet))]
+	}
+}
+
+// RandBytesInRange returns a byte slice with length [minSize,maxSize) with
+// random characters pulled from alphabet.
+func RandBytesInRange(r *rand.Rand, alphabet string, minSize, maxSize int) []byte {
+	b := make([]byte, RandIntInRange(r, minSize, maxSize))
+	FillRandBytes(r, b, alphabet)
+	return b
 }
 
 // FastUint32 returns a lock free uint32 value. Compared to rand.Uint32, this
@@ -222,11 +245,6 @@ func ReadTestdataBytes(r *rand.Rand, arr []byte) {
 		}
 	}
 }
-
-// PrintableKeyAlphabet to use with random string generation to produce strings
-// that doesn't need to be escaped when found as a part of a key and is
-// generally human printable.
-const PrintableKeyAlphabet = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
 
 // RandString generates a random string of the desired length from the
 // input alphabet. It is useful when you want to generate keys that would


### PR DESCRIPTION
**enginepb: add MVCCStats.Formatted**

Move the storage test formatStats function onto the MVCCStats type itself in
preparation for using it in additional places.

**storage: change CheckSSTConflicts start and end types**

Callers of CheckSSTConflicts pass in start and end boundaries for the sstable.
Previously, these were passed as MVCCKeys, although the end key's timestamp was
ignored. This resulted in confusing semantics whereby the end boundary was
interpreted as exclusive end bound of `end.Key`.

**storage: add new CheckSSTConflicts randomized test**

Add a new randomized test exercising CheckSSTConflicts. Additionally, sketch
out a `meta` package to aid in writing randomized tests like this one. In the
future, this package may be extracted to the cockroachdb/metamorphic
repository.

Epic: None
Release note: None
Informs #94141.
Informs cockroachdb/pebble#2086.