### PR TITLE
roachtest: add ROACHTEST_ALWAYS_COLLECT_ARTIFACTS env var

### DIFF
--- a/pkg/cmd/roachtest/test_runner.go
+++ b/pkg/cmd/roachtest/test_runner.go
@@ -50,6 +50,11 @@ import (
 	"github.com/petermattis/goid"
 )
 
+var _, alwaysCollectArtifacts = map[string]bool{
+	"true": true,
+	"1":    true,
+}[os.Getenv("ROACHTEST_ALWAYS_COLLECT_ARTIFACTS")]
+
 var (
 	errTestsFailed = fmt.Errorf("some tests failed")
 
@@ -1111,7 +1116,7 @@ func (r *testRunner) teardownTest(
 			t.L().Printf("no live node found, skipping validation checks")
 		}
 
-		if timedOut || t.Failed() {
+		if timedOut || t.Failed() || alwaysCollectArtifacts {
 			r.collectClusterArtifacts(ctx, c, t.L())
 		}
 	})


### PR DESCRIPTION
When stressing a roachtest, it can be helpful to have the artifacts collected
even when the test passes, for example to check for markers of an interesting
issue[^1] in the logs. I don't think this quite rises to the importance of a
cli flag, but I could be convinced otherwise.

[^1]: https://github.com/cockroachdb/cockroach/issues/99464#issuecomment-1485715481

Epic: none
Release note: None
