### PR TITLE
monitoring: added annotations to demo grafana dashboards

### DIFF
--- a/monitoring/demo/config/grafana/provisioning/datasources/cockroachdb.yaml
+++ b/monitoring/demo/config/grafana/provisioning/datasources/cockroachdb.yaml
@@ -1,0 +1,19 @@
+# This file defines the connection information that Grafana uses to connect to
+# your cluster and query the system.eventlog table. In its current
+# configuration, the Grafana demo dashboards will use this data source to show
+# annotations for several categories of structured events.
+apiVersion: 1
+
+datasources:
+  - name: CockroachDB
+    type: postgres
+    url: roach1:26257
+    user: root
+    jsonData:
+      database: system
+      sslmode: 'disable' # disable/require/verify-ca/verify-full
+      maxOpenConns: 0 # Grafana v5.4+
+      maxIdleConns: 2 # Grafana v5.4+
+      connMaxLifetime: 14400 # Grafana v5.4+
+      postgresVersion: 903 # 903=9.3, 904=9.4, 905=9.5, 906=9.6, 1000=10
+      timescaledb: false

--- a/monitoring/grafana-dashboards/changefeeds.json
+++ b/monitoring/grafana-dashboards/changefeeds.json
@@ -9,6 +9,84 @@
         "iconColor": "rgba(0, 211, 255, 1)",
         "name": "Annotations & Alerts",
         "type": "dashboard"
+      },
+      {
+        "datasource": "CockroachDB",
+        "enable": true,
+        "iconColor": "green",
+        "name": "Schema Changes",
+        "target": {
+          "editorMode": "code",
+          "format": "table",
+          "rawQuery": true,
+          "rawSql": "SELECT timestamp AS time, \"eventType\" AS title, info :: JSONB ->> 'Statement' AS text, encode(\"uniqueID\", 'hex') AS id, 'schema change' AS tags FROM system.eventlog WHERE \"eventType\" LIKE ANY(${ddl_event_types:csv}) ORDER BY timestamp LIMIT 500;",
+          "refId": "Anno"
+        }
+      },
+      {
+        "datasource": "CockroachDB",
+        "enable": true,
+        "iconColor": "yellow",
+        "name": "Cluster Settings",
+        "target": {
+          "editorMode": "code",
+          "format": "table",
+          "rawQuery": true,
+          "rawSql": "SELECT timestamp AS time, \"eventType\" AS title, info :: JSONB ->> 'Statement' AS text, encode(\"uniqueID\", 'hex') AS id, 'cluster setting' AS tags FROM system.eventlog WHERE \"eventType\" LIKE ANY(${cluster_setting_event_types:csv}) ORDER BY timestamp LIMIT 500;",
+          "refId": "Anno"
+        }
+      },
+      {
+        "datasource": "CockroachDB",
+        "enable": false,
+        "iconColor": "purple",
+        "name": "Cluster-wide Events",
+        "target": {
+          "editorMode": "code",
+          "format": "table",
+          "rawQuery": true,
+          "rawSql": "SELECT timestamp AS time, \"eventType\" AS title, concat('Reporting node ID: ', \"reportingID\"::STRING) AS text, encode(\"uniqueID\", 'hex') AS id, 'cluster-wide event' AS tags FROM system.eventlog WHERE \"eventType\" LIKE ANY(${cluster_wide_event_types:csv}) ORDER BY timestamp LIMIT 500;",
+          "refId": "Anno"
+        }
+      },
+      {
+        "datasource": "CockroachDB",
+        "enable": false,
+        "iconColor": "blue",
+        "name": "Jobs",
+        "target": {
+          "editorMode": "code",
+          "format": "table",
+          "rawQuery": true,
+          "rawSql": "SELECT timestamp AS time, \"eventType\" AS title, info :: JSONB ->> 'Description' AS text, encode(\"uniqueID\", 'hex') AS id, 'job' AS tags FROM system.eventlog WHERE \"eventType\" LIKE ANY(${job_event_types:csv}) ORDER BY timestamp LIMIT 500;",
+          "refId": "Anno"
+        }
+      },
+      {
+        "datasource": "CockroachDB",
+        "enable": false,
+        "iconColor": "orange",
+        "name": "SQL Session Events",
+        "target": {
+          "editorMode": "code",
+          "format": "table",
+          "rawQuery": true,
+          "rawSql": "SELECT timestamp AS time, \"eventType\" AS title, concat('SQL client remote address: ', info :: JSONB ->> 'RemoteAddress') AS text, encode(\"uniqueID\", 'hex') AS id, 'SQL session event' AS tags FROM system.eventlog WHERE \"eventType\" LIKE ANY(${sql_session_event_types:csv}) ORDER BY timestamp LIMIT 500;",
+          "refId": "Anno"
+        }
+      },
+      {
+        "datasource": "CockroachDB",
+        "enable": false,
+        "iconColor": "red",
+        "name": "Zone Configurations",
+        "target": {
+          "editorMode": "code",
+          "format": "table",
+          "rawQuery": true,
+          "rawSql": "SELECT timestamp AS time, \"eventType\" AS title, info :: JSONB ->> 'Statement' AS text, encode(\"uniqueID\", 'hex') AS id, 'zone configurations' AS tags FROM system.eventlog WHERE \"eventType\" LIKE ANY(${zone_config_event_types:csv}) ORDER BY timestamp LIMIT 500;",
+          "refId": "Anno"
+        }
       }
     ]
   },
@@ -666,6 +744,126 @@
         "refresh": 2,
         "skipUrlSync": false,
         "type": "interval"
+      },
+      {
+        "current": {
+          "selected": false,
+          "text": "'alter_database_add_region', 'alter_database_drop_region', 'alter_database_placement', 'alter_database_primary_region', 'alter_database_set_zone_config_extension', 'alter_database_survival_goal', 'alter_function_options', 'alter_index', 'alter_index_visible', 'alter_sequence', 'alter_table', 'alter_type', 'comment_on_column', 'comment_on_constraint', 'comment_on_database', 'comment_on_index', 'comment_on_schema', 'comment_on_table', 'convert_to_schema', 'create_database', 'create_function', 'create_index', 'create_schema', 'create_sequence', 'create_statistics', 'create_table', 'create_type', 'create_view', 'drop_database', 'drop_function', 'drop_index', 'drop_schema', 'drop_sequence', 'drop_table', 'drop_type', 'drop_view', 'finish_schema_change', 'finish_schema_change_rollback', 'force_delete_table_data_entry', 'rename_database', 'rename_function', 'rename_schema', 'rename_table', 'rename_type', 'reverse_schema_change', 'set_schema', 'truncate_table', 'unsafe_delete_descriptor', 'unsafe_delete_namespace_entry', 'unsafe_upsert_descriptor', 'unsafe_upsert_namespace_entry'",
+          "value": "'alter_database_add_region', 'alter_database_drop_region', 'alter_database_placement', 'alter_database_primary_region', 'alter_database_set_zone_config_extension', 'alter_database_survival_goal', 'alter_function_options', 'alter_index', 'alter_index_visible', 'alter_sequence', 'alter_table', 'alter_type', 'comment_on_column', 'comment_on_constraint', 'comment_on_database', 'comment_on_index', 'comment_on_schema', 'comment_on_table', 'convert_to_schema', 'create_database', 'create_function', 'create_index', 'create_schema', 'create_sequence', 'create_statistics', 'create_table', 'create_type', 'create_view', 'drop_database', 'drop_function', 'drop_index', 'drop_schema', 'drop_sequence', 'drop_table', 'drop_type', 'drop_view', 'finish_schema_change', 'finish_schema_change_rollback', 'force_delete_table_data_entry', 'rename_database', 'rename_function', 'rename_schema', 'rename_table', 'rename_type', 'reverse_schema_change', 'set_schema', 'truncate_table', 'unsafe_delete_descriptor', 'unsafe_delete_namespace_entry', 'unsafe_upsert_descriptor', 'unsafe_upsert_namespace_entry'"
+        },
+        "description": "The list of event types for DDL statements.",
+        "hide": 2,
+        "name": "ddl_event_types",
+        "options": [
+          {
+            "selected": true,
+            "text": "'alter_database_add_region', 'alter_database_drop_region', 'alter_database_placement', 'alter_database_primary_region', 'alter_database_set_zone_config_extension', 'alter_database_survival_goal', 'alter_function_options', 'alter_index', 'alter_index_visible', 'alter_sequence', 'alter_table', 'alter_type', 'comment_on_column', 'comment_on_constraint', 'comment_on_database', 'comment_on_index', 'comment_on_schema', 'comment_on_table', 'convert_to_schema', 'create_database', 'create_function', 'create_index', 'create_schema', 'create_sequence', 'create_statistics', 'create_table', 'create_type', 'create_view', 'drop_database', 'drop_function', 'drop_index', 'drop_schema', 'drop_sequence', 'drop_table', 'drop_type', 'drop_view', 'finish_schema_change', 'finish_schema_change_rollback', 'force_delete_table_data_entry', 'rename_database', 'rename_function', 'rename_schema', 'rename_table', 'rename_type', 'reverse_schema_change', 'set_schema', 'truncate_table', 'unsafe_delete_descriptor', 'unsafe_delete_namespace_entry', 'unsafe_upsert_descriptor', 'unsafe_upsert_namespace_entry'",
+            "value": "'alter_database_add_region', 'alter_database_drop_region', 'alter_database_placement', 'alter_database_primary_region', 'alter_database_set_zone_config_extension', 'alter_database_survival_goal', 'alter_function_options', 'alter_index', 'alter_index_visible', 'alter_sequence', 'alter_table', 'alter_type', 'comment_on_column', 'comment_on_constraint', 'comment_on_database', 'comment_on_index', 'comment_on_schema', 'comment_on_table', 'convert_to_schema', 'create_database', 'create_function', 'create_index', 'create_schema', 'create_sequence', 'create_statistics', 'create_table', 'create_type', 'create_view', 'drop_database', 'drop_function', 'drop_index', 'drop_schema', 'drop_sequence', 'drop_table', 'drop_type', 'drop_view', 'finish_schema_change', 'finish_schema_change_rollback', 'force_delete_table_data_entry', 'rename_database', 'rename_function', 'rename_schema', 'rename_table', 'rename_type', 'reverse_schema_change', 'set_schema', 'truncate_table', 'unsafe_delete_descriptor', 'unsafe_delete_namespace_entry', 'unsafe_upsert_descriptor', 'unsafe_upsert_namespace_entry'"
+          }
+        ],
+        "query": "'alter_database_add_region', 'alter_database_drop_region', 'alter_database_placement', 'alter_database_primary_region', 'alter_database_set_zone_config_extension', 'alter_database_survival_goal', 'alter_function_options', 'alter_index', 'alter_index_visible', 'alter_sequence', 'alter_table', 'alter_type', 'comment_on_column', 'comment_on_constraint', 'comment_on_database', 'comment_on_index', 'comment_on_schema', 'comment_on_table', 'convert_to_schema', 'create_database', 'create_function', 'create_index', 'create_schema', 'create_sequence', 'create_statistics', 'create_table', 'create_type', 'create_view', 'drop_database', 'drop_function', 'drop_index', 'drop_schema', 'drop_sequence', 'drop_table', 'drop_type', 'drop_view', 'finish_schema_change', 'finish_schema_change_rollback', 'force_delete_table_data_entry', 'rename_database', 'rename_function', 'rename_schema', 'rename_table', 'rename_type', 'reverse_schema_change', 'set_schema', 'truncate_table', 'unsafe_delete_descriptor', 'unsafe_delete_namespace_entry', 'unsafe_upsert_descriptor', 'unsafe_upsert_namespace_entry'",
+        "skipUrlSync": false,
+        "type": "textbox"
+      },
+      {
+        "current": {
+          "selected": false,
+          "text": "'set_cluster_setting', 'set_tenant_cluster_setting'",
+          "value": "'set_cluster_setting', 'set_tenant_cluster_setting'"
+        },
+        "description": "The list of event types for cluster settings.",
+        "hide": 2,
+        "name": "cluster_setting_event_types",
+        "options": [
+          {
+            "selected": true,
+            "text": "'set_cluster_setting', 'set_tenant_cluster_setting'",
+            "value": "'set_cluster_setting', 'set_tenant_cluster_setting'"
+          }
+        ],
+        "query": "'set_cluster_setting', 'set_tenant_cluster_setting'",
+        "skipUrlSync": false,
+        "type": "textbox"
+      },
+      {
+        "current": {
+          "selected": false,
+          "text": "'certs_reload',   'node_decommissioned',   'node_decommissioning',   'node_join',   'node_recommissioned',   'node_restart'",
+          "value": "'certs_reload',   'node_decommissioned',   'node_decommissioning',   'node_join',   'node_recommissioned',   'node_restart'"
+        },
+        "description": "The list of event types for cluster-wide events.",
+        "hide": 2,
+        "name": "cluster_wide_event_types",
+        "options": [
+          {
+            "selected": true,
+            "text": "'certs_reload',   'node_decommissioned',   'node_decommissioning',   'node_join',   'node_recommissioned',   'node_restart'",
+            "value": "'certs_reload',   'node_decommissioned',   'node_decommissioning',   'node_join',   'node_recommissioned',   'node_restart'"
+          }
+        ],
+        "query": "'certs_reload',   'node_decommissioned',   'node_decommissioning',   'node_join',   'node_recommissioned',   'node_restart'",
+        "skipUrlSync": false,
+        "type": "textbox"
+      },
+      {
+        "current": {
+          "selected": false,
+          "text": "'import', 'restore'",
+          "value": "'import', 'restore'"
+        },
+        "description": "The list of event types for jobs.",
+        "hide": 2,
+        "name": "job_event_types",
+        "options": [
+          {
+            "selected": true,
+            "text": "'import', 'restore'",
+            "value": "'import', 'restore'"
+          }
+        ],
+        "query": "'import', 'restore'",
+        "skipUrlSync": false,
+        "type": "textbox"
+      },
+      {
+        "current": {
+          "selected": false,
+          "text": "'client_authentication_failed',   'client_authentication_info',   'client_authentication_ok',   'client_connection_end',   'client_connection_start',   'client_session_end'",
+          "value": "'client_authentication_failed',   'client_authentication_info',   'client_authentication_ok',   'client_connection_end',   'client_connection_start',   'client_session_end'"
+        },
+        "description": "The list of event types for SQL session events.",
+        "hide": 2,
+        "name": "sql_session_event_types",
+        "options": [
+          {
+            "selected": true,
+            "text": "'client_authentication_failed',   'client_authentication_info',   'client_authentication_ok',   'client_connection_end',   'client_connection_start',   'client_session_end'",
+            "value": "'client_authentication_failed',   'client_authentication_info',   'client_authentication_ok',   'client_connection_end',   'client_connection_start',   'client_session_end'"
+          }
+        ],
+        "query": "'client_authentication_failed',   'client_authentication_info',   'client_authentication_ok',   'client_connection_end',   'client_connection_start',   'client_session_end'",
+        "skipUrlSync": false,
+        "type": "textbox"
+      },
+      {
+        "current": {
+          "selected": false,
+          "text": "'set_zone_config', 'remove_zone_config'",
+          "value": "'set_zone_config', 'remove_zone_config'"
+        },
+        "description": "The list of event types for zone configurations.",
+        "hide": 2,
+        "name": "zone_config_event_types",
+        "options": [
+          {
+            "selected": true,
+            "text": "'set_zone_config', 'remove_zone_config'",
+            "value": "'set_zone_config', 'remove_zone_config'"
+          }
+        ],
+        "query": "'set_zone_config', 'remove_zone_config'",
+        "skipUrlSync": false,
+        "type": "textbox"
       }
     ]
   },

--- a/monitoring/grafana-dashboards/distributed.json
+++ b/monitoring/grafana-dashboards/distributed.json
@@ -9,6 +9,84 @@
         "iconColor": "rgba(0, 211, 255, 1)",
         "name": "Annotations & Alerts",
         "type": "dashboard"
+      },
+      {
+        "datasource": "CockroachDB",
+        "enable": true,
+        "iconColor": "green",
+        "name": "Schema Changes",
+        "target": {
+          "editorMode": "code",
+          "format": "table",
+          "rawQuery": true,
+          "rawSql": "SELECT timestamp AS time, \"eventType\" AS title, info :: JSONB ->> 'Statement' AS text, encode(\"uniqueID\", 'hex') AS id, 'schema change' AS tags FROM system.eventlog WHERE \"eventType\" LIKE ANY(${ddl_event_types:csv}) ORDER BY timestamp LIMIT 500;",
+          "refId": "Anno"
+        }
+      },
+      {
+        "datasource": "CockroachDB",
+        "enable": true,
+        "iconColor": "yellow",
+        "name": "Cluster Settings",
+        "target": {
+          "editorMode": "code",
+          "format": "table",
+          "rawQuery": true,
+          "rawSql": "SELECT timestamp AS time, \"eventType\" AS title, info :: JSONB ->> 'Statement' AS text, encode(\"uniqueID\", 'hex') AS id, 'cluster setting' AS tags FROM system.eventlog WHERE \"eventType\" LIKE ANY(${cluster_setting_event_types:csv}) ORDER BY timestamp LIMIT 500;",
+          "refId": "Anno"
+        }
+      },
+      {
+        "datasource": "CockroachDB",
+        "enable": false,
+        "iconColor": "purple",
+        "name": "Cluster-wide Events",
+        "target": {
+          "editorMode": "code",
+          "format": "table",
+          "rawQuery": true,
+          "rawSql": "SELECT timestamp AS time, \"eventType\" AS title, concat('Reporting node ID: ', \"reportingID\"::STRING) AS text, encode(\"uniqueID\", 'hex') AS id, 'cluster-wide event' AS tags FROM system.eventlog WHERE \"eventType\" LIKE ANY(${cluster_wide_event_types:csv}) ORDER BY timestamp LIMIT 500;",
+          "refId": "Anno"
+        }
+      },
+      {
+        "datasource": "CockroachDB",
+        "enable": false,
+        "iconColor": "blue",
+        "name": "Jobs",
+        "target": {
+          "editorMode": "code",
+          "format": "table",
+          "rawQuery": true,
+          "rawSql": "SELECT timestamp AS time, \"eventType\" AS title, info :: JSONB ->> 'Description' AS text, encode(\"uniqueID\", 'hex') AS id, 'job' AS tags FROM system.eventlog WHERE \"eventType\" LIKE ANY(${job_event_types:csv}) ORDER BY timestamp LIMIT 500;",
+          "refId": "Anno"
+        }
+      },
+      {
+        "datasource": "CockroachDB",
+        "enable": false,
+        "iconColor": "orange",
+        "name": "SQL Session Events",
+        "target": {
+          "editorMode": "code",
+          "format": "table",
+          "rawQuery": true,
+          "rawSql": "SELECT timestamp AS time, \"eventType\" AS title, concat('SQL client remote address: ', info :: JSONB ->> 'RemoteAddress') AS text, encode(\"uniqueID\", 'hex') AS id, 'SQL session event' AS tags FROM system.eventlog WHERE \"eventType\" LIKE ANY(${sql_session_event_types:csv}) ORDER BY timestamp LIMIT 500;",
+          "refId": "Anno"
+        }
+      },
+      {
+        "datasource": "CockroachDB",
+        "enable": false,
+        "iconColor": "red",
+        "name": "Zone Configurations",
+        "target": {
+          "editorMode": "code",
+          "format": "table",
+          "rawQuery": true,
+          "rawSql": "SELECT timestamp AS time, \"eventType\" AS title, info :: JSONB ->> 'Statement' AS text, encode(\"uniqueID\", 'hex') AS id, 'zone configurations' AS tags FROM system.eventlog WHERE \"eventType\" LIKE ANY(${zone_config_event_types:csv}) ORDER BY timestamp LIMIT 500;",
+          "refId": "Anno"
+        }
       }
     ]
   },
