### PR TITLE
release-22.1: opt: don't fold sub-operators with null operands during type check

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/suboperators
+++ b/pkg/sql/logictest/testdata/logic_test/suboperators
@@ -426,3 +426,50 @@ query B
 SELECT 1 = ANY ROW()
 ----
 false
+
+# Regression test for #37793 - don't fold sub-operators with untyped NULL
+# operands during type-checking.
+query B
+SELECT NULL = ANY(ARRAY []::INTEGER[]);
+----
+false
+
+query B
+SELECT NULL = SOME(ARRAY []::INTEGER[]);
+----
+false
+
+query B
+SELECT NULL = ALL(ARRAY []::INTEGER[]);
+----
+true
+
+query B
+SELECT NULL = ANY(ARRAY [1]::INTEGER[]);
+----
+NULL
+
+query B
+SELECT NULL = SOME(ARRAY [1]::INTEGER[]);
+----
+NULL
+
+query B
+SELECT NULL = ALL(ARRAY [1]::INTEGER[]);
+----
+NULL
+
+query B
+SELECT NULL = ANY(NULL::INTEGER[]);
+----
+NULL
+
+query B
+SELECT NULL = SOME(NULL::INTEGER[]);
+----
+NULL
+
+query B
+SELECT NULL = ALL(NULL::INTEGER[]);
+----
+NULL

--- a/pkg/sql/sem/tree/normalize.go
+++ b/pkg/sql/sem/tree/normalize.go
@@ -326,9 +326,12 @@ func (expr *ComparisonExpr) normalize(v *NormalizeVisitor) TypedExpr {
 		treecmp.ILike, treecmp.NotILike,
 		treecmp.SimilarTo, treecmp.NotSimilarTo,
 		treecmp.RegMatch, treecmp.NotRegMatch,
-		treecmp.RegIMatch, treecmp.NotRegIMatch,
-		treecmp.Any, treecmp.Some, treecmp.All:
+		treecmp.RegIMatch, treecmp.NotRegIMatch:
 		if expr.TypedLeft() == DNull || expr.TypedRight() == DNull {
+			return DNull
+		}
+	case treecmp.Any, treecmp.Some, treecmp.All:
+		if expr.TypedRight() == DNull {
 			return DNull
 		}
 	}

--- a/pkg/sql/sem/tree/testdata/eval/any_some_all
+++ b/pkg/sql/sem/tree/testdata/eval/any_some_all
@@ -303,3 +303,48 @@ eval
 NULL::string LIKE ANY(ARRAY['bar', NULL])
 ----
 NULL
+
+eval
+NULL = ANY(ARRAY []::INTEGER[])
+----
+false
+
+eval
+NULL = SOME(ARRAY []::INTEGER[])
+----
+false
+
+eval
+NULL = ALL(ARRAY []::INTEGER[])
+----
+true
+
+eval
+NULL = ANY(ARRAY [1]::INTEGER[])
+----
+NULL
+
+eval
+NULL = SOME(ARRAY [1]::INTEGER[])
+----
+NULL
+
+eval
+NULL = ALL(ARRAY [1]::INTEGER[])
+----
+NULL
+
+eval
+NULL = ANY(NULL::INTEGER[])
+----
+NULL
+
+eval
+NULL = SOME(NULL::INTEGER[])
+----
+NULL
+
+eval
+NULL = ALL(NULL::INTEGER[])
+----
+NULL

--- a/pkg/sql/sem/tree/type_check.go
+++ b/pkg/sql/sem/tree/type_check.go
@@ -1973,7 +1973,7 @@ func typeCheckComparisonOpWithSubOperator(
 		}
 
 		rightReturn := rightTyped.ResolvedType()
-		if cmpTypeLeft.Family() == types.UnknownFamily || rightReturn.Family() == types.UnknownFamily {
+		if rightReturn.Family() == types.UnknownFamily {
 			return leftTyped, rightTyped, nil, true /* alwaysNull */, nil
 		}
 

--- a/pkg/sql/sem/tree/type_check_test.go
+++ b/pkg/sql/sem/tree/type_check_test.go
@@ -109,7 +109,7 @@ func TestTypeCheck(t *testing.T) {
 		{`NULL = ALL ARRAY[NULL, NULL]`, `NULL`},
 		{`1 = ALL NULL`, `NULL`},
 		{`'a' = ALL current_schemas(true)`, `'a':::STRING = ALL current_schemas(true)`},
-		{`NULL = ALL current_schemas(true)`, `NULL`},
+		{`NULL = ALL current_schemas(true)`, `NULL = ALL current_schemas(true)`},
 
 		{`INTERVAL '1'`, `'00:00:01':::INTERVAL`},
 		{`DECIMAL '1.0'`, `1.0:::DECIMAL`},


### PR DESCRIPTION
Backport 1/1 commits from #97948.

/cc @cockroachdb/release

---

This commit prevents type-checking from replacing expressions like `NULL = ANY(...)` with `NULL`. This is necessary because in the case when the right operand is an empty array, the result of the expression is `False` instead of `NULL`. It is not always possible to know what the right operand will evaluate to, and constant folding can be handled during normalization anyway.

Fixes #37793

Release note (bug fix): Fixed a long-standing and rare bug in evaluation of `ANY`, `SOME`, and `ALL` sub-operators that would cause expressions like `NULL = ANY(ARRAY[]::INT[])` to return `NULL` instead of `False`.

Release Justification: low-risk fix for edge case correctness bug