### PR TITLE
build: fix pebble nightly test binary build

### DIFF
--- a/DEPS.bzl
+++ b/DEPS.bzl
@@ -1,6 +1,6 @@
 load("@bazel_gazelle//:deps.bzl", "go_repository")
 
-# PRO-TIP: You can inject temorary changes to any of these dependencies by
+# PRO-TIP: You can inject temporary changes to any of these dependencies by
 # by pointing to an alternate remote to clone from. Delete the `sha256`,
 # `strip_prefix`, and `urls` parameters, and add `vcs = "git"` as well as a
 # custom `remote` and `commit`. For example:

--- a/build/teamcity/cockroach/nightlies/pebble_nightly_build_test_binary.sh
+++ b/build/teamcity/cockroach/nightlies/pebble_nightly_build_test_binary.sh
@@ -16,6 +16,13 @@ DEST="$2"
 BAZEL_BIN=$(bazel info bazel-bin --config ci)
 
 bazel run @go_sdk//:bin/go get "github.com/cockroachdb/pebble@$PEBBLE_BRANCH"
+
+# Remove the patch, which doesn't work with older versions (the "unpatched"
+# config assumes the invariants tag is set). Once we remove the patch,
+# cmd/mirror/go below will not find it and it won't be referenced in the
+# resulting DEPS.bzl.
+rm -f build/patches/com_github_cockroachdb_pebble.patch
+
 NEW_DEPS_BZL_CONTENT=$(bazel run //pkg/cmd/mirror/go:mirror)
 echo "$NEW_DEPS_BZL_CONTENT" > DEPS.bzl
 
@@ -32,5 +39,5 @@ cp $BAZEL_BIN/external/com_github_cockroachdb_pebble/internal/metamorphic/metamo
 chmod a+w "$DEST/$PEBBLE_SHA.test"
 echo "$PEBBLE_SHA"
 
-# Return DEPS.bzl to its previous contents.
-git checkout HEAD -- DEPS.bzl
+# Return DEPS.bzl and the patch to its previous contents.
+git checkout HEAD -- DEPS.bzl build/patches

--- a/pkg/cmd/mirror/go/mirror.go
+++ b/pkg/cmd/mirror/go/mirror.go
@@ -335,7 +335,7 @@ func dumpNewDepsBzl(
 
 	fmt.Println(`load("@bazel_gazelle//:deps.bzl", "go_repository")
 
-# PRO-TIP: You can inject temorary changes to any of these dependencies by
+# PRO-TIP: You can inject temporary changes to any of these dependencies by
 # by pointing to an alternate remote to clone from. Delete the ` + "`sha256`" + `,
 # ` + "`strip_prefix`, and `urls` parameters, and add `vcs = \"git\"`" + ` as well as a
 # custom ` + "`remote` and `commit`" + `. For example:


### PR DESCRIPTION
The `pebble_nightly_build_test_binary.sh` is used to create a test binary against older versions of Pebble. The recently updated patch to the pebble `BUILD.bazel` files (`com_github_cockroachdb_pebble.patch`) does not apply against older versions.

The fix is to remove the patch altogether when building the test binary. The "unpatched" configuration corresponds to the `invariant` tag being set (and `pebble_obj_io_tracing` tag being unset), which is what we want.

Fixes #101314.

Release note: None