### PR TITLE
roachprod: change scp flags to avoid copy via local host

### DIFF
--- a/pkg/roachprod/install/cluster_synced.go
+++ b/pkg/roachprod/install/cluster_synced.go
@@ -2381,7 +2381,9 @@ func (c *SyncedCluster) SSH(ctx context.Context, l *logger.Logger, sshArgs, args
 // which we do want to be able to retry.
 func scp(src, dest string) (*RunResultDetails, error) {
 	args := []string{
-		"scp", "-r", "-C",
+		"scp",
+		// ssh to src then scp dsc mode, use agent forwarding, recursive, compression
+		"-R", "-A", "-r", "-C",
 		"-o", "StrictHostKeyChecking=no",
 	}
 	args = append(args, sshAuthArgs()...)


### PR DESCRIPTION
Previously default scp option made it to copy files via local host. This was causing unnecessary delays and network usage because files were first copied to one node, then distributed from that node using scp between remote locations. Unfortunately the default scp behaviour is to fetch from src and put to dst to avoid authenticating from src to dst.
This commit adds scp options to do direct copy.

Fixes: #99103

Release note: None