### PR TITLE
storage: More CheckSSTConflicts fixes

### DIFF
--- a/pkg/kv/kvnemesis/generator.go
+++ b/pkg/kv/kvnemesis/generator.go
@@ -525,12 +525,7 @@ func randAddSSTable(g *generator, rng *rand.Rand) Operation {
 	probTombstone := 0.2             // probability to write a tombstone
 	asWrites := rng.Float64() < 0.2  // IngestAsWrites
 
-	if true {
-		// TODO(erikgrinaker): Disable range keys for now since CheckSSTConflicts
-		// computes incorrect MVCC stats. See:
-		// https://github.com/cockroachdb/cockroach/issues/98473
-		numRangeKeys = 0
-	} else if r := rng.Float64(); r < 0.8 {
+	if r := rng.Float64(); r < 0.8 {
 		// 80% probability of only point keys.
 		numRangeKeys = 0
 	} else if r < 0.9 {


### PR DESCRIPTION
A few additional fixes around CheckSSTConflicts, stats calculations, and Next()ing logic, caught by kvnemesis. Hopefully the last of its kind.

Also re-enable kvnemesis testing for range keys in AddSSTable, reverting https://github.com/cockroachdb/cockroach/pull/98475.

Fixes #94141.
Fixes #98473.
Informs #94876.

Epic: none

Release note: None