### PR TITLE
opt: enable optimizer_always_use_histograms for opt tests

### DIFF
--- a/pkg/sql/opt/memo/testdata/stats_quality/tpcc
+++ b/pkg/sql/opt/memo/testdata/stats_quality/tpcc
@@ -32,6 +32,8 @@ project
       ├── constraint: /1: [/1 - /1]
       ├── cardinality: [0 - 1]
       ├── stats: [rows=1, distinct(1)=1, null(1)=0, distinct(8)=1, null(8)=0]
+      │   histogram(1)=  0  1
+      │                <--- 1
       ├── key: ()
       └── fd: ()-->(1,8)
 
@@ -56,7 +58,7 @@ project
  ├── save-table-name: new_order_02_project_1
  ├── columns: c_discount:16(decimal) c_last:6(varchar) c_credit:14(char)
  ├── cardinality: [0 - 1]
- ├── stats: [rows=1, distinct(6)=0.999502, null(6)=0, distinct(14)=0.78694, null(14)=0, distinct(16)=0.999902, null(16)=0]
+ ├── stats: [rows=0.909016, distinct(6)=0.908604, null(6)=0, distinct(14)=0.730481, null(14)=0, distinct(16)=0.908935, null(16)=0]
  ├── key: ()
  ├── fd: ()-->(6,14,16)
  └── scan customer
@@ -64,7 +66,13 @@ project
       ├── columns: c_id:1(int!null) c_d_id:2(int!null) c_w_id:3(int!null) c_last:6(varchar) c_credit:14(char) c_discount:16(decimal)
       ├── constraint: /3/2/1: [/1/1/50 - /1/1/50]
       ├── cardinality: [0 - 1]
-      ├── stats: [rows=1, distinct(1)=1, null(1)=0, distinct(2)=1, null(2)=0, distinct(3)=1, null(3)=0, distinct(6)=0.999502, null(6)=0, distinct(14)=0.78694, null(14)=0, distinct(16)=0.999902, null(16)=0, distinct(1-3)=1, null(1-3)=0]
+      ├── stats: [rows=0.909016, distinct(1)=0.909016, null(1)=0, distinct(2)=0.909016, null(2)=0, distinct(3)=0.909016, null(3)=0, distinct(6)=0.908604, null(6)=0, distinct(14)=0.730481, null(14)=0, distinct(16)=0.908935, null(16)=0, distinct(1-3)=0.909016, null(1-3)=0]
+      │   histogram(1)=  0 0.90902
+      │                <---- 50 --
+      │   histogram(2)=  0 0.90902
+      │                <----- 1 --
+      │   histogram(3)=  0 0.90902
+      │                <----- 1 --
       ├── key: ()
       └── fd: ()-->(1-3,6,14,16)
 
@@ -112,6 +120,8 @@ scan item
  │    └── [/300 - /300]
  ├── cardinality: [0 - 12]
  ├── stats: [rows=12, distinct(1)=12, null(1)=0, distinct(3)=11.8958, null(3)=0, distinct(4)=11.9934, null(4)=0, distinct(5)=11.9946, null(5)=0]
+ │   histogram(1)=  0  1   0  1   0  1   0   1   0   1   0   1   0   1   0   1   0   1   0   1   0   1   0   1
+ │                <--- 25 --- 50 --- 75 --- 100 --- 125 --- 150 --- 175 --- 200 --- 225 --- 250 --- 275 --- 300
  ├── key: (1)
  ├── fd: (1)-->(3-5)
  └── ordering: +1
@@ -142,7 +152,7 @@ project
  ├── save-table-name: new_order_04_project_1
  ├── columns: s_quantity:3(int) s_ytd:14(int) s_order_cnt:15(int) s_remote_cnt:16(int) s_data:17(varchar) s_dist_05:8(char)  [hidden: s_i_id:1(int!null)]
  ├── cardinality: [0 - 5]
