### PR TITLE
gc: add explicit cases for clear range in randomized tests

### DIFF
--- a/pkg/kv/kvserver/gc/gc_random_test.go
+++ b/pkg/kv/kvserver/gc/gc_random_test.go
@@ -36,10 +36,11 @@ import (
 // running randomized GC tests as well as benchmarking new code vs preserved
 // legacy GC.
 type randomRunGCTestSpec struct {
-	ds           distSpec
-	now          hlc.Timestamp
-	ttlSec       int32
-	intentAgeSec int32
+	ds                distSpec
+	now               hlc.Timestamp
+	ttlSec            int32
+	intentAgeSec      int32
+	clearRangeMinKeys int64 // Set to 0 for test default value or -1 to disable.
 }
 
 var (
@@ -186,6 +187,7 @@ func BenchmarkRun(b *testing.B) {
 			CalculateThreshold(spec.now, ttl), RunOptions{
 				IntentAgeThreshold:  intentThreshold,
 				TxnCleanupThreshold: txnCleanupThreshold,
+				ClearRangeMinKeys:   defaultClearRangeMinKeys,
 			},
 			ttl,
 			NoopGCer{},
@@ -271,12 +273,57 @@ func TestNewVsInvariants(t *testing.T) {
 			now: hlc.Timestamp{
 				WallTime: 100 * time.Second.Nanoseconds(),
 			},
+			ttlSec:       10,
+			intentAgeSec: 15,
+			// Reduced clear range sequence to allow key batches to be split at
+			// various boundaries.
+			clearRangeMinKeys: 49,
+		},
+		{
+			ds: someVersionsWithSomeRangeKeys,
+			now: hlc.Timestamp{
+				WallTime: 100 * time.Second.Nanoseconds(),
+			},
+			ttlSec:       10,
+			intentAgeSec: 15,
+			// Disable clear range to reliably engage specific code paths that handle
+			// simplified no-clear-range batching.
+			clearRangeMinKeys: -1,
+		},
+		{
+			ds: someVersionsWithSomeRangeKeys,
+			now: hlc.Timestamp{
+				WallTime: 100 * time.Second.Nanoseconds(),
+			},
 			// Higher TTL means range tombstones between 70 sec and 50 sec are
 			// not removed.
 			ttlSec: 50,
 		},
+		{
+			ds: someVersionsWithSomeRangeKeys,
+			now: hlc.Timestamp{
+				WallTime: 100 * time.Second.Nanoseconds(),
+			},
+			// Higher TTL means range tombstones between 70 sec and 50 sec are
+			// not removed.
+			ttlSec: 50,
+			// Reduced clear range sequence to allow key batches to be split at
+			// various boundaries.
+			clearRangeMinKeys: 10,
+		},
 	} {
-		t.Run(fmt.Sprintf("%v@%v,ttl=%vsec", tc.ds, tc.now, tc.ttlSec), func(t *testing.T) {
+		clearRangeMinKeys := int64(0)
+		switch tc.clearRangeMinKeys {
+		case -1:
+		case 0:
+			// Default value for test.
+			clearRangeMinKeys = 100
+		default:
+			clearRangeMinKeys = tc.clearRangeMinKeys
+		}
+		name := fmt.Sprintf("%v@%v,ttl=%vsec,clearRangeMinKeys=%d", tc.ds, tc.now, tc.ttlSec,
+			clearRangeMinKeys)
+		t.Run(name, func(t *testing.T) {
 			rng, seed := randutil.NewTestRand()
 			t.Logf("Using subtest seed: %d", seed)
 
@@ -298,7 +345,7 @@ func TestNewVsInvariants(t *testing.T) {
 				gcThreshold, RunOptions{
 					IntentAgeThreshold:  intentAgeThreshold,
 					TxnCleanupThreshold: txnCleanupThreshold,
-					ClearRangeMinKeys:   100,
+					ClearRangeMinKeys:   clearRangeMinKeys,
 				}, ttl,
 				&gcer,
 				gcer.resolveIntents,


### PR DESCRIPTION
Previously there was very small chance that clear range requirements are met in randomized gc testing. This commit adds explicit test cases where clear range thresholds set specifically low to ensure test sees different ways of splitting requests into batches.

Release note: None

Touches #98156