### PR TITLE
sqlproxyccl: Add support for limiting non root connections

### DIFF
--- a/pkg/ccl/cliccl/context.go
+++ b/pkg/ccl/cliccl/context.go
@@ -37,6 +37,7 @@ func setProxyContextDefaults() {
 	proxyContext.PollConfigInterval = 30 * time.Second
 	proxyContext.ThrottleBaseDelay = time.Second
 	proxyContext.DisableConnectionRebalancing = false
+	proxyContext.EnableLimitNonRootConns = false
 }
 
 var testDirectorySvrContext struct {

--- a/pkg/ccl/cliccl/flags.go
+++ b/pkg/ccl/cliccl/flags.go
@@ -27,6 +27,7 @@ func init() {
 		cliflagcfg.StringFlag(f, &proxyContext.DirectoryAddr, cliflags.DirectoryAddr)
 		cliflagcfg.BoolFlag(f, &proxyContext.SkipVerify, cliflags.SkipVerify)
 		cliflagcfg.BoolFlag(f, &proxyContext.Insecure, cliflags.InsecureBackend)
+		cliflagcfg.BoolFlag(f, &proxyContext.EnableLimitNonRootConns, cliflags.LimitNonRootConns)
 		cliflagcfg.DurationFlag(f, &proxyContext.ValidateAccessInterval, cliflags.ValidateAccessInterval)
 		cliflagcfg.DurationFlag(f, &proxyContext.PollConfigInterval, cliflags.PollConfigInterval)
 		cliflagcfg.DurationFlag(f, &proxyContext.ThrottleBaseDelay, cliflags.ThrottleBaseDelay)

--- a/pkg/ccl/sqlproxyccl/connector.go
+++ b/pkg/ccl/sqlproxyccl/connector.go
@@ -144,6 +144,7 @@ func (c *connector) OpenTenantConnWithAuth(
 	requester balancer.ConnectionHandle,
 	clientConn net.Conn,
 	throttleHook func(throttler.AttemptStatus) error,
+	limitHook func(crdbConn net.Conn) error,
 ) (retServerConnection net.Conn, sentToClient bool, retErr error) {
 	// Just a safety check, but this shouldn't happen since we will block the
 	// startup param in the frontend admitter. The only case where we actually
@@ -163,7 +164,8 @@ func (c *connector) OpenTenantConnWithAuth(
 
 	// Perform user authentication for non-token-based auth methods. This will
 	// block until the server has authenticated the client.
-	crdbBackendKeyData, err := authenticate(clientConn, serverConn, c.CancelInfo.proxyBackendKeyData, throttleHook)
+	crdbBackendKeyData, err := authenticate(clientConn, serverConn, c.CancelInfo.proxyBackendKeyData,
+		throttleHook, limitHook)
 	if err != nil {
 		return nil, true, err
 	}

--- a/pkg/ccl/sqlproxyccl/tenant/directory.proto
+++ b/pkg/ccl/sqlproxyccl/tenant/directory.proto
@@ -85,6 +85,27 @@ message WatchPodsResponse {
   Pod pod = 1;
 }
 
+// WatchTenantsRequest is empty as we want to get all notifications.
+message WatchTenantsRequest {}
+
+// WatchTenantsResponse represents the notifications that the server sends to
+// its clients when clients want to monitor the directory server activity.
+message WatchTenantsResponse {
+  Tenant tenant = 1;
+}
+
+// Tenant contains information about a tenant, such as its name, tenantID,
+// and connection limit.
+message Tenant {
+  // ClusterName is the name of the tenant's cluster.
+  string cluster_name = 1;
+  // MaxNonRootConns is the limit on non-root sql connections to this tenant.
+  // A value of -1 indicates no limit.
+  int32 max_non_root_conns = 2;
+  // TenantID identifies the tenant.
+  uint64 tenant_id = 3 [(gogoproto.customname) = "TenantID"];
+}
+
 // EnsurePodRequest is used to ensure that at least one tenant pod is in the
 // RUNNING state.
 message EnsurePodRequest {
@@ -107,7 +128,10 @@ message GetTenantRequest {
 // GetTenantResponse is sent back when a client requests metadata for a tenant.
 message GetTenantResponse {
   // ClusterName is the name of the tenant's cluster.
+  // TODO(alyshan): Deprecate cluster_name field in favour of tenant field.
   string cluster_name = 1; // add more metadata if needed
+  // Tenant contains the information for the tenant specified in the request.
+  Tenant tenant = 2;
 }
 
 // Directory specifies a service that keeps track and manages tenant backends,
@@ -120,6 +144,10 @@ service Directory {
   // are sent when a tenant pod is created, destroyed, or modified. When
   // WatchPods is first called, it returns notifications for all existing pods.
   rpc WatchPods(WatchPodsRequest) returns (stream WatchPodsResponse);
+  // WatchTenants gets a stream of tenant change notifications. Notifications
+  // are sent when a tenant is created, destroyed, or modified. When
+  // WatchTenants is first called, it returns notifications for all existing tenants.
+  rpc WatchTenants(WatchTenantsRequest) returns (stream WatchTenantsResponse);
   // EnsurePod ensures that at least one of the given tenant's pod is in the
   // RUNNING state. If there is already a RUNNING pod, then the server doesn't
   // have to do anything. If there isn't a RUNNING pod, then the server must

--- a/pkg/ccl/sqlproxyccl/tenant/directory_cache.go
+++ b/pkg/ccl/sqlproxyccl/tenant/directory_cache.go
@@ -35,6 +35,12 @@ type DirectoryCache interface {
 	// deleted), this will return a GRPC NotFound error.
 	LookupTenantPods(ctx context.Context, tenantID roachpb.TenantID, clusterName string) ([]*Pod, error)
 
+	// LookupTenant returns the specified tenant.
+	//
+	// If no matching tenant is found (e.g. cluster name mismatch, or tenant was
+	// deleted), this will return a GRPC NotFound error.
+	LookupTenant(ctx context.Context, tenantID roachpb.TenantID, clusterName string) (Tenant, error)
+
 	// TryLookupTenantPods returns the IP addresses for all available SQL
 	// processes for the given tenant. It returns a GRPC NotFound error if the
 	// tenant does not exist.
@@ -54,6 +60,10 @@ type dirOptions struct {
 	deterministic bool
 	refreshDelay  time.Duration
 	podWatcher    chan *Pod
+	// watchTenants is a flag that instructs the directory to
+	// set up a watch on tenants and update tenant entries to
+	// keep track of tenants MaxNonRootConnections.
+	watchTenants bool
 }
 
 // DirOption defines an option that can be passed to directoryCache in order
@@ -81,6 +91,13 @@ func RefreshDelay(delay time.Duration) func(opts *dirOptions) {
 func PodWatcher(podWatcher chan *Pod) func(opts *dirOptions) {
 	return func(opts *dirOptions) {
 		opts.podWatcher = podWatcher
+	}
+}
+
+// WithWatchTenantsOption is used to set the watchTenants option to true.
+func WithWatchTenantsOption() func(opts *dirOptions){
+	return func(opts *dirOptions) {
+		opts.watchTenants = true
 	}
 }
 
@@ -150,6 +167,12 @@ func NewDirectoryCache(
 	if err := dir.watchPods(ctx, stopper); err != nil {
 		return nil, err
 	}
+	if dir.options.watchTenants {
+		// Start the tenant watcher on a background goroutine.
+		if err := dir.watchTenants(ctx, stopper); err != nil {
+			return nil, err
+		}
+	}
 
 	return dir, nil
 }
@@ -176,18 +199,9 @@ func (d *directoryCache) LookupTenantPods(
 	ctx context.Context, tenantID roachpb.TenantID, clusterName string,
 ) ([]*Pod, error) {
 	// Ensure that a directory entry has been created for this tenant.
-	entry, err := d.getEntry(ctx, tenantID, true /* allowCreate */)
+	entry, err := d.ensureDirectoryEntry(ctx, tenantID, clusterName)
 	if err != nil {
 		return nil, err
-	}
-
-	// Check if the cluster name matches. This can be skipped if clusterName
-	// is empty, or the ClusterName returned by the directory server is empty.
-	if clusterName != "" && entry.ClusterName != "" && clusterName != entry.ClusterName {
-		// Return a GRPC NotFound error.
-		log.Errorf(ctx, "cluster name %s doesn't match expected %s", clusterName, entry.ClusterName)
-		return nil, status.Errorf(codes.NotFound,
-			"cluster name %s doesn't match expected %s", clusterName, entry.ClusterName)
 	}
 
 	ctx, _ = d.stopper.WithCancelOnQuiesce(ctx)
@@ -207,6 +221,42 @@ func (d *directoryCache) LookupTenantPods(
 		}
 	}
 	return tenantPods, nil
+}
+
+// ensureDirectoryEntry ensures that an entry has been created for the tenant.
+func (d *directoryCache) ensureDirectoryEntry(ctx context.Context,
+	tenantID roachpb.TenantID, clusterName string) (*tenantEntry, error) {
+	entry, err := d.getEntry(ctx, tenantID, true /* allowCreate */)
+	if err != nil {
+		return nil, err
+	}
+
+	// Check if the cluster name matches. This can be skipped if clusterName
+	// is empty, or the ClusterName returned by the directory server is empty.
+	if clusterName != "" && entry.ClusterName != "" && clusterName != entry.ClusterName {
+		// Return a GRPC NotFound error.
+		log.Errorf(ctx, "cluster name %s doesn't match expected %s", clusterName, entry.ClusterName)
+		return nil, status.Errorf(codes.NotFound,
+			"cluster name %s doesn't match expected %s", clusterName, entry.ClusterName)
+	}
+
+	return entry, nil
+}
+
+
+// LookupTenant returns the specified tenant.
+//
+// If no matching tenant is found (e.g. tenant was deleted), this will
+// return a GRPC NotFound error.
+func (d *directoryCache) LookupTenant(ctx context.Context,
+	tenantID roachpb.TenantID, clusterName string) (Tenant, error) {
+	// Ensure that a directory entry has been created for this tenant.
+	entry, err := d.ensureDirectoryEntry(ctx, tenantID, clusterName)
+	if err != nil {
+		return Tenant{}, err
+	}
+
+	return entry.ToTenantProto(), nil
 }
 
 // TryLookupTenantPods returns a list of SQL pods in the RUNNING and DRAINING
@@ -405,7 +455,7 @@ func (d *directoryCache) watchPods(ctx context.Context, stopper *stop.Stopper) e
 
 			// Update the directory entry for the tenant with the latest
 			// information about this pod.
-			d.updateTenantEntry(ctx, resp.Pod)
+			d.updateTenantEntryWithPod(ctx, resp.Pod)
 
 			// If caller is watching pods, send to its channel now. Only do this
 			// after updating the tenant entry in the directory.
@@ -427,10 +477,67 @@ func (d *directoryCache) watchPods(ctx context.Context, stopper *stop.Stopper) e
 	return err
 }
 
-// updateTenantEntry keeps tenant directory entries up-to-date by handling pod
+// watchTenants establishes a watcher that looks for changes to tenants.
+// Whenever a tenant is created, modified or deleted the watcher will get a notification
+// and update the directory to reflect that change.
+func (d *directoryCache) watchTenants(ctx context.Context, stopper *stop.Stopper) error {
+	req := WatchTenantsRequest{}
+
+	err := stopper.RunAsyncTask(ctx, "watch-tenants-client", func(ctx context.Context) {
+		var client Directory_WatchTenantsClient
+		var err error
+		ctx, _ = stopper.WithCancelOnQuiesce(ctx)
+
+		watchTenantsErr := log.Every(10 * time.Second)
+		recvErr := log.Every(10 * time.Second)
+
+		for ctx.Err() == nil {
+			if client == nil {
+				client, err = d.client.WatchTenants(ctx, &req)
+				if err != nil {
+					if watchTenantsErr.ShouldLog() {
+						log.Errorf(ctx, "err creating new watch tenants client: %s", err)
+					}
+					sleepContext(ctx, time.Second)
+					continue
+				} else {
+					log.Info(ctx, "established watch on tenants")
+				}
+			}
+
+			// Read the next watcher event.
+			resp, err := client.Recv()
+			if err != nil {
+				if recvErr.ShouldLog() {
+					log.Errorf(ctx, "err receiving stream events: %s", err)
+				}
+				// If stream ends, immediately try to establish a new one. Otherwise,
+				// wait for a second to avoid slamming server.
+				if err != io.EOF {
+					time.Sleep(time.Second)
+				}
+				client = nil
+				continue
+			}
+
+			// Update the directory entry for the tenant with the latest
+			// information about this tenant. Note that if an entry does not exist for the
+			// tenant, then we will not create one. This is because there is no value in keeping
+			// entries for tenants that aren't being connected to through the proxy.
+			d.updateTenantEntryWithTenant(ctx, resp.Tenant)
+		}
+	})
+	if err != nil {
+		return err
+	}
+
+	return err
+}
+
+// updateTenantEntryWithPod keeps tenant directory entries up-to-date by handling pod
 // watcher events. When a pod is created, destroyed, or modified, it updates the
 // tenant's entry to reflect that change.
-func (d *directoryCache) updateTenantEntry(ctx context.Context, pod *Pod) {
+func (d *directoryCache) updateTenantEntryWithPod(ctx context.Context, pod *Pod) {
 	if pod.Addr == "" || pod.TenantID == 0 {
 		// Nothing needs to be done if there is no IP address specified.
 		// We also check on TenantID here because roachpb.MustMakeTenantID will
@@ -466,6 +573,32 @@ func (d *directoryCache) updateTenantEntry(ctx context.Context, pod *Pod) {
 		// Pods with UNKNOWN state.
 		log.Infof(ctx, "invalid pod entry with IP address %s for tenant %d", pod.Addr, pod.TenantID)
 	}
+}
+
+// updateTenantEntryWithTenant keeps tenant directory entries up-to-date by handling tenant
+// watcher events. When a tenant is modified, it updates the tenant's entry to reflect that change.
+// Note that if an entry does not exist, this function will not create one. The watcher is only
+// concerned with tenants that are being connected to through the proxy.
+func (d *directoryCache) updateTenantEntryWithTenant(ctx context.Context, tenant *Tenant) {
+	// Nothing to do.
+	if tenant == nil {
+		return
+	}
+
+	entry, err := d.getEntry(ctx, roachpb.MustMakeTenantID(tenant.TenantID), false)
+	if err != nil {
+		if !grpcutil.IsContextCanceled(err) {
+			// This should only happen in case of a deleted tenant or a transient
+			// error during fetch of tenant metadata (i.e. very rarely).
+			log.Errorf(ctx, "ignoring error getting entry for tenant %d: %v", tenant.TenantID, err)
+		}
+		return
+	}
+	if entry == nil {
+		return
+	}
+
+	entry.SetMaxNonRootConnections(tenant.MaxNonRootConns)
 }
 
 // sleepContext sleeps for the given duration or until the given context is

--- a/pkg/ccl/sqlproxyccl/tenantdirsvr/test_directory_svr.go
+++ b/pkg/ccl/sqlproxyccl/tenantdirsvr/test_directory_svr.go
@@ -228,6 +228,14 @@ func (s *TestDirectoryServer) WatchPods(
 	return err
 }
 
+// WatchTenants returns a new stream, that can be used to monitor server
+// activity.
+func (s *TestDirectoryServer) WatchTenants(
+	_ *tenant.WatchTenantsRequest, server tenant.Directory_WatchTenantsServer,
+) error {
+	return nil
+}
+
 // Drain sends out DRAINING pod notifications for each process managed by the
 // test directory. This causes the proxy to start enforcing short idle
 // connection timeouts in order to drain the connections to the pod.

--- a/pkg/ccl/sqlproxyccl/tenantdirsvr/test_simple_directory_svr.go
+++ b/pkg/ccl/sqlproxyccl/tenantdirsvr/test_simple_directory_svr.go
@@ -77,6 +77,15 @@ func (d *TestSimpleDirectoryServer) ListPods(
 	}, nil
 }
 
+// WatchTenants is a no-op for the simple directory.
+//
+// WatchTenants implements the tenant.DirectoryServer interface.
+func (d *TestSimpleDirectoryServer) WatchTenants(
+	req *tenant.WatchTenantsRequest, server tenant.Directory_WatchTenantsServer,
+) error {
+	return nil
+}
+
 // WatchPods is a no-op for the simple directory.
 //
 // WatchPods implements the tenant.DirectoryServer interface.

--- a/pkg/cli/cliflags/flags_mt.go
+++ b/pkg/cli/cliflags/flags_mt.go
@@ -64,6 +64,11 @@ var (
 		Description: "Directory address of the service doing resolution of tenants to their IP addresses.",
 	}
 
+	LimitNonRootConns = FlagInfo{
+		Name:        "limit-non-root-conns",
+		Description: "Enable the limiting of non-root connections for tenants.",
+	}
+
 	// TODO(chrisseto): Remove skip-verify as a CLI option. It should only be
 	// set internally for testing, rather than being exposed to consumers.
 	SkipVerify = FlagInfo{


### PR DESCRIPTION
This commit adds a cli flag `--limit-non-root-conns` to the sqlproxy. When set to true, this enables the sqlproxy to limit the number of non root connections to tenants. This is achieved by modifying the Directory interface to supply an additional field `MaxNonRootConnections` when getting tenants. And adding a watcher for tenants. The sqlproxy is then able to check if the current connection exceeds the `MaxNonRootConnections` limit for the tenant and can close it appropriately with a user friendly error.

This functionality is required for Serverless.
Part of: https://cockroachlabs.atlassian.net/browse/CC-9288

Release note: None