### PR TITLE
kvserver: add `RaftReproposalTimeoutTicks` and bump to 15

### DIFF
--- a/pkg/base/config.go
+++ b/pkg/base/config.go
@@ -235,6 +235,11 @@ var (
 	defaultRaftElectionTimeoutTicks = envutil.EnvOrDefaultInt(
 		"COCKROACH_RAFT_ELECTION_TIMEOUT_TICKS", 10)
 
+	// defaultRaftReproposalTimeoutTicks is the number of ticks before reproposing
+	// a Raft command.
+	defaultRaftReproposalTimeoutTicks = envutil.EnvOrDefaultInt(
+		"COCKROACH_RAFT_REPROPOSAL_TIMEOUT_TICKS", 15)
+
 	// defaultRaftLogTruncationThreshold specifies the upper bound that a single
 	// Range's Raft log can grow to before log truncations are triggered while at
 	// least one follower is missing. If all followers are active, the quota pool
@@ -456,6 +461,11 @@ type RaftConfig struct {
 	// unless overridden.
 	RaftElectionTimeoutTicks int
 
+	// RaftReproposalTimeoutTicks is the number of ticks before reproposing a Raft
+	// command. This also specifies the number of ticks between each reproposal
+	// check, so the actual timeout is 1-2 times this value.
+	RaftReproposalTimeoutTicks int
+
 	// RaftHeartbeatIntervalTicks is the number of ticks that pass between heartbeats.
 	RaftHeartbeatIntervalTicks int
 
@@ -561,6 +571,9 @@ func (cfg *RaftConfig) SetDefaults() {
 	}
 	if cfg.RangeLeaseRenewalFraction == 0 {
 		cfg.RangeLeaseRenewalFraction = defaultRangeLeaseRenewalFraction
+	}
+	if cfg.RaftReproposalTimeoutTicks == 0 {
+		cfg.RaftReproposalTimeoutTicks = defaultRaftReproposalTimeoutTicks
 	}
 	// TODO(andrei): -1 is a special value for RangeLeaseRenewalFraction which
 	// really means "0" (never renew), except that the zero value means "use

--- a/pkg/base/config_test.go
+++ b/pkg/base/config_test.go
@@ -34,6 +34,7 @@ func TestDefaultRaftConfig(t *testing.T) {
 	leaseActive, leaseRenewal := cfg.RangeLeaseDurations()
 	nodeActive, nodeRenewal := cfg.NodeLivenessDurations()
 	raftElectionTimeout := cfg.RaftElectionTimeout()
+	raftReproposalTimeout := cfg.RaftTickInterval * time.Duration(cfg.RaftReproposalTimeoutTicks)
 	raftHeartbeatInterval := cfg.RaftTickInterval * time.Duration(cfg.RaftHeartbeatIntervalTicks)
 
 	{
@@ -41,6 +42,7 @@ func TestDefaultRaftConfig(t *testing.T) {
 		s += spew.Sdump(cfg)
 		s += fmt.Sprintf("RaftHeartbeatInterval: %s\n", raftHeartbeatInterval)
 		s += fmt.Sprintf("RaftElectionTimeout: %s\n", raftElectionTimeout)
+		s += fmt.Sprintf("RaftReproposalTimeout: %s\n", raftReproposalTimeout)
 		s += fmt.Sprintf("RangeLeaseDurations: active=%s renewal=%s\n", leaseActive, leaseRenewal)
 		s += fmt.Sprintf("RangeLeaseAcquireTimeout: %s\n", cfg.RangeLeaseAcquireTimeout())
 		s += fmt.Sprintf("NodeLivenessDurations: active=%s renewal=%s\n", nodeActive, nodeRenewal)

--- a/pkg/base/testdata/raft_config
+++ b/pkg/base/testdata/raft_config
@@ -3,6 +3,7 @@ echo
 (base.RaftConfig) {
  RaftTickInterval: (time.Duration) 200ms,
  RaftElectionTimeoutTicks: (int) 10,
+ RaftReproposalTimeoutTicks: (int) 15,
  RaftHeartbeatIntervalTicks: (int) 5,
  RangeLeaseDuration: (time.Duration) 6s,
  RangeLeaseRenewalFraction: (float64) 0.5,
@@ -17,6 +18,7 @@ echo
 }
 RaftHeartbeatInterval: 1s
 RaftElectionTimeout: 2s
+RaftReproposalTimeout: 3s
 RangeLeaseDurations: active=6s renewal=3s
 RangeLeaseAcquireTimeout: 4s
 NodeLivenessDurations: active=6s renewal=3s

--- a/pkg/kv/kvserver/client_raft_test.go
+++ b/pkg/kv/kvserver/client_raft_test.go
@@ -1699,7 +1699,7 @@ func TestLogGrowthWhenRefreshingPendingCommands(t *testing.T) {
 					// can easily create leader-not-leaseholder scenarios.
 					DisableLeaderFollowsLeaseholder: true,
 					// Refresh pending commands on every Raft group tick instead of
-					// every RaftElectionTimeoutTicks.
+					// every RaftReproposalTimeoutTicks.
 					RefreshReasonTicksPeriod: 1,
 				},
 			},

--- a/pkg/kv/kvserver/replica_raft.go
+++ b/pkg/kv/kvserver/replica_raft.go
@@ -1228,17 +1228,14 @@ func (r *Replica) tick(
 		}
 	}
 
-	refreshAtDelta := r.store.cfg.RaftElectionTimeoutTicks
+	refreshAtDelta := r.store.cfg.RaftReproposalTimeoutTicks
 	if knob := r.store.TestingKnobs().RefreshReasonTicksPeriod; knob > 0 {
 		refreshAtDelta = knob
 	}
 	if !r.store.TestingKnobs().DisableRefreshReasonTicks && r.mu.ticks%refreshAtDelta == 0 {
-		// RaftElectionTimeoutTicks is a reasonable approximation of how long we
-		// should wait before deciding that our previous proposal didn't go
-		// through. Note that the combination of the above condition and passing
-		// RaftElectionTimeoutTicks to refreshProposalsLocked means that commands
-		// will be refreshed when they have been pending for 1 to 2 election
-		// cycles.
+		// The combination of the above condition and passing refreshAtDelta to
+		// refreshProposalsLocked means that commands will be refreshed when they
+		// have been pending for 1 to 2 reproposal timeouts.
 		r.refreshProposalsLocked(ctx, refreshAtDelta, reasonTicks)
 	}
 	return true, nil

--- a/pkg/kv/kvserver/store.go
+++ b/pkg/kv/kvserver/store.go
@@ -263,6 +263,7 @@ func testStoreConfig(clock *hlc.Clock, version roachpb.Version) StoreConfig {
 	// time in tests.
 	sc.RaftHeartbeatIntervalTicks = 1
 	sc.RaftElectionTimeoutTicks = 3
+	sc.RaftReproposalTimeoutTicks = 5
 	sc.RaftTickInterval = 100 * time.Millisecond
 	sc.SetDefaults()
 	return sc
@@ -1153,8 +1154,8 @@ type ConsistencyTestingKnobs struct {
 func (sc *StoreConfig) Valid() bool {
 	return sc.Clock != nil && sc.Transport != nil &&
 		sc.RaftTickInterval != 0 && sc.RaftHeartbeatIntervalTicks > 0 &&
-		sc.RaftElectionTimeoutTicks > 0 && sc.ScanInterval >= 0 &&
-		sc.AmbientCtx.Tracer != nil
+		sc.RaftElectionTimeoutTicks > 0 && sc.RaftReproposalTimeoutTicks > 0 &&
+		sc.ScanInterval >= 0 && sc.AmbientCtx.Tracer != nil
 }
 
 // SetDefaults initializes unset fields in StoreConfig to values


### PR DESCRIPTION
In d2836e6a we reduced `RaftElectionTimeoutTicks` from 15 to 10. This also affected the reproposal timeout, which used the same value, and may now be too aggressive. This patch adds a separate `RaftReproposalTimeoutTicks` with the old value of 15, out of caution.

Resolves #98125.

Epic: none
Release note: None