### PR TITLE
ci: create bazel-fips docker image

### DIFF
--- a/build/.bazelbuilderversion-fips
+++ b/build/.bazelbuilderversion-fips
@@ -1,0 +1,1 @@
+cockroachdb/bazel-fips:20230303-060247

--- a/build/bazelbuilder/Dockerfile.fips
+++ b/build/bazelbuilder/Dockerfile.fips
@@ -1,0 +1,5 @@
+ARG FROM_IMAGE
+FROM $FROM_IMAGE
+RUN apt-get update
+RUN --mount=source=./packages,target=/tmp/packages apt-get install -y /tmp/packages/*.deb 
+RUN apt-get clean

--- a/build/packer/setup_fips.sh
+++ b/build/packer/setup_fips.sh
@@ -2,3 +2,4 @@
 
 set -euo pipefail
 ua enable fips --assume-yes
+apt-get install -y dpkg-repack

--- a/build/teamcity-bazel-support.sh
+++ b/build/teamcity-bazel-support.sh
@@ -35,6 +35,10 @@ run_bazel() {
     return $exit_status
 }
 
+run_bazel_fips() {
+  BAZEL_IMAGE="$(cat $root/build/.bazelbuilderversion-fips)" run_bazel "$@"
+}
+
 # local copy of _tc_build_branch from teamcity-support.sh to avoid imports.
 _tc_build_branch() {
     echo "${TC_BUILD_BRANCH#refs/heads/}"

--- a/build/teamcity/internal/cockroach/build/ci/build-and-push-bazel-builder-image-fips.sh
+++ b/build/teamcity/internal/cockroach/build/ci/build-and-push-bazel-builder-image-fips.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -xeuo pipefail
+
+PKGDIR=build/bazelbuilder/packages
+mkdir $PKGDIR
+cd $PKGDIR
+# repackage FIPS-related packages. This operation has to happen on a FIPS-enabled host.
+for pkg in openssl libssl1.1 libssl1.1-hmac kcapi-tools libkcapi1; do
+    dpkg-repack "$pkg"
+done
+cd -
+
+TAG=$(cut -d: -f2 build/.bazelbuilderversion)
+DOCKER_BUILDKIT=1 docker build -t "cockroachdb/bazel-fips:$TAG" \
+    --build-arg FROM_IMAGE="cockroachdb/bazel:$TAG" \
+    -f build/bazelbuilder/Dockerfile.fips build/bazelbuilder
+docker push "cockroachdb/bazel-fips:$TAG"
+rm -rf $PKGDIR
+
+if [[ "$open_pr_on_success" == "true" ]]; then
+    # Trigger "Open New Bazel Builder Image PR".
+    curl -u "$TC_API_USER:$TC_API_PASSWORD" -X POST \
+      "https://$TC_SERVER_URL/app/rest/buildQueue" \
+      -H 'Accept: application/json' \
+      -H 'Content-Type: application/xml' \
+      -H "Host: $TC_SERVER_URL" \
+      -d '<build branchName="master">
+      <buildType id="Internal_Cockroach_Build_Ci_OpenNewBazelBuilderImagePr"/>
+       <properties>
+            <property name="env.BRANCH" value="'"bazel-builder-update-$TAG"'"/>
+            <property name="env.VERSION" value="'"cockroachdb/bazel-fips:$TAG"'"/>
+        </properties>
+    </build>'
+else
+	echo "No-op - opening a PR was not requested"
+fi

--- a/build/teamcity/internal/cockroach/build/ci/open-new-bazel-builder-image-pr.sh
+++ b/build/teamcity/internal/cockroach/build/ci/open-new-bazel-builder-image-pr.sh
@@ -32,8 +32,14 @@ git_ssh clone "ssh://git@github.com/cockroachdb/cockroach.git" "$WORKDIR/cockroa
 
 # Push commit to fork.
 git checkout -b "$BRANCH"
-echo -n "$VERSION" > build/.bazelbuilderversion
-git commit -a -m "ci: update bazel builder image
+if [[ $VERSION == *"-fips:"* ]]; then
+  IMG=bazel-fips
+  echo -n "$VERSION" > build/.bazelbuilderversion-fips
+else
+  IMG=bazel
+  echo -n "$VERSION" > build/.bazelbuilderversion
+fi
+git commit -a -m "ci: update $IMG builder image
 
 Release note: None
 Epic: None"


### PR DESCRIPTION
Previously, we use cockroachdb/bazel image to build and run our tests. In order to run FIPS tests, the image has to use particular FIPS-enabled packages.

This PR adds a new bazelbuilder image, that uses FIPS-compliant packages.

* Added `build/.bazelbuilderversion-fips` file.
* Added `run_bazel_fips` wrapper.
* The image builder script uses `dpkg-repack` to reproduce the same packages.

Epic: DEVINF-478
Release note: None