### PR TITLE
release-23.1: upgrades_test: use old bootstrap schema instead of injecting descriptors

### DIFF
--- a/pkg/upgrade/upgrades/BUILD.bazel
+++ b/pkg/upgrade/upgrades/BUILD.bazel
@@ -164,7 +164,6 @@ go_test(
         "//pkg/sql/schemachanger/scop",
         "//pkg/sql/schemachanger/scplan",
         "//pkg/sql/sem/builtins/builtinconstants",
-        "//pkg/sql/sem/catconstants",
         "//pkg/sql/sem/catid",
         "//pkg/sql/sem/tree",
         "//pkg/sql/tests",

--- a/pkg/upgrade/upgrades/external_connections_table_user_id_migration_test.go
+++ b/pkg/upgrade/upgrades/external_connections_table_user_id_migration_test.go
@@ -19,17 +19,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/base"
 	_ "github.com/cockroachdb/cockroach/pkg/cloud/userfile"
 	"github.com/cockroachdb/cockroach/pkg/clusterversion"
-	"github.com/cockroachdb/cockroach/pkg/keys"
-	"github.com/cockroachdb/cockroach/pkg/security/username"
 	"github.com/cockroachdb/cockroach/pkg/server"
-	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
-	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catenumpb"
-	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catpb"
-	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
-	"github.com/cockroachdb/cockroach/pkg/sql/catalog/systemschema"
-	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
-	"github.com/cockroachdb/cockroach/pkg/sql/sem/catconstants"
-	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
@@ -52,19 +42,13 @@ func runTestExternalConnectionsUserIDMigration(t *testing.T, numUsers int) {
 	defer leaktest.AfterTest(t)()
 	ctx := context.Background()
 
-	settings := cluster.MakeTestingClusterSettingsWithVersions(
-		clusterversion.TestingBinaryVersion,
-		clusterversion.ByKey(clusterversion.V23_1ExternalConnectionsTableHasOwnerIDColumn-1),
-		false, /* initializeVersion */
-	)
-
 	tc := testcluster.StartTestCluster(t, 1 /* nodes */, base.TestClusterArgs{
 		ServerArgs: base.TestServerArgs{
-			Settings: settings,
 			Knobs: base.TestingKnobs{
 				Server: &server.TestingKnobs{
 					DisableAutomaticVersionUpgrade: make(chan struct{}),
 					BinaryVersionOverride:          clusterversion.ByKey(clusterversion.V23_1ExternalConnectionsTableHasOwnerIDColumn - 1),
+					BootstrapVersionKeyOverride:    clusterversion.V22_2,
 				},
 			},
 		},
@@ -74,12 +58,6 @@ func runTestExternalConnectionsUserIDMigration(t *testing.T, numUsers int) {
 	db := tc.ServerConn(0)
 	defer db.Close()
 	tdb := sqlutils.MakeSQLRunner(db)
-	s := tc.Server(0)
-
-	// Inject the descriptor for system.external_connections table from before
-	// the owner_id column was added.
-	upgrades.InjectLegacyTable(ctx, t, s, systemschema.SystemExternalConnectionsTable,
-		getTableDescForExternalConnectionsTableBeforeOwnerIDCol)
 
 	// Create test users.
 	upgrades.ExecForCountInTxns(ctx, t, db, numUsers, 100 /* txCount */, func(txRunner *sqlutils.SQLRunner, i int) {
@@ -122,46 +100,4 @@ func runTestExternalConnectionsUserIDMigration(t *testing.T, numUsers int) {
 	tdb.CheckQueryResults(t, "SELECT * FROM system.external_connections WHERE owner_id IS NULL", [][]string{})
 	tdb.CheckQueryResults(t, "SELECT count(*) FROM system.external_connections", [][]string{{strconv.Itoa(numUsers)}})
 	tdb.CheckQueryResults(t, "SELECT count(*) FROM system.external_connections JOIN system.users ON owner = username AND owner_id <> user_id", [][]string{{"0"}})
-}
-
-func getTableDescForExternalConnectionsTableBeforeOwnerIDCol() *descpb.TableDescriptor {
-	nowString := "now():::TIMESTAMP"
-	return &descpb.TableDescriptor{
-		Name:                    string(catconstants.SystemExternalConnectionsTableName),
-		ID:                      descpb.InvalidID,
-		ParentID:                keys.SystemDatabaseID,
-		UnexposedParentSchemaID: keys.PublicSchemaID,
-		Version:                 1,
-		Columns: []descpb.ColumnDescriptor{
-			{Name: "connection_name", ID: 1, Type: types.String},
-			{Name: "created", ID: 2, Type: types.Timestamp, DefaultExpr: &nowString},
-			{Name: "updated", ID: 3, Type: types.Timestamp, DefaultExpr: &nowString},
-			{Name: "connection_type", ID: 4, Type: types.String},
-			{Name: "connection_details", ID: 5, Type: types.Bytes},
-			{Name: "owner", ID: 6, Type: types.String},
-		},
-		NextColumnID: 7,
-		Families: []descpb.ColumnFamilyDescriptor{
-			{
-				Name:        "primary",
-				ID:          0,
-				ColumnNames: []string{"connection_name", "created", "updated", "connection_type", "connection_details", "owner"},
-				ColumnIDs:   []descpb.ColumnID{1, 2, 3, 4, 5, 6},
-			},
-		},
-		NextFamilyID: 1,
-		PrimaryIndex: descpb.IndexDescriptor{
-			Name:                "primary",
-			ID:                  1,
-			Unique:              true,
-			KeyColumnNames:      []string{"connection_name"},
-			KeyColumnDirections: []catenumpb.IndexColumn_Direction{catenumpb.IndexColumn_ASC},
-			KeyColumnIDs:        []descpb.ColumnID{1},
-		},
-		NextIndexID:      2,
-		Privileges:       catpb.NewCustomSuperuserPrivilegeDescriptor(privilege.ReadWriteData, username.NodeUserName()),
-		FormatVersion:    descpb.InterleavedFormatVersion,
-		NextMutationID:   1,
-		NextConstraintID: 1,
-	}
 }

--- a/pkg/upgrade/upgrades/role_members_ids_migration_test.go
+++ b/pkg/upgrade/upgrades/role_members_ids_migration_test.go
@@ -51,7 +51,7 @@ func runTestRoleMembersIDMigration(t *testing.T, numUsers int) {
 				Server: &server.TestingKnobs{
 					BootstrapVersionKeyOverride:    clusterversion.V22_2,
 					DisableAutomaticVersionUpgrade: make(chan struct{}),
-					BinaryVersionOverride:          clusterversion.ByKey(clusterversion.V22_2),
+					BinaryVersionOverride:          clusterversion.ByKey(clusterversion.V23_1RoleMembersTableHasIDColumns - 1),
 				},
 			},
 		},

--- a/pkg/upgrade/upgrades/system_privileges_index_migration_test.go
+++ b/pkg/upgrade/upgrades/system_privileges_index_migration_test.go
@@ -16,20 +16,9 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/clusterversion"
-	"github.com/cockroachdb/cockroach/pkg/keys"
-	"github.com/cockroachdb/cockroach/pkg/security/username"
 	"github.com/cockroachdb/cockroach/pkg/server"
-	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
-	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catenumpb"
-	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catpb"
-	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
-	"github.com/cockroachdb/cockroach/pkg/sql/catalog/systemschema"
-	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
-	"github.com/cockroachdb/cockroach/pkg/sql/sem/catconstants"
-	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
-	"github.com/cockroachdb/cockroach/pkg/upgrade/upgrades"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/stretchr/testify/require"
 )
@@ -38,18 +27,12 @@ func TestSystemPrivilegesIndexMigration(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	ctx := context.Background()
 
-	settings := cluster.MakeTestingClusterSettingsWithVersions(
-		clusterversion.TestingBinaryVersion,
-		clusterversion.ByKey(clusterversion.V23_1AlterSystemPrivilegesAddIndexOnPathAndUsername-1),
-		false,
-	)
-
 	tc := testcluster.StartTestCluster(t, 1, base.TestClusterArgs{
 		ServerArgs: base.TestServerArgs{
-			Settings: settings,
 			Knobs: base.TestingKnobs{
 				Server: &server.TestingKnobs{
 					DisableAutomaticVersionUpgrade: make(chan struct{}),
+					BootstrapVersionKeyOverride:    clusterversion.V22_2,
 					BinaryVersionOverride:          clusterversion.ByKey(clusterversion.V23_1AlterSystemPrivilegesAddIndexOnPathAndUsername - 1),
 				},
 			},
@@ -60,17 +43,6 @@ func TestSystemPrivilegesIndexMigration(t *testing.T) {
 	db := tc.ServerConn(0)
 	defer db.Close()
 	tdb := sqlutils.MakeSQLRunner(db)
-	s := tc.Server(0)
-
-	// Inject the descriptor for the system.privileges table from before
-	// the index on (path,user) column was added.
-	upgrades.InjectLegacyTable(
-		ctx,
-		t,
-		s,
-		systemschema.SystemPrivilegeTable,
-		getTableDescForSystemPrivilegesTableBeforeIndexonPathUsername,
-	)
 
 	// Run migration.
 	_, err := tc.Conns[0].ExecContext(
@@ -85,7 +57,7 @@ func TestSystemPrivilegesIndexMigration(t *testing.T) {
 	path STRING NOT NULL,
 	privileges STRING[] NOT NULL,
 	grant_options STRING[] NOT NULL,
-	user_id OID NULL,
+	user_id OID NOT NULL,
 	CONSTRAINT "primary" PRIMARY KEY (username ASC, path ASC),
 	UNIQUE INDEX privileges_path_user_id_key (path ASC, user_id ASC) STORING (privileges, grant_options),
 	UNIQUE INDEX privileges_path_username_key (path ASC, username ASC) STORING (privileges, grant_options)
@@ -94,58 +66,4 @@ func TestSystemPrivilegesIndexMigration(t *testing.T) {
 	var actualSchema string
 	r.Scan(&actualSchema)
 	require.Equal(t, expectedSchema, actualSchema)
-}
-
-func getTableDescForSystemPrivilegesTableBeforeIndexonPathUsername() *descpb.TableDescriptor {
-	return &descpb.TableDescriptor{
-		Name:                    string(catconstants.SystemPrivilegeTableName),
-		ID:                      descpb.InvalidID,
-		ParentID:                keys.SystemDatabaseID,
-		UnexposedParentSchemaID: keys.PublicSchemaID,
-		Version:                 1,
-		Columns: []descpb.ColumnDescriptor{
-			{Name: "username", ID: 1, Type: types.String},
-			{Name: "path", ID: 2, Type: types.String},
-			{Name: "privileges", ID: 3, Type: types.StringArray},
-			{Name: "grant_options", ID: 4, Type: types.StringArray},
-			{Name: "user_id", ID: 5, Type: types.Oid, Nullable: true},
-		},
-		NextColumnID: 6,
-		Families: []descpb.ColumnFamilyDescriptor{
-			{
-				Name:        "primary",
-				ID:          0,
-				ColumnNames: []string{"username", "path", "privileges", "grant_options", "user_id"},
-				ColumnIDs:   []descpb.ColumnID{1, 2, 3, 4, 5},
-			},
-		},
-		NextFamilyID: 1,
-		PrimaryIndex: descpb.IndexDescriptor{
-			Name:                "primary",
-			ID:                  1,
-			Unique:              true,
-			KeyColumnNames:      []string{"username", "path"},
-			KeyColumnDirections: []catenumpb.IndexColumn_Direction{catenumpb.IndexColumn_ASC, catenumpb.IndexColumn_ASC},
-			KeyColumnIDs:        []descpb.ColumnID{1, 2},
-		},
-		Indexes: []descpb.IndexDescriptor{
-			{
-				Name:                "privileges_path_user_id_key",
-				ID:                  2,
-				Unique:              true,
-				KeyColumnNames:      []string{"path", "user_id"},
-				KeyColumnDirections: []catenumpb.IndexColumn_Direction{catenumpb.IndexColumn_ASC, catenumpb.IndexColumn_ASC},
-				KeyColumnIDs:        []descpb.ColumnID{2, 5},
-				KeySuffixColumnIDs:  []descpb.ColumnID{1},
-				StoreColumnNames:    []string{"privileges", "grant_options"},
-				StoreColumnIDs:      []descpb.ColumnID{3, 4},
-				Version:             descpb.StrictIndexColumnIDGuaranteesVersion,
-			},
-		},
-		NextIndexID:      3,
-		Privileges:       catpb.NewCustomSuperuserPrivilegeDescriptor(privilege.ReadWriteData, username.NodeUserName()),
-		FormatVersion:    descpb.InterleavedFormatVersion,
-		NextMutationID:   1,
-		NextConstraintID: 1,
-	}
 }

--- a/pkg/upgrade/upgrades/system_privileges_user_id_migration_test.go
+++ b/pkg/upgrade/upgrades/system_privileges_user_id_migration_test.go
@@ -18,17 +18,8 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/clusterversion"
-	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/security/username"
 	"github.com/cockroachdb/cockroach/pkg/server"
-	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
-	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catenumpb"
-	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catpb"
-	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
-	"github.com/cockroachdb/cockroach/pkg/sql/catalog/systemschema"
-	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
-	"github.com/cockroachdb/cockroach/pkg/sql/sem/catconstants"
-	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
@@ -55,18 +46,12 @@ func runTestSystemPrivilegesUserIDMigration(t *testing.T, numUsers int) {
 	defer leaktest.AfterTest(t)()
 	ctx := context.Background()
 
-	settings := cluster.MakeTestingClusterSettingsWithVersions(
-		clusterversion.TestingBinaryVersion,
-		clusterversion.ByKey(clusterversion.V23_1SystemPrivilegesTableHasUserIDColumn-1),
-		false, /* initializeVersion */
-	)
-
 	tc := testcluster.StartTestCluster(t, 1 /* nodes */, base.TestClusterArgs{
 		ServerArgs: base.TestServerArgs{
-			Settings: settings,
 			Knobs: base.TestingKnobs{
 				Server: &server.TestingKnobs{
 					DisableAutomaticVersionUpgrade: make(chan struct{}),
+					BootstrapVersionKeyOverride:    clusterversion.V22_2,
 					BinaryVersionOverride:          clusterversion.ByKey(clusterversion.V23_1SystemPrivilegesTableHasUserIDColumn - 1),
 				},
 			},
@@ -77,11 +62,6 @@ func runTestSystemPrivilegesUserIDMigration(t *testing.T, numUsers int) {
 	db := tc.ServerConn(0)
 	defer db.Close()
 	tdb := sqlutils.MakeSQLRunner(db)
-	s := tc.Server(0)
-
-	// Inject the descriptor for the system.privileges table from before the
-	// user_id column was added.
-	upgrades.InjectLegacyTable(ctx, t, s, systemschema.SystemPrivilegeTable, getTableDescForSystemPrivilegesTableBeforeUserIDCol)
 
 	// Create test users and add rows for each user to system.privileges.
 	upgrades.ExecForCountInTxns(ctx, t, db, numUsers, 100 /* txCount */, func(txRunner *sqlutils.SQLRunner, i int) {
@@ -125,43 +105,4 @@ func runTestSystemPrivilegesUserIDMigration(t *testing.T, numUsers int) {
 		fmt.Sprintf("SELECT count(*) FROM system.privileges WHERE username = '%s' AND user_id <> %d",
 			username.PublicRole, username.PublicRoleID),
 		[][]string{{"0"}})
-}
-
-func getTableDescForSystemPrivilegesTableBeforeUserIDCol() *descpb.TableDescriptor {
-	return &descpb.TableDescriptor{
-		Name:                    string(catconstants.SystemPrivilegeTableName),
-		ID:                      descpb.InvalidID,
-		ParentID:                keys.SystemDatabaseID,
-		UnexposedParentSchemaID: keys.PublicSchemaID,
-		Version:                 1,
-		Columns: []descpb.ColumnDescriptor{
-			{Name: "username", ID: 1, Type: types.String},
-			{Name: "path", ID: 2, Type: types.String},
-			{Name: "privileges", ID: 3, Type: types.StringArray},
-			{Name: "grant_options", ID: 4, Type: types.StringArray},
-		},
-		NextColumnID: 5,
-		Families: []descpb.ColumnFamilyDescriptor{
-			{
-				Name:        "primary",
-				ID:          0,
-				ColumnNames: []string{"username", "path", "privileges", "grant_options"},
-				ColumnIDs:   []descpb.ColumnID{1, 2, 3, 4},
-			},
-		},
-		NextFamilyID: 1,
-		PrimaryIndex: descpb.IndexDescriptor{
-			Name:                "primary",
-			ID:                  1,
-			Unique:              true,
-			KeyColumnNames:      []string{"username", "path"},
-			KeyColumnDirections: []catenumpb.IndexColumn_Direction{catenumpb.IndexColumn_ASC, catenumpb.IndexColumn_ASC},
-			KeyColumnIDs:        []descpb.ColumnID{1, 2},
-		},
-		NextIndexID:      2,
-		Privileges:       catpb.NewCustomSuperuserPrivilegeDescriptor(privilege.ReadWriteData, username.NodeUserName()),
-		FormatVersion:    descpb.InterleavedFormatVersion,
-		NextMutationID:   1,
-		NextConstraintID: 1,
-	}
 }

--- a/pkg/upgrade/upgrades/web_sessions_table_user_id_migration_test.go
+++ b/pkg/upgrade/upgrades/web_sessions_table_user_id_migration_test.go
@@ -18,17 +18,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/clusterversion"
-	"github.com/cockroachdb/cockroach/pkg/keys"
-	"github.com/cockroachdb/cockroach/pkg/security/username"
 	"github.com/cockroachdb/cockroach/pkg/server"
-	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
-	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catenumpb"
-	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catpb"
-	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
-	"github.com/cockroachdb/cockroach/pkg/sql/catalog/systemschema"
-	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
-	"github.com/cockroachdb/cockroach/pkg/sql/sem/catconstants"
-	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
@@ -55,18 +45,12 @@ func runTestWebSessionsUserIDMigration(t *testing.T, numUsers int) {
 	defer leaktest.AfterTest(t)()
 	ctx := context.Background()
 
-	settings := cluster.MakeTestingClusterSettingsWithVersions(
-		clusterversion.TestingBinaryVersion,
-		clusterversion.ByKey(clusterversion.V23_1WebSessionsTableHasUserIDColumn-1),
-		false, /* initializeVersion */
-	)
-
 	tc := testcluster.StartTestCluster(t, 1 /* nodes */, base.TestClusterArgs{
 		ServerArgs: base.TestServerArgs{
-			Settings: settings,
 			Knobs: base.TestingKnobs{
 				Server: &server.TestingKnobs{
 					DisableAutomaticVersionUpgrade: make(chan struct{}),
+					BootstrapVersionKeyOverride:    clusterversion.V22_2,
 					BinaryVersionOverride:          clusterversion.ByKey(clusterversion.V23_1WebSessionsTableHasUserIDColumn - 1),
 				},
 			},
@@ -77,11 +61,6 @@ func runTestWebSessionsUserIDMigration(t *testing.T, numUsers int) {
 	db := tc.ServerConn(0)
 	defer db.Close()
 	tdb := sqlutils.MakeSQLRunner(db)
-	s := tc.Server(0)
-
-	// Inject the descriptor for the system.web_sessions table from before the
-	// user_id column was added.
-	upgrades.InjectLegacyTable(ctx, t, s, systemschema.WebSessionsTable, getTableDescForSystemWebSessionsTableBeforeUserIDCol)
 
 	// Create test users.
 	upgrades.ExecForCountInTxns(ctx, t, db, numUsers, 100 /* txCount */, func(txRunner *sqlutils.SQLRunner, i int) {
@@ -136,100 +115,4 @@ VALUES (
 	tdb.CheckQueryResults(t, "SELECT * FROM system.web_sessions WHERE user_id IS NULL", [][]string{})
 	tdb.CheckQueryResults(t, "SELECT count(*) FROM system.web_sessions", [][]string{{strconv.Itoa(numUsers)}})
 	tdb.CheckQueryResults(t, "SELECT count(*) FROM system.web_sessions AS a JOIN system.users AS b ON a.username = b.username AND a.user_id <> b.user_id", [][]string{{"0"}})
-}
-
-func getTableDescForSystemWebSessionsTableBeforeUserIDCol() *descpb.TableDescriptor {
-	uniqueRowIDString := "unique_rowid()"
-	nowString := "now():::TIMESTAMP"
-	return &descpb.TableDescriptor{
-		Name:                    string(catconstants.WebSessionsTableName),
-		ID:                      keys.WebSessionsTableID,
-		ParentID:                keys.SystemDatabaseID,
-		UnexposedParentSchemaID: keys.PublicSchemaID,
-		Version:                 1,
-		Columns: []descpb.ColumnDescriptor{
-			{Name: "id", ID: 1, Type: types.Int, DefaultExpr: &uniqueRowIDString},
-			{Name: "hashedSecret", ID: 2, Type: types.Bytes},
-			{Name: "username", ID: 3, Type: types.String},
-			{Name: "createdAt", ID: 4, Type: types.Timestamp, DefaultExpr: &nowString},
-			{Name: "expiresAt", ID: 5, Type: types.Timestamp},
-			{Name: "revokedAt", ID: 6, Type: types.Timestamp, Nullable: true},
-			{Name: "lastUsedAt", ID: 7, Type: types.Timestamp, DefaultExpr: &nowString},
-			{Name: "auditInfo", ID: 8, Type: types.String, Nullable: true},
-		},
-		NextColumnID: 9,
-		Families: []descpb.ColumnFamilyDescriptor{
-			{
-				Name: "fam_0_id_hashedSecret_username_createdAt_expiresAt_revokedAt_lastUsedAt_auditInfo",
-				ID:   0,
-				ColumnNames: []string{
-					"id",
-					"hashedSecret",
-					"username",
-					"createdAt",
-					"expiresAt",
-					"revokedAt",
-					"lastUsedAt",
-					"auditInfo",
-				},
-				ColumnIDs: []descpb.ColumnID{1, 2, 3, 4, 5, 6, 7, 8},
-			},
-		},
-		NextFamilyID: 1,
-		PrimaryIndex: descpb.IndexDescriptor{
-			Name:                "primary",
-			ID:                  1,
-			Unique:              true,
-			KeyColumnNames:      []string{"id"},
-			KeyColumnDirections: []catenumpb.IndexColumn_Direction{catenumpb.IndexColumn_ASC},
-			KeyColumnIDs:        []descpb.ColumnID{1},
-		},
-		Indexes: []descpb.IndexDescriptor{
-			{
-				Name:                "web_sessions_expiresAt_idx",
-				ID:                  2,
-				Unique:              false,
-				KeyColumnNames:      []string{"expiresAt"},
-				KeyColumnDirections: []catenumpb.IndexColumn_Direction{catenumpb.IndexColumn_ASC},
-				KeyColumnIDs:        []descpb.ColumnID{5},
-				KeySuffixColumnIDs:  []descpb.ColumnID{1},
-				Version:             descpb.StrictIndexColumnIDGuaranteesVersion,
-			},
-			{
-				Name:                "web_sessions_createdAt_idx",
-				ID:                  3,
-				Unique:              false,
-				KeyColumnNames:      []string{"createdAt"},
-				KeyColumnDirections: []catenumpb.IndexColumn_Direction{catenumpb.IndexColumn_ASC},
-				KeyColumnIDs:        []descpb.ColumnID{4},
-				KeySuffixColumnIDs:  []descpb.ColumnID{1},
-				Version:             descpb.StrictIndexColumnIDGuaranteesVersion,
-			},
-			{
-				Name:                "web_sessions_revokedAt_idx",
-				ID:                  4,
-				Unique:              false,
-				KeyColumnNames:      []string{"revokedAt"},
-				KeyColumnDirections: []catenumpb.IndexColumn_Direction{catenumpb.IndexColumn_ASC},
-				KeyColumnIDs:        []descpb.ColumnID{6},
-				KeySuffixColumnIDs:  []descpb.ColumnID{1},
-				Version:             descpb.StrictIndexColumnIDGuaranteesVersion,
-			},
-			{
-				Name:                "web_sessions_lastUsedAt_idx",
-				ID:                  5,
-				Unique:              false,
-				KeyColumnNames:      []string{"lastUsedAt"},
-				KeyColumnDirections: []catenumpb.IndexColumn_Direction{catenumpb.IndexColumn_ASC},
-				KeyColumnIDs:        []descpb.ColumnID{7},
-				KeySuffixColumnIDs:  []descpb.ColumnID{1},
-				Version:             descpb.StrictIndexColumnIDGuaranteesVersion,
-			},
-		},
-		NextIndexID:      6,
-		Privileges:       catpb.NewCustomSuperuserPrivilegeDescriptor(privilege.ReadWriteData, username.NodeUserName()),
-		FormatVersion:    descpb.InterleavedFormatVersion,
-		NextMutationID:   1,
-		NextConstraintID: 1,
-	}
 }


### PR DESCRIPTION
Backport 1/1 commits from #100183.

/cc @cockroachdb/release

Release justification: Non-production code changes

---

This patch removes uses of upgrades.InjectLegacyTable within tests for
v22.2 to v23.1 upgrades in favor of using the v22.2 bootstrap schema to
start up the test cluster, since that better resembles the initial state
of non-test clusters and leads to less brittle test code.

Fixes #99974

Release note: None
