### PR TITLE
kv: expose isolation level through kv.Txn API

### DIFF
--- a/pkg/kv/kvclient/kvcoord/BUILD.bazel
+++ b/pkg/kv/kvclient/kvcoord/BUILD.bazel
@@ -49,6 +49,7 @@ go_library(
         "//pkg/kv/kvclient/rangecache",
         "//pkg/kv/kvpb",
         "//pkg/kv/kvserver/closedts",
+        "//pkg/kv/kvserver/concurrency/isolation",
         "//pkg/kv/kvserver/concurrency/lock",
         "//pkg/kv/kvserver/txnwait",
         "//pkg/multitenant",

--- a/pkg/kv/mock_transactional_sender.go
+++ b/pkg/kv/mock_transactional_sender.go
@@ -14,6 +14,7 @@ import (
 	"context"
 
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/concurrency/isolation"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
@@ -70,6 +71,17 @@ func (m *MockTransactionalSender) UpdateRootWithLeafFinalState(
 // TxnStatus is part of the TxnSender interface.
 func (m *MockTransactionalSender) TxnStatus() roachpb.TransactionStatus {
 	return m.txn.Status
+}
+
+// SetIsoLevel is part of the TxnSender interface.
+func (m *MockTransactionalSender) SetIsoLevel(isoLevel isolation.Level) error {
+	m.txn.IsoLevel = isoLevel
+	return nil
+}
+
+// IsoLevel is part of the TxnSender interface.
+func (m *MockTransactionalSender) IsoLevel() isolation.Level {
+	return m.txn.IsoLevel
 }
 
 // SetUserPriority is part of the TxnSender interface.

--- a/pkg/kv/sender.go
+++ b/pkg/kv/sender.go
@@ -14,6 +14,7 @@ import (
 	"context"
 
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/concurrency/isolation"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
@@ -110,6 +111,12 @@ type TxnSender interface {
 	// UpdateRootWithLeafFinalState updates a RootTxn using the final
 	// state of a LeafTxn.
 	UpdateRootWithLeafFinalState(context.Context, *roachpb.LeafTxnFinalState) error
+
+	// SetIsoLevel sets the txn's isolation level.
+	SetIsoLevel(isolation.Level) error
+
+	// IsoLevel returns the txn's isolation level.
+	IsoLevel() isolation.Level
 
 	// SetUserPriority sets the txn's priority.
 	SetUserPriority(roachpb.UserPriority) error

--- a/pkg/kv/txn.go
+++ b/pkg/kv/txn.go
@@ -273,6 +273,25 @@ func (txn *Txn) IsOpen() bool {
 	return txn.statusLocked() == roachpb.PENDING
 }
 
+// SetIsoLevel sets the transaction's isolation level. Transactions default to
+// Serializable isolation. The isolation must be set before any operations are
+// performed on the transaction.
+func (txn *Txn) SetIsoLevel(isoLevel isolation.Level) error {
+	if txn.typ != RootTxn {
+		return errors.AssertionFailedf("SetIsoLevel() called on leaf txn")
+	}
+	txn.mu.Lock()
+	defer txn.mu.Unlock()
+	return txn.mu.sender.SetIsoLevel(isoLevel)
+}
+
+// IsoLevel returns the transaction's isolation level.
+func (txn *Txn) IsoLevel() isolation.Level {
+	txn.mu.Lock()
+	defer txn.mu.Unlock()
+	return txn.mu.sender.IsoLevel()
+}
+
 // SetUserPriority sets the transaction's user priority. Transactions default to
 // normal user priority. The user priority must be set before any operations are
 // performed on the transaction.


### PR DESCRIPTION
Fixes #100130.

This commit exposes isolation levels through the kv.Txn API with the introduction of a new `SetIsoLevel` method. This method behaves similarly to `SetUserPriority`. Notably, the isolation must be set before any operations are performed on the transaction.

Release note: None