### PR TITLE
ccl/multiregionccl: skip these tests just once

### DIFF
--- a/pkg/ccl/multiregionccl/datadriven_test.go
+++ b/pkg/ccl/multiregionccl/datadriven_test.go
@@ -116,14 +116,6 @@ func TestMultiRegionDataDriven(t *testing.T) {
 	skip.UnderRace(t, "flaky test")
 	ctx := context.Background()
 	datadriven.Walk(t, datapathutils.TestDataPath(t), func(t *testing.T, path string) {
-
-		if strings.Contains(path, "regional_by_table") {
-			skip.WithIssue(t, 98020, "flaky test")
-		}
-		if strings.Contains(path, "secondary_region") {
-			skip.WithIssue(t, 92235, "flaky test")
-		}
-
 		ds := datadrivenTestState{}
 		defer ds.cleanup(ctx)
 		var mu syncutil.Mutex


### PR DESCRIPTION
Part of #98020.

These tests were also skipped with datadriven language out in the testdata files in #99121, so let's remove the ad-hoc skips here.

Confirming they're still skipped after this change:

```
…/cockroach (un-double-skip +) ./dev test -v pkg/ccl/multiregionccl/ -f=TestMultiRegionDataDriven/regional_by_table
...
=== RUN   TestMultiRegionDataDriven/regional_by_table
    datadriven_test.go:129: [https://github.com/cockroachdb/cockroach/issues/98020]
=== CONT  TestMultiRegionDataDriven
    datadriven_test.go:428: -- test log scope end --
--- PASS: TestMultiRegionDataDriven (0.00s)
    --- SKIP: TestMultiRegionDataDriven/regional_by_table (0.00s)
...
```

```
…/cockroach (un-double-skip +) ./dev test -v pkg/ccl/multiregionccl/ -f=TestMultiRegionDataDriven/secondary_region
...
=== RUN   TestMultiRegionDataDriven/secondary_region
    datadriven_test.go:129: [https://github.com/cockroachdb/cockroach/issues/98020]
=== CONT  TestMultiRegionDataDriven
    datadriven_test.go:428: -- test log scope end --
--- PASS: TestMultiRegionDataDriven (0.00s)
    --- SKIP: TestMultiRegionDataDriven/secondary_region (0.00s)
...
```

Release note: None