### PR TITLE
opt: do not add derived FK equalities to lookup join ON filters

### DIFF
--- a/pkg/sql/opt/xform/testdata/rules/join
+++ b/pkg/sql/opt/xform/testdata/rules/join
@@ -4618,6 +4618,54 @@ inner-join (lookup t63735)
  └── filters
       └── y:7 = 15 [outer=(7), constraints=(/7: [/15 - /15]; tight), fd=()-->(7)]
 
+# Regression test for #101844. Derived FK equalities should not be added to the
+# ON filters of a lookup join.
+exec-ddl
+CREATE TABLE p101844 (
+  r INT,
+  id INT,
+  PRIMARY KEY (r, id),
+  UNIQUE WITHOUT INDEX (id)
+)
+----
+
+exec-ddl
+CREATE TABLE c101844 (
+  r INT,
+  p_id INT,
+  id INT,
+  PRIMARY KEY (r, p_id, id),
+  UNIQUE INDEX c_p_id_id_key (p_id, id),
+  FOREIGN KEY (r, p_id) REFERENCES p101844 (r, id)
+)
+----
+
+# The derived c.r = p.r filters should not be added to the lookup join ON
+# condition if they aren't used as equality columns.
+opt
+SELECT *
+FROM p101844 p LEFT LOOKUP JOIN c101844@c_p_id_id_key c
+ON c.p_id = p.id AND c.id = 1234
+----
+left-join (lookup c101844@c_p_id_id_key [as=c])
+ ├── columns: r:1!null id:2!null r:5 p_id:6 id:7
+ ├── flags: force lookup join (into right side)
+ ├── key columns: [2 10] = [6 7]
+ ├── lookup columns are key
+ ├── key: (2)
+ ├── fd: (2)-->(1,5-7), (6)-->(5)
+ ├── project
+ │    ├── columns: "lookup_join_const_col_@7":10!null p.r:1!null p.id:2!null
+ │    ├── key: (2)
+ │    ├── fd: ()-->(10), (2)-->(1)
+ │    ├── scan p101844 [as=p]
+ │    │    ├── columns: p.r:1!null p.id:2!null
+ │    │    ├── key: (2)
+ │    │    └── fd: (2)-->(1)
+ │    └── projections
+ │         └── 1234 [as="lookup_join_const_col_@7":10]
+ └── filters (true)
+
 
 # --------------------------------------------------
 # GenerateLookupJoinsWithVirtualCols

--- a/pkg/sql/opt/xform/testdata/rules/limit
+++ b/pkg/sql/opt/xform/testdata/rules/limit
@@ -2796,9 +2796,7 @@ project
  │    │    │    │              └── fd: ()-->(1,2), (5)-->(3,4,9)
  │    │    │    └── filters
  │    │    │         ├── t2.col2:20 = 1 [outer=(20), constraints=(/20: [/1 - /1]; tight), fd=()-->(20)]
- │    │    │         ├── t2.col1:19 = 1 [outer=(19), constraints=(/19: [/1 - /1]; tight), fd=()-->(19)]
- │    │    │         ├── t2.col3:21 = t1.col3:3 [outer=(3,21), constraints=(/3: (/NULL - ]; /21: (/NULL - ]), fd=(3)==(21), (21)==(3)]
- │    │    │         └── t2.col4:22 = t1.col4:4 [outer=(4,22), constraints=(/4: (/NULL - ]; /22: (/NULL - ]), fd=(4)==(22), (22)==(4)]
+ │    │    │         └── t2.col1:19 = 1 [outer=(19), constraints=(/19: [/1 - /1]; tight), fd=()-->(19)]
  │    │    └── aggregations
  │    │         ├── array-agg [as=array_agg:27, outer=(24)]
  │    │         │    └── t2.col6:24
@@ -2953,9 +2951,7 @@ limit
  │    │    │         └── fd: ()-->(1,2), (5)-->(3,4,9)
  │    │    └── filters
  │    │         ├── t2.col2:20 = 1 [outer=(20), constraints=(/20: [/1 - /1]; tight), fd=()-->(20)]
- │    │         ├── t2.col1:19 = 1 [outer=(19), constraints=(/19: [/1 - /1]; tight), fd=()-->(19)]
- │    │         ├── t2.col3:21 = t1.col3:3 [outer=(3,21), constraints=(/3: (/NULL - ]; /21: (/NULL - ]), fd=(3)==(21), (21)==(3)]
- │    │         └── t2.col4:22 = t1.col4:4 [outer=(4,22), constraints=(/4: (/NULL - ]; /22: (/NULL - ]), fd=(4)==(22), (22)==(4)]
+ │    │         └── t2.col1:19 = 1 [outer=(19), constraints=(/19: [/1 - /1]; tight), fd=()-->(19)]
  │    └── aggregations
  │         └── first-agg [as=t2.col2:20, outer=(20)]
  │              └── t2.col2:20


### PR DESCRIPTION
This commit fixes a minor bug introduced in #90599 which can
unnecessarily add derived FK equality filters to a lookup join's ON
condition. The bug is minor because it does not cause incorrect results.
It only adds a bit of extra work to evaluate the equality. This commit
ensures that the derived FK filters are only used as equality columns in
the lookup join.

Fixes #101844

Release note: None
