### PR TITLE
multitenant: Increase timeout for kvtenantccl

### DIFF
--- a/pkg/ccl/kvccl/kvtenantccl/BUILD.bazel
+++ b/pkg/ccl/kvccl/kvtenantccl/BUILD.bazel
@@ -45,7 +45,7 @@ go_library(
 
 go_test(
     name = "kvtenantccl_test",
-    size = "medium",
+    size = "large",
     srcs = [
         "connector_test.go",
         "main_test.go",
@@ -56,7 +56,7 @@ go_test(
         "tenant_trace_test.go",
         "tenant_upgrade_test.go",
     ],
-    args = ["-test.timeout=295s"],
+    args = ["-test.timeout=895s"],
     embed = [":kvtenantccl"],
     shard_count = 16,
     deps = [


### PR DESCRIPTION
The new TestTenantUpgradeInterlock test takes a long time to run (up to a minute locally) and has started timing out in nightly runs. On the suspicion that it's timing out strictly because it's long running, increase the timeout to see if that resolves the failures.

Release note: None