### PR TITLE
roachtest: don't schedule backups for perf tests

### DIFF
--- a/pkg/cmd/roachtest/tests/multitenant_tpch.go
+++ b/pkg/cmd/roachtest/tests/multitenant_tpch.go
@@ -32,7 +32,7 @@ func runMultiTenantTPCH(
 ) {
 	c.Put(ctx, t.Cockroach(), "./cockroach", c.All())
 	c.Put(ctx, t.DeprecatedWorkload(), "./workload", c.Node(1))
-	c.Start(ctx, t.L(), option.DefaultStartOpts(), install.MakeClusterSettings(install.SecureOption(true)), c.All())
+	c.Start(ctx, t.L(), option.DefaultStartOptsNoBackups(), install.MakeClusterSettings(install.SecureOption(true)), c.All())
 
 	setupNames := []string{"single-tenant", "multi-tenant"}
 	const numRunsPerQuery = 3

--- a/pkg/cmd/roachtest/tests/tpchbench.go
+++ b/pkg/cmd/roachtest/tests/tpchbench.go
@@ -67,7 +67,7 @@ func runTPCHBench(ctx context.Context, t test.Test, c cluster.Cluster, b tpchBen
 	}
 
 	t.Status("starting nodes")
-	c.Start(ctx, t.L(), option.DefaultStartOpts(), install.MakeClusterSettings(), roachNodes)
+	c.Start(ctx, t.L(), option.DefaultStartOptsNoBackups(), install.MakeClusterSettings(), roachNodes)
 
 	m := c.NewMonitor(ctx, roachNodes)
 	m.Go(func(ctx context.Context) error {

--- a/pkg/cmd/roachtest/tests/tpchvec.go
+++ b/pkg/cmd/roachtest/tests/tpchvec.go
@@ -527,7 +527,7 @@ func runTPCHVec(
 	firstNode := c.Node(1)
 	c.Put(ctx, t.Cockroach(), "./cockroach", c.All())
 	c.Put(ctx, t.DeprecatedWorkload(), "./workload", firstNode)
-	c.Start(ctx, t.L(), option.DefaultStartOpts(), install.MakeClusterSettings())
+	c.Start(ctx, t.L(), option.DefaultStartOptsNoBackups(), install.MakeClusterSettings())
 
 	conn := c.Conn(ctx, t.L(), 1)
 	t.Status("restoring TPCH dataset for Scale Factor 1")


### PR DESCRIPTION
This commit disables scheduling backups for tests that are somewhat perf sensitive (meaning that we internally use them for perf regressions).

Informs: #101526.

Epic: None

Release note: None