### PR TITLE
sql: disallow creating partial stats by default

### DIFF
--- a/pkg/ccl/backupccl/testdata/backup-restore/metadata
+++ b/pkg/ccl/backupccl/testdata/backup-restore/metadata
@@ -15,6 +15,10 @@ SET CLUSTER SETTING sql.stats.automatic_collection.enabled = false;
 ----
 
 exec-sql
+SET enable_create_stats_using_extremes = true;
+----
+
+exec-sql
 CREATE DATABASE db1;
 USE db1;
 CREATE TABLE tab (a INT PRIMARY KEY, b INT);

--- a/pkg/sql/create_stats.go
+++ b/pkg/sql/create_stats.go
@@ -250,6 +250,18 @@ func (n *createStatsNode) makeJobRecord(ctx context.Context) (*jobs.Record, erro
 		)
 	}
 
+	if n.Options.UsingExtremes && !n.p.SessionData().EnableCreateStatsUsingExtremes {
+		return nil, pgerror.New(pgcode.FeatureNotSupported,
+			"creating partial statistics at extremes is not yet supported",
+		)
+	}
+
+	if n.Options.Where != nil {
+		return nil, pgerror.New(pgcode.FeatureNotSupported,
+			"creating partial statistics with a WHERE clause is not yet supported",
+		)
+	}
+
 	if err := n.p.CheckPrivilege(ctx, tableDesc, privilege.SELECT); err != nil {
 		return nil, err
 	}

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -3470,6 +3470,10 @@ func (m *sessionDataMutator) SetOptimizerAlwaysUseHistograms(val bool) {
 	m.data.OptimizerAlwaysUseHistograms = val
 }
 
+func (m *sessionDataMutator) SetEnableCreateStatsUsingExtremes(val bool) {
+	m.data.EnableCreateStatsUsingExtremes = val
+}
+
 // Utility functions related to scrubbing sensitive information on SQL Stats.
 
 // quantizeCounts ensures that the Count field in the

--- a/pkg/sql/logictest/testdata/logic_test/distsql_stats
+++ b/pkg/sql/logictest/testdata/logic_test/distsql_stats
@@ -1998,6 +1998,15 @@ INSERT INTO abcd VALUES
 statement ok
 INSERT INTO xy VALUES (-1, 9), (-2, 8), (5, 15), (6, 16)
 
+statement error pgcode 0A000 creating partial statistics with a WHERE clause is not yet supported
+CREATE STATISTICS abcd_a_partial ON a FROM abcd WHERE a > 1;
+
+statement error pgcode 0A000 creating partial statistics at extremes is not yet supported
+CREATE STATISTICS abcd_a_partial ON a FROM abcd USING EXTREMES;
+
+statement ok
+SET enable_create_stats_using_extremes = on
+
 statement ok
 CREATE STATISTICS abcd_a_partial ON a FROM abcd USING EXTREMES;
 

--- a/pkg/sql/logictest/testdata/logic_test/information_schema
+++ b/pkg/sql/logictest/testdata/logic_test/information_schema
@@ -4961,6 +4961,7 @@ disable_partially_distributed_plans                   off
 disable_plan_gists                                    off
 disallow_full_table_scans                             off
 enable_auto_rehoming                                  off
+enable_create_stats_using_extremes                    off
 enable_drop_enum_value                                on
 enable_experimental_alter_column_type_general         off
 enable_implicit_select_for_update                     on

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -2595,6 +2595,7 @@ disable_plan_gists                                    off                 NULL  
 disallow_full_table_scans                             off                 NULL      NULL        NULL        string
 distsql                                               off                 NULL      NULL        NULL        string
 enable_auto_rehoming                                  off                 NULL      NULL        NULL        string
+enable_create_stats_using_extremes                    off                 NULL      NULL        NULL        string
 enable_experimental_alter_column_type_general         off                 NULL      NULL        NULL        string
 enable_implicit_select_for_update                     on                  NULL      NULL        NULL        string
 enable_implicit_transaction_for_batch_statements      on                  NULL      NULL        NULL        string
