### PR TITLE
release-23.1: ui: update sort setting on search criteria

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/insights/schemaInsights/schemaInsightsView.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/schemaInsights/schemaInsightsView.tsx
@@ -136,7 +136,7 @@ export const SchemaInsightsView: React.FC<SchemaInsightsViewProps> = ({
     // redux changes and syncs the URL params with redux.
     syncHistory(
       {
-        ascending: sortSetting.ascending.toString(),
+        ascending: sortSetting.ascending?.toString(),
         columnTitle: sortSetting.columnTitle,
         ...getFullFiltersAsStringRecord(filters),
         [SCHEMA_INSIGHT_SEARCH_PARAM]: search,

--- a/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.fixture.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.fixture.ts
@@ -621,6 +621,7 @@ const statementsPagePropsFixture: StatementsPageProps = {
   onFilterChange: noop,
   onChangeLimit: noop,
   onChangeReqSort: noop,
+  onApplySearchCriteria: noop,
 };
 
 export const statementsPagePropsWithRequestError: StatementsPageProps = {

--- a/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.module.scss
@@ -56,6 +56,10 @@ cl-table-container {
   margin-bottom: 0px;
 }
 
+.margin-bottom {
+  margin-bottom: 10px;
+}
+
 .root {
   flex-grow: 0;
   width: 100%;

--- a/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.tsx
@@ -21,7 +21,7 @@ import {
   updateSortSettingQueryParamsOnTab,
 } from "src/sortedtable";
 import { Search } from "src/search";
-import { Pagination } from "src/pagination";
+import { Pagination, ResultsPerPageLabel } from "src/pagination";
 import {
   calculateActiveFilters,
   defaultFilters,
@@ -59,6 +59,7 @@ import {
   SqlStatsSortType,
   StatementsRequest,
   createCombinedStmtsRequest,
+  SqlStatsSortOptions,
 } from "src/api/statementsApi";
 import ClearStats from "../sqlActivity/clearStats";
 import LoadingError from "../sqlActivity/errorComponent";
@@ -83,8 +84,9 @@ import {
   STATS_LONG_LOADING_DURATION,
   stmtRequestSortOptions,
   getSortLabel,
+  getSortColumn,
+  getSubsetWarning,
 } from "src/util/sqlActivityConstants";
-import { Button } from "src/button";
 import { SearchCriteria } from "src/searchCriteria/searchCriteria";
 import timeScaleStyles from "../timeScaleDropdown/timeScale.module.scss";
 
@@ -125,6 +127,7 @@ export interface StatementsPageDispatchProps {
   onTimeScaleChange: (ts: TimeScale) => void;
   onChangeLimit: (limit: number) => void;
   onChangeReqSort: (sort: SqlStatsSortType) => void;
+  onApplySearchCriteria: (ts: TimeScale, limit: number, sort: string) => void;
 }
 export interface StatementsPageStateProps {
   statements: AggregateStatistics[];
@@ -275,6 +278,13 @@ export class StatementsPage extends React.Component<
     }
   };
 
+  isSortSettingSameAsReqSort = (): boolean => {
+    return (
+      getSortColumn(this.state.reqSortSetting) ==
+      this.props.sortSetting.columnTitle
+    );
+  };
+
   changeTimeScale = (ts: TimeScale): void => {
     this.setState(prevState => ({
       ...prevState,
@@ -283,10 +293,30 @@ export class StatementsPage extends React.Component<
   };
 
   updateRequestParams = (): void => {
-    this.props.onChangeLimit(this.state.limit);
-    this.props.onChangeReqSort(this.state.reqSortSetting);
-    this.props.onTimeScaleChange(this.state.timeScale);
+    if (this.props.limit !== this.state.limit) {
+      this.props.onChangeLimit(this.state.limit);
+    }
+
+    if (this.props.reqSortSetting !== this.state.reqSortSetting) {
+      this.props.onChangeReqSort(this.state.reqSortSetting);
+    }
+
+    if (this.props.timeScale !== this.state.timeScale) {
+      this.props.onTimeScaleChange(this.state.timeScale);
+    }
+    if (this.props.onApplySearchCriteria) {
+      this.props.onApplySearchCriteria(
+        this.state.timeScale,
+        this.state.limit,
+        getSortLabel(this.state.reqSortSetting),
+      );
+    }
     this.refreshStatements();
+    const ss: SortSetting = {
+      ascending: false,
+      columnTitle: getSortColumn(this.state.reqSortSetting),
+    };
+    this.changeSortSetting(ss);
   };
 
   resetPagination = (): void => {
@@ -478,6 +508,16 @@ export class StatementsPage extends React.Component<
     this.setState(prevState => ({ ...prevState, reqSortSetting: newSort }));
   };
 
+  hasReqSortOption = (): boolean => {
+    let found = false;
+    Object.values(SqlStatsSortOptions).forEach((option: SqlStatsSortType) => {
+      if (getSortColumn(option) == this.props.sortSetting.columnTitle) {
+        found = true;
+      }
+    });
+    return found;
+  };
+
   renderStatements = (): React.ReactElement => {
     const { pagination, filters, activeFilters } = this.state;
     const {
@@ -598,6 +638,12 @@ export class StatementsPage extends React.Component<
               <p className={timeScaleStylesCx("time-label")}>
                 Showing aggregated stats from{" "}
                 <span className={timeScaleStylesCx("bold")}>{period}</span>
+                {", "}
+                <ResultsPerPageLabel
+                  pagination={{ ...pagination, total: data.length }}
+                  pageName={"Statements"}
+                  search={search}
+                />
               </p>
             </PageConfigItem>
             {hasAdminRole && (
@@ -620,6 +666,19 @@ export class StatementsPage extends React.Component<
             onRemoveFilter={this.onSubmitFilters}
             onClearFilters={this.onClearFilters}
           />
+          {!this.isSortSettingSameAsReqSort() && (
+            <InlineAlert
+              intent="warning"
+              title={getSubsetWarning(
+                "statement",
+                this.props.limit,
+                sortSettingLabel,
+                this.hasReqSortOption(),
+                this.props.sortSetting.columnTitle as StatisticTableColumnKeys,
+              )}
+              className={cx("margin-bottom")}
+            />
+          )}
           <StatementsSortedTable
             className="statements-table"
             data={data}

--- a/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPageConnected.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPageConnected.tsx
@@ -258,6 +258,16 @@ export const ConnectedStatementsPage = withRouter(
           dispatch(updateStmtsPageLimitAction(limit)),
         onChangeReqSort: (sort: SqlStatsSortType) =>
           dispatch(updateStmsPageReqSortAction(sort)),
+        onApplySearchCriteria: (ts: TimeScale, limit: number, sort: string) =>
+          dispatch(
+            analyticsActions.track({
+              name: "Apply Search Criteria",
+              page: "Statements",
+              tsValue: ts.key,
+              limitValue: limit,
+              sortValue: sort,
+            }),
+          ),
       },
       activePageProps: mapDispatchToRecentStatementsPageProps(dispatch),
     }),

--- a/pkg/ui/workspaces/cluster-ui/src/store/analytics/analytics.reducer.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/store/analytics/analytics.reducer.ts
@@ -26,6 +26,14 @@ type Page =
   | "Workload Insights - Statement"
   | "Workload Insights - Transaction";
 
+type ApplySearchCriteriaEvent = {
+  name: "Apply Search Criteria";
+  page: Page;
+  tsValue: string;
+  limitValue: number;
+  sortValue: string;
+};
+
 type BackButtonClick = {
   name: "Back Clicked";
   page: Page;
@@ -102,6 +110,7 @@ type TimeScaleChangeEvent = {
 };
 
 type AnalyticsEvent =
+  | ApplySearchCriteriaEvent
   | BackButtonClick
   | ColumnsChangeEvent
   | FilterEvent

--- a/pkg/ui/workspaces/cluster-ui/src/transactionsPage/transactionsPage.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionsPage/transactionsPage.tsx
@@ -24,7 +24,7 @@ import {
   SortSetting,
   updateSortSettingQueryParamsOnTab,
 } from "../sortedtable";
-import { Pagination } from "../pagination";
+import { Pagination, ResultsPerPageLabel } from "../pagination";
 import { statisticsClasses } from "./transactionsPageClasses";
 import {
   aggregateAcrossNodeIDs,
@@ -54,6 +54,7 @@ import {
   SqlStatsSortType,
   createCombinedStmtsRequest,
   StatementsRequest,
+  SqlStatsSortOptions,
 } from "src/api/statementsApi";
 import ColumnsSelector from "../columnsSelector/columnsSelector";
 import { SelectOption } from "../multiSelectCheckbox/multiSelectCheckbox";
@@ -79,8 +80,9 @@ import {
   STATS_LONG_LOADING_DURATION,
   txnRequestSortOptions,
   getSortLabel,
+  getSortColumn,
+  getSubsetWarning,
 } from "src/util/sqlActivityConstants";
-import { Button } from "src/button";
 import { SearchCriteria } from "src/searchCriteria/searchCriteria";
 import timeScaleStyles from "../timeScaleDropdown/timeScale.module.scss";
 
@@ -131,6 +133,7 @@ export interface TransactionsPageDispatchProps {
     columnTitle: string,
     ascending: boolean,
   ) => void;
+  onApplySearchCriteria: (ts: TimeScale, limit: number, sort: string) => void;
 }
 
 export type TransactionsPageProps = TransactionsPageStateProps &
@@ -289,6 +292,13 @@ export class TransactionsPage extends React.Component<
     }
   };
 
+  isSortSettingSameAsReqSort = (): boolean => {
+    return (
+      getSortColumn(this.state.reqSortSetting) ==
+      this.props.sortSetting.columnTitle
+    );
+  };
+
   onChangePage = (current: number): void => {
     const { pagination } = this.state;
     this.setState({ pagination: { ...pagination, current } });
@@ -391,10 +401,41 @@ export class TransactionsPage extends React.Component<
   };
 
   updateRequestParams = (): void => {
-    this.props.onChangeLimit(this.state.limit);
-    this.props.onChangeReqSort(this.state.reqSortSetting);
-    this.props.onTimeScaleChange(this.state.timeScale);
+    if (this.props.limit !== this.state.limit) {
+      this.props.onChangeLimit(this.state.limit);
+    }
+
+    if (this.props.reqSortSetting !== this.state.reqSortSetting) {
+      this.props.onChangeReqSort(this.state.reqSortSetting);
+    }
+
+    if (this.props.timeScale !== this.state.timeScale) {
+      this.props.onTimeScaleChange(this.state.timeScale);
+    }
+
+    if (this.props.onApplySearchCriteria) {
+      this.props.onApplySearchCriteria(
+        this.state.timeScale,
+        this.state.limit,
+        getSortLabel(this.state.reqSortSetting),
+      );
+    }
     this.refreshData();
+    const ss: SortSetting = {
+      ascending: false,
+      columnTitle: getSortColumn(this.state.reqSortSetting),
+    };
+    this.onChangeSortSetting(ss);
+  };
+
+  hasReqSortOption = (): boolean => {
+    let found = false;
+    Object.values(SqlStatsSortOptions).forEach((option: SqlStatsSortType) => {
+      if (getSortColumn(option) == this.props.sortSetting.columnTitle) {
+        found = true;
+      }
+    });
+    return found;
   };
 
   renderTransactions(): React.ReactElement {
@@ -488,6 +529,7 @@ export class TransactionsPage extends React.Component<
 
     const period = timeScaleToString(this.props.timeScale);
     const sortSettingLabel = getSortLabel(this.props.reqSortSetting);
+
     return (
       <>
         <h5 className={`${commonStyles("base-heading")} ${cx("margin-top")}`}>
@@ -527,6 +569,15 @@ export class TransactionsPage extends React.Component<
               <p className={timeScaleStylesCx("time-label")}>
                 Showing aggregated stats from{" "}
                 <span className={timeScaleStylesCx("bold")}>{period}</span>
+                {", "}
+                <ResultsPerPageLabel
+                  pagination={{
+                    ...pagination,
+                    total: transactionsToDisplay.length,
+                  }}
+                  pageName={"Statements"}
+                  search={search}
+                />
               </p>
             </PageConfigItem>
             {hasAdminRole && (
@@ -549,6 +600,19 @@ export class TransactionsPage extends React.Component<
             onRemoveFilter={this.onSubmitFilters}
             onClearFilters={this.onClearFilters}
           />
+          {!this.isSortSettingSameAsReqSort() && (
+            <InlineAlert
+              intent="warning"
+              title={getSubsetWarning(
+                "transaction",
+                this.props.limit,
+                sortSettingLabel,
+                this.hasReqSortOption(),
+                this.props.sortSetting.columnTitle as StatisticTableColumnKeys,
+              )}
+              className={cx("margin-bottom")}
+            />
+          )}
           <TransactionsTable
             columns={displayColumns}
             transactions={transactionsToDisplay}

--- a/pkg/ui/workspaces/cluster-ui/src/transactionsPage/transactionsPageConnected.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionsPage/transactionsPageConnected.tsx
@@ -171,6 +171,16 @@ export const TransactionsPageConnected = withRouter(
           dispatch(updateTxnsPageLimitAction(limit)),
         onChangeReqSort: (sort: SqlStatsSortType) =>
           dispatch(updateTxnsPageReqSortAction(sort)),
+        onApplySearchCriteria: (ts: TimeScale, limit: number, sort: string) =>
+          dispatch(
+            analyticsActions.track({
+              name: "Apply Search Criteria",
+              page: "Transactions",
+              tsValue: ts.key,
+              limitValue: limit,
+              sortValue: sort,
+            }),
+          ),
       },
       activePageProps: mapDispatchToRecentTransactionsPageProps(dispatch),
     }),

--- a/pkg/ui/workspaces/cluster-ui/src/util/sqlActivityConstants.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/util/sqlActivityConstants.ts
@@ -10,6 +10,10 @@
 
 import { duration } from "moment";
 import { SqlStatsSortOptions, SqlStatsSortType } from "src/api/statementsApi";
+import {
+  getLabel,
+  StatisticTableColumnKeys,
+} from "../statsTableUtil/statsTableUtil";
 
 export const limitOptions = [
   { value: 25, label: "25" },
@@ -37,6 +41,25 @@ export function getSortLabel(sort: SqlStatsSortType): string {
   }
 }
 
+export function getSortColumn(sort: SqlStatsSortType): string {
+  switch (sort) {
+    case SqlStatsSortOptions.SERVICE_LAT:
+      return "time";
+    case SqlStatsSortOptions.EXECUTION_COUNT:
+      return "executionCount";
+    case SqlStatsSortOptions.CPU_TIME:
+      return "cpu";
+    case SqlStatsSortOptions.P99_STMTS_ONLY:
+      return "latencyP99";
+    case SqlStatsSortOptions.CONTENTION_TIME:
+      return "contention";
+    case SqlStatsSortOptions.PCT_RUNTIME:
+      return "workloadPct";
+    default:
+      return "";
+  }
+}
+
 export const stmtRequestSortOptions = Object.values(SqlStatsSortOptions)
   .map(sortVal => ({
     value: sortVal as SqlStatsSortType,
@@ -55,3 +78,18 @@ export const txnRequestSortOptions = stmtRequestSortOptions.filter(
 );
 
 export const STATS_LONG_LOADING_DURATION = duration(2, "s");
+
+export function getSubsetWarning(
+  type: "statement" | "transaction",
+  limit: number,
+  sortLabel: string,
+  showSuggestion: boolean,
+  columnTitle: StatisticTableColumnKeys,
+): string {
+  const warningSuggestion = showSuggestion
+    ? `Update the search criteria to see the ${type} fingerprints 
+    sorted on ${getLabel(columnTitle, type)}.`
+    : "";
+  return `You are viewing a subset (Top ${limit}) of fingerprints by ${sortLabel}.
+    ${warningSuggestion}`;
+}

--- a/pkg/ui/workspaces/db-console/src/redux/analyticsActions.ts
+++ b/pkg/ui/workspaces/db-console/src/redux/analyticsActions.ts
@@ -9,6 +9,7 @@
 // licenses/APL.txt.
 
 import { PayloadAction } from "src/interfaces/action";
+import { TimeScale } from "@cockroachlabs/cluster-ui";
 
 export const TRACK_STATEMENTS_SEARCH =
   "cockroachui/analytics/TRACK_STATEMENTS_SEARCH";
@@ -21,11 +22,19 @@ export const TRACK_CANCEL_DIAGNOSTIC_BUNDLE =
   "cockroachui/analytics/TRACK_CANCEL_DIAGNOSTIC_BUNDLE";
 export const TRACK_STATEMENT_DETAILS_SUBNAV_SELECTION =
   "cockroachui/analytics/TRACK_STATEMENT_DETAILS_SUBNAV_SELECTION";
+export const TRACK_APPLY_SEARCH_CRITERIA =
+  "cockroachui/analytics/TRACK_APPLY_SEARCH_CRITERIA";
 
 export interface TableSortActionPayload {
   tableName: string;
   columnName: string;
   ascending?: boolean;
+}
+
+export interface ApplySearchCriteriaPayload {
+  ts: TimeScale;
+  limit: number;
+  sort: string;
 }
 
 export function trackStatementsSearchAction(
@@ -85,5 +94,20 @@ export function trackStatementDetailsSubnavSelectionAction(
   return {
     type: TRACK_STATEMENT_DETAILS_SUBNAV_SELECTION,
     payload: tabName,
+  };
+}
+
+export function trackApplySearchCriteriaAction(
+  ts: TimeScale,
+  limit: number,
+  sort: string,
+): PayloadAction<ApplySearchCriteriaPayload> {
+  return {
+    type: TRACK_APPLY_SEARCH_CRITERIA,
+    payload: {
+      ts,
+      limit,
+      sort,
+    },
   };
 }

--- a/pkg/ui/workspaces/db-console/src/views/statements/statementsPage.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/statements/statementsPage.tsx
@@ -56,6 +56,7 @@ import {
   setGlobalTimeScaleAction,
 } from "src/redux/statements";
 import {
+  trackApplySearchCriteriaAction,
   trackCancelDiagnosticsBundleAction,
   trackDownloadDiagnosticsBundleAction,
   trackStatementsPaginationAction,
@@ -363,6 +364,7 @@ const fingerprintsPageActions = {
     ),
   onChangeLimit: (newLimit: number) => limitSetting.set(newLimit),
   onChangeReqSort: (sort: api.SqlStatsSortType) => reqSortSetting.set(sort),
+  onApplySearchCriteria: trackApplySearchCriteriaAction,
 };
 
 type StateProps = {

--- a/pkg/ui/workspaces/db-console/src/views/transactions/transactionsPage.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/transactions/transactionsPage.tsx
@@ -50,6 +50,7 @@ import {
   selectTxnsDataValid,
   selectTxnsDataInFlight,
 } from "src/selectors/executionFingerprintsSelectors";
+import { trackApplySearchCriteriaAction } from "src/redux/analyticsActions";
 
 // selectData returns the array of AggregateStatistics to show on the
 // TransactionsPage, based on if the appAttr route parameter is set.
@@ -142,6 +143,7 @@ const fingerprintsPageActions = {
   onSearchComplete: (query: string) => searchLocalSetting.set(query),
   onChangeLimit: (newLimit: number) => limitSetting.set(newLimit),
   onChangeReqSort: (sort: api.SqlStatsSortType) => reqSortSetting.set(sort),
+  onApplySearchCriteria: trackApplySearchCriteriaAction,
 };
 
 type StateProps = {


### PR DESCRIPTION
Backport 1/1 commits from #99541.

/cc @cockroachdb/release

---

Fixes #99397

When a new search criteria is applied, the table on Statement and Transactions are sorted to match the value selected by the search criteria.
When a new column is selected on the table, a warning is displayed to let the users know they're looking into a subset od the data. If the new column selected is one of the options on the search criteria, we give a suggestion to update the search criteria with that value instead.

<img width="1229" alt="Screenshot 2023-03-24 at 8 27 52 PM" src="https://user-images.githubusercontent.com/1017486/227667529-14c9dc5c-dc00-4dd9-b12d-78058c381fc4.png">

https://www.loom.com/share/e123e4033d95434a8eef20c257c83bbd

This commit adds the counter per page on the Statement and Transaction tables.
<img width="705" alt="Screenshot 2023-03-24 at 8 28 01 PM" src="https://user-images.githubusercontent.com/1017486/227667540-bc7aae81-2121-46c1-ad01-94ceda34960b.png">


This commit also adds analytics to the apply button, sending the information about each criteria.

Release note (ui change): Add a warning when a user select a sorting column on Statement and Transaction tables that were not the original selected sorting on the search criteria.

---

Release justification: small change, big impact
