### PR TITLE
upgrade: waitForDelRangeInGCJob should only wait for running jobs

### DIFF
--- a/pkg/sql/schemachanger/sctest/cumulative.go
+++ b/pkg/sql/schemachanger/sctest/cumulative.go
@@ -1684,7 +1684,6 @@ WHERE
 }
 
 func BackupMixedVersionElements(t *testing.T, path string, newCluster NewMixedClusterFunc) {
-	skip.WithIssue(t, 100732)
 	testVersion := clusterversion.ClusterVersion{
 		Version: clusterversion.ByKey(clusterversion.V23_1_SchemaChangerDeprecatedIndexPredicates - 1),
 	}

--- a/pkg/upgrade/upgrades/wait_for_del_range_in_gc_job.go
+++ b/pkg/upgrade/upgrades/wait_for_del_range_in_gc_job.go
@@ -83,7 +83,10 @@ func waitForDelRangeInGCJob(
          elements AS (SELECT * FROM tables UNION ALL SELECT * FROM indexes)
   SELECT id
     FROM elements
-   WHERE COALESCE(progress->>'status' NOT IN ('WAITING_FOR_MVCC_GC', 'CLEARED'), true)
+-- While we are waiting for the GC TTL, the status will be WAITING_FOR_CLEAR because omitempty
+-- set on this field it will not exist in the JSON output. Because tombstone adoption unconditionally
+-- enabled by an earlier version, we should be safe to skip any job that hasn't started GCing yet.
+   WHERE COALESCE(progress->>'status' NOT IN ('WAITING_FOR_MVCC_GC', 'CLEARED'), false)
 GROUP BY id;
 `)
 		if err != nil || len(jobIDs) == 0 {


### PR DESCRIPTION
Previously, the logic to determine that all GC jobs were using DelRange was no-oped because in our testing environments, we always had: storage.mvcc.range_tombstones.enabled set. The mixed version tests for schema would always create GC jobs with DelRange and be fine. Once this default was changed we started to observe the behaviour of this migration was that it will wait till the GC interval before we would move to the next version. To address this, this patch fixes the check inside waitForDelRangeInGCJob to exclude GC jobs that haven't started any work.

Fixes: #100732
Release note: None