### PR TITLE
release-22.2: backupccl: default bulkio.restore.use_simple_import_spans to true

### DIFF
--- a/pkg/ccl/backupccl/restore_job.go
+++ b/pkg/ccl/backupccl/restore_job.go
@@ -81,7 +81,7 @@ var useSimpleImportSpans = settings.RegisterBoolSetting(
 	settings.TenantWritable,
 	"bulkio.restore.use_simple_import_spans",
 	"if set to true, restore will generate its import spans using the makeSimpleImportSpans algorithm",
-	false,
+	true,
 )
 
 // rewriteBackupSpanKey rewrites a backup span start key for the purposes of


### PR DESCRIPTION
Set the default value of bulkio.restore.use_simple_import_spans to true as the generative import spans algorithm has a bug that causes it to emit import spans with missing files on resume.

Fixes: #98779

Release note (bug fix): sets bulkio.restore.use_simple_import_spans to true. If the setting is false, restore can emit miss files from the first few spans on job resume.