### PR TITLE
kvserver: remove `rocksdb.block.cache.pinned-usage`

### DIFF
--- a/pkg/kv/kvserver/client_metrics_test.go
+++ b/pkg/kv/kvserver/client_metrics_test.go
@@ -156,7 +156,6 @@ func verifyStorageStats(t *testing.T, s *kvserver.Store) {
 		{m.RdbBlockCacheHits, 10},
 		{m.RdbBlockCacheMisses, 0},
 		{m.RdbBlockCacheUsage, 0},
-		{m.RdbBlockCachePinnedUsage, 0},
 		{m.RdbBloomFilterPrefixChecked, 0},
 		{m.RdbBloomFilterPrefixUseful, 0},
 		{m.RdbMemtableTotalSize, 5000},

--- a/pkg/kv/kvserver/metrics.go
+++ b/pkg/kv/kvserver/metrics.go
@@ -455,12 +455,6 @@ var (
 		Measurement: "Memory",
 		Unit:        metric.Unit_BYTES,
 	}
-	metaRdbBlockCachePinnedUsage = metric.Metadata{
-		Name:        "rocksdb.block.cache.pinned-usage",
-		Help:        "Bytes pinned by the block cache",
-		Measurement: "Memory",
-		Unit:        metric.Unit_BYTES,
-	}
 	metaRdbBloomFilterPrefixChecked = metric.Metadata{
 		Name:        "rocksdb.bloom.filter.prefix.checked",
 		Help:        "Number of times the bloom filter was checked",
@@ -1938,7 +1932,6 @@ type StoreMetrics struct {
 	RdbBlockCacheHits           *metric.Gauge
 	RdbBlockCacheMisses         *metric.Gauge
 	RdbBlockCacheUsage          *metric.Gauge
-	RdbBlockCachePinnedUsage    *metric.Gauge
 	RdbBloomFilterPrefixChecked *metric.Gauge
 	RdbBloomFilterPrefixUseful  *metric.Gauge
 	RdbMemtableTotalSize        *metric.Gauge
@@ -2518,7 +2511,6 @@ func newStoreMetrics(histogramWindow time.Duration) *StoreMetrics {
 		RdbBlockCacheHits:           metric.NewGauge(metaRdbBlockCacheHits),
 		RdbBlockCacheMisses:         metric.NewGauge(metaRdbBlockCacheMisses),
 		RdbBlockCacheUsage:          metric.NewGauge(metaRdbBlockCacheUsage),
-		RdbBlockCachePinnedUsage:    metric.NewGauge(metaRdbBlockCachePinnedUsage),
 		RdbBloomFilterPrefixChecked: metric.NewGauge(metaRdbBloomFilterPrefixChecked),
 		RdbBloomFilterPrefixUseful:  metric.NewGauge(metaRdbBloomFilterPrefixUseful),
 		RdbMemtableTotalSize:        metric.NewGauge(metaRdbMemtableTotalSize),
@@ -2862,10 +2854,6 @@ func (sm *StoreMetrics) updateEngineMetrics(m storage.Metrics) {
 	sm.RdbBlockCacheHits.Update(m.BlockCache.Hits)
 	sm.RdbBlockCacheMisses.Update(m.BlockCache.Misses)
 	sm.RdbBlockCacheUsage.Update(m.BlockCache.Size)
-	// TODO(jackson): Delete RdbBlockCachePinnedUsage or calculate the
-	// equivalent (the sum of IteratorMetrics.ReadAmp for all open iterator,
-	// times the block size).
-	sm.RdbBlockCachePinnedUsage.Update(0)
 	sm.RdbBloomFilterPrefixUseful.Update(m.Filter.Hits)
 	sm.RdbBloomFilterPrefixChecked.Update(m.Filter.Hits + m.Filter.Misses)
 	sm.RdbMemtableTotalSize.Update(int64(m.MemTable.Size))

--- a/pkg/ts/catalog/chart_catalog.go
+++ b/pkg/ts/catalog/chart_catalog.go
@@ -3080,7 +3080,6 @@ var charts = []sectionDescription{
 			{
 				Title: "Size",
 				Metrics: []string{
-					"rocksdb.block.cache.pinned-usage",
 					"rocksdb.block.cache.usage",
 				},
 			},

--- a/pkg/ui/workspaces/cluster-ui/src/store/nodes/nodes.fixtures.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/store/nodes/nodes.fixtures.ts
@@ -898,7 +898,6 @@ export const getNodeStatus = (): INodeStatus => {
           "requests.slow.raft": 0,
           "rocksdb.block.cache.hits": 52720,
           "rocksdb.block.cache.misses": 4276,
-          "rocksdb.block.cache.pinned-usage": 0,
           "rocksdb.block.cache.usage": 2034335,
           "rocksdb.bloom.filter.prefix.checked": 916,
           "rocksdb.bloom.filter.prefix.useful": 839,


### PR DESCRIPTION
Remove the `rocksdb.block.cache.pinned-usage` timeseries metric. This metric was reported by RocksDB in Cockroach versions that offered RocksDB as a storage engine (20.2 and earlier). Since the introduction of Pebble in 20.1, Pebble has never populated it, always setting its value to zero.

Epic: None
Release note (ops change): Removes a timeseries metric that has not been reported for several versions.