### PR TITLE
kvprober: probe correct keys in `crdb_internal.probe_ranges`

### DIFF
--- a/pkg/kv/kvprober/kvprober.go
+++ b/pkg/kv/kvprober/kvprober.go
@@ -22,7 +22,9 @@ import (
 	"math/rand"
 	"time"
 
+	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/util/contextutil"
@@ -33,6 +35,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
+	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/logtags"
 )
 
@@ -152,8 +155,8 @@ type Metrics struct {
 // proberOpsI is an interface that the prober will use to run ops against some
 // system. This interface exists so that ops can be mocked for tests.
 type proberOpsI interface {
-	Read(key interface{}) func(context.Context, *kv.Txn) error
-	Write(key interface{}) func(context.Context, *kv.Txn) error
+	Read(key roachpb.Key) func(context.Context, *kv.Txn) error
+	Write(key roachpb.Key) func(context.Context, *kv.Txn) error
 }
 
 // proberTxn is an interface that the prober will use to run txns. This
@@ -173,8 +176,11 @@ type proberTxn interface {
 type ProberOps struct{}
 
 // We attempt to commit a txn that reads some data at the key.
-func (p *ProberOps) Read(key interface{}) func(context.Context, *kv.Txn) error {
+func (p *ProberOps) Read(key roachpb.Key) func(context.Context, *kv.Txn) error {
 	return func(ctx context.Context, txn *kv.Txn) error {
+		if err := p.validateKey(key); err != nil {
+			return err
+		}
 		_, err := txn.Get(ctx, key)
 		return err
 	}
@@ -187,8 +193,11 @@ func (p *ProberOps) Read(key interface{}) func(context.Context, *kv.Txn) error {
 // there is no need to clean up data at the key post range split / merge.
 // Note that MVCC tombstones may be left by the probe, but this is okay, as
 // GC will clean it up.
-func (p *ProberOps) Write(key interface{}) func(context.Context, *kv.Txn) error {
+func (p *ProberOps) Write(key roachpb.Key) func(context.Context, *kv.Txn) error {
 	return func(ctx context.Context, txn *kv.Txn) error {
+		if err := p.validateKey(key); err != nil {
+			return err
+		}
 		// Use a single batch so that the entire txn requires a single pass
 		// through Raft. It's not strictly necessary that we Put before we
 		// Del the key, because a Del is blind and leaves a tombstone even
@@ -199,6 +208,22 @@ func (p *ProberOps) Write(key interface{}) func(context.Context, *kv.Txn) error 
 		b.Del(key)
 		return txn.CommitInBatch(ctx, b)
 	}
+}
+
+// validateKey returns an error if the key is not valid for use by the kvprober.
+// This is a sanity check to ensure that the kvprober does not corrupt user data
+// in the global keyspace or other system data in the local keyspace.
+func (p *ProberOps) validateKey(key roachpb.Key) error {
+	_, suffix, _, err := keys.DecodeRangeKey(key)
+	if err != nil {
+		return errors.NewAssertionErrorWithWrappedErrf(err,
+			"key %q is not a valid probe key; could not decode range key", key)
+	}
+	if !suffix.Equal(keys.LocalRangeProbeSuffix.AsRawKey()) {
+		return errors.AssertionFailedf(
+			"key %q is not a valid probe key; incorrect range key suffix", key)
+	}
+	return nil
 }
 
 // proberTxnImpl is used to run transactions.

--- a/pkg/kv/kvprober/kvprober_integration_test.go
+++ b/pkg/kv/kvprober/kvprober_integration_test.go
@@ -20,9 +20,11 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/keys"
+	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvprober"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
@@ -297,6 +299,54 @@ func TestPlannerMakesPlansCoveringAllRanges(t *testing.T) {
 	}
 	for i := 0; i < 20; i++ {
 		test(i)
+	}
+}
+
+func TestProberOpsValidatesProbeKey(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+	s, _, _, cleanup := initTestProber(t, base.TestingKnobs{})
+	defer cleanup()
+
+	var ops kvprober.ProberOps
+	probeOps := []struct {
+		name string
+		op   func(roachpb.Key) func(context.Context, *kv.Txn) error
+	}{
+		{"Read", ops.Read},
+		{"Write", ops.Write},
+	}
+
+	probeKeys := []struct {
+		key   roachpb.Key
+		valid bool
+	}{
+		// Global key.
+		{roachpb.Key("a"), false},
+		// Incorrect range local key.
+		{keys.RangeDescriptorKey(roachpb.RKey("a")), false},
+		// Incorrect range-ID local key.
+		{keys.RangeLeaseKey(1), false},
+		// Correct range local probe key.
+		{keys.RangeProbeKey(roachpb.RKey("a")), true},
+	}
+
+	for _, op := range probeOps {
+		t.Run(op.name, func(t *testing.T) {
+			for _, key := range probeKeys {
+				t.Run(key.key.String(), func(t *testing.T) {
+					err := s.DB().Txn(ctx, op.op(key.key))
+					if key.valid {
+						require.NoError(t, err)
+					} else {
+						require.Error(t, err)
+						require.True(t, errors.IsAssertionFailure(err))
+					}
+				})
+			}
+		})
 	}
 }
 

--- a/pkg/kv/kvprober/kvprober_test.go
+++ b/pkg/kv/kvprober/kvprober_test.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 	"github.com/stretchr/testify/require"
@@ -238,7 +239,7 @@ func (m *mock) next(ctx context.Context) (Step, error) {
 	return step, m.planErr
 }
 
-func (m *mock) Read(key interface{}) func(context.Context, *kv.Txn) error {
+func (m *mock) Read(key roachpb.Key) func(context.Context, *kv.Txn) error {
 	return func(context.Context, *kv.Txn) error {
 		if !m.read {
 			m.t.Error("read call made but not expected")
@@ -247,7 +248,7 @@ func (m *mock) Read(key interface{}) func(context.Context, *kv.Txn) error {
 	}
 }
 
-func (m *mock) Write(key interface{}) func(context.Context, *kv.Txn) error {
+func (m *mock) Write(key roachpb.Key) func(context.Context, *kv.Txn) error {
 	return func(context.Context, *kv.Txn) error {
 		if !m.write {
 			m.t.Error("write call made but not expected")

--- a/pkg/sql/rangeprober/range_prober.go
+++ b/pkg/sql/rangeprober/range_prober.go
@@ -32,7 +32,10 @@ func NewRangeProber(db *kv.DB) *RangeProber {
 }
 
 // RunProbe implements the eval.RangeProber interface.
-func (r *RangeProber) RunProbe(ctx context.Context, key roachpb.Key, isWrite bool) error {
+func (r *RangeProber) RunProbe(
+	ctx context.Context, desc *roachpb.RangeDescriptor, isWrite bool,
+) error {
+	key := kvprober.ProbeKeyForRange(desc)
 	op := r.ops.Read
 	if isWrite {
 		op = r.ops.Write

--- a/pkg/sql/sem/builtins/generator_probe_ranges.go
+++ b/pkg/sql/sem/builtins/generator_probe_ranges.go
@@ -209,13 +209,7 @@ func (p *probeRangeGenerator) Next(ctx context.Context) (bool, error) {
 			return err
 		}
 		p.curr.rangeID = int64(desc.RangeID)
-		key := desc.StartKey.AsRawKey()
-		if desc.RangeID == 1 {
-			// The first range starts at KeyMin, but the replicated keyspace starts only at keys.LocalMax,
-			// so there is a special case here.
-			key = keys.LocalMax
-		}
-		return p.rangeProber.RunProbe(ctx, key, p.isWrite)
+		return p.rangeProber.RunProbe(ctx, &desc, p.isWrite)
 	})
 
 	p.curr.latency = timeutil.Since(tBegin)

--- a/pkg/sql/sem/eval/context.go
+++ b/pkg/sql/sem/eval/context.go
@@ -303,7 +303,7 @@ type ConsistencyCheckRunner interface {
 // crdb_internal.probe_ranges.
 type RangeProber interface {
 	RunProbe(
-		ctx context.Context, key roachpb.Key, isWrite bool,
+		ctx context.Context, desc *roachpb.RangeDescriptor, isWrite bool,
 	) error
 }
 


### PR DESCRIPTION
Fixes #101549.

In #101549, we found that `crdb_internal.probe_ranges` was unintentionally probing at global range start keys, instead of local probe keys derived from these range start keys. This could lead to serious corruption across the cluster which manifests itself in different ways, depending on the range. This commit fixes `crdb_internal.probe_ranges`, ensuring that it probes at the correct local probe keys.

The fix also ensures that we don't make this kind of mistake again. It unifies key encoding code paths for the multiple uses of kvprober to avoid bugs. It also adds validation directly above kvprober's access to the KV client which ensures that probe keys are valid.

Release note: None