### PR TITLE
roachprod: provide workaround for long-running AWS clusters

### DIFF
--- a/pkg/cmd/roachprod/main.go
+++ b/pkg/cmd/roachprod/main.go
@@ -1050,6 +1050,18 @@ var storageSnapshotCmd = &cobra.Command{
 	}),
 }
 
+var fixLongRunningAWSHostnamesCmd = &cobra.Command{
+	Use:   "fix-long-running-aws-hostnames <cluster>",
+	Short: "changes the hostnames of VMs in long-running AWS clusters",
+	Long: `This is a temporary workaround, and will be removed once we no longer ` +
+		`have AWS clusters that were created with the default hostname.`,
+
+	Args: cobra.ExactArgs(1),
+	Run: wrap(func(cmd *cobra.Command, args []string) (retErr error) {
+		return roachprod.FixLongRunningAWSHostnames(context.Background(), roachprodLibraryLogger, args[0])
+	}),
+}
+
 func main() {
 	loggerCfg := logger.Config{Stdout: os.Stdout, Stderr: os.Stderr}
 	var loggerError error
@@ -1105,6 +1117,7 @@ func main() {
 		grafanaDumpCmd,
 		grafanaURLCmd,
 		rootStorageCmd,
+		fixLongRunningAWSHostnamesCmd,
 	)
 	setBashCompletionFunction()
 

--- a/pkg/roachprod/install/session.go
+++ b/pkg/roachprod/install/session.go
@@ -54,6 +54,10 @@ type remoteCommand struct {
 	cmd           string
 	debugDisabled bool
 	debugName     string
+
+	// TODO(renato): remove this option once we no longer have AWS
+	// clusters with default hostnames.
+	hostValidationDisabled bool
 }
 
 type remoteSessionOption = func(c *remoteCommand)
@@ -67,6 +71,12 @@ func withDebugDisabled() remoteSessionOption {
 func withDebugName(name string) remoteSessionOption {
 	return func(c *remoteCommand) {
 		c.debugName = name
+	}
+}
+
+func withHostValidationDisabled() remoteSessionOption {
+	return func(c *remoteCommand) {
+		c.hostValidationDisabled = true
 	}
 }
 

--- a/pkg/roachprod/roachprod.go
+++ b/pkg/roachprod/roachprod.go
@@ -1811,3 +1811,19 @@ func createAttachMountVolumes(
 	}
 	return nil
 }
+
+func FixLongRunningAWSHostnames(ctx context.Context, l *logger.Logger, clusterName string) error {
+	if err := LoadClusters(); err != nil {
+		return err
+	}
+	c, err := newCluster(l, clusterName)
+	if err != nil {
+		return err
+	}
+
+	if err := c.FixLongRunningAWSHostnames(ctx, l); err != nil {
+		return err
+	}
+	l.Printf("Done! You are now able to use your AWS cluster normally.")
+	return nil
+}


### PR DESCRIPTION
In #98076, we started validating hostnames before running any commands to avoid situations where a stale cache could lead to unintended interference with other clusters due to public IP reuse. The check relies on the VM's `hostname` matching the expected cluster name in the cache. GCP and Azure clusters set the hostname to the instance name by default, but that is not the case for AWS; the aforementioned PR explicitly sets the hostname when the instance is created.

However, in the case of long running AWS clusters (created before host validation was introduced) or clusters that are created with an outdated version of `roachprod`, the hostname will still be the default AWS hostname, and any interaction with that cluster will fail if using a recent `roachprod` version. To remedy this situation, this commit includes:

* better error reporting. When we attempt to run a command on an AWS cluster and host validation fails, we display a message to the user explaining that their hostnames may need fixing.

* if the user confirms that the cluster still exists (by running `roachprod list`), they are able to automatically fix the hostnames to the expected value by running a new `fix-long-running-aws-hostnames` command. This is a temporary workaround that should be removed once we no longer have clusters that would be affected by this issue.

This commit will be reverted once we no longer have clusters created with the default hostnames; this will be easier to achieve once we have an easy way for everyone to upgrade their `roachprod` (see #97311).

Epic: none

Release note: None