### PR TITLE
release-23.1: sql: add explicit column family assignments to persisted stats upgrades

### DIFF
--- a/pkg/upgrade/upgrades/create_computed_indexes_sql_statistics.go
+++ b/pkg/upgrade/upgrades/create_computed_indexes_sql_statistics.go
@@ -21,7 +21,7 @@ import (
 
 const addExecutionCountComputedColStmtStats = `
 ALTER TABLE system.statement_statistics
-ADD COLUMN IF NOT EXISTS "execution_count" INT8 
+ADD COLUMN IF NOT EXISTS "execution_count" INT8 FAMILY "primary" 
 AS ((statistics->'statistics'->'cnt')::INT8) STORED
 `
 
@@ -33,7 +33,7 @@ aggregated_ts, app_name, execution_count DESC) WHERE app_name NOT LIKE
 
 const addServiceLatencyComputedColStmtStats = `
 ALTER TABLE system.statement_statistics
-ADD COLUMN IF NOT EXISTS "service_latency" FLOAT 
+ADD COLUMN IF NOT EXISTS "service_latency" FLOAT FAMILY "primary" 
 AS ((statistics->'statistics'->'svcLat'->'mean')::FLOAT) STORED
 `
 
@@ -45,7 +45,7 @@ aggregated_ts, app_name, service_latency DESC) WHERE app_name NOT LIKE
 
 const addCpuSqlNanosComputedColStmtStats = `
 ALTER TABLE system.statement_statistics
-ADD COLUMN IF NOT EXISTS "cpu_sql_nanos" FLOAT 
+ADD COLUMN IF NOT EXISTS "cpu_sql_nanos" FLOAT FAMILY "primary" 
 AS ((statistics->'execution_statistics'->'cpuSQLNanos'->'mean')::FLOAT) STORED
 `
 
@@ -57,7 +57,7 @@ aggregated_ts, app_name, cpu_sql_nanos DESC) WHERE app_name NOT LIKE
 
 const addContentionTimeComputedColStmtStats = `
 ALTER TABLE system.statement_statistics
-ADD COLUMN IF NOT EXISTS "contention_time" FLOAT 
+ADD COLUMN IF NOT EXISTS "contention_time" FLOAT FAMILY "primary" 
 AS ((statistics->'execution_statistics'->'contentionTime'->'mean')::FLOAT) STORED
 `
 
@@ -69,7 +69,7 @@ aggregated_ts, app_name, contention_time DESC) WHERE app_name NOT LIKE
 
 const addTotalEstimatedExecutionTimeComputedColStmtStats = `
 ALTER TABLE system.statement_statistics
-ADD COLUMN IF NOT EXISTS "total_estimated_execution_time" FLOAT 
+ADD COLUMN IF NOT EXISTS "total_estimated_execution_time" FLOAT FAMILY "primary" 
 AS ((statistics->'statistics'->>'cnt')::FLOAT * (statistics->'statistics'->'svcLat'->>'mean')::FLOAT) STORED
 `
 
@@ -81,7 +81,7 @@ aggregated_ts, app_name, total_estimated_execution_time DESC) WHERE app_name NOT
 
 const addP99LatencyComputedColStmtStats = `
 ALTER TABLE system.statement_statistics
-ADD COLUMN IF NOT EXISTS "p99_latency" FLOAT 
+ADD COLUMN IF NOT EXISTS "p99_latency" FLOAT FAMILY "primary" 
 AS ((statistics->'statistics'->'latencyInfo'->'p99')::FLOAT) STORED
 `
 
@@ -94,7 +94,7 @@ aggregated_ts, app_name, p99_latency DESC) WHERE app_name NOT LIKE
 // transaction_statistics
 const addExecutionCountComputedColTxnStats = `
 ALTER TABLE system.transaction_statistics
-ADD COLUMN IF NOT EXISTS "execution_count" INT8 
+ADD COLUMN IF NOT EXISTS "execution_count" INT8 FAMILY "primary"
 AS ((statistics->'statistics'->'cnt')::INT8) STORED
 `
 
@@ -106,7 +106,7 @@ aggregated_ts, app_name, execution_count DESC) WHERE app_name NOT LIKE
 
 const addServiceLatencyComputedColTxnStats = `
 ALTER TABLE system.transaction_statistics
-ADD COLUMN IF NOT EXISTS "service_latency" FLOAT 
+ADD COLUMN IF NOT EXISTS "service_latency" FLOAT FAMILY "primary" 
 AS ((statistics->'statistics'->'svcLat'->'mean')::FLOAT) STORED
 `
 
