### PR TITLE
restore: skip_localities_check no longer works

### DIFF
--- a/pkg/ccl/backupccl/restore_job.go
+++ b/pkg/ccl/backupccl/restore_job.go
@@ -1044,6 +1044,7 @@ func createImportingDescriptors(
 							regionConfig,
 							txn,
 							p.ExecCfg(),
+							!details.SkipLocalitiesCheck,
 							p.ExtendedEvalContext().Tracing.KVTracingEnabled(),
 						); err != nil {
 							return err

--- a/pkg/ccl/backupccl/restore_planning.go
+++ b/pkg/ccl/backupccl/restore_planning.go
@@ -1999,10 +1999,11 @@ func doRestorePlan(
 		// compatability.
 		//
 		// TODO(msbutler): Delete in 23.1
-		RestoreSystemUsers: restoreStmt.DescriptorCoverage == tree.SystemUsers,
-		PreRewriteTenantId: oldTenantID,
-		SchemaOnly:         restoreStmt.Options.SchemaOnly,
-		VerifyData:         restoreStmt.Options.VerifyData,
+		RestoreSystemUsers:  restoreStmt.DescriptorCoverage == tree.SystemUsers,
+		PreRewriteTenantId:  oldTenantID,
+		SchemaOnly:          restoreStmt.Options.SchemaOnly,
+		VerifyData:          restoreStmt.Options.VerifyData,
+		SkipLocalitiesCheck: restoreStmt.Options.SkipLocalitiesCheck,
 	}
 
 	jr := jobs.Record{

--- a/pkg/ccl/backupccl/testdata/backup-restore/multiregion
+++ b/pkg/ccl/backupccl/testdata/backup-restore/multiregion
@@ -65,6 +65,26 @@ RESTORE FROM LATEST IN 'nodelocal://1/full_cluster_backup/';
 pq: detected a mismatch in regions between the restore cluster and the backup cluster, missing regions detected: us-east-1, us-west-1.
 HINT: there are two ways you can resolve this issue: 1) update the cluster to which you're restoring to ensure that the regions present on the nodes' --locality flags match those present in the backup image, or 2) restore with the "skip_localities_check" option
 
+exec-sql
+RESTORE FROM LATEST IN 'nodelocal://1/full_cluster_backup/' WITH skip_localities_check;
+----
+
+exec-sql
+RESTORE DATABASE d FROM LATEST IN 'nodelocal://1/database_backup/' WITH skip_localities_check, new_db_name='d_new';
+----
+
+exec-sql
+DROP DATABASE d_new;
+----
+
+exec-sql
+DROP DATABASE d;
+----
+
+exec-sql
+DROP DATABASE data;
+----
+
 # Create a database with no regions to check default primary regions.
 exec-sql
 CREATE DATABASE no_region_db;

--- a/pkg/jobs/jobspb/jobs.proto
+++ b/pkg/jobs/jobspb/jobs.proto
@@ -461,7 +461,10 @@ message RestoreDetails {
     (gogoproto.customtype) = "github.com/cockroachdb/cockroach/pkg/util/uuid.UUID"
   ];
 
-  // NEXT ID: 29.
+  // Disables loacality checking for zone configs.
+  bool SkipLocalitiesCheck = 29;
+
+  // NEXT ID: 30.
 }
 
 

--- a/pkg/sql/alter_database.go
+++ b/pkg/sql/alter_database.go
@@ -904,6 +904,7 @@ func (n *alterDatabasePrimaryRegionNode) switchPrimaryRegion(params runParams) e
 		updatedRegionConfig,
 		params.p.InternalSQLTxn(),
 		params.p.execCfg,
+		true, /* validateLocalities */
 		params.extendedEvalCtx.Tracing.KVTracingEnabled(),
 	); err != nil {
 		return err
@@ -1277,6 +1278,7 @@ func (n *alterDatabaseSurvivalGoalNode) startExec(params runParams) error {
 		regionConfig,
 		params.p.InternalSQLTxn(),
 		params.p.execCfg,
+		true, /* validateLocalities */
 		params.extendedEvalCtx.Tracing.KVTracingEnabled(),
 	); err != nil {
 		return err
@@ -1405,6 +1407,7 @@ func (n *alterDatabasePlacementNode) startExec(params runParams) error {
 		regionConfig,
 		params.p.InternalSQLTxn(),
 		params.p.execCfg,
+		true, /* validateLocalities */
 		params.extendedEvalCtx.Tracing.KVTracingEnabled(),
 	); err != nil {
 		return err
@@ -1946,6 +1949,7 @@ func (n *alterDatabaseSecondaryRegion) startExec(params runParams) error {
 		updatedRegionConfig,
 		params.p.InternalSQLTxn(),
 		params.p.execCfg,
+		true, /* validateLocalities */
 		params.extendedEvalCtx.Tracing.KVTracingEnabled(),
 	); err != nil {
 		return err
@@ -2051,6 +2055,7 @@ func (n *alterDatabaseDropSecondaryRegion) startExec(params runParams) error {
 		updatedRegionConfig,
 		params.p.InternalSQLTxn(),
 		params.p.execCfg,
+		true, /* validateLocalities */
 		params.extendedEvalCtx.Tracing.KVTracingEnabled(),
 	); err != nil {
 		return err
@@ -2327,7 +2332,7 @@ func (n *alterDatabaseSetZoneConfigExtensionNode) startExec(params runParams) er
 
 	// Validate if the zone config extension is compatible with the database.
 	dbZoneConfig, err := generateAndValidateZoneConfigForMultiRegionDatabase(
-		params.ctx, params.p.InternalSQLTxn().Regions(), params.ExecCfg(), updatedRegionConfig,
+		params.ctx, params.p.InternalSQLTxn().Regions(), params.ExecCfg(), updatedRegionConfig, true, /* validateLocalities */
 	)
 	if err != nil {
 		return err

--- a/pkg/sql/database_region_change_finalizer.go
+++ b/pkg/sql/database_region_change_finalizer.go
@@ -190,6 +190,7 @@ func (r *databaseRegionChangeFinalizer) updateDatabaseZoneConfig(
 		regionConfig,
 		txn,
 		r.localPlanner.ExecCfg(),
+		true, /* validateLocalities */
 		r.localPlanner.extendedEvalCtx.Tracing.KVTracingEnabled(),
 	)
 }


### PR DESCRIPTION
Previously, there was no additional validation for generating zone configurations so if regions were
missing during the process no errors would be generated. Later on the generation process had validation added to validate that all regions reference existed within the zone configuration. To address this, this patch adds an option to skip validation of regions when
generating zone configurations.

Fixes: #100913
Release note (bug fix): Previously, RESTORE with skip_localities_check would still fail with errors if regions were missing on a cluster.