### PR TITLE
kvserver: remove duplicate logging in s-rebalancer

### DIFF
--- a/pkg/kv/kvserver/store_rebalancer.go
+++ b/pkg/kv/kvserver/store_rebalancer.go
@@ -592,6 +592,7 @@ func (sr *StoreRebalancer) LogRangeRebalanceOutcome(ctx context.Context, rctx *R
 			"ran out of replicas worth transferring and load %s is still above desired threshold %s; will check again soon",
 			rctx.LocalDesc.Capacity.Load(), rctx.maxThresholds)
 		sr.metrics.ImbalancedStateOverfullOptionsExhausted.Inc(1)
+		return
 	}
 
 	// We successfully rebalanced below or equal to the max threshold,
@@ -623,9 +624,6 @@ func (sr *StoreRebalancer) RebalanceRanges(
 	)
 
 	if candidateReplica == nil {
-		log.KvDistribution.Infof(ctx,
-			"ran out of replicas worth transferring and load %s is still above desired threshold %s; will check again soon",
-			rctx.LocalDesc.Capacity.Load(), rctx.maxThresholds)
 		return NoRebalanceTarget, candidateReplica, voterTargets, nonVoterTargets
 	}
 


### PR DESCRIPTION
Previously, the store rebalancer would log `load-based replica transfers successfully brought...` even when the store was not below the max threshold. The store rebalancer also logs when there are no available replica rebalancing actions remaining but the store still above the desired load threshold: `ran out of replicas worth transferring and load`. This log line was duplicated in both the post range rebalancing phase and in exiting the range rebalancing phase.

This commit stops duplication by removing the exit log line and ensures that the `load-based replica transfers successfully brought...` log line occurs only when actually successful.

Resolves: #98867

Release note: None