### PR TITLE
colexec: fix seeds in a few benchmarks

### DIFF
--- a/pkg/sql/colexec/aggregators_test.go
+++ b/pkg/sql/colexec/aggregators_test.go
@@ -1017,7 +1017,7 @@ func benchmarkAggregateFunction(
 			return
 		}
 	}
-	rng, _ := randutil.NewTestRand()
+	rng := randutil.NewTestRandWithSeed(17)
 	ctx := context.Background()
 	evalCtx := eval.MakeTestingEvalContext(cluster.MakeTestingClusterSettings())
 	defer evalCtx.Stop(ctx)

--- a/pkg/sql/colexec/and_or_projection_test.go
+++ b/pkg/sql/colexec/and_or_projection_test.go
@@ -234,7 +234,7 @@ func benchmarkLogicalProjOp(
 			Settings: st,
 		},
 	}
-	rng, _ := randutil.NewTestRand()
+	rng := randutil.NewTestRandWithSeed(91)
 
 	batch := testAllocator.NewMemBatchWithMaxCapacity([]*types.T{types.Bool, types.Bool})
 	col1 := batch.ColVec(0).Bool()

--- a/pkg/sql/colexec/distinct_test.go
+++ b/pkg/sql/colexec/distinct_test.go
@@ -472,7 +472,7 @@ func runDistinctBenchmarks(
 	isExternal bool,
 	shuffleInput bool,
 ) {
-	rng, _ := randutil.NewTestRand()
+	rng := randutil.NewTestRandWithSeed(41)
 	const nCols = 2
 	const bytesValueLength = 8
 	distinctCols := []uint32{0, 1}


### PR DESCRIPTION
This commit fixes the seed for benchmarks of logical projection operator (has extremely high variance), distinct (medium variance), and aggregator (low variance) in order to get a more consistent signal.

Epic: None

Release note: None