### PR TITLE
backupccl: lower the buffer size of doneScatterCh in gen split and scatter

### DIFF
--- a/pkg/ccl/backupccl/generative_split_and_scatter_processor.go
+++ b/pkg/ccl/backupccl/generative_split_and_scatter_processor.go
@@ -124,8 +124,11 @@ func newGenerativeSplitAndScatterProcessor(
 		spec:                         spec,
 		chunkSplitAndScatterers:      chunkSplitAndScatterers,
 		chunkEntrySplitAndScatterers: chunkEntrySplitAndScatterers,
-		// Large enough so that it never blocks.
-		doneScatterCh:     make(chan entryNode, spec.NumEntries),
+		// There's not much science behind this sizing of doneScatterCh,
+		// other than it's the max number of entries that can be processed
+		// in parallel downstream. It has been verified ad-hoc that this
+		// sizing does not bottleneck restore.
+		doneScatterCh:     make(chan entryNode, int(spec.NumNodes)*maxConcurrentRestoreWorkers),
 		routingDatumCache: make(map[roachpb.NodeID]rowenc.EncDatum),
 	}
 	if err := ssp.Init(ctx, ssp, post, generativeSplitAndScatterOutputTypes, flowCtx, processorID, nil, /* memMonitor */


### PR DESCRIPTION
Previously, doneScatterCh in GenerativeSplitAndScatterProcessor had a large enough buffer size to never block, which was equal to the number of import spans in the restore job. This can cause restore to buffer all restore span entries in memory at the same time. Lower the limit to be numNodes * maxConcurrentRestoreWorkers, which is the max number of entries that can be processed in parallel downstream.

Release note: None