### PR TITLE
sql/stats: use node user to read stats

### DIFF
--- a/pkg/sql/stats/BUILD.bazel
+++ b/pkg/sql/stats/BUILD.bazel
@@ -46,6 +46,7 @@ go_library(
         "//pkg/sql/rowenc/keyside",
         "//pkg/sql/sem/eval",
         "//pkg/sql/sem/tree",
+        "//pkg/sql/sessiondata",
         "//pkg/sql/sqlerrors",
         "//pkg/sql/types",
         "//pkg/util/cache",

--- a/pkg/sql/stats/stats_cache.go
+++ b/pkg/sql/stats/stats_cache.go
@@ -31,6 +31,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/rowenc"
 	"github.com/cockroachdb/cockroach/pkg/sql/rowenc/keyside"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util/cache"
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
@@ -794,8 +795,8 @@ ORDER BY "createdAt" DESC, "columnIDs" DESC, "statisticID" DESC
 	// TODO(michae2): Add an index on system.table_statistics (tableID, createdAt,
 	// columnIDs, statisticID).
 
-	it, err := sc.db.Executor().QueryIterator(
-		ctx, "get-table-statistics", nil /* txn */, getTableStatisticsStmt, tableID,
+	it, err := sc.db.Executor().QueryIteratorEx(
+		ctx, "get-table-statistics", nil /* txn */, sessiondata.NodeUserSessionDataOverride, getTableStatisticsStmt, tableID,
 	)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
The node user is meant to be used for internal operations like this.

This change is needed because auditing occurs during privilege checking,
but we want to skip auditing for the node user. For most internal
queries, this doesn't actually matter, but this one is special because
the call to get table stats requires a privilege check, and the
privilege check is going to soon start fetching table stats for the
system.role_members table. To avoid an infinite loop, we use the node
user here to short-circuit the query on system.role_members.

Epic: CRDB-7444
Release note: None