### PR TITLE
storepool: set last unavailable on gossip dead

### DIFF
--- a/pkg/kv/kvserver/allocator/storepool/store_pool.go
+++ b/pkg/kv/kvserver/allocator/storepool/store_pool.go
@@ -267,6 +267,7 @@ func (sd *StoreDetail) status(
 	// even before the first gossip arrives for a store.
 	deadAsOf := sd.LastUpdatedTime.Add(deadThreshold)
 	if now.After(deadAsOf) {
+		sd.LastUnavailable = now
 		return storeStatusDead
 	}
 	// If there's no descriptor (meaning no gossip ever arrived for this


### PR DESCRIPTION
Previously, the `LastUnavailable` time was set in most parts of the storepool when a store was considered either `Unavailable`, `Dead`, `Decommissioned` or `Draining`. When `LastUnavailable` is within the last suspect duration (30s default), the node is treated as suspect by other nodes in the cluster.

`LastUnavailable` was not being set when a store was considered dead due to the store not gossiping its store descriptor. This commit updates the `status` storepool function to do just that.

Informs: #98928

Release note: None