### PR TITLE
kvtenantccl: unskip TestTenantUpgrade

### DIFF
--- a/pkg/ccl/kvccl/kvtenantccl/upgradeccl/tenant_upgrade_test.go
+++ b/pkg/ccl/kvccl/kvtenantccl/upgradeccl/tenant_upgrade_test.go
@@ -50,7 +50,6 @@ import (
 // also verifies that the version is correct after a restart
 func TestTenantUpgrade(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	skip.WithIssue(t, 97076, "flaky test")
 	defer log.Scope(t).Close(t)
 	ctx := context.Background()
 	settings := cluster.MakeTestingClusterSettingsWithVersions(


### PR DESCRIPTION
This test was skipped as part of #97076. Re-enable the test.

Fix #97076.

Release note: None.