### PR TITLE
ui: update side nav and titles to match

### DIFF
--- a/pkg/ui/workspaces/db-console/src/app.spec.tsx
+++ b/pkg/ui/workspaces/db-console/src/app.spec.tsx
@@ -65,7 +65,7 @@ const LOADING_CLUSTER_STATUS = /Loading cluster status.*/;
 const NODE_LOG_HEADER = /Logs Node.*/;
 const JOBS_HEADER = "Jobs";
 const SQL_ACTIVITY_HEADER = "SQL Activity";
-const ADVANCED_DEBUG_HEADER = "Advanced Debugging";
+const ADVANCED_DEBUG_HEADER = "Advanced Debug";
 const REDUX_DEBUG_HEADER = "Redux State";
 const CUSTOM_METRICS_CHART_HEADER = "Custom Chart";
 const ENQUEUE_RANGE_HEADER = "Manually enqueue range in a replica queue";
@@ -75,7 +75,7 @@ const PROBLEM_RANGES_HEADER = "Problem Ranges Report";
 const LOCALITIES_REPORT_HEADER = "Localities";
 const NODE_DIAGNOSTICS_REPORT_HEADER = "Node Diagnostics";
 const DECOMMISSIONED_HISTORY_REPORT = "Decommissioned Node History";
-const NETWORK_DIAGNOSTICS_REPORT_HEADER = "Network Diagnostics";
+const NETWORK_DIAGNOSTICS_REPORT_HEADER = "Network";
 const CLUSTER_SETTINGS_REPORT = "Cluster Settings";
 const CERTIFICATES_REPORT_HEADER = "Certificates";
 const RANGE_REPORT_HEADER = /Range Report for.*/;
@@ -471,7 +471,9 @@ describe("Routing to", () => {
   describe("'/debug' path", () => {
     test("routes to <Debug> component", () => {
       navigateToPath("/debug");
-      screen.getByText(ADVANCED_DEBUG_HEADER);
+      screen.getByText(ADVANCED_DEBUG_HEADER, {
+        selector: "h3",
+      });
     });
   });
 
@@ -580,14 +582,18 @@ describe("Routing to", () => {
   describe("'/reports/network' path", () => {
     test("routes to <Network> component", () => {
       navigateToPath("/reports/network");
-      screen.getByText(NETWORK_DIAGNOSTICS_REPORT_HEADER);
+      screen.getByText(NETWORK_DIAGNOSTICS_REPORT_HEADER, {
+        selector: "h3",
+      });
     });
   });
 
   describe("'/reports/network/:nodeIDAttr' path", () => {
     test("routes to <Network> component", () => {
       navigateToPath("/reports/network/1");
-      screen.getByText(NETWORK_DIAGNOSTICS_REPORT_HEADER);
+      screen.getByText(NETWORK_DIAGNOSTICS_REPORT_HEADER, {
+        selector: "h3",
+      });
     });
   });
 

--- a/pkg/ui/workspaces/db-console/src/views/app/components/layoutSidebar/index.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/app/components/layoutSidebar/index.tsx
@@ -51,9 +51,9 @@ export class Sidebar extends React.Component<SidebarProps> {
     },
     {
       path: "/reports/network",
-      text: "Network Latency",
+      text: "Network",
       activeFor: ["/reports/network"],
-      // Do not show Network Latency for single node cluster.
+      // Do not show Network for single node cluster.
       isHidden: () => this.props.isSingleNodeCluster,
     },
     {

--- a/pkg/ui/workspaces/db-console/src/views/app/components/layoutSidebar/layoutSidebar.spec.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/app/components/layoutSidebar/layoutSidebar.spec.tsx
@@ -28,7 +28,7 @@ describe("LayoutSidebar", () => {
     };
   });
 
-  it("does not show Network Latency link for single node cluster", () => {
+  it("does not show Network link for single node cluster", () => {
     const wrapper = shallow(
       <Sidebar
         history={history}
@@ -42,7 +42,7 @@ describe("LayoutSidebar", () => {
     ).toBe(false);
   });
 
-  it("shows Network Latency link for multi node cluster", () => {
+  it("shows Network link for multi node cluster", () => {
     const wrapper = shallow(
       <Sidebar
         history={history}

--- a/pkg/ui/workspaces/db-console/src/views/reports/containers/debug/index.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/reports/containers/debug/index.tsx
@@ -260,7 +260,7 @@ export default function Debug() {
   return (
     <div className="section">
       <Helmet title="Debug" />
-      <h3 className="base-heading">Advanced Debugging</h3>
+      <h3 className="base-heading">Advanced Debug</h3>
       {disable_kv_level_advanced_debug && (
         <section className="section">
           <InlineAlert

--- a/pkg/ui/workspaces/db-console/src/views/reports/containers/network/index.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/reports/containers/network/index.tsx
@@ -102,7 +102,7 @@ export function getValueFromString(
 }
 
 /**
- * Renders the Network Diagnostics Report page.
+ * Renders the Network Report page.
  */
 export class Network extends React.Component<NetworkProps, INetworkState> {
   state: INetworkState = {
@@ -464,8 +464,8 @@ export class Network extends React.Component<NetworkProps, INetworkState> {
     const filters = getFilters(location);
     return (
       <Fragment>
-        <Helmet title="Network Diagnostics | Debug" />
-        <h3 className="base-heading">Network Diagnostics</h3>
+        <Helmet title="Network | Debug" />
+        <h3 className="base-heading">Network</h3>
         <Loading
           loading={!contentAvailable(nodesSummary)}
           page={"network"}

--- a/pkg/ui/workspaces/db-console/src/views/reports/containers/network/sort/sort.styl
+++ b/pkg/ui/workspaces/db-console/src/views/reports/containers/network/sort/sort.styl
@@ -11,7 +11,6 @@
 .Sort-latency
   display flex
   align-items center
-  padding 0 24px
 
 .Sort-latency__dropdown--spacing
   margin-right 24px


### PR DESCRIPTION
Previously the values for Advanced Debug (side nav) and Advanced Debugging (page title) were not matching. This commit uses the name "`Advanced Debug` for both.

Similarly, we were using Network Latency on the side nav and Network Diagnostics on the page title. Since we might want to show more than just latency, this commit updates the title to the more generic `Network`, to match how we name other pages (e.g. SQL Activity, Database, etc).

This commit also removed an extra space on the filter on the Network page.

Before
<img width="968" alt="Screenshot 2023-04-17 at 6 02 56 PM" src="https://user-images.githubusercontent.com/1017486/232657702-c399f8b0-9755-4aff-8043-c1753c7ad913.png">


After
<img width="967" alt="Screenshot 2023-04-17 at 10 43 18 PM" src="https://user-images.githubusercontent.com/1017486/232657728-7b907868-abc4-4926-80c8-5cf616ee2d58.png">


Epic: none

Release note (ui change): Update Network Latency side nav name and Network Diagnostics page title to `Network`. Update the Advanced Debugging page title to `Advanced Debug`.