### PR TITLE
release-23.1: clusterversion: set developmentBranch to false

### DIFF
--- a/docs/generated/settings/settings-for-tenants.txt
+++ b/docs/generated/settings/settings-for-tenants.txt
@@ -293,4 +293,4 @@ trace.opentelemetry.collector	string		address of an OpenTelemetry trace collecto
 trace.snapshot.rate	duration	0s	if non-zero, interval at which background trace snapshots are captured
 trace.span_registry.enabled	boolean	true	if set, ongoing traces can be seen at https://<ui>/#/debug/tracez
 trace.zipkin.collector	string		the address of a Zipkin instance to receive traces, as <host>:<port>. If no port is specified, 9411 will be used.
-version	version	1000022.2-98	set the active cluster version in the format '<major>.<minor>'
+version	version	22.2-98	set the active cluster version in the format '<major>.<minor>'

--- a/docs/generated/settings/settings.html
+++ b/docs/generated/settings/settings.html
@@ -245,6 +245,6 @@
 <tr><td><div id="setting-trace-snapshot-rate" class="anchored"><code>trace.snapshot.rate</code></div></td><td>duration</td><td><code>0s</code></td><td>if non-zero, interval at which background trace snapshots are captured</td></tr>
 <tr><td><div id="setting-trace-span-registry-enabled" class="anchored"><code>trace.span_registry.enabled</code></div></td><td>boolean</td><td><code>true</code></td><td>if set, ongoing traces can be seen at https://&lt;ui&gt;/#/debug/tracez</td></tr>
 <tr><td><div id="setting-trace-zipkin-collector" class="anchored"><code>trace.zipkin.collector</code></div></td><td>string</td><td><code></code></td><td>the address of a Zipkin instance to receive traces, as &lt;host&gt;:&lt;port&gt;. If no port is specified, 9411 will be used.</td></tr>
-<tr><td><div id="setting-version" class="anchored"><code>version</code></div></td><td>version</td><td><code>1000022.2-98</code></td><td>set the active cluster version in the format &#39;&lt;major&gt;.&lt;minor&gt;&#39;</td></tr>
+<tr><td><div id="setting-version" class="anchored"><code>version</code></div></td><td>version</td><td><code>22.2-98</code></td><td>set the active cluster version in the format &#39;&lt;major&gt;.&lt;minor&gt;&#39;</td></tr>
 </tbody>
 </table>

--- a/pkg/cli/testdata/declarative-rules/deprules
+++ b/pkg/cli/testdata/declarative-rules/deprules
@@ -1,6 +1,6 @@
 dep
 ----
-debug declarative-print-rules 1000022.2-98 dep
+debug declarative-print-rules 22.2-98 dep
 deprules
 ----
 - name: 'CheckConstraint transitions to ABSENT uphold 2-version invariant: PUBLIC->VALIDATED'

--- a/pkg/cli/testdata/declarative-rules/invalid_version
+++ b/pkg/cli/testdata/declarative-rules/invalid_version
@@ -4,4 +4,4 @@ invalid_version
 debug declarative-print-rules 1.1 op
 unsupported version number, the supported versions are: 
  latest
- 1000022.2
+ 22.2

--- a/pkg/cli/testdata/declarative-rules/oprules
+++ b/pkg/cli/testdata/declarative-rules/oprules
@@ -1,6 +1,6 @@
 op
 ----
-debug declarative-print-rules 1000022.2-98 op
+debug declarative-print-rules 22.2-98 op
 rules
 ----
 []

