### PR TITLE
release-22.2: sql: link issue to unimplemented mutations in udfs

### DIFF
--- a/pkg/sql/opt/optbuilder/builder.go
+++ b/pkg/sql/opt/optbuilder/builder.go
@@ -299,6 +299,13 @@ func (b *Builder) buildStmt(
 	if b.insideFuncDef {
 		switch stmt := stmt.(type) {
 		case *tree.Select:
+		case tree.SelectStatement:
+		case *tree.Delete:
+			panic(unimplemented.NewWithIssuef(87289, "%s usage inside a function definition", stmt.StatementTag()))
+		case *tree.Insert:
+			panic(unimplemented.NewWithIssuef(87289, "%s usage inside a function definition", stmt.StatementTag()))
+		case *tree.Update:
+			panic(unimplemented.NewWithIssuef(87289, "%s usage inside a function definition", stmt.StatementTag()))
 		default:
 			panic(unimplemented.Newf("user-defined functions", "%s usage inside a function definition", stmt.StatementTag()))
 		}


### PR DESCRIPTION
Backport 1/1 commits from #100965.

/cc @cockroachdb/release

---

Links an issue to the unimplemented errors for mutations in UDFs.

Epic: None
Informs: #87289
Fixes: #99715

Release note: None

Release justification: Changes an existing error message, so change is not risky.