### PR TITLE
jwtauthccl: unskip TestSubjectReservedUser and TestAudienceCheck

### DIFF
--- a/pkg/ccl/jwtauthccl/BUILD.bazel
+++ b/pkg/ccl/jwtauthccl/BUILD.bazel
@@ -28,13 +28,13 @@ go_library(
 
 go_test(
     name = "jwtauthccl_test",
-    size = "small",
+    size = "medium",
     srcs = [
         "authentication_jwt_test.go",
         "main_test.go",
         "settings_test.go",
     ],
-    args = ["-test.timeout=55s"],
+    args = ["-test.timeout=295s"],
     embed = [":jwtauthccl"],
     tags = ["ccl_test"],
     deps = [
@@ -46,7 +46,6 @@ go_test(
         "//pkg/server",
         "//pkg/sql/pgwire/identmap",
         "//pkg/testutils/serverutils",
-        "//pkg/testutils/skip",
         "//pkg/testutils/testcluster",
         "//pkg/util/leaktest",
         "//pkg/util/log",

--- a/pkg/ccl/jwtauthccl/authentication_jwt_test.go
+++ b/pkg/ccl/jwtauthccl/authentication_jwt_test.go
@@ -23,7 +23,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/security/username"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/identmap"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
-	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
@@ -401,7 +400,6 @@ func TestSubjectMappingCheck(t *testing.T) {
 func TestSubjectReservedUser(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	skip.WithIssue(t, 100412)
 
 	ctx := context.Background()
 	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
@@ -432,7 +430,6 @@ func TestSubjectReservedUser(t *testing.T) {
 func TestAudienceCheck(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	skip.WithIssue(t, 100356)
 	ctx := context.Background()
 	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
 	defer s.Stopper().Stop(ctx)

--- a/pkg/ccl/jwtauthccl/main_test.go
+++ b/pkg/ccl/jwtauthccl/main_test.go
@@ -29,3 +29,5 @@ func TestMain(m *testing.M) {
 	serverutils.InitTestClusterFactory(testcluster.TestClusterFactory)
 	os.Exit(m.Run())
 }
+
+//go:generate ../../util/leaktest/add-leaktest.sh *_test.go

--- a/pkg/ccl/jwtauthccl/settings_test.go
+++ b/pkg/ccl/jwtauthccl/settings_test.go
@@ -11,10 +11,12 @@ package jwtauthccl
 import (
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/stretchr/testify/require"
 )
 
 func TestValidateAndParseJWTAuthIssuers(t *testing.T) {
+	defer leaktest.AfterTest(t)()
 	tests := []struct {
 		name            string
 		setting         string
@@ -57,6 +59,7 @@ func TestValidateAndParseJWTAuthIssuers(t *testing.T) {
 }
 
 func TestValidateAndParseJWTAuthAudience(t *testing.T) {
+	defer leaktest.AfterTest(t)()
 	tests := []struct {
 		name            string
 		setting         string
@@ -99,6 +102,7 @@ func TestValidateAndParseJWTAuthAudience(t *testing.T) {
 }
 
 func TestValidateAndParseJWTAuthJWKS(t *testing.T) {
+	defer leaktest.AfterTest(t)()
 	tests := []struct {
 		name          string
 		setting       string

--- a/pkg/ccl/multitenantccl/tenantcostclient/tenant_side_test.go
+++ b/pkg/ccl/multitenantccl/tenantcostclient/tenant_side_test.go
@@ -808,7 +808,7 @@ func TestWaitingRU(t *testing.T) {
 	req := tenantcostmodel.TestingRequestInfo(1, 1, 1021952, 1)
 	resp := tenantcostmodel.TestingResponseInfo(false, 0, 0, 0)
 
-	testutils.SucceedsSoon(t, func() error {
+	testutils.SucceedsWithin(t, func() error {
 		tenantcostclient.TestingSetRate(ctrl, fillRate)
 
 		var doneCount int64
@@ -860,7 +860,7 @@ func TestWaitingRU(t *testing.T) {
 		}
 
 		return errors.Errorf("RUs did not drop below 1K: %0.2f", available)
-	})
+	}, 2*time.Minute)
 }
 
 // TestConsumption verifies consumption reporting from a tenant server process.


### PR DESCRIPTION
I'm making this commit to see if these tests were failing just because the bazel timeout was too low. I'll run it in CI multiple times before merging, since previously this was only failing in CI.

Update: I ran it 10 times in CI without the test failing.

fixes https://github.com/cockroachdb/cockroach/issues/100356
fixes https://github.com/cockroachdb/cockroach/issues/100412

Release note: None