@@ -118,7 +118,7 @@ aggregated_ts, app_name, service_latency DESC) WHERE app_name NOT LIKE
 
 const addCpuSqlNanosComputedColTxnStats = `
 ALTER TABLE system.transaction_statistics
-ADD COLUMN IF NOT EXISTS "cpu_sql_nanos" FLOAT 
+ADD COLUMN IF NOT EXISTS "cpu_sql_nanos" FLOAT FAMILY "primary" 
 AS ((statistics->'execution_statistics'->'cpuSQLNanos'->'mean')::FLOAT) STORED
 `
 
@@ -130,7 +130,7 @@ aggregated_ts, app_name, cpu_sql_nanos DESC) WHERE app_name NOT LIKE
 
 const addContentionTimeComputedColTxnStats = `
 ALTER TABLE system.transaction_statistics
-ADD COLUMN IF NOT EXISTS "contention_time" FLOAT 
+ADD COLUMN IF NOT EXISTS "contention_time" FLOAT FAMILY "primary" 
 AS ((statistics->'execution_statistics'->'contentionTime'->'mean')::FLOAT) STORED
 `
 
@@ -141,7 +141,7 @@ aggregated_ts, app_name, contention_time DESC) WHERE app_name NOT LIKE
 `
 const addTotalEstimatedExecutionTimeComputedColTxnStats = `
 ALTER TABLE system.transaction_statistics
-ADD COLUMN IF NOT EXISTS "total_estimated_execution_time" FLOAT 
+ADD COLUMN IF NOT EXISTS "total_estimated_execution_time" FLOAT FAMILY "primary" 
 AS ((statistics->'statistics'->>'cnt')::FLOAT * (
 statistics->'statistics'->'svcLat'->>'mean')::FLOAT) STORED
 `
@@ -154,7 +154,7 @@ aggregated_ts, app_name, total_estimated_execution_time DESC) WHERE app_name NOT
 
 const addP99LatencyComputedColTxnStats = `
 ALTER TABLE system.transaction_statistics
-ADD COLUMN IF NOT EXISTS "p99_latency" FLOAT 
+ADD COLUMN IF NOT EXISTS "p99_latency" FLOAT FAMILY "primary" 
 AS ((statistics->'statistics'->'latencyInfo'->'p99')::FLOAT) STORED
 `
 

--- a/pkg/upgrade/upgrades/create_computed_indexes_sql_statistics_test.go
+++ b/pkg/upgrade/upgrades/create_computed_indexes_sql_statistics_test.go
@@ -64,6 +64,7 @@ func TestCreateComputedIndexesOnSystemSQLStatistics(t *testing.T) {
 			{Name: "total_estimated_execution_time_idx", ValidationFn: upgrades.HasIndex},
 			{Name: "p99_latency", ValidationFn: upgrades.HasColumn},
 			{Name: "p99_latency_idx", ValidationFn: upgrades.HasIndex},
+			{Name: "primary", ValidationFn: upgrades.OnlyHasColumnFamily},
 		}
 	)
 

--- a/pkg/upgrade/upgrades/helpers_test.go
+++ b/pkg/upgrade/upgrades/helpers_test.go
@@ -30,11 +30,12 @@ import (
 )
 
 var (
-	HasColumn         = hasColumn
-	HasIndex          = hasIndex
-	DoesNotHaveIndex  = doesNotHaveIndex
-	HasColumnFamily   = hasColumnFamily
-	CreateSystemTable = createSystemTable
+	HasColumn           = hasColumn
+	HasIndex            = hasIndex
+	DoesNotHaveIndex    = doesNotHaveIndex
+	HasColumnFamily     = hasColumnFamily
+	CreateSystemTable   = createSystemTable
+	OnlyHasColumnFamily = onlyHasColumnFamily
 )
 
 type Schema struct {


### PR DESCRIPTION
Backport 1/1 commits from #99674.

/cc @cockroachdb/release

---

Fixes #99260.

This commit adds explicit column family assignments to the computed column `ADD COLUMN` statements for
system.statement_statistics and system.transaction_statistics version upgrades.

Epic: none

Release note: None

Release justification: bug fix