### PR TITLE
sql: add new persistedV22_2 views

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/crdb_internal_tenant
+++ b/pkg/ccl/logictestccl/testdata/logic_test/crdb_internal_tenant
@@ -95,6 +95,7 @@ crdb_internal  session_trace                     table  admin  NULL  NULL
 crdb_internal  session_variables                 table  admin  NULL  NULL
 crdb_internal  statement_statistics              view   admin  NULL  NULL
 crdb_internal  statement_statistics_persisted    view   admin  NULL  NULL
+crdb_internal  statement_statistics_persisted_v22_2    view   admin  NULL  NULL
 crdb_internal  super_regions                     table  admin  NULL  NULL
 crdb_internal  system_jobs                       table  admin  NULL  NULL
 crdb_internal  table_columns                     table  admin  NULL  NULL
@@ -106,6 +107,7 @@ crdb_internal  tenant_usage_details              view   admin  NULL  NULL
 crdb_internal  transaction_contention_events     table  admin  NULL  NULL
 crdb_internal  transaction_statistics            view   admin  NULL  NULL
 crdb_internal  transaction_statistics_persisted  view   admin  NULL  NULL
+crdb_internal  transaction_statistics_persisted_v22_2  view   admin  NULL  NULL
 crdb_internal  zones                             table  admin  NULL  NULL
 
 statement ok

--- a/pkg/cli/zip_test.go
+++ b/pkg/cli/zip_test.go
@@ -97,9 +97,11 @@ table_name NOT IN (
 	'tables',
 	'cluster_statement_statistics',
 	'statement_statistics_persisted',
+	'statement_statistics_persistedV22_2',
 	'cluster_transaction_statistics',
 	'statement_statistics',
 	'transaction_statistics_persisted',
+	'transaction_statistics_persistedV22_2',
 	'transaction_statistics',
 	'tenant_usage_details',
   'pg_catalog_table_is_implemented'

--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -181,6 +181,7 @@ var crdbInternal = virtualSchema{
 		catconstants.CrdbInternalSessionVariablesTableID:            crdbInternalSessionVariablesTable,
 		catconstants.CrdbInternalStmtStatsTableID:                   crdbInternalStmtStatsView,
 		catconstants.CrdbInternalStmtStatsPersistedTableID:          crdbInternalStmtStatsPersistedView,
+		catconstants.CrdbInternalStmtStatsPersistedV22_2TableID:     crdbInternalStmtStatsPersistedViewV22_2,
 		catconstants.CrdbInternalTableColumnsTableID:                crdbInternalTableColumnsTable,
 		catconstants.CrdbInternalTableIndexesTableID:                crdbInternalTableIndexesTable,
 		catconstants.CrdbInternalTableSpansTableID:                  crdbInternalTableSpansTable,
@@ -189,6 +190,7 @@ var crdbInternal = virtualSchema{
 		catconstants.CrdbInternalClusterTxnStatsTableID:             crdbInternalClusterTxnStatsTable,
 		catconstants.CrdbInternalTxnStatsTableID:                    crdbInternalTxnStatsView,
 		catconstants.CrdbInternalTxnStatsPersistedTableID:           crdbInternalTxnStatsPersistedView,
+		catconstants.CrdbInternalTxnStatsPersistedV22_2TableID:      crdbInternalTxnStatsPersistedViewV22_2,
 		catconstants.CrdbInternalTransactionStatsTableID:            crdbInternalTransactionStatisticsTable,
 		catconstants.CrdbInternalZonesTableID:                       crdbInternalZonesTable,
 		catconstants.CrdbInternalInvalidDescriptorsTableID:          crdbInternalInvalidDescriptorsTable,
@@ -6450,6 +6452,41 @@ CREATE VIEW crdb_internal.statement_statistics_persisted AS
 	},
 }
 
+// crdb_internal.statement_statistics_persisted_v22_2 view selects persisted statement
+// statistics from the system table. This view is primarily used to query statement
+// stats info by date range. This view is created to be used in mixed version state cluster.
+var crdbInternalStmtStatsPersistedViewV22_2 = virtualSchemaView{
+	schema: `
+CREATE VIEW crdb_internal.statement_statistics_persisted_v22_2 AS
+      SELECT
+          aggregated_ts,
+          fingerprint_id,
+          transaction_fingerprint_id,
+          plan_hash,
+          app_name,
+          node_id,
+          agg_interval,
+          metadata,
+          statistics,
+          plan,
+          index_recommendations
+      FROM
+          system.statement_statistics`,
+	resultColumns: colinfo.ResultColumns{
+		{Name: "aggregated_ts", Typ: types.TimestampTZ},
+		{Name: "fingerprint_id", Typ: types.Bytes},
+		{Name: "transaction_fingerprint_id", Typ: types.Bytes},
+		{Name: "plan_hash", Typ: types.Bytes},
+		{Name: "app_name", Typ: types.String},
+		{Name: "node_id", Typ: types.Int},
+		{Name: "agg_interval", Typ: types.Interval},
+		{Name: "metadata", Typ: types.Jsonb},
+		{Name: "statistics", Typ: types.Jsonb},
+		{Name: "plan", Typ: types.Jsonb},
+		{Name: "index_recommendations", Typ: types.StringArray},
+	},
+}
+
 var crdbInternalActiveRangeFeedsTable = virtualSchemaTable{
 	comment: `node-level table listing all currently running range feeds`,
 	// NB: startTS is exclusive; consider renaming to startAfter.
@@ -6684,6 +6721,33 @@ CREATE VIEW crdb_internal.transaction_statistics_persisted AS
 		{Name: "contention_time", Typ: types.Float},
 		{Name: "total_estimated_execution_time", Typ: types.Float},
 		{Name: "p99_latency", Typ: types.Float},
+	},
+}
+
+// crdb_internal.transaction_statistics_persisted_v22_2 view selects persisted transaction
+// statistics from the system table. This view is primarily used to query transaction
+// stats info by date range. This view is created to be used in mixed version state cluster.
+var crdbInternalTxnStatsPersistedViewV22_2 = virtualSchemaView{
+	schema: `
+CREATE VIEW crdb_internal.transaction_statistics_persisted AS
+      SELECT
+        aggregated_ts,
+        fingerprint_id,
+        app_name,
+        node_id,
+        agg_interval,
+        metadata,
+        statistics
+      FROM
+        system.transaction_statistics`,
+	resultColumns: colinfo.ResultColumns{
+		{Name: "aggregated_ts", Typ: types.TimestampTZ},
+		{Name: "fingerprint_id", Typ: types.Bytes},
+		{Name: "app_name", Typ: types.String},
+		{Name: "node_id", Typ: types.Int},
+		{Name: "agg_interval", Typ: types.Interval},
+		{Name: "metadata", Typ: types.Jsonb},
+		{Name: "statistics", Typ: types.Jsonb},
 	},
 }
 

