### PR TITLE
ui: fix Node Map view loading for insecure clusters

### DIFF
--- a/pkg/ui/workspaces/db-console/ccl/src/views/clusterviz/containers/map/index.spec.tsx
+++ b/pkg/ui/workspaces/db-console/ccl/src/views/clusterviz/containers/map/index.spec.tsx
@@ -10,6 +10,7 @@ import React from "react";
 import { shallow } from "enzyme";
 import { createMemoryHistory, History } from "history";
 import { match as Match } from "react-router-dom";
+import { refreshCluster } from "src/redux/apiReducers";
 
 import { ClusterVisualization } from "./index";
 import { Breadcrumbs } from "./breadcrumbs";
@@ -40,6 +41,7 @@ describe("ClusterVisualization", () => {
           enterpriseEnabled={true}
           licenseDataExists={true}
           match={match}
+          refreshCluster={refreshCluster}
         />,
       );
       history.push("/overview/map");
@@ -57,6 +59,7 @@ describe("ClusterVisualization", () => {
           enterpriseEnabled={true}
           licenseDataExists={true}
           match={match}
+          refreshCluster={refreshCluster}
         />,
       );
 

--- a/pkg/ui/workspaces/db-console/ccl/src/views/clusterviz/containers/map/index.tsx
+++ b/pkg/ui/workspaces/db-console/ccl/src/views/clusterviz/containers/map/index.tsx
@@ -22,6 +22,7 @@ import { AdminUIState } from "src/redux/state";
 import { selectEnterpriseEnabled } from "src/redux/license";
 import { Dropdown } from "src/components/dropdown";
 import { parseSplatParams } from "src/util/parseSplatParams";
+import { refreshCluster } from "src/redux/apiReducers";
 
 const NodeCanvasContent = swapByLicense(
   NeedEnterpriseLicense,
@@ -32,6 +33,7 @@ interface ClusterVisualizationProps {
   licenseDataExists: boolean;
   enterpriseEnabled: boolean;
   clusterDataError: Error | null;
+  refreshCluster: typeof refreshCluster;
 }
 
 export class ClusterVisualization extends React.Component<
@@ -50,6 +52,14 @@ export class ClusterVisualization extends React.Component<
     const { match, location } = this.props;
     const splat = parseSplatParams(match, location);
     return parseLocalityRoute(splat);
+  }
+
+  componentDidMount() {
+    this.props.refreshCluster();
+  }
+
+  componentDidUpdate() {
+    this.props.refreshCluster();
   }
 
   render() {
@@ -106,4 +116,8 @@ function mapStateToProps(state: AdminUIState) {
   };
 }
 
-export default withRouter(connect(mapStateToProps)(ClusterVisualization));
+export default withRouter(
+  connect(mapStateToProps, {
+    refreshCluster,
+  })(ClusterVisualization),
+);


### PR DESCRIPTION
Node Map view on Cluster Overview page relies on `cluster` data that was fetched only from `Alerts` components when Db Console is loaded and Node Map view reused this data.
But recently, the logic of requesting `cluster` data for alerts has been changed (and this is ok) and in turn it affected Node Map view as far as it cannot get required data to render.

This change extends `ClusterVisualization` component (that renders Node Map view) to request `cluster` data when component is loaded or updated to ensure it doesn't rely on any component and self-contained.

Release note (ui change): fix issue to properly render placeholder on Node Map view for insecure clusters.

Resolves: #99714


Affected by change: https://github.com/cockroachdb/cockroach/commit/2f96eeb76e0a47f37b4ead260fc4dc0168c1e538#diff-df26ebfacd94f33f708d63db924dcf48fda69eb9a737159ee3aa739f27403c28L623-L625

