### PR TITLE
server: properly config disk spill storage for shared-process tenant servers

### DIFF
--- a/pkg/ccl/serverccl/server_controller_test.go
+++ b/pkg/ccl/serverccl/server_controller_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/server"
 	"github.com/cockroachdb/cockroach/pkg/server/serverpb"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/lexbase"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/catconstants"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
@@ -121,6 +122,32 @@ ALTER TENANT application START SERVICE SHARED`)
 			require.NoError(t, err)
 		}
 	}
+}
+
+func TestSharedProcessServerInheritsTempStorageLimit(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	const specialSize = 123123123
+
+	// Start a server with a custom temp storage limit.
+	ctx := context.Background()
+	st := cluster.MakeClusterSettings()
+	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{
+		Settings:          st,
+		TempStorageConfig: base.DefaultTestTempStorageConfigWithSize(st, specialSize),
+		DefaultTestTenant: base.TestTenantDisabled,
+	})
+	defer s.Stopper().Stop(ctx)
+
+	// Start a shared process tenant server.
+	ts, _, err := s.StartSharedProcessTenant(ctx, base.TestSharedProcessTenantArgs{
+		TenantName: "hello",
+	})
+	require.NoError(t, err)
+
+	tss := ts.(*server.TestTenant)
+	require.Equal(t, int64(specialSize), tss.SQLCfg.TempStorageConfig.Mon.Limit())
 }
 
 func TestServerControllerHTTP(t *testing.T) {

--- a/pkg/server/server_controller_new_server.go
+++ b/pkg/server/server_controller_new_server.go
@@ -307,11 +307,9 @@ func makeSharedProcessTenantServerConfig(
 		baseCfg.InflightTraceDirName = traceDir
 	}
 
-	// TODO(knz): Define a meaningful storage config for each tenant,
-	// see: https://github.com/cockroachdb/cockroach/issues/84588.
 	useStore := kvServerCfg.SQLConfig.TempStorageConfig.Spec
 	tempStorageCfg := base.TempStorageConfigFromEnv(
-		ctx, st, useStore, "" /* parentDir */, kvServerCfg.SQLConfig.TempStorageConfig.Mon.MaximumBytes())
+		ctx, st, useStore, "" /* parentDir */, kvServerCfg.SQLConfig.TempStorageConfig.Mon.Limit())
 	// TODO(knz): Make tempDir configurable.
 	tempDir := useStore.Path
 	if tempStorageCfg.Path, err = fs.CreateTempDir(tempDir, TempDirPrefix, stopper); err != nil {

--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -657,7 +657,8 @@ func (ts *TestServer) Start(ctx context.Context) error {
 // serverutils.StartTenant method.
 type TestTenant struct {
 	*SQLServer
-	Cfg *BaseConfig
+	Cfg    *BaseConfig
+	SQLCfg *SQLConfig
 	*httpTestServer
 	drain *drainServer
 
@@ -920,6 +921,7 @@ func (ts *TestServer) StartSharedProcessTenant(
 	testTenant := &TestTenant{
 		SQLServer:      sqlServer,
 		Cfg:            sqlServer.cfg,
+		SQLCfg:         sqlServerWrapper.sqlCfg,
 		pgPreServer:    sqlServerWrapper.pgPreServer,
 		httpTestServer: hts,
 		drain:          sqlServerWrapper.drainServer,
@@ -1189,6 +1191,7 @@ func (ts *TestServer) StartTenant(
 	return &TestTenant{
 		SQLServer:      sw.sqlServer,
 		Cfg:            &baseCfg,
+		SQLCfg:         &sqlCfg,
 		pgPreServer:    sw.pgPreServer,
 		httpTestServer: hts,
 		drain:          sw.drainServer,

--- a/pkg/sql/colflow/draining_test.go
+++ b/pkg/sql/colflow/draining_test.go
@@ -101,7 +101,7 @@ func TestDrainingAfterRemoteError(t *testing.T) {
 
 	// Perform a query that uses the join reader when ordering has to be
 	// maintained. Ensure that it encounters the error that we expect.
-	sqlDB.ExpectErr(t, ".*test-disk.*", "SELECT sum(length(v)) FROM large, small WHERE small.k = large.k GROUP BY large.k;")
+	sqlDB.ExpectErr(t, ".*joinreader-disk.*", "SELECT sum(length(v)) FROM large, small WHERE small.k = large.k GROUP BY large.k;")
 	sqlDB.Exec(t, "SET tracing = off;")
 
 	// Now, the crux of the test - verify that the spans for the join reader on

--- a/pkg/sql/colmem/allocator.go
+++ b/pkg/sql/colmem/allocator.go
@@ -125,15 +125,6 @@ func GetProportionalBatchMemSize(b coldata.Batch, length int64) int64 {
 func NewAllocator(
 	ctx context.Context, unlimitedAcc *mon.BoundAccount, factory coldata.ColumnFactory,
 ) *Allocator {
-	if buildutil.CrdbTestBuild {
-		if unlimitedAcc != nil {
-			if l := unlimitedAcc.Monitor().Limit(); l != noMemLimit {
-				colexecerror.InternalError(errors.AssertionFailedf(
-					"unexpectedly NewAllocator is called with an account with limit of %d bytes", l,
-				))
-			}
-		}
-	}
 	return &Allocator{
 		ctx:     ctx,
 		acc:     unlimitedAcc,


### PR DESCRIPTION
Fixes #98247.
Epic: CRDB-23559

Prior to this patch, the temp storage for secondary tenants was using
the "previously seen max actual usage" of the temp storage for the
surrounding KV node. So if not SQL query had been running yet, that
limit would be very low (or zero).

A better limit is to simply propagate the same as the KV node, which
is the one configured on the command line.