### PR TITLE
sql/sessiondata: fixes for parsing of search_path

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -2932,7 +2932,7 @@ require_explicit_primary_keys                         off                 NULL  
 results_buffer_size                                   16384               NULL  user     NULL      16384               16384
 role                                                  none                NULL  user     NULL      none                none
 row_security                                          off                 NULL  user     NULL      off                 off
-search_path                                           "$user", public     NULL  user     NULL      $user,public        $user,public
+search_path                                           "$user", public     NULL  user     NULL      "$user", public     "$user", public
 serial_normalization                                  rowid               NULL  user     NULL      rowid               rowid
 server_encoding                                       UTF8                NULL  user     NULL      UTF8                UTF8
 server_version                                        13.0.0              NULL  user     NULL      13.0.0              13.0.0

--- a/pkg/sql/logictest/testdata/logic_test/schema
+++ b/pkg/sql/logictest/testdata/logic_test/schema
@@ -1169,3 +1169,93 @@ query I
 SELECT abs(1);
 ----
 1
+
+subtest search_path
+
+# Verify that spaces are trimmed.
+statement ok
+SET search_path = public,      a,     "   b  ",   c
+
+query T
+SHOW search_path
+----
+public, a, "   b  ", c
+
+# When each identifier is enclosed in single quotes, the search_path should
+# have multiple elements.
+statement ok
+SET search_path = '$user', 'public'
+
+query T
+SHOW search_path
+----
+"$user", public
+
+# When the whole value is enclosed in single quotes, the search_path should
+# have contain one element.
+statement ok
+SET search_path = '$user, public'
+
+query T
+SHOW search_path
+----
+"$user, public"
+
+# With single quotes, the identifier case is preserved.
+statement ok
+SET search_path = 'Abc', 'public'
+
+query T
+SHOW search_path
+----
+"Abc", public
+
+# Without single quotes, the identifier is normalized to lower case.
+statement ok
+SET search_path = Abc, 'public'
+
+query T
+SHOW search_path
+----
+abc, public
+
+# An empty identifier is allowed.
+statement ok
+SET search_path = ''
+
+query T
+SHOW search_path
+----
+""
+
+# An empty identifier is allowed.
+statement ok
+SET search_path = ""
+
+query T
+SHOW search_path
+----
+""
+
+# A whitespace identifier is allowed.
+statement ok
+SET search_path = "  ", abc
+
+query T
+SHOW search_path
+----
+"  ", abc
+
+# Handle special characters.
+statement ok
+SET search_path = 'a\bc', "d\ef", 'g-hi', "j-kl"
+
+query T
+SHOW search_path
+----
+"a\bc", "d\ef", "g-hi", "j-kl"
+
+statement error syntax error
+SET search_path = abc, def,
+
+subtest end

