### PR TITLE
release-22.2: ttl: allow outbound foreign keys on TTL tables

### DIFF
--- a/pkg/sql/catalog/tabledesc/validate.go
+++ b/pkg/sql/catalog/tabledesc/validate.go
@@ -196,23 +196,14 @@ func (desc *wrapper) ValidateForwardReferences(
 		}
 	}
 
-	// Row-level TTL is not compatible with foreign keys.
+	// Row-level TTL is not compatible with inbound foreign keys.
 	// This check should be in ValidateSelf but interferes with AllocateIDs.
-	if desc.HasRowLevelTTL() {
-		if len(desc.OutboundFKs) > 0 {
-			vea.Report(unimplemented.NewWithIssuef(
-				76407,
-				`foreign keys from table with TTL %q are not permitted`,
-				desc.GetName(),
-			))
-		}
-		if len(desc.InboundFKs) > 0 {
-			vea.Report(unimplemented.NewWithIssuef(
-				76407,
-				`foreign keys to table with TTL %q are not permitted`,
-				desc.GetName(),
-			))
-		}
+	if desc.HasRowLevelTTL() && len(desc.InboundFKs) > 0 {
+		vea.Report(unimplemented.NewWithIssuef(
+			76407,
+			`foreign keys to table with TTL %q are not permitted`,
+			desc.GetName(),
+		))
 	}
 
 	// Check foreign keys.

--- a/pkg/sql/logictest/testdata/logic_test/row_level_ttl
+++ b/pkg/sql/logictest/testdata/logic_test/row_level_ttl
@@ -1,49 +1,49 @@
 subtest ttl_expire_after_must_be_interval
 
 statement error value of "ttl_expire_after" must be an interval
-CREATE TABLE tbl (id INT PRIMARY KEY, text TEXT) WITH (ttl_expire_after = ' xx invalid interval xx')
+CREATE TABLE tbl (id INT PRIMARY KEY) WITH (ttl_expire_after = ' xx invalid interval xx')
 
 subtest end
 
 subtest ttl_expire_after_must_be_at_least_zero
 
 statement error value of "ttl_expire_after" must be at least zero
-CREATE TABLE tbl (id INT PRIMARY KEY, text TEXT) WITH (ttl_expire_after = '-10 minutes')
+CREATE TABLE tbl (id INT PRIMARY KEY) WITH (ttl_expire_after = '-10 minutes')
 
 subtest end
 
 subtest ttl_expiration_expression_must_be_string
 
 statement error parameter "ttl_expiration_expression" requires a string value
-CREATE TABLE tbl (id INT PRIMARY KEY, text TEXT) WITH (ttl_expiration_expression = 0)
+CREATE TABLE tbl (id INT PRIMARY KEY) WITH (ttl_expiration_expression = 0)
 
 subtest end
 
 subtest ttl_expiration_expression_must_be_valid_expression
 
 statement error ttl_expiration_expression "; DROP DATABASE defaultdb" must be a valid expression: at or near "EOF": syntax error
-CREATE TABLE tbl (id INT PRIMARY KEY, text TEXT) WITH (ttl_expiration_expression = '; DROP DATABASE defaultdb')
+CREATE TABLE tbl (id INT PRIMARY KEY) WITH (ttl_expiration_expression = '; DROP DATABASE defaultdb')
 
 subtest end
 
 subtest ttl_expiration_expression_must_be_timestamptz
 
-statement error expected ttl_expiration_expression expression to have type timestamptz, but 'text' has type string
-CREATE TABLE tbl (id INT PRIMARY KEY, text TEXT) WITH (ttl_expiration_expression = 'text')
+statement error expected ttl_expiration_expression expression to have type timestamptz, but 'id' has type int
+CREATE TABLE tbl (id INT PRIMARY KEY) WITH (ttl_expiration_expression = 'id')
 
 subtest end
 
 subtest ttl_expire_after_or_ttl_expiration_expression_must_be_set
 
 statement error "ttl_expire_after" and/or "ttl_expiration_expression" must be set
-CREATE TABLE tbl (id INT PRIMARY KEY, text TEXT) WITH (ttl = 'on')
+CREATE TABLE tbl (id INT PRIMARY KEY) WITH (ttl = 'on')
 
 subtest end
 
 subtest ttl_automatic_column_notice
 
 query T noticetrace
-CREATE TABLE tbl_ttl_automatic_column (id INT PRIMARY KEY, text TEXT) WITH (ttl_automatic_column = 'on')
+CREATE TABLE tbl_ttl_automatic_column (id INT PRIMARY KEY) WITH (ttl_automatic_column = 'on')
 ----
 NOTICE: ttl_automatic_column is no longer used. Setting ttl_expire_after automatically creates a TTL column. Resetting ttl_expire_after removes the automatically created column.
 
@@ -57,7 +57,7 @@ subtest end
 subtest ttl_range_concurrency_notice
 
 query T noticetrace
-CREATE TABLE tbl_ttl_range_concurrency (id INT PRIMARY KEY, text TEXT) WITH (ttl_range_concurrency = 2)
+CREATE TABLE tbl_ttl_range_concurrency (id INT PRIMARY KEY) WITH (ttl_range_concurrency = 2)
 ----
 NOTICE: ttl_range_concurrency is no longer configurable.
 
@@ -73,9 +73,7 @@ subtest create_table_crdb_internal_expiration_incorrect_explicit_default
 statement error expected DEFAULT expression of crdb_internal_expiration to be current_timestamp\(\):::TIMESTAMPTZ \+ '00:10:00':::INTERVAL
 CREATE TABLE tbl (
   id INT PRIMARY KEY,
-  text TEXT,
-  crdb_internal_expiration TIMESTAMPTZ,
-  FAMILY (id, text)
+  crdb_internal_expiration TIMESTAMPTZ
 ) WITH (ttl_expire_after = '10 minutes')
 
 subtest end
@@ -85,9 +83,7 @@ subtest create_table_crdb_internal_expiration_incorrect_explicit_on_update
 statement error expected ON UPDATE expression of crdb_internal_expiration to be current_timestamp\(\):::TIMESTAMPTZ \+ '00:10:00':::INTERVAL
 CREATE TABLE tbl (
   id INT PRIMARY KEY,
-  text TEXT,
-  crdb_internal_expiration TIMESTAMPTZ DEFAULT current_timestamp() + '10 minutes'::interval,
-  FAMILY (id, text)
+  crdb_internal_expiration TIMESTAMPTZ DEFAULT current_timestamp() + '10 minutes'::interval
 ) WITH (ttl_expire_after = '10 minutes')
 
 subtest end
@@ -96,9 +92,7 @@ subtest crdb_internal_functions
 
 statement ok
 CREATE TABLE crdb_internal_functions_tbl (
-  id INT PRIMARY KEY,
-  text TEXT,
-  FAMILY (id, text)
+  id INT PRIMARY KEY
 ) WITH (ttl_expire_after = '10 minutes')
 
 query T
@@ -106,10 +100,8 @@ SELECT create_statement FROM [SHOW CREATE TABLE crdb_internal_functions_tbl]
 ----
 CREATE TABLE public.crdb_internal_functions_tbl (
   id INT8 NOT NULL,
-  text STRING NULL,
   crdb_internal_expiration TIMESTAMPTZ NOT VISIBLE NOT NULL DEFAULT current_timestamp():::TIMESTAMPTZ + '00:10:00':::INTERVAL ON UPDATE current_timestamp():::TIMESTAMPTZ + '00:10:00':::INTERVAL,
-  CONSTRAINT crdb_internal_functions_tbl_pkey PRIMARY KEY (id ASC),
-  FAMILY fam_0_id_text_crdb_internal_expiration (id, text, crdb_internal_expiration)
+  CONSTRAINT crdb_internal_functions_tbl_pkey PRIMARY KEY (id ASC)
 ) WITH (ttl = 'on', ttl_expire_after = '00:10:00':::INTERVAL, ttl_job_cron = '@hourly')
 
 statement ok
@@ -210,9 +202,7 @@ subtest todo_add_subtests
 
 statement ok
 CREATE TABLE tbl (
-  id INT PRIMARY KEY,
-  text TEXT,
-  FAMILY (id, text)
+  id INT PRIMARY KEY
 ) WITH (ttl_expire_after = '10 minutes')
 
 query T
@@ -243,10 +233,8 @@ SELECT create_statement FROM [SHOW CREATE TABLE tbl]
 ----
 CREATE TABLE public.tbl (
   id INT8 NOT NULL,
-  text STRING NULL,
   crdb_internal_expiration TIMESTAMPTZ NOT VISIBLE NOT NULL DEFAULT current_timestamp():::TIMESTAMPTZ + '10 days':::INTERVAL ON UPDATE current_timestamp():::TIMESTAMPTZ + '10 days':::INTERVAL,
-  CONSTRAINT tbl_pkey PRIMARY KEY (id ASC),
-  FAMILY fam_0_id_text_crdb_internal_expiration (id, text, crdb_internal_expiration)
+  CONSTRAINT tbl_pkey PRIMARY KEY (id ASC)
 ) WITH (ttl = 'on', ttl_expire_after = '10 days':::INTERVAL, ttl_job_cron = '@hourly')
 
 statement error cannot modify TTL settings while another schema change on the table is being processed
@@ -263,7 +251,7 @@ ROLLBACK
 statement error cannot perform other schema changes in the same transaction as a TTL mutation
 BEGIN;
 ALTER TABLE tbl RESET (ttl);
-CREATE INDEX tbl_idx ON tbl (text)
+CREATE INDEX tbl_idx ON tbl (id)
 
 statement ok
 ROLLBACK
@@ -281,9 +269,7 @@ SELECT create_statement FROM [SHOW CREATE TABLE tbl]
 ----
 CREATE TABLE public.tbl (
   id INT8 NOT NULL,
-  text STRING NULL,
-  CONSTRAINT tbl_pkey PRIMARY KEY (id ASC),
-  FAMILY fam_0_id_text_crdb_internal_expiration (id, text)
+  CONSTRAINT tbl_pkey PRIMARY KEY (id ASC)
 )
 
 statement ok
@@ -300,13 +286,11 @@ WHERE label = 'row-level-ttl-$table_id'
 
 # Ensure schedules are removed on DROP TABLE.
 statement ok
-DROP TABLE tbl;
+DROP TABLE tbl
 
 statement ok
 CREATE TABLE tbl (
-  id INT PRIMARY KEY,
-  text TEXT,
-  FAMILY (id, text)
+  id INT PRIMARY KEY
 ) WITH (ttl_expire_after = '10 minutes')
 
 let $table_id
@@ -329,7 +313,7 @@ WHERE label = 'row-level-ttl-$table_id'
 
 # Create TTL on a different schema and ensure schedules are removed when dropped.
 statement ok
-CREATE SCHEMA drop_me;
+CREATE SCHEMA drop_me
 
 statement ok
 CREATE TABLE drop_me.tbl () WITH (ttl_expire_after = '10 minutes'::interval);
@@ -358,10 +342,10 @@ WHERE label = 'row-level-ttl-$table_id'
 
 # Create TTL on a different database and ensure schedules are removed when dropped.
 statement ok
-CREATE DATABASE drop_me;
+CREATE DATABASE drop_me
 
 statement ok
-USE drop_me;
+USE drop_me
 
 statement ok
 CREATE TABLE tbl () WITH (ttl_expire_after = '10 minutes'::interval);
@@ -392,16 +376,12 @@ WHERE label = 'row-level-ttl-$table_id'
 statement error table crdb_internal_expiration has TTL defined, but column crdb_internal_expiration is not a TIMESTAMPTZ
 CREATE TABLE tbl (
   id INT PRIMARY KEY,
-  text TEXT,
-  crdb_internal_expiration INTERVAL,
-  FAMILY (id, text)
+  crdb_internal_expiration INTERVAL
 ) WITH (ttl_expire_after = '10 minutes'::interval)
 
 statement ok
 CREATE TABLE tbl (
-  id INT PRIMARY KEY,
-  text TEXT,
-  FAMILY (id, text)
+  id INT PRIMARY KEY
 ) WITH (ttl_expire_after = '10 minutes'::interval)
 
 query T
@@ -409,25 +389,21 @@ SELECT create_statement FROM [SHOW CREATE TABLE tbl]
 ----
 CREATE TABLE public.tbl (
   id INT8 NOT NULL,
-  text STRING NULL,
   crdb_internal_expiration TIMESTAMPTZ NOT VISIBLE NOT NULL DEFAULT current_timestamp():::TIMESTAMPTZ + '00:10:00':::INTERVAL ON UPDATE current_timestamp():::TIMESTAMPTZ + '00:10:00':::INTERVAL,
-  CONSTRAINT tbl_pkey PRIMARY KEY (id ASC),
-  FAMILY fam_0_id_text_crdb_internal_expiration (id, text, crdb_internal_expiration)
+  CONSTRAINT tbl_pkey PRIMARY KEY (id ASC)
 ) WITH (ttl = 'on', ttl_expire_after = '00:10:00':::INTERVAL, ttl_job_cron = '@hourly')
 
 # Test no-ops.
 statement ok
-ALTER TABLE tbl SET (ttl = 'on');
+ALTER TABLE tbl SET (ttl = 'on')
 
 query T
 SELECT create_statement FROM [SHOW CREATE TABLE tbl]
 ----
 CREATE TABLE public.tbl (
   id INT8 NOT NULL,
-  text STRING NULL,
   crdb_internal_expiration TIMESTAMPTZ NOT VISIBLE NOT NULL DEFAULT current_timestamp():::TIMESTAMPTZ + '00:10:00':::INTERVAL ON UPDATE current_timestamp():::TIMESTAMPTZ + '00:10:00':::INTERVAL,
-  CONSTRAINT tbl_pkey PRIMARY KEY (id ASC),
-  FAMILY fam_0_id_text_crdb_internal_expiration (id, text, crdb_internal_expiration)
+  CONSTRAINT tbl_pkey PRIMARY KEY (id ASC)
 ) WITH (ttl = 'on', ttl_expire_after = '00:10:00':::INTERVAL, ttl_job_cron = '@hourly')
 
 let $table_id
@@ -456,9 +432,7 @@ CREATE TABLE tbl () WITH (ttl_expire_after = '10 seconds', ttl_job_cron = 'bad e
 
 statement ok
 CREATE TABLE tbl (
-  id INT PRIMARY KEY,
-  text TEXT,
-  FAMILY (id, text)
+  id INT PRIMARY KEY
 ) WITH (ttl_expire_after = '10 minutes'::interval, ttl_job_cron = '@daily')
 
 query T
@@ -466,10 +440,8 @@ SELECT create_statement FROM [SHOW CREATE TABLE tbl]
 ----
 CREATE TABLE public.tbl (
   id INT8 NOT NULL,
-  text STRING NULL,
   crdb_internal_expiration TIMESTAMPTZ NOT VISIBLE NOT NULL DEFAULT current_timestamp():::TIMESTAMPTZ + '00:10:00':::INTERVAL ON UPDATE current_timestamp():::TIMESTAMPTZ + '00:10:00':::INTERVAL,
-  CONSTRAINT tbl_pkey PRIMARY KEY (id ASC),
-  FAMILY fam_0_id_text_crdb_internal_expiration (id, text, crdb_internal_expiration)
+  CONSTRAINT tbl_pkey PRIMARY KEY (id ASC)
 ) WITH (ttl = 'on', ttl_expire_after = '00:10:00':::INTERVAL, ttl_job_cron = '@daily')
 
 let $table_id
@@ -489,10 +461,8 @@ SELECT create_statement FROM [SHOW CREATE TABLE tbl]
 ----
 CREATE TABLE public.tbl (
   id INT8 NOT NULL,
-  text STRING NULL,
   crdb_internal_expiration TIMESTAMPTZ NOT VISIBLE NOT NULL DEFAULT current_timestamp():::TIMESTAMPTZ + '00:10:00':::INTERVAL ON UPDATE current_timestamp():::TIMESTAMPTZ + '00:10:00':::INTERVAL,
-  CONSTRAINT tbl_pkey PRIMARY KEY (id ASC),
-  FAMILY fam_0_id_text_crdb_internal_expiration (id, text, crdb_internal_expiration)
+  CONSTRAINT tbl_pkey PRIMARY KEY (id ASC)
 ) WITH (ttl = 'on', ttl_expire_after = '00:10:00':::INTERVAL, ttl_job_cron = '@weekly')
 
 
@@ -510,10 +480,8 @@ SELECT create_statement FROM [SHOW CREATE TABLE tbl]
 ----
 CREATE TABLE public.tbl (
   id INT8 NOT NULL,
-  text STRING NULL,
   crdb_internal_expiration TIMESTAMPTZ NOT VISIBLE NOT NULL DEFAULT current_timestamp():::TIMESTAMPTZ + '00:10:00':::INTERVAL ON UPDATE current_timestamp():::TIMESTAMPTZ + '00:10:00':::INTERVAL,
-  CONSTRAINT tbl_pkey PRIMARY KEY (id ASC),
-  FAMILY fam_0_id_text_crdb_internal_expiration (id, text, crdb_internal_expiration)
+  CONSTRAINT tbl_pkey PRIMARY KEY (id ASC)
 ) WITH (ttl = 'on', ttl_expire_after = '00:10:00':::INTERVAL, ttl_job_cron = '@hourly')
 
 query TTT
@@ -523,7 +491,7 @@ WHERE label = 'row-level-ttl-$table_id'
 ACTIVE  @hourly  root
 
 statement ok
-CREATE TABLE no_ttl_table ();
+CREATE TABLE no_ttl_table ()
 
 statement error "ttl_expire_after" and/or "ttl_expiration_expression" must be set
 ALTER TABLE no_ttl_table SET (ttl_select_batch_size = 50)
@@ -541,13 +509,11 @@ statement error "ttl_expire_after" and/or "ttl_expiration_expression" must be se
 ALTER TABLE no_ttl_table SET (ttl_label_metrics = true)
 
 statement ok
-DROP TABLE tbl;
+DROP TABLE tbl
 
 statement ok
 CREATE TABLE tbl (
-  id INT PRIMARY KEY,
-  text TEXT,
-  FAMILY (id, text)
+  id INT PRIMARY KEY
 ) WITH (ttl_expire_after = '10 minutes', ttl_select_batch_size = 50, ttl_delete_rate_limit = 100, ttl_pause = true, ttl_row_stats_poll_interval = '1 minute', ttl_label_metrics = true)
 
 query T
@@ -560,10 +526,8 @@ SELECT create_statement FROM [SHOW CREATE TABLE tbl]
 ----
 CREATE TABLE public.tbl (
   id INT8 NOT NULL,
-  text STRING NULL,
   crdb_internal_expiration TIMESTAMPTZ NOT VISIBLE NOT NULL DEFAULT current_timestamp():::TIMESTAMPTZ + '00:10:00':::INTERVAL ON UPDATE current_timestamp():::TIMESTAMPTZ + '00:10:00':::INTERVAL,
-  CONSTRAINT tbl_pkey PRIMARY KEY (id ASC),
-  FAMILY fam_0_id_text_crdb_internal_expiration (id, text, crdb_internal_expiration)
+  CONSTRAINT tbl_pkey PRIMARY KEY (id ASC)
 ) WITH (ttl = 'on', ttl_expire_after = '00:10:00':::INTERVAL, ttl_job_cron = '@hourly', ttl_select_batch_size = 50, ttl_delete_rate_limit = 100, ttl_pause = true, ttl_row_stats_poll_interval = '1m0s', ttl_label_metrics = true)
 
 statement ok
@@ -574,10 +538,8 @@ SELECT create_statement FROM [SHOW CREATE TABLE tbl]
 ----
 CREATE TABLE public.tbl (
   id INT8 NOT NULL,
-  text STRING NULL,
   crdb_internal_expiration TIMESTAMPTZ NOT VISIBLE NOT NULL DEFAULT current_timestamp():::TIMESTAMPTZ + '00:10:00':::INTERVAL ON UPDATE current_timestamp():::TIMESTAMPTZ + '00:10:00':::INTERVAL,
-  CONSTRAINT tbl_pkey PRIMARY KEY (id ASC),
-  FAMILY fam_0_id_text_crdb_internal_expiration (id, text, crdb_internal_expiration)
+  CONSTRAINT tbl_pkey PRIMARY KEY (id ASC)
 ) WITH (ttl = 'on', ttl_expire_after = '00:10:00':::INTERVAL, ttl_job_cron = '@hourly', ttl_select_batch_size = 50, ttl_delete_batch_size = 100, ttl_delete_rate_limit = 100, ttl_pause = true, ttl_row_stats_poll_interval = '1m0s', ttl_label_metrics = true)
 
 statement error "ttl_select_batch_size" must be at least 1
@@ -600,10 +562,8 @@ SELECT create_statement FROM [SHOW CREATE TABLE tbl]
 ----
 CREATE TABLE public.tbl (
   id INT8 NOT NULL,
-  text STRING NULL,
   crdb_internal_expiration TIMESTAMPTZ NOT VISIBLE NOT NULL DEFAULT current_timestamp():::TIMESTAMPTZ + '00:10:00':::INTERVAL ON UPDATE current_timestamp():::TIMESTAMPTZ + '00:10:00':::INTERVAL,
-  CONSTRAINT tbl_pkey PRIMARY KEY (id ASC),
-  FAMILY fam_0_id_text_crdb_internal_expiration (id, text, crdb_internal_expiration)
+  CONSTRAINT tbl_pkey PRIMARY KEY (id ASC)
 ) WITH (ttl = 'on', ttl_expire_after = '00:10:00':::INTERVAL, ttl_job_cron = '@hourly', ttl_label_metrics = true)
 
 subtest end
@@ -669,13 +629,12 @@ subtest alter_table_ttl_expiration_expression
 statement ok
 CREATE TABLE tbl_alter_table_ttl_expiration_expression (
   id INT PRIMARY KEY,
-  text TEXT,
   expire_at TIMESTAMPTZ,
-  FAMILY (id, text, expire_at)
+  FAMILY (id, expire_at)
 )
 
-statement error expected ttl_expiration_expression expression to have type timestamptz, but 'text' has type string
-ALTER TABLE tbl_alter_table_ttl_expiration_expression SET (ttl_expiration_expression = 'text')
+statement error expected ttl_expiration_expression expression to have type timestamptz, but 'id' has type int
+ALTER TABLE tbl_alter_table_ttl_expiration_expression SET (ttl_expiration_expression = 'id')
 
 statement ok
 ALTER TABLE tbl_alter_table_ttl_expiration_expression SET (ttl_expiration_expression = 'expire_at')
@@ -708,10 +667,9 @@ SELECT create_statement FROM [SHOW CREATE TABLE tbl_alter_table_ttl_expiration_e
 ----
 CREATE TABLE public.tbl_alter_table_ttl_expiration_expression (
   id INT8 NOT NULL,
-  text STRING NULL,
   expire_at TIMESTAMPTZ NULL,
   CONSTRAINT tbl_alter_table_ttl_expiration_expression_pkey PRIMARY KEY (id ASC),
-  FAMILY fam_0_id_text_expire_at (id, text, expire_at)
+  FAMILY fam_0_id_expire_at (id, expire_at)
 ) WITH (ttl = 'on', ttl_expiration_expression = 'expire_at', ttl_job_cron = '@hourly')
 
 # try setting it again
@@ -723,10 +681,9 @@ SELECT create_statement FROM [SHOW CREATE TABLE tbl_alter_table_ttl_expiration_e
 ----
 CREATE TABLE public.tbl_alter_table_ttl_expiration_expression (
   id INT8 NOT NULL,
-  text STRING NULL,
   expire_at TIMESTAMPTZ NULL,
   CONSTRAINT tbl_alter_table_ttl_expiration_expression_pkey PRIMARY KEY (id ASC),
-  FAMILY fam_0_id_text_expire_at (id, text, expire_at)
+  FAMILY fam_0_id_expire_at (id, expire_at)
 ) WITH (ttl = 'on', ttl_expiration_expression = e'((expire_at AT TIME ZONE \'UTC\') + \'5 minutes\':::INTERVAL) AT TIME ZONE \'UTC\'', ttl_job_cron = '@hourly')
 
 statement ok
@@ -737,10 +694,9 @@ SELECT create_statement FROM [SHOW CREATE TABLE tbl_alter_table_ttl_expiration_e
 ----
 CREATE TABLE public.tbl_alter_table_ttl_expiration_expression (
   id INT8 NOT NULL,
-  text STRING NULL,
   expire_at TIMESTAMPTZ NULL,
   CONSTRAINT tbl_alter_table_ttl_expiration_expression_pkey PRIMARY KEY (id ASC),
-  FAMILY fam_0_id_text_expire_at (id, text, expire_at)
+  FAMILY fam_0_id_expire_at (id, expire_at)
 )
 
 subtest end
@@ -911,14 +867,13 @@ subtest todo_add_subtests2
 
 # Test adding to TTL table with crdb_internal_expiration already defined.
 statement ok
-DROP TABLE tbl;
+DROP TABLE tbl
 
 statement ok
 CREATE TABLE tbl (
   id INT PRIMARY KEY,
-  text TEXT,
   crdb_internal_expiration TIMESTAMPTZ,
-  FAMILY (id, text)
+  FAMILY (id, crdb_internal_expiration)
 )
 
 statement error cannot add TTL to table with the crdb_internal_expiration column already defined
@@ -955,33 +910,31 @@ statement ok
 DROP TABLE tbl
 
 statement error non-ascending ordering on PRIMARY KEYs are not supported
-CREATE TABLE tbl (id INT, text TEXT, PRIMARY KEY (id, text DESC)) WITH (ttl_expire_after = '10 minutes')
+CREATE TABLE tbl (id INT, id2 INT, PRIMARY KEY (id, id2 DESC)) WITH (ttl_expire_after = '10 minutes')
 
 statement ok
-CREATE TABLE tbl (id INT, text TEXT, PRIMARY KEY (id, text DESC))
+CREATE TABLE tbl (id INT, id2 INT, PRIMARY KEY (id, id2 DESC))
 
 statement error non-ascending ordering on PRIMARY KEYs are not supported
 ALTER TABLE tbl SET (ttl_expire_after = '10 minutes')
 
 statement ok
-DROP TABLE tbl;
+DROP TABLE tbl
 
 statement ok
-CREATE TABLE tbl (id INT, text TEXT, PRIMARY KEY (id, text)) WITH (ttl_expire_after = '10 minutes')
+CREATE TABLE tbl (id INT, id2 INT, PRIMARY KEY (id, id2)) WITH (ttl_expire_after = '10 minutes')
 
 statement error non-ascending ordering on PRIMARY KEYs are not supported
-ALTER TABLE tbl ALTER PRIMARY KEY USING COLUMNS (id, text DESC)
+ALTER TABLE tbl ALTER PRIMARY KEY USING COLUMNS (id, id2 DESC)
 
 # Create a table without a TTL. Add the TTL to the table and ensure
 # the schedule and TTL is setup correctly.
 statement ok
-DROP TABLE tbl;
+DROP TABLE tbl
 
 statement ok
 CREATE TABLE tbl (
-   id INT PRIMARY KEY,
-   text TEXT,
-   FAMILY (id, text)
+   id INT PRIMARY KEY
 )
 
 statement error cannot modify TTL settings while another schema change on the table is being processed
@@ -997,7 +950,7 @@ ROLLBACK
 
 statement error cannot modify TTL settings while another schema change on the table is being processed
 BEGIN;
-CREATE INDEX tbl_idx ON tbl (text);
+CREATE INDEX tbl_idx ON tbl (id);
 ALTER TABLE tbl SET (ttl_expire_after = '10 minutes');
 
 statement ok
@@ -1006,7 +959,7 @@ ROLLBACK
 statement error cannot perform other schema changes in the same transaction as a TTL mutation
 BEGIN;
 ALTER TABLE tbl SET (ttl_expire_after = '10 minutes');
-CREATE INDEX tbl_idx ON tbl (text)
+CREATE INDEX tbl_idx ON tbl (id)
 
 statement ok
 ROLLBACK
@@ -1020,9 +973,7 @@ subtest create_table_no_ttl_set_ttl_expire_after
 
 statement ok
 CREATE TABLE create_table_no_ttl_set_ttl_expire_after (
-   id INT PRIMARY KEY,
-   text TEXT,
-   FAMILY (id, text)
+   id INT PRIMARY KEY
 )
 
 statement ok
@@ -1033,10 +984,8 @@ SELECT create_statement FROM [SHOW CREATE TABLE create_table_no_ttl_set_ttl_expi
 ----
 CREATE TABLE public.create_table_no_ttl_set_ttl_expire_after (
   id INT8 NOT NULL,
-  text STRING NULL,
   crdb_internal_expiration TIMESTAMPTZ NOT VISIBLE NOT NULL DEFAULT current_timestamp():::TIMESTAMPTZ + '00:10:00':::INTERVAL ON UPDATE current_timestamp():::TIMESTAMPTZ + '00:10:00':::INTERVAL,
-  CONSTRAINT create_table_no_ttl_set_ttl_expire_after_pkey PRIMARY KEY (id ASC),
-  FAMILY fam_0_id_text (id, text, crdb_internal_expiration)
+  CONSTRAINT create_table_no_ttl_set_ttl_expire_after_pkey PRIMARY KEY (id ASC)
 ) WITH (ttl = 'on', ttl_expire_after = '00:10:00':::INTERVAL, ttl_job_cron = '@hourly')
 
 let $table_id
@@ -1063,9 +1012,8 @@ subtest create_table_no_ttl_set_ttl_expiration_expression
 statement ok
 CREATE TABLE create_table_no_ttl_set_ttl_expiration_expression (
    id INT PRIMARY KEY,
-   text TEXT,
    expire_at TIMESTAMPTZ,
-   FAMILY (id, text)
+   FAMILY (id, expire_at)
 )
 
 statement ok
@@ -1076,10 +1024,9 @@ SELECT create_statement FROM [SHOW CREATE TABLE create_table_no_ttl_set_ttl_expi
 ----
 CREATE TABLE public.create_table_no_ttl_set_ttl_expiration_expression (
   id INT8 NOT NULL,
-  text STRING NULL,
   expire_at TIMESTAMPTZ NULL,
   CONSTRAINT create_table_no_ttl_set_ttl_expiration_expression_pkey PRIMARY KEY (id ASC),
-  FAMILY fam_0_id_text_expire_at (id, text, expire_at)
+  FAMILY fam_0_id_expire_at (id, expire_at)
 ) WITH (ttl = 'on', ttl_expiration_expression = 'expire_at', ttl_job_cron = '@hourly')
 
 let $table_id

--- a/pkg/sql/logictest/testdata/logic_test/row_level_ttl
+++ b/pkg/sql/logictest/testdata/logic_test/row_level_ttl
@@ -962,28 +962,25 @@ subtest end
 subtest foreign_key_constraint
 
 statement ok
-CREATE TABLE ref_table (id INT PRIMARY KEY, ref INT)
-
-statement error foreign keys from table with TTL "ttl_table" are not permitted
-CREATE TABLE ttl_table (id INT PRIMARY KEY, ref INT REFERENCES ref_table(id)) WITH (ttl_expire_after = '10 mins')
-
-statement ok
-CREATE TABLE ttl_table (id INT PRIMARY KEY, ref INT) WITH (ttl_expire_after = '10 mins')
+CREATE TABLE ttl_table (id INT PRIMARY KEY) WITH (ttl_expire_after = '10 mins')
 
 statement error foreign keys to table with TTL "ttl_table" are not permitted
-CREATE TABLE new_ref_table (id INT PRIMARY KEY, ref INT REFERENCES ttl_table(id))
+CREATE TABLE ref_table (id INT PRIMARY KEY, ref INT REFERENCES ttl_table(id))
+
+statement ok
+CREATE TABLE ref_table (id INT PRIMARY KEY, ref INT)
 
 statement error foreign keys to table with TTL "ttl_table" are not permitted
 ALTER TABLE ref_table ADD CONSTRAINT fk FOREIGN KEY (ref) REFERENCES ttl_table (id)
 
-statement error foreign keys from table with TTL "ttl_table" are not permitted
-ALTER TABLE ttl_table ADD CONSTRAINT fk FOREIGN KEY (ref) REFERENCES ttl_table (id)
+statement ok
+CREATE TABLE become_ttl_table (id INT PRIMARY KEY)
 
 statement ok
-CREATE TABLE ttl_become_table (id INT PRIMARY KEY, ref INT REFERENCES ref_table (id))
+CREATE TABLE become_ref_table (id INT PRIMARY KEY, ref INT REFERENCES become_ttl_table(id))
 
-statement error foreign keys from table with TTL "ttl_become_table" are not permitted
-ALTER TABLE ttl_become_table SET (ttl_expire_after = '10 minutes')
+statement error foreign keys to table with TTL "become_ttl_table" are not permitted
+ALTER TABLE become_ttl_table SET (ttl_expire_after = '10 mins')
 
 subtest end
 

--- a/pkg/sql/logictest/testdata/logic_test/row_level_ttl
+++ b/pkg/sql/logictest/testdata/logic_test/row_level_ttl
@@ -83,7 +83,7 @@ subtest create_table_crdb_internal_expiration_incorrect_explicit_on_update
 statement error expected ON UPDATE expression of crdb_internal_expiration to be current_timestamp\(\):::TIMESTAMPTZ \+ '00:10:00':::INTERVAL
 CREATE TABLE tbl (
   id INT PRIMARY KEY,
-  crdb_internal_expiration TIMESTAMPTZ DEFAULT current_timestamp() + '10 minutes'::interval
+  crdb_internal_expiration TIMESTAMPTZ DEFAULT current_timestamp() + '10 minutes'
 ) WITH (ttl_expire_after = '10 minutes')
 
 subtest end
@@ -198,20 +198,29 @@ ALTER TABLE alter_column_crdb_internal_expiration_rename RENAME COLUMN crdb_inte
 
 subtest end
 
-subtest todo_add_subtests
+subtest reloptions
 
 statement ok
-CREATE TABLE tbl (
+CREATE TABLE tbl_reloptions (
+  id INT PRIMARY KEY
+) WITH (ttl_expire_after = '10 minutes', ttl_select_batch_size = 10, ttl_delete_batch_size=20, ttl_delete_rate_limit = 30, ttl_pause = true, ttl_row_stats_poll_interval = '1 minute', ttl_label_metrics = true)
+
+query T
+SELECT reloptions FROM pg_class WHERE relname = 'tbl_reloptions'
+----
+{ttl='on',ttl_expire_after='00:10:00':::INTERVAL,ttl_job_cron='@hourly',ttl_select_batch_size=10,ttl_delete_batch_size=20,ttl_delete_rate_limit=30,ttl_pause=true,ttl_row_stats_poll_interval='1m0s',ttl_label_metrics=true}
+
+subtest end
+
+subtest schedules
+
+statement ok
+CREATE TABLE tbl_schedules (
   id INT PRIMARY KEY
 ) WITH (ttl_expire_after = '10 minutes')
 
-query T
-SELECT reloptions FROM pg_class WHERE relname = 'tbl'
-----
-{ttl='on',ttl_expire_after='00:10:00':::INTERVAL,ttl_job_cron='@hourly'}
-
 let $table_id
-SELECT oid FROM pg_class WHERE relname = 'tbl'
+SELECT oid FROM pg_class WHERE relname = 'tbl_schedules'
 
 query I
 SELECT count(1) FROM [SHOW SCHEDULES]
@@ -222,61 +231,109 @@ WHERE label = 'row-level-ttl-$table_id'
 let $schedule_id
 SELECT id FROM [SHOW SCHEDULES] WHERE label = 'row-level-ttl-$table_id'
 
-statement error cannot drop a row level TTL schedule\nHINT: use ALTER TABLE test\.public\.tbl RESET \(ttl\) instead
+statement error cannot drop a row level TTL schedule\nHINT: use ALTER TABLE test\.public\.tbl_schedules RESET \(ttl\) instead
 DROP SCHEDULE $schedule_id
 
-statement ok
-ALTER TABLE tbl SET (ttl_expire_after = '10 days')
+subtest end
 
-query T
-SELECT create_statement FROM [SHOW CREATE TABLE tbl]
-----
-CREATE TABLE public.tbl (
-  id INT8 NOT NULL,
-  crdb_internal_expiration TIMESTAMPTZ NOT VISIBLE NOT NULL DEFAULT current_timestamp():::TIMESTAMPTZ + '10 days':::INTERVAL ON UPDATE current_timestamp():::TIMESTAMPTZ + '10 days':::INTERVAL,
-  CONSTRAINT tbl_pkey PRIMARY KEY (id ASC)
-) WITH (ttl = 'on', ttl_expire_after = '10 days':::INTERVAL, ttl_job_cron = '@hourly')
+subtest existing_ttl_concurrent_schema_change
+
+statement ok
+CREATE TABLE tbl_existing_ttl_concurrent_schema_change (
+  id INT PRIMARY KEY
+) WITH (ttl_expire_after = '10 minutes')
 
 statement error cannot modify TTL settings while another schema change on the table is being processed
-ALTER TABLE tbl RESET (ttl), RESET (ttl_expire_after)
+ALTER TABLE tbl_existing_ttl_concurrent_schema_change RESET (ttl), RESET (ttl_expire_after)
 
 statement error cannot modify TTL settings while another schema change on the table is being processed
 BEGIN;
-ALTER TABLE tbl RESET (ttl);
-ALTER TABLE tbl SET (ttl_select_batch_size = 200)
+ALTER TABLE tbl_existing_ttl_concurrent_schema_change RESET (ttl);
+ALTER TABLE tbl_existing_ttl_concurrent_schema_change SET (ttl_select_batch_size = 200)
 
 statement ok
 ROLLBACK
 
 statement error cannot perform other schema changes in the same transaction as a TTL mutation
 BEGIN;
-ALTER TABLE tbl RESET (ttl);
-CREATE INDEX tbl_idx ON tbl (id)
+ALTER TABLE tbl_existing_ttl_concurrent_schema_change RESET (ttl);
+CREATE INDEX tbl_idx ON tbl_existing_ttl_concurrent_schema_change (id)
 
 statement ok
 ROLLBACK
 
+subtest end
+
+subtest add_ttl_concurrent_schema_change
+
+statement ok
+CREATE TABLE tbl_add_ttl_concurrent_schema_change (
+   id INT PRIMARY KEY
+)
+
+statement error cannot modify TTL settings while another schema change on the table is being processed
+ALTER TABLE tbl_add_ttl_concurrent_schema_change SET (ttl_expire_after = '10 minutes'), SET (ttl_select_batch_size = 200)
+
+statement error cannot modify TTL settings while another schema change on the table is being processed
+BEGIN;
+ALTER TABLE tbl_add_ttl_concurrent_schema_change SET (ttl_expire_after = '10 minutes');
+ALTER TABLE tbl_add_ttl_concurrent_schema_change RESET (ttl_select_batch_size)
+
+statement ok
+ROLLBACK
+
+statement error cannot modify TTL settings while another schema change on the table is being processed
+BEGIN;
+CREATE INDEX tbl_idx ON tbl_add_ttl_concurrent_schema_change (id);
+ALTER TABLE tbl_add_ttl_concurrent_schema_change SET (ttl_expire_after = '10 minutes');
+
+statement ok
+ROLLBACK
+
+statement error cannot perform other schema changes in the same transaction as a TTL mutation
+BEGIN;
+ALTER TABLE tbl_add_ttl_concurrent_schema_change SET (ttl_expire_after = '10 minutes');
+CREATE INDEX tbl_idx ON tbl_add_ttl_concurrent_schema_change (id)
+
+statement ok
+ROLLBACK
+
+subtest end
+
+subtest reset_ttl
+
+statement ok
+CREATE TABLE tbl_reset_ttl (
+  id INT PRIMARY KEY
+) WITH (ttl_expire_after = '10 minutes')
+
+let $table_id
+SELECT oid FROM pg_class WHERE relname = 'tbl_reset_ttl'
+
+query I
+SELECT count(1) FROM [SHOW SCHEDULES]
+WHERE label = 'row-level-ttl-$table_id'
+----
+1
+
 # Cannot reset TTL with SET (ttl = off)
 statement error setting "ttl = 'off'" is not permitted
-ALTER TABLE tbl SET (ttl = 'off')
+ALTER TABLE tbl_reset_ttl SET (ttl = 'off')
 
 # Test when we drop the TTL, ensure column is dropped and the scheduled job is removed.
 statement ok
-ALTER TABLE tbl RESET (ttl)
+ALTER TABLE tbl_reset_ttl RESET (ttl)
 
 query T
-SELECT create_statement FROM [SHOW CREATE TABLE tbl]
+SELECT create_statement FROM [SHOW CREATE TABLE tbl_reset_ttl]
 ----
-CREATE TABLE public.tbl (
+CREATE TABLE public.tbl_reset_ttl (
   id INT8 NOT NULL,
-  CONSTRAINT tbl_pkey PRIMARY KEY (id ASC)
+  CONSTRAINT tbl_reset_ttl_pkey PRIMARY KEY (id ASC)
 )
 
 statement ok
 SELECT crdb_internal.validate_ttl_scheduled_jobs()
-
-let $table_id
-SELECT oid FROM pg_class WHERE relname = 'tbl'
 
 query I
 SELECT count(1) FROM [SHOW SCHEDULES]
@@ -284,17 +341,18 @@ WHERE label = 'row-level-ttl-$table_id'
 ----
 0
 
+subtest end
+
+subtest drop_table
+
 # Ensure schedules are removed on DROP TABLE.
 statement ok
-DROP TABLE tbl
-
-statement ok
-CREATE TABLE tbl (
+CREATE TABLE tbl_drop_table (
   id INT PRIMARY KEY
 ) WITH (ttl_expire_after = '10 minutes')
 
 let $table_id
-SELECT oid FROM pg_class WHERE relname = 'tbl'
+SELECT oid FROM pg_class WHERE relname = 'tbl_drop_table'
 
 query I
 SELECT count(1) FROM [SHOW SCHEDULES]
@@ -303,7 +361,7 @@ WHERE label = 'row-level-ttl-$table_id'
 1
 
 statement ok
-DROP TABLE tbl
+DROP TABLE tbl_drop_table
 
 query I
 SELECT count(1) FROM [SHOW SCHEDULES]
@@ -311,13 +369,17 @@ WHERE label = 'row-level-ttl-$table_id'
 ----
 0
 
+subtest end
+
+subtest drop_schema
+
 # Create TTL on a different schema and ensure schedules are removed when dropped.
 statement ok
 CREATE SCHEMA drop_me
 
 statement ok
-CREATE TABLE drop_me.tbl () WITH (ttl_expire_after = '10 minutes'::interval);
-CREATE TABLE drop_me.tbl2 () WITH (ttl_expire_after = '10 minutes'::interval)
+CREATE TABLE drop_me.tbl () WITH (ttl_expire_after = '10 minutes');
+CREATE TABLE drop_me.tbl2 () WITH (ttl_expire_after = '10 minutes')
 
 let $table_id
 SELECT oid FROM pg_class WHERE relname = 'tbl'
@@ -340,6 +402,10 @@ WHERE label = 'row-level-ttl-$table_id'
 ----
 0
 
+subtest end
+
+subtest drop_database
+
 # Create TTL on a different database and ensure schedules are removed when dropped.
 statement ok
 CREATE DATABASE drop_me
@@ -348,8 +414,8 @@ statement ok
 USE drop_me
 
 statement ok
-CREATE TABLE tbl () WITH (ttl_expire_after = '10 minutes'::interval);
-CREATE TABLE tbl2 () WITH (ttl_expire_after = '10 minutes'::interval)
+CREATE TABLE tbl () WITH (ttl_expire_after = '10 minutes');
+CREATE TABLE tbl2 () WITH (ttl_expire_after = '10 minutes')
 
 let $table_id
 SELECT oid FROM pg_class WHERE relname = 'tbl'
@@ -373,41 +439,49 @@ WHERE label = 'row-level-ttl-$table_id'
 ----
 0
 
+subtest end
+
+subtest crdb_internal_expiration_invalid_type
+
 statement error table crdb_internal_expiration has TTL defined, but column crdb_internal_expiration is not a TIMESTAMPTZ
 CREATE TABLE tbl (
   id INT PRIMARY KEY,
   crdb_internal_expiration INTERVAL
-) WITH (ttl_expire_after = '10 minutes'::interval)
+) WITH (ttl_expire_after = '10 minutes')
+
+subtest end
+
+subtest ttl_on_noop
 
 statement ok
-CREATE TABLE tbl (
+CREATE TABLE tbl_ttl_on_noop (
   id INT PRIMARY KEY
-) WITH (ttl_expire_after = '10 minutes'::interval)
+) WITH (ttl_expire_after = '10 minutes')
 
 query T
-SELECT create_statement FROM [SHOW CREATE TABLE tbl]
+SELECT create_statement FROM [SHOW CREATE TABLE tbl_ttl_on_noop]
 ----
-CREATE TABLE public.tbl (
+CREATE TABLE public.tbl_ttl_on_noop (
   id INT8 NOT NULL,
   crdb_internal_expiration TIMESTAMPTZ NOT VISIBLE NOT NULL DEFAULT current_timestamp():::TIMESTAMPTZ + '00:10:00':::INTERVAL ON UPDATE current_timestamp():::TIMESTAMPTZ + '00:10:00':::INTERVAL,
-  CONSTRAINT tbl_pkey PRIMARY KEY (id ASC)
+  CONSTRAINT tbl_ttl_on_noop_pkey PRIMARY KEY (id ASC)
 ) WITH (ttl = 'on', ttl_expire_after = '00:10:00':::INTERVAL, ttl_job_cron = '@hourly')
 
 # Test no-ops.
 statement ok
-ALTER TABLE tbl SET (ttl = 'on')
+ALTER TABLE tbl_ttl_on_noop SET (ttl = 'on')
 
 query T
-SELECT create_statement FROM [SHOW CREATE TABLE tbl]
+SELECT create_statement FROM [SHOW CREATE TABLE tbl_ttl_on_noop]
 ----
-CREATE TABLE public.tbl (
+CREATE TABLE public.tbl_ttl_on_noop (
   id INT8 NOT NULL,
   crdb_internal_expiration TIMESTAMPTZ NOT VISIBLE NOT NULL DEFAULT current_timestamp():::TIMESTAMPTZ + '00:10:00':::INTERVAL ON UPDATE current_timestamp():::TIMESTAMPTZ + '00:10:00':::INTERVAL,
-  CONSTRAINT tbl_pkey PRIMARY KEY (id ASC)
+  CONSTRAINT tbl_ttl_on_noop_pkey PRIMARY KEY (id ASC)
 ) WITH (ttl = 'on', ttl_expire_after = '00:10:00':::INTERVAL, ttl_job_cron = '@hourly')
 
 let $table_id
-SELECT oid FROM pg_class WHERE relname = 'tbl'
+SELECT oid FROM pg_class WHERE relname = 'tbl_ttl_on_noop'
 
 query TTT
 SELECT schedule_status, recurrence, owner FROM [SHOW SCHEDULES]
@@ -422,30 +496,31 @@ WHERE label = 'row-level-ttl-$table_id'
 query T
 SELECT create_statement FROM [SHOW CREATE SCHEDULE $schedule_id]
 ----
-ALTER TABLE test.public.tbl WITH (ttl = 'on', ...)
+ALTER TABLE test.public.tbl_ttl_on_noop WITH (ttl = 'on', ...)
 
-statement ok
-DROP TABLE tbl
+subtest end
+
+subtest ttl_job_cron
 
 statement error invalid cron expression for "ttl_job_cron"
 CREATE TABLE tbl () WITH (ttl_expire_after = '10 seconds', ttl_job_cron = 'bad expr')
 
 statement ok
-CREATE TABLE tbl (
+CREATE TABLE tbl_ttl_job_cron (
   id INT PRIMARY KEY
-) WITH (ttl_expire_after = '10 minutes'::interval, ttl_job_cron = '@daily')
+) WITH (ttl_expire_after = '10 minutes', ttl_job_cron = '@daily')
 
 query T
-SELECT create_statement FROM [SHOW CREATE TABLE tbl]
+SELECT create_statement FROM [SHOW CREATE TABLE tbl_ttl_job_cron]
 ----
-CREATE TABLE public.tbl (
+CREATE TABLE public.tbl_ttl_job_cron (
   id INT8 NOT NULL,
   crdb_internal_expiration TIMESTAMPTZ NOT VISIBLE NOT NULL DEFAULT current_timestamp():::TIMESTAMPTZ + '00:10:00':::INTERVAL ON UPDATE current_timestamp():::TIMESTAMPTZ + '00:10:00':::INTERVAL,
-  CONSTRAINT tbl_pkey PRIMARY KEY (id ASC)
+  CONSTRAINT tbl_ttl_job_cron_pkey PRIMARY KEY (id ASC)
 ) WITH (ttl = 'on', ttl_expire_after = '00:10:00':::INTERVAL, ttl_job_cron = '@daily')
 
 let $table_id
-SELECT oid FROM pg_class WHERE relname = 'tbl'
+SELECT oid FROM pg_class WHERE relname = 'tbl_ttl_job_cron'
 
 query TTT
 SELECT schedule_status, recurrence, owner FROM [SHOW SCHEDULES]
@@ -454,15 +529,15 @@ WHERE label = 'row-level-ttl-$table_id'
 ACTIVE  @daily  root
 
 statement ok
-ALTER TABLE tbl SET (ttl_job_cron = '@weekly')
+ALTER TABLE tbl_ttl_job_cron SET (ttl_job_cron = '@weekly')
 
 query T
-SELECT create_statement FROM [SHOW CREATE TABLE tbl]
+SELECT create_statement FROM [SHOW CREATE TABLE tbl_ttl_job_cron]
 ----
-CREATE TABLE public.tbl (
+CREATE TABLE public.tbl_ttl_job_cron (
   id INT8 NOT NULL,
   crdb_internal_expiration TIMESTAMPTZ NOT VISIBLE NOT NULL DEFAULT current_timestamp():::TIMESTAMPTZ + '00:10:00':::INTERVAL ON UPDATE current_timestamp():::TIMESTAMPTZ + '00:10:00':::INTERVAL,
-  CONSTRAINT tbl_pkey PRIMARY KEY (id ASC)
+  CONSTRAINT tbl_ttl_job_cron_pkey PRIMARY KEY (id ASC)
 ) WITH (ttl = 'on', ttl_expire_after = '00:10:00':::INTERVAL, ttl_job_cron = '@weekly')
 
 
@@ -473,15 +548,15 @@ WHERE label = 'row-level-ttl-$table_id'
 ACTIVE  @weekly  root
 
 statement ok
-ALTER TABLE tbl RESET (ttl_job_cron)
+ALTER TABLE tbl_ttl_job_cron RESET (ttl_job_cron)
 
 query T
-SELECT create_statement FROM [SHOW CREATE TABLE tbl]
+SELECT create_statement FROM [SHOW CREATE TABLE tbl_ttl_job_cron]
 ----
-CREATE TABLE public.tbl (
+CREATE TABLE public.tbl_ttl_job_cron (
   id INT8 NOT NULL,
   crdb_internal_expiration TIMESTAMPTZ NOT VISIBLE NOT NULL DEFAULT current_timestamp():::TIMESTAMPTZ + '00:10:00':::INTERVAL ON UPDATE current_timestamp():::TIMESTAMPTZ + '00:10:00':::INTERVAL,
-  CONSTRAINT tbl_pkey PRIMARY KEY (id ASC)
+  CONSTRAINT tbl_ttl_job_cron_pkey PRIMARY KEY (id ASC)
 ) WITH (ttl = 'on', ttl_expire_after = '00:10:00':::INTERVAL, ttl_job_cron = '@hourly')
 
 query TTT
@@ -489,6 +564,10 @@ SELECT schedule_status, recurrence, owner FROM [SHOW SCHEDULES]
 WHERE label = 'row-level-ttl-$table_id'
 ----
 ACTIVE  @hourly  root
+
+subtest end
+
+subtest ttl_must_be_set
 
 statement ok
 CREATE TABLE no_ttl_table ()
@@ -508,62 +587,67 @@ ALTER TABLE no_ttl_table SET (ttl_pause = true)
 statement error "ttl_expire_after" and/or "ttl_expiration_expression" must be set
 ALTER TABLE no_ttl_table SET (ttl_label_metrics = true)
 
-statement ok
-DROP TABLE tbl
+subtest end
+
+subtest ttl_params_positive
 
 statement ok
-CREATE TABLE tbl (
+CREATE TABLE tbl_ttl_params_positive (
   id INT PRIMARY KEY
-) WITH (ttl_expire_after = '10 minutes', ttl_select_batch_size = 50, ttl_delete_rate_limit = 100, ttl_pause = true, ttl_row_stats_poll_interval = '1 minute', ttl_label_metrics = true)
-
-query T
-SELECT reloptions FROM pg_class WHERE relname = 'tbl'
-----
-{ttl='on',ttl_expire_after='00:10:00':::INTERVAL,ttl_job_cron='@hourly',ttl_select_batch_size=50,ttl_delete_rate_limit=100,ttl_pause=true,ttl_row_stats_poll_interval='1m0s',ttl_label_metrics=true}
-
-query T
-SELECT create_statement FROM [SHOW CREATE TABLE tbl]
-----
-CREATE TABLE public.tbl (
-  id INT8 NOT NULL,
-  crdb_internal_expiration TIMESTAMPTZ NOT VISIBLE NOT NULL DEFAULT current_timestamp():::TIMESTAMPTZ + '00:10:00':::INTERVAL ON UPDATE current_timestamp():::TIMESTAMPTZ + '00:10:00':::INTERVAL,
-  CONSTRAINT tbl_pkey PRIMARY KEY (id ASC)
-) WITH (ttl = 'on', ttl_expire_after = '00:10:00':::INTERVAL, ttl_job_cron = '@hourly', ttl_select_batch_size = 50, ttl_delete_rate_limit = 100, ttl_pause = true, ttl_row_stats_poll_interval = '1m0s', ttl_label_metrics = true)
-
-statement ok
-ALTER TABLE tbl SET (ttl_delete_batch_size = 100)
-
-query T
-SELECT create_statement FROM [SHOW CREATE TABLE tbl]
-----
-CREATE TABLE public.tbl (
-  id INT8 NOT NULL,
-  crdb_internal_expiration TIMESTAMPTZ NOT VISIBLE NOT NULL DEFAULT current_timestamp():::TIMESTAMPTZ + '00:10:00':::INTERVAL ON UPDATE current_timestamp():::TIMESTAMPTZ + '00:10:00':::INTERVAL,
-  CONSTRAINT tbl_pkey PRIMARY KEY (id ASC)
-) WITH (ttl = 'on', ttl_expire_after = '00:10:00':::INTERVAL, ttl_job_cron = '@hourly', ttl_select_batch_size = 50, ttl_delete_batch_size = 100, ttl_delete_rate_limit = 100, ttl_pause = true, ttl_row_stats_poll_interval = '1m0s', ttl_label_metrics = true)
+) WITH (ttl_expire_after = '10 minutes')
 
 statement error "ttl_select_batch_size" must be at least 1
-ALTER TABLE tbl SET (ttl_select_batch_size = -1)
+ALTER TABLE tbl_ttl_params_positive SET (ttl_select_batch_size = -1)
 
 statement error "ttl_delete_batch_size" must be at least 1
-ALTER TABLE tbl SET (ttl_delete_batch_size = -1)
+ALTER TABLE tbl_ttl_params_positive SET (ttl_delete_batch_size = -1)
 
 statement error "ttl_delete_rate_limit" must be at least 1
-ALTER TABLE tbl SET (ttl_delete_rate_limit = -1)
+ALTER TABLE tbl_ttl_params_positive SET (ttl_delete_rate_limit = -1)
 
 statement error "ttl_row_stats_poll_interval" must be at least 1
-ALTER TABLE tbl SET (ttl_row_stats_poll_interval = '-1 second')
+ALTER TABLE tbl_ttl_params_positive SET (ttl_row_stats_poll_interval = '-1 second')
+
+subtest end
+
+subtest set_ttl_params
 
 statement ok
-ALTER TABLE tbl RESET (ttl_delete_batch_size, ttl_select_batch_size, ttl_delete_rate_limit, ttl_pause, ttl_row_stats_poll_interval)
+CREATE TABLE tbl_set_ttl_params (
+  id INT PRIMARY KEY
+) WITH (ttl_expire_after = '10 minutes', ttl_select_batch_size = 10, ttl_delete_batch_size=20, ttl_delete_rate_limit = 30, ttl_pause = true, ttl_row_stats_poll_interval = '1 minute', ttl_label_metrics = true)
 
 query T
-SELECT create_statement FROM [SHOW CREATE TABLE tbl]
+SELECT create_statement FROM [SHOW CREATE TABLE tbl_set_ttl_params]
 ----
-CREATE TABLE public.tbl (
+CREATE TABLE public.tbl_set_ttl_params (
   id INT8 NOT NULL,
   crdb_internal_expiration TIMESTAMPTZ NOT VISIBLE NOT NULL DEFAULT current_timestamp():::TIMESTAMPTZ + '00:10:00':::INTERVAL ON UPDATE current_timestamp():::TIMESTAMPTZ + '00:10:00':::INTERVAL,
-  CONSTRAINT tbl_pkey PRIMARY KEY (id ASC)
+  CONSTRAINT tbl_set_ttl_params_pkey PRIMARY KEY (id ASC)
+) WITH (ttl = 'on', ttl_expire_after = '00:10:00':::INTERVAL, ttl_job_cron = '@hourly', ttl_select_batch_size = 10, ttl_delete_batch_size = 20, ttl_delete_rate_limit = 30, ttl_pause = true, ttl_row_stats_poll_interval = '1m0s', ttl_label_metrics = true)
+
+statement ok
+ALTER TABLE tbl_set_ttl_params SET (ttl_select_batch_size = 110, ttl_delete_batch_size = 120, ttl_delete_rate_limit = 130, ttl_row_stats_poll_interval = '2m0s')
+
+query T
+SELECT create_statement FROM [SHOW CREATE TABLE tbl_set_ttl_params]
+----
+CREATE TABLE public.tbl_set_ttl_params (
+  id INT8 NOT NULL,
+  crdb_internal_expiration TIMESTAMPTZ NOT VISIBLE NOT NULL DEFAULT current_timestamp():::TIMESTAMPTZ + '00:10:00':::INTERVAL ON UPDATE current_timestamp():::TIMESTAMPTZ + '00:10:00':::INTERVAL,
+  CONSTRAINT tbl_set_ttl_params_pkey PRIMARY KEY (id ASC)
+) WITH (ttl = 'on', ttl_expire_after = '00:10:00':::INTERVAL, ttl_job_cron = '@hourly', ttl_select_batch_size = 110, ttl_delete_batch_size = 120, ttl_delete_rate_limit = 130, ttl_pause = true, ttl_row_stats_poll_interval = '2m0s', ttl_label_metrics = true)
+
+statement ok
+ALTER TABLE tbl_set_ttl_params RESET (ttl_select_batch_size, ttl_delete_batch_size, ttl_delete_rate_limit, ttl_pause, ttl_row_stats_poll_interval)
+
+query T
+SELECT create_statement FROM [SHOW CREATE TABLE tbl_set_ttl_params]
+----
+CREATE TABLE public.tbl_set_ttl_params (
+  id INT8 NOT NULL,
+  crdb_internal_expiration TIMESTAMPTZ NOT VISIBLE NOT NULL DEFAULT current_timestamp():::TIMESTAMPTZ + '00:10:00':::INTERVAL ON UPDATE current_timestamp():::TIMESTAMPTZ + '00:10:00':::INTERVAL,
+  CONSTRAINT tbl_set_ttl_params_pkey PRIMARY KEY (id ASC)
 ) WITH (ttl = 'on', ttl_expire_after = '00:10:00':::INTERVAL, ttl_job_cron = '@hourly', ttl_label_metrics = true)
 
 subtest end
@@ -620,7 +704,6 @@ CREATE TABLE public.tbl_create_table_ttl_expiration_expression_escape_sql (
   CONSTRAINT tbl_create_table_ttl_expiration_expression_escape_sql_pkey PRIMARY KEY (id ASC),
   FAMILY fam_0_id_expire_at (id, expire_at)
 ) WITH (ttl = 'on', ttl_expiration_expression = e'IF(expire_at > parse_timestamp(\'2020-01-01 00:00:00\') AT TIME ZONE \'UTC\', expire_at, NULL)', ttl_job_cron = '@hourly')
-
 
 subtest end
 
@@ -863,23 +946,21 @@ CREATE TABLE public.tbl_ttl_expiration_expression_renamed (
 
 subtest end
 
-subtest todo_add_subtests2
-
-# Test adding to TTL table with crdb_internal_expiration already defined.
-statement ok
-DROP TABLE tbl
+subtest crdb_internal_expiration_already_defined
 
 statement ok
-CREATE TABLE tbl (
+CREATE TABLE tbl_crdb_internal_expiration_already_defined (
   id INT PRIMARY KEY,
-  crdb_internal_expiration TIMESTAMPTZ,
-  FAMILY (id, crdb_internal_expiration)
+  crdb_internal_expiration TIMESTAMPTZ
 )
 
 statement error cannot add TTL to table with the crdb_internal_expiration column already defined
-ALTER TABLE tbl SET (ttl_expire_after = '10 minutes')
+ALTER TABLE tbl_crdb_internal_expiration_already_defined SET (ttl_expire_after = '10 minutes')
 
-# Test we cannot add FKs to a TTL table.
+subtest end
+
+subtest foreign_key_constraint
+
 statement ok
 CREATE TABLE ref_table (id INT PRIMARY KEY, ref INT)
 
@@ -904,68 +985,32 @@ CREATE TABLE ttl_become_table (id INT PRIMARY KEY, ref INT REFERENCES ref_table 
 statement error foreign keys from table with TTL "ttl_become_table" are not permitted
 ALTER TABLE ttl_become_table SET (ttl_expire_after = '10 minutes')
 
-# Check non-ascending PKs are not permitted.
+subtest end
 
-statement ok
-DROP TABLE tbl
-
-statement error non-ascending ordering on PRIMARY KEYs are not supported
-CREATE TABLE tbl (id INT, id2 INT, PRIMARY KEY (id, id2 DESC)) WITH (ttl_expire_after = '10 minutes')
-
-statement ok
-CREATE TABLE tbl (id INT, id2 INT, PRIMARY KEY (id, id2 DESC))
+subtest desc_pk_with_ttl
 
 statement error non-ascending ordering on PRIMARY KEYs are not supported
-ALTER TABLE tbl SET (ttl_expire_after = '10 minutes')
+CREATE TABLE tbl_desc_pk_with_ttl (id INT, id2 INT, PRIMARY KEY (id, id2 DESC)) WITH (ttl_expire_after = '10 minutes')
+
+subtest end
+
+subtest desc_pk_without_ttl_add_ttl
 
 statement ok
-DROP TABLE tbl
-
-statement ok
-CREATE TABLE tbl (id INT, id2 INT, PRIMARY KEY (id, id2)) WITH (ttl_expire_after = '10 minutes')
+CREATE TABLE tbl_desc_pk_without_ttl_add_ttl (id INT, id2 INT, PRIMARY KEY (id, id2 DESC))
 
 statement error non-ascending ordering on PRIMARY KEYs are not supported
-ALTER TABLE tbl ALTER PRIMARY KEY USING COLUMNS (id, id2 DESC)
+ALTER TABLE tbl_desc_pk_without_ttl_add_ttl SET (ttl_expire_after = '10 minutes')
 
-# Create a table without a TTL. Add the TTL to the table and ensure
-# the schedule and TTL is setup correctly.
-statement ok
-DROP TABLE tbl
+subtest end
 
-statement ok
-CREATE TABLE tbl (
-   id INT PRIMARY KEY
-)
-
-statement error cannot modify TTL settings while another schema change on the table is being processed
-ALTER TABLE tbl SET (ttl_expire_after = '10 minutes'), SET (ttl_select_batch_size = 200)
-
-statement error cannot modify TTL settings while another schema change on the table is being processed
-BEGIN;
-ALTER TABLE tbl SET (ttl_expire_after = '10 minutes');
-ALTER TABLE tbl RESET (ttl_select_batch_size)
+subtest asc_pk_alter_desc_pk
 
 statement ok
-ROLLBACK
+CREATE TABLE tbl_asc_pk_alter_desc_pk (id INT, id2 INT, PRIMARY KEY (id, id2)) WITH (ttl_expire_after = '10 minutes')
 
-statement error cannot modify TTL settings while another schema change on the table is being processed
-BEGIN;
-CREATE INDEX tbl_idx ON tbl (id);
-ALTER TABLE tbl SET (ttl_expire_after = '10 minutes');
-
-statement ok
-ROLLBACK
-
-statement error cannot perform other schema changes in the same transaction as a TTL mutation
-BEGIN;
-ALTER TABLE tbl SET (ttl_expire_after = '10 minutes');
-CREATE INDEX tbl_idx ON tbl (id)
-
-statement ok
-ROLLBACK
-
-statement ok
-DROP TABLE tbl
+statement error non-ascending ordering on PRIMARY KEYs are not supported
+ALTER TABLE tbl_asc_pk_alter_desc_pk ALTER PRIMARY KEY USING COLUMNS (id, id2 DESC)
 
 subtest end
 

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_table_alter_primary_key.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_table_alter_primary_key.go
@@ -390,14 +390,10 @@ func fallBackIfDescColInRowLevelTTLTables(b BuildCtx, tableID catid.DescID, t al
 	}
 
 	_, _, ns := scpb.FindNamespace(b.QueryByID(tableID))
-	// Panic if there is any inbound/outbound FK constraints.
+	// Panic if there are any inbound FK constraints.
 	if _, _, inboundFKElem := scpb.FindForeignKeyConstraint(b.BackReferences(tableID)); inboundFKElem != nil {
 		panic(scerrors.NotImplementedErrorf(t.n,
 			`foreign keys to table with TTL %q are not permitted`, ns.Name))
-	}
-	if _, _, outboundFKElem := scpb.FindForeignKeyConstraint(b.QueryByID(tableID)); outboundFKElem != nil {
-		panic(scerrors.NotImplementedErrorf(t.n,
-			`foreign keys from table with TTL %q are not permitted`, ns.Name))
 	}
 }
 


### PR DESCRIPTION
Backport 3/3 commits from #101236.

/cc @cockroachdb/release

---

Fixes #101225

This change allows TTL tables to have outbound foreign keys. Outbound foreign
keys are unaffected by rows being deleted from the TTL table itself.

Release note (sql change): Allow outbound foreign keys on TTL tables.

Release justification: Unblock customers needing outbound FKs on TTL table.