@@ -1081,8 +1159,8 @@
         "auto_min": "10s",
         "current": {
           "selected": false,
-          "text": "1m",
-          "value": "1m"
+          "text": "30s",
+          "value": "30s"
         },
         "description": null,
         "error": null,
@@ -1091,12 +1169,12 @@
         "name": "rate_interval",
         "options": [
           {
-            "selected": false,
+            "selected": true,
             "text": "30s",
             "value": "30s"
           },
           {
-            "selected": true,
+            "selected": false,
             "text": "1m",
             "value": "1m"
           },
@@ -1137,10 +1215,129 @@
           }
         ],
         "query": "30s,1m,5m,10m,30m,1h,6h,12h,1d",
-        "queryValue": "",
         "refresh": 2,
         "skipUrlSync": false,
         "type": "interval"
+      },
+      {
+        "current": {
+          "selected": false,
+          "text": "'alter_database_add_region', 'alter_database_drop_region', 'alter_database_placement', 'alter_database_primary_region', 'alter_database_set_zone_config_extension', 'alter_database_survival_goal', 'alter_function_options', 'alter_index', 'alter_index_visible', 'alter_sequence', 'alter_table', 'alter_type', 'comment_on_column', 'comment_on_constraint', 'comment_on_database', 'comment_on_index', 'comment_on_schema', 'comment_on_table', 'convert_to_schema', 'create_database', 'create_function', 'create_index', 'create_schema', 'create_sequence', 'create_statistics', 'create_table', 'create_type', 'create_view', 'drop_database', 'drop_function', 'drop_index', 'drop_schema', 'drop_sequence', 'drop_table', 'drop_type', 'drop_view', 'finish_schema_change', 'finish_schema_change_rollback', 'force_delete_table_data_entry', 'rename_database', 'rename_function', 'rename_schema', 'rename_table', 'rename_type', 'reverse_schema_change', 'set_schema', 'truncate_table', 'unsafe_delete_descriptor', 'unsafe_delete_namespace_entry', 'unsafe_upsert_descriptor', 'unsafe_upsert_namespace_entry'",
+          "value": "'alter_database_add_region', 'alter_database_drop_region', 'alter_database_placement', 'alter_database_primary_region', 'alter_database_set_zone_config_extension', 'alter_database_survival_goal', 'alter_function_options', 'alter_index', 'alter_index_visible', 'alter_sequence', 'alter_table', 'alter_type', 'comment_on_column', 'comment_on_constraint', 'comment_on_database', 'comment_on_index', 'comment_on_schema', 'comment_on_table', 'convert_to_schema', 'create_database', 'create_function', 'create_index', 'create_schema', 'create_sequence', 'create_statistics', 'create_table', 'create_type', 'create_view', 'drop_database', 'drop_function', 'drop_index', 'drop_schema', 'drop_sequence', 'drop_table', 'drop_type', 'drop_view', 'finish_schema_change', 'finish_schema_change_rollback', 'force_delete_table_data_entry', 'rename_database', 'rename_function', 'rename_schema', 'rename_table', 'rename_type', 'reverse_schema_change', 'set_schema', 'truncate_table', 'unsafe_delete_descriptor', 'unsafe_delete_namespace_entry', 'unsafe_upsert_descriptor', 'unsafe_upsert_namespace_entry'"
+        },
+        "description": "The list of event types for DDL statements.",
+        "hide": 2,
+        "name": "ddl_event_types",
+        "options": [
+          {
+            "selected": true,
+            "text": "'alter_database_add_region', 'alter_database_drop_region', 'alter_database_placement', 'alter_database_primary_region', 'alter_database_set_zone_config_extension', 'alter_database_survival_goal', 'alter_function_options', 'alter_index', 'alter_index_visible', 'alter_sequence', 'alter_table', 'alter_type', 'comment_on_column', 'comment_on_constraint', 'comment_on_database', 'comment_on_index', 'comment_on_schema', 'comment_on_table', 'convert_to_schema', 'create_database', 'create_function', 'create_index', 'create_schema', 'create_sequence', 'create_statistics', 'create_table', 'create_type', 'create_view', 'drop_database', 'drop_function', 'drop_index', 'drop_schema', 'drop_sequence', 'drop_table', 'drop_type', 'drop_view', 'finish_schema_change', 'finish_schema_change_rollback', 'force_delete_table_data_entry', 'rename_database', 'rename_function', 'rename_schema', 'rename_table', 'rename_type', 'reverse_schema_change', 'set_schema', 'truncate_table', 'unsafe_delete_descriptor', 'unsafe_delete_namespace_entry', 'unsafe_upsert_descriptor', 'unsafe_upsert_namespace_entry'",
+            "value": "'alter_database_add_region', 'alter_database_drop_region', 'alter_database_placement', 'alter_database_primary_region', 'alter_database_set_zone_config_extension', 'alter_database_survival_goal', 'alter_function_options', 'alter_index', 'alter_index_visible', 'alter_sequence', 'alter_table', 'alter_type', 'comment_on_column', 'comment_on_constraint', 'comment_on_database', 'comment_on_index', 'comment_on_schema', 'comment_on_table', 'convert_to_schema', 'create_database', 'create_function', 'create_index', 'create_schema', 'create_sequence', 'create_statistics', 'create_table', 'create_type', 'create_view', 'drop_database', 'drop_function', 'drop_index', 'drop_schema', 'drop_sequence', 'drop_table', 'drop_type', 'drop_view', 'finish_schema_change', 'finish_schema_change_rollback', 'force_delete_table_data_entry', 'rename_database', 'rename_function', 'rename_schema', 'rename_table', 'rename_type', 'reverse_schema_change', 'set_schema', 'truncate_table', 'unsafe_delete_descriptor', 'unsafe_delete_namespace_entry', 'unsafe_upsert_descriptor', 'unsafe_upsert_namespace_entry'"
+          }
+        ],
+        "query": "'alter_database_add_region', 'alter_database_drop_region', 'alter_database_placement', 'alter_database_primary_region', 'alter_database_set_zone_config_extension', 'alter_database_survival_goal', 'alter_function_options', 'alter_index', 'alter_index_visible', 'alter_sequence', 'alter_table', 'alter_type', 'comment_on_column', 'comment_on_constraint', 'comment_on_database', 'comment_on_index', 'comment_on_schema', 'comment_on_table', 'convert_to_schema', 'create_database', 'create_function', 'create_index', 'create_schema', 'create_sequence', 'create_statistics', 'create_table', 'create_type', 'create_view', 'drop_database', 'drop_function', 'drop_index', 'drop_schema', 'drop_sequence', 'drop_table', 'drop_type', 'drop_view', 'finish_schema_change', 'finish_schema_change_rollback', 'force_delete_table_data_entry', 'rename_database', 'rename_function', 'rename_schema', 'rename_table', 'rename_type', 'reverse_schema_change', 'set_schema', 'truncate_table', 'unsafe_delete_descriptor', 'unsafe_delete_namespace_entry', 'unsafe_upsert_descriptor', 'unsafe_upsert_namespace_entry'",
+        "skipUrlSync": false,
+        "type": "textbox"
+      },
+      {
+        "current": {
+          "selected": false,
+          "text": "'set_cluster_setting', 'set_tenant_cluster_setting'",
+          "value": "'set_cluster_setting', 'set_tenant_cluster_setting'"
+        },
+        "description": "The list of event types for cluster settings.",
+        "hide": 2,
+        "name": "cluster_setting_event_types",
+        "options": [
+          {
+            "selected": true,
+            "text": "'set_cluster_setting', 'set_tenant_cluster_setting'",
+            "value": "'set_cluster_setting', 'set_tenant_cluster_setting'"
+          }
+        ],
+        "query": "'set_cluster_setting', 'set_tenant_cluster_setting'",
+        "skipUrlSync": false,
+        "type": "textbox"
+      },
+      {
+        "current": {
+          "selected": false,
+          "text": "'certs_reload',   'node_decommissioned',   'node_decommissioning',   'node_join',   'node_recommissioned',   'node_restart'",
+          "value": "'certs_reload',   'node_decommissioned',   'node_decommissioning',   'node_join',   'node_recommissioned',   'node_restart'"
+        },
+        "description": "The list of event types for cluster-wide events.",
+        "hide": 2,
+        "name": "cluster_wide_event_types",
+        "options": [
+          {
+            "selected": true,
+            "text": "'certs_reload',   'node_decommissioned',   'node_decommissioning',   'node_join',   'node_recommissioned',   'node_restart'",
+            "value": "'certs_reload',   'node_decommissioned',   'node_decommissioning',   'node_join',   'node_recommissioned',   'node_restart'"
+          }
+        ],
+        "query": "'certs_reload',   'node_decommissioned',   'node_decommissioning',   'node_join',   'node_recommissioned',   'node_restart'",
+        "skipUrlSync": false,
+        "type": "textbox"
+      },
+      {
+        "current": {
+          "selected": false,
+          "text": "'import', 'restore'",
+          "value": "'import', 'restore'"
+        },
+        "description": "The list of event types for jobs.",
+        "hide": 2,
+        "name": "job_event_types",
+        "options": [
+          {
+            "selected": true,
+            "text": "'import', 'restore'",
+            "value": "'import', 'restore'"
+          }
+        ],
+        "query": "'import', 'restore'",
+        "skipUrlSync": false,
+        "type": "textbox"
+      },
+      {
+        "current": {
+          "selected": false,
+          "text": "'client_authentication_failed',   'client_authentication_info',   'client_authentication_ok',   'client_connection_end',   'client_connection_start',   'client_session_end'",
+          "value": "'client_authentication_failed',   'client_authentication_info',   'client_authentication_ok',   'client_connection_end',   'client_connection_start',   'client_session_end'"
+        },
+        "description": "The list of event types for SQL session events.",
+        "hide": 2,
+        "name": "sql_session_event_types",
+        "options": [
+          {
+            "selected": true,
+            "text": "'client_authentication_failed',   'client_authentication_info',   'client_authentication_ok',   'client_connection_end',   'client_connection_start',   'client_session_end'",
+            "value": "'client_authentication_failed',   'client_authentication_info',   'client_authentication_ok',   'client_connection_end',   'client_connection_start',   'client_session_end'"
+          }
+        ],
+        "query": "'client_authentication_failed',   'client_authentication_info',   'client_authentication_ok',   'client_connection_end',   'client_connection_start',   'client_session_end'",
+        "skipUrlSync": false,
+        "type": "textbox"
+      },
+      {
+        "current": {
+          "selected": false,
+          "text": "'set_zone_config', 'remove_zone_config'",
+          "value": "'set_zone_config', 'remove_zone_config'"
+        },
+        "description": "The list of event types for zone configurations.",
+        "hide": 2,
+        "name": "zone_config_event_types",
+        "options": [
+          {
+            "selected": true,
+            "text": "'set_zone_config', 'remove_zone_config'",
+            "value": "'set_zone_config', 'remove_zone_config'"
+          }
+        ],
+        "query": "'set_zone_config', 'remove_zone_config'",
+        "skipUrlSync": false,
+        "type": "textbox"
       }
     ]
   },

--- a/monitoring/grafana-dashboards/hardware.json
+++ b/monitoring/grafana-dashboards/hardware.json
@@ -9,6 +9,84 @@
         "iconColor": "rgba(0, 211, 255, 1)",
         "name": "Annotations & Alerts",
         "type": "dashboard"
+      },
+      {
+        "datasource": "CockroachDB",
+        "enable": true,
+        "iconColor": "green",
+        "name": "Schema Changes",
+        "target": {
+          "editorMode": "code",
+          "format": "table",
+          "rawQuery": true,
+          "rawSql": "SELECT timestamp AS time, \"eventType\" AS title, info :: JSONB ->> 'Statement' AS text, encode(\"uniqueID\", 'hex') AS id, 'schema change' AS tags FROM system.eventlog WHERE \"eventType\" LIKE ANY(${ddl_event_types:csv}) ORDER BY timestamp LIMIT 500;",
+          "refId": "Anno"
+        }
+      },
+      {
+        "datasource": "CockroachDB",
+        "enable": true,
+        "iconColor": "yellow",
+        "name": "Cluster Settings",
+        "target": {
+          "editorMode": "code",
+          "format": "table",
+          "rawQuery": true,
+          "rawSql": "SELECT timestamp AS time, \"eventType\" AS title, info :: JSONB ->> 'Statement' AS text, encode(\"uniqueID\", 'hex') AS id, 'cluster setting' AS tags FROM system.eventlog WHERE \"eventType\" LIKE ANY(${cluster_setting_event_types:csv}) ORDER BY timestamp LIMIT 500;",
+          "refId": "Anno"
+        }
+      },
+      {
+        "datasource": "CockroachDB",
+        "enable": false,
+        "iconColor": "purple",
+        "name": "Cluster-wide Events",
+        "target": {
+          "editorMode": "code",
+          "format": "table",
+          "rawQuery": true,
+          "rawSql": "SELECT timestamp AS time, \"eventType\" AS title, concat('Reporting node ID: ', \"reportingID\"::STRING) AS text, encode(\"uniqueID\", 'hex') AS id, 'cluster-wide event' AS tags FROM system.eventlog WHERE \"eventType\" LIKE ANY(${cluster_wide_event_types:csv}) ORDER BY timestamp LIMIT 500;",
+          "refId": "Anno"
+        }
+      },
+      {
+        "datasource": "CockroachDB",
+        "enable": false,
+        "iconColor": "blue",
+        "name": "Jobs",
+        "target": {
+          "editorMode": "code",
+          "format": "table",
+          "rawQuery": true,
+          "rawSql": "SELECT timestamp AS time, \"eventType\" AS title, info :: JSONB ->> 'Description' AS text, encode(\"uniqueID\", 'hex') AS id, 'job' AS tags FROM system.eventlog WHERE \"eventType\" LIKE ANY(${job_event_types:csv}) ORDER BY timestamp LIMIT 500;",
+          "refId": "Anno"
+        }
+      },
+      {
+        "datasource": "CockroachDB",
+        "enable": false,
+        "iconColor": "orange",
+        "name": "SQL Session Events",
+        "target": {
+          "editorMode": "code",
+          "format": "table",
+          "rawQuery": true,
+          "rawSql": "SELECT timestamp AS time, \"eventType\" AS title, concat('SQL client remote address: ', info :: JSONB ->> 'RemoteAddress') AS text, encode(\"uniqueID\", 'hex') AS id, 'SQL session event' AS tags FROM system.eventlog WHERE \"eventType\" LIKE ANY(${sql_session_event_types:csv}) ORDER BY timestamp LIMIT 500;",
+          "refId": "Anno"
+        }
+      },
+      {
+        "datasource": "CockroachDB",
+        "enable": false,
+        "iconColor": "red",
+        "name": "Zone Configurations",
+        "target": {
+          "editorMode": "code",
+          "format": "table",
+          "rawQuery": true,
+          "rawSql": "SELECT timestamp AS time, \"eventType\" AS title, info :: JSONB ->> 'Statement' AS text, encode(\"uniqueID\", 'hex') AS id, 'zone configurations' AS tags FROM system.eventlog WHERE \"eventType\" LIKE ANY(${zone_config_event_types:csv}) ORDER BY timestamp LIMIT 500;",
+          "refId": "Anno"
+        }
       }
     ]
   },
@@ -1034,7 +1112,7 @@
         "options": [],
         "query": {
           "query": "sys_uptime{job=\"cockroachdb\"}",
-          "refId": "Prometheusa-cluster-Variable-Query"
+          "refId": "Prometheus-cluster-Variable-Query"
         },
         "refresh": 1,
         "regex": "/cluster=\"([^\"]+)\"/",
