### PR TITLE
tree: apply functions to TEXT expressions compared with the @@ operator

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/tsvector
+++ b/pkg/sql/logictest/testdata/logic_test/tsvector
@@ -360,3 +360,67 @@ LIMIT
 	2
 ----
 0
+
+subtest 98804_regression_test
+
+statement ok
+RESET default_text_search_config
+
+statement ok
+CREATE TABLE ab (a TEXT, b TEXT)
+
+statement ok
+INSERT INTO ab VALUES('fat rats', 'fat cats chased fat, out of shape rats');
+
+query B
+SELECT a @@ b FROM ab
+----
+false
+
+query B
+SELECT b @@ a FROM ab
+----
+true
+
+query B
+SELECT 'fat rats' @@ b FROM ab
+----
+false
+
+query B
+SELECT b @@ 'fat rats' FROM ab
+----
+true
+
+query B
+SELECT a @@ 'fat cats ate fat bats' FROM ab
+----
+false
+
+query B
+SELECT 'fat cats ate fat bats' @@ a FROM ab
+----
+false
+
+statement error pq: syntax error in TSQuery: fat cats chased fat, out of shape rats
+SELECT b @@ a::tsvector FROM ab
+
+statement error pq: syntax error in TSQuery: fat cats chased fat, out of shape rats
+SELECT a::tsvector @@ b FROM ab
+
+query B
+SELECT 'fat bat cat' @@ 'bats fats'
+----
+true
+
+query B
+SELECT 'bats fats' @@ 'fat bat cat'
+----
+false
+
+statement error pq: syntax error in TSQuery: fat cats chased fat, out of shape rats
+SELECT 'fat cats chased fat, out of shape rats' @@ 'fat rats'::tsvector
+
+statement error pq: syntax error in TSQuery: fat cats chased fat, out of shape rats
+SELECT 'fat rats'::tsvector @@ 'fat cats chased fat, out of shape rats'
+

--- a/pkg/sql/sem/tree/overload.go
+++ b/pkg/sql/sem/tree/overload.go
@@ -997,7 +997,7 @@ func (s *overloadTypeChecker) typeCheckOverloadedExprs(
 			return err
 		}
 
-		// The fourth heuristic is to prefer candidates that accepts the "best"
+		// The fourth heuristic is to prefer candidates that accept the "best"
 		// mutual type in the resolvable type set of all constants.
 		if bestConstType, ok := commonConstantType(s.exprs, s.constIdxs); ok {
 			// In case all overloads are filtered out at this step,

--- a/pkg/sql/sem/tree/type_check_test.go
+++ b/pkg/sql/sem/tree/type_check_test.go
@@ -213,6 +213,13 @@ func TestTypeCheck(t *testing.T) {
 
 		// String preference.
 		{`st_geomfromgeojson($1)`, `st_geomfromgeojson($1:::STRING):::GEOMETRY`},
+
+		// TSQuery and TSVector
+		{`'a' @@ 'b'`, `to_tsvector('a':::STRING) @@ plainto_tsquery('b':::STRING)`},
+		{`'a' @@ 'b':::TSQUERY`, `to_tsvector('a':::STRING) @@ '''b''':::TSQUERY`},
+		{`'a':::TSQUERY @@ 'b'`, `'''a''':::TSQUERY @@ to_tsvector('b':::STRING)`},
+		{`'a' @@ 'b':::TSVECTOR`, `'a':::STRING::TSQUERY @@ '''b''':::TSVECTOR`},
+		{`'a':::TSVECTOR @@ 'b'`, `'''a''':::TSVECTOR @@ 'b':::STRING::TSQUERY`},
 	}
 	ctx := context.Background()
 	for _, d := range testData {


### PR DESCRIPTION
The TSQuery and TSVector "matches" operator "@@" returns different results on CRDB vs. Postgres when one of the arguments is a TEXT expression. CRDB always applies a CAST, and only for constants. The rules at https://www.postgresql.org/docs/current/textsearch-intro.html#TEXTSEARCH-MATCHING specify:
> The form text @@ tsquery is equivalent to to_tsvector(x) @@ y.
> The form text @@ text is equivalent to to_tsvector(x) @@ plainto_tsquery(y).

This PR adds these implicit function calls in these "matches" comparison expressions during type checking as well as a cast of TEXT to TSQuery when the other argument is a TSVector, which allows variable expressions to be handled.

Fixes #98875
Fixes #98804

Release note (bug fix): This allows the text search @@ ("matches") operator to work with variable expressions and fixes incorrect results when one of the arguments is a TEXT expression and the other argument is a TEXT or TSQuery expression.