### PR TITLE
builtins: remove WaitPolicy error from fingerprinting builtin

### DIFF
--- a/pkg/sql/sem/builtins/BUILD.bazel
+++ b/pkg/sql/sem/builtins/BUILD.bazel
@@ -50,7 +50,6 @@ go_library(
         "//pkg/kv",
         "//pkg/kv/kvclient",
         "//pkg/kv/kvpb",
-        "//pkg/kv/kvserver/concurrency/lock",
         "//pkg/kv/kvserver/kvserverbase",
         "//pkg/repstream/streampb",
         "//pkg/roachpb",

--- a/pkg/sql/sem/builtins/fingerprint_builtins.go
+++ b/pkg/sql/sem/builtins/fingerprint_builtins.go
@@ -18,7 +18,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
-	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/concurrency/lock"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/eval"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
@@ -60,13 +59,6 @@ func fingerprint(
 	}
 	header := kvpb.Header{
 		Timestamp: evalCtx.Txn.ReadTimestamp(),
-		// We set WaitPolicy to Error, so that the export will return an error
-		// to us instead of a blocking wait if it hits any other txns.
-		//
-		// TODO(adityamaru): We might need to handle WriteIntentErrors
-		// specially in the future so as to allow the fingerprint to complete
-		// in the face of intents.
-		WaitPolicy: lock.WaitPolicy_Error,
 		// TODO(ssd): Setting this disables async sending in
 		// DistSender so it likely substantially impacts
 		// performance.


### PR DESCRIPTION
During development the wait policy for ExportRequests sent during fingerprinting was set to error. This meant that if the ExportRequest encountered an intent it would immediately return and error out. This is fine if we added a retry loop similar to how backup processor requeues the request to be sent at a later time by when the intent is resolved, but as is this is incorrect. We change the WaitPolicy to block so that the ExportRequest blocks until the intent is resolved. If in the future we want to make progress while another ExportRequest is stuck resolving intents we can rework this logic to look similar to our backup strategy.

Release note: None
Epic: none