### PR TITLE
kv: s/client.{Txn,TxnSender}/kv.{Txn,TxnSender}/g 

### DIFF
--- a/pkg/jobs/update.go
+++ b/pkg/jobs/update.go
@@ -362,7 +362,7 @@ func UpdateHighwaterProgressed(highWater hlc.Timestamp, md JobMetadata, ju *JobU
 //
 // Sample usage:
 //
-//	err := j.Update(ctx, func(_ *client.Txn, md jobs.JobMetadata, ju *jobs.JobUpdater) error {
+//	err := j.Update(ctx, func(_ *kv.Txn, md jobs.JobMetadata, ju *jobs.JobUpdater) error {
 //	  if md.Status != StatusRunning {
 //	    return errors.New("job no longer running")
 //	  }

--- a/pkg/kv/doc.go
+++ b/pkg/kv/doc.go
@@ -51,7 +51,7 @@ parallel and then sends a sequence of puts in parallel:
 		log.Fatal(err)
 	}
 
-	b1 := &client.Batch{}
+	b1 := &kv.Batch{}
 	b1.Scan("a", "c\x00", 1000)
 	b1.Scan("x", "z\x00", 1000)
 
@@ -93,7 +93,7 @@ necessary. An example of using transactions with parallel writes:
 		log.Fatal(err)
 	}
 
