### PR TITLE
sql: set index recommendations after planning but before execution

### DIFF
--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -1372,17 +1372,6 @@ func (ex *connExecutor) dispatchToExecutionEngine(
 
 	populateQueryLevelStatsAndRegions(ctx, planner, ex.server.cfg, &stats, &ex.cpuStatsCollector)
 
-	// The transaction (from planner.txn) may already have been committed at this point,
-	// due to one-phase commit optimization or an error. Since we use that transaction
-	// on the optimizer, check if is still open before generating index recommendations.
-	if planner.txn.IsOpen() {
-		// Set index recommendations, so it can be saved on statement statistics.
-		// TODO(yuzefovich): figure out whether we want to set isInternalPlanner
-		// to true for the internal executors.
-		isInternal := ex.executorType == executorTypeInternal || planner.isInternalPlanner
-		planner.instrumentation.SetIndexRecommendations(ctx, ex.server.idxRecommendationsCache, planner, isInternal)
-	}
-
 	// Record the statement summary. This also closes the plan if the
 	// plan has not been closed earlier.
 	stmtFingerprintID = ex.recordStatementSummary(
@@ -1680,6 +1669,12 @@ func (ex *connExecutor) makeExecPlan(ctx context.Context, planner *planner) erro
 	if flags.IsSet(planFlagIsDDL) {
 		ex.extraTxnState.numDDL++
 	}
+
+	// Set index recommendations, so it can be saved on statement statistics.
+	// TODO(yuzefovich): figure out whether we want to set isInternalPlanner
+	// to true for the internal executors.
+	isInternal := ex.executorType == executorTypeInternal || planner.isInternalPlanner
+	planner.instrumentation.SetIndexRecommendations(ctx, ex.server.idxRecommendationsCache, planner, isInternal)
 
 	return nil
 }

--- a/pkg/sql/explain_plan.go
+++ b/pkg/sql/explain_plan.go
@@ -139,7 +139,7 @@ func (e *explainPlanNode) startExec(params runParams) error {
 		}
 	}
 	// Add index recommendations to output, if they exist.
