### PR TITLE
opt: fix UDF inlining

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/udf
+++ b/pkg/sql/logictest/testdata/logic_test/udf
@@ -3426,3 +3426,17 @@ SELECT f100923() FROM (VALUES (10), (20)) v(i)
 ----
 NULL
 NULL
+
+# Regression test for #100915. Do not error when attempting to inline a UDF when
+# it has a subquery argument that corresponds to a parameter that is referenced
+# multiple times in the UDF body.
+statement ok
+CREATE FUNCTION f100915(i INT) RETURNS BOOL STABLE LANGUAGE SQL AS $$
+  SELECT i = 0 OR i = 10
+$$
+
+query B
+SELECT f100915((SELECT y FROM (VALUES (10), (20)) y(y) WHERE x=y)) FROM (VALUES (10), (20)) x(x)
+----
+true
+false

--- a/pkg/sql/logictest/testdata/logic_test/udf
+++ b/pkg/sql/logictest/testdata/logic_test/udf
@@ -3416,3 +3416,13 @@ statement ok
 USE test;
 DROP DATABASE d CASCADE;
 DROP FUNCTION fn;
+
+# Regression test for #100923. Do not attempt to inline an empty UDF and error.
+statement ok
+CREATE FUNCTION f100923() RETURNS BOOL STABLE LANGUAGE SQL AS ''
+
+query B
+SELECT f100923() FROM (VALUES (10), (20)) v(i)
+----
+NULL
+NULL

--- a/pkg/sql/opt/memo/check_expr.go
+++ b/pkg/sql/opt/memo/check_expr.go
@@ -512,8 +512,10 @@ func checkOutputCols(e opt.Expr) {
 		}
 		cols := rel.Relational().OutputCols
 		if set.Intersects(cols) {
+			intersectingCols := set.Intersection(cols)
 			panic(errors.AssertionFailedf(
-				"%s RelExpr children have intersecting columns", redact.Safe(e.Op()),
+				"%s RelExpr children have intersecting columns: %s",
+				redact.Safe(e.Op()), redact.Safe(intersectingCols),
 			))
 		}
 

