### PR TITLE
kvserver: fix rebalancing.(write|read)bytes desc

### DIFF
--- a/pkg/kv/kvserver/metrics.go
+++ b/pkg/kv/kvserver/metrics.go
@@ -357,13 +357,13 @@ var (
 	}
 	metaAverageWriteBytesPerSecond = metric.Metadata{
 		Name:        "rebalancing.writebytespersecond",
-		Help:        "Number of bytes read recently per second, considering the last 30 minutes.",
+		Help:        "Number of bytes written recently per second, considering the last 30 minutes.",
 		Measurement: "Bytes/Sec",
 		Unit:        metric.Unit_BYTES,
 	}
 	metaAverageReadBytesPerSecond = metric.Metadata{
 		Name:        "rebalancing.readbytespersecond",
-		Help:        "Number of bytes written per second, considering the last 30 minutes.",
+		Help:        "Number of bytes read recently per second, considering the last 30 minutes.",
 		Measurement: "Bytes/Sec",
 		Unit:        metric.Unit_BYTES,
 	}


### PR DESCRIPTION
The `rebalancing.readbytespersecond` and `rebalancing.writebytespersecond` metrics had incorrect descriptions which stated "written" for reads and "read" for writes.

This commit updates the metric descriptions to be correct.

Epic: none

Release note (bug fix): Fix the metric description of `rebalancing.readbytespersecond`, `rebalancing.writebytespersecond` to correctly reference bytes read and bytes written respectively.