### PR TITLE
sql: fix spelling in crdb_internal.node_transactions schema

### DIFF
--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -2134,7 +2134,7 @@ CREATE TABLE crdb_internal.%s (
   node_id INT,                     -- the ID of the node running the transaction
   session_id STRING,               -- the ID of the session
   start TIMESTAMP,                 -- the start time of the transaction
-  txn_string STRING,               -- the string representation of the transcation
+  txn_string STRING,               -- the string representation of the transaction
   application_name STRING,         -- the name of the application as per SET application_name
   num_stmts INT,                   -- the number of statements executed so far
   num_retries INT,                 -- the number of times the transaction was restarted


### PR DESCRIPTION
Minor spelling fix.

Epic: None
Release note: None