### PR TITLE
ui: show list of fingerprints for non-admins

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/api/indexDetailsApi.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/api/indexDetailsApi.ts
@@ -100,7 +100,7 @@ export async function getStatementsUsingIndex({
   }
 
   const selectStatements = {
-    sql: `SELECT * FROM system.statement_statistics 
+    sql: `SELECT * FROM crdb_internal.statement_statistics_persisted 
             WHERE $1::jsonb <@ indexes_usage
                 AND app_name NOT LIKE '${INTERNAL_APP_NAME_PREFIX}%' 
                 ${whereClause}

--- a/pkg/ui/workspaces/cluster-ui/src/indexDetailsPage/indexDetailsPage.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/indexDetailsPage/indexDetailsPage.tsx
@@ -585,101 +585,99 @@ export class IndexDetailsPage extends React.Component<
                 </SummaryCard>
               </Col>
             </Row>
-            {hasAdminRole && (
-              <Row gutter={24} className={cx("row-spaced", "bottom-space")}>
-                <Col className="gutter-row" span={24}>
-                  <SummaryCard className={cx("summary-card--row")}>
-                    <Heading type="h5">Index Usage</Heading>
-                    <PageConfig whiteBkg={true}>
-                      <PageConfigItem>
-                        <Search
-                          onSubmit={this.onSubmitSearchField}
-                          onClear={this.onClearSearchField}
-                          defaultValue={search}
-                        />
-                      </PageConfigItem>
-                      <PageConfigItem>
-                        <Filter
-                          onSubmitFilters={this.onSubmitFilters}
-                          appNames={apps}
-                          regions={regions}
-                          nodes={nodes.map(n => "n" + n)}
-                          activeFilters={activeFilters}
-                          filters={filters}
-                          hideTimeLabel={true}
-                          showDB={false}
-                          showSqlType={true}
-                          showScan={true}
-                          showRegions={regions.length > 1}
-                          showNodes={!isTenant && nodes.length > 1}
-                        />
-                      </PageConfigItem>
-                      <PageConfigItem className={commonStyles("separator")}>
-                        <TimeScaleDropdown
-                          options={timeScale1hMinOptions}
-                          currentScale={this.props.timeScale}
-                          setTimeScale={this.changeTimeScale}
-                        />
-                      </PageConfigItem>
-                    </PageConfig>
-                    <Loading
-                      loading={statements == null}
-                      page="index details"
-                      error={this.state.lastStatementsError}
-                      renderError={() =>
-                        LoadingError({
-                          statsType: "statements",
-                          timeout: this.state.lastStatementsError?.message
-                            ?.toLowerCase()
-                            .includes("timeout"),
-                        })
-                      }
-                    >
-                      <TableStatistics
-                        pagination={stmtPagination}
-                        totalCount={filteredStmts.length}
-                        arrayItemName={
-                          "most executed statement fingerprints using this index"
-                        }
+            <Row gutter={24} className={cx("row-spaced", "bottom-space")}>
+              <Col className="gutter-row" span={24}>
+                <SummaryCard className={cx("summary-card--row")}>
+                  <Heading type="h5">Index Usage</Heading>
+                  <PageConfig whiteBkg={true}>
+                    <PageConfigItem>
+                      <Search
+                        onSubmit={this.onSubmitSearchField}
+                        onClear={this.onClearSearchField}
+                        defaultValue={search}
+                      />
+                    </PageConfigItem>
+                    <PageConfigItem>
+                      <Filter
+                        onSubmitFilters={this.onSubmitFilters}
+                        appNames={apps}
+                        regions={regions}
+                        nodes={nodes.map(n => "n" + n)}
                         activeFilters={activeFilters}
-                        onClearFilters={this.onClearFilters}
+                        filters={filters}
+                        hideTimeLabel={true}
+                        showDB={false}
+                        showSqlType={true}
+                        showScan={true}
+                        showRegions={regions.length > 1}
+                        showNodes={!isTenant && nodes.length > 1}
                       />
-                      <SortedTable
-                        data={filteredStmts}
-                        columns={makeStatementsColumns(
-                          statements,
-                          [],
-                          calculateTotalWorkload(statements),
-                          "statement",
-                          isTenant,
-                          hasViewActivityRedactedRole,
-                        ).filter(c => !(isTenant && c.hideIfTenant))}
-                        className={stmtCx("statements-table")}
-                        tableWrapperClassName={cx("table-scroll")}
-                        sortSetting={stmtSortSetting}
-                        onChangeSortSetting={this.onChangeSortSetting}
-                        pagination={stmtPagination}
-                        renderNoResult={
-                          <EmptyStatementsPlaceholder
-                            isEmptySearchResults={
-                              (search?.length > 0 || activeFilters > 0) &&
-                              filteredStmts?.length === 0
-                            }
-                            statementView={StatementViewType.USING_INDEX}
-                          />
-                        }
+                    </PageConfigItem>
+                    <PageConfigItem className={commonStyles("separator")}>
+                      <TimeScaleDropdown
+                        options={timeScale1hMinOptions}
+                        currentScale={this.props.timeScale}
+                        setTimeScale={this.changeTimeScale}
                       />
-                      <Pagination
-                        pageSize={stmtPagination.pageSize}
-                        current={stmtPagination.current}
-                        total={filteredStmts.length}
-                        onChange={this.onChangePage}
-                      />
-                    </Loading>
-                  </SummaryCard>
-                </Col>
-              </Row>
-            )}
+                    </PageConfigItem>
+                  </PageConfig>
+                  <Loading
+                    loading={statements == null}
+                    page="index details"
+                    error={this.state.lastStatementsError}
+                    renderError={() =>
+                      LoadingError({
+                        statsType: "statements",
+                        timeout: this.state.lastStatementsError?.message
+                          ?.toLowerCase()
+                          .includes("timeout"),
+                      })
+                    }
+                  >
+                    <TableStatistics
+                      pagination={stmtPagination}
+                      totalCount={filteredStmts.length}
+                      arrayItemName={
+                        "most executed statement fingerprints using this index"
+                      }
+                      activeFilters={activeFilters}
+                      onClearFilters={this.onClearFilters}
+                    />
+                    <SortedTable
+                      data={filteredStmts}
+                      columns={makeStatementsColumns(
+                        statements,
+                        [],
+                        calculateTotalWorkload(statements),
+                        "statement",
+                        isTenant,
+                        hasViewActivityRedactedRole,
+                      ).filter(c => !(isTenant && c.hideIfTenant))}
+                      className={stmtCx("statements-table")}
+                      tableWrapperClassName={cx("table-scroll")}
+                      sortSetting={stmtSortSetting}
+                      onChangeSortSetting={this.onChangeSortSetting}
+                      pagination={stmtPagination}
+                      renderNoResult={
+                        <EmptyStatementsPlaceholder
+                          isEmptySearchResults={
+                            (search?.length > 0 || activeFilters > 0) &&
+                            filteredStmts?.length === 0
+                          }
+                          statementView={StatementViewType.USING_INDEX}
+                        />
+                      }
+                    />
+                    <Pagination
+                      pageSize={stmtPagination.pageSize}
+                      current={stmtPagination.current}
+                      total={filteredStmts.length}
+                      onChange={this.onChangePage}
+                    />
+                  </Loading>
+                </SummaryCard>
+              </Col>
+            </Row>
           </section>
         </div>
       </div>


### PR DESCRIPTION
Previously, we were not showing the list of most
used fingerprints per index to non-admins, because it was using a system table to get the data.
This commit updates the api to use a view on top
of the system table that have the right permissions.

Fixes #99137

Release note (ui change): Show to non-admins (previously was only to admins) the list of used fingerprints
per index on the index details page.