### PR TITLE
changefeedccl: add WITH key_column option

### DIFF
--- a/pkg/ccl/changefeedccl/cdcevent/event.go
+++ b/pkg/ccl/changefeedccl/cdcevent/event.go
@@ -110,6 +110,15 @@ func (r Row) ForEachUDTColumn() Iterator {
 	return iter{r: r, cols: r.udtCols}
 }
 
+// DatumNamed returns the datum with the specified column name, in the form of an Iterator.
+func (r Row) DatumNamed(n string) (Iterator, error) {
+	idx, ok := r.EventDescriptor.colsByName[n]
+	if !ok {
+		return nil, errors.Errorf("No column with name %s in this row", n)
+	}
+	return iter{r: r, cols: []int{idx}}, nil
+}
+
 // DatumAt returns Datum at specified position.
 func (r Row) DatumAt(at int) (tree.Datum, error) {
 	if at >= len(r.cols) {
@@ -236,10 +245,11 @@ type EventDescriptor struct {
 	cols []ResultColumn
 
 	// Precomputed index lists into cols.
-	keyCols   []int // Primary key columns.
-	valueCols []int // All column family columns.
-	udtCols   []int // Columns containing UDTs.
-	allCols   []int // Contains all the columns
+	keyCols    []int          // Primary key columns.
+	valueCols  []int          // All column family columns.
+	udtCols    []int          // Columns containing UDTs.
+	allCols    []int          // Contains all the columns
+	colsByName map[string]int // All columns, map[col.GetName()]idx in cols
 }
 
 // NewEventDescriptor returns EventDescriptor for specified table and family descriptors.
@@ -260,7 +270,8 @@ func NewEventDescriptor(
 			HasOtherFamilies: desc.NumFamilies() > 1,
 			SchemaTS:         schemaTS,
 		},
-		td: desc,
+		td:         desc,
+		colsByName: make(map[string]int),
 	}
 
 	// addColumn is a helper to add a column to this descriptor.
@@ -278,6 +289,7 @@ func NewEventDescriptor(
 
 		colIdx := len(sd.cols)
 		sd.cols = append(sd.cols, resultColumn)
+		sd.colsByName[col.GetName()] = colIdx
 
 		if col.GetType().UserDefined() {
 			sd.udtCols = append(sd.udtCols, colIdx)

--- a/pkg/ccl/changefeedccl/changefeedbase/options_test.go
+++ b/pkg/ccl/changefeedccl/changefeedbase/options_test.go
@@ -39,6 +39,7 @@ func TestOptionsValidations(t *testing.T) {
 		// Verify that the returned error uses the syntax initial_scan='yes' instead of initial_scan_only. See #97008.
 		{map[string]string{"initial_scan_only": "", "resolved": ""}, true, "cannot specify both initial_scan='only'"},
 		{map[string]string{"initial_scan_only": "", "resolved": ""}, true, "cannot specify both initial_scan='only'"},
+		{map[string]string{"key_column": "b"}, false, "requires the unordered option"},
 		{map[string]string{"diff": "", "format": "parquet"}, true, ""},
 	}
 

--- a/pkg/ccl/changefeedccl/changefeedvalidators/table_validator.go
+++ b/pkg/ccl/changefeedccl/changefeedvalidators/table_validator.go
@@ -86,6 +86,11 @@ func validateTable(
 	if !found {
 		return errors.Errorf(`unwatched table: %s`, tableDesc.GetName())
 	}
+	for _, requiredColumn := range canHandle.RequiredColumns {
+		if catalog.FindColumnByName(tableDesc, requiredColumn) == nil {
+			return errors.Errorf("required column %s not present on table %s", requiredColumn, tableDesc.GetName())
+		}
+	}
 
 	return err
 }


### PR DESCRIPTION
Changefeeds running on an outbox table see a synthetic primary key that isn't useful for downstream partitioning. This PR adds an encoder option to use a different column as the key, not in internal logic, but only in message metadata. This breaks end-to-end ordering because we're only ordered with respect to the actual primary key, and the sink will only order with respect to the key we emit. We therefore require the unordered flag here.

Closes #54461.

Release note (enterprise change): Added the WITH key_column option to override the key used in message metadata. This changes the key hashed to determine Kafka partitions. It does not affect the output of key_in_value or the domain of the per-key ordering guarantee.