### PR TITLE
ts: fix tenant metrics scan in tsdb

### DIFF
--- a/pkg/ts/query.go
+++ b/pkg/ts/query.go
@@ -852,10 +852,13 @@ func (db *DB) readFromDatabase(
 				key := MakeDataKey(seriesName, source, diskResolution, currentTimestamp)
 				b.Get(key)
 			} else {
-				// Otherwise, we scan  all keys that prefix match the source, since the system tenant
-				// reads all tenant time series.
-				startKey := MakeDataKey(seriesName, source, diskResolution, currentTimestamp)
-				endKey := MakeDataKey(seriesName, source, diskResolution, currentTimestamp).PrefixEnd()
+				// Otherwise, we get the source associated with the system tenant.
+				key := MakeDataKey(seriesName, source, diskResolution, currentTimestamp)
+				b.Get(key)
+				// Then we scan all keys that match the tenant source prefix since the system tenant
+				// aggregates sources across all tenants.
+				startKey := MakeDataKey(seriesName, tsutil.MakeTenantSourcePrefix(source), diskResolution, currentTimestamp)
+				endKey := MakeDataKey(seriesName, tsutil.MakeTenantSourcePrefix(source), diskResolution, currentTimestamp).PrefixEnd()
 				b.Scan(startKey, endKey)
 			}
 		}

--- a/pkg/ts/server_test.go
+++ b/pkg/ts/server_test.go
@@ -341,7 +341,7 @@ func TestServerQueryTenant(t *testing.T) {
 		},
 		{
 			Name:   "test.metric",
-			Source: "1-10",
+			Source: "1-2",
 			Datapoints: []tspb.TimeSeriesDatapoint{
 				{
 					TimestampNanos: 400 * 1e9,
@@ -355,7 +355,7 @@ func TestServerQueryTenant(t *testing.T) {
 		},
 		{
 			Name:   "test.metric",
-			Source: "2",
+			Source: "10",
 			Datapoints: []tspb.TimeSeriesDatapoint{
 				{
 					TimestampNanos: 400 * 1e9,
@@ -369,7 +369,7 @@ func TestServerQueryTenant(t *testing.T) {
 		},
 		{
 			Name:   "test.metric",
-			Source: "2-10",
+			Source: "10-2",
 			Datapoints: []tspb.TimeSeriesDatapoint{
 				{
 					TimestampNanos: 400 * 1e9,
@@ -407,7 +407,7 @@ func TestServerQueryTenant(t *testing.T) {
 			{
 				Query: tspb.Query{
 					Name:    "test.metric",
-					Sources: []string{"1", "2"},
+					Sources: []string{"1", "10"},
 				},
 				Datapoints: []tspb.TimeSeriesDatapoint{
 					{
@@ -451,7 +451,7 @@ func TestServerQueryTenant(t *testing.T) {
 	require.Equal(t, expectedSystemResult, systemResponse)
 
 	// App tenant should only report metrics with its tenant ID in the secondary source field
-	tenantID := roachpb.MustMakeTenantID(10)
+	tenantID := roachpb.MustMakeTenantID(2)
 	expectedTenantResponse := &tspb.TimeSeriesQueryResponse{
 		Results: []tspb.TimeSeriesQueryResponse_Result{
 			{
@@ -474,7 +474,7 @@ func TestServerQueryTenant(t *testing.T) {
 			{
 				Query: tspb.Query{
 					Name:     "test.metric",
-					Sources:  []string{"1", "2"},
+					Sources:  []string{"1", "10"},
 					TenantID: tenantID,
 				},
 				Datapoints: []tspb.TimeSeriesDatapoint{
@@ -492,7 +492,7 @@ func TestServerQueryTenant(t *testing.T) {
 	}
 
 	tenant, _ := serverutils.StartTenant(t, testCluster.Server(0), base.TestTenantArgs{TenantID: tenantID})
-	_, err = systemDB.Exec("ALTER TENANT [10] GRANT CAPABILITY can_view_tsdb_metrics=true;\n")
+	_, err = systemDB.Exec("ALTER TENANT [2] GRANT CAPABILITY can_view_tsdb_metrics=true;\n")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/ts/tsutil/util.go
+++ b/pkg/ts/tsutil/util.go
@@ -37,12 +37,20 @@ func DumpRawTo(src tspb.TimeSeries_DumpRawClient, out io.Writer) error {
 	}
 }
 
-// MakeTenantSource creates a source given a NodeID and a TenantID
+// MakeTenantSource creates a source given a NodeID and a TenantID.
 func MakeTenantSource(nodeID string, tenantID string) string {
 	if tenantID != "" {
 		return fmt.Sprintf("%s-%s", nodeID, tenantID)
 	}
 	return nodeID
+}
+
+// MakeTenantSourcePrefix adds the tenant source suffix to a given source.
+func MakeTenantSourcePrefix(source string) string {
+	if source != "" {
+		return fmt.Sprintf("%s-", source)
+	}
+	return source
 }
 
 // DecodeSource splits a source into its individual components.


### PR DESCRIPTION
In https://github.com/cockroachdb/cockroach/pull/98077, we introduced tenant scoped metrics into tsdb. These metric were part of the source field used for NodeIDs previously. Since the intended purpose for the system tenant was to be able to aggregate across all tenant metrics, we introduced a new scan over the entire keyspace for the given Node source. This introduced a bug:

When we prefix match the source to scan over its keyspace, it includes all sources that match that prefix. For a 10 node cluster with 3 tenants, this meant fetching timeseries for Node 1 would include:
```
1
1-2
1-3
10
10-2
10-3
```
This would then aggregate data across Node 1 and Node 10. If there were no secondary tenants, it would include the sources:
```
1
10
```

This fix separates the get of the initial system tenant metric and scan across all tenants (with a tenant prefix) to only scan the desired source. Now in the same 10 Node cluster with 3 tenants, it will include:
```
1
1-2
1-3
```
The scan is now from the beginning of `1-` to its end, ensuring only Node 1's tenants are included and not Node 10 or 100 or 1000.

Fixes: #99486

Release note: None