### PR TITLE
sql/schemachanger: relax rules for setting constraint names

### DIFF
--- a/pkg/cli/testdata/declarative-rules/deprules
+++ b/pkg/cli/testdata/declarative-rules/deprules
@@ -295,7 +295,7 @@ deprules
     - joinTargetNode($next, $next-Target, $next-Node)
 - name: Constraint should be hidden before name
   from: constraint-name-Node
-  kind: SameStagePrecedence
+  kind: Precedence
   to: constraint-Node
   query:
     - $constraint-name[Type] = '*scpb.ConstraintWithoutIndexName'
@@ -308,7 +308,7 @@ deprules
     - joinTargetNode($constraint, $constraint-Target, $constraint-Node)
 - name: Constraint should be hidden before name
   from: constraint-name-Node
-  kind: SameStagePrecedence
+  kind: Precedence
   to: constraint-Node
   query:
     - $constraint-name[Type] = '*scpb.ConstraintWithoutIndexName'
@@ -321,7 +321,7 @@ deprules
     - joinTargetNode($constraint, $constraint-Target, $constraint-Node)
 - name: Constraint should be hidden before name
   from: constraint-name-Node
-  kind: SameStagePrecedence
+  kind: Precedence
   to: constraint-Node
   query:
     - $constraint-name[Type] = '*scpb.ConstraintWithoutIndexName'
@@ -335,7 +335,7 @@ deprules
     - joinTargetNode($constraint, $constraint-Target, $constraint-Node)
 - name: Constraint should be hidden before name
   from: constraint-name-Node
-  kind: SameStagePrecedence
+  kind: Precedence
   to: constraint-Node
   query:
     - $constraint-name[Type] = '*scpb.ConstraintWithoutIndexName'
@@ -3402,7 +3402,7 @@ deprules
     - joinTargetNode($dependent, $dependent-Target, $dependent-Node)
 - name: simple constraint visible before name
   from: simple-constraint-Node
-  kind: SameStagePrecedence
+  kind: Precedence
   to: constraint-name-Node
   query:
     - $simple-constraint[Type] IN ['*scpb.UniqueWithoutIndexConstraint', '*scpb.UniqueWithoutIndexConstraintUnvalidated', '*scpb.CheckConstraint', '*scpb.CheckConstraintUnvalidated', '*scpb.ForeignKeyConstraint', '*scpb.ForeignKeyConstraintUnvalidated', '*scpb.ColumnNotNull']

--- a/pkg/sql/schemachanger/scplan/internal/rules/current/dep_add_constraint.go
+++ b/pkg/sql/schemachanger/scplan/internal/rules/current/dep_add_constraint.go
@@ -52,7 +52,7 @@ func init() {
 	// we won't have the correct message inside errors.
 	registerDepRule(
 		"simple constraint visible before name",
-		scgraph.SameStagePrecedence,
+		scgraph.Precedence,
 		"simple-constraint", "constraint-name",
 		func(from, to NodeVars) rel.Clauses {
 			return rel.Clauses{

--- a/pkg/sql/schemachanger/scplan/internal/rules/current/dep_drop_constraint.go
+++ b/pkg/sql/schemachanger/scplan/internal/rules/current/dep_drop_constraint.go
@@ -72,7 +72,7 @@ func init() {
 	// longer visible.
 	registerDepRuleForDrop(
 		"Constraint should be hidden before name",
-		scgraph.SameStagePrecedence,
+		scgraph.Precedence,
 		"constraint-name", "constraint",
 		scpb.Status_ABSENT, scpb.Status_ABSENT,
 		func(from, to NodeVars) rel.Clauses {

--- a/pkg/sql/schemachanger/scplan/internal/rules/current/testdata/deprules
+++ b/pkg/sql/schemachanger/scplan/internal/rules/current/testdata/deprules
@@ -292,7 +292,7 @@ deprules
     - joinTargetNode($next, $next-Target, $next-Node)
 - name: Constraint should be hidden before name
   from: constraint-name-Node
-  kind: SameStagePrecedence
+  kind: Precedence
   to: constraint-Node
   query:
     - $constraint-name[Type] = '*scpb.ConstraintWithoutIndexName'
@@ -305,7 +305,7 @@ deprules
     - joinTargetNode($constraint, $constraint-Target, $constraint-Node)
 - name: Constraint should be hidden before name
   from: constraint-name-Node
-  kind: SameStagePrecedence
+  kind: Precedence
   to: constraint-Node
   query:
     - $constraint-name[Type] = '*scpb.ConstraintWithoutIndexName'
@@ -318,7 +318,7 @@ deprules
     - joinTargetNode($constraint, $constraint-Target, $constraint-Node)
 - name: Constraint should be hidden before name
   from: constraint-name-Node
-  kind: SameStagePrecedence
+  kind: Precedence
   to: constraint-Node
   query:
     - $constraint-name[Type] = '*scpb.ConstraintWithoutIndexName'
@@ -332,7 +332,7 @@ deprules
     - joinTargetNode($constraint, $constraint-Target, $constraint-Node)
 - name: Constraint should be hidden before name
   from: constraint-name-Node
-  kind: SameStagePrecedence
+  kind: Precedence
   to: constraint-Node
   query:
     - $constraint-name[Type] = '*scpb.ConstraintWithoutIndexName'
@@ -3399,7 +3399,7 @@ deprules
     - joinTargetNode($dependent, $dependent-Target, $dependent-Node)
 - name: simple constraint visible before name
   from: simple-constraint-Node
-  kind: SameStagePrecedence
+  kind: Precedence
   to: constraint-name-Node
   query:
     - $simple-constraint[Type] IN ['*scpb.UniqueWithoutIndexConstraint', '*scpb.UniqueWithoutIndexConstraintUnvalidated', '*scpb.CheckConstraint', '*scpb.CheckConstraintUnvalidated', '*scpb.ForeignKeyConstraint', '*scpb.ForeignKeyConstraintUnvalidated', '*scpb.ColumnNotNull']
@@ -3774,7 +3774,7 @@ deprules
     - joinTargetNode($next, $next-Target, $next-Node)
 - name: Constraint should be hidden before name
   from: constraint-name-Node
-  kind: SameStagePrecedence
+  kind: Precedence
   to: constraint-Node
   query:
     - $constraint-name[Type] = '*scpb.ConstraintWithoutIndexName'
@@ -3787,7 +3787,7 @@ deprules
     - joinTargetNode($constraint, $constraint-Target, $constraint-Node)
 - name: Constraint should be hidden before name
   from: constraint-name-Node
-  kind: SameStagePrecedence
+  kind: Precedence
   to: constraint-Node
   query:
     - $constraint-name[Type] = '*scpb.ConstraintWithoutIndexName'
@@ -3800,7 +3800,7 @@ deprules
     - joinTargetNode($constraint, $constraint-Target, $constraint-Node)
 - name: Constraint should be hidden before name
   from: constraint-name-Node
-  kind: SameStagePrecedence
+  kind: Precedence
   to: constraint-Node
   query:
     - $constraint-name[Type] = '*scpb.ConstraintWithoutIndexName'
@@ -3814,7 +3814,7 @@ deprules
     - joinTargetNode($constraint, $constraint-Target, $constraint-Node)
 - name: Constraint should be hidden before name
   from: constraint-name-Node
-  kind: SameStagePrecedence
+  kind: Precedence
   to: constraint-Node
   query:
     - $constraint-name[Type] = '*scpb.ConstraintWithoutIndexName'
@@ -6881,7 +6881,7 @@ deprules
     - joinTargetNode($dependent, $dependent-Target, $dependent-Node)
 - name: simple constraint visible before name
   from: simple-constraint-Node
-  kind: SameStagePrecedence
+  kind: Precedence
   to: constraint-name-Node
   query:
     - $simple-constraint[Type] IN ['*scpb.UniqueWithoutIndexConstraint', '*scpb.UniqueWithoutIndexConstraintUnvalidated', '*scpb.CheckConstraint', '*scpb.CheckConstraintUnvalidated', '*scpb.ForeignKeyConstraint', '*scpb.ForeignKeyConstraintUnvalidated', '*scpb.ColumnNotNull']

--- a/pkg/sql/schemachanger/scplan/testdata/alter_table_add_check
+++ b/pkg/sql/schemachanger/scplan/testdata/alter_table_add_check
@@ -98,5 +98,5 @@ ALTER TABLE t ADD CHECK (i > 0)
   rule: CheckConstraint transitions to PUBLIC uphold 2-version invariant: WRITE_ONLY->VALIDATED
 - from: [CheckConstraint:{DescID: 104, IndexID: 0, ConstraintID: 2}, WRITE_ONLY]
   to:   [ConstraintWithoutIndexName:{DescID: 104, Name: check_i, ConstraintID: 2}, PUBLIC]
-  kind: SameStagePrecedence
+  kind: Precedence
   rule: simple constraint visible before name

--- a/pkg/sql/schemachanger/scplan/testdata/alter_table_add_check_udf
+++ b/pkg/sql/schemachanger/scplan/testdata/alter_table_add_check_udf
@@ -118,5 +118,5 @@ ALTER TABLE t ADD CONSTRAINT check_b CHECK (f(b) > 1);
   rule: CheckConstraint transitions to PUBLIC uphold 2-version invariant: WRITE_ONLY->VALIDATED
 - from: [CheckConstraint:{DescID: 104, IndexID: 0, ConstraintID: 2}, WRITE_ONLY]
   to:   [ConstraintWithoutIndexName:{DescID: 104, Name: check_b, ConstraintID: 2}, PUBLIC]
-  kind: SameStagePrecedence
+  kind: Precedence
   rule: simple constraint visible before name

--- a/pkg/sql/schemachanger/scplan/testdata/drop_index
+++ b/pkg/sql/schemachanger/scplan/testdata/drop_index
@@ -366,13 +366,14 @@ DROP INDEX idx2 CASCADE
 ops
 DROP INDEX idx3 CASCADE
 ----
-StatementPhase stage 1 of 1 with 5 MutationType ops
+StatementPhase stage 1 of 1 with 6 MutationType ops
   transitions:
     [[Column:{DescID: 104, ColumnID: 5}, ABSENT], PUBLIC] -> WRITE_ONLY
     [[ColumnName:{DescID: 104, Name: crdb_internal_i_shard_16, ColumnID: 5}, ABSENT], PUBLIC] -> ABSENT
     [[ColumnNotNull:{DescID: 104, ColumnID: 5, IndexID: 0}, ABSENT], PUBLIC] -> VALIDATED
     [[SecondaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 0}, ABSENT], PUBLIC] -> VALIDATED
     [[CheckConstraint:{DescID: 104, IndexID: 0, ConstraintID: 2}, ABSENT], PUBLIC] -> VALIDATED
+    [[ConstraintWithoutIndexName:{DescID: 104, Name: check_crdb_internal_i_shard_16, ConstraintID: 2}, ABSENT], PUBLIC] -> ABSENT
   ops:
     *scop.MakePublicColumnNotNullValidated
       ColumnID: 5
@@ -382,6 +383,10 @@ StatementPhase stage 1 of 1 with 5 MutationType ops
       TableID: 104
     *scop.MakePublicCheckConstraintValidated
       ConstraintID: 2
+      TableID: 104
+    *scop.SetConstraintName
+      ConstraintID: 2
+      Name: crdb_internal_constraint_2_name_placeholder
       TableID: 104
     *scop.MakePublicColumnWriteOnly
       ColumnID: 5
@@ -397,16 +402,18 @@ PreCommitPhase stage 1 of 2 with 1 MutationType op
     [[ColumnNotNull:{DescID: 104, ColumnID: 5, IndexID: 0}, ABSENT], VALIDATED] -> PUBLIC
     [[SecondaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 0}, ABSENT], VALIDATED] -> PUBLIC
     [[CheckConstraint:{DescID: 104, IndexID: 0, ConstraintID: 2}, ABSENT], VALIDATED] -> PUBLIC
+    [[ConstraintWithoutIndexName:{DescID: 104, Name: check_crdb_internal_i_shard_16, ConstraintID: 2}, ABSENT], ABSENT] -> PUBLIC
   ops:
     *scop.UndoAllInTxnImmediateMutationOpSideEffects
       {}
-PreCommitPhase stage 2 of 2 with 7 MutationType ops
+PreCommitPhase stage 2 of 2 with 8 MutationType ops
   transitions:
     [[Column:{DescID: 104, ColumnID: 5}, ABSENT], PUBLIC] -> WRITE_ONLY
     [[ColumnName:{DescID: 104, Name: crdb_internal_i_shard_16, ColumnID: 5}, ABSENT], PUBLIC] -> ABSENT
     [[ColumnNotNull:{DescID: 104, ColumnID: 5, IndexID: 0}, ABSENT], PUBLIC] -> VALIDATED
     [[SecondaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 0}, ABSENT], PUBLIC] -> VALIDATED
     [[CheckConstraint:{DescID: 104, IndexID: 0, ConstraintID: 2}, ABSENT], PUBLIC] -> VALIDATED
+    [[ConstraintWithoutIndexName:{DescID: 104, Name: check_crdb_internal_i_shard_16, ConstraintID: 2}, ABSENT], PUBLIC] -> ABSENT
   ops:
     *scop.MakePublicColumnNotNullValidated
       ColumnID: 5
@@ -416,6 +423,10 @@ PreCommitPhase stage 2 of 2 with 7 MutationType ops
       TableID: 104
     *scop.MakePublicCheckConstraintValidated
       ConstraintID: 2
+      TableID: 104
+    *scop.SetConstraintName
+      ConstraintID: 2
+      Name: crdb_internal_constraint_2_name_placeholder
       TableID: 104
     *scop.MakePublicColumnWriteOnly
       ColumnID: 5
@@ -434,12 +445,12 @@ PreCommitPhase stage 2 of 2 with 7 MutationType ops
       - 104
       JobID: 1
       NonCancelable: true
-      RunningStatus: PostCommitNonRevertiblePhase stage 1 of 2 with 9 MutationType ops pending
+      RunningStatus: PostCommitNonRevertiblePhase stage 1 of 2 with 8 MutationType ops pending
       Statements:
       - statement: DROP INDEX idx3 CASCADE
         redactedstatement: DROP INDEX ‹defaultdb›.public.‹t1›@‹idx3› CASCADE
         statementtag: DROP INDEX
-PostCommitNonRevertiblePhase stage 1 of 2 with 11 MutationType ops
+PostCommitNonRevertiblePhase stage 1 of 2 with 10 MutationType ops
   transitions:
     [[Column:{DescID: 104, ColumnID: 5}, ABSENT], WRITE_ONLY] -> DELETE_ONLY
     [[ColumnNotNull:{DescID: 104, ColumnID: 5, IndexID: 0}, ABSENT], VALIDATED] -> ABSENT
@@ -449,14 +460,12 @@ PostCommitNonRevertiblePhase stage 1 of 2 with 11 MutationType ops
     [[SecondaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 0}, ABSENT], VALIDATED] -> DELETE_ONLY
     [[IndexName:{DescID: 104, Name: idx3, IndexID: 6}, ABSENT], PUBLIC] -> ABSENT
     [[CheckConstraint:{DescID: 104, IndexID: 0, ConstraintID: 2}, ABSENT], VALIDATED] -> ABSENT
-    [[ConstraintWithoutIndexName:{DescID: 104, Name: check_crdb_internal_i_shard_16, ConstraintID: 2}, ABSENT], PUBLIC] -> ABSENT
   ops:
     *scop.RemoveColumnNotNull
       ColumnID: 5
       TableID: 104
-    *scop.SetConstraintName
+    *scop.RemoveCheckConstraint
       ConstraintID: 2
-      Name: crdb_internal_constraint_2_name_placeholder
       TableID: 104
     *scop.MakeWriteOnlyColumnDeleteOnly
       ColumnID: 5
@@ -467,9 +476,6 @@ PostCommitNonRevertiblePhase stage 1 of 2 with 11 MutationType ops
     *scop.SetIndexName
       IndexID: 6
       Name: crdb_internal_index_6_name_placeholder
-      TableID: 104
-    *scop.RemoveCheckConstraint
-      ConstraintID: 2
       TableID: 104
     *scop.RemoveColumnFromIndex
       ColumnID: 5
@@ -586,7 +592,7 @@ DROP INDEX idx3 CASCADE
   rules: [dependents removed before column; column type removed right before column when not dropping relation]
 - from: [ConstraintWithoutIndexName:{DescID: 104, Name: check_crdb_internal_i_shard_16, ConstraintID: 2}, ABSENT]
   to:   [CheckConstraint:{DescID: 104, IndexID: 0, ConstraintID: 2}, ABSENT]
-  kind: SameStagePrecedence
+  kind: Precedence
   rule: Constraint should be hidden before name
 - from: [IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 6}, ABSENT]
   to:   [SecondaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 0}, ABSENT]

--- a/pkg/sql/schemachanger/scplan/testdata/drop_table
+++ b/pkg/sql/schemachanger/scplan/testdata/drop_table
@@ -35,12 +35,16 @@ ALTER TABLE shipments ALTER COLUMN udfcol SET DEFAULT f1();
 ops
 DROP TABLE defaultdb.shipments CASCADE;
 ----
-StatementPhase stage 1 of 1 with 19 MutationType ops
+StatementPhase stage 1 of 1 with 23 MutationType ops
   transitions:
+    [[ConstraintWithoutIndexName:{DescID: 109, Name: check, ConstraintID: 5}, ABSENT], PUBLIC] -> ABSENT
     [[ForeignKeyConstraint:{DescID: 109, IndexID: 0, ConstraintID: 2, ReferencedDescID: 104}, ABSENT], PUBLIC] -> VALIDATED
+    [[ConstraintWithoutIndexName:{DescID: 109, Name: fk_customers, ConstraintID: 2}, ABSENT], PUBLIC] -> ABSENT
     [[ConstraintComment:{DescID: 109, ConstraintID: 2, Comment: customer is not god}, ABSENT], PUBLIC] -> ABSENT
     [[ForeignKeyConstraint:{DescID: 109, IndexID: 0, ConstraintID: 3, ReferencedDescID: 105}, ABSENT], PUBLIC] -> VALIDATED
+    [[ConstraintWithoutIndexName:{DescID: 109, Name: fk_orders, ConstraintID: 3}, ABSENT], PUBLIC] -> ABSENT
     [[ForeignKeyConstraint:{DescID: 109, IndexID: 0, ConstraintID: 4, ReferencedDescID: 104}, ABSENT], PUBLIC] -> VALIDATED
+    [[ConstraintWithoutIndexName:{DescID: 109, Name: fk_customers2, ConstraintID: 4}, ABSENT], PUBLIC] -> ABSENT
     [[Namespace:{DescID: 111, Name: v1, ReferencedDescID: 100}, ABSENT], PUBLIC] -> ABSENT
     [[Owner:{DescID: 111}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 111, Name: admin}, ABSENT], PUBLIC] -> ABSENT
