### PR TITLE
sql/tests: give more memory to TestSchemaChangesInParallel

### DIFF
--- a/pkg/sql/tests/schema_changes_in_parallel_test.go
+++ b/pkg/sql/tests/schema_changes_in_parallel_test.go
@@ -39,6 +39,7 @@ func TestSchemaChangesInParallel(t *testing.T) {
 			},
 			JobsTestingKnobs: jobs.NewTestingKnobsWithShortIntervals(),
 		},
+		SQLMemoryPoolSize: 1 << 30, /* 1GiB */
 	})
 	defer s.Stopper().Stop(ctx)
 


### PR DESCRIPTION
The test has previously failed due to running out of memory. Since it's an expensive test, this is somewhat expected.

fixes https://github.com/cockroachdb/cockroach/issues/98850
Release note: None