### PR TITLE
storage: don't return WriteTooOld on inline DeleteRange that hits non-inline value

### DIFF
--- a/pkg/storage/mvcc_test.go
+++ b/pkg/storage/mvcc_test.go
@@ -1780,11 +1780,10 @@ func TestMVCCDeleteRangeInline(t *testing.T) {
 	}
 
 	// Attempt to delete non-inline key at zero timestamp; should fail.
-	const writeTooOldErrString = "WriteTooOldError"
 	if _, _, _, err := MVCCDeleteRange(ctx, engine, nil, testKey6, keyMax,
 		1, hlc.Timestamp{Logical: 0}, hlc.ClockTimestamp{}, nil, true,
-	); !testutils.IsError(err, writeTooOldErrString) {
-		t.Fatalf("got error %v, expected error with text '%s'", err, writeTooOldErrString)
+	); !testutils.IsError(err, inlineMismatchErrString) {
+		t.Fatalf("got error %v, expected error with text '%s'", err, inlineMismatchErrString)
 	}
 
 	// Attempt to delete inline keys in a transaction; should fail.

--- a/pkg/storage/testdata/mvcc_histories/delete_range_inline
+++ b/pkg/storage/testdata/mvcc_histories/delete_range_inline
@@ -1,0 +1,51 @@
+# Mix inline and mvcc delete range requests with inline and mvcc key-values.
+
+run ok
+put k=inline-key v=inline-val ts=0
+----
+>> at end:
+meta: "inline-key"/0,0 -> txn={<nil>} ts=0,0 del=false klen=0 vlen=0 raw=/BYTES/inline-val mergeTs=<nil> txnDidNotUpdateMeta=false
+
+run ok
+put k=mvcc-key v=mvcc-val ts=10
+----
+>> at end:
+meta: "inline-key"/0,0 -> txn={<nil>} ts=0,0 del=false klen=0 vlen=0 raw=/BYTES/inline-val mergeTs=<nil> txnDidNotUpdateMeta=false
+data: "mvcc-key"/10.000000000,0 -> /BYTES/mvcc-val
+
+
+# Incompatible requests.
+
+run error
+del_range k=inline-key end=inline-key-end ts=20
+----
+>> at end:
+meta: "inline-key"/0,0 -> txn={<nil>} ts=0,0 del=false klen=0 vlen=0 raw=/BYTES/inline-val mergeTs=<nil> txnDidNotUpdateMeta=false
+data: "mvcc-key"/10.000000000,0 -> /BYTES/mvcc-val
+error: (*withstack.withStack:) "inline-key"/0,0: put is inline=false, but existing value is inline=true
+
+run error
+del_range k=mvcc-key end=mvcc-key-end ts=0
+----
+>> at end:
+meta: "inline-key"/0,0 -> txn={<nil>} ts=0,0 del=false klen=0 vlen=0 raw=/BYTES/inline-val mergeTs=<nil> txnDidNotUpdateMeta=false
+data: "mvcc-key"/10.000000000,0 -> /BYTES/mvcc-val
+error: (*withstack.withStack:) "mvcc-key"/0,0: put is inline=true, but existing value is inline=false
+
+
+# Compatible requests.
+
+run ok
+del_range k=inline-key end=inline-key-end ts=0
+----
+del_range: "inline-key"-"inline-key-end" -> deleted 1 key(s)
+>> at end:
+data: "mvcc-key"/10.000000000,0 -> /BYTES/mvcc-val
+
+run ok
+del_range k=mvcc-key end=mvcc-key-end ts=20
+----
+del_range: "mvcc-key"-"mvcc-key-end" -> deleted 1 key(s)
+>> at end:
+data: "mvcc-key"/20.000000000,0 -> /<empty>
+data: "mvcc-key"/10.000000000,0 -> /BYTES/mvcc-val


### PR DESCRIPTION
Fixes #101440.

This commit resolves a condition where an inline DeleteRange request could return a WriteTooOld error when encountering a non-inline value, instead of returning the expected assertion error. This could trigger a fatal error in `tryBumpBatchTimestamp`. See the corresponding issue for more details.

Note that this is not resolving any condition that could cause an inline DeleteRange request to hit a non-inline value, it's just ensuring that if corruption creates such a condition, we don't fatal.

Release note: None