### PR TITLE
builtins: fix phraseto_tsquery(text)

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/tsvector
+++ b/pkg/sql/logictest/testdata/logic_test/tsvector
@@ -268,6 +268,22 @@ SELECT * FROM phraseto_tsquery('simple', 'Hello this is a parsi-ng t.est 1.234 4
 ----
 'hello' <-> 'this' <-> 'is' <-> 'a' <-> 'parsi' <-> 'ng' <-> 't' <-> 'est' <-> '1' <-> '234' <-> '4' <-> 'case324'
 
+
+query T
+SELECT phraseto_tsquery('No hardcoded configuration')
+----
+'hardcod' <-> 'configur'
+
+query T
+SELECT plainto_tsquery('No hardcoded configuration')
+----
+'hardcod' & 'configur'
+
+query T
+SELECT to_tsquery('No | hardcoded | configuration')
+----
+'hardcod' | 'configur'
+
 query T
 SELECT * FROM to_tsquery('simple', 'a | b & c <-> d')
 ----

--- a/pkg/sql/sem/builtins/tsearch_builtins.go
+++ b/pkg/sql/sem/builtins/tsearch_builtins.go
@@ -217,7 +217,7 @@ var tsearchBuiltins = map[string]builtinDefinition{
 		tree.Overload{
 			Types:      tree.ParamTypes{{Name: "text", Typ: types.String}},
 			ReturnType: tree.FixedReturnType(types.TSQuery),
-			Fn: func(evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
 				config := tsearch.GetConfigKey(evalCtx.SessionData().DefaultTextSearchConfig)
 				input := string(tree.MustBeDString(args[0]))
 				query, err := tsearch.PhraseToTSQuery(config, input)


### PR DESCRIPTION
The builtin definition had the wrong function signature, and there is no linter that notices it. There was also no test that ran that variant of the function, so that's fixed now.

Epic: CRDB-22357
Release note: None (no release with this bug)