### PR TITLE
roachtest: expand tag functionality to allow filtering by conjunctive…

### DIFF
--- a/build/teamcity/cockroach/nightlies/roachtest_nightly_impl.sh
+++ b/build/teamcity/cockroach/nightlies/roachtest_nightly_impl.sh
@@ -36,4 +36,4 @@ build/teamcity-roachtest-invoke.sh \
   --artifacts-literal="${LITERAL_ARTIFACTS_DIR:-}" \
   --slack-token="${SLACK_TOKEN}" \
   $fips_flag \
-  "${TESTS}"
+  "${TESTS}" "${FILTER}"

--- a/build/teamcity/cockroach/nightlies/roachtest_nightly_impl.sh
+++ b/build/teamcity/cockroach/nightlies/roachtest_nightly_impl.sh
@@ -36,4 +36,4 @@ build/teamcity-roachtest-invoke.sh \
   --artifacts-literal="${LITERAL_ARTIFACTS_DIR:-}" \
   --slack-token="${SLACK_TOKEN}" \
   $fips_flag \
-  "${TESTS}" "${FILTER}"
+  "${TESTS}" ${FILTER}

--- a/build/teamcity/util/roachtest_util.sh
+++ b/build/teamcity/util/roachtest_util.sh
@@ -57,14 +57,13 @@ trap upload_stats EXIT
 PARALLELISM=16
 CPUQUOTA=1024
 TESTS="${TESTS-}"
+FILTER="${FILTER-}"
 case "${CLOUD}" in
   gce)
     ;;
   aws)
-    if [ -z "${TESTS}" ]; then
-      # NB: anchor ycsb to beginning of line to avoid matching `zfs/ycsb/*` which
-      # isn't supported on AWS at time of writing.
-      TESTS="awsdms|kv(0|95)|^ycsb|tpcc/(headroom/n4cpu16)|tpccbench/(nodes=3/cpu=16)|scbench/randomload/(nodes=3/ops=2000/conc=1)|backup/(KMS/AWS/n3cpu4)|restore/.*/aws"
+    if [ -z "${FILTER}" ]; then
+      FILTER="tag:aws"
     fi
     ;;
   *)

--- a/build/teamcity/util/roachtest_util.sh
+++ b/build/teamcity/util/roachtest_util.sh
@@ -60,6 +60,13 @@ TESTS="${TESTS-}"
 FILTER="${FILTER-}"
 case "${CLOUD}" in
   gce)
+      # Confusing due to how we've handled tags in the past where it has been assumed that all tests should
+      # be run on GCE. Now with refactoring of how tags are handled, we need:
+      # - "default" to ensure we select tests that don't have any user specified tags (preserve old behavior)
+      # - "aws" to ensure we select tests that now no longer have "default" because they have the "aws" tag
+      # Ideally, refactor the tags themselves to be explicit about what cloud they are for and when they can run.
+      # https://github.com/cockroachdb/cockroach/issues/100605
+      FILTER="tag:aws tag:default"
     ;;
   aws)
     if [ -z "${FILTER}" ]; then

--- a/pkg/cmd/roachtest/README.md
+++ b/pkg/cmd/roachtest/README.md
@@ -27,6 +27,15 @@ acceptance/cli/node-status [server]
 [...]
 ```
 
+The list can be filtered by passing a regular expression to the `list` command which will match against the test name.
+Multiple `tag:` prefixed args can be specified to further narrow by which tags are present for a test. The following 
+will list all tests with name containing `admission` where test tags match `(weekly && aws) || my-tag`
+
+```
+roachtest list admission tag:weekly,aws tag:my-tag
+```
+
+
 ## Getting the binaries
 
 To run a test, the `roachtest run` command is used. Since a test typically

--- a/pkg/cmd/roachtest/main.go
+++ b/pkg/cmd/roachtest/main.go
@@ -179,15 +179,25 @@ Use --bench to list benchmarks instead of tests.
 
 Each test has a set of tags. The tags are used to skip tests which don't match
 the tag filter. The tag filter is specified by specifying a pattern with the
-"tag:" prefix. The default tag filter is "tag:default" which matches any test
-that has the "default" tag. Note that tests are selected based on their name,
-and skipped based on their tag.
+"tag:" prefix. 
+
+If multiple "tag:" patterns are specified, the test must match at
+least one of them.
+
+Within a single "tag:" pattern, multiple tags can be specified by separating them
+with a comma. In this case, the test must match all of the tags.
 
 Examples:
 
    roachtest list acceptance copy/bank/.*false
-   roachtest list tag:acceptance
+   roachtest list tag:owner-kv
    roachtest list tag:weekly
+
+   # match weekly kv owned tests
+   roachtest list tag:owner-kv,weekly
+
+   # match weekly kv owner tests or aws tests
+   roachtest list tag:owner-kv,weekly tag:aws
 `,
 		RunE: func(_ *cobra.Command, args []string) error {
 			r := makeTestRegistry(cloud, instanceType, zonesF, localSSDArg)

--- a/pkg/cmd/roachtest/main.go
+++ b/pkg/cmd/roachtest/main.go
@@ -220,6 +220,8 @@ Examples:
 	}
 	listCmd.Flags().BoolVar(
 		&listBench, "bench", false, "list benchmarks instead of tests")
