### PR TITLE
kvserver: set noop action by default

### DIFF
--- a/pkg/kv/kvserver/replicate_queue.go
+++ b/pkg/kv/kvserver/replicate_queue.go
@@ -1001,7 +1001,11 @@ func (rq *replicateQueue) PlanOneChange(
 ) (change ReplicateQueueChange, _ error) {
 	// Initially set the change to be a no-op, it is then modified below if a
 	// step may be taken for this replica.
-	change = ReplicateQueueChange{Op: AllocationNoop{}}
+	change = ReplicateQueueChange{
+		Action:  allocatorimpl.AllocatorNoop,
+		Op:      AllocationNoop{},
+		replica: repl,
+	}
 
 	// Check lease and destroy status here. The queue does this higher up already, but
 	// adminScatter (and potential other future callers) also call this method and don't


### PR DESCRIPTION
It was possible for PlanOneChange to error before an allocator action was created. When tracking success/failure metrics for the replicate queue, this caused a `AllocatorAction <> unsupported in metrics tracking` error to be logged.

This commit updates PlanOneChange to set a Noop allocator action by default to avoid this error.

Fixes: #99474

Release note: None