### PR TITLE
testserver: fix version gate for tenant capabilities

### DIFF
--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -1083,7 +1083,7 @@ func (ts *TestServer) StartTenant(
 	baseCfg.DisableTLSForHTTP = params.DisableTLSForHTTP
 	baseCfg.EnableDemoLoginEndpoint = params.EnableDemoLoginEndpoint
 
-	if st.Version.IsActive(ctx, clusterversion.V23_1TenantCapabilities) {
+	if ts.ClusterSettings().Version.IsActive(ctx, clusterversion.V23_1TenantCapabilities) {
 		_, err := ie.Exec(ctx, "testserver-alter-tenant-cap", nil,
 			"ALTER TENANT [$1] GRANT CAPABILITY can_use_nodelocal_storage", params.TenantID.ToUint64())
 		if err != nil {


### PR DESCRIPTION
This was revealed by mixed version testing, and it can flake sometimes.

Epic: None
Release note: None