### PR TITLE
add DR, CDC, Jobs labels to test failures

### DIFF
--- a/TEAMS.yaml
+++ b/TEAMS.yaml
@@ -63,10 +63,13 @@ cockroachdb/prodsec:
   triage_column_id: 0 # TODO as well
 cockroachdb/disaster-recovery:
   triage_column_id: 3097123
+  label: T-disaster-recovery
 cockroachdb/cdc:
   aliases:
     cockroachdb/cdc-prs: other
-  triage_column_id: 3570120
+  # CDC team uses GH projects v2, which doesn't have a REST API, so no triage column ID
+  # see .github/workflows/add-issues-to-project.yml
+  label: T-cdc
 cockroachdb/server:
   aliases:
     cockroachdb/cli-prs: other
@@ -87,6 +90,7 @@ cockroachdb/jobs:
   aliases:
     cockroachdb/jobs-prs: other
   triage_column_id: 16360666
+  label: T-jobs
 cockroachdb/cloud-identity:
   triage_column_id: 18588697
 cockroachdb/unowned:


### PR DESCRIPTION
Ensure that test failures via the `cockroach-teamcity` bot labels DR, CDC and Jobs teams

Epic: none
Jira: none
