### PR TITLE
ui: add draining node as its own value

### DIFF
--- a/pkg/ui/workspaces/db-console/src/redux/nodes.ts
+++ b/pkg/ui/workspaces/db-console/src/redux/nodes.ts
@@ -47,6 +47,8 @@ export function livenessNomenclature(liveness: LivenessStatus) {
       return "decommissioning";
     case LivenessStatus.NODE_STATUS_DECOMMISSIONED:
       return "decommissioned";
+    case LivenessStatus.NODE_STATUS_DRAINING:
+      return "draining";
     default:
       return "dead";
   }
@@ -188,6 +190,7 @@ export type NodeSummaryStats = {
     suspect: number;
     dead: number;
     decommissioned: number;
+    draining: number;
   };
   capacityUsed: number;
   capacityAvailable: number;
@@ -227,6 +230,7 @@ export function sumNodeStats(
       suspect: 0,
       dead: 0,
       decommissioned: 0,
+      draining: 0,
     },
     capacityUsed: 0,
     capacityAvailable: 0,
@@ -255,6 +259,9 @@ export function sumNodeStats(
           break;
         case LivenessStatus.NODE_STATUS_DECOMMISSIONED:
           result.nodeCounts.decommissioned++;
+          break;
+        case LivenessStatus.NODE_STATUS_DRAINING:
+          result.nodeCounts.draining++;
           break;
         case LivenessStatus.NODE_STATUS_DEAD:
         default:

--- a/pkg/ui/workspaces/db-console/src/views/cluster/containers/clusterOverview/cluster.styl
+++ b/pkg/ui/workspaces/db-console/src/views/cluster/containers/clusterOverview/cluster.styl
@@ -42,14 +42,14 @@
     align-items end
     grid-template-columns 6fr 8fr 6fr minmax(auto,8fr) minmax(10px, 2fr) 6fr 6fr 6fr 2fr 6fr 10fr 6fr
     grid-template-rows repeat(3, auto)
-    grid-template-areas "cap-t cap-t cap-t cap-t . live-t live-t live-t . rep-t rep-t rep-t" "cap-m cap-c cap-c cap-c . live-a live-b live-c . rep-a rep-b rep-c" "cap-a1 cap-a2 cap-a3 cap-a4 . live-1 live-2 live-3 . rep-1 rep-2 rep-3"
+    grid-template-areas "cap-t cap-t cap-t cap-t . live-t live-t live-t . rep-t rep-t rep-t" "cap-m cap-c cap-c cap-c . live-a live-b live-c live-d  rep-a rep-b rep-c" "cap-a1 cap-a2 cap-a3 cap-a4 . live-1 live-2 live-3 live-4  rep-1 rep-2 rep-3"
 
     @media screen and (max-width: 960px)
       padding 18px 14px 10px
       align-items center
       grid-template-columns 4fr 5fr 4fr 3fr 5fr 4fr
       grid-template-rows repeat(4, auto)
-      grid-template-areas "cap-t cap-t live-t live-t rep-t rep-t" "cap-m2 cap-m live-1 live-a rep-1 rep-a" "cap-a1 cap-a2 live-2 live-b rep-2 rep-b" "cap-a3 cap-a4 live-3 live-c rep-3 rep-c"
+      grid-template-areas "cap-t cap-t live-t live-t rep-t rep-t" "cap-m2 cap-m live-1 live-a rep-1 rep-a" "cap-a1 cap-a2 live-2 live-b rep-2 rep-b" "cap-a3 cap-a4 live-3 live-c rep-3 rep-c" ". . live-4 live-d . ."
 
     @media screen and (min-width: 1400px)
       grid-template-columns 2fr 3fr 2fr 3fr 4fr 2fr 2fr 2fr 4fr 2fr 3fr 2fr
@@ -100,8 +100,11 @@
       &.cluster-summary__metric.suspect-nodes
           grid-area live-b
 
-      &.cluster-summary__metric.dead-nodes
+      &.cluster-summary__metric.draining-nodes
           grid-area live-c
+
+      &.cluster-summary__metric.dead-nodes
+          grid-area live-d
 
       &.cluster-summary__label.live-nodes
           grid-area live-1
@@ -109,8 +112,11 @@
       &.cluster-summary__label.suspect-nodes
           grid-area live-2
 
-      &.cluster-summary__label.dead-nodes
+      &.cluster-summary__label.draining-nodes
           grid-area live-3
+
+      &.cluster-summary__label.dead-nodes
+          grid-area live-4
 
     .replication-status
       &.cluster-summary__title

--- a/pkg/ui/workspaces/db-console/src/views/cluster/containers/clusterOverview/index.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/cluster/containers/clusterOverview/index.tsx
@@ -31,6 +31,7 @@ import {
   UsableTooltip,
   LiveNodesTooltip,
   SuspectNodesTooltip,
+  DrainingNodesTooltip,
   DeadNodesTooltip,
   TotalRangesTooltip,
   UnderReplicatedRangesTooltip,
@@ -96,10 +97,11 @@ interface NodeLivenessProps {
   liveNodes: number;
   suspectNodes: number;
   deadNodes: number;
+  drainingNodes: number;
 }
 
 function renderNodeLiveness(props: NodeLivenessProps) {
-  const { liveNodes, suspectNodes, deadNodes } = props;
+  const { liveNodes, suspectNodes, deadNodes, drainingNodes } = props;
   const suspectClasses = classNames(
     "node-liveness",
     "cluster-summary__metric",
@@ -107,6 +109,15 @@ function renderNodeLiveness(props: NodeLivenessProps) {
     {
       warning: suspectNodes > 0,
       disabled: suspectNodes === 0,
+    },
+  );
+  const drainingClasses = classNames(
+    "node-liveness",
+    "cluster-summary__metric",
+    "draining-nodes",
+    {
+      warning: drainingNodes > 0,
+      disabled: drainingNodes === 0,
     },
   );
   const deadClasses = classNames(
@@ -138,6 +149,14 @@ function renderNodeLiveness(props: NodeLivenessProps) {
         Nodes
       </SuspectNodesTooltip>
     </div>,
+    <div className={drainingClasses}>{drainingNodes}</div>,
+    <div className="node-liveness cluster-summary__label draining-nodes">
+      <DrainingNodesTooltip>
+        Draining
+        <br />
+        Nodes
+      </DrainingNodesTooltip>
+    </div>,
     <div className={deadClasses}>{deadNodes}</div>,
     <div className="node-liveness cluster-summary__label dead-nodes">
       <DeadNodesTooltip>
@@ -157,6 +176,7 @@ const mapStateToNodeLivenessProps = createSelector(
       liveNodes: nodeCounts.healthy,
       suspectNodes: nodeCounts.suspect,
       deadNodes: nodeCounts.dead,
+      drainingNodes: nodeCounts.draining,
     };
   },
 );

--- a/pkg/ui/workspaces/db-console/src/views/cluster/containers/clusterOverview/tooltips.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/cluster/containers/clusterOverview/tooltips.tsx
@@ -115,6 +115,20 @@ export const SuspectNodesTooltip: React.FC<TooltipProps> = props => (
   </Tooltip>
 );
 
+export const DrainingNodesTooltip: React.FC<TooltipProps> = props => (
+  <Tooltip
+    {...props}
+    placement="bottom"
+    title={
+      <div className="tooltip__table--title">
+        <p>Node is draining.</p>
+      </div>
+    }
+  >
+    {props.children}
+  </Tooltip>
+);
+
 export const DeadNodesTooltip: React.FC<TooltipProps> = props => (
   <Tooltip
     {...props}

--- a/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/summaryBar.spec.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/summaryBar.spec.tsx
@@ -49,6 +49,7 @@ describe("<ClusterNodeTotals>", () => {
         suspect: 0,
         dead: 0,
         decommissioned: 0,
+        draining: 0,
       },
     };
   });
@@ -74,6 +75,7 @@ describe("<ClusterNodeTotals>", () => {
         suspect: 0,
         dead: 0,
         decommissioned: 0,
+        draining: 0,
       },
     });
     const wrapper = mount(component);
@@ -90,6 +92,7 @@ describe("<ClusterNodeTotals>", () => {
         suspect: 1,
         dead: 1,
         decommissioned: 0,
+        draining: 0,
       },
     });
     const wrapper = mount(component);


### PR DESCRIPTION
Previously, a draining node was being counted as
a dead node, which was misleading.
This commit separates a draining node as its own
value on the DB Console overview page.

Fixes #101488

<img width="1664" alt="Screenshot 2023-04-14 at 4 40 14 PM" src="https://user-images.githubusercontent.com/1017486/232151561-ea06c28d-20e9-4dbf-97b7-c89a0c229c76.png">

<img width="857" alt="Screenshot 2023-04-14 at 4 40 26 PM" src="https://user-images.githubusercontent.com/1017486/232151574-1be8ae02-cf7d-4b3a-81b9-0ca501b4d3f2.png">


Release note (ui change): Add draining node as its own value on the overview page of DB Console, instead of counting as a dead node.