### PR TITLE
ttl: remove deprecated TTLSpec.AOST field

### DIFF
--- a/pkg/sql/execinfrapb/processors_ttl.proto
+++ b/pkg/sql/execinfrapb/processors_ttl.proto
@@ -40,14 +40,9 @@ message TTLSpec {
     (gogoproto.customname) = "RowLevelTTLDetails"
   ];
 
-  // Deprecated: AOST has been replaced with AOSTDuration.
-  // TODO(ewall): remove in 24.1
   // AOST is the AS OF SYSTEM TIME value the ttlProcessor uses to select records.
-  optional google.protobuf.Timestamp aost = 3 [
-    (gogoproto.nullable) = false,
-    (gogoproto.customname) = "AOST",
-    (gogoproto.stdtime) = true
-  ];
+  // It has been replaced with AOSTDuration.
+  reserved 3;
 
   // TTLExpr is compared against jobspb.RowLevelTTLDetails.Cutoff by the
   // ttlProcessor to determine what records to delete. Records are deleted

--- a/pkg/sql/ttl/ttljob/ttljob_processor.go
+++ b/pkg/sql/ttl/ttljob/ttljob_processor.go
@@ -247,24 +247,13 @@ func (t *ttlProcessor) runTTLOnQueryBounds(
 	ie := serverCfg.DB.Executor()
 
 	selectBatchSize := ttlSpec.SelectBatchSize
-
-	aostDuration := ttlSpec.AOSTDuration
-	if aostDuration == 0 {
-		// Read AOST in case of mixed 22.2.0/22.2.1+ cluster where the job started on a 22.2.0 node.
-		//lint:ignore SA1019 execinfrapb.TTLSpec.AOST is deprecated
-		aost := ttlSpec.AOST
-		if !aost.IsZero() {
-			aostDuration = aost.Sub(details.Cutoff)
-		}
-	}
-
 	selectBuilder := MakeSelectQueryBuilder(
 		cutoff,
 		pkColNames,
 		pkColDirs,
 		relationName,
 		bounds,
-		aostDuration,
+		ttlSpec.AOSTDuration,
 		selectBatchSize,
 		ttlExpr,
 	)


### PR DESCRIPTION
Fixes #101104
    
This change removes `TTLSpec.AOST` which was needed for 22.2/23.1 compatibility.
    
Release note: None