### PR TITLE
logictest: remove flaky mixed version assertions

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/mixed_version_external_connections_owner_id
+++ b/pkg/sql/logictest/testdata/logic_test/mixed_version_external_connections_owner_id
@@ -27,28 +27,3 @@ SELECT connection_name, owner FROM system.external_connections
 ----
 connection1  t
 connection2  t
-
-# Wait for migrations to run and verify that owner_id column is now present.
-# The sleep directive is needed to reduce flakiness.
-
-upgrade 0
-
-upgrade 2
-
-sleep 10s
-
-query B retry
-SELECT crdb_internal.is_at_least_version('1000022.2-76')
-----
-true
-
-query O
-SELECT user_id FROM system.users WHERE username = 't'
-----
-101
-
-query TTO
-SELECT connection_name, owner, owner_id FROM system.external_connections
-----
-connection1  t  101
-connection2  t  101

--- a/pkg/sql/logictest/testdata/logic_test/mixed_version_role_members_user_ids
+++ b/pkg/sql/logictest/testdata/logic_test/mixed_version_role_members_user_ids
@@ -28,18 +28,6 @@ CREATE USER testuser2
 statement ok
 CREATE USER testuser3
 
-query TO
-SELECT username, user_id FROM system.users
-----
-root       1
-admin      2
-testuser   100
-testuser1  101
-testuser2  102
-testuser3  103
-
-# Create a role membership that will be checked again later on 23.1.
-
 query TTB
 SELECT * FROM system.role_members
 ----
@@ -108,23 +96,3 @@ query B nodeidx=2
 SELECT crdb_internal.node_executable_version() SIMILAR TO '1000022.2-%'
 ----
 true
-
-# Wait for migrations to run.
-# The sleep directive is needed to reduce flakiness.
-
-sleep 10s
-
-query B retry
-SELECT crdb_internal.is_at_least_version('1000022.2-14')
-----
-true
-
-# Verify that ID columns are now present.
-
-query TTBOO
-SELECT * FROM system.role_members
-----
-admin      root       true   2    1
-testuser1  testuser2  false  101  102
-testuser1  testuser3  false  101  103
-testuser2  testuser3  false  102  103


### PR DESCRIPTION
fixes #98424

These tests don't need to be asserting that the migrations run successfully. That is already covered by both unit tests and the version upgrade roachtest.

The focus of these tests instead should be on catching bugs in the mixed version state; and the non-deleted code still does that.

The sources of flakiness were:
- Took a long time to run migrations.
- User IDs are not guaranteed to be sequential.

Release note: None