### PR TITLE
release-22.2: sql: check row level ttl change before truncating a table

### DIFF
--- a/pkg/ccl/logictestccl/tests/3node-tenant/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/3node-tenant/generated_test.go
@@ -1912,6 +1912,13 @@ func TestTenantLogic_truncate(
 	runLogicTest(t, "truncate")
 }
 
+func TestTenantLogic_truncate_with_concurrent_mutation(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "truncate_with_concurrent_mutation")
+}
+
 func TestTenantLogic_tuple(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/testdata/logic_test/truncate_with_concurrent_mutation
+++ b/pkg/sql/logictest/testdata/logic_test/truncate_with_concurrent_mutation
@@ -1,0 +1,123 @@
+statement ok
+SET CLUSTER SETTING jobs.registry.interval.adopt = '50ms';
+
+statement ok
+SET CLUSTER SETTING jobs.registry.interval.cancel = '50ms'
+
+# Make sure that table cannot be truncated if an index is being dropped
+# concurrently.
+statement ok
+CREATE TABLE t1(a int primary key, b int);
+
+statement ok
+CREATE INDEX idx_b ON t1(b);
+
+statement ok
+SET CLUSTER SETTING jobs.debug.pausepoints = 'schemachanger.before.exec,newschemachanger.before.exec';
+
+statement error pq: job \d+ was paused before it completed with reason: pause point
+DROP INDEX t1@idx_b;
+
+statement error pq: unimplemented: cannot perform TRUNCATE on "t1" which has indexes being dropped
+TRUNCATE TABLE t1;
+
+statement ok
+SET CLUSTER SETTING jobs.debug.pausepoints = '';
+
+# Make sure that table cannot be truncated if a column using UDY is being
+# dropped concurrently.
+statement ok
+CREATE TYPE e AS ENUM ('v1', 'v2');
+CREATE TABLE t2(a int primary key, b e);
+
+statement ok
+SET CLUSTER SETTING jobs.debug.pausepoints = 'schemachanger.before.exec,newschemachanger.before.exec';
+
+statement error pq: job \d+ was paused before it completed with reason: pause point
+ALTER TABLE t2 DROP COLUMN b;
+
+statement error pq: unimplemented: cannot perform TRUNCATE on "t2" which has a column \("\w+"\) being dropped which depends on another object
+TRUNCATE TABLE t2;
+
+statement ok
+SET CLUSTER SETTING jobs.debug.pausepoints = '';
+
+# Make sure that table cannot be truncated when a constraint without index is
+# being added concurrently.
+statement ok
+CREATE TABLE t3(a INT PRIMARY KEY, b INT);
+
+statement ok
+SET CLUSTER SETTING jobs.debug.pausepoints = 'schemachanger.before.exec,newschemachanger.before.exec';
+
+statement error pq: job \d+ was paused before it completed with reason: pause point
+ALTER TABLE t3 ADD CONSTRAINT ckb CHECK (b > 3);
+
+statement error pq: unimplemented: cannot perform TRUNCATE on "t3" which has an ongoing CHECK constraint change
+TRUNCATE TABLE t3;
+
+statement ok
+SET CLUSTER SETTING jobs.debug.pausepoints = '';
+
+# Make sure table cannot be truncated if there is concurrent primary key change.
+statement ok
+CREATE TABLE t4(a INT PRIMARY KEY, b INT NOT NULL);
+
+statement ok
+SET CLUSTER SETTING jobs.debug.pausepoints = 'schemachanger.before.exec,newschemachanger.before.exec';
+
+statement error pq: job \d+ was paused before it completed with reason: pause point
+ALTER TABLE t4 ALTER PRIMARY KEY USING COLUMNS (b);
+
+# In Declarative schema changer we don't generate a primary key swap mutation.
+# So the truncate will wait until the concurrent schema change to finish and
+# hang this test. So we need to test this only in legacy schema changer.
+onlyif config local-legacy-schema-changer
+statement error pq: unimplemented: cannot perform TRUNCATE on "t4" which has an ongoing primary key change
+TRUNCATE TABLE t4;
+
+statement ok
+SET CLUSTER SETTING jobs.debug.pausepoints = '';
+
+# Make sure table cannot be truncated when there is concurrent column type
+# change.
+statement ok
+CREATE TABLE t5(a int primary key, b int);
+
+statement ok
+SET CLUSTER SETTING jobs.debug.pausepoints = 'schemachanger.before.exec,newschemachanger.before.exec';
+
+statement ok
+SET enable_experimental_alter_column_type_general = true;
+
+statement error pq: job \d+ was paused before it completed with reason: pause point
+ALTER TABLE t5 ALTER COLUMN b TYPE STRING;
+
+statement error pq: unimplemented: cannot perform TRUNCATE on "t5" which has an ongoing column type change
+TRUNCATE TABLE t5;
+
+statement ok
+SET CLUSTER SETTING jobs.debug.pausepoints = '';
+
+# Make sure that table cannot be truncated is there is a ongoing row level TTL
+# change.
+statement ok
+CREATE TABLE t6(a int primary key, b int);
+
+statement ok
+SET CLUSTER SETTING jobs.debug.pausepoints = 'schemachanger.before.exec,newschemachanger.before.exec';
+
+statement error pq: job \d+ was paused before it completed with reason: pause point
+ALTER TABLE t6 SET (ttl_expire_after = '00:10:00':::INTERVAL);
+
+statement error pq: unimplemented: cannot perform TRUNCATE on "t6" which has an ongoing row level TTL change
+TRUNCATE TABLE t6;
+
+statement ok
+SET CLUSTER SETTING jobs.debug.pausepoints = '';
+
+statement ok
+RESUME JOBS (SELECT job_id FROM crdb_internal.jobs WHERE status = 'paused');
+
+statement ok
+USE test;

--- a/pkg/sql/logictest/tests/fakedist-disk/generated_test.go
+++ b/pkg/sql/logictest/tests/fakedist-disk/generated_test.go
@@ -1885,6 +1885,13 @@ func TestLogic_truncate(
 	runLogicTest(t, "truncate")
 }
 
+func TestLogic_truncate_with_concurrent_mutation(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "truncate_with_concurrent_mutation")
+}
+
 func TestLogic_tuple(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/fakedist-vec-off/generated_test.go
+++ b/pkg/sql/logictest/tests/fakedist-vec-off/generated_test.go
@@ -1892,6 +1892,13 @@ func TestLogic_truncate(
 	runLogicTest(t, "truncate")
 }
 
+func TestLogic_truncate_with_concurrent_mutation(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "truncate_with_concurrent_mutation")
+}
+
 func TestLogic_tuple(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/fakedist/generated_test.go
+++ b/pkg/sql/logictest/tests/fakedist/generated_test.go
@@ -1906,6 +1906,13 @@ func TestLogic_truncate(
 	runLogicTest(t, "truncate")
 }
 
+func TestLogic_truncate_with_concurrent_mutation(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "truncate_with_concurrent_mutation")
+}
+
 func TestLogic_tuple(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/local-legacy-schema-changer/generated_test.go
+++ b/pkg/sql/logictest/tests/local-legacy-schema-changer/generated_test.go
@@ -1871,6 +1871,13 @@ func TestLogic_truncate(
 	runLogicTest(t, "truncate")
 }
 
+func TestLogic_truncate_with_concurrent_mutation(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "truncate_with_concurrent_mutation")
+}
+
 func TestLogic_tuple(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/local-vec-off/generated_test.go
+++ b/pkg/sql/logictest/tests/local-vec-off/generated_test.go
@@ -1899,6 +1899,13 @@ func TestLogic_truncate(
 	runLogicTest(t, "truncate")
 }
 
+func TestLogic_truncate_with_concurrent_mutation(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "truncate_with_concurrent_mutation")
+}
+
 func TestLogic_tuple(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/local/generated_test.go
+++ b/pkg/sql/logictest/tests/local/generated_test.go
@@ -2060,6 +2060,13 @@ func TestLogic_truncate(
 	runLogicTest(t, "truncate")
 }
 
+func TestLogic_truncate_with_concurrent_mutation(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "truncate_with_concurrent_mutation")
+}
+
 func TestLogic_tuple(
 	t *testing.T,
 ) {

--- a/pkg/sql/truncate.go
+++ b/pkg/sql/truncate.go
@@ -364,6 +364,11 @@ func checkTableForDisallowedMutationsWithTruncate(desc *tabledesc.Mutable) error
 				"TRUNCATE concurrent with ongoing schema change",
 				"cannot perform TRUNCATE on %q which has an ongoing column type "+
 					"change", desc.GetName())
+		} else if m.AsModifyRowLevelTTL() != nil {
+			return unimplemented.Newf(
+				"TRUNCATE concurrent with ongoing schema change",
+				"cannot perform TRUNCATE on %q which has an ongoing row level TTL "+
+					"change", desc.GetName())
 		} else {
 			return errors.AssertionFailedf("cannot perform TRUNCATE due to "+
 				"concurrent unknown mutation of type %T for mutation %d in %v", m, i, desc)


### PR DESCRIPTION
Backport 1/1 commits from #98537.

/cc @cockroachdb/release

---

Fixes: #93443

Release note (sql change): This commit fixed a bug where crdb paniced wehn user tried to truncate a table which is has an ongoing row level ttl change. We still don't support table truncates in this scenario, but a more gentle unimplemented error is returned instead of panic.

Release justification: low risk and necessary bug fix.