### PR TITLE
server: avoid some log spam

### DIFF
--- a/pkg/server/BUILD.bazel
+++ b/pkg/server/BUILD.bazel
@@ -159,6 +159,7 @@ go_library(
         "//pkg/security/password",
         "//pkg/security/securityassets",
         "//pkg/security/username",
+        "//pkg/server/autoconfig",
         "//pkg/server/debug",
         "//pkg/server/diagnostics",
         "//pkg/server/diagnostics/diagnosticspb",

--- a/pkg/server/server_sql.go
+++ b/pkg/server/server_sql.go
@@ -52,6 +52,9 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/scheduledjobs"
 	"github.com/cockroachdb/cockroach/pkg/security/clientsecopts"
 	"github.com/cockroachdb/cockroach/pkg/security/username"
+	// Ensure the auto config runner job is registered to avoid log spam.
+	// Pending merge of https://github.com/cockroachdb/cockroach/pull/98466.
+	_ "github.com/cockroachdb/cockroach/pkg/server/autoconfig"
 	"github.com/cockroachdb/cockroach/pkg/server/diagnostics"
 	"github.com/cockroachdb/cockroach/pkg/server/pgurl"
 	"github.com/cockroachdb/cockroach/pkg/server/serverpb"


### PR DESCRIPTION
This change removes the following log spam:
```
could not run claimed job 102: no resumer is available for AUTO CONFIG RUNNER
```

Epic: CRDB-23559
Release note: None