--- a/pkg/sql/opt/norm/inline_funcs.go
+++ b/pkg/sql/opt/norm/inline_funcs.go
@@ -429,7 +429,7 @@ func (c *CustomFuncs) InlineConstVar(f memo.FiltersExpr) memo.FiltersExpr {
 // challenge because we cannot wrap a set-returning function in a CASE
 // expression, like we do for strict, non-set-returning functions.
 func (c *CustomFuncs) IsInlinableUDF(args memo.ScalarListExpr, udfp *memo.UDFPrivate) bool {
-	if udfp.Volatility == volatility.Volatile || len(udfp.Body) > 1 || udfp.SetReturning {
+	if udfp.Volatility == volatility.Volatile || len(udfp.Body) != 1 || udfp.SetReturning {
 		return false
 	}
 	for i := range args {

--- a/pkg/sql/opt/norm/testdata/rules/inline
+++ b/pkg/sql/opt/norm/testdata/rules/inline
@@ -1343,3 +1343,23 @@ project
  ├── scan a
  └── projections
       └── multi_stmt() [as=multi_stmt:10, immutable, udf]
+
+exec-ddl
+CREATE FUNCTION empty() RETURNS BOOL STABLE LANGUAGE SQL AS ''
+----
+
+# Empty UDFs are not inlined.
+norm expect-not=InlineUDF
+SELECT empty() FROM (VALUES (10), (20)) v(i)
+----
+project
+ ├── columns: empty:2
+ ├── cardinality: [2 - 2]
+ ├── stable
+ ├── fd: ()-->(2)
+ ├── values
+ │    ├── cardinality: [2 - 2]
+ │    ├── ()
+ │    └── ()
+ └── projections
+      └── empty() [as=empty:2, stable, udf]

--- a/pkg/sql/opt/norm/testdata/rules/inline
+++ b/pkg/sql/opt/norm/testdata/rules/inline
@@ -1363,3 +1363,159 @@ project
  │    └── ()
  └── projections
       └── empty() [as=empty:2, stable, udf]
+
+exec-ddl
+CREATE FUNCTION x_0_1_y_2(x INT, y INT) RETURNS BOOL IMMUTABLE LANGUAGE SQL AS $$
+  SELECT x = 0 OR x = 1 OR y = 2
+$$
+----
+
+# Do not inline a UDF when the parameter corresponding to a subquery argument is
+# referenced multiple times.
+# TODO(mgartner): Fix the formatting of subquery UDF arguments.
+norm expect-not=InlineUDF
+SELECT x_0_1_y_2((SELECT v FROM (VALUES (10), (20)) v(v) WHERE v > a.i), 10) FROM a
+----
+project
+ ├── columns: x_0_1_y_2:12
+ ├── immutable
+ ├── scan a
+ │    └── columns: i:2
+ └── projections
+      └── u-d-f: &{x_0_1_y_2 [values
+           ├── columns: "?column?":11(bool)
+           ├── outer: (9,10)
+           ├── cardinality: [1 - 1]
+           ├── stats: [rows=1]
+           ├── key: ()
+           ├── fd: ()-->(11)
+           └── tuple [type=tuple{bool}]
+                └── or [type=bool]
+                     ├── or [type=bool]
+                     │    ├── eq [type=bool]
+                     │    │    ├── variable: x:9 [type=int]
+                     │    │    └── const: 0 [type=int]
+                     │    └── eq [type=bool]
+                     │         ├── variable: x:9 [type=int]
+                     │         └── const: 1 [type=int]
+                     └── eq [type=bool]
+                          ├── variable: y:10 [type=int]
+                          └── const: 2 [type=int]
+          ] [9 10] bool false immutable true} [as=x_0_1_y_2:12, outer=(2), immutable, correlated-subquery, udf]
+           ├── subquery
+           │    └── max1-row
+           │         ├── columns: column1:8!null
+           │         ├── error: "more than one row returned by a subquery used as an expression"
+           │         ├── outer: (2)
+           │         ├── cardinality: [0 - 1]
+           │         ├── key: ()
+           │         ├── fd: ()-->(8)
+           │         └── select
+           │              ├── columns: column1:8!null
+           │              ├── outer: (2)
+           │              ├── cardinality: [0 - 2]
+           │              ├── values
+           │              │    ├── columns: column1:8!null
+           │              │    ├── cardinality: [2 - 2]
+           │              │    ├── (10,)
+           │              │    └── (20,)
+           │              └── filters
+           │                   └── column1:8 > i:2 [outer=(2,8), constraints=(/2: (/NULL - ]; /8: (/NULL - ])]
+           └── 10
+
+# If the subquery argument is referenced only once, then the UDF can be inlined.
+norm expect=InlineUDF
+SELECT x_0_1_y_2(10, (SELECT v FROM (VALUES (10), (20)) v(v) WHERE v > a.i)) FROM a
+----
+project
+ ├── columns: x_0_1_y_2:12
+ ├── ensure-distinct-on
+ │    ├── columns: k:1!null column1:8
+ │    ├── grouping columns: k:1!null
+ │    ├── error: "more than one row returned by a subquery used as an expression"
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(8)
+ │    ├── left-join (cross)
+ │    │    ├── columns: k:1!null i:2 column1:8
+ │    │    ├── fd: (1)-->(2)
+ │    │    ├── scan a
+ │    │    │    ├── columns: k:1!null i:2
+ │    │    │    ├── key: (1)
+ │    │    │    └── fd: (1)-->(2)
+ │    │    ├── values
+ │    │    │    ├── columns: column1:8!null
+ │    │    │    ├── cardinality: [2 - 2]
+ │    │    │    ├── (10,)
+ │    │    │    └── (20,)
+ │    │    └── filters
+ │    │         └── column1:8 > i:2 [outer=(2,8), constraints=(/2: (/NULL - ]; /8: (/NULL - ])]
+ │    └── aggregations
+ │         └── const-agg [as=column1:8, outer=(8)]
+ │              └── column1:8
+ └── projections
+      └── column1:8 = 2 [as=x_0_1_y_2:12, outer=(8)]
+
+exec-ddl
+CREATE FUNCTION x_0_y_1(x INT, y INT) RETURNS BOOL IMMUTABLE LANGUAGE SQL AS $$
+  SELECT x = 0 OR y = 1
+$$
+----
+
+# If two subquery arguments are each referenced once, then the UDF can be
+# inlined.
+norm expect=InlineUDF
+SELECT x_0_y_1(
+  (SELECT v FROM (VALUES (10), (20)) v(v) WHERE v > a.i),
+  (SELECT v FROM (VALUES (10), (20)) v(v) WHERE v > a.i)
+) FROM a
+----
+project
+ ├── columns: x_0_y_1:13
+ ├── ensure-distinct-on
+ │    ├── columns: k:1!null column1:8 column1:9
+ │    ├── grouping columns: k:1!null
+ │    ├── error: "more than one row returned by a subquery used as an expression"
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(8,9)
+ │    ├── left-join (cross)
+ │    │    ├── columns: k:1!null i:2 column1:8 column1:9
+ │    │    ├── fd: (1)-->(2,8)
+ │    │    ├── ensure-distinct-on
+ │    │    │    ├── columns: k:1!null i:2 column1:8
+ │    │    │    ├── grouping columns: k:1!null
+ │    │    │    ├── error: "more than one row returned by a subquery used as an expression"
+ │    │    │    ├── key: (1)
+ │    │    │    ├── fd: (1)-->(2,8)
+ │    │    │    ├── left-join (cross)
+ │    │    │    │    ├── columns: k:1!null i:2 column1:8
+ │    │    │    │    ├── fd: (1)-->(2)
+ │    │    │    │    ├── scan a
+ │    │    │    │    │    ├── columns: k:1!null i:2
+ │    │    │    │    │    ├── key: (1)
+ │    │    │    │    │    └── fd: (1)-->(2)
+ │    │    │    │    ├── values
+ │    │    │    │    │    ├── columns: column1:8!null
+ │    │    │    │    │    ├── cardinality: [2 - 2]
+ │    │    │    │    │    ├── (10,)
+ │    │    │    │    │    └── (20,)
+ │    │    │    │    └── filters
+ │    │    │    │         └── column1:8 > i:2 [outer=(2,8), constraints=(/2: (/NULL - ]; /8: (/NULL - ])]
+ │    │    │    └── aggregations
+ │    │    │         ├── const-agg [as=i:2, outer=(2)]
+ │    │    │         │    └── i:2
+ │    │    │         └── const-agg [as=column1:8, outer=(8)]
+ │    │    │              └── column1:8
+ │    │    ├── values
+ │    │    │    ├── columns: column1:9!null
+ │    │    │    ├── cardinality: [2 - 2]
+ │    │    │    ├── (10,)
+ │    │    │    └── (20,)
+ │    │    └── filters
+ │    │         └── column1:9 > i:2 [outer=(2,9), constraints=(/2: (/NULL - ]; /9: (/NULL - ])]
+ │    └── aggregations
+ │         ├── const-agg [as=column1:8, outer=(8)]
+ │         │    └── column1:8
+ │         └── const-agg [as=column1:9, outer=(9)]
+ │              └── column1:9
+ └── projections
+      └── (column1:8 = 0) OR (column1:9 = 1) [as=x_0_y_1:13, outer=(8,9)]


### PR DESCRIPTION
#### opt: do not attempt to inline empty UDFs

This bug fixes an internal error that could occur when the `InlineUDF`
normalization rule attempted to inline an empty UDF. The bug is fixed by
no longer attempting to inline empty UDFs.

Fixes #100923

Release note (bug fix): A bug has been fixed that caused internal errors
when executing user-defined functions with empty bodies. This bug was
only present in alpha pre-release versions of 23.1.

#### opt: improve error check_expr error message

The error message in `check_expr.go` for the error that occurs when the
children of a relational expression have intersecting column IDs now
includes the columns that intersect. This makes it easier to debug rules
that cause this error.

Release note: None

#### opt: do not inline UDFs with subquery args referenced multiple times

This commit fixes a bug that caused errors in test builds and
potentially incorrect results in release builds when invoking a UDF with
a subquery argument that corresponds to a parameter referenced multiple
times in the UDF body. This bug is fixed by no longer attempting to
inline these UDF invocations.

Fixes #100915

Release note (bug fix): A bug has been fixed that caused errors in test
builds and potentially incorrect results in release builds when invoking
a user-defined function with a subquery argument. This bug was only
present in alpha pre-release versions of 23.1.
