### PR TITLE
sqlccl: disable default test tenant for explicit tenant tests

### DIFF
--- a/pkg/ccl/testccl/sqlccl/run_control_test.go
+++ b/pkg/ccl/testccl/sqlccl/run_control_test.go
@@ -41,7 +41,13 @@ func makeRunControlTestCases(t *testing.T) ([]runControlTestCase, func()) {
 	t.Helper()
 	testCases := make([]runControlTestCase, 2)
 	tc := serverutils.StartNewTestCluster(
-		t, 2 /* numNodes */, base.TestClusterArgs{ReplicationMode: base.ReplicationManual},
+		t, 2 /* numNodes */, base.TestClusterArgs{
+			ServerArgs: base.TestServerArgs{
+				// Disable the implicit default test tenant so that we can start our own.
+				DisableDefaultTestTenant: true,
+			},
+			ReplicationMode: base.ReplicationManual,
+		},
 	)
 	testCases[0].name = "SystemTenant"
 	testCases[0].conn1 = tc.ServerConn(0).Conn

--- a/pkg/ccl/testccl/sqlccl/tenant_gc_test.go
+++ b/pkg/ccl/testccl/sqlccl/tenant_gc_test.go
@@ -473,6 +473,8 @@ func TestGCTenantJobWaitsForProtectedTimestamps(t *testing.T) {
 
 	ctx := context.Background()
 	args := base.TestServerArgs{
+		// Disable the implicit default test tenant so that we can start our own.
+		DisableDefaultTestTenant: true,
 		Knobs: base.TestingKnobs{
 			JobsTestingKnobs: jobs.NewTestingKnobsWithShortIntervals(),
 		},


### PR DESCRIPTION
The tests modified in this change start tenants explicitly, and fails when the default test tenant is started as it is not expected. This change disables the starting of the default test tenant.

Epic: None