### PR TITLE
colexechash: clean up the hash table a bit

### DIFF
--- a/pkg/sql/colexec/colexecagg/aggregators_util.go
+++ b/pkg/sql/colexec/colexecagg/aggregators_util.go
@@ -35,6 +35,13 @@ type NewAggregatorArgs struct {
 	Constructors   []execagg.AggregateConstructor
 	ConstArguments []tree.Datums
 	OutputTypes    []*types.T
+
+	TestingKnobs struct {
+		// HashTableNumBuckets if positive will override the initial number of
+		// buckets to be used by the hash table (if this struct is passed to the
+		// hash aggregator).
+		HashTableNumBuckets uint64
+	}
 }
 
 // NewHashAggregatorArgs encompasses all mandatory arguments necessary to

--- a/pkg/sql/colexec/colexecdisk/external_distinct.go
+++ b/pkg/sql/colexec/colexecdisk/external_distinct.go
@@ -172,12 +172,12 @@ func (f *unorderedDistinctFilterer) Next() coldata.Batch {
 		// Remove the duplicates within batch itself.
 		f.ud.Ht.RemoveDuplicates(
 			batch, f.ud.Ht.Keys, f.ud.Ht.ProbeScratch.First, f.ud.Ht.ProbeScratch.Next,
-			f.ud.Ht.CheckProbeForDistinct,
+			f.ud.Ht.CheckProbeForDistinct, true, /* probingAgainstItself */
 		)
 		// Remove the duplicates of already emitted distinct tuples.
 		f.ud.Ht.RemoveDuplicates(
 			batch, f.ud.Ht.Keys, f.ud.Ht.BuildScratch.First, f.ud.Ht.BuildScratch.Next,
-			f.ud.Ht.CheckBuildForDistinct,
+			f.ud.Ht.CheckBuildForDistinct, false, /* probingAgainstItself */
 		)
 		f.ud.MaybeEmitErrorOnDup(origLen, batch.Length())
 		if batch.Length() > 0 {

--- a/pkg/sql/colexec/colexecdisk/external_distinct.go
+++ b/pkg/sql/colexec/colexecdisk/external_distinct.go
@@ -170,9 +170,15 @@ func (f *unorderedDistinctFilterer) Next() coldata.Batch {
 		// all tuples in batch against the hash table.
 		f.ud.Ht.ComputeHashAndBuildChains(batch)
 		// Remove the duplicates within batch itself.
-		f.ud.Ht.RemoveDuplicates(batch, f.ud.Ht.Keys, f.ud.Ht.ProbeScratch.First, f.ud.Ht.ProbeScratch.Next, f.ud.Ht.CheckProbeForDistinct)
+		f.ud.Ht.RemoveDuplicates(
+			batch, f.ud.Ht.Keys, f.ud.Ht.ProbeScratch.First, f.ud.Ht.ProbeScratch.Next,
+			f.ud.Ht.CheckProbeForDistinct,
+		)
 		// Remove the duplicates of already emitted distinct tuples.
-		f.ud.Ht.RemoveDuplicates(batch, f.ud.Ht.Keys, f.ud.Ht.BuildScratch.First, f.ud.Ht.BuildScratch.Next, f.ud.Ht.CheckBuildForDistinct)
+		f.ud.Ht.RemoveDuplicates(
+			batch, f.ud.Ht.Keys, f.ud.Ht.BuildScratch.First, f.ud.Ht.BuildScratch.Next,
+			f.ud.Ht.CheckBuildForDistinct,
+		)
 		f.ud.MaybeEmitErrorOnDup(origLen, batch.Length())
 		if batch.Length() > 0 {
 			return batch

--- a/pkg/sql/colexec/colexechash/hashtable.go
+++ b/pkg/sql/colexec/colexechash/hashtable.go
@@ -679,42 +679,6 @@ func (ht *HashTable) ComputeHashAndBuildChains(batch coldata.Batch) {
 	ht.buildNextChains(ht.ProbeScratch.First, ht.ProbeScratch.Next, 1 /* offset */, uint64(batchLength))
 }
 
-// FindBuckets finds the buckets for all tuples in batch when probing against a
-// hash table that is specified by 'first' and 'next' vectors as well as
-// 'duplicatesChecker'. `duplicatesChecker` takes a slice of key columns of the
-// batch, number of tuples to check, and the selection vector of the batch, and
-// it returns number of tuples that needs to be checked for next iteration.
-// The "buckets" are specified by equal values in ht.ProbeScratch.HeadID.
-// NOTE: *first* and *next* vectors should be properly populated.
-// NOTE: batch is assumed to be non-zero length.
-func (ht *HashTable) FindBuckets(
-	batch coldata.Batch,
-	keyCols []coldata.Vec,
-	first, next []keyID,
-	duplicatesChecker func([]coldata.Vec, uint64, []int) uint64,
-) {
-	batchLength := batch.Length()
-	sel := batch.Selection()
-
-	ht.ProbeScratch.SetupLimitedSlices(batchLength, ht.BuildMode)
-	// Early bounds checks.
-	toCheckIDs := ht.ProbeScratch.ToCheckID
-	_ = toCheckIDs[batchLength-1]
-	for i, hash := range ht.ProbeScratch.HashBuffer[:batchLength] {
-		f := first[hash]
-		//gcassert:bce
-		toCheckIDs[i] = f
-	}
-	copy(ht.ProbeScratch.ToCheck, HashTableInitialToCheck[:batchLength])
-
-	for nToCheck := uint64(batchLength); nToCheck > 0; {
-		// Continue searching for the build table matching keys while the ToCheck
-		// array is non-empty.
-		nToCheck = duplicatesChecker(keyCols, nToCheck, sel)
-		ht.FindNext(next, nToCheck)
-	}
-}
-
 // RemoveDuplicates updates the selection vector of the batch to only include
 // distinct tuples when probing against a hash table specified by 'first' and
 // 'next' vectors as well as 'duplicatesChecker'.
@@ -865,14 +829,6 @@ func (p *hashTableProbeBuffer) SetupLimitedSlices(length int, buildMode HashTabl
 		p.ToCheck = make([]uint64, length)
 	} else {
 		p.ToCheck = p.ToCheck[:length]
-	}
-}
-
-// FindNext determines the id of the next key inside the ToCheckID buckets for
-// each equality column key in ToCheck.
-func (ht *HashTable) FindNext(next []keyID, nToCheck uint64) {
-	for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-		ht.ProbeScratch.ToCheckID[toCheck] = next[ht.ProbeScratch.ToCheckID[toCheck]]
 	}
 }
 

--- a/pkg/sql/colexec/colexechash/hashtable.go
+++ b/pkg/sql/colexec/colexechash/hashtable.go
@@ -158,10 +158,11 @@ type hashTableProbeBuffer struct {
 	// from the corresponding "candidate" tuple specified in ToCheckID.
 	differs []bool
 
-	// distinct stores whether the probing tuple is distinct (i.e. it will
-	// differ from all possible "candidates"). Used only for the hash aggregator
-	// and the unordered distinct.
-	distinct []bool
+	// foundNull stores whether the probing tuple contains a NULL value in the
+	// key. Populated only by the unordered distinct when
+	// allowNullEquality=false since a single NULL makes the key distinct from
+	// all other possible "candidates".
+	foundNull []bool
 
 	// HeadID stores the keyID of the tuple that has an equality match with the
 	// tuple at any given index from the probing batch. Unlike First where we
@@ -407,7 +408,7 @@ func probeBufferInternalMaxMemUsed() int64 {
 	//   - hashTableProbeBuffer.HashBuffer
 	// - two bool slices:
 	//   - hashTableProbeBuffer.differs
-	//   - hashTableProbeBuffer.distinct.
+	//   - hashTableProbeBuffer.foundNull.
 	return memsize.Uint64*int64(5*coldata.BatchSize()) + memsize.Bool*int64(2*coldata.BatchSize())
 }
 
@@ -825,7 +826,10 @@ func (p *hashTableProbeBuffer) SetupLimitedSlices(length int, buildMode HashTabl
 	p.HeadID = colexecutils.MaybeAllocateLimitedUint64Array(p.HeadID, length)
 	p.differs = colexecutils.MaybeAllocateLimitedBoolArray(p.differs, length)
 	if buildMode == HashTableDistinctBuildMode {
-		p.distinct = colexecutils.MaybeAllocateLimitedBoolArray(p.distinct, length)
+		// TODO(yuzefovich): foundNull is not used by the hash aggregator, so we
+		// could only allocate it when the hash table is used by the unordered
+		// distinct.
+		p.foundNull = colexecutils.MaybeAllocateLimitedBoolArray(p.foundNull, length)
 	}
 	// Note that we don't use maybeAllocate* methods below because ToCheckID and
 	// ToCheck don't need to be zeroed out when reused.
@@ -860,8 +864,10 @@ func (ht *HashTable) CheckBuildForDistinct(
 	for toCheckPos := uint64(0); toCheckPos < nToCheck && nDiffers < nToCheck; toCheckPos++ {
 		//gcassert:bce
 		toCheck := toCheckSlice[toCheckPos]
-		if ht.ProbeScratch.distinct[toCheck] {
-			ht.ProbeScratch.distinct[toCheck] = false
+		if ht.ProbeScratch.foundNull[toCheck] {
+			// foundNull is only set to true when allowNullEquality is false, so
+			// since this tuple has a NULL value, it's distinct from all others.
+			ht.ProbeScratch.foundNull[toCheck] = false
 			// Calculated using the convention: keyID = keys.indexOf(key) + 1.
 			ht.ProbeScratch.HeadID[toCheck] = toCheck + 1
 		} else if ht.ProbeScratch.differs[toCheck] {
@@ -888,6 +894,9 @@ func (ht *HashTable) CheckBuildForAggregation(
 	if probeSel == nil {
 		colexecerror.InternalError(errors.AssertionFailedf("invalid selection vector"))
 	}
+	if !ht.allowNullEquality {
+		colexecerror.InternalError(errors.AssertionFailedf("NULL equality is assumed to be allowed in CheckBuildForAggregation"))
+	}
 	ht.checkColsForDistinctTuples(probeVecs, nToCheck, probeSel)
 	nDiffers := uint64(0)
 	toCheckSlice := ht.ProbeScratch.ToCheck
@@ -895,21 +904,17 @@ func (ht *HashTable) CheckBuildForAggregation(
 	for toCheckPos := uint64(0); toCheckPos < nToCheck && nDiffers < nToCheck; toCheckPos++ {
 		//gcassert:bce
 		toCheck := toCheckSlice[toCheckPos]
-		if !ht.ProbeScratch.distinct[toCheck] {
-			// If the tuple is distinct, it doesn't have a duplicate in the
-			// hash table already, so we skip it.
-			if ht.ProbeScratch.differs[toCheck] {
-				// We have a hash collision, so we need to continue probing
-				// against the next tuples in the hash chain.
-				ht.ProbeScratch.differs[toCheck] = false
-				//gcassert:bce
-				toCheckSlice[nDiffers] = toCheck
-				nDiffers++
-			} else {
-				// This tuple has a duplicate in the hash table, so we remember
-				// keyID of that duplicate.
-				ht.ProbeScratch.HeadID[toCheck] = ht.ProbeScratch.ToCheckID[toCheck]
-			}
+		if ht.ProbeScratch.differs[toCheck] {
+			// We have a hash collision, so we need to continue probing against
+			// the next tuples in the hash chain.
+			ht.ProbeScratch.differs[toCheck] = false
+			//gcassert:bce
+			toCheckSlice[nDiffers] = toCheck
+			nDiffers++
+		} else {
+			// This tuple has a duplicate in the hash table, so we remember
+			// keyID of that duplicate.
+			ht.ProbeScratch.HeadID[toCheck] = ht.ProbeScratch.ToCheckID[toCheck]
 		}
 	}
 	return nDiffers
@@ -953,7 +958,7 @@ func (ht *HashTable) Reset(_ context.Context) {
 	// ht.ProbeScratch.Next, ht.Same and ht.Visited are reset separately before
 	// they are used (these slices are not used in all of the code paths).
 	// ht.ProbeScratch.HeadID, ht.ProbeScratch.differs, and
-	// ht.ProbeScratch.distinct are reset before they are used (these slices
+	// ht.ProbeScratch.foundNull are reset before they are used (these slices
 	// are limited in size and dynamically allocated).
 	// ht.ProbeScratch.ToCheckID and ht.ProbeScratch.ToCheck don't need to be
 	// reset because they are populated manually every time before checking the

--- a/pkg/sql/colexec/colexechash/hashtable.go
+++ b/pkg/sql/colexec/colexechash/hashtable.go
@@ -637,13 +637,13 @@ func (ht *HashTable) DistinctBuild(batch coldata.Batch) {
 	ht.ComputeHashAndBuildChains(batch)
 	ht.RemoveDuplicates(
 		batch, ht.Keys, ht.ProbeScratch.First, ht.ProbeScratch.Next,
-		ht.CheckProbeForDistinct,
+		ht.CheckProbeForDistinct, true, /* probingAgainstItself */
 	)
 	// We only check duplicates when there is at least one buffered tuple.
 	if ht.Vals.Length() > 0 {
 		ht.RemoveDuplicates(
 			batch, ht.Keys, ht.BuildScratch.First, ht.BuildScratch.Next,
-			ht.CheckBuildForDistinct,
+			ht.CheckBuildForDistinct, false, /* probingAgainstItself */
 		)
 	}
 	if batch.Length() > 0 {
@@ -695,10 +695,11 @@ func (ht *HashTable) RemoveDuplicates(
 	keyCols []coldata.Vec,
 	first, next []keyID,
 	duplicatesChecker func([]coldata.Vec, uint64, []int) uint64,
+	probingAgainstItself bool,
 ) {
 	ht.FindBuckets(
 		batch, keyCols, first, next, duplicatesChecker,
-		false, /* zeroHeadIDForDistinctTuple */
+		false /* zeroHeadIDForDistinctTuple */, probingAgainstItself,
 	)
 	ht.updateSel(batch)
 }

--- a/pkg/sql/colexec/colexechash/hashtable_distinct.eg.go
+++ b/pkg/sql/colexec/colexechash/hashtable_distinct.eg.go
@@ -3320,8 +3320,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 									}
 
 									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
-								} else {
-									ht.ProbeScratch.distinct[toCheck] = true
 								}
 							}
 						} else {
@@ -3360,8 +3358,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 									}
 
 									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
-								} else {
-									ht.ProbeScratch.distinct[toCheck] = true
 								}
 							}
 						}
@@ -3398,8 +3394,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 									}
 
 									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
-								} else {
-									ht.ProbeScratch.distinct[toCheck] = true
 								}
 							}
 						} else {
@@ -3428,8 +3422,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 									}
 
 									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
-								} else {
-									ht.ProbeScratch.distinct[toCheck] = true
 								}
 							}
 						}
