### PR TITLE
workload/kv: additional parameters for workload generation

### DIFF
--- a/pkg/workload/kv/BUILD.bazel
+++ b/pkg/workload/kv/BUILD.bazel
@@ -14,6 +14,7 @@ go_library(
         "//pkg/sql/pgwire/pgcode",
         "//pkg/sql/types",
         "//pkg/util/bufalloc",
+        "//pkg/util/randutil",
         "//pkg/util/timeutil",
         "//pkg/workload",
         "//pkg/workload/histogram",

--- a/pkg/workload/kv/kv.go
+++ b/pkg/workload/kv/kv.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"hash"
 	"math"
+	"math/big"
 	"math/rand"
 	"strconv"
 	"strings"
@@ -28,6 +29,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util/bufalloc"
+	"github.com/cockroachdb/cockroach/pkg/util/randutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/cockroach/pkg/workload"
 	"github.com/cockroachdb/cockroach/pkg/workload/histogram"
@@ -39,20 +41,20 @@ import (
 
 const (
 	kvSchema = `(
-		k BIGINT NOT NULL PRIMARY KEY,
+		k %s NOT NULL PRIMARY KEY,
 		v BYTES NOT NULL
 	)`
 	kvSchemaWithIndex = `(
-		k BIGINT NOT NULL PRIMARY KEY,
+		k %s NOT NULL PRIMARY KEY,
 		v BYTES NOT NULL,
 		INDEX (v)
 	)`
 	shardedKvSchema = `(
-		k BIGINT NOT NULL PRIMARY KEY USING HASH WITH (bucket_count = %d),
+		k %s NOT NULL PRIMARY KEY USING HASH WITH (bucket_count = %d),
 		v BYTES NOT NULL
 	)`
 	shardedKvSchemaWithIndex = `(
-		k BIGINT NOT NULL PRIMARY KEY USING HASH WITH (bucket_count = %d,
+		k %s NOT NULL PRIMARY KEY USING HASH WITH (bucket_count = %d),
 		v BYTES NOT NULL,
 		INDEX (v)
 	)`
@@ -90,6 +92,7 @@ type kv struct {
 	shards                               int
 	targetCompressionRatio               float64
 	enum                                 bool
+	keySize                              int
 	insertCount                          int
 }
 
@@ -104,9 +107,9 @@ var kvMeta = workload.Meta{
 	By default, keys are picked uniformly at random across the cluster.
 	--concurrency workers alternate between doing selects and upserts (according
 	to a --read-percent ratio). Each select/upsert reads/writes a batch of --batch
-	rows. The write keys are randomly generated in a deterministic fashion (or
-	sequentially if --sequential is specified). Reads select a random batch of ids
-	out of the ones previously written.
+	rows. The write keys are randomly generated in a deterministic fashion
+	(alternatively it could changed to use --sequential or --zipfian distribution).
+	Reads select a random batch of ids out of the ones previously written.
 	--write-seq can be used to incorporate data produced by a previous run into
 	the current run.
 	`,
@@ -167,6 +170,8 @@ var kvMeta = workload.Meta{
 				`uniformly over the key range.`)
 		g.flags.DurationVar(&g.timeout, `timeout`, 0, `Client-side statement timeout.`)
 		RandomSeed.AddFlag(&g.flags)
+		g.flags.IntVar(&g.keySize, `key-size`, 0,
+			`Use string key of appropriate size instead of int`)
 		g.flags.DurationVar(&g.sfuDelay, `sfu-wait-delay`, 10*time.Millisecond,
 			`Delay before sfu write transaction commits or aborts`)
 		g.connFlags = workload.NewConnFlags(&g.flags)
@@ -225,6 +230,13 @@ func (w *kv) validateConfig() (err error) {
 	if w.targetCompressionRatio < 1.0 || math.IsNaN(w.targetCompressionRatio) {
 		return errors.New("'target-compression-ratio' must be a number >= 1.0")
 	}
+	if w.keySize != 0 && w.keySize < minStringKeyDigits {
+		return errors.Errorf("key size must be >= %d to fit integer part, requested %d",
+			minStringKeyDigits, w.keySize)
+	}
+	if w.keySize > 0 && w.insertCount > 0 {
+		return errors.New("string keys used by --key-size doesn't support --insert-count")
+	}
 	if w.writeSeq != "" {
 		first := w.writeSeq[0]
 		if len(w.writeSeq) < 2 || (first != 'R' && first != 'S' && first != 'Z') {
@@ -250,7 +262,7 @@ func (w *kv) validateConfig() (err error) {
 	}
 	// We create generator and discard it to have a single piece of code that
 	// handles generator type which affects target key range.
-	_, _, kr := w.createKeyGenerator()
+	_, _, _, kr := w.createKeyGenerator()
 	if kr.totalKeys() < uint64(w.insertCount) {
 		return errors.Errorf(
 			"`--insert-count` (%d) is greater than the number of unique keys that could be possibly generated [%d,%d)",
@@ -261,7 +273,7 @@ func (w *kv) validateConfig() (err error) {
 
 // Note that sequence is only exposed for testing purposes and is used by
 // returned keyGenerators.
-func (w *kv) createKeyGenerator() (func() keyGenerator, *sequence, keyRange) {
+func (w *kv) createKeyGenerator() (func() keyGenerator, *sequence, keyTransformer, keyRange) {
 	writeSeq := 0
 	if w.writeSeq != "" {
 		var err error
@@ -303,10 +315,17 @@ func (w *kv) createKeyGenerator() (func() keyGenerator, *sequence, keyRange) {
 		}
 	}
 
-	return gen, seq, kr
+	if w.keySize == 0 {
+		return gen, seq, intKeyTransformer{}, kr
+	}
+
+	return gen, seq, stringKeyTransformer{
+		startOffset: kr.min,
+		fillerSize:  w.keySize - minStringKeyDigits,
+	}, kr
 }
 
-func splitFinder(i, splits int, r keyRange) int {
+func splitFinder(i, splits int, r keyRange, k keyTransformer) interface{} {
 	if splits < 0 || i >= splits {
 		panic(fmt.Sprintf("programming error: split index (%d) cannot be less than 0, "+
 			"greater than or equal to the total splits (%d)",
@@ -316,7 +335,7 @@ func splitFinder(i, splits int, r keyRange) int {
 
 	stride := r.max/int64(splits+1) - r.min/int64(splits+1)
 	splitPoint := r.min + int64(i+1)*stride
-	return int(splitPoint)
+	return k.getKey(splitPoint)
 }
 
 func (w *kv) insertCountKey(idx, count int64, kr keyRange) int64 {
@@ -335,13 +354,13 @@ func (w *kv) Tables() []workload.Table {
 	// Tables should only run on initialized workload, safe to call create without
 	// having a panic. We don't need to defer this to the actual table callbacks
 	// like Splits or InitialRows.
-	_, _, kr := w.createKeyGenerator()
+	_, _, kt, kr := w.createKeyGenerator()
 
 	table := workload.Table{Name: `kv`}
 	table.Splits = workload.Tuples(
 		w.splits,
 		func(splitIdx int) []interface{} {
-			return []interface{}{splitFinder(splitIdx, w.splits, kr)}
+			return []interface{}{splitFinder(splitIdx, w.splits, kr, kt)}
 		},
 	)
 
@@ -350,16 +369,18 @@ func (w *kv) Tables() []workload.Table {
 		if w.secondaryIndex {
 			schema = shardedKvSchemaWithIndex
 		}
-		table.Schema = fmt.Sprintf(schema, w.shards)
+		table.Schema = fmt.Sprintf(schema, kt.keySQLType(), w.shards)
 	} else {
+		schema := kvSchema
 		if w.secondaryIndex {
-			table.Schema = kvSchemaWithIndex
-		} else {
-			table.Schema = kvSchema
+			schema = kvSchemaWithIndex
 		}
+		table.Schema = fmt.Sprintf(schema, kt.keySQLType())
 	}
 
 	if w.insertCount > 0 {
+		// TODO: make this function parametric to allow different key types.
+		// Conside making a fillColumn method on key type interface for that.
 		const batchSize = 1000
 		table.InitialRows = workload.BatchedTuples{
 			NumBatches: (w.insertCount + batchSize - 1) / batchSize,
@@ -485,7 +506,7 @@ func (w *kv) Ops(
 	buf.WriteString(`)`)
 	delStmtStr := buf.String()
 
-	gen, _, _ := w.createKeyGenerator()
+	gen, _, kt, _ := w.createKeyGenerator()
 	ql := workload.QueryLoad{SQLDatabase: sqlDatabase}
 	numEmptyResults := new(int64)
 	for i := 0; i < w.connFlags.Concurrency; i++ {
@@ -506,6 +527,7 @@ func (w *kv) Ops(
 		}
 		op.mcp = mcp
 		op.g = gen()
+		op.t = kt
 		ql.WorkerFns = append(ql.WorkerFns, op.run)
 		ql.Close = op.close
 	}
@@ -523,6 +545,7 @@ type kvOp struct {
 	sfuStmt         workload.StmtHandle
 	delStmt         workload.StmtHandle
 	g               keyGenerator
+	t               keyTransformer
 	numEmptyResults *int64 // accessed atomically
 }
 
@@ -537,7 +560,7 @@ func (o *kvOp) run(ctx context.Context) (retErr error) {
 	if statementProbability < o.config.readPercent {
 		args := make([]interface{}, o.config.batchSize)
 		for i := 0; i < o.config.batchSize; i++ {
-			args[i] = o.g.readKey()
+			args[i] = o.t.getKey(o.g.readKey())
 		}
 		start := timeutil.Now()
 		rows, err := o.readStmt.Query(ctx, args...)
@@ -594,7 +617,7 @@ func (o *kvOp) run(ctx context.Context) (retErr error) {
 	}
 	for i := 0; i < o.config.batchSize; i++ {
 		j := i * argCount
-		writeArgs[j+0] = o.g.writeKey()
+		writeArgs[j+0] = o.t.getKey(o.g.writeKey())
 		if sfuArgs != nil {
 			sfuArgs[i] = writeArgs[j]
 		}
@@ -681,6 +704,52 @@ func (s *sequence) write() int64 {
 // require that the key is present.
 func (s *sequence) read() int64 {
 	return atomic.LoadInt64(&s.val) % s.max
+}
+
+// Converts int64 based keys into database keys. Workload uses int64 based
+// keyspace to allow predictable sharding and splitting. Transformer allows
+// mapping integer key into string of arbitrary size for testing keys size.
+type keyTransformer interface {
+	// getKey transforms int keys into table keys for read and write operations.
+	getKey(int64) interface{}
+	// keySQLType returns an SQL type used by create table for key column.
+	keySQLType() string
+}
+
+// intKeyTransformer is a noop transformer that passes int keys as is.
+type intKeyTransformer struct{}
+
+func (e intKeyTransformer) getKey(key int64) interface{} {
+	return key
+}
+
+func (e intKeyTransformer) keySQLType() string {
+	return "BIGINT"
+}
+
+// Minimum size of keys is set to fit base 10 representation of max uint64.
+const minStringKeyDigits = 20
+
+// stringKeyTransformer turns int into a zero padded string representation (for
+// 64 bit unsigned integers) and appends a random characters up to desired
+// length. Note that filler is number of extra bytes on top of 20 digits and
+// the the key size parameter as passed to workload.
+type stringKeyTransformer struct {
+	fillerSize  int
+	startOffset int64
+}
+
+func (s stringKeyTransformer) getKey(i int64) interface{} {
+	filler := randutil.RandString(randutil.NewTestRandWithSeed(i), s.fillerSize, randutil.PrintableKeyAlphabet)
+	var bigKey big.Int
+	bigKey.Sub(big.NewInt(i), big.NewInt(s.startOffset))
+	strKey := bigKey.String()
+	prefix := strings.Repeat("0", minStringKeyDigits-len(strKey))
+	return fmt.Sprintf("%s%s%s", prefix, strKey, filler)
+}
+
+func (s stringKeyTransformer) keySQLType() string {
+	return "STRING"
 }
 
 // keyGenerator generates read and write keys. Read keys may not yet exist and
@@ -809,7 +878,6 @@ func (g *zipfGenerator) rand() *rand.Rand {
 }
 
 func (g *zipfGenerator) state() string {
-	// TODO(oleg): add zipfian parsing
 	return fmt.Sprintf("Z%d", g.seq.read())
 }
 

--- a/pkg/workload/kv/kv.go
+++ b/pkg/workload/kv/kv.go
@@ -60,6 +60,14 @@ const (
 
 var RandomSeed = workload.NewInt64RandomSeed()
 
+type keyRange struct {
+	min, max int64
+}
+
+func (r keyRange) totalKeys() uint64 {
+	return uint64(r.max - r.min)
+}
+
 type kv struct {
 	flags     workload.Flags
 	connFlags *workload.ConnFlags
@@ -184,43 +192,137 @@ CREATE TYPE enum_type AS ENUM ('v');
 ALTER TABLE kv ADD COLUMN e enum_type NOT NULL AS ('v') STORED;`)
 			return err
 		},
-		Validate: func() error {
-			if w.maxBlockSizeBytes < w.minBlockSizeBytes {
-				return errors.Errorf("Value of 'max-block-bytes' (%d) must be greater than or equal to value of 'min-block-bytes' (%d)",
-					w.maxBlockSizeBytes, w.minBlockSizeBytes)
-			}
-			if w.splits < 0 {
-				return errors.Errorf("Value of `--splits` (%d) must not be negative",
-					w.splits)
-			}
-			if w.cycleLength < 1 {
-				return errors.Errorf("Value of `--cycle-length` (%d) must be greater than 0",
-					w.cycleLength)
-			}
-			if w.cycleLength <= int64(w.splits) {
-				return errors.Errorf("Value of `--splits` (%d) must be less than the value of `--cycle-length` (%d)",
-					w.splits, w.cycleLength)
-			}
-			if w.sequential && w.zipfian {
-				return errors.New("'sequential' and 'zipfian' cannot both be enabled")
-			}
-			if w.shards > 0 && !(w.sequential || w.zipfian) {
-				return errors.New("'num-shards' only work with 'sequential' or 'zipfian' key distributions")
-			}
-			if w.readPercent+w.spanPercent+w.delPercent > 100 {
-				return errors.New("'read-percent', 'span-percent' and 'del-precent' combined exceed 100%")
-			}
-			if w.targetCompressionRatio < 1.0 || math.IsNaN(w.targetCompressionRatio) {
-				return errors.New("'target-compression-ratio' must be a number >= 1.0")
-			}
-			if rangeMin, rangeMax := w.keyRange(); rangeMax <= rangeMin+int64(w.insertCount) {
-				return errors.Errorf(
-					"`--insert-count` (%d) is greater than the number of unique keys that could be possibly generated [%d,%d)",
-					w.insertCount, rangeMin, rangeMax)
-			}
-			return nil
-		},
+		Validate: w.validateConfig,
 	}
