### PR TITLE
release-22.2: sql: parallelize FK and UNIQUE constraints

### DIFF
--- a/pkg/ccl/backupccl/backup_processor_planning.go
+++ b/pkg/ccl/backupccl/backup_processor_planning.go
@@ -183,7 +183,7 @@ func distBackup(
 	p.AddNoInputStage(corePlacement, execinfrapb.PostProcessSpec{}, []*types.T{}, execinfrapb.Ordering{})
 	p.PlanToStreamColMap = []int{}
 
-	dsp.FinalizePlan(planCtx, p)
+	sql.FinalizePlan(planCtx, p)
 
 	metaFn := func(_ context.Context, meta *execinfrapb.ProducerMetadata) error {
 		if meta.BulkProcessorProgress != nil {

--- a/pkg/ccl/backupccl/restore_processor_planning.go
+++ b/pkg/ccl/backupccl/restore_processor_planning.go
@@ -229,7 +229,7 @@ func distRestore(
 			}
 		}
 
-		dsp.FinalizePlan(planCtx, p)
+		sql.FinalizePlan(planCtx, p)
 		return p, planCtx, nil
 	}
 

--- a/pkg/ccl/changefeedccl/changefeed_dist.go
+++ b/pkg/ccl/changefeedccl/changefeed_dist.go
@@ -433,7 +433,7 @@ func makePlan(
 		)
 
 		p.PlanToStreamColMap = []int{1, 2, 3}
-		dsp.FinalizePlan(planCtx, p)
+		sql.FinalizePlan(planCtx, p)
 
 		return p, planCtx, nil
 	}

--- a/pkg/ccl/streamingccl/streamingest/stream_ingestion_processor_planning.go
+++ b/pkg/ccl/streamingccl/streamingest/stream_ingestion_processor_planning.go
@@ -135,7 +135,7 @@ func distStreamIngest(
 		execinfrapb.PostProcessSpec{}, streamIngestionResultTypes)
 
 	p.PlanToStreamColMap = []int{0}
-	dsp.FinalizePlan(planCtx, p)
+	sql.FinalizePlan(planCtx, p)
 
 	rw := sql.NewRowResultWriter(nil /* rowContainer */)
 

--- a/pkg/cloud/cloudcheck/cloudcheck_stmt.go
+++ b/pkg/cloud/cloudcheck/cloudcheck_stmt.go
@@ -79,7 +79,7 @@ func ShowCloudStorageTestPlanHook(
 		for i := range plan.PlanToStreamColMap {
 			plan.PlanToStreamColMap[i] = i
 		}
-		dsp.FinalizePlan(planCtx, plan)
+		sql.FinalizePlan(planCtx, plan)
 
 		rateFromDatums := func(bytes tree.Datum, nanos tree.Datum) string {
 			return string(humanizeutil.DataRate(int64(tree.MustBeDInt(bytes)), time.Duration(tree.MustBeDInt(nanos))))

--- a/pkg/kv/txn.go
+++ b/pkg/kv/txn.go
@@ -1026,7 +1026,8 @@ func (txn *Txn) PrepareForRetry(ctx context.Context) {
 	}
 	log.VEventf(ctx, 2, "retrying transaction: %s because of a retryable error: %s",
 		txn.debugNameLocked(), retryErr)
-	txn.handleRetryableErrLocked(ctx, retryErr)
+	txn.resetDeadlineLocked()
+	txn.replaceRootSenderIfTxnAbortedLocked(ctx, retryErr, retryErr.TxnID)
 }
 
 // IsRetryableErrMeantForTxn returns true if err is a retryable
@@ -1104,13 +1105,6 @@ func (txn *Txn) Send(
 		}
 	}
 	return br, pErr
-}
-
-func (txn *Txn) handleRetryableErrLocked(
-	ctx context.Context, retryErr *roachpb.TransactionRetryWithProtoRefreshError,
-) {
-	txn.resetDeadlineLocked()
-	txn.replaceRootSenderIfTxnAbortedLocked(ctx, retryErr, retryErr.TxnID)
 }
 
 // NegotiateAndSend is a specialized version of Send that is capable of
@@ -1284,10 +1278,11 @@ func (txn *Txn) GetLeafTxnInputState(ctx context.Context) *roachpb.LeafTxnInputS
 
 // GetLeafTxnInputStateOrRejectClient is like GetLeafTxnInputState
 // except, if the transaction is already aborted or otherwise in state
