### PR TITLE
sql: remove no longer used channel in createStatsNode

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -48,6 +48,7 @@
 /pkg/sql/stats/              @cockroachdb/sql-queries
 
 /pkg/sql/col*                @cockroachdb/sql-queries
+/pkg/sql/create_stats*       @cockroachdb/sql-queries
 /pkg/sql/distsql*.go         @cockroachdb/sql-queries
 /pkg/sql/exec*               @cockroachdb/sql-queries
 #!/pkg/sql/exec_log*.go        @cockroachdb/sql-queries-noreview

--- a/pkg/sql/create_stats.go
+++ b/pkg/sql/create_stats.go
@@ -104,22 +104,19 @@ type createStatsNode struct {
 // createStatsRun contains the run-time state of createStatsNode during local
 // execution.
 type createStatsRun struct {
-	resultsCh chan tree.Datums
-	errCh     chan error
+	errCh chan error
 }
 
 func (n *createStatsNode) startExec(params runParams) error {
 	telemetry.Inc(sqltelemetry.SchemaChangeCreateCounter("stats"))
-	n.run.resultsCh = make(chan tree.Datums)
 	n.run.errCh = make(chan error)
 	go func() {
-		err := n.startJob(params.ctx, n.run.resultsCh)
+		err := n.startJob(params.ctx)
 		select {
 		case <-params.ctx.Done():
 		case n.run.errCh <- err:
 		}
 		close(n.run.errCh)
-		close(n.run.resultsCh)
 	}()
 	return nil
 }
@@ -130,8 +127,6 @@ func (n *createStatsNode) Next(params runParams) (bool, error) {
 		return false, params.ctx.Err()
 	case err := <-n.run.errCh:
 		return false, err
-	case <-n.run.resultsCh:
-		return true, nil
 	}
 }
 
@@ -139,7 +134,7 @@ func (*createStatsNode) Close(context.Context) {}
 func (*createStatsNode) Values() tree.Datums   { return nil }
 
 // startJob starts a CreateStats job to plan and execute statistics creation.
-func (n *createStatsNode) startJob(ctx context.Context, resultsCh chan<- tree.Datums) error {
+func (n *createStatsNode) startJob(ctx context.Context) error {
 	record, err := n.makeJobRecord(ctx)
 	if err != nil {
 		return err


### PR DESCRIPTION
This hasn't been used as of fe6377c4f1b6e822bb436f64808762e02a815c11. Also mark `create_stats.go` as owned by SQL Queries.

Epic: None

Release note: None