### PR TITLE
kvserver: deflake `TestRejectedLeaseDoesntDictateClosedTimestamp`

### DIFF
--- a/pkg/kv/kvserver/client_raft_test.go
+++ b/pkg/kv/kvserver/client_raft_test.go
@@ -2093,10 +2093,10 @@ func runReplicateRestartAfterTruncation(t *testing.T, removeBeforeTruncateAndReA
 				},
 			},
 			RaftConfig: base.RaftConfig{
-				// Don't timeout raft leaders or range leases (see the relation between
-				// RaftElectionTimeoutTicks and RangeLeaseActiveDuration). This test expects
+				// Don't timeout raft leaders or range leases. This test expects
 				// tc.Servers[0] to hold the range lease for the range under test.
 				RaftElectionTimeoutTicks: 1000000,
+				RangeLeaseDuration:       time.Minute,
 			},
 		}
 	}

--- a/pkg/kv/kvserver/closed_timestamp_test.go
+++ b/pkg/kv/kvserver/closed_timestamp_test.go
@@ -680,12 +680,12 @@ func TestClosedTimestampFrozenAfterSubsumption(t *testing.T) {
 				ServerArgs: base.TestServerArgs{
 					Settings: cs,
 					RaftConfig: base.RaftConfig{
-						// We set the raft election timeout to a small duration. This should
-						// result in the node liveness duration being ~3.6 seconds. Note that
+						// We set the raft election timeout to a small duration. Note that
 						// if we set this too low, the test may flake due to the test
 						// cluster's nodes frequently missing their liveness heartbeats.
 						RaftHeartbeatIntervalTicks: 5,
 						RaftElectionTimeoutTicks:   6,
+						RangeLeaseDuration:         3 * time.Second,
 					},
 					Knobs: base.TestingKnobs{
 						Server: &server.TestingKnobs{

--- a/pkg/kv/kvserver/replica_closedts_test.go
+++ b/pkg/kv/kvserver/replica_closedts_test.go
@@ -539,7 +539,7 @@ func TestRejectedLeaseDoesntDictateClosedTimestamp(t *testing.T) {
 				RangeLeaseRenewalFraction: -1,
 				// Also make expiration-based leases last for a long time, as the test
 				// wants a valid lease after cluster start.
-				RaftElectionTimeoutTicks: 1000,
+				RangeLeaseDuration: time.Minute,
 			},
 			Knobs: base.TestingKnobs{
 				Server: &server.TestingKnobs{


### PR DESCRIPTION
And friends.

In 40cb0758 we decoupled the lease duration from the Raft election timeout. Some tests still relied on the election timeout to control lease durations.

Resolves #98938.
Resolves #99639.

Epic: none
Release note: None