### PR TITLE
sql: do not propagate incorrect misplanned ranges metadata

### DIFF
--- a/pkg/sql/distsql_physical_planner.go
+++ b/pkg/sql/distsql_physical_planner.go
@@ -1833,9 +1833,10 @@ func (dsp *DistSQLPlanner) planTableReaders(
 	ctx context.Context, planCtx *PlanningCtx, p *PhysicalPlan, info *tableReaderPlanningInfo,
 ) error {
 	var (
-		spanPartitions   []SpanPartition
-		parallelizeLocal bool
-		err              error
+		spanPartitions         []SpanPartition
+		parallelizeLocal       bool
+		ignoreMisplannedRanges bool
+		err                    error
 	)
 	if planCtx.isLocal {
 		spanPartitions, parallelizeLocal = dsp.maybeParallelizeLocalScans(ctx, planCtx, info)
@@ -1857,6 +1858,10 @@ func (dsp *DistSQLPlanner) planTableReaders(
 			return err
 		}
 		spanPartitions = []SpanPartition{{sqlInstanceID, info.spans}}
+		// The spans to scan might actually live on different nodes, so we don't
+		// want to create "misplanned ranges" metadata since it can result in
+		// false positives.
+		ignoreMisplannedRanges = true
 	}
 
 	corePlacement := make([]physicalplan.ProcessorCorePlacement, len(spanPartitions))
@@ -1880,6 +1885,7 @@ func (dsp *DistSQLPlanner) planTableReaders(
 		if !tr.Parallelize {
 			tr.BatchBytesLimit = dsp.distSQLSrv.TestingKnobs.TableReaderBatchBytesLimit
 		}
+		tr.IgnoreMisplannedRanges = ignoreMisplannedRanges
 		p.TotalEstimatedScannedRows += info.estimatedRowCount
 
 		corePlacement[i].SQLInstanceID = sp.SQLInstanceID

--- a/pkg/sql/execinfra/readerbase.go
+++ b/pkg/sql/execinfra/readerbase.go
@@ -94,7 +94,7 @@ func MisplannedRanges(
 			}
 			fmt.Fprintf(&b, "%+v", misplannedRanges[i])
 		}
-		log.VEventf(ctx, 2, "misplanned ranges: %s", b.String())
+		log.VEventf(ctx, 2, "%d misplanned ranges: %s", len(misplannedRanges), b.String())
 	}
 
 	return misplannedRanges

--- a/pkg/sql/execinfrapb/processors_sql.proto
+++ b/pkg/sql/execinfrapb/processors_sql.proto
@@ -121,6 +121,12 @@ message TableReaderSpec {
   // to BLOCK when locking_strength is FOR_NONE.
   optional sqlbase.ScanLockingWaitPolicy locking_wait_policy = 11 [(gogoproto.nullable) = false];
 
+  // Indicates that misplanned ranges metadata should not be sent back to the
+  // DistSQLReceiver. This will be set to true for the scan with a hard limit
+  // (in which case we create a single processor that is placed at the
+  // leaseholder of the beginning of the key spans to be scanned).
+  optional bool ignore_misplanned_ranges = 22 [(gogoproto.nullable) = false];
+
   reserved 1, 2, 4, 6, 7, 8, 13, 14, 15, 16, 19;
 }
 

--- a/pkg/sql/logictest/testdata/logic_test/distsql_numtables
+++ b/pkg/sql/logictest/testdata/logic_test/distsql_numtables
@@ -203,3 +203,20 @@ query I
 SELECT count(*) FROM (SELECT 1 AS one FROM NumToSquare WHERE x > 10 ORDER BY xsquared LIMIT 10)
 ----
 10
+
+# Regression test for incorrectly propagating "misplanned ranges" metadata when
+# only a single TableReader is created in a distributed plan (#101471). The
+# query is constructed in such a manner so that the TableReader is placed on
+# node 2 and then it needs to perform remote reads since the range with y >=
+# 4000 lives on node 3.
+statement ok
+SET TRACING = ON;
+SELECT * FROM NumToStr WHERE y >= 3999 LIMIT 2;
+SET TRACING = OFF;
+
+# Ensure that we didn't create the "misplanned ranges" metadata for the range
+# with y >= 4000.
+query I
+SELECT count(*) FROM [SHOW TRACE FOR SESSION] WHERE message LIKE '%misplanned ranges%' AND location LIKE '%readerbase%'
+----
+0

--- a/pkg/sql/rowexec/tablereader.go
+++ b/pkg/sql/rowexec/tablereader.go
@@ -124,7 +124,7 @@ func newTableReader(
 		resultTypes[i] = spec.FetchSpec.FetchedColumns[i].Type
 	}
 
-	tr.ignoreMisplannedRanges = flowCtx.Local
+	tr.ignoreMisplannedRanges = flowCtx.Local || spec.IgnoreMisplannedRanges
 	if err := tr.Init(
 		ctx,
 		tr,


### PR DESCRIPTION
This commit fixes a bug when the "misplanned ranges" metadata was populated when it shouldn't have. In particular, if a distributed query has a hard limit, then we always create only a single TableReader to perform the scan, even though the spans to scan might touch multiple ranges. We place the TableReader on the leaseholder of the smallest key that we need to touch. Previously, we would incorrectly create the "misplanned ranges" metadata in that TableReader that would later evict non-stale entries from the range cache on the gateway node. In other words, we had a false positive eviction. This is now fixed by ensuring that this metadata is only created whenever we used all available nodes for physical planning and, thus, placed the TableReaders exactly according to the range cache of the gateway.

Fixes: #101471.

Release note: None