@@ -3485,8 +3477,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 									}
 
 									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
-								} else {
-									ht.ProbeScratch.distinct[toCheck] = true
 								}
 							}
 						} else {
@@ -3517,8 +3507,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 									}
 
 									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
-								} else {
-									ht.ProbeScratch.distinct[toCheck] = true
 								}
 							}
 						}
@@ -3547,8 +3535,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 									}
 
 									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
-								} else {
-									ht.ProbeScratch.distinct[toCheck] = true
 								}
 							}
 						} else {
@@ -3569,8 +3555,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 									}
 
 									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
-								} else {
-									ht.ProbeScratch.distinct[toCheck] = true
 								}
 							}
 						}
@@ -3632,8 +3616,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 									}
 
 									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
-								} else {
-									ht.ProbeScratch.distinct[toCheck] = true
 								}
 							}
 						} else {
@@ -3664,8 +3646,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 									}
 
 									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
-								} else {
-									ht.ProbeScratch.distinct[toCheck] = true
 								}
 							}
 						}
@@ -3694,8 +3674,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 									}
 
 									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
-								} else {
-									ht.ProbeScratch.distinct[toCheck] = true
 								}
 							}
 						} else {
@@ -3716,8 +3694,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 									}
 
 									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
-								} else {
-									ht.ProbeScratch.distinct[toCheck] = true
 								}
 							}
 						}
@@ -3782,8 +3758,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 									}
 
 									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
-								} else {
-									ht.ProbeScratch.distinct[toCheck] = true
 								}
 							}
 						} else {
@@ -3825,8 +3799,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 									}
 
 									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
-								} else {
-									ht.ProbeScratch.distinct[toCheck] = true
 								}
 							}
 						}
@@ -3866,8 +3838,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 									}
 
 									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
-								} else {
-									ht.ProbeScratch.distinct[toCheck] = true
 								}
 							}
 						} else {
@@ -3899,8 +3869,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 									}
 
 									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
-								} else {
-									ht.ProbeScratch.distinct[toCheck] = true
 								}
 							}
 						}
@@ -3968,8 +3936,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 									}
 
 									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
-								} else {
-									ht.ProbeScratch.distinct[toCheck] = true
 								}
 							}
 						} else {
@@ -4011,8 +3977,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 									}
 
 									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
-								} else {
-									ht.ProbeScratch.distinct[toCheck] = true
 								}
 							}
 						}
@@ -4052,8 +4016,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 									}
 
 									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
-								} else {
-									ht.ProbeScratch.distinct[toCheck] = true
 								}
 							}
 						} else {
@@ -4085,8 +4047,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 									}
 
 									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
-								} else {
-									ht.ProbeScratch.distinct[toCheck] = true
 								}
 							}
 						}
