### PR TITLE
server: skip TestAdminDecommissionedOperations

### DIFF
--- a/pkg/server/admin_test.go
+++ b/pkg/server/admin_test.go
@@ -3008,6 +3008,8 @@ func TestAdminDecommissionedOperations(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
+	skip.WithIssue(t, 100789, "flaky test")
+
 	ctx := context.Background()
 	tc := serverutils.StartNewTestCluster(t, 2, base.TestClusterArgs{
 		ReplicationMode: base.ReplicationManual, // saves time


### PR DESCRIPTION
Informs #100789.

It's currently flaky.

Release note: None