### PR TITLE
release-22.1: colexec: use redact.RedactableString for types in cast error message

### DIFF
--- a/pkg/sql/colexec/colexecbase/BUILD.bazel
+++ b/pkg/sql/colexec/colexecbase/BUILD.bazel
@@ -36,6 +36,7 @@ go_library(
         "//pkg/util/uuid",  # keep
         "@com_github_cockroachdb_apd_v3//:apd",  # keep
         "@com_github_cockroachdb_errors//:errors",
+        "@com_github_cockroachdb_redact//:redact",  # keep
         "@com_github_lib_pq//oid",  # keep
     ],
 )

--- a/pkg/sql/colexec/colexecbase/cast.eg.go
+++ b/pkg/sql/colexec/colexecbase/cast.eg.go
@@ -449,7 +449,11 @@ func GetCastOperator(
 			}
 		}
 	}
-	return nil, errors.Errorf("unhandled cast %s -> %s", fromType.SQLString(), toType.SQLString())
+	return nil, errors.Errorf(
+		"unhandled cast %s -> %s",
+		fromType.SQLStringForError(),
+		toType.SQLStringForError(),
+	)
 }
 
 func IsCastSupported(fromType, toType *types.T) bool {

--- a/pkg/sql/colexec/colexecbase/cast_tmpl.go
+++ b/pkg/sql/colexec/colexecbase/cast_tmpl.go
@@ -173,7 +173,11 @@ func GetCastOperator(
 			// {{end}}
 		}
 	}
-	return nil, errors.Errorf("unhandled cast %s -> %s", fromType.SQLString(), toType.SQLString())
+	return nil, errors.Errorf(
+		"unhandled cast %s -> %s",
+		fromType.SQLStringForError(),
+		toType.SQLStringForError(),
+	)
 }
 
 func IsCastSupported(fromType, toType *types.T) bool {

--- a/pkg/sql/colmem/allocator.go
+++ b/pkg/sql/colmem/allocator.go
@@ -397,14 +397,14 @@ func (a *Allocator) MaybeAppendColumn(b coldata.Batch, t *types.T, colIdx int) {
 		// We have a vector with an unexpected type, so we panic.
 		colexecerror.InternalError(errors.AssertionFailedf(
 			"trying to add a column of %s type at index %d but %s vector already present",
-			t, colIdx, presentType,
+			t.SQLStringForError(), colIdx, presentType.SQLStringForError(),
 		))
 	} else if colIdx > width {
 		// We have a batch of unexpected width which indicates an error in the
 		// planning stage.
 		colexecerror.InternalError(errors.AssertionFailedf(
 			"trying to add a column of %s type at index %d but batch has width %d",
-			t, colIdx, width,
+			t.SQLStringForError(), colIdx, width,
 		))
 	}
 	estimatedMemoryUsage := EstimateBatchSizeBytes([]*types.T{t}, desiredCapacity)
@@ -476,6 +476,7 @@ func (a *Allocator) Used() int64 {
 // - the allocator was created via NewLimitedAllocator with a non-nil unlimited
 //   memory account,
 // - the positive delta allocation is denied by the limited memory account,
+//
 // then the unlimited account is grown by delta. The memory error is still
 // thrown.
 func (a *Allocator) adjustMemoryUsage(delta int64, afterAllocation bool) {
@@ -588,7 +589,7 @@ func EstimateBatchSizeBytes(vecTypes []*types.T, batchLength int) int64 {
 			// Types that have a statically known size.
 			acc += GetFixedSizeTypeSize(t)
 		default:
-			colexecerror.InternalError(errors.AssertionFailedf("unhandled type %s", t))
+			colexecerror.InternalError(errors.AssertionFailedf("unhandled type %s", t.SQLStringForError()))
 		}
 	}
 	// For byte arrays, we initially allocate a constant number of bytes for
@@ -629,7 +630,7 @@ func GetFixedSizeTypeSize(t *types.T) (size int64) {
 	case types.IntervalFamily:
 		size = memsize.Duration
 	default:
-		colexecerror.InternalError(errors.AssertionFailedf("unhandled type %s", t))
+		colexecerror.InternalError(errors.AssertionFailedf("unhandled type %s", t.SQLStringForError()))
 	}
 	return size
 }

--- a/pkg/sql/types/BUILD.bazel
+++ b/pkg/sql/types/BUILD.bazel
@@ -23,6 +23,7 @@ go_library(
         "//pkg/util/errorutil/unimplemented",
         "//pkg/util/protoutil",
         "@com_github_cockroachdb_errors//:errors",
+        "@com_github_cockroachdb_redact//:redact",
         "@com_github_gogo_protobuf//jsonpb",
         "@com_github_gogo_protobuf//proto",
         "@com_github_lib_pq//oid",

--- a/pkg/sql/types/types_test.go
+++ b/pkg/sql/types/types_test.go
@@ -1035,3 +1035,76 @@ func TestWithoutTypeModifiers(t *testing.T) {
 		})
 	}
 }
