### PR TITLE
kvserver: deflake `TestReplicaRangefeedPushesTransactions`

### DIFF
--- a/pkg/kv/kvserver/replica_rangefeed_test.go
+++ b/pkg/kv/kvserver/replica_rangefeed_test.go
@@ -1209,7 +1209,7 @@ func TestReplicaRangefeedPushesTransactions(t *testing.T) {
 
 	// The txn should not be able to commit since its commit timestamp was pushed
 	// and it has observed its timestamp.
-	require.Regexp(t, "TransactionRetryError: retry txn", tx1.Commit())
+	require.Regexp(t, "TransactionRetryWithProtoRefreshError", tx1.Commit())
 
 	// Make sure the RangeFeed hasn't errored yet.
 	select {


### PR DESCRIPTION
This test usually expects this error:

```
pq: restart transaction: TransactionRetryWithProtoRefreshError: TransactionRetryError: retry txn (RETRY_SERIALIZABLE)
```

However, it could sometimes fail when it instead saw this error:

```
pq: restart transaction: TransactionRetryWithProtoRefreshError: TransactionAbortedError(ABORT_REASON_CLIENT_REJECT)
```

This patch changes it to assert on `TransactionRetryWithProtoRefreshError`.

Resolves #100569.

Epic: none
Release note: None