### PR TITLE
sql: handle prepared statements with more param type hints than params in crdb_internal.deserialize_session

### DIFF
--- a/pkg/sql/session_state.go
+++ b/pkg/sql/session_state.go
@@ -169,6 +169,12 @@ func (p *planner) DeserializeSessionState(
 			// with the type hints that were serialized.
 			placeholderTypes = make(tree.PlaceholderTypes, stmt.NumPlaceholders)
 			for i, t := range prepStmt.PlaceholderTypeHints {
+				// Postgres allows more parameter type hints than parameters. Ignore
+				// these if present. For example:
+				// PREPARE p (int) AS SELECT 1;
+				if i == stmt.NumPlaceholders {
+					break
+				}
 				// If the OID is user defined or unknown, then skip it and let the
 				// statementPreparer resolve the type.
 				if t == 0 || t == oid.T_unknown || types.IsOIDUserDefinedType(t) {

--- a/pkg/sql/testdata/session_migration/prepared_statements
+++ b/pkg/sql/testdata/session_migration/prepared_statements
@@ -181,3 +181,31 @@ SELECT name FROM pg_catalog.pg_prepared_statements ORDER BY name
 pscs2
 pscs4
 pscs5
+
+subtest param_type_hints_gt_params
+
+# DEALLOCATE existing prepared statements from other tests.
+exec
+DEALLOCATE ALL
+----
+
+# Prepare a statement with more parameter type hints than parameters.
+exec
+PREPARE p (int) AS SELECT 1
+----
+
+let $session_hex
+SELECT encode(crdb_internal.serialize_session(), 'hex')
+----
+
+# DEALLOCATE p because it will be added back by crdb_internal.deserialize_session.
+exec
+DEALLOCATE p
+----
+
+query
+SELECT crdb_internal.deserialize_session(decode('$session_hex', 'hex'))
+----
+true
+
+subtest end


### PR DESCRIPTION
Fixes #101332
Fixes https://github.com/cockroachdb/cockroach/issues/99009

Previously deserializing a session containing a prepared statement with more parameter type hints than parameters would panic. For example: `PREPARE p (int) AS SELECT 1`

`crdb_internal.deserialize_session` now ignores these extra type hints.

Release note (bug fix): crdb_internal.deserialize_session works properly with prepared statements that have more param type hints than params.