### PR TITLE
upgrades: update helper fn ExecForCountInTxns to retry transactions

### DIFF
--- a/pkg/upgrade/upgrades/BUILD.bazel
+++ b/pkg/upgrade/upgrades/BUILD.bazel
@@ -188,6 +188,7 @@ go_test(
         "//pkg/util/log",
         "//pkg/util/syncutil",
         "//pkg/util/timeutil",
+        "@com_github_cockroachdb_cockroach_go_v2//crdb",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",


### PR DESCRIPTION
This patch updates the ExecForCountInTxns helper function to retry
transactions to prevent spurious test failures.

Fixes: #100158

Release note: None