### PR TITLE
kvserver: remove unused snapshot fields

### DIFF
--- a/pkg/kv/kvserver/allocator/plan/op.go
+++ b/pkg/kv/kvserver/allocator/plan/op.go
@@ -60,7 +60,6 @@ type AllocationChangeReplicasOp struct {
 	Usage             allocator.RangeUsageInfo
 	lhStore           roachpb.StoreID
 	Chgs              kvpb.ReplicationChanges
-	Priority          kvserverpb.SnapshotRequest_Priority
 	AllocatorPriority float64
 	Reason            kvserverpb.RangeLogEventReason
 	Details           string

--- a/pkg/kv/kvserver/allocator/plan/replicate.go
+++ b/pkg/kv/kvserver/allocator/plan/replicate.go
@@ -473,7 +473,6 @@ func (rp ReplicaPlanner) addOrReplaceVoters(
 		lhStore:           repl.StoreID(),
 		Usage:             repl.RangeUsageInfo(),
 		Chgs:              ops,
-		Priority:          kvserverpb.SnapshotRequest_RECOVERY,
 		AllocatorPriority: allocatorPriority,
 		Reason:            kvserverpb.ReasonRangeUnderReplicated,
 		Details:           details,
@@ -525,7 +524,6 @@ func (rp ReplicaPlanner) addOrReplaceNonVoters(
 		lhStore:           repl.StoreID(),
 		Usage:             repl.RangeUsageInfo(),
 		Chgs:              ops,
-		Priority:          kvserverpb.SnapshotRequest_RECOVERY,
 		AllocatorPriority: allocatorPrio,
 		Reason:            kvserverpb.ReasonRangeUnderReplicated,
 		Details:           details,
@@ -666,8 +664,7 @@ func (rp ReplicaPlanner) removeVoter(
 		lhStore:           repl.StoreID(),
 		Usage:             repl.RangeUsageInfo(),
 		Chgs:              kvpb.MakeReplicationChanges(roachpb.REMOVE_VOTER, removeVoter),
-		Priority:          kvserverpb.SnapshotRequest_UNKNOWN, // unused
-		AllocatorPriority: 0.0,                                // unused
+		AllocatorPriority: 0.0, // unused
 		Reason:            kvserverpb.ReasonRangeOverReplicated,
 		Details:           details,
 	}
@@ -706,8 +703,7 @@ func (rp ReplicaPlanner) removeNonVoter(
 		lhStore:           repl.StoreID(),
 		Usage:             repl.RangeUsageInfo(),
 		Chgs:              kvpb.MakeReplicationChanges(roachpb.REMOVE_NON_VOTER, target),
-		Priority:          kvserverpb.SnapshotRequest_UNKNOWN, // unused
-		AllocatorPriority: 0.0,                                // unused
+		AllocatorPriority: 0.0, // unused
 		Reason:            kvserverpb.ReasonRangeOverReplicated,
 		Details:           details,
 	}
@@ -763,8 +759,7 @@ func (rp ReplicaPlanner) removeDecommissioning(
 		lhStore:           repl.StoreID(),
 		Usage:             repl.RangeUsageInfo(),
 		Chgs:              kvpb.MakeReplicationChanges(targetType.RemoveChangeType(), target),
-		Priority:          kvserverpb.SnapshotRequest_UNKNOWN, // unused
-		AllocatorPriority: 0.0,                                // unused
+		AllocatorPriority: 0.0, // unused
 		Reason:            kvserverpb.ReasonStoreDecommissioning,
 		Details:           "",
 	}
@@ -801,8 +796,7 @@ func (rp ReplicaPlanner) removeDead(
 		lhStore:           repl.StoreID(),
 		Usage:             repl.RangeUsageInfo(),
 		Chgs:              kvpb.MakeReplicationChanges(targetType.RemoveChangeType(), target),
-		Priority:          kvserverpb.SnapshotRequest_UNKNOWN, // unused
-		AllocatorPriority: 0.0,                                // unused
+		AllocatorPriority: 0.0, // unused
 		Reason:            kvserverpb.ReasonStoreDead,
 		Details:           "",
 	}
@@ -938,7 +932,6 @@ func (rp ReplicaPlanner) considerRebalance(
 		lhStore:           repl.StoreID(),
 		Usage:             rangeUsageInfo,
 		Chgs:              chgs,
-		Priority:          kvserverpb.SnapshotRequest_REBALANCE,
 		AllocatorPriority: allocatorPrio,
 		Reason:            kvserverpb.ReasonRebalance,
 		Details:           details,

--- a/pkg/kv/kvserver/client_merge_test.go
+++ b/pkg/kv/kvserver/client_merge_test.go
@@ -3721,12 +3721,12 @@ func TestStoreRangeMergeRaftSnapshot(t *testing.T) {
 		inSnap kvserver.IncomingSnapshot,
 		sstNames []string,
 	) error {
-		// Only verify snapshots of type VIA_SNAPSHOT_QUEUE and on the range under
-		// exercise (range 2). Note that the keys of range 2 aren't verified in this
-		// functions. Unreplicated range-id local keys are not verified because
-		// there are too many keys and the other replicated keys are verified later
-		// on in the test. This function verifies that the subsumed replicas have
-		// been handled properly.
+		// Only verify snapshots on the range under exercise (range 2). Note
+		// that the keys of range 2 aren't verified in this functions.
+		// Unreplicated range-id local keys are not verified because there are
+		// too many keys and the other replicated keys are verified later on in
+		// the test. This function verifies that the subsumed replicas have been
+		// handled properly.
 		if inSnap.Desc.RangeID != rangeIds[string(keyA)] {
 			return nil
 		}

--- a/pkg/kv/kvserver/client_raft_test.go
+++ b/pkg/kv/kvserver/client_raft_test.go
@@ -1564,7 +1564,7 @@ func TestReceiveSnapshotLogging(t *testing.T) {
 		chgs := kvpb.MakeReplicationChanges(roachpb.ADD_VOTER, tc.Target(receiverNodeIdx))
 
 		testStartTs := timeutil.Now()
-		_, pErr := repl.ChangeReplicas(ctx, rngDesc, kvserverpb.SnapshotRequest_REBALANCE, kvserverpb.ReasonRangeUnderReplicated, "", chgs)
+		_, pErr := repl.ChangeReplicas(ctx, rngDesc, kvserverpb.ReasonRangeUnderReplicated, "", chgs)
 
 		// When ready, flush logs and check messages from store_raft.go since
 		// call to repl.ChangeReplicas(..).
@@ -2138,7 +2138,7 @@ func TestChangeReplicasDescriptorInvariant(t *testing.T) {
 
 	addReplica := func(storeNum int, desc *roachpb.RangeDescriptor) error {
 		chgs := kvpb.MakeReplicationChanges(roachpb.ADD_VOTER, tc.Target(storeNum))
-		_, err := repl.ChangeReplicas(ctx, desc, kvserverpb.SnapshotRequest_REBALANCE, kvserverpb.ReasonRangeUnderReplicated, "", chgs)
+		_, err := repl.ChangeReplicas(ctx, desc, kvserverpb.ReasonRangeUnderReplicated, "", chgs)
 		return err
 	}
 
@@ -3208,7 +3208,7 @@ func TestRemovePlaceholderRace(t *testing.T) {
 		for _, action := range []roachpb.ReplicaChangeType{roachpb.REMOVE_VOTER, roachpb.ADD_VOTER} {
 			for {
 				chgs := kvpb.MakeReplicationChanges(action, tc.Target(1))
-				if _, err := repl.ChangeReplicas(ctx, repl.Desc(), kvserverpb.SnapshotRequest_REBALANCE, kvserverpb.ReasonUnknown, "", chgs); err != nil {
+				if _, err := repl.ChangeReplicas(ctx, repl.Desc(), kvserverpb.ReasonUnknown, "", chgs); err != nil {
 					if kvserver.IsRetriableReplicationChangeError(err) ||
 						kvserver.IsReplicationChangeInProgressError(err) {
 						continue
@@ -3310,7 +3310,7 @@ func TestReplicaGCRace(t *testing.T) {
 		NodeID:  toStore.Ident.NodeID,
 		StoreID: toStore.Ident.StoreID,
 	})
-	if _, err := repl.ChangeReplicas(ctx, repl.Desc(), kvserverpb.SnapshotRequest_REBALANCE, kvserverpb.ReasonRangeUnderReplicated, "", chgs); err != nil {
+	if _, err := repl.ChangeReplicas(ctx, repl.Desc(), kvserverpb.ReasonRangeUnderReplicated, "", chgs); err != nil {
 		t.Fatal(err)
 	}
 
@@ -3359,7 +3359,7 @@ func TestReplicaGCRace(t *testing.T) {
 
 	// Remove the victim replica and manually GC it.
 	chgs[0].ChangeType = roachpb.REMOVE_VOTER
-	if _, err := repl.ChangeReplicas(ctx, repl.Desc(), kvserverpb.SnapshotRequest_REBALANCE, kvserverpb.ReasonRangeOverReplicated, "", chgs); err != nil {
+	if _, err := repl.ChangeReplicas(ctx, repl.Desc(), kvserverpb.ReasonRangeOverReplicated, "", chgs); err != nil {
 		t.Fatal(err)
 	}
 

--- a/pkg/kv/kvserver/client_replica_test.go
+++ b/pkg/kv/kvserver/client_replica_test.go
@@ -2653,7 +2653,7 @@ func TestDrainRangeRejection(t *testing.T) {
 	drainingIdx := 1
 	tc.GetFirstStoreFromServer(t, 1).SetDraining(true, nil /* reporter */, false /* verbose */)
 	chgs := kvpb.MakeReplicationChanges(roachpb.ADD_VOTER, tc.Target(drainingIdx))
-	if _, err := repl.ChangeReplicas(context.Background(), repl.Desc(), kvserverpb.SnapshotRequest_REBALANCE, kvserverpb.ReasonRangeUnderReplicated, "", chgs); !testutils.IsError(err, "store is draining") {
+	if _, err := repl.ChangeReplicas(context.Background(), repl.Desc(), kvserverpb.ReasonRangeUnderReplicated, "", chgs); !testutils.IsError(err, "store is draining") {
 		t.Fatalf("unexpected error: %+v", err)
 	}
 }
@@ -2673,7 +2673,7 @@ func TestChangeReplicasGeneration(t *testing.T) {
 
 	oldGeneration := repl.Desc().Generation
 	chgs := kvpb.MakeReplicationChanges(roachpb.ADD_VOTER, tc.Target(1))
-	if _, err := repl.ChangeReplicas(context.Background(), repl.Desc(), kvserverpb.SnapshotRequest_REBALANCE, kvserverpb.ReasonRangeUnderReplicated, "", chgs); err != nil {
+	if _, err := repl.ChangeReplicas(context.Background(), repl.Desc(), kvserverpb.ReasonRangeUnderReplicated, "", chgs); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	assert.EqualValues(t, repl.Desc().Generation, oldGeneration+2)
@@ -2681,7 +2681,7 @@ func TestChangeReplicasGeneration(t *testing.T) {
 	oldGeneration = repl.Desc().Generation
 	oldDesc := repl.Desc()
 	chgs[0].ChangeType = roachpb.REMOVE_VOTER
-	newDesc, err := repl.ChangeReplicas(context.Background(), oldDesc, kvserverpb.SnapshotRequest_REBALANCE, kvserverpb.ReasonRangeOverReplicated, "", chgs)
+	newDesc, err := repl.ChangeReplicas(context.Background(), oldDesc, kvserverpb.ReasonRangeOverReplicated, "", chgs)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -3760,7 +3760,7 @@ func TestAdminRelocateRangeSafety(t *testing.T) {
 	change := func() {
 		<-seenAdd
 		chgs := kvpb.MakeReplicationChanges(roachpb.REMOVE_VOTER, makeReplicationTargets(2)...)
-		changedDesc, changeErr = r1.ChangeReplicas(ctx, &expDescAfterAdd, kvserverpb.SnapshotRequest_REBALANCE, "replicate", "testing", chgs)
+		changedDesc, changeErr = r1.ChangeReplicas(ctx, &expDescAfterAdd, "replicate", "testing", chgs)
 	}
 	relocate := func() {
 		relocateErr = db.AdminRelocateRange(

--- a/pkg/kv/kvserver/kvserverpb/raft.go
+++ b/pkg/kv/kvserver/kvserverpb/raft.go
@@ -16,9 +16,6 @@ import (
 	"github.com/cockroachdb/errors"
 )
 
-// SafeValue implements the redact.SafeValue interface.
-func (SnapshotRequest_Type) SafeValue() {}
-
 // Error returns the error contained in the snapshot response, if any.
 //
 // The bool indicates whether this message uses the deprecated behavior of

--- a/pkg/kv/kvserver/kvserverpb/raft.proto
+++ b/pkg/kv/kvserver/kvserverpb/raft.proto
@@ -156,39 +156,6 @@ message RaftMessageResponse {
 
 // SnapshotRequest is the request used to send streaming snapshot requests.
 message SnapshotRequest {
-  enum Priority {
-    UNKNOWN = 0;
-    // RECOVERY is used for a Raft-initiated snapshots and for
-    // up-replication snapshots (i.e. when a dead node has been
-    // removed and the range needs to be up-replicated).
-    RECOVERY = 1;
-    // REBALANCE is used for snapshots involved in rebalancing.
-    REBALANCE = 2;
-  }
-
-  enum Strategy {
-    // KV_BATCH snapshots stream batches of KV pairs for all keys in a
-    // range from the sender the the receiver. These KV pairs are then
-    // combined into a large RocksDB WriteBatch that is atomically
-    // applied.
-    KV_BATCH = 0;
-  }
-
-  // Type is used for metrics collection on the receiver side. See
-  // applySnapshot in replica_raftstorage.go.
-  enum Type {
-    // VIA_SNAPSHOT_QUEUE indicates the snapshots sent by the raft snapshot
-    // queue to all types of replicas.
-    VIA_SNAPSHOT_QUEUE = 0;
-    // INITIAL indicates the initial snapshots sent to LEARNER (before they're
-    // promoted to full voters) and NON_VOTER replicas for upreplication.
-    //
-    // As of the time of writing, we only send this snapshot from the
-    // initializeRaftLearners after creating a new LEARNER or NON_VOTER replica.
-    INITIAL = 1;
-    reserved 2;
-  }
-
   // QueueName indicates the source of the snapshot. Snapshots are prioritized
   // within a queue and round-robin selected between queues for both the sending
   // and receiving side.
@@ -212,32 +179,6 @@ message SnapshotRequest {
     // The estimated size of the range, to be used in reservation decisions.
     int64 range_size = 3;
 
-    // The priority of the snapshot.
-    // Deprecated, prefer sender_queue_priority.
-    // TODO(abaptist): Remove this field when v23.1 compatibility is dropped.
-    Priority deprecated_priority = 6;
-
-    // The strategy of the snapshot.
-    // TODO(abaptist): Remove this field when v23.1 compatibility is dropped.
-    Strategy deprecated_strategy = 7;
-
-    // The type of the snapshot.
-    // Deprecated, prefer sender_queue_name.
-    // TODO(abaptist): Remove this field when v23.1 compatibility is dropped.
-    Type deprecated_type = 9;
-
-    // Whether the snapshot uses the unreplicated RaftTruncatedState or not.
-    // This is always true for snapshots generated in v21.1+ clusters. In v20.2
-    // it was possible for ranges to be using the replicated variant. v21.1
-    // therefore had code expecting that possibility (unlike v21.2 code, where
-    // this field is assumed to always be true and thus never read). For
-    // compatibility with v21.1 nodes however, v21.2 has to explicitly set this
-    // field to true. In v22.1 we can remove it entirely seeing as how v21.2
-    // code never reads the field.
-    //
-    // TODO(irfansharif): Remove this in v22.1.
-    bool deprecated_unreplicated_truncated_state = 8;
-
     // The sending queue's name, to be utilized to ensure fairness across
     // different snapshot sending sources. The default queue name, OTHER, is
     // reserved for any uncategorized and unprioritized snapshots, and requests
@@ -255,7 +196,7 @@ message SnapshotRequest {
     // metadata present in the snapshot, but not file contents.
     bool shared_replicate = 12;
 
-    reserved 1, 4;
+    reserved 1, 4, 6, 7, 8, 9;
   }
 
   // SharedTable represents one shared SSTable present in shared storage.
@@ -378,14 +319,6 @@ message DelegateSendSnapshotRequest {
   // The replica selected to act as the snapshot sender.
   roachpb.ReplicaDescriptor delegated_sender = 4 [(gogoproto.nullable) = false];
 
-  // The priority of the snapshot.
-  // TODO(abaptist): Remove this field when v23.1 compatibility is dropped.
-  SnapshotRequest.Priority deprecated_priority = 5;
-
-  // The type of the snapshot.
-  // TODO(abaptist): Remove this field when v23.1 compatibility is dropped.
-  SnapshotRequest.Type deprecated_type = 6;
-
   // The Raft term of the coordinator (in most cases the leaseholder) replica.
   // The term is used during snapshot receiving to reject messages from an older term.
   uint64 term = 7 [(gogoproto.casttype) = "github.com/cockroachdb/cockroach/pkg/kv/kvpb.RaftTerm"];
@@ -409,6 +342,8 @@ message DelegateSendSnapshotRequest {
   bytes snap_id = 13 [
     (gogoproto.customtype) = "github.com/cockroachdb/cockroach/pkg/util/uuid.UUID",
     (gogoproto.nullable) = false];
+
+  reserved 5, 6;
 }
 
 message DelegateSnapshotResponse {

--- a/pkg/kv/kvserver/raft_snapshot_queue.go
+++ b/pkg/kv/kvserver/raft_snapshot_queue.go
@@ -113,7 +113,6 @@ func (rq *raftSnapshotQueue) processRaftSnapshot(
 	if !ok {
 		return false, errors.Errorf("%s: replica %d not present in %v", repl, id, desc.Replicas())
 	}
-	snapType := kvserverpb.SnapshotRequest_VIA_SNAPSHOT_QUEUE
 
 	if typ := repDesc.Type; typ == roachpb.LEARNER || typ == roachpb.NON_VOTER {
 		if fn := repl.store.cfg.TestingKnobs.RaftSnapshotQueueSkipReplica; fn != nil && fn() {
@@ -133,7 +132,7 @@ func (rq *raftSnapshotQueue) processRaftSnapshot(
 		}
 	}
 
-	err := repl.sendSnapshotUsingDelegate(ctx, repDesc, snapType, kvserverpb.SnapshotRequest_RECOVERY, kvserverpb.SnapshotRequest_RAFT_SNAPSHOT_QUEUE, raftSnapshotPriority)
+	err := repl.sendSnapshotUsingDelegate(ctx, repDesc, kvserverpb.SnapshotRequest_RAFT_SNAPSHOT_QUEUE, raftSnapshotPriority)
 
 	// NB: if the snapshot fails because of an overlapping replica on the
 	// recipient which is also waiting for a snapshot, the "smart" thing is to

--- a/pkg/kv/kvserver/replica_learner_test.go
+++ b/pkg/kv/kvserver/replica_learner_test.go
@@ -950,7 +950,7 @@ func testRaftSnapshotsToNonVoters(t *testing.T, drainReceivingNode bool) {
 	scratchStartKey := tc.ScratchRange(t)
 	g, ctx := errgroup.WithContext(ctx)
 
-	metrics := []string{".rebalancing", ".recovery", ".unknown", ""}
+	metrics := []string{".rebalancing", ".recovery", ""}
 	// Record the snapshot metrics before anything has been sent / received.
 	senderMetricsMapBefore := getSnapshotBytesMetrics(t, tc, 0 /* serverIdx */, metrics)
 	receiverMetricsMapBefore := getSnapshotBytesMetrics(t, tc, 1 /* serverIdx */, metrics)
@@ -1021,7 +1021,7 @@ func testRaftSnapshotsToNonVoters(t *testing.T, drainReceivingNode bool) {
 	// snapshot being sent.
 	<-blockUntilSnapshotSendCh
 	store, repl := getFirstStoreReplica(t, tc.Server(0), scratchStartKey)
-	snapshotLength, err := getExpectedSnapshotSizeBytes(ctx, store, repl, kvserverpb.SnapshotRequest_VIA_SNAPSHOT_QUEUE)
+	snapshotLength, err := getExpectedSnapshotSizeBytes(ctx, store, repl)
 	require.NoError(t, err)
 
 	close(blockSnapshotSendCh)
@@ -1037,7 +1037,6 @@ func testRaftSnapshotsToNonVoters(t *testing.T, drainReceivingNode bool) {
 	senderMapExpected := map[string]snapshotBytesMetrics{
 		".rebalancing": {sentBytes: 0, rcvdBytes: 0},
 		".recovery":    {sentBytes: snapshotLength, rcvdBytes: 0},
-		".unknown":     {sentBytes: 0, rcvdBytes: 0},
 		"":             {sentBytes: snapshotLength, rcvdBytes: 0},
 	}
 	require.Equal(t, senderMapExpected, senderMapDelta)
@@ -1053,7 +1052,6 @@ func testRaftSnapshotsToNonVoters(t *testing.T, drainReceivingNode bool) {
 	receiverMapExpected := map[string]snapshotBytesMetrics{
 		".rebalancing": {sentBytes: 0, rcvdBytes: 0},
 		".recovery":    {sentBytes: 0, rcvdBytes: snapshotLength},
-		".unknown":     {sentBytes: 0, rcvdBytes: 0},
 		"":             {sentBytes: 0, rcvdBytes: snapshotLength},
 	}
 	require.Equal(t, receiverMapExpected, receiverMapDelta)
@@ -2218,10 +2216,7 @@ func getSnapshotMetricsDiff(
 // NB: This calculation assumes the snapshot size is less than
 // `kv.snapshot_sender.batch_size` and will fit in a single storage.Batch.
 func getExpectedSnapshotSizeBytes(
-	ctx context.Context,
-	originStore *kvserver.Store,
-	originRepl *kvserver.Replica,
-	snapType kvserverpb.SnapshotRequest_Type,
+	ctx context.Context, originStore *kvserver.Store, originRepl *kvserver.Replica,
 ) (int64, error) {
 	snap, err := originRepl.GetSnapshot(ctx, uuid.MakeV4())
 	if err != nil {
@@ -2357,7 +2352,7 @@ func TestRebalancingAndCrossRegionZoneSnapshotMetrics(t *testing.T) {
 		// changeReplicaFn and the snapshot being sent.
 		<-blockUntilSnapshotSendCh
 		store, repl := getFirstStoreReplica(t, tc.Server(0), scratchStartKey)
-		snapshotLength, err := getExpectedSnapshotSizeBytes(ctx, store, repl, kvserverpb.SnapshotRequest_INITIAL)
+		snapshotLength, err := getExpectedSnapshotSizeBytes(ctx, store, repl)
 		require.NoError(t, err)
 
 		close(blockSnapshotSendCh)
@@ -2367,7 +2362,7 @@ func TestRebalancingAndCrossRegionZoneSnapshotMetrics(t *testing.T) {
 		return snapshotLength
 	}
 
-	metrics := []string{".rebalancing", ".recovery", ".unknown", ".cross-region", ".cross-zone", ""}
+	metrics := []string{".rebalancing", ".recovery", ".cross-region", ".cross-zone", ""}
 	// Record the snapshot metrics before anything has been sent / received.
 	senderBefore := getSnapshotBytesMetrics(t, tc, 0 /* serverIdx */, metrics)
 	firstReceiverBefore := getSnapshotBytesMetrics(t, tc, 1 /* serverIdx */, metrics)
@@ -2391,7 +2386,6 @@ func TestRebalancingAndCrossRegionZoneSnapshotMetrics(t *testing.T) {
 		senderExpected := map[string]snapshotBytesMetrics{
 			".rebalancing": {sentBytes: totalSnapshotLength, rcvdBytes: 0},
 			".recovery":    {sentBytes: 0, rcvdBytes: 0},
-			".unknown":     {sentBytes: 0, rcvdBytes: 0},
 			// The first snapshot was sent from server0 to server1, so it is
 			// cross-region.
 			".cross-region": {sentBytes: firstSnapshotLength, rcvdBytes: 0},
@@ -2411,7 +2405,6 @@ func TestRebalancingAndCrossRegionZoneSnapshotMetrics(t *testing.T) {
 		firstReceiverExpected := map[string]snapshotBytesMetrics{
 			".rebalancing": {sentBytes: 0, rcvdBytes: firstSnapshotLength},
 			".recovery":    {sentBytes: 0, rcvdBytes: 0},
-			".unknown":     {sentBytes: 0, rcvdBytes: 0},
 			// The first snapshot was sent from server0 to server1, so it is
 			// cross-region.
 			".cross-region": {sentBytes: 0, rcvdBytes: firstSnapshotLength},
@@ -2429,7 +2422,6 @@ func TestRebalancingAndCrossRegionZoneSnapshotMetrics(t *testing.T) {
 		secReceiverExpected := map[string]snapshotBytesMetrics{
 			".rebalancing": {sentBytes: 0, rcvdBytes: secSnapshotLength},
 			".recovery":    {sentBytes: 0, rcvdBytes: 0},
-			".unknown":     {sentBytes: 0, rcvdBytes: 0},
 			// The second snapshot was sent from server0 to server2, so it is
 			// cross-zone within same region.
 			".cross-region": {sentBytes: 0, rcvdBytes: 0},

--- a/pkg/kv/kvserver/replica_send.go
+++ b/pkg/kv/kvserver/replica_send.go
@@ -967,7 +967,7 @@ func (r *Replica) executeAdminBatch(
 
 	case *kvpb.AdminChangeReplicasRequest:
 		chgs := tArgs.Changes()
-		desc, err := r.ChangeReplicas(ctx, &tArgs.ExpDesc, kvserverpb.SnapshotRequest_REBALANCE, kvserverpb.ReasonAdminRequest, "", chgs)
+		desc, err := r.ChangeReplicas(ctx, &tArgs.ExpDesc, kvserverpb.ReasonAdminRequest, "", chgs)
 		pErr = kvpb.NewError(err)
 		if pErr != nil {
 			resp = &kvpb.AdminChangeReplicasResponse{}

--- a/pkg/kv/kvserver/replica_test.go
+++ b/pkg/kv/kvserver/replica_test.go
@@ -6772,7 +6772,6 @@ func TestChangeReplicasDuplicateError(t *testing.T) {
 			if _, err := tc.repl.ChangeReplicas(
 				context.Background(),
 				tc.repl.Desc(),
-				kvserverpb.SnapshotRequest_REBALANCE,
 				kvserverpb.ReasonRebalance,
 				"",
 				chgs,

--- a/pkg/kv/kvserver/replicate_queue.go
+++ b/pkg/kv/kvserver/replicate_queue.go
@@ -817,7 +817,6 @@ func (rq *replicateQueue) applyChange(
 			replica,
 			op.Chgs,
 			replica.Desc(),
-			op.Priority,
 			op.AllocatorPriority,
 			op.Reason,
 			op.Details,
@@ -1104,7 +1103,6 @@ func (rq *replicateQueue) changeReplicas(
 	repl *Replica,
 	chgs kvpb.ReplicationChanges,
 	desc *roachpb.RangeDescriptor,
-	priority kvserverpb.SnapshotRequest_Priority,
 	allocatorPriority float64,
 	reason kvserverpb.RangeLogEventReason,
 	details string,
@@ -1113,7 +1111,7 @@ func (rq *replicateQueue) changeReplicas(
 	// the latter traps tests that try to call it while the replication
 	// queue is active.
 	_, err := repl.changeReplicasImpl(
-		ctx, desc, priority, kvserverpb.SnapshotRequest_REPLICATE_QUEUE, allocatorPriority, reason,
+		ctx, desc, kvserverpb.SnapshotRequest_REPLICATE_QUEUE, allocatorPriority, reason,
 		details, chgs,
 	)
 	return err


### PR DESCRIPTION
This commit removes a number of unused fields in snapshot messages.

Release note: None
Epic: none