@@ -60,8 +64,16 @@ StatementPhase stage 1 of 1 with 19 MutationType ops
     [[ColumnName:{DescID: 111, Name: tableoid, ColumnID: 4294967294}, ABSENT], PUBLIC] -> ABSENT
     [[ColumnType:{DescID: 111, ColumnFamilyID: 0, ColumnID: 4294967294}, ABSENT], PUBLIC] -> ABSENT
   ops:
+    *scop.SetConstraintName
+      ConstraintID: 5
+      Name: crdb_internal_constraint_5_name_placeholder
+      TableID: 109
     *scop.MakePublicForeignKeyConstraintValidated
       ConstraintID: 2
+      TableID: 109
+    *scop.SetConstraintName
+      ConstraintID: 2
+      Name: crdb_internal_constraint_2_name_placeholder
       TableID: 109
     *scop.RemoveConstraintComment
       ConstraintID: 2
@@ -69,8 +81,16 @@ StatementPhase stage 1 of 1 with 19 MutationType ops
     *scop.MakePublicForeignKeyConstraintValidated
       ConstraintID: 3
       TableID: 109
+    *scop.SetConstraintName
+      ConstraintID: 3
+      Name: crdb_internal_constraint_3_name_placeholder
+      TableID: 109
     *scop.MakePublicForeignKeyConstraintValidated
       ConstraintID: 4
+      TableID: 109
+    *scop.SetConstraintName
+      ConstraintID: 4
+      Name: crdb_internal_constraint_4_name_placeholder
       TableID: 109
     *scop.MarkDescriptorAsDropped
       DescriptorID: 111
@@ -126,10 +146,14 @@ StatementPhase stage 1 of 1 with 19 MutationType ops
       User: root
 PreCommitPhase stage 1 of 2 with 1 MutationType op
   transitions:
+    [[ConstraintWithoutIndexName:{DescID: 109, Name: check, ConstraintID: 5}, ABSENT], ABSENT] -> PUBLIC
     [[ForeignKeyConstraint:{DescID: 109, IndexID: 0, ConstraintID: 2, ReferencedDescID: 104}, ABSENT], VALIDATED] -> PUBLIC
+    [[ConstraintWithoutIndexName:{DescID: 109, Name: fk_customers, ConstraintID: 2}, ABSENT], ABSENT] -> PUBLIC
     [[ConstraintComment:{DescID: 109, ConstraintID: 2, Comment: customer is not god}, ABSENT], ABSENT] -> PUBLIC
     [[ForeignKeyConstraint:{DescID: 109, IndexID: 0, ConstraintID: 3, ReferencedDescID: 105}, ABSENT], VALIDATED] -> PUBLIC
+    [[ConstraintWithoutIndexName:{DescID: 109, Name: fk_orders, ConstraintID: 3}, ABSENT], ABSENT] -> PUBLIC
     [[ForeignKeyConstraint:{DescID: 109, IndexID: 0, ConstraintID: 4, ReferencedDescID: 104}, ABSENT], VALIDATED] -> PUBLIC
+    [[ConstraintWithoutIndexName:{DescID: 109, Name: fk_customers2, ConstraintID: 4}, ABSENT], ABSENT] -> PUBLIC
     [[Namespace:{DescID: 111, Name: v1, ReferencedDescID: 100}, ABSENT], ABSENT] -> PUBLIC
     [[Owner:{DescID: 111}, ABSENT], ABSENT] -> PUBLIC
     [[UserPrivileges:{DescID: 111, Name: admin}, ABSENT], ABSENT] -> PUBLIC
@@ -239,6 +263,10 @@ PreCommitPhase stage 2 of 2 with 127 MutationType ops
     [[ColumnName:{DescID: 111, Name: tableoid, ColumnID: 4294967294}, ABSENT], PUBLIC] -> ABSENT
     [[ColumnType:{DescID: 111, ColumnFamilyID: 0, ColumnID: 4294967294}, ABSENT], PUBLIC] -> ABSENT
   ops:
+    *scop.SetConstraintName
+      ConstraintID: 5
+      Name: crdb_internal_constraint_5_name_placeholder
+      TableID: 109
     *scop.MakePublicForeignKeyConstraintValidated
       ConstraintID: 2
       TableID: 109
@@ -305,10 +333,6 @@ PreCommitPhase stage 2 of 2 with 127 MutationType ops
       ColumnID: 4294967294
       Name: crdb_internal_column_4294967294_name_placeholder
       TableID: 111
-    *scop.SetConstraintName
-      ConstraintID: 5
-      Name: crdb_internal_constraint_5_name_placeholder
-      TableID: 109
     *scop.RemoveForeignKeyBackReference
       OriginConstraintID: 2
       OriginTableID: 109
@@ -1271,7 +1295,7 @@ DROP TABLE defaultdb.shipments CASCADE;
   rule: non-data dependents removed before descriptor
 - from: [ConstraintWithoutIndexName:{DescID: 109, Name: check, ConstraintID: 5}, ABSENT]
   to:   [CheckConstraintUnvalidated:{DescID: 109, ConstraintID: 5, ReferencedSequenceIDs: [106]}, ABSENT]
-  kind: SameStagePrecedence
+  kind: Precedence
   rule: Constraint should be hidden before name
 - from: [ConstraintWithoutIndexName:{DescID: 109, Name: check, ConstraintID: 5}, ABSENT]
   to:   [Table:{DescID: 109}, ABSENT]
@@ -1279,7 +1303,7 @@ DROP TABLE defaultdb.shipments CASCADE;
   rule: non-data dependents removed before descriptor
 - from: [ConstraintWithoutIndexName:{DescID: 109, Name: fk_customers, ConstraintID: 2}, ABSENT]
   to:   [ForeignKeyConstraint:{DescID: 109, IndexID: 0, ConstraintID: 2, ReferencedDescID: 104}, ABSENT]
-  kind: SameStagePrecedence
+  kind: Precedence
   rule: Constraint should be hidden before name
 - from: [ConstraintWithoutIndexName:{DescID: 109, Name: fk_customers, ConstraintID: 2}, ABSENT]
   to:   [Table:{DescID: 109}, ABSENT]
@@ -1287,7 +1311,7 @@ DROP TABLE defaultdb.shipments CASCADE;
   rule: non-data dependents removed before descriptor
 - from: [ConstraintWithoutIndexName:{DescID: 109, Name: fk_customers2, ConstraintID: 4}, ABSENT]
   to:   [ForeignKeyConstraint:{DescID: 109, IndexID: 0, ConstraintID: 4, ReferencedDescID: 104}, ABSENT]
-  kind: SameStagePrecedence
+  kind: Precedence
   rule: Constraint should be hidden before name
 - from: [ConstraintWithoutIndexName:{DescID: 109, Name: fk_customers2, ConstraintID: 4}, ABSENT]
   to:   [Table:{DescID: 109}, ABSENT]
@@ -1295,7 +1319,7 @@ DROP TABLE defaultdb.shipments CASCADE;
   rule: non-data dependents removed before descriptor
 - from: [ConstraintWithoutIndexName:{DescID: 109, Name: fk_orders, ConstraintID: 3}, ABSENT]
   to:   [ForeignKeyConstraint:{DescID: 109, IndexID: 0, ConstraintID: 3, ReferencedDescID: 105}, ABSENT]
-  kind: SameStagePrecedence
+  kind: Precedence
   rule: Constraint should be hidden before name
 - from: [ConstraintWithoutIndexName:{DescID: 109, Name: fk_orders, ConstraintID: 3}, ABSENT]
   to:   [Table:{DescID: 109}, ABSENT]
@@ -2715,16 +2739,22 @@ CREATE TABLE defaultdb.greeter (
 ops
 DROP TABLE defaultdb.greeter
 ----
-StatementPhase stage 1 of 1 with 1 MutationType op
+StatementPhase stage 1 of 1 with 2 MutationType ops
   transitions:
     [[CheckConstraint:{DescID: 115, ReferencedTypeIDs: [113 114], IndexID: 0, ConstraintID: 2}, ABSENT], PUBLIC] -> VALIDATED
+    [[ConstraintWithoutIndexName:{DescID: 115, Name: check, ConstraintID: 2}, ABSENT], PUBLIC] -> ABSENT
   ops:
     *scop.MakePublicCheckConstraintValidated
       ConstraintID: 2
       TableID: 115
+    *scop.SetConstraintName
+      ConstraintID: 2
+      Name: crdb_internal_constraint_2_name_placeholder
+      TableID: 115
 PreCommitPhase stage 1 of 2 with 1 MutationType op
   transitions:
     [[CheckConstraint:{DescID: 115, ReferencedTypeIDs: [113 114], IndexID: 0, ConstraintID: 2}, ABSENT], VALIDATED] -> PUBLIC
+    [[ConstraintWithoutIndexName:{DescID: 115, Name: check, ConstraintID: 2}, ABSENT], ABSENT] -> PUBLIC
   ops:
     *scop.UndoAllInTxnImmediateMutationOpSideEffects
       {}

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_drop_constraint_check
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_drop_constraint_check
@@ -23,11 +23,13 @@ begin transaction #1
 checking for feature: ALTER TABLE
 increment telemetry for sql.schema.alter_table
 increment telemetry for sql.schema.alter_table.drop_constraint
-## StatementPhase stage 1 of 1 with 1 MutationType op
+## StatementPhase stage 1 of 1 with 2 MutationType ops
 upsert descriptor #104
   ...
+       constraintId: 2
        expr: i > 0:::INT8
-       name: check_i
+  -    name: check_i
+  +    name: crdb_internal_constraint_2_name_placeholder
   +    validity: Dropping
      columns:
      - id: 1
@@ -61,11 +63,13 @@ upsert descriptor #104
 ## PreCommitPhase stage 1 of 2 with 1 MutationType op
 undo all catalog changes within txn #1
 persist all catalog changes to storage
-## PreCommitPhase stage 2 of 2 with 3 MutationType ops
+## PreCommitPhase stage 2 of 2 with 4 MutationType ops
 upsert descriptor #104
   ...
+       constraintId: 2
        expr: i > 0:::INT8
-       name: check_i
+  -    name: check_i
+  +    name: crdb_internal_constraint_2_name_placeholder
   +    validity: Dropping
      columns:
      - id: 1
@@ -121,7 +125,7 @@ notified job registry to adopt jobs: [1]
 begin transaction #2
 commit transaction #2
 begin transaction #3
-## PostCommitNonRevertiblePhase stage 1 of 1 with 4 MutationType ops
+## PostCommitNonRevertiblePhase stage 1 of 1 with 3 MutationType ops
 upsert descriptor #104
    table:
   -  checks:
@@ -129,7 +133,7 @@ upsert descriptor #104
   -    - 1
   -    constraintId: 2
   -    expr: i > 0:::INT8
-  -    name: check_i
+  -    name: crdb_internal_constraint_2_name_placeholder
   -    validity: Dropping
   +  checks: []
      columns:

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_drop_constraint_fk
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_drop_constraint_fk
@@ -11,7 +11,7 @@ CREATE TABLE t1 (i INT PRIMARY KEY REFERENCES t2(i));
 stage-exec phase=PostCommitNonRevertiblePhase stage=1
 INSERT INTO t1 VALUES (0);
 ----
-pq: insert on table "t1" violates foreign key constraint "t1_i_fkey"
+pq: insert on table "t1" violates foreign key constraint "crdb_internal_constraint_2_name_placeholder"
 
 stage-query phase=PostCommitNonRevertiblePhase stage=1
 SELECT count(*) FROM t1;
@@ -52,8 +52,15 @@ begin transaction #1
 checking for feature: ALTER TABLE
 increment telemetry for sql.schema.alter_table
 increment telemetry for sql.schema.alter_table.drop_constraint
-## StatementPhase stage 1 of 1 with 1 MutationType op
+## StatementPhase stage 1 of 1 with 2 MutationType ops
 upsert descriptor #104
+  ...
+     inboundFks:
+     - constraintId: 2
+  -    name: t1_i_fkey
+  +    name: crdb_internal_constraint_2_name_placeholder
+       originColumnIds:
+       - 1
   ...
        - 1
        referencedTableId: 104
@@ -75,7 +82,7 @@ upsert descriptor #105
   +      constraintType: FOREIGN_KEY
   +      foreignKey:
   +        constraintId: 2
-  +        name: t1_i_fkey
+  +        name: crdb_internal_constraint_2_name_placeholder
   +        originColumnIds:
   +        - 1
   +        originTableId: 105
@@ -114,7 +121,7 @@ upsert descriptor #105
 ## PreCommitPhase stage 1 of 2 with 1 MutationType op
 undo all catalog changes within txn #1
 persist all catalog changes to storage
-## PreCommitPhase stage 2 of 2 with 4 MutationType ops
+## PreCommitPhase stage 2 of 2 with 5 MutationType ops
 upsert descriptor #104
   ...
      createAsOfTime:
@@ -125,6 +132,13 @@ upsert descriptor #104
   +    jobId: "1"
      families:
      - columnIds:
+  ...
+     inboundFks:
+     - constraintId: 2
+  -    name: t1_i_fkey
+  +    name: crdb_internal_constraint_2_name_placeholder
+       originColumnIds:
+       - 1
   ...
        - 1
        referencedTableId: 104
@@ -163,7 +177,7 @@ upsert descriptor #105
   +      constraintType: FOREIGN_KEY
   +      foreignKey:
   +        constraintId: 2
-  +        name: t1_i_fkey
+  +        name: crdb_internal_constraint_2_name_placeholder
   +        originColumnIds:
   +        - 1
   +        originTableId: 105
@@ -207,7 +221,7 @@ notified job registry to adopt jobs: [1]
 begin transaction #2
 commit transaction #2
 begin transaction #3
-## PostCommitNonRevertiblePhase stage 1 of 1 with 6 MutationType ops
+## PostCommitNonRevertiblePhase stage 1 of 1 with 5 MutationType ops
 upsert descriptor #104
   ...
      createAsOfTime:
@@ -223,7 +237,7 @@ upsert descriptor #104
      id: 104
   -  inboundFks:
   -  - constraintId: 2
-  -    name: t1_i_fkey
+  -    name: crdb_internal_constraint_2_name_placeholder
   -    originColumnIds:
   -    - 1
   -    originTableId: 105
@@ -265,7 +279,7 @@ upsert descriptor #105
   -      constraintType: FOREIGN_KEY
   -      foreignKey:
   -        constraintId: 2
-  -        name: t1_i_fkey
+  -        name: crdb_internal_constraint_2_name_placeholder
   -        originColumnIds:
   -        - 1
   -        originTableId: 105

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_drop_constraint_uwi
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_drop_constraint_uwi
@@ -12,7 +12,7 @@ stage-exec phase=PostCommitNonRevertiblePhase stage=1
 INSERT INTO t VALUES ($stageKey, $stageKey);
 INSERT INTO t VALUES ($stageKey+1, $stageKey);
 ----
-pq: duplicate key value violates unique constraint "unique_j"
+pq: duplicate key value violates unique constraint "crdb_internal_constraint_2_name_placeholder"
 
 stage-query phase=PostCommitNonRevertiblePhase stage=1
 SELECT count(*) FROM t;
@@ -28,7 +28,7 @@ begin transaction #1
 checking for feature: ALTER TABLE
 increment telemetry for sql.schema.alter_table
 increment telemetry for sql.schema.alter_table.drop_constraint
-## StatementPhase stage 1 of 1 with 1 MutationType op
+## StatementPhase stage 1 of 1 with 2 MutationType ops
 upsert descriptor #104
   ...
      id: 104
@@ -43,7 +43,7 @@ upsert descriptor #104
   +        columnIds:
   +        - 2
   +        constraintId: 2
-  +        name: unique_j
+  +        name: crdb_internal_constraint_2_name_placeholder
   +        tableId: 104
   +        validity: Dropping
   +    direction: DROP
@@ -67,7 +67,7 @@ upsert descriptor #104
 ## PreCommitPhase stage 1 of 2 with 1 MutationType op
 undo all catalog changes within txn #1
 persist all catalog changes to storage
-## PreCommitPhase stage 2 of 2 with 3 MutationType ops
+## PreCommitPhase stage 2 of 2 with 4 MutationType ops
 upsert descriptor #104
   ...
      createAsOfTime:
@@ -99,7 +99,7 @@ upsert descriptor #104
   +        columnIds:
   +        - 2
   +        constraintId: 2
-  +        name: unique_j
+  +        name: crdb_internal_constraint_2_name_placeholder
   +        tableId: 104
   +        validity: Dropping
   +    direction: DROP
@@ -128,7 +128,7 @@ notified job registry to adopt jobs: [1]
 begin transaction #2
 commit transaction #2
 begin transaction #3
-## PostCommitNonRevertiblePhase stage 1 of 1 with 4 MutationType ops
+## PostCommitNonRevertiblePhase stage 1 of 1 with 3 MutationType ops
 upsert descriptor #104
   ...
      createAsOfTime:
@@ -160,7 +160,7 @@ upsert descriptor #104
   -        columnIds:
   -        - 2
   -        constraintId: 2
-  -        name: unique_j
+  -        name: crdb_internal_constraint_2_name_placeholder
   -        tableId: 104
   -        validity: Dropping
   -    direction: DROP

--- a/pkg/sql/schemachanger/testdata/end_to_end/drop_index_hash_sharded_index
+++ b/pkg/sql/schemachanger/testdata/end_to_end/drop_index_hash_sharded_index
@@ -37,7 +37,7 @@ write *eventpb.DropIndex to event log:
     tag: DROP INDEX
     user: root
   tableName: defaultdb.public.t
-## StatementPhase stage 1 of 1 with 5 MutationType ops
+## StatementPhase stage 1 of 1 with 6 MutationType ops
 upsert descriptor #104
   ...
        - 3
@@ -46,7 +46,8 @@ upsert descriptor #104
   +    expr: crdb_internal_column_3_name_placeholder IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9,
   +      10, 11, 12, 13, 14, 15)
        fromHashShardedColumn: true
