### PR TITLE
pgwire: fix description of sql.conns metric

### DIFF
--- a/pkg/sql/pgwire/server.go
+++ b/pkg/sql/pgwire/server.go
@@ -140,7 +140,7 @@ const (
 var (
 	MetaConns = metric.Metadata{
 		Name:        "sql.conns",
-		Help:        "Number of active SQL connections",
+		Help:        "Number of open SQL connections",
 		Measurement: "Connections",
 		Unit:        metric.Unit_COUNT,
 	}


### PR DESCRIPTION
The word "active" is misleading, since this metric includes connections that are running a query as well as ones that are idle.

Epic: None
Release note: None