### PR TITLE
colexecbase: fix a recently introduced bug with identity cast

### DIFF
--- a/pkg/sql/colexec/colexecbase/cast.eg.go
+++ b/pkg/sql/colexec/colexecbase/cast.eg.go
@@ -1246,7 +1246,7 @@ var _ colexecop.ClosableOperator = &castIdentityOp{}
 var identityOrder []int
 
 func init() {
-	identityOrder = make([]int, coldata.BatchSize())
+	identityOrder = make([]int, coldata.MaxBatchSize)
 	for i := range identityOrder {
 		identityOrder[i] = i
 	}

--- a/pkg/sql/colexec/colexecbase/cast_tmpl.go
+++ b/pkg/sql/colexec/colexecbase/cast_tmpl.go
@@ -314,7 +314,7 @@ var _ colexecop.ClosableOperator = &castIdentityOp{}
 var identityOrder []int
 
 func init() {
-	identityOrder = make([]int, coldata.BatchSize())
+	identityOrder = make([]int, coldata.MaxBatchSize)
 	for i := range identityOrder {
 		identityOrder[i] = i
 	}


### PR DESCRIPTION
This commit fixes a recently introduced bug that can occur when we're randomizing `coldata.BatchSize()` (which we do in tests). In particular, we capped a global singleton at one batch size value, but later we can change it to a higher value, which could lead to index out of bounds. This is now fixed by always using the max batch size.

Fixes: #98660.

Release note: None