### PR TITLE
c2c: add node shutdown roachtests

### DIFF
--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -2421,6 +2421,10 @@ func (c *clusterImpl) Extend(ctx context.Context, d time.Duration, l *logger.Log
 	return nil
 }
 
+// NewMonitor creates a monitor that can watch for unexpected crdb node deaths on m.Wait()
+// and provide roachtest safe goroutines.
+//
+// As a general rule, if the user has a workload node, do not monitor it.
 func (c *clusterImpl) NewMonitor(ctx context.Context, opts ...option.Option) cluster.Monitor {
 	return newMonitor(ctx, c.t, c, opts...)
 }

--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -2424,7 +2424,9 @@ func (c *clusterImpl) Extend(ctx context.Context, d time.Duration, l *logger.Log
 // NewMonitor creates a monitor that can watch for unexpected crdb node deaths on m.Wait()
 // and provide roachtest safe goroutines.
 //
-// As a general rule, if the user has a workload node, do not monitor it.
+// As a general rule, if the user has a workload node, do not monitor it. A
+// monitor's semantics around handling expected node deaths breaks down if it's
+// monitoring a workload node.
 func (c *clusterImpl) NewMonitor(ctx context.Context, opts ...option.Option) cluster.Monitor {
 	return newMonitor(ctx, c.t, c, opts...)
 }

--- a/pkg/cmd/roachtest/tests/cluster_to_cluster.go
+++ b/pkg/cmd/roachtest/tests/cluster_to_cluster.go
@@ -638,7 +638,6 @@ func c2cRegisterWrapper(
 ) {
 
 	clusterOps := make([]spec.Option, 0)
-	clusterOps = append(clusterOps, spec.CPU(sp.cpus))
 	if sp.cpus != 0 {
 		clusterOps = append(clusterOps, spec.CPU(sp.cpus))
 	}

--- a/pkg/cmd/roachtest/tests/jobs.go
+++ b/pkg/cmd/roachtest/tests/jobs.go
@@ -19,7 +19,10 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/test"
 	"github.com/cockroachdb/cockroach/pkg/jobs"
+	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/install"
+	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
+	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/errors"
@@ -44,18 +47,35 @@ type jobStarter func(c cluster.Cluster, t test.Test) (string, error)
 func jobSurvivesNodeShutdown(
 	ctx context.Context, t test.Test, c cluster.Cluster, nodeToShutdown int, startJob jobStarter,
 ) {
-	watcherNode := 1 + (nodeToShutdown)%c.Spec().NodeCount
-	target := c.Node(nodeToShutdown)
+	cfg := nodeShutdownConfig{
+		shutdownNode: nodeToShutdown,
+		watcherNode:  1 + (nodeToShutdown)%c.Spec().NodeCount,
+		crdbNodes:    c.All(),
+	}
+	executeNodeShutdown(ctx, t, c, cfg, startJob)
+}
+
+type nodeShutdownConfig struct {
+	shutdownNode    int
+	watcherNode     int
+	crdbNodes       option.NodeListOption
+	restartSettings []install.ClusterSettingOption
+}
+
+func executeNodeShutdown(
+	ctx context.Context, t test.Test, c cluster.Cluster, cfg nodeShutdownConfig, startJob jobStarter,
+) {
+	target := c.Node(cfg.shutdownNode)
 	t.L().Printf("test has chosen shutdown target node %d, and watcher node %d",
-		nodeToShutdown, watcherNode)
+		cfg.shutdownNode, cfg.watcherNode)
 
 	jobIDCh := make(chan string, 1)
 
-	m := c.NewMonitor(ctx)
+	m := c.NewMonitor(ctx, cfg.crdbNodes)
 	m.Go(func(ctx context.Context) error {
 		defer close(jobIDCh)
 
-		watcherDB := c.Conn(ctx, t.L(), watcherNode)
+		watcherDB := c.Conn(ctx, t.L(), cfg.watcherNode)
 		defer watcherDB.Close()
 
 		// Wait for 3x replication to ensure that the cluster
@@ -110,7 +130,7 @@ func jobSurvivesNodeShutdown(
 		}
 
 		// Check once a second to see if the job has started running.
-		watcherDB := c.Conn(ctx, t.L(), watcherNode)
+		watcherDB := c.Conn(ctx, t.L(), cfg.watcherNode)
 		defer watcherDB.Close()
 		timeToWait := time.Second
 		timer := timeutil.Timer{}
@@ -153,7 +173,7 @@ func jobSurvivesNodeShutdown(
 			}
 		} else {
 			t.L().Printf(`stopping node gracefully %s`, target)
-			if err := c.StopCockroachGracefullyOnNode(ctx, t.L(), nodeToShutdown); err != nil {
+			if err := c.StopCockroachGracefullyOnNode(ctx, t.L(), cfg.shutdownNode); err != nil {
 				return errors.Wrapf(err, "could not stop node %s", target)
 			}
 		}
@@ -168,7 +188,20 @@ func jobSurvivesNodeShutdown(
 	// NB: the roachtest harness checks that at the end of the test, all nodes
 	// that have data also have a running process.
 	t.Status(fmt.Sprintf("restarting %s (node restart test is done)\n", target))
-	if err := c.StartE(ctx, t.L(), option.DefaultStartOpts(), install.MakeClusterSettings(), target); err != nil {
+	// Don't begin another backup schedule, as the parent test driver has already
+	// set or disallowed the automatic backup schedule.
+	if err := c.StartE(ctx, t.L(), option.DefaultStartOptsNoBackups(),
+		install.MakeClusterSettings(cfg.restartSettings...), target); err != nil {
 		t.Fatal(errors.Wrapf(err, "could not restart node %s", target))
 	}
+}
+
+func getJobProgress(t test.Test, db *sqlutils.SQLRunner, jobID jobspb.JobID) *jobspb.Progress {
+	ret := &jobspb.Progress{}
+	var buf []byte
+	db.QueryRow(t, `SELECT progress FROM crdb_internal.system_jobs WHERE id = $1`, jobID).Scan(&buf)
+	if err := protoutil.Unmarshal(buf, ret); err != nil {
+		t.Fatal(err)
+	}
+	return ret
 }

--- a/pkg/cmd/roachtest/tests/registry.go
+++ b/pkg/cmd/roachtest/tests/registry.go
@@ -34,6 +34,7 @@ func RegisterTests(r registry.Registry) {
 	registerClockJumpTests(r)
 	registerClockMonotonicTests(r)
 	registerClusterToCluster(r)
+	registerClusterReplicationResilience(r)
 	registerConnectionLatencyTest(r)
 	registerCopy(r)
 	registerCopyFrom(r)


### PR DESCRIPTION
This patch adds a set of tests that assert the replication jobs persist during a node shutdown event on either the source or destination cluster and on either the coordinator or worker node. The shutdown is currently configured to run during the steady state of the replication job. A future patch will change these tests to randomly shutdown during the initial scan, steady state, or cutover phase of the job.

Informs: #89487

Release note: none