### PR TITLE
bazel: update toolchains to support remote execution

### DIFF
--- a/build/toolchains/crosstool-ng/BUILD.tmpl
+++ b/build/toolchains/crosstool-ng/BUILD.tmpl
@@ -29,7 +29,18 @@ filegroup(
     srcs = [
         "bin/%{target}-gcc",
         "bin/%{target}-g++",
-    ],
+        "libexec/gcc/%{target}/6.5.0/cc1",
+        "libexec/gcc/%{target}/6.5.0/cc1plus",
+    ] + glob([
+        "%{target}/bin/*",
+        "%{target}/include/c++/6.5.0/**",
+        "%{target}/sysroot/mingw/include/**",
+        "%{target}/sysroot/mingw/lib/**",
+        "%{target}/sysroot/mingw/lib32/**",
+        "%{target}/sysroot/usr/include/**",
+        "lib/gcc/%{target}/6.5.0/include/**",
+        "lib/gcc/%{target}/6.5.0/include-fixed/**",
+    ])
 )
 
 filegroup(
@@ -43,7 +54,19 @@ filegroup(
     name = "linker_files",
     srcs = [
         "bin/%{target}-g++",
-    ],
+    ] + glob([
+        "%{target}/sysroot/lib/**",
+        "%{target}/sysroot/lib64/**",
+        "%{target}/sysroot/usr/%{target}/lib32/**",
+        "%{target}/sysroot/usr/%{target}/lib/**",
+        "%{target}/sysroot/usr/lib/**",
+        "%{target}/sysroot/usr/lib64/**",
+    ]) + glob(
+        ["lib/gcc/%{target}/6.5.0/**"],
+        exclude=[
+            "lib/gcc/%{target}/6.5.0/include/**",
+            "lib/gcc/%{target}/6.5.0/include-fixed/**",
+        ]),
 )
 
 filegroup(

--- a/build/toolchains/crosstool-ng/cc_toolchain_config.bzl.tmpl
+++ b/build/toolchains/crosstool-ng/cc_toolchain_config.bzl.tmpl
@@ -37,7 +37,6 @@ def _impl(ctx):
             action_name = ACTION_NAMES.cpp_link_static_library,
             tools = [tool(path="bin/%{target}-ar")],
         ),
-
     ]
 
     opt_feature = feature(
@@ -106,7 +105,6 @@ def _impl(ctx):
         ],
     )
 
-
     default_compile_flags = feature(
         name = "default_compile_flags",
         enabled = True,
@@ -117,7 +115,9 @@ def _impl(ctx):
                     flag_group(
                         flags = [
                             "-Wall",
-                            "-I%{repo_path}/%{target}/include/c++/6.5.0",
+                            "-Iexternal/%{repo_name}/%{target}/include/c++/6.5.0",
+                            "-no-canonical-prefixes",
+                            "-fno-canonical-system-headers",
                         ],
                     ),
                 ]),
@@ -125,7 +125,7 @@ def _impl(ctx):
         ],
     )
 
-    linker_flags = []
+    linker_flags = ["-fno-use-linker-plugin"]
     if "%{target}" == "x86_64-w64-mingw32":
         linker_flags.append("-static")
     if "-linux-" in "%{target}":
@@ -178,11 +178,11 @@ def _impl(ctx):
         action_configs = action_configs,
         cxx_builtin_include_directories = [
             "%sysroot%/usr/include",
-            "%{repo_path}/%{target}/include/c++/6.5.0",
-            "%{repo_path}/lib/gcc/%{target}/6.5.0/include",
-            "%{repo_path}/lib/gcc/%{target}/6.5.0/include-fixed",
+            "external/%{repo_name}/%{target}/include/c++/6.5.0",
+            "external/%{repo_name}/lib/gcc/%{target}/6.5.0/include",
+            "external/%{repo_name}/lib/gcc/%{target}/6.5.0/include-fixed",
         ],
-        builtin_sysroot = "%{repo_path}/%{target}/sysroot",
+        builtin_sysroot = "external/%{repo_name}/%{target}/sysroot",
     )
 
 cc_toolchain_config = rule(

--- a/build/toolchains/crosstool-ng/toolchain.bzl
+++ b/build/toolchains/crosstool-ng/toolchain.bzl
@@ -9,8 +9,6 @@ def _impl(rctx):
         stripPrefix = "x-tools/{}/".format(rctx.attr.target),
     )
 
-    repo_path = str(rctx.path(""))
-
     rctx.template(
         "BUILD",
         Label("@com_github_cockroachdb_cockroach//build:toolchains/crosstool-ng/BUILD.tmpl"),
@@ -26,7 +24,7 @@ def _impl(rctx):
         substitutions = {
             "%{target}": rctx.attr.target,
             "%{host}": rctx.attr.host,
-            "%{repo_path}": repo_path,
+            "%{repo_name}": rctx.name,
         },
         executable = False,
     )


### PR DESCRIPTION
We need to add some extra files to `compiler_files` and `linker_files` and update some compiler flags to make sure remote execution works.

Epic: none
Release note: None