@@ -1049,7 +1127,7 @@
       {
         "allValue": "",
         "current": {
-          "selected": true,
+          "selected": false,
           "text": "All",
           "value": "$__all"
         },
@@ -1065,12 +1143,12 @@
         "options": [],
         "query": {
           "query": "label_values(sys_uptime{job=\"cockroachdb\",cluster=\"$cluster\"},instance)",
-          "refId": "Prometheusa-node-Variable-Query"
+          "refId": "Prometheus-node-Variable-Query"
         },
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,
-        "sort": 3,
+        "sort": 1,
         "tagValuesQuery": "",
         "tags": [],
         "tagsQuery": "",
@@ -1142,6 +1220,126 @@
         "refresh": 2,
         "skipUrlSync": false,
         "type": "interval"
+      },
+      {
+        "current": {
+          "selected": false,
+          "text": "'alter_database_add_region', 'alter_database_drop_region', 'alter_database_placement', 'alter_database_primary_region', 'alter_database_set_zone_config_extension', 'alter_database_survival_goal', 'alter_function_options', 'alter_index', 'alter_index_visible', 'alter_sequence', 'alter_table', 'alter_type', 'comment_on_column', 'comment_on_constraint', 'comment_on_database', 'comment_on_index', 'comment_on_schema', 'comment_on_table', 'convert_to_schema', 'create_database', 'create_function', 'create_index', 'create_schema', 'create_sequence', 'create_statistics', 'create_table', 'create_type', 'create_view', 'drop_database', 'drop_function', 'drop_index', 'drop_schema', 'drop_sequence', 'drop_table', 'drop_type', 'drop_view', 'finish_schema_change', 'finish_schema_change_rollback', 'force_delete_table_data_entry', 'rename_database', 'rename_function', 'rename_schema', 'rename_table', 'rename_type', 'reverse_schema_change', 'set_schema', 'truncate_table', 'unsafe_delete_descriptor', 'unsafe_delete_namespace_entry', 'unsafe_upsert_descriptor', 'unsafe_upsert_namespace_entry'",
+          "value": "'alter_database_add_region', 'alter_database_drop_region', 'alter_database_placement', 'alter_database_primary_region', 'alter_database_set_zone_config_extension', 'alter_database_survival_goal', 'alter_function_options', 'alter_index', 'alter_index_visible', 'alter_sequence', 'alter_table', 'alter_type', 'comment_on_column', 'comment_on_constraint', 'comment_on_database', 'comment_on_index', 'comment_on_schema', 'comment_on_table', 'convert_to_schema', 'create_database', 'create_function', 'create_index', 'create_schema', 'create_sequence', 'create_statistics', 'create_table', 'create_type', 'create_view', 'drop_database', 'drop_function', 'drop_index', 'drop_schema', 'drop_sequence', 'drop_table', 'drop_type', 'drop_view', 'finish_schema_change', 'finish_schema_change_rollback', 'force_delete_table_data_entry', 'rename_database', 'rename_function', 'rename_schema', 'rename_table', 'rename_type', 'reverse_schema_change', 'set_schema', 'truncate_table', 'unsafe_delete_descriptor', 'unsafe_delete_namespace_entry', 'unsafe_upsert_descriptor', 'unsafe_upsert_namespace_entry'"
+        },
+        "description": "The list of event types for DDL statements.",
+        "hide": 2,
+        "name": "ddl_event_types",
+        "options": [
+          {
+            "selected": true,
+            "text": "'alter_database_add_region', 'alter_database_drop_region', 'alter_database_placement', 'alter_database_primary_region', 'alter_database_set_zone_config_extension', 'alter_database_survival_goal', 'alter_function_options', 'alter_index', 'alter_index_visible', 'alter_sequence', 'alter_table', 'alter_type', 'comment_on_column', 'comment_on_constraint', 'comment_on_database', 'comment_on_index', 'comment_on_schema', 'comment_on_table', 'convert_to_schema', 'create_database', 'create_function', 'create_index', 'create_schema', 'create_sequence', 'create_statistics', 'create_table', 'create_type', 'create_view', 'drop_database', 'drop_function', 'drop_index', 'drop_schema', 'drop_sequence', 'drop_table', 'drop_type', 'drop_view', 'finish_schema_change', 'finish_schema_change_rollback', 'force_delete_table_data_entry', 'rename_database', 'rename_function', 'rename_schema', 'rename_table', 'rename_type', 'reverse_schema_change', 'set_schema', 'truncate_table', 'unsafe_delete_descriptor', 'unsafe_delete_namespace_entry', 'unsafe_upsert_descriptor', 'unsafe_upsert_namespace_entry'",
+            "value": "'alter_database_add_region', 'alter_database_drop_region', 'alter_database_placement', 'alter_database_primary_region', 'alter_database_set_zone_config_extension', 'alter_database_survival_goal', 'alter_function_options', 'alter_index', 'alter_index_visible', 'alter_sequence', 'alter_table', 'alter_type', 'comment_on_column', 'comment_on_constraint', 'comment_on_database', 'comment_on_index', 'comment_on_schema', 'comment_on_table', 'convert_to_schema', 'create_database', 'create_function', 'create_index', 'create_schema', 'create_sequence', 'create_statistics', 'create_table', 'create_type', 'create_view', 'drop_database', 'drop_function', 'drop_index', 'drop_schema', 'drop_sequence', 'drop_table', 'drop_type', 'drop_view', 'finish_schema_change', 'finish_schema_change_rollback', 'force_delete_table_data_entry', 'rename_database', 'rename_function', 'rename_schema', 'rename_table', 'rename_type', 'reverse_schema_change', 'set_schema', 'truncate_table', 'unsafe_delete_descriptor', 'unsafe_delete_namespace_entry', 'unsafe_upsert_descriptor', 'unsafe_upsert_namespace_entry'"
+          }
+        ],
+        "query": "'alter_database_add_region', 'alter_database_drop_region', 'alter_database_placement', 'alter_database_primary_region', 'alter_database_set_zone_config_extension', 'alter_database_survival_goal', 'alter_function_options', 'alter_index', 'alter_index_visible', 'alter_sequence', 'alter_table', 'alter_type', 'comment_on_column', 'comment_on_constraint', 'comment_on_database', 'comment_on_index', 'comment_on_schema', 'comment_on_table', 'convert_to_schema', 'create_database', 'create_function', 'create_index', 'create_schema', 'create_sequence', 'create_statistics', 'create_table', 'create_type', 'create_view', 'drop_database', 'drop_function', 'drop_index', 'drop_schema', 'drop_sequence', 'drop_table', 'drop_type', 'drop_view', 'finish_schema_change', 'finish_schema_change_rollback', 'force_delete_table_data_entry', 'rename_database', 'rename_function', 'rename_schema', 'rename_table', 'rename_type', 'reverse_schema_change', 'set_schema', 'truncate_table', 'unsafe_delete_descriptor', 'unsafe_delete_namespace_entry', 'unsafe_upsert_descriptor', 'unsafe_upsert_namespace_entry'",
+        "skipUrlSync": false,
+        "type": "textbox"
+      },
+      {
+        "current": {
+          "selected": false,
+          "text": "'set_cluster_setting', 'set_tenant_cluster_setting'",
+          "value": "'set_cluster_setting', 'set_tenant_cluster_setting'"
+        },
+        "description": "The list of event types for cluster settings.",
+        "hide": 2,
+        "name": "cluster_setting_event_types",
+        "options": [
+          {
+            "selected": true,
+            "text": "'set_cluster_setting', 'set_tenant_cluster_setting'",
+            "value": "'set_cluster_setting', 'set_tenant_cluster_setting'"
+          }
+        ],
+        "query": "'set_cluster_setting', 'set_tenant_cluster_setting'",
+        "skipUrlSync": false,
+        "type": "textbox"
+      },
+      {
+        "current": {
+          "selected": false,
+          "text": "'certs_reload',   'node_decommissioned',   'node_decommissioning',   'node_join',   'node_recommissioned',   'node_restart'",
+          "value": "'certs_reload',   'node_decommissioned',   'node_decommissioning',   'node_join',   'node_recommissioned',   'node_restart'"
+        },
+        "description": "The list of event types for cluster-wide events.",
+        "hide": 2,
+        "name": "cluster_wide_event_types",
+        "options": [
+          {
+            "selected": true,
+            "text": "'certs_reload',   'node_decommissioned',   'node_decommissioning',   'node_join',   'node_recommissioned',   'node_restart'",
+            "value": "'certs_reload',   'node_decommissioned',   'node_decommissioning',   'node_join',   'node_recommissioned',   'node_restart'"
+          }
+        ],
+        "query": "'certs_reload',   'node_decommissioned',   'node_decommissioning',   'node_join',   'node_recommissioned',   'node_restart'",
+        "skipUrlSync": false,
+        "type": "textbox"
+      },
+      {
+        "current": {
+          "selected": false,
+          "text": "'import', 'restore'",
+          "value": "'import', 'restore'"
+        },
+        "description": "The list of event types for jobs.",
+        "hide": 2,
+        "name": "job_event_types",
+        "options": [
+          {
+            "selected": true,
+            "text": "'import', 'restore'",
+            "value": "'import', 'restore'"
+          }
+        ],
+        "query": "'import', 'restore'",
+        "skipUrlSync": false,
+        "type": "textbox"
+      },
+      {
+        "current": {
+          "selected": false,
+          "text": "'client_authentication_failed',   'client_authentication_info',   'client_authentication_ok',   'client_connection_end',   'client_connection_start',   'client_session_end'",
+          "value": "'client_authentication_failed',   'client_authentication_info',   'client_authentication_ok',   'client_connection_end',   'client_connection_start',   'client_session_end'"
+        },
+        "description": "The list of event types for SQL session events.",
+        "hide": 2,
+        "name": "sql_session_event_types",
+        "options": [
+          {
+            "selected": true,
+            "text": "'client_authentication_failed',   'client_authentication_info',   'client_authentication_ok',   'client_connection_end',   'client_connection_start',   'client_session_end'",
+            "value": "'client_authentication_failed',   'client_authentication_info',   'client_authentication_ok',   'client_connection_end',   'client_connection_start',   'client_session_end'"
+          }
+        ],
+        "query": "'client_authentication_failed',   'client_authentication_info',   'client_authentication_ok',   'client_connection_end',   'client_connection_start',   'client_session_end'",
+        "skipUrlSync": false,
+        "type": "textbox"
+      },
+      {
+        "current": {
+          "selected": false,
+          "text": "'set_zone_config', 'remove_zone_config'",
+          "value": "'set_zone_config', 'remove_zone_config'"
+        },
+        "description": "The list of event types for zone configurations.",
+        "hide": 2,
+        "name": "zone_config_event_types",
+        "options": [
+          {
+            "selected": true,
+            "text": "'set_zone_config', 'remove_zone_config'",
+            "value": "'set_zone_config', 'remove_zone_config'"
+          }
+        ],
+        "query": "'set_zone_config', 'remove_zone_config'",
+        "skipUrlSync": false,
+        "type": "textbox"
       }
     ]
   },

--- a/monitoring/grafana-dashboards/overview.json
+++ b/monitoring/grafana-dashboards/overview.json
@@ -9,6 +9,84 @@
         "iconColor": "rgba(0, 211, 255, 1)",
         "name": "Annotations & Alerts",
         "type": "dashboard"
+      },
+      {
+        "datasource": "CockroachDB",
+        "enable": true,
+        "iconColor": "green",
+        "name": "Schema Changes",
+        "target": {
+          "editorMode": "code",
+          "format": "table",
+          "rawQuery": true,
+          "rawSql": "SELECT timestamp AS time, \"eventType\" AS title, info :: JSONB ->> 'Statement' AS text, encode(\"uniqueID\", 'hex') AS id, 'schema change' AS tags FROM system.eventlog WHERE \"eventType\" LIKE ANY(${ddl_event_types:csv}) ORDER BY timestamp LIMIT 500;",
+          "refId": "Anno"
+        }
+      },
+      {
+        "datasource": "CockroachDB",
+        "enable": true,
+        "iconColor": "yellow",
+        "name": "Cluster Settings",
+        "target": {
+          "editorMode": "code",
+          "format": "table",
+          "rawQuery": true,
+          "rawSql": "SELECT timestamp AS time, \"eventType\" AS title, info :: JSONB ->> 'Statement' AS text, encode(\"uniqueID\", 'hex') AS id, 'cluster setting' AS tags FROM system.eventlog WHERE \"eventType\" LIKE ANY(${cluster_setting_event_types:csv}) ORDER BY timestamp LIMIT 500;",
+          "refId": "Anno"
+        }
+      },
+      {
+        "datasource": "CockroachDB",
+        "enable": false,
+        "iconColor": "purple",
+        "name": "Cluster-wide Events",
+        "target": {
+          "editorMode": "code",
+          "format": "table",
+          "rawQuery": true,
+          "rawSql": "SELECT timestamp AS time, \"eventType\" AS title, concat('Reporting node ID: ', \"reportingID\"::STRING) AS text, encode(\"uniqueID\", 'hex') AS id, 'cluster-wide event' AS tags FROM system.eventlog WHERE \"eventType\" LIKE ANY(${cluster_wide_event_types:csv}) ORDER BY timestamp LIMIT 500;",
+          "refId": "Anno"
+        }
+      },
+      {
+        "datasource": "CockroachDB",
+        "enable": false,
+        "iconColor": "blue",
+        "name": "Jobs",
+        "target": {
+          "editorMode": "code",
+          "format": "table",
+          "rawQuery": true,
+          "rawSql": "SELECT timestamp AS time, \"eventType\" AS title, info :: JSONB ->> 'Description' AS text, encode(\"uniqueID\", 'hex') AS id, 'job' AS tags FROM system.eventlog WHERE \"eventType\" LIKE ANY(${job_event_types:csv}) ORDER BY timestamp LIMIT 500;",
+          "refId": "Anno"
+        }
+      },
+      {
+        "datasource": "CockroachDB",
+        "enable": false,
+        "iconColor": "orange",
+        "name": "SQL Session Events",
+        "target": {
+          "editorMode": "code",
+          "format": "table",
+          "rawQuery": true,
+          "rawSql": "SELECT timestamp AS time, \"eventType\" AS title, concat('SQL client remote address: ', info :: JSONB ->> 'RemoteAddress') AS text, encode(\"uniqueID\", 'hex') AS id, 'SQL session event' AS tags FROM system.eventlog WHERE \"eventType\" LIKE ANY(${sql_session_event_types:csv}) ORDER BY timestamp LIMIT 500;",
+          "refId": "Anno"
+        }
+      },
+      {
+        "datasource": "CockroachDB",
+        "enable": false,
+        "iconColor": "red",
+        "name": "Zone Configurations",
+        "target": {
+          "editorMode": "code",
+          "format": "table",
+          "rawQuery": true,
+          "rawSql": "SELECT timestamp AS time, \"eventType\" AS title, info :: JSONB ->> 'Statement' AS text, encode(\"uniqueID\", 'hex') AS id, 'zone configurations' AS tags FROM system.eventlog WHERE \"eventType\" LIKE ANY(${zone_config_event_types:csv}) ORDER BY timestamp LIMIT 500;",
+          "refId": "Anno"
+        }
       }
     ]
   },
@@ -538,7 +616,7 @@
         "auto_count": 30,
         "auto_min": "10s",
         "current": {
-          "selected": true,
+          "selected": false,
           "text": "30s",
           "value": "30s"
         },
@@ -595,10 +673,129 @@
           }
         ],
         "query": "30s,1m,5m,10m,30m,1h,6h,12h,1d",
-        "queryValue": "",
         "refresh": 2,
         "skipUrlSync": false,
         "type": "interval"
+      },
+      {
+        "current": {
+          "selected": false,
+          "text": "'alter_database_add_region', 'alter_database_drop_region', 'alter_database_placement', 'alter_database_primary_region', 'alter_database_set_zone_config_extension', 'alter_database_survival_goal', 'alter_function_options', 'alter_index', 'alter_index_visible', 'alter_sequence', 'alter_table', 'alter_type', 'comment_on_column', 'comment_on_constraint', 'comment_on_database', 'comment_on_index', 'comment_on_schema', 'comment_on_table', 'convert_to_schema', 'create_database', 'create_function', 'create_index', 'create_schema', 'create_sequence', 'create_statistics', 'create_table', 'create_type', 'create_view', 'drop_database', 'drop_function', 'drop_index', 'drop_schema', 'drop_sequence', 'drop_table', 'drop_type', 'drop_view', 'finish_schema_change', 'finish_schema_change_rollback', 'force_delete_table_data_entry', 'rename_database', 'rename_function', 'rename_schema', 'rename_table', 'rename_type', 'reverse_schema_change', 'set_schema', 'truncate_table', 'unsafe_delete_descriptor', 'unsafe_delete_namespace_entry', 'unsafe_upsert_descriptor', 'unsafe_upsert_namespace_entry'",
+          "value": "'alter_database_add_region', 'alter_database_drop_region', 'alter_database_placement', 'alter_database_primary_region', 'alter_database_set_zone_config_extension', 'alter_database_survival_goal', 'alter_function_options', 'alter_index', 'alter_index_visible', 'alter_sequence', 'alter_table', 'alter_type', 'comment_on_column', 'comment_on_constraint', 'comment_on_database', 'comment_on_index', 'comment_on_schema', 'comment_on_table', 'convert_to_schema', 'create_database', 'create_function', 'create_index', 'create_schema', 'create_sequence', 'create_statistics', 'create_table', 'create_type', 'create_view', 'drop_database', 'drop_function', 'drop_index', 'drop_schema', 'drop_sequence', 'drop_table', 'drop_type', 'drop_view', 'finish_schema_change', 'finish_schema_change_rollback', 'force_delete_table_data_entry', 'rename_database', 'rename_function', 'rename_schema', 'rename_table', 'rename_type', 'reverse_schema_change', 'set_schema', 'truncate_table', 'unsafe_delete_descriptor', 'unsafe_delete_namespace_entry', 'unsafe_upsert_descriptor', 'unsafe_upsert_namespace_entry'"
+        },
+        "description": "The list of event types for DDL statements.",
+        "hide": 2,
+        "name": "ddl_event_types",
+        "options": [
+          {
+            "selected": true,
+            "text": "'alter_database_add_region', 'alter_database_drop_region', 'alter_database_placement', 'alter_database_primary_region', 'alter_database_set_zone_config_extension', 'alter_database_survival_goal', 'alter_function_options', 'alter_index', 'alter_index_visible', 'alter_sequence', 'alter_table', 'alter_type', 'comment_on_column', 'comment_on_constraint', 'comment_on_database', 'comment_on_index', 'comment_on_schema', 'comment_on_table', 'convert_to_schema', 'create_database', 'create_function', 'create_index', 'create_schema', 'create_sequence', 'create_statistics', 'create_table', 'create_type', 'create_view', 'drop_database', 'drop_function', 'drop_index', 'drop_schema', 'drop_sequence', 'drop_table', 'drop_type', 'drop_view', 'finish_schema_change', 'finish_schema_change_rollback', 'force_delete_table_data_entry', 'rename_database', 'rename_function', 'rename_schema', 'rename_table', 'rename_type', 'reverse_schema_change', 'set_schema', 'truncate_table', 'unsafe_delete_descriptor', 'unsafe_delete_namespace_entry', 'unsafe_upsert_descriptor', 'unsafe_upsert_namespace_entry'",
+            "value": "'alter_database_add_region', 'alter_database_drop_region', 'alter_database_placement', 'alter_database_primary_region', 'alter_database_set_zone_config_extension', 'alter_database_survival_goal', 'alter_function_options', 'alter_index', 'alter_index_visible', 'alter_sequence', 'alter_table', 'alter_type', 'comment_on_column', 'comment_on_constraint', 'comment_on_database', 'comment_on_index', 'comment_on_schema', 'comment_on_table', 'convert_to_schema', 'create_database', 'create_function', 'create_index', 'create_schema', 'create_sequence', 'create_statistics', 'create_table', 'create_type', 'create_view', 'drop_database', 'drop_function', 'drop_index', 'drop_schema', 'drop_sequence', 'drop_table', 'drop_type', 'drop_view', 'finish_schema_change', 'finish_schema_change_rollback', 'force_delete_table_data_entry', 'rename_database', 'rename_function', 'rename_schema', 'rename_table', 'rename_type', 'reverse_schema_change', 'set_schema', 'truncate_table', 'unsafe_delete_descriptor', 'unsafe_delete_namespace_entry', 'unsafe_upsert_descriptor', 'unsafe_upsert_namespace_entry'"
+          }
+        ],
+        "query": "'alter_database_add_region', 'alter_database_drop_region', 'alter_database_placement', 'alter_database_primary_region', 'alter_database_set_zone_config_extension', 'alter_database_survival_goal', 'alter_function_options', 'alter_index', 'alter_index_visible', 'alter_sequence', 'alter_table', 'alter_type', 'comment_on_column', 'comment_on_constraint', 'comment_on_database', 'comment_on_index', 'comment_on_schema', 'comment_on_table', 'convert_to_schema', 'create_database', 'create_function', 'create_index', 'create_schema', 'create_sequence', 'create_statistics', 'create_table', 'create_type', 'create_view', 'drop_database', 'drop_function', 'drop_index', 'drop_schema', 'drop_sequence', 'drop_table', 'drop_type', 'drop_view', 'finish_schema_change', 'finish_schema_change_rollback', 'force_delete_table_data_entry', 'rename_database', 'rename_function', 'rename_schema', 'rename_table', 'rename_type', 'reverse_schema_change', 'set_schema', 'truncate_table', 'unsafe_delete_descriptor', 'unsafe_delete_namespace_entry', 'unsafe_upsert_descriptor', 'unsafe_upsert_namespace_entry'",
+        "skipUrlSync": false,
+        "type": "textbox"
+      },
+      {
+        "current": {
+          "selected": false,
+          "text": "'set_cluster_setting', 'set_tenant_cluster_setting'",
+          "value": "'set_cluster_setting', 'set_tenant_cluster_setting'"
+        },
+        "description": "The list of event types for cluster settings.",
+        "hide": 2,
+        "name": "cluster_setting_event_types",
+        "options": [
+          {
+            "selected": true,
+            "text": "'set_cluster_setting', 'set_tenant_cluster_setting'",
+            "value": "'set_cluster_setting', 'set_tenant_cluster_setting'"
+          }
+        ],
+        "query": "'set_cluster_setting', 'set_tenant_cluster_setting'",
+        "skipUrlSync": false,
+        "type": "textbox"
+      },
+      {
+        "current": {
+          "selected": false,
+          "text": "'certs_reload',   'node_decommissioned',   'node_decommissioning',   'node_join',   'node_recommissioned',   'node_restart'",
+          "value": "'certs_reload',   'node_decommissioned',   'node_decommissioning',   'node_join',   'node_recommissioned',   'node_restart'"
+        },
+        "description": "The list of event types for cluster-wide events.",
+        "hide": 2,
+        "name": "cluster_wide_event_types",
+        "options": [
+          {
+            "selected": true,
+            "text": "'certs_reload',   'node_decommissioned',   'node_decommissioning',   'node_join',   'node_recommissioned',   'node_restart'",
+            "value": "'certs_reload',   'node_decommissioned',   'node_decommissioning',   'node_join',   'node_recommissioned',   'node_restart'"
+          }
+        ],
+        "query": "'certs_reload',   'node_decommissioned',   'node_decommissioning',   'node_join',   'node_recommissioned',   'node_restart'",
+        "skipUrlSync": false,
+        "type": "textbox"
+      },
+      {
+        "current": {
+          "selected": false,
+          "text": "'import', 'restore'",
+          "value": "'import', 'restore'"
+        },
+        "description": "The list of event types for jobs.",
+        "hide": 2,
+        "name": "job_event_types",
+        "options": [
+          {
+            "selected": true,
+            "text": "'import', 'restore'",
+            "value": "'import', 'restore'"
+          }
+        ],
+        "query": "'import', 'restore'",
+        "skipUrlSync": false,
+        "type": "textbox"
+      },
+      {
+        "current": {
+          "selected": false,
+          "text": "'client_authentication_failed',   'client_authentication_info',   'client_authentication_ok',   'client_connection_end',   'client_connection_start',   'client_session_end'",
+          "value": "'client_authentication_failed',   'client_authentication_info',   'client_authentication_ok',   'client_connection_end',   'client_connection_start',   'client_session_end'"
+        },
+        "description": "The list of event types for SQL session events.",
+        "hide": 2,
+        "name": "sql_session_event_types",
+        "options": [
+          {
+            "selected": true,
+            "text": "'client_authentication_failed',   'client_authentication_info',   'client_authentication_ok',   'client_connection_end',   'client_connection_start',   'client_session_end'",
+            "value": "'client_authentication_failed',   'client_authentication_info',   'client_authentication_ok',   'client_connection_end',   'client_connection_start',   'client_session_end'"
+          }
+        ],
+        "query": "'client_authentication_failed',   'client_authentication_info',   'client_authentication_ok',   'client_connection_end',   'client_connection_start',   'client_session_end'",
+        "skipUrlSync": false,
+        "type": "textbox"
+      },
+      {
+        "current": {
+          "selected": false,
+          "text": "'set_zone_config', 'remove_zone_config'",
+          "value": "'set_zone_config', 'remove_zone_config'"
+        },
+        "description": "The list of event types for zone configurations.",
+        "hide": 2,
+        "name": "zone_config_event_types",
+        "options": [
+          {
+            "selected": true,
+            "text": "'set_zone_config', 'remove_zone_config'",
+            "value": "'set_zone_config', 'remove_zone_config'"
+          }
+        ],
+        "query": "'set_zone_config', 'remove_zone_config'",
+        "skipUrlSync": false,
+        "type": "textbox"
       }
     ]
   },

