### PR TITLE
opt: fix strict UDFs with subquery arguments

### DIFF
--- a/pkg/sql/opt/memo/expr_format.go
+++ b/pkg/sql/opt/memo/expr_format.go
@@ -40,43 +40,15 @@ var ScalarFmtInterceptor func(f *ExprFmtCtx, expr opt.ScalarExpr) string
 // formatted output.
 type ExprFmtFlags int
 
-// ExprFmtFlags takes advantages of bit masking and iota. If you want to add a
-// flag here, you should only add flags to hide things but not to show things.
-// Also, you have to add the flag after ExprFmtHideMiscProps and before
-// ExprFmtHideAll.
-
-// iota is initialized as 0 at the start of const and increments by 1 every time
-// a new const is declared. In addition, expressions are also implicitly repeated.
-// For example,
-// const (                              // const (
-//	First  int = iota // 0              // 	First  int = iota * 3 // 0 * 3
-//	Second            // 1              // 	Second                // 1 * 3
-//	Third             // 2              // )
-//	Fourth            // 3
-// )
-
-// In our example here, 1 means the flag is on and 0 means the flag is off.
-// const (
+// ExprFmtFlags is a bitmask that can contain any of the flags below. The zero
+// value represents showing all possible information when formatting an
+// expression. Flags are used to hide information. For example, to hide
+// constraints and functional dependencies, you can combine the flags
+// ExprFmtHideConstraints and ExprFmtHideFuncDeps:
 //
-//		ExprFmtShowAll int = 0 // iota is 0, but it's not used    0000 0000
-//		ExprFmtHideMiscProps int = 1 << (iota - 1)
-//	                            // iota is 1, 1 << (1 - 1) 0000 0001 = 1
-//		ExprFmtHideConstraints     // iota is 2, 1 << (2 - 1) 0000 0010 = 2
-//		ExprFmtHideFuncDeps        // iota is 3, 1 << (3 - 1) 0000 0100 = 4
-//	 ...
-//	 ExprFmtHideAll             // (1 << iota) - 1
+//	myFlag := ExprFmtHideConstraints|ExprFmtHideFuncDeps
 //
