### PR TITLE
changefeedccl: emit telemetry logs for retryable errors

### DIFF
--- a/pkg/ccl/changefeedccl/helpers_test.go
+++ b/pkg/ccl/changefeedccl/helpers_test.go
@@ -1137,6 +1137,24 @@ func checkCreateChangefeedLogs(t *testing.T, startTime int64) []eventpb.CreateCh
 	return matchingEntries
 }
 
+func checkChangefeedRetryableErrorLog(
+	t *testing.T, startTime int64,
+) []eventpb.ChangefeedRetryableError {
+	var matchingEntries []eventpb.ChangefeedRetryableError
+
+	logStrings := checkStructuredLogs(t, "changefeed_retryable_error", startTime)
+	for _, m := range logStrings {
+		jsonPayload := []byte(m)
+		var event eventpb.ChangefeedRetryableError
+		if err := gojson.Unmarshal(jsonPayload, &event); err != nil {
+			t.Errorf("unmarshalling %q: %v", m, err)
+		}
+		matchingEntries = append(matchingEntries, event)
+	}
+
+	return matchingEntries
+}
+
 func checkChangefeedFailedLogs(t *testing.T, startTime int64) []eventpb.ChangefeedFailed {
 	var matchingEntries []eventpb.ChangefeedFailed
 

--- a/pkg/util/log/eventpb/eventlog_channels_generated.go
+++ b/pkg/util/log/eventpb/eventlog_channels_generated.go
@@ -323,6 +323,9 @@ func (m *ChangefeedEmittedBytes) LoggingChannel() logpb.Channel { return logpb.C
 func (m *ChangefeedFailed) LoggingChannel() logpb.Channel { return logpb.Channel_TELEMETRY }
 
 // LoggingChannel implements the EventPayload interface.
+func (m *ChangefeedRetryableError) LoggingChannel() logpb.Channel { return logpb.Channel_TELEMETRY }
+
+// LoggingChannel implements the EventPayload interface.
 func (m *CreateChangefeed) LoggingChannel() logpb.Channel { return logpb.Channel_TELEMETRY }
 
 // LoggingChannel implements the EventPayload interface.

--- a/pkg/util/log/eventpb/json_encode_generated.go
+++ b/pkg/util/log/eventpb/json_encode_generated.go
@@ -1023,6 +1023,35 @@ func (m *ChangefeedFailed) AppendJSONFields(printComma bool, b redact.Redactable
 }
 
 // AppendJSONFields implements the EventPayload interface.
+func (m *ChangefeedRetryableError) AppendJSONFields(printComma bool, b redact.RedactableBytes) (bool, redact.RedactableBytes) {
+
+	printComma, b = m.CommonChangefeedEventDetails.AppendJSONFields(printComma, b)
+
+	if m.JobId != 0 {
+		if printComma {
+			b = append(b, ',')
+		}
+		printComma = true
+		b = append(b, "\"JobId\":"...)
+		b = strconv.AppendInt(b, int64(m.JobId), 10)
+	}
+
+	if m.Error != "" {
+		if printComma {
+			b = append(b, ',')
+		}
+		printComma = true
+		b = append(b, "\"Error\":\""...)
+		b = append(b, redact.StartMarker()...)
+		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(redact.EscapeMarkers([]byte(m.Error)))))
+		b = append(b, redact.EndMarker()...)
+		b = append(b, '"')
+	}
+
+	return printComma, b
+}
+
+// AppendJSONFields implements the EventPayload interface.
 func (m *ClientAuthenticationFailed) AppendJSONFields(printComma bool, b redact.RedactableBytes) (bool, redact.RedactableBytes) {
 
 	printComma, b = m.CommonEventDetails.AppendJSONFields(printComma, b)

--- a/pkg/util/log/eventpb/telemetry.proto
+++ b/pkg/util/log/eventpb/telemetry.proto
@@ -270,6 +270,17 @@ message ChangefeedEmittedBytes {
   bool closing = 5 [(gogoproto.jsontag) = ",omitempty", (gogoproto.moretags) = "redact:\"nonsensitive\""];
 }
 
+// ChangefeedEmittedBytes is an event representing the bytes emitted by a changefeed over an interval.
+message ChangefeedRetryableError {
+  CommonChangefeedEventDetails common = 1 [(gogoproto.nullable) = false, (gogoproto.jsontag) = "", (gogoproto.embed) = true];
+
+  // The job id for enterprise changefeeds.
+  int64 job_id = 2 [(gogoproto.jsontag) = ",omitempty", (gogoproto.moretags) =  "redact:\"nonsensitive\""];
+
+  // Error text.
+  string error = 3 [(gogoproto.jsontag) = ",omitempty"];
+}
+
 // RecoveryEvent is an event that is logged on every invocation of BACKUP,
 // RESTORE, and on every BACKUP schedule creation, with the appropriate subset
 // of fields populated depending on the type of event. This event is is also


### PR DESCRIPTION
With this change, we will emit retryable errors encountered by enterprise changefeeds to telemetry logging channels.

Closes: https://cockroachlabs.atlassian.net/browse/CRDB-22597
Epic: https://cockroachlabs.atlassian.net/browse/CRDB-13935

Release note: None