### PR TITLE
jobs: update jobs and job_info join queries

### DIFF
--- a/pkg/jobs/job_info_storage.go
+++ b/pkg/jobs/job_info_storage.go
@@ -82,7 +82,7 @@ func (i InfoStorage) get(ctx context.Context, infoKey string) ([]byte, bool, err
 	row, err := i.txn.QueryRowEx(
 		ctx, "job-info-get", i.txn.KV(),
 		sessiondata.NodeUserSessionDataOverride,
-		"SELECT value FROM system.job_info WHERE job_id = $1 AND info_key::string = $2 ORDER BY written LIMIT 1",
+		"SELECT value FROM system.job_info WHERE job_id = $1 AND info_key::string = $2 ORDER BY written DESC LIMIT 1",
 		j.ID(), infoKey,
 	)
 

--- a/pkg/jobs/update.go
+++ b/pkg/jobs/update.go
@@ -389,8 +389,8 @@ func getSelectStmtForJobUpdate(
 	const (
 		selectWithoutSession = `
 WITH
-	latestpayload AS (SELECT job_id, value FROM system.job_info AS payload WHERE info_key = 'legacy_payload'),
-	latestprogress AS (SELECT job_id, value FROM system.job_info AS progress WHERE info_key = 'legacy_progress')
+	latestpayload AS (SELECT job_id, value FROM system.job_info AS payload WHERE info_key = 'legacy_payload' AND job_id = $1 ORDER BY written DESC LIMIT 1),
+	latestprogress AS (SELECT job_id, value FROM system.job_info AS progress WHERE info_key = 'legacy_progress' AND job_id = $1 ORDER BY written DESC LIMIT 1)
 	SELECT
 		status, payload.value AS payload, progress.value AS progress`
 		selectWithSession = selectWithoutSession + `, claim_session_id`

--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -895,15 +895,31 @@ const (
 	// found.
 	SystemJobsAndJobInfoBaseQuery = `
 WITH
-	latestpayload AS (SELECT job_id, value FROM system.job_info AS payload WHERE info_key = 'legacy_payload'),
-	latestprogress AS (SELECT job_id, value FROM system.job_info AS progress WHERE info_key = 'legacy_progress')
+	latestpayload AS (SELECT job_id, value FROM system.job_info AS payload WHERE info_key = 'legacy_payload' ORDER BY written DESC),
+	latestprogress AS (SELECT job_id, value FROM system.job_info AS progress WHERE info_key = 'legacy_progress' ORDER BY written DESC)
 	SELECT 
+		DISTINCT(id), status, created, payload.value AS payload, progress.value AS progress,
+		created_by_type, created_by_id, claim_session_id, claim_instance_id, num_runs, last_run, job_type
+	FROM system.jobs AS j
+	INNER JOIN latestpayload AS payload ON j.id = payload.job_id
+	LEFT JOIN latestprogress AS progress ON j.id = progress.job_id
+`
+
+	// systemJobsAndJobInfoBaseQueryWithIDPredicate is the same as
+	// systemJobsAndJobInfoBaseQuery but with a predicate on `job_id` in the CTE
+	// queries.
+	systemJobsAndJobInfoBaseQueryWithIDPredicate = `
+WITH
+	latestpayload AS (SELECT job_id, value FROM system.job_info AS payload WHERE info_key = 'legacy_payload' AND job_id = $1 ORDER BY written DESC LIMIT 1),
+	latestprogress AS (SELECT job_id, value FROM system.job_info AS progress WHERE info_key = 'legacy_progress' AND job_id = $1 ORDER BY written DESC LIMIT 1)
+	SELECT
 		id, status, created, payload.value AS payload, progress.value AS progress,
 		created_by_type, created_by_id, claim_session_id, claim_instance_id, num_runs, last_run, job_type
 	FROM system.jobs AS j
 	INNER JOIN latestpayload AS payload ON j.id = payload.job_id
 	LEFT JOIN latestprogress AS progress ON j.id = progress.job_id
 `
+
 	// Before clusterversion.V23_1JobInfoTableIsBackfilled, the system.job_info
 	// table has not been fully populated with the payload and progress of jobs in
 	// the cluster.
@@ -943,6 +959,9 @@ func getInternalSystemJobsQueryFromClusterVersion(
 	var baseQuery string
 	if version.IsActive(ctx, clusterversion.V23_1JobInfoTableIsBackfilled) {
 		baseQuery = SystemJobsAndJobInfoBaseQuery
+		if predicate == jobID {
+			baseQuery = systemJobsAndJobInfoBaseQueryWithIDPredicate
+		}
 	} else if version.IsActive(ctx, clusterversion.V23_1BackfillTypeColumnInJobsTable) {
 		baseQuery = systemJobsBaseQuery
 	} else {


### PR DESCRIPTION
This change updates the two places where we perform
a join over the `system.jobs` and `system.job_info`
table to use more performant and correct queries.

The queries are more performant because of an additional
predicate on the `job_id` in each of the CTE queries. This
prevents a full table scan when we are only concerned with
rows corresponding to a particular job. This has been verified
by running both variants of the query through the EXPLAIN ANALYZE (plan)
tool. This tool occassionally reports a full table scan in the CTE queries
when there is no predicate involved.

The queries are more correct because they take into consideration
a job having >1 row for a particular info_key. This is possible
during upgrades. Jobs start writing their payload and progress to
the job_info table once V23_1CreateSystemJobInfoTable is active.
If a job is still running when the cluster steps through
V23_1JobInfoTableIsBackfilled then the job will have duplicate entries
for the payload and prgress rows. This is because we blindly backfill
the contents of the jobs table into the job_info table without
clearing previous entries corresponding to the job.

This change also adds a red-green regression test for the above
correctness problem.

Fixes: https://github.com/cockroachdb/cockroach/issues/99101
Informs: #99219
Release note: None
Epic: CRDB-8964