### PR TITLE
sql: use curDB as test session db instead of hard coded string

### DIFF
--- a/pkg/sql/reference_provider.go
+++ b/pkg/sql/reference_provider.go
@@ -157,6 +157,6 @@ func NewReferenceProviderFactoryForTest(
 	opName string, txn *kv.Txn, user username.SQLUsername, execCfg *ExecutorConfig, curDB string,
 ) (scbuild.ReferenceProviderFactory, func()) {
 	ip, cleanup := newInternalPlanner(opName, txn, user, &MemoryMetrics{}, execCfg, sessiondatapb.SessionData{})
-	ip.SessionData().Database = "defaultdb"
+	ip.SessionData().Database = curDB
 	return &referenceProviderFactory{p: ip}, cleanup
 }


### PR DESCRIPTION
Previously, a mistake was made that "defaultdb" is always used as the session current db when constructing the reference provider. This commit fixes it to use the input `curDB`.

Epic: None
Release note: None