### PR TITLE
pgwire: add server.cockroach_cloud.max_client_connections_per_gateway cluster setting

### DIFF
--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -323,7 +323,8 @@ type Server struct {
 
 	mu struct {
 		syncutil.Mutex
-		connectionCount int64
+		connectionCount     int64
+		rootConnectionCount int64
 	}
 }
 
@@ -789,6 +790,14 @@ func (s *Server) IncrementConnectionCount() {
 	s.mu.connectionCount++
 }
 
+// IncrementRootConnectionCount increases both connectionCount and rootConnectionCount by 1.
+func (s *Server) IncrementRootConnectionCount() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.mu.connectionCount++
+	s.mu.rootConnectionCount++
+}
+
 // DecrementConnectionCount decreases connectionCount by 1.
 func (s *Server) DecrementConnectionCount() {
 	s.mu.Lock()
@@ -796,7 +805,15 @@ func (s *Server) DecrementConnectionCount() {
 	s.mu.connectionCount--
 }
 
-// IncrementConnectionCountIfLessThan increases connectionCount by and returns true if allowedConnectionCount < max,
+// DecrementRootConnectionCount decreases both connectionCount and rootConnectionCount by 1.
+func (s *Server) DecrementRootConnectionCount() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.mu.connectionCount--
+	s.mu.rootConnectionCount--
+}
+
+// IncrementConnectionCountIfLessThan increases connectionCount by 1 and returns true if connectionCount < max,
 // otherwise it does nothing and returns false.
 func (s *Server) IncrementConnectionCountIfLessThan(max int64) bool {
 	s.mu.Lock()
@@ -813,6 +830,13 @@ func (s *Server) GetConnectionCount() int64 {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	return s.mu.connectionCount
+}
+
+// GetNonRootConnectionCount returns the current number of non root connections.
+func (s *Server) GetNonRootConnectionCount() int64 {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.mu.connectionCount - s.mu.rootConnectionCount
 }
 
 // ConnectionHandler is the interface between the result of SetupConn

--- a/pkg/sql/pgwire/conn.go
+++ b/pkg/sql/pgwire/conn.go
@@ -232,13 +232,34 @@ func (c *conn) sendError(ctx context.Context, execCfg *sql.ExecutorConfig, err e
 }
 
 func (c *conn) checkMaxConnections(ctx context.Context, sqlServer *sql.Server) error {
+	// Root user is not affected by connection limits.
+	if c.sessionArgs.User.IsRootUser() {
+		sqlServer.IncrementRootConnectionCount()
+		return nil
+	}
+
+	// First check maxNumNonRootConnections.
+	// Note(alyshan): maxNumNonRootConnections is used by Cockroach Cloud for limiting connections to
+	// serverless clusters.
+	maxNonRootConnectionsValue := maxNumNonRootConnections.Get(&sqlServer.GetExecutorConfig().Settings.SV)
+	if maxNonRootConnectionsValue >= 0 && sqlServer.GetNonRootConnectionCount() >= maxNonRootConnectionsValue {
+		// TODO(alyshan): Add another cluster setting that supplements the error message, so that
+		// clients can know *why* this ReadOnly setting is set and limiting their connections.
+		return c.sendError(ctx, sqlServer.GetExecutorConfig(), errors.WithHintf(
+			pgerror.New(pgcode.TooManyConnections, "cluster connections are limited"),
+			"the maximum number of allowed connections is %d",
+			maxNonRootConnectionsValue,
+		))
+	}
+
+	// Then check maxNumNonAdminConnections.
 	if c.sessionArgs.IsSuperuser {
-		// This user is a super user and is therefore not affected by connection limits.
+		// This user is a super user and is therefore not affected by maxNumNonAdminConnections.
 		sqlServer.IncrementConnectionCount()
 		return nil
 	}
 
-	maxNumConnectionsValue := maxNumConnections.Get(&sqlServer.GetExecutorConfig().Settings.SV)
+	maxNumConnectionsValue := maxNumNonAdminConnections.Get(&sqlServer.GetExecutorConfig().Settings.SV)
 	if maxNumConnectionsValue < 0 {
 		// Unlimited connections are allowed.
 		sqlServer.IncrementConnectionCount()
@@ -249,7 +270,7 @@ func (c *conn) checkMaxConnections(ctx context.Context, sqlServer *sql.Server) e
 			pgerror.New(pgcode.TooManyConnections, "sorry, too many clients already"),
 			"the maximum number of allowed connections is %d and can be modified using the %s config key",
 			maxNumConnectionsValue,
-			maxNumConnections.Key(),
+			maxNumNonAdminConnections.Key(),
 		))
 	}
 	return nil
