### PR TITLE
fixes unit tests: TestLossOfQuorumRecovery, TestBoundedStalenessDataD…

### DIFF
--- a/pkg/ccl/kvccl/kvfollowerreadsccl/boundedstaleness_test.go
+++ b/pkg/ccl/kvccl/kvfollowerreadsccl/boundedstaleness_test.go
@@ -204,6 +204,7 @@ func (bse *boundedStalenessEvents) validate(t *testing.T) {
 				require.True(
 					t,
 					ev.MinTimestampBound.Less(lastTxnRetry.MinTimestampBound),
+					"expected MinTimestampBound=%s to be less than previous retry's MinTimestampBound=%s",
 					ev.MinTimestampBound,
 					lastTxnRetry.MinTimestampBound,
 				)

--- a/pkg/cli/debug_recover_loss_of_quorum_test.go
+++ b/pkg/cli/debug_recover_loss_of_quorum_test.go
@@ -272,7 +272,7 @@ func TestLossOfQuorumRecovery(t *testing.T) {
 			return nil
 		}), "Failed to activate replication queue")
 	}
-	require.NoError(t, err, tcAfter.WaitForFullReplication(), "Failed to perform full replication")
+	require.NoError(t, tcAfter.WaitForFullReplication(), "Failed to perform full replication")
 
 	for i := 0; i < len(tcAfter.Servers); i++ {
 		require.NoError(t, tcAfter.Servers[i].Stores().VisitStores(func(store *kvserver.Store) error {


### PR DESCRIPTION
…riven

Both TestLossOfQuorumRecovery and TestBoundedStalenessDataDriven were in violation of the "msgAndArgs" vararg API as described in [1].

The typo in TestLossOfQuorumRecovery precluded panic, but resulted in swallowing any error returned by WaitForFullReplication, i.e., validation was skipped.

In TestBoundedStalenessDataDriven, panic would have occurred whenever the expression 'ev.MinTimestampBound.Less(lastTxnRetry.MinTimestampBound)' had evaluated to false.

Epic: none
Informs: #101028

Release note: None

[1] https://github.com/cockroachdb/cockroach/issues/101028