### PR TITLE
ui: small fixes to DB Console charts shown for secondary tenants

### DIFF
--- a/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/overview.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/overview.tsx
@@ -135,7 +135,7 @@ export default function (props: GraphDashboardProps) {
 
     <LineGraph
       title="Capacity"
-      isKvGraph={false}
+      isKvGraph={true}
       sources={storeSources}
       tooltip={<CapacityGraphTooltip tooltipSelection={tooltipSelection} />}
       preCalcGraphSize={true}

--- a/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/sql.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/sql.tsx
@@ -331,7 +331,7 @@ export default function (props: GraphDashboardProps) {
 
     <LineGraph
       title="KV Execution Latency: 99th percentile"
-      isKvGraph={false}
+      isKvGraph={true}
       tooltip={`The 99th percentile of latency between query requests and responses over a
           1 minute period. Values are displayed individually for each node.`}
     >
@@ -350,7 +350,7 @@ export default function (props: GraphDashboardProps) {
 
     <LineGraph
       title="KV Execution Latency: 90th percentile"
-      isKvGraph={false}
+      isKvGraph={true}
       tooltip={`The 90th percentile of latency between query requests and responses over a
            1 minute period. Values are displayed individually for each node.`}
     >

--- a/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/storage.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/storage.tsx
@@ -53,6 +53,7 @@ export default function (props: GraphDashboardProps) {
 
     <LineGraph
       title="Live Bytes"
+      isKvGraph={false}
       sources={storeSources}
       tooltip={<LiveBytesGraphTooltip tooltipSelection={tooltipSelection} />}
     >

--- a/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/index.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/index.tsx
@@ -115,7 +115,7 @@ const dashboards: { [key: string]: GraphDashboard } = {
   storage: {
     label: "Storage",
     component: storageDashboard,
-    isKvDashboard: true,
+    isKvDashboard: false,
   },
   replication: {
     label: "Replication",


### PR DESCRIPTION
https://github.com/cockroachdb/cockroach/pull/97995 updated the
DB Console to filter out KV-specific charts from the metrics page
when viewing DB Console as a secondary application tenant.

The PR missed a couple small details. This patch cleans those
up with the following:

- Removes KV latency charts for app tenants
- Adds a single storage graph for app tenants showing livebytes
- Removes the "Capacity" chart on the Overview dashboard for app
  tenants

Release note: none

Epic: https://cockroachlabs.atlassian.net/browse/CRDB-12100

NB: Please only review the final commit. 1st commit is being reviewed separately @ https://github.com/cockroachdb/cockroach/pull/99860