### PR TITLE
sql: add VIEWACTIVITY/VIEWACTIVITREDACTED permission for `ranges_no_leases`

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/crdb_internal_tenant
+++ b/pkg/ccl/logictestccl/testdata/logic_test/crdb_internal_tenant
@@ -453,7 +453,7 @@ select crdb_internal.get_vmodule()
 query error pq: only users with the admin role are allowed to access the node runtime information
 select * from crdb_internal.node_runtime_info
 
-query error pq: only users with the ZONECONFIG privilege or the admin role can read crdb_internal.ranges_no_leases
+query error pq: only users with the VIEWACTIVITY or VIEWACTIVITYREDACTED or ZONECONFIG privilege or the admin role can read crdb_internal.ranges_no_leases
 select * from crdb_internal.ranges
 
 query error pq: only users with the admin role are allowed to read crdb_internal.gossip_nodes

--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -3966,6 +3966,11 @@ CREATE TABLE crdb_internal.ranges_no_leases (
 			if hasAdmin {
 				return true, nil
 			}
+			viewActOrViewActRedact, err := p.HasViewActivityOrViewActivityRedactedRole(ctx)
+			// Return if we have permission or encountered an error.
+			if viewActOrViewActRedact || err != nil {
+				return viewActOrViewActRedact, err
+			}
 			return p.HasPrivilege(ctx, desc, privilege.ZONECONFIG, p.User())
 		}
 
@@ -3978,9 +3983,9 @@ CREATE TABLE crdb_internal.ranges_no_leases (
 				break
 			}
 		}
-		// if the user has no ZONECONFIG privilege on any table/schema/database
+		// if the user has no VIEWACTIVITY or VIEWACTIVITYREDACTED or ZONECONFIG privilege on any table/schema/database
 		if !hasPermission {
-			return nil, nil, pgerror.Newf(pgcode.InsufficientPrivilege, "only users with the ZONECONFIG privilege or the admin role can read crdb_internal.ranges_no_leases")
+			return nil, nil, pgerror.Newf(pgcode.InsufficientPrivilege, "only users with the VIEWACTIVITY or VIEWACTIVITYREDACTED or ZONECONFIG privilege or the admin role can read crdb_internal.ranges_no_leases")
 		}
 
 		execCfg := p.ExecCfg()

