### PR TITLE
sql: skip flaky TestSQLStatsDataDriven

### DIFF
--- a/pkg/sql/sqlstats/persistedsqlstats/testdata/logical_plan_sampling_for_explicit_txn
+++ b/pkg/sql/sqlstats/persistedsqlstats/testdata/logical_plan_sampling_for_explicit_txn
@@ -1,3 +1,6 @@
+skip issue-num=89861
+----
+
 # This test checks the expected behavior of logical plan sampling.
 # Given a tuple of (db_name, implicitTxn, fingerprint string), the logical plan
 # is only sampled if and only if no logical plan has been sampled for the given


### PR DESCRIPTION
This commit skips TestSQLStatsDataDriven. This test is flaky.

Part of #89861.

Epic: none

Release note: None