### PR TITLE
opt: opt_tester statement-bundle support

### DIFF
--- a/pkg/sql/opt/testutils/opttester/opt_tester.go
+++ b/pkg/sql/opt/testutils/opttester/opt_tester.go
@@ -550,6 +550,10 @@ func New(catalog cat.Catalog, sql string) *OptTester {
 //     build set=prefer_lookup_joins_for_fks=true
 //     DELETE FROM parent WHERE p = 3
 //     ----
+//
+//   - statement-bundle file=<path>
+//     Load the schema and stats from a statement bundle, file can be either a
+//     full path or a relative path to testdata.
 func (ot *OptTester) RunCommand(tb testing.TB, d *datadriven.TestData) string {
 	// Allow testcases to override the flags.
 	for _, a := range d.CmdArgs {
@@ -809,6 +813,12 @@ func (ot *OptTester) RunCommand(tb testing.TB, d *datadriven.TestData) string {
 			d.Fatalf(tb, "%+v", err)
 		}
 		return result
+
+	case "statement-bundle":
+		if err := ot.StatementBundle(tb); err != nil {
+			d.Fatalf(tb, "%+v", err)
+		}
+		return ""
 
 	default:
 		d.Fatalf(tb, "unsupported command: %s", d.Cmd)
@@ -2325,4 +2335,52 @@ func (ot *OptTester) ExecBuild(f exec.Factory, mem *memo.Memo, expr opt.Expr) (e
 		false, /* isANSIDML */
 	)
 	return bld.Build()
+}
+
+func (ot *OptTester) StatementBundle(tb testing.TB) error {
+	if ot.Flags.File == "" {
+		return errors.New("statement-bundle requires file argument")
+	}
+	dir := ot.Flags.File
+	f, err := os.Open(dir)
+	if err != nil {
+		// try relative path
+		dir = datapathutils.TestDataPath(tb, dir)
+		var err2 error
+		f, err2 = os.Open(dir)
+		if err2 != nil {
+			return errors.CombineErrors(err, err2)
+		}
+	}
+	s, err := f.Stat()
+	if err != nil {
+		return err
+	}
+	// TODO(cucaroach): support direct from zip
+	if !s.IsDir() {
+		return errors.New("statement-bundle argument must be a directory")
+	}
+	schema, err := os.ReadFile(filepath.Join(dir, "schema.sql"))
+	if err != nil {
+		return err
+	}
+	testCatalog := ot.catalog.(*testcat.Catalog)
+	if err := testCatalog.ExecuteMultipleDDL(string(schema)); err != nil {
+		return err
+	}
+	pat := filepath.Join(dir, "stats-*.sql")
+	files, err := filepath.Glob(pat)
+	if err != nil {
+		return err
+	}
+	for _, sf := range files {
+		stats, err := os.ReadFile(sf)
+		if err != nil {
+			return err
+		}
+		if err := testCatalog.ExecuteMultipleDDL(string(stats)); err != nil {
+			return err
+		}
+	}
+	return nil
 }

--- a/pkg/sql/opt/testutils/opttester/opt_tester_test.go
+++ b/pkg/sql/opt/testutils/opttester/opt_tester_test.go
@@ -30,6 +30,10 @@ func TestOptTester(t *testing.T) {
 			// Skip any .json files; used for inject-stats
 			return
 		}
+		if strings.HasSuffix(path, ".sql") {
+			// Skip any .sql files; used for statement-bundle
+			return
+		}
 		catalog := testcat.New()
 		datadriven.RunTest(t, path, func(t *testing.T, d *datadriven.TestData) string {
 			tester := opttester.New(catalog, d.Input)

--- a/pkg/sql/opt/testutils/opttester/testdata/bundle/schema.sql
+++ b/pkg/sql/opt/testutils/opttester/testdata/bundle/schema.sql
@@ -1,0 +1,10 @@
+CREATE TABLE public.a (
+	a INT8 NOT NULL,
+	b INT8 NULL,
+	CONSTRAINT "primary" PRIMARY KEY (a ASC),
+	FAMILY "primary" (a, b)
+);
+
+CREATE TABLE public."order" (
+    id INT8 PRIMARY KEY
+);

--- a/pkg/sql/opt/testutils/opttester/testdata/bundle/stats-defaultdb.public.a.sql
+++ b/pkg/sql/opt/testutils/opttester/testdata/bundle/stats-defaultdb.public.a.sql
@@ -1,0 +1,52 @@
+ALTER TABLE public.a INJECT STATISTICS '[
+    {
+        "columns": [
+            "a"
+        ],
+        "created_at": "2021-07-23 21:17:16.83267",
+        "distinct_count": 1000,
+        "histo_buckets": [
+            {
+                "distinct_range": 0,
+                "num_eq": 1,
+                "num_range": 0,
+                "upper_bound": "1"
+            },
+            {
+                "distinct_range": 4.919568895628329,
+                "num_eq": 1,
+                "num_range": 5,
+                "upper_bound": "1000"
+            }
+        ],
+        "histo_col_type": "INT8",
+        "name": "__auto__",
+        "null_count": 0,
+        "row_count": 1000
+    },
+    {
+        "columns": [
+            "b"
+        ],
+        "created_at": "2021-07-23 21:17:16.83267",
+        "distinct_count": 1000,
+        "histo_buckets": [
+            {
+                "distinct_range": 0,
+                "num_eq": 1,
+                "num_range": 0,
+                "upper_bound": "8"
+            },
+            {
+                "distinct_range": 998,
+                "num_eq": 1,
+                "num_range": 998,
+                "upper_bound": "1007"
+            }
+        ],
+        "histo_col_type": "INT8",
+        "name": "__auto__",
+        "null_count": 0,
+        "row_count": 1000
+    }
+]';

--- a/pkg/sql/opt/testutils/opttester/testdata/bundle/stats-defaultdb.public.order.sql
+++ b/pkg/sql/opt/testutils/opttester/testdata/bundle/stats-defaultdb.public.order.sql
@@ -1,0 +1,13 @@
+ALTER TABLE public."order" INJECT STATISTICS '[
+    {
+        "columns": [
+            "id"
+        ],
+        "created_at": "2021-06-23 21:17:16.83267",
+        "distinct_count": 0,
+        "histo_col_type": "INT8",
+        "name": "__auto__",
+        "null_count": 0,
+        "row_count": 0
+    }
+]';

--- a/pkg/sql/opt/testutils/opttester/testdata/statement-bundle
+++ b/pkg/sql/opt/testutils/opttester/testdata/statement-bundle
@@ -1,0 +1,20 @@
+statement-bundle file=bundle
+----
+
+opt
+SELECT * FROM a WHERE a > 10 AND b < 5
+---
+----
+select
+ ├── columns: a:1(int!null) b:2(int!null)
+ ├── key: (1)
+ ├── fd: (1)-->(2)
+ ├── scan a
+ │    ├── columns: a:1(int!null) b:2(int)
+ │    ├── constraint: /1: [/11 - ]
+ │    ├── key: (1)
+ │    └── fd: (1)-->(2)
+ └── filters
+      └── lt [type=bool, outer=(2), constraints=(/2: (/NULL - /4]; tight)]
+           ├── variable: b:2 [type=int]
+           └── const: 5 [type=int]


### PR DESCRIPTION
Add a statement-bundle command to opt_tester that allows the schema and stats to be loaded.

Epic: CRDB-14510
Release note: none