### PR TITLE
util/mon: compute a limit from reserved budget and parent pool

### DIFF
--- a/pkg/sql/colflow/draining_test.go
+++ b/pkg/sql/colflow/draining_test.go
@@ -101,7 +101,7 @@ func TestDrainingAfterRemoteError(t *testing.T) {
 
 	// Perform a query that uses the join reader when ordering has to be
 	// maintained. Ensure that it encounters the error that we expect.
-	sqlDB.ExpectErr(t, ".*test-disk.*", "SELECT sum(length(v)) FROM large, small WHERE small.k = large.k GROUP BY large.k;")
+	sqlDB.ExpectErr(t, ".*joinreader-disk.*", "SELECT sum(length(v)) FROM large, small WHERE small.k = large.k GROUP BY large.k;")
 	sqlDB.Exec(t, "SET tracing = off;")
 
 	// Now, the crux of the test - verify that the spans for the join reader on

--- a/pkg/sql/colmem/allocator.go
+++ b/pkg/sql/colmem/allocator.go
@@ -125,15 +125,6 @@ func GetProportionalBatchMemSize(b coldata.Batch, length int64) int64 {
 func NewAllocator(
 	ctx context.Context, unlimitedAcc *mon.BoundAccount, factory coldata.ColumnFactory,
 ) *Allocator {
-	if buildutil.CrdbTestBuild {
-		if unlimitedAcc != nil {
-			if l := unlimitedAcc.Monitor().Limit(); l != noMemLimit {
-				colexecerror.InternalError(errors.AssertionFailedf(
-					"unexpectedly NewAllocator is called with an account with limit of %d bytes", l,
-				))
-			}
-		}
-	}
 	return &Allocator{
 		ctx:     ctx,
 		acc:     unlimitedAcc,


### PR DESCRIPTION
Prereq to fixing #98247.

Release note: None
Epic: CRDB-23559