### PR TITLE
sql: link public issue to unimplemented error with OUT/ INOUT param in udf

### DIFF
--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -4603,9 +4603,9 @@ func_param:
 
 func_param_class:
   IN { $$.val = tree.FunctionParamIn }
-| OUT { return unimplemented(sqllex, "create function with 'OUT' argument class") }
-| INOUT { return unimplemented(sqllex, "create function with 'INOUT' argument class") }
-| IN OUT { return unimplemented(sqllex, "create function with 'IN OUT' argument class") }
+| OUT { return unimplementedWithIssueDetail(sqllex, 100405, "create function with 'OUT' argument class") }
+| INOUT { return unimplementedWithIssueDetail(sqllex, 100405, "create function with 'INOUT' argument class") }
+| IN OUT { return unimplementedWithIssueDetail(sqllex, 100405, "create function with 'IN OUT' argument class") }
 | VARIADIC { return unimplementedWithIssueDetail(sqllex, 88947, "variadic user-defined functions") }
 
 func_param_type:

--- a/pkg/sql/parser/testdata/create_function
+++ b/pkg/sql/parser/testdata/create_function
@@ -223,15 +223,7 @@ DETAIL: source SQL:
 CREATE OR REPLACE FUNCTION f(OUT a int = 7) RETURNS INT AS 'SELECT 1' LANGUAGE SQL
                              ^
 HINT: You have attempted to use a feature that is not yet implemented.
-
-Please check the public issue tracker to check whether this problem is
-already tracked. If you cannot find it there, please report the error
-with details by creating a new issue.
-
-If you would rather not post publicly, please contact us directly
-using the support form.
-
-We appreciate your feedback.
+See: https://go.crdb.dev/issue-v/100405/
 ----
 ----
 
@@ -244,15 +236,7 @@ DETAIL: source SQL:
 CREATE OR REPLACE FUNCTION f(INOUT a int = 7) RETURNS INT AS 'SELECT 1' LANGUAGE SQL
                              ^
 HINT: You have attempted to use a feature that is not yet implemented.
-
-Please check the public issue tracker to check whether this problem is
-already tracked. If you cannot find it there, please report the error
-with details by creating a new issue.
-
-If you would rather not post publicly, please contact us directly
-using the support form.
-
-We appreciate your feedback.
+See: https://go.crdb.dev/issue-v/100405/
 ----
 ----
 
@@ -265,15 +249,7 @@ DETAIL: source SQL:
 CREATE OR REPLACE FUNCTION f(IN OUT a int = 7) RETURNS INT AS 'SELECT 1' LANGUAGE SQL
                                 ^
 HINT: You have attempted to use a feature that is not yet implemented.
-
-Please check the public issue tracker to check whether this problem is
-already tracked. If you cannot find it there, please report the error
-with details by creating a new issue.
-
-If you would rather not post publicly, please contact us directly
-using the support form.
-
-We appreciate your feedback.
+See: https://go.crdb.dev/issue-v/100405/
 ----
 ----
 


### PR DESCRIPTION
fixes: https://github.com/cockroachdb/cockroach/issues/99880

testsing:
```
demo@127.0.0.1:26257/movr> CREATE FUNCTION add_em (IN x int, IN y int, OUT sum int)                                                                                                                                                                         
                        -> AS 'SELECT x + y'                                                                                                                                                                                                                
                        -> LANGUAGE SQL;                                                                                                                                                                                                                    
invalid syntax: statement ignored: at or near "out": syntax error: unimplemented: this syntax
SQLSTATE: 0A000
DETAIL: source SQL:
CREATE FUNCTION add_em (IN x int, IN y int, OUT sum int)
                                            ^
HINT: You have attempted to use a feature that is not yet implemented.
See: https://go.crdb.dev/issue-v/100405/v23.1
```

Release note (sql change): link public issue to unimplemented error with OUT/ INOUT param argmode in udf.