### PR TITLE
kvprober: fortify TestPlannerMakesPlansCoveringAllRanges

### DIFF
--- a/pkg/kv/kvprober/kvprober_integration_test.go
+++ b/pkg/kv/kvprober/kvprober_integration_test.go
@@ -256,7 +256,10 @@ func TestPlannerMakesPlansCoveringAllRanges(t *testing.T) {
 	skip.UnderShort(t)
 
 	ctx := context.Background()
-	_, sqlDB, p, cleanup := initTestProber(t, base.TestingKnobs{})
+	// Disable split and merge queue just in case.
+	_, sqlDB, p, cleanup := initTestProber(t, base.TestingKnobs{
+		Store: &kvserver.StoreTestingKnobs{DisableSplitQueue: true, DisableMergeQueue: true},
+	})
 	defer cleanup()
 
 	rangeIDToTimesWouldBeProbed := make(map[int64]int)
@@ -290,7 +293,7 @@ func TestPlannerMakesPlansCoveringAllRanges(t *testing.T) {
 				}
 			}
 			return true
-		}, time.Second, time.Millisecond)
+		}, testutils.DefaultSucceedsSoonDuration, 20*time.Millisecond)
 	}
 	for i := 0; i < 20; i++ {
 		test(i)


### PR DESCRIPTION
This test flaked a few times a month ago. Investigating it, I found that
it was using a retry loop with a 1s timeout, which was probably too
little in the cases in which it failed. I wasn't able to reproduce the
failure, but I probably would have managed had I cranked up the overload
under stress.

Bump the timeout and also disable splits and merges in this test, just
on the off chance that a range could get merged away and confuse the
test since the test initially pulls a list of RangeIDs it expects the
prober to visit.

> ./dev test --stress --filter TestPlannerMakesPlansCoveringAllRanges  ./pkg/kv/kvprober/
> 3739 runs so far, 0 failures, over 2h23m45s

Closes #96806.

Epic: none
Release note: None
