### PR TITLE
release-22.1: opt: check UDTs by name when checking metadata dependencies

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/schema
+++ b/pkg/sql/logictest/testdata/logic_test/schema
@@ -863,4 +863,83 @@ SELECT comment FROM system.comments LIMIT 1
 ----
 
 statement ok
+USE test;
 DROP DATABASE comment_db
+
+subtest alter_table_schema
+
+# Renaming the schema should invalidate a schema-qualified table reference.
+statement ok
+CREATE SCHEMA sc;
+CREATE TABLE sc.xy (x INT, y INT);
+INSERT INTO sc.xy VALUES (1, 1);
+
+query II
+SELECT * FROM sc.xy;
+----
+1 1
+
+statement ok
+ALTER SCHEMA sc RENAME TO sc1;
+
+query error pq: relation "sc.xy" does not exist
+SELECT * FROM sc.xy;
+
+query II
+SELECT * FROM sc1.xy;
+----
+1 1
+
+statement ok
+DROP SCHEMA sc1 CASCADE;
+
+# Renaming the database should invalidate a database-qualified table reference.
+statement ok
+CREATE DATABASE d;
+USE d;
+CREATE TABLE d.xy (x INT, y INT);
+INSERT INTO d.xy VALUES (1, 1);
+
+query II
+SELECT * FROM d.xy;
+----
+1 1
+
+statement ok
+ALTER DATABASE d RENAME TO d1;
+USE d1;
+
+query error pq: relation "d.xy" does not exist
+SELECT * FROM d.xy;
+
+query II
+SELECT * FROM d1.xy;
+----
+1 1
+
+statement ok
+USE test;
+DROP DATABASE d1 CASCADE;
+
+# Changing the current database should invalidate an unqualified table
+# reference.
+statement ok
+CREATE TABLE xy (x INT, y INT);
+INSERT INTO xy VALUES (1, 1);
+
+query II
+SELECT * FROM xy;
+----
+1 1
+
+statement ok
+CREATE DATABASE d;
+USE d;
+
+query error pq: relation "xy" does not exist
+SELECT * FROM xy;
+
+statement ok
+USE test;
+DROP DATABASE d;
+DROP TABLE xy;

--- a/pkg/sql/logictest/testdata/logic_test/schema
+++ b/pkg/sql/logictest/testdata/logic_test/schema
@@ -943,3 +943,78 @@ statement ok
 USE test;
 DROP DATABASE d;
 DROP TABLE xy;
+
+# Regression tests for #96674.
+subtest alter_udt_schema
+
+# Renaming the schema should invalidate a schema-qualified UDT reference.
+statement ok
+CREATE SCHEMA sc;
+CREATE TYPE sc.t AS ENUM ('HELLO');
+
+query T
+SELECT 'HELLO'::sc.t;
+----
+HELLO
+
+statement ok
+ALTER SCHEMA sc RENAME TO sc1;
+
+query error pq: type "sc.t" does not exist
+SELECT 'HELLO'::sc.t;
+
+query T
+SELECT 'HELLO'::sc1.t;
+----
+HELLO
+
+statement ok
+DROP SCHEMA sc1 CASCADE;
+
+# Renaming the database should invalidate a database-qualified UDT reference.
+statement ok
+CREATE DATABASE d;
+USE d;
+CREATE TYPE d.t AS ENUM ('HELLO');
+
+query T
+SELECT 'HELLO'::d.t;
+----
+HELLO
+
+statement ok
+ALTER DATABASE d RENAME TO d1;
+USE d1;
+
+query error pq: type "d.t" does not exist
+SELECT 'HELLO'::d.t;
+
+query T
+SELECT 'HELLO'::d1.t;
+----
+HELLO
+
+statement ok
+USE test;
+DROP DATABASE d1 CASCADE;
+
+# Changing the current database should invalidate an unqualified UDT reference.
+statement ok
+CREATE TYPE t AS ENUM ('HELLO');
+
+query T
+SELECT 'HELLO'::t;
+----
+HELLO
+
+statement ok
+CREATE DATABASE d;
+USE d;
+
+query error pq: type "t" does not exist
+SELECT 'HELLO'::t;
+
+statement ok
+USE test;
+DROP DATABASE d;
+DROP TYPE t;

