### PR TITLE
release-22.1: kvserver: revert #98150

### DIFF
--- a/pkg/kv/kvserver/replica_proposal.go
+++ b/pkg/kv/kvserver/replica_proposal.go
@@ -392,7 +392,7 @@ func (r *Replica) leasePostApplyLocked(
 	// seconds) in any case due to the liveness heartbeats. And the system config
 	// will be gossiped rarely because it falls on a range with an epoch-based
 	// range lease that is only reacquired extremely infrequently.
-	if leaseChangingHands && iAmTheLeaseHolder {
+	if iAmTheLeaseHolder {
 		// NB: run these in an async task to keep them out of the critical section
 		// (r.mu is held here).
 		_ = r.store.stopper.RunAsyncTask(r.AnnotateCtx(context.Background()), "lease-triggers", func(ctx context.Context) {


### PR DESCRIPTION
Backport 1/2 commits from https://github.com/cockroachdb/cockroach/pull/99643 on behalf of @tbg.

/cc https://github.com/orgs/cockroachdb/teams/release

---

This reverts #98150 because we think it introduced a problem that was detected via the `replicate/wide` roachtest[^1]. It seems that for reasons still unknown we do rely on the periodic gossip trigger on liveness lease extensions.

[^1]: https://github.com/cockroachdb/cockroach/issues/99268#issuecomment-1484968745

Touches #99268.
Touches #97966.
Closes #99268.
Touches #98945.

Epic: none
Release note: None

---

Release justification: critical bug fix.