### PR TITLE
tsearch: speed up TSVector.String

### DIFF
--- a/pkg/sql/sem/tree/datum.go
+++ b/pkg/sql/sem/tree/datum.go
@@ -4059,7 +4059,7 @@ func (d *DTSVector) Min(_ CompareContext) (Datum, bool) {
 
 // Size implements the Datum interface.
 func (d *DTSVector) Size() uintptr {
-	return uintptr(len(d.TSVector.String()))
+	return uintptr(d.TSVector.StringSize())
 }
 
 // AsDTSVector attempts to retrieve a DTSVector from an Expr, returning a

--- a/pkg/util/tsearch/tsvector.go
+++ b/pkg/util/tsearch/tsvector.go
@@ -11,7 +11,6 @@
 package tsearch
 
 import (
-	"fmt"
 	"sort"
 	"strconv"
 	"strings"
@@ -73,24 +72,22 @@ const (
 	weightAny = weightA | weightB | weightC | weightD
 )
 
-func (w tsWeight) String() string {
-	var ret strings.Builder
+func (w tsWeight) writeString(buf *strings.Builder) {
 	if w&weightStar != 0 {
-		ret.WriteByte('*')
+		buf.WriteByte('*')
 	}
 	if w&weightA != 0 {
-		ret.WriteByte('A')
+		buf.WriteByte('A')
 	}
 	if w&weightB != 0 {
-		ret.WriteByte('B')
+		buf.WriteByte('B')
 	}
 	if w&weightC != 0 {
-		ret.WriteByte('C')
+		buf.WriteByte('C')
 	}
 	if w&weightD != 0 {
-		ret.WriteByte('D')
+		buf.WriteByte('D')
 	}
-	return ret.String()
 }
 
 // TSVectorPGEncoding returns the PG-compatible wire protocol encoding for a
@@ -167,28 +164,36 @@ func newLexemeTerm(lexeme string) (tsTerm, error) {
 	return tsTerm{lexeme: lexeme}, nil
 }
 
-func (t tsTerm) String() string {
+func (t tsTerm) writeString(buf *strings.Builder) {
 	if t.operator != 0 {
 		switch t.operator {
 		case and:
-			return "&"
+			buf.WriteString("&")
+			return
 		case or:
-			return "|"
+			buf.WriteString("|")
+			return
 		case not:
-			return "!"
+			buf.WriteString("!")
+			return
 		case lparen:
-			return "("
+			buf.WriteString("(")
+			return
 		case rparen:
-			return ")"
+			buf.WriteString(")")
+			return
 		case followedby:
+			buf.WriteString("<")
 			if t.followedN == 1 {
-				return "<->"
+				buf.WriteString("-")
+			} else {
+				buf.WriteString(strconv.Itoa(int(t.followedN)))
 			}
-			return fmt.Sprintf("<%d>", t.followedN)
+			buf.WriteString(">")
+			return
 		}
 	}
 
-	var buf strings.Builder
 	buf.WriteByte('\'')
 	for _, r := range t.lexeme {
 		if r == '\'' {
@@ -208,9 +213,8 @@ func (t tsTerm) String() string {
 		if pos.position > 0 {
 			buf.WriteString(strconv.Itoa(int(pos.position)))
 		}
-		buf.WriteString(pos.weight.String())
+		pos.weight.writeString(buf)
 	}
-	return buf.String()
 }
 
 func (t tsTerm) matchesWeight(targetWeight tsWeight) bool {
@@ -240,7 +244,7 @@ func (t TSVector) String() string {
 		if i > 0 {
 			buf.WriteByte(' ')
 		}
-		buf.WriteString(term.String())
+		term.writeString(&buf)
 	}
 	return buf.String()
 }

--- a/pkg/util/tsearch/tsvector_test.go
+++ b/pkg/util/tsearch/tsvector_test.go
@@ -187,3 +187,26 @@ func TestParseTSRandom(t *testing.T) {
 		assert.Equal(t, v, v2)
 	}
 }
+
+func BenchmarkTSVector(b *testing.B) {
+	r, _ := randutil.NewTestRand()
+	tsVectors := make([]TSVector, 10000)
+	for i := range tsVectors {
+		tsVectors[i] = RandomTSVector(r)
+	}
+	b.ResetTimer()
+	b.Run("String", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			for _, v := range tsVectors {
+				_ = v.String()
+			}
+		}
+	})
+	b.Run("StringSize", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			for _, v := range tsVectors {
+				_ = len(v.String())
+			}
+		}
+	})
+}

--- a/pkg/util/tsearch/tsvector_test.go
+++ b/pkg/util/tsearch/tsvector_test.go
@@ -188,6 +188,14 @@ func TestParseTSRandom(t *testing.T) {
 	}
 }
 
