### PR TITLE
kv: do not fatal when assertRefreshSpansAtInvalidTimestamp errors

### DIFF
--- a/pkg/kv/kvclient/kvcoord/txn_coord_sender.go
+++ b/pkg/kv/kvclient/kvcoord/txn_coord_sender.go
@@ -195,7 +195,7 @@ type txnInterceptor interface {
 
 	// importLeafFinalState updates any internal state held inside the
 	// interceptor from the given LeafTxn final state.
-	importLeafFinalState(context.Context, *roachpb.LeafTxnFinalState)
+	importLeafFinalState(context.Context, *roachpb.LeafTxnFinalState) error
 
 	// epochBumpedLocked resets the interceptor in the case of a txn epoch
 	// increment.
@@ -1219,7 +1219,7 @@ func (tc *TxnCoordSender) checkTxnStatusLocked(ctx context.Context, opt kv.TxnSt
 // UpdateRootWithLeafFinalState is part of the client.TxnSender interface.
 func (tc *TxnCoordSender) UpdateRootWithLeafFinalState(
 	ctx context.Context, tfs *roachpb.LeafTxnFinalState,
-) {
+) error {
 	tc.mu.Lock()
 	defer tc.mu.Unlock()
 
@@ -1229,7 +1229,7 @@ func (tc *TxnCoordSender) UpdateRootWithLeafFinalState(
 
 	// Sanity check: don't combine if the tfs is for a different txn ID.
 	if tc.mu.txn.ID != tfs.Txn.ID {
-		return
+		return errors.AssertionFailedf("mismatched root id %s and leaf id %s", tc.mu.txn.ID, tfs.Txn.ID)
 	}
 
 	// If the LeafTxnFinalState is telling us the transaction has been
@@ -1247,13 +1247,17 @@ func (tc *TxnCoordSender) UpdateRootWithLeafFinalState(
 	// as any error is received from DistSQL, which would eliminate
 	// qualms about what error comes first.
 	if tfs.Txn.Status != roachpb.PENDING {
-		return
+		return nil
 	}
 
 	tc.mu.txn.Update(&tfs.Txn)
 	for _, reqInt := range tc.interceptorStack {
-		reqInt.importLeafFinalState(ctx, tfs)
+		err := reqInt.importLeafFinalState(ctx, tfs)
+		if err != nil {
+			return err
+		}
 	}
+	return nil
 }
 
 // TestingCloneTxn is part of the client.TxnSender interface.

--- a/pkg/kv/kvclient/kvcoord/txn_coord_sender_test.go
+++ b/pkg/kv/kvclient/kvcoord/txn_coord_sender_test.go
@@ -2615,7 +2615,7 @@ func TestLeafTxnClientRejectError(t *testing.T) {
 // Check that ingesting an Aborted txn record is a no-op. The TxnCoordSender is
 // supposed to reject such updates because they risk putting it into an
 // inconsistent state. See comments in TxnCoordSender.UpdateRootWithLeafFinalState().
-func TestUpdateRoootWithLeafFinalStateInAbortedTxn(t *testing.T) {
+func TestUpdateRootWithLeafFinalStateInAbortedTxn(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	s := createTestDBWithKnobs(t, nil /* knobs */)

--- a/pkg/kv/kvclient/kvcoord/txn_interceptor_committer.go
+++ b/pkg/kv/kvclient/kvcoord/txn_interceptor_committer.go
@@ -539,7 +539,9 @@ func (*txnCommitter) populateLeafInputState(*roachpb.LeafTxnInputState) {}
 func (*txnCommitter) populateLeafFinalState(*roachpb.LeafTxnFinalState) {}
 
 // importLeafFinalState is part of the txnInterceptor interface.
-func (*txnCommitter) importLeafFinalState(context.Context, *roachpb.LeafTxnFinalState) {}
+func (*txnCommitter) importLeafFinalState(context.Context, *roachpb.LeafTxnFinalState) error {
+	return nil
+}
 
 // epochBumpedLocked implements the txnInterceptor interface.
 func (tc *txnCommitter) epochBumpedLocked() {}

--- a/pkg/kv/kvclient/kvcoord/txn_interceptor_heartbeater.go
+++ b/pkg/kv/kvclient/kvcoord/txn_interceptor_heartbeater.go
@@ -270,7 +270,9 @@ func (*txnHeartbeater) populateLeafInputState(*roachpb.LeafTxnInputState) {}
 func (*txnHeartbeater) populateLeafFinalState(*roachpb.LeafTxnFinalState) {}
 
 // importLeafFinalState is part of the txnInterceptor interface.
-func (*txnHeartbeater) importLeafFinalState(context.Context, *roachpb.LeafTxnFinalState) {}
+func (*txnHeartbeater) importLeafFinalState(context.Context, *roachpb.LeafTxnFinalState) error {
+	return nil
+}
 
 // epochBumpedLocked is part of the txnInterceptor interface.
 func (h *txnHeartbeater) epochBumpedLocked() {}

--- a/pkg/kv/kvclient/kvcoord/txn_interceptor_metric_recorder.go
+++ b/pkg/kv/kvclient/kvcoord/txn_interceptor_metric_recorder.go
@@ -71,7 +71,9 @@ func (*txnMetricRecorder) populateLeafInputState(*roachpb.LeafTxnInputState) {}
 func (*txnMetricRecorder) populateLeafFinalState(*roachpb.LeafTxnFinalState) {}
 
 // importLeafFinalState is part of the txnInterceptor interface.
-func (*txnMetricRecorder) importLeafFinalState(context.Context, *roachpb.LeafTxnFinalState) {}
+func (*txnMetricRecorder) importLeafFinalState(context.Context, *roachpb.LeafTxnFinalState) error {
+	return nil
+}
 
 // epochBumpedLocked is part of the txnInterceptor interface.
 func (*txnMetricRecorder) epochBumpedLocked() {}

--- a/pkg/kv/kvclient/kvcoord/txn_interceptor_pipeliner.go
+++ b/pkg/kv/kvclient/kvcoord/txn_interceptor_pipeliner.go
@@ -809,7 +809,9 @@ func (tp *txnPipeliner) initializeLeaf(tis *roachpb.LeafTxnInputState) {
 func (tp *txnPipeliner) populateLeafFinalState(*roachpb.LeafTxnFinalState) {}
 
 // importLeafFinalState is part of the txnInterceptor interface.
-func (tp *txnPipeliner) importLeafFinalState(context.Context, *roachpb.LeafTxnFinalState) {}
+func (tp *txnPipeliner) importLeafFinalState(context.Context, *roachpb.LeafTxnFinalState) error {
+	return nil
+}
 
 // epochBumpedLocked implements the txnInterceptor interface.
 func (tp *txnPipeliner) epochBumpedLocked() {

--- a/pkg/kv/kvclient/kvcoord/txn_interceptor_seq_num_allocator.go
+++ b/pkg/kv/kvclient/kvcoord/txn_interceptor_seq_num_allocator.go
@@ -127,7 +127,8 @@ func (s *txnSeqNumAllocator) populateLeafFinalState(tfs *roachpb.LeafTxnFinalSta
 // importLeafFinalState is part of the txnInterceptor interface.
 func (s *txnSeqNumAllocator) importLeafFinalState(
 	ctx context.Context, tfs *roachpb.LeafTxnFinalState,
-) {
+) error {
+	return nil
 }
 
 // stepLocked bumps the read seqnum to the current write seqnum.

--- a/pkg/kv/kvclient/kvcoord/txn_interceptor_span_refresher.go
+++ b/pkg/kv/kvclient/kvcoord/txn_interceptor_span_refresher.go
@@ -686,9 +686,9 @@ func (sr *txnSpanRefresher) populateLeafFinalState(tfs *roachpb.LeafTxnFinalStat
 // importLeafFinalState is part of the txnInterceptor interface.
 func (sr *txnSpanRefresher) importLeafFinalState(
 	ctx context.Context, tfs *roachpb.LeafTxnFinalState,
-) {
+) error {
 	if err := sr.assertRefreshSpansAtInvalidTimestamp(tfs.Txn.ReadTimestamp); err != nil {
-		log.Fatalf(ctx, "%s", err)
+		return err
 	}
 	if tfs.RefreshInvalid {
 		sr.refreshInvalid = true
@@ -698,6 +698,7 @@ func (sr *txnSpanRefresher) importLeafFinalState(
 		// Check whether we should condense the refresh spans.
 		sr.maybeCondenseRefreshSpans(ctx, &tfs.Txn)
 	}
+	return nil
 }
 
 // epochBumpedLocked implements the txnInterceptor interface.

--- a/pkg/kv/mock_transactional_sender.go
+++ b/pkg/kv/mock_transactional_sender.go
@@ -63,7 +63,7 @@ func (m *MockTransactionalSender) GetLeafTxnFinalState(
 // UpdateRootWithLeafFinalState is part of the TxnSender interface.
 func (m *MockTransactionalSender) UpdateRootWithLeafFinalState(
 	context.Context, *roachpb.LeafTxnFinalState,
-) {
+) error {
 	panic("unimplemented")
 }
 

--- a/pkg/kv/sender.go
+++ b/pkg/kv/sender.go
@@ -112,7 +112,7 @@ type TxnSender interface {
 
 	// UpdateRootWithLeafFinalState updates a RootTxn using the final
 	// state of a LeafTxn.
-	UpdateRootWithLeafFinalState(context.Context, *roachpb.LeafTxnFinalState)
+	UpdateRootWithLeafFinalState(context.Context, *roachpb.LeafTxnFinalState) error
 
 	// SetUserPriority sets the txn's priority.
 	SetUserPriority(roachpb.UserPriority) error

--- a/pkg/kv/txn.go
+++ b/pkg/kv/txn.go
@@ -1300,8 +1300,7 @@ func (txn *Txn) UpdateRootWithLeafFinalState(
 
 	txn.mu.Lock()
 	defer txn.mu.Unlock()
-	txn.mu.sender.UpdateRootWithLeafFinalState(ctx, tfs)
-	return nil
+	return txn.mu.sender.UpdateRootWithLeafFinalState(ctx, tfs)
 }
 
 // UpdateStateOnRemoteRetryableErr updates the txn in response to an error

--- a/pkg/kv/txn_external_test.go
+++ b/pkg/kv/txn_external_test.go
@@ -772,3 +772,65 @@ func TestUpdateStateOnRemoteRetryableErr(t *testing.T) {
 		require.Equal(t, txn.Sender().TestingCloneTxn().ID, txnIDBefore)
 	}
 }
+
+// TestUpdateRootWithLeafStateReadsBelowRefreshTimestamp ensures that if a leaf
+// transaction has performed reads below the root transaction's refreshed
+// timestamp an assertion error is returned. Note that the construction here
+// involves concurrent use of a root and leaf txn, which is not allowed by the
+// Txn API.
+//
+// This test codifies the desired behavior described in
+// https://github.com/cockroachdb/cockroach/issues/99255.
+func TestUpdateRootWithLeafFinalStateReadsBelowRefreshTimestamp(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	s, _, db := serverutils.StartServer(t, base.TestServerArgs{})
+	ctx := context.Background()
+	defer s.Stopper().Stop(ctx)
+
+	keyA := roachpb.Key("a")
+	keyB := roachpb.Key("b")
+
+	performConflictingRead := func(ctx context.Context, key roachpb.Key) (hlc.Timestamp, error) {
+		conflictTxn := kv.NewTxn(ctx, db, 0 /* gatewayNodeID */)
+		if _, err := conflictTxn.Get(ctx, key); err != nil {
+			return hlc.Timestamp{}, err
+		}
+		if err := conflictTxn.Commit(ctx); err != nil {
+			return hlc.Timestamp{}, err
+		}
+		return conflictTxn.CommitTimestamp(), nil
+	}
+	err := db.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
+		// Perform a read to set the timestamp.
+		_, err := txn.Get(ctx, keyA)
+		require.NoError(t, err)
+		// Fork off a leaf transaction before the root is refreshed.
+		leafInputState := txn.GetLeafTxnInputState(ctx)
+		leafTxn := kv.NewLeafTxn(ctx, db, 0, leafInputState)
+
+		readTS, err := performConflictingRead(ctx, keyB)
+		require.NoError(t, err)
+		require.True(t, leafTxn.TestingCloneTxn().ReadTimestamp.Less(readTS))
+
+		// Write to KeyB using the root transaction. This should cause the timestamp
+		// to get bumped, which we will refresh to further down.
+		err = txn.Put(ctx, keyB, "garbage")
+		require.NoError(t, err)
+		err = txn.ManualRefresh(ctx)
+		require.NoError(t, err)
+
+		// Finally, try and update the root with the leaf transaction's state.
+		finalState, err := leafTxn.GetLeafTxnFinalState(ctx)
+		require.NoError(t, err)
+		err = txn.UpdateRootWithLeafFinalState(ctx, finalState)
+		require.Error(t, err)
+		require.True(t, errors.IsAssertionFailure(err), "%+v", err)
+		require.Regexp(
+			t, "attempting to append refresh spans after the tracked timestamp has moved forward", err,
+		)
+		return nil
+	})
+	require.NoError(t, err)
+}


### PR DESCRIPTION
The Txn API prohibits using the root transaction when one or more leaf transactions that have been forked from it are still active. One reason for this is that an operation on a root transaction can cause it to perform a read refresh; however, leaf transactions cannot perform read refreshes and we have no way to talk about a "partially refreshed" set of read spans. As such, when ingesting state from a leaf transaction, the root calls into
 `assertRefreshSpansAtInvalidTimestamp` which makes sure the timestamp
at which the leaf performed its reads is not below the timestamp at which the root has already been refreshed to.

Previously, tripping this assertion would cause the gateway node to crash because we'd log this error as a Fatal. Even though this situation results from a programming mistake by users of the Txn API, the correctness issue is isolated to the query in question. It doesn't cascade to other queries/cause data corruption. As such, it shouldn't warrant crashing the node. Instead, it should be sufficient to simply return this assertion failed error back to the client. While this situation is

Resolves #99255

Epic: none

Release note: None