### PR TITLE
feat: allow starting docker container via env variable

### DIFF
--- a/build/deploy/cockroach.sh
+++ b/build/deploy/cockroach.sh
@@ -295,4 +295,10 @@ _main() {
   esac
 }
 
-_main "$@"
+set_env_var "COCKROACH_ARGS"
+
+if [[ -n "$COCKROACH_ARGS" ]]; then
+  _main "$COCKROACH_ARGS"
+else
+  _main "$@"
+fi


### PR DESCRIPTION
Fixes #87043 by allowing you to specify args via the `COCKROACH_ARGS` env value instead of a command. This is required to be able to use the official cockroach image with GitHub actions via a service. More details in the issue.

Note, do to weirdness with merging commands and env values, I decided that setting the `COCKROACH_ARGS` would ignore any command given. This should reduce issues with people trying to use both ways of specifying args and instead force them to pick one.

Release note (general change): Allow setting docker command args via the `COCKROACH_ARGS` environment variable.