### PR TITLE
multitenant: add AdminRelocateRange capability

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/tenant_capability
+++ b/pkg/ccl/logictestccl/testdata/logic_test/tenant_capability
@@ -30,12 +30,13 @@ CREATE TENANT "no-capabilities-tenant";
 query TT colnames
 SELECT capability_id, capability_value FROM [SHOW TENANT "no-capabilities-tenant" WITH CAPABILITIES]
 ----
-capability_id          capability_value
-can_admin_scatter      true
-can_admin_split        true
-can_admin_unsplit      false
-can_view_node_info     false
-can_view_tsdb_metrics  false
+capability_id             capability_value
+can_admin_relocate_range  false
+can_admin_scatter         true
+can_admin_split           true
+can_admin_unsplit         false
+can_view_node_info        false
+can_view_tsdb_metrics     false
 
 subtest end
 
@@ -50,12 +51,13 @@ ALTER TENANT "bool-capability-no-value-tenant" GRANT CAPABILITY can_admin_split
 query TT colnames
 SELECT capability_id, capability_value FROM [SHOW TENANT "bool-capability-no-value-tenant" WITH CAPABILITIES]
 ----
-capability_id          capability_value
-can_admin_scatter      true
-can_admin_split        true
-can_admin_unsplit      false
-can_view_node_info     false
-can_view_tsdb_metrics  false
+capability_id             capability_value
+can_admin_relocate_range  false
+can_admin_scatter         true
+can_admin_split           true
+can_admin_unsplit         false
+can_view_node_info        false
+can_view_tsdb_metrics     false
 
 statement ok
 ALTER TENANT "bool-capability-no-value-tenant" REVOKE CAPABILITY can_admin_split
@@ -63,12 +65,13 @@ ALTER TENANT "bool-capability-no-value-tenant" REVOKE CAPABILITY can_admin_split
 query TT colnames
 SELECT capability_id, capability_value FROM [SHOW TENANT "bool-capability-no-value-tenant" WITH CAPABILITIES]
 ----
-capability_id          capability_value
-can_admin_scatter      true
-can_admin_split        false
-can_admin_unsplit      false
-can_view_node_info     false
-can_view_tsdb_metrics  false
+capability_id             capability_value
+can_admin_relocate_range  false
+can_admin_scatter         true
+can_admin_split           false
+can_admin_unsplit         false
+can_view_node_info        false
+can_view_tsdb_metrics     false
 
 subtest end
 
@@ -83,12 +86,13 @@ ALTER TENANT "bool-capability-with-value-tenant" GRANT CAPABILITY can_admin_spli
 query TT colnames
 SELECT capability_id, capability_value FROM [SHOW TENANT "bool-capability-with-value-tenant" WITH CAPABILITIES]
 ----
-capability_id          capability_value
-can_admin_scatter      true
-can_admin_split        true
-can_admin_unsplit      false
-can_view_node_info     false
-can_view_tsdb_metrics  false
+capability_id             capability_value
+can_admin_relocate_range  false
+can_admin_scatter         true
+can_admin_split           true
+can_admin_unsplit         false
+can_view_node_info        false
+can_view_tsdb_metrics     false
 
 subtest end
 
@@ -103,12 +107,13 @@ ALTER TENANT "bool-capability-with-expression-value-tenant" GRANT CAPABILITY can
 query TT colnames
 SELECT capability_id, capability_value FROM [SHOW TENANT "bool-capability-with-expression-value-tenant" WITH CAPABILITIES]
 ----
-capability_id          capability_value
-can_admin_scatter      true
-can_admin_split        true
-can_admin_unsplit      false
-can_view_node_info     false
-can_view_tsdb_metrics  false
+capability_id             capability_value
+can_admin_relocate_range  false
+can_admin_scatter         true
+can_admin_split           true
+can_admin_unsplit         false
+can_view_node_info        false
+can_view_tsdb_metrics     false
 
 subtest end
 
@@ -123,12 +128,13 @@ ALTER TENANT "multiple-capability-tenant" GRANT CAPABILITY can_admin_split, can_
 query TT colnames
 SELECT capability_id, capability_value FROM [SHOW TENANT "multiple-capability-tenant" WITH CAPABILITIES]
 ----
-capability_id          capability_value
-can_admin_scatter      true
-can_admin_split        true
-can_admin_unsplit      false
-can_view_node_info     true
-can_view_tsdb_metrics  false
+capability_id             capability_value
+can_admin_relocate_range  false
+can_admin_scatter         true
+can_admin_split           true
+can_admin_unsplit         false
+can_view_node_info        true
+can_view_tsdb_metrics     false
 
 statement ok
 ALTER TENANT "multiple-capability-tenant" REVOKE CAPABILITY can_admin_split, can_view_node_info
@@ -136,11 +142,12 @@ ALTER TENANT "multiple-capability-tenant" REVOKE CAPABILITY can_admin_split, can
 query TT colnames
 SELECT capability_id, capability_value FROM [SHOW TENANT "multiple-capability-tenant" WITH CAPABILITIES]
 ----
-capability_id          capability_value
-can_admin_scatter      true
-can_admin_split        false
-can_admin_unsplit      false
-can_view_node_info     false
-can_view_tsdb_metrics  false
+capability_id             capability_value
+can_admin_relocate_range  false
+can_admin_scatter         true
+can_admin_split           false
+can_admin_unsplit         false
+can_view_node_info        false
+can_view_tsdb_metrics     false
 
 subtest end

