### PR TITLE
ccl/oidcccl: support principal matching on list claims

### DIFF
--- a/pkg/ccl/oidcccl/BUILD.bazel
+++ b/pkg/ccl/oidcccl/BUILD.bazel
@@ -5,6 +5,7 @@ go_library(
     name = "oidcccl",
     srcs = [
         "authentication_oidc.go",
+        "claim_match.go",
         "settings.go",
         "state.go",
     ],

--- a/pkg/ccl/oidcccl/claim_match.go
+++ b/pkg/ccl/oidcccl/claim_match.go
@@ -1,0 +1,97 @@
+// Copyright 2023 The Cockroach Authors.
+//
+// Licensed as a CockroachDB Enterprise file under the Cockroach Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//     https://github.com/cockroachdb/cockroach/blob/master/licenses/CCL.txt
+
+package oidcccl
+
+import (
+	"context"
+	"encoding/json"
+	"regexp"
+	"strings"
+
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/errors"
+)
+
+// extractUsernameFromClaims uses a regex to strip out elements of the value
+// corresponding to the token claim claimKey.
+func extractUsernameFromClaims(
+	ctx context.Context,
+	claims map[string]json.RawMessage,
+	claimKey string,
+	principalRE *regexp.Regexp,
+) (string, error) {
+	var (
+		principal  string
+		principals []string
+	)
+
+	claimKeys := make([]string, len(claims))
+	i := 0
+	for k := range claims {
+		claimKeys[i] = k
+		i++
+	}
+
+	targetClaim, ok := claims[claimKey]
+	if !ok {
+		log.Errorf(
+			ctx, "OIDC: failed to complete authentication: invalid JSON claim key: %s", claimKey,
+		)
+		log.Infof(ctx, "token payload includes the following claims: %s", strings.Join(claimKeys, ", "))
+	}
+
+	if err := json.Unmarshal(targetClaim, &principal); err != nil {
+		// Try parsing assuming the claim value is a list and not a string.
+		if log.V(1) {
+			log.Infof(ctx,
+				"failed parsing claim as string; attempting to parse as a list",
+			)
+		}
+		if err = json.Unmarshal(targetClaim, &principals); err != nil {
+			log.Errorf(ctx,
+				"OIDC: failed to complete authentication: failed to parse value for the claim %s: %v",
+				claimKey, err,
+			)
+			return "", err
+		}
+		if log.V(1) {
+			log.Infof(ctx,
+				"multiple principals in the claim found; selecting first matching principal",
+			)
+		}
+	}
+
+	if len(principals) == 0 {
+		principals = []string{principal}
+	}
+
+	var match []string
+	for _, principal := range principals {
+		match = principalRE.FindStringSubmatch(principal)
+		if len(match) == 2 {
+			log.Infof(ctx,
+				"extracted SQL username %s from the target claim %s", match[1], claimKey,
+			)
+			return match[1], nil
+		}
+	}
+
+	// Error when there is not a match.
+	err := errors.Newf("expected one group in regexp")
+	log.Errorf(ctx, "OIDC: failed to complete authentication: %v", err)
+	if log.V(1) {
+		log.Infof(ctx,
+			"token payload includes the following claims: %s\n"+
+				"check OIDC cluster settings: %s, %s",
+			strings.Join(claimKeys, ", "),
+			OIDCClaimJSONKeySettingName, OIDCPrincipalRegexSettingName,
+		)
+	}
+	return "", err
+}


### PR DESCRIPTION
Previously, matching on ID token claims was not possible if the claim key
specified had a corresponding value that was a list, not a
string. With this change, matching can now occur on claims that are list valued
in order to add login capabilities to DB Console. It is important to note that
this change does NOT offer the user the ability to choose between possible
matches; it simply selects the first match to log the user in.

This change also adds more verbose logging about ID token details.

Epic: none
Fixes: #97301, #97468

Release note (enterprise change): The cluster setting
`server.oidc_authentication.claim_json_key` for DB Console SSO
now accepts list-valued token claims.

Release note (general change): Increasing the logging verbosity
is more helpful with troubleshooting DB Console SSO issues.