### PR TITLE
storage: remove MVCCIterator.Key method

### DIFF
--- a/pkg/ccl/backupccl/full_cluster_backup_restore_test.go
+++ b/pkg/ccl/backupccl/full_cluster_backup_restore_test.go
@@ -220,7 +220,7 @@ CREATE TABLE data2.foo (a int);
 		it.SeekGE(storage.MVCCKey{Key: startKey})
 		hasKey, err := it.Valid()
 		require.NoError(t, err)
-		require.False(t, hasKey, "did not expect to find a key, found %s", it.Key())
+		require.False(t, hasKey, "did not expect to find a key, found %s", it.UnsafeKey())
 	})
 
 	// Allow the restore to make progress after we've checked the pre-restore

--- a/pkg/ccl/backupccl/restore_data_processor_test.go
+++ b/pkg/ccl/backupccl/restore_data_processor_test.go
@@ -127,7 +127,7 @@ func slurpSSTablesLatestKey(
 		if err != nil {
 			t.Fatal(err)
 		}
-		kvs = append(kvs, storage.MVCCKeyValue{Key: it.Key(), Value: val.Value.RawBytes})
+		kvs = append(kvs, storage.MVCCKeyValue{Key: it.UnsafeKey().Clone(), Value: val.Value.RawBytes})
 	}
 	return kvs
 }

--- a/pkg/ccl/streamingccl/replicationutils/utils.go
+++ b/pkg/ccl/streamingccl/replicationutils/utils.go
@@ -76,7 +76,7 @@ func ScanSST(
 			return err
 		}
 		if err = mvccKeyValOp(storage.MVCCKeyValue{
-			Key:   pointIter.Key(),
+			Key:   pointIter.UnsafeKey().Clone(),
 			Value: v,
 		}); err != nil {
 			return err

--- a/pkg/ccl/streamingccl/streamingest/replication_random_client_test.go
+++ b/pkg/ccl/streamingccl/streamingest/replication_random_client_test.go
@@ -329,18 +329,18 @@ func assertExactlyEqualKVs(
 			}
 			break
 		}
-		if maxKVTimestampSeen.Less(it.Key().Timestamp) {
-			maxKVTimestampSeen = it.Key().Timestamp
+		if maxKVTimestampSeen.Less(it.UnsafeKey().Timestamp) {
+			maxKVTimestampSeen = it.UnsafeKey().Timestamp
 		}
-		newKey := (prevKey != nil && !it.Key().Key.Equal(prevKey)) || prevKey == nil
-		prevKey = it.Key().Key
+		newKey := (prevKey != nil && !it.UnsafeKey().Key.Equal(prevKey)) || prevKey == nil
+		prevKey = it.UnsafeKey().Clone().Key
 
 		if newKey {
 			// All value ts should have been drained at this point, otherwise there is
 			// a mismatch between the streamed and ingested data.
 			require.Equal(t, 0, len(valueTimestampTuples))
 			valueTimestampTuples, err = streamValidator.getValuesForKeyBelowTimestamp(
-				string(it.Key().Key), frontierTimestamp)
+				string(it.UnsafeKey().Key), frontierTimestamp)
 			require.NoError(t, err)
 		}
 
@@ -357,10 +357,10 @@ func assertExactlyEqualKVs(
 		v, err := it.Value()
 		require.NoError(t, err)
 		require.Equal(t, roachpb.KeyValue{
-			Key: it.Key().Key,
+			Key: it.UnsafeKey().Key,
 			Value: roachpb.Value{
 				RawBytes:  v,
-				Timestamp: it.Key().Timestamp,
+				Timestamp: it.UnsafeKey().Timestamp,
 			},
 		}, latestVersionInChain)
 		matchingKVs++

--- a/pkg/kv/kvnemesis/validator.go
+++ b/pkg/kv/kvnemesis/validator.go
@@ -631,7 +631,7 @@ func (v *validator) processOp(op Operation) {
 					}
 				}
 
