### PR TITLE
opt: remove panics in execbuilder

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/builder.go
+++ b/pkg/sql/opt/exec/execbuilder/builder.go
@@ -263,17 +263,17 @@ func (b *Builder) Build() (_ exec.Plan, err error) {
 	return b.factory.ConstructPlan(plan.root, b.subqueries, b.cascades, b.checks, rootRowCount)
 }
 
-func (b *Builder) wrapFunction(fnName string) tree.ResolvableFunctionReference {
+func (b *Builder) wrapFunction(fnName string) (tree.ResolvableFunctionReference, error) {
 	if b.evalCtx != nil && b.catalog != nil { // Some tests leave those unset.
 		unresolved := tree.MakeUnresolvedName(fnName)
 		fnDef, err := b.catalog.ResolveFunction(
 			context.Background(), &unresolved, &b.evalCtx.SessionData().SearchPath)
 		if err != nil {
-			panic(err)
+			return tree.ResolvableFunctionReference{}, err
 		}
-		return tree.ResolvableFunctionReference{FunctionReference: fnDef}
+		return tree.ResolvableFunctionReference{FunctionReference: fnDef}, nil
 	}
-	return tree.WrapFunction(fnName)
+	return tree.WrapFunction(fnName), nil
 }
 
 func (b *Builder) build(e opt.Expr) (_ execPlan, err error) {

--- a/pkg/sql/opt/exec/execbuilder/mutation.go
+++ b/pkg/sql/opt/exec/execbuilder/mutation.go
@@ -32,7 +32,11 @@ import (
 func (b *Builder) buildMutationInput(
 	mutExpr, inputExpr memo.RelExpr, colList opt.ColList, p *memo.MutationPrivate,
 ) (execPlan, error) {
-	if b.shouldApplyImplicitLockingToMutationInput(mutExpr) {
+	shouldApplyImplicitLocking, err := b.shouldApplyImplicitLockingToMutationInput(mutExpr)
+	if err != nil {
+		return execPlan{}, err
+	}
+	if shouldApplyImplicitLocking {
 		// Re-entrance is not possible because mutations are never nested.
 		b.forceForUpdateLocking = true
 		defer func() { b.forceForUpdateLocking = false }()
@@ -198,19 +202,19 @@ func (b *Builder) tryBuildFastPathInsert(ins *memo.InsertExpr) (_ execPlan, ok b
 
 		out := &fkChecks[i]
 		out.InsertCols = make([]exec.TableColumnOrdinal, len(lookupJoin.KeyCols))
-		findCol := func(cols opt.OptionalColList, col opt.ColumnID) int {
-			res, ok := cols.Find(col)
-			if !ok {
-				panic(errors.AssertionFailedf("cannot find column %d", col))
-			}
-			return res
-		}
 		for i, keyCol := range lookupJoin.KeyCols {
 			// The keyCol comes from the WithScan operator. We must find the matching
 			// column in the mutation input.
-			withColOrd := findCol(opt.OptionalColList(withScan.OutCols), keyCol)
+			withColOrd, ok := withScan.OutCols.Find(keyCol)
+			if !ok {
+				return execPlan{}, false, errors.AssertionFailedf("cannot find column %d", keyCol)
+			}
 			inputCol := withScan.InCols[withColOrd]
-			out.InsertCols[i] = exec.TableColumnOrdinal(findCol(ins.InsertCols, inputCol))
+			inputColOrd, ok := ins.InsertCols.Find(inputCol)
+			if !ok {
+				return execPlan{}, false, errors.AssertionFailedf("cannot find column %d", inputCol)
+			}
+			out.InsertCols[i] = exec.TableColumnOrdinal(inputColOrd)
 		}
 
 		out.ReferencedTable = md.Table(lookupJoin.Table)
@@ -435,7 +439,10 @@ func (b *Builder) buildUpsert(ups *memo.UpsertExpr) (execPlan, error) {
 	tab := md.Table(ups.Table)
 	canaryCol := exec.NodeColumnOrdinal(-1)
 	if ups.CanaryCol != 0 {
-		canaryCol = input.getNodeColumnOrdinal(ups.CanaryCol)
+		canaryCol, err = input.getNodeColumnOrdinal(ups.CanaryCol)
+		if err != nil {
+			return execPlan{}, err
+		}
 	}
 	insertColOrds := ordinalSetFromColList(ups.InsertCols)
 	fetchColOrds := ordinalSetFromColList(ups.FetchCols)
@@ -712,7 +719,11 @@ func (b *Builder) buildUniqueChecks(checks memo.UniqueChecksExpr) error {
 		mkErr := func(row tree.Datums) error {
 			keyVals := make(tree.Datums, len(c.KeyCols))
 			for i, col := range c.KeyCols {
-				keyVals[i] = row[query.getNodeColumnOrdinal(col)]
+				ord, err := query.getNodeColumnOrdinal(col)
+				if err != nil {
+					return err
+				}
+				keyVals[i] = row[ord]
 			}
 			return mkUniqueCheckErr(md, c, keyVals)
 		}
@@ -738,7 +749,11 @@ func (b *Builder) buildFKChecks(checks memo.FKChecksExpr) error {
 		mkErr := func(row tree.Datums) error {
 			keyVals := make(tree.Datums, len(c.KeyCols))
 			for i, col := range c.KeyCols {
-				keyVals[i] = row[query.getNodeColumnOrdinal(col)]
+				ord, err := query.getNodeColumnOrdinal(col)
+				if err != nil {
+					return err
+				}
+				keyVals[i] = row[ord]
 			}
 			return mkFKCheckErr(md, c, keyVals)
 		}
@@ -961,26 +976,26 @@ var forUpdateLocking = opt.Locking{Strength: tree.ForUpdate}
 // shouldApplyImplicitLockingToMutationInput determines whether or not the
 // builder should apply a FOR UPDATE row-level locking mode to the initial row
 // scan of a mutation expression.
-func (b *Builder) shouldApplyImplicitLockingToMutationInput(mutExpr memo.RelExpr) bool {
+func (b *Builder) shouldApplyImplicitLockingToMutationInput(mutExpr memo.RelExpr) (bool, error) {
 	switch t := mutExpr.(type) {
 	case *memo.InsertExpr:
 		// Unlike with the other three mutation expressions, it never makes
 		// sense to apply implicit row-level locking to the input of an INSERT
 		// expression because any contention results in unique constraint
 		// violations.
-		return false
+		return false, nil
 
 	case *memo.UpdateExpr:
-		return b.shouldApplyImplicitLockingToUpdateInput(t)
+		return b.shouldApplyImplicitLockingToUpdateInput(t), nil
 
 	case *memo.UpsertExpr:
-		return b.shouldApplyImplicitLockingToUpsertInput(t)
+		return b.shouldApplyImplicitLockingToUpsertInput(t), nil
 
 	case *memo.DeleteExpr:
-		return b.shouldApplyImplicitLockingToDeleteInput(t)
+		return b.shouldApplyImplicitLockingToDeleteInput(t), nil
 
 	default:
-		panic(errors.AssertionFailedf("unexpected mutation expression %T", t))
+		return false, errors.AssertionFailedf("unexpected mutation expression %T", t)
 	}
 }
 

--- a/pkg/sql/opt/exec/execbuilder/relational.go
+++ b/pkg/sql/opt/exec/execbuilder/relational.go
@@ -111,37 +111,46 @@ func (ep *execPlan) makeBuildScalarCtx() buildScalarCtx {
 // getNodeColumnOrdinal takes a column that is known to be produced by the execPlan
 // and returns the ordinal index of that column in the result columns of the
 // node.
-func (ep *execPlan) getNodeColumnOrdinal(col opt.ColumnID) exec.NodeColumnOrdinal {
+func (ep *execPlan) getNodeColumnOrdinal(col opt.ColumnID) (exec.NodeColumnOrdinal, error) {
 	ord, ok := ep.outputCols.Get(int(col))
 	if !ok {
-		panic(errors.AssertionFailedf("column %d not in input", redact.Safe(col)))
+		return 0, errors.AssertionFailedf("column %d not in input", redact.Safe(col))
 	}
-	return exec.NodeColumnOrdinal(ord)
+	return exec.NodeColumnOrdinal(ord), nil
 }
 
-func (ep *execPlan) getNodeColumnOrdinalSet(cols opt.ColSet) exec.NodeColumnOrdinalSet {
+func (ep *execPlan) getNodeColumnOrdinalSet(cols opt.ColSet) (exec.NodeColumnOrdinalSet, error) {
 	var res exec.NodeColumnOrdinalSet
-	cols.ForEach(func(colID opt.ColumnID) {
-		res.Add(int(ep.getNodeColumnOrdinal(colID)))
-	})
-	return res
+	for colID, ok := cols.Next(0); ok; colID, ok = cols.Next(colID + 1) {
+		colOrd, err := ep.getNodeColumnOrdinal(colID)
+		if err != nil {
+			return exec.NodeColumnOrdinalSet{}, err
+		}
+		res.Add(int(colOrd))
+	}
+	return res, nil
 }
 
 // reqOrdering converts the provided ordering of a relational expression to an
 // OutputOrdering (according to the outputCols map).
-func (ep *execPlan) reqOrdering(expr memo.RelExpr) exec.OutputOrdering {
-	return exec.OutputOrdering(ep.sqlOrdering(expr.ProvidedPhysical().Ordering))
+func (ep *execPlan) reqOrdering(expr memo.RelExpr) (exec.OutputOrdering, error) {
+	ordering, err := ep.sqlOrdering(expr.ProvidedPhysical().Ordering)
+	return exec.OutputOrdering(ordering), err
 }
 
 // sqlOrdering converts an Ordering to a ColumnOrdering (according to the
 // outputCols map).
-func (ep *execPlan) sqlOrdering(ordering opt.Ordering) colinfo.ColumnOrdering {
+func (ep *execPlan) sqlOrdering(ordering opt.Ordering) (colinfo.ColumnOrdering, error) {
 	if ordering.Empty() {
-		return nil
+		return nil, nil
 	}
 	colOrder := make(colinfo.ColumnOrdering, len(ordering))
 	for i := range ordering {
-		colOrder[i].ColIdx = int(ep.getNodeColumnOrdinal(ordering[i].ID()))
+		ord, err := ep.getNodeColumnOrdinal(ordering[i].ID())
+		if err != nil {
+			return nil, err
+		}
+		colOrder[i].ColIdx = int(ord)
 		if ordering[i].Descending() {
 			colOrder[i].Direction = encoding.Descending
 		} else {
@@ -149,7 +158,7 @@ func (ep *execPlan) sqlOrdering(ordering opt.Ordering) colinfo.ColumnOrdering {
 		}
 	}
 
-	return colOrder
+	return colOrder, nil
 }
 
 func (b *Builder) buildRelational(e memo.RelExpr) (execPlan, error) {
@@ -812,11 +821,15 @@ func (b *Builder) buildScan(scan *memo.ScanExpr) (execPlan, error) {
 		return execPlan{}, err
 	}
 	res := execPlan{outputCols: outputCols}
+	reqOrdering, err := res.reqOrdering(scan)
+	if err != nil {
+		return execPlan{}, err
+	}
 	root, err := b.factory.ConstructScan(
 		tab,
 		tab.Index(scan.Index),
 		params,
-		res.reqOrdering(scan),
+		reqOrdering,
 	)
 	if err != nil {
 		return execPlan{}, err
@@ -886,11 +899,15 @@ func (b *Builder) buildPlaceholderScan(scan *memo.PlaceholderScanExpr) (execPlan
 		return execPlan{}, err
 	}
 	res := execPlan{outputCols: outputCols}
+	reqOrdering, err := res.reqOrdering(scan)
+	if err != nil {
+		return execPlan{}, err
+	}
 	root, err := b.factory.ConstructScan(
 		tab,
 		tab.Index(scan.Index),
 		params,
-		res.reqOrdering(scan),
+		reqOrdering,
 	)
 	if err != nil {
 		return execPlan{}, err
@@ -911,7 +928,10 @@ func (b *Builder) buildSelect(sel *memo.SelectExpr) (execPlan, error) {
 	}
 	// A filtering node does not modify the schema.
 	res := execPlan{outputCols: input.outputCols}
-	reqOrder := res.reqOrdering(sel)
+	reqOrder, err := res.reqOrdering(sel)
+	if err != nil {
+		return execPlan{}, err
+	}
 	res.root, err = b.factory.ConstructFilter(input.root, filter, reqOrder)
 	if err != nil {
 		return execPlan{}, err
@@ -926,7 +946,10 @@ func (b *Builder) buildInvertedFilter(invFilter *memo.InvertedFilterExpr) (execP
 	}
 	// A filtering node does not modify the schema.
 	res := execPlan{outputCols: input.outputCols}
-	invertedCol := input.getNodeColumnOrdinal(invFilter.InvertedColumn)
+	invertedCol, err := input.getNodeColumnOrdinal(invFilter.InvertedColumn)
+	if err != nil {
+		return execPlan{}, err
+	}
 	var typedPreFilterExpr tree.TypedExpr
 	var typ *types.T
 	if invFilter.PreFiltererState != nil && invFilter.PreFiltererState.Expr != nil {
@@ -968,13 +991,21 @@ func (b *Builder) applySimpleProject(
 	// We have only pass-through columns.
 	colList := make([]exec.NodeColumnOrdinal, 0, cols.Len())
 	var res execPlan
-	cols.ForEach(func(i opt.ColumnID) {
+	for i, ok := cols.Next(0); ok; i, ok = cols.Next(i + 1) {
 		res.outputCols.Set(int(i), len(colList))
-		colList = append(colList, input.getNodeColumnOrdinal(i))
-	})
+		ord, err := input.getNodeColumnOrdinal(i)
+		if err != nil {
+			return execPlan{}, err
+		}
+		colList = append(colList, ord)
+	}
 	var err error
+	sqlOrdering, err := res.sqlOrdering(providedOrd)
+	if err != nil {
+		return execPlan{}, err
+	}
 	res.root, err = b.factory.ConstructSimpleProject(
-		input.root, colList, exec.OutputOrdering(res.sqlOrdering(providedOrd)),
+		input.root, colList, exec.OutputOrdering(sqlOrdering),
 	)
 	if err != nil {
 		return execPlan{}, err
@@ -1012,17 +1043,23 @@ func (b *Builder) buildProject(prj *memo.ProjectExpr) (execPlan, error) {
 			Typ:  item.Typ,
 		})
 	}
-	prj.Passthrough.ForEach(func(colID opt.ColumnID) {
+	for colID, ok := prj.Passthrough.Next(0); ok; colID, ok = prj.Passthrough.Next(colID + 1) {
 		res.outputCols.Set(int(colID), len(exprs))
-		indexedVar := b.indexedVar(&ctx, md, colID)
+		indexedVar, err := b.indexedVar(&ctx, md, colID)
+		if err != nil {
+			return execPlan{}, err
+		}
 		exprs = append(exprs, indexedVar)
 		meta := md.ColumnMeta(colID)
 		cols = append(cols, colinfo.ResultColumn{
 			Name: meta.Alias,
 			Typ:  meta.Type,
 		})
-	})
-	reqOrdering := res.reqOrdering(prj)
+	}
+	reqOrdering, err := res.reqOrdering(prj)
+	if err != nil {
+		return execPlan{}, err
+	}
 	res.root, err = b.factory.ConstructRender(input.root, cols, exprs, reqOrdering)
 	if err != nil {
 		return execPlan{}, err
@@ -1036,7 +1073,10 @@ func (b *Builder) buildApplyJoin(join memo.RelExpr) (execPlan, error) {
 	default:
 		return execPlan{}, fmt.Errorf("couldn't execute correlated subquery with op %s", join.Op())
 	}
-	joinType := joinOpToJoinType(join.Op())
+	joinType, err := joinOpToJoinType(join.Op())
+	if err != nil {
+		return execPlan{}, err
+	}
 	leftExpr := join.Child(0).(memo.RelExpr)
 	leftProps := leftExpr.Relational()
 	rightExpr := join.Child(1).(memo.RelExpr)
@@ -1254,7 +1294,10 @@ func (b *Builder) buildHashJoin(join memo.RelExpr) (execPlan, error) {
 		)
 	}
 
-	joinType := joinOpToJoinType(join.Op())
+	joinType, err := joinOpToJoinType(join.Op())
+	if err != nil {
+		return execPlan{}, err
+	}
 	leftExpr := join.Child(0).(memo.RelExpr)
 	rightExpr := join.Child(1).(memo.RelExpr)
 	filters := join.Child(2).(*memo.FiltersExpr)
@@ -1307,8 +1350,14 @@ func (b *Builder) buildHashJoin(join memo.RelExpr) (execPlan, error) {
 	leftEqOrdinals := eqColsBuf[:len(leftEq):len(leftEq)]
 	rightEqOrdinals := eqColsBuf[len(leftEq):]
 	for i := range leftEq {
-		leftEqOrdinals[i] = left.getNodeColumnOrdinal(leftEq[i])
-		rightEqOrdinals[i] = right.getNodeColumnOrdinal(rightEq[i])
+		leftEqOrdinals[i], err = left.getNodeColumnOrdinal(leftEq[i])
+		if err != nil {
+			return execPlan{}, err
+		}
+		rightEqOrdinals[i], err = right.getNodeColumnOrdinal(rightEq[i])
+		if err != nil {
+			return execPlan{}, err
+		}
 	}
 
 	leftEqColsAreKey := leftExpr.Relational().FuncDeps.ColsAreStrictKey(leftEq.ToSet())
@@ -1339,7 +1388,10 @@ func (b *Builder) buildMergeJoin(join *memo.MergeJoinExpr) (execPlan, error) {
 		telemetry.Inc(opt.JoinTypeToUseCounter(join.JoinType))
 	}
 
-	joinType := joinOpToJoinType(join.JoinType)
+	joinType, err := joinOpToJoinType(join.JoinType)
+	if err != nil {
+		return execPlan{}, err
+	}
 	leftExpr, rightExpr := join.Left, join.Right
 	leftEq, rightEq := join.LeftEq, join.RightEq
 
@@ -1368,10 +1420,19 @@ func (b *Builder) buildMergeJoin(join *memo.MergeJoinExpr) (execPlan, error) {
 	if err != nil {
 		return execPlan{}, err
 	}
-	leftOrd := left.sqlOrdering(leftEq)
-	rightOrd := right.sqlOrdering(rightEq)
+	leftOrd, err := left.sqlOrdering(leftEq)
+	if err != nil {
+		return execPlan{}, err
+	}
+	rightOrd, err := right.sqlOrdering(rightEq)
+	if err != nil {
+		return execPlan{}, err
+	}
 	ep := execPlan{outputCols: outputCols}
-	reqOrd := ep.reqOrdering(join)
+	reqOrd, err := ep.reqOrdering(join)
+	if err != nil {
+		return execPlan{}, err
+	}
 	leftEqColsAreKey := leftExpr.Relational().FuncDeps.ColsAreStrictKey(leftEq.ColSet())
 	rightEqColsAreKey := rightExpr.Relational().FuncDeps.ColsAreStrictKey(rightEq.ColSet())
 	b.recordJoinType(joinType)
@@ -1435,28 +1496,28 @@ func joinOutputMap(left, right opt.ColMap) opt.ColMap {
 	return res
 }
 
-func joinOpToJoinType(op opt.Operator) descpb.JoinType {
+func joinOpToJoinType(op opt.Operator) (descpb.JoinType, error) {
 	switch op {
 	case opt.InnerJoinOp, opt.InnerJoinApplyOp:
-		return descpb.InnerJoin
+		return descpb.InnerJoin, nil
 
 	case opt.LeftJoinOp, opt.LeftJoinApplyOp:
-		return descpb.LeftOuterJoin
+		return descpb.LeftOuterJoin, nil
 
 	case opt.RightJoinOp:
-		return descpb.RightOuterJoin
+		return descpb.RightOuterJoin, nil
 
 	case opt.FullJoinOp:
-		return descpb.FullOuterJoin
+		return descpb.FullOuterJoin, nil
 
 	case opt.SemiJoinOp, opt.SemiJoinApplyOp:
-		return descpb.LeftSemiJoin
+		return descpb.LeftSemiJoin, nil
 
 	case opt.AntiJoinOp, opt.AntiJoinApplyOp:
-		return descpb.LeftAntiJoin
+		return descpb.LeftAntiJoin, nil
 
 	default:
-		panic(errors.AssertionFailedf("not a join op %s", redact.Safe(op)))
+		return 0, errors.AssertionFailedf("not a join op %s", redact.Safe(op))
 	}
 }
 
@@ -1471,7 +1532,11 @@ func (b *Builder) buildGroupBy(groupBy memo.RelExpr) (execPlan, error) {
 	groupingColIdx := make([]exec.NodeColumnOrdinal, 0, groupingCols.Len())
 	for i, ok := groupingCols.Next(0); ok; i, ok = groupingCols.Next(i + 1) {
 		ep.outputCols.Set(int(i), len(groupingColIdx))
-		groupingColIdx = append(groupingColIdx, input.getNodeColumnOrdinal(i))
+		ord, err := input.getNodeColumnOrdinal(i)
+		if err != nil {
+			return execPlan{}, err
+		}
+		groupingColIdx = append(groupingColIdx, ord)
 	}
 
 	aggregations := *groupBy.Child(1).(*memo.AggregationsExpr)
@@ -1486,7 +1551,10 @@ func (b *Builder) buildGroupBy(groupBy memo.RelExpr) (execPlan, error) {
 			if !ok {
 				return execPlan{}, errors.AssertionFailedf("only VariableOp args supported")
 			}
-			filterOrd = input.getNodeColumnOrdinal(filter.Col)
+			filterOrd, err = input.getNodeColumnOrdinal(filter.Col)
+			if err != nil {
+				return execPlan{}, err
+			}
 			agg = aggFilter.Input
 		}
 
@@ -1508,7 +1576,11 @@ func (b *Builder) buildGroupBy(groupBy memo.RelExpr) (execPlan, error) {
 				if len(constArgs) != 0 {
 					return execPlan{}, errors.Errorf("constant args must come after variable args")
 				}
-				argCols = append(argCols, input.getNodeColumnOrdinal(variable.Col))
+				ord, err := input.getNodeColumnOrdinal(variable.Col)
+				if err != nil {
+					return execPlan{}, err
+				}
+				argCols = append(argCols, ord)
 			} else {
 				if len(argCols) == 0 {
 					return execPlan{}, errors.Errorf("a constant arg requires at least one variable arg")
@@ -1532,10 +1604,18 @@ func (b *Builder) buildGroupBy(groupBy memo.RelExpr) (execPlan, error) {
 		ep.root, err = b.factory.ConstructScalarGroupBy(input.root, aggInfos)
 	} else {
 		groupBy := groupBy.(*memo.GroupByExpr)
-		groupingColOrder := input.sqlOrdering(ordering.StreamingGroupingColOrdering(
+		var groupingColOrder colinfo.ColumnOrdering
+		groupingColOrder, err = input.sqlOrdering(ordering.StreamingGroupingColOrdering(
 			&groupBy.GroupingPrivate, &groupBy.RequiredPhysical().Ordering,
 		))
-		reqOrdering := ep.reqOrdering(groupBy)
+		if err != nil {
+			return execPlan{}, err
+		}
+		var reqOrdering exec.OutputOrdering
+		reqOrdering, err = ep.reqOrdering(groupBy)
+		if err != nil {
+			return execPlan{}, err
+		}
 		orderType := exec.GroupingOrderType(groupBy.GroupingOrderType(&groupBy.RequiredPhysical().Ordering))
 		ep.root, err = b.factory.ConstructGroupBy(
 			input.root, groupingColIdx, groupingColOrder, aggInfos, reqOrdering, orderType,
@@ -1560,17 +1640,27 @@ func (b *Builder) buildDistinct(distinct memo.RelExpr) (execPlan, error) {
 		return execPlan{}, err
 	}
 
-	distinctCols := input.getNodeColumnOrdinalSet(private.GroupingCols)
+	distinctCols, err := input.getNodeColumnOrdinalSet(private.GroupingCols)
+	if err != nil {
+		return execPlan{}, err
+	}
 	var orderedCols exec.NodeColumnOrdinalSet
 	ordering := ordering.StreamingGroupingColOrdering(
 		private, &distinct.RequiredPhysical().Ordering,
 	)
 	for i := range ordering {
-		orderedCols.Add(int(input.getNodeColumnOrdinal(ordering[i].ID())))
+		ord, err := input.getNodeColumnOrdinal(ordering[i].ID())
+		if err != nil {
+			return execPlan{}, err
+		}
+		orderedCols.Add(int(ord))
 	}
 	ep := execPlan{outputCols: input.outputCols}
 
-	reqOrdering := ep.reqOrdering(distinct)
+	reqOrdering, err := ep.reqOrdering(distinct)
+	if err != nil {
+		return execPlan{}, err
+	}
 	ep.root, err = b.factory.ConstructDistinct(
 		input.root, distinctCols, orderedCols, reqOrdering,
 		private.NullsAreDistinct, private.ErrorOnDup)
@@ -1628,14 +1718,18 @@ func (b *Builder) buildGroupByInput(groupBy memo.RelExpr) (execPlan, error) {
 	for colID, ok := neededCols.Next(0); ok; colID, ok = neededCols.Next(colID + 1) {
 		ordinal, ordOk := input.outputCols.Get(int(colID))
 		if !ordOk {
-			panic(errors.AssertionFailedf("needed column not produced by group-by input"))
+			return execPlan{},
+				errors.AssertionFailedf("needed column not produced by group-by input")
 		}
 		newOutputCols.Set(int(colID), len(cols))
 		cols = append(cols, exec.NodeColumnOrdinal(ordinal))
 	}
 
 	input.outputCols = newOutputCols
-	reqOrdering := input.reqOrdering(groupByInput)
+	reqOrdering, err := input.reqOrdering(groupByInput)
+	if err != nil {
+		return execPlan{}, err
+	}
 	input.root, err = b.factory.ConstructSimpleProject(input.root, cols, reqOrdering)
 	if err != nil {
 		return execPlan{}, err
@@ -1701,7 +1795,7 @@ func (b *Builder) buildSetOp(set memo.RelExpr) (execPlan, error) {
 	case opt.ExceptAllOp:
 		typ, all = tree.ExceptOp, true
 	default:
-		panic(errors.AssertionFailedf("invalid operator %s", redact.Safe(set.Op())))
+		return execPlan{}, errors.AssertionFailedf("invalid operator %s", redact.Safe(set.Op()))
 	}
 
 	switch typ {
@@ -1734,10 +1828,16 @@ func (b *Builder) buildSetOp(set memo.RelExpr) (execPlan, error) {
 	for i, col := range private.OutCols {
 		ep.outputCols.Set(int(col), i)
 	}
-	streamingOrdering := ep.sqlOrdering(
+	streamingOrdering, err := ep.sqlOrdering(
 		ordering.StreamingSetOpOrdering(set, &set.RequiredPhysical().Ordering),
 	)
-	reqOrdering := ep.reqOrdering(set)
+	if err != nil {
+		return execPlan{}, err
+	}
+	reqOrdering, err := ep.reqOrdering(set)
+	if err != nil {
+		return execPlan{}, err
+	}
 
 	if typ == tree.UnionOp && all {
 		ep.root, err = b.factory.ConstructUnionAll(left.root, right.root, reqOrdering, hardLimit, enforceHomeRegion)
@@ -1780,10 +1880,14 @@ func (b *Builder) buildTopK(e *memo.TopKExpr) (execPlan, error) {
 		}
 		alreadyOrderedPrefix = i + 1
 	}
+	sqlOrdering, err := input.sqlOrdering(ordering)
+	if err != nil {
+		return execPlan{}, err
+	}
 	node, err := b.factory.ConstructTopK(
 		input.root,
 		e.K,
-		exec.OutputOrdering(input.sqlOrdering(ordering)),
+		exec.OutputOrdering(sqlOrdering),
 		alreadyOrderedPrefix)
 	if err != nil {
 		return execPlan{}, err
@@ -1834,9 +1938,13 @@ func (b *Builder) buildSort(sort *memo.SortExpr) (execPlan, error) {
 		alreadyOrderedPrefix = i + 1
 	}
 
+	sqlOrdering, err := input.sqlOrdering(ordering)
+	if err != nil {
+		return execPlan{}, err
+	}
 	node, err := b.factory.ConstructSort(
 		input.root,
-		exec.OutputOrdering(input.sqlOrdering(ordering)),
+		exec.OutputOrdering(sqlOrdering),
 		alreadyOrderedPrefix,
 	)
 	if err != nil {
@@ -2048,7 +2156,10 @@ func (b *Builder) buildIndexJoin(join *memo.IndexJoinExpr) (execPlan, error) {
 	b.IndexesUsed = util.CombineUniqueString(b.IndexesUsed, []string{fmt.Sprintf("%d@%d", tab.ID(), pri.ID())})
 	keyCols := make([]exec.NodeColumnOrdinal, pri.KeyColumnCount())
 	for i := range keyCols {
-		keyCols[i] = input.getNodeColumnOrdinal(join.Table.ColumnID(pri.Column(i).Ordinal()))
+		keyCols[i], err = input.getNodeColumnOrdinal(join.Table.ColumnID(pri.Column(i).Ordinal()))
+		if err != nil {
+			return execPlan{}, err
+		}
 	}
 
 	cols := join.Cols
@@ -2062,8 +2173,12 @@ func (b *Builder) buildIndexJoin(join *memo.IndexJoinExpr) (execPlan, error) {
 
 	res := execPlan{outputCols: output}
 	b.recordJoinAlgorithm(exec.IndexJoin)
+	reqOrdering, err := res.reqOrdering(join)
+	if err != nil {
+		return execPlan{}, err
+	}
 	res.root, err = b.factory.ConstructIndexJoin(
-		input.root, tab, keyCols, needed, res.reqOrdering(join), locking, join.RequiredPhysical().LimitHintInt64(),
+		input.root, tab, keyCols, needed, reqOrdering, locking, join.RequiredPhysical().LimitHintInt64(),
 	)
 	if err != nil {
 		return execPlan{}, err
@@ -2287,7 +2402,10 @@ func (b *Builder) buildLookupJoin(join *memo.LookupJoinExpr) (execPlan, error) {
 	}
 	keyCols := make([]exec.NodeColumnOrdinal, len(join.KeyCols))
 	for i, c := range join.KeyCols {
-		keyCols[i] = input.getNodeColumnOrdinal(c)
+		keyCols[i], err = input.getNodeColumnOrdinal(c)
+		if err != nil {
+			return execPlan{}, err
+		}
 	}
 
 	inputCols := join.Input.Relational().OutputCols
@@ -2355,9 +2473,16 @@ func (b *Builder) buildLookupJoin(join *memo.LookupJoinExpr) (execPlan, error) {
 	}
 	b.ContainsNonDefaultKeyLocking = b.ContainsNonDefaultKeyLocking || locking.IsLocking()
 
-	joinType := joinOpToJoinType(join.JoinType)
+	joinType, err := joinOpToJoinType(join.JoinType)
+	if err != nil {
+		return execPlan{}, err
+	}
 	b.recordJoinType(joinType)
 	b.recordJoinAlgorithm(exec.LookupJoin)
+	reqOrdering, err := res.reqOrdering(join)
+	if err != nil {
+		return execPlan{}, err
+	}
 	res.root, err = b.factory.ConstructLookupJoin(
 		joinType,
 		input.root,
@@ -2371,7 +2496,7 @@ func (b *Builder) buildLookupJoin(join *memo.LookupJoinExpr) (execPlan, error) {
 		onExpr,
 		join.IsFirstJoinInPairedJoiner,
 		join.IsSecondJoinInPairedJoiner,
-		res.reqOrdering(join),
+		reqOrdering,
 		locking,
 		join.RequiredPhysical().LimitHintInt64(),
 		join.RemoteOnlyLookups,
@@ -2519,7 +2644,10 @@ func (b *Builder) buildInvertedJoin(join *memo.InvertedJoinExpr) (execPlan, erro
 
 	prefixEqCols := make([]exec.NodeColumnOrdinal, len(join.PrefixKeyCols))
 	for i, c := range join.PrefixKeyCols {
-		prefixEqCols[i] = input.getNodeColumnOrdinal(c)
+		prefixEqCols[i], err = input.getNodeColumnOrdinal(c)
+		if err != nil {
+			return execPlan{}, err
+		}
 	}
 
 	inputCols := join.Input.Relational().OutputCols
@@ -2587,9 +2715,16 @@ func (b *Builder) buildInvertedJoin(join *memo.InvertedJoinExpr) (execPlan, erro
 	}
 	b.ContainsNonDefaultKeyLocking = b.ContainsNonDefaultKeyLocking || locking.IsLocking()
 
-	joinType := joinOpToJoinType(join.JoinType)
+	joinType, err := joinOpToJoinType(join.JoinType)
+	if err != nil {
+		return execPlan{}, err
+	}
 	b.recordJoinType(joinType)
 	b.recordJoinAlgorithm(exec.InvertedJoin)
+	reqOrdering, err := res.reqOrdering(join)
+	if err != nil {
+		return execPlan{}, err
+	}
 	res.root, err = b.factory.ConstructInvertedJoin(
 		joinType,
 		invertedExpr,
@@ -2600,7 +2735,7 @@ func (b *Builder) buildInvertedJoin(join *memo.InvertedJoinExpr) (execPlan, erro
 		lookupOrdinals,
 		onExpr,
 		join.IsFirstJoinInPairedJoiner,
-		res.reqOrdering(join),
+		reqOrdering,
 		locking,
 	)
 	if err != nil {
@@ -2697,6 +2832,10 @@ func (b *Builder) buildZigzagJoin(join *memo.ZigzagJoinExpr) (execPlan, error) {
 	}
 
 	b.recordJoinAlgorithm(exec.ZigZagJoin)
+	reqOrdering, err := res.reqOrdering(join)
+	if err != nil {
+		return execPlan{}, err
+	}
 	res.root, err = b.factory.ConstructZigzagJoin(
 		leftTable,
 		leftIndex,
@@ -2711,7 +2850,7 @@ func (b *Builder) buildZigzagJoin(join *memo.ZigzagJoinExpr) (execPlan, error) {
 		rightEqCols,
 		rightLocking,
 		onExpr,
-		res.reqOrdering(join),
+		reqOrdering,
 	)
 	if err != nil {
 		return execPlan{}, err
@@ -2989,7 +3128,7 @@ func (b *Builder) buildFrame(input execPlan, w *memo.WindowsItem) (*tree.WindowF
 	}
 	if boundExpr, ok := b.extractFromOffset(w.Function); ok {
 		if !b.isOffsetMode(w.Frame.StartBoundType) {
-			panic(errors.AssertionFailedf("expected offset to only be present in offset mode"))
+			return nil, errors.AssertionFailedf("expected offset to only be present in offset mode")
 		}
 		offset, err := b.buildScalar(&scalarCtx, boundExpr)
 		if err != nil {
@@ -3003,7 +3142,7 @@ func (b *Builder) buildFrame(input execPlan, w *memo.WindowsItem) (*tree.WindowF
 
 	if boundExpr, ok := b.extractToOffset(w.Function); ok {
 		if !b.isOffsetMode(newDef.Bounds.EndBound.BoundType) {
-			panic(errors.AssertionFailedf("expected offset to only be present in offset mode"))
+			return nil, errors.AssertionFailedf("expected offset to only be present in offset mode")
 		}
 		offset, err := b.buildScalar(&scalarCtx, boundExpr)
 		if err != nil {
@@ -3051,8 +3190,12 @@ func (b *Builder) buildWindow(w *memo.WindowExpr) (execPlan, error) {
 		if c.Descending() {
 			direction = tree.Descending
 		}
+		indexedVar, err := b.indexedVar(&ctx, b.mem.Metadata(), c.ID())
+		if err != nil {
+			return execPlan{}, err
+		}
 		orderingExprs[i] = &tree.Order{
-			Expr:      b.indexedVar(&ctx, b.mem.Metadata(), c.ID()),
+			Expr:      indexedVar,
 			Direction: direction,
 		}
 	}
@@ -3061,12 +3204,16 @@ func (b *Builder) buildWindow(w *memo.WindowExpr) (execPlan, error) {
 	partitionExprs := make(tree.Exprs, w.Partition.Len())
 
 	i := 0
-	w.Partition.ForEach(func(col opt.ColumnID) {
+	for col, ok := w.Partition.Next(0); ok; col, ok = w.Partition.Next(col + 1) {
 		ordinal, _ := input.outputCols.Get(int(col))
 		partitionIdxs[i] = exec.NodeColumnOrdinal(ordinal)
-		partitionExprs[i] = b.indexedVar(&ctx, b.mem.Metadata(), col)
+		indexedVar, err := b.indexedVar(&ctx, b.mem.Metadata(), col)
+		if err != nil {
+			return execPlan{}, err
+		}
+		partitionExprs[i] = indexedVar
 		i++
-	})
+	}
 
 	argIdxs := make([][]exec.NodeColumnOrdinal, len(w.Windows))
 	filterIdxs := make([]int, len(w.Windows))
@@ -3086,7 +3233,11 @@ func (b *Builder) buildWindow(w *memo.WindowExpr) (execPlan, error) {
 		argIdxs[i] = make([]exec.NodeColumnOrdinal, fn.ChildCount())
 		for j, n := 0, fn.ChildCount(); j < n; j++ {
 			col := fn.Child(j).(*memo.VariableExpr).Col
-			args[j] = b.indexedVar(&ctx, b.mem.Metadata(), col)
+			indexedVar, err := b.indexedVar(&ctx, b.mem.Metadata(), col)
+			if err != nil {
+				return execPlan{}, err
+			}
+			args[j] = indexedVar
 			idx, _ := input.outputCols.Get(int(col))
 			argIdxs[i][j] = exec.NodeColumnOrdinal(idx)
 		}
@@ -3101,7 +3252,8 @@ func (b *Builder) buildWindow(w *memo.WindowExpr) (execPlan, error) {
 		if ok {
 			f, ok := filter.(*memo.VariableExpr)
 			if !ok {
-				panic(errors.AssertionFailedf("expected FILTER expression to be a VariableExpr"))
+				return execPlan{},
+					errors.AssertionFailedf("expected FILTER expression to be a VariableExpr")
 			}
 			filterIdxs[i], _ = input.outputCols.Get(int(f.Col))
 
@@ -3118,8 +3270,12 @@ func (b *Builder) buildWindow(w *memo.WindowExpr) (execPlan, error) {
 			OrderBy:    orderingExprs,
 			Frame:      frame,
 		}
+		wrappedFn, err := b.wrapFunction(name)
+		if err != nil {
+			return execPlan{}, err
+		}
 		exprs[i] = tree.NewTypedFuncExpr(
-			b.wrapFunction(name),
+			wrappedFn,
 			0,
 			args,
 			builtFilter,
@@ -3157,6 +3313,10 @@ func (b *Builder) buildWindow(w *memo.WindowExpr) (execPlan, error) {
 		outputIdxs[i] = windowStart + i
 	}
 
+	sqlOrdering, err := input.sqlOrdering(ord)
+	if err != nil {
+		return execPlan{}, err
+	}
 	node, err := b.factory.ConstructWindow(input.root, exec.WindowInfo{
 		Cols:       resultCols,
 		Exprs:      exprs,
@@ -3164,7 +3324,7 @@ func (b *Builder) buildWindow(w *memo.WindowExpr) (execPlan, error) {
 		ArgIdxs:    argIdxs,
 		FilterIdxs: filterIdxs,
 		Partition:  partitionIdxs,
-		Ordering:   input.sqlOrdering(ord),
+		Ordering:   sqlOrdering,
 	})
 	if err != nil {
 		return execPlan{}, err
@@ -3233,7 +3393,7 @@ func (b *Builder) buildOpaque(opaque *memo.OpaqueRelPrivate) (execPlan, error) {
 // the columns (in the same order), returns needProj=false.
 func (b *Builder) needProjection(
 	input execPlan, colList opt.ColList,
-) (_ []exec.NodeColumnOrdinal, needProj bool) {
+) (_ []exec.NodeColumnOrdinal, needProj bool, err error) {
 	if input.numOutputCols() == len(colList) {
 		identity := true
 		for i, col := range colList {
@@ -3243,16 +3403,20 @@ func (b *Builder) needProjection(
 			}
 		}
 		if identity {
-			return nil, false
+			return nil, false, nil
 		}
 	}
 	cols := make([]exec.NodeColumnOrdinal, 0, len(colList))
 	for _, col := range colList {
 		if col != 0 {
-			cols = append(cols, input.getNodeColumnOrdinal(col))
+			ord, err := input.getNodeColumnOrdinal(col)
+			if err != nil {
+				return nil, false, err
+			}
+			cols = append(cols, ord)
 		}
 	}
-	return cols, true
+	return cols, true, nil
 }
 
 // ensureColumns applies a projection as necessary to make the output match the
@@ -3260,7 +3424,10 @@ func (b *Builder) needProjection(
 func (b *Builder) ensureColumns(
 	input execPlan, inputExpr memo.RelExpr, colList opt.ColList, provided opt.Ordering,
 ) (execPlan, error) {
-	cols, needProj := b.needProjection(input, colList)
+	cols, needProj, err := b.needProjection(input, colList)
+	if err != nil {
+		return execPlan{}, err
+	}
 	if !needProj {
 		return input, nil
 	}
@@ -3272,8 +3439,11 @@ func (b *Builder) ensureColumns(
 	for i, col := range colList {
 		res.outputCols.Set(int(col), i)
 	}
-	reqOrdering := exec.OutputOrdering(res.sqlOrdering(provided))
-	var err error
+	sqlOrdering, err := res.sqlOrdering(provided)
+	if err != nil {
+		return execPlan{}, err
+	}
+	reqOrdering := exec.OutputOrdering(sqlOrdering)
 	res.root, err = b.factory.ConstructSimpleProject(input.root, cols, reqOrdering)
 	return res, err
 }
@@ -3285,7 +3455,11 @@ func (b *Builder) applyPresentation(input execPlan, pres physical.Presentation) 
 	colNames := make([]string, len(pres))
 	var res execPlan
 	for i := range pres {
-		cols[i] = input.getNodeColumnOrdinal(pres[i].ID)
+		ord, err := input.getNodeColumnOrdinal(pres[i].ID)
+		if err != nil {
+			return execPlan{}, err
+		}
+		cols[i] = ord
 		res.outputCols.Set(int(pres[i].ID), i)
 		colNames[i] = pres[i].Alias
 	}
@@ -3296,7 +3470,7 @@ func (b *Builder) applyPresentation(input execPlan, pres physical.Presentation) 
 
 // getEnvData consolidates the information that must be presented in
 // EXPLAIN (opt, env).
-func (b *Builder) getEnvData() exec.ExplainEnvData {
+func (b *Builder) getEnvData() (exec.ExplainEnvData, error) {
 	envOpts := exec.ExplainEnvData{ShowEnv: true}
 	var err error
 	envOpts.Tables, envOpts.Sequences, envOpts.Views, err = b.mem.Metadata().AllDataSourceNames(
@@ -3305,11 +3479,7 @@ func (b *Builder) getEnvData() exec.ExplainEnvData {
 			return b.catalog.FullyQualifiedName(context.TODO(), ds)
 		},
 	)
-	if err != nil {
-		panic(err)
-	}
-
-	return envOpts
+	return envOpts, err
 }
 
 // statementTag returns a string that can be used in an error message regarding

--- a/pkg/sql/opt/exec/execbuilder/scalar.go
+++ b/pkg/sql/opt/exec/execbuilder/scalar.go
@@ -137,17 +137,17 @@ func (b *Builder) buildNull(ctx *buildScalarCtx, scalar opt.ScalarExpr) (tree.Ty
 func (b *Builder) buildVariable(
 	ctx *buildScalarCtx, scalar opt.ScalarExpr,
 ) (tree.TypedExpr, error) {
-	return b.indexedVar(ctx, b.mem.Metadata(), *scalar.Private().(*opt.ColumnID)), nil
+	return b.indexedVar(ctx, b.mem.Metadata(), *scalar.Private().(*opt.ColumnID))
 }
 
 func (b *Builder) indexedVar(
 	ctx *buildScalarCtx, md *opt.Metadata, colID opt.ColumnID,
-) tree.TypedExpr {
+) (tree.TypedExpr, error) {
 	idx, ok := ctx.ivarMap.Get(int(colID))
 	if !ok {
-		panic(errors.AssertionFailedf("cannot map variable %d to an indexed var", redact.Safe(colID)))
+		return nil, errors.AssertionFailedf("cannot map variable %d to an indexed var", redact.Safe(colID))
 	}
-	return ctx.ivh.IndexedVarWithType(idx, md.ColumnMeta(colID).Type)
+	return ctx.ivh.IndexedVarWithType(idx, md.ColumnMeta(colID).Type), nil
 }
 
 func (b *Builder) buildTuple(ctx *buildScalarCtx, scalar opt.ScalarExpr) (tree.TypedExpr, error) {
@@ -228,7 +228,7 @@ func (b *Builder) buildBoolean(ctx *buildScalarCtx, scalar opt.ScalarExpr) (tree
 		return tree.NewTypedIsNotNullExpr(expr), nil
 
 	default:
-		panic(errors.AssertionFailedf("invalid op %s", redact.Safe(scalar.Op())))
+		return nil, errors.AssertionFailedf("invalid op %s", redact.Safe(scalar.Op()))
 	}
 }
 
@@ -294,7 +294,10 @@ func (b *Builder) buildFunction(
 			return nil, err
 		}
 	}
-	funcRef := b.wrapFunction(fn.Name)
+	funcRef, err := b.wrapFunction(fn.Name)
+	if err != nil {
+		return nil, err
+	}
 	return tree.NewTypedFuncExpr(
 		funcRef,
 		0, /* aggQualifier */
@@ -375,7 +378,10 @@ func (b *Builder) buildAssignmentCast(
 		return input, nil
 	}
 	const fnName = "crdb_internal.assignment_cast"
-	funcRef := b.wrapFunction(fnName)
+	funcRef, err := b.wrapFunction(fnName)
+	if err != nil {
+		return nil, err
+	}
 	props, overloads := builtinsregistry.GetBuiltinProperties(fnName)
 	return tree.NewTypedFuncExpr(
 		funcRef,
@@ -494,7 +500,7 @@ func (b *Builder) buildArrayFlatten(
 	// The subquery here should always be uncorrelated: if it were not, we would
 	// have converted it to an aggregation.
 	if !af.Input.Relational().OuterCols.Empty() {
-		panic(errors.AssertionFailedf("input to ArrayFlatten should be uncorrelated"))
+		return nil, errors.AssertionFailedf("input to ArrayFlatten should be uncorrelated")
 	}
 
 	if b.planLazySubqueries {
@@ -634,7 +640,11 @@ func (b *Builder) buildExistsSubquery(
 		// arguments of the routine.
 		args := make(tree.TypedExprs, len(params))
 		for i := range args {
-			args[i] = b.indexedVar(ctx, b.mem.Metadata(), params[i])
+			indexedVar, err := b.indexedVar(ctx, b.mem.Metadata(), params[i])
+			if err != nil {
+				return nil, err
+			}
+			args[i] = indexedVar
 		}
 
 		// Create a new column for the boolean result.
@@ -734,7 +744,11 @@ func (b *Builder) buildSubquery(
 		// The arguments are indexed variables representing the outer columns.
 		args := make(tree.TypedExprs, len(params))
 		for i := range args {
-			args[i] = b.indexedVar(ctx, b.mem.Metadata(), params[i])
+			indexedVar, err := b.indexedVar(ctx, b.mem.Metadata(), params[i])
+			if err != nil {
+				return nil, err
+			}
+			args[i] = indexedVar
 		}
 
 		// Create a single-element RelListExpr representing the subquery.

--- a/pkg/sql/opt/exec/execbuilder/statement.go
+++ b/pkg/sql/opt/exec/execbuilder/statement.go
@@ -138,7 +138,11 @@ func (b *Builder) buildExplainOpt(explain *memo.ExplainExpr) (execPlan, error) {
 	// tell the exec factory what information it needs to fetch.
 	var envOpts exec.ExplainEnvData
 	if explain.Options.Flags[tree.ExplainFlagEnv] {
-		envOpts = b.getEnvData()
+		var err error
+		envOpts, err = b.getEnvData()
+		if err != nil {
+			return execPlan{}, err
+		}
 	}
 
 	node, err := b.factory.ConstructExplainOpt(planText.String(), envOpts)
@@ -397,7 +401,10 @@ func (b *Builder) buildExport(export *memo.ExportExpr) (execPlan, error) {
 			return execPlan{}, err
 		}
 	}
-	notNullColsSet := input.getNodeColumnOrdinalSet(export.Input.Relational().NotNullCols)
+	notNullColsSet, err := input.getNodeColumnOrdinalSet(export.Input.Relational().NotNullCols)
+	if err != nil {
+		return execPlan{}, err
+	}
 
 	node, err := b.factory.ConstructExport(
 		input.root,


### PR DESCRIPTION
This commit replaces `panic`s in execbuilder with returned errors. This
is safer because execbuilder functions are invoked outside the
panic-recoverable `Optimizer.Optimize` function.

Informs #98786

Release note: None
