### PR TITLE
awsdms: key off TC_BUILD_ID for uniqueness

### DIFF
--- a/pkg/cmd/roachtest/tests/awsdms.go
+++ b/pkg/cmd/roachtest/tests/awsdms.go
@@ -103,9 +103,9 @@ const fullLoadTruncate = `{
   }`
 
 func awsdmsVerString(v *version.Version) string {
-	if ciBranch := os.Getenv("TC_BUILD_BRANCH"); ciBranch != "" {
-		ciBranch = strings.ReplaceAll(ciBranch, ".", "-")
-		return fmt.Sprintf("ci-%s", ciBranch)
+	if ciBuildID := os.Getenv("TC_BUILD_ID"); ciBuildID != "" {
+		ciBuildID = strings.ReplaceAll(ciBuildID, ".", "-")
+		return fmt.Sprintf("ci-build-%s", ciBuildID)
 	}
 	ret := fmt.Sprintf("local-%d-%d-%d", v.Major(), v.Minor(), v.Patch())
 	if v.PreRelease() != "" {


### PR DESCRIPTION
Key off TC_BUILD_ID instead of TC_BUILD_BRANCH for TeamCity, in case we run multiple roachtests off the same branch. This unfortunately loses the nice side effect that all resources are cleaned up on AWS DMS failure, but gotta do what you gotta do.

Release note: None
Epic: None

Refs #100410 
Refs #100322