### PR TITLE
roachtest: allow callers to cancel background steps in mixedversion

### DIFF
--- a/pkg/cmd/roachtest/roachtestutil/clusterupgrade/clusterupgrade.go
+++ b/pkg/cmd/roachtest/roachtestutil/clusterupgrade/clusterupgrade.go
@@ -146,9 +146,9 @@ func StartWithBinary(
 	nodes option.NodeListOption,
 	binaryPath string,
 	startOpts option.StartOpts,
-) {
+) error {
 	settings := install.MakeClusterSettings(install.BinaryOption(binaryPath))
-	c.Start(ctx, l, startOpts, settings, nodes)
+	return c.StartE(ctx, l, startOpts, settings, nodes)
 }
 
 // BinaryPathFromVersion shows where the binary for the given version
@@ -200,7 +200,9 @@ func RestartNodesWithNewBinary(
 		if err != nil {
 			return err
 		}
-		StartWithBinary(ctx, l, c, c.Node(node), binary, startOpts)
+		if err := StartWithBinary(ctx, l, c, c.Node(node), binary, startOpts); err != nil {
+			return err
+		}
 
 		// We have seen cases where a transient error could occur when this
 		// newly upgraded node serves as a gateway for a distributed query due

--- a/pkg/cmd/roachtest/roachtestutil/mixedversion/BUILD.bazel
+++ b/pkg/cmd/roachtest/roachtestutil/mixedversion/BUILD.bazel
@@ -22,6 +22,7 @@ go_library(
         "//pkg/util/randutil",
         "//pkg/util/timeutil",
         "//pkg/util/version",
+        "@com_github_cockroachdb_errors//:errors",
     ],
 )
 

--- a/pkg/cmd/roachtest/roachtestutil/mixedversion/mixedversion.go
+++ b/pkg/cmd/roachtest/roachtestutil/mixedversion/mixedversion.go
@@ -72,6 +72,7 @@ import (
 	"fmt"
 	"math/rand"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
@@ -179,11 +180,14 @@ type (
 		// for human-consumption. Displayed when pretty-printing the test
 		// plan.
 		Description() string
-		// Background indicates whether the step should be run in the
-		// background. When a step is *not* run in the background, the
-		// test will wait for it to finish before moving on. When a
-		// background step fails, the entire test fails.
-		Background() bool
+		// Background returns a channel that controls the execution of a
+		// background step: when that channel is closed, the context
+		// associated with the step will be canceled. Returning `nil`
+		// indicates that the step should not be run in the background.
+		// When a step is *not* run in the background, the test will wait
+		// for it to finish before moving on. When a background step
+		// fails, the entire test fails.
+		Background() shouldStop
 		// Run implements the actual functionality of the step.
 		Run(context.Context, *logger.Logger, cluster.Cluster, *Helper) error
 	}
@@ -215,10 +219,29 @@ type (
 		seed  int64
 		hooks *testHooks
 
+		// bgChans collects all channels that control the execution of
+		// background steps in the test (created with `BackgroundFunc`,
+		// `Workload`, et al.). These channels are passsed to the test
+		// runner, and the test author can stop a background function by
+		// closing the channel. When that happens, the test runner will
+		// cancel the underlying context.
+		//
+		// There is one channel in `bgChans` for each hook in
+		// `Test.hooks.background`.
+		bgChans []shouldStop
+
 		// test-only field, allowing us to avoid passing a test.Test
 		// implementation in the tests
 		_buildVersion version.Version
 	}
+
+	shouldStop chan struct{}
+
+	// StopFunc is the signature of the function returned by calls that
+	// create background steps. StopFuncs are meant to be called by test
+	// authors when they want to stop a background step as part of test
+	// logic itself, without causing the test to fail.
+	StopFunc func()
 )
 
 // NewTest creates a Test struct that users can use to create and run
