### PR TITLE
upgrades: update system.web_sessions migration to handle orphaned rows

### DIFF
--- a/pkg/upgrade/upgrades/web_sessions_table_user_id_migration_test.go
+++ b/pkg/upgrade/upgrades/web_sessions_table_user_id_migration_test.go
@@ -101,6 +101,12 @@ VALUES (
 	})
 	tdb.CheckQueryResults(t, "SELECT count(*) FROM system.web_sessions", [][]string{{strconv.Itoa(numUsers)}})
 
+	// Drop a user to test that migration deletes orphaned rows.
+	if numUsers > 0 {
+		tdb.Exec(t, "DROP USER testuser0")
+		numUsers -= 1
+	}
+
 	// Run migrations.
 	_, err := tc.Conns[0].ExecContext(ctx, `SET CLUSTER SETTING version = $1`,
 		clusterversion.ByKey(clusterversion.V23_1WebSessionsTableHasUserIDColumn).String())


### PR DESCRIPTION
This patch updates the system.web_sessions user ID migration to delete
orphaned rows (i.e. rows corresponding to users that have been dropped)
after backfilling user IDs. They need to be deleted since they block
the addition of the NOT NULL constraint on the column.

Part of #87079

Release note: None