### PR TITLE
autoconfig: new cluster settings to disable auto-config jobs

### DIFF
--- a/pkg/server/autoconfig/BUILD.bazel
+++ b/pkg/server/autoconfig/BUILD.bazel
@@ -19,6 +19,7 @@ go_library(
         "//pkg/security/username",
         "//pkg/server/autoconfig/acprovider",
         "//pkg/server/autoconfig/autoconfigpb",
+        "//pkg/settings",
         "//pkg/settings/cluster",
         "//pkg/sql",
         "//pkg/sql/catalog/descs",
@@ -28,6 +29,7 @@ go_library(
         "//pkg/util/log",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_cockroachdb_logtags//:logtags",
+        "@org_golang_x_time//rate",
     ],
 )
 

--- a/pkg/server/autoconfig/auto_config.go
+++ b/pkg/server/autoconfig/auto_config.go
@@ -17,12 +17,38 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
 	"github.com/cockroachdb/cockroach/pkg/server/autoconfig/acprovider"
 	"github.com/cockroachdb/cockroach/pkg/server/autoconfig/autoconfigpb"
+	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/isql"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/errors"
+	"golang.org/x/time/rate"
+)
+
+// autoConfigMaxNewRunnersPerSecond determines the rate at which the
+// top level job can create per-environment runners.
+var autoConfigMaxNewRunnersPerSecond = settings.RegisterFloatSetting(
+	settings.TenantWritable,
+	"jobs.auto_config.new_runners_per_second.max_rate",
+	"maximum rate at which the auto config subsystem can create new per-environment runners (set 0 to suspend job creation entirely)",
+	// We keep this limit low because the tasks subsystem is intended
+	// as a low-frequency, high-latency subsystem. The limit is more meant
+	// as a throttle to prevent runaway creation of jobs.
+	1,
+)
+
+// autoConfigMaxTasksPerSecond determines the rate at which each
+// per-env runner can create new job tasks.
+var autoConfigMaxTasksPerSecond = settings.RegisterFloatSetting(
+	settings.TenantWritable,
+	"jobs.auto_config.new_tasks_per_second.max_rate",
+	"maximum rate at which each task runner can create new jobs (set 0 to suspend job creation entirely)",
+	// We keep this limit low because the tasks subsystem is intended
+	// as a low-frequency, high-latency subsystem. The limit is more meant
+	// as a throttle to prevent runaway creation of jobs.
+	10,
 )
 
 // autoConfigRunner runs the job that accepts new auto configuration
@@ -69,6 +95,10 @@ func (r *autoConfigRunner) Resume(ctx context.Context, execCtx interface{}) erro
 	// environments is updated.
 	waitForEnvChange := provider.EnvUpdate()
 
+	// limiter ensures we don't generate too many jobs per second.
+	prevLimit := float64(0)
+	var limiter *rate.Limiter
+
 	for {
 		// No tasks to create. Just wait until some tasks are delivered.
 		log.Infof(ctx, "waiting for environment activation...")
@@ -79,13 +109,27 @@ func (r *autoConfigRunner) Resume(ctx context.Context, execCtx interface{}) erro
 		case <-waitForEnvChange:
 		}
 
-		r.job.MarkIdle(false)
 		for _, envID := range provider.ActiveEnvironments() {
+			// Check if the rate limit has changed. If it has, make a new limiter.
+			if curLimit := autoConfigMaxNewRunnersPerSecond.Get(&execCfg.Settings.SV); curLimit != prevLimit || limiter == nil {
+				limiter = rate.NewLimiter(rate.Limit(curLimit), 1)
+				prevLimit = curLimit
+			}
+			// Wait according to the configured rate limit.
+			if err := limiter.Wait(ctx); err != nil {
+				return err
+			}
+
+			// Ensure that the idleness is not changed while we call
+			// `limiter.Wait`. This ensures that orchestration feels free to
+			// stop this server if the rate limiter decided we should wait
+			// (or if the operator decided to change the limit to 0).
+			r.job.MarkIdle(false)
 			if err := refreshEnvJob(ctx, execCfg, envID); err != nil {
 				log.Warningf(ctx, "error refreshing environment %q: %v", envID, err)
 			}
+			r.job.MarkIdle(true)
 		}
-		r.job.MarkIdle(true)
 	}
 }
 

--- a/pkg/server/autoconfig/auto_config_env_runner.go
+++ b/pkg/server/autoconfig/auto_config_env_runner.go
@@ -26,6 +26,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/logtags"
+	"golang.org/x/time/rate"
 )
 
 // createEnvRunnerJob creates a job to execute tasks for the given
@@ -88,6 +89,10 @@ func (r *envRunner) Resume(ctx context.Context, execCtx interface{}) error {
 	// Provider gives us tasks to run.
 	provider := getProvider(ctx, execCfg)
 
+	// limiter ensures we don't generate too many jobs per second.
+	prevLimit := float64(0)
+	var limiter *rate.Limiter
+
 	for {
 		log.Infof(ctx, "waiting for more tasks...")
 		task, err := provider.Peek(ctx, r.envID)
@@ -96,6 +101,16 @@ func (r *envRunner) Resume(ctx context.Context, execCtx interface{}) error {
 				// No more tasks to process. Just stop the runner.
 				return nil
 			}
+			return err
+		}
+
+		// Check if the rate limit has changed. If it has, make a new limiter.
+		if curLimit := autoConfigMaxTasksPerSecond.Get(&execCfg.Settings.SV); curLimit != prevLimit || limiter == nil {
+			limiter = rate.NewLimiter(rate.Limit(curLimit), 1)
+			prevLimit = curLimit
+		}
+		// Wait according to the configured rate limit.
+		if err := limiter.Wait(ctx); err != nil {
 			return err
 		}
 


### PR DESCRIPTION
While troubleshooting an issue (CI failures in #98466) it became clear we should have a way to temporarily disable (or at least slow down) the autoconfig tasks.

This patch introduces the following cluster settings:

- `jobs.auto_config.new_runners_per_second.max_rate` (default 1)
- `jobs.auto_config.new_tasks_per_second.max_rate` (default 10)

They can be set to 0 to stop the background jobs and disable task creation.

Release note: None
Epic: CRDB-23559