- ├── stats: [rows=5, distinct(1)=5, null(1)=0, distinct(3)=4.86513, null(3)=0, distinct(8)=4.80371, null(8)=0, distinct(14)=0.993262, null(14)=0, distinct(15)=0.993262, null(15)=0, distinct(16)=0.993262, null(16)=0, distinct(17)=4.99973, null(17)=0]
+ ├── stats: [rows=4.548552, distinct(1)=4.54855, null(1)=0, distinct(3)=4.43676, null(3)=0, distinct(8)=4.38572, null(8)=0, distinct(14)=0.989418, null(14)=0, distinct(15)=0.989418, null(15)=0, distinct(16)=0.989418, null(16)=0, distinct(17)=4.54833, null(17)=0]
  ├── key: (1)
  ├── fd: (1)-->(3,8,14-17)
  ├── ordering: +1
@@ -156,7 +166,11 @@ project
       │    ├── [/4/1400 - /4/1400]
       │    └── [/4/1500 - /4/1500]
       ├── cardinality: [0 - 5]
-      ├── stats: [rows=5, distinct(1)=5, null(1)=0, distinct(2)=1, null(2)=0, distinct(3)=4.86513, null(3)=0, distinct(8)=4.80371, null(8)=0, distinct(14)=0.993262, null(14)=0, distinct(15)=0.993262, null(15)=0, distinct(16)=0.993262, null(16)=0, distinct(17)=4.99973, null(17)=0, distinct(1,2)=5, null(1,2)=0]
+      ├── stats: [rows=4.548552, distinct(1)=4.54855, null(1)=0, distinct(2)=1, null(2)=0, distinct(3)=4.43676, null(3)=0, distinct(8)=4.38572, null(8)=0, distinct(14)=0.989418, null(14)=0, distinct(15)=0.989418, null(15)=0, distinct(16)=0.989418, null(16)=0, distinct(17)=4.54833, null(17)=0, distinct(1,2)=4.54855, null(1,2)=0]
+      │   histogram(1)=  0 0.966 0 0.966  0 0.966  0 0.82528 0 0.82528
+      │                <--- 900 --- 1000 --- 1100 --- 1400 ---- 1500 -
+      │   histogram(2)=  0 4.5486
+      │                <---- 4 --
       ├── key: (1)
       ├── fd: ()-->(2), (1)-->(3,8,14-17)
       └── ordering: +1 opt(2) [actual: +1]
@@ -174,10 +188,10 @@ column_names    row_count  distinct_count  null_count
 ~~~~
 column_names    row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
 {s_data}        5.00           1.00           5.00                1.00                0.00            1.00
-{s_dist_05}     5.00           1.00           5.00                1.00                0.00            1.00
+{s_dist_05}     5.00           1.00           4.00                1.25                0.00            1.00
 {s_i_id}        5.00           1.00           5.00                1.00                0.00            1.00
 {s_order_cnt}   5.00           1.00           1.00                1.00                0.00            1.00
-{s_quantity}    5.00           1.00           5.00                1.25                0.00            1.00
+{s_quantity}    5.00           1.00           4.00                1.00                0.00            1.00
 {s_remote_cnt}  5.00           1.00           1.00                1.00                0.00            1.00
 {s_w_id}        5.00           1.00           1.00                1.00                0.00            1.00
 {s_ytd}         5.00           1.00           1.00                1.00                0.00            1.00
@@ -258,7 +272,7 @@ project
  ├── save-table-name: order_status_01_project_1
  ├── columns: c_balance:17(decimal) c_first:4(varchar) c_middle:5(char) c_last:6(varchar)
  ├── cardinality: [0 - 1]
