### PR TITLE
kvserver: support multiple priority ranges in Raft scheduler

### DIFF
--- a/pkg/keys/spans.go
+++ b/pkg/keys/spans.go
@@ -19,6 +19,9 @@ var (
 	// Meta1Span holds all first level addressing records.
 	Meta1Span = roachpb.Span{Key: roachpb.KeyMin, EndKey: Meta2Prefix}
 
+	// MetaSpan holds all first- and second-level addressing records.
+	MetaSpan = roachpb.Span{Key: MetaMin, EndKey: MetaMax}
+
 	// Meta2MaxSpan begins at key Meta2KeyMax with the last entry in the second
 	// level addressing keyspace. The rest of the span is always empty. We cannot
 	// split at this starting key or between it and MetaMax.

--- a/pkg/kv/kvserver/BUILD.bazel
+++ b/pkg/kv/kvserver/BUILD.bazel
@@ -465,6 +465,7 @@ go_test(
         "//pkg/util/protoutil",
         "//pkg/util/quotapool",
         "//pkg/util/randutil",
+        "//pkg/util/rangedesc",
         "//pkg/util/retry",
         "//pkg/util/stop",
         "//pkg/util/syncutil",

--- a/pkg/kv/kvserver/client_replica_test.go
+++ b/pkg/kv/kvserver/client_replica_test.go
@@ -5061,8 +5061,7 @@ func TestRaftSchedulerPrioritizesNodeLiveness(t *testing.T) {
 	livenessRangeID := livenessRepl.RangeID
 
 	// Assert that the node liveness range is prioritized.
-	priorityID := store.RaftSchedulerPriorityID()
-	require.Equal(t, livenessRangeID, priorityID)
+	require.Equal(t, []roachpb.RangeID{livenessRangeID}, store.RaftSchedulerPriorityIDs())
 }
 
 func setupDBAndWriteAAndB(t *testing.T) (serverutils.TestServerInterface, *kv.DB) {

--- a/pkg/kv/kvserver/client_replica_test.go
+++ b/pkg/kv/kvserver/client_replica_test.go
@@ -5045,25 +5045,6 @@ func TestRangeMigration(t *testing.T) {
 	assertVersion(endV)
 }
 
-func TestRaftSchedulerPrioritizesNodeLiveness(t *testing.T) {
-	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
-
-	ctx := context.Background()
-	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
-	defer s.Stopper().Stop(ctx)
-
-	store, err := s.GetStores().(*kvserver.Stores).GetStore(s.GetFirstStoreID())
-	require.NoError(t, err)
-
-	// Determine the node liveness range ID.
-	livenessRepl := store.LookupReplica(roachpb.RKey(keys.NodeLivenessPrefix))
-	livenessRangeID := livenessRepl.RangeID
-
-	// Assert that the node liveness range is prioritized.
-	require.Equal(t, []roachpb.RangeID{livenessRangeID}, store.RaftSchedulerPriorityIDs())
-}
-
 func setupDBAndWriteAAndB(t *testing.T) (serverutils.TestServerInterface, *kv.DB) {
 	ctx := context.Background()
 	args := base.TestServerArgs{}

--- a/pkg/kv/kvserver/helpers_test.go
+++ b/pkg/kv/kvserver/helpers_test.go
@@ -209,9 +209,9 @@ func (s *Store) ReservationCount() int {
 	return int(s.cfg.SnapshotApplyLimit) - s.snapshotApplyQueue.AvailableLen()
 }
 
-// RaftSchedulerPriorityID returns the Raft scheduler's prioritized range.
-func (s *Store) RaftSchedulerPriorityID() roachpb.RangeID {
-	return s.scheduler.PriorityID()
+// RaftSchedulerPriorityID returns the Raft scheduler's prioritized ranges.
+func (s *Store) RaftSchedulerPriorityIDs() []roachpb.RangeID {
+	return s.scheduler.PriorityIDs()
 }
 
 func NewTestStorePool(cfg StoreConfig) *storepool.StorePool {

--- a/pkg/kv/kvserver/replica_init.go
+++ b/pkg/kv/kvserver/replica_init.go
@@ -400,6 +400,6 @@ func (r *Replica) setDescLockedRaftMuLocked(ctx context.Context, desc *roachpb.R
 	// Prioritize the NodeLiveness Range in the Raft scheduler above all other
 	// Ranges to ensure that liveness never sees high Raft scheduler latency.
 	if bytes.HasPrefix(desc.StartKey, keys.NodeLivenessPrefix) {
-		r.store.scheduler.SetPriorityID(desc.RangeID)
+		r.store.scheduler.AddPriorityID(desc.RangeID)
 	}
 }

--- a/pkg/kv/kvserver/replica_init.go
+++ b/pkg/kv/kvserver/replica_init.go
@@ -11,7 +11,6 @@
 package kvserver
 
 import (
-	"bytes"
 	"context"
 	"time"
 
@@ -397,9 +396,15 @@ func (r *Replica) setDescLockedRaftMuLocked(ctx context.Context, desc *roachpb.R
 	r.concMgr.OnRangeDescUpdated(desc)
 	r.mu.state.Desc = desc
 
-	// Prioritize the NodeLiveness Range in the Raft scheduler above all other
-	// Ranges to ensure that liveness never sees high Raft scheduler latency.
-	if bytes.HasPrefix(desc.StartKey, keys.NodeLivenessPrefix) {
-		r.store.scheduler.AddPriorityID(desc.RangeID)
+	// Give the liveness and meta ranges high priority in the Raft scheduler, to
+	// avoid head-of-line blocking and high scheduling latency.
+	for _, span := range []roachpb.Span{keys.NodeLivenessSpan, keys.MetaSpan} {
+		rspan, err := keys.SpanAddr(span)
+		if err != nil {
+			log.Fatalf(ctx, "can't resolve system span %s: %s", span, err)
+		}
+		if _, err := desc.RSpan().Intersect(rspan); err == nil {
+			r.store.scheduler.AddPriorityID(desc.RangeID)
+		}
 	}
 }

--- a/pkg/kv/kvserver/scheduler.go
+++ b/pkg/kv/kvserver/scheduler.go
@@ -14,8 +14,8 @@ import (
 	"container/list"
 	"context"
 	"fmt"
-	"runtime/debug"
 	"sync"
+	"unsafe"
 
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/util"
@@ -26,6 +26,11 @@ import (
 )
 
 const rangeIDChunkSize = 1000
+
+// priorityIDsValue is a placeholder value for raftScheduler.priorityIDs. IntMap
+// requires an unsafe.Pointer value, but we don't care about the value (only
+// the key), so we can reuse the same allocation.
+var priorityIDsValue = unsafe.Pointer(new(bool))
 
 type rangeIDChunk struct {
 	// Valid contents are buf[rd:wr], read at buf[rd], write at buf[wr].
@@ -65,28 +70,15 @@ func (c *rangeIDChunk) Len() int {
 // that would occur if a slice were used (the copying would occur on slice
 // reallocation).
 //
-// The queue has a naive understanding of priority and fairness. For the most
-// part, it implements a FIFO queueing policy with no prioritization of some
-// ranges over others. However, the queue can be configured with up to one
-// high-priority range, which will always be placed at the front when added.
+// The queue implements a FIFO queueing policy with no prioritization of some
+// ranges over others.
 type rangeIDQueue struct {
-	len int
-
-	// Default priority.
+	len    int
 	chunks list.List
-
-	// High priority.
-	priorityID     roachpb.RangeID
-	priorityStack  []byte // for debugging in case of assertion failure; see #75939
-	priorityQueued bool
 }
 
 func (q *rangeIDQueue) Push(id roachpb.RangeID) {
 	q.len++
-	if q.priorityID == id {
-		q.priorityQueued = true
-		return
-	}
 	if q.chunks.Len() == 0 || q.back().WriteCap() == 0 {
 		q.chunks.PushBack(&rangeIDChunk{})
 	}
@@ -102,10 +94,6 @@ func (q *rangeIDQueue) PopFront() (roachpb.RangeID, bool) {
 		return 0, false
 	}
 	q.len--
-	if q.priorityQueued {
-		q.priorityQueued = false
-		return q.priorityID, true
-	}
 	frontElem := q.chunks.Front()
 	front := frontElem.Value.(*rangeIDChunk)
 	id, ok := front.PopFront()
@@ -120,16 +108,6 @@ func (q *rangeIDQueue) PopFront() (roachpb.RangeID, bool) {
 
 func (q *rangeIDQueue) Len() int {
 	return q.len
-}
-
-func (q *rangeIDQueue) SetPriorityID(id roachpb.RangeID) {
-	if q.priorityID != 0 && q.priorityID != id {
-		panic(fmt.Sprintf(
-			"priority range ID already set: old=%d, new=%d, first set at:\n\n%s",
-			q.priorityID, id, q.priorityStack))
-	}
-	q.priorityStack = debug.Stack()
-	q.priorityID = id
 }
 
 func (q *rangeIDQueue) back() *rangeIDChunk {
@@ -185,38 +163,66 @@ var raftSchedulerBatchPool = sync.Pool{
 
 // raftSchedulerBatch is a batch of range IDs to enqueue. It enables
 // efficient per-shard enqueueing.
-type raftSchedulerBatch [][]roachpb.RangeID // by shard
+type raftSchedulerBatch struct {
+	rangeIDs    [][]roachpb.RangeID // by shard
+	priorityIDs map[roachpb.RangeID]bool
+}
 
-func newRaftSchedulerBatch(numShards int) raftSchedulerBatch {
+func newRaftSchedulerBatch(numShards int, priorityIDs *syncutil.IntMap) *raftSchedulerBatch {
 	b := raftSchedulerBatchPool.Get().(*raftSchedulerBatch)
-	if len(*b) != numShards {
-		*b = make([][]roachpb.RangeID, numShards)
+	if cap(b.rangeIDs) >= numShards {
+		b.rangeIDs = b.rangeIDs[:numShards]
+	} else {
+		b.rangeIDs = make([][]roachpb.RangeID, numShards)
 	}
-	return *b
-}
-
-func (b raftSchedulerBatch) Add(id roachpb.RangeID) {
-	shard := int(id) % len(b)
-	b[shard] = append(b[shard], id)
-}
-
-func (b raftSchedulerBatch) Reset() {
-	for i := range b {
-		b[i] = b[i][:0]
+	if b.priorityIDs == nil {
+		b.priorityIDs = make(map[roachpb.RangeID]bool, 8) // expect few ranges, if any
 	}
+	// Cache the priority range IDs in an owned map, since we expect this to be
+	// very small or empty and we do a lookup for every Add() call.
+	priorityIDs.Range(func(id int64, _ unsafe.Pointer) bool {
+		b.priorityIDs[roachpb.RangeID(id)] = true
+		return true
+	})
+	return b
 }
 
-func (b raftSchedulerBatch) Close() {
-	b.Reset()
-	raftSchedulerBatchPool.Put(&b)
+func (b *raftSchedulerBatch) Add(id roachpb.RangeID) {
+	shardIdx := shardIndex(id, len(b.rangeIDs), b.priorityIDs[id])
+	b.rangeIDs[shardIdx] = append(b.rangeIDs[shardIdx], id)
+}
+
+func (b *raftSchedulerBatch) Close() {
+	for i := range b.rangeIDs {
+		b.rangeIDs[i] = b.rangeIDs[i][:0]
+	}
+	for i := range b.priorityIDs {
+		delete(b.priorityIDs, i)
+	}
+	raftSchedulerBatchPool.Put(b)
+}
+
+// shardIndex returns the raftScheduler shard index of the given range ID based
+// on the shard count and the range's priority. Priority ranges are assigned to
+// the reserved shard 0, other ranges are modulo range ID (ignoring shard 0).
+// numShards will always be 2 or more (1 priority, 1 regular).
+func shardIndex(id roachpb.RangeID, numShards int, priority bool) int {
+	if priority {
+		return 0
+	}
+	return 1 + int(int64(id)%int64(numShards-1)) // int64s to avoid overflow
 }
 
 type raftScheduler struct {
 	ambientContext log.AmbientContext
 	processor      raftProcessor
 	metrics        *StoreMetrics
-	shards         []*raftSchedulerShard // RangeID % len(shards)
-	done           sync.WaitGroup
+	// shards contains scheduler shards. Ranges and workers are allocated to
+	// separate shards to reduce contention at high worker counts. Allocation
+	// is modulo range ID, with shard 0 reserved for priority ranges.
+	shards      []*raftSchedulerShard // 1 + RangeID % (len(shards) - 1)
+	priorityIDs syncutil.IntMap
+	done        sync.WaitGroup
 }
 
 type raftSchedulerShard struct {
@@ -235,6 +241,7 @@ func newRaftScheduler(
 	processor raftProcessor,
 	numWorkers int,
 	shardSize int,
+	priorityWorkers int,
 	maxTicks int,
 ) *raftScheduler {
 	s := &raftScheduler{
@@ -242,9 +249,17 @@ func newRaftScheduler(
 		processor:      processor,
 		metrics:        metrics,
 	}
+
+	// Priority shard at index 0.
+	if priorityWorkers <= 0 {
+		priorityWorkers = 1
+	}
+	s.shards = append(s.shards, newRaftSchedulerShard(priorityWorkers, maxTicks))
+
+	// Regular shards, excluding priority shard.
 	numShards := 1
 	if shardSize > 0 && numWorkers > shardSize {
-		numShards = (numWorkers-1)/shardSize + 1
+		numShards = (numWorkers-1)/shardSize + 1 // ceiling division
 	}
 	for i := 0; i < numShards; i++ {
 		shardWorkers := numWorkers / numShards
@@ -254,15 +269,19 @@ func newRaftScheduler(
 		if shardWorkers <= 0 {
 			shardWorkers = 1 // ensure we always have a worker
 		}
-		shard := &raftSchedulerShard{
-			state:      map[roachpb.RangeID]raftScheduleState{},
-			numWorkers: shardWorkers,
-			maxTicks:   maxTicks,
-		}
-		shard.cond = sync.NewCond(&shard.Mutex)
-		s.shards = append(s.shards, shard)
+		s.shards = append(s.shards, newRaftSchedulerShard(shardWorkers, maxTicks))
 	}
 	return s
+}
+
+func newRaftSchedulerShard(numWorkers, maxTicks int) *raftSchedulerShard {
+	shard := &raftSchedulerShard{
+		state:      map[roachpb.RangeID]raftScheduleState{},
+		numWorkers: numWorkers,
+		maxTicks:   maxTicks,
+	}
+	shard.cond = sync.NewCond(&shard.Mutex)
+	return shard
 }
 
 func (s *raftScheduler) Start(stopper *stop.Stopper) {
@@ -313,20 +332,24 @@ func (s *raftScheduler) Wait(context.Context) {
 	s.done.Wait()
 }
 
-// SetPriorityID configures the single range that the scheduler will prioritize
-// above others. Once set, callers are not permitted to change this value.
-func (s *raftScheduler) SetPriorityID(id roachpb.RangeID) {
-	for _, shard := range s.shards {
-		shard.Lock()
-		shard.queue.SetPriorityID(id)
-		shard.Unlock()
-	}
+// AddPriorityID adds the given range ID to the set of priority ranges.
+func (s *raftScheduler) AddPriorityID(rangeID roachpb.RangeID) {
+	s.priorityIDs.Store(int64(rangeID), priorityIDsValue)
 }
 
-func (s *raftScheduler) PriorityID() roachpb.RangeID {
-	s.shards[0].Lock()
-	defer s.shards[0].Unlock()
-	return s.shards[0].queue.priorityID
+// RemovePriorityID removes the given range ID from the set of priority ranges.
+func (s *raftScheduler) RemovePriorityID(rangeID roachpb.RangeID) {
+	s.priorityIDs.Delete(int64(rangeID))
+}
+
+// PriorityIDs returns the current priority ranges.
+func (s *raftScheduler) PriorityIDs() []roachpb.RangeID {
+	var priorityIDs []roachpb.RangeID
+	s.priorityIDs.Range(func(id int64, _ unsafe.Pointer) bool {
+		priorityIDs = append(priorityIDs, roachpb.RangeID(id))
+		return true
+	})
+	return priorityIDs
 }
 
 func (ss *raftSchedulerShard) worker(
@@ -431,8 +454,8 @@ func (ss *raftSchedulerShard) worker(
 // NewEnqueueBatch creates a new range ID batch for enqueueing via
 // EnqueueRaft(Ticks|Requests). The caller must call Close() on the batch when
 // done.
-func (s *raftScheduler) NewEnqueueBatch() raftSchedulerBatch {
-	return newRaftSchedulerBatch(len(s.shards))
+func (s *raftScheduler) NewEnqueueBatch() *raftSchedulerBatch {
+	return newRaftSchedulerBatch(len(s.shards), &s.priorityIDs)
 }
 
 func (ss *raftSchedulerShard) enqueue1Locked(
@@ -465,7 +488,9 @@ func (ss *raftSchedulerShard) enqueue1Locked(
 
 func (s *raftScheduler) enqueue1(addFlags raftScheduleFlags, id roachpb.RangeID) {
 	now := nowNanos()
-	shard := s.shards[int(id)%len(s.shards)]
+	_, hasPriority := s.priorityIDs.Load(int64(id))
+	shardIdx := shardIndex(id, len(s.shards), hasPriority)
+	shard := s.shards[shardIdx]
 	shard.Lock()
 	n := shard.enqueue1Locked(addFlags, id, now)
 	shard.Unlock()
@@ -496,10 +521,10 @@ func (ss *raftSchedulerShard) enqueueN(addFlags raftScheduleFlags, ids ...roachp
 	return count
 }
 
-func (s *raftScheduler) enqueueBatch(addFlags raftScheduleFlags, batch raftSchedulerBatch) {
-	for i, ids := range batch {
-		count := s.shards[i].enqueueN(addFlags, ids...)
-		s.shards[i].signal(count)
+func (s *raftScheduler) enqueueBatch(addFlags raftScheduleFlags, batch *raftSchedulerBatch) {
+	for shardIdx, ids := range batch.rangeIDs {
+		count := s.shards[shardIdx].enqueueN(addFlags, ids...)
+		s.shards[shardIdx].signal(count)
 	}
 }
 
@@ -521,11 +546,11 @@ func (s *raftScheduler) EnqueueRaftRequest(id roachpb.RangeID) {
 	s.enqueue1(stateRaftRequest, id)
 }
 
-func (s *raftScheduler) EnqueueRaftRequests(batch raftSchedulerBatch) {
+func (s *raftScheduler) EnqueueRaftRequests(batch *raftSchedulerBatch) {
 	s.enqueueBatch(stateRaftRequest, batch)
 }
 
-func (s *raftScheduler) EnqueueRaftTicks(batch raftSchedulerBatch) {
+func (s *raftScheduler) EnqueueRaftTicks(batch *raftSchedulerBatch) {
 	s.enqueueBatch(stateRaftTick, batch)
 }
 

--- a/pkg/kv/kvserver/scheduler_test.go
+++ b/pkg/kv/kvserver/scheduler_test.go
@@ -16,6 +16,7 @@ import (
 	"fmt"
 	"sort"
 	"testing"
+	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
@@ -125,48 +126,13 @@ func TestRangeIDQueue(t *testing.T) {
 	}
 }
 
-func TestRangeIDQueuePrioritization(t *testing.T) {
-	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
-
-	var q rangeIDQueue
-	for _, withPriority := range []bool{false, true} {
-		if withPriority {
-			q.SetPriorityID(3)
-		}
-
-		// Push 5 ranges in order, then pop them off.
-		for i := 1; i <= 5; i++ {
-			q.Push(roachpb.RangeID(i))
-			require.Equal(t, i, q.Len())
-		}
-		var popped []int
-		for i := 5; ; i-- {
-			require.Equal(t, i, q.Len())
-			id, ok := q.PopFront()
-			if !ok {
-				require.Equal(t, i, 0)
-				break
-			}
-			popped = append(popped, int(id))
-		}
-
-		// Assert pop order.
-		if withPriority {
-			require.Equal(t, []int{3, 1, 2, 4, 5}, popped)
-		} else {
-			require.Equal(t, []int{1, 2, 3, 4, 5}, popped)
-		}
-	}
-}
-
 type testProcessor struct {
 	mu struct {
 		syncutil.Mutex
 		raftReady   map[roachpb.RangeID]int
 		raftRequest map[roachpb.RangeID]int
 		raftTick    map[roachpb.RangeID]int
-		ready       func()
+		ready       func(roachpb.RangeID)
 	}
 }
 
@@ -178,7 +144,7 @@ func newTestProcessor() *testProcessor {
 	return p
 }
 
-func (p *testProcessor) onReady(f func()) {
+func (p *testProcessor) onReady(f func(roachpb.RangeID)) {
 	p.mu.Lock()
 	p.mu.ready = f
 	p.mu.Unlock()
@@ -187,11 +153,12 @@ func (p *testProcessor) onReady(f func()) {
 func (p *testProcessor) processReady(rangeID roachpb.RangeID) {
 	p.mu.Lock()
 	p.mu.raftReady[rangeID]++
-	if p.mu.ready != nil {
-		p.mu.ready()
-		p.mu.ready = nil
-	}
+	onReady := p.mu.ready
+	p.mu.ready = nil
 	p.mu.Unlock()
+	if onReady != nil {
+		onReady(rangeID)
+	}
 }
 
 func (p *testProcessor) processRequestQueue(_ context.Context, rangeID roachpb.RangeID) bool {
@@ -206,6 +173,12 @@ func (p *testProcessor) processTick(_ context.Context, rangeID roachpb.RangeID) 
 	p.mu.raftTick[rangeID]++
 	p.mu.Unlock()
 	return false
+}
+
+func (p *testProcessor) readyCount(rangeID roachpb.RangeID) int {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.mu.raftReady[rangeID]
 }
 
 func (p *testProcessor) countsLocked(m map[roachpb.RangeID]int) string {
@@ -248,7 +221,7 @@ func TestSchedulerLoop(t *testing.T) {
 
 	m := newStoreMetrics(metric.TestSampleInterval)
 	p := newTestProcessor()
-	s := newRaftScheduler(log.MakeTestingAmbientContext(stopper.Tracer()), m, p, 1, 1, 1)
+	s := newRaftScheduler(log.MakeTestingAmbientContext(stopper.Tracer()), m, p, 1, 1, 1, 1)
 	s.Start(stopper)
 
 	batch := s.NewEnqueueBatch()
@@ -283,7 +256,7 @@ func TestSchedulerBuffering(t *testing.T) {
 
 	m := newStoreMetrics(metric.TestSampleInterval)
 	p := newTestProcessor()
-	s := newRaftScheduler(log.MakeTestingAmbientContext(stopper.Tracer()), m, p, 1, 1, 5)
+	s := newRaftScheduler(log.MakeTestingAmbientContext(stopper.Tracer()), m, p, 1, 1, 1, 5)
 	s.Start(stopper)
 
 	testCases := []struct {
@@ -310,7 +283,7 @@ func TestSchedulerBuffering(t *testing.T) {
 		var started, done chan struct{}
 		if c.slow {
 			started, done = make(chan struct{}), make(chan struct{})
-			p.onReady(func() {
+			p.onReady(func(roachpb.RangeID) {
 				close(started)
 				<-done
 			})
@@ -352,51 +325,62 @@ func TestNewSchedulerShards(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
+	pri := 2 // priority workers
+
 	testcases := []struct {
-		workers      int
-		shardSize    int
-		expectShards []int
+		priorityWorkers int
+		workers         int
+		shardSize       int
+		expectShards    []int
 	}{
-		// NB: We balance workers across shards instead of filling up shards. We
-		// assume ranges are evenly distributed across shards, and want ranges to
-		// have about the same number of workers available on average.
-		{-1, -1, []int{1}},
-		{0, 0, []int{1}},
-		{1, -1, []int{1}},
-		{1, 0, []int{1}},
-		{1, 1, []int{1}},
-		{1, 2, []int{1}},
-		{2, 2, []int{2}},
-		{3, 2, []int{2, 1}},
-		{1, 3, []int{1}},
-		{2, 3, []int{2}},
-		{3, 3, []int{3}},
-		{4, 3, []int{2, 2}},
-		{5, 3, []int{3, 2}},
-		{6, 3, []int{3, 3}},
-		{7, 3, []int{3, 2, 2}},
-		{8, 3, []int{3, 3, 2}},
-		{9, 3, []int{3, 3, 3}},
-		{10, 3, []int{3, 3, 2, 2}},
-		{11, 3, []int{3, 3, 3, 2}},
-		{12, 3, []int{3, 3, 3, 3}},
+		// We always assign at least 1 priority worker to the priority shard.
+		{-1, 1, 1, []int{1, 1}},
+		{0, 1, 1, []int{1, 1}},
+		{2, 1, 1, []int{2, 1}},
+
+		// We balance workers across shards instead of filling up shards. We assume
+		// ranges are evenly distributed across shards, and want ranges to have
+		// about the same number of workers available on average.
+		//
+		// Shard 0 is reserved for priority ranges, with a constant worker count.
+		{pri, -1, -1, []int{pri, 1}},
+		{pri, 0, 0, []int{pri, 1}},
+		{pri, 1, -1, []int{pri, 1}},
+		{pri, 1, 0, []int{pri, 1}},
+		{pri, 1, 1, []int{pri, 1}},
+		{pri, 1, 2, []int{pri, 1}},
+		{pri, 2, 2, []int{pri, 2}},
+		{pri, 3, 2, []int{pri, 2, 1}},
+		{pri, 1, 3, []int{pri, 1}},
+		{pri, 2, 3, []int{pri, 2}},
+		{pri, 3, 3, []int{pri, 3}},
+		{pri, 4, 3, []int{pri, 2, 2}},
+		{pri, 5, 3, []int{pri, 3, 2}},
+		{pri, 6, 3, []int{pri, 3, 3}},
+		{pri, 7, 3, []int{pri, 3, 2, 2}},
+		{pri, 8, 3, []int{pri, 3, 3, 2}},
+		{pri, 9, 3, []int{pri, 3, 3, 3}},
+		{pri, 10, 3, []int{pri, 3, 3, 2, 2}},
+		{pri, 11, 3, []int{pri, 3, 3, 3, 2}},
+		{pri, 12, 3, []int{pri, 3, 3, 3, 3}},
 
 		// Typical examples, using 8 workers per CPU core. Note that we cap workers
 		// at 96 by default.
-		{1 * 8, 16, []int{8}},
-		{2 * 8, 16, []int{16}},
-		{3 * 8, 16, []int{12, 12}},
-		{4 * 8, 16, []int{16, 16}},
-		{6 * 8, 16, []int{16, 16, 16}},
-		{8 * 8, 16, []int{16, 16, 16, 16}},
-		{12 * 8, 16, []int{16, 16, 16, 16, 16, 16}}, // 96 workers
-		{16 * 8, 16, []int{16, 16, 16, 16, 16, 16, 16, 16}},
+		{pri, 1 * 8, 16, []int{pri, 8}},
+		{pri, 2 * 8, 16, []int{pri, 16}},
+		{pri, 3 * 8, 16, []int{pri, 12, 12}},
+		{pri, 4 * 8, 16, []int{pri, 16, 16}},
+		{pri, 6 * 8, 16, []int{pri, 16, 16, 16}},
+		{pri, 8 * 8, 16, []int{pri, 16, 16, 16, 16}},
+		{pri, 12 * 8, 16, []int{pri, 16, 16, 16, 16, 16, 16}}, // 96 workers
+		{pri, 16 * 8, 16, []int{pri, 16, 16, 16, 16, 16, 16, 16, 16}},
 	}
 	for _, tc := range testcases {
 		t.Run(fmt.Sprintf("workers=%d/shardSize=%d", tc.workers, tc.shardSize), func(t *testing.T) {
 			m := newStoreMetrics(metric.TestSampleInterval)
 			p := newTestProcessor()
-			s := newRaftScheduler(log.MakeTestingAmbientContext(nil), m, p, tc.workers, tc.shardSize, 5)
+			s := newRaftScheduler(log.MakeTestingAmbientContext(nil), m, p,
+				tc.workers, tc.shardSize, tc.priorityWorkers, 5)
 
 			var shardWorkers []int
 			for _, shard := range s.shards {
@@ -405,6 +389,83 @@ func TestNewSchedulerShards(t *testing.T) {
 			require.Equal(t, tc.expectShards, shardWorkers)
 		})
 	}
+}
+
+// TestSchedulerPriority tests that range prioritization is correctly
+// updated and applied.
+func TestSchedulerPriority(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	// Set up a test scheduler with 1 regular non-priority worker.
+	stopper := stop.NewStopper()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	defer stopper.Stop(ctx)
+
+	m := newStoreMetrics(metric.TestSampleInterval)
+	p := newTestProcessor()
+	s := newRaftScheduler(log.MakeTestingAmbientContext(nil), m, p, 1, 1, 1, 5)
+	s.Start(stopper)
+	require.Empty(t, s.PriorityIDs())
+
+	// We use 3 ranges: r1 has priority, r2 blocks, r3 starves due to r2.
+	const (
+		priorityID = 1
+		blockedID  = 2
+		starvedID  = 3
+	)
+	s.AddPriorityID(priorityID)
+	require.Equal(t, []roachpb.RangeID{priorityID}, s.PriorityIDs())
+
+	// Enqueue r2 and wait for it to block.
+	blockedC := make(chan chan struct{}, 1)
+	p.onReady(func(rangeID roachpb.RangeID) {
+		if rangeID == blockedID {
+			unblockC := make(chan struct{})
+			blockedC <- unblockC
+			select {
+			case <-unblockC:
+			case <-ctx.Done():
+			}
+		}
+	})
+	s.EnqueueRaftReady(blockedID)
+
+	var unblockC chan struct{}
+	select {
+	case unblockC = <-blockedC:
+	case <-ctx.Done():
+		return
+	}
+
+	// r3 should get starved.
+	s.EnqueueRaftReady(starvedID)
+	time.Sleep(time.Second)
+	require.Zero(t, p.readyCount(starvedID))
+
+	// r1 should get scheduled.
+	s.EnqueueRaftReady(priorityID)
+	require.Eventually(t, func() bool {
+		return p.readyCount(priorityID) == 1
+	}, 10*time.Second, 100*time.Millisecond)
+
+	// Remove r1's priority. It should now starve as well.
+	s.RemovePriorityID(priorityID)
+	require.Empty(t, s.PriorityIDs())
+
+	s.EnqueueRaftReady(priorityID)
+	time.Sleep(time.Second)
+	require.Equal(t, 1, p.readyCount(priorityID))
+
+	// Unblock r2. r3 and r1 should now both get scheduled.
+	close(unblockC)
+	require.Eventually(t, func() bool {
+		return p.readyCount(starvedID) == 1
+	}, 10*time.Second, 100*time.Millisecond)
+	require.Eventually(t, func() bool {
+		return p.readyCount(priorityID) == 2
+	}, 10*time.Second, 100*time.Millisecond)
 }
 
 // BenchmarkSchedulerEnqueueRaftTicks benchmarks the performance of enqueueing
@@ -441,12 +502,13 @@ func runSchedulerEnqueueRaftTicks(
 	a := log.MakeTestingAmbientContext(stopper.Tracer())
 	m := newStoreMetrics(metric.TestSampleInterval)
 	p := newTestProcessor()
-	s := newRaftScheduler(a, m, p, numWorkers, defaultRaftSchedulerShardSize, 5)
+	s := newRaftScheduler(
+		a, m, p, numWorkers, defaultRaftSchedulerShardSize, defaultRaftSchedulerPriorityShardSize, 5)
 
 	// If requested, add a prioritized range corresponding to e.g. the liveness
 	// range.
 	if priority {
-		s.SetPriorityID(1)
+		s.AddPriorityID(1)
 	}
 
 	// raftTickLoop keeps unquiesced ranges in a map, so we do the same.
@@ -457,10 +519,8 @@ func runSchedulerEnqueueRaftTicks(
 
 	// Collect range IDs in the same way as raftTickLoop does, such that the
 	// performance is comparable.
-	batch := s.NewEnqueueBatch()
-	defer batch.Close()
-	getRangeIDs := func() raftSchedulerBatch {
-		batch.Reset()
+	getRangeIDs := func() *raftSchedulerBatch {
+		batch := s.NewEnqueueBatch()
 		for id := range ranges {
 			batch.Add(id)
 		}
@@ -472,6 +532,7 @@ func runSchedulerEnqueueRaftTicks(
 
 	for i := 0; i < b.N; i++ {
 		if collect {
+			ids.Close()
 			ids = getRangeIDs()
 		}
 		s.EnqueueRaftTicks(ids)
@@ -482,4 +543,5 @@ func runSchedulerEnqueueRaftTicks(
 			shard.queue = rangeIDQueue{}
 		}
 	}
+	ids.Close()
 }

--- a/pkg/kv/kvserver/scheduler_test.go
+++ b/pkg/kv/kvserver/scheduler_test.go
@@ -18,12 +18,16 @@ import (
 	"testing"
 	"time"
 
+	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/metric"
+	"github.com/cockroachdb/cockroach/pkg/util/rangedesc"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/errors"
@@ -466,6 +470,39 @@ func TestSchedulerPriority(t *testing.T) {
 	require.Eventually(t, func() bool {
 		return p.readyCount(priorityID) == 2
 	}, 10*time.Second, 100*time.Millisecond)
+}
+
+// TestSchedulerPrioritizesLivenessAndMeta tests that the meta and liveness
+// ranges are prioritized in the Raft scheduler.
+func TestSchedulerPrioritizesLivenessAndMeta(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	defer s.Stopper().Stop(ctx)
+
+	store, err := s.GetStores().(*Stores).GetStore(s.GetFirstStoreID())
+	require.NoError(t, err)
+
+	iter, err := s.RangeDescIteratorFactory().(rangedesc.IteratorFactory).
+		NewIterator(ctx, keys.EverythingSpan)
+	require.NoError(t, err)
+
+	expectPrioritySpans := []roachpb.Span{keys.NodeLivenessSpan, keys.MetaSpan}
+	expectPriorityIDs := []roachpb.RangeID{}
+	for ; iter.Valid(); iter.Next() {
+		desc := iter.CurRangeDescriptor()
+		for _, span := range expectPrioritySpans {
+			rspan, err := keys.SpanAddr(span)
+			require.NoError(t, err)
+			if _, err := desc.RSpan().Intersect(rspan); err == nil {
+				expectPriorityIDs = append(expectPriorityIDs, desc.RangeID)
+			}
+		}
+	}
+	require.NotEmpty(t, expectPriorityIDs)
+	require.ElementsMatch(t, expectPriorityIDs, store.RaftSchedulerPriorityIDs())
 }
 
 // BenchmarkSchedulerEnqueueRaftTicks benchmarks the performance of enqueueing

--- a/pkg/kv/kvserver/store.go
+++ b/pkg/kv/kvserver/store.go
@@ -135,6 +135,13 @@ var defaultRaftSchedulerConcurrency = envutil.EnvOrDefaultInt(
 // counts, while also avoiding starvation by excessive sharding.
 var defaultRaftSchedulerShardSize = envutil.EnvOrDefaultInt("COCKROACH_SCHEDULER_SHARD_SIZE", 16)
 
+// defaultRaftSchedulerPriorityShardSize specifies the default size of the Raft
+// scheduler priority shard, used for certain system ranges. This shard is
+// always fully populated with workers that don't count towards the concurrency
+// limit, and is thus effectively the number of priority workers per store.
+var defaultRaftSchedulerPriorityShardSize = envutil.EnvOrDefaultInt(
+	"COCKROACH_SCHEDULER_PRIORITY_SHARD_SIZE", 2)
+
 var logSSTInfoTicks = envutil.EnvOrDefaultInt(
 	"COCKROACH_LOG_SST_INFO_TICKS_INTERVAL", 60)
 
@@ -1080,6 +1087,10 @@ type StoreConfig struct {
 	// for this store. Values < 1 imply 1.
 	RaftSchedulerConcurrency int
 
+	// RaftSchedulerConcurrentPriority specifies the number of Raft scheduler
+	// workers for this store's dedicated priority shard. Values < 1 imply 1.
+	RaftSchedulerConcurrencyPriority int
+
 	// RaftSchedulerShardSize specifies the maximum number of Raft scheduler
 	// workers per mutex shard. Values < 1 imply 1.
 	RaftSchedulerShardSize int
@@ -1185,8 +1196,8 @@ func (sc *StoreConfig) Valid() bool {
 	return sc.Clock != nil && sc.Transport != nil &&
 		sc.RaftTickInterval != 0 && sc.RaftHeartbeatIntervalTicks > 0 &&
 		sc.RaftElectionTimeoutTicks > 0 && sc.RaftReproposalTimeoutTicks > 0 &&
-		sc.RaftSchedulerConcurrency > 0 && sc.RaftSchedulerShardSize > 0 &&
-		sc.ScanInterval >= 0 && sc.AmbientCtx.Tracer != nil
+		sc.RaftSchedulerConcurrency > 0 && sc.RaftSchedulerConcurrencyPriority > 0 &&
+		sc.RaftSchedulerShardSize > 0 && sc.ScanInterval >= 0 && sc.AmbientCtx.Tracer != nil
 }
 
 // SetDefaults initializes unset fields in StoreConfig to values
@@ -1206,6 +1217,9 @@ func (sc *StoreConfig) SetDefaults(numStores int) {
 		if numStores > 1 && sc.RaftSchedulerConcurrency > 1 {
 			sc.RaftSchedulerConcurrency = (sc.RaftSchedulerConcurrency-1)/numStores + 1 // ceil division
 		}
+	}
+	if sc.RaftSchedulerConcurrencyPriority == 0 {
+		sc.RaftSchedulerConcurrencyPriority = defaultRaftSchedulerPriorityShardSize
 	}
 	if sc.RaftSchedulerShardSize == 0 {
 		sc.RaftSchedulerShardSize = defaultRaftSchedulerShardSize
@@ -1333,7 +1347,8 @@ func NewStore(
 	// NB: buffer up to RaftElectionTimeoutTicks in Raft scheduler to avoid
 	// unnecessary elections when ticks are temporarily delayed and piled up.
 	s.scheduler = newRaftScheduler(cfg.AmbientCtx, s.metrics, s,
-		cfg.RaftSchedulerConcurrency, cfg.RaftSchedulerShardSize, cfg.RaftElectionTimeoutTicks)
+		cfg.RaftSchedulerConcurrency, cfg.RaftSchedulerShardSize, cfg.RaftSchedulerConcurrencyPriority,
+		cfg.RaftElectionTimeoutTicks)
 
 	s.syncWaiter = logstore.NewSyncWaiterLoop()
 

--- a/pkg/kv/kvserver/store_remove_replica.go
+++ b/pkg/kv/kvserver/store_remove_replica.go
@@ -303,6 +303,7 @@ func (s *Store) unlinkReplicaByRangeIDLocked(ctx context.Context, rangeID roachp
 	s.mu.replicasByRangeID.Delete(rangeID)
 	s.unregisterLeaseholderByID(ctx, rangeID)
 	s.raftRecvQueues.Delete(rangeID)
+	s.scheduler.RemovePriorityID(rangeID)
 }
 
 // removePlaceholder removes a placeholder for the specified range.


### PR DESCRIPTION
**kvserver: add priority range to `BenchmarkSchedulerEnqueueRaftTicks`**

This patch adds `priority=false|true` variants to measure enqueue performance when there is 0 or 1 priority ranges respectively (the common cases given that only the liveness range currently has priority).

Epic: none
Release note: None
  
**kvserver: support multiple priority ranges in Raft scheduler**

Previously, the Raft scheduler only supported a single priority range (the liveness range). However, other critical system ranges should also get priority, in particular when we move responsibility for expiration-based lease extensions to the Raft scheduler.

This patch implements prioritization of multiple ranges. It does so by creating a separate Raft scheduler shard at index 0 with 2 worker goroutines reserved for priority ranges, configurable via
`COCKROACH_SCHEDULER_PRIORITY_SHARD_SIZE`. This has the added benefit of avoiding scheduler starvation by non-priority ranges (although unlikely in practice), and of amortizing the priority check costs at enqueue time rather than incurring it for every dequeue. These goroutines do have a minor cost, especially considering many nodes may not have any priority ranges at all, but the added complexity and risk of dynamically sizing this worker pool down to 0 does not appear justified to avoid 2 idle goroutines.

Benchmarks show some additional enqueue overhead, but this approaches 0% when there are no priority ranges (`priority=false`) and 12% when there is a single priority range (`priority=true`). In absolute terms the overhead is negligible, considering we only enqueue ticks every 500 ms.

```
name                                                                               old time/op  new time/op  delta
SchedulerEnqueueRaftTicks/collect=true/priority=false/ranges=1/workers=64-24        158ns ± 3%   201ns ± 2%  +26.58%  (p=0.000 n=10+9)
SchedulerEnqueueRaftTicks/collect=true/priority=false/ranges=10/workers=64-24       696ns ± 3%   777ns ± 2%  +11.55%  (p=0.000 n=10+10)
SchedulerEnqueueRaftTicks/collect=true/priority=false/ranges=100/workers=64-24     5.69µs ± 2%  6.12µs ± 1%   +7.59%  (p=0.000 n=10+10)
SchedulerEnqueueRaftTicks/collect=true/priority=false/ranges=1000/workers=64-24    59.9µs ± 1%  62.4µs ± 1%   +4.19%  (p=0.000 n=10+10)
SchedulerEnqueueRaftTicks/collect=true/priority=false/ranges=10000/workers=64-24    622µs ± 1%   650µs ± 1%   +4.49%  (p=0.000 n=9+9)
SchedulerEnqueueRaftTicks/collect=true/priority=false/ranges=100000/workers=64-24  8.30ms ± 6%  8.15ms ± 1%     ~     (p=0.211 n=10+9)
SchedulerEnqueueRaftTicks/collect=true/priority=true/ranges=1/workers=64-24         158ns ± 1%   259ns ± 2%  +64.58%  (p=0.000 n=9+10)
SchedulerEnqueueRaftTicks/collect=true/priority=true/ranges=10/workers=64-24        696ns ± 2%   985ns ± 4%  +41.54%  (p=0.000 n=9+10)
SchedulerEnqueueRaftTicks/collect=true/priority=true/ranges=100/workers=64-24      5.68µs ± 2%  6.96µs ± 2%  +22.65%  (p=0.000 n=10+10)
SchedulerEnqueueRaftTicks/collect=true/priority=true/ranges=1000/workers=64-24     59.8µs ± 1%  70.1µs ± 1%  +17.34%  (p=0.000 n=10+10)
SchedulerEnqueueRaftTicks/collect=true/priority=true/ranges=10000/workers=64-24     625µs ± 1%   725µs ± 1%  +15.96%  (p=0.000 n=10+9)
SchedulerEnqueueRaftTicks/collect=true/priority=true/ranges=100000/workers=64-24   8.23ms ± 5%  9.27ms ± 3%  +12.56%  (p=0.000 n=10+10)
```

Epic: none
Release note: None
  
**kvserver: prioritize meta ranges in Raft scheduler**

Previously, only the node liveness range was prioritized in the Raft scheduler. This patch also prioritizes scheduling for the meta ranges.

Resolves #101013.

Epic: none
Release note: None