-// that cannot make progress, it returns an error. If the transaction
-// is aborted, the error will be a retryable one, and the transaction
-// will have been prepared for another transaction attempt (so, on
-// retryable errors, it acts like Send()).
+// that cannot make progress, it returns an error. If the transaction aborted
+// the error returned will be a retryable one; as such, the caller is
+// responsible for handling the error before another attempt by calling
+// PrepareForRetry. Use of the transaction before doing so will continue to be
+// rejected.
 func (txn *Txn) GetLeafTxnInputStateOrRejectClient(
 	ctx context.Context,
 ) (*roachpb.LeafTxnInputState, error) {
@@ -1300,10 +1295,6 @@ func (txn *Txn) GetLeafTxnInputStateOrRejectClient(
 	defer txn.mu.Unlock()
 	tfs, err := txn.mu.sender.GetLeafTxnInputState(ctx, OnlyPending)
 	if err != nil {
-		var retryErr *roachpb.TransactionRetryWithProtoRefreshError
-		if errors.As(err, &retryErr) {
-			txn.handleRetryableErrLocked(ctx, retryErr)
-		}
 		return nil, err
 	}
 	return tfs, nil
@@ -1371,8 +1362,6 @@ func (txn *Txn) UpdateStateOnRemoteRetryableErr(ctx context.Context, pErr *roach
 	}
 
 	pErr = txn.mu.sender.UpdateStateOnRemoteRetryableErr(ctx, pErr)
-	txn.replaceRootSenderIfTxnAbortedLocked(ctx, pErr.GetDetail().(*roachpb.TransactionRetryWithProtoRefreshError), origTxnID)
-
 	return pErr.GoError()
 }
 
@@ -1382,6 +1371,11 @@ func (txn *Txn) UpdateStateOnRemoteRetryableErr(ctx context.Context, pErr *roach
 //
 // origTxnID is the id of the txn that generated retryErr. Note that this can be
 // different from retryErr.Transaction - the latter might be a new transaction.
+//
+// TODO(arul): Now that we only expect this to happen on the PrepareForRetry
+// path, by design, should we just inline this function? Some of the handling
+// of non-aborted transactions in this function feels a bit out of place with
+// the new code structure.
 func (txn *Txn) replaceRootSenderIfTxnAbortedLocked(
 	ctx context.Context, retryErr *roachpb.TransactionRetryWithProtoRefreshError, origTxnID uuid.UUID,
 ) {

--- a/pkg/roachpb/data.go
+++ b/pkg/roachpb/data.go
@@ -1507,6 +1507,13 @@ func PrepareTransactionForRetry(
 	case *WriteTooOldError:
 		// Increase the timestamp to the ts at which we've actually written.
 		txn.WriteTimestamp.Forward(tErr.RetryTimestamp())
+	case *IntentMissingError:
+		// IntentMissingErrors are not expected to be handled at this level;
+		// We instead expect the txnPipeliner to transform them into a
+		// TransactionRetryErrors(RETRY_ASYNC_WRITE_FAILURE) error.
+		log.Fatalf(
+			ctx, "unexpected intent missing error (%T); should be transformed into retry error", pErr.GetDetail(),
+		)
 	default:
 		log.Fatalf(ctx, "invalid retryable err (%T): %s", pErr.GetDetail(), pErr)
 	}

--- a/pkg/sql/apply_join.go
+++ b/pkg/sql/apply_join.go
@@ -321,7 +321,8 @@ func runPlanInsidePlan(
 	evalCtx := params.p.ExtendedEvalContextCopy()
 	plannerCopy := *params.p
 	distributePlan := getPlanDistribution(
-		ctx, &plannerCopy, plannerCopy.execCfg.NodeInfo.NodeID, plannerCopy.SessionData().DistSQLMode, plan.main,
+		ctx, plannerCopy.Descriptors().HasUncommittedTypes(),
+		plannerCopy.SessionData().DistSQLMode, plan.main,
 	)
 	distributeType := DistributionType(DistributionTypeNone)
 	if distributePlan.WillDistribute() {

--- a/pkg/sql/apply_join.go
+++ b/pkg/sql/apply_join.go
@@ -257,7 +257,7 @@ func (a *applyJoinNode) runNextRightSideIteration(params runParams, leftRow tree
 	if err := runPlanInsidePlan(ctx, params, plan, rowResultWriter); err != nil {
 		return err
 	}
-	a.run.rightRowsIterator = newRowContainerIterator(ctx, a.run.rightRows, a.rightTypes)
+	a.run.rightRowsIterator = newRowContainerIterator(ctx, a.run.rightRows)
 	return nil
 }
 

--- a/pkg/sql/buffer.go
+++ b/pkg/sql/buffer.go
@@ -81,7 +81,7 @@ type scanBufferNode struct {
 }
 
 func (n *scanBufferNode) startExec(params runParams) error {
-	n.iterator = newRowContainerIterator(params.ctx, n.buffer.rows, n.buffer.typs)
+	n.iterator = newRowContainerIterator(params.ctx, n.buffer.rows)
 	return nil
 }
 

--- a/pkg/sql/buffer.go
+++ b/pkg/sql/buffer.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
+	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/redact"
 )
 
@@ -71,6 +72,12 @@ func (n *bufferNode) Close(ctx context.Context) {
 // referencing. The bufferNode can be iterated over multiple times
 // simultaneously, however, a new scanBufferNode is needed.
 type scanBufferNode struct {
+	// mu, if non-nil, protects access to buffer as well as creation and closure
+	// of iterator (rowcontainer.RowIterator which is wrapped by
+	// rowContainerIterator is safe for concurrent usage outside of creation and
+	// closure).
+	mu *syncutil.Mutex
+
 	buffer *bufferNode
 
 	iterator   *rowContainerIterator
@@ -80,7 +87,17 @@ type scanBufferNode struct {
 	label string
 }
 
+// makeConcurrencySafe can be called to synchronize access to bufferNode across
+// scanBufferNodes that run in parallel.
+func (n *scanBufferNode) makeConcurrencySafe(mu *syncutil.Mutex) {
+	n.mu = mu
+}
+
 func (n *scanBufferNode) startExec(params runParams) error {
+	if n.mu != nil {
+		n.mu.Lock()
+		defer n.mu.Unlock()
+	}
 	n.iterator = newRowContainerIterator(params.ctx, n.buffer.rows)
 	return nil
 }
@@ -99,6 +116,10 @@ func (n *scanBufferNode) Values() tree.Datums {
 }
 
 func (n *scanBufferNode) Close(context.Context) {
+	if n.mu != nil {
+		n.mu.Lock()
+		defer n.mu.Unlock()
+	}
 	if n.iterator != nil {
 		n.iterator.Close()
 		n.iterator = nil

--- a/pkg/sql/buffer_util.go
+++ b/pkg/sql/buffer_util.go
@@ -135,22 +135,12 @@ func (c *rowContainerHelper) Close(ctx context.Context) {
 // tree.Datums.
 type rowContainerIterator struct {
 	iter rowcontainer.RowIterator
-
-	typs   []*types.T
-	datums tree.Datums
-	da     tree.DatumAlloc
 }
 
 // newRowContainerIterator returns a new rowContainerIterator that must be
 // closed once no longer needed.
-func newRowContainerIterator(
-	ctx context.Context, c rowContainerHelper, typs []*types.T,
-) *rowContainerIterator {
-	i := &rowContainerIterator{
-		iter:   c.rows.NewIterator(ctx),
-		typs:   typs,
-		datums: make(tree.Datums, len(typs)),
-	}
+func newRowContainerIterator(ctx context.Context, c rowContainerHelper) *rowContainerIterator {
+	i := &rowContainerIterator{iter: c.rows.NewIterator(ctx)}
 	i.iter.Rewind()
 	return i
 }
@@ -169,10 +159,7 @@ func (i *rowContainerIterator) Next() (tree.Datums, error) {
 	if err != nil {
 		return nil, err
 	}
-	if err = rowenc.EncDatumRowToDatums(i.typs, i.datums, row, &i.da); err != nil {
-		return nil, err
-	}
-	return i.datums, nil
+	return row, nil
 }
 
 func (i *rowContainerIterator) Close() {

--- a/pkg/sql/catalog/descs/collection.go
+++ b/pkg/sql/catalog/descs/collection.go
@@ -162,6 +162,11 @@ func (tc *Collection) ResetMaxTimestampBound() {
 	tc.maxTimestampBoundDeadlineHolder.maxTimestampBound = hlc.Timestamp{}
 }
 
+// GetMaxTimestampBound returns the maximum timestamp to read schemas at.
+func (tc *Collection) GetMaxTimestampBound() hlc.Timestamp {
+	return tc.maxTimestampBoundDeadlineHolder.maxTimestampBound
+}
+
 // SkipValidationOnWrite avoids validating stored descriptors prior to
 // a transaction commit.
 func (tc *Collection) SkipValidationOnWrite() {

--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -2969,6 +2969,8 @@ func (ex *connExecutor) initEvalCtx(ctx context.Context, evalCtx *extendedEvalCo
 // return for statements executed with this evalCtx. Since generally each
 // statement is supposed to have a different timestamp, the evalCtx generally
 // shouldn't be reused across statements.
+//
+// Safe for concurrent use.
 func (ex *connExecutor) resetEvalCtx(evalCtx *extendedEvalContext, txn *kv.Txn, stmtTS time.Time) {
 	newTxn := txn == nil || evalCtx.Txn != txn
 	evalCtx.TxnState = ex.getTransactionState()
@@ -2993,22 +2995,12 @@ func (ex *connExecutor) resetEvalCtx(evalCtx *extendedEvalContext, txn *kv.Txn, 
 	evalCtx.SchemaChangerState = ex.extraTxnState.schemaChangerState
 	evalCtx.DescIDGenerator = ex.getDescIDGenerator()
 
-	// If we are retrying due to an unsatisfiable timestamp bound which is
-	// retriable, it means we were unable to serve the previous minimum timestamp
-	// as there was a schema update in between. When retrying, we want to keep the
-	// same minimum timestamp for the AOST read, but set the maximum timestamp
-	// to the point just before our failed read to ensure we don't try to read
-	// data which may be after the schema change when we retry.
+	// See resetPlanner for more context on setting the maximum timestamp for
+	// AOST read retries.
 	var minTSErr *roachpb.MinTimestampBoundUnsatisfiableError
 	if err := ex.state.mu.autoRetryReason; err != nil && errors.As(err, &minTSErr) {
-		nextMax := minTSErr.MinTimestampBound
-		ex.extraTxnState.descCollection.SetMaxTimestampBound(nextMax)
-		evalCtx.AsOfSystemTime.MaxTimestampBound = nextMax
+		evalCtx.AsOfSystemTime.MaxTimestampBound = ex.extraTxnState.descCollection.GetMaxTimestampBound()
 	} else if newTxn {
-		// Otherwise, only change the historical timestamps if this is a new txn.
-		// This is because resetPlanner can be called multiple times for the same
-		// txn during the extended protocol.
-		ex.extraTxnState.descCollection.ResetMaxTimestampBound()
 		evalCtx.AsOfSystemTime = nil
 	}
 }
@@ -3054,6 +3046,22 @@ func (ex *connExecutor) resetPlanner(
 	ctx context.Context, p *planner, txn *kv.Txn, stmtTS time.Time,
 ) {
 	p.resetPlanner(ctx, txn, stmtTS, ex.sessionData())
+	// If we are retrying due to an unsatisfiable timestamp bound which is
+	// retriable, it means we were unable to serve the previous minimum timestamp
+	// as there was a schema update in between. When retrying, we want to keep the
+	// same minimum timestamp for the AOST read, but set the maximum timestamp
+	// to the point just before our failed read to ensure we don't try to read
+	// data which may be after the schema change when we retry.
+	var minTSErr *roachpb.MinTimestampBoundUnsatisfiableError
+	if err := ex.state.mu.autoRetryReason; err != nil && errors.As(err, &minTSErr) {
+		nextMax := minTSErr.MinTimestampBound
+		ex.extraTxnState.descCollection.SetMaxTimestampBound(nextMax)
+	} else if newTxn := txn == nil || p.extendedEvalCtx.Txn != txn; newTxn {
+		// Otherwise, only change the historical timestamps if this is a new txn.
+		// This is because resetPlanner can be called multiple times for the same
+		// txn during the extended protocol.
+		ex.extraTxnState.descCollection.ResetMaxTimestampBound()
+	}
 	ex.resetEvalCtx(&p.extendedEvalCtx, txn, stmtTS)
 }
 

--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -1567,19 +1567,23 @@ func (ex *connExecutor) execWithDistSQLEngine(
 	} else if planner.instrumentation.ShouldSaveFlows() {
 		planCtx.saveFlows = planCtx.getDefaultSaveFlowsFunc(ctx, planner, planComponentTypeMainQuery)
 	}
-	planCtx.traceMetadata = planner.instrumentation.traceMetadata
+	planCtx.associateNodeWithComponents = planner.instrumentation.getAssociateNodeWithComponentsFn()
 	planCtx.collectExecStats = planner.instrumentation.ShouldCollectExecStats()
 
-	var evalCtxFactory func() *extendedEvalContext
+	var evalCtxFactory func(usedConcurrently bool) *extendedEvalContext
 	if len(planner.curPlan.subqueryPlans) != 0 ||
 		len(planner.curPlan.cascades) != 0 ||
 		len(planner.curPlan.checkPlans) != 0 {
-		// The factory reuses the same object because the contexts are not used
-		// concurrently.
-		var factoryEvalCtx extendedEvalContext
-		ex.initEvalCtx(ctx, &factoryEvalCtx, planner)
-		evalCtxFactory = func() *extendedEvalContext {
-			ex.resetEvalCtx(&factoryEvalCtx, planner.txn, planner.ExtendedEvalContext().StmtTimestamp)
+		var serialEvalCtx extendedEvalContext
+		ex.initEvalCtx(ctx, &serialEvalCtx, planner)
+		evalCtxFactory = func(usedConcurrently bool) *extendedEvalContext {
+			// Reuse the same object if this factory is not used concurrently.
+			factoryEvalCtx := &serialEvalCtx
+			if usedConcurrently {
+				factoryEvalCtx = &extendedEvalContext{}
+				ex.initEvalCtx(ctx, factoryEvalCtx, planner)
+			}
+			ex.resetEvalCtx(factoryEvalCtx, planner.txn, planner.ExtendedEvalContext().StmtTimestamp)
 			factoryEvalCtx.Placeholders = &planner.semaCtx.Placeholders
 			factoryEvalCtx.Annotations = &planner.semaCtx.Annotations
 			factoryEvalCtx.SessionID = planner.ExtendedEvalContext().SessionID
@@ -1587,7 +1591,7 @@ func (ex *connExecutor) execWithDistSQLEngine(
 			// same one.
 			// TODO(radu): consider removing this if/when #46164 is addressed.
 			factoryEvalCtx.Context = evalCtx.Context
-			return &factoryEvalCtx
+			return factoryEvalCtx
 		}
 	}
 	err := ex.server.cfg.DistSQLPlanner.PlanAndRunAll(ctx, evalCtx, planCtx, planner, recv, evalCtxFactory)

--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -1133,7 +1133,8 @@ func (ex *connExecutor) dispatchToExecutionEngine(
 
 	ex.sessionTracing.TracePlanCheckStart(ctx)
 	distributePlan := getPlanDistribution(
-		ctx, planner, planner.execCfg.NodeInfo.NodeID, ex.sessionData().DistSQLMode, planner.curPlan.main,
+		ctx, planner.Descriptors().HasUncommittedTypes(),
+		ex.sessionData().DistSQLMode, planner.curPlan.main,
 	)
 	ex.sessionTracing.TracePlanCheckEnd(ctx, nil, distributePlan.WillDistribute())
 
@@ -1519,6 +1520,13 @@ type topLevelQueryStats struct {
 	networkEgressEstimate int64
 }
 
+func (s *topLevelQueryStats) add(other *topLevelQueryStats) {
+	s.bytesRead += other.bytesRead
+	s.rowsRead += other.rowsRead
+	s.rowsWritten += other.rowsWritten
+	s.networkEgressEstimate += other.networkEgressEstimate
+}
+
 // execWithDistSQLEngine converts a plan to a distributed SQL physical plan and
 // runs it.
 // If an error is returned, the connection needs to stop processing queries.
@@ -1583,7 +1591,7 @@ func (ex *connExecutor) execWithDistSQLEngine(
 		}
 	}
 	err := ex.server.cfg.DistSQLPlanner.PlanAndRunAll(ctx, evalCtx, planCtx, planner, recv, evalCtxFactory)
-	return *recv.stats, err
+	return recv.stats, err
 }
 
 // beginTransactionTimestampsAndReadMode computes the timestamps and

--- a/pkg/sql/distsql_physical_planner.go
+++ b/pkg/sql/distsql_physical_planner.go
@@ -38,6 +38,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfra/execopnode"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/execstats"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/exec"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/physicalplan"
@@ -117,6 +118,10 @@ type DistSQLPlanner struct {
 	// additional goroutines that can be used to run concurrent TableReaders
 	// for the same stage of the fully local physical plans.
 	parallelLocalScansSem *quotapool.IntPool
+	// parallelChecksSem is a node-wide semaphore on the number of additional
+	// goroutines that can be used to run check postqueries (FK and UNIQUE
+	// constraint checks) in parallel.
+	parallelChecksSem *quotapool.IntPool
 
 	// distSender is used to construct the spanResolver upon SetSQLInstanceInfo.
 	distSender *kvcoord.DistSender
@@ -205,9 +210,15 @@ func NewDistSQLPlanner(
 	localScansConcurrencyLimit.SetOnChange(&st.SV, func(ctx context.Context) {
 		dsp.parallelLocalScansSem.UpdateCapacity(uint64(localScansConcurrencyLimit.Get(&st.SV)))
 	})
+	dsp.parallelChecksSem = quotapool.NewIntPool("parallel checks concurrency",
+		uint64(parallelChecksConcurrencyLimit.Get(&st.SV)))
+	parallelChecksConcurrencyLimit.SetOnChange(&st.SV, func(ctx context.Context) {
+		dsp.parallelChecksSem.UpdateCapacity(uint64(parallelChecksConcurrencyLimit.Get(&st.SV)))
+	})
 	if rpcCtx != nil {
 		// rpcCtx might be nil in some tests.
 		rpcCtx.Stopper.AddCloser(dsp.parallelLocalScansSem.Closer("stopper"))
+		rpcCtx.Stopper.AddCloser(dsp.parallelChecksSem.Closer("stopper"))
 	}
 
 	dsp.runnerCoordinator.init(ctx, stopper, &st.SV)
@@ -779,7 +790,7 @@ type PlanningCtx struct {
 
 	// If set, we will record the mapping from planNode to tracing metadata to
 	// later allow associating statistics with the planNode.
-	traceMetadata execNodeTraceMetadata
+	associateNodeWithComponents func(exec.Node, execComponents)
 
 	// If set, statement execution stats should be collected.
 	collectExecStats bool
@@ -836,7 +847,7 @@ func (p *PlanningCtx) IsLocal() bool {
 }
 
 // getDefaultSaveFlowsFunc returns the default function used to save physical
-// plans and their diagrams.
+// plans and their diagrams. The returned function is **not** concurrency-safe.
 func (p *PlanningCtx) getDefaultSaveFlowsFunc(
 	ctx context.Context, planner *planner, typ planComponentType,
 ) func(map[base.SQLInstanceID]*execinfrapb.FlowSpec, execopnode.OpChains, bool) error {
@@ -3271,7 +3282,7 @@ func (dsp *DistSQLPlanner) createPhysPlanForPlanNode(
 		return plan, err
 	}
 
-	if planCtx.traceMetadata != nil {
+	if planCtx.associateNodeWithComponents != nil {
 		processors := make(execComponents, len(plan.ResultRouters))
 		for i, resultProcIdx := range plan.ResultRouters {
 			processors[i] = execinfrapb.ProcessorComponentID(
@@ -3280,7 +3291,7 @@ func (dsp *DistSQLPlanner) createPhysPlanForPlanNode(
 				int32(resultProcIdx),
 			)
 		}
-		planCtx.traceMetadata.associateNodeWithComponents(node, processors)
+		planCtx.associateNodeWithComponents(node, processors)
 	}
 
 	return plan, err

--- a/pkg/sql/distsql_physical_planner.go
+++ b/pkg/sql/distsql_physical_planner.go
@@ -775,7 +775,7 @@ type PlanningCtx struct {
 
 	// If set, the flows for the physical plan will be passed to this function.
 	// The flows are not safe for use past the lifetime of the saveFlows function.
-	saveFlows func(map[base.SQLInstanceID]*execinfrapb.FlowSpec, execopnode.OpChains) error
+	saveFlows func(_ map[base.SQLInstanceID]*execinfrapb.FlowSpec, _ execopnode.OpChains, vectorized bool) error
 
 	// If set, we will record the mapping from planNode to tracing metadata to
 	// later allow associating statistics with the planNode.
@@ -790,6 +790,10 @@ type PlanningCtx struct {
 	// plan (which prohibit all concurrency) and whether all parts of the plan
 	// are supported natively by the vectorized engine.
 	parallelizeScansIfLocal bool
+
+	// Set if this is either a subquery or a postquery (i.e. not the "main"
+	// query).
+	subOrPostQuery bool
 
 	// mustUseLeafTxn, if set, indicates that this PlanningCtx is used to handle
 	// one of the plans that will run in parallel with other plans. As such, the
@@ -835,8 +839,8 @@ func (p *PlanningCtx) IsLocal() bool {
 // plans and their diagrams.
 func (p *PlanningCtx) getDefaultSaveFlowsFunc(
 	ctx context.Context, planner *planner, typ planComponentType,
-) func(map[base.SQLInstanceID]*execinfrapb.FlowSpec, execopnode.OpChains) error {
-	return func(flows map[base.SQLInstanceID]*execinfrapb.FlowSpec, opChains execopnode.OpChains) error {
+) func(map[base.SQLInstanceID]*execinfrapb.FlowSpec, execopnode.OpChains, bool) error {
+	return func(flows map[base.SQLInstanceID]*execinfrapb.FlowSpec, opChains execopnode.OpChains, vectorized bool) error {
 		var diagram execinfrapb.FlowDiagram
 		if planner.instrumentation.shouldSaveDiagrams() {
 			diagramFlags := execinfrapb.DiagramFlags{
@@ -850,7 +854,7 @@ func (p *PlanningCtx) getDefaultSaveFlowsFunc(
 		}
 		var explainVec []string
 		var explainVecVerbose []string
-		if planner.instrumentation.collectBundle && planner.curPlan.flags.IsSet(planFlagVectorized) {
+		if planner.instrumentation.collectBundle && vectorized {
 			flowCtx := newFlowCtxForExplainPurposes(p, planner)
 			getExplain := func(verbose bool) []string {
 				explain, cleanup, err := colflow.ExplainVec(
@@ -863,7 +867,7 @@ func (p *PlanningCtx) getDefaultSaveFlowsFunc(
 					// In some edge cases (like when subqueries are present or
 					// when certain component doesn't implement execopnode.OpNode
 					// interface) an error might occur. In such scenario, we
-					// don't want to fail the collection of the bundle, so we
+					// don't want to fail the collection of the bundle, so we're
 					// deliberately ignoring the error.
 					explain = nil
 				}
@@ -4333,17 +4337,15 @@ func maybeMoveSingleFlowToGateway(planCtx *PlanningCtx, plan *PhysicalPlan, rowC
 
 // FinalizePlan adds a final "result" stage and a final projection if necessary
 // as well as populates the endpoints of the plan.
-func (dsp *DistSQLPlanner) FinalizePlan(planCtx *PlanningCtx, plan *PhysicalPlan) {
-	dsp.finalizePlanWithRowCount(planCtx, plan, -1 /* rowCount */)
+func FinalizePlan(planCtx *PlanningCtx, plan *PhysicalPlan) {
+	finalizePlanWithRowCount(planCtx, plan, -1 /* rowCount */)
 }
 
 // finalizePlanWithRowCount adds a final "result" stage and a final projection
 // if necessary as well as populates the endpoints of the plan.
 // - rowCount is the estimated number of rows that the plan outputs. Use a
 // negative number if the stats were not available to make an estimate.
-func (dsp *DistSQLPlanner) finalizePlanWithRowCount(
-	planCtx *PlanningCtx, plan *PhysicalPlan, rowCount int64,
-) {
+func finalizePlanWithRowCount(planCtx *PlanningCtx, plan *PhysicalPlan, rowCount int64) {
 	maybeMoveSingleFlowToGateway(planCtx, plan, rowCount)
 
 	// Add a final "result" stage if necessary.

--- a/pkg/sql/distsql_plan_backfill.go
+++ b/pkg/sql/distsql_plan_backfill.go
@@ -106,7 +106,7 @@ func (dsp *DistSQLPlanner) createBackfillerPhysicalPlan(
 		pIdx := p.AddProcessor(proc)
 		p.ResultRouters[i] = pIdx
 	}
-	dsp.FinalizePlan(planCtx, p)
+	FinalizePlan(planCtx, p)
 	return p, nil
 }
 
@@ -178,7 +178,7 @@ func (dsp *DistSQLPlanner) createIndexBackfillerMergePhysicalPlan(
 		pIdx := p.AddProcessor(proc)
 		p.ResultRouters[i] = pIdx
 	}
-	dsp.FinalizePlan(planCtx, p)
+	FinalizePlan(planCtx, p)
 	return p, nil
 }
 

--- a/pkg/sql/distsql_plan_ctas.go
+++ b/pkg/sql/distsql_plan_ctas.go
@@ -54,7 +54,7 @@ func PlanAndRunCTAS(
 
 	// Make copy of evalCtx as Run might modify it.
 	evalCtxCopy := planner.ExtendedEvalContextCopy()
-	dsp.FinalizePlan(planCtx, physPlan)
+	FinalizePlan(planCtx, physPlan)
 	finishedSetupFn, cleanup := getFinishedSetupFn(planner)
 	defer cleanup()
 	dsp.Run(ctx, planCtx, txn, physPlan, recv, evalCtxCopy, finishedSetupFn)()

--- a/pkg/sql/distsql_plan_stats.go
+++ b/pkg/sql/distsql_plan_stats.go
@@ -292,7 +292,7 @@ func (dsp *DistSQLPlanner) planAndRunCreateStats(
 		return err
 	}
 
-	dsp.FinalizePlan(planCtx, physPlan)
+	FinalizePlan(planCtx, physPlan)
 
 	recv := MakeDistSQLReceiver(
 		ctx,

--- a/pkg/sql/distsql_running.go
+++ b/pkg/sql/distsql_running.go
@@ -1620,7 +1620,7 @@ func (dsp *DistSQLPlanner) planAndRunSubquery(
 		// TODO(yuzefovich): this is unfortunate - we're materializing all
 		// buffered rows into a single tuple kept in memory. Refactor it.
 		var result tree.DTuple
-		iterator := newRowContainerIterator(ctx, rows, typs)
+		iterator := newRowContainerIterator(ctx, rows)
 		defer iterator.Close()
 		for {
 			row, err := iterator.Next()
@@ -1665,7 +1665,7 @@ func (dsp *DistSQLPlanner) planAndRunSubquery(
 		case 0:
 			subqueryPlans[planIdx].result = tree.DNull
 		case 1:
-			iterator := newRowContainerIterator(ctx, rows, typs)
+			iterator := newRowContainerIterator(ctx, rows)
 			defer iterator.Close()
 			row, err := iterator.Next()
 			if err != nil {

--- a/pkg/sql/distsql_running.go
+++ b/pkg/sql/distsql_running.go
@@ -37,6 +37,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfra/execopnode"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/flowinfra"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/exec"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/physicalplan"
@@ -1439,7 +1440,7 @@ func (dsp *DistSQLPlanner) PlanAndRunAll(
 	planCtx *PlanningCtx,
 	planner *planner,
 	recv *DistSQLReceiver,
-	evalCtxFactory func() *extendedEvalContext,
+	evalCtxFactory func(usedConcurrently bool) *extendedEvalContext,
 ) error {
 	if len(planner.curPlan.subqueryPlans) != 0 {
 		// Create a separate memory account for the results of the subqueries.
@@ -1448,7 +1449,12 @@ func (dsp *DistSQLPlanner) PlanAndRunAll(
 		subqueryResultMemAcc := planner.EvalContext().Mon.MakeBoundAccount()
 		defer subqueryResultMemAcc.Close(ctx)
 		if !dsp.PlanAndRunSubqueries(
-			ctx, planner, evalCtxFactory, planner.curPlan.subqueryPlans, recv, &subqueryResultMemAcc,
+			ctx,
+			planner,
+			func() *extendedEvalContext { return evalCtxFactory(false /* usedConcurrently */) },
+			planner.curPlan.subqueryPlans,
+			recv,
+			&subqueryResultMemAcc,
 			// Skip the diagram generation since on this "main" query path we
 			// can get it via the statement bundle.
 			true,  /* skipDistSQLDiagramGeneration */
@@ -1574,7 +1580,7 @@ func (dsp *DistSQLPlanner) planAndRunSubquery(
 	if planner.instrumentation.ShouldSaveFlows() {
 		subqueryPlanCtx.saveFlows = subqueryPlanCtx.getDefaultSaveFlowsFunc(ctx, planner, planComponentTypeSubquery)
 	}
-	subqueryPlanCtx.traceMetadata = planner.instrumentation.traceMetadata
+	subqueryPlanCtx.associateNodeWithComponents = planner.instrumentation.getAssociateNodeWithComponentsFn()
 	subqueryPlanCtx.collectExecStats = planner.instrumentation.ShouldCollectExecStats()
 	// Don't close the top-level plan from subqueries - someone else will handle
 	// that.
@@ -1766,7 +1772,7 @@ func (dsp *DistSQLPlanner) PlanAndRun(
 func (dsp *DistSQLPlanner) PlanAndRunCascadesAndChecks(
 	ctx context.Context,
 	planner *planner,
-	evalCtxFactory func() *extendedEvalContext,
+	evalCtxFactory func(usedConcurrently bool) *extendedEvalContext,
 	plan *planComponents,
 	recv *DistSQLReceiver,
 ) bool {
@@ -1776,6 +1782,10 @@ func (dsp *DistSQLPlanner) PlanAndRunCascadesAndChecks(
 
 	prevSteppingMode := planner.Txn().ConfigureStepping(ctx, kv.SteppingEnabled)
 	defer func() { _ = planner.Txn().ConfigureStepping(ctx, prevSteppingMode) }()
+
+	defaultGetSaveFlowsFunc := func(postqueryPlanCtx *PlanningCtx) func(map[base.SQLInstanceID]*execinfrapb.FlowSpec, execopnode.OpChains, bool) error {
+		return postqueryPlanCtx.getDefaultSaveFlowsFunc(ctx, planner, planComponentTypePostquery)
+	}
 
 	// We treat plan.cascades as a queue.
 	for i := 0; i < len(plan.cascades); i++ {
@@ -1808,7 +1818,7 @@ func (dsp *DistSQLPlanner) PlanAndRunCascadesAndChecks(
 			return false
 		}
 
-		evalCtx := evalCtxFactory()
+		evalCtx := evalCtxFactory(false /* usedConcurrently */)
 		execFactory := newExecFactory(planner)
 		// The cascading query is allowed to autocommit only if it is the last
 		// cascade and there are no check queries to run.
@@ -1857,6 +1867,10 @@ func (dsp *DistSQLPlanner) PlanAndRunCascadesAndChecks(
 			planner,
 			evalCtx,
 			recv,
+			false, /* parallelCheck */
+			defaultGetSaveFlowsFunc,
+			planner.instrumentation.getAssociateNodeWithComponentsFn(),
+			recv.stats.add,
 		); err != nil {
 			recv.SetError(err)
 			return false
@@ -1878,30 +1892,95 @@ func (dsp *DistSQLPlanner) PlanAndRunCascadesAndChecks(
 		return false
 	}
 
-	for i := range plan.checkPlans {
-		log.VEventf(ctx, 2, "executing check query %d out of %d", i+1, len(plan.checkPlans))
-		if err := dsp.planAndRunPostquery(
-			ctx,
-			plan.checkPlans[i].plan,
-			planner,
-			evalCtxFactory(),
-			recv,
-		); err != nil {
+	// We'll run the checks in parallel if the parallelization is enabled, we
+	// have multiple checks to run, and we're likely to have quota to do so.
+	runParallelChecks := parallelizeChecks.Get(&dsp.st.SV) &&
+		len(plan.checkPlans) > 1 &&
+		dsp.parallelChecksSem.ApproximateQuota() > 0
+	if runParallelChecks {
+		// At the moment, we rely on not using the newer DistSQL spec factory to
+		// enable parallelization.
+		// TODO(yuzefovich): the planObserver logic in
+		// planAndRunChecksInParallel will need to be adjusted when we switch to
+		// using the DistSQL spec factory.
+		for i := range plan.checkPlans {
+			if plan.checkPlans[i].plan.isPhysicalPlan() {
+				runParallelChecks = false
+				break
+			}
+		}
+	}
+	if runParallelChecks {
+		if err := dsp.planAndRunChecksInParallel(ctx, plan.checkPlans, planner, evalCtxFactory, recv); err != nil {
 			recv.SetError(err)
 			return false
+		}
+	} else {
+		if len(plan.checkPlans) > 1 {
+			log.VEventf(ctx, 2, "executing %d checks serially", len(plan.checkPlans))
+		}
+		for i := range plan.checkPlans {
+			log.VEventf(ctx, 2, "executing check query %d out of %d", i+1, len(plan.checkPlans))
+			if err := dsp.planAndRunPostquery(
+				ctx,
+				plan.checkPlans[i].plan,
+				planner,
+				evalCtxFactory(false /* usedConcurrently */),
+				recv,
+				false, /* parallelCheck */
+				defaultGetSaveFlowsFunc,
+				planner.instrumentation.getAssociateNodeWithComponentsFn(),
+				recv.stats.add,
+			); err != nil {
+				recv.SetError(err)
+				return false
+			}
 		}
 	}
 
 	return true
 }
 
-// planAndRunPostquery runs a cascade or check query.
+var parallelizeChecks = settings.RegisterBoolSetting(
+	settings.TenantWritable,
+	"sql.distsql.parallelize_checks.enabled",
+	"determines whether FOREIGN KEY and UNIQUE constraint checks are performed in parallel",
+	false,
+)
+
+// parallelChecksConcurrencyLimit controls the maximum number of additional
+// goroutines that can be used to run checks in parallel.
+var parallelChecksConcurrencyLimit = settings.RegisterIntSetting(
+	settings.TenantWritable,
+	"sql.distsql.parallelize_checks.concurrency_limit",
+	"maximum number of additional goroutines to run checks in parallel",
+	// The default here is picked somewhat arbitrarily - the thinking is that we
+	// want it to be proportional to the number of CPUs we have, yet this limit
+	// should probably be smaller than kvcoord.senderConcurrencyLimit (which is
+	// 64 x CPUs).
+	int64(16*runtime.GOMAXPROCS(0)),
+	settings.NonNegativeInt,
+)
+
+// planAndRunPostquery runs a cascade or check query. Can be safe for concurrent
+// use if parallelCheck is true.
+//
+// - parallelCheck indicates whether this is a check query that runs in parallel
+// with other check queries. If parallelCheck is true, then getSaveFlowsFunc,
+// associateNodeWithComponents, and addTopLevelQueryStats must be
+// concurrency-safe (if non-nil).
+// - getSaveFlowsFunc will only be called if
+// planner.instrumentation.ShouldSaveFlows() returns true.
 func (dsp *DistSQLPlanner) planAndRunPostquery(
 	ctx context.Context,
 	postqueryPlan planMaybePhysical,
 	planner *planner,
 	evalCtx *extendedEvalContext,
 	recv *DistSQLReceiver,
+	parallelCheck bool,
+	getSaveFlowsFunc func(postqueryPlanCtx *PlanningCtx) func(map[base.SQLInstanceID]*execinfrapb.FlowSpec, execopnode.OpChains, bool) error,
+	associateNodeWithComponents func(exec.Node, execComponents),
+	addTopLevelQueryStats func(stats *topLevelQueryStats),
 ) error {
 	postqueryMonitor := mon.NewMonitor(
 		"postquery",
@@ -1934,10 +2013,11 @@ func (dsp *DistSQLPlanner) planAndRunPostquery(
 	postqueryPlanCtx.skipDistSQLDiagramGeneration = true
 	postqueryPlanCtx.subOrPostQuery = true
 	if planner.instrumentation.ShouldSaveFlows() {
-		postqueryPlanCtx.saveFlows = postqueryPlanCtx.getDefaultSaveFlowsFunc(ctx, planner, planComponentTypePostquery)
+		postqueryPlanCtx.saveFlows = getSaveFlowsFunc(postqueryPlanCtx)
 	}
-	postqueryPlanCtx.traceMetadata = planner.instrumentation.traceMetadata
+	postqueryPlanCtx.associateNodeWithComponents = associateNodeWithComponents
 	postqueryPlanCtx.collectExecStats = planner.instrumentation.ShouldCollectExecStats()
+	postqueryPlanCtx.mustUseLeafTxn = parallelCheck
 
 	postqueryPhysPlan, physPlanCleanup, err := dsp.createPhysPlan(ctx, postqueryPlanCtx, postqueryPlan)
 	defer physPlanCleanup()
@@ -1948,9 +2028,7 @@ func (dsp *DistSQLPlanner) planAndRunPostquery(
 
 	postqueryRecv := recv.clone()
 	defer postqueryRecv.Release()
-	defer recv.stats.add(&postqueryRecv.stats)
-	// TODO(yuzefovich): at the moment, errOnlyResultWriter is sufficient here,
-	// but it may not be the case when we support cascades through the optimizer.
+	defer addTopLevelQueryStats(&postqueryRecv.stats)
 	postqueryResultWriter := &errOnlyResultWriter{}
 	postqueryRecv.resultWriter = postqueryResultWriter
 	postqueryRecv.batchWriter = postqueryResultWriter
@@ -1958,4 +2036,161 @@ func (dsp *DistSQLPlanner) planAndRunPostquery(
 	defer cleanup()
 	dsp.Run(ctx, postqueryPlanCtx, planner.txn, postqueryPhysPlan, postqueryRecv, evalCtx, finishedSetupFn)()
 	return postqueryRecv.resultWriter.Err()
+}
+
+// planAndRunChecksInParallel executes all checkPlans in parallel. The function
+// blocks until all checks that start executing return (i.e. when this function
+// returns, it is guaranteed that the txn is no longer used by the checks).
+//
+// Note that it is assumed that all check plans use the old planNode
+// representation.
+func (dsp *DistSQLPlanner) planAndRunChecksInParallel(
+	ctx context.Context,
+	checkPlans []checkPlan,
+	planner *planner,
+	evalCtxFactory func(usedConcurrently bool) *extendedEvalContext,
+	recv *DistSQLReceiver,
+) error {
+	ctx, cancelCtx := context.WithCancel(ctx)
+	defer cancelCtx()
+
+	// We need to synchronize many operations for the parallel checks, and we
+	// use a single mutex for that. This seems acceptable given that these
+	// operations are pretty quick and occur at different points throughout the
+	// checks' execution, so there should be effectively no mutex contention.
+	var mu syncutil.Mutex
+	// For parallel checks we must make all `scanBufferNode`s in the plans
+	// concurrency-safe. (The need to be able to walk the planNode tree is why
+	// we currently disable the usage of the new DistSQL spec factory.)
+	observer := planObserver{
+		enterNode: func(_ context.Context, _ string, plan planNode) (bool, error) {
+			if s, ok := plan.(*scanBufferNode); ok {
+				s.makeConcurrencySafe(&mu)
+			}
+			return true, nil
+		},
+	}
+	for i := range checkPlans {
+		if checkPlans[i].plan.isPhysicalPlan() {
+			return errors.AssertionFailedf("unexpectedly physical plan is used for a parallel CHECK")
+		}
+		// Ignore the error since our observer never returns an error.
+		_ = walkPlan(
+			ctx,
+			checkPlans[i].plan.planNode,
+			observer,
+		)
+	}
+	var getSaveFlowsFunc func(postqueryPlanCtx *PlanningCtx) func(map[base.SQLInstanceID]*execinfrapb.FlowSpec, execopnode.OpChains, bool) error
+	if planner.instrumentation.ShouldSaveFlows() {
+		// getDefaultSaveFlowsFunc returns a concurrency-unsafe function, so we
+		// need to explicitly protect calls to it. Allocate this function only
+		// when necessary.
+		getSaveFlowsFunc = func(postqueryPlanCtx *PlanningCtx) func(map[base.SQLInstanceID]*execinfrapb.FlowSpec, execopnode.OpChains, bool) error {
+			fn := postqueryPlanCtx.getDefaultSaveFlowsFunc(ctx, planner, planComponentTypePostquery)
+			return func(flowSpec map[base.SQLInstanceID]*execinfrapb.FlowSpec, opChains execopnode.OpChains, vectorized bool) error {
+				mu.Lock()
+				defer mu.Unlock()
+				return fn(flowSpec, opChains, vectorized)
+			}
+		}
+	}
+	var associateNodeWithComponents func(exec.Node, execComponents)
+	if fn := planner.instrumentation.getAssociateNodeWithComponentsFn(); fn != nil {
+		// Since fn is not safe for concurrent use, we have to introduce the
+		// synchronization on top of it.
+		associateNodeWithComponents = func(node exec.Node, components execComponents) {
+			mu.Lock()
+			defer mu.Unlock()
+			fn(node, components)
+		}
+	}
+	// addTopLevelQueryStats is always allocated since it runs unconditionally
+	// at the end of the postquery execution.
+	addTopLevelQueryStats := func(other *topLevelQueryStats) {
+		mu.Lock()
+		defer mu.Unlock()
+		recv.stats.add(other)
+	}
+
+	// We track errors according to the corresponding check plans. This is
+	// needed in order to return the error for the "earliest" plan (which makes
+	// the tests deterministic when multiple checks fail).
+	errs := make([]error, len(checkPlans))
+	runCheck := func(ctx context.Context, checkPlanIdx int) {
+		log.VEventf(ctx, 3, "begin check %d", checkPlanIdx)
+		errs[checkPlanIdx] = dsp.planAndRunPostquery(
+			ctx, checkPlans[checkPlanIdx].plan,
+			planner,
+			evalCtxFactory(true /* usedConcurrently */),
+			recv,
+			true, /* parallelCheck */
+			getSaveFlowsFunc,
+			associateNodeWithComponents,
+			addTopLevelQueryStats,
+		)
+		log.VEventf(ctx, 3, "end check %d", checkPlanIdx)
+	}
+
+	// Determine the concurrency we're allowed to use based on the node-wide
+	// semaphore. We will always run at least one check in the current
+	// goroutine.
+	numParallelChecks := len(checkPlans) - 1
+	if quota := int(dsp.parallelChecksSem.ApproximateQuota()); numParallelChecks > quota {
+		numParallelChecks = quota
+	}
+	for numParallelChecks > 0 {
+		alloc, err := dsp.parallelLocalScansSem.TryAcquire(ctx, uint64(numParallelChecks))
+		if err == nil {
+			defer alloc.Release()
+			break
+		}
+		numParallelChecks--
+	}
+
+	log.VEventf(ctx, 2, "executing %d checks concurrently and %d checks serially", numParallelChecks, len(checkPlans)-numParallelChecks)
+
+	// Set up a wait group so that the main (current) goroutine can block until
+	// all concurrent checks return. We cannot short-circuit if one of the
+	// checks results in a quick error in order to let all the planning infra
+	// cleanup to be performed for each check, before we attempt to clean up the
+	// whole plan.
+	var wg sync.WaitGroup
+	// Execute first numParallelChecks concurrently.
+	for i := range checkPlans[:numParallelChecks] {
+		checkPlanIdx := i
+		wg.Add(1)
+		if err := dsp.stopper.RunAsyncTaskEx(
+			ctx,
+			stop.TaskOpts{
+				TaskName: "parallel-check-runner",
+				SpanOpt:  stop.ChildSpan,
+			},
+			func(ctx context.Context) {
+				defer wg.Done()
+				runCheck(ctx, checkPlanIdx)
+			}); err != nil {
+			// The server is quiescing, so we just make sure to wait for all
+			// already started checks to complete after canceling them.
+			cancelCtx()
+			// The task didn't start, so it won't be able to decrement the wait
+			// group.
+			wg.Done()
+			wg.Wait()
+			return err
+		}
+	}
+	// Execute all other checks serially in the current goroutine.
+	for checkPlanIdx := numParallelChecks; checkPlanIdx < len(checkPlans); checkPlanIdx++ {
+		runCheck(ctx, checkPlanIdx)
+	}
+	// Wait for all concurrent checks to complete and return the error from the
+	// earliest check (if there were any errors).
+	wg.Wait()
+	for _, err := range errs {
+		if err != nil {
+			return err
+		}
+	}
+	return nil
 }

--- a/pkg/sql/distsql_running.go
+++ b/pkg/sql/distsql_running.go
@@ -482,6 +482,7 @@ func (dsp *DistSQLPlanner) setupFlows(
 }
 
 const clientRejectedMsg string = "client rejected when attempting to run DistSQL plan"
+const executingParallelAndSerialChecks = "executing %d checks concurrently and %d checks serially"
 
 // Run executes a physical plan. The plan should have been finalized using
 // FinalizePlan.
@@ -1478,6 +1479,12 @@ func (dsp *DistSQLPlanner) PlanAndRunAll(
 		return recv.commErr
 	}
 
+	if knobs := evalCtx.ExecCfg.DistSQLRunTestingKnobs; knobs != nil {
+		if fn := knobs.RunBeforeCascadesAndChecks; fn != nil {
+			fn(planner.Txn().ID())
+		}
+	}
+
 	dsp.PlanAndRunCascadesAndChecks(
 		ctx, planner, evalCtxFactory, &planner.curPlan.planComponents, recv,
 	)
@@ -2148,7 +2155,9 @@ func (dsp *DistSQLPlanner) planAndRunChecksInParallel(
 		numParallelChecks--
 	}
 
-	log.VEventf(ctx, 2, "executing %d checks concurrently and %d checks serially", numParallelChecks, len(checkPlans)-numParallelChecks)
+	log.VEventf(
+		ctx, 2, executingParallelAndSerialChecks, numParallelChecks, len(checkPlans)-numParallelChecks,
+	)
 
 	// Set up a wait group so that the main (current) goroutine can block until
 	// all concurrent checks return. We cannot short-circuit if one of the

--- a/pkg/sql/distsql_running_test.go
+++ b/pkg/sql/distsql_running_test.go
@@ -716,3 +716,67 @@ func TestDistSQLRunnerCoordinator(t *testing.T) {
 	// Now bump it up to 100.
 	checkNumRunners(100)
 }
+
+// TestDistSQLPlannerParallelChecks can be used to stress the behavior of
+// postquery checks when they run in parallel.
+func TestDistSQLPlannerParallelChecks(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+	s, db, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	defer s.Stopper().Stop(ctx)
+	rng, _ := randutil.NewTestRand()
+
+	sqlDB := sqlutils.MakeSQLRunner(db)
+	// Set up a child table with two foreign keys into two parent tables.
+	sqlDB.Exec(t, `CREATE TABLE parent1 (id1 INT8 PRIMARY KEY)`)
+	sqlDB.Exec(t, `CREATE TABLE parent2 (id2 INT8 PRIMARY KEY)`)
+	sqlDB.Exec(t, `
+CREATE TABLE child (
+    id INT8 PRIMARY KEY, parent_id1 INT8 NOT NULL, parent_id2 INT8 NOT NULL,
+    FOREIGN KEY (parent_id1) REFERENCES parent1 (id1),
+    FOREIGN KEY (parent_id2) REFERENCES parent2 (id2)
+);`)
+	// Disable the insert fast path in order for the foreign key checks to be
+	// planned as parallel postqueries.
+	sqlDB.Exec(t, `SET enable_insert_fast_path = false`)
+	if rng.Float64() < 0.1 {
+		// In 10% of the cases, set a very low workmem limit in order to force
+		// the bufferNode to spill to disk.
+		sqlDB.Exec(t, `SET distsql_workmem = '1KiB'`)
+	}
+
+	const numIDs = 1000
+	for id := 0; id < numIDs; id++ {
+		sqlDB.Exec(t, `INSERT INTO parent1 VALUES ($1)`, id)
+		sqlDB.Exec(t, `INSERT INTO parent2 VALUES ($1)`, id)
+		var prefix string
+		if rng.Float64() < 0.5 {
+			// In 50% of the cases, run the INSERT query with FK checks via
+			// EXPLAIN ANALYZE (or EXPLAIN ANALYZE (DEBUG)) in order to exercise
+			// the planning code paths that are only taken when the tracing is
+			// enabled.
+			prefix = "EXPLAIN ANALYZE "
+			if rng.Float64() < 0.02 {
+				// Run DEBUG flavor only in 1% of all cases since it is
+				// noticeably slower.
+				prefix = "EXPLAIN ANALYZE (DEBUG) "
+			}
+		}
+		if rng.Float64() < 0.1 {
+			// In 10% of the cases, run the INSERT that results in an error (we
+			// don't have any negative ids in the parent tables).
+			invalidID := -1
+			// The FK violation occurs for both FKs, but we expect that the
+			// error for parent_id1 is always chosen.
+			sqlDB.ExpectErr(
+				t,
+				`insert on table "child" violates foreign key constraint "child_parent_id1_fkey"`,
+				fmt.Sprintf(`%[1]sINSERT INTO child VALUES (%[2]d, %[2]d, %[2]d)`, prefix, invalidID),
+			)
+			continue
+		}
+		sqlDB.Exec(t, fmt.Sprintf(`%[1]sINSERT INTO child VALUES (%[2]d, %[2]d, %[2]d)`, prefix, id))
+	}
+}

--- a/pkg/sql/distsql_running_test.go
+++ b/pkg/sql/distsql_running_test.go
@@ -41,6 +41,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
+	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 	"github.com/cockroachdb/datadriven"
@@ -192,6 +193,204 @@ func TestDistSQLRunningInAbortedTxn(t *testing.T) {
 	}
 	if tracing.FindMsgInRecording(getRecAndFinish(), clientRejectedMsg) == -1 {
 		t.Fatalf("didn't find expected message in trace: %s", clientRejectedMsg)
+	}
+}
+
+// TestDistSQLRunningParallelFKChecksAfterAbort simulates a SQL transaction
+// that writes two rows required to validate a FK check and then proceeds to
+// write a third row that would actually trigger this check. The transaction is
+// aborted after the third row is written but before the FK check is performed.
+// We assert that this construction doesn't throw a FK violation; instead, the
+// transaction should be able to retry.
+// This test serves as a regression test for the hazard identified in
+// https://github.com/cockroachdb/cockroach/issues/97141.
+func TestDistSQLRunningParallelFKChecksAfterAbort(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+	mu := struct {
+		syncutil.Mutex
+		abortTxn func(uuid uuid.UUID)
+	}{}
+
+	s, conn, db := serverutils.StartServer(t, base.TestServerArgs{
+		Knobs: base.TestingKnobs{
+			DistSQL: &execinfra.TestingKnobs{
+				RunBeforeCascadesAndChecks: func(txnID uuid.UUID) {
+					mu.Lock()
+					defer mu.Unlock()
+					if mu.abortTxn != nil {
+						mu.abortTxn(txnID)
+					}
+				},
+			},
+		},
+	})
+	defer s.Stopper().Stop(ctx)
+	sqlDB := sqlutils.MakeSQLRunner(conn)
+
+	// Set up schemas for the test. We want a construction that results in 2 FK
+	// checks, of which 1 is done in parallel.
+	sqlDB.Exec(t, "SET CLUSTER SETTING sql.distsql.parallelize_checks.enabled = true")
+	sqlDB.Exec(t, "create database test")
+	sqlDB.Exec(t, "create table test.parent1(a INT PRIMARY KEY)")
+	sqlDB.Exec(t, "create table test.parent2(b INT PRIMARY KEY)")
+	sqlDB.Exec(
+		t,
+		"create table test.child(a INT, b INT, FOREIGN KEY (a) REFERENCES test.parent1(a), FOREIGN KEY (b) REFERENCES test.parent2(b))",
+	)
+	key := roachpb.Key("a")
+
+	setupQueries := []string{
+		"insert into test.parent1 VALUES(1)",
+		"insert into test.parent2 VALUES(2)",
+	}
+	query := "insert into test.child VALUES(1, 2)"
+
+	createPlannerAndRunQuery := func(ctx context.Context, txn *kv.Txn, query string) error {
+		execCfg := s.ExecutorConfig().(ExecutorConfig)
+		// Plan the statement.
+		internalPlanner, cleanup := NewInternalPlanner(
+			"test",
+			txn,
+			username.RootUserName(),
+			&MemoryMetrics{},
+			&execCfg,
+			sessiondatapb.SessionData{},
+		)
+		defer cleanup()
+		p := internalPlanner.(*planner)
+		stmt, err := parser.ParseOne(query)
+		require.NoError(t, err)
+
+		rw := NewCallbackResultWriter(func(ctx context.Context, row tree.Datums) error {
+			return nil
+		})
+		recv := MakeDistSQLReceiver(
+			ctx,
+			rw,
+			stmt.AST.StatementReturnType(),
+			execCfg.RangeDescriptorCache,
+			txn,
+			execCfg.Clock,
+			p.ExtendedEvalContext().Tracing,
+			execCfg.ContentionRegistry,
+			nil, /* testingPushCallback */
+		)
+
+		p.stmt = makeStatement(stmt, clusterunique.ID{})
+		if err := p.makeOptimizerPlan(ctx); err != nil {
+			t.Fatal(err)
+		}
+		defer p.curPlan.close(ctx)
+
+		evalCtx := p.ExtendedEvalContext()
+		planCtx := execCfg.DistSQLPlanner.NewPlanningCtx(ctx, evalCtx, p, txn, DistributionTypeNone)
+		planCtx.stmtType = recv.stmtType
+
+		evalCtxFactory := func(bool) *extendedEvalContext {
+			factoryEvalCtx := extendedEvalContext{Tracing: evalCtx.Tracing}
+			factoryEvalCtx.Context = evalCtx.Context
+			return &factoryEvalCtx
+		}
+		err = execCfg.DistSQLPlanner.PlanAndRunAll(ctx, evalCtx, planCtx, p, recv, evalCtxFactory)
+		if err != nil {
+			return err
+		}
+		return rw.Err()
+	}
+
+	push := func(ctx context.Context, key roachpb.Key) error {
+		// Conflicting transaction that pushes another transaction.
+		conflictTxn := kv.NewTxn(ctx, db, 0 /* gatewayNodeID */)
+		// We need to explicitly set a high priority for the push to happen.
+		if err := conflictTxn.SetUserPriority(roachpb.MaxUserPriority); err != nil {
+			return err
+		}
+		// Push through a Put, as opposed to a Get, so that the pushee gets aborted.
+		if err := conflictTxn.Put(ctx, key, "pusher was here"); err != nil {
+			return err
+		}
+		err := conflictTxn.Commit(ctx)
+		require.NoError(t, err)
+		t.Log(conflictTxn.Rollback(ctx))
+		return err
+	}
+
+	// Make a db with a short heartbeat interval, so that the aborted txn finds
+	// out quickly.
+	ambient := s.AmbientCtx()
+	tsf := kvcoord.NewTxnCoordSenderFactory(
+		kvcoord.TxnCoordSenderFactoryConfig{
+			AmbientCtx: ambient,
+			// Short heartbeat interval.
+			HeartbeatInterval: time.Millisecond,
+			Settings:          s.ClusterSettings(),
+			Clock:             s.Clock(),
+			Stopper:           s.Stopper(),
+		},
+		s.DistSenderI().(*kvcoord.DistSender),
+	)
+	shortDB := kv.NewDB(ambient, tsf, s.Clock(), s.Stopper())
+
+	iter := 0
+	// We'll trace to make sure the test isn't fooling itself.
+	tr := s.TracerI().(*tracing.Tracer)
+	runningCtx, getRecAndFinish := tracing.ContextWithRecordingSpan(ctx, tr, "test")
+	defer getRecAndFinish()
+	err := shortDB.Txn(runningCtx, func(ctx context.Context, txn *kv.Txn) error {
+		iter++
+
+		// set up the test.
+		for _, query := range setupQueries {
+			err := createPlannerAndRunQuery(ctx, txn, query)
+			require.NoError(t, err)
+		}
+
+		if iter == 1 {
+			// On the first iteration, abort the txn by setting the abortTxn function.
+			mu.Lock()
+			mu.abortTxn = func(txnID uuid.UUID) {
+				if txnID != txn.ID() {
+					return // not our txn
+				}
+				if err := txn.Put(ctx, key, "val"); err != nil {
+					t.Fatal(err)
+				}
+				if err := push(ctx, key); err != nil {
+					t.Fatal(err)
+				}
+				// Now wait until the heartbeat loop notices that the transaction is aborted.
+				testutils.SucceedsSoon(t, func() error {
+					if txn.Sender().(*kvcoord.TxnCoordSender).IsTracking() {
+						return fmt.Errorf("txn heartbeat loop running")
+					}
+					return nil
+				})
+			}
+			mu.Unlock()
+			defer func() {
+				// clear the abortTxn function before returning.
+				mu.Lock()
+				mu.abortTxn = nil
+				mu.Unlock()
+			}()
+		}
+
+		// Execute the FK checks.
+		return createPlannerAndRunQuery(ctx, txn, query)
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	require.Equal(t, iter, 2)
+	if tracing.FindMsgInRecording(getRecAndFinish(), clientRejectedMsg) == -1 {
+		t.Fatalf("didn't find expected message in trace: %s", clientRejectedMsg)
+	}
+	concurrentFKChecksLogMessage := fmt.Sprintf(executingParallelAndSerialChecks, 1, 1)
+	if tracing.FindMsgInRecording(getRecAndFinish(), concurrentFKChecksLogMessage) == -1 {
+		t.Fatalf("didn't find expected message in trace: %s", concurrentFKChecksLogMessage)
 	}
 }
 

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -1463,7 +1463,7 @@ type ExecutorTestingKnobs struct {
 	// query (i.e. no subqueries). The physical plan is only safe for use for the
 	// lifetime of this function. Note that returning a nil function is
 	// unsupported and will lead to a panic.
-	TestingSaveFlows func(stmt string) func(map[base.SQLInstanceID]*execinfrapb.FlowSpec, execopnode.OpChains) error
+	TestingSaveFlows func(stmt string) func(map[base.SQLInstanceID]*execinfrapb.FlowSpec, execopnode.OpChains, bool) error
 
 	// DeterministicExplain, if set, will result in overriding fields in EXPLAIN
 	// and EXPLAIN ANALYZE that can vary between runs (like elapsed times).
@@ -1672,8 +1672,7 @@ func shouldDistributeGivenRecAndMode(
 // completed but is quite annoying to do at the moment.
 func getPlanDistribution(
 	ctx context.Context,
-	p *planner,
-	nodeID *base.SQLIDContainer,
+	txnHasUncommittedTypes bool,
 	distSQLMode sessiondatapb.DistSQLExecMode,
 	plan planMaybePhysical,
 ) physicalplan.PlanDistribution {
@@ -1684,7 +1683,7 @@ func getPlanDistribution(
 	// If this transaction has modified or created any types, it is not safe to
 	// distribute due to limitations around leasing descriptors modified in the
 	// current transaction.
-	if p.Descriptors().HasUncommittedTypes() {
+	if txnHasUncommittedTypes {
 		return physicalplan.LocalPlan
 	}
 

--- a/pkg/sql/execinfra/server_config.go
+++ b/pkg/sql/execinfra/server_config.go
@@ -44,6 +44,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/mon"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
+	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 	"github.com/cockroachdb/errors"
 	"github.com/marusama/semaphore"
 )
@@ -306,6 +307,11 @@ type TestingKnobs struct {
 	// ProcessorNoTracingSpan is used to disable the creation of a tracing span
 	// in ProcessorBase.StartInternal if the tracing is enabled.
 	ProcessorNoTracingSpan bool
+
+	// RunBeforeCascadeAndChecks is run before any cascade or check queries are
+	// run. The associated transaction ID of the statement performing the cascade
+	// or check query is passed in as an argument.
+	RunBeforeCascadesAndChecks func(txnID uuid.UUID)
 }
 
 // ModuleTestingKnobs is part of the base.ModuleTestingKnobs interface.

--- a/pkg/sql/execstats/traceanalyzer_test.go
+++ b/pkg/sql/execstats/traceanalyzer_test.go
@@ -59,11 +59,11 @@ func TestTraceAnalyzer(t *testing.T) {
 			UseDatabase: "test",
 			Knobs: base.TestingKnobs{
 				SQLExecutor: &sql.ExecutorTestingKnobs{
-					TestingSaveFlows: func(stmt string) func(map[base.SQLInstanceID]*execinfrapb.FlowSpec, execopnode.OpChains) error {
+					TestingSaveFlows: func(stmt string) func(map[base.SQLInstanceID]*execinfrapb.FlowSpec, execopnode.OpChains, bool) error {
 						if stmt != testStmt {
-							return func(map[base.SQLInstanceID]*execinfrapb.FlowSpec, execopnode.OpChains) error { return nil }
+							return func(map[base.SQLInstanceID]*execinfrapb.FlowSpec, execopnode.OpChains, bool) error { return nil }
 						}
-						return func(flows map[base.SQLInstanceID]*execinfrapb.FlowSpec, _ execopnode.OpChains) error {
+						return func(flows map[base.SQLInstanceID]*execinfrapb.FlowSpec, _ execopnode.OpChains, _ bool) error {
 							flowsMetadata := execstats.NewFlowsMetadata(flows)
 							analyzer := execstats.NewTraceAnalyzer(flowsMetadata)
 							analyzerChan <- analyzer

--- a/pkg/sql/explain_plan.go
+++ b/pkg/sql/explain_plan.go
@@ -63,7 +63,7 @@ func (e *explainPlanNode) startExec(params runParams) error {
 		// after the plan is finalized (when the physical plan is successfully
 		// created).
 		distribution := getPlanDistribution(
-			params.ctx, params.p, params.extendedEvalCtx.ExecCfg.NodeInfo.NodeID,
+			params.ctx, params.p.Descriptors().HasUncommittedTypes(),
 			params.extendedEvalCtx.SessionData().DistSQLMode, plan.main,
 		)
 
@@ -89,7 +89,7 @@ func (e *explainPlanNode) startExec(params runParams) error {
 		} else {
 			// There might be an issue making the physical plan, but that should not
 			// cause an error or panic, so swallow the error. See #40677 for example.
-			distSQLPlanner.finalizePlanWithRowCount(planCtx, physicalPlan, plan.mainRowCount)
+			finalizePlanWithRowCount(planCtx, physicalPlan, plan.mainRowCount)
 			ob.AddDistribution(physicalPlan.Distribution.String())
 			flows := physicalPlan.GenerateFlowSpecs()
 

--- a/pkg/sql/explain_vec.go
+++ b/pkg/sql/explain_vec.go
@@ -43,7 +43,7 @@ func (n *explainVecNode) startExec(params runParams) error {
 	n.run.values = make(tree.Datums, 1)
 	distSQLPlanner := params.extendedEvalCtx.DistSQLPlanner
 	distribution := getPlanDistribution(
-		params.ctx, params.p, params.extendedEvalCtx.ExecCfg.NodeInfo.NodeID,
+		params.ctx, params.p.Descriptors().HasUncommittedTypes(),
 		params.extendedEvalCtx.SessionData().DistSQLMode, n.plan.main,
 	)
 	outerSubqueries := params.p.curPlan.subqueryPlans
@@ -60,7 +60,7 @@ func (n *explainVecNode) startExec(params runParams) error {
 		return err
 	}
 
-	distSQLPlanner.finalizePlanWithRowCount(planCtx, physPlan, n.plan.mainRowCount)
+	finalizePlanWithRowCount(planCtx, physPlan, n.plan.mainRowCount)
 	flows := physPlan.GenerateFlowSpecs()
 	flowCtx := newFlowCtxForExplainPurposes(planCtx, params.p)
 

--- a/pkg/sql/importer/import_processor_planning.go
+++ b/pkg/sql/importer/import_processor_planning.go
@@ -111,7 +111,7 @@ func distImport(
 
 		p.PlanToStreamColMap = []int{0, 1}
 
-		dsp.FinalizePlan(planCtx, p)
+		sql.FinalizePlan(planCtx, p)
 		return p, planCtx, nil
 	}
 

--- a/pkg/sql/instrumentation.go
+++ b/pkg/sql/instrumentation.go
@@ -613,6 +613,16 @@ func (ih *instrumentationHelper) setExplainAnalyzeResult(
 	return nil
 }
 
+// getAssociateNodeWithComponentsFn returns a function, unsafe for concurrent
+// usage, that maintains a mapping from planNode to tracing metadata. It might
+// return nil in which case this mapping is not needed.
+func (ih *instrumentationHelper) getAssociateNodeWithComponentsFn() func(exec.Node, execComponents) {
+	if ih.traceMetadata == nil {
+		return nil
+	}
+	return ih.traceMetadata.associateNodeWithComponents
+}
+
 // execNodeTraceMetadata associates exec.Nodes with metadata for corresponding
 // execution components.
 // Currently, we only store info about processors. A node can correspond to

--- a/pkg/sql/recursive_cte.go
+++ b/pkg/sql/recursive_cte.go
@@ -96,7 +96,7 @@ func (n *recursiveCTENode) Next(params runParams) (bool, error) {
 				return false, err
 			}
 		}
-		n.iterator = newRowContainerIterator(params.ctx, n.workingRows, n.typs)
+		n.iterator = newRowContainerIterator(params.ctx, n.workingRows)
 		n.initialDone = true
 	}
 
@@ -152,7 +152,7 @@ func (n *recursiveCTENode) Next(params runParams) (bool, error) {
 		return false, err
 	}
 
-	n.iterator = newRowContainerIterator(params.ctx, n.workingRows, n.typs)
+	n.iterator = newRowContainerIterator(params.ctx, n.workingRows)
 	n.currentRow, err = n.iterator.Next()
 	if err != nil {
 		return false, err

--- a/pkg/sql/routine.go
+++ b/pkg/sql/routine.go
@@ -110,7 +110,7 @@ func (p *planner) EvalRoutineExpr(
 
 	// Fetch the first row from the row container and return the first
 	// datum.
-	rightRowsIterator := newRowContainerIterator(ctx, rch, retTypes)
+	rightRowsIterator := newRowContainerIterator(ctx, rch)
 	defer rightRowsIterator.Close()
 	res, err := rightRowsIterator.Next()
 	if err != nil {

--- a/pkg/sql/rowcontainer/BUILD.bazel
+++ b/pkg/sql/rowcontainer/BUILD.bazel
@@ -28,6 +28,7 @@ go_library(
         "//pkg/sql/sqlerrors",
         "//pkg/sql/types",
         "//pkg/util",
+        "//pkg/util/bufalloc",
         "//pkg/util/cancelchecker",
         "//pkg/util/encoding",
         "//pkg/util/hlc",

--- a/pkg/sql/rowcontainer/disk_row_container.go
+++ b/pkg/sql/rowcontainer/disk_row_container.go
@@ -38,10 +38,9 @@ type DiskRowContainer struct {
 	// diskAcc keeps track of disk usage.
 	diskAcc mon.BoundAccount
 	// bufferedRows buffers writes to the diskMap.
-	bufferedRows  diskmap.SortedDiskMapBatchWriter
-	scratchKey    []byte
-	scratchVal    []byte
-	scratchEncRow rowenc.EncDatumRow
+	bufferedRows diskmap.SortedDiskMapBatchWriter
+	scratchKey   []byte
+	scratchVal   []byte
 
 	// For computing mean encoded row bytes.
 	totalEncodedRowBytes uint64
@@ -104,14 +103,13 @@ func MakeDiskRowContainer(
 ) DiskRowContainer {
 	diskMap := e.NewSortedDiskMap()
 	d := DiskRowContainer{
-		diskMap:       diskMap,
-		diskAcc:       diskMonitor.MakeBoundAccount(),
-		types:         types,
-		ordering:      ordering,
-		scratchEncRow: make(rowenc.EncDatumRow, len(types)),
-		diskMonitor:   diskMonitor,
-		engine:        e,
-		datumAlloc:    &tree.DatumAlloc{},
+		diskMap:     diskMap,
+		diskAcc:     diskMonitor.MakeBoundAccount(),
+		types:       types,
+		ordering:    ordering,
+		diskMonitor: diskMonitor,
+		engine:      e,
+		datumAlloc:  &tree.DatumAlloc{},
 	}
 	d.bufferedRows = d.diskMap.NewBatchWriter()
 
@@ -337,7 +335,7 @@ func (d *DiskRowContainer) Reorder(ctx context.Context, ordering colinfo.ColumnO
 		} else if !ok {
 			break
 		}
-		row, err := i.Row()
+		row, err := i.EncRow()
 		if err != nil {
 			return err
 		}
@@ -394,45 +392,13 @@ func (d *DiskRowContainer) Close(ctx context.Context) {
 	d.diskAcc.Close(ctx)
 }
 
-// keyValToRow decodes a key and a value byte slice stored with AddRow() into
-// a rowenc.EncDatumRow. The returned EncDatumRow is only valid until the next
-// call to keyValToRow(). The passed in byte slices are used directly, and it is
-// the caller's responsibility to make sure they don't get modified.
-func (d *DiskRowContainer) keyValToRow(k []byte, v []byte) (rowenc.EncDatumRow, error) {
-	for i, orderInfo := range d.ordering {
-		// Types with composite key encodings are decoded from the value.
-		if colinfo.CanHaveCompositeKeyEncoding(d.types[orderInfo.ColIdx]) {
-			// Skip over the encoded key.
-			encLen, err := encoding.PeekLength(k)
-			if err != nil {
-				return nil, err
-			}
-			k = k[encLen:]
-			continue
-		}
-		var err error
-		col := orderInfo.ColIdx
-		d.scratchEncRow[col], k, err = rowenc.EncDatumFromBuffer(d.types[col], d.encodings[i], k)
-		if err != nil {
-			return nil, errors.NewAssertionErrorWithWrappedErrf(err,
-				"unable to decode row, column idx %d", errors.Safe(col))
-		}
-	}
-	for _, i := range d.valueIdxs {
-		var err error
-		d.scratchEncRow[i], v, err = rowenc.EncDatumFromBuffer(d.types[i], descpb.DatumEncoding_VALUE, v)
-		if err != nil {
-			return nil, errors.NewAssertionErrorWithWrappedErrf(err,
-				"unable to decode row, value idx %d", errors.Safe(i))
-		}
-	}
-	return d.scratchEncRow, nil
-}
-
 // diskRowIterator iterates over the rows in a DiskRowContainer.
 type diskRowIterator struct {
-	rowContainer *DiskRowContainer
-	rowBuf       bufalloc.ByteAllocator
+	rowContainer  *DiskRowContainer
+	rowBuf        bufalloc.ByteAllocator
+	scratchEncRow rowenc.EncDatumRow
+	scratchRow    tree.Datums
+	da            tree.DatumAlloc
 	diskmap.SortedDiskMapIterator
 }
 
@@ -442,7 +408,12 @@ func (d *DiskRowContainer) newIterator(ctx context.Context) diskRowIterator {
 	if err := d.bufferedRows.Flush(); err != nil {
 		log.Fatalf(ctx, "%v", err)
 	}
-	return diskRowIterator{rowContainer: d, SortedDiskMapIterator: d.diskMap.NewIterator()}
+	return diskRowIterator{
+		rowContainer:          d,
+		scratchEncRow:         make(rowenc.EncDatumRow, len(d.types)),
+		scratchRow:            make(tree.Datums, len(d.types)),
+		SortedDiskMapIterator: d.diskMap.NewIterator(),
+	}
 }
 
 // NewIterator is part of the SortableRowContainer interface.
@@ -454,9 +425,9 @@ func (d *DiskRowContainer) NewIterator(ctx context.Context) RowIterator {
 	return &i
 }
 
-// Row returns the current row. The returned rowenc.EncDatumRow is only valid
-// until the next call to Row().
-func (r *diskRowIterator) Row() (rowenc.EncDatumRow, error) {
+// EncRow returns the current row. The returned rowenc.EncDatumRow is only valid
+// until the next call to EncRow().
+func (r *diskRowIterator) EncRow() (rowenc.EncDatumRow, error) {
 	if ok, err := r.Valid(); err != nil {
 		return nil, errors.NewAssertionErrorWithWrappedErrf(err, "unable to check row validity")
 	} else if !ok {
@@ -465,14 +436,52 @@ func (r *diskRowIterator) Row() (rowenc.EncDatumRow, error) {
 
 	k := r.UnsafeKey()
 	v := r.UnsafeValue()
-	// keyValToRow will use the encoded key and value bytes as is by shoving
-	// them directly into the EncDatum, so we need to make a copy here. We
-	// cannot reuse the same byte slice across Row() calls because it would lead
-	// to modification of the EncDatums (which is not allowed).
+	// We will use the encoded key and value bytes as is by shoving them
+	// directly into the EncDatum, so we need to make a copy here. We cannot
+	// reuse the same byte slice across EncRow() calls because it would lead to
+	// modification of the EncDatums (which is not allowed).
 	r.rowBuf, k = r.rowBuf.Copy(k, len(v))
 	r.rowBuf, v = r.rowBuf.Copy(v, 0 /* extraCap */)
 
-	return r.rowContainer.keyValToRow(k, v)
+	for i, orderInfo := range r.rowContainer.ordering {
+		// Types with composite key encodings are decoded from the value.
+		if colinfo.CanHaveCompositeKeyEncoding(r.rowContainer.types[orderInfo.ColIdx]) {
+			// Skip over the encoded key.
+			encLen, err := encoding.PeekLength(k)
+			if err != nil {
+				return nil, err
+			}
+			k = k[encLen:]
+			continue
+		}
+		var err error
+		col := orderInfo.ColIdx
+		r.scratchEncRow[col], k, err = rowenc.EncDatumFromBuffer(r.rowContainer.types[col], r.rowContainer.encodings[i], k)
+		if err != nil {
+			return nil, errors.NewAssertionErrorWithWrappedErrf(err,
+				"unable to decode row, column idx %d", errors.Safe(col))
+		}
+	}
+	for _, i := range r.rowContainer.valueIdxs {
+		var err error
+		r.scratchEncRow[i], v, err = rowenc.EncDatumFromBuffer(r.rowContainer.types[i], descpb.DatumEncoding_VALUE, v)
+		if err != nil {
+			return nil, errors.NewAssertionErrorWithWrappedErrf(err,
+				"unable to decode row, value idx %d", errors.Safe(i))
+		}
+	}
+	return r.scratchEncRow, nil
+}
+
+// Row returns the current row. The returned row is only valid until the next
+// call to Row().
+func (r *diskRowIterator) Row() (tree.Datums, error) {
+	encRow, err := r.EncRow()
+	if err != nil {
+		return nil, err
+	}
+	err = rowenc.EncDatumRowToDatums(r.rowContainer.types, r.scratchRow, encRow, &r.da)
+	return r.scratchRow, err
 }
 
 func (r *diskRowIterator) Close() {
@@ -526,7 +535,17 @@ func (r *diskRowFinalIterator) Rewind() {
 	}
 }
 
-func (r *diskRowFinalIterator) Row() (rowenc.EncDatumRow, error) {
+func (r *diskRowFinalIterator) EncRow() (rowenc.EncDatumRow, error) {
+	row, err := r.diskRowIterator.EncRow()
+	if err != nil {
+		return nil, err
+	}
+	r.diskRowIterator.rowContainer.lastReadKey =
+		append(r.diskRowIterator.rowContainer.lastReadKey[:0], r.UnsafeKey()...)
+	return row, nil
+}
+
+func (r *diskRowFinalIterator) Row() (tree.Datums, error) {
 	row, err := r.diskRowIterator.Row()
 	if err != nil {
 		return nil, err

--- a/pkg/sql/rowcontainer/disk_row_container_test.go
+++ b/pkg/sql/rowcontainer/disk_row_container_test.go
@@ -36,11 +36,11 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// compareRows compares l and r according to a column ordering. Returns -1 if
+// compareEncRows compares l and r according to a column ordering. Returns -1 if
 // l < r, 0 if l == r, and 1 if l > r. If an error is returned the int returned
 // is invalid. Note that the comparison is only performed on the ordering
 // columns.
-func compareRows(
+func compareEncRows(
 	lTypes []*types.T,
 	l, r rowenc.EncDatumRow,
 	e *eval.Context,
@@ -49,7 +49,38 @@ func compareRows(
 ) (int, error) {
 	for _, orderInfo := range ordering {
 		col := orderInfo.ColIdx
-		cmp, err := l[col].Compare(lTypes[col], d, e, &r[orderInfo.ColIdx])
+		cmp, err := l[col].Compare(lTypes[col], d, e, &r[col])
+		if err != nil {
+			return 0, err
+		}
+		if cmp != 0 {
+			if orderInfo.Direction == encoding.Descending {
+				cmp = -cmp
+			}
+			return cmp, nil
+		}
+	}
+	return 0, nil
+}
+
+// compareRowToEncRow compares l and r according to a column ordering. Returns
+// -1 if l < r, 0 if l == r, and 1 if l > r. If an error is returned the int
+// returned is invalid. Note that the comparison is only performed on the
+// ordering columns.
+func compareRowToEncRow(
+	lTypes []*types.T,
+	l tree.Datums,
+	r rowenc.EncDatumRow,
+	e *eval.Context,
+	d *tree.DatumAlloc,
+	ordering colinfo.ColumnOrdering,
+) (int, error) {
+	for _, orderInfo := range ordering {
+		col := orderInfo.ColIdx
+		if err := r[col].EnsureDecoded(lTypes[col], d); err != nil {
+			return 0, err
+		}
+		cmp, err := l[col].CompareError(e, r[col].Datum)
 		if err != nil {
 			return 0, err
 		}
@@ -144,17 +175,17 @@ func TestDiskRowContainer(t *testing.T) {
 					} else if !ok {
 						t.Fatal("unexpectedly invalid")
 					}
-					readRow := make(rowenc.EncDatumRow, len(row))
+					readEncRow := make(rowenc.EncDatumRow, len(row))
 
-					temp, err := i.Row()
+					temp, err := i.EncRow()
 					if err != nil {
 						t.Fatal(err)
 					}
-					copy(readRow, temp)
+					copy(readEncRow, temp)
 
 					// Ensure the datum fields are set and no errors occur when
 					// decoding.
-					for i, encDatum := range readRow {
+					for i, encDatum := range readEncRow {
 						if err := encDatum.EnsureDecoded(typs[i], d.datumAlloc); err != nil {
 							t.Fatal(err)
 						}
@@ -162,10 +193,23 @@ func TestDiskRowContainer(t *testing.T) {
 
 					// Check equality of the row we wrote and the row we read.
 					for i := range row {
-						if cmp, err := readRow[i].Compare(typs[i], d.datumAlloc, &evalCtx, &row[i]); err != nil {
+						if cmp, err := readEncRow[i].Compare(typs[i], d.datumAlloc, &evalCtx, &row[i]); err != nil {
 							t.Fatal(err)
 						} else if cmp != 0 {
-							t.Fatalf("encoded %s but decoded %s", row.String(typs), readRow.String(typs))
+							t.Fatalf("encoded %s but decoded %s", row.String(typs), readEncRow.String(typs))
+						}
+					}
+
+					// Now check the tree.Datums row.
+					readRow, err := i.Row()
+					if err != nil {
+						t.Fatal(err)
+					}
+					for i := range row {
+						if cmp, err := readRow[i].CompareError(&evalCtx, row[i].Datum); err != nil {
+							t.Fatal(err)
+						} else if cmp != 0 {
+							t.Fatalf("read %s but expected %s", readRow.String(), row.String(typs))
 						}
 					}
 				}()
@@ -210,7 +254,7 @@ func TestDiskRowContainer(t *testing.T) {
 					} else if !ok {
 						break
 					}
-					row, err := i.Row()
+					row, err := i.EncRow()
 					if err != nil {
 						t.Fatal(err)
 					}
@@ -224,15 +268,17 @@ func TestDiskRowContainer(t *testing.T) {
 					}
 
 					// Check sorted order.
-					if cmp, err := compareRows(
-						types, sortedRows.EncRow(numKeysRead), row, &evalCtx, d.datumAlloc, ordering,
+					sortedRows.getEncRow(sortedRows.scratchEncRow, numKeysRead)
+					if cmp, err := compareEncRows(
+						types, sortedRows.scratchEncRow, row, &evalCtx, d.datumAlloc, ordering,
 					); err != nil {
 						t.Fatal(err)
 					} else if cmp != 0 {
+						sortedRows.getEncRow(sortedRows.scratchEncRow, numKeysRead)
 						t.Fatalf(
 							"expected %s to be equal to %s",
 							row.String(types),
-							sortedRows.EncRow(numKeysRead).String(types),
+							sortedRows.scratchEncRow.String(types),
 						)
 					}
 					numKeysRead++
@@ -315,7 +361,7 @@ func TestDiskRowContainer(t *testing.T) {
 			valid, err := iter.Valid()
 			require.True(t, valid)
 			require.NoError(t, err)
-			row, err := iter.Row()
+			row, err := iter.EncRow()
 			require.NoError(t, err)
 			require.Equal(t, rows[index].String(types), row.String(types))
 		}
@@ -467,7 +513,7 @@ func TestDiskRowContainerFinalIterator(t *testing.T) {
 			} else if !ok {
 				t.Fatalf("unexpectedly reached the end after %d rows read", rowsRead)
 			}
-			row, err := i.Row()
+			row, err := i.EncRow()
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -488,7 +534,7 @@ func TestDiskRowContainerFinalIterator(t *testing.T) {
 			} else if !ok {
 				break
 			}
-			row, err := i.Row()
+			row, err := i.EncRow()
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -519,7 +565,7 @@ func TestDiskRowContainerFinalIterator(t *testing.T) {
 		} else if !ok {
 			break
 		}
-		row, err := i.Row()
+		row, err := i.EncRow()
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -590,7 +636,7 @@ func TestDiskRowContainerUnsafeReset(t *testing.T) {
 			if ok, err := i.Valid(); err != nil || !ok {
 				t.Fatalf("unexpected i.Valid() return values: ok=%t, err=%s", ok, err)
 			}
-			row, err := i.Row()
+			row, err := i.EncRow()
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -617,7 +663,7 @@ func TestDiskRowContainerUnsafeReset(t *testing.T) {
 		} else if !ok {
 			break
 		}
-		_, err := i.Row()
+		_, err := i.EncRow()
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/pkg/sql/rowcontainer/hash_row_container.go
+++ b/pkg/sql/rowcontainer/hash_row_container.go
@@ -305,8 +305,9 @@ func (h *HashMemRowContainer) ReserveMarkMemoryMaybe(ctx context.Context) error 
 
 // hashMemRowBucketIterator iterates over the rows in a bucket.
 type hashMemRowBucketIterator struct {
-	*HashMemRowContainer
-	probeEqCols columns
+	container     *HashMemRowContainer
+	scratchEncRow rowenc.EncDatumRow
+	probeEqCols   columns
 	// rowIdxs are the indices of rows in the bucket.
 	rowIdxs []int
 	curIdx  int
@@ -319,8 +320,9 @@ func (h *HashMemRowContainer) NewBucketIterator(
 	ctx context.Context, row rowenc.EncDatumRow, probeEqCols columns,
 ) (RowMarkerIterator, error) {
 	ret := &hashMemRowBucketIterator{
-		HashMemRowContainer: h,
-		probeEqCols:         probeEqCols,
+		container:     h,
+		scratchEncRow: make(rowenc.EncDatumRow, len(h.types)),
+		probeEqCols:   probeEqCols,
 	}
 
 	if err := ret.Reset(ctx, row); err != nil {
@@ -344,45 +346,51 @@ func (i *hashMemRowBucketIterator) Next() {
 	i.curIdx++
 }
 
+// EncRow implements the RowIterator interface.
+func (i *hashMemRowBucketIterator) EncRow() (rowenc.EncDatumRow, error) {
+	i.container.getEncRow(i.scratchEncRow, i.rowIdxs[i.curIdx])
+	return i.scratchEncRow, nil
+}
+
 // Row implements the RowIterator interface.
-func (i *hashMemRowBucketIterator) Row() (rowenc.EncDatumRow, error) {
-	return i.EncRow(i.rowIdxs[i.curIdx]), nil
+func (i *hashMemRowBucketIterator) Row() (tree.Datums, error) {
+	return i.container.At(i.rowIdxs[i.curIdx]), nil
 }
 
 // IsMarked implements the RowMarkerIterator interface.
 func (i *hashMemRowBucketIterator) IsMarked(ctx context.Context) bool {
-	if !i.shouldMark {
+	if !i.container.shouldMark {
 		log.Fatal(ctx, "hash mem row container not set up for marking")
 	}
-	if i.marked == nil {
+	if i.container.marked == nil {
 		return false
 	}
 
-	return i.marked[i.rowIdxs[i.curIdx]]
+	return i.container.marked[i.rowIdxs[i.curIdx]]
 }
 
 // Mark implements the RowMarkerIterator interface.
 func (i *hashMemRowBucketIterator) Mark(ctx context.Context) error {
-	if !i.shouldMark {
+	if !i.container.shouldMark {
 		log.Fatal(ctx, "hash mem row container not set up for marking")
 	}
-	if i.marked == nil {
-		if !i.markMemoryReserved {
+	if i.container.marked == nil {
+		if !i.container.markMemoryReserved {
 			panic("mark memory should have been reserved already")
 		}
-		i.marked = make([]bool, i.Len())
+		i.container.marked = make([]bool, i.container.Len())
 	}
 
-	i.marked[i.rowIdxs[i.curIdx]] = true
+	i.container.marked[i.rowIdxs[i.curIdx]] = true
 	return nil
 }
 
 func (i *hashMemRowBucketIterator) Reset(ctx context.Context, row rowenc.EncDatumRow) error {
-	encoded, err := i.encodeEqualityCols(ctx, row, i.probeEqCols)
+	encoded, err := i.container.encodeEqualityCols(ctx, row, i.probeEqCols)
 	if err != nil {
 		return err
 	}
-	i.rowIdxs = i.buckets[string(encoded)]
+	i.rowIdxs = i.container.buckets[string(encoded)]
 	return nil
 }
 
@@ -391,8 +399,9 @@ func (i *hashMemRowBucketIterator) Close() {}
 
 // hashMemRowIterator iterates over all unmarked rows in a HashMemRowContainer.
 type hashMemRowIterator struct {
-	*HashMemRowContainer
-	curIdx int
+	container     *HashMemRowContainer
+	scratchEncRow rowenc.EncDatumRow
+	curIdx        int
 
 	// curKey contains the key that would be assigned to the current row if it
 	// were to be put on disk. It is needed to optimize the recreation of the
@@ -405,7 +414,7 @@ var _ RowIterator = &hashMemRowIterator{}
 
 // NewUnmarkedIterator implements the HashRowContainer interface.
 func (h *HashMemRowContainer) NewUnmarkedIterator(ctx context.Context) RowIterator {
-	return &hashMemRowIterator{HashMemRowContainer: h}
+	return &hashMemRowIterator{container: h, scratchEncRow: make(rowenc.EncDatumRow, len(h.types))}
 }
 
 // Rewind implements the RowIterator interface.
@@ -417,7 +426,7 @@ func (i *hashMemRowIterator) Rewind() {
 
 // Valid implements the RowIterator interface.
 func (i *hashMemRowIterator) Valid() (bool, error) {
-	return i.curIdx < i.Len(), nil
+	return i.curIdx < i.container.Len(), nil
 }
 
 // computeKey calculates the key for the current row as if the row is put on
@@ -428,9 +437,8 @@ func (i *hashMemRowIterator) computeKey() error {
 		return err
 	}
 
-	var row rowenc.EncDatumRow
 	if valid {
-		row = i.EncRow(i.curIdx)
+		i.container.getEncRow(i.scratchEncRow, i.curIdx)
 	} else {
 		if i.curIdx == 0 {
 			// There are no rows in the container, so the key corresponding to the
@@ -442,13 +450,18 @@ func (i *hashMemRowIterator) computeKey() error {
 		// will "simulate" the key corresponding to the non-existent row as the key
 		// to the last existing row plus one (plus one part is done below where we
 		// append the index of the row to curKey).
-		row = i.EncRow(i.curIdx - 1)
+		i.container.getEncRow(i.scratchEncRow, i.curIdx-1)
 	}
 
 	i.curKey = i.curKey[:0]
-	for _, col := range i.storedEqCols {
+	for _, col := range i.container.storedEqCols {
 		var err error
-		i.curKey, err = row[col].Encode(i.types[col], &i.columnEncoder.datumAlloc, descpb.DatumEncoding_ASCENDING_KEY, i.curKey)
+		i.curKey, err = i.scratchEncRow[col].Encode(
+			i.container.types[col],
+			&i.container.columnEncoder.datumAlloc,
+			descpb.DatumEncoding_ASCENDING_KEY,
+			i.curKey,
+		)
 		if err != nil {
 			return err
 		}
@@ -461,15 +474,21 @@ func (i *hashMemRowIterator) computeKey() error {
 func (i *hashMemRowIterator) Next() {
 	// Move the curIdx to the next unmarked row.
 	i.curIdx++
-	if i.marked != nil {
-		for ; i.curIdx < len(i.marked) && i.marked[i.curIdx]; i.curIdx++ {
+	if i.container.marked != nil {
+		for ; i.curIdx < len(i.container.marked) && i.container.marked[i.curIdx]; i.curIdx++ {
 		}
 	}
 }
 
+// EncRow implements the RowIterator interface.
+func (i *hashMemRowIterator) EncRow() (rowenc.EncDatumRow, error) {
+	i.container.getEncRow(i.scratchEncRow, i.curIdx)
+	return i.scratchEncRow, nil
+}
+
 // Row implements the RowIterator interface.
-func (i *hashMemRowIterator) Row() (rowenc.EncDatumRow, error) {
-	return i.EncRow(i.curIdx), nil
+func (i *hashMemRowIterator) Row() (tree.Datums, error) {
+	return i.container.At(i.curIdx), nil
 }
 
 // Close implements the RowIterator interface.
@@ -556,7 +575,7 @@ func (h *HashDiskRowContainer) IsEmpty() bool {
 // hashDiskRowBucketIterator iterates over the rows in a bucket.
 type hashDiskRowBucketIterator struct {
 	*diskRowIterator
-	*HashDiskRowContainer
+	container   *HashDiskRowContainer
 	probeEqCols columns
 	// haveMarkedRows returns true if we've marked rows since the last time we
 	// recreated our underlying diskRowIterator.
@@ -575,9 +594,9 @@ func (h *HashDiskRowContainer) NewBucketIterator(
 	ctx context.Context, row rowenc.EncDatumRow, probeEqCols columns,
 ) (RowMarkerIterator, error) {
 	ret := &hashDiskRowBucketIterator{
-		HashDiskRowContainer: h,
-		probeEqCols:          probeEqCols,
-		diskRowIterator:      h.NewIterator(ctx).(*diskRowIterator),
+		container:       h,
+		probeEqCols:     probeEqCols,
+		diskRowIterator: h.NewIterator(ctx).(*diskRowIterator),
 	}
 	if err := ret.Reset(ctx, row); err != nil {
 		ret.Close()
@@ -602,22 +621,36 @@ func (i *hashDiskRowBucketIterator) Valid() (bool, error) {
 	return bytes.HasPrefix(i.UnsafeKey(), i.encodedEqCols), nil
 }
 
+// EncRow implements the RowIterator interface.
+func (i *hashDiskRowBucketIterator) EncRow() (rowenc.EncDatumRow, error) {
+	row, err := i.diskRowIterator.EncRow()
+	if err != nil {
+		return nil, err
+	}
+
+	// Remove the mark from the end of the row.
+	if i.container.shouldMark {
+		row = row[:len(row)-1]
+	}
+	return row, nil
+}
+
 // Row implements the RowIterator interface.
-func (i *hashDiskRowBucketIterator) Row() (rowenc.EncDatumRow, error) {
+func (i *hashDiskRowBucketIterator) Row() (tree.Datums, error) {
 	row, err := i.diskRowIterator.Row()
 	if err != nil {
 		return nil, err
 	}
 
 	// Remove the mark from the end of the row.
-	if i.HashDiskRowContainer.shouldMark {
+	if i.container.shouldMark {
 		row = row[:len(row)-1]
 	}
 	return row, nil
 }
 
 func (i *hashDiskRowBucketIterator) Reset(ctx context.Context, row rowenc.EncDatumRow) error {
-	encoded, err := i.HashDiskRowContainer.encodeEqualityCols(ctx, row, i.probeEqCols)
+	encoded, err := i.container.encodeEqualityCols(ctx, row, i.probeEqCols)
 	if err != nil {
 		return err
 	}
@@ -627,14 +660,14 @@ func (i *hashDiskRowBucketIterator) Reset(ctx context.Context, row rowenc.EncDat
 		// TODO(jordan): do this less by keeping a cache of written marks.
 		i.haveMarkedRows = false
 		i.diskRowIterator.Close()
-		i.diskRowIterator = i.HashDiskRowContainer.NewIterator(ctx).(*diskRowIterator)
+		i.diskRowIterator = i.container.NewIterator(ctx).(*diskRowIterator)
 	}
 	return nil
 }
 
 // IsMarked implements the RowMarkerIterator interface.
 func (i *hashDiskRowBucketIterator) IsMarked(ctx context.Context) bool {
-	if !i.HashDiskRowContainer.shouldMark {
+	if !i.container.shouldMark {
 		log.Fatal(ctx, "hash disk row container not set up for marking")
 	}
 	ok, err := i.diskRowIterator.Valid()
@@ -648,7 +681,7 @@ func (i *hashDiskRowBucketIterator) IsMarked(ctx context.Context) bool {
 
 // Mark implements the RowMarkerIterator interface.
 func (i *hashDiskRowBucketIterator) Mark(ctx context.Context) error {
-	if !i.HashDiskRowContainer.shouldMark {
+	if !i.container.shouldMark {
 		log.Fatal(ctx, "hash disk row container not set up for marking")
 	}
 	i.haveMarkedRows = true
@@ -668,7 +701,7 @@ func (i *hashDiskRowBucketIterator) Mark(ctx context.Context) error {
 	// These marks only matter when using a hashDiskRowIterator to iterate over
 	// unmarked rows. The writes are flushed when creating a NewIterator() in
 	// NewUnmarkedIterator().
-	return i.HashDiskRowContainer.bufferedRows.Put(i.UnsafeKey(), rowVal)
+	return i.container.bufferedRows.Put(i.UnsafeKey(), rowVal)
 }
 
 // hashDiskRowIterator iterates over all unmarked rows in a
@@ -706,8 +739,20 @@ func (i *hashDiskRowIterator) Next() {
 	}
 }
 
+// EncRow implements the RowIterator interface.
+func (i *hashDiskRowIterator) EncRow() (rowenc.EncDatumRow, error) {
+	row, err := i.diskRowIterator.EncRow()
+	if err != nil {
+		return nil, err
+	}
+
+	// Remove the mark from the end of the row.
+	row = row[:len(row)-1]
+	return row, nil
+}
+
 // Row implements the RowIterator interface.
-func (i *hashDiskRowIterator) Row() (rowenc.EncDatumRow, error) {
+func (i *hashDiskRowIterator) Row() (tree.Datums, error) {
 	row, err := i.diskRowIterator.Row()
 	if err != nil {
 		return nil, err
@@ -916,7 +961,7 @@ func (h *HashDiskBackedRowContainer) SpillToDisk(ctx context.Context) error {
 		} else if !ok {
 			break
 		}
-		row, err := i.Row()
+		row, err := i.EncRow()
 		if err != nil {
 			return err
 		}

--- a/pkg/sql/rowcontainer/hash_row_container_test.go
+++ b/pkg/sql/rowcontainer/hash_row_container_test.go
@@ -109,7 +109,7 @@ func TestHashDiskBackedRowContainer(t *testing.T) {
 			// over all rows added so far.
 			i := rc.NewUnmarkedIterator(ctx)
 			defer i.Close()
-			if err := verifyRows(ctx, i, rows[:mid], &evalCtx, ordering); err != nil {
+			if err := verifyRows(i, rows[:mid], &evalCtx, ordering); err != nil {
 				t.Fatalf("verifying memory rows failed with: %s", err)
 			}
 		}()
@@ -127,7 +127,7 @@ func TestHashDiskBackedRowContainer(t *testing.T) {
 		func() {
 			i := rc.NewUnmarkedIterator(ctx)
 			defer i.Close()
-			if err := verifyRows(ctx, i, rows, &evalCtx, ordering); err != nil {
+			if err := verifyRows(i, rows, &evalCtx, ordering); err != nil {
 				t.Fatalf("verifying disk rows failed with: %s", err)
 			}
 		}()
@@ -211,11 +211,11 @@ func TestHashDiskBackedRowContainer(t *testing.T) {
 			} else if !ok {
 				break
 			}
-			row, err := i.Row()
+			row, err := i.EncRow()
 			if err != nil {
 				t.Fatal(err)
 			}
-			if cmp, err := compareRows(
+			if cmp, err := compareEncRows(
 				types.OneIntCol, row, rows[counter], &evalCtx, &tree.DatumAlloc{}, ordering,
 			); err != nil {
 				t.Fatal(err)
@@ -236,11 +236,11 @@ func TestHashDiskBackedRowContainer(t *testing.T) {
 			} else if !ok {
 				break
 			}
-			row, err := i.Row()
+			row, err := i.EncRow()
 			if err != nil {
 				t.Fatal(err)
 			}
-			if cmp, err := compareRows(
+			if cmp, err := compareEncRows(
 				types.OneIntCol, row, rows[counter], &evalCtx, &tree.DatumAlloc{}, ordering,
 			); err != nil {
 				t.Fatal(err)
@@ -286,11 +286,11 @@ func TestHashDiskBackedRowContainer(t *testing.T) {
 			} else if !ok {
 				break
 			}
-			row, err := i.Row()
+			row, err := i.EncRow()
 			if err != nil {
 				t.Fatal(err)
 			}
-			if cmp, err := compareRows(
+			if cmp, err := compareEncRows(
 				types.OneIntCol, row, rows[counter], &evalCtx, &tree.DatumAlloc{}, ordering,
 			); err != nil {
 				t.Fatal(err)
@@ -397,7 +397,7 @@ func TestHashDiskBackedRowContainerPreservesMatchesAndMarks(t *testing.T) {
 			// over all rows added so far.
 			i := rc.NewUnmarkedIterator(ctx)
 			defer i.Close()
-			if err := verifyRows(ctx, i, rows[:mid], &evalCtx, ordering); err != nil {
+			if err := verifyRows(i, rows[:mid], &evalCtx, ordering); err != nil {
 				t.Fatalf("verifying memory rows failed with: %s", err)
 			}
 		}()
@@ -415,7 +415,7 @@ func TestHashDiskBackedRowContainerPreservesMatchesAndMarks(t *testing.T) {
 		func() {
 			i := rc.NewUnmarkedIterator(ctx)
 			defer i.Close()
-			if err := verifyRows(ctx, i, rows, &evalCtx, ordering); err != nil {
+			if err := verifyRows(i, rows, &evalCtx, ordering); err != nil {
 				t.Fatalf("verifying disk rows failed with: %s", err)
 			}
 		}()
@@ -445,7 +445,7 @@ func TestHashDiskBackedRowContainerPreservesMatchesAndMarks(t *testing.T) {
 			// over all rows added so far.
 			i := rc.NewUnmarkedIterator(ctx)
 			defer i.Close()
-			if err := verifyRows(ctx, i, rows, &evalCtx, ordering); err != nil {
+			if err := verifyRows(i, rows, &evalCtx, ordering); err != nil {
 				t.Fatalf("verifying memory rows failed with: %s", err)
 			}
 		}()

--- a/pkg/sql/rowcontainer/kvstreamer_result_disk_buffer.go
+++ b/pkg/sql/rowcontainer/kvstreamer_result_disk_buffer.go
@@ -112,7 +112,7 @@ func (b *kvStreamerResultDiskBuffer) Deserialize(
 		b.iterResultID++
 	}
 	// Now we take the row representing the Result and deserialize it into r.
-	serialized, err := b.iter.Row()
+	serialized, err := b.iter.EncRow()
 	if err != nil {
 		return err
 	}

--- a/pkg/sql/rowcontainer/row_container.go
+++ b/pkg/sql/rowcontainer/row_container.go
@@ -33,6 +33,9 @@ import (
 
 // SortableRowContainer is a container used to store rows and optionally sort
 // these.
+// NOTE: methods of this interface are **not** safe for concurrent use. However,
+// separate RowIterators can be created to perform reads of the rows in the
+// container concurrently.
 type SortableRowContainer interface {
 	Len() int
 	// AddRow adds a row to the container. If an error is returned, then the
@@ -105,7 +108,9 @@ type DeDupingRowContainer interface {
 	Close(context.Context)
 }
 
-// RowIterator is a simple iterator used to iterate over sqlbase.EncDatumRows.
+// RowIterator is a simple iterator used to iterate over rows buffered in the
+// SortableRowContainer.
+//
 // Example use:
 //
 //	var i RowIterator
@@ -115,12 +120,15 @@ type DeDupingRowContainer interface {
 //		} else if !ok {
 //			break
 //		}
-//		row, err := i.Row()
+//		row, err := i.EncRow()
 //		if err != nil {
 //			// Handle error.
 //		}
 //		// Do something.
 //	}
+//
+// Multiple iterators can be created in order to iterate over the same container
+// concurrently.
 type RowIterator interface {
 	// Rewind seeks to the first row.
 	Rewind()
@@ -131,12 +139,20 @@ type RowIterator interface {
 	Valid() (bool, error)
 	// Next advances the iterator to the next row in the iteration.
 	Next()
-	// Row returns the current row. The returned row is only valid until the
-	// next call to Rewind() or Next(). However, datums in the row won't be
+	// EncRow returns the current row. The returned row is only valid until the
+	// next call to Rewind() or Next(). However, EncDatums in the row won't be
 	// modified, so shallow copying is sufficient.
-	Row() (rowenc.EncDatumRow, error)
+	EncRow() (rowenc.EncDatumRow, error)
+	// Row returns the current row. The returned row is only valid until the
+	// next call to Rewind() or Next(). However, tree.Datums in the row won't be
+	// modified, so shallow copying is sufficient.
+	//
+	// NOTE: it does *not* copy the row: callers must copy the row if they wish
+	// to mutate it.
+	Row() (tree.Datums, error)
 
 	// Close frees up resources held by the iterator.
+	// NOTE: unsafe for concurrent calls on different iterators.
 	Close()
 }
 
@@ -190,14 +206,14 @@ func (mc *MemRowContainer) Less(i, j int) bool {
 	return cmp < 0
 }
 
-// EncRow returns the idx-th row as an EncDatumRow. The slice itself is reused
-// so it is only valid until the next call to EncRow.
-func (mc *MemRowContainer) EncRow(idx int) rowenc.EncDatumRow {
+// getEncRow populates the given EncDatumRow with the values of the idx-th row.
+// The behavior is undefined if the given row is of a different width than the
+// rows stored in the container.
+func (mc *MemRowContainer) getEncRow(encRow rowenc.EncDatumRow, idx int) {
 	datums := mc.At(idx)
 	for i, d := range datums {
-		mc.scratchEncRow[i] = rowenc.DatumToEncDatum(mc.types[i], d)
+		encRow[i] = rowenc.DatumToEncDatum(mc.types[i], d)
 	}
-	return mc.scratchEncRow
 }
 
 // AddRow adds a row to the container.
@@ -270,8 +286,9 @@ func (mc *MemRowContainer) InitTopK() {
 // memRowIterator is a RowIterator that iterates over a MemRowContainer. This
 // iterator doesn't iterate over a snapshot of MemRowContainer.
 type memRowIterator struct {
-	*MemRowContainer
-	curIdx int
+	container     *MemRowContainer
+	curIdx        int
+	scratchEncRow rowenc.EncDatumRow
 }
 
 var _ RowIterator = &memRowIterator{}
@@ -280,7 +297,7 @@ var _ RowIterator = &memRowIterator{}
 // MemRowContainer. Note that this iterator doesn't iterate over a snapshot
 // of MemRowContainer.
 func (mc *MemRowContainer) NewIterator(_ context.Context) RowIterator {
-	return &memRowIterator{MemRowContainer: mc}
+	return &memRowIterator{container: mc, scratchEncRow: make(rowenc.EncDatumRow, len(mc.types))}
 }
 
 // Rewind implements the RowIterator interface.
@@ -290,7 +307,7 @@ func (i *memRowIterator) Rewind() {
 
 // Valid implements the RowIterator interface.
 func (i *memRowIterator) Valid() (bool, error) {
-	return i.curIdx < i.Len(), nil
+	return i.curIdx < i.container.Len(), nil
 }
 
 // Next implements the RowIterator interface.
@@ -298,9 +315,18 @@ func (i *memRowIterator) Next() {
 	i.curIdx++
 }
 
+// EncRow implements the RowIterator interface.
+func (i *memRowIterator) EncRow() (rowenc.EncDatumRow, error) {
+	datums := i.container.At(i.curIdx)
+	for colidx, d := range datums {
+		i.scratchEncRow[colidx] = rowenc.DatumToEncDatum(i.container.types[colidx], d)
+	}
+	return i.scratchEncRow, nil
+}
+
 // Row implements the RowIterator interface.
-func (i *memRowIterator) Row() (rowenc.EncDatumRow, error) {
-	return i.EncRow(i.curIdx), nil
+func (i *memRowIterator) Row() (tree.Datums, error) {
+	return i.container.At(i.curIdx), nil
 }
 
 // Close implements the RowIterator interface.
@@ -310,7 +336,8 @@ func (i *memRowIterator) Close() {}
 // This iterator doesn't iterate over a snapshot of MemRowContainer and deletes
 // rows as soon as they are iterated over to free up memory eagerly.
 type memRowFinalIterator struct {
-	*MemRowContainer
+	container     *MemRowContainer
+	scratchEncRow rowenc.EncDatumRow
 
 	ctx context.Context
 }
@@ -320,36 +347,43 @@ type memRowFinalIterator struct {
 // of MemRowContainer and that it deletes rows as soon as they are iterated
 // over.
 func (mc *MemRowContainer) NewFinalIterator(ctx context.Context) RowIterator {
-	return memRowFinalIterator{MemRowContainer: mc, ctx: ctx}
+	return &memRowFinalIterator{container: mc, scratchEncRow: make(rowenc.EncDatumRow, len(mc.types)), ctx: ctx}
 }
 
 // GetRow implements IndexedRowContainer.
 func (mc *MemRowContainer) GetRow(ctx context.Context, pos int) (eval.IndexedRow, error) {
-	return IndexedRow{Idx: pos, Row: mc.EncRow(pos)}, nil
+	mc.getEncRow(mc.scratchEncRow, pos)
+	return IndexedRow{Idx: pos, Row: mc.scratchEncRow}, nil
 }
 
-var _ RowIterator = memRowFinalIterator{}
+var _ RowIterator = &memRowFinalIterator{}
 
 // Rewind implements the RowIterator interface.
-func (i memRowFinalIterator) Rewind() {}
+func (i *memRowFinalIterator) Rewind() {}
 
 // Valid implements the RowIterator interface.
-func (i memRowFinalIterator) Valid() (bool, error) {
-	return i.Len() > 0, nil
+func (i *memRowFinalIterator) Valid() (bool, error) {
+	return i.container.Len() > 0, nil
 }
 
 // Next implements the RowIterator interface.
-func (i memRowFinalIterator) Next() {
-	i.PopFirst(i.ctx)
+func (i *memRowFinalIterator) Next() {
+	i.container.PopFirst(i.ctx)
+}
+
+// EncRow implements the RowIterator interface.
+func (i *memRowFinalIterator) EncRow() (rowenc.EncDatumRow, error) {
+	i.container.getEncRow(i.scratchEncRow, 0)
+	return i.scratchEncRow, nil
 }
 
 // Row implements the RowIterator interface.
-func (i memRowFinalIterator) Row() (rowenc.EncDatumRow, error) {
-	return i.EncRow(0), nil
+func (i *memRowFinalIterator) Row() (tree.Datums, error) {
+	return i.container.At(0), nil
 }
 
 // Close implements the RowIterator interface.
-func (i memRowFinalIterator) Close() {}
+func (i *memRowFinalIterator) Close() {}
 
 // DiskBackedRowContainer is a ReorderableRowContainer that uses a
 // MemRowContainer to store rows and spills back to disk automatically if
@@ -610,7 +644,7 @@ func (f *DiskBackedRowContainer) SpillToDisk(ctx context.Context) error {
 		} else if !ok {
 			break
 		}
-		memRow, err := i.Row()
+		memRow, err := i.EncRow()
 		if err != nil {
 			return err
 		}
@@ -812,7 +846,7 @@ func (f *DiskBackedIndexedRowContainer) GetRow(
 				return nil, errors.Errorf("row at pos %d not found", pos)
 			}
 			if f.idxRowIter == f.nextPosToCache {
-				rowWithIdx, err = f.diskRowIter.Row()
+				rowWithIdx, err = f.diskRowIter.EncRow()
 				if err != nil {
 					return nil, err
 				}
@@ -866,7 +900,9 @@ func (f *DiskBackedIndexedRowContainer) GetRow(
 			f.idxRowIter++
 		}
 	}
-	rowWithIdx = f.DiskBackedRowContainer.mrc.EncRow(pos)
+	mrc := f.DiskBackedRowContainer.mrc
+	mrc.getEncRow(mrc.scratchEncRow, pos)
+	rowWithIdx = mrc.scratchEncRow
 	row, rowIdx := rowWithIdx[:len(rowWithIdx)-1], rowWithIdx[len(rowWithIdx)-1].Datum
 	if idx, ok := rowIdx.(*tree.DInt); ok {
 		return IndexedRow{int(*idx), row}, nil
@@ -947,7 +983,7 @@ func (f *DiskBackedIndexedRowContainer) getRowWithoutCache(
 			panic(errors.AssertionFailedf("row at pos %d not found", pos))
 		}
 		if f.idxRowIter == pos {
-			rowWithIdx, err := f.diskRowIter.Row()
+			rowWithIdx, err := f.diskRowIter.EncRow()
 			if err != nil {
 				panic(err)
 			}

--- a/pkg/sql/rowcontainer/row_container.go
+++ b/pkg/sql/rowcontainer/row_container.go
@@ -132,7 +132,8 @@ type RowIterator interface {
 	// Next advances the iterator to the next row in the iteration.
 	Next()
 	// Row returns the current row. The returned row is only valid until the
-	// next call to Rewind() or Next().
+	// next call to Rewind() or Next(). However, datums in the row won't be
+	// modified, so shallow copying is sufficient.
 	Row() (rowenc.EncDatumRow, error)
 
 	// Close frees up resources held by the iterator.

--- a/pkg/sql/rowcontainer/row_container_test.go
+++ b/pkg/sql/rowcontainer/row_container_test.go
@@ -39,9 +39,8 @@ import (
 )
 
 // verifyRows verifies that the rows read with the given RowIterator match up
-// with  the given rows. evalCtx and ordering are used to compare rows.
+// with the given rows. evalCtx and ordering are used to compare rows.
 func verifyRows(
-	ctx context.Context,
 	i RowIterator,
 	expectedRows rowenc.EncDatumRows,
 	evalCtx *eval.Context,
@@ -53,11 +52,22 @@ func verifyRows(
 		} else if !ok {
 			break
 		}
+		encRow, err := i.EncRow()
+		if err != nil {
+			return err
+		}
+		if cmp, err := compareEncRows(
+			types.OneIntCol, encRow, expectedRows[0], evalCtx, &tree.DatumAlloc{}, ordering,
+		); err != nil {
+			return err
+		} else if cmp != 0 {
+			return fmt.Errorf("unexpected enc row %v, expected %v", encRow, expectedRows[0])
+		}
 		row, err := i.Row()
 		if err != nil {
 			return err
 		}
-		if cmp, err := compareRows(
+		if cmp, err := compareRowToEncRow(
 			types.OneIntCol, row, expectedRows[0], evalCtx, &tree.DatumAlloc{}, ordering,
 		); err != nil {
 			return err
@@ -163,7 +173,7 @@ func TestRowContainerIterators(t *testing.T) {
 			func() {
 				i := mc.NewIterator(ctx)
 				defer i.Close()
-				if err := verifyRows(ctx, i, rows, evalCtx, ordering); err != nil {
+				if err := verifyRows(i, rows, evalCtx, ordering); err != nil {
 					t.Fatalf("rows mismatch on the run number %d: %s", k+1, err)
 				}
 			}()
@@ -176,7 +186,7 @@ func TestRowContainerIterators(t *testing.T) {
 	t.Run("NewFinalIterator", func(t *testing.T) {
 		i := mc.NewFinalIterator(ctx)
 		defer i.Close()
-		if err := verifyRows(ctx, i, rows, evalCtx, ordering); err != nil {
+		if err := verifyRows(i, rows, evalCtx, ordering); err != nil {
 			t.Fatal(err)
 		}
 		if mc.Len() != 0 {
@@ -197,56 +207,58 @@ func TestDiskBackedRowContainer(t *testing.T) {
 	}
 	defer tempEngine.Close()
 
-	// These monitors are started and stopped by subtests.
-	memoryMonitor := mon.NewMonitor(
-		"test-mem",
-		mon.MemoryResource,
-		nil,           /* curCount */
-		nil,           /* maxHist */
-		-1,            /* increment */
-		math.MaxInt64, /* noteworthy */
-		st,
-	)
-	diskMonitor := mon.NewMonitor(
-		"test-disk",
-		mon.DiskResource,
-		nil,           /* curCount */
-		nil,           /* maxHist */
-		-1,            /* increment */
-		math.MaxInt64, /* noteworthy */
-		st,
-	)
-
+	rng, _ := randutil.NewTestRand()
 	const numRows = 10
 	const numCols = 1
 	rows := randgen.MakeIntRows(numRows, numCols)
 	ordering := colinfo.ColumnOrdering{{ColIdx: 0, Direction: encoding.Ascending}}
 
-	rc := DiskBackedRowContainer{}
-	rc.Init(
-		ordering,
-		types.OneIntCol,
-		&evalCtx,
-		tempEngine,
-		memoryMonitor,
-		diskMonitor,
-	)
-	defer rc.Close(ctx)
+	getRowContainer := func(memReserved, diskReserved *mon.BoundAccount) (rc *DiskBackedRowContainer, memoryMonitor, diskMonitor *mon.BytesMonitor, cleanup func(context.Context)) {
+		memoryMonitor = mon.NewMonitor(
+			"test-mem",
+			mon.MemoryResource,
+			nil,           /* curCount */
+			nil,           /* maxHist */
+			-1,            /* increment */
+			math.MaxInt64, /* noteworthy */
+			st,
+		)
+		diskMonitor = mon.NewMonitor(
+			"test-disk",
+			mon.DiskResource,
+			nil,           /* curCount */
+			nil,           /* maxHist */
+			-1,            /* increment */
+			math.MaxInt64, /* noteworthy */
+			st,
+		)
+		memoryMonitor.Start(ctx, nil, memReserved)
+		diskMonitor.Start(ctx, nil, diskReserved)
+
+		rc = &DiskBackedRowContainer{}
+		rc.Init(
+			ordering,
+			types.OneIntCol,
+			&evalCtx,
+			tempEngine,
+			memoryMonitor,
+			diskMonitor,
+		)
+		cleanup = func(ctx context.Context) {
+			rc.Close(ctx)
+			diskMonitor.Stop(ctx)
+			memoryMonitor.Stop(ctx)
+		}
+		return rc, memoryMonitor, diskMonitor, cleanup
+	}
 
 	// NormalRun adds rows to a DiskBackedRowContainer, makes it spill to disk
 	// halfway through, keeps on adding rows, and then verifies that all rows
 	// were properly added to the DiskBackedRowContainer.
 	t.Run("NormalRun", func(t *testing.T) {
-		memoryMonitor.Start(ctx, nil, mon.NewStandaloneBudget(math.MaxInt64))
-		defer memoryMonitor.Stop(ctx)
-		diskMonitor.Start(ctx, nil, mon.NewStandaloneBudget(math.MaxInt64))
-		defer diskMonitor.Stop(ctx)
-
-		defer func() {
-			if err := rc.UnsafeReset(ctx); err != nil {
-				t.Fatal(err)
-			}
-		}()
+		memReserved, diskReserved := mon.NewStandaloneBudget(math.MaxInt64), mon.NewStandaloneBudget(math.MaxInt64)
+		rc, _, _, cleanup := getRowContainer(memReserved, diskReserved)
+		defer cleanup(ctx)
 
 		mid := len(rows) / 2
 		for i := 0; i < mid; i++ {
@@ -260,7 +272,7 @@ func TestDiskBackedRowContainer(t *testing.T) {
 		func() {
 			i := rc.NewIterator(ctx)
 			defer i.Close()
-			if err := verifyRows(ctx, i, rows[:mid], &evalCtx, ordering); err != nil {
+			if err := verifyRows(i, rows[:mid], &evalCtx, ordering); err != nil {
 				t.Fatalf("verifying memory rows failed with: %s", err)
 			}
 		}()
@@ -278,23 +290,16 @@ func TestDiskBackedRowContainer(t *testing.T) {
 		func() {
 			i := rc.NewIterator(ctx)
 			defer i.Close()
-			if err := verifyRows(ctx, i, rows, &evalCtx, ordering); err != nil {
+			if err := verifyRows(i, rows, &evalCtx, ordering); err != nil {
 				t.Fatalf("verifying disk rows failed with: %s", err)
 			}
 		}()
 	})
 
 	t.Run("AddRowOutOfMem", func(t *testing.T) {
-		memoryMonitor.Start(ctx, nil, mon.NewStandaloneBudget(1))
-		defer memoryMonitor.Stop(ctx)
-		diskMonitor.Start(ctx, nil, mon.NewStandaloneBudget(math.MaxInt64))
-		defer diskMonitor.Stop(ctx)
-
-		defer func() {
-			if err := rc.UnsafeReset(ctx); err != nil {
-				t.Fatal(err)
-			}
-		}()
+		memReserved, diskReserved := mon.NewStandaloneBudget(1), mon.NewStandaloneBudget(math.MaxInt64)
+		rc, memoryMonitor, diskMonitor, cleanup := getRowContainer(memReserved, diskReserved)
+		defer cleanup(ctx)
 
 		if err := rc.AddRow(ctx, rows[0]); err != nil {
 			t.Fatal(err)
@@ -311,16 +316,9 @@ func TestDiskBackedRowContainer(t *testing.T) {
 	})
 
 	t.Run("AddRowOutOfDisk", func(t *testing.T) {
-		memoryMonitor.Start(ctx, nil, mon.NewStandaloneBudget(1))
-		defer memoryMonitor.Stop(ctx)
-		diskMonitor.Start(ctx, nil, mon.NewStandaloneBudget(1))
-		defer diskMonitor.Stop(ctx)
-
-		defer func() {
-			if err := rc.UnsafeReset(ctx); err != nil {
-				t.Fatal(err)
-			}
-		}()
+		memReserved, diskReserved := mon.NewStandaloneBudget(1), mon.NewStandaloneBudget(1)
+		rc, memoryMonitor, diskMonitor, cleanup := getRowContainer(memReserved, diskReserved)
+		defer cleanup(ctx)
 
 		err := rc.AddRow(ctx, rows[0])
 		if code := pgerror.GetPGCode(err); code != pgcode.DiskFull {
@@ -336,6 +334,65 @@ func TestDiskBackedRowContainer(t *testing.T) {
 		}
 		if memoryMonitor.AllocBytes() != 0 {
 			t.Fatal("memory monitor reports unexpected usage")
+		}
+	})
+
+	// ConcurrentReads adds rows to a DiskBackedRowContainer (possibly spilling
+	// to disk at some point) and then verifies that all rows can be read
+	// concurrently (via separate iterators) from the container.
+	t.Run("ConcurrentReads", func(t *testing.T) {
+		memReserved, diskReserved := mon.NewStandaloneBudget(math.MaxInt64), mon.NewStandaloneBudget(math.MaxInt64)
+		rc, _, _, cleanup := getRowContainer(memReserved, diskReserved)
+		defer cleanup(ctx)
+
+		// Spill in 50% of cases.
+		spillAfter := numRows
+		if rng.Float64() < 0.5 {
+			spillAfter = rng.Intn(numRows - 1)
+		}
+		for i := 0; i < spillAfter; i++ {
+			if err := rc.AddRow(ctx, rows[i]); err != nil {
+				t.Fatal(err)
+			}
+		}
+		if rc.Spilled() {
+			t.Fatal("unexpectedly using disk")
+		}
+		if spillAfter < numRows {
+			if err := rc.SpillToDisk(ctx); err != nil {
+				t.Fatal(err)
+			}
+			if !rc.Spilled() {
+				t.Fatal("unexpectedly using memory")
+			}
+			for i := spillAfter; i < len(rows); i++ {
+				if err := rc.AddRow(ctx, rows[i]); err != nil {
+					t.Fatal(err)
+				}
+			}
+		}
+		numConcurrentReaders := 2 + rng.Intn(4)
+		errCh := make(chan error)
+		for i := 0; i < numConcurrentReaders; i++ {
+			// Creating and closing iterators must be done serially.
+			iterator := rc.NewIterator(ctx)
+			defer iterator.Close()
+			go func(iterator RowIterator) {
+				if err := verifyRows(iterator, rows, &evalCtx, ordering); err != nil {
+					errCh <- err
+				} else {
+					errCh <- nil
+				}
+			}(iterator)
+		}
+		var firstErr error
+		for i := 0; i < numConcurrentReaders; i++ {
+			if err := <-errCh; err != nil && firstErr == nil {
+				firstErr = err
+			}
+		}
+		if firstErr != nil {
+			t.Fatal(firstErr)
 		}
 	})
 }
@@ -443,7 +500,7 @@ func verifyOrdering(
 		} else if !ok {
 			break
 		}
-		row, err := i.Row()
+		row, err := i.EncRow()
 		if err != nil {
 			return err
 		}

--- a/pkg/sql/rowexec/hashjoiner.go
+++ b/pkg/sql/rowexec/hashjoiner.go
@@ -337,7 +337,7 @@ func (h *hashJoiner) probeRow() (
 	}
 
 	leftRow := h.probingRowState.row
-	rightRow, err := i.Row()
+	rightRow, err := i.EncRow()
 	if err != nil {
 		h.MoveToDraining(err)
 		return hjStateUnknown, nil, h.DrainHelper()
@@ -436,7 +436,7 @@ func (h *hashJoiner) emitRightUnmatched() (
 		return hjStateUnknown, nil, h.DrainHelper()
 	}
 
-	row, err := i.Row()
+	row, err := i.EncRow()
 	if err != nil {
 		h.MoveToDraining(err)
 		return hjStateUnknown, nil, h.DrainHelper()

--- a/pkg/sql/rowexec/sorter.go
+++ b/pkg/sql/rowexec/sorter.go
@@ -97,7 +97,7 @@ func (s *sorterBase) Next() (rowenc.EncDatumRow, *execinfrapb.ProducerMetadata) 
 			break
 		}
 
-		row, err := s.i.Row()
+		row, err := s.i.EncRow()
 		if err != nil {
 			s.MoveToDraining(err)
 			break
@@ -546,7 +546,7 @@ func (s *sortChunksProcessor) Next() (rowenc.EncDatumRow, *execinfrapb.ProducerM
 		}
 
 		// If we have an active chunk, get a row from it.
-		row, err := s.i.Row()
+		row, err := s.i.EncRow()
 		if err != nil {
 			s.MoveToDraining(err)
 			break

--- a/pkg/sql/rowexec/windower.go
+++ b/pkg/sql/rowexec/windower.go
@@ -642,7 +642,7 @@ func (w *windower) computeWindowFunctions(ctx context.Context, evalCtx *eval.Con
 		} else if !ok {
 			break
 		}
-		row, err := i.Row()
+		row, err := i.EncRow()
 		if err != nil {
 			return err
 		}
@@ -719,7 +719,7 @@ func (w *windower) populateNextOutputRow() (bool, error) {
 		} else if !ok {
 			return false, nil
 		}
-		inputRow, err := w.allRowsIterator.Row()
+		inputRow, err := w.allRowsIterator.EncRow()
 		w.allRowsIterator.Next()
 		if err != nil {
 			return false, err

--- a/pkg/sql/rowflow/routers.go
+++ b/pkg/sql/rowflow/routers.go
@@ -175,7 +175,7 @@ func (ro *routerOutput) popRowsLocked(ctx context.Context) ([]rowenc.EncDatumRow
 				} else if !ok {
 					break
 				}
-				row, err := i.Row()
+				row, err := i.EncRow()
 				if err != nil {
 					return err
 				}

--- a/pkg/sql/schema_changer.go
+++ b/pkg/sql/schema_changer.go
@@ -364,9 +364,8 @@ func (sc *SchemaChanger) backfillQueryIntoTable(
 			}
 
 			isLocal := !getPlanDistribution(
-				ctx, localPlanner, localPlanner.execCfg.NodeInfo.NodeID,
-				localPlanner.extendedEvalCtx.SessionData().DistSQLMode,
-				localPlanner.curPlan.main,
+				ctx, localPlanner.Descriptors().HasUncommittedTypes(),
+				localPlanner.extendedEvalCtx.SessionData().DistSQLMode, localPlanner.curPlan.main,
 			).WillDistribute()
 			out := execinfrapb.ProcessorCoreUnion{BulkRowWriter: &execinfrapb.BulkRowWriterSpec{
 				Table: *table.TableDesc(),

--- a/pkg/sql/testutils.go
+++ b/pkg/sql/testutils.go
@@ -185,11 +185,8 @@ func (dsp *DistSQLPlanner) ExecLocalAll(
 		distributionType)
 	planCtx.stmtType = recv.stmtType
 
-	var evalCtxFactory func() *extendedEvalContext
-	var factoryEvalCtx extendedEvalContext = extendedEvalContext{
-		Tracing: &SessionTracing{},
-	}
-	evalCtxFactory = func() *extendedEvalContext {
+	var factoryEvalCtx = extendedEvalContext{Tracing: &SessionTracing{}}
+	evalCtxFactory := func(bool) *extendedEvalContext {
 		factoryEvalCtx.Placeholders = &p.semaCtx.Placeholders
 		factoryEvalCtx.Annotations = &p.semaCtx.Annotations
 		// Query diagnostics can change the Context; make sure we are using the

--- a/pkg/sql/ttl/ttljob/ttljob.go
+++ b/pkg/sql/ttl/ttljob/ttljob.go
@@ -318,7 +318,7 @@ func (t rowLevelTTLResumer) Resume(ctx context.Context, execCtx interface{}) err
 		)
 		physicalPlan.PlanToStreamColMap = []int{}
 
-		distSQLPlanner.FinalizePlan(planCtx, physicalPlan)
+		sql.FinalizePlan(planCtx, physicalPlan)
 
 		metadataCallbackWriter := sql.NewMetadataOnlyMetadataCallbackWriter()
 

--- a/pkg/sql/walk.go
+++ b/pkg/sql/walk.go
@@ -53,7 +53,7 @@ type planVisitor struct {
 
 // makePlanVisitor creates a planVisitor instance.
 // ctx will be stored in the planVisitor and used when visiting planNode's and
-// expressions..
+// expressions.
 func makePlanVisitor(ctx context.Context, observer planObserver) planVisitor {
 	return planVisitor{observer: observer, ctx: ctx}
 }

--- a/pkg/storage/disk_map.go
+++ b/pkg/storage/disk_map.go
@@ -54,11 +54,13 @@ type pebbleMapBatchWriter struct {
 type pebbleMapIterator struct {
 	allowDuplicates bool
 	iter            pebbleiter.Iterator
-	// makeKey is a function that transforms a key into a byte slice with a prefix
-	// used to SeekGE() the underlying iterator.
-	makeKey func(k []byte) []byte
-	// prefix is the prefix of keys that this iterator iterates over.
-	prefix []byte
+	// prefixLen is the length of the prefix of keys that this iterator iterates
+	// over.
+	prefixLen int
+	// makeKeyScratch is a scratch space reused when transforming a key into a
+	// byte slice with a prefix used to SeekGE() the iterator. First prefixLen
+	// bytes are always the prefix of all keys touched by this iterator.
+	makeKeyScratch []byte
 }
 
 // pebbleMap is a SortedDiskMap, similar to rocksDBMap, that uses pebble as its
@@ -118,8 +120,8 @@ func (r *pebbleMap) NewIterator() diskmap.SortedDiskMapIterator {
 		iter: pebbleiter.MaybeWrap(r.store.NewIter(&pebble.IterOptions{
 			UpperBound: roachpb.Key(r.prefix).PrefixEnd(),
 		})),
-		makeKey: r.makeKey,
-		prefix:  r.prefix,
+		prefixLen:      len(r.prefix),
+		makeKeyScratch: append([]byte{}, r.prefix...),
 	}
 }
 
@@ -165,6 +167,14 @@ func (r *pebbleMap) Close(ctx context.Context) {
 	}
 }
 
+// makeKey is a function that transforms a key into a byte slice with a prefix
+// used to SeekGE() the underlying iterator. This key is only valid until the
+// next call to makeKey and **cannot** be mutated.
+func (i *pebbleMapIterator) makeKey(k []byte) []byte {
+	i.makeKeyScratch = append(i.makeKeyScratch[:i.prefixLen], k...)
+	return i.makeKeyScratch
+}
+
 // SeekGE implements the SortedDiskMapIterator interface.
 func (i *pebbleMapIterator) SeekGE(k []byte) {
 	i.iter.SeekGE(i.makeKey(k))
@@ -193,7 +203,7 @@ func (i *pebbleMapIterator) UnsafeKey() []byte {
 		// There are 8 bytes of sequence number at the end of the key, remove them.
 		end -= 8
 	}
-	return unsafeKey[len(i.prefix):end]
+	return unsafeKey[i.prefixLen:end]
 }
 
 // UnsafeValue implements the SortedDiskMapIterator interface.

--- a/pkg/util/mon/bytes_usage.go
+++ b/pkg/util/mon/bytes_usage.go
@@ -774,6 +774,7 @@ func (b *BoundAccount) Clear(ctx context.Context) {
 }
 
 // Close releases all the cumulated allocations of an account at once.
+// TODO(yuzefovich): consider removing this method in favor of Clear.
 func (b *BoundAccount) Close(ctx context.Context) {
 	if b == nil {
 		return


### PR DESCRIPTION
Backport 1/1 commits from #92859.
Backport 3/3 commits from #96123.
Backport 1/1 commits from #98713.

/cc @cockroachdb/release

---

**rowcontainer: support concurrent reads and some cleanup**

This commit refactors the row container infrastructure in order to make
it possible to read from a single container concurrently (via separate
iterators). It required moving some of the scratch space from the
container directly into the iterators (so that the iterators don't share
anything between each other) as well as making a similar adjustment to
the `pebbleMapIterator`. As a result, it is now possible to safely
concurrently iterate over all types of row containers; however, the
iterators need to be created and closed under mutex protection (which
seems like an acceptable limitation). This commit also makes a minor
change to make the container a named parameter inside of the iterator
(which makes it easier to see when an iterator is touching the
container).

The ability to read from the same row container (after all rows have
been added to it) concurrently will be utilized by the follow-up commit
in order to support validation of multiple FK and UNIQUE checks in
parallel.

Additionally, this commit improves `RowIterator` interface a bit by
renaming `Row` to `EncRow` (since the method returns `EncDatumRow`s) and
introducing a new `Row` implementation which returns `tree.Datums`. The
new method is now utilized in the `sql.rowContainerIterator` which
removes some of the unnecessary conversions between different row types.

Release note: None

**sql: miscellaneous cleanup and improvement**

This commit performs a bunch of minor cleanups and improvements in
preparation for the follow-up commit, in which we parallelize the
execution of post-query checks. The main rationale for changes in this
commit is making it easier to reason about concurrency-safety of
DistSQL infra.

The following changes are made:
- remove unused receiver from `FinalizePlan` and
`finalizePlanWithRowCount` methods
- remove an unused parameter from `getPlanDistribution`
- remove the reference to `planner` from `getPlanDistribution` in favor
of passing a single boolean
- refactor `resetEvalCtx` to make it concurrency-safe by extracting out
the modification of `extraTxnState` into `resetPlanner`
- refactor how `topLevelQueryStats` are aggregated across all parts of
the stmt (i.e. across the main query, subqueries, and postqueries) to
make it easier to introduce concurrency-safety to it in a follow-up
- set `planFlagVectorized` only on the main query setup and explicitly
propagate whether the flow is vectorized into `saveFlows`
- fix a couple of typos in comments.

Release note: None

**sql: parallelize FK and UNIQUE constraints**

This commit makes it so that we parallelize the execution of multiple
"check plans" (which include FOREIGN KEY and UNIQUE constraint checks
that run as "postqueries"). The main idea is that we use the LeafTxns
(derived from the RootTxn that was used for the main mutation query) and
execute each check in a separate task. As a result, the checks should be
completed faster, especially so in multi-region environments.

This required introduction of mutex-protection for several
planning-infra-related objects:
- `saveFlows` function that populates miscellaneous info, needed for the
stmt bundle
- `associateNodeWithComponents` function that creates a mapping from
`planNode`s to DistSQL processors, needed for different EXPLAIN variants
- `topLevelQueryStats.add` function that aggregates some execution stats
across all "queries" of a stmt.

Additionally, this commit also needed to make `scanBufferNode`s safe for
concurrent use. The way this works is that in the main query we have
`bufferNode` which has already accumulated some rows into a row
container. That row container can be read from concurrently as long as
the separate iterators are created (the creation and the closure must be
mutex-protected though).

All of these things are synchronized via a single "global" mutex. We
could have introduced a separate mutex for each of these things, but
a single one seems acceptable given that these operations should be
pretty quick and occur at different points throughout the checks'
execution.

Fixes: #95184.

Release note (performance improvement): The execution of multiple
FOREIGN KEY and UNIQUE constraint checks can be parallelized in some
cases. As a result, these checks can be completed faster, especially
so in multi-region environments where the checks require cross-region
reads. The feature is enabled by default on 23.1 release, and in order
to enable it on 22.2 one must change the private
`sql.distsql.parallelize_checks.enabled` cluster setting to `true`.

**sql,kv: bubble up retry errors when creating leaf transactions**

Previously, if we detected that the transaction was aborted when
trying to construct leaf transaction state, we would handle the retry
error instead of bubbling it up to the caller. When a transaction is
aborted, the `TransactionRetryWithProtoRefreshError` carries with it a
new transaction that should be used for subsequent attempts. Handling
the retry error entailed swapping out the old `TxnCoordSender` with a
new one -- one that is associated with this new transaction.

This is bug prone when trying to create multiple leaf transactions in
parallel if the root has been aborted. We would expect the first leaf
transaction to handle the error and all subsequent leaf transactions to
point to the new transaction, as the `TxnCoordSender` has been swapped
out. This wasn't an issue before as we never really created multiple
leaf transactions in parallel. This recently change in
https://github.com/cockroachdb/cockroach/commit/0f4b431af0ea0a13643b5fe8c6a172bf37a73a98, which started parallelizing FK
and uniqueness checks. With this change, we could see FK or uniqueness
violations when in fact the transaction needed to be retried.

This patch fixes the issue described above by not handling the retry
error when creating leaf transactions. Instead, we expect the
ConnExecutor to retry the entire transaction and prepare it for another
iteration.

Fixes https://github.com/cockroachdb/cockroach/issues/97141

Epic: none

Release note: None

Release justification: low-risk high-impact performance improvement disabled by default.