### PR TITLE
opt: speed up lookup constraint builder

### DIFF
--- a/pkg/sql/opt/bench/bench_test.go
+++ b/pkg/sql/opt/bench/bench_test.go
@@ -2000,6 +2000,44 @@ var slowSchemas = []string{
 			UNIQUE (col3_10 DESC, col3_3 ASC, col2_1 DESC, col3_9 ASC)
 		);
 	`,
+	`
+		CREATE TABLE multi_col_pk (
+			region STRING NOT NULL,
+			id INT NOT NULL,
+			c1 INT NOT NULL, c2 INT NOT NULL, c3 INT NOT NULL, c4 INT NOT NULL, c5 INT NOT NULL,
+			c6 INT NOT NULL, c7 INT NOT NULL, c8 INT NOT NULL, c9 INT NOT NULL, c10 INT NOT NULL,
+			c11 INT NOT NULL, c12 INT NOT NULL, c13 INT NOT NULL, c14 INT NOT NULL, c15 INT NOT NULL,
+			c16 INT NOT NULL, c17 INT NOT NULL, c18 INT NOT NULL, c19 INT NOT NULL, c20 INT NOT NULL,
+			c21 INT NOT NULL, c22 INT NOT NULL, c23 INT NOT NULL, c24 INT NOT NULL, c25 INT NOT NULL,
+			c26 INT NOT NULL, c27 INT NOT NULL, c28 INT NOT NULL, c29 INT NOT NULL, c30 INT NOT NULL,
+			c31 INT NOT NULL, c32 INT NOT NULL, c33 INT NOT NULL, c34 INT NOT NULL, c35 INT NOT NULL,
+			c36 INT NOT NULL, c37 INT NOT NULL, c38 INT NOT NULL, c39 INT NOT NULL, c40 INT NOT NULL,
+			c41 INT NOT NULL, c42 INT NOT NULL, c43 INT NOT NULL, c44 INT NOT NULL, c45 INT NOT NULL,
+			c46 INT NOT NULL, c47 INT NOT NULL, c48 INT NOT NULL, c49 INT NOT NULL, c50 INT NOT NULL,
+			CHECK (c41 IN (100, 200, 300, 400, 500, 600, 700, 800, 900, 1000, 1100, 1200)),
+			CHECK (c42 IN (100, 200, 300, 400, 500, 600, 700, 800, 900, 1000, 1100, 1200)),
+			CHECK (c43 IN (100, 200, 300, 400, 500, 600, 700, 800, 900, 1000, 1100, 1200)),
+			CHECK (c44 IN (100, 200, 300, 400, 500, 600, 700, 800, 900, 1000, 1100, 1200)),
+			CHECK (c45 IN (100, 200, 300, 400, 500, 600, 700, 800, 900, 1000, 1100, 1200)),
+			CHECK (c46 IN (100, 200, 300, 400, 500, 600, 700, 800, 900, 1000, 1100, 1200)),
+			CHECK (c47 IN (100, 200, 300, 400, 500, 600, 700, 800, 900, 1000, 1100, 1200)),
+			CHECK (c48 IN (100, 200, 300, 400, 500, 600, 700, 800, 900, 1000, 1100, 1200)),
+			CHECK (c49 IN (100, 200, 300, 400, 500, 600, 700, 800, 900, 1000, 1100, 1200)),
+			CHECK (c50 IN (100, 200, 300, 400, 500, 600, 700, 800, 900, 1000, 1100, 1200)),
+			CHECK (region IN ('east', 'west', 'north', 'south')),
+			INDEX (c41, c31),
+			INDEX (c42, c32),
+			INDEX (c43, c33),
+			INDEX (c44, c34),
+			INDEX (c45, c35),
+			INDEX (c46, c36),
+			INDEX (c47, c37),
+			INDEX (c48, c38),
+			INDEX (c49, c39),
+			INDEX (c50, c40),
+			PRIMARY KEY (region, id)
+		);
+	`,
 }
 
 var slowQueries = [...]benchQuery{
@@ -2190,6 +2228,22 @@ var slowQueries = [...]benchQuery{
         tab1.col8 DESC;
     `,
 		args: []interface{}{},
