### PR TITLE
schemachanger: ALTER PRIMARY KEY when a unique indexes on old PK exists

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/alter_primary_key
+++ b/pkg/sql/logictest/testdata/logic_test/alter_primary_key
@@ -1881,3 +1881,26 @@ t_96730  CREATE TABLE public.t_96730 (
            CONSTRAINT t_96730_pkey PRIMARY KEY (j ASC, k ASC) USING HASH WITH (bucket_count=16),
            UNIQUE INDEX t_96730_i_key (i ASC)
          )
+
+# If we had a partial unique index on the old primary key columns, and after a
+# ALTER PRIMARY KEY, we will create a unique secondary index on the old primary
+# key columns. This subtest ensures that such a partial unique index is NOT a
+# good candidate and a new, non-partial, unique secondary will be created.
+subtest 99303
+
+statement ok
+CREATE TABLE t_99303 (i INT NOT NULL PRIMARY KEY, j INT NOT NULL, UNIQUE INDEX (i) WHERE (i > 0), FAMILY "primary" (i, j));
+
+statement ok
+ALTER TABLE t_99303 ALTER PRIMARY KEY USING COLUMNS (j);
+
+query TT
+SHOW CREATE t_99303
+----
+t_99303  CREATE TABLE public.t_99303 (
+           i INT8 NOT NULL,
+           j INT8 NOT NULL,
+           CONSTRAINT t_99303_pkey PRIMARY KEY (j ASC),
+           UNIQUE INDEX t_99303_i_key1 (i ASC),
+           UNIQUE INDEX t_99303_i_key (i ASC) WHERE i > 0:::INT8
+         )


### PR DESCRIPTION
It's a CRDB feature to create a unique secondary index on the old PK columns for ALTER PRIMARY KEY. There are certain situations where we don't do so, one of which is when there is already a unique secondary index on the old PK columns. However, there exists a bug where if the existing unique secondary index is partial, we don't create a new one. This is inadquate because we do need to create a new, non-partial, unique secondary index on the old PK columns. This PR fixes this.

Fixes #99303
Epic: None