### PR TITLE
sql: fix internal error when calling ts_rank with array longer than 4

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/tsvector
+++ b/pkg/sql/logictest/testdata/logic_test/tsvector
@@ -334,3 +334,13 @@ LIMIT 10
 ----
 0.075990885  0.15198177  0.00042217158  8.555783e-05  'ari':6 'base':3,13 'concept':17 'data':12,21 'form':10 'introduc':24 'model':2 'n':5 'normal':9 'relat':7,14 'sublanguag':22 'univers':20
 0.06079271   0.12158542  0.0003101669   6.095758e-05  '2':3 'appli':15 'certain':4 'consist':22 'discuss':13 'infer':11 'logic':10 'model':27 'oper':5 'problem':18 'redund':20 'relat':7 'section':2 'user':25
+
+# Regression test for #99334. Truncate arrays longer than 4 elements that are
+# passed to ts_rank to avoid an internal error.
+query F
+SELECT
+	ts_rank(ARRAY[1.0039,2.37098,-0.022,0.4277,0.00387]::FLOAT8[], '''AoS'' ''HXfAX'' ''HeWdr'' ''MIHLoJM'' ''UfIQOM'' ''bw'' ''o'''::TSVECTOR, '''QqJVCgwp'''::TSQUERY)
+LIMIT
+	2
+----
+0

--- a/pkg/sql/sem/builtins/tsearch_builtins.go
+++ b/pkg/sql/sem/builtins/tsearch_builtins.go
@@ -337,7 +337,7 @@ func getWeights(arr *tree.DArray) ([]float32, error) {
 	if arr.Len() < len(ret) {
 		return ret, pgerror.New(pgcode.ArraySubscript, "array of weight is too short (must be at least 4)")
 	}
-	for i, d := range arr.Array {
+	for i, d := range arr.Array[:len(ret)] {
 		if d == tree.DNull {
 			return ret, pgerror.New(pgcode.NullValueNotAllowed, "array of weight must not contain null")
 		}


### PR DESCRIPTION
Prior to this commit, an internal error could occur when an array longer than length 4 was passed to `ts_rank`. This commit fixes the error by truncating the array to length 4.

Fixes #99334

Release note: None