### PR TITLE
roachtest: fix assertion in drain test

### DIFF
--- a/pkg/cmd/roachtest/tests/drain.go
+++ b/pkg/cmd/roachtest/tests/drain.go
@@ -335,7 +335,7 @@ func runClusterNotAtQuorum(ctx context.Context, t test.Test, c cluster.Cluster) 
 		"./cockroach node drain --self --insecure --drain-wait=10s",
 	)
 	t.L().Printf("drain output:\n%s\n%s\n", results.Stdout, results.Stderr)
-	require.Contains(t, results.Stderr, "could not check drain related cluster settings")
+	require.Regexp(t, "(cluster settings require a value of at least|could not check drain related cluster settings)", results.Stderr)
 }
 
 // prepareCluster is to start the server on nodes in the given cluster, and set


### PR DESCRIPTION
Sometimes the cluster settings are available when there's only one node left in the cluster, so we shouldn't always check that it failed to find them.

fixes https://github.com/cockroachdb/cockroach/issues/100265
fixes https://github.com/cockroachdb/cockroach/issues/99765
fixes https://github.com/cockroachdb/cockroach/issues/99777

Release note: None