### PR TITLE
execinfra: explicitly pass the output RowReceiver to Processor.Run

### DIFF
--- a/pkg/ccl/backupccl/backup_processor.go
+++ b/pkg/ccl/backupccl/backup_processor.go
@@ -107,7 +107,6 @@ type backupDataProcessor struct {
 
 	flowCtx *execinfra.FlowCtx
 	spec    execinfrapb.BackupDataSpec
-	output  execinfra.RowReceiver
 
 	// cancelAndWaitForWorker cancels the producer goroutine and waits for it to
 	// finish. It can be called multiple times.
@@ -134,7 +133,6 @@ func newBackupDataProcessor(
 	processorID int32,
 	spec execinfrapb.BackupDataSpec,
 	post *execinfrapb.PostProcessSpec,
-	output execinfra.RowReceiver,
 ) (execinfra.Processor, error) {
 	memMonitor := flowCtx.Cfg.BackupMonitor
 	if knobs, ok := flowCtx.TestingKnobs().BackupRestoreTestingKnobs.(*sql.BackupRestoreTestingKnobs); ok {
@@ -146,11 +144,10 @@ func newBackupDataProcessor(
 	bp := &backupDataProcessor{
 		flowCtx: flowCtx,
 		spec:    spec,
-		output:  output,
 		progCh:  make(chan execinfrapb.RemoteProducerMetadata_BulkProcessorProgress),
 		memAcc:  &ba,
 	}
-	if err := bp.Init(ctx, bp, post, backupOutputTypes, flowCtx, processorID, output, nil, /* memMonitor */
+	if err := bp.Init(ctx, bp, post, backupOutputTypes, flowCtx, processorID, nil, /* memMonitor */
 		execinfra.ProcStateOpts{
 			// This processor doesn't have any inputs to drain.
 			InputsToDrain: nil,

--- a/pkg/ccl/backupccl/generative_split_and_scatter_processor.go
+++ b/pkg/ccl/backupccl/generative_split_and_scatter_processor.go
@@ -49,7 +49,6 @@ type generativeSplitAndScatterProcessor struct {
 
 	flowCtx *execinfra.FlowCtx
 	spec    execinfrapb.GenerativeSplitAndScatterSpec
-	output  execinfra.RowReceiver
 
 	// chunkSplitAndScatterers contain the splitAndScatterers for the group of
 	// split and scatter workers that's responsible for splitting and scattering
@@ -80,7 +79,6 @@ func newGenerativeSplitAndScatterProcessor(
 	processorID int32,
 	spec execinfrapb.GenerativeSplitAndScatterSpec,
 	post *execinfrapb.PostProcessSpec,
-	output execinfra.RowReceiver,
 ) (execinfra.Processor, error) {
 	db := flowCtx.Cfg.DB
 	numChunkSplitAndScatterWorkers := int(spec.NumNodes)
@@ -124,14 +122,13 @@ func newGenerativeSplitAndScatterProcessor(
 	ssp := &generativeSplitAndScatterProcessor{
 		flowCtx:                      flowCtx,
 		spec:                         spec,
-		output:                       output,
 		chunkSplitAndScatterers:      chunkSplitAndScatterers,
 		chunkEntrySplitAndScatterers: chunkEntrySplitAndScatterers,
 		// Large enough so that it never blocks.
 		doneScatterCh:     make(chan entryNode, spec.NumEntries),
 		routingDatumCache: make(map[roachpb.NodeID]rowenc.EncDatum),
 	}
-	if err := ssp.Init(ctx, ssp, post, generativeSplitAndScatterOutputTypes, flowCtx, processorID, output, nil, /* memMonitor */
+	if err := ssp.Init(ctx, ssp, post, generativeSplitAndScatterOutputTypes, flowCtx, processorID, nil, /* memMonitor */
 		execinfra.ProcStateOpts{
 			InputsToDrain: nil, // there are no inputs to drain
 			TrailingMetaCallback: func() []execinfrapb.ProducerMetadata {

--- a/pkg/ccl/backupccl/restore_data_processor.go
+++ b/pkg/ccl/backupccl/restore_data_processor.go
@@ -51,7 +51,6 @@ type restoreDataProcessor struct {
 	flowCtx *execinfra.FlowCtx
 	spec    execinfrapb.RestoreDataSpec
 	input   execinfra.RowSource
-	output  execinfra.RowReceiver
 
 	// numWorkers is the number of workers this processor should use. Initialized
 	// at processor creation based on the cluster setting. If the cluster setting
@@ -132,7 +131,6 @@ func newRestoreDataProcessor(
 	spec execinfrapb.RestoreDataSpec,
 	post *execinfrapb.PostProcessSpec,
 	input execinfra.RowSource,
-	output execinfra.RowReceiver,
 ) (execinfra.Processor, error) {
 	sv := &flowCtx.Cfg.Settings.SV
 
@@ -140,13 +138,12 @@ func newRestoreDataProcessor(
 		flowCtx:    flowCtx,
 		input:      input,
 		spec:       spec,
-		output:     output,
 		progCh:     make(chan backuppb.RestoreProgress, maxConcurrentRestoreWorkers),
 		metaCh:     make(chan *execinfrapb.ProducerMetadata, 1),
 		numWorkers: int(numRestoreWorkers.Get(sv)),
 	}
 
-	if err := rd.Init(ctx, rd, post, restoreDataOutputTypes, flowCtx, processorID, output, nil, /* memMonitor */
+	if err := rd.Init(ctx, rd, post, restoreDataOutputTypes, flowCtx, processorID, nil, /* memMonitor */
 		execinfra.ProcStateOpts{
 			InputsToDrain: []execinfra.RowSource{input},
 			TrailingMetaCallback: func() []execinfrapb.ProducerMetadata {

--- a/pkg/ccl/backupccl/split_and_scatter_processor.go
+++ b/pkg/ccl/backupccl/split_and_scatter_processor.go
@@ -192,7 +192,6 @@ type splitAndScatterProcessor struct {
 
 	flowCtx *execinfra.FlowCtx
 	spec    execinfrapb.SplitAndScatterSpec
-	output  execinfra.RowReceiver
 
 	scatterer splitAndScatterer
 	// cancelScatterAndWaitForWorker cancels the scatter goroutine and waits for
@@ -213,7 +212,6 @@ func newSplitAndScatterProcessor(
 	processorID int32,
 	spec execinfrapb.SplitAndScatterSpec,
 	post *execinfrapb.PostProcessSpec,
-	output execinfra.RowReceiver,
 ) (execinfra.Processor, error) {
 
 	numEntries := 0
@@ -236,13 +234,12 @@ func newSplitAndScatterProcessor(
 	ssp := &splitAndScatterProcessor{
 		flowCtx:   flowCtx,
 		spec:      spec,
-		output:    output,
 		scatterer: scatterer,
 		// Large enough so that it never blocks.
 		doneScatterCh:     make(chan entryNode, numEntries),
 		routingDatumCache: make(map[roachpb.NodeID]rowenc.EncDatum),
 	}
-	if err := ssp.Init(ctx, ssp, post, splitAndScatterOutputTypes, flowCtx, processorID, output, nil, /* memMonitor */
+	if err := ssp.Init(ctx, ssp, post, splitAndScatterOutputTypes, flowCtx, processorID, nil, /* memMonitor */
 		execinfra.ProcStateOpts{
 			InputsToDrain: nil, // there are no inputs to drain
 			TrailingMetaCallback: func() []execinfrapb.ProducerMetadata {

--- a/pkg/ccl/backupccl/split_and_scatter_processor_test.go
+++ b/pkg/ccl/backupccl/split_and_scatter_processor_test.go
@@ -247,7 +247,7 @@ func TestSplitAndScatterProcessor(t *testing.T) {
 			require.NoError(t, err)
 
 			post := execinfrapb.PostProcessSpec{}
-			proc, err := newSplitAndScatterProcessor(ctx, &flowCtx, 0 /* processorID */, c.procSpec, &post, out)
+			proc, err := newSplitAndScatterProcessor(ctx, &flowCtx, 0 /* processorID */, c.procSpec, &post)
 			require.NoError(t, err)
 			ssp, ok := proc.(*splitAndScatterProcessor)
 			if !ok {
@@ -257,7 +257,7 @@ func TestSplitAndScatterProcessor(t *testing.T) {
 			// Inject a mock scatterer.
 			ssp.scatterer = &mockScatterer{numNodes: c.numNodes}
 
-			ssp.Run(context.Background())
+			ssp.Run(context.Background(), out)
 			wg.Wait()
 
 			// Ensure that all the outputs are properly closed.

--- a/pkg/ccl/changefeedccl/changefeed_processors.go
+++ b/pkg/ccl/changefeedccl/changefeed_processors.go
@@ -131,7 +131,6 @@ func newChangeAggregatorProcessor(
 	processorID int32,
 	spec execinfrapb.ChangeAggregatorSpec,
 	post *execinfrapb.PostProcessSpec,
-	output execinfra.RowReceiver,
 ) (execinfra.Processor, error) {
 	memMonitor := execinfra.NewMonitor(ctx, flowCtx.Mon, "changeagg-mem")
 	ca := &changeAggregator{
@@ -146,7 +145,6 @@ func newChangeAggregatorProcessor(
 		changefeedResultTypes,
 		flowCtx,
 		processorID,
-		output,
 		memMonitor,
 		execinfra.ProcStateOpts{
 			TrailingMetaCallback: func() []execinfrapb.ProducerMetadata {
@@ -870,7 +868,6 @@ func newChangeFrontierProcessor(
 	spec execinfrapb.ChangeFrontierSpec,
 	input execinfra.RowSource,
 	post *execinfrapb.PostProcessSpec,
-	output execinfra.RowReceiver,
 ) (execinfra.Processor, error) {
 	memMonitor := execinfra.NewMonitor(ctx, flowCtx.Mon, "changefntr-mem")
 	sf, err := makeSchemaChangeFrontier(hlc.Timestamp{}, spec.TrackedSpans...)
@@ -898,7 +895,6 @@ func newChangeFrontierProcessor(
 		input.OutputTypes(),
 		flowCtx,
 		processorID,
-		output,
 		memMonitor,
 		execinfra.ProcStateOpts{
 			TrailingMetaCallback: func() []execinfrapb.ProducerMetadata {

--- a/pkg/ccl/streamingccl/streamingest/stream_ingestion_frontier_processor.go
+++ b/pkg/ccl/streamingccl/streamingest/stream_ingestion_frontier_processor.go
@@ -94,7 +94,6 @@ func newStreamIngestionFrontierProcessor(
 	spec execinfrapb.StreamIngestionFrontierSpec,
 	input execinfra.RowSource,
 	post *execinfrapb.PostProcessSpec,
-	output execinfra.RowReceiver,
 ) (execinfra.Processor, error) {
 	frontier, err := span.MakeFrontierAt(spec.HighWaterAtStart, spec.TrackedSpans...)
 	if err != nil {
@@ -134,7 +133,6 @@ func newStreamIngestionFrontierProcessor(
 		input.OutputTypes(),
 		flowCtx,
 		processorID,
-		output,
 		nil, /* memMonitor */
 		execinfra.ProcStateOpts{
 			InputsToDrain: []execinfra.RowSource{sf.input},

--- a/pkg/ccl/streamingccl/streamingest/stream_ingestion_processor.go
+++ b/pkg/ccl/streamingccl/streamingest/stream_ingestion_processor.go
@@ -128,7 +128,6 @@ type streamIngestionProcessor struct {
 
 	flowCtx *execinfra.FlowCtx
 	spec    execinfrapb.StreamIngestionDataSpec
-	output  execinfra.RowReceiver
 	rekeyer *backupccl.KeyRewriter
 	// rewriteToDiffKey Indicates whether we are rekeying a key into a different key.
 	rewriteToDiffKey bool
@@ -225,7 +224,6 @@ func newStreamIngestionDataProcessor(
 	processorID int32,
 	spec execinfrapb.StreamIngestionDataSpec,
 	post *execinfrapb.PostProcessSpec,
-	output execinfra.RowReceiver,
 ) (execinfra.Processor, error) {
 	rekeyer, err := backupccl.MakeKeyRewriterFromRekeys(flowCtx.Codec(),
 		nil /* tableRekeys */, []execinfrapb.TenantRekey{spec.TenantRekey},
@@ -251,7 +249,6 @@ func newStreamIngestionDataProcessor(
 	sip := &streamIngestionProcessor{
 		flowCtx:           flowCtx,
 		spec:              spec,
-		output:            output,
 		curKVBatch:        make([]storage.MVCCKeyValue, 0),
 		frontier:          frontier,
 		maxFlushRateTimer: timeutil.NewTimer(),
@@ -264,7 +261,7 @@ func newStreamIngestionDataProcessor(
 		rekeyer:          rekeyer,
 		rewriteToDiffKey: spec.TenantRekey.NewID != spec.TenantRekey.OldID,
 	}
-	if err := sip.Init(ctx, sip, post, streamIngestionResultTypes, flowCtx, processorID, output, nil, /* memMonitor */
+	if err := sip.Init(ctx, sip, post, streamIngestionResultTypes, flowCtx, processorID, nil, /* memMonitor */
 		execinfra.ProcStateOpts{
 			InputsToDrain: []execinfra.RowSource{},
 			TrailingMetaCallback: func() []execinfrapb.ProducerMetadata {

--- a/pkg/cloud/cloudcheck/cloudcheck_processor.go
+++ b/pkg/cloud/cloudcheck/cloudcheck_processor.go
@@ -179,10 +179,9 @@ func newCloudCheckProcessor(
 	processorID int32,
 	spec execinfrapb.CloudStorageTestSpec,
 	post *execinfrapb.PostProcessSpec,
-	output execinfra.RowReceiver,
 ) (execinfra.Processor, error) {
 	p := &proc{spec: spec}
-	if err := p.Init(ctx, p, post, flowTypes, flowCtx, processorID, output, nil /* memMonitor */, execinfra.ProcStateOpts{}); err != nil {
+	if err := p.Init(ctx, p, post, flowTypes, flowCtx, processorID, nil /* memMonitor */, execinfra.ProcStateOpts{}); err != nil {
 		return nil, err
 	}
 	return p, nil

--- a/pkg/sql/colexec/colbuilder/execplan.go
+++ b/pkg/sql/colexec/colbuilder/execplan.go
@@ -550,8 +550,7 @@ func (r opResult) createAndWrapRowSource(
 			// here because when wrapping the processor, the materializer will
 			// be its output, and it will be set up in wrapRowSources.
 			proc, err := args.ProcessorConstructor(
-				ctx, flowCtx, processorID, core, post, inputs,
-				[]execinfra.RowReceiver{nil} /* outputs */, args.LocalProcessors,
+				ctx, flowCtx, processorID, core, post, inputs, args.LocalProcessors,
 			)
 			if err != nil {
 				return nil, err

--- a/pkg/sql/colexec/columnarizer.go
+++ b/pkg/sql/colexec/columnarizer.go
@@ -160,7 +160,6 @@ func newColumnarizer(
 		// from being mutated.
 		flowCtx.NewEvalCtx(),
 		processorID,
-		nil, /* output */
 		execinfra.ProcStateOpts{
 			// We append input to inputs to drain below in order to reuse the same
 			// underlying slice from the pooled columnarizer.

--- a/pkg/sql/colexec/materializer.go
+++ b/pkg/sql/colexec/materializer.go
@@ -184,7 +184,6 @@ func NewMaterializer(
 		// from being mutated.
 		flowCtx.NewEvalCtx(),
 		processorID,
-		nil, /* output */
 		execinfra.ProcStateOpts{
 			// We append drainHelper to inputs to drain below in order to reuse
 			// the same underlying slice from the pooled materializer. The

--- a/pkg/sql/colexec/values_test.go
+++ b/pkg/sql/colexec/values_test.go
@@ -155,8 +155,7 @@ func BenchmarkValues(b *testing.B) {
 					var core execinfrapb.ProcessorCoreUnion
 					core.Values = spec
 					proc, err := rowexec.NewProcessor(
-						ctx, &flowCtx, 0 /* processorID */, &core, &post, nil, /* inputs */
-						[]execinfra.RowReceiver{nil} /* outputs */, nil, /* localProcessors */
+						ctx, &flowCtx, 0 /* processorID */, &core, &post, nil /* inputs */, nil, /* localProcessors */
 					)
 					if err != nil {
 						b.Fatal(err)

--- a/pkg/sql/colflow/explain_vec.go
+++ b/pkg/sql/colflow/explain_vec.go
@@ -54,7 +54,7 @@ func convertToVecTree(
 	// execinfra.BatchReceiver, so we always pass in a fakeBatchReceiver to the
 	// creator.
 	creator := newVectorizedFlowCreator(
-		newNoopFlowCreatorHelper(), vectorizedRemoteComponentCreator{}, false, false,
+		nil /* flowBase */, newNoopFlowCreatorHelper(), nil /* componentCreator */, false, false,
 		nil, &execinfra.RowChannel{}, &fakeBatchReceiver{}, flowCtx.Cfg.PodNodeDialer, execinfrapb.FlowID{}, colcontainer.DiskQueueCfg{},
 		flowCtx.Cfg.VecFDSemaphore, flowCtx.NewTypeResolver(flowCtx.Txn),
 		admission.WorkInfo{},

--- a/pkg/sql/colflow/flow_coordinator.go
+++ b/pkg/sql/colflow/flow_coordinator.go
@@ -59,7 +59,6 @@ func NewFlowCoordinator(
 	flowCtx *execinfra.FlowCtx,
 	processorID int32,
 	input execinfra.RowSource,
-	output execinfra.RowReceiver,
 	cancelFlow context.CancelFunc,
 ) *FlowCoordinator {
 	f := flowCoordinatorPool.Get().(*FlowCoordinator)
@@ -73,7 +72,6 @@ func NewFlowCoordinator(
 		// context from being mutated.
 		flowCtx.NewEvalCtx(),
 		processorID,
-		output,
 		execinfra.ProcStateOpts{
 			// We append input to inputs to drain below in order to reuse
 			// the same underlying slice from the pooled FlowCoordinator.

--- a/pkg/sql/colflow/vectorized_flow.go
+++ b/pkg/sql/colflow/vectorized_flow.go
@@ -234,7 +234,6 @@ func (f *vectorizedFlow) Setup(
 	if execstats.ShouldCollectStats(ctx, f.FlowCtx.CollectStats) {
 		recordingStats = true
 	}
-	helper := newVectorizedFlowCreatorHelper(f.FlowBase)
 
 	diskQueueCfg := colcontainer.DiskQueueCfg{
 		FS:                  f.Cfg.TempFS,
@@ -250,8 +249,9 @@ func (f *vectorizedFlow) Setup(
 		f.Cfg.VecFDSemaphore, f.Cfg.Metrics.VecOpenFDs, &flowCtx.EvalCtx.Settings.SV,
 	)
 	f.creator = newVectorizedFlowCreator(
-		helper,
-		vectorizedRemoteComponentCreator{},
+		f.FlowBase,
+		nil, /* helper */
+		nil, /* componentCreator */
 		recordingStats,
 		f.Gateway,
 		f.GetWaitGroup(),
@@ -499,7 +499,6 @@ type runFn func(_ context.Context, flowCtxCancel context.CancelFunc)
 // infrastructure to be run asynchronously as well as to perform some sanity
 // checks.
 type flowCreatorHelper interface {
-	execreleasable.Releasable
 	// addStreamEndpoint stores information about an inbound stream.
 	addStreamEndpoint(execinfrapb.StreamID, *colrpc.Inbox, *sync.WaitGroup)
 	// checkInboundStreamID checks that the provided stream ID has not been seen
@@ -574,6 +573,12 @@ type vectorizedFlowCreator struct {
 	flowCreatorHelper
 	remoteComponentCreator
 
+	// These two fields should not be accessed directly - instead, the embedded
+	// interfaces above should be used. These two structs are embedded in order
+	// to avoid allocations on the main code path.
+	fcHelper  vectorizedFlowCreatorHelper
+	rcCreator vectorizedRemoteComponentCreator
+
 	// rowReceiver is always set.
 	rowReceiver execinfra.RowReceiver
 	// batchReceiver might be set if the consumer supports pushing of
@@ -636,7 +641,15 @@ var vectorizedFlowCreatorPool = sync.Pool{
 	},
 }
 
+// newVectorizedFlowCreator returns a new vectorizedFlowCreator.
+//
+// Only one of flowBase and helper should be set, if the former, then the
+// embedded vectorizedFlowCreatorHelper is updated with the flowBase is used.
+//
+// componentCreator can be nil in which case the embedded
+// vectorizedRemoteComponentCreator is used.
 func newVectorizedFlowCreator(
+	flowBase *flowinfra.FlowBase,
 	helper flowCreatorHelper,
 	componentCreator remoteComponentCreator,
 	recordingStats bool,
@@ -653,26 +666,38 @@ func newVectorizedFlowCreator(
 ) *vectorizedFlowCreator {
 	creator := vectorizedFlowCreatorPool.Get().(*vectorizedFlowCreator)
 	*creator = vectorizedFlowCreator{
-		flowCreatorHelper:      helper,
-		remoteComponentCreator: componentCreator,
-		streamIDToInputOp:      creator.streamIDToInputOp,
-		streamIDToSpecIdx:      creator.streamIDToSpecIdx,
-		recordingStats:         recordingStats,
-		isGatewayNode:          isGatewayNode,
-		waitGroup:              waitGroup,
-		rowReceiver:            rowSyncFlowConsumer,
-		batchReceiver:          batchSyncFlowConsumer,
-		podNodeDialer:          podNodeDialer,
-		flowID:                 flowID,
-		exprHelper:             creator.exprHelper,
-		typeResolver:           typeResolver,
-		admissionInfo:          admissionInfo,
-		procIdxQueue:           creator.procIdxQueue,
-		opChains:               creator.opChains,
-		releasables:            creator.releasables,
-		monitorRegistry:        creator.monitorRegistry,
-		diskQueueCfg:           diskQueueCfg,
-		fdSemaphore:            fdSemaphore,
+		streamIDToInputOp: creator.streamIDToInputOp,
+		streamIDToSpecIdx: creator.streamIDToSpecIdx,
+		recordingStats:    recordingStats,
+		isGatewayNode:     isGatewayNode,
+		waitGroup:         waitGroup,
+		rowReceiver:       rowSyncFlowConsumer,
+		batchReceiver:     batchSyncFlowConsumer,
+		podNodeDialer:     podNodeDialer,
+		flowID:            flowID,
+		exprHelper:        creator.exprHelper,
+		typeResolver:      typeResolver,
+		admissionInfo:     admissionInfo,
+		procIdxQueue:      creator.procIdxQueue,
+		opChains:          creator.opChains,
+		releasables:       creator.releasables,
+		monitorRegistry:   creator.monitorRegistry,
+		diskQueueCfg:      diskQueueCfg,
+		fdSemaphore:       fdSemaphore,
+	}
+	if flowBase != nil {
+		// On the main code path, update the embedded helper with the provided
+		// FlowBase and use it.
+		creator.fcHelper.f = flowBase
+		creator.flowCreatorHelper = &creator.fcHelper
+	} else {
+		creator.flowCreatorHelper = helper
+	}
+	if componentCreator == nil {
+		// On the main code path, use the embedded component creator.
+		creator.remoteComponentCreator = creator.rcCreator
+	} else {
+		creator.remoteComponentCreator = componentCreator
 	}
 	return creator
 }
@@ -698,7 +723,6 @@ func (s *vectorizedFlowCreator) Release() {
 	for k := range s.streamIDToSpecIdx {
 		delete(s.streamIDToSpecIdx, k)
 	}
-	s.flowCreatorHelper.Release()
 	for _, r := range s.releasables {
 		r.Release()
 	}
@@ -1281,24 +1305,10 @@ func (s vectorizedInboundStreamHandler) Timeout(err error) {
 // vectorized infrastructure to be actually run.
 type vectorizedFlowCreatorHelper struct {
 	f          *flowinfra.FlowBase
-	processors []execinfra.Processor
+	processors [1]execinfra.Processor
 }
 
 var _ flowCreatorHelper = &vectorizedFlowCreatorHelper{}
-
-var vectorizedFlowCreatorHelperPool = sync.Pool{
-	New: func() interface{} {
-		return &vectorizedFlowCreatorHelper{
-			processors: make([]execinfra.Processor, 0, 1),
-		}
-	},
-}
-
-func newVectorizedFlowCreatorHelper(f *flowinfra.FlowBase) *vectorizedFlowCreatorHelper {
-	helper := vectorizedFlowCreatorHelperPool.Get().(*vectorizedFlowCreatorHelper)
-	helper.f = f
-	return helper
-}
 
 func (r *vectorizedFlowCreatorHelper) addStreamEndpoint(
 	streamID execinfrapb.StreamID, inbox *colrpc.Inbox, wg *sync.WaitGroup,
@@ -1329,8 +1339,8 @@ func (r *vectorizedFlowCreatorHelper) accumulateAsyncComponent(run runFn) {
 }
 
 func (r *vectorizedFlowCreatorHelper) addFlowCoordinator(f *FlowCoordinator) {
-	r.processors = append(r.processors, f)
-	r.f.SetProcessors(r.processors)
+	r.processors[0] = f
+	r.f.SetProcessors(r.processors[:])
 }
 
 func (r *vectorizedFlowCreatorHelper) getFlowCtxDone() <-chan struct{} {
@@ -1341,20 +1351,6 @@ func (r *vectorizedFlowCreatorHelper) getCancelFlowFn() context.CancelFunc {
 	return r.f.GetCancelFlowFn()
 }
 
-func (r *vectorizedFlowCreatorHelper) Release() {
-	// Note that processors here can only be of 0 or 1 length, but always of
-	// 1 capacity (only the flow coordinator can be appended to this slice).
-	// Unset the slot so that we don't keep the reference to the old flow
-	// coordinator.
-	if len(r.processors) == 1 {
-		r.processors[0] = nil
-	}
-	*r = vectorizedFlowCreatorHelper{
-		processors: r.processors[:0],
-	}
-	vectorizedFlowCreatorHelperPool.Put(r)
-}
-
 // noopFlowCreatorHelper is a flowCreatorHelper that only performs sanity
 // checks.
 type noopFlowCreatorHelper struct {
@@ -1363,16 +1359,10 @@ type noopFlowCreatorHelper struct {
 
 var _ flowCreatorHelper = &noopFlowCreatorHelper{}
 
-var noopFlowCreatorHelperPool = sync.Pool{
-	New: func() interface{} {
-		return &noopFlowCreatorHelper{
-			inboundStreams: make(map[execinfrapb.StreamID]struct{}),
-		}
-	},
-}
-
 func newNoopFlowCreatorHelper() *noopFlowCreatorHelper {
-	return noopFlowCreatorHelperPool.Get().(*noopFlowCreatorHelper)
+	return &noopFlowCreatorHelper{
+		inboundStreams: make(map[execinfrapb.StreamID]struct{}),
+	}
 }
 
 func (r *noopFlowCreatorHelper) addStreamEndpoint(
@@ -1398,13 +1388,6 @@ func (r *noopFlowCreatorHelper) getFlowCtxDone() <-chan struct{} {
 
 func (r *noopFlowCreatorHelper) getCancelFlowFn() context.CancelFunc {
 	return nil
-}
-
-func (r *noopFlowCreatorHelper) Release() {
-	for k := range r.inboundStreams {
-		delete(r.inboundStreams, k)
-	}
-	noopFlowCreatorHelperPool.Put(r)
 }
 
 // IsSupported returns whether a flow specified by spec can be vectorized.

--- a/pkg/sql/colflow/vectorized_flow.go
+++ b/pkg/sql/colflow/vectorized_flow.go
@@ -299,7 +299,7 @@ func (f *vectorizedFlow) Run(ctx context.Context) {
 
 	defer f.Wait()
 
-	if err := f.StartInternal(ctx, nil /* processors */); err != nil {
+	if err := f.StartInternal(ctx, nil /* processors */, nil /* outputs */); err != nil {
 		f.GetRowSyncFlowConsumer().Push(nil /* row */, &execinfrapb.ProducerMetadata{Err: err})
 		f.GetRowSyncFlowConsumer().ProducerDone()
 		return
@@ -509,7 +509,7 @@ type flowCreatorHelper interface {
 	accumulateAsyncComponent(runFn)
 	// addFlowCoordinator adds the FlowCoordinator to the flow. This is only
 	// done on the gateway node.
-	addFlowCoordinator(coordinator *FlowCoordinator)
+	addFlowCoordinator(coordinator *FlowCoordinator, output execinfra.RowReceiver)
 	// getCtxDone returns done channel of the context of this flow.
 	getFlowCtxDone() <-chan struct{}
 	// getCancelFlowFn returns a flow cancellation function.
@@ -1121,7 +1121,6 @@ func (s *vectorizedFlowCreator) setupOutput(
 				flowCtx,
 				pspec.ProcessorID,
 				input,
-				s.rowReceiver,
 				s.getCancelFlowFn(),
 			)
 			// The flow coordinator is a root of its operator chain.
@@ -1129,7 +1128,7 @@ func (s *vectorizedFlowCreator) setupOutput(
 			// NOTE: we don't append f to s.releasables because addFlowCoordinator
 			// adds the FlowCoordinator to FlowBase.processors, which ensures that
 			// it is later released in FlowBase.Cleanup.
-			s.addFlowCoordinator(f)
+			s.addFlowCoordinator(f, s.rowReceiver)
 		}
 
 	default:
@@ -1306,6 +1305,7 @@ func (s vectorizedInboundStreamHandler) Timeout(err error) {
 type vectorizedFlowCreatorHelper struct {
 	f          *flowinfra.FlowBase
 	processors [1]execinfra.Processor
+	outputs    [1]execinfra.RowReceiver
 }
 
 var _ flowCreatorHelper = &vectorizedFlowCreatorHelper{}
@@ -1338,9 +1338,12 @@ func (r *vectorizedFlowCreatorHelper) accumulateAsyncComponent(run runFn) {
 		}))
 }
 
-func (r *vectorizedFlowCreatorHelper) addFlowCoordinator(f *FlowCoordinator) {
+func (r *vectorizedFlowCreatorHelper) addFlowCoordinator(
+	f *FlowCoordinator, output execinfra.RowReceiver,
+) {
 	r.processors[0] = f
-	r.f.SetProcessors(r.processors[:])
+	r.outputs[0] = output
+	_ = r.f.SetProcessorsAndOutputs(r.processors[:1], r.outputs[:1])
 }
 
 func (r *vectorizedFlowCreatorHelper) getFlowCtxDone() <-chan struct{} {
@@ -1380,7 +1383,7 @@ func (r *noopFlowCreatorHelper) checkInboundStreamID(sid execinfrapb.StreamID) e
 
 func (r *noopFlowCreatorHelper) accumulateAsyncComponent(runFn) {}
 
-func (r *noopFlowCreatorHelper) addFlowCoordinator(coordinator *FlowCoordinator) {}
+func (r *noopFlowCreatorHelper) addFlowCoordinator(*FlowCoordinator, execinfra.RowReceiver) {}
 
 func (r *noopFlowCreatorHelper) getFlowCtxDone() <-chan struct{} {
 	return nil

--- a/pkg/sql/colflow/vectorized_flow_shutdown_test.go
+++ b/pkg/sql/colflow/vectorized_flow_shutdown_test.go
@@ -376,7 +376,6 @@ func TestVectorizedFlowShutdown(t *testing.T) {
 						flowCtx,
 						1, /* processorID */
 						materializer,
-						nil, /* output */
 						cancelLocal,
 					)
 					coordinator.Start(ctxLocal)

--- a/pkg/sql/colflow/vectorized_flow_test.go
+++ b/pkg/sql/colflow/vectorized_flow_test.go
@@ -242,7 +242,7 @@ func TestDrainOnlyInputDAG(t *testing.T) {
 	}
 	var wg sync.WaitGroup
 	vfc := newVectorizedFlowCreator(
-		&vectorizedFlowCreatorHelper{f: f}, componentCreator, false, false, &wg, &execinfra.RowChannel{},
+		f, nil /* helper */, componentCreator, false, false, &wg, &execinfra.RowChannel{},
 		nil /* batchSyncFlowConsumer */, nil /* podNodeDialer */, execinfrapb.FlowID{}, colcontainer.DiskQueueCfg{},
 		nil /* fdSemaphore */, descs.DistSQLTypeResolver{}, admission.WorkInfo{},
 	)

--- a/pkg/sql/delete_preserving_index_test.go
+++ b/pkg/sql/delete_preserving_index_test.go
@@ -711,12 +711,12 @@ func TestMergeProcessor(t *testing.T) {
 			Spans:            []roachpb.Span{sp},
 			SpanIdx:          []int32{0},
 			MergeTimestamp:   kvDB.Clock().Now(),
-		}, &output)
+		})
 		if err != nil {
 			t.Fatal(err)
 		}
 
-		im.Run(ctx)
+		im.Run(ctx, &output)
 		if output.err != nil {
 			t.Fatal(output.err)
 		}

--- a/pkg/sql/distsql/columnar_utils_test.go
+++ b/pkg/sql/distsql/columnar_utils_test.go
@@ -117,8 +117,7 @@ func verifyColOperator(t *testing.T, args verifyColOperatorArgs) error {
 	}
 
 	proc, err := rowexec.NewProcessor(
-		ctx, flowCtx, 0, &args.pspec.Core, &args.pspec.Post,
-		inputsProc, []execinfra.RowReceiver{nil}, nil,
+		ctx, flowCtx, 0, &args.pspec.Core, &args.pspec.Post, inputsProc, nil,
 	)
 	if err != nil {
 		return err

--- a/pkg/sql/distsql/vectorized_panic_propagation_test.go
+++ b/pkg/sql/distsql/vectorized_panic_propagation_test.go
@@ -70,7 +70,7 @@ func TestNonVectorizedPanicDoesntHangServer(t *testing.T) {
 	ctx, _, err := base.Setup(ctx, nil, flowinfra.FuseAggressively)
 	require.NoError(t, err)
 
-	base.SetProcessors([]execinfra.Processor{mat})
+	require.NoError(t, base.SetProcessorsAndOutputs([]execinfra.Processor{mat}, []execinfra.RowReceiver{nil}))
 	// This test specifically verifies that a flow doesn't get stuck in Wait for
 	// asynchronous components that haven't been signaled to exit. To simulate
 	// this we just create a mock startable.

--- a/pkg/sql/execinfra/base.go
+++ b/pkg/sql/execinfra/base.go
@@ -309,7 +309,7 @@ func DrainAndClose(
 	ctx context.Context,
 	dst RowReceiver,
 	cause error,
-	pushTrailingMeta func(context.Context),
+	pushTrailingMeta func(context.Context, RowReceiver),
 	srcs ...RowSource,
 ) {
 	if cause != nil {
@@ -329,7 +329,7 @@ func DrainAndClose(
 		DrainAndForwardMetadata(ctx, srcs[0], dst)
 		wg.Wait()
 	}
-	pushTrailingMeta(ctx)
+	pushTrailingMeta(ctx, dst)
 	dst.ProducerDone()
 }
 

--- a/pkg/sql/importer/import_processor.go
+++ b/pkg/sql/importer/import_processor.go
@@ -124,7 +124,6 @@ type readImportDataProcessor struct {
 
 	flowCtx *execinfra.FlowCtx
 	spec    execinfrapb.ReadImportDataSpec
-	output  execinfra.RowReceiver
 
 	cancel context.CancelFunc
 	wg     ctxgroup.Group
@@ -147,15 +146,13 @@ func newReadImportDataProcessor(
 	processorID int32,
 	spec execinfrapb.ReadImportDataSpec,
 	post *execinfrapb.PostProcessSpec,
-	output execinfra.RowReceiver,
 ) (execinfra.Processor, error) {
 	idp := &readImportDataProcessor{
 		flowCtx: flowCtx,
 		spec:    spec,
-		output:  output,
 		progCh:  make(chan execinfrapb.RemoteProducerMetadata_BulkProcessorProgress),
 	}
-	if err := idp.Init(ctx, idp, post, csvOutputTypes, flowCtx, processorID, output, nil, /* memMonitor */
+	if err := idp.Init(ctx, idp, post, csvOutputTypes, flowCtx, processorID, nil, /* memMonitor */
 		execinfra.ProcStateOpts{
 			// This processor doesn't have any inputs to drain.
 			InputsToDrain: nil,

--- a/pkg/sql/importer/import_processor_test.go
+++ b/pkg/sql/importer/import_processor_test.go
@@ -313,12 +313,12 @@ func TestImportIgnoresProcessedFiles(t *testing.T) {
 			spec := setInputOffsets(t, testCase.spec.getConverterSpec(), testCase.inputOffsets)
 			post := execinfrapb.PostProcessSpec{}
 
-			processor, err := newReadImportDataProcessor(ctx, flowCtx, 0, *spec, &post, &errorReportingRowReceiver{t})
+			processor, err := newReadImportDataProcessor(ctx, flowCtx, 0, *spec, &post)
 			if err != nil {
 				t.Fatalf("Could not create data processor: %v", err)
 			}
 
-			processor.Run(ctx)
+			processor.Run(ctx, &errorReportingRowReceiver{t})
 		})
 	}
 }
@@ -607,9 +607,9 @@ func setImportReaderParallelism(parallelism int32) func() {
 	rowexec.NewReadImportDataProcessor = func(
 		ctx context.Context, flowCtx *execinfra.FlowCtx, processorID int32,
 		spec execinfrapb.ReadImportDataSpec, post *execinfrapb.PostProcessSpec,
-		output execinfra.RowReceiver) (execinfra.Processor, error) {
+	) (execinfra.Processor, error) {
 		spec.ReaderParallelism = parallelism
-		return factory(ctx, flowCtx, processorID, spec, post, output)
+		return factory(ctx, flowCtx, processorID, spec, post)
 	}
 
 	return func() {

--- a/pkg/sql/plan_node_to_row_source.go
+++ b/pkg/sql/plan_node_to_row_source.go
@@ -103,13 +103,12 @@ func (p *planNodeToRowSource) MustBeStreaming() bool {
 	}
 }
 
-// InitWithOutput implements the LocalProcessor interface.
-func (p *planNodeToRowSource) InitWithOutput(
+// Init implements the execinfra.LocalProcessor interface.
+func (p *planNodeToRowSource) Init(
 	ctx context.Context,
 	flowCtx *execinfra.FlowCtx,
 	processorID int32,
 	post *execinfrapb.PostProcessSpec,
-	output execinfra.RowReceiver,
 ) error {
 	if err := p.InitWithEvalCtx(
 		ctx,
@@ -123,7 +122,6 @@ func (p *planNodeToRowSource) InitWithOutput(
 		// params.
 		p.params.EvalContext(),
 		processorID,
-		output,
 		nil, /* memMonitor */
 		execinfra.ProcStateOpts{
 			// Input to drain is added in SetInput.

--- a/pkg/sql/rowexec/aggregator_test.go
+++ b/pkg/sql/rowexec/aggregator_test.go
@@ -446,11 +446,11 @@ func BenchmarkAggregation(b *testing.B) {
 			b.SetBytes(int64(8 * numRows * numCols))
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
-				d, err := newAggregator(ctx, flowCtx, 0 /* processorID */, spec, input, post, disposer)
+				d, err := newAggregator(ctx, flowCtx, 0 /* processorID */, spec, input, post)
 				if err != nil {
 					b.Fatal(err)
 				}
-				d.Run(context.Background())
+				d.Run(context.Background(), disposer)
 				input.Reset()
 			}
 			b.StopTimer()
@@ -487,11 +487,11 @@ func BenchmarkCountRows(b *testing.B) {
 	b.SetBytes(int64(8 * numRows * numCols))
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		d, err := newAggregator(ctx, flowCtx, 0 /* processorID */, spec, input, post, disposer)
+		d, err := newAggregator(ctx, flowCtx, 0 /* processorID */, spec, input, post)
 		if err != nil {
 			b.Fatal(err)
 		}
-		d.Run(context.Background())
+		d.Run(context.Background(), disposer)
 		input.Reset()
 	}
 }
@@ -521,11 +521,11 @@ func BenchmarkGrouping(b *testing.B) {
 	b.SetBytes(int64(8 * numRows * numCols))
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		d, err := newAggregator(ctx, flowCtx, 0 /* processorID */, spec, input, post, disposer)
+		d, err := newAggregator(ctx, flowCtx, 0 /* processorID */, spec, input, post)
 		if err != nil {
 			b.Fatal(err)
 		}
-		d.Run(context.Background())
+		d.Run(context.Background(), disposer)
 		input.Reset()
 	}
 	b.StopTimer()
@@ -583,11 +583,11 @@ func benchmarkAggregationWithGrouping(b *testing.B, numOrderedCols int) {
 			b.SetBytes(int64(8 * intPow(groupSize, len(groupedCols)+1) * numCols))
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
-				d, err := newAggregator(ctx, flowCtx, 0 /* processorID */, spec, input, post, disposer)
+				d, err := newAggregator(ctx, flowCtx, 0 /* processorID */, spec, input, post)
 				if err != nil {
 					b.Fatal(err)
 				}
-				d.Run(context.Background())
+				d.Run(context.Background(), disposer)
 				input.Reset()
 			}
 			b.StopTimer()

--- a/pkg/sql/rowexec/bulk_row_writer.go
+++ b/pkg/sql/rowexec/bulk_row_writer.go
@@ -42,7 +42,6 @@ type bulkRowWriter struct {
 	tableDesc      catalog.TableDescriptor
 	spec           execinfrapb.BulkRowWriterSpec
 	input          execinfra.RowSource
-	output         execinfra.RowReceiver
 	summary        kvpb.BulkOpSummary
 }
 
@@ -55,7 +54,6 @@ func newBulkRowWriterProcessor(
 	processorID int32,
 	spec execinfrapb.BulkRowWriterSpec,
 	input execinfra.RowSource,
-	output execinfra.RowReceiver,
 ) (execinfra.Processor, error) {
 	c := &bulkRowWriter{
 		flowCtx:        flowCtx,
@@ -64,10 +62,9 @@ func newBulkRowWriterProcessor(
 		tableDesc:      flowCtx.TableDescriptor(ctx, &spec.Table),
 		spec:           spec,
 		input:          input,
-		output:         output,
 	}
 	if err := c.Init(
-		ctx, c, &execinfrapb.PostProcessSpec{}, CTASPlanResultTypes, flowCtx, processorID, output,
+		ctx, c, &execinfrapb.PostProcessSpec{}, CTASPlanResultTypes, flowCtx, processorID,
 		nil /* memMonitor */, execinfra.ProcStateOpts{InputsToDrain: []execinfra.RowSource{input}},
 	); err != nil {
 		return nil, err

--- a/pkg/sql/rowexec/columnbackfiller.go
+++ b/pkg/sql/rowexec/columnbackfiller.go
@@ -60,8 +60,6 @@ func newColumnBackfiller(
 	flowCtx *execinfra.FlowCtx,
 	processorID int32,
 	spec execinfrapb.BackfillerSpec,
-	post *execinfrapb.PostProcessSpec,
-	output execinfra.RowReceiver,
 ) (*columnBackfiller, error) {
 	columnBackfillerMon := execinfra.NewMonitor(ctx, flowCtx.Cfg.BackfillerMonitor,
 		"column-backfill-mon")
@@ -72,7 +70,6 @@ func newColumnBackfiller(
 			filter:      backfill.ColumnMutationFilter,
 			flowCtx:     flowCtx,
 			processorID: processorID,
-			output:      output,
 			spec:        spec,
 		},
 	}

--- a/pkg/sql/rowexec/countrows.go
+++ b/pkg/sql/rowexec/countrows.go
@@ -41,7 +41,6 @@ func newCountAggregator(
 	processorID int32,
 	input execinfra.RowSource,
 	post *execinfrapb.PostProcessSpec,
-	output execinfra.RowReceiver,
 ) (*countAggregator, error) {
 	ag := &countAggregator{}
 	ag.input = input
@@ -58,7 +57,6 @@ func newCountAggregator(
 		[]*types.T{types.Int},
 		flowCtx,
 		processorID,
-		output,
 		nil, /* memMonitor */
 		execinfra.ProcStateOpts{
 			InputsToDrain: []execinfra.RowSource{ag.input},

--- a/pkg/sql/rowexec/distinct.go
+++ b/pkg/sql/rowexec/distinct.go
@@ -79,7 +79,6 @@ func newDistinct(
 	spec *execinfrapb.DistinctSpec,
 	input execinfra.RowSource,
 	post *execinfrapb.PostProcessSpec,
-	output execinfra.RowReceiver,
 ) (execinfra.RowSourcedProcessor, error) {
 	if len(spec.DistinctColumns) == 0 {
 		return nil, errors.AssertionFailedf("0 distinct columns specified for distinct processor")
@@ -118,7 +117,7 @@ func newDistinct(
 	}
 
 	if err := d.Init(
-		ctx, d, post, d.types, flowCtx, processorID, output, memMonitor, /* memMonitor */
+		ctx, d, post, d.types, flowCtx, processorID, memMonitor, /* memMonitor */
 		execinfra.ProcStateOpts{
 			InputsToDrain: []execinfra.RowSource{d.input},
 			TrailingMetaCallback: func() []execinfrapb.ProducerMetadata {

--- a/pkg/sql/rowexec/distinct_test.go
+++ b/pkg/sql/rowexec/distinct_test.go
@@ -281,12 +281,12 @@ func TestDistinct(t *testing.T) {
 				Mon:     evalCtx.TestingMon,
 			}
 
-			d, err := newDistinct(context.Background(), &flowCtx, 0 /* processorID */, &ds, in, &execinfrapb.PostProcessSpec{}, out)
+			d, err := newDistinct(context.Background(), &flowCtx, 0 /* processorID */, &ds, in, &execinfrapb.PostProcessSpec{})
 			if err != nil {
 				t.Fatal(err)
 			}
 
-			d.Run(context.Background())
+			d.Run(context.Background(), out)
 			if !out.ProducerClosed() {
 				t.Fatalf("output RowReceiver not closed")
 			}
@@ -343,11 +343,11 @@ func benchmarkDistinct(b *testing.B, orderedColumns []uint32) {
 			b.SetBytes(int64(8 * numRows * numCols))
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
-				d, err := newDistinct(ctx, flowCtx, 0 /* processorID */, spec, input, post, &rowDisposer{})
+				d, err := newDistinct(ctx, flowCtx, 0 /* processorID */, spec, input, post)
 				if err != nil {
 					b.Fatal(err)
 				}
-				d.Run(context.Background())
+				d.Run(context.Background(), &rowDisposer{})
 				input.Reset()
 			}
 		})

--- a/pkg/sql/rowexec/filterer.go
+++ b/pkg/sql/rowexec/filterer.go
@@ -42,7 +42,6 @@ func newFiltererProcessor(
 	spec *execinfrapb.FiltererSpec,
 	input execinfra.RowSource,
 	post *execinfrapb.PostProcessSpec,
-	output execinfra.RowReceiver,
 ) (*filtererProcessor, error) {
 	f := &filtererProcessor{input: input}
 	types := input.OutputTypes()
@@ -53,7 +52,6 @@ func newFiltererProcessor(
 		types,
 		flowCtx,
 		processorID,
-		output,
 		nil, /* memMonitor */
 		execinfra.ProcStateOpts{InputsToDrain: []execinfra.RowSource{f.input}},
 	); err != nil {

--- a/pkg/sql/rowexec/filterer_test.go
+++ b/pkg/sql/rowexec/filterer_test.go
@@ -90,12 +90,12 @@ func TestFilterer(t *testing.T) {
 				Filter: execinfrapb.Expression{Expr: c.filter},
 			}
 
-			d, err := newFiltererProcessor(context.Background(), &flowCtx, 0 /* processorID */, &spec, in, &c.post, out)
+			d, err := newFiltererProcessor(context.Background(), &flowCtx, 0 /* processorID */, &spec, in, &c.post)
 			if err != nil {
 				t.Fatal(err)
 			}
 
-			d.Run(context.Background())
+			d.Run(context.Background(), out)
 			if !out.ProducerClosed() {
 				t.Fatalf("output RowReceiver not closed")
 			}
@@ -148,11 +148,11 @@ func BenchmarkFilterer(b *testing.B) {
 			b.SetBytes(int64(8 * numRows * numCols))
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
-				d, err := newFiltererProcessor(ctx, flowCtx, 0 /* processorID */, &spec, input, post, disposer)
+				d, err := newFiltererProcessor(ctx, flowCtx, 0 /* processorID */, &spec, input, post)
 				if err != nil {
 					b.Fatal(err)
 				}
-				d.Run(context.Background())
+				d.Run(context.Background(), disposer)
 				input.Reset()
 			}
 		})

--- a/pkg/sql/rowexec/hashgroupjoiner.go
+++ b/pkg/sql/rowexec/hashgroupjoiner.go
@@ -42,7 +42,6 @@ func newHashGroupJoiner(
 	leftSource execinfra.RowSource,
 	rightSource execinfra.RowSource,
 	post *execinfrapb.PostProcessSpec,
-	output execinfra.RowReceiver,
 ) (*hashGroupJoiner, error) {
 	hjPost := execinfrapb.PostProcessSpec{}
 	if len(spec.JoinOutputColumns) > 0 {
@@ -57,10 +56,6 @@ func newHashGroupJoiner(
 		leftSource,
 		rightSource,
 		&hjPost,
-		// This hash joiner will be fused with the hash aggregator (i.e. will
-		// run in the same goroutine), and the hash aggregator will pull rows as
-		// needed, so the output here won't be used.
-		nil, /* output */
 	)
 	if err != nil {
 		return nil, err
@@ -73,7 +68,6 @@ func newHashGroupJoiner(
 		&spec.AggregatorSpec,
 		hj,
 		post,
-		output,
 	)
 	if err != nil {
 		return nil, err

--- a/pkg/sql/rowexec/hashjoiner.go
+++ b/pkg/sql/rowexec/hashjoiner.go
@@ -108,7 +108,6 @@ func newHashJoiner(
 	leftSource execinfra.RowSource,
 	rightSource execinfra.RowSource,
 	post *execinfrapb.PostProcessSpec,
-	output execinfra.RowReceiver,
 ) (*hashJoiner, error) {
 	h := &hashJoiner{
 		leftSource:   leftSource,
@@ -131,7 +130,6 @@ func newHashJoiner(
 		spec.OnExpr,
 		false, /* outputContinuationColumn */
 		post,
-		output,
 		execinfra.ProcStateOpts{
 			InputsToDrain: []execinfra.RowSource{h.leftSource, h.rightSource},
 			TrailingMetaCallback: func() []execinfrapb.ProducerMetadata {

--- a/pkg/sql/rowexec/hashjoiner_test.go
+++ b/pkg/sql/rowexec/hashjoiner_test.go
@@ -1064,7 +1064,7 @@ func TestHashJoiner(t *testing.T) {
 					OnExpr:         c.onExpr,
 				}
 				h, err := newHashJoiner(
-					ctx, &flowCtx, 0 /* processorID */, spec, leftInput, rightInput, &post, out,
+					ctx, &flowCtx, 0 /* processorID */, spec, leftInput, rightInput, &post,
 				)
 				if err != nil {
 					return err
@@ -1073,7 +1073,7 @@ func TestHashJoiner(t *testing.T) {
 				if hjSetup != nil {
 					hjSetup(h)
 				}
-				h.Run(ctx)
+				h.Run(ctx, out)
 
 				if !out.ProducerClosed() {
 					return errors.New("output RowReceiver not closed")
@@ -1147,13 +1147,13 @@ func TestHashJoinerError(t *testing.T) {
 				OnExpr:         c.onExpr,
 			}
 			h, err := newHashJoiner(
-				ctx, &flowCtx, 0 /* processorID */, spec, leftInput, rightInput, &post, out,
+				ctx, &flowCtx, 0 /* processorID */, spec, leftInput, rightInput, &post,
 			)
 			if err != nil {
 				return err
 			}
 			outTypes := h.OutputTypes()
-			h.Run(ctx)
+			h.Run(ctx, out)
 
 			if !out.ProducerClosed() {
 				return errors.New("output RowReceiver not closed")
@@ -1285,14 +1285,14 @@ func TestHashJoinerDrain(t *testing.T) {
 
 	post := execinfrapb.PostProcessSpec{Projection: true, OutputColumns: outCols}
 	h, err := newHashJoiner(
-		ctx, &flowCtx, 0 /* processorID */, &spec, leftInput, rightInput, &post, out,
+		ctx, &flowCtx, 0 /* processorID */, &spec, leftInput, rightInput, &post,
 	)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	out.ConsumerDone()
-	h.Run(ctx)
+	h.Run(ctx, out)
 
 	if !out.ProducerClosed() {
 		t.Fatalf("output RowReceiver not closed")
@@ -1418,13 +1418,13 @@ func TestHashJoinerDrainAfterBuildPhaseError(t *testing.T) {
 
 	post := execinfrapb.PostProcessSpec{Projection: true, OutputColumns: outCols}
 	h, err := newHashJoiner(
-		ctx, &flowCtx, 0 /* processorID */, &spec, leftInput, rightInput, &post, out,
+		ctx, &flowCtx, 0 /* processorID */, &spec, leftInput, rightInput, &post,
 	)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	h.Run(ctx)
+	h.Run(ctx, out)
 
 	if !out.ProducerClosed() {
 		t.Fatalf("output RowReceiver not closed")
@@ -1505,12 +1505,12 @@ func BenchmarkHashJoiner(b *testing.B) {
 						// TODO(asubiotto): Get rid of uncleared state between
 						// hashJoiner Run()s to omit instantiation time from benchmarks.
 						h, err := newHashJoiner(
-							ctx, flowCtx, 0 /* processorID */, spec, leftInput, rightInput, post, &rowDisposer{},
+							ctx, flowCtx, 0 /* processorID */, spec, leftInput, rightInput, post,
 						)
 						if err != nil {
 							b.Fatal(err)
 						}
-						h.Run(ctx)
+						h.Run(ctx, &rowDisposer{})
 						leftInput.Reset()
 						rightInput.Reset()
 					}

--- a/pkg/sql/rowexec/indexbackfiller.go
+++ b/pkg/sql/rowexec/indexbackfiller.go
@@ -51,8 +51,6 @@ type indexBackfiller struct {
 
 	flowCtx *execinfra.FlowCtx
 
-	output execinfra.RowReceiver
-
 	filter backfill.MutationFilter
 }
 
@@ -69,12 +67,7 @@ var backfillerMaxBufferSize = settings.RegisterByteSizeSetting(
 )
 
 func newIndexBackfiller(
-	ctx context.Context,
-	flowCtx *execinfra.FlowCtx,
-	processorID int32,
-	spec execinfrapb.BackfillerSpec,
-	post *execinfrapb.PostProcessSpec,
-	output execinfra.RowReceiver,
+	ctx context.Context, flowCtx *execinfra.FlowCtx, spec execinfrapb.BackfillerSpec,
 ) (*indexBackfiller, error) {
 	indexBackfillerMon := execinfra.NewMonitor(ctx, flowCtx.Cfg.BackfillerMonitor,
 		"index-backfill-mon")
@@ -82,7 +75,6 @@ func newIndexBackfiller(
 		desc:    flowCtx.TableDescriptor(ctx, &spec.Table),
 		spec:    spec,
 		flowCtx: flowCtx,
-		output:  output,
 		filter:  backfill.IndexMutationFilter,
 	}
 
@@ -340,21 +332,21 @@ func (ib *indexBackfiller) runBackfill(
 	return nil
 }
 
-func (ib *indexBackfiller) Run(ctx context.Context) {
+func (ib *indexBackfiller) Run(ctx context.Context, output execinfra.RowReceiver) {
 	opName := "indexBackfillerProcessor"
 	ctx = logtags.AddTag(ctx, "job", ib.spec.JobID)
 	ctx = logtags.AddTag(ctx, opName, int(ib.spec.Table.ID))
 	ctx, span := execinfra.ProcessorSpan(ctx, opName)
 	defer span.Finish()
-	defer ib.output.ProducerDone()
-	defer execinfra.SendTraceData(ctx, ib.output)
+	defer output.ProducerDone()
+	defer execinfra.SendTraceData(ctx, output)
 	defer ib.Close(ctx)
 
 	progCh := make(chan execinfrapb.RemoteProducerMetadata_BulkProcessorProgress)
 
 	semaCtx := tree.MakeSemaContext()
 	if err := ib.out.Init(ctx, &execinfrapb.PostProcessSpec{}, nil, &semaCtx, ib.flowCtx.NewEvalCtx()); err != nil {
-		ib.output.Push(nil, &execinfrapb.ProducerMetadata{Err: err})
+		output.Push(nil, &execinfrapb.ProducerMetadata{Err: err})
 		return
 	}
 
@@ -372,11 +364,11 @@ func (ib *indexBackfiller) Run(ctx context.Context) {
 		if p.CompletedSpans != nil {
 			log.VEventf(ctx, 2, "sending coordinator completed spans: %+v", p.CompletedSpans)
 		}
-		ib.output.Push(nil, &execinfrapb.ProducerMetadata{BulkProcessorProgress: &p})
+		output.Push(nil, &execinfrapb.ProducerMetadata{BulkProcessorProgress: &p})
 	}
 
 	if err != nil {
-		ib.output.Push(nil, &execinfrapb.ProducerMetadata{Err: err})
+		output.Push(nil, &execinfrapb.ProducerMetadata{Err: err})
 		return
 	}
 }

--- a/pkg/sql/rowexec/inverted_filterer.go
+++ b/pkg/sql/rowexec/inverted_filterer.go
@@ -75,7 +75,6 @@ func newInvertedFilterer(
 	spec *execinfrapb.InvertedFiltererSpec,
 	input execinfra.RowSource,
 	post *execinfrapb.PostProcessSpec,
-	output execinfra.RowReceiver,
 ) (execinfra.RowSourcedProcessor, error) {
 	ifr := &invertedFilterer{
 		input:          input,
@@ -97,7 +96,7 @@ func newInvertedFilterer(
 
 	// Initialize ProcessorBase.
 	if err := ifr.ProcessorBase.Init(
-		ctx, ifr, post, outputColTypes, flowCtx, processorID, output, nil, /* memMonitor */
+		ctx, ifr, post, outputColTypes, flowCtx, processorID, nil, /* memMonitor */
 		execinfra.ProcStateOpts{
 			InputsToDrain: []execinfra.RowSource{ifr.input},
 			TrailingMetaCallback: func() []execinfrapb.ProducerMetadata {

--- a/pkg/sql/rowexec/inverted_joiner.go
+++ b/pkg/sql/rowexec/inverted_joiner.go
@@ -170,7 +170,6 @@ func newInvertedJoiner(
 	datumsToInvertedExpr invertedexpr.DatumsToInvertedExpr,
 	input execinfra.RowSource,
 	post *execinfrapb.PostProcessSpec,
-	output execinfra.RowReceiver,
 ) (execinfra.RowSourcedProcessor, error) {
 	switch spec.Type {
 	case descpb.InnerJoin, descpb.LeftOuterJoin, descpb.LeftSemiJoin, descpb.LeftAntiJoin:
@@ -235,7 +234,7 @@ func newInvertedJoiner(
 	}
 
 	if err := ij.ProcessorBase.Init(
-		ctx, ij, post, outputColTypes, flowCtx, processorID, output, nil, /* memMonitor */
+		ctx, ij, post, outputColTypes, flowCtx, processorID, nil, /* memMonitor */
 		execinfra.ProcStateOpts{
 			InputsToDrain: []execinfra.RowSource{ij.input},
 			TrailingMetaCallback: func() []execinfrapb.ProducerMetadata {

--- a/pkg/sql/rowexec/inverted_joiner_test.go
+++ b/pkg/sql/rowexec/inverted_joiner_test.go
@@ -708,12 +708,11 @@ func TestInvertedJoiner(t *testing.T) {
 					c.datumsToExpr,
 					in,
 					&post,
-					out,
 				)
 				require.NoError(t, err)
 				// Small batch size to exercise multiple batches.
 				ij.(*invertedJoiner).SetBatchSize(2)
-				ij.Run(ctx)
+				ij.Run(ctx, out)
 				require.True(t, in.Done)
 				require.True(t, out.ProducerClosed())
 
@@ -789,7 +788,7 @@ func TestInvertedJoinerDrain(t *testing.T) {
 		DiskMonitor: diskMonitor,
 	}
 
-	testReaderProcessorDrain(ctx, t, func(out execinfra.RowReceiver) (execinfra.Processor, error) {
+	testReaderProcessorDrain(ctx, t, func() (execinfra.Processor, error) {
 		var fetchSpec fetchpb.IndexFetchSpec
 		if err := rowenc.InitIndexFetchSpec(
 			&fetchSpec,
@@ -811,7 +810,6 @@ func TestInvertedJoinerDrain(t *testing.T) {
 			arrayIntersectionExpr{t: t},
 			distsqlutils.NewRowBuffer(types.TwoIntCols, nil /* rows */, distsqlutils.RowBufferArgs{}),
 			&execinfrapb.PostProcessSpec{},
-			out,
 		)
 	})
 }

--- a/pkg/sql/rowexec/joinerbase.go
+++ b/pkg/sql/rowexec/joinerbase.go
@@ -48,7 +48,6 @@ func (jb *joinerBase) init(
 	onExpr execinfrapb.Expression,
 	outputContinuationColumn bool,
 	post *execinfrapb.PostProcessSpec,
-	output execinfra.RowReceiver,
 	opts execinfra.ProcStateOpts,
 ) error {
 	jb.joinType = jType
@@ -85,7 +84,7 @@ func (jb *joinerBase) init(
 	}
 
 	if err := jb.ProcessorBase.Init(
-		ctx, self, post, outputTypes, flowCtx, processorID, output, nil /* memMonitor */, opts,
+		ctx, self, post, outputTypes, flowCtx, processorID, nil /* memMonitor */, opts,
 	); err != nil {
 		return err
 	}

--- a/pkg/sql/rowexec/joinreader.go
+++ b/pkg/sql/rowexec/joinreader.go
@@ -281,7 +281,6 @@ func newJoinReader(
 	spec *execinfrapb.JoinReaderSpec,
 	input execinfra.RowSource,
 	post *execinfrapb.PostProcessSpec,
-	output execinfra.RowReceiver,
 	readerType joinReaderType,
 ) (execinfra.RowSourcedProcessor, error) {
 	if spec.OutputGroupContinuationForLeftRow && !spec.MaintainOrdering {
@@ -409,7 +408,6 @@ func newJoinReader(
 		spec.OnExpr,
 		spec.OutputGroupContinuationForLeftRow,
 		post,
-		output,
 		execinfra.ProcStateOpts{
 			InputsToDrain: []execinfra.RowSource{jr.input},
 			TrailingMetaCallback: func() []execinfrapb.ProducerMetadata {

--- a/pkg/sql/rowexec/joinreader_test.go
+++ b/pkg/sql/rowexec/joinreader_test.go
@@ -1156,7 +1156,6 @@ func TestJoinReader(t *testing.T) {
 								},
 								in,
 								&post,
-								out,
 								lookupJoinReaderType,
 							)
 							if err != nil {
@@ -1169,7 +1168,7 @@ func TestJoinReader(t *testing.T) {
 							}
 							// Else, use the default.
 
-							jr.Run(ctx)
+							jr.Run(ctx, out)
 
 							if !in.Done {
 								t.Fatal("joinReader didn't consume all the rows")
@@ -1326,13 +1325,12 @@ CREATE TABLE test.t (a INT, s STRING, INDEX (a, s))`); err != nil {
 			Projection:    true,
 			OutputColumns: []uint32{2},
 		},
-		out,
 		lookupJoinReaderType,
 	)
 	if err != nil {
 		t.Fatal(err)
 	}
-	jr.Run(ctx)
+	jr.Run(ctx, out)
 
 	count := 0
 	for {
@@ -1415,7 +1413,7 @@ func TestJoinReaderDrain(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	testReaderProcessorDrain(ctx, t, func(out execinfra.RowReceiver) (execinfra.Processor, error) {
+	testReaderProcessorDrain(ctx, t, func() (execinfra.Processor, error) {
 		return newJoinReader(
 			ctx,
 			&flowCtx,
@@ -1423,7 +1421,6 @@ func TestJoinReaderDrain(t *testing.T) {
 			&execinfrapb.JoinReaderSpec{FetchSpec: fetchSpec},
 			distsqlutils.NewRowBuffer(types.OneIntCol, nil /* rows */, distsqlutils.RowBufferArgs{}),
 			&execinfrapb.PostProcessSpec{},
-			out,
 			lookupJoinReaderType,
 		)
 	})
@@ -1444,12 +1441,12 @@ func TestJoinReaderDrain(t *testing.T) {
 		jr, err := newJoinReader(
 			ctx, &flowCtx, 0 /* processorID */, &execinfrapb.JoinReaderSpec{
 				FetchSpec: fetchSpec,
-			}, in, &execinfrapb.PostProcessSpec{},
-			out, lookupJoinReaderType)
+			}, in, &execinfrapb.PostProcessSpec{}, lookupJoinReaderType,
+		)
 		if err != nil {
 			t.Fatal(err)
 		}
-		jr.Run(ctx)
+		jr.Run(ctx, out)
 		row, meta := out.Next()
 		if row != nil {
 			t.Fatalf("row was pushed unexpectedly: %s", row.String(types.OneIntCol))
@@ -1861,12 +1858,12 @@ func benchmarkJoinReader(b *testing.B, bc JRBenchConfig) {
 								for i := 0; i < b.N; i++ {
 									flowCtx.Cfg.TestingKnobs.MemoryLimitBytes = memoryLimit
 									jr, err := newJoinReader(
-										ctx, &flowCtx, 0 /* processorID */, &spec, input, &execinfrapb.PostProcessSpec{}, &output, lookupJoinReaderType,
+										ctx, &flowCtx, 0 /* processorID */, &spec, input, &execinfrapb.PostProcessSpec{}, lookupJoinReaderType,
 									)
 									if err != nil {
 										b.Fatal(err)
 									}
-									jr.Run(ctx)
+									jr.Run(ctx, &output)
 									if !spilled && jr.(*joinReader).Spilled() {
 										spilled = true
 									}
@@ -2070,11 +2067,11 @@ func BenchmarkJoinReaderLookupStress(b *testing.B) {
 			b.ResetTimer()
 
 			for i := 0; i < b.N; i++ {
-				jr, err := newJoinReader(ctx, &flowCtx, 0 /* processorID */, &spec, input, &post, &output, lookupJoinReaderType)
+				jr, err := newJoinReader(ctx, &flowCtx, 0 /* processorID */, &spec, input, &post, lookupJoinReaderType)
 				if err != nil {
 					b.Fatal(err)
 				}
-				jr.Run(ctx)
+				jr.Run(ctx, &output)
 
 				if output.NumRowsDisposed() != numLookupRows {
 					b.Fatalf("got %d output rows, expected %d", output.NumRowsDisposed(), numLookupRows)

--- a/pkg/sql/rowexec/mergejoiner.go
+++ b/pkg/sql/rowexec/mergejoiner.go
@@ -60,7 +60,6 @@ func newMergeJoiner(
 	leftSource execinfra.RowSource,
 	rightSource execinfra.RowSource,
 	post *execinfrapb.PostProcessSpec,
-	output execinfra.RowReceiver,
 ) (*mergeJoiner, error) {
 	m := &mergeJoiner{
 		leftSource:        leftSource,
@@ -76,8 +75,7 @@ func newMergeJoiner(
 
 	if err := m.joinerBase.init(
 		ctx, m /* self */, flowCtx, processorID, leftSource.OutputTypes(), rightSource.OutputTypes(),
-		spec.Type, spec.OnExpr, false, /* outputContinuationColumn */
-		post, output,
+		spec.Type, spec.OnExpr, false /* outputContinuationColumn */, post,
 		execinfra.ProcStateOpts{
 			InputsToDrain: []execinfra.RowSource{leftSource, rightSource},
 			TrailingMetaCallback: func() []execinfrapb.ProducerMetadata {

--- a/pkg/sql/rowexec/mergejoiner_test.go
+++ b/pkg/sql/rowexec/mergejoiner_test.go
@@ -729,12 +729,12 @@ func TestMergeJoiner(t *testing.T) {
 			}
 
 			post := execinfrapb.PostProcessSpec{Projection: true, OutputColumns: c.outCols}
-			m, err := newMergeJoiner(context.Background(), &flowCtx, 0 /* processorID */, &ms, leftInput, rightInput, &post, out)
+			m, err := newMergeJoiner(context.Background(), &flowCtx, 0 /* processorID */, &ms, leftInput, rightInput, &post)
 			if err != nil {
 				t.Fatal(err)
 			}
 
-			m.Run(context.Background())
+			m.Run(context.Background(), out)
 
 			if !out.ProducerClosed() {
 				t.Fatalf("output RowReceiver not closed")
@@ -835,12 +835,12 @@ func TestConsumerClosed(t *testing.T) {
 				Mon:     evalCtx.TestingMon,
 			}
 			post := execinfrapb.PostProcessSpec{Projection: true, OutputColumns: outCols}
-			m, err := newMergeJoiner(context.Background(), &flowCtx, 0 /* processorID */, &spec, leftInput, rightInput, &post, out)
+			m, err := newMergeJoiner(context.Background(), &flowCtx, 0 /* processorID */, &spec, leftInput, rightInput, &post)
 			if err != nil {
 				t.Fatal(err)
 			}
 
-			m.Run(context.Background())
+			m.Run(context.Background(), out)
 
 			if !out.ProducerClosed() {
 				t.Fatalf("output RowReceiver not closed")
@@ -885,11 +885,11 @@ func BenchmarkMergeJoiner(b *testing.B) {
 			b.SetBytes(int64(8 * inputSize * numCols * 2))
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
-				m, err := newMergeJoiner(ctx, flowCtx, 0 /* processorID */, spec, leftInput, rightInput, post, disposer)
+				m, err := newMergeJoiner(ctx, flowCtx, 0 /* processorID */, spec, leftInput, rightInput, post)
 				if err != nil {
 					b.Fatal(err)
 				}
-				m.Run(context.Background())
+				m.Run(context.Background(), disposer)
 				leftInput.Reset()
 				rightInput.Reset()
 			}
@@ -904,11 +904,11 @@ func BenchmarkMergeJoiner(b *testing.B) {
 			b.SetBytes(int64(8 * inputSize * numCols * 2))
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
-				m, err := newMergeJoiner(ctx, flowCtx, 0 /* processorID */, spec, leftInput, rightInput, post, disposer)
+				m, err := newMergeJoiner(ctx, flowCtx, 0 /* processorID */, spec, leftInput, rightInput, post)
 				if err != nil {
 					b.Fatal(err)
 				}
-				m.Run(context.Background())
+				m.Run(context.Background(), disposer)
 				leftInput.Reset()
 				rightInput.Reset()
 			}
@@ -924,11 +924,11 @@ func BenchmarkMergeJoiner(b *testing.B) {
 			b.SetBytes(int64(8 * inputSize * numCols * 2))
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
-				m, err := newMergeJoiner(ctx, flowCtx, 0 /* processorID */, spec, leftInput, rightInput, post, disposer)
+				m, err := newMergeJoiner(ctx, flowCtx, 0 /* processorID */, spec, leftInput, rightInput, post)
 				if err != nil {
 					b.Fatal(err)
 				}
-				m.Run(context.Background())
+				m.Run(context.Background(), disposer)
 				leftInput.Reset()
 				rightInput.Reset()
 			}

--- a/pkg/sql/rowexec/noop.go
+++ b/pkg/sql/rowexec/noop.go
@@ -51,7 +51,6 @@ func newNoopProcessor(
 	processorID int32,
 	input execinfra.RowSource,
 	post *execinfrapb.PostProcessSpec,
-	output execinfra.RowReceiver,
 ) (*noopProcessor, error) {
 	n := noopPool.Get().(*noopProcessor)
 	n.input = input
@@ -62,7 +61,6 @@ func newNoopProcessor(
 		input.OutputTypes(),
 		flowCtx,
 		processorID,
-		output,
 		nil, /* memMonitor */
 		// We append input to inputs to drain below in order to reuse the same
 		// underlying slice from the pooled noopProcessor.

--- a/pkg/sql/rowexec/noop_test.go
+++ b/pkg/sql/rowexec/noop_test.go
@@ -51,11 +51,11 @@ func BenchmarkNoop(b *testing.B) {
 			b.SetBytes(int64(8 * numRows * numCols))
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
-				d, err := newNoopProcessor(ctx, flowCtx, 0 /* processorID */, input, post, disposer)
+				d, err := newNoopProcessor(ctx, flowCtx, 0 /* processorID */, input, post)
 				if err != nil {
 					b.Fatal(err)
 				}
-				d.Run(context.Background())
+				d.Run(context.Background(), disposer)
 				input.Reset()
 			}
 		})

--- a/pkg/sql/rowexec/ordinality.go
+++ b/pkg/sql/rowexec/ordinality.go
@@ -42,7 +42,6 @@ func newOrdinalityProcessor(
 	spec *execinfrapb.OrdinalitySpec,
 	input execinfra.RowSource,
 	post *execinfrapb.PostProcessSpec,
-	output execinfra.RowReceiver,
 ) (execinfra.RowSourcedProcessor, error) {
 	o := &ordinalityProcessor{input: input, curCnt: 1}
 
@@ -56,7 +55,6 @@ func newOrdinalityProcessor(
 		colTypes,
 		flowCtx,
 		processorID,
-		output,
 		nil, /* memMonitor */
 		execinfra.ProcStateOpts{
 			InputsToDrain: []execinfra.RowSource{o.input},

--- a/pkg/sql/rowexec/ordinality_test.go
+++ b/pkg/sql/rowexec/ordinality_test.go
@@ -119,12 +119,12 @@ func TestOrdinality(t *testing.T) {
 				Mon:     evalCtx.TestingMon,
 			}
 
-			d, err := newOrdinalityProcessor(context.Background(), &flowCtx, 0 /* processorID */, &os, in, &execinfrapb.PostProcessSpec{}, out)
+			d, err := newOrdinalityProcessor(context.Background(), &flowCtx, 0 /* processorID */, &os, in, &execinfrapb.PostProcessSpec{})
 			if err != nil {
 				t.Fatal(err)
 			}
 
-			d.Run(context.Background())
+			d.Run(context.Background(), out)
 			if !out.ProducerClosed() {
 				t.Fatalf("output RowReceiver not closed")
 			}
@@ -175,11 +175,11 @@ func BenchmarkOrdinality(b *testing.B) {
 		b.SetBytes(int64(8 * numRows * numCols))
 		b.Run(fmt.Sprintf("rows=%d", numRows), func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
-				o, err := newOrdinalityProcessor(ctx, flowCtx, 0 /* processorID */, spec, input, post, &rowDisposer{})
+				o, err := newOrdinalityProcessor(ctx, flowCtx, 0 /* processorID */, spec, input, post)
 				if err != nil {
 					b.Fatal(err)
 				}
-				o.Run(ctx)
+				o.Run(ctx, &rowDisposer{})
 				input.Reset()
 			}
 		})

--- a/pkg/sql/rowexec/processor_utils_test.go
+++ b/pkg/sql/rowexec/processor_utils_test.go
@@ -161,7 +161,6 @@ func (p *ProcessorTest) RunTestCases(
 			&tc.ProcessorCore,
 			&tc.Post,
 			inputs,
-			[]execinfra.RowReceiver{output},
 			nil, /* localProcessors */
 		)
 		if err != nil {
@@ -173,7 +172,7 @@ func (p *ProcessorTest) RunTestCases(
 			p.config.BeforeTestCase(processor, inputs, output)
 		}
 
-		processor.Run(ctx)
+		processor.Run(ctx, output)
 
 		if p.config.AfterTestCase != nil {
 			p.config.AfterTestCase(processor, inputs, output)

--- a/pkg/sql/rowexec/processors_test.go
+++ b/pkg/sql/rowexec/processors_test.go
@@ -330,7 +330,7 @@ func TestProcessorBaseContext(t *testing.T) {
 		defer flowCtx.EvalCtx.Stop(ctx)
 
 		input := execinfra.NewRepeatableRowSource(types.OneIntCol, randgen.MakeIntRows(10, 1))
-		noop, err := newNoopProcessor(ctx, flowCtx, 0 /* processorID */, input, &execinfrapb.PostProcessSpec{}, &rowDisposer{})
+		noop, err := newNoopProcessor(ctx, flowCtx, 0 /* processorID */, input, &execinfrapb.PostProcessSpec{})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -819,14 +819,14 @@ func TestFlowConcurrentTxnUse(t *testing.T) {
 
 	t.Run("TestSingleGoroutine", func(t *testing.T) {
 		flow := &flowinfra.FlowBase{}
-		flow.SetProcessors([]execinfra.Processor{
+		require.NoError(t, flow.SetProcessorsAndOutputs([]execinfra.Processor{
 			// samplerProcessor is used here and the other subtests because it does
 			// not implement RowSource and so must be run in a separate goroutine (it
 			// cannot be fused).
 			&samplerProcessor{
 				input: &tableReader{},
 			},
-		})
+		}, []execinfra.RowReceiver{nil}))
 		require.False(t, flow.ConcurrentTxnUse(), "expected no concurrent txn use because there is only one goroutine")
 	})
 	t.Run("TestMultipleGoroutinesWithNoConcurrentTxnUse", func(t *testing.T) {
@@ -834,28 +834,28 @@ func TestFlowConcurrentTxnUse(t *testing.T) {
 		// This is a common plan for stats collection. Neither processor implements
 		// RowSource, so the sampleAggregator must be run in a separate goroutine
 		// with a RowChannel connecting the two.
-		flow.SetProcessors([]execinfra.Processor{
+		require.NoError(t, flow.SetProcessorsAndOutputs([]execinfra.Processor{
 			&samplerProcessor{
 				input: &tableReader{},
 			},
 			&sampleAggregator{
 				input: &execinfra.RowChannel{},
 			},
-		})
+		}, []execinfra.RowReceiver{nil, nil}))
 		require.False(t, flow.ConcurrentTxnUse(), "expected no concurrent txn use because the tableReader should be the only txn user")
 	})
 	t.Run("TestMultipleGoroutinesWithConcurrentTxnUse", func(t *testing.T) {
 		flow := &flowinfra.FlowBase{}
 		// This is a scenario that should never happen, but is useful for testing
 		// (multiple concurrent samplerProcessors).
-		flow.SetProcessors([]execinfra.Processor{
+		require.NoError(t, flow.SetProcessorsAndOutputs([]execinfra.Processor{
 			&samplerProcessor{
 				input: &tableReader{},
 			},
 			&samplerProcessor{
 				input: &tableReader{},
 			},
-		})
+		}, []execinfra.RowReceiver{nil, nil}))
 		require.True(t, flow.ConcurrentTxnUse(), "expected concurrent txn use given that there are two tableReaders each in a separate goroutine")
 	})
 }
@@ -866,20 +866,18 @@ func TestFlowConcurrentTxnUse(t *testing.T) {
 // responsibility to set up all the necessary infrastructure. This method is
 // intended to be used by "reader" processors - those that read data from disk.
 func testReaderProcessorDrain(
-	ctx context.Context,
-	t *testing.T,
-	processorConstructor func(out execinfra.RowReceiver) (execinfra.Processor, error),
+	ctx context.Context, t *testing.T, processorConstructor func() (execinfra.Processor, error),
 ) {
 	// ConsumerClosed verifies that when a processor's consumer is closed, the
 	// processor finishes gracefully.
 	t.Run("ConsumerClosed", func(t *testing.T) {
 		out := &distsqlutils.RowBuffer{}
 		out.ConsumerClosed()
-		p, err := processorConstructor(out)
+		p, err := processorConstructor()
 		if err != nil {
 			t.Fatal(err)
 		}
-		p.Run(ctx)
+		p.Run(ctx, out)
 	})
 
 	// ConsumerDone verifies that the producer drains properly by checking that
@@ -888,11 +886,11 @@ func testReaderProcessorDrain(
 	t.Run("ConsumerDone", func(t *testing.T) {
 		out := &distsqlutils.RowBuffer{}
 		out.ConsumerDone()
-		p, err := processorConstructor(out)
+		p, err := processorConstructor()
 		if err != nil {
 			t.Fatal(err)
 		}
-		p.Run(ctx)
+		p.Run(ctx, out)
 		var traceSeen, txnFinalStateSeen bool
 		for {
 			row, meta := out.Next()

--- a/pkg/sql/rowexec/project_set.go
+++ b/pkg/sql/rowexec/project_set.go
@@ -80,7 +80,6 @@ func newProjectSetProcessor(
 	spec *execinfrapb.ProjectSetSpec,
 	input execinfra.RowSource,
 	post *execinfrapb.PostProcessSpec,
-	output execinfra.RowReceiver,
 ) (*projectSetProcessor, error) {
 	outputTypes := append(input.OutputTypes(), spec.GeneratedColumns...)
 	ps := &projectSetProcessor{
@@ -99,7 +98,6 @@ func newProjectSetProcessor(
 		outputTypes,
 		flowCtx,
 		processorID,
-		output,
 		nil, /* memMonitor */
 		execinfra.ProcStateOpts{
 			InputsToDrain: []execinfra.RowSource{ps.input},

--- a/pkg/sql/rowexec/project_set_test.go
+++ b/pkg/sql/rowexec/project_set_test.go
@@ -172,12 +172,12 @@ func BenchmarkProjectSet(b *testing.B) {
 				p, err := NewProcessor(
 					context.Background(), &flowCtx, 0, /* processorID */
 					&execinfrapb.ProcessorCoreUnion{ProjectSet: &c.spec}, &execinfrapb.PostProcessSpec{},
-					[]execinfra.RowSource{in}, []execinfra.RowReceiver{out}, []execinfra.LocalProcessor{})
+					[]execinfra.RowSource{in}, []execinfra.LocalProcessor{})
 				if err != nil {
 					b.Fatal(err)
 				}
 
-				p.Run(context.Background())
+				p.Run(context.Background(), out)
 			}
 		})
 	}

--- a/pkg/sql/rowexec/sample_aggregator.go
+++ b/pkg/sql/rowexec/sample_aggregator.go
@@ -93,7 +93,6 @@ func newSampleAggregator(
 	spec *execinfrapb.SampleAggregatorSpec,
 	input execinfra.RowSource,
 	post *execinfrapb.PostProcessSpec,
-	output execinfra.RowReceiver,
 ) (*sampleAggregator, error) {
 	for _, s := range spec.Sketches {
 		if len(s.Columns) == 0 {
@@ -172,7 +171,7 @@ func newSampleAggregator(
 	}
 
 	if err := s.Init(
-		ctx, nil, post, input.OutputTypes(), flowCtx, processorID, output, memMonitor,
+		ctx, nil, post, input.OutputTypes(), flowCtx, processorID, memMonitor,
 		execinfra.ProcStateOpts{
 			TrailingMetaCallback: func() []execinfrapb.ProducerMetadata {
 				s.close()
@@ -185,22 +184,22 @@ func newSampleAggregator(
 	return s, nil
 }
 
-func (s *sampleAggregator) pushTrailingMeta(ctx context.Context) {
-	execinfra.SendTraceData(ctx, s.Output)
+func (s *sampleAggregator) pushTrailingMeta(ctx context.Context, output execinfra.RowReceiver) {
+	execinfra.SendTraceData(ctx, output)
 }
 
 // Run is part of the Processor interface.
-func (s *sampleAggregator) Run(ctx context.Context) {
+func (s *sampleAggregator) Run(ctx context.Context, output execinfra.RowReceiver) {
 	ctx = s.StartInternal(ctx, sampleAggregatorProcName)
 	s.input.Start(ctx)
 
-	earlyExit, err := s.mainLoop(ctx)
+	earlyExit, err := s.mainLoop(ctx, output)
 	if err != nil {
-		execinfra.DrainAndClose(ctx, s.Output, err, s.pushTrailingMeta, s.input)
+		execinfra.DrainAndClose(ctx, output, err, s.pushTrailingMeta, s.input)
 	} else if !earlyExit {
-		s.pushTrailingMeta(ctx)
+		s.pushTrailingMeta(ctx, output)
 		s.input.ConsumerClosed()
-		s.Output.ProducerDone()
+		output.ProducerDone()
 	}
 	s.MoveToDraining(nil /* err */)
 }
@@ -213,7 +212,9 @@ func (s *sampleAggregator) close() {
 	}
 }
 
-func (s *sampleAggregator) mainLoop(ctx context.Context) (earlyExit bool, err error) {
+func (s *sampleAggregator) mainLoop(
+	ctx context.Context, output execinfra.RowReceiver,
+) (earlyExit bool, err error) {
 	var job *jobs.Job
 	jobID := s.spec.JobID
 	// Some tests run this code without a job, so check if the jobID is 0.
@@ -274,7 +275,7 @@ func (s *sampleAggregator) mainLoop(ctx context.Context) (earlyExit bool, err er
 						sr.Disable()
 					}
 				}
-			} else if !emitHelper(ctx, s.Output, &s.OutputHelper, nil /* row */, meta, s.pushTrailingMeta, s.input) {
+			} else if !emitHelper(ctx, output, &s.OutputHelper, nil /* row */, meta, s.pushTrailingMeta, s.input) {
 				// No cleanup required; emitHelper() took care of it.
 				return true, nil
 			}

--- a/pkg/sql/rowexec/sample_aggregator_test.go
+++ b/pkg/sql/rowexec/sample_aggregator_test.go
@@ -163,12 +163,12 @@ func runSampleAggregator(
 			Sketches:      sketchSpecs,
 		}
 		p, err := newSamplerProcessor(
-			context.Background(), &flowCtx, 0 /* processorID */, spec, in[i], &execinfrapb.PostProcessSpec{}, outputs[i],
+			context.Background(), &flowCtx, 0 /* processorID */, spec, in[i], &execinfrapb.PostProcessSpec{},
 		)
 		if err != nil {
 			t.Fatal(err)
 		}
-		p.Run(context.Background())
+		p.Run(context.Background(), outputs[i])
 	}
 	// Randomly interleave the output rows from the samplers into a single buffer.
 	samplerResults := distsqlutils.NewRowBuffer(samplerOutTypes, nil /* rows */, distsqlutils.RowBufferArgs{})
@@ -197,12 +197,12 @@ func runSampleAggregator(
 	}
 
 	agg, err := newSampleAggregator(
-		context.Background(), &flowCtx, 0 /* processorID */, spec, samplerResults, &execinfrapb.PostProcessSpec{}, finalOut,
+		context.Background(), &flowCtx, 0 /* processorID */, spec, samplerResults, &execinfrapb.PostProcessSpec{},
 	)
 	if err != nil {
 		t.Fatal(err)
 	}
-	agg.Run(context.Background())
+	agg.Run(context.Background(), finalOut)
 	// Make sure there was no error.
 	finalOut.GetRowsNoMeta(t)
 	r := sqlutils.MakeSQLRunner(sqlDB)

--- a/pkg/sql/rowexec/sampler.go
+++ b/pkg/sql/rowexec/sampler.go
@@ -106,7 +106,6 @@ func newSamplerProcessor(
 	spec *execinfrapb.SamplerSpec,
 	input execinfra.RowSource,
 	post *execinfrapb.PostProcessSpec,
-	output execinfra.RowReceiver,
 ) (*samplerProcessor, error) {
 	for _, s := range spec.Sketches {
 		if _, ok := supportedSketchTypes[s.SketchType]; !ok {
@@ -204,7 +203,7 @@ func newSamplerProcessor(
 	s.outTypes = outTypes
 
 	if err := s.Init(
-		ctx, nil, post, outTypes, flowCtx, processorID, output, memMonitor,
+		ctx, nil, post, outTypes, flowCtx, processorID, memMonitor,
 		execinfra.ProcStateOpts{
 			TrailingMetaCallback: func() []execinfrapb.ProducerMetadata {
 				s.close()
@@ -217,27 +216,29 @@ func newSamplerProcessor(
 	return s, nil
 }
 
-func (s *samplerProcessor) pushTrailingMeta(ctx context.Context) {
-	execinfra.SendTraceData(ctx, s.Output)
+func (s *samplerProcessor) pushTrailingMeta(ctx context.Context, output execinfra.RowReceiver) {
+	execinfra.SendTraceData(ctx, output)
 }
 
 // Run is part of the Processor interface.
-func (s *samplerProcessor) Run(ctx context.Context) {
+func (s *samplerProcessor) Run(ctx context.Context, output execinfra.RowReceiver) {
 	ctx = s.StartInternal(ctx, samplerProcName)
 	s.input.Start(ctx)
 
-	earlyExit, err := s.mainLoop(ctx)
+	earlyExit, err := s.mainLoop(ctx, output)
 	if err != nil {
-		execinfra.DrainAndClose(ctx, s.Output, err, s.pushTrailingMeta, s.input)
+		execinfra.DrainAndClose(ctx, output, err, s.pushTrailingMeta, s.input)
 	} else if !earlyExit {
-		s.pushTrailingMeta(ctx)
+		s.pushTrailingMeta(ctx, output)
 		s.input.ConsumerClosed()
-		s.Output.ProducerDone()
+		output.ProducerDone()
 	}
 	s.MoveToDraining(nil /* err */)
 }
 
-func (s *samplerProcessor) mainLoop(ctx context.Context) (earlyExit bool, err error) {
+func (s *samplerProcessor) mainLoop(
+	ctx context.Context, output execinfra.RowReceiver,
+) (earlyExit bool, err error) {
 	rng, _ := randutil.NewPseudoRand()
 	var da tree.DatumAlloc
 	var buf []byte
@@ -252,7 +253,7 @@ func (s *samplerProcessor) mainLoop(ctx context.Context) (earlyExit bool, err er
 	for {
 		row, meta := s.input.Next()
 		if meta != nil {
-			if !emitHelper(ctx, s.Output, &s.OutputHelper, nil /* row */, meta, s.pushTrailingMeta, s.input) {
+			if !emitHelper(ctx, output, &s.OutputHelper, nil /* row */, meta, s.pushTrailingMeta, s.input) {
 				// No cleanup required; emitHelper() took care of it.
 				return true, nil
 			}
@@ -269,7 +270,7 @@ func (s *samplerProcessor) mainLoop(ctx context.Context) (earlyExit bool, err er
 			meta := &execinfrapb.ProducerMetadata{SamplerProgress: &execinfrapb.RemoteProducerMetadata_SamplerProgress{
 				RowsProcessed: uint64(SamplerProgressInterval),
 			}}
-			if !emitHelper(ctx, s.Output, &s.OutputHelper, nil /* row */, meta, s.pushTrailingMeta, s.input) {
+			if !emitHelper(ctx, output, &s.OutputHelper, nil /* row */, meta, s.pushTrailingMeta, s.input) {
 				return true, nil
 			}
 
@@ -321,7 +322,7 @@ func (s *samplerProcessor) mainLoop(ctx context.Context) (earlyExit bool, err er
 				return false, err
 			}
 		}
-		if earlyExit, err = s.sampleRow(ctx, &s.sr, row, rng); earlyExit || err != nil {
+		if earlyExit, err = s.sampleRow(ctx, output, &s.sr, row, rng); earlyExit || err != nil {
 			return earlyExit, err
 		}
 
@@ -350,7 +351,7 @@ func (s *samplerProcessor) mainLoop(ctx context.Context) (earlyExit bool, err er
 				if err := s.invSketch[col].addRow(ctx, invRow, bytesRowType, &buf, &da); err != nil {
 					return false, err
 				}
-				if earlyExit, err = s.sampleRow(ctx, invSr, invRow, rng); earlyExit || err != nil {
+				if earlyExit, err = s.sampleRow(ctx, output, invSr, invRow, rng); earlyExit || err != nil {
 					return earlyExit, err
 				}
 			}
@@ -367,7 +368,7 @@ func (s *samplerProcessor) mainLoop(ctx context.Context) (earlyExit bool, err er
 	for _, sample := range s.sr.Get() {
 		copy(outRow, sample.Row)
 		outRow[s.rankCol] = rowenc.EncDatum{Datum: tree.NewDInt(tree.DInt(sample.Rank))}
-		if !emitHelper(ctx, s.Output, &s.OutputHelper, outRow, nil /* meta */, s.pushTrailingMeta, s.input) {
+		if !emitHelper(ctx, output, &s.OutputHelper, outRow, nil /* meta */, s.pushTrailingMeta, s.input) {
 			return true, nil
 		}
 	}
@@ -383,7 +384,7 @@ func (s *samplerProcessor) mainLoop(ctx context.Context) (earlyExit bool, err er
 			// Reuse the rank column for inverted index keys.
 			outRow[s.rankCol] = rowenc.EncDatum{Datum: tree.NewDInt(tree.DInt(sample.Rank))}
 			outRow[s.invIdxKeyCol] = sample.Row[0]
-			if !emitHelper(ctx, s.Output, &s.OutputHelper, outRow, nil /* meta */, s.pushTrailingMeta, s.input) {
+			if !emitHelper(ctx, output, &s.OutputHelper, outRow, nil /* meta */, s.pushTrailingMeta, s.input) {
 				return true, nil
 			}
 		}
@@ -398,7 +399,7 @@ func (s *samplerProcessor) mainLoop(ctx context.Context) (earlyExit bool, err er
 	}
 	for i, si := range s.sketches {
 		outRow[s.sketchIdxCol] = rowenc.EncDatum{Datum: tree.NewDInt(tree.DInt(i))}
-		if earlyExit, err := s.emitSketchRow(ctx, &si, outRow); earlyExit || err != nil {
+		if earlyExit, err := s.emitSketchRow(ctx, output, &si, outRow); earlyExit || err != nil {
 			return earlyExit, err
 		}
 	}
@@ -409,7 +410,7 @@ func (s *samplerProcessor) mainLoop(ctx context.Context) (earlyExit bool, err er
 	}
 	for col, invSketch := range s.invSketch {
 		outRow[s.invColIdxCol] = rowenc.EncDatum{Datum: tree.NewDInt(tree.DInt(col))}
-		if earlyExit, err := s.emitSketchRow(ctx, invSketch, outRow); earlyExit || err != nil {
+		if earlyExit, err := s.emitSketchRow(ctx, output, invSketch, outRow); earlyExit || err != nil {
 			return earlyExit, err
 		}
 	}
@@ -418,7 +419,7 @@ func (s *samplerProcessor) mainLoop(ctx context.Context) (earlyExit bool, err er
 	meta := &execinfrapb.ProducerMetadata{SamplerProgress: &execinfrapb.RemoteProducerMetadata_SamplerProgress{
 		RowsProcessed: uint64(rowCount % SamplerProgressInterval),
 	}}
-	if !emitHelper(ctx, s.Output, &s.OutputHelper, nil /* row */, meta, s.pushTrailingMeta, s.input) {
+	if !emitHelper(ctx, output, &s.OutputHelper, nil /* row */, meta, s.pushTrailingMeta, s.input) {
 		return true, nil
 	}
 
@@ -426,7 +427,7 @@ func (s *samplerProcessor) mainLoop(ctx context.Context) (earlyExit bool, err er
 }
 
 func (s *samplerProcessor) emitSketchRow(
-	ctx context.Context, si *sketchInfo, outRow rowenc.EncDatumRow,
+	ctx context.Context, output execinfra.RowReceiver, si *sketchInfo, outRow rowenc.EncDatumRow,
 ) (earlyExit bool, err error) {
 	outRow[s.numRowsCol] = rowenc.EncDatum{Datum: tree.NewDInt(tree.DInt(si.numRows))}
 	outRow[s.numNullsCol] = rowenc.EncDatum{Datum: tree.NewDInt(tree.DInt(si.numNulls))}
@@ -436,7 +437,7 @@ func (s *samplerProcessor) emitSketchRow(
 		return false, err
 	}
 	outRow[s.sketchCol] = rowenc.EncDatum{Datum: tree.NewDBytes(tree.DBytes(data))}
-	if !emitHelper(ctx, s.Output, &s.OutputHelper, outRow, nil /* meta */, s.pushTrailingMeta, s.input) {
+	if !emitHelper(ctx, output, &s.OutputHelper, outRow, nil /* meta */, s.pushTrailingMeta, s.input) {
 		return true, nil
 	}
 	return false, nil
@@ -444,7 +445,11 @@ func (s *samplerProcessor) emitSketchRow(
 
 // sampleRow looks at a row and either drops it or adds it to the reservoir.
 func (s *samplerProcessor) sampleRow(
-	ctx context.Context, sr *stats.SampleReservoir, row rowenc.EncDatumRow, rng *rand.Rand,
+	ctx context.Context,
+	output execinfra.RowReceiver,
+	sr *stats.SampleReservoir,
+	row rowenc.EncDatumRow,
+	rng *rand.Rand,
 ) (earlyExit bool, err error) {
 	// Use Int63 so we don't have headaches converting to DInt.
 	rank := uint64(rng.Int63())
@@ -464,7 +469,7 @@ func (s *samplerProcessor) sampleRow(
 		meta := &execinfrapb.ProducerMetadata{SamplerProgress: &execinfrapb.RemoteProducerMetadata_SamplerProgress{
 			HistogramDisabled: true,
 		}}
-		if !emitHelper(ctx, s.Output, &s.OutputHelper, nil /* row */, meta, s.pushTrailingMeta, s.input) {
+		if !emitHelper(ctx, output, &s.OutputHelper, nil /* row */, meta, s.pushTrailingMeta, s.input) {
 			return true, nil
 		}
 	} else if sr.Cap() != prevCapacity {

--- a/pkg/sql/rowexec/sampler_test.go
+++ b/pkg/sql/rowexec/sampler_test.go
@@ -85,12 +85,12 @@ func runSampler(
 		MinSampleSize: uint32(minNumSamples),
 	}
 	p, err := newSamplerProcessor(
-		context.Background(), &flowCtx, 0 /* processorID */, spec, in, &execinfrapb.PostProcessSpec{}, out,
+		context.Background(), &flowCtx, 0 /* processorID */, spec, in, &execinfrapb.PostProcessSpec{},
 	)
 	if err != nil {
 		t.Fatal(err)
 	}
-	p.Run(context.Background())
+	p.Run(context.Background(), out)
 
 	// Verify we have expectedSamples distinct rows.
 	res := make([]int, 0, numSamples)
@@ -383,11 +383,11 @@ func TestSamplerSketch(t *testing.T) {
 				},
 			},
 		}
-		p, err := newSamplerProcessor(context.Background(), &flowCtx, 0 /* processorID */, spec, in, &execinfrapb.PostProcessSpec{}, out)
+		p, err := newSamplerProcessor(context.Background(), &flowCtx, 0 /* processorID */, spec, in, &execinfrapb.PostProcessSpec{})
 		if err != nil {
 			t.Fatal(err)
 		}
-		p.Run(context.Background())
+		p.Run(context.Background(), out)
 
 		// Collect the rows, excluding metadata.
 		rows = rows[:0]

--- a/pkg/sql/rowexec/sorter_test.go
+++ b/pkg/sql/rowexec/sorter_test.go
@@ -292,11 +292,11 @@ func TestSorter(t *testing.T) {
 					in := distsqlutils.NewRowBuffer(c.types, c.input, distsqlutils.RowBufferArgs{})
 					out := &distsqlutils.RowBuffer{}
 
-					s, err := newSorter(context.Background(), &flowCtx, 0 /* processorID */, &c.spec, in, &c.post, out)
+					s, err := newSorter(context.Background(), &flowCtx, 0 /* processorID */, &c.spec, in, &c.post)
 					if err != nil {
 						t.Fatal(err)
 					}
-					s.Run(context.Background())
+					s.Run(context.Background(), out)
 					if !out.ProducerClosed() {
 						t.Fatalf("output RowReceiver not closed")
 					}
@@ -361,9 +361,8 @@ func TestSortInvalidLimit(t *testing.T) {
 
 		post := execinfrapb.PostProcessSpec{}
 		in := distsqlutils.NewRowBuffer([]*types.T{types.Int}, rowenc.EncDatumRows{}, distsqlutils.RowBufferArgs{})
-		out := &distsqlutils.RowBuffer{}
 		proc, err := newSorter(
-			context.Background(), &flowCtx, 0, &spec, in, &post, out,
+			context.Background(), &flowCtx, 0, &spec, in, &post,
 		)
 		if err != nil {
 			t.Fatal(err)
@@ -377,7 +376,7 @@ func TestSortInvalidLimit(t *testing.T) {
 		var k uint64
 		// All arguments apart from spec and post are not necessary.
 		if _, err := newSortTopKProcessor(
-			context.Background(), nil, 0, &spec, nil, nil, nil, k,
+			context.Background(), nil, 0, &spec, nil, nil, k,
 		); !testutils.IsError(err, errSortTopKZeroK.Error()) {
 			t.Fatalf("unexpected error %v, expected %v", err, errSortTopKZeroK)
 		}
@@ -420,12 +419,12 @@ func BenchmarkSortAll(b *testing.B) {
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
 				s, err := newSorter(
-					context.Background(), &flowCtx, 0 /* processorID */, &spec, input, &post, &rowDisposer{},
+					context.Background(), &flowCtx, 0 /* processorID */, &spec, input, &post,
 				)
 				if err != nil {
 					b.Fatal(err)
 				}
-				s.Run(context.Background())
+				s.Run(context.Background(), &rowDisposer{})
 				input.Reset()
 			}
 		})
@@ -467,12 +466,12 @@ func BenchmarkSortLimit(b *testing.B) {
 				for i := 0; i < b.N; i++ {
 					s, err := newSorter(
 						context.Background(), &flowCtx, 0, /* processorID */
-						&spec, input, &execinfrapb.PostProcessSpec{Limit: 0}, &rowDisposer{},
+						&spec, input, &execinfrapb.PostProcessSpec{Limit: 0},
 					)
 					if err != nil {
 						b.Fatal(err)
 					}
-					s.Run(context.Background())
+					s.Run(context.Background(), &rowDisposer{})
 					input.Reset()
 				}
 			})
@@ -520,11 +519,11 @@ func BenchmarkSortChunks(b *testing.B) {
 				b.SetBytes(int64(numRows * numCols * 8))
 				b.ResetTimer()
 				for i := 0; i < b.N; i++ {
-					s, err := newSorter(context.Background(), &flowCtx, 0 /* processorID */, &spec, input, &post, &rowDisposer{})
+					s, err := newSorter(context.Background(), &flowCtx, 0 /* processorID */, &spec, input, &post)
 					if err != nil {
 						b.Fatal(err)
 					}
-					s.Run(context.Background())
+					s.Run(context.Background(), &rowDisposer{})
 					input.Reset()
 				}
 			})

--- a/pkg/sql/rowexec/tablereader.go
+++ b/pkg/sql/rowexec/tablereader.go
@@ -81,7 +81,6 @@ func newTableReader(
 	processorID int32,
 	spec *execinfrapb.TableReaderSpec,
 	post *execinfrapb.PostProcessSpec,
-	output execinfra.RowReceiver,
 ) (*tableReader, error) {
 	// NB: we hit this with a zero NodeID (but !ok) with multi-tenancy.
 	if nodeID, ok := flowCtx.NodeID.OptionalNodeID(); ok && nodeID == 0 {
@@ -132,7 +131,6 @@ func newTableReader(
 		resultTypes,
 		flowCtx,
 		processorID,
-		output,
 		nil, /* memMonitor */
 		execinfra.ProcStateOpts{
 			// We don't pass tr.input as an inputToDrain; tr.input is just an adapter

--- a/pkg/sql/rowexec/tablereader_test.go
+++ b/pkg/sql/rowexec/tablereader_test.go
@@ -147,7 +147,7 @@ func TestTableReader(t *testing.T) {
 					buf = &distsqlutils.RowBuffer{}
 					out = buf
 				}
-				tr, err := newTableReader(ctx, &flowCtx, 0 /* processorID */, &ts, &c.post, out)
+				tr, err := newTableReader(ctx, &flowCtx, 0 /* processorID */, &ts, &c.post)
 				if err != nil {
 					t.Fatal(err)
 				}
@@ -157,7 +157,7 @@ func TestTableReader(t *testing.T) {
 					tr.Start(ctx)
 					results = tr
 				} else {
-					tr.Run(ctx)
+					tr.Run(ctx, out)
 					if !buf.ProducerClosed() {
 						t.Fatalf("output RowReceiver not closed")
 					}
@@ -248,7 +248,7 @@ ALTER TABLE t EXPERIMENTAL_RELOCATE VALUES (ARRAY[2], 1), (ARRAY[1], 2), (ARRAY[
 			buf = &distsqlutils.RowBuffer{}
 			out = buf
 		}
-		tr, err := newTableReader(ctx, &flowCtx, 0 /* processorID */, &spec, &post, out)
+		tr, err := newTableReader(ctx, &flowCtx, 0 /* processorID */, &spec, &post)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -258,7 +258,7 @@ ALTER TABLE t EXPERIMENTAL_RELOCATE VALUES (ARRAY[2], 1), (ARRAY[1], 2), (ARRAY[
 			tr.Start(ctx)
 			results = tr
 		} else {
-			tr.Run(ctx)
+			tr.Run(ctx, out)
 			if !buf.ProducerClosed() {
 				t.Fatalf("output RowReceiver not closed")
 			}
@@ -347,8 +347,8 @@ func TestTableReaderDrain(t *testing.T) {
 	}
 	post := execinfrapb.PostProcessSpec{}
 
-	testReaderProcessorDrain(ctx, t, func(out execinfra.RowReceiver) (execinfra.Processor, error) {
-		return newTableReader(ctx, &flowCtx, 0 /* processorID */, &spec, &post, out)
+	testReaderProcessorDrain(ctx, t, func() (execinfra.Processor, error) {
+		return newTableReader(ctx, &flowCtx, 0 /* processorID */, &spec, &post)
 	})
 }
 
@@ -407,7 +407,7 @@ func TestLimitScans(t *testing.T) {
 	ctx = tracing.ContextWithSpan(ctx, sp)
 	flowCtx.CollectStats = true
 
-	tr, err := newTableReader(ctx, &flowCtx, 0 /* processorID */, &spec, &post, nil /* output */)
+	tr, err := newTableReader(ctx, &flowCtx, 0 /* processorID */, &spec, &post)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -525,7 +525,7 @@ func BenchmarkTableReader(b *testing.B) {
 				// txnKVFetcher reuses the passed-in slice and destructively
 				// modifies it.
 				spec.Spans = []roachpb.Span{span}
-				tr, err := newTableReader(ctx, &flowCtx, 0 /* processorID */, &spec, &post, nil /* output */)
+				tr, err := newTableReader(ctx, &flowCtx, 0 /* processorID */, &spec, &post)
 				if err != nil {
 					b.Fatal(err)
 				}

--- a/pkg/sql/rowexec/utils_test.go
+++ b/pkg/sql/rowexec/utils_test.go
@@ -63,7 +63,7 @@ func runProcessorTest(
 
 	p, err := NewProcessor(
 		context.Background(), &flowCtx, 0 /* processorID */, &core, &post,
-		[]execinfra.RowSource{in}, []execinfra.RowReceiver{out}, []execinfra.LocalProcessor{})
+		[]execinfra.RowSource{in}, []execinfra.LocalProcessor{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -74,7 +74,7 @@ func runProcessorTest(
 		pt.SetBatchSizeBytes(2 * int64(inputRows[0].Size()))
 	}
 
-	p.Run(context.Background())
+	p.Run(context.Background(), out)
 	if !out.ProducerClosed() {
 		t.Fatalf("output RowReceiver not closed")
 	}

--- a/pkg/sql/rowexec/values.go
+++ b/pkg/sql/rowexec/values.go
@@ -47,7 +47,6 @@ func newValuesProcessor(
 	processorID int32,
 	spec *execinfrapb.ValuesCoreSpec,
 	post *execinfrapb.PostProcessSpec,
-	output execinfra.RowReceiver,
 ) (*valuesProcessor, error) {
 	if len(spec.Columns) > 0 && uint64(len(spec.RawBytes)) != spec.NumRows {
 		return nil, errors.AssertionFailedf(
@@ -65,7 +64,7 @@ func newValuesProcessor(
 		v.typs[i] = spec.Columns[i].Type
 	}
 	if err := v.Init(
-		ctx, v, post, v.typs, flowCtx, processorID, output, nil /* memMonitor */, execinfra.ProcStateOpts{},
+		ctx, v, post, v.typs, flowCtx, processorID, nil /* memMonitor */, execinfra.ProcStateOpts{},
 	); err != nil {
 		return nil, err
 	}

--- a/pkg/sql/rowexec/values_test.go
+++ b/pkg/sql/rowexec/values_test.go
@@ -52,11 +52,11 @@ func TestValuesProcessor(t *testing.T) {
 					Mon:     evalCtx.TestingMon,
 				}
 
-				v, err := newValuesProcessor(context.Background(), &flowCtx, 0 /* processorID */, &spec, &execinfrapb.PostProcessSpec{}, out)
+				v, err := newValuesProcessor(context.Background(), &flowCtx, 0 /* processorID */, &spec, &execinfrapb.PostProcessSpec{})
 				if err != nil {
 					t.Fatal(err)
 				}
-				v.Run(context.Background())
+				v.Run(context.Background(), out)
 				if !out.ProducerClosed() {
 					t.Fatalf("output RowReceiver not closed")
 				}
@@ -125,11 +125,11 @@ func BenchmarkValuesProcessor(b *testing.B) {
 				b.SetBytes(int64(8 * numRows * numCols))
 				b.ResetTimer()
 				for i := 0; i < b.N; i++ {
-					v, err := newValuesProcessor(ctx, &flowCtx, 0 /* processorID */, &spec, &post, &output)
+					v, err := newValuesProcessor(ctx, &flowCtx, 0 /* processorID */, &spec, &post)
 					if err != nil {
 						b.Fatal(err)
 					}
-					v.Run(ctx)
+					v.Run(ctx, &output)
 				}
 			})
 		}

--- a/pkg/sql/rowexec/windower.go
+++ b/pkg/sql/rowexec/windower.go
@@ -105,7 +105,6 @@ func newWindower(
 	spec *execinfrapb.WindowerSpec,
 	input execinfra.RowSource,
 	post *execinfrapb.PostProcessSpec,
-	output execinfra.RowReceiver,
 ) (*windower, error) {
 	w := &windower{
 		input: input,
@@ -174,7 +173,6 @@ func newWindower(
 		flowCtx,
 		evalCtx,
 		processorID,
-		output,
 		limitedMon,
 		execinfra.ProcStateOpts{InputsToDrain: []execinfra.RowSource{w.input},
 			TrailingMetaCallback: func() []execinfrapb.ProducerMetadata {

--- a/pkg/sql/rowexec/windower_test.go
+++ b/pkg/sql/rowexec/windower_test.go
@@ -95,11 +95,11 @@ func TestWindowerAccountingForResults(t *testing.T) {
 		types.OneIntCol, nil, distsqlutils.RowBufferArgs{},
 	)
 
-	d, err := newWindower(ctx, flowCtx, 0 /* processorID */, &spec, input, post, output)
+	d, err := newWindower(ctx, flowCtx, 0 /* processorID */, &spec, input, post)
 	if err != nil {
 		t.Fatal(err)
 	}
-	d.Run(ctx)
+	d.Run(ctx, output)
 	for {
 		row, meta := output.Next()
 		if row != nil {
@@ -255,11 +255,11 @@ func BenchmarkWindower(b *testing.B) {
 				b.SetBytes(int64(8 * numRows * numCols))
 				b.ResetTimer()
 				for i := 0; i < b.N; i++ {
-					d, err := newWindower(ctx, flowCtx, 0 /* processorID */, &spec, input, post, disposer)
+					d, err := newWindower(ctx, flowCtx, 0 /* processorID */, &spec, input, post)
 					if err != nil {
 						b.Fatal(err)
 					}
-					d.Run(ctx)
+					d.Run(ctx, disposer)
 					input.Reset()
 				}
 				b.StopTimer()

--- a/pkg/sql/rowexec/zigzagjoiner.go
+++ b/pkg/sql/rowexec/zigzagjoiner.go
@@ -279,7 +279,6 @@ func newZigzagJoiner(
 	spec *execinfrapb.ZigzagJoinerSpec,
 	fixedValues []rowenc.EncDatumRow,
 	post *execinfrapb.PostProcessSpec,
-	output execinfra.RowReceiver,
 ) (*zigzagJoiner, error) {
 	if len(spec.Sides) != 2 {
 		return nil, errors.AssertionFailedf("zigzag joins only of two tables (or indexes) are supported, %d requested", len(spec.Sides))
@@ -315,7 +314,6 @@ func newZigzagJoiner(
 		spec.OnExpr,
 		false, /* outputContinuationColumn */
 		post,
-		output,
 		execinfra.ProcStateOpts{
 			TrailingMetaCallback: func() []execinfrapb.ProducerMetadata {
 				// We need to generate metadata before closing the processor

--- a/pkg/sql/rowexec/zigzagjoiner_test.go
+++ b/pkg/sql/rowexec/zigzagjoiner_test.go
@@ -707,12 +707,12 @@ func TestZigzagJoiner(t *testing.T) {
 
 			out := &distsqlutils.RowBuffer{}
 			post := execinfrapb.PostProcessSpec{Projection: true, OutputColumns: c.outCols}
-			z, err := newZigzagJoiner(ctx, &flowCtx, 0 /* processorID */, &c.spec, c.fixedValues, &post, out)
+			z, err := newZigzagJoiner(ctx, &flowCtx, 0 /* processorID */, &c.spec, c.fixedValues, &post)
 			if err != nil {
 				t.Fatal(err)
 			}
 
-			z.Run(ctx)
+			z.Run(ctx, out)
 
 			if !out.ProducerClosed() {
 				t.Fatalf("output RowReceiver not closed")
@@ -780,7 +780,7 @@ func TestZigzagJoinerDrain(t *testing.T) {
 		Txn:     leafTxn,
 	}
 
-	testReaderProcessorDrain(ctx, t, func(out execinfra.RowReceiver) (execinfra.Processor, error) {
+	testReaderProcessorDrain(ctx, t, func() (execinfra.Processor, error) {
 		return newZigzagJoiner(
 			ctx,
 			&flowCtx,
@@ -800,7 +800,6 @@ func TestZigzagJoinerDrain(t *testing.T) {
 			},
 			[]rowenc.EncDatumRow{{encThree}, {encSeven}},
 			&execinfrapb.PostProcessSpec{Projection: true, OutputColumns: []uint32{0, 1}},
-			out,
 		)
 	})
 }

--- a/pkg/sql/rowflow/row_based_flow.go
+++ b/pkg/sql/rowflow/row_based_flow.go
@@ -83,12 +83,13 @@ func (f *rowBasedFlow) setupProcessors(
 	ctx context.Context, spec *execinfrapb.FlowSpec, inputSyncs [][]execinfra.RowSource,
 ) error {
 	processors := make([]execinfra.Processor, 0, len(spec.Processors))
+	outputs := make([]execinfra.RowReceiver, 0, len(spec.Processors))
 
 	// Populate processors: see which processors need their own goroutine and
 	// which are fused with their consumer.
 	for i := range spec.Processors {
 		pspec := &spec.Processors[i]
-		p, err := f.makeProcessor(ctx, pspec, inputSyncs[i])
+		p, output, err := f.makeProcessorAndOutput(ctx, pspec, inputSyncs[i])
 		if err != nil {
 			return err
 		}
@@ -165,10 +166,10 @@ func (f *rowBasedFlow) setupProcessors(
 		}
 		if !fuse() {
 			processors = append(processors, p)
+			outputs = append(outputs, output)
 		}
 	}
-	f.SetProcessors(processors)
-	return nil
+	return f.SetProcessorsAndOutputs(processors, outputs)
 }
 
 // findProcByOutputStreamID looks in spec for a processor that has a
@@ -200,11 +201,11 @@ func findProcByOutputStreamID(
 	return nil
 }
 
-func (f *rowBasedFlow) makeProcessor(
+func (f *rowBasedFlow) makeProcessorAndOutput(
 	ctx context.Context, ps *execinfrapb.ProcessorSpec, inputs []execinfra.RowSource,
-) (execinfra.Processor, error) {
+) (execinfra.Processor, execinfra.RowReceiver, error) {
 	if len(ps.Output) != 1 {
-		return nil, errors.Errorf("only single-output processors supported")
+		return nil, nil, errors.Errorf("only single-output processors supported")
 	}
 	var output execinfra.RowReceiver
 	spec := &ps.Output[0]
@@ -212,17 +213,17 @@ func (f *rowBasedFlow) makeProcessor(
 		// There is no entity that corresponds to a pass-through router - we just
 		// use its output stream directly.
 		if len(spec.Streams) != 1 {
-			return nil, errors.Errorf("expected one stream for passthrough router")
+			return nil, nil, errors.Errorf("expected one stream for passthrough router")
 		}
 		var err error
 		output, err = f.setupOutboundStream(spec.Streams[0])
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 	} else {
 		r, err := f.setupRouter(spec)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 		output = r
 		f.AddStartable(r)
@@ -237,7 +238,6 @@ func (f *rowBasedFlow) makeProcessor(
 
 	output = &copyingRowReceiver{RowReceiver: output}
 
-	outputs := []execinfra.RowReceiver{output}
 	proc, err := rowexec.NewProcessor(
 		ctx,
 		&f.FlowCtx,
@@ -245,11 +245,10 @@ func (f *rowBasedFlow) makeProcessor(
 		&ps.Core,
 		&ps.Post,
 		inputs,
-		outputs,
 		f.GetLocalProcessors(),
 	)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	// Initialize any routers (the setupRouter case above) and outboxes.
@@ -261,7 +260,7 @@ func (f *rowBasedFlow) makeProcessor(
 	case *flowinfra.Outbox:
 		o.Init(types)
 	}
-	return proc, nil
+	return proc, output, nil
 }
 
 // setupInputSyncs populates a slice of input syncs, one for each Processor in

--- a/pkg/sql/ttl/ttljob/ttljob_processor.go
+++ b/pkg/sql/ttl/ttljob/ttljob_processor.go
@@ -349,11 +349,7 @@ func (t *ttlProcessor) Next() (rowenc.EncDatumRow, *execinfrapb.ProducerMetadata
 }
 
 func newTTLProcessor(
-	ctx context.Context,
-	flowCtx *execinfra.FlowCtx,
-	processorID int32,
-	spec execinfrapb.TTLSpec,
-	output execinfra.RowReceiver,
+	ctx context.Context, flowCtx *execinfra.FlowCtx, processorID int32, spec execinfrapb.TTLSpec,
 ) (execinfra.Processor, error) {
 	ttlProcessor := &ttlProcessor{
 		ttlSpec: spec,
@@ -365,7 +361,6 @@ func newTTLProcessor(
 		[]*types.T{},
 		flowCtx,
 		processorID,
-		output,
 		nil, /* memMonitor */
 		execinfra.ProcStateOpts{},
 	); err != nil {


### PR DESCRIPTION
**colflow: simplify the vectorized flow creator a bit**

This commit refactors the vectorized flow creator to directly embed two
structs that implement interfaces used by the creator. This allows for
those structs to not be allocated on the main code path. Also,
`flowCreatorHelper` no longer implements the `Releasable` interface.

Release note: None

**execinfra: explicitly pass the output RowReceiver to Processor.Run**

This commit modifies how the output of a processor is plumbed through.
Previously, we would pass it on the processor construction and store in
the `ProcessorBaseNoHelper` to later be used when calling
`execinfra.Run` method. However, the upcoming work on multiple active
portals will require updating the output when resuming the flow, so this
commit makes it so that we now pass the output explicitly into
`execinfra.Processor.Run` method. This will make the work on multiple
active portals cleaner, but also this change seems like a good one
independent of that because we're able to store all outputs in the
single place (`FlowBase.outputs`).

Epic: CRDB-17622

Release note: None