### PR TITLE
release-22.2: backupccl: add include_all_secondary_tenants option

### DIFF
--- a/docs/generated/sql/bnf/stmt_block.bnf
+++ b/docs/generated/sql/bnf/stmt_block.bnf
@@ -1125,6 +1125,7 @@ unreserved_keyword ::=
 	| 'IMPORT'
 	| 'INCLUDE'
 	| 'INCLUDING'
+	| 'INCLUDE_ALL_SECONDARY_TENANTS'
 	| 'INCREMENT'
 	| 'INCREMENTAL'
 	| 'INCREMENTAL_LOCATION'
@@ -2275,6 +2276,8 @@ backup_options ::=
 	| 'DETACHED' '=' 'FALSE'
 	| 'KMS' '=' string_or_placeholder_opt_list
 	| 'INCREMENTAL_LOCATION' '=' string_or_placeholder_opt_list
+	| 'INCLUDE_ALL_SECONDARY_TENANTS'
+	| 'INCLUDE_ALL_SECONDARY_TENANTS' '=' a_expr
 
 c_expr ::=
 	d_expr
@@ -2562,6 +2565,8 @@ restore_options ::=
 	| 'SKIP_LOCALITIES_CHECK'
 	| 'DEBUG_PAUSE_ON' '=' string_or_placeholder
 	| 'NEW_DB_NAME' '=' string_or_placeholder
+	| 'INCLUDE_ALL_SECONDARY_TENANTS'
+	| 'INCLUDE_ALL_SECONDARY_TENANTS' '=' a_expr
 	| 'INCREMENTAL_LOCATION' '=' string_or_placeholder_opt_list
 	| 'TENANT' '=' string_or_placeholder
 	| 'SCHEMA_ONLY'
@@ -3475,6 +3480,7 @@ bare_label_keywords ::=
 	| 'DEPENDS'
 	| 'EXTERNAL'
 	| 'IMMUTABLE'
+	| 'INCLUDE_ALL_SECONDARY_TENANTS'
 	| 'INPUT'
 	| 'INVOKER'
 	| 'LEAKPROOF'

--- a/pkg/ccl/backupccl/alter_backup_schedule.go
+++ b/pkg/ccl/backupccl/alter_backup_schedule.go
@@ -324,6 +324,10 @@ func processOptionsForArgs(inOpts tree.BackupOptions, outOpts *tree.BackupOption
 		outOpts.CaptureRevisionHistory = inOpts.CaptureRevisionHistory
 	}
 
+	if inOpts.IncludeAllSecondaryTenants != nil {
+		outOpts.IncludeAllSecondaryTenants = inOpts.IncludeAllSecondaryTenants
+	}
+
 	// If a string-y option is set to empty, interpret this as "unset."
 	if inOpts.EncryptionPassphrase != nil {
 		if tree.AsStringWithFlags(inOpts.EncryptionPassphrase, tree.FmtBareStrings) == "" {

--- a/pkg/ccl/backupccl/backup_planning.go
+++ b/pkg/ccl/backupccl/backup_planning.go
@@ -525,6 +525,7 @@ func backupTypeCheck(
 		},
 		exprutil.Bools{
 			backupStmt.Options.CaptureRevisionHistory,
+			backupStmt.Options.IncludeAllSecondaryTenants,
 		}); err != nil {
 		return false, nil, err
 	}
@@ -594,6 +595,21 @@ func backupPlanHook(
 		)
 		if err != nil {
 			return nil, nil, nil, false, err
+		}
+	}
+
+	// IncludeAllSecondaryTenants exists only for
+	// forward-compatibility with v23.1 for users who want all
+	// tenants.
+	if backupStmt.Options.IncludeAllSecondaryTenants != nil {
+		includeAllSecondaryTenants, err := exprEval.Bool(
+			ctx, backupStmt.Options.IncludeAllSecondaryTenants,
+		)
+		if err != nil {
+			return nil, nil, nil, false, err
+		}
+		if !includeAllSecondaryTenants {
+			return nil, nil, nil, false, errors.Errorf("include_all_secondary_tenants=false is not supported")
 		}
 	}
 

--- a/pkg/ccl/backupccl/testdata/backup-restore/alter-schedule/backup-options
+++ b/pkg/ccl/backupccl/testdata/backup-restore/alter-schedule/backup-options
@@ -102,3 +102,33 @@ with schedules as (show schedules) select id, command->'backup_statement' from s
 ----
 $fullID "BACKUP INTO 'nodelocal://1/example-schedule' WITH revision_history = true, detached"
 $incID "BACKUP INTO LATEST IN 'nodelocal://1/example-schedule' WITH revision_history = true, detached"
