### PR TITLE
opt: reduce allocations in OrderingChoice simplification

### DIFF
--- a/pkg/sql/opt/colset.go
+++ b/pkg/sql/opt/colset.go
@@ -63,6 +63,9 @@ func (s *ColSet) Add(col ColumnID) {
 // Remove removes a column from the set. No-op if the column is not in the set.
 func (s *ColSet) Remove(col ColumnID) { s.set.Remove(setVal(col)) }
 
+// KeepOne removes all but one column from the set. No-op if the set is empty.
+func (s *ColSet) KeepOne() { s.set.KeepOne() }
+
 // Contains returns true if the set contains the column.
 func (s ColSet) Contains(col ColumnID) bool { return s.set.Contains(setVal(col)) }
 

--- a/pkg/sql/opt/props/func_dep.go
+++ b/pkg/sql/opt/props/func_dep.go
@@ -723,6 +723,12 @@ func (f *FuncDepSet) ComputeEquivClosureNoCopy(cols opt.ColSet) opt.ColSet {
 	return cols
 }
 
+// ComputeEquivGroup returns the group of columns that are equivalent to the
+// given column. See ComputeEquivClosure for more details.
+func (f *FuncDepSet) ComputeEquivGroup(rep opt.ColumnID) opt.ColSet {
+	return f.ComputeEquivClosureNoCopy(opt.MakeColSet(rep))
+}
+
 // AddStrictKey adds an FD for a new key. The given key columns are reduced to a
 // candidate key, and that becomes the determinant for the allCols column set.
 // The resulting FD is strict, meaning that a NULL key value always maps to the
@@ -1552,12 +1558,6 @@ func (f *FuncDepSet) EquivReps() opt.ColSet {
 		}
 	}
 	return reps
-}
-
-// ComputeEquivGroup returns the group of columns that are equivalent to the
-// given column. See ComputeEquivClosure for more details.
-func (f *FuncDepSet) ComputeEquivGroup(rep opt.ColumnID) opt.ColSet {
-	return f.ComputeEquivClosureNoCopy(opt.MakeColSet(rep))
 }
 
 // ensureKeyClosure checks whether the closure for this FD set's key (if there

--- a/pkg/sql/opt/props/func_dep.go
+++ b/pkg/sql/opt/props/func_dep.go
@@ -792,6 +792,27 @@ func (f *FuncDepSet) ComputeEquivGroup(rep opt.ColumnID) opt.ColSet {
 	return f.ComputeEquivClosureNoCopy(opt.MakeColSet(rep))
 }
 
+// ComputeEquivGroupAndUnionWith is similar to ComputeEquivGroup, but modifies
+// the given set in place by adding the columns that are in the same equivalence
+// closure of the given column. The give column is always adding to the set.
+func (f *FuncDepSet) ComputeEquivGroupAndUnionWith(cols opt.ColSet, col opt.ColumnID) opt.ColSet {
+	// Don't need to get transitive closure, because equivalence closures are
+	// already maintained for every column.
+	for i := range f.deps {
+		fd := &f.deps[i]
+		if !fd.equiv {
+			continue
+		}
+		fromIsSubset := fd.from.Empty() || (fd.from.Len() == 1 && fd.from.Contains(col))
+		toIsSubset := fd.to.Empty() || (fd.to.Len() == 1 && fd.to.Contains(col))
+		if fromIsSubset && !toIsSubset {
+			cols.UnionWith(fd.to)
+		}
+	}
+	cols.Add(col)
+	return cols
+}
+
 // AddStrictKey adds an FD for a new key. The given key columns are reduced to a
 // candidate key, and that becomes the determinant for the allCols column set.
 // The resulting FD is strict, meaning that a NULL key value always maps to the

