### PR TITLE
kvserver: eagerly renew leases 

### DIFF
--- a/pkg/kv/kvserver/client_lease_test.go
+++ b/pkg/kv/kvserver/client_lease_test.go
@@ -1466,11 +1466,7 @@ func TestLeaseTransfersUseExpirationLeasesAndBumpToEpochBasedOnes(t *testing.T) 
 					WallClock: manualClock,
 				},
 				Store: &kvserver.StoreTestingKnobs{
-					// Outlandishly high to disable proactive renewal of
-					// expiration based leases. Lease upgrades happen
-					// immediately after applying without needing active
-					// renewal.
-					LeaseRenewalDurationOverride: 100 * time.Hour,
+					DisableAutomaticLeaseRenewal: true,
 					LeaseUpgradeInterceptor: func(lease *roachpb.Lease) {
 						mu.Lock()
 						defer mu.Unlock()

--- a/pkg/kv/kvserver/kvserverbase/forced_error.go
+++ b/pkg/kv/kvserver/kvserverbase/forced_error.go
@@ -95,11 +95,11 @@ func CheckForcedErr(
 		requestedLease = *raftCmd.ReplicatedEvalResult.State.Lease
 	}
 	if idKey == "" {
-		// This is an empty Raft command (which is sent by Raft after elections
-		// to trigger reproposals or during concurrent configuration changes).
-		// Nothing to do here except making sure that the corresponding batch
-		// (which is bogus) doesn't get executed (for it is empty and so
-		// properties like key range are undefined).
+		// This is an empty Raft command (which is sent by Raft after elections to
+		// trigger reproposals, during concurrent configuration changes, or to
+		// unquiesce the Raft group). Nothing to do here except making sure that the
+		// corresponding batch (which is bogus) doesn't get executed (for it is
+		// empty and so properties like key range are undefined).
 		return ForcedErrResult{
 			LeaseIndex:  leaseIndex,
 			Rejection:   ProposalRejectionPermanent,

--- a/pkg/kv/kvserver/metrics.go
+++ b/pkg/kv/kvserver/metrics.go
@@ -127,6 +127,12 @@ var (
 		Measurement: "Lease Requests",
 		Unit:        metric.Unit_COUNT,
 	}
+	metaLeaseRequestLatency = metric.Metadata{
+		Name:        "leases.requests.latency",
+		Help:        "Lease request latency (all kinds and outcomes, coalesced)",
+		Measurement: "Latency",
+		Unit:        metric.Unit_NANOSECONDS,
+	}
 	metaLeaseTransferSuccessCount = metric.Metadata{
 		Name:        "leases.transfers.success",
 		Help:        "Number of successful lease transfers",
@@ -1797,6 +1803,7 @@ type StoreMetrics struct {
 	// lease).
 	LeaseRequestSuccessCount  *metric.Counter
 	LeaseRequestErrorCount    *metric.Counter
+	LeaseRequestLatency       metric.IHistogram
 	LeaseTransferSuccessCount *metric.Counter
 	LeaseTransferErrorCount   *metric.Counter
 	LeaseExpirationCount      *metric.Gauge
@@ -2355,8 +2362,14 @@ func newStoreMetrics(histogramWindow time.Duration) *StoreMetrics {
 		OverReplicatedRangeCount:  metric.NewGauge(metaOverReplicatedRangeCount),
 
 		// Lease request metrics.
-		LeaseRequestSuccessCount:  metric.NewCounter(metaLeaseRequestSuccessCount),
-		LeaseRequestErrorCount:    metric.NewCounter(metaLeaseRequestErrorCount),
+		LeaseRequestSuccessCount: metric.NewCounter(metaLeaseRequestSuccessCount),
+		LeaseRequestErrorCount:   metric.NewCounter(metaLeaseRequestErrorCount),
+		LeaseRequestLatency: metric.NewHistogram(metric.HistogramOptions{
+			Mode:     metric.HistogramModePreferHdrLatency,
+			Metadata: metaLeaseRequestLatency,
+			Duration: histogramWindow,
+			Buckets:  metric.NetworkLatencyBuckets,
+		}),
 		LeaseTransferSuccessCount: metric.NewCounter(metaLeaseTransferSuccessCount),
 		LeaseTransferErrorCount:   metric.NewCounter(metaLeaseTransferErrorCount),
 		LeaseExpirationCount:      metric.NewGauge(metaLeaseExpirationCount),

--- a/pkg/kv/kvserver/replica.go
+++ b/pkg/kv/kvserver/replica.go
@@ -1591,13 +1591,8 @@ func (r *Replica) checkExecutionCanProceedBeforeStorageSnapshot(
 		return kvserverpb.LeaseStatus{}, err
 	}
 
-	var shouldExtend bool
-	postRUnlock := func() {}
 	r.mu.RLock()
-	defer func() {
-		r.mu.RUnlock()
-		postRUnlock()
-	}()
+	defer r.mu.RUnlock()
 
 	// Has the replica been initialized?
 	// NB: this should have already been checked in Store.Send, so we don't need
@@ -1622,7 +1617,7 @@ func (r *Replica) checkExecutionCanProceedBeforeStorageSnapshot(
 		return kvserverpb.LeaseStatus{}, err
 	}
 
-	st, shouldExtend, err := r.checkLeaseRLocked(ctx, ba)
+	st, err := r.checkLeaseRLocked(ctx, ba)
 	if err != nil {
 		return kvserverpb.LeaseStatus{}, err
 	}
@@ -1646,13 +1641,6 @@ func (r *Replica) checkExecutionCanProceedBeforeStorageSnapshot(
 		}
 	}
 
-	if shouldExtend {
-		// If we're asked to extend the lease, trigger (async) lease renewal.
-		// Kicking this off requires an exclusive lock, and we hold a read-only lock
-		// already, so we jump through a hoop to run it in a suitably positioned
-		// defer.
-		postRUnlock = func() { r.maybeExtendLeaseAsync(ctx, st) }
-	}
 	return st, nil
 }
 
@@ -1716,12 +1704,10 @@ func (r *Replica) checkExecutionCanProceedRWOrAdmin(
 // checkLeaseRLocked checks the provided batch against the GC
 // threshold and lease. A nil error indicates to go ahead with the batch, and
 // is accompanied either by a valid or zero lease status, the latter case
-// indicating that the request was permitted to bypass the lease check. The
-// returned bool indicates whether the lease should be extended (only on nil
-// error).
+// indicating that the request was permitted to bypass the lease check.
 func (r *Replica) checkLeaseRLocked(
 	ctx context.Context, ba *kvpb.BatchRequest,
-) (kvserverpb.LeaseStatus, bool, error) {
+) (kvserverpb.LeaseStatus, error) {
 	now := r.Clock().NowAsClockTimestamp()
 	// If the request is a write or a consistent read, it requires the
 	// replica serving it to hold the range lease. We pass the write
@@ -1733,7 +1719,6 @@ func (r *Replica) checkLeaseRLocked(
 	reqTS := ba.WriteTimestamp()
 	st := r.leaseStatusForRequestRLocked(ctx, now, reqTS)
 
-	var shouldExtend bool
 	// Write commands that skip the lease check in practice are exactly
 	// RequestLease and TransferLease. Both use the provided previous lease for
 	// verification below raft. We return a zero lease status from this method and
@@ -1744,14 +1729,13 @@ func (r *Replica) checkLeaseRLocked(
 	// doesn't check the lease.
 	if !ba.IsSingleSkipsLeaseCheckRequest() && ba.ReadConsistency != kvpb.INCONSISTENT {
 		// Check the lease.
-		var err error
-		shouldExtend, err = r.leaseGoodToGoForStatusRLocked(ctx, now, reqTS, st)
+		err := r.leaseGoodToGoForStatusRLocked(ctx, now, reqTS, st)
 		if err != nil {
 			// No valid lease, but if we can serve this request via follower reads,
 			// we may continue.
 			if !r.canServeFollowerReadRLocked(ctx, ba) {
 				// If not, return the error.
-				return kvserverpb.LeaseStatus{}, false, err
+				return kvserverpb.LeaseStatus{}, err
 			}
 			// Otherwise, suppress the error. Also, remember that we're not serving
 			// this under the lease by zeroing out the status. We also intentionally
@@ -1759,11 +1743,11 @@ func (r *Replica) checkLeaseRLocked(
 			// this method assumes that a valid status indicates that this replica
 			// holds the lease (see #73123). `shouldExtend` is already false in this
 			// branch, but for completeness we zero it out as well.
-			st, shouldExtend, err = kvserverpb.LeaseStatus{}, false, nil
+			st, err = kvserverpb.LeaseStatus{}, nil
 		}
 	}
 
-	return st, shouldExtend, nil
+	return st, nil
 }
 
 // checkExecutionCanProceedForRangeFeed returns an error if a rangefeed request

--- a/pkg/kv/kvserver/replica_lease_renewal_test.go
+++ b/pkg/kv/kvserver/replica_lease_renewal_test.go
@@ -8,7 +8,7 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
-package kvserver_test
+package kvserver
 
 import (
 	"context"
@@ -17,36 +17,149 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
-	"github.com/cockroachdb/cockroach/pkg/kv/kvserver"
+	"github.com/cockroachdb/cockroach/pkg/keys"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
-	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
+	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/require"
 )
 
+// TestLeaseRenewer tests that the store lease renewer correctly tracks and
+// extends expiration-based leases.
+func TestLeaseRenewer(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	// Too slow.
+	skip.UnderRace(t)
+	skip.UnderDeadlock(t)
+
+	ctx := context.Background()
+
+	tc := serverutils.StartNewTestCluster(t, 3, base.TestClusterArgs{
+		ServerArgs: base.TestServerArgs{
+			RaftConfig: base.RaftConfig{
+				RangeLeaseDuration: time.Second,
+			},
+		},
+	})
+	defer tc.Stopper().Stop(ctx)
+
+	require.NoError(t, tc.WaitForFullReplication())
+
+	lookupNode := func(nodeID roachpb.NodeID) int {
+		for idx, id := range tc.NodeIDs() {
+			if id == nodeID {
+				return idx
+			}
+		}
+		t.Fatalf("couldn't look up node %d", nodeID)
+		return 0
+	}
+
+	getNodeStore := func(nodeID roachpb.NodeID) *Store {
+		srv := tc.Server(lookupNode(nodeID))
+		s, err := srv.GetStores().(*Stores).GetStore(srv.GetFirstStoreID())
+		require.NoError(t, err)
+		return s
+	}
+
+	getNodeReplica := func(nodeID roachpb.NodeID, rangeID roachpb.RangeID) *Replica {
+		repl, err := getNodeStore(nodeID).GetReplica(rangeID)
+		require.NoError(t, err)
+		return repl
+	}
+
+	getLeaseRenewers := func(rangeID roachpb.RangeID) []roachpb.NodeID {
+		var renewers []roachpb.NodeID
+		for _, nodeID := range tc.NodeIDs() {
+			if _, ok := getNodeStore(nodeID).renewableLeases.Load(int64(rangeID)); ok {
+				renewers = append(renewers, nodeID)
+			}
+		}
+		return renewers
+	}
+
+	// assertLeaseRenewal asserts that the given range has an expiration-based
+	// lease, that it's eagerly extended, and only actively renewed by the
+	// leaseholder.
+	assertLeaseRenewal := func(rangeID roachpb.RangeID) {
+		repl := getNodeReplica(1, rangeID)
+		lease, _ := repl.GetLease()
+		require.Equal(t, roachpb.LeaseExpiration, lease.Type())
+
+		var extensions int
+		require.Eventually(t, func() bool {
+			newLease, _ := repl.GetLease()
+			require.Equal(t, roachpb.LeaseExpiration, newLease.Type())
+			if *newLease.Expiration != *lease.Expiration {
+				extensions++
+				lease = newLease
+				t.Logf("r%d lease extended: %v", rangeID, lease)
+			}
+
+			renewers := getLeaseRenewers(repl.RangeID)
+			renewedByLeaseholder := len(renewers) == 1 && renewers[0] == lease.Replica.NodeID
+			if !renewedByLeaseholder {
+				t.Logf("r%d renewers: %v", rangeID, renewers)
+			}
+
+			return extensions >= 3 && renewedByLeaseholder
+		}, 20*time.Second, 100*time.Millisecond)
+	}
+
+	// The meta range should always be eagerly renewed.
+	assertLeaseRenewal(tc.LookupRangeOrFatal(t, keys.MinKey).RangeID)
+
+	// Split off an expiration-based range, and assert that the lease is extended.
+	desc := tc.LookupRangeOrFatal(t, tc.ScratchRangeWithExpirationLease(t))
+	assertLeaseRenewal(desc.RangeID)
+
+	// Transfer the lease to a different leaseholder, and assert that the lease is
+	// still extended.
+	lease, _ := getNodeReplica(1, desc.RangeID).GetLease()
+	target := tc.Target(lookupNode(lease.Replica.NodeID%3 + 1))
+	tc.TransferRangeLeaseOrFatal(t, desc, target)
+	assertLeaseRenewal(desc.RangeID)
+
+	// Merge the range back. This should unregister it from the lease renewer.
+	require.NoError(t, tc.Server(0).DB().AdminMerge(ctx, desc.StartKey.AsRawKey().Prevish(16)))
+	require.Eventually(t, func() bool {
+		if renewers := getLeaseRenewers(desc.RangeID); len(renewers) > 0 {
+			t.Logf("r%d renewers: %v", desc.RangeID, renewers)
+			return false
+		}
+		return true
+	}, 20*time.Second, 100*time.Millisecond)
+}
+
 func setupLeaseRenewerTest(
 	ctx context.Context, t *testing.T, init func(*base.TestClusterArgs),
 ) (
 	cycles *int32, /* atomic */
-	_ *testcluster.TestCluster,
+	_ serverutils.TestClusterInterface,
 ) {
 	cycles = new(int32)
 	var args base.TestClusterArgs
-	args.ServerArgs.Knobs.Store = &kvserver.StoreTestingKnobs{
+	args.ServerArgs.Knobs.Store = &StoreTestingKnobs{
 		LeaseRenewalOnPostCycle: func() {
 			atomic.AddInt32(cycles, 1)
 		},
 	}
 	init(&args)
-	tc := testcluster.StartTestCluster(t, 1, args)
+	tc := serverutils.StartNewTestCluster(t, 1, args)
 	t.Cleanup(func() { tc.Stopper().Stop(ctx) })
 
 	desc := tc.LookupRangeOrFatal(t, tc.ScratchRangeWithExpirationLease(t))
-	s := tc.GetFirstStoreFromServer(t, 0)
+	srv := tc.Server(0)
+	s, err := srv.GetStores().(*Stores).GetStore(srv.GetFirstStoreID())
+	require.NoError(t, err)
 
-	_, err := s.DB().Get(ctx, desc.StartKey)
+	_, err = s.DB().Get(ctx, desc.StartKey)
 	require.NoError(t, err)
 
 	repl, err := s.GetReplica(desc.RangeID)
@@ -67,7 +180,7 @@ func TestLeaseRenewerExtendsExpirationBasedLeases(t *testing.T) {
 	t.Run("triggered", func(t *testing.T) {
 		renewCh := make(chan struct{})
 		cycles, tc := setupLeaseRenewerTest(ctx, t, func(args *base.TestClusterArgs) {
-			args.ServerArgs.Knobs.Store.(*kvserver.StoreTestingKnobs).LeaseRenewalSignalChan = renewCh
+			args.ServerArgs.Knobs.Store.(*StoreTestingKnobs).LeaseRenewalSignalChan = renewCh
 		})
 		defer tc.Stopper().Stop(ctx)
 
@@ -93,7 +206,7 @@ func TestLeaseRenewerExtendsExpirationBasedLeases(t *testing.T) {
 
 	t.Run("periodic", func(t *testing.T) {
 		cycles, tc := setupLeaseRenewerTest(ctx, t, func(args *base.TestClusterArgs) {
-			args.ServerArgs.Knobs.Store.(*kvserver.StoreTestingKnobs).LeaseRenewalDurationOverride = 10 * time.Millisecond
+			args.ServerArgs.Knobs.Store.(*StoreTestingKnobs).LeaseRenewalDurationOverride = 10 * time.Millisecond
 		})
 		defer tc.Stopper().Stop(ctx)
 

--- a/pkg/kv/kvserver/replica_proposal.go
+++ b/pkg/kv/kvserver/replica_proposal.go
@@ -232,6 +232,11 @@ func (r *Replica) leasePostApplyLocked(
 	// Everything we do before then doesn't need to worry about requests being
 	// evaluated under the new lease.
 
+	// maybeSplit is true if we may have been called during leasePostApply,
+	// where prevLease is the same as newLease and we want to register the
+	// RHS leaseholder.
+	var maybeSplit bool
+
 	// Sanity check to make sure that the lease sequence is moving in the right
 	// direction.
 	if s1, s2 := prevLease.Sequence, newLease.Sequence; s1 != 0 {
@@ -249,6 +254,8 @@ func (r *Replica) leasePostApplyLocked(
 				log.Fatalf(ctx, "sequence identical for different leases, prevLease=%s, newLease=%s",
 					redact.Safe(prevLease), redact.Safe(newLease))
 			}
+			maybeSplit = prevLease.Epoch == newLease.Epoch &&
+				prevLease.GetExpiration() == newLease.GetExpiration()
 		case s2 == s1+1:
 			// Lease sequence incremented by 1. Expected case.
 		case s2 > s1+1 && jumpOpt == assertNoLeaseJump:
@@ -367,8 +374,8 @@ func (r *Replica) leasePostApplyLocked(
 		r.gossipFirstRangeLocked(ctx)
 	}
 
-	hasExpirationLease := newLease.Type() == roachpb.LeaseExpiration
-	if leaseChangingHands && iAmTheLeaseHolder && hasExpirationLease && r.ownsValidLeaseRLocked(ctx, now) {
+	if newLease.Type() == roachpb.LeaseExpiration && (leaseChangingHands || maybeSplit) &&
+		iAmTheLeaseHolder && r.ownsValidLeaseRLocked(ctx, now) {
 		if r.requiresExpirationLeaseRLocked() {
 			// Whenever we first acquire an expiration-based lease for a range that
 			// requires it (i.e. the liveness or meta ranges), notify the lease

--- a/pkg/kv/kvserver/replica_raft_quiesce.go
+++ b/pkg/kv/kvserver/replica_raft_quiesce.go
@@ -16,7 +16,6 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverpb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/liveness/livenesspb"
-	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/raftlog"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -88,8 +87,7 @@ func (r *Replica) maybeUnquiesceAndWakeLeaderLocked() bool {
 	r.store.unquiescedReplicas.Unlock()
 	r.maybeCampaignOnWakeLocked(ctx)
 	// Propose an empty command which will wake the leader.
-	data := raftlog.EncodeRaftCommand(raftlog.EntryEncodingStandardWithoutAC, makeIDKey(), nil)
-	_ = r.mu.internalRaftGroup.Propose(data)
+	_ = r.mu.internalRaftGroup.Propose(nil)
 	return true
 }
 

--- a/pkg/kv/kvserver/replica_range_lease.go
+++ b/pkg/kv/kvserver/replica_range_lease.go
@@ -429,6 +429,11 @@ func (p *pendingLeaseRequest) requestLease(
 	status kvserverpb.LeaseStatus,
 	leaseReq kvpb.Request,
 ) error {
+	started := timeutil.Now()
+	defer func() {
+		p.repl.store.metrics.LeaseRequestLatency.RecordValue(timeutil.Since(started).Nanoseconds())
+	}()
+
 	// If requesting an epoch-based lease & current state is expired,
 	// potentially heartbeat our own liveness or increment epoch of
 	// prior owner. Note we only do this if the previous lease was

--- a/pkg/kv/kvserver/replicate_queue.go
+++ b/pkg/kv/kvserver/replicate_queue.go
@@ -689,14 +689,11 @@ func (rq *replicateQueue) shouldQueue(
 	}
 
 	leaseStatus := repl.LeaseStatusAt(ctx, now)
-	if !leaseStatus.IsValid() && leaseStatus.Lease.Type() != roachpb.LeaseExpiration {
-		// The epoch lease for this range is currently invalid. If this replica is
-		// the raft leader then we'd like it to hold a valid lease. We enqueue it
-		// regardless of being a leader or follower, where the leader at the time of
-		// processing will succeed.
-		//
-		// We don't do this for expiration leases, because we'd like them to expire
-		// if the range is idle.
+	if !leaseStatus.IsValid() {
+		// The range has an invalid lease. If this replica is the raft leader then
+		// we'd like it to hold a valid lease. We enqueue it regardless of being a
+		// leader or follower, where the leader at the time of processing will
+		// succeed.
 		log.KvDistribution.VEventf(ctx, 2, "invalid lease, enqueuing")
 		return true, 0
 	}

--- a/pkg/kv/kvserver/store_remove_replica.go
+++ b/pkg/kv/kvserver/store_remove_replica.go
@@ -303,6 +303,7 @@ func (s *Store) unlinkReplicaByRangeIDLocked(ctx context.Context, rangeID roachp
 	s.mu.replicasByRangeID.Delete(rangeID)
 	s.unregisterLeaseholderByID(ctx, rangeID)
 	s.raftRecvQueues.Delete(rangeID)
+	s.renewableLeases.Delete(int64(rangeID))
 }
 
 // removePlaceholder removes a placeholder for the specified range.

--- a/pkg/kv/kvserver/testing_knobs.go
+++ b/pkg/kv/kvserver/testing_knobs.go
@@ -389,14 +389,6 @@ type StoreTestingKnobs struct {
 	// acquire any locks in this method.
 	OnRaftTimeoutCampaign func(roachpb.RangeID)
 
-	// LeaseRenewalSignalChan populates `Store.renewableLeasesSignal`.
-	LeaseRenewalSignalChan chan struct{}
-	// LeaseRenewalOnPostCycle is invoked after each lease renewal cycle.
-	LeaseRenewalOnPostCycle func()
-	// LeaseRenewalDurationOverride replaces the timer duration for proactively
-	// renewing expiration based leases.
-	LeaseRenewalDurationOverride time.Duration
-
 	// RangefeedValueHeaderFilter, if set, is invoked before each value emitted on
 	// the rangefeed, be it in steady state or during the catch-up scan.
 	//

--- a/pkg/testutils/serverutils/test_cluster_shim.go
+++ b/pkg/testutils/serverutils/test_cluster_shim.go
@@ -209,6 +209,10 @@ type TestClusterInterface interface {
 	// range is lazily split off on the first call to ScratchRange.
 	ScratchRange(t testing.TB) roachpb.Key
 
+	// ScratchRangeWithExpirationLease is like ScratchRange, but returns a system
+	// range with an expiration lease.
+	ScratchRangeWithExpirationLease(t testing.TB) roachpb.Key
+
 	// WaitForFullReplication waits until all stores in the cluster
 	// have no ranges with replication pending.
 	WaitForFullReplication() error


### PR DESCRIPTION
Proof of concept. Easily maintains 5000 expiration leases with very little CPU overhead.

Touches #98433.