### PR TITLE
lint: skip TestLowercaseFunctionNames under --short

### DIFF
--- a/pkg/testutils/lint/lint_test.go
+++ b/pkg/testutils/lint/lint_test.go
@@ -127,6 +127,7 @@ func TestLint(t *testing.T) {
 	pkgVar, pkgSpecified := os.LookupEnv("PKG")
 
 	t.Run("TestLowercaseFunctionNames", func(t *testing.T) {
+		skip.UnderShort(t)
 		t.Parallel()
 		reSkipCasedFunction, err := regexp.Compile(`^(Binary file.*|[^:]+:\d+:(` +
 			`query error .*` + // OK when in logic tests


### PR DESCRIPTION
It takes ~350s on my M1, and is the lone straggler.

    $ dev lint --short
    ...
        --- PASS: TestLint/TestEnvutil (1.51s)
        --- PASS: TestLint/TestCopyrightHeaders (0.62s)
        --- PASS: TestLint/TestCrlfmt (8.05s)
        --- PASS: TestLint/TestGofmtSimplify (9.66s)
        --- PASS: TestLint/TestMissingLeakTest (5.48s)
        --- PASS: TestLint/TestLowercaseFunctionNames (357.81s)
    PASS

Release note: None