### PR TITLE
bootstrap: don't install `ccache`

### DIFF
--- a/build/bootstrap/bootstrap-debian.sh
+++ b/build/bootstrap/bootstrap-debian.sh
@@ -16,7 +16,6 @@ sudo DEBIAN_FRONTEND=noninteractive apt-get dist-upgrade -y -o Dpkg::Options::="
 sudo apt-get install -y --no-install-recommends \
   mosh \
   autoconf \
-  ccache \
   docker.io \
   libncurses-dev \
   libresolv-wrapper \
@@ -31,8 +30,7 @@ sudo apt-get install -y --no-install-recommends \
 sudo adduser "${USER}" docker
 
 # Configure environment variables.
-echo 'export PATH="/usr/lib/ccache:${PATH}:$HOME/go/src/github.com/cockroachdb/cockroach/bin:/usr/local/go/bin"' >> ~/.bashrc_bootstrap
-echo 'export COCKROACH_BUILDER_CCACHE=1' >> ~/.bashrc_bootstrap
+echo 'export PATH="${PATH}:$HOME/go/src/github.com/cockroachdb/cockroach/bin:/usr/local/go/bin"' >> ~/.bashrc_bootstrap
 echo '. ~/.bashrc_bootstrap' >> ~/.bashrc
 . ~/.bashrc_bootstrap
 


### PR DESCRIPTION
Having ccache installed breaks the Bazel build.

Epic: none
Release note: None