--- a/pkg/sql/delegate/show_range_for_row.go
+++ b/pkg/sql/delegate/show_range_for_row.go
@@ -15,8 +15,6 @@ import (
 	"fmt"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/cat"
-	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
-	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqltelemetry"
@@ -29,7 +27,8 @@ func (d *delegator) delegateShowRangeForRow(n *tree.ShowRangeForRow) (tree.State
 	if err != nil {
 		return nil, err
 	}
-	if err := checkPrivilegesForShowRanges(d, idx.Table()); err != nil {
+	// Basic requirement is SELECT privileges
+	if err = d.catalog.CheckPrivilege(d.ctx, idx.Table(), privilege.SELECT); err != nil {
 		return nil, err
 	}
 	if idx.Table().IsVirtualTable() {
@@ -95,23 +94,4 @@ WHERE (r.start_key <= crdb_internal.encode_key(%[1]d, %[2]d, %[3]s))
 			idxSpanEnd,
 		),
 	)
-}
-
-func checkPrivilegesForShowRanges(d *delegator, table cat.Table) error {
-	// Basic requirement is SELECT priviliges
-	if err := d.catalog.CheckPrivilege(d.ctx, table, privilege.SELECT); err != nil {
-		return err
-	}
-	hasAdmin, err := d.catalog.HasAdminRole(d.ctx)
-	if err != nil {
-		return err
-	}
-	// User needs to either have admin access or have the correct ZONECONFIG privilege
-	if hasAdmin {
-		return nil
-	}
-	if err := d.catalog.CheckPrivilege(d.ctx, table, privilege.ZONECONFIG); err != nil {
-		return pgerror.Wrapf(err, pgcode.InsufficientPrivilege, "only users with the ZONECONFIG privilege or the admin role can use SHOW RANGES on %s", table.Name())
-	}
-	return nil
 }

--- a/pkg/sql/logictest/testdata/logic_test/crdb_internal
+++ b/pkg/sql/logictest/testdata/logic_test/crdb_internal
@@ -678,10 +678,10 @@ select crdb_internal.get_vmodule()
 query error pq: only users with the admin role are allowed to access the node runtime information
 select * from crdb_internal.node_runtime_info
 
-query error pq: only users with the ZONECONFIG privilege or the admin role can read crdb_internal.ranges_no_leases
+query error pq: only users with the VIEWACTIVITY or VIEWACTIVITYREDACTED or ZONECONFIG privilege or the admin role can read crdb_internal.ranges_no_leases
 select * from crdb_internal.ranges
 
-query error pq: only users with the ZONECONFIG privilege or the admin role can read crdb_internal.ranges_no_leases
+query error pq: only users with the VIEWACTIVITY or VIEWACTIVITYREDACTED or ZONECONFIG privilege or the admin role can read crdb_internal.ranges_no_leases
 SHOW RANGES FROM TABLE foo
 
 query error pq: only users with the admin role are allowed to read crdb_internal.gossip_nodes

--- a/pkg/sql/logictest/testdata/logic_test/ranges
+++ b/pkg/sql/logictest/testdata/logic_test/ranges
@@ -558,10 +558,10 @@ GRANT SELECT ON TABLE t to testuser
 
 user testuser
 
-statement error only users with the ZONECONFIG privilege or the admin role can read crdb_internal.ranges_no_leases
+statement error only users with the VIEWACTIVITY or VIEWACTIVITYREDACTED or ZONECONFIG privilege or the admin role can read crdb_internal.ranges_no_leases
 SHOW RANGES FROM TABLE t
 
-statement error only users with the ZONECONFIG privilege or the admin role can read crdb_internal.ranges_no_leases
+statement error only users with the VIEWACTIVITY or VIEWACTIVITYREDACTED or ZONECONFIG privilege or the admin role can read crdb_internal.ranges_no_leases
 SHOW RANGES FROM INDEX t@idx
 
 user root
@@ -576,6 +576,57 @@ SHOW RANGES FROM TABLE t
 
 statement ok
 SHOW RANGES FROM INDEX t@idx
+
+# Test permissions for showing ranges with VIEWACTIVITY privilege
+
+user root
+
+# Revoke ZONECONFIG, user should not have access to the table.
+statement ok
+REVOKE ZONECONFIG ON TABLE t FROM testuser
+
+user testuser
+
+statement error only users with the VIEWACTIVITY or VIEWACTIVITYREDACTED or ZONECONFIG privilege or the admin role can read crdb_internal.ranges_no_leases
+SHOW RANGES FROM TABLE t
+
+statement error only users with the VIEWACTIVITY or VIEWACTIVITYREDACTED or ZONECONFIG privilege or the admin role can read crdb_internal.ranges_no_leases
+SHOW RANGES FROM INDEX t@idx
+
+user root
+
+# Check user has access with VIEWACTIVITY
+statement ok
+ALTER ROLE testuser WITH VIEWACTIVITY
+
+user testuser
+
+statement ok
+SHOW RANGES FROM TABLE t
+
+statement ok
+SHOW RANGES FROM INDEX t@idx
+
+user root
+
+# Remove VIEWACTIVITY
+statement ok
+ALTER ROLE testuser with NOVIEWACTIVITY
+
+# Check user has access with VIEWACTIVITYREDACTED
+statement ok
+ALTER ROLE testuser with VIEWACTIVITYREDACTED
+
+user testuser
+
+statement ok
+SHOW RANGES FROM TABLE t
+
+statement ok
+SHOW RANGES FROM INDEX t@idx
+
+# Go back to root
+user root
 
 # This is a regression test for an issue in the vectorization of
 # crdb_internal.range_stats whereby NULLs in the input were not


### PR DESCRIPTION
Fixes: #98514

This change adds the `VIEWACTIVITY` and `VIEWACTIVITYREDACTED` permissions access to `ranges_no_leases`. This allows users to view range data, necessary to use popular console pages:
- databases page
- database details page
- database table page

Prior to this change, users with `VIEWACTIVITY`/`VIEWACTIVITYREDACTED` would not be able to view these pages (would show error notification).

Release note (bug fix): Allow users with
`VIEWACTIVITY`/`VIEWACTIVITYREDACTED` permissions to access `ranges_no_leases` table, necessary to view important console pages (databases, database details, and database table pages).