### PR TITLE
[DNM] multiregionccl: attempts to debug ColdStartLatencyTest

### DIFF
--- a/pkg/ccl/multiregionccl/BUILD.bazel
+++ b/pkg/ccl/multiregionccl/BUILD.bazel
@@ -57,6 +57,7 @@ go_test(
         "//pkg/kv/kvbase",
         "//pkg/kv/kvclient/kvcoord",
         "//pkg/kv/kvserver",
+        "//pkg/kv/kvserver/closedts",
         "//pkg/roachpb",
         "//pkg/rpc",
         "//pkg/security/securityassets",

--- a/pkg/kv/kvclient/kvcoord/dist_sender.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender.go
@@ -2032,6 +2032,8 @@ func (ds *DistSender) sendToReplicas(
 	var leaseholderFirst bool
 	switch ba.RoutingPolicy {
 	case kvpb.RoutingPolicy_LEASEHOLDER:
+
+		log.VEventf(ctx, 2, "routing to leaseholder %v %v %v", ds.locality, replicas, ba)
 		// First order by latency, then move the leaseholder to the front of the
 		// list, if it is known.
 		if !ds.dontReorderReplicas {
@@ -2053,8 +2055,9 @@ func (ds *DistSender) sendToReplicas(
 
 	case kvpb.RoutingPolicy_NEAREST:
 		// Order by latency.
-		log.VEvent(ctx, 2, "routing to nearest replica; leaseholder not required")
+		log.VEventf(ctx, 2, "routing to nearest replica; leaseholder not required %v %v", ds.locality, replicas)
 		replicas.OptimizeReplicaOrder(ds.getNodeID(), ds.latencyFunc, ds.locality)
+		log.VEventf(ctx, 2, "ordered routing to nearest replica; leaseholder not required %v %v", ds.locality, replicas)
 
 	default:
 		log.Fatalf(ctx, "unknown routing policy: %s", ba.RoutingPolicy)

--- a/pkg/kv/kvserver/replica_follower_read.go
+++ b/pkg/kv/kvserver/replica_follower_read.go
@@ -99,7 +99,7 @@ func (r *Replica) canServeFollowerReadRLocked(ctx context.Context, ba *kvpb.Batc
 	switch repDesc.Type {
 	case roachpb.VOTER_FULL, roachpb.VOTER_INCOMING, roachpb.NON_VOTER:
 	default:
-		log.Eventf(ctx, "%s replicas cannot serve follower reads", repDesc.Type)
+		log.VEventf(ctx, 2, "%s replicas cannot serve follower reads", repDesc.Type)
 		return false
 	}
 
@@ -115,7 +115,7 @@ func (r *Replica) canServeFollowerReadRLocked(ctx context.Context, ba *kvpb.Batc
 
 		// We can't actually serve the read based on the closed timestamp.
 		// Signal the clients that we want an update so that future requests can succeed.
-		log.Eventf(ctx, "can't serve follower read; closed timestamp too low by: %s; maxClosed: %s ts: %s uncertaintyLimit: %s",
+		log.VEventf(ctx, 2, "can't serve follower read; closed timestamp too low by: %s; maxClosed: %s ts: %s uncertaintyLimit: %s",
 			tsDiff, maxClosed, ba.Timestamp, uncertaintyLimitStr)
 		return false
 	}


### PR DESCRIPTION
`./dev test pkg/ccl/multiregionccl/ --stress-args=-p=16 --stress --filter Cold -v --stream-output --show-logs --vmodule=cold_start_latency_test=2,lease*=2,storage=2,replica_follower_read*=2,replica_command=2,sender=4,receiver=4,conn_executor=2,nodedialer=2,dist_sender=2  -- --test_env=GOMEMLIMIT=3200MiB 2>&1`

The above command prints out a seriously large volume of information. My usual attempt to search through it is to go to:

* `/no connectivit` -- where the test starts
* `/get-user-session` -- find the timeout and the tenant sql pod
* `/.*nsql<pod>.*user=` -- look through the goroutines done looking up the user
* Look at the goroutine dump that happens before the timeout. It'll likely be under the singleflight

The failure modes I've seen lately are that the stats lookups are hitting problems. The stats table should have a global config propagated.

It's a somewhat painful cycle. It can take 10ish minutes to fail.

Release note: None