### PR TITLE
release-22.2: spanconfig: export metrics for protected timestamp records

### DIFF
--- a/monitoring/grafana-dashboards/queues.json
+++ b/monitoring/grafana-dashboards/queues.json
@@ -858,7 +858,7 @@
       "timeFrom": null,
       "timeRegions": [],
       "timeShift": null,
-      "title": "GC Queue",
+      "title": "MVCC GC Queue",
       "tooltip": {
         "shared": true,
         "sort": 0,

--- a/pkg/spanconfig/spanconfigkvsubscriber/BUILD.bazel
+++ b/pkg/spanconfig/spanconfigkvsubscriber/BUILD.bazel
@@ -16,6 +16,7 @@ go_library(
         "//pkg/kv/kvclient/rangefeed/rangefeedbuffer",
         "//pkg/kv/kvclient/rangefeed/rangefeedcache",
         "//pkg/roachpb",
+        "//pkg/settings",
         "//pkg/settings/cluster",
         "//pkg/spanconfig",
         "//pkg/spanconfig/spanconfigstore",

--- a/pkg/spanconfig/spanconfigkvsubscriber/kvsubscriber_test.go
+++ b/pkg/spanconfig/spanconfigkvsubscriber/kvsubscriber_test.go
@@ -14,6 +14,7 @@ import (
 	"context"
 	"sort"
 	"testing"
+	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
@@ -28,6 +29,11 @@ import (
 // TestingRunInner exports the inner run method for testing purposes.
 func (s *KVSubscriber) TestingRunInner(ctx context.Context) error {
 	return s.rfc.Run(ctx)
+}
+
+// TestingUpdateMetrics exports the inner updateMetrics method for testing purposes.
+func (s *KVSubscriber) TestingUpdateMetrics(ctx context.Context) {
+	s.updateMetrics(ctx)
 }
 
 func TestGetProtectionTimestamps(t *testing.T) {
@@ -75,8 +81,12 @@ func TestGetProtectionTimestamps(t *testing.T) {
 	// Mark sp43 as excluded from backup.
 	sp43Cfg.cfg.ExcludeDataFromBackup = true
 
+	const timeDeltaFromTS1 = 10
+	mt := timeutil.NewManualTime(ts1.GoTime())
+	mt.AdvanceTo(ts1.Add(timeDeltaFromTS1, 0).GoTime())
+
 	subscriber := New(
-		nil, /* clock */
+		hlc.NewClock(mt, time.Nanosecond),
 		nil, /* rangeFeedFactory */
 		keys.SpanConfigurationsTableID,
 		1<<20, /* 1 MB */
@@ -132,6 +142,15 @@ func TestGetProtectionTimestamps(t *testing.T) {
 			testCase.test(t, m, subscriber)
 		})
 	}
+
+	// Test internal metrics. We should expect a protected record count of 3,
+	// ignoring the one from ts3 since it has both
+	// {IgnoreIfExcludedFromBackup,ExcludeDataFromBackup} are true. We should
+	// also observe the right delta between the oldest protected timestamp and
+	// current wall clock time.
+	subscriber.TestingUpdateMetrics(ctx)
+	require.Equal(t, int64(3), subscriber.metrics.ProtectedRecordCount.Value())
+	require.Equal(t, int64(timeDeltaFromTS1), subscriber.metrics.OldestProtectedRecordNanos.Value())
 }
 
 var _ spanconfig.Store = &manualStore{}

--- a/pkg/ts/catalog/chart_catalog.go
+++ b/pkg/ts/catalog/chart_catalog.go
@@ -771,8 +771,17 @@ var charts = []sectionDescription{
 		},
 		Charts: []chartDescription{
 			{
-				Title:   "KVSubscriber",
-				Metrics: []string{"spanconfig.kvsubscriber.update_behind_nanos"},
+				Title: "KVSubscriber Lag Metrics",
+				Metrics: []string{
+					"spanconfig.kvsubscriber.oldest_protected_record_nanos",
+					"spanconfig.kvsubscriber.update_behind_nanos",
+				},
+			},
+			{
+				Title: "KVSubscriber Protected Record Count",
+				Metrics: []string{
+					"spanconfig.kvsubscriber.protected_record_count",
+				},
 			},
 		},
 	},

--- a/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/queues.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/queues.tsx
@@ -14,10 +14,10 @@ import { LineGraph } from "src/views/cluster/components/linegraph";
 import { Metric, Axis } from "src/views/shared/components/metricQuery";
 import { AxisUnits } from "@cockroachlabs/cluster-ui";
 
-import { GraphDashboardProps } from "./dashboardUtils";
+import { GraphDashboardProps, nodeDisplayName } from "./dashboardUtils";
 
 export default function (props: GraphDashboardProps) {
-  const { storeSources } = props;
+  const { nodeIDs, nodeSources, storeSources, nodeDisplayNameByID } = props;
 
   return [
     <LineGraph title="Queue Processing Failures" sources={storeSources}>
@@ -212,21 +212,6 @@ export default function (props: GraphDashboardProps) {
       </Axis>
     </LineGraph>,
 
-    <LineGraph title="GC Queue" sources={storeSources}>
-      <Axis units={AxisUnits.Count} label="actions">
-        <Metric
-          name="cr.store.queue.gc.process.success"
-          title="Successful Actions / sec"
-          nonNegativeRate
-        />
-        <Metric
-          name="cr.store.queue.gc.pending"
-          title="Pending Actions"
-          downsampleMax
-        />
-      </Axis>
-    </LineGraph>,
-
     <LineGraph title="Raft Log Queue" sources={storeSources}>
       <Axis units={AxisUnits.Count} label="actions">
         <Metric
@@ -284,6 +269,41 @@ export default function (props: GraphDashboardProps) {
           title="Pending Actions"
           downsampleMax
         />
+      </Axis>
+    </LineGraph>,
+
+    <LineGraph title="MVCC GC Queue" sources={storeSources}>
+      <Axis units={AxisUnits.Count} label="actions">
+        <Metric
+          name="cr.store.queue.gc.process.success"
+          title="Successful Actions / sec"
+          nonNegativeRate
+        />
+        <Metric
+          name="cr.store.queue.gc.pending"
+          title="Pending Actions"
+          downsampleMax
+        />
+      </Axis>
+    </LineGraph>,
+
+    <LineGraph
+      title="Protected Timestamp Records"
+      sources={nodeSources}
+      tooltip={`Number of protected timestamp records (used by backups, changefeeds, etc. to prevent MVCC GC)`}
+    >
+      <Axis units={AxisUnits.Count} label="Records">
+        {nodeIDs.map(nid => (
+          <>
+            <Metric
+              key={nid}
+              name="cr.node.spanconfig.kvsubscriber.protected_record_count"
+              title={nodeDisplayName(nodeDisplayNameByID, nid)}
+              sources={[nid]}
+              downsampleMax
+            />
+          </>
+        ))}
       </Axis>
     </LineGraph>,
   ];


### PR DESCRIPTION
Backport 1/1 commits from #98540.

/cc @cockroachdb/release

---

This commit introduces two new metrics, to help understand the effects of protected timestamps:
- `spanconfig.kvsubscriber.protected_record_count`, which exports the number of protected timestamp records as seen by KV.
- `spanconfig.kvsubscriber.oldest_protected_record_nanos`, which exports difference between the current time and the oldest protected timestamp. Sudden drops indicate a record being released; an ever-increasing duration would indicate the oldest record sticking around and preventing GC if > the configured GC TTL.

Fixes #98532 (as a backportable alternative to a0d6c190 for 22.1, 22.2).

Release note: None
Release justification: Adds helpful metrics that would've come in handy in internal escalations
