### PR TITLE
roachtest: update sstable-corruption test to not block on quorum

### DIFF
--- a/pkg/cmd/roachtest/tests/sstable_corruption.go
+++ b/pkg/cmd/roachtest/tests/sstable_corruption.go
@@ -124,7 +124,7 @@ func runSSTableCorruption(ctx context.Context, t test.Test, c cluster.Cluster) {
 		}
 	}
 
-	if err := c.StartE(ctx, t.L(), option.DefaultStartOpts(), install.MakeClusterSettings(), crdbNodes); err != nil {
+	if err := c.StartE(ctx, t.L(), option.DefaultStartOptsNoBackups(), install.MakeClusterSettings(), crdbNodes); err != nil {
 		// Node detected corruption on start and crashed. This is good. No need
 		// to run workload; the test is complete.
 		_ = c.WipeE(ctx, t.L(), corruptNodes)
@@ -182,6 +182,7 @@ func registerSSTableCorruption(r registry.Registry) {
 		Name:    "sstable-corruption/table",
 		Owner:   registry.OwnerStorage,
 		Cluster: r.MakeClusterSpec(3),
+		Timeout: 2 * time.Hour,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			runSSTableCorruption(ctx, t, c)
 		},


### PR DESCRIPTION
Update the sstable-corruption roachtest to no longer set a new backup schedule when restarting the cluster after corrupting sstables. If corruption caused a quorum of nodes to exit asynchronously after startup, setting the new backup schedule would block indefinitely.

Closes #99280.
Epic: None
Release note: None