### PR TITLE
jobs: add WithCancelOnQuiesce to the registry

### DIFF
--- a/pkg/jobs/adopt.go
+++ b/pkg/jobs/adopt.go
@@ -379,10 +379,13 @@ func (r *Registry) resumeJob(
 	}
 
 	r.metrics.ResumedJobs.Inc(1)
-	if err := r.stopper.RunAsyncTask(ctx, job.taskName(), func(ctx context.Context) {
+	if err := r.stopper.RunAsyncTask(resumeCtx, job.taskName(), func(ctx context.Context) {
 		// Wait for the job to finish. No need to print the error because if there
 		// was one it's been set in the job status already.
-		_ = r.runJob(resumeCtx, resumer, job, status, job.taskName())
+		var cleanup func()
+		ctx, cleanup = r.stopper.WithCancelOnQuiesce(ctx)
+		defer cleanup()
+		_ = r.runJob(ctx, resumer, job, status, job.taskName())
 	}); err != nil {
 		r.unregister(jobID)
 		// Also avoid leaking a goroutine in this case.

--- a/pkg/jobs/registry.go
+++ b/pkg/jobs/registry.go
@@ -1077,8 +1077,8 @@ func (r *Registry) Start(ctx context.Context, stopper *stop.Stopper) error {
 			case <-lc.updated:
 				lc.onUpdate()
 			case <-r.stopper.ShouldQuiesce():
-				log.Warningf(ctx, "canceling all adopted jobs due to stopper quiescing")
-				r.cancelAllAdoptedJobs()
+				// Note: the jobs are cancelled by virtue of being run with a
+				// WithCancelOnQuesce context. See the resumeJob() function.
 				return
 			case <-lc.timer.C:
 				lc.timer.Read = true

--- a/pkg/jobs/wait.go
+++ b/pkg/jobs/wait.go
@@ -42,6 +42,9 @@ func (r *Registry) NotifyToAdoptJobs() {
 func (r *Registry) NotifyToResume(ctx context.Context, jobs ...jobspb.JobID) {
 	m := newJobIDSet(jobs...)
 	_ = r.stopper.RunAsyncTask(ctx, "resume-jobs", func(ctx context.Context) {
+		ctx, cancel := r.stopper.WithCancelOnQuiesce(ctx)
+		defer cancel()
+
 		r.withSession(ctx, func(ctx context.Context, s sqlliveness.Session) {
 			r.filterAlreadyRunningAndCancelFromPreviousSessions(ctx, s, m)
 			if !r.adoptionDisabled(ctx) {

--- a/pkg/kv/kvserver/client_tenant_test.go
+++ b/pkg/kv/kvserver/client_tenant_test.go
@@ -218,7 +218,7 @@ func TestTenantRateLimiter(t *testing.T) {
 	// bounds.
 	writeCostLower := cfg.WriteBatchUnits + cfg.WriteRequestUnits
 	writeCostUpper := cfg.WriteBatchUnits + cfg.WriteRequestUnits + float64(32)*cfg.WriteUnitsPerByte
-	tolerance := 30.0 // Leave space for a couple of other background requests.
+	tolerance := 50.0 // Leave space for a couple of other background requests.
 	// burstWrites is a number of writes that don't exceed the burst limit.
 	burstWrites := int((cfg.Burst - tolerance) / writeCostUpper)
 	// tooManyWrites is a number of writes which definitely exceed the burst

--- a/pkg/sql/flowinfra/flow_registry_test.go
+++ b/pkg/sql/flowinfra/flow_registry_test.go
@@ -721,9 +721,10 @@ func TestErrorOnSlowHandshake(t *testing.T) {
 		err:                      errors.New("dummy error"),
 	}
 
+	receiver := &distsqlutils.RowBuffer{}
 	var wg sync.WaitGroup
 	streamInfo := &InboundStreamInfo{
-		receiver: RowInboundStreamHandler{&distsqlutils.RowBuffer{}, nil /* types */},
+		receiver: RowInboundStreamHandler{receiver, nil /* types */},
 		onFinish: wg.Done,
 	}
 	wg.Add(1)
@@ -776,5 +777,12 @@ func TestErrorOnSlowHandshake(t *testing.T) {
 		// test is to ensure that no deadlocks happen, and we don't care that
 		// much about which particular error was returned.
 		t.Fatalf("unexpected error from ConnectInboundStream: %v", err)
+	}
+	// We expect that "no inbound stream connection" error is pushed into the
+	// receiver.
+	if len(receiver.Mu.Records) != 1 {
+		t.Fatalf("expected a single meta object with an error, got %v", receiver.Mu.Records)
+	} else if r := receiver.Mu.Records[0]; !IsNoInboundStreamConnectionError(r.Meta.Err) {
+		t.Fatalf("unexpected error: %v", r)
 	}
 }


### PR DESCRIPTION
This change adds missing WithCancelOnQuiesce calls to
various callsites in the jobs registry. Previously, we were
relying on the registry to receive a signal when the server
began quiescing that then led to all adopted jobs being cancelled.
Recently, we have seen an uptick in tests failing because
of a `slow quiesce` during shutdown. Some of these stacks are
stuck in `pkg/jobs`. This change wraps the context used in these
asnyc tasks so that they receive a ctx cancellation signal when
the server is quiescing.

Release note: None
Epic: CRDB-8964
Fixes #99242

## flowinfra: fix recently introduced bug with row-based flow shutdown

This commit fixes a bug that was introduced in https://github.com/cockroachdb/cockroach/commit/a71e11c3137a3242a6780c70ab6c2062a31f504a
that I believe to be the root cause of "slow quiesce" CI failures we've
seen on `fakedist-vec-off` logic test config. In particular, the bug is
as follows: that commit made it so that if the handshake with the remote
node (when connecting the inbound stream) fails, we now "cancel" the
stream by marking it as "canceled" and decrementing the wait group.
However, one important piece of the proper cancellation was missed - we
also need to push an error to the receiver. We do that when the inbound
stream timeout timer fires but that commit forgot to do so on the
handshake error, and this is now fixed.

The incorrect assumption in https://github.com/cockroachdb/cockroach/commit/a71e11c3137a3242a6780c70ab6c2062a31f504a was
that canceling the context of the flow is sufficient for the proper
shutdown, but this turns out to not be the case in the row-based flows.
We have some components (e.g. `execinfra.RowChannel`) that will block
until `ProducerDone` is not called, and with just cancelling the context
that could never happen. Now that we properly push the error it will.
The vectorized flows aren't affected by this because there we do listen
for context cancellation signals.

Release note: None