### PR TITLE
sql: allow the in-memory version to be the next fence version

### DIFF
--- a/pkg/sql/BUILD.bazel
+++ b/pkg/sql/BUILD.bazel
@@ -658,6 +658,7 @@ go_test(
         "sequence_test.go",
         "session_migration_test.go",
         "set_zone_config_test.go",
+        "show_cluster_setting_test.go",
         "show_create_all_tables_builtin_test.go",
         "show_create_table_test.go",
         "show_fingerprints_test.go",

--- a/pkg/sql/show_cluster_setting.go
+++ b/pkg/sql/show_cluster_setting.go
@@ -94,14 +94,14 @@ func (p *planner) getCurrentEncodedVersionSettingValue(
 					}
 
 					localRawVal := []byte(s.Get(&st.SV))
-					if !bytes.Equal(localRawVal, kvRawVal) {
+					if err := checkClusterSettingValuesAreEquivalent(
+						localRawVal, kvRawVal,
+					); err != nil {
 						// NB: errors.Wrapf(nil, ...) returns nil.
 						// nolint:errwrap
-						return errors.Errorf(
-							"value differs between local setting (%v) and KV (%v); try again later (%v after %s)",
-							localRawVal, kvRawVal, ctx.Err(), timeutil.Since(tBegin))
+						return errors.WithHintf(err, "try again later (%v after %v)",
+							ctx.Err(), timeutil.Since(tBegin))
 					}
-
 					res = string(kvRawVal)
 					return nil
 				})
@@ -111,6 +111,43 @@ func (p *planner) getCurrentEncodedVersionSettingValue(
 	}
 
 	return res, nil
+}
+
+// checkClusterSettingValuesAreEquivalent returns an error if the cluster
+// setting values are not equivalent. Equivalent cluster setting values
+// are either the byte-for-byte identical, or the local value is the successor
+// to the kv value and the local value is a fence version.
+//
+// The in-memory version gets pushed to the fence but the fence is not persisted,
+// so, while migrations are ongoing, we won't see these values match. In practice
+// this is a problem these days because the migrations take a long time.
+func checkClusterSettingValuesAreEquivalent(localRawVal, kvRawVal []byte) error {
+	if bytes.Equal(localRawVal, kvRawVal) {
+		return nil
+	}
+	type cv = clusterversion.ClusterVersion
+	maybeDecodeVersion := func(data []byte) (cv, any, bool) {
+		if len(data) == 0 {
+			return cv{}, data, false
+		}
+		var v cv
+		if err := protoutil.Unmarshal(data, &v); err != nil {
+			return cv{}, data, false
+		}
+		return v, v, true
+	}
+	decodedLocal, localVal, localOk := maybeDecodeVersion(localRawVal)
+	decodedKV, kvVal, kvOk := maybeDecodeVersion(kvRawVal)
+	if localOk && kvOk && decodedLocal.Internal%2 == 1 /* isFence */ {
+		predecessor := decodedLocal
+		predecessor.Internal--
+		if predecessor.Equal(decodedKV) {
+			return nil
+		}
+	}
+	return errors.Errorf(
+		"value differs between local setting (%v) and KV (%v)",
+		localVal, kvVal)
 }
 
 func (p *planner) ShowClusterSetting(

--- a/pkg/sql/show_cluster_setting_test.go
+++ b/pkg/sql/show_cluster_setting_test.go
@@ -1,0 +1,72 @@
+// Copyright 2023 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package sql
+
+import (
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/clusterversion"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
+	"github.com/stretchr/testify/require"
+)
+
+// TestCheckClusterSettingValuesAreEquivalent exercises the logic used to
+// decide whether `SHOW CLUSTER SETTING version` can return the value it read.
+func TestCheckClusterSettingValuesAreEquivalent(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	encode := func(t *testing.T, s string) []byte {
+		v, err := roachpb.ParseVersion(s)
+		require.NoError(t, err)
+		cv := clusterversion.ClusterVersion{Version: v}
+		data, err := protoutil.Marshal(&cv)
+		require.NoError(t, err)
+		return data
+	}
+	for _, tc := range []struct {
+		local []byte
+		kv    []byte
+		exp   string
+	}{
+		{ // 0
+			local: encode(t, "22.2-10"),
+			kv:    encode(t, "22.2-10"),
+		},
+		{ // 1
+			local: encode(t, "22.2-12"),
+			kv:    encode(t, "22.2-11"),
+			exp:   "value differs between local setting (22.2-12) and KV (22.2-11)",
+		},
+		{ // 2
+			local: encode(t, "22.2-11"),
+			kv:    encode(t, "22.2-10"),
+		},
+		{ // 3
+			local: encode(t, "22.2-11"),
+			kv:    []byte("abc"),
+			exp:   "value differs between local setting (22.2-11) and KV ([97 98 99])",
+		},
+		{ // 4
+			kv:  encode(t, "22.2-11"),
+			exp: "value differs between local setting ([]) and KV (22.2-11)",
+		},
+	} {
+		t.Run("", func(t *testing.T) {
+			err := checkClusterSettingValuesAreEquivalent(tc.local, tc.kv)
+			if tc.exp == "" {
+				require.NoError(t, err)
+			} else {
+				require.EqualError(t, err, tc.exp)
+			}
+		})
+	}
+}


### PR DESCRIPTION
In `SHOW CLUSTER SETTING version` we wait for the stored version to match the in-memory version. The in-memory version get pushed to the fence but the fence is not persisted, so, while migrations are ongoing, we won't see these values match. In practice this is a problem these days because the migrations take a long time.

Epic: none

Informs #99894

Release note: None