### PR TITLE
release-22.2: sql: job SessionData OptimizerFKCascadesLimit not defaulting to optDrivenFKCascadesClusterLimit

### DIFF
--- a/pkg/sql/schema_changer.go
+++ b/pkg/sql/schema_changer.go
@@ -2567,7 +2567,8 @@ func NewFakeSessionData(sv *settings.Values) *sessiondata.SessionData {
 			Internal:      true,
 		},
 		LocalOnlySessionData: sessiondatapb.LocalOnlySessionData{
-			DistSQLMode: sessiondatapb.DistSQLExecMode(DistSQLClusterExecMode.Get(sv)),
+			DistSQLMode:              sessiondatapb.DistSQLExecMode(DistSQLClusterExecMode.Get(sv)),
+			OptimizerFKCascadesLimit: optDrivenFKCascadesClusterLimit.Get(sv),
 		},
 		SearchPath:    sessiondata.DefaultSearchPathForUser(username.NodeUserName()),
 		SequenceState: sessiondata.NewSequenceState(),


### PR DESCRIPTION
Backport 1/1 commits from #101267.

/cc @cockroachdb/release

---

Fixes #101265

`SessionData` available to in the job context has a 0-value `OptimizerFKCascadesLimit`.

This causes DELETE queries run by the job with an inbound on-delete-cascade FK to fail with an error `cascades limit (0) reached`.

This change fixes this by populating OptimizerFKCascadesLimit in `sql.NewFakeSessionData`.

Release note: None

Release justification: Fix session data initialization