-       name: check_crdb_internal_j_shard_16
+  -    name: check_crdb_internal_j_shard_16
+  +    name: crdb_internal_constraint_2_name_placeholder
   +    validity: Dropping
   +  - columnIds:
   +    - 3
@@ -193,7 +194,7 @@ upsert descriptor #104
 ## PreCommitPhase stage 1 of 2 with 1 MutationType op
 undo all catalog changes within txn #1
 persist all catalog changes to storage
-## PreCommitPhase stage 2 of 2 with 7 MutationType ops
+## PreCommitPhase stage 2 of 2 with 8 MutationType ops
 upsert descriptor #104
   ...
        - 3
@@ -202,7 +203,8 @@ upsert descriptor #104
   +    expr: crdb_internal_column_3_name_placeholder IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9,
   +      10, 11, 12, 13, 14, 15)
        fromHashShardedColumn: true
-       name: check_crdb_internal_j_shard_16
+  -    name: check_crdb_internal_j_shard_16
+  +    name: crdb_internal_constraint_2_name_placeholder
   +    validity: Dropping
   +  - columnIds:
   +    - 3
@@ -368,7 +370,7 @@ notified job registry to adopt jobs: [1]
 begin transaction #2
 commit transaction #2
 begin transaction #3
-## PostCommitNonRevertiblePhase stage 1 of 2 with 11 MutationType ops
+## PostCommitNonRevertiblePhase stage 1 of 2 with 10 MutationType ops
 upsert descriptor #104
    table:
   -  checks:
@@ -378,7 +380,7 @@ upsert descriptor #104
   -    expr: crdb_internal_column_3_name_placeholder IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9,
   -      10, 11, 12, 13, 14, 15)
   -    fromHashShardedColumn: true
-  -    name: check_crdb_internal_j_shard_16
+  -    name: crdb_internal_constraint_2_name_placeholder
   -    validity: Dropping
   -  - columnIds:
   -    - 3

--- a/pkg/sql/schemachanger/testdata/explain/alter_table_drop_constraint_check
+++ b/pkg/sql/schemachanger/testdata/explain/alter_table_drop_constraint_check
@@ -7,30 +7,33 @@ EXPLAIN (ddl) ALTER TABLE t DROP CONSTRAINT check_i;
 Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› DROP CONSTRAINT ‹check_i›;
  ├── StatementPhase
  │    └── Stage 1 of 1 in StatementPhase
- │         ├── 1 element transitioning toward ABSENT
- │         │    └── PUBLIC → VALIDATED CheckConstraint:{DescID: 104, IndexID: 0, ConstraintID: 2}
- │         └── 1 Mutation operation
- │              └── MakePublicCheckConstraintValidated {"ConstraintID":2,"TableID":104}
+ │         ├── 2 elements transitioning toward ABSENT
+ │         │    ├── PUBLIC → VALIDATED CheckConstraint:{DescID: 104, IndexID: 0, ConstraintID: 2}
+ │         │    └── PUBLIC → ABSENT    ConstraintWithoutIndexName:{DescID: 104, Name: check_i, ConstraintID: 2}
+ │         └── 2 Mutation operations
+ │              ├── MakePublicCheckConstraintValidated {"ConstraintID":2,"TableID":104}
+ │              └── SetConstraintName {"ConstraintID":2,"Name":"crdb_internal_co...","TableID":104}
  ├── PreCommitPhase
  │    ├── Stage 1 of 2 in PreCommitPhase
- │    │    ├── 1 element transitioning toward ABSENT
- │    │    │    └── VALIDATED → PUBLIC CheckConstraint:{DescID: 104, IndexID: 0, ConstraintID: 2}
+ │    │    ├── 2 elements transitioning toward ABSENT
+ │    │    │    ├── VALIDATED → PUBLIC CheckConstraint:{DescID: 104, IndexID: 0, ConstraintID: 2}
+ │    │    │    └── ABSENT    → PUBLIC ConstraintWithoutIndexName:{DescID: 104, Name: check_i, ConstraintID: 2}
  │    │    └── 1 Mutation operation
  │    │         └── UndoAllInTxnImmediateMutationOpSideEffects
  │    └── Stage 2 of 2 in PreCommitPhase
- │         ├── 1 element transitioning toward ABSENT
- │         │    └── PUBLIC → VALIDATED CheckConstraint:{DescID: 104, IndexID: 0, ConstraintID: 2}
- │         └── 3 Mutation operations
+ │         ├── 2 elements transitioning toward ABSENT
+ │         │    ├── PUBLIC → VALIDATED CheckConstraint:{DescID: 104, IndexID: 0, ConstraintID: 2}
+ │         │    └── PUBLIC → ABSENT    ConstraintWithoutIndexName:{DescID: 104, Name: check_i, ConstraintID: 2}
+ │         └── 4 Mutation operations
  │              ├── MakePublicCheckConstraintValidated {"ConstraintID":2,"TableID":104}
+ │              ├── SetConstraintName {"ConstraintID":2,"Name":"crdb_internal_co...","TableID":104}
  │              ├── SetJobStateOnDescriptor {"DescriptorID":104,"Initialize":true}
  │              └── CreateSchemaChangerJob {"NonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
  └── PostCommitNonRevertiblePhase
       └── Stage 1 of 1 in PostCommitNonRevertiblePhase
-           ├── 2 elements transitioning toward ABSENT
-           │    ├── VALIDATED → ABSENT CheckConstraint:{DescID: 104, IndexID: 0, ConstraintID: 2}
-           │    └── PUBLIC    → ABSENT ConstraintWithoutIndexName:{DescID: 104, Name: check_i, ConstraintID: 2}
-           └── 4 Mutation operations
-                ├── SetConstraintName {"ConstraintID":2,"Name":"crdb_internal_co...","TableID":104}
+           ├── 1 element transitioning toward ABSENT
+           │    └── VALIDATED → ABSENT CheckConstraint:{DescID: 104, IndexID: 0, ConstraintID: 2}
+           └── 3 Mutation operations
                 ├── RemoveCheckConstraint {"ConstraintID":2,"TableID":104}
                 ├── RemoveJobStateFromDescriptor {"DescriptorID":104}
                 └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"all stages compl..."}

--- a/pkg/sql/schemachanger/testdata/explain/alter_table_drop_constraint_fk
+++ b/pkg/sql/schemachanger/testdata/explain/alter_table_drop_constraint_fk
@@ -8,31 +8,34 @@ EXPLAIN (ddl) ALTER TABLE t1 DROP CONSTRAINT t1_i_fkey;
 Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t1› DROP CONSTRAINT ‹t1_i_fkey›;
  ├── StatementPhase
  │    └── Stage 1 of 1 in StatementPhase
- │         ├── 1 element transitioning toward ABSENT
- │         │    └── PUBLIC → VALIDATED ForeignKeyConstraint:{DescID: 105, IndexID: 0, ConstraintID: 2, ReferencedDescID: 104}
- │         └── 1 Mutation operation
- │              └── MakePublicForeignKeyConstraintValidated {"ConstraintID":2,"TableID":105}
+ │         ├── 2 elements transitioning toward ABSENT
+ │         │    ├── PUBLIC → VALIDATED ForeignKeyConstraint:{DescID: 105, IndexID: 0, ConstraintID: 2, ReferencedDescID: 104}
+ │         │    └── PUBLIC → ABSENT    ConstraintWithoutIndexName:{DescID: 105, Name: t1_i_fkey, ConstraintID: 2}
+ │         └── 2 Mutation operations
+ │              ├── MakePublicForeignKeyConstraintValidated {"ConstraintID":2,"TableID":105}
+ │              └── SetConstraintName {"ConstraintID":2,"Name":"crdb_internal_co...","TableID":105}
  ├── PreCommitPhase
  │    ├── Stage 1 of 2 in PreCommitPhase
- │    │    ├── 1 element transitioning toward ABSENT
- │    │    │    └── VALIDATED → PUBLIC ForeignKeyConstraint:{DescID: 105, IndexID: 0, ConstraintID: 2, ReferencedDescID: 104}
+ │    │    ├── 2 elements transitioning toward ABSENT
+ │    │    │    ├── VALIDATED → PUBLIC ForeignKeyConstraint:{DescID: 105, IndexID: 0, ConstraintID: 2, ReferencedDescID: 104}
+ │    │    │    └── ABSENT    → PUBLIC ConstraintWithoutIndexName:{DescID: 105, Name: t1_i_fkey, ConstraintID: 2}
  │    │    └── 1 Mutation operation
  │    │         └── UndoAllInTxnImmediateMutationOpSideEffects
  │    └── Stage 2 of 2 in PreCommitPhase
- │         ├── 1 element transitioning toward ABSENT
- │         │    └── PUBLIC → VALIDATED ForeignKeyConstraint:{DescID: 105, IndexID: 0, ConstraintID: 2, ReferencedDescID: 104}
- │         └── 4 Mutation operations
+ │         ├── 2 elements transitioning toward ABSENT
+ │         │    ├── PUBLIC → VALIDATED ForeignKeyConstraint:{DescID: 105, IndexID: 0, ConstraintID: 2, ReferencedDescID: 104}
+ │         │    └── PUBLIC → ABSENT    ConstraintWithoutIndexName:{DescID: 105, Name: t1_i_fkey, ConstraintID: 2}
+ │         └── 5 Mutation operations
  │              ├── MakePublicForeignKeyConstraintValidated {"ConstraintID":2,"TableID":105}
