### PR TITLE
release-22.1: rowexec: fix projection on top of EXPORT

### DIFF
--- a/pkg/sql/catalog/colinfo/result_columns.go
+++ b/pkg/sql/catalog/colinfo/result_columns.go
@@ -257,3 +257,13 @@ var ExportColumns = ResultColumns{
 	{Name: "rows", Typ: types.Int},
 	{Name: "bytes", Typ: types.Int},
 }
+
+// ExportColumnTypes is the type schema of the EXPORT statement.
+var ExportColumnTypes []*types.T
+
+func init() {
+	ExportColumnTypes = make([]*types.T, len(ExportColumns))
+	for i, c := range ExportColumns {
+		ExportColumnTypes[i] = c.Typ
+	}
+}

--- a/pkg/sql/distsql_physical_planner.go
+++ b/pkg/sql/distsql_physical_planner.go
@@ -3978,12 +3978,8 @@ func (dsp *DistSQLPlanner) createPlanForExport(
 		UserProto:   planCtx.planner.User().EncodeProto(),
 	}
 
-	resTypes := make([]*types.T, len(colinfo.ExportColumns))
-	for i := range colinfo.ExportColumns {
-		resTypes[i] = colinfo.ExportColumns[i].Typ
-	}
 	plan.AddNoGroupingStage(
-		core, execinfrapb.PostProcessSpec{}, resTypes, execinfrapb.Ordering{},
+		core, execinfrapb.PostProcessSpec{}, colinfo.ExportColumnTypes, execinfrapb.Ordering{},
 	)
 
 	// The CSVWriter produces the same columns as the EXPORT statement.

