### PR TITLE
roachtest: GCE/AWS nightly and release roachtest for FIPS

### DIFF
--- a/build/teamcity/cockroach/nightlies/roachtest_compile_bits.sh
+++ b/build/teamcity/cockroach/nightlies/roachtest_compile_bits.sh
@@ -1,12 +1,13 @@
 #!/usr/bin/env bash
 
 # Builds all bits needed for roachtests, stages them in bin/ and lib.docker_amd64/.
+platform=${1:-crosslinux}
 
-bazel build --config crosslinux --config ci --config with_ui -c opt --config force_build_cdeps \
+bazel build --config $platform --config ci --config with_ui -c opt --config force_build_cdeps \
       //pkg/cmd/cockroach //pkg/cmd/workload //pkg/cmd/roachtest \
       //c-deps:libgeos
-bazel build --config crosslinux --config ci -c opt //pkg/cmd/cockroach-short --crdb_test
-BAZEL_BIN=$(bazel info bazel-bin --config crosslinux --config ci --config with_ui -c opt)
+bazel build --config $platform --config ci -c opt //pkg/cmd/cockroach-short --crdb_test
+BAZEL_BIN=$(bazel info bazel-bin --config $platform --config ci --config with_ui -c opt)
 # Move this stuff to bin for simplicity.
 mkdir -p bin
 chmod o+rwx bin

--- a/build/teamcity/cockroach/nightlies/roachtest_nightly_aws_fips.sh
+++ b/build/teamcity/cockroach/nightlies/roachtest_nightly_aws_fips.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+set -exuo pipefail
+
+dir="$(dirname $(dirname $(dirname $(dirname "${0}"))))"
+
+source "$dir/teamcity-support.sh"  # For $root
+source "$dir/teamcity-bazel-support.sh"  # For run_bazel
+
+BAZEL_SUPPORT_EXTRA_DOCKER_ARGS="-e FIPS_ENABLED=1 -e LITERAL_ARTIFACTS_DIR=$root/artifacts -e AWS_ACCESS_KEY_ID -e AWS_ACCESS_KEY_ID_ASSUME_ROLE -e AWS_KMS_KEY_ARN_A -e AWS_KMS_KEY_ARN_B -e AWS_KMS_REGION_A -e AWS_KMS_REGION_B -e AWS_ROLE_ARN -e AWS_SECRET_ACCESS_KEY -e AWS_SECRET_ACCESS_KEY_ASSUME_ROLE -e BUILD_VCS_NUMBER -e CLOUD -e COCKROACH_DEV_LICENSE -e TESTS -e COUNT -e GITHUB_API_TOKEN -e GITHUB_ORG -e GITHUB_REPO -e GOOGLE_EPHEMERAL_CREDENTIALS -e SLACK_TOKEN -e TC_BUILDTYPE_ID -e TC_BUILD_BRANCH -e TC_BUILD_ID -e TC_SERVER_URL" \
+			       run_bazel build/teamcity/cockroach/nightlies/roachtest_nightly_impl.sh

--- a/build/teamcity/cockroach/nightlies/roachtest_nightly_gce_fips.sh
+++ b/build/teamcity/cockroach/nightlies/roachtest_nightly_gce_fips.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+set -exuo pipefail
+
+dir="$(dirname $(dirname $(dirname $(dirname "${0}"))))"
+
+source "$dir/teamcity-support.sh"  # For $root
+source "$dir/teamcity-bazel-support.sh"  # For run_bazel
+
+BAZEL_SUPPORT_EXTRA_DOCKER_ARGS="-e FIPS_ENABLED=1 -e LITERAL_ARTIFACTS_DIR=$root/artifacts -e BUILD_VCS_NUMBER -e CLOUD -e COCKROACH_DEV_LICENSE -e TESTS -e COUNT -e GITHUB_API_TOKEN -e GITHUB_ORG -e GITHUB_REPO -e GOOGLE_EPHEMERAL_CREDENTIALS -e GOOGLE_KMS_KEY_A -e GOOGLE_KMS_KEY_B -e GOOGLE_CREDENTIALS_ASSUME_ROLE -e GOOGLE_SERVICE_ACCOUNT -e SLACK_TOKEN -e TC_BUILDTYPE_ID -e TC_BUILD_BRANCH -e TC_BUILD_ID -e TC_SERVER_URL" \
+    run_bazel build/teamcity/cockroach/nightlies/roachtest_nightly_impl.sh

