### PR TITLE
kv: deflake BenchmarkMVCCGCWithForegroundTraffic

### DIFF
--- a/pkg/kv/kvserver/replica_test.go
+++ b/pkg/kv/kvserver/replica_test.go
@@ -8777,7 +8777,10 @@ func BenchmarkMVCCGCWithForegroundTraffic(b *testing.B) {
 	tc := testContext{}
 	stopper := stop.NewStopper()
 	defer stopper.Stop(ctx)
-	tc.Start(ctx, b, stopper)
+	sc := TestStoreConfig(nil)
+	sc.TestingKnobs.DisableCanAckBeforeApplication = true
+	tc.manualClock = timeutil.NewManualTime(timeutil.Unix(0, 123))
+	tc.StartWithStoreConfig(ctx, b, stopper, sc)
 
 	key := roachpb.Key("test")
 
@@ -8789,7 +8792,7 @@ func BenchmarkMVCCGCWithForegroundTraffic(b *testing.B) {
 		ba.Header = header
 		ba.Add(args)
 		resp, err := tc.Sender().Send(ctx, ba)
-		require.Nil(b, err)
+		require.Nil(b, err, "%+v", err)
 		return resp
 	}
 

--- a/pkg/kv/kvserver/store_rebalancer.go
+++ b/pkg/kv/kvserver/store_rebalancer.go
@@ -174,6 +174,12 @@ func NewStoreRebalancer(
 		subscribedToSpanConfigs: func() bool {
 			// The store rebalancer makes use of span configs. Wait until we've
 			// established subscription.
+			if rq.store.cfg.SpanConfigSubscriber == nil {
+				// Testing-only branch. testContext-style tests do not configure a
+				// SpanConfigSubscriber, so they always return false from this function.
+				// This has the effect of disabling the StoreRebalancer.
+				return false
+			}
 			return !rq.store.cfg.SpanConfigSubscriber.LastUpdated().IsEmpty()
 		},
 	}


### PR DESCRIPTION
Fixes #96266.

The test became flaky after #89632, which made it possible for single-replica tests to see the effects of pre-application raft proposal acks. This was tripping up the MVCC GC in this benchmark, leading to `request to GC non-deleted, latest value of "test"` errors.

Release note: None