### PR TITLE
kvserver: avoid quote in range_str profiler tag

### DIFF
--- a/pkg/kv/kvserver/replica_send.go
+++ b/pkg/kv/kvserver/replica_send.go
@@ -127,7 +127,7 @@ func (r *Replica) SendWithWriteBytes(
 	if r.store.cfg.Settings.CPUProfileType() == cluster.CPUProfileWithLabels {
 		defer pprof.SetGoroutineLabels(ctx)
 		// Note: the defer statement captured the previous context.
-		ctx = pprof.WithLabels(ctx, pprof.Labels("range_str", r.rangeStr.String()))
+		ctx = pprof.WithLabels(ctx, pprof.Labels("range_str", r.rangeStr.ID()))
 		pprof.SetGoroutineLabels(ctx)
 	}
 	// Add the range log tag.


### PR DESCRIPTION
```
 range_str: Total 1.6s
            1.6s (  100%): 62/1
```

Touches https://github.com/cockroachdb/cockroach/issues/101523.

Epic: none
Release note: None
