### PR TITLE
pkg/util/log: flush bufferedSinks as part of crash reporter process

### DIFF
--- a/pkg/ccl/backupccl/utils_test.go
+++ b/pkg/ccl/backupccl/utils_test.go
@@ -656,7 +656,7 @@ func requireRecoveryEvent(
 	expected eventpb.RecoveryEvent,
 ) {
 	testutils.SucceedsSoon(t, func() error {
-		log.Flush()
+		log.FlushFileSinks()
 		entries, err := log.FetchEntriesFromFiles(
 			startTime,
 			math.MaxInt64,

--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -1802,7 +1802,7 @@ func TestChangefeedSchemaChangeNoBackfill(t *testing.T) {
 
 	cdcTest(t, testFn)
 
-	log.Flush()
+	log.FlushFileSinks()
 	entries, err := log.FetchEntriesFromFiles(0, math.MaxInt64, 1, regexp.MustCompile("cdc ux violation"),
 		log.WithFlattenedSensitiveData)
 	if err != nil {
@@ -2172,7 +2172,7 @@ func TestChangefeedSchemaChangeBackfillCheckpoint(t *testing.T) {
 
 	cdcTestWithSystem(t, testFn, feedTestEnterpriseSinks)
 
-	log.Flush()
+	log.FlushFileSinks()
 	entries, err := log.FetchEntriesFromFiles(0, math.MaxInt64, 1,
 		regexp.MustCompile("cdc ux violation"), log.WithFlattenedSensitiveData)
 	if err != nil {
@@ -2358,7 +2358,7 @@ func TestChangefeedSchemaChangeAllowBackfill(t *testing.T) {
 
 	cdcTestWithSystem(t, testFn)
 
-	log.Flush()
+	log.FlushFileSinks()
 	entries, err := log.FetchEntriesFromFiles(0, math.MaxInt64, 1,
 		regexp.MustCompile("cdc ux violation"), log.WithFlattenedSensitiveData)
 	if err != nil {
@@ -2410,7 +2410,7 @@ func TestChangefeedSchemaChangeBackfillScope(t *testing.T) {
 	}
 
 	cdcTestWithSystem(t, testFn)
-	log.Flush()
+	log.FlushFileSinks()
 	entries, err := log.FetchEntriesFromFiles(0, math.MaxInt64, 1,
 		regexp.MustCompile("cdc ux violation"), log.WithFlattenedSensitiveData)
 	if err != nil {
@@ -2517,7 +2517,7 @@ func TestChangefeedAfterSchemaChangeBackfill(t *testing.T) {
 	}
 
 	cdcTest(t, testFn)
-	log.Flush()
+	log.FlushFileSinks()
 	entries, err := log.FetchEntriesFromFiles(0, math.MaxInt64, 1,
 		regexp.MustCompile("cdc ux violation"), log.WithFlattenedSensitiveData)
 	if err != nil {

--- a/pkg/ccl/changefeedccl/helpers_test.go
+++ b/pkg/ccl/changefeedccl/helpers_test.go
@@ -1041,7 +1041,7 @@ var cmLogRe = regexp.MustCompile(`event_log\.go`)
 func checkStructuredLogs(t *testing.T, eventType string, startTime int64) []string {
 	var matchingEntries []string
 	testutils.SucceedsSoon(t, func() error {
-		log.Flush()
+		log.FlushFileSinks()
 		entries, err := log.FetchEntriesFromFiles(startTime,
 			math.MaxInt64, 10000, cmLogRe, log.WithMarkedSensitiveData)
 		if err != nil {

--- a/pkg/ccl/changefeedccl/nemeses_test.go
+++ b/pkg/ccl/changefeedccl/nemeses_test.go
@@ -47,7 +47,7 @@ func TestChangefeedNemeses(t *testing.T) {
 	// nemeses_test.go:39: pq: unimplemented: operation is
 	// unsupported in multi-tenancy mode
 	cdcTest(t, testFn, feedTestNoTenants)
-	log.Flush()
+	log.FlushFileSinks()
 	entries, err := log.FetchEntriesFromFiles(0, math.MaxInt64, 1,
 		regexp.MustCompile("cdc ux violation"), log.WithFlattenedSensitiveData)
 	if err != nil {

--- a/pkg/ccl/telemetryccl/telemetry_logging_test.go
+++ b/pkg/ccl/telemetryccl/telemetry_logging_test.go
@@ -107,7 +107,7 @@ func TestTelemetryLogRegions(t *testing.T) {
 		sqlDB.Exec(t, tc.query)
 	}
 
-	log.Flush()
+	log.FlushFileSinks()
 
 	entries, err := log.FetchEntriesFromFiles(
 		0,
@@ -322,7 +322,7 @@ func TestBulkJobTelemetryLogging(t *testing.T) {
 		execTimestamp++
 	}
 
-	log.Flush()
+	log.FlushFileSinks()
 
 	var filteredSampleQueries []logpb.Entry
 	testutils.SucceedsSoon(t, func() error {

--- a/pkg/ccl/testccl/authccl/auth_test.go
+++ b/pkg/ccl/testccl/authccl/auth_test.go
@@ -528,7 +528,7 @@ func TestClientAddrOverride(t *testing.T) {
 			t.Run("check-server-log-uses-override", func(t *testing.T) {
 				// Wait for the disconnection event in logs.
 				testutils.SucceedsSoon(t, func() error {
-					log.Flush()
+					log.FlushFileSinks()
 					entries, err := log.FetchEntriesFromFiles(testStartTime.UnixNano(), math.MaxInt64, 10000, sessionTerminatedRe,
 						log.WithMarkedSensitiveData)
 					if err != nil {
@@ -541,7 +541,7 @@ func TestClientAddrOverride(t *testing.T) {
 				})
 
 				// Now we want to check that the logging tags are also updated.
-				log.Flush()
+				log.FlushFileSinks()
 				entries, err := log.FetchEntriesFromFiles(testStartTime.UnixNano(), math.MaxInt64, 10000, authLogFileRe,
 					log.WithMarkedSensitiveData)
 				if err != nil {

--- a/pkg/ccl/testccl/sqlccl/tenant_gc_test.go
+++ b/pkg/ccl/testccl/sqlccl/tenant_gc_test.go
@@ -505,7 +505,7 @@ func TestGCTenantJobWaitsForProtectedTimestamps(t *testing.T) {
 
 	checkGCBlockedByPTS := func(t *testing.T, sj *jobs.StartableJob, tenID uint64) {
 		testutils.SucceedsSoon(t, func() error {
-			log.Flush()
+			log.FlushFileSinks()
 			entries, err := log.FetchEntriesFromFiles(0, math.MaxInt64, 1,
 				regexp.MustCompile(fmt.Sprintf("GC TTL for dropped tenant %d has expired, but protected timestamp record\\(s\\)", tenID)),
 				log.WithFlattenedSensitiveData)

--- a/pkg/cli/connect.go
+++ b/pkg/cli/connect.go
@@ -76,7 +76,7 @@ func runConnectInit(cmd *cobra.Command, args []string) (retErr error) {
 	}
 
 	// Ensure that log files are populated when the process terminates.
-	defer log.Flush()
+	defer log.FlushFileSinks()
 
 	peers := []string(serverCfg.JoinList)
 	ctx, cancel := context.WithCancel(context.Background())

--- a/pkg/cli/debug_send_kv_batch_test.go
+++ b/pkg/cli/debug_send_kv_batch_test.go
@@ -123,7 +123,7 @@ func TestSendKVBatch(t *testing.T) {
 		require.JSONEq(t, jsonResponse, output)
 
 		// Check that a structured log event was emitted.
-		log.Flush()
+		log.FlushFileSinks()
 		entries, err := log.FetchEntriesFromFiles(start.UnixNano(), timeutil.Now().UnixNano(), 1,
 			regexp.MustCompile("debug_send_kv_batch"), log.WithFlattenedSensitiveData)
 		require.NoError(t, err)

--- a/pkg/cli/demo.go
+++ b/pkg/cli/demo.go
@@ -376,7 +376,7 @@ func runDemoInternal(
 	}
 
 	// Ensure the last few entries in the log files are flushed at the end.
-	defer log.Flush()
+	defer log.FlushFileSinks()
 
 	return sqlCtx.Run(ctx, conn)
 }

--- a/pkg/cli/start.go
+++ b/pkg/cli/start.go
@@ -771,7 +771,7 @@ func createAndStartServerAsync(
 
 	go func() {
 		// Ensure that the log files see the startup messages immediately.
-		defer log.Flush()
+		defer log.FlushFileSinks()
 		// If anything goes dramatically wrong, use Go's panic/recover
 		// mechanism to intercept the panic and log the panic details to
 		// the error reporting server.
@@ -1524,7 +1524,7 @@ func reportReadinessExternally(ctx context.Context, cmd *cobra.Command, waitForI
 	// Ensure the configuration logging is written to disk in case a
 	// process is waiting for the sdnotify readiness to read important
 	// information from there.
-	log.Flush()
+	log.FlushFileSinks()
 
 	// Signal readiness. This unblocks the process when running with
 	// --background or under systemd.

--- a/pkg/jobs/jobstest/logutils.go
+++ b/pkg/jobs/jobstest/logutils.go
@@ -36,7 +36,7 @@ func CheckEmittedEvents(
 ) {
 	// Check that the structured event was logged.
 	testutils.SucceedsSoon(t, func() error {
-		log.Flush()
+		log.FlushFileSinks()
 		entries, err := log.FetchEntriesFromFiles(startTime,
 			math.MaxInt64, 10000, cmLogRe, log.WithMarkedSensitiveData)
 		if err != nil {

--- a/pkg/jobs/registry_external_test.go
+++ b/pkg/jobs/registry_external_test.go
@@ -543,7 +543,7 @@ SELECT unnest(execution_errors)
 		t *testing.T, id jobspb.JobID, status jobs.Status,
 		from, to time.Time, cause string,
 	) {
-		log.Flush()
+		log.FlushFileSinks()
 		entries, err := log.FetchEntriesFromFiles(
 			from.UnixNano(), to.UnixNano(), 2,
 			regexp.MustCompile(fmt.Sprintf(

--- a/pkg/kv/kvserver/protectedts/ptstorage/storage_test.go
+++ b/pkg/kv/kvserver/protectedts/ptstorage/storage_test.go
@@ -645,7 +645,7 @@ func TestCorruptData(t *testing.T) {
 			require.NoError(t, err)
 		}
 
-		log.Flush()
+		log.FlushFileSinks()
 		entries, err := log.FetchEntriesFromFiles(0, math.MaxInt64, 100, msg,
 			log.WithFlattenedSensitiveData)
 		require.NoError(t, err)
@@ -732,7 +732,7 @@ func TestCorruptData(t *testing.T) {
 		require.Nil(t, got)
 		_, err = pts.GetState(ctx)
 		require.NoError(t, err)
-		log.Flush()
+		log.FlushFileSinks()
 
 		entries, err := log.FetchEntriesFromFiles(0, math.MaxInt64, 100, msg,
 			log.WithFlattenedSensitiveData)

--- a/pkg/kv/kvserver/replica_test.go
+++ b/pkg/kv/kvserver/replica_test.go
@@ -13529,7 +13529,7 @@ func TestProposalNotAcknowledgedOrReproposedAfterApplication(t *testing.T) {
 	if _, pErr := tc.repl.Send(ctx, ba); pErr != nil {
 		t.Fatal(pErr)
 	}
-	log.Flush()
+	log.FlushFileSinks()
 
 	stopper.Quiesce(ctx)
 	entries, err := log.FetchEntriesFromFiles(0, math.MaxInt64, 1,

--- a/pkg/kv/kvserver/replicate_queue_test.go
+++ b/pkg/kv/kvserver/replicate_queue_test.go
@@ -884,7 +884,7 @@ func TestReplicateQueueTracingOnError(t *testing.T) {
 
 	// Flush logs and get log messages from replicate_queue.go since just
 	// before calling store.Enqueue(..).
-	log.Flush()
+	log.FlushFileSinks()
 	entries, err := log.FetchEntriesFromFiles(testStartTs.UnixNano(),
 		math.MaxInt64, 100, regexp.MustCompile(`replicate_queue\.go`), log.WithMarkedSensitiveData)
 	require.NoError(t, err)

--- a/pkg/security/certmgr/cert_manager_test.go
+++ b/pkg/security/certmgr/cert_manager_test.go
@@ -57,7 +57,7 @@ var cmLogRe = regexp.MustCompile(`event_log\.go`)
 
 // Check that the structured event was logged.
 func checkLogStructEntry(t *testing.T, expectSuccess bool, beforeReload time.Time) error {
-	log.Flush()
+	log.FlushFileSinks()
 	entries, err := log.FetchEntriesFromFiles(beforeReload.UnixNano(),
 		math.MaxInt64, 10000, cmLogRe, log.WithMarkedSensitiveData)
 	if err != nil {

--- a/pkg/security/certs_rotation_test.go
+++ b/pkg/security/certs_rotation_test.go
@@ -201,7 +201,7 @@ func TestRotateCerts(t *testing.T) {
 	// the moment the structured logging event is actually
 	// written to the log file.
 	testutils.SucceedsSoon(t, func() error {
-		log.Flush()
+		log.FlushFileSinks()
 		entries, err := log.FetchEntriesFromFiles(beforeReload.UnixNano(),
 			math.MaxInt64, 10000, cmLogRe, log.WithMarkedSensitiveData)
 		if err != nil {

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -592,7 +592,7 @@ func TestPersistHLCUpperBound(t *testing.T) {
 	var fatal bool
 	defer log.ResetExitFunc()
 	log.SetExitFunc(true /* hideStack */, func(r exit.Code) {
-		defer log.Flush()
+		defer log.FlushFileSinks()
 		if r == exit.FatalError() {
 			fatal = true
 		}

--- a/pkg/server/status.go
+++ b/pkg/server/status.go
@@ -1239,7 +1239,7 @@ func (s *statusServer) LogFilesList(
 		}
 		return status.LogFilesList(ctx, req)
 	}
-	log.Flush()
+	log.FlushFileSinks()
 	logFiles, err := log.ListLogFiles()
 	if err != nil {
 		return nil, serverError(ctx, err)
@@ -1279,7 +1279,7 @@ func (s *statusServer) LogFile(
 	inputEditMode := log.SelectEditMode(req.Redact, log.KeepRedactable)
 
 	// Ensure that the latest log entries are available in files.
-	log.Flush()
+	log.FlushFileSinks()
 
 	// Read the logs.
 	reader, err := log.GetLogReader(req.File)
@@ -1409,7 +1409,7 @@ func (s *statusServer) Logs(
 	}
 
 	// Ensure that the latest log entries are available in files.
-	log.Flush()
+	log.FlushFileSinks()
 
 	// Read the logs.
 	entries, err := log.FetchEntriesFromFiles(

--- a/pkg/server/status/runtime_stats_test.go
+++ b/pkg/server/status/runtime_stats_test.go
@@ -44,7 +44,7 @@ func TestStructuredEventLogging(t *testing.T) {
 	time.Sleep(10 * time.Second)
 
 	// Ensure that the entry hits the OS so it can be read back below.
-	log.Flush()
+	log.FlushFileSinks()
 
 	entries, err := log.FetchEntriesFromFiles(testStartTs.UnixNano(),
 		math.MaxInt64, 10000, cmLogRe, log.WithMarkedSensitiveData)

--- a/pkg/server/structlogging/hot_ranges_log_test.go
+++ b/pkg/server/structlogging/hot_ranges_log_test.go
@@ -84,7 +84,7 @@ func TestHotRangesStats(t *testing.T) {
 	})
 
 	testutils.SucceedsWithin(t, func() error {
-		log.Flush()
+		log.FlushFileSinks()
 		entries, err := log.FetchEntriesFromFiles(
 			0,
 			math.MaxInt64,

--- a/pkg/sql/admin_audit_log_test.go
+++ b/pkg/sql/admin_audit_log_test.go
@@ -73,7 +73,7 @@ func TestAdminAuditLogBasic(t *testing.T) {
 	db.Exec(t, `SELECT 1;`)
 
 	var selectAdminRe = regexp.MustCompile(`"EventType":"admin_query","Statement":"SELECT ‹1›","Tag":"SELECT","User":"root"`)
-	log.Flush()
+	log.FlushFileSinks()
 
 	entries, err := log.FetchEntriesFromFiles(0, math.MaxInt64, 10000, selectAdminRe,
 		log.WithMarkedSensitiveData)
@@ -124,7 +124,7 @@ func TestAdminAuditLogRegularUser(t *testing.T) {
 
 	var selectRe = regexp.MustCompile(`SELECT 1`)
 
-	log.Flush()
+	log.FlushFileSinks()
 
 	entries, err := log.FetchEntriesFromFiles(0, math.MaxInt64, 10000, selectRe,
 		log.WithMarkedSensitiveData)
@@ -180,7 +180,7 @@ COMMIT;
 		},
 	}
 
-	log.Flush()
+	log.FlushFileSinks()
 
 	entries, err := log.FetchEntriesFromFiles(
 		0,
@@ -275,7 +275,7 @@ COMMIT;
 		},
 	}
 
-	log.Flush()
+	log.FlushFileSinks()
 
 	entries, err := log.FetchEntriesFromFiles(
 		0,
@@ -319,7 +319,7 @@ COMMIT;
 		t.Fatal(err)
 	}
 
-	log.Flush()
+	log.FlushFileSinks()
 
 	entries, err = log.FetchEntriesFromFiles(
 		0,

--- a/pkg/sql/event_log_test.go
+++ b/pkg/sql/event_log_test.go
@@ -82,7 +82,7 @@ func TestStructuredEventLogging(t *testing.T) {
 	}
 
 	// Ensure that the entries hit the OS so they can be read back below.
-	log.Flush()
+	log.FlushFileSinks()
 
 	entries, err := log.FetchEntriesFromFiles(testStartTs.UnixNano(),
 		math.MaxInt64, 10000, execLogRe, log.WithMarkedSensitiveData)
@@ -736,7 +736,7 @@ func TestPerfLogging(t *testing.T) {
 		}
 
 		var logRe = regexp.MustCompile(tc.logRe)
-		log.Flush()
+		log.FlushFileSinks()
 		entries, err := log.FetchEntriesFromFiles(
 			start, math.MaxInt64, 1000, logRe, log.WithMarkedSensitiveData,
 		)

--- a/pkg/sql/pgwire/auth_test.go
+++ b/pkg/sql/pgwire/auth_test.go
@@ -734,7 +734,7 @@ func TestClientAddrOverride(t *testing.T) {
 			t.Run("check-server-log-uses-override", func(t *testing.T) {
 				// Wait for the disconnection event in logs.
 				testutils.SucceedsSoon(t, func() error {
-					log.Flush()
+					log.FlushFileSinks()
 					entries, err := log.FetchEntriesFromFiles(testStartTime.UnixNano(), math.MaxInt64, 10000, sessionTerminatedRe,
 						log.WithMarkedSensitiveData)
 					if err != nil {
@@ -747,7 +747,7 @@ func TestClientAddrOverride(t *testing.T) {
 				})
 
 				// Now we want to check that the logging tags are also updated.
-				log.Flush()
+				log.FlushFileSinks()
 				entries, err := log.FetchEntriesFromFiles(testStartTime.UnixNano(), math.MaxInt64, 10000, authLogFileRe,
 					log.WithMarkedSensitiveData)
 				if err != nil {

--- a/pkg/sql/scheduledlogging/captured_index_usage_stats_test.go
+++ b/pkg/sql/scheduledlogging/captured_index_usage_stats_test.go
@@ -281,7 +281,7 @@ func checkNumTotalEntriesAndNumIndexEntries(
 	expectedIndividualIndexEntries int,
 	scheduleCompleteChan chan struct{},
 ) error {
-	log.Flush()
+	log.FlushFileSinks()
 	// Fetch log entries.
 	entries, err := log.FetchEntriesFromFiles(
 		0,

--- a/pkg/sql/telemetry_logging_test.go
+++ b/pkg/sql/telemetry_logging_test.go
@@ -365,7 +365,7 @@ func TestTelemetryLogging(t *testing.T) {
 		}
 	}
 
-	log.Flush()
+	log.FlushFileSinks()
 
 	entries, err := log.FetchEntriesFromFiles(
 		0,
@@ -672,7 +672,7 @@ func TestNoTelemetryLogOnTroubleshootMode(t *testing.T) {
 		db.Exec(t, tc.query)
 	}
 
-	log.Flush()
+	log.FlushFileSinks()
 
 	entries, err := log.FetchEntriesFromFiles(
 		0,
@@ -876,7 +876,7 @@ func TestTelemetryLogJoinTypesAndAlgorithms(t *testing.T) {
 		db.Exec(t, tc.query)
 	}
 
-	log.Flush()
+	log.FlushFileSinks()
 
 	entries, err := log.FetchEntriesFromFiles(
 		0,
@@ -1131,7 +1131,7 @@ func TestTelemetryScanCounts(t *testing.T) {
 		db.Exec(t, tc.query)
 	}
 
-	log.Flush()
+	log.FlushFileSinks()
 
 	entries, err := log.FetchEntriesFromFiles(
 		0,
@@ -1245,7 +1245,7 @@ $$`
 
 	db.Exec(t, stmt)
 
-	log.Flush()
+	log.FlushFileSinks()
 
 	entries, err := log.FetchEntriesFromFiles(
 		0,

--- a/pkg/upgrade/upgrades/schema_changes_external_test.go
+++ b/pkg/upgrade/upgrades/schema_changes_external_test.go
@@ -510,7 +510,7 @@ func testMigrationWithFailures(
 			})
 			if test.waitForMigrationRestart {
 				// Ensure that we have observed the expected number of ignored schema change jobs.
-				log.Flush()
+				log.FlushFileSinks()
 				entries, err := log.FetchEntriesFromFiles(
 					0, math.MaxInt64, 10000,
 					regexp.MustCompile("skipping.*operation as the schema change already exists."),

--- a/pkg/util/hlc/hlc_test.go
+++ b/pkg/util/hlc/hlc_test.go
@@ -438,7 +438,7 @@ func TestHLCEnforceWallTimeWithinBoundsInNow(t *testing.T) {
 	var fatal bool
 	defer log.ResetExitFunc()
 	log.SetExitFunc(true /* hideStack */, func(r exit.Code) {
-		defer log.Flush()
+		defer log.FlushFileSinks()
 		if r == exit.FatalError() {
 			fatal = true
 		}
@@ -487,7 +487,7 @@ func TestHLCEnforceWallTimeWithinBoundsInUpdate(t *testing.T) {
 	var fatal bool
 	defer log.ResetExitFunc()
 	log.SetExitFunc(true /* hideStack */, func(r exit.Code) {
-		defer log.Flush()
+		defer log.FlushFileSinks()
 		if r == exit.FatalError() {
 			fatal = true
 		}

--- a/pkg/util/log/clog_test.go
+++ b/pkg/util/log/clog_test.go
@@ -651,7 +651,7 @@ func TestFileSeverityFilter(t *testing.T) {
 	Infof(context.Background(), "test1")
 	Errorf(context.Background(), "test2")
 
-	Flush()
+	FlushFileSinks()
 
 	debugFileSink := debugFileSinkInfo.sink.(*fileSink)
 	contents, err := os.ReadFile(debugFileSink.getFileName(t))

--- a/pkg/util/log/doc.go
+++ b/pkg/util/log/doc.go
@@ -83,8 +83,10 @@
 //
 // # Output
 //
-// Log output is buffered and written periodically using Flush. Programs
-// should call Flush before exiting to guarantee all log output is written.
+// Log output is buffered and written periodically using FlushFileSinks.
+// Programs should call FlushFileSinks before exiting to guarantee all
+// log output is written to files. Note that buffered network sinks also
+// exist. If you'd like to flush these as well, call FlushAllSync.
 //
 // By default, all log statements write to files in a temporary directory.
 // This package provides several flags that modify this behavior.

--- a/pkg/util/log/file.go
+++ b/pkg/util/log/file.go
@@ -67,7 +67,7 @@ type fileSink struct {
 	// name generator for log files.
 	nameGenerator fileNameGenerator
 
-	// bufferedWrites if false calls file.Flush on every log
+	// bufferedWrites if false calls file.FlushFileSinks on every log
 	// write. This can be set per-logger e.g. for audit logging.
 	//
 	// Note that synchronization for all log files simultaneously can

--- a/pkg/util/log/file_log_gc_test.go
+++ b/pkg/util/log/file_log_gc_test.go
@@ -158,7 +158,7 @@ func testLogGC(t *testing.T, fileSink *fileSink, logFn func(ctx context.Context,
 	const newLogFiles = 20
 	for i := 1; i < newLogFiles; i++ {
 		logFn(context.Background(), fmt.Sprint(i))
-		Flush()
+		FlushFileSinks()
 	}
 	if _, err := expectFileCount(newLogFiles); err != nil {
 		t.Fatal(err)
@@ -169,7 +169,7 @@ func testLogGC(t *testing.T, fileSink *fileSink, logFn func(ctx context.Context,
 
 	// Emit a log line which will rotate the files and trigger GC.
 	logFn(context.Background(), "final")
-	Flush()
+	FlushFileSinks()
 
 	succeedsSoon(t, func() error {
 		_, err := expectFileCount(expectedFilesAfterGC)

--- a/pkg/util/log/formats_test.go
+++ b/pkg/util/log/formats_test.go
@@ -79,7 +79,7 @@ func TestFormatRedaction(t *testing.T) {
 							defer cleanupFn()
 
 							Infof(ctx, "safe2 %s", "secret3")
-							Flush()
+							FlushFileSinks()
 
 							contents, err := os.ReadFile(getDebugLogFileName(t))
 							require.NoError(t, err)

--- a/pkg/util/log/log_flush.go
+++ b/pkg/util/log/log_flush.go
@@ -12,6 +12,7 @@ package log
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"time"
 
@@ -26,13 +27,37 @@ type flushSyncWriter interface {
 	io.Writer
 }
 
-// Flush explicitly flushes all pending log file I/O.
+// FlushFileSinks explicitly flushes all pending log file I/O.
 // See also flushDaemon() that manages background (asynchronous)
 // flushes, and signalFlusher() that manages flushes in reaction to a
 // user signal.
-func Flush() {
+func FlushFileSinks() {
 	_ = logging.allSinkInfos.iterFileSinks(func(l *fileSink) error {
 		l.lockAndFlushAndMaybeSync(true /*doSync*/)
+		return nil
+	})
+}
+
+// FlushAllSync explicitly flushes all asynchronous buffered logging sinks,
+// including pending log file I/O and buffered network sinks.
+//
+// NB: This is a synchronous operation, and will block until all flushes
+// have completed. Generally only recommended for use in crash reporting
+// scenarios.
+func FlushAllSync() {
+	FlushFileSinks()
+	_ = logging.allSinkInfos.iterBufferedSinks(func(bs *bufferedSink) error {
+		// Trigger a synchronous flush by calling output on the bufferedSink
+		// with a `forceSync` option.
+		err := bs.output([]byte{}, sinkOutputOptions{forceSync: true})
+		if err != nil {
+			// We don't want to let errors to stop us from iterating and flushing
+			// the remaining buffered log sinks. Nor do we want to log the error
+			// using the logging system, as it's unlikely to make it to the
+			// destination sink anyway (there's a good chance we're flushing
+			// as part of handling a panic). Display the error and continue.
+			fmt.Printf("Error draining buffered log sink: %v\n", err)
+		}
 		return nil
 	})
 }
@@ -61,7 +86,7 @@ const syncWarnDuration = 10 * time.Second
 // flushDaemon periodically flushes and syncs the log file buffers.
 // This manages both the primary and secondary loggers.
 //
-// Flush propagates the in-memory buffer inside CockroachDB to the
+// FlushFileSinks propagates the in-memory buffer inside CockroachDB to the
 // in-memory buffer(s) of the OS. The flush is relatively frequent so
 // that a human operator can see "up to date" logging data in the log
 // file.
@@ -97,7 +122,7 @@ func signalFlusher() {
 	ch := sysutil.RefreshSignaledChan()
 	for sig := range ch {
 		Ops.Infof(context.Background(), "%s received, flushing logs", sig)
-		Flush()
+		FlushFileSinks()
 	}
 }
 
@@ -109,5 +134,5 @@ func signalFlusher() {
 func StartAlwaysFlush() {
 	logging.flushWrites.Set(true)
 	// There may be something in the buffers already; flush it.
-	Flush()
+	FlushFileSinks()
 }

--- a/pkg/util/log/logcrash/crash_reporting.go
+++ b/pkg/util/log/logcrash/crash_reporting.go
@@ -192,7 +192,7 @@ func ReportPanic(ctx context.Context, sv *settings.Values, r interface{}, depth 
 
 	// Ensure that the logs are flushed before letting a panic
 	// terminate the server.
-	log.Flush()
+	log.FlushAllSync()
 }
 
 // PanicAsError turns r into an error if it is not one already.

--- a/pkg/util/log/registry.go
+++ b/pkg/util/log/registry.go
@@ -76,12 +76,25 @@ func (r *sinkInfoRegistry) iter(fn func(l *sinkInfo) error) error {
 	return nil
 }
 
-// iterate iterates over all the file sinks and stops at the first
+// iterFileSinks iterates over all the file sinks and stops at the first
 // error encountered.
 func (r *sinkInfoRegistry) iterFileSinks(fn func(l *fileSink) error) error {
 	return r.iter(func(si *sinkInfo) error {
 		if fs, ok := si.sink.(*fileSink); ok {
 			if err := fn(fs); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+}
+
+// iterBufferedSinks iterates over all the buffered sinks and stops at the first
+// error encountered.
+func (r *sinkInfoRegistry) iterBufferedSinks(fn func(bs *bufferedSink) error) error {
+	return r.iter(func(si *sinkInfo) error {
+		if bs, ok := si.sink.(*bufferedSink); ok {
+			if err := fn(bs); err != nil {
 				return err
 			}
 		}

--- a/pkg/util/log/secondary_log_test.go
+++ b/pkg/util/log/secondary_log_test.go
@@ -71,7 +71,7 @@ func TestSecondaryLog(t *testing.T) {
 	Infof(context.Background(), "test2")
 
 	// Make sure the content made it to disk.
-	Flush()
+	FlushFileSinks()
 
 	// Check that the messages indeed made it to different files.
 
@@ -151,7 +151,7 @@ func TestListLogFilesIncludeSecondaryLogs(t *testing.T) {
 	// Emit some logging and ensure the files gets created.
 	ctx := context.Background()
 	Sessions.Infof(ctx, "story time")
-	Flush()
+	FlushFileSinks()
 
 	results, err := ListLogFiles()
 	if err != nil {

--- a/pkg/util/log/test_log_scope.go
+++ b/pkg/util/log/test_log_scope.go
@@ -365,7 +365,7 @@ func (l *TestLogScope) Rotate(t tShim) {
 	t.Helper()
 	t.Logf("-- test log scope file rotation --")
 	// Ensure remaining logs are written.
-	Flush()
+	FlushFileSinks()
 
 	if err := logging.allSinkInfos.iterFileSinks(func(l *fileSink) error {
 		l.mu.Lock()
@@ -387,7 +387,7 @@ func (l *TestLogScope) Close(t tShim) {
 	t.Logf("-- test log scope end --")
 
 	// Ensure any remaining logs are written to files.
-	Flush()
+	FlushFileSinks()
 
 	if l.logDir != "" {
 		defer func() {


### PR DESCRIPTION
It was brought to our attention that SQL pods in serverless environments experiencing panics were not showing the panic logs in downstream log collection systems like Splunk.

This caused an investigation into the crash reporter, where we found that the crash reporter *only* flushed the file logging sinks, but *not* the buffered network sinks.

Because of this, when the crash reporter logged the panic details to the OPS channel, and the panic log was sent through a fluent-server logging sink, it would simply be buffered. The crash reported would then flush the *file* sinks before propagating the panic again to kill the process. Since we didn't trigger & wait for the flush of the buffered network sinks, the panic almost never made it to the downstream fluentbit collector in time. In the case of SQL pods, where log files are not maintained once the container is destroyed, this meant these panic logs would be lost entirely.

This patch updates the log flush system with a new function called `FlushAll`. Previously, we had `Flush`, which would flush all the file logging sinks. This has been renamed to `FlushFileSinks`. Due to its widespread use throughout the code base, we intentionally maintain separation between the flushing of just the file sinks specifically, and the flushing of *all* buffered logging sinks (including network sinks), to avoid changing the semantics of the pre-existing function and its widespread usages.

NB: The `FlushAll` is a synchronous operation. It will wait for each buffered logging sink to finish flushing before allowing the crash reporter to proceed. This ensures that the buffers are fully drained prior to propagating the panic and killing the process.

Release note: none

Fixes: https://github.com/cockroachdb/cockroach/issues/101369