### PR TITLE
release-22.1: kvserver: fix early timeout in getChecksum test

### DIFF
--- a/pkg/kv/kvserver/replica_consistency_test.go
+++ b/pkg/kv/kvserver/replica_consistency_test.go
@@ -108,8 +108,7 @@ func TestGetChecksumNotSuccessfulExitConditions(t *testing.T) {
 	require.Nil(t, rc.Checksum)
 
 	// Need to reset the context, since we deadlined it above.
-	ctx, cancel = context.WithTimeout(context.Background(), 100*time.Millisecond)
-	defer cancel()
+	ctx = context.Background()
 	// Next condition, node should quiesce.
 	tc.repl.store.Stopper().Quiesce(ctx)
 	rc, err = tc.repl.getChecksum(ctx, uuid.FastMakeV4())


### PR DESCRIPTION
Fixes #99565
Epic: none
Release note: none
Release justification: flaky test fix