### PR TITLE
roachprod: enforce consistent logging

### DIFF
--- a/pkg/cmd/roachprod/BUILD.bazel
+++ b/pkg/cmd/roachprod/BUILD.bazel
@@ -17,7 +17,6 @@ go_library(
         "//pkg/roachprod/config",
         "//pkg/roachprod/errors",
         "//pkg/roachprod/install",
-        "//pkg/roachprod/logger",
         "//pkg/roachprod/ssh",
         "//pkg/roachprod/ui",
         "//pkg/roachprod/vm",

--- a/pkg/cmd/roachprod/flags.go
+++ b/pkg/cmd/roachprod/flags.go
@@ -18,7 +18,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachprod"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/config"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/install"
-	"github.com/cockroachdb/cockroach/pkg/roachprod/logger"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/ssh"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/vm"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/vm/gce"
@@ -78,8 +77,6 @@ var (
 
 	// hostCluster is used for multi-tenant functionality.
 	hostCluster string
-
-	roachprodLibraryLogger *logger.Logger
 )
 
 func initFlags() {

--- a/pkg/cmd/roachprod/main.go
+++ b/pkg/cmd/roachprod/main.go
@@ -29,7 +29,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachprod/config"
 	rperrors "github.com/cockroachdb/cockroach/pkg/roachprod/errors"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/install"
-	"github.com/cockroachdb/cockroach/pkg/roachprod/logger"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/ui"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/vm"
 	"github.com/cockroachdb/errors"
@@ -128,7 +127,7 @@ Local Clusters
 	Args: cobra.ExactArgs(1),
 	Run: wrap(func(cmd *cobra.Command, args []string) (retErr error) {
 		createVMOpts.ClusterName = args[0]
-		return roachprod.Create(context.Background(), roachprodLibraryLogger, username, numNodes, createVMOpts, providerOptsContainer)
+		return roachprod.Create(context.Background(), config.Logger, username, numNodes, createVMOpts, providerOptsContainer)
 	}),
 }
 
@@ -147,7 +146,7 @@ if the user would like to update the keys on the remote hosts.
 
 	Args: cobra.ExactArgs(1),
 	Run: wrap(func(cmd *cobra.Command, args []string) (retErr error) {
-		return roachprod.SetupSSH(context.Background(), roachprodLibraryLogger, args[0])
+		return roachprod.SetupSSH(context.Background(), config.Logger, args[0])
 	}),
 }
 
@@ -168,7 +167,7 @@ directories inside ${HOME}/local directory are removed.
 `,
 	Args: cobra.ArbitraryArgs,
 	Run: wrap(func(cmd *cobra.Command, args []string) error {
-		return roachprod.Destroy(roachprodLibraryLogger, destroyAllMine, destroyAllLocal, args...)
+		return roachprod.Destroy(config.Logger, destroyAllMine, destroyAllLocal, args...)
 	}),
 }
 
@@ -177,7 +176,7 @@ var cachedHostsCmd = &cobra.Command{
 	Short: "list all clusters (and optionally their host numbers) from local cache",
 	Args:  cobra.NoArgs,
 	Run: wrap(func(cmd *cobra.Command, args []string) error {
-		roachprod.CachedClusters(roachprodLibraryLogger, func(clusterName string, numVMs int) {
+		roachprod.CachedClusters(config.Logger, func(clusterName string, numVMs int) {
 			if strings.HasPrefix(clusterName, "teamcity") {
 				return
 			}
@@ -245,7 +244,7 @@ hosts file.
 		if listJSON && listDetails {
 			return errors.New("'json' option cannot be combined with 'details' option")
 		}
-		filteredCloud, err := roachprod.List(roachprodLibraryLogger, listMine, listPattern)
+		filteredCloud, err := roachprod.List(config.Logger, listMine, listPattern)
 		if err != nil {
 			return err
 		}
@@ -271,7 +270,7 @@ hosts file.
 			for _, name := range names {
 				c := filteredCloud.Clusters[name]
 				if listDetails {
-					c.PrintDetails(roachprodLibraryLogger)
+					c.PrintDetails(config.Logger)
 				} else {
 					fmt.Fprintf(tw, "%s\t%s\t%d", c.Name, c.Clouds(), len(c.VMs))
 					if !c.IsLocal() {
@@ -317,7 +316,7 @@ var syncCmd = &cobra.Command{
 	Long:  ``,
 	Args:  cobra.NoArgs,
 	Run: wrap(func(cmd *cobra.Command, args []string) error {
-		_, err := roachprod.Sync(roachprodLibraryLogger, vm.ListOptions{IncludeVolumes: listOpts.IncludeVolumes})
+		_, err := roachprod.Sync(config.Logger, vm.ListOptions{IncludeVolumes: listOpts.IncludeVolumes})
 		_ = rootCmd.GenBashCompletionFile(bashCompletion)
 		return err
 	}),
@@ -333,7 +332,7 @@ hourly by a cronjob so it is not necessary to run manually.
 `,
 	Args: cobra.NoArgs,
 	Run: wrap(func(cmd *cobra.Command, args []string) error {
-		return roachprod.GC(roachprodLibraryLogger, dryrun)
+		return roachprod.GC(config.Logger, dryrun)
 	}),
 }
 
@@ -347,7 +346,7 @@ destroyed:
 `,
 	Args: cobra.ExactArgs(1),
 	Run: wrap(func(cmd *cobra.Command, args []string) error {
-		return roachprod.Extend(roachprodLibraryLogger, args[0], extendLifetime)
+		return roachprod.Extend(config.Logger, args[0], extendLifetime)
 	}),
 }
 
@@ -399,7 +398,7 @@ cluster setting will be set to its value.
 			install.EnvOption(nodeEnv),
 			install.NumRacksOption(numRacks),
 		}
-		return roachprod.Start(context.Background(), roachprodLibraryLogger, args[0], startOpts, clusterSettingsOpts...)
+		return roachprod.Start(context.Background(), config.Logger, args[0], startOpts, clusterSettingsOpts...)
 	}),
 }
 
@@ -429,7 +428,7 @@ SIGHUP), unless you also configure --max-wait.
 			wait = true
 		}
 		stopOpts := roachprod.StopOpts{Wait: wait, MaxWait: maxWait, ProcessTag: tag, Sig: sig}
-		return roachprod.Stop(context.Background(), roachprodLibraryLogger, args[0], stopOpts)
+		return roachprod.Stop(context.Background(), config.Logger, args[0], stopOpts)
 	}),
 }
 
@@ -472,7 +471,7 @@ environment variables to the cockroach process.
 			install.EnvOption(nodeEnv),
 			install.NumRacksOption(numRacks),
 		}
-		return roachprod.StartTenant(context.Background(), roachprodLibraryLogger, tenantCluster, hostCluster, startOpts, clusterSettingsOpts...)
+		return roachprod.StartTenant(context.Background(), config.Logger, tenantCluster, hostCluster, startOpts, clusterSettingsOpts...)
 	}),
 }
 
@@ -487,7 +486,7 @@ default cluster settings. It's intended to be used in conjunction with
 `,
 	Args: cobra.ExactArgs(1),
 	Run: wrap(func(cmd *cobra.Command, args []string) error {
-		return roachprod.Init(context.Background(), roachprodLibraryLogger, args[0], startOpts)
+		return roachprod.Init(context.Background(), config.Logger, args[0], startOpts)
 	}),
 }
 
