### PR TITLE
kvserver: move eager expiration lease extension to Raft scheduler

### DIFF
--- a/pkg/kv/kvserver/client_lease_test.go
+++ b/pkg/kv/kvserver/client_lease_test.go
@@ -1458,11 +1458,10 @@ func TestLeaseTransfersUseExpirationLeasesAndBumpToEpochBasedOnes(t *testing.T) 
 					WallClock: manualClock,
 				},
 				Store: &kvserver.StoreTestingKnobs{
-					// Outlandishly high to disable proactive renewal of
-					// expiration based leases. Lease upgrades happen
-					// immediately after applying without needing active
+					// Disable proactive renewal of expiration based leases. Lease
+					// upgrades happen immediately after applying without needing active
 					// renewal.
-					LeaseRenewalDurationOverride: 100 * time.Hour,
+					DisableAutomaticLeaseRenewal: true,
 					LeaseUpgradeInterceptor: func(lease *roachpb.Lease) {
 						mu.Lock()
 						defer mu.Unlock()

--- a/pkg/kv/kvserver/replica.go
+++ b/pkg/kv/kvserver/replica.go
@@ -1614,13 +1614,8 @@ func (r *Replica) checkExecutionCanProceedBeforeStorageSnapshot(
 		return kvserverpb.LeaseStatus{}, err
 	}
 
-	var shouldExtend bool
-	postRUnlock := func() {}
 	r.mu.RLock()
-	defer func() {
-		r.mu.RUnlock()
-		postRUnlock()
-	}()
+	defer r.mu.RUnlock()
 
 	// Has the replica been initialized?
 	// NB: this should have already been checked in Store.Send, so we don't need
@@ -1645,7 +1640,7 @@ func (r *Replica) checkExecutionCanProceedBeforeStorageSnapshot(
 		return kvserverpb.LeaseStatus{}, err
 	}
 
-	st, shouldExtend, err := r.checkLeaseRLocked(ctx, ba)
+	st, err := r.checkLeaseRLocked(ctx, ba)
 	if err != nil {
 		return kvserverpb.LeaseStatus{}, err
 	}
@@ -1669,19 +1664,6 @@ func (r *Replica) checkExecutionCanProceedBeforeStorageSnapshot(
 		}
 	}
 
-	if shouldExtend && !ExpirationLeasesOnly.Get(&r.ClusterSettings().SV) {
-		// If we're asked to extend the lease, trigger (async) lease renewal. We
-		// don't do this if kv.expiration_leases_only.enabled is true, since we in
-		// that case eagerly extend expiration leases during Raft ticks instead.
-		//
-		// TODO(erikgrinaker): Remove this when we always eagerly extend
-		// expiration leases.
-		//
-		// Kicking this off requires an exclusive lock, and we hold a read-only lock
-		// already, so we jump through a hoop to run it in a suitably positioned
-		// defer.
-		postRUnlock = func() { r.maybeExtendLeaseAsync(ctx, st) }
-	}
 	return st, nil
 }
 
