### PR TITLE
ccl/multiregionccl: skip flaky secondary_region test

### DIFF
--- a/pkg/ccl/multiregionccl/datadriven_test.go
+++ b/pkg/ccl/multiregionccl/datadriven_test.go
@@ -121,7 +121,7 @@ func TestMultiRegionDataDriven(t *testing.T) {
 			skip.WithIssue(t, 98020, "flaky test")
 		}
 		if strings.Contains(path, "secondary_region") {
-			skip.UnderStressWithIssue(t, 92235, "flaky test")
+			skip.WithIssue(t, 92235, "flaky test")
 		}
 
 		ds := datadrivenTestState{}


### PR DESCRIPTION
Part of #92235.
Part of #98020.

It [flaked][1] this morning, after last night's [other skip][2] landed.

[1]: https://github.com/cockroachdb/cockroach/issues/98020#issuecomment-1477815272
[2]: https://github.com/cockroachdb/cockroach/pull/99031

Release note: None