### PR TITLE
sql: fix data race in MemberOfWithAdminOption

### DIFF
--- a/pkg/sql/user_test.go
+++ b/pkg/sql/user_test.go
@@ -24,7 +24,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sqltestutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
-	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -42,11 +41,6 @@ import (
 func TestGetUserTimeout(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-
-	// We want to use a low timeout below to prevent
-	// this test from taking forever, however
-	// race builds are so slow as to trigger this timeout spuriously.
-	skip.UnderRace(t)
 
 	testutils.RunTrueAndFalse(t, "TestGetUserTimeout/single_scan", func(t *testing.T, singleScanEnabled bool) {
 


### PR DESCRIPTION
This patch fixes a race condition in MemberOfWithAdminOption
by using a fresh transaction within the singleflight call.

Fixes #95642
Fixes #96539

Release note: None