### PR TITLE
roachtest: loq recovery use new min range logic

### DIFF
--- a/pkg/cmd/roachtest/tests/loss_of_quorum_recovery.go
+++ b/pkg/cmd/roachtest/tests/loss_of_quorum_recovery.go
@@ -167,7 +167,9 @@ func runRecoverLossOfQuorum(ctx context.Context, t test.Test, c cluster.Cluster,
 	workloadHistogramFile := "restored.json"
 
 	c.Put(ctx, t.Cockroach(), "./cockroach", c.All())
-	settings := install.MakeClusterSettings()
+	settings := install.MakeClusterSettings(install.EnvOption([]string{
+		"COCKROACH_MIN_RANGE_MAX_BYTES=1",
+	}))
 	c.Start(ctx, t.L(), option.DefaultStartOpts(), settings, nodes)
 
 	// Cleanup stale files generated during recovery. We do this for the case
@@ -383,7 +385,9 @@ func runHalfOnlineRecoverLossOfQuorum(
 	workloadHistogramFile := "restored.json"
 
 	c.Put(ctx, t.Cockroach(), "./cockroach", c.All())
-	settings := install.MakeClusterSettings()
+	settings := install.MakeClusterSettings(install.EnvOption([]string{
+		"COCKROACH_MIN_RANGE_MAX_BYTES=1",
+	}))
 	c.Start(ctx, t.L(), option.DefaultStartOpts(), settings, nodes)
 
 	// Cleanup stale files generated during recovery. We do this for the case


### PR DESCRIPTION
This commit makes test compliant with new enforcement of min range size. Test needs small range and it now sets env var that restricts size to value of 1 byte.

Release note: None

Fixes #99529
Fixes #99569
Fixes #99576
Fixes #99577
