### PR TITLE
release-23.1: tree: apply functions to TEXT expressions compared with the @@ operator

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/tsvector
+++ b/pkg/sql/logictest/testdata/logic_test/tsvector
@@ -360,3 +360,67 @@ LIMIT
 	2
 ----
 0
+
+subtest 98804_regression_test
+
+statement ok
+RESET default_text_search_config
+
+statement ok
+CREATE TABLE ab (a TEXT, b TEXT)
+
+statement ok
+INSERT INTO ab VALUES('fat rats', 'fat cats chased fat, out of shape rats');
+
+query B
+SELECT a @@ b FROM ab
+----
+false
+
+query B
+SELECT b @@ a FROM ab
+----
+true
+
+query B
+SELECT 'fat rats' @@ b FROM ab
+----
+false
+
+query B
+SELECT b @@ 'fat rats' FROM ab
+----
+true
+
+query B
+SELECT a @@ 'fat cats ate fat bats' FROM ab
+----
+false
+
+query B
+SELECT 'fat cats ate fat bats' @@ a FROM ab
+----
+false
+
+statement error pq: syntax error in TSQuery: fat cats chased fat, out of shape rats
+SELECT b @@ a::tsvector FROM ab
+
+statement error pq: syntax error in TSQuery: fat cats chased fat, out of shape rats
+SELECT a::tsvector @@ b FROM ab
+
+query B
+SELECT 'fat bat cat' @@ 'bats fats'
+----
+true
+
+query B
+SELECT 'bats fats' @@ 'fat bat cat'
+----
+false
+
+statement error pq: syntax error in TSQuery: fat cats chased fat, out of shape rats
+SELECT 'fat cats chased fat, out of shape rats' @@ 'fat rats'::tsvector
+
+statement error pq: syntax error in TSQuery: fat cats chased fat, out of shape rats
+SELECT 'fat rats'::tsvector @@ 'fat cats chased fat, out of shape rats'
+

--- a/pkg/sql/logictest/testdata/logic_test/tsvector
+++ b/pkg/sql/logictest/testdata/logic_test/tsvector
@@ -402,10 +402,10 @@ SELECT 'fat cats ate fat bats' @@ a FROM ab
 ----
 false
 
-statement error pq: syntax error in TSQuery: fat cats chased fat, out of shape rats
+statement error pgcode 22023 unsupported comparison operator: <string> @@ <tsvector>
 SELECT b @@ a::tsvector FROM ab
 
-statement error pq: syntax error in TSQuery: fat cats chased fat, out of shape rats
+statement error pgcode 22023 unsupported comparison operator: <tsvector> @@ <string>
 SELECT a::tsvector @@ b FROM ab
 
 query B
@@ -418,9 +418,20 @@ SELECT 'bats fats' @@ 'fat bat cat'
 ----
 false
 
-statement error pq: syntax error in TSQuery: fat cats chased fat, out of shape rats
+query B
+SELECT 'fat' @@ 'fat rats'::tsvector
+----
+true
+
+# TODO(#75101): The error should be "syntax error in TSQuery".
+statement error pgcode 22023 unsupported comparison operator: <string> @@ <tsvector>
 SELECT 'fat cats chased fat, out of shape rats' @@ 'fat rats'::tsvector
 
-statement error pq: syntax error in TSQuery: fat cats chased fat, out of shape rats
-SELECT 'fat rats'::tsvector @@ 'fat cats chased fat, out of shape rats'
+query B
+SELECT 'fat rats'::tsvector @@ 'fat'
+----
+true
 
+# TODO(#75101): The error should be "syntax error in TSQuery".
+statement error pgcode 22023 unsupported comparison operator: <tsvector> @@ <string>
+SELECT 'fat rats'::tsvector @@ 'fat cats chased fat, out of shape rats'

--- a/pkg/sql/sem/tree/overload.go
+++ b/pkg/sql/sem/tree/overload.go
@@ -997,7 +997,7 @@ func (s *overloadTypeChecker) typeCheckOverloadedExprs(
 			return err
 		}
 
