### PR TITLE
ui: make tables fill the area instead of fit the content

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/databaseDetailsPage/databaseDetailsPage.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/databaseDetailsPage/databaseDetailsPage.module.scss
@@ -16,21 +16,24 @@
       font-family: $font-family--semi-bold;
     }
 
-    &-size {
-      width: 10em;
-    }
-
+    &-size,
     &-range-count,
     &-column-count,
     &-index-count,
     &-user-count {
-      width: 7em;
+      width: 8em;
+      text-align: right;
+      padding-right: $spacing-x-large;
     }
   }
 
   &__no-result {
     @include text--body-strong;
   }
+}
+
+.sorted-table {
+  width: 100%;
 }
 
 .icon {

--- a/pkg/ui/workspaces/cluster-ui/src/databaseDetailsPage/databaseDetailsPage.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/databaseDetailsPage/databaseDetailsPage.tsx
@@ -809,6 +809,7 @@ export class DatabaseDetailsPage extends React.Component<
             render={() => (
               <DatabaseSortedTable
                 className={cx("database-table")}
+                tableWrapperClassName={cx("sorted-table")}
                 data={tablesToDisplay}
                 columns={this.columns()}
                 sortSetting={sortSetting}

--- a/pkg/ui/workspaces/cluster-ui/src/databaseTablePage/databaseTablePage.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/databaseTablePage/databaseTablePage.module.scss
@@ -22,6 +22,10 @@
   }
 }
 
+.sorted-table {
+  width: 100%;
+}
+
 .tab-pane {
   margin-left: 1px;
 }

--- a/pkg/ui/workspaces/cluster-ui/src/databaseTablePage/databaseTablePage.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/databaseTablePage/databaseTablePage.tsx
@@ -700,6 +700,7 @@ export class DatabaseTablePage extends React.Component<
                     sortSetting={this.state.grantSortSetting}
                     onChangeSortSetting={this.changeGrantSortSetting.bind(this)}
                     loading={this.props.details.loading}
+                    tableWrapperClassName={cx("sorted-table")}
                   />
                 )}
                 renderError={() =>

--- a/pkg/ui/workspaces/cluster-ui/src/databasesPage/databasesPage.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/databasesPage/databasesPage.module.scss
@@ -16,19 +16,25 @@
       font-family: $font-family--semi-bold;
     }
 
-    &-size {
-      width: 10em;
-    }
-
+    &-size,
     &-table-count,
     &-range-count {
-      width: 7em;
+      width: 10em;
+      text-align: right;
+      padding-right: $spacing-x-large;
+    }
+    &-idx-rec {
+      width: 20em;
     }
   }
 
   &__no-result {
     @include text--body-strong;
   }
+}
+
+.sorted-table {
+  width: 100%;
 }
 
 .icon {

--- a/pkg/ui/workspaces/cluster-ui/src/databasesPage/databasesPage.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/databasesPage/databasesPage.tsx
@@ -574,14 +574,15 @@ export class DatabasesPage extends React.Component<
       title: (
         <Tooltip
           placement="bottom"
-          title="Index recommendations will appear if the system detects improper index usage, such as the occurrence of unused indexes. Following index recommendations may help improve query performance."
+          title="Index recommendations will appear if the system detects improper index usage, such as the
+          occurrence of unused indexes. Following index recommendations may help improve query performance."
         >
           Index Recommendations
         </Tooltip>
       ),
       cell: this.renderIndexRecommendations,
       sort: database => database.numIndexRecommendations,
-      className: cx("databases-table__col-node-regions"),
+      className: cx("databases-table__col-idx-rec"),
       name: "numIndexRecommendations",
     },
   ];
