### PR TITLE
release-22.2: sql: add issue number for unimplemented udf default params

### DIFF
--- a/pkg/sql/create_function.go
+++ b/pkg/sql/create_function.go
@@ -471,7 +471,7 @@ func makeFunctionArg(
 	}
 
 	if arg.DefaultVal != nil {
-		return descpb.FunctionDescriptor_Argument{}, unimplemented.New("CREATE FUNCTION argument", "default value")
+		return descpb.FunctionDescriptor_Argument{}, unimplemented.NewWithIssue(100962, "default value")
 	}
 
 	return pbArg, nil

--- a/pkg/sql/logictest/testdata/logic_test/udf
+++ b/pkg/sql/logictest/testdata/logic_test/udf
@@ -100,6 +100,10 @@ CREATE FUNCTION err(b BOOL) RETURNS INT LANGUAGE SQL AS 'SELECT b'
 statement error return type mismatch in function declared to return bool\nDETAIL: Actual return type is int
 CREATE FUNCTION err(i INT, j INT) RETURNS BOOL LANGUAGE SQL AS 'SELECT i - j'
 
+# TODO(100962): Add support for default parameters.
+statement error pgcode 0A000 unimplemented: default value
+CREATE FUNCTION err(i INT, j INT DEFAULT 2) RETURNS INT LANGUAGE SQL AS 'SELECT i - j'
+
 # Make sure using table name as tuple type name works properly.
 # It should pass the return type validation and stored as a tuple type.
 statement ok


### PR DESCRIPTION
Backport 1/1 commits from #100964.

/cc @cockroachdb/release

---

Adds a link to an issue number for UDF DEFAULT parameters, which are not currently supported.

Epic: None
Informs: #100962
Fixes: #99881

Release note: None

Release justification: Modifies an existing error message, so the change is not risky.
