### PR TITLE
clusterversion: clarify where to add new version gates during stability

### DIFF
--- a/docs/generated/settings/settings-for-tenants.txt
+++ b/docs/generated/settings/settings-for-tenants.txt
@@ -291,4 +291,4 @@ trace.opentelemetry.collector	string		address of an OpenTelemetry trace collecto
 trace.snapshot.rate	duration	0s	if non-zero, interval at which background trace snapshots are captured	tenant-rw
 trace.span_registry.enabled	boolean	true	if set, ongoing traces can be seen at https://<ui>/#/debug/tracez	tenant-rw
 trace.zipkin.collector	string		the address of a Zipkin instance to receive traces, as <host>:<port>. If no port is specified, 9411 will be used.	tenant-rw
-version	version	1000023.1-4	set the active cluster version in the format '<major>.<minor>'	tenant-rw
+version	version	1000023.1-2	set the active cluster version in the format '<major>.<minor>'	tenant-rw

--- a/docs/generated/settings/settings.html
+++ b/docs/generated/settings/settings.html
@@ -244,6 +244,6 @@
 <tr><td><div id="setting-trace-snapshot-rate" class="anchored"><code>trace.snapshot.rate</code></div></td><td>duration</td><td><code>0s</code></td><td>if non-zero, interval at which background trace snapshots are captured</td><td>Serverless/Dedicated/Self-Hosted</td></tr>
 <tr><td><div id="setting-trace-span-registry-enabled" class="anchored"><code>trace.span_registry.enabled</code></div></td><td>boolean</td><td><code>true</code></td><td>if set, ongoing traces can be seen at https://&lt;ui&gt;/#/debug/tracez</td><td>Serverless/Dedicated/Self-Hosted</td></tr>
 <tr><td><div id="setting-trace-zipkin-collector" class="anchored"><code>trace.zipkin.collector</code></div></td><td>string</td><td><code></code></td><td>the address of a Zipkin instance to receive traces, as &lt;host&gt;:&lt;port&gt;. If no port is specified, 9411 will be used.</td><td>Serverless/Dedicated/Self-Hosted</td></tr>
-<tr><td><div id="setting-version" class="anchored"><code>version</code></div></td><td>version</td><td><code>1000023.1-4</code></td><td>set the active cluster version in the format &#39;&lt;major&gt;.&lt;minor&gt;&#39;</td><td>Serverless/Dedicated/Self-Hosted</td></tr>
+<tr><td><div id="setting-version" class="anchored"><code>version</code></div></td><td>version</td><td><code>1000023.1-2</code></td><td>set the active cluster version in the format &#39;&lt;major&gt;.&lt;minor&gt;&#39;</td><td>Serverless/Dedicated/Self-Hosted</td></tr>
 </tbody>
 </table>

--- a/pkg/cli/testdata/declarative-rules/deprules
+++ b/pkg/cli/testdata/declarative-rules/deprules
@@ -1,6 +1,6 @@
 dep
 ----
-debug declarative-print-rules 1000023.1-4 dep
+debug declarative-print-rules 1000023.1-2 dep
 deprules
 ----
 - name: 'CheckConstraint transitions to ABSENT uphold 2-version invariant: PUBLIC->VALIDATED'

--- a/pkg/cli/testdata/declarative-rules/oprules
+++ b/pkg/cli/testdata/declarative-rules/oprules
@@ -1,6 +1,6 @@
 op
 ----
-debug declarative-print-rules 1000023.1-4 op
+debug declarative-print-rules 1000023.1-2 op
 rules
 ----
 []

