### PR TITLE
kvserver: eagerly extend expiration leases in Raft scheduler

### DIFF
--- a/pkg/kv/kvserver/replica_lease_renewal_test.go
+++ b/pkg/kv/kvserver/replica_lease_renewal_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
@@ -27,109 +28,170 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestLeaseRenewer tests that the store lease renewer correctly tracks and
-// extends expiration-based leases.
+// TestLeaseRenewer tests that the store lease renewer or the Raft scheduler
+// correctly tracks and extends expiration-based leases. The responsibility
+// is given by kv.expiration_leases_only.enabled.
 func TestLeaseRenewer(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	ctx := context.Background()
-
-	tc := serverutils.StartNewTestCluster(t, 3, base.TestClusterArgs{
-		ServerArgs: base.TestServerArgs{
-			RaftConfig: base.RaftConfig{
-				RangeLeaseDuration: time.Second,
+	// When kv.expiration_leases_only.enabled is true, the Raft scheduler is
+	// responsible for extensions, but we still track expiration leases for system
+	// ranges in the store lease renewer in case the setting changes.
+	testutils.RunTrueAndFalse(t, "kv.expiration_leases_only.enabled", func(t *testing.T, expOnly bool) {
+		ctx := context.Background()
+		st := cluster.MakeTestingClusterSettings()
+		ExpirationLeasesOnly.Override(ctx, &st.SV, expOnly)
+		tc := serverutils.StartNewTestCluster(t, 3, base.TestClusterArgs{
+			ServerArgs: base.TestServerArgs{
+				Settings: st,
+				RaftConfig: base.RaftConfig{
+					RangeLeaseDuration: time.Second,
+					RaftTickInterval:   100 * time.Millisecond,
+				},
 			},
-		},
+		})
+		defer tc.Stopper().Stop(ctx)
+
+		require.NoError(t, tc.WaitForFullReplication())
+
+		lookupNode := func(nodeID roachpb.NodeID) int {
+			for idx, id := range tc.NodeIDs() {
+				if id == nodeID {
+					return idx
+				}
+			}
+			t.Fatalf("couldn't look up node %d", nodeID)
+			return 0
+		}
+
+		getNodeStore := func(nodeID roachpb.NodeID) *Store {
+			srv := tc.Server(lookupNode(nodeID))
+			s, err := srv.GetStores().(*Stores).GetStore(srv.GetFirstStoreID())
+			require.NoError(t, err)
+			return s
+		}
+
+		getNodeReplica := func(nodeID roachpb.NodeID, rangeID roachpb.RangeID) *Replica {
+			repl, err := getNodeStore(nodeID).GetReplica(rangeID)
+			require.NoError(t, err)
+			return repl
+		}
+
+		getLeaseRenewers := func(rangeID roachpb.RangeID) []roachpb.NodeID {
+			var renewers []roachpb.NodeID
+			for _, nodeID := range tc.NodeIDs() {
+				if _, ok := getNodeStore(nodeID).renewableLeases.Load(int64(rangeID)); ok {
+					renewers = append(renewers, nodeID)
+				}
+			}
+			return renewers
+		}
+
+		// assertLeaseExtension asserts that the given range has an expiration-based
+		// lease that is eagerly extended.
+		assertLeaseExtension := func(rangeID roachpb.RangeID) {
+			repl := getNodeReplica(1, rangeID)
+			lease, _ := repl.GetLease()
+			require.Equal(t, roachpb.LeaseExpiration, lease.Type())
+
+			var extensions int
+			require.Eventually(t, func() bool {
+				newLease, _ := repl.GetLease()
+				require.Equal(t, roachpb.LeaseExpiration, newLease.Type())
+				if *newLease.Expiration != *lease.Expiration {
+					extensions++
+					lease = newLease
+					t.Logf("r%d lease extended: %v", rangeID, lease)
+				}
+				return extensions >= 3
+			}, 20*time.Second, 100*time.Millisecond)
+		}
+
+		// assertLeaseUpgrade asserts that the range is eventually upgraded
+		// to an epoch lease.
+		assertLeaseUpgrade := func(rangeID roachpb.RangeID) {
+			repl := getNodeReplica(1, rangeID)
+			require.Eventually(t, func() bool {
+				lease, _ := repl.GetLease()
+				return lease.Type() == roachpb.LeaseEpoch
+			}, 20*time.Second, 100*time.Millisecond)
+		}
+
+		// assertStoreLeaseRenewer asserts that the range is tracked by the store lease
+		// renewer on the leaseholder.
+		assertStoreLeaseRenewer := func(rangeID roachpb.RangeID) {
+			repl := getNodeReplica(1, rangeID)
+			require.Eventually(t, func() bool {
+				lease, _ := repl.GetLease()
+				renewers := getLeaseRenewers(rangeID)
+				renewedByLeaseholder := len(renewers) == 1 && renewers[0] == lease.Replica.NodeID
+				// If kv.expiration_leases_only.enabled is true, then the store lease
+				// renewer is disabled -- it will still track the ranges in case the
+				// setting changes, but won't detect the new lease and untrack them as
+				// long as it has a replica. We therefore allow multiple nodes to track
+				// it, as long as the leaseholder is one of them.
+				if expOnly {
+					for _, renewer := range renewers {
+						if renewer == lease.Replica.NodeID {
+							renewedByLeaseholder = true
+							break
+						}
+					}
+				}
+				if !renewedByLeaseholder {
+					t.Logf("r%d renewers: %v", rangeID, renewers)
+				}
+				return renewedByLeaseholder
+			}, 20*time.Second, 100*time.Millisecond)
+		}
+
+		// assertNoStoreLeaseRenewer asserts that the range is not tracked by any
+		// lease renewer.
+		assertNoStoreLeaseRenewer := func(rangeID roachpb.RangeID) {
+			require.Eventually(t, func() bool {
+				renewers := getLeaseRenewers(rangeID)
+				if len(renewers) > 0 {
+					t.Logf("r%d renewers: %v", rangeID, renewers)
+					return false
+				}
+				return true
+			}, 20*time.Second, 100*time.Millisecond)
+		}
+
+		// The meta range should always be eagerly renewed.
+		firstRangeID := tc.LookupRangeOrFatal(t, keys.MinKey).RangeID
+		assertLeaseExtension(firstRangeID)
+		assertStoreLeaseRenewer(firstRangeID)
+
+		// Split off an expiration-based range, and assert that the lease is extended.
+		desc := tc.LookupRangeOrFatal(t, tc.ScratchRangeWithExpirationLease(t))
+		assertLeaseExtension(desc.RangeID)
+		assertStoreLeaseRenewer(desc.RangeID)
+
+		// Transfer the lease to a different leaseholder, and assert that the lease is
+		// still extended.
+		lease, _ := getNodeReplica(1, desc.RangeID).GetLease()
+		target := tc.Target(lookupNode(lease.Replica.NodeID%3 + 1))
+		tc.TransferRangeLeaseOrFatal(t, desc, target)
+		assertLeaseExtension(desc.RangeID)
+		assertStoreLeaseRenewer(desc.RangeID)
+
+		// Merge the range back. This should unregister it from the lease renewer.
+		require.NoError(t, tc.Server(0).DB().AdminMerge(ctx, desc.StartKey.AsRawKey().Prevish(16)))
+		assertNoStoreLeaseRenewer(desc.RangeID)
+
+		// Split off a regular non-system range. This should only be eagerly
+		// extended if kv.expiration_leases_only.enabled is true, and should never
+		// be tracked by the store lease renewer (which only handles system ranges).
+		desc = tc.LookupRangeOrFatal(t, tc.ScratchRange(t))
+		if expOnly {
+			assertLeaseExtension(desc.RangeID)
+		} else {
+			assertLeaseUpgrade(desc.RangeID)
+		}
+		assertNoStoreLeaseRenewer(desc.RangeID)
 	})
-	defer tc.Stopper().Stop(ctx)
-
-	require.NoError(t, tc.WaitForFullReplication())
-
-	lookupNode := func(nodeID roachpb.NodeID) int {
-		for idx, id := range tc.NodeIDs() {
-			if id == nodeID {
-				return idx
-			}
-		}
-		t.Fatalf("couldn't look up node %d", nodeID)
-		return 0
-	}
-
-	getNodeStore := func(nodeID roachpb.NodeID) *Store {
-		srv := tc.Server(lookupNode(nodeID))
-		s, err := srv.GetStores().(*Stores).GetStore(srv.GetFirstStoreID())
-		require.NoError(t, err)
-		return s
-	}
-
-	getNodeReplica := func(nodeID roachpb.NodeID, rangeID roachpb.RangeID) *Replica {
-		repl, err := getNodeStore(nodeID).GetReplica(rangeID)
-		require.NoError(t, err)
-		return repl
-	}
-
-	getLeaseRenewers := func(rangeID roachpb.RangeID) []roachpb.NodeID {
-		var renewers []roachpb.NodeID
-		for _, nodeID := range tc.NodeIDs() {
-			if _, ok := getNodeStore(nodeID).renewableLeases.Load(int64(rangeID)); ok {
-				renewers = append(renewers, nodeID)
-			}
-		}
-		return renewers
-	}
-
-	// assertLeaseRenewal asserts that the given range has an expiration-based
-	// lease, that it's eagerly extended, and only actively renewed by the
-	// leaseholder.
-	assertLeaseRenewal := func(rangeID roachpb.RangeID) {
-		repl := getNodeReplica(1, rangeID)
-		lease, _ := repl.GetLease()
-		require.Equal(t, roachpb.LeaseExpiration, lease.Type())
-
-		var extensions int
-		require.Eventually(t, func() bool {
-			newLease, _ := repl.GetLease()
-			require.Equal(t, roachpb.LeaseExpiration, newLease.Type())
-			if *newLease.Expiration != *lease.Expiration {
-				extensions++
-				lease = newLease
-				t.Logf("r%d lease extended: %v", rangeID, lease)
-			}
-
-			renewers := getLeaseRenewers(repl.RangeID)
-			renewedByLeaseholder := len(renewers) == 1 && renewers[0] == lease.Replica.NodeID
-			if !renewedByLeaseholder {
-				t.Logf("r%d renewers: %v", rangeID, renewers)
-			}
-
-			return extensions >= 3 && renewedByLeaseholder
-		}, 20*time.Second, 100*time.Millisecond)
-	}
-
-	// The meta range should always be eagerly renewed.
-	assertLeaseRenewal(tc.LookupRangeOrFatal(t, keys.MinKey).RangeID)
-
-	// Split off an expiration-based range, and assert that the lease is extended.
-	desc := tc.LookupRangeOrFatal(t, tc.ScratchRangeWithExpirationLease(t))
-	assertLeaseRenewal(desc.RangeID)
-
-	// Transfer the lease to a different leaseholder, and assert that the lease is
-	// still extended.
-	lease, _ := getNodeReplica(1, desc.RangeID).GetLease()
-	target := tc.Target(lookupNode(lease.Replica.NodeID%3 + 1))
-	tc.TransferRangeLeaseOrFatal(t, desc, target)
-	assertLeaseRenewal(desc.RangeID)
-
-	// Merge the range back. This should unregister it from the lease renewer.
-	require.NoError(t, tc.Server(0).DB().AdminMerge(ctx, desc.StartKey.AsRawKey().Prevish(16)))
-	require.Eventually(t, func() bool {
-		if renewers := getLeaseRenewers(desc.RangeID); len(renewers) > 0 {
-			t.Logf("r%d renewers: %v", desc.RangeID, renewers)
-			return false
-		}
-		return true
-	}, 20*time.Second, 100*time.Millisecond)
 }
 
 func setupLeaseRenewerTest(

--- a/pkg/kv/kvserver/replica_proposal.go
+++ b/pkg/kv/kvserver/replica_proposal.go
@@ -378,9 +378,11 @@ func (r *Replica) leasePostApplyLocked(
 			// Whenever we first acquire an expiration-based lease for a range that
 			// requires it (i.e. the liveness or meta ranges), notify the lease
 			// renewer worker that we want it to keep proactively renewing the lease
-			// before it expires. We don't eagerly renew other expiration leases,
-			// because a more sophisticated scheduler is needed to handle large
-			// numbers of expiration leases.
+			// before it expires.
+			//
+			// Other expiration leases are only proactively renewed if
+			// kv.expiration_leases_only.enabled is true, but in that case the renewal
+			// is handled by the Raft scheduler during Raft ticks.
 			r.store.renewableLeases.Store(int64(r.RangeID), unsafe.Pointer(r))
 			select {
 			case r.store.renewableLeasesSignal <- struct{}{}:

--- a/pkg/kv/kvserver/replica_test.go
+++ b/pkg/kv/kvserver/replica_test.go
@@ -49,6 +49,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/uncertainty"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/server/telemetry"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
@@ -9898,6 +9899,7 @@ func TestApplyPaginatedCommittedEntries(t *testing.T) {
 }
 
 type testQuiescer struct {
+	st              *cluster.Settings
 	desc            roachpb.RangeDescriptor
 	numProposals    int
 	pendingQuota    bool
@@ -9912,6 +9914,10 @@ type testQuiescer struct {
 	// Not used to implement quiescer, but used by tests.
 	livenessMap livenesspb.IsLiveMap
 	paused      map[roachpb.ReplicaID]struct{}
+}
+
+func (q *testQuiescer) ClusterSettings() *cluster.Settings {
+	return q.st
 }
 
 func (q *testQuiescer) descRLocked() *roachpb.RangeDescriptor {
@@ -9956,6 +9962,10 @@ func (q *testQuiescer) StoreID() roachpb.StoreID {
 	return q.storeID
 }
 
+func (q *testQuiescer) getLeaseRLocked() (roachpb.Lease, roachpb.Lease) {
+	return q.leaseStatus.Lease, q.leaseStatus.Lease
+}
+
 func (q *testQuiescer) mergeInProgressRLocked() bool {
 	return q.mergeInProgress
 }
@@ -9979,6 +9989,7 @@ func TestShouldReplicaQuiesce(t *testing.T) {
 			// true. The transform function is intended to perform one mutation to
 			// this quiescer so that shouldReplicaQuiesce will return false.
 			q := &testQuiescer{
+				st:      cluster.MakeTestingClusterSettings(),
 				storeID: 1,
 				desc: roachpb.RangeDescriptor{
 					InternalReplicas: []roachpb.ReplicaDescriptor{
@@ -10010,6 +10021,8 @@ func TestShouldReplicaQuiesce(t *testing.T) {
 				leaseStatus: kvserverpb.LeaseStatus{
 					State: kvserverpb.LeaseState_VALID,
 					Lease: roachpb.Lease{
+						Sequence: 1,
+						Epoch:    1,
 						Replica: roachpb.ReplicaDescriptor{
 							NodeID:    1,
 							StoreID:   1,
@@ -10198,6 +10211,23 @@ func TestShouldReplicaQuiesce(t *testing.T) {
 	test(false, func(q *testQuiescer) *testQuiescer {
 		q.paused = map[roachpb.ReplicaID]struct{}{
 			q.desc.Replicas().AsProto()[0].ReplicaID: {},
+		}
+		return q
+	})
+	// Verify no quiescence with expiration-based leases, but only if
+	// kv.expiration_leases_only.enabled is true.
+	test(false, func(q *testQuiescer) *testQuiescer {
+		ExpirationLeasesOnly.Override(context.Background(), &q.st.SV, true)
+		q.leaseStatus.Lease.Epoch = 0
+		q.leaseStatus.Lease.Expiration = &hlc.Timestamp{
+			WallTime: timeutil.Now().Add(time.Minute).Unix(),
+		}
+		return q
+	})
+	test(true, func(q *testQuiescer) *testQuiescer {
+		q.leaseStatus.Lease.Epoch = 0
+		q.leaseStatus.Lease.Expiration = &hlc.Timestamp{
+			WallTime: timeutil.Now().Add(time.Minute).Unix(),
 		}
 		return q
 	})

--- a/pkg/kv/kvserver/replicate_queue.go
+++ b/pkg/kv/kvserver/replicate_queue.go
@@ -689,14 +689,11 @@ func (rq *replicateQueue) shouldQueue(
 	}
 
 	leaseStatus := repl.LeaseStatusAt(ctx, now)
-	if !leaseStatus.IsValid() && leaseStatus.Lease.Type() != roachpb.LeaseExpiration {
-		// The epoch lease for this range is currently invalid. If this replica is
-		// the raft leader then we'd like it to hold a valid lease. We enqueue it
-		// regardless of being a leader or follower, where the leader at the time of
-		// processing will succeed.
-		//
-		// We don't do this for expiration leases, because we'd like them to expire
-		// if the range is idle.
+	if !leaseStatus.IsValid() {
+		// The range has an invalid lease. If this replica is the raft leader then
+		// we'd like it to hold a valid lease. We enqueue it regardless of being a
+		// leader or follower, where the leader at the time of processing will
+		// succeed.
 		log.KvDistribution.VEventf(ctx, 2, "invalid lease, enqueuing")
 		return true, 0
 	}

--- a/pkg/kv/kvserver/testing_knobs.go
+++ b/pkg/kv/kvserver/testing_knobs.go
@@ -125,8 +125,8 @@ type StoreTestingKnobs struct {
 	// should get rid of such practices once we make TestServer take a
 	// ManualClock.
 	DisableMaxOffsetCheck bool
-	// DisableAutomaticLeaseRenewal enables turning off the background worker
-	// that attempts to automatically renew expiration-based leases.
+	// DisableAutomaticLeaseRenewal disables eager renewal of expiration-based
+	// leases.
 	DisableAutomaticLeaseRenewal bool
 	// LeaseRequestEvent, if set, is called when replica.requestLeaseLocked() is
 	// called to acquire a new lease. This can be used to assert that a request


### PR DESCRIPTION
This is submitted with a 23.1 backport in mind, and is therefore limited in scope. More work is needed to fully address #98433 in the 23.2 timeframe.

---

**kvserver: don't quiesce ranges with expiration-based leases**

This patch prevents quiescence with expiration-based leases, since we'll have to propose a lease extension shortly anyway. Out of caution, we only do this when `kv.expiration_leases_only.enabled` is `true`, with an eye towards 23.1 backports. For 23.2, we will always do this.

Touches #94592.

Epic: none
Release note: None
  
**kvserver: eagerly extend expiration leases in Raft scheduler**

This patch eagerly extends expiration leases in the Raft scheduler, during Raft ticks, but only if `kv.expiration_leases_only.enabled` is `true`. This is possible because we no longer allow ranges with expiration leases to quiesce in this case.

The old store lease renewer is disabled in this case, but still tracks local system ranges with expiration leases in case the setting is later changed. The store lease renewer is still retained for use by default, to allow backporting this change to 23.1 while keeping the existing default behavior.

Doing this during Raft scheduling is compelling, since it already does efficient goroutine scheduling (including liveness range prioritization) and holds the replica mutex.

Compared to an alternative implementation that relied on a separate, improved store lease renewer which also allowed ranges to quiesce between extensions, this has significantly better performance. The main reason for this is that unquiescing involves a Raft append to wake the leader. On an idle cluster with 20.000 ranges using only expiration leases, CPU usage was 26% vs.  30%, write IOPS was 500 vs. 900, and network traffic was 0.8 MB/s vs.  1.0 MB/s. KV benchmark results:

```
name                    old ops/sec  new ops/sec  delta
kv0/enc=false/nodes=3    14.6k ± 3%   15.2k ± 4%  +3.72%  (p=0.003 n=8+8)
kv95/enc=false/nodes=3   30.6k ± 3%   32.2k ± 3%  +5.22%  (p=0.000 n=8+8)

name                    old p50      new p50      delta
kv0/enc=false/nodes=3     11.3 ± 3%    11.0 ± 0%  -2.76%  (p=0.006 n=8+6)
kv95/enc=false/nodes=3    4.59 ± 8%    4.55 ± 3%    ~     (p=0.315 n=8+8)

name                    old p95      new p95      delta
kv0/enc=false/nodes=3     31.5 ± 0%    30.2 ± 4%  -4.25%  (p=0.003 n=6+8)
kv95/enc=false/nodes=3    19.5 ± 7%    18.1 ± 4%  -7.28%  (p=0.000 n=8+7)

name                    old p99      new p99      delta
kv0/enc=false/nodes=3     48.7 ± 3%    47.4 ± 6%    ~     (p=0.059 n=8+8)
kv95/enc=false/nodes=3    32.8 ± 9%    30.2 ± 4%  -8.04%  (p=0.001 n=8+8)
```

Resolves #99812.
Touches #98433.

Epic: none
Release note: None
  
**kvserver: also acquire expiration leases in replicate queue**

Previously, the replicate queue would only reacquire epoch leases, and allow expiration leases to expire. It now reacquires all leases, since they are eagerly extended.

In the future, when quiescence is removed entirely, this responsibility should be moved to the Raft tick loop.

Epic: none
Release note: None
  
**kvserver: conditionally extend expiration leases during requests**

If `kv.expiration_leases_only.enabled` is `true`, this patch disables expiration lease extension during request processing, since the Raft scheduler will eagerly extend leases in this case. This will eventually be removed completely, but is kept for now with an eye towards a 23.1 backport.

Epic: none
Release note: None