### PR TITLE
release-23.1: kvserver: eagerly extend expiration leases in Raft scheduler

### DIFF
--- a/pkg/kv/kvserver/replica_lease_renewal_test.go
+++ b/pkg/kv/kvserver/replica_lease_renewal_test.go
@@ -8,7 +8,7 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
-package kvserver_test
+package kvserver
 
 import (
 	"context"
@@ -17,36 +17,144 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
-	"github.com/cockroachdb/cockroach/pkg/kv/kvserver"
+	"github.com/cockroachdb/cockroach/pkg/keys"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
-	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
+	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/require"
 )
 
+// TestLeaseRenewer tests that the store lease renewer correctly tracks and
+// extends expiration-based leases.
+func TestLeaseRenewer(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+
+	tc := serverutils.StartNewTestCluster(t, 3, base.TestClusterArgs{
+		ServerArgs: base.TestServerArgs{
+			RaftConfig: base.RaftConfig{
+				RangeLeaseDuration: time.Second,
+			},
+		},
+	})
+	defer tc.Stopper().Stop(ctx)
+
+	require.NoError(t, tc.WaitForFullReplication())
+
+	lookupNode := func(nodeID roachpb.NodeID) int {
+		for idx, id := range tc.NodeIDs() {
+			if id == nodeID {
+				return idx
+			}
+		}
+		t.Fatalf("couldn't look up node %d", nodeID)
+		return 0
+	}
+
+	getNodeStore := func(nodeID roachpb.NodeID) *Store {
+		srv := tc.Server(lookupNode(nodeID))
+		s, err := srv.GetStores().(*Stores).GetStore(srv.GetFirstStoreID())
+		require.NoError(t, err)
+		return s
+	}
+
+	getNodeReplica := func(nodeID roachpb.NodeID, rangeID roachpb.RangeID) *Replica {
+		repl, err := getNodeStore(nodeID).GetReplica(rangeID)
+		require.NoError(t, err)
+		return repl
+	}
+
+	getLeaseRenewers := func(rangeID roachpb.RangeID) []roachpb.NodeID {
+		var renewers []roachpb.NodeID
+		for _, nodeID := range tc.NodeIDs() {
+			if _, ok := getNodeStore(nodeID).renewableLeases.Load(int64(rangeID)); ok {
+				renewers = append(renewers, nodeID)
+			}
+		}
+		return renewers
+	}
+
+	// assertLeaseRenewal asserts that the given range has an expiration-based
+	// lease, that it's eagerly extended, and only actively renewed by the
+	// leaseholder.
+	assertLeaseRenewal := func(rangeID roachpb.RangeID) {
+		repl := getNodeReplica(1, rangeID)
+		lease, _ := repl.GetLease()
+		require.Equal(t, roachpb.LeaseExpiration, lease.Type())
+
+		var extensions int
+		require.Eventually(t, func() bool {
+			newLease, _ := repl.GetLease()
+			require.Equal(t, roachpb.LeaseExpiration, newLease.Type())
+			if *newLease.Expiration != *lease.Expiration {
+				extensions++
+				lease = newLease
+				t.Logf("r%d lease extended: %v", rangeID, lease)
+			}
+
+			renewers := getLeaseRenewers(repl.RangeID)
+			renewedByLeaseholder := len(renewers) == 1 && renewers[0] == lease.Replica.NodeID
+			if !renewedByLeaseholder {
+				t.Logf("r%d renewers: %v", rangeID, renewers)
+			}
+
+			return extensions >= 3 && renewedByLeaseholder
+		}, 20*time.Second, 100*time.Millisecond)
+	}
+
+	// The meta range should always be eagerly renewed.
+	assertLeaseRenewal(tc.LookupRangeOrFatal(t, keys.MinKey).RangeID)
+
+	// Split off an expiration-based range, and assert that the lease is extended.
+	desc := tc.LookupRangeOrFatal(t, tc.ScratchRangeWithExpirationLease(t))
+	assertLeaseRenewal(desc.RangeID)
+
+	// Transfer the lease to a different leaseholder, and assert that the lease is
+	// still extended.
+	lease, _ := getNodeReplica(1, desc.RangeID).GetLease()
+	target := tc.Target(lookupNode(lease.Replica.NodeID%3 + 1))
+	tc.TransferRangeLeaseOrFatal(t, desc, target)
+	assertLeaseRenewal(desc.RangeID)
+
+	// Merge the range back. This should unregister it from the lease renewer.
+	require.NoError(t, tc.Server(0).DB().AdminMerge(ctx, desc.StartKey.AsRawKey().Prevish(16)))
+	require.Eventually(t, func() bool {
+		if renewers := getLeaseRenewers(desc.RangeID); len(renewers) > 0 {
+			t.Logf("r%d renewers: %v", desc.RangeID, renewers)
+			return false
+		}
+		return true
+	}, 20*time.Second, 100*time.Millisecond)
+}
+
 func setupLeaseRenewerTest(
 	ctx context.Context, t *testing.T, init func(*base.TestClusterArgs),
 ) (
 	cycles *int32, /* atomic */
-	_ *testcluster.TestCluster,
+	_ serverutils.TestClusterInterface,
 ) {
 	cycles = new(int32)
 	var args base.TestClusterArgs
-	args.ServerArgs.Knobs.Store = &kvserver.StoreTestingKnobs{
+	args.ServerArgs.Knobs.Store = &StoreTestingKnobs{
 		LeaseRenewalOnPostCycle: func() {
 			atomic.AddInt32(cycles, 1)
 		},
 	}
 	init(&args)
-	tc := testcluster.StartTestCluster(t, 1, args)
+	tc := serverutils.StartNewTestCluster(t, 1, args)
 	t.Cleanup(func() { tc.Stopper().Stop(ctx) })
 
 	desc := tc.LookupRangeOrFatal(t, tc.ScratchRangeWithExpirationLease(t))
-	s := tc.GetFirstStoreFromServer(t, 0)
+	srv := tc.Server(0)
+	s, err := srv.GetStores().(*Stores).GetStore(srv.GetFirstStoreID())
+	require.NoError(t, err)
 
-	_, err := s.DB().Get(ctx, desc.StartKey)
+	_, err = s.DB().Get(ctx, desc.StartKey)
 	require.NoError(t, err)
 
 	repl, err := s.GetReplica(desc.RangeID)
@@ -67,7 +175,7 @@ func TestLeaseRenewerExtendsExpirationBasedLeases(t *testing.T) {
 	t.Run("triggered", func(t *testing.T) {
 		renewCh := make(chan struct{})
 		cycles, tc := setupLeaseRenewerTest(ctx, t, func(args *base.TestClusterArgs) {
-			args.ServerArgs.Knobs.Store.(*kvserver.StoreTestingKnobs).LeaseRenewalSignalChan = renewCh
+			args.ServerArgs.Knobs.Store.(*StoreTestingKnobs).LeaseRenewalSignalChan = renewCh
 		})
 		defer tc.Stopper().Stop(ctx)
 
@@ -93,7 +201,7 @@ func TestLeaseRenewerExtendsExpirationBasedLeases(t *testing.T) {
 
 	t.Run("periodic", func(t *testing.T) {
 		cycles, tc := setupLeaseRenewerTest(ctx, t, func(args *base.TestClusterArgs) {
-			args.ServerArgs.Knobs.Store.(*kvserver.StoreTestingKnobs).LeaseRenewalDurationOverride = 10 * time.Millisecond
+			args.ServerArgs.Knobs.Store.(*StoreTestingKnobs).LeaseRenewalDurationOverride = 10 * time.Millisecond
 		})
 		defer tc.Stopper().Stop(ctx)
 

--- a/pkg/kv/kvserver/replica_lease_renewal_test.go
+++ b/pkg/kv/kvserver/replica_lease_renewal_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
@@ -27,109 +28,170 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestLeaseRenewer tests that the store lease renewer correctly tracks and
-// extends expiration-based leases.
+// TestLeaseRenewer tests that the store lease renewer or the Raft scheduler
+// correctly tracks and extends expiration-based leases. The responsibility
+// is given by kv.expiration_leases_only.enabled.
 func TestLeaseRenewer(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	ctx := context.Background()
-
-	tc := serverutils.StartNewTestCluster(t, 3, base.TestClusterArgs{
-		ServerArgs: base.TestServerArgs{
-			RaftConfig: base.RaftConfig{
-				RangeLeaseDuration: time.Second,
+	// When kv.expiration_leases_only.enabled is true, the Raft scheduler is
+	// responsible for extensions, but we still track expiration leases for system
+	// ranges in the store lease renewer in case the setting changes.
+	testutils.RunTrueAndFalse(t, "kv.expiration_leases_only.enabled", func(t *testing.T, expOnly bool) {
+		ctx := context.Background()
+		st := cluster.MakeTestingClusterSettings()
+		ExpirationLeasesOnly.Override(ctx, &st.SV, expOnly)
+		tc := serverutils.StartNewTestCluster(t, 3, base.TestClusterArgs{
+			ServerArgs: base.TestServerArgs{
+				Settings: st,
+				RaftConfig: base.RaftConfig{
+					RangeLeaseDuration: time.Second,
+					RaftTickInterval:   100 * time.Millisecond,
+				},
 			},
-		},
+		})
+		defer tc.Stopper().Stop(ctx)
+
+		require.NoError(t, tc.WaitForFullReplication())
+
+		lookupNode := func(nodeID roachpb.NodeID) int {
+			for idx, id := range tc.NodeIDs() {
+				if id == nodeID {
+					return idx
+				}
+			}
+			t.Fatalf("couldn't look up node %d", nodeID)
+			return 0
+		}
+
+		getNodeStore := func(nodeID roachpb.NodeID) *Store {
+			srv := tc.Server(lookupNode(nodeID))
+			s, err := srv.GetStores().(*Stores).GetStore(srv.GetFirstStoreID())
+			require.NoError(t, err)
+			return s
+		}
+
+		getNodeReplica := func(nodeID roachpb.NodeID, rangeID roachpb.RangeID) *Replica {
+			repl, err := getNodeStore(nodeID).GetReplica(rangeID)
+			require.NoError(t, err)
+			return repl
+		}
+
+		getLeaseRenewers := func(rangeID roachpb.RangeID) []roachpb.NodeID {
+			var renewers []roachpb.NodeID
+			for _, nodeID := range tc.NodeIDs() {
+				if _, ok := getNodeStore(nodeID).renewableLeases.Load(int64(rangeID)); ok {
+					renewers = append(renewers, nodeID)
+				}
+			}
+			return renewers
+		}
+
+		// assertLeaseExtension asserts that the given range has an expiration-based
+		// lease that is eagerly extended.
+		assertLeaseExtension := func(rangeID roachpb.RangeID) {
+			repl := getNodeReplica(1, rangeID)
+			lease, _ := repl.GetLease()
+			require.Equal(t, roachpb.LeaseExpiration, lease.Type())
+
+			var extensions int
+			require.Eventually(t, func() bool {
+				newLease, _ := repl.GetLease()
+				require.Equal(t, roachpb.LeaseExpiration, newLease.Type())
+				if *newLease.Expiration != *lease.Expiration {
+					extensions++
+					lease = newLease
+					t.Logf("r%d lease extended: %v", rangeID, lease)
+				}
+				return extensions >= 3
+			}, 20*time.Second, 100*time.Millisecond)
+		}
+
+		// assertLeaseUpgrade asserts that the range is eventually upgraded
+		// to an epoch lease.
+		assertLeaseUpgrade := func(rangeID roachpb.RangeID) {
+			repl := getNodeReplica(1, rangeID)
+			require.Eventually(t, func() bool {
+				lease, _ := repl.GetLease()
+				return lease.Type() == roachpb.LeaseEpoch
+			}, 20*time.Second, 100*time.Millisecond)
+		}
+
+		// assertStoreLeaseRenewer asserts that the range is tracked by the store lease
+		// renewer on the leaseholder.
+		assertStoreLeaseRenewer := func(rangeID roachpb.RangeID) {
+			repl := getNodeReplica(1, rangeID)
+			require.Eventually(t, func() bool {
+				lease, _ := repl.GetLease()
+				renewers := getLeaseRenewers(rangeID)
+				renewedByLeaseholder := len(renewers) == 1 && renewers[0] == lease.Replica.NodeID
+				// If kv.expiration_leases_only.enabled is true, then the store lease
+				// renewer is disabled -- it will still track the ranges in case the
+				// setting changes, but won't detect the new lease and untrack them as
+				// long as it has a replica. We therefore allow multiple nodes to track
+				// it, as long as the leaseholder is one of them.
+				if expOnly {
+					for _, renewer := range renewers {
+						if renewer == lease.Replica.NodeID {
+							renewedByLeaseholder = true
+							break
+						}
+					}
+				}
+				if !renewedByLeaseholder {
+					t.Logf("r%d renewers: %v", rangeID, renewers)
+				}
+				return renewedByLeaseholder
+			}, 20*time.Second, 100*time.Millisecond)
+		}
+
+		// assertNoStoreLeaseRenewer asserts that the range is not tracked by any
+		// lease renewer.
+		assertNoStoreLeaseRenewer := func(rangeID roachpb.RangeID) {
+			require.Eventually(t, func() bool {
+				renewers := getLeaseRenewers(rangeID)
+				if len(renewers) > 0 {
+					t.Logf("r%d renewers: %v", rangeID, renewers)
+					return false
+				}
+				return true
+			}, 20*time.Second, 100*time.Millisecond)
+		}
+
+		// The meta range should always be eagerly renewed.
+		firstRangeID := tc.LookupRangeOrFatal(t, keys.MinKey).RangeID
+		assertLeaseExtension(firstRangeID)
+		assertStoreLeaseRenewer(firstRangeID)
+
+		// Split off an expiration-based range, and assert that the lease is extended.
+		desc := tc.LookupRangeOrFatal(t, tc.ScratchRangeWithExpirationLease(t))
+		assertLeaseExtension(desc.RangeID)
+		assertStoreLeaseRenewer(desc.RangeID)
+
+		// Transfer the lease to a different leaseholder, and assert that the lease is
+		// still extended.
+		lease, _ := getNodeReplica(1, desc.RangeID).GetLease()
+		target := tc.Target(lookupNode(lease.Replica.NodeID%3 + 1))
+		tc.TransferRangeLeaseOrFatal(t, desc, target)
+		assertLeaseExtension(desc.RangeID)
+		assertStoreLeaseRenewer(desc.RangeID)
+
+		// Merge the range back. This should unregister it from the lease renewer.
+		require.NoError(t, tc.Server(0).DB().AdminMerge(ctx, desc.StartKey.AsRawKey().Prevish(16)))
+		assertNoStoreLeaseRenewer(desc.RangeID)
+
+		// Split off a regular non-system range. This should only be eagerly
+		// extended if kv.expiration_leases_only.enabled is true, and should never
+		// be tracked by the store lease renewer (which only handles system ranges).
+		desc = tc.LookupRangeOrFatal(t, tc.ScratchRange(t))
+		if expOnly {
+			assertLeaseExtension(desc.RangeID)
+		} else {
+			assertLeaseUpgrade(desc.RangeID)
+		}
+		assertNoStoreLeaseRenewer(desc.RangeID)
 	})
-	defer tc.Stopper().Stop(ctx)
-
-	require.NoError(t, tc.WaitForFullReplication())
-
-	lookupNode := func(nodeID roachpb.NodeID) int {
-		for idx, id := range tc.NodeIDs() {
-			if id == nodeID {
-				return idx
-			}
-		}
-		t.Fatalf("couldn't look up node %d", nodeID)
-		return 0
-	}
-
-	getNodeStore := func(nodeID roachpb.NodeID) *Store {
-		srv := tc.Server(lookupNode(nodeID))
-		s, err := srv.GetStores().(*Stores).GetStore(srv.GetFirstStoreID())
-		require.NoError(t, err)
-		return s
-	}
-
-	getNodeReplica := func(nodeID roachpb.NodeID, rangeID roachpb.RangeID) *Replica {
-		repl, err := getNodeStore(nodeID).GetReplica(rangeID)
-		require.NoError(t, err)
-		return repl
-	}
-
-	getLeaseRenewers := func(rangeID roachpb.RangeID) []roachpb.NodeID {
-		var renewers []roachpb.NodeID
-		for _, nodeID := range tc.NodeIDs() {
-			if _, ok := getNodeStore(nodeID).renewableLeases.Load(int64(rangeID)); ok {
-				renewers = append(renewers, nodeID)
-			}
-		}
-		return renewers
-	}
-
-	// assertLeaseRenewal asserts that the given range has an expiration-based
-	// lease, that it's eagerly extended, and only actively renewed by the
-	// leaseholder.
-	assertLeaseRenewal := func(rangeID roachpb.RangeID) {
-		repl := getNodeReplica(1, rangeID)
-		lease, _ := repl.GetLease()
-		require.Equal(t, roachpb.LeaseExpiration, lease.Type())
-
-		var extensions int
-		require.Eventually(t, func() bool {
-			newLease, _ := repl.GetLease()
-			require.Equal(t, roachpb.LeaseExpiration, newLease.Type())
-			if *newLease.Expiration != *lease.Expiration {
-				extensions++
-				lease = newLease
-				t.Logf("r%d lease extended: %v", rangeID, lease)
-			}
-
-			renewers := getLeaseRenewers(repl.RangeID)
-			renewedByLeaseholder := len(renewers) == 1 && renewers[0] == lease.Replica.NodeID
-			if !renewedByLeaseholder {
-				t.Logf("r%d renewers: %v", rangeID, renewers)
-			}
-
-			return extensions >= 3 && renewedByLeaseholder
-		}, 20*time.Second, 100*time.Millisecond)
-	}
-
-	// The meta range should always be eagerly renewed.
-	assertLeaseRenewal(tc.LookupRangeOrFatal(t, keys.MinKey).RangeID)
-
-	// Split off an expiration-based range, and assert that the lease is extended.
-	desc := tc.LookupRangeOrFatal(t, tc.ScratchRangeWithExpirationLease(t))
-	assertLeaseRenewal(desc.RangeID)
-
-	// Transfer the lease to a different leaseholder, and assert that the lease is
-	// still extended.
-	lease, _ := getNodeReplica(1, desc.RangeID).GetLease()
-	target := tc.Target(lookupNode(lease.Replica.NodeID%3 + 1))
-	tc.TransferRangeLeaseOrFatal(t, desc, target)
-	assertLeaseRenewal(desc.RangeID)
-
-	// Merge the range back. This should unregister it from the lease renewer.
-	require.NoError(t, tc.Server(0).DB().AdminMerge(ctx, desc.StartKey.AsRawKey().Prevish(16)))
-	require.Eventually(t, func() bool {
-		if renewers := getLeaseRenewers(desc.RangeID); len(renewers) > 0 {
-			t.Logf("r%d renewers: %v", desc.RangeID, renewers)
-			return false
-		}
-		return true
-	}, 20*time.Second, 100*time.Millisecond)
 }
 
 func setupLeaseRenewerTest(

--- a/pkg/kv/kvserver/replica_lease_renewal_test.go
+++ b/pkg/kv/kvserver/replica_lease_renewal_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/errors"
@@ -35,6 +36,11 @@ func TestLeaseRenewer(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
+	// stressrace and deadlock make the test too slow, resulting in an inability
+	// to maintain leases and Raft leadership.
+	skip.UnderStressRace(t)
+	skip.UnderDeadlock(t)
+
 	// When kv.expiration_leases_only.enabled is true, the Raft scheduler is
 	// responsible for extensions, but we still track expiration leases for system
 	// ranges in the store lease renewer in case the setting changes.
@@ -45,9 +51,18 @@ func TestLeaseRenewer(t *testing.T) {
 		tc := serverutils.StartNewTestCluster(t, 3, base.TestClusterArgs{
 			ServerArgs: base.TestServerArgs{
 				Settings: st,
+				// Speed up lease extensions to speed up the test, but adjust tick-based
+				// timeouts to retain their default wall-time values.
 				RaftConfig: base.RaftConfig{
-					RangeLeaseDuration: time.Second,
-					RaftTickInterval:   100 * time.Millisecond,
+					RangeLeaseRenewalFraction:  0.95,
+					RaftTickInterval:           100 * time.Millisecond,
+					RaftElectionTimeoutTicks:   20,
+					RaftReproposalTimeoutTicks: 30,
+				},
+				Knobs: base.TestingKnobs{
+					Store: &StoreTestingKnobs{
+						LeaseRenewalDurationOverride: 100 * time.Millisecond,
+					},
 				},
 			},
 		})
@@ -170,7 +185,8 @@ func TestLeaseRenewer(t *testing.T) {
 		assertStoreLeaseRenewer(desc.RangeID)
 
 		// Transfer the lease to a different leaseholder, and assert that the lease is
-		// still extended.
+		// still extended. Wait for the split to apply on all nodes first.
+		require.NoError(t, tc.WaitForFullReplication())
 		lease, _ := getNodeReplica(1, desc.RangeID).GetLease()
 		target := tc.Target(lookupNode(lease.Replica.NodeID%3 + 1))
 		tc.TransferRangeLeaseOrFatal(t, desc, target)

--- a/pkg/kv/kvserver/replica_proposal.go
+++ b/pkg/kv/kvserver/replica_proposal.go
@@ -377,9 +377,11 @@ func (r *Replica) leasePostApplyLocked(
 			// Whenever we first acquire an expiration-based lease for a range that
 			// requires it (i.e. the liveness or meta ranges), notify the lease
 			// renewer worker that we want it to keep proactively renewing the lease
-			// before it expires. We don't eagerly renew other expiration leases,
-			// because a more sophisticated scheduler is needed to handle large
-			// numbers of expiration leases.
+			// before it expires.
+			//
+			// Other expiration leases are only proactively renewed if
+			// kv.expiration_leases_only.enabled is true, but in that case the renewal
+			// is handled by the Raft scheduler during Raft ticks.
 			r.store.renewableLeases.Store(int64(r.RangeID), unsafe.Pointer(r))
 			select {
 			case r.store.renewableLeasesSignal <- struct{}{}:

--- a/pkg/kv/kvserver/replica_proposal.go
+++ b/pkg/kv/kvserver/replica_proposal.go
@@ -371,8 +371,8 @@ func (r *Replica) leasePostApplyLocked(
 		r.gossipFirstRangeLocked(ctx)
 	}
 
-	if newLease.Type() == roachpb.LeaseExpiration && (leaseChangingHands || maybeSplit) &&
-		iAmTheLeaseHolder && r.ownsValidLeaseRLocked(ctx, now) {
+	isExpirationLease := newLease.Type() == roachpb.LeaseExpiration
+	if isExpirationLease && (leaseChangingHands || maybeSplit) && iAmTheLeaseHolder {
 		if r.requiresExpirationLeaseRLocked() {
 			// Whenever we first acquire an expiration-based lease for a range that
 			// requires it (i.e. the liveness or meta ranges), notify the lease
@@ -387,7 +387,7 @@ func (r *Replica) leasePostApplyLocked(
 			case r.store.renewableLeasesSignal <- struct{}{}:
 			default:
 			}
-		} else if !r.shouldUseExpirationLeaseRLocked() {
+		} else if !r.shouldUseExpirationLeaseRLocked() && r.ownsValidLeaseRLocked(ctx, now) {
 			// We received an expiration lease for a range that shouldn't keep using
 			// it, most likely as part of a lease transfer (which is always
 			// expiration-based). We've also applied it before it has expired. Upgrade

--- a/pkg/kv/kvserver/replica_range_lease.go
+++ b/pkg/kv/kvserver/replica_range_lease.go
@@ -1407,12 +1407,18 @@ func (r *Replica) redirectOnOrAcquireLeaseForRequest(
 	}
 }
 
-// shouldExtendLeaseRLocked determines whether the lease should be
-// extended asynchronously, even if it is currently valid. The method
-// returns true if this range uses expiration-based leases, the lease is
-// in need of renewal, and there's not already an extension pending.
+// shouldExtendLeaseRLocked determines whether the lease should be extended
+// asynchronously, i.e. if:
+//
+// * The range uses expiration-based leases.
+// * The most recent lease is owned by this replica.
+// * The lease is in need of renewal.
+// * There is no pending extension.
 func (r *Replica) shouldExtendLeaseRLocked(st kvserverpb.LeaseStatus) bool {
 	if st.Lease.Type() != roachpb.LeaseExpiration {
+		return false
+	}
+	if !st.Lease.OwnedBy(r.StoreID()) {
 		return false
 	}
 	if _, ok := r.mu.pendingLeaseRequest.RequestPending(); ok {
@@ -1423,8 +1429,7 @@ func (r *Replica) shouldExtendLeaseRLocked(st kvserverpb.LeaseStatus) bool {
 }
 
 // maybeExtendLeaseAsync attempts to extend the expiration-based lease
-// asynchronously, if doing so is deemed beneficial by an earlier call
-// to shouldExtendLeaseRLocked.
+// asynchronously, if doing so is deemed beneficial by shouldExtendLeaseRLocked.
 func (r *Replica) maybeExtendLeaseAsync(ctx context.Context, st kvserverpb.LeaseStatus) {
 	r.mu.Lock()
 	defer r.mu.Unlock()

--- a/pkg/kv/kvserver/replicate_queue.go
+++ b/pkg/kv/kvserver/replicate_queue.go
@@ -689,14 +689,11 @@ func (rq *replicateQueue) shouldQueue(
 	}
 
 	leaseStatus := repl.LeaseStatusAt(ctx, now)
-	if !leaseStatus.IsValid() && leaseStatus.Lease.Type() != roachpb.LeaseExpiration {
-		// The epoch lease for this range is currently invalid. If this replica is
-		// the raft leader then we'd like it to hold a valid lease. We enqueue it
-		// regardless of being a leader or follower, where the leader at the time of
-		// processing will succeed.
-		//
-		// We don't do this for expiration leases, because we'd like them to expire
-		// if the range is idle.
+	if !leaseStatus.IsValid() {
+		// The range has an invalid lease. If this replica is the raft leader then
+		// we'd like it to hold a valid lease. We enqueue it regardless of being a
+		// leader or follower, where the leader at the time of processing will
+		// succeed.
 		log.KvDistribution.VEventf(ctx, 2, "invalid lease, enqueuing")
 		return true, 0
 	}

--- a/pkg/kv/kvserver/store_remove_replica.go
+++ b/pkg/kv/kvserver/store_remove_replica.go
@@ -303,6 +303,7 @@ func (s *Store) unlinkReplicaByRangeIDLocked(ctx context.Context, rangeID roachp
 	s.mu.replicasByRangeID.Delete(rangeID)
 	s.unregisterLeaseholderByID(ctx, rangeID)
 	s.raftRecvQueues.Delete(rangeID)
+	s.renewableLeases.Delete(int64(rangeID))
 }
 
 // removePlaceholder removes a placeholder for the specified range.

--- a/pkg/kv/kvserver/testing_knobs.go
+++ b/pkg/kv/kvserver/testing_knobs.go
@@ -125,8 +125,8 @@ type StoreTestingKnobs struct {
 	// should get rid of such practices once we make TestServer take a
 	// ManualClock.
 	DisableMaxOffsetCheck bool
-	// DisableAutomaticLeaseRenewal enables turning off the background worker
-	// that attempts to automatically renew expiration-based leases.
+	// DisableAutomaticLeaseRenewal disables eager renewal of expiration-based
+	// leases.
 	DisableAutomaticLeaseRenewal bool
 	// LeaseRequestEvent, if set, is called when replica.requestLeaseLocked() is
 	// called to acquire a new lease. This can be used to assert that a request

--- a/pkg/testutils/serverutils/test_cluster_shim.go
+++ b/pkg/testutils/serverutils/test_cluster_shim.go
@@ -209,6 +209,10 @@ type TestClusterInterface interface {
 	// range is lazily split off on the first call to ScratchRange.
 	ScratchRange(t testing.TB) roachpb.Key
 
+	// ScratchRangeWithExpirationLease is like ScratchRange, but returns a system
+	// range with an expiration lease.
+	ScratchRangeWithExpirationLease(t testing.TB) roachpb.Key
+
 	// WaitForFullReplication waits until all stores in the cluster
 	// have no ranges with replication pending.
 	WaitForFullReplication() error


### PR DESCRIPTION
Backport:
  * 1/1 commits from "kvserver: register lease renewals on splits/merges" (#100392)
  * 4/4 commits from "kvserver: eagerly extend expiration leases in Raft scheduler" (#100430)
  * 2/2 commits from "kvserver: deflake `TestLeaseRenewer`" (#101012)

Please see individual PRs for details.

/cc @cockroachdb/release

Release justification: fixes rangefeed resolved timestamps with expiration leases, gated behind default-off cluster setting.