### PR TITLE
kvserver: hook up TenantStoreMetrics to registry

### DIFF
--- a/pkg/kv/kvserver/metrics.go
+++ b/pkg/kv/kvserver/metrics.go
@@ -2308,9 +2308,11 @@ func newStoreMetrics(histogramWindow time.Duration) *StoreMetrics {
 	rdbLevelSize := storageLevelGaugeSlice(metaRdbLevelSize)
 	rdbLevelScore := storageLevelGaugeFloat64Slice(metaRdbLevelScores)
 
+	tsm := newTenantsStorageMetrics()
+	storeRegistry.AddMetricStruct(tsm)
 	sm := &StoreMetrics{
 		registry:              storeRegistry,
-		TenantsStorageMetrics: newTenantsStorageMetrics(),
+		TenantsStorageMetrics: tsm,
 		LoadSplitterMetrics: &split.LoadSplitterMetrics{
 			PopularKeyCount: metric.NewCounter(metaPopularKeyCount),
 			NoSplitKeyCount: metric.NewCounter(metaNoSplitKeyCount),


### PR DESCRIPTION
TODO needs some sort of test, perhaps.

Closes #99228

Epic: none
Release note: None
