### PR TITLE
kvserver: unskip TestBehaviorDuringLeaseTransfer

### DIFF
--- a/pkg/kv/kvserver/replica_test.go
+++ b/pkg/kv/kvserver/replica_test.go
@@ -607,7 +607,6 @@ func TestReplicaReadConsistency(t *testing.T) {
 // transfer might still apply.
 func TestBehaviorDuringLeaseTransfer(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	skip.WithIssue(t, 91948, "flaky test")
 	defer log.Scope(t).Close(t)
 
 	testutils.RunTrueAndFalse(t, "transferSucceeds", func(t *testing.T, transferSucceeds bool) {


### PR DESCRIPTION
Unskip this test, its not failing locally. Previous teamcity logs are no longer available.

Epic: https://cockroachlabs.atlassian.net/browse/CRDB-21501
Fixes: https://github.com/cockroachdb/cockroach/issues/91948
Release note: None