### PR TITLE
bors: update timeout to 40 minutes

### DIFF
--- a/.github/bors.toml
+++ b/.github/bors.toml
@@ -16,8 +16,8 @@ block_labels = ["do-not-merge"]
 # Number of seconds from when a merge commit is created to when its statuses
 # must pass.
 #
-# Set to 4 hours
-timeout_sec = 14400
+# Set to 40 minutes
+timeout_sec = 2400
 required_approvals = 1
 
 [committer]


### PR DESCRIPTION
This change updates `bors` timeout from 4 hours to 40 minutes. It ensures that TC runs on staging keep running so that they timeout and we see which tests timed out for future investigation but at the same time doesn't block bors on runs that are clearly going to time out.

Release note: None
Epic: none