### PR TITLE
cloud: add optional connection timeout retries

### DIFF
--- a/pkg/cloud/amazon/s3_storage.go
+++ b/pkg/cloud/amazon/s3_storage.go
@@ -741,7 +741,8 @@ func (s *s3Storage) ReadFileAt(
 ) (ioctx.ReadCloserCtx, int64, error) {
 	ctx, sp := tracing.ChildSpan(ctx, "s3.ReadFileAt")
 	defer sp.Finish()
-	sp.RecordStructured(&types.StringValue{Value: fmt.Sprintf("s3.ReadFileAt: %s", path.Join(s.prefix, basename))})
+	path := path.Join(s.prefix, basename)
+	sp.RecordStructured(&types.StringValue{Value: fmt.Sprintf("s3.ReadFileAt: %s", path)})
 
 	stream, err := s.openStreamAt(ctx, basename, offset)
 	if err != nil {
@@ -778,8 +779,8 @@ func (s *s3Storage) ReadFileAt(
 		}
 		return s.Body, nil
 	}
-	return cloud.NewResumingReader(ctx, opener, stream.Body, offset,
-		cloud.IsResumableHTTPError, s3ErrDelay), size, nil
+	return cloud.NewResumingReader(ctx, opener, stream.Body, offset, path,
+		cloud.ResumingReaderRetryOnErrFnForSettings(ctx, s.settings), s3ErrDelay), size, nil
 }
 
 func (s *s3Storage) List(ctx context.Context, prefix, delim string, fn cloud.ListingFn) error {

--- a/pkg/cloud/gcp/gcs_storage.go
+++ b/pkg/cloud/gcp/gcs_storage.go
@@ -295,7 +295,8 @@ func (g *gcsStorage) ReadFileAt(
 		}, // opener
 		nil, //  reader
 		offset,
-		cloud.IsResumableHTTPError,
+		object,
+		cloud.ResumingReaderRetryOnErrFnForSettings(ctx, g.settings),
 		nil, // errFn
 	)
 

--- a/pkg/cloud/httpsink/http_storage.go
+++ b/pkg/cloud/httpsink/http_storage.go
@@ -168,8 +168,8 @@ func (h *httpStorage) ReadFileAt(
 			}
 			return s.Body, err
 		}
-		return cloud.NewResumingReader(ctx, opener, stream.Body, offset,
-			cloud.IsResumableHTTPError, nil), size, nil
+		return cloud.NewResumingReader(ctx, opener, stream.Body, offset, basename,
+			cloud.ResumingReaderRetryOnErrFnForSettings(ctx, h.settings), nil), size, nil
 	}
 	return ioctx.ReadCloserAdapter(stream.Body), size, nil
 }

--- a/pkg/util/sysutil/sysutil.go
+++ b/pkg/util/sysutil/sysutil.go
@@ -70,3 +70,8 @@ func IsErrConnectionReset(err error) bool {
 func IsErrConnectionRefused(err error) bool {
 	return errors.Is(err, syscall.ECONNREFUSED)
 }
+
+// IsErrTimedOut returns true if an error is an ETIMEDOUT error.
+func IsErrTimedOut(err error) bool {
+	return errors.Is(err, syscall.ETIMEDOUT)
+}


### PR DESCRIPTION
This optionally adds connection timeout errors to the set of errors to retry in the resuming reader. Additionally, it adds the file name to error messages returned by the resuming reader.

We test for ETIMEDOUT. Linux returns ETIMEDOUT in cases where the remote end of a connection fails to acknowledge a configured number of TCP Keep-Alive messages.

This shouldn't catch timeouts that are the result of IO deadlines or context cancellations. But, we don't enable this retrying by default, to avoid changing any current behaviour.

Epic: none

Release note: None