### PR TITLE
sqlproxy: fix per-connection memory leaks

### DIFF
--- a/pkg/ccl/sqlproxyccl/tenant/directory_cache.go
+++ b/pkg/ccl/sqlproxyccl/tenant/directory_cache.go
@@ -190,7 +190,8 @@ func (d *directoryCache) LookupTenantPods(
 			"cluster name %s doesn't match expected %s", clusterName, entry.ClusterName)
 	}
 
-	ctx, _ = d.stopper.WithCancelOnQuiesce(ctx)
+	ctx, cancel := d.stopper.WithCancelOnQuiesce(ctx)
+	defer cancel()
 	tenantPods := entry.GetPods()
 
 	// Trigger resumption if there are no RUNNING pods.
@@ -365,7 +366,8 @@ func (d *directoryCache) watchPods(ctx context.Context, stopper *stop.Stopper) e
 		var client Directory_WatchPodsClient
 		var err error
 		firstRun := true
-		ctx, _ = stopper.WithCancelOnQuiesce(ctx)
+		ctx, cancel := stopper.WithCancelOnQuiesce(ctx)
+		defer cancel()
 
 		watchPodsErr := log.Every(10 * time.Second)
 		recvErr := log.Every(10 * time.Second)


### PR DESCRIPTION
Creating a context with a cancellation callback requires modifying the parent context so that it has a pointer to the child. The pointer is cleaned up when the cancel function is called. A side effect of this is if the child's cancel() function is not called, the child context is leaked until the parent context is cancelled.

Previously, the sqlproxy was creating contexts for each tenant connection and tenant watch. These contexts were leaked every time. Now they are cleaned up when the watch stops or the connection is released.

Fixes: CC-24336