### PR TITLE
upgrades: skip flaky tests for TestSystemPrivilegesUserIDMigration

### DIFF
--- a/pkg/upgrade/upgrades/system_privileges_user_id_migration_test.go
+++ b/pkg/upgrade/upgrades/system_privileges_user_id_migration_test.go
@@ -55,6 +55,8 @@ func runTestSystemPrivilegesUserIDMigration(t *testing.T, numUsers int) {
 	defer leaktest.AfterTest(t)()
 	ctx := context.Background()
 
+	skip.WithIssue(t, 99974, "flaky test")
+
 	settings := cluster.MakeTestingClusterSettingsWithVersions(
 		clusterversion.TestingBinaryVersion,
 		clusterversion.ByKey(clusterversion.V23_1SystemPrivilegesTableHasUserIDColumn-1),


### PR DESCRIPTION
Informs #99974.

Release note: None