+ │              ├── SetConstraintName {"ConstraintID":2,"Name":"crdb_internal_co...","TableID":105}
  │              ├── SetJobStateOnDescriptor {"DescriptorID":104,"Initialize":true}
  │              ├── SetJobStateOnDescriptor {"DescriptorID":105,"Initialize":true}
  │              └── CreateSchemaChangerJob {"NonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
  └── PostCommitNonRevertiblePhase
       └── Stage 1 of 1 in PostCommitNonRevertiblePhase
-           ├── 2 elements transitioning toward ABSENT
-           │    ├── VALIDATED → ABSENT ForeignKeyConstraint:{DescID: 105, IndexID: 0, ConstraintID: 2, ReferencedDescID: 104}
-           │    └── PUBLIC    → ABSENT ConstraintWithoutIndexName:{DescID: 105, Name: t1_i_fkey, ConstraintID: 2}
-           └── 6 Mutation operations
-                ├── SetConstraintName {"ConstraintID":2,"Name":"crdb_internal_co...","TableID":105}
+           ├── 1 element transitioning toward ABSENT
+           │    └── VALIDATED → ABSENT ForeignKeyConstraint:{DescID: 105, IndexID: 0, ConstraintID: 2, ReferencedDescID: 104}
+           └── 5 Mutation operations
                 ├── RemoveForeignKeyBackReference {"OriginConstraintID":2,"OriginTableID":105,"ReferencedTableID":104}
                 ├── RemoveForeignKeyConstraint {"ConstraintID":2,"TableID":105}
                 ├── RemoveJobStateFromDescriptor {"DescriptorID":104}

--- a/pkg/sql/schemachanger/testdata/explain/alter_table_drop_constraint_uwi
+++ b/pkg/sql/schemachanger/testdata/explain/alter_table_drop_constraint_uwi
@@ -9,30 +9,33 @@ EXPLAIN (ddl) ALTER TABLE t DROP CONSTRAINT unique_j;
 Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› DROP CONSTRAINT ‹unique_j›;
  ├── StatementPhase
  │    └── Stage 1 of 1 in StatementPhase
- │         ├── 1 element transitioning toward ABSENT
- │         │    └── PUBLIC → VALIDATED UniqueWithoutIndexConstraint:{DescID: 104, IndexID: 0, ConstraintID: 2}
- │         └── 1 Mutation operation
- │              └── MakePublicUniqueWithoutIndexConstraintValidated {"ConstraintID":2,"TableID":104}
+ │         ├── 2 elements transitioning toward ABSENT
+ │         │    ├── PUBLIC → VALIDATED UniqueWithoutIndexConstraint:{DescID: 104, IndexID: 0, ConstraintID: 2}
+ │         │    └── PUBLIC → ABSENT    ConstraintWithoutIndexName:{DescID: 104, Name: unique_j, ConstraintID: 2}
+ │         └── 2 Mutation operations
+ │              ├── MakePublicUniqueWithoutIndexConstraintValidated {"ConstraintID":2,"TableID":104}
+ │              └── SetConstraintName {"ConstraintID":2,"Name":"crdb_internal_co...","TableID":104}
  ├── PreCommitPhase
  │    ├── Stage 1 of 2 in PreCommitPhase
- │    │    ├── 1 element transitioning toward ABSENT
- │    │    │    └── VALIDATED → PUBLIC UniqueWithoutIndexConstraint:{DescID: 104, IndexID: 0, ConstraintID: 2}
+ │    │    ├── 2 elements transitioning toward ABSENT
+ │    │    │    ├── VALIDATED → PUBLIC UniqueWithoutIndexConstraint:{DescID: 104, IndexID: 0, ConstraintID: 2}
+ │    │    │    └── ABSENT    → PUBLIC ConstraintWithoutIndexName:{DescID: 104, Name: unique_j, ConstraintID: 2}
  │    │    └── 1 Mutation operation
  │    │         └── UndoAllInTxnImmediateMutationOpSideEffects
  │    └── Stage 2 of 2 in PreCommitPhase
- │         ├── 1 element transitioning toward ABSENT
- │         │    └── PUBLIC → VALIDATED UniqueWithoutIndexConstraint:{DescID: 104, IndexID: 0, ConstraintID: 2}
- │         └── 3 Mutation operations
+ │         ├── 2 elements transitioning toward ABSENT
+ │         │    ├── PUBLIC → VALIDATED UniqueWithoutIndexConstraint:{DescID: 104, IndexID: 0, ConstraintID: 2}
+ │         │    └── PUBLIC → ABSENT    ConstraintWithoutIndexName:{DescID: 104, Name: unique_j, ConstraintID: 2}
+ │         └── 4 Mutation operations
  │              ├── MakePublicUniqueWithoutIndexConstraintValidated {"ConstraintID":2,"TableID":104}
+ │              ├── SetConstraintName {"ConstraintID":2,"Name":"crdb_internal_co...","TableID":104}
  │              ├── SetJobStateOnDescriptor {"DescriptorID":104,"Initialize":true}
  │              └── CreateSchemaChangerJob {"NonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
  └── PostCommitNonRevertiblePhase
       └── Stage 1 of 1 in PostCommitNonRevertiblePhase
-           ├── 2 elements transitioning toward ABSENT
-           │    ├── VALIDATED → ABSENT UniqueWithoutIndexConstraint:{DescID: 104, IndexID: 0, ConstraintID: 2}
-           │    └── PUBLIC    → ABSENT ConstraintWithoutIndexName:{DescID: 104, Name: unique_j, ConstraintID: 2}
-           └── 4 Mutation operations
-                ├── SetConstraintName {"ConstraintID":2,"Name":"crdb_internal_co...","TableID":104}
+           ├── 1 element transitioning toward ABSENT
+           │    └── VALIDATED → ABSENT UniqueWithoutIndexConstraint:{DescID: 104, IndexID: 0, ConstraintID: 2}
+           └── 3 Mutation operations
                 ├── RemoveUniqueWithoutIndexConstraint {"ConstraintID":2,"TableID":104}
                 ├── RemoveJobStateFromDescriptor {"DescriptorID":104}
                 └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"all stages compl..."}

--- a/pkg/sql/schemachanger/testdata/explain/drop_index_hash_sharded_index
+++ b/pkg/sql/schemachanger/testdata/explain/drop_index_hash_sharded_index
@@ -11,46 +11,51 @@ EXPLAIN (ddl) DROP INDEX idx CASCADE;
 Schema change plan for DROP INDEX ‹defaultdb›.‹public›.‹t›@‹idx› CASCADE;
  ├── StatementPhase
  │    └── Stage 1 of 1 in StatementPhase
- │         ├── 5 elements transitioning toward ABSENT
+ │         ├── 6 elements transitioning toward ABSENT
  │         │    ├── PUBLIC → WRITE_ONLY Column:{DescID: 104, ColumnID: 3}
  │         │    ├── PUBLIC → ABSENT     ColumnName:{DescID: 104, Name: crdb_internal_j_shard_16, ColumnID: 3}
  │         │    ├── PUBLIC → VALIDATED  ColumnNotNull:{DescID: 104, ColumnID: 3, IndexID: 0}
  │         │    ├── PUBLIC → VALIDATED  SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 0}
- │         │    └── PUBLIC → VALIDATED  CheckConstraint:{DescID: 104, IndexID: 0, ConstraintID: 2}
- │         └── 5 Mutation operations
+ │         │    ├── PUBLIC → VALIDATED  CheckConstraint:{DescID: 104, IndexID: 0, ConstraintID: 2}
+ │         │    └── PUBLIC → ABSENT     ConstraintWithoutIndexName:{DescID: 104, Name: check_crdb_internal_j_shard_16, ConstraintID: 2}
+ │         └── 6 Mutation operations
  │              ├── MakePublicColumnNotNullValidated {"ColumnID":3,"TableID":104}
  │              ├── MakePublicSecondaryIndexWriteOnly {"IndexID":2,"TableID":104}
  │              ├── MakePublicCheckConstraintValidated {"ConstraintID":2,"TableID":104}
+ │              ├── SetConstraintName {"ConstraintID":2,"Name":"crdb_internal_co...","TableID":104}
  │              ├── MakePublicColumnWriteOnly {"ColumnID":3,"TableID":104}
  │              └── SetColumnName {"ColumnID":3,"Name":"crdb_internal_co...","TableID":104}
  ├── PreCommitPhase
  │    ├── Stage 1 of 2 in PreCommitPhase
- │    │    ├── 5 elements transitioning toward ABSENT
+ │    │    ├── 6 elements transitioning toward ABSENT
  │    │    │    ├── WRITE_ONLY → PUBLIC Column:{DescID: 104, ColumnID: 3}
  │    │    │    ├── ABSENT     → PUBLIC ColumnName:{DescID: 104, Name: crdb_internal_j_shard_16, ColumnID: 3}
  │    │    │    ├── VALIDATED  → PUBLIC ColumnNotNull:{DescID: 104, ColumnID: 3, IndexID: 0}
  │    │    │    ├── VALIDATED  → PUBLIC SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 0}
- │    │    │    └── VALIDATED  → PUBLIC CheckConstraint:{DescID: 104, IndexID: 0, ConstraintID: 2}
+ │    │    │    ├── VALIDATED  → PUBLIC CheckConstraint:{DescID: 104, IndexID: 0, ConstraintID: 2}
+ │    │    │    └── ABSENT     → PUBLIC ConstraintWithoutIndexName:{DescID: 104, Name: check_crdb_internal_j_shard_16, ConstraintID: 2}
  │    │    └── 1 Mutation operation
  │    │         └── UndoAllInTxnImmediateMutationOpSideEffects
  │    └── Stage 2 of 2 in PreCommitPhase
- │         ├── 5 elements transitioning toward ABSENT
+ │         ├── 6 elements transitioning toward ABSENT
  │         │    ├── PUBLIC → WRITE_ONLY Column:{DescID: 104, ColumnID: 3}
  │         │    ├── PUBLIC → ABSENT     ColumnName:{DescID: 104, Name: crdb_internal_j_shard_16, ColumnID: 3}
  │         │    ├── PUBLIC → VALIDATED  ColumnNotNull:{DescID: 104, ColumnID: 3, IndexID: 0}
  │         │    ├── PUBLIC → VALIDATED  SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 0}
- │         │    └── PUBLIC → VALIDATED  CheckConstraint:{DescID: 104, IndexID: 0, ConstraintID: 2}
- │         └── 7 Mutation operations
+ │         │    ├── PUBLIC → VALIDATED  CheckConstraint:{DescID: 104, IndexID: 0, ConstraintID: 2}
+ │         │    └── PUBLIC → ABSENT     ConstraintWithoutIndexName:{DescID: 104, Name: check_crdb_internal_j_shard_16, ConstraintID: 2}
+ │         └── 8 Mutation operations
  │              ├── MakePublicColumnNotNullValidated {"ColumnID":3,"TableID":104}
  │              ├── MakePublicSecondaryIndexWriteOnly {"IndexID":2,"TableID":104}
  │              ├── MakePublicCheckConstraintValidated {"ConstraintID":2,"TableID":104}
+ │              ├── SetConstraintName {"ConstraintID":2,"Name":"crdb_internal_co...","TableID":104}
  │              ├── MakePublicColumnWriteOnly {"ColumnID":3,"TableID":104}
  │              ├── SetColumnName {"ColumnID":3,"Name":"crdb_internal_co...","TableID":104}
  │              ├── SetJobStateOnDescriptor {"DescriptorID":104,"Initialize":true}
  │              └── CreateSchemaChangerJob {"NonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
  └── PostCommitNonRevertiblePhase
       ├── Stage 1 of 2 in PostCommitNonRevertiblePhase
-      │    ├── 9 elements transitioning toward ABSENT
+      │    ├── 8 elements transitioning toward ABSENT
       │    │    ├── WRITE_ONLY → DELETE_ONLY Column:{DescID: 104, ColumnID: 3}
       │    │    ├── VALIDATED  → ABSENT      ColumnNotNull:{DescID: 104, ColumnID: 3, IndexID: 0}
       │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 2}
@@ -58,15 +63,13 @@ Schema change plan for DROP INDEX ‹defaultdb›.‹public›.‹t›@‹idx›
       │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 2}
       │    │    ├── VALIDATED  → DELETE_ONLY SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 0}
       │    │    ├── PUBLIC     → ABSENT      IndexName:{DescID: 104, Name: idx, IndexID: 2}
-      │    │    ├── VALIDATED  → ABSENT      CheckConstraint:{DescID: 104, IndexID: 0, ConstraintID: 2}
-      │    │    └── PUBLIC     → ABSENT      ConstraintWithoutIndexName:{DescID: 104, Name: check_crdb_internal_j_shard_16, ConstraintID: 2}
-      │    └── 11 Mutation operations
+      │    │    └── VALIDATED  → ABSENT      CheckConstraint:{DescID: 104, IndexID: 0, ConstraintID: 2}
+      │    └── 10 Mutation operations
       │         ├── RemoveColumnNotNull {"ColumnID":3,"TableID":104}
-      │         ├── SetConstraintName {"ConstraintID":2,"Name":"crdb_internal_co...","TableID":104}
+      │         ├── RemoveCheckConstraint {"ConstraintID":2,"TableID":104}
       │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":3,"TableID":104}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":2,"TableID":104}
       │         ├── SetIndexName {"IndexID":2,"Name":"crdb_internal_in...","TableID":104}