+	},
+	{
+		name: "slow-query-4",
+		query: `
+			SELECT * FROM multi_col_pk t1
+			LEFT JOIN multi_col_pk t2 ON t1.region = t2.region AND t1.id = t2.id
+			LEFT JOIN multi_col_pk t3 ON t1.region = t3.region AND t1.id = t3.id
+			LEFT JOIN multi_col_pk t4 ON t1.region = t4.region AND t1.id = t4.id
+			LEFT JOIN multi_col_pk t5 ON t1.region = t5.region AND t1.id = t5.id
+			LEFT JOIN multi_col_pk t6 ON t1.region = t6.region AND t1.id = t6.id
+			LEFT JOIN multi_col_pk t7 ON t1.region = t7.region AND t1.id = t7.id
+			LEFT JOIN multi_col_pk t8 ON t1.region = t8.region AND t1.id = t8.id
+			LEFT JOIN multi_col_pk t9 ON t1.region = t9.region AND t1.id = t9.id
+			WHERE t1.c1 IN ($1, $2, $3) AND t1.c2 IN ($4, $5, $6) AND t1.c3 IN ($7, $8, $9)
+    `,
+		args: []interface{}{10, 20, 30, 40, 50, 60, 70, 80, 90},
 	},
 }
 

--- a/pkg/sql/opt/constraint/constraint_set.go
+++ b/pkg/sql/opt/constraint/constraint_set.go
@@ -314,26 +314,55 @@ func (s *Set) ExtractValueForConstCol(evalCtx *eval.Context, col opt.ColumnID) t
 	return nil
 }
 
