### PR TITLE
kv: mark admission epoch lifo verb as safe string

### DIFF
--- a/pkg/util/admission/work_queue.go
+++ b/pkg/util/admission/work_queue.go
@@ -500,7 +500,7 @@ func (q *WorkQueue) tryCloseEpoch(timeNow time.Time) {
 			tenant.fifoPriorityThreshold = int(admissionpb.LowPri)
 		}
 		if tenant.fifoPriorityThreshold != prevThreshold || doLog {
-			logVerb := "is"
+			logVerb := redact.SafeString("is")
 			if tenant.fifoPriorityThreshold != prevThreshold {
 				logVerb = "changed to"
 			}


### PR DESCRIPTION
Avoids log garbage like this:
```
I230411 02:07:26.905045 79 util/admission/work_queue.go:489 â<8b>® [n59] 1861224 â<80>¹sql-kv-responseâ<80>º: FIFO threshold for tenant 1 â<80>¹isâ<80>º -128
```

Epic: None
Release note: None