### PR TITLE
kv: teach rangefeed about isolation levels

### DIFF
--- a/pkg/kv/kvserver/rangefeed/BUILD.bazel
+++ b/pkg/kv/kvserver/rangefeed/BUILD.bazel
@@ -18,6 +18,7 @@ go_library(
     deps = [
         "//pkg/keys",
         "//pkg/kv/kvpb",
+        "//pkg/kv/kvserver/concurrency/isolation",
         "//pkg/roachpb",
         "//pkg/settings",
         "//pkg/storage",
@@ -60,6 +61,7 @@ go_test(
         "//pkg/clusterversion",
         "//pkg/keys",
         "//pkg/kv/kvpb",
+        "//pkg/kv/kvserver/concurrency/isolation",
         "//pkg/roachpb",
         "//pkg/settings/cluster",
         "//pkg/storage",

--- a/pkg/kv/kvserver/rangefeed/task.go
+++ b/pkg/kv/kvserver/rangefeed/task.go
@@ -140,6 +140,7 @@ func (s *SeparatedIntentScanner) ConsumeIntents(
 		consumer(enginepb.MVCCWriteIntentOp{
 			TxnID:           meta.Txn.ID,
 			TxnKey:          meta.Txn.Key,
+			TxnIsoLevel:     meta.Txn.IsoLevel,
 			TxnMinTimestamp: meta.Txn.MinTimestamp,
 			Timestamp:       meta.Txn.WriteTimestamp,
 		})
@@ -208,6 +209,7 @@ func (l *LegacyIntentScanner) ConsumeIntents(
 			consumer(enginepb.MVCCWriteIntentOp{
 				TxnID:           meta.Txn.ID,
 				TxnKey:          meta.Txn.Key,
+				TxnIsoLevel:     meta.Txn.IsoLevel,
 				TxnMinTimestamp: meta.Txn.MinTimestamp,
 				Timestamp:       meta.Txn.WriteTimestamp,
 			})

--- a/pkg/storage/BUILD.bazel
+++ b/pkg/storage/BUILD.bazel
@@ -149,6 +149,7 @@ go_test(
         "//pkg/clusterversion",
         "//pkg/keys",
         "//pkg/kv/kvpb",
+        "//pkg/kv/kvserver/concurrency/isolation",
         "//pkg/kv/kvserver/concurrency/lock",
         "//pkg/kv/kvserver/diskmap",
         "//pkg/kv/kvserver/spanset",

--- a/pkg/storage/enginepb/mvcc3.proto
+++ b/pkg/storage/enginepb/mvcc3.proto
@@ -328,6 +328,7 @@ message MVCCWriteIntentOp {
     (gogoproto.customname) = "TxnID",
     (gogoproto.nullable) = false];
   bytes txn_key = 2;
+  cockroach.kv.kvserver.concurrency.isolation.Level txn_iso_level = 5;
   util.hlc.Timestamp txn_min_timestamp = 4 [(gogoproto.nullable) = false];
   util.hlc.Timestamp timestamp = 3 [(gogoproto.nullable) = false];
 }

--- a/pkg/storage/mvcc_logical_ops.go
+++ b/pkg/storage/mvcc_logical_ops.go
@@ -123,6 +123,7 @@ func (ol *OpLoggerBatch) logLogicalOp(op MVCCLogicalOpType, details MVCCLogicalO
 		ol.recordOp(&enginepb.MVCCWriteIntentOp{
 			TxnID:           details.Txn.ID,
 			TxnKey:          details.Txn.Key,
+			TxnIsoLevel:     details.Txn.IsoLevel,
 			TxnMinTimestamp: details.Txn.MinTimestamp,
 			Timestamp:       details.Timestamp,
 		})


### PR DESCRIPTION
Part of #100129.

This PR adds in the necessary plumbing to rangefeed to track transactions with their corresponding isolation level and then push transactions with that isolation level. The plumbing starts in `MVCCLogicalOp.MVCCWriteIntentOp`, through `resolvedTimestamp.unresolvedIntentQueue`, to `TxnMeta`, and finally to `TxnPusher.PushTxns`.

This will be important if we have different txn push behavior depending on the pushee's isolation level. Even if we don't, pushing with an accurate isolation level avoids confusion.

Release note: None