### PR TITLE
bazel: delete stale `go_library` in `replicationtestutils`

### DIFF
--- a/pkg/BUILD.bazel
+++ b/pkg/BUILD.bazel
@@ -854,7 +854,6 @@ GO_TARGETS = [
     "//pkg/ccl/storageccl:storageccl",
     "//pkg/ccl/storageccl:storageccl_test",
     "//pkg/ccl/streamingccl/replicationtestutils:replicationtestutils",
-    "//pkg/ccl/streamingccl/replicationtestutils:streamingtest",
     "//pkg/ccl/streamingccl/replicationutils:replicationutils",
     "//pkg/ccl/streamingccl/replicationutils:replicationutils_test",
     "//pkg/ccl/streamingccl/streamclient:streamclient",

--- a/pkg/ccl/streamingccl/replicationtestutils/BUILD.bazel
+++ b/pkg/ccl/streamingccl/replicationtestutils/BUILD.bazel
@@ -2,38 +2,6 @@ load("//build/bazelutil/unused_checker:unused.bzl", "get_x_data")
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 go_library(
-    name = "streamingtest",
-    srcs = [
-        "encoding.go",
-        "replication_helpers.go",
-    ],
-    importpath = "github.com/cockroachdb/cockroach/pkg/ccl/streamingccl/streamingtest",
-    visibility = ["//visibility:public"],
-    deps = [
-        "//pkg/base",
-        "//pkg/ccl/changefeedccl/changefeedbase",
-        "//pkg/ccl/streamingccl",
-        "//pkg/jobs/jobspb",
-        "//pkg/keys",
-        "//pkg/repstream/streampb",
-        "//pkg/roachpb",
-        "//pkg/security/username",
-        "//pkg/sql/catalog",
-        "//pkg/sql/catalog/descpb",
-        "//pkg/sql/catalog/desctestutils",
-        "//pkg/sql/rowenc",
-        "//pkg/sql/sem/tree",
-        "//pkg/testutils/serverutils",
-        "//pkg/testutils/sqlutils",
-        "//pkg/util/hlc",
-        "//pkg/util/protoutil",
-        "//pkg/util/syncutil",
-        "@com_github_cockroachdb_errors//:errors",
-        "@com_github_stretchr_testify//require",
-    ],
-)
-
-go_library(
     name = "replicationtestutils",
     srcs = [
         "encoding.go",


### PR DESCRIPTION
Epic: none
Release note: None