### PR TITLE
roachtest: enable kv/gracefuldraining/nodes=3

### DIFF
--- a/pkg/cmd/roachtest/tests/kv.go
+++ b/pkg/cmd/roachtest/tests/kv.go
@@ -463,7 +463,6 @@ func registerKVGracefulDraining(r registry.Registry) {
 	r.Add(registry.TestSpec{
 		Name:    "kv/gracefuldraining/nodes=3",
 		Owner:   registry.OwnerKV,
-		Skip:    "https://github.com/cockroachdb/cockroach/issues/59094",
 		Cluster: r.MakeClusterSpec(4),
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			nodes := c.Spec().NodeCount - 1


### PR DESCRIPTION
This commit re-enables the `kv/gracefuldraining/nodes=3` roachtest. The
test is still likely to fail occasionally however has produced
interesting findings just in testing to re-enable.

Informs: https://github.com/cockroachdb/cockroach/issues/59094

Release note: None