### PR TITLE
ccl/multiregionccl: skip flaky regional_by_row test

### DIFF
--- a/pkg/ccl/multiregionccl/testdata/regional_by_row
+++ b/pkg/ccl/multiregionccl/testdata/regional_by_row
@@ -1,3 +1,6 @@
+skip issue-num=98020
+----
+
 new-cluster localities=us-east-1,us-east-1,us-east-1,us-central-1,us-central-1,us-central-1,us-west-1,us-west-1,us-west-1,eu-central-1
 ----
 


### PR DESCRIPTION
Part of #98020.

Release note: None