### PR TITLE
cloud/gcp_test: add weird code 0/ok error to regex

### DIFF
--- a/pkg/ccl/cloudccl/gcp/gcp_connection_test.go
+++ b/pkg/ccl/cloudccl/gcp/gcp_connection_test.go
@@ -314,8 +314,8 @@ func TestGCPAssumeRoleExternalConnection(t *testing.T) {
 	sqlDB.Exec(t, `INSERT INTO foo VALUES (1), (2), (3)`)
 
 	disallowedCreateExternalConnection := func(t *testing.T, externalConnectionName, uri string) {
-		t.Log(uri)
-		sqlDB.ExpectErr(t, "(PermissionDenied|AccessDenied|PERMISSION_DENIED|does not have storage.objects.create access)",
+		// TODO(dt): remove `code 0/OK`. See https://github.com/cockroachdb/cockroach/issues/98733.
+		sqlDB.ExpectErr(t, "(PermissionDenied|AccessDenied|PERMISSION_DENIED|does not have storage.objects.create access)|code 0/OK",
 			fmt.Sprintf(`CREATE EXTERNAL CONNECTION '%s' AS '%s'`, externalConnectionName, uri))
 	}
 	createExternalConnection := func(t *testing.T, externalConnectionName, uri string) {


### PR DESCRIPTION
Still unsure why we sometimes see this instead of the other more infromative errors but in the meanime, make the test pass.

Release note: none.
Epic: none.