### PR TITLE
server: unskip TestTenantCannotSeeNonTenantStats test

### DIFF
--- a/pkg/ccl/serverccl/statusccl/tenant_status_test.go
+++ b/pkg/ccl/serverccl/statusccl/tenant_status_test.go
@@ -267,7 +267,6 @@ func TestTenantCannotSeeNonTenantStats(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	ctx := context.Background()
-	skip.WithIssue(t, 77410, "disabled because of stress / intermittent failures")
 	serverParams, _ := tests.CreateTestServerParams()
 	serverParams.Knobs.SpanConfig = &spanconfig.TestingKnobs{
 		ManagerDisableJobCreation: true, // TODO(irfansharif): #74919.


### PR DESCRIPTION
The ticket this test refers to has been closed #77410 so this test should be reinstated.

Stress was run locally for a few minute and did not result in any failures.

Epic: None
Release note: None