### PR TITLE
kvserver: deflake learner joint cfg relocate range

### DIFF
--- a/pkg/kv/kvserver/replica.go
+++ b/pkg/kv/kvserver/replica.go
@@ -2312,6 +2312,12 @@ func (r *Replica) GetLoadStatsForTesting() *load.ReplicaLoad {
 	return r.loadStats
 }
 
+// HasOutstandingLearnerSnapshotInFlightForTesting is for use only by tests to
+// gather whether there are in-flight snapshots to learner replcas.
+func (r *Replica) HasOutstandingLearnerSnapshotInFlightForTesting() bool {
+	return r.hasOutstandingLearnerSnapshotInFlight()
+}
+
 // ReadProtectedTimestampsForTesting is for use only by tests to read and update
 // the Replicas' cached protected timestamp state.
 func (r *Replica) ReadProtectedTimestampsForTesting(ctx context.Context) (err error) {


### PR DESCRIPTION
Previously, in `TestLearnerOrJointConfigAdminRelocateRange` it was possible for there to be an in-flight snapshot towards a learner, prior to sending `AdminRelocateRange` command. When this occurred, the test would fail as `AdminRelocateRange` returns an error when finding any in-flight snapshots to learners. This situation occurred infrequently, causing the test to flake.

This commit updates the `TestLearnerOrJointConfigAdminRelocateRange` test to first assert that there are the expected number of learners, then assert that there are no in-flight snapshots towards learners before beginning the main testing logic. The test is now unskipped.

```
dev test pkg/kv/kvserver \
      -f TestLearnerOrJointConfigAdminRelocateRange \
      -v --stress
...
5652 runs so far, 0 failures, over 12m30s
```

Resolves: #95500

Release note: None