--- a/build/teamcity/cockroach/nightlies/roachtest_nightly_impl.sh
+++ b/build/teamcity/cockroach/nightlies/roachtest_nightly_impl.sh
@@ -10,7 +10,15 @@ if [[ ! -f ~/.ssh/id_rsa.pub ]]; then
   ssh-keygen -q -C "roachtest-nightly-bazel $(date)" -N "" -f ~/.ssh/id_rsa
 fi
 
-source $root/build/teamcity/cockroach/nightlies/roachtest_compile_bits.sh
+if [[ ${FIPS_ENABLED:-0} == 1 ]]; then
+  platform=crosslinuxfips
+  fips_flag="--fips"
+else
+  platform=crosslinux
+  fips_flag=""
+fi
+
+source $root/build/teamcity/cockroach/nightlies/roachtest_compile_bits.sh $platform
 
 artifacts=/artifacts
 source $root/build/teamcity/util/roachtest_util.sh
@@ -27,4 +35,5 @@ build/teamcity-roachtest-invoke.sh \
   --artifacts=/artifacts \
   --artifacts-literal="${LITERAL_ARTIFACTS_DIR:-}" \
   --slack-token="${SLACK_TOKEN}" \
+  $fips_flag \
   "${TESTS}"

--- a/build/teamcity/internal/release/process/roachtest-release-qualification_fips.sh
+++ b/build/teamcity/internal/release/process/roachtest-release-qualification_fips.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+FIPS_ENABLED=1 ./build/teamcity/internal/release/process/roachtest-release-qualification.sh

--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -743,6 +743,7 @@ type clusterConfig struct {
 	localCluster bool
 	useIOBarrier bool
 	alloc        *quotapool.IntAlloc
+	enableFIPS   bool
 }
 
 // clusterFactory is a creator of clusters.
@@ -876,7 +877,7 @@ func (f *clusterFactory) newCluster(
 	providerOptsContainer := vm.CreateProviderOptionsContainer()
 	// The ClusterName is set below in the retry loop to ensure
 	// that each create attempt gets a unique cluster name.
-	createVMOpts, providerOpts, err := cfg.spec.RoachprodOpts("", cfg.useIOBarrier)
+	createVMOpts, providerOpts, err := cfg.spec.RoachprodOpts("", cfg.useIOBarrier, cfg.enableFIPS)
 	if err != nil {
 		// We must release the allocation because cluster creation is not possible at this point.
 		cfg.alloc.Release()

--- a/pkg/cmd/roachtest/main.go
+++ b/pkg/cmd/roachtest/main.go
@@ -94,6 +94,7 @@ func main() {
 	var clusterID string
 	var count = 1
 	var versionsBinaryOverride map[string]string
+	var enableFIPS bool
 
 	cobra.EnableCommandSorting = false
 
@@ -244,6 +245,7 @@ runner itself.
 				user:                   username,
 				clusterID:              clusterID,
 				versionsBinaryOverride: versionsBinaryOverride,
+				enableFIPS:             enableFIPS,
 			})
 		},
 	}
@@ -281,6 +283,7 @@ runner itself.
 				user:                   username,
 				clusterID:              clusterID,
 				versionsBinaryOverride: versionsBinaryOverride,
+				enableFIPS:             enableFIPS,
 			})
 		},
 	}
@@ -333,6 +336,8 @@ runner itself.
 				"is present in the list,"+"the respective binary will be used when a "+
 				"multi-version test asks for the respective binary, instead of "+
 				"`roachprod stage <ver>`. Example: 20.1.4=cockroach-20.1,20.2.0=cockroach-20.2.")
