### PR TITLE
roachtest: add back backups to disk-stalled tests

### DIFF
--- a/pkg/cmd/roachtest/tests/disk_stall.go
+++ b/pkg/cmd/roachtest/tests/disk_stall.go
@@ -100,7 +100,7 @@ func registerDiskStalledDetection(r registry.Registry) {
 func runDiskStalledDetection(
 	ctx context.Context, t test.Test, c cluster.Cluster, s diskStaller, doStall bool,
 ) {
-	startOpts := option.DefaultStartOptsNoBackups()
+	startOpts := option.DefaultStartOpts()
 	startOpts.RoachprodOpts.ExtraArgs = []string{
 		"--store", s.DataDir(),
 		"--log", fmt.Sprintf(`{sinks: {stderr: {filter: INFO}}, file-defaults: {dir: "%s"}}`, s.LogDir()),


### PR DESCRIPTION
Backups were inadvertently disabled in #99747 (to simplify testing). As there is no good reason to run without them, re-enable the backups during the test.

Release note: None.

Epic: CRDB-20293