### PR TITLE
roachtest: unskip `acceptance/gossip/peerings`

### DIFF
--- a/pkg/cmd/roachtest/tests/acceptance.go
+++ b/pkg/cmd/roachtest/tests/acceptance.go
@@ -31,7 +31,7 @@ func registerAcceptance(r registry.Registry) {
 		registry.OwnerKV: {
 			{name: "decommission-self", fn: runDecommissionSelf},
 			{name: "event-log", fn: runEventLog},
-			{name: "gossip/peerings", fn: runGossipPeerings, skip: "flaky test. tracked in #96091"},
+			{name: "gossip/peerings", fn: runGossipPeerings},
 			{name: "gossip/restart", fn: runGossipRestart},
 			{
 				name:              "gossip/restart-node-one",


### PR DESCRIPTION
Addressed by bfed880eaabc3efabb606241c80dcba89f629a00.

Resolves #96091.
Touches #100213.

Epic: none
Release note: None