### PR TITLE
release-23.1.0: sql: add point insert and update enforce_home_region support

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/multi_region_remote_access_error
+++ b/pkg/ccl/logictestccl/testdata/logic_test/multi_region_remote_access_error
@@ -31,6 +31,42 @@ SELECT gateway_region();
 ap-southeast-2
 
 statement ok
+CREATE TABLE xy (
+  x INT NOT NULL,
+  y INT NOT NULL
+);
+
+statement ok
+ALTER TABLE xy ADD COLUMN region crdb_internal_region
+ AS (
+  CASE WHEN x = 0 THEN 'ca-central-1'
+       WHEN x = 1 THEN 'ap-southeast-2'
+       WHEN x = 2 THEN 'us-east-1'
+       WHEN x = 3 THEN 'us-east-1'
+  END
+  ) STORED;
+
+# Add and drop some columns to change the default mapping of columns ordinals
+# to column IDs for testing purposes.
+statement ok
+ALTER TABLE xy ADD COLUMN z INT;
+
+statement ok
+ALTER TABLE xy DROP COLUMN y;
+
+statement ok
+ALTER TABLE xy ADD COLUMN y INT;
+
+statement ok
+ALTER TABLE xy ALTER COLUMN region SET NOT NULL;
+
+statement ok
+ALTER TABLE xy SET LOCALITY REGIONAL BY ROW AS region;
+
+statement ok
+INSERT INTO xy (x, y, z) VALUES (0, 0, 0), (2, 2, 2);
+
+statement ok
 CREATE TABLE t1 (a INT, b INT, c INT, primary key(a)) LOCALITY REGIONAL BY ROW;
 
 statement ok
@@ -293,7 +329,7 @@ skipif config multiregion-9node-3region-3azs-vec-off
 query I retry
 SELECT DISTINCT range_id FROM [SHOW RANGES FROM TABLE messages_rbr]
 ----
-62
+65
 
 # Update does not fail when accessing all rows in messages_rbr because lookup
 # join does not error out the lookup table in phase 1.
@@ -1289,6 +1325,64 @@ ROLLBACK TO SAVEPOINT foo
 
 statement ok
 COMMIT
+
+statement ok
+SET sql_safe_updates = false;
+
+# Unconstrained delete should fail.
+retry
+statement error pq: Query has no home region\. Try adding a filter on xy\.region and/or on key column \(xy\.rowid\)\. For more information, see https://www.cockroachlabs.com/docs/stable/cost-based-optimizer.html#control-whether-queries-are-limited-to-a-single-region
+DELETE FROM xy;
+
+# Insert should error on inserting to a remote region.
+statement error pq: Query has no home region\. Try running the query from region 'ca-central-1'\. For more information, see https://www.cockroachlabs.com/docs/stable/cost-based-optimizer.html#control-whether-queries-are-limited-to-a-single-region
+INSERT INTO xy (z, x, y) VALUES (0, 0, 0);
+
+# Insert should not error on inserting to the local region.
+statement ok
+INSERT INTO xy (z, x, y) VALUES (1, 1, 1);
+
+statement ok
+ALTER TABLE xy ALTER PRIMARY KEY USING COLUMNS (x);
+
+# Insert fast-path should error on inserting to a remote region.
+retry
+statement error pq: Query has no home region\. Try running the query from region 'ca-central-1'\. For more information, see https://www.cockroachlabs.com/docs/stable/cost-based-optimizer.html#control-whether-queries-are-limited-to-a-single-region
+INSERT INTO xy (z, x, y) VALUES (0, 0, 0);
+
+# Upsert should error on looking up the matching row.
+retry
+statement error pq: Query has no home region\. Try adding a filter on xy\.region and/or on key column \(xy\.x\)\. For more information, see https://www.cockroachlabs.com/docs/stable/cost-based-optimizer.html#control-whether-queries-are-limited-to-a-single-region
+UPSERT INTO xy (z, x, y) VALUES (0, 0, 0);
+
+# Attempt to delete remote row fails.
+retry
+statement error pq: Query is not running in its home region\. Try running the query from region 'us-east-1'\. For more information, see https://www.cockroachlabs.com/docs/stable/cost-based-optimizer.html#control-whether-queries-are-limited-to-a-single-region
+DELETE FROM xy WHERE x = 2;
+
+# Deleting a local row is allowed.
+statement ok
+DELETE FROM xy WHERE x = 1;
+
+# Insert fast-path should not error on inserting to the local region.
+retry
+statement ok
+INSERT INTO xy (z, x, y) VALUES (1, 1, 1);
+
+# Remote row update should fail.
+retry
+statement error pq: Query is not running in its home region\. Try running the query from region 'us-east-1'\. For more information, see https://www.cockroachlabs.com/docs/stable/cost-based-optimizer.html#control-whether-queries-are-limited-to-a-single-region
+UPDATE xy set z=5 WHERE x = 2;
+
+# Local row update should succeed.
+retry
+statement ok
+UPDATE xy set z=5 WHERE x = 1;
+
+# Updating the row to be in a different region should fail.
+retry
+statement error pq: Query has no home region\. Try running the query from region 'us-east-1'\. For more information, see https://www.cockroachlabs.com/docs/stable/cost-based-optimizer.html#control-whether-queries-are-limited-to-a-single-region
+UPDATE xy set x=3 WHERE x = 1;
 
 statement ok
 RESET enforce_home_region

