### PR TITLE
sql: TestRandomSyntaxGeneration fixes

### DIFF
--- a/docs/generated/sql/bnf/BUILD.bazel
+++ b/docs/generated/sql/bnf/BUILD.bazel
@@ -82,6 +82,7 @@ FILES = [
     "comment",
     "commit_transaction",
     "copy_stmt",
+    "copy_to_stmt",
     "create_as_col_qual_list",
     "create_as_constraint_def",
     "create_changefeed_stmt",

--- a/docs/generated/sql/bnf/copy_stmt.bnf
+++ b/docs/generated/sql/bnf/copy_stmt.bnf
@@ -9,8 +9,8 @@ copy_stmt ::=
 	| 'COPY' table_name opt_column_list 'TO' 'STDOUT' 'WITH' '(' copy_generic_options_list ')'
 	| 'COPY' table_name opt_column_list 'TO' 'STDOUT'  '(' copy_generic_options_list ')'
 	| 'COPY' table_name opt_column_list 'TO' 'STDOUT' 
-	| 'COPY' '(' preparable_stmt ')' 'TO' 'STDOUT' 'WITH' copy_options ( ( copy_options ) )*
-	| 'COPY' '(' preparable_stmt ')' 'TO' 'STDOUT'  copy_options ( ( copy_options ) )*
-	| 'COPY' '(' preparable_stmt ')' 'TO' 'STDOUT' 'WITH' '(' copy_generic_options_list ')'
-	| 'COPY' '(' preparable_stmt ')' 'TO' 'STDOUT'  '(' copy_generic_options_list ')'
-	| 'COPY' '(' preparable_stmt ')' 'TO' 'STDOUT' 
+	| 'COPY' '(' copy_to_stmt ')' 'TO' 'STDOUT' 'WITH' copy_options ( ( copy_options ) )*
+	| 'COPY' '(' copy_to_stmt ')' 'TO' 'STDOUT'  copy_options ( ( copy_options ) )*
+	| 'COPY' '(' copy_to_stmt ')' 'TO' 'STDOUT' 'WITH' '(' copy_generic_options_list ')'
+	| 'COPY' '(' copy_to_stmt ')' 'TO' 'STDOUT'  '(' copy_generic_options_list ')'
+	| 'COPY' '(' copy_to_stmt ')' 'TO' 'STDOUT' 

--- a/docs/generated/sql/bnf/copy_to_stmt.bnf
+++ b/docs/generated/sql/bnf/copy_to_stmt.bnf
@@ -1,0 +1,6 @@
+copy_to_stmt ::=
+	delete_stmt
+	| insert_stmt
+	| select_stmt
+	| update_stmt
+	| upsert_stmt

--- a/docs/generated/sql/bnf/stmt_block.bnf
+++ b/docs/generated/sql/bnf/stmt_block.bnf
@@ -66,7 +66,7 @@ analyze_stmt ::=
 copy_stmt ::=
 	'COPY' table_name opt_column_list 'FROM' 'STDIN' opt_with_copy_options opt_where_clause
 	| 'COPY' table_name opt_column_list 'TO' 'STDOUT' opt_with_copy_options
-	| 'COPY' '(' preparable_stmt ')' 'TO' 'STDOUT' opt_with_copy_options
+	| 'COPY' '(' copy_to_stmt ')' 'TO' 'STDOUT' opt_with_copy_options
 
 comment_stmt ::=
 	'COMMENT' 'ON' 'DATABASE' database_name 'IS' comment_text
@@ -331,6 +331,13 @@ opt_with_copy_options ::=
 opt_where_clause ::=
 	where_clause
 	| 
+
+copy_to_stmt ::=
+	delete_stmt
+	| insert_stmt
+	| select_stmt
+	| update_stmt
+	| upsert_stmt
 
 database_name ::=
 	name

--- a/pkg/gen/bnf.bzl
+++ b/pkg/gen/bnf.bzl
@@ -82,6 +82,7 @@ BNF_SRCS = [
     "//docs/generated/sql/bnf:comment.bnf",
     "//docs/generated/sql/bnf:commit_transaction.bnf",
     "//docs/generated/sql/bnf:copy_stmt.bnf",
+    "//docs/generated/sql/bnf:copy_to_stmt.bnf",
     "//docs/generated/sql/bnf:create_as_col_qual_list.bnf",
     "//docs/generated/sql/bnf:create_as_constraint_def.bnf",
     "//docs/generated/sql/bnf:create_changefeed_stmt.bnf",

--- a/pkg/gen/diagrams.bzl
+++ b/pkg/gen/diagrams.bzl
@@ -82,6 +82,7 @@ DIAGRAMS_SRCS = [
     "//docs/generated/sql/bnf:comment.html",
     "//docs/generated/sql/bnf:commit_transaction.html",
     "//docs/generated/sql/bnf:copy.html",
+    "//docs/generated/sql/bnf:copy_to.html",
     "//docs/generated/sql/bnf:create.html",
     "//docs/generated/sql/bnf:create_as_col_qual_list.html",
     "//docs/generated/sql/bnf:create_as_constraint_def.html",

--- a/pkg/gen/docs.bzl
+++ b/pkg/gen/docs.bzl
@@ -94,6 +94,7 @@ DOCS_SRCS = [
     "//docs/generated/sql/bnf:comment.bnf",
     "//docs/generated/sql/bnf:commit_transaction.bnf",
     "//docs/generated/sql/bnf:copy_stmt.bnf",
+    "//docs/generated/sql/bnf:copy_to_stmt.bnf",
     "//docs/generated/sql/bnf:create_as_col_qual_list.bnf",
     "//docs/generated/sql/bnf:create_as_constraint_def.bnf",
     "//docs/generated/sql/bnf:create_changefeed_stmt.bnf",

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -1207,6 +1207,7 @@ func (u *sqlSymUnion) showCreateFormatOption() tree.ShowCreateFormatOption {
 %type <tree.Statement> preparable_stmt
 %type <tree.Statement> explainable_stmt
 %type <tree.Statement> row_source_extension_stmt
+%type <tree.Statement> copy_to_stmt
 %type <tree.Statement> export_stmt
 %type <tree.Statement> execute_stmt
 %type <tree.Statement> deallocate_stmt
@@ -3977,7 +3978,7 @@ copy_stmt:
   {
     return unimplementedWithIssue(sqllex, 97181)
   }
-| COPY '(' preparable_stmt ')' TO STDOUT opt_with_copy_options
+| COPY '(' copy_to_stmt ')' TO STDOUT opt_with_copy_options
    {
      /* FORCE DOC */
      $$.val = &tree.CopyTo{
@@ -3985,7 +3986,7 @@ copy_stmt:
         Options: *$7.copyOptions(),
      }
    }
-| COPY '(' preparable_stmt ')' TO error
+| COPY '(' copy_to_stmt ')' TO error
    {
      return unimplementedWithIssue(sqllex, 96590)
    }
@@ -5677,6 +5678,16 @@ row_source_extension_stmt:
     $$.val = $1.slct()
   }
 | show_stmt         // help texts in sub-rule
+| update_stmt       // EXTEND WITH HELP: UPDATE
+| upsert_stmt       // EXTEND WITH HELP: UPSERT
+
+copy_to_stmt:
+  delete_stmt       // EXTEND WITH HELP: DELETE
+| insert_stmt       // EXTEND WITH HELP: INSERT
+| select_stmt       // help texts in sub-rule
+  {
+    $$.val = $1.slct()
+  }
 | update_stmt       // EXTEND WITH HELP: UPDATE
 | upsert_stmt       // EXTEND WITH HELP: UPSERT
 

--- a/pkg/sql/parser/testdata/copy
+++ b/pkg/sql/parser/testdata/copy
@@ -380,3 +380,11 @@ COPY (SELECT * FROM t) TO STDOUT (HEADER, OIDS)
                                               ^
 HINT: You have attempted to use a feature that is not yet implemented.
 See: https://go.crdb.dev/issue-v/41608/
+
+error
+COPY (EXPLAIN SELECT * FROM t) TO STDOUT
+----
+at or near "explain": syntax error
+DETAIL: source SQL:
+COPY (EXPLAIN SELECT * FROM t) TO STDOUT
+      ^

--- a/pkg/sql/parser/testdata/show
+++ b/pkg/sql/parser/testdata/show
@@ -2011,3 +2011,19 @@ SHOW TENANT ALL WITH REPLICATION STATUS
 SHOW TENANT ALL WITH REPLICATION STATUS -- fully parenthesized
 SHOW TENANT ALL WITH REPLICATION STATUS -- literals removed
 SHOW TENANT ALL WITH REPLICATION STATUS -- identifiers removed
+
+parse
+SHOW TENANT foo WITH REPLICATION STATUS, CAPABILITIES
+----
+SHOW TENANT foo WITH REPLICATION STATUS, CAPABILITIES
+SHOW TENANT (foo) WITH REPLICATION STATUS, CAPABILITIES -- fully parenthesized
+SHOW TENANT foo WITH REPLICATION STATUS, CAPABILITIES -- literals removed
+SHOW TENANT _ WITH REPLICATION STATUS, CAPABILITIES -- identifiers removed
+
+parse
+SHOW BACKUP 'family' IN ('string', 'placeholder', 'placeholder', 'placeholder', 'string', 'placeholder', 'string', 'placeholder') WITH incremental_location = 'nullif', privileges, debug_dump_metadata_sst
+----
+SHOW BACKUP 'family' IN ('string', 'placeholder', 'placeholder', 'placeholder', 'string', 'placeholder', 'string', 'placeholder') WITH incremental_location = 'nullif', privileges, debug_dump_metadata_sst
+SHOW BACKUP ('family') IN (('string'), ('placeholder'), ('placeholder'), ('placeholder'), ('string'), ('placeholder'), ('string'), ('placeholder')) WITH incremental_location = ('nullif'), privileges, debug_dump_metadata_sst -- fully parenthesized
+SHOW BACKUP '_' IN ('_', '_', '_', '_', '_', '_', '_', '_') WITH incremental_location = '_', privileges, debug_dump_metadata_sst -- literals removed
+SHOW BACKUP 'family' IN ('string', 'placeholder', 'placeholder', 'placeholder', 'string', 'placeholder', 'string', 'placeholder') WITH incremental_location = 'nullif', privileges, debug_dump_metadata_sst -- identifiers removed

--- a/pkg/sql/sem/tree/show.go
+++ b/pkg/sql/sem/tree/show.go
@@ -21,6 +21,7 @@ package tree
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/lexbase"
 	"github.com/cockroachdb/errors"
@@ -221,6 +222,7 @@ func (o *ShowBackupOptions) Format(ctx *FmtCtx) {
 		ctx.FormatNode(&o.DecryptionKMSURI)
 	}
 	if o.DebugMetadataSST {
+		maybeAddSep()
 		ctx.WriteString("debug_dump_metadata_sst")
 	}
 
@@ -1107,12 +1109,16 @@ func (node *ShowTenant) Format(ctx *FmtCtx) {
 	ctx.WriteString("SHOW TENANT ")
 	ctx.FormatNode(node.TenantSpec)
 
+	withs := []string{}
 	if node.WithReplication {
-		ctx.WriteString(" WITH REPLICATION STATUS")
+		withs = append(withs, "REPLICATION STATUS")
 	}
-
 	if node.WithCapabilities {
-		ctx.WriteString(" WITH CAPABILITIES")
+		withs = append(withs, "CAPABILITIES")
+	}
+	if len(withs) > 0 {
+		ctx.WriteString(" WITH ")
+		ctx.WriteString(strings.Join(withs, ", "))
 	}
 }
 


### PR DESCRIPTION
### sql: fix some TestRandomSyntaxGeneration bugs

The RSG works by calling format on the AST's it generates so its good
at finding Format bugs.

Fix a missing separator in ShowBackupOptions.  Example:

```
SHOW BACKUP 'family' IN ('string', 'placeholder', 'placeholder', 'placeholder', 'string', 'placeholder', 'string', 'placeholder') WITH incremental_location = 'nullif', privilegesdebug_dump_metadata_sst
```

Fix bad construction in ShowTenant.  Example:

```
SHOW TENANT [B'10010'] WITH REPLICATION STATUS WITH CAPABILITIES
```

Epic: none
Release note: None

### copy: fix copy grammar to match PG

Previously COPY would allow a wide range of syntax in the COPY
TO substatement.  Now like PG we limit it to a few things.

PG grammar is:
```
PreparableStmt:
                        SelectStmt
                        | InsertStmt
                        | UpdateStmt
                        | DeleteStmt
                        | MergeStmt
```

And now we do something similar. This prevents the wheels from coming
off when RSG generates EXPLAIN's in the substatement for instance.

Release note: none
Epic: none