--- a/monitoring/grafana-dashboards/queues.json
+++ b/monitoring/grafana-dashboards/queues.json
@@ -9,6 +9,84 @@
         "iconColor": "rgba(0, 211, 255, 1)",
         "name": "Annotations & Alerts",
         "type": "dashboard"
+      },
+      {
+        "datasource": "CockroachDB",
+        "enable": true,
+        "iconColor": "green",
+        "name": "Schema Changes",
+        "target": {
+          "editorMode": "code",
+          "format": "table",
+          "rawQuery": true,
+          "rawSql": "SELECT timestamp AS time, \"eventType\" AS title, info :: JSONB ->> 'Statement' AS text, encode(\"uniqueID\", 'hex') AS id, 'schema change' AS tags FROM system.eventlog WHERE \"eventType\" LIKE ANY(${ddl_event_types:csv}) ORDER BY timestamp LIMIT 500;",
+          "refId": "Anno"
+        }
+      },
+      {
+        "datasource": "CockroachDB",
+        "enable": true,
+        "iconColor": "yellow",
+        "name": "Cluster Settings",
+        "target": {
+          "editorMode": "code",
+          "format": "table",
+          "rawQuery": true,
+          "rawSql": "SELECT timestamp AS time, \"eventType\" AS title, info :: JSONB ->> 'Statement' AS text, encode(\"uniqueID\", 'hex') AS id, 'cluster setting' AS tags FROM system.eventlog WHERE \"eventType\" LIKE ANY(${cluster_setting_event_types:csv}) ORDER BY timestamp LIMIT 500;",
+          "refId": "Anno"
+        }
+      },
+      {
+        "datasource": "CockroachDB",
+        "enable": false,
+        "iconColor": "purple",
+        "name": "Cluster-wide Events",
+        "target": {
+          "editorMode": "code",
+          "format": "table",
+          "rawQuery": true,
+          "rawSql": "SELECT timestamp AS time, \"eventType\" AS title, concat('Reporting node ID: ', \"reportingID\"::STRING) AS text, encode(\"uniqueID\", 'hex') AS id, 'cluster-wide event' AS tags FROM system.eventlog WHERE \"eventType\" LIKE ANY(${cluster_wide_event_types:csv}) ORDER BY timestamp LIMIT 500;",
+          "refId": "Anno"
+        }
+      },
+      {
+        "datasource": "CockroachDB",
+        "enable": false,
+        "iconColor": "blue",
+        "name": "Jobs",
+        "target": {
+          "editorMode": "code",
+          "format": "table",
+          "rawQuery": true,
+          "rawSql": "SELECT timestamp AS time, \"eventType\" AS title, info :: JSONB ->> 'Description' AS text, encode(\"uniqueID\", 'hex') AS id, 'job' AS tags FROM system.eventlog WHERE \"eventType\" LIKE ANY(${job_event_types:csv}) ORDER BY timestamp LIMIT 500;",
+          "refId": "Anno"
+        }
+      },
+      {
+        "datasource": "CockroachDB",
+        "enable": false,
+        "iconColor": "orange",
+        "name": "SQL Session Events",
+        "target": {
+          "editorMode": "code",
+          "format": "table",
+          "rawQuery": true,
+          "rawSql": "SELECT timestamp AS time, \"eventType\" AS title, concat('SQL client remote address: ', info :: JSONB ->> 'RemoteAddress') AS text, encode(\"uniqueID\", 'hex') AS id, 'SQL session event' AS tags FROM system.eventlog WHERE \"eventType\" LIKE ANY(${sql_session_event_types:csv}) ORDER BY timestamp LIMIT 500;",
+          "refId": "Anno"
+        }
+      },
+      {
+        "datasource": "CockroachDB",
+        "enable": false,
+        "iconColor": "red",
+        "name": "Zone Configurations",
+        "target": {
+          "editorMode": "code",
+          "format": "table",
+          "rawQuery": true,
+          "rawSql": "SELECT timestamp AS time, \"eventType\" AS title, info :: JSONB ->> 'Statement' AS text, encode(\"uniqueID\", 'hex') AS id, 'zone configurations' AS tags FROM system.eventlog WHERE \"eventType\" LIKE ANY(${zone_config_event_types:csv}) ORDER BY timestamp LIMIT 500;",
+          "refId": "Anno"
+        }
       }
     ]
   },
@@ -1460,10 +1538,129 @@
           }
         ],
         "query": "30s,1m,5m,10m,30m,1h,6h,12h,1d",
-        "queryValue": "",
         "refresh": 2,
         "skipUrlSync": false,
         "type": "interval"
+      },
+      {
+        "current": {
+          "selected": false,
+          "text": "'alter_database_add_region', 'alter_database_drop_region', 'alter_database_placement', 'alter_database_primary_region', 'alter_database_set_zone_config_extension', 'alter_database_survival_goal', 'alter_function_options', 'alter_index', 'alter_index_visible', 'alter_sequence', 'alter_table', 'alter_type', 'comment_on_column', 'comment_on_constraint', 'comment_on_database', 'comment_on_index', 'comment_on_schema', 'comment_on_table', 'convert_to_schema', 'create_database', 'create_function', 'create_index', 'create_schema', 'create_sequence', 'create_statistics', 'create_table', 'create_type', 'create_view', 'drop_database', 'drop_function', 'drop_index', 'drop_schema', 'drop_sequence', 'drop_table', 'drop_type', 'drop_view', 'finish_schema_change', 'finish_schema_change_rollback', 'force_delete_table_data_entry', 'rename_database', 'rename_function', 'rename_schema', 'rename_table', 'rename_type', 'reverse_schema_change', 'set_schema', 'truncate_table', 'unsafe_delete_descriptor', 'unsafe_delete_namespace_entry', 'unsafe_upsert_descriptor', 'unsafe_upsert_namespace_entry'",
+          "value": "'alter_database_add_region', 'alter_database_drop_region', 'alter_database_placement', 'alter_database_primary_region', 'alter_database_set_zone_config_extension', 'alter_database_survival_goal', 'alter_function_options', 'alter_index', 'alter_index_visible', 'alter_sequence', 'alter_table', 'alter_type', 'comment_on_column', 'comment_on_constraint', 'comment_on_database', 'comment_on_index', 'comment_on_schema', 'comment_on_table', 'convert_to_schema', 'create_database', 'create_function', 'create_index', 'create_schema', 'create_sequence', 'create_statistics', 'create_table', 'create_type', 'create_view', 'drop_database', 'drop_function', 'drop_index', 'drop_schema', 'drop_sequence', 'drop_table', 'drop_type', 'drop_view', 'finish_schema_change', 'finish_schema_change_rollback', 'force_delete_table_data_entry', 'rename_database', 'rename_function', 'rename_schema', 'rename_table', 'rename_type', 'reverse_schema_change', 'set_schema', 'truncate_table', 'unsafe_delete_descriptor', 'unsafe_delete_namespace_entry', 'unsafe_upsert_descriptor', 'unsafe_upsert_namespace_entry'"
+        },
+        "description": "The list of event types for DDL statements.",
+        "hide": 2,
+        "name": "ddl_event_types",
+        "options": [
+          {
+            "selected": true,
+            "text": "'alter_database_add_region', 'alter_database_drop_region', 'alter_database_placement', 'alter_database_primary_region', 'alter_database_set_zone_config_extension', 'alter_database_survival_goal', 'alter_function_options', 'alter_index', 'alter_index_visible', 'alter_sequence', 'alter_table', 'alter_type', 'comment_on_column', 'comment_on_constraint', 'comment_on_database', 'comment_on_index', 'comment_on_schema', 'comment_on_table', 'convert_to_schema', 'create_database', 'create_function', 'create_index', 'create_schema', 'create_sequence', 'create_statistics', 'create_table', 'create_type', 'create_view', 'drop_database', 'drop_function', 'drop_index', 'drop_schema', 'drop_sequence', 'drop_table', 'drop_type', 'drop_view', 'finish_schema_change', 'finish_schema_change_rollback', 'force_delete_table_data_entry', 'rename_database', 'rename_function', 'rename_schema', 'rename_table', 'rename_type', 'reverse_schema_change', 'set_schema', 'truncate_table', 'unsafe_delete_descriptor', 'unsafe_delete_namespace_entry', 'unsafe_upsert_descriptor', 'unsafe_upsert_namespace_entry'",
+            "value": "'alter_database_add_region', 'alter_database_drop_region', 'alter_database_placement', 'alter_database_primary_region', 'alter_database_set_zone_config_extension', 'alter_database_survival_goal', 'alter_function_options', 'alter_index', 'alter_index_visible', 'alter_sequence', 'alter_table', 'alter_type', 'comment_on_column', 'comment_on_constraint', 'comment_on_database', 'comment_on_index', 'comment_on_schema', 'comment_on_table', 'convert_to_schema', 'create_database', 'create_function', 'create_index', 'create_schema', 'create_sequence', 'create_statistics', 'create_table', 'create_type', 'create_view', 'drop_database', 'drop_function', 'drop_index', 'drop_schema', 'drop_sequence', 'drop_table', 'drop_type', 'drop_view', 'finish_schema_change', 'finish_schema_change_rollback', 'force_delete_table_data_entry', 'rename_database', 'rename_function', 'rename_schema', 'rename_table', 'rename_type', 'reverse_schema_change', 'set_schema', 'truncate_table', 'unsafe_delete_descriptor', 'unsafe_delete_namespace_entry', 'unsafe_upsert_descriptor', 'unsafe_upsert_namespace_entry'"
+          }
+        ],
+        "query": "'alter_database_add_region', 'alter_database_drop_region', 'alter_database_placement', 'alter_database_primary_region', 'alter_database_set_zone_config_extension', 'alter_database_survival_goal', 'alter_function_options', 'alter_index', 'alter_index_visible', 'alter_sequence', 'alter_table', 'alter_type', 'comment_on_column', 'comment_on_constraint', 'comment_on_database', 'comment_on_index', 'comment_on_schema', 'comment_on_table', 'convert_to_schema', 'create_database', 'create_function', 'create_index', 'create_schema', 'create_sequence', 'create_statistics', 'create_table', 'create_type', 'create_view', 'drop_database', 'drop_function', 'drop_index', 'drop_schema', 'drop_sequence', 'drop_table', 'drop_type', 'drop_view', 'finish_schema_change', 'finish_schema_change_rollback', 'force_delete_table_data_entry', 'rename_database', 'rename_function', 'rename_schema', 'rename_table', 'rename_type', 'reverse_schema_change', 'set_schema', 'truncate_table', 'unsafe_delete_descriptor', 'unsafe_delete_namespace_entry', 'unsafe_upsert_descriptor', 'unsafe_upsert_namespace_entry'",
+        "skipUrlSync": false,
+        "type": "textbox"
+      },
+      {
+        "current": {
+          "selected": false,
+          "text": "'set_cluster_setting', 'set_tenant_cluster_setting'",
+          "value": "'set_cluster_setting', 'set_tenant_cluster_setting'"
+        },
+        "description": "The list of event types for cluster settings.",
+        "hide": 2,
+        "name": "cluster_setting_event_types",
+        "options": [
+          {
+            "selected": true,
+            "text": "'set_cluster_setting', 'set_tenant_cluster_setting'",
+            "value": "'set_cluster_setting', 'set_tenant_cluster_setting'"
+          }
+        ],
+        "query": "'set_cluster_setting', 'set_tenant_cluster_setting'",
+        "skipUrlSync": false,
+        "type": "textbox"
+      },
+      {
+        "current": {
+          "selected": false,
+          "text": "'certs_reload',   'node_decommissioned',   'node_decommissioning',   'node_join',   'node_recommissioned',   'node_restart'",
+          "value": "'certs_reload',   'node_decommissioned',   'node_decommissioning',   'node_join',   'node_recommissioned',   'node_restart'"
+        },
+        "description": "The list of event types for cluster-wide events.",
+        "hide": 2,
+        "name": "cluster_wide_event_types",
+        "options": [
+          {
+            "selected": true,
+            "text": "'certs_reload',   'node_decommissioned',   'node_decommissioning',   'node_join',   'node_recommissioned',   'node_restart'",
+            "value": "'certs_reload',   'node_decommissioned',   'node_decommissioning',   'node_join',   'node_recommissioned',   'node_restart'"
+          }
+        ],
+        "query": "'certs_reload',   'node_decommissioned',   'node_decommissioning',   'node_join',   'node_recommissioned',   'node_restart'",
+        "skipUrlSync": false,
+        "type": "textbox"
+      },
+      {
+        "current": {
+          "selected": false,
+          "text": "'import', 'restore'",
+          "value": "'import', 'restore'"
+        },
+        "description": "The list of event types for jobs.",
+        "hide": 2,
+        "name": "job_event_types",
+        "options": [
+          {
+            "selected": true,
+            "text": "'import', 'restore'",
+            "value": "'import', 'restore'"
+          }
+        ],
+        "query": "'import', 'restore'",
+        "skipUrlSync": false,
+        "type": "textbox"
+      },
+      {
+        "current": {
+          "selected": false,
+          "text": "'client_authentication_failed',   'client_authentication_info',   'client_authentication_ok',   'client_connection_end',   'client_connection_start',   'client_session_end'",
+          "value": "'client_authentication_failed',   'client_authentication_info',   'client_authentication_ok',   'client_connection_end',   'client_connection_start',   'client_session_end'"
+        },
+        "description": "The list of event types for SQL session events.",
+        "hide": 2,
+        "name": "sql_session_event_types",
+        "options": [
+          {
+            "selected": true,
+            "text": "'client_authentication_failed',   'client_authentication_info',   'client_authentication_ok',   'client_connection_end',   'client_connection_start',   'client_session_end'",
+            "value": "'client_authentication_failed',   'client_authentication_info',   'client_authentication_ok',   'client_connection_end',   'client_connection_start',   'client_session_end'"
+          }
+        ],
+        "query": "'client_authentication_failed',   'client_authentication_info',   'client_authentication_ok',   'client_connection_end',   'client_connection_start',   'client_session_end'",
+        "skipUrlSync": false,
+        "type": "textbox"
+      },
+      {
+        "current": {
+          "selected": false,
+          "text": "'set_zone_config', 'remove_zone_config'",
+          "value": "'set_zone_config', 'remove_zone_config'"
+        },
+        "description": "The list of event types for zone configurations.",
+        "hide": 2,
+        "name": "zone_config_event_types",
+        "options": [
+          {
+            "selected": true,
+            "text": "'set_zone_config', 'remove_zone_config'",
+            "value": "'set_zone_config', 'remove_zone_config'"
+          }
+        ],
+        "query": "'set_zone_config', 'remove_zone_config'",
+        "skipUrlSync": false,
+        "type": "textbox"
       }
     ]
   },

