### PR TITLE
sql: address a few nits from reviewing an old PR

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/mutation.go
+++ b/pkg/sql/opt/exec/execbuilder/mutation.go
@@ -511,9 +511,10 @@ func (b *Builder) buildDelete(del *memo.DeleteExpr) (execPlan, error) {
 	fetchColOrds := ordinalSetFromColList(del.FetchCols)
 	returnColOrds := ordinalSetFromColList(del.ReturnCols)
 
-	//Construct the result columns for the passthrough set
+	// Construct the result columns for the passthrough set.
 	var passthroughCols colinfo.ResultColumns
 	if del.NeedResults() {
+		passthroughCols = make(colinfo.ResultColumns, 0, len(del.PassthroughCols))
 		for _, passthroughCol := range del.PassthroughCols {
 			colMeta := b.mem.Metadata().ColumnMeta(passthroughCol)
 			passthroughCols = append(passthroughCols, colinfo.ResultColumn{Name: colMeta.Alias, Typ: colMeta.Type})

--- a/pkg/sql/opt/exec/factory.opt
+++ b/pkg/sql/opt/exec/factory.opt
@@ -566,7 +566,7 @@ define Upsert {
 # as they appear in the table schema.
 #
 # The passthrough parameter contains all the result columns that are part of
-# the input node that the update node needs to return (passing through from
+# the input node that the delete node needs to return (passing through from
 # the input). The pass through columns are used to return any column from the
 # USING tables that are referenced in the RETURNING clause.
 define Delete {

--- a/pkg/sql/opt/optbuilder/mutation_builder.go
+++ b/pkg/sql/opt/optbuilder/mutation_builder.go
@@ -417,7 +417,7 @@ func (mb *mutationBuilder) buildInputForDelete(
 	if usingClausePresent {
 		usingScope := mb.b.buildFromTables(using, noRowLocking, inScope)
 
-		// Check that the same table name is not used multiple times
+		// Check that the same table name is not used multiple times.
 		mb.b.validateJoinTableNames(mb.fetchScope, usingScope)
 
 		// The USING table columns can be accessed by the RETURNING clause of the
@@ -460,7 +460,7 @@ func (mb *mutationBuilder) buildInputForDelete(
 	mb.outScope = projectionsScope
 
 	// Build a distinct on to ensure there is at most one row in the joined output
-	// for every row in the table
+	// for every row in the table.
 	if usingClausePresent {
 		var pkCols opt.ColSet
 


### PR DESCRIPTION
This commit addresses several nits (a typo, missing periods, and precisely allocating a slice) that I noticed while reviewing the old PR which introduced DELETE FROM ... USING support.

Epic: None

Release note: None