### PR TITLE
tenantcapabilitiesauthorizer: vmodule capability not found log

### DIFF
--- a/pkg/multitenant/tenantcapabilities/tenantcapabilitiesauthorizer/authorizer.go
+++ b/pkg/multitenant/tenantcapabilities/tenantcapabilitiesauthorizer/authorizer.go
@@ -58,10 +58,9 @@ func (a *Authorizer) HasCapabilityForBatch(
 	}
 	cp, found := a.capabilitiesReader.GetCapabilities(tenID)
 	if !found {
-		log.Infof(ctx,
+		log.VInfof(ctx, 2,
 			"no capability information for tenant %s; requests that require capabilities may be denied",
-			tenID,
-		)
+			tenID)
 	}
 
 	for _, ru := range ba.Requests {


### PR DESCRIPTION
This logline shows up a lot in unit tests that run inside a tenant. This change puts it behind vmodule=2.

Release note: None
Epic: none