### PR TITLE
schemachanger: Annotate all tables if ALTER TABLE IF EXISTS on non-existent table

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/alter_table
+++ b/pkg/sql/logictest/testdata/logic_test/alter_table
@@ -3184,3 +3184,13 @@ INSERT INTO t_98269 VALUES (0);
 
 statement error pgcode 0A000 .* cluster_logical_timestamp\(\): nil txn in cluster context
 ALTER TABLE t_98269 ADD COLUMN j DECIMAL NOT NULL DEFAULT cluster_logical_timestamp();
+
+# In #99185, we saw test failures that result from adding a foreign key
+# constraint to a non-existent table with IF EXISTS because we require all tables
+# in the stmt should be marked as non-existent or fully resolved. We didn't do
+# anything to the referenced table name, so the validation logic complained that
+# referenced table name is not fully resolved nor marked as non-existent.
+subtest alter_non_existent_table_with_if_exists
+
+statement ok
+ALTER TABLE IF EXISTS t_non_existent_99185 ADD FOREIGN KEY (i) REFERENCES t_other_99185 (i);

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_table.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_table.go
@@ -146,7 +146,12 @@ func AlterTable(b BuildCtx, n *tree.AlterTable) {
 	})
 	_, target, tbl := scpb.FindTable(elts)
 	if tbl == nil {
-		b.MarkNameAsNonExistent(&tn)
+		// Mark all table names (`tn` and others) in this ALTER TABLE stmt as non-existent.
+		tree.NewFmtCtx(tree.FmtSimple, tree.FmtReformatTableNames(func(
+			ctx *tree.FmtCtx, name *tree.TableName,
+		) {
+			b.MarkNameAsNonExistent(name)
+		})).FormatNode(n)
 		return
 	}
 	if target != scpb.ToPublic {

--- a/pkg/sql/sem/tree/format.go
+++ b/pkg/sql/sem/tree/format.go
@@ -306,7 +306,7 @@ func FmtPlaceholderFormat(placeholderFn func(_ *FmtCtx, _ *Placeholder)) FmtCtxO
 	}
 }
 
-// FmtReformatTableNames modifies FmtCtx to to substitute the printing of table
+// FmtReformatTableNames modifies FmtCtx to substitute the printing of table
 // naFmtParsable using the provided function.
 func FmtReformatTableNames(tableNameFmt func(*FmtCtx, *TableName)) FmtCtxOption {
 	return func(ctx *FmtCtx) {


### PR DESCRIPTION
Previously, if table `t` does not exist, `ALTER TABLE IF EXISTS t` will only mark `t` as non-existent. This is inadequate because for stmt like `ALTER TABLE IF EXISTS t ADD FOREIGN KEY REFERENCES t_other` we will not touch `t_other` and the validation logic will later complain that `t_other` is not fully resolved nor marked as non-existent. This commit fixes it by marking all tables in this ALTER TABLE stmt as non-existent if the `t` is non-existent, so we can pass the validation.

Fixes issues discovered in #99185
Epic: None