### PR TITLE
release-22.2: sql: fix circular dependencies in views

### DIFF
--- a/pkg/sql/drop_view.go
+++ b/pkg/sql/drop_view.go
@@ -20,6 +20,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/funcdesc"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/tabledesc"
 	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/catid"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqltelemetry"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -169,6 +170,18 @@ func (p *planner) canRemoveDependentFromTable(
 	ref descpb.TableDescriptor_Reference,
 	behavior tree.DropBehavior,
 ) error {
+	if p.trackDependency == nil {
+		p.trackDependency = make(map[catid.DescID]bool)
+	}
+	if p.trackDependency[ref.ID] {
+		// This table's dependencies are already tracked.
+		return nil
+	}
+	p.trackDependency[ref.ID] = true
+	defer func() {
+		p.trackDependency[ref.ID] = false
+	}()
+
 	return p.canRemoveDependent(ctx, string(from.DescriptorType()), from.Name, from.ParentID, ref, behavior)
 }
 

--- a/pkg/sql/logictest/testdata/logic_test/views
+++ b/pkg/sql/logictest/testdata/logic_test/views
@@ -21,12 +21,12 @@ CREATE VIEW v1 AS SELECT a, b FROM t
 statement error pgcode 42P07 relation \"test.public.t\" already exists
 CREATE VIEW t AS SELECT a, b FROM t
 
-# view statement ignored if other way around.
-statement ok
-CREATE VIEW IF NOT EXISTS v1 AS SELECT b, a FROM v1
-
 statement ok
 CREATE VIEW IF NOT EXISTS v2 (x, y) AS SELECT a, b FROM t
+
+# view statement ignored if other way around.
+statement ok
+CREATE VIEW IF NOT EXISTS v2 AS SELECT b, a FROM v1
 
 statement error pgcode 42601 CREATE VIEW specifies 1 column name, but data source has 2 columns
 CREATE VIEW v3 (x) AS SELECT a, b FROM t
@@ -1498,3 +1498,37 @@ SELECT * FROM v;
 
 statement ok
 SET DATABASE = test;
+
+subtest circular_dependency
+
+statement ok
+CREATE TABLE t (a INT PRIMARY KEY, b INT);
+
+statement ok
+CREATE VIEW cd_v1 AS SELECT a, b FROM t;
+
+statement ok
+CREATE VIEW cd_v2 AS SELECT a, b FROM cd_v1;
+
+# Note: Creating a circular dependency in views does not result in an error in
+# postgres. In postgres, we only encounter errors during queries on the views.
+statement error pgcode 42P17 pq: cyclic view dependency for relation test.public.cd_v1
+CREATE OR REPLACE VIEW cd_v1 AS SELECT a, b FROM cd_v2;
+
+statement ok
+CREATE VIEW cd_v3 AS SELECT a, b FROM cd_v2;
+
+statement ok
+SELECT * FROM cd_v3;
+
+statement error pgcode 42P17 pq: cyclic view dependency for relation test.public.cd_v1
+CREATE OR REPLACE VIEW cd_v1 AS SELECT a, b FROM cd_v3;
+
+statement ok
+SELECT * FROM cd_v3;
+
+statement error pq: cannot drop relation "cd_v1" because view "cd_v2" depends on it
+DROP VIEW cd_v1;
+
+statement ok
+DROP VIEW cd_v1 CASCADE;

--- a/pkg/sql/opt/optbuilder/builder.go
+++ b/pkg/sql/opt/optbuilder/builder.go
@@ -112,6 +112,10 @@ type Builder struct {
 	// are referenced multiple times in the same query.
 	views map[cat.View]*tree.Select
 
+	// sourceViews contains a map with all the views in the current data source
+	// chain. It is used to detect circular dependencies.
+	sourceViews map[string]struct{}
+
 	// subquery contains a pointer to the subquery which is currently being built
 	// (if any).
 	subquery *subquery

--- a/pkg/sql/opt/optbuilder/create_view.go
+++ b/pkg/sql/opt/optbuilder/create_view.go
@@ -37,12 +37,17 @@ func (b *Builder) buildCreateView(cv *tree.CreateView, inScope *scope) (outScope
 	b.insideViewDef = true
 	b.trackSchemaDeps = true
 	b.qualifyDataSourceNamesInAST = true
+	if b.sourceViews == nil {
+		b.sourceViews = make(map[string]struct{})
+	}
+	b.sourceViews[viewName.FQString()] = struct{}{}
 	defer func() {
 		b.insideViewDef = false
 		b.trackSchemaDeps = false
 		b.schemaDeps = nil
 		b.schemaTypeDeps = util.FastIntSet{}
 		b.qualifyDataSourceNamesInAST = false
+		delete(b.sourceViews, viewName.FQString())
 
 		b.semaCtx.FunctionResolver = preFuncResolver
 		maybePanicOnUnknownFunction("view query")

--- a/pkg/sql/planner.go
+++ b/pkg/sql/planner.go
@@ -34,6 +34,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/idxusage"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/querycache"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/catid"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/eval"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/transform"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
@@ -256,6 +257,9 @@ type planner struct {
 
 	// evalCatalogBuiltins is used as part of the eval.Context.
 	evalCatalogBuiltins evalcatalog.Builtins
+
+	// trackDependency is used to track circular dependencies when dropping views.
+	trackDependency map[catid.DescID]bool
 }
 
 func (evalCtx *extendedEvalContext) setSessionID(sessionID clusterunique.ID) {


### PR DESCRIPTION
Backport 1/1 commits from #99174.

/cc @cockroachdb/release

---

This change fixes node crashes that could happen due to stack overflow if views were created with circular dependencies.

Fixes: #98999
Epic: none
Co-authored-by: chengxiong@cockroachlabs.com

Release note (bug fix): If views are created with circular dependencies, CRDB returns the error "cyclic view dependency for relation" instead of crashing the node. This bug is present since at least 21.1.

Release justification: Fixes a bug that can cause the gateway node to
crash if there are self-referencing views.
