### PR TITLE
appstats: fix percentile greater than max latency

### DIFF
--- a/pkg/sql/appstatspb/app_stats.go
+++ b/pkg/sql/appstatspb/app_stats.go
@@ -253,4 +253,24 @@ func (s *LatencyInfo) Add(other LatencyInfo) {
 	if other.Max > s.Max {
 		s.Max = other.Max
 	}
+	s.checkPercentiles()
+}
+
+// checkPercentiles is a patchy solution and not ideal.
+// When the execution count for a period is smaller than 500,
+// the percentiles sample is including previous aggregation periods,
+// making the p99 possible be greater than the max.
+// For now, we just do a check and update the percentiles to the max
+// possible size.
+// TODO(maryliag): use a proper sample size (#99070)
+func (s *LatencyInfo) checkPercentiles() {
+	if s.P99 > s.Max {
+		s.P99 = s.Max
+	}
+	if s.P90 > s.Max {
+		s.P90 = s.Max
+	}
+	if s.P50 > s.Max {
+		s.P50 = s.Max
+	}
 }


### PR DESCRIPTION
Part Of #99070
When an execution happens, its latency is added to a stream and then ordered so percentiles can be queried.
When getting the percentile values, we don't have the timestamp of when each value was added, meaning when we query the stream we could be getting values from a previous aggregation timestamp, if the current windows has very few executions (the stream has a limit, so we only have the most recent execution, but if the statement is not run frequently this stream can have old data).

The way this information is stored will need to be changed, but for now a patchy solution was added so we don't have the case where we show percentiles greater than the actual max.

Release note (bug fix): Add a check so percentiles are never greater than the max latency value.