### PR TITLE
release-22.2: changefeedccl: reduce duplicate schema registrations

### DIFF
--- a/pkg/ccl/changefeedccl/cdctest/schema_registry.go
+++ b/pkg/ccl/changefeedccl/cdctest/schema_registry.go
@@ -116,6 +116,13 @@ func (r *SchemaRegistry) registerSchema(subject string, schema string) int32 {
 	return id
 }
 
+// RegistrationCount returns the number of Registration requests received.
+func (r *SchemaRegistry) RegistrationCount() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return int(r.mu.idAlloc)
+}
+
 var (
 	// We are slightly stricter than confluent here as they allow
 	// a trailing slash.

--- a/pkg/ccl/changefeedccl/schema_registry_test.go
+++ b/pkg/ccl/changefeedccl/schema_registry_test.go
@@ -11,7 +11,9 @@ package changefeedccl
 import (
 	"context"
 	"errors"
+	"fmt"
 	"net/url"
+	"sync"
 	"testing"
 	"time"
 
@@ -42,7 +44,10 @@ func TestConfluentSchemaRegistry(t *testing.T) {
 		defer regServer.Close()
 		r, err := newConfluentSchemaRegistry(regServer.URL(), nil)
 		require.NoError(t, err)
-		require.Equal(t, defaultSchemaRegistryTimeout, r.client.Timeout)
+		getTimeout := func(r schemaRegistry) time.Duration {
+			return r.(*schemaRegistryWithCache).base.(*confluentSchemaRegistry).client.Timeout
+		}
+		require.Equal(t, defaultSchemaRegistryTimeout, getTimeout(r))
 
 		// add explicit timeout param.
 		u, err := url.Parse(regServer.URL())
@@ -52,8 +57,50 @@ func TestConfluentSchemaRegistry(t *testing.T) {
 		u.RawQuery = values.Encode()
 		r, err = newConfluentSchemaRegistry(u.String(), nil)
 		require.NoError(t, err)
-		require.Equal(t, 42*time.Millisecond, r.client.Timeout)
+		require.Equal(t, 42*time.Millisecond, getTimeout(r))
 	})
+}
+
+func TestConfluentSchemaRegistrySharedCache(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	regServer := cdctest.StartTestSchemaRegistry()
+	defer regServer.Close()
+	require.Equal(t, 0, regServer.RegistrationCount())
+
+	var wg sync.WaitGroup
+
+	// Multiple registrations of the same schema hit a shared cache.
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func() {
+			r, err := newConfluentSchemaRegistry(regServer.URL(), nil)
+			require.NoError(t, err)
+			_, err = r.RegisterSchemaForSubject(context.Background(), "subject1", "schema")
+			require.NoError(t, err)
+			wg.Done()
+
+		}()
+	}
+	wg.Wait()
+	require.Equal(t, 1, regServer.RegistrationCount())
+
+	// Registrations of different schemas don't share a cache, even if the subject is the same.
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func(i int) {
+			r, err := newConfluentSchemaRegistry(regServer.URL(), nil)
+			require.NoError(t, err)
+			_, err = r.RegisterSchemaForSubject(context.Background(), "subject1", fmt.Sprintf("schema1%d", i))
+			require.NoError(t, err)
+			wg.Done()
+
+		}(i)
+	}
+	wg.Wait()
+	require.Equal(t, 11, regServer.RegistrationCount())
+
 }
 
 func TestConfluentSchemaRegistryPing(t *testing.T) {


### PR DESCRIPTION
Backport 1/1 commits from #99833.

/cc @cockroachdb/release

---

When running many changefeeds, and/or changefeeds with many parallel processors, it's possible to overwhelm the schema registry. This PR moves the number of calls to closer to O(number of nodes) by adding a shared in-memory cache by endpoint, subject, and schema.

Informs #99221.

Release note (enterprise change): Changefeeds using the WITH confluent_schema_registry option will make fewer duplicate schema registrations.

Release justification: Single-file fix to a blocking performance issue.
