### PR TITLE
server: ignore spanconfig limit for shared-process tenants

### DIFF
--- a/pkg/ccl/serverccl/BUILD.bazel
+++ b/pkg/ccl/serverccl/BUILD.bazel
@@ -40,6 +40,7 @@ go_test(
         "server_controller_test.go",
         "server_sql_test.go",
         "server_startup_guardrails_test.go",
+        "shared_process_tenant_test.go",
         "tenant_decommissioned_host_test.go",
         "tenant_migration_test.go",
         "tenant_vars_test.go",

--- a/pkg/ccl/serverccl/shared_process_tenant_test.go
+++ b/pkg/ccl/serverccl/shared_process_tenant_test.go
@@ -1,0 +1,61 @@
+// Copyright 2023 The Cockroach Authors.
+//
+// Licensed as a CockroachDB Enterprise file under the Cockroach Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//     https://github.com/cockroachdb/cockroach/blob/master/licenses/CCL.txt
+
+package serverccl
+
+import (
+	"context"
+	gosql "database/sql"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/testutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSharedProcessTenantNoSpanLimit(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+
+	tc := serverutils.StartNewTestCluster(t, 1, base.TestClusterArgs{
+		ServerArgs: base.TestServerArgs{
+			DisableDefaultTestTenant: true,
+		}})
+	defer tc.Stopper().Stop(ctx)
+
+	db := tc.ServerConn(0)
+	_, err := db.Exec("CREATE TENANT hello; ALTER TENANT hello START SERVICE SHARED")
+	require.NoError(t, err)
+
+	_, err = db.Exec("ALTER TENANT ALL SET CLUSTER SETTING spanconfig.tenant_limit = 1000")
+	require.NoError(t, err)
+
+	sqlAddr := tc.Server(0).ServingSQLAddr()
+	var tenantDB *gosql.DB
+	testutils.SucceedsSoon(t, func() error {
+		var err error
+		tenantDB, err = serverutils.OpenDBConnE(sqlAddr, "cluster:hello", false, tc.Stopper())
+		if err != nil {
+			return err
+		}
+
+		if err := tenantDB.Ping(); err != nil {
+			return err
+		}
+		return nil
+	})
+	defer tenantDB.Close()
+
+	_, err = tenantDB.Exec("SELECT crdb_internal.generate_test_objects('foo', 1001)")
+	require.NoError(t, err)
+}


### PR DESCRIPTION
This change installs a noop spanconfig limiter when starting shared-process tenants.  Since shared-process tenants are currently used for "unified architecture" in which the tenant is expected to behave as close as possible to the system tenant.

When we have a tenant-side capabilities reader, we should tie this to a capability instead.

This has an unfortunate side-effect of making any tenant-level override for the span limit a lie for shared-process tenants.

Fixes #93562. 
Fixes #93561.

Release note: None