@@ -679,6 +680,7 @@ export class DatabasesPage extends React.Component<
             render={() => (
               <DatabasesSortedTable
                 className={cx("databases-table")}
+                tableWrapperClassName={cx("sorted-table")}
                 data={databasesToDisplay}
                 columns={displayColumns}
                 sortSetting={this.props.sortSetting}

--- a/pkg/ui/workspaces/cluster-ui/src/jobs/jobs.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/jobs/jobs.module.scss
@@ -104,8 +104,6 @@
   &__cell--description {
     overflow: hidden;
     text-overflow: ellipsis;
-    white-space: nowrap;
-    max-width: 500px;
     word-wrap: break-word;
   }
 
@@ -113,6 +111,10 @@
     display: inline-block;
     margin-right: 7px;
   }
+}
+
+.sorted-table {
+  width: 100%;
 }
 
 .job-details {

--- a/pkg/ui/workspaces/cluster-ui/src/jobs/jobsPage/jobsTable.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/jobs/jobsPage/jobsTable.tsx
@@ -272,6 +272,7 @@ export const JobsTable: React.FC<JobsTableProps> = props => {
       columns={props.visibleColumns}
       className={cx("jobs-table")}
       rowClass={job => cx("jobs-table__row--" + job.status)}
+      tableWrapperClassName={cx("sorted-table")}
       renderNoResult={
         <EmptyTable
           title="No jobs found."

--- a/pkg/ui/workspaces/cluster-ui/src/schedules/schedules.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/schedules/schedules.module.scss
@@ -121,6 +121,10 @@
   }
 }
 
+.sorted-table {
+  width: 100%;
+}
+
 .schedule-details {
   .summary--card__counting {
     margin-bottom: 15px;

--- a/pkg/ui/workspaces/cluster-ui/src/schedules/schedulesPage/scheduleTable.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/schedules/schedulesPage/scheduleTable.tsx
@@ -254,6 +254,7 @@ export class ScheduleTable extends React.Component<
           columns={schedulesTableColumns}
           renderNoResult={this.renderEmptyState()}
           pagination={pagination}
+          tableWrapperClassName={cx("sorted-table")}
         />
         <Pagination
           pageSize={pagination.pageSize}

--- a/pkg/ui/workspaces/db-console/src/views/reports/containers/statementDiagnosticsHistory/index.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/reports/containers/statementDiagnosticsHistory/index.tsx
@@ -247,6 +247,7 @@ class StatementDiagnosticsHistoryView extends React.Component<
         {this.renderTableTitle()}
         <StatementDiagnosticsHistoryTable
           className="statements-table"
+          tableWrapperClassName="sorted-table"
           data={dataSource}
           columns={this.columns}
           loading={loading}

--- a/pkg/ui/workspaces/db-console/src/views/reports/containers/statementDiagnosticsHistory/statementDiagnosticsHistoryView.styl
+++ b/pkg/ui/workspaces/db-console/src/views/reports/containers/statementDiagnosticsHistory/statementDiagnosticsHistoryView.styl
@@ -22,3 +22,7 @@
   &__table-header
     margin-top: $spacing-medium-small
     margin-bottom $spacing-x-small
+
+.sorted-table
+  width 100%
+


### PR DESCRIPTION
On all usages of tables, the width is fitting the content instead of filling the full area.
This commit changes so that all tables fit the full area of the page.

Fixes #71019

| Before | After|
|--|--|
| <img width="1557" alt="Screenshot 2023-04-13 at 7 15 32 PM" src="https://user-images.githubusercontent.com/1017486/231905693-73f67e75-7986-4874-8905-c5b4329a5558.png"> | <img width="1708" alt="Screenshot 2023-04-13 at 7 12 21 PM" src="https://user-images.githubusercontent.com/1017486/231905652-20db755a-f9d7-40e2-ab93-875622e6a5cb.png">|
| <img width="1709" alt="Screenshot 2023-04-13 at 7 17 50 PM" src="https://user-images.githubusercontent.com/1017486/231905896-69ca29bc-799a-40f2-9047-1798054cc110.png"> | <img width="1676" alt="Screenshot 2023-04-13 at 7 23 20 PM" src="https://user-images.githubusercontent.com/1017486/231905917-e0bb1408-9677-4b18-8477-21899b3ad58d.png"> |
| <img width="1688" alt="Screenshot 2023-04-13 at 7 23 58 PM" src="https://user-images.githubusercontent.com/1017486/231905968-5d19408a-fd40-41ab-bf70-d047503b6d7a.png"> | <img width="1664" alt="Screenshot 2023-04-13 at 7 23 32 PM" src="https://user-images.githubusercontent.com/1017486/231905987-34672591-09eb-4fdd-a790-c5203d8037c0.png"> |
| <img width="1691" alt="Screenshot 2023-04-13 at 7 24 29 PM" src="https://user-images.githubusercontent.com/1017486/231906168-594ae162-3e3c-4e95-84a1-4fa7eafc9837.png"> | <img width="1711" alt="Screenshot 2023-04-13 at 7 25 48 PM" src="https://user-images.githubusercontent.com/1017486/231906199-7e7844ad-c415-47f7-99e2-6841fcb9c08e.png">|
| <img width="1715" alt="Screenshot 2023-04-13 at 7 27 21 PM" src="https://user-images.githubusercontent.com/1017486/231906262-dcbfdc09-8709-4aaf-8ef2-9916bc4ddf09.png">| <img width="1704" alt="Screenshot 2023-04-13 at 7 31 53 PM" src="https://user-images.githubusercontent.com/1017486/231906285-1b3a9238-09bb-4d2c-a672-76113c6e909f.png"> |
| <img width="1724" alt="Screenshot 2023-04-13 at 7 33 20 PM" src="https://user-images.githubusercontent.com/1017486/231906317-bc5a90a2-efcc-4d28-ab38-9397cce0e2b6.png"> | <img width="1708" alt="Screenshot 2023-04-13 at 7 35 17 PM" src="https://user-images.githubusercontent.com/1017486/231906341-92c2d8e0-4089-4a08-a2a0-ff041643a972.png">|
| <img width="1711" alt="Screenshot 2023-04-13 at 7 35 49 PM" src="https://user-images.githubusercontent.com/1017486/231906367-d702ed51-f5d6-46bc-81fc-382c29fee515.png">| <img width="1702" alt="Screenshot 2023-04-13 at 7 37 32 PM" src="https://user-images.githubusercontent.com/1017486/231906399-e4e33c09-0ad1-4a2b-9a10-d0bc62f527d8.png">|


Release note: None