--- a/pkg/sql/logictest/testdata/logic_test/crdb_internal
+++ b/pkg/sql/logictest/testdata/logic_test/crdb_internal
@@ -87,6 +87,7 @@ crdb_internal  session_trace                     table  admin  NULL  NULL
 crdb_internal  session_variables                 table  admin  NULL  NULL
 crdb_internal  statement_statistics              view   admin  NULL  NULL
 crdb_internal  statement_statistics_persisted    view   admin  NULL  NULL
+crdb_internal  statement_statistics_persisted_v22_2    view   admin  NULL  NULL
 crdb_internal  super_regions                     table  admin  NULL  NULL
 crdb_internal  system_jobs                       table  admin  NULL  NULL
 crdb_internal  table_columns                     table  admin  NULL  NULL
@@ -98,6 +99,7 @@ crdb_internal  tenant_usage_details              view   admin  NULL  NULL
 crdb_internal  transaction_contention_events     table  admin  NULL  NULL
 crdb_internal  transaction_statistics            view   admin  NULL  NULL
 crdb_internal  transaction_statistics_persisted  view   admin  NULL  NULL
+crdb_internal  transaction_statistics_persisted_v22_2  view   admin  NULL  NULL
 crdb_internal  zones                             table  admin  NULL  NULL
 
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/grant_table
+++ b/pkg/sql/logictest/testdata/logic_test/grant_table
@@ -100,6 +100,7 @@ test           crdb_internal       session_trace                          public
 test           crdb_internal       session_variables                      public   SELECT          false
 test           crdb_internal       statement_statistics                   public   SELECT          false
 test           crdb_internal       statement_statistics_persisted         public   SELECT          false
