### PR TITLE
kvserver: skip replicate queue tests under metamorphic builds

### DIFF
--- a/pkg/kv/kvserver/replicate_queue_test.go
+++ b/pkg/kv/kvserver/replicate_queue_test.go
@@ -622,6 +622,7 @@ func TestReplicateQueueDecommissioningNonVoters(t *testing.T) {
 	defer log.Scope(t).Close(t)
 	skip.UnderRace(t, "takes a long time or times out under race")
 	skip.UnderDeadlockWithIssue(t, 94383)
+	skip.UnderMetamorphicWithIssue(t, 99207)
 
 	ctx := context.Background()
 

--- a/pkg/testutils/skip/skip.go
+++ b/pkg/testutils/skip/skip.go
@@ -148,6 +148,18 @@ func UnderMetamorphic(t SkippableTest, args ...interface{}) {
 	}
 }
 
+// UnderMetamorphicWithIssue skips this test during metamorphic runs, which are
+// tests run with the metamorphic build tag, logging the given issue ID as the
+// reason.
+func UnderMetamorphicWithIssue(t SkippableTest, githubIssueID int, args ...interface{}) {
+	t.Helper()
+	if util.IsMetamorphicBuild() {
+		t.Skip(append([]interface{}{fmt.Sprintf(
+			"disabled under metamorphic. issue: https://github.com/cockroachdb/cockroach/issues/%d", githubIssueID,
+		)}, args...))
+	}
+}
+
 // UnderNonTestBuild skips this test if the build does not have the crdb_test
 // tag.
 func UnderNonTestBuild(t SkippableTest) {


### PR DESCRIPTION
This modifies `TestReplicateQueueDecommissioningNonVoters` to be skipped specifically under metamorphic builds because this may enable mux range feeds, which are not currently working in these test builds (#100783). Once this issue is resolved and the test can work successfully with mux range feeds, this check should be removed.

Fixes: #99207

Release note: None