@@ -4156,8 +4116,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 									}
 
 									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
-								} else {
-									ht.ProbeScratch.distinct[toCheck] = true
 								}
 							}
 						} else {
@@ -4199,8 +4157,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 									}
 
 									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
-								} else {
-									ht.ProbeScratch.distinct[toCheck] = true
 								}
 							}
 						}
@@ -4240,8 +4196,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 									}
 
 									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
-								} else {
-									ht.ProbeScratch.distinct[toCheck] = true
 								}
 							}
 						} else {
@@ -4273,8 +4227,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 									}
 
 									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
-								} else {
-									ht.ProbeScratch.distinct[toCheck] = true
 								}
 							}
 						}
@@ -4358,8 +4310,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 									}
 
 									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
-								} else {
-									ht.ProbeScratch.distinct[toCheck] = true
 								}
 							}
 						} else {
@@ -4409,8 +4359,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 									}
 
 									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
-								} else {
-									ht.ProbeScratch.distinct[toCheck] = true
 								}
 							}
 						}
@@ -4458,8 +4406,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 									}
 
 									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
-								} else {
-									ht.ProbeScratch.distinct[toCheck] = true
 								}
 							}
 						} else {
@@ -4499,8 +4445,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 									}
 
 									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
-								} else {
-									ht.ProbeScratch.distinct[toCheck] = true
 								}
 							}
 						}
@@ -4566,8 +4510,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 									}
 
 									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
-								} else {
-									ht.ProbeScratch.distinct[toCheck] = true
 								}
 							}
 						} else {
@@ -4605,8 +4547,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 									}
 
 									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
-								} else {
-									ht.ProbeScratch.distinct[toCheck] = true
 								}
 							}
 						}
@@ -4642,8 +4582,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 									}
 
 									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
-								} else {
-									ht.ProbeScratch.distinct[toCheck] = true
 								}
 							}
 						} else {
@@ -4671,8 +4609,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 									}
 
 									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
-								} else {
-									ht.ProbeScratch.distinct[toCheck] = true
 								}
 							}
 						}
@@ -4728,8 +4664,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 									}
 
 									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
-								} else {
-									ht.ProbeScratch.distinct[toCheck] = true
 								}
 							}
 						} else {
@@ -4760,8 +4694,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 									}
 
 									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
-								} else {
-									ht.ProbeScratch.distinct[toCheck] = true
 								}
 							}
 						}
@@ -4790,8 +4722,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 									}
 
 									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
-								} else {
-									ht.ProbeScratch.distinct[toCheck] = true
 								}
 							}
 						} else {
@@ -4812,8 +4742,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 									}
 
 									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
-								} else {
-									ht.ProbeScratch.distinct[toCheck] = true
 								}
 							}
 						}
@@ -4875,8 +4803,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 									}
 
 									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
-								} else {
-									ht.ProbeScratch.distinct[toCheck] = true
 								}
 							}
 						} else {
@@ -4913,8 +4839,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 									}
 
 									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
-								} else {
-									ht.ProbeScratch.distinct[toCheck] = true
 								}
 							}
 						}
@@ -4949,8 +4873,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 									}
 
 									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
-								} else {
-									ht.ProbeScratch.distinct[toCheck] = true
 								}
 							}
 						} else {
@@ -4977,8 +4899,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 									}
 
 									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
-								} else {
-									ht.ProbeScratch.distinct[toCheck] = true
 								}
 							}
 						}
@@ -5036,8 +4956,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 									}
 
 									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
-								} else {
-									ht.ProbeScratch.distinct[toCheck] = true
 								}
 							}
 						} else {
@@ -5070,8 +4988,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 									}
 
 									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
-								} else {
-									ht.ProbeScratch.distinct[toCheck] = true
 								}
 							}
 						}
@@ -5102,8 +5018,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 									}
 
 									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
-								} else {
-									ht.ProbeScratch.distinct[toCheck] = true
 								}
 							}
 						} else {
@@ -5126,8 +5040,6 @@ func (ht *HashTable) checkColForDistinctTuples(
 									}
 
 									ht.ProbeScratch.differs[toCheck] = ht.ProbeScratch.differs[toCheck] || unique
-								} else {
-									ht.ProbeScratch.distinct[toCheck] = true
 								}
 							}
 						}
@@ -5156,9 +5068,7 @@ func (ht *HashTable) CheckProbeForDistinct(vecs []coldata.Vec, nToCheck uint64, 
 		}
 		if !ht.ProbeScratch.differs[toCheck] {
 			keyID := ht.ProbeScratch.ToCheckID[toCheck]
-			if ht.ProbeScratch.HeadID[toCheck] == 0 {
-				ht.ProbeScratch.HeadID[toCheck] = keyID
-			}
+			ht.ProbeScratch.HeadID[toCheck] = keyID
 		} else {
 			ht.ProbeScratch.differs[toCheck] = false
 			//gcassert:bce
@@ -5241,6 +5151,12 @@ func (ht *HashTable) updateSel(b coldata.Batch) {
 // batch, number of tuples to check, and the selection vector of the batch, and
 // it returns number of tuples that needs to be checked for next iteration.
 // The "buckets" are specified by equal values in ht.ProbeScratch.HeadID.
+//
+// - zeroHeadIDForDistinctTuple controls how a bucket with a single distinct
+// tuple will be represented (i.e. this tuple is distinct from all tuples in the
+// hash table). If zeroHeadIDForDistinctTuple is true, then this tuple will have
+// HeadID of 0, otherwise, it'll have HeadID[i] = keyID(i) = i + 1.
+//
 // NOTE: *first* and *next* vectors should be properly populated.
 // NOTE: batch is assumed to be non-zero length.
 func (ht *HashTable) FindBuckets(
@@ -5248,27 +5164,112 @@ func (ht *HashTable) FindBuckets(
 	keyCols []coldata.Vec,
 	first, next []keyID,
 	duplicatesChecker func([]coldata.Vec, uint64, []int) uint64,
+	zeroHeadIDForDistinctTuple bool,
 ) {
-	batchLength := batch.Length()
-	sel := batch.Selection()
+	ht.ProbeScratch.SetupLimitedSlices(batch.Length(), ht.BuildMode)
+	if zeroHeadIDForDistinctTuple {
+		{
+			batchLength := batch.Length()
+			sel := batch.Selection()
+			// Early bounds checks.
+			toCheckIDs := ht.ProbeScratch.ToCheckID
+			_ = toCheckIDs[batchLength-1]
+			var nToCheck uint64
+			for i, hash := range ht.ProbeScratch.HashBuffer[:batchLength] {
+				toCheck := uint64(i)
+				nextToCheckID := first[hash]
+				{
+					if nextToCheckID != 0 {
+						//gcassert:bce
+						toCheckIDs[toCheck] = nextToCheckID
+						ht.ProbeScratch.ToCheck[nToCheck] = toCheck
+						nToCheck++
+					} else {
+						_ = true
+					}
+				}
+			}
 
-	ht.ProbeScratch.SetupLimitedSlices(batchLength, ht.BuildMode)
-	// Early bounds checks.
-	toCheckIDs := ht.ProbeScratch.ToCheckID
-	_ = toCheckIDs[batchLength-1]
-	for i, hash := range ht.ProbeScratch.HashBuffer[:batchLength] {
-		f := first[hash]
-		//gcassert:bce
-		toCheckIDs[i] = f
-	}
-	copy(ht.ProbeScratch.ToCheck, HashTableInitialToCheck[:batchLength])
+			for nToCheck > 0 {
+				nToCheck = duplicatesChecker(keyCols, nToCheck, sel)
+				toCheckSlice := ht.ProbeScratch.ToCheck[:nToCheck]
+				nToCheck = 0
+				for _, toCheck := range toCheckSlice {
+					nextToCheckID := next[toCheckIDs[toCheck]]
+					{
+						if nextToCheckID != 0 {
+							//gcassert:bce
+							toCheckIDs[toCheck] = nextToCheckID
+							ht.ProbeScratch.ToCheck[nToCheck] = toCheck
+							nToCheck++
+						} else {
+							_ = true
+						}
+					}
+				}
+			}
+		}
+	} else {
+		{
+			batchLength := batch.Length()
+			sel := batch.Selection()
+			// Early bounds checks.
+			toCheckIDs := ht.ProbeScratch.ToCheckID
+			_ = toCheckIDs[batchLength-1]
+			var nToCheck uint64
+			for i, hash := range ht.ProbeScratch.HashBuffer[:batchLength] {
+				toCheck := uint64(i)
+				nextToCheckID := first[hash]
+				{
+					if nextToCheckID != 0 {
+						//gcassert:bce
+						toCheckIDs[toCheck] = nextToCheckID
+						ht.ProbeScratch.ToCheck[nToCheck] = toCheck
+						nToCheck++
+					} else {
+						_ = true
+						ht.ProbeScratch.HeadID[toCheck] = toCheck + 1
+					}
+				}
+			}
 
-	for nToCheck := uint64(batchLength); nToCheck > 0; {
-		// Continue searching for the build table matching keys while the ToCheck
-		// array is non-empty.
-		nToCheck = duplicatesChecker(keyCols, nToCheck, sel)
-		for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
-			ht.ProbeScratch.ToCheckID[toCheck] = next[ht.ProbeScratch.ToCheckID[toCheck]]
+			for nToCheck > 0 {
+				nToCheck = duplicatesChecker(keyCols, nToCheck, sel)
+				toCheckSlice := ht.ProbeScratch.ToCheck[:nToCheck]
+				nToCheck = 0
+				for _, toCheck := range toCheckSlice {
+					nextToCheckID := next[toCheckIDs[toCheck]]
+					{
+						if nextToCheckID != 0 {
+							//gcassert:bce
+							toCheckIDs[toCheck] = nextToCheckID
+							ht.ProbeScratch.ToCheck[nToCheck] = toCheck
+							nToCheck++
+						} else {
+							_ = true
+							ht.ProbeScratch.HeadID[toCheck] = toCheck + 1
+						}
+					}
+				}
+			}
 		}
 	}
 }
+
+// execgen:inline
+const _ = "template_findBuckets"
+
+// execgen:inline
+const _ = "template_handleNextToCheckID"
+
+// execgen:inline
+const _ = "inlined_findBuckets_true"
+
+// execgen:inline
+const _ = "inlined_findBuckets_false"
+
+// execgen:inline
+const _ = "inlined_handleNextToCheckID_true"
+
+// execgen:inline
+const _ = "inlined_handleNextToCheckID_false"

--- a/pkg/sql/colexec/colexechash/hashtable_distinct.eg.go
+++ b/pkg/sql/colexec/colexechash/hashtable_distinct.eg.go
@@ -67,7 +67,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 												ht.ProbeScratch.differs[toCheck] = true
 											}
 										} else {
-											ht.ProbeScratch.distinct[toCheck] = true
+											ht.ProbeScratch.foundNull[toCheck] = true
 										}
 										continue
 									}
@@ -107,7 +107,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 										if ht.allowNullEquality {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
-											ht.ProbeScratch.distinct[toCheck] = true
+											ht.ProbeScratch.foundNull[toCheck] = true
 										}
 										continue
 									}
