### PR TITLE
liveness: Convert to using hlc.Timestamp

### DIFF
--- a/pkg/kv/kvserver/allocator/storepool/BUILD.bazel
+++ b/pkg/kv/kvserver/allocator/storepool/BUILD.bazel
@@ -48,7 +48,6 @@ go_test(
         "//pkg/util/hlc",
         "//pkg/util/leaktest",
         "//pkg/util/log",
-        "//pkg/util/timeutil",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_kr_pretty//:pretty",
         "@com_github_stretchr_testify//require",

--- a/pkg/kv/kvserver/allocator/storepool/override_store_pool.go
+++ b/pkg/kv/kvserver/allocator/storepool/override_store_pool.go
@@ -50,7 +50,7 @@ var _ AllocatorStorePool = &OverrideStorePool{}
 func OverrideNodeLivenessFunc(
 	overrides map[roachpb.NodeID]livenesspb.NodeLivenessStatus, realNodeLivenessFunc NodeLivenessFunc,
 ) NodeLivenessFunc {
-	return func(nid roachpb.NodeID, now time.Time, timeUntilStoreDead time.Duration) livenesspb.NodeLivenessStatus {
+	return func(nid roachpb.NodeID, now hlc.Timestamp, timeUntilStoreDead time.Duration) livenesspb.NodeLivenessStatus {
 		if override, ok := overrides[nid]; ok {
 			return override
 		}

--- a/pkg/kv/kvserver/allocator/storepool/override_store_pool_test.go
+++ b/pkg/kv/kvserver/allocator/storepool/override_store_pool_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/testutils/gossiputil"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/stretchr/testify/require"
@@ -42,7 +43,7 @@ func TestOverrideStorePoolStatusString(t *testing.T) {
 	sg := gossiputil.NewStoreGossiper(g)
 
 	livenessOverrides := make(map[roachpb.NodeID]livenesspb.NodeLivenessStatus)
-	sp := NewOverrideStorePool(testStorePool, func(nid roachpb.NodeID, now time.Time, timeUntilStoreDead time.Duration) livenesspb.NodeLivenessStatus {
+	sp := NewOverrideStorePool(testStorePool, func(nid roachpb.NodeID, now hlc.Timestamp, timeUntilStoreDead time.Duration) livenesspb.NodeLivenessStatus {
 		if overriddenLiveness, ok := livenessOverrides[nid]; ok {
 			return overriddenLiveness
 		}
@@ -123,7 +124,7 @@ func TestOverrideStorePoolDecommissioningReplicas(t *testing.T) {
 	sg := gossiputil.NewStoreGossiper(g)
 
 	livenessOverrides := make(map[roachpb.NodeID]livenesspb.NodeLivenessStatus)
-	sp := NewOverrideStorePool(testStorePool, func(nid roachpb.NodeID, now time.Time, timeUntilStoreDead time.Duration) livenesspb.NodeLivenessStatus {
+	sp := NewOverrideStorePool(testStorePool, func(nid roachpb.NodeID, now hlc.Timestamp, timeUntilStoreDead time.Duration) livenesspb.NodeLivenessStatus {
 		if overriddenLiveness, ok := livenessOverrides[nid]; ok {
 			return overriddenLiveness
 		}
@@ -240,7 +241,7 @@ func TestOverrideStorePoolGetStoreList(t *testing.T) {
 	sg := gossiputil.NewStoreGossiper(g)
 
 	livenessOverrides := make(map[roachpb.NodeID]livenesspb.NodeLivenessStatus)
-	sp := NewOverrideStorePool(testStorePool, func(nid roachpb.NodeID, now time.Time, timeUntilStoreDead time.Duration) livenesspb.NodeLivenessStatus {
+	sp := NewOverrideStorePool(testStorePool, func(nid roachpb.NodeID, now hlc.Timestamp, timeUntilStoreDead time.Duration) livenesspb.NodeLivenessStatus {
 		if overriddenLiveness, ok := livenessOverrides[nid]; ok {
 			return overriddenLiveness
 		}
@@ -335,7 +336,7 @@ func TestOverrideStorePoolGetStoreList(t *testing.T) {
 
 	// Set suspectedStore as suspected.
 	testStorePool.DetailsMu.Lock()
-	testStorePool.DetailsMu.StoreDetails[suspectedStore.StoreID].LastUnavailable = testStorePool.clock.Now().GoTime()
+	testStorePool.DetailsMu.StoreDetails[suspectedStore.StoreID].LastUnavailable = testStorePool.clock.Now()
 	testStorePool.DetailsMu.Unlock()
 
 	// No filter or limited set of store IDs.

--- a/pkg/kv/kvserver/allocator/storepool/store_pool.go
+++ b/pkg/kv/kvserver/allocator/storepool/store_pool.go
@@ -113,7 +113,7 @@ type NodeCountFunc func() int
 // not the node is live. A node is considered dead if its liveness record has
 // expired by more than TimeUntilStoreDead.
 type NodeLivenessFunc func(
-	nid roachpb.NodeID, now time.Time, timeUntilStoreDead time.Duration,
+	nid roachpb.NodeID, now hlc.Timestamp, timeUntilStoreDead time.Duration,
 ) livenesspb.NodeLivenessStatus
 
 // MakeStorePoolNodeLivenessFunc returns a function which determines
@@ -121,7 +121,7 @@ type NodeLivenessFunc func(
 // NodeLiveness.
 func MakeStorePoolNodeLivenessFunc(nodeLiveness *liveness.NodeLiveness) NodeLivenessFunc {
 	return func(
-		nodeID roachpb.NodeID, now time.Time, timeUntilStoreDead time.Duration,
+		nodeID roachpb.NodeID, now hlc.Timestamp, timeUntilStoreDead time.Duration,
 	) livenesspb.NodeLivenessStatus {
 		liveness, ok := nodeLiveness.GetLiveness(nodeID)
 		if !ok {
@@ -160,7 +160,7 @@ func MakeStorePoolNodeLivenessFunc(nodeLiveness *liveness.NodeLiveness) NodeLive
 // ideally we should remove usage of NodeLivenessStatus altogether. See #50707
 // for more details.
 func LivenessStatus(
-	l livenesspb.Liveness, now time.Time, deadThreshold time.Duration,
+	l livenesspb.Liveness, now hlc.Timestamp, deadThreshold time.Duration,
 ) livenesspb.NodeLivenessStatus {
 	// If we don't have a liveness expiration time, treat the status as unknown.
 	// This is different than unavailable as it doesn't transition through being
@@ -195,16 +195,16 @@ type StoreDetail struct {
 	Desc *roachpb.StoreDescriptor
 	// ThrottledUntil is when a throttled store can be considered available again
 	// due to a failed or declined snapshot.
-	ThrottledUntil time.Time
+	ThrottledUntil hlc.Timestamp
 	// throttledBecause is set to the most recent reason for which a store was
 	// marked as throttled.
 	throttledBecause string
 	// LastUpdatedTime is set when a store is first consulted and every time
 	// gossip arrives for a store.
-	LastUpdatedTime time.Time
+	LastUpdatedTime hlc.Timestamp
 	// LastUnavailable is set when it's detected that a store was unavailable,
 	// i.e. failed liveness.
-	LastUnavailable time.Time
+	LastUnavailable hlc.Timestamp
 }
 
 // storeStatus is the current status of a store.
@@ -238,7 +238,10 @@ const (
 )
 
 func (sd *StoreDetail) status(
-	now time.Time, deadThreshold time.Duration, nl NodeLivenessFunc, suspectDuration time.Duration,
+	now hlc.Timestamp,
+	deadThreshold time.Duration,
+	nl NodeLivenessFunc,
+	suspectDuration time.Duration,
 ) storeStatus {
 	// During normal operation, we expect the state transitions for stores to look like the following:
 	//
@@ -265,7 +268,7 @@ func (sd *StoreDetail) status(
 	// within the liveness threshold. Note that LastUpdatedTime is set
 	// when the store detail is created and will have a non-zero value
 	// even before the first gossip arrives for a store.
-	deadAsOf := sd.LastUpdatedTime.Add(deadThreshold)
+	deadAsOf := sd.LastUpdatedTime.AddDuration(deadThreshold)
 	if now.After(deadAsOf) {
 		sd.LastUnavailable = now
 		return storeStatusDead
@@ -305,7 +308,7 @@ func (sd *StoreDetail) status(
 	// Check whether the store is currently suspect. We measure that by
 	// looking at the time it was last unavailable making sure we have not seen any
 	// failures for a period of time defined by StoreSuspectDuration.
-	if sd.LastUnavailable.Add(suspectDuration).After(now) {
+	if sd.LastUnavailable.AddDuration(suspectDuration).After(now) {
 		return storeStatusSuspect
 	}
 
@@ -443,7 +446,7 @@ type StorePool struct {
 	gossip         *gossip.Gossip
 	nodeCountFn    NodeCountFunc
 	NodeLivenessFn NodeLivenessFunc
-	startTime      time.Time
+	startTime      hlc.Timestamp
 	deterministic  bool
 
 	// We use separate mutexes for storeDetails and nodeLocalities because the
@@ -492,7 +495,7 @@ func NewStorePool(
 		gossip:         g,
 		nodeCountFn:    nodeCountFn,
 		NodeLivenessFn: nodeLivenessFn,
-		startTime:      clock.PhysicalTime(),
+		startTime:      clock.Now(),
 		deterministic:  deterministic,
 	}
 	sp.DetailsMu.StoreDetails = make(map[roachpb.StoreID]*StoreDetail)
@@ -523,7 +526,7 @@ func (sp *StorePool) statusString(nl NodeLivenessFunc) string {
 	sort.Sort(ids)
 
 	var buf bytes.Buffer
-	now := sp.clock.Now().GoTime()
+	now := sp.clock.Now()
 	timeUntilStoreDead := TimeUntilStoreDead.Get(&sp.st.SV)
 	timeAfterStoreSuspect := TimeAfterStoreSuspect.Get(&sp.st.SV)
 
@@ -538,9 +541,8 @@ func (sp *StorePool) statusString(nl NodeLivenessFunc) string {
 			fmt.Fprintf(&buf, ": range-count=%d fraction-used=%.2f",
 				detail.Desc.Capacity.RangeCount, detail.Desc.Capacity.FractionUsed())
 		}
-		throttled := detail.ThrottledUntil.Sub(now)
-		if throttled > 0 {
-			fmt.Fprintf(&buf, " [throttled=%.1fs]", throttled.Seconds())
+		if detail.ThrottledUntil.After(now) {
+			fmt.Fprintf(&buf, " [throttled=%.1fs]", detail.ThrottledUntil.GoTime().Sub(now.GoTime()).Seconds())
 		}
 		_, _ = buf.WriteString("\n")
 	}
@@ -569,7 +571,7 @@ func (sp *StorePool) storeDescriptorUpdate(storeDesc roachpb.StoreDescriptor) {
 	storeID := storeDesc.StoreID
 	curCapacity := storeDesc.Capacity
 
-	now := sp.clock.PhysicalTime()
+	now := sp.clock.Now()
 
 	sp.DetailsMu.Lock()
 	detail := sp.GetStoreDetailLocked(storeID)
@@ -815,9 +817,9 @@ func (sp *StorePool) decommissioningReplicasWithLiveness(
 	sp.DetailsMu.Lock()
 	defer sp.DetailsMu.Unlock()
 
-	// NB: We use clock.Now().GoTime() instead of clock.PhysicalTime() is order to
+	// NB: We use clock.Now() instead of clock.PhysicalTime() is order to
 	// take clock signals from remote nodes into consideration.
-	now := sp.clock.Now().GoTime()
+	now := sp.clock.Now()
 	timeUntilStoreDead := TimeUntilStoreDead.Get(&sp.st.SV)
 	timeAfterStoreSuspect := TimeAfterStoreSuspect.Get(&sp.st.SV)
 
@@ -859,12 +861,12 @@ func (sp *StorePool) IsDead(storeID roachpb.StoreID) (bool, time.Duration, error
 	if !ok {
 		return false, 0, errors.Errorf("store %d was not found", storeID)
 	}
-	// NB: We use clock.Now().GoTime() instead of clock.PhysicalTime() is order to
+	// NB: We use clock.Now() instead of clock.PhysicalTime() is order to
 	// take clock signals from remote nodes into consideration.
-	now := sp.clock.Now().GoTime()
+	now := sp.clock.Now()
 	timeUntilStoreDead := TimeUntilStoreDead.Get(&sp.st.SV)
 
-	deadAsOf := sd.LastUpdatedTime.Add(timeUntilStoreDead)
+	deadAsOf := sd.LastUpdatedTime.AddDuration(timeUntilStoreDead)
 	if now.After(deadAsOf) {
 		return true, 0, nil
 	}
@@ -873,7 +875,7 @@ func (sp *StorePool) IsDead(storeID roachpb.StoreID) (bool, time.Duration, error
 	if sd.Desc == nil {
 		return false, 0, errors.Errorf("store %d status unknown, cant tell if it's dead or alive", storeID)
 	}
-	return false, deadAsOf.Sub(now), nil
+	return false, deadAsOf.GoTime().Sub(now.GoTime()), nil
 }
 
 // IsUnknown returns true if the given store's status is `storeStatusUnknown`
@@ -935,9 +937,9 @@ func (sp *StorePool) storeStatus(
 	if !ok {
 		return storeStatusUnknown, errors.Errorf("store %d was not found", storeID)
 	}
-	// NB: We use clock.Now().GoTime() instead of clock.PhysicalTime() is order to
+	// NB: We use clock.Now() instead of clock.PhysicalTime() is order to
 	// take clock signals from remote nodes into consideration.
-	now := sp.clock.Now().GoTime()
+	now := sp.clock.Now()
 	timeUntilStoreDead := TimeUntilStoreDead.Get(&sp.st.SV)
 	timeAfterStoreSuspect := TimeAfterStoreSuspect.Get(&sp.st.SV)
 	return sd.status(now, timeUntilStoreDead, nl, timeAfterStoreSuspect), nil
@@ -971,7 +973,7 @@ func (sp *StorePool) liveAndDeadReplicasWithLiveness(
 	sp.DetailsMu.Lock()
 	defer sp.DetailsMu.Unlock()
 
-	now := sp.clock.Now().GoTime()
+	now := sp.clock.Now()
 	timeUntilStoreDead := TimeUntilStoreDead.Get(&sp.st.SV)
 	timeAfterStoreSuspect := TimeAfterStoreSuspect.Get(&sp.st.SV)
 
@@ -1247,7 +1249,7 @@ func (sp *StorePool) getStoreListFromIDsLocked(
 	var throttled ThrottledStoreReasons
 	var storeDescriptors []roachpb.StoreDescriptor
 
-	now := sp.clock.Now().GoTime()
+	now := sp.clock.Now()
 	timeUntilStoreDead := TimeUntilStoreDead.Get(&sp.st.SV)
 	timeAfterStoreSuspect := TimeAfterStoreSuspect.Get(&sp.st.SV)
 
@@ -1311,7 +1313,7 @@ func (sp *StorePool) Throttle(reason ThrottleReason, why string, storeID roachpb
 	switch reason {
 	case ThrottleFailed:
 		timeout := FailedReservationsTimeout.Get(&sp.st.SV)
-		detail.ThrottledUntil = sp.clock.PhysicalTime().Add(timeout)
+		detail.ThrottledUntil = sp.clock.Now().AddDuration(timeout)
 		if log.V(2) {
 			ctx := sp.AnnotateCtx(context.TODO())
 			log.Infof(ctx, "snapshot failed (%s), s%d will be throttled for %s until %s",

--- a/pkg/kv/kvserver/allocator/storepool/test_helpers.go
+++ b/pkg/kv/kvserver/allocator/storepool/test_helpers.go
@@ -55,7 +55,7 @@ func (m *MockNodeLiveness) SetNodeStatus(
 // NodeLivenessFunc is the method that can be injected as part of store pool
 // construction to mock out node liveness, in tests.
 func (m *MockNodeLiveness) NodeLivenessFunc(
-	nodeID roachpb.NodeID, now time.Time, threshold time.Duration,
+	nodeID roachpb.NodeID, now hlc.Timestamp, threshold time.Duration,
 ) livenesspb.NodeLivenessStatus {
 	m.Lock()
 	defer m.Unlock()
@@ -76,7 +76,8 @@ func CreateTestStorePool(
 	defaultNodeStatus livenesspb.NodeLivenessStatus,
 ) (*stop.Stopper, *gossip.Gossip, *timeutil.ManualTime, *StorePool, *MockNodeLiveness) {
 	stopper := stop.NewStopper()
-	mc := timeutil.NewManualTime(timeutil.Unix(0, 123))
+	// Pick a random date that is "realistic" and far enough away from 0.
+	mc := timeutil.NewManualTime(time.Date(2020, 0, 0, 0, 0, 0, 0, time.UTC))
 	clock := hlc.NewClockForTesting(mc)
 	ambientCtx := log.MakeTestingAmbientContext(stopper.Tracer())
 	g := gossip.NewTest(1, stopper, metric.NewRegistry(), zonepb.DefaultZoneConfigRef())

--- a/pkg/kv/kvserver/allocator_impl_test.go
+++ b/pkg/kv/kvserver/allocator_impl_test.go
@@ -419,7 +419,7 @@ func TestAllocatorThrottled(t *testing.T) {
 	if !ok {
 		t.Fatalf("store:%d was not found in the store pool", singleStore[0].StoreID)
 	}
-	storeDetail.ThrottledUntil = timeutil.Now().Add(24 * time.Hour)
+	storeDetail.ThrottledUntil = hlc.Timestamp{WallTime: timeutil.Now().Add(24 * time.Hour).UnixNano()}
 	sp.DetailsMu.Unlock()
 	_, _, err = a.AllocateVoter(ctx, sp, simpleSpanConfig, []roachpb.ReplicaDescriptor{}, nil, nil, allocatorimpl.Dead)
 	if _, ok := IsPurgatoryError(err); ok {

--- a/pkg/kv/kvserver/asim/gossip/BUILD.bazel
+++ b/pkg/kv/kvserver/asim/gossip/BUILD.bazel
@@ -15,6 +15,7 @@ go_library(
         "//pkg/kv/kvserver/asim/config",
         "//pkg/kv/kvserver/asim/state",
         "//pkg/roachpb",
+        "//pkg/util/hlc",
         "//pkg/util/protoutil",
     ],
 )

--- a/pkg/kv/kvserver/asim/gossip/exchange.go
+++ b/pkg/kv/kvserver/asim/gossip/exchange.go
@@ -17,6 +17,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/allocator/storepool"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/asim/config"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 )
 
 // exchangeInfo contains the information of a gossiped store descriptor.
@@ -58,6 +59,6 @@ func (u *fixedDelayExchange) updates(tick time.Time) []*storepool.StoreDetail {
 func makeStoreDetail(desc *roachpb.StoreDescriptor, tick time.Time) *storepool.StoreDetail {
 	return &storepool.StoreDetail{
 		Desc:            desc,
-		LastUpdatedTime: tick,
+		LastUpdatedTime: hlc.Timestamp{WallTime: tick.UnixNano()},
 	}
 }

--- a/pkg/kv/kvserver/asim/state/BUILD.bazel
+++ b/pkg/kv/kvserver/asim/state/BUILD.bazel
@@ -59,6 +59,7 @@ go_test(
         "//pkg/kv/kvserver/liveness/livenesspb",
         "//pkg/kv/kvserver/load",
         "//pkg/roachpb",
+        "//pkg/util/hlc",
         "@com_github_stretchr_testify//require",
     ],
 )

--- a/pkg/kv/kvserver/asim/state/impl.go
+++ b/pkg/kv/kvserver/asim/state/impl.go
@@ -968,7 +968,7 @@ func (s *state) SetNodeLiveness(nodeID NodeID, status livenesspb.NodeLivenessSta
 // liveness of the Node with ID NodeID.
 // TODO(kvoli): Find a better home for this method, required by the storepool.
 func (s *state) NodeLivenessFn() storepool.NodeLivenessFunc {
-	return func(nid roachpb.NodeID, now time.Time, timeUntilStoreDead time.Duration) livenesspb.NodeLivenessStatus {
+	return func(nid roachpb.NodeID, now hlc.Timestamp, timeUntilStoreDead time.Duration) livenesspb.NodeLivenessStatus {
 		return s.quickLivenessMap[NodeID(nid)]
 	}
 }

--- a/pkg/kv/kvserver/asim/state/state_test.go
+++ b/pkg/kv/kvserver/asim/state/state_test.go
@@ -14,13 +14,13 @@ import (
 	"math"
 	"math/rand"
 	"testing"
-	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/asim/config"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/asim/workload"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/liveness/livenesspb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/load"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/stretchr/testify/require"
 )
 
@@ -605,9 +605,9 @@ func TestSetNodeLiveness(t *testing.T) {
 
 		// Liveness status returend should ignore time till store dead or the
 		// timestamp given.
-		require.Equal(t, livenesspb.NodeLivenessStatus_LIVE, liveFn(1, time.Time{}, math.MaxInt64))
-		require.Equal(t, livenesspb.NodeLivenessStatus_DEAD, liveFn(2, time.Time{}, math.MaxInt64))
-		require.Equal(t, livenesspb.NodeLivenessStatus_DECOMMISSIONED, liveFn(3, time.Time{}, math.MaxInt64))
+		require.Equal(t, livenesspb.NodeLivenessStatus_LIVE, liveFn(1, hlc.Timestamp{}, math.MaxInt64))
+		require.Equal(t, livenesspb.NodeLivenessStatus_DEAD, liveFn(2, hlc.Timestamp{}, math.MaxInt64))
+		require.Equal(t, livenesspb.NodeLivenessStatus_DECOMMISSIONED, liveFn(3, hlc.Timestamp{}, math.MaxInt64))
 	})
 
 	t.Run("node count fn", func(t *testing.T) {

--- a/pkg/kv/kvserver/client_replica_circuit_breaker_test.go
+++ b/pkg/kv/kvserver/client_replica_circuit_breaker_test.go
@@ -884,7 +884,7 @@ func (cbt *circuitBreakerTest) ExpireAllLeasesAndN1LivenessRecord(
 			testutils.SucceedsSoon(t, func() error {
 				self, ok := lv.Self()
 				require.True(t, ok)
-				if self.IsLive(cbt.Server(n2).Clock().Now().GoTime()) {
+				if self.IsLive(cbt.Server(n2).Clock().Now()) {
 					// Someone else must have incremented epoch.
 					return nil
 				}

--- a/pkg/kv/kvserver/helpers_test.go
+++ b/pkg/kv/kvserver/helpers_test.go
@@ -225,7 +225,7 @@ func NewTestStorePool(cfg StoreConfig) *storepool.StorePool {
 		func() int {
 			return 1
 		},
-		func(roachpb.NodeID, time.Time, time.Duration) livenesspb.NodeLivenessStatus {
+		func(roachpb.NodeID, hlc.Timestamp, time.Duration) livenesspb.NodeLivenessStatus {
 			return livenesspb.NodeLivenessStatus_LIVE
 		},
 		/* deterministic */ false,

--- a/pkg/kv/kvserver/liveness/livenesspb/BUILD.bazel
+++ b/pkg/kv/kvserver/liveness/livenesspb/BUILD.bazel
@@ -11,7 +11,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/roachpb",
-        "//pkg/util/timeutil",
+        "//pkg/util/hlc",
         "@org_golang_google_grpc//codes",
         "@org_golang_google_grpc//status",
     ],

--- a/pkg/kv/kvserver/replica_raft.go
+++ b/pkg/kv/kvserver/replica_raft.go
@@ -2166,7 +2166,7 @@ func shouldCampaignOnLeaseRequestRedirect(
 	// Store.updateLivenessMap). We only care whether the leader is currently live
 	// according to node liveness because this determines whether it will be able
 	// to acquire an epoch-based lease.
-	return !livenessEntry.Liveness.IsLive(now.GoTime())
+	return !livenessEntry.Liveness.IsLive(now)
 }
 
 func (r *Replica) campaignLocked(ctx context.Context) {

--- a/pkg/kv/kvserver/replicate_queue_test.go
+++ b/pkg/kv/kvserver/replicate_queue_test.go
@@ -1059,7 +1059,7 @@ func TestReplicateQueueDeadNonVoters(t *testing.T) {
 						},
 						NodeLiveness: kvserver.NodeLivenessTestingKnobs{
 							StorePoolNodeLivenessFn: func(
-								id roachpb.NodeID, now time.Time, duration time.Duration,
+								id roachpb.NodeID, now hlc.Timestamp, duration time.Duration,
 							) livenesspb.NodeLivenessStatus {
 								val := livenessTrap.Load()
 								if val == nil {

--- a/pkg/server/auto_upgrade.go
+++ b/pkg/server/auto_upgrade.go
@@ -128,7 +128,7 @@ func (s *Server) upgradeStatus(
 		return upgradeBlockedDueToError, err
 	}
 	clock := s.admin.server.clock
-	statusMap, err := getLivenessStatusMap(ctx, s.nodeLiveness, clock.Now().GoTime(), s.st)
+	statusMap, err := getLivenessStatusMap(ctx, s.nodeLiveness, clock.Now(), s.st)
 	if err != nil {
 		return upgradeBlockedDueToError, err
 	}

--- a/pkg/server/clock_monotonicity.go
+++ b/pkg/server/clock_monotonicity.go
@@ -139,7 +139,7 @@ func ensureClockMonotonicity(
 	if delta > 0 {
 		log.Ops.Infof(
 			ctx,
-			"Sleeping till wall time %v to catches up to %v to ensure monotonicity. Delta: %v",
+			"Sleeping till wall time %v to catches up to %v to ensure monotonicity. Sub: %v",
 			currentWallTime,
 			sleepUntil,
 			delta,

--- a/pkg/server/fanout_clients.go
+++ b/pkg/server/fanout_clients.go
@@ -240,7 +240,7 @@ func (k kvFanoutClient) listNodes(ctx context.Context) (*serverpb.NodesResponse,
 	}
 
 	clock := k.clock
-	resp.LivenessByNodeID, err = getLivenessStatusMap(ctx, k.nodeLiveness, clock.Now().GoTime(), k.st)
+	resp.LivenessByNodeID, err = getLivenessStatusMap(ctx, k.nodeLiveness, clock.Now(), k.st)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/server/status.go
+++ b/pkg/server/status.go
@@ -1816,7 +1816,7 @@ func (s *systemStatusServer) nodesHelper(
 	}
 
 	clock := s.clock
-	resp.LivenessByNodeID, err = getLivenessStatusMap(ctx, s.nodeLiveness, clock.Now().GoTime(), s.st)
+	resp.LivenessByNodeID, err = getLivenessStatusMap(ctx, s.nodeLiveness, clock.Now(), s.st)
 	if err != nil {
 		return nil, 0, err
 	}

--- a/pkg/util/hlc/timestamp.go
+++ b/pkg/util/hlc/timestamp.go
@@ -54,6 +54,12 @@ func (t Timestamp) LessEq(s Timestamp) bool {
 	return t.WallTime < s.WallTime || (t.WallTime == s.WallTime && t.Logical <= s.Logical)
 }
 
+// After returns whether the provided timestamp is after our timestamp.
+// This matches the behavior of time.After.
+func (t Timestamp) After(s Timestamp) bool {
+	return !t.LessEq(s)
+}
+
 // Compare returns -1 if this timestamp is lesser than the given timestamp, 1 if
 // it is greater, and 0 if they are equal.
 func (t Timestamp) Compare(s Timestamp) int {
@@ -203,6 +209,14 @@ func (t Timestamp) IsEmpty() bool {
 // gcassert:inline
 func (t Timestamp) IsSet() bool {
 	return !t.IsEmpty()
+}
+
+// AddDuration adds a given duration to this Timestamp. The resulting timestamp
+// is Synthetic. Normally if you want to bump your clock to  the higher of two
+// timestamps, use Forward, however this method is here to create a
+// hlc.Timestamp in the future (or past).
+func (t Timestamp) AddDuration(duration time.Duration) Timestamp {
+	return t.Add(duration.Nanoseconds(), t.Logical)
 }
 
 // Add returns a timestamp with the WallTime and Logical components increased.


### PR DESCRIPTION
Previously there were some conversions back and forth between hlc times and go times. We always use hlc time when looking at the validity of liveness, and this change makes that more clear.

Epic: none

Release note: None