### PR TITLE
randgen: Add tsquery/tsvector types to RandDatumSimple

### DIFF
--- a/pkg/sql/randgen/datum.go
+++ b/pkg/sql/randgen/datum.go
@@ -472,6 +472,10 @@ func RandDatumSimple(rng *rand.Rand, typ *types.T) tree.Datum {
 		datum = tree.NewDUuid(tree.DUuid{
 			UUID: uuid.FromUint128(uint128.FromInts(0, uint64(rng.Intn(simpleRange)))),
 		})
+	case types.TSQueryFamily:
+		datum = tree.NewDTSQuery(tsearch.RandomTSQuery(rng))
+	case types.TSVectorFamily:
+		datum = tree.NewDTSVector(tsearch.RandomTSVector(rng))
 	}
 	return datum
 }


### PR DESCRIPTION
This API is used in sqlsmith and this exposes this new functionality to
all our sqlsmith based random testing.

Epic: none
Release note: None
