### PR TITLE
jobspb: mark the key visualizer job as automatic

### DIFF
--- a/pkg/jobs/jobspb/wrap.go
+++ b/pkg/jobs/jobspb/wrap.go
@@ -149,6 +149,7 @@ var AutomaticJobTypes = [...]Type{
 	TypeAutoSchemaTelemetry,
 	TypePollJobsStats,
 	TypeAutoConfigRunner,
+	TypeKeyVisualizer,
 }
 
 // DetailsType returns the type for a payload detail.


### PR DESCRIPTION
Epic: None
Release note: None