### PR TITLE
raftlog: correctly decode empty commands 

### DIFF
--- a/pkg/kv/kvserver/kvserverbase/forced_error.go
+++ b/pkg/kv/kvserver/kvserverbase/forced_error.go
@@ -95,11 +95,11 @@ func CheckForcedErr(
 		requestedLease = *raftCmd.ReplicatedEvalResult.State.Lease
 	}
 	if idKey == "" {
-		// This is an empty Raft command (which is sent by Raft after elections
-		// to trigger reproposals or during concurrent configuration changes).
-		// Nothing to do here except making sure that the corresponding batch
-		// (which is bogus) doesn't get executed (for it is empty and so
-		// properties like key range are undefined).
+		// This is an empty Raft command, which is sent by Raft after elections to
+		// trigger reproposals, during concurrent configuration changes, or to
+		// unquiesce the Raft group. Nothing to do here except making sure that the
+		// corresponding batch (which is bogus) doesn't get executed (for it is
+		// empty and so properties like key range are undefined).
 		return ForcedErrResult{
 			LeaseIndex:  leaseIndex,
 			Rejection:   ProposalRejectionPermanent,


### PR DESCRIPTION
When unquiescing a Raft group, an empty command is proposed to wake the Raft leader. During application, empty entries are considered noops, but only if they don't have a command ID. However, Raft entry decoding would preserve the command ID of an empty payload. `CheckForcedErr()` thus no longer considered this a noop, instead returning an error because the `ProposerLeaseSequence` of 0 was older than the current lease. Construction and processing of this error had a non-negligible cost when unquiescing a large number of ranges.

This patch makes sure such empty commands are decoded as empty entries, without a command ID, and thus considered noops.

Resolves #100400.

Epic: none
Release note: None