### PR TITLE
release-23.1: opt: fix incorrect ordering of partial index DEL cols in DELETE

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/delete
+++ b/pkg/sql/logictest/testdata/logic_test/delete
@@ -533,3 +533,35 @@ SELECT a FROM pindex@pindex_a_idx WHERE a > 3
 ----
 4.00
 8.00
+
+statement ok
+DELETE FROM pindex USING (VALUES (2.0), (4.0)) v(b) WHERE pindex.a = v.b RETURNING v.b
+
+query F rowsort
+SELECT * FROM pindex;
+----
+1.00
+3.00
+8.00
+
+query F rowsort
+SELECT a FROM pindex@pindex_a_idx WHERE a > 3
+----
+8.00
+
+# Regression test for #99630. Partial index DEL columns should come after
+# passthrough columns in the delete node's column list.
+statement ok
+CREATE TABLE t99630a (a INT, INDEX idx (a) WHERE a > 0);
+CREATE TABLE t99630b (b BOOL);
+INSERT INTO t99630a VALUES (11);
+INSERT INTO t99630b VALUES (false);
+
+query B
+DELETE FROM t99630a USING t99630b RETURNING b
+----
+false
+
+query I
+SELECT a FROM t99630a@idx WHERE a > 0
+----


### PR DESCRIPTION
Backport 1/2 commits from #100301.

/cc @cockroachdb/release

---

This commit fixes a bug in the optimizer that incorrectly ordered
partial index DEL columns in input rows of delete nodes. Previously, the
optimizer put these columns before passthrough columns, which are used
when the `RETURNING` clause contains columns from one of the tables in
the USING clause. However, `execFactory.ConstructDelete` assumes that
the partial index DEL columns come after the passthrough columns when
calculating the partial index column offset in the input row. These
conflicting assumptions could cause internal errors and corrupt partial
indexes. The bug is fixed by putting the passthrough columns before the
partial index DEL columns in the input rows of delete nodes.

Fixes #99630

Release note (bug fix): A bug has been fixed that could cause internal
errors and corrupt partial indexes when deleting rows with the
`DELETE FROM .. USING` syntax. This bug is only present in alpha
versions of v23.1.0.

Release justification: Fixes a bug with new SQL syntax that can corrupt
partial indexes.