### PR TITLE
kv/kvserver: skip TestDecommission

### DIFF
--- a/pkg/kv/kvserver/client_raft_test.go
+++ b/pkg/kv/kvserver/client_raft_test.go
@@ -3263,6 +3263,7 @@ HAVING
 
 func TestDecommission(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	skip.WithIssue(t, 96630, "flaky test")
 	defer log.Scope(t).Close(t)
 
 	// Five nodes is too much to reliably run under testrace with our aggressive


### PR DESCRIPTION
Refs: #96630

Reason: flaky test

Generated by bin/skip-test.

Release justification: non-production code changes
Release note: None
Epic: None