### PR TITLE
build: add build test binaries script for microbenchmarks

### DIFF
--- a/build/teamcity/cockroach/nightlies/microbenchmark_binaries.sh
+++ b/build/teamcity/cockroach/nightlies/microbenchmark_binaries.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+#
+# This script builds portable test binaries required by the microbenchmarks weekly script.
+# It is intended to be used on-demand when new binaries are required.
+# Parameters:
+#   BENCH_PACKAGE: package to build (default: ./pkg/...)
+#   GCS_BINARIES_DIR: GCS directory to copy test binaries archive to. (default: gs://cockroach-microbenchmarks/binaries)
+#   BINARIES_NAME: name of the test binaries archive (default: <branch/tag>-<commit>.tar.gz)
+
+set -exuo pipefail
+
+dir="$(dirname $(dirname $(dirname $(dirname "${0}"))))"
+source "$dir/teamcity-support.sh"
+
+# Set up credentials
+google_credentials="$GOOGLE_EPHEMERAL_CREDENTIALS"
+log_into_gcloud
+
+
+# Configure Bazel and dev tooling
+bazelOpts=(
+"build --config nolintonbuild"
+"build --config=dev"
+"test --test_tmpdir=/tmp/cockroach"
+)
+printf "%s\n" "${bazelOpts[@]}" > ./.bazelrc.user
+
+./dev doctor --interactive=false
+
+# Build test binaries
+./dev test-binaries "$BENCH_PACKAGE"
+
+# Copy binaries to bucket
+gsutil cp ./bin/test_binaries.tar.gz "$GCS_BINARIES_DIR/$BINARIES_NAME.tar.gz"


### PR DESCRIPTION
Adds an on-demand script that can produce portable test binaries. The binaries archive is uploaded to a GCS bucket. These binaries can then be used in the microbenchmarks weekly script to run comparisons against.