### PR TITLE
teamcity/release: use version.txt instead of git-describe to pick build name, ldflag it in

### DIFF
--- a/build/bazelutil/stamp.sh
+++ b/build/bazelutil/stamp.sh
@@ -3,13 +3,14 @@
 # This command is used by bazel as the workspace_status_command
 # to implement build stamping with git information.
 
-# Usage: stamp.sh [target-triple] [build-channel] [build-type]
+# Usage: stamp.sh [target-triple] [build-channel] [build-type] [release-version]
 # All arguments are optional and have appropriate defaults. In this way,
 # stamp.sh with no arguments is appropriate as the `workplace_status_command`
 # for a development build.
 #  target-triple: defaults to the value of `cc -dumpmachine`
 #  build-channel: defaults to `unknown`, but can be `official-binary`
 #  build-type: defaults to `development`, but can be `release`
+#  release-version: defaults to '' in which case binary determines own version.
 
 set -euo pipefail
 
@@ -49,6 +50,16 @@ else
     shift 1
 fi
 
+
+# Handle release version.
+if [ -z "${1+x}" ]
+then
+    BUILD_RELEASE_VERSION=""
+else
+    BUILD_RELEASE_VERSION="$1"
+    shift 1
+fi
+
 if [ "$BUILD_TYPE" = "release" ]
 then
     CRASH_REPORT_ENV=$(cat ./pkg/build/version.txt)
@@ -72,6 +83,7 @@ STABLE_BUILD_CHANNEL ${BUILD_CHANNEL-}
 STABLE_BUILD_TARGET_TRIPLE ${TARGET_TRIPLE-}
 STABLE_BUILD_TYPE ${BUILD_TYPE-}
 STABLE_CRASH_REPORT_ENV ${CRASH_REPORT_ENV-}
+BUILD_RELEASE_VERSION ${BUILD_RELEASE_VERSION-}
 BUILD_REV ${BUILD_REV-}
 BUILD_UTCTIME ${BUILD_UTCTIME-}
 EOF

--- a/build/teamcity/internal/release/process/make-and-publish-build-artifacts.sh
+++ b/build/teamcity/internal/release/process/make-and-publish-build-artifacts.sh
@@ -8,7 +8,15 @@ source "$dir/teamcity-bazel-support.sh"  # for run_bazel
 
 tc_start_block "Variable Setup"
 
-build_name=$(git describe --tags --dirty --match=v[0-9]* 2> /dev/null || git rev-parse --short HEAD;)
+version=$(cat pkg/build/version.txt)
+extra=$(git rev-list ${version}.. --count 2>/dev/null || echo "unknown" )
+
+if [ "${since}" == "0" ];
+then
+  build_name="${version}"
+else
+  build_name="${version}-${extra}-g$(git rev-parse --short HEAD)"
+fi
 
 # On no match, `grep -Eo` returns 1. `|| echo""` makes the script not error.
 release_branch="$(echo "$build_name" | grep -Eo "^v[0-9]+\.[0-9]+" || echo"")"

--- a/build/teamcity/internal/release/process/make-and-publish-build-tagging.sh
+++ b/build/teamcity/internal/release/process/make-and-publish-build-tagging.sh
@@ -8,7 +8,15 @@ source "$dir/teamcity-bazel-support.sh"  # for run_bazel
 
 tc_start_block "Variable Setup"
 
-build_name=$(git describe --tags --dirty --match=v[0-9]* 2> /dev/null || git rev-parse --short HEAD;)
+version=$(cat pkg/build/version.txt)
+extra=$(git rev-list ${version}.. --count 2>/dev/null || echo "unknown" )
+
+if [ "${since}" == "0" ];
+then
+  build_name="${version}"
+else
+  build_name="${version}-${extra}-g$(git rev-parse --short HEAD)"
+fi
 
 # On no match, `grep -Eo` returns 1. `|| echo""` makes the script not error.
 release_branch="$(echo "$build_name" | grep -Eo "^v[0-9]+\.[0-9]+" || echo"")"

--- a/pkg/build/BUILD.bazel
+++ b/pkg/build/BUILD.bazel
@@ -21,6 +21,7 @@ go_library(
         "github.com/cockroachdb/cockroach/pkg/build.rev": "{BUILD_REV}",
         "github.com/cockroachdb/cockroach/pkg/build.typ": "{STABLE_BUILD_TYPE}",
         "github.com/cockroachdb/cockroach/pkg/build.utcTime": "{BUILD_UTCTIME}",
+        "github.com/cockroachdb/cockroach/pkg/build.releaseVersion": "{BUILD_RELEASE_VERSION}",
     },
     deps = [
         "//pkg/util/envutil",

--- a/pkg/build/info.go
+++ b/pkg/build/info.go
@@ -42,7 +42,8 @@ var (
 	envChannel   = envutil.EnvOrDefaultString("COCKROACH_CHANNEL", "unknown")
 	//go:embed version.txt
 	cockroachVersion string
-	binaryVersion    = computeBinaryVersion(cockroachVersion, rev)
+	releaseVersion   string
+	binaryVersion    = computeBinaryVersion(releaseVersion, cockroachVersion, rev)
 )
 
 const (
@@ -61,7 +62,10 @@ func SeemsOfficial() bool {
 	return channel == DefaultTelemetryChannel || channel == FIPSTelemetryChannel
 }
 
-func computeBinaryVersion(versionTxt, revision string) string {
+func computeBinaryVersion(releaseVersion, versionTxt, revision string) string {
+	if releaseVersion != "" {
+		return releaseVersion
+	}
 	txt := strings.TrimSuffix(versionTxt, "\n")
 	v, err := version.Parse(txt)
 	if err != nil {

--- a/pkg/release/build.go
+++ b/pkg/release/build.go
@@ -167,7 +167,7 @@ func MakeRelease(platform Platform, opts BuildOptions, pkgDir string) error {
 		if opts.BuildTag == "" {
 			return errors.Newf("must set BuildTag if Release is set")
 		}
-		buildArgs = append(buildArgs, fmt.Sprintf("--workspace_status_command=./build/bazelutil/stamp.sh %s %s release", targetTriple, opts.Channel))
+		buildArgs = append(buildArgs, fmt.Sprintf("--workspace_status_command=./build/bazelutil/stamp.sh %s %s release %s", targetTriple, opts.Channel, opts.BuildTag))
 	} else {
 		if opts.BuildTag != "" {
 			return errors.Newf("cannot set BuildTag if Release is not set")


### PR DESCRIPTION
This does two things: first it switches teamcity scripts to use the version.txt file as the basis of choosing the "Build ID" version string, instead of git-describe.

Second, it switches the version identifier reported by binaries built by the release CI, and only the release CI, to report their version using the same version string the release CI used to make and publish the artifacts, ensuring that the version used to publish the artifact cannot be different than the version reported by the published artifact when run.

When we publish a release as 'vXYZ', putting artifacts in paths such as some/path/to/vXYZ.tgz
or on container registries as vXYZ, and generally distributing it to customers as vXYZ, it is
critical that the binary at runtime actually identify itself as vXYZ. It is particularly important
that it do so insofar as that means it is *not* identifying itself as vZZZ, which could be a different
release that customers are also running, which would lead to significant operational, support and
telemetry gathering problems.

Forcing a binary that is produced during the release process for a specific named release to identify itself
as that release makes such a situation impossible.

Release note: none.
Epic: none.

