### PR TITLE
sqlsmith: add support for creating udfs

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -903,7 +903,7 @@ func TestChangefeedRandomExpressions(t *testing.T) {
 			sqlsmith.DisableAggregateFuncs(),
 			sqlsmith.DisableWindowFuncs(),
 			sqlsmith.DisableJoins(),
-			sqlsmith.DisableLimits(),
+			sqlsmith.DisableUDFs(),
 			sqlsmith.DisableIndexHints(),
 			sqlsmith.SetScalarComplexity(0.5),
 			sqlsmith.SetComplexity(0.5),
@@ -6538,7 +6538,7 @@ func TestChangefeedBackfillCheckpoint(t *testing.T) {
 		progress := loadProgress()
 		require.NotNil(t, progress.GetChangefeed())
 		h := progress.GetHighWater()
-		noHighWater := (h == nil || h.IsEmpty())
+		noHighWater := h == nil || h.IsEmpty()
 		require.True(t, noHighWater)
 
 		jobCheckpoint := progress.GetChangefeed().Checkpoint

--- a/pkg/internal/sqlsmith/sqlsmith.go
+++ b/pkg/internal/sqlsmith/sqlsmith.go
@@ -104,6 +104,7 @@ type Smither struct {
 	disableInsertSelect        bool
 	disableDivision            bool
 	disableDecimals            bool
+	disableUDFs                bool
 
 	bulkSrv     *httptest.Server
 	bulkFiles   map[string][]byte
@@ -503,6 +504,11 @@ var DisableDivision = simpleOption("disable division", func(s *Smither) {
 // DisableDecimals disables use of decimal type columns in the query.
 var DisableDecimals = simpleOption("disable decimals", func(s *Smither) {
 	s.disableDecimals = true
+})
+
+// DisableUDFs causes the Smither to disable user-defined functions.
+var DisableUDFs = simpleOption("disable udfs", func(s *Smither) {
+	s.disableUDFs = true
 })
 
 // CompareMode causes the Smither to generate statements that have


### PR DESCRIPTION
This PR gives sqlsmith the capability to issue `CREATE FUNCTION` commands. It randomly chooses from available and valid function options. It also contains up to 10 `SELECT` statements in the UDF body.

This PR also leaves several TODOs, including support for params, return types other than records, and calling UDFs in queries after they are created.

Epic: CRDB-20370
Informs: #90782

Release note: None