### PR TITLE
loqrecovery: deflake TestRetrieveApplyStatus

### DIFF
--- a/pkg/kv/kvserver/loqrecovery/server_integration_test.go
+++ b/pkg/kv/kvserver/loqrecovery/server_integration_test.go
@@ -568,7 +568,8 @@ func TestRetrieveApplyStatus(t *testing.T) {
 
 	// Use scratch range to ensure we have a range that loses quorum.
 	sk := tc.ScratchRange(t)
-	require.NoError(t, tc.WaitForFullReplication(), "failed to wait for full replication")
+	require.NoError(t, tc.WaitFor5NodeReplication(),
+		"failed to wait for full replication of 5 node cluster")
 	tc.ToggleReplicateQueues(false)
 	d := tc.LookupRangeOrFatal(t, sk)
 


### PR DESCRIPTION
Test expects fully upreplicated 5 node cluster while TestCluster does not guarantee 5 replica config to propagate and upreplciate before proceeding. This fix adds explicit check during startup to wait appropriate cluster state.

Release note: None

Fixes #98623