@@ -211,7 +211,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 												ht.ProbeScratch.differs[toCheck] = true
 											}
 										} else {
-											ht.ProbeScratch.distinct[toCheck] = true
+											ht.ProbeScratch.foundNull[toCheck] = true
 										}
 										continue
 									}
@@ -251,7 +251,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 										if ht.allowNullEquality {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
-											ht.ProbeScratch.distinct[toCheck] = true
+											ht.ProbeScratch.foundNull[toCheck] = true
 										}
 										continue
 									}
@@ -370,7 +370,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 												ht.ProbeScratch.differs[toCheck] = true
 											}
 										} else {
-											ht.ProbeScratch.distinct[toCheck] = true
+											ht.ProbeScratch.foundNull[toCheck] = true
 										}
 										continue
 									}
@@ -402,7 +402,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 										if ht.allowNullEquality {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
-											ht.ProbeScratch.distinct[toCheck] = true
+											ht.ProbeScratch.foundNull[toCheck] = true
 										}
 										continue
 									}
@@ -482,7 +482,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 												ht.ProbeScratch.differs[toCheck] = true
 											}
 										} else {
-											ht.ProbeScratch.distinct[toCheck] = true
+											ht.ProbeScratch.foundNull[toCheck] = true
 										}
 										continue
 									}
@@ -514,7 +514,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 										if ht.allowNullEquality {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
-											ht.ProbeScratch.distinct[toCheck] = true
+											ht.ProbeScratch.foundNull[toCheck] = true
 										}
 										continue
 									}
@@ -609,7 +609,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 												ht.ProbeScratch.differs[toCheck] = true
 											}
 										} else {
-											ht.ProbeScratch.distinct[toCheck] = true
+											ht.ProbeScratch.foundNull[toCheck] = true
 										}
 										continue
 									}
@@ -641,7 +641,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 										if ht.allowNullEquality {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
-											ht.ProbeScratch.distinct[toCheck] = true
+											ht.ProbeScratch.foundNull[toCheck] = true
 										}
 										continue
 									}
@@ -721,7 +721,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 												ht.ProbeScratch.differs[toCheck] = true
 											}
 										} else {
-											ht.ProbeScratch.distinct[toCheck] = true
+											ht.ProbeScratch.foundNull[toCheck] = true
 										}
 										continue
 									}
@@ -753,7 +753,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 										if ht.allowNullEquality {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
-											ht.ProbeScratch.distinct[toCheck] = true
+											ht.ProbeScratch.foundNull[toCheck] = true
 										}
 										continue
 									}
@@ -846,7 +846,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 												ht.ProbeScratch.differs[toCheck] = true
 											}
 										} else {
-											ht.ProbeScratch.distinct[toCheck] = true
+											ht.ProbeScratch.foundNull[toCheck] = true
 										}
 										continue
 									}
@@ -889,7 +889,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 										if ht.allowNullEquality {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
-											ht.ProbeScratch.distinct[toCheck] = true
+											ht.ProbeScratch.foundNull[toCheck] = true
 										}
 										continue
 									}
@@ -1002,7 +1002,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 												ht.ProbeScratch.differs[toCheck] = true
 											}
 										} else {
-											ht.ProbeScratch.distinct[toCheck] = true
+											ht.ProbeScratch.foundNull[toCheck] = true
 										}
 										continue
 									}
@@ -1045,7 +1045,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 										if ht.allowNullEquality {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
-											ht.ProbeScratch.distinct[toCheck] = true
+											ht.ProbeScratch.foundNull[toCheck] = true
 										}
 										continue
 									}
@@ -1168,7 +1168,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 												ht.ProbeScratch.differs[toCheck] = true
 											}
 										} else {
-											ht.ProbeScratch.distinct[toCheck] = true
+											ht.ProbeScratch.foundNull[toCheck] = true
 										}
 										continue
 									}
@@ -1211,7 +1211,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 										if ht.allowNullEquality {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
-											ht.ProbeScratch.distinct[toCheck] = true
+											ht.ProbeScratch.foundNull[toCheck] = true
 										}
 										continue
 									}
@@ -1324,7 +1324,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 												ht.ProbeScratch.differs[toCheck] = true
 											}
 										} else {
-											ht.ProbeScratch.distinct[toCheck] = true
+											ht.ProbeScratch.foundNull[toCheck] = true
 										}
 										continue
 									}
@@ -1367,7 +1367,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 										if ht.allowNullEquality {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
-											ht.ProbeScratch.distinct[toCheck] = true
+											ht.ProbeScratch.foundNull[toCheck] = true
 										}
 										continue
 									}
@@ -1492,7 +1492,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 												ht.ProbeScratch.differs[toCheck] = true
 											}
 										} else {
-											ht.ProbeScratch.distinct[toCheck] = true
+											ht.ProbeScratch.foundNull[toCheck] = true
 										}
 										continue
 									}
@@ -1535,7 +1535,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 										if ht.allowNullEquality {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
-											ht.ProbeScratch.distinct[toCheck] = true
+											ht.ProbeScratch.foundNull[toCheck] = true
 										}
 										continue
 									}
@@ -1648,7 +1648,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 												ht.ProbeScratch.differs[toCheck] = true
 											}
 										} else {
-											ht.ProbeScratch.distinct[toCheck] = true
+											ht.ProbeScratch.foundNull[toCheck] = true
 										}
 										continue
 									}
@@ -1691,7 +1691,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 										if ht.allowNullEquality {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
-											ht.ProbeScratch.distinct[toCheck] = true
+											ht.ProbeScratch.foundNull[toCheck] = true
 										}
 										continue
 									}
@@ -1819,7 +1819,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 												ht.ProbeScratch.differs[toCheck] = true
 											}
 										} else {
-											ht.ProbeScratch.distinct[toCheck] = true
+											ht.ProbeScratch.foundNull[toCheck] = true
 										}
 										continue
 									}
@@ -1870,7 +1870,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 										if ht.allowNullEquality {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
-											ht.ProbeScratch.distinct[toCheck] = true
+											ht.ProbeScratch.foundNull[toCheck] = true
 										}
 										continue
 									}
@@ -2007,7 +2007,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 												ht.ProbeScratch.differs[toCheck] = true
 											}
 										} else {
-											ht.ProbeScratch.distinct[toCheck] = true
+											ht.ProbeScratch.foundNull[toCheck] = true
 										}
 										continue
 									}
