### PR TITLE
ccl/sqlproxyccl/acl: fix TestParsingErrorHandling flake

### DIFF
--- a/pkg/ccl/sqlproxyccl/acl/file_test.go
+++ b/pkg/ccl/sqlproxyccl/acl/file_test.go
@@ -494,7 +494,7 @@ func TestParsingErrorHandling(t *testing.T) {
 		select {
 		case <-next:
 			t.Error("should not have gotten a new controller")
-		case <-time.After(time.Millisecond * 200):
+		case <-time.After(time.Millisecond * 500):
 			// error count should go up
 			require.Equal(t, int64(1), errorCountMetric.Snapshot().Value())
 		}
@@ -513,7 +513,7 @@ func TestParsingErrorHandling(t *testing.T) {
 					},
 				},
 			}, allowlist.entries)
-		case <-time.After(time.Millisecond * 200):
+		case <-time.After(time.Millisecond * 500):
 			t.Error("should have gotten a new controller")
 		}
 	})


### PR DESCRIPTION
TestParsingErrorHandling asserts that the error count metric is updated
correctly when reading a file fails or succeeds, and the files are checked
at a regular interval. For the tests that interval is set to 100ms, and we waited
200ms to ensure the metric would be updated, but that seems to not be reliable.
This change increases the wait to 500ms which should ensure the file is
re-read before we check the value of the error metics.

Fixes #98839