### PR TITLE
ci: use `TESTS` in roachtest private nightly instead of hard-coding name

### DIFF
--- a/build/teamcity/internal/cockroach/nightlies/private_roachtest.sh
+++ b/build/teamcity/internal/cockroach/nightlies/private_roachtest.sh
@@ -7,5 +7,7 @@ dir="$(dirname $(dirname $(dirname $(dirname $(dirname "${0}")))))"
 source "$dir/teamcity-support.sh"  # For $root
 source "$dir/teamcity-bazel-support.sh"  # For run_bazel
 
+export TESTS="${TESTS:-costfuzz/workload-replay}"
+
 BAZEL_SUPPORT_EXTRA_DOCKER_ARGS="-e LITERAL_ARTIFACTS_DIR=$root/artifacts -e BUILD_VCS_NUMBER -e CLOUD=gce -e TESTS -e COUNT -e GITHUB_API_TOKEN -e GITHUB_ORG -e GITHUB_REPO -e GOOGLE_EPHEMERAL_CREDENTIALS -e SLACK_TOKEN -e TC_BUILDTYPE_ID -e TC_BUILD_BRANCH -e TC_BUILD_ID -e TC_SERVER_URL" \
 			       run_bazel build/teamcity/internal/cockroach/nightlies/private_roachtest_impl.sh

--- a/build/teamcity/internal/cockroach/nightlies/private_roachtest_impl.sh
+++ b/build/teamcity/internal/cockroach/nightlies/private_roachtest_impl.sh
@@ -21,4 +21,4 @@ build/teamcity-roachtest-invoke.sh \
   --cockroach-short="${PWD}/bin/cockroach-short-ea" \
   --artifacts=/artifacts \
   --artifacts-literal="${LITERAL_ARTIFACTS_DIR:-}" \
-  costfuzz/workload-replay
+  "${TESTS}"


### PR DESCRIPTION
Part of: DEVINFHD-809
Epic: none
Release note: None