### PR TITLE
tracing: allow collection of stack history for Structured spans as well

### DIFF
--- a/pkg/util/tracing/tracer_snapshots.go
+++ b/pkg/util/tracing/tracer_snapshots.go
@@ -309,7 +309,7 @@ func (t *Tracer) runPeriodicSnapshotsLoop(
 // such automatic snapshots are available to be searched and if so at what
 // granularity.
 func (sp *Span) MaybeRecordStackHistory(since time.Time) {
-	if sp == nil || !sp.i.hasVerboseSink() {
+	if sp == nil || sp.RecordingType() == tracingpb.RecordingOff {
 		return
 	}
 

--- a/pkg/util/tracing/tracer_test.go
+++ b/pkg/util/tracing/tracer_test.go
@@ -989,32 +989,48 @@ func TestTracerStackHistory(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	tr := NewTracer()
 
-	sp := tr.StartSpan("test", WithRecording(tracingpb.RecordingVerbose))
-	ch := make(chan struct{})
-	defer close(ch)
-	go func() {
-		for range ch {
-			tr.SaveAutomaticSnapshot()
-			<-ch // read again to unpark func.
+	for _, verbose := range []bool{true, false} {
+		sp := tr.StartSpan("test", WithRecording(tracingpb.RecordingStructured))
+		if verbose {
+			sp = tr.StartSpan("test", WithRecording(tracingpb.RecordingVerbose))
 		}
-	}()
+		ch := make(chan struct{})
+		defer close(ch)
+		go func() {
+			for range ch {
+				tr.SaveAutomaticSnapshot()
+				<-ch // read again to unpark func.
+			}
+		}()
 
-	blockingFunc1(ch)
-	started := timeutil.Now()
-	blockingFunc2(ch)
-	blockingFunc3(ch)
-	blockingCaller(ch)
+		blockingFunc1(ch)
+		started := timeutil.Now()
+		blockingFunc2(ch)
+		blockingFunc3(ch)
+		blockingCaller(ch)
 
-	sp.MaybeRecordStackHistory(started)
+		sp.MaybeRecordStackHistory(started)
 
-	rec := sp.FinishAndGetRecording(tracingpb.RecordingVerbose)[0]
-	require.Len(t, rec.StructuredRecords, 3)
-	require.Len(t, rec.Logs, 3)
-	require.Len(t, rec.StructuredRecords, 3)
-	for i := range rec.Logs {
-		require.NotContains(t, rec.Logs[i].Message, "tracing.blockingFunc1")
+		rec := sp.FinishAndGetConfiguredRecording()[0]
+		require.Len(t, rec.StructuredRecords, 3)
+		stacks := make([]string, 3)
+		for i, rec := range rec.StructuredRecords {
+			var stack tracingpb.CapturedStack
+			require.NoError(t, types.UnmarshalAny(rec.Payload, &stack))
+			stacks[i] = stack.Stack
+		}
+		require.Contains(t, stacks[0], "tracing.blockingFunc2")
+		require.Contains(t, stacks[1], "tracing.blockingFunc3")
+		require.Contains(t, stacks[2], "tracing.blockingCaller")
+
+		if verbose {
+			require.Len(t, rec.Logs, 3)
+			for i := range rec.Logs {
+				require.NotContains(t, rec.Logs[i].Message, "tracing.blockingFunc1")
+			}
+			require.Contains(t, rec.Logs[0].Message, "tracing.blockingFunc2")
+			require.Contains(t, rec.Logs[1].Message, "tracing.blockingFunc3")
+			require.Contains(t, rec.Logs[2].Message, "tracing.blockingCaller")
+		}
 	}
-	require.Contains(t, rec.Logs[0].Message, "tracing.blockingFunc2")
-	require.Contains(t, rec.Logs[1].Message, "tracing.blockingFunc3")
-	require.Contains(t, rec.Logs[2].Message, "tracing.blockingCaller")
 }


### PR DESCRIPTION
Previously, we mandated that the span must be Verbose to be able to collect and emit a Structured event containing stack history. This change permits Structured spans to also collect stack history.

Release note: None
Epic: none