### PR TITLE
sql: deflake distsql_automatic_stats logic test

### DIFF
--- a/pkg/ccl/logictestccl/tests/3node-tenant/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/3node-tenant/generated_test.go
@@ -605,6 +605,13 @@ func TestTenantLogic_distinct_on(
 	runLogicTest(t, "distinct_on")
 }
 
+func TestTenantLogic_distsql_automatic_stats(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "distsql_automatic_stats")
+}
+
 func TestTenantLogic_distsql_event_log(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/testdata/logic_test/distsql_automatic_stats
+++ b/pkg/sql/logictest/testdata/logic_test/distsql_automatic_stats
@@ -1,19 +1,8 @@
-# LogicTest: local !local !metamorphic-batch-sizes
+# LogicTest: !metamorphic-batch-sizes
 
-# TODO(yuzefovich): at the moment the tests below that assert a particular set
-# of statistics are flaky, so we disable this file by using a contradictory
-# config set. Once #99751 is addressed, "local !local" part should be removed.
-
-# Disable automatic stats
+# Enable automatic stats for this table.
 statement ok
-SET CLUSTER SETTING sql.stats.automatic_collection.enabled = false
-
-statement ok
-CREATE TABLE data (a INT, b INT, c FLOAT, d DECIMAL, PRIMARY KEY (a, b, c), INDEX d_idx (d))
-
-# Enable automatic stats
-statement ok
-SET CLUSTER SETTING sql.stats.automatic_collection.enabled = true
+CREATE TABLE data (a INT, b INT, c FLOAT, d DECIMAL, PRIMARY KEY (a, b, c), INDEX d_idx (d)) WITH (sql_stats_automatic_collection_enabled = true)
 
 # Generate all combinations of values 1 to 10.
 statement ok
@@ -40,7 +29,7 @@ __auto__         {d}           1000       1               1000
 
 # Disable automatic stats
 statement ok
-SET CLUSTER SETTING sql.stats.automatic_collection.enabled = false
+ALTER TABLE data SET (sql_stats_automatic_collection_enabled = false)
 
 # Update more than 20% of the table.
 statement ok
@@ -61,7 +50,7 @@ __auto__         {d}           1000       1               1000
 
 # Enable automatic stats
 statement ok
-SET CLUSTER SETTING sql.stats.automatic_collection.enabled = true
+ALTER TABLE data SET (sql_stats_automatic_collection_enabled = true)
 
 # Update more than 20% of the table.
 statement ok
@@ -129,7 +118,7 @@ __auto__         {d}           550        1               0
 
 # Test CREATE TABLE ... AS
 statement ok
-CREATE TABLE copy AS SELECT * FROM data
+CREATE TABLE copy WITH (sql_stats_automatic_collection_enabled = true) AS SELECT * FROM data
 
 # Distinct count for rowid can be flaky, so don't show it. The estimate is
 # almost always 550, but occasionally it is 549...
@@ -145,7 +134,7 @@ __auto__         {d}           550        0
 __auto__         {rowid}       550        0
 
 statement ok
-CREATE TABLE test_create (x INT PRIMARY KEY, y CHAR)
+CREATE TABLE test_create (x INT PRIMARY KEY, y CHAR) WITH (sql_stats_automatic_collection_enabled = true)
 
 query TTIII colnames,retry
 SELECT DISTINCT ON (column_names) statistics_name, column_names, row_count, distinct_count, null_count
@@ -175,15 +164,12 @@ __auto__         {rowid}       0          0
 
 # Disable automatic stats
 statement ok
-SET CLUSTER SETTING sql.stats.automatic_collection.enabled = false
-
-statement ok
 CREATE SCHEMA my_schema;
-CREATE TABLE my_schema.my_table (k INT PRIMARY KEY, v STRING);
+CREATE TABLE my_schema.my_table (k INT PRIMARY KEY, v STRING) WITH (sql_stats_automatic_collection_enabled = false)
 
 # Enable automatic stats
 statement ok
-SET CLUSTER SETTING sql.stats.automatic_collection.enabled = true
+ALTER TABLE my_schema.my_table SET (sql_stats_automatic_collection_enabled = true)
 
 # Insert 10 rows.
 statement ok

--- a/pkg/sql/logictest/tests/fakedist-disk/generated_test.go
+++ b/pkg/sql/logictest/tests/fakedist-disk/generated_test.go
@@ -583,6 +583,13 @@ func TestLogic_distinct_on(
 	runLogicTest(t, "distinct_on")
 }
 
+func TestLogic_distsql_automatic_stats(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "distsql_automatic_stats")
+}
+
 func TestLogic_distsql_event_log(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/fakedist-vec-off/generated_test.go
+++ b/pkg/sql/logictest/tests/fakedist-vec-off/generated_test.go
@@ -583,6 +583,13 @@ func TestLogic_distinct_on(
 	runLogicTest(t, "distinct_on")
 }
 
+func TestLogic_distsql_automatic_stats(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "distsql_automatic_stats")
+}
+
 func TestLogic_distsql_event_log(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/fakedist/generated_test.go
+++ b/pkg/sql/logictest/tests/fakedist/generated_test.go
@@ -583,6 +583,13 @@ func TestLogic_distinct_on(
 	runLogicTest(t, "distinct_on")
 }
 
+func TestLogic_distsql_automatic_stats(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "distsql_automatic_stats")
+}
+
 func TestLogic_distsql_event_log(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/local-legacy-schema-changer/generated_test.go
+++ b/pkg/sql/logictest/tests/local-legacy-schema-changer/generated_test.go
@@ -576,6 +576,13 @@ func TestLogic_distinct_on(
 	runLogicTest(t, "distinct_on")
 }
 
+func TestLogic_distsql_automatic_stats(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "distsql_automatic_stats")
+}
+
 func TestLogic_distsql_event_log(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/local-vec-off/generated_test.go
+++ b/pkg/sql/logictest/tests/local-vec-off/generated_test.go
@@ -583,6 +583,13 @@ func TestLogic_distinct_on(
 	runLogicTest(t, "distinct_on")
 }
 
+func TestLogic_distsql_automatic_stats(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "distsql_automatic_stats")
+}
+
 func TestLogic_distsql_event_log(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/local/generated_test.go
+++ b/pkg/sql/logictest/tests/local/generated_test.go
@@ -604,6 +604,13 @@ func TestLogic_distinct_on(
 	runLogicTest(t, "distinct_on")
 }
 
+func TestLogic_distsql_automatic_stats(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "distsql_automatic_stats")
+}
+
 func TestLogic_distsql_event_log(
 	t *testing.T,
 ) {

--- a/pkg/sql/parser/testdata/create_table
+++ b/pkg/sql/parser/testdata/create_table
@@ -2062,6 +2062,14 @@ CREATE TABLE IF NOT EXISTS a (x, y FAMILY f1) AS SELECT (*) FROM b -- fully pare
 CREATE TABLE IF NOT EXISTS a (x, y FAMILY f1) AS SELECT * FROM b -- literals removed
 CREATE TABLE IF NOT EXISTS _ (_, _ FAMILY _) AS SELECT * FROM _ -- identifiers removed
 
+parse
+CREATE TABLE a WITH (fillfactor=100) AS SELECT * FROM b
+----
+CREATE TABLE a WITH (fillfactor = 100) AS SELECT * FROM b -- normalized!
+CREATE TABLE a WITH (fillfactor = (100)) AS SELECT (*) FROM b -- fully parenthesized
+CREATE TABLE a WITH (fillfactor = _) AS SELECT * FROM b -- literals removed
+CREATE TABLE _ WITH (_ = 100) AS SELECT * FROM _ -- identifiers removed
+
 error
 CREATE TABLE test (
   foo INT8 FAMILY a FAMILY b

--- a/pkg/sql/sem/tree/create.go
+++ b/pkg/sql/sem/tree/create.go
@@ -1524,6 +1524,11 @@ func (node *CreateTable) FormatBody(ctx *FmtCtx) {
 			ctx.FormatNode(&node.Defs)
 			ctx.WriteByte(')')
 		}
+		if node.StorageParams != nil {
+			ctx.WriteString(` WITH (`)
+			ctx.FormatNode(&node.StorageParams)
+			ctx.WriteByte(')')
+		}
 		ctx.WriteString(" AS ")
 		ctx.FormatNode(node.AsSource)
 	} else {

--- a/pkg/sql/sem/tree/pretty.go
+++ b/pkg/sql/sem/tree/pretty.go
@@ -1267,6 +1267,10 @@ func (node *CreateTable) doc(p *PrettyCfg) pretty.Doc {
 			title = pretty.ConcatSpace(title,
 				p.bracket("(", p.Doc(&node.Defs), ")"))
 		}
+		if node.StorageParams != nil {
+			title = pretty.ConcatSpace(title, pretty.Keyword("WITH"))
+			title = pretty.ConcatSpace(title, p.bracket(`(`, p.Doc(&node.StorageParams), `)`))
+		}
 		title = pretty.ConcatSpace(title, pretty.Keyword("AS"))
 	} else {
 		title = pretty.ConcatSpace(title,
@@ -1281,7 +1285,7 @@ func (node *CreateTable) doc(p *PrettyCfg) pretty.Doc {
 	if node.PartitionByTable != nil {
 		clauses = append(clauses, p.Doc(node.PartitionByTable))
 	}
-	if node.StorageParams != nil {
+	if node.StorageParams != nil && !node.As() {
 		clauses = append(
 			clauses,
 			pretty.ConcatSpace(


### PR DESCRIPTION
**sql: fix formatting of CREATE TABLE AS with storage parameters**

We were placing the storage parameters in the wrong place when formatting `CREATE TABLE AS` statements.

Fixes: #100243

Epic: None

Release note: None

**sql: deflake distsql_automatic_stats logic test**

Now that automatic stats are disabled for system tables in logic tests, `distsql_automatic_stats` was opening the floodgates with its first `SET CLUSTER SETTING sql.stats.automatic_collection.enabled = true`. With this enabled, the automatic stats refresher was executing `CREATE STATISTICS` for every system table, one at a time, often taking longer than the 45s logic test retry limit to get to the user-defined table we really care about.

Instead of using the cluster setting, change `distsql_automatic_stats` to use the per-table setting.

Fixes: #99751

Epic: None

Release note: None