-		// The fourth heuristic is to prefer candidates that accepts the "best"
+		// The fourth heuristic is to prefer candidates that accept the "best"
 		// mutual type in the resolvable type set of all constants.
 		if bestConstType, ok := commonConstantType(s.exprs, s.constIdxs); ok {
 			// In case all overloads are filtered out at this step,

--- a/pkg/sql/sem/tree/type_check.go
+++ b/pkg/sql/sem/tree/type_check.go
@@ -2345,8 +2345,6 @@ func typeCheckComparisonOp(
 				leftExprs := make(Exprs, 1)
 				leftExprs[0] = typedLeft
 				foldedLeft = &FuncExpr{Func: WrapFunction("to_tsvector"), Exprs: leftExprs, AggType: GeneralAgg}
-			} else if rightFamily == types.TSVectorFamily {
-				foldedLeft = &CastExpr{Expr: typedLeft, Type: types.TSQuery, SyntaxMode: CastShort}
 			}
 		}
 
@@ -2359,8 +2357,6 @@ func typeCheckComparisonOp(
 				rightExprs := make(Exprs, 1)
 				rightExprs[0] = typedRight
 				foldedRight = &FuncExpr{Func: WrapFunction(funcName), Exprs: rightExprs, AggType: GeneralAgg}
-			} else if leftFamily == types.TSVectorFamily {
-				foldedRight = &CastExpr{Expr: typedRight, Type: types.TSQuery, SyntaxMode: CastShort}
 			}
 		}
 	}

--- a/pkg/sql/sem/tree/type_check_test.go
+++ b/pkg/sql/sem/tree/type_check_test.go
@@ -213,6 +213,13 @@ func TestTypeCheck(t *testing.T) {
 
 		// String preference.
 		{`st_geomfromgeojson($1)`, `st_geomfromgeojson($1:::STRING):::GEOMETRY`},
+
+		// TSQuery and TSVector
+		{`'a' @@ 'b'`, `to_tsvector('a':::STRING) @@ plainto_tsquery('b':::STRING)`},
+		{`'a' @@ 'b':::TSQUERY`, `to_tsvector('a':::STRING) @@ '''b''':::TSQUERY`},
+		{`'a':::TSQUERY @@ 'b'`, `'''a''':::TSQUERY @@ to_tsvector('b':::STRING)`},
+		{`'a' @@ 'b':::TSVECTOR`, `'a':::STRING::TSQUERY @@ '''b''':::TSVECTOR`},
+		{`'a':::TSVECTOR @@ 'b'`, `'''a''':::TSVECTOR @@ 'b':::STRING::TSQUERY`},
 	}
 	ctx := context.Background()
 	for _, d := range testData {

--- a/pkg/sql/sem/tree/type_check_test.go
+++ b/pkg/sql/sem/tree/type_check_test.go
@@ -218,8 +218,8 @@ func TestTypeCheck(t *testing.T) {
 		{`'a' @@ 'b'`, `to_tsvector('a':::STRING) @@ plainto_tsquery('b':::STRING)`},
 		{`'a' @@ 'b':::TSQUERY`, `to_tsvector('a':::STRING) @@ '''b''':::TSQUERY`},
 		{`'a':::TSQUERY @@ 'b'`, `'''a''':::TSQUERY @@ to_tsvector('b':::STRING)`},
-		{`'a' @@ 'b':::TSVECTOR`, `'a':::STRING::TSQUERY @@ '''b''':::TSVECTOR`},
-		{`'a':::TSVECTOR @@ 'b'`, `'''a''':::TSVECTOR @@ 'b':::STRING::TSQUERY`},
+		{`'a' @@ 'b':::TSVECTOR`, `'''a''':::TSQUERY @@ '''b''':::TSVECTOR`},
+		{`'a':::TSVECTOR @@ 'b'`, `'''a''':::TSVECTOR @@ '''b''':::TSQUERY`},
 	}
 	ctx := context.Background()
 	for _, d := range testData {


### PR DESCRIPTION
Backport:
  * 1/1 commits from "tree: apply functions to TEXT expressions compared with the @@ operator" (#99583)
  * 1/1 commits from "sql: remove unnecessary casts in `@@` operator type-checking" (#100704)

Please see individual PRs for details.

/cc @cockroachdb/release

Release justification: low risk backport for incorrect results with the @@ operator