### PR TITLE
build: update restore regexp in roachtest AWS suite

### DIFF
--- a/build/teamcity/util/roachtest_util.sh
+++ b/build/teamcity/util/roachtest_util.sh
@@ -66,7 +66,7 @@ case "${CLOUD}" in
     if [ -z "${TESTS}" ]; then
       # NB: anchor ycsb to beginning of line to avoid matching `zfs/ycsb/*` which
       # isn't supported on AWS at time of writing.
-      TESTS="awsdms|kv(0|95)|^ycsb|tpcc/(headroom/n4cpu16)|tpccbench/(nodes=3/cpu=16)|scbench/randomload/(nodes=3/ops=2000/conc=1)|backup/(KMS/AWS/n3cpu4)|restore/tpce|restore/pause"
+      TESTS="awsdms|kv(0|95)|^ycsb|tpcc/(headroom/n4cpu16)|tpccbench/(nodes=3/cpu=16)|scbench/randomload/(nodes=3/ops=2000/conc=1)|backup/(KMS/AWS/n3cpu4)|restore/.*/aws"
     fi
     ;;
   *)


### PR DESCRIPTION
In #98259, the concept of `Low` memory per vCPU was introduced in roachtest's `ClusterSpec`. That setting is currently only supported in GCE; if a test that uses that setting is run on any other cloud, roachtest will panic.

The only roachtest using the low-memory setting is currently a restore test that is meant to run on GCE. However, the check for the appropriate cloud is done by that test during runtime (necessarily so), meaning a cluster will need to be created for the check to happen. By that point, the test runner will panic due to the unsupported memory setting.

In the long term, we want to support ways for roachtests to indicate supported clouds outside the `Run` function (some context in #96655). For now, to stop a panic from happening in roachtest nightly runs on AWS, we update the regexp used to choose tests to run on AWS. We leverage the fact that `restore` tests include the cloud they are supposed to run in their name.

Epic: none

Release note: None