### PR TITLE
release-22.2: roachtest: mark some hibernate/pgjdbc tests as flaky

### DIFF
--- a/pkg/cmd/roachtest/tests/hibernate.go
+++ b/pkg/cmd/roachtest/tests/hibernate.go
@@ -169,7 +169,7 @@ func registerHibernate(r registry.Registry, opt hibernateOptions) {
 			t.Fatal(err)
 		}
 
-		blocklistName, expectedFailures, _, _ := opt.blocklists.getLists(version)
+		blocklistName, expectedFailures, _, ignorelist := opt.blocklists.getLists(version)
 		if expectedFailures == nil {
 			t.Fatalf("No hibernate blocklist defined for cockroach version %s", version)
 		}
@@ -229,7 +229,7 @@ func registerHibernate(r registry.Registry, opt hibernateOptions) {
 
 		parseAndSummarizeJavaORMTestsResults(
 			ctx, t, c, node, "hibernate" /* ormName */, output,
-			blocklistName, expectedFailures, nil /* ignorelist */, version, supportedHibernateTag,
+			blocklistName, expectedFailures, ignorelist, version, supportedHibernateTag,
 		)
 	}
 

--- a/pkg/cmd/roachtest/tests/hibernate_blocklist.go
+++ b/pkg/cmd/roachtest/tests/hibernate_blocklist.go
@@ -245,5 +245,7 @@ var hibernateIgnoreList22_1 = hibernateIgnoreList21_2
 var hibernateIgnoreList21_2 = hibernateIgnoreList21_1
 
 var hibernateIgnoreList21_1 = blocklist{
-	"org.hibernate.userguide.pc.WhereTest.testLifecycle": "unknown",
+	"org.hibernate.userguide.pc.WhereTest.testLifecycle":                                                 "unknown",
+	"org.hibernate.serialization.SessionFactorySerializationTest.testUnNamedSessionFactorySerialization": "flaky",
+	"org.hibernate.serialization.SessionFactorySerializationTest.testNamedSessionFactorySerialization":   "flaky",
 }

--- a/pkg/cmd/roachtest/tests/pgjdbc_blocklist.go
+++ b/pkg/cmd/roachtest/tests/pgjdbc_blocklist.go
@@ -941,6 +941,7 @@ var pgjdbcIgnoreList = blocklist{
 	"org.postgresql.test.jdbc2.BatchedInsertReWriteEnabledTest.testBatchWithReWrittenSpaceAfterValues[3: autoCommit=NO, binary=FORCE]":              "54477",
 	"org.postgresql.test.jdbc2.BatchedInsertReWriteEnabledTest.testReWriteDisabledForPlainBatch[2: autoCommit=NO, binary=REGULAR]":                  "54477",
 	"org.postgresql.test.jdbc2.BatchedInsertReWriteEnabledTest.testReWriteDisabledForPlainBatch[3: autoCommit=NO, binary=FORCE]":                    "54477",
+	"org.postgresql.test.jdbc2.CursorFetchTest.testBasicFetch[binary = FORCE]":                                                                      "flaky",
 	"org.postgresql.test.jdbc2.DatabaseEncodingTest.testBadUTF8Decode":                                                                              "54477",
 	"org.postgresql.test.jdbc2.DatabaseEncodingTest.testTruncatedUTF8Decode":                                                                        "54477",
 	"org.postgresql.test.jdbc2.DatabaseEncodingTest.testUTF8Decode":                                                                                 "54477",


### PR DESCRIPTION
Backport 1/1 commits from #98346.

/cc @cockroachdb/release

fixes https://github.com/cockroachdb/cockroach/issues/96493

Release justification: test only change

---

I've noticed these ones coming up more.

fixes https://github.com/cockroachdb/cockroach/issues/98227
fixes https://github.com/cockroachdb/cockroach/issues/98288
Release note: None
