### PR TITLE
sql: ensure proper syntax roundtrip for ALTER TENANT RENAME TO

### DIFF
--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -6460,7 +6460,7 @@ alter_tenant_rename_stmt:
     /* SKIP DOC */
     $$.val = &tree.AlterTenantRename{
       TenantSpec: $3.tenantSpec(),
-      NewName: $6.expr(),
+      NewName: &tree.TenantSpec{IsName: true, Expr: $6.expr()},
     }
   }
 

--- a/pkg/sql/parser/testdata/alter_tenant
+++ b/pkg/sql/parser/testdata/alter_tenant
@@ -199,6 +199,15 @@ ALTER TENANT ('foo') RENAME TO (bar) -- fully parenthesized
 ALTER TENANT '_' RENAME TO bar -- literals removed
 ALTER TENANT 'foo' RENAME TO _ -- identifiers removed
 
+# Regression test for #99853
+parse
+ALTER TENANT 'string' RENAME TO INTERVAL 'string' MINUTE TO SECOND
+----
+ALTER TENANT 'string' RENAME TO ('string'::INTERVAL MINUTE TO SECOND) -- normalized!
+ALTER TENANT ('string') RENAME TO ((('string')::INTERVAL MINUTE TO SECOND)) -- fully parenthesized
+ALTER TENANT '_' RENAME TO ('_'::INTERVAL MINUTE TO SECOND) -- literals removed
+ALTER TENANT 'string' RENAME TO ('string'::INTERVAL MINUTE TO SECOND) -- identifiers removed
+
 # Regression test for #95612
 parse
 ALTER TENANT INTERVAL 'string' MINUTE RESET CLUSTER SETTING ident

--- a/pkg/sql/rename_tenant.go
+++ b/pkg/sql/rename_tenant.go
@@ -33,7 +33,7 @@ func (p *planner) alterRenameTenant(
 		return nil, err
 	}
 
-	e := n.NewName
+	e := n.NewName.Expr
 	// If the expression is a simple identifier, handle
 	// that specially: we promote that identifier to a SQL string.
 	// This is alike what is done for CREATE USER.

--- a/pkg/sql/sem/tree/alter_tenant.go
+++ b/pkg/sql/sem/tree/alter_tenant.go
@@ -163,7 +163,13 @@ func (n *TenantSpec) Format(ctx *FmtCtx) {
 // AlterTenantRename represents an ALTER TENANT RENAME statement.
 type AlterTenantRename struct {
 	TenantSpec *TenantSpec
-	NewName    Expr
+
+	// For NewName we only support the name syntax, not the numeric
+	// syntax. So we could make-do with just an Expr here. However, we
+	// like to use TenantSpec as a container for that name because it
+	// takes care of pretty-printing with all the special rules. See the
+	// doc of (*TenantSpec).Format() for details.
+	NewName *TenantSpec
 }
 
 var _ Statement = &AlterTenantRename{}

--- a/pkg/sql/sem/tree/walk.go
+++ b/pkg/sql/sem/tree/walk.go
@@ -1149,6 +1149,13 @@ func (n *AlterTenantRename) walkStmt(v Visitor) Statement {
 		}
 		ret.TenantSpec = ts
 	}
+	ts, changed = walkTenantSpec(v, n.NewName)
+	if changed {
+		if ret == n {
+			ret = n.copyNode()
+		}
+		ret.NewName = ts
+	}
 	return ret
 }
 


### PR DESCRIPTION
Fixes #99853.

Release note: None
Epic: CRDB-23559