### PR TITLE
streamingccl: skip acceptance/c2c on remote cluster setup

### DIFF
--- a/pkg/cmd/roachtest/tests/cluster_to_cluster.go
+++ b/pkg/cmd/roachtest/tests/cluster_to_cluster.go
@@ -616,7 +616,7 @@ func (sp *replicationTestSpec) main(ctx context.Context, t test.Test, c cluster.
 }
 func runAcceptanceClusterReplication(ctx context.Context, t test.Test, c cluster.Cluster) {
 	if !c.IsLocal() {
-		t.Fatal("acceptance tests should only run on a local cluster")
+		t.Skip("c2c/acceptance is only meant to run on a local cluster")
 	}
 	sp := replicationTestSpec{
 		srcNodes: 1,


### PR DESCRIPTION
acceptance/c2c currently fails when run on a remote cluster. This patch ensures the test gets skipped when run on a remote cluster. There's no need to run the test on a remote cluster because the other c2c roachtests provide sufficient coverage.

Fixes #99553

Release note: none