### PR TITLE
cloud/amazon: print out asserted error in TestS3BucketDoesNotExist

### DIFF
--- a/pkg/cloud/amazon/s3_storage_test.go
+++ b/pkg/cloud/amazon/s3_storage_test.go
@@ -449,7 +449,7 @@ func TestS3BucketDoesNotExist(t *testing.T) {
 
 	_, err = s.ReadFile(ctx, "")
 	require.Error(t, err, "")
-	require.True(t, errors.Is(err, cloud.ErrFileDoesNotExist))
+	require.True(t, errors.Is(err, cloud.ErrFileDoesNotExist), "error is not cloud.ErrFileDoesNotExist: %v", err)
 }
 
 func TestAntagonisticS3Read(t *testing.T) {


### PR DESCRIPTION
Add a message that prints out the error being asserted on in TestS3BucketDoesNotExist.

Will give more info to test failures like #100671 if this fails again.

Release note: None