### PR TITLE
zip: remove system.jobs.payload from redacted debug zip

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -131,6 +131,7 @@
 /pkg/cli/log*.go             @cockroachdb/obs-inf-prs    @cockroachdb/cli-prs
 /pkg/cli/debug_logconfig.go  @cockroachdb/obs-inf-prs    @cockroachdb/cli-prs
 /pkg/cli/debug_merg_logs*.go @cockroachdb/obs-inf-prs    @cockroachdb/cli-prs
+/pkg/cli/zip*.go             @cockroachdb/obs-inf-prs    @cockroachdb/cli-prs
 
 /pkg/server/                             @cockroachdb/cli-prs
 /pkg/server/addjoin*.go                  @cockroachdb/server-prs @cockroachdb/prodsec

--- a/pkg/cli/zip_table_registry.go
+++ b/pkg/cli/zip_table_registry.go
@@ -942,9 +942,6 @@ var zipSystemTables = DebugZipTableRegistry{
 		},
 	},
 	"system.descriptor": {
-		// `descriptor` column can contain customer-supplied default values
-		// for columns, e.g. `column_name STRING DEFAULT 'some value'`
-		nonSensitiveCols: NonSensitiveColumns{"id"},
 		customQueryUnredacted: `SELECT
 				id,
 				descriptor,
@@ -976,26 +973,24 @@ var zipSystemTables = DebugZipTableRegistry{
 		},
 	},
 	"system.jobs": {
-		// `payload` column may contain customer info, such as URI params
+		// NB: `payload` column may contain customer info, such as URI params
 		// containing access keys, encryption salts, etc.
-		nonSensitiveCols: NonSensitiveColumns{
-			"id",
-			"status",
-			"created",
-			"progress",
-			"created_by_type",
-			"created_by_id",
-			"claim_session_id",
-			"claim_instance_id",
-			"num_runs",
-			"last_run",
-		},
 		customQueryUnredacted: `SELECT *, 
 			to_hex(payload) AS hex_payload, 
 			to_hex(progress) AS hex_progress 
 			FROM system.jobs`,
-		customQueryRedacted: `SELECT *,
-			NULL AS hex_payload,
+		customQueryRedacted: `SELECT id,
+			status,
+			created,
+			'<redacted>' as payload,
+			progress,
+			created_by_type,
+			created_by_id,
+			claim_session_id,
+			claim_instance_id,
+			num_runs,
+			last_run,
+			'<redacted>' AS hex_payload,
 			to_hex(progress) AS hex_progress
 			FROM system.jobs`,
 	},


### PR DESCRIPTION
Ref: https://github.com/cockroachdb/cockroach/pull/90349

The above PR previously updated the debug zip table registry to include a custom redacted query for system.descriptor and system.jobs. While the system.descriptor redacted query properly used SQL builtins to redact the descriptor payload, the updates to system.jobs leaked sensitive data into the redacted debug zip (system.jobs.payload).

Furthermore, the zip table registry was used incorrectly here, where both `nonSensitiveCols` and `customQueryRedacted` were defined for the same table. `customQueryRedacted` will *always* be used over `nonSensitiveCols`, meaning that it doesn't ever make sense to have both defined.

To help protect against this from happening again in the future, a test was added to ensure that no table across the registry has both defined, along with an error message explaining the reasoning and requests to confirm with compliance before introducing any new columns into redacted debug zips.

Luckily, the above PR was never backported, so it never made it into any official release of CockroachDB (I checked the `release-22.2` branch and verified that these changes were not there: https://github.com/cockroachdb/cockroach/blob/release-22.2/pkg/cli/zip_table_registry.go#L836-L855

Release note: none

Fixes: https://github.com/cockroachdb/cockroach/issues/100643