### PR TITLE
roachtest: fix c2c roachtests that read job payload

### DIFF
--- a/pkg/cmd/roachtest/tests/BUILD.bazel
+++ b/pkg/cmd/roachtest/tests/BUILD.bazel
@@ -249,7 +249,6 @@ go_library(
         "@com_github_aws_aws_sdk_go_v2_service_rds//:rds",
         "@com_github_aws_aws_sdk_go_v2_service_rds//types",
         "@com_github_aws_aws_sdk_go_v2_service_secretsmanager//:secretsmanager",
-        "@com_github_cockroachdb_apd_v3//:apd",
         "@com_github_cockroachdb_cockroach_go_v2//crdb",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_cockroachdb_ttycolor//:ttycolor",


### PR DESCRIPTION
In #98608 some changes were made to the c2c roachtests that caused them to break. This change fixes the tests by querying the correct virutal table that interacts with both `system.jobs` and `system.job_info`.

Fixes: #98973
Fixes: #98969
Fixes: #98962
Informs: #98669

Release note: None