### PR TITLE
settingswatcher: version guard support for clusters bootstrapped at old versions

### DIFF
--- a/pkg/server/settingswatcher/settings_watcher.go
+++ b/pkg/server/settingswatcher/settings_watcher.go
@@ -441,6 +441,10 @@ func (s *SettingsWatcher) GetStorageClusterVersion() clusterversion.ClusterVersi
 	return s.mu.storageClusterVersion
 }
 
+// errVersionSettingNotFound is returned by GetClusterVersionFromStorage if the
+// 'version' setting is not present in the system.settings table.
+var errVersionSettingNotFound = errors.New("got nil value for tenant cluster version row")
+
 // GetClusterVersionFromStorage reads the cluster version from the storage via
 // the given transaction.
 func (s *SettingsWatcher) GetClusterVersionFromStorage(
@@ -453,7 +457,7 @@ func (s *SettingsWatcher) GetClusterVersionFromStorage(
 		return clusterversion.ClusterVersion{}, err
 	}
 	if row.Value == nil {
-		return clusterversion.ClusterVersion{}, errors.New("got nil value for tenant cluster version row")
+		return clusterversion.ClusterVersion{}, errVersionSettingNotFound
 	}
 	_, val, _, err := s.dec.DecodeRow(roachpb.KeyValue{Key: row.Key, Value: *row.Value}, nil /* alloc */)
 	if err != nil {


### PR DESCRIPTION
When a cluster is bootstrapping, the sql server is initialized before the cluster version is populated in the DB. Previously, the version guard utility was unable to handle this state if the version is older than the maxVersion used to initialize the version guard. Now, the versionGuard handles this bootstrapping state by falling back on the in-memory cluster version.

Part of #94843

Release note: none