### PR TITLE
kvserver: reduce `SysBytes` MVCC stats race during merges

### DIFF
--- a/pkg/kv/kvnemesis/env.go
+++ b/pkg/kv/kvnemesis/env.go
@@ -14,7 +14,6 @@ import (
 	"context"
 	gosql "database/sql"
 	"fmt"
-	"regexp"
 	"time"
 
 	"github.com/cockroachdb/cockroach-go/v2/crdb"
@@ -68,22 +67,6 @@ func (e *Env) CheckConsistency(ctx context.Context, span roachpb.Span) []error {
 		var key, status, detail string
 		if err := rows.Scan(&rangeID, &key, &status, &detail); err != nil {
 			return []error{err}
-		}
-		// TODO(erikgrinaker): There's a known issue that can result in a 10-byte
-		// discrepancy in SysBytes. This hasn't been investigated, but it's not
-		// critical so we ignore it for now. See:
-		// https://github.com/cockroachdb/cockroach/issues/93896
-		if status == kvpb.CheckConsistencyResponse_RANGE_CONSISTENT_STATS_INCORRECT.String() {
-			m := regexp.MustCompile(`.*\ndelta \(stats-computed\): \{(.*)\}`).FindStringSubmatch(detail)
-			if len(m) > 1 {
-				delta := m[1]
-				// Strip out LastUpdateNanos and all zero-valued fields.
-				delta = regexp.MustCompile(`LastUpdateNanos:\d+`).ReplaceAllString(delta, "")
-				delta = regexp.MustCompile(`\S+:0\b`).ReplaceAllString(delta, "")
-				if regexp.MustCompile(`^\s*SysBytes:10\s*$`).MatchString(delta) {
-					continue
-				}
-			}
 		}
 		switch status {
 		case kvpb.CheckConsistencyResponse_RANGE_INDETERMINATE.String():

--- a/pkg/kv/kvpb/api.proto
+++ b/pkg/kv/kvpb/api.proto
@@ -2079,6 +2079,14 @@ message SubsumeResponse {
     (gogoproto.customname) = "MVCCStats"
   ];
 
+  // RangeIDLocalMVCCStats are the MVCC statistics for the replicated range
+  // ID-local keys. During a merge, these must be subtracted from MVCCStats
+  // since they won't be present in the merged range.
+  storage.enginepb.MVCCStats range_id_local_mvcc_stats = 8 [
+    (gogoproto.nullable) = false,
+    (gogoproto.customname) = "RangeIDLocalMVCCStats"
+  ];
+
   // LeaseAppliedIndex is the lease applied index of the last applied command
   // at the time that the Subsume request executed. This is NOT intended to be
   // the lease index of the SubsumeRequest itself. Instead, it is intended to

--- a/pkg/kv/kvserver/replica_command.go
+++ b/pkg/kv/kvserver/replica_command.go
@@ -764,12 +764,13 @@ func (r *Replica) AdminMerge(
 			Commit: true,
 			InternalCommitTrigger: &roachpb.InternalCommitTrigger{
 				MergeTrigger: &roachpb.MergeTrigger{
-					LeftDesc:             updatedLeftDesc,
-					RightDesc:            rightDesc,
-					RightMVCCStats:       rhsSnapshotRes.MVCCStats,
-					FreezeStart:          rhsSnapshotRes.FreezeStart,
-					RightClosedTimestamp: rhsSnapshotRes.ClosedTimestamp,
-					RightReadSummary:     rhsSnapshotRes.ReadSummary,
+					LeftDesc:                   updatedLeftDesc,
+					RightDesc:                  rightDesc,
+					RightMVCCStats:             rhsSnapshotRes.MVCCStats,
+					RightRangeIDLocalMVCCStats: rhsSnapshotRes.RangeIDLocalMVCCStats,
+					FreezeStart:                rhsSnapshotRes.FreezeStart,
+					RightClosedTimestamp:       rhsSnapshotRes.ClosedTimestamp,
+					RightReadSummary:           rhsSnapshotRes.ReadSummary,
 				},
 			},
 		})

--- a/pkg/roachpb/data.proto
+++ b/pkg/roachpb/data.proto
@@ -153,6 +153,11 @@ message MergeTrigger {
     (gogoproto.nullable) = false
   ];
 
+  storage.enginepb.MVCCStats right_range_id_local_mvcc_stats = 9 [
+    (gogoproto.customname) = "RightRangeIDLocalMVCCStats",
+    (gogoproto.nullable) = false
+  ];
+
   // FreezeStart is a timestamp that is guaranteed to be greater than the
   // timestamps at which any requests were serviced by the right-hand side range
   // before it stopped responding to requests altogether (in anticipation of


### PR DESCRIPTION
During a range merge, we subsume the RHS and ship its MVCC stats via the merge trigger to add them to the LHS stats. Since the RHS range ID-local keys aren't present in the merged range, the merge trigger computed these and subtracted them from the given stats. However, this could race with a lease request, which ignores latches and writes to the range ID-local keyspace, resulting in incorrect `SysBytes` MVCC stats.

This patch instead computes the range ID-local MVCC stats during subsume and sends them via a new `RangeIDLocalMVCCStats` field. This still doesn't guarantee that they're consistent with the RHS's in-memory stats, since the latch-ignoring lease request can update these independently of the subsume request's engine snapshot. However, it substantially reduces the likelihood of this race.

While it would be possible to prevent this race entirely by introducing additional synchronization between lease requests and merge application, this would likely come with significant additional complexity, which doesn't seem worth it just to avoid `SysBytes` being a few bytes wrong. The main fallout is a log message when the consistency checker detects the stats mismatch, and potential test flake. This PR therefore settles for best-effort prevention.

Resolves #93896.
Resolves #94876.
Resolves #99010.

Epic: none
Release note: None