### PR TITLE
release-22.2: changefeedccl: fix kafka external connections

### DIFF
--- a/pkg/ccl/changefeedccl/sink.go
+++ b/pkg/ccl/changefeedccl/sink.go
@@ -212,8 +212,11 @@ func getSink(
 		sink = knobs.WrapSink(sink, jobID)
 	}
 
-	if err := sink.Dial(); err != nil {
-		return nil, err
+	// Avoid dialing twice. For external connections we've dialed inside the recursive call.
+	if u.Scheme != changefeedbase.SinkSchemeExternalConnection {
+		if err := sink.Dial(); err != nil {
+			return nil, err
+		}
 	}
 
 	return sink, nil

--- a/pkg/ccl/changefeedccl/sink_kafka.go
+++ b/pkg/ccl/changefeedccl/sink_kafka.go
@@ -303,8 +303,10 @@ func (s *kafkaSink) newSyncProducer(client kafkaClient) (sarama.SyncProducer, er
 
 // Close implements the Sink interface.
 func (s *kafkaSink) Close() error {
-	close(s.stopWorkerCh)
-	s.worker.Wait()
+	if s.stopWorkerCh != nil {
+		close(s.stopWorkerCh)
+		s.worker.Wait()
+	}
 
 	if s.producer != nil {
 		// Ignore errors related to outstanding messages since we're either shutting


### PR DESCRIPTION
Fixes #98679.
The flow for external connection sinks in 22.2.6 ends up calling .Dial() twice, which causes the Kafka sink to hang on Close. This is fixed by more elaborate
refactors in the current version but this is a simple targeted fix for backporting only.

Release note (enterprise change): Fixed a bug preventing the creation of changefeeds to external:// URIs.

Release justification: Low-impact bug fix.