### PR TITLE
sql: improve how tracing of processors is done on the gateway node

### DIFF
--- a/build/bazelutil/nogo_config.json
+++ b/build/bazelutil/nogo_config.json
@@ -740,6 +740,7 @@
             "pkg/server/dumpstore/dumpstore.go$": "excluded until all uses of io/ioutil are replaced",
             "pkg/server/dumpstore/dumpstore_test.go$": "excluded until all uses of io/ioutil are replaced",
             "pkg/server/profiler/profilestore_test.go$": "excluded until all uses of io/ioutil are replaced",
+            "pkg/util/bulk/tracing_aggregator.go$":"temporary exclusion until #100438 is resolved",
             "pkg/util/log/file_api.go$": "excluded until all uses of io/ioutil are replaced",
             "pkg/build/bazel/bazel\\.go$": "Runfile function deprecated"
         },

--- a/pkg/kv/bulk/bulkpb/ingestion_performance_stats.go
+++ b/pkg/kv/bulk/bulkpb/ingestion_performance_stats.go
@@ -271,5 +271,3 @@ type timing time.Duration
 
 func (t timing) String() string { return time.Duration(t).Round(time.Second).String() }
 func (t timing) SafeValue()     {}
-
-var _ bulk.TracingAggregatorEvent = &IngestionPerformanceStats{}

