### PR TITLE
kvserver: fix buglet in TestRebalanceObjectiveManager

### DIFF
--- a/pkg/kv/kvserver/rebalance_objective_test.go
+++ b/pkg/kv/kvserver/rebalance_objective_test.go
@@ -206,7 +206,7 @@ func TestRebalanceObjectiveManager(t *testing.T) {
 		// Changing the objective to CPU should not work since it isn't
 		// supported on this aarch.
 		LoadBasedRebalancingObjective.Override(ctx, &st.SV, int64(LBRebalancingCPU))
-		require.Equal(t, LBRebalancingCPU, manager.Objective())
+		require.Equal(t, LBRebalancingQueries, manager.Objective())
 		require.Len(t, *callbacks, 0)
 
 		return


### PR DESCRIPTION
The value was supposed to _not_ change. CI runs all
support `grunning`, so this just never got exercised,
but it does get run on my local M1 mac.

Epic: none
Release note: None
