### PR TITLE
roachtest: lower default timeout

### DIFF
--- a/pkg/cmd/roachtest/test_runner.go
+++ b/pkg/cmd/roachtest/test_runner.go
@@ -947,7 +947,7 @@ func (r *testRunner) runTest(
 
 	t.start = timeutil.Now()
 
-	timeout := 10 * time.Hour
+	timeout := 3 * time.Hour
 	if d := s.Timeout; d != 0 {
 		timeout = d
 	}

--- a/pkg/cmd/roachtest/tests/activerecord.go
+++ b/pkg/cmd/roachtest/tests/activerecord.go
@@ -16,6 +16,7 @@ import (
 	"context"
 	"fmt"
 	"regexp"
+	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
@@ -243,6 +244,7 @@ func registerActiveRecord(r registry.Registry) {
 	r.Add(registry.TestSpec{
 		Name:       "activerecord",
 		Owner:      registry.OwnerSQLSessions,
+		Timeout:    5 * time.Hour,
 		Cluster:    r.MakeClusterSpec(1),
 		NativeLibs: registry.LibGEOS,
 		Tags:       []string{`default`, `orm`},

--- a/pkg/cmd/roachtest/tests/multitenant_upgrade.go
+++ b/pkg/cmd/roachtest/tests/multitenant_upgrade.go
@@ -30,6 +30,7 @@ import (
 func registerMultiTenantUpgrade(r registry.Registry) {
 	r.Add(registry.TestSpec{
 		Name:              "multitenant-upgrade",
+		Timeout:           1 * time.Hour,
 		Cluster:           r.MakeClusterSpec(2),
 		Owner:             registry.OwnerMultiTenant,
 		NonReleaseBlocker: false,

--- a/pkg/cmd/roachtest/tests/ruby_pg.go
+++ b/pkg/cmd/roachtest/tests/ruby_pg.go
@@ -17,6 +17,7 @@ import (
 	"fmt"
 	"regexp"
 	"strconv"
+	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
@@ -227,6 +228,7 @@ func registerRubyPG(r registry.Registry) {
 
 	r.Add(registry.TestSpec{
 		Name:       "ruby-pg",
+		Timeout:    1 * time.Hour,
 		Owner:      registry.OwnerSQLSessions,
 		Cluster:    r.MakeClusterSpec(1),
 		NativeLibs: registry.LibGEOS,

--- a/pkg/cmd/roachtest/tests/tpcc.go
+++ b/pkg/cmd/roachtest/tests/tpcc.go
@@ -536,6 +536,7 @@ func registerTPCC(r registry.Registry) {
 	r.Add(registry.TestSpec{
 		// run the same mixed-headroom test, but going back two versions
 		Name:              "tpcc/mixed-headroom/multiple-upgrades/" + mixedHeadroomSpec.String(),
+		Timeout:           5 * time.Hour,
 		Owner:             registry.OwnerTestEng,
 		Tags:              []string{`default`},
 		Cluster:           mixedHeadroomSpec,
@@ -1083,6 +1084,7 @@ func registerTPCCBenchSpec(r registry.Registry, b tpccBenchSpec) {
 		Name:              name,
 		Owner:             owner,
 		Cluster:           nodes,
+		Timeout:           5 * time.Hour,
 		Tags:              b.Tags,
 		EncryptionSupport: encryptionSupport,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {

--- a/pkg/cmd/roachtest/tests/tpce.go
+++ b/pkg/cmd/roachtest/tests/tpce.go
@@ -108,7 +108,7 @@ func registerTPCE(r registry.Registry) {
 
 	for _, opts := range []tpceOptions{
 		// Nightly, small scale configurations.
-		{customers: 5_000, nodes: 3, cpus: 4, ssds: 1},
+		{customers: 5_000, nodes: 3, cpus: 4, ssds: 1, timeout: 4 * time.Hour},
 		// Weekly, large scale configurations.
 		{customers: 100_000, nodes: 5, cpus: 32, ssds: 2, tags: []string{"weekly"}, timeout: 36 * time.Hour},
 	} {

--- a/pkg/cmd/roachtest/tests/version.go
+++ b/pkg/cmd/roachtest/tests/version.go
@@ -219,6 +219,7 @@ func registerVersion(r registry.Registry) {
 	for _, n := range []int{3, 5} {
 		r.Add(registry.TestSpec{
 			Name:    fmt.Sprintf("version/mixed/nodes=%d", n),
+			Timeout: 4 * time.Hour,
 			Owner:   registry.OwnerTestEng,
 			Cluster: r.MakeClusterSpec(n + 1),
 			Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {


### PR DESCRIPTION
The previous default of 10 hours if unnecessarily long. As a consequence, if a test has a bug that causes it to hang, it will take 10h's worth of cluster usage, even if it's a test that generally succeeds in half an hour.

This should hopefully help with the timeouts we have been seeing in roachtest nightly runs.

Epic: none

Release note: None