### PR TITLE
colexecspan: add missing JSON support

### DIFF
--- a/pkg/sql/colexec/execgen/cmd/execgen/span_encoder_gen.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/span_encoder_gen.go
@@ -44,10 +44,6 @@ func genSpanEncoder(inputFileContents string, wr io.Writer) error {
 	for _, asc := range []bool{true, false} {
 		info := spanEncoderDirectionInfo{Asc: asc}
 		for _, family := range supportedCanonicalTypeFamilies {
-			if family == types.JsonFamily {
-				// We are currently unable to encode JSON as a table key.
-				continue
-			}
 			familyInfo := spanEncoderTypeFamilyInfo{TypeFamily: familyToString(family)}
 			for _, width := range supportedWidthsByCanonicalTypeFamily[family] {
 				overload := spanEncoderTmplInfo{
@@ -145,6 +141,18 @@ func (info spanEncoderTmplInfo) AssignSpanEncoding(appendTo, valToEncode string)
 				colexecerror.ExpectedError(err)
 			}
     `, appendTo, funcName, valToEncode)
+	case types.JsonFamily:
+		dir := "encoding.Ascending"
+		if !info.Asc {
+			dir = "encoding.Descending"
+		}
+		return fmt.Sprintf(`
+			var err error
+			%[1]s, err = %[2]s.EncodeForwardIndex(%[1]s, %[3]s)
+			if err != nil {
+				colexecerror.ExpectedError(err)
+			}
+    `, appendTo, valToEncode, dir)
 	case typeconv.DatumVecCanonicalTypeFamily:
 		dir := "encoding.Ascending"
 		if !info.Asc {

--- a/pkg/sql/logictest/testdata/logic_test/json_index
+++ b/pkg/sql/logictest/testdata/logic_test/json_index
@@ -484,3 +484,14 @@ SELECT t1.x FROM t1 INNER LOOKUP JOIN t2 ON t1.x = t2.x
 ----
 [1, [2, 3]]
 
+# Regression test for not supporting vectorized span encoder for JSONs (#101356).
+statement ok
+CREATE TABLE t101356 (j JSONB PRIMARY KEY, i1 INT, i2 INT, INDEX (i1));
+INSERT INTO t101356 VALUES ('1'::JSON, 1, 1);
+
+# This query reads from the index and then performs the index join - during the
+# index join is when the vectorized span encoder is utilized.
+query TII
+SELECT * FROM t101356 WHERE i1 = 1
+----
+1  1  1


### PR DESCRIPTION
Now that we can key-encode JSONs, so we also need to make the span encoder support JSONs too.

Fixes: #101356.

Release note: None