### PR TITLE
storage/cloud: correct the flag name in implicit credentials error message

### DIFF
--- a/pkg/cloud/amazon/aws_kms.go
+++ b/pkg/cloud/amazon/aws_kms.go
@@ -183,7 +183,7 @@ func MakeAWSKMS(ctx context.Context, uri string, env cloud.KMSEnv) (cloud.KMS, e
 	case cloud.AuthParamImplicit:
 		if env.KMSConfig().DisableImplicitCredentials {
 			return nil, errors.New(
-				"implicit credentials disallowed for s3 due to --external-io-implicit-credentials flag")
+				"implicit credentials disallowed for s3 due to --external-io-disable-implicit-credentials flag")
 		}
 		opts.SharedConfigState = session.SharedConfigEnable
 	default:

--- a/pkg/cloud/amazon/s3_storage.go
+++ b/pkg/cloud/amazon/s3_storage.go
@@ -425,7 +425,7 @@ func MakeS3Storage(
 	case cloud.AuthParamImplicit:
 		if args.IOConf.DisableImplicitCredentials {
 			return nil, errors.New(
-				"implicit credentials disallowed for s3 due to --external-io-implicit-credentials flag")
+				"implicit credentials disallowed for s3 due to --external-io-disable-implicit-credentials flag")
 		}
 	default:
 		return nil, errors.Errorf("unsupported value %s for %s", conf.Auth, cloud.AuthParam)

--- a/pkg/cloud/azure/azure_kms.go
+++ b/pkg/cloud/azure/azure_kms.go
@@ -168,7 +168,7 @@ func MakeAzureKMS(ctx context.Context, uri string, env cloud.KMSEnv) (cloud.KMS,
 	case cloudpb.AzureAuth_IMPLICIT:
 		if env.KMSConfig().DisableImplicitCredentials {
 			return nil, errors.New(
-				"implicit credentials disallowed for azure due to --external-io-implicit-credentials flag")
+				"implicit credentials disallowed for azure due to --external-io-disable-implicit-credentials flag")
 		}
 		// The Default credential supports env vars and managed identity magic.
 		// We rely on the former for testing and the latter in prod.

--- a/pkg/cloud/azure/azure_storage.go
+++ b/pkg/cloud/azure/azure_storage.go
@@ -250,7 +250,7 @@ func makeAzureStorage(
 	case cloudpb.AzureAuth_IMPLICIT:
 		if args.IOConf.DisableImplicitCredentials {
 			return nil, errors.New(
-				"implicit credentials disallowed for azure due to --external-io-implicit-credentials flag")
+				"implicit credentials disallowed for azure due to --external-io-disable-implicit-credentials flag")
 		}
 		// The Default credential supports env vars and managed identity magic.
 		// We rely on the former for testing and the latter in prod.

--- a/pkg/cloud/gcp/gcp_kms.go
+++ b/pkg/cloud/gcp/gcp_kms.go
@@ -116,7 +116,7 @@ func MakeGCSKMS(ctx context.Context, uri string, env cloud.KMSEnv) (cloud.KMS, e
 	case cloud.AuthParamImplicit:
 		if env.KMSConfig().DisableImplicitCredentials {
 			return nil, errors.New(
-				"implicit credentials disallowed for gcs due to --external-io-implicit-credentials flag")
+				"implicit credentials disallowed for gcs due to --external-io-disable-implicit-credentials flag")
 		}
 		// If implicit credentials used, no client options needed.
 	default:

--- a/pkg/cloud/gcp/gcp_kms_test.go
+++ b/pkg/cloud/gcp/gcp_kms_test.go
@@ -228,6 +228,6 @@ func TestGCSKMSDisallowImplicitCredentials(t *testing.T) {
 		Settings:         gcpKMSTestSettings,
 		ExternalIOConfig: &base.ExternalIODirConfig{DisableImplicitCredentials: true}})
 	require.True(t, testutils.IsError(err,
-		"implicit credentials disallowed for gcs due to --external-io-implicit-credentials flag"),
+		"implicit credentials disallowed for gcs due to --external-io-disable-implicit-credentials flag"),
 	)
 }


### PR DESCRIPTION
When `--external-io-disable-implicit-credentials` is set and the user issues a command with `AUTH=implicit`, the resulting error message has the wrong flag name (`disable` is left out). Searching for that flag name in the docs doesn't return any results. The flag name is corrected in this PR.

Release note: none
Release justification: CLI bug