- ├── stats: [rows=1, distinct(4)=0.999106, null(4)=0, distinct(5)=0.632121, null(5)=0, distinct(6)=0.999502, null(6)=0, distinct(17)=0.632121, null(17)=0]
+ ├── stats: [rows=0.909016, distinct(4)=0.908277, null(4)=0, distinct(5)=0.59708, null(5)=0, distinct(6)=0.908604, null(6)=0, distinct(17)=0.59708, null(17)=0]
  ├── key: ()
  ├── fd: ()-->(4-6,17)
  └── scan customer
@@ -266,7 +280,13 @@ project
       ├── columns: c_id:1(int!null) c_d_id:2(int!null) c_w_id:3(int!null) c_first:4(varchar) c_middle:5(char) c_last:6(varchar) c_balance:17(decimal)
       ├── constraint: /3/2/1: [/1/1/50 - /1/1/50]
       ├── cardinality: [0 - 1]
-      ├── stats: [rows=1, distinct(1)=1, null(1)=0, distinct(2)=1, null(2)=0, distinct(3)=1, null(3)=0, distinct(4)=0.999106, null(4)=0, distinct(5)=0.632121, null(5)=0, distinct(6)=0.999502, null(6)=0, distinct(17)=0.632121, null(17)=0, distinct(1-3)=1, null(1-3)=0]
+      ├── stats: [rows=0.909016, distinct(1)=0.909016, null(1)=0, distinct(2)=0.909016, null(2)=0, distinct(3)=0.909016, null(3)=0, distinct(4)=0.908277, null(4)=0, distinct(5)=0.59708, null(5)=0, distinct(6)=0.908604, null(6)=0, distinct(17)=0.59708, null(17)=0, distinct(1-3)=0.909016, null(1-3)=0]
+      │   histogram(1)=  0 0.90902
+      │                <---- 50 --
+      │   histogram(2)=  0 0.90902
+      │                <----- 1 --
+      │   histogram(3)=  0 0.90902
+      │                <----- 1 --
       ├── key: ()
       └── fd: ()-->(1-6,17)
 
@@ -578,6 +598,10 @@ project
       ├── constraint: /2/1: [/4/9 - /4/9]
       ├── cardinality: [0 - 1]
       ├── stats: [rows=1, distinct(1)=1, null(1)=0, distinct(2)=1, null(2)=0, distinct(11)=0.633968, null(11)=0, distinct(1,2)=1, null(1,2)=0]
+      │   histogram(1)=  0  1
+      │                <--- 9
+      │   histogram(2)=  0  1
+      │                <--- 4
       ├── key: ()
       └── fd: ()-->(1,2,11)
 

--- a/pkg/sql/opt/testutils/opttester/opt_tester.go
+++ b/pkg/sql/opt/testutils/opttester/opt_tester.go
@@ -295,6 +295,7 @@ func New(catalog cat.Catalog, sql string) *OptTester {
 	ot.evalCtx.SessionData().OptimizerUseImprovedDisjunctionStats = true
 	ot.evalCtx.SessionData().OptimizerUseLimitOrderingForStreamingGroupBy = true
 	ot.evalCtx.SessionData().OptimizerUseImprovedSplitDisjunctionForJoins = true
+	ot.evalCtx.SessionData().OptimizerAlwaysUseHistograms = true
 
 	return ot
 }

--- a/pkg/sql/opt/testutils/opttester/testdata/use-multi-col-stats
+++ b/pkg/sql/opt/testutils/opttester/testdata/use-multi-col-stats
@@ -28,7 +28,9 @@ scan rides
  ├── columns: id:1(uuid!null) city:2(varchar!null) vehicle_city:3(varchar) rider_id:4(uuid) vehicle_id:5(uuid) start_address:6(varchar) end_address:7(varchar) start_time:8(timestamp) end_time:9(timestamp) revenue:10(decimal)
  ├── constraint: /2/1: [/'rome'/'17198184-b24f-4aa8-9933-64a72ff6665f' - /'rome'/'17198184-b24f-4aa8-9933-64a72ff6665f']
  ├── cardinality: [0 - 1]