-      │         ├── RemoveCheckConstraint {"ConstraintID":2,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":2,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":2,"Ordinal":1,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":2,"Kind":1,"TableID":104}

--- a/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_add_check_udf
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_add_check_udf
@@ -22,7 +22,7 @@ EXPLAIN (ddl, verbose) ALTER TABLE t ADD CONSTRAINT check_b CHECK (f(b) > 1);
 │       │   └── • ConstraintWithoutIndexName:{DescID: 104, Name: check_b, ConstraintID: 2}
 │       │       │ ABSENT → PUBLIC
 │       │       │
-│       │       └── • SameStagePrecedence dependency from WRITE_ONLY CheckConstraint:{DescID: 104, IndexID: 0, ConstraintID: 2}
+│       │       └── • Precedence dependency from WRITE_ONLY CheckConstraint:{DescID: 104, IndexID: 0, ConstraintID: 2}
 │       │             rule: "simple constraint visible before name"
 │       │
 │       └── • 3 Mutation operations
@@ -76,7 +76,7 @@ EXPLAIN (ddl, verbose) ALTER TABLE t ADD CONSTRAINT check_b CHECK (f(b) > 1);
 │       │   └── • ConstraintWithoutIndexName:{DescID: 104, Name: check_b, ConstraintID: 2}
 │       │       │ ABSENT → PUBLIC
 │       │       │
-│       │       └── • SameStagePrecedence dependency from WRITE_ONLY CheckConstraint:{DescID: 104, IndexID: 0, ConstraintID: 2}
+│       │       └── • Precedence dependency from WRITE_ONLY CheckConstraint:{DescID: 104, IndexID: 0, ConstraintID: 2}
 │       │             rule: "simple constraint visible before name"
 │       │
 │       └── • 6 Mutation operations

--- a/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_add_check_udf.rollback_1_of_2
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_add_check_udf.rollback_1_of_2
@@ -20,7 +20,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 1 of 2;
         │   │   ├── • PreviousStagePrecedence dependency from WRITE_ONLY CheckConstraint:{DescID: 104, IndexID: 0, ConstraintID: 2}
         │   │   │     rule: "CheckConstraint transitions to ABSENT uphold 2-version invariant: WRITE_ONLY->VALIDATED"
         │   │   │
-        │   │   └── • SameStagePrecedence dependency from ABSENT ConstraintWithoutIndexName:{DescID: 104, Name: check_b, ConstraintID: 2}
+        │   │   └── • Precedence dependency from ABSENT ConstraintWithoutIndexName:{DescID: 104, Name: check_b, ConstraintID: 2}
         │   │         rule: "Constraint should be hidden before name"
         │   │
         │   └── • ConstraintWithoutIndexName:{DescID: 104, Name: check_b, ConstraintID: 2}

--- a/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_add_check_udf.rollback_2_of_2
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_add_check_udf.rollback_2_of_2
@@ -20,7 +20,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 2 of 2;
         │   │   ├── • PreviousStagePrecedence dependency from WRITE_ONLY CheckConstraint:{DescID: 104, IndexID: 0, ConstraintID: 2}
         │   │   │     rule: "CheckConstraint transitions to ABSENT uphold 2-version invariant: WRITE_ONLY->VALIDATED"
         │   │   │
-        │   │   └── • SameStagePrecedence dependency from ABSENT ConstraintWithoutIndexName:{DescID: 104, Name: check_b, ConstraintID: 2}
+        │   │   └── • Precedence dependency from ABSENT ConstraintWithoutIndexName:{DescID: 104, Name: check_b, ConstraintID: 2}
         │   │         rule: "Constraint should be hidden before name"
         │   │
         │   └── • ConstraintWithoutIndexName:{DescID: 104, Name: check_b, ConstraintID: 2}

--- a/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_add_check_vanilla
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_add_check_vanilla
@@ -23,7 +23,7 @@ EXPLAIN (ddl, verbose) ALTER TABLE t ADD CHECK (i > 0)
 │       │   └── • ConstraintWithoutIndexName:{DescID: 104, Name: check_i, ConstraintID: 2}
 │       │       │ ABSENT → PUBLIC
 │       │       │
-│       │       └── • SameStagePrecedence dependency from WRITE_ONLY CheckConstraint:{DescID: 104, IndexID: 0, ConstraintID: 2}
+│       │       └── • Precedence dependency from WRITE_ONLY CheckConstraint:{DescID: 104, IndexID: 0, ConstraintID: 2}
 │       │             rule: "simple constraint visible before name"
 │       │
 │       └── • 2 Mutation operations
@@ -71,7 +71,7 @@ EXPLAIN (ddl, verbose) ALTER TABLE t ADD CHECK (i > 0)
 │       │   └── • ConstraintWithoutIndexName:{DescID: 104, Name: check_i, ConstraintID: 2}
 │       │       │ ABSENT → PUBLIC
 │       │       │
-│       │       └── • SameStagePrecedence dependency from WRITE_ONLY CheckConstraint:{DescID: 104, IndexID: 0, ConstraintID: 2}
+│       │       └── • Precedence dependency from WRITE_ONLY CheckConstraint:{DescID: 104, IndexID: 0, ConstraintID: 2}
 │       │             rule: "simple constraint visible before name"
 │       │
 │       └── • 4 Mutation operations

--- a/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_add_check_vanilla.rollback_1_of_2
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_add_check_vanilla.rollback_1_of_2
@@ -21,7 +21,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 1 of 2;
         │   │   ├── • PreviousStagePrecedence dependency from WRITE_ONLY CheckConstraint:{DescID: 104, IndexID: 0, ConstraintID: 2}
         │   │   │     rule: "CheckConstraint transitions to ABSENT uphold 2-version invariant: WRITE_ONLY->VALIDATED"
         │   │   │
-        │   │   └── • SameStagePrecedence dependency from ABSENT ConstraintWithoutIndexName:{DescID: 104, Name: check_i, ConstraintID: 2}
+        │   │   └── • Precedence dependency from ABSENT ConstraintWithoutIndexName:{DescID: 104, Name: check_i, ConstraintID: 2}
         │   │         rule: "Constraint should be hidden before name"
         │   │
         │   └── • ConstraintWithoutIndexName:{DescID: 104, Name: check_i, ConstraintID: 2}

--- a/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_add_check_vanilla.rollback_2_of_2
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_add_check_vanilla.rollback_2_of_2
@@ -21,7 +21,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 2 of 2;
         │   │   ├── • PreviousStagePrecedence dependency from WRITE_ONLY CheckConstraint:{DescID: 104, IndexID: 0, ConstraintID: 2}
         │   │   │     rule: "CheckConstraint transitions to ABSENT uphold 2-version invariant: WRITE_ONLY->VALIDATED"
         │   │   │
-        │   │   └── • SameStagePrecedence dependency from ABSENT ConstraintWithoutIndexName:{DescID: 104, Name: check_i, ConstraintID: 2}
+        │   │   └── • Precedence dependency from ABSENT ConstraintWithoutIndexName:{DescID: 104, Name: check_i, ConstraintID: 2}
         │   │         rule: "Constraint should be hidden before name"
         │   │
         │   └── • ConstraintWithoutIndexName:{DescID: 104, Name: check_i, ConstraintID: 2}

--- a/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_add_check_with_seq_and_udt
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_add_check_with_seq_and_udt
@@ -23,7 +23,7 @@ EXPLAIN (ddl, verbose) ALTER TABLE t ADD CHECK (i > nextval('s') OR j::typ = 'a'
 │       │   └── • ConstraintWithoutIndexName:{DescID: 107, Name: check_i_j, ConstraintID: 2}
 │       │       │ ABSENT → PUBLIC
 │       │       │
-│       │       └── • SameStagePrecedence dependency from WRITE_ONLY CheckConstraint:{DescID: 107, ReferencedTypeIDs: [105 106], IndexID: 0, ConstraintID: 2, ReferencedSequenceIDs: [104]}
+│       │       └── • Precedence dependency from WRITE_ONLY CheckConstraint:{DescID: 107, ReferencedTypeIDs: [105 106], IndexID: 0, ConstraintID: 2, ReferencedSequenceIDs: [104]}
 │       │             rule: "simple constraint visible before name"
 │       │
 │       └── • 4 Mutation operations
@@ -83,7 +83,7 @@ EXPLAIN (ddl, verbose) ALTER TABLE t ADD CHECK (i > nextval('s') OR j::typ = 'a'
 │       │   └── • ConstraintWithoutIndexName:{DescID: 107, Name: check_i_j, ConstraintID: 2}
 │       │       │ ABSENT → PUBLIC
 │       │       │
-│       │       └── • SameStagePrecedence dependency from WRITE_ONLY CheckConstraint:{DescID: 107, ReferencedTypeIDs: [105 106], IndexID: 0, ConstraintID: 2, ReferencedSequenceIDs: [104]}
+│       │       └── • Precedence dependency from WRITE_ONLY CheckConstraint:{DescID: 107, ReferencedTypeIDs: [105 106], IndexID: 0, ConstraintID: 2, ReferencedSequenceIDs: [104]}
 │       │             rule: "simple constraint visible before name"
 │       │
 │       └── • 9 Mutation operations

--- a/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_add_check_with_seq_and_udt.rollback_1_of_2
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_add_check_with_seq_and_udt.rollback_1_of_2
@@ -21,7 +21,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 1 of 2;
         │   │   ├── • PreviousStagePrecedence dependency from WRITE_ONLY CheckConstraint:{DescID: 107, ReferencedTypeIDs: [105 106], IndexID: 0, ConstraintID: 2, ReferencedSequenceIDs: [104]}
         │   │   │     rule: "CheckConstraint transitions to ABSENT uphold 2-version invariant: WRITE_ONLY->VALIDATED"
         │   │   │
-        │   │   └── • SameStagePrecedence dependency from ABSENT ConstraintWithoutIndexName:{DescID: 107, Name: check_i_j, ConstraintID: 2}
+        │   │   └── • Precedence dependency from ABSENT ConstraintWithoutIndexName:{DescID: 107, Name: check_i_j, ConstraintID: 2}
         │   │         rule: "Constraint should be hidden before name"
         │   │
         │   └── • ConstraintWithoutIndexName:{DescID: 107, Name: check_i_j, ConstraintID: 2}

--- a/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_add_check_with_seq_and_udt.rollback_2_of_2
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_add_check_with_seq_and_udt.rollback_2_of_2
@@ -21,7 +21,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 2 of 2;
         │   │   ├── • PreviousStagePrecedence dependency from WRITE_ONLY CheckConstraint:{DescID: 107, ReferencedTypeIDs: [105 106], IndexID: 0, ConstraintID: 2, ReferencedSequenceIDs: [104]}
         │   │   │     rule: "CheckConstraint transitions to ABSENT uphold 2-version invariant: WRITE_ONLY->VALIDATED"
         │   │   │
-        │   │   └── • SameStagePrecedence dependency from ABSENT ConstraintWithoutIndexName:{DescID: 107, Name: check_i_j, ConstraintID: 2}
+        │   │   └── • Precedence dependency from ABSENT ConstraintWithoutIndexName:{DescID: 107, Name: check_i_j, ConstraintID: 2}
         │   │         rule: "Constraint should be hidden before name"
         │   │
         │   └── • ConstraintWithoutIndexName:{DescID: 107, Name: check_i_j, ConstraintID: 2}

--- a/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_add_foreign_key
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_add_foreign_key
@@ -24,7 +24,7 @@ EXPLAIN (ddl, verbose) ALTER TABLE t1 ADD FOREIGN KEY (i) REFERENCES t2(i);
 │       │   └── • ConstraintWithoutIndexName:{DescID: 104, Name: t1_i_fkey, ConstraintID: 2}
 │       │       │ ABSENT → PUBLIC
 │       │       │
-│       │       └── • SameStagePrecedence dependency from WRITE_ONLY ForeignKeyConstraint:{DescID: 104, IndexID: 0, ConstraintID: 2, ReferencedDescID: 105}
+│       │       └── • Precedence dependency from WRITE_ONLY ForeignKeyConstraint:{DescID: 104, IndexID: 0, ConstraintID: 2, ReferencedDescID: 105}
 │       │             rule: "simple constraint visible before name"
 │       │
 │       └── • 2 Mutation operations
@@ -74,7 +74,7 @@ EXPLAIN (ddl, verbose) ALTER TABLE t1 ADD FOREIGN KEY (i) REFERENCES t2(i);
 │       │   └── • ConstraintWithoutIndexName:{DescID: 104, Name: t1_i_fkey, ConstraintID: 2}
 │       │       │ ABSENT → PUBLIC
 │       │       │
-│       │       └── • SameStagePrecedence dependency from WRITE_ONLY ForeignKeyConstraint:{DescID: 104, IndexID: 0, ConstraintID: 2, ReferencedDescID: 105}
+│       │       └── • Precedence dependency from WRITE_ONLY ForeignKeyConstraint:{DescID: 104, IndexID: 0, ConstraintID: 2, ReferencedDescID: 105}
 │       │             rule: "simple constraint visible before name"
 │       │
 │       └── • 5 Mutation operations

--- a/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_add_foreign_key.rollback_1_of_2
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_add_foreign_key.rollback_1_of_2
@@ -22,7 +22,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 1 of 2;
         │   │   ├── • PreviousStagePrecedence dependency from WRITE_ONLY ForeignKeyConstraint:{DescID: 104, IndexID: 0, ConstraintID: 2, ReferencedDescID: 105}
         │   │   │     rule: "ForeignKeyConstraint transitions to ABSENT uphold 2-version invariant: WRITE_ONLY->VALIDATED"
         │   │   │
-        │   │   └── • SameStagePrecedence dependency from ABSENT ConstraintWithoutIndexName:{DescID: 104, Name: t1_i_fkey, ConstraintID: 2}
+        │   │   └── • Precedence dependency from ABSENT ConstraintWithoutIndexName:{DescID: 104, Name: t1_i_fkey, ConstraintID: 2}
         │   │         rule: "Constraint should be hidden before name"
         │   │
         │   └── • ConstraintWithoutIndexName:{DescID: 104, Name: t1_i_fkey, ConstraintID: 2}

--- a/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_add_foreign_key.rollback_2_of_2
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_add_foreign_key.rollback_2_of_2
@@ -22,7 +22,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 2 of 2;
         │   │   ├── • PreviousStagePrecedence dependency from WRITE_ONLY ForeignKeyConstraint:{DescID: 104, IndexID: 0, ConstraintID: 2, ReferencedDescID: 105}
         │   │   │     rule: "ForeignKeyConstraint transitions to ABSENT uphold 2-version invariant: WRITE_ONLY->VALIDATED"
         │   │   │
-        │   │   └── • SameStagePrecedence dependency from ABSENT ConstraintWithoutIndexName:{DescID: 104, Name: t1_i_fkey, ConstraintID: 2}
+        │   │   └── • Precedence dependency from ABSENT ConstraintWithoutIndexName:{DescID: 104, Name: t1_i_fkey, ConstraintID: 2}
         │   │         rule: "Constraint should be hidden before name"
         │   │
         │   └── • ConstraintWithoutIndexName:{DescID: 104, Name: t1_i_fkey, ConstraintID: 2}

--- a/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_add_unique_without_index
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_add_unique_without_index
@@ -23,7 +23,7 @@ EXPLAIN (ddl, verbose) ALTER TABLE t ADD UNIQUE WITHOUT INDEX (j);
 │       │   └── • ConstraintWithoutIndexName:{DescID: 104, Name: unique_j, ConstraintID: 2}
 │       │       │ ABSENT → PUBLIC
 │       │       │
-│       │       └── • SameStagePrecedence dependency from WRITE_ONLY UniqueWithoutIndexConstraint:{DescID: 104, IndexID: 0, ConstraintID: 2}
+│       │       └── • Precedence dependency from WRITE_ONLY UniqueWithoutIndexConstraint:{DescID: 104, IndexID: 0, ConstraintID: 2}
 │       │             rule: "simple constraint visible before name"
 │       │
 │       └── • 2 Mutation operations
@@ -70,7 +70,7 @@ EXPLAIN (ddl, verbose) ALTER TABLE t ADD UNIQUE WITHOUT INDEX (j);
 │       │   └── • ConstraintWithoutIndexName:{DescID: 104, Name: unique_j, ConstraintID: 2}
 │       │       │ ABSENT → PUBLIC
 │       │       │
-│       │       └── • SameStagePrecedence dependency from WRITE_ONLY UniqueWithoutIndexConstraint:{DescID: 104, IndexID: 0, ConstraintID: 2}
+│       │       └── • Precedence dependency from WRITE_ONLY UniqueWithoutIndexConstraint:{DescID: 104, IndexID: 0, ConstraintID: 2}
 │       │             rule: "simple constraint visible before name"
 │       │
 │       └── • 4 Mutation operations

--- a/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_add_unique_without_index.rollback_1_of_2
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_add_unique_without_index.rollback_1_of_2
@@ -21,7 +21,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 1 of 2;
         │   │   ├── • PreviousStagePrecedence dependency from WRITE_ONLY UniqueWithoutIndexConstraint:{DescID: 104, IndexID: 0, ConstraintID: 2}
         │   │   │     rule: "UniqueWithoutIndexConstraint transitions to ABSENT uphold 2-version invariant: WRITE_ONLY->VALIDATED"
         │   │   │
-        │   │   └── • SameStagePrecedence dependency from ABSENT ConstraintWithoutIndexName:{DescID: 104, Name: unique_j, ConstraintID: 2}
+        │   │   └── • Precedence dependency from ABSENT ConstraintWithoutIndexName:{DescID: 104, Name: unique_j, ConstraintID: 2}
         │   │         rule: "Constraint should be hidden before name"
         │   │
         │   └── • ConstraintWithoutIndexName:{DescID: 104, Name: unique_j, ConstraintID: 2}

--- a/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_add_unique_without_index.rollback_2_of_2
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_add_unique_without_index.rollback_2_of_2
@@ -21,7 +21,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 2 of 2;
         │   │   ├── • PreviousStagePrecedence dependency from WRITE_ONLY UniqueWithoutIndexConstraint:{DescID: 104, IndexID: 0, ConstraintID: 2}
         │   │   │     rule: "UniqueWithoutIndexConstraint transitions to ABSENT uphold 2-version invariant: WRITE_ONLY->VALIDATED"
         │   │   │
-        │   │   └── • SameStagePrecedence dependency from ABSENT ConstraintWithoutIndexName:{DescID: 104, Name: unique_j, ConstraintID: 2}
+        │   │   └── • Precedence dependency from ABSENT ConstraintWithoutIndexName:{DescID: 104, Name: unique_j, ConstraintID: 2}
         │   │         rule: "Constraint should be hidden before name"
         │   │
         │   └── • ConstraintWithoutIndexName:{DescID: 104, Name: unique_j, ConstraintID: 2}

--- a/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_alter_primary_key_using_hash
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_alter_primary_key_using_hash
@@ -41,7 +41,7 @@ EXPLAIN (ddl, verbose) ALTER TABLE t ALTER PRIMARY KEY USING COLUMNS (j) USING H
 │       │   ├── • ConstraintWithoutIndexName:{DescID: 104, Name: check_crdb_internal_j_shard_3, ConstraintID: 2}
 │       │   │   │ ABSENT → PUBLIC
 │       │   │   │
-│       │   │   └── • SameStagePrecedence dependency from WRITE_ONLY CheckConstraint:{DescID: 104, IndexID: 2, ConstraintID: 2}
+│       │   │   └── • Precedence dependency from WRITE_ONLY CheckConstraint:{DescID: 104, IndexID: 2, ConstraintID: 2}
 │       │   │         rule: "simple constraint visible before name"
 │       │   │
 │       │   ├── • PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 3, TemporaryIndexID: 3, SourceIndexID: 1}
@@ -468,7 +468,7 @@ EXPLAIN (ddl, verbose) ALTER TABLE t ALTER PRIMARY KEY USING COLUMNS (j) USING H
 │       │   ├── • ConstraintWithoutIndexName:{DescID: 104, Name: check_crdb_internal_j_shard_3, ConstraintID: 2}
 │       │   │   │ ABSENT → PUBLIC
 │       │   │   │
-│       │   │   └── • SameStagePrecedence dependency from WRITE_ONLY CheckConstraint:{DescID: 104, IndexID: 2, ConstraintID: 2}
+│       │   │   └── • Precedence dependency from WRITE_ONLY CheckConstraint:{DescID: 104, IndexID: 2, ConstraintID: 2}
 │       │   │         rule: "simple constraint visible before name"
 │       │   │
 │       │   ├── • PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 3, TemporaryIndexID: 3, SourceIndexID: 1}

--- a/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_alter_primary_key_using_hash.rollback_1_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_alter_primary_key_using_hash.rollback_1_of_7
@@ -59,7 +59,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 1 of 7;
         │   │   ├── • PreviousStagePrecedence dependency from WRITE_ONLY CheckConstraint:{DescID: 104, IndexID: 2, ConstraintID: 2}
         │   │   │     rule: "CheckConstraint transitions to ABSENT uphold 2-version invariant: WRITE_ONLY->VALIDATED"
         │   │   │
-        │   │   └── • SameStagePrecedence dependency from ABSENT ConstraintWithoutIndexName:{DescID: 104, Name: check_crdb_internal_j_shard_3, ConstraintID: 2}
+        │   │   └── • Precedence dependency from ABSENT ConstraintWithoutIndexName:{DescID: 104, Name: check_crdb_internal_j_shard_3, ConstraintID: 2}
         │   │         rule: "Constraint should be hidden before name"
         │   │
         │   ├── • ConstraintWithoutIndexName:{DescID: 104, Name: check_crdb_internal_j_shard_3, ConstraintID: 2}

--- a/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_alter_primary_key_using_hash.rollback_2_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_alter_primary_key_using_hash.rollback_2_of_7
@@ -43,7 +43,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 2 of 7;
     │   │   │   ├── • PreviousStagePrecedence dependency from WRITE_ONLY CheckConstraint:{DescID: 104, IndexID: 2, ConstraintID: 2}
     │   │   │   │     rule: "CheckConstraint transitions to ABSENT uphold 2-version invariant: WRITE_ONLY->VALIDATED"
     │   │   │   │
-    │   │   │   └── • SameStagePrecedence dependency from ABSENT ConstraintWithoutIndexName:{DescID: 104, Name: check_crdb_internal_j_shard_3, ConstraintID: 2}
+    │   │   │   └── • Precedence dependency from ABSENT ConstraintWithoutIndexName:{DescID: 104, Name: check_crdb_internal_j_shard_3, ConstraintID: 2}
     │   │   │         rule: "Constraint should be hidden before name"
     │   │   │
     │   │   ├── • ConstraintWithoutIndexName:{DescID: 104, Name: check_crdb_internal_j_shard_3, ConstraintID: 2}

--- a/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_alter_primary_key_using_hash.rollback_3_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_alter_primary_key_using_hash.rollback_3_of_7
@@ -43,7 +43,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 3 of 7;
     │   │   │   ├── • PreviousStagePrecedence dependency from WRITE_ONLY CheckConstraint:{DescID: 104, IndexID: 2, ConstraintID: 2}
     │   │   │   │     rule: "CheckConstraint transitions to ABSENT uphold 2-version invariant: WRITE_ONLY->VALIDATED"
     │   │   │   │
-    │   │   │   └── • SameStagePrecedence dependency from ABSENT ConstraintWithoutIndexName:{DescID: 104, Name: check_crdb_internal_j_shard_3, ConstraintID: 2}
+    │   │   │   └── • Precedence dependency from ABSENT ConstraintWithoutIndexName:{DescID: 104, Name: check_crdb_internal_j_shard_3, ConstraintID: 2}
     │   │   │         rule: "Constraint should be hidden before name"
     │   │   │
     │   │   ├── • ConstraintWithoutIndexName:{DescID: 104, Name: check_crdb_internal_j_shard_3, ConstraintID: 2}

--- a/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_alter_primary_key_using_hash.rollback_4_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_alter_primary_key_using_hash.rollback_4_of_7
@@ -43,7 +43,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 4 of 7;
     │   │   │   ├── • PreviousStagePrecedence dependency from WRITE_ONLY CheckConstraint:{DescID: 104, IndexID: 2, ConstraintID: 2}
     │   │   │   │     rule: "CheckConstraint transitions to ABSENT uphold 2-version invariant: WRITE_ONLY->VALIDATED"
     │   │   │   │
-    │   │   │   └── • SameStagePrecedence dependency from ABSENT ConstraintWithoutIndexName:{DescID: 104, Name: check_crdb_internal_j_shard_3, ConstraintID: 2}
+    │   │   │   └── • Precedence dependency from ABSENT ConstraintWithoutIndexName:{DescID: 104, Name: check_crdb_internal_j_shard_3, ConstraintID: 2}
     │   │   │         rule: "Constraint should be hidden before name"
     │   │   │
     │   │   ├── • ConstraintWithoutIndexName:{DescID: 104, Name: check_crdb_internal_j_shard_3, ConstraintID: 2}

--- a/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_alter_primary_key_using_hash.rollback_5_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_alter_primary_key_using_hash.rollback_5_of_7
@@ -43,7 +43,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 5 of 7;
     │   │   │   ├── • PreviousStagePrecedence dependency from WRITE_ONLY CheckConstraint:{DescID: 104, IndexID: 2, ConstraintID: 2}
     │   │   │   │     rule: "CheckConstraint transitions to ABSENT uphold 2-version invariant: WRITE_ONLY->VALIDATED"
     │   │   │   │
-    │   │   │   └── • SameStagePrecedence dependency from ABSENT ConstraintWithoutIndexName:{DescID: 104, Name: check_crdb_internal_j_shard_3, ConstraintID: 2}
+    │   │   │   └── • Precedence dependency from ABSENT ConstraintWithoutIndexName:{DescID: 104, Name: check_crdb_internal_j_shard_3, ConstraintID: 2}
     │   │   │         rule: "Constraint should be hidden before name"
     │   │   │
     │   │   ├── • ConstraintWithoutIndexName:{DescID: 104, Name: check_crdb_internal_j_shard_3, ConstraintID: 2}

--- a/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_alter_primary_key_using_hash.rollback_6_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_alter_primary_key_using_hash.rollback_6_of_7
@@ -43,7 +43,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 6 of 7;
     │   │   │   ├── • PreviousStagePrecedence dependency from WRITE_ONLY CheckConstraint:{DescID: 104, IndexID: 2, ConstraintID: 2}
     │   │   │   │     rule: "CheckConstraint transitions to ABSENT uphold 2-version invariant: WRITE_ONLY->VALIDATED"
     │   │   │   │
-    │   │   │   └── • SameStagePrecedence dependency from ABSENT ConstraintWithoutIndexName:{DescID: 104, Name: check_crdb_internal_j_shard_3, ConstraintID: 2}
+    │   │   │   └── • Precedence dependency from ABSENT ConstraintWithoutIndexName:{DescID: 104, Name: check_crdb_internal_j_shard_3, ConstraintID: 2}
     │   │   │         rule: "Constraint should be hidden before name"
     │   │   │
     │   │   ├── • ConstraintWithoutIndexName:{DescID: 104, Name: check_crdb_internal_j_shard_3, ConstraintID: 2}

--- a/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_alter_primary_key_using_hash.rollback_7_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_alter_primary_key_using_hash.rollback_7_of_7
@@ -43,7 +43,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 7 of 7;
     │   │   │   ├── • PreviousStagePrecedence dependency from WRITE_ONLY CheckConstraint:{DescID: 104, IndexID: 2, ConstraintID: 2}
     │   │   │   │     rule: "CheckConstraint transitions to ABSENT uphold 2-version invariant: WRITE_ONLY->VALIDATED"
     │   │   │   │
-    │   │   │   └── • SameStagePrecedence dependency from ABSENT ConstraintWithoutIndexName:{DescID: 104, Name: check_crdb_internal_j_shard_3, ConstraintID: 2}
+    │   │   │   └── • Precedence dependency from ABSENT ConstraintWithoutIndexName:{DescID: 104, Name: check_crdb_internal_j_shard_3, ConstraintID: 2}
     │   │   │         rule: "Constraint should be hidden before name"
     │   │   │
     │   │   ├── • ConstraintWithoutIndexName:{DescID: 104, Name: check_crdb_internal_j_shard_3, ConstraintID: 2}

--- a/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_drop_constraint_check
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_drop_constraint_check
@@ -10,28 +10,42 @@ EXPLAIN (ddl, verbose) ALTER TABLE t DROP CONSTRAINT check_i;
 │   │
 │   └── • Stage 1 of 1 in StatementPhase
 │       │
-│       ├── • 1 element transitioning toward ABSENT
+│       ├── • 2 elements transitioning toward ABSENT
 │       │   │
-│       │   └── • CheckConstraint:{DescID: 104, IndexID: 0, ConstraintID: 2}
-│       │       │ PUBLIC → VALIDATED
+│       │   ├── • CheckConstraint:{DescID: 104, IndexID: 0, ConstraintID: 2}
+│       │   │   │ PUBLIC → VALIDATED
+│       │   │   │
+│       │   │   └── • PreviousStagePrecedence dependency from PUBLIC CheckConstraint:{DescID: 104, IndexID: 0, ConstraintID: 2}
+│       │   │         rule: "CheckConstraint transitions to ABSENT uphold 2-version invariant: PUBLIC->VALIDATED"
+│       │   │
+│       │   └── • ConstraintWithoutIndexName:{DescID: 104, Name: check_i, ConstraintID: 2}
+│       │       │ PUBLIC → ABSENT
 │       │       │
-│       │       └── • PreviousStagePrecedence dependency from PUBLIC CheckConstraint:{DescID: 104, IndexID: 0, ConstraintID: 2}
-│       │             rule: "CheckConstraint transitions to ABSENT uphold 2-version invariant: PUBLIC->VALIDATED"
+│       │       └── • Precedence dependency from VALIDATED CheckConstraint:{DescID: 104, IndexID: 0, ConstraintID: 2}
+│       │             rule: "Constraint should be hidden before name"
 │       │
-│       └── • 1 Mutation operation
+│       └── • 2 Mutation operations
 │           │
-│           └── • MakePublicCheckConstraintValidated
+│           ├── • MakePublicCheckConstraintValidated
+│           │     ConstraintID: 2
+│           │     TableID: 104
+│           │
+│           └── • SetConstraintName
 │                 ConstraintID: 2
+│                 Name: crdb_internal_constraint_2_name_placeholder
 │                 TableID: 104
 │
 ├── • PreCommitPhase
 │   │
 │   ├── • Stage 1 of 2 in PreCommitPhase
 │   │   │
-│   │   ├── • 1 element transitioning toward ABSENT
+│   │   ├── • 2 elements transitioning toward ABSENT
 │   │   │   │
-│   │   │   └── • CheckConstraint:{DescID: 104, IndexID: 0, ConstraintID: 2}
-│   │   │         VALIDATED → PUBLIC
+│   │   │   ├── • CheckConstraint:{DescID: 104, IndexID: 0, ConstraintID: 2}
+│   │   │   │     VALIDATED → PUBLIC
+│   │   │   │
+│   │   │   └── • ConstraintWithoutIndexName:{DescID: 104, Name: check_i, ConstraintID: 2}
+│   │   │         ABSENT → PUBLIC
 │   │   │
 │   │   └── • 1 Mutation operation
 │   │       │
@@ -40,18 +54,29 @@ EXPLAIN (ddl, verbose) ALTER TABLE t DROP CONSTRAINT check_i;
 │   │
 │   └── • Stage 2 of 2 in PreCommitPhase
 │       │
-│       ├── • 1 element transitioning toward ABSENT
+│       ├── • 2 elements transitioning toward ABSENT
 │       │   │
-│       │   └── • CheckConstraint:{DescID: 104, IndexID: 0, ConstraintID: 2}
-│       │       │ PUBLIC → VALIDATED
+│       │   ├── • CheckConstraint:{DescID: 104, IndexID: 0, ConstraintID: 2}
+│       │   │   │ PUBLIC → VALIDATED
+│       │   │   │
+│       │   │   └── • PreviousStagePrecedence dependency from PUBLIC CheckConstraint:{DescID: 104, IndexID: 0, ConstraintID: 2}
+│       │   │         rule: "CheckConstraint transitions to ABSENT uphold 2-version invariant: PUBLIC->VALIDATED"
+│       │   │
+│       │   └── • ConstraintWithoutIndexName:{DescID: 104, Name: check_i, ConstraintID: 2}
+│       │       │ PUBLIC → ABSENT
 │       │       │
-│       │       └── • PreviousStagePrecedence dependency from PUBLIC CheckConstraint:{DescID: 104, IndexID: 0, ConstraintID: 2}
-│       │             rule: "CheckConstraint transitions to ABSENT uphold 2-version invariant: PUBLIC->VALIDATED"
+│       │       └── • Precedence dependency from VALIDATED CheckConstraint:{DescID: 104, IndexID: 0, ConstraintID: 2}
+│       │             rule: "Constraint should be hidden before name"
 │       │
-│       └── • 3 Mutation operations
+│       └── • 4 Mutation operations
 │           │
 │           ├── • MakePublicCheckConstraintValidated
 │           │     ConstraintID: 2
+│           │     TableID: 104
+│           │
+│           ├── • SetConstraintName
+│           │     ConstraintID: 2
+│           │     Name: crdb_internal_constraint_2_name_placeholder
 │           │     TableID: 104
 │           │
 │           ├── • SetJobStateOnDescriptor
@@ -65,7 +90,7 @@ EXPLAIN (ddl, verbose) ALTER TABLE t DROP CONSTRAINT check_i;
 │                 - 104
 │                 JobID: 1
 │                 NonCancelable: true
-│                 RunningStatus: PostCommitNonRevertiblePhase stage 1 of 1 with 2 MutationType ops pending
+│                 RunningStatus: PostCommitNonRevertiblePhase stage 1 of 1 with 1 MutationType op pending
 │                 Statements:
 │                 - statement: ALTER TABLE t DROP CONSTRAINT check_i
 │                   redactedstatement: ALTER TABLE ‹defaultdb›.‹public›.‹t› DROP CONSTRAINT ‹check_i›
@@ -75,29 +100,18 @@ EXPLAIN (ddl, verbose) ALTER TABLE t DROP CONSTRAINT check_i;
     │
     └── • Stage 1 of 1 in PostCommitNonRevertiblePhase
         │
-        ├── • 2 elements transitioning toward ABSENT
+        ├── • 1 element transitioning toward ABSENT
         │   │
-        │   ├── • CheckConstraint:{DescID: 104, IndexID: 0, ConstraintID: 2}
-        │   │   │ VALIDATED → ABSENT
-        │   │   │
-        │   │   ├── • PreviousStagePrecedence dependency from VALIDATED CheckConstraint:{DescID: 104, IndexID: 0, ConstraintID: 2}
-        │   │   │     rule: "CheckConstraint transitions to ABSENT uphold 2-version invariant: VALIDATED->ABSENT"
-        │   │   │
-        │   │   └── • SameStagePrecedence dependency from ABSENT ConstraintWithoutIndexName:{DescID: 104, Name: check_i, ConstraintID: 2}
-        │   │         rule: "Constraint should be hidden before name"
-        │   │
-        │   └── • ConstraintWithoutIndexName:{DescID: 104, Name: check_i, ConstraintID: 2}
-        │       │ PUBLIC → ABSENT
+        │   └── • CheckConstraint:{DescID: 104, IndexID: 0, ConstraintID: 2}
+        │       │ VALIDATED → ABSENT
         │       │
-        │       └── • Precedence dependency from VALIDATED CheckConstraint:{DescID: 104, IndexID: 0, ConstraintID: 2}
+        │       ├── • PreviousStagePrecedence dependency from VALIDATED CheckConstraint:{DescID: 104, IndexID: 0, ConstraintID: 2}
+        │       │     rule: "CheckConstraint transitions to ABSENT uphold 2-version invariant: VALIDATED->ABSENT"
+        │       │
+        │       └── • Precedence dependency from ABSENT ConstraintWithoutIndexName:{DescID: 104, Name: check_i, ConstraintID: 2}
         │             rule: "Constraint should be hidden before name"
         │
-        └── • 4 Mutation operations
-            │
-            ├── • SetConstraintName
-            │     ConstraintID: 2
-            │     Name: crdb_internal_constraint_2_name_placeholder
-            │     TableID: 104
+        └── • 3 Mutation operations
             │
             ├── • RemoveCheckConstraint
             │     ConstraintID: 2

--- a/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_drop_constraint_fk
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_drop_constraint_fk
@@ -11,28 +11,42 @@ EXPLAIN (ddl, verbose) ALTER TABLE t1 DROP CONSTRAINT t1_i_fkey;
 │   │
 │   └── • Stage 1 of 1 in StatementPhase
 │       │
-│       ├── • 1 element transitioning toward ABSENT
+│       ├── • 2 elements transitioning toward ABSENT
 │       │   │
-│       │   └── • ForeignKeyConstraint:{DescID: 105, IndexID: 0, ConstraintID: 2, ReferencedDescID: 104}
-│       │       │ PUBLIC → VALIDATED
+│       │   ├── • ForeignKeyConstraint:{DescID: 105, IndexID: 0, ConstraintID: 2, ReferencedDescID: 104}
+│       │   │   │ PUBLIC → VALIDATED
+│       │   │   │
+│       │   │   └── • PreviousStagePrecedence dependency from PUBLIC ForeignKeyConstraint:{DescID: 105, IndexID: 0, ConstraintID: 2, ReferencedDescID: 104}
+│       │   │         rule: "ForeignKeyConstraint transitions to ABSENT uphold 2-version invariant: PUBLIC->VALIDATED"
+│       │   │
+│       │   └── • ConstraintWithoutIndexName:{DescID: 105, Name: t1_i_fkey, ConstraintID: 2}
+│       │       │ PUBLIC → ABSENT
 │       │       │
-│       │       └── • PreviousStagePrecedence dependency from PUBLIC ForeignKeyConstraint:{DescID: 105, IndexID: 0, ConstraintID: 2, ReferencedDescID: 104}
-│       │             rule: "ForeignKeyConstraint transitions to ABSENT uphold 2-version invariant: PUBLIC->VALIDATED"
+│       │       └── • Precedence dependency from VALIDATED ForeignKeyConstraint:{DescID: 105, IndexID: 0, ConstraintID: 2, ReferencedDescID: 104}
+│       │             rule: "Constraint should be hidden before name"
 │       │
-│       └── • 1 Mutation operation
+│       └── • 2 Mutation operations
 │           │
-│           └── • MakePublicForeignKeyConstraintValidated
+│           ├── • MakePublicForeignKeyConstraintValidated
+│           │     ConstraintID: 2
+│           │     TableID: 105
+│           │
+│           └── • SetConstraintName
 │                 ConstraintID: 2
+│                 Name: crdb_internal_constraint_2_name_placeholder
 │                 TableID: 105
 │
 ├── • PreCommitPhase
 │   │
 │   ├── • Stage 1 of 2 in PreCommitPhase
 │   │   │
-│   │   ├── • 1 element transitioning toward ABSENT
+│   │   ├── • 2 elements transitioning toward ABSENT
 │   │   │   │
-│   │   │   └── • ForeignKeyConstraint:{DescID: 105, IndexID: 0, ConstraintID: 2, ReferencedDescID: 104}
-│   │   │         VALIDATED → PUBLIC
+│   │   │   ├── • ForeignKeyConstraint:{DescID: 105, IndexID: 0, ConstraintID: 2, ReferencedDescID: 104}
+│   │   │   │     VALIDATED → PUBLIC
+│   │   │   │
+│   │   │   └── • ConstraintWithoutIndexName:{DescID: 105, Name: t1_i_fkey, ConstraintID: 2}
+│   │   │         ABSENT → PUBLIC
 │   │   │
 │   │   └── • 1 Mutation operation
 │   │       │
@@ -41,18 +55,29 @@ EXPLAIN (ddl, verbose) ALTER TABLE t1 DROP CONSTRAINT t1_i_fkey;
 │   │
 │   └── • Stage 2 of 2 in PreCommitPhase
 │       │
-│       ├── • 1 element transitioning toward ABSENT
+│       ├── • 2 elements transitioning toward ABSENT
 │       │   │
-│       │   └── • ForeignKeyConstraint:{DescID: 105, IndexID: 0, ConstraintID: 2, ReferencedDescID: 104}
-│       │       │ PUBLIC → VALIDATED
+│       │   ├── • ForeignKeyConstraint:{DescID: 105, IndexID: 0, ConstraintID: 2, ReferencedDescID: 104}
+│       │   │   │ PUBLIC → VALIDATED
+│       │   │   │
+│       │   │   └── • PreviousStagePrecedence dependency from PUBLIC ForeignKeyConstraint:{DescID: 105, IndexID: 0, ConstraintID: 2, ReferencedDescID: 104}
+│       │   │         rule: "ForeignKeyConstraint transitions to ABSENT uphold 2-version invariant: PUBLIC->VALIDATED"
+│       │   │
+│       │   └── • ConstraintWithoutIndexName:{DescID: 105, Name: t1_i_fkey, ConstraintID: 2}
+│       │       │ PUBLIC → ABSENT
 │       │       │
-│       │       └── • PreviousStagePrecedence dependency from PUBLIC ForeignKeyConstraint:{DescID: 105, IndexID: 0, ConstraintID: 2, ReferencedDescID: 104}
-│       │             rule: "ForeignKeyConstraint transitions to ABSENT uphold 2-version invariant: PUBLIC->VALIDATED"
+│       │       └── • Precedence dependency from VALIDATED ForeignKeyConstraint:{DescID: 105, IndexID: 0, ConstraintID: 2, ReferencedDescID: 104}
+│       │             rule: "Constraint should be hidden before name"
 │       │
-│       └── • 4 Mutation operations
+│       └── • 5 Mutation operations
 │           │
 │           ├── • MakePublicForeignKeyConstraintValidated
 │           │     ConstraintID: 2
+│           │     TableID: 105
+│           │
+│           ├── • SetConstraintName
+│           │     ConstraintID: 2
+│           │     Name: crdb_internal_constraint_2_name_placeholder
 │           │     TableID: 105
 │           │
 │           ├── • SetJobStateOnDescriptor
@@ -71,7 +96,7 @@ EXPLAIN (ddl, verbose) ALTER TABLE t1 DROP CONSTRAINT t1_i_fkey;
 │                 - 105
 │                 JobID: 1
 │                 NonCancelable: true
-│                 RunningStatus: PostCommitNonRevertiblePhase stage 1 of 1 with 3 MutationType ops pending
+│                 RunningStatus: PostCommitNonRevertiblePhase stage 1 of 1 with 2 MutationType ops pending
 │                 Statements:
 │                 - statement: ALTER TABLE t1 DROP CONSTRAINT t1_i_fkey
 │                   redactedstatement: ALTER TABLE ‹defaultdb›.‹public›.‹t1› DROP CONSTRAINT ‹t1_i_fkey›
@@ -81,29 +106,18 @@ EXPLAIN (ddl, verbose) ALTER TABLE t1 DROP CONSTRAINT t1_i_fkey;
     │
     └── • Stage 1 of 1 in PostCommitNonRevertiblePhase
         │
-        ├── • 2 elements transitioning toward ABSENT
+        ├── • 1 element transitioning toward ABSENT
         │   │
-        │   ├── • ForeignKeyConstraint:{DescID: 105, IndexID: 0, ConstraintID: 2, ReferencedDescID: 104}
-        │   │   │ VALIDATED → ABSENT
-        │   │   │
-        │   │   ├── • PreviousStagePrecedence dependency from VALIDATED ForeignKeyConstraint:{DescID: 105, IndexID: 0, ConstraintID: 2, ReferencedDescID: 104}
-        │   │   │     rule: "ForeignKeyConstraint transitions to ABSENT uphold 2-version invariant: VALIDATED->ABSENT"
-        │   │   │
-        │   │   └── • SameStagePrecedence dependency from ABSENT ConstraintWithoutIndexName:{DescID: 105, Name: t1_i_fkey, ConstraintID: 2}
-        │   │         rule: "Constraint should be hidden before name"
-        │   │
-        │   └── • ConstraintWithoutIndexName:{DescID: 105, Name: t1_i_fkey, ConstraintID: 2}
-        │       │ PUBLIC → ABSENT
+        │   └── • ForeignKeyConstraint:{DescID: 105, IndexID: 0, ConstraintID: 2, ReferencedDescID: 104}
+        │       │ VALIDATED → ABSENT
         │       │
-        │       └── • Precedence dependency from VALIDATED ForeignKeyConstraint:{DescID: 105, IndexID: 0, ConstraintID: 2, ReferencedDescID: 104}
+        │       ├── • PreviousStagePrecedence dependency from VALIDATED ForeignKeyConstraint:{DescID: 105, IndexID: 0, ConstraintID: 2, ReferencedDescID: 104}
+        │       │     rule: "ForeignKeyConstraint transitions to ABSENT uphold 2-version invariant: VALIDATED->ABSENT"
+        │       │
+        │       └── • Precedence dependency from ABSENT ConstraintWithoutIndexName:{DescID: 105, Name: t1_i_fkey, ConstraintID: 2}
         │             rule: "Constraint should be hidden before name"
         │
-        └── • 6 Mutation operations
-            │
-            ├── • SetConstraintName
-            │     ConstraintID: 2
-            │     Name: crdb_internal_constraint_2_name_placeholder
-            │     TableID: 105
+        └── • 5 Mutation operations
             │
             ├── • RemoveForeignKeyBackReference
             │     OriginConstraintID: 2

--- a/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_drop_constraint_uwi
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_drop_constraint_uwi
@@ -12,28 +12,42 @@ EXPLAIN (ddl, verbose) ALTER TABLE t DROP CONSTRAINT unique_j;
 │   │
 │   └── • Stage 1 of 1 in StatementPhase
 │       │
-│       ├── • 1 element transitioning toward ABSENT
+│       ├── • 2 elements transitioning toward ABSENT
 │       │   │
-│       │   └── • UniqueWithoutIndexConstraint:{DescID: 104, IndexID: 0, ConstraintID: 2}
-│       │       │ PUBLIC → VALIDATED
+│       │   ├── • UniqueWithoutIndexConstraint:{DescID: 104, IndexID: 0, ConstraintID: 2}
+│       │   │   │ PUBLIC → VALIDATED
+│       │   │   │
+│       │   │   └── • PreviousStagePrecedence dependency from PUBLIC UniqueWithoutIndexConstraint:{DescID: 104, IndexID: 0, ConstraintID: 2}
+│       │   │         rule: "UniqueWithoutIndexConstraint transitions to ABSENT uphold 2-version invariant: PUBLIC->VALIDATED"
+│       │   │
+│       │   └── • ConstraintWithoutIndexName:{DescID: 104, Name: unique_j, ConstraintID: 2}
+│       │       │ PUBLIC → ABSENT
 │       │       │
-│       │       └── • PreviousStagePrecedence dependency from PUBLIC UniqueWithoutIndexConstraint:{DescID: 104, IndexID: 0, ConstraintID: 2}
-│       │             rule: "UniqueWithoutIndexConstraint transitions to ABSENT uphold 2-version invariant: PUBLIC->VALIDATED"
+│       │       └── • Precedence dependency from VALIDATED UniqueWithoutIndexConstraint:{DescID: 104, IndexID: 0, ConstraintID: 2}
+│       │             rule: "Constraint should be hidden before name"
 │       │
-│       └── • 1 Mutation operation
+│       └── • 2 Mutation operations
 │           │
-│           └── • MakePublicUniqueWithoutIndexConstraintValidated
+│           ├── • MakePublicUniqueWithoutIndexConstraintValidated
+│           │     ConstraintID: 2
+│           │     TableID: 104
+│           │
+│           └── • SetConstraintName
 │                 ConstraintID: 2
+│                 Name: crdb_internal_constraint_2_name_placeholder
 │                 TableID: 104
 │
 ├── • PreCommitPhase
 │   │
 │   ├── • Stage 1 of 2 in PreCommitPhase
 │   │   │
-│   │   ├── • 1 element transitioning toward ABSENT
+│   │   ├── • 2 elements transitioning toward ABSENT
 │   │   │   │
-│   │   │   └── • UniqueWithoutIndexConstraint:{DescID: 104, IndexID: 0, ConstraintID: 2}
-│   │   │         VALIDATED → PUBLIC
+│   │   │   ├── • UniqueWithoutIndexConstraint:{DescID: 104, IndexID: 0, ConstraintID: 2}
+│   │   │   │     VALIDATED → PUBLIC
+│   │   │   │
+│   │   │   └── • ConstraintWithoutIndexName:{DescID: 104, Name: unique_j, ConstraintID: 2}
+│   │   │         ABSENT → PUBLIC
 │   │   │
 │   │   └── • 1 Mutation operation
 │   │       │
@@ -42,18 +56,29 @@ EXPLAIN (ddl, verbose) ALTER TABLE t DROP CONSTRAINT unique_j;
 │   │
 │   └── • Stage 2 of 2 in PreCommitPhase
 │       │
-│       ├── • 1 element transitioning toward ABSENT
+│       ├── • 2 elements transitioning toward ABSENT
 │       │   │
-│       │   └── • UniqueWithoutIndexConstraint:{DescID: 104, IndexID: 0, ConstraintID: 2}
-│       │       │ PUBLIC → VALIDATED
+│       │   ├── • UniqueWithoutIndexConstraint:{DescID: 104, IndexID: 0, ConstraintID: 2}
+│       │   │   │ PUBLIC → VALIDATED
+│       │   │   │
+│       │   │   └── • PreviousStagePrecedence dependency from PUBLIC UniqueWithoutIndexConstraint:{DescID: 104, IndexID: 0, ConstraintID: 2}
+│       │   │         rule: "UniqueWithoutIndexConstraint transitions to ABSENT uphold 2-version invariant: PUBLIC->VALIDATED"
+│       │   │
+│       │   └── • ConstraintWithoutIndexName:{DescID: 104, Name: unique_j, ConstraintID: 2}
+│       │       │ PUBLIC → ABSENT
 │       │       │
-│       │       └── • PreviousStagePrecedence dependency from PUBLIC UniqueWithoutIndexConstraint:{DescID: 104, IndexID: 0, ConstraintID: 2}
-│       │             rule: "UniqueWithoutIndexConstraint transitions to ABSENT uphold 2-version invariant: PUBLIC->VALIDATED"
+│       │       └── • Precedence dependency from VALIDATED UniqueWithoutIndexConstraint:{DescID: 104, IndexID: 0, ConstraintID: 2}
+│       │             rule: "Constraint should be hidden before name"
 │       │
-│       └── • 3 Mutation operations
+│       └── • 4 Mutation operations
 │           │
 │           ├── • MakePublicUniqueWithoutIndexConstraintValidated
 │           │     ConstraintID: 2
+│           │     TableID: 104
+│           │
+│           ├── • SetConstraintName
+│           │     ConstraintID: 2
+│           │     Name: crdb_internal_constraint_2_name_placeholder
 │           │     TableID: 104
 │           │
 │           ├── • SetJobStateOnDescriptor
@@ -67,7 +92,7 @@ EXPLAIN (ddl, verbose) ALTER TABLE t DROP CONSTRAINT unique_j;
 │                 - 104
 │                 JobID: 1
 │                 NonCancelable: true
-│                 RunningStatus: PostCommitNonRevertiblePhase stage 1 of 1 with 2 MutationType ops pending
+│                 RunningStatus: PostCommitNonRevertiblePhase stage 1 of 1 with 1 MutationType op pending
 │                 Statements:
 │                 - statement: ALTER TABLE t DROP CONSTRAINT unique_j
 │                   redactedstatement: ALTER TABLE ‹defaultdb›.‹public›.‹t› DROP CONSTRAINT ‹unique_j›
@@ -77,29 +102,18 @@ EXPLAIN (ddl, verbose) ALTER TABLE t DROP CONSTRAINT unique_j;
     │
     └── • Stage 1 of 1 in PostCommitNonRevertiblePhase
         │
-        ├── • 2 elements transitioning toward ABSENT
+        ├── • 1 element transitioning toward ABSENT
         │   │
-        │   ├── • UniqueWithoutIndexConstraint:{DescID: 104, IndexID: 0, ConstraintID: 2}
-        │   │   │ VALIDATED → ABSENT
-        │   │   │
-        │   │   ├── • PreviousStagePrecedence dependency from VALIDATED UniqueWithoutIndexConstraint:{DescID: 104, IndexID: 0, ConstraintID: 2}
-        │   │   │     rule: "UniqueWithoutIndexConstraint transitions to ABSENT uphold 2-version invariant: VALIDATED->ABSENT"
-        │   │   │
-        │   │   └── • SameStagePrecedence dependency from ABSENT ConstraintWithoutIndexName:{DescID: 104, Name: unique_j, ConstraintID: 2}
-        │   │         rule: "Constraint should be hidden before name"
-        │   │
-        │   └── • ConstraintWithoutIndexName:{DescID: 104, Name: unique_j, ConstraintID: 2}
-        │       │ PUBLIC → ABSENT
+        │   └── • UniqueWithoutIndexConstraint:{DescID: 104, IndexID: 0, ConstraintID: 2}
+        │       │ VALIDATED → ABSENT
         │       │
-        │       └── • Precedence dependency from VALIDATED UniqueWithoutIndexConstraint:{DescID: 104, IndexID: 0, ConstraintID: 2}
+        │       ├── • PreviousStagePrecedence dependency from VALIDATED UniqueWithoutIndexConstraint:{DescID: 104, IndexID: 0, ConstraintID: 2}
+        │       │     rule: "UniqueWithoutIndexConstraint transitions to ABSENT uphold 2-version invariant: VALIDATED->ABSENT"
+        │       │
+        │       └── • Precedence dependency from ABSENT ConstraintWithoutIndexName:{DescID: 104, Name: unique_j, ConstraintID: 2}
         │             rule: "Constraint should be hidden before name"
         │
-        └── • 4 Mutation operations
-            │
-            ├── • SetConstraintName
-            │     ConstraintID: 2
-            │     Name: crdb_internal_constraint_2_name_placeholder
-            │     TableID: 104
+        └── • 3 Mutation operations
             │
             ├── • RemoveUniqueWithoutIndexConstraint
             │     ConstraintID: 2

--- a/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_validate_constraint
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_validate_constraint
@@ -22,7 +22,7 @@ EXPLAIN (ddl, verbose) ALTER TABLE t VALIDATE CONSTRAINT check_i;
 │       │   └── • ConstraintWithoutIndexName:{DescID: 104, Name: check_i, ConstraintID: 3}
 │       │       │ ABSENT → PUBLIC
 │       │       │
-│       │       └── • SameStagePrecedence dependency from WRITE_ONLY CheckConstraint:{DescID: 104, IndexID: 0, ConstraintID: 3}
+│       │       └── • Precedence dependency from WRITE_ONLY CheckConstraint:{DescID: 104, IndexID: 0, ConstraintID: 3}
 │       │             rule: "simple constraint visible before name"
 │       │
 │       ├── • 2 elements transitioning toward ABSENT
@@ -30,7 +30,7 @@ EXPLAIN (ddl, verbose) ALTER TABLE t VALIDATE CONSTRAINT check_i;
 │       │   ├── • CheckConstraintUnvalidated:{DescID: 104, ConstraintID: 2}
 │       │   │   │ PUBLIC → ABSENT
 │       │   │   │
-│       │   │   └── • SameStagePrecedence dependency from ABSENT ConstraintWithoutIndexName:{DescID: 104, Name: check_i, ConstraintID: 2}
+│       │   │   └── • Precedence dependency from ABSENT ConstraintWithoutIndexName:{DescID: 104, Name: check_i, ConstraintID: 2}
 │       │   │         rule: "Constraint should be hidden before name"
 │       │   │
 │       │   └── • ConstraintWithoutIndexName:{DescID: 104, Name: check_i, ConstraintID: 2}
@@ -98,7 +98,7 @@ EXPLAIN (ddl, verbose) ALTER TABLE t VALIDATE CONSTRAINT check_i;
 │       │   └── • ConstraintWithoutIndexName:{DescID: 104, Name: check_i, ConstraintID: 3}
 │       │       │ ABSENT → PUBLIC
 │       │       │
-│       │       └── • SameStagePrecedence dependency from WRITE_ONLY CheckConstraint:{DescID: 104, IndexID: 0, ConstraintID: 3}
+│       │       └── • Precedence dependency from WRITE_ONLY CheckConstraint:{DescID: 104, IndexID: 0, ConstraintID: 3}
 │       │             rule: "simple constraint visible before name"
 │       │
 │       ├── • 2 elements transitioning toward ABSENT
@@ -106,7 +106,7 @@ EXPLAIN (ddl, verbose) ALTER TABLE t VALIDATE CONSTRAINT check_i;
 │       │   ├── • CheckConstraintUnvalidated:{DescID: 104, ConstraintID: 2}
 │       │   │   │ PUBLIC → ABSENT
 │       │   │   │
-│       │   │   └── • SameStagePrecedence dependency from ABSENT ConstraintWithoutIndexName:{DescID: 104, Name: check_i, ConstraintID: 2}
+│       │   │   └── • Precedence dependency from ABSENT ConstraintWithoutIndexName:{DescID: 104, Name: check_i, ConstraintID: 2}
 │       │   │         rule: "Constraint should be hidden before name"
 │       │   │
 │       │   └── • ConstraintWithoutIndexName:{DescID: 104, Name: check_i, ConstraintID: 2}

--- a/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_validate_constraint.rollback_1_of_2
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_validate_constraint.rollback_1_of_2
@@ -28,7 +28,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 1 of 2;
         │   │   ├── • PreviousStagePrecedence dependency from WRITE_ONLY CheckConstraint:{DescID: 104, IndexID: 0, ConstraintID: 3}
         │   │   │     rule: "CheckConstraint transitions to ABSENT uphold 2-version invariant: WRITE_ONLY->VALIDATED"
         │   │   │
-        │   │   └── • SameStagePrecedence dependency from ABSENT ConstraintWithoutIndexName:{DescID: 104, Name: check_i, ConstraintID: 3}
+        │   │   └── • Precedence dependency from ABSENT ConstraintWithoutIndexName:{DescID: 104, Name: check_i, ConstraintID: 3}
         │   │         rule: "Constraint should be hidden before name"
         │   │
         │   └── • ConstraintWithoutIndexName:{DescID: 104, Name: check_i, ConstraintID: 3}

--- a/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_validate_constraint.rollback_2_of_2
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_validate_constraint.rollback_2_of_2
@@ -28,7 +28,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 2 of 2;
         │   │   ├── • PreviousStagePrecedence dependency from WRITE_ONLY CheckConstraint:{DescID: 104, IndexID: 0, ConstraintID: 3}
         │   │   │     rule: "CheckConstraint transitions to ABSENT uphold 2-version invariant: WRITE_ONLY->VALIDATED"
         │   │   │
-        │   │   └── • SameStagePrecedence dependency from ABSENT ConstraintWithoutIndexName:{DescID: 104, Name: check_i, ConstraintID: 3}
+        │   │   └── • Precedence dependency from ABSENT ConstraintWithoutIndexName:{DescID: 104, Name: check_i, ConstraintID: 3}
         │   │         rule: "Constraint should be hidden before name"
         │   │
         │   └── • ConstraintWithoutIndexName:{DescID: 104, Name: check_i, ConstraintID: 3}

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_index_hash_sharded_index
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_index_hash_sharded_index
@@ -14,7 +14,7 @@ EXPLAIN (ddl, verbose) DROP INDEX idx CASCADE;
 │   │
 │   └── • Stage 1 of 1 in StatementPhase
 │       │
-│       ├── • 5 elements transitioning toward ABSENT
+│       ├── • 6 elements transitioning toward ABSENT
 │       │   │
 │       │   ├── • Column:{DescID: 104, ColumnID: 3}
 │       │   │   │ PUBLIC → WRITE_ONLY
@@ -43,13 +43,19 @@ EXPLAIN (ddl, verbose) DROP INDEX idx CASCADE;
 │       │   │   └── • PreviousStagePrecedence dependency from PUBLIC SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 0}
 │       │   │         rule: "SecondaryIndex transitions to ABSENT uphold 2-version invariant: PUBLIC->VALIDATED"
 │       │   │
