### PR TITLE
kvserver: remove above-raft throttling of AddSST

### DIFF
--- a/pkg/kv/kvserver/batcheval/eval_context.go
+++ b/pkg/kv/kvserver/batcheval/eval_context.go
@@ -32,10 +32,8 @@ import (
 
 // Limiters is the collection of per-store limits used during cmd evaluation.
 type Limiters struct {
-	BulkIOWriteRate                      *rate.Limiter
-	ConcurrentExportRequests             limit.ConcurrentRequestLimiter
-	ConcurrentAddSSTableRequests         limit.ConcurrentRequestLimiter
-	ConcurrentAddSSTableAsWritesRequests limit.ConcurrentRequestLimiter
+	BulkIOWriteRate          *rate.Limiter
+	ConcurrentExportRequests limit.ConcurrentRequestLimiter
 	// concurrentRangefeedIters is a semaphore used to limit the number of
 	// rangefeeds in the "catch-up" state across the store. The "catch-up" state
 	// is a temporary state at the beginning of a rangefeed which is expensive

--- a/pkg/storage/engine_test.go
+++ b/pkg/storage/engine_test.go
@@ -25,7 +25,6 @@ import (
 	"strconv"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/concurrency/isolation"
@@ -1132,34 +1131,6 @@ func TestCreateCheckpoint_SpanConstrained(t *testing.T) {
 		span := roachpb.Span{Key: key(start), EndKey: key(end)}
 		dir := checkpointSpan(span)
 		verifyCheckpoint(dir, start, end)
-	}
-}
-
-func TestIngestDelayLimit(t *testing.T) {
-	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
-	s := cluster.MakeTestingClusterSettings()
-
-	max, ramp := time.Second*5, time.Second*5/10
-
-	for _, tc := range []struct {
-		exp           time.Duration
-		fileCount     int64
-		sublevelCount int32
-	}{
-		{0, 0, 0},
-		{0, 19, -1},
-		{0, 20, -1},
-		{ramp, 21, -1},
-		{ramp * 2, 22, -1},
-		{ramp * 2, 22, 22},
-		{ramp * 2, 55, 22},
-		{max, 55, -1},
-	} {
-		var m pebble.Metrics
-		m.Levels[0].NumFiles = tc.fileCount
-		m.Levels[0].Sublevels = tc.sublevelCount
-		require.Equal(t, tc.exp, calculatePreIngestDelay(s, &m))
 	}
 }
 

--- a/pkg/storage/pebble.go
+++ b/pkg/storage/pebble.go
@@ -1899,11 +1899,6 @@ func (p *Pebble) IngestExternalFilesWithStats(
 	return p.db.IngestWithStats(paths)
 }
 
-// PreIngestDelay implements the Engine interface.
-func (p *Pebble) PreIngestDelay(ctx context.Context) {
-	preIngestDelay(ctx, p, p.settings)
-}
-
 // ApproximateDiskBytes implements the Engine interface.
 func (p *Pebble) ApproximateDiskBytes(from, to roachpb.Key) (uint64, error) {
 	fromEncoded := EngineKey{Key: from}.Encode()


### PR DESCRIPTION
We now rely on admission control to protect the nodes.[^1]

[^1]: https://github.com/cockroachdb/cockroach/pull/98762#discussion_r1164701947

Epic: none
Release note (ops change): The following cluster settings were retired and no longer have any effect:
- kv.bulk_io_write.concurrent_addsstable_requests
- kv.bulk_io_write.concurrent_addsstable_as_writes_requests
- rocksdb.ingest_backpressure.l0_file_count_threshold
- rocksdb.ingest_backpressure.max_delay
