### PR TITLE
server: clean up sql session and instance on shutdown

### DIFF
--- a/pkg/server/BUILD.bazel
+++ b/pkg/server/BUILD.bazel
@@ -445,6 +445,7 @@ go_test(
         "//pkg/base",
         "//pkg/base/serverident",
         "//pkg/build",
+        "//pkg/ccl/kvccl/kvtenantccl",
         "//pkg/cli/exit",
         "//pkg/clusterversion",
         "//pkg/config",

--- a/pkg/server/drain.go
+++ b/pkg/server/drain.go
@@ -401,8 +401,16 @@ func (s *drainServer) drainClients(
 	// errors/warnings, if any.
 	log.Infof(ctx, "SQL server drained successfully; SQL queries cannot execute any more")
 
-	// FIXME(Jeff): Add code here to remove the sql_instances row or
-	// something similar.
+	session, err := s.sqlServer.sqlLivenessProvider.Release(ctx)
+	if err != nil {
+		return err
+	}
+
+	instanceID := s.sqlServer.sqlIDContainer.SQLInstanceID()
+	err = s.sqlServer.sqlInstanceStorage.ReleaseInstance(ctx, session, instanceID)
+	if err != nil {
+		return err
+	}
 
 	// Mark the node as fully drained.
 	s.sqlServer.gracefulDrainComplete.Set(true)

--- a/pkg/sql/sqlinstance/instancestorage/instancereader_test.go
+++ b/pkg/sql/sqlinstance/instancestorage/instancereader_test.go
@@ -22,7 +22,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/server/settingswatcher"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/desctestutils"
-	"github.com/cockroachdb/cockroach/pkg/sql/enum"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlinstance"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlinstance/instancestorage"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlliveness"
@@ -145,7 +144,6 @@ func TestReader(t *testing.T) {
 		require.NoError(t, reader.WaitForStarted(ctx))
 
 		// Set up expected test data.
-		region := enum.One
 		instanceIDs := []base.SQLInstanceID{1, 2, 3}
 		rpcAddresses := []string{"addr1", "addr2", "addr3"}
 		sqlAddresses := []string{"addr4", "addr5", "addr6"}
@@ -259,7 +257,7 @@ func TestReader(t *testing.T) {
 
 		// Release an instance and verify only active instances are returned.
 		{
-			err := storage.ReleaseInstanceID(ctx, region, instanceIDs[0])
+			err := storage.ReleaseInstance(ctx, sessionIDs[0], instanceIDs[0])
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -314,7 +312,6 @@ func TestReader(t *testing.T) {
 		reader.Start(ctx, sqlinstance.InstanceInfo{})
 		require.NoError(t, reader.WaitForStarted(ctx))
 		// Create three instances and release one.
-		region := enum.One
 		instanceIDs := [...]base.SQLInstanceID{1, 2, 3}
 		rpcAddresses := [...]string{"addr1", "addr2", "addr3"}
 		sqlAddresses := [...]string{"addr4", "addr5", "addr6"}
@@ -367,7 +364,7 @@ func TestReader(t *testing.T) {
 
 		// Verify request for released instance data results in an error.
 		{
-			err := storage.ReleaseInstanceID(ctx, region, instanceIDs[0])
+			err := storage.ReleaseInstance(ctx, sessionIDs[0], instanceIDs[0])
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/sql/sqlliveness/slinstance/BUILD.bazel
+++ b/pkg/sql/sqlliveness/slinstance/BUILD.bazel
@@ -37,11 +37,13 @@ go_test(
         "//pkg/sql/enum",
         "//pkg/sql/sqlliveness",
         "//pkg/sql/sqlliveness/slstorage",
+        "//pkg/testutils",
         "//pkg/util/hlc",
         "//pkg/util/leaktest",
         "//pkg/util/log",
         "//pkg/util/stop",
         "//pkg/util/timeutil",
+        "@com_github_cockroachdb_errors//:errors",
         "@com_github_stretchr_testify//require",
     ],
 )

--- a/pkg/sql/sqlliveness/slinstance/slinstance.go
+++ b/pkg/sql/sqlliveness/slinstance/slinstance.go
@@ -16,6 +16,7 @@ package slinstance
 
 import (
 	"context"
+	"sync"
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/settings"
@@ -62,6 +63,8 @@ type Writer interface {
 	// the storage and if found replaces it with the input returning true.
 	// Otherwise it returns false to indicate that the session does not exist.
 	Update(ctx context.Context, id sqlliveness.SessionID, expiration hlc.Timestamp) (bool, error)
+	// Delete removes the session from the sqlliveness table.
+	Delete(ctx context.Context, id sqlliveness.SessionID) error
 }
 
 type session struct {
@@ -126,7 +129,16 @@ type Instance struct {
 	ttl           func() time.Duration
 	hb            func() time.Duration
 	testKnobs     sqlliveness.TestingKnobs
-	mu            struct {
+
+	// drainOnce and drain are used to signal the shutdown of the heartbeat
+	// loop.
+	drainOnce sync.Once
+	drain     chan struct{}
+
+	// wait tracks the life of the heartbeat goroutine.
+	wait sync.WaitGroup
+
+	mu struct {
 		syncutil.Mutex
 		// stopErr, if set, indicates that the heartbeat loop has stopped because of
 		// this error. Calls to Session() will return this error.
@@ -295,17 +307,26 @@ func (l *Instance) heartbeatLoop(ctx context.Context) {
 		log.Fatal(ctx, "expected heartbeat to always terminate with an error")
 	}
 
-	log.Warning(ctx, "exiting heartbeat loop")
-
 	// Keep track of the fact that this Instance is not usable anymore. Further
 	// Session() calls will return errors.
 	l.mu.Lock()
 	defer l.mu.Unlock()
-	if l.mu.s != nil {
-		_ = l.clearSessionLocked(ctx)
-	}
+
 	l.mu.stopErr = err
-	close(l.mu.blockCh)
+
+	select {
+	case <-l.drain:
+		log.Infof(ctx, "draining heartbeat loop")
+	default:
+		log.Warningf(ctx, "exiting heartbeat loop with error: %v", l.mu.stopErr)
+		if l.mu.s != nil {
+			_ = l.clearSessionLocked(ctx)
+		}
+		// clearSessionLocked allocates a new l.mu.blockCh. Close blockCh so
+		// that callers do not get stuck waiting for a session and observe the
+		// stopErr.
+		close(l.mu.blockCh)
+	}
 }
 
 func (l *Instance) heartbeatLoopInner(ctx context.Context) error {
@@ -322,6 +343,8 @@ func (l *Instance) heartbeatLoopInner(ctx context.Context) error {
 	t.Reset(0)
 	for {
 		select {
+		case <-l.drain:
+			return stop.ErrUnavailable
 		case <-ctx.Done():
 			return stop.ErrUnavailable
 		case <-t.C:
@@ -395,6 +418,7 @@ func NewSQLInstance(
 		hb: func() time.Duration {
 			return DefaultHeartBeat.Get(&settings.SV)
 		},
+		drain: make(chan struct{}),
 	}
 	if testKnobs != nil {
 		l.testKnobs = *testKnobs
@@ -411,7 +435,36 @@ func (l *Instance) Start(ctx context.Context, regionPhysicalRep []byte) {
 	// Detach from ctx's cancelation.
 	taskCtx := l.AnnotateCtx(context.Background())
 	taskCtx = logtags.WithTags(taskCtx, logtags.FromContext(ctx))
-	_ = l.stopper.RunAsyncTask(taskCtx, "slinstance", l.heartbeatLoop)
+
+	l.wait.Add(1)
+	err := l.stopper.RunAsyncTask(taskCtx, "slinstance", func(ctx context.Context) {
+		defer l.wait.Done()
+		l.heartbeatLoop(ctx)
+	})
+	if err != nil {
+		l.wait.Done()
+	}
+}
+
+func (l *Instance) Release(ctx context.Context) (sqlliveness.SessionID, error) {
+	l.drainOnce.Do(func() { close(l.drain) })
+	l.wait.Wait()
+
+	session := func() *session {
+		l.mu.Lock()
+		defer l.mu.Unlock()
+		return l.mu.s
+	}()
+
+	if session == nil {
+		return sqlliveness.SessionID(""), errors.New("no session to release")
+	}
+
+	if err := l.storage.Delete(ctx, session.ID()); err != nil {
+		return sqlliveness.SessionID(""), err
+	}
+
+	return session.ID(), nil
 }
 
 // Session returns a live session id. For each Sqlliveness instance the

--- a/pkg/sql/sqlliveness/slinstance/slinstance_test.go
+++ b/pkg/sql/sqlliveness/slinstance/slinstance_test.go
@@ -21,11 +21,13 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlliveness"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlliveness/slinstance"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlliveness/slstorage"
+	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/require"
 )
 
@@ -99,7 +101,7 @@ func TestSQLInstance(t *testing.T) {
 	require.Error(t, err)
 }
 
-func TestSQLInstanceWithRegion(t *testing.T) {
+func TestSQLInstanceRelease(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
@@ -117,16 +119,38 @@ func TestSQLInstanceWithRegion(t *testing.T) {
 	fakeStorage := slstorage.NewFakeStorage()
 	var ambientCtx log.AmbientContext
 	sqlInstance := slinstance.NewSQLInstance(ambientCtx, stopper, clock, fakeStorage, settings, nil, nil)
-	sqlInstance.Start(ctx, []byte{42})
+	sqlInstance.Start(ctx, enum.One)
 
-	s1, err := sqlInstance.Session(ctx)
+	activeSession, err := sqlInstance.Session(ctx)
 	require.NoError(t, err)
-	a, err := fakeStorage.IsAlive(ctx, s1.ID())
+	activeSessionID := activeSession.ID()
+
+	a, err := fakeStorage.IsAlive(ctx, activeSessionID)
 	require.NoError(t, err)
 	require.True(t, a)
 
-	region, id, err := slstorage.UnsafeDecodeSessionID(s1.ID())
-	require.NoError(t, err)
-	require.Equal(t, []byte{42}, region)
-	require.NotNil(t, id)
+	require.NotEqual(t, 0, stopper.NumTasks())
+
+	// Make sure release is idempotent.
+	for i := 0; i < 5; i++ {
+		finalSession, err := sqlInstance.Release(ctx)
+		require.NoError(t, err)
+
+		// Release should always return the last active session.
+		require.Equal(t, activeSessionID, finalSession)
+
+		// Release should tear down the background heartbeat.
+		testutils.SucceedsSoon(t, func() error {
+			tasks := stopper.NumTasks()
+			if tasks != 0 {
+				return errors.Newf("expected zero runnings tasks, found: %d", tasks)
+			}
+			return nil
+		})
+
+		// Once the instance is shut down, it should return an error instead of
+		// the session.
+		_, err = sqlInstance.Session(ctx)
+		require.ErrorIs(t, err, stop.ErrUnavailable)
+	}
 }

--- a/pkg/sql/sqlliveness/slstorage/slstorage_test.go
+++ b/pkg/sql/sqlliveness/slstorage/slstorage_test.go
@@ -720,13 +720,16 @@ func TestDeleteMidUpdateFails(t *testing.T) {
 	unblock := <-getChan
 
 	// Delete the session being updated.
-	tdb.Exec(t, `DELETE FROM "`+t.Name()+`".sqlliveness WHERE true`)
+	require.NoError(t, storage.Delete(ctx, ID))
 
 	// Unblock the update and ensure that it saw that its session was deleted.
 	close(unblock)
 	res := <-resCh
 	require.False(t, res.exists)
 	require.NoError(t, res.err)
+
+	// Ensure delete is idempotent
+	require.NoError(t, storage.Delete(ctx, ID))
 }
 
 func newSqllivenessTable(

--- a/pkg/sql/sqlliveness/sqlliveness.go
+++ b/pkg/sql/sqlliveness/sqlliveness.go
@@ -39,8 +39,14 @@ type Provider interface {
 
 	// Start starts the sqlliveness subsystem. regionPhysicalRep should
 	// represent the physical representation of the current process region
-	// stored in the multi-region enum type associated with the system database.
+	// stored in the multi-region enum type associated with the system
+	// database.
 	Start(ctx context.Context, regionPhysicalRep []byte)
+
+	// Release delete's the sqlliveness session managed by the provider. This
+	// should be called near the end of the drain process, after the server has
+	// no running tasks that depend on the session.
+	Release(ctx context.Context) (SessionID, error)
 
 	// Metrics returns a metric.Struct which holds metrics for the provider.
 	Metrics() metric.Struct


### PR DESCRIPTION
Remove the sql server's system.sql_instance and sqlliveness.sqlliveness
rows on sql server shut down. The original motivation for this change is
it improves the behavior of DistSQL for serverless tenants. SQL servers
would attempt to schedule DistSQL flows on sql_instance rows that
belonged to shutdown servers.

Cleaning up the session and instance have a hand full of small benefits.
- The sql_instances pre-allocated in a region are less likely to run out
  and trigger the slow cold start path.
- Resources leased by the session, like jobs, may be re-claimed more
  quickly after the server shuts down.

Fixes: CC-9095

Release note: none