### PR TITLE
release-23.1: multitenant: Disable multi-tenant demo for 23.1

### DIFF
--- a/pkg/cli/context.go
+++ b/pkg/cli/context.go
@@ -636,7 +636,7 @@ func setDemoContextDefaults() {
 	demoCtx.SQLPort, _ = strconv.Atoi(base.DefaultPort)
 	demoCtx.HTTPPort, _ = strconv.Atoi(base.DefaultHTTPPort)
 	demoCtx.WorkloadMaxQPS = 25
-	demoCtx.Multitenant = true
+	demoCtx.Multitenant = false
 	demoCtx.DisableServerController = false
 	demoCtx.DefaultEnableRangefeeds = true
 


### PR DESCRIPTION
Backport 1/1 commits from #99395.

/cc @cockroachdb/release

---

master was enabled to run demo with multi-tenant mode on by default. We don't want to ship this way however, because we're not prepared to fully document tenants and the unified architecture. Leaving this enabled by default on master, and disabling it explicitly on the 23.1 branch.

This PR should NOT merge to master, but can be backported to 23.1 manually.

Epic: None
Informs: #72341
Release note: None
Release justification: Low risk change involving new functionality
