### PR TITLE
ccl/kvccl/kvtenantccl: skip TestTenantUpgradeFailure

### DIFF
--- a/pkg/ccl/kvccl/kvtenantccl/tenant_upgrade_test.go
+++ b/pkg/ccl/kvccl/kvtenantccl/tenant_upgrade_test.go
@@ -194,6 +194,7 @@ func v0v1v2() (roachpb.Version, roachpb.Version, roachpb.Version) {
 // between version upgrades.
 func TestTenantUpgradeFailure(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	skip.WithIssue(t, 98555, "flaky test")
 	defer log.Scope(t).Close(t)
 	// Contains information for starting a tenant
 	// and maintaining a stopper.


### PR DESCRIPTION
Refs: #98555

Reason: flaky test

Generated by bin/skip-test.

Release justification: non-production code changes
Release note: None
Epic: None