### PR TITLE
release-22.1: sql/importer: wait for any pending ingestion to complete before rolling back

### DIFF
--- a/pkg/jobs/BUILD.bazel
+++ b/pkg/jobs/BUILD.bazel
@@ -39,6 +39,7 @@ go_library(
         "//pkg/settings",
         "//pkg/settings/cluster",
         "//pkg/sql/catalog",
+        "//pkg/sql/catalog/catpb",
         "//pkg/sql/catalog/colinfo",
         "//pkg/sql/catalog/descpb",
         "//pkg/sql/catalog/descs",

--- a/pkg/jobs/ingeststopped/BUILD.bazel
+++ b/pkg/jobs/ingeststopped/BUILD.bazel
@@ -1,0 +1,33 @@
+load("//build/bazelutil/unused_checker:unused.bzl", "get_x_data")
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "ingeststopped",
+    srcs = [
+        "ingesting_check_processor.go",
+        "ingesting_checker.go",
+    ],
+    importpath = "github.com/cockroachdb/cockroach/pkg/jobs/ingeststopped",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/jobs",
+        "//pkg/jobs/jobspb",
+        "//pkg/kv",
+        "//pkg/sql",
+        "//pkg/sql/catalog/catpb",
+        "//pkg/sql/execinfra",
+        "//pkg/sql/execinfrapb",
+        "//pkg/sql/physicalplan",
+        "//pkg/sql/rowenc",
+        "//pkg/sql/rowexec",
+        "//pkg/sql/sem/tree",
+        "//pkg/sql/types",
+        "//pkg/util/log",
+        "//pkg/util/retry",
+        "//pkg/util/timeutil",
+        "//pkg/util/tracing",
+        "@com_github_cockroachdb_errors//:errors",
+    ],
+)
+
+get_x_data(name = "get_x_data")

--- a/pkg/jobs/ingeststopped/ingesting_check_processor.go
+++ b/pkg/jobs/ingeststopped/ingesting_check_processor.go
@@ -1,0 +1,60 @@
+// Copyright 2023 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package ingeststopped
+
+import (
+	"context"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
+	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
+	"github.com/cockroachdb/cockroach/pkg/sql/rowenc"
+	"github.com/cockroachdb/cockroach/pkg/sql/rowexec"
+	"github.com/cockroachdb/errors"
+)
+
+type proc struct {
+	execinfra.ProcessorBase
+	spec execinfrapb.IngestStoppedSpec
+}
+
+func newIngestStoppedProcessor(
+	ctx context.Context,
+	flowCtx *execinfra.FlowCtx,
+	processorID int32,
+	spec execinfrapb.IngestStoppedSpec,
+	post *execinfrapb.PostProcessSpec,
+	output execinfra.RowReceiver,
+) (execinfra.Processor, error) {
+	p := &proc{spec: spec}
+	if err := p.Init(p, post, nil, flowCtx, processorID, output, nil /* memMonitor */, execinfra.ProcStateOpts{}); err != nil {
+		return nil, err
+	}
+	return p, nil
+}
+
+// Start is part of the RowSource interface.
+func (p *proc) Start(ctx context.Context) {
+	p.StartInternal(ctx, "ingeststopped.proc")
+	if p.FlowCtx.Cfg.JobRegistry.IsIngesting(p.spec.JobID) {
+		p.MoveToDraining(errors.Errorf("jobs is still ingesting on node %d", p.FlowCtx.NodeID.SQLInstanceID()))
+	} else {
+		p.MoveToDraining(nil)
+	}
+}
+
+// Next is part of the RowSource interface.
+func (p *proc) Next() (rowenc.EncDatumRow, *execinfrapb.ProducerMetadata) {
+	return nil, p.DrainHelper()
+}
+
+func init() {
+	rowexec.NewIngestStoppedProcessor = newIngestStoppedProcessor
+}

