### PR TITLE
roachtest: allow opting out of post validation(s)

### DIFF
--- a/pkg/cmd/roachtest/registry/test_spec.go
+++ b/pkg/cmd/roachtest/registry/test_spec.go
@@ -84,9 +84,28 @@ type TestSpec struct {
 	// cannot be run with encryption enabled.
 	EncryptionSupport EncryptionSupport
 
+	// SkipPostValidations is a bit-set of post-validations that should be skipped
+	// after the test completes. This is useful for tests that are known to be
+	// incompatible with some validations. By default, tests will run all
+	// validations.
+	SkipPostValidations PostValidation
+
 	// Run is the test function.
 	Run func(ctx context.Context, t test.Test, c cluster.Cluster)
 }
+
+// PostValidation is a type of post-validation that runs after a test completes.
+type PostValidation int
+
+const (
+	// PostValidationReplicaDivergence detects replica divergence (i.e. ranges in
+	// which replicas have arrived at the same log position with different
+	// states).
+	PostValidationReplicaDivergence PostValidation = 1 << iota
+	// PostValidationInvalidDescriptors checks if there exists any descriptors in
+	// the crdb_internal.invalid_objects virtual table.
+	PostValidationInvalidDescriptors
+)
 
 // MatchType is the type of match a file has to a TestFilter.
 type MatchType int

--- a/pkg/cmd/roachtest/test_runner.go
+++ b/pkg/cmd/roachtest/test_runner.go
@@ -1099,10 +1099,14 @@ func (r *testRunner) teardownTest(
 		if db != nil {
 			defer db.Close()
 			t.L().Printf("running validation checks on node %d (<10m)", node)
-			c.FailOnInvalidDescriptors(ctx, db, t)
+			if t.spec.SkipPostValidations&registry.PostValidationInvalidDescriptors == 0 {
+				c.FailOnInvalidDescriptors(ctx, db, t)
+			}
 			// Detect replica divergence (i.e. ranges in which replicas have arrived
 			// at the same log position with different states).
-			c.FailOnReplicaDivergence(ctx, db, t)
+			if t.spec.SkipPostValidations&registry.PostValidationReplicaDivergence == 0 {
+				c.FailOnReplicaDivergence(ctx, db, t)
+			}
 		} else {
 			t.L().Printf("no live node found, skipping validation checks")
 		}

--- a/pkg/cmd/roachtest/tests/loss_of_quorum_recovery.go
+++ b/pkg/cmd/roachtest/tests/loss_of_quorum_recovery.go
@@ -69,21 +69,23 @@ func registerLOQRecovery(r registry.Registry) {
 	} {
 		testSpec := s
 		r.Add(registry.TestSpec{
-			Name:              s.testName(""),
-			Owner:             registry.OwnerReplication,
-			Tags:              []string{`default`},
-			Cluster:           spec,
-			NonReleaseBlocker: true,
+			Name:                s.testName(""),
+			Owner:               registry.OwnerReplication,
+			Tags:                []string{`default`},
+			Cluster:             spec,
+			SkipPostValidations: registry.PostValidationInvalidDescriptors,
+			NonReleaseBlocker:   true,
 			Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 				runRecoverLossOfQuorum(ctx, t, c, testSpec)
 			},
 		})
 		r.Add(registry.TestSpec{
-			Name:              s.testName("half-online"),
-			Owner:             registry.OwnerReplication,
-			Tags:              []string{`default`},
-			Cluster:           spec,
-			NonReleaseBlocker: true,
+			Name:                s.testName("half-online"),
+			Owner:               registry.OwnerReplication,
+			Tags:                []string{`default`},
+			Cluster:             spec,
+			SkipPostValidations: registry.PostValidationInvalidDescriptors,
+			NonReleaseBlocker:   true,
 			Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 				runHalfOnlineRecoverLossOfQuorum(ctx, t, c, testSpec)
 			},


### PR DESCRIPTION
A few post validations are currently performed after a test completes. In most cases it applies to all tests, but there are some tests that are incompatible with particular post validations. This change adds the ability for a test to specify that it wants to opt-out of certain validations.

Refs: https://github.com/cockroachdb/cockroach/issues/97912
Epic: None