### PR TITLE
release-22.2: sql: add VIEWACTIVITY/VIEWACTIVITREDACTED permission for `ranges_no_leases`

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/crdb_internal_tenant
+++ b/pkg/ccl/logictestccl/testdata/logic_test/crdb_internal_tenant
@@ -419,7 +419,7 @@ select crdb_internal.get_vmodule()
 query error pq: only users with the admin role are allowed to access the node runtime information
 select * from crdb_internal.node_runtime_info
 
-query error pq: only users with the ZONECONFIG privilege or the admin role can read crdb_internal.ranges_no_leases
+query error pq: only users with the VIEWACTIVITY or VIEWACTIVITYREDACTED or ZONECONFIG privilege or the admin role can read crdb_internal.ranges_no_leases
 select * from crdb_internal.ranges
 
 query error pq: only users with the admin role are allowed to read crdb_internal.gossip_nodes

--- a/pkg/sql/delegate/show_range_for_row.go
+++ b/pkg/sql/delegate/show_range_for_row.go
@@ -15,6 +15,7 @@ import (
 	"fmt"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/cat"
+	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqltelemetry"
 	"github.com/cockroachdb/errors"
@@ -26,7 +27,8 @@ func (d *delegator) delegateShowRangeForRow(n *tree.ShowRangeForRow) (tree.State
 	if err != nil {
 		return nil, err
 	}
-	if err := checkPrivilegesForShowRanges(d, idx.Table()); err != nil {
+	// Basic requirement is SELECT privileges
+	if err = d.catalog.CheckPrivilege(d.ctx, idx.Table(), privilege.SELECT); err != nil {
 		return nil, err
 	}
 	if idx.Table().IsVirtualTable() {

--- a/pkg/sql/logictest/testdata/logic_test/crdb_internal
+++ b/pkg/sql/logictest/testdata/logic_test/crdb_internal
@@ -667,8 +667,11 @@ select crdb_internal.get_vmodule()
 query error pq: only users with the admin role are allowed to access the node runtime information
 select * from crdb_internal.node_runtime_info
 
-query error pq: only users with the ZONECONFIG privilege or the admin role can read crdb_internal.ranges_no_leases
+query error pq: only users with the VIEWACTIVITY or VIEWACTIVITYREDACTED or ZONECONFIG privilege or the admin role can read crdb_internal.ranges_no_leases
 select * from crdb_internal.ranges
+
+query error pq: user testuser does not have SELECT privilege on relation foo
+SHOW RANGES FROM TABLE foo
 
 query error pq: only users with the admin role are allowed to read crdb_internal.gossip_nodes
 select * from crdb_internal.gossip_nodes


### PR DESCRIPTION
Backport 1/1 commits from #98535.

/cc @cockroachdb/release

---

Fixes: #98514

This change adds the `VIEWACTIVITY` and `VIEWACTIVITYREDACTED` permissions access to `ranges_no_leases`. This allows users to view range data, necessary to use popular console pages:
- databases page
- database details page
- database table page

Prior to this change, users with `VIEWACTIVITY`/`VIEWACTIVITYREDACTED` would not be able to view these pages (would show error notification).

Release note (bug fix): Allow users with
`VIEWACTIVITY`/`VIEWACTIVITYREDACTED` permissions to access `ranges_no_leases` table, necessary to view important console pages (databases, database details, and database table pages).

Release justification: Category 2: Bug fixes and low-risk updates to new functionality