### PR TITLE
sqlproxyccl/acl: fix the TestParsingErrorHandling flake

### DIFF
--- a/pkg/ccl/sqlproxyccl/acl/BUILD.bazel
+++ b/pkg/ccl/sqlproxyccl/acl/BUILD.bazel
@@ -33,6 +33,7 @@ go_test(
     embed = [":acl"],
     tags = ["ccl_test"],
     deps = [
+        "//pkg/testutils",
         "//pkg/util/leaktest",
         "//pkg/util/metric",
         "//pkg/util/timeutil",


### PR DESCRIPTION
This is attempt number two to fix this test flake. This time, rather
than waiting a fixed amount of time before checking the metric, we
check it every 100ms until some fixed timeout, currently 10 seconds.
It shouldn't take anywhere near that long, but it allows us to continue
to check until the metric gets updated.

Fixes #98838.