### PR TITLE
kv/kvclient: remove GetLeafTxnInputState{OrRejectClient} split

### DIFF
--- a/pkg/kv/kvclient/kvcoord/txn_coord_sender.go
+++ b/pkg/kv/kvclient/kvcoord/txn_coord_sender.go
@@ -1316,6 +1316,13 @@ func (tc *TxnCoordSender) Step(ctx context.Context) error {
 	return tc.interceptorAlloc.txnSeqNumAllocator.stepLocked(ctx)
 }
 
+// GetReadSeqNum is part of the TxnSender interface.
+func (tc *TxnCoordSender) GetReadSeqNum() enginepb.TxnSeq {
+	tc.mu.Lock()
+	defer tc.mu.Unlock()
+	return tc.interceptorAlloc.txnSeqNumAllocator.readSeq
+}
+
 // SetReadSeqNum is part of the TxnSender interface.
 func (tc *TxnCoordSender) SetReadSeqNum(seq enginepb.TxnSeq) error {
 	tc.mu.Lock()

--- a/pkg/kv/kvclient/kvcoord/txn_coord_sender.go
+++ b/pkg/kv/kvclient/kvcoord/txn_coord_sender.go
@@ -1170,14 +1170,15 @@ func (tc *TxnCoordSender) Active() bool {
 
 // GetLeafTxnInputState is part of the client.TxnSender interface.
 func (tc *TxnCoordSender) GetLeafTxnInputState(
-	ctx context.Context, opt kv.TxnStatusOpt,
+	ctx context.Context,
 ) (*roachpb.LeafTxnInputState, error) {
 	tis := new(roachpb.LeafTxnInputState)
 	tc.mu.Lock()
 	defer tc.mu.Unlock()
 
-	if err := tc.checkTxnStatusLocked(ctx, opt); err != nil {
-		return nil, err
+	pErr := tc.maybeRejectClientLocked(ctx, nil /* ba */)
+	if pErr != nil {
+		return nil, pErr.GoError()
 	}
 
 	// Copy mutable state so access is safe for the caller.
@@ -1197,15 +1198,20 @@ func (tc *TxnCoordSender) GetLeafTxnInputState(
 
 // GetLeafTxnFinalState is part of the client.TxnSender interface.
 func (tc *TxnCoordSender) GetLeafTxnFinalState(
-	ctx context.Context, opt kv.TxnStatusOpt,
+	ctx context.Context,
 ) (*roachpb.LeafTxnFinalState, error) {
 	tfs := new(roachpb.LeafTxnFinalState)
 	tc.mu.Lock()
 	defer tc.mu.Unlock()
 
-	if err := tc.checkTxnStatusLocked(ctx, opt); err != nil {
-		return nil, err
-	}
+	// TODO(nvanbenschoten): should we be calling maybeRejectClientLocked here?
+	// The caller in execinfra.GetLeafTxnFinalState is not set up to propagate
+	// errors, so for now, we don't.
+	//
+	//   pErr := tc.maybeRejectClientLocked(ctx, nil /* ba */)
+	//   if pErr != nil {
+	//   	return nil, pErr.GoError()
+	//   }
 
 	// For compatibility with pre-20.1 nodes: populate the command
 	// count.
@@ -1222,22 +1228,6 @@ func (tc *TxnCoordSender) GetLeafTxnFinalState(
 	}
 
 	return tfs, nil
-}
-
-func (tc *TxnCoordSender) checkTxnStatusLocked(ctx context.Context, opt kv.TxnStatusOpt) error {
-	switch opt {
-	case kv.AnyTxnStatus:
-		// Nothing to check.
-	case kv.OnlyPending:
-		// Check the coordinator's proto status.
-		rejectErr := tc.maybeRejectClientLocked(ctx, nil /* ba */)
-		if rejectErr != nil {
-			return rejectErr.GoError()
-		}
-	default:
-		panic("unreachable")
-	}
-	return nil
 }
 
 // UpdateRootWithLeafFinalState is part of the client.TxnSender interface.

--- a/pkg/kv/kvclient/kvcoord/txn_coord_sender_test.go
+++ b/pkg/kv/kvclient/kvcoord/txn_coord_sender_test.go
@@ -1017,7 +1017,8 @@ func TestTxnMultipleCoord(t *testing.T) {
 	}
 
 	// New create a second, leaf coordinator.
-	leafInputState := txn.GetLeafTxnInputState(ctx)
+	leafInputState, err := txn.GetLeafTxnInputState(ctx)
+	require.NoError(t, err)
 	txn2 := kv.NewLeafTxn(ctx, s.DB, 0 /* gatewayNodeID */, leafInputState)
 
 	// Start the second transaction.
@@ -2592,7 +2593,8 @@ func TestLeafTxnClientRejectError(t *testing.T) {
 
 	ctx := context.Background()
 	rootTxn := kv.NewTxn(ctx, s.DB, 0 /* gatewayNodeID */)
-	leafInputState := rootTxn.GetLeafTxnInputState(ctx)
+	leafInputState, err := rootTxn.GetLeafTxnInputState(ctx)
+	require.NoError(t, err)
 
 	// New create a second, leaf coordinator.
 	leafTxn := kv.NewLeafTxn(ctx, s.DB, 0 /* gatewayNodeID */, leafInputState)
@@ -2606,7 +2608,7 @@ func TestLeafTxnClientRejectError(t *testing.T) {
 	// transformed into an UnhandledRetryableError. For our purposes, what this
 	// test is interested in demonstrating is that it's not a
 	// TransactionRetryWithProtoRefreshError.
-	_, err := leafTxn.Get(ctx, roachpb.Key("a"))
+	_, err = leafTxn.Get(ctx, roachpb.Key("a"))
 	if !errors.HasType(err, (*kvpb.UnhandledRetryableError)(nil)) {
 		t.Fatalf("expected UnhandledRetryableError(TransactionAbortedError), got: (%T) %v", err, err)
 	}
@@ -2623,7 +2625,8 @@ func TestUpdateRootWithLeafFinalStateInAbortedTxn(t *testing.T) {
 	ctx := context.Background()
 
 	txn := kv.NewTxn(ctx, s.DB, 0 /* gatewayNodeID */)
-	leafInputState := txn.GetLeafTxnInputState(ctx)
+	leafInputState, err := txn.GetLeafTxnInputState(ctx)
+	require.NoError(t, err)
 	leafTxn := kv.NewLeafTxn(ctx, s.DB, 0, leafInputState)
 
 	finalState, err := leafTxn.GetLeafTxnFinalState(ctx)
@@ -2636,7 +2639,8 @@ func TestUpdateRootWithLeafFinalStateInAbortedTxn(t *testing.T) {
 	}
 
 	// Check that the transaction was not updated.
-	leafInputState2 := txn.GetLeafTxnInputState(ctx)
+	leafInputState2, err := txn.GetLeafTxnInputState(ctx)
+	require.NoError(t, err)
 	if leafInputState2.Txn.Status != roachpb.PENDING {
 		t.Fatalf("expected PENDING txn, got: %s", leafInputState2.Txn.Status)
 	}
@@ -3030,11 +3034,12 @@ func TestTxnTypeCompatibleWithBatchRequest(t *testing.T) {
 	defer s.Stop()
 
 	rootTxn := kv.NewTxn(ctx, s.DB, 0 /* gatewayNodeID */)
-	leafInputState := rootTxn.GetLeafTxnInputState(ctx)
+	leafInputState, err := rootTxn.GetLeafTxnInputState(ctx)
+	require.NoError(t, err)
 	leafTxn := kv.NewLeafTxn(ctx, s.DB, 0 /* gatewayNodeID */, leafInputState)
 
 	// a LeafTxn is not compatible with a locking request
-	_, err := leafTxn.GetForUpdate(ctx, roachpb.Key("a"))
+	_, err = leafTxn.GetForUpdate(ctx, roachpb.Key("a"))
 	require.Error(t, err)
 	require.Regexp(t, "LeafTxn .* incompatible with locking request .*", err)
 	err = leafTxn.Put(ctx, roachpb.Key("a"), []byte("b"))

--- a/pkg/kv/kvclient/kvstreamer/streamer_test.go
+++ b/pkg/kv/kvclient/kvstreamer/streamer_test.go
@@ -39,10 +39,14 @@ func getStreamer(
 	ctx context.Context, s serverutils.TestServerInterface, limitBytes int64, acc *mon.BoundAccount,
 ) *Streamer {
 	rootTxn := kv.NewTxn(ctx, s.DB(), s.NodeID())
+	leafInputState, err := rootTxn.GetLeafTxnInputState(ctx)
+	if err != nil {
+		panic(err)
+	}
 	return NewStreamer(
 		s.DistSenderI().(*kvcoord.DistSender),
 		s.Stopper(),
-		kv.NewLeafTxn(ctx, s.DB(), s.NodeID(), rootTxn.GetLeafTxnInputState(ctx)),
+		kv.NewLeafTxn(ctx, s.DB(), s.NodeID(), leafInputState),
 		cluster.MakeTestingClusterSettings(),
 		lock.WaitPolicy(0),
 		limitBytes,

--- a/pkg/kv/mock_transactional_sender.go
+++ b/pkg/kv/mock_transactional_sender.go
@@ -194,6 +194,9 @@ func (m *MockTransactionalSender) Step(_ context.Context) error {
 	return nil
 }
 
+// GetReadSeqNum is part of the TxnSender interface.
+func (m *MockTransactionalSender) GetReadSeqNum() enginepb.TxnSeq { return 0 }
+
 // SetReadSeqNum is part of the TxnSender interface.
 func (m *MockTransactionalSender) SetReadSeqNum(_ enginepb.TxnSeq) error { return nil }
 

--- a/pkg/kv/mock_transactional_sender.go
+++ b/pkg/kv/mock_transactional_sender.go
@@ -48,14 +48,14 @@ func (m *MockTransactionalSender) Send(
 
 // GetLeafTxnInputState is part of the TxnSender interface.
 func (m *MockTransactionalSender) GetLeafTxnInputState(
-	context.Context, TxnStatusOpt,
+	context.Context,
 ) (*roachpb.LeafTxnInputState, error) {
 	panic("unimplemented")
 }
 
 // GetLeafTxnFinalState is part of the TxnSender interface.
 func (m *MockTransactionalSender) GetLeafTxnFinalState(
-	context.Context, TxnStatusOpt,
+	context.Context,
 ) (*roachpb.LeafTxnFinalState, error) {
 	panic("unimplemented")
 }

--- a/pkg/kv/sender.go
+++ b/pkg/kv/sender.go
@@ -276,6 +276,9 @@ type TxnSender interface {
 	// The method is idempotent.
 	Step(context.Context) error
 
+	// GetReadSeqNum gets the read sequence point for the current transaction.
+	GetReadSeqNum() enginepb.TxnSeq
+
 	// SetReadSeqNum sets the read sequence point for the current transaction.
 	SetReadSeqNum(seq enginepb.TxnSeq) error
 

--- a/pkg/kv/sender.go
+++ b/pkg/kv/sender.go
@@ -100,15 +100,12 @@ type TxnSender interface {
 
 	// GetLeafTxnInputState retrieves the input state necessary and
 	// sufficient to initialize a LeafTxn from the current RootTxn.
-	//
-	// If AnyTxnStatus is passed, then this function never returns
-	// errors.
-	GetLeafTxnInputState(context.Context, TxnStatusOpt) (*roachpb.LeafTxnInputState, error)
+	GetLeafTxnInputState(context.Context) (*roachpb.LeafTxnInputState, error)
 
 	// GetLeafTxnFinalState retrieves the final state of a LeafTxn
 	// necessary and sufficient to update a RootTxn with progress made
 	// on its behalf by the LeafTxn.
-	GetLeafTxnFinalState(context.Context, TxnStatusOpt) (*roachpb.LeafTxnFinalState, error)
+	GetLeafTxnFinalState(context.Context) (*roachpb.LeafTxnFinalState, error)
 
 	// UpdateRootWithLeafFinalState updates a RootTxn using the final
 	// state of a LeafTxn.
@@ -361,21 +358,6 @@ type SavepointToken interface {
 	// forwarded without a refresh.
 	Initial() bool
 }
-
-// TxnStatusOpt represents options for TxnSender.GetMeta().
-type TxnStatusOpt int
-
-const (
-	// AnyTxnStatus means GetMeta() will return the info without
-	// checking the txn's status.
-	AnyTxnStatus TxnStatusOpt = iota
-	// OnlyPending means GetMeta() will return an error if the
-	// transaction is not in the pending state.
-	// This is used when sending the txn from root to leaves so that we
-	// don't create leaves that start up in an aborted state - which is
-	// not allowed.
-	OnlyPending
-)
 
 // TxnSenderFactory is the interface used to create new instances
 // of TxnSender.

--- a/pkg/kv/txn.go
+++ b/pkg/kv/txn.go
@@ -1485,6 +1485,13 @@ func (txn *Txn) Step(ctx context.Context) error {
 	return txn.mu.sender.Step(ctx)
 }
 
+// GetReadSeqNum gets the read sequence number for this transaction.
+func (txn *Txn) GetReadSeqNum() enginepb.TxnSeq {
+	txn.mu.Lock()
+	defer txn.mu.Unlock()
+	return txn.mu.sender.GetReadSeqNum()
+}
+
 // SetReadSeqNum sets the read sequence number for this transaction.
 func (txn *Txn) SetReadSeqNum(seq enginepb.TxnSeq) error {
 	txn.mu.Lock()

--- a/pkg/kv/txn.go
+++ b/pkg/kv/txn.go
@@ -1226,45 +1226,23 @@ func (txn *Txn) applyDeadlineToBoundedStaleness(
 }
 
 // GetLeafTxnInputState returns the LeafTxnInputState information for this
-// transaction for use with InitializeLeafTxn(), when distributing
-// the state of the current transaction to multiple distributed
-// transaction coordinators.
-func (txn *Txn) GetLeafTxnInputState(ctx context.Context) *roachpb.LeafTxnInputState {
-	if txn.typ != RootTxn {
-		panic(errors.WithContextTags(errors.AssertionFailedf("GetLeafTxnInputState() called on leaf txn"), ctx))
-	}
-
-	txn.mu.Lock()
-	defer txn.mu.Unlock()
-	ts, err := txn.mu.sender.GetLeafTxnInputState(ctx, AnyTxnStatus)
-	if err != nil {
-		log.Fatalf(ctx, "unexpected error from GetLeafTxnInputState(AnyTxnStatus): %s", err)
-	}
-	return ts
-}
-
-// GetLeafTxnInputStateOrRejectClient is like GetLeafTxnInputState
-// except, if the transaction is already aborted or otherwise in state
-// that cannot make progress, it returns an error. If the transaction aborted
-// the error returned will be a retryable one; as such, the caller is
-// responsible for handling the error before another attempt by calling
-// PrepareForRetry. Use of the transaction before doing so will continue to be
-// rejected.
-func (txn *Txn) GetLeafTxnInputStateOrRejectClient(
-	ctx context.Context,
-) (*roachpb.LeafTxnInputState, error) {
+// transaction for use with NewLeafTxn(), when distributing the state of the
+// current transaction to multiple distributed transaction coordinators.
+//
+// If the transaction is already aborted or otherwise in a state that cannot
+// make progress, it returns an error. If the transaction is aborted, the error
+// returned will be a retryable one. In such cases, the caller is responsible
+// for handling the error before another attempt by calling PrepareForRetry. Use
+// of the transaction before doing so will continue to be rejected.
+func (txn *Txn) GetLeafTxnInputState(ctx context.Context) (*roachpb.LeafTxnInputState, error) {
 	if txn.typ != RootTxn {
 		return nil, errors.WithContextTags(
-			errors.AssertionFailedf("GetLeafTxnInputStateOrRejectClient() called on leaf txn"), ctx)
+			errors.AssertionFailedf("GetLeafTxnInputState() called on leaf txn"), ctx)
 	}
 
 	txn.mu.Lock()
 	defer txn.mu.Unlock()
-	tfs, err := txn.mu.sender.GetLeafTxnInputState(ctx, OnlyPending)
-	if err != nil {
-		return nil, err
-	}
-	return tfs, nil
+	return txn.mu.sender.GetLeafTxnInputState(ctx)
 }
 
 // GetLeafTxnFinalState returns the LeafTxnFinalState information for this
@@ -1279,11 +1257,11 @@ func (txn *Txn) GetLeafTxnFinalState(ctx context.Context) (*roachpb.LeafTxnFinal
 
 	txn.mu.Lock()
 	defer txn.mu.Unlock()
-	tfs, err := txn.mu.sender.GetLeafTxnFinalState(ctx, AnyTxnStatus)
+	tfs, err := txn.mu.sender.GetLeafTxnFinalState(ctx)
 	if err != nil {
 		return nil, errors.WithContextTags(
 			errors.NewAssertionErrorWithWrappedErrf(err,
-				"unexpected error from GetLeafTxnFinalState(AnyTxnStatus)"), ctx)
+				"unexpected error from GetLeafTxnFinalState()"), ctx)
 	}
 	return tfs, nil
 }

--- a/pkg/kv/txn_external_test.go
+++ b/pkg/kv/txn_external_test.go
@@ -807,7 +807,8 @@ func TestUpdateRootWithLeafFinalStateReadsBelowRefreshTimestamp(t *testing.T) {
 		_, err := txn.Get(ctx, keyA)
 		require.NoError(t, err)
 		// Fork off a leaf transaction before the root is refreshed.
-		leafInputState := txn.GetLeafTxnInputState(ctx)
+		leafInputState, err := txn.GetLeafTxnInputState(ctx)
+		require.NoError(t, err)
 		leafTxn := kv.NewLeafTxn(ctx, db, 0, leafInputState)
 
 		readTS, err := performConflictingRead(ctx, keyB)

--- a/pkg/sql/colflow/colbatch_scan_test.go
+++ b/pkg/sql/colflow/colbatch_scan_test.go
@@ -63,7 +63,10 @@ func TestColBatchScanMeta(t *testing.T) {
 	defer monitorRegistry.Close(ctx)
 
 	rootTxn := kv.NewTxn(ctx, s.DB(), s.NodeID())
-	leafInputState := rootTxn.GetLeafTxnInputState(ctx)
+	leafInputState, err := rootTxn.GetLeafTxnInputState(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
 	leafTxn := kv.NewLeafTxn(ctx, s.DB(), s.NodeID(), leafInputState)
 	flowCtx := execinfra.FlowCtx{
 		EvalCtx: &evalCtx,

--- a/pkg/sql/distsql_running.go
+++ b/pkg/sql/distsql_running.go
@@ -766,7 +766,7 @@ func (dsp *DistSQLPlanner) Run(
 		}
 		if localState.MustUseLeafTxn() {
 			// Set up leaf txns using the txnCoordMeta if we need to.
-			tis, err := txn.GetLeafTxnInputStateOrRejectClient(ctx)
+			tis, err := txn.GetLeafTxnInputState(ctx)
 			if err != nil {
 				log.Infof(ctx, "%s: %s", clientRejectedMsg, err)
 				recv.SetError(err)

--- a/pkg/sql/flowinfra/cluster_test.go
+++ b/pkg/sql/flowinfra/cluster_test.go
@@ -101,7 +101,8 @@ func runTestClusterFlow(
 		int32(servers[0].SQLInstanceID()),
 	)
 	txn := kv.NewTxnFromProto(ctx, kvDB, roachpb.NodeID(servers[0].SQLInstanceID()), now, kv.RootTxn, &txnProto)
-	leafInputState := txn.GetLeafTxnInputState(ctx)
+	leafInputState, err := txn.GetLeafTxnInputState(ctx)
+	require.NoError(t, err)
 
 	var spec fetchpb.IndexFetchSpec
 	if err := rowenc.InitIndexFetchSpec(&spec, codec, desc, desc.ActiveIndexes()[1], []descpb.ColumnID{1, 2}); err != nil {
@@ -420,7 +421,8 @@ func TestLimitedBufferingDeadlock(t *testing.T) {
 	txn := kv.NewTxnFromProto(
 		context.Background(), tc.Server(0).DB(), tc.Server(0).NodeID(),
 		now, kv.RootTxn, &txnProto)
-	leafInputState := txn.GetLeafTxnInputState(context.Background())
+	leafInputState, err := txn.GetLeafTxnInputState(context.Background())
+	require.NoError(t, err)
 
 	req := execinfrapb.SetupFlowRequest{
 		Version:           execinfra.Version,
@@ -713,7 +715,8 @@ func BenchmarkInfrastructure(b *testing.B) {
 					txn := kv.NewTxnFromProto(
 						context.Background(), tc.Server(0).DB(), tc.Server(0).NodeID(),
 						now, kv.RootTxn, &txnProto)
-					leafInputState := txn.GetLeafTxnInputState(context.Background())
+					leafInputState, err := txn.GetLeafTxnInputState(context.Background())
+					require.NoError(b, err)
 					for i := range reqs {
 						reqs[i] = execinfrapb.SetupFlowRequest{
 							Version:           execinfra.Version,

--- a/pkg/sql/flowinfra/server_test.go
+++ b/pkg/sql/flowinfra/server_test.go
@@ -71,7 +71,10 @@ func TestServer(t *testing.T) {
 	}
 
 	txn := kv.NewTxn(ctx, kvDB, s.NodeID())
-	leafInputState := txn.GetLeafTxnInputState(ctx)
+	leafInputState, err := txn.GetLeafTxnInputState(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	req := &execinfrapb.SetupFlowRequest{
 		Version:           execinfra.Version,

--- a/pkg/sql/internal_test.go
+++ b/pkg/sql/internal_test.go
@@ -562,11 +562,12 @@ func TestInternalExecutorInLeafTxnDoesNotPanic(t *testing.T) {
 
 	rootTxn := kvDB.NewTxn(ctx, "root-txn")
 
-	ltis := rootTxn.GetLeafTxnInputState(ctx)
+	ltis, err := rootTxn.GetLeafTxnInputState(ctx)
+	require.NoError(t, err)
 	leafTxn := kv.NewLeafTxn(ctx, kvDB, roachpb.NodeID(1), ltis)
 
 	ie := s.InternalExecutor().(*sql.InternalExecutor)
-	_, err := ie.ExecEx(
+	_, err = ie.ExecEx(
 		ctx, "leaf-query", leafTxn, sessiondata.RootUserSessionDataOverride, "SELECT 1",
 	)
 	require.NoError(t, err)

--- a/pkg/sql/physicalplan/aggregator_funcs_test.go
+++ b/pkg/sql/physicalplan/aggregator_funcs_test.go
@@ -68,7 +68,10 @@ func runTestFlow(
 ) (rowenc.EncDatumRows, error) {
 	distSQLSrv := srv.DistSQLServer().(*distsql.ServerImpl)
 
-	leafInputState := txn.GetLeafTxnInputState(context.Background())
+	leafInputState, err := txn.GetLeafTxnInputState(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
 	req := execinfrapb.SetupFlowRequest{
 		Version:           execinfra.Version,
 		LeafTxnInputState: leafInputState,

--- a/pkg/sql/routine.go
+++ b/pkg/sql/routine.go
@@ -118,7 +118,7 @@ func (g *routineGenerator) Start(ctx context.Context, txn *kv.Txn) (err error) {
 	// invoking statement are visible to the routine.
 	if g.expr.EnableStepping {
 		prevSteppingMode := txn.ConfigureStepping(ctx, kv.SteppingEnabled)
-		prevSeqNum := txn.GetLeafTxnInputState(ctx).ReadSeqNum
+		prevSeqNum := txn.GetReadSeqNum()
 		defer func() {
 			// If the routine errored, the transaction should be aborted, so
 			// there is no need to reconfigure stepping or revert to the

--- a/pkg/sql/rowexec/inverted_joiner_test.go
+++ b/pkg/sql/rowexec/inverted_joiner_test.go
@@ -775,7 +775,8 @@ func TestInvertedJoinerDrain(t *testing.T) {
 	diskMonitor := execinfra.NewTestDiskMonitor(ctx, st)
 	defer diskMonitor.Stop(ctx)
 	rootTxn := kv.NewTxn(ctx, s.DB(), s.NodeID())
-	leafInputState := rootTxn.GetLeafTxnInputState(ctx)
+	leafInputState, err := rootTxn.GetLeafTxnInputState(ctx)
+	require.NoError(t, err)
 	leafTxn := kv.NewLeafTxn(ctx, s.DB(), s.NodeID(), leafInputState)
 	flowCtx := execinfra.FlowCtx{
 		EvalCtx: &evalCtx,

--- a/pkg/sql/rowexec/joinreader_test.go
+++ b/pkg/sql/rowexec/joinreader_test.go
@@ -1387,7 +1387,8 @@ func TestJoinReaderDrain(t *testing.T) {
 	defer diskMonitor.Stop(ctx)
 
 	rootTxn := kv.NewTxn(ctx, s.DB(), s.NodeID())
-	leafInputState := rootTxn.GetLeafTxnInputState(ctx)
+	leafInputState, err := rootTxn.GetLeafTxnInputState(ctx)
+	require.NoError(t, err)
 	leafTxn := kv.NewLeafTxn(ctx, s.DB(), s.NodeID(), leafInputState)
 
 	flowCtx := execinfra.FlowCtx{

--- a/pkg/sql/rowexec/tablereader_test.go
+++ b/pkg/sql/rowexec/tablereader_test.go
@@ -329,7 +329,10 @@ func TestTableReaderDrain(t *testing.T) {
 	defer evalCtx.Stop(ctx)
 
 	rootTxn := kv.NewTxn(ctx, s.DB(), s.NodeID())
-	leafInputState := rootTxn.GetLeafTxnInputState(ctx)
+	leafInputState, err := rootTxn.GetLeafTxnInputState(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
 	leafTxn := kv.NewLeafTxn(ctx, s.DB(), s.NodeID(), leafInputState)
 	flowCtx := execinfra.FlowCtx{
 		EvalCtx: &evalCtx,

--- a/pkg/sql/rowexec/zigzagjoiner_test.go
+++ b/pkg/sql/rowexec/zigzagjoiner_test.go
@@ -771,7 +771,8 @@ func TestZigzagJoinerDrain(t *testing.T) {
 	defer evalCtx.Stop(ctx)
 
 	rootTxn := kv.NewTxn(ctx, s.DB(), s.NodeID())
-	leafInputState := rootTxn.GetLeafTxnInputState(ctx)
+	leafInputState, err := rootTxn.GetLeafTxnInputState(ctx)
+	require.NoError(t, err)
 	leafTxn := kv.NewLeafTxn(ctx, s.DB(), s.NodeID(), leafInputState)
 	flowCtx := execinfra.FlowCtx{
 		EvalCtx: &evalCtx,

--- a/pkg/sql/sql_cursor.go
+++ b/pkg/sql/sql_cursor.go
@@ -102,10 +102,9 @@ func (p *planner) DeclareCursor(ctx context.Context, s *tree.DeclareCursor) (pla
 			if err != nil {
 				return nil, errors.Wrap(err, "failed to DECLARE CURSOR")
 			}
-			inputState := p.txn.GetLeafTxnInputState(ctx)
 			cursor := &sqlCursor{
 				Rows:       rows,
-				readSeqNum: inputState.ReadSeqNum,
+				readSeqNum: p.txn.GetReadSeqNum(),
 				txn:        p.txn,
 				statement:  statement,
 				created:    timeutil.Now(),
@@ -173,12 +172,11 @@ type fetchNode struct {
 }
 
 func (f *fetchNode) startExec(params runParams) error {
-	state := f.cursor.txn.GetLeafTxnInputState(params.ctx)
 	// We need to make sure that we're reading at the same read sequence number
 	// that we had when we created the cursor, to preserve the "sensitivity"
 	// semantics of cursors, which demand that data written after the cursor
 	// was declared is not visible to the cursor.
-	f.origTxnSeqNum = state.ReadSeqNum
+	f.origTxnSeqNum = f.cursor.txn.GetReadSeqNum()
 	return f.cursor.txn.SetReadSeqNum(f.cursor.readSeqNum)
 }
 


### PR DESCRIPTION
Informs #99269.

This PR includes two refactors with no production behavior changes. They combine to make the reference counting attempted in #99269 easier to implement.

### kv/kvclient: introduce txn.GetReadSeqNum

This commit introduces a new `txn.GetReadSeqNum` method.

It then uses this method to avoid unnecessarily heavyweight calls into GetLeafTxnInputState. It turns out that this removes all production calls into `GetLeafTxnInputState`.

### kv/kvclient: remove GetLeafTxnInputState{OrRejectClient} split

This commit removes the split between the `txn.GetLeafTxnInputState` and `txn.GetLeafTxnInputStateOrRejectClient` methods, consolidating on a single method that behaves like the old `txn.GetLeafTxnInputStateOrRejectClient` method behaved. As of the previous commit, there were no remaining production callers of `txn.GetLeafTxnInputState`.

This split between the two methods was introduced in d8630d00, which was a targeted fix that did not questions whether all callers of `GetLeafTxnInputState` (`GetTxnCoordMeta` at the time) could be switched to have this new behavior. It may have also been more difficult to switch all callers over before c00ea847 and 0461b006.

In consolidating this logic, we also remove the `kv.TxnStatusOpt` enum and simplify the `kv.TxnSender` interface.

Release note: None
