### PR TITLE
sql: set FlowCtx.Txn for some EXPLAIN variants

### DIFF
--- a/pkg/sql/explain_vec.go
+++ b/pkg/sql/explain_vec.go
@@ -106,6 +106,7 @@ func newFlowCtxForExplainPurposes(
 		NodeID:  planCtx.EvalContext().NodeID,
 		EvalCtx: planCtx.EvalContext(),
 		Mon:     monitor,
+		Txn:     p.txn,
 		Cfg: &execinfra.ServerConfig{
 			Settings:         p.execCfg.Settings,
 			LogicalClusterID: p.DistSQLPlanner().distSQLSrv.ServerConfig.LogicalClusterID,


### PR DESCRIPTION
Previously, when creating the `FlowCtx` "for EXPLAIN purposes" we forgot to set the txn. This could lead to panics down the line (e.g. if we needed to hydrate some types, and the type descriptors weren't already in the cache). This is now fixed by using the planner's RootTxn in the `FlowCtx`.

The bug has only been seen once in the wild and should be pretty rare in practice, so I'm omitting the release note. There is also no regression test for this since it's tricky to do (we need the lease on the type descriptor to expire after the optimizer has done its part, but before the flow has been set up).

Fixes: #98102.

Release note: None