### PR TITLE
kvserver: unskip merge queue during snapshot test

### DIFF
--- a/pkg/kv/kvserver/replica_learner_test.go
+++ b/pkg/kv/kvserver/replica_learner_test.go
@@ -1721,7 +1721,6 @@ func TestLearnerAndJointConfigAdminMerge(t *testing.T) {
 func TestMergeQueueDoesNotInterruptReplicationChange(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	skip.WithIssue(t, 94951)
 	ctx := context.Background()
 	var activateSnapshotTestingKnob int64
 	blockSnapshot := make(chan struct{})


### PR DESCRIPTION
This change unskips `TestMergeQueueDoesNotInterruptReplicationChange`, which was skipped as potentially flaky in #94951. Despite repeated stress testing, this test no longer seems flaky, and correctly gets an error if attempting to enqueue a range in the merge queue during a replication change.

Fixes: #94951

Release note: None