### PR TITLE
release-23.1: pkg/cmd/roachtest: add multi-region restore roachtest

### DIFF
--- a/pkg/cmd/roachtest/tests/restore.go
+++ b/pkg/cmd/roachtest/tests/restore.go
@@ -289,6 +289,15 @@ func registerRestore(r registry.Registry) {
 			timeout:  1 * time.Hour,
 		},
 		{
+			// Benchmarks if per node throughput remains constant if the cluster
+			// is multi-region.
+			hardware: makeHardwareSpecs(hardwareSpecs{
+				nodes: 9,
+				zones: []string{"us-east-2b", "us-west-2b", "eu-west-1b"}}), // These zones are AWS-specific.
+			backup:  makeBackupSpecs(backupSpecs{}),
+			timeout: 90 * time.Minute,
+		},
+		{
 			// Benchmarks if per node throughput doubles if the vcpu count doubles
 			// relative to default.
 			hardware: makeHardwareSpecs(hardwareSpecs{cpus: 16}),
@@ -397,6 +406,10 @@ type hardwareSpecs struct {
 
 	// mem is the memory per cpu.
 	mem spec.MemPerCPU
+
+	// Availability zones to use. (Values are cloud-provider-specific.)
+	// If unset, the first of the default availability zones for the provider will be used.
+	zones []string
 }
 
 func (hw hardwareSpecs) makeClusterSpecs(r registry.Registry, backupCloud string) spec.ClusterSpec {
@@ -407,6 +420,10 @@ func (hw hardwareSpecs) makeClusterSpecs(r registry.Registry, backupCloud string
 	}
 	if hw.mem != spec.Auto {
 		clusterOpts = append(clusterOpts, spec.Mem(hw.mem))
+	}
+	if len(hw.zones) > 0 {
+		clusterOpts = append(clusterOpts, spec.Zones(strings.Join(hw.zones, ",")))
+		clusterOpts = append(clusterOpts, spec.Geo())
 	}
 	s := r.MakeClusterSpec(hw.nodes, clusterOpts...)
 
@@ -428,6 +445,9 @@ func (hw hardwareSpecs) String(verbose bool) string {
 	builder.WriteString(fmt.Sprintf("/cpus=%d", hw.cpus))
 	if hw.mem != spec.Auto {
 		builder.WriteString(fmt.Sprintf("/%smem", hw.mem))
+	}
+	if len(hw.zones) > 0 {
+		builder.WriteString(fmt.Sprintf("/zones=%s", strings.Join(hw.zones, ",")))
 	}
 	if verbose {
 		builder.WriteString(fmt.Sprintf("/volSize=%dGB", hw.volumeSize))
@@ -451,6 +471,7 @@ func makeHardwareSpecs(override hardwareSpecs) hardwareSpecs {
 	if override.volumeSize != 0 {
 		specs.volumeSize = override.volumeSize
 	}
+	specs.zones = override.zones
 	return specs
 }
 


### PR DESCRIPTION
Backport 1/1 commits from #99072.

/cc @cockroachdb/release

---

New test name:
    `restore/tpce/400GB/aws/nodes=9/cpus=8/zones=us-east-2b,us-west-2b,eu-west-1b`

Note that this is set up with 9 nodes. That's a unique number, but seems reasonable for a three-region setup.
Initial run results:
    Usage 482244 , Nodes 9 , Duration 3312.659089;
    Throughput: 15.776651 mb / node / second

Fixes: #97785

Release note: None

Release justification: Test-only.
