### PR TITLE
sql/catalog/descs: extend timeout

### DIFF
--- a/pkg/sql/catalog/descs/BUILD.bazel
+++ b/pkg/sql/catalog/descs/BUILD.bazel
@@ -77,7 +77,7 @@ go_library(
 
 go_test(
     name = "descs_test",
-    size = "small",
+    size = "medium",
     srcs = [
         "collection_test.go",
         "errors_test.go",
@@ -85,7 +85,7 @@ go_test(
         "txn_external_test.go",
         "txn_with_executor_datadriven_test.go",
     ],
-    args = ["-test.timeout=55s"],
+    args = ["-test.timeout=295s"],
     data = glob(["testdata/**"]),
     embed = [":descs"],
     deps = [


### PR DESCRIPTION
Now that the tests are more overloaded, we need more time to finish them.

Epic: none

Fixes: #99519

Release note: None