+}
+
+func (w *kv) validateConfig() (err error) {
+	if w.maxBlockSizeBytes < w.minBlockSizeBytes {
+		return errors.Errorf("Value of 'max-block-bytes' (%d) must be greater than or equal to value of 'min-block-bytes' (%d)",
+			w.maxBlockSizeBytes, w.minBlockSizeBytes)
+	}
+	if w.splits < 0 {
+		return errors.Errorf("Value of `--splits` (%d) must not be negative",
+			w.splits)
+	}
+	if w.cycleLength < 1 {
+		return errors.Errorf("Value of `--cycle-length` (%d) must be greater than 0",
+			w.cycleLength)
+	}
+	if w.sequential && w.cycleLength <= int64(w.splits) {
+		return errors.Errorf("Value of `--splits` (%d) must be less than the value of `--cycle-length` (%d) if --sequential is used",
+			w.splits, w.cycleLength)
+	}
+	if w.sequential && w.zipfian {
+		return errors.New("'sequential' and 'zipfian' cannot both be enabled")
+	}
+	if w.shards > 0 && !(w.sequential || w.zipfian) {
+		return errors.New("'num-shards' only work with 'sequential' or 'zipfian' key distributions")
+	}
+	if w.readPercent+w.spanPercent+w.delPercent > 100 {
+		return errors.New("'read-percent', 'span-percent' and 'del-precent' combined exceed 100%")
+	}
+	if w.targetCompressionRatio < 1.0 || math.IsNaN(w.targetCompressionRatio) {
+		return errors.New("'target-compression-ratio' must be a number >= 1.0")
+	}
+	if w.writeSeq != "" {
+		first := w.writeSeq[0]
+		if len(w.writeSeq) < 2 || (first != 'R' && first != 'S' && first != 'Z') {
+			return fmt.Errorf("--write-seq has to be of the form '(R|S|Z)<num>'")
+		}
+		rest := w.writeSeq[1:]
+		var err error
+		_, err = strconv.Atoi(rest)
+		if err != nil {
+			return errors.Errorf("--write-seq has to be of the form '(R|S|Z)<num>'")
+		}
+		if first == 'R' && (w.sequential || w.zipfian) {
+			return errors.Errorf("random --write-seq incompatible with a --sequential and --zipfian")
+		}
+		if first == 'S' && !w.sequential {
+			return errors.Errorf(
+				"sequential --write-seq is incompatible with a --zipfian and default (random) key sequence")
+		}
+		if first == 'Z' && !w.zipfian {
+			return errors.Errorf(
+				"zipfian --write-seq is incompatible with a --sequential or default (random) key sequence")
+		}
+	}
+	// We create generator and discard it to have a single piece of code that
+	// handles generator type which affects target key range.
+	_, _, kr := w.createKeyGenerator()
+	if kr.totalKeys() < uint64(w.insertCount) {
+		return errors.Errorf(
+			"`--insert-count` (%d) is greater than the number of unique keys that could be possibly generated [%d,%d)",
+			w.insertCount, kr.min, kr.max)
+	}
+	return nil
+}
+
+// Note that sequence is only exposed for testing purposes and is used by
+// returned keyGenerators.
+func (w *kv) createKeyGenerator() (func() keyGenerator, *sequence, keyRange) {
+	writeSeq := 0
+	if w.writeSeq != "" {
+		var err error
+		writeSeq, err = strconv.Atoi(w.writeSeq[1:])
+		if err != nil {
+			panic("creating generator from unvalidated workload")
+		}
+	}
+
+	// Sequence is shared between all generators.
+	seq := &sequence{max: w.cycleLength, val: int64(writeSeq)}
+
+	var gen func() keyGenerator
+	var kr keyRange
+	switch {
+	case w.zipfian:
+		gen = func() keyGenerator {
+			return newZipfianGenerator(seq, rand.New(rand.NewSource(timeutil.Now().UnixNano())))
+		}
+		kr = keyRange{
+			min: 0,
+			max: math.MaxInt64,
+		}
+	case w.sequential:
+		gen = func() keyGenerator {
+			return newSequentialGenerator(seq, rand.New(rand.NewSource(timeutil.Now().UnixNano())))
+		}
+		kr = keyRange{
+			min: 0,
+			max: w.cycleLength,
+		}
+	default:
+		gen = func() keyGenerator {
+			return newHashGenerator(seq, rand.New(rand.NewSource(timeutil.Now().UnixNano())))
+		}
+		kr = keyRange{
+			min: math.MinInt64,
+			max: math.MaxInt64,
+		}
+	}
+
+	return gen, seq, kr
+}
+
+func splitFinder(i, splits int, r keyRange) int {
+	if splits < 0 || i >= splits {
+		panic(fmt.Sprintf("programming error: split index (%d) cannot be less than 0, "+
+			"greater than or equal to the total splits (%d)",
+			i, splits,
+		))
+	}
+
+	stride := r.max/int64(splits+1) - r.min/int64(splits+1)
+	splitPoint := r.min + int64(i+1)*stride
+	return int(splitPoint)
+}
+
+func (w *kv) insertCountKey(idx, count int64, kr keyRange) int64 {
+	stride := kr.max/(count+1) - kr.min/(count+1)
+	key := kr.min + (idx+1)*stride
+	return key
 }
 
 var kvtableTypes = []*types.T{
@@ -228,52 +330,18 @@ var kvtableTypes = []*types.T{
 	types.Bytes,
 }
 
-func (w *kv) keyRange() (int64, int64) {
-	rangeMin := int64(0)
-	rangeMax := w.cycleLength
-	if w.sequential {
-		// Sequential can generate keys in the range [0, cycleLength)
-	} else if w.zipfian {
-		// Zipfian can generate keys in the range [0, MaxInt64)
-		rangeMax = math.MaxInt64
-	} else {
-		// Hash can generate keys in the range [MinInt64, MaxInt64)
-		rangeMax = math.MaxInt64
-		rangeMin = math.MinInt64
-	}
-	return rangeMin, rangeMax
-}
-
-// splitFinder returns the ith split point, given the key access distribution
-// and number of splits.
-func (w *kv) splitFinder(i int) int {
-	splits := int64(w.splits)
-	if splits < 0 || (splits >= w.cycleLength && w.sequential) {
-		panic(fmt.Sprintf("programming error: splits (%d) cannot be less than 0, "+
-			"greater than or equal to the cycle-length (%d) with sequential",
-			splits, w.cycleLength,
-		))
-	}
-	rangeMin, rangeMax := w.keyRange()
-
-	stride := rangeMax/(splits+1) - rangeMin/(splits+1)
-	splitPoint := int(rangeMin + int64(i+1)*stride)
-	return splitPoint
-}
-
-func (w *kv) insertCountKey(idx, min, max, count int64) int64 {
-	stride := max/(count+1) - min/(count+1)
-	key := min + (idx+1)*stride
-	return key
-}
-
 // Tables implements the Generator interface.
 func (w *kv) Tables() []workload.Table {
+	// Tables should only run on initialized workload, safe to call create without
+	// having a panic. We don't need to defer this to the actual table callbacks
+	// like Splits or InitialRows.
+	_, _, kr := w.createKeyGenerator()
+
 	table := workload.Table{Name: `kv`}
 	table.Splits = workload.Tuples(
 		w.splits,
 		func(splitIdx int) []interface{} {
-			return []interface{}{w.splitFinder(splitIdx)}
+			return []interface{}{splitFinder(splitIdx, w.splits, kr)}
 		},
 	)
 
@@ -293,7 +361,6 @@ func (w *kv) Tables() []workload.Table {
 
 	if w.insertCount > 0 {
 		const batchSize = 1000
-		rangeMin, rangeMax := w.keyRange()
 		table.InitialRows = workload.BatchedTuples{
 			NumBatches: (w.insertCount + batchSize - 1) / batchSize,
 			FillBatch: func(batchIdx int, cb coldata.Batch, a *bufalloc.ByteAllocator) {
@@ -313,7 +380,7 @@ func (w *kv) Tables() []workload.Table {
 				for rowIdx := rowBegin; rowIdx < rowEnd; rowIdx++ {
 					rowOffset := rowIdx - rowBegin
 
-					key := w.insertCountKey(int64(rowIdx), rangeMin, rangeMax, int64(w.insertCount))
+					key := w.insertCountKey(int64(rowIdx), int64(w.insertCount), kr)
 					keyCol.Set(rowOffset, key)
 
 					var payload []byte
@@ -333,27 +400,6 @@ func (w *kv) Tables() []workload.Table {
 func (w *kv) Ops(
 	ctx context.Context, urls []string, reg *histogram.Registry,
 ) (workload.QueryLoad, error) {
-	writeSeq := 0
-	if w.writeSeq != "" {
-		first := w.writeSeq[0]
-		if len(w.writeSeq) < 2 || (first != 'R' && first != 'S') {
-			return workload.QueryLoad{}, fmt.Errorf("--write-seq has to be of the form '(R|S)<num>'")
-		}
-		rest := w.writeSeq[1:]
-		var err error
-		writeSeq, err = strconv.Atoi(rest)
-		if err != nil {
-			return workload.QueryLoad{}, fmt.Errorf("--write-seq has to be of the form '(R|S)<num>'")
-		}
-		if first == 'R' && w.sequential {
-			return workload.QueryLoad{}, fmt.Errorf("--sequential incompatible with a Random --write-seq")
-		}
-		if first == 'S' && !w.sequential {
-			return workload.QueryLoad{}, fmt.Errorf(
-				"--sequential=false incompatible with a Sequential --write-seq")
-		}
-	}
-
 	sqlDatabase, err := workload.SanitizeUrls(w, w.connFlags.DBOverride, urls)
 	if err != nil {
 		return workload.QueryLoad{}, err
@@ -439,8 +485,8 @@ func (w *kv) Ops(
 	buf.WriteString(`)`)
 	delStmtStr := buf.String()
 
+	gen, _, _ := w.createKeyGenerator()
 	ql := workload.QueryLoad{SQLDatabase: sqlDatabase}
-	seq := &sequence{config: w, val: int64(writeSeq)}
 	numEmptyResults := new(int64)
 	for i := 0; i < w.connFlags.Concurrency; i++ {
 		op := &kvOp{
@@ -459,13 +505,7 @@ func (w *kv) Ops(
 			return workload.QueryLoad{}, err
 		}
 		op.mcp = mcp
-		if w.sequential {
-			op.g = newSequentialGenerator(seq)
-		} else if w.zipfian {
-			op.g = newZipfianGenerator(seq)
-		} else {
-			op.g = newHashGenerator(seq)
-		}
+		op.g = gen()
 		ql.WorkerFns = append(ql.WorkerFns, op.run)
 		ql.Close = op.close
 	}
@@ -624,31 +664,23 @@ func (o *kvOp) close(context.Context) {
 	if empty := atomic.LoadInt64(o.numEmptyResults); empty != 0 {
 		fmt.Printf("Number of reads that didn't return any results: %d.\n", empty)
 	}
-	seq := o.g.sequence()
-	var ch string
-	if o.config.sequential {
-		ch = "S"
-	} else {
-		ch = "R"
-	}
-	fmt.Printf("Highest sequence written: %d. Can be passed as --write-seq=%s%d to the next run.\n",
-		seq, ch, seq)
+	fmt.Printf("Write sequence could be resumed by passing --write-seq=%s to the next run.\n",
+		o.g.state())
 }
 
 type sequence struct {
-	config *kv
-	val    int64
+	val, max int64
 }
 
 func (s *sequence) write() int64 {
-	return (atomic.AddInt64(&s.val, 1) - 1) % s.config.cycleLength
+	return (atomic.AddInt64(&s.val, 1) - 1) % s.max
 }
 
 // read returns the last key index that has been written. Note that the returned
 // index might not actually have been written yet, so a read operation cannot
 // require that the key is present.
 func (s *sequence) read() int64 {
-	return atomic.LoadInt64(&s.val) % s.config.cycleLength
+	return atomic.LoadInt64(&s.val) % s.max
 }
 
 // keyGenerator generates read and write keys. Read keys may not yet exist and
@@ -657,7 +689,7 @@ type keyGenerator interface {
 	writeKey() int64
 	readKey() int64
 	rand() *rand.Rand
-	sequence() int64
+	state() string
 }
 
 type hashGenerator struct {
@@ -667,10 +699,10 @@ type hashGenerator struct {
 	buf    [sha1.Size]byte
 }
 
-func newHashGenerator(seq *sequence) *hashGenerator {
+func newHashGenerator(seq *sequence, rng *rand.Rand) *hashGenerator {
 	return &hashGenerator{
 		seq:    seq,
-		random: rand.New(rand.NewSource(timeutil.Now().UnixNano())),
+		random: rng,
 		hasher: sha1.New(),
 	}
 }
@@ -700,8 +732,8 @@ func (g *hashGenerator) rand() *rand.Rand {
 	return g.random
 }
 
-func (g *hashGenerator) sequence() int64 {
-	return atomic.LoadInt64(&g.seq.val)
+func (g *hashGenerator) state() string {
+	return fmt.Sprintf("R%d", g.seq.read())
 }
 
 type sequentialGenerator struct {
@@ -709,10 +741,10 @@ type sequentialGenerator struct {
 	random *rand.Rand
 }
 
-func newSequentialGenerator(seq *sequence) *sequentialGenerator {
+func newSequentialGenerator(seq *sequence, rng *rand.Rand) *sequentialGenerator {
 	return &sequentialGenerator{
 		seq:    seq,
-		random: rand.New(rand.NewSource(timeutil.Now().UnixNano())),
+		random: rng,
 	}
 }
 
@@ -732,8 +764,8 @@ func (g *sequentialGenerator) rand() *rand.Rand {
 	return g.random
 }
 
-func (g *sequentialGenerator) sequence() int64 {
-	return atomic.LoadInt64(&g.seq.val)
+func (g *sequentialGenerator) state() string {
+	return fmt.Sprintf("S%d", g.seq.read())
 }
 
 type zipfGenerator struct {
@@ -743,11 +775,10 @@ type zipfGenerator struct {
 }
 
 // Creates a new zipfian generator.
-func newZipfianGenerator(seq *sequence) *zipfGenerator {
-	random := rand.New(rand.NewSource(timeutil.Now().UnixNano()))
+func newZipfianGenerator(seq *sequence, rng *rand.Rand) *zipfGenerator {
 	return &zipfGenerator{
 		seq:    seq,
-		random: random,
+		random: rng,
 		zipf:   newZipf(1.1, 1, uint64(math.MaxInt64)),
 	}
 }
@@ -777,8 +808,9 @@ func (g *zipfGenerator) rand() *rand.Rand {
 	return g.random
 }
 
-func (g *zipfGenerator) sequence() int64 {
-	return atomic.LoadInt64(&g.seq.val)
+func (g *zipfGenerator) state() string {
+	// TODO(oleg): add zipfian parsing
+	return fmt.Sprintf("Z%d", g.seq.read())
 }
 
 // randBlock returns a sequence of random bytes according to the kv

--- a/pkg/workload/kv/kv.go
+++ b/pkg/workload/kv/kv.go
@@ -234,9 +234,6 @@ func (w *kv) validateConfig() (err error) {
 		return errors.Errorf("key size must be >= %d to fit integer part, requested %d",
 			minStringKeyDigits, w.keySize)
 	}
-	if w.keySize > 0 && w.insertCount > 0 {
-		return errors.New("string keys used by --key-size doesn't support --insert-count")
-	}
 	if w.writeSeq != "" {
 		first := w.writeSeq[0]
 		if len(w.writeSeq) < 2 || (first != 'R' && first != 'S' && first != 'Z') {
@@ -338,15 +335,10 @@ func splitFinder(i, splits int, r keyRange, k keyTransformer) interface{} {
 	return k.getKey(splitPoint)
 }
 
-func (w *kv) insertCountKey(idx, count int64, kr keyRange) int64 {
+func insertCountKey(idx, count int64, kr keyRange) int64 {
 	stride := kr.max/(count+1) - kr.min/(count+1)
 	key := kr.min + (idx+1)*stride
 	return key
-}
-
-var kvtableTypes = []*types.T{
-	types.Int,
-	types.Bytes,
 }
 
 // Tables implements the Generator interface.
@@ -379,8 +371,6 @@ func (w *kv) Tables() []workload.Table {
 	}
 
 	if w.insertCount > 0 {
-		// TODO: make this function parametric to allow different key types.
-		// Conside making a fillColumn method on key type interface for that.
 		const batchSize = 1000
 		table.InitialRows = workload.BatchedTuples{
 			NumBatches: (w.insertCount + batchSize - 1) / batchSize,
@@ -390,9 +380,24 @@ func (w *kv) Tables() []workload.Table {
 					rowEnd = w.insertCount
 				}
 
+				var kvtableTypes = []*types.T{
+					kt.getColumnType(),
+					types.Bytes,
+				}
+
 				cb.Reset(kvtableTypes, rowEnd-rowBegin, coldata.StandardColumnFactory)
 
-				keyCol := cb.ColVec(0).Int64()
+				{
+					seq := rowBegin
+					kt.fillColumnBatch(cb, a, func() (s int64, ok bool) {
+						if seq < rowEnd {
+							seq++
+							return insertCountKey(int64(seq-1), int64(w.insertCount), kr), true
+						}
+						return 0, false
+					})
+				}
+
 				valCol := cb.ColVec(1).Bytes()
 				// coldata.Bytes only allows appends so we have to reset it.
 				valCol.Reset()
@@ -400,10 +405,6 @@ func (w *kv) Tables() []workload.Table {
 
 				for rowIdx := rowBegin; rowIdx < rowEnd; rowIdx++ {
 					rowOffset := rowIdx - rowBegin
-
-					key := w.insertCountKey(int64(rowIdx), int64(w.insertCount), kr)
-					keyCol.Set(rowOffset, key)
-
 					var payload []byte
 					blockSize, uniqueSize := w.randBlockSize(rndBlock)
 					*a, payload = a.Alloc(blockSize, 0 /* extraCap */)
@@ -709,11 +710,20 @@ func (s *sequence) read() int64 {
 // Converts int64 based keys into database keys. Workload uses int64 based
 // keyspace to allow predictable sharding and splitting. Transformer allows
 // mapping integer key into string of arbitrary size for testing keys size.
+// First two methods are used in table creation and ops, while last ones are
+// only needed for import. If transformer doesn't support import, it should
+// be rejected when parsing flags and methods doesn't need to be implemented.
 type keyTransformer interface {
 	// getKey transforms int keys into table keys for read and write operations.
 	getKey(int64) interface{}
 	// keySQLType returns an SQL type used by create table for key column.
 	keySQLType() string
+
+	// getColumnType returns a key type for inserting initial data.
+	getColumnType() *types.T
+	// fillColumnBatch needs to populate key column with sequence of keys returned by
+	// next.
+	fillColumnBatch(cb coldata.Batch, a *bufalloc.ByteAllocator, next func() (seq int64, ok bool))
 }
 
 // intKeyTransformer is a noop transformer that passes int keys as is.
@@ -725,6 +735,21 @@ func (e intKeyTransformer) getKey(key int64) interface{} {
 
 func (e intKeyTransformer) keySQLType() string {
 	return "BIGINT"
+}
+
+func (e intKeyTransformer) getColumnType() *types.T {
+	return types.Int
+}
+
+func (e intKeyTransformer) fillColumnBatch(
+	cb coldata.Batch, a *bufalloc.ByteAllocator, next func() (seq int64, ok bool),
+) {
+	keyCol := cb.ColVec(0).Int64()
+	var i int
+	for key, ok := next(); ok; key, ok = next() {
+		keyCol.Set(i, key)
+		i++
+	}
 }
 
 // Minimum size of keys is set to fit base 10 representation of max uint64.
@@ -740,6 +765,10 @@ type stringKeyTransformer struct {
 }
 
 func (s stringKeyTransformer) getKey(i int64) interface{} {
+	return s.getKeyInternal(i)
+}
+
+func (s stringKeyTransformer) getKeyInternal(i int64) string {
 	filler := randutil.RandString(randutil.NewTestRandWithSeed(i), s.fillerSize, randutil.PrintableKeyAlphabet)
 	var bigKey big.Int
 	bigKey.Sub(big.NewInt(i), big.NewInt(s.startOffset))
@@ -750,6 +779,23 @@ func (s stringKeyTransformer) getKey(i int64) interface{} {
 
 func (s stringKeyTransformer) keySQLType() string {
 	return "STRING"
+}
+
+func (e stringKeyTransformer) getColumnType() *types.T {
+	return types.String
+}
+
+func (e stringKeyTransformer) fillColumnBatch(
+	cb coldata.Batch, a *bufalloc.ByteAllocator, next func() (seq int64, ok bool),
+) {
+	keyCol := cb.ColVec(0).Bytes()
+	keyCol.Reset()
+	var i int
+	for intKey, ok := next(); ok; intKey, ok = next() {
+		key := e.getKeyInternal(intKey)
+		keyCol.Set(i, []byte(key))
+		i++
+	}
 }
 
 // keyGenerator generates read and write keys. Read keys may not yet exist and

--- a/pkg/workload/kv/kv_test.go
+++ b/pkg/workload/kv/kv_test.go
@@ -69,17 +69,93 @@ func TestSplitFinder(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.desc, func(t *testing.T) {
 			splits := tc.config.splits
+			_, _, r := tc.config.createKeyGenerator()
 
 			if tc.expectPanic {
-				require.Panics(t, func() { tc.config.splitFinder(0) })
+				require.Panics(t, func() { splitFinder(0, 0, r) })
 				return
 			}
 
 			results := make([]int, splits)
 			for i := range results {
-				results[i] = tc.config.splitFinder(i)
+				results[i] = splitFinder(i, splits, r)
 			}
 			require.Equal(t, tc.expected, results)
+		})
+	}
+}
+
+func TestInitialSeqValidation(t *testing.T) {
+	testCases := []struct {
+		desc     string
+		config   *kv
+		expected int64
+		err      string
+	}{
+		{
+			desc:     "--sequential",
+			config:   &kv{sequential: true, writeSeq: "S13"},
+			expected: 13,
+		},
+		{
+			desc:     "random",
+			config:   &kv{writeSeq: "R17"},
+			expected: 17,
+		},
+		{
+			desc:     "--zipfian",
+			config:   &kv{zipfian: true, writeSeq: "Z19"},
+			expected: 19,
+		},
+		{
+			desc:   "wrong",
+			config: &kv{writeSeq: "G10"},
+			err:    "--write-seq has to be of the form",
+		},
+		{
+			desc:   "--zipfian with S",
+			config: &kv{zipfian: true, writeSeq: "S10"},
+			err:    "sequential --write-seq is incompatible",
+		},
+		{
+			desc:   "--zipfian with R",
+			config: &kv{zipfian: true, writeSeq: "R10"},
+			err:    "random --write-seq incompatible",
+		},
+		{
+			desc:   "--sequential with Z",
+			config: &kv{sequential: true, writeSeq: "Z10"},
+			err:    "zipfian --write-seq is incompatible",
+		},
+		{
+			desc:   "--sequential with R",
+			config: &kv{sequential: true, writeSeq: "R10"},
+			err:    "random --write-seq incompatible",
+		},
+		{
+			desc:   "random with Z",
+			config: &kv{writeSeq: "Z10"},
+			err:    "zipfian --write-seq is incompatible",
+		},
+		{
+			desc:   "random with S",
+			config: &kv{writeSeq: "S10"},
+			err:    "sequential --write-seq is incompatible",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			// Fill in defaults for params that are typically filled from flags.
+			tc.config.cycleLength = math.MaxInt64
+			tc.config.targetCompressionRatio = 1
+
+			err := tc.config.validateConfig()
+			if len(tc.err) > 0 {
+				require.ErrorContains(t, err, tc.err, "incorrect validation error")
+			} else {
+				require.NoError(t, err, "valid config rejected")
+			}
 		})
 	}
 }

--- a/pkg/workload/kv/kv_test.go
+++ b/pkg/workload/kv/kv_test.go
@@ -11,6 +11,7 @@
 package kv
 
 import (
+	"fmt"
 	"math"
 	"testing"
 
@@ -20,11 +21,12 @@ import (
 func TestSplitFinder(t *testing.T) {
 	mx := math.MaxInt64
 	mn := math.MinInt64
+	mxu := uint64(math.MaxUint64)
 
 	testCases := []struct {
 		desc        string
 		config      *kv
-		expected    []int
+		expected    []interface{}
 		expectPanic bool
 	}{
 		{
@@ -32,27 +34,39 @@ func TestSplitFinder(t *testing.T) {
 			config: &kv{splits: 5, cycleLength: 1 /* irrelevant for hash */},
 			// NB: We perform integer division to determine the split points,
 			//     -2 to account for the error on this case.
-			expected: []int{2*(mn/3) - 2, (mn / 3) - 2, -2, (mx / 3) - 2, 2*(mx/3) - 2},
+			expected: []interface{}{
+				int64(2*(mn/3) - 2),
+				int64((mn / 3) - 2),
+				int64(-2),
+				int64((mx / 3) - 2),
+				int64(2*(mx/3) - 2),
+			},
 		},
 		{
 			desc:     "hash [min,max], 1 splits",
 			config:   &kv{splits: 1},
-			expected: []int{-1},
+			expected: []interface{}{int64(-1)},
 		},
 		{
 			desc:     "sequential [0, 600), 5 splits",
 			config:   &kv{splits: 5, sequential: true, cycleLength: 600},
-			expected: []int{100, 200, 300, 400, 500},
+			expected: []interface{}{int64(100), int64(200), int64(300), int64(400), int64(500)},
 		},
 		{
 			desc:     "sequential [0, 5), 4 splits",
 			config:   &kv{splits: 4, sequential: true, cycleLength: 5},
-			expected: []int{1, 2, 3, 4},
+			expected: []interface{}{int64(1), int64(2), int64(3), int64(4)},
 		},
 		{
-			desc:     "zipfian [0, max), 5 splits",
-			config:   &kv{splits: 5, zipfian: true, cycleLength: 1 /* irrelevant for zipf */},
-			expected: []int{mx / 6, 2 * (mx / 6), 3 * (mx / 6), 4 * (mx / 6), 5 * (mx / 6)},
+			desc:   "zipfian [0, max), 5 splits",
+			config: &kv{splits: 5, zipfian: true, cycleLength: 1 /* irrelevant for zipf */},
+			expected: []interface{}{
+				int64(mx / 6),
+				int64(2 * (mx / 6)),
+				int64(3 * (mx / 6)),
+				int64(4 * (mx / 6)),
+				int64(5 * (mx / 6)),
+			},
 		},
 		{
 			desc:        "invalid: splits >= cycle-length when sequential",
@@ -64,21 +78,43 @@ func TestSplitFinder(t *testing.T) {
 			config:      &kv{splits: -1},
 			expectPanic: true,
 		},
+		{
+			desc:   "sequential [0, 600), 5 splits, strings",
+			config: &kv{splits: 5, sequential: true, cycleLength: 600, keySize: 20},
+			expected: []interface{}{
+				"00000000000000000100",
+				"00000000000000000200",
+				"00000000000000000300",
+				"00000000000000000400",
+				"00000000000000000500",
+			},
+		},
+		{
+			desc:   "hash [0,max], 5 splits, strings",
+			config: &kv{splits: 5, cycleLength: 1 /* irrelevant for hash */, keySize: 20},
+			expected: []interface{}{
+				fmt.Sprintf("%020d", mxu/6),
+				fmt.Sprintf("%020d", 2*(mxu/6)),
+				fmt.Sprintf("%020d", 3*(mxu/6)),
+				fmt.Sprintf("%020d", 4*(mxu/6)),
+				fmt.Sprintf("%020d", 5*(mxu/6)),
+			},
+		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.desc, func(t *testing.T) {
 			splits := tc.config.splits
-			_, _, r := tc.config.createKeyGenerator()
+			_, _, tr, r := tc.config.createKeyGenerator()
 
 			if tc.expectPanic {
-				require.Panics(t, func() { splitFinder(0, 0, r) })
+				require.Panics(t, func() { splitFinder(0, 0, r, tr) })
 				return
 			}
 
-			results := make([]int, splits)
+			results := make([]interface{}, splits)
 			for i := range results {
-				results[i] = splitFinder(i, splits, r)
+				results[i] = splitFinder(i, splits, r, tr)
 			}
 			require.Equal(t, tc.expected, results)
 		})

--- a/pkg/workload/workload.go
+++ b/pkg/workload/workload.go
@@ -47,13 +47,14 @@ type Generator interface {
 // SupportsFixtures returns whether the Generator supports initialization
 // via fixtures.
 func SupportsFixtures(gen Generator) bool {
-	for _, t := range gen.Tables() {
+	tt := gen.Tables()
+	for _, t := range tt {
 		if t.InitialRows.FillBatch == nil {
 			return false
 		}
 	}
 	// Don't use fixtures if there are no tables.
-	return len(gen.Tables()) != 0
+	return len(tt) != 0
 }
 
 // FlagMeta is metadata about a workload flag.

--- a/pkg/workload/workload.go
+++ b/pkg/workload/workload.go
@@ -256,6 +256,8 @@ func TypedTuples(count int, typs []*types.T, fn func(int) []interface{}) Batched
 					col.Bool()[0] = d
 				case int:
 					col.Int64()[0] = int64(d)
+				case int64:
+					col.Int64()[0] = d
 				case float64:
 					col.Float64()[0] = d
 				case string:


### PR DESCRIPTION
This PR adds following features:

This commit adds --sfu-wait-delay option to configure delay between 'select for update' and upsert statements. Tidy up of RuntimeOnly flags to avoid fixture from exposing timeouts etc for data generations options.

Refactors validation and configuration of generator operations and extracts validated parameters to generator and sequence for later use.

Adds --key-size flag to allow creation of primary keys of arbitrary sizes. When key size is used, strings would be used as keys. Key is prefixed by uint64 zero padded string to maintain sort order and allow pre splitting ranges same way as int keys. The rest of the key is filled with random characters with generator seeded with numeric part of the key. That allows us to keep keys less compressible than constants and at the same time allow updates if key cycle is short.

Adds support for string key imports in fixtures to speed up data load.

Epic: none

Release note: None