### PR TITLE
kv: enforce minimum value for kv.range_descriptor_cache.size

### DIFF
--- a/pkg/kv/kvclient/kvcoord/dist_sender.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender.go
@@ -211,6 +211,14 @@ var rangeDescriptorCacheSize = settings.RegisterIntSetting(
 	"kv.range_descriptor_cache.size",
 	"maximum number of entries in the range descriptor cache",
 	1e6,
+	func(v int64) error {
+		// Set a minimum value to avoid a cache that is too small to be useful.
+		const minVal = 64
+		if v < minVal {
+			return errors.Errorf("cannot be set to a value less than %d", minVal)
+		}
+		return nil
+	},
 )
 
 // senderConcurrencyLimit controls the maximum number of asynchronous send


### PR DESCRIPTION
Closes #101011.

This commit adds a minimum value for the kv.range_descriptor_cache.size cluster setting. The minimum value is set to 64, which avoid a cache that is too small to be useful and could thrash.

Release note: None