-│       │   └── • CheckConstraint:{DescID: 104, IndexID: 0, ConstraintID: 2}
-│       │       │ PUBLIC → VALIDATED
+│       │   ├── • CheckConstraint:{DescID: 104, IndexID: 0, ConstraintID: 2}
+│       │   │   │ PUBLIC → VALIDATED
+│       │   │   │
+│       │   │   └── • PreviousStagePrecedence dependency from PUBLIC CheckConstraint:{DescID: 104, IndexID: 0, ConstraintID: 2}
+│       │   │         rule: "CheckConstraint transitions to ABSENT uphold 2-version invariant: PUBLIC->VALIDATED"
+│       │   │
+│       │   └── • ConstraintWithoutIndexName:{DescID: 104, Name: check_crdb_internal_j_shard_16, ConstraintID: 2}
+│       │       │ PUBLIC → ABSENT
 │       │       │
-│       │       └── • PreviousStagePrecedence dependency from PUBLIC CheckConstraint:{DescID: 104, IndexID: 0, ConstraintID: 2}
-│       │             rule: "CheckConstraint transitions to ABSENT uphold 2-version invariant: PUBLIC->VALIDATED"
+│       │       └── • Precedence dependency from VALIDATED CheckConstraint:{DescID: 104, IndexID: 0, ConstraintID: 2}
+│       │             rule: "Constraint should be hidden before name"
 │       │
