### PR TITLE
kvserver,syncutil: introduce TimedMutex and use as raftMu

### DIFF
--- a/pkg/kv/kvserver/metrics.go
+++ b/pkg/kv/kvserver/metrics.go
@@ -955,6 +955,15 @@ of processing.
 		Measurement: "Latency",
 		Unit:        metric.Unit_NANOSECONDS,
 	}
+	metaRaftMutexHeldLatency = metric.Metadata{
+		Name: "raft.mutex.latency",
+		Help: `Durations of critical sections for raft processing mutex.
+
+This mutex is held across I/O.
+`,
+		Measurement: "Latency",
+		Unit:        metric.Unit_NANOSECONDS,
+	}
 	metaRaftTimeoutCampaign = metric.Metadata{
 		Name:        "raft.timeoutcampaign",
 		Help:        "Number of Raft replicas campaigning after missed heartbeats from leader",
@@ -1916,6 +1925,7 @@ type StoreMetrics struct {
 	RaftHandleReadyLatency    metric.IHistogram
 	RaftApplyCommittedLatency metric.IHistogram
 	RaftSchedulerLatency      metric.IHistogram
+	RaftMutexHeldLatency      metric.IHistogram
 	RaftTimeoutCampaign       *metric.Counter
 
 	// Raft message metrics.
@@ -2477,6 +2487,12 @@ func newStoreMetrics(histogramWindow time.Duration) *StoreMetrics {
 		RaftSchedulerLatency: metric.NewHistogram(metric.HistogramOptions{
 			Mode:     metric.HistogramModePreferHdrLatency,
 			Metadata: metaRaftSchedulerLatency,
+			Duration: histogramWindow,
+			Buckets:  metric.IOLatencyBuckets,
+		}),
+		RaftMutexHeldLatency: metric.NewHistogram(metric.HistogramOptions{
+			Mode:     metric.HistogramModePrometheus,
+			Metadata: metaRaftMutexHeldLatency,
 			Duration: histogramWindow,
 			Buckets:  metric.IOLatencyBuckets,
 		}),

--- a/pkg/kv/kvserver/replica.go
+++ b/pkg/kv/kvserver/replica.go
@@ -249,7 +249,7 @@ type Replica struct {
 	//
 	// Locking notes: Replica.raftMu < Replica.mu
 	raftMu struct {
-		syncutil.Mutex
+		*syncutil.TimedMutex
 
 		// Note that there are two StateLoaders, in raftMu and mu,
 		// depending on which lock is being held.

--- a/pkg/util/syncutil/BUILD.bazel
+++ b/pkg/util/syncutil/BUILD.bazel
@@ -9,6 +9,7 @@ go_library(
         "mutex_deadlock.go",  # keep
         "mutex_sync.go",  # keep
         "mutex_sync_race.go",  # keep
+        "mutex_timed.go",
     ],
     importpath = "github.com/cockroachdb/cockroach/pkg/util/syncutil",
     visibility = ["//visibility:public"],

--- a/pkg/util/syncutil/mutex_timed.go
+++ b/pkg/util/syncutil/mutex_timed.go
@@ -1,0 +1,51 @@
+// Copyright 2023 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package syncutil
+
+import "time"
+
+// TimedMutex is a Mutex that helps record the duration of the critical section
+// to a callback.
+type TimedMutex struct {
+	mu  Mutex
+	t   time.Time
+	now func() time.Time
+	rec func(time.Time)
+}
+
+// NewTimedMutex returns a TimedMutex. `rec` will be invoked as part of Unlock
+// after having released the mutex, with the timestamp taken right after the
+// mutex was acquired. `rec` can perform "expensive" work without delaying
+// anyone but the caller of Unlock.
+func NewTimedMutex(now func() time.Time, rec func(time.Time)) *TimedMutex {
+	return &TimedMutex{
+		now: now,
+		rec: rec,
+	}
+}
+
+// Lock locks the mutex.
+func (tm *TimedMutex) Lock() {
+	tm.mu.Lock()
+	tm.t = tm.now()
+}
+
+// Unlock unlocks the mutex.
+func (tm *TimedMutex) Unlock() {
+	tm.mu.Unlock()
+	tm.rec(tm.t)
+}
+
+// AssertHeld asserts that the mutex is held (by someone, not
+// necessarily but usually the caller). See Mutex.AssertHeld.
+func (tm *TimedMutex) AssertHeld() {
+	tm.mu.AssertHeld()
+}


### PR DESCRIPTION
Motivated by https://github.com/cockroachlabs/support/issues/2107.

I'm not 100% sure this is a useful metric to add since it has so much
overlap with `raft.process.handleready.latency`, but we did see in the
above issue that they are not the same. raftMu acquisition latency is
a floor for user-facing latency, so it might make sense to track it
directly.

<details>
<summary>Custom chart from an 8tb restore</summary>

![image](https://user-images.githubusercontent.com/5076964/225061154-6a5641e2-d292-42f2-a62c-d473c9b533b0.png)


</details>

Epic: none
Release note: None
