### PR TITLE
sqlsmith: makeCompare overhaul

### DIFF
--- a/pkg/internal/sqlsmith/BUILD.bazel
+++ b/pkg/internal/sqlsmith/BUILD.bazel
@@ -35,6 +35,7 @@ go_library(
         "//pkg/sql/sem/volatility",
         "//pkg/sql/types",
         "//pkg/util",
+        "//pkg/util/iterutil",
         "//pkg/util/randident",
         "//pkg/util/randident/randidentcfg",
         "//pkg/util/syncutil",

--- a/pkg/internal/sqlsmith/scope.go
+++ b/pkg/internal/sqlsmith/scope.go
@@ -26,6 +26,10 @@ func (c *colRef) typedExpr() tree.TypedExpr {
 	return makeTypedExpr(c.item, c.typ)
 }
 
+func (c *colRef) String() string {
+	return c.item.String() + "::" + c.typ.String()
+}
+
 type colRefs []*colRef
 
 func (t colRefs) extend(refs ...*colRef) colRefs {


### PR DESCRIPTION
makeCompare gives up really easily which is a contributing factor to the
prevalence of unexciting WHERE clauses in sqlsmith. This commit makes it
try a lot harder to come up with something interesting.

Epic: none
Release note: None