### PR TITLE
release-22.2: Updates to SQL Activity pages

### DIFF
--- a/pkg/server/combined_statement_stats.go
+++ b/pkg/server/combined_statement_stats.go
@@ -28,6 +28,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlstats"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlstats/persistedsqlstats/sqlstatsutil"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlutil"
 	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/errors"
@@ -39,6 +40,16 @@ func getTimeFromSeconds(seconds int64) *time.Time {
 		return &t
 	}
 	return nil
+}
+
+func closeIterator(it sqlutil.InternalRows, err error) error {
+	if it != nil {
+		closeErr := it.Close()
+		if closeErr != nil {
+			err = errors.CombineErrors(err, closeErr)
+		}
+	}
+	return err
 }
 
 func (s *statusServer) CombinedStatementStats(
@@ -150,7 +161,7 @@ COALESCE(
     (statistics-> 'statistics' ->> 'cnt')::FLOAT
   )
 , 0)
-FROM crdb_internal.%s_statistics_persisted
+FROM crdb_internal.%s_statistics%s
 %s
 `
 
@@ -160,32 +171,58 @@ FROM crdb_internal.%s_statistics_persisted
 			fmt.Sprintf(`%s-total-runtime`, table),
 			nil,
 			sessiondata.NodeUserSessionDataOverride,
-			fmt.Sprintf(queryWithPlaceholders, table, whereClause),
+			fmt.Sprintf(queryWithPlaceholders, table, `_persisted`, whereClause),
 			args...)
+
+		defer func() {
+			err = closeIterator(it, err)
+		}()
 
 		if err != nil {
 			return 0, err
 		}
-
-		defer func() {
-			closeErr := it.Close()
-			if closeErr != nil {
-				err = errors.CombineErrors(err, closeErr)
-			}
-		}()
-
 		ok, err := it.Next(ctx)
 		if err != nil {
 			return 0, err
 		}
-
 		if !ok {
-			return 0, errors.New("expected one row but got none")
+			return 0, errors.New("expected one row but got none on getTotalRuntimeSecs")
 		}
 
 		var row tree.Datums
 		if row = it.Cur(); row == nil {
-			return 0, errors.New("unexpected null row")
+			return 0, errors.New("unexpected null row on getTotalRuntimeSecs")
+		}
+
+		// If the total runtime is 0 there were no results from the persisted table,
+		// so we retrieve the data from the combined view with data in-memory.
+		if tree.MustBeDFloat(row[0]) == 0 {
+			err := closeIterator(it, err)
+			if err != nil {
+				return 0, err
+			}
+			it, err = ie.QueryIteratorEx(
+				ctx,
+				fmt.Sprintf(`%s-total-runtime-with-memory`, table),
+				nil,
+				sessiondata.NodeUserSessionDataOverride,
+				fmt.Sprintf(queryWithPlaceholders, table, ``, whereClause),
+				args...)
+
+			if err != nil {
+				return 0, err
+			}
+			ok, err = it.Next(ctx)
+			if err != nil {
+				return 0, err
+			}
+			if !ok {
+				return 0, errors.New("expected one row but got none on getTotalRuntimeSecs")
+			}
+
+			if row = it.Cur(); row == nil {
+				return 0, errors.New("unexpected null row on getTotalRuntimeSecs")
+			}
 		}
 
 		return float32(tree.MustBeDFloat(row[0])), nil
@@ -359,8 +396,8 @@ func collectCombinedStatements(
 	}
 
 	aostClause := testingKnobs.GetAOSTClause()
-
-	query := fmt.Sprintf(`
+	const expectedNumDatums = 6
+	queryFormat := `
 SELECT * FROM (
 SELECT
     fingerprint_id,
@@ -369,43 +406,62 @@ SELECT
     max(aggregated_ts) as aggregated_ts,
     metadata,
     crdb_internal.merge_statement_stats(array_agg(statistics)) AS statistics
-		FROM %s %s
+FROM %s %s
 GROUP BY
     fingerprint_id,
     transaction_fingerprint_id,
     app_name,
     metadata
 ) %s
-%s`, table, whereClause, aostClause, orderAndLimit)
+%s`
 
-	const expectedNumDatums = 6
-
+	query := fmt.Sprintf(
+		queryFormat,
+		table,
+		whereClause,
+		aostClause,
+		orderAndLimit)
 	it, err := ie.QueryIteratorEx(ctx, "combined-stmts-by-interval", nil,
 		sessiondata.InternalExecutorOverride{
 			User: username.NodeUserName(),
 		}, query, args...)
 
+	defer func() {
+		err = closeIterator(it, err)
+	}()
+
 	if err != nil {
 		return nil, serverError(ctx, err)
 	}
 
-	defer func() {
-		closeErr := it.Close()
-		if closeErr != nil {
-			err = errors.CombineErrors(err, closeErr)
+	// If there are no results from the persisted table, retrieve the data from the combined view
+	// with data in-memory.
+	if !it.HasResults() {
+		err = closeIterator(it, err)
+
+		query = fmt.Sprintf(
+			queryFormat,
+			`crdb_internal.statement_statistics`,
+			whereClause,
+			aostClause,
+			orderAndLimit)
+		it, err = ie.QueryIteratorEx(ctx, "combined-stmts-by-interval-with-memory", nil,
+			sessiondata.NodeUserSessionDataOverride, query, args...)
+		if err != nil {
+			return nil, serverError(ctx, err)
 		}
-	}()
+	}
 
 	var statements []serverpb.StatementsResponse_CollectedStatementStatistics
 	var ok bool
 	for ok, err = it.Next(ctx); ok; ok, err = it.Next(ctx) {
 		var row tree.Datums
 		if row = it.Cur(); row == nil {
-			return nil, errors.New("unexpected null row")
+			return nil, errors.New("unexpected null row on collectCombinedStatements")
 		}
 
 		if row.Len() != expectedNumDatums {
-			return nil, errors.Newf("expected %d columns, received %d", expectedNumDatums)
+			return nil, errors.Newf("expected %d columns on collectCombinedStatements, received %d", expectedNumDatums)
 		}
 
 		var statementFingerprintID uint64
@@ -465,8 +521,8 @@ func collectCombinedTransactions(
 	testingKnobs *sqlstats.TestingKnobs,
 ) ([]serverpb.StatementsResponse_ExtendedCollectedTransactionStatistics, error) {
 	aostClause := testingKnobs.GetAOSTClause()
-
-	query := fmt.Sprintf(`
+	const expectedNumDatums = 5
+	queryFormat := `
 SELECT * FROM (
 SELECT
     app_name,
@@ -474,42 +530,62 @@ SELECT
     fingerprint_id,
     metadata,
     crdb_internal.merge_transaction_stats(array_agg(statistics)) AS statistics
-FROM crdb_internal.transaction_statistics_persisted %s
+FROM %s %s
 GROUP BY
     app_name,
     fingerprint_id,
     metadata
 ) %s
-%s`, whereClause, aostClause, orderAndLimit)
+%s`
 
-	const expectedNumDatums = 5
+	query := fmt.Sprintf(
+		queryFormat,
+		`crdb_internal.transaction_statistics_persisted`,
+		whereClause,
+		aostClause,
+		orderAndLimit)
 
 	it, err := ie.QueryIteratorEx(ctx, "combined-txns-by-interval", nil,
 		sessiondata.InternalExecutorOverride{
 			User: username.NodeUserName(),
 		}, query, args...)
 
+	defer func() {
+		err = closeIterator(it, err)
+	}()
+
 	if err != nil {
 		return nil, serverError(ctx, err)
 	}
 
-	defer func() {
-		closeErr := it.Close()
-		if closeErr != nil {
-			err = errors.CombineErrors(err, closeErr)
+	// If there are no results from the persisted table, retrieve the data from the combined view
+	// with data in-memory.
+	if !it.HasResults() {
+		err = closeIterator(it, err)
+
+		query = fmt.Sprintf(
+			queryFormat,
+			`crdb_internal.transaction_statistics`,
+			whereClause,
+			aostClause,
+			orderAndLimit)
+		it, err = ie.QueryIteratorEx(ctx, "combined-txn-by-interval-with-memory", nil,
+			sessiondata.NodeUserSessionDataOverride, query, args...)
+		if err != nil {
+			return nil, serverError(ctx, err)
 		}
-	}()
+	}
 
 	var transactions []serverpb.StatementsResponse_ExtendedCollectedTransactionStatistics
 	var ok bool
 	for ok, err = it.Next(ctx); ok; ok, err = it.Next(ctx) {
 		var row tree.Datums
 		if row = it.Cur(); row == nil {
-			return nil, errors.New("unexpected null row")
+			return nil, errors.New("unexpected null row on collectCombinedTransactions")
 		}
 
 		if row.Len() != expectedNumDatums {
-			return nil, errors.Newf("expected %d columns, received %d", expectedNumDatums, row.Len())
+			return nil, errors.Newf("expected %d columns on collectCombinedTransactions, received %d", expectedNumDatums, row.Len())
 		}
 
 		app := string(tree.MustBeDString(row[0]))
@@ -707,8 +783,9 @@ func getTotalStatementDetails(
 	args []interface{},
 	table string,
 ) (serverpb.StatementDetailsResponse_CollectedStatementSummary, error) {
-	query := fmt.Sprintf(
-		`SELECT
+	const expectedNumDatums = 4
+	var statement serverpb.StatementDetailsResponse_CollectedStatementSummary
+	queryFormat := `SELECT
 				crdb_internal.merge_stats_metadata(array_agg(metadata)) AS metadata,
 				array_agg(app_name) as app_names,
 				crdb_internal.merge_statement_stats(array_agg(statistics)) AS statistics,
@@ -716,24 +793,34 @@ func getTotalStatementDetails(
 		FROM %s %s
 		GROUP BY
 				fingerprint_id
-		LIMIT 1`, table, whereClause)
-
-	const expectedNumDatums = 4
-	var statement serverpb.StatementDetailsResponse_CollectedStatementSummary
+		LIMIT 1`
+	query := fmt.Sprintf(queryFormat, `crdb_internal.statement_statistics_persisted`, whereClause)
 
 	row, err := ie.QueryRowEx(ctx, "combined-stmts-details-total", nil,
-		sessiondata.InternalExecutorOverride{
-			User: username.NodeUserName(),
-		}, query, args...)
+		sessiondata.NodeUserSessionDataOverride, query, args...)
 
 	if err != nil {
 		return statement, serverError(ctx, err)
 	}
-	if len(row) == 0 {
+
+	// If there are no results from the persisted table, retrieve the data from the combined view
+	// with data in-memory.
+	if row.Len() == 0 {
+		query = fmt.Sprintf(queryFormat, `crdb_internal.statement_statistics`, whereClause)
+		row, err = ie.QueryRowEx(ctx, "combined-stmts-details-total-with-memory", nil,
+			sessiondata.NodeUserSessionDataOverride, query, args...)
+		if err != nil {
+			return statement, serverError(ctx, err)
+		}
+	}
+
+	// If there are no results in-memory, return empty statement object.
+	if row.Len() == 0 {
 		return statement, nil
 	}
 	if row.Len() != expectedNumDatums {
-		return statement, serverError(ctx, errors.Newf("expected %d columns, received %d", expectedNumDatums))
+		return statement, serverError(ctx, errors.Newf(
+			"expected %d columns on getTotalStatementDetails, received %d", expectedNumDatums))
 	}
 
 	var statistics roachpb.CollectedStatementStatistics
@@ -778,8 +865,8 @@ func getStatementDetailsPerAggregatedTs(
 	limit int64,
 	table string,
 ) ([]serverpb.StatementDetailsResponse_CollectedStatementGroupedByAggregatedTs, error) {
-	query := fmt.Sprintf(
-		`SELECT
+	const expectedNumDatums = 3
+	queryFormat := `SELECT
 				aggregated_ts,
 				crdb_internal.merge_stats_metadata(array_agg(metadata)) AS metadata,
 				crdb_internal.merge_statement_stats(array_agg(statistics)) AS statistics
@@ -787,37 +874,45 @@ func getStatementDetailsPerAggregatedTs(
 		GROUP BY
 				aggregated_ts
 		ORDER BY aggregated_ts ASC
-		LIMIT $%d`, table, whereClause, len(args)+1)
-
+		LIMIT $%d`
+	query := fmt.Sprintf(queryFormat, `crdb_internal.statement_statistics_persisted`, whereClause, len(args)+1)
 	args = append(args, limit)
-	const expectedNumDatums = 3
 
 	it, err := ie.QueryIteratorEx(ctx, "combined-stmts-details-by-aggregated-timestamp", nil,
 		sessiondata.InternalExecutorOverride{
 			User: username.NodeUserName(),
 		}, query, args...)
 
+	defer func() {
+		err = closeIterator(it, err)
+	}()
+
 	if err != nil {
 		return nil, serverError(ctx, err)
 	}
 
-	defer func() {
-		closeErr := it.Close()
-		if closeErr != nil {
-			err = errors.CombineErrors(err, closeErr)
+	// If there are no results from the persisted table, retrieve the data from the combined view
+	// with data in-memory.
+	if !it.HasResults() {
+		err = closeIterator(it, err)
+		query = fmt.Sprintf(queryFormat, `crdb_internal.statement_statistics`, whereClause, len(args))
+		it, err = ie.QueryIteratorEx(ctx, "combined-stmts-details-by-aggregated-timestamp-with-memory", nil,
+			sessiondata.NodeUserSessionDataOverride, query, args...)
+		if err != nil {
+			return nil, serverError(ctx, err)
 		}
-	}()
+	}
 
 	var statements []serverpb.StatementDetailsResponse_CollectedStatementGroupedByAggregatedTs
 	var ok bool
 	for ok, err = it.Next(ctx); ok; ok, err = it.Next(ctx) {
 		var row tree.Datums
 		if row = it.Cur(); row == nil {
-			return nil, errors.New("unexpected null row")
+			return nil, errors.New("unexpected null row on getStatementDetailsPerAggregatedTs")
 		}
 
 		if row.Len() != expectedNumDatums {
-			return nil, errors.Newf("expected %d columns, received %d", expectedNumDatums)
+			return nil, errors.Newf("expected %d columns on getStatementDetailsPerAggregatedTs, received %d", expectedNumDatums)
 		}
 
 		aggregatedTs := tree.MustBeDTimestampTZ(row[0]).Time
@@ -862,6 +957,10 @@ func getExplainPlanFromGist(ctx context.Context, ie *sql.InternalExecutor, planG
 			User: username.NodeUserName(),
 		}, query, args...)
 
+	defer func() {
+		err = closeIterator(it, err)
+	}()
+
 	if err != nil {
 		return planError
 	}
@@ -894,37 +993,36 @@ func getStatementDetailsPerPlanHash(
 	limit int64,
 	withIndexRecs bool,
 ) ([]serverpb.StatementDetailsResponse_CollectedStatementGroupedByPlanHash, error) {
-
-	query := fmt.Sprintf(
-		`SELECT
+	expectedNumDatums := 4
+	table := `crdb_internal.statement_statistics_v22_1`
+	queryFormat := `SELECT
 				plan_hash,
 				(statistics -> 'statistics' -> 'planGists'->>0) as plan_gist,
 				crdb_internal.merge_stats_metadata(array_agg(metadata)) AS metadata,
 				crdb_internal.merge_statement_stats(array_agg(statistics)) AS statistics
-		FROM crdb_internal.statement_statistics_v22_1 %s
+		FROM %s %s
 		GROUP BY
 				plan_hash,
 				plan_gist
-		LIMIT $%d`, whereClause, len(args)+1)
-	expectedNumDatums := 4
+		LIMIT $%d`
 
 	if withIndexRecs {
-		query = fmt.Sprintf(
-			`SELECT
+		expectedNumDatums = 5
+		table = `crdb_internal.statement_statistics_persisted`
+		queryFormat = `SELECT
 				plan_hash,
 				(statistics -> 'statistics' -> 'planGists'->>0) as plan_gist,
 				crdb_internal.merge_stats_metadata(array_agg(metadata)) AS metadata,
 				crdb_internal.merge_statement_stats(array_agg(statistics)) AS statistics,
 				index_recommendations
-		FROM crdb_internal.statement_statistics_persisted %s
+		FROM %s %s
 		GROUP BY
 				plan_hash,
 				plan_gist,
 				index_recommendations
-		LIMIT $%d`, whereClause, len(args)+1)
-		expectedNumDatums = 5
+		LIMIT $%d`
 	}
-
+	query := fmt.Sprintf(queryFormat, table, whereClause, len(args)+1)
 	args = append(args, limit)
 
 	it, err := ie.QueryIteratorEx(ctx, "combined-stmts-details-by-plan-hash", nil,
@@ -932,27 +1030,36 @@ func getStatementDetailsPerPlanHash(
 			User: username.NodeUserName(),
 		}, query, args...)
 
+	defer func() {
+		err = closeIterator(it, err)
+	}()
+
 	if err != nil {
 		return nil, serverError(ctx, err)
 	}
 
-	defer func() {
-		closeErr := it.Close()
-		if closeErr != nil {
-			err = errors.CombineErrors(err, closeErr)
+	// If there are no results from the persisted table, retrieve the data from the combined view
+	// with data in-memory.
+	if !it.HasResults() {
+		err = closeIterator(it, err)
+		query = fmt.Sprintf(queryFormat, `crdb_internal.statement_statistics`, whereClause, len(args))
+		it, err = ie.QueryIteratorEx(ctx, "combined-stmts-details-by-plan-hash-with-memory", nil,
+			sessiondata.NodeUserSessionDataOverride, query, args...)
+		if err != nil {
+			return nil, serverError(ctx, err)
 		}
-	}()
+	}
 
 	var statements []serverpb.StatementDetailsResponse_CollectedStatementGroupedByPlanHash
 	var ok bool
 	for ok, err = it.Next(ctx); ok; ok, err = it.Next(ctx) {
 		var row tree.Datums
 		if row = it.Cur(); row == nil {
-			return nil, errors.New("unexpected null row")
+			return nil, errors.New("unexpected null row on getStatementDetailsPerPlanHash")
 		}
 
 		if row.Len() != expectedNumDatums {
-			return nil, errors.Newf("expected %d columns, received %d", expectedNumDatums)
+			return nil, errors.Newf("expected %d columns on getStatementDetailsPerPlanHash, received %d", expectedNumDatums)
 		}
 
 		var planHash uint64

--- a/pkg/server/combined_statement_stats.go
+++ b/pkg/server/combined_statement_stats.go
@@ -794,7 +794,7 @@ func getTotalStatementDetails(
 		GROUP BY
 				fingerprint_id
 		LIMIT 1`
