### PR TITLE
catalog: utilize scans for a large number of descriptors

### DIFF
--- a/pkg/sql/catalog/internal/catkv/testdata/testdata
+++ b/pkg/sql/catalog/internal/catkv/testdata/testdata
@@ -159,38 +159,14 @@ catalog:
   "107":
     descriptor: function
 trace:
-- Get /Table/3/1/104/2/1
-- Scan /Table/24/1/0/104
-- Scan /Table/24/1/1/104
-- Scan /Table/24/1/2/104
-- Scan /Table/24/1/3/104
-- Scan /Table/24/1/4/104
-- Scan /Table/24/1/5/104
-- Get /Table/5/1/104/2/1
-- Get /Table/3/1/105/2/1
-- Scan /Table/24/1/0/105
-- Scan /Table/24/1/1/105
-- Scan /Table/24/1/2/105
-- Scan /Table/24/1/3/105
-- Scan /Table/24/1/4/105
-- Scan /Table/24/1/5/105
-- Get /Table/5/1/105/2/1
-- Get /Table/3/1/106/2/1
-- Scan /Table/24/1/0/106
-- Scan /Table/24/1/1/106
-- Scan /Table/24/1/2/106
-- Scan /Table/24/1/3/106
-- Scan /Table/24/1/4/106
-- Scan /Table/24/1/5/106
-- Get /Table/5/1/106/2/1
-- Get /Table/3/1/107/2/1
-- Scan /Table/24/1/0/107
-- Scan /Table/24/1/1/107
-- Scan /Table/24/1/2/107
-- Scan /Table/24/1/3/107
-- Scan /Table/24/1/4/107
-- Scan /Table/24/1/5/107
-- Get /Table/5/1/107/2/1
+- Scan Range /Table/3/1/104/2/1 /Table/3/1/108/2/1
+- Scan Range /Table/24/1/0/104 /Table/24/1/0/108
+- Scan Range /Table/24/1/1/104 /Table/24/1/1/108
+- Scan Range /Table/24/1/2/104 /Table/24/1/2/108
+- Scan Range /Table/24/1/3/104 /Table/24/1/3/108
+- Scan Range /Table/24/1/4/104 /Table/24/1/4/108
+- Scan Range /Table/24/1/5/104 /Table/24/1/5/108
+- Scan Range /Table/5/1/104/2/1 /Table/5/1/108/2/1
 
 is_id_in_cache id=107
 ----


### PR DESCRIPTION
Previously, the catalog descriptor would fetch descriptors via point lookups using Get when scanning large batches of descriptors. This was further extended to also look up ZoneConfigs and comments in a similar way. Recently, we we started seeing regression on the Django test suite involving the pg_catalog tables, which tend to do read large number of descriptors, likely linked to extra overhead linked to both comments and zone configs in 23.1. To address this, this patch ill now start using scans for runs of descriptor IDs for batch scans which reduces the overall cost of fetching a large number of descriptors hiding this cost.

Fixes: #100871

Release note: None