### PR TITLE
roachtest: increase timeout for tpcc/mixed-headroom

### DIFF
--- a/pkg/cmd/roachtest/tests/tpcc.go
+++ b/pkg/cmd/roachtest/tests/tpcc.go
@@ -522,8 +522,9 @@ func registerTPCC(r registry.Registry) {
 		// node and on a mixed version cluster which runs its long-running
 		// migrations while TPCC runs. It simulates a real production
 		// deployment in the middle of the migration into a new cluster version.
-		Name:  "tpcc/mixed-headroom/" + mixedHeadroomSpec.String(),
-		Owner: registry.OwnerTestEng,
+		Name:    "tpcc/mixed-headroom/" + mixedHeadroomSpec.String(),
+		Timeout: 5 * time.Hour,
+		Owner:   registry.OwnerTestEng,
 		// TODO(tbg): add release_qualification tag once we know the test isn't
 		// buggy.
 		Tags:              []string{`default`},


### PR DESCRIPTION
This test runs a lot of expensive steps (importing bank fixtures, running tpcc for 100 minutes), so it's not guaranteed that it will finish within the default 3h.

Fixes #99737.

Epic: none

Release note: None