### PR TITLE
backupccl: temporary switch on 'bulio.restore.use_simple_import_spans

### DIFF
--- a/pkg/ccl/backupccl/restore_job.go
+++ b/pkg/ccl/backupccl/restore_job.go
@@ -84,7 +84,7 @@ var useSimpleImportSpans = settings.RegisterBoolSetting(
 	settings.TenantWritable,
 	"bulkio.restore.use_simple_import_spans",
 	"if set to true, restore will generate its import spans using the makeSimpleImportSpans algorithm",
-	false,
+	true,
 )
 
 // rewriteBackupSpanKey rewrites a backup span start key for the purposes of


### PR DESCRIPTION
This prevents generative span generation on the 23.1 release branch, allowing us to demote #98779 to a GA-blocker.

Epic: none

Release note: setting change to lower risk default.