### PR TITLE
kvserver: touch up raft ready handling log

### DIFF
--- a/pkg/kv/kvserver/testdata/handle_raft_ready_stats.txt
+++ b/pkg/kv/kvserver/testdata/handle_raft_ready_stats.txt
@@ -1,3 +1,3 @@
 echo
 ----
-raft ready handling: 5.00s [append=1.00s, apply=1.00s, commit-batch-sync=1.00s, snap=1.00s, other=1.00s], wrote 5.0 KiB sync [append-ent=1.0 KiB (7), append-sst=5.0 MiB (3), apply=3 B (2 in 9 batches)], state_assertions=4, snapshot applied
+raft ready handling: 5.00s [append=1.00s, apply=1.00s, sync=1.00s, snap=1.00s, other=1.00s], wrote [append-batch=5.0 KiB, append-ent=1.0 KiB (7), append-sst=5.0 MiB (3), apply=3 B (2 in 9 batches)], state_assertions=4, snapshot applied


### PR DESCRIPTION
The bytes printed after "wrote" where the append bytes only, this was
confusing. Consolidate. Also, no need to print whether it's sync or
non-blocking-sync again because we already printed that in the timing section.

Found in https://github.com/cockroachdb/cockroach/issues/100096.

Epic: none
Release note: None
