### PR TITLE
release-22.2: ui: format transactions count on sessions

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/sessions/sessionDetails.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/sessions/sessionDetails.tsx
@@ -26,7 +26,7 @@ import { SummaryCard, SummaryCardItem } from "../summaryCard";
 import LoadingError from "../sqlActivity/errorComponent";
 
 import { DurationToMomentDuration, TimestampToMoment } from "src/util/convert";
-import { Bytes, DATE_FORMAT } from "src/util/format";
+import { Bytes, DATE_FORMAT, Count } from "src/util/format";
 import { Col, Row } from "antd";
 import "antd/lib/col/style";
 import "antd/lib/row/style";
@@ -425,7 +425,7 @@ export class SessionDetails extends React.Component<SessionDetailsProps> {
               <SummaryCardItem label={"User Name"} value={session.username} />
               <SummaryCardItem
                 label="Transaction Count"
-                value={session.num_txns_executed}
+                value={Count(session.num_txns_executed)}
               />
             </SummaryCard>
           </Col>

--- a/pkg/ui/workspaces/cluster-ui/src/sessions/sessionsTable.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/sessions/sessionsTable.tsx
@@ -16,7 +16,7 @@ import {
   DurationToNumber,
   TimestampToMoment,
 } from "src/util/convert";
-import { BytesWithPrecision } from "src/util/format";
+import { BytesWithPrecision, Count } from "src/util/format";
 import { Link } from "react-router-dom";
 import React from "react";
 
@@ -224,7 +224,7 @@ export function makeSessionsColumns(
       name: "sessionTxnCount",
       title: statisticsTableTitles.sessionTxnCount(statType),
       className: cx("cl-table__col-session"),
-      cell: session => session.session?.num_txns_executed,
+      cell: session => Count(session.session?.num_txns_executed),
       sort: session => session.session?.num_txns_executed,
     },
     {


### PR DESCRIPTION
Backport 1/1 commits from #95634.

/cc @cockroachdb/release

---

Use Count format function on Transaction Count
on Sessions table and Session Details page.

It also removed the comment added by mistake on
a previous PR.

Epic: None

Release note: None

---
Release justification: small UI improvement
