### PR TITLE
autoconfig: prevent a data race in TestAutoConfig

### DIFF
--- a/pkg/server/autoconfig/BUILD.bazel
+++ b/pkg/server/autoconfig/BUILD.bazel
@@ -21,6 +21,7 @@ go_library(
         "//pkg/server/autoconfig/autoconfigpb",
         "//pkg/settings/cluster",
         "//pkg/sql",
+        "//pkg/sql/catalog/descs",
         "//pkg/sql/isql",
         "//pkg/sql/sessiondata",
         "//pkg/util/encoding",

--- a/pkg/server/autoconfig/BUILD.bazel
+++ b/pkg/server/autoconfig/BUILD.bazel
@@ -54,6 +54,7 @@ go_test(
         "//pkg/testutils/testcluster",
         "//pkg/util/leaktest",
         "//pkg/util/randutil",
+        "//pkg/util/syncutil",
         "@com_github_stretchr_testify//require",
     ],
 )

--- a/pkg/server/autoconfig/auto_config_test.go
+++ b/pkg/server/autoconfig/auto_config_test.go
@@ -48,7 +48,7 @@ var testTasks = []testTask{
 	{task: autoconfigpb.Task{
 		TaskID:      123,
 		Description: "test task that creates a system table",
-		MinVersion:  clusterversion.ByKey(clusterversion.V23_1Start),
+		MinVersion:  clusterversion.TestingBinaryVersion,
 		Payload: &autoconfigpb.Task_SimpleSQL{
 			SimpleSQL: &autoconfigpb.SimpleSQL{
 				UsernameProto: username.NodeUserName().EncodeProto(),
@@ -64,7 +64,7 @@ var testTasks = []testTask{
 	{task: autoconfigpb.Task{
 		TaskID:      345,
 		Description: "test task that fails with an error",
-		MinVersion:  clusterversion.ByKey(clusterversion.V23_1Start),
+		MinVersion:  clusterversion.TestingBinaryVersion,
 		Payload: &autoconfigpb.Task_SimpleSQL{
 			SimpleSQL: &autoconfigpb.SimpleSQL{
 				TransactionalStatements: []string{"SELECT invalid"},
@@ -74,7 +74,7 @@ var testTasks = []testTask{
 	{task: autoconfigpb.Task{
 		TaskID:      456,
 		Description: "test task that creates another system table",
-		MinVersion:  clusterversion.ByKey(clusterversion.V23_1Start),
+		MinVersion:  clusterversion.TestingBinaryVersion,
 		Payload: &autoconfigpb.Task_SimpleSQL{
 			SimpleSQL: &autoconfigpb.SimpleSQL{
 				UsernameProto:              username.NodeUserName().EncodeProto(),

--- a/pkg/server/autoconfig/auto_config_test.go
+++ b/pkg/server/autoconfig/auto_config_test.go
@@ -53,10 +53,12 @@ var testTasks = []testTask{
 			SimpleSQL: &autoconfigpb.SimpleSQL{
 				UsernameProto: username.NodeUserName().EncodeProto(),
 				NonTransactionalStatements: []string{
-					"CREATE TABLE IF NOT EXISTS system.foo(x INT)",
 					// This checks that the non-txn part works properly: SET
 					// CLUSTER SETTING can only be run outside of explicit txns.
 					"SET CLUSTER SETTING cluster.organization = 'woo'",
+				},
+				TransactionalStatements: []string{
+					"CREATE TABLE IF NOT EXISTS system.foo(x INT)",
 				},
 			},
 		},
@@ -77,8 +79,8 @@ var testTasks = []testTask{
 		MinVersion:  clusterversion.TestingBinaryVersion,
 		Payload: &autoconfigpb.Task_SimpleSQL{
 			SimpleSQL: &autoconfigpb.SimpleSQL{
-				UsernameProto:              username.NodeUserName().EncodeProto(),
-				NonTransactionalStatements: []string{"CREATE TABLE IF NOT EXISTS system.bar(y INT)"},
+				UsernameProto:           username.NodeUserName().EncodeProto(),
+				TransactionalStatements: []string{"CREATE TABLE IF NOT EXISTS system.bar(y INT)"},
 			},
 		},
 	}},


### PR DESCRIPTION
Needed for #101069.

The calls to Peek and Pop can run concurrently.

Release note: None
Epic: CRDB-23559