### PR TITLE
release-22.2: distsql: fix sql.mem.distsql.current metric

### DIFF
--- a/pkg/sql/distsql/server.go
+++ b/pkg/sql/distsql/server.go
@@ -85,9 +85,12 @@ func NewServer(
 		memMonitor: mon.NewMonitor(
 			"distsql",
 			mon.MemoryResource,
-			cfg.Metrics.CurBytesCount,
-			cfg.Metrics.MaxBytesHist,
-			-1, /* increment: use default block size */
+			// Note that we don't use 'sql.mem.distsql.*' metrics here since
+			// that would double count them with the 'flow' monitor in
+			// setupFlow.
+			nil, /* curCount */
+			nil, /* maxHist */
+			-1,  /* increment: use default block size */
 			noteworthyMemoryUsageBytes,
 			cfg.Settings,
 		),

--- a/pkg/sql/tablewriter_upsert_opt.go
+++ b/pkg/sql/tablewriter_upsert_opt.go
@@ -105,7 +105,7 @@ func (tu *optTableUpserter) init(
 		return err
 	}
 
-	// rowsNeeded, set upon initialization, indicates pkg/sql/backfill.gowhether or not we want
+	// rowsNeeded, set upon initialization, indicates whether or not we want
 	// rows returned from the operation.
 	if tu.rowsNeeded {
 		tu.resultRow = make(tree.Datums, len(tu.returnCols))


### PR DESCRIPTION
Backport 1/3 commits from #99887.

/cc @cockroachdb/release

---

**distsql: fix sql.mem.distsql.current metric**

This commit fixes double counting of remote DistSQL flows' memory usage
against `sql.mem.distsql.current` metric. This was the case since we
passed the metric to both the `flow` monitor (created for all flows,
both local and remote) and the `distsql` monitor (which tracks the
memory usage of all remote flows). This is now fixed by only passing the
metric in the former case.

Fixes: #91787.

Release note (bug fix): Previously, `sql.mem.distsql.current` metric
would double count the memory usage of remote DistSQL flows and this has
been fixed.

Release justification: bug fix.