### PR TITLE
logictest: skip flaky distsql_automatic_stats for now

### DIFF
--- a/pkg/ccl/logictestccl/tests/3node-tenant/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/3node-tenant/generated_test.go
@@ -605,13 +605,6 @@ func TestTenantLogic_distinct_on(
 	runLogicTest(t, "distinct_on")
 }
 
-func TestTenantLogic_distsql_automatic_stats(
-	t *testing.T,
-) {
-	defer leaktest.AfterTest(t)()
-	runLogicTest(t, "distsql_automatic_stats")
-}
-
 func TestTenantLogic_distsql_event_log(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/testdata/logic_test/distsql_automatic_stats
+++ b/pkg/sql/logictest/testdata/logic_test/distsql_automatic_stats
@@ -1,4 +1,8 @@
-# LogicTest: !metamorphic-batch-sizes
+# LogicTest: local !local !metamorphic-batch-sizes
+
+# TODO(yuzefovich): at the moment the tests below that assert a particular set
+# of statistics are flaky, so we disable this file by using a contradictory
+# config set. Once #99751 is addressed, "local !local" part should be removed.
 
 # Disable automatic stats
 statement ok

--- a/pkg/sql/logictest/tests/fakedist-disk/generated_test.go
+++ b/pkg/sql/logictest/tests/fakedist-disk/generated_test.go
@@ -583,13 +583,6 @@ func TestLogic_distinct_on(
 	runLogicTest(t, "distinct_on")
 }
 
-func TestLogic_distsql_automatic_stats(
-	t *testing.T,
-) {
-	defer leaktest.AfterTest(t)()
-	runLogicTest(t, "distsql_automatic_stats")
-}
-
 func TestLogic_distsql_event_log(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/fakedist-vec-off/generated_test.go
+++ b/pkg/sql/logictest/tests/fakedist-vec-off/generated_test.go
@@ -583,13 +583,6 @@ func TestLogic_distinct_on(
 	runLogicTest(t, "distinct_on")
 }
 
-func TestLogic_distsql_automatic_stats(
-	t *testing.T,
-) {
-	defer leaktest.AfterTest(t)()
-	runLogicTest(t, "distsql_automatic_stats")
-}
-
 func TestLogic_distsql_event_log(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/fakedist/generated_test.go
+++ b/pkg/sql/logictest/tests/fakedist/generated_test.go
@@ -583,13 +583,6 @@ func TestLogic_distinct_on(
 	runLogicTest(t, "distinct_on")
 }
 
-func TestLogic_distsql_automatic_stats(
-	t *testing.T,
-) {
-	defer leaktest.AfterTest(t)()
-	runLogicTest(t, "distsql_automatic_stats")
-}
-
 func TestLogic_distsql_event_log(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/local-legacy-schema-changer/generated_test.go
+++ b/pkg/sql/logictest/tests/local-legacy-schema-changer/generated_test.go
@@ -576,13 +576,6 @@ func TestLogic_distinct_on(
 	runLogicTest(t, "distinct_on")
 }
 
-func TestLogic_distsql_automatic_stats(
-	t *testing.T,
-) {
-	defer leaktest.AfterTest(t)()
-	runLogicTest(t, "distsql_automatic_stats")
-}
-
 func TestLogic_distsql_event_log(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/local-vec-off/generated_test.go
+++ b/pkg/sql/logictest/tests/local-vec-off/generated_test.go
@@ -583,13 +583,6 @@ func TestLogic_distinct_on(
 	runLogicTest(t, "distinct_on")
 }
 
-func TestLogic_distsql_automatic_stats(
-	t *testing.T,
-) {
-	defer leaktest.AfterTest(t)()
-	runLogicTest(t, "distsql_automatic_stats")
-}
-
 func TestLogic_distsql_event_log(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/local/generated_test.go
+++ b/pkg/sql/logictest/tests/local/generated_test.go
@@ -604,13 +604,6 @@ func TestLogic_distinct_on(
 	runLogicTest(t, "distinct_on")
 }
 
-func TestLogic_distsql_automatic_stats(
-	t *testing.T,
-) {
-	defer leaktest.AfterTest(t)()
-	runLogicTest(t, "distsql_automatic_stats")
-}
-
 func TestLogic_distsql_event_log(
 	t *testing.T,
 ) {

--- a/pkg/sql/opt/exec/execbuilder/testdata/forecast
+++ b/pkg/sql/opt/exec/execbuilder/testdata/forecast
@@ -13,7 +13,7 @@ statement ok
 SET CLUSTER SETTING sql.stats.forecasts.enabled = true
 
 statement ok
-CREATE TABLE g (a INT PRIMARY KEY) WITH (sql_stats_automatic_collection_enabled = false)
+CREATE TABLE g (a INT PRIMARY KEY)
 
 statement ok
 ALTER TABLE g INJECT STATISTICS '[
@@ -211,7 +211,7 @@ scan g
 # shrinks at a constant rate.
 
 statement ok
-CREATE TABLE s (b INT PRIMARY KEY) WITH (sql_stats_automatic_collection_enabled = false)
+CREATE TABLE s (b INT PRIMARY KEY)
 
 statement ok
 ALTER TABLE s INJECT STATISTICS '[
@@ -430,7 +430,7 @@ scan s
 # changes at a constant rate.
 
 statement ok
-CREATE TABLE c (h TIMESTAMPTZ PRIMARY KEY) WITH (sql_stats_automatic_collection_enabled = false)
+CREATE TABLE c (h TIMESTAMPTZ PRIMARY KEY)
 
 statement ok
 ALTER TABLE c INJECT STATISTICS '[
@@ -608,7 +608,7 @@ scan c
 # Test for issue 86344.
 
 statement ok
-CREATE TABLE x (a INT PRIMARY KEY) WITH (sql_stats_automatic_collection_enabled = false);
+CREATE TABLE x (a INT PRIMARY KEY)
 
 statement ok
 ALTER TABLE x INJECT STATISTICS '[
@@ -745,8 +745,7 @@ WHERE stat->>'name' = '__forecast__';
 # Test that we can disable forecasts for individual tables.
 
 statement ok
-CREATE TABLE d (d DATE PRIMARY KEY)
-WITH (sql_stats_automatic_collection_enabled = false, sql_stats_forecasts_enabled = false)
+CREATE TABLE d (d DATE PRIMARY KEY) WITH (sql_stats_forecasts_enabled = false)
 
 statement ok
 ALTER TABLE d INJECT STATISTICS '[
@@ -1281,7 +1280,7 @@ CREATE TABLE t (
   b INT,
   INDEX (a) STORING (b),
   INDEX (b) STORING (a)
-) WITH (sql_stats_automatic_collection_enabled = false)
+)
 
 statement ok
 ALTER TABLE t INJECT STATISTICS '[

--- a/pkg/sql/opt/exec/execbuilder/testdata/partial_stats
+++ b/pkg/sql/opt/exec/execbuilder/testdata/partial_stats
@@ -17,7 +17,7 @@ statement ok
 SET CLUSTER SETTING sql.stats.forecasts.enabled = true
 
 statement ok
-CREATE TABLE g (b INT PRIMARY KEY) WITH (sql_stats_automatic_collection_enabled = false)
+CREATE TABLE g (b INT PRIMARY KEY)
 
 statement ok
 ALTER TABLE g INJECT STATISTICS '[
@@ -447,7 +447,7 @@ WHERE stat->>'name' = '__forecast__';
 # updated to that of the partial statistic.
 
 statement ok
-CREATE TABLE h (h INT PRIMARY KEY) WITH (sql_stats_automatic_collection_enabled = false);;
+CREATE TABLE h (h INT PRIMARY KEY)
 
 statement ok
 ALTER TABLE h INJECT STATISTICS '
@@ -573,7 +573,7 @@ WHERE stat->>'name' = '__merged__';
 # values to the start and end of our column.
 
 statement ok
-CREATE TABLE i (i INT PRIMARY KEY) WITH (sql_stats_automatic_collection_enabled = false);
+CREATE TABLE i (i INT PRIMARY KEY)
 
 statement ok
 ALTER TABLE i INJECT STATISTICS '[


### PR DESCRIPTION
**execbuilder: remove redundant auto stats table overrides**

This commit removes table settings overrides of the auto stats
collection in several places. This is unnecessary given that we
explicitly disable the auto stats collection for the whole cluster in
the logic tests.

Release note: None

**logictest: skip flaky distsql_automatic_stats for now**

We've seen this file become more flaky recently, so let's skip it for
now.

Informs: #99751.

Release note: None