### PR TITLE
kv/kvserver: remove timeseries Engine snapshot usage

### DIFF
--- a/pkg/kv/kvserver/ts_maintenance_queue.go
+++ b/pkg/kv/kvserver/ts_maintenance_queue.go
@@ -148,11 +148,10 @@ func (q *timeSeriesMaintenanceQueue) process(
 	ctx context.Context, repl *Replica, _ spanconfig.StoreReader,
 ) (processed bool, err error) {
 	desc := repl.Desc()
-	snap := repl.store.TODOEngine().NewSnapshot()
+	eng := repl.store.StateEngine()
 	now := repl.store.Clock().Now()
-	defer snap.Close()
 	if err := q.tsData.MaintainTimeSeries(
-		ctx, snap, desc.StartKey, desc.EndKey, q.db, q.mem, TimeSeriesMaintenanceMemoryBudget, now,
+		ctx, eng, desc.StartKey, desc.EndKey, q.db, q.mem, TimeSeriesMaintenanceMemoryBudget, now,
 	); err != nil {
 		return false, err
 	}

--- a/pkg/storage/engine.go
+++ b/pkg/storage/engine.go
@@ -917,11 +917,20 @@ type Engine interface {
 	// underlying Engine. The batch accumulates all mutations and applies them
 	// atomically on a call to Commit().
 	NewWriteBatch() WriteBatch
-	// NewSnapshot returns a new instance of a read-only snapshot
-	// engine. Snapshots are instantaneous and, as long as they're
-	// released relatively quickly, inexpensive. Snapshots are released
-	// by invoking Close(). Note that snapshots must not be used after the
-	// original engine has been stopped.
+	// NewSnapshot returns a new instance of a read-only snapshot engine. A
+	// snapshot provides a consistent view of the database across multiple
+	// iterators. If a caller only needs a single consistent iterator, they
+	// should create an iterator directly off the engine instead.
+	//
+	// Acquiring a snapshot is instantaneous and is inexpensive if quickly
+	// released. Snapshots are released by invoking Close(). Open snapshots
+	// prevent compactions from reclaiming space or removing tombstones for any
+	// keys written after the snapshot is acquired. This can be problematic
+	// during rebalancing or large ingestions, so they should be used sparingly
+	// and briefly.
+	//
+	// Note that snapshots must not be used after the original engine has been
+	// stopped.
 	NewSnapshot() Reader
 	// Type returns engine type.
 	Type() enginepb.EngineType

--- a/pkg/ts/maintenance.go
+++ b/pkg/ts/maintenance.go
@@ -34,27 +34,27 @@ func (tsdb *DB) ContainsTimeSeries(start, end roachpb.RKey) bool {
 // of data. This system was designed specifically to be used by scanner queue
 // from the storage package.
 //
-// The snapshot should be supplied by a local store, and is used only to
-// discover the names of time series which are store in that snapshot. The KV
+// The storage Reader should be supplied by a local store, and is used only to
+// discover the names of time series which are present in the engine. The KV
 // client is then used to interact with data from the time series that are
 // discovered; this may result in data being deleted, but may also write new
 // data in the form of rollups.
 //
-// The snapshot is used for key discovery (as opposed to the KV client) because
+// The reader is used for key discovery (as opposed to the KV client) because
 // the task of pruning time series is distributed across the cluster to the
 // individual ranges which contain that time series data. Because replicas of
 // those ranges are guaranteed to have time series data locally, we can use the
-// snapshot to quickly obtain a set of keys to be pruned with no network calls.
+// reader to quickly obtain a set of keys to be pruned with no network calls.
 func (tsdb *DB) MaintainTimeSeries(
 	ctx context.Context,
-	snapshot storage.Reader,
+	reader storage.Reader,
 	start, end roachpb.RKey,
 	db *kv.DB,
 	mem *mon.BytesMonitor,
 	budgetBytes int64,
 	now hlc.Timestamp,
 ) error {
-	series, err := tsdb.findTimeSeries(snapshot, start, end, now)
+	series, err := tsdb.findTimeSeries(reader, start, end, now)
 	if err != nil {
 		return err
 	}

--- a/pkg/ts/pruning.go
+++ b/pkg/ts/pruning.go
@@ -37,11 +37,11 @@ type timeSeriesResolutionInfo struct {
 // pair will only be identified once, even if the range contains keys for that
 // name/resolution pair at multiple timestamps or from multiple sources.
 //
-// An engine snapshot is used, rather than a client, because this function is
+// A local engine is used, rather than a client, because this function is
 // intended to be called by a storage queue which can inspect the local data for
 // a single range without the need for expensive network calls.
 func (tsdb *DB) findTimeSeries(
-	snapshot storage.Reader, startKey, endKey roachpb.RKey, now hlc.Timestamp,
+	reader storage.Reader, startKey, endKey roachpb.RKey, now hlc.Timestamp,
 ) ([]timeSeriesResolutionInfo, error) {
 	var results []timeSeriesResolutionInfo
 
@@ -64,7 +64,7 @@ func (tsdb *DB) findTimeSeries(
 	thresholds := tsdb.computeThresholds(now.WallTime)
 
 	// NB: timeseries don't have intents.
-	iter := snapshot.NewMVCCIterator(storage.MVCCKeyIterKind, storage.IterOptions{UpperBound: endKey.AsRawKey()})
+	iter := reader.NewMVCCIterator(storage.MVCCKeyIterKind, storage.IterOptions{UpperBound: endKey.AsRawKey()})
 	defer iter.Close()
 
 	for iter.SeekGE(next); ; iter.SeekGE(next) {


### PR DESCRIPTION
Previously, the timeseries maintenance queue acquired an Engine snapshot from which it read a list of the active timeseries metrics within a store. This use of an Engine snapshot was unnecessary. The queue only ever created a single iterator over the acquired snapshot.

Epic: none
Release note: none