### PR TITLE
release-22.1: storage: skip TestPebbleMetricEventListener

### DIFF
--- a/pkg/storage/pebble_test.go
+++ b/pkg/storage/pebble_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -463,6 +464,7 @@ func TestPebbleSeparatorSuccessor(t *testing.T) {
 
 func TestPebbleMetricEventListener(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	skip.WithIssue(t, 97843, "flaky test")
 	defer log.Scope(t).Close(t)
 	ctx := context.Background()
 


### PR DESCRIPTION
Informs #97843.
Release note: None.
Release justification: Non-production code changes.