### PR TITLE
sql,multitenant: add support for granting span config bounds

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/tenant_capability
+++ b/pkg/ccl/logictestccl/testdata/logic_test/tenant_capability
@@ -5,19 +5,19 @@ subtest grant_revoke_error
 statement ok
 CREATE TENANT "grant-revoke-error-tenant";
 
-statement error unknown capability: "not_a_capability"
+statement error pgcode 42601 unknown capability: "not_a_capability"
 ALTER TENANT "grant-revoke-error-tenant" GRANT CAPABILITY not_a_capability=true
 
-statement error argument of ALTER TENANT CAPABILITY can_admin_split must be type bool, not type int
+statement error pgcode 42804 argument of ALTER TENANT CAPABILITY can_admin_split must be type bool, not type int
 ALTER TENANT "grant-revoke-error-tenant" GRANT CAPABILITY can_admin_split=1
 
-statement error parameter "can_admin_split" requires a Boolean value
+statement error pgcode 22023 parameter "can_admin_split" requires a Boolean value
 ALTER TENANT "grant-revoke-error-tenant" GRANT CAPABILITY can_admin_split=NULL
 
-statement error unknown capability: "not_a_capability"
+statement error pgcode 42601 unknown capability: "not_a_capability"
 ALTER TENANT "grant-revoke-error-tenant" REVOKE CAPABILITY not_a_capability
 
-statement error no value allowed in revoke: "can_admin_split"
+statement error pgcode 42601 no value allowed in revoke: "can_admin_split"
 ALTER TENANT "grant-revoke-error-tenant" REVOKE CAPABILITY can_admin_split=false
 
 subtest end
@@ -204,5 +204,82 @@ can_view_node_info         false
 can_view_tsdb_metrics      false
 exempt_from_rate_limiting  false
 span_config_bounds         {}
+
+subtest end
+
+
+subtest span_config_bounds
+
+statement ok
+CREATE TENANT scb;
+
+# Test that you can't REVOKE span_config_bounds. The reason is that it'd be
+# confusing; removing the bounds is like setting the capability to be a
+# wildcard. That's hardly REVOKE-ing anything.
+
+statement error pgcode 22023 cannot REVOKE CAPABILITY span_config_bounds
+ALTER TENANT scb REVOKE CAPABILITY span_config_bounds;
+
+statement ok
+ALTER TENANT scb GRANT CAPABILITY span_config_bounds = crdb_internal.json_to_pb(
+    'cockroach.multitenant.tenantcapabilitiespb.SpanConfigBounds',
+    '{"gcTtlSeconds": {"start": 60, "end":600}, "rangeMaxBytes": {"start": 100, "end":200}}'
+)
+
+# Observe the side-effect.
+
+query TT colnames
+SELECT capability_name, capability_value FROM [SHOW TENANT scb WITH CAPABILITIES]
+----
+capability_name            capability_value
+can_admin_relocate_range   false
+can_admin_scatter          true
+can_admin_split            true
+can_admin_unsplit          false
+can_use_nodelocal_storage  false
+can_view_node_info         false
+can_view_tsdb_metrics      false
+exempt_from_rate_limiting  false
+span_config_bounds         range_min_bytes: *
+                           range_max_bytes: [100, 200]
+                           global_reads: *
+                           num_voters: *
+                           num_replicas: *
+                           gc.ttlseconds: [60, 600]
+                           constraints: *
+                           voter_constraints: *
+                           lease_preferences: *
+
+# Ensure that you can set the bounds to NULL, which means there now are no
+# bounds.
+
+statement ok
+ALTER TENANT scb GRANT CAPABILITY span_config_bounds = NULL;
+
+query TT colnames
+SELECT capability_name, capability_value FROM [SHOW TENANT scb WITH CAPABILITIES]
+----
+capability_name            capability_value
+can_admin_relocate_range   false
+can_admin_scatter          true
+can_admin_split            true
+can_admin_unsplit          false
+can_use_nodelocal_storage  false
+can_view_node_info         false
+can_view_tsdb_metrics      false
+exempt_from_rate_limiting  false
+span_config_bounds         {}
+
+# Check that there are appropriate errors for invalid types, malformed and
+# malformed data.
+
+statement error pgcode 22023 invalid span_config_bounds value
+ALTER TENANT scb GRANT CAPABILITY span_config_bounds = x'01ab';
+
+statement error pgcode 42804 argument of ALTER TENANT CAPABILITY span_config_bounds must be type bytes, not type bool
+ALTER TENANT scb GRANT CAPABILITY span_config_bounds = false;
+
+statement error pgcode 42601 value required for capability: span_config_bounds
+ALTER TENANT scb GRANT CAPABILITY span_config_bounds;
 
 subtest end

