### PR TITLE
release-22.2: server,sql: remove usages of prettify on details pages

### DIFF
--- a/pkg/roachpb/app_stats.proto
+++ b/pkg/roachpb/app_stats.proto
@@ -206,9 +206,8 @@ message StatementStatisticsKey {
 
 message AggregatedStatementMetadata {
   optional string query = 1 [(gogoproto.nullable) = false];
-  // Formatted query is the return of the key_data.query after prettify_statement.
-  // The query above cannot be replaced by the formatted value, because is used as is for
-  // diagnostic bundle.
+  // Formatted query is the same value of query. It used to be formatted with prettify_statement,
+  // but until that function is improved (#91197), it should not be used.
   optional string formatted_query = 2 [(gogoproto.nullable) = false];
   optional string query_summary = 3 [(gogoproto.nullable) = false];
   optional string stmt_type = 4 [(gogoproto.nullable) = false];

--- a/pkg/server/combined_statement_stats.go
+++ b/pkg/server/combined_statement_stats.go
@@ -23,7 +23,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/server/serverpb"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql"
-	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/catconstants"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
@@ -536,15 +535,7 @@ func getTotalStatementDetails(
 		return statement, serverError(ctx, err)
 	}
 
-	queryTree, err := parser.ParseOne(aggregatedMetadata.Query)
-	if err != nil {
-		return statement, serverError(ctx, err)
-	}
-	cfg := tree.DefaultPrettyCfg()
-	cfg.Align = tree.PrettyAlignOnly
-	cfg.LineWidth = tree.ConsoleLineWidth
-	aggregatedMetadata.FormattedQuery = cfg.Pretty(queryTree.AST)
-
+	aggregatedMetadata.FormattedQuery = aggregatedMetadata.Query
 	aggregatedMetadata.FingerprintID = string(tree.MustBeDString(row[3]))
 
 	statement = serverpb.StatementDetailsResponse_CollectedStatementSummary{

--- a/pkg/ui/workspaces/cluster-ui/src/insights/utils.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/utils.ts
@@ -280,14 +280,14 @@ export const filterStatementInsights = (
         }
 
         return (
-          (showInternal && isInternal(stmt.application)) ||
-          apps.includes(stmt.application)
+          (showInternal && isInternal(stmt?.application)) ||
+          apps.includes(stmt?.application)
         );
       },
     );
   } else {
     filteredStatements = filteredStatements.filter(
-      stmt => !isInternal(stmt.application),
+      stmt => !isInternal(stmt?.application),
     );
   }
   if (search) {

--- a/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsightDetails/statementInsightDetails.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsightDetails/statementInsightDetails.tsx
@@ -140,6 +140,7 @@ export const StatementInsightDetails: React.FC<
                 <SqlBox
                   size={SqlBoxSize.custom}
                   value={insightEventDetails?.query}
+                  format={true}
                 />
               </Col>
             </Row>

--- a/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsightDetails/transactionInsightDetails.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsightDetails/transactionInsightDetails.tsx
@@ -63,7 +63,7 @@ function insightsTableData(
   }
   return insightDetails.insights
     .filter(insight => insight.name === InsightNameEnum.highContention)
-    .map(insight => {
+    ?.map(insight => {
       return {
         type: "HighContention",
         details: {
@@ -134,11 +134,11 @@ export const TransactionInsightDetails: React.FC<
     getTransactionInsightEventDetailsFromState(insightEventDetails);
 
   const insightQueries =
-    insightDetails?.queries.join("") || "Insight not found.";
+    insightDetails?.queries?.join("") || "Insight not found.";
   const insightsColumns = makeInsightsColumns(isCockroachCloud, hasAdminRole);
 
   const blockingExecutions: EventExecution[] =
-    insightDetails?.blockingContentionDetails.map(x => {
+    insightDetails?.blockingContentionDetails?.map(x => {
       return {
         executionID: x.blockingExecutionID,
         fingerprintID: x.blockingFingerprintID,
@@ -185,7 +185,11 @@ export const TransactionInsightDetails: React.FC<
           <section className={tableCx("section")}>
             <Row gutter={24}>
               <Col className="gutter-row" span={24}>
-                <SqlBox value={insightQueries} size={SqlBoxSize.custom} />
+                <SqlBox
+                  value={insightQueries}
+                  size={SqlBoxSize.custom}
+                  format={true}
+                />
               </Col>
             </Row>
             {insightDetails && (

--- a/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsights/util/queriesCell.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsights/util/queriesCell.tsx
@@ -31,7 +31,7 @@ export function QueriesCell(
     return <div>{transactionQueries[0]}</div>;
   }
 
-  const combinedQuery = transactionQueries.map((query, idx, arr) => (
+  const combinedQuery = transactionQueries?.map((query, idx, arr) => (
     <div key={idx}>
       {idx != 0 && <br />}
       {query}

--- a/pkg/ui/workspaces/cluster-ui/src/jobs/jobDetailsPage/jobDetails.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/jobs/jobDetailsPage/jobDetails.tsx
@@ -99,7 +99,11 @@ export class JobDetails extends React.Component<JobDetailsProps> {
       <>
         <Row gutter={24}>
           <Col className="gutter-row" span={24}>
-            <SqlBox value={job.description} size={SqlBoxSize.custom} />
+            <SqlBox
+              value={job.description}
+              size={SqlBoxSize.custom}
+              format={true}
+            />
           </Col>
         </Row>
         <Row gutter={24}>

--- a/pkg/ui/workspaces/cluster-ui/src/sql/box.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/sql/box.tsx
@@ -14,6 +14,7 @@ import classNames from "classnames/bind";
 
 import styles from "./sqlhighlight.module.scss";
 import * as protos from "@cockroachlabs/crdb-protobuf-client";
+import { FormatQuery } from "src/util";
 
 export enum SqlBoxSize {
   small = "small",
@@ -26,6 +27,7 @@ export interface SqlBoxProps {
   zone?: protos.cockroach.server.serverpb.DatabaseDetailsResponse;
   className?: string;
   size?: SqlBoxSize;
+  format?: boolean;
 }
 
 const cx = classNames.bind(styles);
@@ -33,10 +35,13 @@ const cx = classNames.bind(styles);
 export class SqlBox extends React.Component<SqlBoxProps> {
   preNode: React.RefObject<HTMLPreElement> = React.createRef();
   render(): React.ReactElement {
+    const value = this.props.format
+      ? FormatQuery(this.props.value)
+      : this.props.value;
     const sizeClass = this.props.size ? this.props.size : "";
     return (
       <div className={cx("box-highlight", this.props.className, sizeClass)}>
-        <Highlight {...this.props} />
+        <Highlight {...this.props} value={value} />
       </div>
     );
   }

--- a/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetails.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetails.tsx
@@ -488,6 +488,7 @@ export class StatementDetails extends React.Component<
               <SqlBox
                 value={this.props.latestFormattedQuery}
                 size={SqlBoxSize.custom}
+                format={true}
               />
             </Col>
           </Row>
@@ -634,6 +635,7 @@ export class StatementDetails extends React.Component<
               <SqlBox
                 value={this.props.latestFormattedQuery}
                 size={SqlBoxSize.custom}
+                format={true}
               />
             </Col>
           </Row>
@@ -772,7 +774,11 @@ export class StatementDetails extends React.Component<
         <section className={cx("section")}>
           <Row gutter={24}>
             <Col className="gutter-row" span={24}>
-              <SqlBox value={formatted_query} size={SqlBoxSize.custom} />
+              <SqlBox
+                value={formatted_query}
+                size={SqlBoxSize.custom}
+                format={true}
+              />
             </Col>
           </Row>
           <p className={summaryCardStylesCx("summary--card__divider")} />

--- a/pkg/ui/workspaces/cluster-ui/src/transactionDetails/transactionDetails.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionDetails/transactionDetails.tsx
@@ -310,6 +310,7 @@ export class TransactionDetails extends React.Component<
                         <SqlBox
                           value={latestTransactionText}
                           className={transactionDetailsStylesCx("summary-card")}
+                          format={true}
                         />
                       </Col>
                     </Row>
@@ -399,6 +400,7 @@ export class TransactionDetails extends React.Component<
                       <SqlBox
                         value={latestTransactionText}
                         className={transactionDetailsStylesCx("summary-card")}
+                        format={true}
                       />
                     </Col>
                     <Col span={8}>

--- a/pkg/ui/workspaces/cluster-ui/src/util/format.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/util/format.ts
@@ -329,3 +329,51 @@ export function EncodeDatabaseTableIndexUri(
 export function EncodeDatabaseUri(db: string): string {
   return `/database/${EncodeUriName(db)}`;
 }
+
+interface BreakLineReplacement {
+  [key: string]: string;
+}
+
+const breakLinesKeywords: BreakLineReplacement = {
+  " FROM ": " FROM ",
+  " WHERE ": "   WHERE ",
+  " AND ": "    AND ",
+  " ORDER ": " ORDER ",
+  " LIMIT ": " LIMIT ",
+  " JOIN ": "   JOIN ",
+  " ON ": "    ON ",
+  " VALUES ": "   VALUES ",
+};
+const LINE_BREAK_LIMIT = 100;
+
+export function FormatQuery(query: string): string {
+  if (query == null) {
+    return "";
+  }
+  Object.keys(breakLinesKeywords).forEach(key => {
+    query = query.replace(new RegExp(key, "g"), `\n${breakLinesKeywords[key]}`);
+  });
+  const lines = query.split("\n").map(line => {
+    if (line.length <= LINE_BREAK_LIMIT) {
+      return line;
+    }
+    return breakLongLine(line, LINE_BREAK_LIMIT);
+  });
+
+  return lines.join("\n");
+}
+
+function breakLongLine(line: string, limit: number): string {
+  if (line.length <= limit) {
+    return line;
+  }
+  const idxComma = line.indexOf(",", limit);
+  if (idxComma == -1) {
+    return line;
+  }
+
+  return `${line.substring(0, idxComma + 1)}\n${breakLongLine(
+    line.substring(idxComma + 1).trim(),
+    limit,
+  )}`;
+}


### PR DESCRIPTION
Backport 1/1 commits from #99450.

/cc @cockroachdb/release

---

The usage of `prettify_statement` and `Pretty` could cause OOM. Those were being used on statemen details and transaction insight details.
This commit removes those usages and add a very basic formatting function that can be used on the SQLBox component.

Part Of #91197

Release note (performance improvement): Removal of prettify usages that could cause OOM on Statement Details and Transaction Details page.

---
Release justification: bug fix
