### PR TITLE
cli: correctly obtain GOMEMLIMIT env var value

### DIFF
--- a/pkg/cli/interactive_tests/test_flags.tcl
+++ b/pkg/cli/interactive_tests/test_flags.tcl
@@ -152,5 +152,15 @@ end_test
 
 stop_server $argv
 
+start_test "Check that set GOMEMLIMIT env var without specifying --max-go-memory works"
+send "export GOMEMLIMIT=1GiB;\r"
+eexpect ":/# "
+send "$argv start-single-node --insecure --store=path=logs/mystore\r"
+eexpect "node starting"
+interrupt
+eexpect ":/# "
+stop_server $argv
+end_test
+
 send "exit 0\r"
 eexpect eof


### PR DESCRIPTION
This commit fixes how the value of GOMEMLIMIT env var is obtained in case `--max-go-memory` is not specified. Previously, we were using `envutil.Env*` method which assumes that the env var is internal (i.e. has `COCKROACH_` prefix), so it would result in a panic on startup. Now we properly obtain the value as for external env var.

Fixes: #https://github.com/cockroachlabs/support/issues/2228.

Epic: None

Release note (bug fix): CockroachDB 23.1.0 alpha and beta versions previously would panic on `start` command when `GOMEMLIMIT` env var was set and `--max-go-memory` flag wasn't specified, and this is now fixed.