### PR TITLE
roachtest: copyfrom fix cluster package install

### DIFF
--- a/pkg/roachprod/install/install.go
+++ b/pkg/roachprod/install/install.go
@@ -147,6 +147,11 @@ sudo apt-get update;
 sudo apt-get install -y \
   zfsutils-linux;
 `,
+
+	"postgresql": `
+sudo apt-get update;
+sudo apt-get install -y postgresql;
+`,
 }
 
 // SortedCmds TODO(peter): document


### PR DESCRIPTION
When installing packages, look on cluster remoteness as proxy for arch instead of roachtest runtime which is runs different arch.

Epic: none

Release note: None