### PR TITLE
Add Jobs test failures to new GH project

### DIFF
--- a/.github/workflows/add-issues-to-project.yml
+++ b/.github/workflows/add-issues-to-project.yml
@@ -25,3 +25,8 @@ jobs:
           github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}
           # A comma-separated list of labels to use as a filter for issue to be added
           labeled: T-cdc
+      - uses: actions/add-to-project@v0.4.0
+        with:
+          project-url: https://github.com/orgs/cockroachdb/projects/35
+          github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}
+          labeled: T-jobs

--- a/TEAMS.yaml
+++ b/TEAMS.yaml
@@ -89,7 +89,8 @@ cockroachdb/multi-tenant:
 cockroachdb/jobs:
   aliases:
     cockroachdb/jobs-prs: other
-  triage_column_id: 16360666
+  # Jobs uses GH projects v2, which doesn't have a REST API, so no triage column ID
+  # see .github/workflows/add-issues-to-project.yml
   label: T-jobs
 cockroachdb/cloud-identity:
   triage_column_id: 18588697


### PR DESCRIPTION
And stop adding to the old one

Epic: none
Jira: none