### PR TITLE
cli/interactive_tests: deflake test_demo_memory_warning.tcl

### DIFF
--- a/pkg/cli/interactive_tests/test_demo_memory_warning.tcl
+++ b/pkg/cli/interactive_tests/test_demo_memory_warning.tcl
@@ -7,7 +7,11 @@ spawn $argv demo --no-line-editor --no-example-database --max-sql-memory=10% --n
 
 eexpect "WARNING: HIGH MEMORY USAGE"
 
-eexpect "defaultdb>"
+# try to exit early via Ctrl+C.
 interrupt
+# If the demo command started the prompt before we got a chance to send Ctrl+C above,
+# it's not going to accept Ctrl+C any more. Instead, send a quit command.
+send "\r\\q\r"
+eexpect eof
 
 end_test


### PR DESCRIPTION
This test is currently flaky in CI, because it is very slow to set up its servers and times out before the prompt is displayed. However, we don't care much about the prompt - we just care about the warning.

Epic: None
Fixes #61834.