@@ -1745,12 +1727,10 @@ func (r *Replica) checkExecutionCanProceedRWOrAdmin(
 // checkLeaseRLocked checks the provided batch against the GC
 // threshold and lease. A nil error indicates to go ahead with the batch, and
 // is accompanied either by a valid or zero lease status, the latter case
-// indicating that the request was permitted to bypass the lease check. The
-// returned bool indicates whether the lease should be extended (only on nil
-// error).
+// indicating that the request was permitted to bypass the lease check.
 func (r *Replica) checkLeaseRLocked(
 	ctx context.Context, ba *kvpb.BatchRequest,
-) (kvserverpb.LeaseStatus, bool, error) {
+) (kvserverpb.LeaseStatus, error) {
 	now := r.Clock().NowAsClockTimestamp()
 	// If the request is a write or a consistent read, it requires the
 	// replica serving it to hold the range lease. We pass the write
@@ -1762,7 +1742,6 @@ func (r *Replica) checkLeaseRLocked(
 	reqTS := ba.WriteTimestamp()
 	st := r.leaseStatusForRequestRLocked(ctx, now, reqTS)
 
-	var shouldExtend bool
 	// Write commands that skip the lease check in practice are exactly
 	// RequestLease and TransferLease. Both use the provided previous lease for
 	// verification below raft. We return a zero lease status from this method and
@@ -1773,26 +1752,24 @@ func (r *Replica) checkLeaseRLocked(
 	// doesn't check the lease.
 	if !ba.IsSingleSkipsLeaseCheckRequest() && ba.ReadConsistency != kvpb.INCONSISTENT {
 		// Check the lease.
-		var err error
-		shouldExtend, err = r.leaseGoodToGoForStatusRLocked(ctx, now, reqTS, st)
+		err := r.leaseGoodToGoForStatusRLocked(ctx, now, reqTS, st)
 		if err != nil {
 			// No valid lease, but if we can serve this request via follower reads,
 			// we may continue.
 			if !r.canServeFollowerReadRLocked(ctx, ba) {
 				// If not, return the error.
-				return kvserverpb.LeaseStatus{}, false, err
+				return kvserverpb.LeaseStatus{}, err
 			}
 			// Otherwise, suppress the error. Also, remember that we're not serving
 			// this under the lease by zeroing out the status. We also intentionally
 			// do not pass the original status to checkTSAboveGCThreshold as
 			// this method assumes that a valid status indicates that this replica
-			// holds the lease (see #73123). `shouldExtend` is already false in this
-			// branch, but for completeness we zero it out as well.
-			st, shouldExtend, err = kvserverpb.LeaseStatus{}, false, nil
+			// holds the lease (see #73123).
+			st, err = kvserverpb.LeaseStatus{}, nil
 		}
 	}
 
-	return st, shouldExtend, nil
+	return st, nil
 }
 
 // checkExecutionCanProceedForRangeFeed returns an error if a rangefeed request

--- a/pkg/kv/kvserver/replica_lease_renewal_test.go
+++ b/pkg/kv/kvserver/replica_lease_renewal_test.go
@@ -12,7 +12,6 @@ package kvserver
 
 import (
 	"context"
-	"sync/atomic"
 	"testing"
 	"time"
 
@@ -25,7 +24,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
-	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/require"
 )
 
@@ -41,9 +39,9 @@ func TestLeaseRenewer(t *testing.T) {
 	skip.UnderStressRace(t)
 	skip.UnderDeadlock(t)
 
-	// When kv.expiration_leases_only.enabled is true, the Raft scheduler is
-	// responsible for extensions, but we still track expiration leases for system
-	// ranges in the store lease renewer in case the setting changes.
+	// We test with kv.expiration_leases_only.enabled both enabled and disabled,
+	// to ensure meta/liveness ranges are still eagerly extended, while regular
+	// ranges are upgraded to epoch leases.
 	testutils.RunTrueAndFalse(t, "kv.expiration_leases_only.enabled", func(t *testing.T, expOnly bool) {
 		ctx := context.Background()
 		st := cluster.MakeTestingClusterSettings()
@@ -58,11 +56,6 @@ func TestLeaseRenewer(t *testing.T) {
 					RaftTickInterval:           100 * time.Millisecond,
 					RaftElectionTimeoutTicks:   20,
 					RaftReproposalTimeoutTicks: 30,
-				},
-				Knobs: base.TestingKnobs{
-					Store: &StoreTestingKnobs{
-						LeaseRenewalDurationOverride: 100 * time.Millisecond,
-					},
 				},
 			},
 		})
@@ -91,16 +84,6 @@ func TestLeaseRenewer(t *testing.T) {
 			repl, err := getNodeStore(nodeID).GetReplica(rangeID)
 			require.NoError(t, err)
 			return repl
-		}
-
-		getLeaseRenewers := func(rangeID roachpb.RangeID) []roachpb.NodeID {
-			var renewers []roachpb.NodeID
-			for _, nodeID := range tc.NodeIDs() {
-				if _, ok := getNodeStore(nodeID).renewableLeases.Load(int64(rangeID)); ok {
-					renewers = append(renewers, nodeID)
-				}
-			}
-			return renewers
 		}
 
 		// assertLeaseExtension asserts that the given range has an expiration-based
@@ -133,56 +116,13 @@ func TestLeaseRenewer(t *testing.T) {
 			}, 20*time.Second, 100*time.Millisecond)
 		}
 
-		// assertStoreLeaseRenewer asserts that the range is tracked by the store lease
-		// renewer on the leaseholder.
-		assertStoreLeaseRenewer := func(rangeID roachpb.RangeID) {
-			repl := getNodeReplica(1, rangeID)
-			require.Eventually(t, func() bool {
-				lease, _ := repl.GetLease()
-				renewers := getLeaseRenewers(rangeID)
-				renewedByLeaseholder := len(renewers) == 1 && renewers[0] == lease.Replica.NodeID
-				// If kv.expiration_leases_only.enabled is true, then the store lease
-				// renewer is disabled -- it will still track the ranges in case the
-				// setting changes, but won't detect the new lease and untrack them as
-				// long as it has a replica. We therefore allow multiple nodes to track
-				// it, as long as the leaseholder is one of them.
-				if expOnly {
-					for _, renewer := range renewers {
-						if renewer == lease.Replica.NodeID {
-							renewedByLeaseholder = true
-							break
-						}
-					}
-				}
-				if !renewedByLeaseholder {
-					t.Logf("r%d renewers: %v", rangeID, renewers)
-				}
-				return renewedByLeaseholder
-			}, 20*time.Second, 100*time.Millisecond)
-		}
-
-		// assertNoStoreLeaseRenewer asserts that the range is not tracked by any
-		// lease renewer.
-		assertNoStoreLeaseRenewer := func(rangeID roachpb.RangeID) {
-			require.Eventually(t, func() bool {
-				renewers := getLeaseRenewers(rangeID)
-				if len(renewers) > 0 {
-					t.Logf("r%d renewers: %v", rangeID, renewers)
-					return false
-				}
-				return true
-			}, 20*time.Second, 100*time.Millisecond)
-		}
-
 		// The meta range should always be eagerly renewed.
 		firstRangeID := tc.LookupRangeOrFatal(t, keys.MinKey).RangeID
 		assertLeaseExtension(firstRangeID)
-		assertStoreLeaseRenewer(firstRangeID)
 
 		// Split off an expiration-based range, and assert that the lease is extended.
 		desc := tc.LookupRangeOrFatal(t, tc.ScratchRangeWithExpirationLease(t))
 		assertLeaseExtension(desc.RangeID)
-		assertStoreLeaseRenewer(desc.RangeID)
 
 		// Transfer the lease to a different leaseholder, and assert that the lease is
 		// still extended. Wait for the split to apply on all nodes first.
@@ -191,107 +131,14 @@ func TestLeaseRenewer(t *testing.T) {
 		target := tc.Target(lookupNode(lease.Replica.NodeID%3 + 1))
 		tc.TransferRangeLeaseOrFatal(t, desc, target)
 		assertLeaseExtension(desc.RangeID)
-		assertStoreLeaseRenewer(desc.RangeID)
-
-		// Merge the range back. This should unregister it from the lease renewer.
-		require.NoError(t, tc.Server(0).DB().AdminMerge(ctx, desc.StartKey.AsRawKey().Prevish(16)))
-		assertNoStoreLeaseRenewer(desc.RangeID)
 
 		// Split off a regular non-system range. This should only be eagerly
-		// extended if kv.expiration_leases_only.enabled is true, and should never
-		// be tracked by the store lease renewer (which only handles system ranges).
+		// extended if kv.expiration_leases_only.enabled is true.
 		desc = tc.LookupRangeOrFatal(t, tc.ScratchRange(t))
 		if expOnly {
 			assertLeaseExtension(desc.RangeID)
 		} else {
 			assertLeaseUpgrade(desc.RangeID)
 		}
-		assertNoStoreLeaseRenewer(desc.RangeID)
-	})
-}
-
-func setupLeaseRenewerTest(
-	ctx context.Context, t *testing.T, init func(*base.TestClusterArgs),
-) (
-	cycles *int32, /* atomic */
-	_ serverutils.TestClusterInterface,
-) {
-	st := cluster.MakeTestingClusterSettings()
-	ExpirationLeasesOnly.Override(ctx, &st.SV, false) // override metamorphism
-
-	cycles = new(int32)
-	var args base.TestClusterArgs
-	args.ServerArgs.Settings = st
-	args.ServerArgs.Knobs.Store = &StoreTestingKnobs{
-		LeaseRenewalOnPostCycle: func() {
-			atomic.AddInt32(cycles, 1)
-		},
-	}
-	init(&args)
-	tc := serverutils.StartNewTestCluster(t, 1, args)
-	t.Cleanup(func() { tc.Stopper().Stop(ctx) })
-
-	desc := tc.LookupRangeOrFatal(t, tc.ScratchRangeWithExpirationLease(t))
-	srv := tc.Server(0)
-	s, err := srv.GetStores().(*Stores).GetStore(srv.GetFirstStoreID())
-	require.NoError(t, err)
-
-	_, err = s.DB().Get(ctx, desc.StartKey)
-	require.NoError(t, err)
-
-	repl, err := s.GetReplica(desc.RangeID)
-	require.NoError(t, err)
-
-	// There's a lease since we just split off the range.
-	lease, _ := repl.GetLease()
-	require.Equal(t, s.NodeID(), lease.Replica.NodeID)
-
-	return cycles, tc
-}
-
-func TestLeaseRenewerExtendsExpirationBasedLeases(t *testing.T) {
-	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
-	ctx := context.Background()
-
-	t.Run("triggered", func(t *testing.T) {
-		renewCh := make(chan struct{})
-		cycles, tc := setupLeaseRenewerTest(ctx, t, func(args *base.TestClusterArgs) {
-			args.ServerArgs.Knobs.Store.(*StoreTestingKnobs).LeaseRenewalSignalChan = renewCh
-		})
-		defer tc.Stopper().Stop(ctx)
-
-		trigger := func() {
-			// Need to signal the chan twice to make sure we see the effect
-			// of at least the first iteration.
-			for i := 0; i < 2; i++ {
-				select {
-				case renewCh <- struct{}{}:
-				case <-time.After(10 * time.Second):
-					t.Fatal("unable to send on renewal chan for 10s")
-				}
-			}
-		}
-
-		for i := 0; i < 5; i++ {
-			trigger()
-			n := atomic.LoadInt32(cycles)
-			require.NotZero(t, n, "during cycle #%v", i+1)
-			atomic.AddInt32(cycles, -n)
-		}
-	})
-
-	t.Run("periodic", func(t *testing.T) {
-		cycles, tc := setupLeaseRenewerTest(ctx, t, func(args *base.TestClusterArgs) {
-			args.ServerArgs.Knobs.Store.(*StoreTestingKnobs).LeaseRenewalDurationOverride = 10 * time.Millisecond
-		})
-		defer tc.Stopper().Stop(ctx)
-
-		testutils.SucceedsSoon(t, func() error {
-			if n := atomic.LoadInt32(cycles); n < 5 {
-				return errors.Errorf("saw only %d renewal cycles", n)
-			}
-			return nil
-		})
 	})
 }