--- a/pkg/sql/importer/exportcsv.go
+++ b/pkg/sql/importer/exportcsv.go
@@ -134,6 +134,7 @@ func newCSVWriterProcessor(
 	flowCtx *execinfra.FlowCtx,
 	processorID int32,
 	spec execinfrapb.ExportSpec,
+	post *execinfrapb.PostProcessSpec,
 	input execinfra.RowSource,
 	output execinfra.RowReceiver,
 ) (execinfra.Processor, error) {
@@ -145,7 +146,7 @@ func newCSVWriterProcessor(
 		output:      output,
 	}
 	semaCtx := tree.MakeSemaContext()
-	if err := c.out.Init(&execinfrapb.PostProcessSpec{}, c.OutputTypes(), &semaCtx, flowCtx.NewEvalCtx()); err != nil {
+	if err := c.out.Init(post, colinfo.ExportColumnTypes, &semaCtx, flowCtx.NewEvalCtx()); err != nil {
 		return nil, err
 	}
 	return c, nil
@@ -163,11 +164,7 @@ type csvWriter struct {
 var _ execinfra.Processor = &csvWriter{}
 
 func (sp *csvWriter) OutputTypes() []*types.T {
-	res := make([]*types.T, len(colinfo.ExportColumns))
-	for i := range res {
-		res[i] = colinfo.ExportColumns[i].Typ
-	}
-	return res
+	return sp.out.OutputTypes
 }
 
 func (sp *csvWriter) MustBeStreaming() bool {

--- a/pkg/sql/importer/exportparquet.go
+++ b/pkg/sql/importer/exportparquet.go
@@ -678,6 +678,7 @@ func newParquetWriterProcessor(
 	flowCtx *execinfra.FlowCtx,
 	processorID int32,
 	spec execinfrapb.ExportSpec,
+	post *execinfrapb.PostProcessSpec,
 	input execinfra.RowSource,
 	output execinfra.RowReceiver,
 ) (execinfra.Processor, error) {
@@ -689,7 +690,7 @@ func newParquetWriterProcessor(
 		output:      output,
 	}
 	semaCtx := tree.MakeSemaContext()
-	if err := c.out.Init(&execinfrapb.PostProcessSpec{}, c.OutputTypes(), &semaCtx, flowCtx.NewEvalCtx()); err != nil {
+	if err := c.out.Init(post, colinfo.ExportColumnTypes, &semaCtx, flowCtx.NewEvalCtx()); err != nil {
 		return nil, err
 	}
 	return c, nil
@@ -707,11 +708,7 @@ type parquetWriterProcessor struct {
 var _ execinfra.Processor = &parquetWriterProcessor{}
 
 func (sp *parquetWriterProcessor) OutputTypes() []*types.T {
-	res := make([]*types.T, len(colinfo.ExportColumns))
-	for i := range res {
-		res[i] = colinfo.ExportColumns[i].Typ
-	}
-	return res
+	return sp.out.OutputTypes
 }
 
 // MustBeStreaming currently never gets called by the parquetWriterProcessor as

--- a/pkg/sql/rowexec/processors.go
+++ b/pkg/sql/rowexec/processors.go
@@ -282,9 +282,9 @@ func NewProcessor(
 		}
 
 		if core.Exporter.Format.Format == roachpb.IOFileFormat_Parquet {
-			return NewParquetWriterProcessor(flowCtx, processorID, *core.Exporter, inputs[0], outputs[0])
+			return NewParquetWriterProcessor(flowCtx, processorID, *core.Exporter, post, inputs[0], outputs[0])
 		}
-		return NewCSVWriterProcessor(flowCtx, processorID, *core.Exporter, inputs[0], outputs[0])
+		return NewCSVWriterProcessor(flowCtx, processorID, *core.Exporter, post, inputs[0], outputs[0])
 	}
 
 	if core.BulkRowWriter != nil {
@@ -392,10 +392,10 @@ var NewRestoreDataProcessor func(*execinfra.FlowCtx, int32, execinfrapb.RestoreD
 var NewStreamIngestionDataProcessor func(*execinfra.FlowCtx, int32, execinfrapb.StreamIngestionDataSpec, *execinfrapb.PostProcessSpec, execinfra.RowReceiver) (execinfra.Processor, error)
 
 // NewCSVWriterProcessor is implemented in the non-free (CCL) codebase and then injected here via runtime initialization.
-var NewCSVWriterProcessor func(*execinfra.FlowCtx, int32, execinfrapb.ExportSpec, execinfra.RowSource, execinfra.RowReceiver) (execinfra.Processor, error)
+var NewCSVWriterProcessor func(*execinfra.FlowCtx, int32, execinfrapb.ExportSpec, *execinfrapb.PostProcessSpec, execinfra.RowSource, execinfra.RowReceiver) (execinfra.Processor, error)
 
 // NewParquetWriterProcessor is implemented in the non-free (CCL) codebase and then injected here via runtime initialization.
-var NewParquetWriterProcessor func(*execinfra.FlowCtx, int32, execinfrapb.ExportSpec, execinfra.RowSource, execinfra.RowReceiver) (execinfra.Processor, error)
+var NewParquetWriterProcessor func(*execinfra.FlowCtx, int32, execinfrapb.ExportSpec, *execinfrapb.PostProcessSpec, execinfra.RowSource, execinfra.RowReceiver) (execinfra.Processor, error)
 
 // NewChangeAggregatorProcessor is implemented in the non-free (CCL) codebase and then injected here via runtime initialization.
 var NewChangeAggregatorProcessor func(*execinfra.FlowCtx, int32, execinfrapb.ChangeAggregatorSpec, *execinfrapb.PostProcessSpec, execinfra.RowReceiver) (execinfra.Processor, error)


### PR DESCRIPTION
Backport 1/1 commits from #101791.

/cc @cockroachdb/release

---

Previously, in the EXPORT processors we hard-coded empty `PostProcessSpec`. This was incorrect in case we have a projection or rendering on top of the EXPORT - in such a scenario we would still simply push out rows as they were produced by the EXPORT core (meaning have exactly `ExportColumns` schema with three columns). This could either lead to panics (like index out of bounds) or incorrect results (say we asked for `length(filename)` instead of `filename` column itself). This is now fixed.

Fixes: #101733.

Release note (bug fix): CockroachDB previously incorrectly evaluated EXPORT statements that had projection or rendering on top of the EXPORT (e.g. `WITH cte AS (EXPORT INTO CSV 'nodelocal://1/export1/' FROM SELECT * FROM t) SELECT filename FROM cte;` wouldn't work) - such statements would result in panics or incorrect query results. Note that the exported data wasn't affected, only the presentation of the query result. The bug has been present since 22.1 or earlier.

Release justification: bug fix.