### PR TITLE
release-22.1: kvserver: skip `TestTerm` and `TestTruncateLog`

### DIFF
--- a/pkg/kv/kvserver/batcheval/cmd_truncate_log_test.go
+++ b/pkg/kv/kvserver/batcheval/cmd_truncate_log_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/storage"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -55,6 +56,8 @@ func readTruncStates(
 func TestTruncateLog(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
+
+	skip.WithIssue(t, 79719)
 
 	ctx := context.Background()
 	const (

--- a/pkg/kv/kvserver/replica_test.go
+++ b/pkg/kv/kvserver/replica_test.go
@@ -859,15 +859,15 @@ func TestLeaseReplicaNotInDesc(t *testing.T) {
 }
 
 // TestReplicaRangeMismatchRedirect tests two behaviors that should occur.
-// - Following a Range split, the client may send BatchRequests based on stale
-//   cache data targeting the wrong range. Internally this triggers a
-//   RangeKeyMismatchError, but in the cases where the RHS of the range is still
-//   present on the local store, we opportunistically retry server-side by
-//   re-routing the request to the right range. No error is bubbled up to the
-//   client.
-// - This test also ensures that after a successful server-side retry attempt we
-//   bubble up the most up-to-date RangeInfos for the client to update its range
-//   cache.
+//   - Following a Range split, the client may send BatchRequests based on stale
+//     cache data targeting the wrong range. Internally this triggers a
+//     RangeKeyMismatchError, but in the cases where the RHS of the range is still
+//     present on the local store, we opportunistically retry server-side by
+//     re-routing the request to the right range. No error is bubbled up to the
+//     client.
+//   - This test also ensures that after a successful server-side retry attempt we
+//     bubble up the most up-to-date RangeInfos for the client to update its range
+//     cache.
 func TestReplicaRangeMismatchRedirect(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
@@ -7344,6 +7344,8 @@ func TestTerm(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
+	skip.WithIssue(t, 100449)
+
 	testutils.RunTrueAndFalse(t, "loosely-coupled", func(t *testing.T, looselyCoupled bool) {
 		ctx := context.Background()
 		tc := testContext{}
@@ -8696,13 +8698,12 @@ func TestRefreshFromBelowGCThreshold(t *testing.T) {
 // The test contains a subtest for each of the combinations of the following
 // boolean options:
 //
-// - followerRead: configures whether the read should be served from the
+//   - followerRead: configures whether the read should be served from the
 //     leaseholder replica or from a follower replica.
 //
-// - thresholdFirst: configures whether the GC operation should be split into
+//   - thresholdFirst: configures whether the GC operation should be split into
 //     two requests, with the first bumping the GC threshold and the second
 //     GCing the expired version. This is how the real MVCC GC queue works.
-//
 func TestGCThresholdRacesWithRead(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
@@ -13225,14 +13226,14 @@ func TestSplitSnapshotWarningStr(t *testing.T) {
 //
 // The test does the following things:
 //
-//  * Propose cmd at an initial MaxLeaseIndex.
-//  * Refresh that cmd immediately.
-//  * Fail the initial command with an injected error which will lead to a
-//    reproposal at a higher MaxLeaseIndex.
-//  * Simultaneously update the lease sequence number on the replica so all
-//    future commands will fail with NotLeaseHolderError.
-//  * Enable unconditional refreshes of commands after a raft ready so that
-//    higher MaxLeaseIndex commands are refreshed.
+//   - Propose cmd at an initial MaxLeaseIndex.
+//   - Refresh that cmd immediately.
+//   - Fail the initial command with an injected error which will lead to a
+//     reproposal at a higher MaxLeaseIndex.
+//   - Simultaneously update the lease sequence number on the replica so all
+//     future commands will fail with NotLeaseHolderError.
+//   - Enable unconditional refreshes of commands after a raft ready so that
+//     higher MaxLeaseIndex commands are refreshed.
 //
 // This order of events ensures that there will be a committed command which
 // experiences the lease mismatch error but does not carry the highest


### PR DESCRIPTION
These tests frequently flake with "requested index is unavailable due to compaction". However, stressing the tests locally do not reproduce the issue (even under race, which slows the test down and can provoke flakes).

These tests have been flaky at least as far back as 2019, and the flake is likely a race condition around log truncations that violate the test's expectations. However, the tests are no longer flaky in 22.2 and later, and attempts to find the reason have been unsuccessful.

Since 22.1 is out of support shortly anyway, and this is no longer flaky in newer releases, we cut our losses and skip the tests on `release-22.1`.

Resolves #79719.
Resolves #100449.

Epic: none
Release note: None

Release justification: avoids test flake.