### PR TITLE
cliccl: Add allowlist flag to sqlproxy

### DIFF
--- a/pkg/ccl/cliccl/flags.go
+++ b/pkg/ccl/cliccl/flags.go
@@ -19,6 +19,7 @@ func init() {
 	{
 		f := mtStartSQLProxyCmd.Flags()
 		cliflagcfg.StringFlag(f, &proxyContext.Denylist, cliflags.DenyList)
+		cliflagcfg.StringFlag(f, &proxyContext.Allowlist, cliflags.AllowList)
 		cliflagcfg.StringFlag(f, &proxyContext.ListenAddr, cliflags.ProxyListenAddr)
 		cliflagcfg.StringFlag(f, &proxyContext.ListenCert, cliflags.ListenCert)
 		cliflagcfg.StringFlag(f, &proxyContext.ListenKey, cliflags.ListenKey)

--- a/pkg/cli/cliflags/flags_mt.go
+++ b/pkg/cli/cliflags/flags_mt.go
@@ -29,6 +29,11 @@ var (
 		Description: "Denylist file to limit access to IP addresses and tenant ids.",
 	}
 
+	AllowList = FlagInfo{
+		Name:        "allowlist-file",
+		Description: "Allow file to limit access to tenants based on IP addresses.",
+	}
+
 	ProxyListenAddr = FlagInfo{
 		Name:        "listen-addr",
 		Description: "Listen address for incoming connections.",


### PR DESCRIPTION
proxyContext already contains the Allowlist field, but this change adds the
--allowlist-file flag to the cli.

Jira issue keys: CC-24183