### PR TITLE
release-22.2: ccl/sqlproxyccl: do not classify TCP probes as a connection error

### DIFF
--- a/pkg/ccl/sqlproxyccl/frontend_admitter_test.go
+++ b/pkg/ccl/sqlproxyccl/frontend_admitter_test.go
@@ -35,6 +35,22 @@ func tlsConfig() (*tls.Config, error) {
 	}, nil
 }
 
+func TestFrontendAdmitWithNoBytes(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	cli, srv := net.Pipe()
+	require.NoError(t, srv.SetReadDeadline(timeutil.Now().Add(3e9)))
+	require.NoError(t, cli.SetReadDeadline(timeutil.Now().Add(3e9)))
+
+	// Close the connection to simulate no bytes.
+	cli.Close()
+
+	fe := FrontendAdmit(srv, nil)
+	require.EqualError(t, fe.Err, noStartupMessage.Error())
+	require.NotNil(t, fe.Conn)
+	require.Nil(t, fe.Msg)
+}
+
 func TestFrontendAdmitWithClientSSLDisableAndCustomParam(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 

--- a/pkg/ccl/sqlproxyccl/metrics.go
+++ b/pkg/ccl/sqlproxyccl/metrics.go
@@ -21,6 +21,7 @@ type metrics struct {
 	ClientDisconnectCount  *metric.Counter
 	CurConnCount           *metric.Gauge
 	RoutingErrCount        *metric.Counter
+	AcceptedConnCount      *metric.Counter
 	RefusedConnCount       *metric.Counter
 	SuccessfulConnCount    *metric.Counter
 	ConnectionLatency      metric.IHistogram
@@ -100,6 +101,12 @@ var (
 		Name:        "proxy.err.client_disconnect",
 		Help:        "Number of disconnects initiated by clients",
 		Measurement: "Client Disconnects",
+		Unit:        metric.Unit_COUNT,
+	}
+	metaAcceptedConnCount = metric.Metadata{
+		Name:        "proxy.sql.accepted_conns",
+		Help:        "Number of accepted connections",
+		Measurement: "Accepted connections",
 		Unit:        metric.Unit_COUNT,
 	}
 	metaRefusedConnCount = metric.Metadata{
@@ -221,6 +228,7 @@ func makeProxyMetrics() metrics {
 		ClientDisconnectCount:  metric.NewCounter(metaClientDisconnectCount),
 		CurConnCount:           metric.NewGauge(metaCurConnCount),
 		RoutingErrCount:        metric.NewCounter(metaRoutingErrCount),
+		AcceptedConnCount:      metric.NewCounter(metaAcceptedConnCount),
 		RefusedConnCount:       metric.NewCounter(metaRefusedConnCount),
 		SuccessfulConnCount:    metric.NewCounter(metaSuccessfulConnCount),
 		ConnectionLatency: metric.NewHistogram(metric.HistogramOptions{

--- a/pkg/ccl/sqlproxyccl/proxy_handler_test.go
+++ b/pkg/ccl/sqlproxyccl/proxy_handler_test.go
@@ -1782,6 +1782,91 @@ func TestConnectionMigration(t *testing.T) {
 	}, 10*time.Second, 100*time.Millisecond)
 }
 
+// Ensures that the metric is incremented regardless of connection type
+// (both failed and successful ones).
+func TestAcceptedConnCountMetric(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+
+	// Start KV server.
+	params, _ := tests.CreateTestServerParams()
+	s, _, _ := serverutils.StartServer(t, params)
+	defer s.Stopper().Stop(ctx)
+
+	// Start a single SQL pod.
+	tenantID := serverutils.TestTenantID()
+	tenants := startTestTenantPods(ctx, t, s, tenantID, 1, base.TestingKnobs{})
+
+	// Register the SQL pod in the directory server.
+	tds := tenantdirsvr.NewTestStaticDirectoryServer(s.Stopper(), nil /* timeSource */)
+	tds.CreateTenant(tenantID, "tenant-cluster")
+	tds.AddPod(tenantID, &tenant.Pod{
+		TenantID:       tenantID.ToUint64(),
+		Addr:           tenants[0].SQLAddr(),
+		State:          tenant.RUNNING,
+		StateTimestamp: timeutil.Now(),
+	})
+	require.NoError(t, tds.Start(ctx))
+
+	opts := &ProxyOptions{SkipVerify: true, DisableConnectionRebalancing: true}
+	opts.testingKnobs.directoryServer = tds
+	proxy, addr, _ := newSecureProxyServer(ctx, t, s.Stopper(), opts)
+
+	goodConnStr := fmt.Sprintf("postgres://testuser:hunter2@%s/?sslmode=require&options=--cluster=tenant-cluster-%s", addr, tenantID)
+	badConnStr := fmt.Sprintf("postgres://testuser:hunter2@%s/?sslmode=require&options=nocluster", addr)
+
+	const (
+		numGood = 5
+		numBad  = 6
+		numTCP  = 7
+	)
+	numConns := numGood + numBad + numTCP
+	var wg sync.WaitGroup
+	wg.Add(numConns)
+
+	makeConn := func(connStr string) {
+		defer wg.Done()
+
+		// Opens a new connection, runs SELECT 1, and closes it right away.
+		// Ignore all connection errors.
+		conn, err := pgx.Connect(ctx, connStr)
+		if err != nil {
+			return
+		}
+		_ = conn.Ping(ctx)
+		_ = conn.Close(ctx)
+	}
+
+	for i := 0; i < numGood; i++ {
+		go makeConn(goodConnStr)
+	}
+	for i := 0; i < numBad; i++ {
+		go makeConn(badConnStr)
+	}
+	var dialErr int64
+	for i := 0; i < numTCP; i++ {
+		go func() {
+			defer wg.Done()
+
+			conn, err := net.DialTimeout("tcp", addr, 3*time.Second)
+			defer func() {
+				if conn != nil {
+					_ = conn.Close()
+				}
+			}()
+			if err != nil {
+				atomic.AddInt64(&dialErr, 1)
+			}
+		}()
+	}
+	wg.Wait()
+
+	require.Equal(t, int64(0), atomic.LoadInt64(&dialErr))
+	require.Equal(t, int64(numConns), proxy.metrics.AcceptedConnCount.Count())
+}
+
 // TestCurConnCountMetric ensures that the CurConnCount metric is accurate.
 // Previously, there was a regression where the CurConnCount metric wasn't
 // decremented whenever the connections were closed due to a goroutine leak.

--- a/pkg/ccl/sqlproxyccl/proxy_handler_test.go
+++ b/pkg/ccl/sqlproxyccl/proxy_handler_test.go
@@ -655,6 +655,26 @@ func TestProxyRefuseConn(t *testing.T) {
 	require.Equal(t, int64(0), s.metrics.AuthFailedCount.Count())
 }
 
+func TestProxyHandler_handle(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+	te := newTester()
+	defer te.Close()
+
+	stopper := stop.NewStopper()
+	defer stopper.Stop(ctx)
+	proxy, _, _ := newSecureProxyServer(ctx, t, stopper, &ProxyOptions{})
+
+	p1, p2 := net.Pipe()
+	require.NoError(t, p1.Close())
+
+	// Check that handle does not return any error if the incoming connection
+	// has no data packets.
+	require.Nil(t, proxy.handler.handle(ctx, p2))
+}
+
 func TestDenylistUpdate(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)

--- a/pkg/ccl/sqlproxyccl/server.go
+++ b/pkg/ccl/sqlproxyccl/server.go
@@ -213,6 +213,7 @@ func (s *Server) Serve(ctx context.Context, ln net.Listener) error {
 		if err != nil {
 			return err
 		}
+		s.metrics.AcceptedConnCount.Inc(1)
 
 		err = s.Stopper.RunAsyncTask(ctx, "proxy-con-serve", func(ctx context.Context) {
 			defer func() { _ = conn.Close() }()

--- a/pkg/ccl/sqlproxyccl/server_test.go
+++ b/pkg/ccl/sqlproxyccl/server_test.go
@@ -79,18 +79,18 @@ func TestAwaitNoConnections(t *testing.T) {
 	proxyServer, err := NewServer(ctx, stopper, ProxyOptions{})
 	require.NoError(t, err)
 
-	//simulate a connection coming in
+	// Simulate a connection coming in.
 	proxyServer.metrics.CurConnCount.Inc(1)
 	begin := timeutil.Now()
 
-	// wait a few milliseconds and simulate the connection dropping
+	// Wait a few milliseconds and simulate the connection dropping.
 	waitTime := time.Millisecond * 150
 	_ = stopper.RunAsyncTask(ctx, "decrement-con-count", func(context.Context) {
 		<-time.After(waitTime)
 		proxyServer.metrics.CurConnCount.Dec(1)
 	})
-	// wait for there to be no connections
+	// Wait for there to be no connections.
 	<-proxyServer.AwaitNoConnections(ctx)
-	// make sure we waited for the connection to be dropped
+	// Make sure we waited for the connection to be dropped.
 	require.GreaterOrEqual(t, timeutil.Since(begin), waitTime)
 }


### PR DESCRIPTION
Backport 2/2 commits from #98279.

/cc @cockroachdb/release

---

#### ccl/sqlproxyccl: do not classify TCP probes as a connection error 

Previously, if a client attempted to open a TCP connection without any packets
sent, the proxy will log an error (i.e. while receiving startup message), and
close the connection. This scenario is common with TCP probes, and this is
what cloud load balancers generally do. To avoid these probes spamming the
proxy logs, we will silently ignore these class of errors, and this commit
does that.
  
#### ccl/sqlproxyccl: add proxy.sql.accepted_conns metric to the proxy 

This commit adds a new proxy.sql.accepted_conns metric to indicate the number
of accepted connections by the proxy. The previous commit removed logging
messages for connections that do not have any data packets. This new metric
would aid in debugging (e.g. high cpu usage).

Release note: None

Epic: none

Release justification: SQL proxy logging change. This would allow us to migrate to IP-based NLBs in CC earlier without enforcing v23.1+ on new host cluster creations.
