### PR TITLE
upgrades: ensure that create job_info synchronizes with jobs

### DIFF
--- a/pkg/upgrade/upgrades/system_job_info.go
+++ b/pkg/upgrade/upgrades/system_job_info.go
@@ -14,18 +14,40 @@ import (
 	"context"
 
 	"github.com/cockroachdb/cockroach/pkg/clusterversion"
+	"github.com/cockroachdb/cockroach/pkg/keys"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descs"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/systemschema"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
 	"github.com/cockroachdb/cockroach/pkg/upgrade"
 )
 
-// systemPrivilegesTableMigration creates the system.privileges table.
+// systemPrivilegesTableMigration creates the system.job_info table.
 func systemJobInfoTableMigration(
 	ctx context.Context, _ clusterversion.ClusterVersion, d upgrade.TenantDeps,
 ) error {
-	return createSystemTable(
+	// Create the job_info table proper.
+	if err := createSystemTable(
 		ctx, d.DB.KV(), d.Settings, d.Codec, systemschema.SystemJobInfoTable,
-	)
+	); err != nil {
+		return err
+	}
+
+	// Also bump the version of the descriptor for system.jobs. This
+	// ensures that this migration synchronizes with all other
+	// migrations that touch jobs, and concurrent transactions that
+	// perform DDL operations. We need this because just creating a new
+	// table above does not synchronize with other accesses to
+	// system.jobs on its own.
+	return d.DB.DescsTxn(ctx, func(
+		ctx context.Context, txn descs.Txn,
+	) (err error) {
+		collection := txn.Descriptors()
+		t, err := collection.MutableByID(txn.KV()).Desc(ctx, keys.JobsTableID)
+		if err != nil {
+			return err
+		}
+		return collection.WriteDesc(ctx, true /* kvTracing */, t, txn.KV())
+	})
 }
 
 const alterPayloadToNullableQuery = `


### PR DESCRIPTION
Fixes #105142.
Probably needed for #99087 and #99836.

Prior to this patch, the migration that introduced the new job_info
table did not touch any other descriptor. As such, it couldn't
synchronize properly with any concurrent code that needed to access
the jobs table.

This patch fixes it by forcing a version upgrade on the jobs table
descriptor. This triggers a lease synchronization in the upgrade
manager and results in the proper ordering.

Release note: None
Epic: None