### PR TITLE
release-22.2: roachprod: apply (VM) labels to persistent disks

### DIFF
--- a/pkg/cmd/roachprod/flags.go
+++ b/pkg/cmd/roachprod/flags.go
@@ -106,8 +106,9 @@ func initFlags() {
 			vm.AllProviderNames()))
 	createCmd.Flags().BoolVar(&createVMOpts.GeoDistributed,
 		"geo", false, "Create geo-distributed cluster")
+	// N.B. We set "usage=roachprod" as the default, custom label for billing tracking.
 	createCmd.Flags().StringToStringVar(&createVMOpts.CustomLabels,
-		"label", make(map[string]string),
+		"label", map[string]string{"usage": "roachprod"},
 		"The label(s) to be used when creating new vm instances, must be in '--label name=value' format "+
 			"and value can't be empty string after trimming space, a value that has space must be quoted by single "+
 			"quotes, gce label name only allows hyphens (-), underscores (_), lowercase characters, numbers and "+

--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -817,6 +817,9 @@ func createFlagsOverride(flags *pflag.FlagSet, opts *vm.CreateOpts) {
 		if flags.Changed("geo") {
 			opts.GeoDistributed = overrideOpts.GeoDistributed
 		}
+		if flags.Changed("label") {
+			opts.CustomLabels = overrideOpts.CustomLabels
+		}
 	}
 }
 

