### PR TITLE
jobs: fix bug in the InfoStorage read path

### DIFF
--- a/pkg/jobs/BUILD.bazel
+++ b/pkg/jobs/BUILD.bazel
@@ -105,6 +105,8 @@ go_test(
     shard_count = 16,
     deps = [
         "//pkg/base",
+        "//pkg/ccl/backupccl",
+        "//pkg/cloud/impl:cloudimpl",
         "//pkg/clusterversion",
         "//pkg/jobs/jobspb",
         "//pkg/jobs/jobsprotectedts",
@@ -137,6 +139,7 @@ go_test(
         "//pkg/sql/sqlliveness",
         "//pkg/sql/tests",
         "//pkg/testutils",
+        "//pkg/testutils/jobutils",
         "//pkg/testutils/serverutils",
         "//pkg/testutils/skip",
         "//pkg/testutils/sqlutils",

--- a/pkg/jobs/job_info_storage.go
+++ b/pkg/jobs/job_info_storage.go
@@ -82,7 +82,7 @@ func (i InfoStorage) get(ctx context.Context, infoKey []byte) ([]byte, bool, err
 	row, err := i.txn.QueryRowEx(
 		ctx, "job-info-get", i.txn.KV(),
 		sessiondata.NodeUserSessionDataOverride,
-		"SELECT value FROM system.job_info WHERE job_id = $1 AND info_key = $2",
+		"SELECT value FROM system.job_info WHERE job_id = $1 AND info_key = $2 ORDER BY written LIMIT 1",
 		j.ID(), infoKey,
 	)
 

--- a/pkg/jobs/job_info_storage_test.go
+++ b/pkg/jobs/job_info_storage_test.go
@@ -12,17 +12,24 @@ package jobs_test
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
+	_ "github.com/cockroachdb/cockroach/pkg/ccl/backupccl" // import ccl to be able to run backups
+	_ "github.com/cockroachdb/cockroach/pkg/cloud/impl"    // register cloud storage providers
+	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/jobs"
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
 	"github.com/cockroachdb/cockroach/pkg/keyvisualizer"
 	"github.com/cockroachdb/cockroach/pkg/security/username"
+	"github.com/cockroachdb/cockroach/pkg/server"
 	"github.com/cockroachdb/cockroach/pkg/sql/isql"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/jobutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/upgrade/upgradebase"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -289,4 +296,55 @@ func TestAccessorsWithWrongSQLLivenessSession(t *testing.T) {
 			return nil
 		})
 	}))
+}
+
+// TestJobInfoUpgradeRegressionTests is a regression test where a job that is
+// created before V23_1JobInfoTableIsBackfilled and continues to run during the
+// V23_1JobInfoTableIsBackfilled upgrade will have duplicate payload and
+// progress rows in the job_info table. Prior to the fix this caused the
+// InfoStorage read path to error out on seeing more than one row per jobID,
+// info_key.
+func TestJobInfoUpgradeRegressionTests(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	s, sqlDB, _ := serverutils.StartServer(t, base.TestServerArgs{
+		DisableDefaultTestTenant: true,
+		Knobs: base.TestingKnobs{
+			Server: &server.TestingKnobs{
+				DisableAutomaticVersionUpgrade: make(chan struct{}),
+				BinaryVersionOverride:          clusterversion.ByKey(clusterversion.BinaryMinSupportedVersionKey),
+				BootstrapVersionKeyOverride:    clusterversion.BinaryMinSupportedVersionKey,
+			},
+			JobsTestingKnobs: jobs.NewTestingKnobsWithShortIntervals(),
+		},
+	})
+	ctx := context.Background()
+	defer s.Stopper().Stop(ctx)
+
+	_, err := sqlDB.Exec(`SET CLUSTER SETTING version = $1`, clusterversion.V23_1CreateSystemJobInfoTable.String())
+	require.NoError(t, err)
+
+	_, err = sqlDB.Exec(`SET CLUSTER SETTING jobs.debug.pausepoints = 'backup.after.write_lock'`)
+	require.NoError(t, err)
+
+	var jobID jobspb.JobID
+	require.NoError(t, sqlDB.QueryRow(`BACKUP INTO 'userfile:///foo' WITH detached`).Scan(&jobID))
+	runner := sqlutils.MakeSQLRunner(sqlDB)
+	jobutils.WaitForJobToPause(t, runner, jobID)
+
+	runner.CheckQueryResults(t, fmt.Sprintf(`SELECT count(*) FROM system.job_info WHERE job_id = %d`, jobID),
+		[][]string{{"2"}})
+
+	_, err = sqlDB.Exec(`SET CLUSTER SETTING version = $1`, clusterversion.V23_1JobInfoTableIsBackfilled.String())
+	require.NoError(t, err)
+
+	runner.CheckQueryResults(t, fmt.Sprintf(`SELECT count(*) FROM system.job_info WHERE job_id = %d`, jobID),
+		[][]string{{"4"}})
+
+	err = s.InternalDB().(isql.DB).Txn(ctx, func(ctx context.Context, txn isql.Txn) error {
+		infoStorage := jobs.InfoStorageForJob(txn, jobID)
+		_, _, err := infoStorage.Get(ctx, jobs.GetLegacyPayloadKey())
+		return err
+	})
+	require.NoError(t, err)
 }

--- a/pkg/jobs/jobs_test.go
+++ b/pkg/jobs/jobs_test.go
@@ -2426,6 +2426,7 @@ func TestJobInTxn(t *testing.T) {
 
 	defer sql.ClearPlanHooks()
 	// Piggy back on BACKUP to be able to create a succeeding test job.
+	sql.ClearPlanHooks()
 	sql.AddPlanHook(
 		"test",
 		func(_ context.Context, stmt tree.Statement, execCtx sql.PlanHookState,


### PR DESCRIPTION
In a previous PR we dropped the LIMIT 1 clause
from the read path in InfoStorage under the assumption that for a joID, infoKey we will always have atmost one row. While still true for all users interacting with InfoStorage via the accessors, this assumption might not hold
during upgrades. Jobs start writing their payload and progress to the job_info table once V23_1CreateSystemJobInfoTable is active. If a job is still running when the cluster steps through V23_1JobInfoTableIsBackfilled then the job will have duplicate entries for the payload and prgress rows. This is because we blindly backfill the contents of the `jobs` table into the `job_info` table without clearing previous entries corresponding to the job.

To guard against this case we introduce a LIMIT 1 clause to the read query so that we always get the most recently written row corresponding to a jobID and info_key.

Fixes: #99101

Release note: None