### PR TITLE
kvcoord: Use correct timestamp when restarting range

### DIFF
--- a/pkg/kv/kvclient/kvcoord/dist_sender_rangefeed.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender_rangefeed.go
@@ -489,7 +489,7 @@ func (ds *DistSender) partialRangeFeed(
 			token = rangecache.EvictionToken{}
 		}
 		if errInfo.resolveSpan {
-			return divideSpanOnRangeBoundaries(ctx, ds, rs, active.StartAfter, sendSingleRangeInfo(rangeCh))
+			return divideSpanOnRangeBoundaries(ctx, ds, rs, startAfter, sendSingleRangeInfo(rangeCh))
 		}
 	}
 	return ctx.Err()


### PR DESCRIPTION
Recent changes to rangefeed library (#97957) introduced a silly bug (incorrect code completion/copy paste).

Use correct timestamp when resuming range feed.

Issue: None
Epic: None
Release note: None