### PR TITLE
builtins: remove crdb_internal.no_constant_folding builtin

### DIFF
--- a/docs/generated/sql/functions.md
+++ b/docs/generated/sql/functions.md
@@ -3187,8 +3187,6 @@ active for the current transaction.</p>
 </span></td><td>Volatile</td></tr>
 <tr><td><a name="crdb_internal.locality_value"></a><code>crdb_internal.locality_value(key: <a href="string.html">string</a>) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Returns the value of the specified locality key.</p>
 </span></td><td>Stable</td></tr>
-<tr><td><a name="crdb_internal.no_constant_folding"></a><code>crdb_internal.no_constant_folding(input: anyelement) &rarr; anyelement</code></td><td><span class="funcdesc"><p>This function is used only by CockroachDB’s developers for testing purposes.</p>
-</span></td><td>Volatile</td></tr>
 <tr><td><a name="crdb_internal.node_executable_version"></a><code>crdb_internal.node_executable_version() &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Returns the version of CockroachDB this node is running.</p>
 </span></td><td>Volatile</td></tr>
 <tr><td><a name="crdb_internal.node_id"></a><code>crdb_internal.node_id() &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>Returns the node ID.</p>

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -5307,22 +5307,6 @@ DO NOT USE -- USE 'CREATE TENANT' INSTEAD`,
 		},
 	),
 
-	// Identity function which is marked as impure to avoid constant folding.
-	"crdb_internal.no_constant_folding": makeBuiltin(
-		tree.FunctionProperties{
-			Category: builtinconstants.CategorySystemInfo,
-		},
-		tree.Overload{
-			Types:      tree.ParamTypes{{Name: "input", Typ: types.Any}},
-			ReturnType: tree.IdentityReturnType(0),
-			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
-				return args[0], nil
-			},
-			Info:       "This function is used only by CockroachDB's developers for testing purposes.",
-			Volatility: volatility.Volatile,
-		},
-	),
-
 	"crdb_internal.trim_tenant_prefix": makeBuiltin(
 		tree.FunctionProperties{
 			Category:     builtinconstants.CategoryMultiTenancy,

--- a/pkg/sql/sem/builtins/fixed_oids.go
+++ b/pkg/sql/sem/builtins/fixed_oids.go
@@ -1295,7 +1295,6 @@ var builtinOidsArray = []string{
 	1314: `crdb_internal.force_log_fatal(msg: string) -> int`,
 	1315: `crdb_internal.force_retry(val: interval) -> int`,
 	1316: `crdb_internal.lease_holder(key: bytes) -> int`,
-	1317: `crdb_internal.no_constant_folding(input: anyelement) -> anyelement`,
 	1318: `crdb_internal.trim_tenant_prefix(key: bytes) -> bytes`,
 	1319: `crdb_internal.trim_tenant_prefix(keys: bytes[]) -> bytes[]`,
 	1320: `crdb_internal.tenant_span(tenant_id: int) -> bytes[]`,

--- a/pkg/sql/sem/normalize/normalize_test.go
+++ b/pkg/sql/sem/normalize/normalize_test.go
@@ -156,7 +156,6 @@ func TestNormalizeExpr(t *testing.T) {
 		{`crdb_internal.force_panic('a')`, `crdb_internal.force_panic('a')`},
 		{`crdb_internal.force_log_fatal('a')`, `crdb_internal.force_log_fatal('a')`},
 		{`crdb_internal.force_retry('1 day'::interval)`, `crdb_internal.force_retry('1 day')`},
-		{`crdb_internal.no_constant_folding(123)`, `crdb_internal.no_constant_folding(123)`},
 		{`crdb_internal.set_vmodule('a')`, `crdb_internal.set_vmodule('a')`},
 		{`uuid_v4()`, `uuid_v4()`},
 		{`experimental_uuid_v4()`, `experimental_uuid_v4()`},


### PR DESCRIPTION
This function no longer does what it's intended to do (namely disabling the constant folding of the whole expression, for testing purposes) because it was only supported in the heuristics planner. This builtin is also not used anywhere in our tests.

Epic: None

Release note: None