### PR TITLE
upgrades: make web_sessions migration delete rows for dropped users

### DIFF
--- a/pkg/upgrade/upgrades/web_sessions_table_user_id_migration_test.go
+++ b/pkg/upgrade/upgrades/web_sessions_table_user_id_migration_test.go
@@ -98,6 +98,11 @@ VALUES (
 	'2023-02-14 20:56:30.699447'
 )
 `, i))
+
+		// Drop every tenth user.
+		if i%10 == 0 {
+			txRunner.Exec(t, fmt.Sprintf("DROP USER testuser%d", i))
+		}
 	})
 	tdb.CheckQueryResults(t, "SELECT count(*) FROM system.web_sessions", [][]string{{strconv.Itoa(numUsers)}})
 
@@ -134,7 +139,8 @@ VALUES (
 
 	// Check that the backfill was successful and correct.
 	tdb.CheckQueryResults(t, "SELECT * FROM system.web_sessions WHERE user_id IS NULL", [][]string{})
-	tdb.CheckQueryResults(t, "SELECT count(*) FROM system.web_sessions", [][]string{{strconv.Itoa(numUsers)}})
+	// Multiply by 9/10 because we dropped every tenth user.
+	tdb.CheckQueryResults(t, "SELECT count(*) FROM system.web_sessions", [][]string{{strconv.Itoa((numUsers * 9) / 10)}})
 	tdb.CheckQueryResults(t, "SELECT count(*) FROM system.web_sessions AS a JOIN system.users AS b ON a.username = b.username AND a.user_id <> b.user_id", [][]string{{"0"}})
 }
 


### PR DESCRIPTION
Since the web_sessions table is not modified when a user is dropped, it can have rows for dropped users. If the web_sessions GC task was turned off, these rows could stick around forever. They would block the addition of a non-nullable constraint, so now we get rid of them if needed.

No release note, since this issue was never released.

Epic: None
Release note: None