### PR TITLE
allocator: fix lease io enforcement setting typo

### DIFF
--- a/pkg/kv/kvserver/allocator/allocatorimpl/allocator_scorer.go
+++ b/pkg/kv/kvserver/allocator/allocatorimpl/allocator_scorer.go
@@ -218,7 +218,7 @@ var LeaseIOOverloadThresholdEnforcement = settings.RegisterEnumSetting(
 		"non io-overloaded stores, this is a superset of block_transfer_to",
 	"block_transfer_to",
 	map[int64]string{
-		int64(IOOverloadThresholdIgnore):         "ingore",
+		int64(IOOverloadThresholdIgnore):         "ignore",
 		int64(IOOverloadThresholdBlockTransfers): "block_transfer_to",
 		int64(IOOverloadThresholdShed):           "shed",
 	},


### PR DESCRIPTION
This commit updates the "do nothing" lease IO overload enforcement (`kv.allocator.lease_io_overload_threshold_enforcement`) setting to be correctly spelled "ignore" rather than "ingore".

Part of: #96508

Release note (ops change): The
`kv.allocator.lease_io_overload_threshold_enforcement` setting value which disables enforcement is updated to be spelled correctly as "ignore" rather than "ingore".