### PR TITLE
sqlsmith: disable udf generation in some tests

### DIFF
--- a/pkg/ccl/testccl/sqlccl/show_create_test.go
+++ b/pkg/ccl/testccl/sqlccl/show_create_test.go
@@ -116,6 +116,7 @@ func TestShowCreateRedactableValues(t *testing.T) {
 		sqlsmith.PrefixStringConsts(pii),
 		sqlsmith.DisableMutations(),
 		sqlsmith.DisableWith(),
+		sqlsmith.DisableUDFs(),
 	)
 	if err != nil {
 		t.Fatal(err)

--- a/pkg/cmd/roachtest/tests/query_comparison_util.go
+++ b/pkg/cmd/roachtest/tests/query_comparison_util.go
@@ -195,6 +195,7 @@ func runOneRoundQueryComparison(
 		sqlsmith.UnlikelyRandomNulls(), sqlsmith.DisableCrossJoins(),
 		sqlsmith.DisableIndexHints(), sqlsmith.DisableWith(), sqlsmith.DisableDecimals(),
 		sqlsmith.LowProbabilityWhereClauseWithJoinTables(),
+		sqlsmith.DisableUDFs(),
 		sqlsmith.SetComplexity(.3),
 		sqlsmith.SetScalarComplexity(.1),
 	)


### PR DESCRIPTION
We recently added support for `CREATE FUNCTION` to create UDFs in sqlsmith. This PR audits usages of `NewSmither` to disable UDFs in the smither when generating UDFs would not be appropriate for the test.

Epic: None
Issue: None

Release note: None