### PR TITLE
release: bincheck on windows fails cloning repo

### DIFF
--- a/.github/workflows/bincheck.yml
+++ b/.github/workflows/bincheck.yml
@@ -24,5 +24,6 @@ jobs:
   windows:
     runs-on: windows-latest
     steps:
+    - run: git config --system core.longpaths true
     - uses: actions/checkout@v3
     - run: cd build/release/bincheck && bash test-windows ${{ github.ref_name }} ${{ github.sha }}


### PR DESCRIPTION
Previously, bincheck on Windows failed cloning the repo due to too long path name for some files.

This behaviour can be fixed by setting `core.longpaths` to `true`.

Part of: #101116
Epic: None
Release note: None