--- a/pkg/ccl/logictestccl/testdata/logic_test/tenant_unsupported
+++ b/pkg/ccl/logictestccl/testdata/logic_test/tenant_unsupported
@@ -42,29 +42,3 @@ SELECT * FROM crdb_internal.kv_store_status
 
 statement error operation is unsupported in multi-tenancy mode
 SELECT * FROM crdb_internal.kv_node_status
-
-# Cannot perform operations that issue Admin requests.
-
-statement error tenant cluster setting sql.scatter.allow_for_secondary_tenant.enabled disabled
-ALTER TABLE kv SCATTER
-
-statement error operation is unsupported in multi-tenancy mode
-ALTER TABLE kv EXPERIMENTAL_RELOCATE VALUES (ARRAY[1], 'k')
-
-statement error operation is unsupported in multi-tenancy mode
-ALTER TABLE kv EXPERIMENTAL_RELOCATE LEASE VALUES (1, 'k')
-
-statement error operation is unsupported in multi-tenancy mode
-SELECT crdb_internal.check_consistency(true, '', '')
-
-statement error operation is unsupported in multi-tenancy mode
-ALTER RANGE 1 RELOCATE LEASE TO 2
-
-statement error operation is unsupported in multi-tenancy mode
-ALTER RANGE RELOCATE LEASE TO 2 FOR SELECT range_id FROM [SHOW RANGES FROM TABLE kv]
-
-statement error operation is unsupported in multi-tenancy mode
-ALTER RANGE 1 RELOCATE FROM 1 TO 2
-
-statement error operation is unsupported in multi-tenancy mode
-ALTER RANGE RELOCATE FROM 1 TO 2 FOR SELECT range_id FROM [SHOW RANGES FROM TABLE kv]

