### PR TITLE
release-22.1: server,sql: remove usages of prettify on details pages

### DIFF
--- a/pkg/roachpb/app_stats.proto
+++ b/pkg/roachpb/app_stats.proto
@@ -203,9 +203,8 @@ message StatementStatisticsKey {
 
 message AggregatedStatementMetadata {
   optional string query = 1 [(gogoproto.nullable) = false];
-  // Formatted query is the return of the key_data.query after prettify_statement.
-  // The query above cannot be replaced by the formatted value, because is used as is for
-  // diagnostic bundle.
+  // Formatted query is the same value of query. It used to be formatted with prettify_statement,
+  // but until that function is improved (#91197), it should not be used.
   optional string formatted_query = 2 [(gogoproto.nullable) = false];
   optional string query_summary = 3 [(gogoproto.nullable) = false];
   optional string stmt_type = 4 [(gogoproto.nullable) = false];

--- a/pkg/server/combined_statement_stats.go
+++ b/pkg/server/combined_statement_stats.go
@@ -23,7 +23,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catconstants"
-	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlstats"
@@ -541,15 +540,7 @@ func getTotalStatementDetails(
 	}
 	statistics.Stats.SensitiveInfo.MostRecentPlanDescription = *plan
 
-	queryTree, err := parser.ParseOne(aggregatedMetadata.Query)
-	if err != nil {
-		return statement, serverError(ctx, err)
-	}
-	cfg := tree.DefaultPrettyCfg()
-	cfg.Align = tree.PrettyAlignOnly
-	cfg.LineWidth = tree.ConsoleLineWidth
-	aggregatedMetadata.FormattedQuery = cfg.Pretty(queryTree.AST)
-
+	aggregatedMetadata.FormattedQuery = aggregatedMetadata.Query
 	aggregatedMetadata.FingerprintID = string(tree.MustBeDString(row[5]))
 
 	statement = serverpb.StatementDetailsResponse_CollectedStatementSummary{

--- a/pkg/ui/workspaces/cluster-ui/src/sessions/sessionDetails.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/sessions/sessionDetails.tsx
@@ -346,7 +346,7 @@ export class SessionDetails extends React.Component<SessionDetailsProps> {
                 <SummaryCardItem
                   label={"Gateway Node"}
                   value={
-                    this.props.uiConfig.showGatewayNodeLink ? (
+                    this.props.uiConfig?.showGatewayNodeLink ? (
                       <div className={cx("session-details-link")}>
                         <NodeLink
                           nodeId={session.node_id.toString()}

--- a/pkg/ui/workspaces/cluster-ui/src/sql/box.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/sql/box.tsx
@@ -14,6 +14,7 @@ import classNames from "classnames/bind";
 
 import styles from "./sqlhighlight.module.scss";
 import * as protos from "@cockroachlabs/crdb-protobuf-client";
+import { FormatQuery } from "src/util";
 
 export enum SqlBoxSize {
   small = "small",
@@ -25,17 +26,21 @@ export interface SqlBoxProps {
   zone?: protos.cockroach.server.serverpb.DatabaseDetailsResponse;
   className?: string;
   size?: SqlBoxSize;
+  format?: boolean;
 }
 
 const cx = classNames.bind(styles);
 
 export class SqlBox extends React.Component<SqlBoxProps> {
   preNode: React.RefObject<HTMLPreElement> = React.createRef();
-  render() {
+  render(): React.ReactElement {
+    const value = this.props.format
+      ? FormatQuery(this.props.value)
+      : this.props.value;
     const sizeClass = this.props.size ? this.props.size : "";
     return (
       <div className={cx("box-highlight", this.props.className, sizeClass)}>
-        <Highlight {...this.props} />
+        <Highlight {...this.props} value={value} />
       </div>
     );
   }

--- a/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetails.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetails.tsx
@@ -470,6 +470,7 @@ export class StatementDetails extends React.Component<
               <SqlBox
                 value={this.props.latestFormattedQuery}
                 size={SqlBoxSize.small}
+                format={true}
               />
             </Col>
           </Row>
@@ -622,6 +623,7 @@ export class StatementDetails extends React.Component<
               <SqlBox
                 value={this.props.latestFormattedQuery}
                 size={SqlBoxSize.small}
+                format={true}
               />
             </Col>
           </Row>
@@ -770,7 +772,11 @@ export class StatementDetails extends React.Component<
         <section className={cx("section")}>
           <Row gutter={24}>
             <Col className="gutter-row" span={24}>
-              <SqlBox value={formatted_query} size={SqlBoxSize.small} />
+              <SqlBox
+                value={formatted_query}
+                size={SqlBoxSize.small}
+                format={true}
+              />
             </Col>
           </Row>
           <p className={summaryCardStylesCx("summary--card__divider")} />

--- a/pkg/ui/workspaces/cluster-ui/src/transactionDetails/transactionDetails.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionDetails/transactionDetails.tsx
@@ -294,6 +294,7 @@ export class TransactionDetails extends React.Component<
                         <SqlBox
                           value={latestTransactionText}
                           className={transactionDetailsStylesCx("summary-card")}
+                          format={true}
                         />
                       </Col>
                     </Row>
@@ -348,6 +349,7 @@ export class TransactionDetails extends React.Component<
                       <SqlBox
                         value={latestTransactionText}
                         className={transactionDetailsStylesCx("summary-card")}
+                        format={true}
                       />
                     </Col>
                     <Col span={8}>

--- a/pkg/ui/workspaces/cluster-ui/src/util/format.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/util/format.ts
@@ -218,3 +218,51 @@ export function FixFingerprintHexValue(s: string): string {
   }
   return s;
 }
+
+interface BreakLineReplacement {
+  [key: string]: string;
+}
+
+const breakLinesKeywords: BreakLineReplacement = {
+  " FROM ": " FROM ",
+  " WHERE ": "   WHERE ",
+  " AND ": "    AND ",
+  " ORDER ": " ORDER ",
+  " LIMIT ": " LIMIT ",
+  " JOIN ": "   JOIN ",
+  " ON ": "    ON ",
+  " VALUES ": "   VALUES ",
+};
+const LINE_BREAK_LIMIT = 100;
+
+export function FormatQuery(query: string): string {
+  if (query == null) {
+    return "";
+  }
+  Object.keys(breakLinesKeywords).forEach(key => {
+    query = query.replace(new RegExp(key, "g"), `\n${breakLinesKeywords[key]}`);
+  });
+  const lines = query.split("\n").map(line => {
+    if (line.length <= LINE_BREAK_LIMIT) {
+      return line;
+    }
+    return breakLongLine(line, LINE_BREAK_LIMIT);
+  });
+
+  return lines.join("\n");
+}
+
+function breakLongLine(line: string, limit: number): string {
+  if (line.length <= limit) {
+    return line;
+  }
+  const idxComma = line.indexOf(",", limit);
+  if (idxComma == -1) {
+    return line;
+  }
+
+  return `${line.substring(0, idxComma + 1)}\n${breakLongLine(
+    line.substring(idxComma + 1).trim(),
+    limit,
+  )}`;
+}


### PR DESCRIPTION
Backport 1/1 commits from #99450.

/cc @cockroachdb/release

---

The usage of `prettify_statement` and `Pretty` could cause OOM. Those were being used on statemen details and transaction insight details.
This commit removes those usages and add a very basic formatting function that can be used on the SQLBox component.

Part Of #91197

Release note (performance improvement): Removal of prettify usages that could cause OOM on Statement Details and Transaction Details page.

---
Release justification: bug fix
