### PR TITLE
sql: fix virtual table generation in some cases

### DIFF
--- a/pkg/sql/virtual_table.go
+++ b/pkg/sql/virtual_table.go
@@ -125,11 +125,6 @@ func setupGenerator(
 			case <-comm:
 			}
 			err := worker(ctx, funcRowPusher(addRow))
-			// If the query was canceled, next() will already return a
-			// QueryCanceledError, so just exit here.
-			if errors.Is(err, cancelchecker.QueryCanceledError) {
-				return
-			}
 			// Notify that we are done sending rows.
 			select {
 			case <-ctx.Done():


### PR DESCRIPTION
This commit fixes a long-standing bug which could lead to the generation of the virtual table to hang indefinitely. The generation of a virtual table involves two goroutines:
- one is the reader goroutine that is performing the virtual table scan
- another is the "pusher" ("worker") goroutine that is populating the virtual table one row at a time and is pushing those rows to the reader.

We have tight synchronization between two goroutines so that at most one goroutine is active at any point in time (this is needed to prevent invalid concurrent usage of the txn). Previously, it was possible for the reader to be blocked forever. This was the case when the worker finishes by returning "QueryCanceledError" - in such a case the worker would exit without unblocking the reader. The assumption was that such an error was the result of the context cancellation (i.e. `ctx` in scope of the reader), but that is not necessarily true. For example, the same error could be returned when the node is quescing. There is really no reason for the worker to skip notifying the reader, and we will now just send all errors to the reader.

The bug has been present since the lazy virtual table generation was introduced in d1930c5ca0fd9e771e834536ebcd425b63581646, but it has been exposed in 5d9b97a67c6bade8bb5a921b7fb881ac44f11579. Perhaps the latter commit made it much more likely for the assumption mentioned in the paragraph above to be violated. In particular, we now are more likely to have multiple "nested" internally-executed queries that deal with virtual tables.

Fixes: #99753.

Release note (bug fix): Previously, queries reading from virtual tables (e.g. `crdb_internal.*` and `pg_catalog.*` tables) could hang indefinitely in some rare cases when they result in an error, and this is now fixed.