### PR TITLE
roachtest: SSH errors and cluster creation failure not release blockers

### DIFF
--- a/pkg/cmd/roachtest/github.go
+++ b/pkg/cmd/roachtest/github.go
@@ -116,22 +116,25 @@ func (g *githubIssues) createPostRequest(
 	issueName := t.Name()
 
 	messagePrefix := ""
+	var infraFlake bool
 	// Overrides to shield eng teams from potential flakes
 	if cat == clusterCreationErr {
 		issueOwner = registry.OwnerDevInf
 		issueName = "cluster_creation"
 		messagePrefix = fmt.Sprintf("test %s was skipped due to ", t.Name())
+		infraFlake = true
 	} else if cat == sshErr {
 		issueOwner = registry.OwnerTestEng
 		issueName = "ssh_problem"
 		messagePrefix = fmt.Sprintf("test %s failed due to ", t.Name())
+		infraFlake = true
 	}
 
 	// Issues posted from roachtest are identifiable as such and
 	// they are also release blockers (this label may be removed
 	// by a human upon closer investigation).
 	labels := []string{"O-roachtest"}
-	if !spec.NonReleaseBlocker {
+	if !spec.NonReleaseBlocker && !infraFlake {
 		labels = append(labels, "release-blocker")
 	}
 


### PR DESCRIPTION
This removes the automatic `release-blocker` label from errors related to SSH flakes or cluster creation failures. Every time we create a new release branch, we invariably hit one of these situations and have to manually remove the label after being pinged by the release team.

Epic: none

Release note: None