### PR TITLE
storage: adapt MVCCIterator interface to return validity and error

### DIFF
--- a/pkg/ccl/backupccl/file_sst_sink.go
+++ b/pkg/ccl/backupccl/file_sst_sink.go
@@ -225,7 +225,7 @@ func (s *fileSSTSink) copyPointKeys(dataSST []byte) error {
 		LowerBound: keys.LocalMax,
 		UpperBound: keys.MaxKey,
 	}
-	iter, err := storage.NewMemSSTIterator(dataSST, false, iterOpts)
+	iter, err := storage.WithDeprecatedAPI(storage.NewMemSSTIterator(dataSST, false, iterOpts))
 	if err != nil {
 		return err
 	}
@@ -262,7 +262,7 @@ func (s *fileSSTSink) copyRangeKeys(dataSST []byte) error {
 		LowerBound: keys.LocalMax,
 		UpperBound: keys.MaxKey,
 	}
-	iter, err := storage.NewMemSSTIterator(dataSST, false, iterOpts)
+	iter, err := storage.WithDeprecatedAPI(storage.NewMemSSTIterator(dataSST, false, iterOpts))
 	if err != nil {
 		return err
 	}

--- a/pkg/ccl/backupccl/full_cluster_backup_restore_test.go
+++ b/pkg/ccl/backupccl/full_cluster_backup_restore_test.go
@@ -217,8 +217,7 @@ CREATE TABLE data2.foo (a int);
 			UpperBound: endKey,
 		})
 		defer it.Close()
-		it.SeekGE(storage.MVCCKey{Key: startKey})
-		hasKey, err := it.Valid()
+		hasKey, err := it.SeekGE(storage.MVCCKey{Key: startKey})
 		require.NoError(t, err)
 		require.False(t, hasKey, "did not expect to find a key, found %s", it.UnsafeKey())
 	})

