### PR TITLE
colexechash: switch to operating with uint32 values

### DIFF
--- a/pkg/sql/colexec/aggregators_test.go
+++ b/pkg/sql/colexec/aggregators_test.go
@@ -836,7 +836,7 @@ func TestAggregators(t *testing.T) {
 						ConstArguments: constArguments,
 						OutputTypes:    outputTypes,
 					}
-					args.TestingKnobs.HashTableNumBuckets = uint64(1 + rng.Intn(7))
+					args.TestingKnobs.HashTableNumBuckets = uint32(1 + rng.Intn(7))
 					return agg.new(ctx, args), nil
 				})
 		}
@@ -965,7 +965,7 @@ func TestAggregatorRandom(t *testing.T) {
 						ConstArguments: constArguments,
 						OutputTypes:    outputTypes,
 					}
-					args.TestingKnobs.HashTableNumBuckets = uint64(1 + rng.Intn(31))
+					args.TestingKnobs.HashTableNumBuckets = uint32(1 + rng.Intn(31))
 					a := agg.new(context.Background(), args)
 					a.Init(context.Background())
 

--- a/pkg/sql/colexec/colexecagg/aggregators_util.go
+++ b/pkg/sql/colexec/colexecagg/aggregators_util.go
@@ -40,7 +40,7 @@ type NewAggregatorArgs struct {
 		// HashTableNumBuckets if positive will override the initial number of
 		// buckets to be used by the hash table (if this struct is passed to the
 		// hash aggregator).
-		HashTableNumBuckets uint64
+		HashTableNumBuckets uint32
 	}
 }
 

