### PR TITLE
sql: add sqlsmith support to test partial visibility of indexes

### DIFF
--- a/pkg/internal/sqlsmith/alter.go
+++ b/pkg/internal/sqlsmith/alter.go
@@ -367,7 +367,9 @@ func makeCreateIndex(s *Smither) (tree.Statement, bool) {
 	visibility := 1.0
 	if notvisible := s.d6() == 1; notvisible {
 		visibility = 0.0
-		// TODO(rytaft): sometimes generate a float between (0.0,1.0).
+		if s.coin() {
+			visibility = s.rnd.Float64() // [0.0, 1.0)
+		}
 	}
 
 	return &tree.CreateIndex{

--- a/pkg/sql/randgen/schema.go
+++ b/pkg/sql/randgen/schema.go
@@ -231,7 +231,9 @@ func RandCreateTableWithColumnIndexNumberGeneratorAndName(
 			indexDef.Invisibility = 0.0
 			if notvisible := rng.Intn(6) == 0; notvisible {
 				indexDef.Invisibility = 1.0
-				// TODO(rytaft): sometimes generate a float between (0.0,1.0).
+				if rng.Intn(2) == 0 {
+					indexDef.Invisibility = 1 - rng.Float64()
+				}
 			}
 
 			defs = append(defs, &indexDef)

--- a/pkg/workload/schemachange/operation_generator.go
+++ b/pkg/workload/schemachange/operation_generator.go
@@ -1050,7 +1050,9 @@ func (og *operationGenerator) createIndex(ctx context.Context, tx pgx.Tx) (*opSt
 	visibility := 1.0
 	if notvisible := og.randIntn(20) == 0; notvisible {
 		visibility = 0.0
-		// TODO(rytaft): sometimes generate a float between (0.0,1.0).
+		if og.randIntn(2) == 0 {
+			visibility = og.params.rng.Float64()
+		}
 	}
 
 	def := &tree.CreateIndex{


### PR DESCRIPTION
Sometimes generate a partially invisible index instead of a fully invisible index.

Informs #82363

Release note: None