### PR TITLE
release-22.2: changefeedccl: Allow timeout override

### DIFF
--- a/pkg/ccl/changefeedccl/metrics.go
+++ b/pkg/ccl/changefeedccl/metrics.go
@@ -62,6 +62,7 @@ type AggMetrics struct {
 	RunningCount              *aggmetric.AggGauge
 	BatchReductionCount       *aggmetric.AggGauge
 	InternalRetryMessageCount *aggmetric.AggGauge
+	SchemaRegistrations       *aggmetric.AggCounter
 	SchemaRegistryRetries     *aggmetric.AggCounter
 
 	// There is always at least 1 sliMetrics created for defaultSLI scope.
@@ -116,6 +117,7 @@ type sliMetrics struct {
 	RunningCount              *aggmetric.Gauge
 	BatchReductionCount       *aggmetric.Gauge
 	InternalRetryMessageCount *aggmetric.Gauge
+	SchemaRegistrations       *aggmetric.Counter
 	SchemaRegistryRetries     *aggmetric.Counter
 }
 
@@ -492,6 +494,12 @@ func newAggregateMetrics(histogramWindow time.Duration) *AggMetrics {
 		Measurement: "Retries",
 		Unit:        metric.Unit_COUNT,
 	}
+	metaSchemaRegistryRegistrations := metric.Metadata{
+		Name:        "changefeed.schema_registry.registrations",
+		Help:        "Number of registration attempts with the schema registry",
+		Measurement: "Registrations",
+		Unit:        metric.Unit_COUNT,
+	}
 	// NB: When adding new histograms, use sigFigs = 1.  Older histograms
 	// retain significant figures of 2.
 	b := aggmetric.MakeBuilder("scope")
@@ -544,6 +552,7 @@ func newAggregateMetrics(histogramWindow time.Duration) *AggMetrics {
 		BatchReductionCount:       b.Gauge(metaBatchReductionCount),
 		InternalRetryMessageCount: b.Gauge(metaInternalRetryMessageCount),
 		SchemaRegistryRetries:     b.Counter(metaSchemaRegistryRetriesCount),
+		SchemaRegistrations:       b.Counter(metaSchemaRegistryRegistrations),
 	}
 	a.mu.sliMetrics = make(map[string]*sliMetrics)
 	_, err := a.getOrCreateScope(defaultSLIScope)
@@ -599,6 +608,7 @@ func (a *AggMetrics) getOrCreateScope(scope string) (*sliMetrics, error) {
 		BatchReductionCount:       a.BatchReductionCount.AddChild(scope),
 		InternalRetryMessageCount: a.InternalRetryMessageCount.AddChild(scope),
 		SchemaRegistryRetries:     a.SchemaRegistryRetries.AddChild(scope),
+		SchemaRegistrations:       a.SchemaRegistrations.AddChild(scope),
 	}
 
 	a.mu.sliMetrics[scope] = sm

--- a/pkg/ccl/changefeedccl/schema_registry.go
+++ b/pkg/ccl/changefeedccl/schema_registry.go
@@ -16,6 +16,7 @@ import (
 	"io"
 	"net/url"
 	"path"
+	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/changefeedbase"
@@ -60,23 +61,29 @@ type confluentSchemaRegistry struct {
 
 var _ schemaRegistry = (*confluentSchemaRegistry)(nil)
 
-type schemaRegistryParams map[string][]byte
+type schemaRegistryParams struct {
+	params  map[string][]byte
+	timeout time.Duration
+}
 
 func (s schemaRegistryParams) caCert() []byte {
-	return s[changefeedbase.RegistryParamCACert]
+	return s.params[changefeedbase.RegistryParamCACert]
 }
 
 func (s schemaRegistryParams) clientCert() []byte {
-	return s[changefeedbase.RegistryParamClientCert]
+	return s.params[changefeedbase.RegistryParamClientCert]
 }
 
 func (s schemaRegistryParams) clientKey() []byte {
-	return s[changefeedbase.RegistryParamClientKey]
+	return s.params[changefeedbase.RegistryParamClientKey]
 }
 
-func getAndDeleteParams(u *url.URL) (schemaRegistryParams, error) {
+const timeoutParam = "timeout"
+const defaultSchemaRegistryTimeout = 30 * time.Second
+
+func getAndDeleteParams(u *url.URL) (*schemaRegistryParams, error) {
 	query := u.Query()
-	s := make(schemaRegistryParams, 3)
+	s := schemaRegistryParams{params: make(map[string][]byte, 3)}
 	for _, k := range []string{
 		changefeedbase.RegistryParamCACert,
 		changefeedbase.RegistryParamClientCert,
@@ -87,14 +94,26 @@ func getAndDeleteParams(u *url.URL) (schemaRegistryParams, error) {
 			if err != nil {
 				return nil, errors.Wrapf(err, "param %s must be base 64 encoded", k)
 			}
-			s[k] = decoded
+			s.params[k] = decoded
 			query.Del(k)
 		}
 	}
+
+	if strTimeout := query.Get(timeoutParam); strTimeout != "" {
+		dur, err := time.ParseDuration(strTimeout)
+		if err != nil {
+			return nil, err
+		}
+		s.timeout = dur
+	} else {
+		// Default timeout in httputil is way too low. Use something more reasonable.
+		s.timeout = defaultSchemaRegistryTimeout
+	}
+
 	// remove crdb query params to ensure compatibility with schema
 	// registry implementation
 	u.RawQuery = query.Encode()
-	return s, nil
+	return &s, nil
 }
 
 func newConfluentSchemaRegistry(
@@ -131,14 +150,17 @@ func newConfluentSchemaRegistry(
 // Setup the httputil.Client to use when dialing Confluent schema registry. If `ca_cert`
 // is set as a query param in the registry URL, client should trust the corresponding
 // cert while dialing. Otherwise, use the DefaultClient.
-func setupHTTPClient(baseURL *url.URL, s schemaRegistryParams) (*httputil.Client, error) {
-	if len(s) == 0 {
-		return httputil.DefaultClient, nil
+func setupHTTPClient(baseURL *url.URL, s *schemaRegistryParams) (*httputil.Client, error) {
+	if len(s.params) == 0 {
+		return httputil.NewClientWithTimeout(s.timeout), nil
 	}
+
 	httpClient, err := newClientFromTLSKeyPair(s.caCert(), s.clientCert(), s.clientKey())
 	if err != nil {
 		return nil, err
 	}
+	httpClient.Timeout = s.timeout
+
 	if baseURL.Scheme == "http" {
 		log.Warningf(context.Background(), "TLS configuration provided but schema registry %s uses HTTP", baseURL)
 	}
@@ -207,6 +229,9 @@ func (r *confluentSchemaRegistry) RegisterSchemaForSubject(
 	})
 	if err != nil {
 		return 0, err
+	}
+	if r.sliMetrics != nil {
+		r.sliMetrics.SchemaRegistrations.Inc(1)
 	}
 	return id, nil
 }

--- a/pkg/ts/catalog/chart_catalog.go
+++ b/pkg/ts/catalog/chart_catalog.go
@@ -1546,6 +1546,12 @@ var charts = []sectionDescription{
 					"changefeed.schema_registry.retry_count",
 				},
 			},
+			{
+				Title: "Schema Registry Registrations",
+				Metrics: []string{
+					"changefeed.schema_registry.registrations",
+				},
+			},
 		},
 	},
 	{


### PR DESCRIPTION
Backport 1/1 commits from #99077.

/cc @cockroachdb/release

---

Add timeout URL parameter for schema registry URIs. Prior to this change, all schema registry calls used default time out of 3 seconds.  This PR increases the timeout to 30 seconds, and allows timeout to be specified via `timeout=T` URL parameter.

Informs https://github.com/cockroachlabs/support/issues/2173

Release note (enterprise change): AVRO schema registry URI allow additional `timeout=T` query parameter to change the default timeout for contacting schema registry.
Release justification: stability improvement fix.
