### PR TITLE
cluster-ui: fix pagination for db pages using filters

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/databaseDetailsPage/databaseDetailsPage.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/databaseDetailsPage/databaseDetailsPage.tsx
@@ -860,7 +860,7 @@ export class DatabaseDetailsPage extends React.Component<
         <Pagination
           pageSize={this.state.pagination.pageSize}
           current={this.state.pagination.current}
-          total={this.props.tables.length}
+          total={tablesToDisplay.length}
           onChange={this.changePage.bind(this)}
         />
       </div>

--- a/pkg/ui/workspaces/cluster-ui/src/databasesPage/databasesPage.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/databasesPage/databasesPage.tsx
@@ -417,7 +417,7 @@ export class DatabasesPage extends React.Component<
     );
   };
 
-  // Returns a list of databses to the display based on input from the search
+  // Returns a list of databases to the display based on input from the search
   // box and the applied filters.
   filteredDatabasesData = (): DatabasesPageDataDatabase[] => {
     const { search, databases, filters, nodeRegions } = this.props;
@@ -732,7 +732,7 @@ export class DatabasesPage extends React.Component<
         <Pagination
           pageSize={this.state.pagination.pageSize}
           current={this.state.pagination.current}
-          total={this.props.databases.length}
+          total={databasesToDisplay.length}
           onChange={this.changePage}
         />
       </div>


### PR DESCRIPTION
Previously, the databases and database details pages were displaying pagination (i.e. number of pages/items) relative to the total dataset for the page (i.e. all databases/all tables). However, we are able to filter our dataset on these pages, changing the data being displayed, but the pagination did not change to reflect this making for a weird/incorrect UI. This change fixes the pagination to be based on the results that we display, not the entire dataset.

Release note (bug fix): fixed pagination issue with filtered results on the databases and database details page