### PR TITLE
kvserver: skip `TestLeaseRenewer`

### DIFF
--- a/pkg/kv/kvserver/replica_lease_renewal_test.go
+++ b/pkg/kv/kvserver/replica_lease_renewal_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/errors"
@@ -34,6 +35,8 @@ import (
 func TestLeaseRenewer(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
+
+	skip.WithIssue(t, 100689)
 
 	// When kv.expiration_leases_only.enabled is true, the Raft scheduler is
 	// responsible for extensions, but we still track expiration leases for system


### PR DESCRIPTION
This is flaky under race/deadlock, but also had a couple of failures that indicate minor races in (de)activating extensions. I won't have time to look into this immediately, so skipping it for now.

Touches #100689.

Epic: none
Release note: None