### PR TITLE
flowinfra: fix recently introduced bug with row-based flow shutdown

### DIFF
--- a/pkg/sql/flowinfra/flow_registry_test.go
+++ b/pkg/sql/flowinfra/flow_registry_test.go
@@ -721,9 +721,10 @@ func TestErrorOnSlowHandshake(t *testing.T) {
 		err:                      errors.New("dummy error"),
 	}
 
+	receiver := &distsqlutils.RowBuffer{}
 	var wg sync.WaitGroup
 	streamInfo := &InboundStreamInfo{
-		receiver: RowInboundStreamHandler{&distsqlutils.RowBuffer{}, nil /* types */},
+		receiver: RowInboundStreamHandler{receiver, nil /* types */},
 		onFinish: wg.Done,
 	}
 	wg.Add(1)
@@ -776,5 +777,12 @@ func TestErrorOnSlowHandshake(t *testing.T) {
 		// test is to ensure that no deadlocks happen, and we don't care that
 		// much about which particular error was returned.
 		t.Fatalf("unexpected error from ConnectInboundStream: %v", err)
+	}
+	// We expect that "no inbound stream connection" error is pushed into the
+	// receiver.
+	if len(receiver.Mu.Records) != 1 {
+		t.Fatalf("expected a single meta object with an error, got %v", receiver.Mu.Records)
+	} else if r := receiver.Mu.Records[0]; !IsNoInboundStreamConnectionError(r.Meta.Err) {
+		t.Fatalf("unexpected error: %v", r)
 	}
 }


### PR DESCRIPTION
This commit fixes a bug that was introduced in a71e11c3137a3242a6780c70ab6c2062a31f504a that I believe to be the root cause of "slow quiesce" CI failures we've seen on `fakedist-vec-off` logic test config. In particular, the bug is as follows: that commit made it so that if the handshake with the remote node (when connecting the inbound stream) fails, we now "cancel" the stream by marking it as "canceled" and decrementing the wait group. However, one important piece of the proper cancellation was missed - we also need to push an error to the receiver. We do that when the inbound stream timeout timer fires but that commit forgot to do so on the handshake error, and this is now fixed.

The incorrect assumption in a71e11c3137a3242a6780c70ab6c2062a31f504a was that canceling the context of the flow is sufficient for the proper shutdown, but this turns out to not be the case in the row-based flows. We have some components (e.g. `execinfra.RowChannel`) that will block until `ProducerDone` is not called, and with just cancelling the context that could never happen. Now that we properly push the error it will. The vectorized flows aren't affected by this because there we do listen for context cancellation signals.

Fixes: #99666.

Release note: None