### PR TITLE
ci: fix bug in github-pull-request-make

### DIFF
--- a/pkg/cmd/github-pull-request-make/main.go
+++ b/pkg/cmd/github-pull-request-make/main.go
@@ -125,12 +125,18 @@ func pkgsFromDiff(r io.Reader) (map[string]pkg, error) {
 }
 
 func getDiff(ctx context.Context, sha string) (string, error) {
-	cmd := exec.CommandContext(ctx, "git", "diff", "--no-ext-diff", sha, "origin/master", "--")
+	cmd := exec.CommandContext(ctx, "git", "merge-base", "origin/master", sha)
+	baseShaBytes, err := cmd.Output()
+	if err != nil {
+		return "", err
+	}
+	baseSha := strings.TrimSpace(string(baseShaBytes))
+	cmd = exec.CommandContext(ctx, "git", "diff", "--no-ext-diff", baseSha, sha, "--")
 	outputBytes, err := cmd.Output()
 	if err != nil {
 		return "", err
 	}
-	return string(outputBytes), nil
+	return strings.TrimSpace(string(outputBytes)), nil
 }
 
 func parsePackagesFromEnvironment(input string) (map[string]pkg, error) {

--- a/pkg/testutils/lint/lint_test.go
+++ b/pkg/testutils/lint/lint_test.go
@@ -2290,6 +2290,8 @@ func TestLint(t *testing.T) {
 			stream.GrepNot(`pkg/sql/pgwire/pgerror/pgcode\.go:.*invalid direct cast on error object`),
 			// Cast in decode handler.
 			stream.GrepNot(`pkg/util/contextutil/timeout_error\.go:.*invalid direct cast on error object`),
+			// Direct error cast OK in this case for a low-dependency helper binary.
+			stream.GrepNot(`pkg/cmd/github-pull-request-make/main\.go:.*invalid direct cast on error object`),
 			// The logging package translates log.Fatal calls into errors.
 			// We can't use the regular exception mechanism via functions.go
 			// because addStructured takes its positional argument as []interface{},


### PR DESCRIPTION
Here we were diffing the current SHA against `origin/master`, which is maybe, but not necessarily, correct. `origin/master` may be more or less up-to-date depending on when the build is running compared to when you branched. Instead we should find the `merge-base` between them and diff between the current SHA and the `merge-base`.

Epic: none
Release note: None