### PR TITLE
ci: add FIPS enabled TeamCity agent packer config

### DIFF
--- a/build/packer/setup_fips.sh
+++ b/build/packer/setup_fips.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+set -euo pipefail
+ua enable fips --assume-yes

--- a/build/packer/teamcity-agent-x86-fips.json
+++ b/build/packer/teamcity-agent-x86-fips.json
@@ -1,0 +1,41 @@
+{
+  "variables": {
+    "image_id": "teamcity-agent-fips-{{timestamp}}"
+  },
+
+  "builders": [{
+      "type": "googlecompute",
+      "account_file": "gcp_credentials.json",
+      "project_id": "crl-teamcity-agents",
+      "source_image_family": "ubuntu-pro-fips-2004-lts",
+      "zone": "us-east1-b",
+      "machine_type": "n2-standard-32",
+      "image_name": "{{user `image_id`}}",
+      "image_description": "{{user `image_id`}}",
+      "ssh_username": "packer",
+      "disk_size": 256,
+      "disk_type": "pd-ssd",
+      "state_timeout": "15m"
+  }],
+
+  "provisioners": [{
+    "type": "shell",
+    "script": "teamcity-agent.sh",
+    "execute_command": "sudo sh -c '{{ .Vars }} {{ .Path }}'"
+  },
+  {
+    "type": "shell",
+    "script": "setup_fips.sh",
+    "execute_command": "sudo sh -c '{{ .Vars }} {{ .Path }}'"
+  },
+  {
+    "type": "file",
+    "source": "filebeat/filebeat-agent.yml",
+    "destination": "/tmp/filebeat.yml"
+  },
+  {
+    "type": "shell",
+    "script": "setup_filebeat_on_teamcity_agent.sh",
+    "execute_command": "sudo sh -c '{{ .Vars }} {{ .Path }}'"
+  }]
+}


### PR DESCRIPTION
Previously, TeamCity agents used non FIPS enabled VMs, what made FIPS testing harder.

This PR uses Ubuntu Pro FIPS base image and runs `ua enable fips` in order to enforce FIPS mode.

Epic: DEVINF-478
Release note: None