@@ -2058,7 +2058,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 										if ht.allowNullEquality {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
-											ht.ProbeScratch.distinct[toCheck] = true
+											ht.ProbeScratch.foundNull[toCheck] = true
 										}
 										continue
 									}
@@ -2210,7 +2210,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 												ht.ProbeScratch.differs[toCheck] = true
 											}
 										} else {
-											ht.ProbeScratch.distinct[toCheck] = true
+											ht.ProbeScratch.foundNull[toCheck] = true
 										}
 										continue
 									}
@@ -2249,7 +2249,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 										if ht.allowNullEquality {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
-											ht.ProbeScratch.distinct[toCheck] = true
+											ht.ProbeScratch.foundNull[toCheck] = true
 										}
 										continue
 									}
@@ -2350,7 +2350,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 												ht.ProbeScratch.differs[toCheck] = true
 											}
 										} else {
-											ht.ProbeScratch.distinct[toCheck] = true
+											ht.ProbeScratch.foundNull[toCheck] = true
 										}
 										continue
 									}
@@ -2389,7 +2389,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 										if ht.allowNullEquality {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
-											ht.ProbeScratch.distinct[toCheck] = true
+											ht.ProbeScratch.foundNull[toCheck] = true
 										}
 										continue
 									}
@@ -2505,7 +2505,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 												ht.ProbeScratch.differs[toCheck] = true
 											}
 										} else {
-											ht.ProbeScratch.distinct[toCheck] = true
+											ht.ProbeScratch.foundNull[toCheck] = true
 										}
 										continue
 									}
@@ -2537,7 +2537,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 										if ht.allowNullEquality {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
-											ht.ProbeScratch.distinct[toCheck] = true
+											ht.ProbeScratch.foundNull[toCheck] = true
 										}
 										continue
 									}
@@ -2617,7 +2617,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 												ht.ProbeScratch.differs[toCheck] = true
 											}
 										} else {
-											ht.ProbeScratch.distinct[toCheck] = true
+											ht.ProbeScratch.foundNull[toCheck] = true
 										}
 										continue
 									}
@@ -2649,7 +2649,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 										if ht.allowNullEquality {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
-											ht.ProbeScratch.distinct[toCheck] = true
+											ht.ProbeScratch.foundNull[toCheck] = true
 										}
 										continue
 									}
@@ -2744,7 +2744,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 												ht.ProbeScratch.differs[toCheck] = true
 											}
 										} else {
-											ht.ProbeScratch.distinct[toCheck] = true
+											ht.ProbeScratch.foundNull[toCheck] = true
 										}
 										continue
 									}
@@ -2782,7 +2782,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 										if ht.allowNullEquality {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
-											ht.ProbeScratch.distinct[toCheck] = true
+											ht.ProbeScratch.foundNull[toCheck] = true
 										}
 										continue
 									}
@@ -2880,7 +2880,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 												ht.ProbeScratch.differs[toCheck] = true
 											}
 										} else {
-											ht.ProbeScratch.distinct[toCheck] = true
+											ht.ProbeScratch.foundNull[toCheck] = true
 										}
 										continue
 									}
@@ -2918,7 +2918,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 										if ht.allowNullEquality {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
-											ht.ProbeScratch.distinct[toCheck] = true
+											ht.ProbeScratch.foundNull[toCheck] = true
 										}
 										continue
 									}
@@ -3031,7 +3031,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 												ht.ProbeScratch.differs[toCheck] = true
 											}
 										} else {
-											ht.ProbeScratch.distinct[toCheck] = true
+											ht.ProbeScratch.foundNull[toCheck] = true
 										}
 										continue
 									}
@@ -3065,7 +3065,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 										if ht.allowNullEquality {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
-											ht.ProbeScratch.distinct[toCheck] = true
+											ht.ProbeScratch.foundNull[toCheck] = true
 										}
 										continue
 									}
@@ -3151,7 +3151,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 												ht.ProbeScratch.differs[toCheck] = true
 											}
 										} else {
-											ht.ProbeScratch.distinct[toCheck] = true
+											ht.ProbeScratch.foundNull[toCheck] = true
 										}
 										continue
 									}
@@ -3185,7 +3185,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 										if ht.allowNullEquality {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
-											ht.ProbeScratch.distinct[toCheck] = true
+											ht.ProbeScratch.foundNull[toCheck] = true
 										}
 										continue
 									}
@@ -3293,7 +3293,7 @@ func (ht *HashTable) checkColForDistinctTuples(
 												ht.ProbeScratch.differs[toCheck] = true
 											}
 										} else {
-											ht.ProbeScratch.distinct[toCheck] = true
+											ht.ProbeScratch.foundNull[toCheck] = true
 										}
 										continue
 									}
@@ -3335,7 +3335,7 @@ func (ht *HashTable) checkColForDistinctTuples(
 										if ht.allowNullEquality {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
-											ht.ProbeScratch.distinct[toCheck] = true
+											ht.ProbeScratch.foundNull[toCheck] = true
 										}
 										continue
 									}
@@ -3458,7 +3458,7 @@ func (ht *HashTable) checkColForDistinctTuples(
 												ht.ProbeScratch.differs[toCheck] = true
 											}
 										} else {
-											ht.ProbeScratch.distinct[toCheck] = true
+											ht.ProbeScratch.foundNull[toCheck] = true
 										}
 										continue
 									}
@@ -3492,7 +3492,7 @@ func (ht *HashTable) checkColForDistinctTuples(
 										if ht.allowNullEquality {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
-											ht.ProbeScratch.distinct[toCheck] = true
+											ht.ProbeScratch.foundNull[toCheck] = true
 										}
 										continue
 									}
@@ -3597,7 +3597,7 @@ func (ht *HashTable) checkColForDistinctTuples(
 												ht.ProbeScratch.differs[toCheck] = true
 											}
 										} else {
-											ht.ProbeScratch.distinct[toCheck] = true
+											ht.ProbeScratch.foundNull[toCheck] = true
 										}
 										continue
 									}
@@ -3631,7 +3631,7 @@ func (ht *HashTable) checkColForDistinctTuples(
 										if ht.allowNullEquality {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
-											ht.ProbeScratch.distinct[toCheck] = true
+											ht.ProbeScratch.foundNull[toCheck] = true
 										}
 										continue
 									}
@@ -3728,7 +3728,7 @@ func (ht *HashTable) checkColForDistinctTuples(
 												ht.ProbeScratch.differs[toCheck] = true
 											}
 										} else {
-											ht.ProbeScratch.distinct[toCheck] = true
+											ht.ProbeScratch.foundNull[toCheck] = true
 										}
 										continue
 									}
@@ -3773,7 +3773,7 @@ func (ht *HashTable) checkColForDistinctTuples(
 										if ht.allowNullEquality {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
-											ht.ProbeScratch.distinct[toCheck] = true
+											ht.ProbeScratch.foundNull[toCheck] = true
 										}
 										continue
 									}
@@ -3906,7 +3906,7 @@ func (ht *HashTable) checkColForDistinctTuples(
 												ht.ProbeScratch.differs[toCheck] = true
 											}
 										} else {
-											ht.ProbeScratch.distinct[toCheck] = true
+											ht.ProbeScratch.foundNull[toCheck] = true
 										}
 										continue
 									}
@@ -3951,7 +3951,7 @@ func (ht *HashTable) checkColForDistinctTuples(
 										if ht.allowNullEquality {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
-											ht.ProbeScratch.distinct[toCheck] = true
+											ht.ProbeScratch.foundNull[toCheck] = true
 										}
 										continue
 									}
@@ -4086,7 +4086,7 @@ func (ht *HashTable) checkColForDistinctTuples(
 												ht.ProbeScratch.differs[toCheck] = true
 											}
 										} else {
-											ht.ProbeScratch.distinct[toCheck] = true
+											ht.ProbeScratch.foundNull[toCheck] = true
 										}
 										continue
 									}
@@ -4131,7 +4131,7 @@ func (ht *HashTable) checkColForDistinctTuples(
 										if ht.allowNullEquality {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
-											ht.ProbeScratch.distinct[toCheck] = true
+											ht.ProbeScratch.foundNull[toCheck] = true
 										}
 										continue
 									}
@@ -4272,7 +4272,7 @@ func (ht *HashTable) checkColForDistinctTuples(
 												ht.ProbeScratch.differs[toCheck] = true
 											}
 										} else {
-											ht.ProbeScratch.distinct[toCheck] = true
+											ht.ProbeScratch.foundNull[toCheck] = true
 										}
 										continue
 									}
@@ -4325,7 +4325,7 @@ func (ht *HashTable) checkColForDistinctTuples(
 										if ht.allowNullEquality {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
-											ht.ProbeScratch.distinct[toCheck] = true
+											ht.ProbeScratch.foundNull[toCheck] = true
 										}
 										continue
 									}
