### PR TITLE
roachtest: anonymize failures of `workload-replay` in roachtest

### DIFF
--- a/pkg/cmd/roachtest/registry/test_spec.go
+++ b/pkg/cmd/roachtest/registry/test_spec.go
@@ -92,6 +92,10 @@ type TestSpec struct {
 
 	// Run is the test function.
 	Run func(ctx context.Context, t test.Test, c cluster.Cluster)
+
+	// True iff results from this test should not be published externally,
+	// e.g. to GitHub.
+	RedactResults bool
 }
 
 // PostValidation is a type of post-validation that runs after a test completes.


### PR DESCRIPTION
Epic: DEVINFHD-809
Release note: None