### PR TITLE
sql: make sure mixed version logic tests are enabled for declarative schema changer enabled DDL in 22.2

### DIFF
--- a/pkg/ccl/logictestccl/tests/3node-tenant/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/3node-tenant/generated_test.go
@@ -437,6 +437,13 @@ func TestTenantLogic_column_families(
 	runLogicTest(t, "column_families")
 }
 
+func TestTenantLogic_comment_on(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "comment_on")
+}
+
 func TestTenantLogic_composite_types(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/testdata/logic_test/alter_primary_key
+++ b/pkg/sql/logictest/testdata/logic_test/alter_primary_key
@@ -1,3 +1,4 @@
+# LogicTest: default-configs local-mixed-22.2-23.1
 
 statement ok
 CREATE TABLE t (x INT PRIMARY KEY, y INT NOT NULL, z INT NOT NULL, w INT, INDEX i (x), INDEX i2 (z))

--- a/pkg/sql/logictest/testdata/logic_test/comment_on
+++ b/pkg/sql/logictest/testdata/logic_test/comment_on
@@ -1,0 +1,258 @@
+# LogicTest: default-configs local-mixed-22.2-23.1
+statement ok
+CREATE DATABASE db
+
+statement ok
+COMMENT ON DATABASE db IS 'A'
+
+query TTTTTTT colnames
+SHOW DATABASES WITH COMMENT
+----
+database_name  owner  primary_region  secondary_region  regions  survival_goal  comment
+db             root   NULL            NULL              {}       NULL           A
+defaultdb      root   NULL            NULL              {}       NULL           NULL
+postgres       root   NULL            NULL              {}       NULL           NULL
+system         node   NULL            NULL              {}       NULL           NULL
+test           root   NULL            NULL              {}       NULL           NULL
+
+statement ok
+COMMENT ON DATABASE db IS 'AAA'
+
+query TTTTTTT colnames
+SHOW DATABASES WITH COMMENT
+----
+database_name  owner  primary_region  secondary_region  regions  survival_goal  comment
+db             root   NULL            NULL              {}       NULL           AAA
+defaultdb      root   NULL            NULL              {}       NULL           NULL
+postgres       root   NULL            NULL              {}       NULL           NULL
+system         node   NULL            NULL              {}       NULL           NULL
+test           root   NULL            NULL              {}       NULL           NULL
+
+statement ok
+COMMENT ON DATABASE db IS NULL;
+
+query TTTTTTT colnames
+SHOW DATABASES WITH COMMENT
+----
+database_name  owner  primary_region  secondary_region  regions  survival_goal  comment
+db             root   NULL            NULL              {}       NULL           NULL
+defaultdb      root   NULL            NULL              {}       NULL           NULL
+postgres       root   NULL            NULL              {}       NULL           NULL
+system         node   NULL            NULL              {}       NULL           NULL
+test           root   NULL            NULL              {}       NULL           NULL
+
+statement ok
+CREATE SCHEMA sc
+
+statement ok
+COMMENT ON SCHEMA sc IS 'SC'
+
+query T
+SELECT COMMENT FROM system.comments WHERE type = 4;
+----
+SC
+
+statement ok
+COMMENT ON SCHEMA sc IS 'SC AGAIN'
+
+query T
+SELECT COMMENT FROM system.comments WHERE type = 4;
+----
+SC AGAIN
+
+statement ok
+CREATE TABLE t(
+  a INT PRIMARY KEY,
+  b INT NOT NULL,
+  CONSTRAINT ckb CHECK (b > 1),
+  INDEX idxb (b),
+  FAMILY fam_0_b_a (a, b)
+);
+
+statement ok
+COMMENT ON TABLE t IS 'table t';
+
+query T
+SELECT create_statement FROM [SHOW CREATE TABLE t];
+----
+CREATE TABLE public.t (
+  a INT8 NOT NULL,
+  b INT8 NOT NULL,
+  CONSTRAINT t_pkey PRIMARY KEY (a ASC),
+  INDEX idxb (b ASC),
+  FAMILY fam_0_b_a (a, b),
+  CONSTRAINT ckb CHECK (b > 1:::INT8)
+);
+COMMENT ON TABLE public.t IS 'table t'
+
+statement ok
+COMMENT ON TABLE t IS 'table t AGAIN';
+
+query T
+SELECT create_statement FROM [SHOW CREATE TABLE t];
+----
+CREATE TABLE public.t (
+  a INT8 NOT NULL,
+  b INT8 NOT NULL,
+  CONSTRAINT t_pkey PRIMARY KEY (a ASC),
+  INDEX idxb (b ASC),
+  FAMILY fam_0_b_a (a, b),
+  CONSTRAINT ckb CHECK (b > 1:::INT8)
+);
+COMMENT ON TABLE public.t IS 'table t AGAIN'
+
+statement ok
+COMMENT ON TABLE t IS NULL;
+
+query T
+SELECT create_statement FROM [SHOW CREATE TABLE t];
+----
+CREATE TABLE public.t (
+  a INT8 NOT NULL,
+  b INT8 NOT NULL,
+  CONSTRAINT t_pkey PRIMARY KEY (a ASC),
+  INDEX idxb (b ASC),
+  FAMILY fam_0_b_a (a, b),
+  CONSTRAINT ckb CHECK (b > 1:::INT8)
+)
+
+statement ok
+COMMENT ON COLUMN t.b IS 'column b';
+
+query T
+SELECT create_statement FROM [SHOW CREATE TABLE t];
+----
+CREATE TABLE public.t (
+  a INT8 NOT NULL,
+  b INT8 NOT NULL,
+  CONSTRAINT t_pkey PRIMARY KEY (a ASC),
+  INDEX idxb (b ASC),
+  FAMILY fam_0_b_a (a, b),
+  CONSTRAINT ckb CHECK (b > 1:::INT8)
+);
+COMMENT ON COLUMN public.t.b IS 'column b'
+
+statement ok
+COMMENT ON COLUMN t.b IS 'column b AGAIN';
+
+query T
+SELECT create_statement FROM [SHOW CREATE TABLE t];
+----
+CREATE TABLE public.t (
+  a INT8 NOT NULL,
+  b INT8 NOT NULL,
+  CONSTRAINT t_pkey PRIMARY KEY (a ASC),
+  INDEX idxb (b ASC),
+  FAMILY fam_0_b_a (a, b),
+  CONSTRAINT ckb CHECK (b > 1:::INT8)
+);
+COMMENT ON COLUMN public.t.b IS 'column b AGAIN'
+
+statement ok
+COMMENT ON COLUMN t.b IS NULL;
+
+query T
+SELECT create_statement FROM [SHOW CREATE TABLE t];
+----
+CREATE TABLE public.t (
+  a INT8 NOT NULL,
+  b INT8 NOT NULL,
+  CONSTRAINT t_pkey PRIMARY KEY (a ASC),
+  INDEX idxb (b ASC),
+  FAMILY fam_0_b_a (a, b),
+  CONSTRAINT ckb CHECK (b > 1:::INT8)
+)
+
+statement ok
+COMMENT ON INDEX t@idxb IS 'index b';
+
+query T
+SELECT create_statement FROM [SHOW CREATE TABLE t];
+----
+CREATE TABLE public.t (
+  a INT8 NOT NULL,
+  b INT8 NOT NULL,
+  CONSTRAINT t_pkey PRIMARY KEY (a ASC),
+  INDEX idxb (b ASC),
+  FAMILY fam_0_b_a (a, b),
+  CONSTRAINT ckb CHECK (b > 1:::INT8)
+);
+COMMENT ON INDEX public.t@idxb IS 'index b'
+
+statement ok
+COMMENT ON INDEX t@idxb IS 'index b AGAIN';
+
+query T
+SELECT create_statement FROM [SHOW CREATE TABLE t];
+----
+CREATE TABLE public.t (
+  a INT8 NOT NULL,
+  b INT8 NOT NULL,
+  CONSTRAINT t_pkey PRIMARY KEY (a ASC),
+  INDEX idxb (b ASC),
+  FAMILY fam_0_b_a (a, b),
+  CONSTRAINT ckb CHECK (b > 1:::INT8)
+);
+COMMENT ON INDEX public.t@idxb IS 'index b AGAIN'
+
+statement ok
+COMMENT ON INDEX t@idxb IS NULL;
+
+query T
+SELECT create_statement FROM [SHOW CREATE TABLE t];
+----
+CREATE TABLE public.t (
+  a INT8 NOT NULL,
+  b INT8 NOT NULL,
+  CONSTRAINT t_pkey PRIMARY KEY (a ASC),
+  INDEX idxb (b ASC),
+  FAMILY fam_0_b_a (a, b),
+  CONSTRAINT ckb CHECK (b > 1:::INT8)
+)
+
+statement ok
+COMMENT ON CONSTRAINT ckb ON t IS 'cst b';
+
+query T
+SELECT create_statement FROM [SHOW CREATE TABLE t];
+----
+CREATE TABLE public.t (
+  a INT8 NOT NULL,
+  b INT8 NOT NULL,
+  CONSTRAINT t_pkey PRIMARY KEY (a ASC),
+  INDEX idxb (b ASC),
+  FAMILY fam_0_b_a (a, b),
+  CONSTRAINT ckb CHECK (b > 1:::INT8)
+);
+COMMENT ON CONSTRAINT ckb ON public.t IS 'cst b'
+
+statement ok
+COMMENT ON CONSTRAINT ckb ON t IS 'cst b AGAIN';
+
+query T
+SELECT create_statement FROM [SHOW CREATE TABLE t];
+----
+CREATE TABLE public.t (
+  a INT8 NOT NULL,
+  b INT8 NOT NULL,
+  CONSTRAINT t_pkey PRIMARY KEY (a ASC),
+  INDEX idxb (b ASC),
+  FAMILY fam_0_b_a (a, b),
+  CONSTRAINT ckb CHECK (b > 1:::INT8)
+);
+COMMENT ON CONSTRAINT ckb ON public.t IS 'cst b AGAIN'
+
+statement ok
+COMMENT ON CONSTRAINT ckb ON t IS NULL;
+
+query T
+SELECT create_statement FROM [SHOW CREATE TABLE t];
+----
+CREATE TABLE public.t (
+  a INT8 NOT NULL,
+  b INT8 NOT NULL,
+  CONSTRAINT t_pkey PRIMARY KEY (a ASC),
+  INDEX idxb (b ASC),
+  FAMILY fam_0_b_a (a, b),
+  CONSTRAINT ckb CHECK (b > 1:::INT8)
+)

--- a/pkg/sql/logictest/testdata/logic_test/drop_owned_by
+++ b/pkg/sql/logictest/testdata/logic_test/drop_owned_by
@@ -1,4 +1,4 @@
-# LogicTest: !local-legacy-schema-changer
+# LogicTest: local-mixed-22.2-23.1 default-configs !local-legacy-schema-changer
 # Skipped on legacy schema changer since it unsupported.
 
 # Test dropping nothing.
@@ -645,8 +645,14 @@ CREATE FUNCTION f_drop_udf() RETURNS INT LANGUAGE SQL AS $$ SELECT 1 $$;
 statement ok
 ALTER FUNCTION f_drop_udf OWNER TO u_drop_udf;
 
+# TODO(chengxiong): DROP function was only enabled in 23.1. This skip can be
+# removed in 23.2.
+skipif config local-mixed-22.2-23.1
 statement ok
 DROP OWNED BY u_drop_udf;
 
+# TODO(chengxiong): DROP function was only enabled in 23.1. This skip can be
+# removed in 23.2.
+skipif config local-mixed-22.2-23.1
 statement error pq: unknown function: f_drop_udf\(\): function undefined
 SHOW CREATE FUNCTION f_drop_udf;

--- a/pkg/sql/logictest/tests/fakedist-disk/generated_test.go
+++ b/pkg/sql/logictest/tests/fakedist-disk/generated_test.go
@@ -401,6 +401,13 @@ func TestLogic_collatedstring_uniqueindex2(
 	runLogicTest(t, "collatedstring_uniqueindex2")
 }
 
+func TestLogic_comment_on(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "comment_on")
+}
+
 func TestLogic_composite_types(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/fakedist-vec-off/generated_test.go
+++ b/pkg/sql/logictest/tests/fakedist-vec-off/generated_test.go
@@ -401,6 +401,13 @@ func TestLogic_collatedstring_uniqueindex2(
 	runLogicTest(t, "collatedstring_uniqueindex2")
 }
 
+func TestLogic_comment_on(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "comment_on")
+}
+
 func TestLogic_composite_types(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/fakedist/generated_test.go
+++ b/pkg/sql/logictest/tests/fakedist/generated_test.go
@@ -401,6 +401,13 @@ func TestLogic_collatedstring_uniqueindex2(
 	runLogicTest(t, "collatedstring_uniqueindex2")
 }
 
+func TestLogic_comment_on(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "comment_on")
+}
+
 func TestLogic_composite_types(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/local-legacy-schema-changer/generated_test.go
+++ b/pkg/sql/logictest/tests/local-legacy-schema-changer/generated_test.go
@@ -401,6 +401,13 @@ func TestLogic_collatedstring_uniqueindex2(
 	runLogicTest(t, "collatedstring_uniqueindex2")
 }
 
+func TestLogic_comment_on(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "comment_on")
+}
+
 func TestLogic_composite_types(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/local-mixed-22.2-23.1/BUILD.bazel
+++ b/pkg/sql/logictest/tests/local-mixed-22.2-23.1/BUILD.bazel
@@ -10,7 +10,7 @@ go_test(
         "//c-deps:libgeos",  # keep
         "//pkg/sql/logictest:testdata",  # keep
     ],
-    shard_count = 10,
+    shard_count = 11,
     tags = ["cpu:1"],
     deps = [
         "//pkg/build/bazel",

--- a/pkg/sql/logictest/tests/local-mixed-22.2-23.1/BUILD.bazel
+++ b/pkg/sql/logictest/tests/local-mixed-22.2-23.1/BUILD.bazel
@@ -10,7 +10,7 @@ go_test(
         "//c-deps:libgeos",  # keep
         "//pkg/sql/logictest:testdata",  # keep
     ],
-    shard_count = 11,
+    shard_count = 12,
     tags = ["cpu:1"],
     deps = [
         "//pkg/build/bazel",

--- a/pkg/sql/logictest/tests/local-mixed-22.2-23.1/BUILD.bazel
+++ b/pkg/sql/logictest/tests/local-mixed-22.2-23.1/BUILD.bazel
@@ -10,7 +10,7 @@ go_test(
         "//c-deps:libgeos",  # keep
         "//pkg/sql/logictest:testdata",  # keep
     ],
-    shard_count = 12,
+    shard_count = 13,
     tags = ["cpu:1"],
     deps = [
         "//pkg/build/bazel",

--- a/pkg/sql/logictest/tests/local-mixed-22.2-23.1/generated_test.go
+++ b/pkg/sql/logictest/tests/local-mixed-22.2-23.1/generated_test.go
@@ -79,6 +79,13 @@ func TestLogic_alter_table(
 	runLogicTest(t, "alter_table")
 }
 
+func TestLogic_comment_on(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "comment_on")
+}
+
 func TestLogic_create_index(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/local-mixed-22.2-23.1/generated_test.go
+++ b/pkg/sql/logictest/tests/local-mixed-22.2-23.1/generated_test.go
@@ -72,6 +72,13 @@ func TestLogic_tmp(t *testing.T) {
 	logictest.RunLogicTests(t, logictest.TestServerArgs{}, configIdx, glob)
 }
 
+func TestLogic_alter_primary_key(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "alter_primary_key")
+}
+
 func TestLogic_alter_table(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/local-mixed-22.2-23.1/generated_test.go
+++ b/pkg/sql/logictest/tests/local-mixed-22.2-23.1/generated_test.go
@@ -100,6 +100,13 @@ func TestLogic_drop_index(
 	runLogicTest(t, "drop_index")
 }
 
+func TestLogic_drop_owned_by(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "drop_owned_by")
+}
+
 func TestLogic_drop_schema(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/local-vec-off/generated_test.go
+++ b/pkg/sql/logictest/tests/local-vec-off/generated_test.go
@@ -401,6 +401,13 @@ func TestLogic_collatedstring_uniqueindex2(
 	runLogicTest(t, "collatedstring_uniqueindex2")
 }
 
+func TestLogic_comment_on(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "comment_on")
+}
+
 func TestLogic_composite_types(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/local/generated_test.go
+++ b/pkg/sql/logictest/tests/local/generated_test.go
@@ -415,6 +415,13 @@ func TestLogic_column_families(
 	runLogicTest(t, "column_families")
 }
 
+func TestLogic_comment_on(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "comment_on")
+}
+
 func TestLogic_composite_types(
 	t *testing.T,
 ) {


### PR DESCRIPTION
Informs: #98637

This PR makes sure we enable mixed version logic tests for ddl statements enabled in declarative schema changer in 22.2.

We already have mixed version test coverage for `CREATE INDEX`, `DROP INDEX`, `ADD COLUMN`, `DROP COLUMN` and `ADD CONSTRAINT`.

Each commit turns on mixed version logic test for each of `DROP OWNED BY`, `COMMENT ON` and `ALTER PRIMARY KEY`.