### PR TITLE
build: append `-dirty` suffix if relevant

### DIFF
--- a/build/bazelutil/stamp.sh
+++ b/build/bazelutil/stamp.sh
@@ -56,7 +56,7 @@ else
     CRASH_REPORT_ENV="development"
 fi
 
-BUILD_REV=$(git rev-parse HEAD)
+BUILD_REV=$(git describe --match="" --always --abbrev=40 --dirty)
 BUILD_UTCTIME=$(date -u '+%Y/%m/%d %H:%M:%S')
 
 


### PR DESCRIPTION
This command and the `rev-parse HEAD` command behave identically except if the workspace is dirty, this command adds a `-dirty` suffix.

Epic: none
Release note: None