### PR TITLE
kvserver: update TestSystemZoneConfigs

### DIFF
--- a/pkg/base/test_server_args.go
+++ b/pkg/base/test_server_args.go
@@ -188,6 +188,11 @@ type TestClusterArgs struct {
 	// waits for all nodes to start before returning.
 	ParallelStart bool
 
+	// If true, the test synchronously waits for span config subscription. This
+	// is needed if manually relocating ranges, or enqueueing them through
+	// select KV queues.
+	WaitForSpanConfigs bool
+
 	// ServerArgsPerNode override the default ServerArgs with the value in this
 	// map. The map's key is an index within TestCluster.Servers. If there is
 	// no entry in the map for a particular server, the default ServerArgs are

--- a/pkg/kv/kvserver/client_replica_backpressure_test.go
+++ b/pkg/kv/kvserver/client_replica_backpressure_test.go
@@ -69,6 +69,7 @@ func TestBackpressureNotAppliedWhenReducingRangeSize(t *testing.T) {
 		unblockCh := make(chan struct{}, 1)
 		var rangesBlocked sync.Map
 		args = base.TestClusterArgs{
+			WaitForSpanConfigs: true,
 			ServerArgs: base.TestServerArgs{
 				Knobs: base.TestingKnobs{
 					Store: &kvserver.StoreTestingKnobs{

--- a/pkg/kv/kvserver/client_replica_test.go
+++ b/pkg/kv/kvserver/client_replica_test.go
@@ -19,6 +19,7 @@ import (
 	"reflect"
 	"sort"
 	"strconv"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -2700,9 +2701,6 @@ func TestSystemZoneConfigs(t *testing.T) {
 					DisableLoadBasedSplitting: true,
 				},
 			},
-			// This test was written for the gossip-backed SystemConfigSpan
-			// infrastructure.
-			DisableSpanConfigs: true,
 			// Scan like a bat out of hell to ensure replication and replica GC
 			// happen in a timely manner.
 			ScanInterval: 50 * time.Millisecond,
@@ -2711,10 +2709,21 @@ func TestSystemZoneConfigs(t *testing.T) {
 	defer tc.Stopper().Stop(ctx)
 	log.Info(ctx, "TestSystemZoneConfig: test cluster started")
 
-	expectedSystemRanges, err := tc.Servers[0].ExpectedInitialRangeCount()
+	initialRangeCount, err := tc.Servers[0].ExpectedInitialRangeCount()
 	if err != nil {
 		t.Fatal(err)
 	}
+
+	// The initial splits we have when bootstrapping CRDB, look roughly like so:
+	//   r6:/Table/{0-3} [(n1,s1):1, (n4,s4):2, (n7,s7):3, (n3,s3):4, (n6,s6):5, next=6, gen=8]
+	//   r7:/Table/{3-4} [(n1,s1):1, (n6,s6):2, (n7,s7):3, (n4,s4):4, (n5,s5):5, next=6, gen=8]
+	//
+	// Span configs however collapse the known-empty /Table/{0-3} keyspace into
+	// the adjacent range, so we have:
+	//   r6:/Table/{0-4} [(n1,s1):1, (n4,s4):2, (n3,s3):3, (n2,s2):4, (n5,s5):5, next=6, gen=17]
+	//
+	// Which is why we have this -1 term below.
+	expectedSystemRanges := initialRangeCount - 1
 	expectedUserRanges := 1
 	expectedSystemRanges -= expectedUserRanges
 	systemNumReplicas := int(*zonepb.DefaultSystemZoneConfig().NumReplicas)
@@ -2745,8 +2754,19 @@ func TestSystemZoneConfigs(t *testing.T) {
 		for _, desc := range replicas {
 			totalReplicas += len(desc.Replicas().VoterDescriptors())
 		}
+		sortedDesc := make([]roachpb.RangeDescriptor, 0, len(replicas))
+		for _, desc := range replicas {
+			sortedDesc = append(sortedDesc, desc)
+		}
+		sort.Slice(sortedDesc, func(i, j int) bool {
+			return sortedDesc[i].RangeID < sortedDesc[j].RangeID
+		})
+		var buf strings.Builder
+		for _, desc := range sortedDesc {
+			buf.WriteString(fmt.Sprintf("%s\n", desc))
+		}
 		if totalReplicas != expectedReplicas {
-			return fmt.Errorf("got %d voters, want %d; details: %+v", totalReplicas, expectedReplicas, replicas)
+			return fmt.Errorf("got %d voters, want %d; details: %+v", totalReplicas, expectedReplicas, buf.String())
 		}
 		return nil
 	}

--- a/pkg/kv/kvserver/queue_helpers_testutil.go
+++ b/pkg/kv/kvserver/queue_helpers_testutil.go
@@ -44,7 +44,7 @@ func forceScanAndProcess(ctx context.Context, s *Store, q *baseQueue) error {
 		gotConfReader := false
 		for r := retry.Start(opts); r.Next(); {
 			if _, lastErr = s.GetConfReader(ctx); lastErr != nil {
-				if lastErr == errSpanConfigsUnavailable {
+				if errors.Is(lastErr, errSpanConfigsUnavailable) {
 					continue // retry
 				}
 				return errors.Wrap(lastErr, "unable to retrieve conf reader")

--- a/pkg/kv/kvserver/store.go
+++ b/pkg/kv/kvserver/store.go
@@ -3525,7 +3525,11 @@ func (s *Store) WaitForSpanConfigSubscription(ctx context.Context) error {
 		return nil // nothing to do here
 	}
 
-	for r := retry.StartWithCtx(ctx, base.DefaultRetryOptions()); r.Next(); {
+	ctx = s.AnnotateCtx(ctx)
+	for r := retry.StartWithCtx(ctx, retry.Options{
+		InitialBackoff: 50 * time.Millisecond,
+		MaxBackoff:     50 * time.Millisecond,
+	}); r.Next(); {
 		if !s.cfg.SpanConfigSubscriber.LastUpdated().IsEmpty() {
 			return nil
 		}

--- a/pkg/spanconfig/spanconfig.go
+++ b/pkg/spanconfig/spanconfig.go
@@ -84,20 +84,17 @@ type KVAccessor interface {
 // for the span[3].
 //
 // [1]: The contents of the StoreReader and ProtectedTSReader at t1 corresponds
-//
-//	exactly to the contents of the global span configuration state at t0
-//	where t0 <= t1. If the StoreReader or ProtectedTSReader is read from at
-//	t2 where t2 > t1, it's guaranteed to observe a view of the global state
-//	at t >= t0.
+// exactly to the contents of the global span configuration state at t0
+// where t0 <= t1. If the StoreReader or ProtectedTSReader is read from at
+// t2 where t2 > t1, it's guaranteed to observe a view of the global state
+// at t >= t0.
 //
 // [2]: For the canonical KVSubscriber implementation, this is typically lagging
-//
-//	by the closed timestamp target duration.
+// by the closed timestamp target duration.
 //
 // [3]: The canonical KVSubscriber implementation is bounced whenever errors
-//
-//	occur, which may result in the re-transmission of earlier updates
-//	(typically through a coarsely targeted [min,max) span).
+// occur, which may result in the re-transmission of earlier updates
+// (typically through a coarsely targeted [min,max) span).
 type KVSubscriber interface {
 	StoreReader
 	ProtectedTSReader

--- a/pkg/spanconfig/spanconfigkvsubscriber/BUILD.bazel
+++ b/pkg/spanconfig/spanconfigkvsubscriber/BUILD.bazel
@@ -27,6 +27,7 @@ go_library(
         "//pkg/sql/rowenc/valueside",
         "//pkg/sql/sem/tree",
         "//pkg/sql/types",
+        "//pkg/util/buildutil",
         "//pkg/util/hlc",
         "//pkg/util/log",
         "//pkg/util/metric",


### PR DESCRIPTION
Fixes #98200. This test was written pre-spanconfig days, and when enabling spanconfigs by default, opted out of using it. This commit makes it use spanconfigs after giving up on reproducing/diagnosing the original flake (this test is notoriously slow -- taking 30+s given it waits for actual upreplication and replica movement, so not --stress friendly).

Using spanconfigs here surfaced a rare, latent bug, one this author incorrectly thought was fixed back in #75939. In very rare cases, right during cluster bootstrap before the span config reconciler has ever had a chance to run (i.e. system.span_configurations is empty), it's possible that the subscriber has subscribed to an empty span config state (we've only seen this happen in unit tests with 50ms scan intervals). So it's not been meaningfully "updated" in any sense of the word, but we still previously set a non-empty last-updated timestamp, something various components in KV rely on as proof that we have span configs as of some timestamp. As a result, we saw KV incorrectly merge away the liveness range into adjacent ranges, and then later split it off. We don't think we've ever seen this happen outside of tests as it instantly triggers the following fatal in the raftScheduler, which wants to prioritize the liveness range above all else:

    panic: priority range ID already set: old=2, new=61, first set at:

Release note: None