### PR TITLE
sql: configure MR system database when adding primary region

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/multi_region
+++ b/pkg/ccl/logictestccl/testdata/logic_test/multi_region
@@ -534,8 +534,14 @@ GRANT admin TO testuser
 
 user testuser
 
-# Test adding a primary region to the system database.
-statement error adding a primary region to the system database is not supported
+# Test adding a primary region to the system database as a secondary tenant.
+onlyif config multiregion-9node-3region-3azs-tenant
+statement error pgcode 42501 user testuser may not modify the system database
+ALTER DATABASE system PRIMARY REGION "ap-southeast-2"
+
+# Note that nobody can add a region to the system database of the system tenant.
+skipif config multiregion-9node-3region-3azs-tenant
+statement error pgcode 0A000 modifying the regions of system database is not supported
 ALTER DATABASE system PRIMARY REGION "ap-southeast-2"
 
 user root

--- a/pkg/ccl/multiregionccl/cold_start_latency_test.go
+++ b/pkg/ccl/multiregionccl/cold_start_latency_test.go
@@ -157,22 +157,21 @@ func TestColdStartLatency(t *testing.T) {
 	tdb.Exec(t, `SET CLUSTER SETTING kv.closed_timestamp.lead_for_global_reads_override = '1500ms'`)
 	tdb.Exec(t, `ALTER TENANT ALL SET CLUSTER SETTING spanconfig.reconciliation_job.checkpoint_interval = '500ms'`)
 
-	applyGlobalTables := func(t *testing.T, db *gosql.DB, isTenant bool) {
-		stmts := []string{
-			`alter database system configure zone discard;`,
-			`alter database system set primary region "us-east1";`,
-			`alter database system add region "us-west1";`,
-			`alter database system add region "europe-west1"`,
-		}
-
+	configureSystem := func(t *testing.T, db *gosql.DB, isTenant bool) {
+		var stmts []string
 		if !isTenant {
-			stmts = append(stmts,
+			stmts = []string{
 				"ALTER TENANT ALL SET CLUSTER SETTING sql.zone_configs.allow_for_secondary_tenant.enabled = true",
 				"ALTER TENANT ALL SET CLUSTER SETTING sql.multi_region.allow_abstractions_for_secondary_tenants.enabled = true",
-				`alter range meta configure zone using constraints = '{"+region=us-east1": 1, "+region=us-west1": 1, "+region=europe-west1": 1}';`)
+				`alter range meta configure zone using constraints = '{"+region=us-east1": 1, "+region=us-west1": 1, "+region=europe-west1": 1}';`,
+			}
 		} else {
-			stmts = append(stmts,
-				`SELECT crdb_internal.unsafe_optimize_system_database()`)
+			stmts = []string{`
+BEGIN;
+ALTER DATABASE system PRIMARY REGION "us-east1";
+ALTER DATABASE system ADD REGION "us-west1";
+ALTER DATABASE system ADD REGION "europe-west1";
+COMMIT;`}
 		}
 		tdb := sqlutils.MakeSQLRunner(db)
 		for i, stmt := range stmts {
@@ -180,7 +179,7 @@ func TestColdStartLatency(t *testing.T) {
 			tdb.Exec(t, stmt)
 		}
 	}
-	applyGlobalTables(t, tc.ServerConn(0), false)
+	configureSystem(t, tc.ServerConn(0), false)
 
 	var blockCrossRegionTenantAccess atomic.Bool
 	maybeWait := func(ctx context.Context, a, b int) {
@@ -257,7 +256,7 @@ func TestColdStartLatency(t *testing.T) {
 			},
 			Locality: localities[0],
 		})
-		applyGlobalTables(t, tenantDB, true)
+		configureSystem(t, tenantDB, true)
 		tdb := sqlutils.MakeSQLRunner(tenantDB)
 		tdb.Exec(t, "CREATE USER foo PASSWORD $1 LOGIN", password)
 		tdb.Exec(t, "GRANT admin TO foo")

--- a/pkg/ccl/multiregionccl/multiregion_system_table_test.go
+++ b/pkg/ccl/multiregionccl/multiregion_system_table_test.go
@@ -72,8 +72,6 @@ func TestMrSystemDatabase(t *testing.T) {
 	tDB.Exec(t, `ALTER DATABASE system ADD REGION "us-east2"`)
 	tDB.Exec(t, `ALTER DATABASE system ADD REGION "us-east3"`)
 
-	tDB.Exec(t, `SELECT crdb_internal.unsafe_optimize_system_database()`)
-
 	// Run schema validations to ensure the manual descriptor modifications are
 	// okay.
 	tDB.CheckQueryResults(t, `SELECT * FROM crdb_internal.invalid_objects`, [][]string{})
@@ -234,11 +232,10 @@ func TestMrSystemDatabase(t *testing.T) {
 	})
 
 	t.Run("QueryByEnum", func(t *testing.T) {
-		// This is a regression test for a bug triggered by
-		// unsafe_optimize_system_database. If usnafe_optimize_system_database
-		// does not clear table statistics, this query will fail in the
-		// optimizer, because the stats will have the wrong type for the
-		// crdb_column.
+		// This is a regression test for a bug triggered by setting up the system
+		// database. If the operation to configure the does not clear table
+		// statistics, this query will fail in the optimizer, because the stats
+		// will have the wrong type for the crdb_column.
 		row := tDB.QueryRow(t, `
 			SELECT crdb_region, session_id, expiration 
 			FROM system.sqlliveness 
@@ -304,6 +301,7 @@ func TestTenantStartupWithMultiRegionEnum(t *testing.T) {
 	region, _, err := slstorage.UnsafeDecodeSessionID(sqlliveness.SessionID(sessionID))
 	require.NoError(t, err)
 	require.Equal(t, enum.One, region)
+	ten1SessionID := sessionID
 
 	// Ensure that the sqlliveness entry created by the second SQL server has
 	// the right region and session UUID.
@@ -315,14 +313,21 @@ func TestTenantStartupWithMultiRegionEnum(t *testing.T) {
 
 	rows := tenSQLDB2.Query(t, `SELECT crdb_region, session_id FROM system.sqlliveness`)
 	defer rows.Close()
-	livenessMap := map[string][]byte{}
+	livenessMap := map[string]string{}
 	for rows.Next() {
 		var region, ID string
 		require.NoError(t, rows.Scan(&region, &ID))
-		livenessMap[ID] = []byte(region)
+		livenessMap[ID] = region
 	}
 	require.NoError(t, rows.Err())
-	r, ok := livenessMap[sessionID]
-	require.True(t, ok)
-	require.Equal(t, r, region)
+	{
+		r, ok := livenessMap[sessionID]
+		require.True(t, ok)
+		require.Equal(t, r, "us-east3")
+	}
+	{
+		r, ok := livenessMap[ten1SessionID]
+		require.True(t, ok)
+		require.Equal(t, r, "us-east1")
+	}
 }

--- a/pkg/sql/faketreeeval/evalctx.go
+++ b/pkg/sql/faketreeeval/evalctx.go
@@ -137,12 +137,6 @@ func (so *DummyRegionOperator) ResetMultiRegionZoneConfigsForDatabase(
 	return errors.WithStack(errRegionOperator)
 }
 
-// OptimizeSystemDatabase is part of the eval.RegionOperator
-// interface.
-func (so *DummyRegionOperator) OptimizeSystemDatabase(_ context.Context) error {
-	return errors.WithStack(errRegionOperator)
-}
-
 // DummyStreamManagerFactory implements the eval.StreamManagerFactory interface by
 // returning errors.
 type DummyStreamManagerFactory struct{}

--- a/pkg/sql/importer/import_table_creation.go
+++ b/pkg/sql/importer/import_table_creation.go
@@ -274,11 +274,6 @@ func (so *importRegionOperator) ResetMultiRegionZoneConfigsForDatabase(
 	return errors.WithStack(errRegionOperator)
 }
 
-// OptimizeSystemDatabase is part of the eval.RegionOperator interface.
-func (so *importRegionOperator) OptimizeSystemDatabase(_ context.Context) error {
-	return errors.WithStack(errRegionOperator)
-}
-
 // Implements the eval.SequenceOperators interface.
 type importSequenceOperators struct{}
 

--- a/pkg/sql/region_util.go
+++ b/pkg/sql/region_util.go
@@ -1997,9 +1997,15 @@ func (p *planner) validateZoneConfigForMultiRegionDatabase(
 	currentZoneConfig *zonepb.ZoneConfig,
 	zoneConfigForMultiRegionValidator zoneConfigForMultiRegionValidator,
 ) error {
-	if currentZoneConfig == nil {
+	if currentZoneConfig == nil ||
+		// If this is the system database, and it has the configuration we inject
+		// for the system database at startup, we should treat it as though it has
+		// no zone configs set.
+		(dbDesc.GetID() == keys.SystemDatabaseID &&
+			currentZoneConfig.Equal(zonepb.DefaultSystemZoneConfigRef())) {
 		currentZoneConfig = zonepb.NewZoneConfig()
 	}
+
 	expectedZoneConfig, err := zoneConfigForMultiRegionValidator.getExpectedDatabaseZoneConfig()
 	if err != nil {
 		return err
@@ -2421,8 +2427,10 @@ func (p *planner) GetRangeDescByID(
 	return rangeDesc, nil
 }
 
-// OptimizeSystemDatabase is part of the eval.RegionOperator interface.
-func (p *planner) OptimizeSystemDatabase(ctx context.Context) error {
+// optimizeSystemDatabase configures some tables in the system data as
+// global and regional by row. The locality changes reduce how long it
+// takes a server to start up in a multi-region deployment.
+func (p *planner) optimizeSystemDatabase(ctx context.Context) error {
 	globalTables := []string{
 		"users",
 		"zones",

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -4931,22 +4931,6 @@ DO NOT USE -- USE 'CREATE TENANT' INSTEAD`,
 		},
 	),
 
-	"crdb_internal.unsafe_optimize_system_database": makeBuiltin(
-		tree.FunctionProperties{
-			Category:     builtinconstants.CategoryMultiRegion,
-			Undocumented: true,
-		},
-		tree.Overload{
-			Types:      tree.ParamTypes{},
-			ReturnType: tree.FixedReturnType(types.Bool),
-			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
-				return tree.MakeDBool(tree.DBool(true)), evalCtx.Regions.OptimizeSystemDatabase(ctx)
-			},
-			Info:       "Configures the sytem database to reduce latency during start up",
-			Volatility: volatility.Volatile,
-		},
-	),
-
 	// destroy_tenant is preserved for compatibility with CockroachCloud
 	// intrusion for v22.2 and previous versions.
 	"crdb_internal.destroy_tenant": makeBuiltin(

--- a/pkg/sql/sem/builtins/fixed_oids.go
+++ b/pkg/sql/sem/builtins/fixed_oids.go
@@ -2031,7 +2031,7 @@ var builtinOidsArray = []string{
 	2054: `tsvectorin(input: anyelement) -> tsvector`,
 	2055: `crdb_internal.hide_sql_constants(val: string) -> string`,
 	2056: `crdb_internal.hide_sql_constants(val: string[]) -> string[]`,
-	2057: `crdb_internal.unsafe_optimize_system_database() -> bool`,
+	2057: ``, // formerly crdb_internal.unsafe_optimize_system_database() -> bool
 	2058: `parse_ident(qualified_identifier: string) -> string[]`,
 	2059: `parse_ident(qualified_identifier: string, strict: bool) -> string[]`,
 	2060: `pg_get_function_arguments(func_oid: oid) -> string`,

--- a/pkg/sql/sem/eval/deps.go
+++ b/pkg/sql/sem/eval/deps.go
@@ -523,14 +523,6 @@ type RegionOperator interface {
 	// ResetMultiRegionZoneConfigsForDatabase resets the given database's zone
 	// configuration to its multi-region default.
 	ResetMultiRegionZoneConfigsForDatabase(ctx context.Context, id int64) error
-
-	// OptimizeSystemDatabase configures some tables in the system data as
-	// global and regional by row. The locality changes reduce how long it
-	// takes a server to start up in a multi-region deployment.
-	//
-	// TODO(jeffswenson): remove OptimizeSystemDatabase after cleaning up the
-	// unsafe_optimize_system_database built in.
-	OptimizeSystemDatabase(ctx context.Context) error
 }
 
 // SequenceOperators is used for various sql related functions that can


### PR DESCRIPTION
This PR sets up the system database for secondary tenants automatically when the primary region is first added. It also moves the principal checking into a more generic helper for all MR database statements.

This PR removes the crdb_internal.unsafe_optimize_system_database() builtin which we utilized in earlier stages of this project, and subsumes its logic into the regular SQL syntax for the system database.

There's plenty more follow-up work here:
 * This work does not yet lead other MR database operations to consult the system database
 * It doesn't prevent removing the primary region and thus resetting the region config for the system database
 * It doesn't check for the usage of a region in other databases when going to drop a region.

Epic: CRDB-2526

Informs: #98530

Release note: None