-│       └── • 5 Mutation operations
+│       └── • 6 Mutation operations
 │           │
 │           ├── • MakePublicColumnNotNullValidated
 │           │     ColumnID: 3
@@ -61,6 +67,11 @@ EXPLAIN (ddl, verbose) DROP INDEX idx CASCADE;
 │           │
 │           ├── • MakePublicCheckConstraintValidated
 │           │     ConstraintID: 2
+│           │     TableID: 104
+│           │
+│           ├── • SetConstraintName
+│           │     ConstraintID: 2
+│           │     Name: crdb_internal_constraint_2_name_placeholder
 │           │     TableID: 104
 │           │
 │           ├── • MakePublicColumnWriteOnly
@@ -76,7 +87,7 @@ EXPLAIN (ddl, verbose) DROP INDEX idx CASCADE;
 │   │
 │   ├── • Stage 1 of 2 in PreCommitPhase
 │   │   │
-│   │   ├── • 5 elements transitioning toward ABSENT
+│   │   ├── • 6 elements transitioning toward ABSENT
 │   │   │   │
 │   │   │   ├── • Column:{DescID: 104, ColumnID: 3}
 │   │   │   │     WRITE_ONLY → PUBLIC
@@ -90,8 +101,11 @@ EXPLAIN (ddl, verbose) DROP INDEX idx CASCADE;
 │   │   │   ├── • SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 0}
 │   │   │   │     VALIDATED → PUBLIC
 │   │   │   │
