### PR TITLE
opt: check UDF overloading a builtin invalidates the query cache

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/schema
+++ b/pkg/sql/logictest/testdata/logic_test/schema
@@ -1138,3 +1138,34 @@ statement ok
 USE test;
 DROP DATABASE d;
 DROP FUNCTION fn;
+
+# Regression test for #97757 - invalidate the query cache after changes to the
+# search path cause a function call to resolve to a UDF when it previously
+# resolved to a builtin function.
+subtest invalidate-builtin
+
+statement ok
+CREATE FUNCTION public.abs(val INT) RETURNS INT CALLED ON NULL INPUT LANGUAGE SQL AS $$ SELECT val+100 $$;
+
+query I
+SELECT abs(1);
+----
+1
+
+statement ok
+SET search_path = public, pg_catalog;
+
+# This should use the UDF abs which returns 101.
+query I
+SELECT abs(1);
+----
+101
+
+statement ok
+RESET search_path;
+
+# This should use the builtin abs again.
+query I
+SELECT abs(1);
+----
+1

--- a/pkg/sql/opt/optbuilder/scalar.go
+++ b/pkg/sql/opt/optbuilder/scalar.go
@@ -552,6 +552,7 @@ func (b *Builder) buildFunction(
 	if overload.HasSQLBody() {
 		return b.buildUDF(f, def, inScope, outScope, outCol, colRefs)
 	}
+	b.factory.Metadata().AddBuiltin(f.Func.ReferenceByName)
 
 	if overload.Class == tree.AggregateClass {
 		panic(errors.AssertionFailedf("aggregate function should have been replaced"))


### PR DESCRIPTION
It is possible to define a user-defined function with the same signature as a builtin function. Normally, an unqualified function call will resolve to the builtin function because its schema will be first in the search path. However, it is possible to modify the search path, so that the same function call can resolve to different functions on different executions. Example:
```
CREATE FUNCTION public.abs(val INT) RETURNS INT CALLED ON NULL INPUT LANGUAGE SQL AS $$ SELECT val+100 $$;
SELECT abs(1); --This should resolve to the builtin abs().
SET search_path = public, pg_catalog;
SELECT abs(1); --This should resolve to the udf abs().
```

Fixes #97757

Release note (bug fix): Fixed a bug existing from when user-defined functions were introduced that could cause a function call to resolve to the wrong function after changes to the schema search path.