### PR TITLE
ui: fix inflight request replacement, cleanup database details api

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/sql/highlight.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/sql/highlight.tsx
@@ -39,7 +39,7 @@ export class Highlight extends React.Component<SqlBoxProps> {
 
   renderZone = (): React.ReactElement => {
     const { zone } = this.props;
-    const zoneConfig = zone.zone_config_resp.zone_config;
+    const zoneConfig = zone.zoneConfigResp.zone_config;
     return (
       <span className={cx("sql-highlight", "hljs")}>
         <span className="hljs-keyword">CONFIGURE ZONE USING</span>

--- a/pkg/ui/workspaces/db-console/src/redux/cachedDataReducer.ts
+++ b/pkg/ui/workspaces/db-console/src/redux/cachedDataReducer.ts
@@ -297,14 +297,22 @@ export class CachedDataReducer<
       return this.apiEndpoint(req, this.requestTimeout)
         .then(
           data => {
-            // Dispatch the results to the store.
-            if (this.pendingRequestStarted !== pendingRequestStarted) {
+            // Check if we are replacing requests. If so, do not update the reducer
+            // state if this is not the latest request.
+            if (
+              this.allowReplacementRequests &&
+              this.pendingRequestStarted !== pendingRequestStarted
+            ) {
               return;
             }
+            // Dispatch the results to the store.
             dispatch(this.receiveData(data, req));
           },
           (error: Error) => {
-            if (this.pendingRequestStarted !== pendingRequestStarted) {
+            if (
+              this.allowReplacementRequests &&
+              this.pendingRequestStarted !== pendingRequestStarted
+            ) {
               return;
             }
 
@@ -328,7 +336,10 @@ export class CachedDataReducer<
           },
         )
         .then(() => {
-          if (this.pendingRequestStarted !== pendingRequestStarted) {
+          if (
+            this.allowReplacementRequests &&
+            this.pendingRequestStarted !== pendingRequestStarted
+          ) {
             return;
           }
           // Invalidate data after the invalidation period if one exists.

--- a/pkg/ui/workspaces/db-console/src/util/api.spec.ts
+++ b/pkg/ui/workspaces/db-console/src/util/api.spec.ts
@@ -180,6 +180,7 @@ describe("rest api", function () {
               },
             ],
           },
+          // Database span stats query
           {
             rows: [
               {
@@ -195,24 +196,22 @@ describe("rest api", function () {
 
       return clusterUiApi.getDatabaseDetails(dbName).then(result => {
         expect(fetchMock.calls(clusterUiApi.SQL_API_PATH).length).toBe(1);
-        expect(result.results.id_resp.database_id).toEqual("1");
-        expect(result.results.tables_resp.tables.length).toBe(1);
-        expect(result.results.grants_resp.grants.length).toBe(2);
-        expect(result.results.stats.index_stats.num_index_recommendations).toBe(
+        expect(result.results.idResp.database_id).toEqual("1");
+        expect(result.results.tablesResp.tables.length).toBe(1);
+        expect(result.results.grantsResp.grants.length).toBe(2);
+        expect(result.results.stats.indexStats.num_index_recommendations).toBe(
           1,
         );
-        expect(result.results.zone_config_resp.zone_config).toEqual(
+        expect(result.results.zoneConfigResp.zone_config).toEqual(
           mockZoneConfig,
         );
-        expect(result.results.zone_config_resp.zone_config_level).toBe(
+        expect(result.results.zoneConfigResp.zone_config_level).toBe(
           ZoneConfigurationLevel.DATABASE,
         );
-        expect(result.results.stats.pebble_data.approximate_disk_bytes).toBe(
-          100,
-        );
-        expect(result.results.stats.ranges_data.live_bytes).toBe(200);
-        expect(result.results.stats.ranges_data.total_bytes).toBe(300);
-        expect(result.results.stats.ranges_data.range_count).toBe(400);
+        expect(result.results.stats.spanStats.approximate_disk_bytes).toBe(100);
+        expect(result.results.stats.spanStats.live_bytes).toBe(200);
+        expect(result.results.stats.spanStats.total_bytes).toBe(300);
+        expect(result.results.stats.spanStats.range_count).toBe(400);
       });
     });
 

--- a/pkg/ui/workspaces/db-console/src/views/databases/databaseDetailsPage/redux.ts
+++ b/pkg/ui/workspaces/db-console/src/views/databases/databaseDetailsPage/redux.ts
@@ -130,7 +130,7 @@ export const mapStateToProps = createSelector(
       nodeRegions: nodeRegions,
       isTenant: isTenant,
       tables: _.map(
-        databaseDetails[database]?.data?.results.tables_resp.tables,
+        databaseDetails[database]?.data?.results.tablesResp.tables,
         table => {
           const tableId = generateTableID(database, table);
           const details = tableDetails[tableId];

--- a/pkg/ui/workspaces/db-console/src/views/databases/databasesPage/redux.ts
+++ b/pkg/ui/workspaces/db-console/src/views/databases/databasesPage/redux.ts
@@ -81,16 +81,17 @@ const selectDatabases = createSelector(
     (databases?.databases || []).map(database => {
       const details = databaseDetails[database];
       const stats = details?.data?.results.stats;
-      const sizeInBytes = stats?.pebble_data?.approximate_disk_bytes || 0;
-      const rangeCount = stats?.ranges_data.range_count || 0;
-      const nodes = stats?.ranges_data.node_ids || [];
+      const sizeInBytes = stats?.spanStats?.approximate_disk_bytes || 0;
+      const rangeCount = stats?.spanStats.range_count || 0;
+      // TODO(thomas): Eventually, we should populate this will real node IDs.
+      const nodes = stats?.replicaData.replicas || [];
       const nodesByRegionString = getNodesByRegionString(
         nodes,
         nodeRegions,
         isTenant,
       );
       const numIndexRecommendations =
-        stats?.index_stats.num_index_recommendations || 0;
+        stats?.indexStats.num_index_recommendations || 0;
 
       const combinedErr = combineLoadingErrors(
         details?.lastError,
@@ -104,7 +105,7 @@ const selectDatabases = createSelector(
         lastError: combinedErr,
         name: database,
         sizeInBytes: sizeInBytes,
-        tableCount: details?.data?.results.tables_resp.tables?.length || 0,
+        tableCount: details?.data?.results.tablesResp.tables?.length || 0,
         rangeCount: rangeCount,
         nodes: nodes,
         nodesByRegionString,


### PR DESCRIPTION
Changes to allow in-flight request replacement in this PR: https://github.com/cockroachdb/cockroach/pull/98331 caused breaking changes to `KeyedCachedDataReducer`s. Despite the added `allowReplacementRequests` flag being `false`, in-flight requests would be replaced (specifically, when fetching for initial state). This would prevent all requests but the last one from being stored in the reducer state and leave the remaining requests in a permanent `inFlight` status. Consequently, our pages would break as the permanent `inFlight` status on these requests would prevent us from ever fetching data, putting these pages in a permanent loading state.

This PR adds checks to ensure `allowReplacementRequests` is enabled when we receive a response, before deciding whether to omit it from the reducer state.

It's important to note that this is still not an ideal solution for `KeyedCachedDataReducer`s, should we ever want to replace inflight requests for one. The checks to replace an in-flight request still occur at the reducer-level, whereas in a `KeyedCachedDataReducer` we'd like them to occur at the state-level (i.e. instead of replacement checks for all requests across the reducer, we should check for requests that impact a specific key's state). This way we scope replacements to each key in the reducer, allowing us to fetch data for each key independently (which is the intended functionality). Enabling this for a `KeyedCachedDataReducer` without making this change I believe will cause the breaking behaviour above.

This PR also includes some cleanup to the database details API, namely:
- camel casing response fields
- encapsulating the database span stats response into its own object (instead of across multiple objects), this helps scope any errors deriving from the query to the single stats object

**BEFORE**
https://www.loom.com/share/57c9f278376a4551977398316d6ed7b6

**AFTER**
https://www.loom.com/share/b2d4e074afca4b42a4f711171de3fd72

Release note (bug fix): Fixed replacement of in-flight requests for `KeyedCachedDataReducer`s to prevent permanent loading on requests stuck on an `inFlight` status.