- ├── stats: [rows=0.9111111, distinct(1)=0.911111, null(1)=0, distinct(2)=0.911111, null(2)=0, distinct(1,2)=0.911111, null(1,2)=0]
+ ├── stats: [rows=0.911, distinct(1)=0.911, null(1)=0, distinct(2)=0.911, null(2)=0, distinct(1,2)=0.911, null(1,2)=0]
+ │   histogram(2)=  0  0.911
+ │                <--- 'rome'
  ├── key: ()
  └── fd: ()-->(1-10)
 
@@ -39,6 +41,8 @@ scan rides
  ├── columns: id:1(uuid!null) city:2(varchar!null) vehicle_city:3(varchar) rider_id:4(uuid) vehicle_id:5(uuid) start_address:6(varchar) end_address:7(varchar) start_time:8(timestamp) end_time:9(timestamp) revenue:10(decimal)
  ├── constraint: /2/1: [/'rome'/'17198184-b24f-4aa8-9933-64a72ff6665f' - /'rome'/'17198184-b24f-4aa8-9933-64a72ff6665f']
  ├── cardinality: [0 - 1]
- ├── stats: [rows=0.1111112, distinct(1)=0.111111, null(1)=0, distinct(2)=0.111111, null(2)=0]
+ ├── stats: [rows=0.1100001, distinct(1)=0.11, null(1)=0, distinct(2)=0.11, null(2)=0]
+ │   histogram(2)=  0   0.11
+ │                <--- 'rome'
  ├── key: ()
  └── fd: ()-->(1-10)

--- a/pkg/sql/opt/xform/testdata/coster/scan
+++ b/pkg/sql/opt/xform/testdata/coster/scan
@@ -484,13 +484,13 @@ upsert t64570
  ├── cardinality: [0 - 0]
  ├── volatile, mutations
  ├── stats: [rows=0]
- ├── cost: 9.14483333
+ ├── cost: 9.0725
  └── left-join (cross)
       ├── columns: column1:6!null column2:7!null column3:8!null x:9 y:10 v:11
       ├── cardinality: [1 - 1]
       ├── multiplicity: left-rows(exactly-one), right-rows(exactly-one)
       ├── stats: [rows=1]
-      ├── cost: 9.13483333
+      ├── cost: 9.0625
       ├── key: ()
       ├── fd: ()-->(6-11)
       ├── values
@@ -505,8 +505,10 @@ upsert t64570
       │    ├── columns: x:9!null y:10!null v:11
       │    ├── constraint: /9/10: [/10/10 - /10/10]
       │    ├── cardinality: [0 - 1]
-      │    ├── stats: [rows=0.9333333, distinct(9)=0.933333, null(9)=0, distinct(10)=0.933333, null(10)=0, distinct(9,10)=0.933333, null(9,10)=0]
-      │    ├── cost: 9.066
+      │    ├── stats: [rows=6e-10, distinct(9)=6e-10, null(9)=0, distinct(10)=6e-10, null(10)=0, distinct(9,10)=6e-10, null(9,10)=0]
+      │    │   histogram(9)=
+      │    │   histogram(10)=
+      │    ├── cost: 9.01
       │    ├── key: ()
       │    └── fd: ()-->(9-11)
       └── filters (true)

--- a/pkg/sql/opt/xform/testdata/external/tpce
+++ b/pkg/sql/opt/xform/testdata/external/tpce
@@ -1032,21 +1032,22 @@ project
  │    │    │    │    │    │    │    ├── key columns: [6] = [22]
  │    │    │    │    │    │    │    ├── key: (17)
  │    │    │    │    │    │    │    ├── fd: ()-->(1,2,9), (17)-->(22), (6)==(22), (22)==(6), (1)==(9), (9)==(1)
- │    │    │    │    │    │    │    ├── inner-join (lookup industry)
+ │    │    │    │    │    │    │    ├── inner-join (lookup company@company_co_in_id_idx)
  │    │    │    │    │    │    │    │    ├── columns: in_id:1!null in_name:2!null co_id:6!null co_in_id:9!null
