### PR TITLE
sql: remove streaming builtins from docs

### DIFF
--- a/docs/generated/sql/functions.md
+++ b/docs/generated/sql/functions.md
@@ -2676,29 +2676,6 @@ The swap_ordinate_string parameter is a 2-character string naming the ordinates 
 </span></td><td>Immutable</td></tr></tbody>
 </table>
 
-### Stream Ingestion functions
-
-<table>
-<thead><tr><th>Function &rarr; Returns</th><th>Description</th><th>Volatility</th></tr></thead>
-<tbody>
-<tr><td><a name="crdb_internal.complete_replication_stream"></a><code>crdb_internal.complete_replication_stream(stream_id: <a href="int.html">int</a>, successful_ingestion: <a href="bool.html">bool</a>) &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>This function can be used on the producer side to complete and clean up a replication stream.‘successful_ingestion’ indicates whether the stream ingestion finished successfully.</p>
-</span></td><td>Volatile</td></tr>
-<tr><td><a name="crdb_internal.complete_stream_ingestion_job"></a><code>crdb_internal.complete_stream_ingestion_job(job_id: <a href="int.html">int</a>, cutover_ts: <a href="timestamp.html">timestamptz</a>) &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>This function can be used to signal a running stream ingestion job to complete. The job will eventually stop ingesting, revert to the specified timestamp and leave the cluster in a consistent state. The specified timestamp can only be specified up to the microsecond. This function does not wait for the job to reach a terminal state, but instead returns the job id as soon as it has signaled the job to complete. This builtin can be used in conjunction with <code>SHOW JOBS WHEN COMPLETE</code> to ensure that the job has left the cluster in a consistent state.</p>
-</span></td><td>Volatile</td></tr>
-<tr><td><a name="crdb_internal.replication_stream_progress"></a><code>crdb_internal.replication_stream_progress(stream_id: <a href="int.html">int</a>, frontier_ts: <a href="string.html">string</a>) &rarr; <a href="bytes.html">bytes</a></code></td><td><span class="funcdesc"><p>This function can be used on the consumer side to heartbeat its replication progress to a replication stream in the source cluster. The returns a StreamReplicationStatus message that indicates stream status (<code>ACTIVE</code>, <code>PAUSED</code>, <code>INACTIVE</code>, or <code>STATUS_UNKNOWN_RETRY</code>).</p>
-</span></td><td>Volatile</td></tr>
-<tr><td><a name="crdb_internal.replication_stream_spec"></a><code>crdb_internal.replication_stream_spec(stream_id: <a href="int.html">int</a>) &rarr; <a href="bytes.html">bytes</a></code></td><td><span class="funcdesc"><p>This function can be used on the consumer side to get a replication stream specification for the specified stream. The consumer will later call ‘stream_partition’ to a partition with the spec to start streaming.</p>
-</span></td><td>Volatile</td></tr>
-<tr><td><a name="crdb_internal.start_replication_stream"></a><code>crdb_internal.start_replication_stream(tenant_name: <a href="string.html">string</a>) &rarr; <a href="bytes.html">bytes</a></code></td><td><span class="funcdesc"><p>This function can be used on the producer side to start a replication stream for the specified tenant. The returned stream ID uniquely identifies created stream. The caller must periodically invoke crdb_internal.heartbeat_stream() function to notify that the replication is still ongoing.</p>
-</span></td><td>Volatile</td></tr>
-<tr><td><a name="crdb_internal.stream_ingestion_stats_json"></a><code>crdb_internal.stream_ingestion_stats_json(job_id: <a href="int.html">int</a>) &rarr; jsonb</code></td><td><span class="funcdesc"><p>DEPRECATED, consider using <code>SHOW TENANT name WITH REPLICATION STATUS</code></p>
-</span></td><td>Volatile</td></tr>
-<tr><td><a name="crdb_internal.stream_ingestion_stats_pb"></a><code>crdb_internal.stream_ingestion_stats_pb(job_id: <a href="int.html">int</a>) &rarr; <a href="bytes.html">bytes</a></code></td><td><span class="funcdesc"><p>DEPRECATED, consider using <code>SHOW TENANT name WITH REPLICATION STATUS</code></p>
-</span></td><td>Volatile</td></tr>
-<tr><td><a name="crdb_internal.stream_partition"></a><code>crdb_internal.stream_partition(stream_id: <a href="int.html">int</a>, partition_spec: <a href="bytes.html">bytes</a>) &rarr; tuple{bytes AS stream_event}</code></td><td><span class="funcdesc"><p>Stream partition data</p>
-</span></td><td>Volatile</td></tr></tbody>
-</table>
-
 ### String and byte functions
 
 <table>

