### PR TITLE
sql/logictest: disable stats collection for system tables earlier

### DIFF
--- a/pkg/sql/logictest/logic.go
+++ b/pkg/sql/logictest/logic.go
@@ -1452,6 +1452,14 @@ func (t *logicTest) newCluster(
 	stats.DefaultAsOfTime = 10 * time.Millisecond
 	stats.DefaultRefreshInterval = time.Millisecond
 
+	// Disable stats collection on system tables before the cluster is started,
+	// otherwise there is a race condition where stats may be collected before we
+	// can disable them with `SET CLUSTER SETTING`. We disable stats collection on
+	// system tables in order to have deterministic tests.
+	stats.AutomaticStatisticsOnSystemTables.Override(
+		context.Background(), &params.ServerArgs.TempStorageConfig.Settings.SV, false,
+	)
+
 	t.cluster = serverutils.StartNewTestCluster(t.rootT, cfg.NumNodes, params)
 	if cfg.UseFakeSpanResolver {
 		fakeResolver := physicalplanutils.FakeResolverForTestCluster(t.cluster)
@@ -1637,11 +1645,6 @@ func (t *logicTest) newCluster(
 		// See #37751 for details.
 		if _, err := conn.Exec(
 			"SET CLUSTER SETTING sql.stats.automatic_collection.enabled = false",
-		); err != nil {
-			t.Fatal(err)
-		}
-		if _, err := conn.Exec(
-			"SET CLUSTER SETTING sql.stats.system_tables_autostats.enabled = false",
 		); err != nil {
 			t.Fatal(err)
 		}

--- a/pkg/sql/opt/exec/execbuilder/testdata/explain_analyze
+++ b/pkg/sql/opt/exec/execbuilder/testdata/explain_analyze
@@ -124,18 +124,14 @@ regions: <hidden>
 statement ok
 GRANT SELECT ON crdb_internal.tables TO root;
 
-# For some reason, even though we explicitly disable the automatic stats
-# collection for both user and system tables, rarely we still see that the stats
-# on system.privileges were collected, so we filter out a single line from the
-# output to make the test deterministic.
 query T
-SELECT * FROM [EXPLAIN (VERBOSE) SELECT * FROM system.privileges WHERE path = 'vtable/crdb_internal/tables']
-  WHERE info NOT LIKE '%estimated row count%';
+EXPLAIN (VERBOSE) SELECT * FROM system.privileges WHERE path = 'vtable/crdb_internal/tables'
 ----
 distribution: local
 vectorized: true
 ·
 • scan
   columns: (username, path, privileges, grant_options, user_id)
+  estimated row count: 10 (missing stats)
   table: privileges@privileges_path_user_id_key
   spans: /"vtable/crdb_internal/tables"-/"vtable/crdb_internal/tables"/PrefixEnd


### PR DESCRIPTION
This commit updates the logictests to disable stats collection for system tables before the test cluster is started. This avoids a race condition where stats might be collected on system tables before collection is disabled with `SET CLUSTER SETTING`.

This should prevent flakes for tests that show `EXPLAIN` output for queries over system tables.

Fixes #99118

Release note: None