--- a/pkg/sql/opt/props/func_dep.go
+++ b/pkg/sql/opt/props/func_dep.go
@@ -658,7 +658,14 @@ func (f *FuncDepSet) InClosureOf(cols, in opt.ColSet) bool {
 // columns. Therefore, if two rows have the same value for (a), then the rows
 // will be duplicates, since all other columns will be equal.
 func (f *FuncDepSet) ComputeClosure(cols opt.ColSet) opt.ColSet {
-	cols = cols.Copy()
+	return f.ComputeClosureNoCopy(cols.Copy())
+}
+
+// ComputeClosureNoCopy is similar to ComputeClosure, but computes the closure
+// in-place (e.g. the argument ColSet will be mutated). It should only be used
+// when it is ok to mutate the argument. This avoids allocations when columns
+// overflow the small set of intsets.Fast.
+func (f *FuncDepSet) ComputeClosureNoCopy(cols opt.ColSet) opt.ColSet {
 	for i := 0; i < len(f.deps); i++ {
 		fd := &f.deps[i]
 

--- a/pkg/sql/opt/props/ordering_choice.go
+++ b/pkg/sql/opt/props/ordering_choice.go
@@ -657,12 +657,15 @@ func (oc *OrderingChoice) AppendCol(id opt.ColumnID, descending bool) {
 }
 
 // Copy returns a complete copy of this instance, with a private version of the
-// ordering column array.
+// ordering column slice.
 func (oc *OrderingChoice) Copy() OrderingChoice {
 	var other OrderingChoice
 	other.Optional = oc.Optional.Copy()
 	other.Columns = make([]OrderingColumnChoice, len(oc.Columns))
 	copy(other.Columns, oc.Columns)
+	for i := range other.Columns {
+		other.Columns[i].Group = other.Columns[i].Group.Copy()
+	}
 	return other
 }
 

--- a/pkg/sql/opt/props/ordering_choice.go
+++ b/pkg/sql/opt/props/ordering_choice.go
@@ -737,7 +737,7 @@ func (oc *OrderingChoice) CanSimplify(fdset *FuncDepSet) bool {
 func (oc *OrderingChoice) Simplify(fdset *FuncDepSet) {
 	oc.Optional = fdset.ComputeClosure(oc.Optional)
 
-	closure := oc.Optional
+	closure := oc.Optional.Copy()
 	n := 0
 	for i := range oc.Columns {
 		group := &oc.Columns[i]
@@ -763,8 +763,10 @@ func (oc *OrderingChoice) Simplify(fdset *FuncDepSet) {
 		group.Group = fdset.ComputeEquivGroup(group.AnyID())
 
 		// Add this group's columns and find closure with the new columns.
-		closure = closure.Union(group.Group)
-		closure = fdset.ComputeClosure(closure)
+		closure.UnionWith(group.Group)
+		// ComputeClosureNoCopy is safe here because closure was already copied
+		// before the loop.
+		closure = fdset.ComputeClosureNoCopy(closure)
 
 		if n != i {
 			oc.Columns[n] = oc.Columns[i]

--- a/pkg/sql/opt/props/ordering_choice.go
+++ b/pkg/sql/opt/props/ordering_choice.go
@@ -764,7 +764,8 @@ func (oc *OrderingChoice) Simplify(fdset *FuncDepSet) {
 		// Set group to columns equivalent to an arbitrary column in the group
 		// based on the FD set. This can both add and remove columns from the
 		// group.
-		group.Group = fdset.ComputeEquivGroup(group.AnyID())
+		group.Group.KeepOne()
+		group.Group = fdset.ComputeEquivClosureNoCopy(group.Group)
 
 		// Add this group's columns and find closure with the new columns.
 		closure.UnionWith(group.Group)

--- a/pkg/sql/opt/props/ordering_choice.go
+++ b/pkg/sql/opt/props/ordering_choice.go
@@ -708,8 +708,7 @@ func (oc *OrderingChoice) CanSimplify(fdset *FuncDepSet) bool {
 		}
 
 		// Add this group's columns and find closure with new columns.
-		equiv := fdset.ComputeEquivGroup(group.AnyID())
-		closure.UnionWith(equiv)
+		closure = fdset.ComputeEquivGroupAndUnionWith(closure, group.AnyID())
 		// ComputeClosureNoCopy is safe here because of the implicit copy in the
 		// ComputeClosure above.
 		closure = fdset.ComputeClosureNoCopy(closure)

--- a/pkg/util/intsets/fast.go
+++ b/pkg/util/intsets/fast.go
@@ -93,6 +93,32 @@ func (s *Fast) Remove(i int) {
 	}
 }
 
+// KeepOne removes all but one integer in the set. No-op if the set is empty.
+// This implementation will keep the minimum integer in the range [0, 128), if
+// one exists. If not, it will keep the minimum integer in the set.
+func (s *Fast) KeepOne() {
+	if s.Empty() {
+		return
+	}
+	if s.small == (bitmap{}) {
+		// The large set must have at least one integer if the entire set is
+		// non-empty and the small set is empty.
+		s.large.KeepOne()
+		return
+	}
+	// If the small set is non-empty, remove all but one integer.
+	i, ok := s.small.Next(0)
+	if !ok {
+		panic(errors.AssertionFailedf("expected non-empty bitmap"))
+	}
+	s.small = bitmap{}
+	s.small.Set(i)
+	if s.large != nil {
+		// Clear the large set.
+		s.large.Clear()
+	}
+}
+
 // Contains returns true if the set contains the value.
 func (s Fast) Contains(i int) bool {
 	if i >= 0 && i < smallCutoff {

--- a/pkg/util/intsets/fast_test.go
+++ b/pkg/util/intsets/fast_test.go
@@ -45,6 +45,14 @@ func TestFast(t *testing.T) {
 						in[v] = false
 						s.Remove(v)
 					}
+					if rng.Intn(50) == 0 {
+						// KeepOne operation infrequently.
+						keepOne(in)
+						s.KeepOne()
+						if s.Len() > 1 {
+							t.Fatalf("expected set to have length 0 or 1, has %d", s.Len())
+						}
+					}
 					empty := true
 					for j := minVal; j < maxVal; j++ {
 						empty = empty && !in[j]
@@ -326,4 +334,34 @@ func TestFastString(t *testing.T) {
 			}
 		})
 	}
+}
+
+// keepOne mimics Fast.KeepOne.
+func keepOne(in map[int]bool) {
+	preferred := func(x int) bool {
+		return x >= 0 && x < smallCutoff
+	}
+	min := MaxInt
+	empty := true
+	for k, b := range in {
+		if !b {
+			continue
+		}
+		empty = false
+		switch {
+		case preferred(k) && preferred(min) && k < min:
+			min = k
+		case preferred(k) && !preferred(min):
+			min = k
+		case !preferred(k) && preferred(min):
+			// no-op
+		case k < min:
+			min = k
+		}
+		in[k] = false
+	}
+	if empty {
+		return
+	}
+	in[min] = true
 }

--- a/pkg/util/intsets/oracle.go
+++ b/pkg/util/intsets/oracle.go
@@ -34,6 +34,18 @@ func (o *oracle) Remove(i int) {
 	delete(o.m, i)
 }
 
+// KeepOne removes all but one integer in the set. No-op if the set is empty.
+// This implementation happens to keep the minimum integer in the set, which
+// mimics the behavior of Sparse.KeepOne.
+func (o *oracle) KeepOne() {
+	if o.Empty() {
+		return
+	}
+	min := o.LowerBound(MinInt)
+	o.Clear()
+	o.Add(min)
+}
+
 // Contains returns true if the set contains the given integer.
 func (o oracle) Contains(i int) bool {
 	_, ok := o.m[i]

--- a/pkg/util/intsets/sparse.go
+++ b/pkg/util/intsets/sparse.go
@@ -10,6 +10,8 @@
 
 package intsets
 
+import "github.com/cockroachdb/errors"
+
 // Sparse is a set of integers. It is not thread-safe. It must be copied with
 // the Copy method.
 //
@@ -150,6 +152,22 @@ func (s *Sparse) Remove(i int) {
 		}
 		last = sb
 	}
+}
+
+// KeepOne removes all but one integer in the set. No-op if the set is empty.
+// This implementation happens to keep the minimum integer in the set.
+func (s *Sparse) KeepOne() {
+	sb := &s.root
+	if sb.empty() {
+		return
+	}
+	b, ok := sb.bits.Next(0)
+	if !ok {
+		panic(errors.AssertionFailedf("expected non-empty bitmap"))
+	}
+	sb.bits = bitmap{}
+	sb.bits.Set(b)
+	sb.next = nil
 }
 
 // Contains returns true if the set contains the given integer.

--- a/pkg/util/intsets/sparse_test.go
+++ b/pkg/util/intsets/sparse_test.go
@@ -61,10 +61,21 @@ func TestSparse(t *testing.T) {
 						sCopy.Copy(s)
 						s = sCopy
 					case 3:
-						// Clear operation infrequently.
-						if rng.Intn(20) == 0 {
+						switch rng.Intn(20) {
+						case 0:
+							// Clear operation infrequently.
 							o.Clear()
 							s.Clear()
+						case 1:
+							// KeepOne operation infrequently.
+							o.KeepOne()
+							if o.Len() > 1 {
+								t.Fatalf("expected oracle to have length 0 or 1, has %d", o.Len())
+							}
+							s.KeepOne()
+							if s.Len() > 1 {
+								t.Fatalf("expected sparse to have length 0 or 1, has %d", s.Len())
+							}
 						}
 					}
 					validateSparseSet(t, o, s)


### PR DESCRIPTION
#### opt: move ComputeEquivGroup method

This commit moves the `FuncDep.ComputeEquivGroup` method next to other
methods that perform similar computations, making it easier to maintain
them all.

Release note: None

#### opt: reduce intset.Fast allocations in OrderingChoice.Simplify

This commit introduces the `FuncDep.ComputeClosureNoCopy` method which
is similar to `FuncDep.ComputeClosure`, but mutates the given column
set in-place. This helps avoid unnecessary allocations in
`OrderingChoice.Simplify`.

This commit also reduces copying by creating the temporary `closure`
column set with a single copy, and using `UnionWith` (which does not
copy) instead of `Union` (which copies) to add new columns to `closure`.

Release note: None

#### opt: reduce intset.Fast allocations in OrderingChoice.CanSimplify

This commit reduces allocations in `OrderingChoice.CanSimplify` by
introducing two new methods for `FuncDep`: `IsClosureEqual` and
`IsEquivClosureEqual`. These methods return whether or not the closures
will be equal to the given column set, without allocating new column
sets.

This commit also reduces allocations in `OrderingChoice.CanSimplify` by
using `ComputeClosureNoCopy` instead of `ComputeClosure`.

Release note: None

#### intsets: add KeepOne method to Fast and Sparse

This commit adds the `KeepOne` method to `Fast` and `Sparse` which
removes all but one element from the set. The method is a no-op if the
set is empty.

Release note: None

#### opt: copy ordering choice columns

This commit fixes a long-standing bug in `OrderingChoice.Copy` in which
the `Group` columns were not being copied. As far as we now, this has
caused no user-facing bugs, but it does not follow `Copy`'s description
that the new `OrderingChoice` has a "private" version of the ordering
column slice, and column sets shared between `OrderingChoice`s could
lead to future bugs.

Release note: None

#### opt: reduce allocations in OrderingChoice.Simplify with Fast.KeepOne

This commit reduces allocations in `OrderingChoice.Simplify` by reducing
a group's set with `Fast.KeepOne` and passing the set to
`FuncDep.ComputeEquivClosureNoCopy`. This avoids allocations in
`FuncDep.ComputeEquivGroup` when creating singleton sets with
`MakeColSet` when the column ID is outside the range [1, 128].

Release note: None

#### opt: reduce allocations in OrderingChoice.CanSimplify further

This commit further reduces allocations in `OrderingChoice.CanSimplify`
by using a new method `FuncDep` method, `ComputeEquivGroupAndUnionWith`.
This method avoid allocations in `ComputeEquivGroup` when building up a
temporary column set.

Epic: None

Release note (performance improvement): The optimizer now optimizes
query plans with many joins more quickly and uses significantly less
memory while doing so.
