### PR TITLE
sql: handle invalid comment type more gently

### DIFF
--- a/pkg/sql/catalog/catalogkeys/keys.go
+++ b/pkg/sql/catalog/catalogkeys/keys.go
@@ -74,6 +74,12 @@ var AllCommentTypes = []CommentType{
 	ConstraintCommentType,
 }
 
+// IsValidCommentType checks if a given comment type is in the valid value
+// range.
+func IsValidCommentType(t CommentType) bool {
+	return t >= 0 && t <= MaxCommentTypeValue
+}
+
 func init() {
 	if len(AllCommentTypes) != int(MaxCommentTypeValue+1) {
 		panic("AllCommentTypes should contains all comment types.")

--- a/pkg/sql/catalog/descs/collection.go
+++ b/pkg/sql/catalog/descs/collection.go
@@ -941,7 +941,7 @@ func (tc *Collection) aggregateAllLayers(
 	// Add stored comments which are not shadowed.
 	_ = stored.ForEachComment(func(key catalogkeys.CommentKey, cmt string) error {
 		if _, _, isShadowed := tc.uncommittedComments.getUncommitted(key); !isShadowed {
-			ret.UpsertComment(key, cmt)
+			return ret.UpsertComment(key, cmt)
 		}
 		return nil
 	})
@@ -984,7 +984,9 @@ func (tc *Collection) aggregateAllLayers(
 		})
 	}
 	// Add uncommitted comments and zone configs.
-	tc.uncommittedComments.addAllToCatalog(ret)
+	if err := tc.uncommittedComments.addAllToCatalog(ret); err != nil {
+		return nstree.MutableCatalog{}, err
+	}
 	tc.uncommittedZoneConfigs.addAllToCatalog(ret)
 	// Remove deleted descriptors from consideration, re-read and add the rest.
 	tc.deletedDescs.ForEach(descIDs.Remove)

--- a/pkg/sql/catalog/descs/uncommitted_metadata.go
+++ b/pkg/sql/catalog/descs/uncommitted_metadata.go
@@ -71,10 +71,13 @@ func (uc *uncommittedComments) upsert(key catalogkeys.CommentKey, cmt string) {
 	uc.uncommitted[key] = cmt
 }
 
-func (uc *uncommittedComments) addAllToCatalog(mc nstree.MutableCatalog) {
+func (uc *uncommittedComments) addAllToCatalog(mc nstree.MutableCatalog) error {
 	for ck, cmt := range uc.uncommitted {
-		mc.UpsertComment(ck, cmt)
+		if err := mc.UpsertComment(ck, cmt); err != nil {
+			return err
+		}
 	}
+	return nil
 }
 
 type uncommittedZoneConfigs struct {

--- a/pkg/sql/catalog/descs/virtual_descriptors.go
+++ b/pkg/sql/catalog/descs/virtual_descriptors.go
@@ -101,7 +101,6 @@ func (tc virtualDescriptors) addAllToCatalog(mc nstree.MutableCatalog) {
 		default:
 			return nil
 		}
-		mc.UpsertComment(ck, comment)
-		return nil
+		return mc.UpsertComment(ck, comment)
 	})
 }

--- a/pkg/sql/catalog/internal/catkv/catalog_query.go
+++ b/pkg/sql/catalog/internal/catkv/catalog_query.go
@@ -133,8 +133,7 @@ func (cq catalogQuery) processCommentsResultRow(row kv.KeyValue, cb *nstree.Muta
 	if famID != keys.CommentsTableCommentColFamID {
 		return nil
 	}
-	cb.UpsertComment(cmtKey, string(row.ValueBytes()))
-	return nil
+	return cb.UpsertComment(cmtKey, string(row.ValueBytes()))
 }
 
 func (cq catalogQuery) processZonesResultRow(row kv.KeyValue, cb *nstree.MutableCatalog) error {

--- a/pkg/sql/logictest/testdata/logic_test/comment_on
+++ b/pkg/sql/logictest/testdata/logic_test/comment_on
@@ -256,3 +256,18 @@ CREATE TABLE public.t (
   FAMILY fam_0_b_a (a, b),
   CONSTRAINT ckb CHECK (b > 1:::INT8)
 )
+
+# Make sure invalid comment type does not crash a server.
+subtest regression_99316
+
+statement ok
+CREATE TABLE t_99316(a INT);
+
+statement ok
+INSERT INTO system.comments VALUES (4294967122, 't_99316'::regclass::OID, 0, 'bar');
+
+statement error pgcode XX000 select-comments: invalid comment type 4294967122
+SELECT * FROM pg_catalog.pg_description WHERE objoid = 't'::regclass::OID;
+
+statement ok
+DELETE FROM system.comments WHERE type = 4294967122

--- a/pkg/sql/schemachanger/scdeps/sctestdeps/config.go
+++ b/pkg/sql/schemachanger/scdeps/sctestdeps/config.go
@@ -130,7 +130,9 @@ func WithBackfiller(backfiller scexec.Backfiller) Option {
 func WithComments(comments map[catalogkeys.CommentKey]string) Option {
 	return optionFunc(func(state *TestState) {
 		for key, cmt := range comments {
-			state.committed.UpsertComment(key, cmt)
+			if err := state.committed.UpsertComment(key, cmt); err != nil {
+				panic(err)
+			}
 		}
 	})
 }

--- a/pkg/sql/schemachanger/scdeps/sctestdeps/test_deps.go
+++ b/pkg/sql/schemachanger/scdeps/sctestdeps/test_deps.go
@@ -852,7 +852,9 @@ func (s *TestState) Validate(ctx context.Context) error {
 		} else {
 			s.LogSideEffectf("upsert comment %s(objID: %d, subID: %d) -> %q",
 				key.CommentType, key.ObjectID, key.SubID, cmt)
-			s.uncommittedInMemory.UpsertComment(key, cmt)
+			if err := s.uncommittedInMemory.UpsertComment(key, cmt); err != nil {
+				return err
+			}
 		}
 	}
 	ve := s.uncommittedInMemory.Validate(

--- a/pkg/sql/schemachanger/scdeps/sctestdeps/test_state.go
+++ b/pkg/sql/schemachanger/scdeps/sctestdeps/test_state.go
@@ -152,8 +152,7 @@ func catalogDeepCopy(u nstree.Catalog) (ret nstree.MutableCatalog) {
 		return nil
 	})
 	_ = u.ForEachComment(func(key catalogkeys.CommentKey, cmt string) error {
-		ret.UpsertComment(key, cmt)
-		return nil
+		return ret.UpsertComment(key, cmt)
 	})
 	_ = u.ForEachZoneConfig(func(id catid.DescID, zc catalog.ZoneConfig) error {
 		zc = zc.Clone()


### PR DESCRIPTION
Fixes: #99316

Previously a node can crash if a comment is inserted with an invalid comment type when reading schema catalogs. This commit handles such invalid comment type withint the catalog by validating the comment types.

Release note: None