- │    │    │    │    │    │    │    │    ├── key columns: [9] = [1]
- │    │    │    │    │    │    │    │    ├── lookup columns are key
+ │    │    │    │    │    │    │    │    ├── lookup expression
+ │    │    │    │    │    │    │    │    │    └── filters
+ │    │    │    │    │    │    │    │    │         ├── in_id:1 = co_in_id:9 [outer=(1,9), constraints=(/1: (/NULL - ]; /9: (/NULL - ]), fd=(1)==(9), (9)==(1)]
+ │    │    │    │    │    │    │    │    │         └── (co_id:6 >= 1) AND (co_id:6 <= 5000) [outer=(6), constraints=(/6: [/1 - /5000]; tight)]
  │    │    │    │    │    │    │    │    ├── cardinality: [0 - 5000]
  │    │    │    │    │    │    │    │    ├── key: (6)
  │    │    │    │    │    │    │    │    ├── fd: ()-->(1,2,9), (1)==(9), (9)==(1)
- │    │    │    │    │    │    │    │    ├── scan company
- │    │    │    │    │    │    │    │    │    ├── columns: co_id:6!null co_in_id:9!null
- │    │    │    │    │    │    │    │    │    ├── constraint: /6: [/1 - /5000]
- │    │    │    │    │    │    │    │    │    ├── cardinality: [0 - 5000]
- │    │    │    │    │    │    │    │    │    ├── key: (6)
- │    │    │    │    │    │    │    │    │    └── fd: (6)-->(9)
- │    │    │    │    │    │    │    │    └── filters
- │    │    │    │    │    │    │    │         └── in_name:2 = 'Software' [outer=(2), constraints=(/2: [/'Software' - /'Software']; tight), fd=()-->(2)]
+ │    │    │    │    │    │    │    │    ├── scan industry@industry_in_name_key
+ │    │    │    │    │    │    │    │    │    ├── columns: in_id:1!null in_name:2!null
+ │    │    │    │    │    │    │    │    │    ├── constraint: /2: [/'Software' - /'Software']
+ │    │    │    │    │    │    │    │    │    ├── cardinality: [0 - 1]
+ │    │    │    │    │    │    │    │    │    ├── key: ()
+ │    │    │    │    │    │    │    │    │    └── fd: ()-->(1,2)
+ │    │    │    │    │    │    │    │    └── filters (true)
  │    │    │    │    │    │    │    └── filters
  │    │    │    │    │    │    │         └── (s_co_id:22 >= 1) AND (s_co_id:22 <= 5000) [outer=(22), constraints=(/22: [/1 - /5000]; tight)]
  │    │    │    │    │    │    └── projections
@@ -2801,7 +2802,7 @@ project
  │    │    │    │    ├── cardinality: [0 - 6]
  │    │    │    │    ├── key: (4)
  │    │    │    │    ├── fd: ()-->(1-3), (4)-->(5,6)
- │    │    │    │    └── limit hint: 4.00
+ │    │    │    │    └── limit hint: 1.00
  │    │    │    └── filters
  │    │    │         └── cr_to_qty:5 >= 100 [outer=(5), constraints=(/5: [/100 - ]; tight)]
  │    │    └── 1
@@ -4048,43 +4049,39 @@ project
  │    ├── fd: ()-->(1,8,27,30,31,45-50), (47)==(31), (8)==(45), (45)==(8), (31)==(47)
  │    ├── inner-join (merge)
  │    │    ├── columns: c_id:1!null c_tier:8!null s_symb:27!null s_name:30!null s_ex_id:31!null cr_c_tier:45!null cr_tt_id:46!null cr_ex_id:47!null cr_from_qty:48!null cr_to_qty:49!null commission_rate.cr_rate:50!null
