### PR TITLE
roachprod: add cost estimation to list (gcp only)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -134,6 +134,7 @@ require (
 	github.com/elastic/gosigar v0.14.1
 	github.com/emicklei/dot v0.15.0
 	github.com/facebookgo/clock v0.0.0-20150410010913-600d898af40a
+	github.com/fatih/color v1.9.0
 	github.com/fraugster/parquet-go v0.10.0
 	github.com/fsnotify/fsnotify v1.5.1
 	github.com/getsentry/sentry-go v0.12.0
@@ -330,6 +331,7 @@ require (
 	github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 // indirect
 	github.com/magiconair/properties v1.8.5 // indirect
 	github.com/mailru/easyjson v0.7.6 // indirect
+	github.com/mattn/go-colorable v0.1.12 // indirect
 	github.com/mattn/go-localereader v0.0.1 // indirect
 	github.com/mattn/go-runewidth v0.0.14 // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369 // indirect

--- a/go.sum
+++ b/go.sum
@@ -748,6 +748,7 @@ github.com/fanixk/geohash v0.0.0-20150324002647-c1f9b5fa157a h1:Fyfh/dsHFrC6nkX7
 github.com/fanixk/geohash v0.0.0-20150324002647-c1f9b5fa157a/go.mod h1:UgNw+PTmmGN8rV7RvjvnBMsoTU8ZXXnaT3hYsDTBlgQ=
 github.com/fasthttp-contrib/websocket v0.0.0-20160511215533-1f3b11f56072/go.mod h1:duJ4Jxv5lDcvg4QuQr0oowTf7dz4/CR8NtyCooz9HL8=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
+github.com/fatih/color v1.9.0 h1:8xPHl4/q1VyqGIPif1F+1V3Y3lSmrq01EabUW3CoW5s=
 github.com/fatih/color v1.9.0/go.mod h1:eQcE1qtQxscV5RaZvpXrrb8Drkc3/DdQ+uUYCNjL+zU=
 github.com/fatih/structs v1.1.0 h1:Q7juDM0QtcnhCpeyLGQKyg4TOIghuNXrkL32pHAUMxo=
 github.com/fatih/structs v1.1.0/go.mod h1:9NiDSp5zOcgEDl+j00MP/WkGVPOlPRLejGD8Ga6PJ7M=
@@ -1604,6 +1605,7 @@ github.com/mattn/go-colorable v0.1.6/go.mod h1:u6P/XSegPjTcexA+o6vUJrdnUu04hMope
 github.com/mattn/go-colorable v0.1.7/go.mod h1:u6P/XSegPjTcexA+o6vUJrdnUu04hMope9wVRipJSqc=
 github.com/mattn/go-colorable v0.1.8/go.mod h1:u6P/XSegPjTcexA+o6vUJrdnUu04hMope9wVRipJSqc=
 github.com/mattn/go-colorable v0.1.11/go.mod h1:u5H1YNBxpqRaxsYJYSkiCWKzEfiAb1Gb520KVy5xxl4=
+github.com/mattn/go-colorable v0.1.12 h1:jF+Du6AlPIjs2BiUiQlKOX0rt3SujHxPnksPKZbaA40=
 github.com/mattn/go-colorable v0.1.12/go.mod h1:u5H1YNBxpqRaxsYJYSkiCWKzEfiAb1Gb520KVy5xxl4=
 github.com/mattn/go-ieproxy v0.0.0-20190610004146-91bb50d98149/go.mod h1:31jz6HNzdxOmlERGGEc4v/dMssOfmp2p5bT/okiKFFc=
 github.com/mattn/go-isatty v0.0.3/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNxMWT7Zi4=

--- a/pkg/cmd/roachprod/BUILD.bazel
+++ b/pkg/cmd/roachprod/BUILD.bazel
@@ -22,9 +22,13 @@ go_library(
         "//pkg/roachprod/vm",
         "//pkg/roachprod/vm/gce",
         "//pkg/util/flagutil",
+        "//pkg/util/timeutil",
         "@com_github_cockroachdb_errors//:errors",
+        "@com_github_fatih_color//:color",
         "@com_github_spf13_cobra//:cobra",
         "@org_golang_x_term//:term",
+        "@org_golang_x_text//language",
+        "@org_golang_x_text//message",
     ],
 )
 

--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -1088,7 +1088,7 @@ func (c *clusterImpl) validate(
 	// Perform validation on the existing cluster.
 	c.status("checking that existing cluster matches spec")
 	pattern := "^" + regexp.QuoteMeta(c.name) + "$"
-	cloudClusters, err := roachprod.List(l, false /* listMine */, pattern)
+	cloudClusters, err := roachprod.List(l, false /* listMine */, pattern, vm.ListOptions{})
 	if err != nil {
 		return err
 	}

--- a/pkg/roachprod/cloud/cluster_cloud.go
+++ b/pkg/roachprod/cloud/cluster_cloud.go
@@ -89,6 +89,9 @@ type Cluster struct {
 	CreatedAt time.Time     `json:"created_at"`
 	Lifetime  time.Duration `json:"lifetime"`
 	VMs       vm.List       `json:"vms"`
+	// CostPerHour is an estimate, in dollars, of how much this cluster costs to
+	// run per hour. 0 if the cost estimate is unavailable.
+	CostPerHour float64
 }
 
 // Clouds returns the names of all of the various cloud providers used
@@ -235,6 +238,7 @@ func ListCloud(l *logger.Logger, options vm.ListOptions) (*Cloud, error) {
 			if v.Lifetime < c.Lifetime {
 				c.Lifetime = v.Lifetime
 			}
+			c.CostPerHour += v.CostPerHour
 		}
 	}
 

--- a/pkg/roachprod/roachprod.go
+++ b/pkg/roachprod/roachprod.go
@@ -320,7 +320,9 @@ func Sync(l *logger.Logger, options vm.ListOptions) (*cloud.Cloud, error) {
 // List returns a cloud.Cloud struct of all roachprod clusters matching clusterNamePattern.
 // Alternatively, the 'listMine' option can be provided to get the clusters that are owned
 // by the current user.
-func List(l *logger.Logger, listMine bool, clusterNamePattern string) (cloud.Cloud, error) {
+func List(
+	l *logger.Logger, listMine bool, clusterNamePattern string, opts vm.ListOptions,
+) (cloud.Cloud, error) {
 	if err := LoadClusters(); err != nil {
 		return cloud.Cloud{}, err
 	}
@@ -344,7 +346,7 @@ func List(l *logger.Logger, listMine bool, clusterNamePattern string) (cloud.Clo
 		}
 	}
 
-	cld, err := Sync(l, vm.ListOptions{})
+	cld, err := Sync(l, opts)
 	if err != nil {
 		return cloud.Cloud{}, err
 	}

--- a/pkg/roachprod/vm/gce/BUILD.bazel
+++ b/pkg/roachprod/vm/gce/BUILD.bazel
@@ -17,6 +17,7 @@ go_library(
         "//pkg/util/timeutil",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_spf13_pflag//:pflag",
+        "@org_golang_google_api//cloudbilling/v1beta",
         "@org_golang_x_sync//errgroup",
     ],
 )

--- a/pkg/roachprod/vm/gce/gcloud.go
+++ b/pkg/roachprod/vm/gce/gcloud.go
@@ -31,6 +31,7 @@ import (
 	"github.com/cockroachdb/errors"
 	"github.com/spf13/pflag"
 	"golang.org/x/sync/errgroup"
+	cloudbilling "google.golang.org/api/cloudbilling/v1beta"
 )
 
 const (
@@ -175,22 +176,37 @@ func (jsonVM *jsonVM) toVM(
 	}
 
 	var volumes []vm.Volume
+	var localDisks []vm.Volume
+
+	parseDiskSize := func(size string) int {
+		if val, err := strconv.Atoi(size); err == nil {
+			return val
+		} else {
+			vmErrors = append(vmErrors, errors.Newf("invalid disk size: %q", size))
+		}
+		return 0
+	}
 
 	for _, jsonVMDisk := range jsonVM.Disks {
-		if jsonVMDisk.Source != "" && !jsonVMDisk.Boot {
+		if jsonVMDisk.Source == "" && jsonVMDisk.Type == "SCRATCH" {
+			// This is a scratch disk.
+			localDisks = append(localDisks, vm.Volume{
+				Size:               parseDiskSize(jsonVMDisk.DiskSizeGB),
+				ProviderVolumeType: "local-ssd",
+			})
+			continue
+		}
+		if !jsonVMDisk.Boot {
+			// Find a persistent volume (detailedDisk) matching the attached non-boot disk.
 			for _, detailedDisk := range disks {
 				if detailedDisk.SelfLink == jsonVMDisk.Source {
 					vol := vm.Volume{
 						ProviderResourceID: detailedDisk.Name,
-						ProviderVolumeType: jsonVMDisk.Type,
-						Zone:               jsonVM.Zone,
+						ProviderVolumeType: detailedDisk.Type,
+						Zone:               detailedDisk.Zone,
 						Name:               detailedDisk.Name,
 						Labels:             detailedDisk.Labels,
-					}
-					if val, err := strconv.Atoi(jsonVMDisk.DiskSizeGB); err == nil {
-						vol.Size = val
-					} else {
-						vmErrors = append(vmErrors, errors.Newf("invalid disk size: %q", jsonVMDisk.DiskSizeGB))
+						Size:               parseDiskSize(detailedDisk.SizeGB),
 					}
 					volumes = append(volumes, vol)
 				}
@@ -217,6 +233,7 @@ func (jsonVM *jsonVM) toVM(
 		SQLPort:                config.DefaultSQLPort,
 		AdminUIPort:            config.DefaultAdminUIPort,
 		NonBootAttachedVolumes: volumes,
+		LocalDisks:             localDisks,
 	}
 }
 
@@ -441,6 +458,9 @@ func (p *Provider) CreateVolume(
 }
 
 type instanceDisksResponse struct {
+	// Disks that are attached to the instance.
+	// N.B. Unattached disks can be enumerated via,
+	//	gcloud compute --project $project disks list --filter="-users:*"
 	Disks []attachDiskCmdDisk `json:"disks"`
 }
 type attachDiskCmdDisk struct {
@@ -1038,6 +1058,10 @@ func (p *Provider) FindActiveAccount(l *logger.Logger) (string, error) {
 
 // List queries gcloud to produce a list of VM info objects.
 func (p *Provider) List(l *logger.Logger, opts vm.ListOptions) (vm.List, error) {
+	if opts.IncludeVolumes {
+		l.Printf("WARN: --include-volumes is disabled; attached disks info will be partial")
+	}
+
 	var vms vm.List
 	for _, prj := range p.GetProjects() {
 		args := []string{"compute", "instances", "list", "--project", prj, "--format", "json"}
@@ -1079,11 +1103,156 @@ func (p *Provider) List(l *logger.Logger, opts vm.ListOptions) (vm.List, error) 
 		for _, jsonVM := range jsonVMS {
 			defaultOpts := p.CreateProviderOpts().(*ProviderOpts)
 			disks := userVMToDetailedDisk[jsonVM.SelfLink]
+
+			if len(disks) == 0 {
+				// Since `--include-volumes` is disabled, we convert attachDiskCmdDisk to describeVolumeCommandResponse.
+				// The former is a subset of the latter. Some information like `Labels` will be missing.
+				disks = toDescribeVolumeCommandResponse(jsonVM.Disks, jsonVM.Zone)
+			}
 			vms = append(vms, *jsonVM.toVM(prj, disks, defaultOpts))
 		}
 	}
 
+	if opts.ComputeEstimatedCost {
+		if err := populateCostPerHour(l, vms); err != nil {
+			// N.B. We continue despite the error since it doesn't prevent 'List' and other commands which may depend on it.
+
+			l.Errorf("Error during cost estimation (will continue without): %v", err)
+			if strings.Contains(err.Error(), "could not find default credentials") {
+				l.Printf("To fix this, run `gcloud auth application-default login`")
+			}
+		}
+	}
+
 	return vms, nil
+}
+
+// Convert attachDiskCmdDisk to describeVolumeCommandResponse and link via SelfLink, Source.
+func toDescribeVolumeCommandResponse(
+	disks []attachDiskCmdDisk, zone string,
+) []describeVolumeCommandResponse {
+	res := make([]describeVolumeCommandResponse, 0, len(disks))
+
+	diskType := func(s string) string {
+		if s == "PERSISTENT" {
+			// Unfortunately, we don't know if it's a pd-ssd or pd-standard. We assume pd_ssd since those are common.
+			return "pd-ssd"
+		}
+		return "unknown"
+	}
+
+	for _, d := range disks {
+		if d.Source == "" && d.Type == "SCRATCH" {
+			// Skip scratch disks.
+			continue
+		}
+		res = append(res, describeVolumeCommandResponse{
+			Name:     d.DeviceName,
+			SelfLink: d.Source,
+			SizeGB:   d.DiskSizeGB,
+			Type:     diskType(d.Type),
+			Zone:     zone,
+		})
+	}
+	return res
+}
+
+// populateCostPerHour adds an approximate cost per hour to each VM in the list,
+// using a basic estimation method.
+//  1. Compute and attached disks are estimated at the list prices, ignoring
+//     all discounts, but including any automatically applied credits.
+//  2. Boot disk costs are completely ignored.
+//  3. Network egress costs are completely ignored.
+//  4. Blob storage costs are completely ignored.
+func populateCostPerHour(l *logger.Logger, vms vm.List) error {
+	// Construct cost estimation service
+	ctx := context.Background()
+	service, err := cloudbilling.NewService(ctx)
+	if err != nil {
+		return err
+	}
+	beta := cloudbilling.NewV1betaService(service)
+	scenario := cloudbilling.EstimateCostScenarioWithListPriceRequest{
+		CostScenario: &cloudbilling.CostScenario{
+			ScenarioConfig: &cloudbilling.ScenarioConfig{
+				EstimateDuration: "3600s",
+			},
+			Workloads: []*cloudbilling.Workload{},
+		},
+	}
+	// Workload estimation service can handle 100 workloads at a time, so page
+	// 100 VMs at a time.
+	for len(vms) > 0 {
+		scenario.CostScenario.Workloads = scenario.CostScenario.Workloads[:0]
+		var page vm.List
+		if len(vms) <= 100 {
+			page, vms = vms, nil
+		} else {
+			page, vms = vms[:100], vms[100:]
+		}
+		for _, vm := range page {
+			machineType := vm.MachineType
+			zone := vm.Zone
+
+			workload := cloudbilling.Workload{
+				Name: vm.Name,
+				ComputeVmWorkload: &cloudbilling.ComputeVmWorkload{
+					InstancesRunning: &cloudbilling.Usage{
+						UsageRateTimeline: &cloudbilling.UsageRateTimeline{
+							UsageRateTimelineEntries: []*cloudbilling.UsageRateTimelineEntry{
+								{
+									// We're estimating the cost of 1 vm at a time.
+									UsageRate: 1,
+								},
+							},
+						},
+					},
+					MachineType: &cloudbilling.MachineType{
+						PredefinedMachineType: &cloudbilling.PredefinedMachineType{
+							MachineType: machineType,
+						},
+					},
+					PersistentDisks: []*cloudbilling.PersistentDisk{},
+					Region:          zone[:len(zone)-2],
+				},
+			}
+			for _, v := range vm.NonBootAttachedVolumes {
+				workload.ComputeVmWorkload.PersistentDisks = append(workload.ComputeVmWorkload.PersistentDisks, &cloudbilling.PersistentDisk{
+					DiskSize: &cloudbilling.Usage{
+						UsageRateTimeline: &cloudbilling.UsageRateTimeline{
+							Unit: "GiBy",
+							UsageRateTimelineEntries: []*cloudbilling.UsageRateTimelineEntry{
+								{
+									UsageRate: float64(v.Size),
+								},
+							},
+						},
+					},
+					DiskType: v.ProviderVolumeType,
+					Scope:    "SCOPE_ZONAL",
+				})
+			}
+			scenario.CostScenario.Workloads = append(scenario.CostScenario.Workloads, &workload)
+		}
+		estimate, err := beta.EstimateCostScenario(&scenario).Do()
+		if err != nil {
+			l.Errorf("Error estimating VM costs (will continue without): %v", err)
+			continue
+		}
+		workloadEstimates := estimate.CostEstimationResult.SegmentCostEstimates[0].WorkloadCostEstimates
+		for i := range workloadEstimates {
+			workloadEstimate := workloadEstimates[i].WorkloadTotalCostEstimate.NetCostEstimate
+			page[i].CostPerHour = float64(workloadEstimate.Units) + float64(workloadEstimate.Nanos)/1e9
+			// Add the estimated cost of local disks since the billing API only supports persistent disks.
+			for _, v := range page[i].LocalDisks {
+				// "For example, in the Iowa, Oregon, Taiwan, and Belgium regions, local SSDs cost $0.080 per GB per month."
+				// Normalized to per hour billing, 0.08 / 730 = 0.0001095890410958904
+				// https://cloud.google.com/compute/disks-image-pricing#disk
+				page[i].CostPerHour += float64(v.Size) * 0.00011
+			}
+		}
+	}
+	return nil
 }
 
 func serializeLabel(s string) string {

--- a/pkg/roachprod/vm/vm.go
+++ b/pkg/roachprod/vm/vm.go
@@ -90,8 +90,15 @@ type VM struct {
 	// LocalClusterName is only set for VMs in a local cluster.
 	LocalClusterName string `json:"local_cluster_name,omitempty"`
 
-	// NonBootAttachedVolumes are the non-bootable volumes attached to the VM.
+	// NonBootAttachedVolumes are the non-bootable, _persistent_ volumes attached to the VM.
 	NonBootAttachedVolumes []Volume `json:"non_bootable_volumes"`
+
+	// LocalDisks are the ephemeral SSD disks attached to the VM.
+	LocalDisks []Volume `json:"local_disks"`
+
+	// CostPerHour is the estimated cost per hour of this VM, in US dollars. 0 if
+	//there is no estimate available.
+	CostPerHour float64
 }
 
 // Name generates the name for the i'th node in a cluster.
@@ -209,6 +216,7 @@ func DefaultCreateOpts() CreateOpts {
 		GeoDistributed: false,
 		VMProviders:    []string{},
 		OsVolumeSize:   10,
+		CustomLabels:   map[string]string{"roachtest": "true"},
 	}
 	defaultCreateOpts.SSDOpts.UseLocalSSD = true
 	defaultCreateOpts.SSDOpts.NoExt4Barrier = true
@@ -270,7 +278,8 @@ type VolumeCreateOpts struct {
 }
 
 type ListOptions struct {
-	IncludeVolumes bool
+	IncludeVolumes       bool
+	ComputeEstimatedCost bool
 }
 
 // A Provider is a source of virtual machines running on some hosting platform.


### PR DESCRIPTION
This commit adds cost estimation to roachprod list. It currently supports GCP only.

Example image:
<img width="1522" alt="image" src="https://user-images.githubusercontent.com/43821/226125777-1d6444f5-3a06-492a-ba51-92ea5be6163f.png">

cc @udnay @kenliu-crl @srosenberg 

Epic: None
Release note: None