### PR TITLE
sql: fix udfs with $$ in body

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/udf
+++ b/pkg/sql/logictest/testdata/logic_test/udf
@@ -3430,3 +3430,16 @@ SELECT f100923() FROM (VALUES (10), (20)) v(i)
 ----
 NULL
 NULL
+
+# Regression test for #101253. UDF bodies may contain dollar signs.
+subtest regression_101253
+
+statement error pq: at or near "sfv": syntax error
+CREATE FUNCTION f_101253() RETURNS RECORD VOLATILE NOT LEAKPROOF LANGUAGE SQL AS $$
+  SELECT * FROM (VALUES (e'\x1b'), ('y$$sFV'), (e'\x06'));
+$$;
+
+statement ok
+CREATE FUNCTION f_101253() RETURNS RECORD VOLATILE NOT LEAKPROOF LANGUAGE SQL AS $func$
+  SELECT * FROM (VALUES (e'\x1b'), ('y$$sFV'), (e'\x06'));
+$func$;

--- a/pkg/sql/schemachanger/scbuild/ast_annotator.go
+++ b/pkg/sql/schemachanger/scbuild/ast_annotator.go
@@ -28,8 +28,10 @@ type astAnnotator struct {
 }
 
 func newAstAnnotator(original tree.Statement) (*astAnnotator, error) {
-	// Clone the original tree by re-parsing the input back into an AST.
-	statement, err := parser.ParseOne(original.String())
+	// Clone the original tree by re-parsing the input back into an AST. We need
+	// to keep tagged dollar quotes in case they're necessary to parse the
+	// original statement.
+	statement, err := parser.ParseOne(tree.AsStringWithFlags(original, tree.FmtTagDollarQuotes))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sql/sem/tree/format.go
+++ b/pkg/sql/sem/tree/format.go
@@ -57,15 +57,15 @@ const (
 	// string will be escaped and enclosed in e'...' regardless of
 	// whether FmtBareStrings is specified. See FmtRawStrings below for
 	// an alternative.
-	FmtBareStrings FmtFlags = FmtFlags(lexbase.EncBareStrings)
+	FmtBareStrings = FmtFlags(lexbase.EncBareStrings)
 
 	// FmtBareIdentifiers instructs the pretty-printer to print
 	// identifiers without wrapping quotes in any case.
-	FmtBareIdentifiers FmtFlags = FmtFlags(lexbase.EncBareIdentifiers)
+	FmtBareIdentifiers = FmtFlags(lexbase.EncBareIdentifiers)
 
 	// FmtShowPasswords instructs the pretty-printer to not suppress passwords.
 	// If not set, passwords are replaced by *****.
-	FmtShowPasswords FmtFlags = FmtFlags(lexbase.EncFirstFreeFlagBit) << iota
+	FmtShowPasswords = FmtFlags(lexbase.EncFirstFreeFlagBit) << iota
 
 	// FmtShowTypes instructs the pretty-printer to
 	// annotate expressions with their resolved types.
@@ -170,6 +170,10 @@ const (
 	// for simple names (i.e. Name, UnrestrictedName) from statements.
 	// This flag *overrides* `FmtMarkRedactionNode` above.
 	FmtOmitNameRedaction
+
+	// FmtTagDollarQuotes instructs tags to be kept intact in tagged dollar
+	// quotes. It also applies tags when formatting UDFs.
+	FmtTagDollarQuotes
 )
 
 // PasswordSubstitution is the string that replaces
@@ -187,21 +191,21 @@ const (
 	// FmtPgwireText instructs the pretty-printer to use
 	// a pg-compatible conversion to strings. See comments
 	// in pgwire_encode.go.
-	FmtPgwireText FmtFlags = fmtPgwireFormat | FmtFlags(lexbase.EncBareStrings)
+	FmtPgwireText = fmtPgwireFormat | FmtFlags(lexbase.EncBareStrings)
 
 	// FmtParsable instructs the pretty-printer to produce a representation that
 	// can be parsed into an equivalent expression. If there is a chance that the
 	// formatted data will be stored durably on disk or sent to other nodes,
 	// then this formatting directive is not appropriate, and FmtSerializable
 	// should be used instead.
-	FmtParsable FmtFlags = fmtDisambiguateDatumTypes | FmtParsableNumerics
+	FmtParsable = fmtDisambiguateDatumTypes | FmtParsableNumerics
 
 	// FmtSerializable instructs the pretty-printer to produce a representation
 	// for expressions that can be serialized to disk. It serializes user defined
 	// types using representations that are stable across changes of the type
 	// itself. This should be used when serializing expressions that will be
 	// stored on disk, like DEFAULT expressions of columns.
-	FmtSerializable FmtFlags = FmtParsable | fmtStaticallyFormatUserDefinedTypes
+	FmtSerializable = FmtParsable | fmtStaticallyFormatUserDefinedTypes
 
 	// FmtCheckEquivalence instructs the pretty-printer to produce a representation
 	// that can be used to check equivalence of expressions. Specifically:
@@ -214,7 +218,7 @@ const (
 	//  - user defined types and datums of user defined types are formatted
 	//    using static representations to avoid name resolution and invalidation
 	//    due to changes in the underlying type.
-	FmtCheckEquivalence FmtFlags = fmtSymbolicVars |
+	FmtCheckEquivalence = fmtSymbolicVars |
 		fmtDisambiguateDatumTypes |
 		FmtParsableNumerics |
 		fmtStaticallyFormatUserDefinedTypes
@@ -223,7 +227,7 @@ const (
 	// for the output of array_to_string(). This de-quotes
 	// the strings enclosed in the array and skips the normal escaping
 	// of strings. Special characters are hex-escaped.
-	FmtArrayToString FmtFlags = FmtBareStrings | fmtRawStrings
+	FmtArrayToString = FmtBareStrings | fmtRawStrings
 
 	// FmtExport, if set, formats datums in a raw form suitable for
 	// EXPORT, e.g. suitable for output into a CSV file. The intended
@@ -238,10 +242,10 @@ const (
 	// because the behavior of array_to_string() is fixed for compatibility
 	// with PostgreSQL, whereas EXPORT may evolve over time to support
 	// other things (eg. fixing #33429).
-	FmtExport FmtFlags = FmtBareStrings | fmtRawStrings
+	FmtExport = FmtBareStrings | fmtRawStrings
 )
 
-const flagsRequiringAnnotations FmtFlags = FmtAlwaysQualifyTableNames
+const flagsRequiringAnnotations = FmtAlwaysQualifyTableNames
 
 // FmtCtx is suitable for passing to Format() methods.
 // It also exposes the underlying bytes.Buffer interface for

--- a/pkg/sql/sem/tree/pretty.go
+++ b/pkg/sql/sem/tree/pretty.go
@@ -184,7 +184,7 @@ func (p *PrettyCfg) docAsString(f NodeFormatter) pretty.Doc {
 }
 
 func (p *PrettyCfg) fmtFlags() FmtFlags {
-	prettyFlags := FmtShowPasswords | FmtParsable
+	prettyFlags := FmtShowPasswords | FmtParsable | FmtTagDollarQuotes
 	if p.ValueRedaction {
 		prettyFlags |= FmtMarkRedactionNode | FmtOmitNameRedaction
 	}

--- a/pkg/sql/sem/tree/udf.go
+++ b/pkg/sql/sem/tree/udf.go
@@ -287,13 +287,21 @@ type FunctionBodyStr string
 // Format implements the NodeFormatter interface.
 func (node FunctionBodyStr) Format(ctx *FmtCtx) {
 	ctx.WriteString("AS ")
-	ctx.WriteString("$$")
+	if ctx.flags.HasFlags(FmtTagDollarQuotes) {
+		ctx.WriteString("$funcbody$")
+	} else {
+		ctx.WriteString("$$")
+	}
 	if ctx.flags.HasFlags(FmtAnonymize) || ctx.flags.HasFlags(FmtHideConstants) {
 		ctx.WriteString("_")
 	} else {
 		ctx.WriteString(string(node))
 	}
-	ctx.WriteString("$$")
+	if ctx.flags.HasFlags(FmtTagDollarQuotes) {
+		ctx.WriteString("$funcbody$")
+	} else {
+		ctx.WriteString("$$")
+	}
 }
 
 // FuncParams represents a list of FuncParam.


### PR DESCRIPTION
Before this change, `CREATE FUNCTION`, when used with tagged dollar quote (e.g., `$func$`) syntax, could fail with a syntax error if one of the statements in the UDF body contains a `$$` in a string. With this change, `CREATE FUNCTION` no longer produces the syntax error.

This PR adds a new formatting option that allows tagged dollar quotes, and applies the new format flag for pretty printing and when copying an AST using the `astAnnotator`. The flag adds tagged dollar quotes when formatting a `CREATE FUNCTION` node instead of normal dollar quotes.

Note that like postgres, `CREATE FUNCTION` when used with untagged dollar quotes can still fail with a syntax error if the UDF body contains a `$$`. Similarly, when the body of `CREATE FUNCTION` is wrapped by single quotes `' '`, any strings in the body need to be demarcated using a different method, such as by dollar quotes.

Epic: none
Fixes: #101253

Release note: Fixes a bug in which a `CREATE FUNCTION` may produce a syntax error if the UDF body wrapped in tagged dollar quotes (e.g., `$func$`), contains two consecutive dollar signs `$$`. If the UDF body is known to contain dollar signs, then the caller should use tagged dollar quotes or single quotes when defining the UDF. For example:
```
CREATE FUNCTION f(a STRING) RETURNS STRING LANGUAGE SQL AS $func$
  SELECT concat('$$', a);
$func$
```