--- a/monitoring/grafana-dashboards/replication.json
+++ b/monitoring/grafana-dashboards/replication.json
@@ -9,6 +9,84 @@
         "iconColor": "rgba(0, 211, 255, 1)",
         "name": "Annotations & Alerts",
         "type": "dashboard"
+      },
+      {
+        "datasource": "CockroachDB",
+        "enable": true,
+        "iconColor": "green",
+        "name": "Schema Changes",
+        "target": {
+          "editorMode": "code",
+          "format": "table",
+          "rawQuery": true,
+          "rawSql": "SELECT timestamp AS time, \"eventType\" AS title, info :: JSONB ->> 'Statement' AS text, encode(\"uniqueID\", 'hex') AS id, 'schema change' AS tags FROM system.eventlog WHERE \"eventType\" LIKE ANY(${ddl_event_types:csv}) ORDER BY timestamp LIMIT 500;",
+          "refId": "Anno"
+        }
+      },
+      {
+        "datasource": "CockroachDB",
+        "enable": true,
+        "iconColor": "yellow",
+        "name": "Cluster Settings",
+        "target": {
+          "editorMode": "code",
+          "format": "table",
+          "rawQuery": true,
+          "rawSql": "SELECT timestamp AS time, \"eventType\" AS title, info :: JSONB ->> 'Statement' AS text, encode(\"uniqueID\", 'hex') AS id, 'cluster setting' AS tags FROM system.eventlog WHERE \"eventType\" LIKE ANY(${cluster_setting_event_types:csv}) ORDER BY timestamp LIMIT 500;",
+          "refId": "Anno"
+        }
+      },
+      {
+        "datasource": "CockroachDB",
+        "enable": false,
+        "iconColor": "purple",
+        "name": "Cluster-wide Events",
+        "target": {
+          "editorMode": "code",
+          "format": "table",
+          "rawQuery": true,
+          "rawSql": "SELECT timestamp AS time, \"eventType\" AS title, concat('Reporting node ID: ', \"reportingID\"::STRING) AS text, encode(\"uniqueID\", 'hex') AS id, 'cluster-wide event' AS tags FROM system.eventlog WHERE \"eventType\" LIKE ANY(${cluster_wide_event_types:csv}) ORDER BY timestamp LIMIT 500;",
+          "refId": "Anno"
+        }
+      },
+      {
+        "datasource": "CockroachDB",
+        "enable": false,
+        "iconColor": "blue",
+        "name": "Jobs",
+        "target": {
+          "editorMode": "code",
+          "format": "table",
+          "rawQuery": true,
+          "rawSql": "SELECT timestamp AS time, \"eventType\" AS title, info :: JSONB ->> 'Description' AS text, encode(\"uniqueID\", 'hex') AS id, 'job' AS tags FROM system.eventlog WHERE \"eventType\" LIKE ANY(${job_event_types:csv}) ORDER BY timestamp LIMIT 500;",
+          "refId": "Anno"
+        }
+      },
+      {
+        "datasource": "CockroachDB",
+        "enable": false,
+        "iconColor": "orange",
+        "name": "SQL Session Events",
+        "target": {
+          "editorMode": "code",
+          "format": "table",
+          "rawQuery": true,
+          "rawSql": "SELECT timestamp AS time, \"eventType\" AS title, concat('SQL client remote address: ', info :: JSONB ->> 'RemoteAddress') AS text, encode(\"uniqueID\", 'hex') AS id, 'SQL session event' AS tags FROM system.eventlog WHERE \"eventType\" LIKE ANY(${sql_session_event_types:csv}) ORDER BY timestamp LIMIT 500;",
+          "refId": "Anno"
+        }
+      },
+      {
+        "datasource": "CockroachDB",
+        "enable": false,
+        "iconColor": "red",
+        "name": "Zone Configurations",
+        "target": {
+          "editorMode": "code",
+          "format": "table",
+          "rawQuery": true,
+          "rawSql": "SELECT timestamp AS time, \"eventType\" AS title, info :: JSONB ->> 'Statement' AS text, encode(\"uniqueID\", 'hex') AS id, 'zone configurations' AS tags FROM system.eventlog WHERE \"eventType\" LIKE ANY(${zone_config_event_types:csv}) ORDER BY timestamp LIMIT 500;",
+          "refId": "Anno"
+        }
       }
     ]
   },
@@ -942,7 +1020,6 @@
         "name": "DS_PROMETHEUS",
         "options": [],
         "query": "prometheus",
-        "queryValue": "",
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,
@@ -1042,8 +1119,8 @@
           },
           {
             "selected": false,
-            "text": "15m",
-            "value": "15m"
+            "text": "10m",
+            "value": "10m"
           },
           {
             "selected": false,
@@ -1057,8 +1134,13 @@
           },
           {
             "selected": false,
-            "text": "2h",
-            "value": "2h"
+            "text": "6h",
+            "value": "6h"
+          },
+          {
+            "selected": false,
+            "text": "12h",
+            "value": "12h"
           },
           {
             "selected": false,
@@ -1066,10 +1148,130 @@
             "value": "1d"
           }
         ],
-        "query": "30s,1m,5m,15m,30m,1h,2h,1d",
+        "query": "30s,1m,5m,10m,30m,1h,6h,12h,1d",
         "refresh": 2,
         "skipUrlSync": false,
         "type": "interval"
+      },
+      {
+        "current": {
+          "selected": false,
+          "text": "'alter_database_add_region', 'alter_database_drop_region', 'alter_database_placement', 'alter_database_primary_region', 'alter_database_set_zone_config_extension', 'alter_database_survival_goal', 'alter_function_options', 'alter_index', 'alter_index_visible', 'alter_sequence', 'alter_table', 'alter_type', 'comment_on_column', 'comment_on_constraint', 'comment_on_database', 'comment_on_index', 'comment_on_schema', 'comment_on_table', 'convert_to_schema', 'create_database', 'create_function', 'create_index', 'create_schema', 'create_sequence', 'create_statistics', 'create_table', 'create_type', 'create_view', 'drop_database', 'drop_function', 'drop_index', 'drop_schema', 'drop_sequence', 'drop_table', 'drop_type', 'drop_view', 'finish_schema_change', 'finish_schema_change_rollback', 'force_delete_table_data_entry', 'rename_database', 'rename_function', 'rename_schema', 'rename_table', 'rename_type', 'reverse_schema_change', 'set_schema', 'truncate_table', 'unsafe_delete_descriptor', 'unsafe_delete_namespace_entry', 'unsafe_upsert_descriptor', 'unsafe_upsert_namespace_entry'",
+          "value": "'alter_database_add_region', 'alter_database_drop_region', 'alter_database_placement', 'alter_database_primary_region', 'alter_database_set_zone_config_extension', 'alter_database_survival_goal', 'alter_function_options', 'alter_index', 'alter_index_visible', 'alter_sequence', 'alter_table', 'alter_type', 'comment_on_column', 'comment_on_constraint', 'comment_on_database', 'comment_on_index', 'comment_on_schema', 'comment_on_table', 'convert_to_schema', 'create_database', 'create_function', 'create_index', 'create_schema', 'create_sequence', 'create_statistics', 'create_table', 'create_type', 'create_view', 'drop_database', 'drop_function', 'drop_index', 'drop_schema', 'drop_sequence', 'drop_table', 'drop_type', 'drop_view', 'finish_schema_change', 'finish_schema_change_rollback', 'force_delete_table_data_entry', 'rename_database', 'rename_function', 'rename_schema', 'rename_table', 'rename_type', 'reverse_schema_change', 'set_schema', 'truncate_table', 'unsafe_delete_descriptor', 'unsafe_delete_namespace_entry', 'unsafe_upsert_descriptor', 'unsafe_upsert_namespace_entry'"
+        },
+        "description": "The list of event types for DDL statements.",
+        "hide": 2,
+        "name": "ddl_event_types",
+        "options": [
+          {
+            "selected": true,
+            "text": "'alter_database_add_region', 'alter_database_drop_region', 'alter_database_placement', 'alter_database_primary_region', 'alter_database_set_zone_config_extension', 'alter_database_survival_goal', 'alter_function_options', 'alter_index', 'alter_index_visible', 'alter_sequence', 'alter_table', 'alter_type', 'comment_on_column', 'comment_on_constraint', 'comment_on_database', 'comment_on_index', 'comment_on_schema', 'comment_on_table', 'convert_to_schema', 'create_database', 'create_function', 'create_index', 'create_schema', 'create_sequence', 'create_statistics', 'create_table', 'create_type', 'create_view', 'drop_database', 'drop_function', 'drop_index', 'drop_schema', 'drop_sequence', 'drop_table', 'drop_type', 'drop_view', 'finish_schema_change', 'finish_schema_change_rollback', 'force_delete_table_data_entry', 'rename_database', 'rename_function', 'rename_schema', 'rename_table', 'rename_type', 'reverse_schema_change', 'set_schema', 'truncate_table', 'unsafe_delete_descriptor', 'unsafe_delete_namespace_entry', 'unsafe_upsert_descriptor', 'unsafe_upsert_namespace_entry'",
+            "value": "'alter_database_add_region', 'alter_database_drop_region', 'alter_database_placement', 'alter_database_primary_region', 'alter_database_set_zone_config_extension', 'alter_database_survival_goal', 'alter_function_options', 'alter_index', 'alter_index_visible', 'alter_sequence', 'alter_table', 'alter_type', 'comment_on_column', 'comment_on_constraint', 'comment_on_database', 'comment_on_index', 'comment_on_schema', 'comment_on_table', 'convert_to_schema', 'create_database', 'create_function', 'create_index', 'create_schema', 'create_sequence', 'create_statistics', 'create_table', 'create_type', 'create_view', 'drop_database', 'drop_function', 'drop_index', 'drop_schema', 'drop_sequence', 'drop_table', 'drop_type', 'drop_view', 'finish_schema_change', 'finish_schema_change_rollback', 'force_delete_table_data_entry', 'rename_database', 'rename_function', 'rename_schema', 'rename_table', 'rename_type', 'reverse_schema_change', 'set_schema', 'truncate_table', 'unsafe_delete_descriptor', 'unsafe_delete_namespace_entry', 'unsafe_upsert_descriptor', 'unsafe_upsert_namespace_entry'"
+          }
+        ],
+        "query": "'alter_database_add_region', 'alter_database_drop_region', 'alter_database_placement', 'alter_database_primary_region', 'alter_database_set_zone_config_extension', 'alter_database_survival_goal', 'alter_function_options', 'alter_index', 'alter_index_visible', 'alter_sequence', 'alter_table', 'alter_type', 'comment_on_column', 'comment_on_constraint', 'comment_on_database', 'comment_on_index', 'comment_on_schema', 'comment_on_table', 'convert_to_schema', 'create_database', 'create_function', 'create_index', 'create_schema', 'create_sequence', 'create_statistics', 'create_table', 'create_type', 'create_view', 'drop_database', 'drop_function', 'drop_index', 'drop_schema', 'drop_sequence', 'drop_table', 'drop_type', 'drop_view', 'finish_schema_change', 'finish_schema_change_rollback', 'force_delete_table_data_entry', 'rename_database', 'rename_function', 'rename_schema', 'rename_table', 'rename_type', 'reverse_schema_change', 'set_schema', 'truncate_table', 'unsafe_delete_descriptor', 'unsafe_delete_namespace_entry', 'unsafe_upsert_descriptor', 'unsafe_upsert_namespace_entry'",
+        "skipUrlSync": false,
+        "type": "textbox"
+      },
+      {
+        "current": {
+          "selected": false,
+          "text": "'set_cluster_setting', 'set_tenant_cluster_setting'",
+          "value": "'set_cluster_setting', 'set_tenant_cluster_setting'"
+        },
+        "description": "The list of event types for cluster settings.",
+        "hide": 2,
+        "name": "cluster_setting_event_types",
+        "options": [
+          {
+            "selected": true,
+            "text": "'set_cluster_setting', 'set_tenant_cluster_setting'",
+            "value": "'set_cluster_setting', 'set_tenant_cluster_setting'"
+          }
+        ],
+        "query": "'set_cluster_setting', 'set_tenant_cluster_setting'",
+        "skipUrlSync": false,
+        "type": "textbox"
+      },
+      {
+        "current": {
+          "selected": false,
+          "text": "'certs_reload',   'node_decommissioned',   'node_decommissioning',   'node_join',   'node_recommissioned',   'node_restart'",
+          "value": "'certs_reload',   'node_decommissioned',   'node_decommissioning',   'node_join',   'node_recommissioned',   'node_restart'"
+        },
+        "description": "The list of event types for cluster-wide events.",
+        "hide": 2,
+        "name": "cluster_wide_event_types",
+        "options": [
+          {
+            "selected": true,
+            "text": "'certs_reload',   'node_decommissioned',   'node_decommissioning',   'node_join',   'node_recommissioned',   'node_restart'",
+            "value": "'certs_reload',   'node_decommissioned',   'node_decommissioning',   'node_join',   'node_recommissioned',   'node_restart'"
+          }
+        ],
+        "query": "'certs_reload',   'node_decommissioned',   'node_decommissioning',   'node_join',   'node_recommissioned',   'node_restart'",
+        "skipUrlSync": false,
+        "type": "textbox"
+      },
+      {
+        "current": {
+          "selected": false,
+          "text": "'import', 'restore'",
+          "value": "'import', 'restore'"
+        },
+        "description": "The list of event types for jobs.",
+        "hide": 2,
+        "name": "job_event_types",
+        "options": [
+          {
+            "selected": true,
+            "text": "'import', 'restore'",
+            "value": "'import', 'restore'"
+          }
+        ],
+        "query": "'import', 'restore'",
+        "skipUrlSync": false,
+        "type": "textbox"
+      },
+      {
+        "current": {
+          "selected": false,
+          "text": "'client_authentication_failed',   'client_authentication_info',   'client_authentication_ok',   'client_connection_end',   'client_connection_start',   'client_session_end'",
+          "value": "'client_authentication_failed',   'client_authentication_info',   'client_authentication_ok',   'client_connection_end',   'client_connection_start',   'client_session_end'"
+        },
+        "description": "The list of event types for SQL session events.",
+        "hide": 2,
+        "name": "sql_session_event_types",
+        "options": [
+          {
+            "selected": true,
+            "text": "'client_authentication_failed',   'client_authentication_info',   'client_authentication_ok',   'client_connection_end',   'client_connection_start',   'client_session_end'",
+            "value": "'client_authentication_failed',   'client_authentication_info',   'client_authentication_ok',   'client_connection_end',   'client_connection_start',   'client_session_end'"
+          }
+        ],
+        "query": "'client_authentication_failed',   'client_authentication_info',   'client_authentication_ok',   'client_connection_end',   'client_connection_start',   'client_session_end'",
+        "skipUrlSync": false,
+        "type": "textbox"
+      },
+      {
+        "current": {
+          "selected": false,
+          "text": "'set_zone_config', 'remove_zone_config'",
+          "value": "'set_zone_config', 'remove_zone_config'"
+        },
+        "description": "The list of event types for zone configurations.",
+        "hide": 2,
+        "name": "zone_config_event_types",
+        "options": [
+          {
+            "selected": true,
+            "text": "'set_zone_config', 'remove_zone_config'",
+            "value": "'set_zone_config', 'remove_zone_config'"
+          }
+        ],
+        "query": "'set_zone_config', 'remove_zone_config'",
+        "skipUrlSync": false,
+        "type": "textbox"
       }
     ]
   },

--- a/monitoring/grafana-dashboards/runtime.json
+++ b/monitoring/grafana-dashboards/runtime.json
@@ -9,6 +9,84 @@
         "iconColor": "rgba(0, 211, 255, 1)",
         "name": "Annotations & Alerts",
         "type": "dashboard"
+      },
+      {
+        "datasource": "CockroachDB",
+        "enable": true,
+        "iconColor": "green",
+        "name": "Schema Changes",
+        "target": {
+          "editorMode": "code",
+          "format": "table",
+          "rawQuery": true,
+          "rawSql": "SELECT timestamp AS time, \"eventType\" AS title, info :: JSONB ->> 'Statement' AS text, encode(\"uniqueID\", 'hex') AS id, 'schema change' AS tags FROM system.eventlog WHERE \"eventType\" LIKE ANY(${ddl_event_types:csv}) ORDER BY timestamp LIMIT 500;",
+          "refId": "Anno"
+        }
+      },
+      {
+        "datasource": "CockroachDB",
+        "enable": true,
+        "iconColor": "yellow",
+        "name": "Cluster Settings",
+        "target": {
+          "editorMode": "code",
+          "format": "table",
+          "rawQuery": true,
+          "rawSql": "SELECT timestamp AS time, \"eventType\" AS title, info :: JSONB ->> 'Statement' AS text, encode(\"uniqueID\", 'hex') AS id, 'cluster setting' AS tags FROM system.eventlog WHERE \"eventType\" LIKE ANY(${cluster_setting_event_types:csv}) ORDER BY timestamp LIMIT 500;",
+          "refId": "Anno"
+        }
+      },
+      {
+        "datasource": "CockroachDB",
+        "enable": false,
+        "iconColor": "purple",
+        "name": "Cluster-wide Events",
+        "target": {
+          "editorMode": "code",
+          "format": "table",
+          "rawQuery": true,
+          "rawSql": "SELECT timestamp AS time, \"eventType\" AS title, concat('Reporting node ID: ', \"reportingID\"::STRING) AS text, encode(\"uniqueID\", 'hex') AS id, 'cluster-wide event' AS tags FROM system.eventlog WHERE \"eventType\" LIKE ANY(${cluster_wide_event_types:csv}) ORDER BY timestamp LIMIT 500;",
+          "refId": "Anno"
+        }
+      },
+      {
+        "datasource": "CockroachDB",
+        "enable": false,
+        "iconColor": "blue",
+        "name": "Jobs",
+        "target": {
+          "editorMode": "code",
+          "format": "table",
+          "rawQuery": true,
+          "rawSql": "SELECT timestamp AS time, \"eventType\" AS title, info :: JSONB ->> 'Description' AS text, encode(\"uniqueID\", 'hex') AS id, 'job' AS tags FROM system.eventlog WHERE \"eventType\" LIKE ANY(${job_event_types:csv}) ORDER BY timestamp LIMIT 500;",
+          "refId": "Anno"
+        }
+      },
+      {
+        "datasource": "CockroachDB",
+        "enable": false,
+        "iconColor": "orange",
+        "name": "SQL Session Events",
+        "target": {
+          "editorMode": "code",
+          "format": "table",
+          "rawQuery": true,
+          "rawSql": "SELECT timestamp AS time, \"eventType\" AS title, concat('SQL client remote address: ', info :: JSONB ->> 'RemoteAddress') AS text, encode(\"uniqueID\", 'hex') AS id, 'SQL session event' AS tags FROM system.eventlog WHERE \"eventType\" LIKE ANY(${sql_session_event_types:csv}) ORDER BY timestamp LIMIT 500;",
+          "refId": "Anno"
+        }
+      },
+      {
+        "datasource": "CockroachDB",
+        "enable": false,
+        "iconColor": "red",
+        "name": "Zone Configurations",
+        "target": {
+          "editorMode": "code",
+          "format": "table",
+          "rawQuery": true,
+          "rawSql": "SELECT timestamp AS time, \"eventType\" AS title, info :: JSONB ->> 'Statement' AS text, encode(\"uniqueID\", 'hex') AS id, 'zone configurations' AS tags FROM system.eventlog WHERE \"eventType\" LIKE ANY(${zone_config_event_types:csv}) ORDER BY timestamp LIMIT 500;",
+          "refId": "Anno"
+        }
       }
     ]
   },
