### PR TITLE
sem/tree: remove TODO

### DIFF
--- a/pkg/sql/sem/tree/function_definition.go
+++ b/pkg/sql/sem/tree/function_definition.go
@@ -259,8 +259,6 @@ func (fd *ResolvedFunctionDefinition) MatchOverload(
 ) (QualifiedOverload, error) {
 	matched := func(ol QualifiedOverload, schema string) bool {
 		if ol.IsUDF {
-			// TODO(mgartner/chengxiong-ruan): Differentiate between functions
-			// defined with `Body` and UDFs, now that we use `Body` for built-in functions.
 			return schema == ol.Schema && (paramTypes == nil || ol.params().MatchIdentical(paramTypes))
 		}
 		return schema == ol.Schema && (paramTypes == nil || ol.params().Match(paramTypes))


### PR DESCRIPTION
This commit removes a TODO that was addressed by #96045.

Epic: None

Release note: None