### PR TITLE
screl: Add IndexID as a attr of UniqueWithoutIndex element

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/alter_table
+++ b/pkg/sql/logictest/testdata/logic_test/alter_table
@@ -3194,3 +3194,51 @@ subtest alter_non_existent_table_with_if_exists
 
 statement ok
 ALTER TABLE IF EXISTS t_non_existent_99185 ADD FOREIGN KEY (i) REFERENCES t_other_99185 (i);
+
+# This subtest tests behavior when we have add/drop column and add constraint in one stmt.
+subtest 99281
+
+statement ok
+SET experimental_enable_unique_without_index_constraints = true;
+CREATE TABLE t_99281 (i INT PRIMARY KEY, j INT NOT NULL, k INT NOT NULL, FAMILY "primary" (i,j,k));
+INSERT INTO t_99281 VALUES (0,0,0), (1,0,1);
+
+statement error pq: could not create unique constraint ".*"
+ALTER TABLE t_99281 ADD UNIQUE WITHOUT INDEX (j);
+
+statement error pq: could not create unique constraint ".*"
+ALTER TABLE t_99281 ADD COLUMN p INT DEFAULT unique_rowid(), ADD UNIQUE WITHOUT INDEX (j);
+
+# The following statement will cause the stmt to hang using the legacy schema changer.
+skipif config local-legacy-schema-changer
+skipif config local-mixed-22.2-23.1
+statement error pq: could not create unique constraint ".*"
+ALTER TABLE t_99281 DROP COLUMN k, ADD UNIQUE WITHOUT INDEX (j);
+
+statement error pq: validation of CHECK "i > 0:::INT8" failed on row: i=0, j=0, k=0, p=[0-9]+
+ALTER TABLE t_99281 ADD COLUMN p INT DEFAULT unique_rowid(), ADD CHECK (i > 0);
+
+statement error pq: validation of CHECK "j > 0:::INT8" failed on row: i=[0-1], j=0, k=[0-1], p=[0-9]+
+ALTER TABLE t_99281 ADD COLUMN p INT DEFAULT unique_rowid(), ADD CHECK (i >= 0), ADD CHECK (j > 0);
+
+statement ok
+CREATE TABLE t_99281_other (i INT PRIMARY KEY);
+
+statement error pq: foreign key violation: "t_99281" row j=0, i=[0-1] has no match in "t_99281_other"
+ALTER TABLE t_99281 ADD COLUMN p INT DEFAULT unique_rowid(), ADD FOREIGN KEY (j) REFERENCES t_99281_other;
+
+# The following statement is not supported using the legacy schema changer.
+skipif config local-legacy-schema-changer
+skipif config local-mixed-22.2-23.1
+statement error pq: foreign key violation: "t_99281" row j=0, i=[0-1] has no match in "t_99281_other"
+ALTER TABLE t_99281 ALTER PRIMARY KEY USING COLUMNS (k), ADD FOREIGN KEY (j) REFERENCES t_99281_other;
+
+query TT
+show create table t_99281
+----
+t_99281  CREATE TABLE public.t_99281 (
+           i INT8 NOT NULL,
+           j INT8 NOT NULL,
+           k INT8 NOT NULL,
+           CONSTRAINT t_99281_pkey PRIMARY KEY (i ASC)
+         )

--- a/pkg/sql/schemachanger/scbuild/testdata/alter_table_add_unique_without_index
+++ b/pkg/sql/schemachanger/scbuild/testdata/alter_table_add_unique_without_index
@@ -5,7 +5,7 @@ CREATE TABLE t (i INT PRIMARY KEY, j INT);
 build
 ALTER TABLE t ADD UNIQUE WITHOUT INDEX (j);
 ----
