### PR TITLE
roachtest: own autoupgrade to TestEng

### DIFF
--- a/pkg/cmd/roachtest/tests/autoupgrade.go
+++ b/pkg/cmd/roachtest/tests/autoupgrade.go
@@ -254,7 +254,7 @@ func registerAutoUpgrade(r registry.Registry) {
 
 	r.Add(registry.TestSpec{
 		Name:    `autoupgrade`,
-		Owner:   registry.OwnerKV,
+		Owner:   registry.OwnerTestEng,
 		Cluster: r.MakeClusterSpec(5),
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			if c.IsLocal() && runtime.GOARCH == "arm64" {


### PR DESCRIPTION
Discussed in https://github.com/cockroachdb/cockroach/pull/99479.

Epic: none
Release note: None
