### PR TITLE
sql: fix data race in MemberOfWithAdminOption

### DIFF
--- a/pkg/sql/authorization.go
+++ b/pkg/sql/authorization.go
@@ -545,8 +545,10 @@ func MemberOfWithAdminOption(
 	future, _ := roleMembersCache.populateCacheGroup.DoChan(ctx,
 		fmt.Sprintf("%s-%d", member.Normalized(), tableVersion),
 		singleflight.DoOpts{
-			Stop:               roleMembersCache.stopper,
-			InheritCancelation: false,
+			Stop: roleMembersCache.stopper,
+			// Inheriting the cancellation is not great, but there isn't much choice
+			// because the underlying goroutine uses the leader's transaction.
+			InheritCancelation: true,
 		},
 		func(ctx context.Context) (interface{}, error) {
 			return resolveMemberOfWithAdminOption(


### PR DESCRIPTION
singleflight: mitigate potential data races from context cancellation

This patch ensures that if the leader of a singleflight flight has its
context cancelled while waiting for the result of the flight closure,
it will block until the closure returns to prevent any possible data
races on any data shared with the closure.

Release note: None

----

sql: change role members cache singleflight to inherit cancellation

This patch changes the role members cache singleflight to inherit
cancellation since the flight closure uses the caller's transaction.

Release note: None

----

Fixes #95642
Fixes #96539