### PR TITLE
pgwire: reduce log severity of parsing failures

### DIFF
--- a/pkg/sql/pgwire/conn.go
+++ b/pkg/sql/pgwire/conn.go
@@ -833,7 +833,7 @@ func (c *conn) handleSimpleQuery(
 	startParse := timeutil.Now()
 	stmts, err := c.parser.ParseWithInt(query, unqualifiedIntSize)
 	if err != nil {
-		log.SqlExec.Errorf(ctx, "failed to parse simple query: %s", query)
+		log.SqlExec.Infof(ctx, "could not parse simple query: %s", query)
 		return c.stmtBuf.Push(ctx, sql.SendError{Err: err})
 	}
 	endParse := timeutil.Now()
@@ -971,7 +971,7 @@ func (c *conn) handleParse(
 	startParse := timeutil.Now()
 	stmts, err := c.parser.ParseWithInt(query, nakedIntSize)
 	if err != nil {
-		log.SqlExec.Errorf(ctx, "failed to parse: %s", query)
+		log.SqlExec.Infof(ctx, "could not parse: %s", query)
 		return c.stmtBuf.Push(ctx, sql.SendError{Err: err})
 	}
 	if len(stmts) > 1 {


### PR DESCRIPTION
fixes https://github.com/cockroachdb/cockroach/issues/101005

These would previously be logged as ERROR, but that's not desirable because from an operator perspective, errors should only include things that are exceptional conditions for CockroachDB.

Release note (general change): Queries with invalid syntax are now logged at the INFO level in the SQL_EXEC log channel. Previously these were logged at the ERROR level.