### PR TITLE
ci: set `ROACHTEST_BUCKET` appropriately for private nightlies

### DIFF
--- a/build/teamcity/internal/cockroach/nightlies/private_roachtest.sh
+++ b/build/teamcity/internal/cockroach/nightlies/private_roachtest.sh
@@ -8,6 +8,7 @@ source "$dir/teamcity-support.sh"  # For $root
 source "$dir/teamcity-bazel-support.sh"  # For run_bazel
 
 export TESTS="${TESTS:-costfuzz/workload-replay}"
+export ROACHTEST_BUCKET="${ROACHTEST_BUCKET:-cockroach-nightly-private}"
 
-BAZEL_SUPPORT_EXTRA_DOCKER_ARGS="-e LITERAL_ARTIFACTS_DIR=$root/artifacts -e BUILD_VCS_NUMBER -e CLOUD=gce -e TESTS -e COUNT -e GITHUB_API_TOKEN -e GITHUB_ORG -e GITHUB_REPO -e GOOGLE_EPHEMERAL_CREDENTIALS -e SLACK_TOKEN -e TC_BUILDTYPE_ID -e TC_BUILD_BRANCH -e TC_BUILD_ID -e TC_SERVER_URL" \
+BAZEL_SUPPORT_EXTRA_DOCKER_ARGS="-e LITERAL_ARTIFACTS_DIR=$root/artifacts -e BUILD_VCS_NUMBER -e CLOUD=gce -e TESTS -e COUNT -e GITHUB_API_TOKEN -e GITHUB_ORG -e GITHUB_REPO -e GOOGLE_EPHEMERAL_CREDENTIALS -e ROACHTEST_BUCKET -e SLACK_TOKEN -e TC_BUILDTYPE_ID -e TC_BUILD_BRANCH -e TC_BUILD_ID -e TC_SERVER_URL" \
 			       run_bazel build/teamcity/internal/cockroach/nightlies/private_roachtest_impl.sh

--- a/build/teamcity/util/roachtest_util.sh
+++ b/build/teamcity/util/roachtest_util.sh
@@ -19,7 +19,7 @@ stats_dir="$(date +"%Y%m%d")-${TC_BUILD_ID}"
 # Set up a function we'll invoke at the end.
 function upload_stats {
  if tc_release_branch; then
-      bucket="cockroach-nightly-${CLOUD}"
+      bucket="${ROACHTEST_BUCKET:-cockroach-nightly-${CLOUD}}"
       if [[ "${CLOUD}" == "gce" ]]; then
           # GCE, having been there first, gets an exemption.
           bucket="cockroach-nightly"


### PR DESCRIPTION
This nightly will use an unusual private location for storing artifacts.

Part of: DEVINFHD-809
Release note: None