### PR TITLE
test: prevent memory leak in DB Console tests

### DIFF
--- a/build/teamcity/cockroach/ci/tests/ui_test_impl.sh
+++ b/build/teamcity/cockroach/ci/tests/ui_test_impl.sh
@@ -3,11 +3,4 @@
 set -xeuo pipefail
 
 bazel build //pkg/cmd/bazci --config=ci
-ARCH="$(uname -m)"
-TARGETS_TO_TEST="//pkg/ui/workspaces/db-console:jest //pkg/ui/workspaces/cluster-ui:jest"
-# //pkg/ui/workspaces/db-console:jest is broken under ARM64. 
-# See https://github.com/cockroachdb/cockroach/issues/97179
-if [[ "$ARCH" == "aarch64" || "$ARCH" == "arm64" ]]; then
-    TARGETS_TO_TEST="//pkg/ui/workspaces/cluster-ui:jest"
-fi
-$(bazel info bazel-bin --config=ci)/pkg/cmd/bazci/bazci_/bazci -- test --config=ci $TARGETS_TO_TEST
+$(bazel info bazel-bin --config=ci)/pkg/cmd/bazci/bazci_/bazci -- test --config=ci //pkg/ui/workspaces/db-console:jest //pkg/ui/workspaces/cluster-ui:jest

--- a/pkg/ui/workspaces/db-console/BUILD.bazel
+++ b/pkg/ui/workspaces/db-console/BUILD.bazel
@@ -371,8 +371,16 @@ jest_test(
     size = "enormous",
     data = JEST_DEPS,
     templated_args = [
+        # Increase the JS heap size: https://nodejs.org/docs/latest-v16.x/api/cli.html#--max-old-space-sizesize-in-megabytes
         "--node_options=--max-old-space-size=8192",
-        "-w 25%",
+        # Prevent a v8-internal leak of compiled bytecode: https://github.com/facebook/jest/issues/11956#issuecomment-1401094780
+        "--node_options=--no-compilation-cache",
+        # Populate the global.gc() function during JS execution:
+        # https://github.com/v8/v8/blob/5fe0aa3bc79c0a9d3ad546b79211f07105f09585/src/flags/flag-definitions.h#L1484-L1487
+        "--node_options=--expose-gc",
+        # Force jest workers to collect garbage after each suite: https://jestjs.io/docs/27.x/cli#--logheapusage
+        "--logHeapUsage",
+        "--maxWorkers=4",
         "--ci",
         "--config",
         "$(rootpath jest.config.js)",


### PR DESCRIPTION
It appears there was a memory leak in the tests for pkg/ui/workspaces/
db-console, but not in typical way for a set of JavaScript tests. Rather
than v8's JavaScript heap running out of memory (typically solved by
increasing --max-old-space-size [1]), the v8 JS virtual machine *itself*
seems to be leaking memory. This was only observable by polling `free`
(or watching `htop` and friends), and presented as ever-increasing
memory pressure on the host OS. The systems that run these tests
in CI don't have any swap space available, so this memory pressure
eventually spills over and the entire machine becomes largely
unresponsive [2]. Eventually -- after one hour, thanks to
test_size=enormous [3] -- Bazel force-kills the node binary and reports
the tests as failed.

There's a few references to this behavior on the Internet [4], and the
general consensus is that this started with node 16.11.0. Newer versions
of node, including the current LTS 18.15.0, appear to exhibit the same
leak. New per-worker memory limit options were added to Jest in its
most-recent major version [5], but the upgrade path from our current
27.x to 29.x is non-trivial. Forcing each jest worker to perform a GC
pass after each suite run seems to solve the issue on older versions
well enough, and should allow these tests to run to again completion
without hanging.

[1] https://nodejs.org/docs/latest-v16.x/api/cli.html#--max-old-space-sizesize-in-megabytes
[2] This is reproducible when SSH'd into a remote GCP or AWS instance
    running both x86_64 and aarch64 (where the SSH connection drops),
    but similar behavior seems to happen in TeamCity.
    Aside: It's unclear why neither Bazel nor node were killed via
    some OOM watchdog. Perhaps there simply isn't one configured on
    these machines, or perhaps v8 stops JS execution while waiting for
    additional memory to be allocated that the OS can't provide? Knowing
    why unfortunately doesn't fix the leak.
[3] https://bazel.build/reference/be/common-definitions#test.size
[4] https://github.com/facebook/jest/issues/11956
[5] https://jestjs.io/docs/29.0/configuration#workeridlememorylimit-numberstring

Fixes: https://github.com/cockroachdb/cockroach/issues/97179

Release note (build change): Running './dev ui test' (or
'bazel test //pkg/ui/workspaces/db-console:jest') now uses less memory.