### PR TITLE
cluster-ui: fix table details create statement query

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/api/tableDetailsApi.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/api/tableDetailsApi.ts
@@ -35,7 +35,7 @@ type ZoneConfigLevelType = cockroach.server.serverpb.ZoneConfigurationLevel;
 export function newTableDetailsResponse(): TableDetailsResponse {
   return {
     idResp: { table_id: "" },
-    createStmtResp: { statement: "" },
+    createStmtResp: { create_statement: "" },
     grantsResp: { grants: [] },
     schemaDetails: { columns: [], indexes: [] },
     zoneConfigResp: {
@@ -110,7 +110,7 @@ const getTableId: TableDetailsQuery<TableIdRow> = {
 };
 
 // Table create statement.
-type TableCreateStatementRow = { statement: string };
+type TableCreateStatementRow = { create_statement: string };
 
 const getTableCreateStatement: TableDetailsQuery<TableCreateStatementRow> = {
   createStmt: (dbName, tableName) => {
@@ -129,7 +129,8 @@ const getTableCreateStatement: TableDetailsQuery<TableCreateStatementRow> = {
     resp: TableDetailsResponse,
   ) => {
     if (!txnResultIsEmpty(txn_result)) {
-      resp.createStmtResp.statement = txn_result.rows[0].statement;
+      resp.createStmtResp.create_statement =
+        txn_result.rows[0].create_statement;
     } else {
       txn_result.error = new Error(
         "getTableCreateStatement: unexpected empty results",

--- a/pkg/ui/workspaces/db-console/src/util/api.spec.ts
+++ b/pkg/ui/workspaces/db-console/src/util/api.spec.ts
@@ -305,7 +305,7 @@ describe("rest api", function () {
           // Table schema details query
           { rows: [{ columns: ["a", "b", "c"], indexes: ["d", "e"] }] },
           // Table create statement query
-          { rows: [{ statement: "mock create stmt" }] },
+          { rows: [{ create_statement: "mock create stmt" }] },
           // Table zone config statement query
           { rows: [{ raw_config_sql: "mock zone config stmt" }] },
           // Table heuristics query
@@ -359,7 +359,7 @@ describe("rest api", function () {
           expect(resp.results.grantsResp.grants.length).toBe(1);
           expect(resp.results.schemaDetails.columns.length).toBe(3);
           expect(resp.results.schemaDetails.indexes.length).toBe(2);
-          expect(resp.results.createStmtResp.statement).toBe(
+          expect(resp.results.createStmtResp.create_statement).toBe(
             "mock create stmt",
           );
           expect(resp.results.zoneConfigResp.configure_zone_statement).toBe(

--- a/pkg/ui/workspaces/db-console/src/views/databases/databaseTablePage/redux.spec.ts
+++ b/pkg/ui/workspaces/db-console/src/views/databases/databaseTablePage/redux.spec.ts
@@ -226,7 +226,7 @@ describe("Database Table Page", function () {
           ],
         },
         // Table create statement query
-        { rows: [{ statement: "CREATE TABLE foo" }] },
+        { rows: [{ create_statement: "CREATE TABLE foo" }] },
         // Table zone config statement query
         {},
         // Table heuristics query

--- a/pkg/ui/workspaces/db-console/src/views/databases/databaseTablePage/redux.ts
+++ b/pkg/ui/workspaces/db-console/src/views/databases/databaseTablePage/redux.ts
@@ -150,7 +150,8 @@ export const mapStateToProps = createSelector(
         loading: !!details?.inFlight,
         loaded: !!details?.valid,
         lastError: details?.lastError,
-        createStatement: details?.data?.results.createStmtResp.statement || "",
+        createStatement:
+          details?.data?.results.createStmtResp.create_statement || "",
         replicaCount:
           details?.data?.results.stats.replicaData.replicaCount || 0,
         indexNames: _.uniq(details?.data?.results.schemaDetails.indexes),


### PR DESCRIPTION
Previously, the create statement query was expecting a `statement` field, however, the correct field was `create_statement`. This discrepancy would cause the table details page to load with a blank create statement. The change in this PR rectifies this discrepancy.

Release note (ui change, bug fix): fix a bug where the table's create statement would not display correctly on the table details page.