### PR TITLE
ui: show fingerprints per index with max size limit reached

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/indexDetailsPage/indexDetailsPage.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/indexDetailsPage/indexDetailsPage.tsx
@@ -287,9 +287,9 @@ export class IndexDetailsPage extends React.Component<
       );
       getStatementsUsingIndex(req)
         .then(res => {
-          populateRegionNodeForStatements(res, this.props.nodeRegions);
+          populateRegionNodeForStatements(res.results, this.props.nodeRegions);
           this.setState({
-            statements: res,
+            statements: res.results,
             lastStatementsUpdated: moment(),
             lastStatementsError: null,
           });


### PR DESCRIPTION
Previosuly, the sql used to retrieve the most used fingerprints per index had a limit, but if the content of those fingerprints were big, we could still reach the max size limit on the sql api. If we hit that error we should still show the data returned, but in this case there is no need to add a warning that we might not be showing all data since the list is already a subset of the full list.

This commit makes sure we show the data even when we hit the max size limit error.

Fixes #101704

Video simulating a max size limit reached.
https://www.loom.com/share/c1f7a0c1f3df4b6c99cf757b78ba2e80

Release note (bug fix): Show list of fingerprints used per index even when we hit the max size limit of the sql api.