### PR TITLE
cloud: add optional connection timeout retries

### DIFF
--- a/pkg/cloud/gcp/gcs_storage.go
+++ b/pkg/cloud/gcp/gcs_storage.go
@@ -292,7 +292,8 @@ func (g *gcsStorage) ReadFileAt(
 		}, // opener
 		nil, //  reader
 		offset,
-		cloud.IsResumableHTTPError,
+		object,
+		cloud.ResumingReaderRetryOnErrFnForSettings(ctx, g.settings),
 		nil, // errFn
 	)
 

--- a/pkg/cloud/httpsink/http_storage.go
+++ b/pkg/cloud/httpsink/http_storage.go
@@ -168,8 +168,8 @@ func (h *httpStorage) ReadFileAt(
 			}
 			return s.Body, err
 		}
-		return cloud.NewResumingReader(ctx, opener, stream.Body, offset,
-			cloud.IsResumableHTTPError, nil), size, nil
+		return cloud.NewResumingReader(ctx, opener, stream.Body, offset, basename,
+			cloud.ResumingReaderRetryOnErrFnForSettings(ctx, h.settings), nil), size, nil
 	}
 	return ioctx.ReadCloserAdapter(stream.Body), size, nil
 }

--- a/pkg/util/sysutil/sysutil.go
+++ b/pkg/util/sysutil/sysutil.go
@@ -71,6 +71,11 @@ func IsErrConnectionRefused(err error) bool {
 	return errors.Is(err, syscall.ECONNREFUSED)
 }
 
+// IsErrTimedOut returns true if an error is an ETIMEDOUT error.
+func IsErrTimedOut(err error) bool {
+	return errors.Is(err, syscall.ETIMEDOUT)
+}
+
 // InterruptSelf sends Interrupt to the process itself.
 func InterruptSelf() error {
 	pr, err := os.FindProcess(os.Getpid())


### PR DESCRIPTION
This optionally adds connection timeout errors to the set of errors to retry in the resuming reader. Additionally, it adds the file name to error messages returned by the resuming reader.

We test for ETIMEDOUT. Linux returns ETIMEDOUT in cases where the remote end of a connection fails to acknowledge a configured number of TCP Keep-Alive messages.

This shouldn't catch timeouts that are the result of IO deadlines or context cancellations. But, just in case we've put this behind a cluster setting to avoid changing behaviour.

Epic: none

Release note: None