### PR TITLE
ci: artifacts of FIPS-enabled roachtests should be separate

### DIFF
--- a/build/teamcity/util/roachtest_util.sh
+++ b/build/teamcity/util/roachtest_util.sh
@@ -32,6 +32,10 @@ function upload_stats {
         # the location.
         remote_artifacts_dir="artifacts"
       fi
+      # In FIPS-mode, keep artifacts separate by using the 'fips' suffix.
+      if [[ ${FIPS_ENABLED:-0} == 1 ]]; then
+        remote_artifacts_dir="${remote_artifacts_dir}-fips"
+      fi
 
       # The stats.json files need some path translation:
       #     ${artifacts}/path/to/test/stats.json


### PR DESCRIPTION
When running FIPS-enabled roachtests, we want to separate their artifacts from other roachtests. This removes the confounding factor for performance tests wherein FIPS may result in performance degradation.

Epic: none

Release note: None