### PR TITLE
upgrades: use version gate to see if role members table has id columns

### DIFF
--- a/pkg/ccl/serverccl/tenant_migration_test.go
+++ b/pkg/ccl/serverccl/tenant_migration_test.go
@@ -91,7 +91,8 @@ func TestValidateTargetTenantClusterVersion(t *testing.T) {
 				Settings:          makeSettings(),
 				Knobs: base.TestingKnobs{
 					Server: &server.TestingKnobs{
-						BinaryVersionOverride: test.binaryVersion,
+						BinaryVersionOverride:       test.binaryVersion,
+						BootstrapVersionKeyOverride: clusterversion.BinaryMinSupportedVersionKey,
 						// We're bumping cluster versions manually ourselves. We
 						// want to avoid racing with the auto-upgrade process.
 						DisableAutomaticVersionUpgrade: make(chan struct{}),
@@ -107,7 +108,8 @@ func TestValidateTargetTenantClusterVersion(t *testing.T) {
 					TenantID: serverutils.TestTenantID(),
 					TestingKnobs: base.TestingKnobs{
 						Server: &server.TestingKnobs{
-							BinaryVersionOverride: test.binaryVersion,
+							BootstrapVersionKeyOverride: clusterversion.BinaryMinSupportedVersionKey,
+							BinaryVersionOverride:       test.binaryVersion,
 						},
 					},
 				})
@@ -207,7 +209,9 @@ func TestBumpTenantClusterVersion(t *testing.T) {
 						// This test wants to bootstrap at the previously active
 						// cluster version, so we can actually bump the cluster
 						// version to the binary version.
-						BinaryVersionOverride: test.initialClusterVersion.Version,
+						BinaryVersionOverride:       test.initialClusterVersion.Version,
+						BootstrapVersionKeyOverride: clusterversion.BinaryMinSupportedVersionKey,
+
 						// We're bumping cluster versions manually ourselves. We
 						// want to avoid racing with the auto-upgrade process.
 						DisableAutomaticVersionUpgrade: make(chan struct{}),
@@ -222,7 +226,8 @@ func TestBumpTenantClusterVersion(t *testing.T) {
 					TenantID: serverutils.TestTenantID(),
 					TestingKnobs: base.TestingKnobs{
 						Server: &server.TestingKnobs{
-							BinaryVersionOverride: test.initialClusterVersion.Version,
+							BootstrapVersionKeyOverride: clusterversion.BinaryMinSupportedVersionKey,
+							BinaryVersionOverride:       test.initialClusterVersion.Version,
 						},
 					},
 				})

--- a/pkg/kv/kvserver/client_replica_test.go
+++ b/pkg/kv/kvserver/client_replica_test.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvclient/rangefeed/rangefeedcache"
@@ -4882,8 +4883,8 @@ func TestRangeMigration(t *testing.T) {
 
 	// We're going to be transitioning from startV to endV. Think a cluster of
 	// binaries running vX, but with active version vX-1.
-	startV := roachpb.Version{Major: 41}
-	endV := roachpb.Version{Major: 42}
+	startV := roachpb.Version{Major: clusterversion.TestingBinaryMinSupportedVersion.Major}
+	endV := roachpb.Version{Major: clusterversion.TestingBinaryVersion.Major}
 
 	ctx := context.Background()
 	tc := testcluster.StartTestCluster(t, 1, base.TestClusterArgs{
@@ -4893,6 +4894,7 @@ func TestRangeMigration(t *testing.T) {
 			Knobs: base.TestingKnobs{
 				Server: &server.TestingKnobs{
 					BinaryVersionOverride:          startV,
+					BootstrapVersionKeyOverride:    clusterversion.BinaryMinSupportedVersionKey,
 					DisableAutomaticVersionUpgrade: make(chan struct{}),
 				},
 			},

--- a/pkg/server/version_cluster_test.go
+++ b/pkg/server/version_cluster_test.go
@@ -372,20 +372,6 @@ func TestAllVersionsAgree(t *testing.T) {
 	})
 }
 
-// Returns two versions v0 and v1 which correspond to adjacent releases. v1 will
-// equal the TestingBinaryMinSupportedVersion to avoid rot in tests using this
-// (as we retire old versions).
-func v0v1() (roachpb.Version, roachpb.Version) {
-	v1 := clusterversion.TestingBinaryMinSupportedVersion
-	v0 := clusterversion.TestingBinaryMinSupportedVersion
-	if v0.Minor > 0 {
-		v0.Minor--
-	} else {
-		v0.Major--
-	}
-	return v0, v1
-}
-
 // TestClusterVersionMixedVersionTooOld verifies that we're unable to bump a
 // cluster version in a mixed node cluster where one of the nodes is running a
 // binary that cannot support the targeted cluster version.
@@ -398,7 +384,7 @@ func TestClusterVersionMixedVersionTooOld(t *testing.T) {
 	// GOTRACEBACK=all, as it is on CI.
 	defer log.DisableTracebacks()()
 
-	v0, v1 := v0v1()
+	v0, v1 := clusterversion.TestingBinaryMinSupportedVersion, clusterversion.TestingBinaryVersion
 	v0s := v0.String()
 	v1s := v1.String()
 
@@ -414,6 +400,7 @@ func TestClusterVersionMixedVersionTooOld(t *testing.T) {
 	knobs := base.TestingKnobs{
 		Server: &server.TestingKnobs{
 			DisableAutomaticVersionUpgrade: make(chan struct{}),
+			BootstrapVersionKeyOverride:    clusterversion.BinaryMinSupportedVersionKey,
 			BinaryVersionOverride:          v0,
 		},
 		// Inject an upgrade which would run to upgrade the cluster.

--- a/pkg/upgrade/upgrademanager/manager_external_test.go
+++ b/pkg/upgrade/upgrademanager/manager_external_test.go
@@ -713,6 +713,7 @@ func TestPrecondition(t *testing.T) {
 		Server: &server.TestingKnobs{
 			DisableAutomaticVersionUpgrade: make(chan struct{}),
 			BinaryVersionOverride:          v0,
+			BootstrapVersionKeyOverride:    clusterversion.BinaryMinSupportedVersionKey,
 		},
 		// Inject an upgrade which would run to upgrade the cluster.
 		// We'll validate that we never create a job for this upgrade.


### PR DESCRIPTION
This code change makes the `addRootUser` permanent upgrade
depend solely on the version gate to check if
`V23_1RoleMembersTableHasIDColumns` migration ran.

It also updates tests that were failing because they
bootstrap with unexpected versions to bootstrap with
the right versions.

Release note: None
Epic: CRDB-21741