### PR TITLE
changefeedccl: Do not require rangefeed when running initial scan only.

### DIFF
--- a/pkg/ccl/changefeedccl/alter_changefeed_stmt.go
+++ b/pkg/ccl/changefeedccl/alter_changefeed_stmt.go
@@ -83,10 +83,6 @@ func alterChangefeedPlanHook(
 	}
 
 	fn := func(ctx context.Context, _ []sql.PlanNode, resultsCh chan<- tree.Datums) error {
-		if err := validateSettings(ctx, p); err != nil {
-			return err
-		}
-
 		typedExpr, err := alterChangefeedStmt.Jobs.TypeCheck(ctx, p.SemaCtx(), types.Int)
 		if err != nil {
 			return err
@@ -125,6 +121,14 @@ func alterChangefeedPlanHook(
 			ctx, exprEval, alterChangefeedStmt.Cmds, prevOpts, prevDetails.SinkURI,
 		)
 		if err != nil {
+			return err
+		}
+
+		st, err := newOptions.GetInitialScanType()
+		if err != nil {
+			return err
+		}
+		if err := validateSettings(ctx, st != changefeedbase.OnlyInitialScan, p.ExecCfg()); err != nil {
 			return err
 		}
 

--- a/pkg/ccl/changefeedccl/changefeed_stmt.go
+++ b/pkg/ccl/changefeedccl/changefeed_stmt.go
@@ -175,8 +175,12 @@ func changefeedPlanHook(
 	rowFn := func(ctx context.Context, _ []sql.PlanNode, resultsCh chan<- tree.Datums) error {
 		ctx, span := tracing.ChildSpan(ctx, stmt.StatementTag())
 		defer span.Finish()
-
-		if err := validateSettings(ctx, p); err != nil {
+		opts := changefeedbase.MakeStatementOptions(rawOpts)
+		st, err := opts.GetInitialScanType()
+		if err != nil {
+			return err
+		}
+		if err := validateSettings(ctx, st != changefeedbase.OnlyInitialScan, p.ExecCfg()); err != nil {
 			return err
 		}
 
@@ -185,8 +189,6 @@ func changefeedPlanHook(
 			// already sent the wrong result column headers.
 			return errors.New(`omit the SINK clause for inline results`)
 		}
-
-		opts := changefeedbase.MakeStatementOptions(rawOpts)
 
 		jr, err := createChangefeedJobRecord(
 			ctx,
@@ -719,10 +721,10 @@ func createChangefeedJobRecord(
 	return jr, nil
 }
 
-func validateSettings(ctx context.Context, p sql.PlanHookState) error {
+func validateSettings(ctx context.Context, needsRangeFeed bool, execCfg *sql.ExecutorConfig) error {
 	if err := featureflag.CheckEnabled(
 		ctx,
-		p.ExecCfg(),
+		execCfg,
 		featureChangefeedEnabled,
 		"CHANGEFEED",
 	); err != nil {
@@ -731,7 +733,7 @@ func validateSettings(ctx context.Context, p sql.PlanHookState) error {
 
 	// Changefeeds are based on the Rangefeed abstraction, which
 	// requires the `kv.rangefeed.enabled` setting to be true.
-	if !kvserver.RangefeedEnabled.Get(&p.ExecCfg().Settings.SV) {
+	if needsRangeFeed && !kvserver.RangefeedEnabled.Get(&execCfg.Settings.SV) {
 		return errors.Errorf("rangefeeds require the kv.rangefeed.enabled setting. See %s",
 			docs.URL(`change-data-capture.html#enable-rangefeeds-to-reduce-latency`))
 	}

--- a/pkg/cli/interactive_tests/test_demo_changefeeds.tcl
+++ b/pkg/cli/interactive_tests/test_demo_changefeeds.tcl
@@ -29,8 +29,8 @@ spawn $argv demo --no-line-editor --format=csv --auto-enable-rangefeeds=false
 # We should start in a populated database.
 eexpect "movr>"
 
-# initial_scan=only prevents the changefeed from hanging waiting for more changes. 
-send "CREATE CHANGEFEED FOR users WITH initial_scan='only';\r"
+# changefeed should exist since rangefeed not enabled.
+send "CREATE CHANGEFEED FOR users;\r"
 
 # changefeed should fail fast with an informative error.
 eexpect "ERROR: rangefeeds require the kv.rangefeed.enabled setting."


### PR DESCRIPTION
Fixes #99470

Release note: None