### PR TITLE
kvserver: increase rebalance action impact req

### DIFF
--- a/pkg/kv/kvserver/store_rebalancer_test.go
+++ b/pkg/kv/kvserver/store_rebalancer_test.go
@@ -746,28 +746,30 @@ func TestChooseLeaseToTransfer(t *testing.T) {
 			expectTarget: 5,
 		},
 
+		// NB: The lease has just enough load to be worthwhile rebalancing.
 		{
 			storeIDs:     []roachpb.StoreID{1, 4},
-			qps:          1.5,
-			reqCPU:       1.5 * float64(time.Millisecond),
+			qps:          minLeaseLoadFraction * localDesc.Capacity.QueriesPerSecond,
+			reqCPU:       minLeaseLoadFraction * localDesc.Capacity.CPUPerSecond,
 			expectTarget: 4,
 		},
 		{
 			storeIDs:     []roachpb.StoreID{1, 5},
-			qps:          1.5,
-			reqCPU:       1.5 * float64(time.Millisecond),
+			qps:          minLeaseLoadFraction * localDesc.Capacity.QueriesPerSecond,
+			reqCPU:       minLeaseLoadFraction * localDesc.Capacity.CPUPerSecond,
 			expectTarget: 5,
 		},
+		// NB: The lease is no longer worth rebalancing.
 		{
 			storeIDs:     []roachpb.StoreID{1, 4},
-			qps:          1.49,
-			reqCPU:       1.49 * float64(time.Millisecond),
+			qps:          minLeaseLoadFraction*localDesc.Capacity.QueriesPerSecond - 1,
+			reqCPU:       minLeaseLoadFraction*localDesc.Capacity.CPUPerSecond - 1,
 			expectTarget: 0,
 		},
 		{
 			storeIDs:     []roachpb.StoreID{1, 5},
-			qps:          1.49,
-			reqCPU:       1.49 * float64(time.Millisecond),
+			qps:          minLeaseLoadFraction*localDesc.Capacity.QueriesPerSecond - 1,
+			reqCPU:       minLeaseLoadFraction*localDesc.Capacity.CPUPerSecond - 1,
 			expectTarget: 0,
 		},
 		{


### PR DESCRIPTION
Previously, the store rebalancer would attempt to transfer leases or relocate replicas of a range so long as the load of the range (estimated using the local leaseholder replica) was greater than 0.1% of the store's load.

This commit updates the value to be higher for both lease rebalancing and range rebalancing, specifically:

lease rebalancing: 0.1% -> 0.5%
range rebalancing: 0.1% -> 2.0%

The documented rationale, as for why these values exist is also the reason for the increase: decrease unnecessary churn. Only the hottest ranges are considered, when the impact of a rebalance action for these ranges is estimated to be less than a small fraction of the store's total load, it is indicative that the distribution of replica load is not skewed. Letting the replicate queue balance replica and lease counts is a better option in such distributions (until we consolidate rebalancing responsibility).

Making the minimum for range rebalancing higher is also added, as multiple replicas for a range is inherently more costly than moving a lease.

Resolves: https://github.com/cockroachdb/cockroach/issues/98890

Release note: None