### PR TITLE
upgrades: unskip TestMigrationWithFailuresMultipleAltersOnSameColumn

### DIFF
--- a/pkg/upgrade/upgrades/schema_changes_external_test.go
+++ b/pkg/upgrade/upgrades/schema_changes_external_test.go
@@ -174,8 +174,6 @@ CREATE TABLE test.test_table (
 // alters a column in a table multiple times with failures at different stages
 // of the migration.
 func TestMigrationWithFailuresMultipleAltersOnSameColumn(t *testing.T) {
-	skip.WithIssue(t, 98991)
-
 	const createTableBefore = `
 CREATE TABLE test.test_table (
    username STRING NOT NULL


### PR DESCRIPTION
This did not fail when running under stress. I believe the source of the flakiness was elsewhere.

fixes https://github.com/cockroachdb/cockroach/issues/98991
Release note: None