### PR TITLE
sql: add name resolver to constraint validator for legacy schema changer

### DIFF
--- a/pkg/sql/backfill.go
+++ b/pkg/sql/backfill.go
@@ -793,6 +793,12 @@ func (sc *SchemaChanger) validateConstraints(
 				resolver := descs.NewDistSQLTypeResolver(collection, txn.KV())
 				semaCtx := tree.MakeSemaContext()
 				semaCtx.TypeResolver = &resolver
+				semaCtx.NameResolver = NewSkippingCacheSchemaResolver(
+					txn.Descriptors(),
+					sessiondata.NewStack(NewFakeSessionData(&sc.settings.SV, "validate constraint")),
+					txn.KV(),
+					nil, /* authAccessor */
+				)
 				semaCtx.FunctionResolver = descs.NewDistSQLFunctionResolver(collection, txn.KV())
 				// TODO (rohany): When to release this? As of now this is only going to get released
 				//  after the check is validated.

--- a/pkg/sql/logictest/testdata/logic_test/check_constraints
+++ b/pkg/sql/logictest/testdata/logic_test/check_constraints
@@ -393,3 +393,14 @@ INSERT INTO t67100b VALUES (1)
 
 statement error failed to satisfy CHECK constraint \(true AND \(0:::INT8 > 1:::INT8\)\)
 UPSERT INTO t67100b VALUES (1)
+
+subtest regression_91697
+
+statement ok
+CREATE TABLE t_91697(a OID);
+
+statement ok
+ALTER TABLE t_91697 ADD CHECK (a < 123);
+
+statement error pgcode 23514 pq: failed to satisfy CHECK constraint \(a < 'public.t67100a'::REGCLASS\)
+INSERT INTO t_91697 VALUES (321);


### PR DESCRIPTION
Fixes #91697

Previously, in legacy schema changer, when adding a constraint with expression containing OID datum, it panics because we didn't give the validator a proper name resolver to resolve sequence names when deserializing constraint expressions. The funny logic of deserialization is that it tries to resolve anything that is a OID datum, even it's just a scalar in which case we could fail to find a sequence and we skip it well.

Release note (sql change): this commit fixes a bug where check constraint on a OID type column panics in legacy schema changer.