### PR TITLE
rowflow: remove redundant copyingRowReceiver in gateway row-based flow

### DIFF
--- a/pkg/sql/rowflow/BUILD.bazel
+++ b/pkg/sql/rowflow/BUILD.bazel
@@ -23,6 +23,7 @@ go_library(
         "//pkg/sql/sem/eval",
         "//pkg/sql/sem/tree",
         "//pkg/sql/types",
+        "//pkg/util/buildutil",
         "//pkg/util/log",
         "//pkg/util/mon",
         "//pkg/util/syncutil",


### PR DESCRIPTION
Currently, in row-based flows we always wrap the output of each processor
(most commonly `RowChannel`) with `copyingRowReceiver` which performs
a shallow copy of each row. This is needed because the contract of
`RowSource.Next` is such that the rows are only safe until the next call
to `Next`. Each processor could run in a separate goroutine, so we need
this copying behavior to protect rows from corruption. However, we often
can fuse processors together (meaning that we remove the RowChannel
between two processors and make two of them run in the same goroutine),
and in that case we already remove this `copyingRowReceiver` to avoid
unnecessary row copies.

This commit adds another case where we can safely remove the redundant
`copyingRowReceiver` - when we have a flow on the gateway, then the
output of the "head" processor is `DistSQLReceiver`, and it's pushed
into from the same goroutine as the "head" processor, so we don't need
row copies.

Epic: None

Release note: None