@@ -988,10 +1066,129 @@
           }
         ],
         "query": "30s,1m,5m,10m,30m,1h,6h,12h,1d",
-        "queryValue": "",
         "refresh": 2,
         "skipUrlSync": false,
         "type": "interval"
+      },
+      {
+        "current": {
+          "selected": false,
+          "text": "'alter_database_add_region', 'alter_database_drop_region', 'alter_database_placement', 'alter_database_primary_region', 'alter_database_set_zone_config_extension', 'alter_database_survival_goal', 'alter_function_options', 'alter_index', 'alter_index_visible', 'alter_sequence', 'alter_table', 'alter_type', 'comment_on_column', 'comment_on_constraint', 'comment_on_database', 'comment_on_index', 'comment_on_schema', 'comment_on_table', 'convert_to_schema', 'create_database', 'create_function', 'create_index', 'create_schema', 'create_sequence', 'create_statistics', 'create_table', 'create_type', 'create_view', 'drop_database', 'drop_function', 'drop_index', 'drop_schema', 'drop_sequence', 'drop_table', 'drop_type', 'drop_view', 'finish_schema_change', 'finish_schema_change_rollback', 'force_delete_table_data_entry', 'rename_database', 'rename_function', 'rename_schema', 'rename_table', 'rename_type', 'reverse_schema_change', 'set_schema', 'truncate_table', 'unsafe_delete_descriptor', 'unsafe_delete_namespace_entry', 'unsafe_upsert_descriptor', 'unsafe_upsert_namespace_entry'",
+          "value": "'alter_database_add_region', 'alter_database_drop_region', 'alter_database_placement', 'alter_database_primary_region', 'alter_database_set_zone_config_extension', 'alter_database_survival_goal', 'alter_function_options', 'alter_index', 'alter_index_visible', 'alter_sequence', 'alter_table', 'alter_type', 'comment_on_column', 'comment_on_constraint', 'comment_on_database', 'comment_on_index', 'comment_on_schema', 'comment_on_table', 'convert_to_schema', 'create_database', 'create_function', 'create_index', 'create_schema', 'create_sequence', 'create_statistics', 'create_table', 'create_type', 'create_view', 'drop_database', 'drop_function', 'drop_index', 'drop_schema', 'drop_sequence', 'drop_table', 'drop_type', 'drop_view', 'finish_schema_change', 'finish_schema_change_rollback', 'force_delete_table_data_entry', 'rename_database', 'rename_function', 'rename_schema', 'rename_table', 'rename_type', 'reverse_schema_change', 'set_schema', 'truncate_table', 'unsafe_delete_descriptor', 'unsafe_delete_namespace_entry', 'unsafe_upsert_descriptor', 'unsafe_upsert_namespace_entry'"
+        },
+        "description": "The list of event types for DDL statements.",
+        "hide": 2,
+        "name": "ddl_event_types",
+        "options": [
+          {
+            "selected": true,
+            "text": "'alter_database_add_region', 'alter_database_drop_region', 'alter_database_placement', 'alter_database_primary_region', 'alter_database_set_zone_config_extension', 'alter_database_survival_goal', 'alter_function_options', 'alter_index', 'alter_index_visible', 'alter_sequence', 'alter_table', 'alter_type', 'comment_on_column', 'comment_on_constraint', 'comment_on_database', 'comment_on_index', 'comment_on_schema', 'comment_on_table', 'convert_to_schema', 'create_database', 'create_function', 'create_index', 'create_schema', 'create_sequence', 'create_statistics', 'create_table', 'create_type', 'create_view', 'drop_database', 'drop_function', 'drop_index', 'drop_schema', 'drop_sequence', 'drop_table', 'drop_type', 'drop_view', 'finish_schema_change', 'finish_schema_change_rollback', 'force_delete_table_data_entry', 'rename_database', 'rename_function', 'rename_schema', 'rename_table', 'rename_type', 'reverse_schema_change', 'set_schema', 'truncate_table', 'unsafe_delete_descriptor', 'unsafe_delete_namespace_entry', 'unsafe_upsert_descriptor', 'unsafe_upsert_namespace_entry'",
+            "value": "'alter_database_add_region', 'alter_database_drop_region', 'alter_database_placement', 'alter_database_primary_region', 'alter_database_set_zone_config_extension', 'alter_database_survival_goal', 'alter_function_options', 'alter_index', 'alter_index_visible', 'alter_sequence', 'alter_table', 'alter_type', 'comment_on_column', 'comment_on_constraint', 'comment_on_database', 'comment_on_index', 'comment_on_schema', 'comment_on_table', 'convert_to_schema', 'create_database', 'create_function', 'create_index', 'create_schema', 'create_sequence', 'create_statistics', 'create_table', 'create_type', 'create_view', 'drop_database', 'drop_function', 'drop_index', 'drop_schema', 'drop_sequence', 'drop_table', 'drop_type', 'drop_view', 'finish_schema_change', 'finish_schema_change_rollback', 'force_delete_table_data_entry', 'rename_database', 'rename_function', 'rename_schema', 'rename_table', 'rename_type', 'reverse_schema_change', 'set_schema', 'truncate_table', 'unsafe_delete_descriptor', 'unsafe_delete_namespace_entry', 'unsafe_upsert_descriptor', 'unsafe_upsert_namespace_entry'"
+          }
+        ],
+        "query": "'alter_database_add_region', 'alter_database_drop_region', 'alter_database_placement', 'alter_database_primary_region', 'alter_database_set_zone_config_extension', 'alter_database_survival_goal', 'alter_function_options', 'alter_index', 'alter_index_visible', 'alter_sequence', 'alter_table', 'alter_type', 'comment_on_column', 'comment_on_constraint', 'comment_on_database', 'comment_on_index', 'comment_on_schema', 'comment_on_table', 'convert_to_schema', 'create_database', 'create_function', 'create_index', 'create_schema', 'create_sequence', 'create_statistics', 'create_table', 'create_type', 'create_view', 'drop_database', 'drop_function', 'drop_index', 'drop_schema', 'drop_sequence', 'drop_table', 'drop_type', 'drop_view', 'finish_schema_change', 'finish_schema_change_rollback', 'force_delete_table_data_entry', 'rename_database', 'rename_function', 'rename_schema', 'rename_table', 'rename_type', 'reverse_schema_change', 'set_schema', 'truncate_table', 'unsafe_delete_descriptor', 'unsafe_delete_namespace_entry', 'unsafe_upsert_descriptor', 'unsafe_upsert_namespace_entry'",
+        "skipUrlSync": false,
+        "type": "textbox"
+      },
+      {
+        "current": {
+          "selected": false,
+          "text": "'set_cluster_setting', 'set_tenant_cluster_setting'",
+          "value": "'set_cluster_setting', 'set_tenant_cluster_setting'"
+        },
+        "description": "The list of event types for cluster settings.",
+        "hide": 2,
+        "name": "cluster_setting_event_types",
+        "options": [
+          {
+            "selected": true,
+            "text": "'set_cluster_setting', 'set_tenant_cluster_setting'",
+            "value": "'set_cluster_setting', 'set_tenant_cluster_setting'"
+          }
+        ],
+        "query": "'set_cluster_setting', 'set_tenant_cluster_setting'",
+        "skipUrlSync": false,
+        "type": "textbox"
+      },
+      {
+        "current": {
+          "selected": false,
+          "text": "'certs_reload',   'node_decommissioned',   'node_decommissioning',   'node_join',   'node_recommissioned',   'node_restart'",
+          "value": "'certs_reload',   'node_decommissioned',   'node_decommissioning',   'node_join',   'node_recommissioned',   'node_restart'"
+        },
+        "description": "The list of event types for cluster-wide events.",
+        "hide": 2,
+        "name": "cluster_wide_event_types",
+        "options": [
+          {
+            "selected": true,
+            "text": "'certs_reload',   'node_decommissioned',   'node_decommissioning',   'node_join',   'node_recommissioned',   'node_restart'",
+            "value": "'certs_reload',   'node_decommissioned',   'node_decommissioning',   'node_join',   'node_recommissioned',   'node_restart'"
+          }
+        ],
+        "query": "'certs_reload',   'node_decommissioned',   'node_decommissioning',   'node_join',   'node_recommissioned',   'node_restart'",
+        "skipUrlSync": false,
+        "type": "textbox"
+      },
+      {
+        "current": {
+          "selected": false,
+          "text": "'import', 'restore'",
+          "value": "'import', 'restore'"
+        },
+        "description": "The list of event types for jobs.",
+        "hide": 2,
+        "name": "job_event_types",
+        "options": [
+          {
+            "selected": true,
+            "text": "'import', 'restore'",
+            "value": "'import', 'restore'"
+          }
+        ],
+        "query": "'import', 'restore'",
+        "skipUrlSync": false,
+        "type": "textbox"
+      },
+      {
+        "current": {
+          "selected": false,
+          "text": "'client_authentication_failed',   'client_authentication_info',   'client_authentication_ok',   'client_connection_end',   'client_connection_start',   'client_session_end'",
+          "value": "'client_authentication_failed',   'client_authentication_info',   'client_authentication_ok',   'client_connection_end',   'client_connection_start',   'client_session_end'"
+        },
+        "description": "The list of event types for SQL session events.",
+        "hide": 2,
+        "name": "sql_session_event_types",
+        "options": [
+          {
+            "selected": true,
+            "text": "'client_authentication_failed',   'client_authentication_info',   'client_authentication_ok',   'client_connection_end',   'client_connection_start',   'client_session_end'",
+            "value": "'client_authentication_failed',   'client_authentication_info',   'client_authentication_ok',   'client_connection_end',   'client_connection_start',   'client_session_end'"
+          }
+        ],
+        "query": "'client_authentication_failed',   'client_authentication_info',   'client_authentication_ok',   'client_connection_end',   'client_connection_start',   'client_session_end'",
+        "skipUrlSync": false,
+        "type": "textbox"
+      },
+      {
+        "current": {
+          "selected": false,
+          "text": "'set_zone_config', 'remove_zone_config'",
+          "value": "'set_zone_config', 'remove_zone_config'"
+        },
+        "description": "The list of event types for zone configurations.",
+        "hide": 2,
+        "name": "zone_config_event_types",
+        "options": [
+          {
+            "selected": true,
+            "text": "'set_zone_config', 'remove_zone_config'",
+            "value": "'set_zone_config', 'remove_zone_config'"
+          }
+        ],
+        "query": "'set_zone_config', 'remove_zone_config'",
+        "skipUrlSync": false,
+        "type": "textbox"
       }
     ]
   },

--- a/monitoring/grafana-dashboards/slow_request.json
+++ b/monitoring/grafana-dashboards/slow_request.json
@@ -9,6 +9,84 @@
         "iconColor": "rgba(0, 211, 255, 1)",
         "name": "Annotations & Alerts",
         "type": "dashboard"
+      },
+      {
+        "datasource": "CockroachDB",
+        "enable": true,
+        "iconColor": "green",
+        "name": "Schema Changes",
+        "target": {
+          "editorMode": "code",
+          "format": "table",
+          "rawQuery": true,
+          "rawSql": "SELECT timestamp AS time, \"eventType\" AS title, info :: JSONB ->> 'Statement' AS text, encode(\"uniqueID\", 'hex') AS id, 'schema change' AS tags FROM system.eventlog WHERE \"eventType\" LIKE ANY(${ddl_event_types:csv}) ORDER BY timestamp LIMIT 500;",
+          "refId": "Anno"
+        }
+      },
+      {
+        "datasource": "CockroachDB",
+        "enable": true,
+        "iconColor": "yellow",
+        "name": "Cluster Settings",
+        "target": {
+          "editorMode": "code",
+          "format": "table",
+          "rawQuery": true,
+          "rawSql": "SELECT timestamp AS time, \"eventType\" AS title, info :: JSONB ->> 'Statement' AS text, encode(\"uniqueID\", 'hex') AS id, 'cluster setting' AS tags FROM system.eventlog WHERE \"eventType\" LIKE ANY(${cluster_setting_event_types:csv}) ORDER BY timestamp LIMIT 500;",
+          "refId": "Anno"
+        }
+      },
+      {
+        "datasource": "CockroachDB",
+        "enable": false,
+        "iconColor": "purple",
+        "name": "Cluster-wide Events",
+        "target": {
+          "editorMode": "code",
+          "format": "table",
+          "rawQuery": true,
+          "rawSql": "SELECT timestamp AS time, \"eventType\" AS title, concat('Reporting node ID: ', \"reportingID\"::STRING) AS text, encode(\"uniqueID\", 'hex') AS id, 'cluster-wide event' AS tags FROM system.eventlog WHERE \"eventType\" LIKE ANY(${cluster_wide_event_types:csv}) ORDER BY timestamp LIMIT 500;",
+          "refId": "Anno"
+        }
+      },
+      {
+        "datasource": "CockroachDB",
+        "enable": false,
+        "iconColor": "blue",
+        "name": "Jobs",
+        "target": {
+          "editorMode": "code",
+          "format": "table",
+          "rawQuery": true,
+          "rawSql": "SELECT timestamp AS time, \"eventType\" AS title, info :: JSONB ->> 'Description' AS text, encode(\"uniqueID\", 'hex') AS id, 'job' AS tags FROM system.eventlog WHERE \"eventType\" LIKE ANY(${job_event_types:csv}) ORDER BY timestamp LIMIT 500;",
+          "refId": "Anno"
+        }
+      },
+      {
+        "datasource": "CockroachDB",
+        "enable": false,
+        "iconColor": "orange",
+        "name": "SQL Session Events",
+        "target": {
+          "editorMode": "code",
+          "format": "table",
+          "rawQuery": true,
+          "rawSql": "SELECT timestamp AS time, \"eventType\" AS title, concat('SQL client remote address: ', info :: JSONB ->> 'RemoteAddress') AS text, encode(\"uniqueID\", 'hex') AS id, 'SQL session event' AS tags FROM system.eventlog WHERE \"eventType\" LIKE ANY(${sql_session_event_types:csv}) ORDER BY timestamp LIMIT 500;",
+          "refId": "Anno"
+        }
+      },
+      {
+        "datasource": "CockroachDB",
+        "enable": false,
+        "iconColor": "red",
+        "name": "Zone Configurations",
+        "target": {
+          "editorMode": "code",
+          "format": "table",
+          "rawQuery": true,
+          "rawSql": "SELECT timestamp AS time, \"eventType\" AS title, info :: JSONB ->> 'Statement' AS text, encode(\"uniqueID\", 'hex') AS id, 'zone configurations' AS tags FROM system.eventlog WHERE \"eventType\" LIKE ANY(${zone_config_event_types:csv}) ORDER BY timestamp LIMIT 500;",
+          "refId": "Anno"
+        }
       }
     ]
   },
@@ -442,7 +520,7 @@
         "error": null,
         "hide": 0,
         "includeAll": false,
-        "label": "cluster",
+        "label": "Cluster",
         "multi": false,
         "name": "cluster",
         "options": [],