--- a/pkg/jobs/ingeststopped/ingesting_checker.go
+++ b/pkg/jobs/ingeststopped/ingesting_checker.go
@@ -1,0 +1,123 @@
+// Copyright 2023 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package ingeststopped
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/jobs"
+	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
+	"github.com/cockroachdb/cockroach/pkg/kv"
+	"github.com/cockroachdb/cockroach/pkg/sql"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
+	"github.com/cockroachdb/cockroach/pkg/sql/physicalplan"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/types"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/retry"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+	"github.com/cockroachdb/cockroach/pkg/util/tracing"
+)
+
+// WaitForNoIngestingNodes contacts all nodes in the cluster and verifies that
+// they are not ingesting data for the given job ID, and continues to try to do
+// so for the specified duration until it succeeds or times out.
+func WaitForNoIngestingNodes(
+	ctx context.Context, execCtx sql.JobExecContext, job *jobs.Job, maxWait time.Duration,
+) error {
+	ctx, sp := tracing.ChildSpan(ctx, "WaitForNoIngestingNodes")
+	defer sp.Finish()
+
+	retries := retry.StartWithCtx(ctx, retry.Options{
+		InitialBackoff: time.Second,
+		MaxBackoff:     time.Second * 10,
+	})
+
+	started := timeutil.Now()
+
+	var lastStatusUpdate time.Time
+	const statusUpdateFrequency = time.Second * 30
+
+	for retries.Next() {
+		err := checkAllNodesForIngestingJob(ctx, execCtx, job.ID())
+		if err == nil {
+			break
+		}
+		log.Infof(ctx, "failed to verify job no longer importing on all nodes: %+v", err)
+
+		if timeutil.Since(started) > maxWait {
+			return err
+		}
+
+		if timeutil.Since(lastStatusUpdate) > statusUpdateFrequency {
+			if statusErr := execCtx.ExecCfg().DB.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
+				return job.RunningStatus(ctx, txn, func(_ context.Context, _ jobspb.Details) (jobs.RunningStatus, error) {
+					return jobs.RunningStatus(fmt.Sprintf("waiting for all nodes to finish ingesting writing before proceeding: %s", err)), nil
+				})
+			}); statusErr != nil {
+				log.Warningf(ctx, "failed to update running status of job %d: %s", job.ID(), statusErr)
+			} else {
+				lastStatusUpdate = timeutil.Now()
+			}
+		}
+	}
+	return nil
+}
+
+func checkAllNodesForIngestingJob(
+	ctx context.Context, execCtx sql.JobExecContext, jobID catpb.JobID,
+) error {
+	dsp := execCtx.DistSQLPlanner()
+	evalCtx := execCtx.ExtendedEvalContext()
+
+	// TODO(dt): We should record which nodes were assigned ingestion processors
+	// and then ensure we're reaching out to them specifically here, in particular
+	// in the event a node that was importing is no longer in liveness but might
+	// still be off ingesting.
+	planCtx, sqlInstanceIDs, err := dsp.SetupAllNodesPlanning(ctx, evalCtx, execCtx.ExecCfg())
+	if err != nil {
+		return err
+	}
+
+	p := planCtx.NewPhysicalPlan()
+	corePlacement := make([]physicalplan.ProcessorCorePlacement, len(sqlInstanceIDs))
+	for i := range sqlInstanceIDs {
+		corePlacement[i].SQLInstanceID = sqlInstanceIDs[i]
+		corePlacement[i].Core.IngestStopped = &execinfrapb.IngestStoppedSpec{JobID: jobID}
+	}
+
+	p.AddNoInputStage(
+		corePlacement, execinfrapb.PostProcessSpec{}, []*types.T{}, execinfrapb.Ordering{},
+	)
+	sql.FinalizePlan(planCtx, p)
+
+	res := sql.NewMetadataOnlyMetadataCallbackWriter()
+
+	recv := sql.MakeDistSQLReceiver(
+		ctx,
+		res,
+		tree.Ack,
+		nil, /* rangeCache */
+		nil, /* txn - the flow does not read or write the database */
+		nil, /* clockUpdater */
+		evalCtx.Tracing,
+		nil,
+		nil,
+	)
+	defer recv.Release()
+
+	evalCtxCopy := *evalCtx
+	dsp.Run(ctx, planCtx, nil, p, recv, &evalCtxCopy, nil /* finishedSetupFn */)()
+	return res.Err()
+}

--- a/pkg/sql/execinfrapb/flow_diagram.go
+++ b/pkg/sql/execinfrapb/flow_diagram.go
@@ -605,6 +605,12 @@ func (s *ChangeFrontierSpec) summary() (string, []string) {
 	return "ChangeFrontier", []string{}
 }
 
