### PR TITLE
sql: add "local proposal" as always optional span in a test

### DIFF
--- a/pkg/sql/trace_test.go
+++ b/pkg/sql/trace_test.go
@@ -50,6 +50,7 @@ func TestTrace(t *testing.T) {
 		"outbox",
 		"request range lease",
 		"range lookup",
+		"local proposal",
 	}
 
 	testData := []struct {


### PR DESCRIPTION
It seems like this `local proposal` operation could occur at any point, including while the tracing is enabled in the test, so we should just ignore this span.

Fixes: #99834.

Release note: None