### PR TITLE
release-22.2: storage: encode ApproximateDiskBytes keys

### DIFF
--- a/pkg/storage/pebble.go
+++ b/pkg/storage/pebble.go
@@ -1731,7 +1731,9 @@ func (p *Pebble) PreIngestDelay(ctx context.Context) {
 
 // ApproximateDiskBytes implements the Engine interface.
 func (p *Pebble) ApproximateDiskBytes(from, to roachpb.Key) (uint64, error) {
-	count, err := p.db.EstimateDiskUsage(from, to)
+	fromEncoded := EngineKey{Key: from}.Encode()
+	toEncoded := EngineKey{Key: to}.Encode()
+	count, err := p.db.EstimateDiskUsage(fromEncoded, toEncoded)
 	if err != nil {
 		return 0, err
 	}


### PR DESCRIPTION
22.2 backport of #100870.

----

Previously Engine.ApproximateDiskBytes accepted two roachpb.Keys for bounds which were passed directly to Pebble without additional encoding. When used with EngineCompare, Cockroach would incorrectly try to interpret the final byte as a version length. This could result in incorrect size calculations or ApproximateDiskBytes erroring on out-of-order span bounds.

Epic: None
Release note (bug fix): Fix a bug whereby some tables' physical disk space could not be calculated.
Release justification: Low-risk bug fix.