### PR TITLE
build: use same roachtest parallelism and cpuquota for AWS and GCE

### DIFF
--- a/build/teamcity/util/roachtest_util.sh
+++ b/build/teamcity/util/roachtest_util.sh
@@ -61,8 +61,6 @@ case "${CLOUD}" in
   gce)
     ;;
   aws)
-    PARALLELISM=3
-    CPUQUOTA=384
     if [ -z "${TESTS}" ]; then
       # NB: anchor ycsb to beginning of line to avoid matching `zfs/ycsb/*` which
       # isn't supported on AWS at time of writing.


### PR DESCRIPTION
The parallelism and cpuquota passed to AWS is much lower than that for GCE when invoking roachtest nightly builds. The AWS values have been imported from TeamCity ~3 years ago [1] and haven't changed since then. However, we are starting to see Roachtest Nightly builds time out on AWS [2] now that teams are starting to write more roachtests that run on AWS.

This commit removes the custom `PARALLELISM` and `CPUQUOTA` settings we had in place for AWS, making it consistent with GCE.

[1] see 8219a7f
[2] https://teamcity.cockroachdb.com/viewLog.html?buildId=9182737&buildTypeId=Cockroach_Nightlies_RoachtestNightlyAwsBazel

Epic: none

Release note: None