### PR TITLE
sql/pgwire: buffer messages during COPY TO and startup

### DIFF
--- a/pkg/sql/conn_io.go
+++ b/pkg/sql/conn_io.go
@@ -364,9 +364,6 @@ var _ Command = CopyIn{}
 type CopyOut struct {
 	ParsedStmt parser.Statement
 	Stmt       *tree.CopyTo
-	// Conn is the network connection. Execution of the CopyFrom statement takes
-	// control of the connection.
-	Conn pgwirebase.Conn
 	// TimeReceived is the time at which the message was received
 	// from the client. Used to compute the service latency.
 	TimeReceived time.Time
@@ -682,7 +679,7 @@ type ClientComm interface {
 	// CreateCopyInResult creates a result for a Copy-in command.
 	CreateCopyInResult(pos CmdPos) CopyInResult
 	// CreateCopyOutResult creates a result for a Copy-out command.
-	CreateCopyOutResult(pos CmdPos) CopyOutResult
+	CreateCopyOutResult(cmd CopyOut, pos CmdPos) CopyOutResult
 	// CreateDrainResult creates a result for a Drain command.
 	CreateDrainResult(pos CmdPos) DrainResult
 
@@ -883,9 +880,20 @@ type CopyInResult interface {
 }
 
 // CopyOutResult represents the result of a CopyOut command. Closing this result
-// produces no output for the client.
+// sends a CommandComplete message to the client.
 type CopyOutResult interface {
 	ResultBase
+
+	// SendCopyOut sends the copy out response to the client.
+	SendCopyOut(
+		ctx context.Context, cols colinfo.ResultColumns, format pgwirebase.FormatCode,
+	) error
+
+	// SendCopyData adds a COPY data row to the result.
+	SendCopyData(ctx context.Context, copyData []byte, isHeader bool) error
+
+	// SendCopyDone sends the copy done response to the client.
+	SendCopyDone(ctx context.Context) error
 }
 
 // ClientLock is an interface returned by ClientComm.lockCommunication(). It
@@ -1077,6 +1085,25 @@ func (r *streamingCommandResult) SetPrepStmtOutput(context.Context, colinfo.Resu
 func (r *streamingCommandResult) SetPortalOutput(
 	context.Context, colinfo.ResultColumns, []pgwirebase.FormatCode,
 ) {
+}
+
+// SendCopyOut is part of the sql.CopyOutResult interface.
+func (r *streamingCommandResult) SendCopyOut(
+	ctx context.Context, cols colinfo.ResultColumns, format pgwirebase.FormatCode,
+) error {
+	return errors.AssertionFailedf("streamingCommandResult does not implement SendCopyOut")
+}
+
+// SendCopyData is part of the sql.CopyOutResult interface.
+func (r *streamingCommandResult) SendCopyData(
+	ctx context.Context, copyData []byte, isHeader bool,
+) error {
+	return errors.AssertionFailedf("streamingCommandResult does not implement SendCopyData")
+}
+
+// SendCopyDone is part of the pgwirebase.Conn interface.
+func (r *streamingCommandResult) SendCopyDone(ctx context.Context) error {
+	return errors.AssertionFailedf("streamingCommandResult does not implement SendCopyDone")
 }
 
 // BulkJobInfoKey are for keys stored in pgwire.commandResult.bulkJobInfo.

--- a/pkg/sql/copy_from.go
+++ b/pkg/sql/copy_from.go
@@ -15,7 +15,6 @@ import (
 	"context"
 	"encoding/binary"
 	"io"
-	"strconv"
 	"strings"
 	"time"
 	"unicode/utf8"
@@ -590,13 +589,7 @@ Loop:
 		}
 	}
 
-	// Finalize execution by sending the statement tag and number of rows
-	// inserted.
-	dummy := tree.CopyFrom{}
-	tag := []byte(dummy.StatementTag())
-	tag = append(tag, ' ')
-	tag = strconv.AppendInt(tag, int64(c.insertedRows), 10 /* base */)
-	return c.conn.SendCommandComplete(tag)
+	return nil
 }
 
 const (

--- a/pkg/sql/internal.go
+++ b/pkg/sql/internal.go
@@ -1199,7 +1199,7 @@ func (icc *internalClientComm) CreateEmptyQueryResult(pos CmdPos) EmptyQueryResu
 }
 
 // CreateCopyInResult is part of the ClientComm interface.
-func (icc *internalClientComm) CreateCopyInResult(pos CmdPos) CopyInResult {
+func (icc *internalClientComm) CreateCopyInResult(cmd CopyIn, pos CmdPos) CopyInResult {
 	panic("unimplemented")
 }
 

--- a/pkg/sql/internal.go
+++ b/pkg/sql/internal.go
@@ -1204,7 +1204,7 @@ func (icc *internalClientComm) CreateCopyInResult(pos CmdPos) CopyInResult {
 }
 
 // CreateCopyOutResult is part of the ClientComm interface.
-func (icc *internalClientComm) CreateCopyOutResult(pos CmdPos) CopyOutResult {
+func (icc *internalClientComm) CreateCopyOutResult(cmd CopyOut, pos CmdPos) CopyOutResult {
 	panic("unimplemented")
 }
 

--- a/pkg/sql/pgwire/command_result.go
+++ b/pkg/sql/pgwire/command_result.go
@@ -321,6 +321,12 @@ func (r *commandResult) SetPortalOutput(
 	_ /* err */ = r.conn.writeRowDescription(ctx, cols, formatCodes, &r.conn.writerState.buf)
 }
 
+// SetRowsAffected is part of the sql.CopyIn interface.
+func (r *commandResult) SetRowsAffected(ctx context.Context, n int) {
+	r.assertNotReleased()
+	r.rowsAffected = n
+}
+
 // SendCopyOut is part of the sql.CopyOutResult interface.
 func (r *commandResult) SendCopyOut(
 	ctx context.Context, cols colinfo.ResultColumns, format pgwirebase.FormatCode,

--- a/pkg/sql/pgwire/conn.go
+++ b/pkg/sql/pgwire/conn.go
@@ -1263,12 +1263,6 @@ func (c *conn) BeginCopyIn(
 	return c.msgBuilder.finishMsg(c.conn)
 }
 
-// SendCommandComplete is part of the pgwirebase.Conn interface.
-func (c *conn) SendCommandComplete(tag []byte) error {
-	c.bufferCommandComplete(tag)
-	return nil
-}
-
 // Rd is part of the pgwirebase.Conn interface.
 func (c *conn) Rd() pgwirebase.BufferedReader {
 	return &pgwireReader{conn: c}
@@ -1854,8 +1848,11 @@ func (c *conn) CreateErrorResult(pos sql.CmdPos) sql.ErrorResult {
 }
 
 // CreateCopyInResult is part of the sql.ClientComm interface.
-func (c *conn) CreateCopyInResult(pos sql.CmdPos) sql.CopyInResult {
-	return c.newMiscResult(pos, noCompletionMsg)
+func (c *conn) CreateCopyInResult(cmd sql.CopyIn, pos sql.CmdPos) sql.CopyInResult {
+	res := c.newMiscResult(pos, commandComplete)
+	res.stmtType = cmd.Stmt.StatementReturnType()
+	res.cmdCompleteTag = cmd.Stmt.StatementTag()
+	return res
 }
 
 // CreateCopyOutResult is part of the sql.ClientComm interface.

--- a/pkg/sql/pgwire/pgwirebase/conn.go
+++ b/pkg/sql/pgwire/pgwirebase/conn.go
@@ -31,17 +31,6 @@ type Conn interface {
 	// the columns that are expected for the rows to be inserted.
 	BeginCopyIn(ctx context.Context, columns []colinfo.ResultColumn, format FormatCode) error
 
-	// BeginCopyOut sends the message server message initiating the Copy-in
-	// subprotocol (COPY ... TO STDOUT). This message informs the client about
-	// the columns that are expected for the rows to be output in CopyData format.
-	BeginCopyOut(ctx context.Context, columns []colinfo.ResultColumn, format FormatCode) error
-
-	// SendCopyData sends CopyData out to the connection.
-	SendCopyData(ctx context.Context, copyData []byte) error
-
-	// SendCopyDone sends CopyDone to the connection.
-	SendCopyDone(ctx context.Context) error
-
 	// SendCommandComplete sends a serverMsgCommandComplete with the given
 	// payload.
 	SendCommandComplete(tag []byte) error

--- a/pkg/sql/pgwire/pgwirebase/conn.go
+++ b/pkg/sql/pgwire/pgwirebase/conn.go
@@ -30,8 +30,4 @@ type Conn interface {
 	// subprotocol (COPY ... FROM STDIN). This message informs the client about
 	// the columns that are expected for the rows to be inserted.
 	BeginCopyIn(ctx context.Context, columns []colinfo.ResultColumn, format FormatCode) error
-
-	// SendCommandComplete sends a serverMsgCommandComplete with the given
-	// payload.
-	SendCommandComplete(tag []byte) error
 }


### PR DESCRIPTION
fixes https://github.com/cockroachdb/cockroach/issues/97314
backport fixes https://github.com/cockroachdb/cockroach/issues/99546

---

### sql: buffer COPY OUT data 

Rather than sending each COPY result row one-by-one, now the data will
get buffered, then flushed when the buffer size limit is reached or when
sending ReadyForQuery.

This fixes an issue that was causing the ruby-pg test to hang, since it assumes
the data will be buffered.

---

### pgwire: buffer startup messages when creating connection

This avoids sending each ParameterStatus one-by-one.

---

### sql: refactor CopyIn handling

This makes it so we don't need to manually send a CommandComplete.
Instead, when the CopyInResult is closed, CommandComplete will be sent,
similar to how it works for other message types.

Release note: None