### PR TITLE
ui: fix Insights label

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/insightsTable/insightsTable.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insightsTable/insightsTable.tsx
@@ -99,7 +99,7 @@ function TypeCell(value: InsightType): React.ReactElement {
     insightType(value) === "FailedExecution"
       ? "insight-type-failed"
       : "insight-type";
-  return <div className={cx(className)}>{value}</div>;
+  return <div className={cx(className)}>{insightType(value)}</div>;
 }
 
 const StatementExecution = ({


### PR DESCRIPTION
A prior commit removed the formatting of Insight type. This commit adds it back, to display the correct formatting.

Epic: None

Before
<img width="236" alt="Screenshot 2023-03-23 at 11 54 20 AM" src="https://user-images.githubusercontent.com/1017486/227574487-e582045d-e751-4cc6-a244-75e313578509.png">
<img width="258" alt="Screenshot 2023-03-23 at 11 55 03 AM" src="https://user-images.githubusercontent.com/1017486/227574513-7dc366ec-5523-4130-8fd3-63ab0e8f9d07.png">
<img width="254" alt="Screenshot 2023-03-23 at 11 56 09 AM" src="https://user-images.githubusercontent.com/1017486/227574531-3fbab145-8a47-42b3-8fe0-7c4ac1b44fab.png">


After
<img width="289" alt="Screenshot 2023-03-24 at 11 44 44 AM" src="https://user-images.githubusercontent.com/1017486/227574565-3d591b44-16e2-4134-9f63-26e8bf853357.png">
<img width="309" alt="Screenshot 2023-03-24 at 11 44 52 AM" src="https://user-images.githubusercontent.com/1017486/227574580-f635d423-09f8-4b83-aa41-ae7d7f588dfe.png">
<img width="281" alt="Screenshot 2023-03-24 at 11 45 00 AM" src="https://user-images.githubusercontent.com/1017486/227574605-03be5968-7849-4cfb-bb5c-78db7fc5b7a4.png">


Release note: None