### PR TITLE
sql: use lower admission control priority in schema changes

### DIFF
--- a/pkg/ccl/backupccl/restore_job.go
+++ b/pkg/ccl/backupccl/restore_job.go
@@ -61,6 +61,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
 	"github.com/cockroachdb/cockroach/pkg/sql/stats"
+	"github.com/cockroachdb/cockroach/pkg/util/admission/admissionpb"
 	"github.com/cockroachdb/cockroach/pkg/util/ctxgroup"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/interval"
@@ -1876,7 +1877,7 @@ func revalidateIndexes(
 	runner := descs.NewHistoricalInternalExecTxnRunner(hlc.Timestamp{}, func(ctx context.Context, fn descs.InternalExecFn) error {
 		return execCfg.InternalDB.DescsTxn(ctx, func(ctx context.Context, txn descs.Txn) error {
 			return fn(ctx, txn)
-		})
+		}, isql.WithPriority(admissionpb.BulkNormalPri))
 	})
 
 	invalidIndexes := make(map[descpb.ID][]descpb.IndexID)

--- a/pkg/sql/schema_changer.go
+++ b/pkg/sql/schema_changer.go
@@ -55,6 +55,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondatapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlerrors"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqltelemetry"
+	"github.com/cockroachdb/cockroach/pkg/util/admission/admissionpb"
 	"github.com/cockroachdb/cockroach/pkg/util/grpcutil"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -2460,7 +2461,7 @@ func (sc *SchemaChanger) txn(ctx context.Context, f func(context.Context, descs.
 		ctx context.Context, txn descs.Txn,
 	) error {
 		return f(ctx, txn)
-	})
+	}, isql.WithPriority(admissionpb.BulkNormalPri))
 }
 
 // createSchemaChangeEvalCtx creates an extendedEvalContext() to be used for backfills.

--- a/pkg/sql/schemachanger/scdeps/BUILD.bazel
+++ b/pkg/sql/schemachanger/scdeps/BUILD.bazel
@@ -42,6 +42,7 @@ go_library(
         "//pkg/sql/sqlerrors",
         "//pkg/sql/sqltelemetry",
         "//pkg/sql/types",
+        "//pkg/util/admission/admissionpb",
         "//pkg/util/timeutil",
         "//pkg/util/uuid",
         "@com_github_cockroachdb_errors//:errors",

--- a/pkg/sql/schemachanger/scdeps/validator.go
+++ b/pkg/sql/schemachanger/scdeps/validator.go
@@ -24,6 +24,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/isql"
 	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scexec"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
+	"github.com/cockroachdb/cockroach/pkg/util/admission/admissionpb"
 )
 
 // ValidateForwardIndexesFn callback function for validating forward indexes.
@@ -137,7 +138,7 @@ func (vd validator) makeHistoricalInternalExecTxnRunner() descs.HistoricalIntern
 				return err
 			}
 			return fn(ctx, txn)
-		})
+		}, isql.WithPriority(admissionpb.BulkNormalPri))
 	})
 }
 


### PR DESCRIPTION
This will change the transaction priority for schema changes and the corresponding validation transactions to be run at the BulkPri priority level.

Epic: none

Fixes: #98592

Release note: None