### PR TITLE
Revert "roachprod: change scp flags to avoid copy via local host"

### DIFF
--- a/pkg/roachprod/install/cluster_synced.go
+++ b/pkg/roachprod/install/cluster_synced.go
@@ -2382,9 +2382,7 @@ func (c *SyncedCluster) SSH(ctx context.Context, l *logger.Logger, sshArgs, args
 // which we do want to be able to retry.
 func scp(src, dest string) (*RunResultDetails, error) {
 	args := []string{
-		"scp",
-		// ssh to src then scp dsc mode, use agent forwarding, recursive, compression
-		"-R", "-A", "-r", "-C",
+		"scp", "-r", "-C",
 		"-o", "StrictHostKeyChecking=no",
 	}
 	args = append(args, sshAuthArgs()...)


### PR DESCRIPTION
This reverts commit 9aa8536a3f9a7183824d8410fe7491ecc9c18307.

Epic: None

Release note: None