### PR TITLE
kvserver: add metrics for Entries bytes read

### DIFF
--- a/pkg/kv/kvserver/logstore/logstore.go
+++ b/pkg/kv/kvserver/logstore/logstore.go
@@ -496,7 +496,7 @@ func LoadEntries(
 	eCache *raftentry.Cache,
 	sideloaded SideloadStorage,
 	lo, hi, maxBytes uint64,
-) (_ []raftpb.Entry, _cachedSize int, _loadedSize int, _ error) {
+) (_ []raftpb.Entry, _cachedSize uint64, _loadedSize uint64, _ error) {
 	if lo > hi {
 		return nil, 0, 0, errors.Errorf("lo:%d is greater than hi:%d", lo, hi)
 	}
@@ -512,7 +512,7 @@ func LoadEntries(
 	// Return results if the correct number of results came back or if
 	// we ran into the max bytes limit.
 	if uint64(len(ents)) == hi-lo || exceededMaxBytes {
-		return ents, int(cachedSize), 0, nil
+		return ents, cachedSize, 0, nil
 	}
 
 	combinedSize := cachedSize // size tracks total size of ents.
@@ -567,12 +567,12 @@ func LoadEntries(
 
 	// Did the correct number of results come back? If so, we're all good.
 	if uint64(len(ents)) == hi-lo {
-		return ents, int(cachedSize), int(combinedSize - cachedSize), nil
+		return ents, cachedSize, combinedSize - cachedSize, nil
 	}
 
 	// Did we hit the size limit? If so, return what we have.
 	if exceededMaxBytes {
-		return ents, int(cachedSize), int(combinedSize - cachedSize), nil
+		return ents, cachedSize, combinedSize - cachedSize, nil
 	}
 
 	// Did we get any results at all? Because something went wrong.

--- a/pkg/kv/kvserver/metrics.go
+++ b/pkg/kv/kvserver/metrics.go
@@ -1105,7 +1105,7 @@ of processing.
 		Help: `Counter of raftpb.Entry.Size() read from pebble for raft log entries.
 
 These are the bytes returned from the (raft.Storage).Entries method that were not
-returned via the raft entry cache. This metric plus the raft.storage.read_bytes
+returned via the raft entry cache. This metric plus the raft.entrycache.read_bytes
 metric represent the total bytes returned from the Entries method.
 
 Since pebble might serve these entries from the block cache, only a fraction of this

--- a/pkg/kv/kvserver/metrics.go
+++ b/pkg/kv/kvserver/metrics.go
@@ -1100,6 +1100,34 @@ of processing.
 		Measurement: "Elections called after timeout",
 		Unit:        metric.Unit_COUNT,
 	}
+	metaRaftStorageReadBytes = metric.Metadata{
+		Name: "raft.storage.read_bytes",
+		Help: `Counter of raftpb.Entry.Size() read from pebble for raft log entries.
+
+These are the bytes returned from the (raft.Storage).Entries method that were not
+returned via the raft entry cache. This metric plus the raft.storage.read_bytes
+metric represent the total bytes returned from the Entries method.
+
+Since pebble might serve these entries from the block cache, only a fraction of this
+throughput might manifest in disk metrics.
+
+Entries tracked in this metric incur an unmarshalling-related CPU and memory
+overhead that would not be incurred would the entries be served from the raft
+entry cache.
+
+The bytes returned here do not correspond 1:1 to bytes read from pebble. This
+metric measures the in-memory size of the raftpb.Entry, whereas we read its
+encoded representation from pebble. As there is no compression involved, these
+will generally be comparable.
+
+A common reason for elevated measurements on this metric is that a store is
+falling behind on raft log application. The raft entry cache generally tracks
+entries that were recently appended, so if log application falls behind the
+cache will already have moved on to newer entries.
+`,
+		Measurement: "Bytes",
+		Unit:        metric.Unit_BYTES,
+	}
 
 	// Raft message metrics.
 	metaRaftRcvdProp = metric.Metadata{
@@ -2079,6 +2107,7 @@ type StoreMetrics struct {
 	RaftApplyCommittedLatency metric.IHistogram
 	RaftSchedulerLatency      metric.IHistogram
 	RaftTimeoutCampaign       *metric.Counter
+	RaftStorageReadBytes      *metric.Counter
 
 	// Raft message metrics.
 	//
@@ -2710,7 +2739,8 @@ func newStoreMetrics(histogramWindow time.Duration) *StoreMetrics {
 			Duration: histogramWindow,
 			Buckets:  metric.IOLatencyBuckets,
 		}),
-		RaftTimeoutCampaign: metric.NewCounter(metaRaftTimeoutCampaign),
+		RaftTimeoutCampaign:  metric.NewCounter(metaRaftTimeoutCampaign),
+		RaftStorageReadBytes: metric.NewCounter(metaRaftStorageReadBytes),
 
 		// Raft message metrics.
 		RaftRcvdMessages: [maxRaftMsgType + 1]*metric.Counter{

--- a/pkg/kv/kvserver/raftentry/metrics.go
+++ b/pkg/kv/kvserver/raftentry/metrics.go
@@ -37,23 +37,31 @@ var (
 		Measurement: "Hits",
 		Unit:        metric.Unit_COUNT,
 	}
+	metaEntryCacheReadBytes = metric.Metadata{
+		Name:        "raft.entrycache.read_bytes",
+		Help:        "Counter of bytes in entries returned from the Raft entry cache",
+		Measurement: "Bytes",
+		Unit:        metric.Unit_BYTES,
+	}
 )
 
 // Metrics is the set of metrics for the raft entry cache.
 type Metrics struct {
 	// NB: the values in the gauges are updated asynchronously and may hold stale
 	// values in the face of concurrent updates.
-	Size     *metric.Gauge
-	Bytes    *metric.Gauge
-	Accesses *metric.Counter
-	Hits     *metric.Counter
+	Size      *metric.Gauge
+	Bytes     *metric.Gauge
+	Accesses  *metric.Counter
+	Hits      *metric.Counter
+	ReadBytes *metric.Counter
 }
 
 func makeMetrics() Metrics {
 	return Metrics{
-		Size:     metric.NewGauge(metaEntryCacheSize),
-		Bytes:    metric.NewGauge(metaEntryCacheBytes),
-		Accesses: metric.NewCounter(metaEntryCacheAccesses),
-		Hits:     metric.NewCounter(metaEntryCacheHits),
+		Size:      metric.NewGauge(metaEntryCacheSize),
+		Bytes:     metric.NewGauge(metaEntryCacheBytes),
+		Accesses:  metric.NewCounter(metaEntryCacheAccesses),
+		Hits:      metric.NewCounter(metaEntryCacheHits),
+		ReadBytes: metric.NewCounter(metaEntryCacheReadBytes),
 	}
 }

--- a/pkg/kv/kvserver/replica_raftstorage.go
+++ b/pkg/kv/kvserver/replica_raftstorage.go
@@ -84,8 +84,10 @@ func (r *replicaRaftStorage) Entries(lo, hi, maxBytes uint64) ([]raftpb.Entry, e
 	if r.raftMu.sideloaded == nil {
 		return nil, errors.New("sideloaded storage is uninitialized")
 	}
-	return logstore.LoadEntries(ctx, r.mu.stateLoader.StateLoader, r.store.TODOEngine(), r.RangeID,
+	ents, _, loadedSize, err := logstore.LoadEntries(ctx, r.mu.stateLoader.StateLoader, r.store.TODOEngine(), r.RangeID,
 		r.store.raftEntryCache, r.raftMu.sideloaded, lo, hi, maxBytes)
+	r.store.metrics.RaftStorageReadBytes.Inc(int64(loadedSize))
+	return ents, err
 }
 
 // raftEntriesLocked requires that r.mu is held for writing.

--- a/pkg/kv/kvserver/replica_sideload_test.go
+++ b/pkg/kv/kvserver/replica_sideload_test.go
@@ -183,12 +183,13 @@ func TestRaftSSTableSideloading(t *testing.T) {
 	hi := tc.repl.mu.lastIndexNotDurable + 1
 
 	tc.store.raftEntryCache.Clear(tc.repl.RangeID, hi)
-	ents, err := logstore.LoadEntries(
+	ents, cachedBytes, _, err := logstore.LoadEntries(
 		ctx, rsl, tc.store.TODOEngine(), tc.repl.RangeID, tc.store.raftEntryCache,
 		tc.repl.raftMu.sideloaded, lo, hi, math.MaxUint64,
 	)
 	require.NoError(t, err)
 	require.Len(t, ents, int(hi-lo))
+	require.Zero(t, cachedBytes)
 
 	// Check that the Raft entry cache was populated.
 	_, okLo := tc.store.raftEntryCache.Get(tc.repl.RangeID, lo)

--- a/pkg/ts/catalog/chart_catalog.go
+++ b/pkg/ts/catalog/chart_catalog.go
@@ -4060,6 +4060,17 @@ var charts = []sectionDescription{
 			},
 		},
 	},
+	{
+		Organization: [][]string{{ReplicationLayer, "Raft reads"}},
+		Charts: []chartDescription{
+			{
+				Title: "raft.Storage.Engine Read bytes",
+				Metrics: []string{
+					"raft.storage.read_bytes",
+				},
+			},
+		},
+	},
 }
 
 func jobTypeCharts(title string, varName string) chartDescription {

--- a/pkg/ts/catalog/chart_catalog.go
+++ b/pkg/ts/catalog/chart_catalog.go
@@ -4067,6 +4067,7 @@ var charts = []sectionDescription{
 				Title: "raft.Storage.Engine Read bytes",
 				Metrics: []string{
 					"raft.storage.read_bytes",
+					"raft.entrycache.read_bytes",
 				},
 			},
 		},


### PR DESCRIPTION
I used versions of these for https://github.com/cockroachdb/cockroach/pull/98576, and they are generally useful.

- kvserver: add raft.storage.read_bytes
- raftentry: add raft.entrycache.read_bytes

Part of #97917.

Release note: None
Epic: None
