### PR TITLE
sql: fully qualify pg_catalog and system table names in builtins

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/pg_builtins
+++ b/pkg/sql/logictest/testdata/logic_test/pg_builtins
@@ -832,3 +832,32 @@ SELECT k, pg_get_indexdef('expr_idx'::regclass::oid, k, true) FROM generate_seri
 2  (json->>'bar'::STRING)
 3  (length(id))
 4  ·
+
+# Regression test for #101357. The SQL implementations of pg_get_indexdef and
+# col_description should not have unqualified table names that can conflict with
+# a user tables.
+statement ok
+CREATE TABLE pg_indexes (i INT PRIMARY KEY);
+CREATE TABLE pg_attribute (i INT PRIMARY KEY)
+
+statement ok
+SET search_path TO public,pg_catalog
+
+statement ok
+SELECT i, pg_get_indexdef(0, 1, true) FROM pg_indexes
+
+statement ok
+DROP TABLE pg_indexes;
+DROP TABLE pg_attribute;
+RESET search_path
+
+statement ok
+CREATE SCHEMA system;
+CREATE TABLE system.comments (i INT)
+
+statement ok
+SELECT col_description(0, 0)
+
+statement
+DROP TABLE system.comments;
+DROP SCHEMA system

--- a/pkg/sql/opt/testutils/testcat/vtable.go
+++ b/pkg/sql/opt/testutils/testcat/vtable.go
@@ -161,17 +161,17 @@ func init() {
 // Resolve returns true and the AST node describing the virtual table referenced.
 // TODO(justin): make this complete for all virtual tables.
 func resolveVTable(name *tree.TableName) (*tree.CreateTable, bool) {
-	switch name.SchemaName {
-	case "information_schema":
+	switch {
+	case name.CatalogName == "system" || (name.CatalogName == "" && name.SchemaName == "system"):
+		schema, ok := systemMap[name.ObjectName.String()]
+		return schema, ok
+
+	case name.SchemaName == "information_schema":
 		schema, ok := informationSchemaMap[name.ObjectName.String()]
 		return schema, ok
 
-	case "pg_catalog":
+	case name.SchemaName == "pg_catalog":
 		schema, ok := pgCatalogMap[name.ObjectName.String()]
-		return schema, ok
-
-	case "system":
-		schema, ok := systemMap[name.ObjectName.String()]
 		return schema, ok
 	}
 

--- a/pkg/sql/sem/builtins/pg_builtins.go
+++ b/pkg/sql/sem/builtins/pg_builtins.go
@@ -786,8 +786,8 @@ var pgBuiltins = map[string]builtinDefinition{
 						ELSE a.attname
 					END as pg_get_indexdef
 					FROM pg_catalog.pg_index i
-					LEFT JOIN pg_attribute a ON (a.attrelid = i.indexrelid AND a.attnum = $2)
-					LEFT JOIN pg_indexes defs ON ($2 = 0 AND defs.crdb_oid = i.indexrelid)
+					LEFT JOIN pg_catalog.pg_attribute a ON (a.attrelid = i.indexrelid AND a.attnum = $2)
+					LEFT JOIN pg_catalog.pg_indexes defs ON ($2 = 0 AND defs.crdb_oid = i.indexrelid)
 					WHERE i.indexrelid = $1`,
 			Info:       "Gets the CREATE INDEX command for index, or definition of just one index column when given a non-zero column number",
 			Volatility: volatility.Stable,
@@ -1029,7 +1029,7 @@ var pgBuiltins = map[string]builtinDefinition{
 			// on pg_description and let predicate push-down do its job.
 			Body: fmt.Sprintf(
 				`SELECT comment
-         FROM system.comments c
+				 FROM system.public.comments c
 				 WHERE c.type=%[1]d
 				 AND c.object_id=$1::int
 				 AND c.sub_id=$2::int


### PR DESCRIPTION
This commit fixes bugs in `pg_get_indexdef` and `col_description`
built-ins that could cause incorrect resolution of tables referenced in
those built-ins.

Fixes #101357

Release note (bug fix): A bug has been fixed in the built-in functions
`pg_get_indexdef` and `col_description` that could cause the functions
to return errors if the user created tables named `pg_indexes` or
`pg_attribute`, or if the user created a schema named `system` with a
table named `comments`. This bug was only present on pre-release
versions of 23.1.
