### PR TITLE
sql: support tenant configuration templates

### DIFF
--- a/pkg/multitenant/mtinfopb/info.proto
+++ b/pkg/multitenant/mtinfopb/info.proto
@@ -103,10 +103,23 @@ message UsageInfo {
   // All-time consumption for this tenant. Each field has a corresponding column
   // in system.tenant_usage.
   optional roachpb.TenantConsumption consumption = 4 [(gogoproto.nullable) = false];
+
+  // Next ID: 5
+}
+
+// SettingOverride represents a cluster setting override for one tenant.
+message SettingOverride {
+  option (gogoproto.equal) = true;
+
+  optional string name = 1 [(gogoproto.nullable) = false];
+  optional string value = 2 [(gogoproto.nullable) = false];
+  optional string value_type = 3 [(gogoproto.nullable) = false];
+  optional string reason = 4;
+  // Next ID: 5
 }
 
 // TenantInfoWithUsage contains the information for a tenant in a multi-tenant
-// cluster plus metadata related to cost control and consumption.
+// cluster plus metadata related to cost control and consumption and setting overrides.
 message TenantInfoWithUsage {
   option (gogoproto.equal) = true;
 
@@ -115,5 +128,7 @@ message TenantInfoWithUsage {
 
   optional SQLInfo extra_columns = 3 [(gogoproto.embed) = true, (gogoproto.nullable) = false];
 
-  // Next ID: 4
+  repeated SettingOverride setting_overrides = 4;
+
+  // Next ID: 5
 }

--- a/pkg/sql/create_tenant.go
+++ b/pkg/sql/create_tenant.go
@@ -13,11 +13,14 @@ package sql
 import (
 	"context"
 
+	"github.com/cockroachdb/cockroach/pkg/multitenant/mtinfopb"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/errors"
 )
 
 type createTenantNode struct {
-	tenantSpec tenantSpec
+	tenantSpec     tenantSpec
+	likeTenantSpec tenantSpec
 }
 
 func (p *planner) CreateTenantNode(ctx context.Context, n *tree.CreateTenant) (planNode, error) {
@@ -25,13 +28,35 @@ func (p *planner) CreateTenantNode(ctx context.Context, n *tree.CreateTenant) (p
 	if err != nil {
 		return nil, err
 	}
+	var likeTenantSpec tenantSpec
+	if n.Like.OtherTenant != nil {
+		likeTenantSpec, err = p.planTenantSpec(ctx, n.Like.OtherTenant, "CREATE TENANT LIKE")
+		if err != nil {
+			return nil, err
+		}
+	}
 	return &createTenantNode{
-		tenantSpec: tspec,
+		tenantSpec:     tspec,
+		likeTenantSpec: likeTenantSpec,
 	}, nil
 }
 
 func (n *createTenantNode) startExec(params runParams) error {
 	tid, tenantName, err := n.tenantSpec.getTenantParameters(params.ctx, params.p)
+	if err != nil {
+		return err
+	}
+
+	var tmplInfo *mtinfopb.TenantInfo
+	if n.likeTenantSpec != nil {
+		tmplInfo, err = n.likeTenantSpec.getTenantInfo(params.ctx, params.p)
+		if err != nil {
+			return errors.Wrap(err, "retrieving record for LIKE configuration template")
+		}
+	}
+	configTemplate, err := GetTenantTemplate(params.ctx,
+		params.p.ExecCfg().Settings, params.p.InternalSQLTxn(),
+		tmplInfo, 0, "")
 	if err != nil {
 		return err
 	}
@@ -44,7 +69,7 @@ func (n *createTenantNode) startExec(params runParams) error {
 		tenantID := tid.ToUint64()
 		ctcfg.ID = &tenantID
 	}
-	_, err = params.p.createTenantInternal(params.ctx, ctcfg)
+	_, err = params.p.createTenantInternal(params.ctx, ctcfg, configTemplate)
 	return err
 }
 

--- a/pkg/sql/logictest/testdata/logic_test/tenant
+++ b/pkg/sql/logictest/testdata/logic_test/tenant
@@ -329,3 +329,116 @@ DROP TENANT two
 
 statement ok
 DROP TENANT 'tenant-one'
+
+subtest tenant_templates
+
+query T
+SHOW CLUSTER SETTING sql.create_tenant.default_template
+----
+·
+
+# Check we can't use the system tenant as template.
+statement error using the system tenant as config template
+CREATE TENANT othertenant LIKE system
+
+# Create some "interesting" tenant template.
+statement ok
+CREATE TENANT tmpl;
+ALTER TENANT tmpl GRANT CAPABILITY can_view_node_info; -- will be copied
+ALTER TENANT tmpl SET CLUSTER SETTING trace.debug.enable = true; -- will be copied
+-- Simulate resource limits. Will be copied.
+-- Note: we cannot use the update_tenant_resource_limits() builtin
+-- directly here because it can only be used from a CCL binary.
+INSERT INTO system.tenant_usage(
+        tenant_id, instance_id, next_instance_id, last_update,
+        ru_burst_limit, ru_refill_rate, ru_current, current_share_sum, total_consumption)
+VALUES ((SELECT id FROM system.tenants WHERE name = 'tmpl'), 0, 0, now(),
+        11, 22, 33, 44, ''::BYTES);
+ALTER TENANT tmpl START SERVICE SHARED; -- will not be copied.
+
+# Use it to create a new tenant.
+statement ok
+CREATE TENANT othertenant LIKE tmpl
+
+# Verify the service mode was not copied.
+query ITTT
+SHOW TENANT othertenant
+----
+13  othertenant  ready  none
+
+# Verify the new tenant has the same caps as the template
+# (by showing there's no difference between the two)
+query TT
+SELECT capability_name, capability_value FROM [SHOW TENANT tmpl WITH CAPABILITIES]
+EXCEPT SELECT capability_name, capability_value FROM [SHOW TENANT othertenant WITH CAPABILITIES];
+----
+
+# Check that the setting overrides were copied.
+query TTTT
+SELECT variable, value, type, origin FROM [SHOW CLUSTER SETTINGS FOR TENANT othertenant]
+WHERE origin != 'no-override'
+----
+trace.debug.enable  true  b  per-tenant-override
+
+# Check that the resource usage parameters were copied.
+query IIRRRRI
+SELECT instance_id, next_instance_id,
+       ru_burst_limit, ru_refill_rate, ru_current,
+       current_share_sum, length(total_consumption)
+FROM system.tenant_usage WHERE tenant_id = (SELECT id FROM system.tenants WHERE name = 'othertenant')
+----
+0  0  11  22  33  0  0
+
+# Clean up.
+statement ok
+DROP TENANT othertenant
+
+# Now set the default template and try again.
+statement ok
+SET CLUSTER SETTING sql.create_tenant.default_template = 'nonexistent';
+
+statement error retrieving default tenant configuration template.*tenant "nonexistent" does not exist
+CREATE TENANT othertenant
+
+statement ok
+SET CLUSTER SETTING sql.create_tenant.default_template = 'tmpl';
+
+# Create a new tenant - this should use the template implicitly now.
+statement ok
+CREATE TENANT othertenant
+
+# Verify the service mode was not copied.
+query ITTT
+SHOW TENANT othertenant
+----
+14  othertenant  ready  none
+
+query TT
+SELECT capability_name, capability_value FROM [SHOW TENANT tmpl WITH CAPABILITIES]
+EXCEPT SELECT capability_name, capability_value FROM [SHOW TENANT othertenant WITH CAPABILITIES];
+----
+
+# Check the setting overrides were taken over.
+query TTTT
+SELECT variable, value, type, origin FROM [SHOW CLUSTER SETTINGS FOR TENANT othertenant]
+WHERE origin != 'no-override'
+----
+trace.debug.enable  true  b  per-tenant-override
+
+# Check that the resource usage parameters were copied.
+query IIRRRRI
+SELECT instance_id, next_instance_id,
+       ru_burst_limit, ru_refill_rate, ru_current,
+       current_share_sum, length(total_consumption)
+FROM system.tenant_usage WHERE tenant_id = (SELECT id FROM system.tenants WHERE name = 'othertenant')
+----
+0  0  11  22  33  0  0
+
+# Clean up.
+statement ok
+DROP TENANT othertenant;
+ALTER TENANT tmpl STOP SERVICE;
+DROP TENANT tmpl
+
+statement ok
+RESET CLUSTER SETTING sql.create_tenant.default_template

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -855,6 +855,9 @@ func (u *sqlSymUnion) showRangesOpts() *tree.ShowRangesOptions {
 func (u *sqlSymUnion) tenantSpec() *tree.TenantSpec {
     return u.val.(*tree.TenantSpec)
 }
+func (u *sqlSymUnion) likeTenantSpec() *tree.LikeTenantSpec {
+    return u.val.(*tree.LikeTenantSpec)
+}
 func (u *sqlSymUnion) cteMaterializeClause() tree.CTEMaterializeClause {
     return u.val.(tree.CTEMaterializeClause)
 }
@@ -1168,6 +1171,8 @@ func (u *sqlSymUnion) showTenantOpts() tree.ShowTenantOptions {
 %type <tree.Statement> create_view_stmt
 %type <tree.Statement> create_sequence_stmt
 %type <tree.Statement> create_func_stmt
+
+%type <*tree.LikeTenantSpec> opt_like_tenant
 
 %type <tree.Statement> create_stats_stmt
 %type <*tree.CreateStatsOptions> opt_create_stats_options
@@ -4348,25 +4353,42 @@ create_stmt:
 // %Help: CREATE TENANT - create new tenant
 // %Category: Experimental
 // %Text:
-// CREATE TENANT name
-// CREATE TENANT name FROM REPLICATION OF <tenant_spec> ON <location> [ WITH OPTIONS ... ]
+// CREATE TENANT name [ LIKE <tenant_spec> ]
+// CREATE TENANT name [ LIKE <tenant_spec> ] FROM REPLICATION OF <tenant_spec> ON <location> [ WITH OPTIONS ... ]
 create_tenant_stmt:
-  CREATE TENANT d_expr
+  CREATE TENANT d_expr opt_like_tenant
   {
     /* SKIP DOC */
-    $$.val = &tree.CreateTenant{TenantSpec: &tree.TenantSpec{IsName: true, Expr: $3.expr()}}
+    $$.val = &tree.CreateTenant{
+      TenantSpec: &tree.TenantSpec{IsName: true, Expr: $3.expr()},
+      Like: $4.likeTenantSpec(),
+    }
   }
-| CREATE TENANT d_expr FROM REPLICATION OF d_expr ON d_expr opt_with_tenant_replication_options
+| CREATE TENANT d_expr opt_like_tenant FROM REPLICATION OF d_expr ON d_expr opt_with_tenant_replication_options
   {
     /* SKIP DOC */
     $$.val = &tree.CreateTenantFromReplication{
       TenantSpec: &tree.TenantSpec{IsName: true, Expr: $3.expr()},
-      ReplicationSourceTenantName: &tree.TenantSpec{IsName: true, Expr: $7.expr()},
-      ReplicationSourceAddress: $9.expr(),
-      Options: *$10.tenantReplicationOptions(),
+      ReplicationSourceTenantName: &tree.TenantSpec{IsName: true, Expr: $8.expr()},
+      ReplicationSourceAddress: $10.expr(),
+      Options: *$11.tenantReplicationOptions(),
+      Like: $4.likeTenantSpec(),
     }
   }
 | CREATE TENANT error // SHOW HELP: CREATE TENANT
+
+// opt_like_tenant defines a LIKE clause for CREATE TENANT.
+// Eventually this can grow to support INCLUDING/EXCLUDING options
+// like in CREATE TABLE.
+opt_like_tenant:
+  /* EMPTY */
+  {
+     $$.val = &tree.LikeTenantSpec{}
+  }
+| LIKE tenant_spec
+  {
+      $$.val = &tree.LikeTenantSpec{OtherTenant: $2.tenantSpec()}
+  }
 
 // Optional tenant replication options.
 opt_with_tenant_replication_options:

--- a/pkg/sql/parser/testdata/create_tenant
+++ b/pkg/sql/parser/testdata/create_tenant
@@ -15,12 +15,44 @@ CREATE TENANT "bar-with-hyphen" -- literals removed
 CREATE TENANT _ -- identifiers removed
 
 parse
+CREATE TENANT foo LIKE bar
+----
+CREATE TENANT foo LIKE bar
+CREATE TENANT (foo) LIKE (bar) -- fully parenthesized
+CREATE TENANT foo LIKE bar -- literals removed
+CREATE TENANT _ LIKE _ -- identifiers removed
+
+parse
+CREATE TENANT foo LIKE [123]
+----
+CREATE TENANT foo LIKE [123]
+CREATE TENANT (foo) LIKE [(123)] -- fully parenthesized
+CREATE TENANT foo LIKE [_] -- literals removed
+CREATE TENANT _ LIKE [123] -- identifiers removed
+
+parse
 CREATE TENANT destination FROM REPLICATION OF source ON 'pgurl'
 ----
 CREATE TENANT destination FROM REPLICATION OF source ON 'pgurl'
 CREATE TENANT (destination) FROM REPLICATION OF (source) ON ('pgurl') -- fully parenthesized
 CREATE TENANT destination FROM REPLICATION OF source ON '_' -- literals removed
 CREATE TENANT _ FROM REPLICATION OF _ ON 'pgurl' -- identifiers removed
+
+parse
+CREATE TENANT destination LIKE bar FROM REPLICATION OF source ON 'pgurl'
+----
+CREATE TENANT destination LIKE bar FROM REPLICATION OF source ON 'pgurl'
+CREATE TENANT (destination) LIKE (bar) FROM REPLICATION OF (source) ON ('pgurl') -- fully parenthesized
+CREATE TENANT destination LIKE bar FROM REPLICATION OF source ON '_' -- literals removed
+CREATE TENANT _ LIKE _ FROM REPLICATION OF _ ON 'pgurl' -- identifiers removed
+
+parse
+CREATE TENANT destination LIKE [123] FROM REPLICATION OF source ON 'pgurl'
+----
+CREATE TENANT destination LIKE [123] FROM REPLICATION OF source ON 'pgurl'
+CREATE TENANT (destination) LIKE [(123)] FROM REPLICATION OF (source) ON ('pgurl') -- fully parenthesized
+CREATE TENANT destination LIKE [_] FROM REPLICATION OF source ON '_' -- literals removed
+CREATE TENANT _ LIKE [123] FROM REPLICATION OF _ ON 'pgurl' -- identifiers removed
 
 parse
 CREATE TENANT "destination-hyphen" FROM REPLICATION OF "source-hyphen" ON 'pgurl'

--- a/pkg/sql/sem/tree/create.go
+++ b/pkg/sql/sem/tree/create.go
@@ -2150,12 +2150,27 @@ func (node *CreateExternalConnection) Format(ctx *FmtCtx) {
 // CreateTenant represents a CREATE TENANT statement.
 type CreateTenant struct {
 	TenantSpec *TenantSpec
+	Like       *LikeTenantSpec
 }
 
 // Format implements the NodeFormatter interface.
 func (node *CreateTenant) Format(ctx *FmtCtx) {
 	ctx.WriteString("CREATE TENANT ")
 	ctx.FormatNode(node.TenantSpec)
+	ctx.FormatNode(node.Like)
+}
+
+// LikeTenantSpec represents a LIKE clause in CREATE TENANT.
+type LikeTenantSpec struct {
+	OtherTenant *TenantSpec
+}
+
+func (node *LikeTenantSpec) Format(ctx *FmtCtx) {
+	if node.OtherTenant == nil {
+		return
+	}
+	ctx.WriteString(" LIKE ")
+	ctx.FormatNode(node.OtherTenant)
 }
 
 // CreateTenantFromReplication represents a CREATE TENANT...FROM REPLICATION
@@ -2175,6 +2190,8 @@ type CreateTenantFromReplication struct {
 	ReplicationSourceAddress Expr
 
 	Options TenantReplicationOptions
+
+	Like *LikeTenantSpec
 }
 
 // TenantReplicationOptions  options for the CREATE TENANT FROM REPLICATION command.
@@ -2190,6 +2207,7 @@ func (node *CreateTenantFromReplication) Format(ctx *FmtCtx) {
 	// NB: we do not anonymize the tenant name because we assume that tenant names
 	// do not contain sensitive information.
 	ctx.FormatNode(node.TenantSpec)
+	ctx.FormatNode(node.Like)
 
 	if node.ReplicationSourceAddress != nil {
 		ctx.WriteString(" FROM REPLICATION OF ")

--- a/pkg/sql/sem/tree/walk.go
+++ b/pkg/sql/sem/tree/walk.go
@@ -1041,6 +1041,34 @@ func (n *AlterTenantReplication) walkStmt(v Visitor) Statement {
 	return ret
 }
 
+// copyNode makes a copy of this node without recursing.
+func (n *LikeTenantSpec) copyNode() *LikeTenantSpec {
+	nodeCopy := *n
+	return &nodeCopy
+}
+
+// copyNode makes a copy of this Statement without recursing in any child Statements.
+func (n *CreateTenant) copyNode() *CreateTenant {
+	stmtCopy := *n
+	return &stmtCopy
+}
+
+// walkStmt is part of the walkableStmt interface.
+func (n *CreateTenant) walkStmt(v Visitor) Statement {
+	ret := n
+	if n.Like.OtherTenant != nil {
+		ts, changed := walkTenantSpec(v, n.TenantSpec)
+		if changed {
+			if ret == n {
+				ret = n.copyNode()
+			}
+			ret.Like = n.Like.copyNode()
+			ret.Like.OtherTenant = ts
+		}
+	}
+	return ret
+}
+
 // copyNode makes a copy of this Statement without recursing in any child Statements.
 func (n *CreateTenantFromReplication) copyNode() *CreateTenantFromReplication {
 	stmtCopy := *n
@@ -1071,6 +1099,16 @@ func (n *CreateTenantFromReplication) walkStmt(v Visitor) Statement {
 				ret = n.copyNode()
 			}
 			ret.Options.Retention = e
+		}
+	}
+	if n.Like.OtherTenant != nil {
+		ts, changed := walkTenantSpec(v, n.TenantSpec)
+		if changed {
+			if ret == n {
+				ret = n.copyNode()
+			}
+			ret.Like = n.Like.copyNode()
+			ret.Like.OtherTenant = ts
 		}
 	}
 	return ret
@@ -1900,6 +1938,7 @@ var _ walkableStmt = &CancelSessions{}
 var _ walkableStmt = &ControlJobs{}
 var _ walkableStmt = &ControlSchedules{}
 var _ walkableStmt = &CreateTable{}
+var _ walkableStmt = &CreateTenant{}
 var _ walkableStmt = &CreateTenantFromReplication{}
 var _ walkableStmt = &Delete{}
 var _ walkableStmt = &DropTenant{}

--- a/pkg/sql/tenant_accessors.go
+++ b/pkg/sql/tenant_accessors.go
@@ -15,8 +15,10 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/keys"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
 	"github.com/cockroachdb/cockroach/pkg/multitenant/mtinfopb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/isql"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
@@ -186,4 +188,151 @@ func (p *planner) LookupTenantID(
 		return tid, err
 	}
 	return roachpb.MustMakeTenantID(rec.ID), nil
+}
+
+// GetExtendedTenantInfo hydrates a TenantInfoWithUsage with the
+// additional data beyond the TenantInfo record.
+func GetExtendedTenantInfo(
+	ctx context.Context, txn isql.Txn, info *mtinfopb.TenantInfo,
+) (*mtinfopb.TenantInfoWithUsage, error) {
+	res := &mtinfopb.TenantInfoWithUsage{
+		ProtoInfo: info.ProtoInfo,
+		SQLInfo:   info.SQLInfo,
+	}
+	rows, err := txn.QueryBufferedEx(ctx, "get-tenant-setting-overrides", txn.KV(), sessiondata.NodeUserSessionDataOverride,
+		`SELECT name, value, value_type, reason FROM system.tenant_settings WHERE tenant_id = $1`,
+		info.ID,
+	)
+	if err != nil {
+		return nil, err
+	}
+	for _, row := range rows {
+		override := &mtinfopb.SettingOverride{
+			Name:      string(tree.MustBeDString(row[0])),
+			Value:     string(tree.MustBeDString(row[1])),
+			ValueType: string(tree.MustBeDString(row[2])),
+		}
+		if row[3] != tree.DNull {
+			s := string(tree.MustBeDString(row[3]))
+			override.Reason = &s
+		}
+		res.SettingOverrides = append(res.SettingOverrides, override)
+	}
+
+	row, err := txn.QueryRowEx(ctx, "get-tenant-usage-config", txn.KV(), sessiondata.NodeUserSessionDataOverride,
+		`SELECT ru_current, ru_burst_limit, ru_refill_rate
+       FROM system.tenant_usage
+      WHERE tenant_id = $1 AND instance_id = 0`,
+		info.ID,
+	)
+	if err != nil {
+		return nil, err
+	}
+	if row != nil {
+		res.Usage = &mtinfopb.UsageInfo{
+			RUCurrent:    float64(tree.MustBeDFloat(row[0])),
+			RUBurstLimit: float64(tree.MustBeDFloat(row[1])),
+			RURefillRate: float64(tree.MustBeDFloat(row[2])),
+		}
+	}
+
+	return res, nil
+}
+
+var defaultTenantConfigTemplate = func() *settings.StringSetting {
+	s := settings.RegisterStringSetting(
+		settings.SystemOnly,
+		"sql.create_tenant.default_template",
+		"tenant to use as configuration template when LIKE is not specified in CREATE TENANT",
+		// We use the empty string so that no template is used by default
+		// (i.e. empty proto, no setting overrides).
+		"",
+	)
+	s.SetReportable(true)
+	return s
+}()
+
+// GetTenantTemplate loads the tenant template corresponding to the
+// provided origin tenant. If info is nil, likeTenantID is zero and
+// likeTenantName is empty, the default template is returned.
+func GetTenantTemplate(
+	ctx context.Context,
+	settings *cluster.Settings,
+	txn isql.Txn,
+	info *mtinfopb.TenantInfo,
+	likeTenantID uint64,
+	likeTenantName string,
+) (res *mtinfopb.TenantInfoWithUsage, err error) {
+	if info != nil && (likeTenantID != 0 || likeTenantName != "") {
+		// Sanity check
+		return nil, errors.AssertionFailedf("programming error: cannot pass both default info struct and tenant reference")
+	}
+	if info == nil {
+		if likeTenantID == 0 && likeTenantName == "" {
+			// No LIKE at all. Do we have something in the cluster setting?
+			tmplName := defaultTenantConfigTemplate.Get(&settings.SV)
+			if tmplName == "" {
+				// No template at all - just use an empty protobuf.
+				return &mtinfopb.TenantInfoWithUsage{}, nil
+			}
+			// Use the template specified in the setting.
+			info, err = GetTenantRecordByName(ctx, settings, txn, roachpb.TenantName(tmplName))
+			if err != nil {
+				return nil, errors.Wrapf(err, "retrieving default tenant configuration template %q", tmplName)
+			}
+		} else {
+			if likeTenantID != 0 && likeTenantName != "" {
+				return nil, errors.AssertionFailedf("programming error: conflicting input tenant spec from caller")
+			}
+			// No pre-loaded info, but we have a LIKE clause. Is it by-ID or by-Name?
+			if likeTenantID != 0 {
+				// By-ID.
+				tid, err := roachpb.MakeTenantID(likeTenantID)
+				if err != nil {
+					return nil, errors.Wrap(err, "invalid LIKE tenant ID")
+				}
+				info, err = GetTenantRecordByID(ctx, txn, tid, settings)
+				if err != nil {
+					return nil, errors.Wrap(err, "retrieving LIKE tenant record")
+				}
+			} else {
+				// By-name.
+				info, err = GetTenantRecordByName(ctx, settings, txn, roachpb.TenantName(likeTenantName))
+				if err != nil {
+					return nil, errors.Wrap(err, "retrieving LIKE tenant record")
+				}
+			}
+		}
+	}
+
+	// For now, prevent use of the record for the system tenant. The
+	// user may have the mistaken assumption that "LIKE system" would
+	// create a tenant with all the special cases of the system tenant,
+	// and we do not guarantee that for now.
+	if roachpb.MustMakeTenantID(info.ID).IsSystem() {
+		return nil, errors.WithHint(
+			pgerror.New(pgcode.WrongObjectType, "using the system tenant as config template"),
+			"Create another secondary tenant as template, grant it extra capabilities, and then use that as config template.")
+	}
+
+	// Now we have our info field. Expand it.
+	tmplInfo, err := GetExtendedTenantInfo(ctx, txn, info)
+	if err != nil {
+		return nil, errors.Wrap(err, "retrieving tenant template details")
+	}
+
+	// Clear out the fields we can't reuse in a fresh tenant record.
+	tmplInfo.ID = 0
+	tmplInfo.Name = ""
+	tmplInfo.DataState = mtinfopb.DataStateReady
+	tmplInfo.ServiceMode = mtinfopb.ServiceModeNone
+	tmplInfo.DroppedName = ""
+	tmplInfo.DeprecatedID = 0
+	tmplInfo.DeprecatedDataState = 0
+	tmplInfo.TenantReplicationJobID = 0
+	if tmplInfo.Usage != nil {
+		tmplInfo.Usage.Consumption = kvpb.TenantConsumption{}
+	}
+
+	return tmplInfo, nil
 }


### PR DESCRIPTION
Fixes #98573.
Epic: CRDB-23559
First commit from #98726.

This change introduces the LIKE clause to CREATE TENANT, which makes CREATE TENANT copy the parameters (but not the storage keyspace) from the tenant selected by LIKE.

Also if LIKE is not specified, but the (new) cluster setting `sql.create_tenant.default_template` is not empty, the value of the cluster setting is used implicitly as LIKE clause.

A proposed use of this is cluster-to-cluster replication, considering
cutover as well. On the target (sink) cluster, the operator would do:

```
CREATE TENANT application LIKE app_template
  FROM REPLICATION OF application ON ....
```

And then cutover would look something like the following if they
wanted the tenant to still be named "application"

```
ALTER TENANT application CUTOVER TO LATEST;
DROP TENANT application; -- if there's one already
ALTER TENANT application START SERVICE SHARED;
```

Release note: None