### PR TITLE
release-22.2: schemachanger: fixed a bug dropping a column used in expression index

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/alter_table
+++ b/pkg/sql/logictest/testdata/logic_test/alter_table
@@ -2839,3 +2839,27 @@ INSERT INTO t_98269 VALUES (0);
 
 statement error pgcode 0A000 .* cluster_logical_timestamp\(\): nil txn in cluster context
 ALTER TABLE t_98269 ADD COLUMN j DECIMAL NOT NULL DEFAULT cluster_logical_timestamp();
+
+subtest 99764
+
+statement ok
+CREATE TABLE t_99764 (i INT PRIMARY KEY, j INT, UNIQUE (j, CAST(j AS STRING)), FAMILY "primary" (i, j));
+set sql_safe_updates = false;
+
+# Dropping `j` should also drop the unique index as well as the expression column.
+# Legacy schema change is incapable to do this.
+skipif config local-legacy-schema-changer
+skipif config local-mixed-22.1-22.2
+statement ok
+ALTER TABLE t_99764 DROP COLUMN j CASCADE;
+
+skipif config local-legacy-schema-changer
+skipif config local-mixed-22.1-22.2
+query TT
+show create table t_99764
+----
+t_99764  CREATE TABLE public.t_99764 (
+             i INT8 NOT NULL,
+             CONSTRAINT t_99764_pkey PRIMARY KEY (i ASC)
+         )
+

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_table_drop_column.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_table_drop_column.go
@@ -205,7 +205,10 @@ func dropColumn(
 			})
 		case *scpb.SecondaryIndex:
 			indexElts := b.QueryByID(e.TableID).Filter(hasIndexIDAttrFilter(e.IndexID))
-			_, _, indexName := scpb.FindIndexName(indexElts.Filter(publicTargetFilter))
+			_, indexTargetStatus, indexName := scpb.FindIndexName(indexElts)
+			if indexTargetStatus == scpb.ToAbsent {
+				return
+			}
 			name := tree.TableIndexName{
 				Table: *tn,
 				Index: tree.UnrestrictedName(indexName.Name),


### PR DESCRIPTION
Backport 1/1 commits from #100750.

/cc @cockroachdb/release

---

Previously, if we are dropping a column used in an index that includes other columns, we will hit a nil-pointer dereference error. The root cause here is that we might be dropping the same secondary index twice without enough "idempotency" checks.

Epic: None
Fixes: #99764
Release justification: bug fix
Release note (bug fix): Fixed a bug where dropping a column cascade when that column is used in an index that involves other expression column caused a panic.
