### PR TITLE
roachprod: fix creation of AWS clusters with custom labels

### DIFF
--- a/pkg/roachprod/vm/aws/aws.go
+++ b/pkg/roachprod/vm/aws/aws.go
@@ -964,26 +964,25 @@ func (p *Provider) runInstance(
 		vm.TagRoachprod: "Roachprod",
 	}
 
-	var sb strings.Builder
+	var labelPairs []string
+	addLabel := func(key, value string) {
+		labelPairs = append(labelPairs, fmt.Sprintf("{Key=%s,Value=%s}", key, value))
+	}
 
-	sep := ""
 	for key, value := range opts.CustomLabels {
 		_, ok := m[strings.ToLower(key)]
 		if ok {
 			return fmt.Errorf("duplicate label name defined: %s", key)
 		}
-		fmt.Fprintf(&sb, "%s{Key=%s,Value=%s}", sep, key, value)
-		sep = ","
+		addLabel(key, value)
 	}
-	sep = ""
 	for key, value := range m {
 		if n, ok := awsLabelsNameMap[key]; ok {
 			key = n
 		}
-		fmt.Fprintf(&sb, "%s{Key=%s,Value=%s}", sep, key, value)
-		sep = ","
+		addLabel(key, value)
 	}
-	labels := sb.String()
+	labels := strings.Join(labelPairs, ",")
 	vmTagSpecs := fmt.Sprintf("ResourceType=instance,Tags=[%s]", labels)
 	volumeTagSpecs := fmt.Sprintf("ResourceType=volume,Tags=[%s]", labels)
 


### PR DESCRIPTION
This fixes a small bug introduced in #99423 where roachprod cannot create AWS clusters with custom labels because of a missing comma in the list of labels passed to AWS (more specifically, the `tag-specifications` flag). The consequence is that we wouldn't be able to run roachtests on AWS (as that applies the `roachtest` custom label). It would also fail if we passed a custom label with `--label` when running `roachprod create`.

Epic: none

Release note: None