### PR TITLE
kv: don't preemptively refresh under weak isolation levels

### DIFF
--- a/pkg/kv/kvclient/kvcoord/txn_interceptor_span_refresher.go
+++ b/pkg/kv/kvclient/kvcoord/txn_interceptor_span_refresher.go
@@ -432,6 +432,15 @@ func (sr *txnSpanRefresher) maybeRefreshPreemptivelyLocked(
 		return ba, nil
 	}
 
+	// If the transaction can tolerate write skew, no preemptive refresh is
+	// necessary, even if its write timestamp has been bumped. Transactions run at
+	// weak isolation levels may refresh in response to WriteTooOld errors or
+	// ReadWithinUncertaintyInterval errors returned by requests, but they do not
+	// need to refresh preemptively ahead of an EndTxn request.
+	if ba.Txn.IsoLevel.ToleratesWriteSkew() {
+		return ba, nil
+	}
+
 	// If true, tryRefreshTxnSpans will trivially succeed.
 	refreshFree := ba.CanForwardReadTimestamp
 


### PR DESCRIPTION
Informs #100131.

This commit disables preemptive transaction refreshes under weak isolation levels. These transactions can tolerate write skew, so they can commit even if their write timestamp has been bumped. Transactions run at weak isolation levels may refresh in response to WriteTooOld errors or ReadWithinUncertaintyInterval errors returned by requests, but they do not need to refresh preemptively ahead of an EndTxn request.

Release note: None