-// HasSingleColumnConstValues returns true if the Set contains a single
-// constraint on a single column which allows for one or more non-ranging
-// constant values. On success, returns the column and the constant value.
-func (s *Set) HasSingleColumnConstValues(
+// HasSingleColumnNonNullConstValues returns the single column constrained by
+// the Set if it is constrained to one or more non-ranging constant values. If
+// any of the constant values are NULL, or the Set does not constrain a single
+// column to one or more non-ranging values, then ok=false is returned.
+func (s *Set) HasSingleColumnNonNullConstValues(evalCtx *eval.Context) (col opt.ColumnID, ok bool) {
+	if s.Length() != 1 {
+		return 0, false
+	}
+	c := s.Constraint(0)
+	if c.Columns.Count() != 1 {
+		return 0, false
+	}
+	for i, n := 0, c.Spans.Count(); i < n; i++ {
+		sp := c.Spans.Get(i)
+		start := sp.StartKey()
+		end := sp.EndKey()
+		if start.Length() < 1 || end.Length() < 1 {
+			return 0, false
+		}
+		startVal := start.Value(0)
+		if startVal == tree.DNull {
+			return 0, false
+		}
+		if startVal.Compare(evalCtx, end.Value(0)) != 0 {
+			return 0, false
+		}
+	}
+	return c.Columns.Get(0).ID(), true
+}
+
+// ExtractSingleColumnNonNullConstValues returns the single column constrained by the
+// Set and a slice of constant values it is constrained to. If any of the
+// constant values are NULL, or the Set does not constrain a single column to
+// one or more non-ranging values, then ok=false is returned.
+func (s *Set) ExtractSingleColumnNonNullConstValues(
 	evalCtx *eval.Context,
 ) (col opt.ColumnID, constValues tree.Datums, ok bool) {
-	if s.Length() != 1 {
+	col, ok = s.HasSingleColumnNonNullConstValues(evalCtx)
+	if !ok {
 		return 0, nil, false
 	}
 	c := s.Constraint(0)
-	if c.Columns.Count() != 1 || c.Prefix(evalCtx) != 1 {
-		return 0, nil, false
-	}
 	numSpans := c.Spans.Count()
 	constValues = make(tree.Datums, numSpans)
 	for i := range constValues {
 		val := c.Spans.Get(i).StartKey().Value(0)
 		constValues[i] = val
 	}
-	return c.Columns.Get(0).ID(), constValues, true
+	return col, constValues, true
 }
 
 // allocConstraint allocates space for a new constraint in the set and returns

--- a/pkg/sql/opt/constraint/constraint_set.go
+++ b/pkg/sql/opt/constraint/constraint_set.go
@@ -314,46 +314,51 @@ func (s *Set) ExtractValueForConstCol(evalCtx *eval.Context, col opt.ColumnID) t
 	return nil
 }
 
-// HasSingleColumnNonNullConstValues returns the single column constrained by
-// the Set if it is constrained to one or more non-ranging constant values. If
-// any of the constant values are NULL, or the Set does not constrain a single
-// column to one or more non-ranging values, then ok=false is returned.
-func (s *Set) HasSingleColumnNonNullConstValues(evalCtx *eval.Context) (col opt.ColumnID, ok bool) {
+// HasSingleColumnNonNullConstValues returns true if all of the following are
+// true:
+//   - The given column is the only constrained column.
+//   - The column is constrained to a set of constant values.
+//   - None of the values are NULL.
+func (s *Set) HasSingleColumnNonNullConstValues(evalCtx *eval.Context, col opt.ColumnID) bool {
 	if s.Length() != 1 {
-		return 0, false
+		return false
 	}
 	c := s.Constraint(0)
 	if c.Columns.Count() != 1 {
-		return 0, false
+		return false
+	}
+	if c.Columns.Get(0).ID() != col {
+		return false
 	}
 	for i, n := 0, c.Spans.Count(); i < n; i++ {
 		sp := c.Spans.Get(i)
 		start := sp.StartKey()
 		end := sp.EndKey()
 		if start.Length() < 1 || end.Length() < 1 {
-			return 0, false
+			return false
 		}
 		startVal := start.Value(0)
 		if startVal == tree.DNull {
-			return 0, false
+			return false
 		}
 		if startVal.Compare(evalCtx, end.Value(0)) != 0 {
-			return 0, false
+			return false
 		}
 	}
-	return c.Columns.Get(0).ID(), true
+	return true
 }
 
-// ExtractSingleColumnNonNullConstValues returns the single column constrained by the
-// Set and a slice of constant values it is constrained to. If any of the
-// constant values are NULL, or the Set does not constrain a single column to
-// one or more non-ranging values, then ok=false is returned.
+// ExtractSingleColumnNonNullConstValues returns the constant values that the
+// given column is constrained to. It returns ok=false if any of the following
+// are not true:
+//   - The given column is the only constrained column.
+//   - The column is constrained to a set of constant values.
+//   - None of the values are NULL.
 func (s *Set) ExtractSingleColumnNonNullConstValues(
-	evalCtx *eval.Context,
-) (col opt.ColumnID, constValues tree.Datums, ok bool) {
-	col, ok = s.HasSingleColumnNonNullConstValues(evalCtx)
-	if !ok {
-		return 0, nil, false
+	evalCtx *eval.Context, col opt.ColumnID,
+) (constValues tree.Datums, ok bool) {
+	if ok := s.HasSingleColumnNonNullConstValues(evalCtx, col); !ok {
+		return nil, false
 	}
 	c := s.Constraint(0)
 	numSpans := c.Spans.Count()
@@ -362,7 +367,7 @@ func (s *Set) ExtractSingleColumnNonNullConstValues(
 		val := c.Spans.Get(i).StartKey().Value(0)
 		constValues[i] = val
 	}
-	return col, constValues, true
+	return constValues, true
 }
 
 // allocConstraint allocates space for a new constraint in the set and returns

--- a/pkg/sql/opt/constraint/constraint_set_test.go
+++ b/pkg/sql/opt/constraint/constraint_set_test.go
@@ -370,18 +370,18 @@ func TestHasSingleColumnNonNullConstValues(t *testing.T) {
 	cases := []testCase{
 		{[]string{`/1: [/10 - /10]`}, 1, true},
 		{[]string{`/-1: [/10 - /10]`}, 1, true},
-		{[]string{`/1: [/10 - /11]`}, 0, false},
+		{[]string{`/1: [/10 - /11]`}, 1, false},
 		{[]string{`/1: [/10 - /10] [/11 - /11]`}, 1, true},
 		{[]string{`/1: [/10 - /10] [/11 - /11] [/12 - /12]`}, 1, true},
-		{[]string{`/1: [/10 - /10] [/11 - /11] [/12 - /13]`}, 0, false},
-		{[]string{`/1: [/NULL - /NULL]`}, 0, false},
-		{[]string{`/1: [/NULL - /NULL] [/10 - /10] [/11 - /11]`}, 0, false},
-		{[]string{`/1/2: [/10/2 - /10/4]`}, 0, false},
-		{[]string{`/1/2: [/10/2 - /10/2]`}, 0, false},
-		{[]string{`/1: [/10 - /10]`, `/2: [/8 - /8]`}, 0, false},
-		{[]string{`/1: [/10 - /10]`, `/2: [/8 - /8]`}, 0, false},
-		{[]string{`/1: [/10 - /10]`, `/1/2: [/10/8 - /10/8]`}, 0, false},
-		{[]string{`/1: [/10 - /10]`, `/1/2: [/10/8 - /10/8]`}, 0, false},
+		{[]string{`/1: [/10 - /10] [/11 - /11] [/12 - /13]`}, 1, false},
+		{[]string{`/1: [/NULL - /NULL]`}, 1, false},
+		{[]string{`/1: [/NULL - /NULL] [/10 - /10] [/11 - /11]`}, 1, false},
+		{[]string{`/1/2: [/10/2 - /10/4]`}, 1, false},
+		{[]string{`/1/2: [/10/2 - /10/2]`}, 2, false},
+		{[]string{`/1: [/10 - /10]`, `/2: [/8 - /8]`}, 1, false},
+		{[]string{`/1: [/10 - /10]`, `/2: [/8 - /8]`}, 2, false},
+		{[]string{`/1: [/10 - /10]`, `/1/2: [/10/8 - /10/8]`}, 1, false},
+		{[]string{`/1: [/10 - /10]`, `/1/2: [/10/8 - /10/8]`}, 2, false},
 	}
 	st := cluster.MakeTestingClusterSettings()
 	evalCtx := eval.NewTestingEvalContext(st)
@@ -391,10 +391,9 @@ func TestHasSingleColumnNonNullConstValues(t *testing.T) {
 			constraint := ParseConstraint(evalCtx, constraint)
 			cs = cs.Intersect(evalCtx, SingleConstraint(&constraint))
 		}
-		col, res := cs.HasSingleColumnNonNullConstValues(evalCtx)
-		if res != tc.expected || col != tc.col {
-			t.Errorf("%s: expected %t,%d got %t,%d", cs, tc.expected, tc.col, res, col)
-
+		res := cs.HasSingleColumnNonNullConstValues(evalCtx, tc.col)
+		if res != tc.expected {
+			t.Errorf("%s: expected %t got %t", cs, tc.expected, res)
 		}
 	}
 }
@@ -439,13 +438,13 @@ func TestExtractSingleColumnNonNullConstValues(t *testing.T) {
 			constraint := ParseConstraint(evalCtx, constraint)
 			cs = cs.Intersect(evalCtx, SingleConstraint(&constraint))
 		}
-		col, vals, _ := cs.ExtractSingleColumnNonNullConstValues(evalCtx)
+		vals, _ := cs.ExtractSingleColumnNonNullConstValues(evalCtx, tc.col)
 		var intVals []int
 		for _, val := range vals {
 			intVals = append(intVals, int(*val.(*tree.DInt)))
 		}
-		if tc.col != col || !reflect.DeepEqual(tc.vals, intVals) {
-			t.Errorf("%s: expected %d,%d got %d,%d", cs, tc.col, tc.vals, col, intVals)
+		if !reflect.DeepEqual(tc.vals, intVals) {
+			t.Errorf("%s: expected %d got %d", cs, tc.vals, intVals)
 		}
 	}
 }

--- a/pkg/sql/opt/constraint/constraint_set_test.go
+++ b/pkg/sql/opt/constraint/constraint_set_test.go
@@ -361,7 +361,45 @@ func TestExtractConstColsForSet(t *testing.T) {
 	}
 }
 
-func TestHasSingleColumnConstValues(t *testing.T) {
+func TestHasSingleColumnNonNullConstValues(t *testing.T) {
+	type testCase struct {
+		constraints []string
+		col         opt.ColumnID
+		expected    bool
+	}
+	cases := []testCase{
+		{[]string{`/1: [/10 - /10]`}, 1, true},
+		{[]string{`/-1: [/10 - /10]`}, 1, true},
+		{[]string{`/1: [/10 - /11]`}, 0, false},
+		{[]string{`/1: [/10 - /10] [/11 - /11]`}, 1, true},
+		{[]string{`/1: [/10 - /10] [/11 - /11] [/12 - /12]`}, 1, true},
+		{[]string{`/1: [/10 - /10] [/11 - /11] [/12 - /13]`}, 0, false},
+		{[]string{`/1: [/NULL - /NULL]`}, 0, false},
+		{[]string{`/1: [/NULL - /NULL] [/10 - /10] [/11 - /11]`}, 0, false},
+		{[]string{`/1/2: [/10/2 - /10/4]`}, 0, false},
+		{[]string{`/1/2: [/10/2 - /10/2]`}, 0, false},
+		{[]string{`/1: [/10 - /10]`, `/2: [/8 - /8]`}, 0, false},
+		{[]string{`/1: [/10 - /10]`, `/2: [/8 - /8]`}, 0, false},
+		{[]string{`/1: [/10 - /10]`, `/1/2: [/10/8 - /10/8]`}, 0, false},
+		{[]string{`/1: [/10 - /10]`, `/1/2: [/10/8 - /10/8]`}, 0, false},
+	}
+	st := cluster.MakeTestingClusterSettings()
+	evalCtx := eval.NewTestingEvalContext(st)
+	for _, tc := range cases {
+		cs := Unconstrained
+		for _, constraint := range tc.constraints {
+			constraint := ParseConstraint(evalCtx, constraint)
+			cs = cs.Intersect(evalCtx, SingleConstraint(&constraint))
+		}
+		col, res := cs.HasSingleColumnNonNullConstValues(evalCtx)
+		if res != tc.expected || col != tc.col {
+			t.Errorf("%s: expected %t,%d got %t,%d", cs, tc.expected, tc.col, res, col)
+
+		}
+	}
+}
+
+func TestExtractSingleColumnNonNullConstValues(t *testing.T) {
 	type testCase struct {
 		constraints []string
 		col         opt.ColumnID
@@ -374,6 +412,8 @@ func TestHasSingleColumnConstValues(t *testing.T) {
 		{[]string{`/1: [/10 - /10] [/11 - /11]`}, 1, []int{10, 11}},
 		{[]string{`/1: [/10 - /10] [/11 - /11] [/12 - /12]`}, 1, []int{10, 11, 12}},
 		{[]string{`/1: [/10 - /10] [/11 - /11] [/12 - /13]`}, 0, nil},
+		{[]string{`/1: [/NULL - /NULL]`}, 0, nil},
+		{[]string{`/1: [/NULL - /NULL] [/10 - /10] [/11 - /11]`}, 0, nil},
 		{[]string{`/1/2: [/10/2 - /10/4]`}, 0, nil},
 		{[]string{`/1/2: [/10/2 - /10/2]`}, 0, nil},
 		{
@@ -399,7 +439,7 @@ func TestHasSingleColumnConstValues(t *testing.T) {
 			constraint := ParseConstraint(evalCtx, constraint)
 			cs = cs.Intersect(evalCtx, SingleConstraint(&constraint))
 		}
-		col, vals, _ := cs.HasSingleColumnConstValues(evalCtx)
+		col, vals, _ := cs.ExtractSingleColumnNonNullConstValues(evalCtx)
 		var intVals []int
 		for _, val := range vals {
 			intVals = append(intVals, int(*val.(*tree.DInt)))

--- a/pkg/sql/opt/lookupjoin/constraint_builder.go
+++ b/pkg/sql/opt/lookupjoin/constraint_builder.go
@@ -179,7 +179,7 @@ func (b *ConstraintBuilder) Build(
 	firstIdxCol := b.table.IndexColumnID(index, 0)
 	if _, ok := rightEq.Find(firstIdxCol); !ok {
 		if _, ok := b.findComputedColJoinEquality(b.table, firstIdxCol, rightEqSet); !ok {
-			if _, _, ok := FindJoinFilterConstants(allFilters, firstIdxCol, b.evalCtx); !ok {
+			if !HasJoinFilterConstants(allFilters, firstIdxCol, b.evalCtx) {
 				if _, ok := rightCmp.Find(firstIdxCol); !ok {
 					return Constraint{}, false
 				}

--- a/pkg/sql/opt/lookupjoin/constraint_builder.go
+++ b/pkg/sql/opt/lookupjoin/constraint_builder.go
@@ -191,7 +191,6 @@ func (b *ConstraintBuilder) Build(
 	// an equality with another column or a constant.
 	numIndexKeyCols := index.LaxKeyColumnCount()
 
-	keyCols := make(opt.ColList, 0, numIndexKeyCols)
 	var derivedEquivCols opt.ColSet
 	// Don't change the selectivity estimate of this join vs. other joins which
 	// don't use derivedFkOnFilters. Add column IDs from these filters to the set
@@ -212,14 +211,16 @@ func (b *ConstraintBuilder) Build(
 		}
 	}
 
-	rightSideCols := make(opt.ColList, 0, numIndexKeyCols)
+	colsAlloc := make(opt.ColList, numIndexKeyCols*2)
+	keyCols := colsAlloc[0:0:numIndexKeyCols]
+	rightSideCols := colsAlloc[numIndexKeyCols : numIndexKeyCols : numIndexKeyCols*2]
 	var inputProjections memo.ProjectionsExpr
 	var lookupExpr memo.FiltersExpr
 	var allLookupFilters memo.FiltersExpr
 	var filterOrdsToExclude intsets.Fast
 	foundLookupCols := false
 	lookupExprRequired := false
-	remainingFilters := make(memo.FiltersExpr, 0, len(onFilters))
+	var remainingFilters memo.FiltersExpr
 
 	// addEqualityColumns adds the given columns as an equality in keyCols if
 	// lookupExprRequired is false. Otherwise, the equality is added as an
@@ -382,6 +383,7 @@ func (b *ConstraintBuilder) Build(
 			allLookupFilters = append(allLookupFilters, allFilters[filterIdx])
 			filterOrdsToExclude.Add(filterIdx)
 			if remaining != nil {
+				remainingFilters = make(memo.FiltersExpr, 0, len(onFilters))
 				remainingFilters = append(remainingFilters, *remaining)
 			}
 		}
@@ -414,6 +416,9 @@ func (b *ConstraintBuilder) Build(
 	// Reduce the remaining filters.
 	for i := range onFilters {
 		if !filterOrdsToExclude.Contains(i) {
+			if remainingFilters == nil {
+				remainingFilters = make(memo.FiltersExpr, 0, len(onFilters))
+			}
 			remainingFilters = append(remainingFilters, onFilters[i])
 		}
 	}

--- a/pkg/sql/opt/lookupjoin/filter.go
+++ b/pkg/sql/opt/lookupjoin/filter.go
@@ -25,8 +25,7 @@ func HasJoinFilterConstants(
 	for filterIdx := range filters {
 		props := filters[filterIdx].ScalarProps()
 		if props.TightConstraints {
-			constCol, ok := props.Constraints.HasSingleColumnNonNullConstValues(evalCtx)
-			if ok && constCol == col {
+			if ok := props.Constraints.HasSingleColumnNonNullConstValues(evalCtx, col); ok {
 				return true
 			}
 		}
@@ -48,8 +47,8 @@ func FindJoinFilterConstants(
 	for filterIdx := range filters {
 		props := filters[filterIdx].ScalarProps()
 		if props.TightConstraints {
-			constCol, constVals, ok := props.Constraints.ExtractSingleColumnNonNullConstValues(evalCtx)
-			if !ok || constCol != col {
+			constVals, ok := props.Constraints.ExtractSingleColumnNonNullConstValues(evalCtx, col)
+			if !ok {
 				continue
 			}
 			if bestValues == nil || len(bestValues) > len(constVals) {

--- a/pkg/sql/opt/xform/join_funcs.go
+++ b/pkg/sql/opt/xform/join_funcs.go
@@ -1404,7 +1404,7 @@ func (c *CustomFuncs) GetLocalityOptimizedLookupJoinExprs(
 	// Check whether the filter constrains the first column of the index
 	// to at least two constant values. We need at least two values so that one
 	// can target a local partition and one can target a remote partition.
-	col, vals, ok := filter.ScalarProps().Constraints.HasSingleColumnConstValues(c.e.evalCtx)
+	col, vals, ok := filter.ScalarProps().Constraints.ExtractSingleColumnNonNullConstValues(c.e.evalCtx)
 	if !ok || len(vals) < 2 {
 		return nil, nil, false
 	}

--- a/pkg/sql/opt/xform/join_funcs.go
+++ b/pkg/sql/opt/xform/join_funcs.go
@@ -1379,7 +1379,8 @@ func (c *CustomFuncs) GetLocalityOptimizedLookupJoinExprs(
 			return nil, nil, false
 		}
 	}
-	tabMeta := c.e.mem.Metadata().TableMeta(private.Table)
+	md := c.e.mem.Metadata()
+	tabMeta := md.TableMeta(private.Table)
 
 	// The PrefixSorter has collected all the prefixes from all the different
 	// partitions (remembering which ones came from local partitions), and has
@@ -1404,7 +1405,9 @@ func (c *CustomFuncs) GetLocalityOptimizedLookupJoinExprs(
 	// Check whether the filter constrains the first column of the index
 	// to at least two constant values. We need at least two values so that one
 	// can target a local partition and one can target a remote partition.
-	col, vals, ok := filter.ScalarProps().Constraints.ExtractSingleColumnNonNullConstValues(c.e.evalCtx)
+	idx := md.Table(private.Table).Index(private.Index)
+	firstCol := private.Table.ColumnID(idx.Column(0).Ordinal())
+	vals, ok := filter.ScalarProps().Constraints.ExtractSingleColumnNonNullConstValues(c.e.evalCtx, firstCol)
 	if !ok || len(vals) < 2 {
 		return nil, nil, false
 	}
@@ -1427,7 +1430,7 @@ func (c *CustomFuncs) GetLocalityOptimizedLookupJoinExprs(
 	c.e.f.DisableOptimizationsTemporarily(func() {
 		// Disable normalization rules when constructing the lookup expression
 		// so that it does not get normalized into a non-canonical expression.
-		localExpr[filterIdx] = c.e.f.ConstructConstFilter(col, localValues)
+		localExpr[filterIdx] = c.e.f.ConstructConstFilter(firstCol, localValues)
 	})
 
 	remoteExpr = make(memo.FiltersExpr, len(private.LookupExpr))
@@ -1435,7 +1438,7 @@ func (c *CustomFuncs) GetLocalityOptimizedLookupJoinExprs(
 	c.e.f.DisableOptimizationsTemporarily(func() {
 		// Disable normalization rules when constructing the lookup expression
 		// so that it does not get normalized into a non-canonical expression.
-		remoteExpr[filterIdx] = c.e.f.ConstructConstFilter(col, remoteValues)
+		remoteExpr[filterIdx] = c.e.f.ConstructConstFilter(firstCol, remoteValues)
 	})
 
 	return localExpr, remoteExpr, true


### PR DESCRIPTION
#### opt: add benchmark with many lookup joins

This commit adds an optimizer benchmark that explores many lookup joins.
It explores many potential lookup joins that do not ultimately get added
to the memo, as well as many lookup joins that do get added to the memo.

Release note: None

#### opt: split HasSingleColumnConstValues into two functions

This commit splits HasSingleColumnConstValues into two functions - one
that returns a boolean if a constraint set constrains a single column to
a set of constant, non-null values, and another function that returns
the constant values. The former is more efficient when the only the
boolean is needed.

Release note: None

#### opt: simplify lookup join constraint builder

This commit reduces computation and allocations when attempting to
build lookup join constraints by performing a simple column ID equality
before more complex computations and allocations.

Release note: None

#### opt: reduce allocations when building lookup join constraints

During the construction of lookup join constraints, two allocations of a
`opt.ColList` have been combined into a single allocation, and
allocation of a `memo.FiltersExpr` to store remaining filters is now
only performed if necessary.

Release note: None

These changes offer a nice speedup for the newly added benchmark:

```
name                         old time/op    new time/op    delta
SlowQueries/slow-query-1-10    15.8ms ± 1%    15.7ms ± 1%     ~     (p=0.690 n=5+5)
SlowQueries/slow-query-2-10     220ms ± 0%     219ms ± 0%     ~     (p=0.095 n=5+5)
SlowQueries/slow-query-3-10    63.0ms ± 1%    62.4ms ± 0%   -0.98%  (p=0.008 n=5+5)
SlowQueries/slow-query-4-10     1.70s ± 1%     1.38s ± 0%  -19.22%  (p=0.008 n=5+5)

name                         old alloc/op   new alloc/op   delta
SlowQueries/slow-query-1-10    7.04MB ± 0%    6.98MB ± 0%   -0.79%  (p=0.008 n=5+5)
SlowQueries/slow-query-2-10    48.7MB ± 0%    48.7MB ± 0%   -0.11%  (p=0.008 n=5+5)
SlowQueries/slow-query-3-10    45.1MB ± 0%    44.9MB ± 0%   -0.55%  (p=0.008 n=5+5)
SlowQueries/slow-query-4-10     878MB ± 0%     737MB ± 0%  -16.03%  (p=0.008 n=5+5)

name                         old allocs/op  new allocs/op  delta
SlowQueries/slow-query-1-10     76.1k ± 0%     75.8k ± 0%   -0.38%  (p=0.008 n=5+5)
SlowQueries/slow-query-2-10      401k ± 0%      400k ± 0%   -0.25%  (p=0.008 n=5+5)
SlowQueries/slow-query-3-10      390k ± 0%      389k ± 0%   -0.21%  (p=0.008 n=5+5)
SlowQueries/slow-query-4-10     18.2M ± 0%     17.4M ± 0%   -4.44%  (p=0.008 n=5+5)
```

Epic: None
