### PR TITLE
closedts: log err when incoming stream drops

### DIFF
--- a/pkg/kv/kvserver/closedts/sidetransport/receiver.go
+++ b/pkg/kv/kvserver/closedts/sidetransport/receiver.go
@@ -136,7 +136,7 @@ func (s *Receiver) onRecvErr(ctx context.Context, nodeID roachpb.NodeID, err err
 	defer s.mu.Unlock()
 
 	if err != io.EOF {
-		log.Warningf(ctx, "closed timestamps side-transport connection dropped from node: %d", nodeID)
+		log.Warningf(ctx, "closed timestamps side-transport connection dropped from node: %d (%s)", nodeID, err)
 	} else {
 		log.VEventf(ctx, 2, "closed timestamps side-transport connection dropped from node: %d (%s)", nodeID, err)
 	}


### PR DESCRIPTION
Currently we don't log error in the warning if incoming closedts stream is dropped by remote. Since those events are not frequent it would be beneficial to log actual error as we don't expect anything other than EOF which is handled separately.
This PR adds error to the log message.

Epic: none

Release note: None