### PR TITLE
rpc: attempt SRV query on every dial

### DIFF
--- a/pkg/rpc/BUILD.bazel
+++ b/pkg/rpc/BUILD.bazel
@@ -50,6 +50,7 @@ go_library(
         "//pkg/util/log/severity",
         "//pkg/util/metric",
         "//pkg/util/netutil",
+        "//pkg/util/randutil",
         "//pkg/util/stop",
         "//pkg/util/syncutil",
         "//pkg/util/timeutil",

--- a/pkg/rpc/context.go
+++ b/pkg/rpc/context.go
@@ -40,6 +40,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/netutil"
+	"github.com/cockroachdb/cockroach/pkg/util/randutil"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
@@ -542,6 +543,10 @@ type ContextOptions struct {
 	// node-to-node connections and prevents one-way partitions from occurring by
 	// turing them into two-way partitions.
 	NeedsDialback bool
+
+	// PreferSRVLookup indicates whether SRV records are preferred over A/AAAA
+	// records when dialing network targets.
+	PreferSRVLookup bool
 }
 
 func (c ContextOptions) validate() error {
@@ -1829,6 +1834,12 @@ func (rpcCtx *Context) dialOptsNetwork(
 	// which is only definitely provided during dial.
 	dialer := onlyOnceDialer{}
 	dialerFunc := dialer.dial
+	if rpcCtx.ContextOptions.PreferSRVLookup {
+		dialer := &srvResolvingDialer{
+			dialerFunc: dialerFunc,
+		}
+		dialerFunc = dialer.dial
+	}
 	if rpcCtx.Knobs.InjectedLatencyOracle != nil {
 		latency := rpcCtx.Knobs.InjectedLatencyOracle.GetLatency(target)
 		log.VEventf(ctx, 1, "connecting with simulated latency %dms",
@@ -2006,6 +2017,25 @@ func (ald *artificialLatencyDialer) dial(ctx context.Context, addr string) (net.
 		enabled: ald.enabled,
 		readBuf: new(bytes.Buffer),
 	}, nil
+}
+
+// srvResolvingDialer first queries SRV records for addr, and dials
+// a random member of the result.
+// If the result is empty, it dials the addr directly.
+type srvResolvingDialer struct {
+	dialerFunc dialerFunc
+}
+
+func (srd *srvResolvingDialer) dial(ctx context.Context, addr string) (net.Conn, error) {
+	addrs, err := netutil.SRV(ctx, addr)
+	if err != nil {
+		return nil, err
+	}
+	if len(addrs) == 0 {
+		// If SRV lookup returns empty, we fallback to addr.
+		addrs = []string{addr}
+	}
+	return srd.dialerFunc(ctx, addrs[int(randutil.FastUint32())%len(addrs)])
 }
 
 type delayingListener struct {

--- a/pkg/server/BUILD.bazel
+++ b/pkg/server/BUILD.bazel
@@ -531,7 +531,6 @@ go_test(
         "//pkg/util/log",
         "//pkg/util/log/logpb",
         "//pkg/util/metric",
-        "//pkg/util/netutil",
         "//pkg/util/netutil/addr",
         "//pkg/util/protoutil",
         "//pkg/util/randident",

--- a/pkg/server/config_test.go
+++ b/pkg/server/config_test.go
@@ -12,7 +12,6 @@ package server
 
 import (
 	"context"
-	"net"
 	"os"
 	"reflect"
 	"testing"
@@ -24,7 +23,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/envutil"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
-	"github.com/cockroachdb/cockroach/pkg/util/netutil"
 	"github.com/cockroachdb/cockroach/pkg/util/netutil/addr"
 	"github.com/kr/pretty"
 	"github.com/stretchr/testify/require"
@@ -240,11 +238,8 @@ func TestParseBootstrapResolvers(t *testing.T) {
 
 	t.Run("srv", func(t *testing.T) {
 		cfg.JoinPreferSRVRecords = true
-		cfg.JoinList = append(base.JoinListType(nil), "othername")
-
-		defer netutil.TestingOverrideSRVLookupFn(func(service, proto, name string) (string, []*net.SRV, error) {
-			return "cluster", []*net.SRV{{Target: expectedName, Port: 111}}, nil
-		})()
+		const srvName = "srv-name"
+		cfg.JoinList = append(base.JoinListType(nil), srvName)
 
 		addresses, err := cfg.parseGossipBootstrapAddresses(context.Background())
 		if err != nil {
@@ -253,18 +248,15 @@ func TestParseBootstrapResolvers(t *testing.T) {
 		if len(addresses) != 1 {
 			t.Fatalf("expected 1 address, got %# v", pretty.Formatter(addresses))
 		}
-		host, port, err := addr.SplitHostPort(addresses[0].String(), "UNKNOWN")
+		host, port, err := addr.SplitHostPort(addresses[0].String(), "defaultPort")
 		if err != nil {
 			t.Fatal(err)
 		}
-		if port == "UNKNOWN" {
-			t.Fatalf("expected port defined in resover: %# v", pretty.Formatter(addresses))
+		if port != "defaultPort" {
+			t.Fatalf("unexpected port defined in resover: %# v", pretty.Formatter(addresses))
 		}
-		if port != "111" {
-			t.Fatalf("expected port 111 from SRV, got %q", port)
-		}
-		if host != expectedName {
-			t.Errorf("expected name %q, got %q", expectedName, host)
+		if host != srvName {
+			t.Errorf("expected host %q, got %q", srvName, host)
 		}
 	})
 }

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -321,6 +321,7 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 		},
 		TenantRPCAuthorizer: authorizer,
 		NeedsDialback:       true,
+		PreferSRVLookup:     cfg.JoinPreferSRVRecords,
 	}
 	if knobs := cfg.TestingKnobs.Server; knobs != nil {
 		serverKnobs := knobs.(*TestingKnobs)


### PR DESCRIPTION
Previously, SRV resolution (when `experimental-dns-srv` is set) is only attempted during bootstrapping.
If SRV records don't exist then,
it defaults to 26287 port.
This can cause the node never to be able to join
the cluster.

This PR makes crdb to query for SRV records
on every dial attempt, when `experimental-dns-srv` is set. If SRV query returns empty, it falls back to dial
the target directly.

Fixes: #102415
Release note: None