### PR TITLE
logictest: correctly disable auto stats on system tables

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/testdata/explain_analyze
+++ b/pkg/sql/opt/exec/execbuilder/testdata/explain_analyze
@@ -124,18 +124,14 @@ regions: <hidden>
 statement ok
 GRANT SELECT ON crdb_internal.tables TO root;
 
-# For some reason, even though we explicitly disable the automatic stats
-# collection for both user and system tables, rarely we still see that the stats
-# on system.privileges were collected, so we filter out a single line from the
-# output to make the test deterministic.
 query T
-SELECT * FROM [EXPLAIN (VERBOSE) SELECT * FROM system.privileges WHERE path = 'vtable/crdb_internal/tables']
-  WHERE info NOT LIKE '%estimated row count%';
+EXPLAIN (VERBOSE) SELECT * FROM system.privileges WHERE path = 'vtable/crdb_internal/tables'
 ----
 distribution: local
 vectorized: true
 ·
 • scan
   columns: (username, path, privileges, grant_options, user_id)
+  estimated row count: 10 (missing stats)
   table: privileges@privileges_path_user_id_key
   spans: /"vtable/crdb_internal/tables"-/"vtable/crdb_internal/tables"/PrefixEnd


### PR DESCRIPTION
This commit fixes an oversight of https://github.com/cockroachdb/cockroach/commit/9c6fcd19a0892592b11bc803408b6daad0c780dc
where we attempted to disable the auto stats collection on system tables
by overriding the corresponding cluster setting before the cluster is
started. The problem with that change was that we overrode the cluster
setting object that is only used by the temp storage config and has no
bearing on the settings used by each node in the cluster. As it turns
out, previously we didn't explicitly initialize the `Settings` field of
the arguments for each node, so a fresh copy was always created. This
oversight is now fixed - we explicitly create a settings object for each
node / tenant and then override the auto stats on system tables to be
disabled on it.

Fixes: #99897.

Release note: None