### PR TITLE
build: make sure toolchain has correct arguments for linking shared lib

### DIFF
--- a/build/toolchains/crosstool-ng/cc_toolchain_config.bzl.tmpl
+++ b/build/toolchains/crosstool-ng/cc_toolchain_config.bzl.tmpl
@@ -12,6 +12,7 @@ all_compile_actions = [
 ]
 
 all_link_actions = [
+    ACTION_NAMES.cpp_link_dynamic_library,
     ACTION_NAMES.cpp_link_executable,
 ]
 


### PR DESCRIPTION
`geos` has been failing to build without this change since #100313. This fixes it.

Epic: none
Release note: None