### PR TITLE
sql: avoid tenant ID reuse

### DIFF
--- a/pkg/multitenant/mtinfopb/info.go
+++ b/pkg/multitenant/mtinfopb/info.go
@@ -81,7 +81,7 @@ func (s TenantDataState) String() string {
 	case DataStateReady:
 		return "ready"
 	case DataStateDrop:
-		return "drop"
+		return "dropping"
 	default:
 		return fmt.Sprintf("unimplemented-%d", int(s))
 	}
@@ -89,9 +89,9 @@ func (s TenantDataState) String() string {
 
 // TenantDataStateValues facilitates the string -> TenantDataState conversion.
 var TenantDataStateValues = map[string]TenantDataState{
-	"add":   DataStateAdd,
-	"ready": DataStateReady,
-	"drop":  DataStateDrop,
+	"add":      DataStateAdd,
+	"ready":    DataStateReady,
+	"dropping": DataStateDrop,
 }
 
 // TenantInfo captures both a ProtoInfo and the SQLInfo columns that

--- a/pkg/multitenant/mtinfopb/info.go
+++ b/pkg/multitenant/mtinfopb/info.go
@@ -71,6 +71,9 @@ const (
 	// DataStateDrop indicates tenant data is being deleted. Not
 	// available for SQL sessions.
 	DataStateDrop TenantDataState = 2
+	// DataStateDeleted indicates that the tenant has been deleted. Used
+	// to ensure old IDs don't get reused.
+	DataStateDeleted TenantDataState = 3
 )
 
 // String implements fmt.Stringer.
@@ -82,6 +85,8 @@ func (s TenantDataState) String() string {
 		return "ready"
 	case DataStateDrop:
 		return "dropping"
+	case DataStateDeleted:
+		return "deleted"
 	default:
 		return fmt.Sprintf("unimplemented-%d", int(s))
 	}
@@ -92,6 +97,7 @@ var TenantDataStateValues = map[string]TenantDataState{
 	"add":      DataStateAdd,
 	"ready":    DataStateReady,
 	"dropping": DataStateDrop,
+	"deleted":  DataStateDeleted,
 }
 
 // TenantInfo captures both a ProtoInfo and the SQLInfo columns that

--- a/pkg/sql/show_tenant.go
+++ b/pkg/sql/show_tenant.go
@@ -166,7 +166,7 @@ func (n *showTenantNode) getTenantValues(
 					values.protectedTimestamp = record.Timestamp
 				}
 			}
-		case mtinfopb.DataStateReady, mtinfopb.DataStateDrop:
+		case mtinfopb.DataStateReady, mtinfopb.DataStateDrop, mtinfopb.DataStateDeleted:
 			values.dataState = values.tenantInfo.DataState.String()
 		default:
 			return nil, errors.Newf("tenant %q state is unknown: %s", tenantInfo.Name, values.tenantInfo.DataState)

--- a/pkg/sql/tenant_creation.go
+++ b/pkg/sql/tenant_creation.go
@@ -513,11 +513,7 @@ func getAvailableTenantID(
 	// since been dropped and gc'ed.
 	row, err := txn.QueryRowEx(ctx, "next-tenant-id", txn.KV(),
 		sessiondata.NodeUserSessionDataOverride, `
-   SELECT id+1 AS newid
-    FROM (VALUES (1) UNION ALL SELECT id FROM system.tenants) AS u(id)
-   WHERE NOT EXISTS (SELECT 1 FROM system.tenants t WHERE t.id=u.id+1)
-     AND ($1 = '' OR NOT EXISTS (SELECT 1 FROM system.tenants t WHERE t.name=$1))
-   ORDER BY id LIMIT 1
+   SELECT max(id)+1 AS newid FROM system.tenants
 `, tenantName)
 	if err != nil {
 		return roachpb.TenantID{}, err

--- a/pkg/sql/tenant_gc.go
+++ b/pkg/sql/tenant_gc.go
@@ -47,7 +47,7 @@ func GCTenantSync(ctx context.Context, execCfg *ExecutorConfig, info *mtinfopb.T
 	err := execCfg.InternalDB.Txn(ctx, func(ctx context.Context, txn isql.Txn) error {
 		if num, err := txn.ExecEx(
 			ctx, "delete-tenant", txn.KV(), sessiondata.NodeUserSessionDataOverride,
-			`DELETE FROM system.tenants WHERE id = $1`, info.ID,
+			`UPDATE system.tenants SET data_state = $2 WHERE id = $1`, info.ID, mtinfopb.DataStateDeleted,
 		); err != nil {
 			return errors.Wrapf(err, "deleting tenant %d", info.ID)
 		} else if num != 1 {


### PR DESCRIPTION
Prior to this patch, `DROP TENANT` would delete rows from `system.tenants` and `CREATE TENANT` would reuse IDs not already in the table.

Tenant ID reuse is known to incur correctness problems in the following two cases:

- we do not yet wait for server shutdown when the service mode is changed to 'NONE'. This makes it possible to start dropping a tenant and then reusing its ID before servers from the previous record have fully shut down. This creates a possibility for a past server to start serving traffic for a freshly created tenant, which is unacceptable.

- we have a cache of tenant capabilites on every node. We do not yet implement an invalidation protocol to clear that cache upon tenant deletion. This makes it possible for requests from a new tenant to be authorized using the capabilities of a previous tenant, which is also unacceptable.

Until we implement the necessary synchronization, we can avoid the correctness issues by preventing ID reuse.

This patch achieves this -- by preventing the deletion of rows in system.tenants.

Release note: None
Epic: CRDB-23559
Fixes #100615.