### PR TITLE
changefeedccl: fix pubsub v2 unit tests on AWS

### DIFF
--- a/pkg/ccl/changefeedccl/testfeed_test.go
+++ b/pkg/ccl/changefeedccl/testfeed_test.go
@@ -2359,11 +2359,11 @@ func makePubsubFeedFactory(srvOrCluster interface{}, db *gosql.DB) cdctest.TestF
 
 	switch t := srvOrCluster.(type) {
 	case serverutils.TestTenantInterface:
-		t.DistSQLServer().(*distsql.ServerImpl).TestingKnobs.Changefeed.(*TestingKnobs).PubsubClientSkipCredentialsCheck = true
+		t.DistSQLServer().(*distsql.ServerImpl).TestingKnobs.Changefeed.(*TestingKnobs).PubsubClientSkipClientCreation = true
 	case serverutils.TestClusterInterface:
 		servers := make([]feedInjectable, t.NumServers())
 		for i := range servers {
-			t.Server(i).DistSQLServer().(*distsql.ServerImpl).TestingKnobs.Changefeed.(*TestingKnobs).PubsubClientSkipCredentialsCheck = true
+			t.Server(i).DistSQLServer().(*distsql.ServerImpl).TestingKnobs.Changefeed.(*TestingKnobs).PubsubClientSkipClientCreation = true
 		}
 	}
 
@@ -2404,8 +2404,6 @@ func (p *pubsubFeedFactory) Feed(create string, args ...interface{}) (cdctest.Te
 		defer mu.Unlock()
 		if batchingSink, ok := s.(*batchingSink); ok {
 			if sinkClient, ok := batchingSink.client.(*pubsubSinkClient); ok {
-				_ = sinkClient.client.Close()
-
 				conn, _ := mockServer.Dial()
 				mockClient, _ := pubsubv1.NewPublisherClient(context.Background(), option.WithGRPCConn(conn))
 				sinkClient.client = mockClient

--- a/pkg/ccl/changefeedccl/testing_knobs.go
+++ b/pkg/ccl/changefeedccl/testing_knobs.go
@@ -32,8 +32,9 @@ type TestingKnobs struct {
 	// It allows the tests to muck with the Sink, and even return altogether different
 	// implementation.
 	WrapSink func(s Sink, jobID jobspb.JobID) Sink
-	// PubsubClientSkipCredentialsCheck, if set, skips the gcp credentials checking
-	PubsubClientSkipCredentialsCheck bool
+	// PubsubClientSkipClientCreation, if set, skips creating a google cloud
+	// client as it is expected that the test manually sets a client.
+	PubsubClientSkipClientCreation bool
 	// FilterSpanWithMutation is a filter returning true if the resolved span event should
 	// be skipped. This method takes a pointer in case resolved spans need to be mutated.
 	FilterSpanWithMutation func(resolved *jobspb.ResolvedSpan) bool


### PR DESCRIPTION
Resolves https://github.com/cockroachdb/cockroach/issues/100968
Resolves https://github.com/cockroachdb/cockroach/issues/100969
Resolves https://github.com/cockroachdb/cockroach/issues/100970
Resolves https://github.com/cockroachdb/cockroach/issues/100971
Resolves https://github.com/cockroachdb/cockroach/issues/100972
Resolves https://github.com/cockroachdb/cockroach/issues/100973
Resolves https://github.com/cockroachdb/cockroach/issues/100974
Resolves https://github.com/cockroachdb/cockroach/issues/100985
Resolves https://github.com/cockroachdb/cockroach/issues/100986
Resolves https://github.com/cockroachdb/cockroach/issues/100987
Resolves https://github.com/cockroachdb/cockroach/issues/100988
Resolves https://github.com/cockroachdb/cockroach/issues/101014
Resolves https://github.com/cockroachdb/cockroach/issues/101015
Resolves https://github.com/cockroachdb/cockroach/issues/101016
Resolves https://github.com/cockroachdb/cockroach/issues/101017
Resolves https://github.com/cockroachdb/cockroach/issues/101018
Resolves https://github.com/cockroachdb/cockroach/issues/101019
Resolves https://github.com/cockroachdb/cockroach/issues/101020
Resolves https://github.com/cockroachdb/cockroach/issues/101030
Resolves https://github.com/cockroachdb/cockroach/issues/101031
Resolves https://github.com/cockroachdb/cockroach/issues/101032
Resolves https://github.com/cockroachdb/cockroach/issues/101033
Resolves https://github.com/cockroachdb/cockroach/issues/101034
Resolves https://github.com/cockroachdb/cockroach/issues/101035
Resolves https://github.com/cockroachdb/cockroach/issues/101036
Resolves https://github.com/cockroachdb/cockroach/issues/101040
Resolves https://github.com/cockroachdb/cockroach/issues/101041
Resolves https://github.com/cockroachdb/cockroach/issues/101042
Resolves https://github.com/cockroachdb/cockroach/issues/101043
Resolves https://github.com/cockroachdb/cockroach/issues/101044
Resolves https://github.com/cockroachdb/cockroach/issues/101045
Resolves https://github.com/cockroachdb/cockroach/issues/101062
Resolves https://github.com/cockroachdb/cockroach/issues/101063
Resolves https://github.com/cockroachdb/cockroach/issues/101064
Resolves https://github.com/cockroachdb/cockroach/issues/101065
Resolves https://github.com/cockroachdb/cockroach/issues/101066
Resolves https://github.com/cockroachdb/cockroach/issues/101067
Resolves https://github.com/cockroachdb/cockroach/issues/101079
Resolves https://github.com/cockroachdb/cockroach/issues/101080
Resolves https://github.com/cockroachdb/cockroach/issues/101081
Resolves https://github.com/cockroachdb/cockroach/issues/101082
Resolves https://github.com/cockroachdb/cockroach/issues/101083
Resolves https://github.com/cockroachdb/cockroach/issues/101084
Resolves https://github.com/cockroachdb/cockroach/issues/101085
Resolves https://github.com/cockroachdb/cockroach/issues/101086
Resolves https://github.com/cockroachdb/cockroach/issues/101099
Resolves https://github.com/cockroachdb/cockroach/issues/101100
Resolves https://github.com/cockroachdb/cockroach/issues/101106
Resolves https://github.com/cockroachdb/cockroach/issues/101107
Resolves https://github.com/cockroachdb/cockroach/issues/101113
Resolves https://github.com/cockroachdb/cockroach/issues/101114
Resolves https://github.com/cockroachdb/cockroach/issues/101115


The pubsub V2 tests would fail with
```
failed to start feed for job 0: pq: opening client: google: could not find
default credentials. See
https://developers.google.com/accounts/docs/application-default-credentials for
more information
```
only on release-23.1 test runs because every other test was running on google cloud machines, where you didn't need to even have `gcloud` installed for it to work.  This happens only on the initial attempt to initialize a PubsubClient when the GRPCConn is not overriden.

This PR fixes it by skipping initialization entirely so that we don't have to deal with errors like this or having ensure the old connection is cleaned up before setting the mock one.

Release note: None