### PR TITLE
kvserver: add test retries for INCONSISTENT scan

### DIFF
--- a/pkg/kv/kvclient/rangecache/range_cache.go
+++ b/pkg/kv/kvclient/rangecache/range_cache.go
@@ -83,6 +83,14 @@ const (
 	ReadFromFollower = kvpb.INCONSISTENT
 	// ReadFromLeaseholder is the RangeLookupConsistency used to read from the
 	// leaseholder.
+	// TODO(baptist): This may be incorrect. An uncommitted read may not see the
+	// updated value. Revisit if this should be a CONSISTENT read against the
+	// leaseholder. READ_UNCOMMITTED does not guarantee a more up-to-date view
+	// than INCONSISTENT, it only guarantees that the read is on the leaseholder,
+	// but may not include writes that have been appended to Raft, but not yet
+	// applied. In the case of certain disk issues, the leaseholders disk may be
+	// significantly behind. An alternative would be to change READ_UNCOMMITTED to
+	// acquire latches. See #98862.
 	ReadFromLeaseholder = kvpb.READ_UNCOMMITTED
 )
 

--- a/pkg/kv/kvpb/api.proto
+++ b/pkg/kv/kvpb/api.proto
@@ -41,7 +41,15 @@ enum ReadConsistencyType {
   // The consistency type is similar to INCONSISTENT in that using it
   // can result in dirty reads. However, like the CONSISTENT type, it
   // requires the replica performing the read to hold a valid read lease,
-  // meaning that it can't return arbitrarily stale data.
+  // meaning that it can't return arbitrarily stale data. Note that
+  // read-committed does not imply any real-time constraints. If process A
+  // completes write w, then process B begins a read r, r is not necessarily
+  // guaranteed to observe w even if they are from the same client. This can
+  // occur due to the unbounded time delay between Raft appends and state
+  // machine application.
+  // TODO(baptist): Should we remove this level as it is virtually identical to
+  // INCONSISTENT. See #98862 as we may change the behavior to give stronger
+  // guarantees.
   READ_UNCOMMITTED = 1;
   // INCONSISTENT reads return the latest available, committed values.
   // They are more efficient, but may read stale values as pending


### PR DESCRIPTION
A read request at READ_UNCOMMITTED or INCONSISTENT levels are not guaranteed to return the latest data. This is especially true after aysnc raft where a put operation on the leaseholder returns after the data is appended to raft but not yet applied to the state machine.

This change adds retries to the scan to ensure that the data does get there eventually and the scan stil returns the correct results.

Epic: none
Fixes: #91856