### PR TITLE
ui: add timescale to diag details page

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/searchCriteria/searchCriteria.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/searchCriteria/searchCriteria.tsx
@@ -11,16 +11,14 @@
 import React from "react";
 import classNames from "classnames/bind";
 import styles from "./searchCriteria.module.scss";
+import { PageConfig, PageConfigItem } from "src/pageConfig";
+import { Button } from "src/button";
+import { commonStyles, selectCustomStyles } from "src/common";
 import {
-  Button,
-  commonStyles,
-  PageConfig,
-  PageConfigItem,
-  selectCustomStyles,
   TimeScale,
   timeScale1hMinOptions,
   TimeScaleDropdown,
-} from "src";
+} from "src/timeScaleDropdown";
 import { applyBtn } from "../queryFilter/filterClasses";
 import Select from "react-select";
 import { limitOptions } from "../util/sqlActivityConstants";

--- a/pkg/ui/workspaces/cluster-ui/src/statementDetails/diagnostics/diagnosticsUtils.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/statementDetails/diagnostics/diagnosticsUtils.ts
@@ -8,7 +8,7 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
-import { isUndefined } from "lodash";
+import { TimeScale, toDateRange } from "src/timeScaleDropdown";
 import { DiagnosticStatuses } from "src/statementsDiagnostics";
 import { StatementDiagnosticsReport } from "../../api";
 import moment from "moment-timezone";
@@ -19,60 +19,17 @@ export function getDiagnosticsStatus(
   if (diagnosticsRequest.completed) {
     return "READY";
   }
-
   return "WAITING";
 }
 