--- a/pkg/multitenant/tenantcapabilities/capabilities.go
+++ b/pkg/multitenant/tenantcapabilities/capabilities.go
@@ -154,6 +154,12 @@ type TenantCapabilities interface {
 const (
 	_ CapabilityID = iota
 
+	// CanAdminRelocateRange describes the ability of a tenant to perform manual
+	// KV relocate range requests. These operations need a capability
+	// because excessive KV range relocation can overwhelm the storage
+	// cluster.
+	CanAdminRelocateRange // can_admin_relocate_range
+
 	// CanAdminScatter describes the ability of a tenant to scatter ranges using
 	// an AdminScatter request. By default, secondary tenants are allowed to
 	// scatter as doing so is integral to the performance of IMPORT/RESTORE.
@@ -220,6 +226,7 @@ const (
 func (c CapabilityID) CapabilityType() Type {
 	switch c {
 	case
+		CanAdminRelocateRange,
 		CanAdminScatter,
 		CanAdminSplit,
 		CanAdminUnsplit,

--- a/pkg/multitenant/tenantcapabilities/capabilities.go
+++ b/pkg/multitenant/tenantcapabilities/capabilities.go
@@ -13,7 +13,6 @@ package tenantcapabilities
 import (
 	"context"
 	"fmt"
-	"strings"
 
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
@@ -96,25 +95,18 @@ func (u Update) String() string {
 	return fmt.Sprintf("update: %v", u.Entry)
 }
 
-// AllCapabilitiesString prints all capability values. This is different from
-// TenantCapabilities.String which only prints non-zero value fields.
-func AllCapabilitiesString(capabilities TenantCapabilities) string {
-	var builder strings.Builder
-	builder.WriteByte('{')
-	for i, capID := range CapabilityIDs {
-		if i > 0 {
-			builder.WriteByte(' ')
-		}
-		builder.WriteString(capID.String())
-		builder.WriteByte(':')
-		builder.WriteString(capabilities.Cap(capID).Get().String())
-	}
-	builder.WriteByte('}')
-	return builder.String()
+var defaultCaps TenantCapabilities
+
+// DefaultCapabilities returns the default state of capabilities.
+func DefaultCapabilities() TenantCapabilities {
+	return defaultCaps
 }
 
+// RegisterDefaultCapabilities is called from the tenantcapabilitiespb package.
+func RegisterDefaultCapabilities(caps TenantCapabilities) { defaultCaps = caps }
+
 func (u Entry) String() string {
-	return fmt.Sprintf("ten=%v cap=%v", u.TenantID, AllCapabilitiesString(u.TenantCapabilities))
+	return fmt.Sprintf("ten=%v cap=%v", u.TenantID, u.TenantCapabilities)
 }
 
 // CapabilityID represents a handle to a tenant capability.

--- a/pkg/multitenant/tenantcapabilities/capabilityid_string.go
+++ b/pkg/multitenant/tenantcapabilities/capabilityid_string.go
@@ -8,18 +8,19 @@ func _() {
 	// An "invalid array index" compiler error signifies that the constant values have changed.
 	// Re-run the stringer command to generate them again.
 	var x [1]struct{}
-	_ = x[CanAdminScatter-1]
-	_ = x[CanAdminSplit-2]
-	_ = x[CanAdminUnsplit-3]
-	_ = x[CanViewNodeInfo-4]
-	_ = x[CanViewTSDBMetrics-5]
-	_ = x[TenantSpanConfigBounds-6]
-	_ = x[MaxCapabilityID-6]
+	_ = x[CanAdminRelocateRange-1]
+	_ = x[CanAdminScatter-2]
+	_ = x[CanAdminSplit-3]
+	_ = x[CanAdminUnsplit-4]
+	_ = x[CanViewNodeInfo-5]
+	_ = x[CanViewTSDBMetrics-6]
+	_ = x[TenantSpanConfigBounds-7]
+	_ = x[MaxCapabilityID-7]
 }
 
-const _CapabilityID_name = "can_admin_scattercan_admin_splitcan_admin_unsplitcan_view_node_infocan_view_tsdb_metricsspan_config_bounds"
+const _CapabilityID_name = "can_admin_relocate_rangecan_admin_scattercan_admin_splitcan_admin_unsplitcan_view_node_infocan_view_tsdb_metricsspan_config_bounds"
 
-var _CapabilityID_index = [...]uint8{0, 17, 32, 49, 67, 88, 106}
+var _CapabilityID_index = [...]uint8{0, 24, 41, 56, 73, 91, 112, 130}
 
 func (i CapabilityID) String() string {
 	i -= 1

--- a/pkg/multitenant/tenantcapabilities/tenantcapabilitiesauthorizer/authorizer.go
+++ b/pkg/multitenant/tenantcapabilities/tenantcapabilitiesauthorizer/authorizer.go
@@ -154,15 +154,15 @@ var reqMethodToCap = map[kvpb.Method]tenantcapabilities.CapabilityID{
 	kvpb.Scan:               noCapCheckNeeded,
 
 	// The following are authorized via specific capabilities.
-	kvpb.AdminScatter: tenantcapabilities.CanAdminScatter,
-	kvpb.AdminSplit:   tenantcapabilities.CanAdminSplit,
-	kvpb.AdminUnsplit: tenantcapabilities.CanAdminUnsplit,
+	kvpb.AdminChangeReplicas: tenantcapabilities.CanAdminRelocateRange,
+	kvpb.AdminScatter:        tenantcapabilities.CanAdminScatter,
+	kvpb.AdminSplit:          tenantcapabilities.CanAdminSplit,
+	kvpb.AdminUnsplit:        tenantcapabilities.CanAdminUnsplit,
+	kvpb.AdminRelocateRange:  tenantcapabilities.CanAdminRelocateRange,
+	kvpb.AdminTransferLease:  tenantcapabilities.CanAdminRelocateRange,
 
 	// TODO(ecwall): The following should also be authorized via specific capabilities.
-	kvpb.AdminChangeReplicas: noCapCheckNeeded,
-	kvpb.AdminMerge:          noCapCheckNeeded,
-	kvpb.AdminRelocateRange:  noCapCheckNeeded,
-	kvpb.AdminTransferLease:  noCapCheckNeeded,
+	kvpb.AdminMerge: noCapCheckNeeded,
 
 	// TODO(knz,arul): Verify with the relevant teams whether secondary
 	// tenants have legitimate access to any of those.

--- a/pkg/multitenant/tenantcapabilities/tenantcapabilitiesauthorizer/testdata/basic
+++ b/pkg/multitenant/tenantcapabilities/tenantcapabilitiesauthorizer/testdata/basic
@@ -1,8 +1,12 @@
-upsert ten=10 can_admin_scatter=true can_admin_split=true can_admin_unsplit=true can_view_node_info=true can_view_tsdb_metrics=true
+upsert ten=10 can_admin_relocate_range=true can_admin_scatter=true can_admin_split=true can_admin_unsplit=true can_view_node_info=true can_view_tsdb_metrics=true
 ----
 ok
 
-upsert ten=11 can_admin_scatter=false can_admin_split=false can_admin_unsplit=false can_view_node_info=false can_view_tsdb_metrics=false
+upsert ten=11 can_admin_relocate_range=false can_admin_scatter=false can_admin_split=false can_admin_unsplit=false can_view_node_info=false can_view_tsdb_metrics=false
+----
+ok
+
+has-capability-for-batch ten=10 cmds=(AdminChangeReplicas, AdminRelocateRange, AdminTransferLease, Scan, ConditionalPut)
 ----
 ok
 
@@ -20,6 +24,14 @@ has-capability-for-batch ten=10 cmds=(AdminUnsplit, Scan, ConditionalPut)
 ----
 ok
 
+has-capability-for-batch ten=11 cmds=(AdminChangeReplicas, Scan, ConditionalPut)
+----
+client tenant does not have capability "can_admin_relocate_range" (*kvpb.AdminChangeReplicasRequest)
+
+has-capability-for-batch ten=11 cmds=(AdminRelocateRange, Scan, ConditionalPut)
+----
+client tenant does not have capability "can_admin_relocate_range" (*kvpb.AdminRelocateRangeRequest)
+
 has-capability-for-batch ten=11 cmds=(AdminScatter, Scan, ConditionalPut)
 ----
 client tenant does not have capability "can_admin_scatter" (*kvpb.AdminScatterRequest)
@@ -28,6 +40,10 @@ client tenant does not have capability "can_admin_scatter" (*kvpb.AdminScatterRe
 has-capability-for-batch ten=11 cmds=(AdminSplit, Scan, ConditionalPut)
 ----
 client tenant does not have capability "can_admin_split" (*kvpb.AdminSplitRequest)
+
+has-capability-for-batch ten=11 cmds=(AdminTransferLease, Scan, ConditionalPut)
+----
+client tenant does not have capability "can_admin_relocate_range" (*kvpb.AdminTransferLeaseRequest)
 
 has-capability-for-batch ten=11 cmds=(AdminUnsplit, Scan, ConditionalPut)
 ----
@@ -51,7 +67,23 @@ ok
 
 # Lastly, flip tenant 10's capability for splits; ensure it can no longer issue
 # splits as a result.
-upsert ten=10 can_admin_scatter=true can_admin_split=false can_admin_unsplit=false can_view_node_info=true can_view_tsdb_metrics=true
+upsert ten=10 can_admin_relocate_range=false can_admin_scatter=true can_admin_split=false can_admin_unsplit=false can_view_node_info=true can_view_tsdb_metrics=true
+----
+ok
+
+has-capability-for-batch ten=10 cmds=(AdminChangeReplicas, Scan, ConditionalPut)
+----
+client tenant does not have capability "can_admin_relocate_range" (*kvpb.AdminChangeReplicasRequest)
+
+has-capability-for-batch ten=10 cmds=(AdminRelocateRange, Scan, ConditionalPut)
+----
+client tenant does not have capability "can_admin_relocate_range" (*kvpb.AdminRelocateRangeRequest)
+
+has-capability-for-batch ten=10 cmds=(AdminChangeReplicas, Scan, ConditionalPut)
+----
+client tenant does not have capability "can_admin_relocate_range" (*kvpb.AdminChangeReplicasRequest)
+
+has-capability-for-batch ten=10 cmds=(AdminScatter, Scan, ConditionalPut)
 ----
 ok
 
@@ -63,6 +95,10 @@ client tenant does not have capability "can_admin_split" (*kvpb.AdminSplitReques
 has-capability-for-batch ten=10 cmds=(AdminScatter, Scan, ConditionalPut)
 ----
 ok
+
+has-capability-for-batch ten=10 cmds=(AdminTransferLease, Scan, ConditionalPut)
+----
+client tenant does not have capability "can_admin_relocate_range" (*kvpb.AdminTransferLeaseRequest)
 
 has-capability-for-batch ten=10 cmds=(AdminUnsplit, Scan, ConditionalPut)
 ----

--- a/pkg/multitenant/tenantcapabilities/tenantcapabilitiespb/capabilities.go
+++ b/pkg/multitenant/tenantcapabilities/tenantcapabilitiespb/capabilities.go
@@ -78,6 +78,8 @@ func (t *TenantCapabilities) Cap(
 	capabilityID tenantcapabilities.CapabilityID,
 ) tenantcapabilities.Capability {
 	switch capabilityID {
+	case tenantcapabilities.CanAdminRelocateRange:
+		return boolCap{&t.CanAdminRelocateRange}
 	case tenantcapabilities.CanAdminScatter:
 		return invertedBoolCap{&t.DisableAdminScatter}
 	case tenantcapabilities.CanAdminSplit:
@@ -98,6 +100,8 @@ func (t *TenantCapabilities) Cap(
 // It is an optimization.
 func (t *TenantCapabilities) GetBool(capabilityID tenantcapabilities.CapabilityID) bool {
 	switch capabilityID {
+	case tenantcapabilities.CanAdminRelocateRange:
+		return t.CanAdminRelocateRange
 	case tenantcapabilities.CanAdminScatter:
 		return !t.DisableAdminScatter
 	case tenantcapabilities.CanAdminSplit:

--- a/pkg/multitenant/tenantcapabilities/tenantcapabilitiespb/capabilities.go
+++ b/pkg/multitenant/tenantcapabilities/tenantcapabilitiespb/capabilities.go
@@ -16,6 +16,10 @@ import (
 	"github.com/cockroachdb/redact"
 )
 
+func init() {
+	tenantcapabilities.RegisterDefaultCapabilities(&TenantCapabilities{})
+}
+
 // boolCapValue is a wrapper around bool that ensures that values can
 // be included in reportables.
 type boolCapValue bool

--- a/pkg/multitenant/tenantcapabilities/tenantcapabilitiespb/capabilities.proto
+++ b/pkg/multitenant/tenantcapabilities/tenantcapabilitiespb/capabilities.proto
@@ -76,7 +76,10 @@ message TenantCapabilities {
   // successfully perform `AdminUnsplit` requests.
   bool can_admin_unsplit = 5;
 
-  // Next id: 7
+  // CanAdminRelocateRange if set to true, grants the tenant the ability to
+  // successfully perform `AdminChangeReplicas`, `AdminRelocateRange`,
+  // `AdminTransferLease` requests.
+  bool can_admin_relocate_range = 7;
 };
 
 // SpanConfigBound is used to constrain the possible values a SpanConfig may

--- a/pkg/multitenant/tenantcapabilities/tenantcapabilitieswatcher/testdata/basic
+++ b/pkg/multitenant/tenantcapabilities/tenantcapabilitieswatcher/testdata/basic
@@ -18,13 +18,13 @@ ok
 updates
 ----
 Incremental Update
-update: ten=10 cap={can_admin_scatter:true can_admin_split:true can_admin_unsplit:true can_view_node_info:false can_view_tsdb_metrics:false}
-update: ten=11 cap={can_admin_scatter:true can_admin_split:true can_admin_unsplit:false can_view_node_info:false can_view_tsdb_metrics:false}
+update: ten=10 cap={can_admin_unsplit:true}
+update: ten=11 cap={default}
 
 flush-state
 ----
-ten=10 cap={can_admin_scatter:true can_admin_split:true can_admin_unsplit:true can_view_node_info:false can_view_tsdb_metrics:false}
-ten=11 cap={can_admin_scatter:true can_admin_split:true can_admin_unsplit:false can_view_node_info:false can_view_tsdb_metrics:false}
+ten=10 cap={can_admin_unsplit:true}
+ten=11 cap={default}
 
 upsert ten=11 can_admin_unsplit=true
 ----
@@ -33,11 +33,11 @@ ok
 updates
 ----
 Incremental Update
-update: ten=11 cap={can_admin_scatter:true can_admin_split:true can_admin_unsplit:true can_view_node_info:false can_view_tsdb_metrics:false}
+update: ten=11 cap={can_admin_unsplit:true}
 
 get-capabilities ten=11
 ----
-{can_admin_scatter:true can_admin_split:true can_admin_unsplit:true can_view_node_info:false can_view_tsdb_metrics:false}
+{can_admin_unsplit:true}
 
 delete ten=10
 ----
@@ -64,7 +64,7 @@ updates
 # what we'd expect.
 flush-state
 ----
-ten=11 cap={can_admin_scatter:true can_admin_split:true can_admin_unsplit:true can_view_node_info:false can_view_tsdb_metrics:false}
+ten=11 cap={can_admin_unsplit:true}
 
 upsert ten=15 can_admin_unsplit=true
 ----
@@ -73,7 +73,7 @@ ok
 updates
 ----
 Incremental Update
-update: ten=15 cap={can_admin_scatter:true can_admin_split:true can_admin_unsplit:true can_view_node_info:false can_view_tsdb_metrics:false}
+update: ten=15 cap={can_admin_unsplit:true}
 
 # Ensure only the last update is applied, even when there are multiple updates
 # to a single key.
@@ -100,7 +100,7 @@ not-found
 
 flush-state
 ----
-ten=15 cap={can_admin_scatter:true can_admin_split:true can_admin_unsplit:true can_view_node_info:false can_view_tsdb_metrics:false}
+ten=15 cap={can_admin_unsplit:true}
 
 # Same thing, but this time instead of deleting the key, leave it behind.
 delete ten=15
@@ -118,12 +118,12 @@ ok
 updates
 ----
 Incremental Update
-update: ten=15 cap={can_admin_scatter:true can_admin_split:true can_admin_unsplit:false can_view_node_info:false can_view_tsdb_metrics:false}
+update: ten=15 cap={default}
 
 flush-state
 ----
-ten=15 cap={can_admin_scatter:true can_admin_split:true can_admin_unsplit:false can_view_node_info:false can_view_tsdb_metrics:false}
+ten=15 cap={default}
 
 get-capabilities ten=15
 ----
-{can_admin_scatter:true can_admin_split:true can_admin_unsplit:false can_view_node_info:false can_view_tsdb_metrics:false}
+{default}

--- a/pkg/multitenant/tenantcapabilities/tenantcapabilitieswatcher/testdata/initial_scan
+++ b/pkg/multitenant/tenantcapabilities/tenantcapabilitieswatcher/testdata/initial_scan
@@ -38,13 +38,13 @@ ok
 updates
 ----
 Complete Update
-update: ten=11 cap={can_admin_scatter:true can_admin_split:true can_admin_unsplit:false can_view_node_info:false can_view_tsdb_metrics:false}
-update: ten=15 cap={can_admin_scatter:true can_admin_split:true can_admin_unsplit:true can_view_node_info:false can_view_tsdb_metrics:false}
+update: ten=11 cap={default}
+update: ten=15 cap={can_admin_unsplit:true}
 
 flush-state
 ----
-ten=11 cap={can_admin_scatter:true can_admin_split:true can_admin_unsplit:false can_view_node_info:false can_view_tsdb_metrics:false}
-ten=15 cap={can_admin_scatter:true can_admin_split:true can_admin_unsplit:true can_view_node_info:false can_view_tsdb_metrics:false}
+ten=11 cap={default}
+ten=15 cap={can_admin_unsplit:true}
 
 get-capabilities ten=10
 ----
@@ -52,4 +52,4 @@ not-found
 
 get-capabilities ten=15
 ----
-{can_admin_scatter:true can_admin_split:true can_admin_unsplit:true can_view_node_info:false can_view_tsdb_metrics:false}
+{can_admin_unsplit:true}

--- a/pkg/multitenant/tenantcapabilities/tenantcapabilitieswatcher/testdata/rangefeed_errors
+++ b/pkg/multitenant/tenantcapabilities/tenantcapabilitieswatcher/testdata/rangefeed_errors
@@ -25,9 +25,9 @@ ok
 updates
 ----
 Incremental Update
-update: ten=10 cap={can_admin_scatter:true can_admin_split:true can_admin_unsplit:true can_view_node_info:false can_view_tsdb_metrics:false}
-update: ten=11 cap={can_admin_scatter:true can_admin_split:true can_admin_unsplit:false can_view_node_info:false can_view_tsdb_metrics:false}
-update: ten=12 cap={can_admin_scatter:true can_admin_split:true can_admin_unsplit:false can_view_node_info:false can_view_tsdb_metrics:false}
+update: ten=10 cap={can_admin_unsplit:true}
+update: ten=11 cap={default}
+update: ten=12 cap={default}
 
 inject-error
 ----
@@ -56,9 +56,9 @@ updates
 
 flush-state
 ----
-ten=10 cap={can_admin_scatter:true can_admin_split:true can_admin_unsplit:true can_view_node_info:false can_view_tsdb_metrics:false}
-ten=11 cap={can_admin_scatter:true can_admin_split:true can_admin_unsplit:false can_view_node_info:false can_view_tsdb_metrics:false}
-ten=12 cap={can_admin_scatter:true can_admin_split:true can_admin_unsplit:false can_view_node_info:false can_view_tsdb_metrics:false}
+ten=10 cap={can_admin_unsplit:true}
+ten=11 cap={default}
+ten=12 cap={default}
 
 get-capabilities ten=50
 ----
@@ -66,11 +66,11 @@ not-found
 
 get-capabilities ten=12
 ----
-{can_admin_scatter:true can_admin_split:true can_admin_unsplit:false can_view_node_info:false can_view_tsdb_metrics:false}
+{default}
 
 get-capabilities ten=10
 ----
-{can_admin_scatter:true can_admin_split:true can_admin_unsplit:true can_view_node_info:false can_view_tsdb_metrics:false}
+{can_admin_unsplit:true}
 
 # Let the Watcher attempt to restart.
 restart-after-injected-error
@@ -82,23 +82,23 @@ ok
 updates
 ----
 Complete Update
-update: ten=11 cap={can_admin_scatter:true can_admin_split:true can_admin_unsplit:false can_view_node_info:false can_view_tsdb_metrics:false}
-update: ten=12 cap={can_admin_scatter:true can_admin_split:true can_admin_unsplit:true can_view_node_info:false can_view_tsdb_metrics:false}
-update: ten=50 cap={can_admin_scatter:true can_admin_split:true can_admin_unsplit:false can_view_node_info:false can_view_tsdb_metrics:false}
+update: ten=11 cap={default}
+update: ten=12 cap={can_admin_unsplit:true}
+update: ten=50 cap={default}
 
 flush-state
 ----
-ten=11 cap={can_admin_scatter:true can_admin_split:true can_admin_unsplit:false can_view_node_info:false can_view_tsdb_metrics:false}
-ten=12 cap={can_admin_scatter:true can_admin_split:true can_admin_unsplit:true can_view_node_info:false can_view_tsdb_metrics:false}
-ten=50 cap={can_admin_scatter:true can_admin_split:true can_admin_unsplit:false can_view_node_info:false can_view_tsdb_metrics:false}
+ten=11 cap={default}
+ten=12 cap={can_admin_unsplit:true}
+ten=50 cap={default}
 
 get-capabilities ten=50
 ----
-{can_admin_scatter:true can_admin_split:true can_admin_unsplit:false can_view_node_info:false can_view_tsdb_metrics:false}
+{default}
 
 get-capabilities ten=12
 ----
-{can_admin_scatter:true can_admin_split:true can_admin_unsplit:true can_view_node_info:false can_view_tsdb_metrics:false}
+{can_admin_unsplit:true}
 
 get-capabilities ten=10
 ----

--- a/pkg/multitenant/tenantcapabilities/tenantcapabilitieswatcher/watcher_test.go
+++ b/pkg/multitenant/tenantcapabilities/tenantcapabilitieswatcher/watcher_test.go
@@ -196,7 +196,11 @@ func TestDataDriven(t *testing.T) {
 					if i+1 != len(receivedUpdates) && receivedUpdates[i+1].TenantID.Equal(receivedUpdates[i].TenantID) {
 						continue // de-duplicate
 					}
-					output.WriteString(fmt.Sprintf("%+v\n", receivedUpdates[i]))
+					if receivedUpdates[i].Deleted {
+						output.WriteString(fmt.Sprintf("delete: ten=%v\n", receivedUpdates[i].TenantID))
+					} else {
+						output.WriteString(fmt.Sprintf("update: ten=%v cap=%v\n", receivedUpdates[i].TenantID, tenantcapabilitiestestutils.AlteredCapabilitiesString(receivedUpdates[i].TenantCapabilities)))
+					}
 				}
 				return output.String()
 
@@ -231,13 +235,13 @@ func TestDataDriven(t *testing.T) {
 				if !found {
 					return "not-found"
 				}
-				return fmt.Sprintf("%v", tenantcapabilities.AllCapabilitiesString(cp))
+				return fmt.Sprintf("%v", tenantcapabilitiestestutils.AlteredCapabilitiesString(cp))
 
 			case "flush-state":
 				var output strings.Builder
 				entries := watcher.TestingFlushCapabilitiesState()
 				for _, entry := range entries {
-					output.WriteString(fmt.Sprintf("%+v\n", entry))
+					output.WriteString(fmt.Sprintf("ten=%v cap=%v\n", entry.TenantID, tenantcapabilitiestestutils.AlteredCapabilitiesString(entry.TenantCapabilities)))
 				}
 				return output.String()
 			case "inject-error":

--- a/pkg/sql/BUILD.bazel
+++ b/pkg/sql/BUILD.bazel
@@ -822,7 +822,6 @@ go_test(
         "//pkg/util/ctxgroup",
         "//pkg/util/duration",
         "//pkg/util/encoding",
-        "//pkg/util/errorutil",
         "//pkg/util/fsm",
         "//pkg/util/hlc",
         "//pkg/util/httputil",

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -103,7 +103,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/upgrade/upgradebase"
 	"github.com/cockroachdb/cockroach/pkg/util/bitarray"
 	"github.com/cockroachdb/cockroach/pkg/util/duration"
-	"github.com/cockroachdb/cockroach/pkg/util/errorutil"
 	"github.com/cockroachdb/cockroach/pkg/util/errorutil/unimplemented"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -1620,10 +1619,6 @@ type TenantTestingKnobs struct {
 	// OverrideTokenBucketProvider allows a test-only TokenBucketProvider (which
 	// can optionally forward requests to the real provider).
 	OverrideTokenBucketProvider func(origProvider kvtenant.TokenBucketProvider) kvtenant.TokenBucketProvider
-
-	// SkipSQLSystemTentantCheck is a temporary knob to test which admin functions fail for secondary tenants.
-	// TODO(ewall): Remove when usages in multitenant_admin_function_test.go are removed.
-	SkipSQLSystemTentantCheck bool
 
 	// BeforeCheckingForDescriptorIDSequence, if set, is called before
 	// the connExecutor checks for the presence of system.descriptor_id_seq after
@@ -3618,20 +3613,6 @@ func (cfg *ExecutorConfig) GetRowMetrics(internal bool) *rowinfra.Metrics {
 		return cfg.InternalRowMetrics
 	}
 	return cfg.RowMetrics
-}
-
-// RequireSystemTenant returns an unsupported error if executed from inside a
-// secondary tenant. Tests may circumvent this check using a testing knob.
-// TODO(ewall): Replace usages of this with tenant capability checks in KV.
-func (cfg *ExecutorConfig) RequireSystemTenant() error {
-	if cfg.Codec.ForSystemTenant() {
-		return nil
-	}
-	knobs := cfg.TenantTestingKnobs
-	if knobs != nil && knobs.SkipSQLSystemTentantCheck {
-		return nil
-	}
-	return errorutil.UnsupportedWithMultiTenancy(errorutil.FeatureNotAvailableToNonSystemTenantsIssue)
 }
 
 // RequireSystemTenantOrClusterSetting returns a setting disabled error if

--- a/pkg/sql/logictest/testdata/logic_test/tenant_builtins
+++ b/pkg/sql/logictest/testdata/logic_test/tenant_builtins
@@ -40,17 +40,23 @@ SELECT crdb_internal.create_tenant('tenant-number-eleven')
 ----
 2
 
-query IBTIIT colnames
-SELECT id, active, name, data_state, service_mode,
-       crdb_internal.pb_to_json('cockroach.multitenant.ProtoInfo', info, true)
+query IBTIITT colnames
+SELECT
+  id,
+  active,
+  name,
+  data_state,
+  service_mode,
+  json_extract_path_text(crdb_internal.pb_to_json('cockroach.multitenant.ProtoInfo', info, true), 'deprecatedDataState') AS deprecated_data_state,
+  json_extract_path_text(crdb_internal.pb_to_json('cockroach.multitenant.ProtoInfo', info, true), 'droppedName') AS dropped_name
 FROM system.tenants
 ORDER BY id
 ----
-id  active  name                  data_state  service_mode  crdb_internal.pb_to_json
-1   true    system                1           2             {"capabilities": {"canAdminUnsplit": false, "canViewNodeInfo": false, "canViewTsdbMetrics": false, "disableAdminScatter": false, "disableAdminSplit": false, "spanConfigBounds": null}, "deprecatedDataState": "READY", "deprecatedId": "1", "droppedName": "", "tenantReplicationJobId": "0"}
-2   true    tenant-number-eleven  1           0             {"capabilities": {"canAdminUnsplit": false, "canViewNodeInfo": false, "canViewTsdbMetrics": false, "disableAdminScatter": false, "disableAdminSplit": false, "spanConfigBounds": null}, "deprecatedDataState": "READY", "deprecatedId": "2", "droppedName": "", "tenantReplicationJobId": "0"}
-5   true    tenant-5              1           0             {"capabilities": {"canAdminUnsplit": false, "canViewNodeInfo": false, "canViewTsdbMetrics": false, "disableAdminScatter": false, "disableAdminSplit": false, "spanConfigBounds": null}, "deprecatedDataState": "READY", "deprecatedId": "5", "droppedName": "", "tenantReplicationJobId": "0"}
-10  true    tenant-number-ten     1           0             {"capabilities": {"canAdminUnsplit": false, "canViewNodeInfo": false, "canViewTsdbMetrics": false, "disableAdminScatter": false, "disableAdminSplit": false, "spanConfigBounds": null}, "deprecatedDataState": "READY", "deprecatedId": "10", "droppedName": "", "tenantReplicationJobId": "0"}
+id  active  name                  data_state  service_mode  deprecated_data_state  dropped_name
+1   true    system                1           2             READY                  ·
+2   true    tenant-number-eleven  1           0             READY                  ·
+5   true    tenant-5              1           0             READY                  ·
+10  true    tenant-number-ten     1           0             READY                  ·
 
 # Check we can add a name where none existed before.
 statement ok
@@ -111,17 +117,23 @@ SELECT crdb_internal.gc_tenant(5)
 statement ok
 DROP TENANT [5]
 
-query IBTIIT colnames
-SELECT id, active, name, data_state, service_mode,
-       crdb_internal.pb_to_json('cockroach.multitenant.ProtoInfo', info, true)
+query IBTIITT colnames
+SELECT
+  id,
+  active,
+  name,
+  data_state,
+  service_mode,
+  json_extract_path_text(crdb_internal.pb_to_json('cockroach.multitenant.ProtoInfo', info, true), 'deprecatedDataState') AS deprecated_data_state,
+  json_extract_path_text(crdb_internal.pb_to_json('cockroach.multitenant.ProtoInfo', info, true), 'droppedName') AS dropped_name
 FROM system.tenants
 ORDER BY id
 ----
-id  active  name                  data_state  service_mode  crdb_internal.pb_to_json
-1   true    system                1           2             {"capabilities": {"canAdminUnsplit": false, "canViewNodeInfo": false, "canViewTsdbMetrics": false, "disableAdminScatter": false, "disableAdminSplit": false, "spanConfigBounds": null}, "deprecatedDataState": "READY", "deprecatedId": "1", "droppedName": "", "tenantReplicationJobId": "0"}
-2   true    tenant-number-eleven  1           0             {"capabilities": {"canAdminUnsplit": false, "canViewNodeInfo": false, "canViewTsdbMetrics": false, "disableAdminScatter": false, "disableAdminSplit": false, "spanConfigBounds": null}, "deprecatedDataState": "READY", "deprecatedId": "2", "droppedName": "", "tenantReplicationJobId": "0"}
-5   false   NULL                  2           0             {"capabilities": {"canAdminUnsplit": false, "canViewNodeInfo": false, "canViewTsdbMetrics": false, "disableAdminScatter": false, "disableAdminSplit": false, "spanConfigBounds": null}, "deprecatedDataState": "DROP", "deprecatedId": "5", "droppedName": "my-new-tenant-name", "tenantReplicationJobId": "0"}
-10  true    tenant-number-ten     1           0             {"capabilities": {"canAdminUnsplit": false, "canViewNodeInfo": false, "canViewTsdbMetrics": false, "disableAdminScatter": false, "disableAdminSplit": false, "spanConfigBounds": null}, "deprecatedDataState": "READY", "deprecatedId": "10", "droppedName": "", "tenantReplicationJobId": "0"}
+id  active  name                  data_state  service_mode  deprecated_data_state  dropped_name
+1   true    system                1           2             READY                  ·
+2   true    tenant-number-eleven  1           0             READY                  ·
+5   false   NULL                  2           0             DROP                   my-new-tenant-name
+10  true    tenant-number-ten     1           0             READY                  ·
 
 
 # Try to recreate an existing tenant.
@@ -222,16 +234,22 @@ succeeded
 statement error pgcode 42704 tenant "5" does not exist
 DROP TENANT [5]
 
-query IBTIIT colnames
-SELECT id, active, name, data_state, service_mode,
-       crdb_internal.pb_to_json('cockroach.multitenant.ProtoInfo', info, true)
+query IBTIITT colnames
+SELECT
+  id,
+  active,
+  name,
+  data_state,
+  service_mode,
+  json_extract_path_text(crdb_internal.pb_to_json('cockroach.multitenant.ProtoInfo', info, true), 'deprecatedDataState') AS deprecated_data_state,
+  json_extract_path_text(crdb_internal.pb_to_json('cockroach.multitenant.ProtoInfo', info, true), 'droppedName') AS dropped_name
 FROM system.tenants
 ORDER BY id
 ----
-id  active  name                  data_state  service_mode  crdb_internal.pb_to_json
-1   true    system                1           2             {"capabilities": {"canAdminUnsplit": false, "canViewNodeInfo": false, "canViewTsdbMetrics": false, "disableAdminScatter": false, "disableAdminSplit": false, "spanConfigBounds": null}, "deprecatedDataState": "READY", "deprecatedId": "1", "droppedName": "", "tenantReplicationJobId": "0"}
-2   true    tenant-number-eleven  1           0             {"capabilities": {"canAdminUnsplit": false, "canViewNodeInfo": false, "canViewTsdbMetrics": false, "disableAdminScatter": false, "disableAdminSplit": false, "spanConfigBounds": null}, "deprecatedDataState": "READY", "deprecatedId": "2", "droppedName": "", "tenantReplicationJobId": "0"}
-10  true    tenant-number-ten     1           0             {"capabilities": {"canAdminUnsplit": false, "canViewNodeInfo": false, "canViewTsdbMetrics": false, "disableAdminScatter": false, "disableAdminSplit": false, "spanConfigBounds": null}, "deprecatedDataState": "READY", "deprecatedId": "10", "droppedName": "", "tenantReplicationJobId": "0"}
+id  active  name                  data_state  service_mode  deprecated_data_state  dropped_name
+1   true    system                1           2             READY                  ·
+2   true    tenant-number-eleven  1           0             READY                  ·
+10  true    tenant-number-ten     1           0             READY                  ·
 
 query error tenant resource limits require a CCL binary
 SELECT crdb_internal.update_tenant_resource_limits(10, 1000, 100, 0, now(), 0)

--- a/pkg/sql/opt_exec_factory.go
+++ b/pkg/sql/opt_exec_factory.go
@@ -2018,11 +2018,6 @@ func (ef *execFactory) ConstructAlterTableUnsplitAll(index cat.Index) (exec.Node
 func (ef *execFactory) ConstructAlterTableRelocate(
 	index cat.Index, input exec.Node, relocateSubject tree.RelocateSubject,
 ) (exec.Node, error) {
-
-	if err := ef.planner.ExecCfg().RequireSystemTenant(); err != nil {
-		return nil, err
-	}
-
 	return &relocateNode{
 		subjectReplicas: relocateSubject,
 		tableDesc:       index.Table().(*optTable).desc,
@@ -2038,9 +2033,6 @@ func (ef *execFactory) ConstructAlterRangeRelocate(
 	toStoreID tree.TypedExpr,
 	fromStoreID tree.TypedExpr,
 ) (exec.Node, error) {
-	if err := ef.planner.ExecCfg().RequireSystemTenant(); err != nil {
-		return nil, err
-	}
 	return &relocateRange{
 		rows:            input.(planNode),
 		subjectReplicas: relocateSubject,


### PR DESCRIPTION
Fixes #98467

1) Add a new `tenantcapabilities.AdminRelocateRange` capability.
2) Check capability in `Authorizer.HasCapabilityForBatch` for
   `AdminChangeReplicas`, `AdminRelocateRange`, `AdminTransferLease`.
3) Remove unused `SkipSQLSystemTentantCheck`.

Release note: None