### PR TITLE
sqlccl: skip TestGCTenantJobWaitsForProtectedTimestamps

### DIFF
--- a/pkg/ccl/testccl/sqlccl/tenant_gc_test.go
+++ b/pkg/ccl/testccl/sqlccl/tenant_gc_test.go
@@ -469,6 +469,7 @@ func TestGCTableOrIndexWaitsForProtectedTimestamps(t *testing.T) {
 func TestGCTenantJobWaitsForProtectedTimestamps(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
+	skip.WithIssue(t, 94808)
 	defer gcjob.SetSmallMaxGCIntervalForTest()()
 
 	ctx := context.Background()


### PR DESCRIPTION
Skip flaky test.

Informs #94808

Release note: None