### PR TITLE
changefeedccl: enable TestChangefeedPropagatesTerminalError

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -6008,7 +6008,6 @@ func TestChangefeedHandlesDrainingNodes(t *testing.T) {
 
 func TestChangefeedPropagatesTerminalError(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	skip.WithIssue(t, 95057, "flaky test")
 	defer log.Scope(t).Close(t)
 
 	opts := makeOptions()


### PR DESCRIPTION
Fixes: #95057

The test TestChangefeedPropagatesTerminalError no longer seems to flake after running it under stress on a GCE worker for a while, so this change re-enables it.

Release note: None