### PR TITLE
roachtest: remove old executables before installing ruby

### DIFF
--- a/pkg/cmd/roachtest/tests/ruby_pg.go
+++ b/pkg/cmd/roachtest/tests/ruby_pg.go
@@ -87,6 +87,7 @@ func registerRubyPG(r registry.Registry) {
 			"install ruby 3.1.2",
 			`mkdir -p ruby-install && \
         curl -fsSL https://github.com/postmodern/ruby-install/archive/v0.8.3.tar.gz | tar --strip-components=1 -C ruby-install -xz && \
+        sudo rm -rf /usr/local/bin/* && \
         sudo make -C ruby-install install && \
         sudo ruby-install --system ruby 3.1.2 && \
         sudo gem update --system`,


### PR DESCRIPTION
This should prevent errors during installation.

fixes https://github.com/cockroachdb/cockroach/issues/95004
fixes https://github.com/cockroachdb/cockroach/issues/100428
backport fixes https://github.com/cockroachdb/cockroach/issues/100586

Release note: None