-export function sortByRequestedAtField(
-  a: StatementDiagnosticsReport,
-  b: StatementDiagnosticsReport,
-): number {
-  const activatedOnA = moment(a.requested_at)?.unix();
-  const activatedOnB = moment(b.requested_at)?.unix();
-  if (isUndefined(activatedOnA) && isUndefined(activatedOnB)) {
-    return 0;
-  }
-  if (activatedOnA < activatedOnB) {
-    return -1;
-  }
-  if (activatedOnA > activatedOnB) {
-    return 1;
-  }
-  return 0;
-}
-
-export function sortByCompletedField(
-  a: StatementDiagnosticsReport,
-  b: StatementDiagnosticsReport,
-): number {
-  const completedA = a.completed ? 1 : -1;
-  const completedB = b.completed ? 1 : -1;
-  if (completedA < completedB) {
-    return -1;
-  }
-  if (completedA > completedB) {
-    return 1;
-  }
-  return 0;
-}
-
-export function sortByStatementFingerprintField(
-  a: StatementDiagnosticsReport,
-  b: StatementDiagnosticsReport,
-): number {
-  const statementFingerprintA = a.statement_fingerprint;
-  const statementFingerprintB = b.statement_fingerprint;
-  if (
-    isUndefined(statementFingerprintA) &&
-    isUndefined(statementFingerprintB)
-  ) {
-    return 0;
-  }
-  if (statementFingerprintA < statementFingerprintB) {
-    return -1;
-  }
-  if (statementFingerprintA > statementFingerprintB) {
-    return 1;
-  }
-  return 0;
+export function filterByTimeScale(
+  diagnostics: StatementDiagnosticsReport[],
+  ts: TimeScale,
+): StatementDiagnosticsReport[] {
+  const [start, end] = toDateRange(ts);
+  return diagnostics.filter(
+    diag =>
+      start.isSameOrBefore(moment(diag.requested_at)) &&
+      end.isSameOrAfter(moment(diag.requested_at)),
+  );
 }

--- a/pkg/ui/workspaces/cluster-ui/src/statementDetails/diagnostics/diagnosticsView.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/statementDetails/diagnostics/diagnosticsView.module.scss
@@ -4,7 +4,7 @@
   display: flex;
   flex-direction: column;
 
-  &__title {
+  &__header {
     display: flex;
     flex-direction: row;
     justify-content: space-between;
@@ -78,4 +78,20 @@
   > svg {
     margin-right: $spacing-x-small;
   }
+}
+
+.column-size-medium {
+  width: 230px;
+}
+
+.column-size-small {
+  width: 140px;
+}
+
+.sorted-table {
+  width: 100%;
+}
+
+.margin-bottom {
+  margin-bottom: $spacing-smaller;
 }

--- a/pkg/ui/workspaces/cluster-ui/src/statementDetails/diagnostics/diagnosticsView.spec.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementDetails/diagnostics/diagnosticsView.spec.tsx
@@ -15,24 +15,31 @@ import { MemoryRouter } from "react-router-dom";
 import { Button } from "@cockroachlabs/ui-components";
 
 import { DiagnosticsView } from "./diagnosticsView";
-import { Table } from "src/table";
 import { TestStoreProvider } from "src/test-utils";
 import { StatementDiagnosticsReport } from "../../api";
 import moment from "moment-timezone";
+import { SortedTable } from "src/sortedtable";
 
 const activateDiagnosticsRef = { current: { showModalFor: jest.fn() } };
+const ts = {
+  windowSize: moment.duration(20, "day"),
+  sampleSize: moment.duration(5, "minutes"),
+  fixedWindowEnd: moment.utc("2023.01.5"),
+  key: "Custom",
+};
+const mockSetTimeScale = jest.fn();
 
 function generateDiagnosticsRequest(
   extendObject: Partial<StatementDiagnosticsReport> = {},
 ): StatementDiagnosticsReport {
-  const requestedAt = moment.now();
+  const requestedAt = moment("2023-01-01 00:00:00");
   const report: StatementDiagnosticsReport = {
     id: "124354678574635",
     statement_fingerprint: "SELECT * FROM table",
     completed: true,
     requested_at: moment(requestedAt),
     min_execution_latency: moment.duration(10),
-    expires_at: moment(requestedAt + 10),
+    expires_at: moment("2023-01-01 00:00:10"),
   };
   Object.assign(report, extendObject);
   return report;
@@ -52,6 +59,8 @@ describe("DiagnosticsView", () => {
             hasData={false}
             diagnosticsReports={[]}
             dismissAlertMessage={() => {}}
+            currentScale={ts}
+            onChangeTimeScale={mockSetTimeScale}
           />
         </MemoryRouter>,
       );
@@ -81,13 +90,15 @@ describe("DiagnosticsView", () => {
             hasData={true}
             diagnosticsReports={diagnosticsRequests}
             dismissAlertMessage={() => {}}
+            currentScale={ts}
+            onChangeTimeScale={mockSetTimeScale}
           />
         </TestStoreProvider>,
       );
     });
 
     it("renders Table component when diagnostics data is provided", () => {
-      assert.isTrue(wrapper.find(Table).exists());
+      assert.isTrue(wrapper.find(SortedTable).exists());
     });
 
     it("opens the statement diagnostics modal when Activate button is clicked", () => {
@@ -113,6 +124,8 @@ describe("DiagnosticsView", () => {
             hasData={true}
             diagnosticsReports={diagnosticsRequests}
             dismissAlertMessage={() => {}}
+            currentScale={ts}
+            onChangeTimeScale={mockSetTimeScale}
           />
         </TestStoreProvider>,
       );
@@ -135,6 +148,8 @@ describe("DiagnosticsView", () => {
             hasData={true}
             diagnosticsReports={diagnosticsRequests}
             dismissAlertMessage={() => {}}
+            currentScale={ts}
+            onChangeTimeScale={mockSetTimeScale}
           />
         </TestStoreProvider>,
       );

--- a/pkg/ui/workspaces/cluster-ui/src/statementDetails/diagnostics/diagnosticsView.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementDetails/diagnostics/diagnosticsView.tsx
@@ -14,29 +14,30 @@ import moment from "moment-timezone";
 import classnames from "classnames/bind";
 import { Button, Icon } from "@cockroachlabs/ui-components";
 import { Button as CancelButton } from "src/button";
-import { Text, TextTypes } from "src/text";
-import { Table, ColumnsConfig } from "src/table";
 import { SummaryCard } from "src/summaryCard";
 import {
   ActivateDiagnosticsModalRef,
   DiagnosticStatusBadge,
 } from "src/statementsDiagnostics";
 import emptyListResultsImg from "src/assets/emptyState/empty-list-results.svg";
-import {
-  getDiagnosticsStatus,
-  sortByCompletedField,
-  sortByRequestedAtField,
-} from "./diagnosticsUtils";
+import { filterByTimeScale, getDiagnosticsStatus } from "./diagnosticsUtils";
 import { EmptyTable } from "src/empty";
 import styles from "./diagnosticsView.module.scss";
 import { getBasePath, StatementDiagnosticsReport } from "../../api";
 import { DATE_FORMAT_24_UTC } from "../../util";
+import {
+  TimeScale,
+  timeScale1hMinOptions,
+  TimeScaleDropdown,
+} from "src/timeScaleDropdown";
+import { ColumnDescriptor, SortedTable, SortSetting } from "src/sortedtable";
 
 export interface DiagnosticsViewStateProps {
   hasData: boolean;
   diagnosticsReports: StatementDiagnosticsReport[];
   showDiagnosticsViewLink?: boolean;
   activateDiagnosticsRef: React.RefObject<ActivateDiagnosticsModalRef>;
+  currentScale: TimeScale;
 }
 
 export interface DiagnosticsViewDispatchProps {
@@ -48,6 +49,7 @@ export interface DiagnosticsViewDispatchProps {
     columnTitle: string,
     ascending: boolean,
   ) => void;
+  onChangeTimeScale: (ts: TimeScale) => void;
 }
 
 export interface DiagnosticsViewOwnProps {
@@ -59,9 +61,7 @@ export type DiagnosticsViewProps = DiagnosticsViewOwnProps &
   DiagnosticsViewDispatchProps;
 
 interface DiagnosticsViewState {
-  traces: {
-    [diagnosticsId: string]: string;
-  };
+  sortSetting: SortSetting;
 }
 
 const cx = classnames.bind(styles);
@@ -111,23 +111,33 @@ export class DiagnosticsView extends React.Component<
   DiagnosticsViewProps,
   DiagnosticsViewState
 > {
-  columns: ColumnsConfig<StatementDiagnosticsReport> = [
-    {
-      key: "activatedOn",
-      title: "Activated on",
-      sorter: sortByRequestedAtField,
-      defaultSortOrder: "descend",
-      render: (_text, record) => {
-        return moment.utc(record.requested_at).format(DATE_FORMAT_24_UTC);
+  constructor(props: DiagnosticsViewProps) {
+    super(props);
+    this.state = {
+      sortSetting: {
+        ascending: true,
+        columnTitle: "activatedOn",
       },
+    };
+  }
+
+  columns: ColumnDescriptor<StatementDiagnosticsReport>[] = [
+    {
+      name: "activatedOn",
+      title: "Activated on",
+      hideTitleUnderline: true,
+      cell: (diagnostic: StatementDiagnosticsReport) =>
+        moment.utc(diagnostic.requested_at).format(DATE_FORMAT_24_UTC),
+      sort: (diagnostic: StatementDiagnosticsReport) =>
+        moment(diagnostic.requested_at)?.unix(),
     },
     {
-      key: "status",
+      name: "status",
       title: "Status",
-      sorter: sortByCompletedField,
-      width: "160px",
-      render: (_text, record) => {
-        const status = getDiagnosticsStatus(record);
+      hideTitleUnderline: true,
+      className: cx("column-size-small"),
+      cell: (diagnostic: StatementDiagnosticsReport) => {
+        const status = getDiagnosticsStatus(diagnostic);
         return (
           <DiagnosticStatusBadge
             status={status}
@@ -135,64 +145,60 @@ export class DiagnosticsView extends React.Component<
           />
         );
       },
+      sort: (diagnostic: StatementDiagnosticsReport) =>
+        String(diagnostic.completed),
     },
     {
-      key: "actions",
+      name: "actions",
       title: "",
-      sorter: false,
-      width: "160px",
-      render: (() => {
-        const {
-          onDownloadDiagnosticBundleClick,
-          onDiagnosticCancelRequestClick,
-        } = this.props;
-        return (_text: string, record: StatementDiagnosticsReport) => {
-          if (record.completed) {
-            return (
-              <div
-                className={cx(
-                  "crl-statements-diagnostics-view__actions-column",
-                )}
-              >
-                <Button
-                  as="a"
-                  size="small"
-                  intent="tertiary"
-                  href={`${getBasePath()}/_admin/v1/stmtbundle/${
-                    record.statement_diagnostics_id
-                  }`}
-                  onClick={() =>
-                    onDownloadDiagnosticBundleClick &&
-                    onDownloadDiagnosticBundleClick(
-                      record.statement_fingerprint,
-                    )
-                  }
-                  className={cx("download-bundle-button")}
-                >
-                  <Icon iconName="Download" />
-                  Bundle (.zip)
-                </Button>
-              </div>
-            );
-          }
+      hideTitleUnderline: true,
+      className: cx("column-size-medium"),
+      cell: (diagnostic: StatementDiagnosticsReport) => {
+        if (diagnostic.completed) {
           return (
             <div
               className={cx("crl-statements-diagnostics-view__actions-column")}
             >
-              <CancelButton
+              <Button
+                as="a"
                 size="small"
-                type="secondary"
+                intent="tertiary"
+                href={`${getBasePath()}/_admin/v1/stmtbundle/${
+                  diagnostic.statement_diagnostics_id
+                }`}
                 onClick={() =>
-                  onDiagnosticCancelRequestClick &&
-                  onDiagnosticCancelRequestClick(record)
+                  this.props.onDownloadDiagnosticBundleClick &&
+                  this.props.onDownloadDiagnosticBundleClick(
+                    diagnostic.statement_fingerprint,
+                  )
                 }
+                className={cx("download-bundle-button")}
               >
-                Cancel request
-              </CancelButton>
+                <Icon iconName="Download" />
+                Bundle (.zip)
+              </Button>
             </div>
           );
-        };
-      })(),
+        }
+        return (
+          <div
+            className={cx("crl-statements-diagnostics-view__actions-column")}
+          >
+            <CancelButton
+              size="small"
+              type="secondary"
+              onClick={() =>
+                this.props.onDiagnosticCancelRequestClick &&
+                this.props.onDiagnosticCancelRequestClick(diagnostic)
+              }
+            >
+              Cancel request
+            </CancelButton>
+          </div>
+        );
+      },
+      sort: (diagnostic: StatementDiagnosticsReport) =>
+        String(diagnostic.completed),
     },
   ];
 
@@ -200,10 +206,16 @@ export class DiagnosticsView extends React.Component<
     this.props.dismissAlertMessage();
   }
 
-  onSortingChange = (columnName: string, ascending: boolean): void => {
+  onSortingChange = (ss: SortSetting): void => {
     if (this.props.onSortingChange) {
-      this.props.onSortingChange("Diagnostics", columnName, ascending);
+      this.props.onSortingChange("Diagnostics", ss.columnTitle, ss.ascending);
     }
+    this.setState({
+      sortSetting: {
+        ascending: ss.ascending,
+        columnTitle: ss.columnTitle,
+      },
+    });
   };
 
   render(): React.ReactElement {
@@ -213,29 +225,47 @@ export class DiagnosticsView extends React.Component<
       showDiagnosticsViewLink,
       statementFingerprint,
       activateDiagnosticsRef,
+      currentScale,
+      onChangeTimeScale,
     } = this.props;
 
     const readyToRequestDiagnostics = diagnosticsReports.every(
       diagnostic => diagnostic.completed,
     );
 
-    const dataSource = diagnosticsReports.map((diagnosticsReport, idx) => ({
-      ...diagnosticsReport,
-      key: idx,
-    }));
+    const dataSource = filterByTimeScale(
+      diagnosticsReports.map((diagnosticsReport, idx) => ({
+        ...diagnosticsReport,
+        key: idx,
+      })),
+      currentScale,
+    );
 
     if (!hasData) {
       return (
-        <SummaryCard>
-          <EmptyDiagnosticsView {...this.props} />
-        </SummaryCard>
+        <>
+          <TimeScaleDropdown
+            options={timeScale1hMinOptions}
+            currentScale={currentScale}
+            setTimeScale={onChangeTimeScale}
+            className={cx("timescale-small", "margin-bottom")}
+          />
+          <SummaryCard>
+            <EmptyDiagnosticsView {...this.props} />
+          </SummaryCard>
+        </>
       );
     }
 
     return (
-      <SummaryCard>
-        <div className={cx("crl-statements-diagnostics-view__title")}>
-          <Text textType={TextTypes.Heading3}>Statement diagnostics</Text>
+      <>
+        <div className={cx("crl-statements-diagnostics-view__header")}>
+          <TimeScaleDropdown
+            options={timeScale1hMinOptions}
+            currentScale={currentScale}
+            setTimeScale={onChangeTimeScale}
+            className={cx("timescale-small")}
+          />
           {readyToRequestDiagnostics && (
             <Button
               onClick={() =>
@@ -250,10 +280,13 @@ export class DiagnosticsView extends React.Component<
             </Button>
           )}
         </div>
-        <Table
-          dataSource={dataSource}
+        <SortedTable
+          data={dataSource}
           columns={this.columns}
-          onSortingChange={this.onSortingChange}
+          className={cx("jobs-table")}
+          sortSetting={this.state.sortSetting}
+          onChangeSortSetting={this.onSortingChange}
+          tableWrapperClassName={cx("sorted-table")}
         />
         {showDiagnosticsViewLink && (
           <div className={cx("crl-statements-diagnostics-view__footer")}>
@@ -265,7 +298,7 @@ export class DiagnosticsView extends React.Component<
             </Link>
           </div>
         )}
-      </SummaryCard>
+      </>
     );
   }
 }


### PR DESCRIPTION
Fixes https://github.com/cockroachdb/cockroach/issues/92417

This commit adds a time scale picker to the Diagnostics
tab on Statement Details page. The time scale is aligned
with the other ones, and now is possible to see bundles
from only the selected period.

This commit also makes some UX updates on the same tab,
making it use the same SortedTable component as other pages,
removing the white background and title to align with
all other pages that no longer have those items.

Before
<img width="1539" alt="Screenshot 2023-04-13 at 11 12 04 AM" src="https://user-images.githubusercontent.com/1017486/231869218-75499e39-6bdd-4814-b53f-4c4ddce2c299.png">


After
<img width="1539" alt="Screenshot 2023-04-13 at 3 47 12 PM" src="https://user-images.githubusercontent.com/1017486/231869268-d3c659c4-fdcf-4a23-afb7-50553854c1ed.png">
<img width="1546" alt="Screenshot 2023-04-13 at 3 47 21 PM" src="https://user-images.githubusercontent.com/1017486/231869270-ed585ffb-2b85-46a2-8eb3-bc157389880f.png">

https://www.loom.com/share/69f024c0523c4a8c814276f2786ab8a8


Release note (ui change): Add a time scale selector to the Diagnostics
tab under the Statement Details page, make it possible to see bundles
only from the selected period.