### PR TITLE
lock: track isolation level information in lock modes

### DIFF
--- a/pkg/kv/kvserver/concurrency/isolation/levels.go
+++ b/pkg/kv/kvserver/concurrency/isolation/levels.go
@@ -46,3 +46,7 @@ func (l Level) PerStatementReadSnapshot() bool {
 
 // SafeValue implements the redact.SafeValue interface.
 func (Level) SafeValue() {}
+
+// Levels returns a list of all isolation levels, ordered from strongest to
+// weakest.
+func Levels() []Level { return []Level{Serializable, Snapshot, ReadCommitted} }

--- a/pkg/kv/kvserver/concurrency/lock/BUILD.bazel
+++ b/pkg/kv/kvserver/concurrency/lock/BUILD.bazel
@@ -13,6 +13,7 @@ go_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/kv/kvserver/concurrency/lock",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/kv/kvserver/concurrency/isolation",
         "//pkg/settings",
         "//pkg/util/hlc",
         "@com_github_cockroachdb_errors//:errors",
@@ -29,6 +30,7 @@ proto_library(
     strip_import_prefix = "/pkg",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/kv/kvserver/concurrency/isolation:isolation_proto",
         "//pkg/storage/enginepb:enginepb_proto",
         "//pkg/util/hlc:hlc_proto",
         "@com_github_gogo_protobuf//gogoproto:gogo_proto",
@@ -43,6 +45,7 @@ go_proto_library(
     proto = ":lock_proto",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/kv/kvserver/concurrency/isolation",
         "//pkg/storage/enginepb",
         "//pkg/util/hlc",
         "@com_github_gogo_protobuf//gogoproto",
@@ -58,11 +61,13 @@ go_test(
     args = ["-test.timeout=295s"],
     deps = [
         ":lock",
+        "//pkg/kv/kvserver/concurrency/isolation",
         "//pkg/roachpb",
         "//pkg/settings/cluster",
         "//pkg/storage/enginepb",
-        "//pkg/testutils",
         "//pkg/util/hlc",
+        "//pkg/util/leaktest",
+        "//pkg/util/log",
         "//pkg/util/uuid",
         "@com_github_cockroachdb_redact//:redact",
         "@com_github_stretchr_testify//require",

--- a/pkg/kv/kvserver/concurrency/lock/locking.proto
+++ b/pkg/kv/kvserver/concurrency/lock/locking.proto
@@ -12,6 +12,7 @@ syntax = "proto3";
 package cockroach.kv.kvserver.concurrency.lock;
 option go_package = "github.com/cockroachdb/cockroach/pkg/kv/kvserver/concurrency/lock";
 
+import "kv/kvserver/concurrency/isolation/levels.proto";
 import "gogoproto/gogo.proto";
 import "util/hlc/timestamp.proto";
 
@@ -130,10 +131,11 @@ enum Strength {
 //
 // The protection a lock offers is primarily determined by the Strength it is
 // held with. However, lock Modes also contain auxiliary information (eg. the
-// timestamp at which the lock was acquired), which may be used in conjunction
-// with a lock's Strength to resolve conflicts between a lock holder and a
-// concurrent lock acquirer. This allows us to codify conflict rules as a pure
-// function of 2 lock Modes.
+// timestamp at which the lock was acquired, the isolation level associated with
+// a non-locking read), which may be used in conjunction with a lock's Strength
+// to resolve conflicts between a lock holder and a concurrent overlapping
+// request. This allows us to codify conflict rules as a pure function of 2 lock
+// Modes.
 //
 // Users of the key-value layer are expected to indicate locking intentions
 // using lock Strengths; lock Mode is an internal concept for the concurrency
@@ -167,21 +169,29 @@ enum Strength {
 // lock's timestamp. If the read's timestamp is below the Intent lock's
 // timestamp then the two are compatible.
 //
-// [*] historically, CockroachDB did not make a strength distinction between
-// Exclusive locks and Intents. As such, reads under optimistic concurrency
-// control would conflict with Exclusive locks if the read's timestamp was at or
-// above the Exclusive lock's timestamp. Now that there is a distinction between
-// Exclusive locks and Intents, non-locking reads do not block on Exclusive
-// locks, regardless of their timestamp. However, there is a desire to let users
-// opt into the old behavior using the ExclusiveLocksBlockNonLockingReads
-// cluster setting.
+// [*] until the re-introduction of weaker isolation levels, all transactions in
+// CockroachDB used serializable isolation. Historically, CockroachDB did not
+// make a strength distinction between Exclusive locks and Intents. As such,
+// reads under concurrency control would conflict with Exclusive locks if the
+// read's timestamp was at or above the Exclusive lock's timestamp. Now that
+// there is such a distinction, non-locking reads from serializable transactions
+// do not block on Exclusive locks, regardless of their timestamp. However,
+// there is a desire to let users opt into the old behavior using the
+// ExclusiveLocksBlockNonLockingReads cluster setting. Note that this only
+// applies when both the non-locking read and Exclusive lock belong to
+// serializable  transactions, as that's the only "old" behavior to speak of
+// here.
 message Mode {
   // Strength in which the lock is held.
   Strength strength = 1;
 
-  // Timestamp at which the lock was/is being acquired. This field must be set
-  // for None, Exclusive, and Intent locking strengths.
+  // Timestamp at which the lock was/is being acquired. This field must (and
+  // only) be set for None, Exclusive, and Intent locking strengths.
   util.hlc.Timestamp timestamp = 2 [(gogoproto.nullable)=false];
+
+  // IsoLevel is the isolation level of the associated transaction. This field
+  // is only set for None and Exclusive locking strength.
+  cockroach.kv.kvserver.concurrency.isolation.Level iso_level = 3;
 }
 
 // Durability represents the different durability properties of a lock acquired


### PR DESCRIPTION
This adds tracking for isolation level information of the associated transaction in lock modes. This is only done for non-locking reads. We then use this to modify conflict resolution rules between non-locking reads and exclusive locks -- non-locking read requests that belong to transactions running at weaker isolation levels (snapshot isolation, read committed) do not conflict with exclusive locks, regardless of their timestamp.

Behavior for non-locking read requests belonging to serializable transactions remains unchanged. It is dictated by the (now renamed) ExclusiveLocksBlockNonLockingRaedsFromSerializableTransactions cluster setting. By default, they block on exclusive locks if their timestamp is at or greater than that of the lock.

Note that lock modes are yet to be hooked up to the concurrency control package, and as such, the patch itself doesn't resolve the linked issue.

Informs #94729

Release note: None