-				key := iter.Key().Key
+				key := iter.UnsafeKey().Clone().Key
 				rawValue, err := iter.Value()
 				if err != nil {
 					return err

--- a/pkg/kv/kvnemesis/watcher.go
+++ b/pkg/kv/kvnemesis/watcher.go
@@ -346,7 +346,7 @@ func (w *Watcher) handleSSTable(ctx context.Context, data []byte) error {
 		}
 
 		// Add point keys.
-		key := iter.Key()
+		key := iter.UnsafeKey().Clone()
 		rawValue, err := iter.Value()
 		if err != nil {
 			return err

--- a/pkg/kv/kvserver/batch_spanset_test.go
+++ b/pkg/kv/kvserver/batch_spanset_test.go
@@ -171,20 +171,20 @@ func TestSpanSetBatchBoundaries(t *testing.T) {
 		if ok, err := iter.Valid(); !ok || err != nil {
 			t.Fatalf("expected valid iterator, err=%v", err)
 		}
-		if !reflect.DeepEqual(iter.Key(), insideKey) {
-			t.Fatalf("expected key %s, got %s", insideKey, iter.Key())
+		if !reflect.DeepEqual(iter.UnsafeKey(), insideKey) {
+			t.Fatalf("expected key %s, got %s", insideKey, iter.UnsafeKey())
 		}
 		iter.Next()
 		if ok, err := iter.Valid(); !ok || err != nil {
 			t.Fatalf("expected valid iterator, err=%v", err)
 		}
-		if !reflect.DeepEqual(iter.Key(), insideKey2) {
-			t.Fatalf("expected key %s, got %s", insideKey2, iter.Key())
+		if !reflect.DeepEqual(iter.UnsafeKey(), insideKey2) {
+			t.Fatalf("expected key %s, got %s", insideKey2, iter.UnsafeKey())
 		}
 		// Scan out of bounds.
 		iter.Next()
 		if ok, err := iter.Valid(); ok {
-			t.Fatalf("expected invalid iterator; found valid at key %s", iter.Key())
+			t.Fatalf("expected invalid iterator; found valid at key %s", iter.UnsafeKey())
 		} else if err != nil {
 			// Scanning out of bounds sets Valid() to false but is not an error.
 			t.Errorf("unexpected error on iterator: %+v", err)
@@ -210,20 +210,20 @@ func TestSpanSetBatchBoundaries(t *testing.T) {
 		if ok, err := iter.Valid(); !ok || err != nil {
 			t.Fatalf("expected valid iterator, err=%v", err)
 		}
-		if !reflect.DeepEqual(iter.Key(), insideKey2) {
-			t.Fatalf("expected key %s, got %s", insideKey2, iter.Key())
+		if !reflect.DeepEqual(iter.UnsafeKey(), insideKey2) {
+			t.Fatalf("expected key %s, got %s", insideKey2, iter.UnsafeKey())
 		}
 		iter.Prev()
 		if ok, err := iter.Valid(); !ok || err != nil {
 			t.Fatalf("expected valid iterator, err=%v", err)
 		}
-		if !reflect.DeepEqual(iter.Key(), insideKey) {
-			t.Fatalf("expected key %s, got %s", insideKey, iter.Key())
+		if !reflect.DeepEqual(iter.UnsafeKey(), insideKey) {
+			t.Fatalf("expected key %s, got %s", insideKey, iter.UnsafeKey())
 		}
 		// Scan out of bounds.
 		iter.Prev()
 		if ok, err := iter.Valid(); ok {
-			t.Fatalf("expected invalid iterator; found valid at key %s", iter.Key())
+			t.Fatalf("expected invalid iterator; found valid at key %s", iter.UnsafeKey())
 		} else if err != nil {
 			t.Errorf("unexpected error on iterator: %+v", err)
 		}
@@ -236,7 +236,7 @@ func TestSpanSetBatchBoundaries(t *testing.T) {
 		// SeekLT to the lower bound is invalid.
 		iter.SeekLT(insideKey)
 		if ok, err := iter.Valid(); ok {
-			t.Fatalf("expected invalid iterator; found valid at key %s", iter.Key())
+			t.Fatalf("expected invalid iterator; found valid at key %s", iter.UnsafeKey())
 		} else if !isReadSpanErr(err) {
 			t.Fatalf("SeekLT: unexpected error %v", err)
 		}
@@ -390,16 +390,16 @@ func TestSpanSetIteratorTimestamps(t *testing.T) {
 		if ok, err := iter.Valid(); !ok {
 			t.Fatalf("expected valid iterator, err=%v", err)
 		}
-		if !reflect.DeepEqual(iter.Key(), k1) {
-			t.Fatalf("expected key %s, got %s", k1, iter.Key())
+		if !reflect.DeepEqual(iter.UnsafeKey(), k1) {
+			t.Fatalf("expected key %s, got %s", k1, iter.UnsafeKey())
 		}
 
 		iter.Next()
 		if ok, err := iter.Valid(); !ok {
 			t.Fatalf("expected valid iterator, err=%v", err)
 		}
-		if !reflect.DeepEqual(iter.Key(), k2) {
-			t.Fatalf("expected key %s, got %s", k2, iter.Key())
+		if !reflect.DeepEqual(iter.UnsafeKey(), k2) {
+			t.Fatalf("expected key %s, got %s", k2, iter.UnsafeKey())
 		}
 	}()
 
@@ -410,15 +410,15 @@ func TestSpanSetIteratorTimestamps(t *testing.T) {
 
 		iter.SeekGE(k1)
 		if ok, _ := iter.Valid(); ok {
-			t.Fatalf("expected invalid iterator; found valid at key %s", iter.Key())
+			t.Fatalf("expected invalid iterator; found valid at key %s", iter.UnsafeKey())
 		}
 
 		iter.SeekGE(k2)
 		if ok, err := iter.Valid(); !ok {
 			t.Fatalf("expected valid iterator, err=%v", err)
 		}
-		if !reflect.DeepEqual(iter.Key(), k2) {
-			t.Fatalf("expected key %s, got %s", k2, iter.Key())
+		if !reflect.DeepEqual(iter.UnsafeKey(), k2) {
+			t.Fatalf("expected key %s, got %s", k2, iter.UnsafeKey())
 		}
 	}()
 
@@ -430,12 +430,12 @@ func TestSpanSetIteratorTimestamps(t *testing.T) {
 
 		iter.SeekGE(k1)
 		if ok, _ := iter.Valid(); ok {
-			t.Fatalf("expected invalid iterator; found valid at key %s", iter.Key())
+			t.Fatalf("expected invalid iterator; found valid at key %s", iter.UnsafeKey())
 		}
 
 		iter.SeekGE(k2)
 		if ok, _ := iter.Valid(); ok {
-			t.Fatalf("expected invalid iterator; found valid at key %s", iter.Key())
+			t.Fatalf("expected invalid iterator; found valid at key %s", iter.UnsafeKey())
 		}
 	}
 

--- a/pkg/kv/kvserver/batcheval/cmd_add_sstable.go
+++ b/pkg/kv/kvserver/batcheval/cmd_add_sstable.go
@@ -388,7 +388,7 @@ func EvalAddSSTable(
 		if ok, err := existingIter.Valid(); err != nil {
 			return result.Result{}, errors.Wrap(err, "error while searching for non-empty span start")
 		} else if ok {
-			reply.FollowingLikelyNonEmptySpanStart = existingIter.Key().Key
+			reply.FollowingLikelyNonEmptySpanStart = existingIter.UnsafeKey().Key.Clone()
 		}
 	}
 

--- a/pkg/kv/kvserver/client_split_test.go
+++ b/pkg/kv/kvserver/client_split_test.go
@@ -393,9 +393,9 @@ func TestStoreRangeSplitIntents(t *testing.T) {
 			break
 		}
 
-		if bytes.HasPrefix([]byte(iter.Key().Key), txnPrefix(roachpb.KeyMin)) ||
-			bytes.HasPrefix([]byte(iter.Key().Key), txnPrefix(splitKey)) {
-			t.Errorf("unexpected system key: %s; txn record should have been cleaned up", iter.Key())
+		if bytes.HasPrefix([]byte(iter.UnsafeKey().Key), txnPrefix(roachpb.KeyMin)) ||
+			bytes.HasPrefix([]byte(iter.UnsafeKey().Key), txnPrefix(splitKey)) {
+			t.Errorf("unexpected system key: %s; txn record should have been cleaned up", iter.UnsafeKey())
 		}
 	}
 }

--- a/pkg/kv/kvserver/gc/gc_old_test.go
+++ b/pkg/kv/kvserver/gc/gc_old_test.go
@@ -187,13 +187,13 @@ func runGCOld(
 			// Stop iterating if our context has expired.
 			return Info{}, err
 		}
-		iterKey := iter.Key()
+		iterKey := iter.UnsafeKey().Clone()
 		if !iterKey.IsValue() || !iterKey.Key.Equal(expBaseKey) {
 			// Moving to the next key (& values).
 			processKeysAndValues()
 			expBaseKey = iterKey.Key
 			if !iterKey.IsValue() {
-				keys = []storage.MVCCKey{iter.Key()}
+				keys = []storage.MVCCKey{iter.UnsafeKey().Clone()}
 				v, err := iter.Value()
 				if err != nil {
 					return Info{}, err
@@ -212,7 +212,7 @@ func runGCOld(
 		if err != nil {
 			return Info{}, err
 		}
-		keys = append(keys, iter.Key())
+		keys = append(keys, iter.UnsafeKey().Clone())
 		vals = append(vals, v)
 	}
 	// Handle last collected set of keys/vals.

--- a/pkg/kv/kvserver/gc/gc_random_test.go
+++ b/pkg/kv/kvserver/gc/gc_random_test.go
@@ -495,7 +495,7 @@ func getExpectationsGenerator(
 				}
 				p, r := it.HasPointAndRange()
 				if p {
-					k := it.Key()
+					k := it.UnsafeKey().Clone()
 					v, err := it.Value()
 					require.NoError(t, err)
 					if len(baseKey) == 0 {

--- a/pkg/kv/kvserver/gc/gc_test.go
+++ b/pkg/kv/kvserver/gc/gc_test.go
@@ -1534,7 +1534,7 @@ func engineData(t *testing.T, r storage.Reader, desc roachpb.RangeDescriptor) []
 				v = prefix + string(b)
 			}
 			result = append(result, tableCell{
-				key:   it.Key(),
+				key:   it.UnsafeKey().Clone(),
 				value: v,
 			})
 			prefix = ""

--- a/pkg/kv/kvserver/loqrecovery/record.go
+++ b/pkg/kv/kvserver/loqrecovery/record.go
@@ -97,7 +97,7 @@ func RegisterOfflineRecoveryEvents(
 		record := loqrecoverypb.ReplicaRecoveryRecord{}
 		if err := iter.ValueProto(&record); err != nil {
 			processingErrors = errors.CombineErrors(processingErrors, errors.Wrapf(err,
-				"failed to deserialize replica recovery event at key %s", iter.Key()))
+				"failed to deserialize replica recovery event at key %s", iter.UnsafeKey()))
 			continue
 		}
 		removeEvent, err := registerEvent(ctx, record)
@@ -109,7 +109,7 @@ func RegisterOfflineRecoveryEvents(
 		if removeEvent {
 			if err := readWriter.ClearUnversioned(iter.UnsafeKey().Key); err != nil {
 				processingErrors = errors.CombineErrors(processingErrors, errors.Wrapf(
-					err, "failed to delete replica recovery record at key %s", iter.Key()))
+					err, "failed to delete replica recovery record at key %s", iter.UnsafeKey()))
 				continue
 			}
 		}

--- a/pkg/kv/kvserver/raft_log_truncator_test.go
+++ b/pkg/kv/kvserver/raft_log_truncator_test.go
@@ -208,7 +208,7 @@ func (r *replicaTruncatorTest) printEngine(t *testing.T, eng storage.Engine) {
 	fmt.Fprintf(r.buf, "log entries:")
 	printPrefixStr := ""
 	for valid {
-		key := iter.Key()
+		key := iter.UnsafeKey()
 		_, index, err := encoding.DecodeUint64Ascending(key.Key[len(prefix):])
 		require.NoError(t, err)
 		fmt.Fprintf(r.buf, "%s %d", printPrefixStr, index)

--- a/pkg/kv/kvserver/rditer/replica_data_iter.go
+++ b/pkg/kv/kvserver/rditer/replica_data_iter.go
@@ -256,11 +256,6 @@ func (ri *ReplicaMVCCDataIterator) Valid() (bool, error) {
 	return true, nil
 }
 
-// Key returns the current key. Only called in tests.
-func (ri *ReplicaMVCCDataIterator) Key() storage.MVCCKey {
-	return ri.it.Key()
-}
-
 // Value returns the current value. Only called in tests.
 func (ri *ReplicaMVCCDataIterator) Value() ([]byte, error) {
 	return ri.it.Value()

--- a/pkg/kv/kvserver/rditer/replica_data_iter_test.go
+++ b/pkg/kv/kvserver/rditer/replica_data_iter_test.go
@@ -349,9 +349,9 @@ func TestIterateMVCCReplicaKeySpansSpansSet(t *testing.T) {
 				p, r := iter.HasPointAndRange()
 				if p {
 					if !reverse {
-						actualKeys = append(actualKeys, iter.Key())
+						actualKeys = append(actualKeys, iter.UnsafeKey().Clone())
 					} else {
-						actualKeys = append([]storage.MVCCKey{iter.Key()}, actualKeys...)
+						actualKeys = append([]storage.MVCCKey{iter.UnsafeKey().Clone()}, actualKeys...)
 					}
 				}
 				if r {

--- a/pkg/kv/kvserver/replica_evaluate.go
+++ b/pkg/kv/kvserver/replica_evaluate.go
@@ -115,8 +115,8 @@ func optimizePuts(
 		// running without the optimization?
 		log.Errorf(context.TODO(), "Seek returned error; disabling blind-put optimization: %+v", err)
 		return origReqs
-	} else if ok && bytes.Compare(iter.Key().Key, maxKey) <= 0 {
-		iterKey = iter.Key().Key
+	} else if ok && bytes.Compare(iter.UnsafeKey().Key, maxKey) <= 0 {
+		iterKey = iter.UnsafeKey().Key.Clone()
 	}
 	// Set the prefix of the run which is being written to virgin
 	// keyspace to "blindly" put values.

--- a/pkg/kv/kvserver/spanset/batch.go
+++ b/pkg/kv/kvserver/spanset/batch.go
@@ -159,11 +159,6 @@ func (i *MVCCIterator) checkAllowedValidPos(span roachpb.Span, errIfDisallowed b
 	}
 }
 
-// Key is part of the storage.MVCCIterator interface.
-func (i *MVCCIterator) Key() storage.MVCCKey {
-	return i.i.Key()
-}
-
 // Value is part of the storage.MVCCIterator interface.
 func (i *MVCCIterator) Value() ([]byte, error) {
 	return i.i.Value()

--- a/pkg/sql/catalog/lease/kv_writer_test.go
+++ b/pkg/sql/catalog/lease/kv_writer_test.go
@@ -157,7 +157,7 @@ func getRawHistoryKVs(
 				} else if !ok {
 					return nil
 				}
-				k := it.Key()
+				k := it.UnsafeKey().Clone()
 				suffix, _, err := codec.DecodeTablePrefix(k.Key)
 				require.NoError(t, err)
 				v, err := it.Value()

--- a/pkg/sql/row/fetcher_mvcc_test.go
+++ b/pkg/sql/row/fetcher_mvcc_test.go
@@ -63,7 +63,7 @@ func slurpUserDataKVs(t testing.TB, e storage.Engine) []roachpb.KeyValue {
 			}
 			value := mvccValue.Value
 			value.Timestamp = it.UnsafeKey().Timestamp
-			kv := roachpb.KeyValue{Key: it.Key().Key, Value: value}
+			kv := roachpb.KeyValue{Key: it.UnsafeKey().Key.Clone(), Value: value}
 			kvs = append(kvs, kv)
 		}
 		return nil

--- a/pkg/storage/batch_test.go
+++ b/pkg/storage/batch_test.go
@@ -674,8 +674,8 @@ func TestUnindexedBatchThatSupportsReader(t *testing.T) {
 	if ok, err := iter.Valid(); !ok {
 		t.Fatalf("expected iterator to be valid, err=%v", err)
 	}
-	if string(iter.Key().Key) != "b" {
-		t.Fatalf("expected b, but got %s", iter.Key())
+	if string(iter.UnsafeKey().Key) != "b" {
+		t.Fatalf("expected b, but got %s", iter.UnsafeKey())
 	}
 	iter.Close()
 
@@ -750,8 +750,8 @@ func TestBatchIteration(t *testing.T) {
 	if ok, err := iter.Valid(); !ok {
 		t.Fatal(err)
 	}
-	if !reflect.DeepEqual(iter.Key(), k1) {
-		t.Fatalf("expected %s, got %s", k1, iter.Key())
+	if !reflect.DeepEqual(iter.UnsafeKey(), k1) {
+		t.Fatalf("expected %s, got %s", k1, iter.UnsafeKey())
 	}
 	checkValErr := func(v []byte, err error) []byte {
 		require.NoError(t, err)
@@ -764,8 +764,8 @@ func TestBatchIteration(t *testing.T) {
 	if ok, err := iter.Valid(); !ok {
 		t.Fatal(err)
 	}
-	if !reflect.DeepEqual(iter.Key(), k2) {
-		t.Fatalf("expected %s, got %s", k2, iter.Key())
+	if !reflect.DeepEqual(iter.UnsafeKey(), k2) {
+		t.Fatalf("expected %s, got %s", k2, iter.UnsafeKey())
 	}
 	if !reflect.DeepEqual(checkValErr(iter.Value()), v2) {
 		t.Fatalf("expected %s, got %s", v2, checkValErr(iter.Value()))
@@ -774,7 +774,7 @@ func TestBatchIteration(t *testing.T) {
 	if ok, err := iter.Valid(); err != nil {
 		t.Fatal(err)
 	} else if ok {
-		t.Fatalf("expected invalid, got valid at key %s", iter.Key())
+		t.Fatalf("expected invalid, got valid at key %s", iter.UnsafeKey())
 	}
 
 	// Reverse iteration.
@@ -782,8 +782,8 @@ func TestBatchIteration(t *testing.T) {
 	if ok, err := iter.Valid(); !ok {
 		t.Fatal(err)
 	}
-	if !reflect.DeepEqual(iter.Key(), k2) {
-		t.Fatalf("expected %s, got %s", k2, iter.Key())
+	if !reflect.DeepEqual(iter.UnsafeKey(), k2) {
+		t.Fatalf("expected %s, got %s", k2, iter.UnsafeKey())
 	}
 	if !reflect.DeepEqual(checkValErr(iter.Value()), v2) {
 		t.Fatalf("expected %s, got %s", v2, checkValErr(iter.Value()))
@@ -793,8 +793,8 @@ func TestBatchIteration(t *testing.T) {
 	if ok, err := iter.Valid(); !ok || err != nil {
 		t.Fatalf("expected success, but got invalid: %v", err)
 	}
-	if !reflect.DeepEqual(iter.Key(), k1) {
-		t.Fatalf("expected %s, got %s", k1, iter.Key())
+	if !reflect.DeepEqual(iter.UnsafeKey(), k1) {
+		t.Fatalf("expected %s, got %s", k1, iter.UnsafeKey())
 	}
 	if !reflect.DeepEqual(checkValErr(iter.Value()), v1) {
 		t.Fatalf("expected %s, got %s", v1, checkValErr(iter.Value()))

--- a/pkg/storage/engine_test.go
+++ b/pkg/storage/engine_test.go
@@ -307,8 +307,8 @@ func TestEngineBatch(t *testing.T) {
 			if currentBatch[len(currentBatch)-1].value != nil {
 				t.Errorf("%d: batch seek invalid, err=%v", i, err)
 			}
-		} else if !iter.Key().Equal(key) {
-			t.Errorf("%d: batch seek expected key %s, but got %s", i, key, iter.Key())
+		} else if !iter.UnsafeKey().Equal(key) {
+			t.Errorf("%d: batch seek expected key %s, but got %s", i, key, iter.UnsafeKey())
 		} else {
 			var m enginepb.MVCCMetadata
 			if err := iter.ValueProto(&m); err != nil {
@@ -2448,7 +2448,7 @@ func scanPointKeys(t *testing.T, r Reader) []MVCCKey {
 		if !ok {
 			break
 		}
-		pointKeys = append(pointKeys, iter.Key())
+		pointKeys = append(pointKeys, iter.UnsafeKey().Clone())
 	}
 	return pointKeys
 }

--- a/pkg/storage/intent_interleaving_iter.go
+++ b/pkg/storage/intent_interleaving_iter.go
@@ -982,14 +982,6 @@ func (i *intentInterleavingIter) ValueLen() int {
 	return i.iter.ValueLen()
 }
 
-func (i *intentInterleavingIter) Key() MVCCKey {
-	key := i.UnsafeKey()
-	keyCopy := make([]byte, len(key.Key))
-	copy(keyCopy, key.Key)
-	key.Key = keyCopy
-	return key
-}
-
 func (i *intentInterleavingIter) Value() ([]byte, error) {
 	if i.isCurAtIntentIter() {
 		return i.intentIter.Value()

--- a/pkg/storage/intent_interleaving_iter_test.go
+++ b/pkg/storage/intent_interleaving_iter_test.go
@@ -99,11 +99,6 @@ func checkAndOutputIter(iter MVCCIterator, b *strings.Builder) {
 		return
 	}
 	k1 := makePrintableKey(iter.UnsafeKey())
-	k2 := makePrintableKey(iter.Key())
-	if !k1.Equal(k2) {
-		fmt.Fprintf(b, "output: key: %s != %s\n", k1, k2)
-		return
-	}
 	engineKey, ok := DecodeEngineKey(iter.UnsafeRawKey())
 	if !ok {
 		fmt.Fprintf(b, "output: could not DecodeEngineKey: %x\n", iter.UnsafeRawKey())

--- a/pkg/storage/mvcc.go
+++ b/pkg/storage/mvcc.go
@@ -5889,7 +5889,7 @@ func MVCCFindSplitKey(
 		if _, _, err := keys.MakeSQLCodec(tenID).DecodeTablePrefix(it.UnsafeKey().Key); err == nil {
 			// The first key in this range represents a row in a SQL table. Advance the
 			// minSplitKey past this row to avoid the problems described above.
-			firstRowKey, err := keys.EnsureSafeSplitKey(it.Key().Key)
+			firstRowKey, err := keys.EnsureSafeSplitKey(it.UnsafeKey().Key.Clone())
 			if err != nil {
 				return nil, err
 			}
@@ -5900,7 +5900,7 @@ func MVCCFindSplitKey(
 	if minSplitKey == nil {
 		// The first key in the range does not represent a row in a SQL table.
 		// Allow a split at any key that sorts after it.
-		minSplitKey = it.Key().Key.Next()
+		minSplitKey = it.UnsafeKey().Key.Clone().Next()
 	}
 
 	splitKey, err := it.FindSplitKey(key.AsRawKey(), endKey.AsRawKey(), minSplitKey, targetSize)

--- a/pkg/storage/mvcc_history_metamorphic_iterator_test.go
+++ b/pkg/storage/mvcc_history_metamorphic_iterator_test.go
@@ -374,10 +374,6 @@ func (m *metamorphicMVCCIterator) SeekIntentGE(key roachpb.Key, txnUUID uuid.UUI
 	m.moveAround()
 }
 
-func (m *metamorphicMVCCIterator) Key() storage.MVCCKey {
-	return m.it.(storage.MVCCIterator).Key()
-}
-
 func (m *metamorphicMVCCIterator) UnsafeRawKey() []byte {
 	return m.it.(storage.MVCCIterator).UnsafeRawKey()
 }

--- a/pkg/storage/mvcc_incremental_iterator_test.go
+++ b/pkg/storage/mvcc_incremental_iterator_test.go
@@ -1482,13 +1482,13 @@ func collectMatchingWithMVCCIterator(
 		} else if !ok {
 			break
 		}
-		ts := iter.Key().Timestamp
+		ts := iter.UnsafeKey().Timestamp
 		if (ts.Less(end) || end == ts) && start.Less(ts) {
 			v, err := iter.Value()
 			if err != nil {
 				t.Fatal(err)
 			}
-			expectedKVs = append(expectedKVs, MVCCKeyValue{Key: iter.Key(), Value: v})
+			expectedKVs = append(expectedKVs, MVCCKeyValue{Key: iter.UnsafeKey().Clone(), Value: v})
 		}
 		iter.Next()
 	}

--- a/pkg/storage/pebble_iterator.go
+++ b/pkg/storage/pebble_iterator.go
@@ -368,12 +368,11 @@ func (p *pebbleIterator) Valid() (bool, error) {
 		return false, p.iter.Error()
 	}
 
-	// The MVCCIterator interface is broken in that it silently discards
-	// the error when UnsafeKey(), Key() are unable to parse the key as
-	// an MVCCKey. This is especially problematic if the caller is
-	// accidentally iterating into the lock table key space, since that
-	// parsing will fail. We do a cheap check here to make sure we are
-	// not in the lock table key space.
+	// The MVCCIterator interface is broken in that it silently discards the
+	// error when UnsafeKey() is unable to parse the key as an MVCCKey. This is
+	// especially problematic if the caller is accidentally iterating into the
+	// lock table key space, since that parsing will fail. We do a cheap check
+	// here to make sure we are not in the lock table key space.
 	//
 	// TODO(sumeer): fix this properly by changing those method signatures.
 	k := p.iter.Key()
@@ -603,15 +602,6 @@ func (p *pebbleIterator) PrevEngineKeyWithLimit(
 		return state, p.iter.Error()
 	}
 	return state, nil
-}
-
-// Key implements the MVCCIterator interface.
-func (p *pebbleIterator) Key() MVCCKey {
-	key := p.UnsafeKey()
-	keyCopy := make([]byte, len(key.Key))
-	copy(keyCopy, key.Key)
-	key.Key = keyCopy
-	return key
 }
 
 // EngineKey implements the EngineIterator interface.

--- a/pkg/ts/pruning.go
+++ b/pkg/ts/pruning.go
@@ -73,7 +73,7 @@ func (tsdb *DB) findTimeSeries(
 		} else if !ok || !iter.UnsafeKey().Less(end) {
 			break
 		}
-		foundKey := iter.Key().Key
+		foundKey := iter.UnsafeKey().Key.Clone()
 
 		// Extract the name and resolution from the discovered key.
 		name, _, res, tsNanos, err := DecodeDataKey(foundKey)


### PR DESCRIPTION
The MVCCIterator interface previously exposed two methods for accessing the current iterator postion as a MVCC key—UnsafeKey and Key. Key() was equivalent to UnsafeKey().Clone().

This commit removes the Key() variant, pushing the onus of key copying onto the caller. This reduces the interface surface area, avoids accidental key copying (some of which is addressed within this commit), and does not impose any unreasonable burden on callers.

Epic: None
Informs #82589.
Release note: None