### PR TITLE
sql: add table storage params to set histogram samples and buckets count

### DIFF
--- a/pkg/sql/catalog/descpb/structured.proto
+++ b/pkg/sql/catalog/descpb/structured.proto
@@ -1170,11 +1170,21 @@ message TableDescriptor {
   // this table, in which case the global setting is used.
   optional bool forecast_stats = 52 [(gogoproto.nullable) = true, (gogoproto.customname) = "ForecastStats"];
 
+  // HistogramSamples indicates the number of rows to sample when building a
+  // histogram for this table. It is null if unset for this table, in which case
+  // the global setting is used.
+  optional uint32 histogram_samples = 56 [(gogoproto.nullable) = true, (gogoproto.customname) = "HistogramSamples"];
+
+  // HistogramBuckets indicates the number of buckets to build when constructing
+  // a histogram for this table. It is null if unset for this table, in which
+  // case the global setting is used.
+  optional uint32 histogram_buckets = 57 [(gogoproto.nullable) = true, (gogoproto.customname) = "HistogramBuckets"];
+
   // ImportStartWallTime contains the start wall time of an in-progress import.
   // This field is non zero if this table is offline during an import.
   optional int64 import_start_wall_time = 54 [(gogoproto.nullable) = false, (gogoproto.customname) = "ImportStartWallTime"];
 
-  // Next ID: 56
+  // Next ID: 58
 }
 
 // SurvivalGoal is the survival goal for a database.

--- a/pkg/sql/catalog/descriptor.go
+++ b/pkg/sql/catalog/descriptor.go
@@ -722,6 +722,15 @@ type TableDescriptor interface {
 	// enabled or disabled for this table. If ok is true, then the enabled value
 	// is valid, otherwise this has not been set at the table level.
 	ForecastStatsEnabled() (enabled bool, ok bool)
+	// HistogramSamplesCount indicates the number of rows to sample when building
+	// a histogram for this table. If ok is true, then the histogramSamplesCount
+	// value is valid, otherwise this has not been set at the table level.
+	HistogramSamplesCount() (histogramSamplesCount uint32, ok bool)
+	// HistogramBucketsCount indicates the number of buckets to build when
+	// constructing a histogram for this table. If ok is true, then the
+	// histogramBucketsCount value is valid, otherwise this has not been set at
+	// the table level.
+	HistogramBucketsCount() (histogramBucketsCount uint32, ok bool)
 	// IsRefreshViewRequired indicates if a REFRESH VIEW operation needs to be called
 	// on a materialized view.
 	IsRefreshViewRequired() bool

--- a/pkg/sql/catalog/tabledesc/structured.go
+++ b/pkg/sql/catalog/tabledesc/structured.go
@@ -2415,6 +2415,12 @@ func (desc *wrapper) GetStorageParams(spaceBetweenEqual bool) []string {
 	if enabled, ok := desc.ForecastStatsEnabled(); ok {
 		appendStorageParam(`sql_stats_forecasts_enabled`, strconv.FormatBool(enabled))
 	}
+	if count, ok := desc.HistogramSamplesCount(); ok {
+		appendStorageParam(`sql_stats_histogram_samples_count`, fmt.Sprintf("%d", count))
+	}
+	if count, ok := desc.HistogramBucketsCount(); ok {
+		appendStorageParam(`sql_stats_histogram_buckets_count`, fmt.Sprintf("%d", count))
+	}
 	return storageParams
 }
 
@@ -2476,6 +2482,22 @@ func (desc *wrapper) ForecastStatsEnabled() (enabled bool, ok bool) {
 		return false, false
 	}
 	return *desc.ForecastStats, true
+}
+
+// HistogramSamplesCount implements the TableDescriptor interface.
+func (desc *wrapper) HistogramSamplesCount() (histogramSamplesCount uint32, ok bool) {
+	if desc.HistogramSamples == nil {
+		return 0, false
+	}
+	return *desc.HistogramSamples, true
+}
+
+// HistogramBucketsCount implements the TableDescriptor interface.
+func (desc *wrapper) HistogramBucketsCount() (histogramBucketsCount uint32, ok bool) {
+	if desc.HistogramBuckets == nil {
+		return 0, false
+	}
+	return *desc.HistogramBuckets, true
 }
 
 // SetTableLocalityRegionalByTable sets the descriptor's locality config to