+
+exec-sql
+alter backup schedule $incID set with include_all_secondary_tenants = true
+----
+
+query-sql
+with schedules as (show schedules) select command->'backup_statement' from schedules where label='datatest' order by command->>'backup_type' asc;
+----
+"BACKUP INTO 'nodelocal://1/example-schedule' WITH revision_history = true, detached, include_all_secondary_tenants = true"
+"BACKUP INTO LATEST IN 'nodelocal://1/example-schedule' WITH revision_history = true, detached, include_all_secondary_tenants = true"
+
+
+exec-sql
+create schedule 'with-secondary' for backup into 'nodelocal://1/example-schedule-with-secondary' WITH include_all_secondary_tenants recurring '@daily' full backup '@weekly';
+----
+
+let $withSecondaryFullID $withSecondaryIncID
+with schedules as (show schedules) select id from schedules where label='with-secondary' order by command->>'backup_type' asc;
+----
+
+query-sql
+with schedules as (show schedules) select command->'backup_statement' from schedules where label='with-secondary' order by command->>'backup_type' asc;
+----
+"BACKUP INTO 'nodelocal://1/example-schedule-with-secondary' WITH detached, include_all_secondary_tenants = true"
+"BACKUP INTO LATEST IN 'nodelocal://1/example-schedule-with-secondary' WITH detached, include_all_secondary_tenants = true"
+
+exec-sql expect-error-regex=(include_all_secondary_tenants=false is not supported)
+alter backup schedule $withSecondaryIncID set with include_all_secondary_tenants = false
+----
+regex matches error

--- a/pkg/ccl/backupccl/testdata/backup-restore/restore-tenants
+++ b/pkg/ccl/backupccl/testdata/backup-restore/restore-tenants
@@ -25,6 +25,16 @@ exec-sql
 BACKUP INTO 'nodelocal://1/cluster'
 ----
 
+exec-sql
+BACKUP INTO 'nodelocal://1/cluster_with_tenants_explicitly' WITH include_all_secondary_tenants
+----
+
+exec-sql expect-error-regex=(include_all_secondary_tenants=false is not supported)
+BACKUP INTO 'nodelocal://1/shouldnotwork' WITH include_all_secondary_tenants=false
+----
+regex matches error
+
+
 exec-sql expect-error-regex=(tenant 5 is not active)
 BACKUP TENANT 5 INTO 'nodelocal://1/tenant5'
 ----
