### PR TITLE
kv: clean up bookkeeping on the client for transaction aborts

### DIFF
--- a/pkg/kv/kvserver/intent_resolver_integration_test.go
+++ b/pkg/kv/kvserver/intent_resolver_integration_test.go
@@ -579,7 +579,8 @@ func TestReliableIntentCleanup(t *testing.T) {
 					require.Fail(t, "too many txn retries", "attempt %v errored: %v", attempt, err)
 				} else {
 					t.Logf("retrying unexpected txn error: %v", err)
-					require.True(t, txn.IsRetryableErrMeantForTxn(*retryErr))
+					// Sanity check the retry error is meant for our transaction.
+					require.Equal(t, retryErr.TxnID, txn.ID())
 				}
 			}
 


### PR DESCRIPTION
This patch cleans up the bookkeeping we do to handle
TransactionAbortedErrors in the client kv.Txn API. When a transaction is
aborted, the TransactionRetryWithProtoRefreshError that's returned to
the client comes prepared with a new transaction that should be used by
the client on its next attempt. Previously, this scheme could lead to
multiple incarnations of the "same" transaction to be active at any
given time. As such, it required us to keep track of IDs from previous
incarnations of the transaction. We would use this to then swallow
retryable errors in certain cases.

This bookkeeping is completely unnecessary in the current code's form.
In particular, with the way `PrepareForRetry` is structured, we are
guaranteed that at no point both the old and new incarnation of a
transaction are active. This patch solidifies this guarantee and
removes the unnecessary bookkeeping.

While here, we also improve how `PrepareForRetry` works. Previously,
it delegated the responsibility to prepare the Txn for all retryable
errors (not just transaction aborts) to
 `replaceRootSenderIfTxnAbortedLocked`. This wasn't extremely obvious,
given the function name. This change gets rid of this function. Instead,
we now handle all retryable errors (bar transaction aborts) in
`PrepareForRetry` itself. The handling of transaction abort errors
continues to be delegated to a different function, except we call the
thing `handleTransactionAbortedErrorLocked` now.

Release note: None
Release justification: None. Not intending to merge this before the
23.1 branch is cut.