### PR TITLE
ci: more logging for `github-pull-request-make` if query fails

### DIFF
--- a/build/bazelutil/nogo_config.json
+++ b/build/bazelutil/nogo_config.json
@@ -46,6 +46,7 @@
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
             "cockroach/pkg/.*_generated\\.go$": "generated code",
+            "cockroach/pkg/cmd/github-pull-request-make/main.go": "invalid direct cast on error object",
             "cockroach/pkg/kv/kvclient/kvcoord/lock_spans_over_budget_error\\.go$": "invalid direct cast on error object",
             "cockroach/pkg/kv/kvpb/batch_generated-gen\\.go$": "invalid direct cast on error object",
             "cockroach/pkg/kv/kvpb/errors\\.go$": "invalid direct cast on error object",

--- a/pkg/cmd/github-pull-request-make/main.go
+++ b/pkg/cmd/github-pull-request-make/main.go
@@ -250,7 +250,11 @@ func main() {
 					if err == nil {
 						break
 					} else {
-						fmt.Printf("bazel query failed; got output %s\n", string(out))
+						var stderr []byte
+						if exitErr, ok := err.(*exec.ExitError); ok {
+							stderr = exitErr.Stderr
+						}
+						fmt.Printf("bazel query over pkg %s failed; got stdout %s, stderr %s\n", name, string(out), string(stderr))
 						if tries == 3 {
 							log.Fatal(err)
 						}


### PR DESCRIPTION
Epic: none
Release note: None