### PR TITLE
colexecbase: speed up identity cast with selection vector

### DIFF
--- a/pkg/sql/colexec/colexecbase/cast_tmpl.go
+++ b/pkg/sql/colexec/colexecbase/cast_tmpl.go
@@ -310,6 +310,16 @@ type castIdentityOp struct {
 
 var _ colexecop.ClosableOperator = &castIdentityOp{}
 
+// identityOrder is a slice in which every integer equals its ordinal.
+var identityOrder []int
+
+func init() {
+	identityOrder = make([]int, coldata.BatchSize())
+	for i := range identityOrder {
+		identityOrder[i] = i
+	}
+}
+
 func (c *castIdentityOp) Next() coldata.Batch {
 	batch := c.Input.Next()
 	n := batch.Length()
@@ -318,17 +328,19 @@ func (c *castIdentityOp) Next() coldata.Batch {
 	}
 	projVec := batch.ColVec(c.outputIdx)
 	c.allocator.PerformOperation([]coldata.Vec{projVec}, func() {
-		maxIdx := n
+		srcVec := batch.ColVec(c.colIdx)
 		if sel := batch.Selection(); sel != nil {
 			// We don't want to perform the deselection during copying, so we
-			// will copy everything up to (and including) the last selected
-			// element, without the selection vector.
-			maxIdx = sel[n-1] + 1
+			// use a special copy in which we use the identity order but apply
+			// the selection vector.
+			projVec.CopyWithReorderedSource(srcVec, sel[:n], identityOrder)
+		} else {
+			projVec.Copy(coldata.SliceArgs{
+				Src:         srcVec,
+				SrcStartIdx: 0,
+				SrcEndIdx:   n,
+			})
 		}
-		projVec.Copy(coldata.SliceArgs{
-			Src:       batch.ColVec(c.colIdx),
-			SrcEndIdx: maxIdx,
-		})
 	})
 	return batch
 }


### PR DESCRIPTION
Previously, the identity cast operator could be quite inefficient when
the input batch had a selection vector. In particular, this was the case
because we copied all values in `[0, sel[n-1]]` range, including all the
not selected values. This stemmed from the fact that we don't want to
perform the "deselection" on the batch, so we must copy the selected
values into the same positions in the output as they have in the input.
As it turns out we already have a primitive that can be used for this
while only copying the selected values, so this commit updates the
identity cast operator to use that primitive when necessary.

Fixes: #98210.

Release note: None