### PR TITLE
Kafka quota backpressure

### DIFF
--- a/pkg/ccl/changefeedccl/BUILD.bazel
+++ b/pkg/ccl/changefeedccl/BUILD.bazel
@@ -163,6 +163,7 @@ go_library(
         "@com_github_klauspost_compress//zstd",
         "@com_github_klauspost_pgzip//:pgzip",
         "@com_github_linkedin_goavro_v2//:goavro",
+        "@com_github_rcrowley_go_metrics//:go-metrics",
         "@com_github_shopify_sarama//:sarama",
         "@com_github_xdg_go_scram//:scram",
         "@com_google_cloud_go_pubsub//:pubsub",

--- a/pkg/ccl/changefeedccl/cdcutils/throttle.go
+++ b/pkg/ccl/changefeedccl/cdcutils/throttle.go
@@ -66,6 +66,11 @@ func (t *Throttler) AcquireFlushQuota(ctx context.Context) error {
 	return waitQuota(ctx, 1, t.flushLimiter, t.metrics.FlushPushbackNanos)
 }
 
+// UpdateBytePerSecondRate updates only the ByteRate of t.
+func (t *Throttler) UpdateBytePerSecondRate(newRate float64) {
+	t.byteLimiter.UpdateLimit(quotapool.Limit(newRate), int64(newRate))
+}
+
 func (t *Throttler) updateConfig(config changefeedbase.SinkThrottleConfig) {
 	setLimits := func(rl *quotapool.RateLimiter, rate, burst float64) {
 		// set rateBudget to unlimited if rate is 0.

--- a/pkg/cmd/roachtest/tests/cdc.go
+++ b/pkg/cmd/roachtest/tests/cdc.go
@@ -215,6 +215,10 @@ func (ct *cdcTester) setupSink(args feedArgs) string {
 		kafka.install(ct.ctx)
 		kafka.start(ct.ctx, "kafka")
 
+		if args.kafkaQuota > 0 {
+			kafka.setProducerQuota(ct.ctx, args.kafkaQuota)
+		}
+
 		if args.kafkaChaos {
 			ct.mon.Go(func(ctx context.Context) error {
 				period, downTime := 2*time.Minute, 20*time.Second
@@ -361,6 +365,7 @@ type feedArgs struct {
 	targets         []string
 	opts            map[string]string
 	kafkaChaos      bool
+	kafkaQuota      int
 	assumeRole      string
 	tolerateErrors  bool
 	sinkURIOverride string
@@ -1024,6 +1029,29 @@ func registerCDC(r registry.Registry) {
 			ct.runFeedLatencyVerifier(feed, latencyTargets{
 				initialScanLatency: 30 * time.Minute,
 				steadyLatency:      time.Minute,
+			})
+			ct.waitForWorkload()
+		},
+	})
+	r.Add(registry.TestSpec{
+		Name:            "cdc/kafka-quota",
+		Owner:           `cdc`,
+		Cluster:         r.MakeClusterSpec(4, spec.CPU(16)),
+		RequiresLicense: true,
+		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
+			ct := newCDCTester(ctx, t, c)
+			defer ct.Close()
+
+			ct.runTPCCWorkload(tpccArgs{warehouses: 100, duration: "30m"})
+
+			feed := ct.newChangefeed(feedArgs{
+				sinkType:   kafkaSink,
+				targets:    allTpccTargets,
+				kafkaQuota: 262144,
+			})
+			ct.runFeedLatencyVerifier(feed, latencyTargets{
+				initialScanLatency: 3 * time.Minute,
+				steadyLatency:      5 * time.Minute,
 			})
 			ct.waitForWorkload()
 		},
@@ -2001,6 +2029,16 @@ func (k kafkaManager) start(ctx context.Context, service string, envVars ...stri
 	// This isn't necessary for the nightly tests, but it's nice for iteration.
 	k.c.Run(ctx, k.nodes, k.makeCommand("confluent", "local destroy || true"))
 	k.restart(ctx, service, envVars...)
+}
+
+func (k kafkaManager) setProducerQuota(ctx context.Context, bytesPerSecond int) {
+	k.t.Status("setting producer quota to %d bytes per second for all users", bytesPerSecond)
+	k.c.Run(ctx, k.nodes, filepath.Join(k.binDir(), "kafka-configs"),
+		"--zookeeper", "localhost:2181",
+		"--alter",
+		"--add-config", fmt.Sprintf("producer_byte_rate=%d", bytesPerSecond),
+		"--entity-type", "users",
+		"--entity-name", "default")
 }
 
 var kafkaServices = map[string][]string{

--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -5012,7 +5012,7 @@ CREATE TABLE crdb_internal.regions (
 )
 	`,
 	populate: func(ctx context.Context, p *planner, _ catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) error {
-		resp, err := p.InternalSQLTxn().Regions().GetRegions(ctx)
+		resp, err := p.extendedEvalCtx.TenantStatusServer.Regions(ctx, &serverpb.RegionsRequest{})
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Draftiest of draft PRs -- needs tests and logging cleanup, and also I'd like to try to rework just about every aspect of the implementation. But! This PR converts [Kafka throttling](https://docs.confluent.io/kafka/design/quotas.html#request-rate-quotas) protocol messages into changefeed backpressure. See top two commits for details.