### PR TITLE
jobs: avoid race conditions in tests

### DIFF
--- a/pkg/jobs/adopt.go
+++ b/pkg/jobs/adopt.go
@@ -319,7 +319,7 @@ func (r *Registry) resumeJob(
 
 	// If the job's type was registered to disable tenant cost control, then
 	// exclude the job's costs from tenant accounting.
-	if opts, ok := options[payload.Type()]; ok && opts.disableTenantCostControl {
+	if opts, ok := getRegisterOptions(payload.Type()); ok && opts.disableTenantCostControl {
 		resumeCtx = multitenant.WithTenantCostControlExemption(resumeCtx)
 	}
 	if alreadyAdopted := r.addAdoptedJob(jobID, s, cancel); alreadyAdopted {

--- a/pkg/jobs/helpers.go
+++ b/pkg/jobs/helpers.go
@@ -14,9 +14,15 @@ import "github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
 
 // ResetConstructors resets the registered Resumer constructors.
 func ResetConstructors() func() {
+	globalMu.Lock()
+	defer globalMu.Unlock()
 	old := make(map[jobspb.Type]Constructor)
-	for k, v := range constructors {
+	for k, v := range globalMu.constructors {
 		old[k] = v
 	}
-	return func() { constructors = old }
+	return func() {
+		globalMu.Lock()
+		defer globalMu.Unlock()
+		globalMu.constructors = old
+	}
 }

--- a/pkg/jobs/metrics.go
+++ b/pkg/jobs/metrics.go
@@ -282,7 +282,7 @@ func (m *Metrics) init(histogramWindowInterval time.Duration) {
 			ExpiredPTS:             metric.NewCounter(makeMetaExpiredPTS(typeStr)),
 			ProtectedAge:           metric.NewGauge(makeMetaProtectedAge(typeStr)),
 		}
-		if opts, ok := options[jt]; ok && opts.metrics != nil {
+		if opts, ok := getRegisterOptions(jt); ok && opts.metrics != nil {
 			m.JobSpecificMetrics[jt] = opts.metrics
 		}
 	}


### PR DESCRIPTION
Needed for #98440.
Epic: CRDB-23559

When investigating jobs created during cluster migrations I found that the unit tests in the jobs packages have a race condition with the registry, because they register new job types (adding new constructors) concurrently with job adoption occurring during startup (using constructors).

This patch fixes it.

Release note: None