### PR TITLE
sql: add enums to statement bundles

### DIFF
--- a/pkg/cli/testdata/explain-bundle/bundle/schema.sql
+++ b/pkg/cli/testdata/explain-bundle/bundle/schema.sql
@@ -1,10 +1,12 @@
-CREATE TABLE public.a (
-	a INT8 NOT NULL,
-	b INT8 NULL,
-	CONSTRAINT "primary" PRIMARY KEY (a ASC),
-	FAMILY "primary" (a, b)
+CREATE TABLE public.a
+(
+  a      INT8 NOT NULL,
+  b      INT8 NULL,
+  CONSTRAINT "primary" PRIMARY KEY (a ASC),
+  FAMILY "primary" (a, b)
 );
 
-CREATE TABLE public."order" (
-    id INT8 PRIMARY KEY
+CREATE TABLE public."order"
+(
+  id INT8 PRIMARY KEY
 );

--- a/pkg/sql/explain_bundle.go
+++ b/pkg/sql/explain_bundle.go
@@ -459,6 +459,11 @@ func (b *stmtBundleBuilder) addEnv(ctx context.Context) {
 			fmt.Fprintf(&buf, "-- error getting schema for sequence %s: %v\n", sequences[i].String(), err)
 		}
 	}
+	// Get all user-defined types. If redaction is a
+	blankLine()
+	if err := c.PrintCreateEnum(&buf, b.flags.RedactValues); err != nil {
+		fmt.Fprintf(&buf, "-- error getting schema for enums: %v\n", err)
+	}
 	for i := range tables {
 		blankLine()
 		if err := c.PrintCreateTable(&buf, &tables[i], b.flags.RedactValues); err != nil {
@@ -793,6 +798,22 @@ func (c *stmtEnvCollector) PrintCreateSequence(w io.Writer, tn *tree.TableName) 
 		return err
 	}
 	fmt.Fprintf(w, "%s;\n", createStatement)
+	return nil
+}
+
+func (c *stmtEnvCollector) PrintCreateEnum(w io.Writer, redactValues bool) error {
+	qry := "SELECT create_statement FROM [SHOW CREATE ALL TYPES]"
+	if redactValues {
+		qry = "SELECT crdb_internal.redact(crdb_internal.redactable_sql_constants(create_statement)) FROM [SHOW CREATE ALL TYPES]"
+
+	}
+	createStatement, err := c.queryRows(qry)
+	if err != nil {
+		return err
+	}
+	for _, cs := range createStatement {
+		fmt.Fprintf(w, "%s\n", cs)
+	}
 	return nil
 }
 

--- a/pkg/sql/explain_bundle_test.go
+++ b/pkg/sql/explain_bundle_test.go
@@ -284,6 +284,7 @@ CREATE TABLE users(id UUID DEFAULT gen_random_uuid() PRIMARY KEY, promo_id INT R
 	})
 
 	t.Run("redact", func(t *testing.T) {
+		r.Exec(t, "CREATE TYPE plesiosaur AS ENUM ('pterodactyl', '5555555555554444');")
 		r.Exec(t, "CREATE TABLE pterosaur (cardholder STRING PRIMARY KEY, cardno INT, INDEX (cardno));")
 		r.Exec(t, "INSERT INTO pterosaur VALUES ('pterodactyl', 5555555555554444);")
 		r.Exec(t, "CREATE STATISTICS jurassic FROM pterosaur;")
@@ -303,6 +304,18 @@ CREATE TABLE users(id UUID DEFAULT gen_random_uuid() PRIMARY KEY, promo_id INT R
 			},
 			plans, "statement.sql stats-defaultdb.public.pterosaur.sql env.sql vec.txt vec-v.txt",
 		)
+	})
+
+	t.Run("types", func(t *testing.T) {
+		r.Exec(t, "CREATE TYPE test_type1 AS ENUM ('hello','world');")
+		r.Exec(t, "CREATE TYPE test_type2 AS ENUM ('goodbye','earth');")
+		rows := r.QueryStr(t, "EXPLAIN ANALYZE (DEBUG) SELECT 1;")
+		checkBundle(
+			t, fmt.Sprint(rows), "test_type1", nil, base, plans,
+			"distsql.html vec.txt vec-v.txt")
+		checkBundle(
+			t, fmt.Sprint(rows), "test_type2", nil, base, plans,
+			"distsql.html vec.txt vec-v.txt")
 	})
 }
 

--- a/pkg/sql/sem/tree/create.go
+++ b/pkg/sql/sem/tree/create.go
@@ -32,6 +32,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/collatedstring"
 	"github.com/cockroachdb/cockroach/pkg/util/pretty"
 	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/redact"
 	"golang.org/x/text/language"
 )
 
@@ -332,6 +333,10 @@ func (n *EnumValue) Format(ctx *FmtCtx) {
 	f := ctx.flags
 	if f.HasFlags(FmtAnonymize) {
 		ctx.WriteByte('_')
+	} else if f.HasFlags(FmtMarkRedactionNode) {
+		ctx.WriteString(string(redact.StartMarker()))
+		lexbase.EncodeSQLString(&ctx.Buffer, string(*n))
+		ctx.WriteString(string(redact.EndMarker()))
 	} else {
 		lexbase.EncodeSQLString(&ctx.Buffer, string(*n))
 	}


### PR DESCRIPTION
Statement bundles now include the `CREATE` statements for enums in `schema.sql`.

Epic: None
Fixes: #100377

Release note: None