### PR TITLE
kvserver: revert #98150

### DIFF
--- a/pkg/kv/kvserver/replica_proposal.go
+++ b/pkg/kv/kvserver/replica_proposal.go
@@ -424,8 +424,7 @@ func (r *Replica) leasePostApplyLocked(
 	// this gossip if we're taking over after a leaseholder failure. In both cases,
 	// incremental liveness updates may have been lost, so we want to make sure that
 	// the latest view of node liveness ends up in gossip.
-	nls := keys.NodeLivenessSpan
-	if leaseChangingHands && iAmTheLeaseHolder && kvserverbase.ContainsKeyRange(r.descRLocked(), nls.Key, nls.EndKey) {
+	if leaseChangingHands && iAmTheLeaseHolder {
 		// NB: run these in an async task to keep them out of the critical section
 		// (r.mu is held here).
 		_ = r.store.stopper.RunAsyncTask(r.AnnotateCtx(context.Background()), "lease-triggers", func(ctx context.Context) {

--- a/pkg/kv/kvserver/replica_proposal.go
+++ b/pkg/kv/kvserver/replica_proposal.go
@@ -419,12 +419,14 @@ func (r *Replica) leasePostApplyLocked(
 		}
 	}
 
-	// Potentially re-gossip if the range contains node liveness data. We need to
-	// perform this gossip at startup as soon as possible. We also need to perform
-	// this gossip if we're taking over after a leaseholder failure. In both cases,
-	// incremental liveness updates may have been lost, so we want to make sure that
-	// the latest view of node liveness ends up in gossip.
-	if leaseChangingHands && iAmTheLeaseHolder {
+	// Potentially re-gossip if the range contains system data (e.g. system
+	// config or node liveness). We need to perform this gossip at startup as
+	// soon as possible. Trying to minimize how often we gossip is a fool's
+	// errand. The node liveness info will be gossiped frequently (every few
+	// seconds) in any case due to the liveness heartbeats. And the system config
+	// will be gossiped rarely because it falls on a range with an epoch-based
+	// range lease that is only reacquired extremely infrequently.
+	if iAmTheLeaseHolder {
 		// NB: run these in an async task to keep them out of the critical section
 		// (r.mu is held here).
 		_ = r.store.stopper.RunAsyncTask(r.AnnotateCtx(context.Background()), "lease-triggers", func(ctx context.Context) {


### PR DESCRIPTION
This reverts #98150 because we think it introduced a problem that was detected
via the `replicate/wide` roachtest[^1]. It seems that for reasons still unknown
we do rely on the periodic gossip trigger on liveness lease extensions.

[^1]: #99268 (comment)

Touches #99268.
Touches #97966.
Closes #99268.
Touches #98945.

Tracked in https://github.com/cockroachdb/cockroach/issues/99652.

Epic: none
Release note: None