### PR TITLE
roachtest: fix gorm test

### DIFF
--- a/pkg/cmd/roachtest/tests/gorm.go
+++ b/pkg/cmd/roachtest/tests/gorm.go
@@ -104,7 +104,7 @@ func registerGORM(r registry.Registry) {
 		err = c.RunE(
 			ctx,
 			node,
-			fmt.Sprintf(`cd %s && go get -u -t ./... && go mod download && go mod tidy `, gormTestPath),
+			fmt.Sprintf(`cd %s && go mod tidy && go mod download`, gormTestPath),
 		)
 		require.NoError(t, err)
 


### PR DESCRIPTION
fixes https://github.com/cockroachdb/cockroach/issues/98364
backport fixes https://github.com/cockroachdb/cockroach/issues/99199
backport fixes https://github.com/cockroachdb/cockroach/issues/98430
backport fixes https://github.com/cockroachdb/cockroach/issues/94584

This removes the part that downloads the latest dependencies. That would cause it to fetch libraries that depend on the latest version of gorm, which won't work since we are pinning the version of gorm under test.

Release note: None