@@ -308,9 +331,19 @@ func (t *Test) AfterUpgradeFinalized(desc string, fn userFunc) {
 // steps have finished). If the `userFunc` returns an error, it will
 // cause the test to fail. These functions can run indefinitely but
 // should respect the context passed to them, which will be canceled
-// when the test terminates (successfully or not).
-func (t *Test) BackgroundFunc(desc string, fn userFunc) {
+// when the test terminates (successfully or not). Returns a function
+// that can be called to terminate the step, which will cancel the
+// context passed to `userFunc`.
+func (t *Test) BackgroundFunc(desc string, fn userFunc) StopFunc {
 	t.hooks.AddBackground(versionUpgradeHook{name: desc, fn: fn})
+
+	ch := make(shouldStop)
+	t.bgChans = append(t.bgChans, ch)
+	var closeOnce sync.Once
+	// Make sure to only close the background channel once, allowing the
+	// caller to call the StopFunc multiple times (subsequent calls will
+	// be no-ops).
+	return func() { closeOnce.Do(func() { close(ch) }) }
 }
 
 // BackgroundCommand is a convenience wrapper around `BackgroundFunc`
@@ -322,8 +355,8 @@ func (t *Test) BackgroundFunc(desc string, fn userFunc) {
 // command itself lived within the `mixed-version/*.log` files.
 func (t *Test) BackgroundCommand(
 	desc string, nodes option.NodeListOption, cmd *roachtestutil.Command,
-) {
-	t.BackgroundFunc(desc, t.runCommandFunc(nodes, cmd.String()))
+) StopFunc {
+	return t.BackgroundFunc(desc, t.runCommandFunc(nodes, cmd.String()))
 }
 
 // Workload is a convenience wrapper that allows callers to run
@@ -333,7 +366,7 @@ func (t *Test) BackgroundCommand(
 // command to actually run the command; it is run in the background.
 func (t *Test) Workload(
 	name string, node option.NodeListOption, initCmd, runCmd *roachtestutil.Command,
-) {
+) StopFunc {
 	seed := uint64(t.prng.Int63())
 	addSeed := func(cmd *roachtestutil.Command) {
 		if !cmd.HasFlag("seed") {
@@ -347,7 +380,7 @@ func (t *Test) Workload(
 	}
 
 	addSeed(runCmd)
-	t.BackgroundCommand(fmt.Sprintf("%s workload", name), node, runCmd)
+	return t.BackgroundCommand(fmt.Sprintf("%s workload", name), node, runCmd)
 }
 
 // Run runs the mixed-version test. It should be called once all
@@ -385,6 +418,7 @@ func (t *Test) plan() (*TestPlan, error) {
 		crdbNodes:      t.crdbNodes,
 		hooks:          t.hooks,
 		prng:           t.prng,
+		bgChans:        t.bgChans,
 	}
 
 	return planner.Plan(), nil
@@ -414,8 +448,8 @@ type startFromCheckpointStep struct {
 	crdbNodes option.NodeListOption
 }
 
-func (s startFromCheckpointStep) ID() int          { return s.id }
-func (s startFromCheckpointStep) Background() bool { return false }
+func (s startFromCheckpointStep) ID() int                { return s.id }
+func (s startFromCheckpointStep) Background() shouldStop { return nil }
 
 func (s startFromCheckpointStep) Description() string {
 	return fmt.Sprintf("starting cluster from fixtures for version %q", s.version)
@@ -438,8 +472,7 @@ func (s startFromCheckpointStep) Run(
 
 	startOpts := option.DefaultStartOptsNoBackups()
 	startOpts.RoachprodOpts.Sequential = false
-	clusterupgrade.StartWithBinary(ctx, l, c, s.crdbNodes, binaryPath, startOpts)
-	return nil
+	return clusterupgrade.StartWithBinary(ctx, l, c, s.crdbNodes, binaryPath, startOpts)
 }
 
 // uploadCurrentVersionStep uploads the current cockroach binary to
@@ -453,8 +486,8 @@ type uploadCurrentVersionStep struct {
 	dest      string
 }
 
-func (s uploadCurrentVersionStep) ID() int          { return s.id }
-func (s uploadCurrentVersionStep) Background() bool { return false }
+func (s uploadCurrentVersionStep) ID() int                { return s.id }
+func (s uploadCurrentVersionStep) Background() shouldStop { return nil }
 
 func (s uploadCurrentVersionStep) Description() string {
 	return fmt.Sprintf("upload current binary to all cockroach nodes (%v)", s.crdbNodes)
@@ -480,8 +513,8 @@ type waitForStableClusterVersionStep struct {
 	nodes option.NodeListOption
 }
 
-func (s waitForStableClusterVersionStep) ID() int          { return s.id }
-func (s waitForStableClusterVersionStep) Background() bool { return false }
+func (s waitForStableClusterVersionStep) ID() int                { return s.id }
+func (s waitForStableClusterVersionStep) Background() shouldStop { return nil }
 
 func (s waitForStableClusterVersionStep) Description() string {
 	return fmt.Sprintf(
@@ -504,8 +537,8 @@ type preserveDowngradeOptionStep struct {
 	prng      *rand.Rand
 }
 
-func (s preserveDowngradeOptionStep) ID() int          { return s.id }
-func (s preserveDowngradeOptionStep) Background() bool { return false }
+func (s preserveDowngradeOptionStep) ID() int                { return s.id }
+func (s preserveDowngradeOptionStep) Background() shouldStop { return nil }
 
 func (s preserveDowngradeOptionStep) Description() string {
 	return "preventing auto-upgrades by setting `preserve_downgrade_option`"
@@ -539,8 +572,8 @@ type restartWithNewBinaryStep struct {
 	node    int
 }
 
-func (s restartWithNewBinaryStep) ID() int          { return s.id }
-func (s restartWithNewBinaryStep) Background() bool { return false }
+func (s restartWithNewBinaryStep) ID() int                { return s.id }
+func (s restartWithNewBinaryStep) Background() shouldStop { return nil }
 
 func (s restartWithNewBinaryStep) Description() string {
 	return fmt.Sprintf("restart node %d with binary version %s", s.node, versionMsg(s.version))
@@ -574,8 +607,8 @@ type finalizeUpgradeStep struct {
 	prng      *rand.Rand
 }
 
-func (s finalizeUpgradeStep) ID() int          { return s.id }
-func (s finalizeUpgradeStep) Background() bool { return false }
+func (s finalizeUpgradeStep) ID() int                { return s.id }
+func (s finalizeUpgradeStep) Background() shouldStop { return nil }
 
 func (s finalizeUpgradeStep) Description() string {
 	return "finalize upgrade by resetting `preserve_downgrade_option`"
@@ -597,11 +630,11 @@ type runHookStep struct {
 	testContext Context
 	prng        *rand.Rand
 	hook        versionUpgradeHook
-	background  bool
+	stopChan    shouldStop
 }
 
-func (s runHookStep) ID() int          { return s.id }
-func (s runHookStep) Background() bool { return s.background }
+func (s runHookStep) ID() int                { return s.id }
+func (s runHookStep) Background() shouldStop { return s.stopChan }
 
 func (s runHookStep) Description() string {
 	return fmt.Sprintf("run %q", s.hook.name)
@@ -684,15 +717,28 @@ func (h hooks) Filter(testContext Context) hooks {
 // AsSteps transforms the sequence of hooks into a corresponding test
 // step. If there is only one hook, the corresponding `runHookStep` is
 // returned. Otherwise, a `concurrentRunStep` is returned, where every
-// hook is run concurrently.
+// hook is run concurrently. `stopChans` should either be `nil` for
+// steps that are not meant to be run in the background, or contain
+// one stop channel (`shouldStop`) for each hook.
 func (h hooks) AsSteps(
-	label string, idGen func() int, prng *rand.Rand, testContext Context, background bool,
+	label string, idGen func() int, prng *rand.Rand, testContext Context, stopChans []shouldStop,
 ) []testStep {
 	steps := make([]testStep, 0, len(h))
-	for _, hook := range h {
+	stopChanFor := func(j int) shouldStop {
+		if len(stopChans) == 0 {
+			return nil
+		}
+		return stopChans[j]
+	}
+
+	for j, hook := range h {
 		hookPrng := rngFromRNG(prng)
 		steps = append(steps, runHookStep{
-			id: idGen(), prng: hookPrng, hook: hook, background: background, testContext: testContext,
+			id:          idGen(),
+			prng:        hookPrng,
+			hook:        hook,
+			stopChan:    stopChanFor(j),
+			testContext: testContext,
 		})
 	}
 
@@ -720,21 +766,23 @@ func (th *testHooks) AddAfterUpgradeFinalized(hook versionUpgradeHook) {
 }
 
 func (th *testHooks) StartupSteps(idGen func() int, testContext Context) []testStep {
-	return th.startup.AsSteps(startupLabel, idGen, th.prng, testContext, false)
+	return th.startup.AsSteps(startupLabel, idGen, th.prng, testContext, nil)
 }
 
-func (th *testHooks) BackgroundSteps(idGen func() int, testContext Context) []testStep {
-	return th.background.AsSteps(backgroundLabel, idGen, th.prng, testContext, true)
+func (th *testHooks) BackgroundSteps(
+	idGen func() int, testContext Context, stopChans []shouldStop,
+) []testStep {
+	return th.background.AsSteps(backgroundLabel, idGen, th.prng, testContext, stopChans)
 }
 
 func (th *testHooks) MixedVersionSteps(testContext Context, idGen func() int) []testStep {
 	return th.mixedVersion.
 		Filter(testContext).
-		AsSteps(mixedVersionLabel, idGen, th.prng, testContext, false)
+		AsSteps(mixedVersionLabel, idGen, th.prng, testContext, nil)
 }
 
 func (th *testHooks) AfterUpgradeFinalizedSteps(idGen func() int, testContext Context) []testStep {
-	return th.afterUpgradeFinalized.AsSteps(afterTestLabel, idGen, th.prng, testContext, false)
+	return th.afterUpgradeFinalized.AsSteps(afterTestLabel, idGen, th.prng, testContext, nil)
 }
 
 func randomDelay(rng *rand.Rand) time.Duration {

--- a/pkg/cmd/roachtest/roachtestutil/mixedversion/planner.go
+++ b/pkg/cmd/roachtest/roachtestutil/mixedversion/planner.go
@@ -40,6 +40,7 @@ type (
 		rt             test.Test
 		hooks          *testHooks
 		prng           *rand.Rand
+		bgChans        []shouldStop
 	}
 )
 
@@ -78,7 +79,7 @@ func (p *testPlanner) Plan() *TestPlan {
 	addSteps := func(ss []testStep) { steps = append(steps, ss...) }
 
 	addSteps(p.initSteps())
-	addSteps(p.hooks.BackgroundSteps(p.nextID, p.initialContext()))
+	addSteps(p.hooks.BackgroundSteps(p.nextID, p.initialContext(), p.bgChans))
 
 	// previous -> current
 	addSteps(p.upgradeSteps(p.initialVersion, clusterupgrade.MainVersion))

--- a/pkg/cmd/roachtest/tests/backup.go
+++ b/pkg/cmd/roachtest/tests/backup.go
@@ -17,6 +17,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"net"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -35,6 +36,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/jobs"
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/install"
+	"github.com/cockroachdb/cockroach/pkg/roachprod/logger"
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/jobutils"
@@ -151,24 +153,29 @@ func importBankCommand(cockroach string, rows, ranges, csvPort, node int) string
 // waitForPort waits until the given `port` is ready to receive
 // connections on all `nodes` given.
 func waitForPort(
-	ctx context.Context, nodes option.NodeListOption, port int, c cluster.Cluster,
+	ctx context.Context, l *logger.Logger, nodes option.NodeListOption, port int, c cluster.Cluster,
 ) error {
-	// TODO(ssd): An alternative here would be to try to connect
-	// using some go code rather than calling lsof.
-	maybeSudo := "sudo "
-	if c.IsLocal() {
-		maybeSudo = ""
-	}
-	cmd := fmt.Sprintf("%slsof -i:%d | grep -q LISTEN", maybeSudo, port)
-
-	retryConfig := retry.Options{
-		MaxBackoff: 500 * time.Millisecond,
+	ips, err := c.ExternalIP(ctx, l, nodes)
+	if err != nil {
+		return fmt.Errorf("failed to get nodes external IPs: %w", err)
 	}
 
-	if err := retry.WithMaxAttempts(ctx, retryConfig, 10, func() error {
-		return c.RunE(ctx, nodes, cmd)
-	}); err != nil {
-		return fmt.Errorf("timed out waiting for port %d: %w", port, err)
+	retryConfig := retry.Options{MaxBackoff: 500 * time.Millisecond}
+	for j, ip := range ips {
+		if err := retry.WithMaxAttempts(ctx, retryConfig, 10, func() error {
+			addr := net.JoinHostPort(ip, fmt.Sprintf("%d", port))
+			conn, err := net.Dial("tcp", addr)
+			if err != nil {
+				return fmt.Errorf("error connecting to node %d (%s): %w", nodes[j], addr, err)
+			}
+
+			if err := conn.Close(); err != nil {
+				return fmt.Errorf("error closing connection to node %d (%s): %w", nodes[j], addr, err)
+			}
+			return nil
+		}); err != nil {
+			return err
+		}
 	}
 
 	return nil
@@ -178,7 +185,7 @@ func runImportBankDataSplit(ctx context.Context, rows, ranges int, t test.Test, 
 	csvPort := 8081
 	csvCmd := importBankCSVServerCommand("./cockroach", csvPort)
 	c.Run(ctx, c.All(), csvCmd+` &> logs/workload-csv-server.log < /dev/null &`)
-	if err := waitForPort(ctx, c.All(), csvPort, c); err != nil {
+	if err := waitForPort(ctx, t.L(), c.All(), csvPort, c); err != nil {
 		t.Fatal(err)
 	}
 	importNode := 1

--- a/pkg/cmd/roachtest/tests/versionupgrade.go
+++ b/pkg/cmd/roachtest/tests/versionupgrade.go
@@ -276,7 +276,9 @@ func uploadAndStartFromCheckpointFixture(nodes option.NodeListOption, v string) 
 		startOpts := option.DefaultStartOpts()
 		// NB: can't start sequentially since cluster already bootstrapped.
 		startOpts.RoachprodOpts.Sequential = false
-		clusterupgrade.StartWithBinary(ctx, t.L(), u.c, nodes, binary, startOpts)
+		if err := clusterupgrade.StartWithBinary(ctx, t.L(), u.c, nodes, binary, startOpts); err != nil {
+			t.Fatal(err)
+		}
 	}
 }
 
@@ -286,7 +288,9 @@ func uploadAndStart(nodes option.NodeListOption, v string) versionStep {
 		startOpts := option.DefaultStartOpts()
 		// NB: can't start sequentially since cluster already bootstrapped.
 		startOpts.RoachprodOpts.Sequential = false
-		clusterupgrade.StartWithBinary(ctx, t.L(), u.c, nodes, binary, startOpts)
+		if err := clusterupgrade.StartWithBinary(ctx, t.L(), u.c, nodes, binary, startOpts); err != nil {
+			t.Fatal(err)
+		}
 	}
 }
 


### PR DESCRIPTION
This commit updates the signature of functions in the `mixedversion` package that create steps that run in the background; this includes functions in the `Helper` struct, as well as in the main `mixedversion.Test` struct. These functions now all return a `mixedversion.StopFunc` that test authors can call when they wish to stop a background function without causing the test to fail.

When the stop function is called, the context passed to the background functions is canceled; however, that context cancelation is captured by the framework and logged as an expected termination. If the context is canceled through other means, the test will fail as usual.

Epic: CRDB-19321

Release note: None