### PR TITLE
release-23.1: upgrades: hardcode descriptors in system_rbr_indexes

### DIFF
--- a/pkg/upgrade/upgrades/BUILD.bazel
+++ b/pkg/upgrade/upgrades/BUILD.bazel
@@ -56,6 +56,8 @@ go_library(
         "//pkg/settings/cluster",
         "//pkg/sql/catalog",
         "//pkg/sql/catalog/catalogkeys",
+        "//pkg/sql/catalog/catenumpb",
+        "//pkg/sql/catalog/catpb",
         "//pkg/sql/catalog/descidgen",
         "//pkg/sql/catalog/descpb",
         "//pkg/sql/catalog/descs",


### PR DESCRIPTION
Backport 1/1 commits from #99172.

/cc @cockroachdb/release

Release Justification: The change is low risk and reduces the probability of a future back port accidentally breaking backward compatibility. 

---

Previously, if a change was made to the system.sql_instances, system.lease, or system.sqlliveness bootstrap schema, it would change the behavior of the upgrade attached to the V23_1_SystemRbrReadNew version gate.

Now, the content of the descriptors is hard coded in the upgrade so that the behavior is not accidentally changed in the future.

Fixes: #99074

Release note: None
