### PR TITLE
sql: better dependent name formatting when dropping a function

### DIFF
--- a/pkg/sql/drop_function.go
+++ b/pkg/sql/drop_function.go
@@ -13,6 +13,7 @@ package sql
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/cockroachdb/cockroach/pkg/jobs"
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
@@ -85,8 +86,8 @@ func (p *planner) DropFunction(
 			}
 			return nil, pgerror.Newf(
 				pgcode.DependentObjectsStillExist,
-				"cannot drop function %q because other objects (%v) still depend on it",
-				mut.Name, depNames,
+				"cannot drop function %q because other objects ([%v]) still depend on it",
+				mut.Name, strings.Join(depNames, ", "),
 			)
 		}
 		dropNode.toDrop = append(dropNode.toDrop, mut)

--- a/pkg/sql/logictest/testdata/logic_test/udf_in_column_defaults
+++ b/pkg/sql/logictest/testdata/logic_test/udf_in_column_defaults
@@ -349,16 +349,23 @@ CREATE TABLE t1(
   b INT DEFAULT f1(),
   FAMILY fam_0 (a, b)
 );
+CREATE TABLE t2(
+  a INT PRIMARY KEY,
+  b INT DEFAULT f1(),
+  FAMILY fam_0 (a, b)
+);
 
-statement error cannot drop function "f1" because other objects \(\[test.public.t1\]\) still depend on it
+statement error cannot drop function "f1" because other objects \(\[test.public.t1, test.public.t2\]\) still depend on it
 DROP FUNCTION f1;
 
 statement ok
 ALTER TABLE t1 ALTER COLUMN b SET DEFAULT NULL;
+ALTER TABLE t2 ALTER COLUMN b SET DEFAULT NULL;
 
 statement ok
 DROP FUNCTION f1;
 DROP TABLE t1;
+DROP TABLE t2;
 
 # Make sure that CREATE FUNCTION and CREATE TABLE works in one txn.
 statement ok
@@ -380,8 +387,8 @@ SELECT oid::int - 100000 FROM pg_catalog.pg_proc WHERE proname = 'f1';
 query T
 SELECT get_col_fn_ids($tbl_id);
 ----
-(118,1,,)
-(118,2,"""[FUNCTION 100117]()""",[117])
+(119,1,,)
+(119,2,"""[FUNCTION 100118]()""",[118])
 
 query T
 SELECT get_fn_depended_on_by($fn_id);
@@ -391,7 +398,7 @@ SELECT get_fn_depended_on_by($fn_id);
         "columnIds": [
             2
         ],
-        "id": 118
+        "id": 119
     }
 ]
 
@@ -422,8 +429,8 @@ SELECT oid::int - 100000 FROM pg_catalog.pg_proc WHERE proname = 'f1';
 query T
 SELECT get_col_fn_ids($tbl_id);
 ----
-(119,1,,)
-(119,2,"""[FUNCTION 100120]()""",[120])
+(120,1,,)
+(120,2,"""[FUNCTION 100121]()""",[121])
 
 query T
 SELECT get_fn_depended_on_by($fn_id);
@@ -433,7 +440,7 @@ SELECT get_fn_depended_on_by($fn_id);
         "columnIds": [
             2
         ],
-        "id": 119
+        "id": 120
     }
 ]
 

--- a/pkg/sql/logictest/testdata/logic_test/udf_in_constraints
+++ b/pkg/sql/logictest/testdata/logic_test/udf_in_constraints
@@ -209,6 +209,7 @@ SELECT get_fn_depended_on_by($fn_id)
 # Make sure that DROP TABLE remove references properly.
 statement ok
 DROP TABLE t1;
+DROP TABLE t2;
 
 query T
 SELECT get_fn_depended_on_by($fn_id)
@@ -222,18 +223,25 @@ CREATE TABLE t1(
   b INT CHECK (f1(b) > 1),
   FAMILY fam_0 (a, b)
 );
+CREATE TABLE t2(
+  a INT PRIMARY KEY,
+  b INT CHECK (f1(b) > 1),
+  FAMILY fam_0 (a, b)
+);
 
-statement error cannot drop function "f1" because other objects \(\[test.public.t1\]\) still depend on it
+statement error cannot drop function "f1" because other objects \(\[test.public.t1, test.public.t2\]\) still depend on it
 DROP FUNCTION f1;
 
 statement ok
 ALTER TABLE t1 DROP CONSTRAINT check_b;
+ALTER TABLE t2 DROP CONSTRAINT check_b;
 
 statement ok
 DROP FUNCTION f1;
 
 statement ok
 DROP TABLE t1;
+DROP TABLE t2;
 
 # Make sure that CREATE FUNCTION and CREATE TABLE works in one txn.
 statement ok
@@ -261,7 +269,7 @@ SELECT get_checks($tbl_id);
             2
         ],
         "constraintId": 2,
-        "expr": "[FUNCTION 100114](b) \u003e 1:::INT8",
+        "expr": "[FUNCTION 100115](b) \u003e 1:::INT8",
         "name": "check_b"
     }
 ]
@@ -274,7 +282,7 @@ SELECT get_fn_depended_on_by($fn_id);
         "constraintIds": [
             2
         ],
-        "id": 115
+        "id": 116
     }
 ]
 
@@ -313,7 +321,7 @@ SELECT get_checks($tbl_id);
             2
         ],
         "constraintId": 2,
-        "expr": "[FUNCTION 100117](b) \u003e 1:::INT8",
+        "expr": "[FUNCTION 100118](b) \u003e 1:::INT8",
         "name": "check_b"
     }
 ]
@@ -326,7 +334,7 @@ SELECT get_fn_depended_on_by($fn_id);
         "constraintIds": [
             2
         ],
-        "id": 116
+        "id": 117
     }
 ]
 

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/drop_function.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/drop_function.go
@@ -11,6 +11,8 @@
 package scbuildstmt
 
 import (
+	"strings"
+
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scerrors"
@@ -51,8 +53,8 @@ func DropFunction(b BuildCtx, n *tree.DropFunction) {
 		if len(dependentNames) > 0 {
 			panic(pgerror.Newf(
 				pgcode.DependentObjectsStillExist,
-				"cannot drop function %q because other objects (%v) still depend on it",
-				toCheckBackRefsNames[i].Name, dependentNames,
+				"cannot drop function %q because other objects ([%v]) still depend on it",
+				toCheckBackRefsNames[i].Name, strings.Join(dependentNames, ", "),
 			))
 
 		}


### PR DESCRIPTION
Fixes: #99279

This commit make the dependent names as comma separated when dropping a function for better human readability.

Release note: None