### PR TITLE
jobs: prevent a deadlock during upgrades

### DIFF
--- a/pkg/ccl/streamingccl/streamingest/stream_ingestion_job.go
+++ b/pkg/ccl/streamingccl/streamingest/stream_ingestion_job.go
@@ -99,7 +99,7 @@ type streamIngestionResumer struct {
 }
 
 func connectToActiveClient(
-	ctx context.Context, ingestionJob *jobs.Job,
+	ctx context.Context, ingestionJob *jobs.Job, db isql.DB,
 ) (streamclient.Client, error) {
 	details := ingestionJob.Details().(jobspb.StreamIngestionDetails)
 	progress := ingestionJob.Progress()
@@ -119,7 +119,7 @@ func connectToActiveClient(
 	// Without a list of addresses from existing progress we use the stream
 	// address from the creation statement
 	streamAddress := streamingccl.StreamAddress(details.StreamAddress)
-	client, err := streamclient.NewStreamClient(ctx, streamAddress, ingestionJob.GetInternalDB())
+	client, err := streamclient.NewStreamClient(ctx, streamAddress, db)
 
 	return client, errors.Wrapf(err, "ingestion job %d failed to connect to stream address or existing topology for planning", ingestionJob.ID())
 }
@@ -250,7 +250,7 @@ func ingest(ctx context.Context, execCtx sql.JobExecContext, ingestionJob *jobs.
 			return err
 		}
 	}
-	client, err := connectToActiveClient(ctx, ingestionJob)
+	client, err := connectToActiveClient(ctx, ingestionJob, execCtx.ExecCfg().InternalDB)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/github-pull-request-make/BUILD.bazel
+++ b/pkg/cmd/github-pull-request-make/BUILD.bazel
@@ -9,6 +9,7 @@ go_library(
     deps = [
         "//pkg/build/bazel",
         "//pkg/testutils/buildutil",
+        "@com_github_cockroachdb_errors//:errors",
     ],
 )
 

--- a/pkg/cmd/github-pull-request-make/main.go
+++ b/pkg/cmd/github-pull-request-make/main.go
@@ -36,6 +36,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/build/bazel"
 	_ "github.com/cockroachdb/cockroach/pkg/testutils/buildutil"
