### PR TITLE
release-22.2: sql: fix bug when using glob which matches nothing

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/grant_table
+++ b/pkg/sql/logictest/testdata/logic_test/grant_table
@@ -1974,3 +1974,29 @@ REVOKE SELECT ON system.lease FROM testuser
 # we error explicitly instead of getting 100% compatibility.
 statement error invalid privilege type RULE for table
 GRANT RULE ON t TO testuser
+
+# This glob expands to no tables, that should be fine and should return the
+# correct errors.
+statement error pgcode 42704 no object matched
+GRANT SELECT ON TABLE empty.* TO testuser;
+
+statement ok
+create schema empty.sc
+
+statement error pgcode 42704 no object matched
+GRANT SELECT ON TABLE empty.sc.* TO testuser;
+
+# Add a test to ensure that when you mix virtual and physical tables in a grant
+# that you get the error we
+subtest mixed_virtual_physical
+
+statement ok
+CREATE DATABASE db;
+USE db;
+CREATE TABLE t (i INT);
+
+statement error pgcode 0A000 cannot mix grants between virtual and non-virtual tables
+GRANT SELECT ON TABLE t, crdb_internal.tables TO testuser;
+
+statement error pgcode 0A000 cannot mix grants between virtual and non-virtual tables
+GRANT SELECT ON TABLE crdb_internal.tables, t TO testuser;


### PR DESCRIPTION
Backport 1/1 commits from #93173.

/cc @cockroachdb/release

fixes https://github.com/cockroachdb/cockroach/issues/99233
fixes https://github.com/cockroachdb/cockroach/issues/93417

Release justification: bug fix

---

Logic in the 22.2 cycle for synthetic privileges erroneously assumed that if no physical tables matched, that it must mean that virtual tables matched. It also assumed that if the first entry in a pattern matched, it applied to all entries. Both of these assumptions were wrong. They lead to ugly panics.

Fixes: #92483

Release note (bug fix): Fixed a bug whereby glob patterns which matched no tables in `GRANT` or `REVOKE` statements would return an internal error with a confusing message as opposed to the appropriate "no objects matched" error.
