### PR TITLE
server: remove Recover* methods from non system tenant admin

### DIFF
--- a/pkg/server/admin.go
+++ b/pkg/server/admin.go
@@ -4334,38 +4334,6 @@ func (s *adminServer) SetTraceRecordingType(
 	return &serverpb.SetTraceRecordingTypeResponse{}, nil
 }
 
-func (s *adminServer) RecoveryCollectReplicaInfo(
-	request *serverpb.RecoveryCollectReplicaInfoRequest,
-	server serverpb.Admin_RecoveryCollectReplicaInfoServer,
-) error {
-	return errors.AssertionFailedf("To be implemented by #93040")
-}
-
-func (s *adminServer) RecoveryCollectLocalReplicaInfo(
-	request *serverpb.RecoveryCollectLocalReplicaInfoRequest,
-	server serverpb.Admin_RecoveryCollectLocalReplicaInfoServer,
-) error {
-	return errors.AssertionFailedf("To be implemented by #93040")
-}
-
-func (s *adminServer) RecoveryStagePlan(
-	ctx context.Context, request *serverpb.RecoveryStagePlanRequest,
-) (*serverpb.RecoveryStagePlanResponse, error) {
-	return nil, errors.AssertionFailedf("To be implemented by #93044")
-}
-
-func (s *adminServer) RecoveryNodeStatus(
-	ctx context.Context, request *serverpb.RecoveryNodeStatusRequest,
-) (*serverpb.RecoveryNodeStatusResponse, error) {
-	return nil, errors.AssertionFailedf("To be implemented by #93043")
-}
-
-func (s *adminServer) RecoveryVerify(
-	ctx context.Context, request *serverpb.RecoveryVerifyRequest,
-) (*serverpb.RecoveryVerifyResponse, error) {
-	return nil, errors.AssertionFailedf("To be implemented by #93043")
-}
-
 // ListTenants returns a list of tenants that are served
 // by shared-process services in this server.
 func (s *systemAdminServer) ListTenants(


### PR DESCRIPTION
This commit removes loss of quorum recovery methods (Recover.*) from adminServer and only keeps them on systemAdminServer since those operations are cluster wide.

Release note: None

Fixes #98300