### PR TITLE
kvserver: fix `EnableLeaseHistory` data race

### DIFF
--- a/pkg/kv/kvserver/lease_history.go
+++ b/pkg/kv/kvserver/lease_history.go
@@ -26,9 +26,9 @@ type leaseHistory struct {
 	history []roachpb.Lease // A circular buffer with index.
 }
 
-func newLeaseHistory() *leaseHistory {
+func newLeaseHistory(maxEntries int) *leaseHistory {
 	lh := &leaseHistory{
-		history: make([]roachpb.Lease, 0, leaseHistoryMaxEntries),
+		history: make([]roachpb.Lease, 0, maxEntries),
 	}
 	return lh
 }
@@ -44,7 +44,7 @@ func (lh *leaseHistory) add(lease roachpb.Lease) {
 		lh.history[lh.index] = lease
 	}
 	lh.index++
-	if lh.index >= leaseHistoryMaxEntries {
+	if lh.index >= cap(lh.history) {
 		lh.index = 0
 	}
 }
@@ -55,7 +55,7 @@ func (lh *leaseHistory) get() []roachpb.Lease {
 	if len(lh.history) == 0 {
 		return nil
 	}
-	if len(lh.history) < leaseHistoryMaxEntries || lh.index == 0 {
+	if len(lh.history) < cap(lh.history) || lh.index == 0 {
 		result := make([]roachpb.Lease, len(lh.history))
 		copy(result, lh.history)
 		return result

--- a/pkg/kv/kvserver/lease_history_test.go
+++ b/pkg/kv/kvserver/lease_history_test.go
@@ -22,7 +22,7 @@ import (
 func TestLeaseHistory(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	history := newLeaseHistory()
+	history := newLeaseHistory(leaseHistoryMaxEntries)
 
 	for i := 0; i < leaseHistoryMaxEntries; i++ {
 		leases := history.get()

--- a/pkg/kv/kvserver/replica.go
+++ b/pkg/kv/kvserver/replica.go
@@ -2246,9 +2246,9 @@ func (r *Replica) GetLeaseHistory() []roachpb.Lease {
 	return r.leaseHistory.get()
 }
 
-// EnableLeaseHistory turns on the lease history for testing purposes. Returns
-// a function to return it to its original state that can be deferred.
-func EnableLeaseHistory(maxEntries int) func() {
+// EnableLeaseHistoryForTesting turns on the lease history for testing purposes.
+// Returns a function to return it to its original state that can be deferred.
+func EnableLeaseHistoryForTesting(maxEntries int) func() {
 	originalValue := leaseHistoryMaxEntries
 	leaseHistoryMaxEntries = maxEntries
 	return func() {

--- a/pkg/kv/kvserver/replica_init.go
+++ b/pkg/kv/kvserver/replica_init.go
@@ -116,7 +116,7 @@ func newUninitializedReplica(
 	r.mu.proposalBuf.testing.submitProposalFilter = store.cfg.TestingKnobs.TestingProposalSubmitFilter
 
 	if leaseHistoryMaxEntries > 0 {
-		r.leaseHistory = newLeaseHistory()
+		r.leaseHistory = newLeaseHistory(leaseHistoryMaxEntries)
 	}
 
 	if store.cfg.StorePool != nil {

--- a/pkg/kv/kvserver/replica_test.go
+++ b/pkg/kv/kvserver/replica_test.go
@@ -1043,7 +1043,7 @@ func TestReplicaNotLeaseHolderError(t *testing.T) {
 func TestReplicaLeaseCounters(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	defer EnableLeaseHistory(100)()
+	defer EnableLeaseHistoryForTesting(100)()
 	ctx := context.Background()
 	stopper := stop.NewStopper()
 	defer stopper.Stop(ctx)

--- a/pkg/server/status_test.go
+++ b/pkg/server/status_test.go
@@ -1158,7 +1158,7 @@ func TestHotRanges2ResponseWithViewActivityOptions(t *testing.T) {
 func TestRangesResponse(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	defer kvserver.EnableLeaseHistory(100)()
+	defer kvserver.EnableLeaseHistoryForTesting(100)()
 	ts := startServer(t)
 	defer ts.Stopper().Stop(context.Background())
 
@@ -1511,7 +1511,7 @@ func TestDiagnosticsResponse(t *testing.T) {
 func TestRangeResponse(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	defer kvserver.EnableLeaseHistory(100)()
+	defer kvserver.EnableLeaseHistoryForTesting(100)()
 	ts := startServer(t)
 	defer ts.Stopper().Stop(context.Background())
 


### PR DESCRIPTION
`EnableLeaseHistory()` is used in tests to temporarily modify the maximum lease history size. This could trip the race detector, since lease history mutations keep referring to the global variable, and these could happen concurrently with test cleanup. This patch only uses the global variable during server setup, which avoids the race.

Resolves #100453.

Epic: none
Release note: None