### PR TITLE
awsdms: retry testing the connection on StartReplicationTask

### DIFF
--- a/pkg/cmd/roachtest/tests/awsdms.go
+++ b/pkg/cmd/roachtest/tests/awsdms.go
@@ -840,6 +840,7 @@ func setupDMSEndpointsAndTask(
 				)
 				return retErr
 			}(); lastErr == nil {
+				t.L().Printf("test for %s successful", *ep.in.EndpointIdentifier)
 				break
 			} else {
 				t.L().Printf("replication endpoint test failed, retrying: %s", lastErr)
@@ -872,16 +873,30 @@ func setupDMSEndpointsAndTask(
 		if err := dms.NewReplicationTaskReadyWaiter(dmsCli).Wait(ctx, dmsDescribeTasksInput(t.BuildVersion(), task.tableName), awsdmsWaitTimeLimit); err != nil {
 			return err
 		}
+
 		t.L().Printf("starting replication task")
-		if _, err := dmsCli.StartReplicationTask(
-			ctx,
-			&dms.StartReplicationTaskInput{
-				ReplicationTaskArn:       replTaskOut.ReplicationTask.ReplicationTaskArn,
-				StartReplicationTaskType: dmstypes.StartReplicationTaskTypeValueReloadTarget,
-			},
-		); err != nil {
-			return err
+		r := retry.StartWithCtx(ctx, retry.Options{
+			InitialBackoff: 10 * time.Second,
+			MaxBackoff:     20 * time.Second,
+			MaxRetries:     10,
+		})
+		var lastErr error
+		for r.Next() {
+			if _, lastErr = dmsCli.StartReplicationTask(
+				ctx,
+				&dms.StartReplicationTaskInput{
+					ReplicationTaskArn:       replTaskOut.ReplicationTask.ReplicationTaskArn,
+					StartReplicationTaskType: dmstypes.StartReplicationTaskTypeValueReloadTarget,
+				},
+			); lastErr == nil {
+				break
+			}
+			t.L().Printf("got error starting DMS task; retrying: %+v", err)
 		}
+		if lastErr != nil {
+			return lastErr
+		}
+
 		t.L().Printf("waiting for replication task to be running")
 		if err := dms.NewReplicationTaskRunningWaiter(dmsCli).Wait(
 			ctx,


### PR DESCRIPTION
DMS seems to sometimes not start up because it thinks the tested connection wasn't successful (despite it clearly being successful earlier). Counter this for now by retrying.

Release note: None
Informs: https://github.com/cockroachdb/cockroach/issues/101417, https://github.com/cockroachdb/cockroach/issues/101517, https://github.com/cockroachdb/cockroach/issues/100322
Release justification: test only fix