### PR TITLE
kvcoord: introduce RangeUnavailableError and DistSender fail-fast behavior

### DIFF
--- a/pkg/kv/kvpb/BUILD.bazel
+++ b/pkg/kv/kvpb/BUILD.bazel
@@ -16,6 +16,7 @@ go_library(
         "data.go",
         "errors.go",
         "method.go",
+        "range_unavailable_error.go",
         "replica_unavailable_error.go",
         ":gen-batch-generated",  # keep
         ":gen-errordetailtype-stringer",  # keep
@@ -54,6 +55,7 @@ go_test(
         "api_test.go",
         "batch_test.go",
         "errors_test.go",
+        "range_unavailable_error_test.go",
         "replica_unavailable_error_test.go",
         "string_test.go",
     ],

--- a/pkg/kv/kvpb/errors.proto
+++ b/pkg/kv/kvpb/errors.proto
@@ -407,6 +407,11 @@ message ReplicaUnavailableError {
   optional errorspb.EncodedError cause = 5 [(gogoproto.nullable) = false];
 }
 
+message RangeUnavailableError {
+  optional roachpb.RangeDescriptor desc = 2 [(gogoproto.nullable) = false];
+  optional errorspb.EncodedError cause = 5 [(gogoproto.nullable) = false];
+}
+
 // A RaftGroupDeletedError indicates a raft group has been deleted for
 // the replica.
 message RaftGroupDeletedError {
@@ -720,7 +725,6 @@ message Error {
 
   reserved 1, 2, 3, 6 ;
 }
-
 
 // InsufficientSpaceError is an error due to insufficient space remaining.
 message InsufficientSpaceError {

--- a/pkg/kv/kvpb/range_unavailable_error.go
+++ b/pkg/kv/kvpb/range_unavailable_error.go
@@ -1,0 +1,65 @@
+// Copyright 2023 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package kvpb
+
+import (
+	context "context"
+	"fmt"
+
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/errors"
+	"github.com/gogo/protobuf/proto"
+)
+
+// NewRangeUnavailableError initializes a new *RangeUnavailableError. It is
+// provided with the relevant range descriptor.
+func NewRangeUnavailableError(cause error, desc *roachpb.RangeDescriptor) error {
+	return &RangeUnavailableError{
+		Desc:  *desc,
+		Cause: errors.EncodeError(context.Background(), cause),
+	}
+}
+
+var _ errors.SafeFormatter = (*RangeUnavailableError)(nil)
+var _ fmt.Formatter = (*RangeUnavailableError)(nil)
+var _ errors.Wrapper = (*RangeUnavailableError)(nil)
+
+// SafeFormatError implements errors.SafeFormatter.
+func (e *RangeUnavailableError) SafeFormatError(p errors.Printer) error {
+	p.Printf("range unavailable: unable to serve request to %s: %s", e.Desc, e.Unwrap())
+	return nil
+}
+
+// Format implements fmt.Formatter.
+func (e *RangeUnavailableError) Format(s fmt.State, verb rune) { errors.FormatError(e, s, verb) }
+
+// Error implements error.
+func (e *RangeUnavailableError) Error() string {
+	return fmt.Sprint(e)
+}
+
+// Unwrap implements errors.Wrapper.
+func (e *RangeUnavailableError) Unwrap() error {
+	return errors.DecodeError(context.Background(), e.Cause)
+}
+
+func init() {
+	encode := func(ctx context.Context, err error) (msgPrefix string, safeDetails []string, payload proto.Message) {
+		errors.As(err, &payload) // payload = err.(proto.Message)
+		return "", nil, payload
+	}
+	decode := func(ctx context.Context, cause error, msgPrefix string, safeDetails []string, payload proto.Message) error {
+		return payload.(*RangeUnavailableError)
+	}
+	typeName := errors.GetTypeKey((*RangeUnavailableError)(nil))
+	errors.RegisterWrapperEncoder(typeName, encode)
+	errors.RegisterWrapperDecoder(typeName, decode)
+}

--- a/pkg/kv/kvpb/range_unavailable_error_test.go
+++ b/pkg/kv/kvpb/range_unavailable_error_test.go
@@ -1,0 +1,39 @@
+// Copyright 2023 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package kvpb
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/testutils/echotest"
+	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/redact"
+)
+
+func TestRangeUnavailableError(t *testing.T) {
+	ctx := context.Background()
+	var _ = (*RangeUnavailableError)(nil)
+	rDesc := roachpb.ReplicaDescriptor{NodeID: 1, StoreID: 2, ReplicaID: 3}
+	var set roachpb.ReplicaSet
+	set.AddReplica(rDesc)
+	desc := roachpb.NewRangeDescriptor(123, roachpb.RKeyMin, roachpb.RKeyMax, set)
+
+	errRangeUnavailable := errors.New("too many failed range sending attempts with no response")
+	var err = NewRangeUnavailableError(errRangeUnavailable, desc)
+	err = errors.DecodeError(ctx, errors.EncodeError(ctx, err))
+
+	s := fmt.Sprintf("%s\n%s", err, redact.Sprint(err))
+	echotest.Require(t, s, filepath.Join("testdata", "range_unavailable_error.txt"))
+}

--- a/pkg/kv/kvpb/testdata/range_unavailable_error.txt
+++ b/pkg/kv/kvpb/testdata/range_unavailable_error.txt
@@ -1,0 +1,4 @@
+echo
+----
+range unavailable: unable to serve request to r123:/M{in-ax} [(n1,s2):1, next=2, gen=0]: too many failed range sending attempts with no response
+range unavailable: unable to serve request to r123:‹/M{in-ax}› [(n1,s2):1, next=2, gen=0]: too many failed range sending attempts with no response

--- a/pkg/testutils/lint/lint_test.go
+++ b/pkg/testutils/lint/lint_test.go
@@ -1256,6 +1256,7 @@ func TestLint(t *testing.T) {
 			":!kv/kvclient/kvcoord/lock_spans_over_budget_error.go",
 			":!spanconfig/errors.go",
 			":!kv/kvpb/replica_unavailable_error.go",
+			":!kv/kvpb/range_unavailable_error.go",
 			":!kv/kvpb/ambiguous_result_error.go",
 			":!sql/flowinfra/flow_registry.go",
 			":!sql/pgwire/pgerror/constraint_name.go",


### PR DESCRIPTION
Previously, the RangeUnavailableError did not exist,
and the DistSender would continue infinitely if
no responses from replicas representing a range
were received, as noted in the fail-fast DistSender
work requested in #74503. This fail-fast work also
requires a RangeUnavailableError. Therefore, this PR
resolves that unmet requirement by introducing the error
along with creating the fail-fast behavior within DistSender.
    
Epic: none
Release note (performance improvement): introduces the
RangeUnavailableError and enables fail-fast behavior in
DistSender.