### PR TITLE
builtins: add builtin functions which cast to OID to the distSQL block list

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/cast
+++ b/pkg/sql/logictest/testdata/logic_test/cast
@@ -1490,3 +1490,59 @@ statement error pq: expected ON UPDATE expression to have type .*, but .* has ty
 CREATE TABLE fail_assn_cast (
   a NUMERIC ON UPDATE '1-2'::INTERVAL
 )
+
+subtest regression_98373
+
+statement ok
+CREATE TABLE IF NOT EXISTS t98373 AS
+        SELECT
+                g::INT2 AS _int2,
+                g::INT4 AS _int4,
+                g::INT8 AS _int8,
+                g::FLOAT8 AS _float8,
+                '2001-01-01'::DATE + g AS _date,
+                '2001-01-01'::TIMESTAMP + g * '1 day'::INTERVAL AS _timestamp
+        FROM
+                generate_series(1, 5) AS g;
+
+query T
+SELECT
+        regproc(_int2::INT8)::REGPROC AS col865
+FROM
+        t98373@[0]
+----
+array_agg
+array_agg
+array_agg
+array_agg
+array_agg
+
+statement OK
+SET vectorize = off
+
+statement OK
+SET distsql = always
+
+# The query plan should be disallowed from executing in a distributed fashion
+# even with distsql = always.
+query T
+EXPLAIN SELECT
+        regproc(_int2::INT8)::REGPROC AS col865
+FROM
+        t98373@[0]
+----
+distribution: local
+vectorized: false
+·
+• render
+│
+└── • scan
+      missing stats
+      table: t98373@t98373_pkey
+      spans: FULL SCAN
+
+statement OK
+RESET vectorize
+
+statement OK
+RESET distsql

--- a/pkg/sql/sem/builtins/pg_builtins.go
+++ b/pkg/sql/sem/builtins/pg_builtins.go
@@ -147,11 +147,13 @@ func init() {
 		if !ok {
 			return
 		}
+		distSQLBlockList := toType.Family() == types.OidFamily
 		if _, ok := castBuiltins[toOID]; !ok {
 			castBuiltins[toOID] = &builtinDefinition{
 				props: tree.FunctionProperties{
-					Category:     builtinconstants.CategoryCast,
-					Undocumented: true,
+					Category:         builtinconstants.CategoryCast,
+					Undocumented:     true,
+					DistsqlBlocklist: distSQLBlockList,
 				},
 			}
 		}


### PR DESCRIPTION
Distributed SQL which executes functions or casts to OID rely on `planner` receiver functions to execute internal SQL to get information about the OID from system tables. If these casts occur on a remote processor, the `planner` is not accessible and a dummy planner is used, which does not implement these receiver functions. To prevent internal errors, these casts or problem functions are added to a distSQL block list by `distSQLExprCheckVisitor`. A cast to an OID can also be done via a builtin function of the same name as the target type, e.g. `regproc`. These builtins do not currently have `DistsqlBlocklist` set, allowing distributed execution.

The solution is to mark `DistsqlBlocklist` as true for any builtin function which casts to an OID type.

Fixes #98373

Release note: None