### PR TITLE
CI: skip `//pkg/ui/workspaces/db-console:jest` under arm64

### DIFF
--- a/build/teamcity/cockroach/ci/tests/ui_test_impl.sh
+++ b/build/teamcity/cockroach/ci/tests/ui_test_impl.sh
@@ -3,4 +3,11 @@
 set -xeuo pipefail
 
 bazel build //pkg/cmd/bazci --config=ci
-$(bazel info bazel-bin --config=ci)/pkg/cmd/bazci/bazci_/bazci -- test --config=ci //pkg/ui/workspaces/db-console:jest //pkg/ui/workspaces/cluster-ui:jest
+ARCH="$(uname -m)"
+TARGETS_TO_TEST="//pkg/ui/workspaces/db-console:jest //pkg/ui/workspaces/cluster-ui:jest"
+# //pkg/ui/workspaces/db-console:jest is broken under ARM64. 
+# See https://github.com/cockroachdb/cockroach/issues/97179
+if [[ "$ARCH" == "aarch64" || "$ARCH" == "arm64" ]]; then
+    TARGETS_TO_TEST="//pkg/ui/workspaces/cluster-ui:jest"
+fi
+$(bazel info bazel-bin --config=ci)/pkg/cmd/bazci/bazci_/bazci -- test --config=ci $TARGETS_TO_TEST


### PR DESCRIPTION
Release note: None
Epic: none