@@ -4484,7 +4484,7 @@ func (ht *HashTable) checkColForDistinctTuples(
 												ht.ProbeScratch.differs[toCheck] = true
 											}
 										} else {
-											ht.ProbeScratch.distinct[toCheck] = true
+											ht.ProbeScratch.foundNull[toCheck] = true
 										}
 										continue
 									}
@@ -4525,7 +4525,7 @@ func (ht *HashTable) checkColForDistinctTuples(
 										if ht.allowNullEquality {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
-											ht.ProbeScratch.distinct[toCheck] = true
+											ht.ProbeScratch.foundNull[toCheck] = true
 										}
 										continue
 									}
@@ -4645,7 +4645,7 @@ func (ht *HashTable) checkColForDistinctTuples(
 												ht.ProbeScratch.differs[toCheck] = true
 											}
 										} else {
-											ht.ProbeScratch.distinct[toCheck] = true
+											ht.ProbeScratch.foundNull[toCheck] = true
 										}
 										continue
 									}
@@ -4679,7 +4679,7 @@ func (ht *HashTable) checkColForDistinctTuples(
 										if ht.allowNullEquality {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
-											ht.ProbeScratch.distinct[toCheck] = true
+											ht.ProbeScratch.foundNull[toCheck] = true
 										}
 										continue
 									}
@@ -4778,7 +4778,7 @@ func (ht *HashTable) checkColForDistinctTuples(
 												ht.ProbeScratch.differs[toCheck] = true
 											}
 										} else {
-											ht.ProbeScratch.distinct[toCheck] = true
+											ht.ProbeScratch.foundNull[toCheck] = true
 										}
 										continue
 									}
@@ -4818,7 +4818,7 @@ func (ht *HashTable) checkColForDistinctTuples(
 										if ht.allowNullEquality {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
-											ht.ProbeScratch.distinct[toCheck] = true
+											ht.ProbeScratch.foundNull[toCheck] = true
 										}
 										continue
 									}
@@ -4935,7 +4935,7 @@ func (ht *HashTable) checkColForDistinctTuples(
 												ht.ProbeScratch.differs[toCheck] = true
 											}
 										} else {
-											ht.ProbeScratch.distinct[toCheck] = true
+											ht.ProbeScratch.foundNull[toCheck] = true
 										}
 										continue
 									}
@@ -4971,7 +4971,7 @@ func (ht *HashTable) checkColForDistinctTuples(
 										if ht.allowNullEquality {
 											ht.ProbeScratch.differs[toCheck] = true
 										} else {
-											ht.ProbeScratch.distinct[toCheck] = true
+											ht.ProbeScratch.foundNull[toCheck] = true
 										}
 										continue
 									}
@@ -5057,23 +5057,41 @@ func (ht *HashTable) CheckProbeForDistinct(vecs []coldata.Vec, nToCheck uint64, 
 		ht.checkColAgainstItselfForDistinct(vecs[i], nToCheck, sel)
 	}
 	nDiffers := uint64(0)
