### PR TITLE
roachtest: Add tpcc test to match published numbers

### DIFF
--- a/pkg/workload/debug/tpcc_results.go
+++ b/pkg/workload/debug/tpcc_results.go
@@ -32,6 +32,7 @@ var tpccMergeResultsCmd = &cobra.Command{
 func init() {
 	flags := tpccMergeResultsCmd.Flags()
 	flags.Int("warehouses", 0, "number of aggregate warehouses in all of the histograms")
+	_ = tpccMergeResultsCmd.MarkFlagRequired("warehouses")
 }
 
 func tpccMergeResults(cmd *cobra.Command, args []string) error {

--- a/pkg/workload/tpcc/partition.go
+++ b/pkg/workload/tpcc/partition.go
@@ -392,22 +392,26 @@ func (p *partitioner) randActive(rng *rand.Rand) int {
 // default it adds constraints/preferences in terms of racks, but if the zones
 // flag is passed into tpcc, it will set the constraints/preferences based on
 // the geographic zones provided.
-func configureZone(db *gosql.DB, cfg zoneConfig, table, partition string, partIdx int) error {
-	var kv string
+func configureZone(db *gosql.DB, cfg zoneConfig, table, partition string, partIdx int, totalParts int) error {
+	var constraint string
+	var lease string
 	if len(cfg.zones) > 0 {
-		kv = fmt.Sprintf("zone=%s", cfg.zones[partIdx])
+		constraint = fmt.Sprintf("[+zone=%s]", cfg.zones[partIdx])
 	} else {
-		kv = fmt.Sprintf("rack=%d", partIdx)
+		// Note that this only specifies 3 replica locations. If the number of
+		// replicas is >3 this will only specify the location for 3 of them.
+		constraint = fmt.Sprintf(`{+rack=%d: 1, +rack=%d: 1, +rack=%d: 1}`, partIdx, (partIdx+totalParts/3)%totalParts, (partIdx+2*totalParts/3)%totalParts)
+		lease = fmt.Sprintf("[[+rack=%d]]", partIdx)
 	}
 
 	var opts string
 	switch cfg.strategy {
 	case partitionedReplication:
 		// Place all replicas in the zone.
-		opts = fmt.Sprintf(`constraints = '[+%s]'`, kv)
+		opts = fmt.Sprintf(`constraints = '%s'`, constraint)
 	case partitionedLeases:
 		// Place one replica in the zone and give that replica lease preference.
-		opts = fmt.Sprintf(`num_replicas = COPY FROM PARENT, constraints = '{"+%s":1}', lease_preferences = '[[+%s]]'`, kv, kv)
+		opts = fmt.Sprintf(`num_replicas = COPY FROM PARENT, constraints = '%s', lease_preferences = '%s'`, constraint, lease)
 	default:
 		panic("unexpected")
 	}
@@ -442,7 +446,7 @@ func partitionObject(
 	}
 
 	for i := 0; i < p.parts; i++ {
-		if err := configureZone(db, cfg, table, fmt.Sprintf("p%d_%d", idx, i), i); err != nil {
+		if err := configureZone(db, cfg, table, fmt.Sprintf("p%d_%d", idx, i), i, p.parts); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
We publish tpcc numbers here:
https://www.cockroachlabs.com/docs/stable/performance-benchmarking-with-tpcc-large.html

We didn't have an automated test to reproduce these results. This PR adds that test so that we can reproduce this on demand. It also adds the 15 node test to weekly so we can monitor this behavior over time.

Epic: none
Release note: None