### PR TITLE
kv: remove expensive print

### DIFF
--- a/pkg/kv/kvserver/batcheval/cmd_refresh_range_bench_test.go
+++ b/pkg/kv/kvserver/batcheval/cmd_refresh_range_bench_test.go
@@ -125,6 +125,8 @@ func runRefreshRangeBenchmark(b *testing.B, emk engineMaker, opts benchOptions) 
 	startKey := roachpb.Key(encoding.EncodeUvarintAscending([]byte("key-"), uint64(0)))
 	endKey := roachpb.Key(encoding.EncodeUvarintAscending([]byte("key-"), uint64(opts.dataOpts.numKeys)))
 
+	var refreshErr *kvpb.RefreshFailedError
+
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		func() {
@@ -157,7 +159,7 @@ func runRefreshRangeBenchmark(b *testing.B, emk engineMaker, opts benchOptions) 
 				require.NoError(b, err)
 			} else {
 				require.Error(b, err)
-				require.Regexp(b, "encountered recently written committed value", err)
+				require.ErrorAs(b, err, &refreshErr)
 			}
 		}()
 	}


### PR DESCRIPTION
Removes an unnecessarily expensive assertion from the bench test as it was taking >50% of the runtime. Now the test correctly spends time on the important code.

Informs: #98881

Epic: none
Release note: None