### PR TITLE
kv: return on quiesce in rangeFeedSlowClosedTimestampNudge task

### DIFF
--- a/pkg/kv/kvserver/replica_rangefeed.go
+++ b/pkg/kv/kvserver/replica_rangefeed.go
@@ -731,6 +731,7 @@ func (r *Replica) handleClosedTimestampUpdateRaftMuLocked(
 				select {
 				case m.RangeFeedSlowClosedTimestampNudgeSem <- struct{}{}:
 				case <-ctx.Done():
+					return nil, ctx.Err()
 				}
 				defer func() { <-m.RangeFeedSlowClosedTimestampNudgeSem }()
 				if err := r.ensureClosedTimestampStarted(ctx); err != nil {


### PR DESCRIPTION
This commit adds a context cancellation return path back to the rangeFeedSlowClosedTimestampNudge task. This was lost in 51295787. Without this return path, the task could deadlock while attempting to return a token to a semaphore that it had not received one from.

Epic: None
Release note: None