### PR TITLE
ci: attempt to shard huge test targets more

### DIFF
--- a/build/teamcity/cockroach/ci/tests/unit_tests_ccl.sh
+++ b/build/teamcity/cockroach/ci/tests/unit_tests_ccl.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+dir="$(dirname $(dirname $(dirname $(dirname $(dirname "${0}")))))"
+
+source "$dir/teamcity-support.sh"  # For $root
+source "$dir/teamcity-bazel-support.sh"  # For run_bazel
+
+tc_start_block "Run unit tests"
+BAZEL_SUPPORT_EXTRA_DOCKER_ARGS="-e TC_BUILD_BRANCH -e GITHUB_API_TOKEN -e BUILD_VCS_NUMBER -e TC_BUILD_ID -e TC_SERVER_URL -e TC_BUILDTYPE_ID -e GITHUB_REPO" run_bazel build/teamcity/cockroach/ci/tests/unit_tests_ccl_impl.sh
+tc_end_block "Run unit tests"

--- a/build/teamcity/cockroach/ci/tests/unit_tests_ccl_impl.sh
+++ b/build/teamcity/cockroach/ci/tests/unit_tests_ccl_impl.sh
@@ -16,5 +16,5 @@ if tc_release_branch; then
 fi
 
 $(bazel info bazel-bin --config=ci)/pkg/cmd/bazci/bazci_/bazci -- test --config=cinolint -c fastbuild \
-                                  //pkg:small_non_ccl_tests //pkg:medium_non_ccl_tests //pkg:large_non_ccl_tests //pkg:enormous_non_ccl_tests \
+                                  //pkg:ccl_tests \
                                    --profile=/artifacts/profile.gz $EXTRA_PARAMS

