### PR TITLE
release-22.1: storage: don't return WriteTooOld on inline DeleteRange that hits non…

### DIFF
--- a/pkg/storage/mvcc.go
+++ b/pkg/storage/mvcc.go
@@ -2167,6 +2167,31 @@ func MVCCDeleteRange(
 	txn *roachpb.Transaction,
 	returnKeys bool,
 ) ([]roachpb.Key, *roachpb.Span, int64, error) {
+	// Scan to find the keys to delete.
+	//
+	// For a versioned delete range, scan at the request timestamp and with the
+	// FailOnMoreRecent option set to true. Doing so returns all non-tombstoned
+	// keys at or below the request timestamp and throws a WriteTooOld error on
+	// any key (mvcc tombstone or otherwise) above the request timestamp. This is
+	// different from scanning at MaxTimestamp and deferring write-write conflict
+	// checking to mvccPutInternal below. That approach ignores mvcc tombstones
+	// above the request timestamp, which could lead to serializability anomalies
+	// (see #56458).
+	//
+	// For an inline delete range, scan at MaxTimestamp. Doing so is not needed to
+	// retrieve inline values, but it ensures that all non-inline values are also
+	// returned. It is incompatible to mix an inline delete range with mvcc
+	// versions, so we want to pass these incompatible keys to mvccPutInternal to
+	// detect the condition and return an error. We also scan with the
+	// FailOnMoreRecent set to false. This is not strictly necessary (nothing is
+	// more recent than MaxTimestamp), but it provides added protection against
+	// the scan returning a WriteTooOld error.
+	scanTs := timestamp
+	failOnMoreRecent := true
+	if timestamp.IsEmpty() /* inline */ {
+		scanTs = hlc.MaxTimestamp
+		failOnMoreRecent = false
+	}
 	// In order for this operation to be idempotent when run transactionally, we
 	// need to perform the initial scan at the previous sequence number so that
 	// we don't see the result from equal or later sequences.
@@ -2176,8 +2201,8 @@ func MVCCDeleteRange(
 		prevSeqTxn.Sequence--
 		scanTxn = prevSeqTxn
 	}
-	res, err := MVCCScan(ctx, rw, key, endKey, timestamp, MVCCScanOptions{
-		FailOnMoreRecent: true, Txn: scanTxn, MaxKeys: max,
+	res, err := MVCCScan(ctx, rw, key, endKey, scanTs, MVCCScanOptions{
+		FailOnMoreRecent: failOnMoreRecent, Txn: scanTxn, MaxKeys: max,
 	})
 	if err != nil {
 		return nil, nil, 0, err

--- a/pkg/storage/mvcc_test.go
+++ b/pkg/storage/mvcc_test.go
@@ -1971,11 +1971,10 @@ func TestMVCCDeleteRangeInline(t *testing.T) {
 			}
 
 			// Attempt to delete non-inline key at zero timestamp; should fail.
-			const writeTooOldErrString = "WriteTooOldError"
 			if _, _, _, err := MVCCDeleteRange(
 				ctx, engine, nil, testKey6, keyMax, 1, hlc.Timestamp{Logical: 0}, nil, true,
-			); !testutils.IsError(err, writeTooOldErrString) {
-				t.Fatalf("got error %v, expected error with text '%s'", err, writeTooOldErrString)
+			); !testutils.IsError(err, inlineMismatchErrString) {
+				t.Fatalf("got error %v, expected error with text '%s'", err, inlineMismatchErrString)
 			}
 
 			// Attempt to delete inline keys in a transaction; should fail.

--- a/pkg/storage/testdata/mvcc_histories/delete_range_inline
+++ b/pkg/storage/testdata/mvcc_histories/delete_range_inline
@@ -1,0 +1,51 @@
+# Mix inline and mvcc delete range requests with inline and mvcc key-values.
+
+run ok
+put k=inline-key v=inline-val ts=0
+----
+>> at end:
+meta: "inline-key"/0,0 -> txn={<nil>} ts=0,0 del=false klen=0 vlen=0 raw=/BYTES/inline-val mergeTs=<nil> txnDidNotUpdateMeta=false
+
+run ok
+put k=mvcc-key v=mvcc-val ts=10
+----
+>> at end:
+meta: "inline-key"/0,0 -> txn={<nil>} ts=0,0 del=false klen=0 vlen=0 raw=/BYTES/inline-val mergeTs=<nil> txnDidNotUpdateMeta=false
+data: "mvcc-key"/10.000000000,0 -> /BYTES/mvcc-val
+
+
+# Incompatible requests.
+
+run error
+del_range k=inline-key end=inline-key-end ts=20
+----
+>> at end:
+meta: "inline-key"/0,0 -> txn={<nil>} ts=0,0 del=false klen=0 vlen=0 raw=/BYTES/inline-val mergeTs=<nil> txnDidNotUpdateMeta=false
+data: "mvcc-key"/10.000000000,0 -> /BYTES/mvcc-val
+error: (*withstack.withStack:) "inline-key"/0,0: put is inline=false, but existing value is inline=true
+
+run error
+del_range k=mvcc-key end=mvcc-key-end ts=0
+----
+>> at end:
+meta: "inline-key"/0,0 -> txn={<nil>} ts=0,0 del=false klen=0 vlen=0 raw=/BYTES/inline-val mergeTs=<nil> txnDidNotUpdateMeta=false
+data: "mvcc-key"/10.000000000,0 -> /BYTES/mvcc-val
+error: (*withstack.withStack:) "mvcc-key"/0,0: put is inline=true, but existing value is inline=false
+
+
+# Compatible requests.
+
+run ok
+del_range k=inline-key end=inline-key-end ts=0
+----
+del_range: "inline-key"-"inline-key-end" -> deleted 1 key(s)
+>> at end:
+data: "mvcc-key"/10.000000000,0 -> /BYTES/mvcc-val
+
+run ok
+del_range k=mvcc-key end=mvcc-key-end ts=20
+----
+del_range: "mvcc-key"-"mvcc-key-end" -> deleted 1 key(s)
+>> at end:
+data: "mvcc-key"/20.000000000,0 -> /<empty>
+data: "mvcc-key"/10.000000000,0 -> /BYTES/mvcc-val


### PR DESCRIPTION
This is a backport of #101445 to 22.1.

---

…-inline value

Fixes #101440.

This commit resolves a condition where an inline DeleteRange request could return a WriteTooOld error when encountering a non-inline value, instead of returning the expected assertion error. This could trigger a fatal error in `tryBumpBatchTimestamp`. See the corresponding issue for more details.

Note that this is not resolving any condition that could cause an inline DeleteRange request to hit a non-inline value, it's just ensuring that if corruption creates such a condition, we don't fatal.

Release note: None

Release justification: Alleviates node restarts related to a high severity bug.