### PR TITLE
storage: encode ApproximateDiskBytes keys

### DIFF
--- a/pkg/storage/pebble.go
+++ b/pkg/storage/pebble.go
@@ -1906,7 +1906,9 @@ func (p *Pebble) PreIngestDelay(ctx context.Context) {
 
 // ApproximateDiskBytes implements the Engine interface.
 func (p *Pebble) ApproximateDiskBytes(from, to roachpb.Key) (uint64, error) {
-	count, err := p.db.EstimateDiskUsage(from, to)
+	fromEncoded := EngineKey{Key: from}.Encode()
+	toEncoded := EngineKey{Key: to}.Encode()
+	count, err := p.db.EstimateDiskUsage(fromEncoded, toEncoded)
 	if err != nil {
 		return 0, err
 	}

--- a/pkg/storage/pebble_test.go
+++ b/pkg/storage/pebble_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
+	"github.com/cockroachdb/cockroach/pkg/util/randutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 	"github.com/cockroachdb/errors"
@@ -1342,4 +1343,46 @@ func TestNoMinVerFile(t *testing.T) {
 
 	_, err = Open(ctx, loc, st)
 	require.ErrorContains(t, err, "store has no min-version file")
+}
+
+func TestApproximateDiskBytes(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	ctx := context.Background()
+
+	rng, _ := randutil.NewTestRand()
+
+	p, err := Open(ctx, InMemory(), cluster.MakeTestingClusterSettings())
+	require.NoError(t, err)
+	defer p.Close()
+
+	key := func(i int) roachpb.Key {
+		return keys.SystemSQLCodec.TablePrefix(uint32(i))
+	}
+
+	// Write keys 0000...0999.
+	b := p.NewWriteBatch()
+	for i := 0; i < 1000; i++ {
+		require.NoError(t, b.PutMVCC(
+			MVCCKey{Key: key(i), Timestamp: hlc.Timestamp{WallTime: int64(i + 1)}},
+			MVCCValue{Value: roachpb.Value{RawBytes: randutil.RandBytes(rng, 100)}},
+		))
+	}
+	require.NoError(t, b.Commit(true /* sync */))
+	require.NoError(t, p.Flush())
+
+	approxBytes := func(span roachpb.Span) uint64 {
+		v, err := p.ApproximateDiskBytes(span.Key, span.EndKey)
+		require.NoError(t, err)
+		t.Logf("%s (%x-%x): %d bytes", span, span.Key, span.EndKey, v)
+		return v
+	}
+
+	all := approxBytes(roachpb.Span{Key: roachpb.KeyMin, EndKey: roachpb.KeyMax})
+	for i := 0; i < 1000; i++ {
+		s := roachpb.Span{Key: key(i), EndKey: key(i + 1)}
+		if v := approxBytes(s); v >= all {
+			t.Errorf("ApproximateDiskBytes(%q) = %d >= entire DB size %d", s, v, all)
+		}
+	}
 }


### PR DESCRIPTION
Previously Engine.ApproximateDiskBytes accepted two roachpb.Keys for bounds which were passed directly to Pebble without additional encoding. When used with EngineCompare, Cockroach would incorrectly try to interpret the final byte as a version length. This could result in incorrect size calculations or ApproximateDiskBytes erroring on out-of-order span bounds.

Kudos to @THardy98 for uncovering this one.

Epic: None
Release note (bug fix): Fix a bug whereby some tables' physical disk space could not be calculated.