+test           crdb_internal       statement_statistics_persisted_v22_2   public   SELECT          false
 test           crdb_internal       super_regions                          public   SELECT          false
 test           crdb_internal       system_jobs                            public   SELECT          false
 test           crdb_internal       table_columns                          public   SELECT          false
@@ -111,6 +112,7 @@ test           crdb_internal       tenant_usage_details                   public
 test           crdb_internal       transaction_contention_events          public   SELECT          false
 test           crdb_internal       transaction_statistics                 public   SELECT          false
 test           crdb_internal       transaction_statistics_persisted       public   SELECT          false
+test           crdb_internal       transaction_statistics_persisted_v22_2 public   SELECT          false
 test           crdb_internal       zones                                  public   SELECT          false
 test           information_schema  NULL                                   public   USAGE           false
 test           information_schema  administrable_role_authorizations      public   SELECT          false

--- a/pkg/sql/logictest/testdata/logic_test/information_schema
+++ b/pkg/sql/logictest/testdata/logic_test/information_schema
@@ -465,6 +465,7 @@ crdb_internal       session_trace
 crdb_internal       session_variables
 crdb_internal       statement_statistics
 crdb_internal       statement_statistics_persisted
+crdb_internal       statement_statistics_persisted_v22_2
 crdb_internal       super_regions
 crdb_internal       system_jobs
 crdb_internal       table_columns
@@ -476,6 +477,7 @@ crdb_internal       tenant_usage_details
 crdb_internal       transaction_contention_events
 crdb_internal       transaction_statistics
 crdb_internal       transaction_statistics_persisted
+crdb_internal       transaction_statistics_persisted_v22_2
 crdb_internal       zones
 information_schema  administrable_role_authorizations
 information_schema  applicable_roles
@@ -804,6 +806,7 @@ session_trace
 session_variables
 statement_statistics
 statement_statistics_persisted
+statement_statistics_persisted_v22_2
 super_regions
 system_jobs
 table_columns
@@ -815,6 +818,7 @@ tenant_usage_details
 transaction_contention_events
 transaction_statistics
 transaction_statistics_persisted
+transaction_statistics_persisted_v22_2
 zones
 administrable_role_authorizations
 applicable_roles
@@ -1089,6 +1093,7 @@ type_privileges
 triggers
 triggered_update_columns
 transforms
+transaction_statistics_persisted_v22_2
 transaction_statistics_persisted
 transaction_statistics
 transaction_contention_events
@@ -1184,6 +1189,7 @@ system         crdb_internal       session_trace                          SYSTEM
 system         crdb_internal       session_variables                      SYSTEM VIEW  NO                  1
 system         crdb_internal       statement_statistics                   SYSTEM VIEW  NO                  1
 system         crdb_internal       statement_statistics_persisted         SYSTEM VIEW  NO                  1
+system         crdb_internal       statement_statistics_persisted_v22_2   SYSTEM VIEW  NO                  1
 system         crdb_internal       super_regions                          SYSTEM VIEW  NO                  1
 system         crdb_internal       system_jobs                            SYSTEM VIEW  NO                  1
 system         crdb_internal       table_columns                          SYSTEM VIEW  NO                  1
@@ -1195,6 +1201,7 @@ system         crdb_internal       tenant_usage_details                   SYSTEM
 system         crdb_internal       transaction_contention_events          SYSTEM VIEW  NO                  1
 system         crdb_internal       transaction_statistics                 SYSTEM VIEW  NO                  1
 system         crdb_internal       transaction_statistics_persisted       SYSTEM VIEW  NO                  1
+system         crdb_internal       transaction_statistics_persisted_v22_2 SYSTEM VIEW  NO                  1
 system         crdb_internal       zones                                  SYSTEM VIEW  NO                  1
 system         information_schema  administrable_role_authorizations      SYSTEM VIEW  NO                  1
 system         information_schema  applicable_roles                       SYSTEM VIEW  NO                  1