-// )
-// If we want to set ExprFmtHideMiscProps and ExprFmtHideConstraints on, we
-// would have f := ExprFmtHideMiscProps | ExprFmtHideConstraints 0000 0011.
-// ExprFmtShowAll has all 0000 0000. This is because all flags represent when
-// something is hiding. If every bit is 0, that just means everything is
-// showing. ExprFmtHideAll is (1 << iota) - 1. For example, if the last const
-// iota is 4, ExprFmtHideAll would have (1 << 4) - 1 which is 0001 0000 - 1 =
-// 0000 1111 which is just setting all flags on => hiding everything. If we have
-// a flag that show things, ShowAll = 0000..000 would actually turn this flag
-// off. Thus, in order for ExprFmtShowAll and ExprFmtHideAll to be correct, we
-// can only add flags to hide things but not flags to show things.
+// New flags should be added before the ExprFmtHideAll flag.
 const (
 	// ExprFmtShowAll shows all properties of the expression.
 	ExprFmtShowAll ExprFmtFlags = 0

--- a/pkg/sql/opt/memo/expr_format.go
+++ b/pkg/sql/opt/memo/expr_format.go
@@ -948,6 +948,9 @@ func (f *ExprFmtCtx) formatScalarWithLabel(
 ) {
 	formatUDFInputAndBody := func(udf *UDFExpr, tp treeprinter.Node) {
 		var n treeprinter.Node
+		if !udf.CalledOnNullInput {
+			tp.Child("strict")
+		}
 		if len(udf.Params) > 0 {
 			f.formatColList(tp, "params:", udf.Params, opt.ColSet{} /* notNullCols */)
 			n = tp.Child("args")

--- a/pkg/sql/opt/norm/testdata/rules/inline
+++ b/pkg/sql/opt/norm/testdata/rules/inline
@@ -1107,6 +1107,12 @@ $$
 ----
 
 exec-ddl
+CREATE FUNCTION add_strict(x INT, y INT) RETURNS INT STRICT IMMUTABLE LANGUAGE SQL AS $$
+  SELECT x + y
+$$
+----
+
+exec-ddl
 CREATE FUNCTION rec(r RECORD) RETURNS RECORD IMMUTABLE LANGUAGE SQL AS $$
   SELECT r
 $$
@@ -1177,6 +1183,23 @@ project
  │    └── columns: i:2
  └── projections
       └── (1, i:2, $1) [as=rec:10, outer=(2)]
+
+# A strict UDF is not inlined.
+norm expect-not=InlineUDF
+SELECT add_strict(1, i) FROM (VALUES (1), (2), (3)) v(i)
+----
+project
+ ├── columns: add_strict:5
+ ├── cardinality: [3 - 3]
+ ├── immutable
+ ├── values
+ │    ├── columns: column1:1!null
+ │    ├── cardinality: [3 - 3]
+ │    ├── (1,)
+ │    ├── (2,)
+ │    └── (3,)
+ └── projections
+      └── add_strict(1, column1:1) [as=add_strict:5, outer=(1), immutable, udf]
 
 # A UDF is not inlined when the arguments are not constants or either Variable or Const
 # expressions.

--- a/pkg/sql/opt/norm/testdata/rules/inline
+++ b/pkg/sql/opt/norm/testdata/rules/inline
@@ -1113,6 +1113,12 @@ $$
 ----
 
 exec-ddl
+CREATE FUNCTION one_strict() RETURNS INT STRICT IMMUTABLE LANGUAGE SQL AS $$
+  SELECT 1
+$$
+----
+
+exec-ddl
 CREATE FUNCTION rec(r RECORD) RETURNS RECORD IMMUTABLE LANGUAGE SQL AS $$
   SELECT r
 $$
@@ -1151,7 +1157,7 @@ project
       └── filters
            └── i:2 = 9 [outer=(2), constraints=(/2: [/9 - /9]; tight), fd=()-->(2)]
 
-# A UDF with a placehold argument should be inlined.
+# A UDF with a placeholder argument should be inlined.
 norm expect=InlineUDF
 SELECT add(1, $1)
 ----
@@ -1184,8 +1190,8 @@ project
  └── projections
       └── (1, i:2, $1) [as=rec:10, outer=(2)]
 
-# A strict UDF is not inlined.
-norm expect-not=InlineUDF
+# A strict UDF is inlined and wrapped in a CASE expression.
+norm expect=InlineUDF
 SELECT add_strict(1, i) FROM (VALUES (1), (2), (3)) v(i)
 ----
 project
@@ -1199,10 +1205,70 @@ project
  │    ├── (2,)
  │    └── (3,)
  └── projections
-      └── add_strict(1, column1:1) [as=add_strict:5, outer=(1), immutable, udf]
+      └── case [as=add_strict:5, outer=(1), immutable, correlated-subquery]
+           ├── true
+           ├── when
+           │    ├── column1:1 IS NULL
+           │    └── CAST(NULL AS INT8)
+           └── subquery
+                └── values
+                     ├── columns: "?column?":4
+                     ├── outer: (1)
+                     ├── cardinality: [1 - 1]
+                     ├── immutable
+                     ├── key: ()
+                     ├── fd: ()-->(4)
+                     └── (column1:1 + 1,)
 
-# A UDF is not inlined when the arguments are not constants or either Variable or Const
-# expressions.
+# A strict non-set-returning UDF used as a datasource is inlined.
+norm expect=InlineUDF
+SELECT * FROM add_strict(1, $1)
+----
+project-set
+ ├── columns: add_strict:4
+ ├── immutable, has-placeholder
+ ├── values
+ │    ├── cardinality: [1 - 1]
+ │    ├── key: ()
+ │    └── ()
+ └── zip
+      └── case [immutable, subquery]
+           ├── true
+           ├── when
+           │    ├── $1 IS NULL
+           │    └── CAST(NULL AS INT8)
+           └── subquery
+                └── values
+                     ├── columns: "?column?":3
+                     ├── cardinality: [1 - 1]
+                     ├── immutable, has-placeholder
+                     ├── key: ()
+                     ├── fd: ()-->(3)
+                     └── ($1 + 1,)
+
+# A strict UDF with zero arguments is inlined without a CASE expression.
+norm expect=InlineUDF
+SELECT one_strict() FROM (VALUES (1), (2), (3)) v(i)
+----
+project
+ ├── columns: one_strict:3
+ ├── cardinality: [3 - 3]
+ ├── values
+ │    ├── cardinality: [3 - 3]
+ │    ├── ()
+ │    ├── ()
+ │    └── ()
+ └── projections
+      └── subquery [as=one_strict:3, subquery]
+           └── values
+                ├── columns: "?column?":2!null
+                ├── cardinality: [1 - 1]
+                ├── key: ()
+                ├── fd: ()-->(2)
+                └── (1,)
+
+# A UDF is not inlined when the arguments are not constants or either Variable
+# or Const expressions.
 norm expect-not=InlineUDF
 SELECT add(1, i+10) FROM (VALUES (1), (2), (3)) v(i)
 ----

--- a/pkg/sql/opt/norm/testdata/rules/udf
+++ b/pkg/sql/opt/norm/testdata/rules/udf
@@ -53,6 +53,7 @@ values
  ├── fd: ()-->(5)
  └── tuple
       └── udf: strict_fn
+           ├── strict
            ├── params: i:1 t:2 b:3
            ├── args
            │    ├── const: 1

--- a/pkg/sql/opt/optbuilder/testdata/udf
+++ b/pkg/sql/opt/optbuilder/testdata/udf
@@ -1048,6 +1048,7 @@ project
  │    └── tuple
  └── projections
       └── udf: strict_fn [as=strict_fn:5]
+           ├── strict
            ├── params: i:1 t:2 b:3
            ├── args
            │    ├── const: 1
@@ -1076,6 +1077,7 @@ project
  │    └── filters
  │         └── eq
  │              ├── udf: strict_fn
+ │              │    ├── strict
  │              │    ├── params: i:6 t:7 b:8
  │              │    ├── args
  │              │    │    ├── plus
@@ -1099,6 +1101,7 @@ project
  │              └── const: 10
  └── projections
       └── udf: strict_fn [as=strict_fn:14]
+           ├── strict
            ├── params: i:10 t:11 b:12
            ├── args
            │    ├── variable: a:1
@@ -1137,6 +1140,7 @@ project
  │    └── columns: t1.i:1
  └── projections
       └── udf: f101516 [as=f101516:16]
+           ├── strict
            ├── params: x:14
            ├── args
            │    └── subquery

--- a/pkg/sql/opt/optbuilder/testdata/udf
+++ b/pkg/sql/opt/optbuilder/testdata/udf
@@ -1047,37 +1047,22 @@ project
  ├── values
  │    └── tuple
  └── projections
-      └── case [as=strict_fn:5]
-           ├── true
-           ├── when
-           │    ├── or
-           │    │    ├── is
-           │    │    │    ├── false
-           │    │    │    └── null
-           │    │    └── or
-           │    │         ├── is
-           │    │         │    ├── const: 'foo'
-           │    │         │    └── null
-           │    │         └── is
-           │    │              ├── const: 1
-           │    │              └── null
-           │    └── null
-           └── udf: strict_fn
-                ├── params: i:1 t:2 b:3
-                ├── args
-                │    ├── const: 1
-                │    ├── const: 'foo'
-                │    └── false
-                └── body
-                     └── limit
-                          ├── columns: i:4
-                          ├── project
-                          │    ├── columns: i:4
-                          │    ├── values
-                          │    │    └── tuple
-                          │    └── projections
-                          │         └── variable: i:1 [as=i:4]
-                          └── const: 1
+      └── udf: strict_fn [as=strict_fn:5]
+           ├── params: i:1 t:2 b:3
+           ├── args
+           │    ├── const: 1
+           │    ├── const: 'foo'
+           │    └── false
+           └── body
+                └── limit
+                     ├── columns: i:4
+                     ├── project
+                     │    ├── columns: i:4
+                     │    ├── values
+                     │    │    └── tuple
+                     │    └── projections
+                     │         └── variable: i:1 [as=i:4]
+                     └── const: 1
 
 build format=show-scalars
 SELECT strict_fn(a, b::TEXT, false) FROM abc WHERE strict_fn(a+1+2, b::TEXT, false) = 10
@@ -1090,81 +1075,91 @@ project
  │    │    └── columns: a:1!null abc.b:2 c:3 crdb_internal_mvcc_timestamp:4 tableoid:5
  │    └── filters
  │         └── eq
- │              ├── case
- │              │    ├── true
- │              │    ├── when
- │              │    │    ├── or
- │              │    │    │    ├── is
- │              │    │    │    │    ├── false
- │              │    │    │    │    └── null
- │              │    │    │    └── or
- │              │    │    │         ├── is
- │              │    │    │         │    ├── cast: STRING
- │              │    │    │         │    │    └── variable: abc.b:2
- │              │    │    │         │    └── null
- │              │    │    │         └── is
- │              │    │    │              ├── plus
- │              │    │    │              │    ├── plus
- │              │    │    │              │    │    ├── variable: a:1
- │              │    │    │              │    │    └── const: 1
- │              │    │    │              │    └── const: 2
- │              │    │    │              └── null
- │              │    │    └── null
- │              │    └── udf: strict_fn
- │              │         ├── params: i:6 t:7 b:8
- │              │         ├── args
- │              │         │    ├── plus
- │              │         │    │    ├── plus
- │              │         │    │    │    ├── variable: a:1
- │              │         │    │    │    └── const: 1
- │              │         │    │    └── const: 2
- │              │         │    ├── cast: STRING
- │              │         │    │    └── variable: abc.b:2
- │              │         │    └── false
- │              │         └── body
- │              │              └── limit
- │              │                   ├── columns: i:9
- │              │                   ├── project
- │              │                   │    ├── columns: i:9
- │              │                   │    ├── values
- │              │                   │    │    └── tuple
- │              │                   │    └── projections
- │              │                   │         └── variable: i:6 [as=i:9]
- │              │                   └── const: 1
+ │              ├── udf: strict_fn
+ │              │    ├── params: i:6 t:7 b:8
+ │              │    ├── args
+ │              │    │    ├── plus
+ │              │    │    │    ├── plus
+ │              │    │    │    │    ├── variable: a:1
+ │              │    │    │    │    └── const: 1
+ │              │    │    │    └── const: 2
+ │              │    │    ├── cast: STRING
+ │              │    │    │    └── variable: abc.b:2
+ │              │    │    └── false
+ │              │    └── body
+ │              │         └── limit
+ │              │              ├── columns: i:9
+ │              │              ├── project
+ │              │              │    ├── columns: i:9
+ │              │              │    ├── values
+ │              │              │    │    └── tuple
+ │              │              │    └── projections
+ │              │              │         └── variable: i:6 [as=i:9]
+ │              │              └── const: 1
  │              └── const: 10
  └── projections
-      └── case [as=strict_fn:14]
-           ├── true
-           ├── when
-           │    ├── or
-           │    │    ├── is
-           │    │    │    ├── false
-           │    │    │    └── null
-           │    │    └── or
-           │    │         ├── is
-           │    │         │    ├── cast: STRING
-           │    │         │    │    └── variable: abc.b:2
-           │    │         │    └── null
-           │    │         └── is
-           │    │              ├── variable: a:1
-           │    │              └── null
-           │    └── null
-           └── udf: strict_fn
-                ├── params: i:10 t:11 b:12
-                ├── args
-                │    ├── variable: a:1
-                │    ├── cast: STRING
-                │    │    └── variable: abc.b:2
-                │    └── false
-                └── body
-                     └── limit
-                          ├── columns: i:13
-                          ├── project
-                          │    ├── columns: i:13
-                          │    ├── values
-                          │    │    └── tuple
-                          │    └── projections
-                          │         └── variable: i:10 [as=i:13]
+      └── udf: strict_fn [as=strict_fn:14]
+           ├── params: i:10 t:11 b:12
+           ├── args
+           │    ├── variable: a:1
+           │    ├── cast: STRING
+           │    │    └── variable: abc.b:2
+           │    └── false
+           └── body
+                └── limit
+                     ├── columns: i:13
+                     ├── project
+                     │    ├── columns: i:13
+                     │    ├── values
+                     │    │    └── tuple
+                     │    └── projections
+                     │         └── variable: i:10 [as=i:13]
+                     └── const: 1
+
+exec-ddl
+CREATE TABLE t101516 (i INT)
+----
+
+exec-ddl
+CREATE FUNCTION f101516(x INT) RETURNS INT STRICT LANGUAGE SQL AS 'SELECT 1'
+----
+
+# Regression test for #101516. Subquery arguments should not be duplicated in a
+# CASE expression for STRICT UDFs. This can cause intersecting columns in the
+# left and right children of a join after hoisting the subquery. We use the norm
+# directive here so that the subqueries are hoisted.
+norm format=show-scalars
+SELECT f101516((SELECT t1.i FROM t101516 t2 JOIN t101516 t3 ON t2.i = t3.i)) FROM t101516 t1
+----
+project
+ ├── columns: f101516:16
+ ├── scan t101516 [as=t1]
+ │    └── columns: t1.i:1
+ └── projections
+      └── udf: f101516 [as=f101516:16]
+           ├── params: x:14
+           ├── args
+           │    └── subquery
+           │         └── max1-row
+           │              ├── columns: i:13
+           │              └── project
+           │                   ├── columns: i:13
+           │                   ├── inner-join (hash)
+           │                   │    ├── columns: t2.i:5!null t3.i:9!null
+           │                   │    ├── scan t101516 [as=t2]
+           │                   │    │    └── columns: t2.i:5
+           │                   │    ├── scan t101516 [as=t3]
+           │                   │    │    └── columns: t3.i:9
+           │                   │    └── filters
+           │                   │         └── eq
+           │                   │              ├── variable: t2.i:5
+           │                   │              └── variable: t3.i:9
+           │                   └── projections
+           │                        └── variable: t1.i:1 [as=i:13]
+           └── body
+                └── values
+                     ├── columns: "?column?":15!null
+                     └── tuple
                           └── const: 1
 
 

--- a/pkg/sql/routine.go
+++ b/pkg/sql/routine.go
@@ -28,6 +28,16 @@ import (
 func (p *planner) EvalRoutineExpr(
 	ctx context.Context, expr *tree.RoutineExpr, args tree.Datums,
 ) (result tree.Datum, err error) {
+	// Strict routines (CalledOnNullInput=false) should not be invoked and they
+	// should immediately return NULL if any of their arguments are NULL.
+	if !expr.CalledOnNullInput {
+		for i := range args {
+			if args[i] == tree.DNull {
+				return tree.DNull, nil
+			}
+		}
+	}
+
 	// Return the cached result if it exists.
 	if expr.CachedResult != nil {
 		return expr.CachedResult, nil


### PR DESCRIPTION
#### opt: fix strict UDFs with subquery arguments

Previously, we wrapped all strict UDFs with a `CASE` expression to
prevent the UDF from being invoked when any of the arguments were
`NULL`. This was required in order to inline strict UDFs (see #94797).

Unfortunately, wrapping the arguments in a `CASE` expression caused
problems when the arguments were subqueries. The subqueries would be
duplicated in the optimizer expression, one copy used in the `CASE`
expression and another as an argument to the UDF`, with each copy
containing the same table and column IDs. Normalization rules could then
transform these subqueries into apply-joins that would have intersecting
columns in their left and right children. This caused optimizer
assertion failures in debug builds and could cause incorrect results in
release builds.

This commit implements a temporary fix which removes the synthesized
`CASE` expression entirely. The logic for returning `NULL` immediately
when a strict UDF is invoked with a `NULL` argument has been added back
into `planner.EvalRoutineExpr`, and strict UDFs are not longer inlined.

We should be able to inline strict UDFs by adding the `CASE` expression
during the `InlineUDF` normalization rule, as long as the arguments are
not complex expressions (e.g., only variables, constants, or
placeholders). This is left for a future commit.

Fixes #101516

Release note (bug fix): A bug has been fixed that could cause incorrect
results for queries invoking `STRICT` user-defined functions. This bug
was only present in pre-release versions of 23.1.

#### opt: add strict field to UDF expression format

Release note: None

#### opt: simplify description of ExprFmtFlags

The description of ExprFmtFlags has been simplified. It previously
contained a very detailed description of bitmasks and iota, which
probably isn't warranted because it is such a common pattern in the
codebase.

#### opt: inline strict UDFs

This commit inlines strict UDFs by wrapping the generated subquery
expression with a `CASE` expression. The `CASE` expression results in
`NULL` if any of the arguments of the UDF are `NULL`.

Note that even though the subquery is wrapped in a `CASE` expression, it
may still be evaluated due to the fact that non-correlated subqueries
are eagerly evaluated, see #20298. This should be fine because these
inlined UDFs shouldn't have side-effects - we don't inline volatile
UDFs.

Release note: None