--- a/pkg/clusterversion/cockroach_versions.go
+++ b/pkg/clusterversion/cockroach_versions.go
@@ -510,23 +510,35 @@ const (
 	// that are optimized for the console.
 	V23_1AddSystemActivityTables
 
+	// V23_1StopWritingPayloadAndProgressToSystemJobs is the version where the
+	// payload and progress columns are no longer written to system.jobs.
+	V23_1StopWritingPayloadAndProgressToSystemJobs
+
 	// V23_1ChangeSQLStatsTTL is the version where the gc TTL was updated to all
 	// SQL Stats tables.
 	V23_1ChangeSQLStatsTTL
 
+	// **********************************************************
+	// ** If we haven't yet selected a final 23.1 RC candidate **
+	// Step 1a: Add new versions for release-23.1 branch above here.
+	// **********************************************************
+	// Where to add new versions?
+	// - If the version gate is being backported to release-23.1, add the new version above this comment.
+	//   This can be done during 23.1 Stability until we select a final RC.
+	// - If the version gate is for 23.2 development (not being backported to release-23.1), add the
+	//   new version above "Step 1b"
+	// - Do not add new versions to a patch release.
+	// *************************************************
+
 	// V23_1 is CockroachDB v23.1. It's used for all v23.1.x patch releases.
 	V23_1
 
-	// V23_2_Start demarcates the start of cluster versions stepped through during
+	// V23_2Start demarcates the start of cluster versions stepped through during
 	// the process of upgrading from previous supported releases to 23.2.
 	V23_2Start
 
-	// V23_2StopWritingPayloadAndProgressToSystemJobs is the version where the
-	// payload and progress columns are no longer written to system.jobs.
-	V23_2StopWritingPayloadAndProgressToSystemJobs
-
 	// *************************************************
-	// Step (1): Add new versions here.
+	// Step 1b: Add new version for 23.2 development here.
 	// Do not add new versions to a patch release.
 	// *************************************************
 )
@@ -899,9 +911,26 @@ var rawVersionsSingleton = keyedVersions{
 		Version: roachpb.Version{Major: 22, Minor: 2, Internal: 94},
 	},
 	{
-		Key:     V23_1ChangeSQLStatsTTL,
+		Key:     V23_1StopWritingPayloadAndProgressToSystemJobs,
 		Version: roachpb.Version{Major: 22, Minor: 2, Internal: 96},
 	},
+	{
+		Key:     V23_1ChangeSQLStatsTTL,
+		Version: roachpb.Version{Major: 22, Minor: 2, Internal: 98},
+	},
+
+	// **********************************************************
+	// ** If we haven't yet selected a final 23.1 RC candidate **
+	// Step 2a: Add new versions for release-23.1 branch above here.
+	// **********************************************************
+	// Where to add new versions?
+	// - If the version gate is being backported to release-23.1, add the new version above this comment.
+	//   This can be done during 23.1 Stability until we select a final RC.
+	// - If the version gate is for 23.2 development (not being backported to release-23.1), add the
+	//   new version above "Step 2b"
+	// - Do not add new versions to a patch release.
+	// *************************************************
+
 	{
 		Key:     V23_1,
 		Version: roachpb.Version{Major: 23, Minor: 1, Internal: 0},
@@ -910,13 +939,9 @@ var rawVersionsSingleton = keyedVersions{
 		Key:     V23_2Start,
 		Version: roachpb.Version{Major: 23, Minor: 1, Internal: 2},
 	},
-	{
-		Key:     V23_2StopWritingPayloadAndProgressToSystemJobs,
-		Version: roachpb.Version{Major: 23, Minor: 1, Internal: 4},
-	},
 
 	// *************************************************
-	// Step (2): Add new versions here.
+	// Step 2b: Add new version gates for 23.2 development here.
 	// Do not add new versions to a patch release.
 	// *************************************************
 }