--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -1082,9 +1082,9 @@ func (ex *connExecutor) handleAOST(ctx context.Context, stmt tree.Statement) err
 		// home regions does not have to read rows from remote regions.
 		p.extendedEvalCtx.SetTxnTimestamp(asOf.Timestamp.GoTime())
 		if err := ex.state.setHistoricalTimestamp(ctx, asOf.Timestamp); err != nil {
-			return errors.AssertionFailedf(
-				"problem setting follower read timestamp for enforce_home_region dynamic error checking",
-			)
+			// If the table was just created, we may not be able to set a historical
+			// timestamp.
+			return execinfra.MaybeGetNonRetryableDynamicQueryHasNoHomeRegionError(ex.state.mu.autoRetryReason)
 		}
 	}
 	asOf, err := p.isAsOf(ctx, stmt)

--- a/pkg/sql/opt_exec_factory.go
+++ b/pkg/sql/opt_exec_factory.go
@@ -1372,6 +1372,8 @@ func (ef *execFactory) ConstructInsert(
 		},
 	}
 
+	ins.run.regionLocalInfo.setupEnforceHomeRegion(ef.planner, table, cols, ins.run.ti.ri.InsertColIDtoRowIndex)
+
 	// If rows are not needed, no columns are returned.
 	if rowsNeeded {
 		returnCols := makeColList(table, returnColOrdSet)
@@ -1442,6 +1444,8 @@ func (ef *execFactory) ConstructInsertFastPath(
 			},
 		},
 	}
+
+	ins.run.regionLocalInfo.setupEnforceHomeRegion(ef.planner, table, cols, ins.run.ti.ri.InsertColIDtoRowIndex)
 
 	if len(fkChecks) > 0 {
 		ins.run.fkChecks = make([]insertFastPathFKCheck, len(fkChecks))
@@ -1557,6 +1561,9 @@ func (ef *execFactory) ConstructUpdate(
 			numPassthrough: len(passthrough),
 		},
 	}
+
+	upd.run.regionLocalInfo.setupEnforceHomeRegion(ef.planner, table, ru.UpdateCols,
+		upd.run.tu.ru.UpdateColIDtoRowIndex)
 
 	// If rows are not needed, no columns are returned.
 	if rowsNeeded {

--- a/pkg/sql/update.go
+++ b/pkg/sql/update.go
@@ -119,6 +119,10 @@ type updateRun struct {
 	// columns of the target table being returned, that we must pass through
 	// from the input node.
 	numPassthrough int
+
+	// regionLocalInfo handles erroring out the UPDATE when the
+	// enforce_home_region setting is on.
+	regionLocalInfo regionLocalInfoType
 }
 
 func (u *updateNode) startExec(params runParams) error {
@@ -308,6 +312,12 @@ func (u *updateNode) processSourceRow(params runParams, sourceVals tree.Datums) 
 		if err != nil {
 			return err
 		}
+	}
+
+	// Error out the update if the enforce_home_region session setting is on and
+	// the row's locality doesn't match the gateway region.
+	if err := u.run.regionLocalInfo.checkHomeRegion(u.run.updateValues); err != nil {
+		return err
 	}
 
 	// Queue the insert in the KV batch.


### PR DESCRIPTION
Backport 1/1 commits from #100967.

/cc @cockroachdb/release

---

This adds missing support for erroring out insert, fast-path insert and
update when the enforce_home_region setting is on and we're attempting
to write a row to a remote region. Note that delete is already handled  
by code handling the scan it performs and upsert is handled by code     
handling the locality-optimized join (or regular join in the case of    
non-RBR tables) it performs.  

Epic: none
Fixes: #99580

Release note (bug fix): Support has been added for erroring out point
inserts and updates which write to a remote region of a table created
with the REGIONAL BY ROW AS clause.

Release justification: Low risk fix for missing point insert and update enforce_home_region support 