### PR TITLE
bench: fix brokenness in the InsertDistinct SQL benchmark

### DIFF
--- a/pkg/bench/BUILD.bazel
+++ b/pkg/bench/BUILD.bazel
@@ -59,6 +59,7 @@ go_test(
         "//pkg/util/retry",
         "//pkg/util/stop",
         "//pkg/util/tracing",
+        "@com_github_cockroachdb_errors//:errors",
         "@com_github_go_sql_driver_mysql//:mysql",
         "@com_github_lib_pq//:pq",
         "@com_github_stretchr_testify//require",


### PR DESCRIPTION
The test was leaking goroutines upon errors. This change fixes it.

Release note: None
Epic: CRDB-23559