### PR TITLE
[DNM] serverutils: test with default test tenant on

### DIFF
--- a/pkg/testutils/serverutils/test_server_shim.go
+++ b/pkg/testutils/serverutils/test_server_shim.go
@@ -67,7 +67,7 @@ const (
 // If both the environment variable and the test flag are set, the environment
 // variable wins out.
 func ShouldStartDefaultTestTenant(t testing.TB) bool {
-	var defaultProbabilityOfStartingTestTenant = 0.5
+	var defaultProbabilityOfStartingTestTenant = 1.0 // NOTE(herko): forcing default test tenant for CI
 	if skip.UnderBench() {
 		// Until #83461 is resolved, we want to make sure that we don't use the
 		// multi-tenant setup so that the comparison against old single-tenant


### PR DESCRIPTION
Fixed the probability to test with the default test tenant always on to find flakes.