-	err := db.Txn(func(ctx context.Context, txn *client.Txn) error {
+	err := db.Txn(func(ctx context.Context, txn *kv.Txn) error {
 		b := txn.NewBatch()
 		for i := 0; i < 100; i++ {
 			key := fmt.Sprintf("testkey-%02d", i)

--- a/pkg/kv/kvclient/kvcoord/txn_coord_sender.go
+++ b/pkg/kv/kvclient/kvcoord/txn_coord_sender.go
@@ -71,7 +71,7 @@ const (
 	txnFinalized
 )
 
-// A TxnCoordSender is the production implementation of client.TxnSender. It is
+// A TxnCoordSender is the production implementation of kv.TxnSender. It is
 // a Sender which wraps a lower-level Sender (a DistSender) to which it sends
 // commands. It works on behalf of the client to keep a transaction's state
 // (e.g. intents) and to perform periodic heartbeating of the transaction
@@ -410,7 +410,7 @@ func newLeafTxnCoordSender(
 	return tcs
 }
 
-// DisablePipelining is part of the client.TxnSender interface.
+// DisablePipelining is part of the kv.TxnSender interface.
 func (tc *TxnCoordSender) DisablePipelining() error {
 	tc.mu.Lock()
 	defer tc.mu.Unlock()
@@ -469,7 +469,7 @@ func (tc *TxnCoordSender) finalizeNonLockingTxnLocked(
 	return nil
 }
 
-// Send is part of the client.TxnSender interface.
+// Send is part of the kv.TxnSender interface.
 func (tc *TxnCoordSender) Send(
 	ctx context.Context, ba *kvpb.BatchRequest,
 ) (*kvpb.BatchResponse, *kvpb.Error) {
@@ -998,14 +998,14 @@ func sanityCheckErrWithTxn(
 	return err
 }
 
-// TxnStatus is part of the client.TxnSender interface.
+// TxnStatus is part of the kv.TxnSender interface.
 func (tc *TxnCoordSender) TxnStatus() roachpb.TransactionStatus {
 	tc.mu.Lock()
 	defer tc.mu.Unlock()
 	return tc.mu.txn.Status
 }
 
-// SetUserPriority is part of the client.TxnSender interface.
+// SetUserPriority is part of the kv.TxnSender interface.
 func (tc *TxnCoordSender) SetUserPriority(pri roachpb.UserPriority) error {
 	tc.mu.Lock()
 	defer tc.mu.Unlock()
@@ -1017,7 +1017,7 @@ func (tc *TxnCoordSender) SetUserPriority(pri roachpb.UserPriority) error {
 	return nil
 }
 
-// SetDebugName is part of the client.TxnSender interface.
+// SetDebugName is part of the kv.TxnSender interface.
 func (tc *TxnCoordSender) SetDebugName(name string) {
 	tc.mu.Lock()
 	defer tc.mu.Unlock()
@@ -1032,28 +1032,28 @@ func (tc *TxnCoordSender) SetDebugName(name string) {
 	tc.mu.txn.Name = name
 }
 
-// String is part of the client.TxnSender interface.
+// String is part of the kv.TxnSender interface.
 func (tc *TxnCoordSender) String() string {
 	tc.mu.Lock()
 	defer tc.mu.Unlock()
 	return tc.mu.txn.String()
 }
 
-// ReadTimestamp is part of the client.TxnSender interface.
+// ReadTimestamp is part of the kv.TxnSender interface.
 func (tc *TxnCoordSender) ReadTimestamp() hlc.Timestamp {
 	tc.mu.Lock()
 	defer tc.mu.Unlock()
 	return tc.mu.txn.ReadTimestamp
 }
 
-// ProvisionalCommitTimestamp is part of the client.TxnSender interface.
+// ProvisionalCommitTimestamp is part of the kv.TxnSender interface.
 func (tc *TxnCoordSender) ProvisionalCommitTimestamp() hlc.Timestamp {
 	tc.mu.Lock()
 	defer tc.mu.Unlock()
 	return tc.mu.txn.WriteTimestamp
 }
 
-// CommitTimestamp is part of the client.TxnSender interface.
+// CommitTimestamp is part of the kv.TxnSender interface.
 func (tc *TxnCoordSender) CommitTimestamp() hlc.Timestamp {
 	tc.mu.Lock()
 	defer tc.mu.Unlock()
@@ -1062,14 +1062,14 @@ func (tc *TxnCoordSender) CommitTimestamp() hlc.Timestamp {
 	return txn.ReadTimestamp
 }
 
-// CommitTimestampFixed is part of the client.TxnSender interface.
+// CommitTimestampFixed is part of the kv.TxnSender interface.
 func (tc *TxnCoordSender) CommitTimestampFixed() bool {
 	tc.mu.Lock()
 	defer tc.mu.Unlock()
 	return tc.mu.txn.CommitTimestampFixed
 }
 
-// SetFixedTimestamp is part of the client.TxnSender interface.
+// SetFixedTimestamp is part of the kv.TxnSender interface.
 func (tc *TxnCoordSender) SetFixedTimestamp(ctx context.Context, ts hlc.Timestamp) error {
 	tc.mu.Lock()
 	defer tc.mu.Unlock()
@@ -1094,14 +1094,14 @@ func (tc *TxnCoordSender) SetFixedTimestamp(ctx context.Context, ts hlc.Timestam
 	return nil
 }
 
-// RequiredFrontier is part of the client.TxnSender interface.
+// RequiredFrontier is part of the kv.TxnSender interface.
 func (tc *TxnCoordSender) RequiredFrontier() hlc.Timestamp {
 	tc.mu.Lock()
 	defer tc.mu.Unlock()
 	return tc.mu.txn.RequiredFrontier()
 }
 
-// ManualRestart is part of the client.TxnSender interface.
+// ManualRestart is part of the kv.TxnSender interface.
 func (tc *TxnCoordSender) ManualRestart(
 	ctx context.Context, pri roachpb.UserPriority, ts hlc.Timestamp,
 ) {
@@ -1126,7 +1126,7 @@ func (tc *TxnCoordSender) ManualRestart(
 	tc.mu.txnState = txnPending
 }
 
-// IsSerializablePushAndRefreshNotPossible is part of the client.TxnSender interface.
+// IsSerializablePushAndRefreshNotPossible is part of the kv.TxnSender interface.
 func (tc *TxnCoordSender) IsSerializablePushAndRefreshNotPossible() bool {
 	tc.mu.Lock()
 	defer tc.mu.Unlock()
@@ -1139,14 +1139,14 @@ func (tc *TxnCoordSender) IsSerializablePushAndRefreshNotPossible() bool {
 	return isTxnPushed && refreshAttemptNotPossible
 }
 
-// Epoch is part of the client.TxnSender interface.
+// Epoch is part of the kv.TxnSender interface.
 func (tc *TxnCoordSender) Epoch() enginepb.TxnEpoch {
 	tc.mu.Lock()
 	defer tc.mu.Unlock()
 	return tc.mu.txn.Epoch
 }
 
-// IsLocking is part of the client.TxnSender interface.
+// IsLocking is part of the kv.TxnSender interface.
 func (tc *TxnCoordSender) IsLocking() bool {
 	tc.mu.Lock()
 	defer tc.mu.Unlock()
@@ -1168,7 +1168,7 @@ func (tc *TxnCoordSender) Active() bool {
 	return tc.mu.active
 }
 
-// GetLeafTxnInputState is part of the client.TxnSender interface.
+// GetLeafTxnInputState is part of the kv.TxnSender interface.
 func (tc *TxnCoordSender) GetLeafTxnInputState(
 	ctx context.Context,
 ) (*roachpb.LeafTxnInputState, error) {
@@ -1196,7 +1196,7 @@ func (tc *TxnCoordSender) GetLeafTxnInputState(
 	return tis, nil
 }
 
-// GetLeafTxnFinalState is part of the client.TxnSender interface.
+// GetLeafTxnFinalState is part of the kv.TxnSender interface.
 func (tc *TxnCoordSender) GetLeafTxnFinalState(
 	ctx context.Context,
 ) (*roachpb.LeafTxnFinalState, error) {
@@ -1230,7 +1230,7 @@ func (tc *TxnCoordSender) GetLeafTxnFinalState(
 	return tfs, nil
 }
 
-// UpdateRootWithLeafFinalState is part of the client.TxnSender interface.
+// UpdateRootWithLeafFinalState is part of the kv.TxnSender interface.
 func (tc *TxnCoordSender) UpdateRootWithLeafFinalState(
 	ctx context.Context, tfs *roachpb.LeafTxnFinalState,
 ) error {
@@ -1274,7 +1274,7 @@ func (tc *TxnCoordSender) UpdateRootWithLeafFinalState(
 	return nil
 }
 
-// TestingCloneTxn is part of the client.TxnSender interface.
+// TestingCloneTxn is part of the kv.TxnSender interface.
 // This is for use by tests only. To derive leaf TxnCoordSenders,
 // use GetLeafTxnInitialState instead.
 func (tc *TxnCoordSender) TestingCloneTxn() *roachpb.Transaction {
@@ -1283,7 +1283,7 @@ func (tc *TxnCoordSender) TestingCloneTxn() *roachpb.Transaction {
 	return tc.mu.txn.Clone()
 }
 
-// PrepareRetryableError is part of the client.TxnSender interface.
+// PrepareRetryableError is part of the kv.TxnSender interface.
 func (tc *TxnCoordSender) PrepareRetryableError(
 	ctx context.Context, msg redact.RedactableString,
 ) error {

--- a/pkg/kv/kvclient/kvcoord/txn_coord_sender.go
+++ b/pkg/kv/kvclient/kvcoord/txn_coord_sender.go
@@ -87,13 +87,13 @@ const (
 // - Attaching lock spans to EndTxn requests, for cleanup.
 // - Handles retriable errors by either bumping the transaction's epoch or, in
 // case of TransactionAbortedErrors, cleaning up the transaction (in this case,
-// the client.Txn is expected to create a new TxnCoordSender instance
-// transparently for the higher-level client).
+// the kv.Txn is expected to create a new TxnCoordSender instance transparently
+// for the higher-level client).
 //
 // Since it is stateful, the TxnCoordSender needs to understand when a
 // transaction is "finished" and the state can be destroyed. As such there's a
-// contract that the client.Txn needs obey. Read-only transactions don't matter
-// - they're stateless. For the others, once an intent write is sent by the
+// contract that the kv.Txn needs obey. Read-only transactions don't matter -
+// they're stateless. For the others, once an intent write is sent by the
 // client, the TxnCoordSender considers the transactions completed in the
 // following situations:
 // - A batch containing an EndTxns (commit or rollback) succeeds.

--- a/pkg/kv/kvclient/kvcoord/txn_coord_sender_factory.go
+++ b/pkg/kv/kvclient/kvcoord/txn_coord_sender_factory.go
@@ -23,7 +23,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
 )
 
-// TxnCoordSenderFactory implements client.TxnSenderFactory.
+// TxnCoordSenderFactory implements kv.TxnSenderFactory.
 type TxnCoordSenderFactory struct {
 	log.AmbientContext
 

--- a/pkg/kv/kvclient/kvcoord/txn_coord_sender_savepoints.go
+++ b/pkg/kv/kvclient/kvcoord/txn_coord_sender_savepoints.go
@@ -57,7 +57,7 @@ func (s *savepoint) Initial() bool {
 	return !s.active
 }
 
-// CreateSavepoint is part of the client.TxnSender interface.
+// CreateSavepoint is part of the kv.TxnSender interface.
 func (tc *TxnCoordSender) CreateSavepoint(ctx context.Context) (kv.SavepointToken, error) {
 	if tc.typ != kv.RootTxn {
 		return nil, errors.AssertionFailedf("cannot get savepoint in non-root txn")
@@ -92,7 +92,7 @@ func (tc *TxnCoordSender) CreateSavepoint(ctx context.Context) (kv.SavepointToke
 	return s, nil
 }
 
-// RollbackToSavepoint is part of the client.TxnSender interface.
+// RollbackToSavepoint is part of the kv.TxnSender interface.
 func (tc *TxnCoordSender) RollbackToSavepoint(ctx context.Context, s kv.SavepointToken) error {
 	if tc.typ != kv.RootTxn {
 		return errors.AssertionFailedf("cannot rollback savepoint in non-root txn")
@@ -151,7 +151,7 @@ func (tc *TxnCoordSender) RollbackToSavepoint(ctx context.Context, s kv.Savepoin
 	return nil
 }
 
-// ReleaseSavepoint is part of the client.TxnSender interface.
+// ReleaseSavepoint is part of the kv.TxnSender interface.
 func (tc *TxnCoordSender) ReleaseSavepoint(ctx context.Context, s kv.SavepointToken) error {
 	if tc.typ != kv.RootTxn {
 		return errors.AssertionFailedf("cannot release savepoint in non-root txn")

--- a/pkg/kv/kvclient/kvcoord/txn_coord_sender_server_test.go
+++ b/pkg/kv/kvclient/kvcoord/txn_coord_sender_server_test.go
@@ -40,7 +40,7 @@ import (
 // transaction status and do an async abort.
 // After the heartbeat loop finds out about the abort, subsequent requests sent
 // through the TxnCoordSender return TransactionAbortedErrors. On those errors,
-// the contract is that the client.Txn creates a new transaction internally and
+// the contract is that the kv.Txn creates a new transaction internally and
 // switches the TxnCoordSender instance. The expectation is that the old
 // transaction has been cleaned up by that point.
 func TestHeartbeatFindsOutAboutAbortedTransaction(t *testing.T) {

--- a/pkg/kv/kvpb/errors.proto
+++ b/pkg/kv/kvpb/errors.proto
@@ -464,7 +464,7 @@ message UnhandledRetryableError {
 //
 // It contains the final form of the Transaction proto that should be used on
 // next attempts. After being produced by the TxnCoordSender, this error is
-// handled first by the client.Txn, which uses the Transaction inside to update
+// handled first by the kv.Txn, which uses the Transaction inside to update
 // its state, and then passed along to SQL in a pErr (through the
 // client.Sender() interface).
 message TransactionRetryWithProtoRefreshError {
@@ -494,7 +494,7 @@ message TransactionRetryWithProtoRefreshError {
 
 // TxnAlreadyEncounteredErrorError indicates that an operation tried to use a
 // transaction that already received an error from a previous request. Once that
-// happens, client.Txn rejects future requests.
+// happens, kv.Txn rejects future requests.
 message TxnAlreadyEncounteredErrorError{
   // prev_error is the message from the error that the txn encountered
   // previously.

--- a/pkg/kv/kvserver/replica_rangefeed_test.go
+++ b/pkg/kv/kvserver/replica_rangefeed_test.go
@@ -401,7 +401,7 @@ func TestReplicaRangefeed(t *testing.T) {
 	// Wait for all streams to observe the expected events.
 	expVal2 := roachpb.MakeValueFromBytesAndTimestamp([]byte("val2"), ts2)
 	expVal3 := roachpb.MakeValueFromBytesAndTimestamp([]byte("val3"), ts3)
-	expVal3.InitChecksum([]byte("m")) // client.Txn sets value checksum
+	expVal3.InitChecksum([]byte("m")) // kv.Txn sets value checksum
 	expVal4 := roachpb.Value{Timestamp: ts4}
 	expVal4.SetInt(18)
 	expVal4.InitChecksum(roachpb.Key("b"))

--- a/pkg/kv/mock_transactional_sender.go
+++ b/pkg/kv/mock_transactional_sender.go
@@ -138,17 +138,17 @@ func (m *MockTransactionalSender) IsSerializablePushAndRefreshNotPossible() bool
 	return false
 }
 
-// CreateSavepoint is part of the client.TxnSender interface.
+// CreateSavepoint is part of the kv.TxnSender interface.
 func (m *MockTransactionalSender) CreateSavepoint(context.Context) (SavepointToken, error) {
 	panic("unimplemented")
 }
 
-// RollbackToSavepoint is part of the client.TxnSender interface.
+// RollbackToSavepoint is part of the kv.TxnSender interface.
 func (m *MockTransactionalSender) RollbackToSavepoint(context.Context, SavepointToken) error {
 	panic("unimplemented")
 }
 
-// ReleaseSavepoint is part of the client.TxnSender interface.
+// ReleaseSavepoint is part of the kv.TxnSender interface.
 func (m *MockTransactionalSender) ReleaseSavepoint(context.Context, SavepointToken) error {
 	panic("unimplemented")
 }
@@ -176,10 +176,10 @@ func (m *MockTransactionalSender) UpdateStateOnRemoteRetryableErr(
 	panic("unimplemented")
 }
 
-// DisablePipelining is part of the client.TxnSender interface.
+// DisablePipelining is part of the kv.TxnSender interface.
 func (m *MockTransactionalSender) DisablePipelining() error { return nil }
 
-// PrepareRetryableError is part of the client.TxnSender interface.
+// PrepareRetryableError is part of the kv.TxnSender interface.
 func (m *MockTransactionalSender) PrepareRetryableError(
 	ctx context.Context, msg redact.RedactableString,
 ) error {

--- a/pkg/kv/sender.go
+++ b/pkg/kv/sender.go
@@ -21,8 +21,8 @@ import (
 )
 
 // TxnType specifies whether a transaction is the root (parent)
-// transaction, or a leaf (child) in a tree of client.Txns, as
-// is used in a DistSQL flow.
+// transaction, or a leaf (child) in a tree of kv.Txns, as is
+// used in a DistSQL flow.
 type TxnType int
 
 const (
@@ -51,8 +51,8 @@ const (
 // the "client" and the "server", involved in passing along and
 // ultimately evaluating requests (batches). The interface is now
 // considered regrettable because it's too narrow and at times leaky.
-// Notable implementors: client.Txn, kv.TxnCoordSender, storage.Node,
-// storage.Store, storage.Replica.
+// Notable implementors: kv.Txn, kvcoord.TxnCoordSender, server.Node,
+// kvserver.Store, kvserver.Replica.
 type Sender interface {
 	// Send sends a batch for evaluation. Either a response or an error is
 	// returned.
@@ -77,7 +77,7 @@ type Sender interface {
 	//
 	// TODO(andrei): The client does not currently use this last
 	// guarantee; it clones the txn for every request. Given that a
-	// client.Txn can be used concurrently, in order for the client to
+	// kv.Txn can be used concurrently, in order for the client to
 	// take advantage of this, it would need to switch to a
 	// copy-on-write scheme so that its updates to the txn do not race
 	// with the server reading it. We should do this to avoid the
@@ -94,7 +94,7 @@ type Sender interface {
 // TxnSender is the interface used to call into a CockroachDB instance
 // when sending transactional requests. In addition to the usual
 // Sender interface, TxnSender facilitates marshaling of transaction
-// metadata between the "root" client.Txn and "leaf" instances.
+// metadata between the "root" kv.Txn and "leaf" instances.
 type TxnSender interface {
 	Sender
 

--- a/pkg/kv/txn.go
+++ b/pkg/kv/txn.go
@@ -927,7 +927,7 @@ func (txn *Txn) exec(ctx context.Context, fn func(context.Context, *Txn) error) 
 		if err == nil {
 			if !txn.IsCommitted() {
 				err = txn.Commit(ctx)
-				log.Eventf(ctx, "client.Txn did AutoCommit. err: %v", err)
+				log.Eventf(ctx, "kv.Txn did AutoCommit. err: %v", err)
 				if err != nil {
 					if !errors.HasType(err, (*kvpb.TransactionRetryWithProtoRefreshError)(nil)) {
 						// We can't retry, so let the caller know we tried to

--- a/pkg/kv/txn_test.go
+++ b/pkg/kv/txn_test.go
@@ -61,14 +61,14 @@ func TestTxnVerboseTrace(t *testing.T) {
 	dump := collectedSpans.String()
 	// dump:
 	//    0.105ms      0.000ms    event:inside txn
-	//    0.275ms      0.171ms    event:client.Txn did AutoCommit. err: <nil>
+	//    0.275ms      0.171ms    event:kv.Txn did AutoCommit. err: <nil>
 	//    0.278ms      0.173ms    event:txn complete
 	found, err := regexp.MatchString(
 		// The (?s) makes "." match \n. This makes the test resilient to other log
 		// lines being interspersed.
 		`(?s)`+
 			`.*event:[^:]*:\d+ inside txn\n`+
-			`.*event:[^:]*:\d+ client\.Txn did AutoCommit\. err: <nil>\n`+
+			`.*event:[^:]*:\d+ kv\.Txn did AutoCommit\. err: <nil>\n`+
 			`.*event:[^:]*:\d+ txn complete.*`,
 		dump)
 	if err != nil {

--- a/pkg/roachpb/data.proto
+++ b/pkg/roachpb/data.proto
@@ -707,7 +707,7 @@ message LeafTxnInputState {
   // Current read seqnum. When stepping_mode_enabled is true,
   // this field becomes the sequence number used for reads,
   // regardless of the current seqnum generated for writes. This is
-  // updated via the (client.TxnSender).Step() operation.
+  // updated via the (kv.TxnSender).Step() operation.
   int32 read_seq_num = 10 [
     (gogoproto.casttype) = "github.com/cockroachdb/cockroach/pkg/storage/enginepb.TxnSeq"];
 }

--- a/pkg/sql/check.go
+++ b/pkg/sql/check.go
@@ -45,7 +45,7 @@ import (
 // validation query to validate against a specific index.
 //
 // It operates entirely on the current goroutine and is thus able to
-// reuse an existing client.Txn safely.
+// reuse an existing kv.Txn safely.
 func validateCheckExpr(
 	ctx context.Context,
 	semaCtx *tree.SemaContext,

--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -687,7 +687,7 @@ func (ex *connExecutor) execStmtInOpenState(
 	// change would forget to add the call).
 	//
 	// TODO(andrei): really the code should be rearchitected to ensure
-	// that all uses of SQL execution initialize the client.Txn using a
+	// that all uses of SQL execution initialize the kv.Txn using a
 	// single/common function. That would be where the stepping mode
 	// gets enabled once for all SQL statements executed "underneath".
 	prevSteppingMode := ex.state.mu.txn.ConfigureStepping(ctx, kv.SteppingEnabled)

--- a/pkg/sql/execinfrapb/api.proto
+++ b/pkg/sql/execinfrapb/api.proto
@@ -32,7 +32,7 @@ message SetupFlowRequest {
   optional util.tracing.tracingpb.TraceInfo trace_info = 11;
   optional string job_tag = 13 [(gogoproto.nullable) = false];
 
-  // LeafTxnInputState is the input parameter for the *client.Txn needed for
+  // LeafTxnInputState is the input parameter for the *kv.Txn needed for
   // executing the flow.
   // If nil, the flow will not run in a higher-level transaction
   // (i.e. it is responsible for managing its own transactions, if any). Most

--- a/pkg/sql/row/kv_batch_fetcher.go
+++ b/pkg/sql/row/kv_batch_fetcher.go
@@ -58,7 +58,7 @@ var defaultKVBatchSize = rowinfra.KeyLimit(util.ConstantWithMetamorphicTestValue
 ))
 
 // sendFunc is the function used to execute a KV batch; normally
-// wraps (*client.Txn).Send.
+// wraps (*kv.Txn).Send.
 type sendFunc func(
 	ctx context.Context, ba *kvpb.BatchRequest,
 ) (*kvpb.BatchResponse, error)

--- a/pkg/sql/set_zone_config.go
+++ b/pkg/sql/set_zone_config.go
@@ -1218,7 +1218,7 @@ func writeZoneConfigUpdate(
 // or it is run on behalf of a tenant.
 //
 // It operates entirely on the current goroutine and is thus able to
-// reuse an existing client.Txn safely.
+// reuse an existing kv.Txn safely.
 func RemoveIndexZoneConfigs(
 	ctx context.Context,
 	txn descs.Txn,

--- a/pkg/sql/txn_state.go
+++ b/pkg/sql/txn_state.go
@@ -37,9 +37,9 @@ import (
 // txnState contains state associated with an ongoing SQL txn; it constitutes
 // the ExtendedState of a connExecutor's state machine (defined in conn_fsm.go).
 // It contains fields that are mutated as side-effects of state transitions;
-// notably the KV client.Txn.  All mutations to txnState are performed through
-// calling fsm.Machine.Apply(event); see conn_fsm.go for the definition of the
-// state machine.
+// notably the kv.Txn. All mutations to txnState are performed through calling
+// fsm.Machine.Apply(event); see conn_fsm.go for the definition of the state
+// machine.
 type txnState struct {
 	// Mutable fields accessed from goroutines not synchronized by this txn's
 	// session, such as when a SHOW SESSIONS statement is executed on another
@@ -143,7 +143,7 @@ const (
 )
 
 // resetForNewSQLTxn (re)initializes the txnState for a new transaction.
-// It creates a new client.Txn and initializes it using the session defaults
+// It creates a new kv.Txn and initializes it using the session defaults
 // and returns the ID of the new transaction.
 //
 // connCtx: The context in which the new transaction is started (usually a

--- a/pkg/sql/txn_state_test.go
+++ b/pkg/sql/txn_state_test.go
@@ -182,8 +182,8 @@ func checkAdv(
 	return nil
 }
 
-// expKVTxn is used with checkTxn to check that fields on a client.Txn
-// correspond to expectations. Any field left nil will not be checked.
+// expKVTxn is used with checkTxn to check that fields on a kv.Txn correspond to
+// expectations. Any field left nil will not be checked.
 type expKVTxn struct {
 	debugName    *string
 	userPriority *roachpb.UserPriority


### PR DESCRIPTION
The `client` package was renamed to `kv` some time ago, so this corrects comments that were still referring to the old package structure.

Epic: None
Release note: None