### PR TITLE
server: fix the tenant server error handling

### DIFF
--- a/pkg/ccl/serverccl/BUILD.bazel
+++ b/pkg/ccl/serverccl/BUILD.bazel
@@ -55,6 +55,7 @@ go_test(
         "//pkg/ccl/kvccl",
         "//pkg/ccl/utilccl/licenseccl",
         "//pkg/clusterversion",
+        "//pkg/jobs",
         "//pkg/kv/kvserver/liveness",
         "//pkg/kv/kvserver/liveness/livenesspb",
         "//pkg/multitenant/tenantcapabilities",

--- a/pkg/ccl/serverccl/BUILD.bazel
+++ b/pkg/ccl/serverccl/BUILD.bazel
@@ -90,7 +90,6 @@ go_test(
         "//pkg/util/metric",
         "//pkg/util/protoutil",
         "//pkg/util/randutil",
-        "//pkg/util/stop",
         "//pkg/util/timeutil",
         "@com_github_cockroachdb_datadriven//:datadriven",
         "@com_github_cockroachdb_errors//:errors",

--- a/pkg/ccl/serverccl/server_controller_test.go
+++ b/pkg/ccl/serverccl/server_controller_test.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/jobs"
 	"github.com/cockroachdb/cockroach/pkg/multitenant/tenantcapabilities"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/server"
@@ -391,6 +392,9 @@ func TestServerControllerMultiNodeTenantStartup(t *testing.T) {
 	numNodes := 3
 	tc := serverutils.StartNewTestCluster(t, numNodes, base.TestClusterArgs{
 		ServerArgs: base.TestServerArgs{
+			Knobs: base.TestingKnobs{
+				JobsTestingKnobs: jobs.NewTestingKnobsWithShortIntervals(),
+			},
 			DefaultTestTenant: base.TestTenantDisabled,
 		}})
 	defer func() {

--- a/pkg/ccl/serverccl/server_controller_test.go
+++ b/pkg/ccl/serverccl/server_controller_test.go
@@ -387,34 +387,51 @@ func TestServerControllerMultiNodeTenantStartup(t *testing.T) {
 
 	ctx := context.Background()
 
+	t.Logf("starting test cluster")
 	numNodes := 3
 	tc := serverutils.StartNewTestCluster(t, numNodes, base.TestClusterArgs{
 		ServerArgs: base.TestServerArgs{
 			DefaultTestTenant: base.TestTenantDisabled,
 		}})
-	defer tc.Stopper().Stop(ctx)
+	defer func() {
+		t.Logf("stopping test cluster")
+		tc.Stopper().Stop(ctx)
+	}()
 
+	t.Logf("starting tenant servers")
 	db := tc.ServerConn(0)
 	_, err := db.Exec("CREATE TENANT hello; ALTER TENANT hello START SERVICE SHARED")
 	require.NoError(t, err)
 
 	// Pick a random node, try to run some SQL inside that tenant.
 	rng, _ := randutil.NewTestRand()
-	sqlAddr := tc.Server(int(rng.Int31n(int32(numNodes)))).ServingSQLAddr()
+	serverIdx := int(rng.Int31n(int32(numNodes)))
+	sqlAddr := tc.Server(serverIdx).ServingSQLAddr()
+	t.Logf("attempting to use tenant server on node %d (%s)", serverIdx, sqlAddr)
 	testutils.SucceedsSoon(t, func() error {
 		tenantDB, err := serverutils.OpenDBConnE(sqlAddr, "cluster:hello", false, tc.Stopper())
 		if err != nil {
+			t.Logf("error connecting to tenant server (will retry): %v", err)
 			return err
 		}
 		defer tenantDB.Close()
-		if _, err := tenantDB.Exec("CREATE ROLE foo"); err != nil {
+		if err := tenantDB.Ping(); err != nil {
+			t.Logf("connection not ready (will retry): %v", err)
 			return err
 		}
+		if _, err := tenantDB.Exec("CREATE ROLE foo"); err != nil {
+			// This is not retryable -- if the server accepts the
+			// connection, it better be ready.
+			t.Fatal(err)
+		}
 		if _, err := tenantDB.Exec("GRANT ADMIN TO foo"); err != nil {
-			return err
+			// This is not retryable -- if the server accepts the
+			// connection, it better be ready.
+			t.Fatal(err)
 		}
 		return nil
 	})
+	t.Logf("tenant server on node %d (%s) is ready", serverIdx, sqlAddr)
 }
 
 func TestServerStartStop(t *testing.T) {

--- a/pkg/ccl/serverccl/server_startup_guardrails_test.go
+++ b/pkg/ccl/serverccl/server_startup_guardrails_test.go
@@ -22,7 +22,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
-	"github.com/cockroachdb/cockroach/pkg/util/stop"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
 )
 
 // TestServerStartupGuardrails ensures that a SQL server will fail to start if
@@ -74,69 +74,59 @@ func TestServerStartupGuardrails(t *testing.T) {
 	}
 
 	for i, test := range tests {
-		storageSettings := cluster.MakeTestingClusterSettingsWithVersions(
-			test.storageBinaryVersion,
-			test.storageBinaryMinSupportedVersion,
-			false, /* initializeVersion */
-		)
+		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
+			defer log.Scope(t).Close(t)
 
-		s, _, _ := serverutils.StartServer(t, base.TestServerArgs{
-			// Disable the default test tenant, since we create one explicitly
-			// below.
-			DefaultTestTenant: base.TestTenantDisabled,
-			Settings:          storageSettings,
-			Knobs: base.TestingKnobs{
-				Server: &server.TestingKnobs{
-					BinaryVersionOverride:          test.storageBinaryVersion,
-					BootstrapVersionKeyOverride:    clusterversion.V22_2,
-					DisableAutomaticVersionUpgrade: make(chan struct{}),
-				},
-				SQLEvalContext: &eval.TestingKnobs{
-					TenantLogicalVersionKeyOverride: test.TenantLogicalVersionKey,
-				},
-			},
-		})
+			storageSettings := cluster.MakeTestingClusterSettingsWithVersions(
+				test.storageBinaryVersion,
+				test.storageBinaryMinSupportedVersion,
+				false, /* initializeVersion */
+			)
 
-		tenantSettings := cluster.MakeTestingClusterSettingsWithVersions(
-			test.tenantBinaryVersion,
-			test.tenantBinaryMinSupportedVersion,
-			true, /* initializeVersion */
-		)
-
-		// The tenant will be created with an active version equal to the version
-		// corresponding to TenantLogicalVersionKey. Tenant creation is expected
-		// to succeed for all test cases but server creation is expected to succeed
-		// only if tenantBinaryVersion is at least equal to the version corresponding
-		// to TenantLogicalVersionKey.
-		stopper := stop.NewStopper()
-		tenantServer, err := s.StartTenant(context.Background(),
-			base.TestTenantArgs{
-				Settings: tenantSettings,
-				TenantID: serverutils.TestTenantID(),
-				Stopper:  stopper,
-				TestingKnobs: base.TestingKnobs{
+			s, _, _ := serverutils.StartServer(t, base.TestServerArgs{
+				// Disable the default test tenant, since we create one explicitly
+				// below.
+				DefaultTestTenant: base.TestTenantDisabled,
+				Settings:          storageSettings,
+				Knobs: base.TestingKnobs{
 					Server: &server.TestingKnobs{
-						BinaryVersionOverride:          test.tenantBinaryVersion,
+						BinaryVersionOverride:          test.storageBinaryVersion,
+						BootstrapVersionKeyOverride:    clusterversion.V22_2,
 						DisableAutomaticVersionUpgrade: make(chan struct{}),
+					},
+					SQLEvalContext: &eval.TestingKnobs{
+						TenantLogicalVersionKeyOverride: test.TenantLogicalVersionKey,
 					},
 				},
 			})
+			defer s.Stopper().Stop(context.Background())
 
-		if !testutils.IsError(err, test.expErrMatch) {
-			t.Fatalf("test %d: got error %s, wanted error matching '%s'", i, err, test.expErrMatch)
-		}
+			tenantSettings := cluster.MakeTestingClusterSettingsWithVersions(
+				test.tenantBinaryVersion,
+				test.tenantBinaryMinSupportedVersion,
+				true, /* initializeVersion */
+			)
 
-		// Only attempt to stop the tenant if it was started successfully.
-		if err == nil {
-			tenantServer.Stopper().Stop(context.Background())
-		} else {
-			// Test - stop the failed SQL server using a custom stopper
-			// NOTE: This custom stopper should not be required, but is because
-			// currently, if a SQL server fails to start it will not be cleaned
-			// up immediately without invoking the custom stopper. This could
-			// be a problem, and is tracked with #98868.
-			stopper.Stop(context.Background())
-		}
-		s.Stopper().Stop(context.Background())
+			// The tenant will be created with an active version equal to the version
+			// corresponding to TenantLogicalVersionKey. Tenant creation is expected
+			// to succeed for all test cases but server creation is expected to succeed
+			// only if tenantBinaryVersion is at least equal to the version corresponding
+			// to TenantLogicalVersionKey.
+			_, err := s.StartTenant(context.Background(),
+				base.TestTenantArgs{
+					Settings: tenantSettings,
+					TenantID: serverutils.TestTenantID(),
+					TestingKnobs: base.TestingKnobs{
+						Server: &server.TestingKnobs{
+							BinaryVersionOverride:          test.tenantBinaryVersion,
+							DisableAutomaticVersionUpgrade: make(chan struct{}),
+						},
+					},
+				})
+
+			if !testutils.IsError(err, test.expErrMatch) {
+				t.Fatalf("test %d: got error %s, wanted error matching '%s'", i, err, test.expErrMatch)
+			}
+		})
 	}
 }

--- a/pkg/server/server_controller.go
+++ b/pkg/server/server_controller.go
@@ -203,7 +203,12 @@ func (t *tenantServerWrapper) preStart(ctx context.Context) error {
 }
 
 func (t *tenantServerWrapper) acceptClients(ctx context.Context) error {
-	return t.server.AcceptClients(ctx)
+	if err := t.server.AcceptClients(ctx); err != nil {
+		return err
+	}
+	// Show the tenant details in logs.
+	// TODO(knz): Remove this once we can use a single listener.
+	return t.server.reportTenantInfo(ctx)
 }
 
 func (t *tenantServerWrapper) stop(ctx context.Context) {

--- a/pkg/server/server_controller_new_server.go
+++ b/pkg/server/server_controller_new_server.go
@@ -157,7 +157,7 @@ func startTenantServerInternal(
 
 	// Show the tenant details in logs.
 	// TODO(knz): Remove this once we can use a single listener.
-	if err := reportTenantInfo(startCtx, baseCfg, sqlCfg); err != nil {
+	if err := tenantServer.reportTenantInfo(startCtx); err != nil {
 		return tenantServer, err
 	}
 
@@ -411,11 +411,11 @@ func rederivePort(index int, addrToChange string, prevAddr string, portOffset in
 	return net.JoinHostPort(h, port), nil
 }
 
-func reportTenantInfo(ctx context.Context, baseCfg BaseConfig, sqlCfg SQLConfig) error {
+func (s *SQLServerWrapper) reportTenantInfo(ctx context.Context) error {
 	var buf redact.StringBuilder
 	buf.Printf("started tenant SQL server at %s\n", timeutil.Now())
-	buf.Printf("webui:\t%s\n", baseCfg.AdminURL())
-	clientConnOptions, serverParams := MakeServerOptionsForURL(baseCfg.Config)
+	buf.Printf("webui:\t%s\n", s.cfg.AdminURL())
+	clientConnOptions, serverParams := MakeServerOptionsForURL(s.cfg.Config)
 	pgURL, err := clientsecopts.MakeURLForServer(clientConnOptions, serverParams, url.User(username.RootUser))
 	if err != nil {
 		log.Errorf(ctx, "failed computing the URL: %v", err)
@@ -423,15 +423,15 @@ func reportTenantInfo(ctx context.Context, baseCfg BaseConfig, sqlCfg SQLConfig)
 		buf.Printf("sql:\t%s\n", pgURL.ToPQ())
 		buf.Printf("sql (JDBC):\t%s\n", pgURL.ToJDBC())
 	}
-	if baseCfg.SocketFile != "" {
-		buf.Printf("socket:\t%s\n", baseCfg.SocketFile)
+	if s.cfg.SocketFile != "" {
+		buf.Printf("socket:\t%s\n", s.cfg.SocketFile)
 	}
-	if tmpDir := sqlCfg.TempStorageConfig.Path; tmpDir != "" {
+	if tmpDir := s.sqlCfg.TempStorageConfig.Path; tmpDir != "" {
 		buf.Printf("temp dir:\t%s\n", tmpDir)
 	}
-	buf.Printf("clusterID:\t%s\n", baseCfg.ClusterIDContainer.Get())
-	buf.Printf("tenantID:\t%s\n", sqlCfg.TenantID)
-	buf.Printf("instanceID:\t%d\n", baseCfg.IDContainer.Get())
+	buf.Printf("clusterID:\t%s\n", s.cfg.ClusterIDContainer.Get())
+	buf.Printf("tenantID:\t%s\n", s.sqlCfg.TenantID)
+	buf.Printf("instanceID:\t%d\n", s.cfg.IDContainer.Get())
 	// Collect the formatted string and show it to the user.
 	msg, err := util.ExpandTabsInRedactableBytes(buf.RedactableBytes())
 	if err != nil {

--- a/pkg/server/server_controller_new_server.go
+++ b/pkg/server/server_controller_new_server.go
@@ -83,7 +83,7 @@ func (s *Server) newTenantServer(
 	// Apply the TestTenantArgs, if any.
 	baseCfg.TestingKnobs = testArgs.Knobs
 
-	tenantServer, err := s.startTenantServerInternal(ctx, baseCfg, sqlCfg, tenantStopper, tenantNameContainer)
+	tenantServer, err := startTenantServerInternal(ctx, baseCfg, sqlCfg, tenantStopper, tenantNameContainer)
 	if err != nil {
 		return nil, err
 	}
@@ -129,7 +129,7 @@ func (s *Server) getTenantID(
 //
 // Note that even if an error is returned, tasks might have been started with
 // the stopper, so the caller needs to Stop() it.
-func (s *Server) startTenantServerInternal(
+func startTenantServerInternal(
 	ctx context.Context,
 	baseCfg BaseConfig,
 	sqlCfg SQLConfig,
@@ -146,7 +146,7 @@ func (s *Server) startTenantServerInternal(
 	log.Infof(startCtx, "starting tenant server")
 
 	// Now start the tenant proper.
-	tenantServer, err := NewSharedProcessTenantServer(startCtx, stopper, baseCfg, sqlCfg, tenantNameContainer)
+	tenantServer, err := newSharedProcessTenantServer(startCtx, stopper, baseCfg, sqlCfg, tenantNameContainer)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/server/server_controller_orchestration.go
+++ b/pkg/server/server_controller_orchestration.go
@@ -276,7 +276,7 @@ func (c *serverController) startControlledServer(
 		ctx := tenantCtx
 		// We want a context that gets cancelled when the tenant is
 		// shutting down, for the possible few cases in
-		// startServerInternal which are not looking at the
+		// newServerInternal/preStart/acceptClients which are not looking at the
 		// tenant.ShouldQuiesce() channel but are sensitive to context
 		// cancellation.
 		var cancel func()
@@ -291,8 +291,18 @@ func (c *serverController) startControlledServer(
 
 		var s onDemandServer
 		for retry := retry.StartWithCtx(ctx, retryOpts); retry.Next(); {
-			var err error
-			s, err = c.startServerInternal(ctx, entry.nameContainer, tenantStopper)
+			err := func() error {
+				var err error
+				s, err = c.newServerInternal(ctx, entry.nameContainer, tenantStopper)
+				if err != nil {
+					return err
+				}
+				startCtx := s.annotateCtx(context.Background())
+				if err := s.preStart(startCtx); err != nil {
+					return err
+				}
+				return s.acceptClients(startCtx)
+			}()
 			if err != nil {
 				c.logStartEvent(ctx, roachpb.TenantID{}, 0,
 					entry.nameContainer.Get(), false /* success */, err)
@@ -406,7 +416,7 @@ func (c *serverController) startAndWaitForRunningServer(
 	}
 }
 
-func (c *serverController) startServerInternal(
+func (c *serverController) newServerInternal(
 	ctx context.Context, nameContainer *roachpb.TenantNameContainer, tenantStopper *stop.Stopper,
 ) (onDemandServer, error) {
 	tenantName := nameContainer.Get()

--- a/pkg/server/tenant.go
+++ b/pkg/server/tenant.go
@@ -86,6 +86,7 @@ type SQLServerWrapper struct {
 	// TODO(knz): Find a way to merge these two togethers so there is just
 	// one implementation.
 
+	cfg        *BaseConfig
 	clock      *hlc.Clock
 	rpcContext *rpc.Context
 	// The gRPC server on which the different RPC handlers will be registered.
@@ -418,6 +419,8 @@ func newTenantServer(
 	)
 
 	return &SQLServerWrapper{
+		cfg: args.BaseConfig,
+
 		clock:      args.clock,
 		rpcContext: args.rpcContext,
 

--- a/pkg/server/tenant.go
+++ b/pkg/server/tenant.go
@@ -192,13 +192,13 @@ func NewSeparateProcessTenantServer(
 	return newTenantServer(ctx, stopper, baseCfg, sqlCfg, tenantNameContainer, deps)
 }
 
-// NewSharedProcessTenantServer creates a tenant-specific, SQL-only
+// newSharedProcessTenantServer creates a tenant-specific, SQL-only
 // server against a KV backend, with defaults appropriate for a
 // SQLServer that is not located in the same process as a KVServer.
 //
 // The caller is responsible for listening to the server's ShutdownRequested()
 // channel and stopping cfg.stopper when signaled.
-func NewSharedProcessTenantServer(
+func newSharedProcessTenantServer(
 	ctx context.Context,
 	stopper *stop.Stopper,
 	baseCfg BaseConfig,


### PR DESCRIPTION
Needed for #99958.
Fixes  #97661.
Fixes #98868.
Epic: CRDB-23559
First commit from #100579.

Prior to this patch, if an error occurred during the initialization or
startup of a secondary tenant server, the initialization would leak
state into the stopper defined for that tenant. Generally, reusing
a stopper across server startup failures is not safe (and API
violation).

This patch fixes it by decoupling the intermediate stopper used for
orchestration from the one used per tenant server.