### PR TITLE
roachprod: only use cluster with positive lifetime

### DIFF
--- a/pkg/roachprod/cloud/cluster_cloud.go
+++ b/pkg/roachprod/cloud/cluster_cloud.go
@@ -132,6 +132,15 @@ func (c *Cluster) LifetimeRemaining() time.Duration {
 	return time.Until(c.GCAt())
 }
 
+// IsLive is true if last known lifetime is still greater than one minute.
+// One minute is arbitrary, we just want to give roachprod some time to run
+// actual command before cluster disappears.
+// If lifetime was not parsed, then we don't know so pretend it is live to
+// avoid making it unusable.
+func (c *Cluster) IsLive() bool {
+	return c.Lifetime == 0 || c.LifetimeRemaining() > time.Minute
+}
+
 func (c *Cluster) String() string {
 	var buf bytes.Buffer
 	fmt.Fprintf(&buf, "%s: %d", c.Name, len(c.VMs))

--- a/pkg/roachprod/roachprod.go
+++ b/pkg/roachprod/roachprod.go
@@ -168,6 +168,13 @@ func newCluster(
 		return nil, err
 	}
 
+	if !metadata.IsLive() {
+		err := errors.Newf(`expired cluster: %s`, name)
+		err = errors.WithHintf(err, "\nRemaining lifetime: %s\n  ", metadata.LifetimeRemaining())
+		err = errors.WithHint(err, `Use "roachprod sync" to update cluster lifetime if cluster cache is out of sync.`)
+		return nil, err
+	}
+
 	if clusterSettings.DebugDir == "" {
 		clusterSettings.DebugDir = os.ExpandEnv(config.DefaultDebugDir)
 	}


### PR DESCRIPTION
Previously it was possible to use locally cached cluster which is already expired and was GCd. That could lead to operations affecting VMs that belong to different clusters that is now reusing old cluster IPs.
This PR adds an expiration check when reading cluster info from local file cache.

Epic: none

Release note: None