### PR TITLE
kv/kvserver: skip TestDefaultConnectionDisruptionDoesNotInterfereWith…

### DIFF
--- a/pkg/kv/kvserver/client_raft_test.go
+++ b/pkg/kv/kvserver/client_raft_test.go
@@ -4834,6 +4834,7 @@ func (cs *disablingClientStream) SendMsg(m interface{}) error {
 // traffic on the SystemClass connection.
 func TestDefaultConnectionDisruptionDoesNotInterfereWithSystemTraffic(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	skip.WithIssue(t, 94875, "flaky test")
 	defer log.Scope(t).Close(t)
 
 	stickyEngineRegistry := server.NewStickyInMemEnginesRegistry()


### PR DESCRIPTION
…SystemTraffic

Refs: #94875

Reason: flaky test

Generated by bin/skip-test.

Release justification: non-production code changes
Release note: None
Epic: None