--- a/pkg/jobs/registry.go
+++ b/pkg/jobs/registry.go
@@ -501,7 +501,7 @@ func batchJobInsertStmt(
 
 	// TODO(adityamaru: Remove this once we are outside the compatability
 	// window for 22.2.
-	if r.settings.Version.IsActive(ctx, clusterversion.V23_2StopWritingPayloadAndProgressToSystemJobs) {
+	if r.settings.Version.IsActive(ctx, clusterversion.V23_1StopWritingPayloadAndProgressToSystemJobs) {
 		columns = []string{`id`, `created`, `status`, `claim_session_id`, `claim_instance_id`, `job_type`}
 		valueFns = map[string]func(*Job) (interface{}, error){
 			`id`:                func(job *Job) (interface{}, error) { return job.ID(), nil },
@@ -615,7 +615,7 @@ func (r *Registry) CreateJobWithTxn(
 		cols := []string{"id", "created", "status", "payload", "progress", "claim_session_id", "claim_instance_id", "job_type"}
 		vals := []interface{}{jobID, created, StatusRunning, payloadBytes, progressBytes, s.ID().UnsafeBytes(), r.ID(), jobType.String()}
 		log.Infof(ctx, "active version is %s", r.settings.Version.ActiveVersion(ctx))
-		if r.settings.Version.IsActive(ctx, clusterversion.V23_2StopWritingPayloadAndProgressToSystemJobs) {
+		if r.settings.Version.IsActive(ctx, clusterversion.V23_1StopWritingPayloadAndProgressToSystemJobs) {
 			cols = []string{"id", "created", "status", "claim_session_id", "claim_instance_id", "job_type"}
 			vals = []interface{}{jobID, created, StatusRunning, s.ID().UnsafeBytes(), r.ID(), jobType.String()}
 		}
@@ -739,7 +739,7 @@ func (r *Registry) CreateAdoptableJobWithTxn(
 		if !r.settings.Version.IsActive(ctx, clusterversion.V23_1AddTypeColumnToJobsTable) {
 			nCols -= 1
 		}
-		if r.settings.Version.IsActive(ctx, clusterversion.V23_2StopWritingPayloadAndProgressToSystemJobs) {
+		if r.settings.Version.IsActive(ctx, clusterversion.V23_1StopWritingPayloadAndProgressToSystemJobs) {
 			cols = []string{"id", "status", "created_by_type", "created_by_id", "job_type"}
 			placeholders = []string{"$1", "$2", "$3", "$4", "$5"}
 			values = []interface{}{jobID, StatusRunning, createdByType, createdByID, typ}

--- a/pkg/jobs/update.go
+++ b/pkg/jobs/update.go
@@ -220,7 +220,7 @@ func (u Updater) update(ctx context.Context, useReadLock bool, updateFn UpdateFn
 		}
 	}
 
-	if !u.j.registry.settings.Version.IsActive(ctx, clusterversion.V23_2StopWritingPayloadAndProgressToSystemJobs) {
+	if !u.j.registry.settings.Version.IsActive(ctx, clusterversion.V23_1StopWritingPayloadAndProgressToSystemJobs) {
 		if payloadBytes != nil {
 			addSetter("payload", payloadBytes)
 		}

--- a/pkg/upgrade/upgrades/upgrades.go
+++ b/pkg/upgrade/upgrades/upgrades.go
@@ -312,7 +312,7 @@ var upgrades = []upgradebase.Upgrade{
 	),
 	upgrade.NewTenantUpgrade(
 		"stop writing payload and progress to system.jobs",
-		toCV(clusterversion.V23_2StopWritingPayloadAndProgressToSystemJobs),
+		toCV(clusterversion.V23_1StopWritingPayloadAndProgressToSystemJobs),
 		upgrade.NoPrecondition,
 		alterPayloadColumnToNullable,
 	),


### PR DESCRIPTION
The previous direction said to always put append version gates to the end
of the list. However, during the stability period, before we mint the
release branch, there are two places to add new gates:

- new gates should go _before_ the "mint" version, if it is being backported
  to the release branch and we have not yet merged the "mint" version to
  the release branch.
- new gates for the upcoming development, should be appended to the end
  of the list.

This direction should be reverted/simplified (to direct to always append) once the commit to "mint" 23.1 has been backported and merged to release-23.1. Tracking issue for this is: https://cockroachlabs.atlassian.net/browse/REL-311

Release note: None
Epic: REL-283