### PR TITLE
rpc: unskip TestGRPCKeepaliveFailureFailsInflightRPCs

### DIFF
--- a/pkg/rpc/context_test.go
+++ b/pkg/rpc/context_test.go
@@ -1654,7 +1654,7 @@ func TestRemoteOffsetUnhealthy(t *testing.T) {
 // its response stream even if it doesn't get any new requests.
 func TestGRPCKeepaliveFailureFailsInflightRPCs(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	skip.WithIssue(t, 51800, "Takes too long given https://github.com/grpc/grpc-go/pull/2642")
+	skip.UnderShort(t, "Takes too long given https://github.com/grpc/grpc-go/pull/2642")
 
 	sc := log.Scope(t)
 	defer sc.Close(t)


### PR DESCRIPTION
This test is useful and while it takes longer to run it is not flakey. It should be included in non-short test runs.

Fixes: #51800
Epic: none

Release note: None