### PR TITLE
storage: encode engine keys passed as checkpoint bounds

### DIFF
--- a/pkg/storage/open.go
+++ b/pkg/storage/open.go
@@ -107,6 +107,17 @@ func BlockSize(size int) ConfigOption {
 	}
 }
 
+// TargetFileSize sets the target file size across all levels of the LSM,
+// primarily for testing purposes.
+func TargetFileSize(size int64) ConfigOption {
+	return func(cfg *engineConfig) error {
+		for i := range cfg.Opts.Levels {
+			cfg.Opts.Levels[i].TargetFileSize = size
+		}
+		return nil
+	}
+}
+
 // MaxWriterConcurrency sets the concurrency of the sstable Writers. A concurrency
 // of 0 implies no parallelism in the Writer, and a concurrency of 1 or more implies
 // parallelism in the Writer. Currently, there's no difference between a concurrency

--- a/pkg/storage/pebble.go
+++ b/pkg/storage/pebble.go
@@ -1950,7 +1950,10 @@ func (p *Pebble) CreateCheckpoint(dir string, spans []roachpb.Span) error {
 	if l := len(spans); l > 0 {
 		s := make([]pebble.CheckpointSpan, 0, l)
 		for _, span := range spans {
-			s = append(s, pebble.CheckpointSpan{Start: span.Key, End: span.EndKey})
+			s = append(s, pebble.CheckpointSpan{
+				Start: EngineKey{Key: span.Key}.Encode(),
+				End:   EngineKey{Key: span.EndKey}.Encode(),
+			})
 		}
 		opts = append(opts, pebble.WithRestrictToSpans(s))
 	}


### PR DESCRIPTION
Previously, CreateCheckpoint would restrict a checkpoint by passing invalid keys to Pebble. These keys were unencoded `roachpb.Key`s without a version length last byte.

The unit test is skipped, because it reveals another ununderstood problem.

Close #100919.
Informs #100935.
Epic: none
Release note: None