### PR TITLE
roachtest: use local SSDs for disk-stall failover tests

### DIFF
--- a/pkg/cmd/roachtest/tests/disk_stall.go
+++ b/pkg/cmd/roachtest/tests/disk_stall.go
@@ -47,6 +47,8 @@ func registerDiskStalledDetection(r registry.Registry) {
 	}
 	makeSpec := func() spec.ClusterSpec {
 		s := r.MakeClusterSpec(4, spec.ReuseNone())
+		// Use PDs in an attempt to work around flakes encountered when using SSDs.
+		// See #97968.
 		s.PreferLocalSSD = false
 		return s
 	}


### PR DESCRIPTION
The disk-stalled roachtests were updated in #99747 to use local SSDs. This change broke the `failover/*/disk-stall` tests, which look for `/dev/sdb` on GCE (the used for GCE Persistent Disks), but the tests still create clusters with local SSDs (the roachtest default).

Fix #99902.
Fix #99926.
Fix #99930.

Touches #97968.

Release note: None.