-- [[UniqueWithoutIndexConstraint:{DescID: 104, ConstraintID: 2}, PUBLIC], ABSENT]
+- [[UniqueWithoutIndexConstraint:{DescID: 104, IndexID: 0, ConstraintID: 2}, PUBLIC], ABSENT]
   {columnIds: [2], constraintId: 2, tableId: 104}
 - [[ConstraintWithoutIndexName:{DescID: 104, Name: unique_j, ConstraintID: 2}, PUBLIC], ABSENT]
   {constraintId: 2, name: unique_j, tableId: 104}

--- a/pkg/sql/schemachanger/screl/attr.go
+++ b/pkg/sql/schemachanger/screl/attr.go
@@ -180,6 +180,7 @@ var elementSchemaOptions = []rel.SchemaOption{
 	rel.EntityMapping(t((*scpb.UniqueWithoutIndexConstraint)(nil)),
 		rel.EntityAttr(DescID, "TableID"),
 		rel.EntityAttr(ConstraintID, "ConstraintID"),
+		rel.EntityAttr(IndexID, "IndexIDForValidation"),
 	),
 	rel.EntityMapping(t((*scpb.UniqueWithoutIndexConstraintUnvalidated)(nil)),
 		rel.EntityAttr(DescID, "TableID"),

--- a/pkg/sql/schemachanger/testdata/explain/alter_table_add_unique_without_index
+++ b/pkg/sql/schemachanger/testdata/explain/alter_table_add_unique_without_index
@@ -9,18 +9,18 @@ Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› ADD CONS
  ├── StatementPhase
  │    └── Stage 1 of 1 in StatementPhase
  │         ├── 1 element transitioning toward PUBLIC
- │         │    └── ABSENT → WRITE_ONLY UniqueWithoutIndexConstraint:{DescID: 104, ConstraintID: 2}
+ │         │    └── ABSENT → WRITE_ONLY UniqueWithoutIndexConstraint:{DescID: 104, IndexID: 0, ConstraintID: 2}
  │         └── 1 Mutation operation
  │              └── AddUniqueWithoutIndexConstraint {"ConstraintID":2,"TableID":104,"Validity":2}
  ├── PreCommitPhase
  │    ├── Stage 1 of 2 in PreCommitPhase
  │    │    ├── 1 element transitioning toward PUBLIC
- │    │    │    └── WRITE_ONLY → ABSENT UniqueWithoutIndexConstraint:{DescID: 104, ConstraintID: 2}
+ │    │    │    └── WRITE_ONLY → ABSENT UniqueWithoutIndexConstraint:{DescID: 104, IndexID: 0, ConstraintID: 2}
  │    │    └── 1 Mutation operation
  │    │         └── UndoAllInTxnImmediateMutationOpSideEffects
  │    └── Stage 2 of 2 in PreCommitPhase
  │         ├── 1 element transitioning toward PUBLIC
- │         │    └── ABSENT → WRITE_ONLY UniqueWithoutIndexConstraint:{DescID: 104, ConstraintID: 2}
+ │         │    └── ABSENT → WRITE_ONLY UniqueWithoutIndexConstraint:{DescID: 104, IndexID: 0, ConstraintID: 2}
  │         └── 3 Mutation operations
  │              ├── AddUniqueWithoutIndexConstraint {"ConstraintID":2,"TableID":104,"Validity":2}
  │              ├── SetJobStateOnDescriptor {"DescriptorID":104,"Initialize":true}
@@ -28,12 +28,12 @@ Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› ADD CONS
  └── PostCommitPhase
       ├── Stage 1 of 2 in PostCommitPhase
       │    ├── 1 element transitioning toward PUBLIC
-      │    │    └── WRITE_ONLY → VALIDATED UniqueWithoutIndexConstraint:{DescID: 104, ConstraintID: 2}
+      │    │    └── WRITE_ONLY → VALIDATED UniqueWithoutIndexConstraint:{DescID: 104, IndexID: 0, ConstraintID: 2}
       │    └── 1 Validation operation
       │         └── ValidateConstraint {"ConstraintID":2,"TableID":104}
       └── Stage 2 of 2 in PostCommitPhase
            ├── 2 elements transitioning toward PUBLIC
-           │    ├── VALIDATED → PUBLIC UniqueWithoutIndexConstraint:{DescID: 104, ConstraintID: 2}
+           │    ├── VALIDATED → PUBLIC UniqueWithoutIndexConstraint:{DescID: 104, IndexID: 0, ConstraintID: 2}
            │    └── ABSENT    → PUBLIC ConstraintWithoutIndexName:{DescID: 104, Name: unique_j, ConstraintID: 2}
            └── 4 Mutation operations
                 ├── SetConstraintName {"ConstraintID":2,"Name":"unique_j","TableID":104}

--- a/pkg/sql/schemachanger/testdata/explain/alter_table_add_unique_without_index.rollback_1_of_2
+++ b/pkg/sql/schemachanger/testdata/explain/alter_table_add_unique_without_index.rollback_1_of_2
@@ -10,7 +10,7 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› A
  └── PostCommitNonRevertiblePhase
       └── Stage 1 of 1 in PostCommitNonRevertiblePhase
            ├── 1 element transitioning toward ABSENT
-           │    └── WRITE_ONLY → ABSENT UniqueWithoutIndexConstraint:{DescID: 104, ConstraintID: 2}
+           │    └── WRITE_ONLY → ABSENT UniqueWithoutIndexConstraint:{DescID: 104, IndexID: 0, ConstraintID: 2}
            └── 3 Mutation operations
                 ├── RemoveUniqueWithoutIndexConstraint {"ConstraintID":2,"TableID":104}
                 ├── RemoveJobStateFromDescriptor {"DescriptorID":104}

--- a/pkg/sql/schemachanger/testdata/explain/alter_table_add_unique_without_index.rollback_2_of_2
+++ b/pkg/sql/schemachanger/testdata/explain/alter_table_add_unique_without_index.rollback_2_of_2
@@ -10,7 +10,7 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› A
  └── PostCommitNonRevertiblePhase
       └── Stage 1 of 1 in PostCommitNonRevertiblePhase
            ├── 1 element transitioning toward ABSENT
-           │    └── WRITE_ONLY → ABSENT UniqueWithoutIndexConstraint:{DescID: 104, ConstraintID: 2}
+           │    └── WRITE_ONLY → ABSENT UniqueWithoutIndexConstraint:{DescID: 104, IndexID: 0, ConstraintID: 2}
            └── 3 Mutation operations
                 ├── RemoveUniqueWithoutIndexConstraint {"ConstraintID":2,"TableID":104}
                 ├── RemoveJobStateFromDescriptor {"DescriptorID":104}

--- a/pkg/sql/schemachanger/testdata/explain/alter_table_drop_constraint_uwi
+++ b/pkg/sql/schemachanger/testdata/explain/alter_table_drop_constraint_uwi
@@ -10,7 +10,7 @@ Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› DROP CON
  ├── StatementPhase
  │    └── Stage 1 of 1 in StatementPhase
  │         ├── 2 elements transitioning toward ABSENT
- │         │    ├── PUBLIC → VALIDATED UniqueWithoutIndexConstraint:{DescID: 104, ConstraintID: 2}
+ │         │    ├── PUBLIC → VALIDATED UniqueWithoutIndexConstraint:{DescID: 104, IndexID: 0, ConstraintID: 2}
  │         │    └── PUBLIC → ABSENT    ConstraintWithoutIndexName:{DescID: 104, Name: unique_j, ConstraintID: 2}
  │         └── 2 Mutation operations
  │              ├── MakePublicUniqueWithoutIndexConstraintValidated {"ConstraintID":2,"TableID":104}
@@ -18,13 +18,13 @@ Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› DROP CON
  ├── PreCommitPhase
  │    ├── Stage 1 of 2 in PreCommitPhase
  │    │    ├── 2 elements transitioning toward ABSENT
- │    │    │    ├── VALIDATED → PUBLIC UniqueWithoutIndexConstraint:{DescID: 104, ConstraintID: 2}
+ │    │    │    ├── VALIDATED → PUBLIC UniqueWithoutIndexConstraint:{DescID: 104, IndexID: 0, ConstraintID: 2}
  │    │    │    └── ABSENT    → PUBLIC ConstraintWithoutIndexName:{DescID: 104, Name: unique_j, ConstraintID: 2}
  │    │    └── 1 Mutation operation
  │    │         └── UndoAllInTxnImmediateMutationOpSideEffects
  │    └── Stage 2 of 2 in PreCommitPhase
  │         ├── 2 elements transitioning toward ABSENT
- │         │    ├── PUBLIC → VALIDATED UniqueWithoutIndexConstraint:{DescID: 104, ConstraintID: 2}
+ │         │    ├── PUBLIC → VALIDATED UniqueWithoutIndexConstraint:{DescID: 104, IndexID: 0, ConstraintID: 2}
  │         │    └── PUBLIC → ABSENT    ConstraintWithoutIndexName:{DescID: 104, Name: unique_j, ConstraintID: 2}
  │         └── 4 Mutation operations
  │              ├── MakePublicUniqueWithoutIndexConstraintValidated {"ConstraintID":2,"TableID":104}
@@ -34,7 +34,7 @@ Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› DROP CON
  └── PostCommitNonRevertiblePhase
       └── Stage 1 of 1 in PostCommitNonRevertiblePhase
            ├── 1 element transitioning toward ABSENT
-           │    └── VALIDATED → ABSENT UniqueWithoutIndexConstraint:{DescID: 104, ConstraintID: 2}
+           │    └── VALIDATED → ABSENT UniqueWithoutIndexConstraint:{DescID: 104, IndexID: 0, ConstraintID: 2}
            └── 3 Mutation operations
                 ├── RemoveUniqueWithoutIndexConstraint {"ConstraintID":2,"TableID":104}
                 ├── RemoveJobStateFromDescriptor {"DescriptorID":104}

--- a/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_add_unique_without_index
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_add_unique_without_index
@@ -13,10 +13,10 @@ EXPLAIN (ddl, verbose) ALTER TABLE t ADD UNIQUE WITHOUT INDEX (j);
 │       │
 │       ├── • 1 element transitioning toward PUBLIC
 │       │   │
-│       │   └── • UniqueWithoutIndexConstraint:{DescID: 104, ConstraintID: 2}
+│       │   └── • UniqueWithoutIndexConstraint:{DescID: 104, IndexID: 0, ConstraintID: 2}
 │       │       │ ABSENT → WRITE_ONLY
 │       │       │
-│       │       └── • PreviousStagePrecedence dependency from ABSENT UniqueWithoutIndexConstraint:{DescID: 104, ConstraintID: 2}
+│       │       └── • PreviousStagePrecedence dependency from ABSENT UniqueWithoutIndexConstraint:{DescID: 104, IndexID: 0, ConstraintID: 2}
 │       │             rule: "UniqueWithoutIndexConstraint transitions to PUBLIC uphold 2-version invariant: ABSENT->WRITE_ONLY"
 │       │
 │       └── • 1 Mutation operation
@@ -34,7 +34,7 @@ EXPLAIN (ddl, verbose) ALTER TABLE t ADD UNIQUE WITHOUT INDEX (j);
 │   │   │
 │   │   ├── • 1 element transitioning toward PUBLIC
 │   │   │   │
-│   │   │   └── • UniqueWithoutIndexConstraint:{DescID: 104, ConstraintID: 2}
+│   │   │   └── • UniqueWithoutIndexConstraint:{DescID: 104, IndexID: 0, ConstraintID: 2}
 │   │   │         WRITE_ONLY → ABSENT
 │   │   │
 │   │   └── • 1 Mutation operation
@@ -46,10 +46,10 @@ EXPLAIN (ddl, verbose) ALTER TABLE t ADD UNIQUE WITHOUT INDEX (j);
 │       │
 │       ├── • 1 element transitioning toward PUBLIC
 │       │   │
-│       │   └── • UniqueWithoutIndexConstraint:{DescID: 104, ConstraintID: 2}
+│       │   └── • UniqueWithoutIndexConstraint:{DescID: 104, IndexID: 0, ConstraintID: 2}
 │       │       │ ABSENT → WRITE_ONLY
 │       │       │
-│       │       └── • PreviousStagePrecedence dependency from ABSENT UniqueWithoutIndexConstraint:{DescID: 104, ConstraintID: 2}
+│       │       └── • PreviousStagePrecedence dependency from ABSENT UniqueWithoutIndexConstraint:{DescID: 104, IndexID: 0, ConstraintID: 2}
 │       │             rule: "UniqueWithoutIndexConstraint transitions to PUBLIC uphold 2-version invariant: ABSENT->WRITE_ONLY"
 │       │
 │       └── • 3 Mutation operations
@@ -84,10 +84,10 @@ EXPLAIN (ddl, verbose) ALTER TABLE t ADD UNIQUE WITHOUT INDEX (j);
     │   │
     │   ├── • 1 element transitioning toward PUBLIC
     │   │   │
-    │   │   └── • UniqueWithoutIndexConstraint:{DescID: 104, ConstraintID: 2}
+    │   │   └── • UniqueWithoutIndexConstraint:{DescID: 104, IndexID: 0, ConstraintID: 2}
     │   │       │ WRITE_ONLY → VALIDATED
     │   │       │
-    │   │       └── • PreviousStagePrecedence dependency from WRITE_ONLY UniqueWithoutIndexConstraint:{DescID: 104, ConstraintID: 2}
+    │   │       └── • PreviousStagePrecedence dependency from WRITE_ONLY UniqueWithoutIndexConstraint:{DescID: 104, IndexID: 0, ConstraintID: 2}
     │   │             rule: "UniqueWithoutIndexConstraint transitions to PUBLIC uphold 2-version invariant: WRITE_ONLY->VALIDATED"
     │   │
     │   └── • 1 Validation operation
@@ -100,10 +100,10 @@ EXPLAIN (ddl, verbose) ALTER TABLE t ADD UNIQUE WITHOUT INDEX (j);
         │
         ├── • 2 elements transitioning toward PUBLIC
         │   │
-        │   ├── • UniqueWithoutIndexConstraint:{DescID: 104, ConstraintID: 2}
+        │   ├── • UniqueWithoutIndexConstraint:{DescID: 104, IndexID: 0, ConstraintID: 2}
         │   │   │ VALIDATED → PUBLIC
         │   │   │
-        │   │   ├── • PreviousStagePrecedence dependency from VALIDATED UniqueWithoutIndexConstraint:{DescID: 104, ConstraintID: 2}
+        │   │   ├── • PreviousStagePrecedence dependency from VALIDATED UniqueWithoutIndexConstraint:{DescID: 104, IndexID: 0, ConstraintID: 2}
         │   │   │     rule: "UniqueWithoutIndexConstraint transitions to PUBLIC uphold 2-version invariant: VALIDATED->PUBLIC"
         │   │   │
         │   │   └── • SameStagePrecedence dependency from PUBLIC ConstraintWithoutIndexName:{DescID: 104, Name: unique_j, ConstraintID: 2}

--- a/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_add_unique_without_index.rollback_1_of_2
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_add_unique_without_index.rollback_1_of_2
@@ -14,10 +14,10 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 1 of 2;
         │
         ├── • 1 element transitioning toward ABSENT
         │   │
-        │   └── • UniqueWithoutIndexConstraint:{DescID: 104, ConstraintID: 2}
+        │   └── • UniqueWithoutIndexConstraint:{DescID: 104, IndexID: 0, ConstraintID: 2}
         │       │ WRITE_ONLY → ABSENT
         │       │
-        │       ├── • PreviousStagePrecedence dependency from WRITE_ONLY UniqueWithoutIndexConstraint:{DescID: 104, ConstraintID: 2}
+        │       ├── • PreviousStagePrecedence dependency from WRITE_ONLY UniqueWithoutIndexConstraint:{DescID: 104, IndexID: 0, ConstraintID: 2}
         │       │     rule: "UniqueWithoutIndexConstraint transitions to ABSENT uphold 2-version invariant: WRITE_ONLY->VALIDATED"
         │       │
         │       └── • Precedence dependency from ABSENT ConstraintWithoutIndexName:{DescID: 104, Name: unique_j, ConstraintID: 2}

--- a/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_add_unique_without_index.rollback_2_of_2
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_add_unique_without_index.rollback_2_of_2
@@ -14,10 +14,10 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 2 of 2;
         │
         ├── • 1 element transitioning toward ABSENT
         │   │
-        │   └── • UniqueWithoutIndexConstraint:{DescID: 104, ConstraintID: 2}
+        │   └── • UniqueWithoutIndexConstraint:{DescID: 104, IndexID: 0, ConstraintID: 2}
         │       │ WRITE_ONLY → ABSENT
         │       │
-        │       ├── • PreviousStagePrecedence dependency from WRITE_ONLY UniqueWithoutIndexConstraint:{DescID: 104, ConstraintID: 2}
+        │       ├── • PreviousStagePrecedence dependency from WRITE_ONLY UniqueWithoutIndexConstraint:{DescID: 104, IndexID: 0, ConstraintID: 2}
         │       │     rule: "UniqueWithoutIndexConstraint transitions to ABSENT uphold 2-version invariant: WRITE_ONLY->VALIDATED"
         │       │
         │       └── • Precedence dependency from ABSENT ConstraintWithoutIndexName:{DescID: 104, Name: unique_j, ConstraintID: 2}

--- a/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_drop_constraint_uwi
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_drop_constraint_uwi
@@ -14,16 +14,16 @@ EXPLAIN (ddl, verbose) ALTER TABLE t DROP CONSTRAINT unique_j;
 │       │
 │       ├── • 2 elements transitioning toward ABSENT
 │       │   │
-│       │   ├── • UniqueWithoutIndexConstraint:{DescID: 104, ConstraintID: 2}
+│       │   ├── • UniqueWithoutIndexConstraint:{DescID: 104, IndexID: 0, ConstraintID: 2}
 │       │   │   │ PUBLIC → VALIDATED
 │       │   │   │
-│       │   │   └── • PreviousStagePrecedence dependency from PUBLIC UniqueWithoutIndexConstraint:{DescID: 104, ConstraintID: 2}
+│       │   │   └── • PreviousStagePrecedence dependency from PUBLIC UniqueWithoutIndexConstraint:{DescID: 104, IndexID: 0, ConstraintID: 2}
 │       │   │         rule: "UniqueWithoutIndexConstraint transitions to ABSENT uphold 2-version invariant: PUBLIC->VALIDATED"
 │       │   │
 │       │   └── • ConstraintWithoutIndexName:{DescID: 104, Name: unique_j, ConstraintID: 2}
 │       │       │ PUBLIC → ABSENT
 │       │       │
-│       │       └── • Precedence dependency from VALIDATED UniqueWithoutIndexConstraint:{DescID: 104, ConstraintID: 2}
+│       │       └── • Precedence dependency from VALIDATED UniqueWithoutIndexConstraint:{DescID: 104, IndexID: 0, ConstraintID: 2}
 │       │             rule: "constraint no longer public before dependents"
 │       │
 │       └── • 2 Mutation operations
@@ -43,7 +43,7 @@ EXPLAIN (ddl, verbose) ALTER TABLE t DROP CONSTRAINT unique_j;
 │   │   │
 │   │   ├── • 2 elements transitioning toward ABSENT
 │   │   │   │
-│   │   │   ├── • UniqueWithoutIndexConstraint:{DescID: 104, ConstraintID: 2}
+│   │   │   ├── • UniqueWithoutIndexConstraint:{DescID: 104, IndexID: 0, ConstraintID: 2}
 │   │   │   │     VALIDATED → PUBLIC
 │   │   │   │
 │   │   │   └── • ConstraintWithoutIndexName:{DescID: 104, Name: unique_j, ConstraintID: 2}
@@ -58,16 +58,16 @@ EXPLAIN (ddl, verbose) ALTER TABLE t DROP CONSTRAINT unique_j;
 │       │
 │       ├── • 2 elements transitioning toward ABSENT
 │       │   │
-│       │   ├── • UniqueWithoutIndexConstraint:{DescID: 104, ConstraintID: 2}
+│       │   ├── • UniqueWithoutIndexConstraint:{DescID: 104, IndexID: 0, ConstraintID: 2}
 │       │   │   │ PUBLIC → VALIDATED
 │       │   │   │
-│       │   │   └── • PreviousStagePrecedence dependency from PUBLIC UniqueWithoutIndexConstraint:{DescID: 104, ConstraintID: 2}
+│       │   │   └── • PreviousStagePrecedence dependency from PUBLIC UniqueWithoutIndexConstraint:{DescID: 104, IndexID: 0, ConstraintID: 2}
 │       │   │         rule: "UniqueWithoutIndexConstraint transitions to ABSENT uphold 2-version invariant: PUBLIC->VALIDATED"
 │       │   │
 │       │   └── • ConstraintWithoutIndexName:{DescID: 104, Name: unique_j, ConstraintID: 2}
 │       │       │ PUBLIC → ABSENT
 │       │       │
-│       │       └── • Precedence dependency from VALIDATED UniqueWithoutIndexConstraint:{DescID: 104, ConstraintID: 2}
+│       │       └── • Precedence dependency from VALIDATED UniqueWithoutIndexConstraint:{DescID: 104, IndexID: 0, ConstraintID: 2}
 │       │             rule: "constraint no longer public before dependents"
 │       │
 │       └── • 4 Mutation operations
@@ -104,10 +104,10 @@ EXPLAIN (ddl, verbose) ALTER TABLE t DROP CONSTRAINT unique_j;
         │
         ├── • 1 element transitioning toward ABSENT
         │   │
-        │   └── • UniqueWithoutIndexConstraint:{DescID: 104, ConstraintID: 2}
+        │   └── • UniqueWithoutIndexConstraint:{DescID: 104, IndexID: 0, ConstraintID: 2}
         │       │ VALIDATED → ABSENT
         │       │
-        │       ├── • PreviousStagePrecedence dependency from VALIDATED UniqueWithoutIndexConstraint:{DescID: 104, ConstraintID: 2}
+        │       ├── • PreviousStagePrecedence dependency from VALIDATED UniqueWithoutIndexConstraint:{DescID: 104, IndexID: 0, ConstraintID: 2}
         │       │     rule: "UniqueWithoutIndexConstraint transitions to ABSENT uphold 2-version invariant: VALIDATED->ABSENT"
         │       │
         │       └── • Precedence dependency from ABSENT ConstraintWithoutIndexName:{DescID: 104, Name: unique_j, ConstraintID: 2}


### PR DESCRIPTION
Previously, ALTER TABLE stmt where we add column/drop column/alter PK and adding a unique without index is problematic in that the it can succeed even when there are duplicate values. We already had a dep rule that enforces the new primary index to be backfilled before we validate the constraint against it. Unfortunately, this rule is not enforced on unique without index constraint because IndexID was not a attr of it. This commit fixes this.

Fixes https://github.com/cockroachdb/cockroach/issues/99281
Epic: None
Release note (bug fix): Fixed a bug in v23.1 in the declarative schema changer where unique without index can be incorrectly added in tables with duplicate values if it's with a ADD/DROP COLUMN in one ALTER TABLE statement.