-│   │   │   └── • CheckConstraint:{DescID: 104, IndexID: 0, ConstraintID: 2}
-│   │   │         VALIDATED → PUBLIC
+│   │   │   ├── • CheckConstraint:{DescID: 104, IndexID: 0, ConstraintID: 2}
+│   │   │   │     VALIDATED → PUBLIC
+│   │   │   │
+│   │   │   └── • ConstraintWithoutIndexName:{DescID: 104, Name: check_crdb_internal_j_shard_16, ConstraintID: 2}
+│   │   │         ABSENT → PUBLIC
 │   │   │
 │   │   └── • 1 Mutation operation
 │   │       │
@@ -100,7 +114,7 @@ EXPLAIN (ddl, verbose) DROP INDEX idx CASCADE;
 │   │
 │   └── • Stage 2 of 2 in PreCommitPhase
 │       │
-│       ├── • 5 elements transitioning toward ABSENT
+│       ├── • 6 elements transitioning toward ABSENT
 │       │   │
 │       │   ├── • Column:{DescID: 104, ColumnID: 3}
 │       │   │   │ PUBLIC → WRITE_ONLY
@@ -129,13 +143,19 @@ EXPLAIN (ddl, verbose) DROP INDEX idx CASCADE;
 │       │   │   └── • PreviousStagePrecedence dependency from PUBLIC SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 0}
 │       │   │         rule: "SecondaryIndex transitions to ABSENT uphold 2-version invariant: PUBLIC->VALIDATED"
 │       │   │
-│       │   └── • CheckConstraint:{DescID: 104, IndexID: 0, ConstraintID: 2}
-│       │       │ PUBLIC → VALIDATED
+│       │   ├── • CheckConstraint:{DescID: 104, IndexID: 0, ConstraintID: 2}
+│       │   │   │ PUBLIC → VALIDATED
+│       │   │   │
+│       │   │   └── • PreviousStagePrecedence dependency from PUBLIC CheckConstraint:{DescID: 104, IndexID: 0, ConstraintID: 2}
+│       │   │         rule: "CheckConstraint transitions to ABSENT uphold 2-version invariant: PUBLIC->VALIDATED"
+│       │   │
+│       │   └── • ConstraintWithoutIndexName:{DescID: 104, Name: check_crdb_internal_j_shard_16, ConstraintID: 2}
+│       │       │ PUBLIC → ABSENT
 │       │       │
-│       │       └── • PreviousStagePrecedence dependency from PUBLIC CheckConstraint:{DescID: 104, IndexID: 0, ConstraintID: 2}
-│       │             rule: "CheckConstraint transitions to ABSENT uphold 2-version invariant: PUBLIC->VALIDATED"
+│       │       └── • Precedence dependency from VALIDATED CheckConstraint:{DescID: 104, IndexID: 0, ConstraintID: 2}
+│       │             rule: "Constraint should be hidden before name"
 │       │
-│       └── • 7 Mutation operations
+│       └── • 8 Mutation operations
 │           │
 │           ├── • MakePublicColumnNotNullValidated
 │           │     ColumnID: 3
@@ -147,6 +167,11 @@ EXPLAIN (ddl, verbose) DROP INDEX idx CASCADE;
 │           │
 │           ├── • MakePublicCheckConstraintValidated
 │           │     ConstraintID: 2
+│           │     TableID: 104
+│           │
+│           ├── • SetConstraintName
+│           │     ConstraintID: 2
+│           │     Name: crdb_internal_constraint_2_name_placeholder
 │           │     TableID: 104
 │           │
 │           ├── • MakePublicColumnWriteOnly
@@ -169,7 +194,7 @@ EXPLAIN (ddl, verbose) DROP INDEX idx CASCADE;
 │                 - 104
 │                 JobID: 1
 │                 NonCancelable: true
-│                 RunningStatus: PostCommitNonRevertiblePhase stage 1 of 2 with 9 MutationType ops pending
+│                 RunningStatus: PostCommitNonRevertiblePhase stage 1 of 2 with 8 MutationType ops pending
 │                 Statements:
 │                 - statement: DROP INDEX idx CASCADE
 │                   redactedstatement: DROP INDEX ‹defaultdb›.‹public›.‹t›@‹idx› CASCADE
@@ -179,7 +204,7 @@ EXPLAIN (ddl, verbose) DROP INDEX idx CASCADE;
     │
     ├── • Stage 1 of 2 in PostCommitNonRevertiblePhase
     │   │
-    │   ├── • 9 elements transitioning toward ABSENT
+    │   ├── • 8 elements transitioning toward ABSENT
     │   │   │
     │   │   ├── • Column:{DescID: 104, ColumnID: 3}
     │   │   │   │ WRITE_ONLY → DELETE_ONLY
@@ -235,30 +260,23 @@ EXPLAIN (ddl, verbose) DROP INDEX idx CASCADE;
     │   │   │   └── • Precedence dependency from VALIDATED SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 0}
     │   │   │         rule: "index no longer public before dependents, excluding columns"
     │   │   │
-    │   │   ├── • CheckConstraint:{DescID: 104, IndexID: 0, ConstraintID: 2}
-    │   │   │   │ VALIDATED → ABSENT
-    │   │   │   │
-    │   │   │   ├── • PreviousStagePrecedence dependency from VALIDATED CheckConstraint:{DescID: 104, IndexID: 0, ConstraintID: 2}
-    │   │   │   │     rule: "CheckConstraint transitions to ABSENT uphold 2-version invariant: VALIDATED->ABSENT"
-    │   │   │   │
-    │   │   │   └── • SameStagePrecedence dependency from ABSENT ConstraintWithoutIndexName:{DescID: 104, Name: check_crdb_internal_j_shard_16, ConstraintID: 2}
-    │   │   │         rule: "Constraint should be hidden before name"
-    │   │   │
-    │   │   └── • ConstraintWithoutIndexName:{DescID: 104, Name: check_crdb_internal_j_shard_16, ConstraintID: 2}
-    │   │       │ PUBLIC → ABSENT
+    │   │   └── • CheckConstraint:{DescID: 104, IndexID: 0, ConstraintID: 2}
+    │   │       │ VALIDATED → ABSENT
     │   │       │
-    │   │       └── • Precedence dependency from VALIDATED CheckConstraint:{DescID: 104, IndexID: 0, ConstraintID: 2}
+    │   │       ├── • PreviousStagePrecedence dependency from VALIDATED CheckConstraint:{DescID: 104, IndexID: 0, ConstraintID: 2}
+    │   │       │     rule: "CheckConstraint transitions to ABSENT uphold 2-version invariant: VALIDATED->ABSENT"
+    │   │       │
+    │   │       └── • Precedence dependency from ABSENT ConstraintWithoutIndexName:{DescID: 104, Name: check_crdb_internal_j_shard_16, ConstraintID: 2}
     │   │             rule: "Constraint should be hidden before name"
     │   │
-    │   └── • 11 Mutation operations
+    │   └── • 10 Mutation operations
     │       │
     │       ├── • RemoveColumnNotNull
     │       │     ColumnID: 3
     │       │     TableID: 104
     │       │
-    │       ├── • SetConstraintName
+    │       ├── • RemoveCheckConstraint
     │       │     ConstraintID: 2
-    │       │     Name: crdb_internal_constraint_2_name_placeholder
     │       │     TableID: 104
     │       │
     │       ├── • MakeWriteOnlyColumnDeleteOnly
@@ -272,10 +290,6 @@ EXPLAIN (ddl, verbose) DROP INDEX idx CASCADE;
     │       ├── • SetIndexName
     │       │     IndexID: 2
     │       │     Name: crdb_internal_index_2_name_placeholder
-    │       │     TableID: 104
-    │       │
-    │       ├── • RemoveCheckConstraint
-    │       │     ConstraintID: 2
     │       │     TableID: 104
     │       │
     │       ├── • RemoveColumnFromIndex


### PR DESCRIPTION
Previously, the rules for adding and removing constraint names were strict, which could lead to mixed version compatibility issues. Specifically, plans on the 23.1 branch could have names set in later stages violating a rule that said a constraint should be public/non-public with the name. To address this, this patch will relax these rules to have Precedence instead of SameStagePrecedence

Fixes: #100908

Release note: None