### PR TITLE
server, sql: show in-memory data when no data is persisted

### DIFF
--- a/pkg/server/status_test.go
+++ b/pkg/server/status_test.go
@@ -52,7 +52,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlstats"
-	"github.com/cockroachdb/cockroach/pkg/sql/sqlstats/persistedsqlstats"
 	"github.com/cockroachdb/cockroach/pkg/sql/tests"
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
@@ -1646,9 +1645,6 @@ func TestStatusAPICombinedTransactions(t *testing.T) {
 		}
 	}
 
-	// Flush stats, as combinedstmts reads only from system.
-	thirdServer.SQLServer().(*sql.Server).GetSQLStatsProvider().(*persistedsqlstats.PersistedSQLStats).Flush(ctx)
-
 	// Hit query endpoint.
 	var resp serverpb.StatementsResponse
 	if err := getStatusJSONProto(firstServerProto, "combinedstmts", &resp); err != nil {
@@ -2021,8 +2017,6 @@ func TestStatusAPICombinedStatements(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	ctx := context.Background()
-
 	// Aug 30 2021 19:50:00 GMT+0000
 	aggregatedTs := int64(1630353000)
 	testCluster := serverutils.StartNewTestCluster(t, 3, base.TestClusterArgs{
@@ -2060,8 +2054,6 @@ func TestStatusAPICombinedStatements(t *testing.T) {
 	for _, stmt := range statements {
 		thirdServerSQL.Exec(t, stmt.stmt)
 	}
-
-	testCluster.Server(2).SQLServer().(*sql.Server).GetSQLStatsProvider().(*persistedsqlstats.PersistedSQLStats).Flush(ctx)
 
 	var resp serverpb.StatementsResponse
 	// Test that non-admin without VIEWACTIVITY privileges cannot access.
@@ -2192,8 +2184,6 @@ func TestStatusAPIStatementDetails(t *testing.T) {
 	// The liveness session might expire before the stress race can finish.
 	skip.UnderStressRace(t, "expensive tests")
 
-	ctx := context.Background()
-
 	// Aug 30 2021 19:50:00 GMT+0000
 	aggregatedTs := int64(1630353000)
 	testCluster := serverutils.StartNewTestCluster(t, 3, base.TestClusterArgs{
@@ -2252,9 +2242,6 @@ func TestStatusAPIStatementDetails(t *testing.T) {
 	}
 
 	testPath := func(path string, expected resultValues) {
-		// Need to flush since this EP reads only flushed data.
-		testCluster.Server(2).SQLServer().(*sql.Server).GetSQLStatsProvider().(*persistedsqlstats.PersistedSQLStats).Flush(ctx)
-
 		err := getStatusJSONProtoWithAdminOption(firstServerProto, path, &resp, false)
 		require.NoError(t, err)
 		require.Equal(t, int64(expected.totalCount), resp.Statement.Stats.Count)

--- a/pkg/sql/internal.go
+++ b/pkg/sql/internal.go
@@ -501,6 +501,10 @@ func (r *rowsIterator) Types() colinfo.ResultColumns {
 	return r.resultCols
 }
 
+func (r *rowsIterator) HasResults() bool {
+	return r.first.row != nil
+}
+
 // QueryBuffered executes the supplied SQL statement and returns the resulting
 // rows (meaning all of them are buffered at once). If no user has been
 // previously set through SetSessionData, the statement is executed as the root

--- a/pkg/sql/isql/isql_db.go
+++ b/pkg/sql/isql/isql_db.go
@@ -244,4 +244,7 @@ type Rows interface {
 	// WARNING: this method is safe to call anytime *after* the first call to
 	// Next() (including after Close() was called).
 	Types() colinfo.ResultColumns
+
+	// HasResults returns true if there are results to the query, false otherwise.
+	HasResults() bool
 }

--- a/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.tsx
@@ -280,7 +280,7 @@ export class StatementsPage extends React.Component<
 
   isSortSettingSameAsReqSort = (): boolean => {
     return (
-      getSortColumn(this.state.reqSortSetting) ==
+      getSortColumn(this.props.reqSortSetting) ==
       this.props.sortSetting.columnTitle
     );
   };

--- a/pkg/ui/workspaces/cluster-ui/src/transactionsPage/transactionsPage.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionsPage/transactionsPage.tsx
@@ -294,7 +294,7 @@ export class TransactionsPage extends React.Component<
 
   isSortSettingSameAsReqSort = (): boolean => {
     return (
-      getSortColumn(this.state.reqSortSetting) ==
+      getSortColumn(this.props.reqSortSetting) ==
       this.props.sortSetting.columnTitle
     );
   };


### PR DESCRIPTION
Fixes #100439

When no data is persisted to sql stats tables (because no flush happened yet or because the flush is disabled), the endpoints should fall back to the combined view that contains the in-memory data.

https://www.loom.com/share/b5e3a227a9904a19a5279ed828a3b3f3

Release note (sql change): When there is no data persisted, show the in-memory data.