@@ -3154,6 +3161,7 @@ NULL     public   system         crdb_internal       session_trace              
 NULL     public   system         crdb_internal       session_variables                      SELECT          NO            YES
 NULL     public   system         crdb_internal       statement_statistics                   SELECT          NO            YES
 NULL     public   system         crdb_internal       statement_statistics_persisted         SELECT          NO            YES
+NULL     public   system         crdb_internal       statement_statistics_persisted_v22_2   SELECT          NO            YES
 NULL     public   system         crdb_internal       super_regions                          SELECT          NO            YES
 NULL     public   system         crdb_internal       system_jobs                            SELECT          NO            YES
 NULL     public   system         crdb_internal       table_columns                          SELECT          NO            YES
@@ -3165,6 +3173,7 @@ NULL     public   system         crdb_internal       tenant_usage_details       
 NULL     public   system         crdb_internal       transaction_contention_events          SELECT          NO            YES
 NULL     public   system         crdb_internal       transaction_statistics                 SELECT          NO            YES
 NULL     public   system         crdb_internal       transaction_statistics_persisted       SELECT          NO            YES
+NULL     public   system         crdb_internal       transaction_statistics_persisted_v22_2 SELECT          NO            YES
 NULL     public   system         crdb_internal       zones                                  SELECT          NO            YES
 NULL     public   system         information_schema  administrable_role_authorizations      SELECT          NO            YES
 NULL     public   system         information_schema  applicable_roles                       SELECT          NO            YES
@@ -3801,6 +3810,7 @@ NULL     public   system         crdb_internal       session_trace              
 NULL     public   system         crdb_internal       session_variables                      SELECT          NO            YES
 NULL     public   system         crdb_internal       statement_statistics                   SELECT          NO            YES
 NULL     public   system         crdb_internal       statement_statistics_persisted         SELECT          NO            YES
+NULL     public   system         crdb_internal       statement_statistics_persisted_v22_2   SELECT          NO            YES
 NULL     public   system         crdb_internal       super_regions                          SELECT          NO            YES
 NULL     public   system         crdb_internal       system_jobs                            SELECT          NO            YES
 NULL     public   system         crdb_internal       table_columns                          SELECT          NO            YES
@@ -3812,6 +3822,7 @@ NULL     public   system         crdb_internal       tenant_usage_details       
 NULL     public   system         crdb_internal       transaction_contention_events          SELECT          NO            YES
 NULL     public   system         crdb_internal       transaction_statistics                 SELECT          NO            YES
 NULL     public   system         crdb_internal       transaction_statistics_persisted       SELECT          NO            YES
+NULL     public   system         crdb_internal       transaction_statistics_persisted_v22_2 SELECT          NO            YES
 NULL     public   system         crdb_internal       zones                                  SELECT          NO            YES
 NULL     public   system         information_schema  administrable_role_authorizations      SELECT          NO            YES
 NULL     public   system         information_schema  applicable_roles                       SELECT          NO            YES

--- a/pkg/sql/sem/catconstants/constants.go
+++ b/pkg/sql/sem/catconstants/constants.go
@@ -164,6 +164,7 @@ const (
 	CrdbInternalSessionVariablesTableID
 	CrdbInternalStmtStatsTableID
 	CrdbInternalStmtStatsPersistedTableID
+	CrdbInternalStmtStatsPersistedV22_2TableID
 	CrdbInternalTableColumnsTableID
 	CrdbInternalTableIndexesTableID
 	CrdbInternalTableSpansTableID
@@ -172,6 +173,7 @@ const (
 	CrdbInternalTransactionStatsTableID
 	CrdbInternalTxnStatsTableID
 	CrdbInternalTxnStatsPersistedTableID
+	CrdbInternalTxnStatsPersistedV22_2TableID
 	CrdbInternalZonesTableID
 	CrdbInternalInvalidDescriptorsTableID
 	CrdbInternalClusterDatabasePrivilegesTableID


### PR DESCRIPTION
Fixes #100501

Adds `{statement|transaction}_statistics_persisted_v22_2` like they were added on #96454.
Check the version of the cluster before deciding which view to use.
This is required for mixed version cluster with 22.2 and 23.1 versions.

Release note: None
state between 22.2 and 23.1