### PR TITLE
kv: deflake TestAbortCountConflictingWrites

### DIFF
--- a/pkg/testutils/storageutils/mocking.go
+++ b/pkg/testutils/storageutils/mocking.go
@@ -96,5 +96,8 @@ func (c *ReplayProtectionFilterWrapper) run(args kvserverbase.FilterArgs) *kvpb.
 	c.Unlock()
 
 	res := future.WaitForResult(args.Ctx)
+	if res.Err != nil {
+		return kvpb.NewError(res.Err)
+	}
 	return shallowCloneErrorWithTxn(res.Val.(*kvpb.Error))
 }


### PR DESCRIPTION
Fixes #96839.

The test was made flaky by 5129578. See the comment in https://github.com/cockroachdb/cockroach/issues/96839#issuecomment-1466557458 for an explanation.

This commit resolves that flakiness.

Release note: None