### PR TITLE
release-23.1: storage: set range tombstone cluster setting default to false

### DIFF
--- a/pkg/cmd/roachtest/roachtestutil/clusterupgrade/clusterupgrade.go
+++ b/pkg/cmd/roachtest/roachtestutil/clusterupgrade/clusterupgrade.go
@@ -230,7 +230,7 @@ func WaitForClusterUpgrade(
 
 	l.Printf("waiting for cluster to auto-upgrade to %s", newVersion)
 	for _, node := range nodes {
-		err := retry.ForDuration(5*time.Minute, func() error {
+		err := retry.ForDuration(10*time.Minute, func() error {
 			currentVersion, err := ClusterVersion(ctx, dbFunc(node))
 			if err != nil {
 				return err

--- a/pkg/sql/logictest/testdata/logic_test/mixed_version_range_tombstones
+++ b/pkg/sql/logictest/testdata/logic_test/mixed_version_range_tombstones
@@ -1,0 +1,85 @@
+# LogicTest: cockroach-go-testserver-upgrade-to-master
+
+query I
+SELECT 1
+----
+1
+
+query T
+SELECT crdb_internal.node_executable_version()
+----
+22.2
+
+# By default, range tombstones are not enabled.
+
+query B
+SHOW CLUSTER SETTING storage.mvcc.range_tombstones.enabled;
+----
+false
+
+# Upgrade one node to 23.1.
+
+upgrade 0
+
+query B nodeidx=0
+SELECT crdb_internal.node_executable_version() SIMILAR TO '1000022.2-%'
+----
+true
+
+# Range tombstones remain disabled.
+
+query B
+SHOW CLUSTER SETTING storage.mvcc.range_tombstones.enabled;
+----
+false
+
+# Create a table, write something to it, then drop it.
+
+statement ok
+CREATE TABLE foo (bar INT);
+
+statement ok
+INSERT INTO foo VALUES (123);
+
+statement ok
+DROP TABLE foo;
+
+# Assuming that a range tombstone _would_ be written, provide enough time for
+# the async job responsible for dropping the table to complete. Ideally the
+# following sleep would not be required. However, without it, the test is prone
+# to flaking.
+
+sleep 10s
+
+# We do not expect there to be range tombstones written.
+
+query B
+SELECT sum((crdb_internal.range_stats(start_key)->>'range_key_count')::INT) = 0
+FROM crdb_internal.ranges_no_leases;
+----
+true
+
+# Enable the cluster setting.
+
+statement ok
+SET CLUSTER SETTING storage.mvcc.range_tombstones.enabled = 'true';
+
+# Performing the same table drop this time results in range tombstones being
+# written.
+
+statement ok
+CREATE TABLE foo (bar INT);
+
+statement ok
+INSERT INTO foo VALUES (123);
+
+statement ok
+DROP TABLE foo;
+
+sleep 10s
+
+query B
+SELECT sum((crdb_internal.range_stats(start_key)->>'range_key_count')::INT) > 0
+FROM crdb_internal.ranges_no_leases;
+----
+true

--- a/pkg/sql/logictest/tests/cockroach-go-testserver-upgrade-to-master/BUILD.bazel
+++ b/pkg/sql/logictest/tests/cockroach-go-testserver-upgrade-to-master/BUILD.bazel
@@ -11,7 +11,7 @@ go_test(
         "//pkg/cmd/cockroach-short",  # keep
         "//pkg/sql/logictest:testdata",  # keep
     ],
-    shard_count = 7,
+    shard_count = 8,
     tags = ["cpu:2"],
     deps = [
         "//pkg/build/bazel",

--- a/pkg/sql/logictest/tests/cockroach-go-testserver-upgrade-to-master/generated_test.go
+++ b/pkg/sql/logictest/tests/cockroach-go-testserver-upgrade-to-master/generated_test.go
@@ -107,6 +107,13 @@ func TestLogic_mixed_version_new_system_privileges(
 	runLogicTest(t, "mixed_version_new_system_privileges")
 }
 
+func TestLogic_mixed_version_range_tombstones(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "mixed_version_range_tombstones")
+}
+
 func TestLogic_mixed_version_role_members_user_ids(
 	t *testing.T,
 ) {

--- a/pkg/sql/schemachanger/sctest/cumulative.go
+++ b/pkg/sql/schemachanger/sctest/cumulative.go
@@ -1684,6 +1684,7 @@ WHERE
 }
 
 func BackupMixedVersionElements(t *testing.T, path string, newCluster NewMixedClusterFunc) {
+	skip.WithIssue(t, 100732)
 	testVersion := clusterversion.ClusterVersion{
 		Version: clusterversion.ByKey(clusterversion.V23_1_SchemaChangerDeprecatedIndexPredicates - 1),
 	}

--- a/pkg/storage/mvcc.go
+++ b/pkg/storage/mvcc.go
@@ -93,8 +93,8 @@ var minWALSyncInterval = settings.RegisterDurationSetting(
 var MVCCRangeTombstonesEnabledInMixedClusters = settings.RegisterBoolSetting(
 	settings.TenantReadOnly,
 	"storage.mvcc.range_tombstones.enabled",
-	"controls the use of MVCC range tombstones in mixed version clusters; range tombstones are always on in 23.1 clusters",
-	true)
+	"controls the use of MVCC range tombstones in mixed version clusters; range tombstones are always on in finalized 23.1 clusters",
+	false)
 
 // CanUseMVCCRangeTombstones returns true if the caller can begin writing MVCC
 // range tombstones, by setting DeleteRangeRequest.UseRangeTombstone. It


### PR DESCRIPTION
Currently, range tombstones are written under the following circumstances:

  - the `storage.mvcc.range_tombstones.enabled` cluster setting has a value of `true`, OR
  - the cluster is at or above the `V23_1_MVCCRangeTombstonesUnconditionallyEnabled` internal cluster version.

In a cluster where the cluster setting is not set, the default value is used. Currently, this default value is `true`. This results in the potential for range tombstones to be written in a mixed-version cluster, which was not the intention.

Flip the default value for the cluster setting to `false`.

Add a mixed-version logic test that demonstrates that when upgrading one node in a cluster to 23.1.x, range tombstones are not written when dropping a table, unless the cluster setting is enabled.

Bump the timeout in the mixed version roachtest from 5 to 10 minutes to allow the migration job to complete.

Additionally, skip schemachangerccl.TestBackupMixedVersionElements to work around an upgrade-time race. The skipped test is tracked in #100732.

Fix #100303.
Release note: None
Release justification: Fix high severity issue in mixed version clusters that could allow range keys to be written on v22.2.0 nodes (which contain known issues)