### PR TITLE
serverccl: conditionally apply DevOffset in TestServerStartupGuardrails

### DIFF
--- a/pkg/ccl/serverccl/server_startup_guardrails_test.go
+++ b/pkg/ccl/serverccl/server_startup_guardrails_test.go
@@ -30,8 +30,16 @@ import (
 func TestServerStartupGuardrails(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
+	// We need to conditionally apply the DevOffset for the version
+	// returned by this function to work both on master (where the dev
+	// offset applies) and on release branches (where it doesn't).
 	v := func(major, minor int32) roachpb.Version {
-		return roachpb.Version{Major: clusterversion.DevOffset + major, Minor: minor}
+		binaryVersion := clusterversion.ByKey(clusterversion.BinaryVersionKey)
+		var offset int32
+		if binaryVersion.Major > clusterversion.DevOffset {
+			offset = clusterversion.DevOffset
+		}
+		return roachpb.Version{Major: offset + major, Minor: minor}
 	}
 
 	tests := []struct {


### PR DESCRIPTION
When overwriting versions for that test, we were unconditionally applying `clusterversion.DevOffset` to all versions. While that works on master, it makes the test break when it runs on a release branch (where no offsetting happens). In this commit, we check whether binary versions are offset, and only add the DevOffset if they are.

Unfortunately, we can't reference versions by key in this test as it references versions from two releases ago.

Informs: #100685

Epic: none

Release note: None