### PR TITLE
sql: complete EXPLAIN (VEC, VERBOSE) in the bundle

### DIFF
--- a/pkg/sql/distsql_physical_planner.go
+++ b/pkg/sql/distsql_physical_planner.go
@@ -918,10 +918,13 @@ func (p *PlanningCtx) getDefaultSaveFlowsFunc(
 			flowCtx, cleanup := newFlowCtxForExplainPurposes(ctx, p, planner)
 			defer cleanup()
 			getExplain := func(verbose bool) []string {
+				// When we're collecting the bundle, we're always recording the
+				// stats.
+				const recordingStats = true
 				explain, err := colflow.ExplainVec(
 					ctx, flowCtx, flows, p.infra.LocalProcessors, opChains,
 					planner.extendedEvalCtx.DistSQLPlanner.gatewaySQLInstanceID,
-					verbose, planner.curPlan.flags.IsDistributed(),
+					verbose, planner.curPlan.flags.IsDistributed(), recordingStats,
 				)
 				if err != nil {
 					// In some edge cases (like when subqueries are present or

--- a/pkg/sql/explain_vec.go
+++ b/pkg/sql/explain_vec.go
@@ -76,9 +76,13 @@ func (n *explainVecNode) startExec(params runParams) error {
 	}
 	verbose := n.options.Flags[tree.ExplainFlagVerbose]
 	willDistribute := physPlan.Distribution.WillDistribute()
+	// When running EXPLAIN (VEC) we choose the option of "not recording stats"
+	// since we don't know whether the next invocation of the explained
+	// statement would result in the collection of execution stats or not.
+	const recordingStats = false
 	n.run.lines, err = colflow.ExplainVec(
 		params.ctx, flowCtx, flows, physPlan.LocalProcessors, nil, /* opChains */
-		distSQLPlanner.gatewaySQLInstanceID, verbose, willDistribute,
+		distSQLPlanner.gatewaySQLInstanceID, verbose, willDistribute, recordingStats,
 	)
 	if err != nil {
 		return err


### PR DESCRIPTION
This commit makes it so that `vec-v.txt` file in the stmt bundle is complete. In particular, previously we would not include the auxiliary stats-related operators since we hard-coded `recordingStats=false` when generating the operator chains, and this is now fixed. The impact is very minor so there is no release note, but I believe it's worth backporting still.

Informs: #99741

Epic: None

Release note: None