### PR TITLE
ui: fix jobs column name

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/jobs/jobsPage/jobsTable.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/jobs/jobsPage/jobsTable.tsx
@@ -193,7 +193,7 @@ export function makeJobsColumns(): ColumnDescriptor<Job>[] {
           style="tableTitle"
           content={<p>Date and time the job was last executed.</p>}
         >
-          {jobsColumnLabels.lastModifiedTime}
+          {jobsColumnLabels.lastExecutionTime}
         </Tooltip>
       ),
       cell: job => TimestampToMoment(job?.last_run).format(DATE_FORMAT_24_UTC),


### PR DESCRIPTION
The Last Execution Time called was previously labelled as Last Modified Time by mistake.
This commit fixes to use the correct name.

Epic: None

Release note (ui change): Update the Jobs table column name to the correct Last Execution Time.