### PR TITLE
opt: fixed issue with incorrectly building data sources with an alias

### DIFF
--- a/pkg/sql/opt/optbuilder/select.go
+++ b/pkg/sql/opt/optbuilder/select.go
@@ -82,7 +82,6 @@ func (b *Builder) buildDataSource(
 		}
 
 		if source.As.Alias != "" {
-			inScope = inScope.push()
 			inScope.alias = &source.As
 			locking = locking.filter(source.As.Alias)
 		}

--- a/pkg/sql/opt/optbuilder/testdata/subquery
+++ b/pkg/sql/opt/optbuilder/testdata/subquery
@@ -2276,3 +2276,44 @@ build
 SELECT (1, 1) = ANY (VALUES (1, 2, 3))
 ----
 error (22023): unsupported comparison operator: <tuple{int, int}> = ANY <tuple{tuple{int AS column1, int AS column2, int AS column3}}>
+
+# Regression test for #95470. Ensure that using an alias for a data source does
+# not cause us to falsely conclude a subquery has outer columns.
+exec-ddl
+CREATE TABLE t95470 (a STRING)
+----
+
+exec-ddl
+CREATE VIEW v95470 (a) AS
+SELECT a FROM t95470, ROWS FROM (upper(a)) AS alias1
+----
+
+build
+SELECT count((SELECT a FROM v95470))
+----
+scalar-group-by
+ ├── columns: count:7!null
+ ├── project
+ │    ├── columns: column6:6
+ │    ├── values
+ │    │    └── ()
+ │    └── projections
+ │         └── subquery [as=column6:6]
+ │              └── max1-row
+ │                   ├── columns: a:1
+ │                   └── project
+ │                        ├── columns: a:1
+ │                        └── inner-join-apply
+ │                             ├── columns: a:1 rowid:2!null crdb_internal_mvcc_timestamp:3 tableoid:4 upper:5
+ │                             ├── scan t95470
+ │                             │    └── columns: a:1 rowid:2!null crdb_internal_mvcc_timestamp:3 tableoid:4
+ │                             ├── project-set
+ │                             │    ├── columns: upper:5
+ │                             │    ├── values
+ │                             │    │    └── ()
+ │                             │    └── zip
+ │                             │         └── upper(a:1)
+ │                             └── filters (true)
+ └── aggregations
+      └── count [as=count:7]
+           └── column6:6


### PR DESCRIPTION
This commit fixes an oversight that occurred when building data sources with an alias. We were incorrectly "pushing" a new scope in this case, which could cause us to fail to find columns in the scope. As a result, various issues could occur. For example, if the aliased data source was inside a subquery, we might incorrectly determine that a referenced column was an outer column. Depending on where this subquery was used, the presence of outer columns could cause internal errors or other issues.

Fixes #95470

Release note (bug fix): Fixed a bug introduced in 22.2.0 that could cause queries containing a subquery with a lateral join, in which the right side of the lateral join was an aliased data source, to return an internal error in some cases. For example, it could cause an error if the subquery was provided as an argument to an aggregate function. This bug has now been fixed.