### PR TITLE
server: fix `WriteBytesPerSecond` stat assignment

### DIFF
--- a/pkg/server/status.go
+++ b/pkg/server/status.go
@@ -2144,7 +2144,7 @@ func (s *systemStatusServer) rangesHelper(
 				RequestsPerSecond:   loadStats.RequestsPerSecond,
 				WritesPerSecond:     loadStats.WriteKeysPerSecond,
 				ReadsPerSecond:      loadStats.ReadKeysPerSecond,
-				WriteBytesPerSecond: loadStats.WriteKeysPerSecond,
+				WriteBytesPerSecond: loadStats.WriteBytesPerSecond,
 				ReadBytesPerSecond:  loadStats.ReadBytesPerSecond,
 				CPUTimePerSecond:    loadStats.RaftCPUNanosPerSecond + loadStats.RequestCPUNanosPerSecond,
 			},


### PR DESCRIPTION
This patch fixes incorrect assignment of `WriteBytesPerSecond` stat in
 `rangeInfo` func that is used by StatusServer APIs only.

Fixes: #99291

Release note: None