### PR TITLE
kvserver: de-flake TestReplicaCircuitBreaker_Follower_QuorumLoss

### DIFF
--- a/pkg/kv/kvserver/client_replica_circuit_breaker_test.go
+++ b/pkg/kv/kvserver/client_replica_circuit_breaker_test.go
@@ -302,7 +302,6 @@ func TestReplicaCircuitBreaker_Leaseholder_QuorumLoss(t *testing.T) {
 // leases have lots of special casing internally, this is easy to get wrong.
 func TestReplicaCircuitBreaker_Follower_QuorumLoss(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	skip.WithIssue(t, 76781, "flaky test")
 	defer log.Scope(t).Close(t)
 	tc := setupCircuitBreakerTest(t)
 	defer tc.Stopper().Stop(context.Background())
@@ -734,6 +733,7 @@ func setupCircuitBreakerTest(t *testing.T) *circuitBreakerTest {
 			pErr := kvpb.NewErrorf("test prevents lease acquisition by n2")
 			return 0, pErr
 		},
+		RangeLeaseAcquireTimeoutOverride: testutils.DefaultSucceedsSoonDuration,
 	}
 	// In some tests we'll restart servers, which means that we will be waiting
 	// for raft elections. Speed this up by campaigning aggressively. This also
@@ -846,7 +846,22 @@ func (cbt *circuitBreakerTest) ExpireAllLeasesAndN1LivenessRecord(
 		self, ok := lv.Self()
 		require.True(t, ok)
 
-		cbt.ManualClock.Forward(self.Expiration.WallTime)
+		ts := hlc.Timestamp{WallTime: self.Expiration.WallTime}
+		require.NoError(t, srv.Stores().VisitStores(func(s *kvserver.Store) error {
+			s.VisitReplicas(func(replica *kvserver.Replica) (wantMore bool) {
+				lease, next := replica.GetLease()
+				if lease.Expiration != nil {
+					ts.Forward(*lease.Expiration)
+				}
+				if next.Expiration != nil {
+					ts.Forward(*next.Expiration)
+				}
+				return true // more
+			})
+			return nil
+		}))
+
+		cbt.ManualClock.Forward(ts.WallTime)
 		if idx == n1 {
 			// Invalidate n1's liveness record, to make sure that ranges on n1 need
 			// to acquire a new lease (vs waiting for a heartbeat to the liveness

--- a/pkg/kv/kvserver/replica_range_lease.go
+++ b/pkg/kv/kvserver/replica_range_lease.go
@@ -1166,6 +1166,13 @@ func (r *Replica) TestingAcquireLease(ctx context.Context) (kvserverpb.LeaseStat
 	return l, pErr.GoError()
 }
 
+func (s *Store) rangeLeaseAcquireTimeout() time.Duration {
+	if d := s.cfg.TestingKnobs.RangeLeaseAcquireTimeoutOverride; d != 0 {
+		return d
+	}
+	return s.cfg.RangeLeaseAcquireTimeout()
+}
+
 // redirectOnOrAcquireLeaseForRequest is like redirectOnOrAcquireLease,
 // but it accepts a specific request timestamp instead of assuming that
 // the request is operating at the current time.
@@ -1174,7 +1181,7 @@ func (r *Replica) redirectOnOrAcquireLeaseForRequest(
 ) (status kvserverpb.LeaseStatus, pErr *kvpb.Error) {
 	// Does not use RunWithTimeout(), because we do not want to mask the
 	// NotLeaseHolderError on context cancellation.
-	ctx, cancel := context.WithTimeout(ctx, r.store.cfg.RangeLeaseAcquireTimeout()) // nolint:context
+	ctx, cancel := context.WithTimeout(ctx, r.store.rangeLeaseAcquireTimeout()) // nolint:context
 	defer cancel()
 
 	// Try fast-path.

--- a/pkg/kv/kvserver/testing_knobs.go
+++ b/pkg/kv/kvserver/testing_knobs.go
@@ -471,6 +471,9 @@ type StoreTestingKnobs struct {
 	// DisableMergeWaitForReplicasInit skips the waitForReplicasInit calls
 	// during merges. Useful for testContext tests that want to use merges.
 	DisableMergeWaitForReplicasInit bool
+
+	// RangeLeaseAcquireTimeoutOverride overrides RaftConfig.RangeLeaseAcquireTimeout().
+	RangeLeaseAcquireTimeoutOverride time.Duration
 }
 
 // ModuleTestingKnobs is part of the base.ModuleTestingKnobs interface.


### PR DESCRIPTION
Two problems:

- we've since introduced a separate ctx timeout for lease acquisitions,
  which could fire before the circuit breaker would first trip, and in
  that case we'd fail a write with a NotLeaseholderError instead of the
  desired circuit breaker error.
  Add a testing knob that bumps that ctx timeout up significantly for
  this test.
- I think there was something about the first lease following the lease
  transfer in this test now being expiration-based, which the method to
  expire leases didn't properly account for.
  Fortified the method to also bump the clock above all leases'
  expiration.


14594 runs so far, 0 failures, over 46m10s



Fixes https://github.com/cockroachdb/cockroach/issues/76781.

Epic: none
Release note: None
