### PR TITLE
[dnm] server: add multi-tenant modes for default test tenant 

### DIFF
--- a/pkg/base/test_server_args.go
+++ b/pkg/base/test_server_args.go
@@ -159,6 +159,11 @@ type TestServerArgs struct {
 	// within tenants.
 	DisableDefaultTestTenant bool
 
+	// DefaultTestTenantMode specifies the mode in which the default test
+	// tenant will be started, if the test tenant is not disabled. See
+	// TestTenantMode for more details.
+	DefaultTestTenantMode TestTenantMode
+
 	// StartDiagnosticsReporting checks cluster.TelemetryOptOut(), and
 	// if not disabled starts the asynchronous goroutine that checks for
 	// CockroachDB upgrades and periodically reports diagnostics to
@@ -169,6 +174,22 @@ type TestServerArgs struct {
 	// If empty, exporting events is inhibited.
 	ObsServiceAddr string
 }
+
+// TestTenantMode specifies in which mode to start the default test tenant.
+type TestTenantMode int
+
+const (
+	// TestTenantModeProbabilistic means that the test tenant will
+	// probabilistically be started in either shared or separate process mode.
+	// This is the default.
+	TestTenantModeProbabilistic TestTenantMode = iota
+	// TestTenantModeSharedProcess means that the test tenant will be started in the
+	// same process as the test server.
+	TestTenantModeSharedProcess
+	// TestTenantModeSeparateProcess means that the test tenant will be started in
+	// a separate process.
+	TestTenantModeSeparateProcess
+)
 
 // TestClusterArgs contains the parameters one can set when creating a test
 // cluster. It contains a TestServerArgs instance which will be copied over to

--- a/pkg/testutils/serverutils/test_server_shim.go
+++ b/pkg/testutils/serverutils/test_server_shim.go
@@ -67,7 +67,9 @@ const (
 // If both the environment variable and the test flag are set, the environment
 // variable wins out.
 func ShouldStartDefaultTestTenant(t testing.TB) bool {
-	var defaultProbabilityOfStartingTestTenant = 0.5
+	// TODO(herko): Revert this after testing is complete. This is a temporary
+	// change to force full testing of multi-tenants.
+	var defaultProbabilityOfStartingTestTenant = 1.0
 	if skip.UnderBench() {
 		// Until #83461 is resolved, we want to make sure that we don't use the
 		// multi-tenant setup so that the comparison against old single-tenant


### PR DESCRIPTION
Informs #106772. 
Epic: CRDB-18499

Work in progress - do not merge

Currently this PR is forced to start the default test tenant and use the shared process mode to track failures.