### PR TITLE
server/drain: shut down SQL subsystems gracefully before releasing table leases

### DIFF
--- a/pkg/jobs/adopt.go
+++ b/pkg/jobs/adopt.go
@@ -422,6 +422,10 @@ func (r *Registry) addAdoptedJob(
 func (r *Registry) runJob(
 	ctx context.Context, resumer Resumer, job *Job, status Status, taskName string,
 ) error {
+	if r.IsDraining() {
+		return errors.Newf("refusing to start %q; job registry is draining", taskName)
+	}
+
 	job.mu.Lock()
 	var finalResumeError error
 	if job.mu.payload.FinalResumeError != nil {

--- a/pkg/jobs/registry.go
+++ b/pkg/jobs/registry.go
@@ -16,6 +16,7 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
@@ -163,6 +164,9 @@ type Registry struct {
 		draining bool
 	}
 
+	drainJobs                chan struct{}
+	startedControllerTasksWG sync.WaitGroup
+
 	// withSessionEvery ensures that logging when failing to get a live session
 	// is not too loud.
 	withSessionEvery log.EveryN
@@ -236,6 +240,7 @@ func MakeRegistry(
 		// if a notification is already queued.
 		adoptionCh:       make(chan adoptionNotice, 1),
 		withSessionEvery: log.Every(time.Second),
+		drainJobs:        make(chan struct{}),
 	}
 	if knobs != nil {
 		r.knobs = *knobs
@@ -1065,7 +1070,10 @@ func (r *Registry) Start(ctx context.Context, stopper *stop.Stopper) error {
 		}
 	})
 
+	r.startedControllerTasksWG.Add(1)
 	if err := stopper.RunAsyncTask(ctx, "jobs/cancel", func(ctx context.Context) {
+		defer r.startedControllerTasksWG.Done()
+
 		ctx, cancel := stopper.WithCancelOnQuiesce(ctx)
 		defer cancel()
 
@@ -1080,6 +1088,10 @@ func (r *Registry) Start(ctx context.Context, stopper *stop.Stopper) error {
 				// Note: the jobs are cancelled by virtue of being run with a
 				// WithCancelOnQuesce context. See the resumeJob() function.
 				return
+			case <-r.drainJobs:
+				log.Warningf(ctx, "canceling all adopted jobs due to graceful drain request")
+				r.cancelAllAdoptedJobs()
+				return
 			case <-lc.timer.C:
 				lc.timer.Read = true
 				cancelLoopTask(ctx)
@@ -1087,9 +1099,14 @@ func (r *Registry) Start(ctx context.Context, stopper *stop.Stopper) error {
 			}
 		}
 	}); err != nil {
+		r.startedControllerTasksWG.Done()
 		return err
 	}
+
+	r.startedControllerTasksWG.Add(1)
 	if err := stopper.RunAsyncTask(ctx, "jobs/gc", func(ctx context.Context) {
+		defer r.startedControllerTasksWG.Done()
+
 		ctx, cancel := stopper.WithCancelOnQuiesce(ctx)
 		defer cancel()
 
@@ -1110,6 +1127,8 @@ func (r *Registry) Start(ctx context.Context, stopper *stop.Stopper) error {
 				lc.onUpdate()
 			case <-stopper.ShouldQuiesce():
 				return
+			case <-r.drainJobs:
+				return
 			case <-lc.timer.C:
 				lc.timer.Read = true
 				old := timeutil.Now().Add(-1 * retentionDuration())
@@ -1120,9 +1139,14 @@ func (r *Registry) Start(ctx context.Context, stopper *stop.Stopper) error {
 			}
 		}
 	}); err != nil {
+		r.startedControllerTasksWG.Done()
 		return err
 	}
-	return stopper.RunAsyncTask(ctx, "jobs/adopt", func(ctx context.Context) {
+
+	r.startedControllerTasksWG.Add(1)
+	if err := stopper.RunAsyncTask(ctx, "jobs/adopt", func(ctx context.Context) {
+		defer r.startedControllerTasksWG.Done()
+
 		ctx, cancel := stopper.WithCancelOnQuiesce(ctx)
 		defer cancel()
 		lc, cleanup := makeLoopController(r.settings, adoptIntervalSetting, r.knobs.IntervalOverrides.Adopt)
@@ -1132,6 +1156,8 @@ func (r *Registry) Start(ctx context.Context, stopper *stop.Stopper) error {
 			case <-lc.updated:
 				lc.onUpdate()
 			case <-stopper.ShouldQuiesce():
+				return
+			case <-r.drainJobs:
 				return
 			case shouldClaim := <-r.adoptionCh:
 				// Try to adopt the most recently created job.
@@ -1146,7 +1172,11 @@ func (r *Registry) Start(ctx context.Context, stopper *stop.Stopper) error {
 				lc.onExecute()
 			}
 		}
-	})
+	}); err != nil {
+		r.startedControllerTasksWG.Done()
+		return err
+	}
+	return nil
 }
 
 func (r *Registry) maybeCancelJobs(ctx context.Context, s sqlliveness.Session) {
@@ -1915,14 +1945,22 @@ func (r *Registry) IsDraining() bool {
 	return r.mu.draining
 }
 
+// WaitForJobShutdown(ctx context.Context) {
+func (r *Registry) WaitForRegistryShutdown(ctx context.Context) {
+	log.Infof(ctx, "starting to wait for job registry to shut down")
+	defer log.Infof(ctx, "job registry tasks successfully shut down")
+	r.startedControllerTasksWG.Wait()
+}
+
 // SetDraining informs the job system if the node is draining.
-//
-// NB: Check the implementation of drain before adding code that would
-// make this block.
-func (r *Registry) SetDraining(draining bool) {
+func (r *Registry) SetDraining() {
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	r.mu.draining = draining
+	alreadyDraining := r.mu.draining
+	r.mu.draining = true
+	if !alreadyDraining {
+		close(r.drainJobs)
+	}
 }
 
 // TestingIsJobIdle returns true if the job is adopted and currently idle.

--- a/pkg/server/drain.go
+++ b/pkg/server/drain.go
@@ -397,8 +397,15 @@ func (s *drainServer) drainClients(
 	// given sessions a chance to finish ongoing work.
 	s.sqlServer.leaseMgr.SetDraining(ctx, true /* drain */, reporter)
 
+	// Mark this phase in the logs to clarify the context of any subsequent
+	// errors/warnings, if any.
+	log.Infof(ctx, "SQL server drained successfully; SQL queries cannot execute any more")
+
 	// FIXME(Jeff): Add code here to remove the sql_instances row or
 	// something similar.
+
+	// Mark the node as fully drained.
+	s.sqlServer.gracefulDrainComplete.Set(true)
 
 	// Done. This executes the defers set above to drain SQL leases.
 	return nil

--- a/pkg/server/drain.go
+++ b/pkg/server/drain.go
@@ -381,7 +381,9 @@ func (s *drainServer) drainClients(
 	s.sqlServer.distSQLServer.Drain(ctx, queryMaxWait, reporter)
 
 	// Flush in-memory SQL stats into the statement stats system table.
-	s.sqlServer.pgServer.SQLServer.GetSQLStatsProvider().(*persistedsqlstats.PersistedSQLStats).Flush(ctx)
+	statsProvider := s.sqlServer.pgServer.SQLServer.GetSQLStatsProvider().(*persistedsqlstats.PersistedSQLStats)
+	statsProvider.Flush(ctx)
+	statsProvider.Stop(ctx)
 
 	// Inform the async tasks for table stats that the node is draining
 	// and wait for task shutdown.

--- a/pkg/server/drain.go
+++ b/pkg/server/drain.go
@@ -347,9 +347,6 @@ func (s *drainServer) drainClients(
 		s.drainSleepFn(drainWait.Get(&s.sqlServer.execCfg.Settings.SV))
 	}
 
-	// Inform the job system that the node is draining.
-	s.sqlServer.jobRegistry.SetDraining(true)
-
 	// Wait for users to close the existing SQL connections.
 	// During this phase, the server is rejecting new SQL connections.
 	// The server exits this phase either once all SQL connections are closed,
@@ -357,6 +354,15 @@ func (s *drainServer) drainClients(
 	if err := s.sqlServer.pgServer.WaitForSQLConnsToClose(ctx, connectionWait.Get(&s.sqlServer.execCfg.Settings.SV), s.stopper); err != nil {
 		return err
 	}
+
+	// Inform the job system that the node is draining.
+	//
+	// We cannot do this before SQL clients disconnect, because
+	// otherwise there is a risk that one of the remaining SQL sessions
+	// issues a BACKUP or some other job-based statement before it
+	// disconnects, and encounters a job error as a result -- that the
+	// registry is now unavailable due to the drain.
+	s.sqlServer.jobRegistry.SetDraining()
 
 	// Drain any remaining SQL connections.
 	// The queryWait duration is a timeout for waiting for SQL queries to finish.
@@ -374,9 +380,16 @@ func (s *drainServer) drainClients(
 	// Flush in-memory SQL stats into the statement stats system table.
 	s.sqlServer.pgServer.SQLServer.GetSQLStatsProvider().(*persistedsqlstats.PersistedSQLStats).Flush(ctx)
 
+	// Inform the job system that the node is draining and wait for task
+	// shutdown.
+	s.sqlServer.jobRegistry.WaitForRegistryShutdown(ctx)
+
 	// Drain all SQL table leases. This must be done after the pgServer has
 	// given sessions a chance to finish ongoing work.
 	s.sqlServer.leaseMgr.SetDraining(ctx, true /* drain */, reporter)
+
+	// FIXME(Jeff): Add code here to remove the sql_instances row or
+	// something similar.
 
 	// Done. This executes the defers set above to drain SQL leases.
 	return nil

--- a/pkg/server/server_sql.go
+++ b/pkg/server/server_sql.go
@@ -191,6 +191,11 @@ type SQLServer struct {
 	// This is set to true when the server has started accepting client conns.
 	isReady syncutil.AtomicBool
 
+	// gracefulDrainComplete indicates when a graceful drain has
+	// completed successfully. We use this to document cases where a
+	// graceful drain did _not_ occur.
+	gracefulDrainComplete syncutil.AtomicBool
+
 	// internalDBMemMonitor is the memory monitor corresponding to the
 	// InternalDB singleton. It only gets closed when
 	// Server is closed. Every Executor created via the factory
@@ -1649,6 +1654,24 @@ func (s *SQLServer) preStart(
 		s.execCfg.CaptureIndexUsageStatsKnobs,
 	)
 	s.execCfg.SyntheticPrivilegeCache.Start(ctx)
+
+	// Report a warning if the server is being shut down via the stopper
+	// before it was gracefully drained. This warning may be innocuous
+	// in tests where there is no use of the test server/cluster after
+	// shutdown; but may be a sign of a problem in production or for
+	// tests that need to restart a server.
+	stopper.AddCloser(stop.CloserFn(func() {
+		if !s.gracefulDrainComplete.Get() {
+			warnCtx := s.AnnotateCtx(context.Background())
+
+			if knobs.Server != nil && knobs.Server.(*TestingKnobs).RequireGracefulDrain {
+				log.Fatalf(warnCtx, "drain required but not performed")
+			}
+
+			log.Warningf(warnCtx, "server shutdown without a prior graceful drain")
+		}
+	}))
+
 	return nil
 }
 

--- a/pkg/server/testing_knobs.go
+++ b/pkg/server/testing_knobs.go
@@ -134,6 +134,10 @@ type TestingKnobs struct {
 	// We use clusterversion.Key rather than a roachpb.Version because it will be used
 	// to get initial values to use during bootstrap.
 	BootstrapVersionKeyOverride clusterversion.Key
+
+	// RequireGracefulDrain, if set, causes a shutdown to fail with a log.Fatal
+	// if the server is not gracefully drained prior to its stopper shutting down.
+	RequireGracefulDrain bool
 }
 
 // ModuleTestingKnobs is part of the base.ModuleTestingKnobs interface.

--- a/pkg/sql/sqlliveness/slprovider/slprovider.go
+++ b/pkg/sql/sqlliveness/slprovider/slprovider.go
@@ -43,7 +43,7 @@ func New(
 	sessionEvents slinstance.SessionEventListener,
 ) sqlliveness.Provider {
 	storage := slstorage.NewStorage(ambientCtx, stopper, clock, db, codec, settings, settingsWatcher)
-	instance := slinstance.NewSQLInstance(stopper, clock, storage, settings, testingKnobs, sessionEvents)
+	instance := slinstance.NewSQLInstance(ambientCtx, stopper, clock, storage, settings, testingKnobs, sessionEvents)
 	return &provider{
 		Storage:  storage,
 		Instance: instance,

--- a/pkg/sql/stats/automatic_stats.go
+++ b/pkg/sql/stats/automatic_stats.go
@@ -15,6 +15,7 @@ import (
 	"fmt"
 	"math"
 	"math/rand"
+	"sync"
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
@@ -242,6 +243,15 @@ type Refresher struct {
 
 	// numTablesEnsured is an internal counter for testing ensureAllTables.
 	numTablesEnsured int
+
+	// drainAutoStats is a channel that is closed when the server starts
+	// to shut down gracefully.
+	drainAutoStats chan struct{}
+	setDraining    sync.Once
+
+	// startedTasksWG is a sync group that tracks the auto-stats
+	// background tasks.
+	startedTasksWG sync.WaitGroup
 }
 
 // mutation contains metadata about a SQL mutation and is the message passed to
@@ -284,6 +294,7 @@ func MakeRefresher(
 		extraTime:        time.Duration(rand.Int63n(int64(time.Hour))),
 		mutationCounts:   make(map[descpb.ID]int64, 16),
 		settingOverrides: make(map[descpb.ID]catpb.AutoStatsSettings),
+		drainAutoStats:   make(chan struct{}),
 	}
 }
 
@@ -364,6 +375,23 @@ func (r *Refresher) getTableDescriptor(
 	return desc
 }
 
+// WaitForAutoStatsShutdown waits for all auto-stats tasks to shut down.
+func (r *Refresher) WaitForAutoStatsShutdown(ctx context.Context) {
+	log.Infof(ctx, "starting to wait for auto-stats tasks to shut down")
+	defer log.Infof(ctx, "auto-stats tasks successfully shut down")
+	r.startedTasksWG.Wait()
+}
+
+// SetDraining informs the job system if the node is draining.
+//
+// NB: Check the implementation of drain before adding code that would
+// make this block.
+func (r *Refresher) SetDraining() {
+	r.setDraining.Do(func() {
+		close(r.drainAutoStats)
+	})
+}
+
 // Start starts the stats refresher thread, which polls for messages about
 // new SQL mutations and refreshes the table statistics with probability
 // proportional to the percentage of rows affected.
@@ -371,7 +399,10 @@ func (r *Refresher) Start(
 	ctx context.Context, stopper *stop.Stopper, refreshInterval time.Duration,
 ) error {
 	bgCtx := r.AnnotateCtx(context.Background())
-	_ = stopper.RunAsyncTask(bgCtx, "refresher", func(ctx context.Context) {
+	r.startedTasksWG.Add(1)
+	if err := stopper.RunAsyncTask(bgCtx, "refresher", func(ctx context.Context) {
+		defer r.startedTasksWG.Done()
+
 		// We always sleep for r.asOfTime at the beginning of each refresh, so
 		// subtract it from the refreshInterval.
 		refreshInterval -= r.asOfTime
@@ -416,8 +447,11 @@ func (r *Refresher) Start(
 					}
 				}
 
+				r.startedTasksWG.Add(1)
 				if err := stopper.RunAsyncTask(
 					ctx, "stats.Refresher: maybeRefreshStats", func(ctx context.Context) {
+						defer r.startedTasksWG.Done()
+
 						// Record the start time of processing this batch of tables.
 						start := timeutil.Now()
 
@@ -428,6 +462,8 @@ func (r *Refresher) Start(
 						select {
 						case <-timerAsOf.C:
 							break
+						case <-r.drainAutoStats:
+							return
 						case <-stopper.ShouldQuiesce():
 							return
 						}
@@ -470,19 +506,23 @@ func (r *Refresher) Start(
 									explicitSettings = &settings
 								}
 							}
-							r.maybeRefreshStats(ctx, tableID, explicitSettings, rowsAffected, r.asOfTime)
+							r.maybeRefreshStats(ctx, stopper, tableID, explicitSettings, rowsAffected, r.asOfTime)
 
 							select {
 							case <-stopper.ShouldQuiesce():
 								// Don't bother trying to refresh the remaining tables if we
 								// are shutting down.
 								return
+							case <-r.drainAutoStats:
+								// Ditto.
+								return
 							default:
 							}
 						}
 						timer.Reset(refreshInterval)
 					}); err != nil {
-					log.Errorf(ctx, "failed to refresh stats: %v", err)
+					r.startedTasksWG.Done()
+					log.Errorf(ctx, "failed to start async stats task: %v", err)
 				}
 				// This clears out any tables that may have been added to the
 				// mutationCounts map by ensureAllTables and any mutation counts that
@@ -503,12 +543,18 @@ func (r *Refresher) Start(
 			case clusterSettingOverride := <-r.settings:
 				r.settingOverrides[clusterSettingOverride.tableID] = clusterSettingOverride.settings
 
+			case <-r.drainAutoStats:
+				log.Infof(ctx, "draining auto stats refresher")
+				return
 			case <-stopper.ShouldQuiesce():
 				log.Info(ctx, "quiescing auto stats refresher")
 				return
 			}
 		}
-	})
+	}); err != nil {
+		r.startedTasksWG.Done()
+		log.Warningf(ctx, "refresher task failed to start: %v", err)
+	}
 	return nil
 }
 
@@ -676,6 +722,7 @@ func (r *Refresher) NotifyMutation(table catalog.TableDescriptor, rowsAffected i
 // for this table.
 func (r *Refresher) maybeRefreshStats(
 	ctx context.Context,
+	stopper *stop.Stopper,
 	tableID descpb.ID,
 	explicitSettings *catpb.AutoStatsSettings,
 	rowsAffected int64,
@@ -734,6 +781,7 @@ func (r *Refresher) maybeRefreshStats(
 		if errors.Is(err, ConcurrentCreateStatsError) {
 			// Another stats job was already running. Attempt to reschedule this
 			// refresh.
+			var newEvent mutation
 			if mustRefresh {
 				// For the cases where mustRefresh=true (stats don't yet exist or it
 				// has been 2x the average time since a refresh), we want to make sure
@@ -741,16 +789,29 @@ func (r *Refresher) maybeRefreshStats(
 				// cycle so that we have another chance to trigger a refresh. We pass
 				// rowsAffected=0 so that we don't force a refresh if another node has
 				// already done it.
-				r.mutations <- mutation{tableID: tableID, rowsAffected: 0}
+				newEvent = mutation{tableID: tableID, rowsAffected: 0}
 			} else {
 				// If this refresh was caused by a "dice roll", we want to make sure
 				// that the refresh is rescheduled so that we adhere to the
 				// AutomaticStatisticsFractionStaleRows statistical ideal. We
 				// ensure that the refresh is triggered during the next cycle by
 				// passing a very large number for rowsAffected.
-				r.mutations <- mutation{tableID: tableID, rowsAffected: math.MaxInt32}
+				newEvent = mutation{tableID: tableID, rowsAffected: math.MaxInt32}
 			}
-			return
+			select {
+			case r.mutations <- newEvent:
+				return
+			case <-r.drainAutoStats:
+				// Shutting down due to a graceful drain.
+				// We don't want to force a write to the mutations here
+				// otherwise we could block the graceful shutdown.
+				err = errors.New("server is shutting down")
+			case <-stopper.ShouldQuiesce():
+				// Shutting down due to direct stopper Stop call.
+				// This is not strictly required for correctness but
+				// helps avoiding log spam.
+				err = errors.New("server is shutting down")
+			}
 		}
 
 		// Log other errors but don't automatically reschedule the refresh, since


### PR DESCRIPTION
Needed for #99941 and #99958.
Epic: CRDB-23559

See individual commits for details.