### PR TITLE
ui: update column selector button

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/columnsSelector/columnsSelector.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/columnsSelector/columnsSelector.module.scss
@@ -61,3 +61,8 @@
   position: absolute;
   z-index: 2;
 }
+
+.icon {
+  margin-top: 3px;
+  margin-right: 5px;
+}

--- a/pkg/ui/workspaces/cluster-ui/src/columnsSelector/columnsSelector.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/columnsSelector/columnsSelector.tsx
@@ -18,7 +18,7 @@ import {
   dropdownContentWrapper,
   hidden,
 } from "../queryFilter/filterClasses";
-import { List } from "@cockroachlabs/icons";
+import { Gear } from "@cockroachlabs/icons";
 import {
   DeselectOptionActionMeta,
   SelectOptionActionMeta,
@@ -233,7 +233,8 @@ export default class ColumnsSelector extends React.Component<
         className={cx("float")}
       >
         <Button type="secondary" size="small" onClick={this.toggleOpen}>
-          <List />
+          <Gear className={cx("icon")} />
+          Columns
         </Button>
         <div className={dropdownArea}>
           <div className={dropdownContentWrapper}>


### PR DESCRIPTION
Update column selector design to show gear icon
and "Columns".

<img width="187" alt="Screenshot 2023-03-16 at 8 22 38 PM" src="https://user-images.githubusercontent.com/1017486/225781537-6e4a849c-de17-4d62-a61f-5676e6a44a3e.png">


Epic: None

Release note (ui change): Update the column selector icon.