### PR TITLE
backupccl: introduce concurrency to the stats insertion phase of restore

### DIFF
--- a/pkg/ccl/backupccl/backup_test.go
+++ b/pkg/ccl/backupccl/backup_test.go
@@ -5785,18 +5785,46 @@ func TestBackupHandlesDroppedTypeStatsCollection(t *testing.T) {
 	sqlDB.Exec(t, `BACKUP foo TO $1`, dest)
 }
 
+type fakeResumer struct {
+	unblockCh chan struct{}
+	doneCh    chan struct{}
+}
+
+var _ jobs.Resumer = (*fakeResumer)(nil)
+
+func (d *fakeResumer) Resume(ctx context.Context, execCtx interface{}) error {
+	<-d.unblockCh
+	d.doneCh <- struct{}{}
+	return nil
+}
+
+func (d *fakeResumer) OnFailOrCancel(context.Context, interface{}, error) error {
+	return nil
+}
+
 // TestBatchedInsertStats is a test for the `insertStats` method used in a
 // cluster restore to restore backed up statistics.
 func TestBatchedInsertStats(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
+	defer jobs.ResetConstructors()()
 
-	const numAccounts = 1
-	tc, sqlDB, _, cleanupFn := backupRestoreTestSetup(t, singleNode, numAccounts,
-		InitManualReplication)
-	defer cleanupFn()
+	unblockCh := make(chan struct{})
+	doneCh := make(chan struct{})
+	jobs.RegisterConstructor(jobspb.TypeRestore, func(job *jobs.Job, _ *cluster.Settings) jobs.Resumer {
+		return &fakeResumer{
+			unblockCh: unblockCh,
+			doneCh:    doneCh,
+		}
+	}, jobs.UsesTenantCostControl)
+	params := base.TestServerArgs{Knobs: base.TestingKnobs{
+		JobsTestingKnobs: jobs.NewTestingKnobsWithShortIntervals(),
+	}}
+	server, db, _ := serverutils.StartServer(t, params)
+	defer server.Stopper().Stop(context.Background())
+	s := server.TenantOrServer()
+	sqlDB := sqlutils.MakeSQLRunner(db)
 	ctx := context.Background()
-	s := tc.Server(0)
 	execCfg := s.ExecutorConfig().(sql.ExecutorConfig)
 	registry := s.JobRegistry().(*jobs.Registry)
 	mkJob := func(t *testing.T) *jobs.Job {
@@ -5811,6 +5839,7 @@ func TestBatchedInsertStats(t *testing.T) {
 		require.NoError(t, err)
 		return job
 	}
+	job := mkJob(t)
 
 	generateTableStatistics := func(numStats int) []*stats.TableStatisticProto {
 		tableStats := make([]*stats.TableStatisticProto, 0, numStats)
@@ -5850,6 +5879,10 @@ func TestBatchedInsertStats(t *testing.T) {
 			name:          "greater-than-batch-size",
 			numTableStats: 15,
 		},
+		{
+			name:          "greater-than-batch-size-times-concurrent-workers",
+			numTableStats: 100,
+		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			dbName := fmt.Sprintf("foo%d", i)
@@ -5860,17 +5893,27 @@ func TestBatchedInsertStats(t *testing.T) {
 
 			// Clear the stats.
 			sqlDB.Exec(t, `DELETE FROM system.table_statistics WHERE true`)
-			job := mkJob(t)
 			require.NoError(t, insertStats(ctx, job, &execCfg, stats))
 			// If there are no stats to insert, we exit early without updating the
 			// job.
 			if test.numTableStats != 0 {
 				require.True(t, job.Details().(jobspb.RestoreDetails).StatsInserted)
 			}
-			res := sqlDB.QueryStr(t, `SELECT * FROM system.table_statistics`)
-			require.Len(t, res, test.numTableStats)
+			var count int
+			sqlDB.QueryRow(t, `SELECT	count(*) FROM system.table_statistics`).Scan(&count)
+			require.Equal(t, test.numTableStats, count)
+
+			// Reset the job state, for the next iteration of the test.
+			details := job.Details().(jobspb.RestoreDetails)
+			details.StatsInserted = false
+			require.NoError(t, job.NoTxn().SetDetails(ctx, details))
+			var err error
+			job, err = registry.LoadJob(ctx, job.ID())
+			require.NoError(t, err)
 		})
 	}
+	close(unblockCh)
+	<-doneCh
 }
 
 func TestBackupRestoreCorruptedStatsIgnored(t *testing.T) {

--- a/pkg/ccl/backupccl/restore_job.go
+++ b/pkg/ccl/backupccl/restore_job.go
@@ -71,6 +71,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/mon"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 	"github.com/cockroachdb/cockroach/pkg/util/retry"
+	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 	"github.com/cockroachdb/errors"
@@ -78,13 +79,21 @@ import (
 
 // restoreStatsInsertBatchSize is an arbitrarily chosen value of the number of
 // tables we process in a single txn when restoring their table statistics.
-var restoreStatsInsertBatchSize = 10
+const restoreStatsInsertBatchSize = 10
 
 var useSimpleImportSpans = settings.RegisterBoolSetting(
 	settings.TenantWritable,
 	"bulkio.restore.use_simple_import_spans",
 	"if set to true, restore will generate its import spans using the makeSimpleImportSpans algorithm",
 	false,
+)
+
+var restoreStatsInsertionConcurrency = settings.RegisterIntSetting(
+	settings.TenantWritable,
+	"bulkio.restore.insert_stats_workers",
+	"number of concurrent workers that will restore backed up table statistics",
+	5,
+	settings.PositiveInt,
 )
 
 // rewriteBackupSpanKey rewrites a backup span start key for the purposes of
@@ -2009,52 +2018,90 @@ func insertStats(
 	if details.StatsInserted {
 		return nil
 	}
-
-	totalNumBatches := len(latestStats) / restoreStatsInsertBatchSize
-	log.Infof(ctx, "restore will insert %d TableStatistics in %d batches", len(latestStats), totalNumBatches)
-	insertStatsProgress := log.Every(10 * time.Second)
+	if len(latestStats) == 0 {
+		return nil
+	}
 
 	// We could be restoring hundreds of tables, so insert the new stats in
 	// batches instead of all in a single, long-running txn. This prevents intent
 	// buildup in the face of txn retries.
+	batchSize := restoreStatsInsertBatchSize
+	totalNumBatches := len(latestStats) / batchSize
+	if len(latestStats)%batchSize != 0 {
+		totalNumBatches += 1
+	}
+	log.Infof(ctx, "restore will insert %d TableStatistics in %d batches", len(latestStats), totalNumBatches)
+	insertStatsProgress := log.Every(10 * time.Second)
+
+	startingStatsInsertion := timeutil.Now()
+	batchCh := make(chan []*stats.TableStatisticProto, totalNumBatches)
 	for {
 		if len(latestStats) == 0 {
-			return nil
+			break
 		}
-
-		if len(latestStats) < restoreStatsInsertBatchSize {
-			restoreStatsInsertBatchSize = len(latestStats)
+		if len(latestStats) < batchSize {
+			batchSize = len(latestStats)
 		}
-
-		if err := execCfg.InternalDB.Txn(ctx, func(ctx context.Context, txn isql.Txn) error {
-			if err := stats.InsertNewStats(
-				ctx, execCfg.Settings, txn, latestStats[:restoreStatsInsertBatchSize],
-			); err != nil {
-				return errors.Wrapf(err, "inserting stats from backup")
-			}
-
-			// If this is the last batch, mark the stats insertion complete.
-			if restoreStatsInsertBatchSize == len(latestStats) {
-				details.StatsInserted = true
-				if err := job.WithTxn(txn).SetDetails(ctx, details); err != nil {
-					return errors.Wrapf(err, "updating job marking stats insertion complete")
-				}
-				return nil
-			}
-
-			return nil
-		}); err != nil {
-			return err
-		}
+		batchCh <- latestStats[:batchSize]
 
 		// Truncate the stats that we have inserted in the txn above.
-		latestStats = latestStats[restoreStatsInsertBatchSize:]
-
-		if insertStatsProgress.ShouldLog() {
-			remainingBatches := len(latestStats) / restoreStatsInsertBatchSize
-			log.Infof(ctx, "restore has %d/%d TableStatistics batches remaining to insert", remainingBatches, totalNumBatches)
-		}
+		latestStats = latestStats[batchSize:]
 	}
+	close(batchCh)
+
+	logStatsProgress := func(remainingBatches, completedBatches int) {
+		msg := fmt.Sprintf("restore has %d/%d TableStatistics batches remaining to insert",
+			remainingBatches, totalNumBatches)
+		timeSinceStart := int(timeutil.Since(startingStatsInsertion).Seconds())
+		if completedBatches != 0 && timeSinceStart != 0 {
+			rate := completedBatches / timeSinceStart
+			msg = fmt.Sprintf("%s; ingesting at the rate of %d batches/sec", msg, rate)
+		}
+		log.Infof(ctx, "%s", msg)
+	}
+
+	mu := struct {
+		syncutil.Mutex
+		completedBatches int
+	}{}
+	if err := ctxgroup.GroupWorkers(ctx, int(restoreStatsInsertionConcurrency.Get(&execCfg.Settings.SV)),
+		func(ctx context.Context, i int) error {
+			for {
+				select {
+				case <-ctx.Done():
+					return ctx.Err()
+				case b, ok := <-batchCh:
+					if !ok {
+						return nil
+					}
+					if err := execCfg.InternalDB.Txn(ctx, func(ctx context.Context, txn isql.Txn) error {
+						if err := stats.InsertNewStats(
+							ctx, execCfg.Settings, txn, b,
+						); err != nil {
+							return errors.Wrapf(err, "inserting stats from backup")
+						}
+						return nil
+					}); err != nil {
+						return err
+					}
+					mu.Lock()
+					mu.completedBatches++
+					remainingBatches := totalNumBatches - mu.completedBatches
+					completedBatches := mu.completedBatches
+					mu.Unlock()
+					if insertStatsProgress.ShouldLog() {
+						logStatsProgress(remainingBatches, completedBatches)
+					}
+				}
+			}
+		}); err != nil {
+		return errors.Wrap(err, "failed to restore stats")
+	}
+	logStatsProgress(0, totalNumBatches)
+
+	// Mark the stats insertion complete.
+	details.StatsInserted = true
+	return errors.Wrap(job.NoTxn().SetDetails(ctx, details), "updating job marking stats insertion complete")
 }
 
 // publishDescriptors updates the RESTORED descriptors' status from OFFLINE to

--- a/pkg/ccl/backupccl/utils_test.go
+++ b/pkg/ccl/backupccl/utils_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/ccl/backupccl/backupinfo"
 	"github.com/cockroachdb/cockroach/pkg/ccl/backupccl/backuppb"
 	"github.com/cockroachdb/cockroach/pkg/ccl/backupccl/backuptestutils"
+	"github.com/cockroachdb/cockroach/pkg/jobs"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/keyvisualizer"
 	"github.com/cockroachdb/cockroach/pkg/kv"
@@ -82,6 +83,9 @@ func backupRestoreTestSetupWithParams(
 	dir, dirCleanupFn := testutils.TempDir(t)
 	params.ServerArgs.ExternalIODir = dir
 	params.ServerArgs.UseDatabase = "data"
+	if params.ServerArgs.Knobs.JobsTestingKnobs == nil {
+		params.ServerArgs.Knobs.JobsTestingKnobs = jobs.NewTestingKnobsWithShortIntervals()
+	}
 	if len(params.ServerArgsPerNode) > 0 {
 		for i := range params.ServerArgsPerNode {
 			param := params.ServerArgsPerNode[i]
@@ -178,6 +182,9 @@ func backupRestoreTestSetupEmptyWithParams(
 	ctx := logtags.AddTag(context.Background(), "backup-restore-test-setup-empty", nil)
 
 	params.ServerArgs.ExternalIODir = dir
+	if params.ServerArgs.Knobs.JobsTestingKnobs == nil {
+		params.ServerArgs.Knobs.JobsTestingKnobs = jobs.NewTestingKnobsWithShortIntervals()
+	}
 	if len(params.ServerArgsPerNode) > 0 {
 		for i := range params.ServerArgsPerNode {
 			param := params.ServerArgsPerNode[i]

--- a/pkg/jobs/registry.go
+++ b/pkg/jobs/registry.go
@@ -610,7 +610,6 @@ func (r *Registry) CreateJobWithTxn(
 
 		cols := []string{"id", "created", "status", "payload", "progress", "claim_session_id", "claim_instance_id", "job_type"}
 		vals := []interface{}{jobID, created, StatusRunning, payloadBytes, progressBytes, s.ID().UnsafeBytes(), r.ID(), jobType.String()}
-		log.Infof(ctx, "active version is %s", r.settings.Version.ActiveVersion(ctx))
 		if r.settings.Version.IsActive(ctx, clusterversion.V23_1StopWritingPayloadAndProgressToSystemJobs) {
 			cols = []string{"id", "created", "status", "claim_session_id", "claim_instance_id", "job_type"}
 			vals = []interface{}{jobID, created, StatusRunning, s.ID().UnsafeBytes(), r.ID(), jobType.String()}


### PR DESCRIPTION
Previously, restore would insert the backed up batches of table statistics serially. This change spins up 5 workers (by default) to concurrently insert the backed up table statistics. Usually this phase does not take a significant amount of time but we have recently seen a support issue where the accumulation of a large number of stale statistics in the backup, or a large number of descriptors could add a non-trivial tail to the restore. We ahve observed ~29k rows of backed up statistics ingested at the rate of ~70ms per insert adding up to ~30 minutes to the restore even after it has ingested all the backed up user data.

Some experiments on a `BACKUP-STATISTICS` file with ~20k backed up stats rows show the following results:

Serially: ~21 seconds
<img width="1162" alt="Screenshot 2023-04-11 at 10 22 43 PM" src="https://user-images.githubusercontent.com/13837382/231338449-79b6a6cd-da87-4dc1-9bd9-2f81f73b21a8.png">

Concurrently: ~6 seconds
<img width="1214" alt="Screenshot 2023-04-11 at 10 16 17 PM" src="https://user-images.githubusercontent.com/13837382/231338483-6ba931ce-90ac-48bb-acc1-0ad9de9823e6.png">



Fixes: #101053
Release note (performance improvement): adds concurrency to speed up the phase of the restore that ingests backed up table statisitcs