### PR TITLE
release-23.1: insights, server: fix mixed version insights cluster-wide fanout

### DIFF
--- a/pkg/server/status.go
+++ b/pkg/server/status.go
@@ -395,7 +395,15 @@ func (b *baseStatusServer) localExecutionInsights(
 
 	reader := b.sqlServer.pgServer.SQLServer.GetInsightsReader()
 	reader.IterateInsights(ctx, func(ctx context.Context, insight *insights.Insight) {
-		response.Insights = append(response.Insights, *insight)
+		if insight == nil {
+			return
+		}
+
+		// Versions <=22.2.6 expects that Statement is not null when building the exec insights virtual table.
+		insightWithStmt := *insight
+		insightWithStmt.Statement = &insights.Statement{}
+
+		response.Insights = append(response.Insights, insightWithStmt)
 	})
 
 	return &response, nil

--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -7417,6 +7417,10 @@ func populateTxnExecutionInsights(
 	// We should truncate the query if it surpasses some absurd limit.
 	queryMax := 5000
 	for _, insight := range response.Insights {
+		if insight.Transaction == nil {
+			continue
+		}
+
 		var errorCode string
 		var queryBuilder strings.Builder
 		for i := range insight.Statements {
@@ -7593,6 +7597,12 @@ func populateStmtInsights(
 		return err
 	}
 	for _, insight := range response.Insights {
+		// We don't expect the transaction to be null here, but we should provide
+		// this check to ensure we only show valid data.
+		if insight.Transaction == nil {
+			continue
+		}
+
 		for _, s := range insight.Statements {
 
 			causes := tree.NewDArray(types.String)

--- a/pkg/sql/logictest/testdata/logic_test/mixed_version_insights_queries
+++ b/pkg/sql/logictest/testdata/logic_test/mixed_version_insights_queries
@@ -1,0 +1,78 @@
+# LogicTest: cockroach-go-testserver-upgrade-to-master
+
+# Verify that all nodes are running 22.2 binaries.
+
+query T nodeidx=0
+SELECT crdb_internal.node_executable_version()
+----
+22.2
+
+query T nodeidx=1
+SELECT crdb_internal.node_executable_version()
+----
+22.2
+
+query T nodeidx=2
+SELECT crdb_internal.node_executable_version()
+----
+22.2
+
+upgrade 1
+
+# Test that there are no problems reading from insights tables in mixed version state.
+
+# Insert some insights into nodes of both versions.
+
+user root nodeidx=1
+
+query B
+select pg_sleep(1)
+----
+true
+
+user root nodeidx=0
+
+query B
+select pg_sleep(1)
+----
+true
+
+
+# Sleep to ensure our queries above are written to the insights system.
+sleep 3s
+
+
+# Verify we have insights in each node.
+
+user root nodeidx=0
+
+
+query B
+SELECT count(*) > 0 FROM crdb_internal.node_execution_insights
+----
+true
+
+
+user root nodeidx=1
+
+query B
+SELECT count(*) > 0 FROM crdb_internal.node_execution_insights
+----
+true
+
+user root nodeidx=0
+
+# Verify issuing insights cluster-wide fanout from 22.2 causes no problems.
+query B
+SELECT count(*) > 0 FROM crdb_internal.cluster_execution_insights
+----
+true
+
+
+user root nodeidx=1
+
+# Verify issuing insights cluster-wide fanout from 23.1 causes no problems.
+query B
+SELECT count(*) > 0 FROM crdb_internal.cluster_execution_insights
+----
+true

--- a/pkg/sql/logictest/tests/cockroach-go-testserver-upgrade-to-master/BUILD.bazel
+++ b/pkg/sql/logictest/tests/cockroach-go-testserver-upgrade-to-master/BUILD.bazel
@@ -11,7 +11,7 @@ go_test(
         "//pkg/cmd/cockroach-short",  # keep
         "//pkg/sql/logictest:testdata",  # keep
     ],
-    shard_count = 6,
+    shard_count = 7,
     tags = ["cpu:2"],
     deps = [
         "//pkg/build/bazel",

--- a/pkg/sql/logictest/tests/cockroach-go-testserver-upgrade-to-master/generated_test.go
+++ b/pkg/sql/logictest/tests/cockroach-go-testserver-upgrade-to-master/generated_test.go
@@ -93,6 +93,13 @@ func TestLogic_mixed_version_external_connections_owner_id(
 	runLogicTest(t, "mixed_version_external_connections_owner_id")
 }
 
+func TestLogic_mixed_version_insights_queries(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "mixed_version_insights_queries")
+}
+
 func TestLogic_mixed_version_new_system_privileges(
 	t *testing.T,
 ) {

--- a/pkg/sql/sqlstats/insights/insights.proto
+++ b/pkg/sql/sqlstats/insights/insights.proto
@@ -135,7 +135,14 @@ message Insight {
   Session session = 1 [(gogoproto.nullable) = false];
   Transaction transaction = 2;
   repeated Statement statements = 6;
-  reserved 3;
-  reserved 4;
-  reserved 5;
+
+  // This field is deprecated, but we have to keep it around for 22.2
+  // backwards compatibility. 22.2 actually expects this as non-null
+  // when generating the exec insights virtual table. Removing this will
+  // cause a nil pointer deref on versions <= 22.2.6.
+  // TODO: Move these fields to 'reserved' at 23.2.
+  Statement statement = 3;
+
+  reserved  4; // Previously problem.
+  reserved 5; // Previously causes.
 }


### PR DESCRIPTION
Backport 1/1 commits from #100221.

/cc @cockroachdb/release

---

23.1 deprecated the `statement` field in the `Insight` proto
message, changing it to a reserved field. Although this field
was nullable, during the generation of the exec insights virtual
table in 22.2, we read the `statement` field without a null check.
This causes the 22.2 node to panic when requesting insights from
a 23.1 node. This commit reintroduces the `statement` field, setting
it to an empty Statement message when sending insights via the
status server endpoint.

Epic: none

Release note: None

Release justification: bug fix

After: https://www.loom.com/share/5696dd3451cd49dc9bb081c05fe3d9a1
