### PR TITLE
scripts: use pprofme for pprof-post

### DIFF
--- a/scripts/pprof-post.sh
+++ b/scripts/pprof-post.sh
@@ -1,11 +1,9 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Usage: $0 "optional description, defaults to current date" < somefile.pb.gz
-out=$(curl -s 'https://api.polarsignals.com/api/share/v1/profiles' \
-	-X POST \
-	-F "description=${1-$(date -u)}" \
-	-F "profile=@-")
-echo -n "https://share.polarsignals.com/"
-grep -Eo '[0-9a-f]{4,}' <<< "${out}"
-	
+if ! which pprofme; then
+	echo "pprofme missing, setup instructions: https://github.com/polarsignals/pprofme#install"
+	exit 1
+fi
+
+pprofme upload "$@"


### PR DESCRIPTION
They've changed their endpoints and the script no longer works. But they
now have a `cli`. Make the script a wrapper around the cli so that
anyone who uses pprof-post will find out it exists.

Epic: none
Release note: None
