### PR TITLE
backupccl: deflake TestFullClusterBackup

### DIFF
--- a/pkg/ccl/backupccl/full_cluster_backup_restore_test.go
+++ b/pkg/ccl/backupccl/full_cluster_backup_restore_test.go
@@ -286,6 +286,9 @@ CREATE TABLE data2.foo (a int);
 			case systemschema.CommentsTable.GetName():
 				query := fmt.Sprintf("SELECT comment FROM system.%s", table)
 				verificationQueries[i] = query
+			case systemschema.ScheduledJobsTable.GetName():
+				query := fmt.Sprintf("SELECT schedule_id, schedule_name FROM system.%s", table)
+				verificationQueries[i] = query
 			default:
 				query := fmt.Sprintf("SELECT * FROM system.%s", table)
 				verificationQueries[i] = query


### PR DESCRIPTION
TestFullClusterBackup would flake if the test ran at a specific time during the week due to #100094. This patch prevents this flake.

Fixes #100094

Release note: none