### PR TITLE
opt: fix ordering-related optimizer panics

### DIFF
--- a/pkg/sql/opt/xform/testdata/physprops/ordering
+++ b/pkg/sql/opt/xform/testdata/physprops/ordering
@@ -3072,7 +3072,7 @@ sort
  ├── cardinality: [0 - 0]
  ├── key: ()
  ├── fd: ()-->(6,12,23)
- ├── ordering: +(12|23),-6 [actual: ]
+ ├── ordering: +(12|23),-6 [actual: +12,-6]
  └── values
       ├── columns: tab_922.crdb_internal_mvcc_timestamp:6!null col1_4:12!null col_2150:23!null
       ├── cardinality: [0 - 0]
@@ -3097,16 +3097,51 @@ distinct-on
  │    ├── columns: c1:1!null c2:2
  │    ├── key: (1)
  │    ├── fd: (1)-->(2)
- │    ├── ordering: +1 [actual: +2,+1]
+ │    ├── ordering: +1
  │    ├── scan v0@i3
  │    │    ├── columns: c1:5!null c2:6
  │    │    ├── constraint: /6/5: [/'2023-01-31 00:00:00' - /'2023-01-31 00:00:00']
  │    │    ├── key: (5)
  │    │    ├── fd: (5)-->(6)
- │    │    └── ordering: +5 [actual: +6,+5]
+ │    │    └── ordering: +5
  │    └── projections
  │         ├── c1:5 [as=c1:1, outer=(5)]
  │         └── c2:6 [as=c2:2, outer=(6)]
  └── aggregations
       └── const-agg [as=c2:2, outer=(2)]
            └── c2:2
+
+opt
+SELECT c1 FROM v0
+WHERE (c1 = c1 AND c2 = '01-31-2023 00:00:00'::TIMESTAMP)
+  OR (c1 = b'00' AND c1 = b'0')
+  OR (c1 IS NULL AND c2 IS NULL)
+ORDER BY c1;
+----
+project
+ ├── columns: c1:1!null
+ ├── key: (1)
+ ├── ordering: +1
+ └── distinct-on
+      ├── columns: c1:1!null c2:2
+      ├── grouping columns: c1:1!null
+      ├── key: (1)
+      ├── fd: (1)-->(2)
+      ├── ordering: +1
+      ├── project
+      │    ├── columns: c1:1!null c2:2
+      │    ├── key: (1)
+      │    ├── fd: (1)-->(2)
+      │    ├── ordering: +1
+      │    ├── scan v0@i3
+      │    │    ├── columns: c1:5!null c2:6
+      │    │    ├── constraint: /6/5: [/'2023-01-31 00:00:00' - /'2023-01-31 00:00:00']
+      │    │    ├── key: (5)
+      │    │    ├── fd: (5)-->(6)
+      │    │    └── ordering: +5
+      │    └── projections
+      │         ├── c1:5 [as=c1:1, outer=(5)]
+      │         └── c2:6 [as=c2:2, outer=(6)]
+      └── aggregations
+           └── const-agg [as=c2:2, outer=(2)]
+                └── c2:2

--- a/pkg/sql/opt/xform/testdata/rules/join
+++ b/pkg/sql/opt/xform/testdata/rules/join
@@ -9823,7 +9823,7 @@ project
       │         ├── cardinality: [0 - 1]
       │         ├── key: (25)
       │         ├── fd: (25)-->(26,27), (27)~~>(25,26)
-      │         ├── ordering: +25 [actual: ]
+      │         ├── ordering: +25
       │         └── project
       │              ├── columns: a:25!null b:26!null c:27!null q:31!null r:32!null
       │              ├── cardinality: [0 - 1]


### PR DESCRIPTION
It is possible for some functional-dependency information to be visible to a child operator but invisible to its parent. This could previously cause panics when a child provided an ordering that could be proven to satisfy the required ordering with the child FDs, but not with the parent's FDs.

This patch adds a step to the logic that builds provided orderings that ensures a provided ordering can be proven to respect the required ordering without needing additional FD information. This ensures that a parent never needs to know its child's FDs in order to prove that the provided ordering is correct. The extra step is a no-op in the common case when the provided ordering can already be proven to respect the required ordering.

Informs #85393
Informs #87806
Fixes #96288

Release note (bug fix): Fixed a rare internal error in the optimizer that has existed since before version 22.1, which could occur while enforcing orderings between SQL operators.