@@ -707,7 +728,11 @@ func (c *conn) processCommandsAsync(
 		if retErr = c.checkMaxConnections(ctx, sqlServer); retErr != nil {
 			return
 		}
-		defer sqlServer.DecrementConnectionCount()
+		if c.sessionArgs.User.IsRootUser() {
+			defer sqlServer.DecrementRootConnectionCount()
+		} else {
+			defer sqlServer.DecrementConnectionCount()
+		}
 
 		if retErr = c.authOKMessage(); retErr != nil {
 			return

--- a/pkg/sql/pgwire/conn.go
+++ b/pkg/sql/pgwire/conn.go
@@ -243,10 +243,13 @@ func (c *conn) checkMaxConnections(ctx context.Context, sqlServer *sql.Server) e
 	// serverless clusters.
 	maxNonRootConnectionsValue := maxNumNonRootConnections.Get(&sqlServer.GetExecutorConfig().Settings.SV)
 	if maxNonRootConnectionsValue >= 0 && sqlServer.GetNonRootConnectionCount() >= maxNonRootConnectionsValue {
-		// TODO(alyshan): Add another cluster setting that supplements the error message, so that
-		// clients can know *why* this ReadOnly setting is set and limiting their connections.
+		// Check if there is a reason to use in the error message.
+		msg := "cluster connections are limited"
+		if reason := maxNumNonRootConnectionsReason.Get(&sqlServer.GetExecutorConfig().Settings.SV); reason != "" {
+			msg = reason
+		}
 		return c.sendError(ctx, sqlServer.GetExecutorConfig(), errors.WithHintf(
-			pgerror.New(pgcode.TooManyConnections, "cluster connections are limited"),
+			pgerror.Newf(pgcode.TooManyConnections, "%s", msg),
 			"the maximum number of allowed connections is %d",
 			maxNonRootConnectionsValue,
 		))

--- a/pkg/sql/pgwire/conn_test.go
+++ b/pkg/sql/pgwire/conn_test.go
@@ -1946,6 +1946,13 @@ func TestPGWireRejectsNewConnIfTooManyConns(t *testing.T) {
 		require.NoError(t, err)
 	}
 
+	setMaxNonRootConnectionsReason := func(reason string) {
+		conn, cleanup := openConnWithUserSuccess(rootUser)
+		defer cleanup()
+		_, err := conn.Exec(ctx, "SET CLUSTER SETTING server.cockroach_cloud.max_client_connections_per_gateway_reason = $1", reason)
+		require.NoError(t, err)
+	}
+
 	createUser := func(user string, isAdmin bool) {
 		conn, cleanup := openConnWithUserSuccess(rootUser)
 		defer cleanup()
@@ -2052,6 +2059,19 @@ func TestPGWireRejectsNewConnIfTooManyConns(t *testing.T) {
 		rootCleanup()
 		nonAdminCleanup()
 		requireConnectionCount(t, 0)
+	})
+
+	t.Run("max_non_root_connections_reason", func(t *testing.T) {
+		setMaxNonRootConnections(0)
+		setMaxNonRootConnectionsReason("foobar")
+		requireConnectionCount(t, 0)
+		_, cleanup, err := openConnWithUser(admin)
+		defer cleanup()
+		require.Error(t, err)
+		var pgErr *pgconn.PgError
+		require.ErrorAs(t, err, &pgErr)
+		require.Equal(t, pgcode.TooManyConnections.String(), pgErr.Code)
+		require.Regexp(t, "foobar", pgErr.Error())
 	})
 }
 

--- a/pkg/sql/pgwire/server.go
+++ b/pkg/sql/pgwire/server.go
@@ -82,7 +82,11 @@ var logSessionAuth = settings.RegisterBoolSetting(
 	"if set, log SQL session login/disconnection events (note: may hinder performance on loaded nodes)",
 	false).WithPublic()
 
-var maxNumConnections = settings.RegisterIntSetting(
+// TODO(alyshan): This setting is enforcing max number of connections with superusers not being affected by
+// the limit. However, admin users connections are counted towards the max count. So we should either update the
+// description to say "the maximum number of connections per gateway ... Superusers are not affected by this limit"
+// or stop counting superuser connections towards the max count.
+var maxNumNonAdminConnections = settings.RegisterIntSetting(
 	settings.TenantWritable,
 	"server.max_connections_per_gateway",
 	"the maximum number of non-superuser SQL connections per gateway allowed at a given time "+
@@ -90,6 +94,21 @@ var maxNumConnections = settings.RegisterIntSetting(
 		"Negative values result in unlimited number of connections. Superusers are not affected by this limit.",
 	-1, // Postgres defaults to 100, but we default to -1 to match our previous behavior of unlimited.
 ).WithPublic()
+
+// Note(alyshan): This setting is not public. It is intended to be used by Cockroach Cloud to limit
+// connections to serverless clusters while still being able to connect from the Cockroach Cloud control plane.
+// This setting may be extended one day to include an arbitrary list of users to exclude from connection limiting.
+// This setting may be removed one day.
+var maxNumNonRootConnections = settings.RegisterIntSetting(
+	settings.TenantWritable,
+	"server.cockroach_cloud.max_client_connections_per_gateway",
+	"this setting is intended to be used by Cockroach Cloud for limiting connections to serverless clusters. "+
+		"The maximum number of SQL connections per gateway allowed at a given time "+
+		"(note: this will only limit future connection attempts and will not affect already established connections). "+
+		"Negative values result in unlimited number of connections. Cockroach Cloud internal users (including root user) "+
+		"are not affected by this limit.",
+	-1,
+)
 
 const (
 	// ErrSSLRequired is returned when a client attempts to connect to a

--- a/pkg/sql/pgwire/server.go
+++ b/pkg/sql/pgwire/server.go
@@ -110,6 +110,19 @@ var maxNumNonRootConnections = settings.RegisterIntSetting(
 	-1,
 )
 
+// maxNumNonRootConnectionsReason is used to supplement the error message for connections that denied due to
+// server.cockroach_cloud.max_client_connections_per_gateway.
+// Note(alyshan): This setting is not public. It is intended to be used by Cockroach Cloud when limiting
+// connections to serverless clusters.
+// This setting may be removed one day.
+var maxNumNonRootConnectionsReason = settings.RegisterStringSetting(
+	settings.TenantWritable,
+	"server.cockroach_cloud.max_client_connections_per_gateway_reason",
+	"a reason to provide in the error message for connections that are denied due to "+
+		"server.cockroach_cloud.max_client_connections_per_gateway",
+	"",
+)
+
 const (
 	// ErrSSLRequired is returned when a client attempts to connect to a
 	// secure server in cleartext.


### PR DESCRIPTION
This setting specifies a maximum number of external connections that a server can have open at any given time. External is defined as connections that are not root connections. In the future, we can have the definition of external be a configurable list of users.
<0 - Connections are unlimited (existing behavior)
=0 - External connections are disabled
>0 - External connections are limited
If a new connection would exceed this limit, an error message is returned as postgres: "cluster connections are limited" with the 53300 error code that corresponds to "too many connections".

This functionality is required for serverless.
Part of: https://cockroachlabs.atlassian.net/browse/CC-9288

Release note: None