### PR TITLE
roachtest: fix distsql version issue with mt upgrade roachtest

### DIFF
--- a/pkg/cmd/roachtest/tests/multitenant_upgrade.go
+++ b/pkg/cmd/roachtest/tests/multitenant_upgrade.go
@@ -226,6 +226,15 @@ func runMultiTenantUpgrade(ctx context.Context, t test.Test, c cluster.Cluster, 
 		`pq: error validating the version of one or more SQL server instances: validate cluster version failed: some tenant pods running on binary less than 23.1`,
 		"SET CLUSTER SETTING version = crdb_internal.node_executable_version()")
 
+	// Note that here we'd like to validate that the first tenant 11 server can
+	// query the storage cluster. The problem however, is that due to #88927,
+	// they can't because they're at different DistSQL versions. We plan to never change
+	// the DistSQL version again so once we have 23.1 images to test against we should
+	// add a check in here that we're able to query from tenant 11 first server.
+	t.Status("stop the second tenant 11 server and restart it on the new binary")
+	tenant11b.stop(ctx, t, c)
+	tenant11b.start(ctx, t, c, currentBinary)
+
 	t.Status("verify that the first tenant 11 server can now query the storage cluster")
 	{
 		verifySQL(t, tenant11a.pgURL,
@@ -234,10 +243,6 @@ func runMultiTenantUpgrade(ctx context.Context, t test.Test, c cluster.Cluster, 
 			mkStmt("SHOW CLUSTER SETTING version").
 				withResults([][]string{{initialVersion}}))
 	}
-
-	t.Status("stop the second tenant 11 server and restart it on the new binary")
-	tenant11b.stop(ctx, t, c)
-	tenant11b.start(ctx, t, c, currentBinary)
 
 	t.Status("verify the second tenant 11 server works with the new binary")
 	{


### PR DESCRIPTION
This code change only fixes one issue with the test by not validating the cluster in the intermediate state because the SQL servers will have different DistSQL versions.

Release note: None
Epic: none