--- a/pkg/BUILD.bazel
+++ b/pkg/BUILD.bazel
@@ -3378,9 +3378,20 @@ test_suite(
 )
 
 test_suite(
-    name = "small_tests",
+    name = "ccl_tests",
     tags = [
         "-broken_in_bazel",
+        "ccl_test",
+        "-integration",
+    ],
+    tests = ALL_TESTS,
+)
+
+test_suite(
+    name = "small_non_ccl_tests",
+    tags = [
+        "-broken_in_bazel",
+        "-ccl_test",
         "-flaky",
         "-integration",
         "small",
@@ -3389,9 +3400,10 @@ test_suite(
 )
 
 test_suite(
-    name = "medium_tests",
+    name = "medium_non_ccl_tests",
     tags = [
         "-broken_in_bazel",
+        "-ccl_test",
         "-flaky",
         "-integration",
         "medium",
@@ -3400,9 +3412,10 @@ test_suite(
 )
 
 test_suite(
-    name = "large_tests",
+    name = "large_non_ccl_tests",
     tags = [
         "-broken_in_bazel",
+        "-ccl_test",
         "-flaky",
         "-integration",
         "large",
@@ -3411,9 +3424,10 @@ test_suite(
 )
 
 test_suite(
-    name = "enormous_tests",
+    name = "enormous_non_ccl_tests",
     tags = [
         "-broken_in_bazel",
+        "-ccl_test",
         "-flaky",
         "-integration",
         "enormous",

--- a/pkg/ccl/backupccl/BUILD.bazel
+++ b/pkg/ccl/backupccl/BUILD.bazel
@@ -195,7 +195,8 @@ go_test(
     args = ["-test.timeout=3595s"],
     data = glob(["testdata/**"]) + ["//c-deps:libgeos"],
     embed = [":backupccl"],
-    shard_count = 16,
+    shard_count = 48,
+    tags = ["ccl_test"],
     deps = [
         "//pkg/base",
         "//pkg/blobs",

--- a/pkg/ccl/backupccl/backupdest/BUILD.bazel
+++ b/pkg/ccl/backupccl/backupdest/BUILD.bazel
@@ -42,6 +42,7 @@ go_test(
         "main_test.go",
     ],
     args = ["-test.timeout=295s"],
+    tags = ["ccl_test"],
     deps = [
         ":backupdest",
         "//pkg/ccl",

--- a/pkg/ccl/backupccl/backupinfo/BUILD.bazel
+++ b/pkg/ccl/backupccl/backupinfo/BUILD.bazel
@@ -65,6 +65,7 @@ go_test(
         "manifest_handling_test.go",
     ],
     args = ["-test.timeout=295s"],
+    tags = ["ccl_test"],
     deps = [
         ":backupinfo",
         "//pkg/base",

--- a/pkg/ccl/backupccl/backuprand/BUILD.bazel
+++ b/pkg/ccl/backupccl/backuprand/BUILD.bazel
@@ -9,6 +9,7 @@ go_test(
     ],
     args = ["-test.timeout=295s"],
     data = ["//c-deps:libgeos"],
+    tags = ["ccl_test"],
     deps = [
         "//pkg/base",
         "//pkg/ccl",

--- a/pkg/ccl/backupccl/backupresolver/BUILD.bazel
+++ b/pkg/ccl/backupccl/backupresolver/BUILD.bazel
@@ -32,6 +32,7 @@ go_test(
     ],
     args = ["-test.timeout=295s"],
     embed = [":backupresolver"],
+    tags = ["ccl_test"],
     deps = [
         "//pkg/ccl",
         "//pkg/ccl/storageccl",

--- a/pkg/ccl/baseccl/BUILD.bazel
+++ b/pkg/ccl/baseccl/BUILD.bazel
@@ -24,6 +24,7 @@ go_test(
     srcs = ["encryption_spec_test.go"],
     args = ["-test.timeout=55s"],
     embed = [":baseccl"],
+    tags = ["ccl_test"],
     deps = ["//pkg/util/leaktest"],
 )
 

--- a/pkg/ccl/benchccl/rttanalysisccl/BUILD.bazel
+++ b/pkg/ccl/benchccl/rttanalysisccl/BUILD.bazel
@@ -11,6 +11,7 @@ go_test(
     args = ["-test.timeout=3595s"],
     data = glob(["testdata/**"]),
     shard_count = 16,
+    tags = ["ccl_test"],
     deps = [
         "//pkg/base",
         "//pkg/bench/rttanalysis",

--- a/pkg/ccl/changefeedccl/BUILD.bazel
+++ b/pkg/ccl/changefeedccl/BUILD.bazel
@@ -195,6 +195,7 @@ go_test(
     args = ["-test.timeout=3595s"],
     embed = [":changefeedccl"],
     shard_count = 16,
+    tags = ["ccl_test"],
     deps = [
         "//pkg/base",
         "//pkg/blobs",

--- a/pkg/ccl/changefeedccl/cdceval/BUILD.bazel
+++ b/pkg/ccl/changefeedccl/cdceval/BUILD.bazel
@@ -63,6 +63,7 @@ go_test(
     ],
     args = ["-test.timeout=295s"],
     embed = [":cdceval"],
+    tags = ["ccl_test"],
     deps = [
         "//pkg/base",
         "//pkg/ccl/changefeedccl/cdcevent",

--- a/pkg/ccl/changefeedccl/cdcevent/BUILD.bazel
+++ b/pkg/ccl/changefeedccl/cdcevent/BUILD.bazel
@@ -52,6 +52,7 @@ go_test(
     ],
     args = ["-test.timeout=295s"],
     embed = [":cdcevent"],
+    tags = ["ccl_test"],
     deps = [
         "//pkg/base",
         "//pkg/ccl/changefeedccl/cdctest",

--- a/pkg/ccl/changefeedccl/cdctest/BUILD.bazel
+++ b/pkg/ccl/changefeedccl/cdctest/BUILD.bazel
@@ -50,6 +50,7 @@ go_test(
     ],
     args = ["-test.timeout=55s"],
     embed = [":cdctest"],
+    tags = ["ccl_test"],
     deps = [
         "//pkg/base",
         "//pkg/ccl",

--- a/pkg/ccl/changefeedccl/cdcutils/BUILD.bazel
+++ b/pkg/ccl/changefeedccl/cdcutils/BUILD.bazel
@@ -22,6 +22,7 @@ go_test(
     srcs = ["throttle_test.go"],
     args = ["-test.timeout=295s"],
     embed = [":cdcutils"],
+    tags = ["ccl_test"],
     deps = [
         "//pkg/ccl/changefeedccl/changefeedbase",
         "//pkg/settings/cluster",

--- a/pkg/ccl/changefeedccl/changefeedbase/BUILD.bazel
+++ b/pkg/ccl/changefeedccl/changefeedbase/BUILD.bazel
@@ -31,6 +31,7 @@ go_test(
     srcs = ["options_test.go"],
     args = ["-test.timeout=295s"],
     embed = [":changefeedbase"],
+    tags = ["ccl_test"],
     deps = [
         "//pkg/util/leaktest",
         "//pkg/util/log",

--- a/pkg/ccl/changefeedccl/kvevent/BUILD.bazel
+++ b/pkg/ccl/changefeedccl/kvevent/BUILD.bazel
@@ -43,6 +43,7 @@ go_test(
     ],
     args = ["-test.timeout=295s"],
     embed = [":kvevent"],
+    tags = ["ccl_test"],
     deps = [
         "//pkg/jobs/jobspb",
         "//pkg/keys",

--- a/pkg/ccl/changefeedccl/kvfeed/BUILD.bazel
+++ b/pkg/ccl/changefeedccl/kvfeed/BUILD.bazel
@@ -49,6 +49,7 @@ go_test(
     ],
     args = ["-test.timeout=55s"],
     embed = [":kvfeed"],
+    tags = ["ccl_test"],
     deps = [
         "//pkg/base",
         "//pkg/ccl",

--- a/pkg/ccl/changefeedccl/schemafeed/BUILD.bazel
+++ b/pkg/ccl/changefeedccl/schemafeed/BUILD.bazel
@@ -55,6 +55,7 @@ go_test(
     args = ["-test.timeout=295s"],
     data = glob(["testdata/**"]),
     embed = [":schemafeed"],
+    tags = ["ccl_test"],
     deps = [
         "//pkg/base",
         "//pkg/ccl",

--- a/pkg/ccl/cliccl/BUILD.bazel
+++ b/pkg/ccl/cliccl/BUILD.bazel
@@ -55,6 +55,7 @@ go_test(
     ],
     args = ["-test.timeout=295s"],
     embed = [":cliccl"],
+    tags = ["ccl_test"],
     deps = [
         "//pkg/build",
         "//pkg/ccl",

--- a/pkg/ccl/cloudccl/amazon/BUILD.bazel
+++ b/pkg/ccl/cloudccl/amazon/BUILD.bazel
@@ -8,6 +8,7 @@ go_test(
         "s3_connection_test.go",
     ],
     args = ["-test.timeout=295s"],
+    tags = ["ccl_test"],
     deps = [
         "//pkg/base",
         "//pkg/ccl",

--- a/pkg/ccl/cloudccl/azure/BUILD.bazel
+++ b/pkg/ccl/cloudccl/azure/BUILD.bazel
@@ -8,6 +8,7 @@ go_test(
         "main_test.go",
     ],
     args = ["-test.timeout=295s"],
+    tags = ["ccl_test"],
     deps = [
         "//pkg/base",
         "//pkg/ccl",

--- a/pkg/ccl/cloudccl/cloudprivilege/BUILD.bazel
+++ b/pkg/ccl/cloudccl/cloudprivilege/BUILD.bazel
@@ -8,6 +8,7 @@ go_test(
         "privileges_test.go",
     ],
     args = ["-test.timeout=295s"],
+    tags = ["ccl_test"],
     deps = [
         "//pkg/base",
         "//pkg/ccl",

--- a/pkg/ccl/cloudccl/externalconn/BUILD.bazel
+++ b/pkg/ccl/cloudccl/externalconn/BUILD.bazel
@@ -9,6 +9,7 @@ go_test(
     ],
     args = ["-test.timeout=295s"],
     data = glob(["testdata/**"]),
+    tags = ["ccl_test"],
     deps = [
         "//pkg/base",
         "//pkg/ccl/backupccl",

--- a/pkg/ccl/cloudccl/gcp/BUILD.bazel
+++ b/pkg/ccl/cloudccl/gcp/BUILD.bazel
@@ -8,6 +8,7 @@ go_test(
         "main_test.go",
     ],
     args = ["-test.timeout=295s"],
+    tags = ["ccl_test"],
     deps = [
         "//pkg/base",
         "//pkg/ccl",

--- a/pkg/ccl/importerccl/BUILD.bazel
+++ b/pkg/ccl/importerccl/BUILD.bazel
@@ -12,6 +12,7 @@ go_test(
         "//c-deps:libgeos",
         "//pkg/sql/importer:testdata",
     ],
+    tags = ["ccl_test"],
     deps = [
         "//pkg/base",
         "//pkg/build/bazel",

--- a/pkg/ccl/jobsccl/jobsprotectedtsccl/BUILD.bazel
+++ b/pkg/ccl/jobsccl/jobsprotectedtsccl/BUILD.bazel
@@ -8,6 +8,7 @@ go_test(
         "main_test.go",
     ],
     args = ["-test.timeout=295s"],
+    tags = ["ccl_test"],
     deps = [
         "//pkg/base",
         "//pkg/ccl",

--- a/pkg/ccl/jwtauthccl/BUILD.bazel
+++ b/pkg/ccl/jwtauthccl/BUILD.bazel
@@ -36,6 +36,7 @@ go_test(
     ],
     args = ["-test.timeout=55s"],
     embed = [":jwtauthccl"],
+    tags = ["ccl_test"],
     deps = [
         "//pkg/base",
         "//pkg/ccl",

--- a/pkg/ccl/kvccl/kvfollowerreadsccl/BUILD.bazel
+++ b/pkg/ccl/kvccl/kvfollowerreadsccl/BUILD.bazel
@@ -45,6 +45,7 @@ go_test(
     args = ["-test.timeout=295s"],
     data = glob(["testdata/**"]),
     embed = [":kvfollowerreadsccl"],
+    tags = ["ccl_test"],
     deps = [
         "//pkg/base",
         "//pkg/ccl",

--- a/pkg/ccl/kvccl/kvtenantccl/BUILD.bazel
+++ b/pkg/ccl/kvccl/kvtenantccl/BUILD.bazel
@@ -59,6 +59,7 @@ go_test(
     args = ["-test.timeout=895s"],
     embed = [":kvtenantccl"],
     shard_count = 16,
+    tags = ["ccl_test"],
     deps = [
         "//pkg/base",
         "//pkg/ccl",

--- a/pkg/ccl/logictestccl/tests/3node-tenant-multiregion/BUILD.bazel
+++ b/pkg/ccl/logictestccl/tests/3node-tenant-multiregion/BUILD.bazel
@@ -12,7 +12,10 @@ go_test(
         "//pkg/sql/opt/exec/execbuilder:testdata",  # keep
     ],
     shard_count = 4,
-    tags = ["cpu:2"],
+    tags = [
+        "ccl_test",
+        "cpu:2",
+    ],
     deps = [
         "//pkg/build/bazel",
         "//pkg/ccl",

--- a/pkg/ccl/logictestccl/tests/3node-tenant/BUILD.bazel
+++ b/pkg/ccl/logictestccl/tests/3node-tenant/BUILD.bazel
@@ -12,8 +12,11 @@ go_test(
         "//pkg/sql/logictest:testdata",  # keep
         "//pkg/sql/opt/exec/execbuilder:testdata",  # keep
     ],
-    shard_count = 16,
-    tags = ["cpu:2"],
+    shard_count = 48,
+    tags = [
+        "ccl_test",
+        "cpu:2",
+    ],
     deps = [
         "//pkg/build/bazel",
         "//pkg/ccl",

--- a/pkg/ccl/logictestccl/tests/5node/BUILD.bazel
+++ b/pkg/ccl/logictestccl/tests/5node/BUILD.bazel
@@ -11,7 +11,10 @@ go_test(
         "//pkg/ccl/logictestccl:testdata",  # keep
     ],
     shard_count = 5,
-    tags = ["cpu:3"],
+    tags = [
+        "ccl_test",
+        "cpu:3",
+    ],
     deps = [
         "//pkg/build/bazel",
         "//pkg/ccl",

--- a/pkg/ccl/logictestccl/tests/fakedist-disk/BUILD.bazel
+++ b/pkg/ccl/logictestccl/tests/fakedist-disk/BUILD.bazel
@@ -11,7 +11,10 @@ go_test(
         "//pkg/ccl/logictestccl:testdata",  # keep
     ],
     shard_count = 5,
-    tags = ["cpu:2"],
+    tags = [
+        "ccl_test",
+        "cpu:2",
+    ],
     deps = [
         "//pkg/build/bazel",
         "//pkg/ccl",

--- a/pkg/ccl/logictestccl/tests/fakedist-vec-off/BUILD.bazel
+++ b/pkg/ccl/logictestccl/tests/fakedist-vec-off/BUILD.bazel
@@ -11,7 +11,10 @@ go_test(
         "//pkg/ccl/logictestccl:testdata",  # keep
     ],
     shard_count = 5,
-    tags = ["cpu:2"],
+    tags = [
+        "ccl_test",
+        "cpu:2",
+    ],
     deps = [
         "//pkg/build/bazel",
         "//pkg/ccl",

--- a/pkg/ccl/logictestccl/tests/fakedist/BUILD.bazel
+++ b/pkg/ccl/logictestccl/tests/fakedist/BUILD.bazel
@@ -11,7 +11,10 @@ go_test(
         "//pkg/ccl/logictestccl:testdata",  # keep
     ],
     shard_count = 6,
-    tags = ["cpu:2"],
+    tags = [
+        "ccl_test",
+        "cpu:2",
+    ],
     deps = [
         "//pkg/build/bazel",
         "//pkg/ccl",

--- a/pkg/ccl/logictestccl/tests/local-legacy-schema-changer/BUILD.bazel
+++ b/pkg/ccl/logictestccl/tests/local-legacy-schema-changer/BUILD.bazel
@@ -11,7 +11,10 @@ go_test(
         "//pkg/ccl/logictestccl:testdata",  # keep
     ],
     shard_count = 5,
-    tags = ["cpu:1"],
+    tags = [
+        "ccl_test",
+        "cpu:1",
+    ],
     deps = [
         "//pkg/build/bazel",
         "//pkg/ccl",

--- a/pkg/ccl/logictestccl/tests/local-vec-off/BUILD.bazel
+++ b/pkg/ccl/logictestccl/tests/local-vec-off/BUILD.bazel
@@ -11,7 +11,10 @@ go_test(
         "//pkg/ccl/logictestccl:testdata",  # keep
     ],
     shard_count = 5,
-    tags = ["cpu:1"],
+    tags = [
+        "ccl_test",
+        "cpu:1",
+    ],
     deps = [
         "//pkg/build/bazel",
         "//pkg/ccl",

--- a/pkg/ccl/logictestccl/tests/local/BUILD.bazel
+++ b/pkg/ccl/logictestccl/tests/local/BUILD.bazel
@@ -10,8 +10,11 @@ go_test(
         "//c-deps:libgeos",  # keep
         "//pkg/ccl/logictestccl:testdata",  # keep
     ],
-    shard_count = 16,
-    tags = ["cpu:1"],
+    shard_count = 19,
+    tags = [
+        "ccl_test",
+        "cpu:1",
+    ],
     deps = [
         "//pkg/build/bazel",
         "//pkg/ccl",

--- a/pkg/ccl/logictestccl/tests/multiregion-15node-5region-3azs/BUILD.bazel
+++ b/pkg/ccl/logictestccl/tests/multiregion-15node-5region-3azs/BUILD.bazel
@@ -11,7 +11,10 @@ go_test(
         "//pkg/ccl/logictestccl:testdata",  # keep
     ],
     shard_count = 4,
-    tags = ["cpu:4"],
+    tags = [
+        "ccl_test",
+        "cpu:4",
+    ],
     deps = [
         "//pkg/build/bazel",
         "//pkg/ccl",

--- a/pkg/ccl/logictestccl/tests/multiregion-3node-3superlongregions/BUILD.bazel
+++ b/pkg/ccl/logictestccl/tests/multiregion-3node-3superlongregions/BUILD.bazel
@@ -11,7 +11,10 @@ go_test(
         "//pkg/ccl/logictestccl:testdata",  # keep
     ],
     shard_count = 1,
-    tags = ["cpu:2"],
+    tags = [
+        "ccl_test",
+        "cpu:2",
+    ],
     deps = [
         "//pkg/build/bazel",
         "//pkg/ccl",

--- a/pkg/ccl/logictestccl/tests/multiregion-9node-3region-3azs-no-los/BUILD.bazel
+++ b/pkg/ccl/logictestccl/tests/multiregion-9node-3region-3azs-no-los/BUILD.bazel
@@ -10,8 +10,11 @@ go_test(
         "//c-deps:libgeos",  # keep
         "//pkg/ccl/logictestccl:testdata",  # keep
     ],
-    shard_count = 16,
-    tags = ["cpu:4"],
+    shard_count = 19,
+    tags = [
+        "ccl_test",
+        "cpu:4",
+    ],
     deps = [
         "//pkg/build/bazel",
         "//pkg/ccl",

--- a/pkg/ccl/logictestccl/tests/multiregion-9node-3region-3azs-tenant/BUILD.bazel
+++ b/pkg/ccl/logictestccl/tests/multiregion-9node-3region-3azs-tenant/BUILD.bazel
@@ -11,7 +11,10 @@ go_test(
         "//pkg/ccl/logictestccl:testdata",  # keep
     ],
     shard_count = 14,
-    tags = ["cpu:4"],
+    tags = [
+        "ccl_test",
+        "cpu:4",
+    ],
     deps = [
         "//pkg/build/bazel",
         "//pkg/ccl",

--- a/pkg/ccl/logictestccl/tests/multiregion-9node-3region-3azs-vec-off/BUILD.bazel
+++ b/pkg/ccl/logictestccl/tests/multiregion-9node-3region-3azs-vec-off/BUILD.bazel
@@ -11,7 +11,10 @@ go_test(
         "//pkg/ccl/logictestccl:testdata",  # keep
     ],
     shard_count = 8,
-    tags = ["cpu:4"],
+    tags = [
+        "ccl_test",
+        "cpu:4",
+    ],
     deps = [
         "//pkg/build/bazel",
         "//pkg/ccl",

--- a/pkg/ccl/logictestccl/tests/multiregion-9node-3region-3azs/BUILD.bazel
+++ b/pkg/ccl/logictestccl/tests/multiregion-9node-3region-3azs/BUILD.bazel
@@ -10,8 +10,11 @@ go_test(
         "//c-deps:libgeos",  # keep
         "//pkg/ccl/logictestccl:testdata",  # keep
     ],
-    shard_count = 16,
-    tags = ["cpu:4"],
+    shard_count = 26,
+    tags = [
+        "ccl_test",
+        "cpu:4",
+    ],
     deps = [
         "//pkg/build/bazel",
         "//pkg/ccl",

--- a/pkg/ccl/multiregionccl/BUILD.bazel
+++ b/pkg/ccl/multiregionccl/BUILD.bazel
@@ -43,6 +43,7 @@ go_test(
     data = glob(["testdata/**"]),
     embed = [":multiregionccl"],
     shard_count = 16,
+    tags = ["ccl_test"],
     deps = [
         "//pkg/base",
         "//pkg/ccl",

--- a/pkg/ccl/multitenantccl/tenantcapabilitiesccl/BUILD.bazel
+++ b/pkg/ccl/multitenantccl/tenantcapabilitiesccl/BUILD.bazel
@@ -9,6 +9,7 @@ go_test(
     ],
     args = ["-test.timeout=295s"],
     data = glob(["testdata/**"]),
+    tags = ["ccl_test"],
     deps = [
         "//pkg/base",
         "//pkg/ccl",

--- a/pkg/ccl/multitenantccl/tenantcostclient/BUILD.bazel
+++ b/pkg/ccl/multitenantccl/tenantcostclient/BUILD.bazel
@@ -46,6 +46,7 @@ go_test(
     args = ["-test.timeout=295s"],
     data = glob(["testdata/**"]),
     embed = [":tenantcostclient"],
+    tags = ["ccl_test"],
     deps = [
         "//pkg/base",
         "//pkg/blobs",

--- a/pkg/ccl/multitenantccl/tenantcostserver/BUILD.bazel
+++ b/pkg/ccl/multitenantccl/tenantcostserver/BUILD.bazel
@@ -47,6 +47,7 @@ go_test(
     args = ["-test.timeout=295s"],
     data = glob(["testdata/**"]),
     embed = [":tenantcostserver"],
+    tags = ["ccl_test"],
     deps = [
         "//pkg/base",
         "//pkg/kv",

--- a/pkg/ccl/multitenantccl/tenantcostserver/tenanttokenbucket/BUILD.bazel
+++ b/pkg/ccl/multitenantccl/tenantcostserver/tenanttokenbucket/BUILD.bazel
@@ -19,6 +19,7 @@ go_test(
     args = ["-test.timeout=295s"],
     data = glob(["testdata/**"]),
     embed = [":tenanttokenbucket"],
+    tags = ["ccl_test"],
     deps = [
         "//pkg/kv/kvpb",
         "//pkg/testutils/datapathutils",

--- a/pkg/ccl/oidcccl/BUILD.bazel
+++ b/pkg/ccl/oidcccl/BUILD.bazel
@@ -40,6 +40,7 @@ go_test(
     ],
     args = ["-test.timeout=55s"],
     embed = [":oidcccl"],
+    tags = ["ccl_test"],
     deps = [
         "//pkg/base",
         "//pkg/ccl",

--- a/pkg/ccl/partitionccl/BUILD.bazel
+++ b/pkg/ccl/partitionccl/BUILD.bazel
@@ -42,6 +42,7 @@ go_test(
     ],
     args = ["-test.timeout=295s"],
     embed = [":partitionccl"],
+    tags = ["ccl_test"],
     deps = [
         "//pkg/base",
         "//pkg/ccl",

--- a/pkg/ccl/schemachangerccl/BUILD.bazel
+++ b/pkg/ccl/schemachangerccl/BUILD.bazel
@@ -17,8 +17,11 @@ go_test(
         "//pkg/sql/schemachanger:testdata",
     ],
     embed = [":schemachangerccl"],
-    shard_count = 16,
-    tags = ["cpu:3"],
+    shard_count = 48,
+    tags = [
+        "ccl_test",
+        "cpu:3",
+    ],
     deps = [
         "//pkg/base",
         "//pkg/ccl",

--- a/pkg/ccl/serverccl/BUILD.bazel
+++ b/pkg/ccl/serverccl/BUILD.bazel
@@ -47,6 +47,7 @@ go_test(
     args = ["-test.timeout=3595s"],
     data = glob(["testdata/**"]),
     embed = [":serverccl"],
+    tags = ["ccl_test"],
     deps = [
         "//pkg/base",
         "//pkg/ccl",

--- a/pkg/ccl/serverccl/adminccl/BUILD.bazel
+++ b/pkg/ccl/serverccl/adminccl/BUILD.bazel
@@ -8,6 +8,7 @@ go_test(
         "tenant_admin_test.go",
     ],
     args = ["-test.timeout=295s"],
+    tags = ["ccl_test"],
     deps = [
         "//pkg/ccl",
         "//pkg/ccl/serverccl",

--- a/pkg/ccl/serverccl/diagnosticsccl/BUILD.bazel
+++ b/pkg/ccl/serverccl/diagnosticsccl/BUILD.bazel
@@ -8,6 +8,7 @@ go_test(
         "reporter_test.go",
     ],
     args = ["-test.timeout=295s"],
+    tags = ["ccl_test"],
     deps = [
         "//pkg/base",
         "//pkg/ccl/kvccl/kvtenantccl",

--- a/pkg/ccl/serverccl/statusccl/BUILD.bazel
+++ b/pkg/ccl/serverccl/statusccl/BUILD.bazel
@@ -9,6 +9,7 @@ go_test(
         "tenant_status_test.go",
     ],
     args = ["-test.timeout=295s"],
+    tags = ["ccl_test"],
     deps = [
         "//pkg/base",
         "//pkg/ccl",

--- a/pkg/ccl/spanconfigccl/spanconfigkvaccessorccl/BUILD.bazel
+++ b/pkg/ccl/spanconfigccl/spanconfigkvaccessorccl/BUILD.bazel
@@ -8,6 +8,7 @@ go_test(
         "main_test.go",
     ],
     args = ["-test.timeout=295s"],
+    tags = ["ccl_test"],
     deps = [
         "//pkg/base",
         "//pkg/ccl",

--- a/pkg/ccl/spanconfigccl/spanconfiglimiterccl/BUILD.bazel
+++ b/pkg/ccl/spanconfigccl/spanconfiglimiterccl/BUILD.bazel
@@ -10,6 +10,7 @@ go_test(
     ],
     args = ["-test.timeout=295s"],
     data = glob(["testdata/**"]),
+    tags = ["ccl_test"],
     deps = [
         "//pkg/base",
         "//pkg/ccl",

--- a/pkg/ccl/spanconfigccl/spanconfigreconcilerccl/BUILD.bazel
+++ b/pkg/ccl/spanconfigccl/spanconfigreconcilerccl/BUILD.bazel
@@ -9,6 +9,7 @@ go_test(
     ],
     args = ["-test.timeout=295s"],
     data = glob(["testdata/**"]),
+    tags = ["ccl_test"],
     deps = [
         "//pkg/base",
         "//pkg/ccl",

--- a/pkg/ccl/spanconfigccl/spanconfigsplitterccl/BUILD.bazel
+++ b/pkg/ccl/spanconfigccl/spanconfigsplitterccl/BUILD.bazel
@@ -9,6 +9,7 @@ go_test(
     ],
     args = ["-test.timeout=295s"],
     data = glob(["testdata/**"]),
+    tags = ["ccl_test"],
     deps = [
         "//pkg/base",
         "//pkg/ccl",

--- a/pkg/ccl/spanconfigccl/spanconfigsqltranslatorccl/BUILD.bazel
+++ b/pkg/ccl/spanconfigccl/spanconfigsqltranslatorccl/BUILD.bazel
@@ -9,6 +9,7 @@ go_test(
     ],
     args = ["-test.timeout=295s"],
     data = glob(["testdata/**"]),
+    tags = ["ccl_test"],
     deps = [
         "//pkg/base",
         "//pkg/ccl",

--- a/pkg/ccl/spanconfigccl/spanconfigsqlwatcherccl/BUILD.bazel
+++ b/pkg/ccl/spanconfigccl/spanconfigsqlwatcherccl/BUILD.bazel
@@ -8,6 +8,7 @@ go_test(
         "sqlwatcher_test.go",
     ],
     args = ["-test.timeout=295s"],
+    tags = ["ccl_test"],
     deps = [
         "//pkg/base",
         "//pkg/ccl",

--- a/pkg/ccl/sqlitelogictestccl/BUILD.bazel
+++ b/pkg/ccl/sqlitelogictestccl/BUILD.bazel
@@ -17,6 +17,7 @@ go_test(
         "@com_github_cockroachdb_sqllogictest//:testfiles",
     ],
     embed = [":sqlitelogictestccl"],
+    tags = ["ccl_test"],
 )
 
 get_x_data(name = "get_x_data")

--- a/pkg/ccl/sqlitelogictestccl/tests/3node-tenant/BUILD.bazel
+++ b/pkg/ccl/sqlitelogictestccl/tests/3node-tenant/BUILD.bazel
@@ -10,7 +10,7 @@ go_test(
         "//c-deps:libgeos",  # keep
         "@com_github_cockroachdb_sqllogictest//:testfiles",  # keep
     ],
-    shard_count = 16,
+    shard_count = 48,
     tags = ["cpu:2"],
     deps = [
         "//pkg/build/bazel",

--- a/pkg/ccl/sqlproxyccl/BUILD.bazel
+++ b/pkg/ccl/sqlproxyccl/BUILD.bazel
@@ -76,6 +76,7 @@ go_test(
     args = ["-test.timeout=295s"],
     data = glob(["testdata/**"]),
     embed = [":sqlproxyccl"],
+    tags = ["ccl_test"],
     deps = [
         "//pkg/base",
         "//pkg/ccl",

--- a/pkg/ccl/sqlproxyccl/acl/BUILD.bazel
+++ b/pkg/ccl/sqlproxyccl/acl/BUILD.bazel
@@ -31,6 +31,7 @@ go_test(
     ],
     args = ["-test.timeout=295s"],
     embed = [":acl"],
+    tags = ["ccl_test"],
     deps = [
         "//pkg/util/leaktest",
         "//pkg/util/metric",

--- a/pkg/ccl/sqlproxyccl/balancer/BUILD.bazel
+++ b/pkg/ccl/sqlproxyccl/balancer/BUILD.bazel
@@ -38,6 +38,7 @@ go_test(
     ],
     args = ["-test.timeout=295s"],
     embed = [":balancer"],
+    tags = ["ccl_test"],
     deps = [
         "//pkg/ccl/sqlproxyccl/tenant",
         "//pkg/roachpb",

--- a/pkg/ccl/sqlproxyccl/interceptor/BUILD.bazel
+++ b/pkg/ccl/sqlproxyccl/interceptor/BUILD.bazel
@@ -32,6 +32,7 @@ go_test(
     ],
     args = ["-test.timeout=295s"],
     embed = [":interceptor"],
+    tags = ["ccl_test"],
     deps = [
         "//pkg/sql/pgwire/pgwirebase",
         "//pkg/util/leaktest",

--- a/pkg/ccl/sqlproxyccl/tenant/BUILD.bazel
+++ b/pkg/ccl/sqlproxyccl/tenant/BUILD.bazel
@@ -55,6 +55,7 @@ go_test(
     ],
     args = ["-test.timeout=895s"],
     embed = [":tenant"],
+    tags = ["ccl_test"],
     deps = [
         "//pkg/base",
         "//pkg/ccl",

--- a/pkg/ccl/sqlproxyccl/throttler/BUILD.bazel
+++ b/pkg/ccl/sqlproxyccl/throttler/BUILD.bazel
@@ -26,6 +26,7 @@ go_test(
     ],
     args = ["-test.timeout=295s"],
     embed = [":throttler"],
+    tags = ["ccl_test"],
     deps = [
         "//pkg/util/timeutil",
         "@com_github_stretchr_testify//require",

--- a/pkg/ccl/storageccl/BUILD.bazel
+++ b/pkg/ccl/storageccl/BUILD.bazel
@@ -35,6 +35,7 @@ go_test(
     ],
     args = ["-test.timeout=895s"],
     embed = [":storageccl"],
+    tags = ["ccl_test"],
     deps = [
         "//pkg/base",
         "//pkg/blobs",

--- a/pkg/ccl/storageccl/engineccl/BUILD.bazel
+++ b/pkg/ccl/storageccl/engineccl/BUILD.bazel
@@ -39,6 +39,7 @@ go_test(
     args = ["-test.timeout=55s"],
     data = glob(["testdata/**"]),
     embed = [":engineccl"],
+    tags = ["ccl_test"],
     deps = [
         "//pkg/base",
         "//pkg/ccl/baseccl",

--- a/pkg/ccl/streamingccl/replicationutils/BUILD.bazel
+++ b/pkg/ccl/streamingccl/replicationutils/BUILD.bazel
@@ -28,6 +28,7 @@ go_test(
     srcs = ["utils_test.go"],
     args = ["-test.timeout=295s"],
     embed = [":replicationutils"],
+    tags = ["ccl_test"],
     deps = [
         "//pkg/clusterversion",
         "//pkg/kv/kvpb",

--- a/pkg/ccl/streamingccl/streamclient/BUILD.bazel
+++ b/pkg/ccl/streamingccl/streamclient/BUILD.bazel
@@ -51,6 +51,7 @@ go_test(
     ],
     args = ["-test.timeout=55s"],
     embed = [":streamclient"],
+    tags = ["ccl_test"],
     deps = [
         "//pkg/base",
         "//pkg/ccl",

--- a/pkg/ccl/streamingccl/streamingest/BUILD.bazel
+++ b/pkg/ccl/streamingccl/streamingest/BUILD.bazel
@@ -93,6 +93,7 @@ go_test(
     args = ["-test.timeout=895s"],
     data = glob(["testdata/**"]),
     embed = [":streamingest"],
+    tags = ["ccl_test"],
     deps = [
         "//pkg/base",
         "//pkg/ccl",

--- a/pkg/ccl/streamingccl/streamproducer/BUILD.bazel
+++ b/pkg/ccl/streamingccl/streamproducer/BUILD.bazel
@@ -66,6 +66,7 @@ go_test(
     ],
     args = ["-test.timeout=895s"],
     embed = [":streamproducer"],
+    tags = ["ccl_test"],
     deps = [
         "//pkg/base",
         "//pkg/ccl",

--- a/pkg/ccl/telemetryccl/BUILD.bazel
+++ b/pkg/ccl/telemetryccl/BUILD.bazel
@@ -11,6 +11,7 @@ go_test(
     args = ["-test.timeout=295s"],
     data = glob(["testdata/**"]),
     shard_count = 16,
+    tags = ["ccl_test"],
     deps = [
         "//pkg/base",
         "//pkg/ccl",

--- a/pkg/ccl/testccl/authccl/BUILD.bazel
+++ b/pkg/ccl/testccl/authccl/BUILD.bazel
@@ -9,6 +9,7 @@ go_test(
     ],
     args = ["-test.timeout=295s"],
     data = glob(["testdata/**"]),
+    tags = ["ccl_test"],
     deps = [
         "//pkg/base",
         "//pkg/ccl",

--- a/pkg/ccl/testccl/sqlccl/BUILD.bazel
+++ b/pkg/ccl/testccl/sqlccl/BUILD.bazel
@@ -19,6 +19,7 @@ go_test(
         "//c-deps:libgeos",  # keep
     ],
     shard_count = 16,
+    tags = ["ccl_test"],
     deps = [
         "//pkg/base",
         "//pkg/ccl",

--- a/pkg/ccl/testccl/sqlstatsccl/BUILD.bazel
+++ b/pkg/ccl/testccl/sqlstatsccl/BUILD.bazel
@@ -8,6 +8,7 @@ go_test(
         "sql_stats_test.go",
     ],
     args = ["-test.timeout=295s"],
+    tags = ["ccl_test"],
     deps = [
         "//pkg/base",
         "//pkg/ccl",

--- a/pkg/ccl/testccl/workload/schemachange/BUILD.bazel
+++ b/pkg/ccl/testccl/workload/schemachange/BUILD.bazel
@@ -12,6 +12,7 @@ go_test(
     data = [
         "//c-deps:libgeos",
     ],
+    tags = ["ccl_test"],
     deps = [
         "//pkg/base",
         "//pkg/ccl",

--- a/pkg/ccl/utilccl/BUILD.bazel
+++ b/pkg/ccl/utilccl/BUILD.bazel
@@ -39,6 +39,7 @@ go_test(
     ],
     args = ["-test.timeout=55s"],
     embed = [":utilccl"],
+    tags = ["ccl_test"],
     deps = [
         "//pkg/base",
         "//pkg/ccl",

--- a/pkg/ccl/utilccl/sampledataccl/BUILD.bazel
+++ b/pkg/ccl/utilccl/sampledataccl/BUILD.bazel
@@ -20,6 +20,7 @@ go_test(
     srcs = ["main_test.go"],
     args = ["-test.timeout=55s"],
     embed = [":sampledataccl"],
+    tags = ["ccl_test"],
     deps = [
         "//pkg/ccl",
         "//pkg/security/securityassets",

--- a/pkg/ccl/workloadccl/BUILD.bazel
+++ b/pkg/ccl/workloadccl/BUILD.bazel
@@ -37,6 +37,7 @@ go_test(
         "main_test.go",
     ],
     args = ["-test.timeout=55s"],
+    tags = ["ccl_test"],
     deps = [
         ":workloadccl",
         "//pkg/base",

--- a/pkg/ccl/workloadccl/allccl/BUILD.bazel
+++ b/pkg/ccl/workloadccl/allccl/BUILD.bazel
@@ -46,6 +46,7 @@ go_test(
     args = ["-test.timeout=895s"],
     embed = [":allccl"],
     shard_count = 16,
+    tags = ["ccl_test"],
     deps = [
         "//pkg/base",
         "//pkg/ccl",

--- a/pkg/cmd/generate-bazel-extra/main.go
+++ b/pkg/cmd/generate-bazel-extra/main.go
@@ -232,12 +232,24 @@ test_suite(
     tests = ALL_TESTS,
 )`)
 
+	fmt.Fprintln(w, `
+test_suite(
+    name = "ccl_tests",
+    tags = [
+        "-broken_in_bazel",
+        "ccl_test",
+        "-integration",
+    ],
+    tests = ALL_TESTS,
+)`)
+
 	for _, size := range []string{"small", "medium", "large", "enormous"} {
 		fmt.Fprintf(w, `
 test_suite(
-    name = "%[1]s_tests",
+    name = "%[1]s_non_ccl_tests",
     tags = [
         "-broken_in_bazel",
+        "-ccl_test",
         "-flaky",
         "-integration",
         "%[1]s",
@@ -340,6 +352,15 @@ func generateTestsTimeouts() {
 			targets[size]...,
 		))
 	}
+	var ccl_targets []string
+	for _, targetsForSize := range targets {
+		for _, target := range targetsForSize {
+			if strings.HasPrefix(target, "//pkg/ccl") {
+				ccl_targets = append(ccl_targets, target)
+			}
+		}
+	}
+	runBuildozer(append([]string{`add tags "ccl_test"`}, ccl_targets...))
 }
 
 func main() {

--- a/pkg/cmd/generate-logictest/templates.go
+++ b/pkg/cmd/generate-logictest/templates.go
@@ -266,7 +266,7 @@ go_test(
         "//pkg/sql/logictest:testdata",  # keep{{ end }}{{ if .ExecBuildLogicTest }}
         "//pkg/sql/opt/exec/execbuilder:testdata",  # keep{{ end }}
     ],
-    shard_count = {{ if gt .TestCount 16 }}16{{ else }}{{ .TestCount }}{{end}},
+    shard_count = {{ if gt .TestCount 48 }}48{{ else }}{{ .TestCount }}{{end}},
     tags = ["cpu:{{ if gt .NumCPU 4 }}4{{ else }}{{ .NumCPU }}{{ end }}"],
     deps = [
         "//pkg/build/bazel",{{ if .Ccl }}

--- a/pkg/kv/kvserver/BUILD.bazel
+++ b/pkg/kv/kvserver/BUILD.bazel
@@ -334,7 +334,7 @@ go_test(
     args = ["-test.timeout=3595s"],
     data = glob(["testdata/**"]),
     embed = [":kvserver"],
-    shard_count = 8,
+    shard_count = 48,
     tags = ["cpu:2"],
     deps = [
         "//pkg/base",

--- a/pkg/sql/logictest/tests/5node/BUILD.bazel
+++ b/pkg/sql/logictest/tests/5node/BUILD.bazel
@@ -10,7 +10,7 @@ go_test(
         "//c-deps:libgeos",  # keep
         "//pkg/sql/logictest:testdata",  # keep
     ],
-    shard_count = 16,
+    shard_count = 20,
     tags = ["cpu:3"],
     deps = [
         "//pkg/build/bazel",

--- a/pkg/sql/logictest/tests/fakedist-disk/BUILD.bazel
+++ b/pkg/sql/logictest/tests/fakedist-disk/BUILD.bazel
@@ -10,7 +10,7 @@ go_test(
         "//c-deps:libgeos",  # keep
         "//pkg/sql/logictest:testdata",  # keep
     ],
-    shard_count = 16,
+    shard_count = 48,
     tags = ["cpu:2"],
     deps = [
         "//pkg/build/bazel",

--- a/pkg/sql/logictest/tests/fakedist-vec-off/BUILD.bazel
+++ b/pkg/sql/logictest/tests/fakedist-vec-off/BUILD.bazel
@@ -10,7 +10,7 @@ go_test(
         "//c-deps:libgeos",  # keep
         "//pkg/sql/logictest:testdata",  # keep
     ],
-    shard_count = 16,
+    shard_count = 48,
     tags = ["cpu:2"],
     deps = [
         "//pkg/build/bazel",

--- a/pkg/sql/logictest/tests/fakedist/BUILD.bazel
+++ b/pkg/sql/logictest/tests/fakedist/BUILD.bazel
@@ -10,7 +10,7 @@ go_test(
         "//c-deps:libgeos",  # keep
         "//pkg/sql/logictest:testdata",  # keep
     ],
-    shard_count = 16,
+    shard_count = 48,
     tags = ["cpu:2"],
     deps = [
         "//pkg/build/bazel",

--- a/pkg/sql/logictest/tests/local-legacy-schema-changer/BUILD.bazel
+++ b/pkg/sql/logictest/tests/local-legacy-schema-changer/BUILD.bazel
@@ -10,7 +10,7 @@ go_test(
         "//c-deps:libgeos",  # keep
         "//pkg/sql/logictest:testdata",  # keep
     ],
-    shard_count = 16,
+    shard_count = 48,
     tags = ["cpu:1"],
     deps = [
         "//pkg/build/bazel",

--- a/pkg/sql/logictest/tests/local-vec-off/BUILD.bazel
+++ b/pkg/sql/logictest/tests/local-vec-off/BUILD.bazel
@@ -10,7 +10,7 @@ go_test(
         "//c-deps:libgeos",  # keep
         "//pkg/sql/logictest:testdata",  # keep
     ],
-    shard_count = 16,
+    shard_count = 48,
     tags = ["cpu:1"],
     deps = [
         "//pkg/build/bazel",

--- a/pkg/sql/logictest/tests/local/BUILD.bazel
+++ b/pkg/sql/logictest/tests/local/BUILD.bazel
@@ -10,7 +10,7 @@ go_test(
         "//c-deps:libgeos",  # keep
         "//pkg/sql/logictest:testdata",  # keep
     ],
-    shard_count = 16,
+    shard_count = 48,
     tags = ["cpu:1"],
     deps = [
         "//pkg/build/bazel",

--- a/pkg/sql/opt/exec/execbuilder/tests/5node/BUILD.bazel
+++ b/pkg/sql/opt/exec/execbuilder/tests/5node/BUILD.bazel
@@ -10,7 +10,7 @@ go_test(
         "//c-deps:libgeos",  # keep
         "//pkg/sql/opt/exec/execbuilder:testdata",  # keep
     ],
-    shard_count = 16,
+    shard_count = 29,
     tags = ["cpu:3"],
     deps = [
         "//pkg/build/bazel",

--- a/pkg/sql/opt/exec/execbuilder/tests/local/BUILD.bazel
+++ b/pkg/sql/opt/exec/execbuilder/tests/local/BUILD.bazel
@@ -10,7 +10,7 @@ go_test(
         "//c-deps:libgeos",  # keep
         "//pkg/sql/opt/exec/execbuilder:testdata",  # keep
     ],
-    shard_count = 16,
+    shard_count = 48,
     tags = ["cpu:1"],
     deps = [
         "//pkg/build/bazel",

--- a/pkg/sql/sqlitelogictest/tests/fakedist-disk/BUILD.bazel
+++ b/pkg/sql/sqlitelogictest/tests/fakedist-disk/BUILD.bazel
@@ -10,7 +10,7 @@ go_test(
         "//c-deps:libgeos",  # keep
         "@com_github_cockroachdb_sqllogictest//:testfiles",  # keep
     ],
-    shard_count = 16,
+    shard_count = 48,
     tags = ["cpu:2"],
     deps = [
         "//pkg/build/bazel",

--- a/pkg/sql/sqlitelogictest/tests/fakedist-vec-off/BUILD.bazel
+++ b/pkg/sql/sqlitelogictest/tests/fakedist-vec-off/BUILD.bazel
@@ -10,7 +10,7 @@ go_test(
         "//c-deps:libgeos",  # keep
         "@com_github_cockroachdb_sqllogictest//:testfiles",  # keep
     ],
-    shard_count = 16,
+    shard_count = 48,
     tags = ["cpu:2"],
     deps = [
         "//pkg/build/bazel",

--- a/pkg/sql/sqlitelogictest/tests/fakedist/BUILD.bazel
+++ b/pkg/sql/sqlitelogictest/tests/fakedist/BUILD.bazel
@@ -10,7 +10,7 @@ go_test(
         "//c-deps:libgeos",  # keep
         "@com_github_cockroachdb_sqllogictest//:testfiles",  # keep
     ],
-    shard_count = 16,
+    shard_count = 48,
     tags = ["cpu:2"],
     deps = [
         "//pkg/build/bazel",

--- a/pkg/sql/sqlitelogictest/tests/local-legacy-schema-changer/BUILD.bazel
+++ b/pkg/sql/sqlitelogictest/tests/local-legacy-schema-changer/BUILD.bazel
@@ -10,7 +10,7 @@ go_test(
         "//c-deps:libgeos",  # keep
         "@com_github_cockroachdb_sqllogictest//:testfiles",  # keep
     ],
-    shard_count = 16,
+    shard_count = 48,
     tags = ["cpu:1"],
     deps = [
         "//pkg/build/bazel",

--- a/pkg/sql/sqlitelogictest/tests/local-vec-off/BUILD.bazel
+++ b/pkg/sql/sqlitelogictest/tests/local-vec-off/BUILD.bazel
@@ -10,7 +10,7 @@ go_test(
         "//c-deps:libgeos",  # keep
         "@com_github_cockroachdb_sqllogictest//:testfiles",  # keep
     ],
-    shard_count = 16,
+    shard_count = 48,
     tags = ["cpu:1"],
     deps = [
         "//pkg/build/bazel",

--- a/pkg/sql/sqlitelogictest/tests/local/BUILD.bazel
+++ b/pkg/sql/sqlitelogictest/tests/local/BUILD.bazel
@@ -10,7 +10,7 @@ go_test(
         "//c-deps:libgeos",  # keep
         "@com_github_cockroachdb_sqllogictest//:testfiles",  # keep
     ],
-    shard_count = 16,
+    shard_count = 48,
     tags = ["cpu:1"],
     deps = [
         "//pkg/build/bazel",

--- a/pkg/storage/metamorphic/BUILD.bazel
+++ b/pkg/storage/metamorphic/BUILD.bazel
@@ -45,7 +45,7 @@ go_test(
     args = ["-test.timeout=3595s"],
     data = glob(["testdata/**"]),
     embed = [":metamorphic"],
-    shard_count = 16,
+    shard_count = 8,
     deps = [
         "//pkg/settings/cluster",
         "//pkg/testutils",


### PR DESCRIPTION
This code change attempts to shard some test
targets that could benefit from more sharding. It
also splits unit tests in TeamCity into two runs:
ccl unit tests, and non-ccl unit tests. The current
build config will be used to run non-ccl unit tests.
The new build config will be used for ccl tests (those
under `pkg/ccl`). This cuts unit tests wall time by
half while keeping machine time almost the same.

Release note: None
Epic: none