### PR TITLE
roachprod-microbench: do not publish subdirectories

### DIFF
--- a/pkg/cmd/roachprod-microbench/storage.go
+++ b/pkg/cmd/roachprod-microbench/storage.go
@@ -102,6 +102,10 @@ func publishDirectory(localSrcDir, dstDir string) error {
 	errorsFound := false
 	wg.Add(len(files))
 	for index := range files {
+		if files[index].IsDir() {
+			wg.Done()
+			continue
+		}
 		go func(index int) {
 			defer wg.Done()
 			path := files[index]


### PR DESCRIPTION
This is a small fix to prevent the publish function from trying to publish subdirectories. It's only function should be to publish all logs in the directory it is pointed to.

Epic: None