@@ -48,6 +58,11 @@ SELECT id,active,crdb_internal.pb_to_json('cockroach.sql.sqlbase.TenantInfo', in
 5 false {"id": "5", "state": "DROP"}
 6 true {"id": "6", "state": "ACTIVE"}
 
+exec-sql expect-error-regex=(tenant 6 already exists)
+RESTORE TENANT 6 FROM LATEST IN 'nodelocal://1/tenant6';
+----
+regex matches error
+
 exec-sql
 RESTORE TENANT 6 FROM LATEST IN 'nodelocal://1/tenant6' WITH tenant = '7';
 ----
@@ -58,3 +73,8 @@ SELECT id,active,crdb_internal.pb_to_json('cockroach.sql.sqlbase.TenantInfo', in
 5 false {"id": "5", "state": "DROP"}
 6 true {"id": "6", "state": "ACTIVE"}
 7 true {"id": "7", "state": "ACTIVE"}
+
+exec-sql expect-error-regex=(include_all_secondary_tenants=false is not supported)
+RESTORE FROM LATEST IN 'nodelocal://1/cluster' WITH include_all_secondary_tenants=false
+----
+regex matches error

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -885,7 +885,7 @@ func (u *sqlSymUnion) functionObjs() tree.FuncObjs {
 
 %token <str> IDENTITY
 %token <str> IF IFERROR IFNULL IGNORE_FOREIGN_KEYS ILIKE IMMEDIATE IMMUTABLE IMPORT IN INCLUDE
-%token <str> INCLUDING INCREMENT INCREMENTAL INCREMENTAL_LOCATION
+%token <str> INCLUDING INCLUDE_ALL_SECONDARY_TENANTS INCREMENT INCREMENTAL INCREMENTAL_LOCATION
 %token <str> INET INET_CONTAINED_BY_OR_EQUALS
 %token <str> INET_CONTAINS_OR_EQUALS INDEX INDEXES INHERITS INJECT INITIALLY
 %token <str> INNER INOUT INPUT INSENSITIVE INSERT INT INTEGER
@@ -3060,6 +3060,7 @@ opt_clear_data:
 //    kms="[kms_provider]://[kms_host]/[master_key_identifier]?[parameters]" : encrypt backups using KMS
 //    detached: execute backup job asynchronously, without waiting for its completion
 //    incremental_location: specify a different path to store the incremental backup
+//    include_all_secondary_tenants: enable backups of all secondary tenants during a cluster backup in the system tenant
 //
 // %SeeAlso: RESTORE, WEBDOCS/backup.html
 backup_stmt:
@@ -3180,6 +3181,14 @@ backup_options:
 | INCREMENTAL_LOCATION '=' string_or_placeholder_opt_list
   {
   $$.val = &tree.BackupOptions{IncrementalStorage: $3.stringOrPlaceholderOptList()}
+  }
+| INCLUDE_ALL_SECONDARY_TENANTS
+  {
+    $$.val = &tree.BackupOptions{IncludeAllSecondaryTenants: tree.MakeDBool(true)}
+  }
+| INCLUDE_ALL_SECONDARY_TENANTS '=' a_expr
+  {
+    $$.val = &tree.BackupOptions{IncludeAllSecondaryTenants: $3.expr()}
   }
 
 
@@ -3493,6 +3502,7 @@ drop_external_connection_stmt:
 //    skip_localities_check: ignore difference of zone configuration between restore cluster and backup cluster
 //    debug_pause_on: describes the events that the job should pause itself on for debugging purposes.
 //    new_db_name: renames the restored database. only applies to database restores
+//    include_all_secondary_tenants: enable backups of all secondary tenants during a cluster backup in the system tenant
 // %SeeAlso: BACKUP, WEBDOCS/restore.html
 restore_stmt:
   RESTORE FROM list_of_string_or_placeholder_opt_list opt_as_of_clause opt_with_restore_options
@@ -3677,6 +3687,14 @@ restore_options:
 | NEW_DB_NAME '=' string_or_placeholder
   {
     $$.val = &tree.RestoreOptions{NewDBName: $3.expr()}
+  }
+| INCLUDE_ALL_SECONDARY_TENANTS
+  {
+    $$.val = &tree.RestoreOptions{IncludeAllSecondaryTenants: tree.MakeDBool(true)}
+  }
+| INCLUDE_ALL_SECONDARY_TENANTS '=' a_expr
+  {
+    $$.val = &tree.RestoreOptions{IncludeAllSecondaryTenants: $3.expr()}
   }
 | INCREMENTAL_LOCATION '=' string_or_placeholder_opt_list
 	{
@@ -15342,6 +15360,7 @@ unreserved_keyword:
 | IMPORT
 | INCLUDE
 | INCLUDING
+| INCLUDE_ALL_SECONDARY_TENANTS
 | INCREMENT
 | INCREMENTAL
 | INCREMENTAL_LOCATION
@@ -15636,6 +15655,7 @@ bare_label_keywords:
 | DEPENDS
 | EXTERNAL
 | IMMUTABLE
+| INCLUDE_ALL_SECONDARY_TENANTS
 | INPUT
 | INVOKER
 | LEAKPROOF

--- a/pkg/sql/parser/testdata/backup_restore
+++ b/pkg/sql/parser/testdata/backup_restore
@@ -803,6 +803,38 @@ RESTORE TABLE (foo) FROM ('bar') WITH skip_missing_foreign_keys, skip_missing_se
 RESTORE TABLE foo FROM '_' WITH skip_missing_foreign_keys, skip_missing_sequences, detached -- literals removed
 RESTORE TABLE _ FROM 'bar' WITH skip_missing_foreign_keys, skip_missing_sequences, detached -- identifiers removed
 
+parse
+BACKUP INTO 'bar' WITH include_all_secondary_tenants = $1, detached
+----
+BACKUP INTO 'bar' WITH detached, include_all_secondary_tenants = $1 -- normalized!
+BACKUP INTO ('bar') WITH detached, include_all_secondary_tenants = ($1) -- fully parenthesized
+BACKUP INTO '_' WITH detached, include_all_secondary_tenants = $1 -- literals removed
+BACKUP INTO 'bar' WITH detached, include_all_secondary_tenants = $1 -- identifiers removed
+
+parse
+BACKUP INTO 'bar' WITH include_all_secondary_tenants, detached
+----
+BACKUP INTO 'bar' WITH detached, include_all_secondary_tenants = true -- normalized!
+BACKUP INTO ('bar') WITH detached, include_all_secondary_tenants = (true) -- fully parenthesized
+BACKUP INTO '_' WITH detached, include_all_secondary_tenants = _ -- literals removed
+BACKUP INTO 'bar' WITH detached, include_all_secondary_tenants = true -- identifiers removed
+
+parse
+RESTORE FROM LATEST IN 'bar' WITH include_all_secondary_tenants = $1, detached
+----
+RESTORE FROM 'latest' IN 'bar' WITH detached, include_all_secondary_tenants = $1 -- normalized!
+RESTORE FROM ('latest') IN ('bar') WITH detached, include_all_secondary_tenants = ($1) -- fully parenthesized
+RESTORE FROM '_' IN '_' WITH detached, include_all_secondary_tenants = $1 -- literals removed
+RESTORE FROM 'latest' IN 'bar' WITH detached, include_all_secondary_tenants = $1 -- identifiers removed
+
+parse
+RESTORE FROM LATEST IN 'bar' WITH include_all_secondary_tenants, detached
+----
+RESTORE FROM 'latest' IN 'bar' WITH detached, include_all_secondary_tenants = true -- normalized!
+RESTORE FROM ('latest') IN ('bar') WITH detached, include_all_secondary_tenants = (true) -- fully parenthesized
+RESTORE FROM '_' IN '_' WITH detached, include_all_secondary_tenants = _ -- literals removed
+RESTORE FROM 'latest' IN 'bar' WITH detached, include_all_secondary_tenants = true -- identifiers removed
+
 error
 BACKUP foo TO 'bar' WITH key1, key2 = 'value'
 ----
@@ -845,6 +877,14 @@ BACKUP foo TO 'bar' WITH detached=true, revision_history, detached=true
                                                                    ^
 
 error
+BACKUP TO 'bar' WITH include_all_secondary_tenants=false, include_all_secondary_tenants
+----
+at or near "EOF": syntax error: include_all_secondary_tenants specified multiple times
+DETAIL: source SQL:
+BACKUP TO 'bar' WITH include_all_secondary_tenants=false, include_all_secondary_tenants
+                                                                                       ^
+
+error
 BACKUP foo TO 'bar' WITH detached=$1, revision_history
 ----
 at or near "1": syntax error
@@ -885,6 +925,14 @@ at or near "detached": syntax error: detached option specified multiple times
 DETAIL: source SQL:
 RESTORE foo FROM 'bar' WITH detached, skip_missing_views, detached
                                                           ^
+
+error
+RESTORE FROM 'bar' WITH include_all_secondary_tenants=false, include_all_secondary_tenants
+----
+at or near "EOF": syntax error: include_all_secondary_tenants specified multiple times
+DETAIL: source SQL:
+RESTORE FROM 'bar' WITH include_all_secondary_tenants=false, include_all_secondary_tenants
+                                                                                          ^
 
 error
 BACKUP ROLE foo, bar TO 'baz'

--- a/pkg/sql/sem/tree/walk.go
+++ b/pkg/sql/sem/tree/walk.go
@@ -1001,6 +1001,17 @@ func (stmt *Backup) walkStmt(v Visitor) Statement {
 			ret.Options.EncryptionPassphrase = pw
 		}
 	}
+
+	if stmt.Options.IncludeAllSecondaryTenants != nil {
+		include, changed := WalkExpr(v, stmt.Options.IncludeAllSecondaryTenants)
+		if changed {
+			if ret == stmt {
+				ret = stmt.copyNode()
+			}
+			ret.Options.IncludeAllSecondaryTenants = include
+		}
+	}
+
 	return ret
 }
 
@@ -1268,6 +1279,17 @@ func (stmt *Restore) walkStmt(v Visitor) Statement {
 			ret.Options.IntoDB = intoDB
 		}
 	}
+
+	if stmt.Options.IncludeAllSecondaryTenants != nil {
+		include, changed := WalkExpr(v, stmt.Options.IncludeAllSecondaryTenants)
+		if changed {
+			if ret == stmt {
+				ret = stmt.copyNode()
+			}
+			ret.Options.IncludeAllSecondaryTenants = include
+		}
+	}
+
 	return ret
 }
 


### PR DESCRIPTION
Backport 1/1 commits from #95673. This is a partial backport with substantially 
different behaviour.

/cc @cockroachdb/release

---

To facilitate upgrading from v22.2 to v23.1, this change adds an
include_all_secondary_tenants option. We leave the default behaviour
unchanged, so this option does nothing. Attempts to set the option to
false explicitly results in an error.

But, users can set it in advance of upgrading to 23.1 where the
behaviour will change. It also allows managing a fleet of cockroach
clusters that may be on 22.2 and 23.1 without special cases for the
version.

Epic: CRDB-14582

Release note: None

Release justification: Low risk change to allow easier rollout of 23.1 to CC.
