### PR TITLE
streamingccl: don't require TLS certificates

### DIFF
--- a/pkg/ccl/streamingccl/streamingest/stream_ingestion_planning.go
+++ b/pkg/ccl/streamingccl/streamingest/stream_ingestion_planning.go
@@ -166,16 +166,6 @@ func ingestionPlanHook(
 		if err != nil {
 			return err
 		}
-		q := streamURL.Query()
-
-		// Operator should specify a postgres scheme address with cert authentication.
-		if hasPostgresAuthentication := (q.Get("sslmode") == "verify-full") &&
-			q.Has("sslrootcert") && q.Has("sslkey") && q.Has("sslcert"); (streamURL.Scheme == "postgres") &&
-			!hasPostgresAuthentication {
-			return errors.Errorf(
-				"stream replication address should have cert authentication if in postgres scheme: %s", streamAddress)
-		}
-
 		streamAddress = streamingccl.StreamAddress(streamURL.String())
 
 		// TODO(adityamaru): Add privileges checks. Probably the same as RESTORE.


### PR DESCRIPTION
Users may want to use password auth to simplify their replication setup. While we may recommend TLS certificate auth, I don't see a strong reason to _require_ it.

Epic: none

Release note: None