--- a/pkg/sql/colexec/colexecdisk/external_hash_joiner.go
+++ b/pkg/sql/colexec/colexecdisk/external_hash_joiner.go
@@ -93,7 +93,7 @@ func NewExternalHashJoiner(
 			RightSource:              partitionedInputs[1],
 			// We start with relatively large initial number of buckets since we
 			// expect each partition to be of significant size.
-			InitialNumBuckets: uint64(coldata.BatchSize()),
+			InitialNumBuckets: uint32(coldata.BatchSize()),
 		})
 	}
 	diskBackedFallbackOpConstructor := func(

--- a/pkg/sql/colexec/colexechash/hash_utils.eg.go
+++ b/pkg/sql/colexec/colexechash/hash_utils.eg.go
@@ -42,6 +42,1066 @@ var (
 // column values) at a given column and computes a new hash by applying a
 // transformation to the existing hash.
 func rehash(
+	buckets []uint32,
+	col coldata.Vec,
+	nKeys int,
+	sel []int,
+	cancelChecker colexecutils.CancelChecker,
+	datumAlloc *tree.DatumAlloc,
+) {
+	switch col.CanonicalTypeFamily() {
+	case types.BoolFamily:
+		switch col.Type().Width() {
+		case -1:
+		default:
+			keys, nulls := col.Bool(), col.Nulls()
+			if col.MaybeHasNulls() {
+				if sel != nil {
+					// Early bounds checks.
+					_ = buckets[nKeys-1]
+					_ = sel[nKeys-1]
+					var selIdx int
+					for i := 0; i < nKeys; i++ {
+						//gcassert:bce
+						selIdx = sel[i]
+						if nulls.NullAt(selIdx) {
+							continue
+						}
+						v := keys.Get(selIdx)
+						//gcassert:bce
+						p := uintptr(buckets[i])
+
+						x := 0
+						if v {
+							x = 1
+						}
+						p = p*31 + uintptr(x)
+
+						//gcassert:bce
+						buckets[i] = uint32(p)
+					}
+				} else {
+					// Early bounds checks.
+					_ = buckets[nKeys-1]
+					_ = keys.Get(nKeys - 1)
+					var selIdx int
+					for i := 0; i < nKeys; i++ {
+						selIdx = i
+						if nulls.NullAt(selIdx) {
+							continue
+						}
+						//gcassert:bce
+						v := keys.Get(selIdx)
+						//gcassert:bce
+						p := uintptr(buckets[i])
+
+						x := 0
+						if v {
+							x = 1
+						}
+						p = p*31 + uintptr(x)
+
+						//gcassert:bce
+						buckets[i] = uint32(p)
+					}
+				}
+			} else {
+				if sel != nil {
+					// Early bounds checks.
+					_ = buckets[nKeys-1]
+					_ = sel[nKeys-1]
+					var selIdx int
+					for i := 0; i < nKeys; i++ {
+						//gcassert:bce
+						selIdx = sel[i]
+						v := keys.Get(selIdx)
+						//gcassert:bce
+						p := uintptr(buckets[i])
+
+						x := 0
+						if v {
+							x = 1
+						}
+						p = p*31 + uintptr(x)
+
+						//gcassert:bce
+						buckets[i] = uint32(p)
+					}
+				} else {
+					// Early bounds checks.
+					_ = buckets[nKeys-1]
+					_ = keys.Get(nKeys - 1)
+					var selIdx int
+					for i := 0; i < nKeys; i++ {
+						selIdx = i
+						//gcassert:bce
+						v := keys.Get(selIdx)
+						//gcassert:bce
+						p := uintptr(buckets[i])
+
+						x := 0
+						if v {
+							x = 1
+						}
+						p = p*31 + uintptr(x)
+
+						//gcassert:bce
+						buckets[i] = uint32(p)
+					}
+				}
+			}
+		}
+	case types.BytesFamily:
+		switch col.Type().Width() {
+		case -1:
+		default:
+			keys, nulls := col.Bytes(), col.Nulls()
+			if col.MaybeHasNulls() {
+				if sel != nil {
+					// Early bounds checks.
+					_ = buckets[nKeys-1]
+					_ = sel[nKeys-1]
+					var selIdx int
+					for i := 0; i < nKeys; i++ {
+						//gcassert:bce
+						selIdx = sel[i]
+						if nulls.NullAt(selIdx) {
+							continue
+						}
+						v := keys.Get(selIdx)
+						//gcassert:bce
+						p := uintptr(buckets[i])
+
+						sh := (*reflect.SliceHeader)(unsafe.Pointer(&v))
+						p = memhash(unsafe.Pointer(sh.Data), p, uintptr(len(v)))
+
+						//gcassert:bce
+						buckets[i] = uint32(p)
+					}
+				} else {
+					// Early bounds checks.
+					_ = buckets[nKeys-1]
+					var selIdx int
+					for i := 0; i < nKeys; i++ {
+						selIdx = i
+						if nulls.NullAt(selIdx) {
+							continue
+						}
+						v := keys.Get(selIdx)
+						//gcassert:bce
+						p := uintptr(buckets[i])
+
+						sh := (*reflect.SliceHeader)(unsafe.Pointer(&v))
+						p = memhash(unsafe.Pointer(sh.Data), p, uintptr(len(v)))
+
+						//gcassert:bce
+						buckets[i] = uint32(p)
+					}
+				}
+			} else {
+				if sel != nil {
+					// Early bounds checks.
+					_ = buckets[nKeys-1]
+					_ = sel[nKeys-1]
+					var selIdx int
+					for i := 0; i < nKeys; i++ {
+						//gcassert:bce
+						selIdx = sel[i]
+						v := keys.Get(selIdx)
+						//gcassert:bce
+						p := uintptr(buckets[i])
+
+						sh := (*reflect.SliceHeader)(unsafe.Pointer(&v))
+						p = memhash(unsafe.Pointer(sh.Data), p, uintptr(len(v)))
+
+						//gcassert:bce
+						buckets[i] = uint32(p)
+					}
+				} else {
+					// Early bounds checks.
+					_ = buckets[nKeys-1]
+					var selIdx int
+					for i := 0; i < nKeys; i++ {
+						selIdx = i
+						v := keys.Get(selIdx)
+						//gcassert:bce
+						p := uintptr(buckets[i])
+
+						sh := (*reflect.SliceHeader)(unsafe.Pointer(&v))
+						p = memhash(unsafe.Pointer(sh.Data), p, uintptr(len(v)))
+
+						//gcassert:bce
+						buckets[i] = uint32(p)
+					}
+				}
+			}
+		}
+	case types.DecimalFamily:
+		switch col.Type().Width() {
+		case -1:
+		default:
+			keys, nulls := col.Decimal(), col.Nulls()
+			if col.MaybeHasNulls() {
+				if sel != nil {
+					// Early bounds checks.
+					_ = buckets[nKeys-1]
+					_ = sel[nKeys-1]
+					var selIdx int
+					for i := 0; i < nKeys; i++ {
+						//gcassert:bce
+						selIdx = sel[i]
+						if nulls.NullAt(selIdx) {
+							continue
+						}
+						v := keys.Get(selIdx)
+						//gcassert:bce
+						p := uintptr(buckets[i])
+
+						// In order for equal decimals to hash to the same value we need to
+						// remove the trailing zeroes if there are any.
+						var tmpDec apd.Decimal //gcassert:noescape
+						tmpDec.Reduce(&v)
+						b := []byte(tmpDec.String())
+						sh := (*reflect.SliceHeader)(unsafe.Pointer(&b))
+						p = memhash(unsafe.Pointer(sh.Data), p, uintptr(len(b)))
+
+						//gcassert:bce
+						buckets[i] = uint32(p)
+					}
+				} else {
+					// Early bounds checks.
+					_ = buckets[nKeys-1]
+					_ = keys.Get(nKeys - 1)
+					var selIdx int
+					for i := 0; i < nKeys; i++ {
+						selIdx = i
+						if nulls.NullAt(selIdx) {
+							continue
+						}
+						//gcassert:bce
+						v := keys.Get(selIdx)
+						//gcassert:bce
+						p := uintptr(buckets[i])
+
+						// In order for equal decimals to hash to the same value we need to
+						// remove the trailing zeroes if there are any.
+						var tmpDec apd.Decimal //gcassert:noescape
+						tmpDec.Reduce(&v)
+						b := []byte(tmpDec.String())
+						sh := (*reflect.SliceHeader)(unsafe.Pointer(&b))
+						p = memhash(unsafe.Pointer(sh.Data), p, uintptr(len(b)))
+
+						//gcassert:bce
+						buckets[i] = uint32(p)
+					}
+				}
+			} else {
+				if sel != nil {
+					// Early bounds checks.
+					_ = buckets[nKeys-1]
+					_ = sel[nKeys-1]
+					var selIdx int
+					for i := 0; i < nKeys; i++ {
+						//gcassert:bce
+						selIdx = sel[i]
+						v := keys.Get(selIdx)
+						//gcassert:bce
+						p := uintptr(buckets[i])
+
+						// In order for equal decimals to hash to the same value we need to
+						// remove the trailing zeroes if there are any.
+						var tmpDec apd.Decimal //gcassert:noescape
+						tmpDec.Reduce(&v)
+						b := []byte(tmpDec.String())
+						sh := (*reflect.SliceHeader)(unsafe.Pointer(&b))
+						p = memhash(unsafe.Pointer(sh.Data), p, uintptr(len(b)))
+
+						//gcassert:bce
+						buckets[i] = uint32(p)
+					}
+				} else {
+					// Early bounds checks.
+					_ = buckets[nKeys-1]
+					_ = keys.Get(nKeys - 1)
+					var selIdx int
+					for i := 0; i < nKeys; i++ {
+						selIdx = i
+						//gcassert:bce
+						v := keys.Get(selIdx)
+						//gcassert:bce
+						p := uintptr(buckets[i])
+
+						// In order for equal decimals to hash to the same value we need to
+						// remove the trailing zeroes if there are any.
+						var tmpDec apd.Decimal //gcassert:noescape
+						tmpDec.Reduce(&v)
+						b := []byte(tmpDec.String())
+						sh := (*reflect.SliceHeader)(unsafe.Pointer(&b))
+						p = memhash(unsafe.Pointer(sh.Data), p, uintptr(len(b)))
+
+						//gcassert:bce
+						buckets[i] = uint32(p)
+					}
+				}
+			}
+		}
+	case types.IntFamily:
+		switch col.Type().Width() {
+		case 16:
+			keys, nulls := col.Int16(), col.Nulls()
+			if col.MaybeHasNulls() {
+				if sel != nil {
+					// Early bounds checks.
+					_ = buckets[nKeys-1]
+					_ = sel[nKeys-1]
+					var selIdx int
+					for i := 0; i < nKeys; i++ {
+						//gcassert:bce
+						selIdx = sel[i]
+						if nulls.NullAt(selIdx) {
+							continue
+						}
+						v := keys.Get(selIdx)
+						//gcassert:bce
+						p := uintptr(buckets[i])
+
+						// In order for integers with different widths but of the same value to
+						// to hash to the same value, we upcast all of them to int64.
+						asInt64 := int64(v)
+						p = memhash64(noescape(unsafe.Pointer(&asInt64)), p)
+						//gcassert:bce
+						buckets[i] = uint32(p)
+					}
+				} else {
+					// Early bounds checks.
+					_ = buckets[nKeys-1]
+					_ = keys.Get(nKeys - 1)
+					var selIdx int
+					for i := 0; i < nKeys; i++ {
+						selIdx = i
+						if nulls.NullAt(selIdx) {
+							continue
+						}
+						//gcassert:bce
+						v := keys.Get(selIdx)
+						//gcassert:bce
+						p := uintptr(buckets[i])
+
+						// In order for integers with different widths but of the same value to
+						// to hash to the same value, we upcast all of them to int64.
+						asInt64 := int64(v)
+						p = memhash64(noescape(unsafe.Pointer(&asInt64)), p)
+						//gcassert:bce
+						buckets[i] = uint32(p)
+					}
+				}
+			} else {
+				if sel != nil {
+					// Early bounds checks.
+					_ = buckets[nKeys-1]
+					_ = sel[nKeys-1]
+					var selIdx int
+					for i := 0; i < nKeys; i++ {
+						//gcassert:bce
+						selIdx = sel[i]
+						v := keys.Get(selIdx)
+						//gcassert:bce
+						p := uintptr(buckets[i])
+
+						// In order for integers with different widths but of the same value to
+						// to hash to the same value, we upcast all of them to int64.
+						asInt64 := int64(v)
+						p = memhash64(noescape(unsafe.Pointer(&asInt64)), p)
+						//gcassert:bce
+						buckets[i] = uint32(p)
+					}
+				} else {
+					// Early bounds checks.
+					_ = buckets[nKeys-1]
+					_ = keys.Get(nKeys - 1)
+					var selIdx int
+					for i := 0; i < nKeys; i++ {
+						selIdx = i
+						//gcassert:bce
+						v := keys.Get(selIdx)
+						//gcassert:bce
+						p := uintptr(buckets[i])
+
+						// In order for integers with different widths but of the same value to
+						// to hash to the same value, we upcast all of them to int64.
+						asInt64 := int64(v)
+						p = memhash64(noescape(unsafe.Pointer(&asInt64)), p)
+						//gcassert:bce
+						buckets[i] = uint32(p)
+					}
+				}
+			}
+		case 32:
+			keys, nulls := col.Int32(), col.Nulls()
+			if col.MaybeHasNulls() {
+				if sel != nil {
+					// Early bounds checks.
+					_ = buckets[nKeys-1]
+					_ = sel[nKeys-1]
+					var selIdx int
+					for i := 0; i < nKeys; i++ {
+						//gcassert:bce
+						selIdx = sel[i]
+						if nulls.NullAt(selIdx) {
+							continue
+						}
+						v := keys.Get(selIdx)
+						//gcassert:bce
+						p := uintptr(buckets[i])
+
+						// In order for integers with different widths but of the same value to
+						// to hash to the same value, we upcast all of them to int64.
+						asInt64 := int64(v)
+						p = memhash64(noescape(unsafe.Pointer(&asInt64)), p)
+						//gcassert:bce
+						buckets[i] = uint32(p)
+					}
+				} else {
+					// Early bounds checks.
+					_ = buckets[nKeys-1]
+					_ = keys.Get(nKeys - 1)
+					var selIdx int
+					for i := 0; i < nKeys; i++ {
+						selIdx = i
+						if nulls.NullAt(selIdx) {
+							continue
+						}
+						//gcassert:bce
+						v := keys.Get(selIdx)
+						//gcassert:bce
+						p := uintptr(buckets[i])
+
+						// In order for integers with different widths but of the same value to
+						// to hash to the same value, we upcast all of them to int64.
+						asInt64 := int64(v)
+						p = memhash64(noescape(unsafe.Pointer(&asInt64)), p)
+						//gcassert:bce
+						buckets[i] = uint32(p)
+					}
+				}
+			} else {
+				if sel != nil {
+					// Early bounds checks.
+					_ = buckets[nKeys-1]
+					_ = sel[nKeys-1]
+					var selIdx int
+					for i := 0; i < nKeys; i++ {
+						//gcassert:bce
+						selIdx = sel[i]
+						v := keys.Get(selIdx)
+						//gcassert:bce
+						p := uintptr(buckets[i])
+
+						// In order for integers with different widths but of the same value to
+						// to hash to the same value, we upcast all of them to int64.
+						asInt64 := int64(v)
+						p = memhash64(noescape(unsafe.Pointer(&asInt64)), p)
+						//gcassert:bce
+						buckets[i] = uint32(p)
+					}
+				} else {
+					// Early bounds checks.
+					_ = buckets[nKeys-1]
+					_ = keys.Get(nKeys - 1)
+					var selIdx int
+					for i := 0; i < nKeys; i++ {
+						selIdx = i
+						//gcassert:bce
+						v := keys.Get(selIdx)
+						//gcassert:bce
+						p := uintptr(buckets[i])
+
+						// In order for integers with different widths but of the same value to
+						// to hash to the same value, we upcast all of them to int64.
+						asInt64 := int64(v)
+						p = memhash64(noescape(unsafe.Pointer(&asInt64)), p)
+						//gcassert:bce
+						buckets[i] = uint32(p)
+					}
+				}
+			}
+		case -1:
+		default:
+			keys, nulls := col.Int64(), col.Nulls()
+			if col.MaybeHasNulls() {
+				if sel != nil {
+					// Early bounds checks.
+					_ = buckets[nKeys-1]
+					_ = sel[nKeys-1]
+					var selIdx int
+					for i := 0; i < nKeys; i++ {
+						//gcassert:bce
+						selIdx = sel[i]
+						if nulls.NullAt(selIdx) {
+							continue
+						}
+						v := keys.Get(selIdx)
+						//gcassert:bce
+						p := uintptr(buckets[i])
+
+						// In order for integers with different widths but of the same value to
+						// to hash to the same value, we upcast all of them to int64.
+						asInt64 := int64(v)
+						p = memhash64(noescape(unsafe.Pointer(&asInt64)), p)
+						//gcassert:bce
+						buckets[i] = uint32(p)
+					}
+				} else {
+					// Early bounds checks.
+					_ = buckets[nKeys-1]
+					_ = keys.Get(nKeys - 1)
+					var selIdx int
+					for i := 0; i < nKeys; i++ {
+						selIdx = i
+						if nulls.NullAt(selIdx) {
+							continue
+						}
+						//gcassert:bce
+						v := keys.Get(selIdx)
+						//gcassert:bce
+						p := uintptr(buckets[i])
+
+						// In order for integers with different widths but of the same value to
+						// to hash to the same value, we upcast all of them to int64.
+						asInt64 := int64(v)
+						p = memhash64(noescape(unsafe.Pointer(&asInt64)), p)
+						//gcassert:bce
+						buckets[i] = uint32(p)
+					}
+				}
+			} else {
+				if sel != nil {
+					// Early bounds checks.
+					_ = buckets[nKeys-1]
+					_ = sel[nKeys-1]
+					var selIdx int
+					for i := 0; i < nKeys; i++ {
+						//gcassert:bce
+						selIdx = sel[i]
+						v := keys.Get(selIdx)
+						//gcassert:bce
+						p := uintptr(buckets[i])
+
+						// In order for integers with different widths but of the same value to
+						// to hash to the same value, we upcast all of them to int64.
+						asInt64 := int64(v)
+						p = memhash64(noescape(unsafe.Pointer(&asInt64)), p)
+						//gcassert:bce
+						buckets[i] = uint32(p)
+					}
+				} else {
+					// Early bounds checks.
+					_ = buckets[nKeys-1]
+					_ = keys.Get(nKeys - 1)
+					var selIdx int
+					for i := 0; i < nKeys; i++ {
+						selIdx = i
+						//gcassert:bce
+						v := keys.Get(selIdx)
+						//gcassert:bce
+						p := uintptr(buckets[i])
+
+						// In order for integers with different widths but of the same value to
+						// to hash to the same value, we upcast all of them to int64.
+						asInt64 := int64(v)
+						p = memhash64(noescape(unsafe.Pointer(&asInt64)), p)
+						//gcassert:bce
+						buckets[i] = uint32(p)
+					}
+				}
+			}
+		}
+	case types.FloatFamily:
+		switch col.Type().Width() {
+		case -1:
+		default:
+			keys, nulls := col.Float64(), col.Nulls()
+			if col.MaybeHasNulls() {
+				if sel != nil {
+					// Early bounds checks.
+					_ = buckets[nKeys-1]
+					_ = sel[nKeys-1]
+					var selIdx int
+					for i := 0; i < nKeys; i++ {
+						//gcassert:bce
+						selIdx = sel[i]
+						if nulls.NullAt(selIdx) {
+							continue
+						}
+						v := keys.Get(selIdx)
+						//gcassert:bce
+						p := uintptr(buckets[i])
+
+						f := v
+						if math.IsNaN(float64(f)) {
+							f = 0
+						}
+						p = f64hash(noescape(unsafe.Pointer(&f)), p)
+
+						//gcassert:bce
+						buckets[i] = uint32(p)
+					}
+				} else {
+					// Early bounds checks.
+					_ = buckets[nKeys-1]
+					_ = keys.Get(nKeys - 1)
+					var selIdx int
+					for i := 0; i < nKeys; i++ {
+						selIdx = i
+						if nulls.NullAt(selIdx) {
+							continue
+						}
+						//gcassert:bce
+						v := keys.Get(selIdx)
+						//gcassert:bce
+						p := uintptr(buckets[i])
+
+						f := v
+						if math.IsNaN(float64(f)) {
+							f = 0
+						}
+						p = f64hash(noescape(unsafe.Pointer(&f)), p)
+
+						//gcassert:bce
+						buckets[i] = uint32(p)
+					}
+				}
+			} else {
+				if sel != nil {
+					// Early bounds checks.
+					_ = buckets[nKeys-1]
+					_ = sel[nKeys-1]
+					var selIdx int
+					for i := 0; i < nKeys; i++ {
+						//gcassert:bce
+						selIdx = sel[i]
+						v := keys.Get(selIdx)
+						//gcassert:bce
+						p := uintptr(buckets[i])
+
+						f := v
+						if math.IsNaN(float64(f)) {
+							f = 0
+						}
+						p = f64hash(noescape(unsafe.Pointer(&f)), p)
+
+						//gcassert:bce
+						buckets[i] = uint32(p)
+					}
+				} else {
+					// Early bounds checks.
+					_ = buckets[nKeys-1]
+					_ = keys.Get(nKeys - 1)
+					var selIdx int
+					for i := 0; i < nKeys; i++ {
+						selIdx = i
+						//gcassert:bce
+						v := keys.Get(selIdx)
+						//gcassert:bce
+						p := uintptr(buckets[i])
+
+						f := v
+						if math.IsNaN(float64(f)) {
+							f = 0
+						}
+						p = f64hash(noescape(unsafe.Pointer(&f)), p)
+
+						//gcassert:bce
+						buckets[i] = uint32(p)
+					}
+				}
+			}
+		}
+	case types.TimestampTZFamily:
+		switch col.Type().Width() {
+		case -1:
+		default:
+			keys, nulls := col.Timestamp(), col.Nulls()
+			if col.MaybeHasNulls() {
+				if sel != nil {
+					// Early bounds checks.
+					_ = buckets[nKeys-1]
+					_ = sel[nKeys-1]
+					var selIdx int
+					for i := 0; i < nKeys; i++ {
+						//gcassert:bce
+						selIdx = sel[i]
+						if nulls.NullAt(selIdx) {
+							continue
+						}
+						v := keys.Get(selIdx)
+						//gcassert:bce
+						p := uintptr(buckets[i])
+
+						s := v.UnixNano()
+						p = memhash64(noescape(unsafe.Pointer(&s)), p)
+
+						//gcassert:bce
+						buckets[i] = uint32(p)
+					}
+				} else {
+					// Early bounds checks.
+					_ = buckets[nKeys-1]
+					_ = keys.Get(nKeys - 1)
+					var selIdx int
+					for i := 0; i < nKeys; i++ {
+						selIdx = i
+						if nulls.NullAt(selIdx) {
+							continue
+						}
+						//gcassert:bce
+						v := keys.Get(selIdx)
+						//gcassert:bce
+						p := uintptr(buckets[i])
+
+						s := v.UnixNano()
+						p = memhash64(noescape(unsafe.Pointer(&s)), p)
+
+						//gcassert:bce
+						buckets[i] = uint32(p)
+					}
+				}
+			} else {
+				if sel != nil {
+					// Early bounds checks.
+					_ = buckets[nKeys-1]
+					_ = sel[nKeys-1]
+					var selIdx int
+					for i := 0; i < nKeys; i++ {
+						//gcassert:bce
+						selIdx = sel[i]
+						v := keys.Get(selIdx)
+						//gcassert:bce
+						p := uintptr(buckets[i])
+
+						s := v.UnixNano()
+						p = memhash64(noescape(unsafe.Pointer(&s)), p)
+
+						//gcassert:bce
+						buckets[i] = uint32(p)
+					}
+				} else {
+					// Early bounds checks.
+					_ = buckets[nKeys-1]
+					_ = keys.Get(nKeys - 1)
+					var selIdx int
+					for i := 0; i < nKeys; i++ {
+						selIdx = i
+						//gcassert:bce
+						v := keys.Get(selIdx)
+						//gcassert:bce
+						p := uintptr(buckets[i])
+
+						s := v.UnixNano()
+						p = memhash64(noescape(unsafe.Pointer(&s)), p)
+
+						//gcassert:bce
+						buckets[i] = uint32(p)
+					}
+				}
+			}
+		}
+	case types.IntervalFamily:
+		switch col.Type().Width() {
+		case -1:
+		default:
+			keys, nulls := col.Interval(), col.Nulls()
+			if col.MaybeHasNulls() {
+				if sel != nil {
+					// Early bounds checks.
+					_ = buckets[nKeys-1]
+					_ = sel[nKeys-1]
+					var selIdx int
+					for i := 0; i < nKeys; i++ {
+						//gcassert:bce
+						selIdx = sel[i]
+						if nulls.NullAt(selIdx) {
+							continue
+						}
+						v := keys.Get(selIdx)
+						//gcassert:bce
+						p := uintptr(buckets[i])
+
+						months, days, nanos := v.Months, v.Days, v.Nanos()
+						p = memhash64(noescape(unsafe.Pointer(&months)), p)
+						p = memhash64(noescape(unsafe.Pointer(&days)), p)
+						p = memhash64(noescape(unsafe.Pointer(&nanos)), p)
+
+						//gcassert:bce
+						buckets[i] = uint32(p)
+					}
+				} else {
+					// Early bounds checks.
+					_ = buckets[nKeys-1]
+					_ = keys.Get(nKeys - 1)
+					var selIdx int
+					for i := 0; i < nKeys; i++ {
+						selIdx = i
+						if nulls.NullAt(selIdx) {
+							continue
+						}
+						//gcassert:bce
+						v := keys.Get(selIdx)
+						//gcassert:bce
+						p := uintptr(buckets[i])
+
+						months, days, nanos := v.Months, v.Days, v.Nanos()
+						p = memhash64(noescape(unsafe.Pointer(&months)), p)
+						p = memhash64(noescape(unsafe.Pointer(&days)), p)
+						p = memhash64(noescape(unsafe.Pointer(&nanos)), p)
+
+						//gcassert:bce
+						buckets[i] = uint32(p)
+					}
+				}
+			} else {
+				if sel != nil {
+					// Early bounds checks.
+					_ = buckets[nKeys-1]
+					_ = sel[nKeys-1]
+					var selIdx int
+					for i := 0; i < nKeys; i++ {
+						//gcassert:bce
+						selIdx = sel[i]
+						v := keys.Get(selIdx)
+						//gcassert:bce
+						p := uintptr(buckets[i])
+
+						months, days, nanos := v.Months, v.Days, v.Nanos()
+						p = memhash64(noescape(unsafe.Pointer(&months)), p)
+						p = memhash64(noescape(unsafe.Pointer(&days)), p)
+						p = memhash64(noescape(unsafe.Pointer(&nanos)), p)
+
+						//gcassert:bce
+						buckets[i] = uint32(p)
+					}
+				} else {
+					// Early bounds checks.
+					_ = buckets[nKeys-1]
+					_ = keys.Get(nKeys - 1)
+					var selIdx int
+					for i := 0; i < nKeys; i++ {
+						selIdx = i
+						//gcassert:bce
+						v := keys.Get(selIdx)
+						//gcassert:bce
+						p := uintptr(buckets[i])
+
+						months, days, nanos := v.Months, v.Days, v.Nanos()
+						p = memhash64(noescape(unsafe.Pointer(&months)), p)
+						p = memhash64(noescape(unsafe.Pointer(&days)), p)
+						p = memhash64(noescape(unsafe.Pointer(&nanos)), p)
+
+						//gcassert:bce
+						buckets[i] = uint32(p)
+					}
+				}
+			}
+		}
+	case types.JsonFamily:
+		switch col.Type().Width() {
+		case -1:
+		default:
+			keys, nulls := col.JSON(), col.Nulls()
+			if col.MaybeHasNulls() {
+				if sel != nil {
+					// Early bounds checks.
+					_ = buckets[nKeys-1]
+					_ = sel[nKeys-1]
+					var selIdx int
+					for i := 0; i < nKeys; i++ {
+						//gcassert:bce
+						selIdx = sel[i]
+						if nulls.NullAt(selIdx) {
+							continue
+						}
+						//gcassert:bce
+						p := uintptr(buckets[i])
+
+						// Access the underlying []byte directly which allows us to skip
+						// decoding-encoding of the JSON object.
+						_b := keys.Bytes.Get(selIdx)
+
+						sh := (*reflect.SliceHeader)(unsafe.Pointer(&_b))
+						p = memhash(unsafe.Pointer(sh.Data), p, uintptr(len(_b)))
+
+						//gcassert:bce
+						buckets[i] = uint32(p)
+					}
+				} else {
+					// Early bounds checks.
+					_ = buckets[nKeys-1]
+					var selIdx int
+					for i := 0; i < nKeys; i++ {
+						selIdx = i
+						if nulls.NullAt(selIdx) {
+							continue
+						}
+						//gcassert:bce
+						p := uintptr(buckets[i])
+
+						// Access the underlying []byte directly which allows us to skip
+						// decoding-encoding of the JSON object.
+						_b := keys.Bytes.Get(selIdx)
+
+						sh := (*reflect.SliceHeader)(unsafe.Pointer(&_b))
+						p = memhash(unsafe.Pointer(sh.Data), p, uintptr(len(_b)))
+
+						//gcassert:bce
+						buckets[i] = uint32(p)
+					}
+				}
+			} else {
+				if sel != nil {
+					// Early bounds checks.
+					_ = buckets[nKeys-1]
+					_ = sel[nKeys-1]
+					var selIdx int
+					for i := 0; i < nKeys; i++ {
+						//gcassert:bce
+						selIdx = sel[i]
+						//gcassert:bce
+						p := uintptr(buckets[i])
+
+						// Access the underlying []byte directly which allows us to skip
+						// decoding-encoding of the JSON object.
+						_b := keys.Bytes.Get(selIdx)
+
+						sh := (*reflect.SliceHeader)(unsafe.Pointer(&_b))
+						p = memhash(unsafe.Pointer(sh.Data), p, uintptr(len(_b)))
+
+						//gcassert:bce
+						buckets[i] = uint32(p)
+					}
+				} else {
+					// Early bounds checks.
+					_ = buckets[nKeys-1]
+					var selIdx int
+					for i := 0; i < nKeys; i++ {
+						selIdx = i
+						//gcassert:bce
+						p := uintptr(buckets[i])
+
+						// Access the underlying []byte directly which allows us to skip
+						// decoding-encoding of the JSON object.
+						_b := keys.Bytes.Get(selIdx)
+
+						sh := (*reflect.SliceHeader)(unsafe.Pointer(&_b))
+						p = memhash(unsafe.Pointer(sh.Data), p, uintptr(len(_b)))
+
+						//gcassert:bce
+						buckets[i] = uint32(p)
+					}
+				}
+			}
+		}
+	case typeconv.DatumVecCanonicalTypeFamily:
+		switch col.Type().Width() {
+		case -1:
+		default:
+			keys, nulls := col.Datum(), col.Nulls()
+			if col.MaybeHasNulls() {
+				if sel != nil {
+					// Early bounds checks.
+					_ = buckets[nKeys-1]
+					_ = sel[nKeys-1]
+					var selIdx int
+					for i := 0; i < nKeys; i++ {
+						//gcassert:bce
+						selIdx = sel[i]
+						if nulls.NullAt(selIdx) {
+							continue
+						}
+						v := keys.Get(selIdx)
+						//gcassert:bce
+						p := uintptr(buckets[i])
+						b := coldataext.Hash(v.(tree.Datum), datumAlloc)
+						sh := (*reflect.SliceHeader)(unsafe.Pointer(&b))
+						p = memhash(unsafe.Pointer(sh.Data), p, uintptr(len(b)))
+
+						//gcassert:bce
+						buckets[i] = uint32(p)
+					}
+				} else {
+					// Early bounds checks.
+					_ = buckets[nKeys-1]
+					var selIdx int
+					for i := 0; i < nKeys; i++ {
+						selIdx = i
+						if nulls.NullAt(selIdx) {
+							continue
+						}
+						v := keys.Get(selIdx)
+						//gcassert:bce
+						p := uintptr(buckets[i])
+						b := coldataext.Hash(v.(tree.Datum), datumAlloc)
+						sh := (*reflect.SliceHeader)(unsafe.Pointer(&b))
+						p = memhash(unsafe.Pointer(sh.Data), p, uintptr(len(b)))
+
+						//gcassert:bce
+						buckets[i] = uint32(p)
+					}
+				}
+			} else {
+				if sel != nil {
+					// Early bounds checks.
+					_ = buckets[nKeys-1]
+					_ = sel[nKeys-1]
+					var selIdx int
+					for i := 0; i < nKeys; i++ {
+						//gcassert:bce
+						selIdx = sel[i]
+						v := keys.Get(selIdx)
+						//gcassert:bce
+						p := uintptr(buckets[i])
+						b := coldataext.Hash(v.(tree.Datum), datumAlloc)
+						sh := (*reflect.SliceHeader)(unsafe.Pointer(&b))
+						p = memhash(unsafe.Pointer(sh.Data), p, uintptr(len(b)))
+
+						//gcassert:bce
+						buckets[i] = uint32(p)
+					}
+				} else {
+					// Early bounds checks.
+					_ = buckets[nKeys-1]
+					var selIdx int
+					for i := 0; i < nKeys; i++ {
+						selIdx = i
+						v := keys.Get(selIdx)
+						//gcassert:bce
+						p := uintptr(buckets[i])
+						b := coldataext.Hash(v.(tree.Datum), datumAlloc)
+						sh := (*reflect.SliceHeader)(unsafe.Pointer(&b))
+						p = memhash(unsafe.Pointer(sh.Data), p, uintptr(len(b)))
+
+						//gcassert:bce
+						buckets[i] = uint32(p)
+					}
+				}
+			}
+		}
+	default:
+		colexecerror.InternalError(errors.AssertionFailedf("unhandled type %s", col.Type()))
+	}
+	cancelChecker.CheckEveryCall()
+}
+
+// rehash64 takes an element of a key (tuple representing a row of equality
+// column values) at a given column and computes a new hash by applying a
+// transformation to the existing hash.
+//
+// Note that this function is a duplicate of rehash except that it works on
+// uint64s instead of uint32s. The function could be made generic, but that
+// incurs a small performance penalty because one of the arguments is an
+// interface.
+// TODO(yuzefovich): if / when we make coldata.Vec to no longer be an interface,
+// then we should remove the code duplication here.
+func rehash64(
 	buckets []uint64,
 	col coldata.Vec,
 	nKeys int,

--- a/pkg/sql/colexec/colexechash/hash_utils.go
+++ b/pkg/sql/colexec/colexechash/hash_utils.go
@@ -37,11 +37,19 @@ import (
 const DefaultInitHashValue = 1
 
 var (
+	uint32OneColumn []uint32
+	uint32TwoColumn []uint32
 	uint64OneColumn []uint64
 	uint64TwoColumn []uint64
 )
 
 func init() {
+	uint32OneColumn = make([]uint32, coldata.MaxBatchSize)
+	uint32TwoColumn = make([]uint32, coldata.MaxBatchSize)
+	for i := range uint32OneColumn {
+		uint32OneColumn[i] = 1
+		uint32TwoColumn[i] = 2
+	}
 	uint64OneColumn = make([]uint64, coldata.MaxBatchSize)
 	uint64TwoColumn = make([]uint64, coldata.MaxBatchSize)
 	for i := range uint64OneColumn {
@@ -59,7 +67,25 @@ func init() {
 // initHash initializes the hash value of each key to its initial state for
 // rehashing purposes.
 // NOTE: initValue *must* be non-zero and nKeys is assumed to be positive.
-func initHash(buckets []uint64, nKeys int, initValue uint64) {
+func initHash(buckets []uint32, nKeys int, initValue uint32) {
+	switch initValue {
+	case 1:
+		for n := 0; n < nKeys; n += copy(buckets[n:], uint32OneColumn) {
+		}
+	case 2:
+		for n := 0; n < nKeys; n += copy(buckets[n:], uint32TwoColumn) {
+		}
+	default:
+		// Early bounds checks.
+		_ = buckets[nKeys-1]
+		for i := 0; i < nKeys; i++ {
+			//gcassert:bce
+			buckets[i] = initValue
+		}
+	}
+}
+
+func initHash64(buckets []uint64, nKeys int, initValue uint64) {
 	switch initValue {
 	case 1:
 		for n := 0; n < nKeys; n += copy(buckets[n:], uint64OneColumn) {
@@ -80,7 +106,7 @@ func initHash(buckets []uint64, nKeys int, initValue uint64) {
 // finalizeHash takes each key's hash value and applies a final transformation
 // onto it so that it fits within numBuckets buckets.
 // NOTE: nKeys is assumed to be positive.
-func finalizeHash(buckets []uint64, nKeys int, numBuckets uint64) {
+func finalizeHash[T uint32 | uint64](buckets []T, nKeys int, numBuckets T) {
 	// Early bounds checks.
 	_ = buckets[nKeys-1]
 	isPowerOfTwo := numBuckets&(numBuckets-1) == 0
@@ -146,7 +172,7 @@ func (d *TupleHashDistributor) Distribute(b coldata.Batch, hashCols []uint32) []
 	} else {
 		d.buckets = d.buckets[:n]
 	}
-	initHash(d.buckets, n, d.InitHashValue)
+	initHash64(d.buckets, n, d.InitHashValue)
 
 	// Check if we received a batch with more tuples than the current
 	// allocation size and increase it if so.
@@ -155,7 +181,7 @@ func (d *TupleHashDistributor) Distribute(b coldata.Batch, hashCols []uint32) []
 	}
 
 	for _, i := range hashCols {
-		rehash(d.buckets, b.ColVec(int(i)), n, b.Selection(), d.cancelChecker, &d.datumAlloc)
+		rehash64(d.buckets, b.ColVec(int(i)), n, b.Selection(), d.cancelChecker, &d.datumAlloc)
 	}
 
 	finalizeHash(d.buckets, n, uint64(len(d.selections)))

--- a/pkg/sql/colexec/colexechash/hash_utils_test.go
+++ b/pkg/sql/colexec/colexechash/hash_utils_test.go
@@ -30,23 +30,23 @@ func TestHashFunctionFamily(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	bucketsA, bucketsB := make([]uint64, coldata.BatchSize()), make([]uint64, coldata.BatchSize())
+	bucketsA, bucketsB := make([]uint32, coldata.BatchSize()), make([]uint32, coldata.BatchSize())
 	nKeys := coldata.BatchSize()
 	keyTypes := []*types.T{types.Int}
 	keys := []coldata.Vec{testAllocator.NewMemColumn(keyTypes[0], coldata.BatchSize())}
 	for i := int64(0); i < int64(coldata.BatchSize()); i++ {
 		keys[0].Int64()[i] = i
 	}
-	numBuckets := uint64(16)
+	numBuckets := uint32(16)
 	var (
 		cancelChecker colexecutils.CancelChecker
 		datumAlloc    tree.DatumAlloc
 	)
 	cancelChecker.Init(context.Background())
 
-	for initHashValue, buckets := range [][]uint64{bucketsA, bucketsB} {
+	for initHashValue, buckets := range [][]uint32{bucketsA, bucketsB} {
 		// We need +1 here because 0 is not a valid initial hash value.
-		initHash(buckets, nKeys, uint64(initHashValue+1))
+		initHash(buckets, nKeys, uint32(initHashValue+1))
 		for _, keysCol := range keys {
 			rehash(buckets, keysCol, nKeys, nil /* sel */, cancelChecker, &datumAlloc)
 		}

--- a/pkg/sql/colexec/colexechash/hash_utils_tmpl.go
+++ b/pkg/sql/colexec/colexechash/hash_utils_tmpl.go
@@ -65,13 +65,14 @@ func _ASSIGN_HASH(_, _, _, _ interface{}) uint64 {
 
 // {{/*
 func _REHASH_BODY(
-	buckets []uint64,
+	buckets []uint32,
 	keys _GOTYPESLICE,
 	nulls *coldata.Nulls,
 	nKeys int,
 	sel []int,
 	_HAS_SEL bool,
 	_HAS_NULLS bool,
+	_UINT64 bool,
 ) { // */}}
 	// {{define "rehashBody" -}}
 	// Early bounds checks.
@@ -108,7 +109,11 @@ func _REHASH_BODY(
 		p := uintptr(buckets[i])
 		_ASSIGN_HASH(p, v, keys, selIdx)
 		//gcassert:bce
+		// {{if .Uint64}}
 		buckets[i] = uint64(p)
+		// {{else}}
+		buckets[i] = uint32(p)
+		// {{end}}
 	}
 	// {{end}}
 
@@ -121,6 +126,53 @@ func _REHASH_BODY(
 // column values) at a given column and computes a new hash by applying a
 // transformation to the existing hash.
 func rehash(
+	buckets []uint32,
+	col coldata.Vec,
+	nKeys int,
+	sel []int,
+	cancelChecker colexecutils.CancelChecker,
+	datumAlloc *tree.DatumAlloc,
+) {
+	switch col.CanonicalTypeFamily() {
+	// {{range .}}
+	case _CANONICAL_TYPE_FAMILY:
+		switch col.Type().Width() {
+		// {{range .WidthOverloads}}
+		case _TYPE_WIDTH:
+			keys, nulls := col.TemplateType(), col.Nulls()
+			if col.MaybeHasNulls() {
+				if sel != nil {
+					_REHASH_BODY(buckets, keys, nulls, nKeys, sel, true, true, false)
+				} else {
+					_REHASH_BODY(buckets, keys, nulls, nKeys, sel, false, true, false)
+				}
+			} else {
+				if sel != nil {
+					_REHASH_BODY(buckets, keys, nulls, nKeys, sel, true, false, false)
+				} else {
+					_REHASH_BODY(buckets, keys, nulls, nKeys, sel, false, false, false)
+				}
+			}
+			// {{end}}
+		}
+		// {{end}}
+	default:
+		colexecerror.InternalError(errors.AssertionFailedf("unhandled type %s", col.Type()))
+	}
+	cancelChecker.CheckEveryCall()
+}
+
+// rehash64 takes an element of a key (tuple representing a row of equality
+// column values) at a given column and computes a new hash by applying a
+// transformation to the existing hash.
+//
+// Note that this function is a duplicate of rehash except that it works on
+// uint64s instead of uint32s. The function could be made generic, but that
+// incurs a small performance penalty because one of the arguments is an
+// interface.
+// TODO(yuzefovich): if / when we make coldata.Vec to no longer be an interface,
+// then we should remove the code duplication here.
+func rehash64(
 	buckets []uint64,
 	col coldata.Vec,
 	nKeys int,
@@ -137,15 +189,15 @@ func rehash(
 			keys, nulls := col.TemplateType(), col.Nulls()
 			if col.MaybeHasNulls() {
 				if sel != nil {
-					_REHASH_BODY(buckets, keys, nulls, nKeys, sel, true, true)
+					_REHASH_BODY(buckets, keys, nulls, nKeys, sel, true, true, true)
 				} else {
-					_REHASH_BODY(buckets, keys, nulls, nKeys, sel, false, true)
+					_REHASH_BODY(buckets, keys, nulls, nKeys, sel, false, true, true)
 				}
 			} else {
 				if sel != nil {
-					_REHASH_BODY(buckets, keys, nulls, nKeys, sel, true, false)
+					_REHASH_BODY(buckets, keys, nulls, nKeys, sel, true, false, true)
 				} else {
-					_REHASH_BODY(buckets, keys, nulls, nKeys, sel, false, false)
+					_REHASH_BODY(buckets, keys, nulls, nKeys, sel, false, false, true)
 				}
 			}
 			// {{end}}

--- a/pkg/sql/colexec/colexechash/hashtable_distinct.eg.go
+++ b/pkg/sql/colexec/colexechash/hashtable_distinct.eg.go
@@ -35,7 +35,7 @@ var (
 // checkColAgainstItselfForDistinct is similar to checkCol, but it probes the
 // vector against itself for the purposes of finding matches to unordered
 // distinct columns.
-func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck uint64, sel []int) {
+func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck uint32, sel []int) {
 	probeVec, buildVec, probeSel := vec, vec, sel
 	switch probeVec.CanonicalTypeFamily() {
 	case types.BoolFamily:
@@ -3569,7 +3569,7 @@ func (ht *HashTable) checkColAgainstItselfForDistinct(vec coldata.Vec, nToCheck 
 }
 
 func (ht *HashTable) checkColForDistinctTuples(
-	probeVec, buildVec coldata.Vec, nToCheck uint64, probeSel []int,
+	probeVec, buildVec coldata.Vec, nToCheck uint32, probeSel []int,
 ) {
 	switch probeVec.CanonicalTypeFamily() {
 	case types.BoolFamily:
@@ -5426,15 +5426,15 @@ func (ht *HashTable) checkColForDistinctTuples(
 
 // CheckProbeForDistinct performs a column by column check for duplicated tuples
 // in the probe table.
-func (ht *HashTable) CheckProbeForDistinct(vecs []coldata.Vec, nToCheck uint64, sel []int) uint64 {
+func (ht *HashTable) CheckProbeForDistinct(vecs []coldata.Vec, nToCheck uint32, sel []int) uint32 {
 	for i := range ht.keyCols {
 		ht.checkColAgainstItselfForDistinct(vecs[i], nToCheck, sel)
 	}
-	nDiffers := uint64(0)
+	nDiffers := uint32(0)
 	if ht.allowNullEquality {
 		toCheckSlice := ht.ProbeScratch.ToCheck
 		_ = toCheckSlice[nToCheck-1]
-		for toCheckPos := uint64(0); toCheckPos < nToCheck && nDiffers < nToCheck; toCheckPos++ {
+		for toCheckPos := uint32(0); toCheckPos < nToCheck && nDiffers < nToCheck; toCheckPos++ {
 			//gcassert:bce
 			toCheck := toCheckSlice[toCheckPos]
 			if !ht.ProbeScratch.differs[toCheck] {
@@ -5450,7 +5450,7 @@ func (ht *HashTable) CheckProbeForDistinct(vecs []coldata.Vec, nToCheck uint64, 
 	} else {
 		toCheckSlice := ht.ProbeScratch.ToCheck
 		_ = toCheckSlice[nToCheck-1]
-		for toCheckPos := uint64(0); toCheckPos < nToCheck && nDiffers < nToCheck; toCheckPos++ {
+		for toCheckPos := uint32(0); toCheckPos < nToCheck && nDiffers < nToCheck; toCheckPos++ {
 			//gcassert:bce
 			toCheck := toCheckSlice[toCheckPos]
 			if ht.ProbeScratch.foundNull[toCheck] {
@@ -5558,7 +5558,7 @@ func (ht *HashTable) FindBuckets(
 	batch coldata.Batch,
 	keyCols []coldata.Vec,
 	first, next []keyID,
-	duplicatesChecker func([]coldata.Vec, uint64, []int) uint64,
+	duplicatesChecker func([]coldata.Vec, uint32, []int) uint32,
 	zeroHeadIDForDistinctTuple bool,
 	probingAgainstItself bool,
 ) {
@@ -5573,19 +5573,20 @@ func (ht *HashTable) FindBuckets(
 				_ = toCheckIDs[batchLength-1]
 				headIDs := ht.ProbeScratch.HeadID
 				_ = headIDs[batchLength-1]
-				var nToCheck uint64
+				var nToCheck uint32
 				for i, hash := range ht.ProbeScratch.HashBuffer[:batchLength] {
-					toCheck := uint64(i)
+					toCheck := uint32(i)
 					nextToCheckID := first[hash]
 					{
-						if uint64(toCheck+1) == nextToCheckID {
+						if toCheck+1 == nextToCheckID {
 							_ = true
 							//gcassert:gce
 							headIDs[toCheck] = nextToCheckID
 						} else {
 							{
+								_ = true
 								//gcassert:bce
-								toCheckIDs[toCheck] = nextToCheckID
+								toCheckIDs[i] = nextToCheckID
 								ht.ProbeScratch.ToCheck[nToCheck] = toCheck
 								nToCheck++
 							}
@@ -5600,11 +5601,12 @@ func (ht *HashTable) FindBuckets(
 					for _, toCheck := range toCheckSlice {
 						nextToCheckID := next[toCheckIDs[toCheck]]
 						{
-							if uint64(toCheck+1) == nextToCheckID {
+							if toCheck+1 == nextToCheckID {
 								_ = true
 								headIDs[toCheck] = nextToCheckID
 							} else {
 								{
+									_ = true
 									//gcassert:bce
 									toCheckIDs[toCheck] = nextToCheckID
 									ht.ProbeScratch.ToCheck[nToCheck] = toCheck
@@ -5622,15 +5624,16 @@ func (ht *HashTable) FindBuckets(
 				// Early bounds checks.
 				toCheckIDs := ht.ProbeScratch.ToCheckID
 				_ = toCheckIDs[batchLength-1]
-				var nToCheck uint64
+				var nToCheck uint32
 				for i, hash := range ht.ProbeScratch.HashBuffer[:batchLength] {
-					toCheck := uint64(i)
+					toCheck := uint32(i)
 					nextToCheckID := first[hash]
 					{
 						if nextToCheckID != 0 {
 							{
+								_ = true
 								//gcassert:bce
-								toCheckIDs[toCheck] = nextToCheckID
+								toCheckIDs[i] = nextToCheckID
 								ht.ProbeScratch.ToCheck[nToCheck] = toCheck
 								nToCheck++
 							}
@@ -5649,6 +5652,7 @@ func (ht *HashTable) FindBuckets(
 						{
 							if nextToCheckID != 0 {
 								{
+									_ = true
 									//gcassert:bce
 									toCheckIDs[toCheck] = nextToCheckID
 									ht.ProbeScratch.ToCheck[nToCheck] = toCheck
@@ -5672,19 +5676,20 @@ func (ht *HashTable) FindBuckets(
 				_ = toCheckIDs[batchLength-1]
 				headIDs := ht.ProbeScratch.HeadID
 				_ = headIDs[batchLength-1]
-				var nToCheck uint64
+				var nToCheck uint32
 				for i, hash := range ht.ProbeScratch.HashBuffer[:batchLength] {
-					toCheck := uint64(i)
+					toCheck := uint32(i)
 					nextToCheckID := first[hash]
 					{
-						if uint64(toCheck+1) == nextToCheckID {
+						if toCheck+1 == nextToCheckID {
 							_ = true
 							//gcassert:gce
 							headIDs[toCheck] = nextToCheckID
 						} else {
 							{
+								_ = true
 								//gcassert:bce
-								toCheckIDs[toCheck] = nextToCheckID
+								toCheckIDs[i] = nextToCheckID
 								ht.ProbeScratch.ToCheck[nToCheck] = toCheck
 								nToCheck++
 							}
@@ -5699,11 +5704,12 @@ func (ht *HashTable) FindBuckets(
 					for _, toCheck := range toCheckSlice {
 						nextToCheckID := next[toCheckIDs[toCheck]]
 						{
-							if uint64(toCheck+1) == nextToCheckID {
+							if toCheck+1 == nextToCheckID {
 								_ = true
 								headIDs[toCheck] = nextToCheckID
 							} else {
 								{
+									_ = true
 									//gcassert:bce
 									toCheckIDs[toCheck] = nextToCheckID
 									ht.ProbeScratch.ToCheck[nToCheck] = toCheck
@@ -5723,15 +5729,16 @@ func (ht *HashTable) FindBuckets(
 				_ = toCheckIDs[batchLength-1]
 				headIDs := ht.ProbeScratch.HeadID
 				_ = headIDs[batchLength-1]
-				var nToCheck uint64
+				var nToCheck uint32
 				for i, hash := range ht.ProbeScratch.HashBuffer[:batchLength] {
-					toCheck := uint64(i)
+					toCheck := uint32(i)
 					nextToCheckID := first[hash]
 					{
 						if nextToCheckID != 0 {
 							{
+								_ = true
 								//gcassert:bce
-								toCheckIDs[toCheck] = nextToCheckID
+								toCheckIDs[i] = nextToCheckID
 								ht.ProbeScratch.ToCheck[nToCheck] = toCheck
 								nToCheck++
 							}
@@ -5753,6 +5760,7 @@ func (ht *HashTable) FindBuckets(
 						{
 							if nextToCheckID != 0 {
 								{
+									_ = true
 									//gcassert:bce
 									toCheckIDs[toCheck] = nextToCheckID
 									ht.ProbeScratch.ToCheck[nToCheck] = toCheck
@@ -5778,7 +5786,7 @@ const _ = "template_findBuckets"
 const _ = "template_handleNextToCheckID"
 
 // execgen:inline
-const _ = "inlined_includeTupleToCheck"
+const _ = "template_includeTupleToCheck"
 
 // execgen:inline
 const _ = "inlined_findBuckets_true_true"
@@ -5815,3 +5823,9 @@ const _ = "inlined_handleNextToCheckID_false_false_true"
 
 // execgen:inline
 const _ = "inlined_handleNextToCheckID_false_false_false"
+
+// execgen:inline
+const _ = "inlined_includeTupleToCheck_true"
+
+// execgen:inline
+const _ = "inlined_includeTupleToCheck_false"

--- a/pkg/sql/colexec/colexechash/hashtable_full_default.eg.go
+++ b/pkg/sql/colexec/colexechash/hashtable_full_default.eg.go
@@ -37,7 +37,7 @@ var (
 // the HashTable disallows null equality, then if any element in the key is
 // null, there is no match.
 func (ht *HashTable) checkCol(
-	probeVec, buildVec coldata.Vec, keyColIdx int, nToCheck uint64, probeSel []int,
+	probeVec, buildVec coldata.Vec, keyColIdx int, nToCheck uint32, probeSel []int,
 ) {
 	switch probeVec.CanonicalTypeFamily() {
 	case types.BoolFamily:
@@ -5671,3 +5671,9 @@ const _ = "inlined_handleNextToCheckID_false_false_true"
 
 // execgen:inline
 const _ = "inlined_handleNextToCheckID_false_false_false"
+
+// execgen:inline
+const _ = "inlined_includeTupleToCheck_true"
+
+// execgen:inline
+const _ = "inlined_includeTupleToCheck_false"

--- a/pkg/sql/colexec/colexechash/hashtable_full_deleting.eg.go
+++ b/pkg/sql/colexec/colexechash/hashtable_full_deleting.eg.go
@@ -38,7 +38,7 @@ var (
 // bucket has reached the end, the key is rejected. If the HashTable disallows
 // null equality, then if any element in the key is null, there is no match.
 func (ht *HashTable) checkColDeleting(
-	probeVec, buildVec coldata.Vec, keyColIdx int, nToCheck uint64, probeSel []int,
+	probeVec, buildVec coldata.Vec, keyColIdx int, nToCheck uint32, probeSel []int,
 ) {
 	switch probeVec.CanonicalTypeFamily() {
 	case types.BoolFamily:
@@ -6337,15 +6337,15 @@ func (ht *HashTable) checkColDeleting(
 // We also have fully visited all tuples in the hash table, so all future
 // probing batches will be handled more efficiently (namely, once we find a
 // match, we stop probing for the corresponding tuple).
-func (ht *HashTable) Check(nToCheck uint64, probeSel []int) uint64 {
+func (ht *HashTable) Check(nToCheck uint32, probeSel []int) uint32 {
 	ht.checkCols(ht.Keys, nToCheck, probeSel)
-	nDiffers := uint64(0)
+	nDiffers := uint32(0)
 	switch ht.probeMode {
 	case HashTableDefaultProbeMode:
 		if ht.Same != nil {
 			toCheckSlice := ht.ProbeScratch.ToCheck
 			_ = toCheckSlice[nToCheck-1]
-			for toCheckPos := uint64(0); toCheckPos < nToCheck && nDiffers < nToCheck; toCheckPos++ {
+			for toCheckPos := uint32(0); toCheckPos < nToCheck && nDiffers < nToCheck; toCheckPos++ {
 				//gcassert:bce
 				toCheck := toCheckSlice[toCheckPos]
 				if ht.ProbeScratch.foundNull[toCheck] {
@@ -6378,7 +6378,7 @@ func (ht *HashTable) Check(nToCheck uint64, probeSel []int) uint64 {
 		} else {
 			toCheckSlice := ht.ProbeScratch.ToCheck
 			_ = toCheckSlice[nToCheck-1]
-			for toCheckPos := uint64(0); toCheckPos < nToCheck && nDiffers < nToCheck; toCheckPos++ {
+			for toCheckPos := uint32(0); toCheckPos < nToCheck && nDiffers < nToCheck; toCheckPos++ {
 				//gcassert:bce
 				toCheck := toCheckSlice[toCheckPos]
 				if ht.ProbeScratch.foundNull[toCheck] {
@@ -6401,7 +6401,7 @@ func (ht *HashTable) Check(nToCheck uint64, probeSel []int) uint64 {
 	case HashTableDeletingProbeMode:
 		toCheckSlice := ht.ProbeScratch.ToCheck
 		_ = toCheckSlice[nToCheck-1]
-		for toCheckPos := uint64(0); toCheckPos < nToCheck && nDiffers < nToCheck; toCheckPos++ {
+		for toCheckPos := uint32(0); toCheckPos < nToCheck && nDiffers < nToCheck; toCheckPos++ {
 			//gcassert:bce
 			toCheck := toCheckSlice[toCheckPos]
 			if !ht.ProbeScratch.differs[toCheck] {
@@ -6464,3 +6464,9 @@ const _ = "inlined_handleNextToCheckID_false_false_true"
 
 // execgen:inline
 const _ = "inlined_handleNextToCheckID_false_false_false"
+
+// execgen:inline
+const _ = "inlined_includeTupleToCheck_true"
+
+// execgen:inline
+const _ = "inlined_includeTupleToCheck_false"

--- a/pkg/sql/colexec/colexecutils/utils.go
+++ b/pkg/sql/colexec/colexecutils/utils.go
@@ -220,14 +220,14 @@ func (b *AppendOnlyBufferedBatch) AppendTuples(batch coldata.Batch, startIdx, en
 	})
 }
 
-// MaybeAllocateUint64Array makes sure that the passed in array is allocated, of
+// MaybeAllocateUint32Array makes sure that the passed in array is allocated, of
 // the desired length and zeroed out.
-func MaybeAllocateUint64Array(array []uint64, length int) []uint64 {
+func MaybeAllocateUint32Array(array []uint32, length int) []uint32 {
 	if cap(array) < length {
-		return make([]uint64, length)
+		return make([]uint32, length)
 	}
 	array = array[:length]
-	for n := 0; n < length; n += copy(array[n:], ZeroUint64Column) {
+	for n := 0; n < length; n += copy(array[n:], ZeroUint32Column) {
 	}
 	return array
 }
@@ -244,15 +244,15 @@ func MaybeAllocateBoolArray(array []bool, length int) []bool {
 	return array
 }
 
-// MaybeAllocateLimitedUint64Array is an optimized version of
-// MaybeAllocateUint64Array that can *only* be used when length is at most
+// MaybeAllocateLimitedUint32Array is an optimized version of
+// MaybeAllocateUint32Array that can *only* be used when length is at most
 // coldata.MaxBatchSize.
-func MaybeAllocateLimitedUint64Array(array []uint64, length int) []uint64 {
+func MaybeAllocateLimitedUint32Array(array []uint32, length int) []uint32 {
 	if cap(array) < length {
-		return make([]uint64, length)
+		return make([]uint32, length)
 	}
 	array = array[:length]
-	copy(array, ZeroUint64Column)
+	copy(array, ZeroUint32Column)
 	return array
 }
 
@@ -272,9 +272,9 @@ var (
 	// ZeroBoolColumn is zeroed out boolean slice of coldata.MaxBatchSize
 	// length.
 	ZeroBoolColumn = make([]bool, coldata.MaxBatchSize)
-	// ZeroUint64Column is zeroed out uint64 slice of coldata.MaxBatchSize
+	// ZeroUint32Column is zeroed out uint64 slice of coldata.MaxBatchSize
 	// length.
-	ZeroUint64Column = make([]uint64, coldata.MaxBatchSize)
+	ZeroUint32Column = make([]uint32, coldata.MaxBatchSize)
 )
 
 // HandleErrorFromDiskQueue takes in non-nil error emitted by colcontainer.Queue

--- a/pkg/sql/colexec/distinct_test.go
+++ b/pkg/sql/colexec/distinct_test.go
@@ -395,7 +395,7 @@ func TestDistinct(t *testing.T) {
 			ud := NewUnorderedDistinct(
 				testAllocator, input[0], tc.distinctCols, tc.typs, tc.nullsAreDistinct, tc.errorOnDup,
 			)
-			ud.(*UnorderedDistinct).hashTableNumBuckets = uint64(1 + rng.Intn(7))
+			ud.(*UnorderedDistinct).hashTableNumBuckets = uint32(1 + rng.Intn(7))
 			return ud, nil
 		})
 		if tc.isOrderedOnDistinctCols {
@@ -445,7 +445,7 @@ func TestUnorderedDistinctRandom(t *testing.T) {
 	colexectestutils.RunTestsWithTyps(t, testAllocator, []colexectestutils.Tuples{tups}, [][]*types.T{typs}, expected, colexectestutils.UnorderedVerifier,
 		func(input []colexecop.Operator) (colexecop.Operator, error) {
 			ud := NewUnorderedDistinct(testAllocator, input[0], distinctCols, typs, false /* nullsAreDistinct */, "" /* errorOnDup */)
-			ud.(*UnorderedDistinct).hashTableNumBuckets = uint64(1 + rng.Intn(7))
+			ud.(*UnorderedDistinct).hashTableNumBuckets = uint32(1 + rng.Intn(7))
 			return ud, nil
 		},
 	)

--- a/pkg/sql/colexec/execgen/cmd/execgen/hash_utils_gen.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/hash_utils_gen.go
@@ -31,8 +31,8 @@ func genHashUtils(inputFileContents string, wr io.Writer) error {
 	assignHash := makeFunctionRegex("_ASSIGN_HASH", 4)
 	s = assignHash.ReplaceAllString(s, makeTemplateFunctionCall("Global.AssignHash", 4))
 
-	rehash := makeFunctionRegex("_REHASH_BODY", 7)
-	s = rehash.ReplaceAllString(s, `{{template "rehashBody" buildDict "Global" . "HasSel" $6 "HasNulls" $7}}`)
+	rehash := makeFunctionRegex("_REHASH_BODY", 8)
+	s = rehash.ReplaceAllString(s, `{{template "rehashBody" buildDict "Global" . "HasSel" $6 "HasNulls" $7 "Uint64" $8}}`)
 
 	s = replaceManipulationFuncsAmbiguous(".Global", s)
 

--- a/pkg/sql/colexec/hash_aggregator.go
+++ b/pkg/sql/colexec/hash_aggregator.go
@@ -112,7 +112,7 @@ type hashAggregator struct {
 	// ht stores tuples that are "heads" of the corresponding aggregation
 	// groups ("head" here means the tuple that was first seen from the group).
 	ht                  *colexechash.HashTable
-	hashTableNumBuckets uint64
+	hashTableNumBuckets uint32
 
 	// state stores the current state of hashAggregator.
 	state hashAggregatorState
@@ -207,7 +207,7 @@ func NewHashAggregator(
 	}
 	// This number was chosen after running the micro-benchmarks and relevant
 	// TPCH queries using tpchvec/bench.
-	hashTableNumBuckets := uint64(256)
+	hashTableNumBuckets := uint32(256)
 	if args.TestingKnobs.HashTableNumBuckets != 0 {
 		hashTableNumBuckets = args.TestingKnobs.HashTableNumBuckets
 	}

--- a/pkg/sql/colexec/hash_aggregator_test.go
+++ b/pkg/sql/colexec/hash_aggregator_test.go
@@ -443,7 +443,7 @@ func TestHashAggregator(t *testing.T) {
 					ConstArguments: constArguments,
 					OutputTypes:    outputTypes,
 				}
-				args.TestingKnobs.HashTableNumBuckets = uint64(1 + rng.Intn(7))
+				args.TestingKnobs.HashTableNumBuckets = uint32(1 + rng.Intn(7))
 				return NewHashAggregator(
 					context.Background(),
 					&colexecagg.NewHashAggregatorArgs{

--- a/pkg/sql/colexec/unordered_distinct.go
+++ b/pkg/sql/colexec/unordered_distinct.go
@@ -58,7 +58,7 @@ type UnorderedDistinct struct {
 	nullsAreDistinct   bool
 
 	Ht                  *colexechash.HashTable
-	hashTableNumBuckets uint64
+	hashTableNumBuckets uint32
 	// lastInputBatch tracks the last input batch read from the input and not
 	// emitted into the output. It is the only batch that we need to export when
 	// spilling to disk, and it will contain only the distinct tuples that need


### PR DESCRIPTION
This commit switches the hash table to operate on uint32 hash values
rather than uint64. This switch allows us to reduce the memory
footprint as well as to actually speed up the computation. Full
microbenchmarks are [here](https://gist.github.com/yuzefovich/8a672586343a903f2669fa883c67c265), but the gist is as follows:
- hash aggregator has speedup of 10-20% and reduced mem usage of 5-40%
- unordered distinct has speedup of 2-6% and reduced mem usage of 2-30%
- hash joiner has speedup of 2-25% and reduced mem usage of 4-10%

Difference on TPCH queries (average over 100 runs):
```
Q1:	before: 3.32s	after: 3.16s	 -4.93%
Q2:	before: 3.42s	after: 3.15s	 -8.08%
Q3:	before: 2.68s	after: 2.39s	 -10.88%
Q4:	before: 1.72s	after: 1.64s	 -4.46%
Q5:	before: 2.45s	after: 2.35s	 -4.22%
Q6:	before: 4.56s	after: 4.49s	 -1.49%
Q7:	before: 5.69s	after: 5.57s	 -2.16%
Q8:	before: 1.10s	after: 1.09s	 -0.66%
Q9:	before: 5.69s	after: 5.80s	 2.00%
Q10:	before: 2.09s	after: 1.98s	 -5.17%
Q11:	before: 0.95s	after: 0.91s	 -4.13%
Q12:	before: 4.26s	after: 4.28s	 0.57%
Q13:	before: 1.34s	after: 1.26s	 -6.20%
Q14:	before: 0.44s	after: 0.45s	 2.28%
Q15:	before: 2.47s	after: 2.47s	 -0.13%
Q16:	before: 0.93s	after: 0.88s	 -4.68%
Q17:	before: 0.25s	after: 0.24s	 -2.76%
Q18:	before: 2.18s	after: 2.12s	 -2.48%
Q19:	before: 0.51s	after: 0.49s	 -2.79%
Q20:	before: 9.80s	after: 9.53s	 -2.70%
Q21:	before: 4.96s	after: 4.85s	 -2.26%
Q22:	before: 0.58s	after: 0.57s	 -1.67%
```

The rationale for why this change is not breaking is that we don't expect
to need more than 4 billion buckets. For the hash table that would mean
that about 4 billion rows are buffered in memory which we should never
reach given the workmem limit that kicks in at around million of tuples
in the hash table.

Note that we still internally compute the hash of stuff using uint64,
but then later when we assign it to return outside of the hash functions
we trim it down to uint32.

However, in order to not change the routing behavior of the hash router
(which uses the tuple hash distributor that is also powered by the hash
utilities) we need to preserve uint64 usage in that case. We do so by
duplicating a couple of helper functions and making another function
generic. Note that we couldn't make `initHash` because we use
concretely-typed slice for fast zeroing out, but we could have made
`rehash` generic, however, that currently incurs a small performance
penalty, so we choose to duplicate the generated code there.

Epic: None

Release note: None