+	listCmd.Flags().StringVar(
+		&cloud, "cloud", cloud, "cloud provider to use (aws, azure, or gce)")
 
 	var runCmd = &cobra.Command{
 		// Don't display usage when tests fail.
@@ -405,6 +407,9 @@ func runTests(register func(registry.Registry), cfg cliCfg) error {
 		return fmt.Errorf("--count (%d) must by greater than 0", cfg.count)
 	}
 	r := makeTestRegistry(cloud, instanceType, zonesF, localSSDArg)
+
+	// actual registering of tests
+	// TODO: don't register if we can't run on the specified registry cloud
 	register(&r)
 	cr := newClusterRegistry()
 	stopper := stop.NewStopper()

--- a/pkg/cmd/roachtest/registry/test_spec.go
+++ b/pkg/cmd/roachtest/registry/test_spec.go
@@ -48,7 +48,7 @@ type TestSpec struct {
 	// Tags is a set of tags associated with the test that allow grouping
 	// tests. If no tags are specified, the set ["default"] is automatically
 	// given.
-	Tags []string
+	Tags map[string]struct{}
 	// Cluster provides the specification for the cluster to use for the test.
 	Cluster spec.ClusterSpec
 	// NativeLibs specifies the native libraries required to be present on
@@ -137,10 +137,9 @@ func (t *TestSpec) Match(filter *TestFilter) MatchType {
 		return Matched
 	}
 
-	testTags := stringSliceToSet(t.Tags)
 	for tag := range filter.Tags {
 		// If the tag is a single CSV e.g. "foo,bar,baz", we match all the tags
-		if matchesAll(testTags, strings.Split(tag, ",")) {
+		if matchesAll(t.Tags, strings.Split(tag, ",")) {
 			return Matched
 		}
 	}
@@ -172,9 +171,10 @@ func matchesAll(testTags map[string]struct{}, filterTags []string) bool {
 	return true
 }
 
-func stringSliceToSet(slice []string) map[string]struct{} {
+// Tags returns a set of strings.
+func Tags(values ...string) map[string]struct{} {
 	set := make(map[string]struct{})
-	for _, s := range slice {
+	for _, s := range values {
 		set[s] = struct{}{}
 	}
 	return set

--- a/pkg/cmd/roachtest/registry/test_spec.go
+++ b/pkg/cmd/roachtest/registry/test_spec.go
@@ -13,6 +13,7 @@ package registry
 import (
 	"context"
 	"regexp"
+	"strings"
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
@@ -131,17 +132,19 @@ func (t *TestSpec) Match(filter *TestFilter) MatchType {
 	if !filter.Name.MatchString(t.Name) {
 		return FailedFilter
 	}
-	if len(t.Tags) == 0 {
-		if !filter.Tag.MatchString("default") {
-			return FailedTags
-		}
+
+	if len(filter.Tags) == 0 {
 		return Matched
 	}
-	for _, t := range t.Tags {
-		if filter.Tag.MatchString(t) {
+
+	testTags := stringSliceToSet(t.Tags)
+	for tag := range filter.Tags {
+		// If the tag is a single CSV e.g. "foo,bar,baz", we match all the tags
+		if matchesAll(testTags, strings.Split(tag, ",")) {
 			return Matched
 		}
 	}
+
 	return FailedTags
 }
 
@@ -151,4 +154,28 @@ func (t *TestSpec) Match(filter *TestFilter) MatchType {
 func PromSub(raw string) string {
 	invalidPromRE := regexp.MustCompile("[^a-zA-Z0-9_]")
 	return invalidPromRE.ReplaceAllLiteralString(raw, "_")
+}
+
+func matchesAll(testTags map[string]struct{}, filterTags []string) bool {
+	for _, tag := range filterTags {
+		negate := false
+		if tag[0] == '!' {
+			negate = true
+			tag = tag[1:]
+		}
+		_, tagExists := testTags[tag]
+
+		if negate == tagExists {
+			return false
+		}
+	}
+	return true
+}
+
+func stringSliceToSet(slice []string) map[string]struct{} {
+	set := make(map[string]struct{})
+	for _, s := range slice {
+		set[s] = struct{}{}
+	}
+	return set
 }

--- a/pkg/cmd/roachtest/test_registry.go
+++ b/pkg/cmd/roachtest/test_registry.go
@@ -115,9 +115,9 @@ func (r *testRegistryImpl) prepareSpec(spec *registry.TestSpec) error {
 		return fmt.Errorf(`%s: unknown owner [%s]`, spec.Name, spec.Owner)
 	}
 	if len(spec.Tags) == 0 {
-		spec.Tags = []string{registry.DefaultTag}
+		spec.Tags = registry.Tags(registry.DefaultTag)
 	}
-	spec.Tags = append(spec.Tags, "owner-"+string(spec.Owner))
+	spec.Tags["owner-"+string(spec.Owner)] = struct{}{}
 
 	// At the time of writing, we expect the roachtest job to finish within 24h
 	// and have corresponding timeouts set up in CI. Since each individual test
@@ -127,10 +127,8 @@ func (r *testRegistryImpl) prepareSpec(spec *registry.TestSpec) error {
 	const maxTimeout = 18 * time.Hour
 	if spec.Timeout > maxTimeout {
 		var weekly bool
-		for _, tag := range spec.Tags {
-			if tag == "weekly" {
-				weekly = true
-			}
+		if _, ok := spec.Tags["weekly"]; ok {
+			weekly = true
 		}
 		if !weekly {
 			return fmt.Errorf(

--- a/pkg/cmd/roachtest/test_runner.go
+++ b/pkg/cmd/roachtest/test_runner.go
@@ -899,8 +899,10 @@ func (r *testRunner) runTest(
 				shout(ctx, l, stdout, "--- PASS: %s (%s)", runID, durationStr)
 			}
 
-			shout(ctx, l, stdout, "##teamcity[testFinished name='%s' flowId='%s' duration='%d']",
-				t.Name(), runID, t.duration().Milliseconds())
+			if teamCity {
+				shout(ctx, l, stdout, "##teamcity[testFinished name='%s' flowId='%s' duration='%d']",
+					t.Name(), runID, t.duration().Milliseconds())
+			}
 		}
 
 		if teamCity {

--- a/pkg/cmd/roachtest/test_test.go
+++ b/pkg/cmd/roachtest/test_test.go
@@ -55,15 +55,24 @@ func TestMatchOrSkip(t *testing.T) {
 		expected registry.MatchType
 	}{
 		{nil, "foo", nil, registry.Matched},
-		{nil, "foo", []string{"bar"}, registry.FailedTags},
-		{[]string{"tag:b"}, "foo", []string{"bar"}, registry.Matched},
+		{nil, "foo", []string{"bar"}, registry.Matched},
+		{[]string{"tag:bar"}, "foo", []string{"bar"}, registry.Matched},
+		// Partial tag match is not supported
+		{[]string{"tag:b"}, "foo", []string{"bar"}, registry.FailedTags},
 		{[]string{"tag:b"}, "foo", nil, registry.FailedTags},
-		{[]string{"tag:default"}, "foo", nil, registry.Matched},
 		{[]string{"tag:f"}, "foo", []string{"bar"}, registry.FailedTags},
-		{[]string{"f"}, "foo", []string{"bar"}, registry.FailedTags},
+		// Specifying no tag filters matches all tags.
+		{[]string{"f"}, "foo", []string{"bar"}, registry.Matched},
 		{[]string{"f"}, "bar", []string{"bar"}, registry.FailedFilter},
-		{[]string{"f", "tag:b"}, "foo", []string{"bar"}, registry.Matched},
+		{[]string{"f", "tag:bar"}, "foo", []string{"bar"}, registry.Matched},
+		{[]string{"f", "tag:b"}, "foo", []string{"bar"}, registry.FailedTags},
 		{[]string{"f", "tag:f"}, "foo", []string{"bar"}, registry.FailedTags},
+		// Match tests that have both tags 'abc' and 'bar'
+		{[]string{"f", "tag:abc,bar"}, "foo", []string{"abc", "bar"}, registry.Matched},
+		{[]string{"f", "tag:abc,bar"}, "foo", []string{"abc"}, registry.FailedTags},
+		// Match tests that have tag 'abc' but not 'bar'
+		{[]string{"f", "tag:abc,!bar"}, "foo", []string{"abc"}, registry.Matched},
+		{[]string{"f", "tag:abc,!bar"}, "foo", []string{"abc", "bar"}, registry.FailedTags},
 	}
 	for _, c := range testCases {
 		t.Run("", func(t *testing.T) {

--- a/pkg/cmd/roachtest/test_test.go
+++ b/pkg/cmd/roachtest/test_test.go
@@ -51,28 +51,28 @@ func TestMatchOrSkip(t *testing.T) {
 	testCases := []struct {
 		filter   []string
 		name     string
-		tags     []string
+		tags     map[string]struct{}
 		expected registry.MatchType
 	}{
 		{nil, "foo", nil, registry.Matched},
-		{nil, "foo", []string{"bar"}, registry.Matched},
-		{[]string{"tag:bar"}, "foo", []string{"bar"}, registry.Matched},
+		{nil, "foo", registry.Tags("bar"), registry.Matched},
+		{[]string{"tag:bar"}, "foo", registry.Tags("bar"), registry.Matched},
 		// Partial tag match is not supported
-		{[]string{"tag:b"}, "foo", []string{"bar"}, registry.FailedTags},
+		{[]string{"tag:b"}, "foo", registry.Tags("bar"), registry.FailedTags},
 		{[]string{"tag:b"}, "foo", nil, registry.FailedTags},
-		{[]string{"tag:f"}, "foo", []string{"bar"}, registry.FailedTags},
+		{[]string{"tag:f"}, "foo", registry.Tags("bar"), registry.FailedTags},
 		// Specifying no tag filters matches all tags.
-		{[]string{"f"}, "foo", []string{"bar"}, registry.Matched},
-		{[]string{"f"}, "bar", []string{"bar"}, registry.FailedFilter},
-		{[]string{"f", "tag:bar"}, "foo", []string{"bar"}, registry.Matched},
-		{[]string{"f", "tag:b"}, "foo", []string{"bar"}, registry.FailedTags},
-		{[]string{"f", "tag:f"}, "foo", []string{"bar"}, registry.FailedTags},
+		{[]string{"f"}, "foo", registry.Tags("bar"), registry.Matched},
+		{[]string{"f"}, "bar", registry.Tags("bar"), registry.FailedFilter},
+		{[]string{"f", "tag:bar"}, "foo", registry.Tags("bar"), registry.Matched},
+		{[]string{"f", "tag:b"}, "foo", registry.Tags("bar"), registry.FailedTags},
+		{[]string{"f", "tag:f"}, "foo", registry.Tags("bar"), registry.FailedTags},
 		// Match tests that have both tags 'abc' and 'bar'
-		{[]string{"f", "tag:abc,bar"}, "foo", []string{"abc", "bar"}, registry.Matched},
-		{[]string{"f", "tag:abc,bar"}, "foo", []string{"abc"}, registry.FailedTags},
+		{[]string{"f", "tag:abc,bar"}, "foo", registry.Tags("abc", "bar"), registry.Matched},
+		{[]string{"f", "tag:abc,bar"}, "foo", registry.Tags("abc"), registry.FailedTags},
 		// Match tests that have tag 'abc' but not 'bar'
-		{[]string{"f", "tag:abc,!bar"}, "foo", []string{"abc"}, registry.Matched},
-		{[]string{"f", "tag:abc,!bar"}, "foo", []string{"abc", "bar"}, registry.FailedTags},
+		{[]string{"f", "tag:abc,!bar"}, "foo", registry.Tags("abc"), registry.Matched},
+		{[]string{"f", "tag:abc,!bar"}, "foo", registry.Tags("abc", "bar"), registry.FailedTags},
 	}
 	for _, c := range testCases {
 		t.Run("", func(t *testing.T) {

--- a/pkg/cmd/roachtest/tests/acceptance.go
+++ b/pkg/cmd/roachtest/tests/acceptance.go
@@ -76,7 +76,6 @@ func registerAcceptance(r registry.Registry) {
 			},
 		},
 	}
-	tags := []string{"default", "quick"}
 	specTemplate := registry.TestSpec{
 		// NB: teamcity-post-failures.py relies on the acceptance tests
 		// being named acceptance/<testname> and will avoid posting a
@@ -86,7 +85,7 @@ func registerAcceptance(r registry.Registry) {
 		// will be posted.
 		Name:    "acceptance",
 		Timeout: 10 * time.Minute,
-		Tags:    tags,
+		Tags:    registry.Tags("default", "quick"),
 	}
 
 	for owner, tests := range testCases {

--- a/pkg/cmd/roachtest/tests/activerecord.go
+++ b/pkg/cmd/roachtest/tests/activerecord.go
@@ -247,7 +247,7 @@ func registerActiveRecord(r registry.Registry) {
 		Timeout:    5 * time.Hour,
 		Cluster:    r.MakeClusterSpec(1),
 		NativeLibs: registry.LibGEOS,
-		Tags:       []string{`default`, `orm`},
+		Tags:       registry.Tags(`default`, `orm`),
 		Run:        runActiveRecord,
 	})
 }

--- a/pkg/cmd/roachtest/tests/admission_control_elastic_backup.go
+++ b/pkg/cmd/roachtest/tests/admission_control_elastic_backup.go
@@ -39,7 +39,7 @@ func registerElasticControlForBackups(r registry.Registry) {
 	r.Add(registry.TestSpec{
 		Name:    "admission-control/elastic-backup",
 		Owner:   registry.OwnerAdmissionControl,
-		Tags:    []string{`weekly`},
+		Tags:    registry.Tags(`weekly`),
 		Cluster: r.MakeClusterSpec(4, spec.CPU(8)),
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			if c.Spec().NodeCount < 4 {

--- a/pkg/cmd/roachtest/tests/admission_control_elastic_cdc.go
+++ b/pkg/cmd/roachtest/tests/admission_control_elastic_cdc.go
@@ -32,7 +32,7 @@ func registerElasticControlForCDC(r registry.Registry) {
 	r.Add(registry.TestSpec{
 		Name:            "admission-control/elastic-cdc",
 		Owner:           registry.OwnerAdmissionControl,
-		Tags:            []string{`weekly`},
+		Tags:            registry.Tags(`weekly`),
 		Cluster:         r.MakeClusterSpec(4, spec.CPU(8)),
 		RequiresLicense: true,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {

--- a/pkg/cmd/roachtest/tests/admission_control_index_overload.go
+++ b/pkg/cmd/roachtest/tests/admission_control_index_overload.go
@@ -35,7 +35,7 @@ func registerIndexOverload(r registry.Registry) {
 	r.Add(registry.TestSpec{
 		Name:    "admission-control/index-overload",
 		Owner:   registry.OwnerAdmissionControl,
-		Tags:    []string{`weekly`},
+		Tags:    registry.Tags("weekly"),
 		Cluster: r.MakeClusterSpec(4, spec.CPU(8)),
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			crdbNodes := c.Spec().NodeCount - 1

--- a/pkg/cmd/roachtest/tests/admission_control_multi_store_overload.go
+++ b/pkg/cmd/roachtest/tests/admission_control_multi_store_overload.go
@@ -94,7 +94,7 @@ func registerMultiStoreOverload(r registry.Registry) {
 	r.Add(registry.TestSpec{
 		Name:    "admission-control/multi-store-with-overload",
 		Owner:   registry.OwnerAdmissionControl,
-		Tags:    []string{`weekly`},
+		Tags:    registry.Tags(`weekly`),
 		Cluster: r.MakeClusterSpec(2, spec.CPU(8), spec.SSD(2)),
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			runKV(ctx, t, c)

--- a/pkg/cmd/roachtest/tests/admission_control_snapshot_overload.go
+++ b/pkg/cmd/roachtest/tests/admission_control_snapshot_overload.go
@@ -41,7 +41,7 @@ func registerSnapshotOverload(r registry.Registry) {
 	r.Add(registry.TestSpec{
 		Name:    "admission-control/snapshot-overload",
 		Owner:   registry.OwnerAdmissionControl,
-		Tags:    []string{`weekly`},
+		Tags:    registry.Tags(`weekly`),
 		Cluster: r.MakeClusterSpec(4, spec.CPU(8)),
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			if c.Spec().NodeCount < 4 {

--- a/pkg/cmd/roachtest/tests/admission_control_tpcc_overload.go
+++ b/pkg/cmd/roachtest/tests/admission_control_tpcc_overload.go
@@ -164,7 +164,7 @@ func registerTPCCOverload(r registry.Registry) {
 		r.Add(registry.TestSpec{
 			Name:              name,
 			Owner:             registry.OwnerAdmissionControl,
-			Tags:              []string{`weekly`},
+			Tags:              registry.Tags(`weekly`),
 			Cluster:           r.MakeClusterSpec(s.Nodes+1, spec.CPU(s.CPUs)),
 			Run:               s.run,
 			EncryptionSupport: registry.EncryptionMetamorphic,

--- a/pkg/cmd/roachtest/tests/asyncpg.go
+++ b/pkg/cmd/roachtest/tests/asyncpg.go
@@ -141,7 +141,7 @@ func registerAsyncpg(r registry.Registry) {
 		Name:    "asyncpg",
 		Owner:   registry.OwnerSQLSessions,
 		Cluster: r.MakeClusterSpec(1, spec.CPU(16)),
-		Tags:    []string{`default`, `orm`},
+		Tags:    registry.Tags(`default`, `orm`),
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			runAsyncpg(ctx, t, c)
 		},

--- a/pkg/cmd/roachtest/tests/awsdms.go
+++ b/pkg/cmd/roachtest/tests/awsdms.go
@@ -191,7 +191,7 @@ func registerAWSDMS(r registry.Registry) {
 		Name:    "awsdms",
 		Owner:   registry.OwnerSQLSessions, // TODO(otan): add a migrations OWNERS team
 		Cluster: r.MakeClusterSpec(1),
-		Tags:    []string{`default`, `awsdms`},
+		Tags:    []string{`default`, `awsdms`, `aws`},
 		Run:     runAWSDMS,
 	})
 }

--- a/pkg/cmd/roachtest/tests/awsdms.go
+++ b/pkg/cmd/roachtest/tests/awsdms.go
@@ -191,7 +191,7 @@ func registerAWSDMS(r registry.Registry) {
 		Name:    "awsdms",
 		Owner:   registry.OwnerSQLSessions, // TODO(otan): add a migrations OWNERS team
 		Cluster: r.MakeClusterSpec(1),
-		Tags:    []string{`default`, `awsdms`, `aws`},
+		Tags:    registry.Tags(`default`, `awsdms`, `aws`),
 		Run:     runAWSDMS,
 	})
 }

--- a/pkg/cmd/roachtest/tests/backup.go
+++ b/pkg/cmd/roachtest/tests/backup.go
@@ -520,10 +520,10 @@ func registerBackup(r registry.Registry) {
 	for _, item := range []struct {
 		kmsProvider string
 		machine     string
-		tags        []string
+		tags        map[string]struct{}
 	}{
 		{kmsProvider: "GCS", machine: spec.GCE},
-		{kmsProvider: "AWS", machine: spec.AWS, tags: []string{"aws"}},
+		{kmsProvider: "AWS", machine: spec.AWS, tags: registry.Tags("aws")},
 	} {
 		item := item
 		r.Add(registry.TestSpec{

--- a/pkg/cmd/roachtest/tests/backup.go
+++ b/pkg/cmd/roachtest/tests/backup.go
@@ -520,9 +520,10 @@ func registerBackup(r registry.Registry) {
 	for _, item := range []struct {
 		kmsProvider string
 		machine     string
+		tags        []string
 	}{
 		{kmsProvider: "GCS", machine: spec.GCE},
-		{kmsProvider: "AWS", machine: spec.AWS},
+		{kmsProvider: "AWS", machine: spec.AWS, tags: []string{"aws"}},
 	} {
 		item := item
 		r.Add(registry.TestSpec{
@@ -530,6 +531,7 @@ func registerBackup(r registry.Registry) {
 			Owner:             registry.OwnerDisasterRecovery,
 			Cluster:           KMSSpec,
 			EncryptionSupport: registry.EncryptionMetamorphic,
+			Tags:              item.tags,
 			Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 				if c.Spec().Cloud != item.machine {
 					t.Skip("backupKMS roachtest is only configured to run on "+item.machine, "")

--- a/pkg/cmd/roachtest/tests/cdc.go
+++ b/pkg/cmd/roachtest/tests/cdc.go
@@ -989,7 +989,7 @@ func registerCDC(r registry.Registry) {
 		Name:            "cdc/tpcc-1000/sink=null",
 		Owner:           registry.OwnerCDC,
 		Cluster:         r.MakeClusterSpec(4, spec.CPU(16)),
-		Tags:            []string{"manual"},
+		Tags:            registry.Tags("manual"),
 		RequiresLicense: true,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			ct := newCDCTester(ctx, t, c)

--- a/pkg/cmd/roachtest/tests/cluster_to_cluster.go
+++ b/pkg/cmd/roachtest/tests/cluster_to_cluster.go
@@ -307,6 +307,9 @@ type replicationTestSpec struct {
 	// when there are no other roachtest connections to the database.
 	replicationStartHook func(ctx context.Context, sp *replicationTestSpec)
 
+	// tags are used to categorize the test.
+	tags []string
+
 	// fields below are instantiated at runtime
 	setup   *c2cSetup
 	t       test.Test
@@ -651,6 +654,7 @@ func c2cRegisterWrapper(
 		Cluster:         r.MakeClusterSpec(sp.dstNodes+sp.srcNodes+1, clusterOps...),
 		Timeout:         sp.timeout,
 		Skip:            sp.skip,
+		Tags:            sp.tags,
 		RequiresLicense: true,
 		Run:             run,
 	})
@@ -715,6 +719,7 @@ func registerClusterToCluster(r registry.Registry) {
 			timeout:            1 * time.Hour,
 			additionalDuration: 10 * time.Minute,
 			cutover:            5 * time.Minute,
+			tags:               []string{"aws"},
 		},
 		{
 			name:               "c2c/UnitTest",

--- a/pkg/cmd/roachtest/tests/cluster_to_cluster.go
+++ b/pkg/cmd/roachtest/tests/cluster_to_cluster.go
@@ -308,7 +308,7 @@ type replicationTestSpec struct {
 	replicationStartHook func(ctx context.Context, sp *replicationTestSpec)
 
 	// tags are used to categorize the test.
-	tags []string
+	tags map[string]struct{}
 
 	// fields below are instantiated at runtime
 	setup   *c2cSetup
@@ -719,7 +719,7 @@ func registerClusterToCluster(r registry.Registry) {
 			timeout:            1 * time.Hour,
 			additionalDuration: 10 * time.Minute,
 			cutover:            5 * time.Minute,
-			tags:               []string{"aws"},
+			tags:               registry.Tags("aws"),
 		},
 		{
 			name:               "c2c/UnitTest",

--- a/pkg/cmd/roachtest/tests/django.go
+++ b/pkg/cmd/roachtest/tests/django.go
@@ -217,7 +217,7 @@ func registerDjango(r registry.Registry) {
 		Name:    "django",
 		Owner:   registry.OwnerSQLSessions,
 		Cluster: r.MakeClusterSpec(1, spec.CPU(16)),
-		Tags:    []string{`default`, `orm`},
+		Tags:    registry.Tags(`default`, `orm`),
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			runDjango(ctx, t, c)
 		},

--- a/pkg/cmd/roachtest/tests/fixtures.go
+++ b/pkg/cmd/roachtest/tests/fixtures.go
@@ -65,7 +65,7 @@ func registerFixtures(r registry.Registry) {
 	spec := registry.TestSpec{
 		Name:    "generate-fixtures",
 		Timeout: 30 * time.Minute,
-		Tags:    []string{"fixtures"},
+		Tags:    registry.Tags("fixtures"),
 		Owner:   registry.OwnerDevInf,
 		Cluster: r.MakeClusterSpec(4),
 		Run:     runFixtures,

--- a/pkg/cmd/roachtest/tests/gopg.go
+++ b/pkg/cmd/roachtest/tests/gopg.go
@@ -158,7 +158,7 @@ func registerGopg(r registry.Registry) {
 		Name:    "gopg",
 		Owner:   registry.OwnerSQLSessions,
 		Cluster: r.MakeClusterSpec(1),
-		Tags:    []string{`default`, `orm`},
+		Tags:    registry.Tags(`default`, `orm`),
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			runGopg(ctx, t, c)
 		},

--- a/pkg/cmd/roachtest/tests/gorm.go
+++ b/pkg/cmd/roachtest/tests/gorm.go
@@ -136,7 +136,7 @@ func registerGORM(r registry.Registry) {
 		Name:    "gorm",
 		Owner:   registry.OwnerSQLSessions,
 		Cluster: r.MakeClusterSpec(1),
-		Tags:    []string{`default`, `orm`},
+		Tags:    registry.Tags(`default`, `orm`),
 		Run:     runGORM,
 	})
 }

--- a/pkg/cmd/roachtest/tests/hibernate.go
+++ b/pkg/cmd/roachtest/tests/hibernate.go
@@ -247,7 +247,7 @@ func registerHibernate(r registry.Registry, opt hibernateOptions) {
 		Owner:      registry.OwnerSQLSessions,
 		Cluster:    r.MakeClusterSpec(1),
 		NativeLibs: registry.LibGEOS,
-		Tags:       []string{`default`, `orm`},
+		Tags:       registry.Tags(`default`, `orm`),
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			runHibernate(ctx, t, c)
 		},

--- a/pkg/cmd/roachtest/tests/jasyncsql.go
+++ b/pkg/cmd/roachtest/tests/jasyncsql.go
@@ -143,7 +143,7 @@ func registerJasyncSQL(r registry.Registry) {
 		Name:    "jasync",
 		Owner:   registry.OwnerSQLSessions,
 		Cluster: r.MakeClusterSpec(1),
-		Tags:    []string{`default`, `orm`},
+		Tags:    registry.Tags(`default`, `orm`),
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			runJasyncSQL(ctx, t, c)
 		},

--- a/pkg/cmd/roachtest/tests/knex.go
+++ b/pkg/cmd/roachtest/tests/knex.go
@@ -131,7 +131,7 @@ func registerKnex(r registry.Registry) {
 		Owner:      registry.OwnerSQLSessions,
 		Cluster:    r.MakeClusterSpec(1),
 		NativeLibs: registry.LibGEOS,
-		Tags:       []string{`default`, `orm`},
+		Tags:       registry.Tags(`default`, `orm`),
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			runKnex(ctx, t, c)
 		},

--- a/pkg/cmd/roachtest/tests/kv.go
+++ b/pkg/cmd/roachtest/tests/kv.go
@@ -64,7 +64,7 @@ func registerKV(r registry.Registry) {
 		raid0                    bool
 		duration                 time.Duration
 		tracing                  bool // `trace.debug.enable`
-		tags                     []string
+		tags                     map[string]struct{}
 		owner                    registry.Owner // defaults to KV
 	}
 	computeNumSplits := func(opts kvOptions) int {
@@ -249,8 +249,8 @@ func registerKV(r registry.Registry) {
 		{nodes: 1, cpus: 32, readPercent: 95, spanReads: true, splits: -1 /* no splits */, disableLoadSplits: true, sequential: true},
 
 		// Weekly larger scale configurations.
-		{nodes: 32, cpus: 8, readPercent: 0, tags: []string{"weekly"}, duration: time.Hour},
-		{nodes: 32, cpus: 8, readPercent: 95, tags: []string{"weekly"}, duration: time.Hour},
+		{nodes: 32, cpus: 8, readPercent: 0, tags: registry.Tags("weekly"), duration: time.Hour},
+		{nodes: 32, cpus: 8, readPercent: 95, tags: registry.Tags("weekly"), duration: time.Hour},
 	} {
 		opts := opts
 
@@ -261,7 +261,11 @@ func registerKV(r registry.Registry) {
 		}
 		nameParts = append(nameParts, fmt.Sprintf("kv%d%s", opts.readPercent, limitedSpanStr))
 		if len(opts.tags) > 0 {
-			nameParts = append(nameParts, strings.Join(opts.tags, "/"))
+			var keys []string
+			for k := range opts.tags {
+				keys = append(keys, k)
+			}
+			nameParts = append(nameParts, strings.Join(keys, "/"))
 		}
 		nameParts = append(nameParts, fmt.Sprintf("enc=%t", opts.encryption))
 		nameParts = append(nameParts, fmt.Sprintf("nodes=%d", opts.nodes))
@@ -311,9 +315,9 @@ func registerKV(r registry.Registry) {
 		}
 		cSpec := r.MakeClusterSpec(opts.nodes+1, spec.CPU(opts.cpus), spec.SSD(opts.ssds), spec.RAID0(opts.raid0))
 
-		// All the kv0|95 tests not using ssd should run on AWS by default
+		// All the kv0|95 tests should run on AWS by default
 		if opts.tags == nil && opts.ssds == 0 && (opts.readPercent == 95 || opts.readPercent == 0) {
-			opts.tags = []string{"aws"}
+			opts.tags = registry.Tags("aws")
 		}
 
 		var skip string
@@ -950,7 +954,7 @@ func registerKVRestartImpact(r registry.Registry) {
 	r.Add(registry.TestSpec{
 		Name: "kv/restart/nodes=12",
 		// This test is expensive (104vcpu), we run it weekly.
-		Tags:    []string{`weekly`},
+		Tags:    registry.Tags(`weekly`),
 		Owner:   registry.OwnerKV,
 		Cluster: r.MakeClusterSpec(13, spec.CPU(8)),
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {

--- a/pkg/cmd/roachtest/tests/kv.go
+++ b/pkg/cmd/roachtest/tests/kv.go
@@ -310,6 +310,12 @@ func registerKV(r registry.Registry) {
 			encryption = registry.EncryptionAlwaysEnabled
 		}
 		cSpec := r.MakeClusterSpec(opts.nodes+1, spec.CPU(opts.cpus), spec.SSD(opts.ssds), spec.RAID0(opts.raid0))
+
+		// All the kv0|95 tests not using ssd should run on AWS by default
+		if opts.tags == nil && opts.ssds == 0 && (opts.readPercent == 95 || opts.readPercent == 0) {
+			opts.tags = []string{"aws"}
+		}
+
 		var skip string
 		if opts.ssds != 0 && cSpec.Cloud != spec.GCE {
 			skip = fmt.Sprintf("multi-store tests are not supported on cloud %s", cSpec.Cloud)

--- a/pkg/cmd/roachtest/tests/kvbench.go
+++ b/pkg/cmd/roachtest/tests/kvbench.go
@@ -92,7 +92,7 @@ func registerKVBenchSpec(r registry.Registry, b kvBenchSpec) {
 		// for --max-rate.
 		// TODO(andrei): output something to roachperf and start running them
 		// nightly.
-		Tags:    []string{"manual"},
+		Tags:    registry.Tags("manual"),
 		Owner:   registry.OwnerKV,
 		Cluster: nodes,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {

--- a/pkg/cmd/roachtest/tests/libpq.go
+++ b/pkg/cmd/roachtest/tests/libpq.go
@@ -138,7 +138,7 @@ func registerLibPQ(r registry.Registry) {
 		Name:    "lib/pq",
 		Owner:   registry.OwnerSQLSessions,
 		Cluster: r.MakeClusterSpec(1),
-		Tags:    []string{`default`, `driver`},
+		Tags:    registry.Tags(`default`, `driver`),
 		Run:     runLibPQ,
 	})
 }

--- a/pkg/cmd/roachtest/tests/liquibase.go
+++ b/pkg/cmd/roachtest/tests/liquibase.go
@@ -134,7 +134,7 @@ func registerLiquibase(r registry.Registry) {
 		Name:    "liquibase",
 		Owner:   registry.OwnerSQLSessions,
 		Cluster: r.MakeClusterSpec(1),
-		Tags:    []string{`default`, `tool`},
+		Tags:    registry.Tags(`default`, `tool`),
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			runLiquibase(ctx, t, c)
 		},

--- a/pkg/cmd/roachtest/tests/loss_of_quorum_recovery.go
+++ b/pkg/cmd/roachtest/tests/loss_of_quorum_recovery.go
@@ -71,7 +71,7 @@ func registerLOQRecovery(r registry.Registry) {
 		r.Add(registry.TestSpec{
 			Name:                s.testName(""),
 			Owner:               registry.OwnerReplication,
-			Tags:                []string{`default`},
+			Tags:                registry.Tags(`default`),
 			Cluster:             spec,
 			SkipPostValidations: registry.PostValidationInvalidDescriptors,
 			NonReleaseBlocker:   true,
@@ -82,7 +82,7 @@ func registerLOQRecovery(r registry.Registry) {
 		r.Add(registry.TestSpec{
 			Name:                s.testName("half-online"),
 			Owner:               registry.OwnerReplication,
-			Tags:                []string{`default`},
+			Tags:                registry.Tags(`default`),
 			Cluster:             spec,
 			SkipPostValidations: registry.PostValidationInvalidDescriptors,
 			NonReleaseBlocker:   true,

--- a/pkg/cmd/roachtest/tests/nodejs_postgres.go
+++ b/pkg/cmd/roachtest/tests/nodejs_postgres.go
@@ -170,7 +170,7 @@ PGSSLCERT=$HOME/certs/client.%s.crt PGSSLKEY=$HOME/certs/client.%s.key PGSSLROOT
 		Name:    "node-postgres",
 		Owner:   registry.OwnerSQLSessions,
 		Cluster: r.MakeClusterSpec(1),
-		Tags:    []string{`default`, `driver`},
+		Tags:    registry.Tags(`default`, `driver`),
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			runNodeJSPostgres(ctx, t, c)
 		},

--- a/pkg/cmd/roachtest/tests/npgsql.go
+++ b/pkg/cmd/roachtest/tests/npgsql.go
@@ -169,7 +169,7 @@ echo '%s' | git apply --ignore-whitespace -`, npgsqlPatch),
 		Name:    "npgsql",
 		Owner:   registry.OwnerSQLSessions,
 		Cluster: r.MakeClusterSpec(1),
-		Tags:    []string{`default`, `driver`},
+		Tags:    registry.Tags(`default`, `driver`),
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			runNpgsql(ctx, t, c)
 		},

--- a/pkg/cmd/roachtest/tests/pebble_write_throughput.go
+++ b/pkg/cmd/roachtest/tests/pebble_write_throughput.go
@@ -36,7 +36,7 @@ func registerPebbleWriteThroughput(r registry.Registry) {
 		Owner:   registry.OwnerStorage,
 		Timeout: 10 * time.Hour,
 		Cluster: r.MakeClusterSpec(5, spec.CPU(16), spec.SSD(16), spec.RAID0(true)),
-		Tags:    []string{"pebble_nightly_write"},
+		Tags:    registry.Tags("pebble_nightly_write"),
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			runPebbleWriteBenchmark(ctx, t, c, size, pebble)
 		},

--- a/pkg/cmd/roachtest/tests/pebble_ycsb.go
+++ b/pkg/cmd/roachtest/tests/pebble_ycsb.go
@@ -55,7 +55,7 @@ func registerPebbleYCSB(r registry.Registry) {
 				Owner:   registry.OwnerStorage,
 				Timeout: 12 * time.Hour,
 				Cluster: r.MakeClusterSpec(5, spec.CPU(16)),
-				Tags:    []string{tag},
+				Tags:    registry.Tags(tag),
 				Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 					runPebbleYCSB(ctx, t, c, size, pebble, d, nil, true /* artifacts */)
 				},
@@ -69,7 +69,7 @@ func registerPebbleYCSB(r registry.Registry) {
 		Owner:   registry.OwnerStorage,
 		Timeout: 12 * time.Hour,
 		Cluster: r.MakeClusterSpec(5, spec.CPU(16)),
-		Tags:    []string{"pebble_nightly_ycsb_race"},
+		Tags:    registry.Tags("pebble_nightly_ycsb_race"),
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			runPebbleYCSB(ctx, t, c, 64, pebble, 30, []string{"A"}, false /* artifacts */)
 		},

--- a/pkg/cmd/roachtest/tests/pgjdbc.go
+++ b/pkg/cmd/roachtest/tests/pgjdbc.go
@@ -213,7 +213,7 @@ func registerPgjdbc(r registry.Registry) {
 		Name:    "pgjdbc",
 		Owner:   registry.OwnerSQLSessions,
 		Cluster: r.MakeClusterSpec(1),
-		Tags:    []string{`default`, `driver`},
+		Tags:    registry.Tags(`default`, `driver`),
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			runPgjdbc(ctx, t, c)
 		},

--- a/pkg/cmd/roachtest/tests/pgx.go
+++ b/pkg/cmd/roachtest/tests/pgx.go
@@ -134,7 +134,7 @@ func registerPgx(r registry.Registry) {
 		Name:    "pgx",
 		Owner:   registry.OwnerSQLSessions,
 		Cluster: r.MakeClusterSpec(1),
-		Tags:    []string{`default`, `driver`},
+		Tags:    registry.Tags(`default`, `driver`),
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			runPgx(ctx, t, c)
 		},

--- a/pkg/cmd/roachtest/tests/pop.go
+++ b/pkg/cmd/roachtest/tests/pop.go
@@ -102,7 +102,7 @@ func registerPop(r registry.Registry) {
 		Name:    "pop",
 		Owner:   registry.OwnerSQLSessions,
 		Cluster: r.MakeClusterSpec(1),
-		Tags:    []string{`default`, `orm`},
+		Tags:    registry.Tags(`default`, `orm`),
 		Run:     runPop,
 	})
 }

--- a/pkg/cmd/roachtest/tests/psycopg.go
+++ b/pkg/cmd/roachtest/tests/psycopg.go
@@ -143,7 +143,7 @@ func registerPsycopg(r registry.Registry) {
 		Name:    "psycopg",
 		Owner:   registry.OwnerSQLSessions,
 		Cluster: r.MakeClusterSpec(1),
-		Tags:    []string{`default`, `driver`},
+		Tags:    registry.Tags(`default`, `driver`),
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			runPsycopg(ctx, t, c)
 		},

--- a/pkg/cmd/roachtest/tests/restore.go
+++ b/pkg/cmd/roachtest/tests/restore.go
@@ -130,7 +130,7 @@ func registerRestore(r registry.Registry) {
 		Owner:   registry.OwnerDisasterRecovery,
 		Cluster: withPauseSpecs.hardware.makeClusterSpecs(r, withPauseSpecs.backup.cloud),
 		Timeout: withPauseSpecs.timeout,
-		Tags:    []string{`aws`},
+		Tags:    registry.Tags("aws"),
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 
 			if c.Spec().Cloud != withPauseSpecs.backup.cloud {
@@ -282,7 +282,7 @@ func registerRestore(r registry.Registry) {
 			hardware: makeHardwareSpecs(hardwareSpecs{}),
 			backup:   makeBackupSpecs(backupSpecs{}),
 			timeout:  1 * time.Hour,
-			tags:     []string{"aws"},
+			tags:     registry.Tags("aws"),
 		},
 		{
 			// Note that the default specs in makeHardwareSpecs() spin up restore tests in aws,
@@ -304,7 +304,7 @@ func registerRestore(r registry.Registry) {
 			hardware: makeHardwareSpecs(hardwareSpecs{nodes: 8}),
 			backup:   makeBackupSpecs(backupSpecs{}),
 			timeout:  1 * time.Hour,
-			tags:     []string{"aws"},
+			tags:     registry.Tags("aws"),
 		},
 		{
 			// Benchmarks if per node throughput doubles if the vcpu count doubles
@@ -312,7 +312,7 @@ func registerRestore(r registry.Registry) {
 			hardware: makeHardwareSpecs(hardwareSpecs{cpus: 16}),
 			backup:   makeBackupSpecs(backupSpecs{}),
 			timeout:  1 * time.Hour,
-			tags:     []string{"aws"},
+			tags:     registry.Tags("aws"),
 		},
 		{
 			// Ensures we can restore a 48 length incremental chain.
@@ -320,7 +320,7 @@ func registerRestore(r registry.Registry) {
 			hardware: makeHardwareSpecs(hardwareSpecs{}),
 			backup:   makeBackupSpecs(backupSpecs{backupsIncluded: 48}),
 			timeout:  1 * time.Hour,
-			tags:     []string{"aws"},
+			tags:     registry.Tags("aws"),
 		},
 		{
 			// The nightly 8TB Restore test.
@@ -329,7 +329,7 @@ func registerRestore(r registry.Registry) {
 				version:  "v22.2.1",
 				workload: tpceRestore{customers: 500000}}),
 			timeout: 5 * time.Hour,
-			tags:    []string{"aws"},
+			tags:    registry.Tags("aws"),
 		},
 		{
 			// The weekly 32TB Restore test.
@@ -338,7 +338,7 @@ func registerRestore(r registry.Registry) {
 				version:  "v22.2.1",
 				workload: tpceRestore{customers: 2000000}}),
 			timeout: 24 * time.Hour,
-			tags:    []string{"weekly", "aws-weekly"},
+			tags:    registry.Tags("weekly", "aws-weekly"),
 		},
 		{
 			// A teeny weeny 15GB restore that could be used to bisect scale agnostic perf regressions.
@@ -621,7 +621,7 @@ type restoreSpecs struct {
 	hardware hardwareSpecs
 	backup   backupSpecs
 	timeout  time.Duration
-	tags     []string
+	tags     map[string]struct{}
 
 	// namePrefix appears in the name of the roachtest, i.e. `restore/{prefix}/{config}`.
 	namePrefix string

--- a/pkg/cmd/roachtest/tests/restore.go
+++ b/pkg/cmd/roachtest/tests/restore.go
@@ -130,6 +130,7 @@ func registerRestore(r registry.Registry) {
 		Owner:   registry.OwnerDisasterRecovery,
 		Cluster: withPauseSpecs.hardware.makeClusterSpecs(r, withPauseSpecs.backup.cloud),
 		Timeout: withPauseSpecs.timeout,
+		Tags:    []string{`aws`},
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 
 			if c.Spec().Cloud != withPauseSpecs.backup.cloud {
@@ -281,6 +282,7 @@ func registerRestore(r registry.Registry) {
 			hardware: makeHardwareSpecs(hardwareSpecs{}),
 			backup:   makeBackupSpecs(backupSpecs{}),
 			timeout:  1 * time.Hour,
+			tags:     []string{"aws"},
 		},
 		{
 			// Note that the default specs in makeHardwareSpecs() spin up restore tests in aws,
@@ -302,6 +304,7 @@ func registerRestore(r registry.Registry) {
 			hardware: makeHardwareSpecs(hardwareSpecs{nodes: 8}),
 			backup:   makeBackupSpecs(backupSpecs{}),
 			timeout:  1 * time.Hour,
+			tags:     []string{"aws"},
 		},
 		{
 			// Benchmarks if per node throughput doubles if the vcpu count doubles
@@ -309,6 +312,7 @@ func registerRestore(r registry.Registry) {
 			hardware: makeHardwareSpecs(hardwareSpecs{cpus: 16}),
 			backup:   makeBackupSpecs(backupSpecs{}),
 			timeout:  1 * time.Hour,
+			tags:     []string{"aws"},
 		},
 		{
 			// Ensures we can restore a 48 length incremental chain.
@@ -316,6 +320,7 @@ func registerRestore(r registry.Registry) {
 			hardware: makeHardwareSpecs(hardwareSpecs{}),
 			backup:   makeBackupSpecs(backupSpecs{backupsIncluded: 48}),
 			timeout:  1 * time.Hour,
+			tags:     []string{"aws"},
 		},
 		{
 			// The nightly 8TB Restore test.
@@ -324,6 +329,7 @@ func registerRestore(r registry.Registry) {
 				version:  "v22.2.1",
 				workload: tpceRestore{customers: 500000}}),
 			timeout: 5 * time.Hour,
+			tags:    []string{"aws"},
 		},
 		{
 			// The weekly 32TB Restore test.

--- a/pkg/cmd/roachtest/tests/roachtest.go
+++ b/pkg/cmd/roachtest/tests/roachtest.go
@@ -25,14 +25,14 @@ import (
 func registerRoachtest(r registry.Registry) {
 	r.Add(registry.TestSpec{
 		Name:    "roachtest/noop",
-		Tags:    []string{"roachtest"},
+		Tags:    registry.Tags("roachtest"),
 		Owner:   registry.OwnerTestEng,
 		Run:     func(_ context.Context, _ test.Test, _ cluster.Cluster) {},
 		Cluster: r.MakeClusterSpec(0),
 	})
 	r.Add(registry.TestSpec{
 		Name:  "roachtest/noop-maybefail",
-		Tags:  []string{"roachtest"},
+		Tags:  registry.Tags("roachtest"),
 		Owner: registry.OwnerTestEng,
 		Run: func(_ context.Context, t test.Test, _ cluster.Cluster) {
 			if rand.Float64() <= 0.2 {
@@ -45,7 +45,7 @@ func registerRoachtest(r registry.Registry) {
 	// In particular, can manually verify that suitable artifacts are created.
 	r.Add(registry.TestSpec{
 		Name:  "roachtest/hang",
-		Tags:  []string{"roachtest"},
+		Tags:  registry.Tags("roachtest"),
 		Owner: registry.OwnerTestEng,
 		Run: func(_ context.Context, t test.Test, c cluster.Cluster) {
 			ctx := context.Background() // intentional

--- a/pkg/cmd/roachtest/tests/ruby_pg.go
+++ b/pkg/cmd/roachtest/tests/ruby_pg.go
@@ -232,7 +232,7 @@ func registerRubyPG(r registry.Registry) {
 		Owner:      registry.OwnerSQLSessions,
 		Cluster:    r.MakeClusterSpec(1),
 		NativeLibs: registry.LibGEOS,
-		Tags:       []string{`default`, `orm`},
+		Tags:       registry.Tags(`default`, `orm`),
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			runRubyPGTest(ctx, t, c)
 		},

--- a/pkg/cmd/roachtest/tests/rust_postgres.go
+++ b/pkg/cmd/roachtest/tests/rust_postgres.go
@@ -168,7 +168,7 @@ func registerRustPostgres(r registry.Registry) {
 		Name:    "rust-postgres",
 		Owner:   registry.OwnerSQLSessions,
 		Cluster: r.MakeClusterSpec(1, spec.CPU(16)),
-		Tags:    []string{`default`, `orm`},
+		Tags:    registry.Tags(`default`, `orm`),
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			runRustPostgres(ctx, t, c)
 		},

--- a/pkg/cmd/roachtest/tests/schemachange_random_load.go
+++ b/pkg/cmd/roachtest/tests/schemachange_random_load.go
@@ -33,6 +33,7 @@ type randomLoadBenchSpec struct {
 	Nodes       int
 	Ops         int
 	Concurrency int
+	Tags        []string
 }
 
 func registerSchemaChangeRandomLoad(r registry.Registry) {
@@ -66,6 +67,7 @@ func registerSchemaChangeRandomLoad(r registry.Registry) {
 		Nodes:       3,
 		Ops:         2000,
 		Concurrency: 1,
+		Tags:        []string{"aws"},
 	})
 
 	registerRandomLoadBenchSpec(r, randomLoadBenchSpec{
@@ -97,6 +99,7 @@ func registerRandomLoadBenchSpec(r registry.Registry, b randomLoadBenchSpec) {
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			runSchemaChangeRandomLoad(ctx, t, c, b.Ops, b.Concurrency)
 		},
+		Tags: b.Tags,
 	})
 }
 

--- a/pkg/cmd/roachtest/tests/schemachange_random_load.go
+++ b/pkg/cmd/roachtest/tests/schemachange_random_load.go
@@ -33,7 +33,7 @@ type randomLoadBenchSpec struct {
 	Nodes       int
 	Ops         int
 	Concurrency int
-	Tags        []string
+	Tags        map[string]struct{}
 }
 
 func registerSchemaChangeRandomLoad(r registry.Registry) {
@@ -67,7 +67,7 @@ func registerSchemaChangeRandomLoad(r registry.Registry) {
 		Nodes:       3,
 		Ops:         2000,
 		Concurrency: 1,
-		Tags:        []string{"aws"},
+		Tags:        registry.Tags("aws"),
 	})
 
 	registerRandomLoadBenchSpec(r, randomLoadBenchSpec{

--- a/pkg/cmd/roachtest/tests/sequelize.go
+++ b/pkg/cmd/roachtest/tests/sequelize.go
@@ -154,7 +154,7 @@ func registerSequelize(r registry.Registry) {
 		Owner:      registry.OwnerSQLSessions,
 		Cluster:    r.MakeClusterSpec(1),
 		NativeLibs: registry.LibGEOS,
-		Tags:       []string{`default`, `orm`},
+		Tags:       registry.Tags(`default`, `orm`),
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			runSequelize(ctx, t, c)
 		},

--- a/pkg/cmd/roachtest/tests/smoketest_secure.go
+++ b/pkg/cmd/roachtest/tests/smoketest_secure.go
@@ -28,7 +28,7 @@ func registerSecure(r registry.Registry) {
 	for _, numNodes := range []int{1, 3} {
 		r.Add(registry.TestSpec{
 			Name:    fmt.Sprintf("smoketest/secure/nodes=%d", numNodes),
-			Tags:    []string{"smoketest", "weekly"},
+			Tags:    registry.Tags("smoketest", "weekly"),
 			Owner:   registry.OwnerTestEng,
 			Cluster: r.MakeClusterSpec(numNodes),
 			Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {

--- a/pkg/cmd/roachtest/tests/sqlalchemy.go
+++ b/pkg/cmd/roachtest/tests/sqlalchemy.go
@@ -39,7 +39,7 @@ func registerSQLAlchemy(r registry.Registry) {
 		Name:    "sqlalchemy",
 		Owner:   registry.OwnerSQLSessions,
 		Cluster: r.MakeClusterSpec(1),
-		Tags:    []string{`default`, `orm`},
+		Tags:    registry.Tags(`default`, `orm`),
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			runSQLAlchemy(ctx, t, c)
 		},

--- a/pkg/cmd/roachtest/tests/tpcc.go
+++ b/pkg/cmd/roachtest/tests/tpcc.go
@@ -491,7 +491,7 @@ func registerTPCC(r registry.Registry) {
 		// running with the max supported warehouses.
 		Name:              "tpcc/headroom/" + headroomSpec.String(),
 		Owner:             registry.OwnerTestEng,
-		Tags:              []string{`default`, `release_qualification`, `aws`},
+		Tags:              registry.Tags(`default`, `release_qualification`, `aws`),
 		Cluster:           headroomSpec,
 		EncryptionSupport: registry.EncryptionMetamorphic,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
@@ -517,7 +517,7 @@ func registerTPCC(r registry.Registry) {
 		Owner:   registry.OwnerTestEng,
 		// TODO(tbg): add release_qualification tag once we know the test isn't
 		// buggy.
-		Tags:              []string{`default`},
+		Tags:              registry.Tags(`default`),
 		Cluster:           mixedHeadroomSpec,
 		EncryptionSupport: registry.EncryptionMetamorphic,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
@@ -529,7 +529,7 @@ func registerTPCC(r registry.Registry) {
 		Name:              "tpcc/mixed-headroom/multiple-upgrades/" + mixedHeadroomSpec.String(),
 		Timeout:           5 * time.Hour,
 		Owner:             registry.OwnerTestEng,
-		Tags:              []string{`default`},
+		Tags:              registry.Tags(`default`),
 		Cluster:           mixedHeadroomSpec,
 		EncryptionSupport: registry.EncryptionMetamorphic,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
@@ -553,7 +553,7 @@ func registerTPCC(r registry.Registry) {
 	r.Add(registry.TestSpec{
 		Name:    "weekly/tpcc/headroom",
 		Owner:   registry.OwnerTestEng,
-		Tags:    []string{`weekly`},
+		Tags:    registry.Tags(`weekly`),
 		Cluster: r.MakeClusterSpec(4, spec.CPU(16)),
 		// Give the test a generous extra 10 hours to load the dataset and
 		// slowly ramp up the load.
@@ -826,7 +826,7 @@ func registerTPCC(r registry.Registry) {
 
 		LoadWarehouses: gceOrAws(cloud, 3500, 3900),
 		EstimatedMax:   gceOrAws(cloud, 2900, 3500),
-		Tags:           []string{`aws`},
+		Tags:           registry.Tags(`aws`),
 	})
 	registerTPCCBenchSpec(r, tpccBenchSpec{
 		Nodes: 12,
@@ -835,7 +835,7 @@ func registerTPCC(r registry.Registry) {
 		LoadWarehouses: gceOrAws(cloud, 11500, 11500),
 		EstimatedMax:   gceOrAws(cloud, 10000, 10000),
 
-		Tags: []string{`weekly`},
+		Tags: registry.Tags(`weekly`),
 	})
 	registerTPCCBenchSpec(r, tpccBenchSpec{
 		Nodes:        6,
@@ -882,7 +882,7 @@ func registerTPCC(r registry.Registry) {
 		LoadWarehouses:    gceOrAws(cloud, 3500, 3900),
 		EstimatedMax:      gceOrAws(cloud, 2900, 3500),
 		EncryptionEnabled: true,
-		Tags:              []string{`aws`},
+		Tags:              registry.Tags(`aws`),
 	})
 	registerTPCCBenchSpec(r, tpccBenchSpec{
 		Nodes: 12,
@@ -892,7 +892,7 @@ func registerTPCC(r registry.Registry) {
 		EstimatedMax:      gceOrAws(cloud, 10000, 10000),
 		EncryptionEnabled: true,
 
-		Tags: []string{`weekly`},
+		Tags: registry.Tags(`weekly`),
 	})
 }
 
@@ -982,7 +982,7 @@ type tpccBenchSpec struct {
 	// MinVersion to pass to testRegistryImpl.Add.
 	MinVersion string
 	// Tags to pass to testRegistryImpl.Add.
-	Tags []string
+	Tags map[string]struct{}
 	// EncryptionEnabled determines if the benchmark uses encrypted stores (i.e.
 	// Encryption-At-Rest / EAR).
 	EncryptionEnabled bool

--- a/pkg/cmd/roachtest/tests/tpcc.go
+++ b/pkg/cmd/roachtest/tests/tpcc.go
@@ -491,7 +491,7 @@ func registerTPCC(r registry.Registry) {
 		// running with the max supported warehouses.
 		Name:              "tpcc/headroom/" + headroomSpec.String(),
 		Owner:             registry.OwnerTestEng,
-		Tags:              []string{`default`, `release_qualification`},
+		Tags:              []string{`default`, `release_qualification`, `aws`},
 		Cluster:           headroomSpec,
 		EncryptionSupport: registry.EncryptionMetamorphic,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
@@ -826,6 +826,7 @@ func registerTPCC(r registry.Registry) {
 
 		LoadWarehouses: gceOrAws(cloud, 3500, 3900),
 		EstimatedMax:   gceOrAws(cloud, 2900, 3500),
+		Tags:           []string{`aws`},
 	})
 	registerTPCCBenchSpec(r, tpccBenchSpec{
 		Nodes: 12,
@@ -881,6 +882,7 @@ func registerTPCC(r registry.Registry) {
 		LoadWarehouses:    gceOrAws(cloud, 3500, 3900),
 		EstimatedMax:      gceOrAws(cloud, 2900, 3500),
 		EncryptionEnabled: true,
+		Tags:              []string{`aws`},
 	})
 	registerTPCCBenchSpec(r, tpccBenchSpec{
 		Nodes: 12,

--- a/pkg/cmd/roachtest/tests/tpce.go
+++ b/pkg/cmd/roachtest/tests/tpce.go
@@ -33,7 +33,7 @@ func registerTPCE(r registry.Registry) {
 		cpus      int
 		ssds      int
 
-		tags    []string
+		tags    map[string]struct{}
 		timeout time.Duration
 	}
 
@@ -110,7 +110,7 @@ func registerTPCE(r registry.Registry) {
 		// Nightly, small scale configurations.
 		{customers: 5_000, nodes: 3, cpus: 4, ssds: 1, timeout: 4 * time.Hour},
 		// Weekly, large scale configurations.
-		{customers: 100_000, nodes: 5, cpus: 32, ssds: 2, tags: []string{"weekly"}, timeout: 36 * time.Hour},
+		{customers: 100_000, nodes: 5, cpus: 32, ssds: 2, tags: registry.Tags("weekly"), timeout: 36 * time.Hour},
 	} {
 		opts := opts
 		owner := registry.OwnerTestEng

--- a/pkg/cmd/roachtest/tests/typeorm.go
+++ b/pkg/cmd/roachtest/tests/typeorm.go
@@ -182,7 +182,7 @@ func registerTypeORM(r registry.Registry) {
 		Name:    "typeorm",
 		Owner:   registry.OwnerSQLSessions,
 		Cluster: r.MakeClusterSpec(1),
-		Tags:    []string{`default`, `orm`},
+		Tags:    registry.Tags(`default`, `orm`),
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			runTypeORM(ctx, t, c)
 		},

--- a/pkg/cmd/roachtest/tests/ycsb.go
+++ b/pkg/cmd/roachtest/tests/ycsb.go
@@ -108,6 +108,7 @@ func registerYCSB(r registry.Registry) {
 				Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 					runYCSB(ctx, t, c, wl, cpus, false /* rangeTombstone */)
 				},
+				Tags: []string{`aws`},
 			})
 
 			if wl == "A" {
@@ -129,6 +130,7 @@ func registerYCSB(r registry.Registry) {
 					Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 						runYCSB(ctx, t, c, wl, cpus, true /* rangeTombstone */)
 					},
+					Tags: []string{`aws`},
 				})
 			}
 		}

--- a/pkg/cmd/roachtest/tests/ycsb.go
+++ b/pkg/cmd/roachtest/tests/ycsb.go
@@ -108,7 +108,7 @@ func registerYCSB(r registry.Registry) {
 				Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 					runYCSB(ctx, t, c, wl, cpus, false /* rangeTombstone */)
 				},
-				Tags: []string{`aws`},
+				Tags: registry.Tags(`aws`),
 			})
 
 			if wl == "A" {
@@ -130,7 +130,7 @@ func registerYCSB(r registry.Registry) {
 					Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 						runYCSB(ctx, t, c, wl, cpus, true /* rangeTombstone */)
 					},
-					Tags: []string{`aws`},
+					Tags: registry.Tags(`aws`),
 				})
 			}
 		}


### PR DESCRIPTION
… tags.

oday, tests are matched if they have any of the specified tags. This patch introduces the ability to match tests which have all specified tags, whilst attempting to maintain backward compatibility.

Commits
1 - expand tag filtering (AND, !)
2 - convert `TestSpec.Tags` to `map[string]struct{}`
3 - suppress TeamCity log statement


Epic: none
Fixes: #96655

Release note: None