@@ -507,17 +506,17 @@ The "status" command outputs the binary and PID for the specified nodes:
 `,
 	Args: cobra.ExactArgs(1),
 	Run: wrap(func(cmd *cobra.Command, args []string) error {
-		statuses, err := roachprod.Status(context.Background(), roachprodLibraryLogger, args[0], tag)
+		statuses, err := roachprod.Status(context.Background(), config.Logger, args[0], tag)
 		if err != nil {
 			return err
 		}
 		for _, status := range statuses {
 			if status.Err != nil {
-				roachprodLibraryLogger.Printf("  %2d: %s %s\n", status.NodeID, status.Err.Error())
+				config.Logger.Printf("  %2d: %s %s\n", status.NodeID, status.Err.Error())
 			} else if !status.Running {
-				roachprodLibraryLogger.Printf("  %2d: not running\n", status.NodeID)
+				config.Logger.Printf("  %2d: not running\n", status.NodeID)
 			} else {
-				roachprodLibraryLogger.Printf("  %2d: %s %s\n", status.NodeID, status.Version, status.Pid)
+				config.Logger.Printf("  %2d: %s %s\n", status.NodeID, status.Version, status.Pid)
 			}
 		}
 		return nil
@@ -545,7 +544,7 @@ into a single stream.
 		} else {
 			dest = args[0] + ".logs"
 		}
-		return roachprod.Logs(roachprodLibraryLogger, args[0], dest, username, logsOpts)
+		return roachprod.Logs(config.Logger, args[0], dest, username, logsOpts)
 	}),
 }
 
@@ -568,7 +567,7 @@ of nodes, outputting a line whenever a change is detected:
 `,
 	Args: cobra.ExactArgs(1),
 	Run: wrap(func(cmd *cobra.Command, args []string) error {
-		messages, err := roachprod.Monitor(context.Background(), roachprodLibraryLogger, args[0], monitorOpts)
+		messages, err := roachprod.Monitor(context.Background(), config.Logger, args[0], monitorOpts)
 		if err != nil {
 			return err
 		}
@@ -597,7 +596,7 @@ nodes.
 `,
 	Args: cobra.ExactArgs(1),
 	Run: wrap(func(cmd *cobra.Command, args []string) error {
-		return roachprod.Wipe(context.Background(), roachprodLibraryLogger, args[0], wipePreserveCerts)
+		return roachprod.Wipe(context.Background(), config.Logger, args[0], wipePreserveCerts)
 	}),
 }
 
@@ -627,7 +626,7 @@ the 'zfs rollback' command:
 
 	Args: cobra.ExactArgs(2),
 	Run: wrap(func(cmd *cobra.Command, args []string) error {
-		return roachprod.Reformat(context.Background(), roachprodLibraryLogger, args[0], args[1])
+		return roachprod.Reformat(context.Background(), config.Logger, args[0], args[1])
 	}),
 }
 
@@ -639,7 +638,7 @@ var runCmd = &cobra.Command{
 `,
 	Args: cobra.MinimumNArgs(1),
 	Run: wrap(func(_ *cobra.Command, args []string) error {
-		return roachprod.Run(context.Background(), roachprodLibraryLogger, args[0], extraSSHOptions, tag, secure, os.Stdout, os.Stderr, args[1:])
+		return roachprod.Run(context.Background(), config.Logger, args[0], extraSSHOptions, tag, secure, os.Stdout, os.Stderr, args[1:])
 	}),
 }
 
@@ -650,7 +649,7 @@ var resetCmd = &cobra.Command{
 environments and will fall back to a no-op.`,
 	Args: cobra.ExactArgs(1),
 	Run: wrap(func(cmd *cobra.Command, args []string) (retErr error) {
-		return roachprod.Reset(roachprodLibraryLogger, args[0])
+		return roachprod.Reset(config.Logger, args[0])
 	}),
 }
 
@@ -663,7 +662,7 @@ var installCmd = &cobra.Command{
 `,
 	Args: cobra.MinimumNArgs(2),
 	Run: wrap(func(cmd *cobra.Command, args []string) error {
-		return roachprod.Install(context.Background(), roachprodLibraryLogger, args[0], args[1:])
+		return roachprod.Install(context.Background(), config.Logger, args[0], args[1:])
 	}),
 }
 
@@ -678,7 +677,7 @@ var downloadCmd = &cobra.Command{
 		if len(args) == 4 {
 			dest = args[3]
 		}
-		return roachprod.Download(context.Background(), roachprodLibraryLogger, args[0], src, sha, dest)
+		return roachprod.Download(context.Background(), config.Logger, args[0], src, sha, dest)
 	}),
 }
 
@@ -700,7 +699,7 @@ Currently available application options are:
 		if len(args) == 2 {
 			versionArg = args[1]
 		}
-		urls, err := roachprod.StageURL(roachprodLibraryLogger, args[0], versionArg, stageOS)
+		urls, err := roachprod.StageURL(config.Logger, args[0], versionArg, stageOS)
 		if err != nil {
 			return err
 		}
@@ -739,7 +738,7 @@ Some examples of usage:
 		if len(args) == 3 {
 			versionArg = args[2]
 		}
-		return roachprod.Stage(context.Background(), roachprodLibraryLogger, args[0], stageOS, stageDir, args[1], versionArg)
+		return roachprod.Stage(context.Background(), config.Logger, args[0], stageOS, stageDir, args[1], versionArg)
 	}),
 }
 
@@ -753,7 +752,7 @@ start."
 `,
 	Args: cobra.ExactArgs(1),
 	Run: wrap(func(cmd *cobra.Command, args []string) error {
-		return roachprod.DistributeCerts(context.Background(), roachprodLibraryLogger, args[0])
+		return roachprod.DistributeCerts(context.Background(), config.Logger, args[0])
 	}),
 }
 
@@ -769,7 +768,7 @@ var putCmd = &cobra.Command{
 		if len(args) == 3 {
 			dest = args[2]
 		}
-		return roachprod.Put(context.Background(), roachprodLibraryLogger, args[0], src, dest, useTreeDist)
+		return roachprod.Put(context.Background(), config.Logger, args[0], src, dest, useTreeDist)
 	}),
 }
 
@@ -786,7 +785,7 @@ multiple nodes the destination file name will be prefixed with the node number.
 		if len(args) == 3 {
 			dest = args[2]
 		}
-		return roachprod.Get(roachprodLibraryLogger, args[0], src, dest)
+		return roachprod.Get(config.Logger, args[0], src, dest)
 	}),
 }
 
@@ -796,7 +795,7 @@ var sqlCmd = &cobra.Command{
 	Long:  "Run `cockroach sql` on a remote cluster.\n",
 	Args:  cobra.MinimumNArgs(1),
 	Run: wrap(func(cmd *cobra.Command, args []string) error {
-		return roachprod.SQL(context.Background(), roachprodLibraryLogger, args[0], secure, tenantName, args[1:])
+		return roachprod.SQL(context.Background(), config.Logger, args[0], secure, tenantName, args[1:])
 	}),
 }
 
@@ -807,7 +806,7 @@ var pgurlCmd = &cobra.Command{
 `,
 	Args: cobra.ExactArgs(1),
 	Run: wrap(func(cmd *cobra.Command, args []string) error {
-		urls, err := roachprod.PgURL(context.Background(), roachprodLibraryLogger, args[0], pgurlCertsDir, roachprod.PGURLOptions{
+		urls, err := roachprod.PgURL(context.Background(), config.Logger, args[0], pgurlCertsDir, roachprod.PGURLOptions{
 			External:   external,
 			Secure:     secure,
 			TenantName: tenantName,
@@ -842,7 +841,7 @@ Examples:
 		if cmd.CalledAs() == "pprof-heap" {
 			pprofOpts.Heap = true
 		}
-		return roachprod.Pprof(roachprodLibraryLogger, args[0], pprofOpts)
+		return roachprod.Pprof(config.Logger, args[0], pprofOpts)
 	}),
 }
 
@@ -854,7 +853,7 @@ var adminurlCmd = &cobra.Command{
 `,
 	Args: cobra.ExactArgs(1),
 	Run: wrap(func(cmd *cobra.Command, args []string) error {
-		urls, err := roachprod.AdminURL(roachprodLibraryLogger, args[0], adminurlPath, adminurlIPs, adminurlOpen, secure)
+		urls, err := roachprod.AdminURL(config.Logger, args[0], adminurlPath, adminurlIPs, adminurlOpen, secure)
 		if err != nil {
 			return err
 		}
@@ -872,7 +871,7 @@ var ipCmd = &cobra.Command{
 `,
 	Args: cobra.ExactArgs(1),
 	Run: wrap(func(cmd *cobra.Command, args []string) error {
-		ips, err := roachprod.IP(context.Background(), roachprodLibraryLogger, args[0], external)
+		ips, err := roachprod.IP(context.Background(), config.Logger, args[0], external)
 		if err != nil {
 			return err
 		}
@@ -887,7 +886,7 @@ var versionCmd = &cobra.Command{
 	Use:   `version`,
 	Short: `print version information`,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		fmt.Println(roachprod.Version(roachprodLibraryLogger))
+		fmt.Println(roachprod.Version(config.Logger))
 		return nil
 	},
 }
@@ -935,7 +934,7 @@ var grafanaStartCmd = &cobra.Command{
 			}
 		}
 
-		return roachprod.StartGrafana(context.Background(), roachprodLibraryLogger, args[0],
+		return roachprod.StartGrafana(context.Background(), config.Logger, args[0],
 			grafanaConfigURL, grafanaDashboardJSONs, nil)
 	}),
 }
@@ -945,7 +944,7 @@ var grafanaStopCmd = &cobra.Command{
 	Short: `spins down prometheus and grafana instances on the last node in the cluster`,
 	Args:  cobra.ExactArgs(1),
 	Run: wrap(func(cmd *cobra.Command, args []string) error {
-		return roachprod.StopGrafana(context.Background(), roachprodLibraryLogger, args[0], "")
+		return roachprod.StopGrafana(context.Background(), config.Logger, args[0], "")
 	}),
 }
 
@@ -957,7 +956,7 @@ var grafanaDumpCmd = &cobra.Command{
 		if grafanaDumpDir == "" {
 			return errors.New("--dump-dir unspecified")
 		}
-		return roachprod.PrometheusSnapshot(context.Background(), roachprodLibraryLogger, args[0], grafanaDumpDir)
+		return roachprod.PrometheusSnapshot(context.Background(), config.Logger, args[0], grafanaDumpDir)
 	}),
 }
 