+		cmd.Flags().BoolVar(
+			&enableFIPS, "fips", false, "Run tests in enableFIPS mode")
 	}
 
 	parseCreateOpts(runCmd.Flags(), &overrideOpts)
@@ -382,6 +387,7 @@ type cliCfg struct {
 	user                   string
 	clusterID              string
 	versionsBinaryOverride map[string]string
+	enableFIPS             bool
 }
 
 func runTests(register func(registry.Registry), cfg cliCfg) error {
@@ -419,6 +425,7 @@ func runTests(register func(registry.Registry), cfg cliCfg) error {
 		cpuQuota:    cfg.cpuQuota,
 		debugMode:   cfg.debugMode,
 		clusterID:   cfg.clusterID,
+		enableFIPS:  cfg.enableFIPS,
 	}
 	if err := runner.runHTTPServer(cfg.httpPort, os.Stdout, bindTo); err != nil {
 		return err

--- a/pkg/cmd/roachtest/spec/cluster_spec.go
+++ b/pkg/cmd/roachtest/spec/cluster_spec.go
@@ -189,7 +189,7 @@ func getAzureOpts(machineType string, zones []string) vm.ProviderOpts {
 // RoachprodOpts returns the opts to use when calling `roachprod.Create()`
 // in order to create the cluster described in the spec.
 func (s *ClusterSpec) RoachprodOpts(
-	clusterName string, useIOBarrier bool,
+	clusterName string, useIOBarrier bool, enableFIPS bool,
 ) (vm.CreateOpts, vm.ProviderOpts, error) {
 
 	createVMOpts := vm.DefaultCreateOpts()
@@ -220,6 +220,7 @@ func (s *ClusterSpec) RoachprodOpts(
 	}
 
 	createVMOpts.GeoDistributed = s.Geo
+	createVMOpts.EnableFIPS = enableFIPS
 	machineType := s.InstanceType
 	ssdCount := s.SSDs
 	if s.CPUs != 0 {
@@ -275,6 +276,11 @@ func (s *ClusterSpec) RoachprodOpts(
 		}
 	}
 
+	if createVMOpts.EnableFIPS && !(s.Cloud == GCE || s.Cloud == AWS) {
+		return vm.CreateOpts{}, nil, errors.Errorf(
+			"node creation with enableFIPS enabled not yet supported on %s", s.Cloud,
+		)
+	}
 	var providerOpts vm.ProviderOpts
 	switch s.Cloud {
 	case AWS:

--- a/pkg/cmd/roachtest/test_runner.go
+++ b/pkg/cmd/roachtest/test_runner.go
@@ -161,7 +161,8 @@ type clustersOpt struct {
 	cpuQuota int
 
 	// Controls whether the cluster is cleaned up at the end of the test.
-	debugMode debugMode
+	debugMode  debugMode
+	enableFIPS bool
 }
 
 type debugMode int
@@ -437,6 +438,7 @@ func defaultClusterAllocator(
 			username:     clustersOpt.user,
 			localCluster: clustersOpt.typ == localCluster,
 			alloc:        alloc,
+			enableFIPS:   clustersOpt.enableFIPS,
 		}
 		return clusterFactory.newCluster(ctx, cfg, wStatus.SetStatus, lopt.tee)
 	}

--- a/pkg/roachprod/vm/aws/aws.go
+++ b/pkg/roachprod/vm/aws/aws.go
@@ -1002,7 +1002,7 @@ func (p *Provider) runInstance(
 			extraMountOpts = "nobarrier"
 		}
 	}
-	filename, err := writeStartupScript(name, extraMountOpts, providerOpts.UseMultipleDisks)
+	filename, err := writeStartupScript(name, extraMountOpts, providerOpts.UseMultipleDisks, opts.EnableFIPS)
 	if err != nil {
 		return errors.Wrapf(err, "could not write AWS startup script to temp file")
 	}
@@ -1017,12 +1017,16 @@ func (p *Provider) runInstance(
 		return *fl
 	}
 
+	imageID := withFlagOverride(az.region.AMI, &providerOpts.ImageAMI)
+	if opts.EnableFIPS {
+		imageID = withFlagOverride(az.region.AMI_FIPS, &providerOpts.ImageAMI)
+	}
 	args := []string{
 		"ec2", "run-instances",
 		"--associate-public-ip-address",
 		"--count", "1",
 		"--instance-type", machineType,
-		"--image-id", withFlagOverride(az.region.AMI, &providerOpts.ImageAMI),
+		"--image-id", imageID,
 		"--key-name", keyName,
 		"--region", az.region.Name,
 		"--security-group-ids", az.region.SecurityGroup,

--- a/pkg/roachprod/vm/aws/config.go
+++ b/pkg/roachprod/vm/aws/config.go
@@ -68,6 +68,7 @@ type awsRegion struct {
 	Name              string            `json:"region"`
 	SecurityGroup     string            `json:"security_group"`
 	AMI               string            `json:"ami_id"`
+	AMI_FIPS          string            `json:"ami_id_fips"`
 	AvailabilityZones availabilityZones `json:"subnets"`
 }
 

--- a/pkg/roachprod/vm/aws/config.json
+++ b/pkg/roachprod/vm/aws/config.json
@@ -5,6 +5,7 @@
         "value": [
             {
                 "ami_id": "ami-09ff2b6ef00accc2e",
+                "ami_id_fips": "ami-09bfd307c31e4669c",
                 "region": "ap-northeast-1",
                 "security_group": "sg-0006e480d77a10104",
                 "subnets": {
@@ -15,6 +16,7 @@
             },
             {
                 "ami_id": "ami-0b329fb1f17558744",
+                "ami_id_fips": "ami-0dd93e9ad24d01f62",
                 "region": "ap-northeast-2",
                 "security_group": "sg-0e00c2f8f274a0fea",
                 "subnets": {
@@ -26,6 +28,7 @@
             },
             {
                 "ami_id": "ami-01957c76cce45de38",
+                "ami_id_fips": "ami-04ea778eedaf3a8df",
                 "region": "ap-south-1",
                 "security_group": "sg-03a68bb0d765c135e",
                 "subnets": {
@@ -36,6 +39,7 @@
             },
             {
                 "ami_id": "ami-048b4b1ddefe6759f",
+                "ami_id_fips": "ami-0145aa2d8188220bc",
                 "region": "ap-southeast-1",
                 "security_group": "sg-089484fc595751cf7",
                 "subnets": {
@@ -46,6 +50,7 @@
             },
             {
                 "ami_id": "ami-052a251c7ca533c26",
+                "ami_id_fips": "ami-066f9bd76e75011be",
                 "region": "ap-southeast-2",
                 "security_group": "sg-00bbe741d9d00fd3a",
                 "subnets": {
@@ -56,6 +61,7 @@
             },
             {
                 "ami_id": "ami-095509bf36d02a8e0",
+                "ami_id_fips": "ami-0713fd833b63915e3",
                 "region": "ca-central-1",
                 "security_group": "sg-0d97f7ec3edc8f7c1",
                 "subnets": {
@@ -66,6 +72,7 @@
             },
             {
                 "ami_id": "ami-0d3905203a039e3b0",
+                "ami_id_fips": "ami-02cc4114e1c012f9c",
                 "region": "eu-central-1",
                 "security_group": "sg-05979c18ed21a6757",
                 "subnets": {
@@ -76,6 +83,7 @@
             },
             {
                 "ami_id": "ami-0b7fd7bc9c6fb1c78",
+                "ami_id_fips": "ami-014603057f9da7d50",
                 "region": "eu-west-1",
                 "security_group": "sg-033eb468bf7e3c6b5",
                 "subnets": {
@@ -86,6 +94,7 @@
             },
             {
                 "ami_id": "ami-02ead6ecbd926d792",
+                "ami_id_fips": "ami-0fcf0f89559d79e80",
                 "region": "eu-west-2",
                 "security_group": "sg-0cb561f660955a29c",
                 "subnets": {
@@ -96,6 +105,7 @@
             },
             {
                 "ami_id": "ami-0d7b738ade930e24a",
+                "ami_id_fips": "ami-03ecf0588cc1bd0f4",
                 "region": "eu-west-3",
                 "security_group": "sg-032bca7008934e2ce",
                 "subnets": {
@@ -106,6 +116,7 @@
             },
             {
                 "ami_id": "ami-03f2389c2526e67bd",
+                "ami_id_fips": "ami-0977da93caf83799e",
                 "region": "sa-east-1",
                 "security_group": "sg-0e7fdf92c3b1dbd11",
                 "subnets": {
@@ -116,6 +127,7 @@
             },
             {
                 "ami_id": "ami-04cc2b0ad9e30a9c8",
+                "ami_id_fips": "ami-03cf7ddd346310b5f",
                 "region": "us-east-1",
                 "security_group": "sg-09730a5bc7432abe7",
                 "subnets": {
@@ -129,6 +141,7 @@
             },
             {
                 "ami_id": "ami-02fc6052104add5ae",
+                "ami_id_fips": "ami-08692707dfc6f8b64",
                 "region": "us-east-2",
                 "security_group": "sg-0319fc9c9599a6145",
                 "subnets": {
@@ -139,6 +152,7 @@
             },
             {
                 "ami_id": "ami-07be40433001d2433",
+                "ami_id_fips": "ami-026c3cf51388880d6",
                 "region": "us-west-1",
                 "security_group": "sg-0d1ae4a3dc5d6040e",
                 "subnets": {
@@ -148,6 +162,7 @@
             },
             {
                 "ami_id": "ami-0a62a78cfedc09d76",
+                "ami_id_fips": "ami-0dc12dcaaa9dcf99d",
                 "region": "us-west-2",
                 "security_group": "sg-067af4f878a9f27e3",
                 "subnets": {

--- a/pkg/roachprod/vm/aws/support.go
+++ b/pkg/roachprod/vm/aws/support.go
@@ -153,6 +153,10 @@ sysctl --system  # reload sysctl settings
 # validation logic that relies on this -- see comment on cluster_synced.go
 sudo hostnamectl set-hostname {{.VMName}}
 
+{{ if .EnableFIPS }}
+sudo ua enable fips --assume-yes
+{{ end }}
+
 sudo touch /mnt/data1/.roachprod-initialized
 `
 
@@ -162,15 +166,21 @@ sudo touch /mnt/data1/.roachprod-initialized
 //
 // extraMountOpts, if not empty, is appended to the default mount options. It is
 // a comma-separated list of options for the "mount -o" flag.
-func writeStartupScript(name string, extraMountOpts string, useMultiple bool) (string, error) {
+func writeStartupScript(
+	name string, extraMountOpts string, useMultiple bool, enableFips bool,
+) (string, error) {
 	type tmplParams struct {
 		VMName           string
 		ExtraMountOpts   string
 		UseMultipleDisks bool
+		EnableFIPS       bool
 	}
 
 	args := tmplParams{
-		VMName: name, ExtraMountOpts: extraMountOpts, UseMultipleDisks: useMultiple,
+		VMName:           name,
+		ExtraMountOpts:   extraMountOpts,
+		UseMultipleDisks: useMultiple,
+		EnableFIPS:       enableFips,
 	}
 
 	tmpfile, err := os.CreateTemp("", "aws-startup-script")

--- a/pkg/roachprod/vm/aws/terraform/aws-region/ami.tf
+++ b/pkg/roachprod/vm/aws/terraform/aws-region/ami.tf
@@ -5,3 +5,10 @@ data "aws_ami" "node_ami" {
     values = ["${var.image_name}"]
   }
 }
+
+data "aws_ami" "node_ami_fips" {
+  filter {
+    name   = "name"
+    values = ["${var.image_name_fips}"]
+  }
+}

--- a/pkg/roachprod/vm/aws/terraform/aws-region/main.tf
+++ b/pkg/roachprod/vm/aws/terraform/aws-region/main.tf
@@ -7,14 +7,19 @@ provider "aws" {}
 # ---------------------------------------------------------------------------------------------------------------------
 # Module variables
 # ---------------------------------------------------------------------------------------------------------------------
-variable "region"                 { description = "AWS Region name" }
-variable "image_name"             { 
-    description = "CockroachDB base image name" 
-    default = "ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210325"
+variable "region" { description = "AWS Region name" }
+variable "image_name" {
+  description = "CockroachDB base image name"
+  default     = "ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210325"
+}
+
+variable "image_name_fips" {
+  description = "CockroachDB base image name"
+  default     = "ubuntu-pro-fips-server/images/hvm-ssd/ubuntu-focal-20.04-amd64-pro-fips-server-20221121-7bc828d1-c072-4d33-a989-fbad50380cfb"
 }
 
 variable "label" {
-    description = "Used as the resource name prefix."
+  description = "Used as the resource name prefix."
 }
 
 # ---------------------------------------------------------------------------------------------------------------------
@@ -37,9 +42,10 @@ output "region_info" {
     "region"         = "${var.region}"
     "security_group" = "${aws_security_group.region_security_group.id}"
     "ami_id"         = "${data.aws_ami.node_ami.image_id}"
-    "subnets"        = "${zipmap(
-        "${aws_subnet.region_subnets.*.availability_zone}", 
-        "${aws_subnet.region_subnets.*.id}"
+    "ami_id_fips"    = "${data.aws_ami.node_ami_fips.image_id}"
+    "subnets" = "${zipmap(
+      "${aws_subnet.region_subnets.*.availability_zone}",
+      "${aws_subnet.region_subnets.*.id}"
     )}"
   }
 }

--- a/pkg/roachprod/vm/gce/utils.go
+++ b/pkg/roachprod/vm/gce/utils.go
@@ -220,6 +220,10 @@ echo "kernel.core_pattern=$CORE_PATTERN" >> /etc/sysctl.conf
 
 sysctl --system  # reload sysctl settings
 
+{{ if .EnableFIPS }}
+sudo ua enable fips --assume-yes
+{{ end }}
+
 sudo touch /mnt/data1/.roachprod-initialized
 `
 
@@ -230,18 +234,20 @@ sudo touch /mnt/data1/.roachprod-initialized
 // extraMountOpts, if not empty, is appended to the default mount options. It is
 // a comma-separated list of options for the "mount -o" flag.
 func writeStartupScript(
-	extraMountOpts string, fileSystem string, useMultiple bool,
+	extraMountOpts string, fileSystem string, useMultiple bool, enableFIPS bool,
 ) (string, error) {
 	type tmplParams struct {
 		ExtraMountOpts   string
 		UseMultipleDisks bool
 		Zfs              bool
+		EnableFIPS       bool
 	}
 
 	args := tmplParams{
 		ExtraMountOpts:   extraMountOpts,
 		UseMultipleDisks: useMultiple,
 		Zfs:              fileSystem == vm.Zfs,
+		EnableFIPS:       enableFIPS,
 	}
 
 	tmpfile, err := os.CreateTemp("", "gce-startup-script")

--- a/pkg/roachprod/vm/vm.go
+++ b/pkg/roachprod/vm/vm.go
@@ -188,6 +188,7 @@ type CreateOpts struct {
 	CustomLabels map[string]string
 
 	GeoDistributed bool
+	EnableFIPS     bool
 	VMProviders    []string
 	SSDOpts        struct {
 		UseLocalSSD bool


### PR DESCRIPTION
Previously, roachtest nightly tests were limited to run on regular VMs. In order to check FIPS functionality, we need to run the tests on FIPS-enabled VMs.

This PR adds a flag in order to select FIPS-enabled GCE or AWS VMs.

* Added `--fips` flag.
* Added wrapper scripts to selectively run FIPS-enabled tests.
* Updated the AWS configs to have an alternative AMIs for FIPS.

Epic: DEVINF-478
Release note: None