### PR TITLE
sql/stats: remove timeout from TestAtMostOneRunningCreateStats

### DIFF
--- a/pkg/sql/stats/create_stats_job_test.go
+++ b/pkg/sql/stats/create_stats_job_test.go
@@ -164,19 +164,10 @@ func TestAtMostOneRunningCreateStats(t *testing.T) {
 	}
 
 	autoStatsRunShouldFail := func() {
-		expectErrCh := make(chan error, 1)
-		go func() {
-			_, err := conn.Exec(`CREATE STATISTICS __auto__ FROM d.t`)
-			expectErrCh <- err
-		}()
-		select {
-		case err := <-expectErrCh:
-			expected := "another CREATE STATISTICS job is already running"
-			if !testutils.IsError(err, expected) {
-				t.Fatalf("expected '%s' error, but got %v", expected, err)
-			}
-		case <-time.After(time.Second):
-			panic("CREATE STATISTICS job which was expected to fail, timed out instead")
+		_, err := conn.Exec(`CREATE STATISTICS __auto__ FROM d.t`)
+		expected := "another CREATE STATISTICS job is already running"
+		if !testutils.IsError(err, expected) {
+			t.Fatalf("expected '%s' error, but got %v", expected, err)
 		}
 	}
 


### PR DESCRIPTION
This patch removes the timeout from `TestAtMostOneRunningCreateStats` when it asserts that stats creation fails when a stats creation job is already running. This is necessary because the timeout can be exceeded in rare cases depending on the environment and test configuration, which caused flakes.

Fixes #101482

Release note: None