### PR TITLE
sql: deflake TestErrorDuringExtendedProtocolCommit

### DIFF
--- a/pkg/sql/tests/BUILD.bazel
+++ b/pkg/sql/tests/BUILD.bazel
@@ -119,6 +119,7 @@ go_test(
         "//pkg/util/syncutil",
         "//pkg/util/timeutil",
         "//pkg/util/tracing",
+        "//pkg/util/tracing/tracingpb",
         "//pkg/util/uuid",
         "@com_github_cockroachdb_cockroach_go_v2//crdb",
         "@com_github_cockroachdb_cockroach_go_v2//crdb/crdbpgx",

--- a/pkg/sql/tests/autocommit_extended_protocol_test.go
+++ b/pkg/sql/tests/autocommit_extended_protocol_test.go
@@ -26,6 +26,8 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
+	"github.com/cockroachdb/cockroach/pkg/util/tracing"
+	"github.com/cockroachdb/cockroach/pkg/util/tracing/tracingpb"
 	"github.com/jackc/pgx/v4"
 	"github.com/stretchr/testify/require"
 )
@@ -156,18 +158,26 @@ func TestErrorDuringExtendedProtocolCommit(t *testing.T) {
 	var db *gosql.DB
 
 	var shouldErrorOnAutoCommit syncutil.AtomicBool
+	var traceID tracingpb.TraceID
 	params, _ := CreateTestServerParams()
 	params.Knobs.SQLExecutor = &sql.ExecutorTestingKnobs{
 		DisableAutoCommitDuringExec: true,
 		BeforeExecute: func(ctx context.Context, stmt string, descriptors *descs.Collection) {
 			if strings.Contains(stmt, "SELECT 'cat'") {
 				shouldErrorOnAutoCommit.Set(true)
+				traceID = tracing.SpanFromContext(ctx).TraceID()
 			}
 		},
 		BeforeAutoCommit: func(ctx context.Context, stmt string) error {
 			if shouldErrorOnAutoCommit.Get() {
 				shouldErrorOnAutoCommit.Set(false)
-				return errors.New("injected error")
+				// Only inject the error if we're in the same trace as the one we
+				// saw when executing our test query. This is so we know that this
+				// autocommit corresponds to our test qyery rather than an internal
+				// query.
+				if traceID == tracing.SpanFromContext(ctx).TraceID() {
+					return errors.New("injected error")
+				}
 			}
 			return nil
 		},


### PR DESCRIPTION
This uses the traceID to make sure that the error is injected for the correct auto-commit. Previously, internal queries could race with the query we want to error out on.

fixes https://github.com/cockroachdb/cockroach/issues/75549
backport fixes https://github.com/cockroachdb/cockroach/issues/100480
backport fixes https://github.com/cockroachdb/cockroach/issues/82010

Release note: None