### PR TITLE
sqlstats: ignore SET stmts on insights

### DIFF
--- a/pkg/sql/sqlstats/insights/detector.go
+++ b/pkg/sql/sqlstats/insights/detector.go
@@ -12,6 +12,7 @@ package insights
 
 import (
 	"container/list"
+	"strings"
 
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/appstatspb"
@@ -169,4 +170,16 @@ func (d *latencyThresholdDetector) isSlow(s *Statement) bool {
 
 func isFailed(s *Statement) bool {
 	return s.Status == Statement_Failed
+}
+
+var prefixesToIgnore = []string{"SET "}
+
+// shouldIgnoreStatement returns true if we don't want to analyze the statement.
+func shouldIgnoreStatement(s *Statement) bool {
+	for _, start := range prefixesToIgnore {
+		if strings.HasPrefix(s.Query, start) {
+			return true
+		}
+	}
+	return false
 }

--- a/pkg/sql/sqlstats/insights/registry.go
+++ b/pkg/sql/sqlstats/insights/registry.go
@@ -100,7 +100,7 @@ func (r *lockingRegistry) ObserveTransaction(sessionID clusterunique.ID, transac
 	// Mark statements which are detected as slow or have a failed status.
 	var slowOrFailedStatements intsets.Fast
 	for i, s := range *statements {
-		if r.detector.isSlow(s) || isFailed(s) {
+		if !shouldIgnoreStatement(s) && (r.detector.isSlow(s) || isFailed(s)) {
 			slowOrFailedStatements.Add(i)
 		}
 	}

--- a/pkg/sql/sqlstats/insights/registry_test.go
+++ b/pkg/sql/sqlstats/insights/registry_test.go
@@ -223,7 +223,7 @@ func TestRegistry(t *testing.T) {
 			FingerprintID:    appstatspb.StmtFingerprintID(100),
 			LatencyInSeconds: 2,
 		}
-		siblingStatment := &Statement{
+		siblingStatement := &Statement{
 			ID:            clusterunique.IDFromBytes([]byte("dddddddddddddddddddddddddddddddd")),
 			FingerprintID: appstatspb.StmtFingerprintID(101),
 		}
@@ -233,7 +233,7 @@ func TestRegistry(t *testing.T) {
 		store := newStore(st)
 		registry := newRegistry(st, &latencyThresholdDetector{st: st}, store)
 		registry.ObserveStatement(session.ID, statement)
-		registry.ObserveStatement(session.ID, siblingStatment)
+		registry.ObserveStatement(session.ID, siblingStatement)
 		registry.ObserveTransaction(session.ID, transaction)
 
 		expected := []*Insight{
@@ -242,7 +242,7 @@ func TestRegistry(t *testing.T) {
 				Transaction: transaction,
 				Statements: []*Statement{
 					newStmtWithProblemAndCauses(statement, Problem_SlowExecution, nil),
-					siblingStatment,
+					siblingStatement,
 				},
 			},
 		}
@@ -305,5 +305,50 @@ func TestRegistry(t *testing.T) {
 
 		require.Equal(t, expected, actual)
 		require.Equal(t, transaction.Status, Transaction_Status(statement.Status))
+	})
+
+	t.Run("statement that is slow but should be ignored", func(t *testing.T) {
+		statementNotIgnored := &Statement{
+			Status:           Statement_Completed,
+			ID:               clusterunique.IDFromBytes([]byte("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb")),
+			FingerprintID:    appstatspb.StmtFingerprintID(100),
+			LatencyInSeconds: 2,
+			Query:            "SELECT * FROM users",
+		}
+		statementIgnored := &Statement{
+			ID:               clusterunique.IDFromBytes([]byte("dddddddddddddddddddddddddddddddd")),
+			FingerprintID:    appstatspb.StmtFingerprintID(101),
+			LatencyInSeconds: 2,
+			Query:            "SET vectorize = '_'",
+		}
+
+		st := cluster.MakeTestingClusterSettings()
+		LatencyThreshold.Override(ctx, &st.SV, 1*time.Second)
+		store := newStore(st)
+		registry := newRegistry(st, &latencyThresholdDetector{st: st}, store)
+		registry.ObserveStatement(session.ID, statementNotIgnored)
+		registry.ObserveStatement(session.ID, statementIgnored)
+		registry.ObserveTransaction(session.ID, transaction)
+
+		expected := []*Insight{
+			{
+				Session:     session,
+				Transaction: transaction,
+				Statements: []*Statement{
+					newStmtWithProblemAndCauses(statementNotIgnored, Problem_SlowExecution, nil),
+					statementIgnored,
+				},
+			},
+		}
+		var actual []*Insight
+		store.IterateInsights(
+			context.Background(),
+			func(ctx context.Context, o *Insight) {
+				actual = append(actual, o)
+			},
+		)
+
+		require.Equal(t, expected, actual)
+		require.Equal(t, transaction.Status, Transaction_Status(statementNotIgnored.Status))
 	})
 }


### PR DESCRIPTION
Statements such as `SET vectorize = _` were being listed on Insights, but there is nothing the user can do about this, since is expected to be slow on some cases.
This commit creates an ignore function, that currently only ignore statements startings with `SET `, but can be improved with more feedback and other statements that don't make sense to be part of our insights can be added to the list.

Fixes #98358

Release note (sql change): Statements of type `SET ` are not longer displayed on the Insights page.