### PR TITLE
logictest: add skip_on_retry to tests with schema changes

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/alter_primary_key
+++ b/pkg/sql/logictest/testdata/logic_test/alter_primary_key
@@ -1005,6 +1005,8 @@ SELECT index_id, index_name FROM crdb_internal.table_indexes WHERE descriptor_na
 statement ok
 DROP TABLE IF EXISTS t
 
+skip_on_retry
+
 statement ok
 BEGIN
 

--- a/pkg/sql/logictest/testdata/logic_test/alter_table
+++ b/pkg/sql/logictest/testdata/logic_test/alter_table
@@ -2245,6 +2245,8 @@ SELECT * FROM multipleinstmt ORDER BY id ASC;
 2  b  b  false  NULL  true  NULL
 3  c  c  false  NULL  true  NULL
 
+skip_on_retry
+
 subtest column_backfiller_update_batching
 
 let $use_decl_sc

--- a/pkg/sql/logictest/testdata/logic_test/schema_change_in_txn
+++ b/pkg/sql/logictest/testdata/logic_test/schema_change_in_txn
@@ -683,6 +683,8 @@ subtest rollback_mutations
 statement ok
 INSERT INTO customers (k) VALUES ('z'), ('x')
 
+skip_on_retry
+
 statement ok
 BEGIN
 


### PR DESCRIPTION
It's unfortunate to skip these tests on txn retry errors, but this is better than the tests failing for an error that is somewhat expected.

fixes https://github.com/cockroachdb/cockroach/issues/100446
fixes https://github.com/cockroachdb/cockroach/issues/100109
fixes https://github.com/cockroachdb/cockroach/issues/100416

Release note: None