### PR TITLE
rowexec: fix projection on top of EXPORT

### DIFF
--- a/pkg/ccl/logictestccl/tests/3node-tenant/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/3node-tenant/generated_test.go
@@ -780,6 +780,13 @@ func TestTenantLogic_explain_analyze(
 	runLogicTest(t, "explain_analyze")
 }
 
+func TestTenantLogic_export(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "export")
+}
+
 func TestTenantLogic_expression_index(
 	t *testing.T,
 ) {

--- a/pkg/sql/catalog/colinfo/result_columns.go
+++ b/pkg/sql/catalog/colinfo/result_columns.go
@@ -273,6 +273,16 @@ var ExportColumns = ResultColumns{
 	{Name: "bytes", Typ: types.Int},
 }
 
+// ExportColumnTypes is the type schema of the EXPORT statement.
+var ExportColumnTypes []*types.T
+
+func init() {
+	ExportColumnTypes = make([]*types.T, len(ExportColumns))
+	for i, c := range ExportColumns {
+		ExportColumnTypes[i] = c.Typ
+	}
+}
+
 // TenantColumns appear in all SHOW TENANT queries.
 var TenantColumns = ResultColumns{
 	{Name: "id", Typ: types.Int},

--- a/pkg/sql/distsql_physical_planner.go
+++ b/pkg/sql/distsql_physical_planner.go
@@ -4423,12 +4423,8 @@ func (dsp *DistSQLPlanner) createPlanForExport(
 		UserProto:   planCtx.planner.User().EncodeProto(),
 	}
 
-	resTypes := make([]*types.T, len(colinfo.ExportColumns))
-	for i := range colinfo.ExportColumns {
-		resTypes[i] = colinfo.ExportColumns[i].Typ
-	}
 	plan.AddNoGroupingStage(
-		core, execinfrapb.PostProcessSpec{}, resTypes, execinfrapb.Ordering{},
+		core, execinfrapb.PostProcessSpec{}, colinfo.ExportColumnTypes, execinfrapb.Ordering{},
 	)
 
 	// The CSVWriter produces the same columns as the EXPORT statement.

--- a/pkg/sql/importer/exportcsv.go
+++ b/pkg/sql/importer/exportcsv.go
@@ -135,6 +135,7 @@ func newCSVWriterProcessor(
 	flowCtx *execinfra.FlowCtx,
 	processorID int32,
 	spec execinfrapb.ExportSpec,
+	post *execinfrapb.PostProcessSpec,
 	input execinfra.RowSource,
 ) (execinfra.Processor, error) {
 	c := &csvWriter{
@@ -144,7 +145,7 @@ func newCSVWriterProcessor(
 		input:       input,
 	}
 	semaCtx := tree.MakeSemaContext()
-	if err := c.out.Init(ctx, &execinfrapb.PostProcessSpec{}, c.OutputTypes(), &semaCtx, flowCtx.NewEvalCtx()); err != nil {
+	if err := c.out.Init(ctx, post, colinfo.ExportColumnTypes, &semaCtx, flowCtx.NewEvalCtx()); err != nil {
 		return nil, err
 	}
 	return c, nil
@@ -161,11 +162,7 @@ type csvWriter struct {
 var _ execinfra.Processor = &csvWriter{}
 
 func (sp *csvWriter) OutputTypes() []*types.T {
-	res := make([]*types.T, len(colinfo.ExportColumns))
-	for i := range res {
-		res[i] = colinfo.ExportColumns[i].Typ
-	}
-	return res
+	return sp.out.OutputTypes
 }
 
 func (sp *csvWriter) MustBeStreaming() bool {

--- a/pkg/sql/importer/exportparquet.go
+++ b/pkg/sql/importer/exportparquet.go
@@ -693,6 +693,7 @@ func newParquetWriterProcessor(
 	flowCtx *execinfra.FlowCtx,
 	processorID int32,
 	spec execinfrapb.ExportSpec,
+	post *execinfrapb.PostProcessSpec,
 	input execinfra.RowSource,
 ) (execinfra.Processor, error) {
 	c := &parquetWriterProcessor{
@@ -702,7 +703,7 @@ func newParquetWriterProcessor(
 		input:       input,
 	}
 	semaCtx := tree.MakeSemaContext()
-	if err := c.out.Init(ctx, &execinfrapb.PostProcessSpec{}, c.OutputTypes(), &semaCtx, flowCtx.NewEvalCtx()); err != nil {
+	if err := c.out.Init(ctx, post, colinfo.ExportColumnTypes, &semaCtx, flowCtx.NewEvalCtx()); err != nil {
 		return nil, err
 	}
 	return c, nil
@@ -719,11 +720,7 @@ type parquetWriterProcessor struct {
 var _ execinfra.Processor = &parquetWriterProcessor{}
 
 func (sp *parquetWriterProcessor) OutputTypes() []*types.T {
-	res := make([]*types.T, len(colinfo.ExportColumns))
-	for i := range res {
-		res[i] = colinfo.ExportColumns[i].Typ
-	}
-	return res
+	return sp.out.OutputTypes
 }
 
 // MustBeStreaming currently never gets called by the parquetWriterProcessor as

--- a/pkg/sql/logictest/testdata/logic_test/export
+++ b/pkg/sql/logictest/testdata/logic_test/export
@@ -1,0 +1,10 @@
+# Regression test for incorrectly handling projection on top of the EXPORT
+# (#101733).
+statement ok
+CREATE TABLE t (k PRIMARY KEY) AS SELECT 1;
+
+statement ok
+WITH cte AS (EXPORT INTO CSV 'nodelocal://1/export1/' FROM SELECT * FROM t) SELECT filename FROM cte;
+
+statement ok
+WITH cte AS (EXPORT INTO PARQUET 'nodelocal://1/export1/' FROM SELECT * FROM t) SELECT filename FROM cte;

--- a/pkg/sql/logictest/tests/fakedist-disk/generated_test.go
+++ b/pkg/sql/logictest/tests/fakedist-disk/generated_test.go
@@ -751,6 +751,13 @@ func TestLogic_explain_analyze(
 	runLogicTest(t, "explain_analyze")
 }
 
+func TestLogic_export(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "export")
+}
+
 func TestLogic_expression_index(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/fakedist-vec-off/generated_test.go
+++ b/pkg/sql/logictest/tests/fakedist-vec-off/generated_test.go
@@ -751,6 +751,13 @@ func TestLogic_explain_analyze(
 	runLogicTest(t, "explain_analyze")
 }
 
+func TestLogic_export(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "export")
+}
+
 func TestLogic_expression_index(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/fakedist/generated_test.go
+++ b/pkg/sql/logictest/tests/fakedist/generated_test.go
@@ -751,6 +751,13 @@ func TestLogic_explain_analyze(
 	runLogicTest(t, "explain_analyze")
 }
 
+func TestLogic_export(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "export")
+}
+
 func TestLogic_expression_index(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/local-legacy-schema-changer/generated_test.go
+++ b/pkg/sql/logictest/tests/local-legacy-schema-changer/generated_test.go
@@ -737,6 +737,13 @@ func TestLogic_explain_analyze(
 	runLogicTest(t, "explain_analyze")
 }
 
+func TestLogic_export(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "export")
+}
+
 func TestLogic_expression_index(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/local-mixed-22.2-23.1/generated_test.go
+++ b/pkg/sql/logictest/tests/local-mixed-22.2-23.1/generated_test.go
@@ -737,6 +737,13 @@ func TestLogic_explain_analyze(
 	runLogicTest(t, "explain_analyze")
 }
 
+func TestLogic_export(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "export")
+}
+
 func TestLogic_expression_index(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/local-vec-off/generated_test.go
+++ b/pkg/sql/logictest/tests/local-vec-off/generated_test.go
@@ -758,6 +758,13 @@ func TestLogic_explain_analyze(
 	runLogicTest(t, "explain_analyze")
 }
 
+func TestLogic_export(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "export")
+}
+
 func TestLogic_expression_index(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/local/generated_test.go
+++ b/pkg/sql/logictest/tests/local/generated_test.go
@@ -779,6 +779,13 @@ func TestLogic_explain_analyze(
 	runLogicTest(t, "explain_analyze")
 }
 
+func TestLogic_export(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "export")
+}
+
 func TestLogic_expression_index(
 	t *testing.T,
 ) {

--- a/pkg/sql/rowexec/processors.go
+++ b/pkg/sql/rowexec/processors.go
@@ -303,9 +303,9 @@ func NewProcessor(
 		}
 
 		if core.Exporter.Format.Format == roachpb.IOFileFormat_Parquet {
-			return NewParquetWriterProcessor(ctx, flowCtx, processorID, *core.Exporter, inputs[0])
+			return NewParquetWriterProcessor(ctx, flowCtx, processorID, *core.Exporter, post, inputs[0])
 		}
-		return NewCSVWriterProcessor(ctx, flowCtx, processorID, *core.Exporter, inputs[0])
+		return NewCSVWriterProcessor(ctx, flowCtx, processorID, *core.Exporter, post, inputs[0])
 	}
 
 	if core.BulkRowWriter != nil {
@@ -429,10 +429,10 @@ var NewRestoreDataProcessor func(context.Context, *execinfra.FlowCtx, int32, exe
 var NewStreamIngestionDataProcessor func(context.Context, *execinfra.FlowCtx, int32, execinfrapb.StreamIngestionDataSpec, *execinfrapb.PostProcessSpec) (execinfra.Processor, error)
 
 // NewCSVWriterProcessor is implemented in the non-free (CCL) codebase and then injected here via runtime initialization.
-var NewCSVWriterProcessor func(context.Context, *execinfra.FlowCtx, int32, execinfrapb.ExportSpec, execinfra.RowSource) (execinfra.Processor, error)
+var NewCSVWriterProcessor func(context.Context, *execinfra.FlowCtx, int32, execinfrapb.ExportSpec, *execinfrapb.PostProcessSpec, execinfra.RowSource) (execinfra.Processor, error)
 
 // NewParquetWriterProcessor is implemented in the non-free (CCL) codebase and then injected here via runtime initialization.
-var NewParquetWriterProcessor func(context.Context, *execinfra.FlowCtx, int32, execinfrapb.ExportSpec, execinfra.RowSource) (execinfra.Processor, error)
+var NewParquetWriterProcessor func(context.Context, *execinfra.FlowCtx, int32, execinfrapb.ExportSpec, *execinfrapb.PostProcessSpec, execinfra.RowSource) (execinfra.Processor, error)
 
 // NewChangeAggregatorProcessor is implemented in the non-free (CCL) codebase and then injected here via runtime initialization.
 var NewChangeAggregatorProcessor func(context.Context, *execinfra.FlowCtx, int32, execinfrapb.ChangeAggregatorSpec, *execinfrapb.PostProcessSpec) (execinfra.Processor, error)


### PR DESCRIPTION
Previously, in the EXPORT processors we hard-coded empty `PostProcessSpec`. This was incorrect in case we have a projection or rendering on top of the EXPORT - in such a scenario we would still simply push out rows as they were produced by the EXPORT core (meaning have exactly `ExportColumns` schema with three columns). This could either lead to panics (like index out of bounds) or incorrect results (say we asked for `length(filename)` instead of `filename` column itself). This is now fixed.

Fixes: #101733.

Release note (bug fix): CockroachDB previously incorrectly evaluated EXPORT statements that had projection or rendering on top of the EXPORT (e.g. `WITH cte AS (EXPORT INTO CSV 'nodelocal://1/export1/' FROM SELECT * FROM t) SELECT filename FROM cte;` wouldn't work) - such statements would result in panics or incorrect query results. Note that the exported data wasn't affected, only the presentation of the query result. The bug has been present since 22.1 or earlier.