### PR TITLE
execbuilder: ignore estimated row count line in one test

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/testdata/explain_analyze
+++ b/pkg/sql/opt/exec/execbuilder/testdata/explain_analyze
@@ -124,14 +124,18 @@ regions: <hidden>
 statement ok
 GRANT SELECT ON crdb_internal.tables TO root;
 
+# For some reason, even though we explicitly disable the automatic stats
+# collection for both user and system tables, rarely we still see that the stats
+# on system.privileges were collected, so we filter out a single line from the
+# output to make the test deterministic.
 query T
-EXPLAIN (VERBOSE) SELECT * FROM system.privileges WHERE path = 'vtable/crdb_internal/tables'
+SELECT * FROM [EXPLAIN (VERBOSE) SELECT * FROM system.privileges WHERE path = 'vtable/crdb_internal/tables']
+  WHERE info NOT LIKE '%estimated row count%';
 ----
 distribution: local
 vectorized: true
 ·
 • scan
   columns: (username, path, privileges, grant_options, user_id)
-  estimated row count: 10 (missing stats)
   table: privileges@privileges_path_user_id_key
   spans: /"vtable/crdb_internal/tables"-/"vtable/crdb_internal/tables"/PrefixEnd


### PR DESCRIPTION
This is a partial revert of 9c6fcd19a0892592b11bc803408b6daad0c780dc. We've just seen this test fail a couple of times even with the fix in that SHA, so for now let's just ignore the row count line.

Informs: #99897.

Release note: None