### PR TITLE
tenantcapabilitiestestutils: add a missing default case

### DIFF
--- a/pkg/multitenant/tenantcapabilities/tenantcapabilitiestestutils/testutils.go
+++ b/pkg/multitenant/tenantcapabilities/tenantcapabilitiestestutils/testutils.go
@@ -77,6 +77,8 @@ func ParseTenantCapabilityUpsert(
 				return roachpb.TenantID{}, nil, err
 			}
 			c.Value(&caps).Set(spanconfigbounds.New(&v))
+		default:
+			t.Fatalf("unknown capability type %T for capability %s", c, arg.Key)
 		}
 	}
 	return tID, &caps, nil


### PR DESCRIPTION
The test should fail if we ever add a new type of capability and use it in the data driven test but don't update the test to handle it.

Epic: none

Follow-up from https://github.com/cockroachdb/cockroach/pull/100217#pullrequestreview-1366732787

Release note: None