-	toCheckSlice := ht.ProbeScratch.ToCheck
-	_ = toCheckSlice[nToCheck-1]
-	for toCheckPos := uint64(0); toCheckPos < nToCheck && nDiffers < nToCheck; toCheckPos++ {
-		//gcassert:bce
-		toCheck := toCheckSlice[toCheckPos]
-		if ht.ProbeScratch.distinct[toCheck] {
-			ht.ProbeScratch.HeadID[toCheck] = toCheck + 1
-			continue
-		}
-		if !ht.ProbeScratch.differs[toCheck] {
-			keyID := ht.ProbeScratch.ToCheckID[toCheck]
-			ht.ProbeScratch.HeadID[toCheck] = keyID
-		} else {
-			ht.ProbeScratch.differs[toCheck] = false
+	if ht.allowNullEquality {
+		toCheckSlice := ht.ProbeScratch.ToCheck
+		_ = toCheckSlice[nToCheck-1]
+		for toCheckPos := uint64(0); toCheckPos < nToCheck && nDiffers < nToCheck; toCheckPos++ {
 			//gcassert:bce
-			toCheckSlice[nDiffers] = toCheck
-			nDiffers++
+			toCheck := toCheckSlice[toCheckPos]
+			if !ht.ProbeScratch.differs[toCheck] {
+				keyID := ht.ProbeScratch.ToCheckID[toCheck]
+				ht.ProbeScratch.HeadID[toCheck] = keyID
+			} else {
+				ht.ProbeScratch.differs[toCheck] = false
+				//gcassert:bce
+				toCheckSlice[nDiffers] = toCheck
+				nDiffers++
+			}
+		}
+	} else {
+		toCheckSlice := ht.ProbeScratch.ToCheck
+		_ = toCheckSlice[nToCheck-1]
+		for toCheckPos := uint64(0); toCheckPos < nToCheck && nDiffers < nToCheck; toCheckPos++ {
+			//gcassert:bce
+			toCheck := toCheckSlice[toCheckPos]
+			if ht.ProbeScratch.foundNull[toCheck] {
+				ht.ProbeScratch.HeadID[toCheck] = toCheck + 1
+				continue
+			}
+			if !ht.ProbeScratch.differs[toCheck] {
+				keyID := ht.ProbeScratch.ToCheckID[toCheck]
+				ht.ProbeScratch.HeadID[toCheck] = keyID
+			} else {
+				ht.ProbeScratch.differs[toCheck] = false
+				//gcassert:bce
+				toCheckSlice[nDiffers] = toCheck
+				nDiffers++
+			}
 		}
 	}
 	return nDiffers
@@ -5097,8 +5115,8 @@ func (ht *HashTable) updateSel(b coldata.Batch) {
 		hashBuffer := ht.ProbeScratch.HashBuffer
 		_ = HeadIDs[batchLength-1]
 		_ = hashBuffer[batchLength-1]
-		// Reuse the buffer allocated for distinct.
-		visited := ht.ProbeScratch.distinct
+		// Reuse the buffer allocated for foundNull.
+		visited := ht.ProbeScratch.foundNull
 		copy(visited, colexecutils.ZeroBoolColumn)
 		distinctCount := 0
 		for i := 0; i < batchLength && distinctCount < batchLength; i++ {
@@ -5124,8 +5142,8 @@ func (ht *HashTable) updateSel(b coldata.Batch) {
 		hashBuffer := ht.ProbeScratch.HashBuffer
 		_ = HeadIDs[batchLength-1]
 		_ = hashBuffer[batchLength-1]
-		// Reuse the buffer allocated for distinct.
-		visited := ht.ProbeScratch.distinct
+		// Reuse the buffer allocated for foundNull.
+		visited := ht.ProbeScratch.foundNull
 		copy(visited, colexecutils.ZeroBoolColumn)
 		distinctCount := 0
 		for i := 0; i < batchLength && distinctCount < batchLength; i++ {

--- a/pkg/sql/colexec/colexechash/hashtable_full_default.eg.go
+++ b/pkg/sql/colexec/colexechash/hashtable_full_default.eg.go
@@ -5431,3 +5431,15 @@ func (ht *HashTable) checkCol(
 		}
 	}
 }
+
+// execgen:inline
+const _ = "inlined_findBuckets_true"
+
+// execgen:inline
+const _ = "inlined_findBuckets_false"
+
+// execgen:inline
+const _ = "inlined_handleNextToCheckID_true"
+
+// execgen:inline
+const _ = "inlined_handleNextToCheckID_false"

--- a/pkg/sql/colexec/colexechash/hashtable_full_default.eg.go
+++ b/pkg/sql/colexec/colexechash/hashtable_full_default.eg.go
@@ -5433,13 +5433,37 @@ func (ht *HashTable) checkCol(
 }
 
 // execgen:inline
-const _ = "inlined_findBuckets_true"
+const _ = "inlined_findBuckets_true_true"
 
 // execgen:inline
-const _ = "inlined_findBuckets_false"
+const _ = "inlined_findBuckets_true_false"
 
 // execgen:inline
-const _ = "inlined_handleNextToCheckID_true"
+const _ = "inlined_findBuckets_false_true"
 
 // execgen:inline
-const _ = "inlined_handleNextToCheckID_false"
+const _ = "inlined_findBuckets_false_false"
+
+// execgen:inline
+const _ = "inlined_handleNextToCheckID_true_true_true"
+
+// execgen:inline
+const _ = "inlined_handleNextToCheckID_true_true_false"
+
+// execgen:inline
+const _ = "inlined_handleNextToCheckID_true_false_true"
+
+// execgen:inline
+const _ = "inlined_handleNextToCheckID_true_false_false"
+
+// execgen:inline
+const _ = "inlined_handleNextToCheckID_false_true_true"
+
+// execgen:inline
+const _ = "inlined_handleNextToCheckID_false_true_false"
+
+// execgen:inline
+const _ = "inlined_handleNextToCheckID_false_false_true"
+
+// execgen:inline
+const _ = "inlined_handleNextToCheckID_false_false_false"

--- a/pkg/sql/colexec/colexechash/hashtable_full_deleting.eg.go
+++ b/pkg/sql/colexec/colexechash/hashtable_full_deleting.eg.go
@@ -6067,3 +6067,15 @@ func (ht *HashTable) Check(probeVecs []coldata.Vec, nToCheck uint64, probeSel []
 	}
 	return nDiffers
 }
+
+// execgen:inline
+const _ = "inlined_findBuckets_true"
+
+// execgen:inline
+const _ = "inlined_findBuckets_false"
+
+// execgen:inline
+const _ = "inlined_handleNextToCheckID_true"
+
+// execgen:inline
+const _ = "inlined_handleNextToCheckID_false"

--- a/pkg/sql/colexec/colexechash/hashtable_full_deleting.eg.go
+++ b/pkg/sql/colexec/colexechash/hashtable_full_deleting.eg.go
@@ -6069,13 +6069,37 @@ func (ht *HashTable) Check(probeVecs []coldata.Vec, nToCheck uint64, probeSel []
 }
 
 // execgen:inline
-const _ = "inlined_findBuckets_true"
+const _ = "inlined_findBuckets_true_true"
 
 // execgen:inline
-const _ = "inlined_findBuckets_false"
+const _ = "inlined_findBuckets_true_false"
 
 // execgen:inline
-const _ = "inlined_handleNextToCheckID_true"
+const _ = "inlined_findBuckets_false_true"
 
 // execgen:inline
-const _ = "inlined_handleNextToCheckID_false"
+const _ = "inlined_findBuckets_false_false"
+
+// execgen:inline
+const _ = "inlined_handleNextToCheckID_true_true_true"
+
+// execgen:inline
+const _ = "inlined_handleNextToCheckID_true_true_false"
+
+// execgen:inline
+const _ = "inlined_handleNextToCheckID_true_false_true"
+
+// execgen:inline
+const _ = "inlined_handleNextToCheckID_true_false_false"
+
+// execgen:inline
+const _ = "inlined_handleNextToCheckID_false_true_true"
+
+// execgen:inline
+const _ = "inlined_handleNextToCheckID_false_true_false"
+
+// execgen:inline
+const _ = "inlined_handleNextToCheckID_false_false_true"
+
+// execgen:inline
+const _ = "inlined_handleNextToCheckID_false_false_false"

--- a/pkg/sql/colexec/colexechash/hashtable_tmpl.go
+++ b/pkg/sql/colexec/colexechash/hashtable_tmpl.go
@@ -678,4 +678,42 @@ func (ht *HashTable) updateSel(b coldata.Batch) {
 	}
 }
 
+// FindBuckets finds the buckets for all tuples in batch when probing against a
+// hash table that is specified by 'first' and 'next' vectors as well as
+// 'duplicatesChecker'. `duplicatesChecker` takes a slice of key columns of the
+// batch, number of tuples to check, and the selection vector of the batch, and
+// it returns number of tuples that needs to be checked for next iteration.
+// The "buckets" are specified by equal values in ht.ProbeScratch.HeadID.
+// NOTE: *first* and *next* vectors should be properly populated.
+// NOTE: batch is assumed to be non-zero length.
+func (ht *HashTable) FindBuckets(
+	batch coldata.Batch,
+	keyCols []coldata.Vec,
+	first, next []keyID,
+	duplicatesChecker func([]coldata.Vec, uint64, []int) uint64,
+) {
+	batchLength := batch.Length()
+	sel := batch.Selection()
+
+	ht.ProbeScratch.SetupLimitedSlices(batchLength, ht.BuildMode)
+	// Early bounds checks.
+	toCheckIDs := ht.ProbeScratch.ToCheckID
+	_ = toCheckIDs[batchLength-1]
+	for i, hash := range ht.ProbeScratch.HashBuffer[:batchLength] {
+		f := first[hash]
+		//gcassert:bce
+		toCheckIDs[i] = f
+	}
+	copy(ht.ProbeScratch.ToCheck, HashTableInitialToCheck[:batchLength])
+
+	for nToCheck := uint64(batchLength); nToCheck > 0; {
+		// Continue searching for the build table matching keys while the ToCheck
+		// array is non-empty.
+		nToCheck = duplicatesChecker(keyCols, nToCheck, sel)
+		for _, toCheck := range ht.ProbeScratch.ToCheck[:nToCheck] {
+			ht.ProbeScratch.ToCheckID[toCheck] = next[ht.ProbeScratch.ToCheckID[toCheck]]
+		}
+	}
+}
+
 // {{end}}

--- a/pkg/sql/colexec/colexecjoin/hashjoiner.go
+++ b/pkg/sql/colexec/colexecjoin/hashjoiner.go
@@ -570,7 +570,11 @@ func (hj *hashJoiner) exec() coldata.Batch {
 				// buckets. If the key is found or end of next chain is reached, the key is
 				// removed from the ToCheck array.
 				nToCheck = hj.ht.DistinctCheck(nToCheck, sel)
-				hj.ht.FindNext(hj.ht.BuildScratch.Next, nToCheck)
+				// TODO(yuzefovich): check whether we can omit the 'toCheck'
+				// tuple if the new ToCheckID is 0.
+				for _, toCheck := range hj.ht.ProbeScratch.ToCheck[:nToCheck] {
+					hj.ht.ProbeScratch.ToCheckID[toCheck] = hj.ht.BuildScratch.Next[hj.ht.ProbeScratch.ToCheckID[toCheck]]
+				}
 			}
 
 			nResults = hj.distinctCollect(batch, batchSize, sel)
@@ -579,7 +583,11 @@ func (hj *hashJoiner) exec() coldata.Batch {
 				// Continue searching for the build table matching keys while the ToCheck
 				// array is non-empty.
 				nToCheck = hj.ht.Check(hj.ht.Keys, nToCheck, sel)
-				hj.ht.FindNext(hj.ht.BuildScratch.Next, nToCheck)
+				// TODO(yuzefovich): check whether we can omit the 'toCheck'
+				// tuple if the new ToCheckID is 0.
+				for _, toCheck := range hj.ht.ProbeScratch.ToCheck[:nToCheck] {
+					hj.ht.ProbeScratch.ToCheckID[toCheck] = hj.ht.BuildScratch.Next[hj.ht.ProbeScratch.ToCheckID[toCheck]]
+				}
 			}
 
 			// We're processing a new batch, so we'll reset the index to start

--- a/pkg/sql/colexec/distinct_test.go
+++ b/pkg/sql/colexec/distinct_test.go
@@ -392,9 +392,11 @@ func TestDistinct(t *testing.T) {
 	for _, tc := range distinctTestCases {
 		log.Infof(context.Background(), "unordered")
 		tc.runTests(t, colexectestutils.OrderedVerifier, func(input []colexecop.Operator) (colexecop.Operator, error) {
-			return NewUnorderedDistinct(
+			ud := NewUnorderedDistinct(
 				testAllocator, input[0], tc.distinctCols, tc.typs, tc.nullsAreDistinct, tc.errorOnDup,
-			), nil
+			)
+			ud.(*UnorderedDistinct).hashTableNumBuckets = uint64(1 + rng.Intn(7))
+			return ud, nil
 		})
 		if tc.isOrderedOnDistinctCols {
 			for numOrderedCols := 1; numOrderedCols < len(tc.distinctCols); numOrderedCols++ {
@@ -442,7 +444,9 @@ func TestUnorderedDistinctRandom(t *testing.T) {
 	tups, expected := generateRandomDataForUnorderedDistinct(rng, nTuples, nCols, newTupleProbability)
 	colexectestutils.RunTestsWithTyps(t, testAllocator, []colexectestutils.Tuples{tups}, [][]*types.T{typs}, expected, colexectestutils.UnorderedVerifier,
 		func(input []colexecop.Operator) (colexecop.Operator, error) {
-			return NewUnorderedDistinct(testAllocator, input[0], distinctCols, typs, false /* nullsAreDistinct */, "" /* errorOnDup */), nil
+			ud := NewUnorderedDistinct(testAllocator, input[0], distinctCols, typs, false /* nullsAreDistinct */, "" /* errorOnDup */)
+			ud.(*UnorderedDistinct).hashTableNumBuckets = uint64(1 + rng.Intn(7))
+			return ud, nil
 		},
 	)
 }

--- a/pkg/sql/colexec/execgen/cmd/execgen/hashtable_gen.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/hashtable_gen.go
@@ -108,9 +108,9 @@ func genHashTable(inputFileContents string, wr io.Writer, htm hashTableMode) err
 		`{{template "checkColFunctionTemplate" buildDict "Global" . "SelectDistinct" $1 "ProbingAgainstItself" $2 "DeletingProbeMode" $3}}`,
 	)
 
-	checkBody := makeFunctionRegex("_CHECK_BODY", 3)
+	checkBody := makeFunctionRegex("_CHECK_BODY", 4)
 	s = checkBody.ReplaceAllString(s,
-		`{{template "checkBody" buildDict "Global" . "SelectSameTuples" $1 "DeletingProbeMode" $2 "SelectDistinct" $3}}`,
+		`{{template "checkBody" buildDict "Global" . "SelectSameTuples" $1 "DeletingProbeMode" $2 "SelectDistinct" $3 "AllowNullEquality" $4}}`,
 	)
 
 	updateSelBody := makeFunctionRegex("_UPDATE_SEL_BODY", 1)

--- a/pkg/sql/colexec/hash_aggregator.go
+++ b/pkg/sql/colexec/hash_aggregator.go
@@ -349,7 +349,7 @@ func (op *hashAggregator) onlineAgg(b coldata.Batch) {
 	op.ht.ComputeHashAndBuildChains(b)
 	op.ht.FindBuckets(
 		b, op.ht.Keys, op.ht.ProbeScratch.First, op.ht.ProbeScratch.Next, op.ht.CheckProbeForDistinct,
-		false, /* zeroHeadIDForDistinctTuple */
+		false /* zeroHeadIDForDistinctTuple */, true, /* probingAgainstItself */
 	)
 
 	// Step 2: now that we have op.ht.ProbeScratch.HeadID populated we can
@@ -372,7 +372,7 @@ func (op *hashAggregator) onlineAgg(b coldata.Batch) {
 		const zeroHeadIDForDistinctTuple = true
 		op.ht.FindBuckets(
 			b, op.ht.Keys, op.ht.BuildScratch.First, op.ht.BuildScratch.Next, op.ht.CheckBuildForAggregation,
-			zeroHeadIDForDistinctTuple,
+			zeroHeadIDForDistinctTuple, false, /* probingAgainstItself */
 		)
 		for eqChainsSlot, HeadID := range op.ht.ProbeScratch.HeadID[:eqChainsCount] {
 			if HeadID != 0 {

--- a/pkg/sql/colexec/hash_aggregator.go
+++ b/pkg/sql/colexec/hash_aggregator.go
@@ -111,7 +111,8 @@ type hashAggregator struct {
 	buckets []*aggBucket
 	// ht stores tuples that are "heads" of the corresponding aggregation
 	// groups ("head" here means the tuple that was first seen from the group).
-	ht *colexechash.HashTable
+	ht                  *colexechash.HashTable
+	hashTableNumBuckets uint64
 
 	// state stores the current state of hashAggregator.
 	state hashAggregatorState
@@ -204,17 +205,24 @@ func NewHashAggregator(
 	if err != nil {
 		colexecerror.InternalError(err)
 	}
+	// This number was chosen after running the micro-benchmarks and relevant
+	// TPCH queries using tpchvec/bench.
+	hashTableNumBuckets := uint64(256)
+	if args.TestingKnobs.HashTableNumBuckets != 0 {
+		hashTableNumBuckets = args.TestingKnobs.HashTableNumBuckets
+	}
 	hashAgg := &hashAggregator{
-		OneInputNode:       colexecop.NewOneInputNode(args.Input),
-		hashTableAllocator: args.HashTableAllocator,
-		spec:               args.Spec,
-		state:              hashAggregatorBuffering,
-		inputTypes:         args.InputTypes,
-		outputTypes:        args.OutputTypes,
-		inputArgsConverter: inputArgsConverter,
-		toClose:            toClose,
-		aggFnsAlloc:        aggFnsAlloc,
-		hashAlloc:          aggBucketAlloc{allocator: args.Allocator},
+		OneInputNode:        colexecop.NewOneInputNode(args.Input),
+		hashTableAllocator:  args.HashTableAllocator,
+		spec:                args.Spec,
+		state:               hashAggregatorBuffering,
+		inputTypes:          args.InputTypes,
+		outputTypes:         args.OutputTypes,
+		inputArgsConverter:  inputArgsConverter,
+		toClose:             toClose,
+		aggFnsAlloc:         aggFnsAlloc,
+		hashAlloc:           aggBucketAlloc{allocator: args.Allocator},
+		hashTableNumBuckets: hashTableNumBuckets,
 	}
 	hashAgg.accountingHelper.Init(args.OutputUnlimitedAllocator, args.MaxOutputBatchMemSize, args.OutputTypes, false /* alwaysReallocate */)
 	hashAgg.bufferingState.tuples = colexecutils.NewAppendOnlyBufferedBatch(args.Allocator, args.InputTypes, nil /* colsToStore */)
@@ -237,15 +245,14 @@ func (op *hashAggregator) Init(ctx context.Context) {
 		return
 	}
 	op.Input.Init(op.Ctx)
-	// These numbers were chosen after running the micro-benchmarks and relevant
+	// This number was chosen after running the micro-benchmarks and relevant
 	// TPCH queries using tpchvec/bench.
 	const hashTableLoadFactor = 0.1
-	const hashTableNumBuckets = 256
 	op.ht = colexechash.NewHashTable(
 		op.Ctx,
 		op.hashTableAllocator,
 		hashTableLoadFactor,
-		hashTableNumBuckets,
+		op.hashTableNumBuckets,
 		op.inputTypes,
 		op.spec.GroupCols,
 		true, /* allowNullEquality */
@@ -342,6 +349,7 @@ func (op *hashAggregator) onlineAgg(b coldata.Batch) {
 	op.ht.ComputeHashAndBuildChains(b)
 	op.ht.FindBuckets(
 		b, op.ht.Keys, op.ht.ProbeScratch.First, op.ht.ProbeScratch.Next, op.ht.CheckProbeForDistinct,
+		false, /* zeroHeadIDForDistinctTuple */
 	)
 
 	// Step 2: now that we have op.ht.ProbeScratch.HeadID populated we can
@@ -359,8 +367,12 @@ func (op *hashAggregator) onlineAgg(b coldata.Batch) {
 	// the equality chains (which the selection vector on b currently contains)
 	// against the heads of the existing groups.
 	if len(op.buckets) > 0 {
+		// Here we want for each equality chain that doesn't have a match with
+		// already existing groups have its HeadID value set to 0.
+		const zeroHeadIDForDistinctTuple = true
 		op.ht.FindBuckets(
 			b, op.ht.Keys, op.ht.BuildScratch.First, op.ht.BuildScratch.Next, op.ht.CheckBuildForAggregation,
+			zeroHeadIDForDistinctTuple,
 		)
 		for eqChainsSlot, HeadID := range op.ht.ProbeScratch.HeadID[:eqChainsCount] {
 			if HeadID != 0 {

--- a/pkg/sql/colexec/unordered_distinct.go
+++ b/pkg/sql/colexec/unordered_distinct.go
@@ -38,6 +38,8 @@ func NewUnorderedDistinct(
 		typs:                 typs,
 		nullsAreDistinct:     nullsAreDistinct,
 		UpsertDistinctHelper: colexecbase.UpsertDistinctHelper{ErrorOnDup: errorOnDup},
+		// This number was chosen after running the micro-benchmarks.
+		hashTableNumBuckets: 128,
 	}
 }
 
@@ -55,7 +57,8 @@ type UnorderedDistinct struct {
 	typs               []*types.T
 	nullsAreDistinct   bool
 
-	Ht *colexechash.HashTable
+	Ht                  *colexechash.HashTable
+	hashTableNumBuckets uint64
 	// lastInputBatch tracks the last input batch read from the input and not
 	// emitted into the output. It is the only batch that we need to export when
 	// spilling to disk, and it will contain only the distinct tuples that need
@@ -75,14 +78,13 @@ func (op *UnorderedDistinct) Init(ctx context.Context) {
 		return
 	}
 	op.Input.Init(op.Ctx)
-	// These numbers were chosen after running the micro-benchmarks.
+	// This number was chosen after running the micro-benchmarks.
 	const hashTableLoadFactor = 2.0
-	const hashTableNumBuckets = 128
 	op.Ht = colexechash.NewHashTable(
 		op.Ctx,
 		op.hashTableAllocator,
 		hashTableLoadFactor,
-		hashTableNumBuckets,
+		op.hashTableNumBuckets,
 		op.typs,
 		op.distinctCols,
 		!op.nullsAreDistinct, /* allowNullEquality */


### PR DESCRIPTION
This PR contains several commits that refactor the hash table a bit with the main goal of not accessing `hashTableProbeBuffer.distinct` slice (now named `foundNull`) from the hash aggregator. This is a nice-to-have cleanup for the vectorized hash group joiner. Last commit optimizes the code a bit. The benchmarks of `colexec` [package](https://gist.github.com/yuzefovich/98c4bd6766eb9ee95bc3b13949905c85) show mixed results, but mostly positive improvements (ignore benches unrelated to hash aggregator and unordered distinct).

Epic: None

Release note: None