### PR TITLE
backupccl: unskip TestBackupRestoreWithConcurrentWrites

### DIFF
--- a/pkg/ccl/backupccl/backup_test.go
+++ b/pkg/ccl/backupccl/backup_test.go
@@ -3421,7 +3421,6 @@ func startBackgroundWrites(
 
 func TestBackupRestoreWithConcurrentWrites(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	skip.WithIssue(t, 58211, "flaky test")
 	defer log.Scope(t).Close(t)
 
 	const rows = 10


### PR DESCRIPTION
Unskip TestBackupRestoreWithConcurrentWrites as it is no longer failing. Verified after 500 runs.

Fixes #58211

Release note: None