### PR TITLE
server: unregister metric registry for in-process tenants

### DIFF
--- a/pkg/server/status/recorder.go
+++ b/pkg/server/status/recorder.go
@@ -189,6 +189,14 @@ func (mr *MetricsRecorder) AddTenantRegistry(tenantID roachpb.TenantID, rec *met
 	mr.mu.tenantRegistries[tenantID] = rec
 }
 
+// RemoveTenantRegistry removes shared-process tenant's registry.
+func (mr *MetricsRecorder) RemoveTenantRegistry(tenantID roachpb.TenantID) {
+	mr.mu.Lock()
+	defer mr.mu.Unlock()
+
+	delete(mr.mu.tenantRegistries, tenantID)
+}
+
 // AddNode adds the Registry from an initialized node, along with its descriptor
 // and start time.
 func (mr *MetricsRecorder) AddNode(

--- a/pkg/server/tenant.go
+++ b/pkg/server/tenant.go
@@ -617,8 +617,9 @@ func (s *SQLServerWrapper) PreStart(ctx context.Context) error {
 	// If there's a higher-level recorder, we link our metrics registry to it.
 	if s.sqlCfg.NodeMetricsRecorder != nil {
 		s.sqlCfg.NodeMetricsRecorder.AddTenantRegistry(s.sqlCfg.TenantID, s.registry)
-		// TODO(aadityasondhi): Unlink the tenant registry if the tenant is stopped.
-		// See #97889.
+		s.stopper.AddCloser(stop.CloserFn(func() {
+			s.sqlCfg.NodeMetricsRecorder.RemoveTenantRegistry(s.sqlCfg.TenantID)
+		}))
 	} else {
 		// Export statistics to graphite, if enabled by configuration. We only do
 		// this if there isn't a higher-level recorder; if there is, that one takes


### PR DESCRIPTION
As a follow up to #97889, this patch adds a function to unregister a tenant's metric registry when it is stopped.

Fixes #98100.

Release note: None