### PR TITLE
server: fix tenant auth for status server

### DIFF
--- a/pkg/rpc/context.go
+++ b/pkg/rpc/context.go
@@ -883,18 +883,6 @@ func makeInternalClientAdapter(
 			// the outer RPC.
 			ctx = grpcutil.NewLocalRequestContext(ctx, clientTenantID)
 
-			// Clear any leftover gRPC incoming metadata, if this call
-			// is originating from a RPC handler function called as
-			// a result of a tenant call. This is this case:
-			//
-			//    tenant -(rpc)-> tenant -(rpc)-> KV
-			//                            ^ YOU ARE HERE
-			//
-			// at this point, the left side RPC has left some incoming
-			// metadata in the context, but we need to get rid of it
-			// before we let the call go through KV.
-			ctx = grpcutil.ClearIncomingContext(ctx)
-
 			// If the caller and callee use separate tracers, we make things
 			// look closer to a remote call from the tracing point of view.
 			if separateTracers {

--- a/pkg/server/status.go
+++ b/pkg/server/status.go
@@ -2476,6 +2476,13 @@ type tableMeta struct {
 func (t *statusServer) HotRangesV2(
 	ctx context.Context, req *serverpb.HotRangesRequest,
 ) (*serverpb.HotRangesResponseV2, error) {
+	ctx = t.AnnotateCtx(ctx)
+
+	err := t.privilegeChecker.requireViewClusterMetadataPermission(ctx)
+	if err != nil {
+		return nil, err
+	}
+
 	return t.sqlServer.tenantConnect.HotRangesV2(ctx, req)
 }
 


### PR DESCRIPTION
Previously, the authentication for gRPC endpoints that are exposed
via HTTP on the tenant was not implemented correctly. Because the HTTP
session is decoded into gRPC metadata, and that metadata was contained
in the Context object passed through to the Tenant Connector, the
username from the tenant could leak into the kv layer and be treated
as an authenticated username. If that username happened to match one
in the system tenant it would be accepted as valid.

Additinally, some endpoints were missing their authentication code.
This did not break functionality because a gRPC request without any
metadata is treated as an internal request with admin permissions.

*Warning*: If a request contains a validated username as part of gRPC
metadata and that metadata is preserved as the request is handed down
to the KV layer, it could be interpreted as a valid user on the system
tenant and cause an escalation of privileges.

This commit adds authentication to the HotRangesV2 endpoint and
SpanStats endpoints which were missing it, and contains tests that
ensure that the endpoints return errors when the user does not have
the correct permissions.

Epic: CRDB-12100

Release note: None