### PR TITLE
opt: set udf CalledOnNullInput correctly for scalar UDFs

### DIFF
--- a/pkg/sql/opt/ops/scalar.opt
+++ b/pkg/sql/opt/ops/scalar.opt
@@ -1273,6 +1273,10 @@ define UDFPrivate {
     # CalledOnNullInput is true if the function should be called when any of its
     # inputs are NULL. If false, the function will not be evaluated in the
     # presence of NULL inputs, and will instead evaluate directly to NULL.
+    #
+    # Note that this field only affects evaluation of UDFs within project-set
+    # operators. Non-scalar UDFs are always in a project-set operator, while
+    # scalar UDFs can be if used as a data source (e.g. SELECT * FROM udf()).
     CalledOnNullInput bool
 }
 

--- a/pkg/sql/opt/optbuilder/scalar.go
+++ b/pkg/sql/opt/optbuilder/scalar.go
@@ -775,13 +775,6 @@ func (b *Builder) buildUDF(
 	}
 	b.insideUDF = false
 
-	// For set-returning functions, we handle STRICT behavior in the routine
-	// execution logic. For scalar UDFs this is handled by a CASE statement - see
-	// below.
-	calledOnNullInput := true
-	if isSetReturning {
-		calledOnNullInput = o.CalledOnNullInput
-	}
 	out = b.factory.ConstructUDF(
 		args,
 		&memo.UDFPrivate{
@@ -791,7 +784,7 @@ func (b *Builder) buildUDF(
 			Typ:               f.ResolvedType(),
 			SetReturning:      isSetReturning,
 			Volatility:        o.Volatility,
-			CalledOnNullInput: calledOnNullInput,
+			CalledOnNullInput: o.CalledOnNullInput,
 		},
 	)
 

--- a/pkg/sql/sem/tree/routine.go
+++ b/pkg/sql/sem/tree/routine.go
@@ -98,7 +98,10 @@ type RoutineExpr struct {
 	// its inputs are NULL. If false, the function will not be evaluated in the
 	// presence of null inputs, and will instead evaluate directly to NULL.
 	//
-	// NOTE: This boolean only affects evaluation of set-returning Routines.
+	// NOTE: This boolean only affects evaluation of Routines within project-set
+	// operators. This can apply to scalar routines if they are used as data
+	// source (e.g. SELECT * FROM scalar_udf()), and always applies to
+	// set-returning routines.
 	// Strict non-set-returning routines are not invoked when their arguments
 	// are NULL because optbuilder wraps them in a CASE expressions.
 	CalledOnNullInput bool


### PR DESCRIPTION
Previously, the `UDFPrivate.CalledOnNullInput` field would be set to true for scalar UDFs, since strict behavior is handled using a CASE statement. However, this is confusing and it is also correct to just set `CalledOnNullInput` to the value implied by the function's definition.

Informs CRDB-20535

Release note: None