### PR TITLE
kvserver: expose LSM snapshot storage-engine timeseries metrics

### DIFF
--- a/pkg/ts/catalog/chart_catalog.go
+++ b/pkg/ts/catalog/chart_catalog.go
@@ -3112,6 +3112,14 @@ var charts = []sectionDescription{
 				Title:   "Tombstone Count",
 				Metrics: []string{"storage.keys.tombstone.count"},
 			},
+			{
+				Title:   "Pinned Keys Written",
+				Metrics: []string{"storage.compactions.keys.pinned.count"},
+			},
+			{
+				Title:   "Pinned Key Bytes Written",
+				Metrics: []string{"storage.compactions.keys.pinned.bytes"},
+			},
 		},
 	},
 	{


### PR DESCRIPTION
Expose two new storage-engine metrics that provide visibility into LSM snapshots. These two new metrics record cumulative count and size of obsolete keys written to sstables during flushes and compactions.

Epic: None
Release note (ops change): Expose two new timeseries metrics `storage.compactions.keys.pinned.count` and
`storage.compactions.keys.pinned.bytes` providing some observability into the volume of keys preserved by open LSM snapshots.

Informs cockroachdb/pebble#1204.