### PR TITLE
server: fix `DataDistribution` server error when creating a tenant

### DIFF
--- a/pkg/server/admin.go
+++ b/pkg/server/admin.go
@@ -3082,6 +3082,17 @@ func (s *adminServer) dataDistributionHelper(
 			if err != nil {
 				return err
 			}
+
+			// A range descriptor for a secondary tenant may not contain
+			// a table prefix. Often, the start key for a tenant will be just
+			// the tenant prefix itself, e.g. `/Tenant/2`. Once the tenant prefix
+			// is stripped inside `DecodeTablePrefix`, nothing (aka `/Min`) is left.
+			keySansPrefix, _ := keys.MakeSQLCodec(tenID).StripTenantPrefix(rangeDesc.StartKey.AsRawKey())
+			if keys.MinKey.Equal(keySansPrefix) {
+				// There's no table prefix to be decoded.
+				// Try the next descriptor.
+				continue
+			}
 			_, tableID, err := keys.MakeSQLCodec(tenID).DecodeTablePrefix(rangeDesc.StartKey.AsRawKey())
 			if err != nil {
 				return err

--- a/pkg/server/admin_test.go
+++ b/pkg/server/admin_test.go
@@ -2220,6 +2220,9 @@ func TestAdminAPIDataDistribution(t *testing.T) {
 	sqlDB.Exec(t, `CREATE DATABASE "sp'ec\ch""ars"`)
 	sqlDB.Exec(t, `CREATE TABLE "sp'ec\ch""ars"."more\spec'chars" (id INT PRIMARY KEY)`)
 
+	// Make sure secondary tenants don't cause the endpoint to error.
+	sqlDB.Exec(t, "CREATE TENANT 'app'")
+
 	// Verify that we see their replicas in the DataDistribution response, evenly spread
 	// across the test cluster's three nodes.
 


### PR DESCRIPTION
This is a stop-gap commit that enables the DataDistribution endpoint to handle the parts of the key space belonging to secondary tenants without error.

Despite no error, the result returned for secondary tenants is not correct. The DataDistribution endpoint was written before #79700, and therefore doesn't know that multiple tables can exist within a range. 

Additionally, the results for the system tenant will be incorrect soon because #81008 is in progress.
Improvements are tracked by https://github.com/cockroachdb/cockroach/issues/97942

Fixes: #97993
Release note: None