### PR TITLE
backup: use locality filter to restrict processes to locality

### DIFF
--- a/pkg/ccl/backupccl/backup_test.go
+++ b/pkg/ccl/backupccl/backup_test.go
@@ -277,6 +277,55 @@ func TestBackupRestoreJobTagAndLabel(t *testing.T) {
 	require.True(t, found)
 }
 
+func findSST(t *testing.T, location string) string {
+	sstMatcher := regexp.MustCompile(`\d+\.sst`)
+	subDir := filepath.Join(location, "data")
+	files, err := os.ReadDir(subDir)
+	if err != nil {
+		if oserror.IsNotExist(err) {
+			return ""
+		}
+		t.Fatal(err)
+	}
+	for _, f := range files {
+		if sstMatcher.MatchString(f.Name()) {
+			return f.Name()
+		}
+	}
+	return ""
+}
+
+func requireHasSSTs(t *testing.T, locations ...string) {
+	for _, location := range locations {
+		require.NotEqual(t, "", findSST(t, location))
+	}
+}
+
+func requireHasNoSSTs(t *testing.T, locations ...string) {
+	for _, location := range locations {
+		require.Equal(t, "", findSST(t, location))
+	}
+}
+
+// ensureLeaseholder ensures that each node has at least one leaseholder. These
+// are wrapped with SucceedsSoon() because EXPERIMENTAL_RELOCATE can fail if
+// there are other replication changes happening.
+func ensureLeaseholder(t *testing.T, sqlDB *sqlutils.SQLRunner) {
+	for _, stmt := range []string{
+		`ALTER TABLE data.bank SPLIT AT VALUES (0)`,
+		`ALTER TABLE data.bank SPLIT AT VALUES (100)`,
+		`ALTER TABLE data.bank SPLIT AT VALUES (200)`,
+		`ALTER TABLE data.bank EXPERIMENTAL_RELOCATE VALUES (ARRAY[1], 0)`,
+		`ALTER TABLE data.bank EXPERIMENTAL_RELOCATE VALUES (ARRAY[2], 100)`,
+		`ALTER TABLE data.bank EXPERIMENTAL_RELOCATE VALUES (ARRAY[3], 200)`,
+	} {
+		testutils.SucceedsSoon(t, func() error {
+			_, err := sqlDB.DB.ExecContext(context.Background(), stmt)
+			return err
+		})
+	}
+}
+
 func TestBackupRestorePartitioned(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
@@ -317,53 +366,19 @@ func TestBackupRestorePartitioned(t *testing.T) {
 		},
 	}
 
-	ctx := context.Background()
 	_, sqlDB, dir, cleanupFn := backupRestoreTestSetupWithParams(t, 3 /* nodes */, numAccounts, InitManualReplication, args)
 	defer cleanupFn()
 
-	// locationToDir converts backup URIs based on localFoo to the temporary
+	// dirOf converts backup URIs based on localFoo to the temporary
 	// file it represents on disk.
