### PR TITLE
ui: encode time window in url for metrics charts

### DIFF
--- a/pkg/ui/workspaces/db-console/src/views/cluster/components/linegraph/index.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/cluster/components/linegraph/index.tsx
@@ -228,13 +228,6 @@ export class LineGraph extends React.Component<LineGraphProps, {}> {
     }
     this.props.setMetricsFixedWindow(newTimeWindow);
     this.props.setTimeScale(newTimeScale);
-    const { pathname, search } = this.props.history.location;
-    const urlParams = new URLSearchParams(search);
-
-    this.props.history.push({
-      pathname,
-      search: urlParams.toString(),
-    });
   }
 
   u: uPlot;

--- a/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/index.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/index.tsx
@@ -75,11 +75,8 @@ import {
   selectTimeScale,
 } from "src/redux/timeScale";
 import { InlineAlert } from "src/components";
-import {
-  Anchor,
-  TimeScaleDropdown,
-  TimeScale,
-} from "@cockroachlabs/cluster-ui";
+import TimeScaleDropdown from "../timeScaleDropdownWithSearchParams";
+import { Anchor, TimeScale } from "@cockroachlabs/cluster-ui";
 import { reduceStorageOfTimeSeriesDataOperationalFlags } from "src/util/docs";
 import moment from "moment-timezone";
 import {

--- a/pkg/ui/workspaces/db-console/src/views/cluster/containers/timeScaleDropdownWithSearchParams/index.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/cluster/containers/timeScaleDropdownWithSearchParams/index.tsx
@@ -23,6 +23,7 @@ import {
 } from "@cockroachlabs/cluster-ui";
 import { createSelector } from "reselect";
 import moment from "moment-timezone";
+import { PayloadAction } from "src/interfaces/action";
 
 // The time scale dropdown from cluster-ui that updates route params as
 // options are selected.
@@ -79,39 +80,41 @@ const TimeScaleDropdownWithSearchParams = (
     const urlSearchParams = new URLSearchParams(history.location.search);
     const queryStart = urlSearchParams.get("start");
     const queryEnd = urlSearchParams.get("end");
-    const start = queryStart && moment.unix(Number(queryStart)).utc();
-    const end = queryEnd && moment.unix(Number(queryEnd)).utc();
 
-    setDatesByQueryParams({ start, end });
+    // Only set the timescale if the url params exist.
+    if (queryStart !== null && queryEnd !== null) {
+      const start = queryStart && moment.unix(Number(queryStart)).utc();
+      const end = queryEnd && moment.unix(Number(queryEnd)).utc();
+      setDatesByQueryParams({ start, end });
+    }
+
+    // Passing an empty array of dependencies will cause this effect
+    // to only run on the initial render.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  const setQueryParamsByDates = (
-    duration: moment.Duration,
-    dateEnd: moment.Moment,
-  ) => {
+  const onTimeScaleChange = (timeScale: TimeScale) => {
+    props.setTimeScale(timeScale);
+  };
+
+  useEffect(() => {
+    // When history or props change, this effect will
+    // convert the start and end of the current time scale and
+    // write them to the URL as query params.
+    const duration = props.currentScale.windowSize;
+    const dateEnd = props.currentScale.fixedWindowEnd || moment.utc();
     const { pathname, search } = history.location;
     const urlParams = new URLSearchParams(search);
     const seconds = duration.clone().asSeconds();
     const end = dateEnd.clone();
     const start = moment.utc(end).subtract(seconds, "seconds").format("X");
-
     urlParams.set("start", start);
     urlParams.set("end", moment.utc(dateEnd).format("X"));
-
     history.push({
       pathname,
       search: urlParams.toString(),
     });
-  };
-
-  const onTimeScaleChange = (timeScale: TimeScale) => {
-    props.setTimeScale(timeScale);
-    setQueryParamsByDates(
-      timeScale.windowSize,
-      timeScale.fixedWindowEnd || moment.utc(),
-    );
-  };
+  }, [history, props]);
 
   return <TimeScaleDropdown {...props} setTimeScale={onTimeScaleChange} />;
 };
@@ -121,7 +124,11 @@ const scaleSelector = createSelector(
   tw => tw?.scale,
 );
 
-export default connect(
+export default connect<
+  { currentScale: TimeScale },
+  { setTimeScale: (ts: TimeScale) => PayloadAction<TimeScale> },
+  Partial<TimeScaleDropdownProps>
+>(
   (state: AdminUIState) => ({
     currentScale: scaleSelector(state),
   }),

--- a/pkg/ui/workspaces/db-console/src/views/reports/containers/customChart/index.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/reports/containers/customChart/index.tsx
@@ -22,11 +22,8 @@ import { LineGraph } from "src/views/cluster/components/linegraph";
 import { DropdownOption } from "src/views/shared/components/dropdown";
 import { MetricsDataProvider } from "src/views/shared/containers/metricDataProvider";
 import { Metric, Axis } from "src/views/shared/components/metricQuery";
-import {
-  AxisUnits,
-  TimeScaleDropdown,
-  TimeScale,
-} from "@cockroachlabs/cluster-ui";
+import TimeScaleDropdown from "oss/src/views/cluster/containers/timeScaleDropdownWithSearchParams";
+import { AxisUnits, TimeScale } from "@cockroachlabs/cluster-ui";
 import {
   PageConfig,
   PageConfigItem,


### PR DESCRIPTION
This commit makes URLs to metrics charts more shareable by encoding the time window into the URL.

loom: https://www.loom.com/share/d00c40649bc543f18faf981f80b56e64

Known issues:
1. Navigating to a different metrics category via the dropdown will clear the time window params from the URL. No graph functionality is impaired. This is just an inconvenience for someone trying to share a link. The status quo is that nothing is shareable, so this is fine.

2. The logic to decide if the time window should grow as new data becomes available is based on a heuristic. Therefore, it's possible that a user opens a URL with time window params and expects the window to keep growing but we treat it as a "frozen-in-time" custom selection, or vice-versa.

Resolves #95971
Epic: none
Release note (ui change): The time window selection for metrics charts is now encoded in the URL via query params.