### PR TITLE
server: only set default tenant if login successful

### DIFF
--- a/pkg/ccl/serverccl/server_controller_test.go
+++ b/pkg/ccl/serverccl/server_controller_test.go
@@ -9,6 +9,7 @@
 package serverccl
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"io"
@@ -19,6 +20,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/server"
 	"github.com/cockroachdb/cockroach/pkg/server/serverpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/lexbase"
@@ -209,6 +211,47 @@ VALUES($1, $2, $3, $4, $5, (SELECT user_id FROM system.users WHERE username = $3
 	require.Equal(t, body.Sessions[0].ApplicationName, "hello system")
 
 	t.Logf("end of test")
+}
+
+// TestServerControllerDefaultHTTPTenant ensures that the default
+// tenant selected in the cookie does not use the default tenant
+// from the cluster setting *unless* the user successfully logged
+// in to that tenant.
+func TestServerControllerDefaultHTTPTenant(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+
+	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{DisableDefaultTestTenant: true})
+	defer s.Stopper().Stop(ctx)
+
+	_, sql, err := s.StartSharedProcessTenant(ctx, base.TestSharedProcessTenantArgs{
+		TenantName: "hello",
+		TenantID:   roachpb.MustMakeTenantID(10),
+	})
+	require.NoError(t, err)
+
+	_, err = sql.Exec("CREATE user foo with password 'cockroach'")
+	require.NoError(t, err)
+
+	client, err := s.GetUnauthenticatedHTTPClient()
+	require.NoError(t, err)
+
+	resp, err := client.Post(s.AdminURL()+"/login",
+		"application/json",
+		bytes.NewBuffer([]byte("{\"username\":\"foo\",\"password\":\"cockroach\"})")),
+	)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	tenantCookie := ""
+	for _, c := range resp.Cookies() {
+		if c.Name == server.TenantSelectCookieName {
+			tenantCookie = c.Value
+		}
+	}
+	require.Equal(t, "hello", tenantCookie)
 }
 
 // TestServerControllerBadHTTPCookies tests the controller's proxy


### PR DESCRIPTION
Previously, we would always set the default tenant cookie to the default tenant cluster setting regardless of what tenants the user logged-in to successfully.

This change ensures that the default tenant selection is only used when the successful logins include that tenant. Otherwise, we select the first tenant from the list of successful logins.

Epic: CRDB-12100
Release note: None