@@ -461,7 +539,7 @@
         "useTags": false
       },
       {
-        "allValue": ".*",
+        "allValue": "",
         "current": {
           "selected": false,
           "text": "All",
@@ -484,7 +562,7 @@
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,
-        "sort": 3,
+        "sort": 1,
         "tagValuesQuery": "",
         "tags": [],
         "tagsQuery": "",
@@ -556,6 +634,126 @@
         "refresh": 2,
         "skipUrlSync": false,
         "type": "interval"
+      },
+      {
+        "current": {
+          "selected": false,
+          "text": "'alter_database_add_region', 'alter_database_drop_region', 'alter_database_placement', 'alter_database_primary_region', 'alter_database_set_zone_config_extension', 'alter_database_survival_goal', 'alter_function_options', 'alter_index', 'alter_index_visible', 'alter_sequence', 'alter_table', 'alter_type', 'comment_on_column', 'comment_on_constraint', 'comment_on_database', 'comment_on_index', 'comment_on_schema', 'comment_on_table', 'convert_to_schema', 'create_database', 'create_function', 'create_index', 'create_schema', 'create_sequence', 'create_statistics', 'create_table', 'create_type', 'create_view', 'drop_database', 'drop_function', 'drop_index', 'drop_schema', 'drop_sequence', 'drop_table', 'drop_type', 'drop_view', 'finish_schema_change', 'finish_schema_change_rollback', 'force_delete_table_data_entry', 'rename_database', 'rename_function', 'rename_schema', 'rename_table', 'rename_type', 'reverse_schema_change', 'set_schema', 'truncate_table', 'unsafe_delete_descriptor', 'unsafe_delete_namespace_entry', 'unsafe_upsert_descriptor', 'unsafe_upsert_namespace_entry'",
+          "value": "'alter_database_add_region', 'alter_database_drop_region', 'alter_database_placement', 'alter_database_primary_region', 'alter_database_set_zone_config_extension', 'alter_database_survival_goal', 'alter_function_options', 'alter_index', 'alter_index_visible', 'alter_sequence', 'alter_table', 'alter_type', 'comment_on_column', 'comment_on_constraint', 'comment_on_database', 'comment_on_index', 'comment_on_schema', 'comment_on_table', 'convert_to_schema', 'create_database', 'create_function', 'create_index', 'create_schema', 'create_sequence', 'create_statistics', 'create_table', 'create_type', 'create_view', 'drop_database', 'drop_function', 'drop_index', 'drop_schema', 'drop_sequence', 'drop_table', 'drop_type', 'drop_view', 'finish_schema_change', 'finish_schema_change_rollback', 'force_delete_table_data_entry', 'rename_database', 'rename_function', 'rename_schema', 'rename_table', 'rename_type', 'reverse_schema_change', 'set_schema', 'truncate_table', 'unsafe_delete_descriptor', 'unsafe_delete_namespace_entry', 'unsafe_upsert_descriptor', 'unsafe_upsert_namespace_entry'"
+        },
+        "description": "The list of event types for DDL statements.",
+        "hide": 2,
+        "name": "ddl_event_types",
+        "options": [
+          {
+            "selected": true,
+            "text": "'alter_database_add_region', 'alter_database_drop_region', 'alter_database_placement', 'alter_database_primary_region', 'alter_database_set_zone_config_extension', 'alter_database_survival_goal', 'alter_function_options', 'alter_index', 'alter_index_visible', 'alter_sequence', 'alter_table', 'alter_type', 'comment_on_column', 'comment_on_constraint', 'comment_on_database', 'comment_on_index', 'comment_on_schema', 'comment_on_table', 'convert_to_schema', 'create_database', 'create_function', 'create_index', 'create_schema', 'create_sequence', 'create_statistics', 'create_table', 'create_type', 'create_view', 'drop_database', 'drop_function', 'drop_index', 'drop_schema', 'drop_sequence', 'drop_table', 'drop_type', 'drop_view', 'finish_schema_change', 'finish_schema_change_rollback', 'force_delete_table_data_entry', 'rename_database', 'rename_function', 'rename_schema', 'rename_table', 'rename_type', 'reverse_schema_change', 'set_schema', 'truncate_table', 'unsafe_delete_descriptor', 'unsafe_delete_namespace_entry', 'unsafe_upsert_descriptor', 'unsafe_upsert_namespace_entry'",
+            "value": "'alter_database_add_region', 'alter_database_drop_region', 'alter_database_placement', 'alter_database_primary_region', 'alter_database_set_zone_config_extension', 'alter_database_survival_goal', 'alter_function_options', 'alter_index', 'alter_index_visible', 'alter_sequence', 'alter_table', 'alter_type', 'comment_on_column', 'comment_on_constraint', 'comment_on_database', 'comment_on_index', 'comment_on_schema', 'comment_on_table', 'convert_to_schema', 'create_database', 'create_function', 'create_index', 'create_schema', 'create_sequence', 'create_statistics', 'create_table', 'create_type', 'create_view', 'drop_database', 'drop_function', 'drop_index', 'drop_schema', 'drop_sequence', 'drop_table', 'drop_type', 'drop_view', 'finish_schema_change', 'finish_schema_change_rollback', 'force_delete_table_data_entry', 'rename_database', 'rename_function', 'rename_schema', 'rename_table', 'rename_type', 'reverse_schema_change', 'set_schema', 'truncate_table', 'unsafe_delete_descriptor', 'unsafe_delete_namespace_entry', 'unsafe_upsert_descriptor', 'unsafe_upsert_namespace_entry'"
+          }
+        ],
+        "query": "'alter_database_add_region', 'alter_database_drop_region', 'alter_database_placement', 'alter_database_primary_region', 'alter_database_set_zone_config_extension', 'alter_database_survival_goal', 'alter_function_options', 'alter_index', 'alter_index_visible', 'alter_sequence', 'alter_table', 'alter_type', 'comment_on_column', 'comment_on_constraint', 'comment_on_database', 'comment_on_index', 'comment_on_schema', 'comment_on_table', 'convert_to_schema', 'create_database', 'create_function', 'create_index', 'create_schema', 'create_sequence', 'create_statistics', 'create_table', 'create_type', 'create_view', 'drop_database', 'drop_function', 'drop_index', 'drop_schema', 'drop_sequence', 'drop_table', 'drop_type', 'drop_view', 'finish_schema_change', 'finish_schema_change_rollback', 'force_delete_table_data_entry', 'rename_database', 'rename_function', 'rename_schema', 'rename_table', 'rename_type', 'reverse_schema_change', 'set_schema', 'truncate_table', 'unsafe_delete_descriptor', 'unsafe_delete_namespace_entry', 'unsafe_upsert_descriptor', 'unsafe_upsert_namespace_entry'",
+        "skipUrlSync": false,
+        "type": "textbox"
+      },
+      {
+        "current": {
+          "selected": false,
+          "text": "'set_cluster_setting', 'set_tenant_cluster_setting'",
+          "value": "'set_cluster_setting', 'set_tenant_cluster_setting'"
+        },
+        "description": "The list of event types for cluster settings.",
+        "hide": 2,
+        "name": "cluster_setting_event_types",
+        "options": [
+          {
+            "selected": true,
+            "text": "'set_cluster_setting', 'set_tenant_cluster_setting'",
+            "value": "'set_cluster_setting', 'set_tenant_cluster_setting'"
+          }
+        ],
+        "query": "'set_cluster_setting', 'set_tenant_cluster_setting'",
+        "skipUrlSync": false,
+        "type": "textbox"
+      },
+      {
+        "current": {
+          "selected": false,
+          "text": "'certs_reload',   'node_decommissioned',   'node_decommissioning',   'node_join',   'node_recommissioned',   'node_restart'",
+          "value": "'certs_reload',   'node_decommissioned',   'node_decommissioning',   'node_join',   'node_recommissioned',   'node_restart'"
+        },
+        "description": "The list of event types for cluster-wide events.",
+        "hide": 2,
+        "name": "cluster_wide_event_types",
+        "options": [
+          {
+            "selected": true,
+            "text": "'certs_reload',   'node_decommissioned',   'node_decommissioning',   'node_join',   'node_recommissioned',   'node_restart'",
+            "value": "'certs_reload',   'node_decommissioned',   'node_decommissioning',   'node_join',   'node_recommissioned',   'node_restart'"
+          }
+        ],
+        "query": "'certs_reload',   'node_decommissioned',   'node_decommissioning',   'node_join',   'node_recommissioned',   'node_restart'",
+        "skipUrlSync": false,
+        "type": "textbox"
+      },
+      {
+        "current": {
+          "selected": false,
+          "text": "'import', 'restore'",
+          "value": "'import', 'restore'"
+        },
+        "description": "The list of event types for jobs.",
+        "hide": 2,
+        "name": "job_event_types",
+        "options": [
+          {
+            "selected": true,
+            "text": "'import', 'restore'",
+            "value": "'import', 'restore'"
+          }
+        ],
+        "query": "'import', 'restore'",
+        "skipUrlSync": false,
+        "type": "textbox"
+      },
+      {
+        "current": {
+          "selected": false,
+          "text": "'client_authentication_failed',   'client_authentication_info',   'client_authentication_ok',   'client_connection_end',   'client_connection_start',   'client_session_end'",
+          "value": "'client_authentication_failed',   'client_authentication_info',   'client_authentication_ok',   'client_connection_end',   'client_connection_start',   'client_session_end'"
+        },
+        "description": "The list of event types for SQL session events.",
+        "hide": 2,
+        "name": "sql_session_event_types",
+        "options": [
+          {
+            "selected": true,
+            "text": "'client_authentication_failed',   'client_authentication_info',   'client_authentication_ok',   'client_connection_end',   'client_connection_start',   'client_session_end'",
+            "value": "'client_authentication_failed',   'client_authentication_info',   'client_authentication_ok',   'client_connection_end',   'client_connection_start',   'client_session_end'"
+          }
+        ],
+        "query": "'client_authentication_failed',   'client_authentication_info',   'client_authentication_ok',   'client_connection_end',   'client_connection_start',   'client_session_end'",
+        "skipUrlSync": false,
+        "type": "textbox"
+      },
+      {
+        "current": {
+          "selected": false,
+          "text": "'set_zone_config', 'remove_zone_config'",
+          "value": "'set_zone_config', 'remove_zone_config'"
+        },
+        "description": "The list of event types for zone configurations.",
+        "hide": 2,
+        "name": "zone_config_event_types",
+        "options": [
+          {
+            "selected": true,
+            "text": "'set_zone_config', 'remove_zone_config'",
+            "value": "'set_zone_config', 'remove_zone_config'"
+          }
+        ],
+        "query": "'set_zone_config', 'remove_zone_config'",
+        "skipUrlSync": false,
+        "type": "textbox"
       }
     ]
   },

--- a/monitoring/grafana-dashboards/sql.json
+++ b/monitoring/grafana-dashboards/sql.json
@@ -9,6 +9,84 @@
         "iconColor": "rgba(0, 211, 255, 1)",
         "name": "Annotations & Alerts",
         "type": "dashboard"
+      },
+      {
+        "datasource": "CockroachDB",
+        "enable": true,
+        "iconColor": "green",
+        "name": "Schema Changes",
+        "target": {
+          "editorMode": "code",
+          "format": "table",
+          "rawQuery": true,
+          "rawSql": "SELECT timestamp AS time, \"eventType\" AS title, info :: JSONB ->> 'Statement' AS text, encode(\"uniqueID\", 'hex') AS id, 'schema change' AS tags FROM system.eventlog WHERE \"eventType\" LIKE ANY(${ddl_event_types:csv}) ORDER BY timestamp LIMIT 500;",
+          "refId": "Anno"
+        }
+      },
+      {
+        "datasource": "CockroachDB",
+        "enable": true,
+        "iconColor": "yellow",
+        "name": "Cluster Settings",
+        "target": {
+          "editorMode": "code",
+          "format": "table",
+          "rawQuery": true,
+          "rawSql": "SELECT timestamp AS time, \"eventType\" AS title, info :: JSONB ->> 'Statement' AS text, encode(\"uniqueID\", 'hex') AS id, 'cluster setting' AS tags FROM system.eventlog WHERE \"eventType\" LIKE ANY(${cluster_setting_event_types:csv}) ORDER BY timestamp LIMIT 500;",
+          "refId": "Anno"
+        }
+      },
+      {
+        "datasource": "CockroachDB",
+        "enable": false,
+        "iconColor": "purple",
+        "name": "Cluster-wide Events",
+        "target": {
+          "editorMode": "code",
+          "format": "table",
+          "rawQuery": true,
+          "rawSql": "SELECT timestamp AS time, \"eventType\" AS title, concat('Reporting node ID: ', \"reportingID\"::STRING) AS text, encode(\"uniqueID\", 'hex') AS id, 'cluster-wide event' AS tags FROM system.eventlog WHERE \"eventType\" LIKE ANY(${cluster_wide_event_types:csv}) ORDER BY timestamp LIMIT 500;",
+          "refId": "Anno"
+        }
+      },
+      {
+        "datasource": "CockroachDB",
+        "enable": false,
+        "iconColor": "blue",
+        "name": "Jobs",
+        "target": {
+          "editorMode": "code",
+          "format": "table",
+          "rawQuery": true,
+          "rawSql": "SELECT timestamp AS time, \"eventType\" AS title, info :: JSONB ->> 'Description' AS text, encode(\"uniqueID\", 'hex') AS id, 'job' AS tags FROM system.eventlog WHERE \"eventType\" LIKE ANY(${job_event_types:csv}) ORDER BY timestamp LIMIT 500;",
+          "refId": "Anno"
+        }
+      },
+      {
+        "datasource": "CockroachDB",
+        "enable": false,
+        "iconColor": "orange",
+        "name": "SQL Session Events",
+        "target": {
+          "editorMode": "code",
+          "format": "table",
+          "rawQuery": true,
+          "rawSql": "SELECT timestamp AS time, \"eventType\" AS title, concat('SQL client remote address: ', info :: JSONB ->> 'RemoteAddress') AS text, encode(\"uniqueID\", 'hex') AS id, 'SQL session event' AS tags FROM system.eventlog WHERE \"eventType\" LIKE ANY(${sql_session_event_types:csv}) ORDER BY timestamp LIMIT 500;",
+          "refId": "Anno"
+        }
+      },
+      {
+        "datasource": "CockroachDB",
+        "enable": false,
+        "iconColor": "red",
+        "name": "Zone Configurations",
+        "target": {
+          "editorMode": "code",
+          "format": "table",
+          "rawQuery": true,
+          "rawSql": "SELECT timestamp AS time, \"eventType\" AS title, info :: JSONB ->> 'Statement' AS text, encode(\"uniqueID\", 'hex') AS id, 'zone configurations' AS tags FROM system.eventlog WHERE \"eventType\" LIKE ANY(${zone_config_event_types:csv}) ORDER BY timestamp LIMIT 500;",
+          "refId": "Anno"
+        }
       }
     ]
   },
@@ -1906,7 +1984,7 @@
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,
-        "sort": 3,
+        "sort": 1,
         "tagValuesQuery": "",
         "tags": [],
         "tagsQuery": "",
@@ -1919,8 +1997,8 @@
         "auto_min": "10s",
         "current": {
           "selected": false,
-          "text": "1m",
-          "value": "1m"
+          "text": "30s",
+          "value": "30s"
         },
         "description": null,
         "error": null,
@@ -1929,12 +2007,12 @@
         "name": "rate_interval",
         "options": [
           {
-            "selected": false,
+            "selected": true,
             "text": "30s",
             "value": "30s"
           },
           {
-            "selected": true,
+            "selected": false,
             "text": "1m",
             "value": "1m"
           },
@@ -1975,10 +2053,129 @@
           }
         ],
         "query": "30s,1m,5m,10m,30m,1h,6h,12h,1d",
-        "queryValue": "",
         "refresh": 2,
         "skipUrlSync": false,
         "type": "interval"
+      },
+      {
+        "current": {
+          "selected": false,
+          "text": "'alter_database_add_region', 'alter_database_drop_region', 'alter_database_placement', 'alter_database_primary_region', 'alter_database_set_zone_config_extension', 'alter_database_survival_goal', 'alter_function_options', 'alter_index', 'alter_index_visible', 'alter_sequence', 'alter_table', 'alter_type', 'comment_on_column', 'comment_on_constraint', 'comment_on_database', 'comment_on_index', 'comment_on_schema', 'comment_on_table', 'convert_to_schema', 'create_database', 'create_function', 'create_index', 'create_schema', 'create_sequence', 'create_statistics', 'create_table', 'create_type', 'create_view', 'drop_database', 'drop_function', 'drop_index', 'drop_schema', 'drop_sequence', 'drop_table', 'drop_type', 'drop_view', 'finish_schema_change', 'finish_schema_change_rollback', 'force_delete_table_data_entry', 'rename_database', 'rename_function', 'rename_schema', 'rename_table', 'rename_type', 'reverse_schema_change', 'set_schema', 'truncate_table', 'unsafe_delete_descriptor', 'unsafe_delete_namespace_entry', 'unsafe_upsert_descriptor', 'unsafe_upsert_namespace_entry'",
+          "value": "'alter_database_add_region', 'alter_database_drop_region', 'alter_database_placement', 'alter_database_primary_region', 'alter_database_set_zone_config_extension', 'alter_database_survival_goal', 'alter_function_options', 'alter_index', 'alter_index_visible', 'alter_sequence', 'alter_table', 'alter_type', 'comment_on_column', 'comment_on_constraint', 'comment_on_database', 'comment_on_index', 'comment_on_schema', 'comment_on_table', 'convert_to_schema', 'create_database', 'create_function', 'create_index', 'create_schema', 'create_sequence', 'create_statistics', 'create_table', 'create_type', 'create_view', 'drop_database', 'drop_function', 'drop_index', 'drop_schema', 'drop_sequence', 'drop_table', 'drop_type', 'drop_view', 'finish_schema_change', 'finish_schema_change_rollback', 'force_delete_table_data_entry', 'rename_database', 'rename_function', 'rename_schema', 'rename_table', 'rename_type', 'reverse_schema_change', 'set_schema', 'truncate_table', 'unsafe_delete_descriptor', 'unsafe_delete_namespace_entry', 'unsafe_upsert_descriptor', 'unsafe_upsert_namespace_entry'"
+        },
+        "description": "The list of event types for DDL statements.",
+        "hide": 2,
+        "name": "ddl_event_types",
+        "options": [
+          {
+            "selected": true,
+            "text": "'alter_database_add_region', 'alter_database_drop_region', 'alter_database_placement', 'alter_database_primary_region', 'alter_database_set_zone_config_extension', 'alter_database_survival_goal', 'alter_function_options', 'alter_index', 'alter_index_visible', 'alter_sequence', 'alter_table', 'alter_type', 'comment_on_column', 'comment_on_constraint', 'comment_on_database', 'comment_on_index', 'comment_on_schema', 'comment_on_table', 'convert_to_schema', 'create_database', 'create_function', 'create_index', 'create_schema', 'create_sequence', 'create_statistics', 'create_table', 'create_type', 'create_view', 'drop_database', 'drop_function', 'drop_index', 'drop_schema', 'drop_sequence', 'drop_table', 'drop_type', 'drop_view', 'finish_schema_change', 'finish_schema_change_rollback', 'force_delete_table_data_entry', 'rename_database', 'rename_function', 'rename_schema', 'rename_table', 'rename_type', 'reverse_schema_change', 'set_schema', 'truncate_table', 'unsafe_delete_descriptor', 'unsafe_delete_namespace_entry', 'unsafe_upsert_descriptor', 'unsafe_upsert_namespace_entry'",
+            "value": "'alter_database_add_region', 'alter_database_drop_region', 'alter_database_placement', 'alter_database_primary_region', 'alter_database_set_zone_config_extension', 'alter_database_survival_goal', 'alter_function_options', 'alter_index', 'alter_index_visible', 'alter_sequence', 'alter_table', 'alter_type', 'comment_on_column', 'comment_on_constraint', 'comment_on_database', 'comment_on_index', 'comment_on_schema', 'comment_on_table', 'convert_to_schema', 'create_database', 'create_function', 'create_index', 'create_schema', 'create_sequence', 'create_statistics', 'create_table', 'create_type', 'create_view', 'drop_database', 'drop_function', 'drop_index', 'drop_schema', 'drop_sequence', 'drop_table', 'drop_type', 'drop_view', 'finish_schema_change', 'finish_schema_change_rollback', 'force_delete_table_data_entry', 'rename_database', 'rename_function', 'rename_schema', 'rename_table', 'rename_type', 'reverse_schema_change', 'set_schema', 'truncate_table', 'unsafe_delete_descriptor', 'unsafe_delete_namespace_entry', 'unsafe_upsert_descriptor', 'unsafe_upsert_namespace_entry'"
+          }
+        ],
+        "query": "'alter_database_add_region', 'alter_database_drop_region', 'alter_database_placement', 'alter_database_primary_region', 'alter_database_set_zone_config_extension', 'alter_database_survival_goal', 'alter_function_options', 'alter_index', 'alter_index_visible', 'alter_sequence', 'alter_table', 'alter_type', 'comment_on_column', 'comment_on_constraint', 'comment_on_database', 'comment_on_index', 'comment_on_schema', 'comment_on_table', 'convert_to_schema', 'create_database', 'create_function', 'create_index', 'create_schema', 'create_sequence', 'create_statistics', 'create_table', 'create_type', 'create_view', 'drop_database', 'drop_function', 'drop_index', 'drop_schema', 'drop_sequence', 'drop_table', 'drop_type', 'drop_view', 'finish_schema_change', 'finish_schema_change_rollback', 'force_delete_table_data_entry', 'rename_database', 'rename_function', 'rename_schema', 'rename_table', 'rename_type', 'reverse_schema_change', 'set_schema', 'truncate_table', 'unsafe_delete_descriptor', 'unsafe_delete_namespace_entry', 'unsafe_upsert_descriptor', 'unsafe_upsert_namespace_entry'",
+        "skipUrlSync": false,
+        "type": "textbox"
+      },
+      {
+        "current": {
+          "selected": false,
+          "text": "'set_cluster_setting', 'set_tenant_cluster_setting'",
+          "value": "'set_cluster_setting', 'set_tenant_cluster_setting'"
+        },
+        "description": "The list of event types for cluster settings.",
+        "hide": 2,
+        "name": "cluster_setting_event_types",
+        "options": [
+          {
+            "selected": true,
+            "text": "'set_cluster_setting', 'set_tenant_cluster_setting'",
+            "value": "'set_cluster_setting', 'set_tenant_cluster_setting'"
+          }
+        ],
+        "query": "'set_cluster_setting', 'set_tenant_cluster_setting'",
+        "skipUrlSync": false,
+        "type": "textbox"
+      },
+      {
+        "current": {
+          "selected": false,
+          "text": "'certs_reload',   'node_decommissioned',   'node_decommissioning',   'node_join',   'node_recommissioned',   'node_restart'",
+          "value": "'certs_reload',   'node_decommissioned',   'node_decommissioning',   'node_join',   'node_recommissioned',   'node_restart'"
+        },
+        "description": "The list of event types for cluster-wide events.",
+        "hide": 2,
+        "name": "cluster_wide_event_types",
+        "options": [
+          {
+            "selected": true,
+            "text": "'certs_reload',   'node_decommissioned',   'node_decommissioning',   'node_join',   'node_recommissioned',   'node_restart'",
+            "value": "'certs_reload',   'node_decommissioned',   'node_decommissioning',   'node_join',   'node_recommissioned',   'node_restart'"
+          }
+        ],
+        "query": "'certs_reload',   'node_decommissioned',   'node_decommissioning',   'node_join',   'node_recommissioned',   'node_restart'",
+        "skipUrlSync": false,
+        "type": "textbox"
+      },
+      {
+        "current": {
+          "selected": false,
+          "text": "'import', 'restore'",
+          "value": "'import', 'restore'"
+        },
+        "description": "The list of event types for jobs.",
+        "hide": 2,
+        "name": "job_event_types",
+        "options": [
+          {
+            "selected": true,
+            "text": "'import', 'restore'",
+            "value": "'import', 'restore'"
+          }
+        ],
+        "query": "'import', 'restore'",
+        "skipUrlSync": false,
+        "type": "textbox"
+      },
+      {
+        "current": {
+          "selected": false,
+          "text": "'client_authentication_failed',   'client_authentication_info',   'client_authentication_ok',   'client_connection_end',   'client_connection_start',   'client_session_end'",
+          "value": "'client_authentication_failed',   'client_authentication_info',   'client_authentication_ok',   'client_connection_end',   'client_connection_start',   'client_session_end'"
+        },
+        "description": "The list of event types for SQL session events.",
+        "hide": 2,
+        "name": "sql_session_event_types",
+        "options": [
+          {
+            "selected": true,
+            "text": "'client_authentication_failed',   'client_authentication_info',   'client_authentication_ok',   'client_connection_end',   'client_connection_start',   'client_session_end'",
+            "value": "'client_authentication_failed',   'client_authentication_info',   'client_authentication_ok',   'client_connection_end',   'client_connection_start',   'client_session_end'"
+          }
+        ],
+        "query": "'client_authentication_failed',   'client_authentication_info',   'client_authentication_ok',   'client_connection_end',   'client_connection_start',   'client_session_end'",
+        "skipUrlSync": false,
+        "type": "textbox"
+      },
+      {
+        "current": {
+          "selected": false,
+          "text": "'set_zone_config', 'remove_zone_config'",
+          "value": "'set_zone_config', 'remove_zone_config'"
+        },
+        "description": "The list of event types for zone configurations.",
+        "hide": 2,
+        "name": "zone_config_event_types",
+        "options": [
+          {
+            "selected": true,
+            "text": "'set_zone_config', 'remove_zone_config'",
+            "value": "'set_zone_config', 'remove_zone_config'"
+          }
+        ],
+        "query": "'set_zone_config', 'remove_zone_config'",
+        "skipUrlSync": false,
+        "type": "textbox"
       }
     ]
   },

