### PR TITLE
democluster: skip TestTransientClusterSimulateLatencies

### DIFF
--- a/pkg/cli/democluster/demo_cluster_test.go
+++ b/pkg/cli/democluster/demo_cluster_test.go
@@ -149,6 +149,8 @@ func TestTransientClusterSimulateLatencies(t *testing.T) {
 	// has a very high simulated latency between each node.
 	skip.UnderRace(t)
 
+	skip.WithIssue(t, 99768, "flaky test")
+
 	demoCtx := newDemoCtx()
 	// Set up an empty 9-node cluster with simulated latencies.
 	demoCtx.SimulateLatency = true


### PR DESCRIPTION
Informs #99768.

The test is encountering a KV issue when writing liveness records with extra simulated latencies. Skipping.

Release note: None