### PR TITLE
ui: add trace rate option to stmt diagnostics

### DIFF
--- a/pkg/sql/stmtdiagnostics/statement_diagnostics.go
+++ b/pkg/sql/stmtdiagnostics/statement_diagnostics.go
@@ -297,7 +297,7 @@ func (r *Registry) insertRequestInternal(
 		if minExecutionLatency == 0 {
 			return 0, errors.Newf(
 				"got non-zero sampling probability %f and empty min exec latency",
-				minExecutionLatency)
+				samplingProbability)
 		}
 	}
 

--- a/pkg/ui/workspaces/cluster-ui/src/api/statementDiagnosticsApi.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/api/statementDiagnosticsApi.ts
@@ -9,6 +9,7 @@
 // licenses/APL.txt.
 
 import moment from "moment-timezone";
+import { Duration } from "src/util/format";
 import {
   executeInternalSql,
   SqlExecutionRequest,
@@ -74,7 +75,7 @@ export type InsertStmtDiagnosticRequest = {
 };
 
 export type InsertStmtDiagnosticResponse = {
-  stmt_diag_req_id: string;
+  req_resp: boolean;
 };
 
 export function createStatementDiagnosticsReport({
@@ -83,32 +84,26 @@ export function createStatementDiagnosticsReport({
   minExecutionLatencySeconds,
   expiresAfterSeconds,
 }: InsertStmtDiagnosticRequest): Promise<InsertStmtDiagnosticResponse> {
-  const requestedAt = moment.now(); // milliseconds
-  const args: any = [stmtFingerprint, moment.utc(requestedAt).toISOString()];
-  const cols = ["statement_fingerprint", "requested_at"];
+  const args: any = [stmtFingerprint];
 
-  if (samplingProbability && samplingProbability !== 0) {
+  if (samplingProbability) {
     args.push(samplingProbability);
-    cols.push("sampling_probability");
+  } else {
+    args.push(0);
   }
-  if (minExecutionLatencySeconds && minExecutionLatencySeconds !== 0) {
-    args.push(minExecutionLatencySeconds.toString());
-    cols.push("min_execution_latency");
+  if (minExecutionLatencySeconds) {
+    args.push(Duration(minExecutionLatencySeconds * 1e9));
+  } else {
+    args.push("0");
   }
   if (expiresAfterSeconds && expiresAfterSeconds !== 0) {
-    const expiresAt = requestedAt + expiresAfterSeconds * 1000;
-    args.push(moment.utc(expiresAt).toISOString());
-    cols.push("expires_at");
+    args.push(Duration(expiresAfterSeconds * 1e9));
+  } else {
+    args.push("0");
   }
 
-  const queryCols = cols.join(", ");
-  const placeHolders = args.map((elem: any, idx: number) => `$${idx + 1}`);
-
   const createStmtDiag = {
-    sql: `
-        INSERT INTO system.statement_diagnostics_requests 
-            (${queryCols}) 
-             VALUES (${placeHolders}) RETURNING id as stmt_diag_req_id;`,
+    sql: `SELECT crdb_internal.request_statement_bundle($1, $2, $3::INTERVAL, $4::INTERVAL) as req_resp`,
     arguments: args,
   };
 
@@ -124,7 +119,10 @@ export function createStatementDiagnosticsReport({
         throw res.error;
       }
 
-      if (res.execution?.txn_results[0]?.rows?.length === 0) {
+      if (
+        res.execution?.txn_results[0]?.rows?.length === 0 ||
+        res.execution?.txn_results[0]?.rows[0]["req_resp"] === false
+      ) {
         throw new Error("Failed to insert statement diagnostics request");
       }
 
@@ -178,7 +176,11 @@ export type CancelStmtDiagnosticResponse = {
 export function cancelStatementDiagnosticsReport({
   requestId,
 }: CancelStmtDiagnosticRequest): Promise<CancelStmtDiagnosticResponse> {
-  const query = `UPDATE system.statement_diagnostics_requests SET expires_at = '1970-01-01' WHERE completed = false AND id = $1::INT8 AND (expires_at IS NULL OR expires_at > now()) RETURNING id as stmt_diag_req_id`;
+  const query = `UPDATE system.statement_diagnostics_requests 
+SET expires_at = '1970-01-01' 
+WHERE completed = false 
+AND id = $1::INT8 
+AND (expires_at IS NULL OR expires_at > now()) RETURNING id as stmt_diag_req_id`;
   const req: SqlExecutionRequest = {
     execute: true,
     statements: [

--- a/pkg/ui/workspaces/cluster-ui/src/statementDetails/diagnostics/diagnosticsView.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementDetails/diagnostics/diagnosticsView.tsx
@@ -12,7 +12,6 @@ import React from "react";
 import { Link } from "react-router-dom";
 import moment from "moment-timezone";
 import classnames from "classnames/bind";
-import { cockroach } from "@cockroachlabs/crdb-protobuf-client";
 import { Button, Icon } from "@cockroachlabs/ui-components";
 import { Button as CancelButton } from "src/button";
 import { Text, TextTypes } from "src/text";

--- a/pkg/ui/workspaces/cluster-ui/src/statementsDiagnostics/activateStatementDiagnosticsModal.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsDiagnostics/activateStatementDiagnosticsModal.scss
@@ -40,6 +40,7 @@
 
   &__heading {
     font-family: $font-family--semi-bold;
+    margin-bottom: $spacing-smaller;
   }
 
   &__btn-group {
@@ -48,7 +49,6 @@
   }
 
   &__radio-btn {
-    margin-top: $spacing-smaller;
     font-family: $font-family--base;
     font-weight: $font-weight--light;
   }
@@ -57,12 +57,29 @@
     display: flex;
     flex-direction: column;
     margin-left: $spacing-medium;
+    margin-top: $spacing-smaller;
   }
 
   &__min-latency-container {
     display: flex;
     flex-direction: row;
     margin-top: $spacing-smaller;
+  }
+
+  &__trace-container {
+    display: flex;
+    flex-direction: row;
+    margin-top: $spacing-smaller;
+    margin-bottom: $spacing-smaller;
+  }
+
+  &__trace-warning {
+    font-family: $font-family--base;
+    font-size: $font-size--small;
+    font-weight: $font-weight--light;
+    margin-left: $spacing-x-small;
+    white-space: break-spaces;
+    width: 240px;
   }
 
   &__expires-after-container {
@@ -74,6 +91,12 @@
     font-family: $font-family--base;
     font-weight: $font-weight--light;
     display: inline;
+  }
+
+  &__select-text {
+    font-family: $font-family--base;
+    font-weight: $font-weight--light;
+    display: block;
   }
 
   &__input {
@@ -99,25 +122,25 @@
         margin-top: 0;
       }
     }
+    &__trace {
+      width: 215px;
+      height: 40px;
+      line-height: 40px;
+
+      .ant-select-selection__rendered {
+        margin-top: 0;
+      }
+    }
   }
 
   &__alert {
     margin-top: $spacing-small;
     margin-left: $spacing-medium;
+    white-space: normal;
+  }
 
-    .ant-alert-info {
-      background-color: $colors--primary-blue-alert;
-      border: none;
-    }
-
-    &-icon {
-      margin-top: $spacing-medium-small;
-    }
-
-    &-message {
-      font-family: $font-family--base;
-      font-weight: $font-weight--light;
-      margin-left: $spacing-smaller;
-    }
+  &__warning {
+    margin: $spacing-xx-small 0px;
+    white-space: normal;
   }
 }

--- a/pkg/ui/workspaces/cluster-ui/src/store/statementDiagnostics/statementDiagnostics.sagas.spec.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/store/statementDiagnostics/statementDiagnostics.sagas.spec.ts
@@ -43,7 +43,7 @@ describe("statementsDiagnostics sagas", () => {
     };
 
     const insertResponse: InsertStmtDiagnosticResponse = {
-      stmt_diag_req_id: "4132456789089978654",
+      req_resp: true,
     };
 
     const reportsResponse: StatementDiagnosticsResponse = [];


### PR DESCRIPTION
Fixes #92415

Add option to select the trace rate for statement
diagnostics collection directly on the Console.

https://www.loom.com/share/beaf1ce16f7d4efc845056e33cb3bee1

<img width="587" alt="Screenshot 2023-04-12 at 4 09 50 PM" src="https://user-images.githubusercontent.com/1017486/231573175-e05ea6dd-d03d-4044-ae53-bb4cba55bb77.png">

<img width="591" alt="Screenshot 2023-04-12 at 4 10 00 PM" src="https://user-images.githubusercontent.com/1017486/231573195-5189fee3-8af2-4ada-af1b-8cc6fde5ceb2.png">


Release note (ui change): Add option to select the trace rate for statement diagnostics collection.