### PR TITLE
sql: deflake TestExecBuild_sql_statistics_persisted

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/testdata/sql_statistics_persisted
+++ b/pkg/sql/opt/exec/execbuilder/testdata/sql_statistics_persisted
@@ -3,7 +3,7 @@
 statement ok
 CREATE STATISTICS system_statement_stats FROM system.statement_statistics
 
-query T
+query T retry
 EXPLAIN (VERBOSE)
 SELECT * FROM ((SELECT
   aggregated_ts,
@@ -478,7 +478,7 @@ vectorized: true
 statement ok
 CREATE STATISTICS system_transaction_stats FROM system.transaction_statistics
 
-query T
+query T retry
 EXPLAIN (VERBOSE)
 SELECT * FROM ((SELECT
   aggregated_ts,


### PR DESCRIPTION
This commit deflakes `TestExecBuild_sql_statistics_persisted` by adding a retry directive to each query that is run directly after calling `CREATE STATISTICS`. This is important since the stats might take some time to propagate to the caches after creation.

Fixes #99399

Release note: None