### PR TITLE
ui: don't continue polling endpoints that return 403 errors

### DIFF
--- a/pkg/ui/workspaces/db-console/src/redux/localities.spec.ts
+++ b/pkg/ui/workspaces/db-console/src/redux/localities.spec.ts
@@ -30,6 +30,7 @@ function makeStateWithLocalities(localities: LocalityTier[][]) {
         data: nodes,
         inFlight: false,
         valid: true,
+        unauthorized: false,
       },
       liveness: {},
     },

--- a/pkg/ui/workspaces/db-console/src/redux/locations.spec.ts
+++ b/pkg/ui/workspaces/db-console/src/redux/locations.spec.ts
@@ -52,6 +52,7 @@ function makeStateWithLocations(locationData: ILocation[]) {
         }),
         inFlight: false,
         valid: true,
+        unauthorized: false,
       },
     },
   };
@@ -64,6 +65,7 @@ describe("selectLocations", function () {
         locations: {
           inFlight: false,
           valid: false,
+          unauthorized: false,
         },
       },
     };

--- a/pkg/ui/workspaces/db-console/src/redux/nodes.spec.ts
+++ b/pkg/ui/workspaces/db-console/src/redux/nodes.spec.ts
@@ -237,6 +237,7 @@ describe("selectCommissionedNodeStatuses", function () {
           data: nodeStatuses,
           inFlight: false,
           valid: true,
+          unauthorized: false,
         },
         liveness: {
           data: {
@@ -244,6 +245,7 @@ describe("selectCommissionedNodeStatuses", function () {
           },
           inFlight: false,
           valid: true,
+          unauthorized: false,
         },
       },
     };

--- a/pkg/ui/workspaces/db-console/src/views/statements/statements.spec.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/statements/statements.spec.tsx
@@ -645,6 +645,7 @@ function makeStateWithStatementsAndLastReset(
         ),
         inFlight: false,
         valid: true,
+        unauthorized: false,
       };
     }
   }


### PR DESCRIPTION
It was brought to our attention that endpoints such as `v1/settings` would continue to be polled by DB Console even if they returned 403 errors.

If an endpoint returns 403 errors, we should not continue to poll it since the required access is not present for the current user.

This patch updates the polling mechanism to short-circuit the `refresh` process if a 403 error is encountered throughout the lifecycle of the poller.

Release note: none

Fixes: https://github.com/cockroachdb/cockroach/issues/98356