### PR TITLE
kvcoord: Rework error propagation in mux rangefeed

### DIFF
--- a/pkg/kv/kvserver/client_replica_circuit_breaker_test.go
+++ b/pkg/kv/kvserver/client_replica_circuit_breaker_test.go
@@ -428,7 +428,11 @@ func waitReplicaRangeFeed(
 	if ctxErr != nil {
 		return ctxErr
 	}
-	return rfErr
+	var event kvpb.RangeFeedEvent
+	event.SetValue(&kvpb.RangeFeedError{
+		Error: *kvpb.NewError(rfErr),
+	})
+	return stream.Send(&event)
 }
 
 // This test verifies that RangeFeed bypasses the circuit breaker. When the

--- a/pkg/kv/kvserver/rangefeed/registry.go
+++ b/pkg/kv/kvserver/rangefeed/registry.go
@@ -503,10 +503,8 @@ func (reg *registry) Disconnect(span roachpb.Span) {
 // DisconnectWithErr disconnects all registrations that overlap the specified
 // span with the provided error.
 func (reg *registry) DisconnectWithErr(span roachpb.Span, pErr *kvpb.Error) {
-	err := pErr.GoError()
 	reg.forOverlappingRegs(span, func(r *registration) (bool, *kvpb.Error) {
-		r.done.Set(err)
-		return true, pErr
+		return true /* disconned */, pErr
 	})
 }
 

--- a/pkg/kv/kvserver/replica_rangefeed.go
+++ b/pkg/kv/kvserver/replica_rangefeed.go
@@ -159,12 +159,7 @@ func (r *Replica) RangeFeed(
 	}
 
 	if err := r.ensureClosedTimestampStarted(ctx); err != nil {
-		if err := stream.Send(&kvpb.RangeFeedEvent{Error: &kvpb.RangeFeedError{
-			Error: *err,
-		}}); err != nil {
-			return future.MakeCompletedErrorFuture(err)
-		}
-		return future.MakeCompletedErrorFuture(nil)
+		return future.MakeCompletedErrorFuture(err.GoError())
 	}
 
 	// If the RangeFeed is performing a catch-up scan then it will observe all


### PR DESCRIPTION
Prior to this change, there were cases where a future used to wait for a single range feed completion, may be completed multiple times, or a message about range feed termination may be sent multiple times on a single mux rangefeed stream.

One of those cases was a check for `ensureClosedTimestampStarted`. If this method returned an error, we would immediately send the error on the rpc stream, and then complete the future with nil error.

Another instance was when registry would `DisconnectWithErr` -- in that case, we would first complete future in this method, and then, complete it again later.

It appears that completing future multiple times should be okay; however, it is still a bit worrysome.  The deadlocks observed were all in the local RPC bypas (`rpc/context.go`), and it's not a stretch to imagine that as soon as the first error (e.g. from ensureClosedTimestampStarted) is returned, the goroutine reading these messages terminates, and causes the subsequent attempt to send the error deadlock.

Another hypothetical issue is how the mux rangefeed sent the error when the future completed.  Prior to this change, this happened inline (via `WhenReady` closure).  This is dangerous since this closure may run when important locks (such as raft mu) are being held.  What could happen is that mux rangefeed encounters a retryable error.  The future is prepared with error value, which causes an error to be sent to the client.  This happens with some lock being held.  The client, notices this error, and attempts to restart rangefeed -- to the same server, and that could block; At least in theory.  Regardless, it seems that performing IO while the locks could be potentially held, is not a good idea.  This PR fixes this problem by shunting logical rangefeed completion notification to a dedicated go routine.

Informs #99560
Informs #99640
Informs #99214
Informs #98925
Informs #99092
Informs #99212
Informs #99910
Informs #99560

Release note: None