### PR TITLE
kvserver: grow goroutine stack for `requestLease`

### DIFF
--- a/pkg/kv/kvserver/BUILD.bazel
+++ b/pkg/kv/kvserver/BUILD.bazel
@@ -185,6 +185,7 @@ go_library(
         "//pkg/util/envutil",
         "//pkg/util/errorutil",
         "//pkg/util/future",
+        "//pkg/util/growstack",
         "//pkg/util/grpcutil",
         "//pkg/util/grunning",
         "//pkg/util/hlc",


### PR DESCRIPTION
We pre-grow the goroutine stack when processing batch requests via RPC, to avoid frequent stack copying. However, this did not apply to lease requests, which are submitted directly to the local replica. When eagerly extending 20.000 expiration leases, `requestLease` stack growth made up 4% of total CPU usage -- this patch reduces that to 1%.

Touches #98433.

Epic: none
Release note: None