### PR TITLE
release-23.1: roachtest: set 30m timeout for all disk stall roachtests

### DIFF
--- a/pkg/cmd/roachtest/tests/disk_stall.go
+++ b/pkg/cmd/roachtest/tests/disk_stall.go
@@ -51,7 +51,7 @@ func registerDiskStalledDetection(r registry.Registry) {
 			Name:    fmt.Sprintf("disk-stalled/%s", name),
 			Owner:   registry.OwnerStorage,
 			Cluster: r.MakeClusterSpec(4, spec.ReuseNone()),
-			Timeout: 20 * time.Minute,
+			Timeout: 30 * time.Minute,
 			Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 				runDiskStalledDetection(ctx, t, c, makeStaller(t, c), true /* doStall */)
 			},
@@ -77,6 +77,7 @@ func registerDiskStalledDetection(r registry.Registry) {
 				),
 				Owner:   registry.OwnerStorage,
 				Cluster: r.MakeClusterSpec(4, spec.ReuseNone()),
+				Timeout: 30 * time.Minute,
 				Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 					runDiskStalledDetection(ctx, t, c, &fuseDiskStaller{
 						t:         t,


### PR DESCRIPTION
Backport 1/1 commits from #99045.

/cc @cockroachdb/release

---

This commit sets a new 30m timeout for all disk stall roachtests. Previously,
the FUSE filesystem variants had no timeout and inherited the default 10h
timeout. The other variants had a 20m timeout, which has been observed to be
too short due to upreplication latency.

Informs #98904.
Informs #98886.
Epic: None
Release note: None
Release justification: Non-production code changes.