@@ -966,7 +965,7 @@ var grafanaURLCmd = &cobra.Command{
 	Short: `returns a url to the grafana dashboard`,
 	Args:  cobra.ExactArgs(1),
 	Run: wrap(func(cmd *cobra.Command, args []string) error {
-		url, err := roachprod.GrafanaURL(context.Background(), roachprodLibraryLogger, args[0],
+		url, err := roachprod.GrafanaURL(context.Background(), config.Logger, args[0],
 			grafanaurlOpen)
 		if err != nil {
 			return err
@@ -998,7 +997,7 @@ var collectionStartCmd = &cobra.Command{
 		cluster := args[0]
 		return roachprod.StorageCollectionPerformAction(
 			context.Background(),
-			roachprodLibraryLogger,
+			config.Logger,
 			cluster,
 			"start",
 			volumeCreateOpts,
@@ -1014,7 +1013,7 @@ var collectionStopCmd = &cobra.Command{
 		cluster := args[0]
 		return roachprod.StorageCollectionPerformAction(
 			context.Background(),
-			roachprodLibraryLogger,
+			config.Logger,
 			cluster,
 			"stop",
 			volumeCreateOpts,
@@ -1030,7 +1029,7 @@ var collectionListVolumes = &cobra.Command{
 		cluster := args[0]
 		return roachprod.StorageCollectionPerformAction(
 			context.Background(),
-			roachprodLibraryLogger,
+			config.Logger,
 			cluster,
 			"list-volumes",
 			volumeCreateOpts,
@@ -1046,7 +1045,7 @@ var storageSnapshotCmd = &cobra.Command{
 		cluster := args[0]
 		name := args[1]
 		desc := args[2]
-		return roachprod.SnapshotVolume(context.Background(), roachprodLibraryLogger, cluster, name, desc)
+		return roachprod.SnapshotVolume(context.Background(), config.Logger, cluster, name, desc)
 	}),
 }
 
@@ -1058,19 +1057,11 @@ var fixLongRunningAWSHostnamesCmd = &cobra.Command{
 
 	Args: cobra.ExactArgs(1),
 	Run: wrap(func(cmd *cobra.Command, args []string) (retErr error) {
-		return roachprod.FixLongRunningAWSHostnames(context.Background(), roachprodLibraryLogger, args[0])
+		return roachprod.FixLongRunningAWSHostnames(context.Background(), config.Logger, args[0])
 	}),
 }
 
 func main() {
-	loggerCfg := logger.Config{Stdout: os.Stdout, Stderr: os.Stderr}
-	var loggerError error
-	roachprodLibraryLogger, loggerError = loggerCfg.NewLogger("")
-	if loggerError != nil {
-		fmt.Fprintf(os.Stderr, "unable to configure logger: %s\n", loggerError)
-		os.Exit(1)
-	}
-
 	_ = roachprod.InitProviders()
 	providerOptsContainer = vm.CreateProviderOptionsContainer()
 	// The commands are displayed in the order they are added to rootCmd. Note

--- a/pkg/roachprod/BUILD.bazel
+++ b/pkg/roachprod/BUILD.bazel
@@ -26,7 +26,6 @@ go_library(
         "//pkg/server/debug/replay",
         "//pkg/util/ctxgroup",
         "//pkg/util/httputil",
-        "//pkg/util/log",
         "//pkg/util/syncutil",
         "//pkg/util/timeutil",
         "@com_github_cockroachdb_errors//:errors",

--- a/pkg/roachprod/cloud/BUILD.bazel
+++ b/pkg/roachprod/cloud/BUILD.bazel
@@ -14,7 +14,6 @@ go_library(
         "//pkg/roachprod/config",
         "//pkg/roachprod/logger",
         "//pkg/roachprod/vm",
-        "//pkg/util/log",
         "//pkg/util/timeutil",
         "@com_github_aws_aws_sdk_go_v2_config//:config",
         "@com_github_aws_aws_sdk_go_v2_service_ec2//:ec2",

--- a/pkg/roachprod/cloud/cluster_cloud.go
+++ b/pkg/roachprod/cloud/cluster_cloud.go
@@ -274,21 +274,21 @@ func CreateCluster(
 }
 
 // DestroyCluster TODO(peter): document
-func DestroyCluster(c *Cluster) error {
+func DestroyCluster(l *logger.Logger, c *Cluster) error {
 	return vm.FanOut(c.VMs, func(p vm.Provider, vms vm.List) error {
 		// Enable a fast-path for providers that can destroy a cluster in one shot.
 		if x, ok := p.(vm.DeleteCluster); ok {
-			return x.DeleteCluster(c.Name)
+			return x.DeleteCluster(l, c.Name)
 		}
-		return p.Delete(vms)
+		return p.Delete(l, vms)
 	})
 }
 
 // ExtendCluster TODO(peter): document
-func ExtendCluster(c *Cluster, extension time.Duration) error {
+func ExtendCluster(l *logger.Logger, c *Cluster, extension time.Duration) error {
 	// Round new lifetime to nearest second.
 	newLifetime := (c.Lifetime + extension).Round(time.Second)
 	return vm.FanOut(c.VMs, func(p vm.Provider, vms vm.List) error {
-		return p.Extend(vms, newLifetime)
+		return p.Extend(l, vms, newLifetime)
 	})
 }

--- a/pkg/roachprod/config/BUILD.bazel
+++ b/pkg/roachprod/config/BUILD.bazel
@@ -7,6 +7,7 @@ go_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/roachprod/config",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/roachprod/logger",
         "//pkg/util/envutil",
         "//pkg/util/log",
     ],

--- a/pkg/roachprod/config/config.go
+++ b/pkg/roachprod/config/config.go
@@ -12,9 +12,11 @@ package config
 
 import (
 	"context"
+	"os"
 	"os/user"
 	"regexp"
 
+	"github.com/cockroachdb/cockroach/pkg/roachprod/logger"
 	"github.com/cockroachdb/cockroach/pkg/util/envutil"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 )
@@ -27,7 +29,12 @@ var (
 	// OSUser TODO(peter): document
 	OSUser *user.User
 	// Quiet is used to disable fancy progress output.
-	Quiet = true
+	Quiet = false
+	// The default roachprod logger.
+	// N.B. When roachprod is used via CLI, this logger is used for all output.
+	//	When roachprod is used via API (e.g. from roachtest), this logger is used only in the few cases,
+	//	during bootstrapping, at which time the caller has not yet had a chance to configure a custom logger.
+	Logger *logger.Logger
 	// MaxConcurrency specifies the maximum number of operations
 	// to execute on nodes concurrently, set to zero for infinite.
 	MaxConcurrency = 32
@@ -40,6 +47,13 @@ func init() {
 	OSUser, err = user.Current()
 	if err != nil {
 		log.Fatalf(context.Background(), "Unable to determine OS user: %v", err)
+	}
+
+	loggerCfg := logger.Config{Stdout: os.Stdout, Stderr: os.Stderr}
+	var loggerError error
+	Logger, loggerError = loggerCfg.NewLogger("")
+	if loggerError != nil {
+		log.Fatalf(context.Background(), "unable to configure logger: %v", loggerError)
 	}
 }
 

--- a/pkg/roachprod/vm/aws/BUILD.bazel
+++ b/pkg/roachprod/vm/aws/BUILD.bazel
@@ -18,7 +18,6 @@ go_library(
         "//pkg/roachprod/logger",
         "//pkg/roachprod/vm",
         "//pkg/roachprod/vm/flagstub",
-        "//pkg/util/log",
         "//pkg/util/retry",
         "//pkg/util/syncutil",
         "//pkg/util/timeutil",

--- a/pkg/roachprod/vm/aws/aws.go
+++ b/pkg/roachprod/vm/aws/aws.go
@@ -11,7 +11,6 @@
 package aws
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"math/rand"
@@ -25,7 +24,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachprod/logger"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/vm"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/vm/flagstub"
-	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/retry"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
@@ -360,13 +358,13 @@ func (o *ProviderOpts) ConfigureClusterFlags(flags *pflag.FlagSet, _ vm.Multiple
 
 // CleanSSH is part of vm.Provider.  This implementation is a no-op,
 // since we depend on the user's local identity file.
-func (p *Provider) CleanSSH() error {
+func (p *Provider) CleanSSH(l *logger.Logger) error {
 	return nil
 }
 
 // ConfigSSH is part of the vm.Provider interface.
-func (p *Provider) ConfigSSH(zones []string) error {
-	keyName, err := p.sshKeyName()
+func (p *Provider) ConfigSSH(l *logger.Logger, zones []string) error {
+	keyName, err := p.sshKeyName(l)
 	if err != nil {
 		return err
 	}
@@ -387,17 +385,16 @@ func (p *Provider) ConfigSSH(zones []string) error {
 		// capture loop variable
 		region := r
 		g.Go(func() error {
-			exists, err := p.sshKeyExists(keyName, region)
+			exists, err := p.sshKeyExists(l, keyName, region)
 			if err != nil {
 				return err
 			}
 			if !exists {
-				err = p.sshKeyImport(keyName, region)
+				err = p.sshKeyImport(l, keyName, region)
 				if err != nil {
 					return err
 				}
-				log.Infof(context.Background(), "imported %s as %s in region %s",
-					sshPublicKeyFile, keyName, region)
+				l.Printf("imported %s as %s in region %s", sshPublicKeyFile, keyName, region)
 			}
 			return nil
 		})
@@ -422,7 +419,7 @@ func (p *Provider) Create(
 	}
 
 	// We need to make sure that the SSH keys have been distributed to all regions.
-	if err := p.ConfigSSH(expandedZones); err != nil {
+	if err := p.ConfigSSH(l, expandedZones); err != nil {
 		return err
 	}
 
@@ -463,12 +460,13 @@ func (p *Provider) Create(
 		res := limiter.Reserve()
 		g.Go(func() error {
 			time.Sleep(res.Delay())
-			return p.runInstance(capName, placement, opts, providerOpts)
+			return p.runInstance(l, capName, placement, opts, providerOpts)
 		})
 	}
 	if err := g.Wait(); err != nil {
 		return err
 	}
+
 	return p.waitForIPs(l, names, regions, providerOpts)
 }
 
@@ -512,7 +510,7 @@ func (p *Provider) waitForIPs(
 
 // Delete is part of vm.Provider.
 // This will delete all instances in a single AWS command.
-func (p *Provider) Delete(vms vm.List) error {
+func (p *Provider) Delete(l *logger.Logger, vms vm.List) error {
 	byRegion, err := regionMap(vms)
 	if err != nil {
 		return err
@@ -535,20 +533,20 @@ func (p *Provider) Delete(vms vm.List) error {
 			if len(data.TerminatingInstances) > 0 {
 				_ = data.TerminatingInstances[0].InstanceID // silence unused warning
 			}
-			return p.runJSONCommand(args, &data)
+			return p.runJSONCommand(l, args, &data)
 		})
 	}
 	return g.Wait()
 }
 
 // Reset is part of vm.Provider. It is a no-op.
-func (p *Provider) Reset(vms vm.List) error {
+func (p *Provider) Reset(l *logger.Logger, vms vm.List) error {
 	return nil // unimplemented
 }
 
 // Extend is part of the vm.Provider interface.
 // This will update the Lifetime tag on the instances.
-func (p *Provider) Extend(vms vm.List, lifetime time.Duration) error {
+func (p *Provider) Extend(l *logger.Logger, vms vm.List, lifetime time.Duration) error {
 	byRegion, err := regionMap(vms)
 	if err != nil {
 		return err
@@ -565,7 +563,7 @@ func (p *Provider) Extend(vms vm.List, lifetime time.Duration) error {
 		args = append(args, list.ProviderIDs()...)
 
 		g.Go(func() error {
-			_, err := p.runCommand(args)
+			_, err := p.runCommand(l, args)
 			return err
 		})
 	}
@@ -577,19 +575,19 @@ var cachedActiveAccount string
 
 // FindActiveAccount is part of the vm.Provider interface.
 // This queries the AWS command for the current IAM user or role.
-func (p *Provider) FindActiveAccount() (string, error) {
+func (p *Provider) FindActiveAccount(l *logger.Logger) (string, error) {
 	if len(cachedActiveAccount) > 0 {
 		return cachedActiveAccount, nil
 	}
 	var account string
 	var err error
 	if p.Profile == "" {
-		account, err = p.iamGetUser()
+		account, err = p.iamGetUser(l)
 		if err != nil {
 			return "", err
 		}
 	} else {
-		account, err = p.stsGetCallerIdentity()
+		account, err = p.stsGetCallerIdentity(l)
 		if err != nil {
 			return "", err
 		}
@@ -599,14 +597,14 @@ func (p *Provider) FindActiveAccount() (string, error) {
 }
 
 // iamGetUser returns the identity of an IAM user.
-func (p *Provider) iamGetUser() (string, error) {
+func (p *Provider) iamGetUser(l *logger.Logger) (string, error) {
 	var userInfo struct {
 		User struct {
 			UserName string
 		}
 	}
 	args := []string{"iam", "get-user"}
-	err := p.runJSONCommand(args, &userInfo)
+	err := p.runJSONCommand(l, args, &userInfo)
 	if err != nil {
 		return "", err
 	}
@@ -618,12 +616,12 @@ func (p *Provider) iamGetUser() (string, error) {
 
 // stsGetCallerIdentity returns the identity of a user assuming a role
 // into the account.
-func (p *Provider) stsGetCallerIdentity() (string, error) {
+func (p *Provider) stsGetCallerIdentity(l *logger.Logger) (string, error) {
 	var userInfo struct {
 		Arn string
 	}
 	args := []string{"sts", "get-caller-identity"}
-	err := p.runJSONCommand(args, &userInfo)
+	err := p.runJSONCommand(l, args, &userInfo)
 	if err != nil {
 		return "", err
 	}
@@ -657,7 +655,7 @@ func (p *Provider) listRegions(
 		// capture loop variable
 		region := r
 		g.Go(func() error {
-			vms, err := p.listRegion(region, opts, listOpts)
+			vms, err := p.listRegion(l, region, opts, listOpts)
 			if err != nil {
 				l.Printf("Failed to list AWS VMs in region: %s\n%v\n", region, err)
 				return nil
@@ -718,7 +716,7 @@ func (p *Provider) regionZones(region string, allZones []string) (zones []string
 }
 
 func (p *Provider) getVolumesForInstance(
-	region, instanceID string,
+	l *logger.Logger, region, instanceID string,
 ) (vols map[string]vm.Volume, err error) {
 	type describeVolume struct {
 		Volumes []struct {
@@ -753,7 +751,7 @@ func (p *Provider) getVolumesForInstance(
 		"--filters", "Name=attachment.instance-id,Values=" + instanceID,
 	}
 
-	err = p.runJSONCommand(getVolumesArgs, &volumeOut)
+	err = p.runJSONCommand(l, getVolumesArgs, &volumeOut)
 	if err != nil {
 		return vols, err
 	}
@@ -775,7 +773,7 @@ func (p *Provider) getVolumesForInstance(
 // listRegion extracts the roachprod-managed instances in the
 // given region.
 func (p *Provider) listRegion(
-	region string, opts ProviderOpts, listOpt vm.ListOptions,
+	l *logger.Logger, region string, opts ProviderOpts, listOpt vm.ListOptions,
 ) (vm.List, error) {
 	var data struct {
 		Reservations []struct {
@@ -816,7 +814,7 @@ func (p *Provider) listRegion(
 		"ec2", "describe-instances",
 		"--region", region,
 	}
-	err := p.runJSONCommand(args, &data)
+	err := p.runJSONCommand(l, args, &data)
 	if err != nil {
 		return nil, err
 	}
@@ -866,7 +864,7 @@ func (p *Provider) listRegion(
 						if volMap == nil {
 							// TODO(leon, jackson): Change this to fetch the volumes in a
 							// batch instead of fetching them one at a time
-							volMap, err = p.getVolumesForInstance(region, in.InstanceID)
+							volMap, err = p.getVolumesForInstance(l, region, in.InstanceID)
 							if err != nil {
 								errs = append(errs, err)
 							}
@@ -915,7 +913,7 @@ func (p *Provider) listRegion(
 // we need to do a bit of work to look up all of the various ids that
 // we need in order to actually allocate an instance.
 func (p *Provider) runInstance(
-	name string, zone string, opts vm.CreateOpts, providerOpts *ProviderOpts,
+	l *logger.Logger, name string, zone string, opts vm.CreateOpts, providerOpts *ProviderOpts,
 ) error {
 	// There exist different flags to control the machine type when ssd is true.
 	// This enables sane defaults for either setting but the behavior can be
@@ -940,7 +938,7 @@ func (p *Provider) runInstance(
 			p.Config.regionNames(), zone)
 	}
 
-	keyName, err := p.sshKeyName()
+	keyName, err := p.sshKeyName(l)
 	if err != nil {
 		return err
 	}
@@ -1042,6 +1040,35 @@ func (p *Provider) runInstance(
 	if p.IAMProfile != "" {
 		args = append(args, "--iam-instance-profile", "Name="+p.IAMProfile)
 	}
+	ebsVolumes := assignEBSVolumes(&opts, providerOpts)
+	args, err = genDeviceMapping(ebsVolumes, args)
+	if err != nil {
+		return err
+	}
+	return p.runJSONCommand(l, args, &data)
+}
+
+func genDeviceMapping(ebsVolumes ebsVolumeList, args []string) ([]string, error) {
+	mapping, err := json.Marshal(ebsVolumes)
+	if err != nil {
+		return nil, err
+	}
+
+	deviceMapping, err := os.CreateTemp("", "aws-block-device-mapping")
+	if err != nil {
+		return nil, err
+	}
+	defer deviceMapping.Close()
+	if _, err := deviceMapping.Write(mapping); err != nil {
+		return nil, err
+	}
+	return append(args,
+		"--block-device-mapping",
+		"file://"+deviceMapping.Name(),
+	), nil
+}
+
+func assignEBSVolumes(opts *vm.CreateOpts, providerOpts *ProviderOpts) ebsVolumeList {
 	// Make a local copy of providerOpts.EBSVolumes to prevent data races
 	ebsVolumes := providerOpts.EBSVolumes
 	// The local NVMe devices are automatically mapped.  Otherwise, we need to map an EBS data volume.
@@ -1068,26 +1095,7 @@ func (p *Provider) runInstance(
 			DeleteOnTermination: true,
 		},
 	}
-	ebsVolumes = append(ebsVolumes, osDiskVolume)
-
-	mapping, err := json.Marshal(ebsVolumes)
-	if err != nil {
-		return err
-	}
-
-	deviceMapping, err := os.CreateTemp("", "aws-block-device-mapping")
-	if err != nil {
-		return err
-	}
-	defer deviceMapping.Close()
-	if _, err := deviceMapping.Write(mapping); err != nil {
-		return err
-	}
-	args = append(args,
-		"--block-device-mapping",
-		"file://"+deviceMapping.Name(),
-	)
-	return p.runJSONCommand(args, &data)
+	return append(ebsVolumes, osDiskVolume)
 }
 
 // Active is part of the vm.Provider interface.
@@ -1108,7 +1116,7 @@ type attachJsonResponse struct {
 	Device     string `json:"Device"`
 }
 
-func (p *Provider) AttachVolumeToVM(volume vm.Volume, vm *vm.VM) (string, error) {
+func (p *Provider) AttachVolumeToVM(l *logger.Logger, volume vm.Volume, vm *vm.VM) (string, error) {
 	// TODO(leon): what happens if this device already exists?
 	deviceName := "/dev/sdf"
 	args := []string{
@@ -1121,7 +1129,7 @@ func (p *Provider) AttachVolumeToVM(volume vm.Volume, vm *vm.VM) (string, error)
 	}
 
 	var commandResponse attachJsonResponse
-	err := p.runJSONCommand(args, &commandResponse)
+	err := p.runJSONCommand(l, args, &commandResponse)
 	if err != nil {
 		return "", err
 	}
@@ -1138,7 +1146,7 @@ func (p *Provider) AttachVolumeToVM(volume vm.Volume, vm *vm.VM) (string, error)
 		"--block-device-mappings",
 		"DeviceName=" + deviceName + ",Ebs={DeleteOnTermination=true,VolumeId=" + volume.ProviderResourceID + "}",
 	}
-	_, err = p.runCommand(args)
+	_, err = p.runCommand(l, args)
 	if err != nil {
 		return "", err
 	}
@@ -1159,7 +1167,9 @@ type createVolume struct {
 	Size             int       `json:"Size"`
 }
 
-func (p *Provider) CreateVolume(vco vm.VolumeCreateOpts) (vol vm.Volume, err error) {
+func (p *Provider) CreateVolume(
+	l *logger.Logger, vco vm.VolumeCreateOpts,
+) (vol vm.Volume, err error) {
 	// TODO(leon): SourceSnapshotID and IOPS, are not handled
 	if vco.SourceSnapshotID != "" || vco.IOPS != 0 {
 		err = errors.New("Creating a volume with SourceSnapshotID or IOPS is not supported at this time.")
@@ -1208,7 +1218,7 @@ func (p *Provider) CreateVolume(vco vm.VolumeCreateOpts) (vol vm.Volume, err err
 	}
 	args = append(args, "--size", strconv.Itoa(vco.Size))
 	var volumeDetails createVolume
-	err = p.runJSONCommand(args, &volumeDetails)
+	err = p.runJSONCommand(l, args, &volumeDetails)
 	if err != nil {
 		return vol, err
 	}
@@ -1231,7 +1241,7 @@ func (p *Provider) CreateVolume(vco vm.VolumeCreateOpts) (vol vm.Volume, err err
 		"--query", "Volumes[*].State",
 	}
 	for waitForVolume.Next() {
-		err = p.runJSONCommand(args, &state)
+		err = p.runJSONCommand(l, args, &state)
 		if len(state) > 0 && state[0] == "available" {
 			close(waitForVolumeCloser)
 		}
@@ -1270,7 +1280,7 @@ type snapshotOutput struct {
 }
 
 func (p *Provider) SnapshotVolume(
-	volume vm.Volume, name, description string, labels map[string]string,
+	l *logger.Logger, volume vm.Volume, name, description string, labels map[string]string,
 ) (string, error) {
 	region := volume.Zone[:len(volume.Zone)-1]
 	labels["Name"] = name
@@ -1288,6 +1298,6 @@ func (p *Provider) SnapshotVolume(
 	}
 
 	var so snapshotOutput
-	err := p.runJSONCommand(args, &so)
+	err := p.runJSONCommand(l, args, &so)
 	return so.SnapshotID, err
 }

--- a/pkg/roachprod/vm/aws/keys.go
+++ b/pkg/roachprod/vm/aws/keys.go
@@ -18,6 +18,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/cockroachdb/cockroach/pkg/roachprod/logger"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/errors/oserror"
@@ -26,7 +27,7 @@ import (
 const sshPublicKeyFile = "${HOME}/.ssh/id_rsa.pub"
 
 // sshKeyExists checks to see if there is a an SSH key with the given name in the given region.
-func (p *Provider) sshKeyExists(keyName, region string) (bool, error) {
+func (p *Provider) sshKeyExists(l *logger.Logger, keyName, region string) (bool, error) {
 	var data struct {
 		KeyPairs []struct {
 			KeyName string
@@ -36,7 +37,7 @@ func (p *Provider) sshKeyExists(keyName, region string) (bool, error) {
 		"ec2", "describe-key-pairs",
 		"--region", region,
 	}
-	err := p.runJSONCommand(args, &data)
+	err := p.runJSONCommand(l, args, &data)
 	if err != nil {
 		return false, err
 	}
@@ -50,7 +51,7 @@ func (p *Provider) sshKeyExists(keyName, region string) (bool, error) {
 
 // sshKeyImport takes the user's local, public SSH key and imports it into the ec2 region so that
 // we can create new hosts with it.
-func (p *Provider) sshKeyImport(keyName, region string) error {
+func (p *Provider) sshKeyImport(l *logger.Logger, keyName, region string) error {
 	_, err := os.Stat(os.ExpandEnv(sshPublicKeyFile))
 	if err != nil {
 		if oserror.IsNotExist(err) {
@@ -64,7 +65,7 @@ func (p *Provider) sshKeyImport(keyName, region string) error {
 	}
 	_ = data.KeyName // silence unused warning
 
-	user, err := p.FindActiveAccount()
+	user, err := p.FindActiveAccount(l)
 	if err != nil {
 		return err
 	}
@@ -83,7 +84,7 @@ func (p *Provider) sshKeyImport(keyName, region string) error {
 		"--public-key-material", fmt.Sprintf("fileb://%s", sshPublicKeyFile),
 		"--tag-specifications", tagSpecs,
 	}
-	err = p.runJSONCommand(args, &data)
+	err = p.runJSONCommand(l, args, &data)
 	// If two roachprod instances run at the same time with the same key, they may
 	// race to upload the key pair.
 	if err == nil || strings.Contains(err.Error(), "InvalidKeyPair.Duplicate") {
@@ -93,8 +94,8 @@ func (p *Provider) sshKeyImport(keyName, region string) error {
 }
 
 // sshKeyName computes the name of the ec2 ssh key that we'll store the local user's public key in
-func (p *Provider) sshKeyName() (string, error) {
-	user, err := p.FindActiveAccount()
+func (p *Provider) sshKeyName(l *logger.Logger) (string, error) {
+	user, err := p.FindActiveAccount(l)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/roachprod/vm/aws/support.go
+++ b/pkg/roachprod/vm/aws/support.go
@@ -12,15 +12,14 @@ package aws
 
 import (
 	"bytes"
-	"context"
 	"encoding/json"
 	"os"
 	"os/exec"
 	"strings"
 	"text/template"
 
+	"github.com/cockroachdb/cockroach/pkg/roachprod/logger"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/vm"
-	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/errors"
 )
 
@@ -37,6 +36,12 @@ const awsStartupScriptTemplate = `#!/usr/bin/env bash
 # Script for setting up a AWS machine for roachprod use.
 
 set -x
+
+if [ -e /mnt/data1/.roachprod-initialized ]; then
+  echo "Already initialized, exiting."
+  exit 0
+fi
+
 sudo apt-get update
 sudo apt-get install -qy --no-install-recommends mdadm
 
@@ -90,6 +95,10 @@ else
   echo "${raiddisk} ${mountpoint} ext4 ${mount_opts} 1 1" | tee -a /etc/fstab
   tune2fs -m 0 ${raiddisk}
 fi
+
+# Print the block device and FS usage output. This is useful for debugging.
+lsblk
+df -h
 
 sudo apt-get install -qy chrony
 
@@ -197,7 +206,7 @@ func writeStartupScript(
 }
 
 // runCommand is used to invoke an AWS command.
-func (p *Provider) runCommand(args []string) ([]byte, error) {
+func (p *Provider) runCommand(l *logger.Logger, args []string) ([]byte, error) {
 
 	if p.Profile != "" {
 		args = append(args[:len(args):len(args)], "--profile", p.Profile)
@@ -208,7 +217,7 @@ func (p *Provider) runCommand(args []string) ([]byte, error) {
 	output, err := cmd.Output()
 	if err != nil {
 		if exitErr := (*exec.ExitError)(nil); errors.As(err, &exitErr) {
-			log.Infof(context.Background(), "%s", string(exitErr.Stderr))
+			l.Printf("%s", string(exitErr.Stderr))
 		}
 		return nil, errors.Wrapf(err, "failed to run: aws %s: stderr: %v",
 			strings.Join(args, " "), stderrBuf.String())
@@ -217,10 +226,10 @@ func (p *Provider) runCommand(args []string) ([]byte, error) {
 }
 
 // runJSONCommand invokes an aws command and parses the json output.
-func (p *Provider) runJSONCommand(args []string, parsed interface{}) error {
+func (p *Provider) runJSONCommand(l *logger.Logger, args []string, parsed interface{}) error {
 	// Force json output in case the user has overridden the default behavior.
 	args = append(args[:len(args):len(args)], "--output", "json")
-	rawJSON, err := p.runCommand(args)
+	rawJSON, err := p.runCommand(l, args)
 	if err != nil {
 		return err
 	}

--- a/pkg/roachprod/vm/azure/BUILD.bazel
+++ b/pkg/roachprod/vm/azure/BUILD.bazel
@@ -18,7 +18,6 @@ go_library(
         "//pkg/roachprod/logger",
         "//pkg/roachprod/vm",
         "//pkg/roachprod/vm/flagstub",
-        "//pkg/util/log",
         "//pkg/util/syncutil",
         "//pkg/util/timeutil",
         "@com_github_azure_azure_sdk_for_go//profiles/latest/compute/mgmt/compute",

--- a/pkg/roachprod/vm/flagstub/flagstub.go
+++ b/pkg/roachprod/vm/flagstub/flagstub.go
@@ -32,25 +32,27 @@ type provider struct {
 	unimplemented string
 }
 
-func (p *provider) SnapshotVolume(vm.Volume, string, string, map[string]string) (string, error) {
+func (p *provider) SnapshotVolume(
+	*logger.Logger, vm.Volume, string, string, map[string]string,
+) (string, error) {
 	return "", errors.Newf("%s", p.unimplemented)
 }
 
-func (p *provider) CreateVolume(vm.VolumeCreateOpts) (vol vm.Volume, err error) {
+func (p *provider) CreateVolume(*logger.Logger, vm.VolumeCreateOpts) (vol vm.Volume, err error) {
 	return vol, errors.Newf("%s", p.unimplemented)
 }
 
-func (p *provider) AttachVolumeToVM(vm.Volume, *vm.VM) (string, error) {
+func (p *provider) AttachVolumeToVM(*logger.Logger, vm.Volume, *vm.VM) (string, error) {
 	return "", errors.Newf("%s", p.unimplemented)
 }
 
 // CleanSSH implements vm.Provider and is a no-op.
-func (p *provider) CleanSSH() error {
+func (p *provider) CleanSSH(l *logger.Logger) error {
 	return nil
 }
 
 // ConfigSSH implements vm.Provider and is a no-op.
-func (p *provider) ConfigSSH(zones []string) error {
+func (p *provider) ConfigSSH(l *logger.Logger, zones []string) error {
 	return nil
 }
 
@@ -62,22 +64,22 @@ func (p *provider) Create(
 }
 
 // Delete implements vm.Provider and returns Unimplemented.
-func (p *provider) Delete(vms vm.List) error {
+func (p *provider) Delete(l *logger.Logger, vms vm.List) error {
 	return errors.Newf("%s", p.unimplemented)
 }
 
 // Reset implements vm.Provider and is a no-op.
-func (p *provider) Reset(vms vm.List) error {
+func (p *provider) Reset(l *logger.Logger, vms vm.List) error {
 	return nil
 }
 
 // Extend implements vm.Provider and returns Unimplemented.
-func (p *provider) Extend(vms vm.List, lifetime time.Duration) error {
+func (p *provider) Extend(l *logger.Logger, vms vm.List, lifetime time.Duration) error {
 	return errors.Newf("%s", p.unimplemented)
 }
 
 // FindActiveAccount implements vm.Provider and returns an empty account.
-func (p *provider) FindActiveAccount() (string, error) {
+func (p *provider) FindActiveAccount(l *logger.Logger) (string, error) {
 	return "", nil
 }
 

--- a/pkg/roachprod/vm/gce/gcloud.go
+++ b/pkg/roachprod/vm/gce/gcloud.go
@@ -54,6 +54,9 @@ func DefaultProject() string {
 // projects for which a cron GC job exists.
 var projectsWithGC = []string{defaultProject, "andrei-jepsen"}
 
+// Denotes if this provider was successfully initialized.
+var initialized = false
+
 // Init registers the GCE provider into vm.Providers.
 //
 // If the gcloud tool is not available on the local path, the provider is a
@@ -70,6 +73,7 @@ func Init() error {
 			"(https://cloud.google.com/sdk/downloads)")
 		return errors.New("gcloud not found")
 	}
+	initialized = true
 	vm.Providers[ProviderName] = providerInstance
 	return nil
 }
@@ -294,7 +298,7 @@ type snapshotCreateJson struct {
 }
 
 func (p *Provider) SnapshotVolume(
-	volume vm.Volume, name, description string, labels map[string]string,
+	l *logger.Logger, volume vm.Volume, name, description string, labels map[string]string,
 ) (string, error) {
 	args := []string{
 		"compute",
@@ -324,9 +328,9 @@ func (p *Provider) SnapshotVolume(
 		"add-labels", name,
 		"--labels", s[:len(s)-1],
 	}
-
 	cmd := exec.Command("gcloud", args...)
 	_, err = cmd.CombinedOutput()
+
 	if err != nil {
 		return "", err
 	}
@@ -349,7 +353,9 @@ type describeVolumeCommandResponse struct {
 	Users                  []string          `json:"users"`
 }
 
-func (p *Provider) CreateVolume(vco vm.VolumeCreateOpts) (vol vm.Volume, err error) {
+func (p *Provider) CreateVolume(
+	l *logger.Logger, vco vm.VolumeCreateOpts,
+) (vol vm.Volume, err error) {
 	// TODO(leon): SourceSnapshotID and IOPS, are not handled
 	if vco.SourceSnapshotID != "" || vco.IOPS != 0 {
 		err = errors.New("Creating a volume with SourceSnapshotID or IOPS is not supported at this time.")
@@ -419,6 +425,7 @@ func (p *Provider) CreateVolume(vco vm.VolumeCreateOpts) (vol vm.Volume, err err
 	}
 	cmd := exec.Command("gcloud", args...)
 	_, err = cmd.CombinedOutput()
+
 	if err != nil {
 		return vol, err
 	}
@@ -449,7 +456,7 @@ type attachDiskCmdDisk struct {
 	Type       string `json:"type"`
 }
 
-func (p *Provider) AttachVolumeToVM(volume vm.Volume, vm *vm.VM) (string, error) {
+func (p *Provider) AttachVolumeToVM(l *logger.Logger, volume vm.Volume, vm *vm.VM) (string, error) {
 	// Volume attach
 	args := []string{
 		"compute",
@@ -634,7 +641,7 @@ func (o *ProviderOpts) ConfigureClusterFlags(flags *pflag.FlagSet, opt vm.Multip
 }
 
 // CleanSSH TODO(peter): document
-func (p *Provider) CleanSSH() error {
+func (p *Provider) CleanSSH(l *logger.Logger) error {
 	for _, prj := range p.GetProjects() {
 		args := []string{"compute", "config-ssh", "--project", prj, "--quiet", "--remove"}
 		cmd := exec.Command("gcloud", args...)
@@ -648,7 +655,7 @@ func (p *Provider) CleanSSH() error {
 }
 
 // ConfigSSH is part of the vm.Provider interface
-func (p *Provider) ConfigSSH(zones []string) error {
+func (p *Provider) ConfigSSH(l *logger.Logger, zones []string) error {
 	// Populate SSH config files with Host entries from each instance in active projects.
 	for _, prj := range p.GetProjects() {
 		args := []string{"compute", "config-ssh", "--project", prj, "--quiet"}
@@ -838,7 +845,7 @@ func min(a, b int) int {
 }
 
 // Delete TODO(peter): document
-func (p *Provider) Delete(vms vm.List) error {
+func (p *Provider) Delete(l *logger.Logger, vms vm.List) error {
 	// Map from project to map of zone to list of machines in that project/zone.
 	projectZoneMap := make(map[string]map[string][]string)
 	for _, v := range vms {
@@ -882,7 +889,7 @@ func (p *Provider) Delete(vms vm.List) error {
 }
 
 // Reset implements the vm.Provider interface.
-func (p *Provider) Reset(vms vm.List) error {
+func (p *Provider) Reset(l *logger.Logger, vms vm.List) error {
 	// Map from project to map of zone to list of machines in that project/zone.
 	projectZoneMap := make(map[string]map[string][]string)
 	for _, v := range vms {
@@ -925,7 +932,7 @@ func (p *Provider) Reset(vms vm.List) error {
 }
 
 // Extend TODO(peter): document
-func (p *Provider) Extend(vms vm.List, lifetime time.Duration) error {
+func (p *Provider) Extend(l *logger.Logger, vms vm.List, lifetime time.Duration) error {
 	// The gcloud command only takes a single instance.  Unlike Delete() above, we have to
 	// perform the iteration here.
 	for _, v := range vms {
@@ -947,7 +954,7 @@ func (p *Provider) Extend(vms vm.List, lifetime time.Duration) error {
 }
 
 // FindActiveAccount TODO(peter): document
-func (p *Provider) FindActiveAccount() (string, error) {
+func (p *Provider) FindActiveAccount(l *logger.Logger) (string, error) {
 	args := []string{"auth", "list", "--format", "json", "--filter", "status~ACTIVE"}
 
 	accounts := make([]jsonAuth, 0)
@@ -1038,7 +1045,7 @@ func (p *Provider) Name() string {
 
 // Active is part of the vm.Provider interface.
 func (p *Provider) Active() bool {
-	return true
+	return initialized
 }
 
 // ProjectActive is part of the vm.Provider interface.

--- a/pkg/roachprod/vm/gce/utils.go
+++ b/pkg/roachprod/vm/gce/utils.go
@@ -41,6 +41,8 @@ var Subdomain = func() string {
 const gceDiskStartupScriptTemplate = `#!/usr/bin/env bash
 # Script for setting up a GCE machine for roachprod use.
 
+set -x
+
 if [ -e /mnt/data1/.roachprod-initialized ]; then
   echo "Already initialized, exiting."
   exit 0
@@ -78,6 +80,7 @@ for d in $(ls /dev/disk/by-id/google-local-* /dev/disk/by-id/google-persistent-d
     echo "Disk ${d} already mounted, skipping..."
   fi
 done
+
 
 if [ "${#disks[@]}" -eq "0" ]; then
   mountpoint="${mount_prefix}1"
@@ -274,9 +277,11 @@ func SyncDNS(l *logger.Logger, vms vm.List) error {
 		return err
 	}
 	defer f.Close()
+
+	// Keep imported zone file in dry run mode.
 	defer func() {
 		if err := os.Remove(f.Name()); err != nil {
-			fmt.Fprintf(l.Stderr, "removing %s failed: %v", f.Name(), err)
+			l.Errorf("removing %s failed: %v", f.Name(), err)
 		}
 	}()
 
@@ -284,7 +289,7 @@ func SyncDNS(l *logger.Logger, vms vm.List) error {
 	for _, vm := range vms {
 		entry, err := vm.ZoneEntry()
 		if err != nil {
-			fmt.Fprintf(l.Stderr, "WARN: skipping: %s\n", err)
+			l.Printf("WARN: skipping: %s\n", err)
 			continue
 		}
 		zoneBuilder.WriteString(entry)
@@ -293,7 +298,7 @@ func SyncDNS(l *logger.Logger, vms vm.List) error {
 	f.Close()
 
 	args := []string{"--project", dnsProject, "dns", "record-sets", "import",
-		"-z", dnsZone, "--delete-all-existing", "--zone-file-format", f.Name()}
+		f.Name(), "-z", dnsZone, "--delete-all-existing", "--zone-file-format"}
 	cmd := exec.Command("gcloud", args...)
 	output, err := cmd.CombinedOutput()
 
@@ -303,7 +308,7 @@ func SyncDNS(l *logger.Logger, vms vm.List) error {
 // GetUserAuthorizedKeys retrieves reads a list of user public keys from the
 // gcloud cockroach-ephemeral project and returns them formatted for use in
 // an authorized_keys file.
-func GetUserAuthorizedKeys() (authorizedKeys []byte, err error) {
+func GetUserAuthorizedKeys(l *logger.Logger) (authorizedKeys []byte, err error) {
 	var outBuf bytes.Buffer
 	// The below command will return a stream of user:pubkey as text.
 	cmd := exec.Command("gcloud", "compute", "project-info", "describe",
@@ -311,6 +316,7 @@ func GetUserAuthorizedKeys() (authorizedKeys []byte, err error) {
 		"--format=value(commonInstanceMetadata.ssh-keys)")
 	cmd.Stderr = os.Stderr
 	cmd.Stdout = &outBuf
+
 	if err := cmd.Run(); err != nil {
 		return nil, err
 	}

--- a/pkg/roachprod/vm/vm.go
+++ b/pkg/roachprod/vm/vm.go
@@ -140,10 +140,10 @@ func (vm *VM) ZoneEntry() (string, error) {
 	return fmt.Sprintf("%s 60 IN A %s\n", vm.Name, vm.PublicIP), nil
 }
 
-func (vm *VM) AttachVolume(v Volume) (deviceName string, err error) {
+func (vm *VM) AttachVolume(l *logger.Logger, v Volume) (deviceName string, err error) {
 	vm.NonBootAttachedVolumes = append(vm.NonBootAttachedVolumes, v)
 	err = ForProvider(vm.Provider, func(provider Provider) error {
-		deviceName, err = provider.AttachVolumeToVM(v, vm)
+		deviceName, err = provider.AttachVolumeToVM(l, v, vm)
 		return err
 	})
 	return deviceName, err
@@ -276,17 +276,17 @@ type ListOptions struct {
 // A Provider is a source of virtual machines running on some hosting platform.
 type Provider interface {
 	CreateProviderOpts() ProviderOpts
-	CleanSSH() error
+	CleanSSH(l *logger.Logger) error
 
 	// ConfigSSH takes a list of zones and configures SSH for machines in those
 	// zones for the given provider.
-	ConfigSSH(zones []string) error
+	ConfigSSH(l *logger.Logger, zones []string) error
 	Create(l *logger.Logger, names []string, opts CreateOpts, providerOpts ProviderOpts) error
-	Reset(vms List) error
-	Delete(vms List) error
-	Extend(vms List, lifetime time.Duration) error
+	Reset(l *logger.Logger, vms List) error
+	Delete(l *logger.Logger, vms List) error
+	Extend(l *logger.Logger, vms List, lifetime time.Duration) error
 	// Return the account name associated with the provider
-	FindActiveAccount() (string, error)
+	FindActiveAccount(l *logger.Logger) (string, error)
 	List(l *logger.Logger, opts ListOptions) (List, error)
 	// The name of the Provider, which will also surface in the top-level Providers map.
 	Name() string
@@ -303,15 +303,15 @@ type Provider interface {
 	// provider.
 	ProjectActive(project string) bool
 
-	CreateVolume(vco VolumeCreateOpts) (Volume, error)
-	AttachVolumeToVM(volume Volume, vm *VM) (string, error)
-	SnapshotVolume(volume Volume, name, description string, labels map[string]string) (string, error)
+	CreateVolume(l *logger.Logger, vco VolumeCreateOpts) (Volume, error)
+	AttachVolumeToVM(l *logger.Logger, volume Volume, vm *VM) (string, error)
+	SnapshotVolume(l *logger.Logger, volume Volume, name, description string, labels map[string]string) (string, error)
 }
 
 // DeleteCluster is an optional capability for a Provider which can
 // destroy an entire cluster in a single operation.
 type DeleteCluster interface {
-	DeleteCluster(name string) error
+	DeleteCluster(l *logger.Logger, name string) error
 }
 
 // Providers contains all known Provider instances. This is initialized by subpackage init() functions.
@@ -378,14 +378,14 @@ var cachedActiveAccounts map[string]string
 
 // FindActiveAccounts queries the active providers for the name of the user
 // account.
-func FindActiveAccounts() (map[string]string, error) {
+func FindActiveAccounts(l *logger.Logger) (map[string]string, error) {
 	source := cachedActiveAccounts
 
 	if source == nil {
 		// Ask each Provider for its active account name.
 		source = map[string]string{}
 		err := ProvidersSequential(AllProviderNames(), func(p Provider) error {
-			account, err := p.FindActiveAccount()
+			account, err := p.FindActiveAccount(l)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
Previously, roachprod used three different logging implementations. This change ensures only roachprod/logger is used. A few miscellaneous refactoring changes are there in preparation for the upcoming PR with --dry-run mode.

Resolves: https://github.com/cockroachdb/cockroach/issues/99090
Release note: None

Epic: CRDB-10428