### PR TITLE
sqlstats: add aost to select query on flush

### DIFF
--- a/pkg/sql/sqlstats/persistedsqlstats/flush.go
+++ b/pkg/sql/sqlstats/persistedsqlstats/flush.go
@@ -100,6 +100,7 @@ SELECT
     count(*)
 FROM
     system.statement_statistics
+AS OF SYSTEM TIME follower_read_timestamp()
 `
 
 	row, err := s.cfg.DB.Executor().QueryRowEx(
@@ -125,6 +126,7 @@ SELECT
     count(*)
 FROM
     system.transaction_statistics
+AS OF SYSTEM TIME follower_read_timestamp()
 `
 
 	row, err := s.cfg.DB.Executor().QueryRowEx(


### PR DESCRIPTION
The statements getting a count of sql stats tables during the flush where not using AOST.
This commit adds `AS OF SYSTEM TIME` to those statements to improve performance when the tables have a lot of garbage.

Epic: None
Release note: None