--- a/pkg/cmd/roachtest/spec/cluster_spec.go
+++ b/pkg/cmd/roachtest/spec/cluster_spec.go
@@ -160,6 +160,8 @@ func (s *ClusterSpec) RoachprodOpts(
 ) (vm.CreateOpts, vm.ProviderOpts, error) {
 
 	createVMOpts := vm.DefaultCreateOpts()
+	// N.B. We set "usage=roachtest" as the default, custom label for billing tracking.
+	createVMOpts.CustomLabels = map[string]string{"usage": "roachtest"}
 	createVMOpts.ClusterName = clusterName
 	if s.Lifetime != 0 {
 		createVMOpts.Lifetime = s.Lifetime

--- a/pkg/roachprod/vm/aws/aws.go
+++ b/pkg/roachprod/vm/aws/aws.go
@@ -849,22 +849,27 @@ func (p *Provider) runInstance(
 	}
 
 	var sb strings.Builder
-	sb.WriteString("ResourceType=instance,Tags=[")
+
+	sep := ""
 	for key, value := range opts.CustomLabels {
 		_, ok := m[strings.ToLower(key)]
 		if ok {
 			return fmt.Errorf("duplicate label name defined: %s", key)
 		}
-		fmt.Fprintf(&sb, "{Key=%s,Value=%s},", key, value)
+		fmt.Fprintf(&sb, "%s{Key=%s,Value=%s}", sep, key, value)
+		sep = ","
 	}
+	sep = ""
 	for key, value := range m {
 		if n, ok := awsLabelsNameMap[key]; ok {
 			key = n
 		}
-		fmt.Fprintf(&sb, "{Key=%s,Value=%s},", key, value)
+		fmt.Fprintf(&sb, "%s{Key=%s,Value=%s}", sep, key, value)
+		sep = ","
 	}
-	s := sb.String()
-	tagSpecs := fmt.Sprintf("%s]", s[:len(s)-1])
+	labels := sb.String()
+	vmTagSpecs := fmt.Sprintf("ResourceType=instance,Tags=[%s]", labels)
+	volumeTagSpecs := fmt.Sprintf("ResourceType=volume,Tags=[%s]", labels)
 
 	var data struct {
 		Instances []struct {
@@ -909,7 +914,7 @@ func (p *Provider) runInstance(
 		"--region", az.region.Name,
 		"--security-group-ids", az.region.SecurityGroup,
 		"--subnet-id", az.subnetID,
-		"--tag-specifications", tagSpecs,
+		"--tag-specifications", vmTagSpecs, volumeTagSpecs,
 		"--user-data", "file://" + filename,
 	}
 

--- a/pkg/roachprod/vm/gce/gcloud.go
+++ b/pkg/roachprod/vm/gce/gcloud.go
@@ -513,22 +513,24 @@ func (p *Provider) Create(
 	for key, value := range m {
 		fmt.Fprintf(&sb, "%s=%s,", key, value)
 	}
-	s := sb.String()
-	args = append(args, "--labels", s[:len(s)-1])
-
+	labels := sb.String()
+	args = append(args, "--labels", labels)
 	args = append(args, "--metadata-from-file", fmt.Sprintf("startup-script=%s", filename))
 	args = append(args, "--project", project)
 	args = append(args, fmt.Sprintf("--boot-disk-size=%dGB", opts.OsVolumeSize))
 	var g errgroup.Group
 
 	nodeZones := vm.ZonePlacement(len(zones), len(names))
-	zoneHostNames := make([][]string, len(zones))
+	// N.B. when len(zones) > len(names), we don't need to map unused zones
+	zoneToHostNames := make(map[string][]string, min(len(zones), len(names)))
 	for i, name := range names {
-		zone := nodeZones[i]
-		zoneHostNames[zone] = append(zoneHostNames[zone], name)
+		zone := zones[nodeZones[i]]
+		zoneToHostNames[zone] = append(zoneToHostNames[zone], name)
 	}
-	for i, zoneHosts := range zoneHostNames {
-		argsWithZone := append(args[:len(args):len(args)], "--zone", zones[i])
+	l.Printf("Creating %d instances, distributed across [%s]", len(names), strings.Join(zones, ", "))
+
+	for zone, zoneHosts := range zoneToHostNames {
+		argsWithZone := append(args[:len(args):len(args)], "--zone", zone)
 		argsWithZone = append(argsWithZone, zoneHosts...)
 		g.Go(func() error {
 			cmd := exec.Command("gcloud", argsWithZone...)
@@ -541,7 +543,72 @@ func (p *Provider) Create(
 		})
 
 	}
+	err = g.Wait()
+	if err != nil {
+		return err
+	}
+
+	return propagateDiskLabels(l, project, labels, zoneToHostNames, &opts)
+}
+
+// N.B. neither boot disk nor additional persistent disks are assigned VM labels by default.
+// Hence, we must propagate them. See: https://cloud.google.com/compute/docs/labeling-resources#labeling_boot_disks
+func propagateDiskLabels(
+	l *logger.Logger,
+	project string,
+	labels string,
+	zoneToHostNames map[string][]string,
+	opts *vm.CreateOpts,
+) error {
+	var g errgroup.Group
+
+	l.Printf("Propagating labels across all disks")
+
+	for zone, zoneHosts := range zoneToHostNames {
+		zoneArg := []string{"--zone", zone}
+
+		for _, host := range zoneHosts {
+			args := []string{"compute", "disks", "update"}
+			args = append(args, "--update-labels", labels[:len(labels)-1])
+			args = append(args, "--project", project)
+			args = append(args, zoneArg...)
+			host := host
+
+			g.Go(func() error {
+				// N.B. boot disk has the same name as the host.
+				bootDiskArgs := append(args, host)
+				cmd := exec.Command("gcloud", bootDiskArgs...)
+
+				output, err := cmd.CombinedOutput()
+				if err != nil {
+					return errors.Wrapf(err, "Command: gcloud %s\nOutput: %s", bootDiskArgs, output)
+				}
+				return nil
+			})
+
+			if !opts.SSDOpts.UseLocalSSD {
+				g.Go(func() error {
+					// N.B. additional persistent disks are suffixed with the offset, starting at 1.
+					persistentDiskArgs := append(args, fmt.Sprintf("%s-1", host))
+					cmd := exec.Command("gcloud", persistentDiskArgs...)
+
+					output, err := cmd.CombinedOutput()
+					if err != nil {
+						return errors.Wrapf(err, "Command: gcloud %s\nOutput: %s", persistentDiskArgs, output)
+					}
+					return nil
+				})
+			}
+		}
+	}
 	return g.Wait()
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
 }
 
 // Delete TODO(peter): document


### PR DESCRIPTION
Backport 1/1 commits from #99423.

/cc @cockroachdb/release

---

Previously, roachprod provisioning in GCE and AWS didn't propagate VM labels to the corresponding persistent disks. In GCE, the labels specified via
 `--labels` [1] are applied only to the VM instances, and not their persistent disks.
There is further evidence [2] this isn't supported in GCE, although the documentation doesn't make it explicit. In AWS, `--tag-specifications` supports multiple resources as of ~2017; roachprod was passing only 'ResourceType=instance'. In Azure, labels appear to be propagated by default; i.e., no change is required.

The missing storage labels made it difficult to accurately determine the cost of a roachprod cluster, based on the usage label. This change ensures the usage (and other) labels are propagated to all persistent disks provisioned via roachprod.

Resolves: https://github.com/cockroachdb/cockroach/issues/90592

Epic: CRDB-10428
Release note: None
Release justification: infra change

[1] https://cloud.google.com/sdk/gcloud/reference/compute/instances/create
[2] https://issuetracker.google.com/issues/163152709