--- a/pkg/sql/sessiondata/BUILD.bazel
+++ b/pkg/sql/sessiondata/BUILD.bazel
@@ -5,6 +5,7 @@ go_library(
     name = "sessiondata",
     srcs = [
         "internal.go",
+        "parse_search_path.go",
         "search_path.go",
         "sequence_state.go",
         "session_data.go",
@@ -38,6 +39,7 @@ go_test(
     embed = [":sessiondata"],
     deps = [
         "//pkg/sql/sessiondatapb",
+        "//pkg/util/randutil",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
     ],

--- a/pkg/sql/sessiondata/parse_search_path.go
+++ b/pkg/sql/sessiondata/parse_search_path.go
@@ -1,0 +1,167 @@
+// Copyright 2023 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package sessiondata
+
+import (
+	"strings"
+	"unicode"
+	"unicode/utf8"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/lexbase"
+)
+
+// gobbleString advances the parser for the remainder of the current string
+// until it sees a non-escaped termination character, returning the resulting
+// string, not including the termination character.
+func (p *parseState) gobbleString(isQuoted bool) (out string, ok bool) {
+	result := &strings.Builder{}
+	start := 0
+	i := 0
+	isTerminatingChar := func(ch byte) bool { return false }
+	if !isQuoted {
+		isTerminatingChar = func(ch byte) bool {
+			return ch == ','
+		}
+	}
+
+	for i < len(p.s) && !isTerminatingChar(p.s[i]) {
+		if p.s[i] == '"' {
+			if !isQuoted {
+				// It's always invalid to see a quote if we are not in a quoted string.
+				return "", false
+			}
+			result.WriteString(p.s[start:i])
+			if i+1 < len(p.s) && p.s[i+1] == '"' {
+				// If the string is quoted and the following character is also a double
+				// quote, then the two characters are treated as an escape sequence for
+				// one double quote.
+				result.WriteByte(p.s[i+1])
+				i += 2
+				start = i
+				continue
+			}
+			// Otherwise, this quote is the end of the string.
+			start = i
+			break
+		} else {
+			i++
+		}
+	}
+	if isQuoted && i >= len(p.s) {
+		return "", false
+	} else if i > len(p.s) {
+		return "", false
+	}
+	result.WriteString(p.s[start:i])
+	p.s = p.s[i:]
+	return result.String(), true
+}
+
+type parseState struct {
+	s      string
+	result []string
+}
+
+func (p *parseState) advance() {
+	_, l := utf8.DecodeRuneInString(p.s)
+	p.s = p.s[l:]
+}
+
+func (p *parseState) eatWhitespace() {
+	for unicode.IsSpace(p.peek()) {
+		p.advance()
+	}
+}
+
+func (p *parseState) peek() rune {
+	r, _ := utf8.DecodeRuneInString(p.s)
+	return r
+}
+
+func (p *parseState) eof() bool {
+	return len(p.s) == 0
+}
+
+func (p *parseState) parseQuotedString() (string, bool) {
+	return p.gobbleString(true)
+}
+
+func (p *parseState) parseUnquotedString() (string, bool) {
+	out, ok := p.gobbleString(false)
+	if !ok {
+		return "", false
+	}
+	out = strings.TrimSpace(out)
+	if out == "" {
+		return "", false
+	}
+	return lexbase.NormalizeName(out), true
+}
+
+func (p *parseState) parseElement() bool {
+	var next string
+	var ok bool
+	r := p.peek()
+	switch r {
+	case '"':
+
+		p.advance()
+		next, ok = p.parseQuotedString()
+		if !ok {
+			return false
+		}
+		p.advance()
+	default:
+		if r == ',' {
+			return false
+		}
+		next, ok = p.parseUnquotedString()
+		if !ok {
+			return false
+		}
+	}
+
+	p.result = append(p.result, next)
+	return true
+}
+
+// doParseSearchPathFromString parses a search path string into a list of
+// schema names. Each element in the resulting list is guaranteed to be a
+// valid bare identifier. If the input cannot be parsed, the function returns
+// false.
+func doParseSearchPathFromString(s string) ([]string, bool) {
+	parser := parseState{
+		s:      s,
+		result: make([]string, 0, strings.Count(s, ",")),
+	}
+
+	parser.eatWhitespace()
+	if parser.eof() {
+		return nil, false
+	}
+	if ok := parser.parseElement(); !ok {
+		return nil, false
+	}
+	parser.eatWhitespace()
+	for string(parser.peek()) == "," {
+		parser.advance()
+		parser.eatWhitespace()
+		if ok := parser.parseElement(); !ok {
+			return nil, false
+		}
+	}
+	parser.eatWhitespace()
+	if !parser.eof() {
+		return nil, false
+	}
+
+	return parser.result, true
+}

--- a/pkg/sql/tests/BUILD.bazel
+++ b/pkg/sql/tests/BUILD.bazel
@@ -50,6 +50,7 @@ go_test(
         "repair_test.go",
         "rsg_test.go",
         "schema_changes_in_parallel_test.go",
+        "search_path_test.go",
         "show_commit_timestamp_test.go",
         "split_test.go",
         "system_table_test.go",

--- a/pkg/sql/tests/search_path_test.go
+++ b/pkg/sql/tests/search_path_test.go
@@ -1,0 +1,80 @@
+// Copyright 2023 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package tests
+
+import (
+	"context"
+	gosql "database/sql"
+	"net/url"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/security/username"
+	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSearchPathEndToEnd(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	ctx := context.Background()
+	defer s.Stopper().Stop(ctx)
+
+	pgURL, cleanupFunc := sqlutils.PGUrl(
+		t, s.ServingSQLAddr(), "TestSearchPathQuotingInConnectionString" /* prefix */, url.User(username.RootUser),
+	)
+	defer cleanupFunc()
+
+	pgURL.RawQuery += `&search_path="Abc", Abc`
+	db, err := gosql.Open("postgres", pgURL.String())
+	require.NoError(t, err)
+	defer db.Close()
+
+	for _, stmt := range []string{
+		`CREATE SCHEMA abc`,
+		`CREATE TABLE abc.t(a text);`,
+		`INSERT INTO abc.t values ('lower case schema')`,
+	} {
+		_, err = db.Exec(stmt)
+		require.NoError(t, err)
+	}
+
+	var searchPath string
+	err = db.QueryRow("SHOW search_path").Scan(&searchPath)
+	require.NoError(t, err)
+	require.Equal(t, `"Abc", abc`, searchPath)
+
+	var a string
+	err = db.QueryRow("SELECT a FROM t").Scan(&a)
+	require.NoError(t, err)
+	// But the `Abc` schema in the search_path gets normalized to `abc`.
+	require.Equal(t, "lower case schema", a)
+
+	for _, stmt := range []string{
+		`CREATE SCHEMA "Abc"`,
+		`CREATE TABLE "Abc".t(a text);`,
+		`INSERT INTO "Abc".t values ('mixed case schema')`,
+	} {
+		_, err = db.Exec(stmt)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	err = db.QueryRow("SELECT a FROM t").Scan(&a)
+	require.NoError(t, err)
+	// Now the `"Abc"` schema should be preferred.
+	require.Equal(t, "mixed case schema", a)
+}

--- a/pkg/util/randutil/rand.go
+++ b/pkg/util/randutil/rand.go
@@ -227,11 +227,12 @@ const PrintableKeyAlphabet = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWX
 // be printable without further escaping if alphabet is restricted to
 // alphanumeric chars.
 func RandString(rng *rand.Rand, length int, alphabet string) string {
-	buf := make([]byte, length)
-	for i := range buf {
-		buf[i] = alphabet[rng.Intn(len(alphabet))]
+	runes := []rune(alphabet)
+	buf := &strings.Builder{}
+	for i := 0; i < length; i++ {
+		buf.WriteRune(runes[rng.Intn(len(runes))])
 	}
-	return string(buf)
+	return buf.String()
 }
 
 // SeedForTests seeds the random number generator and prints the seed


### PR DESCRIPTION
fixes https://github.com/cockroachdb/cockroach/issues/101394
fixes https://github.com/cockroachdb/cockroach/issues/53971

This commit improves the handling of the search_path variable by adding a custom parser for the string representation of the search_path. The parser is similar to the ones in parse_tuple.go and parse_array.go, which handle very similar escaping rules.

Release note (bug fix): The search_path session variable now supports schema names that have commas in them. This patch also fixes a bug with parsing the search_path if it was specified in the connection string and the search_path had a quote in it.

Release note (backward-incompatible change): Previously, if a
search_path was specified in the connection string parameters, it would
be treated case sensitively always. Now, in order to have the schema
names in the search_path respect case, the name must be quoted with
double quotes.