### PR TITLE
workload/tpcc: disable check 3.3.2.11 after workload

### DIFF
--- a/pkg/workload/tpcc/tpcc.go
+++ b/pkg/workload/tpcc/tpcc.go
@@ -513,6 +513,10 @@ func (w *tpcc) Hooks() workload.Hooks {
 				if !w.expensiveChecks && check.Expensive {
 					continue
 				}
+				if check.LoadOnly {
+					// TODO(nvanbenschoten): support load-only checks.
+					continue
+				}
 				start := timeutil.Now()
 				err := check.Fn(db, "" /* asOfSystemTime */)
 				log.Infof(ctx, `check %s took %s`, check.Name, timeutil.Since(start))

--- a/pkg/workload/tpccchecks/checks_generator.go
+++ b/pkg/workload/tpccchecks/checks_generator.go
@@ -48,6 +48,10 @@ foreground TPC-C workload`,
 				" AS OF SYSTEM TIME CLAUSE for all checks.")
 		checkNames := func() (checkNames []string) {
 			for _, c := range tpcc.AllChecks() {
+				if c.LoadOnly {
+					// TODO(nvanbenschoten): support load-only checks.
+					continue
+				}
 				checkNames = append(checkNames, c.Name)
 			}
 			return checkNames


### PR DESCRIPTION
Fixes #99619.
Fixes #99594.
Fixes #99603.
Fixes #99604.
Fixes #99617.
Fixes #99616.
Fixes #99613.
Fixes #99611.
Fixes #99604.
Fixes #99603.
Fixes #99600.
Fixes #99599.
Fixes #99598.
Fixes #99596.
Fixes #99595.
Fixes #99594.

This commit disables TPC-C's consistency check 3.3.2.11 (added in #99542) after the workload has run. The check asserts a relationship between the number of rows in the "order" table and rows in the "new_order" table. Rows are inserted into these tables transactional by the NewOrder transaction. However, only rows in the "new_order" table are deleted by the Delivery transaction. Consequently, the consistency condition will fail after the first Delivery transaction is run by the workload.

See https://github.com/cockroachdb/cockroach/pull/99542#issuecomment-1485227793 for more details.

Release note: None