### PR TITLE
sql: rewrite table names with ID references in UDFs

### DIFF
--- a/pkg/ccl/backupccl/backup_test.go
+++ b/pkg/ccl/backupccl/backup_test.go
@@ -10663,7 +10663,7 @@ CREATE TABLE sc1.tbl1(a INT PRIMARY KEY);
 CREATE TYPE sc1.enum1 AS ENUM('Good');
 CREATE SEQUENCE sc1.sq1;
 CREATE FUNCTION sc1.f1(a sc1.enum1) RETURNS INT LANGUAGE SQL AS $$
-  SELECT a FROM sc1.tbl1;
+  SELECT sc1.tbl1.a FROM sc1.tbl1;
   SELECT nextval('sc1.sq1');
 $$;
 `)
@@ -10702,7 +10702,7 @@ $$;
 		require.Equal(t, 111, int(fnDesc.GetID()))
 		require.Equal(t, 104, int(fnDesc.GetParentID()))
 		require.Equal(t, 106, int(fnDesc.GetParentSchemaID()))
-		require.Equal(t, "SELECT a FROM db1.sc1.tbl1;\nSELECT nextval(110:::REGCLASS);", fnDesc.GetFunctionBody())
+		require.Equal(t, "SELECT {TABLE:107}.a FROM {TABLE:107};\nSELECT nextval(110:::REGCLASS);", fnDesc.GetFunctionBody())
 		require.Equal(t, 100108, int(fnDesc.GetParams()[0].Type.Oid()))
 		require.Equal(t, []descpb.ID{107, 110}, fnDesc.GetDependsOn())
 		require.Equal(t, []descpb.ID{108, 109}, fnDesc.GetDependsOnTypes())
@@ -10755,7 +10755,7 @@ $$;
 		require.Equal(t, 112, int(fnDesc.GetParentID()))
 		require.Equal(t, 114, int(fnDesc.GetParentSchemaID()))
 		// Make sure db name and IDs are rewritten in function body.
-		require.Equal(t, "SELECT a FROM db1_new.sc1.tbl1;\nSELECT nextval(118:::REGCLASS);", fnDesc.GetFunctionBody())
+		require.Equal(t, "SELECT {TABLE:115}.a FROM {TABLE:115};\nSELECT nextval(118:::REGCLASS);", fnDesc.GetFunctionBody())
 		require.Equal(t, 100116, int(fnDesc.GetParams()[0].Type.Oid()))
 		require.Equal(t, []descpb.ID{115, 118}, fnDesc.GetDependsOn())
 		require.Equal(t, []descpb.ID{116, 117}, fnDesc.GetDependsOnTypes())
@@ -10802,7 +10802,7 @@ CREATE TABLE sc1.tbl1(a INT PRIMARY KEY);
 CREATE TYPE sc1.enum1 AS ENUM('Good');
 CREATE SEQUENCE sc1.sq1;
 CREATE FUNCTION sc1.f1(a sc1.enum1) RETURNS INT LANGUAGE SQL AS $$
-  SELECT a FROM sc1.tbl1;
+  SELECT sc1.tbl1.a FROM sc1.tbl1;
   SELECT nextval('sc1.sq1');
 $$;
 `)
@@ -10841,7 +10841,7 @@ $$;
 		require.Equal(t, 111, int(fnDesc.GetID()))
 		require.Equal(t, 104, int(fnDesc.GetParentID()))
 		require.Equal(t, 106, int(fnDesc.GetParentSchemaID()))
-		require.Equal(t, "SELECT a FROM db1.sc1.tbl1;\nSELECT nextval(110:::REGCLASS);", fnDesc.GetFunctionBody())
+		require.Equal(t, "SELECT {TABLE:107}.a FROM {TABLE:107};\nSELECT nextval(110:::REGCLASS);", fnDesc.GetFunctionBody())
 		require.Equal(t, 100108, int(fnDesc.GetParams()[0].Type.Oid()))
 		require.Equal(t, []descpb.ID{107, 110}, fnDesc.GetDependsOn())
 		require.Equal(t, []descpb.ID{108, 109}, fnDesc.GetDependsOnTypes())
@@ -10896,7 +10896,7 @@ $$;
 		require.Equal(t, 107, int(fnDesc.GetParentID()))
 		require.Equal(t, 125, int(fnDesc.GetParentSchemaID()))
 		// Make sure db name and IDs are rewritten in function body.
-		require.Equal(t, "SELECT a FROM db1.sc1.tbl1;\nSELECT nextval(129:::REGCLASS);", fnDesc.GetFunctionBody())
+		require.Equal(t, "SELECT {TABLE:126}.a FROM {TABLE:126};\nSELECT nextval(129:::REGCLASS);", fnDesc.GetFunctionBody())
 		require.Equal(t, 100127, int(fnDesc.GetParams()[0].Type.Oid()))
 		require.Equal(t, []descpb.ID{126, 129}, fnDesc.GetDependsOn())
 		require.Equal(t, []descpb.ID{127, 128}, fnDesc.GetDependsOnTypes())

--- a/pkg/ccl/logictestccl/testdata/logic_test/multi_region_remote_access_error
+++ b/pkg/ccl/logictestccl/testdata/logic_test/multi_region_remote_access_error
@@ -382,7 +382,7 @@ CREATE OR REPLACE FUNCTION rbr() RETURNS INT AS 'SELECT max(account_id) FROM mes
 
 # A UDF with no home region should fail.
 retry
-statement error pq: Query has no home region\. Try adding a filter on messages_rbr\.crdb_region and/or on key column \(multi_region_test_db\.public\.messages_rbr\.account_id\)\. For more information, see https://www.cockroachlabs.com/docs/stable/cost-based-optimizer.html#control-whether-queries-are-limited-to-a-single-region
+statement error pq: Query has no home region\. Try adding a filter on messages_rbr\.crdb_region and/or on key column \(messages_rbr\.account_id\)\. For more information, see https://www.cockroachlabs.com/docs/stable/cost-based-optimizer.html#control-whether-queries-are-limited-to-a-single-region
 SELECT rbr()
 
 # An EXISTS subquery with no home region should fail.
@@ -406,7 +406,7 @@ SELECT * FROM messages_rbr rbr, LATERAL
 
 # An array scalar expression with no home region should fail.
 retry
-statement error pq: Query has no home region\. Try adding a filter on messages_rbr\.crdb_region and/or on key column \(multi_region_test_db\.public\.messages_rbr\.account_id\)\. For more information, see https://www.cockroachlabs.com/docs/stable/cost-based-optimizer.html#control-whether-queries-are-limited-to-a-single-region
+statement error pq: Query has no home region\. Try adding a filter on messages_rbr\.crdb_region and/or on key column \(messages_rbr\.account_id\)\. For more information, see https://www.cockroachlabs.com/docs/stable/cost-based-optimizer.html#control-whether-queries-are-limited-to-a-single-region
 SELECT ARRAY[rbr(),rbr()]
 
 # An ALL subquery with no home region should fail.

--- a/pkg/ccl/logictestccl/tests/3node-tenant/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/3node-tenant/generated_test.go
@@ -2110,6 +2110,13 @@ func TestTenantLogic_udf(
 	runLogicTest(t, "udf")
 }
 
+func TestTenantLogic_udf_body_rewrite(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "udf_body_rewrite")
+}
+
 func TestTenantLogic_udf_delete(
 	t *testing.T,
 ) {

--- a/pkg/sql/catalog/colinfo/BUILD.bazel
+++ b/pkg/sql/catalog/colinfo/BUILD.bazel
@@ -50,6 +50,7 @@ go_test(
         "//pkg/sql/types",
         "//pkg/util/leaktest",
         "//pkg/util/log",
+        "@com_github_cockroachdb_errors//:errors",
         "@com_github_stretchr_testify//require",
     ],
 )

--- a/pkg/sql/catalog/colinfo/column_item_resolver.go
+++ b/pkg/sql/catalog/colinfo/column_item_resolver.go
@@ -60,6 +60,11 @@ type ColumnItemResolver interface {
 	Resolve(
 		ctx context.Context, prefix *tree.TableName, srcMeta ColumnSourceMeta, colHint int, col tree.Name,
 	) (ColumnResolutionResult, error)
+
+	// FindSourceWithID searches for a data source with an id.
+	FindSourceWithID(
+		ctx context.Context, id int64,
+	) (prefix *tree.TableName, srcMeta ColumnSourceMeta, err error)
 }
 
 // ColumnSourceMeta is an opaque reference passed through column item resolution.
@@ -144,4 +149,16 @@ func ResolveColumnItem(
 			"no data source matches prefix: %s in this context", c.TableName)
 	}
 	return r.Resolve(ctx, srcName, srcMeta, -1, colName)
+}
+
+// ResolveColumnNameRef performs name resolution for a column prefixed with
+// table id reference.
+func ResolveColumnNameRef(
+	ctx context.Context, r ColumnItemResolver, c *tree.ColumnNameRef,
+) (ColumnResolutionResult, error) {
+	srcName, srcMeta, err := r.FindSourceWithID(ctx, c.Table.ID)
+	if err != nil {
+		return nil, err
+	}
+	return r.Resolve(ctx, srcName, srcMeta, -1, c.ColumnName)
 }

--- a/pkg/sql/catalog/colinfo/column_item_resolver_test.go
+++ b/pkg/sql/catalog/colinfo/column_item_resolver_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/errors"
 )
 
 // fakeSource represents a fake column resolution environment for tests.
@@ -79,6 +80,13 @@ func (f *fakeSource) FindSourceMatchingName(
 		return colinfo.NoResults, nil, nil, nil
 	}
 	return colinfo.ExactlyOne, prefix, columns, nil
+}
+
+// FindSourceWithID implements colinfo.ColumnItemResolver interface.
+func (f *fakeSource) FindSourceWithID(
+	ctx context.Context, id int64,
+) (prefix *tree.TableName, srcMeta colinfo.ColumnSourceMeta, err error) {
+	return nil, nil, errors.AssertionFailedf("FindSourceWithID not implemented")
 }
 
 // FindSourceProvidingColumn is part of the ColumnItemResolver interface.

--- a/pkg/sql/catalog/colinfo/column_resolver.go
+++ b/pkg/sql/catalog/colinfo/column_resolver.go
@@ -19,6 +19,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/errors"
 )
 
 // ProcessTargetColumns returns the column descriptors identified by the
@@ -98,7 +99,7 @@ type ColumnResolver struct {
 	}
 }
 
