### PR TITLE
sql_test: unskip TestShowTraceReplica

### DIFF
--- a/pkg/sql/show_trace_replica_test.go
+++ b/pkg/sql/show_trace_replica_test.go
@@ -21,7 +21,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/server"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
-	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
@@ -33,8 +32,6 @@ import (
 func TestShowTraceReplica(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-
-	skip.WithIssue(t, 34213)
 
 	const numNodes = 4
 


### PR DESCRIPTION
Testing TestShowTraceReplica under stress and race no longer fails, so this test is unskipped.

To test:
```
./dev test pkg/sql --filter TestShowTraceReplica --stress --race --test-args "TESTTIMEOUT=5m STRESSFLAGS='-maxtime 20m -timeout 10m'"
```

Fixes: #34213

Release note: None