--- a/pkg/sql/colexec/colbuilder/execplan.go
+++ b/pkg/sql/colexec/colbuilder/execplan.go
@@ -438,6 +438,8 @@ func (r opResult) createDiskBackedSort(
 			outputUnlimitedAllocator := colmem.NewAllocator(ctx, accounts[2], factory)
 			diskAccount := args.MonitorRegistry.CreateDiskAccount(ctx, flowCtx, opName, processorID)
 			es := colexecdisk.NewExternalSorter(
+				flowCtx,
+				processorID,
 				sortUnlimitedAllocator,
 				mergeUnlimitedAllocator,
 				outputUnlimitedAllocator,
@@ -922,7 +924,7 @@ func NewColOperator(
 				if canUseDirectScan() {
 					scanOp, resultTypes, err = colfetcher.NewColBatchDirectScan(
 						ctx, colmem.NewAllocator(ctx, accounts[0], factory), accounts[1],
-						flowCtx, core.TableReader, post, args.TypeResolver,
+						flowCtx, spec.ProcessorID, core.TableReader, post, args.TypeResolver,
 					)
 					if err != nil {
 						return r, err
@@ -932,7 +934,7 @@ func NewColOperator(
 			if scanOp == nil {
 				scanOp, resultTypes, err = colfetcher.NewColBatchScan(
 					ctx, colmem.NewAllocator(ctx, accounts[0], factory), accounts[1],
-					flowCtx, core.TableReader, post, estimatedRowCount, args.TypeResolver,
+					flowCtx, spec.ProcessorID, core.TableReader, post, estimatedRowCount, args.TypeResolver,
 				)
 				if err != nil {
 					return r, err
@@ -965,7 +967,7 @@ func NewColOperator(
 			indexJoinOp, err := colfetcher.NewColIndexJoin(
 				ctx, getStreamingAllocator(ctx, args),
 				colmem.NewAllocator(ctx, accounts[0], factory),
-				accounts[1], accounts[2], flowCtx,
+				accounts[1], accounts[2], flowCtx, spec.ProcessorID,
 				inputs[0].Root, core.JoinReader, post, inputTypes,
 				streamerDiskMonitor, args.TypeResolver,
 			)

--- a/pkg/sql/colexec/colexecbase/simple_project_test.go
+++ b/pkg/sql/colexec/colexecbase/simple_project_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/colexec/colexecbase"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexec/colexectestutils"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexecop"
+	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -121,7 +122,7 @@ func TestSimpleProjectOpWithUnorderedSynchronizer(t *testing.T) {
 			for i := range parallelUnorderedSynchronizerInputs {
 				parallelUnorderedSynchronizerInputs[i].Root = inputs[i]
 			}
-			input = colexec.NewParallelUnorderedSynchronizer(testAllocator, parallelUnorderedSynchronizerInputs, &wg)
+			input = colexec.NewParallelUnorderedSynchronizer(&execinfra.FlowCtx{Local: true, Gateway: true}, 0 /* processorID */, testAllocator, parallelUnorderedSynchronizerInputs, &wg)
 			input = colexecbase.NewSimpleProjectOp(input, len(inputTypes), []uint32{0})
 			return colexecbase.NewConstOp(testAllocator, input, types.Int, constVal, 1)
 		})

--- a/pkg/sql/colexec/colexecdisk/external_sort.go
+++ b/pkg/sql/colexec/colexecdisk/external_sort.go
@@ -117,6 +117,8 @@ type externalSorter struct {
 	colexecop.InitHelper
 	colexecop.NonExplainable
 	colexecop.CloserHelper
+	flowCtx     *execinfra.FlowCtx
+	processorID int32
 
 	// mergeUnlimitedAllocator is used to track the memory under the batches
 	// dequeued from partitions during the merge operation.
@@ -220,6 +222,8 @@ var _ colexecop.ClosableOperator = &externalSorter{}
 // the partitioned disk queue acquire file descriptors instead of acquiring
 // them up front in Next. This should only be true in tests.
 func NewExternalSorter(
+	flowCtx *execinfra.FlowCtx,
+	processorID int32,
 	sortUnlimitedAllocator *colmem.Allocator,
 	mergeUnlimitedAllocator *colmem.Allocator,
 	outputUnlimitedAllocator *colmem.Allocator,
@@ -298,6 +302,8 @@ func NewExternalSorter(
 	}
 	es := &externalSorter{
 		OneInputNode:             colexecop.NewOneInputNode(inMemSorter),
+		flowCtx:                  flowCtx,
+		processorID:              processorID,
 		mergeUnlimitedAllocator:  mergeUnlimitedAllocator,
 		outputUnlimitedAllocator: outputUnlimitedAllocator,
 		mergeMemoryLimit:         mergeMemoryLimit,
@@ -711,8 +717,8 @@ func (s *externalSorter) createMergerForPartitions(n int) *colexec.OrderedSynchr
 		outputBatchMemSize = minOutputBatchMemSize
 	}
 	return colexec.NewOrderedSynchronizer(
-		s.outputUnlimitedAllocator, outputBatchMemSize, syncInputs,
-		s.inputTypes, s.columnOrdering, tuplesToMerge,
+		s.flowCtx, s.processorID, s.outputUnlimitedAllocator, outputBatchMemSize,
+		syncInputs, s.inputTypes, s.columnOrdering, tuplesToMerge,
 	)
 }
 

--- a/pkg/sql/colexec/ordered_synchronizer.eg.go
+++ b/pkg/sql/colexec/ordered_synchronizer.eg.go
@@ -36,7 +36,9 @@ import (
 // stream are assumed to be ordered according to the same set of columns.
 type OrderedSynchronizer struct {
 	colexecop.InitHelper
-	span *tracing.Span
+	flowCtx     *execinfra.FlowCtx
+	processorID int32
+	span        *tracing.Span
 
 	accountingHelper      colmem.SetAccountingHelper
 	inputs                []colexecargs.OpWithMetaInfo
@@ -86,6 +88,8 @@ func (o *OrderedSynchronizer) Child(nth int, verbose bool) execopnode.OpNode {
 // - tuplesToMerge, if positive, indicates the total number of tuples that will
 // be emitted by all inputs, use 0 if unknown.
 func NewOrderedSynchronizer(
+	flowCtx *execinfra.FlowCtx,
+	processorID int32,
 	allocator *colmem.Allocator,
 	memoryLimit int64,
 	inputs []colexecargs.OpWithMetaInfo,
@@ -94,6 +98,8 @@ func NewOrderedSynchronizer(
 	tuplesToMerge int64,
 ) *OrderedSynchronizer {
 	os := &OrderedSynchronizer{
+		flowCtx:               flowCtx,
+		processorID:           processorID,
 		inputs:                inputs,
 		ordering:              ordering,
 		typs:                  typs,
@@ -284,7 +290,7 @@ func (o *OrderedSynchronizer) Init(ctx context.Context) {
 	if !o.InitHelper.Init(ctx) {
 		return
 	}
-	o.Ctx, o.span = execinfra.ProcessorSpan(o.Ctx, "ordered sync")
+	o.Ctx, o.span = execinfra.ProcessorSpan(o.Ctx, o.flowCtx, "ordered sync", o.processorID)
 	o.inputIndices = make([]int, len(o.inputs))
 	for i := range o.inputs {
 		o.inputs[i].Root.Init(o.Ctx)
@@ -304,7 +310,7 @@ func (o *OrderedSynchronizer) DrainMeta() []execinfrapb.ProducerMetadata {
 				o.span.RecordStructured(stats.GetStats())
 			}
 		}
-		if meta := execinfra.GetTraceDataAsMetadata(o.span); meta != nil {
+		if meta := execinfra.GetTraceDataAsMetadata(o.flowCtx, o.span); meta != nil {
 			bufferedMeta = append(bufferedMeta, *meta)
 		}
 	}

--- a/pkg/sql/colexec/ordered_synchronizer_test.go
+++ b/pkg/sql/colexec/ordered_synchronizer_test.go
@@ -148,7 +148,7 @@ func TestOrderedSync(t *testing.T) {
 			typs[i] = types.Int
 		}
 		colexectestutils.RunTests(t, testAllocator, tc.sources, tc.expected, colexectestutils.OrderedVerifier, func(inputs []colexecop.Operator) (colexecop.Operator, error) {
-			return NewOrderedSynchronizer(testAllocator, execinfra.DefaultMemoryLimit, colexectestutils.MakeInputs(inputs), typs, tc.ordering, 0 /* tuplesToMerge */), nil
+			return NewOrderedSynchronizer(&execinfra.FlowCtx{Gateway: true}, 0 /* processorID */, testAllocator, execinfra.DefaultMemoryLimit, colexectestutils.MakeInputs(inputs), typs, tc.ordering, 0 /* tuplesToMerge */), nil
 		})
 	}
 }
@@ -189,7 +189,7 @@ func TestOrderedSyncRandomInput(t *testing.T) {
 		inputs[i].Root = colexectestutils.NewOpTestInput(testAllocator, batchSize, sources[i], typs)
 	}
 	ordering := colinfo.ColumnOrdering{{ColIdx: 0, Direction: encoding.Ascending}}
-	op := NewOrderedSynchronizer(testAllocator, execinfra.DefaultMemoryLimit, inputs, typs, ordering, 0 /* tuplesToMerge */)
+	op := NewOrderedSynchronizer(&execinfra.FlowCtx{Gateway: true}, 0 /* processorID */, testAllocator, execinfra.DefaultMemoryLimit, inputs, typs, ordering, 0 /* tuplesToMerge */)
 	op.Init(context.Background())
 	out := colexectestutils.NewOpTestOutput(op, expected)
 	if err := out.Verify(); err != nil {
@@ -218,7 +218,7 @@ func BenchmarkOrderedSynchronizer(b *testing.B) {
 	}
 
 	ordering := colinfo.ColumnOrdering{{ColIdx: 0, Direction: encoding.Ascending}}
-	op := NewOrderedSynchronizer(testAllocator, execinfra.DefaultMemoryLimit, inputs, typs, ordering, 0 /* tuplesToMerge */)
+	op := NewOrderedSynchronizer(&execinfra.FlowCtx{Gateway: true}, 0 /* processorID */, testAllocator, execinfra.DefaultMemoryLimit, inputs, typs, ordering, 0 /* tuplesToMerge */)
 	op.Init(ctx)
 
 	b.SetBytes(8 * int64(coldata.BatchSize()) * numInputs)

--- a/pkg/sql/colexec/ordered_synchronizer_tmpl.go
+++ b/pkg/sql/colexec/ordered_synchronizer_tmpl.go
@@ -57,7 +57,9 @@ const _TYPE_WIDTH = 0
 // stream are assumed to be ordered according to the same set of columns.
 type OrderedSynchronizer struct {
 	colexecop.InitHelper
-	span *tracing.Span
+	flowCtx     *execinfra.FlowCtx
+	processorID int32
+	span        *tracing.Span
 
 	accountingHelper      colmem.SetAccountingHelper
 	inputs                []colexecargs.OpWithMetaInfo
@@ -107,6 +109,8 @@ func (o *OrderedSynchronizer) Child(nth int, verbose bool) execopnode.OpNode {
 // - tuplesToMerge, if positive, indicates the total number of tuples that will
 // be emitted by all inputs, use 0 if unknown.
 func NewOrderedSynchronizer(
+	flowCtx *execinfra.FlowCtx,
+	processorID int32,
 	allocator *colmem.Allocator,
 	memoryLimit int64,
 	inputs []colexecargs.OpWithMetaInfo,
@@ -115,6 +119,8 @@ func NewOrderedSynchronizer(
 	tuplesToMerge int64,
 ) *OrderedSynchronizer {
 	os := &OrderedSynchronizer{
+		flowCtx:               flowCtx,
+		processorID:           processorID,
 		inputs:                inputs,
 		ordering:              ordering,
 		typs:                  typs,
@@ -232,7 +238,7 @@ func (o *OrderedSynchronizer) Init(ctx context.Context) {
 	if !o.InitHelper.Init(ctx) {
 		return
 	}
-	o.Ctx, o.span = execinfra.ProcessorSpan(o.Ctx, "ordered sync")
+	o.Ctx, o.span = execinfra.ProcessorSpan(o.Ctx, o.flowCtx, "ordered sync", o.processorID)
 	o.inputIndices = make([]int, len(o.inputs))
 	for i := range o.inputs {
 		o.inputs[i].Root.Init(o.Ctx)
@@ -252,7 +258,7 @@ func (o *OrderedSynchronizer) DrainMeta() []execinfrapb.ProducerMetadata {
 				o.span.RecordStructured(stats.GetStats())
 			}
 		}
-		if meta := execinfra.GetTraceDataAsMetadata(o.span); meta != nil {
+		if meta := execinfra.GetTraceDataAsMetadata(o.flowCtx, o.span); meta != nil {
 			bufferedMeta = append(bufferedMeta, *meta)
 		}
 	}

--- a/pkg/sql/colexec/parallel_unordered_synchronizer.go
+++ b/pkg/sql/colexec/parallel_unordered_synchronizer.go
@@ -66,16 +66,15 @@ const (
 type ParallelUnorderedSynchronizer struct {
 	colexecop.InitHelper
 
-	allocator *colmem.Allocator
-	inputs    []colexecargs.OpWithMetaInfo
-	inputCtxs []context.Context
+	flowCtx     *execinfra.FlowCtx
+	processorID int32
+	allocator   *colmem.Allocator
+	inputs      []colexecargs.OpWithMetaInfo
+	inputCtxs   []context.Context
 	// cancelLocalInput stores context cancellation functions for each of the
-	// inputs. The functions are populated only if LocalPlan is true.
+	// inputs. The functions are populated only if localPlan is true.
 	cancelLocalInput []context.CancelFunc
-	// LocalPlan indicates whether this synchronizer is a part of the fully
-	// local plan.
-	LocalPlan    bool
-	tracingSpans []*tracing.Span
+	tracingSpans     []*tracing.Span
 	// readNextBatch is a slice of channels, where each channel corresponds to the
 	// input at the same index in inputs. It is used as a barrier for input
 	// goroutines to wait on until the Next goroutine signals that it is safe to
@@ -134,7 +133,11 @@ func (s *ParallelUnorderedSynchronizer) Child(nth int, verbose bool) execopnode.
 // zero-length batch received from Next.
 // - allocator must use a memory account that is not shared with any other user.
 func NewParallelUnorderedSynchronizer(
-	allocator *colmem.Allocator, inputs []colexecargs.OpWithMetaInfo, wg *sync.WaitGroup,
+	flowCtx *execinfra.FlowCtx,
+	processorID int32,
+	allocator *colmem.Allocator,
+	inputs []colexecargs.OpWithMetaInfo,
+	wg *sync.WaitGroup,
 ) *ParallelUnorderedSynchronizer {
 	readNextBatch := make([]chan struct{}, len(inputs))
 	for i := range readNextBatch {
@@ -143,6 +146,8 @@ func NewParallelUnorderedSynchronizer(
 		readNextBatch[i] = make(chan struct{}, 1)
 	}
 	return &ParallelUnorderedSynchronizer{
+		flowCtx:           flowCtx,
+		processorID:       processorID,
 		allocator:         allocator,
 		inputs:            inputs,
 		inputCtxs:         make([]context.Context, len(inputs)),
@@ -172,13 +177,15 @@ func (s *ParallelUnorderedSynchronizer) Init(ctx context.Context) {
 		return
 	}
 	for i, input := range s.inputs {
-		s.inputCtxs[i], s.tracingSpans[i] = execinfra.ProcessorSpan(s.Ctx, fmt.Sprintf("parallel unordered sync input %d", i))
-		if s.LocalPlan {
-			// If there plan is local, there are no colrpc.Inboxes in this input
+		s.inputCtxs[i], s.tracingSpans[i] = execinfra.ProcessorSpan(
+			s.Ctx, s.flowCtx, fmt.Sprintf("parallel unordered sync input %d", i), s.processorID,
+		)
+		if s.flowCtx.Local {
+			// If the plan is local, there are no colrpc.Inboxes in this input
 			// tree, and the synchronizer can cancel the current work eagerly
 			// when transitioning into draining.
 			//
-			// If there plan is distributed, there might be an inbox in the
+			// If the plan is distributed, there might be an inbox in the
 			// input tree, and the synchronizer cannot cancel the work eagerly
 			// because canceling the context would break the gRPC stream and
 			// make it impossible to fetch the remote metadata. Furthermore, it
@@ -287,7 +294,7 @@ func (s *ParallelUnorderedSynchronizer) init() {
 						for _, s := range input.StatsCollectors {
 							span.RecordStructured(s.GetStats())
 						}
-						if meta := execinfra.GetTraceDataAsMetadata(span); meta != nil {
+						if meta := execinfra.GetTraceDataAsMetadata(s.flowCtx, span); meta != nil {
 							msg.meta = append(msg.meta, *meta)
 						}
 					}

--- a/pkg/sql/colexec/serial_unordered_synchronizer_test.go
+++ b/pkg/sql/colexec/serial_unordered_synchronizer_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/colexec/colexecargs"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexec/colexectestutils"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexecop"
+	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
@@ -54,7 +55,10 @@ func TestSerialUnorderedSynchronizer(t *testing.T) {
 			},
 		}
 	}
-	s := NewSerialUnorderedSynchronizer(inputs,
+	s := NewSerialUnorderedSynchronizer(
+		&execinfra.FlowCtx{Gateway: true},
+		0, /* processorID */
+		inputs,
 		0,   /* serialInputIdxExclusiveUpperBound */
 		nil, /* exceedsInputIdxExclusiveUpperBoundError */
 	)

--- a/pkg/sql/colexecop/operator.go
+++ b/pkg/sql/colexecop/operator.go
@@ -78,6 +78,9 @@ type KVReader interface {
 	// GetScanStats returns statistics about the scan that happened during the
 	// KV reads. It must be safe for concurrent use.
 	GetScanStats() execstats.ScanStats
+	// GetConsumedRU returns the number of RUs that were consumed during the
+	// KV reads.
+	GetConsumedRU() uint64
 	// GetKVCPUTime returns the CPU time consumed *on the current goroutine* by
 	// KV requests. It must be safe for concurrent use. It is used to calculate
 	// the SQL CPU time.

--- a/pkg/sql/colfetcher/colbatch_direct_scan.go
+++ b/pkg/sql/colfetcher/colbatch_direct_scan.go
@@ -57,11 +57,10 @@ func (s *ColBatchDirectScan) Init(ctx context.Context) {
 	if !s.InitHelper.Init(ctx) {
 		return
 	}
-	// If tracing is enabled, we need to start a child span so that the only
-	// contention events present in the recording would be because of this
-	// fetcher. Note that ProcessorSpan method itself will check whether tracing
-	// is enabled.
-	s.Ctx, s.tracingSpan = execinfra.ProcessorSpan(s.Ctx, s.flowCtx, "colbatchdirectscan", s.processorID)
+	s.Ctx, s.tracingSpan = execinfra.ProcessorSpan(
+		s.Ctx, s.flowCtx, "colbatchdirectscan", s.processorID,
+		&s.contentionEventsListener, &s.scanStatsListener, &s.tenantConsumptionListener,
+	)
 	firstBatchLimit := cFetcherFirstBatchLimit(s.limitHint, s.spec.MaxKeysPerRow)
 	err := s.fetcher.SetupNextFetch(
 		ctx, s.Spans, nil /* spanIDs */, s.batchBytesLimit, firstBatchLimit, false, /* spansCanOverlap */
@@ -146,6 +145,9 @@ func (s *ColBatchDirectScan) GetBytesRead() int64 {
 func (s *ColBatchDirectScan) GetBatchRequestsIssued() int64 {
 	return s.fetcher.GetBatchRequestsIssued()
 }
+
+// TODO(yuzefovich): check whether GetScanStats and GetConsumedRU should be
+// reimplemented.
 
 // GetKVCPUTime is part of the colexecop.KVReader interface.
 //

--- a/pkg/sql/colfetcher/colbatch_direct_scan.go
+++ b/pkg/sql/colfetcher/colbatch_direct_scan.go
@@ -61,7 +61,7 @@ func (s *ColBatchDirectScan) Init(ctx context.Context) {
 	// contention events present in the recording would be because of this
 	// fetcher. Note that ProcessorSpan method itself will check whether tracing
 	// is enabled.
-	s.Ctx, s.tracingSpan = execinfra.ProcessorSpan(s.Ctx, "colbatchdirectscan")
+	s.Ctx, s.tracingSpan = execinfra.ProcessorSpan(s.Ctx, s.flowCtx, "colbatchdirectscan", s.processorID)
 	firstBatchLimit := cFetcherFirstBatchLimit(s.limitHint, s.spec.MaxKeysPerRow)
 	err := s.fetcher.SetupNextFetch(
 		ctx, s.Spans, nil /* spanIDs */, s.batchBytesLimit, firstBatchLimit, false, /* spansCanOverlap */
@@ -178,12 +178,13 @@ func NewColBatchDirectScan(
 	allocator *colmem.Allocator,
 	kvFetcherMemAcc *mon.BoundAccount,
 	flowCtx *execinfra.FlowCtx,
+	processorID int32,
 	spec *execinfrapb.TableReaderSpec,
 	post *execinfrapb.PostProcessSpec,
 	typeResolver *descs.DistSQLTypeResolver,
 ) (*ColBatchDirectScan, []*types.T, error) {
 	base, bsHeader, tableArgs, err := newColBatchScanBase(
-		ctx, kvFetcherMemAcc, flowCtx, spec, post, typeResolver,
+		ctx, kvFetcherMemAcc, flowCtx, processorID, spec, post, typeResolver,
 	)
 	if err != nil {
 		return nil, nil, err

--- a/pkg/sql/colfetcher/colbatch_scan.go
+++ b/pkg/sql/colfetcher/colbatch_scan.go
@@ -74,8 +74,10 @@ func (s *colBatchScanBase) drainMeta() []execinfrapb.ProducerMetadata {
 	if tfs := execinfra.GetLeafTxnFinalState(s.Ctx, s.flowCtx.Txn); tfs != nil {
 		trailingMeta = append(trailingMeta, execinfrapb.ProducerMetadata{LeafTxnFinalState: tfs})
 	}
-	if trace := tracing.SpanFromContext(s.Ctx).GetConfiguredRecording(); trace != nil {
-		trailingMeta = append(trailingMeta, execinfrapb.ProducerMetadata{TraceData: trace})
+	if !s.flowCtx.Gateway {
+		if trace := tracing.SpanFromContext(s.Ctx).GetConfiguredRecording(); trace != nil {
+			trailingMeta = append(trailingMeta, execinfrapb.ProducerMetadata{TraceData: trace})
+		}
 	}
 	return trailingMeta
 }

--- a/pkg/sql/colfetcher/index_join.go
+++ b/pkg/sql/colfetcher/index_join.go
@@ -376,8 +376,10 @@ func (s *ColIndexJoin) DrainMeta() []execinfrapb.ProducerMetadata {
 	meta.Metrics.BytesRead = s.GetBytesRead()
 	meta.Metrics.RowsRead = s.GetRowsRead()
 	trailingMeta = append(trailingMeta, *meta)
-	if trace := tracing.SpanFromContext(s.Ctx).GetConfiguredRecording(); trace != nil {
-		trailingMeta = append(trailingMeta, execinfrapb.ProducerMetadata{TraceData: trace})
+	if !s.flowCtx.Gateway {
+		if trace := tracing.SpanFromContext(s.Ctx).GetConfiguredRecording(); trace != nil {
+			trailingMeta = append(trailingMeta, execinfrapb.ProducerMetadata{TraceData: trace})
+		}
 	}
 	return trailingMeta
 }

--- a/pkg/sql/colflow/BUILD.bazel
+++ b/pkg/sql/colflow/BUILD.bazel
@@ -63,7 +63,6 @@ go_library(
         "@com_github_cockroachdb_logtags//:logtags",
         "@com_github_cockroachdb_redact//:redact",
         "@com_github_marusama_semaphore//:semaphore",
-        "@io_opentelemetry_go_otel//attribute",
     ],
 )
 
@@ -142,7 +141,6 @@ go_test(
         "//pkg/util/stop",
         "//pkg/util/syncutil",
         "//pkg/util/timeutil",
-        "//pkg/util/uuid",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_stretchr_testify//require",
     ],

--- a/pkg/sql/colflow/colrpc/BUILD.bazel
+++ b/pkg/sql/colflow/colrpc/BUILD.bazel
@@ -73,7 +73,6 @@ go_test(
         "//pkg/util/randutil",
         "//pkg/util/stop",
         "//pkg/util/timeutil",
-        "//pkg/util/uuid",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_cockroachdb_logtags//:logtags",
         "@com_github_stretchr_testify//require",

--- a/pkg/sql/colflow/colrpc/colrpc_test.go
+++ b/pkg/sql/colflow/colrpc/colrpc_test.go
@@ -40,7 +40,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
-	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/logtags"
 	"github.com/stretchr/testify/require"
@@ -278,6 +277,8 @@ func TestOutboxInbox(t *testing.T) {
 			outboxConverterMemAcc := testMemMonitor.MakeBoundAccount()
 			defer outboxConverterMemAcc.Close(ctx)
 			outbox, err := NewOutbox(
+				&execinfra.FlowCtx{Gateway: false},
+				0, /* processorID */
 				colmem.NewAllocator(outboxCtx, &outboxMemAcc, coldata.StandardColumnFactory),
 				&outboxConverterMemAcc, colexecargs.OpWithMetaInfo{Root: input}, typs, nil, /* getStats */
 			)
@@ -521,6 +522,8 @@ func TestInboxHostCtxCancellation(t *testing.T) {
 	outboxMemAcc := testMemMonitor.MakeBoundAccount()
 	defer outboxMemAcc.Close(outboxHostCtx)
 	outbox, err := NewOutbox(
+		&execinfra.FlowCtx{Gateway: false},
+		0, /* processorID */
 		colmem.NewAllocator(outboxHostCtx, &outboxMemAcc, coldata.StandardColumnFactory),
 		testMemAcc, colexecargs.OpWithMetaInfo{Root: outboxInput}, typs, nil, /* getStats */
 	)
@@ -702,6 +705,8 @@ func TestOutboxInboxMetadataPropagation(t *testing.T) {
 				expectedMetadata = tc.overrideExpectedMetadata
 			}
 			outbox, err := NewOutbox(
+				&execinfra.FlowCtx{Gateway: false},
+				0, /* processorID */
 				colmem.NewAllocator(ctx, &outboxMemAcc, coldata.StandardColumnFactory),
 				testMemAcc,
 				colexecargs.OpWithMetaInfo{
@@ -798,6 +803,8 @@ func BenchmarkOutboxInbox(b *testing.B) {
 	outboxMemAcc := testMemMonitor.MakeBoundAccount()
 	defer outboxMemAcc.Close(ctx)
 	outbox, err := NewOutbox(
+		&execinfra.FlowCtx{Gateway: false},
+		0, /* processorID */
 		colmem.NewAllocator(ctx, &outboxMemAcc, coldata.StandardColumnFactory),
 		testMemAcc, colexecargs.OpWithMetaInfo{Root: input}, typs, nil, /* getStats */
 	)
@@ -863,6 +870,8 @@ func TestOutboxStreamIDPropagation(t *testing.T) {
 	outboxMemAcc := testMemMonitor.MakeBoundAccount()
 	defer outboxMemAcc.Close(ctx)
 	outbox, err := NewOutbox(
+		&execinfra.FlowCtx{Gateway: false},
+		0, /* processorID */
 		colmem.NewAllocator(ctx, &outboxMemAcc, coldata.StandardColumnFactory),
 		testMemAcc, colexecargs.OpWithMetaInfo{Root: input}, typs, nil, /* getStats */
 	)
@@ -874,7 +883,6 @@ func TestOutboxStreamIDPropagation(t *testing.T) {
 			ctx,
 			dialer,
 			base.SQLInstanceID(0),
-			execinfrapb.FlowID{UUID: uuid.MakeV4()},
 			outboxStreamID,
 			nil, /* flowCtxCancel */
 			0,   /* connectionTimeout */

--- a/pkg/sql/colflow/colrpc/outbox.go
+++ b/pkg/sql/colflow/colrpc/outbox.go
@@ -346,14 +346,16 @@ func (o *Outbox) sendMetadata(ctx context.Context, stream flowStreamClient, errT
 			msg.Data.Metadata = append(msg.Data.Metadata, execinfrapb.LocalMetaToRemoteProducerMeta(ctx, meta))
 		}
 	}
-	if trace := tracing.SpanFromContext(ctx).GetConfiguredRecording(); trace != nil {
-		msg.Data.Metadata = append(msg.Data.Metadata, execinfrapb.RemoteProducerMetadata{
-			Value: &execinfrapb.RemoteProducerMetadata_TraceData_{
-				TraceData: &execinfrapb.RemoteProducerMetadata_TraceData{
-					CollectedSpans: trace,
+	if !o.flowCtx.Gateway {
+		if trace := tracing.SpanFromContext(ctx).GetConfiguredRecording(); trace != nil {
+			msg.Data.Metadata = append(msg.Data.Metadata, execinfrapb.RemoteProducerMetadata{
+				Value: &execinfrapb.RemoteProducerMetadata_TraceData_{
+					TraceData: &execinfrapb.RemoteProducerMetadata_TraceData{
+						CollectedSpans: trace,
+					},
 				},
-			},
-		})
+			})
+		}
 	}
 	if len(msg.Data.Metadata) == 0 {
 		return nil

--- a/pkg/sql/colflow/colrpc/outbox.go
+++ b/pkg/sql/colflow/colrpc/outbox.go
@@ -48,6 +48,8 @@ type flowStreamClient interface {
 // given remote endpoint.
 type Outbox struct {
 	colexecop.OneInputNode
+	flowCtx     *execinfra.FlowCtx
+	processorID int32
 	// inputMetaInfo contains all of the meta components that the outbox is
 	// responsible for. OneInputNode.Input is the deselector operator with Root
 	// field as its input. Notably StatsCollectors are not accessed directly -
@@ -85,6 +87,8 @@ type Outbox struct {
 //   - getStats, when non-nil, returns all of the execution statistics of the
 //     operators that are in the same tree as this Outbox.
 func NewOutbox(
+	flowCtx *execinfra.FlowCtx,
+	processorID int32,
 	unlimitedAllocator *colmem.Allocator,
 	converterMemAcc *mon.BoundAccount,
 	input colexecargs.OpWithMetaInfo,
@@ -103,6 +107,8 @@ func NewOutbox(
 		// Add a deselector as selection vectors are not serialized (nor should they
 		// be).
 		OneInputNode:       colexecop.NewOneInputNode(colexecutils.NewDeselectorOp(unlimitedAllocator, input.Root, typs)),
+		flowCtx:            flowCtx,
+		processorID:        processorID,
 		inputMetaInfo:      input,
 		typs:               typs,
 		unlimitedAllocator: unlimitedAllocator,
@@ -151,7 +157,6 @@ func (o *Outbox) Run(
 	ctx context.Context,
 	dialer execinfra.Dialer,
 	sqlInstanceID base.SQLInstanceID,
-	flowID execinfrapb.FlowID,
 	streamID execinfrapb.StreamID,
 	flowCtxCancel context.CancelFunc,
 	connectionTimeout time.Duration,
@@ -165,11 +170,12 @@ func (o *Outbox) Run(
 	// be safe.
 	defer outboxCtxCancel()
 
-	ctx, o.span = execinfra.ProcessorSpan(ctx, "outbox")
+	ctx, o.span = execinfra.ProcessorSpan(ctx, o.flowCtx, "outbox", o.processorID)
 	if o.span != nil {
 		defer o.span.Finish()
-		o.span.SetTag(execinfrapb.FlowIDTagKey, attribute.StringValue(flowID.String()))
-		o.span.SetTag(execinfrapb.StreamIDTagKey, attribute.IntValue(int(streamID)))
+		if o.span.IsVerbose() {
+			o.span.SetTag(execinfrapb.StreamIDTagKey, attribute.IntValue(int(streamID)))
+		}
 	}
 
 	o.runnerCtx = ctx
@@ -209,7 +215,7 @@ func (o *Outbox) Run(
 		log.VEvent(ctx, 2, "Outbox sending header")
 		// Send header message to establish the remote server (consumer).
 		if err := stream.Send(
-			&execinfrapb.ProducerMessage{Header: &execinfrapb.ProducerHeader{FlowID: flowID, StreamID: streamID}},
+			&execinfrapb.ProducerMessage{Header: &execinfrapb.ProducerHeader{FlowID: o.flowCtx.ID, StreamID: streamID}},
 		); err != nil {
 			log.Warningf(
 				ctx,

--- a/pkg/sql/colflow/colrpc/outbox_test.go
+++ b/pkg/sql/colflow/colrpc/outbox_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/colexecerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexecop"
 	"github.com/cockroachdb/cockroach/pkg/sql/colmem"
+	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
@@ -40,7 +41,7 @@ func TestOutboxCatchesPanics(t *testing.T) {
 		rpcLayer = makeMockFlowStreamRPCLayer()
 	)
 	input.Init(ctx)
-	outbox, err := NewOutbox(testAllocator, testMemAcc, colexecargs.OpWithMetaInfo{Root: input}, typs, nil /* getStats */)
+	outbox, err := NewOutbox(&execinfra.FlowCtx{Gateway: false}, 0 /* processorID */, testAllocator, testMemAcc, colexecargs.OpWithMetaInfo{Root: input}, typs, nil /* getStats */)
 	require.NoError(t, err)
 
 	// This test relies on the fact that BatchBuffer panics when there are no
@@ -96,6 +97,8 @@ func TestOutboxDrainsMetadataSources(t *testing.T) {
 	newOutboxWithMetaSources := func() (*Outbox, *uint32, error) {
 		var sourceDrained uint32
 		outbox, err := NewOutbox(
+			&execinfra.FlowCtx{Gateway: false},
+			0, /* processorID */
 			testAllocator,
 			testMemAcc,
 			colexecargs.OpWithMetaInfo{

--- a/pkg/sql/colflow/explain_vec.go
+++ b/pkg/sql/colflow/explain_vec.go
@@ -58,7 +58,7 @@ func convertToVecTree(
 		nil /* flowBase */, newNoopFlowCreatorHelper(), nil, /* componentCreator */
 		recordingStats, false /* isGatewayNode */, nil, /* waitGroup */
 		&execinfra.RowChannel{}, &fakeBatchReceiver{}, flowCtx.Cfg.PodNodeDialer,
-		execinfrapb.FlowID{}, colcontainer.DiskQueueCfg{}, flowCtx.Cfg.VecFDSemaphore,
+		colcontainer.DiskQueueCfg{}, flowCtx.Cfg.VecFDSemaphore,
 		flowCtx.NewTypeResolver(flowCtx.Txn), admission.WorkInfo{},
 	)
 	opChains, _, err = creator.setupFlow(ctx, flowCtx, flow.Processors, localProcessors, nil /*localVectorSources*/, fuseOpt)

--- a/pkg/sql/colflow/routers_test.go
+++ b/pkg/sql/colflow/routers_test.go
@@ -907,6 +907,8 @@ func TestHashRouterOneOutput(t *testing.T) {
 			converterMemAcc := tu.testMemMonitor.MakeBoundAccount()
 			defer converterMemAcc.Close(ctx)
 			r, routerOutputs := NewHashRouter(
+				&execinfra.FlowCtx{Gateway: true},
+				0, /* processorID */
 				[]*colmem.Allocator{tu.testAllocator},
 				colexecargs.OpWithMetaInfo{
 					Root: colexectestutils.NewOpFixedSelTestInput(tu.testAllocator, sel, len(sel), data, typs),
@@ -1342,6 +1344,8 @@ func BenchmarkHashRouter(b *testing.B) {
 					defer converterMemAcc.Close(ctx)
 				}
 				r, outputs := NewHashRouter(
+					&execinfra.FlowCtx{Gateway: true},
+					0, /* processorID */
 					allocators,
 					colexecargs.OpWithMetaInfo{Root: input},
 					typs,

--- a/pkg/sql/colflow/stats.go
+++ b/pkg/sql/colflow/stats.go
@@ -270,7 +270,7 @@ func (vsc *vectorizedStatsCollectorImpl) GetStats() *execinfrapb.ComponentStats 
 		s.KV.ContentionTime.Set(vsc.kvReader.GetContentionTime())
 		scanStats := vsc.kvReader.GetScanStats()
 		execstats.PopulateKVMVCCStats(&s.KV, &scanStats)
-		s.Exec.ConsumedRU.Set(scanStats.ConsumedRU)
+		s.Exec.ConsumedRU.Set(vsc.kvReader.GetConsumedRU())
 
 		// In order to account for SQL CPU time, we have to subtract the CPU time
 		// spent while serving KV requests on a SQL goroutine.

--- a/pkg/sql/colflow/vectorized_flow.go
+++ b/pkg/sql/colflow/vectorized_flow.go
@@ -259,7 +259,6 @@ func (f *vectorizedFlow) Setup(
 		f.GetRowSyncFlowConsumer(),
 		f.GetBatchSyncFlowConsumer(),
 		flowCtx.Cfg.PodNodeDialer,
-		f.GetID(),
 		diskQueueCfg,
 		f.countingSemaphore,
 		flowCtx.NewTypeResolver(flowCtx.Txn),
@@ -543,6 +542,8 @@ type admissionOptions struct {
 // several components in a remote flow. Mostly for testing purposes.
 type remoteComponentCreator interface {
 	newOutbox(
+		flowCtx *execinfra.FlowCtx,
+		processorID int32,
 		allocator *colmem.Allocator,
 		converterMemAcc *mon.BoundAccount,
 		input colexecargs.OpWithMetaInfo,
@@ -561,13 +562,15 @@ type remoteComponentCreator interface {
 type vectorizedRemoteComponentCreator struct{}
 
 func (vectorizedRemoteComponentCreator) newOutbox(
+	flowCtx *execinfra.FlowCtx,
+	processorID int32,
 	allocator *colmem.Allocator,
 	converterMemAcc *mon.BoundAccount,
 	input colexecargs.OpWithMetaInfo,
 	typs []*types.T,
 	getStats func(context.Context) []*execinfrapb.ComponentStats,
 ) (*colrpc.Outbox, error) {
-	return colrpc.NewOutbox(allocator, converterMemAcc, input, typs, getStats)
+	return colrpc.NewOutbox(flowCtx, processorID, allocator, converterMemAcc, input, typs, getStats)
 }
 
 func (vectorizedRemoteComponentCreator) newInbox(
@@ -612,7 +615,6 @@ type vectorizedFlowCreator struct {
 	isGatewayNode     bool
 	waitGroup         *sync.WaitGroup
 	podNodeDialer     *nodedialer.Dialer
-	flowID            execinfrapb.FlowID
 	exprHelper        *colexecargs.ExprHelper
 	typeResolver      descs.DistSQLTypeResolver
 	admissionInfo     admission.WorkInfo
@@ -676,7 +678,6 @@ func newVectorizedFlowCreator(
 	rowSyncFlowConsumer execinfra.RowReceiver,
 	batchSyncFlowConsumer execinfra.BatchReceiver,
 	podNodeDialer *nodedialer.Dialer,
-	flowID execinfrapb.FlowID,
 	diskQueueCfg colcontainer.DiskQueueCfg,
 	fdSemaphore semaphore.Semaphore,
 	typeResolver descs.DistSQLTypeResolver,
@@ -692,7 +693,6 @@ func newVectorizedFlowCreator(
 		rowReceiver:       rowSyncFlowConsumer,
 		batchReceiver:     batchSyncFlowConsumer,
 		podNodeDialer:     podNodeDialer,
-		flowID:            flowID,
 		exprHelper:        creator.exprHelper,
 		typeResolver:      typeResolver,
 		admissionInfo:     admissionInfo,
@@ -782,6 +782,7 @@ func (s *vectorizedFlowCreator) Release() {
 func (s *vectorizedFlowCreator) setupRemoteOutputStream(
 	ctx context.Context,
 	flowCtx *execinfra.FlowCtx,
+	processorID int32,
 	op colexecargs.OpWithMetaInfo,
 	outputTyps []*types.T,
 	stream *execinfrapb.StreamEndpointSpec,
@@ -789,7 +790,7 @@ func (s *vectorizedFlowCreator) setupRemoteOutputStream(
 	getStats func(context.Context) []*execinfrapb.ComponentStats,
 ) (execopnode.OpNode, error) {
 	outbox, err := s.remoteComponentCreator.newOutbox(
-		colmem.NewAllocator(ctx, s.monitorRegistry.NewStreamingMemAccount(flowCtx), factory),
+		flowCtx, processorID, colmem.NewAllocator(ctx, s.monitorRegistry.NewStreamingMemAccount(flowCtx), factory),
 		s.monitorRegistry.NewStreamingMemAccount(flowCtx),
 		op, outputTyps, getStats,
 	)
@@ -803,7 +804,6 @@ func (s *vectorizedFlowCreator) setupRemoteOutputStream(
 			ctx,
 			s.podNodeDialer,
 			stream.TargetNodeID,
-			s.flowID,
 			stream.StreamID,
 			flowCtxCancel,
 			flowinfra.SettingFlowStreamTimeout.Get(&flowCtx.Cfg.Settings.SV),
@@ -822,6 +822,7 @@ func (s *vectorizedFlowCreator) setupRemoteOutputStream(
 func (s *vectorizedFlowCreator) setupRouter(
 	ctx context.Context,
 	flowCtx *execinfra.FlowCtx,
+	processorID int32,
 	input colexecargs.OpWithMetaInfo,
 	outputTyps []*types.T,
 	output *execinfrapb.OutputRouterSpec,
@@ -854,7 +855,7 @@ func (s *vectorizedFlowCreator) setupRouter(
 	}
 	diskMon, diskAccounts := s.monitorRegistry.CreateDiskAccounts(ctx, flowCtx, mmName, numOutputs)
 	router, outputs := NewHashRouter(
-		allocators, input, outputTyps, output.HashColumns, execinfra.GetWorkMemLimit(flowCtx),
+		flowCtx, processorID, allocators, input, outputTyps, output.HashColumns, execinfra.GetWorkMemLimit(flowCtx),
 		s.diskQueueCfg, s.fdSemaphore, diskAccounts, converterAccounts,
 	)
 	runRouter := func(ctx context.Context, _ context.CancelFunc) {
@@ -874,7 +875,7 @@ func (s *vectorizedFlowCreator) setupRouter(
 			return errors.Errorf("unexpected sync response output when setting up router")
 		case execinfrapb.StreamEndpointSpec_REMOTE:
 			if _, err := s.setupRemoteOutputStream(
-				ctx, flowCtx, colexecargs.OpWithMetaInfo{
+				ctx, flowCtx, processorID, colexecargs.OpWithMetaInfo{
 					Root:            op,
 					MetadataSources: colexecop.MetadataSources{op},
 				}, outputTyps, stream, factory, nil, /* getStats */
@@ -920,6 +921,7 @@ func (s *vectorizedFlowCreator) setupRouter(
 func (s *vectorizedFlowCreator) setupInput(
 	ctx context.Context,
 	flowCtx *execinfra.FlowCtx,
+	processorID int32,
 	input execinfrapb.InputSyncSpec,
 	opt flowinfra.FuseOpt,
 	factory coldata.ColumnFactory,
@@ -997,9 +999,12 @@ func (s *vectorizedFlowCreator) setupInput(
 		statsInputs := inputStreamOps
 		if input.Type == execinfrapb.InputSyncSpec_ORDERED {
 			os := colexec.NewOrderedSynchronizer(
+				flowCtx,
+				processorID,
 				colmem.NewAllocator(ctx, s.monitorRegistry.NewStreamingMemAccount(flowCtx), factory),
 				execinfra.GetWorkMemLimit(flowCtx), inputStreamOps,
-				input.ColumnTypes, execinfrapb.ConvertToColumnOrdering(input.Ordering), 0, /* tuplesToMerge */
+				input.ColumnTypes, execinfrapb.ConvertToColumnOrdering(input.Ordering),
+				0, /* tuplesToMerge */
 			)
 			opWithMetaInfo = colexecargs.OpWithMetaInfo{
 				Root:            os,
@@ -1014,7 +1019,7 @@ func (s *vectorizedFlowCreator) setupInput(
 					err = execinfra.NewDynamicQueryHasNoHomeRegionError(err)
 				}
 			}
-			sync := colexec.NewSerialUnorderedSynchronizer(inputStreamOps, input.EnforceHomeRegionStreamExclusiveUpperBound, err)
+			sync := colexec.NewSerialUnorderedSynchronizer(flowCtx, processorID, inputStreamOps, input.EnforceHomeRegionStreamExclusiveUpperBound, err)
 			opWithMetaInfo = colexecargs.OpWithMetaInfo{
 				Root:            sync,
 				MetadataSources: colexecop.MetadataSources{sync},
@@ -1025,8 +1030,7 @@ func (s *vectorizedFlowCreator) setupInput(
 			// must use the serial unordered sync above in order to remove any
 			// concurrency.
 			allocator := colmem.NewAllocator(ctx, s.monitorRegistry.NewStreamingMemAccount(flowCtx), factory)
-			sync := colexec.NewParallelUnorderedSynchronizer(allocator, inputStreamOps, s.waitGroup)
-			sync.LocalPlan = flowCtx.Local
+			sync := colexec.NewParallelUnorderedSynchronizer(flowCtx, processorID, allocator, inputStreamOps, s.waitGroup)
 			opWithMetaInfo = colexecargs.OpWithMetaInfo{
 				Root:            sync,
 				MetadataSources: colexecop.MetadataSources{sync},
@@ -1078,6 +1082,7 @@ func (s *vectorizedFlowCreator) setupOutput(
 		return s.setupRouter(
 			ctx,
 			flowCtx,
+			pspec.ProcessorID,
 			opWithMetaInfo,
 			opOutputTypes,
 			output,
@@ -1095,7 +1100,7 @@ func (s *vectorizedFlowCreator) setupOutput(
 	case execinfrapb.StreamEndpointSpec_REMOTE:
 		// Set up an Outbox.
 		outbox, err := s.setupRemoteOutputStream(
-			ctx, flowCtx, opWithMetaInfo, opOutputTypes, outputStream, factory,
+			ctx, flowCtx, pspec.ProcessorID, opWithMetaInfo, opOutputTypes, outputStream, factory,
 			s.makeGetStatsFnForOutbox(flowCtx, opWithMetaInfo.StatsCollectors, outputStream.OriginNodeID),
 		)
 		if err != nil {
@@ -1195,7 +1200,7 @@ func (s *vectorizedFlowCreator) setupFlow(
 
 			inputs := make([]colexecargs.OpWithMetaInfo, len(pspec.Input))
 			for i := range pspec.Input {
-				inputs[i], err = s.setupInput(ctx, flowCtx, pspec.Input[i], opt, factory)
+				inputs[i], err = s.setupInput(ctx, flowCtx, pspec.ProcessorID, pspec.Input[i], opt, factory)
 				if err != nil {
 					return
 				}

--- a/pkg/sql/colflow/vectorized_flow_test.go
+++ b/pkg/sql/colflow/vectorized_flow_test.go
@@ -48,6 +48,8 @@ type callbackRemoteComponentCreator struct {
 var _ remoteComponentCreator = &callbackRemoteComponentCreator{}
 
 func (c callbackRemoteComponentCreator) newOutbox(
+	_ *execinfra.FlowCtx,
+	_ int32,
 	allocator *colmem.Allocator,
 	converterMemAcc *mon.BoundAccount,
 	input colexecargs.OpWithMetaInfo,
@@ -220,7 +222,7 @@ func TestDrainOnlyInputDAG(t *testing.T) {
 			require.Len(t, input.MetadataSources, 1)
 			inbox := colexec.MaybeUnwrapInvariantsChecker(input.MetadataSources[0].(colexecop.Operator)).(*colrpc.Inbox)
 			require.Len(t, inboxToNumInputTypes[inbox], numInputTypesToOutbox)
-			return colrpc.NewOutbox(allocator, converterMemAcc, input, typs, nil /* getStats */)
+			return colrpc.NewOutbox(&execinfra.FlowCtx{Gateway: false}, 0 /* processorID */, allocator, converterMemAcc, input, typs, nil /* getStats */)
 		},
 		newInboxFn: func(allocator *colmem.Allocator, typs []*types.T, streamID execinfrapb.StreamID) (*colrpc.Inbox, error) {
 			inbox, err := colrpc.NewInbox(allocator, typs, streamID)
@@ -244,7 +246,7 @@ func TestDrainOnlyInputDAG(t *testing.T) {
 	var wg sync.WaitGroup
 	vfc := newVectorizedFlowCreator(
 		f, nil /* helper */, componentCreator, false, false, &wg, &execinfra.RowChannel{},
-		nil /* batchSyncFlowConsumer */, nil /* podNodeDialer */, execinfrapb.FlowID{}, colcontainer.DiskQueueCfg{},
+		nil /* batchSyncFlowConsumer */, nil /* podNodeDialer */, colcontainer.DiskQueueCfg{},
 		nil /* fdSemaphore */, descs.DistSQLTypeResolver{}, admission.WorkInfo{},
 	)
 

--- a/pkg/sql/delete_preserving_index_test.go
+++ b/pkg/sql/delete_preserving_index_test.go
@@ -704,7 +704,7 @@ func TestMergeProcessor(t *testing.T) {
 		sp := tableDesc.IndexSpan(codec, srcIndex.GetID())
 
 		output := fakeReceiver{}
-		im, err := backfill.NewIndexBackfillMerger(ctx, &flowCtx, execinfrapb.IndexBackfillMergerSpec{
+		im, err := backfill.NewIndexBackfillMerger(ctx, &flowCtx, 0 /* processorID */, execinfrapb.IndexBackfillMergerSpec{
 			Table:            tableDesc.TableDescriptor,
 			TemporaryIndexes: []descpb.IndexID{srcIndex.GetID()},
 			AddedIndexes:     []descpb.IndexID{dstIndex.GetID()},

--- a/pkg/sql/distsql/inbound_test.go
+++ b/pkg/sql/distsql/inbound_test.go
@@ -98,7 +98,7 @@ func TestOutboxInboundStreamIntegration(t *testing.T) {
 	}
 
 	streamID := execinfrapb.StreamID(1)
-	outbox := flowinfra.NewOutbox(&flowCtx, execinfra.StaticSQLInstanceID, streamID, nil /* numOutboxes */, false /* isGatewayNode */)
+	outbox := flowinfra.NewOutbox(&flowCtx, 0 /* processorID */, execinfra.StaticSQLInstanceID, streamID, nil /* numOutboxes */, false /* isGatewayNode */)
 	outbox.Init(types.OneIntCol)
 
 	// WaitGroup for the outbox and inbound stream. If the WaitGroup is done, no

--- a/pkg/sql/execinfra/BUILD.bazel
+++ b/pkg/sql/execinfra/BUILD.bazel
@@ -74,7 +74,6 @@ go_library(
         "//pkg/util/stop",
         "//pkg/util/timeutil",
         "//pkg/util/tracing",
-        "//pkg/util/tracing/tracingpb",
         "//pkg/util/uuid",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_cockroachdb_pebble//vfs",

--- a/pkg/sql/execinfra/base.go
+++ b/pkg/sql/execinfra/base.go
@@ -254,7 +254,7 @@ func DrainAndForwardMetadata(ctx context.Context, src RowSource, dst RowReceiver
 
 // GetTraceDataAsMetadata returns the trace data as execinfrapb.ProducerMetadata
 // object.
-func GetTraceDataAsMetadata(span *tracing.Span) *execinfrapb.ProducerMetadata {
+func GetTraceDataAsMetadata(_ *FlowCtx, span *tracing.Span) *execinfrapb.ProducerMetadata {
 	if trace := span.GetConfiguredRecording(); len(trace) > 0 {
 		meta := execinfrapb.GetProducerMeta()
 		meta.TraceData = trace
@@ -267,8 +267,8 @@ func GetTraceDataAsMetadata(span *tracing.Span) *execinfrapb.ProducerMetadata {
 // dst. The ConsumerStatus returned by dst is ignored.
 //
 // Note that the tracing data is distinct between different processors, since
-// each one gets its own trace "recording group".
-func SendTraceData(ctx context.Context, dst RowReceiver) {
+// each one gets its own "detached" tracing span.
+func SendTraceData(ctx context.Context, _ *FlowCtx, dst RowReceiver) {
 	if rec := tracing.SpanFromContext(ctx).GetConfiguredRecording(); rec != nil {
 		dst.Push(nil /* row */, &execinfrapb.ProducerMetadata{TraceData: rec})
 	}

--- a/pkg/sql/execinfra/base.go
+++ b/pkg/sql/execinfra/base.go
@@ -253,8 +253,11 @@ func DrainAndForwardMetadata(ctx context.Context, src RowSource, dst RowReceiver
 }
 
 // GetTraceDataAsMetadata returns the trace data as execinfrapb.ProducerMetadata
-// object.
-func GetTraceDataAsMetadata(_ *FlowCtx, span *tracing.Span) *execinfrapb.ProducerMetadata {
+// object when called not on the gateway.
+func GetTraceDataAsMetadata(flowCtx *FlowCtx, span *tracing.Span) *execinfrapb.ProducerMetadata {
+	if flowCtx.Gateway {
+		return nil
+	}
 	if trace := span.GetConfiguredRecording(); len(trace) > 0 {
 		meta := execinfrapb.GetProducerMeta()
 		meta.TraceData = trace
@@ -264,11 +267,15 @@ func GetTraceDataAsMetadata(_ *FlowCtx, span *tracing.Span) *execinfrapb.Produce
 }
 
 // SendTraceData collects the tracing information from the ctx and pushes it to
-// dst. The ConsumerStatus returned by dst is ignored.
+// dst when called not on the gateway. The ConsumerStatus returned by dst is
+// ignored.
 //
 // Note that the tracing data is distinct between different processors, since
-// each one gets its own "detached" tracing span.
-func SendTraceData(ctx context.Context, _ *FlowCtx, dst RowReceiver) {
+// each one gets its own "detached" tracing span (when not on the gateway).
+func SendTraceData(ctx context.Context, flowCtx *FlowCtx, dst RowReceiver) {
+	if flowCtx.Gateway {
+		return
+	}
 	if rec := tracing.SpanFromContext(ctx).GetConfiguredRecording(); rec != nil {
 		dst.Push(nil /* row */, &execinfrapb.ProducerMetadata{TraceData: rec})
 	}

--- a/pkg/sql/execinfra/processorsbase.go
+++ b/pkg/sql/execinfra/processorsbase.go
@@ -28,7 +28,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/mon"
 	"github.com/cockroachdb/cockroach/pkg/util/optional"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
-	"github.com/cockroachdb/cockroach/pkg/util/tracing/tracingpb"
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/redact"
 	"go.opentelemetry.io/otel/attribute"
@@ -378,14 +377,6 @@ type ProcessorBaseNoHelper struct {
 	//
 	// Can return nil.
 	ExecStatsForTrace func() *execinfrapb.ComponentStats
-	// storeExecStatsTrace indicates whether ExecStatsTrace should be populated
-	// in InternalClose.
-	storeExecStatsTrace bool
-	// ExecStatsTrace stores the recording in case HijackExecStatsForTrace has
-	// been called. This is needed in order to provide the access to the
-	// recording after the span has been finished in InternalClose. Only set if
-	// storeExecStatsTrace is true.
-	ExecStatsTrace tracingpb.Recording
 	// trailingMetaCallback, if set, will be called by moveToTrailingMeta(). The
 	// callback is expected to close all inputs, do other cleanup on the processor
 	// (including calling InternalClose()) and generate the trailing meta that
@@ -639,13 +630,7 @@ func (pb *ProcessorBase) HijackExecStatsForTrace() func() *execinfrapb.Component
 	}
 	execStatsForTrace := pb.ExecStatsForTrace
 	pb.ExecStatsForTrace = nil
-	pb.storeExecStatsTrace = true
-	return func() *execinfrapb.ComponentStats {
-		cs := execStatsForTrace()
-		// Make sure to unset the trace since we don't need it anymore.
-		pb.ExecStatsTrace = nil
-		return cs
-	}
+	return execStatsForTrace
 }
 
 // moveToTrailingMeta switches the processor to the "trailing meta" state: only
@@ -679,9 +664,6 @@ func (pb *ProcessorBaseNoHelper) moveToTrailingMeta() {
 		}
 		if trace := pb.span.GetConfiguredRecording(); trace != nil {
 			pb.trailingMeta = append(pb.trailingMeta, execinfrapb.ProducerMetadata{TraceData: trace})
-			if pb.storeExecStatsTrace {
-				pb.ExecStatsTrace = trace
-			}
 		}
 	}
 
@@ -838,14 +820,23 @@ func (pb *ProcessorBase) AppendTrailingMeta(meta execinfrapb.ProducerMetadata) {
 // ProcessorSpan creates a child span for a processor (if we are doing any
 // tracing). The returned span needs to be finished using tracing.FinishSpan.
 func ProcessorSpan(
-	ctx context.Context, flowCtx *FlowCtx, name string, processorID int32,
+	ctx context.Context,
+	flowCtx *FlowCtx,
+	name string,
+	processorID int32,
+	eventListeners ...tracing.EventListener,
 ) (context.Context, *tracing.Span) {
 	sp := tracing.SpanFromContext(ctx)
 	if sp == nil {
 		return ctx, nil
 	}
-	retCtx, retSpan := sp.Tracer().StartSpanCtx(ctx, name,
-		tracing.WithParent(sp), tracing.WithDetachedRecording())
+	var listenersOpt tracing.SpanOption
+	if len(eventListeners) > 0 {
+		listenersOpt = tracing.WithEventListeners(eventListeners...)
+	}
+	retCtx, retSpan := sp.Tracer().StartSpanCtx(
+		ctx, name, tracing.WithParent(sp), tracing.WithDetachedRecording(), listenersOpt,
+	)
 	if retSpan.IsVerbose() {
 		retSpan.SetTag(execinfrapb.FlowIDTagKey, attribute.StringValue(flowCtx.ID.String()))
 		retSpan.SetTag(execinfrapb.ProcessorIDTagKey, attribute.IntValue(int(processorID)))
@@ -864,13 +855,15 @@ func ProcessorSpan(
 //	< other initialization >
 //
 // so that the caller doesn't mistakenly use old ctx object.
-func (pb *ProcessorBaseNoHelper) StartInternal(ctx context.Context, name string) context.Context {
+func (pb *ProcessorBaseNoHelper) StartInternal(
+	ctx context.Context, name string, eventListeners ...tracing.EventListener,
+) context.Context {
 	pb.origCtx = ctx
 	pb.ctx = ctx
 	noSpan := pb.FlowCtx != nil && pb.FlowCtx.Cfg != nil &&
 		pb.FlowCtx.Cfg.TestingKnobs.ProcessorNoTracingSpan
 	if !noSpan {
-		pb.ctx, pb.span = ProcessorSpan(ctx, pb.FlowCtx, name, pb.ProcessorID)
+		pb.ctx, pb.span = ProcessorSpan(ctx, pb.FlowCtx, name, pb.ProcessorID, eventListeners...)
 	}
 	pb.evalOrigCtx = pb.EvalCtx.SetDeprecatedContext(pb.ctx)
 	return pb.ctx

--- a/pkg/sql/execinfra/processorsbase.go
+++ b/pkg/sql/execinfra/processorsbase.go
@@ -662,8 +662,15 @@ func (pb *ProcessorBaseNoHelper) moveToTrailingMeta() {
 				pb.span.RecordStructured(stats)
 			}
 		}
-		if trace := pb.span.GetConfiguredRecording(); trace != nil {
-			pb.trailingMeta = append(pb.trailingMeta, execinfrapb.ProducerMetadata{TraceData: trace})
+		// Note that we need to propagate the trace only from the remote nodes
+		// because there we create spans with the detached option (see
+		// ProcessorSpan). If we're on the gateway, then the recording of this
+		// span is already included into the parent, thus, we don't generate the
+		// metadata for it.
+		if !pb.FlowCtx.Gateway {
+			if trace := pb.span.GetConfiguredRecording(); trace != nil {
+				pb.trailingMeta = append(pb.trailingMeta, execinfrapb.ProducerMetadata{TraceData: trace})
+			}
 		}
 	}
 
@@ -834,9 +841,22 @@ func ProcessorSpan(
 	if len(eventListeners) > 0 {
 		listenersOpt = tracing.WithEventListeners(eventListeners...)
 	}
-	retCtx, retSpan := sp.Tracer().StartSpanCtx(
-		ctx, name, tracing.WithParent(sp), tracing.WithDetachedRecording(), listenersOpt,
-	)
+	var retCtx context.Context
+	var retSpan *tracing.Span
+	if flowCtx.Gateway {
+		retCtx, retSpan = sp.Tracer().StartSpanCtx(
+			ctx, name, tracing.WithParent(sp), listenersOpt,
+		)
+	} else {
+		// The trace from each processor will be imported into the span of the
+		// flow on the gateway, in DistSQLReceiver.pushMeta, so we use the
+		// detached option.
+		// TODO(yuzefovich): only use the detached recording for the root
+		// components of the remote flows.
+		retCtx, retSpan = sp.Tracer().StartSpanCtx(
+			ctx, name, tracing.WithParent(sp), tracing.WithDetachedRecording(), listenersOpt,
+		)
+	}
 	if retSpan.IsVerbose() {
 		retSpan.SetTag(execinfrapb.FlowIDTagKey, attribute.StringValue(flowCtx.ID.String()))
 		retSpan.SetTag(execinfrapb.ProcessorIDTagKey, attribute.IntValue(int(processorID)))

--- a/pkg/sql/execinfrapb/data.go
+++ b/pkg/sql/execinfrapb/data.go
@@ -184,7 +184,8 @@ type ProducerMetadata struct {
 	Ranges []roachpb.RangeInfo
 	// TODO(vivek): change to type Error
 	Err error
-	// TraceData is sent if tracing is enabled.
+	// TraceData is sent if tracing is enabled, by all processors on the remote
+	// nodes.
 	TraceData []tracingpb.RecordedSpan
 	// LeafTxnFinalState contains the final state of the LeafTxn to be
 	// sent from leaf flows to the RootTxn held by the flow's ultimate

--- a/pkg/sql/execstats/BUILD.bazel
+++ b/pkg/sql/execstats/BUILD.bazel
@@ -16,6 +16,7 @@ go_library(
         "//pkg/sql/execinfrapb",
         "//pkg/util/buildutil",
         "//pkg/util/optional",
+        "//pkg/util/protoutil",
         "//pkg/util/tracing",
         "//pkg/util/tracing/tracingpb",
         "@com_github_cockroachdb_errors//:errors",

--- a/pkg/sql/execstats/stats.go
+++ b/pkg/sql/execstats/stats.go
@@ -17,9 +17,8 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 	"github.com/cockroachdb/cockroach/pkg/util/optional"
+	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
-	"github.com/cockroachdb/cockroach/pkg/util/tracing/tracingpb"
-	pbtypes "github.com/gogo/protobuf/types"
 )
 
 // ShouldCollectStats is a helper function used to determine if a processor
@@ -30,28 +29,78 @@ func ShouldCollectStats(ctx context.Context, collectStats bool) bool {
 	return collectStats && tracing.SpanFromContext(ctx) != nil
 }
 
-// GetCumulativeContentionTime is a helper function to return the cumulative
-// contention time. It calculates the cumulative contention time from the given
-// recording or, if the recording is nil, from the tracing span from the
-// context. All contention events found in the trace are included.
-func GetCumulativeContentionTime(ctx context.Context, recording tracingpb.Recording) time.Duration {
-	var cumulativeContentionTime time.Duration
-	if recording == nil {
-		recording = tracing.SpanFromContext(ctx).GetRecording(tracingpb.RecordingStructured)
+// ContentionEventsListener calculates the cumulative contention time across all
+// kvpb.ContentionEvents seen by the listener.
+type ContentionEventsListener struct {
+	CumulativeContentionTime time.Duration
+}
+
+var _ tracing.EventListener = &ContentionEventsListener{}
+
+// Notify is part of the tracing.EventListener interface.
+func (c *ContentionEventsListener) Notify(event tracing.Structured) tracing.EventConsumptionStatus {
+	ce, ok := event.(protoutil.Message).(*kvpb.ContentionEvent)
+	if !ok {
+		return tracing.EventNotConsumed
 	}
-	var ev kvpb.ContentionEvent
-	for i := range recording {
-		recording[i].Structured(func(any *pbtypes.Any, _ time.Time) {
-			if !pbtypes.Is(any, &ev) {
-				return
-			}
-			if err := pbtypes.UnmarshalAny(any, &ev); err != nil {
-				return
-			}
-			cumulativeContentionTime += ev.Duration
-		})
+	c.CumulativeContentionTime += ce.Duration
+	return tracing.EventConsumed
+}
+
+// ScanStatsListener aggregates all kvpb.ScanStats objects into a single
+// ScanStats object.
+type ScanStatsListener struct {
+	ScanStats
+}
+
+var _ tracing.EventListener = &ScanStatsListener{}
+
+// Notify is part of the tracing.EventListener interface.
+func (l *ScanStatsListener) Notify(event tracing.Structured) tracing.EventConsumptionStatus {
+	ss, ok := event.(protoutil.Message).(*kvpb.ScanStats)
+	if !ok {
+		return tracing.EventNotConsumed
 	}
-	return cumulativeContentionTime
+	l.ScanStats.NumInterfaceSteps += ss.NumInterfaceSteps
+	l.ScanStats.NumInternalSteps += ss.NumInternalSteps
+	l.ScanStats.NumInterfaceSeeks += ss.NumInterfaceSeeks
+	l.ScanStats.NumInternalSeeks += ss.NumInternalSeeks
+	l.ScanStats.BlockBytes += ss.BlockBytes
+	l.ScanStats.BlockBytesInCache += ss.BlockBytesInCache
+	l.ScanStats.KeyBytes += ss.KeyBytes
+	l.ScanStats.ValueBytes += ss.ValueBytes
+	l.ScanStats.PointCount += ss.PointCount
+	l.ScanStats.PointsCoveredByRangeTombstones += ss.PointsCoveredByRangeTombstones
+	l.ScanStats.RangeKeyCount += ss.RangeKeyCount
+	l.ScanStats.RangeKeyContainedPoints += ss.RangeKeyContainedPoints
+	l.ScanStats.RangeKeySkippedPoints += ss.RangeKeySkippedPoints
+	l.ScanStats.SeparatedPointCount += ss.SeparatedPointCount
+	l.ScanStats.SeparatedPointValueBytes += ss.SeparatedPointValueBytes
+	l.ScanStats.SeparatedPointValueBytesFetched += ss.SeparatedPointValueBytesFetched
+	l.ScanStats.NumGets += ss.NumGets
+	l.ScanStats.NumScans += ss.NumScans
+	l.ScanStats.NumReverseScans += ss.NumReverseScans
+	return tracing.EventConsumed
+}
+
+// TenantConsumptionListener aggregates consumed RUs from all
+// kvpb.TenantConsumption events seen by the listener.
+type TenantConsumptionListener struct {
+	ConsumedRU uint64
+}
+
+var _ tracing.EventListener = &TenantConsumptionListener{}
+
+// Notify is part of the tracing.EventListener interface.
+func (l *TenantConsumptionListener) Notify(
+	event tracing.Structured,
+) tracing.EventConsumptionStatus {
+	tc, ok := event.(protoutil.Message).(*kvpb.TenantConsumption)
+	if !ok {
+		return tracing.EventNotConsumed
+	}
+	l.ConsumedRU += uint64(tc.RU)
+	return tracing.EventConsumed
 }
 
 // ScanStats contains statistics on the internal MVCC operators used to satisfy
@@ -84,12 +133,9 @@ type ScanStats struct {
 	SeparatedPointCount             uint64
 	SeparatedPointValueBytes        uint64
 	SeparatedPointValueBytesFetched uint64
-	// ConsumedRU is the number of RUs that were consumed during the course of a
-	// scan.
-	ConsumedRU      uint64
-	NumGets         uint64
-	NumScans        uint64
-	NumReverseScans uint64
+	NumGets                         uint64
+	NumScans                        uint64
+	NumReverseScans                 uint64
 }
 
 // PopulateKVMVCCStats adds data from the input ScanStats to the input KVStats.
@@ -110,49 +156,4 @@ func PopulateKVMVCCStats(kvStats *execinfrapb.KVStats, ss *ScanStats) {
 	kvStats.NumGets = optional.MakeUint(ss.NumGets)
 	kvStats.NumScans = optional.MakeUint(ss.NumScans)
 	kvStats.NumReverseScans = optional.MakeUint(ss.NumReverseScans)
-}
-
-// GetScanStats is a helper function to calculate scan stats from the given
-// recording or, if the recording is nil, from the tracing span from the
-// context.
-func GetScanStats(ctx context.Context, recording tracingpb.Recording) (scanStats ScanStats) {
-	if recording == nil {
-		recording = tracing.SpanFromContext(ctx).GetRecording(tracingpb.RecordingStructured)
-	}
-	var ss kvpb.ScanStats
-	var tc kvpb.TenantConsumption
-	for i := range recording {
-		recording[i].Structured(func(any *pbtypes.Any, _ time.Time) {
-			if pbtypes.Is(any, &ss) {
-				if err := pbtypes.UnmarshalAny(any, &ss); err != nil {
-					return
-				}
-				scanStats.NumInterfaceSteps += ss.NumInterfaceSteps
-				scanStats.NumInternalSteps += ss.NumInternalSteps
-				scanStats.NumInterfaceSeeks += ss.NumInterfaceSeeks
-				scanStats.NumInternalSeeks += ss.NumInternalSeeks
-				scanStats.BlockBytes += ss.BlockBytes
-				scanStats.BlockBytesInCache += ss.BlockBytesInCache
-				scanStats.KeyBytes += ss.KeyBytes
-				scanStats.ValueBytes += ss.ValueBytes
-				scanStats.PointCount += ss.PointCount
-				scanStats.PointsCoveredByRangeTombstones += ss.PointsCoveredByRangeTombstones
-				scanStats.RangeKeyCount += ss.RangeKeyCount
-				scanStats.RangeKeyContainedPoints += ss.RangeKeyContainedPoints
-				scanStats.RangeKeySkippedPoints += ss.RangeKeySkippedPoints
-				scanStats.SeparatedPointCount += ss.SeparatedPointCount
-				scanStats.SeparatedPointValueBytes += ss.SeparatedPointValueBytes
-				scanStats.SeparatedPointValueBytesFetched += ss.SeparatedPointValueBytesFetched
-				scanStats.NumGets += ss.NumGets
-				scanStats.NumScans += ss.NumScans
-				scanStats.NumReverseScans += ss.NumReverseScans
-			} else if pbtypes.Is(any, &tc) {
-				if err := pbtypes.UnmarshalAny(any, &tc); err != nil {
-					return
-				}
-				scanStats.ConsumedRU += uint64(tc.RU)
-			}
-		})
-	}
-	return scanStats
 }

--- a/pkg/sql/explain_test.go
+++ b/pkg/sql/explain_test.go
@@ -341,34 +341,44 @@ func TestExplainMVCCSteps(t *testing.T) {
 	defer srv.Stopper().Stop(ctx)
 	r := sqlutils.MakeSQLRunner(godb)
 
-	r.Exec(t, "CREATE TABLE ab (a PRIMARY KEY, b) AS SELECT g, g FROM generate_series(1,1000) g(g)")
-	r.Exec(t, "CREATE TABLE bc (b PRIMARY KEY, c) AS SELECT g, g FROM generate_series(1,1000) g(g)")
+	for _, vectorize := range []bool{true, false} {
+		if vectorize {
+			r.Exec(t, "SET vectorize = on")
+		} else {
+			r.Exec(t, "SET vectorize = off")
+		}
+		r.Exec(t, "DROP TABLE IF EXISTS ab")
+		r.Exec(t, "DROP TABLE IF EXISTS bc")
+		r.Exec(t, "CREATE TABLE ab (a PRIMARY KEY, b) AS SELECT g, g FROM generate_series(1,1000) g(g)")
+		r.Exec(t, "CREATE TABLE bc (b PRIMARY KEY, c) AS SELECT g, g FROM generate_series(1,1000) g(g)")
 
-	scanQuery := "SELECT count(*) FROM ab"
-	expectedSteps, expectedSeeks := 1000, 1
-	foundSteps, foundSeeks := getMVCCStats(t, r, scanQuery)
+		scanQuery := "SELECT count(*) FROM ab"
+		expectedSteps, expectedSeeks := 1000, 1
+		foundSteps, foundSeeks := getMVCCStats(t, r, scanQuery)
 
-	assert.Equal(t, expectedSteps, foundSteps)
-	assert.Equal(t, expectedSeeks, foundSeeks)
-	assert.Equal(t, expectedSteps, foundSteps)
-	assert.Equal(t, expectedSeeks, foundSeeks)
+		assert.Equal(t, expectedSteps, foundSteps)
+		assert.Equal(t, expectedSeeks, foundSeeks)
+		assert.Equal(t, expectedSteps, foundSteps)
+		assert.Equal(t, expectedSeeks, foundSeeks)
 
-	// Update all rows.
-	r.Exec(t, "UPDATE ab SET b=b+1 WHERE true")
+		// Update all rows.
+		r.Exec(t, "UPDATE ab SET b=b+1 WHERE true")
 
-	expectedSteps, expectedSeeks = 1000, 1
-	foundSteps, foundSeeks = getMVCCStats(t, r, scanQuery)
+		expectedSteps, expectedSeeks = 1000, 1
+		foundSteps, foundSeeks = getMVCCStats(t, r, scanQuery)
 
-	assert.Equal(t, expectedSteps, foundSteps)
-	assert.Equal(t, expectedSeeks, foundSeeks)
+		assert.Equal(t, expectedSteps, foundSteps)
+		assert.Equal(t, expectedSeeks, foundSeeks)
 
-	// Check that the lookup join (which is executed via a row-by-row processor
-	// wrapped into the vectorized flow) correctly propagates the scan stats.
-	lookupJoinQuery := "SELECT count(*) FROM ab INNER LOOKUP JOIN bc ON ab.b = bc.b"
-	foundSteps, foundSeeks = getMVCCStats(t, r, lookupJoinQuery)
-	// We're mainly interested in the fact whether the propagation takes place,
-	// so one of the values being positive is sufficient.
-	assert.Greater(t, foundSteps+foundSeeks, 0)
+		// Check that the lookup join (which is executed via a row-by-row
+		// processor wrapped into the vectorized flow when vectorize=true)
+		// correctly propagates the scan stats.
+		lookupJoinQuery := "SELECT count(*) FROM ab INNER LOOKUP JOIN bc ON ab.b = bc.b"
+		foundSteps, foundSeeks = getMVCCStats(t, r, lookupJoinQuery)
+		// We're mainly interested in the fact whether the propagation takes
+		// place, so one of the values being positive is sufficient.
+		assert.Greater(t, foundSteps+foundSeeks, 0)
+	}
 }
 
 // getMVCCStats returns the number of MVCC steps and seeks found in the EXPLAIN

--- a/pkg/sql/flowinfra/outbox.go
+++ b/pkg/sql/flowinfra/outbox.go
@@ -319,10 +319,12 @@ func (m *Outbox) mainLoop(ctx context.Context, wg *sync.WaitGroup) (retErr error
 						m.stats.FlowStats.ConsumedRU.Set(uint64(m.flowCtx.TenantCPUMonitor.EndCollection(ctx)))
 					}
 					span.RecordStructured(&m.stats)
-					if trace := tracing.SpanFromContext(ctx).GetConfiguredRecording(); trace != nil {
-						err := m.AddRow(ctx, nil, &execinfrapb.ProducerMetadata{TraceData: trace})
-						if err != nil {
-							return err
+					if !m.flowCtx.Gateway {
+						if trace := tracing.SpanFromContext(ctx).GetConfiguredRecording(); trace != nil {
+							err := m.AddRow(ctx, nil, &execinfrapb.ProducerMetadata{TraceData: trace})
+							if err != nil {
+								return err
+							}
 						}
 					}
 				}

--- a/pkg/sql/flowinfra/outbox_test.go
+++ b/pkg/sql/flowinfra/outbox_test.go
@@ -81,7 +81,7 @@ func TestOutbox(t *testing.T) {
 		NodeID: base.TestingIDContainer,
 	}
 	streamID := execinfrapb.StreamID(42)
-	outbox := flowinfra.NewOutbox(&flowCtx, execinfra.StaticSQLInstanceID, streamID, nil /* numOutboxes */, false /* isGatewayNode */)
+	outbox := flowinfra.NewOutbox(&flowCtx, 0 /* processorID */, execinfra.StaticSQLInstanceID, streamID, nil /* numOutboxes */, false /* isGatewayNode */)
 	outbox.Init(types.OneIntCol)
 	var outboxWG sync.WaitGroup
 	var cancel func()
@@ -247,7 +247,7 @@ func TestOutboxInitializesStreamBeforeReceivingAnyRows(t *testing.T) {
 		NodeID: base.TestingIDContainer,
 	}
 	streamID := execinfrapb.StreamID(42)
-	outbox := flowinfra.NewOutbox(&flowCtx, execinfra.StaticSQLInstanceID, streamID, nil /* numOutboxes */, false /* isGatewayNode */)
+	outbox := flowinfra.NewOutbox(&flowCtx, 0 /* processorID */, execinfra.StaticSQLInstanceID, streamID, nil /* numOutboxes */, false /* isGatewayNode */)
 
 	var outboxWG sync.WaitGroup
 	outbox.Init(types.OneIntCol)
@@ -326,7 +326,7 @@ func TestOutboxClosesWhenConsumerCloses(t *testing.T) {
 			var cancel func()
 			ctx, cancel = context.WithCancel(ctx)
 			defer cancel()
-			outbox = flowinfra.NewOutbox(&flowCtx, execinfra.StaticSQLInstanceID, streamID, nil /* numOutboxes */, false /* isGatewayNode */)
+			outbox = flowinfra.NewOutbox(&flowCtx, 0 /* processorID */, execinfra.StaticSQLInstanceID, streamID, nil /* numOutboxes */, false /* isGatewayNode */)
 			outbox.Init(types.OneIntCol)
 			outbox.Start(ctx, &wg, cancel)
 
@@ -411,7 +411,7 @@ func TestOutboxCancelsFlowOnError(t *testing.T) {
 		ctxCanceled = true
 	}
 
-	outbox = flowinfra.NewOutbox(&flowCtx, execinfra.StaticSQLInstanceID, streamID, nil /* numOutboxes */, false /* isGatewayNode */)
+	outbox = flowinfra.NewOutbox(&flowCtx, 0 /* processorID */, execinfra.StaticSQLInstanceID, streamID, nil /* numOutboxes */, false /* isGatewayNode */)
 	outbox.Init(types.OneIntCol)
 	outbox.Start(ctx, &wg, mockCancel)
 
@@ -460,7 +460,7 @@ func TestOutboxUnblocksProducers(t *testing.T) {
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
-	outbox = flowinfra.NewOutbox(&flowCtx, execinfra.StaticSQLInstanceID, streamID, nil /* numOutboxes */, false /* isGatewayNode */)
+	outbox = flowinfra.NewOutbox(&flowCtx, 0 /* processorID */, execinfra.StaticSQLInstanceID, streamID, nil /* numOutboxes */, false /* isGatewayNode */)
 	outbox.Init(types.OneIntCol)
 
 	// Fill up the outbox.
@@ -529,7 +529,7 @@ func BenchmarkOutbox(b *testing.B) {
 				},
 				NodeID: base.TestingIDContainer,
 			}
-			outbox := flowinfra.NewOutbox(&flowCtx, execinfra.StaticSQLInstanceID, streamID, nil /* numOutboxes */, false /* isGatewayNode */)
+			outbox := flowinfra.NewOutbox(&flowCtx, 0 /* processorID */, execinfra.StaticSQLInstanceID, streamID, nil /* numOutboxes */, false /* isGatewayNode */)
 			outbox.Init(types.MakeIntCols(numCols))
 			var outboxWG sync.WaitGroup
 			var cancel func()

--- a/pkg/sql/rowexec/backfiller.go
+++ b/pkg/sql/rowexec/backfiller.go
@@ -89,10 +89,10 @@ func (*backfiller) MustBeStreaming() bool {
 func (b *backfiller) Run(ctx context.Context, output execinfra.RowReceiver) {
 	opName := fmt.Sprintf("%sBackfiller", b.name)
 	ctx = logtags.AddTag(ctx, opName, int(b.spec.Table.ID))
-	ctx, span := execinfra.ProcessorSpan(ctx, opName)
+	ctx, span := execinfra.ProcessorSpan(ctx, b.flowCtx, opName, b.processorID)
 	defer span.Finish()
 	meta := b.doRun(ctx)
-	execinfra.SendTraceData(ctx, output)
+	execinfra.SendTraceData(ctx, b.flowCtx, output)
 	if emitHelper(ctx, output, &b.out, nil /* row */, meta, func(context.Context, execinfra.RowReceiver) {}) {
 		output.ProducerDone()
 	}

--- a/pkg/sql/rowexec/inverted_joiner_test.go
+++ b/pkg/sql/rowexec/inverted_joiner_test.go
@@ -786,6 +786,7 @@ func TestInvertedJoinerDrain(t *testing.T) {
 			TempStorage: tempEngine,
 		},
 		Txn:         leafTxn,
+		Gateway:     false,
 		DiskMonitor: diskMonitor,
 	}
 

--- a/pkg/sql/rowexec/joinreader_test.go
+++ b/pkg/sql/rowexec/joinreader_test.go
@@ -1399,6 +1399,7 @@ func TestJoinReaderDrain(t *testing.T) {
 			TempStorage: tempEngine,
 		},
 		Txn:         leafTxn,
+		Gateway:     false,
 		DiskMonitor: diskMonitor,
 	}
 

--- a/pkg/sql/rowexec/processors.go
+++ b/pkg/sql/rowexec/processors.go
@@ -217,7 +217,7 @@ func NewProcessor(
 		}
 		switch core.Backfiller.Type {
 		case execinfrapb.BackfillerSpec_Index:
-			return newIndexBackfiller(ctx, flowCtx, *core.Backfiller)
+			return newIndexBackfiller(ctx, flowCtx, processorID, *core.Backfiller)
 		case execinfrapb.BackfillerSpec_Column:
 			return newColumnBackfiller(ctx, flowCtx, processorID, *core.Backfiller)
 		}
@@ -372,7 +372,7 @@ func NewProcessor(
 		if err := checkNumIn(inputs, 0); err != nil {
 			return nil, err
 		}
-		return backfill.NewIndexBackfillMerger(ctx, flowCtx, *core.IndexBackfillMerger)
+		return backfill.NewIndexBackfillMerger(ctx, flowCtx, processorID, *core.IndexBackfillMerger)
 	}
 	if core.Ttl != nil {
 		if err := checkNumIn(inputs, 0); err != nil {

--- a/pkg/sql/rowexec/sample_aggregator.go
+++ b/pkg/sql/rowexec/sample_aggregator.go
@@ -185,7 +185,7 @@ func newSampleAggregator(
 }
 
 func (s *sampleAggregator) pushTrailingMeta(ctx context.Context, output execinfra.RowReceiver) {
-	execinfra.SendTraceData(ctx, output)
+	execinfra.SendTraceData(ctx, s.FlowCtx, output)
 }
 
 // Run is part of the Processor interface.

--- a/pkg/sql/rowexec/tablereader_test.go
+++ b/pkg/sql/rowexec/tablereader_test.go
@@ -340,9 +340,9 @@ func TestTableReaderDrain(t *testing.T) {
 		Cfg: &execinfra.ServerConfig{
 			Settings: st,
 		},
-		Txn:    leafTxn,
-		Local:  true,
-		NodeID: evalCtx.NodeID,
+		Txn:     leafTxn,
+		Gateway: false,
+		NodeID:  evalCtx.NodeID,
 	}
 	spec := execinfrapb.TableReaderSpec{
 		Spans:     []roachpb.Span{td.PrimaryIndexSpan(keys.SystemSQLCodec)},
@@ -393,8 +393,9 @@ func TestLimitScans(t *testing.T) {
 				func() int64 { return 2 << 10 }, s.Stopper(),
 			),
 		},
-		Txn:    kv.NewTxn(ctx, kvDB, s.NodeID()),
-		NodeID: evalCtx.NodeID,
+		Txn:     kv.NewTxn(ctx, kvDB, s.NodeID()),
+		NodeID:  evalCtx.NodeID,
+		Gateway: true,
 	}
 	spec := execinfrapb.TableReaderSpec{
 		FetchSpec: makeFetchSpec(t, tableDesc, "t_pkey", ""),
@@ -422,12 +423,6 @@ func TestLimitScans(t *testing.T) {
 		if row != nil {
 			rows++
 		}
-
-		// Simulate what the DistSQLReceiver does and ingest the trace.
-		if meta != nil && len(meta.TraceData) > 0 {
-			sp.ImportRemoteRecording(meta.TraceData)
-		}
-
 		if row == nil && meta == nil {
 			break
 		}

--- a/pkg/sql/rowexec/zigzagjoiner_test.go
+++ b/pkg/sql/rowexec/zigzagjoiner_test.go
@@ -779,6 +779,7 @@ func TestZigzagJoinerDrain(t *testing.T) {
 		Mon:     evalCtx.TestingMon,
 		Cfg:     &execinfra.ServerConfig{Settings: s.ClusterSettings()},
 		Txn:     leafTxn,
+		Gateway: false,
 	}
 
 	testReaderProcessorDrain(ctx, t, func() (execinfra.Processor, error) {

--- a/pkg/sql/rowflow/routers_test.go
+++ b/pkg/sql/rowflow/routers_test.go
@@ -70,7 +70,7 @@ func setupRouter(
 		Mon:         evalCtx.TestingMon,
 		DiskMonitor: diskMonitor,
 	}
-	r.init(ctx, &flowCtx, inputTypes)
+	r.init(ctx, &flowCtx, 0 /* processorID */, inputTypes)
 	wg := &sync.WaitGroup{}
 	r.Start(ctx, wg, nil /* flowCtxCancel */)
 	return r, wg
@@ -680,7 +680,7 @@ func TestRouterBlocks(t *testing.T) {
 				Mon:         evalCtx.TestingMon,
 				DiskMonitor: diskMonitor,
 			}
-			router.init(ctx, &flowCtx, colTypes)
+			router.init(ctx, &flowCtx, 0 /* processorID */, colTypes)
 			var wg sync.WaitGroup
 			router.Start(ctx, &wg, nil /* flowCtxCancel */)
 
@@ -818,7 +818,7 @@ func TestRouterDiskSpill(t *testing.T) {
 		// writes to the channel (after the first one).
 		rowChan.InitWithBufSizeAndNumSenders(types.OneIntCol, 1 /* chanBufSize */, 1 /* numSenders */)
 		rb.setupStreams(&spec, []execinfra.RowReceiver{&rowChan})
-		rb.init(ctx, &flowCtx, types.OneIntCol)
+		rb.init(ctx, &flowCtx, 0 /* processorID */, types.OneIntCol)
 		// output is the sole router output in this test.
 		output := &rb.outputs[0]
 		if !memErrorWhenConsumingRows {

--- a/pkg/sql/rowflow/test_utils.go
+++ b/pkg/sql/rowflow/test_utils.go
@@ -32,7 +32,7 @@ func MakeTestRouter(
 	if err != nil {
 		return nil, err
 	}
-	r.init(ctx, flowCtx, types)
+	r.init(ctx, flowCtx, 0 /* processorID */, types)
 	r.Start(ctx, wg, nil /* flowCtxCancel */)
 	return r, nil
 }

--- a/pkg/testutils/lint/lint_test.go
+++ b/pkg/testutils/lint/lint_test.go
@@ -1799,6 +1799,8 @@ func TestLint(t *testing.T) {
 				stream.GrepNot(`pkg/sql/row/expr_walker_test.go:.* evalCtx.SetDeprecatedContext is deprecated: .*`),
 				stream.GrepNot(`pkg/sql/schemachanger/scbuild/tree_context_builder.go:.* evalCtx.SetDeprecatedContext is deprecated: .*`),
 				stream.GrepNot(`pkg/sql/schemachanger/scplan/internal/rules/.*/.*go:.* should not use dot imports \(ST1001\)`),
+				// TODO(yuzefovich): remove this exclusion (#100438).
+				stream.GrepNot(`pkg/util/bulk/tracing_aggregator.go:.*SetLazyTagLocked is deprecated: .*`),
 			), func(s string) {
 				t.Errorf("\n%s", s)
 			}); err != nil {

--- a/pkg/util/bulk/tracing_aggregator.go
+++ b/pkg/util/bulk/tracing_aggregator.go
@@ -62,7 +62,7 @@ func (b *TracingAggregator) Notify(event tracing.Structured) tracing.EventConsum
 	eventTag := bulkEvent.Tag()
 	if _, ok := b.mu.aggregatedEvents[bulkEvent.Tag()]; !ok {
 		b.mu.aggregatedEvents[eventTag] = bulkEvent.Identity()
-		b.mu.sp.SetLazyTag(eventTag, b.mu.aggregatedEvents[eventTag])
+		b.mu.sp.SetLazyTagLocked(eventTag, b.mu.aggregatedEvents[eventTag])
 	}
 	b.mu.aggregatedEvents[eventTag].Combine(bulkEvent)
 	return tracing.EventNotConsumed

--- a/pkg/util/bulk/tracing_aggregator.go
+++ b/pkg/util/bulk/tracing_aggregator.go
@@ -48,10 +48,10 @@ type TracingAggregator struct {
 }
 
 // Notify implements the tracing.EventListener interface.
-func (b *TracingAggregator) Notify(event tracing.Structured) {
+func (b *TracingAggregator) Notify(event tracing.Structured) tracing.EventConsumptionStatus {
 	bulkEvent, ok := event.(TracingAggregatorEvent)
 	if !ok {
-		return
+		return tracing.EventNotConsumed
 	}
 
 	b.mu.Lock()
@@ -65,6 +65,7 @@ func (b *TracingAggregator) Notify(event tracing.Structured) {
 		b.mu.sp.SetLazyTag(eventTag, b.mu.aggregatedEvents[eventTag])
 	}
 	b.mu.aggregatedEvents[eventTag].Combine(bulkEvent)
+	return tracing.EventNotConsumed
 }
 
 // Close is responsible for finishing the Aggregators' tracing span.

--- a/pkg/util/tracing/crdbspan.go
+++ b/pkg/util/tracing/crdbspan.go
@@ -962,28 +962,28 @@ func (s *crdbSpan) getLazyTagLocked(key string) (interface{}, bool) {
 // convention between parents and children.
 func (s *crdbSpan) notifyEventListeners(item Structured) {
 	s.mu.Lock()
+	var unlocked bool
+	defer func() {
+		if !unlocked {
+			s.mu.Unlock()
+		}
+	}()
 
 	// Check if the span has been finished concurrently with this notify call.
 	// This can happen when the signal comes from a child span; in that case the
 	// child calls into the parent without holding the child's lock, so the call
 	// can race with parent.Finish().
 	if s.mu.finished {
-		s.mu.Unlock()
 		return
 	}
-	s.mu.Unlock()
 
 	// Notify s' eventListeners first, before passing the event to parent.
-	//
-	// We can operate on s' eventListeners without holding the mutex because the
-	// slice is only written to once during span creation.
 	for _, listener := range s.eventListeners {
 		if listener.Notify(item) == EventConsumed {
 			return
 		}
 	}
 
-	s.mu.Lock()
 	if s.mu.recording.notifyParentOnStructuredEvent {
 		parent := s.mu.parent.Span.i.crdb
 		// Take a reference of s' parent before releasing the mutex. This ensures
@@ -992,9 +992,8 @@ func (s *crdbSpan) notifyEventListeners(item Structured) {
 		parentRef := makeSpanRef(s.mu.parent.Span)
 		defer parentRef.release()
 		s.mu.Unlock()
+		unlocked = true
 		parent.notifyEventListeners(item)
-	} else {
-		s.mu.Unlock()
 	}
 }
 

--- a/pkg/util/tracing/span.go
+++ b/pkg/util/tracing/span.go
@@ -539,8 +539,23 @@ type EventListener interface {
 	// span recording Structured events during traced operations.
 	//
 	// Notify will not be called concurrently on the same span.
-	Notify(event Structured)
+	Notify(event Structured) EventConsumptionStatus
 }
+
+// EventConsumptionStatus describes whether the structured event has been "consumed"
+// by the EventListener.
+type EventConsumptionStatus int
+
+const (
+	// EventNotConsumed indicates that the event wasn't "consumed" by the
+	// EventListener, so other listeners as well as any ancestor spans should be
+	// notified about the event.
+	EventNotConsumed EventConsumptionStatus = iota
+	// EventConsumed indicates that the event has been "consumed" by the
+	// EventListener, so neither other listeners for the span nor the ancestor
+	// spans should be notified about it.
+	EventConsumed
+)
 
 // TraceID retrieves a span's trace ID.
 func (sp *Span) TraceID() tracingpb.TraceID {

--- a/pkg/util/tracing/span.go
+++ b/pkg/util/tracing/span.go
@@ -520,6 +520,19 @@ func (sp *Span) SetLazyTag(key string, value interface{}) {
 	sp.i.SetLazyTag(key, value)
 }
 
+// SetLazyTagLocked is the same as SetLazyTag but assumes that the mutex of sp
+// is being held.
+//
+// Deprecated: this method should not be used because it's introduced only to go
+// around some tech debt (#100438). Once that issue is addressed, this method
+// should be removed.
+func (sp *Span) SetLazyTagLocked(key string, value interface{}) {
+	if sp.detectUseAfterFinish() {
+		return
+	}
+	sp.i.setLazyTagLocked(key, value)
+}
+
 // GetLazyTag returns the value of the tag with the given key. If that tag doesn't
 // exist, the bool retval is false.
 func (sp *Span) GetLazyTag(key string) (interface{}, bool) {
@@ -535,8 +548,7 @@ type EventListener interface {
 	// Notify is invoked on every Structured event recorded by the span and its
 	// children, recursively.
 	//
-	// Note that this method should not run for a long time as it will hold up the
-	// span recording Structured events during traced operations.
+	// The caller holds the mutex of the span.
 	//
 	// Notify will not be called concurrently on the same span.
 	Notify(event Structured) EventConsumptionStatus

--- a/pkg/util/tracing/span_inner.go
+++ b/pkg/util/tracing/span_inner.go
@@ -241,6 +241,14 @@ func (s *spanInner) SetLazyTag(key string, value interface{}) *spanInner {
 	return s
 }
 
+func (s *spanInner) setLazyTagLocked(key string, value interface{}) *spanInner {
+	if s.isNoop() {
+		return s
+	}
+	s.crdb.setLazyTagLocked(key, value)
+	return s
+}
+
 // GetLazyTag returns the value of the tag with the given key. If that tag doesn't
 // exist, the bool retval is false.
 func (s *spanInner) GetLazyTag(key string) (interface{}, bool) {

--- a/pkg/util/tracing/span_test.go
+++ b/pkg/util/tracing/span_test.go
@@ -1310,16 +1310,12 @@ func TestWithRemoteParentFromTraceInfo(t *testing.T) {
 
 type mockEventListener struct {
 	eventsSeen int
-	notifyImpl func()
 	// If set, then the events are "consumed" by this listener.
 	consuming bool
 }
 
 func (f *mockEventListener) Notify(_ Structured) EventConsumptionStatus {
 	f.eventsSeen++
-	if f.notifyImpl != nil {
-		f.notifyImpl()
-	}
 	if f.consuming {
 		return EventConsumed
 	}
@@ -1390,25 +1386,6 @@ func TestEventListener(t *testing.T) {
 	childSp2.RecordStructured(&types.Int32Value{Value: 12})
 	require.Equal(t, 7, rootEventListener.eventsSeen)
 	childSp2.Finish()
-}
-
-func TestEventListenerNotifiedWithoutHoldingSpanMutex(t *testing.T) {
-	tr := NewTracer()
-	rootEventListener := &mockEventListener{}
-	sp := tr.StartSpan("root", WithRecording(tracingpb.RecordingStructured),
-		WithEventListeners(rootEventListener))
-	defer sp.Finish()
-
-	// Set the EventListeners Notify() method to acquire the span's mutex.
-	rootEventListener.notifyImpl = func() {
-		sp.i.crdb.mu.Lock()
-		defer sp.i.crdb.mu.Unlock()
-	}
-
-	// Record a StructuredEvent, if Notify() were called holding the span's mutex
-	// this would deadlock.
-	sp.RecordStructured(&types.Int32Value{Value: 5})
-	require.Equal(t, 1, rootEventListener.eventsSeen)
 }
 
 // TestFinishedChildrenMetadata tests that on Finish() the parent span's


### PR DESCRIPTION
**tracing: make it possible for EventListeners to "consume" the event**

This commit extends `Notify` signature with a return argument in order
to introduce the notion of "event consumption". Once a listener
"consumes" the event, no other listener for the span nor the ancestor
spans will be notified about the event. This behavior is needed by the
follow-up commit which changes how DistSQL processors examine their
traces to pick out their "own" events from the events of their inputs.

This also resulted in notifications of the span's listeners be done
before the ancestor.

Release note: None

**execinfra: plumb FlowCtx and processorID into ProcessorSpan method**

This commit is mostly a mechanical change to plumb `FlowCtx` object as
well as the processor ID into `ProcessorSpan` method. The main goal of
this work is to be able to know whether the method is called on the
gateway node or not (this will be used by the follow-up commit), but
this change also results in unification of how FlowID and ProcessoID
tags are set on the tracing span.

Release note: None

**execstats: collect some stats via EventListeners**

This commit changes how contention time, scan stats, and consumed RU
information are accumulated by the processors. Previously, we would
analyze the trace recording of the processor to pick out all applicable
events from the trace and aggregate across all of them. This worked well
because currently we always create "detached" spans for all processors
(in other words, a contention event attached to the span of one
processor will not be seen by the parent processor).

However, the following commit will change that for processors on the
gateway. Namely, all processors on the gateway will no longer use the
detached option. As a result, we need to have a different way to
distinguish between events seen by the processor itself versus events
seen by the "child" processor. This commit introduces that way via the
EventListeners. In particular, it defines three types of listeners (for
all kinds of structured events we're interested in), which are then used
by all processors.

Release note: None

**sql: don't propagate spans from local processors as metadata**

This commit changes how we create tracing spans for components of the
flow on the gateway. Previously, we would always create them with the
detached option, and, as a result, we needed to collect the traces and
propagate them as metadata to be imported by the DistSQLReceiver into
the span of the flow on the gateway. However, this is not necessary to
do so on the gateway - we can just let the regular tracing behavior to
happen there.

The main benefit of this change is that we now preserve the hierarchy of
the tracing spans in the gateway flows making them much more
understandable when viewing via the jaeger. Perhaps this is also a minor
performance improvement since the native trace collection is probably
faster than having to import the trace data via the metadata, as was
done previously.

An additional improvement can be made to create the spans with the
detached recording only for the root components of the remote flows.
This is left as a TODO for now.

Epic: None

Release note: None

**tracing: Notify EventListeners while holding the span's mutex**

This commit addresses an oversight that was introduced in https://github.com/cockroachdb/cockroach/commit/6a3c0f9207eda2d136046a367049160f0386cd8b
where we made the notifications of the EventListeners done without
holding the span's mutex. However, the contract of `WithEventListeners`
implies that the callbacks are not called any more after `Finish()`
returns, so that commit introduced a bug that is now fixed in this
commit.

The fix done in this commit is suboptimal though - it introduces an
exported method `SetLazyTagLocked` which is not great. The proper fix
would be to refactor `TracingAggregator` to avoid setting the lazy tag
dynamically, in the event listener callback, but that seems like
a non-trivial change, and I'd like to get this commit backported. To
avoid introducing more callsites of this `SetLazyTagLocked` method it is
marked as "deprecated" and https://github.com/cockroachdb/cockroach/issues/100438 tracks addressing this piece of the
tech debt.

Release note: None