### PR TITLE
release-23.1: scripts: update branch for bump-pebble script

### DIFF
--- a/scripts/bump-pebble.sh
+++ b/scripts/bump-pebble.sh
@@ -20,7 +20,7 @@ popd() { builtin popd "$@" > /dev/null; }
 # NOTE: After a new release has been cut, update this to the appropriate
 # Cockroach branch name (i.e. release-22.2, etc.), and corresponding Pebble
 # branch name (e.g. crl-release-21.2, etc.).
-BRANCH=master
+BRANCH=release-23.1
 PEBBLE_BRANCH=crl-release-23.1
 
 # The script can only be run from a specific branch.


### PR DESCRIPTION
Point the bump-pebble script at the `release-23.1` branch.

Release note: None.

Epic: None.

Release justification: Updating build infrastructure.