### PR TITLE
kv: don't perform async intent resolution on 1PC with point lock spans

### DIFF
--- a/pkg/kv/kvserver/kvserverbase/base.go
+++ b/pkg/kv/kvserver/kvserverbase/base.go
@@ -178,7 +178,8 @@ func ContainsKeyRange(desc *roachpb.RangeDescriptor, start, end roachpb.Key) boo
 // into up to three pieces: A first piece which is contained in the Range,
 // and a slice of up to two further spans which are outside of the key
 // range. An span for which [Key, EndKey) is empty does not result in any
-// spans; thus IntersectSpan only applies to span ranges.
+// spans; thus IntersectSpan only applies to span ranges and point keys will
+// cause the function to panic.
 //
 // A range-local span range is never split: It's returned as either
 // belonging to or outside of the descriptor's key range, and passing an
@@ -191,8 +192,7 @@ func IntersectSpan(
 ) (middle *roachpb.Span, outside []roachpb.Span) {
 	start, end := desc.StartKey.AsRawKey(), desc.EndKey.AsRawKey()
 	if len(span.EndKey) == 0 {
-		outside = append(outside, span)
-		return
+		panic("unsupported point key")
 	}
 	if bytes.Compare(span.Key, keys.LocalRangeMax) < 0 {
 		if bytes.Compare(span.EndKey, keys.LocalRangeMax) >= 0 {


### PR DESCRIPTION
Fixes #98571.

This commit fixes the regression detected in #98571. In that issue, we saw that the bug fix in 86a5852 (#98044) caused a regression in kv0 (and other benchmarks). This was due to a bug in `kvserverbase.IntersectSpan`, which was considering local point spans to be external to the provided range span.

This commit fixes the bug by not calling `kvserverbase.IntersectSpan` for point lock spans.

The commit also makes the utility panic instead of silently returning incorrect results. There's an existing TODO on the utility to generalize it. For now, we just make it harder to misuse.

Finally, we add a test that asserts against the presence of async intent resolution after one-phase commits when external intent resolution is not needed.

```
name                            old time/op    new time/op    delta
KV/Insert/Native/rows=1-10        61.2µs ± 3%    48.9µs ± 3%  -20.10%  (p=0.000 n=8+9)
KV/Insert/Native/rows=10-10       93.3µs ±15%    76.2µs ± 3%  -18.34%  (p=0.000 n=9+9)
KV/Insert/Native/rows=1000-10     2.84ms ±12%    2.42ms ± 4%  -14.97%  (p=0.000 n=9+9)
KV/Insert/Native/rows=100-10       365µs ± 5%     320µs ± 8%  -12.40%  (p=0.000 n=10+9)
KV/Insert/Native/rows=10000-10    27.6ms ± 6%    24.4ms ± 3%  -11.53%  (p=0.000 n=9+9)

name                            old alloc/op   new alloc/op   delta
KV/Insert/Native/rows=1000-10     4.66MB ± 1%    2.76MB ± 1%  -40.89%  (p=0.000 n=9+9)
KV/Insert/Native/rows=100-10       478kB ± 1%     287kB ± 1%  -39.90%  (p=0.000 n=10+10)
KV/Insert/Native/rows=10000-10    54.2MB ± 2%    34.3MB ± 3%  -36.73%  (p=0.000 n=10+10)
KV/Insert/Native/rows=10-10       64.2kB ± 1%    42.1kB ± 1%  -34.39%  (p=0.000 n=10+9)
KV/Insert/Native/rows=1-10        22.1kB ± 1%    17.3kB ± 1%  -21.56%  (p=0.000 n=9+10)

name                            old allocs/op  new allocs/op  delta
KV/Insert/Native/rows=1000-10      21.5k ± 0%     14.7k ± 0%  -31.70%  (p=0.000 n=8+9)
KV/Insert/Native/rows=10000-10      212k ± 0%      146k ± 0%  -31.31%  (p=0.000 n=9+10)
KV/Insert/Native/rows=100-10       2.34k ± 1%     1.61k ± 0%  -31.31%  (p=0.000 n=10+10)
KV/Insert/Native/rows=10-10          392 ± 1%       276 ± 0%  -29.59%  (p=0.000 n=8+8)
KV/Insert/Native/rows=1-10           173 ± 1%       123 ± 0%  -29.04%  (p=0.000 n=9+8)
```

Release note: None