-	if recs := params.p.instrumentation.indexRecs; recs != nil {
+	if recs := params.p.instrumentation.explainIndexRecs; recs != nil {
 		// First add empty row.
 		rows = append(rows, "")
 		rows = append(rows, fmt.Sprintf("index recommendations: %d", len(recs)))

--- a/pkg/sql/instrumentation.go
+++ b/pkg/sql/instrumentation.go
@@ -151,10 +151,11 @@ type instrumentationHelper struct {
 	costEstimate float64
 
 	// indexRecs contains index recommendations for the planned statement. It
-	// will only be populated if the statement is an EXPLAIN statement, or if
-	// recommendations are requested for the statement for populating the
-	// statement_statistics table.
+	// will only be populated if recommendations are requested for the statement
+	// for populating the statement_statistics table.
 	indexRecs []indexrec.Rec
+	// explainIndexRecs contains index recommendations for EXPLAIN statements.
+	explainIndexRecs []indexrec.Rec
 
 	// maxFullScanRows is the maximum number of rows scanned by a full scan, as
 	// estimated by the optimizer.
@@ -789,24 +790,29 @@ func (ih *instrumentationHelper) SetIndexRecommendations(
 		stmtType,
 		isInternal,
 	) {
-		opc := &planner.optPlanningCtx
-		opc.reset(ctx)
-		f := opc.optimizer.Factory()
-		evalCtx := opc.p.EvalContext()
-		f.Init(ctx, evalCtx, opc.catalog)
-		f.FoldingControl().AllowStableFolds()
-		bld := optbuilder.New(ctx, &opc.p.semaCtx, evalCtx, opc.catalog, f, opc.p.stmt.AST)
-		err := bld.Build()
-		if err != nil {
-			log.Warningf(ctx, "unable to build memo: %s", err)
+		// If the statement is an EXPLAIN, then we might have already generated
+		// the index recommendations. If so, we can skip generation here.
+		if ih.explainIndexRecs != nil {
+			recommendations = ih.explainIndexRecs
 		} else {
-			err = opc.makeQueryIndexRecommendation(ctx)
+			opc := &planner.optPlanningCtx
+			opc.reset(ctx)
+			f := opc.optimizer.Factory()
+			evalCtx := opc.p.EvalContext()
+			f.Init(ctx, evalCtx, opc.catalog)
+			f.FoldingControl().AllowStableFolds()
+			bld := optbuilder.New(ctx, &opc.p.semaCtx, evalCtx, opc.catalog, f, opc.p.stmt.AST)
+			err := bld.Build()
 			if err != nil {
-				log.Warningf(ctx, "unable to generate index recommendations: %s", err)
+				log.Warningf(ctx, "unable to build memo: %s", err)
+			} else {
+				recommendations, err = opc.makeQueryIndexRecommendation(ctx)
+				if err != nil {
+					log.Warningf(ctx, "unable to generate index recommendations: %s", err)
+				}
 			}
 		}
 		reset = true
-		recommendations = ih.indexRecs
 	}
 	ih.indexRecs = idxRec.UpdateIndexRecommendations(
 		ih.fingerprint,

--- a/pkg/sql/plan_opt.go
+++ b/pkg/sql/plan_opt.go
@@ -578,9 +578,11 @@ func (opc *optPlanningCtx) buildExecMemo(ctx context.Context) (_ *memo.Memo, _ e
 	// find potential index candidates in the memo.
 	_, isExplain := opc.p.stmt.AST.(*tree.Explain)
 	if isExplain && p.SessionData().IndexRecommendationsEnabled {
-		if err := opc.makeQueryIndexRecommendation(ctx); err != nil {
+		indexRecs, err := opc.makeQueryIndexRecommendation(ctx)
+		if err != nil {
 			return nil, err
 		}
+		opc.p.instrumentation.explainIndexRecs = indexRecs
 	}
 
 	if _, isCanned := opc.p.stmt.AST.(*tree.CannedOptPlan); !isCanned {
@@ -721,7 +723,9 @@ func (p *planner) DecodeGist(gist string, external bool) ([]string, error) {
 // indexes hypothetically added to the table. An index recommendation for the
 // query is outputted based on which hypothetical indexes are helpful in the
 // optimal plan.
-func (opc *optPlanningCtx) makeQueryIndexRecommendation(ctx context.Context) (err error) {
+func (opc *optPlanningCtx) makeQueryIndexRecommendation(
+	ctx context.Context,
+) (_ []indexrec.Rec, err error) {
 	defer func() {
 		if r := recover(); r != nil {
 			// This code allows us to propagate internal errors without having to add
@@ -757,7 +761,7 @@ func (opc *optPlanningCtx) makeQueryIndexRecommendation(ctx context.Context) (er
 		return ruleName.IsNormalize()
 	})
 	if _, err = opc.optimizer.Optimize(); err != nil {
-		return err
+		return nil, err
 	}
 
 	// Walk through the fully normalized memo to determine index candidates and
@@ -775,12 +779,13 @@ func (opc *optPlanningCtx) makeQueryIndexRecommendation(ctx context.Context) (er
 	)
 	opc.optimizer.Memo().Metadata().UpdateTableMeta(f.EvalContext(), hypTables)
 	if _, err = opc.optimizer.Optimize(); err != nil {
-		return err
+		return nil, err
 	}
 
-	opc.p.instrumentation.indexRecs, err = indexrec.FindRecs(ctx, f.Memo().RootExpr(), f.Metadata())
+	var indexRecs []indexrec.Rec
+	indexRecs, err = indexrec.FindRecs(ctx, f.Memo().RootExpr(), f.Metadata())
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	// Re-initialize the optimizer (which also re-initializes the factory) and
@@ -794,5 +799,5 @@ func (opc *optPlanningCtx) makeQueryIndexRecommendation(ctx context.Context) (er
 		f.CopyWithoutAssigningPlaceholders,
 	)
 
-	return nil
+	return indexRecs, nil
 }


### PR DESCRIPTION
This commit moves the call to set the index recommendations to be done
right after planning was completed. Previously, it was done after the
execution, but it makes more sense to do it after planning. This also
allows us to remove the check on the txn still being open.

This required clarifying how `instrumentationHelper.indexRecs` is used.
Previously, it was used for two purposes:
- for recording recommendations to be included in the
`statement_statistics` system table
- for showing when executing EXPLAIN statement.

These two usages have somewhat different requirements, so this commit
splits them out into two different slices. This also allows us to reuse
the recommendations from the latter should we choose to generate the
recommendations for the former (previously, this would result in
redundant regeneration of the recommendations).

Epic: None

Release note: None