### PR TITLE
multitenant: NewIterator connector infinite retry loop

### DIFF
--- a/pkg/ccl/kvccl/kvtenantccl/connector.go
+++ b/pkg/ccl/kvccl/kvtenantccl/connector.go
@@ -536,9 +536,12 @@ func (c *Connector) NewIterator(
 						curIdx:     0,
 					}, nil
 				}
-				// TODO(arul): We probably don't want to treat all errors here as "soft".
-				// Soft RPC error. Drop client and retry.
 				log.Warningf(ctx, "error consuming GetRangeDescriptors RPC: %v", err)
+				if grpcutil.IsAuthError(err) {
+					// Authentication or authorization error. Propagate.
+					return nil, err
+				}
+				// Soft RPC error. Drop client and retry.
 				c.tryForgetClient(ctx, client)
 				break
 			}


### PR DESCRIPTION
Fixes #98822

This change fixes an infinite retry loop in `Connector.NewIterator` that would occur when the `GetRangeDescriptors` stream returned an auth error. An example trigger would be passing in a span that was outside of the calling tenant's keyspace.

Now `NewIterator` correctly propagates auth errors up to the caller.

Release note: None