### PR TITLE
ccl/sqlproxyccl: deflake TestDenylistLogic

### DIFF
--- a/pkg/ccl/sqlproxyccl/acl/BUILD.bazel
+++ b/pkg/ccl/sqlproxyccl/acl/BUILD.bazel
@@ -37,6 +37,7 @@ go_test(
         "//pkg/util/leaktest",
         "//pkg/util/metric",
         "//pkg/util/timeutil",
+        "@com_github_cockroachdb_errors//:errors",
         "@com_github_google_btree//:btree",
         "@com_github_stretchr_testify//require",
         "@in_gopkg_yaml_v2//:yaml_v2",

--- a/pkg/ccl/sqlproxyccl/acl/watcher.go
+++ b/pkg/ccl/sqlproxyccl/acl/watcher.go
@@ -122,14 +122,26 @@ func NewWatcher(ctx context.Context, opts ...Option) (*Watcher, error) {
 	}
 
 	if options.allowlistFile != "" {
-		c, next, err := newAccessControllerFromFile[*Allowlist](ctx, options.allowlistFile, w.options.pollingInterval, w.options.errorCount)
+		c, next, err := newAccessControllerFromFile[*Allowlist](
+			ctx,
+			options.allowlistFile,
+			options.timeSource,
+			w.options.pollingInterval,
+			w.options.errorCount,
+		)
 		if err != nil {
 			return nil, err
 		}
 		w.addAccessController(c, next)
 	}
 	if options.denylistFile != "" {
-		c, next, err := newAccessControllerFromFile[*Denylist](ctx, options.denylistFile, w.options.pollingInterval, w.options.errorCount)
+		c, next, err := newAccessControllerFromFile[*Denylist](
+			ctx,
+			options.denylistFile,
+			options.timeSource,
+			w.options.pollingInterval,
+			w.options.errorCount,
+		)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Fixes #100295, hopefully.

It's unclear what causes the flakes in TestDenylistLogic. This commit updates the test to run with their scopes (i.e. subtest names) for easier debugging. At the same time, this commit updates newAccessControllerFromFile to use a custom time source instead of the default one.

Release note: None

Epic: none

Release justification: Low-risk change aimed to help with test debugging in sqlproxyccl.