### PR TITLE
builtins: add hint for hide_sql_constants and redactable_sql_constants

### DIFF
--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -7704,7 +7704,7 @@ expires until the statement bundle is collected`,
 			},
 			types.String,
 			"Removes constants from a SQL statement. String provided must contain at most "+
-				"1 statement.",
+				"1 statement. (Hint: one way to easily quote arbitrary SQL is to use dollar-quotes.)",
 			volatility.Immutable,
 		),
 		tree.Overload{
@@ -7741,7 +7741,8 @@ expires until the statement bundle is collected`,
 				return result, nil
 			},
 			Info: "Hide constants for each element in an array of SQL statements. " +
-				"Note that maximum 1 statement is permitted per string element.",
+				"Note that maximum 1 statement is permitted per string element. (Hint: one way to easily " +
+				"quote arbitrary SQL is to use dollar-quotes.)",
 			Volatility: volatility.Immutable,
 		},
 	),
@@ -7780,7 +7781,8 @@ expires until the statement bundle is collected`,
 			},
 			types.String,
 			"Surrounds constants in SQL statement with redaction markers. String provided must "+
-				"contain at most 1 statement.",
+				"contain at most 1 statement. (Hint: one way to easily quote arbitrary SQL is to use "+
+				"dollar-quotes.)",
 			volatility.Immutable,
 		),
 		tree.Overload{
@@ -7817,7 +7819,8 @@ expires until the statement bundle is collected`,
 				return result, nil
 			},
 			Info: "Surrounds constants with redaction markers for each element in an array of SQL " +
-				"statements. Note that maximum 1 statement is permitted per string element.",
+				"statements. Note that maximum 1 statement is permitted per string element. (Hint: one " +
+				"way to easily quote arbitrary SQL is to use dollar-quotes.)",
 			Volatility: volatility.Immutable,
 		},
 	),


### PR DESCRIPTION
Add a hint about using dollar-quotes to the info message for builtin functions `crdb_internal.hide_sql_constants` and
`crdb_internal.redactable_sql_constants`.

Fixes: #99132

Epic: None

Release note: None