### PR TITLE
multitenant: display the dropping state as "dropping" not "drop"

### DIFF
--- a/pkg/multitenant/mtinfopb/info.go
+++ b/pkg/multitenant/mtinfopb/info.go
@@ -81,7 +81,7 @@ func (s TenantDataState) String() string {
 	case DataStateReady:
 		return "ready"
 	case DataStateDrop:
-		return "drop"
+		return "dropping"
 	default:
 		return fmt.Sprintf("unimplemented-%d", int(s))
 	}
@@ -89,9 +89,9 @@ func (s TenantDataState) String() string {
 
 // TenantDataStateValues facilitates the string -> TenantDataState conversion.
 var TenantDataStateValues = map[string]TenantDataState{
-	"add":   DataStateAdd,
-	"ready": DataStateReady,
-	"drop":  DataStateDrop,
+	"add":      DataStateAdd,
+	"ready":    DataStateReady,
+	"dropping": DataStateDrop,
 }
 
 // TenantInfo captures both a ProtoInfo and the SQLInfo columns that


### PR DESCRIPTION
Requested by @ecwall [here](https://github.com/cockroachdb/cockroach/pull/100613#pullrequestreview-1371606851).
Needed for #100613.

This specific data state for secondary tenants indicate that the tenant keyspace is queued for asynchronous deletion by a GC jobs; however, it may not have been deleted yet.

Therefore, the visual representation of that state is best named "dropping" instead of "drop".

Release note: None
Epic: CRDB-23559