+func TestTSVectorStringSize(t *testing.T) {
+	r, _ := randutil.NewTestRand()
+	for i := 0; i < 1000; i++ {
+		v := RandomTSVector(r)
+		require.Equal(t, len(v.String()), v.StringSize())
+	}
+}
+
 func BenchmarkTSVector(b *testing.B) {
 	r, _ := randutil.NewTestRand()
 	tsVectors := make([]TSVector, 10000)
@@ -205,7 +213,7 @@ func BenchmarkTSVector(b *testing.B) {
 	b.Run("StringSize", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
 			for _, v := range tsVectors {
-				_ = len(v.String())
+				_ = v.StringSize()
 			}
 		}
 	})


### PR DESCRIPTION
Fixes: #98595.

**tsearch: speed up TSVector.String**

This commit speeds up `TSVector.String` by reusing exactly the same
`strings.Builder` object for all parts of the TSVector.

This commit also introduces a simple benchmark for this method.
`benchstat` seems to be busted a bit, but the impact of this commit is:
```
                       │ /tmp/tmp.Unz2XLUFdB/bench.HEAD^^ │   /tmp/tmp.Unz2XLUFdB/bench.HEAD^   │
                       │              sec/op              │   sec/op     vs base                │
TSVector/String-24                           14.590m ± 0%   8.272m ± 0%  -43.31% (p=0.000 n=10)
TSVector/StringSize-24                       14.654m ± 0%   8.269m ± 0%  -43.57% (p=0.000 n=10)
geomean                                       14.62m        8.270m       -43.44%

                       │ /tmp/tmp.Unz2XLUFdB/bench.HEAD^^ │   /tmp/tmp.Unz2XLUFdB/bench.HEAD^    │
                       │               B/op               │     B/op      vs base                │
TSVector/String-24                           4.516Mi ± 0%   2.319Mi ± 0%  -48.65% (p=0.000 n=10)
TSVector/StringSize-24                       4.516Mi ± 0%   2.319Mi ± 0%  -48.65% (p=0.000 n=10)
geomean                                      4.516Mi        2.319Mi       -48.65%

                       │ /tmp/tmp.Unz2XLUFdB/bench.HEAD^^ │   /tmp/tmp.Unz2XLUFdB/bench.HEAD^   │
                       │            allocs/op             │  allocs/op   vs base                │
TSVector/String-24                            273.6k ± 0%   105.6k ± 0%  -61.41% (p=0.000 n=10)
TSVector/StringSize-24                        273.6k ± 0%   105.6k ± 0%  -61.41% (p=0.000 n=10)
geomean                                       273.6k        105.6k       -61.41%
```

Release note: None

**tsearch: add optimize StringSize method**

This commit introduces `TSVector.StringSize` method which is optimized
equivalent of `len(TSVector.String())` which avoids the construction of
the string. This method is now utilized by `DTSVector.Size`. This
results in some code duplication but it seems worth it:
```
                       │ /tmp/tmp.zD8FYqMrdo/bench.HEAD^ │   /tmp/tmp.zD8FYqMrdo/bench.HEAD    │
                       │             sec/op              │   sec/op     vs base                │
TSVector/String-24                           8.404m ± 0%   8.135m ± 0%   -3.20% (p=0.000 n=10)
TSVector/StringSize-24                       8.381m ± 0%   3.547m ± 0%  -57.67% (p=0.000 n=10)
geomean                                      8.393m        5.372m       -35.99%

                       │ /tmp/tmp.zD8FYqMrdo/bench.HEAD^ │    /tmp/tmp.zD8FYqMrdo/bench.HEAD    │
                       │              B/op               │     B/op      vs base                │
TSVector/String-24                          2.349Mi ± 0%   2.323Mi ± 0%   -1.12% (p=0.000 n=10)
TSVector/StringSize-24                     2405.6Ki ± 0%   192.1Ki ± 0%  -92.02% (p=0.000 n=10)
geomean                                     2.349Mi        675.9Ki       -71.90%

                       │ /tmp/tmp.zD8FYqMrdo/bench.HEAD^ │   /tmp/tmp.zD8FYqMrdo/bench.HEAD    │
                       │            allocs/op            │  allocs/op   vs base                │
TSVector/String-24                           106.7k ± 0%   105.8k ± 0%   -0.88% (p=0.000 n=10)
TSVector/StringSize-24                      106.72k ± 0%   61.46k ± 0%  -42.41% (p=0.000 n=10)
geomean                                      106.7k        80.63k       -24.44%
```

Release note: None