### PR TITLE
[dnm] kvserver: more logging for #100096

### DIFF
--- a/pkg/cmd/roachtest/test_runner.go
+++ b/pkg/cmd/roachtest/test_runner.go
@@ -50,6 +50,11 @@ import (
 	"github.com/petermattis/goid"
 )
 
+var _, alwaysCollectArtifacts = map[string]bool{
+	"true": true,
+	"1":    true,
+}[os.Getenv("ROACHTEST_ALWAYS_COLLECT_ARTIFACTS")]
+
 var (
 	errTestsFailed = fmt.Errorf("some tests failed")
 
@@ -1111,7 +1116,7 @@ func (r *testRunner) teardownTest(
 			t.L().Printf("no live node found, skipping validation checks")
 		}
 
-		if timedOut || t.Failed() {
+		if timedOut || t.Failed() || alwaysCollectArtifacts {
 			r.collectClusterArtifacts(ctx, c, t.L())
 		}
 	})

--- a/pkg/cmd/roachtest/tests/copyfrom.go
+++ b/pkg/cmd/roachtest/tests/copyfrom.go
@@ -119,6 +119,10 @@ func runCopyFromCRDB(ctx context.Context, t test.Test, c cluster.Cluster, sf int
 	stmt := fmt.Sprintf("ALTER ROLE ALL SET copy_from_atomic_enabled = %t", atomic)
 	_, err = db.ExecContext(ctx, stmt)
 	require.NoError(t, err)
+	// See https://github.com/cockroachdb/cockroach/issues/99464#issuecomment-1482912491.
+	// This setting only has an effect if !atomic.
+	_, err = db.ExecContext(ctx, fmt.Sprintf(`ALTER ROLE ALL SET copy_from_retries_enabled = %t`, true))
+	require.NoError(t, err)
 	urls, err := c.InternalPGUrl(ctx, t.L(), c.Node(1), "")
 	require.NoError(t, err)
 	m := c.NewMonitor(ctx, c.All())

--- a/pkg/kv/kvserver/raft.go
+++ b/pkg/kv/kvserver/raft.go
@@ -14,6 +14,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"runtime/debug"
 	"sync"
 
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverbase"
@@ -88,6 +89,7 @@ func (r *raftLogger) Warning(v ...interface{}) {
 
 func (r *raftLogger) Warningf(format string, v ...interface{}) {
 	log.WarningfDepth(r.ctx, 1, format, v...)
+	log.WarningfDepth(r.ctx, 1, "stack: %s", debug.Stack())
 }
 
 func (r *raftLogger) Error(v ...interface{}) {

--- a/pkg/kv/kvserver/replica_proposal_bench_test.go
+++ b/pkg/kv/kvserver/replica_proposal_bench_test.go
@@ -22,7 +22,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
 	"github.com/cockroachdb/cockroach/pkg/util/humanizeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
-	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
 	"github.com/stretchr/testify/require"
 )
@@ -56,7 +55,7 @@ func BenchmarkReplicaProposal(b *testing.B) {
 
 func runBenchmarkReplicaProposal(b *testing.B, bytes int64, withFollower bool) {
 	defer leaktest.AfterTest(b)()
-	defer log.Scope(b).Close(b)
+	//defer log.Scope(b).Close(b)
 	ctx := context.Background()
 
 	nodes := 1

--- a/pkg/kv/kvserver/replica_proposal_buf.go
+++ b/pkg/kv/kvserver/replica_proposal_buf.go
@@ -934,7 +934,9 @@ func maybeLogErrProposalDropped(
 ) error {
 	var bytes int
 	if len(ents) != len(props) {
-		return errors.AssertionFailedf("have %d ents but %d proposals", len(ents), len(props))
+		err := errors.AssertionFailedf("have %d ents but %d proposals", len(ents), len(props))
+		panic(err) // HACK
+		//return err
 	}
 	for i := range ents {
 		bytes += ents[i].Size()
@@ -943,7 +945,7 @@ func maybeLogErrProposalDropped(
 			log.Eventf(p.ctx, "proposal dropped")
 		}
 	}
-	if everyErrProposalDropped.ShouldLog() {
+	if true || everyErrProposalDropped.ShouldLog() {
 		log.Infof(ctx, "dropped %d proposals (%s)", len(ents), humanizeutil.IBytes(int64(bytes)))
 	}
 	return nil

--- a/pkg/kv/kvserver/replica_raft.go
+++ b/pkg/kv/kvserver/replica_raft.go
@@ -636,12 +636,12 @@ func (s handleRaftReadyStats) SafeFormat(p redact.SafePrinter, _ rune) {
 		var sync redact.SafeString
 		if s.append.Sync {
 			if s.append.NonBlocking {
-				sync = "-non-blocking-sync"
+				sync = "non-blocking-sync" // actual sync time not reflected in this case
 			} else {
-				sync = "-sync"
+				sync = "sync"
 			}
 		}
-		p.Printf("raft ready handling: %.2fs [append=%.2fs, apply=%.2fs, commit-batch%s=%.2fs",
+		p.Printf("raft ready handling: %.2fs [append=%.2fs, apply=%.2fs, commit-append-%s=%.2fs",
 			dTotal.Seconds(), dAppend.Seconds(), dApply.Seconds(), sync, dPebble.Seconds())
 	}
 	if dSnap > 0 {
@@ -649,17 +649,10 @@ func (s handleRaftReadyStats) SafeFormat(p redact.SafePrinter, _ rune) {
 	}
 	p.Printf(", other=%.2fs]", dUnaccounted.Seconds())
 
-	p.Printf(", wrote %s",
-		humanizeutil.IBytes(s.append.PebbleBytes),
-	)
-	if s.append.Sync {
-		p.SafeString(" sync")
-		if s.append.NonBlocking {
-			p.SafeString("(non-blocking)")
-		}
+	p.Printf(", wrote [")
+	if b := s.append.PebbleBytes; b > 0 {
+		p.Printf("append-batch=%s, ", humanizeutil.IBytes(b))
 	}
-	p.SafeString(" [")
-
 	if b, n := s.append.RegularBytes, s.append.RegularEntries; n > 0 || b > 0 {
 		p.Printf("append-ent=%s (%d), ", humanizeutil.IBytes(b), n)
 	}

--- a/pkg/kv/kvserver/replica_raft_quiesce.go
+++ b/pkg/kv/kvserver/replica_raft_quiesce.go
@@ -91,7 +91,7 @@ func (r *Replica) maybeUnquiesceAndWakeLeaderLocked() bool {
 	// Propose an empty command which will wake the leader.
 	data := raftlog.EncodeRaftCommand(raftlog.EntryEncodingStandardWithoutAC, makeIDKey(), nil)
 	if r.RangeID > 60 {
-		log.Infof(ctx, "XXX UNQUIESCE li=%t", r.raftLastIndexRLocked())
+		log.Infof(ctx, "XXX UNQUIESCE li=%d", r.raftLastIndexRLocked())
 	}
 	_ = r.mu.internalRaftGroup.Propose(data)
 	return true
@@ -191,7 +191,7 @@ func (r *Replica) maybeQuiesceRaftMuLockedReplicaMuLocked(
 		return false
 	}
 	if r.RangeID > 60 {
-		log.Infof(ctx, "XXX SHOULD QUIESCE c=%d a=%d li=%t\n%s", status.Commit, status.Applied, r.raftLastIndexRLocked(), debug.Stack())
+		log.Infof(ctx, "XXX SHOULD QUIESCE c=%d a=%d li=%d\n%s", status.Commit, status.Applied, r.raftLastIndexRLocked(), debug.Stack())
 	}
 	return r.quiesceAndNotifyRaftMuLockedReplicaMuLocked(ctx, status, lagging)
 }

--- a/pkg/kv/kvserver/store_raft.go
+++ b/pkg/kv/kvserver/store_raft.go
@@ -651,7 +651,7 @@ func (s *Store) processReady(rangeID roachpb.RangeID) {
 	// use for warning about excessive raft mutex lock hold times. Long
 	// processing time means we'll have starved local replicas of ticks and
 	// remote replicas will likely start campaigning.
-	if elapsed >= defaultReplicaRaftMuWarnThreshold {
+	if elapsed >= defaultReplicaRaftMuWarnThreshold || stats.append.PebbleBytes > 1<<20 || stats.apply.numEntriesProcessedBytes > 1<<20 {
 		log.Infof(ctx, "%s; node might be overloaded", stats)
 	}
 }

--- a/pkg/kv/kvserver/testdata/handle_raft_ready_stats.txt
+++ b/pkg/kv/kvserver/testdata/handle_raft_ready_stats.txt
@@ -1,3 +1,3 @@
 echo
 ----
-raft ready handling: 5.00s [append=1.00s, apply=1.00s, commit-batch-sync=1.00s, snap=1.00s, other=1.00s], wrote 5.0 KiB sync [append-ent=1.0 KiB (7), append-sst=5.0 MiB (3), apply=3 B (2 in 9 batches)], state_assertions=4, snapshot applied
+raft ready handling: 5.00s [append=1.00s, apply=1.00s, commit-append-sync=1.00s, snap=1.00s, other=1.00s], wrote [append-batch=5.0 KiB, append-ent=1.0 KiB (7), append-sst=5.0 MiB (3), apply=3 B (2 in 9 batches)], state_assertions=4, snapshot applied


### PR DESCRIPTION
See https://github.com/cockroachdb/cockroach/issues/99464#issuecomment-1482912491 and https://github.com/cockroachdb/cockroach/issues/100096.

Run via gceworker:

```
gh pr checkout -f 99482
ROACHTEST_ALWAYS_COLLECT_ARTIFACTS=true ./pkg/cmd/roachtest/roachstress.sh -c 1 copyfrom/crdb-nonatomic/sf=1/nodes=1
```

Then look at logs from artifacts.

Epic: none
Release note: None
