### PR TITLE
backupccl: fix incorrect schema ID used during object collision check

### DIFF
--- a/pkg/ccl/backupccl/testdata/backup-restore/in-progress-restores
+++ b/pkg/ccl/backupccl/testdata/backup-restore/in-progress-restores
@@ -1,6 +1,3 @@
-skip issue-num=93731
-----
-
 # This test ensures that table, database and cluster backups properly backup and
 # restore (i.e. capture) an in progress database or table RESTORE. The
 # in-progress restore may take other kinds of descriptors offline (e.g. type,
@@ -158,10 +155,10 @@ SELECT * FROM b2.me.baz;
 
 
 query-sql
-SELECT * FROM [SHOW INDEX FROM b2.me.baz] WHERE index_name = 'greeting_idx';
+SELECT table_name,index_name,non_unique,seq_in_index,column_name FROM [SHOW INDEX FROM b2.me.baz] WHERE index_name = 'greeting_idx';
 ----
-baz greeting_idx true 1 y ASC false false true
-baz greeting_idx true 2 rowid ASC false true true
+baz greeting_idx true 1 y
+baz greeting_idx true 2 rowid
 
 
 #################

--- a/pkg/ccl/backupccl/testdata/backup-restore/regression-tests
+++ b/pkg/ccl/backupccl/testdata/backup-restore/regression-tests
@@ -171,3 +171,91 @@ SELECT * FROM "restore-test".t4 ORDER BY k
 3 3 3
 
 subtest end
+
+# incorrect-schema-id is a regression test to ensure that we use the correct schema ID
+# when checking for object collision during restore.
+subtest incorrect-schema-id
+
+new-cluster name=s4
+----
+
+exec-sql
+CREATE DATABASE b;
+----
+
+exec-sql
+CREATE SCHEMA b.me;
+----
+
+exec-sql
+CREATE TABLE b.me.foo (id INT);
+----
+
+exec-sql
+INSERT INTO b.me.foo VALUES (1), (2), (3);
+----
+
+exec-sql
+BACKUP INTO 'nodelocal://1/cluster'
+----
+
+query-sql
+SELECT id, name FROM system.namespace WHERE name = 'me';
+----
+109 me
+
+new-cluster name=s5 share-io-dir=s4
+----
+
+exec-sql
+CREATE DATABASE d
+----
+
+exec-sql
+CREATE SCHEMA d.foo;
+CREATE SCHEMA d.bar;
+CREATE SCHEMA d.baz;
+----
+
+exec-sql
+CREATE DATABASE collide
+----
+
+query-sql
+SELECT id, name FROM system.namespace WHERE name = 'collide'
+----
+109 collide
+
+exec-sql
+RESTORE TABLE b.me.foo FROM LATEST IN 'nodelocal://1/cluster' WITH into_db=collide
+----
+
+query-sql
+SELECT * FROM collide.me.foo ORDER BY id
+----
+1
+2
+3
+
+exec-sql
+CREATE DATABASE d2;
+CREATE SCHEMA d2.me;
+----
+
+exec-sql
+RESTORE TABLE b.me.foo FROM LATEST IN 'nodelocal://1/cluster' WITH into_db=d2
+----
+
+query-sql
+SELECT * FROM d2.me.foo ORDER BY id
+----
+1
+2
+3
+
+exec-sql expect-error-regex=relation \"foo\" already exists
+RESTORE TABLE b.me.foo FROM LATEST IN 'nodelocal://1/cluster' WITH into_db=d2
+----
+regex matches error
+
+subtest end


### PR DESCRIPTION
Previously, when restoring tables, we would use the schema ID in the backed
up table descriptor when checking if a table with the same name existed in
the db.schema we were about to restore to. The schema ID in the backed up table
descriptor could mean something entirely different in the restoring cluster.
In the red-green test added as part of this PR, the schema ID in the backed up
descriptor collides with the database ID in the restoring cluster. This results
in the collision check failing because it attempts to resolve a schema with an
ID corresponding to a database.

To fix this we tighten the rules for when we need to perform collission checks.
If the table is being restored into an existing schema in the restoring cluster,
then we check for a collission using the existing schema's ID. If the table is
being restored into a schema that is also being restored then we do not need to
perform any collission checks. A similar refactor is done for types as well.

Fixes: https://github.com/cockroachdb/cockroach/issues/93731

Release note (bug fix): restoring a backup with user defined schemas could occassionally
fail due to incorrect schema ID resolution