### PR TITLE
release-23.1: sql: inject stats into TestExecBuild_sql_statistics_persisted testdata

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/testdata/sql_statistics_persisted
+++ b/pkg/sql/opt/exec/execbuilder/testdata/sql_statistics_persisted
@@ -1,9 +1,356 @@
 # LogicTest: local
 
+# Ensure we can run ALTER statements on the system.statement_statistics and
+# system.transaction_statistics tables.
 statement ok
-CREATE STATISTICS system_statement_stats FROM system.statement_statistics
+INSERT INTO system.users VALUES ('node', NULL, true, 3);
 
-query T retry
+statement ok
+GRANT node TO root;
+
+statement ok
+ALTER TABLE system.statement_statistics INJECT STATISTICS '[
+    {
+        "columns": [
+            "aggregated_ts"
+        ],
+        "created_at": "2023-03-24 21:22:03.381873",
+        "distinct_count": 1000000,
+        "histo_col_type": "TIMESTAMPTZ",
+        "null_count": 0,
+        "row_count": 1000000
+    },
+    {
+        "columns": [
+            "aggregated_ts",
+            "fingerprint_id",
+            "transaction_fingerprint_id",
+            "plan_hash",
+            "app_name",
+            "node_id",
+            "crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_plan_hash_transaction_fingerprint_id_shard_8"
+        ],
+        "created_at": "2023-03-24 21:22:03.381873",
+        "distinct_count": 1000000,
+        "null_count": 0,
+        "row_count": 1000000
+    },
+    {
+        "columns": [
+            "aggregated_ts",
+            "fingerprint_id",
+            "transaction_fingerprint_id",
+            "plan_hash",
+            "app_name",
+            "crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_plan_hash_transaction_fingerprint_id_shard_8"
+        ],
+        "created_at": "2023-03-24 21:22:03.381873",
+        "distinct_count": 1000000,
+        "null_count": 0,
+        "row_count": 1000000
+    },
+    {
+        "columns": [
+            "aggregated_ts",
+            "fingerprint_id",
+            "transaction_fingerprint_id",
+            "plan_hash",
+            "crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_plan_hash_transaction_fingerprint_id_shard_8"
+        ],
+        "created_at": "2023-03-24 21:22:03.381873",
+        "distinct_count": 1000000,
+        "null_count": 0,
+        "row_count": 1000000
+    },
+    {
+        "columns": [
+            "aggregated_ts",
+            "fingerprint_id",
+            "transaction_fingerprint_id",
+            "crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_plan_hash_transaction_fingerprint_id_shard_8"
+        ],
+        "created_at": "2023-03-24 21:22:03.381873",
+        "distinct_count": 1000000,
+        "null_count": 0,
+        "row_count": 1000000
+    },
+    {
+        "columns": [
+            "aggregated_ts",
+            "fingerprint_id",
+            "crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_plan_hash_transaction_fingerprint_id_shard_8"
+        ],
+        "created_at": "2023-03-24 21:22:03.381873",
+        "distinct_count": 1000000,
+        "null_count": 0,
+        "row_count": 1000000
+    },
+    {
+        "columns": [
+            "aggregated_ts",
+            "app_name"
+        ],
+        "created_at": "2023-03-24 21:22:03.381873",
+        "distinct_count": 1000000,
+        "null_count": 0,
+        "row_count": 1000000
+    },
+    {
+        "columns": [
+            "aggregated_ts",
+            "app_name",
+            "execution_count"
+        ],
+        "created_at": "2023-03-24 21:22:03.381873",
+        "distinct_count": 1000000,
+        "null_count": 0,
+        "row_count": 1000000
+    },
+    {
+        "columns": [
+            "aggregated_ts",
+            "app_name",
+            "service_latency"
+        ],
+        "created_at": "2023-03-24 21:22:03.381873",
+        "distinct_count": 1000000,
+        "null_count": 0,
+        "row_count": 1000000
+    },
+    {
+        "columns": [
+            "aggregated_ts",
+            "app_name",
+            "cpu_sql_nanos"
+        ],
+        "created_at": "2023-03-24 21:22:03.381873",
+        "distinct_count": 1000000,
+        "null_count": 0,
+        "row_count": 1000000
+    },
+    {
+        "columns": [
+            "aggregated_ts",
+            "app_name",
+            "contention_time"
+        ],
+        "created_at": "2023-03-24 21:22:03.381873",
+        "distinct_count": 1000000,
+        "null_count": 0,
+        "row_count": 1000000
+    },
+    {
+        "columns": [
+            "aggregated_ts",
+            "app_name",
+            "total_estimated_execution_time"
+        ],
+        "created_at": "2023-03-24 21:22:03.381873",
+        "distinct_count": 1000000,
+        "null_count": 0,
+        "row_count": 1000000
+    },
+    {
+        "columns": [
+            "aggregated_ts",
+            "app_name",
+            "p99_latency"
+        ],
+        "created_at": "2023-03-24 21:22:03.381873",
+        "distinct_count": 1000000,
+        "null_count": 0,
+        "row_count": 1000000
+    },
+    {
+        "columns": [
+            "aggregated_ts",
+            "crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_plan_hash_transaction_fingerprint_id_shard_8"
+        ],
+        "created_at": "2023-03-24 21:22:03.381873",
+        "distinct_count": 1000000,
+        "null_count": 0,
+        "row_count": 1000000
+    },
+    {
+        "columns": [
+            "fingerprint_id"
+        ],
+        "created_at": "2023-03-24 21:22:03.381873",
+        "distinct_count": 1000000,
+        "histo_col_type": "BYTES",
+        "null_count": 0,
+        "row_count": 1000000
+    },
+    {
+        "columns": [
+            "fingerprint_id",
+            "transaction_fingerprint_id"
+        ],
+        "created_at": "2023-03-24 21:22:03.381873",
+        "distinct_count": 1000000,
+        "null_count": 0,
+        "row_count": 1000000
+    },
+    {
+        "columns": [
+            "transaction_fingerprint_id"
+        ],
+        "created_at": "2023-03-24 21:22:03.381873",
+        "distinct_count": 1000000,
+        "histo_col_type": "BYTES",
+        "null_count": 0,
+        "row_count": 1000000
+    },
+    {
+        "columns": [
+            "plan_hash"
+        ],
+        "created_at": "2023-03-24 21:22:03.381873",
+        "distinct_count": 1000000,
+        "histo_col_type": "BYTES",
+        "null_count": 0,
+        "row_count": 1000000
+    },
+    {
+        "columns": [
+            "app_name"
+        ],
+        "created_at": "2023-03-24 21:22:03.381873",
+        "distinct_count": 1000000,
+        "histo_col_type": "STRING",
+        "null_count": 0,
+        "row_count": 1000000
+    },
+    {
+        "columns": [
+            "node_id"
+        ],
+        "created_at": "2023-03-24 21:22:03.381873",
+        "distinct_count": 1000000,
+        "histo_col_type": "INT8",
+        "null_count": 0,
+        "row_count": 1000000
+    },
+    {
+        "columns": [
+            "agg_interval"
+        ],
+        "created_at": "2023-03-24 21:22:03.381873",
+        "distinct_count": 1000000,
+        "histo_col_type": "INTERVAL",
+        "null_count": 0,
+        "row_count": 1000000
+    },
+    {
+        "columns": [
+            "metadata"
+        ],
+        "created_at": "2023-03-24 21:22:03.381873",
+        "distinct_count": 1000000,
+        "null_count": 0,
+        "row_count": 1000000
+    },
+    {
+        "columns": [
+            "statistics"
+        ],
+        "created_at": "2023-03-24 21:22:03.381873",
+        "distinct_count": 1000000,
+        "null_count": 0,
+        "row_count": 1000000
+    },
+    {
+        "columns": [
+            "plan"
+        ],
+        "created_at": "2023-03-24 21:22:03.381873",
+        "distinct_count": 1000000,
+        "null_count": 0,
+        "row_count": 1000000
+    },
+    {
+        "columns": [
+            "crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_plan_hash_transaction_fingerprint_id_shard_8"
+        ],
+        "created_at": "2023-03-24 21:22:03.381873",
+        "distinct_count": 1000000,
+        "histo_col_type": "INT4",
+        "null_count": 0,
+        "row_count": 1000000
+    },
+    {
+        "columns": [
+            "index_recommendations"
+        ],
+        "created_at": "2023-03-24 21:22:03.381873",
+        "distinct_count": 1000000,
+        "histo_col_type": "STRING[]",
+        "null_count": 0,
+        "row_count": 1000000
+    },
+    {
+        "columns": [
+            "execution_count"
+        ],
+        "created_at": "2023-03-24 21:22:03.381873",
+        "distinct_count": 1000000,
+        "histo_col_type": "INT8",
+        "null_count": 0,
+        "row_count": 1000000
+    },
+    {
+        "columns": [
+            "service_latency"
+        ],
+        "created_at": "2023-03-24 21:22:03.381873",
+        "distinct_count": 1000000,
+        "histo_col_type": "FLOAT8",
+        "null_count": 0,
+        "row_count": 1000000
+    },
+    {
+        "columns": [
+            "cpu_sql_nanos"
+        ],
+        "created_at": "2023-03-24 21:22:03.381873",
+        "distinct_count": 1000000,
+        "histo_col_type": "FLOAT8",
+        "null_count": 0,
+        "row_count": 1000000
+    },
+    {
+        "columns": [
+            "contention_time"
+        ],
+        "created_at": "2023-03-24 21:22:03.381873",
+        "distinct_count": 1000000,
+        "histo_col_type": "FLOAT8",
+        "null_count": 0,
+        "row_count": 1000000
+    },
+    {
+        "columns": [
+            "total_estimated_execution_time"
+        ],
+        "created_at": "2023-03-24 21:22:03.381873",
+        "distinct_count": 1000000,
+        "histo_col_type": "FLOAT8",
+        "null_count": 0,
+        "row_count": 1000000
+    },
+    {
+        "columns": [
+            "p99_latency"
+        ],
+        "created_at": "2023-03-24 21:22:03.381873",
+        "distinct_count": 1000000,
+        "histo_col_type": "FLOAT8",
+        "null_count": 0,
+        "row_count": 1000000
+    }
+]'
+
+query T
 EXPLAIN (VERBOSE)
 SELECT * FROM ((SELECT
   aggregated_ts,
@@ -107,135 +454,135 @@ vectorized: true
 ·
 • union
 │ columns: (aggregated_ts, fingerprint_id, transaction_fingerprint_id, app_name, execution_count, service_latency, cpu_sql_nanos, contention_time, total_estimated_execution_time, p99_latency, metadata, statistics)
-│ estimated row count: 2
+│ estimated row count: 3,000
 │
 ├── • union
 │   │ columns: (aggregated_ts, fingerprint_id, transaction_fingerprint_id, app_name, execution_count, service_latency, cpu_sql_nanos, contention_time, total_estimated_execution_time, p99_latency, metadata, statistics)
-│   │ estimated row count: 2
+│   │ estimated row count: 2,500
 │   │
 │   ├── • union
 │   │   │ columns: (aggregated_ts, fingerprint_id, transaction_fingerprint_id, app_name, execution_count, service_latency, cpu_sql_nanos, contention_time, total_estimated_execution_time, p99_latency, metadata, statistics)
-│   │   │ estimated row count: 1
+│   │   │ estimated row count: 2,000
 │   │   │
 │   │   ├── • union
 │   │   │   │ columns: (aggregated_ts, fingerprint_id, transaction_fingerprint_id, app_name, execution_count, service_latency, cpu_sql_nanos, contention_time, total_estimated_execution_time, p99_latency, metadata, statistics)
-│   │   │   │ estimated row count: 1
+│   │   │   │ estimated row count: 1,500
 │   │   │   │
 │   │   │   ├── • union
 │   │   │   │   │ columns: (aggregated_ts, fingerprint_id, transaction_fingerprint_id, app_name, execution_count, service_latency, cpu_sql_nanos, contention_time, total_estimated_execution_time, p99_latency, metadata, statistics)
-│   │   │   │   │ estimated row count: 1
+│   │   │   │   │ estimated row count: 1,000
 │   │   │   │   │
 │   │   │   │   ├── • index join
 │   │   │   │   │   │ columns: (aggregated_ts, fingerprint_id, transaction_fingerprint_id, app_name, execution_count, service_latency, cpu_sql_nanos, contention_time, total_estimated_execution_time, p99_latency, metadata, statistics)
-│   │   │   │   │   │ estimated row count: 0
+│   │   │   │   │   │ estimated row count: 500
 │   │   │   │   │   │ table: statement_statistics@primary
 │   │   │   │   │   │ key columns: crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_plan_hash_transaction_fingerprint_id_shard_8, aggregated_ts, fingerprint_id, transaction_fingerprint_id, plan_hash, app_name, node_id
 │   │   │   │   │   │
 │   │   │   │   │   └── • top-k
 │   │   │   │   │       │ columns: (aggregated_ts, fingerprint_id, transaction_fingerprint_id, plan_hash, app_name, node_id, crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_plan_hash_transaction_fingerprint_id_shard_8, execution_count)
 │   │   │   │   │       │ ordering: -execution_count
-│   │   │   │   │       │ estimated row count: 0
+│   │   │   │   │       │ estimated row count: 500
 │   │   │   │   │       │ order: -execution_count
 │   │   │   │   │       │ k: 500
 │   │   │   │   │       │
 │   │   │   │   │       └── • scan
 │   │   │   │   │             columns: (aggregated_ts, fingerprint_id, transaction_fingerprint_id, plan_hash, app_name, node_id, crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_plan_hash_transaction_fingerprint_id_shard_8, execution_count)
-│   │   │   │   │             estimated row count: 0 (33% of the table; stats collected <hidden> ago)
+│   │   │   │   │             estimated row count: 333,333 (33% of the table; stats collected <hidden> ago)
 │   │   │   │   │             table: statement_statistics@execution_count_idx (partial index)
 │   │   │   │   │             spans: /2023-03-21T14:05:00.000001Z-
 │   │   │   │   │
 │   │   │   │   └── • index join
 │   │   │   │       │ columns: (aggregated_ts, fingerprint_id, transaction_fingerprint_id, app_name, execution_count, service_latency, cpu_sql_nanos, contention_time, total_estimated_execution_time, p99_latency, metadata, statistics)
-│   │   │   │       │ estimated row count: 0
+│   │   │   │       │ estimated row count: 500
 │   │   │   │       │ table: statement_statistics@primary
 │   │   │   │       │ key columns: crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_plan_hash_transaction_fingerprint_id_shard_8, aggregated_ts, fingerprint_id, transaction_fingerprint_id, plan_hash, app_name, node_id
 │   │   │   │       │
 │   │   │   │       └── • top-k
 │   │   │   │           │ columns: (aggregated_ts, fingerprint_id, transaction_fingerprint_id, plan_hash, app_name, node_id, crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_plan_hash_transaction_fingerprint_id_shard_8, service_latency)
 │   │   │   │           │ ordering: -service_latency
-│   │   │   │           │ estimated row count: 0
+│   │   │   │           │ estimated row count: 500
 │   │   │   │           │ order: -service_latency
 │   │   │   │           │ k: 500
 │   │   │   │           │
 │   │   │   │           └── • scan
 │   │   │   │                 columns: (aggregated_ts, fingerprint_id, transaction_fingerprint_id, plan_hash, app_name, node_id, crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_plan_hash_transaction_fingerprint_id_shard_8, service_latency)
-│   │   │   │                 estimated row count: 0 (33% of the table; stats collected <hidden> ago)
+│   │   │   │                 estimated row count: 333,333 (33% of the table; stats collected <hidden> ago)
 │   │   │   │                 table: statement_statistics@service_latency_idx (partial index)
 │   │   │   │                 spans: /2023-03-21T14:05:00.000001Z-
 │   │   │   │
 │   │   │   └── • index join
 │   │   │       │ columns: (aggregated_ts, fingerprint_id, transaction_fingerprint_id, app_name, execution_count, service_latency, cpu_sql_nanos, contention_time, total_estimated_execution_time, p99_latency, metadata, statistics)
-│   │   │       │ estimated row count: 0
+│   │   │       │ estimated row count: 500
 │   │   │       │ table: statement_statistics@primary
 │   │   │       │ key columns: crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_plan_hash_transaction_fingerprint_id_shard_8, aggregated_ts, fingerprint_id, transaction_fingerprint_id, plan_hash, app_name, node_id
 │   │   │       │
 │   │   │       └── • top-k
 │   │   │           │ columns: (aggregated_ts, fingerprint_id, transaction_fingerprint_id, plan_hash, app_name, node_id, crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_plan_hash_transaction_fingerprint_id_shard_8, cpu_sql_nanos)
 │   │   │           │ ordering: -cpu_sql_nanos
-│   │   │           │ estimated row count: 0
+│   │   │           │ estimated row count: 500
 │   │   │           │ order: -cpu_sql_nanos
 │   │   │           │ k: 500
 │   │   │           │
 │   │   │           └── • scan
 │   │   │                 columns: (aggregated_ts, fingerprint_id, transaction_fingerprint_id, plan_hash, app_name, node_id, crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_plan_hash_transaction_fingerprint_id_shard_8, cpu_sql_nanos)
-│   │   │                 estimated row count: 0 (33% of the table; stats collected <hidden> ago)
+│   │   │                 estimated row count: 333,333 (33% of the table; stats collected <hidden> ago)
 │   │   │                 table: statement_statistics@cpu_sql_nanos_idx (partial index)
 │   │   │                 spans: /2023-03-21T14:05:00.000001Z-
 │   │   │
 │   │   └── • index join
 │   │       │ columns: (aggregated_ts, fingerprint_id, transaction_fingerprint_id, app_name, execution_count, service_latency, cpu_sql_nanos, contention_time, total_estimated_execution_time, p99_latency, metadata, statistics)
-│   │       │ estimated row count: 0
+│   │       │ estimated row count: 500
 │   │       │ table: statement_statistics@primary
 │   │       │ key columns: crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_plan_hash_transaction_fingerprint_id_shard_8, aggregated_ts, fingerprint_id, transaction_fingerprint_id, plan_hash, app_name, node_id
 │   │       │
 │   │       └── • top-k
 │   │           │ columns: (aggregated_ts, fingerprint_id, transaction_fingerprint_id, plan_hash, app_name, node_id, crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_plan_hash_transaction_fingerprint_id_shard_8, contention_time)
 │   │           │ ordering: -contention_time
-│   │           │ estimated row count: 0
+│   │           │ estimated row count: 500
 │   │           │ order: -contention_time
 │   │           │ k: 500
 │   │           │
 │   │           └── • scan
 │   │                 columns: (aggregated_ts, fingerprint_id, transaction_fingerprint_id, plan_hash, app_name, node_id, crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_plan_hash_transaction_fingerprint_id_shard_8, contention_time)
-│   │                 estimated row count: 0 (33% of the table; stats collected <hidden> ago)
+│   │                 estimated row count: 333,333 (33% of the table; stats collected <hidden> ago)
 │   │                 table: statement_statistics@contention_time_idx (partial index)
 │   │                 spans: /2023-03-21T14:05:00.000001Z-
 │   │
 │   └── • index join
 │       │ columns: (aggregated_ts, fingerprint_id, transaction_fingerprint_id, app_name, execution_count, service_latency, cpu_sql_nanos, contention_time, total_estimated_execution_time, p99_latency, metadata, statistics)
-│       │ estimated row count: 0
+│       │ estimated row count: 500
 │       │ table: statement_statistics@primary
 │       │ key columns: crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_plan_hash_transaction_fingerprint_id_shard_8, aggregated_ts, fingerprint_id, transaction_fingerprint_id, plan_hash, app_name, node_id
 │       │
 │       └── • top-k
 │           │ columns: (aggregated_ts, fingerprint_id, transaction_fingerprint_id, plan_hash, app_name, node_id, crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_plan_hash_transaction_fingerprint_id_shard_8, total_estimated_execution_time)
 │           │ ordering: -total_estimated_execution_time
-│           │ estimated row count: 0
+│           │ estimated row count: 500
 │           │ order: -total_estimated_execution_time
 │           │ k: 500
 │           │
 │           └── • scan
 │                 columns: (aggregated_ts, fingerprint_id, transaction_fingerprint_id, plan_hash, app_name, node_id, crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_plan_hash_transaction_fingerprint_id_shard_8, total_estimated_execution_time)
-│                 estimated row count: 0 (33% of the table; stats collected <hidden> ago)
+│                 estimated row count: 333,333 (33% of the table; stats collected <hidden> ago)
 │                 table: statement_statistics@total_estimated_execution_time_idx (partial index)
 │                 spans: /2023-03-21T14:05:00.000001Z-
 │
 └── • index join
     │ columns: (aggregated_ts, fingerprint_id, transaction_fingerprint_id, app_name, execution_count, service_latency, cpu_sql_nanos, contention_time, total_estimated_execution_time, p99_latency, metadata, statistics)
-    │ estimated row count: 0
+    │ estimated row count: 500
     │ table: statement_statistics@primary
     │ key columns: crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_plan_hash_transaction_fingerprint_id_shard_8, aggregated_ts, fingerprint_id, transaction_fingerprint_id, plan_hash, app_name, node_id
     │
     └── • top-k
         │ columns: (aggregated_ts, fingerprint_id, transaction_fingerprint_id, plan_hash, app_name, node_id, crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_plan_hash_transaction_fingerprint_id_shard_8, p99_latency)
         │ ordering: -p99_latency
-        │ estimated row count: 0
+        │ estimated row count: 500
         │ order: -p99_latency
         │ k: 500
         │
         └── • scan
               columns: (aggregated_ts, fingerprint_id, transaction_fingerprint_id, plan_hash, app_name, node_id, crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_plan_hash_transaction_fingerprint_id_shard_8, p99_latency)
-              estimated row count: 0 (33% of the table; stats collected <hidden> ago)
+              estimated row count: 333,333 (33% of the table; stats collected <hidden> ago)
               table: statement_statistics@p99_latency_idx (partial index)
               spans: /2023-03-21T14:05:00.000001Z-
 
@@ -343,142 +690,403 @@ vectorized: true
 ·
 • union
 │ columns: (aggregated_ts, fingerprint_id, transaction_fingerprint_id, app_name, execution_count, service_latency, cpu_sql_nanos, contention_time, total_estimated_execution_time, p99_latency, metadata, statistics)
-│ estimated row count: 2
+│ estimated row count: 3,000
 │
 ├── • union
 │   │ columns: (aggregated_ts, fingerprint_id, transaction_fingerprint_id, app_name, execution_count, service_latency, cpu_sql_nanos, contention_time, total_estimated_execution_time, p99_latency, metadata, statistics)
-│   │ estimated row count: 2
+│   │ estimated row count: 2,500
 │   │
 │   ├── • union
 │   │   │ columns: (aggregated_ts, fingerprint_id, transaction_fingerprint_id, app_name, execution_count, service_latency, cpu_sql_nanos, contention_time, total_estimated_execution_time, p99_latency, metadata, statistics)
-│   │   │ estimated row count: 1
+│   │   │ estimated row count: 2,000
 │   │   │
 │   │   ├── • union
 │   │   │   │ columns: (aggregated_ts, fingerprint_id, transaction_fingerprint_id, app_name, execution_count, service_latency, cpu_sql_nanos, contention_time, total_estimated_execution_time, p99_latency, metadata, statistics)
-│   │   │   │ estimated row count: 1
+│   │   │   │ estimated row count: 1,500
 │   │   │   │
 │   │   │   ├── • union
 │   │   │   │   │ columns: (aggregated_ts, fingerprint_id, transaction_fingerprint_id, app_name, execution_count, service_latency, cpu_sql_nanos, contention_time, total_estimated_execution_time, p99_latency, metadata, statistics)
-│   │   │   │   │ estimated row count: 1
+│   │   │   │   │ estimated row count: 1,000
 │   │   │   │   │
 │   │   │   │   ├── • index join
 │   │   │   │   │   │ columns: (aggregated_ts, fingerprint_id, transaction_fingerprint_id, app_name, execution_count, service_latency, cpu_sql_nanos, contention_time, total_estimated_execution_time, p99_latency, metadata, statistics)
-│   │   │   │   │   │ estimated row count: 0
+│   │   │   │   │   │ estimated row count: 500
 │   │   │   │   │   │ table: statement_statistics@primary
 │   │   │   │   │   │ key columns: crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_plan_hash_transaction_fingerprint_id_shard_8, aggregated_ts, fingerprint_id, transaction_fingerprint_id, plan_hash, app_name, node_id
 │   │   │   │   │   │
 │   │   │   │   │   └── • top-k
 │   │   │   │   │       │ columns: (aggregated_ts, fingerprint_id, transaction_fingerprint_id, plan_hash, app_name, node_id, crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_plan_hash_transaction_fingerprint_id_shard_8, execution_count)
 │   │   │   │   │       │ ordering: -execution_count
-│   │   │   │   │       │ estimated row count: 0
+│   │   │   │   │       │ estimated row count: 500
 │   │   │   │   │       │ order: -execution_count
 │   │   │   │   │       │ k: 500
 │   │   │   │   │       │
 │   │   │   │   │       └── • scan
 │   │   │   │   │             columns: (aggregated_ts, fingerprint_id, transaction_fingerprint_id, plan_hash, app_name, node_id, crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_plan_hash_transaction_fingerprint_id_shard_8, execution_count)
-│   │   │   │   │             estimated row count: 0 (33% of the table; stats collected <hidden> ago)
+│   │   │   │   │             estimated row count: 333,333 (33% of the table; stats collected <hidden> ago)
 │   │   │   │   │             table: statement_statistics@execution_count_idx (partial index)
 │   │   │   │   │             spans: /2023-03-21T14:05:00.000001Z-
 │   │   │   │   │
 │   │   │   │   └── • index join
 │   │   │   │       │ columns: (aggregated_ts, fingerprint_id, transaction_fingerprint_id, app_name, execution_count, service_latency, cpu_sql_nanos, contention_time, total_estimated_execution_time, p99_latency, metadata, statistics)
-│   │   │   │       │ estimated row count: 0
+│   │   │   │       │ estimated row count: 500
 │   │   │   │       │ table: statement_statistics@primary
 │   │   │   │       │ key columns: crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_plan_hash_transaction_fingerprint_id_shard_8, aggregated_ts, fingerprint_id, transaction_fingerprint_id, plan_hash, app_name, node_id
 │   │   │   │       │
 │   │   │   │       └── • top-k
 │   │   │   │           │ columns: (aggregated_ts, fingerprint_id, transaction_fingerprint_id, plan_hash, app_name, node_id, crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_plan_hash_transaction_fingerprint_id_shard_8, service_latency)
 │   │   │   │           │ ordering: -service_latency
-│   │   │   │           │ estimated row count: 0
+│   │   │   │           │ estimated row count: 500
 │   │   │   │           │ order: -service_latency
 │   │   │   │           │ k: 500
 │   │   │   │           │
 │   │   │   │           └── • scan
 │   │   │   │                 columns: (aggregated_ts, fingerprint_id, transaction_fingerprint_id, plan_hash, app_name, node_id, crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_plan_hash_transaction_fingerprint_id_shard_8, service_latency)
-│   │   │   │                 estimated row count: 0 (33% of the table; stats collected <hidden> ago)
+│   │   │   │                 estimated row count: 333,333 (33% of the table; stats collected <hidden> ago)
 │   │   │   │                 table: statement_statistics@service_latency_idx (partial index)
 │   │   │   │                 spans: /2023-03-21T14:05:00.000001Z-
 │   │   │   │
 │   │   │   └── • index join
 │   │   │       │ columns: (aggregated_ts, fingerprint_id, transaction_fingerprint_id, app_name, execution_count, service_latency, cpu_sql_nanos, contention_time, total_estimated_execution_time, p99_latency, metadata, statistics)
-│   │   │       │ estimated row count: 0
+│   │   │       │ estimated row count: 500
 │   │   │       │ table: statement_statistics@primary
 │   │   │       │ key columns: crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_plan_hash_transaction_fingerprint_id_shard_8, aggregated_ts, fingerprint_id, transaction_fingerprint_id, plan_hash, app_name, node_id
 │   │   │       │
 │   │   │       └── • top-k
 │   │   │           │ columns: (aggregated_ts, fingerprint_id, transaction_fingerprint_id, plan_hash, app_name, node_id, crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_plan_hash_transaction_fingerprint_id_shard_8, cpu_sql_nanos)
 │   │   │           │ ordering: -cpu_sql_nanos
-│   │   │           │ estimated row count: 0
+│   │   │           │ estimated row count: 500
 │   │   │           │ order: -cpu_sql_nanos
 │   │   │           │ k: 500
 │   │   │           │
 │   │   │           └── • scan
 │   │   │                 columns: (aggregated_ts, fingerprint_id, transaction_fingerprint_id, plan_hash, app_name, node_id, crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_plan_hash_transaction_fingerprint_id_shard_8, cpu_sql_nanos)
-│   │   │                 estimated row count: 0 (33% of the table; stats collected <hidden> ago)
+│   │   │                 estimated row count: 333,333 (33% of the table; stats collected <hidden> ago)
 │   │   │                 table: statement_statistics@cpu_sql_nanos_idx (partial index)
 │   │   │                 spans: /2023-03-21T14:05:00.000001Z-
 │   │   │
 │   │   └── • index join
 │   │       │ columns: (aggregated_ts, fingerprint_id, transaction_fingerprint_id, app_name, execution_count, service_latency, cpu_sql_nanos, contention_time, total_estimated_execution_time, p99_latency, metadata, statistics)
-│   │       │ estimated row count: 0
+│   │       │ estimated row count: 500
 │   │       │ table: statement_statistics@primary
 │   │       │ key columns: crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_plan_hash_transaction_fingerprint_id_shard_8, aggregated_ts, fingerprint_id, transaction_fingerprint_id, plan_hash, app_name, node_id
 │   │       │
 │   │       └── • top-k
 │   │           │ columns: (aggregated_ts, fingerprint_id, transaction_fingerprint_id, plan_hash, app_name, node_id, crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_plan_hash_transaction_fingerprint_id_shard_8, contention_time)
 │   │           │ ordering: -contention_time
-│   │           │ estimated row count: 0
+│   │           │ estimated row count: 500
 │   │           │ order: -contention_time
 │   │           │ k: 500
 │   │           │
 │   │           └── • scan
 │   │                 columns: (aggregated_ts, fingerprint_id, transaction_fingerprint_id, plan_hash, app_name, node_id, crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_plan_hash_transaction_fingerprint_id_shard_8, contention_time)
-│   │                 estimated row count: 0 (33% of the table; stats collected <hidden> ago)
+│   │                 estimated row count: 333,333 (33% of the table; stats collected <hidden> ago)
 │   │                 table: statement_statistics@contention_time_idx (partial index)
 │   │                 spans: /2023-03-21T14:05:00.000001Z-
 │   │
 │   └── • index join
 │       │ columns: (aggregated_ts, fingerprint_id, transaction_fingerprint_id, app_name, execution_count, service_latency, cpu_sql_nanos, contention_time, total_estimated_execution_time, p99_latency, metadata, statistics)
-│       │ estimated row count: 0
+│       │ estimated row count: 500
 │       │ table: statement_statistics@primary
 │       │ key columns: crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_plan_hash_transaction_fingerprint_id_shard_8, aggregated_ts, fingerprint_id, transaction_fingerprint_id, plan_hash, app_name, node_id
 │       │
 │       └── • top-k
 │           │ columns: (aggregated_ts, fingerprint_id, transaction_fingerprint_id, plan_hash, app_name, node_id, crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_plan_hash_transaction_fingerprint_id_shard_8, total_estimated_execution_time)
 │           │ ordering: -total_estimated_execution_time
-│           │ estimated row count: 0
+│           │ estimated row count: 500
 │           │ order: -total_estimated_execution_time
 │           │ k: 500
 │           │
 │           └── • scan
 │                 columns: (aggregated_ts, fingerprint_id, transaction_fingerprint_id, plan_hash, app_name, node_id, crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_plan_hash_transaction_fingerprint_id_shard_8, total_estimated_execution_time)
-│                 estimated row count: 0 (33% of the table; stats collected <hidden> ago)
+│                 estimated row count: 333,333 (33% of the table; stats collected <hidden> ago)
 │                 table: statement_statistics@total_estimated_execution_time_idx (partial index)
 │                 spans: /2023-03-21T14:05:00.000001Z-
 │
 └── • index join
     │ columns: (aggregated_ts, fingerprint_id, transaction_fingerprint_id, app_name, execution_count, service_latency, cpu_sql_nanos, contention_time, total_estimated_execution_time, p99_latency, metadata, statistics)
-    │ estimated row count: 0
+    │ estimated row count: 500
     │ table: statement_statistics@primary
     │ key columns: crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_plan_hash_transaction_fingerprint_id_shard_8, aggregated_ts, fingerprint_id, transaction_fingerprint_id, plan_hash, app_name, node_id
     │
     └── • top-k
         │ columns: (aggregated_ts, fingerprint_id, transaction_fingerprint_id, plan_hash, app_name, node_id, crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_plan_hash_transaction_fingerprint_id_shard_8, p99_latency)
         │ ordering: -p99_latency
-        │ estimated row count: 0
+        │ estimated row count: 500
         │ order: -p99_latency
         │ k: 500
         │
         └── • scan
               columns: (aggregated_ts, fingerprint_id, transaction_fingerprint_id, plan_hash, app_name, node_id, crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_plan_hash_transaction_fingerprint_id_shard_8, p99_latency)
-              estimated row count: 0 (33% of the table; stats collected <hidden> ago)
+              estimated row count: 333,333 (33% of the table; stats collected <hidden> ago)
               table: statement_statistics@p99_latency_idx (partial index)
               spans: /2023-03-21T14:05:00.000001Z-
 
 statement ok
-CREATE STATISTICS system_transaction_stats FROM system.transaction_statistics
+ALTER TABLE system.transaction_statistics INJECT STATISTICS '[
+    {
+        "columns": [
+            "aggregated_ts"
+        ],
+        "created_at": "2023-03-24 21:14:26.994348",
+        "distinct_count": 1000000,
+        "histo_col_type": "TIMESTAMPTZ",
+        "null_count": 0,
+        "row_count": 1000000
+    },
+    {
+        "columns": [
+            "aggregated_ts",
+            "fingerprint_id",
+            "app_name",
+            "node_id",
+            "crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_shard_8"
+        ],
+        "created_at": "2023-03-24 21:14:26.994348",
+        "distinct_count": 1000000,
+        "null_count": 0,
+        "row_count": 1000000
+    },
+    {
+        "columns": [
+            "aggregated_ts",
+            "fingerprint_id",
+            "app_name",
+            "crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_shard_8"
+        ],
+        "created_at": "2023-03-24 21:14:26.994348",
+        "distinct_count": 1000000,
+        "null_count": 0,
+        "row_count": 1000000
+    },
+    {
+        "columns": [
+            "aggregated_ts",
+            "fingerprint_id",
+            "crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_shard_8"
+        ],
+        "created_at": "2023-03-24 21:14:26.994348",
+        "distinct_count": 1000000,
+        "null_count": 0,
+        "row_count": 1000000
+    },
+    {
+        "columns": [
+            "aggregated_ts",
+            "app_name"
+        ],
+        "created_at": "2023-03-24 21:14:26.994348",
+        "distinct_count": 1000000,
+        "null_count": 0,
+        "row_count": 1000000
+    },
+    {
+        "columns": [
+            "aggregated_ts",
+            "app_name",
+            "execution_count"
+        ],
+        "created_at": "2023-03-24 21:14:26.994348",
+        "distinct_count": 1000000,
+        "null_count": 0,
+        "row_count": 1000000
+    },
+    {
+        "columns": [
+            "aggregated_ts",
+            "app_name",
+            "service_latency"
+        ],
+        "created_at": "2023-03-24 21:14:26.994348",
+        "distinct_count": 1000000,
+        "null_count": 0,
+        "row_count": 1000000
+    },
+    {
+        "columns": [
+            "aggregated_ts",
+            "app_name",
+            "cpu_sql_nanos"
+        ],
+        "created_at": "2023-03-24 21:14:26.994348",
+        "distinct_count": 1000000,
+        "null_count": 0,
+        "row_count": 1000000
+    },
+    {
+        "columns": [
+            "aggregated_ts",
+            "app_name",
+            "contention_time"
+        ],
+        "created_at": "2023-03-24 21:14:26.994348",
+        "distinct_count": 1000000,
+        "null_count": 0,
+        "row_count": 1000000
+    },
+    {
+        "columns": [
+            "aggregated_ts",
+            "app_name",
+            "total_estimated_execution_time"
+        ],
+        "created_at": "2023-03-24 21:14:26.994348",
+        "distinct_count": 1000000,
+        "null_count": 0,
+        "row_count": 1000000
+    },
+    {
+        "columns": [
+            "aggregated_ts",
+            "app_name",
+            "p99_latency"
+        ],
+        "created_at": "2023-03-24 21:14:26.994348",
+        "distinct_count": 1000000,
+        "null_count": 0,
+        "row_count": 1000000
+    },
+    {
+        "columns": [
+            "aggregated_ts",
+            "crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_shard_8"
+        ],
+        "created_at": "2023-03-24 21:14:26.994348",
+        "distinct_count": 1000000,
+        "null_count": 0,
+        "row_count": 1000000
+    },
+    {
+        "columns": [
+            "fingerprint_id"
+        ],
+        "created_at": "2023-03-24 21:14:26.994348",
+        "distinct_count": 1000000,
+        "histo_col_type": "BYTES",
+        "null_count": 0,
+        "row_count": 1000000
+    },
+    {
+        "columns": [
+            "app_name"
+        ],
+        "created_at": "2023-03-24 21:14:26.994348",
+        "distinct_count": 1000000,
+        "histo_col_type": "STRING",
+        "null_count": 0,
+        "row_count": 1000000
+    },
+    {
+        "columns": [
+            "node_id"
+        ],
+        "created_at": "2023-03-24 21:14:26.994348",
+        "distinct_count": 1000000,
+        "histo_col_type": "INT8",
+        "null_count": 0,
+        "row_count": 1000000
+    },
+    {
+        "columns": [
+            "agg_interval"
+        ],
+        "created_at": "2023-03-24 21:14:26.994348",
+        "distinct_count": 1000000,
+        "histo_col_type": "INTERVAL",
+        "null_count": 0,
+        "row_count": 1000000
+    },
+    {
+        "columns": [
+            "metadata"
+        ],
+        "created_at": "2023-03-24 21:14:26.994348",
+        "distinct_count": 1000000,
+        "null_count": 0,
+        "row_count": 1000000
+    },
+    {
+        "columns": [
+            "statistics"
+        ],
+        "created_at": "2023-03-24 21:14:26.994348",
+        "distinct_count": 1000000,
+        "null_count": 0,
+        "row_count": 1000000
+    },
+    {
+        "columns": [
+            "crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_shard_8"
+        ],
+        "created_at": "2023-03-24 21:14:26.994348",
+        "distinct_count": 1000000,
+        "histo_col_type": "INT4",
+        "null_count": 0,
+        "row_count": 1000000
+    },
+    {
+        "columns": [
+            "execution_count"
+        ],
+        "created_at": "2023-03-24 21:14:26.994348",
+        "distinct_count": 1000000,
+        "histo_col_type": "INT8",
+        "null_count": 0,
+        "row_count": 1000000
+    },
+    {
+        "columns": [
+            "service_latency"
+        ],
+        "created_at": "2023-03-24 21:14:26.994348",
+        "distinct_count": 1000000,
+        "histo_col_type": "FLOAT8",
+        "null_count": 0,
+        "row_count": 1000000
+    },
+    {
+        "columns": [
+            "cpu_sql_nanos"
+        ],
+        "created_at": "2023-03-24 21:14:26.994348",
+        "distinct_count": 1000000,
+        "histo_col_type": "FLOAT8",
+        "null_count": 0,
+        "row_count": 1000000
+    },
+    {
+        "columns": [
+            "contention_time"
+        ],
+        "created_at": "2023-03-24 21:14:26.994348",
+        "distinct_count": 1000000,
+        "histo_col_type": "FLOAT8",
+        "null_count": 0,
+        "row_count": 1000000
+    },
+    {
+        "columns": [
+            "total_estimated_execution_time"
+        ],
+        "created_at": "2023-03-24 21:14:26.994348",
+        "distinct_count": 1000000,
+        "histo_col_type": "FLOAT8",
+        "null_count": 0,
+        "row_count": 1000000
+    },
+    {
+        "columns": [
+            "p99_latency"
+        ],
+        "created_at": "2023-03-24 21:14:26.994348",
+        "distinct_count": 1000000,
+        "histo_col_type": "FLOAT8",
+        "null_count": 0,
+        "row_count": 1000000
+    }
+]'
 
-query T retry
+query T
 EXPLAIN (VERBOSE)
 SELECT * FROM ((SELECT
   aggregated_ts,
@@ -576,135 +1184,135 @@ vectorized: true
 ·
 • union
 │ columns: (aggregated_ts, fingerprint_id, app_name, execution_count, service_latency, cpu_sql_nanos, contention_time, total_estimated_execution_time, p99_latency, metadata, statistics)
-│ estimated row count: 2
+│ estimated row count: 3,000
 │
 ├── • union
 │   │ columns: (aggregated_ts, fingerprint_id, app_name, execution_count, service_latency, cpu_sql_nanos, contention_time, total_estimated_execution_time, p99_latency, metadata, statistics)
-│   │ estimated row count: 2
+│   │ estimated row count: 2,500
 │   │
 │   ├── • union
 │   │   │ columns: (aggregated_ts, fingerprint_id, app_name, execution_count, service_latency, cpu_sql_nanos, contention_time, total_estimated_execution_time, p99_latency, metadata, statistics)
-│   │   │ estimated row count: 1
+│   │   │ estimated row count: 2,000
 │   │   │
 │   │   ├── • union
 │   │   │   │ columns: (aggregated_ts, fingerprint_id, app_name, execution_count, service_latency, cpu_sql_nanos, contention_time, total_estimated_execution_time, p99_latency, metadata, statistics)
-│   │   │   │ estimated row count: 1
+│   │   │   │ estimated row count: 1,500
 │   │   │   │
 │   │   │   ├── • union
 │   │   │   │   │ columns: (aggregated_ts, fingerprint_id, app_name, execution_count, service_latency, cpu_sql_nanos, contention_time, total_estimated_execution_time, p99_latency, metadata, statistics)
-│   │   │   │   │ estimated row count: 1
+│   │   │   │   │ estimated row count: 1,000
 │   │   │   │   │
 │   │   │   │   ├── • index join
 │   │   │   │   │   │ columns: (aggregated_ts, fingerprint_id, app_name, execution_count, service_latency, cpu_sql_nanos, contention_time, total_estimated_execution_time, p99_latency, metadata, statistics)
-│   │   │   │   │   │ estimated row count: 0
+│   │   │   │   │   │ estimated row count: 500
 │   │   │   │   │   │ table: transaction_statistics@primary
 │   │   │   │   │   │ key columns: crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_shard_8, aggregated_ts, fingerprint_id, app_name, node_id
 │   │   │   │   │   │
 │   │   │   │   │   └── • top-k
 │   │   │   │   │       │ columns: (aggregated_ts, fingerprint_id, app_name, node_id, crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_shard_8, execution_count)
 │   │   │   │   │       │ ordering: -execution_count
-│   │   │   │   │       │ estimated row count: 0
+│   │   │   │   │       │ estimated row count: 500
 │   │   │   │   │       │ order: -execution_count
 │   │   │   │   │       │ k: 500
 │   │   │   │   │       │
 │   │   │   │   │       └── • scan
 │   │   │   │   │             columns: (aggregated_ts, fingerprint_id, app_name, node_id, crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_shard_8, execution_count)
-│   │   │   │   │             estimated row count: 0 (33% of the table; stats collected <hidden> ago)
+│   │   │   │   │             estimated row count: 333,333 (33% of the table; stats collected <hidden> ago)
 │   │   │   │   │             table: transaction_statistics@execution_count_idx (partial index)
 │   │   │   │   │             spans: /2023-03-21T14:05:00.000001Z-
 │   │   │   │   │
 │   │   │   │   └── • index join
 │   │   │   │       │ columns: (aggregated_ts, fingerprint_id, app_name, execution_count, service_latency, cpu_sql_nanos, contention_time, total_estimated_execution_time, p99_latency, metadata, statistics)
-│   │   │   │       │ estimated row count: 0
+│   │   │   │       │ estimated row count: 500
 │   │   │   │       │ table: transaction_statistics@primary
 │   │   │   │       │ key columns: crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_shard_8, aggregated_ts, fingerprint_id, app_name, node_id
 │   │   │   │       │
 │   │   │   │       └── • top-k
 │   │   │   │           │ columns: (aggregated_ts, fingerprint_id, app_name, node_id, crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_shard_8, service_latency)
 │   │   │   │           │ ordering: -service_latency
-│   │   │   │           │ estimated row count: 0
+│   │   │   │           │ estimated row count: 500
 │   │   │   │           │ order: -service_latency
 │   │   │   │           │ k: 500
 │   │   │   │           │
 │   │   │   │           └── • scan
 │   │   │   │                 columns: (aggregated_ts, fingerprint_id, app_name, node_id, crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_shard_8, service_latency)
-│   │   │   │                 estimated row count: 0 (33% of the table; stats collected <hidden> ago)
+│   │   │   │                 estimated row count: 333,333 (33% of the table; stats collected <hidden> ago)
 │   │   │   │                 table: transaction_statistics@service_latency_idx (partial index)
 │   │   │   │                 spans: /2023-03-21T14:05:00.000001Z-
 │   │   │   │
 │   │   │   └── • index join
 │   │   │       │ columns: (aggregated_ts, fingerprint_id, app_name, execution_count, service_latency, cpu_sql_nanos, contention_time, total_estimated_execution_time, p99_latency, metadata, statistics)
-│   │   │       │ estimated row count: 0
+│   │   │       │ estimated row count: 500
 │   │   │       │ table: transaction_statistics@primary
 │   │   │       │ key columns: crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_shard_8, aggregated_ts, fingerprint_id, app_name, node_id
 │   │   │       │
 │   │   │       └── • top-k
 │   │   │           │ columns: (aggregated_ts, fingerprint_id, app_name, node_id, crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_shard_8, cpu_sql_nanos)
 │   │   │           │ ordering: -cpu_sql_nanos
-│   │   │           │ estimated row count: 0
+│   │   │           │ estimated row count: 500
 │   │   │           │ order: -cpu_sql_nanos
 │   │   │           │ k: 500
 │   │   │           │
 │   │   │           └── • scan
 │   │   │                 columns: (aggregated_ts, fingerprint_id, app_name, node_id, crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_shard_8, cpu_sql_nanos)
-│   │   │                 estimated row count: 0 (33% of the table; stats collected <hidden> ago)
+│   │   │                 estimated row count: 333,333 (33% of the table; stats collected <hidden> ago)
 │   │   │                 table: transaction_statistics@cpu_sql_nanos_idx (partial index)
 │   │   │                 spans: /2023-03-21T14:05:00.000001Z-
 │   │   │
 │   │   └── • index join
 │   │       │ columns: (aggregated_ts, fingerprint_id, app_name, execution_count, service_latency, cpu_sql_nanos, contention_time, total_estimated_execution_time, p99_latency, metadata, statistics)
-│   │       │ estimated row count: 0
+│   │       │ estimated row count: 500
 │   │       │ table: transaction_statistics@primary
 │   │       │ key columns: crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_shard_8, aggregated_ts, fingerprint_id, app_name, node_id
 │   │       │
 │   │       └── • top-k
 │   │           │ columns: (aggregated_ts, fingerprint_id, app_name, node_id, crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_shard_8, contention_time)
 │   │           │ ordering: -contention_time
-│   │           │ estimated row count: 0
+│   │           │ estimated row count: 500
 │   │           │ order: -contention_time
 │   │           │ k: 500
 │   │           │
 │   │           └── • scan
 │   │                 columns: (aggregated_ts, fingerprint_id, app_name, node_id, crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_shard_8, contention_time)
-│   │                 estimated row count: 0 (33% of the table; stats collected <hidden> ago)
+│   │                 estimated row count: 333,333 (33% of the table; stats collected <hidden> ago)
 │   │                 table: transaction_statistics@contention_time_idx (partial index)
 │   │                 spans: /2023-03-21T14:05:00.000001Z-
 │   │
 │   └── • index join
 │       │ columns: (aggregated_ts, fingerprint_id, app_name, execution_count, service_latency, cpu_sql_nanos, contention_time, total_estimated_execution_time, p99_latency, metadata, statistics)
-│       │ estimated row count: 0
+│       │ estimated row count: 500
 │       │ table: transaction_statistics@primary
 │       │ key columns: crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_shard_8, aggregated_ts, fingerprint_id, app_name, node_id
 │       │
 │       └── • top-k
 │           │ columns: (aggregated_ts, fingerprint_id, app_name, node_id, crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_shard_8, total_estimated_execution_time)
 │           │ ordering: -total_estimated_execution_time
-│           │ estimated row count: 0
+│           │ estimated row count: 500
 │           │ order: -total_estimated_execution_time
 │           │ k: 500
 │           │
 │           └── • scan
 │                 columns: (aggregated_ts, fingerprint_id, app_name, node_id, crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_shard_8, total_estimated_execution_time)
-│                 estimated row count: 0 (33% of the table; stats collected <hidden> ago)
+│                 estimated row count: 333,333 (33% of the table; stats collected <hidden> ago)
 │                 table: transaction_statistics@total_estimated_execution_time_idx (partial index)
 │                 spans: /2023-03-21T14:05:00.000001Z-
 │
 └── • index join
     │ columns: (aggregated_ts, fingerprint_id, app_name, execution_count, service_latency, cpu_sql_nanos, contention_time, total_estimated_execution_time, p99_latency, metadata, statistics)
-    │ estimated row count: 0
+    │ estimated row count: 500
     │ table: transaction_statistics@primary
     │ key columns: crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_shard_8, aggregated_ts, fingerprint_id, app_name, node_id
     │
     └── • top-k
         │ columns: (aggregated_ts, fingerprint_id, app_name, node_id, crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_shard_8, p99_latency)
         │ ordering: -p99_latency
-        │ estimated row count: 0
+        │ estimated row count: 500
         │ order: -p99_latency
         │ k: 500
         │
         └── • scan
               columns: (aggregated_ts, fingerprint_id, app_name, node_id, crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_shard_8, p99_latency)
-              estimated row count: 0 (33% of the table; stats collected <hidden> ago)
+              estimated row count: 333,333 (33% of the table; stats collected <hidden> ago)
               table: transaction_statistics@p99_latency_idx (partial index)
               spans: /2023-03-21T14:05:00.000001Z-
 
@@ -806,134 +1414,134 @@ vectorized: true
 ·
 • union
 │ columns: (aggregated_ts, fingerprint_id, app_name, execution_count, service_latency, cpu_sql_nanos, contention_time, total_estimated_execution_time, p99_latency, metadata, statistics)
-│ estimated row count: 2
+│ estimated row count: 3,000
 │
 ├── • union
 │   │ columns: (aggregated_ts, fingerprint_id, app_name, execution_count, service_latency, cpu_sql_nanos, contention_time, total_estimated_execution_time, p99_latency, metadata, statistics)
-│   │ estimated row count: 2
+│   │ estimated row count: 2,500
 │   │
 │   ├── • union
 │   │   │ columns: (aggregated_ts, fingerprint_id, app_name, execution_count, service_latency, cpu_sql_nanos, contention_time, total_estimated_execution_time, p99_latency, metadata, statistics)
-│   │   │ estimated row count: 1
+│   │   │ estimated row count: 2,000
 │   │   │
 │   │   ├── • union
 │   │   │   │ columns: (aggregated_ts, fingerprint_id, app_name, execution_count, service_latency, cpu_sql_nanos, contention_time, total_estimated_execution_time, p99_latency, metadata, statistics)
-│   │   │   │ estimated row count: 1
+│   │   │   │ estimated row count: 1,500
 │   │   │   │
 │   │   │   ├── • union
 │   │   │   │   │ columns: (aggregated_ts, fingerprint_id, app_name, execution_count, service_latency, cpu_sql_nanos, contention_time, total_estimated_execution_time, p99_latency, metadata, statistics)
-│   │   │   │   │ estimated row count: 1
+│   │   │   │   │ estimated row count: 1,000
 │   │   │   │   │
 │   │   │   │   ├── • index join
 │   │   │   │   │   │ columns: (aggregated_ts, fingerprint_id, app_name, execution_count, service_latency, cpu_sql_nanos, contention_time, total_estimated_execution_time, p99_latency, metadata, statistics)
-│   │   │   │   │   │ estimated row count: 0
+│   │   │   │   │   │ estimated row count: 500
 │   │   │   │   │   │ table: transaction_statistics@primary
 │   │   │   │   │   │ key columns: crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_shard_8, aggregated_ts, fingerprint_id, app_name, node_id
 │   │   │   │   │   │
 │   │   │   │   │   └── • top-k
 │   │   │   │   │       │ columns: (aggregated_ts, fingerprint_id, app_name, node_id, crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_shard_8, execution_count)
 │   │   │   │   │       │ ordering: -execution_count
-│   │   │   │   │       │ estimated row count: 0
+│   │   │   │   │       │ estimated row count: 500
 │   │   │   │   │       │ order: -execution_count
 │   │   │   │   │       │ k: 500
 │   │   │   │   │       │
 │   │   │   │   │       └── • scan
 │   │   │   │   │             columns: (aggregated_ts, fingerprint_id, app_name, node_id, crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_shard_8, execution_count)
-│   │   │   │   │             estimated row count: 0 (33% of the table; stats collected <hidden> ago)
+│   │   │   │   │             estimated row count: 333,333 (33% of the table; stats collected <hidden> ago)
 │   │   │   │   │             table: transaction_statistics@execution_count_idx (partial index)
 │   │   │   │   │             spans: /2023-03-21T14:05:00.000001Z-
 │   │   │   │   │
 │   │   │   │   └── • index join
 │   │   │   │       │ columns: (aggregated_ts, fingerprint_id, app_name, execution_count, service_latency, cpu_sql_nanos, contention_time, total_estimated_execution_time, p99_latency, metadata, statistics)
-│   │   │   │       │ estimated row count: 0
+│   │   │   │       │ estimated row count: 500
 │   │   │   │       │ table: transaction_statistics@primary
 │   │   │   │       │ key columns: crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_shard_8, aggregated_ts, fingerprint_id, app_name, node_id
 │   │   │   │       │
 │   │   │   │       └── • top-k
 │   │   │   │           │ columns: (aggregated_ts, fingerprint_id, app_name, node_id, crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_shard_8, service_latency)
 │   │   │   │           │ ordering: -service_latency
-│   │   │   │           │ estimated row count: 0
+│   │   │   │           │ estimated row count: 500
 │   │   │   │           │ order: -service_latency
 │   │   │   │           │ k: 500
 │   │   │   │           │
 │   │   │   │           └── • scan
 │   │   │   │                 columns: (aggregated_ts, fingerprint_id, app_name, node_id, crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_shard_8, service_latency)
-│   │   │   │                 estimated row count: 0 (33% of the table; stats collected <hidden> ago)
+│   │   │   │                 estimated row count: 333,333 (33% of the table; stats collected <hidden> ago)
 │   │   │   │                 table: transaction_statistics@service_latency_idx (partial index)
 │   │   │   │                 spans: /2023-03-21T14:05:00.000001Z-
 │   │   │   │
 │   │   │   └── • index join
 │   │   │       │ columns: (aggregated_ts, fingerprint_id, app_name, execution_count, service_latency, cpu_sql_nanos, contention_time, total_estimated_execution_time, p99_latency, metadata, statistics)
-│   │   │       │ estimated row count: 0
+│   │   │       │ estimated row count: 500
 │   │   │       │ table: transaction_statistics@primary
 │   │   │       │ key columns: crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_shard_8, aggregated_ts, fingerprint_id, app_name, node_id
 │   │   │       │
 │   │   │       └── • top-k
 │   │   │           │ columns: (aggregated_ts, fingerprint_id, app_name, node_id, crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_shard_8, cpu_sql_nanos)
 │   │   │           │ ordering: -cpu_sql_nanos
-│   │   │           │ estimated row count: 0
+│   │   │           │ estimated row count: 500
 │   │   │           │ order: -cpu_sql_nanos
 │   │   │           │ k: 500
 │   │   │           │
 │   │   │           └── • scan
 │   │   │                 columns: (aggregated_ts, fingerprint_id, app_name, node_id, crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_shard_8, cpu_sql_nanos)
-│   │   │                 estimated row count: 0 (33% of the table; stats collected <hidden> ago)
+│   │   │                 estimated row count: 333,333 (33% of the table; stats collected <hidden> ago)
 │   │   │                 table: transaction_statistics@cpu_sql_nanos_idx (partial index)
 │   │   │                 spans: /2023-03-21T14:05:00.000001Z-
 │   │   │
 │   │   └── • index join
 │   │       │ columns: (aggregated_ts, fingerprint_id, app_name, execution_count, service_latency, cpu_sql_nanos, contention_time, total_estimated_execution_time, p99_latency, metadata, statistics)
-│   │       │ estimated row count: 0
+│   │       │ estimated row count: 500
 │   │       │ table: transaction_statistics@primary
 │   │       │ key columns: crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_shard_8, aggregated_ts, fingerprint_id, app_name, node_id
 │   │       │
 │   │       └── • top-k
 │   │           │ columns: (aggregated_ts, fingerprint_id, app_name, node_id, crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_shard_8, contention_time)
 │   │           │ ordering: -contention_time
-│   │           │ estimated row count: 0
+│   │           │ estimated row count: 500
 │   │           │ order: -contention_time
 │   │           │ k: 500
 │   │           │
 │   │           └── • scan
 │   │                 columns: (aggregated_ts, fingerprint_id, app_name, node_id, crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_shard_8, contention_time)
-│   │                 estimated row count: 0 (33% of the table; stats collected <hidden> ago)
+│   │                 estimated row count: 333,333 (33% of the table; stats collected <hidden> ago)
 │   │                 table: transaction_statistics@contention_time_idx (partial index)
 │   │                 spans: /2023-03-21T14:05:00.000001Z-
 │   │
 │   └── • index join
 │       │ columns: (aggregated_ts, fingerprint_id, app_name, execution_count, service_latency, cpu_sql_nanos, contention_time, total_estimated_execution_time, p99_latency, metadata, statistics)
-│       │ estimated row count: 0
+│       │ estimated row count: 500
 │       │ table: transaction_statistics@primary
 │       │ key columns: crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_shard_8, aggregated_ts, fingerprint_id, app_name, node_id
 │       │
 │       └── • top-k
 │           │ columns: (aggregated_ts, fingerprint_id, app_name, node_id, crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_shard_8, total_estimated_execution_time)
 │           │ ordering: -total_estimated_execution_time
-│           │ estimated row count: 0
+│           │ estimated row count: 500
 │           │ order: -total_estimated_execution_time
 │           │ k: 500
 │           │
 │           └── • scan
 │                 columns: (aggregated_ts, fingerprint_id, app_name, node_id, crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_shard_8, total_estimated_execution_time)
-│                 estimated row count: 0 (33% of the table; stats collected <hidden> ago)
+│                 estimated row count: 333,333 (33% of the table; stats collected <hidden> ago)
 │                 table: transaction_statistics@total_estimated_execution_time_idx (partial index)
 │                 spans: /2023-03-21T14:05:00.000001Z-
 │
 └── • index join
     │ columns: (aggregated_ts, fingerprint_id, app_name, execution_count, service_latency, cpu_sql_nanos, contention_time, total_estimated_execution_time, p99_latency, metadata, statistics)
-    │ estimated row count: 0
+    │ estimated row count: 500
     │ table: transaction_statistics@primary
     │ key columns: crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_shard_8, aggregated_ts, fingerprint_id, app_name, node_id
     │
     └── • top-k
         │ columns: (aggregated_ts, fingerprint_id, app_name, node_id, crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_shard_8, p99_latency)
         │ ordering: -p99_latency
-        │ estimated row count: 0
+        │ estimated row count: 500
         │ order: -p99_latency
         │ k: 500
         │
         └── • scan
               columns: (aggregated_ts, fingerprint_id, app_name, node_id, crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_shard_8, p99_latency)
-              estimated row count: 0 (33% of the table; stats collected <hidden> ago)
+              estimated row count: 333,333 (33% of the table; stats collected <hidden> ago)
               table: transaction_statistics@p99_latency_idx (partial index)
               spans: /2023-03-21T14:05:00.000001Z-


### PR DESCRIPTION
Backport 1/1 commits from #99532.

/cc @cockroachdb/release

---

Background thread: https://github.com/cockroachdb/cockroach/pull/99240#issuecomment-1483241941

Part of https://github.com/cockroachdb/cockroach/issues/99399.

This commit replaces the `CREATE STATISTICS` statements in the `TestExecBuild_sql_statistics_persisted` testdata with `ALTER TABLE ... INJECT STATISTICS` and removes the retry directives added to deflake the test in #99447.

Epic: none

Release note: None

Release justification: Test-only change