### PR TITLE
release-23.1.0: copy: fix copyfrom roachtest session var settings

### DIFF
--- a/pkg/cmd/roachtest/tests/copyfrom.go
+++ b/pkg/cmd/roachtest/tests/copyfrom.go
@@ -13,6 +13,7 @@ package tests
 import (
 	"context"
 	"fmt"
+	"net/url"
 	"runtime"
 	"strings"
 
@@ -127,18 +128,29 @@ func runCopyFromCRDB(ctx context.Context, t test.Test, c cluster.Cluster, sf int
 	initTest(ctx, t, c, sf)
 	db, err := c.ConnE(ctx, t.L(), 1)
 	require.NoError(t, err)
-	stmt := fmt.Sprintf("ALTER ROLE ALL SET copy_from_atomic_enabled = %t", atomic)
-	_, err = db.ExecContext(ctx, stmt)
-	require.NoError(t, err)
+	stmts := []string{
+		"CREATE USER importer",
+		fmt.Sprintf("ALTER ROLE importer SET copy_from_atomic_enabled = %t", atomic),
+	}
+	for _, stmt := range stmts {
+		_, err = db.ExecContext(ctx, stmt)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
 	urls, err := c.InternalPGUrl(ctx, t.L(), c.Node(1), "")
 	require.NoError(t, err)
 	m := c.NewMonitor(ctx, c.All())
 	m.Go(func(ctx context.Context) error {
-		// psql w/ url first are doesn't support --db arg so have to do this.
-		url := strings.Replace(urls[0], "?", "/defaultdb?", 1)
-		c.Run(ctx, c.Node(1), fmt.Sprintf("psql %s -c 'SELECT 1'", url))
-		c.Run(ctx, c.Node(1), fmt.Sprintf("psql %s -c '%s'", url, lineitemSchema))
-		runTest(ctx, t, c, fmt.Sprintf("psql '%s'", url))
+		// psql w/ url first doesn't support --db arg so have to do this.
+		urlstr := strings.Replace(urls[0], "?", "/defaultdb?", 1)
+		u, err := url.Parse(urlstr)
+		require.NoError(t, err)
+		u.User = url.User("importer")
+		urlstr = u.String()
+		c.Run(ctx, c.Node(1), fmt.Sprintf("psql %s -c 'SELECT 1'", urlstr))
+		c.Run(ctx, c.Node(1), fmt.Sprintf("psql %s -c '%s'", urlstr, lineitemSchema))
+		runTest(ctx, t, c, fmt.Sprintf("psql '%s'", urlstr))
 		return nil
 	})
 	m.Wait()


### PR DESCRIPTION
Backport 1/1 commits from #101159.

/cc @cockroachdb/release

---

Need to use a separate user as root user cannot have session vars set
via ALTER ROLE.

Epic: None
Fixes: #101158
Release note: None

Release justification: Test only change

