### PR TITLE
release-23.1: logictest: correctly disable auto stats on system tables

### DIFF
--- a/pkg/sql/logictest/logic.go
+++ b/pkg/sql/logictest/logic.go
@@ -1294,6 +1294,26 @@ func (t *logicTest) newTestServerCluster(bootstrapBinaryPath string, upgradeBina
 func (t *logicTest) newCluster(
 	serverArgs TestServerArgs, clusterOpts []clusterOpt, knobOpts []knobOpt, toa tenantOverrideArgs,
 ) {
+	makeClusterSettings := func(forSystemTenant bool) *cluster.Settings {
+		var st *cluster.Settings
+		if forSystemTenant {
+			// System tenants use the constructor that doesn't initialize the
+			// cluster version (see makeTestConfigFromParams). This is needed
+			// for local-mixed-22.2-23.1 config.
+			st = cluster.MakeClusterSettings()
+		} else {
+			// Regular tenants use the constructor that initializes the cluster
+			// version (see TestServer.StartTenant).
+			st = cluster.MakeTestingClusterSettings()
+		}
+		// Disable stats collection on system tables before the cluster is
+		// started, otherwise there is a race condition where stats may be
+		// collected before we can disable them with `SET CLUSTER SETTING`. We
+		// disable stats collection on system tables in order to have
+		// deterministic tests.
+		stats.AutomaticStatisticsOnSystemTables.Override(context.Background(), &st.SV, false)
+		return st
+	}
 	var corpusCollectionCallback func(p scplan.Plan, stageIdx int) error
 	if serverArgs.DeclarativeCorpusCollection && t.declarativeCorpusCollector != nil {
 		corpusCollectionCallback = t.declarativeCorpusCollector.GetBeforeStage(t.rootT.Name(), t.t())
@@ -1317,10 +1337,7 @@ func (t *logicTest) newCluster(
 
 	params := base.TestClusterArgs{
 		ServerArgs: base.TestServerArgs{
-			SQLMemoryPoolSize: serverArgs.MaxSQLMemoryLimit,
-			TempStorageConfig: base.DefaultTestTempStorageConfigWithSize(
-				cluster.MakeTestingClusterSettings(), tempStorageDiskLimit,
-			),
+			SQLMemoryPoolSize:        serverArgs.MaxSQLMemoryLimit,
 			DisableDefaultTestTenant: t.cfg.UseTenant || t.cfg.DisableDefaultTestTenant,
 			Knobs: base.TestingKnobs{
 				Store: &kvserver.StoreTestingKnobs{
@@ -1408,6 +1425,10 @@ func (t *logicTest) newCluster(
 		} else {
 			require.Lenf(t.rootT, cfg.Localities, 0, "node %d does not have a locality set", i+1)
 		}
+		nodeParams.Settings = makeClusterSettings(true /* forSystemTenant */)
+		nodeParams.TempStorageConfig = base.DefaultTestTempStorageConfigWithSize(
+			nodeParams.Settings, tempStorageDiskLimit,
+		)
 		paramsPerNode[i] = nodeParams
 	}
 	params.ServerArgsPerNode = paramsPerNode
@@ -1419,14 +1440,6 @@ func (t *logicTest) newCluster(
 	stats.DefaultAsOfTime = 10 * time.Millisecond
 	stats.DefaultRefreshInterval = time.Millisecond
 
-	// Disable stats collection on system tables before the cluster is started,
-	// otherwise there is a race condition where stats may be collected before we
-	// can disable them with `SET CLUSTER SETTING`. We disable stats collection on
-	// system tables in order to have deterministic tests.
-	stats.AutomaticStatisticsOnSystemTables.Override(
-		context.Background(), &params.ServerArgs.TempStorageConfig.Settings.SV, false,
-	)
-
 	t.cluster = serverutils.StartNewTestCluster(t.rootT, cfg.NumNodes, params)
 	if cfg.UseFakeSpanResolver {
 		fakeResolver := physicalplanutils.FakeResolverForTestCluster(t.cluster)
@@ -1437,8 +1450,11 @@ func (t *logicTest) newCluster(
 	if cfg.UseTenant {
 		t.tenantAddrs = make([]string, cfg.NumNodes)
 		for i := 0; i < cfg.NumNodes; i++ {
+			settings := makeClusterSettings(false /* forSystemTenant */)
+			tempStorageConfig := base.DefaultTestTempStorageConfigWithSize(settings, tempStorageDiskLimit)
 			tenantArgs := base.TestTenantArgs{
 				TenantID: serverutils.TestTenantID(),
+				Settings: settings,
 				TestingKnobs: base.TestingKnobs{
 					SQLExecutor: &sql.ExecutorTestingKnobs{
 						DeterministicExplain:            true,
@@ -1450,7 +1466,7 @@ func (t *logicTest) newCluster(
 					RangeFeed: paramsPerNode[i].Knobs.RangeFeed,
 				},
 				MemoryPoolSize:    params.ServerArgs.SQLMemoryPoolSize,
-				TempStorageConfig: &params.ServerArgs.TempStorageConfig,
+				TempStorageConfig: &tempStorageConfig,
 				Locality:          paramsPerNode[i].Locality,
 				TracingDefault:    params.ServerArgs.TracingDefault,
 				// Give every tenant its own ExternalIO directory.


### PR DESCRIPTION
Backport 1/1 commits from #99987.

/cc @cockroachdb/release

---

This commit fixes an oversight of https://github.com/cockroachdb/cockroach/commit/9c6fcd19a0892592b11bc803408b6daad0c780dc
where we attempted to disable the auto stats collection on system tables
by overriding the corresponding cluster setting before the cluster is
started. The problem with that change was that we overrode the cluster
setting object that is only used by the temp storage config and has no
bearing on the settings used by each node in the cluster. As it turns
out, previously we didn't explicitly initialize the `Settings` field of
the arguments for each node, so a fresh copy was always created. This
oversight is now fixed - we explicitly create a settings object for each
node / tenant and then override the auto stats on system tables to be
disabled on it.

Fixes: #99897.
Fixes: #100469.

Release note: None

Release justification: test-only change.