### PR TITLE
streamingest,sql: SHOW TENANT WITH REPL succeeds even if no replication

### DIFF
--- a/pkg/ccl/streamingccl/streamingest/testdata/simple
+++ b/pkg/ccl/streamingccl/streamingest/testdata/simple
@@ -30,6 +30,11 @@ SELECT strip_host(source_cluster_uri) FROM [SHOW TENANT destination WITH REPLICA
 ----
 postgres://root@?sslcert=redacted&sslkey=redacted&sslmode=verify-full&sslrootcert=redacted
 
+query-sql as=source-system
+SHOW TENANT source WITH REPLICATION STATUS
+----
+10 source ready none <nil> <nil> <nil> <nil> <nil> <nil>
+
 exec-sql as=source-tenant
 CREATE TABLE d.x (id INT PRIMARY KEY, n INT);
 ----
@@ -53,6 +58,12 @@ SHOW TENANTS
 ----
 1 system ready shared
 2 destination replicating none
+
+query-sql as=destination-system
+SELECT id, name, data_state, service_mode, source_tenant_name, cutover_time FROM [SHOW TENANTS WITH REPLICATION STATUS]
+----
+1 system ready shared <nil> <nil>
+2 destination replicating none source <nil>
 
 let $ts as=source-system
 SELECT clock_timestamp()::timestamp::string

--- a/pkg/sql/logictest/testdata/logic_test/tenant
+++ b/pkg/sql/logictest/testdata/logic_test/tenant
@@ -112,14 +112,14 @@ SELECT * FROM [SHOW TENANTS] WHERE id = 4
 id  name   data_state  service_mode
 4   three  ready       none
 
+query ITTTT colnames
+SELECT id, name, data_state, service_mode, source_tenant_name FROM [SHOW TENANTS WITH REPLICATION STATUS] WHERE id = 4
+----
+id  name   data_state  service_mode  source_tenant_name
+4   three  ready       none          NULL
+
 statement error tenant "seven" does not exist
 SHOW TENANT seven
-
-statement error pq: tenant "tenant-one" does not have an active replication job
-SHOW TENANT "tenant-one" WITH REPLICATION STATUS
-
-statement error pq: tenant "two" does not have an active replication job
-SHOW TENANT two WITH REPLICATION STATUS
 
 # Test creating a tenant with the same name as an existing tenant, but a unique
 # ID.

--- a/pkg/sql/show_tenant.go
+++ b/pkg/sql/show_tenant.go
@@ -124,10 +124,6 @@ func (n *showTenantNode) getTenantValues(
 	// Tenant status + replication status fields.
 	jobId := tenantInfo.TenantReplicationJobID
 	if jobId == 0 {
-		// No replication job, this is a non-replicating tenant.
-		if n.withReplication {
-			return nil, errors.Newf("tenant %q does not have an active replication job", tenantInfo.Name)
-		}
 		values.dataState = values.tenantInfo.DataState.String()
 	} else {
 		switch values.tenantInfo.DataState {
@@ -215,13 +211,14 @@ func (n *showTenantNode) Values() tree.Datums {
 		// This is a 'SHOW TENANT name WITH REPLICATION STATUS' command.
 		sourceTenantName := tree.DNull
 		sourceClusterUri := tree.DNull
-		replicationJobId := tree.NewDInt(tree.DInt(tenantInfo.TenantReplicationJobID))
+		replicationJobId := tree.DNull
 		replicatedTimestamp := tree.DNull
 		retainedTimestamp := tree.DNull
 		cutoverTimestamp := tree.DNull
 
 		replicationInfo := v.replicationInfo
 		if replicationInfo != nil {
+			replicationJobId = tree.NewDInt(tree.DInt(tenantInfo.TenantReplicationJobID))
 			sourceTenantName = tree.NewDString(string(replicationInfo.IngestionDetails.SourceTenantName))
 			sourceClusterUri = tree.NewDString(replicationInfo.IngestionDetails.StreamAddress)
 			if replicationInfo.ReplicationLagInfo != nil {


### PR DESCRIPTION
Currently the command `SHOW TENANT name WITH REPLICATION STATUS` fails if the tenant is not a replication destination. This commit changes this command to succeed, and shows NULLs in all replication fields. For example:

```
 show tenant dest1 with replication status;
  id | name  | data_state | service_mode | source_tenant_name | source_cluster_uri | replication_job_id | replicated_time | retained_time | cutover_time
-----+-------+------------+--------------+--------------------+--------------------+--------------------+-----------------+---------------+---------------
   4 | dest1 | ready      | none         | NULL               | NULL               |               NULL | NULL            | NULL          |         NULL
(1 row)

Time: 3ms total (execution 3ms / network 0ms)
```

Epic: none

Release note: None