### PR TITLE
rpc: correctly check for nil before cast

### DIFF
--- a/pkg/rpc/context.go
+++ b/pkg/rpc/context.go
@@ -2715,7 +2715,7 @@ func (rpcCtx *Context) loadOrCreateConnAttempt(
 		select {
 		case <-previousAttempt.initialHeartbeatDone:
 			// The connection attempt was completed, return the outcome of it.
-			err := previousAttempt.err.Load().(error)
+			err, _ := previousAttempt.err.Load().(error)
 			if err == nil {
 				// If it completed without error then don't track the connection
 				// anymore. If it did have an error we need to track it until it later gets cleared.


### PR DESCRIPTION
As part of the fix of #99104, a cast without a nil check was introduced. This PR addresses that by only casting if it is known to be not nil.

Epic: none
Fixes: #100275
Release note: None