### PR TITLE
util/bulk: remove now redundant mutex from TracingAggregator

### DIFF
--- a/pkg/util/bulk/BUILD.bazel
+++ b/pkg/util/bulk/BUILD.bazel
@@ -9,10 +9,7 @@ go_library(
     ],
     importpath = "github.com/cockroachdb/cockroach/pkg/util/bulk",
     visibility = ["//visibility:public"],
-    deps = [
-        "//pkg/util/syncutil",
-        "//pkg/util/tracing",
-    ],
+    deps = ["//pkg/util/tracing"],
 )
 
 go_test(


### PR DESCRIPTION
Now that the span's mutex is being held during `EventListener.Notify` call, we no longer need a separate mutex in the TracingAggregator and it can be safely removed.

Epic: None

Release note: None