### PR TITLE
release-22.2: execinfra: correctly propagate processorID for LocalProcessors

### DIFF
--- a/pkg/sql/execinfra/processorsbase.go
+++ b/pkg/sql/execinfra/processorsbase.go
@@ -967,7 +967,7 @@ func NewLimitedMonitorNoFlowCtx(
 type LocalProcessor interface {
 	RowSourcedProcessor
 	// InitWithOutput initializes this processor.
-	InitWithOutput(flowCtx *FlowCtx, post *execinfrapb.PostProcessSpec, output RowReceiver) error
+	InitWithOutput(flowCtx *FlowCtx, processorID int32, post *execinfrapb.PostProcessSpec, output RowReceiver) error
 	// SetInput initializes this LocalProcessor with an input RowSource. Not all
 	// LocalProcessors need inputs, but this needs to be called if a
 	// LocalProcessor expects to get its data from another RowSource.

--- a/pkg/sql/plan_node_to_row_source.go
+++ b/pkg/sql/plan_node_to_row_source.go
@@ -99,7 +99,10 @@ func (p *planNodeToRowSource) MustBeStreaming() bool {
 
 // InitWithOutput implements the LocalProcessor interface.
 func (p *planNodeToRowSource) InitWithOutput(
-	flowCtx *execinfra.FlowCtx, post *execinfrapb.PostProcessSpec, output execinfra.RowReceiver,
+	flowCtx *execinfra.FlowCtx,
+	processorID int32,
+	post *execinfrapb.PostProcessSpec,
+	output execinfra.RowReceiver,
 ) error {
 	if err := p.InitWithEvalCtx(
 		p,
@@ -111,7 +114,7 @@ func (p *planNodeToRowSource) InitWithOutput(
 		// newPlanNodeToRowSource, so we can just use the eval context from the
 		// params.
 		p.params.EvalContext(),
-		0, /* processorID */
+		processorID,
 		output,
 		nil, /* memMonitor */
 		execinfra.ProcStateOpts{

--- a/pkg/sql/rowexec/processors.go
+++ b/pkg/sql/rowexec/processors.go
@@ -320,7 +320,7 @@ func NewProcessor(
 			return nil, err
 		}
 		processor := localProcessors[core.LocalPlanNode.RowSourceIdx]
-		if err := processor.InitWithOutput(flowCtx, post, outputs[0]); err != nil {
+		if err := processor.InitWithOutput(flowCtx, processorID, post, outputs[0]); err != nil {
 			return nil, err
 		}
 		if numInputs == 1 {


### PR DESCRIPTION
Backport 1/1 commits from #98654.

/cc @cockroachdb/release

---

Previously, this was incorrectly hard-coded as zero. The impact of this seems minor (I believe this would only make it so that we could incorrectly attribute `ComponentStats` object of `planNodeToRowSource` to the wrong processor), but I think it still deserves to be backported.

Epic: None

Release note: None

Release justification: low risk bug fix.