### PR TITLE
copy: enable copy_from_retries_enabled by default

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/information_schema
+++ b/pkg/sql/logictest/testdata/logic_test/information_schema
@@ -5187,7 +5187,7 @@ check_function_bodies                                 on
 client_encoding                                       UTF8
 client_min_messages                                   notice
 copy_from_atomic_enabled                              on
-copy_from_retries_enabled                             off
+copy_from_retries_enabled                             on
 cost_scans_with_default_col_size                      off
 database                                              test
 datestyle                                             ISO, MDY

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -2685,7 +2685,7 @@ check_function_bodies                                 on                  NULL  
 client_encoding                                       UTF8                NULL      NULL        NULL        string
 client_min_messages                                   notice              NULL      NULL        NULL        string
 copy_from_atomic_enabled                              on                  NULL      NULL        NULL        string
-copy_from_retries_enabled                             off                 NULL      NULL        NULL        string
+copy_from_retries_enabled                             on                  NULL      NULL        NULL        string
 cost_scans_with_default_col_size                      off                 NULL      NULL        NULL        string
 database                                              test                NULL      NULL        NULL        string
 datestyle                                             ISO, MDY            NULL      NULL        NULL        string
@@ -2838,7 +2838,7 @@ check_function_bodies                                 on                  NULL  
 client_encoding                                       UTF8                NULL  user     NULL      UTF8                UTF8
 client_min_messages                                   notice              NULL  user     NULL      notice              notice
 copy_from_atomic_enabled                              on                  NULL  user     NULL      on                  on
-copy_from_retries_enabled                             off                 NULL  user     NULL      off                 off
+copy_from_retries_enabled                             on                  NULL  user     NULL      on                  on
 cost_scans_with_default_col_size                      off                 NULL  user     NULL      off                 off
 database                                              test                NULL  user     NULL      ·                   test
 datestyle                                             ISO, MDY            NULL  user     NULL      ISO, MDY            ISO, MDY

--- a/pkg/sql/logictest/testdata/logic_test/show_source
+++ b/pkg/sql/logictest/testdata/logic_test/show_source
@@ -37,7 +37,7 @@ check_function_bodies                                 on
 client_encoding                                       UTF8
 client_min_messages                                   notice
 copy_from_atomic_enabled                              on
-copy_from_retries_enabled                             off
+copy_from_retries_enabled                             on
 cost_scans_with_default_col_size                      off
 database                                              test
 datestyle                                             ISO, MDY

--- a/pkg/sql/vars.go
+++ b/pkg/sql/vars.go
@@ -2410,7 +2410,7 @@ var varGen = map[string]sessionVar{
 		Get: func(evalCtx *extendedEvalContext, _ *kv.Txn) (string, error) {
 			return formatBoolAsPostgresSetting(evalCtx.SessionData().CopyFromRetriesEnabled), nil
 		},
-		GlobalDefault: globalFalse,
+		GlobalDefault: globalTrue,
 	},
 
 	// CockroachDB extension.


### PR DESCRIPTION
This turned out to be necessary to get customers over the line with DMS
in 22.2.  Now that its had time to prove itself enable it by default.

Epic: none
Informs: #99327
Fixes: #99464
