### PR TITLE
roachtest: maybe deflake `change-replicas/mixed-version`

### DIFF
--- a/pkg/cmd/roachtest/tests/mixed_version_change_replicas.go
+++ b/pkg/cmd/roachtest/tests/mixed_version_change_replicas.go
@@ -125,10 +125,11 @@ func runChangeReplicasMixedVersion(ctx context.Context, t test.Test, c cluster.C
 					InitialBackoff: 100 * time.Millisecond,
 					MaxBackoff:     5 * time.Second,
 					Multiplier:     2,
-					MaxRetries:     8,
+					MaxRetries:     12,
 				}
 				var rangeErrors map[int]string
 				for r := retry.StartWithCtx(ctx, retryOpts); r.Next(); {
+					setReplicateQueueEnabled(false)
 					if errCount := len(rangeErrors); errCount > 0 {
 						t.L().Printf("%d ranges failed, retrying", errCount)
 					}
@@ -153,6 +154,10 @@ func runChangeReplicasMixedVersion(ctx context.Context, t test.Test, c cluster.C
 					if len(rangeErrors) == 0 {
 						break
 					}
+					// The failure may be caused by conflicts with ongoing configuration
+					// changes by the replicate queue, so we re-enable it and let it run
+					// for a bit before the next retry.
+					setReplicateQueueEnabled(true)
 				}
 
 				if len(rangeErrors) > 0 {


### PR DESCRIPTION
Touches #98429.

Epic: none
Release note: None