### PR TITLE
kv: deflake and unskip TestRangeLocalUncertaintyLimitAfterNewLease

### DIFF
--- a/pkg/kv/kvserver/client_merge_test.go
+++ b/pkg/kv/kvserver/client_merge_test.go
@@ -5146,7 +5146,7 @@ func setupClusterWithSubsumedRange(
 		})
 		require.NoError(t, tc.(*testcluster.TestCluster).WaitForFullReplication())
 		testutils.SucceedsSoon(t, func() error {
-			if count := len(replsForRange(ctx, t, tc, newDesc, numNodes)); count != 2 {
+			if count := len(replsForRange(ctx, t, tc, newDesc)); count != 2 {
 				return errors.Newf("expected %d replicas for range %d; found %d", 2, newDesc.RangeID, count)
 			}
 			return nil

--- a/pkg/kv/kvserver/client_relocate_range_test.go
+++ b/pkg/kv/kvserver/client_relocate_range_test.go
@@ -359,7 +359,7 @@ func TestAdminRelocateRangeFailsWithDuplicates(t *testing.T) {
 		ReplicationMode: base.ReplicationManual,
 	}
 
-	tc := testcluster.StartTestCluster(t, numNodes, args)
+	tc := testcluster.StartTestCluster(t, 3, args)
 	defer tc.Stopper().Stop(ctx)
 
 	k := keys.MustAddr(tc.ScratchRange(t))

--- a/pkg/kv/kvserver/client_replica_test.go
+++ b/pkg/kv/kvserver/client_replica_test.go
@@ -2387,7 +2387,7 @@ func getLeaseInfoOrFatal(
 func TestRemoveLeaseholder(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	tc := testcluster.StartTestCluster(t, numNodes,
+	tc := testcluster.StartTestCluster(t, 3,
 		base.TestClusterArgs{
 			ReplicationMode: base.ReplicationManual,
 		})

--- a/pkg/kv/kvserver/client_replica_test.go
+++ b/pkg/kv/kvserver/client_replica_test.go
@@ -1964,8 +1964,6 @@ func TestRangeLocalUncertaintyLimitAfterNewLease(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	skip.WithIssue(t, 100491, "flaky test")
-
 	numServers := 2
 	var manuals []*hlc.HybridManualClock
 	for i := 0; i < numServers; i++ {
@@ -1982,7 +1980,7 @@ func TestRangeLocalUncertaintyLimitAfterNewLease(t *testing.T) {
 		}
 	}
 	ctx := context.Background()
-	tc := testcluster.StartTestCluster(t, numNodes,
+	tc := testcluster.StartTestCluster(t, numServers,
 		base.TestClusterArgs{
 			ReplicationMode:   base.ReplicationManual,
 			ServerArgsPerNode: serverArgs,

--- a/pkg/kv/kvserver/closed_timestamp_test.go
+++ b/pkg/kv/kvserver/closed_timestamp_test.go
@@ -95,7 +95,7 @@ func TestClosedTimestampCanServe(t *testing.T) {
 				tc.Target(2))
 		}
 
-		repls := replsForRange(ctx, t, tc, desc, numNodes)
+		repls := replsForRange(ctx, t, tc, desc)
 		ts := tc.Server(0).Clock().Now()
 		baRead := makeTxnReadBatchForDesc(desc, ts)
 		testutils.SucceedsSoon(t, func() error {
@@ -168,7 +168,7 @@ func TestClosedTimestampCanServeOnVoterIncoming(t *testing.T) {
 	// Sleep for a sufficiently long time so that reqTS can be closed.
 	time.Sleep(3 * testingTargetDuration)
 	baRead := makeTxnReadBatchForDesc(desc, reqTS)
-	repls := replsForRange(ctx, t, tc, desc, numNodes)
+	repls := replsForRange(ctx, t, tc, desc)
 	testutils.SucceedsSoon(t, func() error {
 		return verifyCanReadFromAllRepls(ctx, t, baRead, repls, expectRows(1))
 	})
@@ -189,7 +189,7 @@ func TestClosedTimestampCanServeThroughoutLeaseTransfer(t *testing.T) {
 	ctx := context.Background()
 	tc, db0, desc := setupClusterForClosedTSTesting(ctx, t, testingTargetDuration, aggressiveResolvedTimestampClusterArgs, "cttest", "kv")
 	defer tc.Stopper().Stop(ctx)
-	repls := replsForRange(ctx, t, tc, desc, numNodes)
+	repls := replsForRange(ctx, t, tc, desc)
 
 	if _, err := db0.Exec(`INSERT INTO cttest.kv VALUES(1, $1)`, "foo"); err != nil {
 		t.Fatal(err)
@@ -267,7 +267,7 @@ func TestClosedTimestampCantServeWithConflictingIntent(t *testing.T) {
 	ctx := context.Background()
 	tc, _, desc := setupClusterForClosedTSTesting(ctx, t, testingTargetDuration, aggressiveResolvedTimestampClusterArgs, "cttest", "kv")
 	defer tc.Stopper().Stop(ctx)
-	repls := replsForRange(ctx, t, tc, desc, numNodes)
+	repls := replsForRange(ctx, t, tc, desc)
 	ds := tc.Server(0).DistSenderI().(*kvcoord.DistSender)
 
 	// Write N different intents for the same transaction, where N is the number
@@ -373,7 +373,7 @@ func TestClosedTimestampCanServeAfterSplitAndMerges(t *testing.T) {
 
 	ctx := context.Background()
 	tc, db0, desc := setupClusterForClosedTSTesting(ctx, t, testingTargetDuration, aggressiveResolvedTimestampClusterArgs, "cttest", "kv")
-	repls := replsForRange(ctx, t, tc, desc, numNodes)
+	repls := replsForRange(ctx, t, tc, desc)
 	// Disable the automatic merging.
 	if _, err := db0.Exec("SET CLUSTER SETTING kv.range_merge.queue_enabled = false"); err != nil {
 		t.Fatal(err)
@@ -410,8 +410,8 @@ func TestClosedTimestampCanServeAfterSplitAndMerges(t *testing.T) {
 	}
 
 	// Ensure that we can perform follower reads from all replicas.
-	lRepls := replsForRange(ctx, t, tc, lr, numNodes)
-	rRepls := replsForRange(ctx, t, tc, rr, numNodes)
+	lRepls := replsForRange(ctx, t, tc, lr)
+	rRepls := replsForRange(ctx, t, tc, rr)
 	// Now immediately query both the ranges and there's 1 value per range.
 	// We need to tolerate RangeNotFound as the split range may not have been
 	// created yet.
@@ -426,7 +426,7 @@ func TestClosedTimestampCanServeAfterSplitAndMerges(t *testing.T) {
 	// the merged range.
 	merged, err := tc.Server(0).MergeRanges(lr.StartKey.AsRawKey())
 	require.Nil(t, err)
-	mergedRepls := replsForRange(ctx, t, tc, merged, numNodes)
+	mergedRepls := replsForRange(ctx, t, tc, merged)
 	// The hazard here is that a follower is not yet aware of the merge and will
 	// return an error. We'll accept that because a client wouldn't see that error
 	// from distsender.
@@ -454,7 +454,7 @@ func TestClosedTimestampCantServeBasedOnUncertaintyLimit(t *testing.T) {
 	// drive MaxClosed.
 	tc, db0, desc := setupClusterForClosedTSTesting(ctx, t, testingTargetDuration, aggressiveResolvedTimestampClusterArgs, "cttest", "kv")
 	defer tc.Stopper().Stop(ctx)
-	repls := replsForRange(ctx, t, tc, desc, numNodes)
+	repls := replsForRange(ctx, t, tc, desc)
 
 	if _, err := db0.Exec(`INSERT INTO cttest.kv VALUES(1, $1)`, "foo"); err != nil {
 		t.Fatal(err)
@@ -487,7 +487,7 @@ func TestClosedTimestampCanServeForWritingTransaction(t *testing.T) {
 	ctx := context.Background()
 	tc, db0, desc := setupClusterForClosedTSTesting(ctx, t, testingTargetDuration, aggressiveResolvedTimestampClusterArgs, "cttest", "kv")
 	defer tc.Stopper().Stop(ctx)
-	repls := replsForRange(ctx, t, tc, desc, numNodes)
+	repls := replsForRange(ctx, t, tc, desc)
 
 	if _, err := db0.Exec(`INSERT INTO cttest.kv VALUES(1, $1)`, "foo"); err != nil {
 		t.Fatal(err)
@@ -534,7 +534,7 @@ func TestClosedTimestampCantServeForNonTransactionalReadRequest(t *testing.T) {
 	ctx := context.Background()
 	tc, db0, desc := setupClusterForClosedTSTesting(ctx, t, testingTargetDuration, aggressiveResolvedTimestampClusterArgs, "cttest", "kv")
 	defer tc.Stopper().Stop(ctx)
-	repls := replsForRange(ctx, t, tc, desc, numNodes)
+	repls := replsForRange(ctx, t, tc, desc)
 
 	if _, err := db0.Exec(`INSERT INTO cttest.kv VALUES(1, $1)`, "foo"); err != nil {
 		t.Fatal(err)
@@ -576,7 +576,7 @@ func TestClosedTimestampCantServeForNonTransactionalBatch(t *testing.T) {
 		ctx := context.Background()
 		tc, db0, desc := setupClusterForClosedTSTesting(ctx, t, testingTargetDuration, aggressiveResolvedTimestampClusterArgs, "cttest", "kv")
 		defer tc.Stopper().Stop(ctx)
-		repls := replsForRange(ctx, t, tc, desc, numNodes)
+		repls := replsForRange(ctx, t, tc, desc)
 
 		if _, err := db0.Exec(`INSERT INTO cttest.kv VALUES(1, $1)`, "foo"); err != nil {
 			t.Fatal(err)
@@ -717,6 +717,7 @@ func TestClosedTimestampFrozenAfterSubsumption(t *testing.T) {
 			// Set up the closed timestamp timing such that, when we block a merge and
 			// transfer the RHS lease, the closed timestamp advances over the LHS
 			// lease but not over the RHS lease.
+			const numNodes = 3
 			tc, _ := setupTestClusterWithDummyRange(t, clusterArgs, "cttest" /* dbName */, "kv" /* tableName */, numNodes)
 			defer tc.Stopper().Stop(ctx)
 			sqlDB := sqlutils.MakeSQLRunner(tc.ServerConn(0))
@@ -1041,7 +1042,7 @@ func getFollowerReplicas(
 	rangeDesc roachpb.RangeDescriptor,
 	leaseholder roachpb.ReplicationTarget,
 ) []*kvserver.Replica {
-	repls := replsForRange(ctx, t, tc, rangeDesc, numNodes)
+	repls := replsForRange(ctx, t, tc, rangeDesc)
 	followers := make([]*kvserver.Replica, 0, len(repls)-1)
 	for _, repl := range repls {
 		if repl.StoreID() == leaseholder.StoreID && repl.NodeID() == leaseholder.NodeID {
@@ -1113,21 +1114,15 @@ const testingTargetDuration = 300 * time.Millisecond
 
 const testingSideTransportInterval = 100 * time.Millisecond
 
-// TODO(nvanbenschoten): this is a pretty bad variable name to leak into the
-// global scope of the kvserver_test package. At least one test was using it
-// unintentionally. Remove it.
-const numNodes = 3
-
 func replsForRange(
 	ctx context.Context,
 	t *testing.T,
 	tc serverutils.TestClusterInterface,
 	desc roachpb.RangeDescriptor,
-	numNodes int,
 ) (repls []*kvserver.Replica) {
 	testutils.SucceedsSoon(t, func() error {
 		repls = nil
-		for i := 0; i < numNodes; i++ {
+		for i := 0; i < tc.NumServers(); i++ {
 			repl, _, err := tc.Server(i).GetStores().(*kvserver.Stores).GetReplicaForRangeID(ctx, desc.RangeID)
 			if err != nil {
 				return err
@@ -1199,6 +1194,7 @@ func setupClusterForClosedTSTesting(
 	clusterArgs base.TestClusterArgs,
 	dbName, tableName string,
 ) (tc serverutils.TestClusterInterface, db0 *gosql.DB, kvTableDesc roachpb.RangeDescriptor) {
+	const numNodes = 3
 	tc, desc := setupTestClusterWithDummyRange(t, clusterArgs, dbName, tableName, numNodes)
 	sqlRunner := sqlutils.MakeSQLRunner(tc.ServerConn(0))
 	sqlRunner.ExecMultiple(t, strings.Split(fmt.Sprintf(`

--- a/pkg/kv/kvserver/replica_rangefeed_test.go
+++ b/pkg/kv/kvserver/replica_rangefeed_test.go
@@ -1118,7 +1118,7 @@ func TestReplicaRangefeedPushesTransactions(t *testing.T) {
 	ctx := context.Background()
 	tc, db, desc := setupClusterForClosedTSTesting(ctx, t, testingTargetDuration, aggressiveResolvedTimestampClusterArgs, "cttest", "kv")
 	defer tc.Stopper().Stop(ctx)
-	repls := replsForRange(ctx, t, tc, desc, numNodes)
+	repls := replsForRange(ctx, t, tc, desc)
 
 	sqlDB := sqlutils.MakeSQLRunner(db)
 	sqlDB.Exec(t, `SET CLUSTER SETTING kv.rangefeed.enabled = true`)


### PR DESCRIPTION
Fixes #99527.
Fixes #100491.

This commit deflakes and unskips TestRangeLocalUncertaintyLimitAfterNewLease. The test was flaky because it was pausing the clock for some but not all nodes in the cluster. This was because it was accidentally using a 3-node cluster instead of a 2-node cluster, like it was intending.

Release note: None