+// summary implements the diagramCellType interface.
+func (i *IngestStoppedSpec) summary() (string, []string) {
+	detail := fmt.Sprintf("job %d ingest stopped spans", i.JobID)
+	return "IngestStoppedSpec", []string{detail}
+}
+
 type diagramCell struct {
 	Title   string   `json:"title"`
 	Details []string `json:"details"`

--- a/pkg/sql/execinfrapb/processors.proto
+++ b/pkg/sql/execinfrapb/processors.proto
@@ -125,8 +125,10 @@ message ProcessorCoreUnion {
   optional StreamIngestionFrontierSpec streamIngestionFrontier = 36;
   optional ExportSpec exporter = 37;
   optional IndexBackfillMergerSpec indexBackfillMerger = 38;
+  optional IngestStoppedSpec ingestStopped = 44;
 
   reserved 6, 12;
+  // NEXT ID: 45.
 }
 
 // NoopCoreSpec indicates a "no-op" processor core. This is used when we just

--- a/pkg/sql/execinfrapb/processors_bulk_io.proto
+++ b/pkg/sql/execinfrapb/processors_bulk_io.proto
@@ -177,6 +177,11 @@ message ReadImportDataSpec {
   // NEXTID: 20.
 }
 
+message IngestStoppedSpec {
+  optional int64 job_id = 1 [(gogoproto.nullable) = false, (gogoproto.customname) = "JobID",
+  (gogoproto.casttype) = "github.com/cockroachdb/cockroach/pkg/jobs/jobspb.JobID"];
+}
+
 message StreamIngestionDataSpec {
   reserved 1;
 

--- a/pkg/sql/importer/BUILD.bazel
+++ b/pkg/sql/importer/BUILD.bazel
@@ -37,6 +37,7 @@ go_library(
         "//pkg/geo",
         "//pkg/geo/geopb",
         "//pkg/jobs",
+        "//pkg/jobs/ingeststopped",
         "//pkg/jobs/joberror",
         "//pkg/jobs/jobspb",
         "//pkg/keys",

--- a/pkg/sql/importer/import_job.go
+++ b/pkg/sql/importer/import_job.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/jobs"
+	"github.com/cockroachdb/cockroach/pkg/jobs/ingeststopped"
 	"github.com/cockroachdb/cockroach/pkg/jobs/joberror"
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
 	"github.com/cockroachdb/cockroach/pkg/keys"
@@ -1407,6 +1408,20 @@ func (r *importResumer) OnFailOrCancel(ctx context.Context, execCtx interface{},
 
 	details := r.job.Details().(jobspb.ImportDetails)
 	addToFileFormatTelemetry(details.Format.Format.String(), "failed")
+
+	// If the import completed preparation and started writing, verify it has
+	// stopped writing before proceeding to revert it.
+	if details.PrepareComplete {
+		log.Infof(ctx, "need to verify that no nodes are still importing since job had started writing...")
+		const maxWait = time.Minute * 5
+		if err := ingeststopped.WaitForNoIngestingNodes(ctx, p, r.job, maxWait); err != nil {
+			log.Errorf(ctx, "unable to verify that attempted IMPORT job %d had stopped writing before reverting after %s: %v", r.job.ID(), maxWait, err)
+		} else {
+			log.Infof(ctx, "verified no nodes still ingesting on behalf of job %d", r.job.ID())
+		}
+
+	}
+
 	cfg := execCtx.(sql.JobExecContext).ExecCfg()
 	var jobsToRunAfterTxnCommit []jobspb.JobID
 	if err := sql.DescsTxn(ctx, cfg, func(

--- a/pkg/sql/importer/import_processor.go
+++ b/pkg/sql/importer/import_processor.go
@@ -346,6 +346,8 @@ func ingestKvs(
 	ctx, span := tracing.ChildSpan(ctx, "import-ingest-kvs")
 	defer span.Finish()
 
+	defer flowCtx.Cfg.JobRegistry.MarkAsIngesting(spec.Progress.JobID)()
+
 	writeTS := hlc.Timestamp{WallTime: spec.WalltimeNanos}
 	writeAtBatchTimestamp := true
 	if !importAtNow.Get(&flowCtx.Cfg.Settings.SV) {

--- a/pkg/sql/importer/import_processor_test.go
+++ b/pkg/sql/importer/import_processor_test.go
@@ -231,6 +231,7 @@ func TestImportIgnoresProcessedFiles(t *testing.T) {
 	flowCtx := &execinfra.FlowCtx{
 		EvalCtx: &evalCtx,
 		Cfg: &execinfra.ServerConfig{
+			JobRegistry:     &jobs.Registry{},
 			Settings:        &cluster.Settings{},
 			ExternalStorage: externalStorageFactory,
 			BulkAdder: func(
@@ -331,6 +332,7 @@ func TestImportHonorsResumePosition(t *testing.T) {
 	flowCtx := &execinfra.FlowCtx{
 		EvalCtx: &evalCtx,
 		Cfg: &execinfra.ServerConfig{
+			JobRegistry:     &jobs.Registry{},
 			Settings:        &cluster.Settings{},
 			ExternalStorage: externalStorageFactory,
 			BulkAdder: func(
@@ -458,6 +460,7 @@ func TestImportHandlesDuplicateKVs(t *testing.T) {
 	flowCtx := &execinfra.FlowCtx{
 		EvalCtx: &evalCtx,
 		Cfg: &execinfra.ServerConfig{
+			JobRegistry:     &jobs.Registry{},
 			Settings:        &cluster.Settings{},
 			ExternalStorage: externalStorageFactory,
 			BulkAdder: func(

--- a/pkg/sql/rowexec/processors.go
+++ b/pkg/sql/rowexec/processors.go
@@ -240,6 +240,15 @@ func NewProcessor(
 		}
 		return NewReadImportDataProcessor(flowCtx, processorID, *core.ReadImport, post, outputs[0])
 	}
+	if core.IngestStopped != nil {
+		if err := checkNumInOut(inputs, outputs, 0, 1); err != nil {
+			return nil, err
+		}
+		if NewIngestStoppedProcessor == nil {
+			return nil, errors.New("IsIngestingImport processor unimplemented")
+		}
+		return NewIngestStoppedProcessor(ctx, flowCtx, processorID, *core.IngestStopped, post, outputs[0])
+	}
 	if core.BackupData != nil {
 		if err := checkNumInOut(inputs, outputs, 0, 1); err != nil {
 			return nil, err
@@ -378,6 +387,9 @@ func NewProcessor(
 
 // NewReadImportDataProcessor is implemented in the non-free (CCL) codebase and then injected here via runtime initialization.
 var NewReadImportDataProcessor func(*execinfra.FlowCtx, int32, execinfrapb.ReadImportDataSpec, *execinfrapb.PostProcessSpec, execinfra.RowReceiver) (execinfra.Processor, error)
+
+// NewIngestStoppedProcessor is implemented in the non-free (CCL) codebase and then injected here via runtime initialization.
+var NewIngestStoppedProcessor func(context.Context, *execinfra.FlowCtx, int32, execinfrapb.IngestStoppedSpec, *execinfrapb.PostProcessSpec, execinfra.RowReceiver) (execinfra.Processor, error)
 
 // NewBackupDataProcessor is implemented in the non-free (CCL) codebase and then injected here via runtime initialization.
 var NewBackupDataProcessor func(*execinfra.FlowCtx, int32, execinfrapb.BackupDataSpec, *execinfrapb.PostProcessSpec, execinfra.RowReceiver) (execinfra.Processor, error)


### PR DESCRIPTION
Backport 3/3 commits from #101444.

/cc @cockroachdb/release

---

Backport 3/3 commits from #97071.

/cc @cockroachdb/release

---

This change adds a new method the job registry, allowing any ingestion
activity related to a given job ID to be indicated to the job registry,
including ingestion activity that is being performed by a processor that
is being run on this node on behalf of a job being coordinated by some
other node.

The registry also exposes a method to query if a given job has indicated
to the registry on a given node that it is engaged in ingestion activity
on that node.

In conjunction, these APIs can allow a job to indicate when and where it
is running ingestion tasks and for inspection of this information by
other tasks, including potentially subsequent retries or phases of the
same job. Implementation of such usages is left to a future change.

This adds a new helper utility that can be used to check if a given job
has indicated that it is currently performing ingestion work on any node
using the job Registry's MarkAsIngesting API.

This is done by running a distSQL flow on all nodes that invokes a new
processor which simply reads this registry API, returning an error if
the given job ID is ingesting and no error if it is not.

This utility is intended for use when a job needs to positively verify
that ingestion activity for a given job -- typically itself in a previous
phase or retry -- has ceases before moving on to a new phase or retry.

Typically, a job only moves on to a new phase after the flow running its
ingestion activity returns after every ingesting processor exits. However
in some rare edge cases, it is possible for this not to be the case: a
very slow, delayed ingestion could still be flushing after the coordinator
for the job terminated and the job was adopted on a different node. In
such a case, that new execution of the job, potentially now in a reverting
phase, could race with this delayed ingestion. In the case of a revert,
such a race could lead to incomplete cleanup by the revert, as data may
be added by the delayed ingestion after the reverting phase processes a
given span.

Integration of this new utility into jobs that require it is left to a
future change.

Release note (bug fix): Fix a potential bug whereby a failed or
cancelled IMPORT could in some cases leave some of the imported rows
behind after it was cancelled, in the rare event that the writing
processes were slow enough to continue writing after the cleanup process
started. 

Epic: none.

Release justification: bug fix.
