### PR TITLE
autoconfig: fix the start/completion marker prefix encoding

### DIFF
--- a/pkg/server/autoconfig/task_markers.go
+++ b/pkg/server/autoconfig/task_markers.go
@@ -34,20 +34,36 @@ const infoKeyStartPrefix = "started-"
 // InfoKeyStartPrefix returns the info_key scan start key for
 // all task start markers for the given environment.
 func InfoKeyStartPrefix(env EnvironmentID) string {
+	orderedKeyBytes := make([]byte, 0, len(env)+10)
+	orderedKeyBytes = encoding.EncodeStringAscending(orderedKeyBytes, string(env))
+
 	var buf strings.Builder
-	buf.Grow(len(infoKeyStartPrefix) + len(env))
+	buf.Grow(len(infoKeyStartPrefix) + hex.EncodedLen(len(orderedKeyBytes)))
 	buf.WriteString(infoKeyStartPrefix)
-	buf.WriteString(string(env))
+	hexEncode := hex.NewEncoder(&buf)
+	_, err := hexEncode.Write(orderedKeyBytes)
+	if err != nil {
+		// This can't happen because strings.Builder always auto-grows.
+		panic(errors.HandleAsAssertionFailure(err))
+	}
 	return buf.String()
 }
 
 // InfoKeyCompletionPrefix returns the info_key scan start key for
 // all task completion markers for the given environment.
 func InfoKeyCompletionPrefix(env EnvironmentID) string {
+	orderedKeyBytes := make([]byte, 0, len(env)+10)
+	orderedKeyBytes = encoding.EncodeStringAscending(orderedKeyBytes, string(env))
+
 	var buf strings.Builder
-	buf.Grow(len(infoKeyCompletionPrefix) + len(env))
+	buf.Grow(len(infoKeyStartPrefix) + hex.EncodedLen(len(orderedKeyBytes)))
 	buf.WriteString(infoKeyCompletionPrefix)
-	buf.WriteString(string(env))
+	hexEncode := hex.NewEncoder(&buf)
+	_, err := hexEncode.Write(orderedKeyBytes)
+	if err != nil {
+		// This can't happen because strings.Builder always auto-grows.
+		panic(errors.HandleAsAssertionFailure(err))
+	}
 	return buf.String()
 }
 

--- a/pkg/server/autoconfig/task_markers_test.go
+++ b/pkg/server/autoconfig/task_markers_test.go
@@ -14,6 +14,7 @@ import (
 	"fmt"
 	"math"
 	"sort"
+	"strings"
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/server/autoconfig"
@@ -47,6 +48,25 @@ func TestEncodeDecodeMarkers(t *testing.T) {
 				require.Error(t, tr2.DecodeStartMarkerKey(encodedComplete))
 			})
 		}
+	}
+}
+
+// TestPrefixes ensures that the prefix keys used for job info searches
+// are properly encoded.
+func TestPrefixes(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	for _, testEnv := range []autoconfig.EnvironmentID{"", "foo", "bar"} {
+		t.Run(string(testEnv), func(t *testing.T) {
+			tref := autoconfig.InfoKeyTaskRef{Environment: testEnv}
+
+			prefix := autoconfig.InfoKeyStartPrefix(testEnv)
+			marker := tref.EncodeStartMarkerKey()
+			require.True(t, strings.HasPrefix(marker, prefix), "%q vs %q", marker, prefix)
+
+			prefix = autoconfig.InfoKeyCompletionPrefix(testEnv)
+			marker = tref.EncodeCompletionMarkerKey()
+			require.True(t, strings.HasPrefix(marker, prefix), "%q vs %q", marker, prefix)
+		})
 	}
 }
 


### PR DESCRIPTION
Fixes #101157.

In the previous PR in this area, while the PR was in-flux we changed the info key encoding. However, half of the marker API wasn't updated accordingly.

This patch fixes it.

Release note: None