### PR TITLE
spanconfig: do not fatal in NeedsSplit and ComputeSplitKey

### DIFF
--- a/pkg/config/system.go
+++ b/pkg/config/system.go
@@ -700,14 +700,15 @@ func (s *SystemConfig) tenantBoundarySplitKey(
 
 // NeedsSplit returns whether the range [startKey, endKey) needs a split due
 // to zone configs.
-func (s *SystemConfig) NeedsSplit(ctx context.Context, startKey, endKey roachpb.RKey) bool {
-	// TODO(arul): bubble up this error.
+func (s *SystemConfig) NeedsSplit(
+	ctx context.Context, startKey, endKey roachpb.RKey,
+) (bool, error) {
 	splits, err := s.ComputeSplitKey(ctx, startKey, endKey)
 	if err != nil {
-		log.FatalfDepth(ctx, 3, "unable to compute split key for needs split: %v", err)
+		return false, err
 	}
 
-	return len(splits) > 0
+	return len(splits) > 0, nil
 }
 
 // shouldSplitOnSystemTenantObject checks if the ID is eligible for a split at

--- a/pkg/config/system_test.go
+++ b/pkg/config/system_test.go
@@ -332,7 +332,8 @@ func TestComputeSplitKeySystemRanges(t *testing.T) {
 		Values: kvs,
 	}
 	for tcNum, tc := range testCases {
-		splitKey := cfg.ComputeSplitKey(context.Background(), tc.start, tc.end)
+		splitKey, err := cfg.ComputeSplitKey(context.Background(), tc.start, tc.end)
+		require.NoError(t, err)
 		expected := roachpb.RKey(tc.split)
 		if !splitKey.Equal(expected) {
 			t.Errorf("#%d: bad split:\ngot: %v\nexpected: %v", tcNum, splitKey, expected)
@@ -443,7 +444,8 @@ func TestComputeSplitKeyTableIDs(t *testing.T) {
 	cfg := config.NewSystemConfig(zonepb.DefaultZoneConfigRef())
 	for tcNum, tc := range testCases {
 		cfg.Values = tc.values
-		splitKey := cfg.ComputeSplitKey(context.Background(), tc.start, tc.end)
+		splitKey, err := cfg.ComputeSplitKey(context.Background(), tc.start, tc.end)
+		require.NoError(t, err)
 		if !splitKey.Equal(tc.split) {
 			t.Errorf("#%d: bad split:\ngot: %v\nexpected: %v", tcNum, splitKey, tc.split)
 		}
@@ -530,7 +532,8 @@ func TestComputeSplitKeyTenantBoundaries(t *testing.T) {
 	cfg := config.NewSystemConfig(zonepb.DefaultZoneConfigRef())
 	for tcNum, tc := range testCases {
 		cfg.Values = tc.values
-		splitKey := cfg.ComputeSplitKey(context.Background(), tc.start, tc.end)
+		splitKey, err := cfg.ComputeSplitKey(context.Background(), tc.start, tc.end)
+		require.NoError(t, err)
 		if !splitKey.Equal(tc.split) {
 			t.Errorf("#%d: bad split:\ngot: %v\nexpected: %v", tcNum, splitKey, tc.split)
 		}

--- a/pkg/kv/kvserver/client_spanconfigs_test.go
+++ b/pkg/kv/kvserver/client_spanconfigs_test.go
@@ -177,7 +177,7 @@ func (m *mockSpanConfigSubscriber) NeedsSplit(ctx context.Context, start, end ro
 
 func (m *mockSpanConfigSubscriber) ComputeSplitKey(
 	ctx context.Context, start, end roachpb.RKey,
-) roachpb.RKey {
+) (roachpb.RKey, error) {
 	return m.Store.ComputeSplitKey(ctx, start, end)
 }
 

--- a/pkg/kv/kvserver/client_spanconfigs_test.go
+++ b/pkg/kv/kvserver/client_spanconfigs_test.go
@@ -171,7 +171,9 @@ func newMockSpanConfigSubscriber(
 	}
 }
 
-func (m *mockSpanConfigSubscriber) NeedsSplit(ctx context.Context, start, end roachpb.RKey) bool {
+func (m *mockSpanConfigSubscriber) NeedsSplit(
+	ctx context.Context, start, end roachpb.RKey,
+) (bool, error) {
 	return m.Store.NeedsSplit(ctx, start, end)
 }
 

--- a/pkg/kv/kvserver/merge_queue.go
+++ b/pkg/kv/kvserver/merge_queue.go
@@ -147,7 +147,17 @@ func (mq *mergeQueue) shouldQueue(
 		return false, 0
 	}
 
-	if confReader.NeedsSplit(ctx, desc.StartKey, desc.EndKey.Next()) {
+	needsSplit, err := confReader.NeedsSplit(ctx, desc.StartKey, desc.EndKey.Next())
+	if err != nil {
+		log.Warningf(
+			ctx,
+			"could not compute if extending range would result in a split (err=%v); skipping merge for range %s",
+			err,
+			desc.RangeID,
+		)
+		return false, 0
+	}
+	if needsSplit {
 		// This range would need to be split if it extended just one key further.
 		// There is thus no possible right-hand neighbor that it could be merged
 		// with.

--- a/pkg/kv/kvserver/queue_test.go
+++ b/pkg/kv/kvserver/queue_test.go
@@ -712,11 +712,15 @@ func TestAcceptsUnsplitRanges(t *testing.T) {
 		return nil
 	})
 	neverSplitsDesc := neverSplits.Desc()
-	if cfg.NeedsSplit(ctx, neverSplitsDesc.StartKey, neverSplitsDesc.EndKey) {
+	needsSplit, err := cfg.NeedsSplit(ctx, neverSplitsDesc.StartKey, neverSplitsDesc.EndKey)
+	require.NoError(t, err)
+	if needsSplit {
 		t.Fatal("System config says range needs to be split")
 	}
 	willSplitDesc := willSplit.Desc()
-	if cfg.NeedsSplit(ctx, willSplitDesc.StartKey, willSplitDesc.EndKey) {
+	needsSplit, err = cfg.NeedsSplit(ctx, willSplitDesc.StartKey, willSplitDesc.EndKey)
+	require.NoError(t, err)
+	if needsSplit {
 		t.Fatal("System config says range needs to be split")
 	}
 
@@ -748,11 +752,15 @@ func TestAcceptsUnsplitRanges(t *testing.T) {
 
 	// Check our config.
 	neverSplitsDesc = neverSplits.Desc()
-	if cfg.NeedsSplit(ctx, neverSplitsDesc.StartKey, neverSplitsDesc.EndKey) {
+	needsSplit, err = cfg.NeedsSplit(ctx, neverSplitsDesc.StartKey, neverSplitsDesc.EndKey)
+	require.NoError(t, err)
+	if needsSplit {
 		t.Fatal("System config says range needs to be split")
 	}
 	willSplitDesc = willSplit.Desc()
-	if !cfg.NeedsSplit(ctx, willSplitDesc.StartKey, willSplitDesc.EndKey) {
+	needsSplit, err = cfg.NeedsSplit(ctx, willSplitDesc.StartKey, willSplitDesc.EndKey)
+	require.NoError(t, err)
+	if !needsSplit {
 		t.Fatal("System config says range does not need to be split")
 	}
 

--- a/pkg/kv/kvserver/split_queue.go
+++ b/pkg/kv/kvserver/split_queue.go
@@ -139,7 +139,12 @@ func shouldSplitRange(
 	shouldBackpressureWrites bool,
 	confReader spanconfig.StoreReader,
 ) (shouldQ bool, priority float64) {
-	if confReader.NeedsSplit(ctx, desc.StartKey, desc.EndKey) {
+	needsSplit, err := confReader.NeedsSplit(ctx, desc.StartKey, desc.EndKey)
+	if err != nil {
+		log.Warningf(ctx, "unable to compute NeedsSpilt (%v); skipping range %s", err, desc.RangeID)
+		return false, 0
+	}
+	if needsSplit {
 		// Set priority to 1 in the event the range is split by zone configs.
 		priority = 1
 		shouldQ = true

--- a/pkg/kv/kvserver/split_queue.go
+++ b/pkg/kv/kvserver/split_queue.go
@@ -236,7 +236,11 @@ func (sq *splitQueue) processAttempt(
 ) (processed bool, err error) {
 	desc := r.Desc()
 	// First handle the case of splitting due to span config maps.
-	if splitKey := confReader.ComputeSplitKey(ctx, desc.StartKey, desc.EndKey); splitKey != nil {
+	splitKey, err := confReader.ComputeSplitKey(ctx, desc.StartKey, desc.EndKey)
+	if err != nil {
+		return false, errors.Wrapf(err, "unable to compute split key")
+	}
+	if splitKey != nil {
 		if _, err := r.adminSplitWithDescriptor(
 			ctx,
 			kvpb.AdminSplitRequest{

--- a/pkg/kv/kvserver/store_test.go
+++ b/pkg/kv/kvserver/store_test.go
@@ -3411,7 +3411,9 @@ type mockSpanConfigReader struct {
 	overrides map[string]roachpb.SpanConfig
 }
 
-func (m *mockSpanConfigReader) NeedsSplit(ctx context.Context, start, end roachpb.RKey) bool {
+func (m *mockSpanConfigReader) NeedsSplit(
+	ctx context.Context, start, end roachpb.RKey,
+) (bool, error) {
 	panic("unimplemented")
 }
 

--- a/pkg/kv/kvserver/store_test.go
+++ b/pkg/kv/kvserver/store_test.go
@@ -3417,7 +3417,7 @@ func (m *mockSpanConfigReader) NeedsSplit(ctx context.Context, start, end roachp
 
 func (m *mockSpanConfigReader) ComputeSplitKey(
 	ctx context.Context, start, end roachpb.RKey,
-) roachpb.RKey {
+) (roachpb.RKey, error) {
 	panic("unimplemented")
 }
 

--- a/pkg/spanconfig/spanconfig.go
+++ b/pkg/spanconfig/spanconfig.go
@@ -274,7 +274,7 @@ type StoreWriter interface {
 // StoreReader is the read-only portion of the Store interface. It doubles as an
 // adaptor interface for config.SystemConfig.
 type StoreReader interface {
-	NeedsSplit(ctx context.Context, start, end roachpb.RKey) bool
+	NeedsSplit(ctx context.Context, start, end roachpb.RKey) (bool, error)
 	ComputeSplitKey(ctx context.Context, start, end roachpb.RKey) (roachpb.RKey, error)
 	GetSpanConfigForKey(ctx context.Context, key roachpb.RKey) (roachpb.SpanConfig, error)
 }

--- a/pkg/spanconfig/spanconfig.go
+++ b/pkg/spanconfig/spanconfig.go
@@ -275,7 +275,7 @@ type StoreWriter interface {
 // adaptor interface for config.SystemConfig.
 type StoreReader interface {
 	NeedsSplit(ctx context.Context, start, end roachpb.RKey) bool
-	ComputeSplitKey(ctx context.Context, start, end roachpb.RKey) roachpb.RKey
+	ComputeSplitKey(ctx context.Context, start, end roachpb.RKey) (roachpb.RKey, error)
 	GetSpanConfigForKey(ctx context.Context, key roachpb.RKey) (roachpb.SpanConfig, error)
 }
 

--- a/pkg/spanconfig/spanconfigkvsubscriber/datadriven_test.go
+++ b/pkg/spanconfig/spanconfigkvsubscriber/datadriven_test.go
@@ -284,7 +284,8 @@ func TestDataDriven(t *testing.T) {
 					d.ScanArgs(t, cmdArg.Key, &spanStr)
 					span := spanconfigtestutils.ParseSpan(t, spanStr)
 					start, end := roachpb.RKey(span.Key), roachpb.RKey(span.EndKey)
-					splitKey := kvSubscriber.ComputeSplitKey(ctx, start, end)
+					splitKey, err := kvSubscriber.ComputeSplitKey(ctx, start, end)
+					require.NoError(t, err)
 					return string(splitKey)
 
 				case "needs-split":

--- a/pkg/spanconfig/spanconfigkvsubscriber/datadriven_test.go
+++ b/pkg/spanconfig/spanconfigkvsubscriber/datadriven_test.go
@@ -293,7 +293,8 @@ func TestDataDriven(t *testing.T) {
 					d.ScanArgs(t, cmdArg.Key, &spanStr)
 					span := spanconfigtestutils.ParseSpan(t, spanStr)
 					start, end := roachpb.RKey(span.Key), roachpb.RKey(span.EndKey)
-					result := kvSubscriber.NeedsSplit(ctx, start, end)
+					result, err := kvSubscriber.NeedsSplit(ctx, start, end)
+					require.NoError(t, err)
 					return fmt.Sprintf("%t", result)
 
 				default:

--- a/pkg/spanconfig/spanconfigkvsubscriber/dummy.go
+++ b/pkg/spanconfig/spanconfigkvsubscriber/dummy.go
@@ -43,8 +43,8 @@ func (n *noopKVSubscriber) LastUpdated() hlc.Timestamp {
 }
 
 // NeedsSplit is part of the spanconfig.KVSubscriber interface.
-func (n *noopKVSubscriber) NeedsSplit(context.Context, roachpb.RKey, roachpb.RKey) bool {
-	return false
+func (n *noopKVSubscriber) NeedsSplit(context.Context, roachpb.RKey, roachpb.RKey) (bool, error) {
+	return false, nil
 }
 
 // ComputeSplitKey is part of the spanconfig.KVSubscriber interface.

--- a/pkg/spanconfig/spanconfigkvsubscriber/dummy.go
+++ b/pkg/spanconfig/spanconfigkvsubscriber/dummy.go
@@ -50,8 +50,8 @@ func (n *noopKVSubscriber) NeedsSplit(context.Context, roachpb.RKey, roachpb.RKe
 // ComputeSplitKey is part of the spanconfig.KVSubscriber interface.
 func (n *noopKVSubscriber) ComputeSplitKey(
 	context.Context, roachpb.RKey, roachpb.RKey,
-) roachpb.RKey {
-	return roachpb.RKey{}
+) (roachpb.RKey, error) {
+	return roachpb.RKey{}, nil
 }
 
 // GetSpanConfigForKey is part of the spanconfig.KVSubscriber interface.

--- a/pkg/spanconfig/spanconfigkvsubscriber/kvsubscriber.go
+++ b/pkg/spanconfig/spanconfigkvsubscriber/kvsubscriber.go
@@ -339,7 +339,9 @@ func (s *KVSubscriber) NeedsSplit(ctx context.Context, start, end roachpb.RKey) 
 }
 
 // ComputeSplitKey is part of the spanconfig.KVSubscriber interface.
-func (s *KVSubscriber) ComputeSplitKey(ctx context.Context, start, end roachpb.RKey) roachpb.RKey {
+func (s *KVSubscriber) ComputeSplitKey(
+	ctx context.Context, start, end roachpb.RKey,
+) (roachpb.RKey, error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 

--- a/pkg/spanconfig/spanconfigkvsubscriber/kvsubscriber.go
+++ b/pkg/spanconfig/spanconfigkvsubscriber/kvsubscriber.go
@@ -331,7 +331,7 @@ func (s *KVSubscriber) LastUpdated() hlc.Timestamp {
 }
 
 // NeedsSplit is part of the spanconfig.KVSubscriber interface.
-func (s *KVSubscriber) NeedsSplit(ctx context.Context, start, end roachpb.RKey) bool {
+func (s *KVSubscriber) NeedsSplit(ctx context.Context, start, end roachpb.RKey) (bool, error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 

--- a/pkg/spanconfig/spanconfigkvsubscriber/kvsubscriber_test.go
+++ b/pkg/spanconfig/spanconfigkvsubscriber/kvsubscriber_test.go
@@ -176,7 +176,9 @@ func (m *manualStore) NeedsSplit(context.Context, roachpb.RKey, roachpb.RKey) bo
 }
 
 // ComputeSplitKey implements the spanconfig.Store interface.
-func (m *manualStore) ComputeSplitKey(context.Context, roachpb.RKey, roachpb.RKey) roachpb.RKey {
+func (m *manualStore) ComputeSplitKey(
+	context.Context, roachpb.RKey, roachpb.RKey,
+) (roachpb.RKey, error) {
 	panic("unimplemented")
 }
 

--- a/pkg/spanconfig/spanconfigkvsubscriber/kvsubscriber_test.go
+++ b/pkg/spanconfig/spanconfigkvsubscriber/kvsubscriber_test.go
@@ -171,7 +171,7 @@ func (m *manualStore) Apply(
 }
 
 // NeedsSplit implements the spanconfig.Store interface.
-func (m *manualStore) NeedsSplit(context.Context, roachpb.RKey, roachpb.RKey) bool {
+func (m *manualStore) NeedsSplit(context.Context, roachpb.RKey, roachpb.RKey) (bool, error) {
 	panic("unimplemented")
 }
 

--- a/pkg/spanconfig/spanconfigptsreader/adapter_test.go
+++ b/pkg/spanconfig/spanconfigptsreader/adapter_test.go
@@ -115,7 +115,7 @@ func (m *manualSubscriber) Start(context.Context, *stop.Stopper) error {
 	panic("unimplemented")
 }
 
-func (m *manualSubscriber) NeedsSplit(ctx context.Context, start, end roachpb.RKey) bool {
+func (m *manualSubscriber) NeedsSplit(ctx context.Context, start, end roachpb.RKey) (bool, error) {
 	panic("unimplemented")
 }
 

--- a/pkg/spanconfig/spanconfigptsreader/adapter_test.go
+++ b/pkg/spanconfig/spanconfigptsreader/adapter_test.go
@@ -121,7 +121,7 @@ func (m *manualSubscriber) NeedsSplit(ctx context.Context, start, end roachpb.RK
 
 func (m *manualSubscriber) ComputeSplitKey(
 	context.Context, roachpb.RKey, roachpb.RKey,
-) roachpb.RKey {
+) (roachpb.RKey, error) {
 	panic("unimplemented")
 }
 

--- a/pkg/spanconfig/spanconfigreporter/datadriven_test.go
+++ b/pkg/spanconfig/spanconfigreporter/datadriven_test.go
@@ -274,7 +274,7 @@ func (s *mockCluster) Scan(
 }
 
 // NeedsSplit implements spanconfig.StoreReader.
-func (s *mockCluster) NeedsSplit(ctx context.Context, start, end roachpb.RKey) bool {
+func (s *mockCluster) NeedsSplit(ctx context.Context, start, end roachpb.RKey) (bool, error) {
 	return s.store.NeedsSplit(ctx, start, end)
 }
 

--- a/pkg/spanconfig/spanconfigreporter/datadriven_test.go
+++ b/pkg/spanconfig/spanconfigreporter/datadriven_test.go
@@ -279,7 +279,9 @@ func (s *mockCluster) NeedsSplit(ctx context.Context, start, end roachpb.RKey) b
 }
 
 // ComputeSplitKey implements spanconfig.StoreReader.
-func (s *mockCluster) ComputeSplitKey(ctx context.Context, start, end roachpb.RKey) roachpb.RKey {
+func (s *mockCluster) ComputeSplitKey(
+	ctx context.Context, start, end roachpb.RKey,
+) (roachpb.RKey, error) {
 	return s.store.ComputeSplitKey(ctx, start, end)
 }
 

--- a/pkg/spanconfig/spanconfigstore/store.go
+++ b/pkg/spanconfig/spanconfigstore/store.go
@@ -96,14 +96,13 @@ func New(
 }
 
 // NeedsSplit is part of the spanconfig.StoreReader interface.
-func (s *Store) NeedsSplit(ctx context.Context, start, end roachpb.RKey) bool {
-	// TODO(arul): bubble up this error.
+func (s *Store) NeedsSplit(ctx context.Context, start, end roachpb.RKey) (bool, error) {
 	splits, err := s.ComputeSplitKey(ctx, start, end)
 	if err != nil {
-		log.FatalfDepth(ctx, 3, "unable to compute split key for needs split: %v", err)
+		return false, err
 	}
 
-	return len(splits) > 0
+	return len(splits) > 0, nil
 }
 
 // ComputeSplitKey is part of the spanconfig.StoreReader interface.

--- a/pkg/spanconfig/spanconfigstore/store_test.go
+++ b/pkg/spanconfig/spanconfigstore/store_test.go
@@ -162,7 +162,8 @@ func TestDataDriven(t *testing.T) {
 				d.ScanArgs(t, "span", &spanStr)
 				span := spanconfigtestutils.ParseSpan(t, spanStr)
 				start, end := roachpb.RKey(span.Key), roachpb.RKey(span.EndKey)
-				splitKey := store.ComputeSplitKey(ctx, start, end)
+				splitKey, err := store.ComputeSplitKey(ctx, start, end)
+				require.NoError(t, err)
 				if splitKey == nil {
 					return "n/a"
 				}
@@ -320,7 +321,8 @@ func BenchmarkStoreComputeSplitKey(b *testing.B) {
 
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
-				_ = store.ComputeSplitKey(ctx, roachpb.RKey(query.Key), roachpb.RKey(query.EndKey))
+				_, err := store.ComputeSplitKey(ctx, roachpb.RKey(query.Key), roachpb.RKey(query.EndKey))
+				require.NoError(b, err)
 			}
 		})
 	}

--- a/pkg/spanconfig/spanconfigstore/store_test.go
+++ b/pkg/spanconfig/spanconfigstore/store_test.go
@@ -155,7 +155,8 @@ func TestDataDriven(t *testing.T) {
 				d.ScanArgs(t, "span", &spanStr)
 				span := spanconfigtestutils.ParseSpan(t, spanStr)
 				start, end := roachpb.RKey(span.Key), roachpb.RKey(span.EndKey)
-				result := store.NeedsSplit(ctx, start, end)
+				result, err := store.NeedsSplit(ctx, start, end)
+				require.NoError(t, err)
 				return fmt.Sprintf("%t", result)
 
 			case "compute-split":


### PR DESCRIPTION
See individual commits for details. 

Fixes #97336.