### PR TITLE
rangefeed: de-flake TestUnrecoverableErrors

### DIFF
--- a/pkg/kv/kvclient/kvcoord/dist_sender_mux_rangefeed.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender_mux_rangefeed.go
@@ -362,6 +362,7 @@ func (m *rangefeedMuxer) receiveEventsFromNode(
 			event, err = receiver.Recv()
 			return err
 		}); err != nil {
+			log.Infof(ctx, "XXX stuckwatcher fired: %s", err)
 			return err
 		}
 
@@ -375,8 +376,8 @@ func (m *rangefeedMuxer) receiveEventsFromNode(
 		// which one executes is a coin flip) and so it is possible that we may see
 		// additional event(s) arriving for a stream that is no longer active.
 		if active == nil {
-			if log.V(1) {
-				log.Infof(ctx, "received stray event stream %d: %v", event.StreamID, event)
+			if true || log.V(1) {
+				log.Infof(ctx, "XXX received stray event stream %d: %v", event.StreamID, event)
 			}
 			continue
 		}

--- a/pkg/kv/kvclient/kvcoord/dist_sender_mux_rangefeed.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender_mux_rangefeed.go
@@ -306,6 +306,7 @@ func (m *rangefeedMuxer) startNodeMuxRangeFeed(
 
 	mux, err := client.MuxRangeFeed(ctx)
 	if err != nil {
+		log.Infof(ctx, "XXX client MuxRangeFeed err: %s", err)
 		return future.MustSet(stream, muxStreamOrError{err: err})
 	}
 
@@ -319,6 +320,7 @@ func (m *rangefeedMuxer) startNodeMuxRangeFeed(
 	defer stuckWatcher.stop()
 
 	if recvErr := m.receiveEventsFromNode(ctx, mux, stuckWatcher, &ms); recvErr != nil {
+		log.Infof(ctx, "XXX client MuxRangeFeed recvErr: %s", recvErr)
 		// Clear out this client, and restart all streams on this node.
 		// Note: there is a race here where we may delete this muxClient, while
 		// another go routine loaded it.  That's fine, since we would not
@@ -395,7 +397,7 @@ func (m *rangefeedMuxer) receiveEventsFromNode(
 				active.startAfter.Forward(t.ResolvedTS)
 			}
 		case *kvpb.RangeFeedError:
-			log.VErrEventf(ctx, 2, "RangeFeedError: %s", t.Error.GoError())
+			log.Infof(ctx, "RangeFeedError: %s", t.Error.GoError())
 			if active.catchupRes != nil {
 				m.ds.metrics.RangefeedErrorCatchup.Inc(1)
 			}
@@ -440,7 +442,7 @@ func (m *rangefeedMuxer) receiveEventsFromNode(
 func (m *rangefeedMuxer) restartActiveRangeFeed(
 	ctx context.Context, active *activeMuxRangeFeed, reason error,
 ) error {
-	if log.V(1) {
+	if true || log.V(1) {
 		log.Infof(ctx, "RangeFeed %s@%s disconnected with last checkpoint %s ago: %v",
 			active.Span, active.StartAfter, timeutil.Since(active.Resolved.GoTime()), reason)
 	}

--- a/pkg/kv/kvclient/kvcoord/dist_sender_mux_rangefeed.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender_mux_rangefeed.go
@@ -426,6 +426,7 @@ func (m *rangefeedMuxer) receiveEventsFromNode(
 			if threshold := stuckThreshold(); threshold > 0 {
 				if _, err := ms.eachStream(func(id int64, a *activeMuxRangeFeed) error {
 					if !a.startAfter.IsEmpty() && timeutil.Since(a.startAfter.GoTime()) > stuckThreshold() {
+						log.Infof(ctx, "XXX delete stuck stream")
 						ms.streams.Delete(id)
 						return m.restartActiveRangeFeed(ctx, a, errRestartStuckRange)
 					}

--- a/pkg/kv/kvclient/kvcoord/dist_sender_rangefeed.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender_rangefeed.go
@@ -762,7 +762,7 @@ func (ds *DistSender) singleRangeFeed(
 					args.Timestamp.Forward(t.ResolvedTS)
 				}
 			case *kvpb.RangeFeedError:
-				log.VErrEventf(ctx, 2, "RangeFeedError: %s", t.Error.GoError())
+				log.Infof(ctx, "XXX RangeFeedError: %s", t.Error.GoError())
 				if catchupRes != nil {
 					ds.metrics.RangefeedErrorCatchup.Inc(1)
 				}

--- a/pkg/kv/kvclient/rangefeed/rangefeed.go
+++ b/pkg/kv/kvclient/rangefeed/rangefeed.go
@@ -24,7 +24,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
-	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/ctxgroup"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -267,7 +266,7 @@ func (f *RangeFeed) Close() {
 // will be reset.
 const resetThreshold = 30 * time.Second
 
-var useMuxRangeFeed = util.ConstantWithMetamorphicTestBool("use-mux-rangefeed", false)
+var useMuxRangeFeed = true // util.ConstantWithMetamorphicTestBool("use-mux-rangefeed", false)
 
 // run will run the RangeFeed until the context is canceled or if the client
 // indicates that an initial scan error is non-recoverable.

--- a/pkg/kv/kvclient/rangefeed/rangefeed.go
+++ b/pkg/kv/kvclient/rangefeed/rangefeed.go
@@ -311,6 +311,9 @@ func (f *RangeFeed) run(ctx context.Context, frontier *span.Frontier) {
 		start := timeutil.Now()
 
 		rangeFeedTask := func(ctx context.Context) error {
+			if ts.WallTime == 1 && ts.Logical == 0 {
+				return f.client.RangeFeed(ctx, f.spans, ts, eventCh, rangefeedOpts...)
+			}
 			return f.client.RangeFeed(ctx, f.spans, ts, eventCh, rangefeedOpts...)
 		}
 		processEventsTask := func(ctx context.Context) error {

--- a/pkg/kv/kvclient/rangefeed/rangefeed_external_test.go
+++ b/pkg/kv/kvclient/rangefeed/rangefeed_external_test.go
@@ -907,8 +907,11 @@ func TestUnrecoverableErrors(t *testing.T) {
 		mu.Lock()
 		defer mu.Unlock()
 
+		if mu.internalErr == nil {
+			return errors.New("no error yet")
+		}
 		if !errors.HasType(mu.internalErr, &kvpb.BatchTimestampBeforeGCError{}) {
-			return errors.New("expected internal error")
+			return errors.Wrap(mu.internalErr, "unexpected error")
 		}
 		return nil
 	})

--- a/pkg/kv/kvclient/rangefeed/rangefeed_external_test.go
+++ b/pkg/kv/kvclient/rangefeed/rangefeed_external_test.go
@@ -892,7 +892,9 @@ func TestUnrecoverableErrors(t *testing.T) {
 	})
 
 	r, err := f.RangeFeed(ctx, "test", []roachpb.Span{sp}, preGCThresholdTS,
-		func(context.Context, *kvpb.RangeFeedValue) {},
+		func(_ context.Context, v *kvpb.RangeFeedValue) {
+			t.Logf("rangefeed: %v", v)
+		},
 		rangefeed.WithDiff(true),
 		rangefeed.WithOnInternalError(func(ctx context.Context, err error) {
 			mu.Lock()

--- a/pkg/kv/kvserver/client_raft_test.go
+++ b/pkg/kv/kvserver/client_raft_test.go
@@ -4116,6 +4116,9 @@ func TestTransferRaftLeadership(t *testing.T) {
 
 	// Verify leadership is transferred.
 	testutils.SucceedsSoon(t, func() error {
+		if lease, _ := repl0.GetLease(); lease.Replica.StoreID != 2 {
+			return errors.Errorf("expected leaseholder %d; got %d", 2, lease.Replica.StoreID)
+		}
 		if a, e := repl0.RaftStatus().Lead, uint64(rd1.ReplicaID); a != e {
 			return errors.Errorf("expected raft leader be %d; got %d", e, a)
 		}

--- a/pkg/kv/kvserver/replica.go
+++ b/pkg/kv/kvserver/replica.go
@@ -1785,6 +1785,9 @@ func (r *Replica) checkExecutionCanProceedForRangeFeed(
 	} else if err := r.checkTSAboveGCThresholdRLocked(ts, status, false /* isAdmin */); err != nil {
 		return err
 	}
+	if ts.WallTime == 1 && ts.Logical == 0 {
+		log.Infof(ctx, "XXX RangeFeed passed")
+	}
 	return nil
 }
 
@@ -1805,6 +1808,9 @@ func (r *Replica) checkTSAboveGCThresholdRLocked(
 	ts hlc.Timestamp, st kvserverpb.LeaseStatus, isAdmin bool,
 ) error {
 	threshold := r.getImpliedGCThresholdRLocked(st, isAdmin)
+	if ts.WallTime == 1 && ts.Logical == 0 {
+		log.Infof(context.Background(), "XXX impliedThreshold=%s ts=%s", threshold, ts)
+	}
 	if threshold.Less(ts) {
 		return nil
 	}

--- a/pkg/server/node.go
+++ b/pkg/server/node.go
@@ -1442,6 +1442,7 @@ func (n *Node) RangeFeed(args *kvpb.RangeFeedRequest, stream kvpb.Internal_Range
 	if err := errors.CombineErrors(future.Wait(ctx, n.stores.RangeFeed(args, stream))); err != nil {
 		// Got stream context error, probably won't be able to propagate it to the stream,
 		// but give it a try anyway.
+		log.Infof(ctx, "XXX node rangefeed future error: %s", err)
 		var event kvpb.RangeFeedEvent
 		event.SetValue(&kvpb.RangeFeedError{
 			Error: *kvpb.NewError(err),
@@ -1520,6 +1521,7 @@ func (n *Node) MuxRangeFeed(stream kvpb.Internal_MuxRangeFeedServer) error {
 		f.WhenReady(func(err error) {
 			if err != nil {
 				var event kvpb.RangeFeedEvent
+				log.Infof(context.TODO(), "XXX rangefeed sending error %s", err)
 				event.SetValue(&kvpb.RangeFeedError{
 					Error: *kvpb.NewError(err),
 				})


### PR DESCRIPTION
Closes https://github.com/cockroachdb/cockroach/issues/99096.

```
655857 runs so far, 0 failures, over 12h38m45s
^C
tobias@gceworker-tobias:~/go/src/github.com/cockroachdb/cockroach$ ./dev test --stress ./pkg/kv/kvserver --filter TestUnrecoverableErrors -- --define gotags=bazel,gss,deadlock 2>&1 | tee stress.log
```

on b89fa2cc4bc1fb9447ab1009b34b6f354f9618f0

Epic: none
Release note: None
