### PR TITLE
kvserver: re-enable `kv.expiration_leases_only.enabled` test metamorphism

### DIFF
--- a/pkg/kv/kvserver/replica_lease_renewal_test.go
+++ b/pkg/kv/kvserver/replica_lease_renewal_test.go
@@ -216,8 +216,12 @@ func setupLeaseRenewerTest(
 	cycles *int32, /* atomic */
 	_ serverutils.TestClusterInterface,
 ) {
+	st := cluster.MakeTestingClusterSettings()
+	ExpirationLeasesOnly.Override(ctx, &st.SV, false) // override metamorphism
+
 	cycles = new(int32)
 	var args base.TestClusterArgs
+	args.ServerArgs.Settings = st
 	args.ServerArgs.Knobs.Store = &StoreTestingKnobs{
 		LeaseRenewalOnPostCycle: func() {
 			atomic.AddInt32(cycles, 1)

--- a/pkg/kv/kvserver/replica_range_lease.go
+++ b/pkg/kv/kvserver/replica_range_lease.go
@@ -57,6 +57,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/raftutil"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings"
+	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/retry"
@@ -79,10 +80,7 @@ var ExpirationLeasesOnly = settings.RegisterBoolSetting(
 	settings.SystemOnly,
 	"kv.expiration_leases_only.enabled",
 	"only use expiration-based leases, never epoch-based ones (experimental, affects performance)",
-	false,
-	// TODO(erikgrinaker): Make this metamorphic when they don't prevent closed
-	// timestamp updates: https://github.com/cockroachdb/cockroach/issues/99812
-	//util.ConstantWithMetamorphicTestBool("kv.expiration_leases_only.enabled", false),
+	util.ConstantWithMetamorphicTestBool("kv.expiration_leases_only.enabled", false),
 )
 
 var leaseStatusLogLimiter = func() *log.EveryN {

--- a/pkg/kv/kvserver/replica_test.go
+++ b/pkg/kv/kvserver/replica_test.go
@@ -10228,6 +10228,7 @@ func TestShouldReplicaQuiesce(t *testing.T) {
 		return q
 	})
 	test(true, func(q *testQuiescer) *testQuiescer {
+		ExpirationLeasesOnly.Override(context.Background(), &q.st.SV, false)
 		q.leaseStatus.Lease.Epoch = 0
 		q.leaseStatus.Lease.Expiration = &hlc.Timestamp{
 			WallTime: timeutil.Now().Add(time.Minute).Unix(),


### PR DESCRIPTION
The test flakiness should have been addressed by eager lease extensions.

Epic: none
Release note: None