### PR TITLE
logictest: fix bug in upgrade directive

### DIFF
--- a/pkg/sql/logictest/logic.go
+++ b/pkg/sql/logictest/logic.go
@@ -3028,8 +3028,11 @@ func (t *logicTest) processSubtest(
 				}
 				delete(m, nodeIdx)
 			}
-			db := t.getOrOpenClient(t.user, nodeIdx)
-			t.db = db
+			// If we upgraded the node we are currently on, we need to open a new
+			// connection since the previous one might now be invalid.
+			if t.nodeIdx == nodeIdx {
+				t.setUser(t.user, nodeIdx)
+			}
 		default:
 			return errors.Errorf("%s:%d: unknown command: %s",
 				path, s.Line+subtest.lineLineIndexIntoFile, cmd,


### PR DESCRIPTION
This patch fixes a subtle bug in the upgrade directive that would cause
the active database client to change to the newly upgraded node without
updating the `nodeIdx` recorded in the `logicTest` struct.

Fixes #100331

Release note: None