### PR TITLE
release-22.2: sql: add version gate for ALTER DEFAULT PRIVILEGES ... ON FUNCTIONS

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/alter_default_privileges_for_all_roles
+++ b/pkg/sql/logictest/testdata/logic_test/alter_default_privileges_for_all_roles
@@ -1,3 +1,5 @@
+# LogicTest: default-configs local-mixed-22.1-22.2
+
 statement ok
 ALTER DEFAULT PRIVILEGES FOR ALL ROLES GRANT SELECT ON TABLES TO testuser
 
@@ -59,8 +61,16 @@ test           public       t4          admin     ALL             true
 test           public       t4          root      ALL             true
 test           public       t4          testuser  CREATE          false
 
+skipif config local-mixed-22.1-22.2
 statement ok
 CREATE USER testuser2
+
+# We need this hack for local-mixed-22.1-22.2, since the test is using the 22.2
+# system schema, even though the bootstrap version is 22.1. This limitation is
+# fixed in the 23.1 branch.
+onlyif config local-mixed-22.1-22.2
+statement ok
+INSERT INTO system.users VALUES ('testuser2', '', false, 101)
 
 statement ok
 ALTER DEFAULT PRIVILEGES FOR ALL ROLES GRANT CREATE ON TABLES TO testuser, testuser2
@@ -160,3 +170,7 @@ test           public       typ        public     USAGE           false
 test           public       typ        root       ALL             true
 test           public       typ        testuser   ALL             false
 test           public       typ        testuser2  ALL             false
+
+onlyif config local-mixed-22.1-22.2
+statement error cannot alter default privileges for functions until cluster is upgraded to v22.2
+ALTER DEFAULT PRIVILEGES FOR ALL ROLES GRANT EXECUTE ON FUNCTIONS TO testuser WITH GRANT OPTION

--- a/pkg/sql/logictest/testdata/logic_test/alter_default_privileges_in_schema
+++ b/pkg/sql/logictest/testdata/logic_test/alter_default_privileges_in_schema
@@ -1,3 +1,5 @@
+# LogicTest: default-configs local-mixed-22.1-22.2
+
 # Test cases for defining default privileges on the schema.
 
 statement error pq: cannot use IN SCHEMA clause when using GRANT/REVOKE ON SCHEMAS
@@ -6,8 +8,16 @@ ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT USAGE ON SCHEMAS TO root
 statement error pq: crdb_internal is not a physical schema
 ALTER DEFAULT PRIVILEGES IN SCHEMA crdb_internal GRANT SELECT ON TABLES TO root
 
+skipif config local-mixed-22.1-22.2
 statement ok
 CREATE USER testuser2
+
+# We need this hack for local-mixed-22.1-22.2, since the test is using the 22.2
+# system schema, even though the bootstrap version is 22.1. This limitation is
+# fixed in the 23.1 branch.
+onlyif config local-mixed-22.1-22.2
+statement ok
+INSERT INTO system.users VALUES ('testuser2', '', false, 101)
 
 statement ok
 GRANT CREATE ON DATABASE test TO testuser
@@ -286,3 +296,7 @@ query TBTTTB colnames
 SHOW DEFAULT PRIVILEGES IN SCHEMA "'; drop database test; SELECT '";
 ----
 role  for_all_roles  object_type  grantee  privilege_type  is_grantable
+
+onlyif config local-mixed-22.1-22.2
+statement error cannot alter default privileges for functions until cluster is upgraded to v22.2
+ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT EXECUTE ON FUNCTIONS TO testuser

--- a/pkg/sql/logictest/tests/local-mixed-22.1-22.2/BUILD.bazel
+++ b/pkg/sql/logictest/tests/local-mixed-22.1-22.2/BUILD.bazel
@@ -10,7 +10,7 @@ go_test(
         "//c-deps:libgeos",  # keep
         "//pkg/sql/logictest:testdata",  # keep
     ],
-    shard_count = 11,
+    shard_count = 13,
     tags = ["cpu:1"],
     deps = [
         "//pkg/build/bazel",

--- a/pkg/sql/logictest/tests/local-mixed-22.1-22.2/generated_test.go
+++ b/pkg/sql/logictest/tests/local-mixed-22.1-22.2/generated_test.go
@@ -72,6 +72,20 @@ func TestLogic_tmp(t *testing.T) {
 	logictest.RunLogicTests(t, logictest.TestServerArgs{}, configIdx, glob)
 }
 
+func TestLogic_alter_default_privileges_for_all_roles(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "alter_default_privileges_for_all_roles")
+}
+
+func TestLogic_alter_default_privileges_in_schema(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "alter_default_privileges_in_schema")
+}
+
 func TestLogic_alter_table(
 	t *testing.T,
 ) {


### PR DESCRIPTION
fixes https://github.com/cockroachdb/cockroach/issues/99728
Release justification: critical bug fix

Release note (bug fix): The `ALTER DEFAULT PRIVILEGES ... ON FUNCTIONS ...` command is no longer allowed unless all nodes are running on v22.2 and the upgrade is finalized. This prevents a bug where executing this command in a mixed version cluster could cause nodes still running on v22.1 to crash.