--- a/monitoring/grafana-dashboards/storage.json
+++ b/monitoring/grafana-dashboards/storage.json
@@ -9,6 +9,84 @@
         "iconColor": "rgba(0, 211, 255, 1)",
         "name": "Annotations & Alerts",
         "type": "dashboard"
+      },
+      {
+        "datasource": "CockroachDB",
+        "enable": true,
+        "iconColor": "green",
+        "name": "Schema Changes",
+        "target": {
+          "editorMode": "code",
+          "format": "table",
+          "rawQuery": true,
+          "rawSql": "SELECT timestamp AS time, \"eventType\" AS title, info :: JSONB ->> 'Statement' AS text, encode(\"uniqueID\", 'hex') AS id, 'schema change' AS tags FROM system.eventlog WHERE \"eventType\" LIKE ANY(${ddl_event_types:csv}) ORDER BY timestamp LIMIT 500;",
+          "refId": "Anno"
+        }
+      },
+      {
+        "datasource": "CockroachDB",
+        "enable": true,
+        "iconColor": "yellow",
+        "name": "Cluster Settings",
+        "target": {
+          "editorMode": "code",
+          "format": "table",
+          "rawQuery": true,
+          "rawSql": "SELECT timestamp AS time, \"eventType\" AS title, info :: JSONB ->> 'Statement' AS text, encode(\"uniqueID\", 'hex') AS id, 'cluster setting' AS tags FROM system.eventlog WHERE \"eventType\" LIKE ANY(${cluster_setting_event_types:csv}) ORDER BY timestamp LIMIT 500;",
+          "refId": "Anno"
+        }
+      },
+      {
+        "datasource": "CockroachDB",
+        "enable": false,
+        "iconColor": "purple",
+        "name": "Cluster-wide Events",
+        "target": {
+          "editorMode": "code",
+          "format": "table",
+          "rawQuery": true,
+          "rawSql": "SELECT timestamp AS time, \"eventType\" AS title, concat('Reporting node ID: ', \"reportingID\"::STRING) AS text, encode(\"uniqueID\", 'hex') AS id, 'cluster-wide event' AS tags FROM system.eventlog WHERE \"eventType\" LIKE ANY(${cluster_wide_event_types:csv}) ORDER BY timestamp LIMIT 500;",
+          "refId": "Anno"
+        }
+      },
+      {
+        "datasource": "CockroachDB",
+        "enable": false,
+        "iconColor": "blue",
+        "name": "Jobs",
+        "target": {
+          "editorMode": "code",
+          "format": "table",
+          "rawQuery": true,
+          "rawSql": "SELECT timestamp AS time, \"eventType\" AS title, info :: JSONB ->> 'Description' AS text, encode(\"uniqueID\", 'hex') AS id, 'job' AS tags FROM system.eventlog WHERE \"eventType\" LIKE ANY(${job_event_types:csv}) ORDER BY timestamp LIMIT 500;",
+          "refId": "Anno"
+        }
+      },
+      {
+        "datasource": "CockroachDB",
+        "enable": false,
+        "iconColor": "orange",
+        "name": "SQL Session Events",
+        "target": {
+          "editorMode": "code",
+          "format": "table",
+          "rawQuery": true,
+          "rawSql": "SELECT timestamp AS time, \"eventType\" AS title, concat('SQL client remote address: ', info :: JSONB ->> 'RemoteAddress') AS text, encode(\"uniqueID\", 'hex') AS id, 'SQL session event' AS tags FROM system.eventlog WHERE \"eventType\" LIKE ANY(${sql_session_event_types:csv}) ORDER BY timestamp LIMIT 500;",
+          "refId": "Anno"
+        }
+      },
+      {
+        "datasource": "CockroachDB",
+        "enable": false,
+        "iconColor": "red",
+        "name": "Zone Configurations",
+        "target": {
+          "editorMode": "code",
+          "format": "table",
+          "rawQuery": true,
+          "rawSql": "SELECT timestamp AS time, \"eventType\" AS title, info :: JSONB ->> 'Statement' AS text, encode(\"uniqueID\", 'hex') AS id, 'zone configurations' AS tags FROM system.eventlog WHERE \"eventType\" LIKE ANY(${zone_config_event_types:csv}) ORDER BY timestamp LIMIT 500;",
+          "refId": "Anno"
+        }
       }
     ]
   },
@@ -1370,10 +1448,129 @@
           }
         ],
         "query": "30s,1m,5m,10m,30m,1h,6h,12h,1d",
-        "queryValue": "",
         "refresh": 2,
         "skipUrlSync": false,
         "type": "interval"
+      },
+      {
+        "current": {
+          "selected": false,
+          "text": "'alter_database_add_region', 'alter_database_drop_region', 'alter_database_placement', 'alter_database_primary_region', 'alter_database_set_zone_config_extension', 'alter_database_survival_goal', 'alter_function_options', 'alter_index', 'alter_index_visible', 'alter_sequence', 'alter_table', 'alter_type', 'comment_on_column', 'comment_on_constraint', 'comment_on_database', 'comment_on_index', 'comment_on_schema', 'comment_on_table', 'convert_to_schema', 'create_database', 'create_function', 'create_index', 'create_schema', 'create_sequence', 'create_statistics', 'create_table', 'create_type', 'create_view', 'drop_database', 'drop_function', 'drop_index', 'drop_schema', 'drop_sequence', 'drop_table', 'drop_type', 'drop_view', 'finish_schema_change', 'finish_schema_change_rollback', 'force_delete_table_data_entry', 'rename_database', 'rename_function', 'rename_schema', 'rename_table', 'rename_type', 'reverse_schema_change', 'set_schema', 'truncate_table', 'unsafe_delete_descriptor', 'unsafe_delete_namespace_entry', 'unsafe_upsert_descriptor', 'unsafe_upsert_namespace_entry'",
+          "value": "'alter_database_add_region', 'alter_database_drop_region', 'alter_database_placement', 'alter_database_primary_region', 'alter_database_set_zone_config_extension', 'alter_database_survival_goal', 'alter_function_options', 'alter_index', 'alter_index_visible', 'alter_sequence', 'alter_table', 'alter_type', 'comment_on_column', 'comment_on_constraint', 'comment_on_database', 'comment_on_index', 'comment_on_schema', 'comment_on_table', 'convert_to_schema', 'create_database', 'create_function', 'create_index', 'create_schema', 'create_sequence', 'create_statistics', 'create_table', 'create_type', 'create_view', 'drop_database', 'drop_function', 'drop_index', 'drop_schema', 'drop_sequence', 'drop_table', 'drop_type', 'drop_view', 'finish_schema_change', 'finish_schema_change_rollback', 'force_delete_table_data_entry', 'rename_database', 'rename_function', 'rename_schema', 'rename_table', 'rename_type', 'reverse_schema_change', 'set_schema', 'truncate_table', 'unsafe_delete_descriptor', 'unsafe_delete_namespace_entry', 'unsafe_upsert_descriptor', 'unsafe_upsert_namespace_entry'"
+        },
+        "description": "The list of event types for DDL statements.",
+        "hide": 2,
+        "name": "ddl_event_types",
+        "options": [
+          {
+            "selected": true,
+            "text": "'alter_database_add_region', 'alter_database_drop_region', 'alter_database_placement', 'alter_database_primary_region', 'alter_database_set_zone_config_extension', 'alter_database_survival_goal', 'alter_function_options', 'alter_index', 'alter_index_visible', 'alter_sequence', 'alter_table', 'alter_type', 'comment_on_column', 'comment_on_constraint', 'comment_on_database', 'comment_on_index', 'comment_on_schema', 'comment_on_table', 'convert_to_schema', 'create_database', 'create_function', 'create_index', 'create_schema', 'create_sequence', 'create_statistics', 'create_table', 'create_type', 'create_view', 'drop_database', 'drop_function', 'drop_index', 'drop_schema', 'drop_sequence', 'drop_table', 'drop_type', 'drop_view', 'finish_schema_change', 'finish_schema_change_rollback', 'force_delete_table_data_entry', 'rename_database', 'rename_function', 'rename_schema', 'rename_table', 'rename_type', 'reverse_schema_change', 'set_schema', 'truncate_table', 'unsafe_delete_descriptor', 'unsafe_delete_namespace_entry', 'unsafe_upsert_descriptor', 'unsafe_upsert_namespace_entry'",
+            "value": "'alter_database_add_region', 'alter_database_drop_region', 'alter_database_placement', 'alter_database_primary_region', 'alter_database_set_zone_config_extension', 'alter_database_survival_goal', 'alter_function_options', 'alter_index', 'alter_index_visible', 'alter_sequence', 'alter_table', 'alter_type', 'comment_on_column', 'comment_on_constraint', 'comment_on_database', 'comment_on_index', 'comment_on_schema', 'comment_on_table', 'convert_to_schema', 'create_database', 'create_function', 'create_index', 'create_schema', 'create_sequence', 'create_statistics', 'create_table', 'create_type', 'create_view', 'drop_database', 'drop_function', 'drop_index', 'drop_schema', 'drop_sequence', 'drop_table', 'drop_type', 'drop_view', 'finish_schema_change', 'finish_schema_change_rollback', 'force_delete_table_data_entry', 'rename_database', 'rename_function', 'rename_schema', 'rename_table', 'rename_type', 'reverse_schema_change', 'set_schema', 'truncate_table', 'unsafe_delete_descriptor', 'unsafe_delete_namespace_entry', 'unsafe_upsert_descriptor', 'unsafe_upsert_namespace_entry'"
+          }
+        ],
+        "query": "'alter_database_add_region', 'alter_database_drop_region', 'alter_database_placement', 'alter_database_primary_region', 'alter_database_set_zone_config_extension', 'alter_database_survival_goal', 'alter_function_options', 'alter_index', 'alter_index_visible', 'alter_sequence', 'alter_table', 'alter_type', 'comment_on_column', 'comment_on_constraint', 'comment_on_database', 'comment_on_index', 'comment_on_schema', 'comment_on_table', 'convert_to_schema', 'create_database', 'create_function', 'create_index', 'create_schema', 'create_sequence', 'create_statistics', 'create_table', 'create_type', 'create_view', 'drop_database', 'drop_function', 'drop_index', 'drop_schema', 'drop_sequence', 'drop_table', 'drop_type', 'drop_view', 'finish_schema_change', 'finish_schema_change_rollback', 'force_delete_table_data_entry', 'rename_database', 'rename_function', 'rename_schema', 'rename_table', 'rename_type', 'reverse_schema_change', 'set_schema', 'truncate_table', 'unsafe_delete_descriptor', 'unsafe_delete_namespace_entry', 'unsafe_upsert_descriptor', 'unsafe_upsert_namespace_entry'",
+        "skipUrlSync": false,
+        "type": "textbox"
+      },
+      {
+        "current": {
+          "selected": false,
+          "text": "'set_cluster_setting', 'set_tenant_cluster_setting'",
+          "value": "'set_cluster_setting', 'set_tenant_cluster_setting'"
+        },
+        "description": "The list of event types for cluster settings.",
+        "hide": 2,
+        "name": "cluster_setting_event_types",
+        "options": [
+          {
+            "selected": true,
+            "text": "'set_cluster_setting', 'set_tenant_cluster_setting'",
+            "value": "'set_cluster_setting', 'set_tenant_cluster_setting'"
+          }
+        ],
+        "query": "'set_cluster_setting', 'set_tenant_cluster_setting'",
+        "skipUrlSync": false,
+        "type": "textbox"
+      },
+      {
+        "current": {
+          "selected": false,
+          "text": "'certs_reload',   'node_decommissioned',   'node_decommissioning',   'node_join',   'node_recommissioned',   'node_restart'",
+          "value": "'certs_reload',   'node_decommissioned',   'node_decommissioning',   'node_join',   'node_recommissioned',   'node_restart'"
+        },
+        "description": "The list of event types for cluster-wide events.",
+        "hide": 2,
+        "name": "cluster_wide_event_types",
+        "options": [
+          {
+            "selected": true,
+            "text": "'certs_reload',   'node_decommissioned',   'node_decommissioning',   'node_join',   'node_recommissioned',   'node_restart'",
+            "value": "'certs_reload',   'node_decommissioned',   'node_decommissioning',   'node_join',   'node_recommissioned',   'node_restart'"
+          }
+        ],
+        "query": "'certs_reload',   'node_decommissioned',   'node_decommissioning',   'node_join',   'node_recommissioned',   'node_restart'",
+        "skipUrlSync": false,
+        "type": "textbox"
+      },
+      {
+        "current": {
+          "selected": false,
+          "text": "'import', 'restore'",
+          "value": "'import', 'restore'"
+        },
+        "description": "The list of event types for jobs.",
+        "hide": 2,
+        "name": "job_event_types",
+        "options": [
+          {
+            "selected": true,
+            "text": "'import', 'restore'",
+            "value": "'import', 'restore'"
+          }
+        ],
+        "query": "'import', 'restore'",
+        "skipUrlSync": false,
+        "type": "textbox"
+      },
+      {
+        "current": {
+          "selected": false,
+          "text": "'client_authentication_failed',   'client_authentication_info',   'client_authentication_ok',   'client_connection_end',   'client_connection_start',   'client_session_end'",
+          "value": "'client_authentication_failed',   'client_authentication_info',   'client_authentication_ok',   'client_connection_end',   'client_connection_start',   'client_session_end'"
+        },
+        "description": "The list of event types for SQL session events.",
+        "hide": 2,
+        "name": "sql_session_event_types",
+        "options": [
+          {
+            "selected": true,
+            "text": "'client_authentication_failed',   'client_authentication_info',   'client_authentication_ok',   'client_connection_end',   'client_connection_start',   'client_session_end'",
+            "value": "'client_authentication_failed',   'client_authentication_info',   'client_authentication_ok',   'client_connection_end',   'client_connection_start',   'client_session_end'"
+          }
+        ],
+        "query": "'client_authentication_failed',   'client_authentication_info',   'client_authentication_ok',   'client_connection_end',   'client_connection_start',   'client_session_end'",
+        "skipUrlSync": false,
+        "type": "textbox"
+      },
+      {
+        "current": {
+          "selected": false,
+          "text": "'set_zone_config', 'remove_zone_config'",
+          "value": "'set_zone_config', 'remove_zone_config'"
+        },
+        "description": "The list of event types for zone configurations.",
+        "hide": 2,
+        "name": "zone_config_event_types",
+        "options": [
+          {
+            "selected": true,
+            "text": "'set_zone_config', 'remove_zone_config'",
+            "value": "'set_zone_config', 'remove_zone_config'"
+          }
+        ],
+        "query": "'set_zone_config', 'remove_zone_config'",
+        "skipUrlSync": false,
+        "type": "textbox"
       }
     ]
   },


### PR DESCRIPTION
This commit introduces annotations to the demo Grafana dashboards. These annotations surface structured events, via queries to the system.eventlog table.

Loom: https://www.loom.com/share/a677e757592048d5ae7a6f9f0cf51f28

Epic: none