### PR TITLE
release-22.2: ui: add badges for filter elements

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/insights/schemaInsights/schemaInsightsView.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/schemaInsights/schemaInsightsView.tsx
@@ -26,6 +26,7 @@ import {
   defaultFilters,
   Filter,
   getFullFiltersAsStringRecord,
+  SelectedFilters,
 } from "../../queryFilter";
 import { queryByName, syncHistory } from "../../util";
 import { getTableSortFromURL } from "../../sortedtable/getTableSortFromURL";
@@ -218,6 +219,12 @@ export const SchemaInsightsView: React.FC<SchemaInsightsViewProps> = ({
           />
         </PageConfigItem>
       </PageConfig>
+      <SelectedFilters
+        filters={filters}
+        onRemoveFilter={onSubmitFilters}
+        onClearFilters={clearFilters}
+        className={cx("margin-adjusted")}
+      />
       <div className={cx("table-area")}>
         <Loading
           loading={schemaInsights === null}
@@ -234,7 +241,6 @@ export const SchemaInsightsView: React.FC<SchemaInsightsViewProps> = ({
                   totalCount={filteredSchemaInsights?.length}
                   arrayItemName="schema insights"
                   activeFilters={countActiveFilters}
-                  onClearFilters={clearFilters}
                 />
               </div>
               <InsightsSortedTable

--- a/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsights/statementInsights/statementInsightsView.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsights/statementInsights/statementInsightsView.tsx
@@ -22,6 +22,7 @@ import {
   calculateActiveFilters,
   Filter,
   getFullFiltersAsStringRecord,
+  SelectedFilters,
 } from "src/queryFilter/filter";
 import { getWorkloadInsightEventFiltersFromURL } from "src/queryFilter/utils";
 import { Pagination } from "src/pagination";
@@ -244,6 +245,12 @@ export const StatementInsightsView: React.FC<StatementInsightsViewProps> = (
           />
         </PageConfigItem>
       </PageConfig>
+      <SelectedFilters
+        filters={filters}
+        onRemoveFilter={onSubmitFilters}
+        onClearFilters={clearFilters}
+        className={cx("margin-adjusted")}
+      />
       <div className={cx("table-area")}>
         <Loading
           loading={statements === null}
@@ -265,7 +272,6 @@ export const StatementInsightsView: React.FC<StatementInsightsViewProps> = (
                   totalCount={statementInsights?.length}
                   arrayItemName="statement insights"
                   activeFilters={countActiveFilters}
-                  onClearFilters={clearFilters}
                 />
               </div>
               <StatementInsightsTable

--- a/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsights/transactionInsights/transactionInsightsView.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsights/transactionInsights/transactionInsightsView.tsx
@@ -22,6 +22,7 @@ import {
   calculateActiveFilters,
   Filter,
   getFullFiltersAsStringRecord,
+  SelectedFilters,
 } from "src/queryFilter/filter";
 import { getWorkloadInsightEventFiltersFromURL } from "src/queryFilter/utils";
 import { Pagination } from "src/pagination";
@@ -216,6 +217,12 @@ export const TransactionInsightsView: React.FC<TransactionInsightsViewProps> = (
           />
         </PageConfigItem>
       </PageConfig>
+      <SelectedFilters
+        filters={filters}
+        onRemoveFilter={onSubmitFilters}
+        onClearFilters={clearFilters}
+        className={cx("margin-adjusted")}
+      />
       <div className={cx("table-area")}>
         <Loading
           loading={transactions === null}
@@ -232,7 +239,6 @@ export const TransactionInsightsView: React.FC<TransactionInsightsViewProps> = (
                   totalCount={filteredTransactions?.length}
                   arrayItemName="transaction insights"
                   activeFilters={countActiveFilters}
-                  onClearFilters={clearFilters}
                 />
               </div>
               <TransactionInsightsTable

--- a/pkg/ui/workspaces/cluster-ui/src/queryFilter/filter.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/queryFilter/filter.module.scss
@@ -127,3 +127,32 @@ $dropdown-hover-color: darken($colors--background, 2.5%);
 .hide {
   display: none;
 }
+
+.badges-area {
+  display: flex;
+  margin-bottom: 5px;
+}
+
+.badge-wrapper {
+  background-color: $colors--neutral-2;
+  border-radius: 3px;
+  color: $colors--neutral-7;
+  display: flex;
+  font-family: $font-family--semi-bold;
+  font-size: $font-size--small;
+  line-height: $line-height--small;
+  margin: 5px 5px 5px 0;
+  padding: 3px 7px;
+  width: fit-content;
+}
+
+.close-area {
+  margin-top: 4px;
+  margin-left: 5px;
+  width: 12px;
+  cursor: pointer;
+}
+
+.clear-btn {
+  margin-top: 3px;
+}

--- a/pkg/ui/workspaces/cluster-ui/src/queryFilter/filter.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/queryFilter/filter.tsx
@@ -11,7 +11,7 @@
 import React from "react";
 import Select from "react-select";
 import { Button } from "../button";
-import { CaretDown } from "@cockroachlabs/icons";
+import { CaretDown, Cancel } from "@cockroachlabs/icons";
 import { Input } from "antd";
 import "antd/lib/input/style";
 import { History } from "history";
@@ -26,6 +26,8 @@ import {
   hidden,
   caretDown,
   checkbox,
+  badge,
+  clearBnt,
 } from "./filterClasses";
 import { MultiSelectCheckbox } from "../multiSelectCheckbox/multiSelectCheckbox";
 import { syncHistory } from "../util";
@@ -238,7 +240,7 @@ export const updateFiltersQueryParamsOnTab = (
 };
 
 /**
- * The State of the filter that is consider inactive.
+ * The State of the filter that is considered inactive.
  * It's different from defaultFilters because we don't want to take
  * timeUnit into consideration.
  * For example, if the timeUnit changes, but the timeValue is still 0,
@@ -252,18 +254,20 @@ export const inactiveFiltersState: Required<Omit<Filters, "timeUnit">> = {
   database: "",
   regions: "",
   nodes: "",
+  schemaInsightType: "",
+  username: "",
+};
+
+const getActiveFilters = (filters: Filters): string[] => {
+  return Object.keys(inactiveFiltersState).filter(
+    filter =>
+      filters[filter] != null &&
+      inactiveFiltersState[filter] !== filters[filter],
+  );
 };
 
 export const calculateActiveFilters = (filters: Filters): number => {
-  return Object.keys(inactiveFiltersState).reduce(
-    (active, filter: keyof Filters) => {
-      return filters[filter] != null &&
-        inactiveFiltersState[filter] !== filters[filter]
-        ? (active += 1)
-        : active;
-    },
-    0,
-  );
+  return getActiveFilters(filters).length;
 };
 
 export const getTimeValueInSeconds = (filters: Filters): number | "empty" => {
@@ -419,7 +423,7 @@ export class Filter extends React.Component<QueryFilter, FilterState> {
     });
     const appFilter = (
       <div>
-        <div className={filterLabel.margin}>Application Name</div>
+        <div className={filterLabel.margin}>{getLabelFromKey("app")}</div>
         <MultiSelectCheckbox
           options={appsOptions}
           placeholder="All"
@@ -442,7 +446,7 @@ export class Filter extends React.Component<QueryFilter, FilterState> {
     });
     const dbFilter = (
       <div>
-        <div className={filterLabel.margin}>Database</div>
+        <div className={filterLabel.margin}>{getLabelFromKey("database")}</div>
         <MultiSelectCheckbox
           options={databasesOptions}
           placeholder="All"
@@ -465,7 +469,7 @@ export class Filter extends React.Component<QueryFilter, FilterState> {
     });
     const usernameFilter = (
       <div>
-        <div className={filterLabel.margin}>User Name</div>
+        <div className={filterLabel.margin}>{getLabelFromKey("username")}</div>
         <MultiSelectCheckbox
           options={usernameOptions}
           placeholder="All"
@@ -491,7 +495,9 @@ export class Filter extends React.Component<QueryFilter, FilterState> {
     });
     const sessionStatusFilter = (
       <div>
-        <div className={filterLabel.margin}>Session Status</div>
+        <div className={filterLabel.margin}>
+          {getLabelFromKey("sessionStatus")}
+        </div>
         <MultiSelectCheckbox
           options={sessionStatusOptions}
           placeholder="All"
@@ -517,7 +523,9 @@ export class Filter extends React.Component<QueryFilter, FilterState> {
     });
     const schemaInsightTypeFilter = (
       <div>
-        <div className={filterLabel.margin}>Schema Insight Type</div>
+        <div className={filterLabel.margin}>
+          {getLabelFromKey("schemaInsightType")}
+        </div>
         <MultiSelectCheckbox
           options={schemaInsightTypeOptions}
           placeholder="All"
@@ -540,7 +548,7 @@ export class Filter extends React.Component<QueryFilter, FilterState> {
     );
     const regionsFilter = (
       <div>
-        <div className={filterLabel.margin}>Region</div>
+        <div className={filterLabel.margin}>{getLabelFromKey("regions")}</div>
         <MultiSelectCheckbox
           options={regionsOptions}
           placeholder="All"
@@ -563,7 +571,7 @@ export class Filter extends React.Component<QueryFilter, FilterState> {
     });
     const nodesFilter = (
       <div>
-        <div className={filterLabel.margin}>Node</div>
+        <div className={filterLabel.margin}>{getLabelFromKey("nodes")}</div>
         <MultiSelectCheckbox
           options={nodesOptions}
           placeholder="All"
@@ -604,7 +612,7 @@ export class Filter extends React.Component<QueryFilter, FilterState> {
     });
     const sqlTypeFilter = (
       <div>
-        <div className={filterLabel.margin}>Statement Type</div>
+        <div className={filterLabel.margin}>{getLabelFromKey("sqlType")}</div>
         <MultiSelectCheckbox
           options={sqlTypes}
           placeholder="All"
@@ -687,5 +695,113 @@ export class Filter extends React.Component<QueryFilter, FilterState> {
         </div>
       </div>
     );
+  }
+}
+
+interface SelectedFilterProps {
+  filters: Filters;
+  onRemoveFilter: (filters: Filters) => void;
+  onClearFilters: () => void;
+  className?: string;
+}
+
+export function SelectedFilters(
+  props: SelectedFilterProps,
+): React.ReactElement {
+  const { filters, onRemoveFilter, onClearFilters, className } = props;
+  const activeFilters = getActiveFilters(filters);
+  const badges = activeFilters.map(filter => {
+    return (
+      <FilterBadge
+        filters={filters}
+        name={filter}
+        values={filters[filter]}
+        unit={filters["timeUnit"]}
+        key={filter}
+        onRemoveFilter={onRemoveFilter}
+      />
+    );
+  });
+
+  return (
+    <div className={`${badge.area} ${className}`}>
+      {badges}
+      {activeFilters.length > 0 && (
+        <Button
+          onClick={() => onClearFilters()}
+          type="flat"
+          size="small"
+          className={clearBnt.btn}
+        >
+          Clear filters
+        </Button>
+      )}
+    </div>
+  );
+}
+
+function removeFilter(
+  filters: Filters,
+  filter: string,
+  onRemoveFilter: (filters: Filters) => void,
+): void {
+  filters[filter] = inactiveFiltersState[filter];
+  onRemoveFilter({ ...filters });
+}
+
+interface FilterBadgeProps {
+  filters: Filters;
+  name: string;
+  values: string | boolean;
+  unit: string;
+  onRemoveFilter: (filters: Filters) => void;
+}
+
+function FilterBadge(props: FilterBadgeProps): React.ReactElement {
+  const { filters, name, values, onRemoveFilter } = props;
+  const unit = name === "timeNumber" ? props.unit : "";
+  let value = `${getLabelFromKey(name)}: ${values.toString()} ${unit}`;
+  if (value.length > 100) {
+    value = value.substring(0, 100) + "...";
+  }
+  return (
+    <div className={badge.wrapper}>
+      {value}
+      <Cancel
+        className={badge.closeArea}
+        onClick={() => removeFilter(filters, name, onRemoveFilter)}
+      />
+    </div>
+  );
+}
+
+function getLabelFromKey(key: string): string {
+  switch (key) {
+    case "app":
+      return "Application Name";
+    case "database":
+      return "Database";
+    case "executionStatus":
+      return "Execution Status";
+    case "fullScan":
+      return "Full Scan";
+    case "nodes":
+      return "Node";
+    case "regions":
+      return "Region";
+    case "schemaInsightType":
+      return "Schema Insight Type";
+    case "sessionStatus":
+      return "Session Status";
+    case "sqlType":
+      return "Statement Type";
+    case "timeNumber":
+      return "Runs Longer Than";
+    case "username":
+      return "User Name";
+    case "workloadInsightType":
+      return "Workload Insight Type";
+    default:
+      return key;
   }
 }

--- a/pkg/ui/workspaces/cluster-ui/src/queryFilter/filterClasses.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/queryFilter/filterClasses.ts
@@ -39,3 +39,13 @@ export const applyBtn = {
   wrapper: cx("apply-btn__wrapper"),
   btn: cx("apply-btn__btn"),
 };
+
+export const clearBnt = {
+  btn: cx("clear-btn"),
+};
+
+export const badge = {
+  area: cx("badges-area"),
+  wrapper: cx("badge-wrapper"),
+  closeArea: cx("close-area"),
+};

--- a/pkg/ui/workspaces/cluster-ui/src/sessions/sessionsPage.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/sessions/sessionsPage.tsx
@@ -41,6 +41,7 @@ import {
   Filters,
   getTimeValueInSeconds,
   handleFiltersFromQueryString,
+  SelectedFilters,
 } from "../queryFilter";
 
 import TerminateQueryModal, {
@@ -405,6 +406,11 @@ export class SessionsPage extends React.Component<
             filters={filters}
             timeLabel={"Session duration"}
           />
+          <SelectedFilters
+            filters={filters}
+            onRemoveFilter={this.onSubmitFilters}
+            onClearFilters={this.onClearFilters}
+          />
         </div>
         <section className={sessionsPageCx("sessions-table-area")}>
           <div className={statementsPageCx("cl-table-statistic")}>
@@ -419,7 +425,6 @@ export class SessionsPage extends React.Component<
                 totalCount={sessionsToDisplay.length}
                 arrayItemName="sessions"
                 activeFilters={activeFilters}
-                onClearFilters={this.onClearFilters}
               />
             </div>
           </div>

--- a/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.module.scss
@@ -113,3 +113,8 @@ cl-table-container {
 .margin-top {
   margin-top: 20px;
 }
+
+.margin-adjusted {
+  margin-top: 5px;
+  margin-bottom: -15px;
+}

--- a/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.tsx
@@ -29,6 +29,7 @@ import {
   Filters,
   getTimeValueInSeconds,
   handleFiltersFromQueryString,
+  SelectedFilters,
   updateFiltersQueryParamsOnTab,
 } from "../queryFilter";
 
@@ -623,16 +624,6 @@ export class StatementsPage extends React.Component<
     );
 
     const period = timeScaleToString(this.props.timeScale);
-    const clearFilter = activeFilters ? (
-      <PageConfigItem>
-        <Button onClick={this.onClearFilters} type="flat" size="small">
-          clear filter
-        </Button>
-      </PageConfigItem>
-    ) : (
-      <></>
-    );
-
     const sortSettingLabel = getSortLabel(this.props.reqSortSetting);
 
     return (
@@ -671,7 +662,6 @@ export class StatementsPage extends React.Component<
                 onSubmitColumns={onColumnsChange}
               />
             </PageConfigItem>
-            {clearFilter}
           </PageConfig>
           <PageConfig className={cx("float-right")}>
             <PageConfigItem>
@@ -695,6 +685,11 @@ export class StatementsPage extends React.Component<
           </PageConfig>
         </section>
         <section className={sortableTableCx("cl-table-container")}>
+          <SelectedFilters
+            filters={filters}
+            onRemoveFilter={this.onSubmitFilters}
+            onClearFilters={this.onClearFilters}
+          />
           <StatementsSortedTable
             className="statements-table"
             data={data}

--- a/pkg/ui/workspaces/cluster-ui/src/tableStatistics/tableStatistics.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/tableStatistics/tableStatistics.tsx
@@ -64,14 +64,20 @@ export const TableStatistics: React.FC<TableStatistics> = ({
     </>
   );
 
+  const clearBtn = (
+    <>
+      | &nbsp;
+      <Button onClick={() => onClearFilters()} type="flat" size="small">
+        Clear filters
+      </Button>
+    </>
+  );
+
   const resultsCountAndClear = (
     <>
       {totalCount} {totalCount === 1 ? "result" : "results"}
       {period && periodLabel}
-      &nbsp;&nbsp;&nbsp;| &nbsp;
-      <Button onClick={() => onClearFilters()} type="flat" size="small">
-        clear filter
-      </Button>
+      &nbsp;&nbsp;&nbsp;{onClearFilters && clearBtn}
     </>
   );
 

--- a/pkg/ui/workspaces/cluster-ui/src/transactionsPage/transactionsPage.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionsPage/transactionsPage.tsx
@@ -46,6 +46,7 @@ import {
   defaultFilters,
   handleFiltersFromQueryString,
   updateFiltersQueryParamsOnTab,
+  SelectedFilters,
 } from "../queryFilter";
 import { UIConfigState } from "../store";
 import {
@@ -490,16 +491,6 @@ export class TransactionsPage extends React.Component<
     );
 
     const period = timeScaleToString(this.props.timeScale);
-    const clearFilter = activeFilters ? (
-      <PageConfigItem>
-        <Button onClick={this.onClearFilters} type="flat" size="small">
-          clear filter
-        </Button>
-      </PageConfigItem>
-    ) : (
-      <></>
-    );
-
     const sortSettingLabel = getSortLabel(this.props.reqSortSetting);
     return (
       <>
@@ -534,7 +525,6 @@ export class TransactionsPage extends React.Component<
                 onSubmitColumns={onColumnsChange}
               />
             </PageConfigItem>
-            {clearFilter}
           </PageConfig>
           <PageConfig className={cx("float-right")}>
             <PageConfigItem>
@@ -558,6 +548,11 @@ export class TransactionsPage extends React.Component<
           </PageConfig>
         </section>
         <section className={statisticsClasses.tableContainerClass}>
+          <SelectedFilters
+            filters={filters}
+            onRemoveFilter={this.onSubmitFilters}
+            onClearFilters={this.onClearFilters}
+          />
           <TransactionsTable
             columns={displayColumns}
             transactions={transactionsToDisplay}


### PR DESCRIPTION
Backport 1/1 commits from #98988.

/cc @cockroachdb/release

Image on 22.2

<img width="1700" alt="Screenshot 2023-04-10 at 2 10 24 PM" src="https://user-images.githubusercontent.com/1017486/230964809-34589085-60f3-49ab-af8c-34955e3638ce.png">

---

Adds badges for each of the selected filters on SQL Activity and
Insights pages.

Part Of #98891

https://www.loom.com/share/e7417209fc704d71b2733f58609fb4de

<img width="1160" alt="Screenshot 2023-03-19 at 1 30 49 PM" src="https://user-images.githubusercontent.com/1017486/226195412-03d3ef58-5d6d-4c24-84f1-6a55b952f5c0.png">

Release note (ui change): Adds badges for each selected
filter on SQL Activity and Insights pages.

---
Release justification: small change, big impact feature