--- a/pkg/sql/sem/builtins/replication_builtins.go
+++ b/pkg/sql/sem/builtins/replication_builtins.go
@@ -41,6 +41,7 @@ var replicationBuiltins = map[string]builtinDefinition{
 	"crdb_internal.complete_stream_ingestion_job": makeBuiltin(
 		tree.FunctionProperties{
 			Category:         builtinconstants.CategoryStreamIngestion,
+			Undocumented:     true,
 			DistsqlBlocklist: true,
 		},
 		tree.Overload{
@@ -79,6 +80,7 @@ var replicationBuiltins = map[string]builtinDefinition{
 	"crdb_internal.stream_ingestion_stats_json": makeBuiltin(
 		tree.FunctionProperties{
 			Category:         builtinconstants.CategoryStreamIngestion,
+			Undocumented:     true,
 			DistsqlBlocklist: true,
 		},
 
@@ -99,6 +101,7 @@ var replicationBuiltins = map[string]builtinDefinition{
 	"crdb_internal.stream_ingestion_stats_pb": makeBuiltin(
 		tree.FunctionProperties{
 			Category:         builtinconstants.CategoryStreamIngestion,
+			Undocumented:     true,
 			DistsqlBlocklist: true,
 		},
 
@@ -120,6 +123,7 @@ var replicationBuiltins = map[string]builtinDefinition{
 	"crdb_internal.start_replication_stream": makeBuiltin(
 		tree.FunctionProperties{
 			Category:         builtinconstants.CategoryStreamIngestion,
+			Undocumented:     true,
 			DistsqlBlocklist: true,
 		},
 		tree.Overload{
@@ -154,6 +158,7 @@ var replicationBuiltins = map[string]builtinDefinition{
 	"crdb_internal.replication_stream_progress": makeBuiltin(
 		tree.FunctionProperties{
 			Category:         builtinconstants.CategoryStreamIngestion,
+			Undocumented:     true,
 			DistsqlBlocklist: true,
 		},
 		tree.Overload{
@@ -194,6 +199,7 @@ var replicationBuiltins = map[string]builtinDefinition{
 	"crdb_internal.stream_partition": makeBuiltin(
 		tree.FunctionProperties{
 			Category:           builtinconstants.CategoryStreamIngestion,
+			Undocumented:       true,
 			DistsqlBlocklist:   false,
 			VectorizeStreaming: true,
 		},
@@ -224,6 +230,7 @@ var replicationBuiltins = map[string]builtinDefinition{
 	"crdb_internal.replication_stream_spec": makeBuiltin(
 		tree.FunctionProperties{
 			Category:         builtinconstants.CategoryStreamIngestion,
+			Undocumented:     true,
 			DistsqlBlocklist: true,
 		},
 		tree.Overload{
@@ -258,6 +265,7 @@ var replicationBuiltins = map[string]builtinDefinition{
 	"crdb_internal.complete_replication_stream": makeBuiltin(
 		tree.FunctionProperties{
 			Category:         builtinconstants.CategoryStreamIngestion,
+			Undocumented:     true,
 			DistsqlBlocklist: true,
 		},
 		tree.Overload{


### PR DESCRIPTION
These are internal functions related to an in-development feature and should not be documented.

Epic: none

Release note: None