--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -2444,11 +2444,11 @@ func fetchDescVersionModificationTime(
 		t.Fatal(pErr.GoError())
 	}
 	for _, file := range res.(*kvpb.ExportResponse).Files {
-		it, err := storage.NewMemSSTIterator(file.SST, false /* verify */, storage.IterOptions{
+		it, err := storage.WithDeprecatedAPI(storage.NewMemSSTIterator(file.SST, false /* verify */, storage.IterOptions{
 			KeyTypes:   storage.IterKeyTypePointsAndRanges,
 			LowerBound: keys.MinKey,
 			UpperBound: keys.MaxKey,
-		})
+		}))
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/pkg/ccl/changefeedccl/schemafeed/schema_feed.go
+++ b/pkg/ccl/changefeedccl/schemafeed/schema_feed.go
@@ -651,12 +651,12 @@ func (tf *schemaFeed) fetchDescriptorVersions(
 		exportResp := res.(*kvpb.ExportResponse)
 		for _, file := range exportResp.Files {
 			if err := func() error {
-				it, err := storage.NewMemSSTIterator(file.SST, false /* verify */, storage.IterOptions{
+				it, err := storage.WithDeprecatedAPI(storage.NewMemSSTIterator(file.SST, false /* verify */, storage.IterOptions{
 					// NB: We assume there will be no MVCC range tombstones here.
 					KeyTypes:   storage.IterKeyTypePointsOnly,
 					LowerBound: keys.MinKey,
 					UpperBound: keys.MaxKey,
-				})
+				}))
 				if err != nil {
 					return err
 				}

--- a/pkg/ccl/storageccl/engineccl/bench_test.go
+++ b/pkg/ccl/storageccl/engineccl/bench_test.go
@@ -151,14 +151,12 @@ func runIterate(
 		}
 		it := makeIterator(eng, startTime, endTime)
 		defer it.Close()
-		for it.SeekGE(storage.MVCCKey{Key: keys.LocalMax}); ; it.Next() {
-			if ok, err := it.Valid(); !ok {
-				if err != nil {
-					b.Fatal(err)
-				}
-				break
-			}
+		ok, err := it.SeekGE(storage.MVCCKey{Key: keys.LocalMax})
+		for ; ok; ok, err = it.Next() {
 			n++
+		}
+		if err != nil {
+			b.Fatal(err)
 		}
 		if e := int(loadFactor * numKeys); n < e {
 			b.Fatalf("expected at least %d keys, but got %d\n", e, n)

--- a/pkg/ccl/storageccl/external_sst_reader_test.go
+++ b/pkg/ccl/storageccl/external_sst_reader_test.go
@@ -162,11 +162,9 @@ func TestNewExternalSSTReader(t *testing.T) {
 
 	iter, err := ExternalSSTReader(ctx, fileStores, nil, iterOpts)
 	require.NoError(t, err)
-	for iter.SeekGE(storage.MVCCKey{Key: keys.LocalMax}); ; iter.Next() {
-		ok, err := iter.Valid()
-		require.NoError(t, err)
-		if !ok {
-			break
-		}
+	ok, err := iter.SeekGE(storage.MVCCKey{Key: keys.LocalMax})
+	for ok {
+		ok, err = iter.Next()
 	}
+	require.NoError(t, err)
 }

--- a/pkg/ccl/streamingccl/replicationutils/utils.go
+++ b/pkg/ccl/streamingccl/replicationutils/utils.go
@@ -56,12 +56,12 @@ func ScanSST(
 
 	// We iterate points and ranges separately on the SST for clarity
 	// and simplicity.
-	pointIter, err := storage.NewMemSSTIterator(sst.Data, true,
+	pointIter, err := storage.WithDeprecatedAPI(storage.NewMemSSTIterator(sst.Data, true,
 		storage.IterOptions{
 			KeyTypes: storage.IterKeyTypePointsOnly,
 			// Only care about upper bound as we are iterating forward.
 			UpperBound: scanWithin.EndKey,
-		})
+		}))
 	if err != nil {
 		return err
 	}
@@ -85,11 +85,11 @@ func ScanSST(
 		}
 	}
 
-	rangeIter, err := storage.NewMemSSTIterator(sst.Data, true,
+	rangeIter, err := storage.WithDeprecatedAPI(storage.NewMemSSTIterator(sst.Data, true,
 		storage.IterOptions{
 			KeyTypes:   storage.IterKeyTypeRangesOnly,
 			UpperBound: scanWithin.EndKey,
-		})
+		}))
 	if err != nil {
 		return err
 	}

--- a/pkg/ccl/streamingccl/streamingest/rangekey_batcher_test.go
+++ b/pkg/ccl/streamingccl/streamingest/rangekey_batcher_test.go
@@ -173,15 +173,11 @@ func rangeKeysInSSTToString(t *testing.T, data []byte) string {
 	require.NoError(t, err)
 	defer iter.Close()
 
-	iter.SeekGE(storage.MVCCKey{Key: roachpb.KeyMin})
-	for {
-		if ok, err := iter.Valid(); err != nil {
-			t.Fatal(err)
-		} else if !ok {
-			break
-		}
+	ok, err := iter.SeekGE(storage.MVCCKey{Key: roachpb.KeyMin})
+	for ok {
 		fmt.Fprintf(&buf, "%v\n", iter.RangeKeys())
-		iter.Next()
+		ok, err = iter.Next()
 	}
+	require.NoError(t, err)
 	return strings.TrimSpace(buf.String())
 }

--- a/pkg/ccl/streamingccl/streamingest/replication_random_client_test.go
+++ b/pkg/ccl/streamingccl/streamingest/replication_random_client_test.go
@@ -312,10 +312,10 @@ func assertExactlyEqualKVs(
 ) hlc.Timestamp {
 	// Iterate over the store.
 	store := tc.GetFirstStoreFromServer(t, 0)
-	it := store.TODOEngine().NewMVCCIterator(storage.MVCCKeyIterKind, storage.IterOptions{
+	it := storage.DeprecatedMVCCIterator{store.TODOEngine().NewMVCCIterator(storage.MVCCKeyIterKind, storage.IterOptions{
 		LowerBound: tenantPrefix,
 		UpperBound: tenantPrefix.PrefixEnd(),
-	})
+	})}
 	defer it.Close()
 	var prevKey roachpb.Key
 	var valueTimestampTuples []roachpb.KeyValue

--- a/pkg/ccl/streamingccl/streamingest/stream_ingestion_processor.go
+++ b/pkg/ccl/streamingccl/streamingest/stream_ingestion_processor.go
@@ -972,11 +972,11 @@ func splitRangeKeySSTAtKey(
 		return nil
 	}
 
-	iter, err := storage.NewMemSSTIterator(data, true, storage.IterOptions{
+	iter, err := storage.WithDeprecatedAPI(storage.NewMemSSTIterator(data, true, storage.IterOptions{
 		KeyTypes:   storage.IterKeyTypeRangesOnly,
 		LowerBound: start,
 		UpperBound: end,
-	})
+	}))
 	if err != nil {
 		return nil, nil, err
 	}

--- a/pkg/ccl/streamingccl/streamingest/stream_ingestion_processor_test.go
+++ b/pkg/ccl/streamingccl/streamingest/stream_ingestion_processor_test.go
@@ -378,10 +378,10 @@ func assertEqualKVs(
 	// Iterate over the store.
 	store, err := srv.GetStores().(*kvserver.Stores).GetStore(srv.GetFirstStoreID())
 	require.NoError(t, err)
-	it := store.TODOEngine().NewMVCCIterator(storage.MVCCKeyAndIntentsIterKind, storage.IterOptions{
+	it := storage.DeprecatedMVCCIterator{store.TODOEngine().NewMVCCIterator(storage.MVCCKeyAndIntentsIterKind, storage.IterOptions{
 		LowerBound: targetSpan.Key,
 		UpperBound: targetSpan.EndKey,
-	})
+	})}
 	defer it.Close()
 	var prevKey roachpb.Key
 	var valueTimestampTuples []roachpb.KeyValue

--- a/pkg/kv/bulk/sst_batcher_test.go
+++ b/pkg/kv/bulk/sst_batcher_test.go
@@ -80,14 +80,10 @@ func TestDuplicateHandling(t *testing.T) {
 			it, err := storage.NewMemSSTIterator(file.SST, false /* verify */, iterOpts)
 			require.NoError(t, err)
 			defer it.Close()
-			for it.SeekGE(storage.NilKey); ; it.Next() {
-				ok, err := it.Valid()
-				require.NoError(t, err)
-				if !ok {
-					break
-				}
+			require.NoError(t, storage.Iterate(it, storage.NilKey, func(storage.IteratorPos) error {
 				keyCount++
-			}
+				return nil
+			}))
 		}
 		require.Equal(t, count, keyCount)
 	}

--- a/pkg/kv/kvclient/revision_reader.go
+++ b/pkg/kv/kvclient/revision_reader.go
@@ -60,12 +60,12 @@ func GetAllRevisions(
 				LowerBound: file.Span.Key,
 				UpperBound: file.Span.EndKey,
 			}
-			iter, err := storage.NewMemSSTIterator(file.SST, true, iterOpts)
+			iter, err := storage.WithDeprecatedAPI(storage.NewMemSSTIterator(file.SST, true, iterOpts))
 			if err != nil {
 				return err
 			}
 			defer func() {
-				if iter != nil {
+				if iter.MVCCIterator != nil {
 					iter.Close()
 				}
 			}()
@@ -98,7 +98,7 @@ func GetAllRevisions(
 
 			// Close and nil out the iter to release the underlying resources.
 			iter.Close()
-			iter = nil
+			iter.MVCCIterator = nil
 		}
 
 		select {

--- a/pkg/kv/kvnemesis/operations.go
+++ b/pkg/kv/kvnemesis/operations.go
@@ -263,11 +263,11 @@ func (op AddSSTableOperation) format(w *strings.Builder, fctx formatCtx) {
 		fmt.Fprintf(w, ` (as writes)`)
 	}
 
-	iter, err := storage.NewMemSSTIterator(op.Data, false /* verify */, storage.IterOptions{
+	iter, err := storage.WithDeprecatedAPI(storage.NewMemSSTIterator(op.Data, false /* verify */, storage.IterOptions{
 		KeyTypes:   storage.IterKeyTypePointsAndRanges,
 		LowerBound: keys.MinKey,
 		UpperBound: keys.MaxKey,
-	})
+	}))
 	if err != nil {
 		panic(err)
 	}

--- a/pkg/kv/kvnemesis/validator.go
+++ b/pkg/kv/kvnemesis/validator.go
@@ -564,11 +564,11 @@ func (v *validator) processOp(op Operation) {
 			break
 		}
 		err := func() error {
-			iter, err := storage.NewMemSSTIterator(t.Data, false /* verify */, storage.IterOptions{
+			iter, err := storage.WithDeprecatedAPI(storage.NewMemSSTIterator(t.Data, false /* verify */, storage.IterOptions{
 				KeyTypes:   storage.IterKeyTypePointsAndRanges,
 				LowerBound: keys.MinKey,
 				UpperBound: keys.MaxKey,
-			})
+			}))
 			if err != nil {
 				return err
 			}

--- a/pkg/kv/kvnemesis/watcher.go
+++ b/pkg/kv/kvnemesis/watcher.go
@@ -307,11 +307,11 @@ func (w *Watcher) handleSSTable(ctx context.Context, data []byte) error {
 		return errors.AssertionFailedf("no SST data found")
 	}
 
-	iter, err := storage.NewMemSSTIterator(data, false /* verify */, storage.IterOptions{
+	iter, err := storage.WithDeprecatedAPI(storage.NewMemSSTIterator(data, false /* verify */, storage.IterOptions{
 		KeyTypes:   storage.IterKeyTypePointsAndRanges,
 		LowerBound: keys.MinKey,
 		UpperBound: keys.MaxKey,
-	})
+	}))
 	if err != nil {
 		return err
 	}

--- a/pkg/kv/kvserver/batch_spanset_test.go
+++ b/pkg/kv/kvserver/batch_spanset_test.go
@@ -158,32 +158,27 @@ func TestSpanSetBatchBoundaries(t *testing.T) {
 		defer iter.Close()
 
 		// MVCCIterators check boundaries on seek and next/prev
-		iter.SeekGE(outsideKey)
-		if _, err := iter.Valid(); !isReadSpanErr(err) {
+		if _, err := iter.SeekGE(outsideKey); !isReadSpanErr(err) {
 			t.Fatalf("Seek: unexpected error %v", err)
 		}
-		iter.SeekGE(outsideKey3)
-		if _, err := iter.Valid(); !isReadSpanErr(err) {
+		if _, err := iter.SeekGE(outsideKey3); !isReadSpanErr(err) {
 			t.Fatalf("Seek: unexpected error %v", err)
 		}
 		// Seeking back in bounds restores validity.
-		iter.SeekGE(insideKey)
-		if ok, err := iter.Valid(); !ok || err != nil {
+		if ok, err := iter.SeekGE(insideKey); !ok || err != nil {
 			t.Fatalf("expected valid iterator, err=%v", err)
 		}
 		if !reflect.DeepEqual(iter.UnsafeKey(), insideKey) {
 			t.Fatalf("expected key %s, got %s", insideKey, iter.UnsafeKey())
 		}
-		iter.Next()
-		if ok, err := iter.Valid(); !ok || err != nil {
+		if ok, err := iter.Next(); !ok || err != nil {
 			t.Fatalf("expected valid iterator, err=%v", err)
 		}
 		if !reflect.DeepEqual(iter.UnsafeKey(), insideKey2) {
 			t.Fatalf("expected key %s, got %s", insideKey2, iter.UnsafeKey())
 		}
 		// Scan out of bounds.
-		iter.Next()
-		if ok, err := iter.Valid(); ok {
+		if ok, err := iter.Next(); ok {
 			t.Fatalf("expected invalid iterator; found valid at key %s", iter.UnsafeKey())
 		} else if err != nil {
 			// Scanning out of bounds sets Valid() to false but is not an error.
@@ -201,48 +196,41 @@ func TestSpanSetBatchBoundaries(t *testing.T) {
 	t.Run("reverse scans", func(t *testing.T) {
 		iter := spanset.NewIterator(eng.NewMVCCIterator(storage.MVCCKeyAndIntentsIterKind, storage.IterOptions{UpperBound: roachpb.KeyMax}), &ss)
 		defer iter.Close()
-		iter.SeekLT(outsideKey4)
-		if _, err := iter.Valid(); !isReadSpanErr(err) {
+		if _, err := iter.SeekLT(outsideKey4); !isReadSpanErr(err) {
 			t.Fatalf("SeekLT: unexpected error %v", err)
 		}
 		// Seeking back in bounds restores validity.
-		iter.SeekLT(insideKey3)
-		if ok, err := iter.Valid(); !ok || err != nil {
+		if ok, err := iter.SeekLT(insideKey3); !ok || err != nil {
 			t.Fatalf("expected valid iterator, err=%v", err)
 		}
 		if !reflect.DeepEqual(iter.UnsafeKey(), insideKey2) {
 			t.Fatalf("expected key %s, got %s", insideKey2, iter.UnsafeKey())
 		}
-		iter.Prev()
-		if ok, err := iter.Valid(); !ok || err != nil {
+		if ok, err := iter.Prev(); !ok || err != nil {
 			t.Fatalf("expected valid iterator, err=%v", err)
 		}
 		if !reflect.DeepEqual(iter.UnsafeKey(), insideKey) {
 			t.Fatalf("expected key %s, got %s", insideKey, iter.UnsafeKey())
 		}
 		// Scan out of bounds.
-		iter.Prev()
-		if ok, err := iter.Valid(); ok {
+		if ok, err := iter.Prev(); ok {
 			t.Fatalf("expected invalid iterator; found valid at key %s", iter.UnsafeKey())
 		} else if err != nil {
 			t.Errorf("unexpected error on iterator: %+v", err)
 		}
 
 		// Seeking back in bounds restores validity.
-		iter.SeekLT(insideKey2)
-		if ok, err := iter.Valid(); !ok || err != nil {
+		if ok, err := iter.SeekLT(insideKey2); !ok || err != nil {
 			t.Fatalf("expected valid iterator, err=%v", err)
 		}
 		// SeekLT to the lower bound is invalid.
-		iter.SeekLT(insideKey)
-		if ok, err := iter.Valid(); ok {
+		if ok, err := iter.SeekLT(insideKey); ok {
 			t.Fatalf("expected invalid iterator; found valid at key %s", iter.UnsafeKey())
 		} else if !isReadSpanErr(err) {
 			t.Fatalf("SeekLT: unexpected error %v", err)
 		}
 		// SeekLT to upper bound restores validity.
-		iter.SeekLT(outsideKey3)
-		if ok, err := iter.Valid(); !ok || err != nil {
+		if ok, err := iter.SeekLT(outsideKey3); !ok || err != nil {
 			t.Fatalf("expected valid iterator, err=%v", err)
 		}
 	})
@@ -386,16 +374,14 @@ func TestSpanSetIteratorTimestamps(t *testing.T) {
 		iter := batchAt1.NewMVCCIterator(storage.MVCCKeyAndIntentsIterKind, storage.IterOptions{UpperBound: roachpb.KeyMax})
 		defer iter.Close()
 
-		iter.SeekGE(k1)
-		if ok, err := iter.Valid(); !ok {
+		if ok, err := iter.SeekGE(k1); !ok {
 			t.Fatalf("expected valid iterator, err=%v", err)
 		}
 		if !reflect.DeepEqual(iter.UnsafeKey(), k1) {
 			t.Fatalf("expected key %s, got %s", k1, iter.UnsafeKey())
 		}
 
-		iter.Next()
-		if ok, err := iter.Valid(); !ok {
+		if ok, err := iter.Next(); !ok {
 			t.Fatalf("expected valid iterator, err=%v", err)
 		}
 		if !reflect.DeepEqual(iter.UnsafeKey(), k2) {
@@ -408,13 +394,11 @@ func TestSpanSetIteratorTimestamps(t *testing.T) {
 		iter := batchAt2.NewMVCCIterator(storage.MVCCKeyAndIntentsIterKind, storage.IterOptions{UpperBound: roachpb.KeyMax})
 		defer iter.Close()
 
-		iter.SeekGE(k1)
-		if ok, _ := iter.Valid(); ok {
+		if ok, _ := iter.SeekGE(k1); ok {
 			t.Fatalf("expected invalid iterator; found valid at key %s", iter.UnsafeKey())
 		}
 
-		iter.SeekGE(k2)
-		if ok, err := iter.Valid(); !ok {
+		if ok, err := iter.SeekGE(k2); !ok {
 			t.Fatalf("expected valid iterator, err=%v", err)
 		}
 		if !reflect.DeepEqual(iter.UnsafeKey(), k2) {
@@ -428,13 +412,11 @@ func TestSpanSetIteratorTimestamps(t *testing.T) {
 		iter := batch.NewMVCCIterator(storage.MVCCKeyAndIntentsIterKind, storage.IterOptions{UpperBound: roachpb.KeyMax})
 		defer iter.Close()
 
-		iter.SeekGE(k1)
-		if ok, _ := iter.Valid(); ok {
+		if ok, _ := iter.SeekGE(k1); ok {
 			t.Fatalf("expected invalid iterator; found valid at key %s", iter.UnsafeKey())
 		}
 
-		iter.SeekGE(k2)
-		if ok, _ := iter.Valid(); ok {
+		if ok, _ := iter.SeekGE(k2); ok {
 			t.Fatalf("expected invalid iterator; found valid at key %s", iter.UnsafeKey())
 		}
 	}

--- a/pkg/kv/kvserver/batcheval/cmd_clear_range_test.go
+++ b/pkg/kv/kvserver/batcheval/cmd_clear_range_test.go
@@ -209,8 +209,7 @@ func TestCmdClearRange(t *testing.T) {
 					UpperBound: endKey,
 				})
 				defer iter.Close()
-				iter.SeekGE(storage.MVCCKey{Key: keys.LocalMax})
-				ok, err := iter.Valid()
+				ok, err := iter.SeekGE(storage.MVCCKey{Key: keys.LocalMax})
 				require.NoError(t, err)
 				require.False(t, ok, "expected empty span, found key %s", iter.UnsafeKey())
 

--- a/pkg/kv/kvserver/batcheval/cmd_export_test.go
+++ b/pkg/kv/kvserver/batcheval/cmd_export_test.go
@@ -93,22 +93,19 @@ func TestExportCmd(t *testing.T) {
 			}
 			defer sst.Close()
 
-			sst.SeekGE(storage.MVCCKey{Key: keys.MinKey})
-			for {
-				if valid, err := sst.Valid(); !valid || err != nil {
-					if err != nil {
-						t.Fatalf("%+v", err)
-					}
-					break
-				}
+			valid, err := sst.SeekGE(storage.MVCCKey{Key: keys.MinKey})
+			for valid {
 				newKv := storage.MVCCKeyValue{}
 				newKv.Key.Key = append(newKv.Key.Key, sst.UnsafeKey().Key...)
 				newKv.Key.Timestamp = sst.UnsafeKey().Timestamp
-				v, err := sst.UnsafeValue()
-				require.NoError(t, err)
+				v, verr := sst.UnsafeValue()
+				require.NoError(t, verr)
 				newKv.Value = append(newKv.Value, v...)
 				kvs = append(kvs, newKv)
-				sst.Next()
+				valid, err = sst.Next()
+			}
+			if err != nil {
+				t.Fatalf("%+v", err)
 			}
 		}
 
@@ -518,7 +515,7 @@ func exportUsingGoIterator(
 	defer sst.Close()
 
 	var skipTombstones bool
-	var iterFn func(*storage.MVCCIncrementalIterator)
+	var iterFn func(*storage.MVCCIncrementalIterator) (bool, error)
 	switch filter {
 	case kvpb.MVCCFilter_Latest:
 		skipTombstones = true
@@ -536,17 +533,8 @@ func exportUsingGoIterator(
 		EndTime:   endTime,
 	})
 	defer iter.Close()
-	for iter.SeekGE(storage.MakeMVCCMetadataKey(startKey)); ; iterFn(iter) {
-		ok, err := iter.Valid()
-		if err != nil {
-			// The error may be a WriteIntentError. In which case, returning it will
-			// cause this command to be retried.
-			return nil, err
-		}
-		if !ok || iter.UnsafeKey().Key.Compare(endKey) >= 0 {
-			break
-		}
-
+	ok, err := iter.SeekGE(storage.MakeMVCCMetadataKey(startKey))
+	for ; ok && iter.UnsafeKey().Key.Compare(endKey) < 0; ok, err = iterFn(iter) {
 		// Skip tombstone (len=0) records when startTime is zero
 		// (non-incremental) and we're not exporting all versions.
 		v, err := iter.UnsafeValue()
@@ -560,6 +548,11 @@ func exportUsingGoIterator(
 		if err := sst.Put(iter.UnsafeKey(), v); err != nil {
 			return nil, err
 		}
+	}
+	if err != nil {
+		// The error may be a WriteIntentError. In which case, returning it will
+		// cause this command to be retried.
+		return nil, err
 	}
 	if err := sst.Finish(); err != nil {
 		return nil, err
@@ -591,29 +584,18 @@ func loadSST(t *testing.T, data []byte, start, end roachpb.Key) []storage.MVCCKe
 	defer sst.Close()
 
 	var kvs []storage.MVCCKeyValue
-	sst.SeekGE(storage.MVCCKey{Key: start})
-	for {
-		if valid, err := sst.Valid(); !valid || err != nil {
-			if err != nil {
-				t.Fatal(err)
-			}
-			break
-		}
-		if !sst.UnsafeKey().Less(storage.MVCCKey{Key: end}) {
-			break
-		}
+	valid, err := sst.SeekGE(storage.MVCCKey{Key: start})
+	for valid && sst.UnsafeKey().Less(storage.MVCCKey{Key: end}) {
 		newKv := storage.MVCCKeyValue{}
 		newKv.Key.Key = append(newKv.Key.Key, sst.UnsafeKey().Key...)
 		newKv.Key.Timestamp = sst.UnsafeKey().Timestamp
-		v, err := sst.UnsafeValue()
-		if err != nil {
-			t.Fatal(err)
-		}
+		v, verr := sst.UnsafeValue()
+		require.NoError(t, verr)
 		newKv.Value = append(newKv.Value, v...)
 		kvs = append(kvs, newKv)
-		sst.Next()
+		valid, err = sst.Next()
 	}
-
+	require.NoError(t, err)
 	return kvs
 }
 

--- a/pkg/kv/kvserver/batcheval/cmd_revert_range.go
+++ b/pkg/kv/kvserver/batcheval/cmd_revert_range.go
@@ -84,8 +84,7 @@ func isEmptyKeyTimeRange(
 		MaxTimestampHint: until,
 	})
 	defer iter.Close()
-	iter.SeekGE(storage.MVCCKey{Key: from})
-	ok, err := iter.Valid()
+	ok, err := iter.SeekGE(storage.MVCCKey{Key: from})
 	return !ok, err
 }
 

--- a/pkg/kv/kvserver/client_split_test.go
+++ b/pkg/kv/kvserver/client_split_test.go
@@ -386,7 +386,7 @@ func TestStoreRangeSplitIntents(t *testing.T) {
 	// Verify the transaction record is gone.
 	start := storage.MakeMVCCMetadataKey(keys.MakeRangeKeyPrefix(roachpb.RKeyMin))
 	end := storage.MakeMVCCMetadataKey(keys.MakeRangeKeyPrefix(roachpb.RKeyMax))
-	iter := store.TODOEngine().NewMVCCIterator(storage.MVCCKeyAndIntentsIterKind, storage.IterOptions{UpperBound: end.Key})
+	iter := storage.DeprecatedMVCCIterator{store.TODOEngine().NewMVCCIterator(storage.MVCCKeyAndIntentsIterKind, storage.IterOptions{UpperBound: end.Key})}
 
 	defer iter.Close()
 	for iter.SeekGE(start); ; iter.Next() {

--- a/pkg/kv/kvserver/gc/gc_iterator_test.go
+++ b/pkg/kv/kvserver/gc/gc_iterator_test.go
@@ -163,14 +163,14 @@ func TestGCIterator(t *testing.T) {
 			ds.setupTest(t, eng, desc)
 			snap := eng.NewSnapshot()
 			defer snap.Close()
-			mvccIt := snap.NewMVCCIterator(storage.MVCCKeyAndIntentsIterKind, storage.IterOptions{
+			mvccIt := storage.DeprecatedMVCCIterator{MVCCIterator: snap.NewMVCCIterator(storage.MVCCKeyAndIntentsIterKind, storage.IterOptions{
 				LowerBound: desc.StartKey.AsRawKey(),
 				UpperBound: desc.EndKey.AsRawKey(),
 				KeyTypes:   storage.IterKeyTypePointsAndRanges,
-			})
+			})}
 			mvccIt.SeekLT(storage.MVCCKey{Key: desc.EndKey.AsRawKey()})
 			defer mvccIt.Close()
-			it := makeGCIterator(mvccIt, tc.gcThreshold)
+			it := makeGCIterator(mvccIt.MVCCIterator, tc.gcThreshold)
 			expectations := tc.expectations
 			for i, ex := range expectations {
 				s, ok := it.state()

--- a/pkg/kv/kvserver/gc/gc_test.go
+++ b/pkg/kv/kvserver/gc/gc_test.go
@@ -1142,21 +1142,21 @@ func requireEqualReaders(
 ) {
 	// First compare only points. We assert points and ranges separately for
 	// simplicity.
-	itExp := exected.NewMVCCIterator(storage.MVCCKeyIterKind, storage.IterOptions{
+	itExp := storage.DeprecatedMVCCIterator{MVCCIterator: exected.NewMVCCIterator(storage.MVCCKeyIterKind, storage.IterOptions{
 		LowerBound:           desc.StartKey.AsRawKey(),
 		UpperBound:           desc.EndKey.AsRawKey(),
 		KeyTypes:             storage.IterKeyTypePointsOnly,
 		RangeKeyMaskingBelow: hlc.Timestamp{},
-	})
+	})}
 	defer itExp.Close()
 	itExp.SeekGE(storage.MVCCKey{Key: desc.StartKey.AsRawKey()})
 
-	itActual := actual.NewMVCCIterator(storage.MVCCKeyIterKind, storage.IterOptions{
+	itActual := storage.DeprecatedMVCCIterator{MVCCIterator: actual.NewMVCCIterator(storage.MVCCKeyIterKind, storage.IterOptions{
 		LowerBound:           desc.StartKey.AsRawKey(),
 		UpperBound:           desc.EndKey.AsRawKey(),
 		KeyTypes:             storage.IterKeyTypePointsOnly,
 		RangeKeyMaskingBelow: hlc.Timestamp{},
-	})
+	})}
 	defer itActual.Close()
 	itActual.SeekGE(storage.MVCCKey{Key: desc.StartKey.AsRawKey()})
 
@@ -1190,21 +1190,21 @@ func requireEqualReaders(
 	}
 
 	// Compare only ranges.
-	itExpRanges := exected.NewMVCCIterator(storage.MVCCKeyIterKind, storage.IterOptions{
+	itExpRanges := storage.DeprecatedMVCCIterator{exected.NewMVCCIterator(storage.MVCCKeyIterKind, storage.IterOptions{
 		LowerBound:           desc.StartKey.AsRawKey(),
 		UpperBound:           desc.EndKey.AsRawKey(),
 		KeyTypes:             storage.IterKeyTypeRangesOnly,
 		RangeKeyMaskingBelow: hlc.Timestamp{},
-	})
+	})}
 	defer itExpRanges.Close()
 	itExpRanges.SeekGE(storage.MVCCKey{Key: desc.StartKey.AsRawKey()})
 
-	itActualRanges := actual.NewMVCCIterator(storage.MVCCKeyIterKind, storage.IterOptions{
+	itActualRanges := storage.DeprecatedMVCCIterator{actual.NewMVCCIterator(storage.MVCCKeyIterKind, storage.IterOptions{
 		LowerBound:           desc.StartKey.AsRawKey(),
 		UpperBound:           desc.EndKey.AsRawKey(),
 		KeyTypes:             storage.IterKeyTypeRangesOnly,
 		RangeKeyMaskingBelow: hlc.Timestamp{},
-	})
+	})}
 	defer itActualRanges.Close()
 	itActualRanges.SeekGE(storage.MVCCKey{Key: desc.StartKey.AsRawKey()})
 
@@ -1430,12 +1430,12 @@ func (d tableData) liveDistribution() dataDistribution {
 func engineData(t *testing.T, r storage.Reader, desc roachpb.RangeDescriptor) []tableCell {
 	var result []tableCell
 
-	rangeIt := r.NewMVCCIterator(storage.MVCCKeyIterKind, storage.IterOptions{
+	rangeIt := storage.DeprecatedMVCCIterator{MVCCIterator: r.NewMVCCIterator(storage.MVCCKeyIterKind, storage.IterOptions{
 		LowerBound:           desc.StartKey.AsRawKey(),
 		UpperBound:           desc.EndKey.AsRawKey(),
 		KeyTypes:             storage.IterKeyTypeRangesOnly,
 		RangeKeyMaskingBelow: hlc.Timestamp{},
-	})
+	})}
 	defer rangeIt.Close()
 	rangeIt.SeekGE(storage.MVCCKey{Key: desc.StartKey.AsRawKey()})
 	makeRangeCells := func(rks []storage.MVCCRangeKey) (tc []tableCell) {
@@ -1505,12 +1505,12 @@ func engineData(t *testing.T, r storage.Reader, desc roachpb.RangeDescriptor) []
 	}
 	result = append(result, makeRangeCells(partialRangeKeys)...)
 
-	it := r.NewMVCCIterator(storage.MVCCKeyAndIntentsIterKind, storage.IterOptions{
+	it := storage.DeprecatedMVCCIterator{MVCCIterator: r.NewMVCCIterator(storage.MVCCKeyAndIntentsIterKind, storage.IterOptions{
 		LowerBound:           desc.StartKey.AsRawKey(),
 		UpperBound:           desc.EndKey.AsRawKey(),
 		KeyTypes:             storage.IterKeyTypePointsOnly,
 		RangeKeyMaskingBelow: hlc.Timestamp{},
-	})
+	})}
 	defer it.Close()
 	it.SeekGE(storage.MVCCKey{Key: desc.StartKey.AsRawKey()})
 	prefix := ""

--- a/pkg/kv/kvserver/kvstorage/init.go
+++ b/pkg/kv/kvserver/kvstorage/init.go
@@ -161,9 +161,8 @@ func IterateIDPrefixKeys(
 ) error {
 	rangeID := roachpb.RangeID(1)
 	// NB: Range-ID local keys have no versions and no intents.
-	iter := reader.NewMVCCIterator(storage.MVCCKeyIterKind, storage.IterOptions{
-		UpperBound: keys.LocalRangeIDPrefix.PrefixEnd().AsRawKey(),
-	})
+	iter := storage.DeprecatedMVCCIterator{MVCCIterator: reader.NewMVCCIterator(storage.MVCCKeyIterKind,
+		storage.IterOptions{UpperBound: keys.LocalRangeIDPrefix.PrefixEnd().AsRawKey()})}
 	defer iter.Close()
 
 	for {

--- a/pkg/kv/kvserver/logstore/stateloader.go
+++ b/pkg/kv/kvserver/logstore/stateloader.go
@@ -57,8 +57,10 @@ func (sl StateLoader) LoadLastIndex(ctx context.Context, reader storage.Reader) 
 	defer iter.Close()
 
 	var lastIndex uint64
-	iter.SeekLT(storage.MakeMVCCMetadataKey(keys.RaftLogKeyFromPrefix(prefix, math.MaxUint64)))
-	if ok, _ := iter.Valid(); ok {
+	ok, _ := iter.SeekLT(storage.MakeMVCCMetadataKey(keys.RaftLogKeyFromPrefix(prefix, math.MaxUint64)))
+	// TODO(jackson): Find out if it's intentional that we're ignore the error
+	// return value from the seek.
+	if ok {
 		key := iter.UnsafeKey().Key
 		if len(key) < len(prefix) {
 			log.Fatalf(ctx, "unable to decode Raft log index key: len(%s) < len(%s)", key.String(), prefix.String())

--- a/pkg/kv/kvserver/loqrecovery/record.go
+++ b/pkg/kv/kvserver/loqrecovery/record.go
@@ -75,11 +75,11 @@ func RegisterOfflineRecoveryEvents(
 	successCount := 0
 	var processingErrors error
 
-	iter := readWriter.NewMVCCIterator(
+	iter := storage.DeprecatedMVCCIterator{MVCCIterator: readWriter.NewMVCCIterator(
 		storage.MVCCKeyIterKind, storage.IterOptions{
 			LowerBound: keys.LocalStoreUnsafeReplicaRecoveryKeyMin,
 			UpperBound: keys.LocalStoreUnsafeReplicaRecoveryKeyMax,
-		})
+		})}
 	defer iter.Close()
 
 	iter.SeekGE(storage.MVCCKey{Key: keys.LocalStoreUnsafeReplicaRecoveryKeyMin})

--- a/pkg/kv/kvserver/raft_log_truncator_test.go
+++ b/pkg/kv/kvserver/raft_log_truncator_test.go
@@ -202,8 +202,7 @@ func (r *replicaTruncatorTest) printEngine(t *testing.T, eng storage.Engine) {
 		UpperBound: r.stateLoader.RaftLogKey(math.MaxUint64),
 	})
 	defer iter.Close()
-	iter.SeekGE(storage.MVCCKey{Key: r.stateLoader.RaftLogKey(0)})
-	valid, err := iter.Valid()
+	valid, err := iter.SeekGE(storage.MVCCKey{Key: r.stateLoader.RaftLogKey(0)})
 	require.NoError(t, err)
 	fmt.Fprintf(r.buf, "log entries:")
 	printPrefixStr := ""
@@ -213,8 +212,7 @@ func (r *replicaTruncatorTest) printEngine(t *testing.T, eng storage.Engine) {
 		require.NoError(t, err)
 		fmt.Fprintf(r.buf, "%s %d", printPrefixStr, index)
 		printPrefixStr = ","
-		iter.Next()
-		valid, err = iter.Valid()
+		valid, err = iter.Next()
 		require.NoError(t, err)
 	}
 	fmt.Fprintf(r.buf, "\n")

--- a/pkg/kv/kvserver/raftlog/iter_bench_test.go
+++ b/pkg/kv/kvserver/raftlog/iter_bench_test.go
@@ -35,13 +35,13 @@ type mockStorageIter struct {
 	val []byte
 }
 
-func (m *mockStorageIter) SeekGE(storage.MVCCKey) {}
+func (m *mockStorageIter) SeekGE(storage.MVCCKey) (bool, error) { return true, nil }
 
 func (m *mockStorageIter) Valid() (bool, error) {
 	return true, nil
 }
 
-func (m *mockStorageIter) Next() {}
+func (m *mockStorageIter) Next() (bool, error) { return true, nil }
 
 func (m *mockStorageIter) Close() {}
 

--- a/pkg/kv/kvserver/rangefeed/task.go
+++ b/pkg/kv/kvserver/rangefeed/task.go
@@ -182,13 +182,8 @@ func (l *LegacyIntentScanner) ConsumeIntents(
 	// will always be the first version of a key if it exists, so its fine that
 	// we skip over all other versions of keys.
 	var meta enginepb.MVCCMetadata
-	for l.iter.SeekGE(startKey); ; l.iter.NextKey() {
-		if ok, err := l.iter.Valid(); err != nil {
-			return err
-		} else if !ok || !l.iter.UnsafeKey().Less(endKey) {
-			break
-		}
-
+	ok, err := l.iter.SeekGE(startKey)
+	for ; ok && l.iter.UnsafeKey().Less(endKey); ok, err = l.iter.NextKey() {
 		// If the key is not a metadata key, ignore it.
 		unsafeKey := l.iter.UnsafeKey()
 		if unsafeKey.IsValue() {
@@ -215,7 +210,7 @@ func (l *LegacyIntentScanner) ConsumeIntents(
 			})
 		}
 	}
-	return nil
+	return err
 }
 
 // Close implements the IntentScanner interface.

--- a/pkg/kv/kvserver/rditer/replica_data_iter_test.go
+++ b/pkg/kv/kvserver/rditer/replica_data_iter_test.go
@@ -339,7 +339,8 @@ func TestIterateMVCCReplicaKeySpansSpansSet(t *testing.T) {
 		err := IterateMVCCReplicaKeySpans(&desc, readWriter, IterateOptions{
 			CombineRangesAndPoints: false,
 			Reverse:                reverse,
-		}, func(iter storage.MVCCIterator, span roachpb.Span, keyType storage.IterKeyType) error {
+		}, func(mvccIter storage.MVCCIterator, span roachpb.Span, keyType storage.IterKeyType) error {
+			iter := storage.DeprecatedMVCCIterator{MVCCIterator: mvccIter}
 			for {
 				ok, err := iter.Valid()
 				require.NoError(t, err)
@@ -665,9 +666,9 @@ func TestIterateMVCCReplicaKeySpans(t *testing.T) {
 				}
 				advance := func(iter storage.MVCCIterator) {
 					if reverse {
-						iter.Prev()
+						_, _ = iter.Prev()
 					} else {
-						iter.Next()
+						_, _ = iter.Next()
 					}
 				}
 				t.Run("sequential", func(t *testing.T) {

--- a/pkg/kv/kvserver/replica_evaluate.go
+++ b/pkg/kv/kvserver/replica_evaluate.go
@@ -96,12 +96,12 @@ func optimizePuts(
 	// iter is being used to find the parts of the key range that is empty. We
 	// don't need to see intents for this purpose since intents also have
 	// provisional values that we will see.
-	iter := reader.NewMVCCIterator(storage.MVCCKeyIterKind, storage.IterOptions{
+	iter := storage.DeprecatedMVCCIterator{MVCCIterator: reader.NewMVCCIterator(storage.MVCCKeyIterKind, storage.IterOptions{
 		KeyTypes: storage.IterKeyTypePointsAndRanges,
 		// We want to include maxKey in our scan. Since UpperBound is exclusive, we
 		// need to set it to the key after maxKey.
 		UpperBound: maxKey.Next(),
-	})
+	})}
 	defer iter.Close()
 
 	// If there are enough puts in the run to justify calling seek,

--- a/pkg/kv/kvserver/replica_rangefeed_test.go
+++ b/pkg/kv/kvserver/replica_rangefeed_test.go
@@ -246,12 +246,10 @@ func TestReplicaRangefeed(t *testing.T) {
 				require.NoError(t, err)
 				defer sstIter.Close()
 
-				expIter.SeekGE(storage.MVCCKey{Key: keys.MinKey})
-				sstIter.SeekGE(storage.MVCCKey{Key: keys.MinKey})
+				expOK, expErr := expIter.SeekGE(storage.MVCCKey{Key: keys.MinKey})
+				sstOK, sstErr := sstIter.SeekGE(storage.MVCCKey{Key: keys.MinKey})
 				for {
-					expOK, expErr := expIter.Valid()
 					require.NoError(t, expErr)
-					sstOK, sstErr := sstIter.Valid()
 					require.NoError(t, sstErr)
 					if !expOK {
 						require.False(t, sstOK)
@@ -271,8 +269,8 @@ func TestReplicaRangefeed(t *testing.T) {
 					// assert on the write timestamp instead.
 					require.Equal(t, sst.expectTS, sstKey.Timestamp)
 
-					expIter.Next()
-					sstIter.Next()
+					expOK, expErr = expIter.Next()
+					sstOK, sstErr = sstIter.Next()
 				}
 			}
 		}

--- a/pkg/kv/kvserver/replica_test.go
+++ b/pkg/kv/kvserver/replica_test.go
@@ -3035,9 +3035,8 @@ func TestReplicaTSCacheForwardsIntentTS(t *testing.T) {
 				iter := tc.engine.NewMVCCIterator(storage.MVCCKeyAndIntentsIterKind, storage.IterOptions{Prefix: true})
 				defer iter.Close()
 				mvccKey := storage.MakeMVCCMetadataKey(key)
-				iter.SeekGE(mvccKey)
 				var keyMeta enginepb.MVCCMetadata
-				if ok, err := iter.Valid(); !ok || !iter.UnsafeKey().Equal(mvccKey) {
+				if ok, err := iter.SeekGE(mvccKey); !ok || !iter.UnsafeKey().Equal(mvccKey) {
 					t.Fatalf("missing mvcc metadata for %q: %+v", mvccKey, err)
 				} else if err := iter.ValueProto(&keyMeta); err != nil {
 					t.Fatalf("failed to unmarshal metadata for %q", mvccKey)

--- a/pkg/kv/kvserver/spanset/batch.go
+++ b/pkg/kv/kvserver/spanset/batch.go
@@ -79,41 +79,47 @@ func (i *MVCCIterator) Valid() (bool, error) {
 }
 
 // SeekGE is part of the storage.MVCCIterator interface.
-func (i *MVCCIterator) SeekGE(key storage.MVCCKey) {
-	i.i.SeekGE(key)
+func (i *MVCCIterator) SeekGE(key storage.MVCCKey) (valid bool, err error) {
+	valid, err = i.i.SeekGE(key)
 	i.checkAllowed(roachpb.Span{Key: key.Key}, true)
+	return valid, err
 }
 
 // SeekIntentGE is part of the storage.MVCCIterator interface.
-func (i *MVCCIterator) SeekIntentGE(key roachpb.Key, txnUUID uuid.UUID) {
-	i.i.SeekIntentGE(key, txnUUID)
+func (i *MVCCIterator) SeekIntentGE(key roachpb.Key, txnUUID uuid.UUID) (valid bool, err error) {
+	valid, err = i.i.SeekIntentGE(key, txnUUID)
 	i.checkAllowed(roachpb.Span{Key: key}, true)
+	return valid, err
 }
 
 // SeekLT is part of the storage.MVCCIterator interface.
-func (i *MVCCIterator) SeekLT(key storage.MVCCKey) {
-	i.i.SeekLT(key)
+func (i *MVCCIterator) SeekLT(key storage.MVCCKey) (valid bool, err error) {
+	valid, err = i.i.SeekLT(key)
 	// CheckAllowed{At} supports the span representation of [,key), which
 	// corresponds to the span [key.Prev(),).
 	i.checkAllowed(roachpb.Span{EndKey: key.Key}, true)
+	return valid, err
 }
 
 // Next is part of the storage.MVCCIterator interface.
-func (i *MVCCIterator) Next() {
-	i.i.Next()
+func (i *MVCCIterator) Next() (valid bool, err error) {
+	valid, err = i.i.Next()
 	i.checkAllowedCurrPosForward(false)
+	return valid, err
 }
 
 // Prev is part of the storage.MVCCIterator interface.
-func (i *MVCCIterator) Prev() {
-	i.i.Prev()
+func (i *MVCCIterator) Prev() (valid bool, err error) {
+	valid, err = i.i.Prev()
 	i.checkAllowedCurrPosForward(false)
+	return valid, err
 }
 
 // NextKey is part of the storage.MVCCIterator interface.
-func (i *MVCCIterator) NextKey() {
-	i.i.NextKey()
+func (i *MVCCIterator) NextKey() (valid bool, err error) {
+	valid, err = i.i.NextKey()
 	i.checkAllowedCurrPosForward(false)
+	return valid, err
 }
 
 // checkAllowedCurrPosForward checks the span starting at the current iterator

--- a/pkg/sql/row/fetcher_mvcc_test.go
+++ b/pkg/sql/row/fetcher_mvcc_test.go
@@ -44,7 +44,8 @@ func slurpUserDataKVs(t testing.TB, e storage.Engine) []roachpb.KeyValue {
 	var kvs []roachpb.KeyValue
 	testutils.SucceedsSoon(t, func() error {
 		kvs = nil
-		it := e.NewMVCCIterator(storage.MVCCKeyAndIntentsIterKind, storage.IterOptions{UpperBound: roachpb.KeyMax})
+		it := storage.DeprecatedMVCCIterator{MVCCIterator: e.NewMVCCIterator(
+			storage.MVCCKeyAndIntentsIterKind, storage.IterOptions{UpperBound: roachpb.KeyMax})}
 		defer it.Close()
 		for it.SeekGE(storage.MVCCKey{Key: bootstrap.TestingUserTableDataMin()}); ; it.NextKey() {
 			ok, err := it.Valid()

--- a/pkg/storage/BUILD.bazel
+++ b/pkg/storage/BUILD.bazel
@@ -18,6 +18,7 @@ go_library(
         "in_mem.go",
         "intent_interleaving_iter.go",
         "intent_reader_writer.go",
+        "interface_adapter.go",
         "min_version.go",
         "mvcc.go",
         "mvcc_incremental_iterator.go",

--- a/pkg/storage/fingerprint_writer.go
+++ b/pkg/storage/fingerprint_writer.go
@@ -226,7 +226,7 @@ func FingerprintRangekeys(
 		KeyTypes:   IterKeyTypePointsOnly,
 		UpperBound: keys.MaxKey,
 	}
-	pointKeyIter, err := NewMultiMemSSTIterator(ssts, false /* verify */, pointKeyIterOpts)
+	pointKeyIter, err := WithDeprecatedAPI(NewMultiMemSSTIterator(ssts, false /* verify */, pointKeyIterOpts))
 	if err != nil {
 		return 0, err
 	}
@@ -250,7 +250,7 @@ func FingerprintRangekeys(
 		UpperBound: keys.MaxKey,
 	}
 	var fingerprint uint64
-	iter, err := NewMultiMemSSTIterator(ssts, true /* verify */, rangeKeyIterOpts)
+	iter, err := WithDeprecatedAPI(NewMultiMemSSTIterator(ssts, true /* verify */, rangeKeyIterOpts))
 	if err != nil {
 		return fingerprint, err
 	}

--- a/pkg/storage/interface_adapter.go
+++ b/pkg/storage/interface_adapter.go
@@ -1,0 +1,322 @@
+// Copyright 2023 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package storage
+
+import (
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/util/uuid"
+)
+
+// WithDeprecatedAPI returns if err is non-nil. Otherwise it returns the
+// provided MVCCIterator, wrapped in the DeprecatedMVCCIterator struct.
+func WithDeprecatedAPI(it MVCCIterator, err error) (DeprecatedMVCCIterator, error) {
+	if err != nil {
+		return DeprecatedMVCCIterator{}, err
+	}
+	return DeprecatedMVCCIterator{it}, nil
+}
+
+// WithDeprecatedSimpleAPI returns if err is non-nil. Otherwise it returns the
+// provided SimpleMVCCIterator, wrapped in the DeprecatedSimpleMVCCIterator
+// struct.
+func WithDeprecatedSimpleAPI(
+	it SimpleMVCCIterator, err error,
+) (DeprecatedSimpleMVCCIterator, error) {
+	if err != nil {
+		return DeprecatedSimpleMVCCIterator{}, err
+	}
+	return DeprecatedSimpleMVCCIterator{it}, nil
+}
+
+// DeprecatedSimpleMVCCIterator wraps a SimpleMVCCIterator with the old,
+// deprecated MVCCIterator interface that does not return validity or errors
+// through return values. This type is a temporary, adapter type that should be
+// removed once all SimpleMVCCIterator usages are updated to use the new
+// interface.
+type DeprecatedSimpleMVCCIterator struct {
+	SimpleMVCCIterator
+}
+
+// Close frees up resources held by the iterator.
+func (d DeprecatedSimpleMVCCIterator) Close() {
+	d.SimpleMVCCIterator.Close()
+}
+
+// SeekGE advances the iterator to the first key in the engine which is >= the
+// provided key. This may be in the middle of a bare range key straddling the
+// seek key.
+func (d DeprecatedSimpleMVCCIterator) SeekGE(key MVCCKey) {
+	_, _ = d.SimpleMVCCIterator.SeekGE(key)
+}
+
+// Valid must be called after any call to Seek(), Next(), Prev(), or
+// similar methods. It returns (true, nil) if the iterator points to
+// a valid key (it is undefined to call Key(), Value(), or similar
+// methods unless Valid() has returned (true, nil)). It returns
+// (false, nil) if the iterator has moved past the end of the valid
+// range, or (false, err) if an error has occurred. Valid() will
+// never return true with a non-nil error.
+func (d DeprecatedSimpleMVCCIterator) Valid() (bool, error) {
+	return d.SimpleMVCCIterator.Valid()
+}
+
+// Next advances the iterator to the next key in the iteration. After this
+// call, Valid() will be true if the iterator was not positioned at the last
+// key.
+func (d DeprecatedSimpleMVCCIterator) Next() {
+	_, _ = d.SimpleMVCCIterator.Next()
+}
+
+// NextKey advances the iterator to the next MVCC key. This operation is
+// distinct from Next which advances to the next version of the current key
+// or the next key if the iterator is currently located at the last version
+// for a key. NextKey must not be used to switch iteration direction from
+// reverse iteration to forward iteration.
+//
+// If NextKey() lands on a bare range key, it is possible that there exists a
+// versioned point key at the start key too. Calling NextKey() again would
+// skip over this point key, since the start key was already emitted. If the
+// caller wants to see it, it must call Next() to check for it. Note that
+// this is not the case with intents: they don't have a timestamp, so the
+// encoded key is identical to the range key's start bound, and they will
+// be emitted together at that position.
+func (d DeprecatedSimpleMVCCIterator) NextKey() {
+	_, _ = d.SimpleMVCCIterator.NextKey()
+}
+
+// UnsafeKey returns the current key position. This may be a point key, or
+// the current position inside a range key (typically the start key
+// or the seek key when using SeekGE within its bounds).
+//
+// The memory is invalidated on the next call to {Next,NextKey,Prev,SeekGE,
+// SeekLT,Close}. Use Key() if this is undesirable.
+func (d DeprecatedSimpleMVCCIterator) UnsafeKey() MVCCKey {
+	return d.SimpleMVCCIterator.UnsafeKey()
+}
+
+// UnsafeValue returns the current point key value as a byte slice.
+// This must only be called when it is known that the iterator is positioned
+// at a point value, i.e. HasPointAndRange has returned (true, *). If
+// possible, use MVCCValueLenAndIsTombstone() instead.
+//
+// The memory is invalidated on the next call to {Next,NextKey,Prev,SeekGE,SeekLT,Close}.
+// Use Value() if that is undesirable.
+func (d DeprecatedSimpleMVCCIterator) UnsafeValue() ([]byte, error) {
+	return d.SimpleMVCCIterator.UnsafeValue()
+}
+
+// MVCCValueLenAndIsTombstone should be called only for MVCC (i.e.,
+// UnsafeKey().IsValue()) point values, when the actual point value is not
+// needed, for example when updating stats and making GC decisions, and it
+// is sufficient for the caller to know the length (len(UnsafeValue()), and
+// whether the underlying MVCCValue is a tombstone
+// (MVCCValue.IsTombstone()). This is an optimization that can allow the
+// underlying storage layer to avoid retrieving the value.
+// REQUIRES: HasPointAndRange() has returned (true, *).
+func (d DeprecatedSimpleMVCCIterator) MVCCValueLenAndIsTombstone() (int, bool, error) {
+	return d.SimpleMVCCIterator.MVCCValueLenAndIsTombstone()
+}
+
+// ValueLen can be called for MVCC or non-MVCC values, when only the value
+// length is needed. This is an optimization that can allow the underlying
+// storage layer to avoid retrieving the value.
+// REQUIRES: HasPointAndRange() has returned (true, *).
+func (d DeprecatedSimpleMVCCIterator) ValueLen() int {
+	return d.SimpleMVCCIterator.ValueLen()
+}
+
+// HasPointAndRange returns whether the current iterator position has a point
+// key and/or a range key. Must check Valid() first. At least one of these
+// will always be true for a valid iterator. For details on range keys, see
+// comment on SimpleMVCCIterator.
+func (d DeprecatedSimpleMVCCIterator) HasPointAndRange() (bool, bool) {
+	return d.SimpleMVCCIterator.HasPointAndRange()
+}
+
+// RangeBounds returns the range bounds for the current range key, or an
+// empty span if there are none. The returned keys are valid until the
+// range key changes, see RangeKeyChanged().
+func (d DeprecatedSimpleMVCCIterator) RangeBounds() roachpb.Span {
+	return d.SimpleMVCCIterator.RangeBounds()
+}
+
+// RangeKeys returns a stack of all range keys (with different timestamps) at
+// the current key position. When at a point key, it will return all range
+// keys overlapping that point key. The stack is valid until the range key
+// changes, see RangeKeyChanged().
+//
+// For details on range keys, see SimpleMVCCIterator comment, or tech note:
+// https://github.com/cockroachdb/cockroach/blob/master/docs/tech-notes/mvcc-range-tombstones.md
+func (d DeprecatedSimpleMVCCIterator) RangeKeys() MVCCRangeKeyStack {
+	return d.SimpleMVCCIterator.RangeKeys()
+}
+
+// RangeKeyChanged returns true if the previous seek or step moved to a
+// different range key (or none at all). Requires a valid iterator, but an
+// exhausted iterator is considered to have had no range keys when calling
+// this after repositioning.
+func (d DeprecatedSimpleMVCCIterator) RangeKeyChanged() bool {
+	return d.SimpleMVCCIterator.RangeKeyChanged()
+}
+
+// DeprecatedMVCCIterator wraps a MVCCIterator with the old, deprecated
+// MVCCIterator interface that does not return validity or errors through return
+// values. This type is a temporary, adapter type that should be removed once
+// all MVCCIterator usages are updated to use the new interface.
+type DeprecatedMVCCIterator struct {
+	MVCCIterator
+}
+
+// Close frees up resources held by the iterator.
+func (d DeprecatedMVCCIterator) Close() {
+	d.MVCCIterator.Close()
+}
+
+// SeekGE advances the iterator to the first key in the engine which is >= the
+// provided key. This may be in the middle of a bare range key straddling the
+// seek key.
+func (d DeprecatedMVCCIterator) SeekGE(key MVCCKey) {
+	_, _ = d.MVCCIterator.SeekGE(key)
+}
+
+// SeekLT advances the iterator to the first key in the engine which is < the
+// provided key. Unlike SeekGE, when calling SeekLT within range key bounds
+// this will not land on the seek key, but rather on the closest point key
+// overlapping the range key or the range key's start bound.
+func (d DeprecatedMVCCIterator) SeekLT(key MVCCKey) {
+	_, _ = d.MVCCIterator.SeekLT(key)
+}
+
+// Valid must be called after any call to Seek(), Next(), Prev(), or
+// similar methods. It returns (true, nil) if the iterator points to
+// a valid key (it is undefined to call Key(), Value(), or similar
+// methods unless Valid() has returned (true, nil)). It returns
+// (false, nil) if the iterator has moved past the end of the valid
+// range, or (false, err) if an error has occurred. Valid() will
+// never return true with a non-nil error.
+func (d DeprecatedMVCCIterator) Valid() (bool, error) {
+	return d.MVCCIterator.Valid()
+}
+
+// Next advances the iterator to the next key in the iteration. After this
+// call, Valid() will be true if the iterator was not positioned at the last
+// key.
+func (d DeprecatedMVCCIterator) Next() {
+	_, _ = d.MVCCIterator.Next()
+}
+
+// NextKey advances the iterator to the next MVCC key. This operation is
+// distinct from Next which advances to the next version of the current key
+// or the next key if the iterator is currently located at the last version
+// for a key. NextKey must not be used to switch iteration direction from
+// reverse iteration to forward iteration.
+//
+// If NextKey() lands on a bare range key, it is possible that there exists a
+// versioned point key at the start key too. Calling NextKey() again would
+// skip over this point key, since the start key was already emitted. If the
+// caller wants to see it, it must call Next() to check for it. Note that
+// this is not the case with intents: they don't have a timestamp, so the
+// encoded key is identical to the range key's start bound, and they will
+// be emitted together at that position.
+func (d DeprecatedMVCCIterator) NextKey() {
+	_, _ = d.MVCCIterator.NextKey()
+}
+
+// Prev moves the iterator backward to the previous key in the iteration.
+// After this call, Valid() will be true if the iterator was not positioned at
+// the first key.
+func (d DeprecatedMVCCIterator) Prev() {
+	_, _ = d.MVCCIterator.Prev()
+}
+
+// SeekIntentGE is a specialized version of SeekGE(MVCCKey{Key: key}), when
+// the caller expects to find an intent, and additionally has the txnUUID
+// for the intent it is looking for. When running with separated intents,
+// this can optimize the behavior of the underlying Engine for write heavy
+// keys by avoiding the need to iterate over many deleted intents.
+func (d DeprecatedMVCCIterator) SeekIntentGE(key roachpb.Key, txnUUID uuid.UUID) {
+	_, _ = d.MVCCIterator.SeekIntentGE(key, txnUUID)
+}
+
+// UnsafeKey returns the current key position. This may be a point key, or
+// the current position inside a range key (typically the start key
+// or the seek key when using SeekGE within its bounds).
+//
+// The memory is invalidated on the next call to {Next,NextKey,Prev,SeekGE,
+// SeekLT,Close}. Use Key() if this is undesirable.
+func (d DeprecatedMVCCIterator) UnsafeKey() MVCCKey {
+	return d.MVCCIterator.UnsafeKey()
+}
+
+// UnsafeValue returns the current point key value as a byte slice.
+// This must only be called when it is known that the iterator is positioned
+// at a point value, i.e. HasPointAndRange has returned (true, *). If
+// possible, use MVCCValueLenAndIsTombstone() instead.
+//
+// The memory is invalidated on the next call to {Next,NextKey,Prev,SeekGE,SeekLT,Close}.
+// Use Value() if that is undesirable.
+func (d DeprecatedMVCCIterator) UnsafeValue() ([]byte, error) {
+	return d.MVCCIterator.UnsafeValue()
+}
+
+// MVCCValueLenAndIsTombstone should be called only for MVCC (i.e.,
+// UnsafeKey().IsValue()) point values, when the actual point value is not
+// needed, for example when updating stats and making GC decisions, and it
+// is sufficient for the caller to know the length (len(UnsafeValue()), and
+// whether the underlying MVCCValue is a tombstone
+// (MVCCValue.IsTombstone()). This is an optimization that can allow the
+// underlying storage layer to avoid retrieving the value.
+// REQUIRES: HasPointAndRange() has returned (true, *).
+func (d DeprecatedMVCCIterator) MVCCValueLenAndIsTombstone() (int, bool, error) {
+	return d.MVCCIterator.MVCCValueLenAndIsTombstone()
+}
+
+// ValueLen can be called for MVCC or non-MVCC values, when only the value
+// length is needed. This is an optimization that can allow the underlying
+// storage layer to avoid retrieving the value.
+// REQUIRES: HasPointAndRange() has returned (true, *).
+func (d DeprecatedMVCCIterator) ValueLen() int {
+	return d.MVCCIterator.ValueLen()
+}
+
+// HasPointAndRange returns whether the current iterator position has a point
+// key and/or a range key. Must check Valid() first. At least one of these
+// will always be true for a valid iterator. For details on range keys, see
+// comment on SimpleMVCCIterator.
+func (d DeprecatedMVCCIterator) HasPointAndRange() (bool, bool) {
+	return d.MVCCIterator.HasPointAndRange()
+}
+
+// RangeBounds returns the range bounds for the current range key, or an
+// empty span if there are none. The returned keys are valid until the
+// range key changes, see RangeKeyChanged().
+func (d DeprecatedMVCCIterator) RangeBounds() roachpb.Span {
+	return d.MVCCIterator.RangeBounds()
+}
+
+// RangeKeys returns a stack of all range keys (with different timestamps) at
+// the current key position. When at a point key, it will return all range
+// keys overlapping that point key. The stack is valid until the range key
+// changes, see RangeKeyChanged().
+//
+// For details on range keys, see SimpleMVCCIterator comment, or tech note:
+// https://github.com/cockroachdb/cockroach/blob/master/docs/tech-notes/mvcc-range-tombstones.md
+func (d DeprecatedMVCCIterator) RangeKeys() MVCCRangeKeyStack {
+	return d.MVCCIterator.RangeKeys()
+}
+
+// RangeKeyChanged returns true if the previous seek or step moved to a
+// different range key (or none at all). Requires a valid iterator, but an
+// exhausted iterator is considered to have had no range keys when calling
+// this after repositioning.
+func (d DeprecatedMVCCIterator) RangeKeyChanged() bool {
+	return d.MVCCIterator.RangeKeyChanged()
+}

--- a/pkg/storage/mvcc_history_test.go
+++ b/pkg/storage/mvcc_history_test.go
@@ -2476,8 +2476,8 @@ type mvccIncrementalIteratorI interface {
 	storage.SimpleMVCCIterator
 	RangeKeysIgnoringTime() storage.MVCCRangeKeyStack
 	RangeKeyChangedIgnoringTime() bool
-	NextIgnoringTime()
-	NextKeyIgnoringTime()
+	NextIgnoringTime() (bool, error)
+	NextKeyIgnoringTime() (bool, error)
 	TryGetIntentError() error
 }
 

--- a/pkg/storage/mvcc_stats_test.go
+++ b/pkg/storage/mvcc_stats_test.go
@@ -1481,7 +1481,7 @@ var mvccStatsTests = []struct {
 				UpperBound: end,
 			})
 			defer iter.Close()
-			iter.SeekGE(MVCCKey{Key: start})
+			_, _ = iter.SeekGE(MVCCKey{Key: start})
 			return ComputeStatsForIter(iter, nowNanos)
 		},
 	},

--- a/pkg/storage/pebble_batch.go
+++ b/pkg/storage/pebble_batch.go
@@ -354,11 +354,11 @@ func (p *pebbleBatch) ClearMVCCIteratorRange(
 	start, end roachpb.Key, pointKeys, rangeKeys bool,
 ) error {
 	clearPointKeys := func(start, end roachpb.Key) error {
-		iter := p.NewMVCCIterator(MVCCKeyAndIntentsIterKind, IterOptions{
+		iter := DeprecatedMVCCIterator{p.NewMVCCIterator(MVCCKeyAndIntentsIterKind, IterOptions{
 			KeyTypes:   IterKeyTypePointsOnly,
 			LowerBound: start,
 			UpperBound: end,
-		})
+		})}
 		defer iter.Close()
 		for iter.SeekGE(MVCCKey{Key: start}); ; iter.Next() {
 			if valid, err := iter.Valid(); err != nil {
@@ -382,11 +382,11 @@ func (p *pebbleBatch) ClearMVCCIteratorRange(
 	}
 
 	clearRangeKeys := func(start, end roachpb.Key) error {
-		iter := p.NewMVCCIterator(MVCCKeyIterKind, IterOptions{
+		iter := DeprecatedMVCCIterator{p.NewMVCCIterator(MVCCKeyIterKind, IterOptions{
 			KeyTypes:   IterKeyTypeRangesOnly,
 			LowerBound: start,
 			UpperBound: end,
-		})
+		})}
 		defer iter.Close()
 		for iter.SeekGE(MVCCKey{Key: start}); ; iter.Next() {
 			if valid, err := iter.Valid(); err != nil {

--- a/pkg/storage/pebble_iterator_test.go
+++ b/pkg/storage/pebble_iterator_test.go
@@ -126,11 +126,9 @@ func TestPebbleIterator_ExternalCorruption(t *testing.T) {
 		return
 	}
 
-	it.SeekGE(NilKey)
-	valid, err := it.Valid()
+	valid, err := it.SeekGE(NilKey)
 	for valid {
-		it.Next()
-		valid, err = it.Valid()
+		valid, err = it.Next()
 	}
 	// Or we may error during iteration.
 	if err != nil {

--- a/pkg/testutils/storageutils/mvcc.go
+++ b/pkg/testutils/storageutils/mvcc.go
@@ -29,8 +29,8 @@ func MVCCGetRaw(t *testing.T, r storage.Reader, key storage.MVCCKey) []byte {
 func MVCCGetRawWithError(t *testing.T, r storage.Reader, key storage.MVCCKey) ([]byte, error) {
 	iter := r.NewMVCCIterator(storage.MVCCKeyAndIntentsIterKind, storage.IterOptions{Prefix: true})
 	defer iter.Close()
-	iter.SeekGE(key)
-	if ok, err := iter.Valid(); err != nil || !ok {
+	ok, err := iter.SeekGE(key)
+	if !ok {
 		return nil, err
 	}
 	return iter.Value()

--- a/pkg/testutils/storageutils/scan.go
+++ b/pkg/testutils/storageutils/scan.go
@@ -36,12 +36,8 @@ func ScanIter(t *testing.T, iter storage.SimpleMVCCIterator) KVs {
 
 	var kvs []interface{}
 	var prevRangeStart roachpb.Key
-	for iter.SeekGE(storage.MVCCKey{Key: keys.LocalMax}); ; iter.Next() {
-		ok, err := iter.Valid()
-		require.NoError(t, err)
-		if !ok {
-			break
-		}
+	ok, err := iter.SeekGE(storage.MVCCKey{Key: keys.LocalMax})
+	for ; ok; ok, err = iter.Next() {
 		hasPoint, hasRange := iter.HasPointAndRange()
 		if hasRange {
 			if bounds := iter.RangeBounds(); !bounds.Key.Equal(prevRangeStart) {
@@ -79,6 +75,7 @@ func ScanIter(t *testing.T, iter storage.SimpleMVCCIterator) KVs {
 			})
 		}
 	}
+	require.NoError(t, err)
 	return kvs
 }
 

--- a/pkg/testutils/storageutils/stats.go
+++ b/pkg/testutils/storageutils/stats.go
@@ -40,7 +40,7 @@ func SSTStats(t *testing.T, sst []byte, nowNanos int64) *enginepb.MVCCStats {
 	})
 	require.NoError(t, err)
 	defer iter.Close()
-	iter.SeekGE(storage.MVCCKey{Key: keys.MinKey})
+	_, _ = iter.SeekGE(storage.MVCCKey{Key: keys.MinKey})
 	stats, err := storage.ComputeStatsForIter(iter, nowNanos)
 	require.NoError(t, err)
 	return &stats

--- a/pkg/ts/pruning.go
+++ b/pkg/ts/pruning.go
@@ -64,7 +64,8 @@ func (tsdb *DB) findTimeSeries(
 	thresholds := tsdb.computeThresholds(now.WallTime)
 
 	// NB: timeseries don't have intents.
-	iter := snapshot.NewMVCCIterator(storage.MVCCKeyIterKind, storage.IterOptions{UpperBound: endKey.AsRawKey()})
+	iter := storage.DeprecatedMVCCIterator{MVCCIterator: snapshot.NewMVCCIterator(
+		storage.MVCCKeyIterKind, storage.IterOptions{UpperBound: endKey.AsRawKey()})}
 	defer iter.Close()
 
 	for iter.SeekGE(next); ; iter.SeekGE(next) {


### PR DESCRIPTION
Adapt the MVCCIterator and its sub-interface SimpleMVCCIterator to return iterator validity and any error from positioning methods.

Epic: None
Informs: #82589
Release note: None