--- a/pkg/clusterversion/cockroach_versions.go
+++ b/pkg/clusterversion/cockroach_versions.go
@@ -914,10 +914,9 @@ var rawVersionsSingleton = keyedVersions{
 // frozen. It can be forced to a specific value in two circumstances:
 // 1. forced to `false` on development branches: this is used for
 // upgrade testing purposes and should never be done in real clusters;
-// 2. forced to `false` on release branches: this allows running a
+// 2. forced to `true` on release branches: this allows running a
 // release binary in a dev cluster.
-var developmentBranch = !envutil.EnvOrDefaultBool("COCKROACH_TESTING_FORCE_RELEASE_BRANCH", false) ||
-	envutil.EnvOrDefaultBool("COCKROACH_FORCE_DEV_VERSION", false)
+var developmentBranch = envutil.EnvOrDefaultBool("COCKROACH_FORCE_DEV_VERSION", false)
 
 const (
 	// finalVersion should be set on a release branch to the minted final cluster

--- a/pkg/sql/logictest/testdata/logic_test/crdb_internal
+++ b/pkg/sql/logictest/testdata/logic_test/crdb_internal
@@ -566,7 +566,7 @@ select crdb_internal.get_vmodule()
 query T
 select regexp_replace(crdb_internal.node_executable_version()::string, '(-\d+)?$', '');
 ----
-1000022.2
+22.2
 
 query ITTT colnames
 select node_id, component, field, regexp_replace(regexp_replace(value, '^\d+$', '<port>'), e':\\d+', ':<port>') as value from crdb_internal.node_runtime_info
@@ -720,7 +720,7 @@ SELECT * FROM crdb_internal.check_consistency(true, b'\x02', b'\x04')
 query T
 select regexp_replace(crdb_internal.node_executable_version()::string, '(-\d+)?$', '');
 ----
-1000022.2
+22.2
 
 user root
 

--- a/pkg/sql/logictest/testdata/logic_test/mixed_version_can_login
+++ b/pkg/sql/logictest/testdata/logic_test/mixed_version_can_login
@@ -21,7 +21,7 @@ SELECT crdb_internal.create_tenant(1001)
 upgrade 1
 
 query B
-SELECT crdb_internal.node_executable_version() SIMILAR TO '1000022.2-%'
+SELECT crdb_internal.node_executable_version() SIMILAR TO '22.2-%'
 ----
 true
 
@@ -34,7 +34,7 @@ SELECT crdb_internal.node_executable_version()
 user testuser nodeidx=0
 
 query B
-SELECT crdb_internal.node_executable_version() SIMILAR TO '1000022.2-%'
+SELECT crdb_internal.node_executable_version() SIMILAR TO '22.2-%'
 ----
 true
 
@@ -42,7 +42,7 @@ true
 user root nodeidx=1
 
 query B
-SELECT crdb_internal.node_executable_version() SIMILAR TO '1000022.2-%'
+SELECT crdb_internal.node_executable_version() SIMILAR TO '22.2-%'
 ----
 true
 
@@ -65,7 +65,7 @@ SELECT crdb_internal.node_executable_version()
 upgrade 2
 
 query B
-SELECT crdb_internal.node_executable_version() SIMILAR TO '1000022.2-%'
+SELECT crdb_internal.node_executable_version() SIMILAR TO '22.2-%'
 ----
 true
 

--- a/pkg/sql/logictest/testdata/logic_test/mixed_version_range_tombstones
+++ b/pkg/sql/logictest/testdata/logic_test/mixed_version_range_tombstones
@@ -22,7 +22,7 @@ false
 upgrade 0
 
 query B nodeidx=0
-SELECT crdb_internal.node_executable_version() SIMILAR TO '1000022.2-%'
+SELECT crdb_internal.node_executable_version() SIMILAR TO '22.2-%'
 ----
 true
 

--- a/pkg/sql/logictest/testdata/logic_test/mixed_version_role_members_user_ids
+++ b/pkg/sql/logictest/testdata/logic_test/mixed_version_role_members_user_ids
@@ -47,7 +47,7 @@ upgrade 1
 # Test that there are no problems creating role memberships on a mixed 22.2/23.1 cluster.
 
 query B nodeidx=1
-SELECT crdb_internal.node_executable_version() SIMILAR TO '1000022.2-%'
+SELECT crdb_internal.node_executable_version() SIMILAR TO '22.2-%'
 ----
 true
 
@@ -83,16 +83,16 @@ upgrade 2
 # Verify that all nodes are now running 23.1 binaries.
 
 query B nodeidx=0
-SELECT crdb_internal.node_executable_version() SIMILAR TO '1000022.2-%'
+SELECT crdb_internal.node_executable_version() SIMILAR TO '22.2-%'
 ----
 true
 
 query B nodeidx=1
-SELECT crdb_internal.node_executable_version() SIMILAR TO '1000022.2-%'
+SELECT crdb_internal.node_executable_version() SIMILAR TO '22.2-%'
 ----
 true
 
 query B nodeidx=2
-SELECT crdb_internal.node_executable_version() SIMILAR TO '1000022.2-%'
+SELECT crdb_internal.node_executable_version() SIMILAR TO '22.2-%'
 ----
 true


### PR DESCRIPTION
This PR sets developmentBranch to false, which must be set before selected a beta.1 candidate.

Release note: none.
Epic: REL-283
Release justification: Infra-only change. Denotes `release-23.1` as a release branch/versions.

Backport 1/4 commits from #99128.

/cc @cockroachdb/release

---

As part of the 23.1 stability period tasks, this PR preps the 23.1 release branch and initializes 23.2 development, as per this release runbook: [Prep Release and Define Start of Development for Next Release](https://cockroachlabs.atlassian.net/wiki/spaces/RE/pages/2924740768/Prep+Release+and+Define+Start+of+Development+for+Next+Release).

This PR will contain 4 commits:

|commit|backported when|
|-|-|
|1. Set developmentBranch to false|soon after branch cut / before selecting beta.1 candidate|
|2. Update version.txt to alpha.8 (next release)|soon after branch cut / before selecting ~beta.1~ this week's alpha.8 candidate|
|3. Mint the previous release|should be final backport before the final RC / before selecting final RC candidate|
|4. Define the start of 23.2 development and placeholder key|_(not backported)_|


Release note: none.
Epic: REL-283
