### PR TITLE
roachtest/awsdms: fix version to 13

### DIFF
--- a/pkg/cmd/roachtest/tests/awsdms.go
+++ b/pkg/cmd/roachtest/tests/awsdms.go
@@ -617,7 +617,7 @@ func setupRDSCluster(
 		rdsGroup, err := rdsCli.CreateDBClusterParameterGroup(
 			ctx,
 			&rds.CreateDBClusterParameterGroupInput{
-				DBParameterGroupFamily:      proto.String("aurora-postgresql14"),
+				DBParameterGroupFamily:      proto.String("aurora-postgresql13"),
 				DBClusterParameterGroupName: proto.String(awsdmsRoachtestDMSParameterGroup(t.BuildVersion())),
 				Description:                 proto.String("roachtest awsdms parameter groups"),
 			},
@@ -652,6 +652,7 @@ func setupRDSCluster(
 			&rds.CreateDBClusterInput{
 				DBClusterIdentifier:         proto.String(awsdmsRoachtestRDSClusterName(t.BuildVersion())),
 				Engine:                      proto.String("aurora-postgresql"),
+				EngineVersion:               proto.String("13"),
 				DBClusterParameterGroupName: proto.String(awsdmsRoachtestDMSParameterGroup(t.BuildVersion())),
 				MasterUsername:              proto.String(awsdmsUser),
 				MasterUserPassword:          proto.String(awsdmsPassword),


### PR DESCRIPTION
Instead of going to 14, try go always stand up 13 instead.

Release note: None

Informs https://github.com/cockroachdb/cockroach/issues/91468
Informs https://github.com/cockroachdb/cockroach/issues/98121