### PR TITLE
kvserver: skip `TestReplicateQueueExpirationLeasesOnly` under deadlock

### DIFF
--- a/pkg/kv/kvserver/replicate_queue_test.go
+++ b/pkg/kv/kvserver/replicate_queue_test.go
@@ -2363,6 +2363,7 @@ func TestReplicateQueueExpirationLeasesOnly(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	skip.UnderRace(t) // too slow under stressrace
+	skip.UnderDeadlock(t)
 	skip.UnderShort(t)
 
 	ctx := context.Background()


### PR DESCRIPTION
I give up.

Resolves #99015.

Epic: none
Release note: None