### PR TITLE
multitenant: don't panic if reader doesn't exist yet

### DIFF
--- a/pkg/multitenant/tenantcapabilities/tenantcapabilitiesauthorizer/BUILD.bazel
+++ b/pkg/multitenant/tenantcapabilities/tenantcapabilitiesauthorizer/BUILD.bazel
@@ -16,7 +16,6 @@ go_library(
         "//pkg/settings",
         "//pkg/settings/cluster",
         "//pkg/util/log",
-        "//pkg/util/log/logcrash",
         "@com_github_cockroachdb_errors//:errors",
     ],
 )


### PR DESCRIPTION
While shared-process tenant servers are not likely to make requests
before the capability reader exists, the limiter factory looks up the
relevant tenant ID from the start key of the range descriptor and it
isn't unlikely that we'll see requests against tenant ranges before we
have a capability reader available.

Epic: none

Release note: None

Release justification: Low risk fix to avoid panics in tests.