### PR TITLE
sql: cap the tenant IDs that can be allocated via create_tenant

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/tenant_builtins
+++ b/pkg/sql/logictest/testdata/logic_test/tenant_builtins
@@ -380,3 +380,8 @@ query I
 SELECT crdb_internal.create_tenant('{"name":"tenant-number-ten", "if_not_exists": true}'::JSONB)
 ----
 NULL
+
+subtest avoid_too_large_ids
+
+query error tenant ID 10000000000 out of range
+SELECT crdb_internal.create_tenant(10000000000)

--- a/pkg/sql/tenant_creation.go
+++ b/pkg/sql/tenant_creation.go
@@ -617,6 +617,8 @@ HAVING ($1 = '' OR NOT EXISTS (SELECT 1 FROM system.tenants t WHERE t.name = $1)
 	return roachpb.MakeTenantID(nextID)
 }
 
+var tenantIDSequenceFQN = tree.MakeTableNameWithSchema(catconstants.SystemDatabaseName, tree.PublicSchemaName, tree.Name(catconstants.TenantIDSequenceTableName))
+
 // getTenantIDSequenceDesc retrieves a leased descriptor for the
 // sequence system.tenant_id_seq.
 func getTenantIDSequenceDesc(ctx context.Context, txn isql.Txn) (catalog.TableDescriptor, error) {
@@ -635,9 +637,8 @@ func getTenantIDSequenceDesc(ctx context.Context, txn isql.Txn) (catalog.TableDe
 	coll := itxn.Descriptors()
 
 	// Full name of the sequence.
-	tn := tree.MakeTableNameWithSchema(catconstants.SystemDatabaseName, tree.PublicSchemaName, tree.Name(catconstants.TenantIDSequenceTableName))
 	// Look up the sequence by name with lease.
-	_, desc, err := descs.PrefixAndTable(ctx, coll.ByNameWithLeased(txn.KV()).Get(), &tn)
+	_, desc, err := descs.PrefixAndTable(ctx, coll.ByNameWithLeased(txn.KV()).Get(), &tenantIDSequenceFQN)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Requested  by @yuzefovich [here](https://github.com/cockroachdb/cockroach/pull/101845#pullrequestreview-1394392309).

This patch introduces a limit (MaxUint32) to the fixed IDs that can be
selected by `crdb_internal.create_tenant`. This ensures that there are
always IDs remaining available for CREATE TENANT after the maximum
value has been selected via `create_tenant`.

Release note: None
Epic: CRDB-23559