### PR TITLE
util/bulk: fix locking order in TracingAggregator

### DIFF
--- a/pkg/ccl/backupccl/backup_processor.go
+++ b/pkg/ccl/backupccl/backup_processor.go
@@ -217,8 +217,8 @@ func (bp *backupDataProcessor) Next() (rowenc.EncDatumRow, *execinfrapb.Producer
 
 func (bp *backupDataProcessor) close() {
 	bp.cancelAndWaitForWorker()
-	bp.agg.Close()
 	if bp.InternalClose() {
+		bp.agg.Close()
 		bp.memAcc.Close(bp.Ctx())
 	}
 }


### PR DESCRIPTION
This commit fixes an inconsistent locking order in TracingAggregator that was recently introduced in c120153ebf434362c51b12c1c56ec17cc676f777. In particular, now `EventListener.Notify` is called while holding the span's mutex. However, `TracingAggregator.Close` was implemented in such a fashion that its internal mutex was acquired before `Finish` (which acquires the span's mutex). This commit fixes this issue by getting rid of unnecessary locking in `Close` - namely, it's now required that `Close` is called exactly once, so we can just call `span.Finish`.

Fixes: #100562

Release note: None