### PR TITLE
upgrades: use v22_2 bootstrap schema with role_members test

### DIFF
--- a/pkg/upgrade/upgrades/role_members_ids_migration_test.go
+++ b/pkg/upgrade/upgrades/role_members_ids_migration_test.go
@@ -18,16 +18,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/clusterversion"
-	"github.com/cockroachdb/cockroach/pkg/keys"
-	"github.com/cockroachdb/cockroach/pkg/security/username"
 	"github.com/cockroachdb/cockroach/pkg/server"
-	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
-	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catenumpb"
-	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catpb"
-	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
-	"github.com/cockroachdb/cockroach/pkg/sql/catalog/systemschema"
-	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
-	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
@@ -54,19 +45,13 @@ func runTestRoleMembersIDMigration(t *testing.T, numUsers int) {
 	defer leaktest.AfterTest(t)()
 	ctx := context.Background()
 
-	settings := cluster.MakeTestingClusterSettingsWithVersions(
-		clusterversion.TestingBinaryVersion,
-		clusterversion.ByKey(clusterversion.V23_1RoleMembersTableHasIDColumns-1),
-		false,
-	)
-
 	tc := testcluster.StartTestCluster(t, 1 /* nodes */, base.TestClusterArgs{
 		ServerArgs: base.TestServerArgs{
-			Settings: settings,
 			Knobs: base.TestingKnobs{
 				Server: &server.TestingKnobs{
+					BootstrapVersionKeyOverride:    clusterversion.V22_2,
 					DisableAutomaticVersionUpgrade: make(chan struct{}),
-					BinaryVersionOverride:          clusterversion.ByKey(clusterversion.V23_1RoleMembersTableHasIDColumns - 1),
+					BinaryVersionOverride:          clusterversion.ByKey(clusterversion.V22_2),
 				},
 			},
 		},
@@ -76,15 +61,10 @@ func runTestRoleMembersIDMigration(t *testing.T, numUsers int) {
 	db := tc.ServerConn(0)
 	defer db.Close()
 	tdb := sqlutils.MakeSQLRunner(db)
-	s := tc.Server(0)
 
 	// Delete all rows from the system.role_members table.
 	tdb.Exec(t, "DELETE FROM system.role_members WHERE true")
 	tdb.CheckQueryResults(t, "SELECT * FROM system.role_members", [][]string{})
-
-	// Inject the descriptor for the system.role_members table from before the
-	// ID columns were added.
-	upgrades.InjectLegacyTable(ctx, t, s, systemschema.RoleMembersTable, getTableDescForSystemRoleMembersTableBeforeIDCols)
 
 	// Insert row that would have been added in a legacy startup migration.
 	tdb.Exec(t, `INSERT INTO system.role_members ("role", "member", "isAdmin") VALUES ('admin', 'root', true)`)
@@ -150,71 +130,4 @@ func runTestRoleMembersIDMigration(t *testing.T, numUsers int) {
 	var actualSchema string
 	require.NoError(t, r.Scan(&actualSchema))
 	require.Equal(t, expectedSchema, actualSchema)
-}
-
-func getTableDescForSystemRoleMembersTableBeforeIDCols() *descpb.TableDescriptor {
-	return &descpb.TableDescriptor{
-		Name:                    "role_members",
-		ID:                      keys.RoleMembersTableID,
-		ParentID:                keys.SystemDatabaseID,
-		UnexposedParentSchemaID: keys.PublicSchemaID,
-		Version:                 1,
-		Columns: []descpb.ColumnDescriptor{
-			{Name: "role", ID: 1, Type: types.String},
-			{Name: "member", ID: 2, Type: types.String},
-			{Name: "isAdmin", ID: 3, Type: types.Bool},
-		},
-		NextColumnID: 4,
-		Families: []descpb.ColumnFamilyDescriptor{
-			{
-				Name:        "primary",
-				ID:          0,
-				ColumnNames: []string{"role", "member"},
-				ColumnIDs:   []descpb.ColumnID{1, 2},
-			},
-			{
-				Name:            "fam_3_isAdmin",
-				ID:              3,
-				ColumnNames:     []string{"isAdmin"},
-				ColumnIDs:       []descpb.ColumnID{3},
-				DefaultColumnID: 3,
-			},
-		},
-		NextFamilyID: 4,
-		PrimaryIndex: descpb.IndexDescriptor{
-			Name:                "primary",
-			ID:                  1,
-			Unique:              true,
-			KeyColumnNames:      []string{"role", "member"},
-			KeyColumnDirections: []catenumpb.IndexColumn_Direction{catenumpb.IndexColumn_ASC, catenumpb.IndexColumn_ASC},
-			KeyColumnIDs:        []descpb.ColumnID{1, 2},
-		},
-		Indexes: []descpb.IndexDescriptor{
-			{
-				Name:                "role_members_role_idx",
-				ID:                  2,
-				Unique:              false,
-				KeyColumnNames:      []string{"role"},
-				KeyColumnDirections: []catenumpb.IndexColumn_Direction{catenumpb.IndexColumn_ASC},
-				KeyColumnIDs:        []descpb.ColumnID{1},
-				KeySuffixColumnIDs:  []descpb.ColumnID{2},
-				Version:             descpb.StrictIndexColumnIDGuaranteesVersion,
-			},
-			{
-				Name:                "role_members_member_idx",
-				ID:                  3,
-				Unique:              false,
-				KeyColumnNames:      []string{"member"},
-				KeyColumnDirections: []catenumpb.IndexColumn_Direction{catenumpb.IndexColumn_ASC},
-				KeyColumnIDs:        []descpb.ColumnID{2},
-				KeySuffixColumnIDs:  []descpb.ColumnID{1},
-				Version:             descpb.StrictIndexColumnIDGuaranteesVersion,
-			},
-		},
-		NextIndexID:      4,
-		Privileges:       catpb.NewCustomSuperuserPrivilegeDescriptor(privilege.ReadWriteData, username.NodeUserName()),
-		FormatVersion:    descpb.InterleavedFormatVersion,
-		NextMutationID:   1,
-		NextConstraintID: 1,
-	}
 }


### PR DESCRIPTION
Previously the role members test used the v23_1 schema with the V23_1RoleMembersTableHasIDColumns version gate. This caused problems for PR #98446 because the lease schema does not match the lease version gates.

Now, the test uses the BootstrapVersionKeyOverride to bootstrap with the V22_2 schema. Setting the cluster version walks the cluster through all of the migrations including the role members migration.

Part of #98446

Release Note: none