+	"github.com/cockroachdb/errors"
 )
 
 const (
@@ -251,7 +252,7 @@ func main() {
 						break
 					} else {
 						var stderr []byte
-						if exitErr, ok := err.(*exec.ExitError); ok {
+						if exitErr := (*exec.ExitError)(nil); errors.As(err, &exitErr) {
 							stderr = exitErr.Stderr
 						}
 						fmt.Printf("bazel query over pkg %s failed; got stdout %s, stderr %s\n", name, string(out), string(stderr))

--- a/pkg/jobs/adopt.go
+++ b/pkg/jobs/adopt.go
@@ -74,7 +74,7 @@ func (r *Registry) maybeDumpTrace(
 	// could have been canceled at this point.
 	dumpCtx, _ := r.makeCtx()
 
-	ieNotBoundToTxn := r.internalDB.Executor()
+	ieNotBoundToTxn := r.db.Executor()
 
 	// If the job has failed, and the dump mode is set to anything
 	// except noDump, then we should dump the trace.
@@ -538,7 +538,7 @@ RETURNING id, status
 `
 
 func (r *Registry) servePauseAndCancelRequests(ctx context.Context, s sqlliveness.Session) error {
-	return r.internalDB.Txn(ctx, func(ctx context.Context, txn isql.Txn) error {
+	return r.db.Txn(ctx, func(ctx context.Context, txn isql.Txn) error {
 		// Run the claim transaction at low priority to ensure that it does not
 		// contend with foreground reads.
 		if err := txn.KV().SetUserPriority(roachpb.MinUserPriority); err != nil {

--- a/pkg/jobs/jobs.go
+++ b/pkg/jobs/jobs.go
@@ -722,11 +722,6 @@ func (j *Job) FractionCompleted() float32 {
 	return progress.GetFractionCompleted()
 }
 
-// GetInternalDB returns the internal executor factory.
-func (j *Job) GetInternalDB() isql.DB {
-	return j.registry.internalDB
-}
-
 // MarkIdle marks the job as Idle.  Idleness should not be toggled frequently
 // (no more than ~twice a minute) as the action is logged.
 func (j *Job) MarkIdle(isIdle bool) {
@@ -826,7 +821,7 @@ func (j *Job) loadJobPayloadAndProgress(
 
 func (u Updater) load(ctx context.Context) (retErr error) {
 	if u.txn == nil {
-		return u.j.registry.internalDB.Txn(ctx, func(
+		return u.j.registry.db.Txn(ctx, func(
 			ctx context.Context, txn isql.Txn,
 		) error {
 			u.txn = txn

--- a/pkg/jobs/registry_test.go
+++ b/pkg/jobs/registry_test.go
@@ -1384,23 +1384,22 @@ func TestJobRecordMissingUsername(t *testing.T) {
 		Details:  jobspb.ImportDetails{},
 		Progress: jobspb.ImportProgress{},
 	}
-	idb := r.internalDB
 	{
-		err := idb.Txn(ctx, func(ctx context.Context, txn isql.Txn) error {
+		err := r.db.Txn(ctx, func(ctx context.Context, txn isql.Txn) error {
 			_, err := r.CreateAdoptableJobWithTxn(ctx, invalidRecord, 0, txn)
 			return err
 		})
 		assert.EqualError(t, err, "job record missing username; could not make payload")
 	}
 	{
-		err := idb.Txn(ctx, func(ctx context.Context, txn isql.Txn) error {
+		err := r.db.Txn(ctx, func(ctx context.Context, txn isql.Txn) error {
 			_, err := r.CreateJobWithTxn(ctx, invalidRecord, 0, txn)
 			return err
 		})
 		assert.EqualError(t, err, "job record missing username; could not make payload")
 	}
 	{
-		err := idb.Txn(ctx, func(ctx context.Context, txn isql.Txn) error {
+		err := r.db.Txn(ctx, func(ctx context.Context, txn isql.Txn) error {
 			_, err := r.CreateJobsWithTxn(ctx, txn, []*Record{&invalidRecord})
 			return err
 		})

--- a/pkg/jobs/update.go
+++ b/pkg/jobs/update.go
@@ -63,7 +63,7 @@ func (j *Job) maybeWithTxn(txn isql.Txn) Updater {
 
 func (u Updater) update(ctx context.Context, useReadLock bool, updateFn UpdateFn) (retErr error) {
 	if u.txn == nil {
-		return u.j.registry.internalDB.Txn(ctx, func(
+		return u.j.registry.db.Txn(ctx, func(
 			ctx context.Context, txn isql.Txn,
 		) error {
 			u.txn = txn

--- a/pkg/server/server_sql.go
+++ b/pkg/server/server_sql.go
@@ -628,7 +628,6 @@ func newSQLServer(ctx context.Context, cfg sqlServerArgs) (*SQLServer, error) {
 			cfg.AmbientCtx,
 			cfg.stopper,
 			cfg.clock,
-			cfg.internalDB,
 			cfg.rpcContext.LogicalClusterID,
 			cfg.nodeIDContainer,
 			cfg.sqlLivenessProvider,

--- a/pkg/sql/internal.go
+++ b/pkg/sql/internal.go
@@ -1539,3 +1539,70 @@ func (ief *InternalDB) txn(
 		}
 	}
 }
+
+// SessionDataOverride is a function that can be used to override some
+// fields in the session data through all uses of a isql.DB.
+//
+// This override is applied first; then any additional overrides from
+// the sessiondata.InternalExecutorOverride passed to the "*Ex()"
+// methods of Executor are applied on top.
+//
+// This particular override mechanism is useful for packages that do
+// not use the "Ex*()" methods or to safeguard the same set of
+// overrides throughout all uses (prevents mistakes due to
+// inconsistent overrides in different places).
+type SessionDataOverride = func(sd *sessiondata.SessionData)
+
+type internalDBWithOverrides struct {
+	baseDB               isql.DB
+	sessionDataOverrides []SessionDataOverride
+}
+
+var _ isql.DB = (*internalDBWithOverrides)(nil)
+
+// NewInternalDBWithSessionDataOverrides creates a new DB that wraps
+// the given DB and customizes the session data. The customizations
+// passed here are applied *before* any other customizations via the
+// sessiondata.InternalExecutorOverride parameter to the "*Ex()"
+// methods of Executor.
+func NewInternalDBWithSessionDataOverrides(
+	baseDB isql.DB, sessionDataOverrides ...SessionDataOverride,
+) isql.DB {
+	return &internalDBWithOverrides{
+		baseDB:               baseDB,
+		sessionDataOverrides: sessionDataOverrides,
+	}
+}
+
+// KV is part of the isql.DB interface.
+func (db *internalDBWithOverrides) KV() *kv.DB {
+	return db.baseDB.KV()
+}
+
+// Txn is part of the isql.DB interface.
+func (db *internalDBWithOverrides) Txn(
+	ctx context.Context, fn func(context.Context, isql.Txn) error, opts ...isql.TxnOption,
+) error {
+	return db.baseDB.Txn(ctx, func(ctx context.Context, txn isql.Txn) error {
+		for _, o := range db.sessionDataOverrides {
+			o(txn.SessionData())
+		}
+		return fn(ctx, txn)
+	}, opts...)
+}
+
+// Executor is part of the isql.DB interface.
+func (db *internalDBWithOverrides) Executor(opts ...isql.ExecutorOption) isql.Executor {
+	var cfg isql.ExecutorConfig
+	cfg.Init(opts...)
+	sd := cfg.GetSessionData()
+	if sd == nil {
+		// newSessionData is the default value used by InternalExecutor
+		// when no session data is provided otherwise.
+		sd = newSessionData(SessionArgs{})
+	}
+	for _, o := range db.sessionDataOverrides {
+		o(sd)
+	}
+	return db.baseDB.Executor(isql.WithSessionData(sd))
+}


### PR DESCRIPTION
Needed for #100436.
Informs #100578
Epic: None

Prior to this patch, if multiple SQL instances were started
side-by-side but behind on migrations, they would deadlock on
performing their migrations because distsql on each instance would be
unable to reach other other instances.

More generally, we're finding it undesirable for the jobs subsystem to
operate on system.jobs / job_info using distributed queries.

This patch fixes it by disabling query distribution during job
operations.

The testing here is implicit when the test TestServerControllerMultiNodeTenantStartup is stressed - this used to deadlock under stress without this patch.