### PR TITLE
ui: fix linegraph render for large clusters

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/graphs/utils/domain.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/graphs/utils/domain.ts
@@ -307,10 +307,7 @@ export function calculateYAxisDomain(
   data: number[],
 ): AxisDomain {
   const allDatapoints = data.concat([0, 1]);
-  const yExtent = [
-    Math.min(...allDatapoints),
-    Math.max(...allDatapoints),
-  ] as Extent;
+  const yExtent = [_.min(allDatapoints), _.max(allDatapoints)] as Extent;
 
   switch (axisUnits) {
     case AxisUnits.Bytes:


### PR DESCRIPTION
We were feeding `Math.min` and `Math.max` very large arrays (length equal to ~10e7). These functions take variadic arguments, and the runtime can't handle that many arguments. As a result we blow the stack, causing uncaught range errors.

Instead, we'll use lodash min and max which are not variadic. Resolves https://github.com/cockroachdb/cockroach/issues/101377 Epic: None
Release note: None


Reproduction and Fix demonstrated on the command line:

<img width="722" alt="Screenshot 2023-04-20 at 4 56 41 PM" src="https://user-images.githubusercontent.com/5423191/233486016-fd740a98-9a0d-4fef-a6d8-67e9cb4e318e.png">
