### PR TITLE
sql: add support for re-using lease cache for audit logging

### DIFF
--- a/pkg/bench/rttanalysis/BUILD.bazel
+++ b/pkg/bench/rttanalysis/BUILD.bazel
@@ -36,6 +36,7 @@ go_test(
     size = "large",
     srcs = [
         "alter_table_bench_test.go",
+        "audit_bench_test.go",
         "bench_test.go",
         "create_alter_role_bench_test.go",
         "discard_bench_test.go",

--- a/pkg/bench/rttanalysis/audit_bench_test.go
+++ b/pkg/bench/rttanalysis/audit_bench_test.go
@@ -1,0 +1,25 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package rttanalysis
+
+import "testing"
+
+func BenchmarkAudit(b *testing.B) { reg.Run(b) }
+func init() {
+	reg.Register("Audit", []RoundTripBenchTestCase{
+		{
+			Name: "select from an audit table",
+			Setup: `CREATE TABLE audit_table(a INT);
+							ALTER TABLE audit_table EXPERIMENTAL_AUDIT SET READ WRITE;`,
+			Stmt: "SELECT * from audit_table",
+		},
+	})
+}

--- a/pkg/bench/rttanalysis/testdata/benchmark_expectations
+++ b/pkg/bench/rttanalysis/testdata/benchmark_expectations
@@ -27,6 +27,7 @@ exp,benchmark
 7,AlterTableUnsplit/alter_table_unsplit_at_1_value
 9,AlterTableUnsplit/alter_table_unsplit_at_2_values
 11,AlterTableUnsplit/alter_table_unsplit_at_3_values
+5,Audit/select_from_an_audit_table
 20,CreateRole/create_role_with_1_option
 23,CreateRole/create_role_with_2_options
 26,CreateRole/create_role_with_3_options


### PR DESCRIPTION
Previously, when a query needed to resolve table names for audit we would always take the hit of a KV call. This could be problematic since we could incur extra round trips on multi-region clusters. To address this, this patch will add support for using the lease cache for these looks up and eliminate any extra round trips.

Fixes: #99475

Release note (performance improvement): audit logging could incur extra latency when resolving table/view/sequence names.