### PR TITLE
build: use git tag to stamp 'release' builds

### DIFF
--- a/pkg/build/BUILD.bazel
+++ b/pkg/build/BUILD.bazel
@@ -19,7 +19,7 @@ go_library(
         "github.com/cockroachdb/cockroach/pkg/build.cgoTargetTriple": "{STABLE_BUILD_TARGET_TRIPLE}",
         "github.com/cockroachdb/cockroach/pkg/build.channel": "{STABLE_BUILD_CHANNEL}",
         "github.com/cockroachdb/cockroach/pkg/build.rev": "{BUILD_REV}",
-        "github.com/cockroachdb/cockroach/pkg/build.typ": "{STABLE_BUILD_TYPE}",
+        "github.com/cockroachdb/cockroach/pkg/build.releaseAs": "{BUILD_RELEASE_AS}",
         "github.com/cockroachdb/cockroach/pkg/build.utcTime": "{BUILD_UTCTIME}",
     },
     deps = [


### PR DESCRIPTION
The file version.txt was introduced to avoid the SCM state changing, such as when a new release is tagged or tags are fetched, from changing how tests run in sudden and unexpected ways. This made the build process more predictable and easier to understand, but had the additional effect of meaning that two different 'release' builds could incorrectly both identify themselves as being the same version, if the version.txt file was not edited by hand between their revisions.

This changes how specifically 'release' binaries identify their version: to mark a binary as a release binary, instead of passing a binary type of flag of 'release', we now pass the flag 'releaseAs' to the version identifier we want this release to use, calculated from the scm state using the same mechanism that was previously used to identify verisons. Unlike the previous situation where this could cause sudden and unexpected test failures in development, this behavior now *only* applies to release binaries -- and is the way to indicate a binary is a release binary.

Non-release binaries continue to identify themselves using the content of version.txt with the stamped SHA if available.

Release note: none.
Epic: none.