--- a/pkg/sql/catalog/tabledesc/validate_test.go
+++ b/pkg/sql/catalog/tabledesc/validate_test.go
@@ -135,6 +135,8 @@ var validationMap = []struct {
 			"AutoStatsSettings":             {status: iSolemnlySwearThisFieldIsValidated},
 			"ForecastStats":                 {status: thisFieldReferencesNoObjects},
 			"ImportStartWallTime":           {status: thisFieldReferencesNoObjects},
+			"HistogramBuckets":              {status: thisFieldReferencesNoObjects},
+			"HistogramSamples":              {status: thisFieldReferencesNoObjects},
 		},
 	},
 	{

--- a/pkg/sql/create_stats.go
+++ b/pkg/sql/create_stats.go
@@ -272,7 +272,7 @@ func (n *createStatsNode) makeJobRecord(ctx context.Context) (*jobs.Record, erro
 			multiColEnabled = stats.MultiColumnStatisticsClusterMode.Get(&n.p.ExecCfg().Settings.SV)
 			deleteOtherStats = true
 		}
-		defaultHistogramBuckets := uint32(stats.DefaultHistogramBuckets.Get(n.p.ExecCfg().SV()))
+		defaultHistogramBuckets := stats.GetDefaultHistogramBuckets(n.p.ExecCfg().SV(), tableDesc)
 		if colStats, err = createStatsDefaultColumns(
 			tableDesc, multiColEnabled, defaultHistogramBuckets,
 		); err != nil {
@@ -303,7 +303,7 @@ func (n *createStatsNode) makeJobRecord(ctx context.Context) (*jobs.Record, erro
 		// STATISTICS or other SQL on table_statistics.
 		_ = stats.MakeSortedColStatKey(columnIDs)
 		isInvIndex := colinfo.ColumnTypeIsOnlyInvertedIndexable(col.GetType())
-		defaultHistogramBuckets := uint32(stats.DefaultHistogramBuckets.Get(n.p.ExecCfg().SV()))
+		defaultHistogramBuckets := stats.GetDefaultHistogramBuckets(n.p.ExecCfg().SV(), tableDesc)
 		colStats = []jobspb.CreateStatsDetails_ColStat{{
 			ColumnIDs: columnIDs,
 			// By default, create histograms on all explicitly requested column stats

--- a/pkg/sql/importer/import_job.go
+++ b/pkg/sql/importer/import_job.go
@@ -1036,7 +1036,7 @@ func (r *importResumer) writeStubStatisticsForImportedTables(
 			// single-column stats to avoid the appearance of perfectly correlated
 			// columns.
 			multiColEnabled := false
-			defaultHistogramBuckets := uint32(stats.DefaultHistogramBuckets.Get(execCfg.SV()))
+			defaultHistogramBuckets := stats.GetDefaultHistogramBuckets(execCfg.SV(), desc)
 			statistics, err := sql.StubTableStats(
 				desc, jobspb.ImportStatsName, multiColEnabled, defaultHistogramBuckets,
 			)

--- a/pkg/sql/logictest/testdata/logic_test/distsql_stats
+++ b/pkg/sql/logictest/testdata/logic_test/distsql_stats
@@ -123,7 +123,7 @@ SHOW STATISTICS USING JSON FOR TABLE data
 
 # Verify that we can control the number of samples and buckets collected.
 statement ok
-SET CLUSTER SETTING sql.stats.histogram_buckets.count = 3
+SET CLUSTER SETTING sql.stats.histogram_buckets.count = 2
 
 statement ok
 CREATE STATISTICS s2 ON a FROM data
@@ -136,8 +136,28 @@ SHOW HISTOGRAM $hist_id_2
 ----
 upper_bound  range_rows  distinct_range_rows  equal_rows
 1            0           0                    64
+4            128         2                    64
+
+# We can also control this with a table setting.
+statement ok
+ALTER TABLE data SET (sql_stats_histogram_buckets_count = 3)
+
+statement ok
+CREATE STATISTICS s3 ON a FROM data
+
+let $hist_id_3
+SELECT histogram_id FROM [SHOW STATISTICS FOR TABLE data] WHERE statistics_name = 's3'
+
+query TIRI colnames
+SHOW HISTOGRAM $hist_id_3
+----
+upper_bound  range_rows  distinct_range_rows  equal_rows
+1            0           0                    64
 3            64          1                    64
 4            0           0                    64
+
+statement ok
+ALTER TABLE data RESET (sql_stats_histogram_buckets_count)
 
 # We can verify the number of samples collected based on the number of
 # buckets produced.
@@ -162,8 +182,9 @@ SELECT count(*) FROM [SHOW HISTOGRAM $hist_id_20000]
 ----
 20000
 
+# We can also control this with a table setting.
 statement ok
-SET CLUSTER SETTING sql.stats.histogram_samples.count = 500
+ALTER TABLE big SET (sql_stats_histogram_samples_count = 500)
 
 statement ok
 CREATE STATISTICS s500 FROM big

--- a/pkg/sql/stats/histogram.go
+++ b/pkg/sql/stats/histogram.go
@@ -17,6 +17,7 @@ import (
 	"strings"
 
 	"github.com/cockroachdb/cockroach/pkg/settings"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/cat"
 	"github.com/cockroachdb/cockroach/pkg/sql/rowenc/keyside"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
@@ -75,6 +76,15 @@ Please add new entries at the top.
   omitted on Version 0 histograms.
 
 */
+
+// GetDefaultHistogramBuckets gets the default number of histogram buckets to
+// create for the given table.
+func GetDefaultHistogramBuckets(sv *settings.Values, desc catalog.TableDescriptor) uint32 {
+	if count, ok := desc.HistogramBucketsCount(); ok {
+		return count
+	}
+	return uint32(DefaultHistogramBuckets.Get(sv))
+}
 
 // EquiDepthHistogram creates a histogram where each bucket contains roughly
 // the same number of samples (though it can vary when a boundary value has

--- a/pkg/sql/storageparam/tablestorageparam/table_storage_param.go
+++ b/pkg/sql/storageparam/tablestorageparam/table_storage_param.go
@@ -14,6 +14,7 @@ package tablestorageparam
 
 import (
 	"context"
+	"math"
 	"strings"
 
 	"github.com/cockroachdb/cockroach/pkg/settings"
@@ -478,6 +479,46 @@ var tableParams = map[string]tableParam{
 		},
 		onReset: func(_ context.Context, po *Setter, evalCtx *eval.Context, key string) error {
 			po.TableDesc.ForecastStats = nil
+			return nil
+		},
+	},
+	`sql_stats_histogram_samples_count`: {
+		onSet: func(
+			ctx context.Context, po *Setter, semaCtx *tree.SemaContext, evalCtx *eval.Context, key string, datum tree.Datum,
+		) error {
+			intVal, err := intFromDatum(ctx, evalCtx, key, datum)
+			if err != nil {
+				return err
+			}
+			if err = settings.NonNegativeIntWithMaximum(math.MaxUint32)(intVal); err != nil {
+				return errors.Wrapf(err, "invalid integer value for %s", key)
+			}
+			uint32Val := uint32(intVal)
+			po.TableDesc.HistogramSamples = &uint32Val
+			return nil
+		},
+		onReset: func(_ context.Context, po *Setter, evalCtx *eval.Context, key string) error {
+			po.TableDesc.HistogramSamples = nil
+			return nil
+		},
+	},
+	`sql_stats_histogram_buckets_count`: {
+		onSet: func(
+			ctx context.Context, po *Setter, semaCtx *tree.SemaContext, evalCtx *eval.Context, key string, datum tree.Datum,
+		) error {
+			intVal, err := intFromDatum(ctx, evalCtx, key, datum)
+			if err != nil {
+				return err
+			}
+			if err = settings.NonNegativeIntWithMaximum(math.MaxUint32)(intVal); err != nil {
+				return errors.Wrapf(err, "invalid integer value for %s", key)
+			}
+			uint32Val := uint32(intVal)
+			po.TableDesc.HistogramBuckets = &uint32Val
+			return nil
+		},
+		onReset: func(_ context.Context, po *Setter, evalCtx *eval.Context, key string) error {
+			po.TableDesc.HistogramBuckets = nil
 			return nil
 		},
 	},


### PR DESCRIPTION
Fixes #72418
Informs #97701

Release note (sql change): Added two new table storage parameters,
`sql_stats_histogram_buckets_count` and `sql_stats_histogram_samples_count`.
These parameters can be used to override the cluster settings
`sql.stats.histogram_buckets.count` and `sql.stats.histogram_samples.count`
at the table level. These settings enable users to change the number of
histogram samples and buckets collected when building histograms as part
of table statistics collection. While the default values should work for
most cases, it may be beneficial to increase the number of samples and
buckets for very large tables to avoid creating a histogram that misses
important values.
