### PR TITLE
sql: add issue number for unimplemented udf default params

### DIFF
--- a/pkg/sql/create_function.go
+++ b/pkg/sql/create_function.go
@@ -457,7 +457,7 @@ func makeFunctionParam(
 	}
 
 	if param.DefaultVal != nil {
-		return descpb.FunctionDescriptor_Parameter{}, unimplemented.New("CREATE FUNCTION argument", "default value")
+		return descpb.FunctionDescriptor_Parameter{}, unimplemented.NewWithIssue(100962, "default value")
 	}
 
 	return pbParam, nil

--- a/pkg/sql/logictest/testdata/logic_test/udf
+++ b/pkg/sql/logictest/testdata/logic_test/udf
@@ -79,6 +79,10 @@ CREATE FUNCTION err(b BOOL) RETURNS INT LANGUAGE SQL AS 'SELECT b'
 statement error return type mismatch in function declared to return bool\nDETAIL: Actual return type is int
 CREATE FUNCTION err(i INT, j INT) RETURNS BOOL LANGUAGE SQL AS 'SELECT i - j'
 
+# TODO(100962): Add support for default parameters.
+statement error pgcode 0A000 unimplemented: default value
+CREATE FUNCTION err(i INT, j INT DEFAULT 2) RETURNS INT LANGUAGE SQL AS 'SELECT i - j'
+
 # Make sure using table name as tuple type name works properly.
 # It should pass the return type validation and stored as a tuple type.
 statement ok

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/create_function.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/create_function.go
@@ -69,7 +69,7 @@ func CreateFunction(b BuildCtx, n *tree.CreateFunction) {
 		// TODO(chengxiong): create `FunctionParamDefaultExpression` element when
 		// default parameter default expression is enabled.
 		if param.DefaultVal != nil {
-			panic(unimplemented.New("CREATE FUNCTION argument", "default value"))
+			panic(unimplemented.NewWithIssue(100962, "default value"))
 		}
 		paramCls, err := funcinfo.ParamClassToProto(param.Class)
 		if err != nil {


### PR DESCRIPTION
Adds a link to an issue number for UDF DEFAULT parameters, which are not currently supported.

Epic: None
Informs: #100962
Fixes: #99881

Release note: None