### PR TITLE
release-22.2: sql/schemachanger: use force puts when writing to new primary indexes

### DIFF
--- a/pkg/sql/catalog/table_col_set.go
+++ b/pkg/sql/catalog/table_col_set.go
@@ -68,6 +68,11 @@ func (s TableColSet) Difference(other TableColSet) TableColSet {
 	return TableColSet{set: s.set.Difference(other.set)}
 }
 
+// Equals returns the column IDs in s are equal to the ones in other.
+func (s TableColSet) Equals(other TableColSet) bool {
+	return s.set.Equals(other.set)
+}
+
 // Ordered returns a slice with all the descpb.ColumnIDs in the set, in
 // increasing order.
 func (s TableColSet) Ordered() []descpb.ColumnID {

--- a/pkg/sql/catalog/tabledesc/mutation.go
+++ b/pkg/sql/catalog/tabledesc/mutation.go
@@ -29,10 +29,11 @@ var _ catalog.Mutation = mutation{}
 // and is embedded in table element interface implementations column and index
 // as well as mutation.
 type maybeMutation struct {
-	mutationID         descpb.MutationID
-	mutationDirection  descpb.DescriptorMutation_Direction
-	mutationState      descpb.DescriptorMutation_State
-	mutationIsRollback bool
+	mutationID                     descpb.MutationID
+	mutationDirection              descpb.DescriptorMutation_Direction
+	mutationState                  descpb.DescriptorMutation_State
+	mutationIsRollback             bool
+	mutationForcePutForIndexWrites bool
 }
 
 // IsMutation returns true iff this table element is in a mutation.
@@ -394,11 +395,13 @@ func newMutationCache(desc *descpb.TableDescriptor) *mutationCache {
 			})
 			backingStructs[i].column = &columns[len(columns)-1]
 		} else if pb := m.GetIndex(); pb != nil {
-			indexes = append(indexes, index{
+			idx := index{
 				maybeMutation: mm,
 				desc:          pb,
 				ordinal:       1 + len(desc.Indexes) + len(indexes),
-			})
+			}
+			idx.mutationForcePutForIndexWrites = determineIfIndexNeedsForcePuts(idx, desc)
+			indexes = append(indexes, idx)
 			backingStructs[i].index = &indexes[len(indexes)-1]
 		} else if pb := m.GetConstraint(); pb != nil {
 			constraints = append(constraints, constraintToUpdate{
@@ -453,4 +456,27 @@ func newMutationCache(desc *descpb.TableDescriptor) *mutationCache {
 		}
 	}
 	return &c
+}
+
+// determineIfIndexNeedsForcePuts based on a given index this function will
+// determine if this mutation should set the force puts flag. This flag indicates
+// that conditional puts are not safe. See index.ForcePut for the exact
+// scenarios.
+func determineIfIndexNeedsForcePuts(index catalog.Index, tableDesc *descpb.TableDescriptor) bool {
+	// If we are doing any of the following mutations, then force puts:
+	//   - delete preserving indexes
+	//   - merging indexes
+	//   - dropping primary indexes
+	if index.Merging() || index.IndexDesc().UseDeletePreservingEncoding ||
+		index.Dropped() && index.IsUnique() && index.GetEncodingType() == descpb.PrimaryIndexEncoding {
+		return true
+	}
+
+	// If we are adding primary indexes with new columns (same key), then
+	// we should also force puts. Attempting conditional puts for UPDATE's
+	// can end badly since we need to compute the expected value with the
+	// new columns.
+	return index.GetEncodingType() == descpb.PrimaryIndexEncoding &&
+		catalog.MakeTableColSet(tableDesc.PrimaryIndex.KeyColumnIDs...).Equals(
+			catalog.MakeTableColSet(index.IndexDesc().KeyColumnIDs...))
 }


### PR DESCRIPTION
Backport 1/1 commits from #98354.

/cc @cockroachdb/release

---

Previously, when primary indexes where swapped for adding new columns, we would use conditional puts for updates. This was problematic because when computing the expected values for the new primary index we didn't include the new column, since its not readable yet. To address this, this patch uses force puts updating new primary indexes as a result of added / dropped columns, since there is no risk of key duplication.

Additionally, extend our testing to cover IUD during ADD/DROP COLUMN.

Fixes: #98130

Release note (bug fix): If an UPDATE was performed during an on-going ADD/DROP column change on a table, the update could incorrectly cause the schema change to fail with a duplicate key error.

Release justification: low risk and resolve a major regression with schema changes