### PR TITLE
changefeedccl: disable pubsub v2 in 23.1 unit tests

### DIFF
--- a/pkg/ccl/changefeedccl/sink.go
+++ b/pkg/ccl/changefeedccl/sink.go
@@ -173,7 +173,7 @@ var PubsubV2Enabled = settings.RegisterBoolSetting(
 	"changefeed.new_pubsub_sink_enabled",
 	"if enabled, this setting enables a new implementation of the pubsub sink"+
 		" that allows for a higher throughput",
-	util.ConstantWithMetamorphicTestBool("changefeed.new_pubsub_sink_enabled", false),
+	false, // `true` fails in CI with "google: could not find default credentials"
 )
 
 func getSink(


### PR DESCRIPTION
Informs https://github.com/cockroachdb/cockroach/issues/101067

Tests have been failing specifically on release-23.1 with `changefeed_test.go:6157: failed to start feed for job 0: pq: opening client: google: could not find default credentials. See https://developers.google.com/accounts/docs/application-default-credentials for more information.`

Reproducing this has been difficult, the error doesn't show up even when removing `gcloud` entirely, so disabling pubsub v2 for now to reduce new spam.

Release note: None
Release justification: test only change