### PR TITLE
kv/kvserver: skip TestReplicaTombstone

### DIFF
--- a/pkg/kv/kvserver/client_replica_test.go
+++ b/pkg/kv/kvserver/client_replica_test.go
@@ -3555,6 +3555,7 @@ func TestReplicaTombstone(t *testing.T) {
 	})
 	t.Run("(4) (4.1) raft messages to newer replicaID ", func(t *testing.T) {
 		defer leaktest.AfterTest(t)()
+		skip.WithIssue(t, 98883, "flaky test")
 		defer log.Scope(t).Close(t)
 		ctx := context.Background()
 		tc := testcluster.StartTestCluster(t, 3, base.TestClusterArgs{


### PR DESCRIPTION
Refs: #98883

Reason: flaky test

Generated by bin/skip-test.

Release justification: non-production code changes
Release note: None
Epic: None