-	locationToDir := func(location string) string {
+	dirOf := func(location string) string {
 		return strings.Replace(location, localFoo, filepath.Join(dir, "foo"), 1)
-	}
-
-	hasSSTs := func(t *testing.T, location string) bool {
-		sstMatcher := regexp.MustCompile(`\d+\.sst`)
-		subDir := filepath.Join(locationToDir(location), "data")
-		files, err := os.ReadDir(subDir)
-		if err != nil {
-			if oserror.IsNotExist(err) {
-				return false
-			}
-
-			t.Fatal(err)
-		}
-		found := false
-		for _, f := range files {
-			if sstMatcher.MatchString(f.Name()) {
-				found = true
-				break
-			}
-		}
-		return found
-	}
-
-	requireHasSSTs := func(t *testing.T, locations ...string) {
-		for _, location := range locations {
-			require.True(t, hasSSTs(t, location))
-		}
-	}
-
-	requireHasNoSSTs := func(t *testing.T, locations ...string) {
-		for _, location := range locations {
-			require.False(t, hasSSTs(t, location))
-		}
 	}
 
 	requireCompressedManifest := func(t *testing.T, locations ...string) {
 		partitionMatcher := regexp.MustCompile(`^BACKUP_PART_`)
 		for _, location := range locations {
-			subDir := locationToDir(location)
+			subDir := dirOf(location)
 			files, err := os.ReadDir(subDir)
 			if err != nil {
 				t.Fatal(err)
@@ -392,25 +407,6 @@ func TestBackupRestorePartitioned(t *testing.T) {
 		sqlDB.Exec(t, restoreQuery, locationURIArgs...)
 	}
 
-	// Ensure that each node has at least one leaseholder. These are wrapped with
-	// SucceedsSoon() because EXPERIMENTAL_RELOCATE can fail if there are other
-	// replication changes happening.
-	ensureLeaseholder := func(t *testing.T, sqlDB *sqlutils.SQLRunner) {
-		for _, stmt := range []string{
-			`ALTER TABLE data.bank SPLIT AT VALUES (0)`,
-			`ALTER TABLE data.bank SPLIT AT VALUES (100)`,
-			`ALTER TABLE data.bank SPLIT AT VALUES (200)`,
-			`ALTER TABLE data.bank EXPERIMENTAL_RELOCATE VALUES (ARRAY[1], 0)`,
-			`ALTER TABLE data.bank EXPERIMENTAL_RELOCATE VALUES (ARRAY[2], 100)`,
-			`ALTER TABLE data.bank EXPERIMENTAL_RELOCATE VALUES (ARRAY[3], 200)`,
-		} {
-			testutils.SucceedsSoon(t, func() error {
-				_, err := sqlDB.DB.ExecContext(ctx, stmt)
-				return err
-			})
-		}
-	}
-
 	t.Run("partition-by-unique-key", func(t *testing.T) {
 		ensureLeaseholder(t, sqlDB)
 		testSubDir := t.Name()
@@ -429,7 +425,7 @@ func TestBackupRestorePartitioned(t *testing.T) {
 		runBackupRestore(t, sqlDB, backupURIs)
 
 		// Verify that at least one SST exists in each backup destination.
-		requireHasSSTs(t, locations...)
+		requireHasSSTs(t, dirOf(locations[0]), dirOf(locations[1]), dirOf(locations[2]))
 
 		// Verify that all of the partition manifests are compressed.
 		requireCompressedManifest(t, locations...)
@@ -456,8 +452,8 @@ func TestBackupRestorePartitioned(t *testing.T) {
 
 		// All data should be covered by az=az1 or az=az2, so expect all the
 		// data on those locations.
-		requireHasNoSSTs(t, locations[0], locations[1])
-		requireHasSSTs(t, locations[2], locations[3])
+		requireHasNoSSTs(t, dirOf(locations[0]), dirOf(locations[1]))
+		requireHasSSTs(t, dirOf(locations[2]), dirOf(locations[3]))
 	})
 
 	t.Run("partition-by-several-keys", func(t *testing.T) {
@@ -480,6 +476,91 @@ func TestBackupRestorePartitioned(t *testing.T) {
 		locationFmtString, locationURIArgs := uriFmtStringAndArgs(backupURIs, 0)
 		backupQuery := fmt.Sprintf("BACKUP DATABASE data TO %s", locationFmtString)
 		sqlDB.ExpectErr(t, `tier must be in the form "key=value" not "region=east,az=az1"`, backupQuery, locationURIArgs...)
+	})
+}
+
+func TestBackupRestoreExecLocality(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	const numAccounts = 1000
+
+	// Disabled to run within tenant as certain MR features are not available to tenants.
+	args := base.TestClusterArgs{
+		ServerArgsPerNode: map[int]base.TestServerArgs{
+			0: {
+				ExternalIODir:            "/west0",
+				DisableDefaultTestTenant: true,
+				Locality: roachpb.Locality{Tiers: []roachpb.Tier{
+					{Key: "tier", Value: "0"},
+					{Key: "region", Value: "west"},
+				}},
+			},
+			1: {
+				ExternalIODir:            "/west1",
+				DisableDefaultTestTenant: true,
+				Locality: roachpb.Locality{Tiers: []roachpb.Tier{
+					{Key: "tier", Value: "1"},
+					{Key: "region", Value: "west"},
+				}},
+			},
+			2: {
+				ExternalIODir:            "/east0",
+				DisableDefaultTestTenant: true,
+				Locality: roachpb.Locality{Tiers: []roachpb.Tier{
+					{Key: "tier", Value: "0"},
+					{Key: "region", Value: "east"},
+				}},
+			},
+			3: {
+				ExternalIODir:            "/east1",
+				DisableDefaultTestTenant: true,
+				Locality: roachpb.Locality{Tiers: []roachpb.Tier{
+					{Key: "tier", Value: "1"},
+					{Key: "region", Value: "east"},
+				}},
+			},
+		},
+	}
+
+	tc, sqlDB, dir, cleanupFn := backupRestoreTestSetupWithParams(t, 4 /* nodes */, numAccounts, InitManualReplication, args)
+	defer cleanupFn()
+
+	// Job exec relocation will return an error while it waits for resumption on a
+	// matching node, but this makes for a slow test, so just send the job stmt to
+	// the node which will not need to relocate the coordination, i.e. n3 or n4.
+	n3, n4 := sqlutils.MakeSQLRunner(tc.Conns[2]), sqlutils.MakeSQLRunner(tc.Conns[3])
+
+	t.Run("pin-top", func(t *testing.T) {
+		ensureLeaseholder(t, sqlDB)
+		n3.Exec(t, "BACKUP DATABASE data TO $1 WITH EXECUTION LOCALITY = $2",
+			"nodelocal://0/a", "tier=0")
+		// Check that at least one tier 0 node dir has an SST in it.
+		require.True(t, findSST(t, path.Join(dir, "west0", "a")) != "" || findSST(t, path.Join(dir, "east0", "a")) != "")
+		// Check that neither tier 1 node dir has an sst.
+		requireHasNoSSTs(t, path.Join(dir, "west1", "a"), path.Join(dir, "east1", "a"))
+	})
+
+	t.Run("pin-mid", func(t *testing.T) {
+		ensureLeaseholder(t, sqlDB)
+		n4.Exec(t, "BACKUP DATABASE data TO $1 WITH EXECUTION LOCALITY = $2",
+			"nodelocal://0/b", "region=east")
+
+		// Check that at least one east node dir has an SST in it.
+		require.True(t, findSST(t, path.Join(dir, "east0", "b")) != "" || findSST(t, path.Join(dir, "east1", "b")) != "")
+		// Check that neither west node dir has an sst.
+		requireHasNoSSTs(t, path.Join(dir, "west0", "b"), path.Join(dir, "west1", "b"))
+	})
+
+	t.Run("pin-single", func(t *testing.T) {
+		ensureLeaseholder(t, sqlDB)
+		n4.Exec(t, "BACKUP DATABASE data TO $1 WITH EXECUTION LOCALITY = $2",
+			"nodelocal://0/c", "tier=1,region=east")
+
+		// Check that at least the only node allowed has data in it.
+		requireHasSSTs(t, path.Join(dir, "east1", "c"))
+		// Check that no other node has data in it.
+		requireHasNoSSTs(t, path.Join(dir, "east0", "c"), path.Join(dir, "west0", "c"), path.Join(dir, "west1", "c"))
 	})
 }
 

--- a/pkg/ccl/backupccl/utils_test.go
+++ b/pkg/ccl/backupccl/utils_test.go
@@ -83,7 +83,7 @@ func backupRestoreTestSetupWithParams(
 	if len(params.ServerArgsPerNode) > 0 {
 		for i := range params.ServerArgsPerNode {
 			param := params.ServerArgsPerNode[i]
-			param.ExternalIODir = dir
+			param.ExternalIODir = dir + param.ExternalIODir
 			param.UseDatabase = "data"
 			params.ServerArgsPerNode[i] = param
 		}

--- a/pkg/roachpb/metadata.go
+++ b/pkg/roachpb/metadata.go
@@ -595,6 +595,11 @@ func (l Locality) String() string {
 	return strings.Join(tiers, ",")
 }
 
+// Empty returns true if the tiers are empty.
+func (l Locality) Empty() bool {
+	return len(l.Tiers) == 0
+}
+
 // NonEmpty returns true if the tiers are non-empty.
 func (l Locality) NonEmpty() bool {
 	return len(l.Tiers) > 0

--- a/pkg/sql/distsql_physical_planner.go
+++ b/pkg/sql/distsql_physical_planner.go
@@ -791,7 +791,10 @@ const (
 // a single query.
 type PlanningCtx struct {
 	ExtendedEvalCtx *extendedEvalContext
-	spanIter        physicalplan.SpanResolverIterator
+
+	localityFilter roachpb.Locality
+
+	spanIter physicalplan.SpanResolverIterator
 	// nodeStatuses contains info for all SQLInstanceIDs that are referenced by
 	// any PhysicalPlan we generate with this context.
 	nodeStatuses map[base.SQLInstanceID]NodeStatus
@@ -1305,7 +1308,7 @@ func (dsp *DistSQLPlanner) deprecatedPartitionSpansSystem(
 func (dsp *DistSQLPlanner) partitionSpans(
 	ctx context.Context, planCtx *PlanningCtx, spans roachpb.Spans,
 ) (partitions []SpanPartition, _ error) {
-	resolver, instances, err := dsp.makeInstanceResolver(ctx)
+	resolver, instances, err := dsp.makeInstanceResolver(ctx, planCtx.localityFilter)
 	if err != nil {
 		return nil, err
 	}
@@ -1334,8 +1337,10 @@ func (dsp *DistSQLPlanner) partitionSpans(
 			return nil, err
 		}
 	}
-	if err = dsp.maybeReassignToGatewaySQLInstance(partitions, instances); err != nil {
-		return nil, err
+	if planCtx.localityFilter.Empty() {
+		if err = dsp.maybeReassignToGatewaySQLInstance(partitions, instances); err != nil {
+			return nil, err
+		}
 	}
 	return partitions, nil
 }
@@ -1378,9 +1383,11 @@ func instanceIDForKVNodeHostedInstance(nodeID roachpb.NodeID) base.SQLInstanceID
 // If the instance was assigned statically or the instance list had no locality
 // information leading to random assignments then no instance list is returned.
 func (dsp *DistSQLPlanner) makeInstanceResolver(
-	ctx context.Context,
+	ctx context.Context, locFilter roachpb.Locality,
 ) (func(roachpb.NodeID) base.SQLInstanceID, []sqlinstance.InstanceInfo, error) {
-	if _, mixedProcessMode := dsp.distSQLSrv.NodeID.OptionalNodeID(); mixedProcessMode {
+	_, mixedProcessMode := dsp.distSQLSrv.NodeID.OptionalNodeID()
+
+	if mixedProcessMode && locFilter.Empty() {
 		return instanceIDForKVNodeHostedInstance, nil, nil
 	}
 
@@ -1397,15 +1404,35 @@ func (dsp *DistSQLPlanner) makeInstanceResolver(
 	rng, _ := randutil.NewPseudoRand()
 
 	instancesHaveLocality := false
-	for i := range instances {
-		if instances[i].Locality.NonEmpty() {
-			instancesHaveLocality = true
-			break
+
+	var gatewayIsEligible bool
+	if locFilter.NonEmpty() {
+		eligible := make([]sqlinstance.InstanceInfo, 0, len(instances))
+		for i := range instances {
+			if ok, _ := instances[i].Locality.Matches(locFilter); ok {
+				eligible = append(eligible, instances[i])
+				if instances[i].InstanceID == dsp.gatewaySQLInstanceID {
+					gatewayIsEligible = true
+				}
+			}
 		}
+		if len(eligible) == 0 {
+			return nil, nil, errors.New("no healthy sql instances available matching locality requirement")
+		}
+		instances = eligible
+		instancesHaveLocality = true
+	} else {
+		for i := range instances {
+			if instances[i].Locality.NonEmpty() {
+				instancesHaveLocality = true
+				break
+			}
+		}
+		gatewayIsEligible = true
 	}
 
 	// If we were able to determine the locality information for at least some
-	// instances, use the region-aware resolver.
+	// instances, use the locality-aware resolver.
 	if instancesHaveLocality {
 		resolver := func(nodeID roachpb.NodeID) base.SQLInstanceID {
 			// Lookup the node localities to compare to the instance localities.
@@ -1414,13 +1441,32 @@ func (dsp *DistSQLPlanner) makeInstanceResolver(
 				log.Eventf(ctx, "unable to get node descriptor for KV node %s", nodeID)
 				return dsp.gatewaySQLInstanceID
 			}
+
+			// If we're in mixed-mode, check if the picked node already matches the
+			// locality filter in which case we can just use it.
+			if mixedProcessMode {
+				if ok, _ := nodeDesc.Locality.Matches(locFilter); ok {
+					return instanceIDForKVNodeHostedInstance(nodeID)
+				} else {
+					log.VEventf(ctx, 2,
+						"node %d locality %s does not match locality filter %s, finding alternative placement...",
+						nodeID, nodeDesc.Locality, locFilter,
+					)
+				}
+			}
+
 			// TODO(dt): Pre-compute / cache this result, e.g. in the instance reader.
 			if closest := closestInstances(instances, nodeDesc.Locality); len(closest) > 0 {
 				return closest[rng.Intn(len(closest))]
 			}
+
 			// No instances had any locality tiers in common with the node locality so
-			// just return the gateway.
-			return dsp.gatewaySQLInstanceID
+			// just return the gateway if it is eligible. If it isn't, just pick a
+			// random instance from the eligible instances.
+			if gatewayIsEligible {
+				return dsp.gatewaySQLInstanceID
+			}
+			return instances[rng.Intn(len(instances))].InstanceID
 		}
 		return resolver, instances, nil
 	}
@@ -1537,19 +1583,19 @@ func (dsp *DistSQLPlanner) getInstanceIDForScan(
 		return 0, err
 	}
 
-	if dsp.useGossipPlanning(ctx, planCtx) {
+	if dsp.useGossipPlanning(ctx, planCtx) && planCtx.localityFilter.Empty() {
 		return dsp.deprecatedSQLInstanceIDForKVNodeIDSystem(ctx, planCtx, replDesc.NodeID), nil
 	}
-	resolver, _, err := dsp.makeInstanceResolver(ctx)
+	resolver, _, err := dsp.makeInstanceResolver(ctx, planCtx.localityFilter)
 	if err != nil {
 		return 0, err
 	}
 	return resolver(replDesc.NodeID), nil
 }
 
-func (dsp *DistSQLPlanner) useGossipPlanning(ctx context.Context, _ *PlanningCtx) bool {
+func (dsp *DistSQLPlanner) useGossipPlanning(ctx context.Context, planCtx *PlanningCtx) bool {
 	// TODO(dt): enable this by default, e.g. // && !dsp.distSQLSrv.Settings.Version.IsActive(ctx, clusterversion.V23_1)
-	return dsp.codec.ForSystemTenant()
+	return dsp.codec.ForSystemTenant() && planCtx.localityFilter.Empty()
 }
 
 // convertOrdering maps the columns in props.ordering to the output columns of a
@@ -4499,7 +4545,9 @@ func (dsp *DistSQLPlanner) NewPlanningCtx(
 	txn *kv.Txn,
 	distributionType DistributionType,
 ) *PlanningCtx {
-	return dsp.NewPlanningCtxWithOracle(ctx, evalCtx, planner, txn, distributionType, physicalplan.DefaultReplicaChooser)
+	return dsp.NewPlanningCtxWithOracle(
+		ctx, evalCtx, planner, txn, distributionType, physicalplan.DefaultReplicaChooser, roachpb.Locality{},
+	)
 }
 
 // NewPlanningCtxWithOracle is a variant of NewPlanningCtx that allows passing a
@@ -4511,11 +4559,13 @@ func (dsp *DistSQLPlanner) NewPlanningCtxWithOracle(
 	txn *kv.Txn,
 	distributionType DistributionType,
 	oracle replicaoracle.Oracle,
+	localityFiler roachpb.Locality,
 ) *PlanningCtx {
 	distribute := distributionType == DistributionTypeAlways || (distributionType == DistributionTypeSystemTenantOnly && evalCtx.Codec.ForSystemTenant())
 	infra := physicalplan.NewPhysicalInfrastructure(uuid.FastMakeV4(), dsp.gatewaySQLInstanceID)
 	planCtx := &PlanningCtx{
 		ExtendedEvalCtx: evalCtx,
+		localityFilter:  localityFiler,
 		infra:           infra,
 		isLocal:         !distribute,
 		planner:         planner,

--- a/pkg/sql/distsql_physical_planner_test.go
+++ b/pkg/sql/distsql_physical_planner_test.go
@@ -669,6 +669,8 @@ func TestPartitionSpans(t *testing.T) {
 		// the span is actually a point lookup.
 		spans [][2]string
 
+		locFilter string
+
 		// expected result: a map of node to list of spans.
 		partitions map[int][][2]string
 	}{
@@ -789,6 +791,49 @@ func TestPartitionSpans(t *testing.T) {
 				1: {{"A", "B"}},
 			},
 		},
+		// Test some locality-filtered planning too.
+		{
+			ranges:      []testSpanResolverRange{{"A", 1}, {"B", 2}, {"C", 1}, {"D", 3}},
+			gatewayNode: 1,
+
+			spans:     [][2]string{{"A1", "C1"}, {"D1", "X"}},
+			locFilter: "x=1",
+			partitions: map[int][][2]string{
+				1: {{"A1", "B"}, {"C", "C1"}, {"D1", "X"}},
+				2: {{"B", "C"}},
+			},
+		},
+		{
+			ranges:      []testSpanResolverRange{{"A", 1}, {"B", 2}, {"C", 1}, {"D", 3}},
+			gatewayNode: 1,
+
+			spans:     [][2]string{{"A1", "C1"}, {"D1", "X"}},
+			locFilter: "y=0",
+			partitions: map[int][][2]string{
+				2: {{"A1", "C1"}},
+				4: {{"D1", "X"}},
+			},
+		},
+		{
+			ranges:      []testSpanResolverRange{{"A", 1}, {"B", 2}, {"C", 1}, {"D", 3}},
+			gatewayNode: 7,
+
+			spans:     [][2]string{{"A1", "C1"}, {"D1", "X"}},
+			locFilter: "x=3",
+			partitions: map[int][][2]string{
+				7: {{"A1", "C1"}, {"D1", "X"}},
+			},
+		},
+		{
+			ranges:      []testSpanResolverRange{{"A", 1}, {"B", 2}, {"C", 1}, {"D", 3}},
+			gatewayNode: 1,
+
+			spans:     [][2]string{{"A1", "C1"}, {"D1", "X"}},
+			locFilter: "x=3,y=1",
+			partitions: map[int][][2]string{
+				7: {{"A1", "C1"}, {"D1", "X"}},
+			},
+		},
 	}
 
 	// We need a mock Gossip to contain addresses for the nodes. Otherwise the
@@ -797,12 +842,17 @@ func TestPartitionSpans(t *testing.T) {
 	defer testStopper.Stop(context.Background())
 	mockGossip := gossip.NewTest(roachpb.NodeID(1), testStopper, metric.NewRegistry(), zonepb.DefaultZoneConfigRef())
 	var nodeDescs []*roachpb.NodeDescriptor
+	mockInstances := make(mockAddressResolver)
 	for i := 1; i <= 10; i++ {
 		sqlInstanceID := base.SQLInstanceID(i)
+		var l roachpb.Locality
+		require.NoError(t, l.Set(fmt.Sprintf("x=%d,y=%d", (i/3)+1, i%2)))
 		desc := &roachpb.NodeDescriptor{
-			NodeID:  roachpb.NodeID(sqlInstanceID),
-			Address: util.UnresolvedAddr{AddressField: fmt.Sprintf("addr%d", i)},
+			NodeID:   roachpb.NodeID(sqlInstanceID),
+			Address:  util.UnresolvedAddr{AddressField: fmt.Sprintf("addr%d", i)},
+			Locality: l,
 		}
+		mockInstances[sqlInstanceID] = l
 		if err := mockGossip.SetNodeDescriptor(desc); err != nil {
 			t.Fatal(err)
 		}
@@ -830,6 +880,9 @@ func TestPartitionSpans(t *testing.T) {
 				ranges: tc.ranges,
 			}
 
+			nID := &base.NodeIDContainer{}
+			nID.Reset(tsp.nodes[tc.gatewayNode-1].NodeID)
+
 			gw := gossip.MakeOptionalGossip(mockGossip)
 			dsp := DistSQLPlanner{
 				planVersion:          execinfra.Version,
@@ -852,13 +905,20 @@ func TestPartitionSpans(t *testing.T) {
 						return true
 					},
 				},
-				codec: keys.SystemSQLCodec,
+				sqlAddressResolver: mockInstances,
+				distSQLSrv:         &distsql.ServerImpl{ServerConfig: execinfra.ServerConfig{NodeID: base.NewSQLIDContainerForNode(nID)}},
+				codec:              keys.SystemSQLCodec,
+				nodeDescs:          mockGossip,
 			}
 
 			ctx := context.Background()
-			planCtx := dsp.NewPlanningCtx(ctx, &extendedEvalContext{
+			var locFilter roachpb.Locality
+			if tc.locFilter != "" {
+				require.NoError(t, locFilter.Set(tc.locFilter))
+			}
+			planCtx := dsp.NewPlanningCtxWithOracle(ctx, &extendedEvalContext{
 				Context: eval.Context{Codec: keys.SystemSQLCodec},
-			}, nil, nil, DistributionTypeSystemTenantOnly)
+			}, nil, nil, DistributionTypeSystemTenantOnly, physicalplan.DefaultReplicaChooser, locFilter)
 			var spans []roachpb.Span
 			for _, s := range tc.spans {
 				spans = append(spans, roachpb.Span{Key: roachpb.Key(s[0]), EndKey: roachpb.Key(s[1])})
@@ -1390,6 +1450,26 @@ func TestCheckScanParallelizationIfLocal(t *testing.T) {
 		require.Equal(t, tc.prohibitParallelization, prohibitParallelization)
 		require.Equal(t, tc.hasScanNodeToParallelize, hasScanNodeToParallize)
 	}
+}
+
+type mockAddressResolver map[base.SQLInstanceID]roachpb.Locality
+
+var _ sqlinstance.AddressResolver = mockAddressResolver{}
+
+func (m mockAddressResolver) GetInstance(
+	_ context.Context, id base.SQLInstanceID,
+) (sqlinstance.InstanceInfo, error) {
+	return sqlinstance.InstanceInfo{InstanceID: id, Locality: m[id]}, nil
+}
+
+func (m mockAddressResolver) GetAllInstances(
+	_ context.Context,
+) ([]sqlinstance.InstanceInfo, error) {
+	res := make([]sqlinstance.InstanceInfo, 0, len(m))
+	for i := range m {
+		res = append(res, sqlinstance.InstanceInfo{InstanceID: i, Locality: m[i]})
+	}
+	return res, nil
 }
 
 func TestClosestInstances(t *testing.T) {


### PR DESCRIPTION
This extends the previous locality filter option that pinned the backup job to a specific
locality filter to also pin the processors which backup the actual row data as well, allowing
assignment of a backup job to only the instances running in a particular locality.

Those instances will attempt to read from the closest replica they can, however a potential
optimization would be to pick an instace closest to a replica that also matches the locality
filter if there is one -- currently it will likely just pick the instance closest to the
leaseholder which matches the filter, however there may be an instance closer to a usable
replica that is not the leaseholder. To make use of these replicas, a replica oracle that
ranks replicas matching the filter would need to be passed when locality filtering placement
is in-use; this optimization is left to a follow-up.

Release note (sql change): the nodes involved in the execution of backups, including processing of row data and the job coordination, can now be controlled using an execution-locality filter.
Epic: CRDB-9547.


