### PR TITLE
release-22.1: kvprober: probe correct keys in `crdb_internal.probe_ranges`

### DIFF
--- a/pkg/kv/kvprober/kvprober_test.go
+++ b/pkg/kv/kvprober/kvprober_test.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 	"github.com/stretchr/testify/require"
@@ -238,7 +239,7 @@ func (m *mock) next(ctx context.Context) (Step, error) {
 	return step, m.planErr
 }
 
-func (m *mock) Read(key interface{}) func(context.Context, *kv.Txn) error {
+func (m *mock) Read(key roachpb.Key) func(context.Context, *kv.Txn) error {
 	return func(context.Context, *kv.Txn) error {
 		if !m.read {
 			m.t.Error("read call made but not expected")
@@ -247,7 +248,7 @@ func (m *mock) Read(key interface{}) func(context.Context, *kv.Txn) error {
 	}
 }
 
-func (m *mock) Write(key interface{}) func(context.Context, *kv.Txn) error {
+func (m *mock) Write(key roachpb.Key) func(context.Context, *kv.Txn) error {
 	return func(context.Context, *kv.Txn) error {
 		if !m.write {
 			m.t.Error("write call made but not expected")

--- a/pkg/sql/sem/builtins/generator_probe_ranges.go
+++ b/pkg/sql/sem/builtins/generator_probe_ranges.go
@@ -197,17 +197,12 @@ func (p *probeRangeGenerator) Next(ctx context.Context) (bool, error) {
 		}
 		p.curr.rangeID = int64(desc.RangeID)
 
+		key := kvprober.ProbeKeyForRange(&desc)
 		op := p.ops.Read
 		if p.isWrite {
 			op = p.ops.Write
 		}
 
-		key := desc.StartKey.AsRawKey()
-		if desc.RangeID == 1 {
-			// The first range starts at KeyMin, but the replicated keyspace starts only at keys.LocalMax,
-			// so there is a special case here.
-			key = keys.LocalMax
-		}
 		// NB: intentionally using a separate txn per probe to avoid undesirable cross-probe effects.
 		return p.db.Txn(ctx, op(key))
 	})


### PR DESCRIPTION
Backport 1/1 commits from #101554.

/cc @cockroachdb/release

---

Fixes #101549.

In #101549, we found that `crdb_internal.probe_ranges` was unintentionally probing at global range start keys, instead of local probe keys derived from these range start keys. This could lead to serious corruption across the cluster which manifests itself in different ways, depending on the range. This commit fixes `crdb_internal.probe_ranges`, ensuring that it probes at the correct local probe keys.

The fix also ensures that we don't make this kind of mistake again. It unifies key encoding code paths for the multiple uses of kvprober to avoid bugs. It also adds validation directly above kvprober's access to the KV client which ensures that probe keys are valid.

Release note: None

----

Release justification: avoids unsafe builtin function that causes corruption.
