### PR TITLE
 backupccl: support 'execution locality' option in scheduled backups

### DIFF
--- a/pkg/ccl/backupccl/alter_backup_schedule.go
+++ b/pkg/ccl/backupccl/alter_backup_schedule.go
@@ -340,6 +340,10 @@ func processOptionsForArgs(inOpts tree.BackupOptions, outOpts *tree.BackupOption
 		outOpts.CaptureRevisionHistory = inOpts.CaptureRevisionHistory
 	}
 
+	if inOpts.ExecutionLocality != nil {
+		outOpts.ExecutionLocality = inOpts.ExecutionLocality
+	}
+
 	if inOpts.IncludeAllSecondaryTenants != nil {
 		outOpts.IncludeAllSecondaryTenants = inOpts.IncludeAllSecondaryTenants
 	}
@@ -350,6 +354,13 @@ func processOptionsForArgs(inOpts tree.BackupOptions, outOpts *tree.BackupOption
 			outOpts.EncryptionPassphrase = nil
 		} else {
 			outOpts.EncryptionPassphrase = inOpts.EncryptionPassphrase
+		}
+	}
+	if inOpts.ExecutionLocality != nil {
+		if tree.AsStringWithFlags(inOpts.ExecutionLocality, tree.FmtBareStrings) == "" {
+			outOpts.ExecutionLocality = nil
+		} else {
+			outOpts.ExecutionLocality = inOpts.ExecutionLocality
 		}
 	}
 	if inOpts.EncryptionKMSURI != nil {

--- a/pkg/ccl/backupccl/backup_planning.go
+++ b/pkg/ccl/backupccl/backup_planning.go
@@ -197,6 +197,7 @@ func resolveOptionsForBackupJobDescription(
 	newOpts := tree.BackupOptions{
 		CaptureRevisionHistory: opts.CaptureRevisionHistory,
 		Detached:               opts.Detached,
+		ExecutionLocality:      opts.ExecutionLocality,
 	}
 
 	if opts.EncryptionPassphrase != nil {

--- a/pkg/ccl/backupccl/testdata/backup-restore/alter-schedule/backup-options
+++ b/pkg/ccl/backupccl/testdata/backup-restore/alter-schedule/backup-options
@@ -1,4 +1,4 @@
-new-cluster name=s1 allow-implicit-access
+new-cluster name=s1 allow-implicit-access localities=us-east-1
 ----
 
 # Create test schedules.
@@ -35,16 +35,20 @@ exec-sql
 alter backup schedule $incID set with revision_history = false;
 ----
 
+exec-sql
+alter backup schedule $incID set with execution locality = 'region=us-east-1'
+----
+
 query-sql
 with schedules as (show schedules) select id, command->'backup_statement' from schedules where label='datatest' order by command->>'backup_type' asc;
 ----
-$fullID "BACKUP INTO 'nodelocal://1/example-schedule' WITH revision_history = false, detached"
-$incID "BACKUP INTO LATEST IN 'nodelocal://1/example-schedule' WITH revision_history = false, detached"
+$fullID "BACKUP INTO 'nodelocal://1/example-schedule' WITH revision_history = false, detached, execution locality = 'region=us-east-1'"
+$incID "BACKUP INTO LATEST IN 'nodelocal://1/example-schedule' WITH revision_history = false, detached, execution locality = 'region=us-east-1'"
 
 # Change an option and set another.
 
 exec-sql
-alter backup schedule $incID set with revision_history = true, set with encryption_passphrase = 'abc';
+alter backup schedule $incID set with revision_history = true, set with execution locality = '', set with encryption_passphrase = 'abc';
 ----
 
 query-sql


### PR DESCRIPTION
Release note: none.
Epic: CRDB-9547.