### PR TITLE
c2c: add acceptance test

### DIFF
--- a/pkg/cmd/roachtest/tests/acceptance.go
+++ b/pkg/cmd/roachtest/tests/acceptance.go
@@ -68,6 +68,13 @@ func registerAcceptance(r registry.Registry) {
 				timeout: 30 * time.Minute,
 			},
 		},
+		registry.OwnerDisasterRecovery: {
+			{
+				name:     "c2c",
+				fn:       runAcceptanceClusterReplication,
+				numNodes: 3,
+			},
+		},
 	}
 	tags := []string{"default", "quick"}
 	specTemplate := registry.TestSpec{

--- a/pkg/cmd/roachtest/tests/cluster_to_cluster.go
+++ b/pkg/cmd/roachtest/tests/cluster_to_cluster.go
@@ -564,6 +564,8 @@ func (sp *replicationTestSpec) main(ctx context.Context, t test.Test, c cluster.
 	sp.metrics.initalScanStart = newMetricSnapshot(metricSnapper, timeutil.Now())
 	ingestionJobID := sp.startReplicationStream()
 
+	removeTenantRateLimiters(t, sp.setup.dst.sysSQL, sp.setup.dst.name)
+
 	lv := makeLatencyVerifier("stream-ingestion", 0, 2*time.Minute, t.L(), getStreamIngestionJobInfo, t.Status, false)
 	defer lv.maybeLogLatencyHist()
 

--- a/pkg/cmd/roachtest/tests/cluster_to_cluster.go
+++ b/pkg/cmd/roachtest/tests/cluster_to_cluster.go
@@ -614,6 +614,23 @@ func (sp *replicationTestSpec) main(ctx context.Context, t test.Test, c cluster.
 	)
 	lv.assertValid(t)
 }
+func runAcceptanceClusterReplication(ctx context.Context, t test.Test, c cluster.Cluster) {
+	if !c.IsLocal() {
+		t.Fatal("acceptance tests should only run on a local cluster")
+	}
+	sp := replicationTestSpec{
+		srcNodes: 1,
+		dstNodes: 1,
+		// The timeout field ensures the c2c roachtest driver behaves properly.
+		timeout:            10 * time.Minute,
+		workload:           replicateKV{readPercent: 0, debugRunDurationMinutes: 1},
+		additionalDuration: 0 * time.Minute,
+		cutover:            30 * time.Second,
+	}
+	sp.setupC2C(ctx, t, c)
+	sp.main(ctx, t, c)
+}
+
 func registerClusterToCluster(r registry.Registry) {
 	for _, sp := range []replicationTestSpec{
 		{
@@ -664,7 +681,7 @@ func registerClusterToCluster(r registry.Registry) {
 			cpus:               4,
 			pdSize:             10,
 			workload:           replicateKV{readPercent: 0, debugRunDurationMinutes: 1},
-			timeout:            20 * time.Minute,
+			timeout:            5 * time.Minute,
 			additionalDuration: 0 * time.Minute,
 			cutover:            30 * time.Second,
 			skip:               "for local ad hoc testing",
@@ -683,7 +700,9 @@ func registerClusterToCluster(r registry.Registry) {
 	} {
 		sp := sp
 		clusterOps := make([]spec.Option, 0)
-		clusterOps = append(clusterOps, spec.CPU(sp.cpus))
+		if sp.cpus != 0 {
+			clusterOps = append(clusterOps, spec.CPU(sp.cpus))
+		}
 		if sp.pdSize != 0 {
 			clusterOps = append(clusterOps, spec.VolumeSize(sp.pdSize))
 		}

--- a/pkg/cmd/roachtest/tests/multitenant_utils.go
+++ b/pkg/cmd/roachtest/tests/multitenant_utils.go
@@ -366,7 +366,5 @@ func createInMemoryTenant(
 
 // removeTenantRateLimiters ensures the tenant is not throttled by limiters.
 func removeTenantRateLimiters(t test.Test, systemSQL *sqlutils.SQLRunner, tenantName string) {
-	systemSQL.Exec(t, `SELECT crdb_internal.update_tenant_resource_limits($1::STRING, 10000000000, 0,
-10000000000, now(), 0);`, tenantName)
 	systemSQL.Exec(t, `ALTER TENANT $1 GRANT CAPABILITY exempt_from_rate_limiting=true`, tenantName)
 }


### PR DESCRIPTION
c2c: add acceptance test

This patch adds a lightweight acceptance test that calls the main c2c roachtest
driver. This will add a c2c roachtest to Essential CI, preventing future
patches from inadvertently breaking the C2C roachtest driver.

Fixes #99230

Release note: None