- │    │    ├── left ordering: +45
- │    │    ├── right ordering: +8
+ │    │    ├── left ordering: +31
+ │    │    ├── right ordering: +47
  │    │    ├── key: (48)
  │    │    ├── fd: ()-->(1,8,27,30,31,45-47), (48)-->(49,50), (31)==(47), (47)==(31), (8)==(45), (45)==(8)
  │    │    ├── limit hint: 1.00
- │    │    ├── inner-join (lookup commission_rate)
- │    │    │    ├── columns: s_symb:27!null s_name:30!null s_ex_id:31!null cr_c_tier:45!null cr_tt_id:46!null cr_ex_id:47!null cr_from_qty:48!null cr_to_qty:49!null commission_rate.cr_rate:50!null
- │    │    │    ├── lookup expression
- │    │    │    │    └── filters
- │    │    │    │         ├── cr_c_tier:45 IN (1, 2, 3) [outer=(45), constraints=(/45: [/1 - /1] [/2 - /2] [/3 - /3]; tight)]
- │    │    │    │         ├── "lookup_join_const_col_@46":54 = cr_tt_id:46 [outer=(46,54), constraints=(/46: (/NULL - ]; /54: (/NULL - ]), fd=(46)==(54), (54)==(46)]
- │    │    │    │         ├── s_ex_id:31 = cr_ex_id:47 [outer=(31,47), constraints=(/31: (/NULL - ]; /47: (/NULL - ]), fd=(31)==(47), (47)==(31)]
- │    │    │    │         └── cr_from_qty:48 <= 100 [outer=(48), constraints=(/48: (/NULL - /100]; tight)]
- │    │    │    ├── key: (45,48)
- │    │    │    ├── fd: ()-->(27,30,31,46,47), (45,48)-->(49,50), (31)==(47), (47)==(31)
- │    │    │    ├── ordering: +45 opt(27,30,31,46,47) [actual: +45]
- │    │    │    ├── project
- │    │    │    │    ├── columns: "lookup_join_const_col_@46":54!null s_symb:27!null s_name:30!null s_ex_id:31!null
- │    │    │    │    ├── cardinality: [0 - 1]
- │    │    │    │    ├── key: ()
- │    │    │    │    ├── fd: ()-->(27,30,31,54)
- │    │    │    │    ├── scan security
- │    │    │    │    │    ├── columns: s_symb:27!null s_name:30!null s_ex_id:31!null
- │    │    │    │    │    ├── constraint: /27: [/'ROACH' - /'ROACH']
- │    │    │    │    │    ├── cardinality: [0 - 1]
- │    │    │    │    │    ├── key: ()
- │    │    │    │    │    └── fd: ()-->(27,30,31)
- │    │    │    │    └── projections
- │    │    │    │         └── 'TLS' [as="lookup_join_const_col_@46":54]
- │    │    │    └── filters
- │    │    │         └── cr_to_qty:49 >= 200 [outer=(49), constraints=(/49: [/200 - ]; tight)]
- │    │    ├── scan customer
- │    │    │    ├── columns: c_id:1!null c_tier:8!null
- │    │    │    ├── constraint: /1: [/0 - /0]
+ │    │    ├── scan security
+ │    │    │    ├── columns: s_symb:27!null s_name:30!null s_ex_id:31!null
+ │    │    │    ├── constraint: /27: [/'ROACH' - /'ROACH']
  │    │    │    ├── cardinality: [0 - 1]
  │    │    │    ├── key: ()