@@ -2743,6 +2744,7 @@ disable_plan_gists                                    off                 NULL  
 disallow_full_table_scans                             off                 NULL  user     NULL      off                 off
 distsql                                               off                 NULL  user     NULL      off                 off
 enable_auto_rehoming                                  off                 NULL  user     NULL      off                 off
+enable_create_stats_using_extremes                    off                 NULL  user     NULL      off                 off
 enable_experimental_alter_column_type_general         off                 NULL  user     NULL      off                 off
 enable_implicit_select_for_update                     on                  NULL  user     NULL      on                  on
 enable_implicit_transaction_for_batch_statements      on                  NULL  user     NULL      on                  on
@@ -2889,6 +2891,7 @@ disallow_full_table_scans                             NULL    NULL     NULL     
 distsql                                               NULL    NULL     NULL     NULL        NULL
 distsql_workmem                                       NULL    NULL     NULL     NULL        NULL
 enable_auto_rehoming                                  NULL    NULL     NULL     NULL        NULL
+enable_create_stats_using_extremes                    NULL    NULL     NULL     NULL        NULL
 enable_experimental_alter_column_type_general         NULL    NULL     NULL     NULL        NULL
 enable_implicit_select_for_update                     NULL    NULL     NULL     NULL        NULL
 enable_implicit_transaction_for_batch_statements      NULL    NULL     NULL     NULL        NULL

--- a/pkg/sql/logictest/testdata/logic_test/show_source
+++ b/pkg/sql/logictest/testdata/logic_test/show_source
@@ -57,6 +57,7 @@ disable_plan_gists                                    off
 disallow_full_table_scans                             off
 distsql                                               off
 enable_auto_rehoming                                  off
+enable_create_stats_using_extremes                    off
 enable_experimental_alter_column_type_general         off
 enable_implicit_select_for_update                     on
 enable_implicit_transaction_for_batch_statements      on

--- a/pkg/sql/sessiondatapb/local_only_session_data.proto
+++ b/pkg/sql/sessiondatapb/local_only_session_data.proto
@@ -346,6 +346,9 @@ message LocalOnlySessionData {
   // OptimizerAlwaysUseHistograms, when true, ensures that the optimizer
   // always uses histograms to calculate statistics if available.
   bool optimizer_always_use_histograms = 94;
+  // EnableCreateStatsUsingExtremes, when true, allows the use of CREATE
+  // STATISTICS .. USING EXTREMES.
+  bool enable_create_stats_using_extremes = 95;
 
   ///////////////////////////////////////////////////////////////////////////
   // WARNING: consider whether a session parameter you're adding needs to  //

--- a/pkg/sql/vars.go
+++ b/pkg/sql/vars.go
@@ -2532,6 +2532,23 @@ var varGen = map[string]sessionVar{
 		},
 		GlobalDefault: globalTrue,
 	},
+
+	// CockroachDB extension.
+	`enable_create_stats_using_extremes`: {
+		GetStringVal: makePostgresBoolGetStringValFn(`enable_create_stats_using_extremes`),
+		Set: func(_ context.Context, m sessionDataMutator, s string) error {
+			b, err := paramparse.ParseBoolVar("enable_create_stats_using_extremes", s)
+			if err != nil {
+				return err
+			}
+			m.SetEnableCreateStatsUsingExtremes(b)
+			return nil
+		},
+		Get: func(evalCtx *extendedEvalContext, _ *kv.Txn) (string, error) {
+			return formatBoolAsPostgresSetting(evalCtx.SessionData().EnableCreateStatsUsingExtremes), nil
+		},
+		GlobalDefault: globalFalse,
+	},
 }
 
 // We want test coverage for this on and off so make it metamorphic.


### PR DESCRIPTION
This commit adds the `enable_create_stats_using_extremes` session
setting which allows users to run `CREATE STATISTICS .. USING EXTREMES`
when enabled. It is disabled by default.

This commit also presents a "feature not supported" error when a user
tries to create partial statistics with a `WHERE` clause. This feature
has not yet been implemented.

Epic: CRDB-19449

Fixes #95233 

Release note: None
