### PR TITLE
spanconfig: export metrics for protected timestamp records

### DIFF
--- a/monitoring/grafana-dashboards/queues.json
+++ b/monitoring/grafana-dashboards/queues.json
@@ -858,7 +858,7 @@
       "timeFrom": null,
       "timeRegions": [],
       "timeShift": null,
-      "title": "GC Queue",
+      "title": "MVCC GC Queue",
       "tooltip": {
         "shared": true,
         "sort": 0,

--- a/monitoring/splunk-dashboard/queues.xml
+++ b/monitoring/splunk-dashboard/queues.xml
@@ -241,7 +241,7 @@ where index=$index_name$  span=10s</query>
   </row>
   <row>
     <panel>
-      <title>GC Queue</title>
+      <title>MVCC GC Queue</title>
       <chart>
         <search>
           <query>| mstats rate_sum(queue_gc_process_success) as "Successful Actions / sec",

--- a/pkg/cmd/roachprod/grafana/configs/queues.json
+++ b/pkg/cmd/roachprod/grafana/configs/queues.json
@@ -858,7 +858,7 @@
       "timeFrom": null,
       "timeRegions": [],
       "timeShift": null,
-      "title": "GC Queue",
+      "title": "MVCC GC Queue",
       "tooltip": {
         "shared": true,
         "sort": 0,

--- a/pkg/spanconfig/spanconfigkvsubscriber/BUILD.bazel
+++ b/pkg/spanconfig/spanconfigkvsubscriber/BUILD.bazel
@@ -17,6 +17,7 @@ go_library(
         "//pkg/kv/kvclient/rangefeed/rangefeedcache",
         "//pkg/kv/kvpb",
         "//pkg/roachpb",
+        "//pkg/settings",
         "//pkg/settings/cluster",
         "//pkg/spanconfig",
         "//pkg/spanconfig/spanconfigstore",

--- a/pkg/ts/catalog/chart_catalog.go
+++ b/pkg/ts/catalog/chart_catalog.go
@@ -817,8 +817,17 @@ var charts = []sectionDescription{
 		},
 		Charts: []chartDescription{
 			{
-				Title:   "KVSubscriber",
-				Metrics: []string{"spanconfig.kvsubscriber.update_behind_nanos"},
+				Title: "KVSubscriber Lag Metrics",
+				Metrics: []string{
+					"spanconfig.kvsubscriber.oldest_protected_record_nanos",
+					"spanconfig.kvsubscriber.update_behind_nanos",
+				},
+			},
+			{
+				Title: "KVSubscriber Protected Record Count",
+				Metrics: []string{
+					"spanconfig.kvsubscriber.protected_record_count",
+				},
 			},
 		},
 	},

--- a/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/queues.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/queues.tsx
@@ -14,10 +14,10 @@ import { LineGraph } from "src/views/cluster/components/linegraph";
 import { Metric, Axis } from "src/views/shared/components/metricQuery";
 import { AxisUnits } from "@cockroachlabs/cluster-ui";
 
-import { GraphDashboardProps } from "./dashboardUtils";
+import { GraphDashboardProps, nodeDisplayName } from "./dashboardUtils";
 
 export default function (props: GraphDashboardProps) {
-  const { storeSources } = props;
+  const { nodeIDs, nodeSources, storeSources, nodeDisplayNameByID } = props;
 
   return [
     <LineGraph title="Queue Processing Failures" sources={storeSources}>
@@ -212,21 +212,6 @@ export default function (props: GraphDashboardProps) {
       </Axis>
     </LineGraph>,
 
-    <LineGraph title="GC Queue" sources={storeSources}>
-      <Axis units={AxisUnits.Count} label="actions">
-        <Metric
-          name="cr.store.queue.gc.process.success"
-          title="Successful Actions / sec"
-          nonNegativeRate
-        />
-        <Metric
-          name="cr.store.queue.gc.pending"
-          title="Pending Actions"
-          downsampleMax
-        />
-      </Axis>
-    </LineGraph>,
-
     <LineGraph title="Raft Log Queue" sources={storeSources}>
       <Axis units={AxisUnits.Count} label="actions">
         <Metric
@@ -284,6 +269,41 @@ export default function (props: GraphDashboardProps) {
           title="Pending Actions"
           downsampleMax
         />
+      </Axis>
+    </LineGraph>,
+
+    <LineGraph title="MVCC GC Queue" sources={storeSources}>
+      <Axis units={AxisUnits.Count} label="actions">
+        <Metric
+          name="cr.store.queue.gc.process.success"
+          title="Successful Actions / sec"
+          nonNegativeRate
+        />
+        <Metric
+          name="cr.store.queue.gc.pending"
+          title="Pending Actions"
+          downsampleMax
+        />
+      </Axis>
+    </LineGraph>,
+
+    <LineGraph
+      title="Protected Timestamp Records"
+      sources={nodeSources}
+      tooltip={`Number of protected timestamp records (used by backups, changefeeds, etc. to prevent MVCC GC)`}
+    >
+      <Axis units={AxisUnits.Count} label="Records">
+        {nodeIDs.map(nid => (
+          <>
+            <Metric
+              key={nid}
+              name="cr.node.spanconfig.kvsubscriber.protected_record_count"
+              title={nodeDisplayName(nodeDisplayNameByID, nid)}
+              sources={[nid]}
+              downsampleMax
+            />
+          </>
+        ))}
       </Axis>
     </LineGraph>,
   ];


### PR DESCRIPTION
This commit introduces two new metrics, to help understand the effects of protected timestamps:
- `spanconfig.kvsubscriber.protected_record_count`, which exports the number of protected timestamp records as seen by KV.
- `spanconfig.kvsubscriber.oldest_protected_record_nanos`, which exports difference between the current time and the oldest protected timestamp. Sudden drops indicate a record being released; an ever-increasing duration would indicate the oldest record sticking around and preventing GC if > the configured GC TTL.

Fixes #98532 (as a backportable alternative to a0d6c190 for 22.1, 22.2).

Release note: None