### PR TITLE
release-22.2: sqlstats: ignore SET stmts on insights

### DIFF
--- a/pkg/sql/sqlstats/insights/detector.go
+++ b/pkg/sql/sqlstats/insights/detector.go
@@ -12,6 +12,7 @@ package insights
 
 import (
 	"container/list"
+	"strings"
 
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
@@ -140,4 +141,16 @@ func (d *latencyThresholdDetector) enabled() bool {
 
 func (d *latencyThresholdDetector) isSlow(s *Statement) bool {
 	return d.enabled() && s.LatencyInSeconds >= LatencyThreshold.Get(&d.st.SV).Seconds()
+}
+
+var prefixesToIgnore = []string{"SET "}
+
+// shouldIgnoreStatement returns true if we don't want to analyze the statement.
+func shouldIgnoreStatement(s *Statement) bool {
+	for _, start := range prefixesToIgnore {
+		if strings.HasPrefix(s.Query, start) {
+			return true
+		}
+	}
+	return false
 }

--- a/pkg/sql/sqlstats/insights/registry.go
+++ b/pkg/sql/sqlstats/insights/registry.go
@@ -93,7 +93,7 @@ func (r *lockingRegistry) ObserveTransaction(sessionID clusterunique.ID, transac
 
 	var slowStatements util.FastIntSet
 	for i, s := range *statements {
-		if r.detector.isSlow(s) {
+		if !shouldIgnoreStatement(s) && r.detector.isSlow(s) {
 			slowStatements.Add(i)
 		}
 	}


### PR DESCRIPTION
Backport 1/1 commits from #101563.

/cc @cockroachdb/release

---

Statements such as `SET vectorize = _` were being listed on Insights, but there is nothing the user can do about this, since is expected to be slow on some cases.
This commit creates an ignore function, that currently only ignore statements startings with `SET `, but can be improved with more feedback and other statements that don't make sense to be part of our insights can be added to the list.

Fixes #98358

Release note (sql change): Statements of type `SET ` are not longer displayed on the Insights page.

---
Release justification: small change, big improvement
