### PR TITLE
kvserver/allocator: remove dupe logging and fix load delta min

### DIFF
--- a/pkg/kv/kvserver/allocator/allocatorimpl/allocator.go
+++ b/pkg/kv/kvserver/allocator/allocatorimpl/allocator.go
@@ -2450,28 +2450,13 @@ func getCandidateWithMinLoad(
 	return bestCandidate
 }
 
-// getLoadDelta returns the difference between the store serving the highest QPS
-// and the store serving the lowest QPS, among the set of stores in the
-// `domain`.
+// getLoadDelta returns the difference between the store serving the highest
+// load and the store serving the lowest load in the dimension given, among the
+// set of stores in the `domain`.
 func getLoadDelta(
 	storeLoadMap map[roachpb.StoreID]load.Load, domain []roachpb.StoreID, dimension load.Dimension,
 ) float64 {
-	maxCandidateLoad := float64(0)
-	minCandidateLoad := math.MaxFloat64
-	for _, cand := range domain {
-		candidateLoad, ok := storeLoadMap[cand]
-		if !ok {
-			continue
-		}
-		candidateLoadDim := candidateLoad.Dim(dimension)
-		if maxCandidateLoad < candidateLoadDim {
-			maxCandidateLoad = candidateLoadDim
-		}
-		if minCandidateLoad > candidateLoadDim {
-			minCandidateLoad = candidateLoadDim
-		}
-	}
-	return maxCandidateLoad - minCandidateLoad
+	return loadDomainElementWiseDelta(makeLoadDomain(storeLoadMap, domain)).Dim(dimension)
 }
 
 // ShouldTransferLease returns true if the specified store is overfull in terms

--- a/pkg/kv/kvserver/store_rebalancer.go
+++ b/pkg/kv/kvserver/store_rebalancer.go
@@ -714,7 +714,7 @@ func (sr *StoreRebalancer) chooseLeaseToTransfer(
 		// Don't bother moving leases whose load is below some small fraction of the
 		// store's load. It's just unnecessary churn with no benefit to move leases
 		// responsible for, for example, 1 load unit on a store with 5000 load units.
-		const minLoadFraction = .001
+		const minLoadFraction = .005
 		if candidateReplica.RangeUsageInfo().TransferImpact().Dim(rctx.loadDimension) <
 			rctx.LocalDesc.Capacity.Load().Dim(rctx.loadDimension)*minLoadFraction {
 			log.KvDistribution.VEventf(ctx, 3, "r%d's %s load is too little to matter relative to s%d's %s total load",
@@ -836,7 +836,7 @@ func (sr *StoreRebalancer) chooseRangeToRebalance(
 		// Don't bother moving ranges whose load is below some small fraction of the
 		// store's load. It's just unnecessary churn with no benefit to move ranges
 		// responsible for, for example, 1 load unit on a store with 5000 load units.
-		const minLoadFraction = .001
+		const minLoadFraction = .02
 		if candidateReplica.RangeUsageInfo().Load().Dim(rctx.loadDimension) <
 			rctx.LocalDesc.Capacity.Load().Dim(rctx.loadDimension)*minLoadFraction {
 			log.KvDistribution.VEventf(

--- a/pkg/kv/kvserver/store_rebalancer.go
+++ b/pkg/kv/kvserver/store_rebalancer.go
@@ -592,6 +592,7 @@ func (sr *StoreRebalancer) LogRangeRebalanceOutcome(ctx context.Context, rctx *R
 			"ran out of replicas worth transferring and load %s is still above desired threshold %s; will check again soon",
 			rctx.LocalDesc.Capacity.Load(), rctx.maxThresholds)
 		sr.metrics.ImbalancedStateOverfullOptionsExhausted.Inc(1)
+		return
 	}
 
 	// We successfully rebalanced below or equal to the max threshold,
@@ -623,9 +624,6 @@ func (sr *StoreRebalancer) RebalanceRanges(
 	)
 
 	if candidateReplica == nil {
-		log.KvDistribution.Infof(ctx,
-			"ran out of replicas worth transferring and load %s is still above desired threshold %s; will check again soon",
-			rctx.LocalDesc.Capacity.Load(), rctx.maxThresholds)
 		return NoRebalanceTarget, candidateReplica, voterTargets, nonVoterTargets
 	}
 


### PR DESCRIPTION
Previously, the store rebalancer would log `load-based replica transfers
successfully brought...` even the store was not below the max threshold.
The store rebalancer also logs when there are no available replica
rebalancing actions remaining but the store still above the desired load
threshold: `ran out of replicas worth transferring and load`. This log
line was duplicated in both the post range rebalancing phase and in
exiting the range rebalancing phase.

This commit stops duplication by removing the exit log line and ensures
that the `load-based replica transfers successfully brought...` log line
occurs only when actually successful.

There were a few references to old variable values, or in terms of QPS
in the load based best target logic. The logic also was duplicate and
non-uniform in approach. The domain store list was also incorrectly
including all stores in the store map passed in, which is incorrect as
the domain of possible stores should be just the candidate+existing
stores. The domain store list is used to calculate the mean, so
including additional stores that are not candidates (only occurred for
lease transfers) results in a poor comparison point.

This commit updates the comments within `bestStoreToMinimizeDelta` to be
more accurate. The logic is also slightly updated to reuse functions.
This function is one of the most important allocator logic for load
based target scoring.

The incorrect store list creation is also updated, so that the store
list contains only the candidate+existing store.

Previously, the store rebalancer would attempt to transfer leases or
relocate replicas of a range so long as the load of the range (estimated
using the local leaseholder replica) was greater than 0.1% of the
store's load.

This commit updates the value to be higher for both lease rebalancing
and range rebalancing, specifically:

lease rebalancing: 0.1% -> 0.5%
range rebalancing: 0.1% -> 2.0%

The documented rationale, as for why these values exist is also the
reason for the increase: decrease unnecessary churn. Only the hottest
ranges are considered, when the impact of a rebalance action for these
ranges is estimated to be less than a small fraction of the store's
total load, it is indicative that the distribution of replica load is
not skewed. Letting the replicate queue balance replica and lease counts
is a better option in such distributions.

Making the minimum for range rebalancing higher is also added, as
multiple replicas for a range is inherently more costly than moving a
lease.

Resolves: #98867
Resolves: #98870

Release note: None