### PR TITLE
pkg/roachtest: increase multi-region restore timeout

### DIFF
--- a/pkg/cmd/roachtest/tests/restore.go
+++ b/pkg/cmd/roachtest/tests/restore.go
@@ -298,7 +298,7 @@ func registerRestore(r registry.Registry) {
 				nodes: 9,
 				zones: []string{"us-east-2b", "us-west-2b", "eu-west-1b"}}), // These zones are AWS-specific.
 			backup:  makeBackupSpecs(backupSpecs{}),
-			timeout: 1 * time.Hour,
+			timeout: 90 * time.Minute,
 			tags:    registry.Tags("aws"),
 		},
 		{


### PR DESCRIPTION
New timeout is 90 minutes. This makes sense because the test involves sending 400GB across the Atlantic.

Fixes: #101287

Release note: None