### PR TITLE
acceptance: ensure `go test` timeout is less than `bazel` timeout

### DIFF
--- a/pkg/acceptance/BUILD.bazel
+++ b/pkg/acceptance/BUILD.bazel
@@ -42,7 +42,8 @@ go_test(
         "debug_remote_test.go",
         "main_test.go",
     ],
-    args = ["-test.timeout=3595s"],
+    # Note: we overide bazel timeout to 1800s using test_timeout.
+    args = ["-test.timeout=1795s"],
     data = glob([
         "testdata/**",
         "compose/**",

--- a/pkg/cmd/generate-bazel-extra/main.go
+++ b/pkg/cmd/generate-bazel-extra/main.go
@@ -315,6 +315,8 @@ func excludeReallyEnormousTargets(targets []string) []string {
 		for _, toExclude := range []string{
 			"//pkg/ccl/sqlitelogictestccl",
 			"//pkg/sql/sqlitelogictest",
+			// acceptance is excluded because it's an integration test.
+			"//pkg/acceptance",
 		} {
 			if strings.HasPrefix(targets[i], toExclude) {
 				excluded = true


### PR DESCRIPTION
Release note: None
Epic: none