### PR TITLE
opt: do not attempt to inline empty UDFs

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/udf
+++ b/pkg/sql/logictest/testdata/logic_test/udf
@@ -3420,3 +3420,13 @@ statement ok
 USE test;
 DROP DATABASE d CASCADE;
 DROP FUNCTION fn;
+
+# Regression test for #100923. Do not attempt to inline an empty UDF and error.
+statement ok
+CREATE FUNCTION f100923() RETURNS BOOL STABLE LANGUAGE SQL AS ''
+
+query B
+SELECT f100923() FROM (VALUES (10), (20)) v(i)
+----
+NULL
+NULL

--- a/pkg/sql/opt/norm/inline_funcs.go
+++ b/pkg/sql/opt/norm/inline_funcs.go
@@ -429,7 +429,7 @@ func (c *CustomFuncs) InlineConstVar(f memo.FiltersExpr) memo.FiltersExpr {
 // challenge because we cannot wrap a set-returning function in a CASE
 // expression, like we do for strict, non-set-returning functions.
 func (c *CustomFuncs) IsInlinableUDF(args memo.ScalarListExpr, udfp *memo.UDFPrivate) bool {
-	if udfp.Volatility == volatility.Volatile || len(udfp.Body) > 1 || udfp.SetReturning {
+	if udfp.Volatility == volatility.Volatile || len(udfp.Body) != 1 || udfp.SetReturning {
 		return false
 	}
 	for i := range args {

--- a/pkg/sql/opt/norm/testdata/rules/inline
+++ b/pkg/sql/opt/norm/testdata/rules/inline
@@ -1343,3 +1343,23 @@ project
  ├── scan a
  └── projections
       └── multi_stmt() [as=multi_stmt:10, immutable, udf]
+
+exec-ddl
+CREATE FUNCTION empty() RETURNS BOOL STABLE LANGUAGE SQL AS ''
+----
+
+# Empty UDFs are not inlined.
+norm expect-not=InlineUDF
+SELECT empty() FROM (VALUES (10), (20)) v(i)
+----
+project
+ ├── columns: empty:2
+ ├── cardinality: [2 - 2]
+ ├── stable
+ ├── fd: ()-->(2)
+ ├── values
+ │    ├── cardinality: [2 - 2]
+ │    ├── ()
+ │    └── ()
+ └── projections
+      └── empty() [as=empty:2, stable, udf]


### PR DESCRIPTION
This commit fixes an internal error that could occur when the `InlineUDF`
normalization rule attempted to inline an empty UDF. The bug is fixed by
no longer attempting to inline empty UDFs.

Fixes #100923

Release note (bug fix): A bug has been fixed that caused internal errors
when executing user-defined functions with empty bodies. This bug was
only present in alpha pre-release versions of 23.1.
