### PR TITLE
build: update pebble BUILD.bazel patch

### DIFF
--- a/build/patches/com_github_cockroachdb_pebble.patch
+++ b/build/patches/com_github_cockroachdb_pebble.patch
@@ -9,3 +9,14 @@ diff -urN a/internal/invariants/BUILD.bazel b/internal/invariants/BUILD.bazel
          "on.go",
          "race_off.go",
          "race_on.go",
+diff -urN a/objstorage/objstorageprovider/objiotracing/BUILD.bazel b/objstorage/objstorageprovider/objiotracing/BUILD.bazel
+--- a/objstorage/objstorageprovider/objiotracing/BUILD.bazel 1969-12-31 19:00:00.000000000 -0500
+--- b/objstorage/objstorageprovider/objiotracing/BUILD.bazel 2023-03-29 09:59:04.529504100 -0700
+@@ -5,6 +5,7 @@
+     srcs = [
+         "obj_io_tracing.go",
+         "obj_io_tracing_off.go",
++        "obj_io_tracing_on.go",
+     ],
+     importpath = "github.com/cockroachdb/pebble/objstorage/objstorageprovider/objiotracing",
+     visibility = ["//visibility:public"],


### PR DESCRIPTION
This change updates the pebble `BUILD.bazel` patch to allow building with the `pebble_obj_io_tracing` tag.

The high-level picture here is that the build process creates `BUILD.bazel` files for all our deps using gazelle. This tool assumes it knows exactly which build tags are true and which aren't (and excludes files entirely based on that).

In our case, we want to allow building with or without the tag (similar to the `invariants` tag). To achieve this, we patch the resulting `BUILD.bazel` files to include `obj_io_tracing_on.go` which gazelle excludes based on the build tags.

Note that the `invariants` tag is handled in the opposite way - we specify in DEPS.bazl that this tag is always on and then we add the `off.go` file via the patch. Both ways are equivalent.

A cleaner solution would be if we could specify to gazelle which tags are "indefinite", but AFAICT this is not currently supported.

The following can be used to build cockroach with pebble obj IO tracing:

```
bazel build //pkg/cmd/cockroach:cockroach --config=with_ui --define gotags=bazel,gss,pebble_obj_io_tracing
cp _bazel/bin/pkg/cmd/cockroach/cockroach_/cockroach ./cockroach
```

Epic: none
Release note: None