### PR TITLE
pkg/server: move DataDistribution to systemAdminServer

### DIFF
--- a/pkg/server/admin.go
+++ b/pkg/server/admin.go
@@ -2973,7 +2973,14 @@ func (s *systemAdminServer) Decommission(
 }
 
 // DataDistribution returns a count of replicas on each node for each table.
-func (s *adminServer) DataDistribution(
+//
+// TODO(kv): Now that we have coalesced ranges, this endpoint no longer reports
+// accurate replica counts. Furthermore, since it doesn't take coalesced ranges
+// into account, this endpoint doesn't work for secondary tenants whose ranges are
+// *always* coalesced. Update this endpoint to handle coalesced ranges and
+// implement tenant filtering, after which it can be moved back into the
+// adminServer instead of the systemAdminServer.
+func (s *systemAdminServer) DataDistribution(
 	ctx context.Context, req *serverpb.DataDistributionRequest,
 ) (_ *serverpb.DataDistributionResponse, retErr error) {
 	if err := s.requireViewClusterMetadataPermission(ctx); err != nil {


### PR DESCRIPTION
The DataDistribution endpoint reports replica counts by database and table. When it was built, it operated off the assumption that a range would only ever contain a single table's data within.

Now that we have coalesced ranges, a single range can span multiple tables. Unfortunately, the DataDistribution endpoint does not take this fact into account, meaning it reports garbled and inaccurate data, unless the `spanconfig.storage_coalesce_adjacent.enabled` setting is set to false (see https://github.com/cockroachdb/cockroach/pull/98820).

For secondary tenants, ranges are *always* coalesced, so this endpoint in its current state could never report meaningful data for a tenant.

Given all of this, we have decided to make this endpoint only available for the system tenant. This patch
accomplishes this by moving the endpoint away from the adminServer and into the systemAdminServer, making it effectively unimplemented for secondary tenants.

Release note: none

Informs: https://github.com/cockroachdb/cockroach/issues/97942