### PR TITLE
release-22.1: pgwire: fix description of sql.conns metric

### DIFF
--- a/pkg/sql/pgwire/server.go
+++ b/pkg/sql/pgwire/server.go
@@ -118,7 +118,7 @@ const (
 var (
 	MetaConns = metric.Metadata{
 		Name:        "sql.conns",
-		Help:        "Number of active sql connections",
+		Help:        "Number of open SQL connections",
 		Measurement: "Connections",
 		Unit:        metric.Unit_COUNT,
 	}


### PR DESCRIPTION
Backport 1/1 commits from #101348.

/cc @cockroachdb/release

Release justification: docs only change

---

The word "active" is misleading, since this metric includes connections that are running a query as well as ones that are idle.

Epic: None
Release note: None
