### PR TITLE
multitenant: add tenant end key split to MetadataSchema

### DIFF
--- a/pkg/keys/sql.go
+++ b/pkg/keys/sql.go
@@ -121,7 +121,7 @@ func (e sqlEncoder) TenantPrefix() roachpb.Key {
 	return *e.buf
 }
 
-// TenantPrefix returns the key prefix used for the tenants's data.
+// TenantSpan returns a span representing the tenant's keyspace.
 func (e sqlEncoder) TenantSpan() roachpb.Span {
 	key := *e.buf
 	return roachpb.Span{Key: key, EndKey: key.PrefixEnd()}

--- a/pkg/multitenant/mtinfopb/info.go
+++ b/pkg/multitenant/mtinfopb/info.go
@@ -96,7 +96,7 @@ var TenantDataStateValues = map[string]TenantDataState{
 
 // TenantInfo captures both a ProtoInfo and the SQLInfo columns that
 // go alongside it, sufficient to represent an entire row in
-// system.tenans.
+// system.tenants.
 type TenantInfo struct {
 	ProtoInfo
 	SQLInfo

--- a/pkg/server/BUILD.bazel
+++ b/pkg/server/BUILD.bazel
@@ -260,7 +260,6 @@ go_library(
         "//pkg/storage",
         "//pkg/storage/enginepb",
         "//pkg/storage/fs",
-        "//pkg/testutils",
         "//pkg/testutils/serverutils",
         "//pkg/testutils/skip",
         "//pkg/ts",

--- a/pkg/sql/logictest/logic.go
+++ b/pkg/sql/logictest/logic.go
@@ -1466,9 +1466,6 @@ func (t *logicTest) newCluster(
 			if err != nil {
 				t.rootT.Fatalf("%+v", err)
 			}
-			if err := tenant.WaitForTenantEndKeySplit(context.Background()); err != nil {
-				t.rootT.Fatalf("%+v", err)
-			}
 			t.tenantAddrs[i] = tenant.SQLAddr()
 		}
 

--- a/pkg/sql/tests/testdata/initial_keys
+++ b/pkg/sql/tests/testdata/initial_keys
@@ -275,8 +275,9 @@ initial-keys tenant=5
  /Tenant/5/NamespaceTable/30/1/1/29/"web_sessions"/4/1
  /Tenant/5/NamespaceTable/30/1/1/29/"zones"/4/1
  /Tenant/5/Table/48/1/0/0
-1 splits:
+2 splits:
  /Tenant/5
+ /Tenant/6
 
 initial-keys tenant=999
 ----
@@ -377,5 +378,6 @@ initial-keys tenant=999
  /Tenant/999/NamespaceTable/30/1/1/29/"web_sessions"/4/1
  /Tenant/999/NamespaceTable/30/1/1/29/"zones"/4/1
  /Tenant/999/Table/48/1/0/0
-1 splits:
+2 splits:
  /Tenant/999
+ /Tenant/1000

--- a/pkg/testutils/serverutils/test_tenant_shim.go
+++ b/pkg/testutils/serverutils/test_tenant_shim.go
@@ -185,14 +185,6 @@ type TestTenantInterface interface {
 	// Tracer returns a reference to the tenant's Tracer.
 	Tracer() *tracing.Tracer
 
-	// WaitForTenantEndKeySplit blocks until the tenant's initial range is split
-	// at the end key. For example, this will wait until tenant 10 has a split at
-	// /Tenant/11.
-	//
-	// Tests that use crdb_internal.ranges, crdb_internal.ranges_no_leases, or
-	// SHOW RANGES from a secondary tenant should call this to avoid races.
-	WaitForTenantEndKeySplit(ctx context.Context) error
-
 	// MigrationServer returns the tenant's migration server, which is used in
 	// upgrade testing.
 	MigrationServer() interface{}


### PR DESCRIPTION
Fixes #97985

Previously #95100 created tenant end key split points asynchronously which
allowed for a brief period after tenant creation where the tenant's keyspace
had an end key of /Max instead of the next tenant's start key.

This change creates that split point synchronously on tenant creation to avoid
race conditions.

Release note: None