--- a/pkg/sql/opt/BUILD.bazel
+++ b/pkg/sql/opt/BUILD.bazel
@@ -24,6 +24,7 @@ go_library(
         "//pkg/server/telemetry",
         "//pkg/sql/catalog",
         "//pkg/sql/catalog/colinfo",
+        "//pkg/sql/catalog/typedesc",
         "//pkg/sql/opt/cat",
         "//pkg/sql/opt/partition",
         "//pkg/sql/pgwire/pgcode",

--- a/pkg/sql/opt/BUILD.bazel
+++ b/pkg/sql/opt/BUILD.bazel
@@ -22,6 +22,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/server/telemetry",
+        "//pkg/sql/catalog",
         "//pkg/sql/catalog/colinfo",
         "//pkg/sql/opt/cat",
         "//pkg/sql/opt/partition",

--- a/pkg/sql/opt/metadata.go
+++ b/pkg/sql/opt/metadata.go
@@ -16,6 +16,7 @@ import (
 	"math/bits"
 	"strings"
 
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/cat"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
@@ -76,7 +77,8 @@ type privilegeBitmap uint32
 // In this query, `l.x` is not equivalent to `r.x` and `l.y` is not equivalent
 // to `r.y`. Therefore, we need to give these columns different ids.
 type Metadata struct {
-	// schemas stores each schema used in the query, indexed by SchemaID.
+	// schemas stores each schema used by the query if it is a CREATE statement,
+	// indexed by SchemaID.
 	schemas []cat.Schema
 
 	// cols stores information about each metadata column, indexed by
@@ -99,15 +101,6 @@ type Metadata struct {
 	userDefinedTypes      map[oid.Oid]struct{}
 	userDefinedTypesSlice []*types.T
 
-	// deps stores information about all data source objects depended on by the
-	// query, as well as the privileges required to access them. The objects are
-	// deduplicated: any name/object pair shows up at most once.
-	// Note: the same data source object can appear multiple times if different
-	// names were used. For example, in the query `SELECT * from t, db.t` the two
-	// tables might resolve to the same object now but to different objects later;
-	// we want to verify the resolution of both names.
-	deps []mdDep
-
 	// views stores the list of referenced views. This information is only
 	// needed for EXPLAIN (opt, env).
 	views []cat.View
@@ -119,33 +112,20 @@ type Metadata struct {
 	// mutation operators, used to determine the logical properties of WithScan.
 	withBindings map[WithID]Expr
 
+	// dataSourceDeps stores each data source object that the query depends on.
+	dataSourceDeps map[cat.StableID]cat.DataSource
+
+	// objectRefsByName stores each unique name that the query uses to reference
+	// each object. It is needed because changes to the search path may change
+	// which object a given name refers to; for example, switching the database.
+	objectRefsByName map[cat.StableID][]*tree.UnresolvedObjectName
+
+	// privileges stores the privileges needed to access each object that the
+	// query depends on.
+	privileges map[cat.StableID]privilegeBitmap
+
 	// NOTE! When adding fields here, update Init (if reusing allocated
 	// data structures is desired), CopyFrom and TestMetadata.
-}
-
-type mdDep struct {
-	ds cat.DataSource
-
-	name MDDepName
-
-	// privileges is the union of all required privileges.
-	privileges privilegeBitmap
-}
-
-// MDDepName stores either the unresolved DataSourceName or the StableID from
-// the query that was used to resolve a data source.
-type MDDepName struct {
-	// byID is non-zero if and only if the data source was looked up using the
-	// StableID.
-	byID cat.StableID
-
-	// byName is non-zero if and only if the data source was looked up using a
-	// name.
-	byName cat.DataSourceName
-}
-
-func (n *MDDepName) equals(other *MDDepName) bool {
-	return n.byID == other.byID && n.byName.Equals(&other.byName)
 }
 
 // Init prepares the metadata for use (or reuse).
@@ -172,14 +152,33 @@ func (md *Metadata) Init() {
 		sequences[i] = nil
 	}
 
-	deps := md.deps
-	for i := range deps {
-		deps[i] = mdDep{}
-	}
-
 	views := md.views
 	for i := range views {
 		views[i] = nil
+	}
+
+	dataSourceDeps := md.dataSourceDeps
+	if dataSourceDeps == nil {
+		dataSourceDeps = make(map[cat.StableID]cat.DataSource)
+	}
+	for id := range md.dataSourceDeps {
+		delete(md.dataSourceDeps, id)
+	}
+
+	objectRefsByName := md.objectRefsByName
+	if objectRefsByName == nil {
+		objectRefsByName = make(map[cat.StableID][]*tree.UnresolvedObjectName)
+	}
+	for id := range md.objectRefsByName {
+		delete(md.objectRefsByName, id)
+	}
+
+	privileges := md.privileges
+	if privileges == nil {
+		privileges = make(map[cat.StableID]privilegeBitmap)
+	}
+	for id := range md.privileges {
+		delete(md.privileges, id)
 	}
 
 	// This initialization pattern ensures that fields are not unwittingly
@@ -189,8 +188,10 @@ func (md *Metadata) Init() {
 	md.cols = cols[:0]
 	md.tables = tables[:0]
 	md.sequences = sequences[:0]
-	md.deps = deps[:0]
 	md.views = views[:0]
+	md.dataSourceDeps = dataSourceDeps
+	md.objectRefsByName = objectRefsByName
+	md.privileges = privileges
 }
 
 // CopyFrom initializes the metadata with a copy of the provided metadata.
@@ -203,8 +204,9 @@ func (md *Metadata) Init() {
 // expression.
 func (md *Metadata) CopyFrom(from *Metadata, copyScalarFn func(Expr) Expr) {
 	if len(md.schemas) != 0 || len(md.cols) != 0 || len(md.tables) != 0 ||
-		len(md.sequences) != 0 || len(md.deps) != 0 || len(md.views) != 0 ||
-		len(md.userDefinedTypes) != 0 || len(md.userDefinedTypesSlice) != 0 {
+		len(md.sequences) != 0 || len(md.views) != 0 || len(md.userDefinedTypes) != 0 ||
+		len(md.userDefinedTypesSlice) != 0 || len(md.dataSourceDeps) != 0 ||
+		len(md.objectRefsByName) != 0 || len(md.privileges) != 0 {
 		panic(errors.AssertionFailedf("CopyFrom requires empty destination"))
 	}
 	md.schemas = append(md.schemas, from.schemas...)
@@ -231,13 +233,47 @@ func (md *Metadata) CopyFrom(from *Metadata, copyScalarFn func(Expr) Expr) {
 		md.tables[i].copyFrom(&from.tables[i], copyScalarFn)
 	}
 
+	for id, dataSource := range from.dataSourceDeps {
+		if md.dataSourceDeps == nil {
+			md.dataSourceDeps = make(map[cat.StableID]cat.DataSource)
+		}
+		md.dataSourceDeps[id] = dataSource
+	}
+
+	for id, names := range from.objectRefsByName {
+		if md.objectRefsByName == nil {
+			md.objectRefsByName = make(map[cat.StableID][]*tree.UnresolvedObjectName)
+		}
+		newNames := make([]*tree.UnresolvedObjectName, len(names))
+		copy(newNames, names)
+		md.objectRefsByName[id] = newNames
+	}
+
+	for id, privilegeSet := range from.privileges {
+		if md.privileges == nil {
+			md.privileges = make(map[cat.StableID]privilegeBitmap)
+		}
+		md.privileges[id] = privilegeSet
+	}
+
 	md.sequences = append(md.sequences, from.sequences...)
-	md.deps = append(md.deps, from.deps...)
 	md.views = append(md.views, from.views...)
 	md.currUniqueID = from.currUniqueID
 
 	// We cannot copy the bound expressions; they must be rebuilt in the new memo.
 	md.withBindings = nil
+}
+
+// MDDepName stores either the unresolved DataSourceName or the StableID from
+// the query that was used to resolve a data source.
+type MDDepName struct {
+	// byID is non-zero if and only if the data source was looked up using the
+	// StableID.
+	byID cat.StableID
+
+	// byName is non-zero if and only if the data source was looked up using a
+	// name.
+	byName cat.DataSourceName
 }
 
 // DepByName is used with AddDependency when the data source was looked up using a
@@ -257,83 +293,112 @@ func DepByID(id cat.StableID) MDDepName {
 // detect if the name resolves to a different data source now, or if changes to
 // schema or permissions on the data source has invalidated the cached metadata.
 func (md *Metadata) AddDependency(name MDDepName, ds cat.DataSource, priv privilege.Kind) {
-	// Search for the same name / object pair.
-	for i := range md.deps {
-		if md.deps[i].ds == ds && md.deps[i].name.equals(&name) {
-			md.deps[i].privileges |= (1 << priv)
-			return
-		}
+	id := ds.ID()
+	md.dataSourceDeps[id] = ds
+	md.privileges[id] = md.privileges[id] | (1 << priv)
+	if name.byID == 0 {
+		// This data source was referenced by name.
+		md.objectRefsByName[id] = append(md.objectRefsByName[id], name.byName.ToUnresolvedObjectName())
 	}
-	md.deps = append(md.deps, mdDep{
-		ds:         ds,
-		name:       name,
-		privileges: (1 << priv),
-	})
 }
 
-// CheckDependencies resolves (again) each data source on which this metadata
-// depends, in order to check that all data source names resolve to the same
-// objects, and that the user still has sufficient privileges to access the
-// objects. If the dependencies are no longer up-to-date, then CheckDependencies
-// returns false.
+// CheckDependencies resolves (again) each database object on which this
+// metadata depends, in order to check the following conditions:
+//  1. The object has not been modified.
+//  2. If referenced by name, the name does not resolve to a different object.
+//  3. The user still has sufficient privileges to access the object. Note that
+//     this point currently only applies to data sources.
 //
-// This function cannot swallow errors and return only a boolean, as it may
-// perform KV operations on behalf of the transaction associated with the
-// provided catalog, and those errors are required to be propagated.
+// If the dependencies are no longer up-to-date, then CheckDependencies returns
+// false.
+//
+// This function can only swallow "undefined" or "dropped" errors, since these
+// are expected. Other error types must be propagated, since CheckDependencies
+// may perform KV operations on behalf of the transaction associated with the
+// provided catalog.
 func (md *Metadata) CheckDependencies(
-	ctx context.Context, catalog cat.Catalog,
+	ctx context.Context, optCatalog cat.Catalog,
 ) (upToDate bool, err error) {
-	for i := range md.deps {
-		name := &md.deps[i].name
+	// Check that no referenced data sources have changed.
+	for id, dataSource := range md.dataSourceDeps {
 		var toCheck cat.DataSource
-		var err error
-		if name.byID != 0 {
-			toCheck, _, err = catalog.ResolveDataSourceByID(ctx, cat.Flags{}, name.byID)
-		} else {
-			// Resolve data source object.
-			toCheck, _, err = catalog.ResolveDataSource(ctx, cat.Flags{}, &name.byName)
-		}
-		if err != nil {
-			return false, err
-		}
-
-		// Ensure that it's the same object, and there were no schema or table
-		// statistics changes.
-		if !toCheck.Equals(md.deps[i].ds) {
-			return false, nil
-		}
-
-		for privs := md.deps[i].privileges; privs != 0; {
-			// Strip off each privilege bit and make call to CheckPrivilege for it.
-			// Note that priv == 0 can occur when a dependency was added with
-			// privilege.Kind = 0 (e.g. for a table within a view, where the table
-			// privileges do not need to be checked). Ignore the "zero privilege".
-			priv := privilege.Kind(bits.TrailingZeros32(uint32(privs)))
-			if priv != 0 {
-				if err := catalog.CheckPrivilege(ctx, toCheck, priv); err != nil {
-					return false, err
+		if names, ok := md.objectRefsByName[id]; ok {
+			// The data source was referenced by name at least once.
+			for _, name := range names {
+				tableName := name.ToTableName()
+				toCheck, _, err = optCatalog.ResolveDataSource(ctx, cat.Flags{}, &tableName)
+				if err != nil || !dataSource.Equals(toCheck) {
+					return false, maybeSwallowMetadataResolveErr(err)
 				}
 			}
-
-			// Set the just-handled privilege bit to zero and look for next.
-			privs &= ^(1 << priv)
-		}
-	}
-	// Check that all of the user defined types present have not changed.
-	for _, typ := range md.AllUserDefinedTypes() {
-		toCheck, err := catalog.ResolveTypeByOID(ctx, typ.Oid())
-		if err != nil {
-			// Handle when the type no longer exists.
-			if pgerror.GetPGCode(err) == pgcode.UndefinedObject {
-				return false, nil
+		} else {
+			// The data source was only referenced by ID.
+			toCheck, _, err = optCatalog.ResolveDataSourceByID(ctx, cat.Flags{}, dataSource.ID())
+			if err != nil || !dataSource.Equals(toCheck) {
+				return false, maybeSwallowMetadataResolveErr(err)
 			}
+		}
+		// Ensure that all required privileges for the data source are still valid.
+		if err := md.checkDataSourcePrivileges(ctx, optCatalog, toCheck); err != nil {
 			return false, err
 		}
-		if typ.TypeMeta.Version != toCheck.TypeMeta.Version {
-			return false, nil
+	}
+
+	// Check that all of the user defined types present have not changed.
+	for _, typ := range md.AllUserDefinedTypes() {
+		toCheck, err := optCatalog.ResolveTypeByOID(ctx, typ.Oid())
+		if err != nil || typ.TypeMeta.Version != toCheck.TypeMeta.Version {
+			return false, maybeSwallowMetadataResolveErr(err)
 		}
 	}
+
 	return true, nil
+}
+
+// handleMetadataResolveErr swallows errors that are thrown when a database
+// object is dropped, since such an error potentially only means that the
+// metadata is stale and should be re-resolved.
+func maybeSwallowMetadataResolveErr(err error) error {
+	if err == nil {
+		return nil
+	}
+	// Handle when the object no longer exists.
+	switch pgerror.GetPGCode(err) {
+	case pgcode.UndefinedObject, pgcode.UndefinedTable, pgcode.UndefinedDatabase,
+		pgcode.UndefinedSchema, pgcode.UndefinedFunction, pgcode.InvalidName,
+		pgcode.InvalidSchemaName, pgcode.InvalidCatalogName:
+		return nil
+	}
+	if errors.Is(err, catalog.ErrDescriptorDropped) {
+		return nil
+	}
+	return err
+}
+
+// checkDataSourcePrivileges checks that none of the privileges required by the
+// query for the given data source have been revoked.
+func (md *Metadata) checkDataSourcePrivileges(
+	ctx context.Context, optCatalog cat.Catalog, dataSource cat.DataSource,
+) error {
+	if dataSource == nil {
+		panic(errors.AssertionFailedf("expected data source for privilege check to be non-nil"))
+	}
+	privileges := md.privileges[dataSource.ID()]
+	for privs := privileges; privs != 0; {
+		// Strip off each privilege bit and make call to CheckPrivilege for it.
+		// Note that priv == 0 can occur when a dependency was added with
+		// privilege.Kind = 0 (e.g. for a table within a view, where the table
+		// privileges do not need to be checked). Ignore the "zero privilege".
+		priv := privilege.Kind(bits.TrailingZeros32(uint32(privs)))
+		if priv != 0 {
+			if err := optCatalog.CheckPrivilege(ctx, dataSource, priv); err != nil {
+				return err
+			}
+		}
+		// Set the just-handled privilege bit to zero and look for next.
+		privs &= ^(1 << priv)
+	}
+	return nil
 }
 
 // AddSchema indexes a new reference to a schema used by the query.
@@ -817,4 +882,19 @@ func (md *Metadata) ForEachWithBinding(fn func(WithID, Expr)) {
 	for id, expr := range md.withBindings {
 		fn(id, expr)
 	}
+}
+
+// TestingDataSourceDeps exposes the dataSourceDeps for testing.
+func (md *Metadata) TestingDataSourceDeps() map[cat.StableID]cat.DataSource {
+	return md.dataSourceDeps
+}
+
+// TestingObjectRefsByName exposes the objectRefsByName for testing.
+func (md *Metadata) TestingObjectRefsByName() map[cat.StableID][]*tree.UnresolvedObjectName {
+	return md.objectRefsByName
+}
+
+// TestingPrivileges exposes the privileges for testing.
+func (md *Metadata) TestingPrivileges() map[cat.StableID]privilegeBitmap {
+	return md.privileges
 }

--- a/pkg/sql/opt/metadata_test.go
+++ b/pkg/sql/opt/metadata_test.go
@@ -39,7 +39,7 @@ func TestMetadata(t *testing.T) {
 	tabID := md.AddTable(&testcat.Table{}, &tree.TableName{})
 	seqID := md.AddSequence(&testcat.Sequence{})
 	md.AddView(&testcat.View{})
-	md.AddUserDefinedType(types.MakeEnum(152100, 154180))
+	md.AddUserDefinedType(types.MakeEnum(152100, 154180), nil /* name */)
 
 	// Call Init and add objects from catalog, verifying that IDs have been reset.
 	testCat := testcat.New()
@@ -88,7 +88,7 @@ func TestMetadata(t *testing.T) {
 		t.Fatalf("unexpected views")
 	}
 
-	md.AddUserDefinedType(types.MakeEnum(151500, 152510))
+	md.AddUserDefinedType(types.MakeEnum(151500, 152510), nil /* name */)
 	if len(md.AllUserDefinedTypes()) != 1 {
 		fmt.Println(md)
 		t.Fatalf("unexpected types")

--- a/pkg/sql/opt/metadata_test.go
+++ b/pkg/sql/opt/metadata_test.go
@@ -43,7 +43,11 @@ func TestMetadata(t *testing.T) {
 
 	// Call Init and add objects from catalog, verifying that IDs have been reset.
 	testCat := testcat.New()
-	tab := &testcat.Table{Revoked: true}
+	tabName := tree.MakeTableNameWithSchema("t", "public", "tab")
+	tab := &testcat.Table{
+		TabName: tabName,
+		Revoked: true,
+	}
 	testCat.AddTable(tab)
 
 	// Create a (col = 1) scalar expression.
@@ -148,6 +152,30 @@ func TestMetadata(t *testing.T) {
 
 	if ts := mdNew.AllUserDefinedTypes(); len(ts) != 1 && ts[151500].Equal(types.MakeEnum(151500, 152510)) {
 		t.Fatalf("unexpected type")
+	}
+
+	newDSDeps, oldDSDeps := mdNew.TestingDataSourceDeps(), md.TestingDataSourceDeps()
+	for id, dataSource := range oldDSDeps {
+		if newDSDeps[id] != dataSource {
+			t.Fatalf("expected data source dependency to be copied")
+		}
+	}
+
+	newNamesByID, oldNamesByID := mdNew.TestingObjectRefsByName(), md.TestingObjectRefsByName()
+	for id, names := range oldNamesByID {
+		newNames := newNamesByID[id]
+		for i, name := range names {
+			if newNames[i] != name {
+				t.Fatalf("expected object name to be copied")
+			}
+		}
+	}
+
+	newPrivileges, oldPrivileges := mdNew.TestingPrivileges(), md.TestingPrivileges()
+	for id, privileges := range oldPrivileges {
+		if newPrivileges[id] != privileges {
+			t.Fatalf("expected privileges to be copied")
+		}
 	}
 
 	depsUpToDate, err = md.CheckDependencies(context.Background(), testCat)

--- a/pkg/sql/opt/optbuilder/builder.go
+++ b/pkg/sql/opt/optbuilder/builder.go
@@ -474,7 +474,7 @@ func (o *optTrackingTypeResolver) ResolveType(
 	if err != nil {
 		return nil, err
 	}
-	o.metadata.AddUserDefinedType(typ)
+	o.metadata.AddUserDefinedType(typ, name)
 	return typ, nil
 }
 
@@ -486,6 +486,6 @@ func (o *optTrackingTypeResolver) ResolveTypeByOID(
 	if err != nil {
 		return nil, err
 	}
-	o.metadata.AddUserDefinedType(typ)
+	o.metadata.AddUserDefinedType(typ, nil /* name */)
 	return typ, nil
 }


### PR DESCRIPTION
Backport 2/4 commits from #96045.

/cc @cockroachdb/release

---

#### opt: refactor metadata dependency tracking

This commit performs some refactoring for the way data source objects
are tracked in `opt.Metadata` in order to make future changes to UDT
and UDF dependency tracking easier. More particularly, UDTs and UDFs
will be able to re-resolve any references by name. This is necessary
in order to handle cases where changes to the search-path cause names
in the query to resolve to different objects.

#### opt: track UDT references by name in the Metadata

Previously, it was possible for invalid queries to be kept in the cache
after a schema change, since user-defined types were tracked only by OID.
This missed cases where the search path changed which object a name in
the query resolved to (or whether it resolved at all).

This patch fixes this behavior by tracking UDT references by name, similar
to what was already done for data sources. This ensures that the query
staleness check doesn't miss changes to the search path.

Fixes #96674

Release note (bug fix): Fixed a bug that could prevent a cached query from being invalidated when a UDT referenced by that query was altered or dropped, or when the schema or database of a UDT was altered or dropped.

Release Justification: low-risk bug fix for rare incorrect results for UDTs