--- a/pkg/kv/kvserver/replica_raft_quiesce.go
+++ b/pkg/kv/kvserver/replica_raft_quiesce.go
@@ -290,14 +290,9 @@ func shouldReplicaQuiesce(
 	// Fast path: don't quiesce expiration-based leases, since they'll likely be
 	// renewed soon. The lease may not be ours, but in that case we wouldn't be
 	// able to quiesce anyway (see leaseholder condition below).
-	//
-	// TODO(erikgrinaker): Out of caution, we only do this when
-	// kv.expiration_leases_only.enabled is true. We should always do this.
 	if l, _ := q.getLeaseRLocked(); l.Type() == roachpb.LeaseExpiration && l.Sequence != 0 {
-		if ExpirationLeasesOnly.Get(&q.ClusterSettings().SV) {
-			log.VInfof(ctx, 4, "not quiescing: expiration-based lease")
-			return nil, nil, false
-		}
+		log.VInfof(ctx, 4, "not quiescing: expiration-based lease")
+		return nil, nil, false
 	}
 	if q.hasPendingProposalsRLocked() {
 		if log.V(4) {

--- a/pkg/kv/kvserver/replica_range_lease.go
+++ b/pkg/kv/kvserver/replica_range_lease.go
@@ -1079,31 +1079,27 @@ func (r *Replica) checkRequestTimeRLocked(now hlc.ClockTimestamp, reqTS hlc.Time
 // (4) the lease is valid, held locally, and capable of serving the
 //
 //	given request. In this case, no error is returned.
-//
-// In addition to the lease status, the method also returns whether the
-// lease should be considered for extension using maybeExtendLeaseAsync
-// after the replica's read lock has been dropped.
 func (r *Replica) leaseGoodToGoRLocked(
 	ctx context.Context, now hlc.ClockTimestamp, reqTS hlc.Timestamp,
-) (_ kvserverpb.LeaseStatus, shouldExtend bool, _ error) {
+) (kvserverpb.LeaseStatus, error) {
 	st := r.leaseStatusForRequestRLocked(ctx, now, reqTS)
-	shouldExtend, err := r.leaseGoodToGoForStatusRLocked(ctx, now, reqTS, st)
+	err := r.leaseGoodToGoForStatusRLocked(ctx, now, reqTS, st)
 	if err != nil {
-		return kvserverpb.LeaseStatus{}, false, err
+		return kvserverpb.LeaseStatus{}, err
 	}
-	return st, shouldExtend, err
+	return st, err
 }
 
 func (r *Replica) leaseGoodToGoForStatusRLocked(
 	ctx context.Context, now hlc.ClockTimestamp, reqTS hlc.Timestamp, st kvserverpb.LeaseStatus,
-) (shouldExtend bool, _ error) {
+) error {
 	if err := r.checkRequestTimeRLocked(now, reqTS); err != nil {
 		// Case (1): invalid request.
-		return false, err
+		return err
 	}
 	if !st.IsValid() {
 		// Case (2): invalid lease.
-		return false, &kvpb.InvalidLeaseError{}
+		return &kvpb.InvalidLeaseError{}
 	}
 	if !st.Lease.OwnedBy(r.store.StoreID()) {
 		// Case (3): not leaseholder.
@@ -1145,19 +1141,19 @@ func (r *Replica) leaseGoodToGoForStatusRLocked(
 		}
 		// Otherwise, if the lease is currently held by another replica, redirect
 		// to the holder.
-		return false, kvpb.NewNotLeaseHolderError(
+		return kvpb.NewNotLeaseHolderError(
 			st.Lease, r.store.StoreID(), r.descRLocked(), "lease held by different store",
 		)
 	}
 	// Case (4): all good.
-	return r.shouldExtendLeaseRLocked(st), nil
+	return nil
 }
 
 // leaseGoodToGo is like leaseGoodToGoRLocked, but will acquire the replica read
 // lock.
 func (r *Replica) leaseGoodToGo(
 	ctx context.Context, now hlc.ClockTimestamp, reqTS hlc.Timestamp,
-) (_ kvserverpb.LeaseStatus, shouldExtend bool, _ error) {
+) (kvserverpb.LeaseStatus, error) {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 	return r.leaseGoodToGoRLocked(ctx, now, reqTS)
@@ -1214,11 +1210,8 @@ func (r *Replica) redirectOnOrAcquireLeaseForRequest(
 	// Try fast-path.
 	now := r.store.Clock().NowAsClockTimestamp()
 	{
-		status, shouldExtend, err := r.leaseGoodToGo(ctx, now, reqTS)
+		status, err := r.leaseGoodToGo(ctx, now, reqTS)
 		if err == nil {
-			if shouldExtend {
-				r.maybeExtendLeaseAsync(ctx, status)
-			}
 			return status, nil
 		} else if !errors.HasType(err, (*kvpb.InvalidLeaseError)(nil)) {
 			return kvserverpb.LeaseStatus{}, kvpb.NewError(err)
@@ -1434,19 +1427,9 @@ func (r *Replica) shouldExtendLeaseRLocked(st kvserverpb.LeaseStatus) bool {
 	return renewal.LessEq(st.Now.ToTimestamp())
 }
 
-// maybeExtendLeaseAsync attempts to extend the expiration-based lease
+// maybeExtendLeaseAsyncLocked attempts to extend the expiration-based lease
 // asynchronously, if doing so is deemed beneficial by shouldExtendLeaseRLocked.
-func (r *Replica) maybeExtendLeaseAsync(ctx context.Context, st kvserverpb.LeaseStatus) {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-
-	r.maybeExtendLeaseAsyncLocked(ctx, st)
-}
-
 func (r *Replica) maybeExtendLeaseAsyncLocked(ctx context.Context, st kvserverpb.LeaseStatus) {
-	// Check shouldExtendLeaseRLocked again, because others may have raced to
-	// extend the lease and beaten us here after we made the determination
-	// (under a shared lock) that the extension was needed.
 	if !r.shouldExtendLeaseRLocked(st) {
 		return
 	}
@@ -1454,9 +1437,8 @@ func (r *Replica) maybeExtendLeaseAsyncLocked(ctx context.Context, st kvserverpb
 		log.Infof(ctx, "extending lease %s at %s", st.Lease, st.Now)
 	}
 	// We explicitly ignore the returned handle as we won't block on it. This
-	// context will likely be cancelled soon (when the originating request
-	// completes), but the lease request will continue to completion independently
-	// of the caller's context
+	// context might be cancelled soon (when the caller completes), but the lease
+	// request will continue to completion independently of the caller's context
 	_ = r.requestLeaseLocked(ctx, st)
 }
 

--- a/pkg/kv/kvserver/replica_test.go
+++ b/pkg/kv/kvserver/replica_test.go
@@ -10160,8 +10160,8 @@ func TestShouldReplicaQuiesce(t *testing.T) {
 		}
 		return q
 	})
-	// Verify no quiescence with expiration-based leases, but only if
-	// kv.expiration_leases_only.enabled is true.
+	// Verify no quiescence with expiration-based leases, regardless
+	// of kv.expiration_leases_only.enabled.
 	test(false, func(q *testQuiescer) *testQuiescer {
 		ExpirationLeasesOnly.Override(context.Background(), &q.st.SV, true)
 		q.lease.Epoch = 0
@@ -10170,7 +10170,7 @@ func TestShouldReplicaQuiesce(t *testing.T) {
 		}
 		return q
 	})
-	test(true, func(q *testQuiescer) *testQuiescer {
+	test(false, func(q *testQuiescer) *testQuiescer {
 		ExpirationLeasesOnly.Override(context.Background(), &q.st.SV, false)
 		q.lease.Epoch = 0
 		q.lease.Expiration = &hlc.Timestamp{

--- a/pkg/kv/kvserver/store_remove_replica.go
+++ b/pkg/kv/kvserver/store_remove_replica.go
@@ -303,7 +303,6 @@ func (s *Store) unlinkReplicaByRangeIDLocked(ctx context.Context, rangeID roachp
 	s.mu.replicasByRangeID.Delete(rangeID)
 	s.unregisterLeaseholderByID(ctx, rangeID)
 	s.raftRecvQueues.Delete(rangeID)
-	s.renewableLeases.Delete(int64(rangeID))
 }
 
 // removePlaceholder removes a placeholder for the specified range.

--- a/pkg/kv/kvserver/testing_knobs.go
+++ b/pkg/kv/kvserver/testing_knobs.go
@@ -389,14 +389,6 @@ type StoreTestingKnobs struct {
 	// acquire any locks in this method.
 	OnRaftTimeoutCampaign func(roachpb.RangeID)
 
-	// LeaseRenewalSignalChan populates `Store.renewableLeasesSignal`.
-	LeaseRenewalSignalChan chan struct{}
-	// LeaseRenewalOnPostCycle is invoked after each lease renewal cycle.
-	LeaseRenewalOnPostCycle func()
-	// LeaseRenewalDurationOverride replaces the timer duration for proactively
-	// renewing expiration based leases.
-	LeaseRenewalDurationOverride time.Duration
-
 	// RangefeedValueHeaderFilter, if set, is invoked before each value emitted on
 	// the rangefeed, be it in steady state or during the catch-up scan.
 	//


### PR DESCRIPTION
**kvserver: never quiesce expiration leases**

Previously, this was contingent on `kv.expiration_leases_only.enabled`. This patch therefore, in practice, disables quiescence for the meta/liveness ranges and for any ranges that are transferring an expiration lease before upgrading it to an epoch lease. Quiescing these will tend to result in more work rather than less, because we'll have to wake the ranges up again shortly which incurs an additional Raft append.

Epic: none
Release note: None
  
**kvserver: move eager expiration lease extension to Raft scheduler**

This patch makes the Raft scheduler responsible for eagerly extending all expiration-based leases, replacing the store lease renewer. Previously, this was contingent on `kv.expiration_leases_only.enabled`, and by default only the meta/liveness ranges were eagerly extended by the store lease renewer.

Touches #98433.

Epic: none
Release note: None
  
**kvserver: don't extend leases during request processing**

This patch removes expiration lease extension during request processing, since the Raft scheduler now always eagerly extends expiration leases. Previously, this was contingent on `kv.expiration_leases_only.enabled`.

Epic: none
Release note: None