### PR TITLE
*: identify remaining uses of TODOSQLCodec

### DIFF
--- a/pkg/ccl/backupccl/BUILD.bazel
+++ b/pkg/ccl/backupccl/BUILD.bazel
@@ -278,6 +278,7 @@ go_test(
         "//pkg/testutils/datapathutils",
         "//pkg/testutils/distsqlutils",
         "//pkg/testutils/jobutils",
+        "//pkg/testutils/keysutils",
         "//pkg/testutils/serverutils",
         "//pkg/testutils/skip",
         "//pkg/testutils/sqlutils",

--- a/pkg/ccl/backupccl/backup_test.go
+++ b/pkg/ccl/backupccl/backup_test.go
@@ -89,6 +89,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/stats"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/jobutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/keysutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
@@ -6132,7 +6133,7 @@ func getMockTableDesc(
 // methods.
 func TestPublicIndexTableSpans(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	codec := keys.TODOSQLCodec
+	codec := keysutils.TestingSQLCodec
 	execCfg := &sql.ExecutorConfig{
 		Codec: codec,
 	}

--- a/pkg/ccl/streamingccl/streamingest/BUILD.bazel
+++ b/pkg/ccl/streamingccl/streamingest/BUILD.bazel
@@ -135,6 +135,7 @@ go_test(
         "//pkg/testutils/datapathutils",
         "//pkg/testutils/distsqlutils",
         "//pkg/testutils/jobutils",
+        "//pkg/testutils/keysutils",
         "//pkg/testutils/serverutils",
         "//pkg/testutils/skip",
         "//pkg/testutils/sqlutils",

--- a/pkg/ccl/streamingccl/streamingest/stream_ingestion_processor_test.go
+++ b/pkg/ccl/streamingccl/streamingest/stream_ingestion_processor_test.go
@@ -37,6 +37,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/distsqlutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/keysutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/storageutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
@@ -363,7 +364,7 @@ func assertEqualKVs(
 	tableID int,
 	partitionTimestamp hlc.Timestamp,
 ) {
-	key := keys.TODOSQLCodec.TablePrefix(uint32(tableID))
+	key := keysutils.TestingSQLCodec.TablePrefix(uint32(tableID))
 
 	// Iterate over the store.
 	store := tc.GetFirstStoreFromServer(t, 0)

--- a/pkg/keys/sql.go
+++ b/pkg/keys/sql.go
@@ -154,11 +154,6 @@ func MakeSQLCodec(tenID roachpb.TenantID) SQLCodec {
 // SystemSQLCodec is a SQL key codec for the system tenant.
 var SystemSQLCodec = MakeSQLCodec(roachpb.SystemTenantID)
 
-// TODOSQLCodec is a SQL key codec. It is equivalent to SystemSQLCodec, but
-// should be used when it is unclear which tenant should be referenced by the
-// surrounding context.
-var TODOSQLCodec = MakeSQLCodec(roachpb.SystemTenantID)
-
 // ForSystemTenant returns whether the encoder is bound to the system tenant.
 func (e sqlEncoder) ForSystemTenant() bool {
 	return len(e.TenantPrefix()) == 0

--- a/pkg/kv/kvserver/reports/reporter.go
+++ b/pkg/kv/kvserver/reports/reporter.go
@@ -447,9 +447,12 @@ func visitAncestors(
 	cfg *config.SystemConfig,
 	visitor func(context.Context, *zonepb.ZoneConfig, ZoneKey) bool,
 ) (bool, error) {
+	// This is a bug: see https://github.com/cockroachdb/cockroach/issues/48123.
+	var FIXMEIDONTKNOWWHICHCODECTOUSE = keys.MakeSQLCodec(roachpb.SystemTenantID)
+
 	// Check to see if it's a table. If so, inherit from the database.
 	// For all other cases, inherit from the default.
-	descVal := cfg.GetValue(catalogkeys.MakeDescMetadataKey(keys.TODOSQLCodec, descpb.ID(id)))
+	descVal := cfg.GetValue(catalogkeys.MakeDescMetadataKey(FIXMEIDONTKNOWWHICHCODECTOUSE, descpb.ID(id)))
 	if descVal == nil {
 		// Couldn't find a descriptor. This is not expected to happen.
 		// Let's just look at the default zone config.

--- a/pkg/server/BUILD.bazel
+++ b/pkg/server/BUILD.bazel
@@ -501,6 +501,7 @@ go_test(
         "//pkg/testutils",
         "//pkg/testutils/datapathutils",
         "//pkg/testutils/diagutils",
+        "//pkg/testutils/keysutils",
         "//pkg/testutils/serverutils",
         "//pkg/testutils/skip",
         "//pkg/testutils/sqlutils",

--- a/pkg/server/decommission_test.go
+++ b/pkg/server/decommission_test.go
@@ -15,13 +15,13 @@ import (
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
-	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/allocator"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/allocator/allocatorimpl"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/security/username"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/keysutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
@@ -129,8 +129,8 @@ func TestDecommissionPreCheckEvaluation(t *testing.T) {
 	require.NoError(t, err)
 	tblBID, err := firstSvr.admin.queryTableID(ctx, username.RootUserName(), "test", "tblB")
 	require.NoError(t, err)
-	startKeyTblA := keys.TODOSQLCodec.TablePrefix(uint32(tblAID))
-	startKeyTblB := keys.TODOSQLCodec.TablePrefix(uint32(tblBID))
+	startKeyTblA := keysutils.TestingSQLCodec.TablePrefix(uint32(tblAID))
+	startKeyTblB := keysutils.TestingSQLCodec.TablePrefix(uint32(tblBID))
 
 	// Split off ranges for tblA and tblB.
 	_, rDescA, err := firstSvr.SplitRange(startKeyTblA)
@@ -234,7 +234,7 @@ func TestDecommissionPreCheckOddToEven(t *testing.T) {
 	runQueries(alterQueries...)
 	tblAID, err := firstSvr.admin.queryTableID(ctx, username.RootUserName(), "test", "tblA")
 	require.NoError(t, err)
-	startKeyTblA := keys.TODOSQLCodec.TablePrefix(uint32(tblAID))
+	startKeyTblA := keysutils.TestingSQLCodec.TablePrefix(uint32(tblAID))
 
 	// Split off range for tblA.
 	_, rDescA, err := firstSvr.SplitRange(startKeyTblA)

--- a/pkg/sql/row/BUILD.bazel
+++ b/pkg/sql/row/BUILD.bazel
@@ -133,6 +133,7 @@ go_test(
         "//pkg/sql/sem/tree",
         "//pkg/storage",
         "//pkg/testutils",
+        "//pkg/testutils/keysutils",
         "//pkg/testutils/serverutils",
         "//pkg/testutils/sqlutils",
         "//pkg/util/encoding",

--- a/pkg/sql/row/expr_walker_test.go
+++ b/pkg/sql/row/expr_walker_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/isql"
 	"github.com/cockroachdb/cockroach/pkg/sql/row"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/eval"
+	"github.com/cockroachdb/cockroach/pkg/testutils/keysutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -201,7 +202,7 @@ func TestJobBackedSeqChunkProvider(t *testing.T) {
 			}
 
 			for id, val := range test.seqIDToExpectedVal {
-				seqDesc := createAndIncrementSeqDescriptor(ctx, t, id, keys.TODOSQLCodec,
+				seqDesc := createAndIncrementSeqDescriptor(ctx, t, id, keysutils.TestingSQLCodec,
 					test.incrementBy, test.seqIDToOpts[id], kvDB)
 				seqMetadata := &row.SequenceMetadata{
 					SeqDesc:         seqDesc,

--- a/pkg/testutils/keysutils/pretty_scanner.go
+++ b/pkg/testutils/keysutils/pretty_scanner.go
@@ -67,7 +67,7 @@ func parseTableKeysAsAscendingInts(
 	if !ok {
 		panic(fmt.Sprintf("unknown table: %s", tableName))
 	}
-	output := keys.TODOSQLCodec.TablePrefix(uint32(tableID))
+	output := TestingSQLCodec.TablePrefix(uint32(tableID))
 	if remainder == "" {
 		return "", output
 	}
@@ -167,3 +167,8 @@ func parseAscendingIntIndexKey(input string) (string, roachpb.Key) {
 	}
 	return remainder, key
 }
+
+// TestingSQLCodec is a SQL key codec. It is equivalent to keys.SystemSQLCodec, but
+// should be used when it is unclear which tenant should be referenced by the
+// surrounding context.
+var TestingSQLCodec = keys.MakeSQLCodec(roachpb.SystemTenantID)


### PR DESCRIPTION
The `TODOSQLCodec` was a bug waiting to happen.

The only reasonable remaining purpose is for use in tests. As such, this change moves its definition to a test-only package (we have a linter that verifies that `testutils` is not included in non-test code).

This change then identifies the one non-reasonable remaining purposes and identifies it properly as a bug linked to #48123.

Release note: None
Epic: None