### PR TITLE
jobs: missing error return in job stats poller

### DIFF
--- a/pkg/jobs/metricspoller/job_statistics.go
+++ b/pkg/jobs/metricspoller/job_statistics.go
@@ -221,8 +221,11 @@ func processSchedulePTSRecord(
 ) error {
 	sj, err := jobs.ScheduledJobTxn(txn).
 		Load(ctx, scheduledjobs.ProdJobSchedulerEnv, scheduleID)
-	if jobs.HasScheduledJobNotFoundError(err) {
-		return nil // nolint:returnerrcheck -- schedule maybe deleted when we run; just keep going.
+	if err != nil {
+		if jobs.HasScheduledJobNotFoundError(err) {
+			return nil // nolint:returnerrcheck -- schedule maybe deleted when we run; just keep going.
+		}
+		return err
 	}
 	ex, err := jobs.GetScheduledJobExecutor(sj.ExecutorType())
 	if err != nil {


### PR DESCRIPTION
Previously, we were swallowing the error, if any, when loading the schedule before processing it. This error could be a txn retry error that needs to be surfaced to the client so that the txn is retried correctly.

Fixes: #98629

Release note: None