+
+func TestSQLStringForError(t *testing.T) {
+	const userDefinedOID = oidext.CockroachPredefinedOIDMax + 500
+	userDefinedEnum := MakeEnum(userDefinedOID, userDefinedOID+3)
+	userDefinedEnum.TypeMeta = UserDefinedTypeMetadata{Name: &UserDefinedTypeName{Name: "bar"}}
+	nonUserDefinedEnum := MakeEnum(500, 503)
+	nonUserDefinedEnum.TypeMeta = UserDefinedTypeMetadata{Name: &UserDefinedTypeName{Name: "baz"}}
+	userDefinedTuple := &T{
+		InternalType: InternalType{
+			Family: TupleFamily, Oid: userDefinedOID, TupleContents: []*T{Int}, Locale: &emptyLocale,
+		},
+		TypeMeta: UserDefinedTypeMetadata{Name: &UserDefinedTypeName{Name: "foo"}},
+	}
+	arrayWithUserDefinedContent := MakeArray(userDefinedEnum)
+
+	testCases := []struct {
+		typ      *T
+		expected string
+	}{
+		{ // Case 1: un-redacted
+			typ:      Int,
+			expected: "INT8",
+		},
+		{ // Case 2: un-redacted
+			typ:      Float,
+			expected: "FLOAT8",
+		},
+		{ // Case 3: un-redacted
+			typ:      Decimal,
+			expected: "DECIMAL",
+		},
+		{ // Case 4: un-redacted
+			typ:      String,
+			expected: "STRING",
+		},
+		{ // Case 5: un-redacted
+			typ:      TimestampTZ,
+			expected: "TIMESTAMPTZ",
+		},
+		{ // Case 6: un-redacted
+			typ:      nonUserDefinedEnum,
+			expected: "baz",
+		},
+		{ // Case 7: redacted because user-defined
+			typ:      userDefinedEnum,
+			expected: "USER DEFINED ENUM: ‹bar›",
+		},
+		{ // Case 8: un-redacted
+			typ:      MakeTuple([]*T{Int, Float}),
+			expected: "RECORD",
+		},
+		{ // Case 9: un-redacted because contents are not visible
+			typ:      MakeTuple([]*T{Int, userDefinedEnum}),
+			expected: "RECORD",
+		},
+		{ // Case 10: redacted because user-defined
+			typ:      userDefinedTuple,
+			expected: "USER DEFINED RECORD: ‹FOO›",
+		},
+		{ // Case 11: un-redacted
+			typ:      MakeArray(Int),
+			expected: "INT8[]",
+		},
+		{ // Case 12: redacted element type
+			typ:      arrayWithUserDefinedContent,
+			expected: "USER DEFINED ARRAY: ‹bar[]›",
+		},
+	}
+
+	for i, tc := range testCases {
+		require.Equalf(t, tc.expected, string(tc.typ.SQLStringForError()), "test case %d", i+1)
+	}
+}


### PR DESCRIPTION
Backport 1/1 commits from #91892.

/cc @cockroachdb/release

---

This patch adds a `SQLStringForError` method to `types.T` that returns
a `redact.RedactableString`. It is used by the "unhandled cast" error
message to prevent safe type information from being removed from the
error message. This will make debugging sentry issues easier.

Fixes #90760

Epic: [CRDB-20535](https://cockroachlabs.atlassian.net/browse/CRDB-20535)

Release note: None

Release Justification: low-risk improvement to sentry issue observability