### PR TITLE
ui: load insights with contention error

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/api/contentionApi.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/api/contentionApi.ts
@@ -60,9 +60,15 @@ export async function getContentionDetailsApi(
   const result = await executeInternalSql<ContentionResponseColumns>(request);
 
   if (sqlResultsAreEmpty(result)) {
+    if (result.error) {
+      // We don't return an error if it failed to retrieve the contention information.
+      console.error(
+        `Insights encounter an error while retrieving contention information: ${result.error}`,
+      );
+    }
     return formatApiResult<ContentionDetails[]>(
       [],
-      result.error,
+      null,
       "retrieving contention information",
     );
   }


### PR DESCRIPTION
When the retrieval of contention was failing, the full Insights page was returning an error. We should still load the page normally and log the error.

Part Of #101726

https://www.loom.com/share/93e931c92f5d4fa187a92c6d2789aa4c

Release note (bug fix): Show Insights even when there is an issue while decoding contention information.