### PR TITLE
util: make CombineUnique generic, clarify semantics

### DIFF
--- a/pkg/server/combined_statement_stats.go
+++ b/pkg/server/combined_statement_stats.go
@@ -952,7 +952,7 @@ func getTotalStatementDetails(
 	apps := tree.MustBeDArray(row[1])
 	var appNames []string
 	for _, s := range apps.Array {
-		appNames = util.CombineUniqueString(appNames, []string{string(tree.MustBeDString(s))})
+		appNames = util.CombineUnique(appNames, []string{string(tree.MustBeDString(s))})
 	}
 	aggregatedMetadata.AppNames = appNames
 
@@ -1222,7 +1222,7 @@ func getStatementDetailsPerPlanHash(
 		recommendations := tree.MustBeDArray(row[4])
 		var idxRecommendations []string
 		for _, s := range recommendations.Array {
-			idxRecommendations = util.CombineUniqueString(idxRecommendations, []string{string(tree.MustBeDString(s))})
+			idxRecommendations = util.CombineUnique(idxRecommendations, []string{string(tree.MustBeDString(s))})
 		}
 
 		// A metadata is unique for each plan, meaning if any of the counts are greater than zero,

--- a/pkg/sql/appstatspb/app_stats.go
+++ b/pkg/sql/appstatspb/app_stats.go
@@ -155,11 +155,11 @@ func (s *StatementStatistics) Add(other *StatementStatistics) {
 	s.BytesRead.Add(other.BytesRead, s.Count, other.Count)
 	s.RowsRead.Add(other.RowsRead, s.Count, other.Count)
 	s.RowsWritten.Add(other.RowsWritten, s.Count, other.Count)
-	s.Nodes = util.CombineUniqueInt64(s.Nodes, other.Nodes)
-	s.Regions = util.CombineUniqueString(s.Regions, other.Regions)
-	s.PlanGists = util.CombineUniqueString(s.PlanGists, other.PlanGists)
+	s.Nodes = util.CombineUnique(s.Nodes, other.Nodes)
+	s.Regions = util.CombineUnique(s.Regions, other.Regions)
+	s.PlanGists = util.CombineUnique(s.PlanGists, other.PlanGists)
 	s.IndexRecommendations = other.IndexRecommendations
-	s.Indexes = util.CombineUniqueString(s.Indexes, other.Indexes)
+	s.Indexes = util.CombineUnique(s.Indexes, other.Indexes)
 
 	s.ExecStats.Add(other.ExecStats)
 	s.LatencyInfo.Add(other.LatencyInfo)

--- a/pkg/sql/executor_statement_metrics.go
+++ b/pkg/sql/executor_statement_metrics.go
@@ -188,7 +188,7 @@ func (ex *connExecutor) recordStatementSummary(
 		log.Warningf(ctx, "failed to convert node ID to int: %s", err)
 	}
 
-	nodes := util.CombineUniqueInt64(getNodesFromPlanner(planner), []int64{nodeID})
+	nodes := util.CombineUnique(getNodesFromPlanner(planner), []int64{nodeID})
 	regions := getRegionsForNodes(ctx, nodes, planner.DistSQLPlanner().sqlAddressResolver)
 
 	recordedStmtStats := sqlstats.RecordedStmtStats{

--- a/pkg/sql/instrumentation.go
+++ b/pkg/sql/instrumentation.go
@@ -752,7 +752,7 @@ func (m execNodeTraceMetadata) annotateExplain(
 				}
 				sort.Strings(regions)
 				nodeStats.Regions = regions
-				allRegions = util.CombineUniqueString(allRegions, regions)
+				allRegions = util.CombineUnique(allRegions, regions)
 				n.Annotate(exec.ExecutionStatsID, &nodeStats)
 			}
 		}

--- a/pkg/sql/opt/exec/execbuilder/relational.go
+++ b/pkg/sql/opt/exec/execbuilder/relational.go
@@ -750,7 +750,7 @@ func (b *Builder) buildScan(scan *memo.ScanExpr) (execPlan, error) {
 		return execPlan{},
 			errors.AssertionFailedf("expected inverted index scan to have an inverted constraint")
 	}
-	b.IndexesUsed = util.CombineUniqueString(b.IndexesUsed, []string{fmt.Sprintf("%d@%d", tab.ID(), idx.ID())})
+	b.IndexesUsed = util.CombineUnique(b.IndexesUsed, []string{fmt.Sprintf("%d@%d", tab.ID(), idx.ID())})
 
 	// Save if we planned a full table/index scan on the builder so that the
 	// planner can be made aware later. We only do this for non-virtual tables.
@@ -2158,7 +2158,7 @@ func (b *Builder) buildIndexJoin(join *memo.IndexJoinExpr) (execPlan, error) {
 	// TODO(radu): the distsql implementation of index join assumes that the input
 	// starts with the PK columns in order (#40749).
 	pri := tab.Index(cat.PrimaryIndex)
-	b.IndexesUsed = util.CombineUniqueString(b.IndexesUsed, []string{fmt.Sprintf("%d@%d", tab.ID(), pri.ID())})
+	b.IndexesUsed = util.CombineUnique(b.IndexesUsed, []string{fmt.Sprintf("%d@%d", tab.ID(), pri.ID())})
 	keyCols := make([]exec.NodeColumnOrdinal, pri.KeyColumnCount())
 	for i := range keyCols {
 		keyCols[i], err = input.getNodeColumnOrdinal(join.Table.ColumnID(pri.Column(i).Ordinal()))
@@ -2470,7 +2470,7 @@ func (b *Builder) buildLookupJoin(join *memo.LookupJoinExpr) (execPlan, error) {
 
 	tab := md.Table(join.Table)
 	idx := tab.Index(join.Index)
-	b.IndexesUsed = util.CombineUniqueString(b.IndexesUsed, []string{fmt.Sprintf("%d@%d", tab.ID(), idx.ID())})
+	b.IndexesUsed = util.CombineUnique(b.IndexesUsed, []string{fmt.Sprintf("%d@%d", tab.ID(), idx.ID())})
 
 	locking := join.Locking
 	if b.forceForUpdateLocking {
@@ -2645,7 +2645,7 @@ func (b *Builder) buildInvertedJoin(join *memo.InvertedJoinExpr) (execPlan, erro
 	md := b.mem.Metadata()
 	tab := md.Table(join.Table)
 	idx := tab.Index(join.Index)
-	b.IndexesUsed = util.CombineUniqueString(b.IndexesUsed, []string{fmt.Sprintf("%d@%d", tab.ID(), idx.ID())})
+	b.IndexesUsed = util.CombineUnique(b.IndexesUsed, []string{fmt.Sprintf("%d@%d", tab.ID(), idx.ID())})
 
 	prefixEqCols := make([]exec.NodeColumnOrdinal, len(join.PrefixKeyCols))
 	for i, c := range join.PrefixKeyCols {
@@ -2758,9 +2758,9 @@ func (b *Builder) buildZigzagJoin(join *memo.ZigzagJoinExpr) (execPlan, error) {
 	rightTable := md.Table(join.RightTable)
 	leftIndex := leftTable.Index(join.LeftIndex)
 	rightIndex := rightTable.Index(join.RightIndex)
-	b.IndexesUsed = util.CombineUniqueString(b.IndexesUsed,
+	b.IndexesUsed = util.CombineUnique(b.IndexesUsed,
 		[]string{fmt.Sprintf("%d@%d", leftTable.ID(), leftIndex.ID())})
-	b.IndexesUsed = util.CombineUniqueString(b.IndexesUsed,
+	b.IndexesUsed = util.CombineUnique(b.IndexesUsed,
 		[]string{fmt.Sprintf("%d@%d", rightTable.ID(), rightIndex.ID())})
 
 	leftEqCols := make([]exec.TableColumnOrdinal, len(join.LeftEqCols))

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -4255,7 +4255,7 @@ value if you rely on the HLC for accuracy.`,
 					metadata.Query = statistics.Key.Query
 					metadata.QuerySummary = statistics.Key.QuerySummary
 					metadata.StmtType = statistics.Stats.SQLType
-					metadata.Databases = util.CombineUniqueString(metadata.Databases, []string{statistics.Key.Database})
+					metadata.Databases = util.CombineUnique(metadata.Databases, []string{statistics.Key.Database})
 
 					if statistics.Key.DistSQL {
 						metadata.DistSQLCount++

--- a/pkg/sql/sqlstats/persistedsqlstats/stmt_reader.go
+++ b/pkg/sql/sqlstats/persistedsqlstats/stmt_reader.go
@@ -192,7 +192,7 @@ func rowToStmtStats(row tree.Datums) (*appstatspb.CollectedStatementStatistics, 
 	recommendations := tree.MustBeDArray(row[9])
 	var indexRecommendations []string
 	for _, s := range recommendations.Array {
-		indexRecommendations = util.CombineUniqueString(indexRecommendations, []string{string(tree.MustBeDString(s))})
+		indexRecommendations = util.CombineUnique(indexRecommendations, []string{string(tree.MustBeDString(s))})
 	}
 	stats.Stats.IndexRecommendations = indexRecommendations
 

--- a/pkg/sql/sqlstats/ssmemstorage/ss_mem_writer.go
+++ b/pkg/sql/sqlstats/ssmemstorage/ss_mem_writer.go
@@ -136,11 +136,11 @@ func (s *Container) RecordStatement(
 	stats.mu.data.RowsRead.Record(stats.mu.data.Count, float64(value.RowsRead))
 	stats.mu.data.RowsWritten.Record(stats.mu.data.Count, float64(value.RowsWritten))
 	stats.mu.data.LastExecTimestamp = s.getTimeNow()
-	stats.mu.data.Nodes = util.CombineUniqueInt64(stats.mu.data.Nodes, value.Nodes)
-	stats.mu.data.Regions = util.CombineUniqueString(stats.mu.data.Regions, value.Regions)
-	stats.mu.data.PlanGists = util.CombineUniqueString(stats.mu.data.PlanGists, []string{value.PlanGist})
+	stats.mu.data.Nodes = util.CombineUnique(stats.mu.data.Nodes, value.Nodes)
+	stats.mu.data.Regions = util.CombineUnique(stats.mu.data.Regions, value.Regions)
+	stats.mu.data.PlanGists = util.CombineUnique(stats.mu.data.PlanGists, []string{value.PlanGist})
 	stats.mu.data.IndexRecommendations = value.IndexRecommendations
-	stats.mu.data.Indexes = util.CombineUniqueString(stats.mu.data.Indexes, value.Indexes)
+	stats.mu.data.Indexes = util.CombineUnique(stats.mu.data.Indexes, value.Indexes)
 
 	// Percentile latencies are only being sampled if the latency was above the
 	// AnomalyDetectionLatencyThreshold.

--- a/pkg/util/BUILD.bazel
+++ b/pkg/util/BUILD.bazel
@@ -37,6 +37,7 @@ go_library(
         "//pkg/util/syncutil",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_cockroachdb_redact//:redact",
+        "@org_golang_x_exp//constraints",
     ],
 )
 

--- a/pkg/util/slices.go
+++ b/pkg/util/slices.go
@@ -10,48 +10,16 @@
 
 package util
 
-// CombineUniqueInt64 combines two ordered int64 slices and returns
-// the result without duplicates.
-// This function is used for combine slices where one of the slices is small or
-// has mostly the same elements as the other.
-// If the two slices are large and don't have many duplications, this function should be avoided,
-// because of the usage of `copy` that can increase CPU.
-func CombineUniqueInt64(a []int64, b []int64) []int64 {
-	// We want b to be the smaller slice, so there are fewer elements
-	// to be added.
-	if len(b) > len(a) {
-		b, a = a, b
-	}
-	aIter, bIter := 0, 0
-	for aIter < len(a) && bIter < len(b) {
-		if a[aIter] == b[bIter] {
-			aIter++
-			bIter++
-		} else if a[aIter] < b[bIter] {
-			aIter++
-		} else {
-			a = append(a, 0)
-			copy(a[aIter+1:], a[aIter:])
-			a[aIter] = b[bIter]
-			aIter++
-			bIter++
-		}
-	}
-	if bIter < len(b) {
-		a = append(a, b[bIter:]...)
-	}
-	return a
-}
+import "golang.org/x/exp/constraints"
 
-// CombineUniqueString combines two ordered string slices and returns
-// the result without duplicates.
+// CombineUnique combines two ordered slices and returns the result without
+// duplicates.
 // This function is used for combine slices where one of the slices is small or
 // has mostly the same elements as the other.
 // If the two slices are large and don't have many duplications, this function should be avoided,
 // because of the usage of `copy` that can increase CPU.
-func CombineUniqueString(a []string, b []string) []string {
-	// We want b to be the smaller slice, so there are fewer elements
-	// to be added.
+func CombineUnique[T constraints.Ordered](a, b []T) []T {
+	// We want b to be the smaller slice, so there are fewer elements to be added.
 	if len(b) > len(a) {
 		b, a = a, b
 	}
@@ -63,7 +31,8 @@ func CombineUniqueString(a []string, b []string) []string {
 		} else if a[aIter] < b[bIter] {
 			aIter++
 		} else {
-			a = append(a, "")
+			var zero T
+			a = append(a, zero)
 			copy(a[aIter+1:], a[aIter:])
 			a[aIter] = b[bIter]
 			aIter++

--- a/pkg/util/slices.go
+++ b/pkg/util/slices.go
@@ -12,12 +12,16 @@ package util
 
 import "golang.org/x/exp/constraints"
 
-// CombineUnique combines two ordered slices and returns the result without
-// duplicates.
-// This function is used for combine slices where one of the slices is small or
-// has mostly the same elements as the other.
-// If the two slices are large and don't have many duplications, this function should be avoided,
-// because of the usage of `copy` that can increase CPU.
+// CombineUnique merges two ordered slices. If both slices have unique elements
+// then so does the resulting slice. More generally, each element is present
+// max(timesInA, timesInB) times.
+//
+// Takes ownership of both slices, and uses the longer one to store the result.
+//
+// This function is used to combine slices where one of the slices is small or
+// has mostly the same elements as the other. If the two slices are large and
+// don't have many duplicates, this function should be avoided, because of the
+// usage of `copy` that can increase CPU.
 func CombineUnique[T constraints.Ordered](a, b []T) []T {
 	// We want b to be the smaller slice, so there are fewer elements to be added.
 	if len(b) > len(a) {

--- a/pkg/util/slices_test.go
+++ b/pkg/util/slices_test.go
@@ -17,37 +17,33 @@ import (
 )
 
 func TestCombinesUniqueInt64(t *testing.T) {
-	for _, tc := range []struct{ inputA, inputB, expected []int64 }{
-		{
-			inputA:   []int64{1, 2, 4},
-			inputB:   []int64{3, 5},
-			expected: []int64{1, 2, 3, 4, 5},
-		},
-		{
-			inputA:   []int64{1, 2, 4},
-			inputB:   []int64{1, 3, 4},
-			expected: []int64{1, 2, 3, 4},
-		},
-		{
-			inputA:   []int64{1, 2, 3},
-			inputB:   []int64{1, 2, 3},
-			expected: []int64{1, 2, 3},
-		},
-		{
-			inputA:   []int64{},
-			inputB:   []int64{1, 3},
-			expected: []int64{1, 3},
-		},
-		{
-			inputA:   []int64{4, 4},
-			inputB:   []int64{1, 1, 4, 4, 4, 5, 5},
-			expected: []int64{1, 1, 4, 4, 4, 5, 5},
-		},
-		{
-			inputA:   []int64{4, 4, 4},
-			inputB:   []int64{1, 1, 4, 4, 5, 5},
-			expected: []int64{1, 1, 4, 4, 4, 5, 5},
-		},
+	for _, tc := range []struct {
+		inputA, inputB, expected []int64
+	}{{
+		inputA:   []int64{1, 2, 4},
+		inputB:   []int64{3, 5},
+		expected: []int64{1, 2, 3, 4, 5},
+	}, {
+		inputA:   []int64{1, 2, 4},
+		inputB:   []int64{1, 3, 4},
+		expected: []int64{1, 2, 3, 4},
+	}, {
+		inputA:   []int64{1, 2, 3},
+		inputB:   []int64{1, 2, 3},
+		expected: []int64{1, 2, 3},
+	}, {
+		inputA:   []int64{},
+		inputB:   []int64{1, 3},
+		expected: []int64{1, 3},
+	}, {
+		inputA:   []int64{4, 4},
+		inputB:   []int64{1, 1, 4, 4, 4, 5, 5},
+		expected: []int64{1, 1, 4, 4, 4, 5, 5},
+	}, {
+		inputA:   []int64{4, 4, 4},
+		inputB:   []int64{1, 1, 4, 4, 5, 5},
+		expected: []int64{1, 1, 4, 4, 4, 5, 5},
+	},
 	} {
 		output := CombineUnique(tc.inputA, tc.inputB)
 		require.Equal(t, tc.expected, output)
@@ -55,32 +51,29 @@ func TestCombinesUniqueInt64(t *testing.T) {
 }
 
 func TestCombinesUniqueStrings(t *testing.T) {
-	for _, tc := range []struct{ inputA, inputB, expected []string }{
-		{
-			inputA:   []string{"a", "b", "d"},
-			inputB:   []string{"c", "e"},
-			expected: []string{"a", "b", "c", "d", "e"},
-		},
-		{
-			inputA:   []string{"a", "b", "d"},
-			inputB:   []string{"a", "c", "d"},
-			expected: []string{"a", "b", "c", "d"},
-		},
-		{
-			inputA:   []string{"a", "b", "c"},
-			inputB:   []string{"a", "b", "c"},
-			expected: []string{"a", "b", "c"},
-		},
-		{
-			inputA:   []string{},
-			inputB:   []string{"a", "c"},
-			expected: []string{"a", "c"},
-		},
-		{
-			inputA:   []string{"a", "a", "a"},
-			inputB:   []string{"b", "b", "b"},
-			expected: []string{"a", "a", "a", "b", "b", "b"},
-		},
+	for _, tc := range []struct {
+		inputA, inputB, expected []string
+	}{{
+		inputA:   []string{"a", "b", "d"},
+		inputB:   []string{"c", "e"},
+		expected: []string{"a", "b", "c", "d", "e"},
+	}, {
+		inputA:   []string{"a", "b", "d"},
+		inputB:   []string{"a", "c", "d"},
+		expected: []string{"a", "b", "c", "d"},
+	}, {
+		inputA:   []string{"a", "b", "c"},
+		inputB:   []string{"a", "b", "c"},
+		expected: []string{"a", "b", "c"},
+	}, {
+		inputA:   []string{},
+		inputB:   []string{"a", "c"},
+		expected: []string{"a", "c"},
+	}, {
+		inputA:   []string{"a", "a", "a"},
+		inputB:   []string{"b", "b", "b"},
+		expected: []string{"a", "a", "a", "b", "b", "b"},
+	},
 	} {
 		output := CombineUnique(tc.inputA, tc.inputB)
 		require.Equal(t, tc.expected, output)

--- a/pkg/util/slices_test.go
+++ b/pkg/util/slices_test.go
@@ -38,6 +38,16 @@ func TestCombinesUniqueInt64(t *testing.T) {
 			inputB:   []int64{1, 3},
 			expected: []int64{1, 3},
 		},
+		{
+			inputA:   []int64{4, 4},
+			inputB:   []int64{1, 1, 4, 4, 4, 5, 5},
+			expected: []int64{1, 1, 4, 4, 4, 5, 5},
+		},
+		{
+			inputA:   []int64{4, 4, 4},
+			inputB:   []int64{1, 1, 4, 4, 5, 5},
+			expected: []int64{1, 1, 4, 4, 4, 5, 5},
+		},
 	} {
 		output := CombineUnique(tc.inputA, tc.inputB)
 		require.Equal(t, tc.expected, output)
@@ -65,6 +75,11 @@ func TestCombinesUniqueStrings(t *testing.T) {
 			inputA:   []string{},
 			inputB:   []string{"a", "c"},
 			expected: []string{"a", "c"},
+		},
+		{
+			inputA:   []string{"a", "a", "a"},
+			inputB:   []string{"b", "b", "b"},
+			expected: []string{"a", "a", "a", "b", "b", "b"},
 		},
 	} {
 		output := CombineUnique(tc.inputA, tc.inputB)

--- a/pkg/util/slices_test.go
+++ b/pkg/util/slices_test.go
@@ -39,7 +39,7 @@ func TestCombinesUniqueInt64(t *testing.T) {
 			expected: []int64{1, 3},
 		},
 	} {
-		output := CombineUniqueInt64(tc.inputA, tc.inputB)
+		output := CombineUnique(tc.inputA, tc.inputB)
 		require.Equal(t, tc.expected, output)
 	}
 }
@@ -67,7 +67,7 @@ func TestCombinesUniqueStrings(t *testing.T) {
 			expected: []string{"a", "c"},
 		},
 	} {
-		output := CombineUniqueString(tc.inputA, tc.inputB)
+		output := CombineUnique(tc.inputA, tc.inputB)
 		require.Equal(t, tc.expected, output)
 	}
 }


### PR DESCRIPTION
This PR replaces two identical `CombineUnique<Type>` functions (only the input type differs) with a generic. It also clarifies the semantics of the function, adds a few tests, and improves formatting.

Release note: none
Epic: none