### PR TITLE
sql_test: re-skip TestShowTraceReplica

### DIFF
--- a/pkg/sql/show_trace_replica_test.go
+++ b/pkg/sql/show_trace_replica_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/server"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
@@ -32,6 +33,8 @@ import (
 func TestShowTraceReplica(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
+
+	skip.WithIssue(t, 98598)
 
 	const numNodes = 4
 


### PR DESCRIPTION
TestShowTraceReplica wasn't failing under stress, but failed in TeamCity
once enabled. This re-skips the test until it can be reliably reproduced
and debugged.

Informs #98598

Release note: None 