### PR TITLE
kvserver: skip TestBackpressureNotAppliedWhenReducingRangeSize under …

### DIFF
--- a/pkg/kv/kvserver/client_replica_backpressure_test.go
+++ b/pkg/kv/kvserver/client_replica_backpressure_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
@@ -39,6 +40,8 @@ import (
 func TestBackpressureNotAppliedWhenReducingRangeSize(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
+
+	skip.UnderRace(t, "takes >1m under race")
 
 	rRand, _ := randutil.NewTestRand()
 	ctx := context.Background()


### PR DESCRIPTION
…race

Fixing an omission in https://github.com/cockroachdb/cockroach/pull/96725. This test sends snapshots and takes many minutes under race. This PR skips it.

Epic: none
Release note: None