### PR TITLE
sql: do not propagate contention events as processor metadata

### DIFF
--- a/pkg/sql/colexecop/BUILD.bazel
+++ b/pkg/sql/colexecop/BUILD.bazel
@@ -13,7 +13,6 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/col/coldata",
-        "//pkg/kv/kvpb",
         "//pkg/sql/colexecerror",
         "//pkg/sql/colmem",
         "//pkg/sql/execinfra/execopnode",

--- a/pkg/sql/colexecop/operator.go
+++ b/pkg/sql/colexecop/operator.go
@@ -15,7 +15,6 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
-	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexecerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfra/execopnode"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
@@ -73,9 +72,9 @@ type KVReader interface {
 	// GetBatchRequestsIssued returns the number of BatchRequests issued to KV
 	// by this operator. It must be safe for concurrent use.
 	GetBatchRequestsIssued() int64
-	// GetContentionInfo returns the amount of time KV reads spent
+	// GetContentionTime returns the amount of time KV reads spent
 	// contending. It must be safe for concurrent use.
-	GetContentionInfo() (time.Duration, []kvpb.ContentionEvent)
+	GetContentionTime() time.Duration
 	// GetScanStats returns statistics about the scan that happened during the
 	// KV reads. It must be safe for concurrent use.
 	GetScanStats() execstats.ScanStats

--- a/pkg/sql/colfetcher/colbatch_scan.go
+++ b/pkg/sql/colfetcher/colbatch_scan.go
@@ -83,8 +83,8 @@ func (s *colBatchScanBase) GetRowsRead() int64 {
 	return s.mu.rowsRead
 }
 
-// GetContentionInfo is part of the colexecop.KVReader interface.
-func (s *colBatchScanBase) GetContentionInfo() (time.Duration, []kvpb.ContentionEvent) {
+// GetContentionTime is part of the colexecop.KVReader interface.
+func (s *colBatchScanBase) GetContentionTime() time.Duration {
 	return execstats.GetCumulativeContentionTime(s.Ctx, nil /* recording */)
 }
 

--- a/pkg/sql/colfetcher/index_join.go
+++ b/pkg/sql/colfetcher/index_join.go
@@ -19,7 +19,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
 	"github.com/cockroachdb/cockroach/pkg/col/typeconv"
 	"github.com/cockroachdb/cockroach/pkg/kv"
-	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descs"
@@ -406,8 +405,8 @@ func (s *ColIndexJoin) GetKVCPUTime() time.Duration {
 	return s.cf.cpuStopWatch.Elapsed()
 }
 
-// GetContentionInfo is part of the colexecop.KVReader interface.
-func (s *ColIndexJoin) GetContentionInfo() (time.Duration, []kvpb.ContentionEvent) {
+// GetContentionTime is part of the colexecop.KVReader interface.
+func (s *ColIndexJoin) GetContentionTime() time.Duration {
 	return execstats.GetCumulativeContentionTime(s.Ctx, nil /* recording */)
 }
 

--- a/pkg/sql/colflow/stats.go
+++ b/pkg/sql/colflow/stats.go
@@ -267,9 +267,7 @@ func (vsc *vectorizedStatsCollectorImpl) GetStats() *execinfrapb.ComponentStats 
 		s.KV.TuplesRead.Set(uint64(vsc.kvReader.GetRowsRead()))
 		s.KV.BytesRead.Set(uint64(vsc.kvReader.GetBytesRead()))
 		s.KV.BatchRequestsIssued.Set(uint64(vsc.kvReader.GetBatchRequestsIssued()))
-		totalContentionTime, events := vsc.kvReader.GetContentionInfo()
-		s.KV.ContentionTime.Set(totalContentionTime)
-		s.KV.ContentionEvents = events
+		s.KV.ContentionTime.Set(vsc.kvReader.GetContentionTime())
 		scanStats := vsc.kvReader.GetScanStats()
 		execstats.PopulateKVMVCCStats(&s.KV, &scanStats)
 		s.Exec.ConsumedRU.Set(scanStats.ConsumedRU)

--- a/pkg/sql/execinfrapb/component_stats.proto
+++ b/pkg/sql/execinfrapb/component_stats.proto
@@ -15,7 +15,6 @@ option go_package = "github.com/cockroachdb/cockroach/pkg/sql/execinfrapb";
 import "gogoproto/gogo.proto";
 
 import "util/optional/optional.proto";
-import "kv/kvpb/api.proto";
 
 // ComponentID identifies a component in a flow. There are multiple types of
 // components (e.g. processors, streams); each component of a certain type has
@@ -150,9 +149,6 @@ message KVStats {
   optional util.optional.Uint range_key_count = 18 [(gogoproto.nullable) = false];
   optional util.optional.Uint range_key_contained_points = 19 [(gogoproto.nullable) = false];
   optional util.optional.Uint range_key_skipped_points = 20 [(gogoproto.nullable) = false];
-
-  // contention_events hit at the statement level.
-  repeated cockroach.roachpb.ContentionEvent contention_events = 10 [(gogoproto.nullable) = false];
 
   // Cumulated CPU time spent fulfilling KV requests on a SQL goroutine. This
   // would not include CPU time spent on a remote node, but would include time

--- a/pkg/sql/execstats/stats.go
+++ b/pkg/sql/execstats/stats.go
@@ -30,20 +30,15 @@ func ShouldCollectStats(ctx context.Context, collectStats bool) bool {
 	return collectStats && tracing.SpanFromContext(ctx) != nil
 }
 
-// GetCumulativeContentionTime is a helper function to return all the contention
-// events from trace and the cumulative contention time. It calculates the
-// cumulative contention time from the given recording or, if the recording is
-// nil, from the tracing span from the context. All contention events found in
-// the trace are included.
-func GetCumulativeContentionTime(
-	ctx context.Context, recording tracingpb.Recording,
-) (time.Duration, []kvpb.ContentionEvent) {
+// GetCumulativeContentionTime is a helper function to return the cumulative
+// contention time. It calculates the cumulative contention time from the given
+// recording or, if the recording is nil, from the tracing span from the
+// context. All contention events found in the trace are included.
+func GetCumulativeContentionTime(ctx context.Context, recording tracingpb.Recording) time.Duration {
 	var cumulativeContentionTime time.Duration
 	if recording == nil {
-		recording = tracing.SpanFromContext(ctx).GetConfiguredRecording()
+		recording = tracing.SpanFromContext(ctx).GetRecording(tracingpb.RecordingStructured)
 	}
-
-	var contentionEvents []kvpb.ContentionEvent
 	var ev kvpb.ContentionEvent
 	for i := range recording {
 		recording[i].Structured(func(any *pbtypes.Any, _ time.Time) {
@@ -54,10 +49,9 @@ func GetCumulativeContentionTime(
 				return
 			}
 			cumulativeContentionTime += ev.Duration
-			contentionEvents = append(contentionEvents, ev)
 		})
 	}
-	return cumulativeContentionTime, contentionEvents
+	return cumulativeContentionTime
 }
 
 // ScanStats contains statistics on the internal MVCC operators used to satisfy

--- a/pkg/sql/rowexec/inverted_joiner.go
+++ b/pkg/sql/rowexec/inverted_joiner.go
@@ -763,15 +763,13 @@ func (ij *invertedJoiner) execStatsForTrace() *execinfrapb.ComponentStats {
 		return nil
 	}
 	ij.scanStats = execstats.GetScanStats(ij.Ctx(), ij.ExecStatsTrace)
-	contentionTime, contentionEvents := execstats.GetCumulativeContentionTime(ij.Ctx(), ij.ExecStatsTrace)
 	ret := execinfrapb.ComponentStats{
 		Inputs: []execinfrapb.InputStats{is},
 		KV: execinfrapb.KVStats{
 			BytesRead:           optional.MakeUint(uint64(ij.fetcher.GetBytesRead())),
 			TuplesRead:          fis.NumTuples,
 			KVTime:              fis.WaitTime,
-			ContentionTime:      optional.MakeTimeValue(contentionTime),
-			ContentionEvents:    contentionEvents,
+			ContentionTime:      optional.MakeTimeValue(execstats.GetCumulativeContentionTime(ij.Ctx(), ij.ExecStatsTrace)),
 			BatchRequestsIssued: optional.MakeUint(uint64(ij.fetcher.GetBatchRequestsIssued())),
 			KVCPUTime:           optional.MakeTimeValue(fis.kvCPUTime),
 		},

--- a/pkg/sql/rowexec/joinreader.go
+++ b/pkg/sql/rowexec/joinreader.go
@@ -1201,15 +1201,13 @@ func (jr *joinReader) execStatsForTrace() *execinfrapb.ComponentStats {
 	}
 
 	jr.scanStats = execstats.GetScanStats(jr.Ctx(), jr.ExecStatsTrace)
-	contentionTime, contentionEvents := execstats.GetCumulativeContentionTime(jr.Ctx(), jr.ExecStatsTrace)
 	ret := &execinfrapb.ComponentStats{
 		Inputs: []execinfrapb.InputStats{is},
 		KV: execinfrapb.KVStats{
 			BytesRead:           optional.MakeUint(uint64(jr.fetcher.GetBytesRead())),
 			TuplesRead:          fis.NumTuples,
 			KVTime:              fis.WaitTime,
-			ContentionTime:      optional.MakeTimeValue(contentionTime),
-			ContentionEvents:    contentionEvents,
+			ContentionTime:      optional.MakeTimeValue(execstats.GetCumulativeContentionTime(jr.Ctx(), jr.ExecStatsTrace)),
 			BatchRequestsIssued: optional.MakeUint(uint64(jr.fetcher.GetBatchRequestsIssued())),
 			KVCPUTime:           optional.MakeTimeValue(fis.kvCPUTime),
 		},

--- a/pkg/sql/rowexec/tablereader.go
+++ b/pkg/sql/rowexec/tablereader.go
@@ -307,14 +307,12 @@ func (tr *tableReader) execStatsForTrace() *execinfrapb.ComponentStats {
 		return nil
 	}
 	tr.scanStats = execstats.GetScanStats(tr.Ctx(), tr.ExecStatsTrace)
-	contentionTime, contentionEvents := execstats.GetCumulativeContentionTime(tr.Ctx(), tr.ExecStatsTrace)
 	ret := &execinfrapb.ComponentStats{
 		KV: execinfrapb.KVStats{
 			BytesRead:           optional.MakeUint(uint64(tr.fetcher.GetBytesRead())),
 			TuplesRead:          is.NumTuples,
 			KVTime:              is.WaitTime,
-			ContentionTime:      optional.MakeTimeValue(contentionTime),
-			ContentionEvents:    contentionEvents,
+			ContentionTime:      optional.MakeTimeValue(execstats.GetCumulativeContentionTime(tr.Ctx(), tr.ExecStatsTrace)),
 			BatchRequestsIssued: optional.MakeUint(uint64(tr.fetcher.GetBatchRequestsIssued())),
 			KVCPUTime:           optional.MakeTimeValue(is.kvCPUTime),
 		},

--- a/pkg/sql/rowexec/zigzagjoiner.go
+++ b/pkg/sql/rowexec/zigzagjoiner.go
@@ -845,11 +845,9 @@ func (z *zigzagJoiner) ConsumerClosed() {
 func (z *zigzagJoiner) execStatsForTrace() *execinfrapb.ComponentStats {
 	z.scanStats = execstats.GetScanStats(z.Ctx(), z.ExecStatsTrace)
 
-	contentionTime, contentionEvents := execstats.GetCumulativeContentionTime(z.Ctx(), z.ExecStatsTrace)
 	kvStats := execinfrapb.KVStats{
 		BytesRead:           optional.MakeUint(uint64(z.getBytesRead())),
-		ContentionTime:      optional.MakeTimeValue(contentionTime),
-		ContentionEvents:    contentionEvents,
+		ContentionTime:      optional.MakeTimeValue(execstats.GetCumulativeContentionTime(z.Ctx(), z.ExecStatsTrace)),
 		BatchRequestsIssued: optional.MakeUint(uint64(z.getBatchRequestsIssued())),
 	}
 	execstats.PopulateKVMVCCStats(&kvStats, &z.scanStats)


### PR DESCRIPTION
This commit switches the way contention events are obtained for the query level stats. Previously, every processor was responsible for accumulating the contention events it encountered and then attaching all of them to the `KVStats` part of the "execution metadata". This results in the contention events being propagated twice - once via the metadata, and the second time via the structured events of the trace. This commit makes it so that at the end of the query execution we analyze the trace to extract all contention events (i.e. to use the latter), so we can remove the former. This isn't a big deal on its own, but it seems cleaner this way.

Epic: None

Release note: None