- │    │    │    └── fd: ()-->(1,8)
+ │    │    │    └── fd: ()-->(27,30,31)
+ │    │    ├── inner-join (lookup commission_rate)
+ │    │    │    ├── columns: c_id:1!null c_tier:8!null cr_c_tier:45!null cr_tt_id:46!null cr_ex_id:47!null cr_from_qty:48!null cr_to_qty:49!null commission_rate.cr_rate:50!null
+ │    │    │    ├── key columns: [8 56] = [45 46]
+ │    │    │    ├── key: (47,48)
+ │    │    │    ├── fd: ()-->(1,8,45,46), (47,48)-->(49,50), (8)==(45), (45)==(8)
+ │    │    │    ├── ordering: +47 opt(1,8,45,46) [actual: +47]
+ │    │    │    ├── project
+ │    │    │    │    ├── columns: "lookup_join_const_col_@46":56!null c_id:1!null c_tier:8!null
+ │    │    │    │    ├── cardinality: [0 - 1]
+ │    │    │    │    ├── key: ()
+ │    │    │    │    ├── fd: ()-->(1,8,56)
+ │    │    │    │    ├── scan customer
+ │    │    │    │    │    ├── columns: c_id:1!null c_tier:8!null
+ │    │    │    │    │    ├── constraint: /1: [/0 - /0]
+ │    │    │    │    │    ├── cardinality: [0 - 1]
+ │    │    │    │    │    ├── key: ()
+ │    │    │    │    │    └── fd: ()-->(1,8)
+ │    │    │    │    └── projections
+ │    │    │    │         └── 'TLS' [as="lookup_join_const_col_@46":56]
+ │    │    │    └── filters
+ │    │    │         ├── cr_from_qty:48 <= 100 [outer=(48), constraints=(/48: (/NULL - /100]; tight)]
+ │    │    │         └── cr_to_qty:49 >= 200 [outer=(49), constraints=(/49: [/200 - ]; tight)]
  │    │    └── filters (true)
  │    └── 1
  └── projections
@@ -4131,26 +4128,24 @@ project
  │    │    │    ├── cardinality: [0 - 1]
  │    │    │    ├── key: ()
  │    │    │    ├── fd: ()-->(1,8,27,30,31,54)
- │    │    │    ├── limit hint: 1.00
  │    │    │    ├── inner-join (cross)
  │    │    │    │    ├── columns: c_id:1!null c_tier:8!null s_symb:27!null s_name:30!null s_ex_id:31!null
  │    │    │    │    ├── cardinality: [0 - 1]
  │    │    │    │    ├── multiplicity: left-rows(zero-or-one), right-rows(zero-or-one)
  │    │    │    │    ├── key: ()
  │    │    │    │    ├── fd: ()-->(1,8,27,30,31)
- │    │    │    │    ├── limit hint: 1.00
- │    │    │    │    ├── scan customer
- │    │    │    │    │    ├── columns: c_id:1!null c_tier:8!null
- │    │    │    │    │    ├── constraint: /1: [/0 - /0]
- │    │    │    │    │    ├── cardinality: [0 - 1]
- │    │    │    │    │    ├── key: ()
- │    │    │    │    │    └── fd: ()-->(1,8)
  │    │    │    │    ├── scan security
  │    │    │    │    │    ├── columns: s_symb:27!null s_name:30!null s_ex_id:31!null
  │    │    │    │    │    ├── constraint: /27: [/'ROACH' - /'ROACH']
  │    │    │    │    │    ├── cardinality: [0 - 1]
  │    │    │    │    │    ├── key: ()
  │    │    │    │    │    └── fd: ()-->(27,30,31)
+ │    │    │    │    ├── scan customer
+ │    │    │    │    │    ├── columns: c_id:1!null c_tier:8!null
+ │    │    │    │    │    ├── constraint: /1: [/0 - /0]
+ │    │    │    │    │    ├── cardinality: [0 - 1]
+ │    │    │    │    │    ├── key: ()
+ │    │    │    │    │    └── fd: ()-->(1,8)
  │    │    │    │    └── filters (true)
  │    │    │    └── projections
  │    │    │         └── 'TLS' [as="lookup_join_const_col_@46":54]


### PR DESCRIPTION
This setting is enabled by default, so it should be enabled in optimizer
tests so that they are representative of a production environment.

Epic: None

Release note: None
