### PR TITLE
build: tweak openssl config for FIPS buils

### DIFF
--- a/build/deploy/Dockerfile
+++ b/build/deploy/Dockerfile
@@ -1,5 +1,5 @@
 FROM registry.access.redhat.com/ubi8/ubi-minimal
-ARG additional_packages
+ARG fips_enabled
 
 # For deployment, we need the following additionally installed:
 # tzdata - for time zone functions; reinstalled to replace the missing
@@ -8,8 +8,23 @@ ARG additional_packages
 # tar - used by kubectl cp
 RUN microdnf update -y \
     && rpm --erase --nodeps tzdata \
-    && microdnf install tzdata hostname tar gzip xz $additional_packages -y \
+    && microdnf install tzdata hostname tar gzip xz -y \
     && rm -rf /var/cache/yum
+# FIPS mode requires the `openssl` package installed. Also we need to temporarily
+# install the `crypto-policies-scripts` packege to tweak some configs. Because
+# `microdnf` doesn't support `autoremove`, we need to record the list of
+# packages before and after, and remove the installed ones afterward.
+RUN if [ "$fips_enabled" == "1" ]; then \
+    microdnf install -y openssl && \
+    rpm -qa | sort > /before.txt && \
+    microdnf install crypto-policies-scripts && \
+    fips-mode-setup --enable --no-bootcfg && \
+    rpm -qa | sort > /after.txt && \
+    microdnf remove -y $(comm -13 /before.txt /after.txt) && \
+    microdnf clean all && \
+    rm -rf /var/cache/yum /before.txt /after.txt; \
+    fi
+
 
 RUN mkdir /usr/local/lib/cockroach /cockroach /licenses /docker-entrypoint-initdb.d
 COPY cockroach.sh cockroach /cockroach/

--- a/build/teamcity/internal/release/process/make-and-publish-build-artifacts.sh
+++ b/build/teamcity/internal/release/process/make-and-publish-build-artifacts.sh
@@ -112,7 +112,7 @@ cp --recursive licenses "build/deploy-${platform_name}"
 mv build/deploy-${platform_name}/lib/* build/deploy-${platform_name}/
 rmdir build/deploy-${platform_name}/lib
 
-docker build --no-cache --pull --platform "linux/amd64" --tag="${gcr_tag_fips}" --build-arg additional_packages=openssl "build/deploy-${platform_name}"
+docker build --no-cache --pull --platform "linux/amd64" --tag="${gcr_tag_fips}" --build-arg fips_enabled=1 "build/deploy-${platform_name}"
 docker push "$gcr_tag_fips"
 
 tc_end_block "Make and push FIPS docker image"

--- a/build/teamcity/internal/release/process/publish-cockroach-release.sh
+++ b/build/teamcity/internal/release/process/publish-cockroach-release.sh
@@ -169,7 +169,7 @@ docker build \
   --platform="linux/amd64" \
   --tag="${dockerhub_tag_fips}" \
   --tag="${gcr_tag_fips}" \
-  --build-arg additional_packages=openssl \
+  --build-arg fips_enabled=1 \
   "build/deploy-${platform_name}"
 docker push "$gcr_tag_fips"
 docker push "$dockerhub_tag_fips"


### PR DESCRIPTION
Previously, for FIPS-enabled builds, the OpenSSL configs were untouched, and as a result, some of the configuration options were not FIPS-compliant.

This PR tweaks the configs to be FIPS-compliant.

Epic: DEVINF-478
Release note: None