-	query := fmt.Sprintf(queryFormat, `crdb_internal.statement_statistics_persisted`, whereClause)
+	query := fmt.Sprintf(queryFormat, table, whereClause)
 
 	row, err := ie.QueryRowEx(ctx, "combined-stmts-details-total", nil,
 		sessiondata.NodeUserSessionDataOverride, query, args...)
@@ -875,7 +875,7 @@ func getStatementDetailsPerAggregatedTs(
 				aggregated_ts
 		ORDER BY aggregated_ts ASC
 		LIMIT $%d`
-	query := fmt.Sprintf(queryFormat, `crdb_internal.statement_statistics_persisted`, whereClause, len(args)+1)
+	query := fmt.Sprintf(queryFormat, table, whereClause, len(args)+1)
 	args = append(args, limit)
 
 	it, err := ie.QueryIteratorEx(ctx, "combined-stmts-details-by-aggregated-timestamp", nil,

--- a/pkg/server/status_test.go
+++ b/pkg/server/status_test.go
@@ -49,7 +49,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlstats"
-	"github.com/cockroachdb/cockroach/pkg/sql/sqlstats/persistedsqlstats"
 	"github.com/cockroachdb/cockroach/pkg/sql/tests"
 	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
@@ -1491,9 +1490,6 @@ func TestStatusAPICombinedTransactions(t *testing.T) {
 		}
 	}
 
-	// Flush stats, as combinedstmts reads only from system.
-	thirdServer.SQLServer().(*sql.Server).GetSQLStatsProvider().(*persistedsqlstats.PersistedSQLStats).Flush(ctx)
-
 	// Hit query endpoint.
 	var resp serverpb.StatementsResponse
 	if err := getStatusJSONProto(firstServerProto, "combinedstmts", &resp); err != nil {
@@ -1866,8 +1862,6 @@ func TestStatusAPICombinedStatements(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	ctx := context.Background()
-
 	// Aug 30 2021 19:50:00 GMT+0000
 	aggregatedTs := int64(1630353000)
 	testCluster := serverutils.StartNewTestCluster(t, 3, base.TestClusterArgs{
@@ -1905,8 +1899,6 @@ func TestStatusAPICombinedStatements(t *testing.T) {
 	for _, stmt := range statements {
 		thirdServerSQL.Exec(t, stmt.stmt)
 	}
-
-	testCluster.Server(2).SQLServer().(*sql.Server).GetSQLStatsProvider().(*persistedsqlstats.PersistedSQLStats).Flush(ctx)
 
 	var resp serverpb.StatementsResponse
 	// Test that non-admin without VIEWACTIVITY privileges cannot access.
@@ -2037,8 +2029,6 @@ func TestStatusAPIStatementDetails(t *testing.T) {
 	// The liveness session might expire before the stress race can finish.
 	skip.UnderStressRace(t, "expensive tests")
 
-	ctx := context.Background()
-
 	// Aug 30 2021 19:50:00 GMT+0000
 	aggregatedTs := int64(1630353000)
 	testCluster := serverutils.StartNewTestCluster(t, 3, base.TestClusterArgs{
@@ -2097,9 +2087,6 @@ func TestStatusAPIStatementDetails(t *testing.T) {
 	}
 
 	testPath := func(path string, expected resultValues) {
-		// Need to flush since this EP reads only flushed data.
-		testCluster.Server(2).SQLServer().(*sql.Server).GetSQLStatsProvider().(*persistedsqlstats.PersistedSQLStats).Flush(ctx)
-
 		err := getStatusJSONProtoWithAdminOption(firstServerProto, path, &resp, false)
 		require.NoError(t, err)
 		require.Equal(t, int64(expected.totalCount), resp.Statement.Stats.Count)

--- a/pkg/sql/internal.go
+++ b/pkg/sql/internal.go
@@ -517,6 +517,10 @@ func (r *rowsIterator) Types() colinfo.ResultColumns {
 	return r.resultCols
 }
 
+func (r *rowsIterator) HasResults() bool {
+	return r.first.row != nil
+}
+
 // QueryBuffered executes the supplied SQL statement and returns the resulting
 // rows (meaning all of them are buffered at once). If no user has been
 // previously set through SetSessionData, the statement is executed as the root

--- a/pkg/sql/sqlutil/internal_executor.go
+++ b/pkg/sql/sqlutil/internal_executor.go
@@ -205,6 +205,9 @@ type InternalRows interface {
 	// WARNING: this method is safe to call anytime *after* the first call to
 	// Next() (including after Close() was called).
 	Types() colinfo.ResultColumns
+
+	// HasResults returns true if there are results to the query, false otherwise.
+	HasResults() bool
 }
 
 // InternalExecutorFactory is an interface that allow the creation of an

--- a/pkg/ui/workspaces/cluster-ui/src/insights/schemaInsights/schemaInsightsView.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/schemaInsights/schemaInsightsView.tsx
@@ -134,7 +134,7 @@ export const SchemaInsightsView: React.FC<SchemaInsightsViewProps> = ({
     // redux changes and syncs the URL params with redux.
     syncHistory(
       {
-        ascending: sortSetting.ascending.toString(),
+        ascending: sortSetting.ascending?.toString(),
         columnTitle: sortSetting.columnTitle,
         ...getFullFiltersAsStringRecord(filters),
         [SCHEMA_INSIGHT_SEARCH_PARAM]: search,

--- a/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.fixture.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.fixture.ts
@@ -907,6 +907,7 @@ const statementsPagePropsFixture: StatementsPageProps = {
   onFilterChange: noop,
   onChangeLimit: noop,
   onChangeReqSort: noop,
+  onApplySearchCriteria: noop,
 };
 
 export const statementsPagePropsWithRequestError: StatementsPageProps = {

--- a/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.module.scss
@@ -46,6 +46,10 @@ cl-table-container {
   margin-bottom: 0px;
 }
 
+.margin-bottom {
+  margin-bottom: 10px;
+}
+
 .root {
   flex-grow: 0;
   width: 100%;

--- a/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.tsx
@@ -309,7 +309,7 @@ export class StatementsPage extends React.Component<
       this.props.onApplySearchCriteria(
         this.state.timeScale,
         this.state.limit,
-        getSortLabel(this.state.reqSortSetting),
+        getSortLabel(this.state.reqSortSetting, "Statement"),
       );
     }
     this.refreshStatements();
@@ -578,13 +578,10 @@ export class StatementsPage extends React.Component<
   };
 
   hasReqSortOption = (): boolean => {
-    let found = false;
-    Object.values(SqlStatsSortOptions).forEach((option: SqlStatsSortType) => {
-      if (getSortColumn(option) == this.props.sortSetting.columnTitle) {
-        found = true;
-      }
-    });
-    return found;
+    return Object.values(SqlStatsSortOptions).some(
+      (option: SqlStatsSortType) =>
+        getSortColumn(option) == this.props.sortSetting.columnTitle,
+    );
   };
 
   renderStatements = (): React.ReactElement => {
@@ -655,7 +652,10 @@ export class StatementsPage extends React.Component<
     );
 
     const period = timeScaleToString(this.props.timeScale);
-    const sortSettingLabel = getSortLabel(this.props.reqSortSetting);
+    const sortSettingLabel = getSortLabel(
+      this.props.reqSortSetting,
+      "Statement",
+    );
 
     return (
       <>

--- a/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.tsx
@@ -281,7 +281,7 @@ export class StatementsPage extends React.Component<
 
   isSortSettingSameAsReqSort = (): boolean => {
     return (
-      getSortColumn(this.state.reqSortSetting) ==
+      getSortColumn(this.props.reqSortSetting) ==
       this.props.sortSetting.columnTitle
     );
   };

--- a/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.tsx
@@ -21,7 +21,7 @@ import {
   updateSortSettingQueryParamsOnTab,
 } from "src/sortedtable";
 import { Search } from "src/search";
-import { Pagination } from "src/pagination";
+import { Pagination, ResultsPerPageLabel } from "src/pagination";
 import {
   calculateActiveFilters,
   defaultFilters,
@@ -61,6 +61,7 @@ import {
   SqlStatsSortType,
   StatementsRequest,
   createCombinedStmtsRequest,
+  SqlStatsSortOptions,
 } from "src/api/statementsApi";
 import ClearStats from "../sqlActivity/clearStats";
 import LoadingError from "../sqlActivity/errorComponent";
@@ -80,8 +81,9 @@ import {
   STATS_LONG_LOADING_DURATION,
   stmtRequestSortOptions,
   getSortLabel,
+  getSortColumn,
+  getSubsetWarning,
 } from "src/util/sqlActivityConstants";
-import { Button } from "src/button";
 import { SearchCriteria } from "src/searchCriteria/searchCriteria";
 import timeScaleStyles from "../timeScaleDropdown/timeScale.module.scss";
 
@@ -126,6 +128,7 @@ export interface StatementsPageDispatchProps {
   onTimeScaleChange: (ts: TimeScale) => void;
   onChangeLimit: (limit: number) => void;
   onChangeReqSort: (sort: SqlStatsSortType) => void;
+  onApplySearchCriteria: (ts: TimeScale, limit: number, sort: string) => void;
 }
 export interface StatementsPageStateProps {
   statements: AggregateStatistics[];
@@ -276,6 +279,13 @@ export class StatementsPage extends React.Component<
     }
   };
 
+  isSortSettingSameAsReqSort = (): boolean => {
+    return (
+      getSortColumn(this.state.reqSortSetting) ==
+      this.props.sortSetting.columnTitle
+    );
+  };
+
   changeTimeScale = (ts: TimeScale): void => {
     this.setState(prevState => ({
       ...prevState,
@@ -295,8 +305,19 @@ export class StatementsPage extends React.Component<
     if (this.props.timeScale !== this.state.timeScale) {
       this.props.onTimeScaleChange(this.state.timeScale);
     }
-
+    if (this.props.onApplySearchCriteria) {
+      this.props.onApplySearchCriteria(
+        this.state.timeScale,
+        this.state.limit,
+        getSortLabel(this.state.reqSortSetting),
+      );
+    }
     this.refreshStatements();
+    const ss: SortSetting = {
+      ascending: false,
+      columnTitle: getSortColumn(this.state.reqSortSetting),
+    };
+    this.changeSortSetting(ss);
   };
 
   resetPagination = (): void => {
@@ -556,6 +577,16 @@ export class StatementsPage extends React.Component<
     this.setState(prevState => ({ ...prevState, reqSortSetting: newSort }));
   };
 
+  hasReqSortOption = (): boolean => {
+    let found = false;
+    Object.values(SqlStatsSortOptions).forEach((option: SqlStatsSortType) => {
+      if (getSortColumn(option) == this.props.sortSetting.columnTitle) {
+        found = true;
+      }
+    });
+    return found;
+  };
+
   renderStatements = (): React.ReactElement => {
     const { pagination, filters, activeFilters } = this.state;
     const {
@@ -668,6 +699,12 @@ export class StatementsPage extends React.Component<
               <p className={timeScaleStylesCx("time-label")}>
                 Showing aggregated stats from{" "}
                 <span className={timeScaleStylesCx("bold")}>{period}</span>
+                {", "}
+                <ResultsPerPageLabel
+                  pagination={{ ...pagination, total: data.length }}
+                  pageName={"Statements"}
+                  search={search}
+                />
               </p>
             </PageConfigItem>
             {hasAdminRole && (
@@ -690,6 +727,19 @@ export class StatementsPage extends React.Component<
             onRemoveFilter={this.onSubmitFilters}
             onClearFilters={this.onClearFilters}
           />
+          {!this.isSortSettingSameAsReqSort() && (
+            <InlineAlert
+              intent="warning"
+              title={getSubsetWarning(
+                "statement",
+                this.props.limit,
+                sortSettingLabel,
+                this.hasReqSortOption(),
+                this.props.sortSetting.columnTitle as StatisticTableColumnKeys,
+              )}
+              className={cx("margin-bottom")}
+            />
+          )}
           <StatementsSortedTable
             className="statements-table"
             data={data}

--- a/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPageConnected.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPageConnected.tsx
@@ -272,6 +272,16 @@ export const ConnectedStatementsPage = withRouter(
           dispatch(updateStmtsPageLimitAction(limit)),
         onChangeReqSort: (sort: SqlStatsSortType) =>
           dispatch(updateStmsPageReqSortAction(sort)),
+        onApplySearchCriteria: (ts: TimeScale, limit: number, sort: string) =>
+          dispatch(
+            analyticsActions.track({
+              name: "Apply Search Criteria",
+              page: "Statements",
+              tsValue: ts.key,
+              limitValue: limit,
+              sortValue: sort,
+            }),
+          ),
       },
       activePageProps: mapDispatchToActiveStatementsPageProps(dispatch),
     }),

--- a/pkg/ui/workspaces/cluster-ui/src/store/analytics/analytics.reducer.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/store/analytics/analytics.reducer.ts
@@ -26,6 +26,14 @@ type Page =
   | "Workload Insights - Statement"
   | "Workload Insights - Transaction";
 
+type ApplySearchCriteriaEvent = {
+  name: "Apply Search Criteria";
+  page: Page;
+  tsValue: string;
+  limitValue: number;
+  sortValue: string;
+};
+
 type BackButtonClick = {
   name: "Back Clicked";
   page: Page;
@@ -102,6 +110,7 @@ type TimeScaleChangeEvent = {
 };
 
 type AnalyticsEvent =
+  | ApplySearchCriteriaEvent
   | BackButtonClick
   | ColumnsChangeEvent
   | FilterEvent

--- a/pkg/ui/workspaces/cluster-ui/src/transactionsPage/transactionsPage.stories.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionsPage/transactionsPage.stories.tsx
@@ -59,6 +59,7 @@ storiesOf("Transactions Page", module)
       reqSortSetting={SqlStatsSortOptions.PCT_RUNTIME}
       onChangeLimit={noop}
       onChangeReqSort={noop}
+      onApplySearchCriteria={noop}
     />
   ))
   .add("without data", () => {
@@ -86,6 +87,7 @@ storiesOf("Transactions Page", module)
         reqSortSetting={SqlStatsSortOptions.PCT_RUNTIME}
         onChangeLimit={noop}
         onChangeReqSort={noop}
+        onApplySearchCriteria={noop}
       />
     );
   })
@@ -121,6 +123,7 @@ storiesOf("Transactions Page", module)
         reqSortSetting={SqlStatsSortOptions.PCT_RUNTIME}
         onChangeLimit={noop}
         onChangeReqSort={noop}
+        onApplySearchCriteria={noop}
       />
     );
   })
@@ -149,6 +152,7 @@ storiesOf("Transactions Page", module)
         reqSortSetting={SqlStatsSortOptions.PCT_RUNTIME}
         onChangeLimit={noop}
         onChangeReqSort={noop}
+        onApplySearchCriteria={noop}
       />
     );
   })
@@ -184,6 +188,7 @@ storiesOf("Transactions Page", module)
         reqSortSetting={SqlStatsSortOptions.PCT_RUNTIME}
         onChangeLimit={noop}
         onChangeReqSort={noop}
+        onApplySearchCriteria={noop}
       />
     );
   });

--- a/pkg/ui/workspaces/cluster-ui/src/transactionsPage/transactionsPage.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionsPage/transactionsPage.tsx
@@ -292,7 +292,7 @@ export class TransactionsPage extends React.Component<
 
   isSortSettingSameAsReqSort = (): boolean => {
     return (
-      getSortColumn(this.state.reqSortSetting) ==
+      getSortColumn(this.props.reqSortSetting) ==
       this.props.sortSetting.columnTitle
     );
   };

--- a/pkg/ui/workspaces/cluster-ui/src/transactionsPage/transactionsPage.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionsPage/transactionsPage.tsx
@@ -415,7 +415,7 @@ export class TransactionsPage extends React.Component<
       this.props.onApplySearchCriteria(
         this.state.timeScale,
         this.state.limit,
-        getSortLabel(this.state.reqSortSetting),
+        getSortLabel(this.state.reqSortSetting, "Transaction"),
       );
     }
     this.refreshData();
@@ -427,13 +427,10 @@ export class TransactionsPage extends React.Component<
   };
 
   hasReqSortOption = (): boolean => {
-    let found = false;
-    Object.values(SqlStatsSortOptions).forEach((option: SqlStatsSortType) => {
-      if (getSortColumn(option) == this.props.sortSetting.columnTitle) {
-        found = true;
-      }
-    });
-    return found;
+    return Object.values(SqlStatsSortOptions).some(
+      (option: SqlStatsSortType) =>
+        getSortColumn(option) == this.props.sortSetting.columnTitle,
+    );
   };
 
   renderTransactions(): React.ReactElement {
@@ -523,7 +520,10 @@ export class TransactionsPage extends React.Component<
     );
 
     const period = timeScaleToString(this.props.timeScale);
-    const sortSettingLabel = getSortLabel(this.props.reqSortSetting);
+    const sortSettingLabel = getSortLabel(
+      this.props.reqSortSetting,
+      "Transaction",
+    );
 
     return (
       <>

--- a/pkg/ui/workspaces/cluster-ui/src/transactionsPage/transactionsPage.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionsPage/transactionsPage.tsx
@@ -24,7 +24,7 @@ import {
   SortSetting,
   updateSortSettingQueryParamsOnTab,
 } from "../sortedtable";
-import { Pagination } from "../pagination";
+import { Pagination, ResultsPerPageLabel } from "../pagination";
 import { statisticsClasses } from "./transactionsPageClasses";
 import {
   aggregateAcrossNodeIDs,
@@ -53,6 +53,7 @@ import {
   SqlStatsSortType,
   createCombinedStmtsRequest,
   StatementsRequest,
+  SqlStatsSortOptions,
 } from "src/api/statementsApi";
 import ColumnsSelector from "../columnsSelector/columnsSelector";
 import { SelectOption } from "../multiSelectCheckbox/multiSelectCheckbox";
@@ -78,8 +79,9 @@ import {
   STATS_LONG_LOADING_DURATION,
   txnRequestSortOptions,
   getSortLabel,
+  getSortColumn,
+  getSubsetWarning,
 } from "src/util/sqlActivityConstants";
-import { Button } from "src/button";
 import { SearchCriteria } from "src/searchCriteria/searchCriteria";
 import timeScaleStyles from "../timeScaleDropdown/timeScale.module.scss";
 
@@ -130,6 +132,7 @@ export interface TransactionsPageDispatchProps {
     columnTitle: string,
     ascending: boolean,
   ) => void;
+  onApplySearchCriteria: (ts: TimeScale, limit: number, sort: string) => void;
 }
 
 export type TransactionsPageProps = TransactionsPageStateProps &
@@ -287,6 +290,13 @@ export class TransactionsPage extends React.Component<
     }
   };
 
+  isSortSettingSameAsReqSort = (): boolean => {
+    return (
+      getSortColumn(this.state.reqSortSetting) ==
+      this.props.sortSetting.columnTitle
+    );
+  };
+
   onChangePage = (current: number): void => {
     const { pagination } = this.state;
     this.setState({ pagination: { ...pagination, current } });
@@ -401,7 +411,29 @@ export class TransactionsPage extends React.Component<
       this.props.onTimeScaleChange(this.state.timeScale);
     }
 
+    if (this.props.onApplySearchCriteria) {
+      this.props.onApplySearchCriteria(
+        this.state.timeScale,
+        this.state.limit,
+        getSortLabel(this.state.reqSortSetting),
+      );
+    }
     this.refreshData();
+    const ss: SortSetting = {
+      ascending: false,
+      columnTitle: getSortColumn(this.state.reqSortSetting),
+    };
+    this.onChangeSortSetting(ss);
+  };
+
+  hasReqSortOption = (): boolean => {
+    let found = false;
+    Object.values(SqlStatsSortOptions).forEach((option: SqlStatsSortType) => {
+      if (getSortColumn(option) == this.props.sortSetting.columnTitle) {
+        found = true;
+      }
+    });
+    return found;
   };
 
   renderTransactions(): React.ReactElement {
@@ -492,6 +524,7 @@ export class TransactionsPage extends React.Component<
 
     const period = timeScaleToString(this.props.timeScale);
     const sortSettingLabel = getSortLabel(this.props.reqSortSetting);
+
     return (
       <>
         <h5 className={`${commonStyles("base-heading")} ${cx("margin-top")}`}>
@@ -531,6 +564,15 @@ export class TransactionsPage extends React.Component<
               <p className={timeScaleStylesCx("time-label")}>
                 Showing aggregated stats from{" "}
                 <span className={timeScaleStylesCx("bold")}>{period}</span>
+                {", "}
+                <ResultsPerPageLabel
+                  pagination={{
+                    ...pagination,
+                    total: transactionsToDisplay.length,
+                  }}
+                  pageName={"Statements"}
+                  search={search}
+                />
               </p>
             </PageConfigItem>
             {hasAdminRole && (
@@ -553,6 +595,19 @@ export class TransactionsPage extends React.Component<
             onRemoveFilter={this.onSubmitFilters}
             onClearFilters={this.onClearFilters}
           />
+          {!this.isSortSettingSameAsReqSort() && (
+            <InlineAlert
+              intent="warning"
+              title={getSubsetWarning(
+                "transaction",
+                this.props.limit,
+                sortSettingLabel,
+                this.hasReqSortOption(),
+                this.props.sortSetting.columnTitle as StatisticTableColumnKeys,
+              )}
+              className={cx("margin-bottom")}
+            />
+          )}
           <TransactionsTable
             columns={displayColumns}
             transactions={transactionsToDisplay}

--- a/pkg/ui/workspaces/cluster-ui/src/transactionsPage/transactionsPageConnected.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionsPage/transactionsPageConnected.tsx
@@ -171,6 +171,16 @@ export const TransactionsPageConnected = withRouter(
           dispatch(updateTxnsPageLimitAction(limit)),
         onChangeReqSort: (sort: SqlStatsSortType) =>
           dispatch(updateTxnsPageReqSortAction(sort)),
+        onApplySearchCriteria: (ts: TimeScale, limit: number, sort: string) =>
+          dispatch(
+            analyticsActions.track({
+              name: "Apply Search Criteria",
+              page: "Transactions",
+              tsValue: ts.key,
+              limitValue: limit,
+              sortValue: sort,
+            }),
+          ),
       },
       activePageProps: mapDispatchToActiveTransactionsPageProps(dispatch),
     }),

--- a/pkg/ui/workspaces/cluster-ui/src/util/sqlActivityConstants.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/util/sqlActivityConstants.ts
@@ -10,6 +10,10 @@
 
 import { duration } from "moment";
 import { SqlStatsSortOptions, SqlStatsSortType } from "src/api/statementsApi";
+import {
+  getLabel,
+  StatisticTableColumnKeys,
+} from "../statsTableUtil/statsTableUtil";
 
 export const limitOptions = [
   { value: 25, label: "25" },
@@ -27,7 +31,22 @@ export function getSortLabel(sort: SqlStatsSortType): string {
     case SqlStatsSortOptions.CONTENTION_TIME:
       return "Contention Time";
     case SqlStatsSortOptions.PCT_RUNTIME:
-      return "% Of All Runtime";
+      return "% of All Runtime";
+    default:
+      return "";
+  }
+}
+
+export function getSortColumn(sort: SqlStatsSortType): string {
+  switch (sort) {
+    case SqlStatsSortOptions.SERVICE_LAT:
+      return "time";
+    case SqlStatsSortOptions.EXECUTION_COUNT:
+      return "executionCount";
+    case SqlStatsSortOptions.CONTENTION_TIME:
+      return "contention";
+    case SqlStatsSortOptions.PCT_RUNTIME:
+      return "workloadPct";
     default:
       return "";
   }
@@ -49,3 +68,18 @@ export const txnRequestSortOptions = stmtRequestSortOptions.filter(
 );
 
 export const STATS_LONG_LOADING_DURATION = duration(2, "s");
+
+export function getSubsetWarning(
+  type: "statement" | "transaction",
+  limit: number,
+  sortLabel: string,
+  showSuggestion: boolean,
+  columnTitle: StatisticTableColumnKeys,
+): string {
+  const warningSuggestion = showSuggestion
+    ? `Update the search criteria to see the ${type} fingerprints 
+    sorted on ${getLabel(columnTitle, type)}.`
+    : "";
+  return `You are viewing a subset (Top ${limit}) of fingerprints by ${sortLabel}.
+    ${warningSuggestion}`;
+}

--- a/pkg/ui/workspaces/cluster-ui/src/util/sqlActivityConstants.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/util/sqlActivityConstants.ts
@@ -22,10 +22,13 @@ export const limitOptions = [
   { value: 500, label: "500" },
 ];
 
-export function getSortLabel(sort: SqlStatsSortType): string {
+export function getSortLabel(
+  sort: SqlStatsSortType,
+  type: "Statement" | "Transaction",
+): string {
   switch (sort) {
     case SqlStatsSortOptions.SERVICE_LAT:
-      return "Service Latency";
+      return `${type} Time`;
     case SqlStatsSortOptions.EXECUTION_COUNT:
       return "Execution Count";
     case SqlStatsSortOptions.CONTENTION_TIME:
@@ -55,7 +58,7 @@ export function getSortColumn(sort: SqlStatsSortType): string {
 export const stmtRequestSortOptions = Object.values(SqlStatsSortOptions)
   .map(sortVal => ({
     value: sortVal as SqlStatsSortType,
-    label: getSortLabel(sortVal as SqlStatsSortType),
+    label: getSortLabel(sortVal as SqlStatsSortType, "Statement"),
   }))
   .sort((a, b) => {
     if (a.label < b.label) return -1;
@@ -63,9 +66,17 @@ export const stmtRequestSortOptions = Object.values(SqlStatsSortOptions)
     return 0;
   });
 
-export const txnRequestSortOptions = stmtRequestSortOptions.filter(
-  option => option.value !== SqlStatsSortOptions.PCT_RUNTIME,
-);
+export const txnRequestSortOptions = Object.values(SqlStatsSortOptions)
+  .map(sortVal => ({
+    value: sortVal as SqlStatsSortType,
+    label: getSortLabel(sortVal as SqlStatsSortType, "Transaction"),
+  }))
+  .sort((a, b) => {
+    if (a.label < b.label) return -1;
+    if (a.label > b.label) return 1;
+    return 0;
+  })
+  .filter(option => option.value !== SqlStatsSortOptions.PCT_RUNTIME);
 
 export const STATS_LONG_LOADING_DURATION = duration(2, "s");
 

--- a/pkg/ui/workspaces/db-console/src/redux/analyticsActions.ts
+++ b/pkg/ui/workspaces/db-console/src/redux/analyticsActions.ts
@@ -9,6 +9,7 @@
 // licenses/APL.txt.
 
 import { PayloadAction } from "src/interfaces/action";
+import { TimeScale } from "@cockroachlabs/cluster-ui";
 
 export const TRACK_STATEMENTS_SEARCH =
   "cockroachui/analytics/TRACK_STATEMENTS_SEARCH";
@@ -21,11 +22,19 @@ export const TRACK_CANCEL_DIAGNOSTIC_BUNDLE =
   "cockroachui/analytics/TRACK_CANCEL_DIAGNOSTIC_BUNDLE";
 export const TRACK_STATEMENT_DETAILS_SUBNAV_SELECTION =
   "cockroachui/analytics/TRACK_STATEMENT_DETAILS_SUBNAV_SELECTION";
+export const TRACK_APPLY_SEARCH_CRITERIA =
+  "cockroachui/analytics/TRACK_APPLY_SEARCH_CRITERIA";
 
 export interface TableSortActionPayload {
   tableName: string;
   columnName: string;
   ascending?: boolean;
+}
+
+export interface ApplySearchCriteriaPayload {
+  ts: TimeScale;
+  limit: number;
+  sort: string;
 }
 
 export function trackStatementsSearchAction(
@@ -85,5 +94,20 @@ export function trackStatementDetailsSubnavSelectionAction(
   return {
     type: TRACK_STATEMENT_DETAILS_SUBNAV_SELECTION,
     payload: tabName,
+  };
+}
+
+export function trackApplySearchCriteriaAction(
+  ts: TimeScale,
+  limit: number,
+  sort: string,
+): PayloadAction<ApplySearchCriteriaPayload> {
+  return {
+    type: TRACK_APPLY_SEARCH_CRITERIA,
+    payload: {
+      ts,
+      limit,
+      sort,
+    },
   };
 }

--- a/pkg/ui/workspaces/db-console/src/views/statements/statementsPage.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/statements/statementsPage.tsx
@@ -55,6 +55,7 @@ import {
   setGlobalTimeScaleAction,
 } from "src/redux/statements";
 import {
+  trackApplySearchCriteriaAction,
   trackCancelDiagnosticsBundleAction,
   trackDownloadDiagnosticsBundleAction,
   trackStatementsPaginationAction,
@@ -359,6 +360,7 @@ const fingerprintsPageActions = {
     ),
   onChangeLimit: (newLimit: number) => limitSetting.set(newLimit),
   onChangeReqSort: (sort: api.SqlStatsSortType) => reqSortSetting.set(sort),
+  onApplySearchCriteria: trackApplySearchCriteriaAction,
 };
 
 type StateProps = {

--- a/pkg/ui/workspaces/db-console/src/views/transactions/transactionsPage.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/transactions/transactionsPage.tsx
@@ -50,6 +50,7 @@ import {
   selectTxnsDataValid,
   selectTxnsDataInFlight,
 } from "src/selectors/executionFingerprintsSelectors";
+import { trackApplySearchCriteriaAction } from "src/redux/analyticsActions";
 
 // selectData returns the array of AggregateStatistics to show on the
 // TransactionsPage, based on if the appAttr route parameter is set.
@@ -142,6 +143,7 @@ const fingerprintsPageActions = {
   onSearchComplete: (query: string) => searchLocalSetting.set(query),
   onChangeLimit: (newLimit: number) => limitSetting.set(newLimit),
   onChangeReqSort: (sort: api.SqlStatsSortType) => reqSortSetting.set(sort),
+  onApplySearchCriteria: trackApplySearchCriteriaAction,
 };
 
 type StateProps = {


### PR DESCRIPTION
Backport:
  * 1/1 commits from "ui: update sort setting on search criteria" (#99541)
  * 1/1 commits from "server, sql: show in-memory data when no data is persisted" (#100440)
  * 1/1 commits from "ui: search criteria ux improvements" (#100893)

Please see individual PRs for details.

22.2:
https://www.loom.com/share/67f989a2d5a741bbb827502f32e320d0

/cc @cockroachdb/release

---

Release justification: performance improvements