--- a/pkg/multitenant/tenantcapabilities/values_test.go
+++ b/pkg/multitenant/tenantcapabilities/values_test.go
@@ -38,3 +38,27 @@ func TestGetSet(t *testing.T) {
 		}
 	}
 }
+
+// TestSpanConfigBoundsSetGet ensures calling Get on SpanConfigBounds that have
+// been previously modified using a Set returns the correct value.
+func TestSpanConfigBoundsSetGet(t *testing.T) {
+	capability := spanConfigBoundsCapability(TenantSpanConfigBounds)
+	val := capability.Value(DefaultCapabilities())
+
+	// Construct some span config bounds that apply to GC TTLs.
+	var v tenantcapabilitiespb.TenantCapabilities
+	const ttlStart = int32(500)
+	const ttlEnd = int32(1000)
+	v.SpanConfigBounds = &tenantcapabilitiespb.SpanConfigBounds{
+		GCTTLSeconds: &tenantcapabilitiespb.SpanConfigBounds_Int32Range{
+			Start: ttlStart,
+			End:   ttlEnd,
+		},
+	}
+
+	// Modify the default capabilities we're working with by setting the bounds.
+	val.Set(capability.Value(&v).Get())
+	// Ensure getting the bounds returns the correct values.
+	require.Equal(t, val.Get().GCTTLSeconds.Start, ttlStart)
+	require.Equal(t, val.Get().GCTTLSeconds.End, ttlEnd)
+}

--- a/pkg/spanconfig/spanconfigbounds/span_config_bounds.go
+++ b/pkg/spanconfig/spanconfigbounds/span_config_bounds.go
@@ -11,7 +11,9 @@
 package spanconfigbounds
 
 import (
+	"fmt"
 	"sort"
+	"strings"
 
 	"github.com/cockroachdb/cockroach/pkg/config"
 	"github.com/cockroachdb/cockroach/pkg/multitenant/tenantcapabilities/tenantcapabilitiespb"
@@ -51,7 +53,13 @@ func New(b *tenantcapabilitiespb.SpanConfigBounds) *Bounds {
 }
 
 func (b *Bounds) String() string {
-	return redact.Sprint(b).StripMarkers()
+	var buf strings.Builder
+	sep := ""
+	for _, field := range fields {
+		_, _ = fmt.Fprintf(&buf, "%s%s: %s", sep, field, field.FieldBound(b))
+		sep = "\n"
+	}
+	return buf.String()
 }
 
 // Clamp will update the SpanConfig in place, clamping any properties

--- a/pkg/sql/BUILD.bazel
+++ b/pkg/sql/BUILD.bazel
@@ -346,6 +346,7 @@ go_library(
         "//pkg/settings",
         "//pkg/settings/cluster",
         "//pkg/spanconfig",
+        "//pkg/spanconfig/spanconfigbounds",
         "//pkg/sql/appstatspb",
         "//pkg/sql/backfill",
         "//pkg/sql/catalog",


### PR DESCRIPTION
Epic: CRDB-16706
Fixes #99911.

This PR adapts https://github.com/cockroachdb/cockroach/pull/98199 from @ajwerner to the current state of tenant capabilities.

With this commit, users are able to issue
`ALTER TENANT ... GRANT CAPABILITY span_config_bounds`. The capability takes a bytes value which is an encoded protobuf. The `crdb_internal_pb_to_json` builtin makes interacting as such straight forward.

While here, we also add TestSpanConfigBoundsSetGet to ensure updated capabilites reflect correct values. It wasn't failing before this patch. I initially added this when trying to diagnose an unrelated issue with `SHOW TENANTS`. It's worth keeping around.

