### PR TITLE
multitenant: re-enable TestTenantUpgradeInterlock

### DIFF
--- a/pkg/ccl/kvccl/kvtenantccl/tenant_upgrade_test.go
+++ b/pkg/ccl/kvccl/kvtenantccl/tenant_upgrade_test.go
@@ -403,7 +403,6 @@ func TestTenantUpgradeFailure(t *testing.T) {
 // is too low.
 func TestTenantUpgradeInterlock(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	skip.WithIssue(t, 98987)
 	// Times out under stress race
 	skip.UnderStressRace(t)
 	// Test takes 30s to run


### PR DESCRIPTION
TestTenantUpgradeInterlock was skipped with #99121 because it was timing out regularly. In response to the timeouts however, #98997 was merged to increase the timeout duration for the test (since its run length is proportional to the number of migrations in the release, which has been increasing). Unfortuntely, our wires got crossed and the skip was introduced before the test had a chance to run with the new timeout. #98987 hasn't shown a failure with the new timeout length, so it may be the case that the longer timeout has resolved the problem.

Reenabling the test to see if it has better success under the new timeout length.

Fixes: #98987
Epic: None
Release note: None