### PR TITLE
opt: fix incorrect ordering of partial index DEL cols in DELETE

### DIFF
--- a/pkg/sql/delete.go
+++ b/pkg/sql/delete.go
@@ -49,11 +49,6 @@ type deleteRun struct {
 	// traceKV caches the current KV tracing flag.
 	traceKV bool
 
-	// partialIndexDelValsOffset is the offset of partial index delete
-	// indicators in the source values. It is equal to the sum of the number
-	// of fetched columns and the number of passthrough columns.
-	partialIndexDelValsOffset int
-
 	// rowIdxToRetIdx is the mapping from the columns returned by the deleter
 	// to the columns in the resultRowBuffer. A value of -1 is used to indicate
 	// that the column at that index is not part of the resultRowBuffer
@@ -162,7 +157,7 @@ func (d *deleteNode) processSourceRow(params runParams, sourceVals tree.Datums) 
 	// This set is passed as a argument to tableDeleter.row below.
 	var pm row.PartialIndexUpdateHelper
 	if n := len(d.run.td.tableDesc().PartialIndexes()); n > 0 {
-		offset := d.run.partialIndexDelValsOffset
+		offset := len(d.run.td.rd.FetchCols) + d.run.numPassthrough
 		partialIndexDelVals := sourceVals[offset : offset+n]
 
 		err := pm.Init(nil /*partialIndexPutVals */, partialIndexDelVals, d.run.td.tableDesc())
@@ -172,7 +167,7 @@ func (d *deleteNode) processSourceRow(params runParams, sourceVals tree.Datums) 
 
 		// Truncate sourceVals so that it no longer includes partial index
 		// predicate values.
-		sourceVals = sourceVals[:d.run.partialIndexDelValsOffset]
+		sourceVals = sourceVals[:offset]
 	}
 
 	// Queue the deletion in the KV batch.

--- a/pkg/sql/logictest/testdata/logic_test/delete
+++ b/pkg/sql/logictest/testdata/logic_test/delete
@@ -533,3 +533,35 @@ SELECT a FROM pindex@pindex_a_idx WHERE a > 3
 ----
 4.00
 8.00
+
+statement ok
+DELETE FROM pindex USING (VALUES (2.0), (4.0)) v(b) WHERE pindex.a = v.b RETURNING v.b
+
+query F rowsort
+SELECT * FROM pindex;
+----
+1.00
+3.00
+8.00
+
+query F rowsort
+SELECT a FROM pindex@pindex_a_idx WHERE a > 3
+----
+8.00
+
+# Regression test for #99630. Partial index DEL columns should come after
+# passthrough columns in the delete node's column list.
+statement ok
+CREATE TABLE t99630a (a INT, INDEX idx (a) WHERE a > 0);
+CREATE TABLE t99630b (b BOOL);
+INSERT INTO t99630a VALUES (11);
+INSERT INTO t99630b VALUES (false);
+
+query B
+DELETE FROM t99630a USING t99630b RETURNING b
+----
+false
+
+query I
+SELECT a FROM t99630a@idx WHERE a > 0
+----

--- a/pkg/sql/opt_exec_factory.go
+++ b/pkg/sql/opt_exec_factory.go
@@ -1726,9 +1726,8 @@ func (ef *execFactory) ConstructDelete(
 	*del = deleteNode{
 		source: input.(planNode),
 		run: deleteRun{
-			td:                        tableDeleter{rd: rd, alloc: ef.getDatumAlloc()},
-			partialIndexDelValsOffset: len(rd.FetchCols) + len(passthrough),
-			numPassthrough:            len(passthrough),
+			td:             tableDeleter{rd: rd, alloc: ef.getDatumAlloc()},
+			numPassthrough: len(passthrough),
 		},
 	}
 


### PR DESCRIPTION
This commit fixes a bug in the optimizer that incorrectly ordered
partial index DEL columns in input rows of delete nodes. Previously, the
optimizer put these columns before passthrough columns, which are used
when the `RETURNING` clause contains columns from one of the tables in
the USING clause. However, `execFactory.ConstructDelete` assumes that
the partial index DEL columns come after the passthrough columns when
calculating the partial index column offset in the input row. These
conflicting assumptions could cause internal errors and corrupt partial
indexes. The bug is fixed by putting the passthrough columns before the
partial index DEL columns in the input rows of delete nodes.

Fixes #99630

Release note (bug fix): A bug has been fixed that could cause internal
errors and corrupt partial indexes when deleting rows with the
`DELETE FROM .. USING` syntax. This bug is only present in alpha
versions of v23.1.0.

#### sql: remove `deleteRun.partialIndexDelValsOffset`

The `partialIndexDelValsOffset` field of the `deleteRun` struct is not
necessary because it can be computed from other fields. It has been
removed.

Release note: None
