### PR TITLE
sqlsmith: call udfs in sqlsmith queries

### DIFF
--- a/pkg/internal/sqlsmith/scalar.go
+++ b/pkg/internal/sqlsmith/scalar.go
@@ -415,6 +415,9 @@ func makeFunc(s *Smither, ctx Context, typ *types.T, refs colRefs) (tree.TypedEx
 		return nil, false
 	}
 	fn := fns[s.rnd.Intn(len(fns))]
+	if s.disableUDFs && fn.overload.IsUDF {
+		return nil, false
+	}
 	if s.disableNondeterministicFns && fn.overload.Volatility > volatility.Immutable {
 		return nil, false
 	}


### PR DESCRIPTION
This PR adds UDFs created by sqlsmith to the list of available functions that can then be called in other queries generated by sqlsmith.

Epic: CRDB-20370
Informs: #90782

Release note: None