### PR TITLE
cli: trash `TestNoLinkForbidden`

### DIFF
--- a/pkg/cli/BUILD.bazel
+++ b/pkg/cli/BUILD.bazel
@@ -388,7 +388,6 @@ go_test(
         "//pkg/sql/tests",
         "//pkg/storage",
         "//pkg/testutils",
-        "//pkg/testutils/buildutil",
         "//pkg/testutils/datapathutils",
         "//pkg/testutils/serverutils",
         "//pkg/testutils/skip",

--- a/pkg/cli/flags_test.go
+++ b/pkg/cli/flags_test.go
@@ -31,7 +31,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/security/securitytest"
 	"github.com/cockroachdb/cockroach/pkg/server/status"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
-	"github.com/cockroachdb/cockroach/pkg/testutils/buildutil"
 	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
@@ -55,25 +54,6 @@ func TestStdFlagToPflag(t *testing.T) {
 			t.Errorf("unable to find \"%s\"", f.Name)
 		}
 	})
-}
-
-func TestNoLinkForbidden(t *testing.T) {
-	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
-
-	// Verify that the cockroach binary doesn't depend on certain packages.
-	buildutil.VerifyNoImports(t,
-		"github.com/cockroachdb/cockroach/pkg/cmd/cockroach", true,
-		[]string{
-			"testing",  // defines flags
-			"go/build", // probably not something we want in the main binary
-		},
-		[]string{},
-		// The errors library uses go/build to determine
-		// the list of source directories (used to strip the source prefix
-		// in stack trace reports).
-		"github.com/cockroachdb/errors/withstack",
-	)
 }
 
 func TestCacheFlagValue(t *testing.T) {


### PR DESCRIPTION
This test does not work:
1. The test [has been broken](https://github.com/cockroachdb/cockroach/issues/74119) for years.
2. The test is not sensible in the Bazel world anyway, and under remote execution the test fails with an error like the following:

```
 build.go:59: go/build: go list github.com/cockroachdb/cockroach/pkg/cmd/cockroach: fork/exec GOROOT/bin/go: no such file or directory
```

The bug to replace this test with working functionality based on Bazel is #81526.

Epic: CRDB-17165
Release note: None
Closes #74119.