### PR TITLE
ci: add local roachtest wrappers

### DIFF
--- a/build/teamcity/cockroach/ci/tests/local_roachtest_fips.sh
+++ b/build/teamcity/cockroach/ci/tests/local_roachtest_fips.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+set -exuo pipefail
+
+dir="$(dirname $(dirname $(dirname $(dirname $(dirname "${0}")))))"
+
+source "$dir/teamcity-support.sh"  # For $root
+source "$dir/teamcity-bazel-support.sh"  # For run_bazel
+
+tc_start_block "Run local roachtests"
+BAZEL_SUPPORT_EXTRA_DOCKER_ARGS="-e COCKROACH_DEV_LICENSE -e BUILD_VCS_NUMBER -e TC_BUILD_ID -e TC_BUILD_BRANCH" \
+  run_bazel_fips build/teamcity/cockroach/ci/tests/local_roachtest_fips_impl.sh
+tc_end_block "Run local roachtests"

--- a/build/teamcity/cockroach/ci/tests/local_roachtest_fips_impl.sh
+++ b/build/teamcity/cockroach/ci/tests/local_roachtest_fips_impl.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+set -euox pipefail
+
+fips_enabled=$(cat /proc/sys/crypto/fips_enabled)
+
+if [[ $fips_enabled != "1" ]]; then
+  echo "FIPS mode is not enabled. Exiting."
+  exit 1
+fi
+
+export CROSSLINUX_CONFIG="crosslinuxfips"
+
+bazel build --config=$CROSSLINUX_CONFIG --config=ci //pkg/cmd/cockroach-short \
+      //pkg/cmd/roachtest \
+      //pkg/cmd/roachprod \
+      //pkg/cmd/workload
+
+BAZEL_BIN=$(bazel info bazel-bin --config=$CROSSLINUX_CONFIG --config=ci)
+
+# if there are any local clusters on this host, stop them before we
+# attempt to run acceptance tests. While this is generally not the
+# case, if a previous `roachtest` run was abruptly killed, the local
+# cluster would remain active and cause every test below to fail.
+$BAZEL_BIN/pkg/cmd/roachprod/roachprod_/roachprod destroy --all-local
+
+$BAZEL_BIN/pkg/cmd/roachtest/roachtest_/roachtest run acceptance kv/splits cdc/bank \
+  --local \
+  --parallelism=1 \
+  --cockroach "$BAZEL_BIN/pkg/cmd/cockroach-short/cockroach-short_/cockroach-short" \
+  --workload "$BAZEL_BIN/pkg/cmd/workload/workload_/workload" \
+  --artifacts /artifacts \
+  --teamcity


### PR DESCRIPTION
This PR add wrappers to run FIPS local roachtests in CI.

Epic: DEVINF-478
Informs: #98824
Release note: None