### PR TITLE
storage,kv: reenable rewrite concurrency and add format error checking

### DIFF
--- a/pkg/kv/kvserver/batcheval/cmd_add_sstable.go
+++ b/pkg/kv/kvserver/batcheval/cmd_add_sstable.go
@@ -77,8 +77,7 @@ var AddSSTableRewriteConcurrency = settings.RegisterIntSetting(
 	settings.SystemOnly,
 	"kv.bulk_io_write.sst_rewrite_concurrency.per_call",
 	"concurrency to use when rewriting sstable timestamps by block, or 0 to use a loop",
-	// TODO(radu): temporarily disabled because of #97076.
-	0, // int64(util.ConstantWithMetamorphicTestRange("addsst-rewrite-concurrency", 4, 0, 16)),
+	int64(util.ConstantWithMetamorphicTestRange("addsst-rewrite-concurrency", 4, 0, 16)),
 	settings.NonNegativeInt,
 )
 

--- a/pkg/storage/sst_writer.go
+++ b/pkg/storage/sst_writer.go
@@ -75,6 +75,17 @@ func MakeIngestionWriterOptions(ctx context.Context, cs *cluster.Settings) sstab
 	return opts
 }
 
+// makeSSTRewriteOptions should be used instead of MakeIngestionWriterOptions
+// when we are going to rewrite ssts. It additionally returns the minimum
+// table format that we accept, since sst rewriting will often preserve the
+// input table format.
+func makeSSTRewriteOptions(
+	ctx context.Context, cs *cluster.Settings,
+) (opts sstable.WriterOptions, minTableFormat sstable.TableFormat) {
+	// v22.2 clusters use sstable.TableFormatPebblev2.
+	return MakeIngestionWriterOptions(ctx, cs), sstable.TableFormatPebblev2
+}
+
 // MakeBackupSSTWriter creates a new SSTWriter tailored for backup SSTs which
 // are typically only ever iterated in their entirety.
 func MakeBackupSSTWriter(ctx context.Context, cs *cluster.Settings, f io.Writer) SSTWriter {


### PR DESCRIPTION
Epic: none

Fixes: #97076

Release note: None