### PR TITLE
kvserver: properly wrap kvserver errors during merge and rangefeed

### DIFF
--- a/pkg/kv/kvserver/replica_command.go
+++ b/pkg/kv/kvserver/replica_command.go
@@ -805,7 +805,7 @@ func (r *Replica) AdminMerge(
 		}
 		if !errors.HasType(err, (*kvpb.TransactionRetryWithProtoRefreshError)(nil)) {
 			if err != nil {
-				return reply, kvpb.NewErrorf("merge failed: %s", err)
+				return reply, kvpb.NewError(errors.Wrap(err, "merge failed"))
 			}
 			return reply, nil
 		}

--- a/pkg/kv/kvserver/replica_rangefeed.go
+++ b/pkg/kv/kvserver/replica_rangefeed.go
@@ -637,8 +637,9 @@ func (r *Replica) handleLogicalOpLogRaftMuLocked(
 			err = errors.New("value missing in reader")
 		}
 		if err != nil {
-			r.disconnectRangefeedWithErr(p, kvpb.NewErrorf(
-				"error consuming %T for key %v @ ts %v: %v", op, key, ts, err,
+
+			r.disconnectRangefeedWithErr(p, kvpb.NewError(
+				errors.Wrapf(err, "error consuming %T for key %v @ ts %v", op, key, ts),
 			))
 			return
 		}


### PR DESCRIPTION
We had a few locations in kvserver where we returned errors that were not properly wrapped, but just formatted into the text of a new error such as `fmt.Errorf("got err: %s", err)`, rather than properly wrapping the error to preserve the chain of causality, such as `errors.Wrap(err, "got err")`. This should be caught during linting by `errwrap`.

In the case of the merge queue, this will have the effect of causing merges to be immediately re-queued when the stored range descriptor is out of sync with the one being used by the merge queue, rather than going into purgatory (to be retried after the purgatory check interval, which is currently 1 minute). This occurs when a merge queue operation is racing with other concurrent operations that modify the range descriptor of the LHS, returning as a `ConditionFailedError`. Properly returning this wrapped error will result in the merge operation commencing as soon as possible once the other operation completes, speeding up waiting merges.

Epic: none

Release note: None