### PR TITLE
sql: add closest-instance physical planning

### DIFF
--- a/pkg/roachpb/metadata.go
+++ b/pkg/roachpb/metadata.go
@@ -612,6 +612,17 @@ func (l Locality) Matches(filter Locality) (bool, Tier) {
 	return true, Tier{}
 }
 
+// SharedPrefix returns the number of this locality's tiers which match those of
+// the passed locality.
+func (l Locality) SharedPrefix(other Locality) int {
+	for i := range l.Tiers {
+		if i >= len(other.Tiers) || l.Tiers[i] != other.Tiers[i] {
+			return i
+		}
+	}
+	return len(l.Tiers)
+}
+
 // Type returns the underlying type in string form. This is part of pflag's
 // value interface.
 func (Locality) Type() string {

--- a/pkg/roachpb/metadata_test.go
+++ b/pkg/roachpb/metadata_test.go
@@ -221,6 +221,44 @@ func TestLocalityMatches(t *testing.T) {
 	}
 }
 
+func TestLocalitySharedPrefix(t *testing.T) {
+	for _, tc := range []struct {
+		a        string
+		b        string
+		expected int
+	}{
+		// Test basic match and mismatch cases.
+		{"a=b", "a=b", 1},
+		{"a=b,c=d", "a=b,c=d", 2},
+		{"a=b", "a=b,c=d", 1},
+		{"", "", 0},
+
+		// Test cases with differing lengths.
+		{"a=b", "x=y", 0},
+		{"a=b,x=y", "", 0},
+		{"a=b,x=y", "a=c", 0},
+		{"a=b,x=y", "a=c,x=y", 0},
+
+		// Test cases where the mismatch occurs in different positions.
+		{"a=b,c=d,e=f", "a=z,c=d,e=f", 0},
+		{"a=b,c=d,e=f", "a=b,c=z,e=f", 1},
+		{"a=b,c=d,e=f", "a=b,c=d,e=z", 2},
+		{"a=b,c=d,e=f", "a=b,c=d,e=f", 3},
+	} {
+		t.Run(fmt.Sprintf("%s_=_%s", tc.a, tc.b), func(t *testing.T) {
+			var a, b Locality
+			if tc.a != "" {
+				require.NoError(t, a.Set(tc.a))
+			}
+			if tc.b != "" {
+				require.NoError(t, b.Set(tc.b))
+			}
+			require.Equal(t, tc.expected, a.SharedPrefix(b))
+			require.Equal(t, tc.expected, b.SharedPrefix(a))
+		})
+	}
+}
+
 func TestDiversityScore(t *testing.T) {
 	// Keys are not considered for score, just the order, so we don't need to
 	// specify them.

--- a/pkg/sql/BUILD.bazel
+++ b/pkg/sql/BUILD.bazel
@@ -795,6 +795,7 @@ go_test(
         "//pkg/sql/sessiondata",
         "//pkg/sql/sessiondatapb",
         "//pkg/sql/sessionphase",
+        "//pkg/sql/sqlinstance",
         "//pkg/sql/sqlliveness",
         "//pkg/sql/sqlstats",
         "//pkg/sql/sqltestutils",


### PR DESCRIPTION
This changes physical planning, specifically how the SQL instance for a
given KV node ID is resolved, to be more generalized w.r.t. different
locality tier taxonomies.

Previously this function had a special case that checked for, and only
for, a specific locality tier with the key "region" and if it was
found, picked a random instance from the subset of instances where their
value for that matched the value for the KV node.

Matching on and only on the "region" tier is both too specific and not
specific enough: it is "too specific" in that it requires a tier with
the key "region" to be used and to match, and is "not specific enough"
in that it simultaneously ignores more specific locality tiers that
would indicate closer matches (e.g. subregion, AZ, data-center or rack).

Instead, this change generalizes this function to identify the subset of
instances that have the "closest match" in localities to the KV node and
pick one of them, where closest match is defined as the longest matching
prefix of locality tiers. In a simple, single-tier locality taxonomy
using the key "region" this should yield the same behavior as the
previous implementation, as all instances with a matching "region" will
have the same longest matching prefix (at length 1), however this more
general approach should better handle other locality taxonomies that use
more tiers and/or tiers with names other than "region".

Currently this change only applies to physical planning for secondary
tenants until physical planning is unified for system and secondary
tenants.

Release note: none.
Epic: CRDB-16910
