### PR TITLE
release-23.1: changefeedccl: add execution_locality option

### DIFF
--- a/pkg/ccl/changefeedccl/BUILD.bazel
+++ b/pkg/ccl/changefeedccl/BUILD.bazel
@@ -133,6 +133,7 @@ go_library(
         "//pkg/util/metric/aggmetric",
         "//pkg/util/mon",
         "//pkg/util/protoutil",
+        "//pkg/util/randutil",
         "//pkg/util/retry",
         "//pkg/util/span",
         "//pkg/util/syncutil",

--- a/pkg/ccl/changefeedccl/changefeed_stmt.go
+++ b/pkg/ccl/changefeedccl/changefeed_stmt.go
@@ -30,6 +30,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/protectedts"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/protectedts/ptpb"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/server/status"
 	"github.com/cockroachdb/cockroach/pkg/server/telemetry"
 	"github.com/cockroachdb/cockroach/pkg/settings"
@@ -51,6 +52,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/log/eventpb"
+	"github.com/cockroachdb/cockroach/pkg/util/randutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
@@ -665,6 +667,23 @@ func createChangefeedJobRecord(
 	}
 	details.Opts = opts.AsMap()
 
+	if locFilter := details.Opts[changefeedbase.OptExecutionLocality]; locFilter != "" {
+		if !p.ExecCfg().Settings.Version.IsActive(ctx, clusterversion.V23_1) {
+			return nil, pgerror.Newf(
+				pgcode.FeatureNotSupported,
+				"cannot create new changefeed with %s until upgrade to version %s is complete",
+				changefeedbase.OptExecutionLocality, clusterversion.V23_1.String(),
+			)
+		}
+		var executionLocality roachpb.Locality
+		if err := executionLocality.Set(locFilter); err != nil {
+			return nil, err
+		}
+		if _, err := p.DistSQLPlanner().GetAllInstancesByLocality(ctx, executionLocality); err != nil {
+			return nil, err
+		}
+	}
+
 	ptsExpiration, err := opts.GetPTSExpiration()
 	if err != nil {
 		return nil, err
@@ -1049,12 +1068,54 @@ func (b *changefeedResumer) Resume(ctx context.Context, execCtx interface{}) err
 	return nil
 }
 
+// TODO(dt): remove this copy pasta from backupResumer in favor of a shared func
+// somewhere in pkg/jobs or the job registry.
+func (b *changefeedResumer) maybeRelocateJobExecution(
+	ctx context.Context, p sql.JobExecContext, locality roachpb.Locality,
+) error {
+	if locality.NonEmpty() {
+		current, err := p.DistSQLPlanner().GetSQLInstanceInfo(p.ExecCfg().JobRegistry.ID())
+		if err != nil {
+			return err
+		}
+		if ok, missedTier := current.Locality.Matches(locality); !ok {
+			log.Infof(ctx,
+				"CHANGEFEED job %d initially adopted on instance %d but it does not match locality filter %s, finding a new coordinator",
+				b.job.ID(), current.NodeID, missedTier.String(),
+			)
+
+			instancesInRegion, err := p.DistSQLPlanner().GetAllInstancesByLocality(ctx, locality)
+			if err != nil {
+				return err
+			}
+			rng, _ := randutil.NewPseudoRand()
+			dest := instancesInRegion[rng.Intn(len(instancesInRegion))]
+
+			var res error
+			if err := p.ExecCfg().InternalDB.Txn(ctx, func(ctx context.Context, txn isql.Txn) error {
+				var err error
+				res, err = p.ExecCfg().JobRegistry.RelocateLease(ctx, txn, b.job.ID(), dest.InstanceID, dest.SessionID)
+				return err
+			}); err != nil {
+				return errors.Wrapf(err, "failed to relocate job coordinator to %d", dest.InstanceID)
+			}
+			return res
+		}
+	}
+	return nil
+}
+
 func (b *changefeedResumer) handleChangefeedError(
 	ctx context.Context,
 	changefeedErr error,
 	details jobspb.ChangefeedDetails,
 	jobExec sql.JobExecContext,
 ) error {
+	// Execution relocation errors just get returned immediately, as they indicate
+	// another node has taken over execution and this execution should end now.
+	if jobs.IsLeaseRelocationError(changefeedErr) {
+		return changefeedErr
+	}
 	opts := changefeedbase.MakeStatementOptions(details.Opts)
 	onError, errErr := opts.GetOnError()
 	if errErr != nil {
@@ -1097,6 +1158,19 @@ func (b *changefeedResumer) resumeWithRetries(
 	progress jobspb.Progress,
 	execCfg *sql.ExecutorConfig,
 ) error {
+	// If execution needs to be and is relocated, the resulting error should be
+	// returned without retry, as it indicates _this_ execution should cease now
+	// that execution is elsewhere, so check this before the retry loop.
+	if filter := details.Opts[changefeedbase.OptExecutionLocality]; filter != "" {
+		var loc roachpb.Locality
+		if err := loc.Set(filter); err != nil {
+			return err
+		}
+		if err := b.maybeRelocateJobExecution(ctx, jobExec, loc); err != nil {
+			return err
+		}
+	}
+
 	// We'd like to avoid failing a changefeed unnecessarily, so when an error
 	// bubbles up to this level, we'd like to "retry" the flow if possible. This
 	// could be because the sink is down or because a cockroach node has crashed

--- a/pkg/ccl/changefeedccl/changefeedbase/options.go
+++ b/pkg/ccl/changefeedccl/changefeedbase/options.go
@@ -100,6 +100,7 @@ const (
 	OptMetricsScope             = `metrics_label`
 	OptUnordered                = `unordered`
 	OptVirtualColumns           = `virtual_columns`
+	OptExecutionLocality        = `execution_locality`
 
 	OptVirtualColumnsOmitted VirtualColumnVisibility = `omitted`
 	OptVirtualColumnsNull    VirtualColumnVisibility = `null`
@@ -339,6 +340,7 @@ var ChangefeedOptionExpectValues = map[string]OptionPermittedValues{
 	OptMetricsScope:             stringOption,
 	OptUnordered:                flagOption,
 	OptVirtualColumns:           enum("omitted", "null"),
+	OptExecutionLocality:        stringOption,
 }
 
 // CommonOptions is options common to all sinks
@@ -350,7 +352,9 @@ var CommonOptions = makeStringSet(OptCursor, OptEndTime, OptEnvelope,
 	OptSchemaChangeEvents, OptSchemaChangePolicy,
 	OptProtectDataFromGCOnPause, OptOnError,
 	OptInitialScan, OptNoInitialScan, OptInitialScanOnly, OptUnordered, OptCustomKeyColumn,
-	OptMinCheckpointFrequency, OptMetricsScope, OptVirtualColumns, Topics, OptExpirePTSAfter)
+	OptMinCheckpointFrequency, OptMetricsScope, OptVirtualColumns, Topics, OptExpirePTSAfter,
+	OptExecutionLocality,
+)
 
 // SQLValidOptions is options exclusive to SQL sink
 var SQLValidOptions map[string]struct{} = nil

--- a/pkg/jobs/registry.go
+++ b/pkg/jobs/registry.go
@@ -1549,7 +1549,7 @@ func (r *Registry) stepThroughStateMachine(
 			jm.ResumeRetryError.Inc(1)
 			return errors.Errorf("job %d: node liveness error: restarting in background", job.ID())
 		}
-		if errors.Is(err, errJobLeaseNotHeld) {
+		if IsLeaseRelocationError(err) {
 			return err
 		}
 
@@ -1868,6 +1868,11 @@ func (r *Registry) RelocateLease(
 	}
 
 	return errors.Mark(errors.Newf("execution of job %d relocated to %d", id, destID), errJobLeaseNotHeld), nil
+}
+
+// IsLeaseRelocationError returns true if the error indicates lease relocation.
+func IsLeaseRelocationError(err error) bool {
+	return errors.Is(err, errJobLeaseNotHeld)
 }
 
 // IsDraining returns true if the job system has been informed that


### PR DESCRIPTION
Backport 1/1 commits from #99358.

/cc @cockroachdb/release

---

Release note (enterprise change): CREATE CHANGEFEED now accepts an 'execution_locality' option to restrict execution of the changefeed to nodes within the specified locality filter.
Release justification: customer requested functionality; disabled by default.

Epic: CRDB-21737.
Fixes #84969
