### PR TITLE
release-22.2: sql: make inner plans in postqueries use LeafTxn if necessary

### DIFF
--- a/pkg/sql/distsql_running.go
+++ b/pkg/sql/distsql_running.go
@@ -1928,7 +1928,8 @@ func (dsp *DistSQLPlanner) planAndRunPostquery(
 	postqueryResultWriter := &errOnlyResultWriter{}
 	postqueryRecv.resultWriter = postqueryResultWriter
 	postqueryRecv.batchWriter = postqueryResultWriter
-	// Postqueries cannot have "inner" plans, so we use nil finishedSetupFn.
-	dsp.Run(ctx, postqueryPlanCtx, planner.txn, postqueryPhysPlan, postqueryRecv, evalCtx, nil /* finishedSetupFn */)()
+	finishedSetupFn, cleanup := getFinishedSetupFn(planner)
+	defer cleanup()
+	dsp.Run(ctx, postqueryPlanCtx, planner.txn, postqueryPhysPlan, postqueryRecv, evalCtx, finishedSetupFn)()
 	return postqueryRecv.resultWriter.Err()
 }


### PR DESCRIPTION
Backport 1/1 commits from #98656.

/cc @cockroachdb/release

---

This commit fixes a theoretical case when the inner plans (e.g. apply join iterations) of the postqueries could incorrectly use the RootTxn when the postquery itself used the LeafTxn. This improves recently merged fix.

Epic: None

Release note: None

Release justification: low risk cleanup.