### PR TITLE
kv: unit test IsEndTxnExceedingDeadline and IsEndTxnTriggeringRetryError

### DIFF
--- a/pkg/kv/kvpb/api.proto
+++ b/pkg/kv/kvpb/api.proto
@@ -839,9 +839,9 @@ message EndTxnRequest {
   // If set, deadline represents the maximum (exclusive) timestamp at which the
   // transaction can commit (i.e. the maximum timestamp for the txn's reads and
   // writes).
-  // If EndTxn(Commit=true) finds that the txn's timestamp has been pushed above
-  // this deadline, an error will be returned and the client is supposed to
-  // rollback the txn.
+  // If EndTxn(Commit=true) finds that the txn's timestamp has been pushed to or
+  // above this deadline, an error will be returned and the client is supposed
+  // to rollback the txn.
   util.hlc.Timestamp deadline = 3 [(gogoproto.nullable) = false];
   // commit triggers. Note that commit triggers are for
   // internal use only and will cause an error if requested through the

--- a/pkg/kv/kvserver/replica_write.go
+++ b/pkg/kv/kvserver/replica_write.go
@@ -796,7 +796,7 @@ func isOnePhaseCommit(ba *kvpb.BatchRequest) bool {
 	}
 	arg, _ := ba.GetArg(kvpb.EndTxn)
 	etArg := arg.(*kvpb.EndTxnRequest)
-	if retry, _, _ := batcheval.IsEndTxnTriggeringRetryError(ba.Txn, etArg); retry {
+	if retry, _, _ := batcheval.IsEndTxnTriggeringRetryError(ba.Txn, etArg.Deadline); retry {
 		return false
 	}
 	// If the transaction has already restarted at least once then it may have


### PR DESCRIPTION
Informs #100131.

This commit adds unit testing around IsEndTxnExceedingDeadline and IsEndTxnTriggeringRetryError. We'll be changing the latter function in future commits, so it's helpful to have tests in place.

While here, the commit cleans up the code slightly. It narrows the signature of the IsEndTxnTriggeringRetryError function to make its inputs more clear. It also makes the logic more readable.

Release note: None