### PR TITLE
ttl: change delete priority to TTLLowPri

### DIFF
--- a/pkg/sql/ttl/ttljob/ttljob_processor.go
+++ b/pkg/sql/ttl/ttljob/ttljob_processor.go
@@ -326,7 +326,7 @@ func (t *ttlProcessor) runTTLOnSpan(
 				return nil
 			}
 			if err := serverCfg.DB.Txn(
-				ctx, do, isql.SteppingEnabled(), isql.WithPriority(admissionpb.UserLowPri),
+				ctx, do, isql.SteppingEnabled(), isql.WithPriority(admissionpb.TTLLowPri),
 			); err != nil {
 				return spanRowCount, errors.Wrapf(err, "error during row deletion")
 			}


### PR DESCRIPTION
Fixes #100333

Change TTL deletes to use TTLLowPri (-100) instead of UserLowPri (-50) to avoid interfering with user traffic.

Release note: None