### PR TITLE
build: mark/fix actions broken under remote execution

### DIFF
--- a/build/STRINGER.bzl
+++ b/build/STRINGER.bzl
@@ -5,6 +5,7 @@ def stringer(src, typ, name, additional_args=[]):
         name = name,
         srcs = [src],  # Accessed below using `$<`.
         outs = [typ.lower() + "_string.go"],
+        tags = ["no-remote"],
         # golang.org/x/tools executes commands via
         # golang.org/x/sys/execabs which requires all PATH lookups to
         # result in absolute paths. To account for this, we resolve the
@@ -13,7 +14,7 @@ def stringer(src, typ, name, additional_args=[]):
 GO_REL_PATH=`dirname $(location @go_sdk//:bin/go)`
 GO_ABS_PATH=`cd $$GO_REL_PATH && pwd`
 # Set GOPATH to something to workaround https://github.com/golang/go/issues/43938
-env PATH=$$GO_ABS_PATH HOME=$(GENDIR) GOPATH=/nonexist-gopath \
+env PATH=$$GO_ABS_PATH HOME=$(GENDIR) GOPATH=/nonexist-gopath GOROOT= \
 $(location @com_github_cockroachdb_tools//cmd/stringer:stringer) -output=$@ -type={typ} {args} $<
 """.format(
          typ = typ,

--- a/pkg/col/coldata/BUILD.bazel
+++ b/pkg/col/coldata/BUILD.bazel
@@ -43,7 +43,7 @@ go_test(
     ],
     args = ["-test.timeout=55s"],
     embed = [":coldata"],
-    tags = ["no-remote"],
+    tags = ["no-remote"],  # keep
     deps = [
         "//pkg/col/coldatatestutils",
         "//pkg/sql/colconv",
@@ -67,6 +67,7 @@ GO_ABS_PATH=`cd $$GO_REL_PATH && pwd`
 export PATH=$$GO_ABS_PATH:$$PATH
 export HOME=$(GENDIR)
 export GOPATH=/nonexist-gopath
+export GOROOT=
 $(location //pkg/sql/colexec/execgen/cmd/execgen) \
     -fmt=false pkg/col/coldata/$@ > $@
 $(location @com_github_cockroachdb_gostdlib//x/tools/cmd/goimports) -w $@
@@ -76,6 +77,7 @@ $(location @com_github_cockroachdb_gostdlib//x/tools/cmd/goimports) -w $@
         "@com_github_cockroachdb_gostdlib//x/tools/cmd/goimports",
         "@go_sdk//:bin/go",
     ],
+    tags = ["no-remote"],  # keep
     visibility = [
         ":__pkg__",
         "//pkg/gen:__pkg__",

--- a/pkg/sql/colexec/COLEXEC.bzl
+++ b/pkg/sql/colexec/COLEXEC.bzl
@@ -5,6 +5,7 @@ def gen_sort_partitioner_rule(name, target, visibility = ["//visibility:private"
         name = name,
         srcs = ["//pkg/sql/colexec/colexecbase:distinct_tmpl.go"],
         outs = [target],
+	tags = ["no-remote"],
         cmd = """\
 GO_REL_PATH=`dirname $(location @go_sdk//:bin/go)`
 GO_ABS_PATH=`cd $$GO_REL_PATH && pwd`
@@ -13,6 +14,7 @@ export PATH=$$GO_ABS_PATH:$$PATH
 export HOME=$(GENDIR)
 export GOPATH=/nonexist-gopath
 export COCKROACH_INTERNAL_DISABLE_METAMORPHIC_TESTING=true
+export GOROOT=
 $(location :execgen) -template $(SRCS) -fmt=false pkg/sql/colexec/$@ > $@
 $(location :goimports) -w $@
 """,

--- a/pkg/sql/colexecop/EXECGEN.bzl
+++ b/pkg/sql/colexecop/EXECGEN.bzl
@@ -30,6 +30,7 @@ def gen_eg_go_rules(targets):
             name = name,
             srcs = [template],
             outs = [target],
+            tags = ["no-remote"],
             cmd = """
 GO_REL_PATH=`dirname $(location @go_sdk//:bin/go)`
 GO_ABS_PATH=`cd $$GO_REL_PATH && pwd`
@@ -37,6 +38,7 @@ export PATH=$$GO_ABS_PATH:$$PATH
 export HOME=$(GENDIR)
 export GOPATH=/nonexist-gopath
 export COCKROACH_INTERNAL_DISABLE_METAMORPHIC_TESTING=true
+export GOROOT=
 $(location :execgen) -template $(SRCS) \
         -fmt=false pkg/sql/colexec/$@ > $@
 $(location :goimports) -w $@

--- a/pkg/sql/opt/BUILD.bazel
+++ b/pkg/sql/opt/BUILD.bazel
@@ -151,6 +151,7 @@ genrule(
         "@go_sdk//:bin/go",
         "@com_github_cockroachdb_tools//cmd/stringer",
     ],
+    tags = ["no-remote"],  # keep
     visibility = [
         ":__pkg__",
         "//pkg/gen:__pkg__",

--- a/pkg/sql/parser/BUILD.bazel
+++ b/pkg/sql/parser/BUILD.bazel
@@ -98,6 +98,7 @@ GO_ABS_PATH=`cd $$GO_REL_PATH && pwd`
 export PATH=$$GO_ABS_PATH:$$PATH
 export HOME=$(GENDIR)
 export GOPATH=/nonexist-gopath
+export GOROOT=
 $(location :sql-gen) $(location sql.y) $(location replace_help_rules.awk) \
     $(location sql.go) $(location @org_golang_x_tools//cmd/goyacc) \
     $(location @com_github_cockroachdb_gostdlib//x/tools/cmd/goimports)
@@ -108,6 +109,7 @@ $(location :sql-gen) $(location sql.y) $(location replace_help_rules.awk) \
         "@go_sdk//:bin/go",
         "@org_golang_x_tools//cmd/goyacc",
     ],
+    tags = ["no-remote"],  # keep
     visibility = ["//visibility:public"],
 )
 

--- a/pkg/util/encoding/BUILD.bazel
+++ b/pkg/util/encoding/BUILD.bazel
@@ -90,13 +90,14 @@ genrule(
        GO_ABS_PATH=`cd $$GO_REL_PATH && pwd`
        # Set GOPATH to something to workaround https://github.com/golang/go/issues/43938
        sed -e 's/type Type encodingtype.T/type Type int/' $(location encoding.go) > encoding_tmp.go && \
-       env PATH=$$GO_ABS_PATH HOME=$(GENDIR) GOPATH=/nonexist-gopath \
+       env PATH=$$GO_ABS_PATH HOME=$(GENDIR) GOPATH=/nonexist-gopath GOROOT= \
          $(location @com_github_cockroachdb_tools//cmd/stringer:stringer) -output=$@ -type=Type encoding_tmp.go
     """,
     exec_tools = [
         "@go_sdk//:bin/go",
         "@com_github_cockroachdb_tools//cmd/stringer",
     ],
+    tags = ["no-remote"],  # keep
     visibility = [
         ":__pkg__",
         "//pkg/gen:__pkg__",


### PR DESCRIPTION
Some actions are broken under the presence of remote execution; here I have tagged or fixed those.

Epic: none
Release note: None