### PR TITLE
kvserver: register lease renewals on splits/merges

### DIFF
--- a/pkg/kv/kvserver/replica_lease_renewal_test.go
+++ b/pkg/kv/kvserver/replica_lease_renewal_test.go
@@ -8,7 +8,7 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
-package kvserver_test
+package kvserver
 
 import (
 	"context"
@@ -17,36 +17,144 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
-	"github.com/cockroachdb/cockroach/pkg/kv/kvserver"
+	"github.com/cockroachdb/cockroach/pkg/keys"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
-	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
+	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/require"
 )
 
+// TestLeaseRenewer tests that the store lease renewer correctly tracks and
+// extends expiration-based leases.
+func TestLeaseRenewer(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+
+	tc := serverutils.StartNewTestCluster(t, 3, base.TestClusterArgs{
+		ServerArgs: base.TestServerArgs{
+			RaftConfig: base.RaftConfig{
+				RangeLeaseDuration: time.Second,
+			},
+		},
+	})
+	defer tc.Stopper().Stop(ctx)
+
+	require.NoError(t, tc.WaitForFullReplication())
+
+	lookupNode := func(nodeID roachpb.NodeID) int {
+		for idx, id := range tc.NodeIDs() {
+			if id == nodeID {
+				return idx
+			}
+		}
+		t.Fatalf("couldn't look up node %d", nodeID)
+		return 0
+	}
+
+	getNodeStore := func(nodeID roachpb.NodeID) *Store {
+		srv := tc.Server(lookupNode(nodeID))
+		s, err := srv.GetStores().(*Stores).GetStore(srv.GetFirstStoreID())
+		require.NoError(t, err)
+		return s
+	}
+
+	getNodeReplica := func(nodeID roachpb.NodeID, rangeID roachpb.RangeID) *Replica {
+		repl, err := getNodeStore(nodeID).GetReplica(rangeID)
+		require.NoError(t, err)
+		return repl
+	}
+
+	getLeaseRenewers := func(rangeID roachpb.RangeID) []roachpb.NodeID {
+		var renewers []roachpb.NodeID
+		for _, nodeID := range tc.NodeIDs() {
+			if _, ok := getNodeStore(nodeID).renewableLeases.Load(int64(rangeID)); ok {
+				renewers = append(renewers, nodeID)
+			}
+		}
+		return renewers
+	}
+
+	// assertLeaseRenewal asserts that the given range has an expiration-based
+	// lease, that it's eagerly extended, and only actively renewed by the
+	// leaseholder.
+	assertLeaseRenewal := func(rangeID roachpb.RangeID) {
+		repl := getNodeReplica(1, rangeID)
+		lease, _ := repl.GetLease()
+		require.Equal(t, roachpb.LeaseExpiration, lease.Type())
+
+		var extensions int
+		require.Eventually(t, func() bool {
+			newLease, _ := repl.GetLease()
+			require.Equal(t, roachpb.LeaseExpiration, newLease.Type())
+			if *newLease.Expiration != *lease.Expiration {
+				extensions++
+				lease = newLease
+				t.Logf("r%d lease extended: %v", rangeID, lease)
+			}
+
+			renewers := getLeaseRenewers(repl.RangeID)
+			renewedByLeaseholder := len(renewers) == 1 && renewers[0] == lease.Replica.NodeID
+			if !renewedByLeaseholder {
+				t.Logf("r%d renewers: %v", rangeID, renewers)
+			}
+
+			return extensions >= 3 && renewedByLeaseholder
+		}, 20*time.Second, 100*time.Millisecond)
+	}
+
+	// The meta range should always be eagerly renewed.
+	assertLeaseRenewal(tc.LookupRangeOrFatal(t, keys.MinKey).RangeID)
+
+	// Split off an expiration-based range, and assert that the lease is extended.
+	desc := tc.LookupRangeOrFatal(t, tc.ScratchRangeWithExpirationLease(t))
+	assertLeaseRenewal(desc.RangeID)
+
+	// Transfer the lease to a different leaseholder, and assert that the lease is
+	// still extended.
+	lease, _ := getNodeReplica(1, desc.RangeID).GetLease()
+	target := tc.Target(lookupNode(lease.Replica.NodeID%3 + 1))
+	tc.TransferRangeLeaseOrFatal(t, desc, target)
+	assertLeaseRenewal(desc.RangeID)
+
+	// Merge the range back. This should unregister it from the lease renewer.
+	require.NoError(t, tc.Server(0).DB().AdminMerge(ctx, desc.StartKey.AsRawKey().Prevish(16)))
+	require.Eventually(t, func() bool {
+		if renewers := getLeaseRenewers(desc.RangeID); len(renewers) > 0 {
+			t.Logf("r%d renewers: %v", desc.RangeID, renewers)
+			return false
+		}
+		return true
+	}, 20*time.Second, 100*time.Millisecond)
+}
+
 func setupLeaseRenewerTest(
 	ctx context.Context, t *testing.T, init func(*base.TestClusterArgs),
 ) (
 	cycles *int32, /* atomic */
-	_ *testcluster.TestCluster,
+	_ serverutils.TestClusterInterface,
 ) {
 	cycles = new(int32)
 	var args base.TestClusterArgs
-	args.ServerArgs.Knobs.Store = &kvserver.StoreTestingKnobs{
+	args.ServerArgs.Knobs.Store = &StoreTestingKnobs{
 		LeaseRenewalOnPostCycle: func() {
 			atomic.AddInt32(cycles, 1)
 		},
 	}
 	init(&args)
-	tc := testcluster.StartTestCluster(t, 1, args)
+	tc := serverutils.StartNewTestCluster(t, 1, args)
 	t.Cleanup(func() { tc.Stopper().Stop(ctx) })
 
 	desc := tc.LookupRangeOrFatal(t, tc.ScratchRangeWithExpirationLease(t))
-	s := tc.GetFirstStoreFromServer(t, 0)
+	srv := tc.Server(0)
+	s, err := srv.GetStores().(*Stores).GetStore(srv.GetFirstStoreID())
+	require.NoError(t, err)
 
-	_, err := s.DB().Get(ctx, desc.StartKey)
+	_, err = s.DB().Get(ctx, desc.StartKey)
 	require.NoError(t, err)
 
 	repl, err := s.GetReplica(desc.RangeID)
@@ -67,7 +175,7 @@ func TestLeaseRenewerExtendsExpirationBasedLeases(t *testing.T) {
 	t.Run("triggered", func(t *testing.T) {
 		renewCh := make(chan struct{})
 		cycles, tc := setupLeaseRenewerTest(ctx, t, func(args *base.TestClusterArgs) {
-			args.ServerArgs.Knobs.Store.(*kvserver.StoreTestingKnobs).LeaseRenewalSignalChan = renewCh
+			args.ServerArgs.Knobs.Store.(*StoreTestingKnobs).LeaseRenewalSignalChan = renewCh
 		})
 		defer tc.Stopper().Stop(ctx)
 
@@ -93,7 +201,7 @@ func TestLeaseRenewerExtendsExpirationBasedLeases(t *testing.T) {
 
 	t.Run("periodic", func(t *testing.T) {
 		cycles, tc := setupLeaseRenewerTest(ctx, t, func(args *base.TestClusterArgs) {
-			args.ServerArgs.Knobs.Store.(*kvserver.StoreTestingKnobs).LeaseRenewalDurationOverride = 10 * time.Millisecond
+			args.ServerArgs.Knobs.Store.(*StoreTestingKnobs).LeaseRenewalDurationOverride = 10 * time.Millisecond
 		})
 		defer tc.Stopper().Stop(ctx)
 

--- a/pkg/kv/kvserver/replica_proposal.go
+++ b/pkg/kv/kvserver/replica_proposal.go
@@ -232,6 +232,10 @@ func (r *Replica) leasePostApplyLocked(
 	// Everything we do before then doesn't need to worry about requests being
 	// evaluated under the new lease.
 
+	// maybeSplit is true if we may have been called during splitPostApply, where
+	// prevLease equals newLease and we're applying the RHS lease.
+	var maybeSplit bool
+
 	// Sanity check to make sure that the lease sequence is moving in the right
 	// direction.
 	if s1, s2 := prevLease.Sequence, newLease.Sequence; s1 != 0 {
@@ -249,6 +253,7 @@ func (r *Replica) leasePostApplyLocked(
 				log.Fatalf(ctx, "sequence identical for different leases, prevLease=%s, newLease=%s",
 					redact.Safe(prevLease), redact.Safe(newLease))
 			}
+			maybeSplit = prevLease.Equal(newLease)
 		case s2 == s1+1:
 			// Lease sequence incremented by 1. Expected case.
 		case s2 > s1+1 && jumpOpt == assertNoLeaseJump:
@@ -367,8 +372,8 @@ func (r *Replica) leasePostApplyLocked(
 		r.gossipFirstRangeLocked(ctx)
 	}
 
-	hasExpirationLease := newLease.Type() == roachpb.LeaseExpiration
-	if leaseChangingHands && iAmTheLeaseHolder && hasExpirationLease && r.ownsValidLeaseRLocked(ctx, now) {
+	if newLease.Type() == roachpb.LeaseExpiration && (leaseChangingHands || maybeSplit) &&
+		iAmTheLeaseHolder && r.ownsValidLeaseRLocked(ctx, now) {
 		if r.requiresExpirationLeaseRLocked() {
 			// Whenever we first acquire an expiration-based lease for a range that
 			// requires it (i.e. the liveness or meta ranges), notify the lease

--- a/pkg/kv/kvserver/store_remove_replica.go
+++ b/pkg/kv/kvserver/store_remove_replica.go
@@ -303,6 +303,7 @@ func (s *Store) unlinkReplicaByRangeIDLocked(ctx context.Context, rangeID roachp
 	s.mu.replicasByRangeID.Delete(rangeID)
 	s.unregisterLeaseholderByID(ctx, rangeID)
 	s.raftRecvQueues.Delete(rangeID)
+	s.renewableLeases.Delete(int64(rangeID))
 }
 
 // removePlaceholder removes a placeholder for the specified range.

--- a/pkg/testutils/serverutils/test_cluster_shim.go
+++ b/pkg/testutils/serverutils/test_cluster_shim.go
@@ -209,6 +209,10 @@ type TestClusterInterface interface {
 	// range is lazily split off on the first call to ScratchRange.
 	ScratchRange(t testing.TB) roachpb.Key
 
+	// ScratchRangeWithExpirationLease is like ScratchRange, but returns a system
+	// range with an expiration lease.
+	ScratchRangeWithExpirationLease(t testing.TB) roachpb.Key
+
 	// WaitForFullReplication waits until all stores in the cluster
 	// have no ranges with replication pending.
 	WaitForFullReplication() error


### PR DESCRIPTION
The store lease renewer, which eagerly extends expiration-based leases, did not correctly (un)register ranges on splits/merges/relocations. This could cause the lease renewer to not eagerly extend leases for some ranges, but was mitigated by the lease renewer only being used for the meta and liveness ranges which rarely/never split.

This patch makes sure the lease renewer is notified on these events. It also incidentally fixes an unlikely race where a range split immediately following an expiration-based lease transfer could leave the RHS using an expiration-based lease until it was transferred elsewhere.

Epic: none
Release note: None