### PR TITLE
testutils: move tenant or server logic into test server

### DIFF
--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -1640,6 +1640,19 @@ func (ts *TestServer) ExecutorConfig() interface{} {
 	return *ts.sqlServer.execCfg
 }
 
+// StartedDefaultTestTenant is part of the TestServerInterface.
+func (ts *TestServer) StartedDefaultTestTenant() bool {
+	return !ts.cfg.DisableDefaultTestTenant
+}
+
+// TenantOrServer is part of the TestServerInterface.
+func (ts *TestServer) TenantOrServer() serverutils.TestTenantInterface {
+	if ts.StartedDefaultTestTenant() {
+		return ts.testTenants[0]
+	}
+	return ts
+}
+
 // TracerI is part of the TestServerInterface.
 func (ts *TestServer) TracerI() interface{} {
 	return ts.Tracer()

--- a/pkg/testutils/serverutils/test_server_shim.go
+++ b/pkg/testutils/serverutils/test_server_shim.go
@@ -275,6 +275,14 @@ type TestServerInterface interface {
 
 	// TestTenants returns the test tenants associated with the server
 	TestTenants() []TestTenantInterface
+
+	// StartedDefaultTestTenant returns true if the server has started the default
+	// test tenant.
+	StartedDefaultTestTenant() bool
+
+	// TenantOrServer returns the default test tenant, if it was started or this
+	// server if not.
+	TenantOrServer() TestTenantInterface
 }
 
 // TestServerFactory encompasses the actual implementation of the shim

--- a/pkg/testutils/testcluster/testcluster.go
+++ b/pkg/testutils/testcluster/testcluster.go
@@ -121,17 +121,13 @@ func (tc *TestCluster) Stopper() *stop.Stopper {
 // StartedDefaultTestTenant returns whether this cluster started a default
 // test tenant.
 func (tc *TestCluster) StartedDefaultTestTenant() bool {
-	return !tc.Servers[0].Cfg.DisableDefaultTestTenant
+	return tc.Servers[0].StartedDefaultTestTenant()
 }
 
 // TenantOrServer returns either the ith server in the cluster or the tenant server associated with
 // the ith server if the cluster started with a default test tenant.
 func (tc *TestCluster) TenantOrServer(idx int) serverutils.TestTenantInterface {
-	s := tc.Server(idx)
-	if tc.StartedDefaultTestTenant() {
-		return s.TestTenants()[0]
-	}
-	return s
+	return tc.Server(idx).TenantOrServer()
 }
 
 // stopServers stops the stoppers for each individual server in the cluster.


### PR DESCRIPTION
The logic to decide between returning a default test tenant, if one was started, or the server has been added to `testcluster` previously, but `testserver` can also benefit from exposing this logic for tests that do not require a whole cluster. Hence, this logic has been refactored to be available in both test cluster and test server.

Epic: CRDB-18499