-// FindSourceMatchingName is part of the tree.ColumnItemResolver interface.
+// FindSourceMatchingName is part of the colinfo.ColumnItemResolver interface.
 func (r *ColumnResolver) FindSourceMatchingName(
 	ctx context.Context, tn tree.TableName,
 ) (res NumResolutionResults, prefix *tree.TableName, srcMeta ColumnSourceMeta, err error) {
@@ -109,7 +110,7 @@ func (r *ColumnResolver) FindSourceMatchingName(
 	return ExactlyOne, prefix, nil, nil
 }
 
-// FindSourceProvidingColumn is part of the tree.ColumnItemResolver interface.
+// FindSourceProvidingColumn is part of the colinfo.ColumnItemResolver interface.
 func (r *ColumnResolver) FindSourceProvidingColumn(
 	ctx context.Context, col tree.Name,
 ) (prefix *tree.TableName, srcMeta ColumnSourceMeta, colHint int, err error) {
@@ -134,7 +135,14 @@ func (r *ColumnResolver) FindSourceProvidingColumn(
 	return prefix, nil, colIdx, nil
 }
 
-// Resolve is part of the tree.ColumnItemResolver interface.
+// FindSourceWithID is part of the colinfo.ColumnItemResolver interface.
+func (r *ColumnResolver) FindSourceWithID(
+	ctx context.Context, id int64,
+) (prefix *tree.TableName, srcMeta ColumnSourceMeta, err error) {
+	return nil, nil, errors.AssertionFailedf("FindSourceWithID not implemented")
+}
+
+// Resolve is part of the colinfo.ColumnItemResolver interface.
 func (r *ColumnResolver) Resolve(
 	ctx context.Context, prefix *tree.TableName, srcMeta ColumnSourceMeta, colHint int, col tree.Name,
 ) (ColumnResolutionResult, error) {

--- a/pkg/sql/catalog/redact/redact_test.go
+++ b/pkg/sql/catalog/redact/redact_test.go
@@ -68,6 +68,6 @@ $$`)
 		fn := desctestutils.TestGetFunctionDescriptor(kvDB, keys.SystemSQLCodec, "defaultdb", "public", "f1")
 		mut := funcdesc.NewBuilder(fn.FuncDesc()).BuildCreatedMutableFunction()
 		require.Empty(t, redact.Redact(mut.DescriptorProto()))
-		require.Equal(t, `SELECT k FROM defaultdb.public.kv WHERE v != '_'; SELECT k FROM defaultdb.public.kv WHERE v = '_';`, mut.FunctionBody)
+		require.Equal(t, `SELECT k FROM {TABLE:104} WHERE v != '_'; SELECT k FROM {TABLE:104} WHERE v = '_';`, mut.FunctionBody)
 	})
 }

--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -3294,7 +3294,11 @@ CREATE TABLE crdb_internal.create_function_statements (
 					if err != nil {
 						return err
 					}
-					stmtStrs := strings.Split(seqReplacedBody, "\n")
+					tableIDReplacedBody, err := formatTableReferenceForDisplay(ctx, &p.semaCtx, seqReplacedBody, true /* multiStmt */)
+					if err != nil {
+						return err
+					}
+					stmtStrs := strings.Split(tableIDReplacedBody, "\n")
 					for i := range stmtStrs {
 						stmtStrs[i] = "\t" + stmtStrs[i]
 					}

--- a/pkg/sql/create_function_test.go
+++ b/pkg/sql/create_function_test.go
@@ -77,10 +77,10 @@ $$;
 		require.Equal(t, funcDesc.GetName(), "f")
 
 		require.Equal(t,
-			`SELECT a FROM defaultdb.public.t;
-SELECT b FROM defaultdb.public.t@t_idx_b;
-SELECT c FROM defaultdb.public.t@t_idx_c;
-SELECT a FROM defaultdb.public.v;
+			`SELECT a FROM {TABLE:104};
+SELECT b FROM {TABLE:104}@t_idx_b;
+SELECT c FROM {TABLE:104}@t_idx_c;
+SELECT a FROM {TABLE:107};
 SELECT nextval(105:::REGCLASS);`,
 			funcDesc.GetFunctionBody())
 
@@ -317,8 +317,8 @@ $$;
 		require.Equal(t, funcDesc.GetName(), "f")
 
 		require.Equal(t,
-			`SELECT b FROM defaultdb.public.t1@t1_idx_b;
-SELECT a FROM defaultdb.public.v1;
+			`SELECT b FROM {TABLE:104}@t1_idx_b;
+SELECT a FROM {TABLE:108};
 SELECT nextval(106:::REGCLASS);`,
 			funcDesc.GetFunctionBody())
 
@@ -360,8 +360,8 @@ $$;
 		require.Equal(t, funcDesc.GetName(), "f")
 
 		require.Equal(t,
-			`SELECT b FROM defaultdb.public.t2@t2_idx_b;
-SELECT a FROM defaultdb.public.v2;
+			`SELECT b FROM {TABLE:105}@t2_idx_b;
+SELECT a FROM {TABLE:109};
 SELECT nextval(107:::REGCLASS);`,
 			funcDesc.GetFunctionBody())
 

--- a/pkg/sql/drop_function_test.go
+++ b/pkg/sql/drop_function_test.go
@@ -67,10 +67,10 @@ CREATE SCHEMA test_sc;
 		require.Equal(t, funcDesc.GetName(), "f")
 
 		require.Equal(t,
-			`SELECT a FROM defaultdb.public.t;
-SELECT b FROM defaultdb.public.t@t_idx_b;
-SELECT c FROM defaultdb.public.t@t_idx_c;
-SELECT a FROM defaultdb.public.v;
+			`SELECT a FROM {TABLE:104};
+SELECT b FROM {TABLE:104}@t_idx_b;
+SELECT c FROM {TABLE:104}@t_idx_c;
+SELECT a FROM {TABLE:106};
 SELECT nextval(105:::REGCLASS);`,
 			funcDesc.GetFunctionBody())
 

--- a/pkg/sql/function_resolver_test.go
+++ b/pkg/sql/function_resolver_test.go
@@ -122,10 +122,10 @@ CREATE FUNCTION f(INT) RETURNS INT VOLATILE LANGUAGE SQL AS $$ SELECT a FROM t $
 
 		_, overload, err := funcResolver.ResolveFunctionByOID(ctx, funcDef.Overloads[0].Oid)
 		require.NoError(t, err)
-		require.Equal(t, `SELECT a FROM defaultdb.public.t;
-SELECT b FROM defaultdb.public.t@t_idx_b;
-SELECT c FROM defaultdb.public.t@t_idx_c;
-SELECT a FROM defaultdb.public.v;
+		require.Equal(t, `SELECT a FROM {TABLE:104};
+SELECT b FROM {TABLE:104}@t_idx_b;
+SELECT c FROM {TABLE:104}@t_idx_c;
+SELECT a FROM {TABLE:107};
 SELECT nextval(105:::REGCLASS);`, overload.Body)
 		require.True(t, overload.IsUDF)
 		require.False(t, overload.UDFContainsOnlySignature)
@@ -144,7 +144,7 @@ SELECT nextval(105:::REGCLASS);`, overload.Body)
 
 		_, overload, err = funcResolver.ResolveFunctionByOID(ctx, funcDef.Overloads[2].Oid)
 		require.NoError(t, err)
-		require.Equal(t, `SELECT a FROM defaultdb.public.t;`, overload.Body)
+		require.Equal(t, `SELECT a FROM {TABLE:104};`, overload.Body)
 		require.True(t, overload.IsUDF)
 		require.False(t, overload.UDFContainsOnlySignature)
 		require.Equal(t, 1, len(overload.Types.Types()))

--- a/pkg/sql/logictest/testdata/logic_test/udf
+++ b/pkg/sql/logictest/testdata/logic_test/udf
@@ -1736,57 +1736,6 @@ SELECT sc2.f_seq()
 4
 
 statement ok
-SET DATABASE = test
-
-subtest select_from_seq_rename
-
-statement ok
-CREATE DATABASE tdb_seq_select;
-SET DATABASE = tdb_seq_select;
-
-statement ok
-CREATE SCHEMA sc;
-CREATE SEQUENCE sc.sq;
-CREATE FUNCTION f() RETURNS INT LANGUAGE SQL AS $$ SELECT last_value FROM sc.sq $$;
-
-query I
-SELECT f()
-----
-0
-
-statement ok
-ALTER SEQUENCE sc.sq RENAME TO sq_new;
-
-statement error pq: relation "tdb_seq_select.sc.sq" does not exist
-SELECT f()
-
-statement ok
-ALTER SEQUENCE sc.sq_new RENAME TO sq;
-SELECT f();
-
-statement ok
-ALTER SCHEMA sc RENAME TO sc_new;
-
-statement error pq: unknown schema "sc"
-SELECT f()
-
-statement ok
-ALTER SCHEMA sc_new RENAME TO sc;
-SELECT f()
-
-statement ok
-ALTER DATABASE tdb_seq_select RENAME TO tdb_seq_select_new;
-SET DATABASE = tdb_seq_select_new;
-
-statement error pq: database "tdb_seq_select" does not exist
-SELECT f()
-
-statement ok
-ALTER DATABASE tdb_seq_select_new RENAME TO tdb_seq_select;
-SET DATABASE = tdb_seq_select;
-SELECT f()
-
-statement ok
 SET DATABASE = test;
 
 subtest event_logging
@@ -1810,7 +1759,7 @@ WITH tmp AS (
 )
 SELECT etype, info_json->'DescriptorID', info_json->'FunctionName', info_json->'Statement' FROM tmp;
 ----
-create_function  203  "test.public.f_test_log"  "CREATE FUNCTION test.public.f_test_log()\n\tRETURNS INT8\n\tLANGUAGE SQL\n\tAS $$SELECT 1;$$"
+create_function  198  "test.public.f_test_log"  "CREATE FUNCTION test.public.f_test_log()\n\tRETURNS INT8\n\tLANGUAGE SQL\n\tAS $$SELECT 1;$$"
 
 statement ok
 CREATE OR REPLACE FUNCTION f_test_log() RETURNS INT LANGUAGE SQL AS $$ SELECT 2 $$;
@@ -1826,8 +1775,8 @@ SELECT etype, info_json->'DescriptorID', info_json->'FunctionName', info_json->'
 FROM tmp
 ORDER BY 4
 ----
-create_function  203  "test.public.f_test_log"  "CREATE FUNCTION test.public.f_test_log()\n\tRETURNS INT8\n\tLANGUAGE SQL\n\tAS $$SELECT 1;$$"
-create_function  203  "test.public.f_test_log"  "CREATE OR REPLACE FUNCTION test.public.f_test_log()\n\tRETURNS INT8\n\tLANGUAGE SQL\n\tAS $$SELECT 2;$$"
+create_function  198  "test.public.f_test_log"  "CREATE FUNCTION test.public.f_test_log()\n\tRETURNS INT8\n\tLANGUAGE SQL\n\tAS $$SELECT 1;$$"
+create_function  198  "test.public.f_test_log"  "CREATE OR REPLACE FUNCTION test.public.f_test_log()\n\tRETURNS INT8\n\tLANGUAGE SQL\n\tAS $$SELECT 2;$$"
 
 statement ok
 ALTER FUNCTION f_test_log RENAME TO f_test_log_new;
@@ -1841,7 +1790,7 @@ WITH tmp AS (
 )
 SELECT etype, info_json->'DescriptorID', info_json->'FunctionName', info_json->'NewFunctionName', info_json->'Statement' FROM tmp;
 ----
-rename_function  203  "test.public.f_test_log"  "test.public.f_test_log_new"  "ALTER FUNCTION \"\".\"\".f_test_log RENAME TO f_test_log_new"
+rename_function  198  "test.public.f_test_log"  "test.public.f_test_log_new"  "ALTER FUNCTION \"\".\"\".f_test_log RENAME TO f_test_log_new"
 
 statement ok
 ALTER FUNCTION f_test_log_new RENAME TO f_test_log;
@@ -1858,7 +1807,7 @@ WITH tmp AS (
 )
 SELECT etype, info_json->'DescriptorID', info_json->'FunctionName', info_json->'Owner', info_json->'Statement' FROM tmp;
 ----
-alter_function_owner  203  "test.public.f_test_log"  "u_test_event"  "ALTER FUNCTION \"\".\"\".f_test_log OWNER TO u_test_event"
+alter_function_owner  198  "test.public.f_test_log"  "u_test_event"  "ALTER FUNCTION \"\".\"\".f_test_log OWNER TO u_test_event"
 
 statement ok
 ALTER FUNCTION f_test_log SET SCHEMA sc_test_event;
@@ -1872,7 +1821,7 @@ WITH tmp AS (
 )
 SELECT etype, info_json->'DescriptorID', info_json->'DescriptorName', info_json->'NewDescriptorName', info_json->'Statement' FROM tmp;
 ----
-set_schema  203  "test.public.f_test_log"  "test.sc_test_event.f_test_log"  "ALTER FUNCTION \"\".\"\".f_test_log SET SCHEMA sc_test_event"
+set_schema  198  "test.public.f_test_log"  "test.sc_test_event.f_test_log"  "ALTER FUNCTION \"\".\"\".f_test_log SET SCHEMA sc_test_event"
 
 statement ok
 ALTER FUNCTION sc_test_event.f_test_log SET SCHEMA public;
@@ -1888,7 +1837,7 @@ WITH tmp AS (
 )
 SELECT etype, info_json->'DescriptorID', info_json->'FunctionName', info_json->'Statement' FROM tmp;
 ----
-alter_function_options  203  "test.public.f_test_log"  "ALTER FUNCTION \"\".\"\".f_test_log IMMUTABLE"
+alter_function_options  198  "test.public.f_test_log"  "ALTER FUNCTION \"\".\"\".f_test_log IMMUTABLE"
 
 onlyif config local-legacy-schema-changer
 query TTTT retry
@@ -1899,7 +1848,7 @@ WITH tmp AS (
 )
 SELECT etype, info_json->'DescriptorID', info_json->'FunctionName', info_json->'Statement' FROM tmp;
 ----
-drop_function  203  "test.public.f_test_log"  "DROP FUNCTION \"\".\"\".f_test_log"
+drop_function  198  "test.public.f_test_log"  "DROP FUNCTION \"\".\"\".f_test_log"
 
 subtest show_grants
 
@@ -1920,10 +1869,10 @@ SELECT * FROM [
 ] ORDER BY function_signature, grantee
 ----
 database_name  schema_name          function_id  function_signature                   grantee             privilege_type  is_grantable
-test           sc_test_show_grants  100205       f_test_show_grants(int8)             root                EXECUTE         true
-test           sc_test_show_grants  100205       f_test_show_grants(int8)             u_test_show_grants  EXECUTE         false
-test           sc_test_show_grants  100206       f_test_show_grants(int8, text, oid)  root                EXECUTE         true
-test           sc_test_show_grants  100206       f_test_show_grants(int8, text, oid)  u_test_show_grants  EXECUTE         false
+test           sc_test_show_grants  100200       f_test_show_grants(int8)             root                EXECUTE         true
+test           sc_test_show_grants  100200       f_test_show_grants(int8)             u_test_show_grants  EXECUTE         false
+test           sc_test_show_grants  100201       f_test_show_grants(int8, text, oid)  root                EXECUTE         true
+test           sc_test_show_grants  100201       f_test_show_grants(int8, text, oid)  u_test_show_grants  EXECUTE         false
 
 statement error pq: function f_test_show_grants\(string\) does not exist: function undefined
 SHOW GRANTS ON FUNCTION f_test_show_grants(string);
@@ -1932,15 +1881,15 @@ query TTTTTTB colnames
 SELECT * FROM [SHOW GRANTS ON FUNCTION f_test_show_grants(INT)] ORDER BY grantee
 ----
 database_name  schema_name          function_id  function_signature        grantee             privilege_type  is_grantable
-test           sc_test_show_grants  100205       f_test_show_grants(int8)  root                EXECUTE         true
-test           sc_test_show_grants  100205       f_test_show_grants(int8)  u_test_show_grants  EXECUTE         false
+test           sc_test_show_grants  100200       f_test_show_grants(int8)  root                EXECUTE         true
+test           sc_test_show_grants  100200       f_test_show_grants(int8)  u_test_show_grants  EXECUTE         false
 
 query TTTTTTB colnames
 SELECT * FROM [SHOW GRANTS ON FUNCTION f_test_show_grants(INT, string, OID)] ORDER BY function_signature, grantee
 ----
 database_name  schema_name          function_id  function_signature                   grantee             privilege_type  is_grantable
-test           sc_test_show_grants  100206       f_test_show_grants(int8, text, oid)  root                EXECUTE         true
-test           sc_test_show_grants  100206       f_test_show_grants(int8, text, oid)  u_test_show_grants  EXECUTE         false
+test           sc_test_show_grants  100201       f_test_show_grants(int8, text, oid)  root                EXECUTE         true
+test           sc_test_show_grants  100201       f_test_show_grants(int8, text, oid)  u_test_show_grants  EXECUTE         false
 
 statement error pq: unknown function: f_not_existing\(\): function undefined
 SHOW GRANTS ON FUNCTION f_not_existing;
@@ -1951,8 +1900,8 @@ SELECT * FROM [
 ] ORDER BY function_id
 ----
 database_name  schema_name          function_id  function_signature                   grantee             privilege_type  is_grantable
-test           sc_test_show_grants  100205       f_test_show_grants(int8)             u_test_show_grants  EXECUTE         false
-test           sc_test_show_grants  100206       f_test_show_grants(int8, text, oid)  u_test_show_grants  EXECUTE         false
+test           sc_test_show_grants  100200       f_test_show_grants(int8)             u_test_show_grants  EXECUTE         false
+test           sc_test_show_grants  100201       f_test_show_grants(int8, text, oid)  u_test_show_grants  EXECUTE         false
 
 query TTTTTB colnames
 SELECT * FROM [SHOW GRANTS FOR u_test_show_grants] ORDER BY relation_name
@@ -3094,10 +3043,10 @@ SELECT oid, proname, pronamespace, proowner, prolang, proleakproof, proisstrict,
 FROM pg_catalog.pg_proc WHERE proname IN ('f_93314', 'f_93314_alias', 'f_93314_comp', 'f_93314_comp_t')
 ORDER BY oid;
 ----
-100273  f_93314         105  1546506610  14  false  false  false  v  0  100272  ·  {}  NULL  SELECT i, e FROM test.public.t_93314 ORDER BY i LIMIT 1;
-100275  f_93314_alias   105  1546506610  14  false  false  false  v  0  100274  ·  {}  NULL  SELECT i, e FROM test.public.t_93314_alias ORDER BY i LIMIT 1;
-100279  f_93314_comp    105  1546506610  14  false  false  false  v  0  100276  ·  {}  NULL  SELECT (1, 2);
-100280  f_93314_comp_t  105  1546506610  14  false  false  false  v  0  100278  ·  {}  NULL  SELECT a, c FROM test.public.t_93314_comp LIMIT 1;
+100268  f_93314         105  1546506610  14  false  false  false  v  0  100267  ·  {}  NULL  SELECT i, e FROM {TABLE:267} ORDER BY i LIMIT 1;
+100270  f_93314_alias   105  1546506610  14  false  false  false  v  0  100269  ·  {}  NULL  SELECT i, e FROM {TABLE:269} ORDER BY i LIMIT 1;
+100274  f_93314_comp    105  1546506610  14  false  false  false  v  0  100271  ·  {}  NULL  SELECT (1, 2);
+100275  f_93314_comp_t  105  1546506610  14  false  false  false  v  0  100273  ·  {}  NULL  SELECT a, c FROM {TABLE:273} LIMIT 1;
 
 # Regression test for #95240. Strict UDFs that are inlined should result in NULL
 # when presented with NULL arguments.

--- a/pkg/sql/logictest/testdata/logic_test/udf_body_rewrite
+++ b/pkg/sql/logictest/testdata/logic_test/udf_body_rewrite
@@ -41,7 +41,19 @@ SELECT get_body_str('f');
 ----
 "SELECT a FROM {TABLE:106} WHERE b > 20 ORDER BY b;"
 
-# TODO(chengxiong): add SHOW CREATE FUNCTION test.
+# Make sure show create function deserializes it.
+query T
+SELECT create_statement FROM [SHOW CREATE FUNCTION f]
+----
+CREATE FUNCTION public.f()
+  RETURNS INT8
+  VOLATILE
+  NOT LEAKPROOF
+  CALLED ON NULL INPUT
+  LANGUAGE SQL
+  AS $$
+  SELECT a FROM test.public.t1 WHERE b > 20 ORDER BY b;
+$$
 
 # Make sure function is still executable.
 query I
@@ -63,7 +75,19 @@ SELECT get_body_str('f');
 ----
 "SELECT {TABLE:106}.a FROM {TABLE:106} WHERE {TABLE:106}.b > 20 ORDER BY {TABLE:106}.b;"
 
-# TODO(chengxiong): add SHOW CREATE FUNCTION test.
+# Make sure show create function deserializes it.
+query T
+SELECT create_statement FROM [SHOW CREATE FUNCTION f]
+----
+CREATE FUNCTION public.f()
+  RETURNS INT8
+  VOLATILE
+  NOT LEAKPROOF
+  CALLED ON NULL INPUT
+  LANGUAGE SQL
+  AS $$
+  SELECT test.public.t1.a FROM test.public.t1 WHERE test.public.t1.b > 20 ORDER BY test.public.t1.b;
+$$
 
 query I
 SELECT f()
@@ -83,7 +107,18 @@ SELECT get_body_str('f');
 ----
 "SELECT t.a FROM (SELECT a FROM {TABLE:106} WHERE b > 20 ORDER BY b) AS t WHERE t.a > 1 ORDER BY t.a;"
 
-# TODO(chengxiong): add SHOW CREATE FUNCTION test.
+query T
+SELECT create_statement FROM [SHOW CREATE FUNCTION f]
+----
+CREATE FUNCTION public.f()
+  RETURNS INT8
+  VOLATILE
+  NOT LEAKPROOF
+  CALLED ON NULL INPUT
+  LANGUAGE SQL
+  AS $$
+  SELECT t.a FROM (SELECT a FROM test.public.t1 WHERE b > 20 ORDER BY b) AS t WHERE t.a > 1 ORDER BY t.a;
+$$
 
 query I
 SELECT f()
@@ -106,7 +141,18 @@ SELECT get_body_str('f_order_star');
 ----
 "SELECT {TABLE:106}.a, {TABLE:106}.b, {TABLE:106}.c, {TABLE:107}.a, {TABLE:107}.b, {TABLE:107}.d FROM {TABLE:106} JOIN {TABLE:107} ON c = d GROUP BY t1.*, t2.* ORDER BY t1.*, t2.*;"
 
-# TODO(chengxiong): add SHOW CREATE FUNCTION test.
+query T
+SELECT create_statement FROM [SHOW CREATE FUNCTION f_order_star]
+----
+CREATE FUNCTION public.f_order_star()
+  RETURNS RECORD
+  VOLATILE
+  NOT LEAKPROOF
+  CALLED ON NULL INPUT
+  LANGUAGE SQL
+  AS $$
+  SELECT test.public.t1.a, test.public.t1.b, test.public.t1.c, test.public.t2.a, test.public.t2.b, test.public.t2.d FROM test.public.t1 JOIN test.public.t2 ON c = d GROUP BY t1.*, t2.* ORDER BY t1.*, t2.*;
+$$
 
 query T
 SELECT f_order_star()
@@ -126,7 +172,18 @@ SELECT get_body_str('f_order_srf');
 ----
 "SELECT (pg_get_keywords()).word, (pg_get_keywords()).catcode, (pg_get_keywords()).catdesc ORDER BY word LIMIT 1;"
 
-# TODO(chengxiong): add SHOW CREATE FUNCTION test.
+query T
+SELECT create_statement FROM [SHOW CREATE FUNCTION f_order_star]
+----
+CREATE FUNCTION public.f_order_star()
+  RETURNS RECORD
+  VOLATILE
+  NOT LEAKPROOF
+  CALLED ON NULL INPUT
+  LANGUAGE SQL
+  AS $$
+  SELECT test.public.t1.a, test.public.t1.b, test.public.t1.c, test.public.t2.a, test.public.t2.b, test.public.t2.d FROM test.public.t1 JOIN test.public.t2 ON c = d GROUP BY t1.*, t2.* ORDER BY t1.*, t2.*;
+$$
 
 query T
 SELECT f_order_srf()
@@ -151,7 +208,20 @@ SELECT get_body_str('f');
 ----
 "SELECT {TABLE:106}.a + {TABLE:107}.a FROM {TABLE:106} JOIN {TABLE:107} ON {TABLE:106}.b = {TABLE:107}.b GROUP BY {TABLE:106}.a + {TABLE:107}.a HAVING ({TABLE:106}.a + {TABLE:107}.a) > 1 ORDER BY {TABLE:106}.a + {TABLE:107}.a;"
 
-# TODO(chengxiong): add SHOW CREATE FUNCTION test.
+# TODO(chengxiong) make sure ON condition is walked so we show table names in
+# the create statement.
+query T
+SELECT create_statement FROM [SHOW CREATE FUNCTION f]
+----
+CREATE FUNCTION public.f()
+  RETURNS INT8
+  VOLATILE
+  NOT LEAKPROOF
+  CALLED ON NULL INPUT
+  LANGUAGE SQL
+  AS $$
+  SELECT test.public.t1.a + test.public.t2.a FROM test.public.t1 JOIN test.public.t2 ON {TABLE:106}.b = {TABLE:107}.b GROUP BY test.public.t1.a + test.public.t2.a HAVING (test.public.t1.a + test.public.t2.a) > 1 ORDER BY test.public.t1.a + test.public.t2.a;
+$$
 
 query I
 SELECT f()
@@ -177,7 +247,18 @@ SELECT get_body_str('f');
 ----
 "SELECT c + d FROM {TABLE:106} JOIN {TABLE:107} ON c = d GROUP BY c + d HAVING (c + d) > 1 ORDER BY c + d;"
 
-# TODO(chengxiong): add SHOW CREATE FUNCTION test.
+query T
+SELECT create_statement FROM [SHOW CREATE FUNCTION f]
+----
+CREATE FUNCTION public.f()
+  RETURNS INT8
+  VOLATILE
+  NOT LEAKPROOF
+  CALLED ON NULL INPUT
+  LANGUAGE SQL
+  AS $$
+  SELECT c + d FROM test.public.t1 JOIN test.public.t2 ON c = d GROUP BY c + d HAVING (c + d) > 1 ORDER BY c + d;
+$$
 
 query I
 SELECT f()
@@ -199,7 +280,18 @@ SELECT get_body_str('f');
 ----
 "SELECT {TABLE:106}.a + {TABLE:107}.a FROM {TABLE:106} JOIN {TABLE:107} USING (a);"
 
-# TODO(chengxiong): add SHOW CREATE FUNCTION test.
+query T
+SELECT create_statement FROM [SHOW CREATE FUNCTION f]
+----
+CREATE FUNCTION public.f()
+  RETURNS INT8
+  VOLATILE
+  NOT LEAKPROOF
+  CALLED ON NULL INPUT
+  LANGUAGE SQL
+  AS $$
+  SELECT test.public.t1.a + test.public.t2.a FROM test.public.t1 JOIN test.public.t2 USING (a);
+$$
 
 # Make sure table aliases are not rewritten.
 statement ok
@@ -219,7 +311,18 @@ SELECT get_body_str('f');
 ----
 "SELECT p.a + q.a FROM {TABLE:106} AS p JOIN {TABLE:107} AS q ON p.b = q.b GROUP BY p.a + q.a HAVING (p.a + q.a) > 1 ORDER BY p.a + q.a;"
 
-# TODO(chengxiong): add SHOW CREATE FUNCTION test.
+query T
+SELECT create_statement FROM [SHOW CREATE FUNCTION f]
+----
+CREATE FUNCTION public.f()
+  RETURNS INT8
+  VOLATILE
+  NOT LEAKPROOF
+  CALLED ON NULL INPUT
+  LANGUAGE SQL
+  AS $$
+  SELECT p.a + q.a FROM test.public.t1 AS p JOIN test.public.t2 AS q ON p.b = q.b GROUP BY p.a + q.a HAVING (p.a + q.a) > 1 ORDER BY p.a + q.a;
+$$
 
 query I
 SELECT f()
@@ -239,7 +342,18 @@ SELECT get_body_str('f');
 ----
 "SELECT DISTINCT ON (a) b FROM {TABLE:106} ORDER BY a;"
 
-# TODO(chengxiong): add SHOW CREATE FUNCTION test.
+query T
+SELECT create_statement FROM [SHOW CREATE FUNCTION f]
+----
+CREATE FUNCTION public.f()
+  RETURNS INT8
+  VOLATILE
+  NOT LEAKPROOF
+  CALLED ON NULL INPUT
+  LANGUAGE SQL
+  AS $$
+  SELECT DISTINCT ON (a) b FROM test.public.t1 ORDER BY a;
+$$
 
 query I
 SELECT f()
@@ -259,7 +373,18 @@ SELECT get_body_str('f');
 ----
 "SELECT DISTINCT ON ({TABLE:106}.a) {TABLE:106}.b FROM {TABLE:106} ORDER BY a;"
 
-# TODO(chengxiong): add SHOW CREATE FUNCTION test.
+query T
+SELECT create_statement FROM [SHOW CREATE FUNCTION f]
+----
+CREATE FUNCTION public.f()
+  RETURNS INT8
+  VOLATILE
+  NOT LEAKPROOF
+  CALLED ON NULL INPUT
+  LANGUAGE SQL
+  AS $$
+  SELECT DISTINCT ON (test.public.t1.a) test.public.t1.b FROM test.public.t1 ORDER BY a;
+$$
 
 query I
 SELECT f()
@@ -279,7 +404,18 @@ SELECT get_body_str('f_expand');
 ----
 "SELECT {TABLE:106}.a, {TABLE:106}.b, {TABLE:106}.c, a FROM {TABLE:106};"
 
-# TODO(chengxiong): add SHOW CREATE FUNCTION test.
+query T
+SELECT create_statement FROM [SHOW CREATE FUNCTION f_expand]
+----
+CREATE FUNCTION public.f_expand()
+  RETURNS RECORD
+  VOLATILE
+  NOT LEAKPROOF
+  CALLED ON NULL INPUT
+  LANGUAGE SQL
+  AS $$
+  SELECT test.public.t1.a, test.public.t1.b, test.public.t1.c, a FROM test.public.t1;
+$$
 
 query T
 SELECT f_expand()
@@ -299,7 +435,18 @@ SELECT get_body_str('f_expand');
 ----
 "SELECT t.a, t.b, t.c, t.a FROM (SELECT {TABLE:106}.a, {TABLE:106}.b, {TABLE:106}.c, a FROM {TABLE:106}) AS t;"
 
-# TODO(chengxiong): add SHOW CREATE FUNCTION test.
+query T
+SELECT create_statement FROM [SHOW CREATE FUNCTION f_expand]
+----
+CREATE FUNCTION public.f_expand()
+  RETURNS RECORD
+  VOLATILE
+  NOT LEAKPROOF
+  CALLED ON NULL INPUT
+  LANGUAGE SQL
+  AS $$
+  SELECT t.a, t.b, t.c, t.a FROM (SELECT test.public.t1.a, test.public.t1.b, test.public.t1.c, a FROM test.public.t1) AS t;
+$$
 
 query T
 SELECT f_expand()

--- a/pkg/sql/logictest/testdata/logic_test/udf_body_rewrite
+++ b/pkg/sql/logictest/testdata/logic_test/udf_body_rewrite
@@ -1,0 +1,317 @@
+statement ok
+CREATE TABLE t1 (a INT, b INT, c INT);
+CREATE TABLE t2 (a INT, b INT, d INT);
+INSERT INTO t1 VALUES (1, 11, 111), (2, 22, 222), (3, 33, 333);
+INSERT INTO t2 VALUES (1, 11, 111), (2, 22, 222), (3, 33, 333);
+
+# Need to turn declarative schema changer off because function `get_body_str`
+# created below would resolve a descriptorless public schema "system.public"
+# which is not supported in declarative schema changer. Declarative schema
+# changer falls back to legacy schema changer, and the descriptor id counter is
+# increased twice. It cause the test to fail due to id inconsistency.
+skipif config local-legacy-schema-changer
+statement ok
+SET use_declarative_schema_changer = 'off'
+
+statement ok
+CREATE FUNCTION get_body_str(fn_name STRING) RETURNS STRING
+LANGUAGE SQL
+AS $$
+  SELECT crdb_internal.pb_to_json(
+    'cockroach.sql.sqlbase.Descriptor', descriptor, false
+  )->'function'->'functionBody'
+  FROM system.descriptor WHERE id = fn_name::regproc::int - 100000;
+$$;
+
+skipif config local-legacy-schema-changer
+statement ok
+SET use_declarative_schema_changer = 'on'
+
+# Make sure that unqualified columns names are not rewritten.
+statement ok
+CREATE OR REPLACE FUNCTION f() RETURNS INT
+LANGUAGE SQL
+AS $$
+  SELECT a FROM t1 WHERE b > 20 ORDER BY b;
+$$
+
+# Make sure table names are rewritten.
+query T
+SELECT get_body_str('f');
+----
+"SELECT a FROM {TABLE:106} WHERE b > 20 ORDER BY b;"
+
+# TODO(chengxiong): add SHOW CREATE FUNCTION test.
+
+# Make sure function is still executable.
+query I
+SELECT f()
+----
+2
+
+# Make sure that qualified column names are rewritten.
+statement ok
+CREATE OR REPLACE FUNCTION f() RETURNS INT
+LANGUAGE SQL
+AS $$
+  SELECT t1.a FROM t1 WHERE t1.b > 20 ORDER BY t1.b;
+$$
+
+# Make sure table names are rewritten.
+query T
+SELECT get_body_str('f');
+----
+"SELECT {TABLE:106}.a FROM {TABLE:106} WHERE {TABLE:106}.b > 20 ORDER BY {TABLE:106}.b;"
+
+# TODO(chengxiong): add SHOW CREATE FUNCTION test.
+
+query I
+SELECT f()
+----
+2
+
+# Make sure that column names from subquery are not rewritten.
+statement ok
+CREATE OR REPLACE FUNCTION f() RETURNS INT
+LANGUAGE SQL
+AS $$
+  SELECT t.a FROM (SELECT a FROM t1 WHERE b > 20 ORDER BY b) t WHERE t.a > 1 ORDER BY t.a;
+$$
+
+query T
+SELECT get_body_str('f');
+----
+"SELECT t.a FROM (SELECT a FROM {TABLE:106} WHERE b > 20 ORDER BY b) AS t WHERE t.a > 1 ORDER BY t.a;"
+
+# TODO(chengxiong): add SHOW CREATE FUNCTION test.
+
+query I
+SELECT f()
+----
+2
+
+# Make sure that "ORDER BY star" and "GROUP BY star" are not rewritten.
+statement ok
+CREATE OR REPLACE FUNCTION f_order_star() RETURNS RECORD
+LANGUAGE SQL
+AS $$
+  SELECT *
+  FROM t1 JOIN t2 ON c = d
+  GROUP BY t1.*, t2.*
+  ORDER BY t1.*, t2.*;
+$$
+
+query T
+SELECT get_body_str('f_order_star');
+----
+"SELECT {TABLE:106}.a, {TABLE:106}.b, {TABLE:106}.c, {TABLE:107}.a, {TABLE:107}.b, {TABLE:107}.d FROM {TABLE:106} JOIN {TABLE:107} ON c = d GROUP BY t1.*, t2.* ORDER BY t1.*, t2.*;"
+
+# TODO(chengxiong): add SHOW CREATE FUNCTION test.
+
+query T
+SELECT f_order_star()
+----
+(1,11,111,1,11,111)
+
+# Make sure that SRF column in ORDER BY is not rewritten.
+statement ok
+CREATE OR REPLACE FUNCTION f_order_srf() RETURNS RECORD
+LANGUAGE SQL
+AS $$
+  SELECT (pg_get_keywords()).* ORDER BY word LIMIT 1
+$$
+
+query T
+SELECT get_body_str('f_order_srf');
+----
+"SELECT (pg_get_keywords()).word, (pg_get_keywords()).catcode, (pg_get_keywords()).catdesc ORDER BY word LIMIT 1;"
+
+# TODO(chengxiong): add SHOW CREATE FUNCTION test.
+
+query T
+SELECT f_order_srf()
+----
+(abort,U,unreserved)
+
+# Make sure qualified column names in JOIN, GROUP BY, HAVING are rewritten.
+statement ok
+CREATE OR REPLACE FUNCTION f() RETURNS INT
+LANGUAGE SQL
+AS $$
+  SELECT t1.a + t2.a
+  FROM t1
+  JOIN t2 ON t1.b = t2.b
+  GROUP BY t1.a + t2.a
+  HAVING t1.a + t2.a > 1
+  ORDER BY t1.a + t2.a;
+$$
+
+query T
+SELECT get_body_str('f');
+----
+"SELECT {TABLE:106}.a + {TABLE:107}.a FROM {TABLE:106} JOIN {TABLE:107} ON {TABLE:106}.b = {TABLE:107}.b GROUP BY {TABLE:106}.a + {TABLE:107}.a HAVING ({TABLE:106}.a + {TABLE:107}.a) > 1 ORDER BY {TABLE:106}.a + {TABLE:107}.a;"
+
+# TODO(chengxiong): add SHOW CREATE FUNCTION test.
+
+query I
+SELECT f()
+----
+2
+
+# Make sure unqualified column names in JOIN, GROUP BY, HAVING are not
+# rewritten.
+statement ok
+CREATE OR REPLACE FUNCTION f() RETURNS INT
+LANGUAGE SQL
+AS $$
+  SELECT c + d
+  FROM t1
+  JOIN t2 ON c = d
+  GROUP BY c + d
+  HAVING c + d > 1
+  ORDER BY c + d;
+$$
+
+query T
+SELECT get_body_str('f');
+----
+"SELECT c + d FROM {TABLE:106} JOIN {TABLE:107} ON c = d GROUP BY c + d HAVING (c + d) > 1 ORDER BY c + d;"
+
+# TODO(chengxiong): add SHOW CREATE FUNCTION test.
+
+query I
+SELECT f()
+----
+222
+
+# Make sure JOIN USING is not rewritten.
+statement ok
+CREATE OR REPLACE FUNCTION f() RETURNS INT
+LANGUAGE SQL
+AS $$
+  SELECT t1.a + t2.a
+  FROM t1
+  JOIN t2 USING (a)
+$$
+
+query T
+SELECT get_body_str('f');
+----
+"SELECT {TABLE:106}.a + {TABLE:107}.a FROM {TABLE:106} JOIN {TABLE:107} USING (a);"
+
+# TODO(chengxiong): add SHOW CREATE FUNCTION test.
+
+# Make sure table aliases are not rewritten.
+statement ok
+CREATE OR REPLACE FUNCTION f() RETURNS INT
+LANGUAGE SQL
+AS $$
+  SELECT p.a + q.a
+  FROM t1 as p
+  JOIN t2 as q ON p.b = q.b
+  GROUP BY p.a + q.a
+  HAVING p.a + q.a > 1
+  ORDER BY p.a + q.a;
+$$
+
+query T
+SELECT get_body_str('f');
+----
+"SELECT p.a + q.a FROM {TABLE:106} AS p JOIN {TABLE:107} AS q ON p.b = q.b GROUP BY p.a + q.a HAVING (p.a + q.a) > 1 ORDER BY p.a + q.a;"
+
+# TODO(chengxiong): add SHOW CREATE FUNCTION test.
+
+query I
+SELECT f()
+----
+2
+
+# Make sure unqualified DISTINCT ON columns are not rewritten.
+statement ok
+CREATE OR REPLACE FUNCTION f() RETURNS INT
+LANGUAGE SQL
+AS $$
+  SELECT DISTINCT ON (a) b FROM t1 ORDER BY a;
+$$
+
+query T
+SELECT get_body_str('f');
+----
+"SELECT DISTINCT ON (a) b FROM {TABLE:106} ORDER BY a;"
+
+# TODO(chengxiong): add SHOW CREATE FUNCTION test.
+
+query I
+SELECT f()
+----
+11
+
+# Make sure qualified DISTINCT ON columns are rewritten.
+statement ok
+CREATE OR REPLACE FUNCTION f() RETURNS INT
+LANGUAGE SQL
+AS $$
+  SELECT DISTINCT ON (t1.a) t1.b FROM t1 ORDER BY a;
+$$
+
+query T
+SELECT get_body_str('f');
+----
+"SELECT DISTINCT ON ({TABLE:106}.a) {TABLE:106}.b FROM {TABLE:106} ORDER BY a;"
+
+# TODO(chengxiong): add SHOW CREATE FUNCTION test.
+
+query I
+SELECT f()
+----
+11
+
+# Make sure * expanded columns are rewritten.
+statement ok
+CREATE OR REPLACE FUNCTION f_expand() RETURNS RECORD
+LANGUAGE SQL
+AS $$
+  SELECT *, a FROM t1;
+$$
+
+query T
+SELECT get_body_str('f_expand');
+----
+"SELECT {TABLE:106}.a, {TABLE:106}.b, {TABLE:106}.c, a FROM {TABLE:106};"
+
+# TODO(chengxiong): add SHOW CREATE FUNCTION test.
+
+query T
+SELECT f_expand()
+----
+(1,11,111,1)
+
+# Make sure * expanded columns are only rewritten for columns from non-aliased source.
+statement ok
+CREATE OR REPLACE FUNCTION f_expand() RETURNS RECORD
+LANGUAGE SQL
+AS $$
+  SELECT * FROM (SELECT *, a FROM t1) t;
+$$
+
+query T
+SELECT get_body_str('f_expand');
+----
+"SELECT t.a, t.b, t.c, t.a FROM (SELECT {TABLE:106}.a, {TABLE:106}.b, {TABLE:106}.c, a FROM {TABLE:106}) AS t;"
+
+# TODO(chengxiong): add SHOW CREATE FUNCTION test.
+
+query T
+SELECT f_expand()
+----
+(1,11,111,1)
+
+# Make sure that unknown table ids should resolve to an error.
+statement error pq: {TABLE:12800}: relation "\[12800\]" does not exist
+SELECT * FROM {TABLE:12800};
+
+statement error pq: relation "\[12800\]" does not exist
+SELECT {TABLE:12800}.a FROM t1;
+
+statement error pq: relation "\[12800\]" does not exist
+SELECT {TABLE:12800}.a FROM {TABLE:106};

--- a/pkg/sql/logictest/testdata/logic_test/udf_body_rewrite
+++ b/pkg/sql/logictest/testdata/logic_test/udf_body_rewrite
@@ -315,3 +315,34 @@ SELECT {TABLE:12800}.a FROM t1;
 
 statement error pq: relation "\[12800\]" does not exist
 SELECT {TABLE:12800}.a FROM {TABLE:106};
+
+# Make sure view ID is used instead of source table ID.
+statement ok
+CREATE OR REPLACE VIEW v1 AS SELECT a FROM t1;
+
+statement ok
+CREATE OR REPLACE FUNCTION f() RETURNS INT
+LANGUAGE SQL
+AS $$
+  SELECT v1.a FROM v1 ORDER BY v1.a;
+$$
+
+query I
+SELECT 'v1'::REGCLASS::INT
+----
+113
+
+query I
+SELECT 't1'::REGCLASS::INT
+----
+106
+
+query T
+SELECT get_body_str('f');
+----
+"SELECT {TABLE:113}.a FROM {TABLE:113} ORDER BY {TABLE:113}.a;"
+
+query I
+SELECT f();
+----
+1

--- a/pkg/sql/logictest/testdata/logic_test/udf_record
+++ b/pkg/sql/logictest/testdata/logic_test/udf_record
@@ -81,7 +81,7 @@ f_table  CREATE FUNCTION public.f_table()
            CALLED ON NULL INPUT
            LANGUAGE SQL
            AS $$
-           SELECT t.a, t.b FROM test.public.t ORDER BY a LIMIT 1;
+           SELECT test.public.t.a, test.public.t.b FROM test.public.t ORDER BY a LIMIT 1;
          $$
 
 query T

--- a/pkg/sql/logictest/testdata/logic_test/udf_star
+++ b/pkg/sql/logictest/testdata/logic_test/udf_star
@@ -112,7 +112,7 @@ f_subquery  CREATE FUNCTION public.f_subquery()
               CALLED ON NULL INPUT
               LANGUAGE SQL
               AS $$
-              SELECT bar.a FROM (SELECT a FROM (SELECT t_onecol.a FROM test.public.t_onecol) AS foo) AS bar;
+              SELECT bar.a FROM (SELECT a FROM (SELECT test.public.t_onecol.a FROM test.public.t_onecol) AS foo) AS bar;
             $$
 
 query TT

--- a/pkg/sql/logictest/testdata/logic_test/udf_star
+++ b/pkg/sql/logictest/testdata/logic_test/udf_star
@@ -86,19 +86,19 @@ query TTT
 SELECT oid, proname, prosrc
 FROM pg_catalog.pg_proc WHERE proname LIKE 'f\_%' ORDER BY oid;
 ----
-100108  f_unqualified_onecol      SELECT t_onecol.a FROM test.public.t_onecol;
-100109  f_subquery                SELECT bar.a FROM (SELECT a FROM (SELECT t_onecol.a FROM test.public.t_onecol) AS foo) AS bar;
-100110  f_subquery_unaliased      SELECT "?subquery1?".a FROM (SELECT a FROM (SELECT t_onecol.a FROM test.public.t_onecol) AS "?subquery2?") AS "?subquery1?";
-100111  f_unqualified_twocol      SELECT t_twocol.a, t_twocol.b FROM test.public.t_twocol;
-100112  f_allcolsel               SELECT t_twocol.a, t_twocol.b FROM test.public.t_twocol;
-100113  f_allcolsel_alias         SELECT t1.a, t1.b FROM test.public.t_twocol AS t1, test.public.t_twocol AS t2 WHERE t1.a = t2.a;
-100114  f_tuplestar               SELECT t_twocol.a, t_twocol.b FROM test.public.t_twocol;
-100115  f_unqualified_multicol    SELECT t_onecol.a, a FROM test.public.t_onecol;
+100108  f_unqualified_onecol      SELECT {TABLE:106}.a FROM {TABLE:106};
+100109  f_subquery                SELECT bar.a FROM (SELECT a FROM (SELECT {TABLE:106}.a FROM {TABLE:106}) AS foo) AS bar;
+100110  f_subquery_unaliased      SELECT "?subquery1?".a FROM (SELECT a FROM (SELECT {TABLE:106}.a FROM {TABLE:106}) AS "?subquery2?") AS "?subquery1?";
+100111  f_unqualified_twocol      SELECT {TABLE:107}.a, {TABLE:107}.b FROM {TABLE:107};
+100112  f_allcolsel               SELECT {TABLE:107}.a, {TABLE:107}.b FROM {TABLE:107};
+100113  f_allcolsel_alias         SELECT t1.a, t1.b FROM {TABLE:107} AS t1, {TABLE:107} AS t2 WHERE t1.a = t2.a;
+100114  f_tuplestar               SELECT {TABLE:107}.a, {TABLE:107}.b FROM {TABLE:107};
+100115  f_unqualified_multicol    SELECT {TABLE:106}.a, a FROM {TABLE:106};
                                   SELECT 1;
-100116  f_unqualified_doublestar  SELECT t_onecol.a, t_onecol.a FROM test.public.t_onecol;
+100116  f_unqualified_doublestar  SELECT {TABLE:106}.a, {TABLE:106}.a FROM {TABLE:106};
                                   SELECT 1;
 100117  f_exprstar                SELECT word FROM (SELECT (pg_get_keywords()).word, (pg_get_keywords()).catcode, (pg_get_keywords()).catdesc ORDER BY word LIMIT 1) AS foo;
-100118  f_anon_subqueries         SELECT "?subquery1?".a, "?subquery2?".a FROM (SELECT a FROM test.public.t_onecol) AS "?subquery1?" JOIN (SELECT a FROM test.public.t_twocol) AS "?subquery2?" ON true;
+100118  f_anon_subqueries         SELECT "?subquery1?".a, "?subquery2?".a FROM (SELECT a FROM {TABLE:106}) AS "?subquery1?" JOIN (SELECT a FROM {TABLE:107}) AS "?subquery2?" ON true;
                                   SELECT 1;
 
 
@@ -214,31 +214,20 @@ statement ok
 DROP FUNCTION f_tuplestar;
 DROP FUNCTION f_allcolsel_alias;
 
-# Dropping a column using CASCADE is ok,
-# although the legacy schema changer has troubles with it,
-# see: https://github.com/cockroachdb/cockroach/issues/97546
-skipif config local-legacy-schema-changer
 statement ok
 ALTER TABLE t_twocol DROP COLUMN b CASCADE;
 
 statement ok
 DROP TABLE t_onecol CASCADE;
 
-# The only remaining function should not reference the tables.
-# NB: remove the skipif directive when #97546 is resolved.
-skipif config local-legacy-schema-changer
 query TTT
 SELECT oid, proname, prosrc
 FROM pg_catalog.pg_proc WHERE proname LIKE 'f\_%' ORDER BY oid;
 ----
 100117  f_exprstar  SELECT word FROM (SELECT (pg_get_keywords()).word, (pg_get_keywords()).catcode, (pg_get_keywords()).catdesc ORDER BY word LIMIT 1) AS foo;
 
-# Remove this when #97546 is resolved.
-onlyif config local-legacy-schema-changer
 query TTT
 SELECT oid, proname, prosrc
 FROM pg_catalog.pg_proc WHERE proname LIKE 'f\_%' ORDER BY oid;
 ----
-100111  f_unqualified_twocol  SELECT t_twocol.a, t_twocol.b FROM test.public.t_twocol;
-100112  f_allcolsel           SELECT t_twocol.a, t_twocol.b FROM test.public.t_twocol;
 100117  f_exprstar            SELECT word FROM (SELECT (pg_get_keywords()).word, (pg_get_keywords()).catcode, (pg_get_keywords()).catdesc ORDER BY word LIMIT 1) AS foo;

--- a/pkg/sql/logictest/testdata/logic_test/udf_volatility_check
+++ b/pkg/sql/logictest/testdata/logic_test/udf_volatility_check
@@ -20,14 +20,14 @@ CREATE FUNCTION f() RETURNS FLOAT LANGUAGE SQL STABLE AS $$ SELECT random() $$;
 statement error pq: volatile statement not allowed in immutable function: SELECT @1 FROM ROWS FROM \(random\(\)\)
 CREATE FUNCTION f() RETURNS FLOAT LANGUAGE SQL IMMUTABLE AS $$ SELECT @1 FROM random() $$;
 
-statement error pq: volatile statement not allowed in immutable function: SELECT t1\.a FROM test\.public\.t1 JOIN test\.public\.t2 ON t1\.a = \(t2\.a \+ random\(\)::INT8\)
+statement error pq: volatile statement not allowed in immutable function: SELECT {TABLE:106}\.a FROM {TABLE:106} JOIN {TABLE:107} ON {TABLE:106}\.a = \({TABLE:107}\.a \+ random\(\)::INT8\)
 CREATE FUNCTION f() RETURNS INT LANGUAGE SQL IMMUTABLE AS $$
   SELECT t1.a
   FROM t1
   JOIN t2 ON t1.a = t2.a + random()::INT
 $$;
 
-statement error pq: volatile statement not allowed in immutable function: SELECT a FROM test\.public\.t1 WHERE b = \(1\.0 \+ random\(\)\)
+statement error pq: volatile statement not allowed in immutable function: SELECT a FROM {TABLE:106} WHERE b = \(1\.0 \+ random\(\)\)
 CREATE FUNCTION f() RETURNS INT LANGUAGE SQL IMMUTABLE AS $$
   SELECT a
   FROM t1
@@ -54,14 +54,14 @@ CREATE OR REPLACE FUNCTION f() RETURNS INT LANGUAGE SQL STABLE AS $$ SELECT rand
 statement error pq: volatile statement not allowed in immutable function: SELECT @1 FROM ROWS FROM \(random\(\)\)
 CREATE OR REPLACE FUNCTION f() RETURNS INT LANGUAGE SQL IMMUTABLE AS $$ SELECT @1 FROM random() $$;
 
-statement error pq: volatile statement not allowed in immutable function: SELECT t1\.a FROM test\.public\.t1 JOIN test\.public\.t2 ON t1\.a = \(t2\.a \+ random\(\)::INT8\)
+statement error pq: volatile statement not allowed in immutable function: SELECT {TABLE:106}\.a FROM {TABLE:106} JOIN {TABLE:107} ON {TABLE:106}\.a = \({TABLE:107}\.a \+ random\(\)::INT8\)
 CREATE OR REPLACE FUNCTION f() RETURNS INT LANGUAGE SQL IMMUTABLE AS $$
   SELECT t1.a
   FROM t1
   JOIN t2 ON t1.a = t2.a + random()::INT
 $$;
 
-statement error pq: volatile statement not allowed in immutable function: SELECT a FROM test\.public\.t1 WHERE b = \(1\.0 \+ random\(\)\)
+statement error pq: volatile statement not allowed in immutable function: SELECT a FROM {TABLE:106} WHERE b = \(1\.0 \+ random\(\)\)
 CREATE OR REPLACE FUNCTION f() RETURNS INT LANGUAGE SQL IMMUTABLE AS $$
   SELECT a
   FROM t1

--- a/pkg/sql/logictest/tests/fakedist-disk/generated_test.go
+++ b/pkg/sql/logictest/tests/fakedist-disk/generated_test.go
@@ -2074,6 +2074,13 @@ func TestLogic_udf(
 	runLogicTest(t, "udf")
 }
 
+func TestLogic_udf_body_rewrite(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "udf_body_rewrite")
+}
+
 func TestLogic_udf_delete(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/fakedist-vec-off/generated_test.go
+++ b/pkg/sql/logictest/tests/fakedist-vec-off/generated_test.go
@@ -2081,6 +2081,13 @@ func TestLogic_udf(
 	runLogicTest(t, "udf")
 }
 
+func TestLogic_udf_body_rewrite(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "udf_body_rewrite")
+}
+
 func TestLogic_udf_delete(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/fakedist/generated_test.go
+++ b/pkg/sql/logictest/tests/fakedist/generated_test.go
@@ -2095,6 +2095,13 @@ func TestLogic_udf(
 	runLogicTest(t, "udf")
 }
 
+func TestLogic_udf_body_rewrite(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "udf_body_rewrite")
+}
+
 func TestLogic_udf_delete(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/local-legacy-schema-changer/generated_test.go
+++ b/pkg/sql/logictest/tests/local-legacy-schema-changer/generated_test.go
@@ -2067,6 +2067,13 @@ func TestLogic_udf(
 	runLogicTest(t, "udf")
 }
 
+func TestLogic_udf_body_rewrite(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "udf_body_rewrite")
+}
+
 func TestLogic_udf_delete(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/local-mixed-22.2-23.1/generated_test.go
+++ b/pkg/sql/logictest/tests/local-mixed-22.2-23.1/generated_test.go
@@ -2025,6 +2025,13 @@ func TestLogic_udf(
 	runLogicTest(t, "udf")
 }
 
+func TestLogic_udf_body_rewrite(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "udf_body_rewrite")
+}
+
 func TestLogic_udf_delete(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/local-vec-off/generated_test.go
+++ b/pkg/sql/logictest/tests/local-vec-off/generated_test.go
@@ -2095,6 +2095,13 @@ func TestLogic_udf(
 	runLogicTest(t, "udf")
 }
 
+func TestLogic_udf_body_rewrite(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "udf_body_rewrite")
+}
+
 func TestLogic_udf_delete(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/local/generated_test.go
+++ b/pkg/sql/logictest/tests/local/generated_test.go
@@ -2298,6 +2298,13 @@ func TestLogic_udf(
 	runLogicTest(t, "udf")
 }
 
+func TestLogic_udf_body_rewrite(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "udf_body_rewrite")
+}
+
 func TestLogic_udf_delete(
 	t *testing.T,
 ) {

--- a/pkg/sql/opt/optbuilder/distinct.go
+++ b/pkg/sql/opt/optbuilder/distinct.go
@@ -192,14 +192,18 @@ func (b *Builder) buildDistinctOn(
 // analyzeDistinctOnArgs analyzes the DISTINCT ON columns and adds the
 // resulting typed expressions to distinctOnScope.
 func (b *Builder) analyzeDistinctOnArgs(
-	distinctOn tree.DistinctOn, inScope, projectionsScope *scope,
+	distinctOn *tree.DistinctOn, inScope, projectionsScope *scope,
 ) (distinctOnScope *scope) {
-	if len(distinctOn) == 0 {
+	if distinctOn == nil {
+		return nil
+	}
+	d := *distinctOn
+	if len(d) == 0 {
 		return nil
 	}
 
 	distinctOnScope = inScope.push()
-	distinctOnScope.cols = make([]scopeColumn, 0, len(distinctOn))
+	distinctOnScope.cols = make([]scopeColumn, 0, len(d))
 
 	// We need to save and restore the previous value of the field in
 	// semaCtx in case we are recursively called within a subquery
@@ -208,15 +212,20 @@ func (b *Builder) analyzeDistinctOnArgs(
 	b.semaCtx.Properties.Require(exprKindDistinctOn.String(), tree.RejectGenerators)
 	inScope.context = exprKindDistinctOn
 
-	for i := range distinctOn {
+	for i := range d {
 		b.analyzeExtraArgument(
-			distinctOn[i],
+			&d[i],
 			inScope,
 			projectionsScope,
 			distinctOnScope,
 			true, /* nullsDefaultOrder */
 		)
 	}
+
+	if b.insideFuncDef {
+		*distinctOn = d
+	}
+
 	return distinctOnScope
 }
 

--- a/pkg/sql/opt/optbuilder/groupby.go
+++ b/pkg/sql/opt/optbuilder/groupby.go
@@ -332,7 +332,7 @@ func (b *Builder) buildGroupingColumns(sel *tree.SelectClause, projectionsScope,
 	g := fromScope.groupby
 
 	// The "from" columns are visible to any grouping expressions.
-	b.buildGroupingList(sel.GroupBy, sel.Exprs, projectionsScope, fromScope)
+	b.buildGroupingList(&sel.GroupBy, sel.Exprs, projectionsScope, fromScope)
 
 	// Copy the grouping columns to the aggOutScope.
 	g.aggOutScope.appendColumns(g.groupingCols())
@@ -462,7 +462,11 @@ func (b *Builder) analyzeHaving(having *tree.Where, fromScope *scope) tree.Typed
 		exprKindHaving.String(), tree.RejectWindowApplications|tree.RejectGenerators,
 	)
 	fromScope.context = exprKindHaving
-	return fromScope.resolveAndRequireType(having.Expr, types.Bool)
+	typedHavingExpr := fromScope.resolveAndRequireType(having.Expr, types.Bool)
+	if b.insideFuncDef {
+		having.Expr, _ = tree.WalkExpr(newColumnPrefixRewriter(fromScope), having.Expr)
+	}
+	return typedHavingExpr
 }
 
 // buildHaving builds a set of memo groups that represent the given HAVING
@@ -492,12 +496,16 @@ func (b *Builder) buildHaving(having tree.TypedExpr, fromScope *scope) opt.Scala
 //
 // fromScope The scope for the input to the aggregation (the FROM clause).
 func (b *Builder) buildGroupingList(
-	groupBy tree.GroupBy, selects tree.SelectExprs, projectionsScope *scope, fromScope *scope,
+	groupBy *tree.GroupBy, selects tree.SelectExprs, projectionsScope *scope, fromScope *scope,
 ) {
+	if groupBy == nil {
+		return
+	}
+	gb := *groupBy
 	g := fromScope.groupby
-	g.groupStrs = make(groupByStrSet, len(groupBy))
+	g.groupStrs = make(groupByStrSet, len(gb))
 	if g.aggInScope.cols == nil {
-		g.aggInScope.cols = make([]scopeColumn, 0, len(groupBy))
+		g.aggInScope.cols = make([]scopeColumn, 0, len(gb))
 	}
 
 	// The buildingGroupingCols flag is used to ensure that a grouping error is
@@ -509,8 +517,11 @@ func (b *Builder) buildGroupingList(
 	// used in an aggregate function`. The builder cannot know whether there is
 	// a grouping error until the grouping columns are fully built.
 	g.buildingGroupingCols = true
-	for _, e := range groupBy {
-		b.buildGrouping(e, selects, projectionsScope, fromScope, g.aggInScope)
+	for i := range gb {
+		b.buildGrouping(&gb[i], selects, projectionsScope, fromScope, g.aggInScope)
+	}
+	if b.insideFuncDef {
+		*groupBy = gb
 	}
 	g.buildingGroupingCols = false
 }
@@ -536,10 +547,10 @@ func (b *Builder) buildGroupingList(
 //
 //	as the aggregate function arguments.
 func (b *Builder) buildGrouping(
-	groupBy tree.Expr, selects tree.SelectExprs, projectionsScope, fromScope, aggInScope *scope,
+	groupByIn *tree.Expr, selects tree.SelectExprs, projectionsScope, fromScope, aggInScope *scope,
 ) {
 	// Unwrap parenthesized expressions like "((a))" to "a".
-	groupBy = tree.StripParens(groupBy)
+	groupBy := tree.StripParens(*groupByIn)
 	alias := ""
 
 	// Comment below pasted from PostgreSQL (findTargetListEntrySQL92 in
@@ -645,6 +656,10 @@ func (b *Builder) buildGrouping(
 		col := aggInScope.addColumn(scopeColName(tree.Name(alias)), e)
 		b.buildScalar(e, fromScope, aggInScope, col, nil)
 		fromScope.groupby.groupStrs[exprStr] = col
+	}
+
+	if b.insideFuncDef {
+		*groupByIn, _ = tree.WalkExpr(newColumnPrefixRewriter(fromScope), *groupByIn)
 	}
 }
 

--- a/pkg/sql/opt/optbuilder/join.go
+++ b/pkg/sql/opt/optbuilder/join.go
@@ -33,7 +33,7 @@ import (
 func (b *Builder) buildJoin(
 	join *tree.JoinTableExpr, locking lockingSpec, inScope *scope,
 ) (outScope *scope) {
-	leftScope := b.buildDataSource(join.Left, nil /* indexFlags */, locking, inScope)
+	leftScope := b.buildDataSource(&join.Left, nil /* indexFlags */, locking, inScope)
 
 	inScopeRight := inScope
 	isLateral := b.exprIsLateral(join.Right)
@@ -45,7 +45,7 @@ func (b *Builder) buildJoin(
 		inScopeRight.context = exprKindLateralJoin
 	}
 
-	rightScope := b.buildDataSource(join.Right, nil /* indexFlags */, locking, inScopeRight)
+	rightScope := b.buildDataSource(&join.Right, nil /* indexFlags */, locking, inScopeRight)
 
 	// Check that the same table name is not used on both sides.
 	b.validateJoinTableNames(leftScope, rightScope)
@@ -122,6 +122,10 @@ func (b *Builder) buildJoin(
 				outScope.resolveAndRequireType(on.Expr, types.Bool), outScope, nil, nil, nil,
 			)
 			filters = memo.FiltersExpr{b.factory.ConstructFiltersItem(filter)}
+			if b.insideFuncDef {
+				newExpr, _ := tree.WalkExpr(newColumnPrefixRewriter(outScope), on.Expr)
+				join.Cond = &tree.OnJoinCond{Expr: newExpr}
+			}
 		} else {
 			filters = memo.TrueFilter
 		}

--- a/pkg/sql/opt/optbuilder/mutation_builder.go
+++ b/pkg/sql/opt/optbuilder/mutation_builder.go
@@ -336,7 +336,7 @@ func (mb *mutationBuilder) buildInputForUpdate(
 	// SELECT + ORDER BY (which may add projected expressions)
 	projectionsScope := mb.outScope.replace()
 	projectionsScope.appendColumnsFromScope(mb.outScope)
-	orderByScope := mb.b.analyzeOrderBy(orderBy, mb.outScope, projectionsScope, tree.RejectGenerators)
+	orderByScope := mb.b.analyzeOrderBy(&orderBy, mb.outScope, projectionsScope, tree.RejectGenerators)
 	mb.b.buildOrderBy(mb.outScope, projectionsScope, orderByScope)
 	mb.b.constructProjectForScope(mb.outScope, projectionsScope)
 
@@ -448,7 +448,7 @@ func (mb *mutationBuilder) buildInputForDelete(
 	// SELECT + ORDER BY (which may add projected expressions)
 	projectionsScope := mb.outScope.replace()
 	projectionsScope.appendColumnsFromScope(mb.outScope)
-	orderByScope := mb.b.analyzeOrderBy(orderBy, mb.outScope, projectionsScope, tree.RejectGenerators)
+	orderByScope := mb.b.analyzeOrderBy(&orderBy, mb.outScope, projectionsScope, tree.RejectGenerators)
 	mb.b.buildOrderBy(mb.outScope, projectionsScope, orderByScope)
 	mb.b.constructProjectForScope(mb.outScope, projectionsScope)
 

--- a/pkg/sql/opt/optbuilder/orderby.go
+++ b/pkg/sql/opt/optbuilder/orderby.go
@@ -28,14 +28,18 @@ import (
 // analyzeOrderBy analyzes an Ordering physical property from the ORDER BY
 // clause and adds the resulting typed expressions to orderByScope.
 func (b *Builder) analyzeOrderBy(
-	orderBy tree.OrderBy, inScope, projectionsScope *scope, rejectFlags tree.SemaRejectFlags,
+	orderBy *tree.OrderBy, inScope, projectionsScope *scope, rejectFlags tree.SemaRejectFlags,
 ) (orderByScope *scope) {
 	if orderBy == nil {
 		return nil
 	}
+	ob := *orderBy
+	if len(ob) == 0 {
+		return nil
+	}
 
 	orderByScope = inScope.push()
-	orderByScope.cols = make([]scopeColumn, 0, len(orderBy))
+	orderByScope.cols = make([]scopeColumn, 0, len(ob))
 
 	// We need to save and restore the previous value of the field in
 	// semaCtx in case we are recursively called within a subquery
@@ -44,8 +48,11 @@ func (b *Builder) analyzeOrderBy(
 	b.semaCtx.Properties.Require(exprKindOrderBy.String(), rejectFlags)
 	inScope.context = exprKindOrderBy
 
-	for i := range orderBy {
-		b.analyzeOrderByArg(orderBy[i], inScope, projectionsScope, orderByScope)
+	for i := range ob {
+		b.analyzeOrderByArg(ob[i], inScope, projectionsScope, orderByScope)
+	}
+	if b.insideFuncDef {
+		*orderBy = ob
 	}
 	return orderByScope
 }
@@ -174,7 +181,7 @@ func (b *Builder) analyzeOrderByArg(
 
 	// Analyze the ORDER BY column(s).
 	start := len(orderByScope.cols)
-	b.analyzeExtraArgument(order.Expr, inScope, projectionsScope, orderByScope, nullsDefaultOrder)
+	b.analyzeExtraArgument(&order.Expr, inScope, projectionsScope, orderByScope, nullsDefaultOrder)
 	for i := start; i < len(orderByScope.cols); i++ {
 		col := &orderByScope.cols[i]
 		col.descending = order.Direction == tree.Descending
@@ -203,10 +210,10 @@ func (b *Builder) buildOrderByArg(
 // required to explicitly place nulls first or nulls last (when
 // nullsDefaultOrder is false).
 func (b *Builder) analyzeExtraArgument(
-	expr tree.Expr, inScope, projectionsScope, extraColsScope *scope, nullsDefaultOrder bool,
+	exprIn *tree.Expr, inScope, projectionsScope, extraColsScope *scope, nullsDefaultOrder bool,
 ) {
 	// Unwrap parenthesized expressions like "((a))" to "a".
-	expr = tree.StripParens(expr)
+	expr := tree.StripParens(*exprIn)
 
 	// The logical data source for ORDER BY or DISTINCT ON is the list of column
 	// expressions for a SELECT, as specified in the input SQL text (or an entire
@@ -273,6 +280,11 @@ func (b *Builder) analyzeExtraArgument(
 			)
 		}
 		extraColsScope.addColumn(scopeColName(""), e)
+	}
+
+	// Only do rewrite when the expression is not an alias and ordinal.
+	if b.insideFuncDef && idx == -1 {
+		*exprIn, _ = tree.WalkExpr(newColumnPrefixRewriter(inScope), expr)
 	}
 }
 

--- a/pkg/sql/opt/optbuilder/project.go
+++ b/pkg/sql/opt/optbuilder/project.go
@@ -192,6 +192,11 @@ func (b *Builder) analyzeSelectList(
 		}
 	}
 	if b.insideFuncDef || b.insideViewDef {
+		if b.insideFuncDef {
+			for i := range expansions {
+				expansions[i].Expr, _ = tree.WalkExpr(newColumnPrefixRewriter(inScope), expansions[i].Expr)
+			}
+		}
 		*selects = expansions
 	}
 }

--- a/pkg/sql/opt/optbuilder/scope.go
+++ b/pkg/sql/opt/optbuilder/scope.go
@@ -932,6 +932,31 @@ func (s *scope) FindSourceMatchingName(
 	return colinfo.NoResults, nil, s, nil
 }
 
+// FindSourceWithID implements the colinfo.ColumnItemResolver interface.
+func (s *scope) FindSourceWithID(
+	ctx context.Context, id int64,
+) (prefix *tree.TableName, srcMeta colinfo.ColumnSourceMeta, err error) {
+	var flags cat.Flags
+	if s.builder.insideViewDef || s.builder.insideFuncDef {
+		// Avoid taking descriptor leases when we're creating a view or a
+		// function.
+		flags.AvoidDescriptorCaches = true
+	}
+	ds, _, err := s.builder.catalog.ResolveDataSourceByID(ctx, flags, cat.StableID(id))
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// We found the data source name by ID, but we still need to get a proper
+	// scope for it so that the scope would contain all the required columns.
+	_, prefix, srcMeta, err = s.FindSourceMatchingName(ctx, tree.MakeUnqualifiedTableName(ds.Name()))
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return prefix, srcMeta, nil
+}
+
 // sourceNameMatches checks whether a request for table name toFind
 // can be satisfied by the FROM source name srcName.
 //
@@ -1035,6 +1060,13 @@ func (s *scope) VisitPre(expr tree.Expr) (recurse bool, newExpr tree.Expr) {
 					return s.VisitPre(columnNameAsTupleStar(string(t.ColumnName)))
 				}()
 			}
+			panic(resolveErr)
+		}
+		return false, colI.(*scopeColumn)
+
+	case *tree.ColumnNameRef:
+		colI, resolveErr := colinfo.ResolveColumnNameRef(s.builder.ctx, s, t)
+		if resolveErr != nil {
 			panic(resolveErr)
 		}
 		return false, colI.(*scopeColumn)

--- a/pkg/sql/opt/optbuilder/scope_column.go
+++ b/pkg/sql/opt/optbuilder/scope_column.go
@@ -75,6 +75,13 @@ type scopeColumn struct {
 	// exprStr contains a stringified representation of expr, or the original
 	// column name if expr is nil. It is populated lazily inside getExprStr().
 	exprStr string
+
+	// viewID is non-zero if the scopeColumn was built from a View. This is
+	// helpful, for the time being, for rewriting table/view names in UDF/View
+	// query as ID references. This is because we build views as select queries
+	// and the generated scopeColumns are linked to the source tables, but we need
+	// the view id to do the rewriting.
+	viewID cat.StableID
 }
 
 // columnVisibility is an extension of cat.ColumnVisibility.

--- a/pkg/sql/opt/optbuilder/select.go
+++ b/pkg/sql/opt/optbuilder/select.go
@@ -378,6 +378,7 @@ func (b *Builder) buildView(
 		outScope.cols[i].table = *viewName
 		if hasCols {
 			outScope.cols[i].name = scopeColName(view.ColumnName(i))
+			outScope.cols[i].viewID = view.ID()
 		}
 	}
 

--- a/pkg/sql/opt/optbuilder/select.go
+++ b/pkg/sql/opt/optbuilder/select.go
@@ -48,7 +48,7 @@ import (
 // See Builder.buildStmt for a description of the remaining input and
 // return values.
 func (b *Builder) buildDataSource(
-	texpr tree.TableExpr, indexFlags *tree.IndexFlags, locking lockingSpec, inScope *scope,
+	texpr *tree.TableExpr, indexFlags *tree.IndexFlags, locking lockingSpec, inScope *scope,
 ) (outScope *scope) {
 	defer func(prevAtRoot bool, prevInsideDataSource bool) {
 		inScope.atRoot = prevAtRoot
@@ -57,7 +57,7 @@ func (b *Builder) buildDataSource(
 	inScope.atRoot = false
 	b.insideDataSource = true
 	// NB: The case statements are sorted lexicographically.
-	switch source := (texpr).(type) {
+	switch source := (*texpr).(type) {
 	case *tree.AliasedTableExpr:
 		if source.IndexFlags != nil {
 			telemetry.Inc(sqltelemetry.IndexHintUseCounter)
@@ -88,7 +88,7 @@ func (b *Builder) buildDataSource(
 			locking = locking.filter(source.As.Alias)
 		}
 
-		outScope = b.buildDataSource(source.Expr, indexFlags, locking, inScope)
+		outScope = b.buildDataSource(&source.Expr, indexFlags, locking, inScope)
 
 		if source.Ordinality {
 			outScope = b.buildWithOrdinality(outScope)
@@ -140,6 +140,15 @@ func (b *Builder) buildDataSource(
 			b.checkPrivilege(depName, ds, privilege.UPDATE)
 		}
 
+		if b.insideFuncDef {
+			if tbl, ok := ds.(cat.Table); !ok || (!tbl.IsVirtualTable() && !tbl.IsSystemTable()) {
+				idRef := &tree.TableIDRef{
+					ID: int64(ds.ID()),
+				}
+				*texpr = idRef
+			}
+		}
+
 		switch t := ds.(type) {
 		case cat.Table:
 			tabMeta := b.addTable(t, &resName)
@@ -165,7 +174,7 @@ func (b *Builder) buildDataSource(
 		}
 
 	case *tree.ParenTableExpr:
-		return b.buildDataSource(source.Expr, indexFlags, locking, inScope)
+		return b.buildDataSource(&source.Expr, indexFlags, locking, inScope)
 
 	case *tree.RowsFromExpr:
 		return b.buildZip(source.Items, inScope)
@@ -252,30 +261,46 @@ func (b *Builder) buildDataSource(
 			b.checkPrivilege(depName, ds, privilege.UPDATE)
 		}
 
-		switch t := ds.(type) {
-		case cat.Table:
-			outScope = b.buildScanFromTableRef(t, source, indexFlags, locking, inScope)
-		case cat.View:
-			if source.Columns != nil {
-				panic(pgerror.Newf(pgcode.FeatureNotSupported,
-					"cannot specify an explicit column list when accessing a view by reference"))
-			}
-			tn := tree.MakeUnqualifiedTableName(t.Name())
-
-			outScope = b.buildView(t, &tn, locking, inScope)
-		case cat.Sequence:
-			tn := tree.MakeUnqualifiedTableName(t.Name())
-			// Any explicitly listed columns are ignored.
-			outScope = b.buildSequenceSelect(t, &tn, inScope)
-		default:
-			panic(errors.AssertionFailedf("unsupported catalog object"))
-		}
+		outScope = b.buildScanFromDatasource(ds, source, indexFlags, locking, inScope)
 		b.renameSource(source.As, outScope)
 		return outScope
+
+	case *tree.TableIDRef:
+		ds, _ := b.resolveDataSourceIDRef(source, privilege.SELECT)
+		return b.buildScanFromDatasource(ds, nil, indexFlags, locking, inScope)
 
 	default:
 		panic(errors.AssertionFailedf("unknown table expr: %T", texpr))
 	}
+}
+
+func (b *Builder) buildScanFromDatasource(
+	ds cat.DataSource,
+	ref *tree.TableRef,
+	indexFlags *tree.IndexFlags,
+	locking lockingSpec,
+	inScope *scope,
+) (outScope *scope) {
+	switch t := ds.(type) {
+	case cat.Table:
+		outScope = b.buildScanFromTableRef(t, ref, indexFlags, locking, inScope)
+	case cat.View:
+		if ref != nil && ref.Columns != nil {
+			panic(pgerror.Newf(pgcode.FeatureNotSupported,
+				"cannot specify an explicit column list when accessing a view by reference"))
+		}
+		tn := tree.MakeUnqualifiedTableName(t.Name())
+
+		outScope = b.buildView(t, &tn, locking, inScope)
+	case cat.Sequence:
+		tn := tree.MakeUnqualifiedTableName(t.Name())
+		// Any explicitly listed columns are ignored.
+		outScope = b.buildSequenceSelect(t, &tn, inScope)
+	default:
+		panic(errors.AssertionFailedf("unsupported catalog object"))
+	}
+
+	return outScope
 }
 
 // buildView parses the view query text and builds it as a Select expression.
@@ -436,7 +461,7 @@ func (b *Builder) buildScanFromTableRef(
 	inScope *scope,
 ) (outScope *scope) {
 	var ordinals []int
-	if ref.Columns != nil {
+	if ref != nil && ref.Columns != nil {
 		// See tree.TableRef: "Note that a nil [Columns] array means 'unspecified'
 		// (all columns). whereas an array of length 0 means 'zero columns'.
 		// Lists of zero columns are not supported and will throw an error."
@@ -983,7 +1008,7 @@ func (b *Builder) buildSelect(
 ) (outScope *scope) {
 	wrapped := stmt.Select
 	with := stmt.With
-	orderBy := stmt.OrderBy
+	orderBy := &stmt.OrderBy
 	limit := stmt.Limit
 	locking.apply(stmt.Locking)
 
@@ -1002,12 +1027,12 @@ func (b *Builder) buildSelect(
 			with = s.Select.With
 		}
 		if stmt.OrderBy != nil {
-			if orderBy != nil {
+			if *orderBy != nil {
 				panic(pgerror.Newf(
 					pgcode.Syntax, "multiple ORDER BY clauses not allowed",
 				))
 			}
-			orderBy = stmt.OrderBy
+			orderBy = &stmt.OrderBy
 		}
 		if stmt.Limit != nil {
 			if limit != nil {
@@ -1037,7 +1062,7 @@ func (b *Builder) buildSelect(
 // return values.
 func (b *Builder) buildSelectStmtWithoutParens(
 	wrapped tree.SelectStatement,
-	orderBy tree.OrderBy,
+	orderBy *tree.OrderBy,
 	limit *tree.Limit,
 	locking lockingSpec,
 	desiredTypes []*types.T,
@@ -1069,7 +1094,7 @@ func (b *Builder) buildSelectStmtWithoutParens(
 			"unknown select statement: %T", wrapped))
 	}
 
-	if outScope.ordering.Empty() && orderBy != nil {
+	if outScope.ordering.Empty() && *orderBy != nil {
 		projectionsScope := outScope.replace()
 		projectionsScope.cols = make([]scopeColumn, 0, len(outScope.cols))
 		for i := range outScope.cols {
@@ -1101,7 +1126,7 @@ func (b *Builder) buildSelectStmtWithoutParens(
 // return values.
 func (b *Builder) buildSelectClause(
 	sel *tree.SelectClause,
-	orderBy tree.OrderBy,
+	orderBy *tree.OrderBy,
 	locking lockingSpec,
 	desiredTypes []*types.T,
 	inScope *scope,
@@ -1123,7 +1148,7 @@ func (b *Builder) buildSelectClause(
 	// exist) will be added here.
 	havingExpr := b.analyzeHaving(sel.Having, fromScope)
 	orderByScope := b.analyzeOrderBy(orderBy, fromScope, projectionsScope, tree.RejectGenerators)
-	distinctOnScope := b.analyzeDistinctOnArgs(sel.DistinctOn, fromScope, projectionsScope)
+	distinctOnScope := b.analyzeDistinctOnArgs(&sel.DistinctOn, fromScope, projectionsScope)
 
 	var having opt.ScalarExpr
 	needsAgg := b.needsAggregation(sel, fromScope)
@@ -1235,6 +1260,10 @@ func (b *Builder) buildWhere(where *tree.Where, inScope *scope) {
 		inScope,
 	)
 
+	if b.insideFuncDef {
+		where.Expr, _ = tree.WalkExpr(newColumnPrefixRewriter(inScope), where.Expr)
+	}
+
 	// Wrap the filter in a FiltersOp.
 	inScope.expr = b.factory.ConstructSelect(
 		inScope.expr,
@@ -1281,7 +1310,7 @@ func (b *Builder) buildFromTables(
 func (b *Builder) buildFromTablesRightDeep(
 	tables tree.TableExprs, locking lockingSpec, inScope *scope,
 ) (outScope *scope) {
-	outScope = b.buildDataSource(tables[0], nil /* indexFlags */, locking, inScope)
+	outScope = b.buildDataSource(&tables[0], nil /* indexFlags */, locking, inScope)
 
 	// Recursively build table join.
 	tables = tables[1:]
@@ -1331,7 +1360,7 @@ func (b *Builder) exprIsLateral(t tree.TableExpr) bool {
 func (b *Builder) buildFromWithLateral(
 	tables tree.TableExprs, locking lockingSpec, inScope *scope,
 ) (outScope *scope) {
-	outScope = b.buildDataSource(tables[0], nil /* indexFlags */, locking, inScope)
+	outScope = b.buildDataSource(&tables[0], nil /* indexFlags */, locking, inScope)
 	for i := 1; i < len(tables); i++ {
 		scope := inScope
 		// Lateral expressions need to be able to refer to the expressions that
@@ -1340,7 +1369,7 @@ func (b *Builder) buildFromWithLateral(
 			scope = outScope
 			scope.context = exprKindLateralJoin
 		}
-		tableScope := b.buildDataSource(tables[i], nil /* indexFlags */, locking, scope)
+		tableScope := b.buildDataSource(&tables[i], nil /* indexFlags */, locking, scope)
 
 		// Check that the same table name is not used multiple times.
 		b.validateJoinTableNames(outScope, tableScope)

--- a/pkg/sql/opt/optbuilder/testdata/create_function
+++ b/pkg/sql/opt/optbuilder/testdata/create_function
@@ -42,7 +42,7 @@ create-function
  ├── CREATE FUNCTION f()
  │   	RETURNS workday
  │   	LANGUAGE SQL
- │   	AS $$SELECT w FROM t.public.workdays;$$
+ │   	AS $$SELECT w FROM {TABLE:55};$$
  └── dependencies
       ├── workdays [columns: w]
       └── workday
@@ -65,7 +65,7 @@ create-function
  ├── CREATE FUNCTION f()
  │   	RETURNS STRING
  │   	LANGUAGE SQL
- │   	AS $$SELECT w::STRING FROM t.public.workdays;$$
+ │   	AS $$SELECT w::STRING FROM {TABLE:55};$$
  └── dependencies
       └── workdays [columns: w]
 
@@ -76,7 +76,7 @@ create-function
  ├── CREATE FUNCTION f(IN a INT8)
  │   	RETURNS INT8
  │   	LANGUAGE SQL
- │   	AS $$SELECT a FROM t.public.ab;$$
+ │   	AS $$SELECT a FROM {TABLE:53};$$
  └── dependencies
       └── ab [columns: a]
 
@@ -87,7 +87,7 @@ create-function
  ├── CREATE FUNCTION f()
  │   	RETURNS INT8
  │   	LANGUAGE SQL
- │   	AS $$SELECT b FROM t.public.ab@idx;$$
+ │   	AS $$SELECT b FROM {TABLE:53}@idx;$$
  └── dependencies
       └── ab@idx [columns: b]
 
@@ -101,7 +101,7 @@ create-function
  ├── CREATE FUNCTION f()
  │   	RETURNS INT8
  │   	LANGUAGE SQL
- │   	AS $$SELECT a FROM t.public.ab;
+ │   	AS $$SELECT a FROM {TABLE:53};
  │   SELECT nextval('s');$$
  └── dependencies
       ├── ab [columns: a]
@@ -114,7 +114,7 @@ create-function
  ├── CREATE FUNCTION f()
  │   	RETURNS ab
  │   	LANGUAGE SQL
- │   	AS $$SELECT ab.a, ab.b FROM t.public.ab;$$
+ │   	AS $$SELECT {TABLE:53}.a, {TABLE:53}.b FROM {TABLE:53};$$
  └── dependencies
       └── ab [columns: a b]
 
@@ -125,7 +125,7 @@ create-function
  ├── CREATE FUNCTION f()
  │   	RETURNS ab
  │   	LANGUAGE SQL
- │   	AS $$SELECT "?subquery1?".a, "?subquery1?".b FROM (SELECT ab.a, ab.b FROM t.public.ab) AS "?subquery1?";$$
+ │   	AS $$SELECT "?subquery1?".a, "?subquery1?".b FROM (SELECT {TABLE:53}.a, {TABLE:53}.b FROM {TABLE:53}) AS "?subquery1?";$$
  └── dependencies
       └── ab [columns: a b]
 

--- a/pkg/sql/opt/optbuilder/testdata/select_table_id_reference
+++ b/pkg/sql/opt/optbuilder/testdata/select_table_id_reference
@@ -1,0 +1,190 @@
+exec-ddl
+CREATE TABLE t1 (a INT PRIMARY KEY, b INT, c INT)
+----
+
+exec-ddl
+CREATE TABLE t2 (a INT PRIMARY KEY, b INT, d INT)
+----
+
+exec-ddl
+CREATE OR REPLACE VIEW v1 AS SELECT a FROM t1
+----
+
+# 53 is the id of t1
+# 54 is the id of t2
+# 55 is the id of v1
+
+build
+SELECT a FROM {TABLE:53}
+----
+project
+ ├── columns: a:1!null
+ └── scan t1
+      └── columns: a:1!null b:2 c:3 crdb_internal_mvcc_timestamp:4 tableoid:5
+
+build
+SELECT {TABLE:53}.a FROM {TABLE:53} WHERE {TABLE:53}.b > 20 ORDER BY {TABLE:53}.b;
+----
+sort
+ ├── columns: a:1!null  [hidden: b:2!null]
+ ├── ordering: +2
+ └── project
+      ├── columns: a:1!null b:2!null
+      └── select
+           ├── columns: a:1!null b:2!null c:3 crdb_internal_mvcc_timestamp:4 tableoid:5
+           ├── scan t1
+           │    └── columns: a:1!null b:2 c:3 crdb_internal_mvcc_timestamp:4 tableoid:5
+           └── filters
+                └── b:2 > 20
+
+build
+SELECT t.a FROM (SELECT a FROM {TABLE:53} WHERE b > 20 ORDER BY b) AS t WHERE t.a > 1 ORDER BY t.a;
+----
+project
+ ├── columns: a:1!null
+ ├── ordering: +1
+ └── select
+      ├── columns: a:1!null b:2!null
+      ├── ordering: +1
+      ├── project
+      │    ├── columns: a:1!null b:2!null
+      │    ├── ordering: +1
+      │    └── select
+      │         ├── columns: a:1!null b:2!null c:3 crdb_internal_mvcc_timestamp:4 tableoid:5
+      │         ├── ordering: +1
+      │         ├── scan t1
+      │         │    ├── columns: a:1!null b:2 c:3 crdb_internal_mvcc_timestamp:4 tableoid:5
+      │         │    └── ordering: +1
+      │         └── filters
+      │              └── b:2 > 20
+      └── filters
+           └── a:1 > 1
+
+build
+SELECT {TABLE:53}.a, {TABLE:53}.b, {TABLE:53}.c, {TABLE:54}.a, {TABLE:54}.b, {TABLE:54}.d
+FROM {TABLE:53}
+JOIN {TABLE:54} ON c = d
+GROUP BY t1.*, t2.* ORDER BY t1.*, t2.*;
+----
+group-by (streaming)
+ ├── columns: a:1!null b:2 c:3!null a:6!null b:7 d:8!null
+ ├── grouping columns: t1.a:1!null t1.b:2 c:3!null t2.a:6!null t2.b:7 d:8!null
+ ├── ordering: +1,+2,+3,+6,+7,+8
+ └── sort
+      ├── columns: t1.a:1!null t1.b:2 c:3!null t2.a:6!null t2.b:7 d:8!null
+      ├── ordering: +1,+6
+      └── project
+           ├── columns: t1.a:1!null t1.b:2 c:3!null t2.a:6!null t2.b:7 d:8!null
+           └── inner-join (hash)
+                ├── columns: t1.a:1!null t1.b:2 c:3!null t1.crdb_internal_mvcc_timestamp:4 t1.tableoid:5 t2.a:6!null t2.b:7 d:8!null t2.crdb_internal_mvcc_timestamp:9 t2.tableoid:10
+                ├── scan t1
+                │    └── columns: t1.a:1!null t1.b:2 c:3 t1.crdb_internal_mvcc_timestamp:4 t1.tableoid:5
+                ├── scan t2
+                │    └── columns: t2.a:6!null t2.b:7 d:8 t2.crdb_internal_mvcc_timestamp:9 t2.tableoid:10
+                └── filters
+                     └── c:3 = d:8
+
+build
+SELECT {TABLE:53}.a + {TABLE:54}.a
+FROM {TABLE:53} JOIN {TABLE:54} ON {TABLE:53}.b = {TABLE:54}.b
+GROUP BY {TABLE:53}.a + {TABLE:54}.a
+HAVING ({TABLE:53}.a + {TABLE:54}.a) > 1
+ORDER BY {TABLE:53}.a + {TABLE:54}.a
+----
+sort
+ ├── columns: "?column?":11!null
+ ├── ordering: +11
+ └── select
+      ├── columns: column11:11!null
+      ├── group-by (hash)
+      │    ├── columns: column11:11!null
+      │    ├── grouping columns: column11:11!null
+      │    └── project
+      │         ├── columns: column11:11!null
+      │         ├── inner-join (hash)
+      │         │    ├── columns: t1.a:1!null t1.b:2!null c:3 t1.crdb_internal_mvcc_timestamp:4 t1.tableoid:5 t2.a:6!null t2.b:7!null d:8 t2.crdb_internal_mvcc_timestamp:9 t2.tableoid:10
+      │         │    ├── scan t1
+      │         │    │    └── columns: t1.a:1!null t1.b:2 c:3 t1.crdb_internal_mvcc_timestamp:4 t1.tableoid:5
+      │         │    ├── scan t2
+      │         │    │    └── columns: t2.a:6!null t2.b:7 d:8 t2.crdb_internal_mvcc_timestamp:9 t2.tableoid:10
+      │         │    └── filters
+      │         │         └── t1.b:2 = t2.b:7
+      │         └── projections
+      │              └── t1.a:1 + t2.a:6 [as=column11:11]
+      └── filters
+           └── column11:11 > 1
+
+build
+SELECT {TABLE:53}.a + {TABLE:54}.a
+FROM {TABLE:53} JOIN {TABLE:54} USING (a)
+----
+project
+ ├── columns: "?column?":11!null
+ ├── inner-join (hash)
+ │    ├── columns: t1.a:1!null t1.b:2 c:3 t1.crdb_internal_mvcc_timestamp:4 t1.tableoid:5 t2.a:6!null t2.b:7 d:8 t2.crdb_internal_mvcc_timestamp:9 t2.tableoid:10
+ │    ├── scan t1
+ │    │    └── columns: t1.a:1!null t1.b:2 c:3 t1.crdb_internal_mvcc_timestamp:4 t1.tableoid:5
+ │    ├── scan t2
+ │    │    └── columns: t2.a:6!null t2.b:7 d:8 t2.crdb_internal_mvcc_timestamp:9 t2.tableoid:10
+ │    └── filters
+ │         └── t1.a:1 = t2.a:6
+ └── projections
+      └── t1.a:1 + t2.a:6 [as="?column?":11]
+
+build
+SELECT p.a + q.a
+FROM {TABLE:53} AS p
+JOIN {TABLE:54} AS q ON p.b = q.b
+GROUP BY p.a + q.a
+HAVING (p.a + q.a) > 1
+ORDER BY p.a + q.a;
+----
+sort
+ ├── columns: "?column?":11!null
+ ├── ordering: +11
+ └── select
+      ├── columns: column11:11!null
+      ├── group-by (hash)
+      │    ├── columns: column11:11!null
+      │    ├── grouping columns: column11:11!null
+      │    └── project
+      │         ├── columns: column11:11!null
+      │         ├── inner-join (hash)
+      │         │    ├── columns: p.a:1!null p.b:2!null c:3 p.crdb_internal_mvcc_timestamp:4 p.tableoid:5 q.a:6!null q.b:7!null d:8 q.crdb_internal_mvcc_timestamp:9 q.tableoid:10
+      │         │    ├── scan t1 [as=p]
+      │         │    │    └── columns: p.a:1!null p.b:2 c:3 p.crdb_internal_mvcc_timestamp:4 p.tableoid:5
+      │         │    ├── scan t2 [as=q]
+      │         │    │    └── columns: q.a:6!null q.b:7 d:8 q.crdb_internal_mvcc_timestamp:9 q.tableoid:10
+      │         │    └── filters
+      │         │         └── p.b:2 = q.b:7
+      │         └── projections
+      │              └── p.a:1 + q.a:6 [as=column11:11]
+      └── filters
+           └── column11:11 > 1
+
+build
+SELECT DISTINCT ON ({TABLE:53}.a) {TABLE:53}.b FROM {TABLE:53} ORDER BY a;
+----
+distinct-on
+ ├── columns: b:2  [hidden: a:1!null]
+ ├── grouping columns: a:1!null
+ ├── ordering: +1
+ ├── project
+ │    ├── columns: a:1!null b:2
+ │    ├── ordering: +1
+ │    └── scan t1
+ │         ├── columns: a:1!null b:2 c:3 crdb_internal_mvcc_timestamp:4 tableoid:5
+ │         └── ordering: +1
+ └── aggregations
+      └── first-agg [as=b:2]
+           └── b:2
+
+build
+SELECT {TABLE:55}.a FROM {TABLE:55} ORDER BY {TABLE:55}.a;
+----
+project
+ ├── columns: a:1!null
+ ├── ordering: +1
+ └── scan t1
+      ├── columns: a:1!null b:2 c:3 crdb_internal_mvcc_timestamp:4 tableoid:5
+      └── ordering: +1

--- a/pkg/sql/opt/optbuilder/util.go
+++ b/pkg/sql/opt/optbuilder/util.go
@@ -672,6 +672,26 @@ func (b *Builder) resolveDataSourceRef(
 	return ds, depName
 }
 
+// resolveDataSourceIDRef returns the data source in the catalog that matches
+// the given table id reference. Error will be returned if no data source
+// matches, or if the current user does not have the given privilege.
+func (b *Builder) resolveDataSourceIDRef(
+	ref *tree.TableIDRef, priv privilege.Kind,
+) (cat.DataSource, opt.MDDepName) {
+	var flags cat.Flags
+	if b.insideViewDef || b.insideFuncDef {
+		// Avoid taking table leases when we're creating a view or a function.
+		flags.AvoidDescriptorCaches = true
+	}
+	ds, _, err := b.catalog.ResolveDataSourceByID(b.ctx, flags, cat.StableID(ref.ID))
+	if err != nil {
+		panic(pgerror.Wrapf(err, pgcode.UndefinedObject, "%s", tree.ErrString(ref)))
+	}
+	depName := opt.DepByID(cat.StableID(ref.ID))
+	b.checkPrivilege(depName, ds, priv)
+	return ds, depName
+}
+
 // checkPrivilege ensures that the current user has the privilege needed to
 // access the given object in the catalog. If not, then checkPrivilege raises an
 // error. It also adds the object and it's original unresolved name as a
@@ -762,4 +782,78 @@ func tableOrdinals(tab cat.Table, k columnKinds) []int {
 		}
 	}
 	return ordinals
+}
+
+// columnPrefixRewriter is a tree.Visitor implementation to rewrite a column
+// representation's prefix in to table ID references.
+type columnPrefixRewriter struct {
+	s *scope
+}
+
+func newColumnPrefixRewriter(s *scope) *columnPrefixRewriter {
+	return &columnPrefixRewriter{
+		s: s,
+	}
+}
+
+// VisitPre is part of the tree.Visitor interface.
+func (r *columnPrefixRewriter) VisitPre(expr tree.Expr) (recurse bool, newExpr tree.Expr) {
+	switch t := expr.(type) {
+	case *tree.AllColumnsSelector, *tree.TupleStar:
+		// Leave star as it is.
+		return false, expr
+
+	case *tree.UnresolvedName:
+		vn, err := t.NormalizeVarName()
+		if err != nil {
+			panic(err)
+		}
+		return r.VisitPre(vn)
+
+	case *tree.ColumnItem:
+		// If the ColumnItem is not prefixed, there is no need to rewrite.
+		if t.TableName == nil || t.TableName.NumParts == 0 {
+			return false, expr
+		}
+		colI, err := colinfo.ResolveColumnItem(r.s.builder.ctx, r.s, t)
+		if err != nil {
+			panic(err)
+		}
+		scopeCol := colI.(*scopeColumn)
+		md := r.s.builder.factory.Metadata()
+		tblID := md.ColumnMeta(scopeCol.id).Table
+		// Table ID would be zero if the scopeColumn represents a UDF input
+		// parameter. There is no need to rewrite parameter names.
+		if tblID == 0 {
+			return false, expr
+		}
+		tbl := md.Table(tblID)
+		// Do not rewrite if the table is a system table or virtual table.
+		if tbl.IsSystemTable() || tbl.IsVirtualTable() {
+			return false, expr
+		}
+		tblStableID := md.Table(tblID).ID()
+
+		if scopeCol.table.CatalogName != "" && scopeCol.table.SchemaName != "" {
+			// If a column is a reference from a real table.
+			return false, &tree.ColumnNameRef{
+				Table:      &tree.TableIDRef{ID: int64(tblStableID)},
+				ColumnName: scopeCol.name.ReferenceName(),
+			}
+		} else {
+			// If the table is not fully qualified, which means that the table name
+			// can be a table alias or a subquery alias, then we don't need to
+			// rewrite it.
+			return false, &tree.ColumnItem{
+				TableName:  scopeCol.table.ToUnresolvedObjectName(),
+				ColumnName: scopeCol.name.ReferenceName(),
+			}
+		}
+	}
+	return true, expr
+}
+
+// VisitPost is part of the tree.Visitor interface.
+func (*columnPrefixRewriter) VisitPost(expr tree.Expr) tree.Expr {
+	return expr
 }

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -1522,7 +1522,7 @@ func (u *sqlSymUnion) showCreateFormatOption() tree.ShowCreateFormatOption {
 %type <bool> opt_ordinality opt_compact
 %type <*tree.Order> sortby
 %type <tree.IndexElem> index_elem index_elem_options create_as_param
-%type <tree.TableExpr> table_ref numeric_table_ref func_table
+%type <tree.TableExpr> table_ref numeric_table_ref func_table table_id_ref
 %type <tree.Exprs> rowsfrom_list
 %type <tree.Expr> rowsfrom_item
 %type <tree.TableExpr> joined_table
@@ -12932,6 +12932,16 @@ table_ref:
         As:         $4.aliasClause(),
     }
   }
+| table_id_ref opt_index_flags opt_ordinality opt_alias_clause
+  {
+    /* SKIP DOC */
+    $$.val = &tree.AliasedTableExpr{
+        Expr:       $1.tblExpr(),
+        IndexFlags: $2.indexFlags(),
+        Ordinality: $3.bool(),
+        As:         $4.aliasClause(),
+    }
+  }
 | relation_expr opt_index_flags opt_ordinality opt_alias_clause
   {
     name := $1.unresolvedObjectName().ToTableName()
@@ -13015,6 +13025,15 @@ numeric_table_ref:
       TableID: $2.int64(),
       Columns: $3.tableRefCols(),
       As:      $4.aliasClause(),
+    }
+  }
+
+table_id_ref:
+  '{' TABLE ':' iconst64 '}'
+  {
+    /* SKIP DOC */
+    $$.val = &tree.TableIDRef{
+      ID: $4.int64(),
     }
   }
 
@@ -14446,6 +14465,14 @@ a_expr:
 | DEFAULT
   {
     $$.val = tree.DefaultVal{}
+  }
+| table_id_ref '.' name
+  {
+    /* SKIP DOC */
+    $$.val = &tree.ColumnNameRef{
+      Table: $1.tblExpr().(*tree.TableIDRef),
+      ColumnName: tree.Name($3),
+    }
   }
 // The UNIQUE predicate is a standard SQL feature but not yet implemented
 // in PostgreSQL (as of 10.5).

--- a/pkg/sql/parser/testdata/column_ref
+++ b/pkg/sql/parser/testdata/column_ref
@@ -1,0 +1,23 @@
+parse
+SELECT {TABLE:123}.a FROM t;
+----
+SELECT {TABLE:123}.a FROM t -- normalized!
+SELECT ({TABLE:123}.a) FROM t -- fully parenthesized
+SELECT {TABLE:123}.a FROM t -- literals removed
+SELECT {TABLE:123}._ FROM _ -- identifiers removed
+
+parse
+SELECT {TABLE:123}.a FROM t WHERE {TABLE:123}.b > 20 ORDER BY {TABLE:123}.b;
+----
+SELECT {TABLE:123}.a FROM t WHERE {TABLE:123}.b > 20 ORDER BY {TABLE:123}.b -- normalized!
+SELECT ({TABLE:123}.a) FROM t WHERE (({TABLE:123}.b) > (20)) ORDER BY ({TABLE:123}.b) -- fully parenthesized
+SELECT {TABLE:123}.a FROM t WHERE {TABLE:123}.b > _ ORDER BY {TABLE:123}.b -- literals removed
+SELECT {TABLE:123}._ FROM _ WHERE {TABLE:123}._ > 20 ORDER BY {TABLE:123}._ -- identifiers removed
+
+parse
+SELECT {TABLE:123}.a + {TABLE:321}.a FROM t1 JOIN t2 ON {TABLE:123}.b = {TABLE:321}.b GROUP BY {TABLE:123}.a + {TABLE:321}.a HAVING {TABLE:123}.a + {TABLE:321}.a > 1;
+----
+SELECT {TABLE:123}.a + {TABLE:321}.a FROM t1 JOIN t2 ON {TABLE:123}.b = {TABLE:321}.b GROUP BY {TABLE:123}.a + {TABLE:321}.a HAVING ({TABLE:123}.a + {TABLE:321}.a) > 1 -- normalized!
+SELECT (({TABLE:123}.a) + ({TABLE:321}.a)) FROM t1 JOIN t2 ON (({TABLE:123}.b) = ({TABLE:321}.b)) GROUP BY (({TABLE:123}.a) + ({TABLE:321}.a)) HAVING (((({TABLE:123}.a) + ({TABLE:321}.a))) > (1)) -- fully parenthesized
+SELECT {TABLE:123}.a + {TABLE:321}.a FROM t1 JOIN t2 ON {TABLE:123}.b = {TABLE:321}.b GROUP BY {TABLE:123}.a + {TABLE:321}.a HAVING ({TABLE:123}.a + {TABLE:321}.a) > _ -- literals removed
+SELECT {TABLE:123}._ + {TABLE:321}._ FROM _ JOIN _ ON {TABLE:123}._ = {TABLE:321}._ GROUP BY {TABLE:123}._ + {TABLE:321}._ HAVING ({TABLE:123}._ + {TABLE:321}._) > 1 -- identifiers removed

--- a/pkg/sql/parser/testdata/table_by_id
+++ b/pkg/sql/parser/testdata/table_by_id
@@ -118,3 +118,35 @@ DELETE FROM [123 AS t]@idx
 DELETE FROM [123 AS t]@idx -- fully parenthesized
 DELETE FROM [123 AS t]@idx -- literals removed
 DELETE FROM [123 AS _]@_ -- identifiers removed
+
+parse
+SELECT * FROM {TABLE:123}
+----
+SELECT * FROM {TABLE:123}
+SELECT (*) FROM {TABLE:123} -- fully parenthesized
+SELECT * FROM {TABLE:123} -- literals removed
+SELECT * FROM {TABLE:123} -- identifiers removed
+
+parse
+SELECT a FROM {TABLE:123}@idx
+----
+SELECT a FROM {TABLE:123}@idx
+SELECT (a) FROM {TABLE:123}@idx -- fully parenthesized
+SELECT a FROM {TABLE:123}@idx -- literals removed
+SELECT _ FROM {TABLE:123}@_ -- identifiers removed
+
+parse
+SELECT 'a' FROM {TABLE:123}@{FORCE_INDEX=[123]}
+----
+SELECT 'a' FROM {TABLE:123}@[123] -- normalized!
+SELECT ('a') FROM {TABLE:123}@[123] -- fully parenthesized
+SELECT '_' FROM {TABLE:123}@[123] -- literals removed
+SELECT 'a' FROM {TABLE:123}@[123] -- identifiers removed
+
+parse
+SELECT * FROM {TABLE:123}@[456]
+----
+SELECT * FROM {TABLE:123}@[456]
+SELECT (*) FROM {TABLE:123}@[456] -- fully parenthesized
+SELECT * FROM {TABLE:123}@[456] -- literals removed
+SELECT * FROM {TABLE:123}@[456] -- identifiers removed

--- a/pkg/sql/schemachanger/scbuild/testdata/drop_function
+++ b/pkg/sql/schemachanger/scbuild/testdata/drop_function
@@ -40,4 +40,4 @@ DROP FUNCTION f;
 - [[FunctionNullInputBehavior:{DescID: 109}, ABSENT], PUBLIC]
   {functionId: 109, nullInputBehavior: {nullInputBehavior: CALLED_ON_NULL_INPUT}}
 - [[FunctionBody:{DescID: 109}, ABSENT], PUBLIC]
-  {body: "SELECT a FROM defaultdb.public.t;\nSELECT b FROM defaultdb.public.t@t_idx_b;\nSELECT c FROM defaultdb.public.t@t_idx_c;\nSELECT a FROM defaultdb.public.v;\nSELECT nextval(105:::REGCLASS);", functionId: 109, lang: {lang: SQL}, usesSequenceIds: [105], usesTables: [{columnIds: [1], tableId: 104}, {columnIds: [2], indexId: 2, tableId: 104}, {columnIds: [3], indexId: 3, tableId: 104}], usesTypeIds: [107, 108], usesViews: [{columnIds: [1], viewId: 106}]}
+  {body: "SELECT a FROM {TABLE:104};\nSELECT b FROM {TABLE:104}@t_idx_b;\nSELECT c FROM {TABLE:104}@t_idx_c;\nSELECT a FROM {TABLE:106};\nSELECT nextval(105:::REGCLASS);", functionId: 109, lang: {lang: SQL}, usesSequenceIds: [105], usesTables: [{columnIds: [1], tableId: 104}, {columnIds: [2], indexId: 2, tableId: 104}, {columnIds: [3], indexId: 3, tableId: 104}], usesTypeIds: [107, 108], usesViews: [{columnIds: [1], viewId: 106}]}

--- a/pkg/sql/schemachanger/scdecomp/testdata/function
+++ b/pkg/sql/schemachanger/scdecomp/testdata/function
@@ -73,10 +73,10 @@ ElementState:
   Status: PUBLIC
 - FunctionBody:
     body: |-
-      SELECT a FROM defaultdb.public.t;
-      SELECT b FROM defaultdb.public.t@t_idx_b;
-      SELECT c FROM defaultdb.public.t@t_idx_c;
-      SELECT a FROM defaultdb.public.v;
+      SELECT a FROM {TABLE:104};
+      SELECT b FROM {TABLE:104}@t_idx_b;
+      SELECT c FROM {TABLE:104}@t_idx_c;
+      SELECT a FROM {TABLE:107};
       SELECT nextval(105:::REGCLASS);
     functionId: 110
     lang:

--- a/pkg/sql/schemachanger/testdata/end_to_end/create_function/create_function.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/create_function/create_function.explain
@@ -24,7 +24,7 @@ Schema change plan for CREATE FUNCTION ‹defaultdb›.‹public›.‹f›(IN �
 	RETURNS INT8
 	VOLATILE
 	LANGUAGE SQL
-	AS $$SELECT ‹a› FROM ‹defaultdb›.‹public›.‹t›; SELECT ‹b› FROM ‹defaultdb›.‹public›.‹t›@‹t_idx_b›; SELECT ‹c› FROM ‹defaultdb›.‹public›.‹t›@‹t_idx_c›; SELECT ‹a› FROM ‹defaultdb›.‹public›.‹v›; SELECT nextval(‹'sq1'›);$$;
+	AS $$SELECT ‹a› FROM {TABLE:104}; SELECT ‹b› FROM {TABLE:104}@‹t_idx_b›; SELECT ‹c› FROM {TABLE:104}@‹t_idx_c›; SELECT ‹a› FROM {TABLE:106}; SELECT nextval(‹'sq1'›);$$;
  ├── StatementPhase
  │    └── Stage 1 of 1 in StatementPhase
  │         ├── 8 elements transitioning toward PUBLIC

--- a/pkg/sql/schemachanger/testdata/end_to_end/create_function/create_function.explain_shape
+++ b/pkg/sql/schemachanger/testdata/end_to_end/create_function/create_function.explain_shape
@@ -24,5 +24,5 @@ Schema change plan for CREATE FUNCTION ‹defaultdb›.‹public›.‹f›(IN �
 	RETURNS INT8
 	VOLATILE
 	LANGUAGE SQL
-	AS $$SELECT ‹a› FROM ‹defaultdb›.‹public›.‹t›; SELECT ‹b› FROM ‹defaultdb›.‹public›.‹t›@‹t_idx_b›; SELECT ‹c› FROM ‹defaultdb›.‹public›.‹t›@‹t_idx_c›; SELECT ‹a› FROM ‹defaultdb›.‹public›.‹v›; SELECT nextval(‹'sq1'›);$$;
+	AS $$SELECT ‹a› FROM {TABLE:104}; SELECT ‹b› FROM {TABLE:104}@‹t_idx_b›; SELECT ‹c› FROM {TABLE:104}@‹t_idx_c›; SELECT ‹a› FROM {TABLE:106}; SELECT nextval(‹'sq1'›);$$;
  └── execute 1 system table mutations transaction

--- a/pkg/sql/schemachanger/testdata/end_to_end/create_function/create_function.side_effects
+++ b/pkg/sql/schemachanger/testdata/end_to_end/create_function/create_function.side_effects
@@ -36,9 +36,9 @@ write *eventpb.CreateFunction to event log:
   sql:
     descriptorId: 110
     statement: "CREATE FUNCTION ‹defaultdb›.‹public›.‹f›(IN ‹a› ‹notmyworkday›)\n\tRETURNS
-      INT8\n\tVOLATILE\n\tLANGUAGE SQL\n\tAS $$SELECT ‹a› FROM ‹defaultdb›.‹public›.‹t›;
-      SELECT ‹b› FROM ‹defaultdb›.‹public›.‹t›@‹t_idx_b›; SELECT ‹c› FROM ‹defaultdb›.‹public›.‹t›@‹t_idx_c›;
-      SELECT ‹a› FROM ‹defaultdb›.‹public›.‹v›; SELECT nextval(‹'sq1'›);$$"
+      INT8\n\tVOLATILE\n\tLANGUAGE SQL\n\tAS $$SELECT ‹a› FROM {TABLE:104}; SELECT ‹b›
+      FROM {TABLE:104}@‹t_idx_b›; SELECT ‹c› FROM {TABLE:104}@‹t_idx_c›; SELECT ‹a›
+      FROM {TABLE:106}; SELECT nextval(‹'sq1'›);$$"
     tag: CREATE FUNCTION
     user: root
 ## StatementPhase stage 1 of 1 with 11 MutationType ops

--- a/pkg/sql/sem/tree/col_name.go
+++ b/pkg/sql/sem/tree/col_name.go
@@ -69,6 +69,9 @@ func ComputeColNameInternal(
 	case *ColumnItem:
 		return 2, e.Column(), nil
 
+	case *ColumnNameRef:
+		return 2, string(e.ColumnName), nil
+
 	case *IndirectionExpr:
 		return ComputeColNameInternal(ctx, sp, e.Expr, funcResolver)
 

--- a/pkg/sql/sem/tree/select.go
+++ b/pkg/sql/sem/tree/select.go
@@ -284,13 +284,15 @@ type TableExpr interface {
 	WalkTableExpr(Visitor) TableExpr
 }
 
-func (*TableIDRef) tableExpr()       {}
 func (*AliasedTableExpr) tableExpr() {}
 func (*ParenTableExpr) tableExpr()   {}
 func (*JoinTableExpr) tableExpr()    {}
 func (*RowsFromExpr) tableExpr()     {}
 func (*Subquery) tableExpr()         {}
 func (*StatementSource) tableExpr()  {}
+func (*TableIDRef) tableExpr()       {}
+func (*TableName) tableExpr()        {}
+func (*TableRef) tableExpr()         {}
 
 // StatementSource encapsulates one of the other statements as a data source.
 type StatementSource struct {

--- a/pkg/sql/sem/tree/select.go
+++ b/pkg/sql/sem/tree/select.go
@@ -284,6 +284,7 @@ type TableExpr interface {
 	WalkTableExpr(Visitor) TableExpr
 }
 
+func (*TableIDRef) tableExpr()       {}
 func (*AliasedTableExpr) tableExpr() {}
 func (*ParenTableExpr) tableExpr()   {}
 func (*JoinTableExpr) tableExpr()    {}

--- a/pkg/sql/sem/tree/table_name.go
+++ b/pkg/sql/sem/tree/table_name.go
@@ -65,9 +65,6 @@ func (t *TableName) Equals(other *TableName) bool {
 	return *t == *other
 }
 
-// tableExpr implements the TableExpr interface.
-func (*TableName) tableExpr() {}
-
 // NewTableNameWithSchema creates a new table name qualified with a given
 // catalog and schema.
 func NewTableNameWithSchema(db, sc, tbl Name) *TableName {

--- a/pkg/sql/sem/tree/table_ref.go
+++ b/pkg/sql/sem/tree/table_ref.go
@@ -60,9 +60,6 @@ func (n *TableRef) Format(ctx *FmtCtx) {
 }
 func (n *TableRef) String() string { return AsString(n) }
 
-// tableExpr implements the TableExpr interface.
-func (n *TableRef) tableExpr() {}
-
 // TableIDRef represents a table by its descriptor ID.
 type TableIDRef struct {
 	ID int64
@@ -72,8 +69,52 @@ func (expr *TableIDRef) Format(ctx *FmtCtx) {
 	ctx.WriteString(fmt.Sprintf("{TABLE:%v}", expr.ID))
 }
 
+func (expr *TableIDRef) String() string {
+	return AsString(expr)
+}
+
 func (expr *TableIDRef) WalkTableExpr(visitor Visitor) TableExpr {
+	newExpr, changed := WalkExpr(visitor, &TableIDRefExpr{TableIDRef: *expr})
+	if changed {
+		switch t := newExpr.(type) {
+		case *TableIDRefExpr:
+			return &t.TableIDRef
+		case *TableNameExpr:
+			return &t.TableName
+		default:
+			panic("TableIDRef cannot be changed to other types other than TableIDRef and TableName")
+		}
+	}
 	return expr
+}
+
+// TableNameExpr is a wrapper of TableName implementing the Expr interface. It's
+// being used as a helper for UDF/View query rewriting where the expression need
+// to be walked by WalkExpr() function. Wrapping TableName because we can't make
+// TableName implement Expr since all Exprs are parenthesized in
+// FmtAlwaysGroupExprs with formatting flag and parenthesized TableName cannot
+// be parsed as valid syntax.
+type TableNameExpr struct {
+	TableName
+}
+
+// TableIDRefExpr is a wrapper of TableIDRef implementing the Expr interface.
+// It's being used as a helper for UDF/View query rewriting where the expression
+// need to be walked by WalkExpr() function. Wrapping TableIDRef because we
+// can't make TableIDRef implement Expr since all Exprs are parenthesized in
+// FmtAlwaysGroupExprs with formatting flag and parenthesized TableIDRef cannot
+// be parsed as valid syntax.
+type TableIDRefExpr struct {
+	TableIDRef
+}
+
+// Format implements the NodeFormatter interface.
+func (expr *TableIDRefExpr) Format(ctx *FmtCtx) {
+	ctx.WriteString(fmt.Sprintf("{TABLE:%v}", expr.ID))
+}
+
+func (expr *TableIDRefExpr) String() string {
+	return AsString(expr)
 }
 
 // ColumnNameRef represent a column prefixed with a table id reference.

--- a/pkg/sql/sem/tree/type_check.go
+++ b/pkg/sql/sem/tree/type_check.go
@@ -1455,6 +1455,22 @@ func (expr *ColumnNameRef) TypeCheck(
 }
 
 // TypeCheck implements the Expr interface.
+func (expr *TableIDRefExpr) TypeCheck(
+	_ context.Context, _ *SemaContext, _ *types.T,
+) (TypedExpr, error) {
+	return nil, pgerror.Newf(pgcode.UndefinedColumn,
+		"table id reference %q type check not supported", ErrString(expr))
+}
+
+// TypeCheck implements the Expr interface.
+func (expr *TableNameExpr) TypeCheck(
+	_ context.Context, _ *SemaContext, _ *types.T,
+) (TypedExpr, error) {
+	return nil, pgerror.Newf(pgcode.UndefinedColumn,
+		"table id reference %q type check not supported", ErrString(expr))
+}
+
+// TypeCheck implements the Expr interface.
 func (expr UnqualifiedStar) TypeCheck(
 	_ context.Context, _ *SemaContext, desired *types.T,
 ) (TypedExpr, error) {

--- a/pkg/sql/sem/tree/type_check.go
+++ b/pkg/sql/sem/tree/type_check.go
@@ -1447,6 +1447,14 @@ func (expr *ColumnItem) TypeCheck(
 }
 
 // TypeCheck implements the Expr interface.
+func (expr *ColumnNameRef) TypeCheck(
+	_ context.Context, _ *SemaContext, _ *types.T,
+) (TypedExpr, error) {
+	return nil, pgerror.Newf(pgcode.UndefinedColumn,
+		"column %q type check not supported", ErrString(expr))
+}
+
+// TypeCheck implements the Expr interface.
 func (expr UnqualifiedStar) TypeCheck(
 	_ context.Context, _ *SemaContext, desired *types.T,
 ) (TypedExpr, error) {

--- a/pkg/sql/sem/tree/walk.go
+++ b/pkg/sql/sem/tree/walk.go
@@ -708,6 +708,16 @@ func (expr *ColumnNameRef) Walk(_ Visitor) Expr {
 }
 
 // Walk implements the Expr interface.
+func (expr *TableIDRefExpr) Walk(_ Visitor) Expr {
+	return expr
+}
+
+// Walk implements the Expr interface.
+func (expr *TableNameExpr) Walk(_ Visitor) Expr {
+	return expr
+}
+
+// Walk implements the Expr interface.
 func (expr DefaultVal) Walk(_ Visitor) Expr { return expr }
 
 // Walk implements the Expr interface.

--- a/pkg/sql/sem/tree/walk.go
+++ b/pkg/sql/sem/tree/walk.go
@@ -703,6 +703,11 @@ func (expr *ColumnItem) Walk(_ Visitor) Expr {
 }
 
 // Walk implements the Expr interface.
+func (expr *ColumnNameRef) Walk(_ Visitor) Expr {
+	return expr
+}
+
+// Walk implements the Expr interface.
 func (expr DefaultVal) Walk(_ Visitor) Expr { return expr }
 
 // Walk implements the Expr interface.

--- a/pkg/sql/show_create_clauses.go
+++ b/pkg/sql/show_create_clauses.go
@@ -239,6 +239,55 @@ func formatQuerySequencesForDisplay(
 	return fmtCtx.CloseAndGetString(), nil
 }
 
+// formatTableReferenceForDisplay walks the view query and looks for table ID
+// references in the statement. If it finds any, it will replace the IDs with
+// the descriptor's fully qualified name.
+func formatTableReferenceForDisplay(
+	ctx context.Context, semaCtx *tree.SemaContext, queries string, multiStmt bool,
+) (string, error) {
+	replaceFunc := func(expr tree.Expr) (recurse bool, newExpr tree.Expr, err error) {
+		newExpr, err = schemaexpr.ReplaceTableIDsWithFQNames(ctx, expr, semaCtx)
+		if err != nil {
+			return false, expr, err
+		}
+		return false, newExpr, nil
+	}
+
+	var stmts tree.Statements
+	if multiStmt {
+		parsedStmts, err := parser.Parse(queries)
+		if err != nil {
+			return "", err
+		}
+		stmts = make(tree.Statements, len(parsedStmts))
+		for i, stmt := range parsedStmts {
+			stmts[i] = stmt.AST
+		}
+	} else {
+		stmt, err := parser.ParseOne(queries)
+		if err != nil {
+			return "", err
+		}
+		stmts = tree.Statements{stmt.AST}
+	}
+
+	fmtCtx := tree.NewFmtCtx(tree.FmtSimple)
+	for i, stmt := range stmts {
+		newStmt, err := tree.SimpleStmtVisit(stmt, replaceFunc)
+		if err != nil {
+			return "", err
+		}
+		if i > 0 {
+			fmtCtx.WriteString("\n")
+		}
+		fmtCtx.FormatNode(newStmt)
+		if multiStmt {
+			fmtCtx.WriteString(";")
+		}
+	}
+	return fmtCtx.CloseAndGetString(), nil
+}
+
 // formatViewQueryTypesForDisplay walks the view query and
 // look for serialized user-defined types. If it finds any,
 // it will deserialize it to display its name.

--- a/pkg/sql/telemetry_logging_test.go
+++ b/pkg/sql/telemetry_logging_test.go
@@ -1423,7 +1423,7 @@ SELECT k FROM kv WHERE v = 1;
 SELECT v FROM kv WHERE k = 'Foo';
 $$`
 
-	expectedLogStmt := `CREATE FUNCTION defaultdb.public.f()\n\tRETURNS INT8\n\tLANGUAGE SQL\n\tAS $$SELECT k FROM defaultdb.public.kv WHERE v = ‹1›; SELECT v FROM defaultdb.public.kv WHERE k = ‹'Foo'›;$$`
+	expectedLogStmt := `CREATE FUNCTION defaultdb.public.f()\n\tRETURNS INT8\n\tLANGUAGE SQL\n\tAS $$SELECT k FROM {TABLE:104} WHERE v = ‹1›; SELECT v FROM {TABLE:104} WHERE k = ‹'Foo'›;$$`
 
 	db.Exec(t, stmt)
 


### PR DESCRIPTION
(1) sql: add table id reference syntax
  This commit adds new syntax for ID reference to a table, as
  well as syntax for reference to a column with table id reference
  prefix.

(2) optbuilder: rewrite table name as id reference in udf SELECTs
  This commit adds logic to rewrite table names in SELECT queries
  within a UDF as id references. Both data source name and column
  prefixes are rewritten. However, we don't rewrite column prefixes
  that are alias.

(3) optbuilder: scopeColumn tracks source view id
  We build view as select query and the generated scopeColumns are
  linked to the source tables not views. This commit adds view ID
  to scopeColumn so that we can rewrite queries using view ids instead
  of the view's source table ids.

(4) sql: deserialize rewritten udf body
  This commit adds logic to deserialize table id references in udf
  body back to human readable qualified names.

(5) sql: rewrite ID references in UDF body during restore
  Descriptor IDs can change during restore into another db/cluster.
  This commit rewrites ID reference within UDF body to use new IDs
  of referenced descriptors.

Informs: #83233