### PR TITLE
sql: make inner plans in postqueries use LeafTxn if necessary

### DIFF
--- a/pkg/sql/distsql_running.go
+++ b/pkg/sql/distsql_running.go
@@ -2097,8 +2097,9 @@ func (dsp *DistSQLPlanner) planAndRunPostquery(
 	postqueryResultWriter := &errOnlyResultWriter{}
 	postqueryRecv.resultWriterMu.row = postqueryResultWriter
 	postqueryRecv.resultWriterMu.batch = postqueryResultWriter
-	// Postqueries cannot have "inner" plans, so we use nil finishedSetupFn.
-	dsp.Run(ctx, postqueryPlanCtx, planner.txn, postqueryPhysPlan, postqueryRecv, evalCtx, nil /* finishedSetupFn */)
+	finishedSetupFn, cleanup := getFinishedSetupFn(planner)
+	defer cleanup()
+	dsp.Run(ctx, postqueryPlanCtx, planner.txn, postqueryPhysPlan, postqueryRecv, evalCtx, finishedSetupFn)
 	return postqueryRecv.getError()
 }
 


### PR DESCRIPTION
This commit fixes a theoretical case when the inner plans (e.g. apply join iterations) of the postqueries could incorrectly use the RootTxn when the postquery itself used the LeafTxn. This improves recently merged fix.

Epic: None

Release note: None